### PR TITLE
Introduce ProportionalDecompositionData to deduplicate proportional‑MPV hypotheses

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -438,6 +438,48 @@ end IsNormalCanonicalFormBNT
 
 /-! ### Bridge to BNT/PermutationRigidity -/
 
+/-- Common proportional-decomposition hypotheses used by the BNT bridge theorems. -/
+structure ProportionalDecompositionData
+    {rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (DtotA DtotB : ℕ) : Type where
+  A_total : MPSTensor d DtotA
+  B_total : MPSTensor d DtotB
+  aCoeff : ℕ → Fin rA → ℂ
+  bCoeff : ℕ → Fin rB → ℂ
+  aLim : Fin rA → ℂ
+  bLim : Fin rB → ℂ
+  c : ℕ → ℂ
+  cLim : ℂ
+  hA_decomp : ∀ N (σ : Fin N → Fin d),
+    mpv A_total σ = ∑ j : Fin rA, (aCoeff N j) * mpv (A j) σ
+  hB_decomp : ∀ N (σ : Fin N → Fin d),
+    mpv B_total σ = ∑ k : Fin rB, (bCoeff N k) * mpv (B k) σ
+  haCoeff : ∀ j, Tendsto (fun N => aCoeff N j) atTop (nhds (aLim j))
+  hbCoeff : ∀ k, Tendsto (fun N => bCoeff N k) atTop (nhds (bLim k))
+  haLim_ne : ∀ j, aLim j ≠ 0
+  hbLim_ne : ∀ k, bLim k ≠ 0
+  hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ
+  hc : Tendsto c atTop (nhds cLim)
+  hcLim_ne : cLim ≠ 0
+
+/-- Conclusion shared by the BNT proportional-MPV bridge theorems. -/
+abbrev ProportionalDecompositionConclusion
+    {rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k)) : Prop :=
+  ∃ _h : rA = rB,
+    ∃ perm : Fin rA ≃ Fin rB,
+      ∀ j : Fin rA,
+        ∃ hdim : dimA j = dimB (perm j),
+          GaugePhaseEquiv (d := d)
+            (cast (congr_arg (MPSTensor d) hdim) (A j))
+            (B (perm j))
+
 /-- Split-data bridge theorem for CF-BNT-style decompositions (Thm 4.4).
 
 The theorem only needs the separated pieces of data used by the proportional-MPV argument:
@@ -458,29 +500,8 @@ theorem fundamentalTheorem_of_separated_CFBNT_data
     (hB_left : IsLeftCanonicalBlockFamily (d := d) B)
     (hB_overlap : HasNormalizedSelfOverlap (d := d) B)
     (hB_blocks : BlocksNotGaugePhaseEquiv (d := d) B)
-    (A_total : MPSTensor d DtotA)
-    (B_total : MPSTensor d DtotB)
-    (aCoeff : ℕ → Fin rA → ℂ) (bCoeff : ℕ → Fin rB → ℂ)
-    (aLim : Fin rA → ℂ) (bLim : Fin rB → ℂ)
-    (c : ℕ → ℂ) (cLim : ℂ)
-    (hA_decomp : ∀ N (σ : Fin N → Fin d),
-      mpv A_total σ = ∑ j : Fin rA, (aCoeff N j) * mpv (A j) σ)
-    (hB_decomp : ∀ N (σ : Fin N → Fin d),
-      mpv B_total σ = ∑ k : Fin rB, (bCoeff N k) * mpv (B k) σ)
-    (haCoeff : ∀ j, Tendsto (fun N => aCoeff N j) atTop (nhds (aLim j)))
-    (hbCoeff : ∀ k, Tendsto (fun N => bCoeff N k) atTop (nhds (bLim k)))
-    (haLim_ne : ∀ j, aLim j ≠ 0)
-    (hbLim_ne : ∀ k, bLim k ≠ 0)
-    (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
-    (hc : Tendsto c atTop (nhds cLim))
-    (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    (hDecomp : ProportionalDecompositionData (d := d) A B DtotA DtotB) :
+    ProportionalDecompositionConclusion (d := d) A B :=
   exists_eq_numBlocks_and_equiv_gaugePhase_of_proportional_decomp
     (A := A) (B := B)
     (hA_inj := hA_inj.block_injective)
@@ -493,14 +514,14 @@ theorem fundamentalTheorem_of_separated_CFBNT_data
     (hB_self := hB_overlap.overlap_tendsto_one)
     (hB_off := fun i j hij =>
       cross_overlap_tendsto_zero_of_separated_CFBNT_data B hB_inj hB_left hB_blocks i j hij)
-    (A_total := A_total) (B_total := B_total)
-    (aCoeff := aCoeff) (bCoeff := bCoeff)
-    (aLim := aLim) (bLim := bLim)
-    (c := c) (cLim := cLim)
-    (hA_decomp := hA_decomp) (hB_decomp := hB_decomp)
-    (haCoeff := haCoeff) (hbCoeff := hbCoeff)
-    (_haLim_ne := haLim_ne) (_hbLim_ne := hbLim_ne)
-    (hProp := hProp) (hc := hc) (_hcLim_ne := hcLim_ne)
+    (A_total := hDecomp.A_total) (B_total := hDecomp.B_total)
+    (aCoeff := hDecomp.aCoeff) (bCoeff := hDecomp.bCoeff)
+    (aLim := hDecomp.aLim) (bLim := hDecomp.bLim)
+    (c := hDecomp.c) (cLim := hDecomp.cLim)
+    (hA_decomp := hDecomp.hA_decomp) (hB_decomp := hDecomp.hB_decomp)
+    (haCoeff := hDecomp.haCoeff) (hbCoeff := hDecomp.hbCoeff)
+    (_haLim_ne := hDecomp.haLim_ne) (_hbLim_ne := hDecomp.hbLim_ne)
+    (hProp := hDecomp.hProp) (hc := hDecomp.hc) (_hcLim_ne := hDecomp.hcLim_ne)
 
 /-- **Fundamental theorem bridge for CF-BNT decompositions (Thm 4.4).**
 
@@ -536,13 +557,7 @@ theorem fundamentalTheorem_of_IsCanonicalFormBNT
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    ProportionalDecompositionConclusion (d := d) A B :=
   fundamentalTheorem_of_separated_CFBNT_data A B
     hA.toHasInjectiveBlocks
     hA.toIsLeftCanonicalBlockFamily
@@ -552,8 +567,8 @@ theorem fundamentalTheorem_of_IsCanonicalFormBNT
     hB.toIsLeftCanonicalBlockFamily
     hB.toHasNormalizedSelfOverlap
     hB.blocks_not_equiv
-    A_total B_total aCoeff bCoeff aLim bLim c cLim
-    hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
+    ⟨A_total, B_total, aCoeff, bCoeff, aLim, bLim, c, cLim,
+      hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
 /-- Split-data bridge theorem for normal-CF-BNT-style decompositions (NT Thm 4.4). -/
 theorem fundamentalTheorem_of_separated_normalCFBNT_data
@@ -568,29 +583,8 @@ theorem fundamentalTheorem_of_separated_normalCFBNT_data
     (hA_blocks : BlocksNotGaugePhaseEquiv (d := d) A)
     (hB_ncf : IsNormalCanonicalForm μB B)
     (hB_blocks : BlocksNotGaugePhaseEquiv (d := d) B)
-    (A_total : MPSTensor d DtotA)
-    (B_total : MPSTensor d DtotB)
-    (aCoeff : ℕ → Fin rA → ℂ) (bCoeff : ℕ → Fin rB → ℂ)
-    (aLim : Fin rA → ℂ) (bLim : Fin rB → ℂ)
-    (c : ℕ → ℂ) (cLim : ℂ)
-    (hA_decomp : ∀ N (σ : Fin N → Fin d),
-      mpv A_total σ = ∑ j : Fin rA, (aCoeff N j) * mpv (A j) σ)
-    (hB_decomp : ∀ N (σ : Fin N → Fin d),
-      mpv B_total σ = ∑ k : Fin rB, (bCoeff N k) * mpv (B k) σ)
-    (haCoeff : ∀ j, Tendsto (fun N => aCoeff N j) atTop (nhds (aLim j)))
-    (hbCoeff : ∀ k, Tendsto (fun N => bCoeff N k) atTop (nhds (bLim k)))
-    (haLim_ne : ∀ j, aLim j ≠ 0)
-    (hbLim_ne : ∀ k, bLim k ≠ 0)
-    (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
-    (hc : Tendsto c atTop (nhds cLim))
-    (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    (hDecomp : ProportionalDecompositionData (d := d) A B DtotA DtotB) :
+    ProportionalDecompositionConclusion (d := d) A B :=
   exists_eq_numBlocks_and_equiv_gaugePhase_of_proportional_decomp_of_irreducible_TP
     (A := A) (B := B)
     (hA_irr := hA_ncf.block_irreducible)
@@ -609,14 +603,14 @@ theorem fundamentalTheorem_of_separated_normalCFBNT_data
         hB_ncf.toHasIrreducibleBlocks
         hB_ncf.toIsLeftCanonicalBlockFamily
         hB_blocks i j hij)
-    (A_total := A_total) (B_total := B_total)
-    (aCoeff := aCoeff) (bCoeff := bCoeff)
-    (aLim := aLim) (bLim := bLim)
-    (c := c) (cLim := cLim)
-    (hA_decomp := hA_decomp) (hB_decomp := hB_decomp)
-    (haCoeff := haCoeff) (hbCoeff := hbCoeff)
-    (_haLim_ne := haLim_ne) (_hbLim_ne := hbLim_ne)
-    (hProp := hProp) (hc := hc) (_hcLim_ne := hcLim_ne)
+    (A_total := hDecomp.A_total) (B_total := hDecomp.B_total)
+    (aCoeff := hDecomp.aCoeff) (bCoeff := hDecomp.bCoeff)
+    (aLim := hDecomp.aLim) (bLim := hDecomp.bLim)
+    (c := hDecomp.c) (cLim := hDecomp.cLim)
+    (hA_decomp := hDecomp.hA_decomp) (hB_decomp := hDecomp.hB_decomp)
+    (haCoeff := hDecomp.haCoeff) (hbCoeff := hDecomp.hbCoeff)
+    (_haLim_ne := hDecomp.haLim_ne) (_hbLim_ne := hDecomp.hbLim_ne)
+    (hProp := hDecomp.hProp) (hc := hDecomp.hc) (_hcLim_ne := hDecomp.hcLim_ne)
 
 /-- Fundamental theorem bridge for normal-CF-BNT decompositions (NT Thm 4.4). -/
 theorem fundamentalTheorem_of_IsNormalCanonicalFormBNT
@@ -645,17 +639,11 @@ theorem fundamentalTheorem_of_IsNormalCanonicalFormBNT
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    ProportionalDecompositionConclusion (d := d) A B :=
   fundamentalTheorem_of_separated_normalCFBNT_data A B
     hA.toIsNormalCanonicalForm hA.blocks_not_equiv
     hB.toIsNormalCanonicalForm hB.blocks_not_equiv
-    A_total B_total aCoeff bCoeff aLim bLim c cLim
-    hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
+    ⟨A_total, B_total, aCoeff, bCoeff, aLim, bLim, c, cLim,
+      hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -183,8 +183,8 @@ theorem fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data
   fundamentalTheorem_of_separated_CFBNT_data A B
     hA_inj hA_left hA_overlap hA_blocks
     hB_inj hB_left hB_overlap hB_blocks
-    A_total B_total aCoeff bCoeff aLim bLim c cLim
-    hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
+    ⟨A_total, B_total, aCoeff, bCoeff, aLim, bLim, c, cLim,
+      hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
 /-- **Proportional-MPV Fundamental Theorem for CF-BNT (Thm 4.4).**
 
@@ -278,8 +278,8 @@ theorem fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data
               (B (perm j)) :=
   fundamentalTheorem_of_separated_normalCFBNT_data A B
     hA_ncf hA_blocks hB_ncf hB_blocks
-    A_total B_total aCoeff bCoeff aLim bLim c cLim
-    hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
+    ⟨A_total, B_total, aCoeff, bCoeff, aLim, bLim, c, cLim,
+      hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
 /-- Fundamental Theorem (proportional case) for normal canonical form blocks. -/
 theorem fundamentalTheorem_proportionalMPV_normalCFBNT


### PR DESCRIPTION
### Motivation
- Several bridge and wrapper theorems repeated the same long sequence of proportional‑decomposition hypotheses and existential conclusion shapes, creating large duplicated tails in the BNT/FT layer that hurt readability and maintenance.
- The change packages that repeated argument tail so theorems can be called with a single record, reducing duplication and chance of copy/paste error. 

### Description
- Added a new record `ProportionalDecompositionData` that bundles `A_total`, `B_total`, the decomposition coefficients and limits, the proportionality `c` and its limit, and the decomposition/convergence/nonzero/proportionality witnesses. 
- Added `ProportionalDecompositionConclusion` (an `abbrev`) to name the repeated existential conclusion shape returned by the bridge theorems. 
- Refactored `fundamentalTheorem_of_separated_CFBNT_data` and `fundamentalTheorem_of_separated_normalCFBNT_data` to accept a single `hDecomp : ProportionalDecompositionData ...` argument and use its fields when invoking the downstream helper lemmas. 
- Updated legacy wrappers and delegating theorems (e.g. `fundamentalTheorem_of_IsCanonicalFormBNT`, `fundamentalTheorem_of_IsNormalCanonicalFormBNT`, and call sites in `TNLean/MPS/FundamentalTheorem/Full.lean`) to construct and pass the packed `ProportionalDecompositionData` so external behavior is preserved; modified files: `TNLean/MPS/BNT/Construction.lean` and `TNLean/MPS/FundamentalTheorem/Full.lean`.

### Testing
- Ran the duplicate-block scan scripts used during the refactor to locate high-value duplication candidates (scripts succeeded). 
- Performed a full project build with `lake build`, which completed successfully (`Build completed successfully (8214 jobs).`). 
- The build emitted existing linter/`sorry` warnings in unrelated files but produced no new errors from this refactor and the changed modules built cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02ffb20248324b4baf5b331026add)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change that repackages existing hypotheses into a record and updates call sites; main risk is minor breakage for downstream code depending on the old theorem argument lists.
> 
> **Overview**
> Introduces `ProportionalDecompositionData` (and `ProportionalDecompositionConclusion`) to bundle the repeated proportional-decomposition assumptions and standardize the returned existential shape.
> 
> Refactors the CF-BNT and normal-CF-BNT bridge theorems (`fundamentalTheorem_of_separated_CFBNT_data` / `..._normalCFBNT_data`) to take a single `hDecomp` record, and updates legacy wrapper theorems and `FundamentalTheorem/Full.lean` call sites to construct/pass this record so the resulting statements remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e096a14957f6f67e7a1d3eb5f1985dc3abd34b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->