### PR TITLE
[Wolf Ch7] Add Dyson iterates and one-step recursive norm bound in Perturbation

### DIFF
--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -220,4 +220,67 @@ theorem perturbation_bound_unit_norm
         rw [Real.volume_Icc, ENNReal.toReal_ofReal (by linarith : (0 : ℝ) ≤ t - 0)]
         ring
 
+/-! ## Dyson-Phillips iterates -/
+
+/-- Recursive Dyson-Phillips terms built from the unperturbed semigroup `L`
+and perturbation `L' - L`. -/
+noncomputable def dysonTerm
+    (L L' : CLM D) (t : ℝ) : ℕ → CLM D
+  | 0 => expSemigroupCLM L t
+  | n + 1 =>
+      ∫ s in Set.Icc 0 t,
+        expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n
+
+@[simp] lemma dysonTerm_zero (L L' : CLM D) (t : ℝ) :
+    dysonTerm L L' t 0 = expSemigroupCLM L t := rfl
+
+@[simp] lemma dysonTerm_succ (L L' : CLM D) (t : ℝ) (n : ℕ) :
+    dysonTerm L L' t (n + 1) =
+      ∫ s in Set.Icc 0 t,
+        expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n := rfl
+
+/-- Zeroth Dyson term is controlled by the same compact-interval `iSup` used above. -/
+lemma norm_dysonTerm_zero_le
+    (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) :
+    ‖dysonTerm L L' t 0‖ ≤ ⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖ := by
+  simpa [dysonTerm] using
+    (norm_expSemigroup_le_biSup (L := L) (t := t) ht (x := t) (Set.right_mem_Icc.mpr ht))
+
+/-- One-step norm estimate for the Dyson recursion.
+This is the inductive estimate used to bootstrap higher-order bounds. -/
+lemma norm_dysonTerm_succ_le
+    (L L' : CLM D) {t K : ℝ} (ht : 0 ≤ t) (n : ℕ)
+    (hK : ∀ s ∈ Set.Icc 0 t, ‖dysonTerm L L' s n‖ ≤ K) :
+    ‖dysonTerm L L' t (n + 1)‖ ≤
+      t *
+        (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖) * ‖L' - L‖ * K := by
+  rw [dysonTerm_succ]
+  set M : ℝ := ⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖
+  have hmeas : volume (Set.Icc (0 : ℝ) t) < ⊤ := by
+    rw [Real.volume_Icc]
+    exact ENNReal.ofReal_lt_top
+  have hpointwise : ∀ s ∈ Set.Icc 0 t,
+      ‖expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n‖ ≤ M * ‖L' - L‖ * K := by
+    intro s hs
+    calc ‖expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n‖
+        ≤ ‖expSemigroupCLM L (t - s) * (L' - L)‖ * ‖dysonTerm L L' s n‖ := norm_mul_le _ _
+      _ ≤ ‖expSemigroupCLM L (t - s)‖ * ‖L' - L‖ * ‖dysonTerm L L' s n‖ :=
+          mul_le_mul_of_nonneg_right (norm_mul_le _ _) (norm_nonneg _)
+      _ ≤ M * ‖L' - L‖ * K := by
+          apply mul_le_mul (mul_le_mul_of_nonneg_right ?_ (norm_nonneg _)) ?_
+            (norm_nonneg _) (mul_nonneg ?_ (norm_nonneg _))
+          · exact norm_expSemigroup_le_biSup L ht
+              ⟨sub_nonneg.mpr hs.2, sub_le_self t hs.1⟩
+          · exact hK s hs
+          · exact le_trans (norm_nonneg _)
+              (norm_expSemigroup_le_biSup L ht (Set.left_mem_Icc.mpr ht))
+  calc ‖∫ s in Set.Icc 0 t, expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n‖
+      ≤ M * ‖L' - L‖ * K * (volume (Set.Icc (0 : ℝ) t)).toReal :=
+        norm_setIntegral_le_of_norm_le_const hmeas hpointwise
+    _ = t * M * ‖L' - L‖ * K := by
+        rw [Real.volume_Icc, ENNReal.toReal_ofReal (by linarith : (0 : ℝ) ≤ t - 0)]
+        ring
+    _ = t * (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖) * ‖L' - L‖ * K := by
+        simp [M, mul_left_comm, mul_comm]
+
 end -- noncomputable section


### PR DESCRIPTION
### Motivation
- Extend the single-step Duhamel identity toward the Dyson–Phillips series by introducing the iterated Duhamel terms and the core inductive estimate needed to obtain factorial norm bounds and summability.

### Description
- Add a recursive definition `dysonTerm` implementing the Dyson-Phillips iterates with base `dysonTerm ... 0 = expSemigroupCLM L t` and recursive integral step `dysonTerm ... (n+1) = ∫₀ᵗ expSemigroupCLM L (t-s) * (L' - L) * dysonTerm ... s n` in `TNLean/Channel/Semigroup/Perturbation.lean`.
- Provide simp lemmas `dysonTerm_zero` and `dysonTerm_succ` for unfolding the recursion.
- Add the base control lemma `norm_dysonTerm_zero_le` bounding the zeroth term by the existing interval `iSup` for `expSemigroupCLM`.
- Add the core one-step inductive estimate `norm_dysonTerm_succ_le`, formulated with an explicit hypothesis `hK : ∀ s ∈ [0,t], ‖dysonTerm ... s n‖ ≤ K`, proving `‖dysonTerm ... (n+1)‖ ≤ t * M * ‖L' - L‖ * K` where `M = ⨆_{s∈[0,t]} ‖expSemigroupCLM L s‖`.

### Testing
- Built the updated target with `lake build TNLean.Channel.Semigroup.Perturbation` and the target build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2a43123c8324a4fda687c9ae0c91)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to new Lean definitions/lemmas in `Perturbation.lean` with no impact on runtime behavior, though they may affect downstream proof obligations via new simp lemmas.
> 
> **Overview**
> Adds a recursive definition `dysonTerm` implementing Dyson–Phillips iterates for a perturbed semigroup, plus simp lemmas (`dysonTerm_zero`, `dysonTerm_succ`) to unfold the recursion.
> 
> Proves foundational bounds for later series estimates: `norm_dysonTerm_zero_le` (zeroth term controlled by the existing interval `iSup`) and `norm_dysonTerm_succ_le` (a one-step inductive norm bound for the recursive integral term).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 492f9ed3f2e5f6306c081850c5bb5eaf13fb61f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->