### PR TITLE
feat: close sorry in tensor_proportional (Lemma 2)

### DIFF
--- a/TNLean/MPS/Chain/TensorEquality.lean
+++ b/TNLean/MPS/Chain/TensorEquality.lean
@@ -1,5 +1,6 @@
 import TNLean.MPS.Chain.OneSidedInverse
 import TNLean.Algebra.TracePairing
+import Mathlib.Data.Matrix.Basis
 
 /-!
 # Tensor equality up to a scalar on a 2-site chain
@@ -87,15 +88,100 @@ theorem tensor_proportional
       Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (B₂ j * Y * B₁ i)) :
     ∃ (lambda_ : ℂ), lambda_ ≠ 0 ∧
       (∀ i, A₁ i = lambda_ • B₁ i) ∧ (∀ j, A₂ j = lambda_⁻¹ • B₂ j) := by
-  -- Step 1 and Step 2 from the proof sketch: identify all mixed products.
+  -- Handle D = 0: the matrix ring is trivial, all matrices are equal.
+  by_cases hD : D = 0
+  · subst hD
+    exact ⟨1, one_ne_zero, fun i => Subsingleton.elim _ _, fun j => by
+      simp [Subsingleton.elim (A₂ j) (B₂ j)]⟩
+  -- Step 1: From trace conditions, derive matrix product equalities.
   have hProdL : ∀ i j, A₂ j * A₁ i = B₂ j * B₁ i :=
     internal_products_eq A₁ A₂ B₁ B₂ hInt
   have hProdR : ∀ i j, A₁ i * A₂ j = B₁ i * B₂ j :=
     external_products_eq A₁ A₂ B₁ B₂ hExt
-
-  -- The remaining algebraic argument (linear extension from injectivity,
-  -- centrality, and center of full matrix algebra) is recorded as a TODO.
-  -- It follows the standard blueprint route described in the PR thread.
-  sorry
+  -- Step 2: Extract Z with A₁ i = Z * B₁ i for all i.
+  -- Decompose 1 in the spanning set {A₂ j}, apply same coefficients to {B₂ j}.
+  let Z := Fintype.linearCombination ℂ B₂ (decompositionMap hA₂ 1)
+  have hZ : ∀ i, A₁ i = Z * B₁ i := by
+    intro i
+    have h : Fintype.linearCombination ℂ A₂ (decompositionMap hA₂ 1) * A₁ i =
+        Fintype.linearCombination ℂ B₂ (decompositionMap hA₂ 1) * B₁ i := by
+      simp only [Fintype.linearCombination_apply, Finset.sum_mul, smul_mul_assoc]
+      simp_rw [hProdL i]
+    rwa [decompositionMap_spec, one_mul] at h
+  -- Step 3: Extract W with A₂ j = W * B₂ j for all j.
+  let W := Fintype.linearCombination ℂ B₁ (decompositionMap hA₁ 1)
+  have hW : ∀ j, A₂ j = W * B₂ j := by
+    intro j
+    have h : Fintype.linearCombination ℂ A₁ (decompositionMap hA₁ 1) * A₂ j =
+        Fintype.linearCombination ℂ B₁ (decompositionMap hA₁ 1) * B₂ j := by
+      simp only [Fintype.linearCombination_apply, Finset.sum_mul, smul_mul_assoc]
+      simp_rw [hProdR _ j]
+    rwa [decompositionMap_spec, one_mul] at h
+  -- Step 4: Show Z * M * W = M for all M via spanning arguments.
+  have hZMW : ∀ M : Matrix (Fin D) (Fin D) ℂ, Z * M * W = M := by
+    -- First: Z * B₁ i * W = B₁ i for all i (by spanning in B₂)
+    have hZBW : ∀ i, Z * B₁ i * W = B₁ i := by
+      intro i
+      have hvan : ∀ j, (Z * B₁ i * W - B₁ i) * B₂ j = 0 := by
+        intro j
+        have h := hProdR i j; rw [hZ i, hW j] at h
+        rw [sub_mul, sub_eq_zero, mul_assoc]; exact h
+      have hf : LinearMap.mulLeft ℂ (Z * B₁ i * W - B₁ i) = 0 :=
+        LinearMap.ext_on_range (v := B₂) (hv := hB₂.span_eq_top) fun j => by
+          simp only [LinearMap.mulLeft_apply, LinearMap.zero_apply]; exact hvan j
+      have h := LinearMap.congr_fun hf 1
+      simp only [LinearMap.mulLeft_apply, LinearMap.zero_apply, mul_one] at h
+      exact sub_eq_zero.mp h
+    -- Extend to all M (by spanning in B₁): Z * (M * W) = M
+    have key : ∀ i, Z * (B₁ i * W) = B₁ i := fun i => by
+      rw [← mul_assoc]; exact hZBW i
+    have hf : (LinearMap.mulLeft ℂ Z).comp (LinearMap.mulRight ℂ W) -
+        LinearMap.id = 0 :=
+      LinearMap.ext_on_range (v := B₁) (hv := hB₁.span_eq_top) fun i => by
+        simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
+            LinearMap.sub_apply, LinearMap.id_apply, LinearMap.zero_apply, sub_eq_zero]
+        exact key i
+    intro M
+    have h := LinearMap.congr_fun hf M
+    simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
+        LinearMap.sub_apply, LinearMap.id_apply, LinearMap.zero_apply, sub_eq_zero] at h
+    rw [← mul_assoc] at h; exact h
+  -- Step 5: Z * W = 1 and Z commutes with everything.
+  have hZW : Z * W = 1 := by have h := hZMW 1; rwa [mul_one] at h
+  have hComm : ∀ M : Matrix (Fin D) (Fin D) ℂ, Z * M = M * Z := by
+    intro M
+    have h := hZMW (M * Z)
+    rw [mul_assoc, mul_assoc, hZW, mul_one] at h
+    exact h
+  -- Step 6: Z is scalar (center of M_D(ℂ) = ℂ · I for commutative ℂ).
+  have hCenter : Z ∈ Set.center (Matrix (Fin D) (Fin D) ℂ) :=
+    Semigroup.mem_center_iff.mpr fun g => (hComm g).symm
+  rw [Matrix.center_eq_range] at hCenter
+  obtain ⟨lambda_, hlambda⟩ := hCenter
+  -- hlambda : Matrix.scalar (Fin D) lambda_ = Z
+  -- Step 7: Z = lambda_ • 1 (connect scalar to smul)
+  have hZ_eq : Z = lambda_ • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [← hlambda, Matrix.scalar_apply, ← Matrix.smul_one_eq_diagonal]
+  -- Step 8: lambda_ ≠ 0 (since Z * W = 1 and Z = lambda_ • 1).
+  have hne : lambda_ ≠ 0 := by
+    intro h; rw [h, zero_smul] at hZ_eq; rw [hZ_eq, zero_mul] at hZW
+    -- hZW : 0 = 1 in Matrix (Fin D) (Fin D) ℂ; D ≥ 1 so 1 ≠ 0
+    have : (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
+      have : NeZero D := ⟨hD⟩
+      exact one_ne_zero
+    exact this hZW.symm
+  -- Step 9: Derive A₁ i = lambda_ • B₁ i.
+  have hA₁_eq : ∀ i, A₁ i = lambda_ • B₁ i := by
+    intro i; rw [hZ i, hZ_eq, smul_mul_assoc, one_mul]
+  -- Step 10: Derive W = lambda_⁻¹ • 1 and A₂ j = lambda_⁻¹ • B₂ j.
+  have hW_eq : W = lambda_⁻¹ • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    have hsmul : lambda_ • W = 1 := by
+      have := hZW; rw [hZ_eq, smul_mul_assoc, one_mul] at this; exact this
+    have h1 : lambda_⁻¹ • (lambda_ • W) = lambda_⁻¹ • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+      rw [hsmul]
+    rwa [smul_smul, inv_mul_cancel₀ hne, one_smul] at h1
+  have hA₂_eq : ∀ j, A₂ j = lambda_⁻¹ • B₂ j := by
+    intro j; rw [hW j, hW_eq, smul_mul_assoc, one_mul]
+  exact ⟨lambda_, hne, hA₁_eq, hA₂_eq⟩
 
 end MPSTensor


### PR DESCRIPTION
Close the remaining sorry in `tensor_proportional` (Lemma 2 of arXiv:1804.04964). **0 sorries, 0 errors.**

## Proof
1. Construct Z, W via decompositionMap with A₁ i = Z * B₁ i, A₂ j = W * B₂ j
2. Show Z * M * W = M for all M via spanning arguments
3. Derive Z * W = 1 and Z central
4. Center of M_D(ℂ) = scalars → Z = λ • 1
5. λ ≠ 0 from Z * W = 1

Closes #7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Finishes a previously `sorry`ed core lemma by adding a nontrivial algebraic proof and a new `D = 0` edge-case branch; risk is mainly proof fragility/maintenance rather than runtime behavior.
> 
> **Overview**
> Completes the previously unfinished `tensor_proportional` proof in `TNLean/MPS/Chain/TensorEquality.lean`, deriving that two injective 2-site tensor pairs agreeing on all trace insertions are proportional by inverse nonzero scalars.
> 
> The proof now constructs intertwining matrices `Z` and `W` via `decompositionMap`, proves `Z * M * W = M` by spanning arguments, concludes `Z` is central and hence scalar using `Matrix.center_eq_range`, and extracts the scalar `lambda_` (with `lambda_ ≠ 0`) to obtain the desired proportionality. Adds an explicit `D = 0` trivial-matrix-algebra case and imports `Mathlib.Data.Matrix.Basis` to support the center/scalar step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8375c3e091db870593080d3175e1de8e879f58d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->