### PR TITLE
[Wolf Ch2] Add transfer-matrix representation of channels (Ch2.2)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -45,6 +45,7 @@ import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Stinespring
+import TNLean.Channel.TransferMatrix
 
 -- Layer 2a: Density-matrix Brouwer fixed-point theorem used in Perron--Frobenius existence
 import TNLean.Axioms.BrouwerFixedPoint

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
 import TNLean.MPS.Core.Transfer
-import Mathlib.LinearAlgebra.Matrix.Kronecker
+import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.Data.Matrix.Basis
 
 /-!
@@ -13,7 +13,7 @@ import Mathlib.Data.Matrix.Basis
 This file defines the **transfer matrix** (matrix representation) of a linear
 map `T : M_D(ℂ) → M_D(ℂ)`. Given an ordered basis `{E_{kl}}` of standard
 matrix units for `M_D(ℂ)`, the transfer matrix `T̂` is the `D² × D²` matrix
-whose `((i,j),(k,l))`-entry is `(T(E_{kl}))_{ij}`.
+that represents `T` in the column-stacking vectorization `Matrix.vec`.
 
 The main result is that `T̂` faithfully represents `T` in the vectorized
 picture: `vec(T(ρ)) = T̂ *ᵥ vec(ρ)`, and this representation is compatible
@@ -21,11 +21,8 @@ with composition. We also relate it to the Kraus representation.
 
 ## Main definitions
 
-* `Matrix.vecMatrix`: vectorization `M_D(ℂ) → ℂ^{D×D}`, viewing a matrix as
-  a function on the product index type `Fin D × Fin D`
-* `Matrix.unvecMatrix`: the inverse, rebuilding a matrix from a vector
 * `transferMatrix`: the `(Fin D × Fin D) × (Fin D × Fin D)` matrix
-  representing `T` in the standard-basis vectorization
+  representing `T` in the column-stacking vectorization `Matrix.vec`
 * `transferMatrixLM`: `transferMatrix` as a linear map from superoperators to
   matrices on the vectorized space
 
@@ -35,85 +32,40 @@ with composition. We also relate it to the Kraus representation.
 * `transferMatrix_comp`: `(S ∘ T)^ = Ŝ * T̂`
 * `transferMatrix_id`: the transfer matrix of the identity is the identity
 * `transferMatrix_kraus`: for a Kraus map `T(X) = ∑ᵢ Kᵢ X Kᵢ†`, the transfer
-  matrix is `∑ᵢ Kᵢ ⊗ K̄ᵢ`
+  matrix is `∑ᵢ K̄ᵢ ⊗ₖ Kᵢ`
 * `MPSTensor.transferMatrix_eq`: the MPS transfer map `E_A` has transfer
-  matrix `∑ᵢ Aᵢ ⊗ Āᵢ`
+  matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ`
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2.2][Wolf2012QChannels]
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators Kronecker
 open Matrix Finset
 
 variable {D : ℕ}
-
-namespace Matrix
-
-/-! ### Vectorization of matrices -/
-
-/-- **Vectorization**: view a `D × D` matrix as a function on the product
-index type `Fin D × Fin D`. This is the column-stacking map `vec`. -/
-def vecMatrix (M : Matrix (Fin D) (Fin D) ℂ) : Fin D × Fin D → ℂ :=
-  fun ⟨i, j⟩ => M i j
-
-/-- **Unvectorization**: rebuild a `D × D` matrix from a function on
-`Fin D × Fin D`. -/
-def unvecMatrix (v : Fin D × Fin D → ℂ) : Matrix (Fin D) (Fin D) ℂ :=
-  fun i j => v (i, j)
-
-@[simp]
-theorem vecMatrix_apply (M : Matrix (Fin D) (Fin D) ℂ) (i j : Fin D) :
-    vecMatrix M (i, j) = M i j := rfl
-
-@[simp]
-theorem unvecMatrix_apply (v : Fin D × Fin D → ℂ) (i j : Fin D) :
-    unvecMatrix v i j = v (i, j) := rfl
-
-@[simp]
-theorem unvecMatrix_vecMatrix (M : Matrix (Fin D) (Fin D) ℂ) :
-    unvecMatrix (vecMatrix M) = M := by
-  ext i j; simp
-
-@[simp]
-theorem vecMatrix_unvecMatrix (v : Fin D × Fin D → ℂ) :
-    vecMatrix (unvecMatrix v) = v := by
-  ext ⟨i, j⟩; simp
-
-/-- Vectorization is linear. -/
-noncomputable def vecMatrixLM : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] (Fin D × Fin D → ℂ) where
-  toFun := vecMatrix
-  map_add' _ _ := by ext ⟨i, j⟩; simp [vecMatrix, Pi.add_apply]
-  map_smul' _ _ := by ext ⟨i, j⟩; simp [vecMatrix, Pi.smul_apply, smul_eq_mul]
-
-/-- Unvectorization is linear. -/
-noncomputable def unvecMatrixLM : (Fin D × Fin D → ℂ) →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ where
-  toFun := unvecMatrix
-  map_add' _ _ := by ext i j; simp [unvecMatrix]
-  map_smul' _ _ := by ext i j; simp [unvecMatrix, smul_eq_mul]
-
-end Matrix
 
 /-! ### The transfer matrix -/
 
 /-- The **transfer matrix** of a linear map `T : M_D(ℂ) → M_D(ℂ)`:
 
-  `T̂_{(i,j),(k,l)} = (T(E_{kl}))_{ij}`
+  `T̂_{p,q} = vec(T(E_{q.2,q.1}))_p`
 
 where `E_{kl} = Matrix.single k l 1` is the standard matrix unit.
 This is a `(Fin D × Fin D) × (Fin D × Fin D)` matrix that represents `T`
-in the vectorized picture. -/
+in the column-stacking vectorization `Matrix.vec`:
+`T̂ *ᵥ vec(ρ) = vec(T(ρ))`. -/
 noncomputable def transferMatrix
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
-  fun ⟨i, j⟩ ⟨k, l⟩ => (T (Matrix.single k l 1)) i j
+  fun p q => (T (Matrix.single q.2 q.1 1)) p.2 p.1
 
 @[simp]
 theorem transferMatrix_apply
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (i j k l : Fin D) :
-    transferMatrix T (i, j) (k, l) = (T (Matrix.single k l 1)) i j := rfl
+    transferMatrix T (j, i) (l, k) = (T (Matrix.single k l 1)) i j := rfl
 
 private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
     ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 := by
@@ -125,23 +77,24 @@ private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
 /-! ### Fundamental property: T̂ represents T in the vectorized picture -/
 
 /-- **Key property**: the transfer matrix faithfully represents `T`:
-`(T̂ *ᵥ vec(ρ))_{(i,j)} = (T(ρ))_{ij}`.
+`(T̂ *ᵥ vec(ρ)) = vec(T(ρ))`.
 
 This is the defining property of the transfer-matrix representation:
 vectorizing `T(ρ)` is the same as multiplying `T̂` by `vec(ρ)`. -/
 theorem transferMatrix_mulVec_eq
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (ρ : Matrix (Fin D) (Fin D) ℂ) :
-    transferMatrix T *ᵥ Matrix.vecMatrix ρ =
-      Matrix.vecMatrix (T ρ) := by
-  ext ⟨i, j⟩
+    transferMatrix T *ᵥ ρ.vec = (T ρ).vec := by
+  ext ⟨j, i⟩
   simp only [Matrix.mulVec, dotProduct, transferMatrix_apply,
-    Matrix.vecMatrix_apply, Fintype.sum_prod_type]
+    Matrix.vec, Fintype.sum_prod_type]
   have key : T ρ = ∑ k, ∑ l, ρ k l • T (Matrix.single k l 1) := by
     conv_lhs => rw [sum_smul_single_eq ρ]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
-  simp [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul, mul_comm]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  rw [Finset.sum_comm]
+  congr 1; ext k; congr 1; ext l; ring
 
 /-! ### Compatibility with composition -/
 
@@ -149,7 +102,7 @@ theorem transferMatrix_mulVec_eq
 theorem transferMatrix_comp
     (S T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     transferMatrix (S ∘ₗ T) = transferMatrix S * transferMatrix T := by
-  ext ⟨i, j⟩ ⟨k, l⟩
+  ext ⟨j, i⟩ ⟨l, k⟩
   simp only [transferMatrix_apply, LinearMap.comp_apply, Matrix.mul_apply,
     Fintype.sum_prod_type]
   have key : S (T (Matrix.single k l 1)) =
@@ -157,16 +110,18 @@ theorem transferMatrix_comp
     conv_lhs => rw [sum_smul_single_eq (T (Matrix.single k l 1))]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
-  simp [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul, mul_comm]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  rw [Finset.sum_comm]
+  congr 1; ext a; congr 1; ext b; ring
 
 /-- The transfer matrix of the identity map is the identity matrix. -/
 @[simp]
 theorem transferMatrix_id :
     transferMatrix (LinearMap.id : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] _) = 1 := by
-  ext ⟨i, j⟩ ⟨k, l⟩
+  ext ⟨j, i⟩ ⟨l, k⟩
   simp only [transferMatrix_apply, LinearMap.id_apply, Matrix.one_apply, Prod.mk.injEq]
   rw [Matrix.single_apply]
-  simp [eq_comm]
+  simp [eq_comm, and_comm]
 
 /-- `transferMatrix` is injective: distinct linear maps have distinct
 transfer matrices. -/
@@ -176,8 +131,8 @@ theorem transferMatrix_injective :
         Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) := by
   intro S T h
   ext M i j
-  have key := congr_fun (congr_fun (congrArg Matrix.mulVec h) (Matrix.vecMatrix M)) (i, j)
-  simp only [transferMatrix_mulVec_eq, Matrix.vecMatrix_apply] at key
+  have key := congr_fun (congr_fun (congrArg Matrix.mulVec h) M.vec) (j, i)
+  simp only [transferMatrix_mulVec_eq, Matrix.vec] at key
   exact key
 
 /-! ### Transfer matrix as a linear map -/
@@ -189,16 +144,17 @@ noncomputable def transferMatrixLM :
       Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ where
   toFun := transferMatrix
   map_add' S T := by
-    ext ⟨i, j⟩ ⟨k, l⟩
-    simp [transferMatrix_apply, LinearMap.add_apply, Matrix.add_apply]
+    ext ⟨j, i⟩ ⟨l, k⟩
+    simp [transferMatrix, LinearMap.add_apply, Matrix.add_apply]
   map_smul' c T := by
-    ext ⟨i, j⟩ ⟨k, l⟩
-    simp [transferMatrix_apply, LinearMap.smul_apply, Matrix.smul_apply, smul_eq_mul]
+    ext ⟨j, i⟩ ⟨l, k⟩
+    simp [transferMatrix, LinearMap.smul_apply, Matrix.smul_apply, smul_eq_mul]
 
 /-! ### Kraus representation of the transfer matrix -/
 
 /-- For a Kraus map `T(X) = ∑ᵢ Kᵢ X Kᵢ†`, the transfer matrix is
-`∑ᵢ Kᵢ ⊗ K̄ᵢ` (Kronecker product of `Kᵢ` with its entrywise conjugate).
+`∑ᵢ K̄ᵢ ⊗ₖ Kᵢ` (Kronecker product of the entrywise conjugate of `Kᵢ`
+with `Kᵢ`).
 
 This connects the channel-theoretic Kraus representation with the
 vectorized transfer-matrix picture. -/
@@ -207,30 +163,29 @@ theorem transferMatrix_kraus
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ) :
     transferMatrix T =
-      ∑ n : Fin r,
-        kroneckerMap (· * ·) (K n) ((K n).map (starRingEnd ℂ)) := by
-  ext ⟨i, j⟩ ⟨k, l⟩
+      ∑ n : Fin r, (K n).map (starRingEnd ℂ) ⊗ₖ K n := by
+  ext ⟨j, i⟩ ⟨l, k⟩
   simp only [transferMatrix_apply, hK, Matrix.sum_apply, kroneckerMap_apply, Matrix.map_apply,
     starRingEnd_apply]
   congr 1; ext n
-  -- (K n * E_{kl} * (K n)ᴴ)_{ij} = (K n)_{ik} * star((K n)_{jl})
+  -- (K n * E_{kl} * (K n)ᴴ)_{ij} = conj((K n)_{jl}) * (K n)_{ik}
   simp only [Matrix.mul_apply, Matrix.single_apply, Matrix.conjTranspose_apply]
   simp only [ite_and, mul_ite, mul_one, mul_zero, ite_mul, zero_mul,
-    Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte]
+    Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte, mul_comm]
 
 /-! ### Connection to MPS transfer maps -/
 
 namespace MPSTensor
 
 /-- The MPS transfer map `E_A(X) = ∑ᵢ Aᵢ X Aᵢ†` has transfer matrix
-`∑ᵢ Aᵢ ⊗ Āᵢ`.
+`∑ᵢ Āᵢ ⊗ₖ Aᵢ`.
 
 This bridges Wolf's channel-side §2.2 transfer matrix with the MPS-side
 transfer operator. -/
 theorem transferMatrix_eq (A : MPSTensor d D) :
     transferMatrix (MPSTensor.transferMap A) =
       ∑ n : Fin d,
-        kroneckerMap (· * ·) (A n) ((A n).map (starRingEnd ℂ)) :=
+        (A n).map (starRingEnd ℂ) ⊗ₖ A n :=
   transferMatrix_kraus A _ (fun X => by simp [transferMap_apply])
 
 end MPSTensor

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -1,0 +1,237 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Basic
+import TNLean.MPS.Core.Transfer
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+import Mathlib.Data.Matrix.Basis
+
+/-!
+# Transfer-matrix representation of channels (Wolf §2.2)
+
+This file defines the **transfer matrix** (matrix representation) of a linear
+map `T : M_D(ℂ) → M_D(ℂ)`. Given an ordered basis `{E_{kl}}` of standard
+matrix units for `M_D(ℂ)`, the transfer matrix `T̂` is the `D² × D²` matrix
+whose `((i,j),(k,l))`-entry is `(T(E_{kl}))_{ij}`.
+
+The main result is that `T̂` faithfully represents `T` in the vectorized
+picture: `vec(T(ρ)) = T̂ *ᵥ vec(ρ)`, and this representation is compatible
+with composition. We also relate it to the Kraus representation.
+
+## Main definitions
+
+* `Matrix.vecMatrix`: vectorization `M_D(ℂ) → ℂ^{D×D}`, viewing a matrix as
+  a function on the product index type `Fin D × Fin D`
+* `Matrix.unvecMatrix`: the inverse, rebuilding a matrix from a vector
+* `transferMatrix`: the `(Fin D × Fin D) × (Fin D × Fin D)` matrix
+  representing `T` in the standard-basis vectorization
+* `transferMatrixLM`: `transferMatrix` as a linear map from superoperators to
+  matrices on the vectorized space
+
+## Main results
+
+* `transferMatrix_mulVec_eq`: `T̂ *ᵥ vec(ρ) = vec(T(ρ))`
+* `transferMatrix_comp`: `(S ∘ T)^ = Ŝ * T̂`
+* `transferMatrix_id`: the transfer matrix of the identity is the identity
+* `transferMatrix_kraus`: for a Kraus map `T(X) = ∑ᵢ Kᵢ X Kᵢ†`, the transfer
+  matrix is `∑ᵢ Kᵢ ⊗ K̄ᵢ`
+* `MPSTensor.transferMatrix_eq`: the MPS transfer map `E_A` has transfer
+  matrix `∑ᵢ Aᵢ ⊗ Āᵢ`
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2.2][Wolf2012QChannels]
+-/
+
+open scoped Matrix BigOperators
+open Matrix Finset
+
+variable {D : ℕ}
+
+namespace Matrix
+
+/-! ### Vectorization of matrices -/
+
+/-- **Vectorization**: view a `D × D` matrix as a function on the product
+index type `Fin D × Fin D`. This is the column-stacking map `vec`. -/
+def vecMatrix (M : Matrix (Fin D) (Fin D) ℂ) : Fin D × Fin D → ℂ :=
+  fun ⟨i, j⟩ => M i j
+
+/-- **Unvectorization**: rebuild a `D × D` matrix from a function on
+`Fin D × Fin D`. -/
+def unvecMatrix (v : Fin D × Fin D → ℂ) : Matrix (Fin D) (Fin D) ℂ :=
+  fun i j => v (i, j)
+
+@[simp]
+theorem vecMatrix_apply (M : Matrix (Fin D) (Fin D) ℂ) (i j : Fin D) :
+    vecMatrix M (i, j) = M i j := rfl
+
+@[simp]
+theorem unvecMatrix_apply (v : Fin D × Fin D → ℂ) (i j : Fin D) :
+    unvecMatrix v i j = v (i, j) := rfl
+
+@[simp]
+theorem unvecMatrix_vecMatrix (M : Matrix (Fin D) (Fin D) ℂ) :
+    unvecMatrix (vecMatrix M) = M := by
+  ext i j; simp
+
+@[simp]
+theorem vecMatrix_unvecMatrix (v : Fin D × Fin D → ℂ) :
+    vecMatrix (unvecMatrix v) = v := by
+  ext ⟨i, j⟩; simp
+
+/-- Vectorization is linear. -/
+noncomputable def vecMatrixLM : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] (Fin D × Fin D → ℂ) where
+  toFun := vecMatrix
+  map_add' _ _ := by ext ⟨i, j⟩; simp [vecMatrix, Pi.add_apply]
+  map_smul' _ _ := by ext ⟨i, j⟩; simp [vecMatrix, Pi.smul_apply, smul_eq_mul]
+
+/-- Unvectorization is linear. -/
+noncomputable def unvecMatrixLM : (Fin D × Fin D → ℂ) →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ where
+  toFun := unvecMatrix
+  map_add' _ _ := by ext i j; simp [unvecMatrix]
+  map_smul' _ _ := by ext i j; simp [unvecMatrix, smul_eq_mul]
+
+end Matrix
+
+/-! ### The transfer matrix -/
+
+/-- The **transfer matrix** of a linear map `T : M_D(ℂ) → M_D(ℂ)`:
+
+  `T̂_{(i,j),(k,l)} = (T(E_{kl}))_{ij}`
+
+where `E_{kl} = Matrix.single k l 1` is the standard matrix unit.
+This is a `(Fin D × Fin D) × (Fin D × Fin D)` matrix that represents `T`
+in the vectorized picture. -/
+noncomputable def transferMatrix
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
+  fun ⟨i, j⟩ ⟨k, l⟩ => (T (Matrix.single k l 1)) i j
+
+@[simp]
+theorem transferMatrix_apply
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (i j k l : Fin D) :
+    transferMatrix T (i, j) (k, l) = (T (Matrix.single k l 1)) i j := rfl
+
+/-! ### Fundamental property: T̂ represents T in the vectorized picture -/
+
+/-- **Key property**: the transfer matrix faithfully represents `T`:
+`(T̂ *ᵥ vec(ρ))_{(i,j)} = (T(ρ))_{ij}`.
+
+This is the defining property of the transfer-matrix representation:
+vectorizing `T(ρ)` is the same as multiplying `T̂` by `vec(ρ)`. -/
+theorem transferMatrix_mulVec_eq
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    transferMatrix T *ᵥ Matrix.vecMatrix ρ =
+      Matrix.vecMatrix (T ρ) := by
+  ext ⟨i, j⟩
+  simp only [Matrix.mulVec_def, Matrix.dotProduct, transferMatrix_apply,
+    Matrix.vecMatrix_apply, Fintype.sum_prod_type]
+  -- Expand ρ in the standard basis: ρ = ∑_{k,l} ρ_{kl} · E_{kl}
+  conv_rhs =>
+    rw [show ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 from by
+      ext a b
+      simp [Matrix.sum_apply, Matrix.smul_apply, Matrix.single, smul_eq_mul,
+        Finset.sum_ite_eq', Finset.mem_univ]]
+  simp [map_sum, LinearMap.map_smul, Matrix.smul_apply, smul_eq_mul]
+
+/-! ### Compatibility with composition -/
+
+/-- The transfer matrix of a composition is the product of transfer matrices. -/
+theorem transferMatrix_comp
+    (S T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    transferMatrix (S ∘ₗ T) = transferMatrix S * transferMatrix T := by
+  ext ⟨i, j⟩ ⟨k, l⟩
+  simp only [transferMatrix_apply, LinearMap.comp_apply, Matrix.mul_apply,
+    Fintype.sum_prod_type]
+  -- S(T(E_{kl})) = S(∑_{a,b} (T(E_{kl}))_{ab} · E_{ab}) = ∑_{a,b} (T(E_{kl}))_{ab} · S(E_{ab})
+  conv_lhs =>
+    rw [show T (Matrix.single k l 1) =
+      ∑ a : Fin D, ∑ b : Fin D,
+        (T (Matrix.single k l 1)) a b • Matrix.single a b 1 from by
+      ext x y
+      simp [Matrix.sum_apply, Matrix.smul_apply, Matrix.single, smul_eq_mul,
+        Finset.sum_ite_eq', Finset.mem_univ]]
+  simp [map_sum, LinearMap.map_smul, Matrix.smul_apply, smul_eq_mul]
+
+/-- The transfer matrix of the identity map is the identity matrix. -/
+@[simp]
+theorem transferMatrix_id :
+    transferMatrix (LinearMap.id : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] _) = 1 := by
+  ext ⟨i, j⟩ ⟨k, l⟩
+  simp [transferMatrix_apply, Matrix.single, Matrix.one_apply, Prod.ext_iff]
+  constructor
+  · rintro ⟨rfl, rfl⟩; rfl
+  · intro h; exact ⟨h.1, h.2⟩
+
+/-- `transferMatrix` is injective: distinct linear maps have distinct
+transfer matrices. -/
+theorem transferMatrix_injective :
+    Function.Injective
+      (transferMatrix : (Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] _) →
+        Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) := by
+  intro S T h
+  ext M i j
+  have key := congr_fun (congr_fun (congrArg Matrix.mulVec h) (Matrix.vecMatrix M)) (i, j)
+  simp only [transferMatrix_mulVec_eq, Matrix.vecMatrix_apply] at key
+  exact key
+
+/-! ### Transfer matrix as a linear map -/
+
+/-- `transferMatrix` as a linear map from superoperators to matrices on the
+vectorized space. -/
+noncomputable def transferMatrixLM :
+    (Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) →ₗ[ℂ]
+      Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ where
+  toFun := transferMatrix
+  map_add' S T := by
+    ext ⟨i, j⟩ ⟨k, l⟩
+    simp [transferMatrix_apply, LinearMap.add_apply, Matrix.add_apply]
+  map_smul' c T := by
+    ext ⟨i, j⟩ ⟨k, l⟩
+    simp [transferMatrix_apply, LinearMap.smul_apply, Matrix.smul_apply, smul_eq_mul]
+
+/-! ### Kraus representation of the transfer matrix -/
+
+/-- For a Kraus map `T(X) = ∑ᵢ Kᵢ X Kᵢ†`, the transfer matrix is
+`∑ᵢ Kᵢ ⊗ K̄ᵢ` (Kronecker product of `Kᵢ` with its entrywise conjugate).
+
+This connects the channel-theoretic Kraus representation with the
+vectorized transfer-matrix picture. -/
+theorem transferMatrix_kraus
+    {r : ℕ} (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ) :
+    transferMatrix T =
+      ∑ n : Fin r,
+        kroneckerMap (· * ·) (K n) (star (K n)) := by
+  ext ⟨i, j⟩ ⟨k, l⟩
+  simp only [transferMatrix_apply, hK, Matrix.sum_apply, kroneckerMap_apply,
+    Matrix.conjTranspose_apply, Pi.star_apply, starRingEnd_self_apply]
+  congr 1; ext n
+  simp only [Matrix.mul_apply, Matrix.single, Matrix.of_apply]
+  -- (K n * E_{kl} * (K n)ᴴ)_{ij} = (K n)_{ik} * conj((K n)_{jl})
+  simp_rw [Finset.mul_sum]
+  simp only [ite_mul, one_mul, zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte,
+    Matrix.conjTranspose_apply]
+  ring
+
+/-! ### Connection to MPS transfer maps -/
+
+namespace MPSTensor
+
+/-- The MPS transfer map `E_A(X) = ∑ᵢ Aᵢ X Aᵢ†` has transfer matrix
+`∑ᵢ Aᵢ ⊗ Āᵢ`.
+
+This bridges Wolf's channel-side §2.2 transfer matrix with the MPS-side
+transfer operator. -/
+theorem transferMatrix_eq (A : MPSTensor d D) :
+    transferMatrix (MPSTensor.transferMap A) =
+      ∑ n : Fin d,
+        kroneckerMap (· * ·) (A n) (star (A n)) :=
+  transferMatrix_kraus A _ (fun X => by simp [transferMap_apply])
+
+end MPSTensor

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -115,6 +115,13 @@ theorem transferMatrix_apply
     (i j k l : Fin D) :
     transferMatrix T (i, j) (k, l) = (T (Matrix.single k l 1)) i j := rfl
 
+private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 := by
+  conv_lhs => rw [Matrix.matrix_eq_sum_single ρ]
+  refine Finset.sum_congr rfl fun k _ => Finset.sum_congr rfl fun l _ => ?_
+  ext a b
+  simp [Matrix.single_apply, smul_eq_mul]
+
 /-! ### Fundamental property: T̂ represents T in the vectorized picture -/
 
 /-- **Key property**: the transfer matrix faithfully represents `T`:
@@ -128,15 +135,13 @@ theorem transferMatrix_mulVec_eq
     transferMatrix T *ᵥ Matrix.vecMatrix ρ =
       Matrix.vecMatrix (T ρ) := by
   ext ⟨i, j⟩
-  simp only [Matrix.mulVec_def, Matrix.dotProduct, transferMatrix_apply,
+  simp only [Matrix.mulVec, dotProduct, transferMatrix_apply,
     Matrix.vecMatrix_apply, Fintype.sum_prod_type]
-  -- Expand ρ in the standard basis: ρ = ∑_{k,l} ρ_{kl} · E_{kl}
-  conv_rhs =>
-    rw [show ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 from by
-      ext a b
-      simp [Matrix.sum_apply, Matrix.smul_apply, Matrix.single, smul_eq_mul,
-        Finset.sum_ite_eq', Finset.mem_univ]]
-  simp [map_sum, LinearMap.map_smul, Matrix.smul_apply, smul_eq_mul]
+  have key : T ρ = ∑ k, ∑ l, ρ k l • T (Matrix.single k l 1) := by
+    conv_lhs => rw [sum_smul_single_eq ρ]
+    simp_rw [map_sum, LinearMap.map_smul]
+  rw [key]
+  simp [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul, mul_comm]
 
 /-! ### Compatibility with composition -/
 
@@ -147,25 +152,21 @@ theorem transferMatrix_comp
   ext ⟨i, j⟩ ⟨k, l⟩
   simp only [transferMatrix_apply, LinearMap.comp_apply, Matrix.mul_apply,
     Fintype.sum_prod_type]
-  -- S(T(E_{kl})) = S(∑_{a,b} (T(E_{kl}))_{ab} · E_{ab}) = ∑_{a,b} (T(E_{kl}))_{ab} · S(E_{ab})
-  conv_lhs =>
-    rw [show T (Matrix.single k l 1) =
-      ∑ a : Fin D, ∑ b : Fin D,
-        (T (Matrix.single k l 1)) a b • Matrix.single a b 1 from by
-      ext x y
-      simp [Matrix.sum_apply, Matrix.smul_apply, Matrix.single, smul_eq_mul,
-        Finset.sum_ite_eq', Finset.mem_univ]]
-  simp [map_sum, LinearMap.map_smul, Matrix.smul_apply, smul_eq_mul]
+  have key : S (T (Matrix.single k l 1)) =
+      ∑ a, ∑ b, (T (Matrix.single k l 1)) a b • S (Matrix.single a b 1) := by
+    conv_lhs => rw [sum_smul_single_eq (T (Matrix.single k l 1))]
+    simp_rw [map_sum, LinearMap.map_smul]
+  rw [key]
+  simp [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul, mul_comm]
 
 /-- The transfer matrix of the identity map is the identity matrix. -/
 @[simp]
 theorem transferMatrix_id :
     transferMatrix (LinearMap.id : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] _) = 1 := by
   ext ⟨i, j⟩ ⟨k, l⟩
-  simp [transferMatrix_apply, Matrix.single, Matrix.one_apply, Prod.ext_iff]
-  constructor
-  · rintro ⟨rfl, rfl⟩; rfl
-  · intro h; exact ⟨h.1, h.2⟩
+  simp only [transferMatrix_apply, LinearMap.id_apply, Matrix.one_apply, Prod.mk.injEq]
+  rw [Matrix.single_apply]
+  simp [eq_comm]
 
 /-- `transferMatrix` is injective: distinct linear maps have distinct
 transfer matrices. -/
@@ -207,17 +208,15 @@ theorem transferMatrix_kraus
     (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ) :
     transferMatrix T =
       ∑ n : Fin r,
-        kroneckerMap (· * ·) (K n) (star (K n)) := by
+        kroneckerMap (· * ·) (K n) ((K n).map (starRingEnd ℂ)) := by
   ext ⟨i, j⟩ ⟨k, l⟩
-  simp only [transferMatrix_apply, hK, Matrix.sum_apply, kroneckerMap_apply,
-    Matrix.conjTranspose_apply, Pi.star_apply, starRingEnd_self_apply]
+  simp only [transferMatrix_apply, hK, Matrix.sum_apply, kroneckerMap_apply, Matrix.map_apply,
+    starRingEnd_apply]
   congr 1; ext n
-  simp only [Matrix.mul_apply, Matrix.single, Matrix.of_apply]
-  -- (K n * E_{kl} * (K n)ᴴ)_{ij} = (K n)_{ik} * conj((K n)_{jl})
-  simp_rw [Finset.mul_sum]
-  simp only [ite_mul, one_mul, zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte,
-    Matrix.conjTranspose_apply]
-  ring
+  -- (K n * E_{kl} * (K n)ᴴ)_{ij} = (K n)_{ik} * star((K n)_{jl})
+  simp only [Matrix.mul_apply, Matrix.single_apply, Matrix.conjTranspose_apply]
+  simp only [ite_and, mul_ite, mul_one, mul_zero, ite_mul, zero_mul,
+    Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte]
 
 /-! ### Connection to MPS transfer maps -/
 
@@ -231,7 +230,7 @@ transfer operator. -/
 theorem transferMatrix_eq (A : MPSTensor d D) :
     transferMatrix (MPSTensor.transferMap A) =
       ∑ n : Fin d,
-        kroneckerMap (· * ·) (A n) (star (A n)) :=
+        kroneckerMap (· * ·) (A n) ((A n).map (starRingEnd ℂ)) :=
   transferMatrix_kraus A _ (fun X => by simp [transferMap_apply])
 
 end MPSTensor

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -8,6 +8,7 @@ import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Stinespring
+import TNLean.Channel.TransferMatrix
 
 /-!
 # Wolf Lecture Notes — Chapter 2: Representations
@@ -40,6 +41,18 @@ representations of quantum channels.
   - `stinespringV_isometry_iff_kraus_normalized` — `V†V = 𝟙` ↔ TP ✅
   - `stinespring_schrodinger_representation` — `T(ρ) = tr_r(VρV†)` ✅
 
+### §2.2 Transfer matrix
+
+* `transferMatrix` — the `D² × D²` matrix representing `T` in the
+  standard-basis vectorization ✅
+* `transferMatrix_mulVec_eq` — `T̂ *ᵥ vec(ρ) = vec(T(ρ))` ✅
+* `transferMatrix_comp` — `(S ∘ T)^ = Ŝ * T̂` ✅
+* `transferMatrix_id` — transfer matrix of identity = identity ✅
+* `transferMatrix_injective` — the representation is faithful ✅
+* `transferMatrix_kraus` — Kraus form: `T̂ = ∑ᵢ Kᵢ ⊗ K̄ᵢ` ✅
+* `MPSTensor.transferMatrix_eq` — MPS bridge:
+  `E_A` has transfer matrix `∑ᵢ Aᵢ ⊗ Āᵢ` ✅
+
 ### Infrastructure
 
 | Definition | File | Lean name |
@@ -52,6 +65,8 @@ representations of quantum channels.
 | Tensor product of maps | `TensorMap.lean` | `Matrix.tensorMapId` |
 | Choi matrix | `ChoiJamiolkowski.lean` | `ChoiJamiolkowski.choiMatrix` |
 | Stinespring isometry | `Stinespring.lean` | `stinespringV` |
+| Transfer matrix | `TransferMatrix.lean` | `transferMatrix` |
+| Vectorization | `TransferMatrix.lean` | `Matrix.vecMatrix` |
 
 ### Not yet formalized
 
@@ -65,7 +80,6 @@ representations of quantum channels.
 | Thm 2.4 (Radon-Nikodym) | Follows from Thm 2.3 |
 | Thm 2.5 (open-system representation) | Embedding into unitary |
 | Thm 2.6 (Neumark's theorem) | POVM embedding |
-| §2.2 (transfer matrix) | Matrix representation of channels |
 | §2.3 (normal forms) | Lorentz normal form etc. |
 
 ## References

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -49,9 +49,9 @@ representations of quantum channels.
 * `transferMatrix_comp` — `(S ∘ T)^ = Ŝ * T̂` ✅
 * `transferMatrix_id` — transfer matrix of identity = identity ✅
 * `transferMatrix_injective` — the representation is faithful ✅
-* `transferMatrix_kraus` — Kraus form: `T̂ = ∑ᵢ Kᵢ ⊗ K̄ᵢ` ✅
+* `transferMatrix_kraus` — Kraus form: `T̂ = ∑ᵢ K̄ᵢ ⊗ₖ Kᵢ` ✅
 * `MPSTensor.transferMatrix_eq` — MPS bridge:
-  `E_A` has transfer matrix `∑ᵢ Aᵢ ⊗ Āᵢ` ✅
+  `E_A` has transfer matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ` ✅
 
 ### Infrastructure
 
@@ -66,7 +66,7 @@ representations of quantum channels.
 | Choi matrix | `ChoiJamiolkowski.lean` | `ChoiJamiolkowski.choiMatrix` |
 | Stinespring isometry | `Stinespring.lean` | `stinespringV` |
 | Transfer matrix | `TransferMatrix.lean` | `transferMatrix` |
-| Vectorization | `TransferMatrix.lean` | `Matrix.vecMatrix` |
+| Vectorization | `Mathlib.LinearAlgebra.Matrix.Vec` | `Matrix.vec` |
 
 ### Not yet formalized
 


### PR DESCRIPTION
Formalize the transfer-matrix representation of channels from Wolf Chapter 2, §2.2.

## Changes

- New file `TNLean/Channel/TransferMatrix.lean` with vectorization, transfer matrix, composition, Kraus form, and MPS bridge
- Updated `WolfChapter2Index.lean` with §2.2 coverage
- Added root import in `TNLean.lean`

Closes LionSR/QICLean#117

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new formalization module and re-exports it; no existing channel logic is modified, so risk is mainly around new lemmas/definitions affecting downstream imports and compile times.
> 
> **Overview**
> Adds a new `TransferMatrix` module formalizing Wolf §2.2’s transfer-matrix (vectorized) representation for linear maps `M_D(ℂ) →ₗ M_D(ℂ)`, including the core `vec(T(ρ)) = T̂ *ᵥ vec(ρ)` lemma, composition/identity results, and injectivity of the representation.
> 
> Proves a Kraus-form characterization `T̂ = ∑ᵢ K̄ᵢ ⊗ₖ Kᵢ` and links it to MPS transfer maps via `MPSTensor.transferMatrix_eq`. Exposes the new material by importing `TNLean.Channel.TransferMatrix` from `TNLean.lean` and indexing it in `WolfChapter2Index.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c16cbce1cfb2fd4f5c52a06f65c293609c90795. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


Refs LionSR/QICLean#15
