### PR TITLE
Deduplicate cast transport in MPSTensor overlap-decay proofs

### DIFF
--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -3,6 +3,7 @@ import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.Spectral.SpectralGapRect
 import TNLean.MPS.Overlap.Basic
 import TNLean.MPS.Overlap.CastLemmas
+import TNLean.MPS.Overlap.CastDecay
 
 import Mathlib.Analysis.SpecificLimits.Basic
 import Mathlib.Data.Fintype.Card
@@ -261,10 +262,10 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
         (cast (congr_arg (MPSTensor d) hdim) (A (f j)) i)ᴴ *
         (cast (congr_arg (MPSTensor d) hdim) (A (f j)) i) = 1 :=
       (leftCanonical_cast_dim hdim (A (f j))).mpr (hA_norm (f j))
-    have hto0 := mpvOverlap_tendsto_zero
-      (cast (congr_arg (MPSTensor d) hdim) (A (f j))) (B j)
-      hAcst_inj (hB_inj j) hAcst_norm (hB_norm j) hNot
-    exact hf_spec j (hto0.congr fun N => mpvOverlap_cast_dim_left hdim (A (f j)) (B j) N)
+    exact hf_spec j (tendsto_mpvOverlap_uncast_left hdim (A (f j)) (B j) <|
+      mpvOverlap_tendsto_zero
+        (cast (congr_arg (MPSTensor d) hdim) (A (f j))) (B j)
+        hAcst_inj (hB_inj j) hAcst_norm (hB_norm j) hNot)
   --
   -- ═══════════════════════════════════════════════════════════════════════════
   -- Step 4: Show f is injective (hence a bijection on Fin g).

--- a/TNLean/MPS/Overlap/CastDecay.lean
+++ b/TNLean/MPS/Overlap/CastDecay.lean
@@ -19,6 +19,16 @@ open Filter
 
 namespace MPSTensor
 
+/-- Transport an overlap-decay limit from a casted left tensor back to the original tensor. -/
+private theorem tendsto_mpvOverlap_uncast_left
+    {d D₁ D₂ : ℕ} (hdim : D₁ = D₂)
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hcast :
+      Tendsto (fun N => mpvOverlap (d := d) (cast (congr_arg (MPSTensor d) hdim) A) B N)
+        atTop (nhds 0)) :
+    Tendsto (fun N => mpvOverlap (d := d) A B N) atTop (nhds 0) :=
+  hcast.congr fun N => mpvOverlap_cast_dim_left hdim A B N
+
 /-- If the left tensor is cast along a dimension equality, then the injective overlap-decay theorem
 still yields decay for the original uncasted overlap. -/
 theorem mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left
@@ -37,9 +47,8 @@ theorem mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left
         (cast (congr_arg (MPSTensor d) hdim) A i)ᴴ *
           (cast (congr_arg (MPSTensor d) hdim) A i) = 1 :=
     (leftCanonical_cast_dim hdim A).mpr hA_norm
-  have hto0 := mpvOverlap_tendsto_zero
+  exact tendsto_mpvOverlap_uncast_left hdim A B <| mpvOverlap_tendsto_zero
     (cast (congr_arg (MPSTensor d) hdim) A) B hAcst_inj hB_inj hAcst_norm hB_norm hNot
-  exact hto0.congr fun N => mpvOverlap_cast_dim_left hdim A B N
 
 /-- If the left tensor is cast along a dimension equality, then the irreducible / TP
 overlap-decay theorem still yields decay for the original uncasted overlap. -/
@@ -59,8 +68,7 @@ theorem mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_
         (cast (congr_arg (MPSTensor d) hdim) A i)ᴴ *
           (cast (congr_arg (MPSTensor d) hdim) A i) = 1 :=
     (leftCanonical_cast_dim hdim A).mpr hA_norm
-  have hto0 := mpvOverlap_tendsto_zero_of_irreducible_TP
+  exact tendsto_mpvOverlap_uncast_left hdim A B <| mpvOverlap_tendsto_zero_of_irreducible_TP
     (cast (congr_arg (MPSTensor d) hdim) A) B hAcst_irr hB_irr hAcst_norm hB_norm hNot
-  exact hto0.congr fun N => mpvOverlap_cast_dim_left hdim A B N
 
 end MPSTensor

--- a/TNLean/MPS/Overlap/CastDecay.lean
+++ b/TNLean/MPS/Overlap/CastDecay.lean
@@ -20,7 +20,7 @@ open Filter
 namespace MPSTensor
 
 /-- Transport an overlap-decay limit from a casted left tensor back to the original tensor. -/
-private theorem tendsto_mpvOverlap_uncast_left
+theorem tendsto_mpvOverlap_uncast_left
     {d D₁ D₂ : ℕ} (hdim : D₁ = D₂)
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hcast :


### PR DESCRIPTION
### Motivation
- Reduce duplicated `Tendsto.congr`/cast-transport boilerplate when converting overlap-decay limits across `MPSTensor` dimension casts by centralizing the step into a small helper.

### Description
- Add a private helper theorem `tendsto_mpvOverlap_uncast_left` in `TNLean/MPS/Overlap/CastDecay.lean` and replace the repeated transport code in `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left` and `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP` to call this helper, removing the duplicated `Tendsto.congr` pattern.

### Testing
- Ran `lake build` from the repository root and the build completed successfully (built all targets, 8214 jobs); existing non-blocking warnings (linter suggestions about `simpa` and some `sorry` usages) are unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02ffb20248324b4baf5b331026add)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that factors a repeated `Tendsto.congr`/cast-transport step into a helper theorem and updates a few proofs to use it; should not change mathematical statements, only proof structure and imports.
> 
> **Overview**
> Adds `tendsto_mpvOverlap_uncast_left` in `TNLean/MPS/Overlap/CastDecay.lean` to reuse the common step of transporting a `mpvOverlap` decay limit from a casted-left tensor back to the original tensor.
> 
> Updates existing overlap-decay lemmas in `CastDecay.lean` and the permutation-rigidity proof in `PermutationRigidityPrimitive.lean` to call this helper instead of repeating `Tendsto.congr` with `mpvOverlap_cast_dim_left`, and wires in the new `CastDecay` import where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03d1ac6d9f7c3e3169efe2cad2b6e07ae2ffd1ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->