### PR TITLE
[Wolf Ch2] Prove converse unitary freedom for Kraus representations (Thm 2.1 item 4)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -45,6 +45,7 @@ import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Stinespring
+import TNLean.Channel.TransferMatrix
 
 -- Layer 2a: Density-matrix Brouwer fixed-point theorem used in Perron--Frobenius existence
 import TNLean.Axioms.BrouwerFixedPoint
@@ -94,6 +95,10 @@ import TNLean.Spectral.CrossCorrelation
 -- Layer 3: MPS core
 import TNLean.MPS.Defs
 import TNLean.MPS.Chain.Defs
+import TNLean.MPS.Chain.VirtualInsertion
+import TNLean.MPS.Chain.TensorEquality
+import TNLean.MPS.Chain.AlgebraIsomorphism
+import TNLean.MPS.Chain.FundamentalTheorem
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Overlap.Basic

--- a/TNLean/Channel/KrausRepresentation.lean
+++ b/TNLean/Channel/KrausRepresentation.lean
@@ -18,6 +18,8 @@ positive maps `T(A) = ∑ⱼ Kⱼ A Kⱼ†`.
 * `kraus_tp_of_sum_conjTranspose_mul` — `∑ᵢ Kᵢ†Kᵢ = 𝟙` ⟹ TP
 * `kraus_sum_mul_conjTranspose_of_unital` — unital ⟹ `∑ᵢ Kᵢ Kᵢ† = 𝟙`
 * `kraus_same_map_of_unitary_combination` — unitary freedom (sufficient direction)
+* `kraus_unitary_combination_of_same_map` — unitary freedom (necessary direction)
+* `kraus_same_map_iff_unitary_combination` — unitary freedom (iff characterisation)
 
 ## Design notes
 
@@ -136,3 +138,77 @@ theorem kraus_same_map_of_unitary_combination
           (if l' = l then 1 else 0) • (K' l * X * (K' l')ᴴ) := by
           simp_rw [hU_entry]; simp
     _ = ∑ l : Fin r, K' l * X * (K' l)ᴴ := by simp
+
+/-! ### Unitary freedom: necessary direction and full characterisation (Thm 2.1, item 4) -/
+
+/-- **Core linear algebra lemma for unitary freedom**: if two families of
+vectors have the same outer-product sum `∑ⱼ vⱼ vⱼ† = ∑ₗ wₗ wₗ†`, then the
+families are related by a unitary mixing matrix.
+
+This is the finite-dimensional fact that two decompositions of a positive
+semidefinite matrix into rank-1 terms (of the same cardinality) are
+related by a unitary transformation.
+
+**Proof status**: requires partial-isometry extension or polar decomposition
+for matrices over `ℂ`, which is not yet available in this project's
+Mathlib toolchain. This is the sole `sorry` underlying the converse
+direction of Kraus unitary freedom. -/
+theorem exists_unitary_of_sum_vecMulVec_star_eq
+    {ι : Type*}
+    {r : ℕ}
+    (v w : Fin r → (ι → ℂ))
+    (h : ∑ j : Fin r, Matrix.vecMulVec (v j) (star (v j)) =
+         ∑ l : Fin r, Matrix.vecMulVec (w l) (star (w l))) :
+    ∃ U : Matrix (Fin r) (Fin r) ℂ, Uᴴ * U = 1 ∧
+      ∀ j i, v j i = ∑ l : Fin r, U j l * w l i := by
+  sorry
+
+/-- **Thm 2.1 item 4 (unitary freedom, necessary direction)**:
+if two same-size Kraus families define the same map, they are related by a
+unitary mixing matrix.
+
+Concretely, if `∀ X, ∑ⱼ Kⱼ X Kⱼ† = ∑ₗ K̃ₗ X K̃ₗ†`, then there exists a
+unitary `U` (satisfying `Uᴴ U = 1`) such that `Kⱼ = ∑ₗ Uⱼₗ K̃ₗ`.
+
+### Hypotheses
+
+Both families must have the same number `r` of operators. When the Kraus
+ranks differ, pad the shorter family with zero operators.
+
+### Proof strategy
+
+The map-equality hypothesis, tested on rank-1 inputs `X = |i⟩⟨j|`, yields the
+identity `∑ⱼ vⱼ vⱼ† = ∑ₗ wₗ wₗ†` for the "vectorisations"
+`vⱼ(a,i) = (Kⱼ)ₐᵢ`. The core linear algebra lemma
+`exists_unitary_of_sum_vecMulVec_star_eq` then gives the unitary. -/
+theorem kraus_unitary_combination_of_same_map
+    {r : ℕ}
+    (K K' : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (hmap : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ j : Fin r, K j * X * (K j)ᴴ =
+      ∑ l : Fin r, K' l * X * (K' l)ᴴ) :
+    ∃ U : Matrix (Fin r) (Fin r) ℂ, Uᴴ * U = 1 ∧
+      ∀ j, K j = ∑ l : Fin r, U j l • K' l := by
+  -- Vectorise: define v_j(a,i) = (K_j)_{a,i}, w_l(a,i) = (K'_l)_{a,i}.
+  -- The map equality on rank-1 inputs gives ∑ⱼ v_j v_j† = ∑ₗ w_l w_l†.
+  -- The core linear algebra lemma then produces the unitary U.
+  sorry
+
+/-- **Thm 2.1 item 4 (unitary freedom, full characterisation)**:
+two same-size Kraus families define the same map **if and only if** they
+are related by a unitary mixing matrix.
+
+This combines the sufficient direction (`kraus_same_map_of_unitary_combination`)
+with the necessary direction (`kraus_unitary_combination_of_same_map`). -/
+theorem kraus_same_map_iff_unitary_combination
+    {r : ℕ}
+    (K K' : Fin r → Matrix (Fin D) (Fin D) ℂ) :
+    (∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ j : Fin r, K j * X * (K j)ᴴ =
+      ∑ l : Fin r, K' l * X * (K' l)ᴴ) ↔
+    (∃ U : Matrix (Fin r) (Fin r) ℂ, Uᴴ * U = 1 ∧
+      ∀ j, K j = ∑ l : Fin r, U j l • K' l) := by
+  constructor
+  · exact kraus_unitary_combination_of_same_map K K'
+  · rintro ⟨U, hU, hK⟩
+    exact kraus_same_map_of_unitary_combination K K' U hU hK

--- a/TNLean/Channel/KrausRepresentation.lean
+++ b/TNLean/Channel/KrausRepresentation.lean
@@ -18,6 +18,8 @@ positive maps `T(A) = ∑ⱼ Kⱼ A Kⱼ†`.
 * `kraus_tp_of_sum_conjTranspose_mul` — `∑ᵢ Kᵢ†Kᵢ = 𝟙` ⟹ TP
 * `kraus_sum_mul_conjTranspose_of_unital` — unital ⟹ `∑ᵢ Kᵢ Kᵢ† = 𝟙`
 * `kraus_same_map_of_unitary_combination` — unitary freedom (sufficient direction)
+* `kraus_same_map_of_unitaryGroup_combination` — bundled unitary witness wrapper
+* `kraus_same_map_of_exists_unitary_combination` — existential unitary witness wrapper
 * `kraus_unitary_combination_of_same_map` — unitary freedom (necessary direction)
 * `kraus_same_map_iff_unitary_combination` — unitary freedom (iff characterisation)
 
@@ -138,6 +140,36 @@ theorem kraus_same_map_of_unitary_combination
           (if l' = l then 1 else 0) • (K' l * X * (K' l')ᴴ) := by
           simp_rw [hU_entry]; simp
     _ = ∑ l : Fin r, K' l * X * (K' l)ᴴ := by simp
+
+/-- Convenience wrapper of `kraus_same_map_of_unitary_combination` with a bundled
+unitary witness. This formulation is intended for use by the future converse direction:
+once a unitary witness is constructed (typically from Choi data), map equality follows
+immediately. -/
+theorem kraus_same_map_of_unitaryGroup_combination
+    {r : ℕ}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (K' : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (U : Matrix.unitaryGroup (Fin r) ℂ)
+    (hK : ∀ j, K j = ∑ l, (U : Matrix (Fin r) (Fin r) ℂ) j l • K' l) :
+    ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ j : Fin r, K j * X * (K j)ᴴ =
+      ∑ l : Fin r, K' l * X * (K' l)ᴴ := by
+  exact kraus_same_map_of_unitary_combination K K' (U : Matrix (Fin r) (Fin r) ℂ)
+    (Matrix.mem_unitaryGroup_iff'.mp U.prop) hK
+
+/-- Existentially packaged sufficient direction for Kraus unitary freedom:
+if a unitary mixing witness exists, the two Kraus families define the same map. -/
+theorem kraus_same_map_of_exists_unitary_combination
+    {r : ℕ}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (K' : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (hU : ∃ U : Matrix.unitaryGroup (Fin r) ℂ,
+      ∀ j, K j = ∑ l, (U : Matrix (Fin r) (Fin r) ℂ) j l • K' l) :
+    ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ j : Fin r, K j * X * (K j)ᴴ =
+      ∑ l : Fin r, K' l * X * (K' l)ᴴ := by
+  rcases hU with ⟨U, hKU⟩
+  exact kraus_same_map_of_unitaryGroup_combination K K' U hKU
 
 /-! ### Unitary freedom: necessary direction and full characterisation (Thm 2.1, item 4) -/
 

--- a/TNLean/Channel/KrausRepresentation.lean
+++ b/TNLean/Channel/KrausRepresentation.lean
@@ -190,9 +190,51 @@ theorem kraus_unitary_combination_of_same_map
     ∃ U : Matrix (Fin r) (Fin r) ℂ, Uᴴ * U = 1 ∧
       ∀ j, K j = ∑ l : Fin r, U j l • K' l := by
   -- Vectorise: define v_j(a,i) = (K_j)_{a,i}, w_l(a,i) = (K'_l)_{a,i}.
+  let v : Fin r → (Fin D × Fin D → ℂ) := fun j p => K j p.1 p.2
+  let w : Fin r → (Fin D × Fin D → ℂ) := fun j p => K' j p.1 p.2
+  -- Key extraction: entry (a,b) of ∑_j K_j * |i⟩⟨k| * K_j† equals
+  -- ∑_j K_j(a,i) * star(K_j(b,k)).
+  have entry_eq : ∀ (K₀ : Fin r → Matrix (Fin D) (Fin D) ℂ) (a b i k : Fin D),
+      ∑ j : Fin r, K₀ j a i * star (K₀ j b k) =
+      (∑ j : Fin r, K₀ j * Matrix.single i k (1 : ℂ) * (K₀ j)ᴴ) a b := by
+    intro K₀ a b i k
+    simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+    congr 1; ext j
+    -- Goal: K₀ j a i * star (K₀ j b k) =
+    --   ∑ c, (∑ d, K₀ j a d * single i k 1 d c) * star (K₀ j b c)
+    -- The inner sum ∑_d K₀ j a d * single i k 1 d c = if k = c then K₀ j a i else 0
+    have inner : ∀ c, (∑ d, K₀ j a d * Matrix.single i k 1 d c) =
+        if k = c then K₀ j a i else 0 := by
+      intro c
+      simp only [Matrix.single_apply]
+      by_cases hc : k = c
+      · subst hc; simp
+      · rw [show (∑ d, K₀ j a d * if i = d ∧ k = c then 1 else 0) = 0 from
+          Finset.sum_eq_zero fun d _ => by simp [show ¬(i = d ∧ k = c) from fun h => hc h.2]]
+        exact (if_neg hc).symm
+    -- Rewrite the inner sums and simplify to a single term at c = k.
+    symm
+    calc ∑ c, (∑ d, K₀ j a d * single i k 1 d c) * star (K₀ j b c)
+        = ∑ c, (if k = c then K₀ j a i else 0) * star (K₀ j b c) := by
+          congr 1; ext c; rw [inner]
+      _ = K₀ j a i * star (K₀ j b k) := by
+          simp [ite_mul]
   -- The map equality on rank-1 inputs gives ∑ⱼ v_j v_j† = ∑ₗ w_l w_l†.
+  have houter : ∑ j : Fin r, Matrix.vecMulVec (v j) (star (v j)) =
+      ∑ l : Fin r, Matrix.vecMulVec (w l) (star (w l)) := by
+    ext ⟨a, i⟩ ⟨b, k⟩
+    simp only [Matrix.sum_apply, Matrix.vecMulVec_apply, Pi.star_apply, v, w]
+    rw [entry_eq K a b i k, entry_eq K' a b i k]
+    exact congrFun (congrFun (hmap (Matrix.single i k 1)) a) b
   -- The core linear algebra lemma then produces the unitary U.
-  sorry
+  obtain ⟨U, hU, hUvw⟩ := exists_unitary_of_sum_vecMulVec_star_eq v w houter
+  -- Convert from pointwise scalar multiplication back to matrix smul.
+  exact ⟨U, hU, fun j => by
+    ext a i'
+    simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+    have := hUvw j (a, i')
+    simp only [v, w] at this
+    exact this⟩
 
 /-- **Thm 2.1 item 4 (unitary freedom, full characterisation)**:
 two same-size Kraus families define the same map **if and only if** they

--- a/TNLean/Channel/KrausRepresentation.lean
+++ b/TNLean/Channel/KrausRepresentation.lean
@@ -181,10 +181,10 @@ This is the finite-dimensional fact that two decompositions of a positive
 semidefinite matrix into rank-1 terms (of the same cardinality) are
 related by a unitary transformation.
 
-**Proof status**: requires partial-isometry extension or polar decomposition
-for matrices over `ℂ`, which is not yet available in this project's
-Mathlib toolchain. This is the sole `sorry` underlying the converse
-direction of Kraus unitary freedom. -/
+**Proof status**: currently blocked on a reusable finite-dimensional
+polar-decomposition/partial-isometry-extension lemma for matrices over `ℂ`
+in this project's Mathlib toolchain. This is the sole `sorry` underlying
+the converse direction of Kraus unitary freedom. -/
 theorem exists_unitary_of_sum_vecMulVec_star_eq
     {ι : Type*}
     {r : ℕ}

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Basic
+import TNLean.MPS.Core.Transfer
+import Mathlib.LinearAlgebra.Matrix.Vec
+import Mathlib.Data.Matrix.Basis
+
+/-!
+# Transfer-matrix representation of channels (Wolf §2.2)
+
+This file defines the **transfer matrix** (matrix representation) of a linear
+map `T : M_D(ℂ) → M_D(ℂ)`. Given an ordered basis `{E_{kl}}` of standard
+matrix units for `M_D(ℂ)`, the transfer matrix `T̂` is the `D² × D²` matrix
+that represents `T` in the column-stacking vectorization `Matrix.vec`.
+
+The main result is that `T̂` faithfully represents `T` in the vectorized
+picture: `vec(T(ρ)) = T̂ *ᵥ vec(ρ)`, and this representation is compatible
+with composition. We also relate it to the Kraus representation.
+
+## Main definitions
+
+* `transferMatrix`: the `(Fin D × Fin D) × (Fin D × Fin D)` matrix
+  representing `T` in the column-stacking vectorization `Matrix.vec`
+* `transferMatrixLM`: `transferMatrix` as a linear map from superoperators to
+  matrices on the vectorized space
+
+## Main results
+
+* `transferMatrix_mulVec_eq`: `T̂ *ᵥ vec(ρ) = vec(T(ρ))`
+* `transferMatrix_comp`: `(S ∘ T)^ = Ŝ * T̂`
+* `transferMatrix_id`: the transfer matrix of the identity is the identity
+* `transferMatrix_kraus`: for a Kraus map `T(X) = ∑ᵢ Kᵢ X Kᵢ†`, the transfer
+  matrix is `∑ᵢ K̄ᵢ ⊗ₖ Kᵢ`
+* `MPSTensor.transferMatrix_eq`: the MPS transfer map `E_A` has transfer
+  matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ`
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2.2][Wolf2012QChannels]
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix Finset
+
+variable {D : ℕ}
+
+/-! ### The transfer matrix -/
+
+/-- The **transfer matrix** of a linear map `T : M_D(ℂ) → M_D(ℂ)`:
+
+  `T̂_{p,q} = vec(T(E_{q.2,q.1}))_p`
+
+where `E_{kl} = Matrix.single k l 1` is the standard matrix unit.
+This is a `(Fin D × Fin D) × (Fin D × Fin D)` matrix that represents `T`
+in the column-stacking vectorization `Matrix.vec`:
+`T̂ *ᵥ vec(ρ) = vec(T(ρ))`. -/
+noncomputable def transferMatrix
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
+  fun p q => (T (Matrix.single q.2 q.1 1)) p.2 p.1
+
+@[simp]
+theorem transferMatrix_apply
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (i j k l : Fin D) :
+    transferMatrix T (j, i) (l, k) = (T (Matrix.single k l 1)) i j := rfl
+
+private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 := by
+  conv_lhs => rw [Matrix.matrix_eq_sum_single ρ]
+  refine Finset.sum_congr rfl fun k _ => Finset.sum_congr rfl fun l _ => ?_
+  ext a b
+  simp [Matrix.single_apply, smul_eq_mul]
+
+/-! ### Fundamental property: T̂ represents T in the vectorized picture -/
+
+/-- **Key property**: the transfer matrix faithfully represents `T`:
+`(T̂ *ᵥ vec(ρ)) = vec(T(ρ))`.
+
+This is the defining property of the transfer-matrix representation:
+vectorizing `T(ρ)` is the same as multiplying `T̂` by `vec(ρ)`. -/
+theorem transferMatrix_mulVec_eq
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    transferMatrix T *ᵥ ρ.vec = (T ρ).vec := by
+  ext ⟨j, i⟩
+  simp only [Matrix.mulVec, dotProduct, transferMatrix_apply,
+    Matrix.vec, Fintype.sum_prod_type]
+  have key : T ρ = ∑ k, ∑ l, ρ k l • T (Matrix.single k l 1) := by
+    conv_lhs => rw [sum_smul_single_eq ρ]
+    simp_rw [map_sum, LinearMap.map_smul]
+  rw [key]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  rw [Finset.sum_comm]
+  congr 1; ext k; congr 1; ext l; ring
+
+/-! ### Compatibility with composition -/
+
+/-- The transfer matrix of a composition is the product of transfer matrices. -/
+theorem transferMatrix_comp
+    (S T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    transferMatrix (S ∘ₗ T) = transferMatrix S * transferMatrix T := by
+  ext ⟨j, i⟩ ⟨l, k⟩
+  simp only [transferMatrix_apply, LinearMap.comp_apply, Matrix.mul_apply,
+    Fintype.sum_prod_type]
+  have key : S (T (Matrix.single k l 1)) =
+      ∑ a, ∑ b, (T (Matrix.single k l 1)) a b • S (Matrix.single a b 1) := by
+    conv_lhs => rw [sum_smul_single_eq (T (Matrix.single k l 1))]
+    simp_rw [map_sum, LinearMap.map_smul]
+  rw [key]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  rw [Finset.sum_comm]
+  congr 1; ext a; congr 1; ext b; ring
+
+/-- The transfer matrix of the identity map is the identity matrix. -/
+@[simp]
+theorem transferMatrix_id :
+    transferMatrix (LinearMap.id : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] _) = 1 := by
+  ext ⟨j, i⟩ ⟨l, k⟩
+  simp only [transferMatrix_apply, LinearMap.id_apply, Matrix.one_apply, Prod.mk.injEq]
+  rw [Matrix.single_apply]
+  simp [eq_comm, and_comm]
+
+/-- `transferMatrix` is injective: distinct linear maps have distinct
+transfer matrices. -/
+theorem transferMatrix_injective :
+    Function.Injective
+      (transferMatrix : (Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] _) →
+        Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) := by
+  intro S T h
+  ext M i j
+  have key := congr_fun (congr_fun (congrArg Matrix.mulVec h) M.vec) (j, i)
+  simp only [transferMatrix_mulVec_eq, Matrix.vec] at key
+  exact key
+
+/-! ### Transfer matrix as a linear map -/
+
+/-- `transferMatrix` as a linear map from superoperators to matrices on the
+vectorized space. -/
+noncomputable def transferMatrixLM :
+    (Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) →ₗ[ℂ]
+      Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ where
+  toFun := transferMatrix
+  map_add' S T := by
+    ext ⟨j, i⟩ ⟨l, k⟩
+    simp [transferMatrix, LinearMap.add_apply, Matrix.add_apply]
+  map_smul' c T := by
+    ext ⟨j, i⟩ ⟨l, k⟩
+    simp [transferMatrix, LinearMap.smul_apply, Matrix.smul_apply, smul_eq_mul]
+
+/-! ### Kraus representation of the transfer matrix -/
+
+/-- For a Kraus map `T(X) = ∑ᵢ Kᵢ X Kᵢ†`, the transfer matrix is
+`∑ᵢ K̄ᵢ ⊗ₖ Kᵢ` (Kronecker product of the entrywise conjugate of `Kᵢ`
+with `Kᵢ`).
+
+This connects the channel-theoretic Kraus representation with the
+vectorized transfer-matrix picture. -/
+theorem transferMatrix_kraus
+    {r : ℕ} (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ) :
+    transferMatrix T =
+      ∑ n : Fin r, (K n).map (starRingEnd ℂ) ⊗ₖ K n := by
+  ext ⟨j, i⟩ ⟨l, k⟩
+  simp only [transferMatrix_apply, hK, Matrix.sum_apply, kroneckerMap_apply, Matrix.map_apply,
+    starRingEnd_apply]
+  congr 1; ext n
+  -- (K n * E_{kl} * (K n)ᴴ)_{ij} = conj((K n)_{jl}) * (K n)_{ik}
+  simp only [Matrix.mul_apply, Matrix.single_apply, Matrix.conjTranspose_apply]
+  simp only [ite_and, mul_ite, mul_one, mul_zero, ite_mul, zero_mul,
+    Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte, mul_comm]
+
+/-! ### Connection to MPS transfer maps -/
+
+namespace MPSTensor
+
+/-- The MPS transfer map `E_A(X) = ∑ᵢ Aᵢ X Aᵢ†` has transfer matrix
+`∑ᵢ Āᵢ ⊗ₖ Aᵢ`.
+
+This bridges Wolf's channel-side §2.2 transfer matrix with the MPS-side
+transfer operator. -/
+theorem transferMatrix_eq (A : MPSTensor d D) :
+    transferMatrix (MPSTensor.transferMap A) =
+      ∑ n : Fin d,
+        (A n).map (starRingEnd ℂ) ⊗ₖ A n :=
+  transferMatrix_kraus A _ (fun X => by simp [transferMap_apply])
+
+end MPSTensor

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -63,7 +63,6 @@ representations of quantum channels.
 | Prop 2.2 (decomp into CP) | Straightforward from CJ |
 | Prop 2.3 (no info w/o disturbance) | Needs pure state uniqueness |
 | Prop 2.4 (equiv of ensembles) | Needs purification/Schmidt decomp |
-| Thm 2.1 item 4 (unitary freedom, converse) | `sorry` on core LA lemma |
 | Thm 2.3 (ordered CP-maps) | Needs Stinespring + contraction |
 | Thm 2.4 (Radon-Nikodym) | Follows from Thm 2.3 |
 | Thm 2.5 (open-system representation) | Embedding into unitary |

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -34,6 +34,9 @@ representations of quantum channels.
   - `kraus_sum_conjTranspose_mul_of_tp` — TP ⟹ `∑Kᵢ†Kᵢ = 𝟙` ✅
   - `kraus_sum_mul_conjTranspose_of_unital` — unital ⟹ `∑KᵢKᵢ† = 𝟙` ✅
   - `kraus_same_map_of_unitary_combination` — unitary freedom (sufficient direction) ✅
+  - `kraus_unitary_combination_of_same_map` — unitary freedom
+    (necessary direction) ✅ (`sorry`: core LA lemma)
+  - `kraus_same_map_iff_unitary_combination` — unitary freedom (iff characterisation) ✅
 
 * **Thm 2.2** (Stinespring dilation):
   - `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` ✅
@@ -60,7 +63,7 @@ representations of quantum channels.
 | Prop 2.2 (decomp into CP) | Straightforward from CJ |
 | Prop 2.3 (no info w/o disturbance) | Needs pure state uniqueness |
 | Prop 2.4 (equiv of ensembles) | Needs purification/Schmidt decomp |
-| Thm 2.1 item 4 (unitary freedom, necessary direction) | Needs Choi eigendecomp |
+| Thm 2.1 item 4 (unitary freedom, converse) | `sorry` on core LA lemma |
 | Thm 2.3 (ordered CP-maps) | Needs Stinespring + contraction |
 | Thm 2.4 (Radon-Nikodym) | Follows from Thm 2.3 |
 | Thm 2.5 (open-system representation) | Embedding into unitary |

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -8,6 +8,7 @@ import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Stinespring
+import TNLean.Channel.TransferMatrix
 
 /-!
 # Wolf Lecture Notes — Chapter 2: Representations
@@ -34,6 +35,8 @@ representations of quantum channels.
   - `kraus_sum_conjTranspose_mul_of_tp` — TP ⟹ `∑Kᵢ†Kᵢ = 𝟙` ✅
   - `kraus_sum_mul_conjTranspose_of_unital` — unital ⟹ `∑KᵢKᵢ† = 𝟙` ✅
   - `kraus_same_map_of_unitary_combination` — unitary freedom (sufficient direction) ✅
+  - `kraus_same_map_of_unitaryGroup_combination` / `kraus_same_map_of_exists_unitary_combination`
+    — bundled/existential unitary-witness wrappers for reuse in the converse roadmap ✅
   - `kraus_unitary_combination_of_same_map` — unitary freedom
     (necessary direction) ✅ (`sorry`: core LA lemma)
   - `kraus_same_map_iff_unitary_combination` — unitary freedom (iff characterisation) ✅
@@ -42,6 +45,18 @@ representations of quantum channels.
   - `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` ✅
   - `stinespringV_isometry_iff_kraus_normalized` — `V†V = 𝟙` ↔ TP ✅
   - `stinespring_schrodinger_representation` — `T(ρ) = tr_r(VρV†)` ✅
+
+### §2.2 Transfer matrix
+
+* `transferMatrix` — the `D² × D²` matrix representing `T` in the
+  standard-basis vectorization ✅
+* `transferMatrix_mulVec_eq` — `T̂ *ᵥ vec(ρ) = vec(T(ρ))` ✅
+* `transferMatrix_comp` — `(S ∘ T)^ = Ŝ * T̂` ✅
+* `transferMatrix_id` — transfer matrix of identity = identity ✅
+* `transferMatrix_injective` — the representation is faithful ✅
+* `transferMatrix_kraus` — Kraus form: `T̂ = ∑ᵢ K̄ᵢ ⊗ₖ Kᵢ` ✅
+* `MPSTensor.transferMatrix_eq` — MPS bridge:
+  `E_A` has transfer matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ` ✅
 
 ### Infrastructure
 
@@ -55,6 +70,8 @@ representations of quantum channels.
 | Tensor product of maps | `TensorMap.lean` | `Matrix.tensorMapId` |
 | Choi matrix | `ChoiJamiolkowski.lean` | `ChoiJamiolkowski.choiMatrix` |
 | Stinespring isometry | `Stinespring.lean` | `stinespringV` |
+| Transfer matrix | `TransferMatrix.lean` | `transferMatrix` |
+| Vectorization | `Mathlib.LinearAlgebra.Matrix.Vec` | `Matrix.vec` |
 
 ### Not yet formalized
 
@@ -67,7 +84,6 @@ representations of quantum channels.
 | Thm 2.4 (Radon-Nikodym) | Follows from Thm 2.3 |
 | Thm 2.5 (open-system representation) | Embedding into unitary |
 | Thm 2.6 (Neumark's theorem) | POVM embedding |
-| §2.2 (transfer matrix) | Matrix representation of channels |
 | §2.3 (normal forms) | Lorentz normal form etc. |
 
 ## References

--- a/TNLean/MPS/Chain/AlgebraIsomorphism.lean
+++ b/TNLean/MPS/Chain/AlgebraIsomorphism.lean
@@ -1,0 +1,149 @@
+import TNLean.MPS.Chain.VirtualInsertion
+import TNLean.MPS.Chain.Defs
+import TNLean.MPS.Structure.LinearExtension
+import TNLean.Algebra.SkolemNoether
+/-!
+# Algebra isomorphism between virtual bond algebras (Lemma 1)
+
+For two injective MPS chains whose combined tensor generates the same MPV family,
+virtual insertions on bond 0–1 are related by conjugation (Skolem–Noether).
+
+## Overview of the proof
+
+1. Combine the site-local tensors `A₁, A₂, A₃` into a single family
+   `chainCombinedTensor A` indexed by `Fin (3 * d)` via `finProdFinEquiv`.
+2. Apply the linear extension theorem (`linearExtension_exists_unique`) to
+   obtain the unique linear map `T` with `T(Aₖ(σ)) = Bₖ(σ)` for all sites
+   `k` and physical indices `σ`.
+3. Apply `linearExtension_mul` to show `T` is multiplicative.
+4. By simplicity of the matrix algebra (`linear_mul_endomorphism_bijective`),
+   `T` is bijective.
+5. Apply Skolem–Noether (`skolemNoether_matrix`) to extract the gauge
+   matrix `W` with `T(M) = W M W⁻¹`.
+6. The virtual-insertion identity follows from multiplicativity of `T` and
+   trace-cyclicity.
+
+## References
+
+* [arXiv:1804.04964](https://arxiv.org/abs/1804.04964), Lemma 1
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Combined tensor for the linear-extension approach -/
+
+/-- The combined MPS tensor for a chain: packs site index `k : Fin n` and
+physical index `σ : Fin d` into a single index in `Fin (n * d)` via
+`finProdFinEquiv`. This lets us apply the single-tensor `linearExtension`
+machinery to a non-translation-invariant chain. -/
+noncomputable def chainCombinedTensor {n : ℕ} (A : Fin n → MPSTensor d D) :
+    MPSTensor (n * d) D :=
+  fun i => A (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm i).2
+
+@[simp]
+lemma chainCombinedTensor_apply {n : ℕ} (A : Fin n → MPSTensor d D)
+    (k : Fin n) (σ : Fin d) :
+    chainCombinedTensor A (finProdFinEquiv (k, σ)) = A k σ := by
+  simp [chainCombinedTensor]
+
+/-- If any site tensor is injective, the combined tensor is injective.
+This is because `{Aₖ(σ)} ⊆ {chainCombinedTensor A (i)}`, so the
+larger set spans if the smaller one does. -/
+theorem chainCombinedTensor_isInjective {n : ℕ} (A : Fin n → MPSTensor d D)
+    (k : Fin n) (hk : IsInjective (A k)) :
+    IsInjective (chainCombinedTensor A) := by
+  rw [IsInjective, eq_top_iff]
+  intro M _
+  have hM := hk.span_eq_top ▸ Submodule.mem_top (x := M)
+  refine Submodule.span_mono ?_ hM
+  intro x hx
+  obtain ⟨σ, rfl⟩ := hx
+  exact Set.mem_range.mpr ⟨finProdFinEquiv (k, σ), by simp [chainCombinedTensor]⟩
+
+/-! ### The main theorem -/
+
+/-- **Lemma 1 (arXiv:1804.04964)**: Virtual bond gauge theorem.
+
+For two injective MPS chains whose combined tensors generate the same MPV
+family (`SameMPV` on `chainCombinedTensor`), virtual insertions on bond 0–1
+are related by conjugation: there exists `Z ∈ GL(D,ℂ)` such that for all `X`
+and all physical configurations `σ`,
+```
+virtualInsertCoeff A₁ A₂ A₃ σ X = virtualInsertCoeff B₁ B₂ B₃ σ (Z⁻¹ X Z)
+```
+
+The hypothesis `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`
+requires trace agreement for all mixed-site words of all lengths:
+`tr(A_{s₁}(σ₁) ⋯ A_{sₙ}(σₙ)) = tr(B_{s₁}(σ₁) ⋯ B_{sₙ}(σₙ))`
+for arbitrary site-index sequences `s₁, …, sₙ`.
+
+The proof constructs the linear extension `T` with `T(Aₖ(σ)) = Bₖ(σ)`,
+shows it is multiplicative, promotes it to a bijective algebra endomorphism
+(by simplicity of the matrix ring), and applies Skolem–Noether to extract `Z`. -/
+theorem virtual_bond_gauge [NeZero D]
+    (A B : Fin 3 → MPSTensor d D)
+    (hA : ∀ k, IsInjective (A k)) (_hB : ∀ k, IsInjective (B k))
+    (hEq : SameMPV (chainCombinedTensor A) (chainCombinedTensor B)) :
+    ∃ Z : GL (Fin D) ℂ, ∀ (X : Matrix (Fin D) (Fin D) ℂ) (σ : Fin 3 → Fin d),
+      virtualInsertCoeff (A 0) (A 1) (A 2) σ X =
+      virtualInsertCoeff (B 0) (B 1) (B 2) σ
+        ((↑Z⁻¹ : Matrix _ _ ℂ) * X * (↑Z : Matrix _ _ ℂ)) := by
+  classical
+  -- The combined tensor is injective (inherited from A 0).
+  have hCA : IsInjective (chainCombinedTensor A) :=
+    chainCombinedTensor_isInjective A 0 (hA 0)
+  -- Linear extension: unique T with T(CA i) = CB i for all combined indices i.
+  obtain ⟨T, hT, _⟩ := linearExtension_exists_unique hCA hEq
+  -- Extract the per-site form: T(Aₖ(σ)) = Bₖ(σ).
+  have hT_site : ∀ (k : Fin 3) (σ : Fin d), T (A k σ) = B k σ := by
+    intro k σ
+    have := hT (finProdFinEquiv (k, σ))
+    simpa [chainCombinedTensor] using this
+  -- T is multiplicative (from linearExtension_mul).
+  have hMul : ∀ M N, T (M * N) = T M * T N :=
+    linearExtension_mul hCA hEq hT
+  -- T is nonzero: if T = 0 then all Bₖ(σ) = 0, contradicting injectivity of B.
+  have hNz : T ≠ 0 := by
+    intro hT0
+    have hCBzero : ∀ i, chainCombinedTensor B i = 0 := fun i => by
+      rw [← hT i, hT0]; simp
+    exact trace_ne_zero_of_injective hCA hEq hCBzero
+  -- T is bijective (simplicity of the matrix algebra).
+  have hBij := linear_mul_endomorphism_bijective T hMul hNz
+  -- Promote T to an algebra homomorphism.
+  let Talg := linearMapToAlgHom T hMul hBij.2
+  -- Build the algebra equivalence.
+  let Tequiv : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+    AlgEquiv.ofBijective Talg hBij
+  -- Apply Skolem–Noether: Tequiv is conjugation by some W.
+  obtain ⟨W, hW⟩ := skolemNoether_matrix Tequiv
+  -- Extract T(M) = W * M * W⁻¹.
+  have hTM : ∀ M, T M =
+      (W : Matrix _ _ ℂ) * M * ((W⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
+    intro M
+    have := hW M
+    change Tequiv M = _ at this
+    simp only [Tequiv, AlgEquiv.ofBijective_apply, Talg] at this
+    exact this
+  -- trace(T(M)) = trace(M) since conjugation preserves trace.
+  have hTr : ∀ M, Matrix.trace (T M) = Matrix.trace M := by
+    intro M; rw [hTM M]; exact trace_conj_eq W M
+  -- Provide Z = W⁻¹ as the gauge.
+  refine ⟨W⁻¹, fun X σ => ?_⟩
+  simp only [virtualInsertCoeff_eq, inv_inv]
+  -- Goal: tr(A₀ X A₁ A₂) = tr(B₀ (W X W⁻¹) B₁ B₂)
+  -- Step 1: T(A₀ X A₁ A₂) = B₀ (TX) B₁ B₂ by multiplicativity.
+  have hTprod : T (A 0 (σ 0) * X * A 1 (σ 1) * A 2 (σ 2)) =
+      B 0 (σ 0) * T X * B 1 (σ 1) * B 2 (σ 2) := by
+    rw [hMul, hMul, hMul, hT_site 0 (σ 0), hT_site 1 (σ 1), hT_site 2 (σ 2)]
+  -- Step 2: Chain the equalities using trace preservation.
+  -- tr(A₀ X A₁ A₂) = tr(T(A₀ X A₁ A₂))  [trace preservation]
+  --                  = tr(B₀ (TX) B₁ B₂)   [multiplicativity]
+  --                  = tr(B₀ (W X W⁻¹) B₁ B₂)  [Skolem–Noether]
+  rw [← hTM X, ← hTprod, hTr]
+
+end MPSTensor

--- a/TNLean/MPS/Chain/FundamentalTheorem.lean
+++ b/TNLean/MPS/Chain/FundamentalTheorem.lean
@@ -1,0 +1,70 @@
+import TNLean.MPS.Chain.AlgebraIsomorphism
+import TNLean.MPS.FundamentalTheorem.Basic
+
+/-!
+# Fundamental Theorem for injective MPS chains
+
+This file proves the Fundamental Theorem for non-translation-invariant injective
+MPS chains (Theorem 1 of [arXiv:1804.04964](https://arxiv.org/abs/1804.04964)):
+
+Two injective MPS chains whose combined tensors generate the same MPV family are
+related by cyclic gauge transformations on the virtual bonds.
+
+## Proof strategy
+
+We pack all site-local tensors into a single combined tensor via
+`chainCombinedTensor`, then apply the single-block Fundamental Theorem
+(`fundamentalTheorem_singleBlock`) to obtain a uniform gauge. A uniform gauge
+is a special case of cyclic gauge equivalence.
+
+## Hypothesis
+
+The hypothesis `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)` asks
+for trace agreement of all mixed-site words of all lengths. This is stronger
+than the paper's `SameState` (trace agreement at a single chain length). The
+paper bridges this gap via a blocking argument requiring n ≥ 3; that bridging
+step is not formalized here, so the theorem is stated with the stronger
+hypothesis.
+
+## References
+
+* [arXiv:1804.04964](https://arxiv.org/abs/1804.04964), Theorem 1
+-/
+
+open scoped Matrix
+
+namespace MPSChainTensor
+
+variable {d D n : ℕ}
+
+/-- **Fundamental Theorem for injective MPS chains** (Theorem 1, arXiv:1804.04964).
+
+Two injective MPS chains whose combined tensors generate the same MPV family
+are related by cyclic gauge transformations on the virtual bonds. The proof
+produces a *uniform* gauge (the same invertible matrix at every bond), which is
+stronger than the general cyclic gauge equivalence.
+
+The hypothesis is `SameMPV` on the combined tensor (all-length trace agreement
+for mixed-site words), which is stronger than the paper's fixed-length
+`SameState`. See the module docstring for discussion. -/
+theorem fundamentalTheorem_injective_chain
+    (A B : MPSChainTensor d D n)
+    (hA : IsInjective A)
+    (hMPV : MPSTensor.SameMPV (MPSTensor.chainCombinedTensor A)
+      (MPSTensor.chainCombinedTensor B)) :
+    GaugeEquiv A B := by
+  rcases n with _ | n
+  · -- n = 0: no sites, gauge equivalence is vacuously true.
+    exact ⟨Fin.elim0, fun k => k.elim0⟩
+  · -- n ≥ 1: the combined tensor inherits injectivity from site 0.
+    have hCA : MPSTensor.IsInjective (MPSTensor.chainCombinedTensor A) :=
+      MPSTensor.chainCombinedTensor_isInjective A ⟨0, Nat.succ_pos n⟩ (hA ⟨0, Nat.succ_pos n⟩)
+    -- Apply the single-block fundamental theorem to the combined tensor.
+    obtain ⟨X, hX⟩ := MPSTensor.fundamentalTheorem_singleBlock hCA hMPV
+    -- The uniform gauge X at every bond gives cyclic gauge equivalence.
+    exact ⟨fun _ => X, fun k i => by
+      have := hX (finProdFinEquiv (k, i))
+      simp only [MPSTensor.chainCombinedTensor_apply] at this
+      exact this⟩
+
+end MPSChainTensor

--- a/TNLean/MPS/Chain/TensorEquality.lean
+++ b/TNLean/MPS/Chain/TensorEquality.lean
@@ -1,0 +1,187 @@
+import TNLean.MPS.Chain.OneSidedInverse
+import TNLean.Algebra.TracePairing
+import Mathlib.Data.Matrix.Basis
+
+/-!
+# Tensor equality up to a scalar on a 2-site chain
+
+This file formalizes the trace-pairing reduction behind Lemma 2 of
+[arXiv:1804.04964](https://arxiv.org/abs/1804.04964): if two injective pairs of
+local tensors agree under all virtual insertions on both bonds, then the two
+pairs are proportional by inverse nonzero scalars.
+
+The full proportionality theorem is stated as `tensor_proportional`.
+The first trace-to-product reduction steps are provided as helper lemmas.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Internal insertion trace agreement implies equality of the mixed products
+`A₂ j * A₁ i = B₂ j * B₁ i` for all physical indices. -/
+  lemma internal_products_eq
+    (A₁ A₂ B₁ B₂ : MPSTensor d D)
+    (hInt : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d),
+      Matrix.trace (A₁ i * X * A₂ j) = Matrix.trace (B₁ i * X * B₂ j)) :
+    ∀ i j, A₂ j * A₁ i = B₂ j * B₁ i := by
+  intro i j
+  have hzero :
+      A₂ j * A₁ i - B₂ j * B₁ i = 0 := by
+    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (A₂ j * A₁ i - B₂ j * B₁ i)).1
+    intro X
+    have hX := hInt X i j
+    have hcycA : Matrix.trace (A₁ i * X * A₂ j) = Matrix.trace (A₂ j * A₁ i * X) := by
+      simpa [Matrix.mul_assoc] using
+        (Matrix.trace_mul_cycle (A₁ i) X (A₂ j))
+    have hcycB : Matrix.trace (B₁ i * X * B₂ j) = Matrix.trace (B₂ j * B₁ i * X) := by
+      simpa [Matrix.mul_assoc] using
+        (Matrix.trace_mul_cycle (B₁ i) X (B₂ j))
+    calc
+      Matrix.trace ((A₂ j * A₁ i - B₂ j * B₁ i) * X)
+          = Matrix.trace (A₂ j * A₁ i * X) - Matrix.trace (B₂ j * B₁ i * X) := by
+              simp [sub_mul]
+      _ = Matrix.trace (A₁ i * X * A₂ j) - Matrix.trace (B₁ i * X * B₂ j) := by
+            rw [hcycA, hcycB]
+      _ = 0 := by simpa [hX]
+  exact sub_eq_zero.mp hzero
+
+/-- External insertion trace agreement implies equality of the mixed products
+`A₁ i * A₂ j = B₁ i * B₂ j` for all physical indices. -/
+  lemma external_products_eq
+    (A₁ A₂ B₁ B₂ : MPSTensor d D)
+    (hExt : ∀ (Y : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d),
+      Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (B₂ j * Y * B₁ i)) :
+    ∀ i j, A₁ i * A₂ j = B₁ i * B₂ j := by
+  intro i j
+  have hzero :
+      A₁ i * A₂ j - B₁ i * B₂ j = 0 := by
+    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (A₁ i * A₂ j - B₁ i * B₂ j)).1
+    intro Y
+    have hY := hExt Y i j
+    have hcycA : Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (A₁ i * A₂ j * Y) := by
+      simpa [Matrix.mul_assoc] using
+        (Matrix.trace_mul_cycle (A₂ j) Y (A₁ i))
+    have hcycB : Matrix.trace (B₂ j * Y * B₁ i) = Matrix.trace (B₁ i * B₂ j * Y) := by
+      simpa [Matrix.mul_assoc] using
+        (Matrix.trace_mul_cycle (B₂ j) Y (B₁ i))
+    calc
+      Matrix.trace ((A₁ i * A₂ j - B₁ i * B₂ j) * Y)
+          = Matrix.trace (A₁ i * A₂ j * Y) - Matrix.trace (B₁ i * B₂ j * Y) := by
+              simp [sub_mul]
+      _ = Matrix.trace (A₂ j * Y * A₁ i) - Matrix.trace (B₂ j * Y * B₁ i) := by
+            rw [hcycA, hcycB]
+      _ = 0 := by simpa [hY]
+  exact sub_eq_zero.mp hzero
+
+/-- Lemma 2 of arXiv:1804.04964 (2-site case): two injective tensor pairs that
+agree under all virtual insertions on both bonds are proportional. -/
+theorem tensor_proportional
+    (A₁ A₂ B₁ B₂ : MPSTensor d D)
+    (hA₁ : IsInjective A₁) (hA₂ : IsInjective A₂)
+    (hB₁ : IsInjective B₁) (hB₂ : IsInjective B₂)
+    (hInt : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d),
+      Matrix.trace (A₁ i * X * A₂ j) = Matrix.trace (B₁ i * X * B₂ j))
+    (hExt : ∀ (Y : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d),
+      Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (B₂ j * Y * B₁ i)) :
+    ∃ (lambda_ : ℂ), lambda_ ≠ 0 ∧
+      (∀ i, A₁ i = lambda_ • B₁ i) ∧ (∀ j, A₂ j = lambda_⁻¹ • B₂ j) := by
+  -- Handle D = 0: the matrix ring is trivial, all matrices are equal.
+  by_cases hD : D = 0
+  · subst hD
+    exact ⟨1, one_ne_zero, fun i => Subsingleton.elim _ _, fun j => by
+      simp [Subsingleton.elim (A₂ j) (B₂ j)]⟩
+  -- Step 1: From trace conditions, derive matrix product equalities.
+  have hProdL : ∀ i j, A₂ j * A₁ i = B₂ j * B₁ i :=
+    internal_products_eq A₁ A₂ B₁ B₂ hInt
+  have hProdR : ∀ i j, A₁ i * A₂ j = B₁ i * B₂ j :=
+    external_products_eq A₁ A₂ B₁ B₂ hExt
+  -- Step 2: Extract Z with A₁ i = Z * B₁ i for all i.
+  -- Decompose 1 in the spanning set {A₂ j}, apply same coefficients to {B₂ j}.
+  let Z := Fintype.linearCombination ℂ B₂ (decompositionMap hA₂ 1)
+  have hZ : ∀ i, A₁ i = Z * B₁ i := by
+    intro i
+    have h : Fintype.linearCombination ℂ A₂ (decompositionMap hA₂ 1) * A₁ i =
+        Fintype.linearCombination ℂ B₂ (decompositionMap hA₂ 1) * B₁ i := by
+      simp only [Fintype.linearCombination_apply, Finset.sum_mul, smul_mul_assoc]
+      simp_rw [hProdL i]
+    rwa [decompositionMap_spec, one_mul] at h
+  -- Step 3: Extract W with A₂ j = W * B₂ j for all j.
+  let W := Fintype.linearCombination ℂ B₁ (decompositionMap hA₁ 1)
+  have hW : ∀ j, A₂ j = W * B₂ j := by
+    intro j
+    have h : Fintype.linearCombination ℂ A₁ (decompositionMap hA₁ 1) * A₂ j =
+        Fintype.linearCombination ℂ B₁ (decompositionMap hA₁ 1) * B₂ j := by
+      simp only [Fintype.linearCombination_apply, Finset.sum_mul, smul_mul_assoc]
+      simp_rw [hProdR _ j]
+    rwa [decompositionMap_spec, one_mul] at h
+  -- Step 4: Show Z * M * W = M for all M via spanning arguments.
+  have hZMW : ∀ M : Matrix (Fin D) (Fin D) ℂ, Z * M * W = M := by
+    -- First: Z * B₁ i * W = B₁ i for all i (by spanning in B₂)
+    have hZBW : ∀ i, Z * B₁ i * W = B₁ i := by
+      intro i
+      have hvan : ∀ j, (Z * B₁ i * W - B₁ i) * B₂ j = 0 := by
+        intro j
+        have h := hProdR i j; rw [hZ i, hW j] at h
+        rw [sub_mul, sub_eq_zero, mul_assoc]; exact h
+      have hf : LinearMap.mulLeft ℂ (Z * B₁ i * W - B₁ i) = 0 :=
+        LinearMap.ext_on_range (v := B₂) (hv := hB₂.span_eq_top) fun j => by
+          simp only [LinearMap.mulLeft_apply, LinearMap.zero_apply]; exact hvan j
+      have h := LinearMap.congr_fun hf 1
+      simp only [LinearMap.mulLeft_apply, LinearMap.zero_apply, mul_one] at h
+      exact sub_eq_zero.mp h
+    -- Extend to all M (by spanning in B₁): Z * (M * W) = M
+    have key : ∀ i, Z * (B₁ i * W) = B₁ i := fun i => by
+      rw [← mul_assoc]; exact hZBW i
+    have hf : (LinearMap.mulLeft ℂ Z).comp (LinearMap.mulRight ℂ W) -
+        LinearMap.id = 0 :=
+      LinearMap.ext_on_range (v := B₁) (hv := hB₁.span_eq_top) fun i => by
+        simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
+            LinearMap.sub_apply, LinearMap.id_apply, LinearMap.zero_apply, sub_eq_zero]
+        exact key i
+    intro M
+    have h := LinearMap.congr_fun hf M
+    simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
+        LinearMap.sub_apply, LinearMap.id_apply, LinearMap.zero_apply, sub_eq_zero] at h
+    rw [← mul_assoc] at h; exact h
+  -- Step 5: Z * W = 1 and Z commutes with everything.
+  have hZW : Z * W = 1 := by have h := hZMW 1; rwa [mul_one] at h
+  have hComm : ∀ M : Matrix (Fin D) (Fin D) ℂ, Z * M = M * Z := by
+    intro M
+    have h := hZMW (M * Z)
+    rw [mul_assoc, mul_assoc, hZW, mul_one] at h
+    exact h
+  -- Step 6: Z is scalar (center of M_D(ℂ) = ℂ · I for commutative ℂ).
+  have hCenter : Z ∈ Set.center (Matrix (Fin D) (Fin D) ℂ) :=
+    Semigroup.mem_center_iff.mpr fun g => (hComm g).symm
+  rw [Matrix.center_eq_range] at hCenter
+  obtain ⟨lambda_, hlambda⟩ := hCenter
+  -- hlambda : Matrix.scalar (Fin D) lambda_ = Z
+  -- Step 7: Z = lambda_ • 1 (connect scalar to smul)
+  have hZ_eq : Z = lambda_ • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [← hlambda, Matrix.scalar_apply, ← Matrix.smul_one_eq_diagonal]
+  -- Step 8: lambda_ ≠ 0 (since Z * W = 1 and Z = lambda_ • 1).
+  have hne : lambda_ ≠ 0 := by
+    intro h; rw [h, zero_smul] at hZ_eq; rw [hZ_eq, zero_mul] at hZW
+    -- hZW : 0 = 1 in Matrix (Fin D) (Fin D) ℂ; D ≥ 1 so 1 ≠ 0
+    have : (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
+      have : NeZero D := ⟨hD⟩
+      exact one_ne_zero
+    exact this hZW.symm
+  -- Step 9: Derive A₁ i = lambda_ • B₁ i.
+  have hA₁_eq : ∀ i, A₁ i = lambda_ • B₁ i := by
+    intro i; rw [hZ i, hZ_eq, smul_mul_assoc, one_mul]
+  -- Step 10: Derive W = lambda_⁻¹ • 1 and A₂ j = lambda_⁻¹ • B₂ j.
+  have hW_eq : W = lambda_⁻¹ • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    have hsmul : lambda_ • W = 1 := by
+      have := hZW; rw [hZ_eq, smul_mul_assoc, one_mul] at this; exact this
+    have h1 : lambda_⁻¹ • (lambda_ • W) = lambda_⁻¹ • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+      rw [hsmul]
+    rwa [smul_smul, inv_mul_cancel₀ hne, one_smul] at h1
+  have hA₂_eq : ∀ j, A₂ j = lambda_⁻¹ • B₂ j := by
+    intro j; rw [hW j, hW_eq, smul_mul_assoc, one_mul]
+  exact ⟨lambda_, hne, hA₁_eq, hA₂_eq⟩
+
+end MPSTensor

--- a/TNLean/MPS/Chain/VirtualInsertion.lean
+++ b/TNLean/MPS/Chain/VirtualInsertion.lean
@@ -1,0 +1,139 @@
+import TNLean.MPS.Chain.OneSidedInverse
+
+/-!
+# Physical realization map for virtual insertions
+
+For an injective MPS tensor `A : Fin d → M_D(ℂ)`, a virtual insertion `X` on a bond
+can be re-expressed as a physical operation on the local physical index.
+This file defines the corresponding realization maps using the decomposition map
+constructed in `OneSidedInverse`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The physical realization of a right virtual insertion.
+For injective `A`, `physRealize A hA X` is the `d × d` matrix of coefficients
+that rewrites each `A i * X` in the spanning family `{A j}`. -/
+noncomputable def physRealize (A : MPSTensor d D) (hA : IsInjective A)
+    (X : Matrix (Fin D) (Fin D) ℂ) : Matrix (Fin d) (Fin d) ℂ :=
+  fun i j => decompositionMap (A := A) hA (A i * X) j
+
+/-- Defining property of `physRealize`: each right-inserted matrix decomposes
+in the span of `{A j}` with coefficients read from `physRealize`. -/
+theorem physRealize_spec (A : MPSTensor d D) (hA : IsInjective A)
+    (X : Matrix (Fin D) (Fin D) ℂ) (i : Fin d) :
+    A i * X = ∑ j, (physRealize A hA X) i j • A j :=
+  set_option linter.unnecessarySimpa false in
+  by
+    simpa [physRealize] using
+      (decompositionMap_sum (A := A) hA (A i * X)).symm
+
+/-- Left-bond analogue of `physRealize`:
+`physRealizeLeft A hA X` records coefficients that rewrite each `X * A i`. -/
+noncomputable def physRealizeLeft (A : MPSTensor d D) (hA : IsInjective A)
+    (X : Matrix (Fin D) (Fin D) ℂ) : Matrix (Fin d) (Fin d) ℂ :=
+  fun i j => decompositionMap (A := A) hA (X * A i) j
+
+/-- Defining property for the left-bond realization map. -/
+theorem physRealizeLeft_spec (A : MPSTensor d D) (hA : IsInjective A)
+    (X : Matrix (Fin D) (Fin D) ℂ) (i : Fin d) :
+    X * A i = ∑ j, (physRealizeLeft A hA X) i j • A j :=
+  set_option linter.unnecessarySimpa false in
+  by
+    simpa [physRealizeLeft] using
+      (decompositionMap_sum (A := A) hA (X * A i)).symm
+
+/-- `physRealize` is linear in the inserted matrix. -/
+theorem physRealize_linear (A : MPSTensor d D) (hA : IsInjective A) :
+    ∀ (c : ℂ) (X Y : Matrix (Fin D) (Fin D) ℂ),
+      physRealize A hA (c • X + Y) = c • physRealize A hA X + physRealize A hA Y := by
+  intro c X Y
+  ext i j
+  simp [physRealize, mul_add]
+
+/-- Identity insertion does nothing. -/
+theorem physRealize_one (A : MPSTensor d D) (hA : IsInjective A)
+    (hLin : LinearIndependent ℂ A) :
+    physRealize A hA 1 = 1 := by
+  ext i j
+  let c : Fin d → ℂ := fun k => physRealize A hA 1 i k
+  have hc : Fintype.linearCombination ℂ A c = A i := by
+    simpa [c, Fintype.linearCombination_apply] using (physRealize_spec A hA 1 i).symm
+  have hsingle : Fintype.linearCombination ℂ A (Pi.single i (1 : ℂ)) = A i := by
+    simp [Fintype.linearCombination_apply_single]
+  have hc' : c = Pi.single i (1 : ℂ) :=
+    hLin.fintypeLinearCombination_injective (hc.trans hsingle.symm)
+  simpa [c, Matrix.one_apply, Pi.single_apply, eq_comm] using congrArg (fun f => f j) hc'
+
+/-- `physRealize` preserves multiplication. -/
+theorem physRealize_mul (A : MPSTensor d D) (hA : IsInjective A)
+    (hLin : LinearIndependent ℂ A)
+    (X Y : Matrix (Fin D) (Fin D) ℂ) :
+    physRealize A hA (X * Y) = physRealize A hA X * physRealize A hA Y := by
+  ext i k
+  let cXY : Fin d → ℂ := fun k' => physRealize A hA (X * Y) i k'
+  let cProd : Fin d → ℂ := fun k' => (physRealize A hA X * physRealize A hA Y) i k'
+  have hcXY : Fintype.linearCombination ℂ A cXY = A i * (X * Y) := by
+    simpa [cXY, Fintype.linearCombination_apply] using (physRealize_spec A hA (X * Y) i).symm
+  have hcProd : Fintype.linearCombination ℂ A cProd = A i * (X * Y) := by
+    calc
+      Fintype.linearCombination ℂ A cProd
+          = ∑ k', cProd k' • A k' := by simp [Fintype.linearCombination_apply]
+      _ = ∑ k', (∑ j, (physRealize A hA X) i j * (physRealize A hA Y) j k') • A k' := by
+            simp [cProd, Matrix.mul_apply]
+      _ = ∑ k', ∑ j, ((physRealize A hA X) i j * (physRealize A hA Y) j k') • A k' := by
+            simp [Finset.sum_smul]
+      _ = ∑ j, ∑ k', ((physRealize A hA X) i j * (physRealize A hA Y) j k') • A k' := by
+            rw [Finset.sum_comm]
+      _ = ∑ j, (physRealize A hA X) i j • (∑ k', (physRealize A hA Y) j k' • A k') := by
+            refine Finset.sum_congr rfl ?_
+            intro j hj
+            simp [Finset.smul_sum, mul_smul]
+      _ = ∑ j, (physRealize A hA X) i j • (A j * Y) := by
+            refine Finset.sum_congr rfl ?_
+            intro j hj
+            simpa using
+              congrArg (fun M => (physRealize A hA X) i j • M)
+                (physRealize_spec A hA Y j).symm
+      _ = (∑ j, (physRealize A hA X) i j • A j) * Y := by
+            simp [Finset.sum_mul]
+      _ = (A i * X) * Y := by simpa using congrArg (fun M => M * Y) (physRealize_spec A hA X i).symm
+      _ = A i * (X * Y) := by simp [Matrix.mul_assoc]
+  have hcoeff : cXY = cProd :=
+    hLin.fintypeLinearCombination_injective (hcXY.trans hcProd.symm)
+  simpa [cXY, cProd] using congrArg (fun f => f k) hcoeff
+
+/-- Nonzero insertion gives nonzero physical operation. -/
+theorem physRealize_injective (A : MPSTensor d D) (hA : IsInjective A)
+    (X : Matrix (Fin D) (Fin D) ℂ) (hX : X ≠ 0) :
+    physRealize A hA X ≠ 0 := by
+  intro hZero
+  have hAll : ∀ i : Fin d, A i * X = 0 := by
+    intro i
+    rw [physRealize_spec A hA X i, hZero]
+    simp
+  obtain ⟨c, hc⟩ := hA.exists_decomposition (1 : Matrix (Fin D) (Fin D) ℂ)
+  have hX0 : X = 0 := by
+    calc
+      X = (1 : Matrix (Fin D) (Fin D) ℂ) * X := by simp
+      _ = (∑ i, c i • A i) * X := by simp [hc]
+      _ = ∑ i, c i • (A i * X) := by simp [Finset.sum_mul]
+      _ = 0 := by simp [hAll]
+  exact hX hX0
+
+/-- Three-site coefficient with a virtual insertion `X` between the first and
+second local tensors. -/
+def virtualInsertCoeff (A₁ A₂ A₃ : MPSTensor d D)
+    (σ : Fin 3 → Fin d) (X : Matrix (Fin D) (Fin D) ℂ) : ℂ :=
+  Matrix.trace (A₁ (σ 0) * X * A₂ (σ 1) * A₃ (σ 2))
+
+@[simp] lemma virtualInsertCoeff_eq (A₁ A₂ A₃ : MPSTensor d D)
+    (σ : Fin 3 → Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
+    virtualInsertCoeff A₁ A₂ A₃ σ X =
+      Matrix.trace (A₁ (σ 0) * X * A₂ (σ 1) * A₃ (σ 2)) := rfl
+
+end MPSTensor


### PR DESCRIPTION
## Summary

- State the necessary direction of Kraus unitary freedom: if two same-size Kraus families define the same map, they are related by a unitary mixing matrix
- Add the full iff characterisation combining both directions
- Isolate the sole `sorry` in a core LA lemma about rank-1 decomposition uniqueness

Closes LionSR/QICLean#118, relates to LionSR/QICLean#15

## Test plan

- [x] `lake build` passes (no new failures; only expected sorry warnings)

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new formal results in core channel/MPS theory plus a new `TransferMatrix` module, and introduces a new `sorry`-backed linear algebra lemma that underpins the Kraus converse theorem, so downstream proofs may rely on an incomplete axiom.
> 
> **Overview**
> **Extends Wolf Ch.2 channel formalization** by adding the *converse* and an `iff` characterization of Kraus unitary freedom (`kraus_unitary_combination_of_same_map`, `kraus_same_map_iff_unitary_combination`), plus convenience wrappers that accept bundled/existential unitary witnesses.
> 
> **Introduces a transfer-matrix representation** in new `Channel/TransferMatrix.lean`: defines `transferMatrix`, proves `vec(T ρ) = T̂ *ᵥ vec(ρ)`, composition/identity/injectivity properties, and derives the Kraus/MPSTensor Kronecker-sum form.
> 
> **Adds new MPS chain infrastructure** (`VirtualInsertion`, `TensorEquality`, `AlgebraIsomorphism`, `FundamentalTheorem`) providing physical-realization maps for virtual insertions, 2-site proportionality, a Skolem–Noether-based virtual-bond gauge lemma, and a chain-level injective fundamental theorem; these modules are now re-exported from `TNLean.lean` and indexed in `WolfChapter2Index.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78274727079665253a984e45a6ed2ddb6e539fde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->