### PR TITLE
Extract Frobenius norm and matrix embedding to shared module

### DIFF
--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -446,29 +446,7 @@ section OverlapBounds
 
 variable {d : ℕ}
 
-/-- Cauchy–Schwarz for complex sums, in a convenient squared form.
-
-This is the same estimate as `MPSTensor.norm_sq_sum_mul_le` in `SpectralGap.lean`, but we keep a
-local copy here to avoid depending on private lemmas. -/
-private lemma norm_sq_sum_mul_le {ι : Type*} [Fintype ι] (a b : ι → ℂ) :
-    ‖(∑ i : ι, a i * b i)‖ ^ 2 ≤ (∑ i : ι, ‖a i‖ ^ 2) * (∑ i : ι, ‖b i‖ ^ 2) := by
-  classical
-  -- Triangle inequality + Cauchy–Schwarz for real sequences of norms.
-  have h :
-      ‖(∑ i : ι, a i * b i)‖ ≤ ∑ i : ι, ‖a i‖ * ‖b i‖ := by
-    -- `Fintype.sum` is definitionally a `Finset.univ` sum.
-    simpa [norm_mul] using
-      (norm_sum_le (s := (Finset.univ : Finset ι)) (f := fun i => a i * b i)).trans
-        (Finset.sum_le_sum (fun i _ => by simp [norm_mul]))
-  have hsq :
-      ‖(∑ i : ι, a i * b i)‖ ^ 2 ≤ (∑ i : ι, ‖a i‖ * ‖b i‖) ^ 2 :=
-    pow_le_pow_left₀ (norm_nonneg _) h 2
-  have hcs :
-      (∑ i : ι, ‖a i‖ * ‖b i‖) ^ 2 ≤ (∑ i : ι, ‖a i‖ ^ 2) * (∑ i : ι, ‖b i‖ ^ 2) := by
-    simpa using
-      (Finset.sum_mul_sq_le_sq_mul_sq (s := (Finset.univ : Finset ι))
-        (f := fun i => ‖a i‖) (g := fun i => ‖b i‖))
-  exact hsq.trans hcs
+-- `norm_sq_sum_mul_le` is now provided by `TNLean.Spectral.FrobeniusNorm`.
 
 /-- Trace inequality: $|\mathrm{tr}(M)|^2 \le D\,\mathrm{tr}(M^\dagger M)$. -/
 private lemma norm_trace_sq_le_dim_mul_trace_conjTranspose_mul
@@ -498,8 +476,8 @@ private lemma norm_trace_sq_le_dim_mul_trace_conjTranspose_mul
       exact hsingle
     exact Finset.sum_le_sum (fun i _ => hper i)
   -- Rewrite the Frobenius square sum as `trace(M†M).re`.
-  have hfrob : (Matrix.trace (Mᴴ * M)).re = ∑ i : Fin D, ∑ j : Fin D, ‖M i j‖ ^ 2 := by
-    simpa [MPSTensor.frobSq] using (MPSTensor.frobSq_eq_sum (D := D) M)
+  have hfrob : (Matrix.trace (Mᴴ * M)).re = ∑ i : Fin D, ∑ j : Fin D, ‖M i j‖ ^ 2 :=
+    (MPSTensor.frobSq_trace M).symm
   -- Assemble.
   calc
     ‖Matrix.trace M‖ ^ 2

--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Analysis.Matrix.Order
+
+/-!
+# Frobenius norm squared and Euclidean-space embedding for matrices
+
+Shared infrastructure for the spectral-gap modules (`SpectralGap.lean`,
+`SpectralGapRect.lean`).  Everything here works for *rectangular*
+`Matrix (Fin m) (Fin n) ℂ`; the square case is obtained by setting `m = n`.
+
+## Main definitions
+
+* `MPSTensor.frobSq`: Frobenius norm squared, `∑ i j, ‖X i j‖²`.
+* `MPSTensor.matToES`: Isometric embedding of a matrix into `EuclideanSpace ℂ (Fin m × Fin n)`.
+
+## Main results
+
+* `MPSTensor.frobSq_trace`: `frobSq X = (trace(X† X)).re`.
+* `MPSTensor.frobSq_eq_zero_iff`, `frobSq_pos_of_ne_zero`, `frobSq_smul`.
+* `MPSTensor.norm_matToES_sq`: `‖matToES X‖² = frobSq X`.
+* `MPSTensor.norm_sq_sum_mul_le`: Cauchy–Schwarz helper for norm-squared of
+  an inner product.
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPSTensor
+
+variable {m n : ℕ}
+
+/-! ### Frobenius norm squared -/
+
+/-- Frobenius norm squared of a (possibly rectangular) matrix: `∑ i j, ‖X i j‖²`. -/
+noncomputable def frobSq (X : Matrix (Fin m) (Fin n) ℂ) : ℝ :=
+  ∑ i : Fin m, ∑ j : Fin n, ‖X i j‖ ^ 2
+
+lemma frobSq_nonneg (X : Matrix (Fin m) (Fin n) ℂ) : 0 ≤ frobSq X :=
+  Finset.sum_nonneg fun i _ => Finset.sum_nonneg fun j _ => by positivity
+
+private lemma complex_mul_star_re (z : ℂ) : (z * star z).re = ‖z‖ ^ 2 := by
+  rw [show star z = starRingEnd ℂ z from rfl, Complex.mul_conj', ← Complex.ofReal_pow]
+  exact Complex.ofReal_re _
+
+/-- The Frobenius norm squared equals `(trace(X† X)).re`. -/
+lemma frobSq_trace (X : Matrix (Fin m) (Fin n) ℂ) :
+    frobSq X = (Matrix.trace (Xᴴ * X)).re := by
+  simp only [frobSq, Matrix.trace, Matrix.diag, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, Complex.re_sum]
+  rw [Finset.sum_comm]
+  congr 1; ext i; congr 1; ext j
+  rw [show star (X j i) * X j i = ↑(Complex.normSq (X j i)) from
+    Complex.normSq_eq_conj_mul_self.symm, Complex.ofReal_re, Complex.normSq_eq_norm_sq]
+
+lemma frobSq_eq_zero_iff (X : Matrix (Fin m) (Fin n) ℂ) : frobSq X = 0 ↔ X = 0 := by
+  constructor
+  · intro h; ext i j
+    have h1 := (Finset.sum_eq_zero_iff_of_nonneg fun i _ =>
+      Finset.sum_nonneg fun j _ => by positivity).mp h i (Finset.mem_univ _)
+    have h2 := (Finset.sum_eq_zero_iff_of_nonneg fun j _ => by positivity).mp h1 j
+      (Finset.mem_univ _)
+    rwa [sq_eq_zero_iff, norm_eq_zero] at h2
+  · rintro rfl; simp [frobSq]
+
+lemma frobSq_pos_of_ne_zero (X : Matrix (Fin m) (Fin n) ℂ) (hX : X ≠ 0) :
+    0 < frobSq X :=
+  lt_of_le_of_ne (frobSq_nonneg X) (Ne.symm (mt (frobSq_eq_zero_iff X).mp hX))
+
+lemma frobSq_smul (c : ℂ) (X : Matrix (Fin m) (Fin n) ℂ) :
+    frobSq (c • X) = ‖c‖ ^ 2 * frobSq X := by
+  simp only [frobSq, Matrix.smul_apply, smul_eq_mul, norm_mul, mul_pow, Finset.mul_sum]
+
+/-! ### Euclidean-space embedding -/
+
+/-- Embed a matrix into the Euclidean space `ℂ^(m × n)` by flattening entries. -/
+noncomputable def matToES (M : Matrix (Fin m) (Fin n) ℂ) :
+    EuclideanSpace ℂ (Fin m × Fin n) :=
+  (EuclideanSpace.equiv (Fin m × Fin n) ℂ).symm (fun p => M p.1 p.2)
+
+@[simp] lemma matToES_apply (M : Matrix (Fin m) (Fin n) ℂ) (p : Fin m × Fin n) :
+    matToES M p = M p.1 p.2 := by simp [matToES, EuclideanSpace.equiv]
+
+lemma matToES_finset_sum {ι : Type*} (s : Finset ι)
+    (f : ι → Matrix (Fin m) (Fin n) ℂ) :
+    matToES (∑ i ∈ s, f i) = ∑ i ∈ s, matToES (f i) := by
+  ext p; simp [Matrix.sum_apply, Finset.sum_apply]
+
+lemma norm_matToES_sq (M : Matrix (Fin m) (Fin n) ℂ) :
+    ‖matToES M‖ ^ 2 = frobSq M := by
+  rw [sq, ← @inner_self_eq_norm_mul_norm ℂ]
+  change RCLike.re (@inner ℂ _ _ (matToES M) (matToES M)) = _
+  simp only [PiLp.inner_apply, RCLike.inner_apply', matToES_apply, starRingEnd_apply]
+  rw [show (∑ x : Fin m × Fin n, star (M x.1 x.2) * M x.1 x.2) =
+    ∑ i, ∑ j, star (M i j) * M i j from Fintype.sum_prod_type _]
+  simp only [frobSq, Complex.re_sum, RCLike.re_to_complex]
+  congr 1; ext i; congr 1; ext j
+  rw [mul_comm, show M i j * star (M i j) = (↑(‖M i j‖ ^ 2) : ℂ) from by
+    rw [show star (M i j) = starRingEnd ℂ (M i j) from rfl, Complex.mul_conj',
+      ← Complex.ofReal_pow]]
+  exact Complex.ofReal_re _
+
+/-! ### Cauchy–Schwarz helper -/
+
+/-- Cauchy–Schwarz for `‖∑ aₖ bₖ‖²`. -/
+lemma norm_sq_sum_mul_le {D : ℕ} (a b : Fin D → ℂ) :
+    ‖∑ k, a k * b k‖ ^ 2 ≤ (∑ k, ‖a k‖ ^ 2) * (∑ k, ‖b k‖ ^ 2) :=
+  (pow_le_pow_left₀ (norm_nonneg _)
+    ((norm_sum_le _ _).trans (Finset.sum_le_sum fun _ _ => norm_mul_le _ _)) 2).trans
+    (Finset.sum_mul_sq_le_sq_mul_sq _ _ _)
+
+end MPSTensor

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Spectral.MixedTransfer
+import TNLean.Spectral.FrobeniusNorm
 import TNLean.QPF.Assembly
 import TNLean.Channel.FixedPoint.CanonicalGauge
 import TNLean.Channel.Schwarz.Basic
@@ -10,8 +11,6 @@ import Mathlib.Data.Matrix.Block
 import Mathlib.Analysis.Normed.Algebra.GelfandFormula
 import Mathlib.Analysis.SpecificLimits.Normed
 import Mathlib.LinearAlgebra.Eigenspace.Basic
-import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.Analysis.Matrix.Order
 
 /-!
 # Spectral gap for the mixed transfer operator
@@ -100,44 +99,16 @@ theorem mixedTransferSpectralRadius_eq (A B : MPSTensor d D) :
         ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
           (mixedTransferMap A B)) := rfl
 
-/-! ### Frobenius norm squared -/
+/-! ### Frobenius norm squared
 
-/-- Frobenius norm squared of a matrix: `tr(X† X).re`. -/
-noncomputable def frobSq (X : Matrix (Fin D) (Fin D) ℂ) : ℝ :=
-  (Matrix.trace (Xᴴ * X)).re
+The definition and basic API (`frobSq`, `frobSq_nonneg`, `frobSq_eq_zero_iff`,
+`frobSq_pos_of_ne_zero`, `frobSq_smul`, `frobSq_trace`, `matToES`, …) are
+provided by `TNLean.Spectral.FrobeniusNorm` for general rectangular matrices.
+Below we add the square-matrix-specific lemma `frobSq_mul_le`. -/
 
-lemma frobSq_nonneg (X : Matrix (Fin D) (Fin D) ℂ) : 0 ≤ frobSq X :=
-  (Complex.le_def.mp (Matrix.posSemidef_conjTranspose_mul_self X).trace_nonneg).1
-
-private lemma complex_mul_star_re (z : ℂ) : (z * star z).re = ‖z‖ ^ 2 := by
-  rw [show star z = starRingEnd ℂ z from rfl, Complex.mul_conj', ← Complex.ofReal_pow]
-  exact Complex.ofReal_re _
-
+/-- `frobSq X = ∑ i j, ‖X i j‖²` (definitional; kept for backward compatibility). -/
 lemma frobSq_eq_sum (X : Matrix (Fin D) (Fin D) ℂ) :
-    frobSq X = ∑ i : Fin D, ∑ j : Fin D, ‖X i j‖ ^ 2 := by
-  simp only [frobSq, Matrix.trace, Matrix.diag, Matrix.mul_apply, Matrix.conjTranspose_apply]
-  rw [show (∑ i, ∑ j, star (X j i) * X j i) =
-      (∑ j, ∑ i, star (X j i) * X j i) from Finset.sum_comm]
-  simp only [Complex.re_sum]; congr 1; ext i; congr 1; ext j
-  rw [mul_comm, complex_mul_star_re]
-
-lemma frobSq_eq_zero_iff (X : Matrix (Fin D) (Fin D) ℂ) : frobSq X = 0 ↔ X = 0 := by
-  rw [frobSq_eq_sum]; constructor
-  · intro h; ext i j
-    have := (Finset.sum_eq_zero_iff_of_nonneg fun i _ =>
-      Finset.sum_nonneg fun j _ => by positivity).mp h i (Finset.mem_univ _)
-    have := (Finset.sum_eq_zero_iff_of_nonneg fun j _ => by positivity).mp this j
-      (Finset.mem_univ _)
-    rwa [sq_eq_zero_iff, norm_eq_zero] at this
-  · rintro rfl; simp
-
-lemma frobSq_pos_of_ne_zero (X : Matrix (Fin D) (Fin D) ℂ) (hX : X ≠ 0) :
-    0 < frobSq X :=
-  lt_of_le_of_ne (frobSq_nonneg X) (Ne.symm (mt (frobSq_eq_zero_iff X).mp hX))
-
-lemma frobSq_smul (c : ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :
-    frobSq (c • X) = ‖c‖ ^ 2 * frobSq X := by
-  simp only [frobSq_eq_sum, Matrix.smul_apply, smul_eq_mul, norm_mul, mul_pow, Finset.mul_sum]
+    frobSq X = ∑ i : Fin D, ∑ j : Fin D, ‖X i j‖ ^ 2 := rfl
 
 /-! ### Eigenvector iteration -/
 
@@ -180,41 +151,14 @@ lemma trace_transferMap (A : MPSTensor d D) (Z : Matrix (Fin D) (Fin D) ℂ)
       rw [Matrix.trace_mul_comm (A i * Z) _, Matrix.mul_assoc]]
   rw [← Matrix.trace_sum, ← Finset.sum_mul, hA, one_mul]
 
-/-! ### Hilbert–Schmidt contraction for the mixed transfer operator -/
+/-! ### Hilbert–Schmidt contraction for the mixed transfer operator
 
-private noncomputable def toES (M : Matrix (Fin D) (Fin D) ℂ) :
-    EuclideanSpace ℂ (Fin D × Fin D) :=
-  (EuclideanSpace.equiv (Fin D × Fin D) ℂ).symm (fun p => M p.1 p.2)
-
-@[simp] private lemma toES_apply (M : Matrix (Fin D) (Fin D) ℂ) (p : Fin D × Fin D) :
-    toES M p = M p.1 p.2 := by simp [toES, EuclideanSpace.equiv]
-
-private lemma toES_finset_sum {ι : Type*} (s : Finset ι)
-    (f : ι → Matrix (Fin D) (Fin D) ℂ) :
-    toES (∑ i ∈ s, f i) = ∑ i ∈ s, toES (f i) := by
-  ext p; simp [Matrix.sum_apply, Finset.sum_apply]
-
-private lemma norm_toES_sq (M : Matrix (Fin D) (Fin D) ℂ) :
-    ‖toES M‖ ^ 2 = frobSq M := by
-  rw [sq, ← @inner_self_eq_norm_mul_norm ℂ]
-  change RCLike.re (@inner ℂ _ _ (toES M) (toES M)) = _
-  simp only [PiLp.inner_apply, RCLike.inner_apply', toES_apply, starRingEnd_apply,
-    frobSq, Matrix.trace, Matrix.diag, Matrix.mul_apply, Matrix.conjTranspose_apply]
-  rw [show (∑ x : Fin D × Fin D, star (M x.1 x.2) * M x.1 x.2) =
-    ∑ i, ∑ j, star (M i j) * M i j from Fintype.sum_prod_type _,
-    show (∑ i, ∑ j, star (M i j) * M i j) =
-    ∑ j, ∑ i, star (M i j) * M i j from Finset.sum_comm]
-  simp [RCLike.re_to_complex]
-
-private lemma norm_sq_sum_mul_le (a b : Fin D → ℂ) :
-    ‖∑ k, a k * b k‖ ^ 2 ≤ (∑ k, ‖a k‖ ^ 2) * (∑ k, ‖b k‖ ^ 2) :=
-  (pow_le_pow_left₀ (norm_nonneg _)
-    ((norm_sum_le _ _).trans (Finset.sum_le_sum fun _ _ => norm_mul_le _ _)) 2).trans
-    (Finset.sum_mul_sq_le_sq_mul_sq _ _ _)
+The Euclidean-space embedding `matToES` and its basic API are imported from
+`TNLean.Spectral.FrobeniusNorm`.  Below we add square-matrix submultiplicativity. -/
 
 private lemma frobSq_mul_le (A B : Matrix (Fin D) (Fin D) ℂ) :
     frobSq (A * B) ≤ frobSq A * frobSq B := by
-  simp only [frobSq_eq_sum, Matrix.mul_apply]
+  simp only [frobSq, Matrix.mul_apply]
   calc ∑ i, ∑ j, ‖∑ k, A i k * B k j‖ ^ 2
       ≤ ∑ i, ∑ j, (∑ k, ‖A i k‖ ^ 2) * (∑ k, ‖B k j‖ ^ 2) :=
         Finset.sum_le_sum fun i _ => Finset.sum_le_sum fun j _ => norm_sq_sum_mul_le _ _
@@ -222,12 +166,12 @@ private lemma frobSq_mul_le (A B : Matrix (Fin D) (Fin D) ℂ) :
         simp_rw [← Finset.mul_sum, ← Finset.sum_mul]
     _ = _ := by congr 1; exact Finset.sum_comm
 
-private lemma norm_toES_mul_le (A B : Matrix (Fin D) (Fin D) ℂ) :
-    ‖toES (A * B)‖ ≤ ‖toES A‖ * ‖toES B‖ := by
-  have h : ‖toES (A * B)‖ ^ 2 ≤ (‖toES A‖ * ‖toES B‖) ^ 2 := by
-    rw [norm_toES_sq, mul_pow, norm_toES_sq, norm_toES_sq]; exact frobSq_mul_le A B
-  nlinarith [Real.sqrt_le_sqrt h, Real.sqrt_sq (norm_nonneg (toES (A * B))),
-    Real.sqrt_sq (mul_nonneg (norm_nonneg (toES A)) (norm_nonneg (toES B)))]
+private lemma norm_matToES_mul_le (A B : Matrix (Fin D) (Fin D) ℂ) :
+    ‖matToES (A * B)‖ ≤ ‖matToES A‖ * ‖matToES B‖ := by
+  have h : ‖matToES (A * B)‖ ^ 2 ≤ (‖matToES A‖ * ‖matToES B‖) ^ 2 := by
+    rw [norm_matToES_sq, mul_pow, norm_matToES_sq, norm_matToES_sq]; exact frobSq_mul_le A B
+  nlinarith [Real.sqrt_le_sqrt h, Real.sqrt_sq (norm_nonneg (matToES (A * B))),
+    Real.sqrt_sq (mul_nonneg (norm_nonneg (matToES A)) (norm_nonneg (matToES B)))]
 
 private lemma trace_cycle_for_frobSq (w v : Matrix (Fin D) (Fin D) ℂ) :
     (w * vᴴ * (v * wᴴ)).trace = (wᴴ * w * (vᴴ * v)).trace := by
@@ -239,7 +183,7 @@ private lemma trace_cycle_for_frobSq (w v : Matrix (Fin D) (Fin D) ℂ) :
 private lemma sum_frobSq_right (B : MPSTensor d D) (hB : ∑ i : Fin d, (B i)ᴴ * B i = 1)
     (v : Matrix (Fin D) (Fin D) ℂ) (n : ℕ) :
     ∑ σ : Fin n → Fin d, frobSq (v * (evalWord B (List.ofFn σ))ᴴ) = frobSq v := by
-  simp only [frobSq, Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+  simp only [frobSq_trace, Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
   conv_lhs => arg 2; ext σ; rw [trace_cycle_for_frobSq (evalWord B (List.ofFn σ)) v]
   rw [← Complex.re_sum, ← Matrix.trace_sum, ← Finset.sum_mul,
       word_conjTranspose_mul_sum B hB n, Matrix.one_mul]
@@ -247,7 +191,7 @@ private lemma sum_frobSq_right (B : MPSTensor d D) (hB : ∑ i : Fin d, (B i)ᴴ
 private lemma sum_frobSq_words (K : MPSTensor d D) (hK : ∑ i : Fin d, (K i)ᴴ * K i = 1)
     (n : ℕ) :
     ∑ σ : Fin n → Fin d, frobSq (evalWord K (List.ofFn σ)) = (D : ℝ) := by
-  simp only [frobSq]
+  simp only [frobSq_trace]
   rw [← Complex.re_sum, ← Matrix.trace_sum, word_conjTranspose_mul_sum K hK n]
   simp [Matrix.trace_one, Fintype.card_fin]
 
@@ -264,21 +208,21 @@ private lemma hs_contraction_mixedTransfer [NeZero D]
     congr 1; ext σ; rw [Matrix.mul_assoc]]
   rw [show frobSq (∑ σ : Fin n → Fin d,
     evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ)) =
-    ‖toES (∑ σ : Fin n → Fin d,
+    ‖matToES (∑ σ : Fin n → Fin d,
     evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ))‖ ^ 2 from
-    (norm_toES_sq _).symm]
-  set fA := fun σ : Fin n → Fin d => ‖toES (evalWord A (List.ofFn σ))‖ with hfA_def
-  set fB := fun σ : Fin n → Fin d => ‖toES (X * (evalWord B (List.ofFn σ))ᴴ)‖ with hfB_def
-  have h_chain : ‖toES (∑ σ : Fin n → Fin d,
+    (norm_matToES_sq _).symm]
+  set fA := fun σ : Fin n → Fin d => ‖matToES (evalWord A (List.ofFn σ))‖ with hfA_def
+  set fB := fun σ : Fin n → Fin d => ‖matToES (X * (evalWord B (List.ofFn σ))ᴴ)‖ with hfB_def
+  have h_chain : ‖matToES (∑ σ : Fin n → Fin d,
     evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ))‖ ≤
     ∑ σ : Fin n → Fin d, fA σ * fB σ :=
-    ((by rw [toES_finset_sum]; exact norm_sum_le _ _) : ‖toES _‖ ≤ _).trans
-      (Finset.sum_le_sum fun σ _ => norm_toES_mul_le _ _)
+    ((by rw [matToES_finset_sum]; exact norm_sum_le _ _) : ‖matToES _‖ ≤ _).trans
+      (Finset.sum_le_sum fun σ _ => norm_matToES_mul_le _ _)
   have h_A : ∑ σ : Fin n → Fin d, fA σ ^ 2 = (D : ℝ) := by
-    simp_rw [hfA_def, norm_toES_sq]; exact sum_frobSq_words A hA_norm n
+    simp_rw [hfA_def, norm_matToES_sq]; exact sum_frobSq_words A hA_norm n
   have h_B : ∑ σ : Fin n → Fin d, fB σ ^ 2 = frobSq X := by
-    simp_rw [hfB_def, norm_toES_sq]; exact sum_frobSq_right B hB_norm X n
-  calc ‖toES _‖ ^ 2
+    simp_rw [hfB_def, norm_matToES_sq]; exact sum_frobSq_right B hB_norm X n
+  calc ‖matToES _‖ ^ 2
       ≤ (∑ σ : Fin n → Fin d, fA σ * fB σ) ^ 2 :=
         pow_le_pow_left₀ (norm_nonneg _) h_chain 2
     _ ≤ (∑ σ, fA σ ^ 2) * (∑ σ, fB σ ^ 2) :=

--- a/TNLean/Spectral/SpectralGapRect.lean
+++ b/TNLean/Spectral/SpectralGapRect.lean
@@ -64,127 +64,33 @@ theorem mixedTransferSpectralRadius₂_eq
         ((Module.End.toContinuousLinearMap (Matrix (Fin D₁) (Fin D₂) ℂ))
           (mixedTransferMap₂ A B)) := rfl
 
-/-! ## Rectangular Frobenius norm -/
+/-! ## Rectangular Frobenius norm and Euclidean-space embedding
 
-section FrobeniusRect
+The general definitions `frobSq`, `matToES`, and their basic API are imported from
+`TNLean.Spectral.FrobeniusNorm`.  We introduce `frobSq₂` as a deprecated alias kept
+for local readability, and add the mixed-shape submultiplicativity lemma. -/
 
-/-- Frobenius norm squared of a rectangular matrix: `∑ i j, ‖X i j‖²`. -/
-noncomputable def frobSq₂ (X : Matrix (Fin D₁) (Fin D₂) ℂ) : ℝ :=
-  ∑ i : Fin D₁, ∑ j : Fin D₂, ‖X i j‖ ^ 2
+/-- Deprecated alias: `frobSq₂ = frobSq` for rectangular matrices.
+Kept for local readability in this file. -/
+noncomputable abbrev frobSq₂ (X : Matrix (Fin D₁) (Fin D₂) ℂ) : ℝ := frobSq X
 
-lemma frobSq₂_nonneg (X : Matrix (Fin D₁) (Fin D₂) ℂ) : 0 ≤ frobSq₂ X :=
-  Finset.sum_nonneg fun i _ => Finset.sum_nonneg fun j _ => by positivity
-
-lemma frobSq₂_eq_zero_iff (X : Matrix (Fin D₁) (Fin D₂) ℂ) : frobSq₂ X = 0 ↔ X = 0 := by
-  constructor
-  · intro h; ext i j
-    have h1 := (Finset.sum_eq_zero_iff_of_nonneg fun i _ =>
-      Finset.sum_nonneg fun j _ => by positivity).mp h i (Finset.mem_univ _)
-    have h2 := (Finset.sum_eq_zero_iff_of_nonneg fun j _ => by positivity).mp h1 j
-      (Finset.mem_univ _)
-    rwa [sq_eq_zero_iff, norm_eq_zero] at h2
-  · rintro rfl; simp [frobSq₂]
-
-lemma frobSq₂_pos_of_ne_zero (X : Matrix (Fin D₁) (Fin D₂) ℂ) (hX : X ≠ 0) :
-    0 < frobSq₂ X :=
-  lt_of_le_of_ne (frobSq₂_nonneg X) (Ne.symm (mt (frobSq₂_eq_zero_iff X).mp hX))
-
-lemma frobSq₂_smul (c : ℂ) (X : Matrix (Fin D₁) (Fin D₂) ℂ) :
-    frobSq₂ (c • X) = ‖c‖ ^ 2 * frobSq₂ X := by
-  simp only [frobSq₂, Matrix.smul_apply, smul_eq_mul, norm_mul, mul_pow, Finset.mul_sum]
-
-private lemma frobSq₂_trace (X : Matrix (Fin D₁) (Fin D₂) ℂ) :
-    frobSq₂ X = (Matrix.trace (Xᴴ * X)).re := by
-  simp only [frobSq₂, Matrix.trace, Matrix.diag, Matrix.mul_apply,
-    Matrix.conjTranspose_apply, Complex.re_sum]
-  rw [Finset.sum_comm]
-  congr 1; ext i; congr 1; ext j
-  rw [show star (X j i) * X j i = ↑(Complex.normSq (X j i)) from
-    Complex.normSq_eq_conj_mul_self.symm, Complex.ofReal_re, Complex.normSq_eq_norm_sq]
-
-end FrobeniusRect
-
-/-! ## Euclidean space embedding for rectangular matrices -/
-
-section HSRect
-
-private noncomputable def toES₂ (M : Matrix (Fin D₁) (Fin D₂) ℂ) :
-    EuclideanSpace ℂ (Fin D₁ × Fin D₂) :=
-  (EuclideanSpace.equiv (Fin D₁ × Fin D₂) ℂ).symm (fun p => M p.1 p.2)
-
-@[simp] private lemma toES₂_apply (M : Matrix (Fin D₁) (Fin D₂) ℂ) (p : Fin D₁ × Fin D₂) :
-    toES₂ M p = M p.1 p.2 := by simp [toES₂, EuclideanSpace.equiv]
-
-private lemma toES₂_finset_sum {ι : Type*} (s : Finset ι)
-    (f : ι → Matrix (Fin D₁) (Fin D₂) ℂ) :
-    toES₂ (∑ i ∈ s, f i) = ∑ i ∈ s, toES₂ (f i) := by
-  ext p; simp [Matrix.sum_apply, Finset.sum_apply]
-
-private lemma norm_toES₂_sq (M : Matrix (Fin D₁) (Fin D₂) ℂ) :
-    ‖toES₂ M‖ ^ 2 = frobSq₂ M := by
-  rw [sq, ← @inner_self_eq_norm_mul_norm ℂ]
-  change RCLike.re (@inner ℂ _ _ (toES₂ M) (toES₂ M)) = _
-  simp only [PiLp.inner_apply, RCLike.inner_apply', toES₂_apply, starRingEnd_apply]
-  rw [show (∑ x : Fin D₁ × Fin D₂, star (M x.1 x.2) * M x.1 x.2) =
-    ∑ i, ∑ j, star (M i j) * M i j from Fintype.sum_prod_type _]
-  simp only [frobSq₂, Complex.re_sum, RCLike.re_to_complex]
-  congr 1; ext i; congr 1; ext j
-  rw [mul_comm, show M i j * star (M i j) = (↑(‖M i j‖ ^ 2) : ℂ) from by
-    rw [show star (M i j) = starRingEnd ℂ (M i j) from rfl, Complex.mul_conj',
-      ← Complex.ofReal_pow]]
-  exact Complex.ofReal_re _
-
-/-- Euclidean space embedding for square D₁×D₁ matrices (local copy for cross-shape bounds). -/
-private noncomputable def toESSq₁ (M : Matrix (Fin D₁) (Fin D₁) ℂ) :
-    EuclideanSpace ℂ (Fin D₁ × Fin D₁) :=
-  (EuclideanSpace.equiv (Fin D₁ × Fin D₁) ℂ).symm (fun p => M p.1 p.2)
-
-@[simp] private lemma toESSq₁_apply (M : Matrix (Fin D₁) (Fin D₁) ℂ) (p : Fin D₁ × Fin D₁) :
-    toESSq₁ M p = M p.1 p.2 := by simp [toESSq₁, EuclideanSpace.equiv]
-
-private lemma norm_toESSq₁_sq (M : Matrix (Fin D₁) (Fin D₁) ℂ) :
-    ‖toESSq₁ M‖ ^ 2 = frobSq₂ M := by
-  rw [sq, ← @inner_self_eq_norm_mul_norm ℂ]
-  change RCLike.re (@inner ℂ _ _ (toESSq₁ M) (toESSq₁ M)) = _
-  simp only [PiLp.inner_apply, RCLike.inner_apply', toESSq₁_apply, starRingEnd_apply]
-  rw [show (∑ x : Fin D₁ × Fin D₁, star (M x.1 x.2) * M x.1 x.2) =
-    ∑ i, ∑ j, star (M i j) * M i j from Fintype.sum_prod_type _]
-  simp only [frobSq₂, Complex.re_sum, RCLike.re_to_complex]
-  congr 1; ext i; congr 1; ext j
-  rw [mul_comm, show M i j * star (M i j) = (↑(‖M i j‖ ^ 2) : ℂ) from by
-    rw [show star (M i j) = starRingEnd ℂ (M i j) from rfl, Complex.mul_conj',
-      ← Complex.ofReal_pow]]
-  exact Complex.ofReal_re _
-
-private lemma toESSq₁_finset_sum {ι : Type*} (s : Finset ι)
-    (f : ι → Matrix (Fin D₁) (Fin D₁) ℂ) :
-    toESSq₁ (∑ i ∈ s, f i) = ∑ i ∈ s, toESSq₁ (f i) := by
-  ext p; simp [Matrix.sum_apply, Finset.sum_apply]
-
-private lemma norm_toES₂_mul_le
+private lemma norm_matToES_rect_mul_le
     (A : Matrix (Fin D₁) (Fin D₁) ℂ) (B : Matrix (Fin D₁) (Fin D₂) ℂ) :
-    ‖toES₂ (A * B)‖ ≤ ‖toESSq₁ A‖ * ‖toES₂ B‖ := by
-  have h : ‖toES₂ (A * B)‖ ^ 2 ≤ (‖toESSq₁ A‖ * ‖toES₂ B‖) ^ 2 := by
-    rw [norm_toES₂_sq, mul_pow, norm_toESSq₁_sq, norm_toES₂_sq]
+    ‖matToES (A * B)‖ ≤ ‖matToES A‖ * ‖matToES B‖ := by
+  have h : ‖matToES (A * B)‖ ^ 2 ≤ (‖matToES A‖ * ‖matToES B‖) ^ 2 := by
+    rw [norm_matToES_sq, mul_pow, norm_matToES_sq, norm_matToES_sq]
     -- Frobenius submultiplicativity for mixed-shape matrices
-    simp only [frobSq₂, Matrix.mul_apply]
-    have norm_sq_cs (a b : Fin D₁ → ℂ) :
-        ‖∑ k, a k * b k‖ ^ 2 ≤ (∑ k, ‖a k‖ ^ 2) * (∑ k, ‖b k‖ ^ 2) :=
-      (pow_le_pow_left₀ (norm_nonneg _)
-        ((norm_sum_le _ _).trans (Finset.sum_le_sum fun _ _ => norm_mul_le _ _)) 2).trans
-        (Finset.sum_mul_sq_le_sq_mul_sq _ _ _)
+    simp only [frobSq, Matrix.mul_apply]
     calc ∑ i, ∑ j, ‖∑ k, A i k * B k j‖ ^ 2
         ≤ ∑ i, ∑ j, (∑ k, ‖A i k‖ ^ 2) * (∑ k, ‖B k j‖ ^ 2) :=
           Finset.sum_le_sum fun i _ => Finset.sum_le_sum fun j _ =>
-            norm_sq_cs _ _
+            norm_sq_sum_mul_le _ _
       _ = (∑ i, ∑ k, ‖A i k‖ ^ 2) * (∑ j, ∑ k, ‖B k j‖ ^ 2) := by
           simp_rw [← Finset.mul_sum, ← Finset.sum_mul]
       _ = (∑ i, ∑ j, ‖A i j‖ ^ 2) * (∑ i, ∑ j, ‖B i j‖ ^ 2) := by
           (congr 1; exact Finset.sum_comm)
-  nlinarith [Real.sqrt_le_sqrt h, Real.sqrt_sq (norm_nonneg (toES₂ (A * B))),
-    Real.sqrt_sq (mul_nonneg (norm_nonneg (toESSq₁ A)) (norm_nonneg (toES₂ B)))]
-
-end HSRect
+  nlinarith [Real.sqrt_le_sqrt h, Real.sqrt_sq (norm_nonneg (matToES (A * B))),
+    Real.sqrt_sq (mul_nonneg (norm_nonneg (matToES A)) (norm_nonneg (matToES B)))]
 
 /-! ## Hilbert–Schmidt contraction for the rectangular mixed transfer -/
 
@@ -192,7 +98,7 @@ section HSContraction
 
 /-- Right-sum identity: `∑_σ ‖X · w_B(σ)†‖_F² = ‖X‖_F²` for rectangular X.
 
-The proof uses trace cycling: `frobSq₂(v M†) = tr(M† M · v† v).re`, then sum over σ. -/
+The proof uses trace cycling: `frobSq(v M†) = tr(M† M · v† v).re`, then sum over σ. -/
 private lemma sum_frobSq₂_right (B : MPSTensor d D₂) (hB : ∑ i : Fin d, (B i)ᴴ * B i = 1)
     (v : Matrix (Fin D₁) (Fin D₂) ℂ) (n : ℕ) :
     ∑ σ : Fin n → Fin d, frobSq₂ (v * (evalWord B (List.ofFn σ))ᴴ) = frobSq₂ v := by
@@ -208,7 +114,7 @@ private lemma sum_frobSq₂_right (B : MPSTensor d D₂) (hB : ∑ i : Fin d, (B
       Matrix.trace_mul_comm (M * (vᴴ * v)) Mᴴ,
       ← Matrix.mul_assoc Mᴴ M (vᴴ * v)]
   -- Apply trace cycling to the sum.
-  simp_rw [frobSq₂_trace]
+  simp_rw [frobSq_trace]
   conv_lhs => arg 2; ext σ; rw [trace_cycle (evalWord B (List.ofFn σ))]
   rw [← Complex.re_sum, ← Matrix.trace_sum, ← Finset.sum_mul,
     word_conjTranspose_mul_sum B hB n, Matrix.one_mul]
@@ -217,7 +123,7 @@ private lemma sum_frobSq₂_right (B : MPSTensor d D₂) (hB : ∑ i : Fin d, (B
 private lemma sum_frobSq₂_words (K : MPSTensor d D₁) (hK : ∑ i : Fin d, (K i)ᴴ * K i = 1)
     (n : ℕ) :
     ∑ σ : Fin n → Fin d, frobSq₂ (evalWord K (List.ofFn σ)) = (D₁ : ℝ) := by
-  simp_rw [frobSq₂_trace]
+  simp_rw [frobSq_trace]
   rw [← Complex.re_sum, ← Matrix.trace_sum, word_conjTranspose_mul_sum K hK n]
   simp [Matrix.trace_one, Fintype.card_fin]
 
@@ -235,28 +141,29 @@ private lemma hs_contraction_rect [NeZero D₁] [NeZero D₂]
     congr 1; ext σ; rw [Matrix.mul_assoc]]
   rw [show frobSq₂ (∑ σ : Fin n → Fin d,
     evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ)) =
-    ‖toES₂ (∑ σ : Fin n → Fin d,
+    ‖matToES (∑ σ : Fin n → Fin d,
     evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ))‖ ^ 2 from
-    (norm_toES₂_sq _).symm]
-  set fA := fun σ : Fin n → Fin d => ‖toESSq₁ (evalWord A (List.ofFn σ))‖ with hfA_def
-  set fB := fun σ : Fin n → Fin d => ‖toES₂ (X * (evalWord B (List.ofFn σ))ᴴ)‖ with hfB_def
-  have h_chain : ‖toES₂ (∑ σ : Fin n → Fin d,
+    (norm_matToES_sq _).symm]
+  set fA := fun σ : Fin n → Fin d => ‖matToES (evalWord A (List.ofFn σ))‖ with hfA_def
+  set fB := fun σ : Fin n → Fin d =>
+    ‖matToES (X * (evalWord B (List.ofFn σ))ᴴ)‖ with hfB_def
+  have h_chain : ‖matToES (∑ σ : Fin n → Fin d,
     evalWord A (List.ofFn σ) * (X * (evalWord B (List.ofFn σ))ᴴ))‖ ≤
     ∑ σ : Fin n → Fin d, fA σ * fB σ :=
-    ((by rw [toES₂_finset_sum]; exact norm_sum_le _ _) : ‖toES₂ _‖ ≤ _).trans
-      (Finset.sum_le_sum fun σ _ => norm_toES₂_mul_le _ _)
+    ((by rw [matToES_finset_sum]; exact norm_sum_le _ _) : ‖matToES _‖ ≤ _).trans
+      (Finset.sum_le_sum fun σ _ => norm_matToES_rect_mul_le _ _)
   have h_A : ∑ σ : Fin n → Fin d, fA σ ^ 2 = (D₁ : ℝ) := by
-    simp_rw [hfA_def, norm_toESSq₁_sq]; exact sum_frobSq₂_words A hA_norm n
+    simp_rw [hfA_def, norm_matToES_sq]; exact sum_frobSq₂_words A hA_norm n
   have h_B : ∑ σ : Fin n → Fin d, fB σ ^ 2 = frobSq₂ X := by
-    simp_rw [hfB_def, norm_toES₂_sq]; exact sum_frobSq₂_right B hB_norm X n
-  calc ‖toES₂ _‖ ^ 2
+    simp_rw [hfB_def, norm_matToES_sq]; exact sum_frobSq₂_right B hB_norm X n
+  calc ‖matToES _‖ ^ 2
       ≤ (∑ σ : Fin n → Fin d, fA σ * fB σ) ^ 2 :=
         pow_le_pow_left₀ (norm_nonneg _) h_chain 2
     _ ≤ (∑ σ, fA σ ^ 2) * (∑ σ, fB σ ^ 2) :=
         Finset.sum_mul_sq_le_sq_mul_sq Finset.univ fA fB
     _ = (D₁ : ℝ) * frobSq₂ X := by rw [h_A, h_B]
     _ ≤ (D₁ : ℝ) ^ 2 * frobSq₂ X := by
-        nlinarith [sq_nonneg ((D₁ : ℝ) - 1), frobSq₂_nonneg X,
+        nlinarith [sq_nonneg ((D₁ : ℝ) - 1), frobSq_nonneg X,
           show (1 : ℝ) ≤ D₁ from by exact_mod_cast NeZero.one_le (n := D₁)]
 
 end HSContraction
@@ -275,10 +182,11 @@ theorem eigenvalue_norm_le_one₂ [NeZero D₁] [NeZero D₂]
   obtain ⟨v, hv_mem, hv_ne⟩ := hμ.exists_hasEigenvector
   have hFv := Module.End.mem_eigenspace_iff.mp hv_mem
   by_contra h_gt; push_neg at h_gt
-  have h_pos := frobSq₂_pos_of_ne_zero v hv_ne
+  have h_pos := frobSq_pos_of_ne_zero v hv_ne
   have h_bound : ∀ n : ℕ, ‖μ‖ ^ (2 * n) ≤ (D₁ : ℝ) ^ 2 := fun n => by
     have h1 := hs_contraction_rect A B v hA_norm hB_norm n
-    rw [eigenvector_pow _ v μ hFv n, frobSq₂_smul, norm_pow] at h1
+    rw [eigenvector_pow _ v μ hFv n] at h1
+    simp only [frobSq₂, frobSq_smul, norm_pow] at h1
     calc ‖μ‖ ^ (2 * n) = (‖μ‖ ^ n) ^ 2 := by ring
     _ ≤ _ := le_of_mul_le_mul_right (by linarith) h_pos
   have htend := tendsto_pow_atTop_atTop_of_one_lt (by nlinarith : 1 < ‖μ‖ ^ 2)


### PR DESCRIPTION
## Summary

Refactor the Frobenius norm squared (`frobSq`) and Euclidean-space matrix embedding (`matToES`) infrastructure into a new shared module `TNLean.Spectral.FrobeniusNorm`. This eliminates code duplication between the square-matrix (`SpectralGap.lean`) and rectangular-matrix (`SpectralGapRect.lean`) spectral-gap proofs.

## Key Changes

- **New module `TNLean/Spectral/FrobeniusNorm.lean`**: Provides general definitions and lemmas for rectangular matrices:
  - `frobSq`: Frobenius norm squared as `∑ i j, ‖X i j‖²`
  - `matToES`: Isometric embedding into `EuclideanSpace ℂ (Fin m × Fin n)`
  - Supporting lemmas: `frobSq_nonneg`, `frobSq_eq_zero_iff`, `frobSq_pos_of_ne_zero`, `frobSq_smul`, `frobSq_trace`
  - `norm_matToES_sq`: Norm-squared equals Frobenius norm squared
  - `norm_sq_sum_mul_le`: Cauchy–Schwarz helper for inner products

- **`TNLean/Spectral/SpectralGap.lean`**: 
  - Remove duplicate definitions of `frobSq`, `toES`, and related lemmas
  - Import `FrobeniusNorm` module
  - Keep only square-matrix-specific lemma `frobSq_mul_le`
  - Rename `toES` → `matToES`, `norm_toES_sq` → `norm_matToES_sq`, `norm_toES_mul_le` → `norm_matToES_mul_le`
  - Update `frobSq_eq_sum` to be definitional (just `rfl`)

- **`TNLean/Spectral/SpectralGapRect.lean`**:
  - Remove duplicate Frobenius norm and Euclidean-space embedding sections
  - Introduce `frobSq₂` as a deprecated alias to `frobSq` for local readability
  - Rename `toES₂` → `matToES`, `toESSq₁` → `matToES`, `norm_toES₂_sq` → `norm_matToES_sq`
  - Rename `norm_toES₂_mul_le` → `norm_matToES_rect_mul_le`
  - Update all references to use the shared infrastructure

- **`TNLean/PiAlgebra/CanonicalFormSepAux.lean`**:
  - Remove local copy of `norm_sq_sum_mul_le` (now provided by `FrobeniusNorm`)
  - Update reference to use `MPSTensor.frobSq_trace`

## Implementation Details

- The new `FrobeniusNorm` module works for arbitrary rectangular matrices `Matrix (Fin m) (Fin n) ℂ`
- All definitions are placed in the `MPSTensor` namespace for consistency
- The rectangular case (`SpectralGapRect`) uses `frobSq₂` as a local alias for clarity while leveraging the shared definitions
- Removed unnecessary imports (`Mathlib.Analysis.InnerProductSpace.PiL2`, `Mathlib.Analysis.Matrix.Order`) from `SpectralGap.lean` (now in `FrobeniusNorm`)

https://claude.ai/code/session_01QgoivBt3S8NPxguagncrjS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a refactor, but it touches foundational lemmas (`frobSq`, `matToES`, Cauchy–Schwarz helper) used across spectral-gap proofs; small definitional/rewriting changes could break downstream theorems or simp behavior.
> 
> **Overview**
> Extracts the Frobenius norm-squared and Euclidean-space embedding machinery into a new shared module `TNLean.Spectral.FrobeniusNorm`, generalizing it to rectangular matrices and centralizing lemmas like `frobSq_trace`, `norm_matToES_sq`, and `norm_sq_sum_mul_le`.
> 
> Updates `SpectralGap.lean`, `SpectralGapRect.lean`, and `CanonicalFormSepAux.lean` to drop local duplicates and switch proofs over to the shared API (including renaming `toES*` usage to `matToES` and replacing ad-hoc Frobenius/trace rewrites with `frobSq_trace`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 056294c9d3a0f2e1ea065462f95a92a972b73988. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->