### PR TITLE
[Wolf Ch2] Add unitary-witness wrappers for Kraus map equality

### DIFF
--- a/TNLean/Channel/KrausRepresentation.lean
+++ b/TNLean/Channel/KrausRepresentation.lean
@@ -136,3 +136,33 @@ theorem kraus_same_map_of_unitary_combination
           (if l' = l then 1 else 0) • (K' l * X * (K' l')ᴴ) := by
           simp_rw [hU_entry]; simp
     _ = ∑ l : Fin r, K' l * X * (K' l)ᴴ := by simp
+
+/-- Convenience wrapper of `kraus_same_map_of_unitary_combination` with a bundled
+unitary witness. This formulation is intended for use by the future converse direction:
+once a unitary witness is constructed (typically from Choi data), map equality follows
+immediately. -/
+theorem kraus_same_map_of_unitaryGroup_combination
+    {r : ℕ}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (K' : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (U : Matrix.unitaryGroup (Fin r) ℂ)
+    (hK : ∀ j, K j = ∑ l, (U : Matrix (Fin r) (Fin r) ℂ) j l • K' l) :
+    ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ j : Fin r, K j * X * (K j)ᴴ =
+      ∑ l : Fin r, K' l * X * (K' l)ᴴ := by
+  exact kraus_same_map_of_unitary_combination K K' (U : Matrix (Fin r) (Fin r) ℂ)
+    (Matrix.mem_unitaryGroup_iff'.mp U.prop) hK
+
+/-- Existentially packaged sufficient direction for Kraus unitary freedom:
+if a unitary mixing witness exists, the two Kraus families define the same map. -/
+theorem kraus_same_map_of_exists_unitary_combination
+    {r : ℕ}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (K' : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (hU : ∃ U : Matrix.unitaryGroup (Fin r) ℂ,
+      ∀ j, K j = ∑ l, (U : Matrix (Fin r) (Fin r) ℂ) j l • K' l) :
+    ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ j : Fin r, K j * X * (K j)ᴴ =
+      ∑ l : Fin r, K' l * X * (K' l)ᴴ := by
+  rcases hU with ⟨U, hKU⟩
+  exact kraus_same_map_of_unitaryGroup_combination K K' U hKU

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -34,6 +34,8 @@ representations of quantum channels.
   - `kraus_sum_conjTranspose_mul_of_tp` — TP ⟹ `∑Kᵢ†Kᵢ = 𝟙` ✅
   - `kraus_sum_mul_conjTranspose_of_unital` — unital ⟹ `∑KᵢKᵢ† = 𝟙` ✅
   - `kraus_same_map_of_unitary_combination` — unitary freedom (sufficient direction) ✅
+  - `kraus_same_map_of_unitaryGroup_combination` / `kraus_same_map_of_exists_unitary_combination`
+    — bundled/existential unitary-witness wrappers for reuse in the converse roadmap ✅
 
 * **Thm 2.2** (Stinespring dilation):
   - `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` ✅


### PR DESCRIPTION
### Motivation

- Provide small API helpers to make it easy to discharge the sufficient-direction unitary-freedom step once a unitary witness (e.g. from Choi eigendecomposition) is constructed.

### Description

- Added `kraus_same_map_of_unitaryGroup_combination` which accepts a bundled `Matrix.unitaryGroup` witness and forwards to `kraus_same_map_of_unitary_combination`.
- Added `kraus_same_map_of_exists_unitary_combination`, an existential wrapper that accepts `∃ U, …` and applies the previous lemma.
- Updated the Chapter 2 index (`TNLean/Channel/WolfChapter2Index.lean`) to record the new helpers as infrastructure for the converse (necessary) unitary-freedom roadmap.
- Small typing fix: use `Matrix.mem_unitaryGroup_iff'` to extract the `Aᴴ * A = 1` property from a `Matrix.unitaryGroup` element.

### Testing

- Ran `lake build TNLean.Channel.KrausRepresentation TNLean.Channel.WolfChapter2Index` which completed successfully.
- Ran full `lake build` which completed successfully; there remain pre-existing warnings about `sorry` in unrelated files but no new failures from these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69befdc2a77083249101b92c922a201a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two wrapper theorems around existing `kraus_same_map_of_unitary_combination` without changing core proofs or semantics; only potential risk is minor typeclass/lemma mismatch around `unitaryGroup` coercions.
> 
> **Overview**
> Adds two convenience theorems in `KrausRepresentation.lean` that repackage the existing unitary-freedom result: one takes a bundled `Matrix.unitaryGroup` witness (`kraus_same_map_of_unitaryGroup_combination`), and one takes an existential unitary witness (`kraus_same_map_of_exists_unitary_combination`).
> 
> Updates `WolfChapter2Index.lean` to list these new helpers under Thm 2.1’s unitary-freedom coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c62487aac4afbeec0c358d5b7ae1e812686687d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


Refs LionSR/QICLean#118
Refs LionSR/QICLean#15
