### PR TITLE
Add TensorEquality module (Lemma 2 scaffold) and export from root

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -96,6 +96,7 @@ import TNLean.Spectral.CrossCorrelation
 import TNLean.MPS.Defs
 import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Chain.VirtualInsertion
+import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Overlap.Basic

--- a/TNLean/MPS/Chain/TensorEquality.lean
+++ b/TNLean/MPS/Chain/TensorEquality.lean
@@ -1,0 +1,101 @@
+import TNLean.MPS.Chain.OneSidedInverse
+import TNLean.Algebra.TracePairing
+
+/-!
+# Tensor equality up to a scalar on a 2-site chain
+
+This file formalizes the trace-pairing reduction behind Lemma 2 of
+[arXiv:1804.04964](https://arxiv.org/abs/1804.04964): if two injective pairs of
+local tensors agree under all virtual insertions on both bonds, then the two
+pairs are proportional by inverse nonzero scalars.
+
+The full proportionality theorem is stated as `tensor_proportional`.
+The first trace-to-product reduction steps are provided as helper lemmas.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Internal insertion trace agreement implies equality of the mixed products
+`A₂ j * A₁ i = B₂ j * B₁ i` for all physical indices. -/
+  lemma internal_products_eq
+    (A₁ A₂ B₁ B₂ : MPSTensor d D)
+    (hInt : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d),
+      Matrix.trace (A₁ i * X * A₂ j) = Matrix.trace (B₁ i * X * B₂ j)) :
+    ∀ i j, A₂ j * A₁ i = B₂ j * B₁ i := by
+  intro i j
+  have hzero :
+      A₂ j * A₁ i - B₂ j * B₁ i = 0 := by
+    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (A₂ j * A₁ i - B₂ j * B₁ i)).1
+    intro X
+    have hX := hInt X i j
+    have hcycA : Matrix.trace (A₁ i * X * A₂ j) = Matrix.trace (A₂ j * A₁ i * X) := by
+      simpa [Matrix.mul_assoc] using
+        (Matrix.trace_mul_cycle (A₁ i) X (A₂ j))
+    have hcycB : Matrix.trace (B₁ i * X * B₂ j) = Matrix.trace (B₂ j * B₁ i * X) := by
+      simpa [Matrix.mul_assoc] using
+        (Matrix.trace_mul_cycle (B₁ i) X (B₂ j))
+    calc
+      Matrix.trace ((A₂ j * A₁ i - B₂ j * B₁ i) * X)
+          = Matrix.trace (A₂ j * A₁ i * X) - Matrix.trace (B₂ j * B₁ i * X) := by
+              simp [sub_mul]
+      _ = Matrix.trace (A₁ i * X * A₂ j) - Matrix.trace (B₁ i * X * B₂ j) := by
+            rw [hcycA, hcycB]
+      _ = 0 := by simpa [hX]
+  exact sub_eq_zero.mp hzero
+
+/-- External insertion trace agreement implies equality of the mixed products
+`A₁ i * A₂ j = B₁ i * B₂ j` for all physical indices. -/
+  lemma external_products_eq
+    (A₁ A₂ B₁ B₂ : MPSTensor d D)
+    (hExt : ∀ (Y : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d),
+      Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (B₂ j * Y * B₁ i)) :
+    ∀ i j, A₁ i * A₂ j = B₁ i * B₂ j := by
+  intro i j
+  have hzero :
+      A₁ i * A₂ j - B₁ i * B₂ j = 0 := by
+    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (A₁ i * A₂ j - B₁ i * B₂ j)).1
+    intro Y
+    have hY := hExt Y i j
+    have hcycA : Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (A₁ i * A₂ j * Y) := by
+      simpa [Matrix.mul_assoc] using
+        (Matrix.trace_mul_cycle (A₂ j) Y (A₁ i))
+    have hcycB : Matrix.trace (B₂ j * Y * B₁ i) = Matrix.trace (B₁ i * B₂ j * Y) := by
+      simpa [Matrix.mul_assoc] using
+        (Matrix.trace_mul_cycle (B₂ j) Y (B₁ i))
+    calc
+      Matrix.trace ((A₁ i * A₂ j - B₁ i * B₂ j) * Y)
+          = Matrix.trace (A₁ i * A₂ j * Y) - Matrix.trace (B₁ i * B₂ j * Y) := by
+              simp [sub_mul]
+      _ = Matrix.trace (A₂ j * Y * A₁ i) - Matrix.trace (B₂ j * Y * B₁ i) := by
+            rw [hcycA, hcycB]
+      _ = 0 := by simpa [hY]
+  exact sub_eq_zero.mp hzero
+
+/-- Lemma 2 of arXiv:1804.04964 (2-site case): two injective tensor pairs that
+agree under all virtual insertions on both bonds are proportional. -/
+theorem tensor_proportional
+    (A₁ A₂ B₁ B₂ : MPSTensor d D)
+    (hA₁ : IsInjective A₁) (hA₂ : IsInjective A₂)
+    (hB₁ : IsInjective B₁) (hB₂ : IsInjective B₂)
+    (hInt : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d),
+      Matrix.trace (A₁ i * X * A₂ j) = Matrix.trace (B₁ i * X * B₂ j))
+    (hExt : ∀ (Y : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d),
+      Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (B₂ j * Y * B₁ i)) :
+    ∃ (lambda_ : ℂ), lambda_ ≠ 0 ∧
+      (∀ i, A₁ i = lambda_ • B₁ i) ∧ (∀ j, A₂ j = lambda_⁻¹ • B₂ j) := by
+  -- Step 1 and Step 2 from the proof sketch: identify all mixed products.
+  have hProdL : ∀ i j, A₂ j * A₁ i = B₂ j * B₁ i :=
+    internal_products_eq A₁ A₂ B₁ B₂ hInt
+  have hProdR : ∀ i j, A₁ i * A₂ j = B₁ i * B₂ j :=
+    external_products_eq A₁ A₂ B₁ B₂ hExt
+
+  -- The remaining algebraic argument (linear extension from injectivity,
+  -- centrality, and center of full matrix algebra) is recorded as a TODO.
+  -- It follows the standard blueprint route described in the PR thread.
+  sorry
+
+end MPSTensor


### PR DESCRIPTION
### Motivation

- Provide the 2-site proportionality reduction (Lemma 2 of arXiv:1804.04964) so the MPS chain reasoning can continue from the trace-equality hypotheses to matrix-product equalities and eventual proportionality.
- Expose the new results from the root import surface so downstream modules can use the helper lemmas.

### Description

- Added `TNLean/MPS/Chain/TensorEquality.lean` which contains a module docstring and the targeted theorem `tensor_proportional` (2-site proportionality) together with helper lemmas.
- Implemented `internal_products_eq` which uses trace cyclicity and `Matrix.trace_mul_right_eq_zero_iff` to derive `A₂ j * A₁ i = B₂ j * B₁ i` from the internal insertion trace hypothesis. 
- Implemented `external_products_eq` which similarly derives `A₁ i * A₂ j = B₁ i * B₂ j` from the external insertion trace hypothesis. 
- Added the new module to the top-level export by importing `TNLean.MPS.Chain.TensorEquality` in `TNLean.lean`.
- The full algebraic conclusion in `tensor_proportional` (linear-extension construction and centrality→scalar step) is sketched and left as a single `sorry` placeholder to be completed in a follow-up change.

### Testing

- Ran `lake build TNLean.MPS.Chain.TensorEquality`, which completed successfully. 
- Ran `lake build TNLean` (full project), which completed successfully; the build shows the expected `sorry` warning in the new theorem and pre-existing unrelated `sorry` warnings remain in the tree. 
- No unit tests were added in this change; the automated Lean builds above were used to validate that the new file compiles and integrates with the import surface.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfd98145e083249c8658cbace4d614)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new MPS-chain lemmas and a publicly exported theorem statement with an unfinished `sorry`, which can affect downstream dependents and proof completeness.
> 
> **Overview**
> Adds new module `TNLean.MPS.Chain.TensorEquality` formalizing the trace-pairing reduction for the 2-site case: `internal_products_eq` and `external_products_eq` derive mixed-product equalities from internal/external virtual-insertion trace agreement.
> 
> Exports this module from the root `TNLean.lean` import surface and introduces the top-level theorem statement `tensor_proportional` (proportionality by inverse nonzero scalars) with the final algebraic step left as `sorry`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e143117106a6bbdc87a0e8a0263a2a2abf52b4ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->