### PR TITLE
[Wolf Ch7] Add telescoping quantitative bound for Lie–Trotter (power lemma + bridge)

### DIFF
--- a/TNLean/Channel/Semigroup/ProductFormula.lean
+++ b/TNLean/Channel/Semigroup/ProductFormula.lean
@@ -113,13 +113,13 @@ theorem expSemigroupCLM_pow_eq
         ring
       rw [← expSemigroupCLM_add, hm]
 
-/-- Telescope estimate for powers in a normed algebra. -/
-theorem norm_pow_sub_pow_le [NeZero D]
+/-- Telescope estimate for powers in a normed algebra under uniform norm bounds. -/
+theorem norm_pow_sub_pow_le_of_norm_le [NeZero D]
     {A B : CLM D} {M : ℝ} (hM : 1 ≤ M) (hA : ‖A‖ ≤ M) (hB : ‖B‖ ≤ M) :
     ∀ m : ℕ, ‖A ^ m - B ^ m‖ ≤ (m : ℝ) * M ^ m * ‖A - B‖
   | 0 => by simp
   | m + 1 => by
-      have hm := norm_pow_sub_pow_le hM hA hB m
+      have hm := norm_pow_sub_pow_le_of_norm_le hM hA hB m
       have hsplit : A ^ (m + 1) - B ^ (m + 1) = A ^ m * (A - B) + (A ^ m - B ^ m) * B := by
         rw [pow_succ, pow_succ, mul_sub, sub_mul]
         abel
@@ -175,7 +175,8 @@ theorem norm_trotter_pow_sub_exp_le_of_step [NeZero D]
     exact Real.one_le_exp (mul_nonneg hs_nonneg (add_nonneg (norm_nonneg _) (norm_nonneg _)))
   have hpow : ‖E ^ (n + 1) - S ^ (n + 1)‖ ≤
       ((n + 1 : ℕ) : ℝ) * (Real.exp (s * (‖A‖ + ‖B‖))) ^ (n + 1) * ‖E - S‖ := by
-    exact norm_pow_sub_pow_le (D := D) (A := E) (B := S) (M := Real.exp (s * (‖A‖ + ‖B‖)))
+    exact norm_pow_sub_pow_le_of_norm_le (D := D) (A := E) (B := S)
+      (M := Real.exp (s * (‖A‖ + ‖B‖)))
       hM hE_le hS_le (n + 1)
   have hMpow : (Real.exp (s * (‖A‖ + ‖B‖))) ^ (n + 1) = Real.exp (t * (‖A‖ + ‖B‖)) := by
     dsimp [s]

--- a/TNLean/Channel/Semigroup/ProductFormula.lean
+++ b/TNLean/Channel/Semigroup/ProductFormula.lean
@@ -113,6 +113,92 @@ theorem expSemigroupCLM_pow_eq
         ring
       rw [← expSemigroupCLM_add, hm]
 
+/-- Telescope estimate for powers in a normed algebra. -/
+theorem norm_pow_sub_pow_le [NeZero D]
+    {A B : CLM D} {M : ℝ} (hM : 1 ≤ M) (hA : ‖A‖ ≤ M) (hB : ‖B‖ ≤ M) :
+    ∀ m : ℕ, ‖A ^ m - B ^ m‖ ≤ (m : ℝ) * M ^ m * ‖A - B‖
+  | 0 => by simp
+  | m + 1 => by
+      have hm := norm_pow_sub_pow_le hM hA hB m
+      have hsplit : A ^ (m + 1) - B ^ (m + 1) = A ^ m * (A - B) + (A ^ m - B ^ m) * B := by
+        rw [pow_succ, pow_succ, mul_sub, sub_mul]
+        abel
+      rw [hsplit]
+      have hδ_nonneg : 0 ≤ ‖A - B‖ := norm_nonneg _
+      calc
+        ‖A ^ m * (A - B) + (A ^ m - B ^ m) * B‖ ≤
+            ‖A ^ m * (A - B)‖ + ‖(A ^ m - B ^ m) * B‖ := norm_add_le _ _
+        _ ≤ ‖A ^ m‖ * ‖A - B‖ + ‖A ^ m - B ^ m‖ * ‖B‖ := by
+              gcongr <;> exact norm_mul_le _ _
+        _ ≤ M ^ m * ‖A - B‖ + ((m : ℝ) * M ^ m * ‖A - B‖) * M := by
+              gcongr
+              · exact norm_pow_le _ _ |>.trans <|
+                  pow_le_pow_left₀ (show 0 ≤ ‖A‖ from norm_nonneg _) hA _
+        _ = M ^ m * ‖A - B‖ + (m : ℝ) * M ^ (m + 1) * ‖A - B‖ := by
+              ring_nf
+        _ ≤ M ^ (m + 1) * ‖A - B‖ + (m : ℝ) * M ^ (m + 1) * ‖A - B‖ := by
+              have hpowδ : M ^ m * ‖A - B‖ ≤ M ^ (m + 1) * ‖A - B‖ := by
+                exact mul_le_mul_of_nonneg_right (pow_le_pow_right₀ hM (Nat.le_succ m)) hδ_nonneg
+              nlinarith
+        _ = ((m + 1 : ℕ) : ℝ) * M ^ (m + 1) * ‖A - B‖ := by
+              rw [Nat.cast_add, Nat.cast_one]
+              ring
+
+/-- Quantitative Lie--Trotter error from a one-step bound at mesh size `t/(n+1)`. -/
+theorem norm_trotter_pow_sub_exp_le_of_step [NeZero D]
+    (A B : CLM D) (t : ℝ) (n : ℕ) (ht : 0 ≤ t) {δ : ℝ}
+    (hδ : ‖expSemigroupCLM A (t / (n + 1)) * expSemigroupCLM B (t / (n + 1))
+          - expSemigroupCLM (A + B) (t / (n + 1))‖ ≤ δ) :
+    ‖(expSemigroupCLM A (t / (n + 1)) * expSemigroupCLM B (t / (n + 1))) ^ (n + 1)
+      - expSemigroupCLM (A + B) t‖
+      ≤ ((n + 1 : ℕ) : ℝ) * Real.exp (t * (‖A‖ + ‖B‖)) * δ := by
+  let s : ℝ := t / (n + 1)
+  let E : CLM D := expSemigroupCLM A s * expSemigroupCLM B s
+  let S : CLM D := expSemigroupCLM (A + B) s
+  have hs_nonneg : 0 ≤ s := by
+    dsimp [s]
+    positivity
+  have hE_le : ‖E‖ ≤ Real.exp (s * (‖A‖ + ‖B‖)) := by
+    calc
+      ‖E‖ = ‖expSemigroupCLM A s * expSemigroupCLM B s‖ := by rfl
+      _ ≤ Real.exp (s * ‖A‖) * Real.exp (s * ‖B‖) := norm_trotter_step_le A B s hs_nonneg
+      _ = Real.exp (s * ‖A‖ + s * ‖B‖) := by rw [Real.exp_add]
+      _ = Real.exp (s * (‖A‖ + ‖B‖)) := by ring_nf
+  have hS_le0 : ‖S‖ ≤ Real.exp (s * ‖A + B‖) := by
+    simpa [S] using norm_expSemigroupCLM_le (A := A + B) s hs_nonneg
+  have hS_le : ‖S‖ ≤ Real.exp (s * (‖A‖ + ‖B‖)) := by
+    have hmul : s * ‖A + B‖ ≤ s * (‖A‖ + ‖B‖) := by
+      gcongr
+      exact norm_add_le A B
+    exact hS_le0.trans <| by gcongr
+  have hM : 1 ≤ Real.exp (s * (‖A‖ + ‖B‖)) := by
+    exact Real.one_le_exp (mul_nonneg hs_nonneg (add_nonneg (norm_nonneg _) (norm_nonneg _)))
+  have hpow : ‖E ^ (n + 1) - S ^ (n + 1)‖ ≤
+      ((n + 1 : ℕ) : ℝ) * (Real.exp (s * (‖A‖ + ‖B‖))) ^ (n + 1) * ‖E - S‖ := by
+    exact norm_pow_sub_pow_le (D := D) (A := E) (B := S) (M := Real.exp (s * (‖A‖ + ‖B‖)))
+      hM hE_le hS_le (n + 1)
+  have hMpow : (Real.exp (s * (‖A‖ + ‖B‖))) ^ (n + 1) = Real.exp (t * (‖A‖ + ‖B‖)) := by
+    dsimp [s]
+    rw [← Real.exp_nat_mul]
+    congr 1
+    rw [Nat.cast_add, Nat.cast_one]
+    field_simp
+  have hS_eq : S ^ (n + 1) = expSemigroupCLM (A + B) t := by
+    dsimp [S, s]
+    rw [expSemigroupCLM_pow_eq (A := A + B) (s := t / (n + 1)) (m := n + 1)]
+    congr 1
+    rw [Nat.cast_add, Nat.cast_one]
+    field_simp
+  have hE_minus_S : ‖E - S‖ ≤ δ := by
+    simpa [E, S, s] using hδ
+  rw [← hS_eq]
+  calc
+    ‖E ^ (n + 1) - S ^ (n + 1)‖ ≤
+        ((n + 1 : ℕ) : ℝ) * (Real.exp (s * (‖A‖ + ‖B‖))) ^ (n + 1) * ‖E - S‖ := hpow
+    _ ≤ ((n + 1 : ℕ) : ℝ) * (Real.exp (s * (‖A‖ + ‖B‖))) ^ (n + 1) * δ := by
+          gcongr
+    _ = ((n + 1 : ℕ) : ℝ) * Real.exp (t * (‖A‖ + ‖B‖)) * δ := by rw [hMpow]
+
 end ProductFormulaHelpers
 
 end -- noncomputable section


### PR DESCRIPTION
### Motivation
- Isolate the telescoping step needed to upgrade a one-step Lie–Trotter defect into a global O(1/n) convergence bound, so only a sharp single-step `O(s^2)` estimate remains to prove Suzuki/Wolf Eq. 7.28.
- Provide a reusable power-telescope lemma for bounded operators so downstream proofs can amplify local errors into the n-fold product formula error cleanly.

### Description
- Added `norm_pow_sub_pow_le` to `TNLean/Channel/Semigroup/ProductFormula.lean`, a telescope lemma giving `‖A^m - B^m‖ ≤ m · M^m · ‖A - B‖` under uniform norm bounds `‖A‖, ‖B‖ ≤ M` and `1 ≤ M`.
- Added `norm_trotter_pow_sub_exp_le_of_step` to `TNLean/Channel/Semigroup/ProductFormula.lean`, which turns a one-step defect bound at mesh `s = t/(n+1)` into a global bound
  `‖(e^{sA} e^{sB})^{n+1} - e^{t(A+B)}‖ ≤ (n+1) · e^{t(‖A‖+‖B‖)} · δ`.
- Used existing infrastructure (`norm_expSemigroupCLM_le`, `norm_trotter_step_le`, `expSemigroupCLM_pow_eq`) and a small equality tweak (`Real.exp_add`) to make the estimates explicit and Lean-checkable.

### Testing
- Ran `lake build TNLean.Channel.Semigroup.ProductFormula` and iterated on a small proof-equality fix; the final build completed successfully for the target module.
- The modified file `TNLean/Channel/Semigroup/ProductFormula.lean` compiles and the new lemmas typecheck.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf29d5ae1c8324921e76bdfed7e7eb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean theorems/proofs (no runtime code), but the new inequalities and algebraic rewrites could affect downstream proof obligations if their statements are used incorrectly.
> 
> **Overview**
> Adds a reusable telescope lemma `norm_pow_sub_pow_le_of_norm_le` bounding `‖A^m - B^m‖` in terms of a uniform operator-norm bound `M` and `‖A - B‖`.
> 
> Builds on that to introduce `norm_trotter_pow_sub_exp_le_of_step`, which upgrades a one-step Lie–Trotter defect at mesh `t/(n+1)` into an explicit global bound for `‖(e^{sA}e^{sB})^{n+1} - e^{t(A+B)}‖`, using existing exponential norm estimates and the `expSemigroupCLM_pow_eq` collapse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 778f66a3ae928bf1b912edf2eeaca378731fc93c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->