### PR TITLE
Add AlgebraIsomorphism chain module and expose it in root imports

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -95,6 +95,7 @@ import TNLean.Spectral.CrossCorrelation
 import TNLean.MPS.Defs
 import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Chain.VirtualInsertion
+import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Overlap.Basic

--- a/TNLean/MPS/Chain/AlgebraIsomorphism.lean
+++ b/TNLean/MPS/Chain/AlgebraIsomorphism.lean
@@ -1,0 +1,35 @@
+import TNLean.MPS.Chain.VirtualInsertion
+import TNLean.MPS.Structure.LinearExtension
+import TNLean.Algebra.SkolemNoether
+
+/-!
+# Algebra isomorphism on the virtual bond for equal 3-site injective chains
+
+This file introduces the chain-level bond gauge statement used in Stage 2.
+The proof is intended to follow the direct trace-pairing construction route
+(via `virtualInsertCoeff` identities), avoiding `physRealize_mul`.
+TODO: replace this interface axiom with the direct trace-pairing proof.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Bond-gauge form for two 3-site injective chains with equal coefficients.
+
+If two length-3 chains `A` and `B` are sitewise injective and have equal physical
+coefficients on every configuration, then virtual insertion on the middle bond is
+related by conjugation with a single invertible matrix. -/
+axiom virtual_bond_gauge
+    (A B : Fin 3 → MPSTensor d D)
+    (hA : ∀ k, IsInjective (A k)) (hB : ∀ k, IsInjective (B k))
+    (hEq : ∀ σ : Fin 3 → Fin d,
+      Matrix.trace (Fin.prod fun k => A k (σ k)) =
+      Matrix.trace (Fin.prod fun k => B k (σ k))) :
+    ∃ Z : GL (Fin D) ℂ, ∀ (X : Matrix (Fin D) (Fin D) ℂ) (σ : Fin 3 → Fin d),
+      virtualInsertCoeff (A 0) (A 1) (A 2) σ X =
+      virtualInsertCoeff (B 0) (B 1) (B 2) σ (Z⁻¹ * X * Z)
+
+end MPSTensor


### PR DESCRIPTION
### Motivation
- Provide the Stage‑2 API surface for the chain-level bond algebra/gauge result so the direct trace‑pairing proof (map T and Skolem–Noether packaging) can be implemented next, avoiding the `physRealize_mul` route.

### Description
- Add `TNLean/MPS/Chain/AlgebraIsomorphism.lean` which imports `TNLean.MPS.Chain.VirtualInsertion`, `TNLean.MPS.Structure.LinearExtension`, and `TNLean.Algebra.SkolemNoether` and exposes the chain-level statement `virtual_bond_gauge` as an axiom (placeholder) that asserts existence of `Z : GL (Fin D) ℂ` relating `virtualInsertCoeff` via conjugation.
- Expose the new module in the root imports by adding `import TNLean.MPS.Chain.AlgebraIsomorphism` to `TNLean.lean` and include a `TODO` note to replace the axiom with the direct trace‑pairing proof implementation.

### Testing
- Ran `lake build TNLean.MPS.Chain.AlgebraIsomorphism` which completed successfully.
- Ran `lake build TNLean` which completed successfully (existing upstream warnings were unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa871df8083249ad24ca7873d0a0c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new `axiom` (`virtual_bond_gauge`) into the public import surface, which weakens logical soundness and can mask proof obligations downstream. Although small in LOC, it affects foundational correctness for any results depending on the new statement.
> 
> **Overview**
> Adds a new module `TNLean/MPS/Chain/AlgebraIsomorphism.lean` that declares `virtual_bond_gauge`, an *axiomatic* chain-level statement: if two length-3 sitewise-injective chains have equal trace coefficients, then their `virtualInsertCoeff` values are related by conjugation with some `Z : GL (Fin D) ℂ`.
> 
> Exposes this new API at the root by importing `TNLean.MPS.Chain.AlgebraIsomorphism` from `TNLean.lean` (with a TODO to replace the axiom by a trace-pairing proof later).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fddcb6543a50ba18c9c718e83cf86c3a9c1a4ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->