### PR TITLE
[refactor] Deduplicate proportional-FT conclusion into shared alias

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -637,13 +637,8 @@ theorem weakFundamentalTheorem_conditional
     (hProp : ∀ N (σ : Fin N → Fin d'), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d')
-              (cast (congr_arg (MPSTensor d') hdim) (A j))
-              (B (perm j)) :=
+    MPSTensor.ProportionalMPVPermutationConclusion
+      (d := d') (dimA := dimA) (dimB := dimB) A B :=
   MPSTensor.fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data A B
     hA_ncf hA_blocks hB_ncf hB_blocks
     A_total B_total aCoeff bCoeff aLim bLim c cLim

--- a/TNLean/MPS/FundamentalTheorem/CoefficientConvergence.lean
+++ b/TNLean/MPS/FundamentalTheorem/CoefficientConvergence.lean
@@ -270,13 +270,7 @@ theorem fundamentalTheorem_proportionalMPV_CFBNT_auto
       mpv (toTensorFromBlocks μA A) σ = c N * mpv (toTensorFromBlocks μB B) σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    ProportionalMPVPermutationConclusion (d := d) (dimA := dimA) (dimB := dimB) A B :=
   fundamentalTheorem_proportionalMPV_CFBNT A B hA hB
     (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)
     aCoeff bCoeff aLim bLim c cLim

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -133,6 +133,22 @@ This is the content of Theorem 4.4 from arXiv:1606.00608 (primitive branch).
 The theorem takes convergent coefficient data as explicit hypotheses.
 -/
 
+/-- Common conclusion shape for proportional-MPV fundamental theorem variants:
+block-count equality together with a block permutation matching dimensions and
+gauge-phase classes. -/
+abbrev ProportionalMPVPermutationConclusion
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k)) : Prop :=
+  ∃ _h : rA = rB,
+    ∃ perm : Fin rA ≃ Fin rB,
+      ∀ j : Fin rA,
+        ∃ hdim : dimA j = dimB (perm j),
+          GaugePhaseEquiv (d := d)
+            (cast (congr_arg (MPSTensor d) hdim) (A j))
+            (B (perm j))
+
 /-- Split-data proportional-MPV Fundamental Theorem for CF-BNT-style data (Thm 4.4).
 
 This is the Stage B low-risk interface: it packages only the hypotheses actually used by the
@@ -173,13 +189,7 @@ theorem fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    ProportionalMPVPermutationConclusion (d := d) (dimA := dimA) (dimB := dimB) A B :=
   fundamentalTheorem_of_separated_CFBNT_data A B
     hA_inj hA_left hA_overlap hA_blocks
     hB_inj hB_left hB_overlap hB_blocks
@@ -226,13 +236,7 @@ theorem fundamentalTheorem_proportionalMPV_CFBNT
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    ProportionalMPVPermutationConclusion (d := d) (dimA := dimA) (dimB := dimB) A B :=
   fundamentalTheorem_of_IsCanonicalFormBNT A B hA hB A_total B_total aCoeff bCoeff aLim bLim c
     cLim hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
 
@@ -269,13 +273,7 @@ theorem fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    ProportionalMPVPermutationConclusion (d := d) (dimA := dimA) (dimB := dimB) A B :=
   fundamentalTheorem_of_separated_normalCFBNT_data A B
     hA_ncf hA_blocks hB_ncf hB_blocks
     A_total B_total aCoeff bCoeff aLim bLim c cLim
@@ -308,13 +306,7 @@ theorem fundamentalTheorem_proportionalMPV_normalCFBNT
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    ProportionalMPVPermutationConclusion (d := d) (dimA := dimA) (dimB := dimB) A B :=
   fundamentalTheorem_of_IsNormalCanonicalFormBNT A B hA hB
     A_total B_total aCoeff bCoeff aLim bLim c cLim
     hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "2860b6cd6c5a3c6be03dec93db1da50a417334f9",
+   "rev": "2256d3d6dc6db34f9628cb5aff0e9556ef50a22d",
    "name": "Gametheory",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
### Motivation
- Remove a large repeated existential/permutation/gauge-phase proposition that appeared verbatim in several proportional fundamental-theorem wrappers to reduce duplication and maintenance burden.
- Make future changes to the proportional-FT conclusion shape easier by centralizing the type-level description into a single alias.

### Description
- Add the `ProportionalMPVPermutationConclusion` abbrev in `TNLean/MPS/FundamentalTheorem/Full.lean` to capture the repeated conclusion shape. 
- Update the proportional fundamental-theorem wrappers in `TNLean/MPS/FundamentalTheorem/Full.lean` to return `ProportionalMPVPermutationConclusion` instead of repeating the long dependent-existential block. 
- Update `weakFundamentalTheorem_conditional` in `TNLean/MPS/CanonicalForm/Assembly.lean` to reuse the same alias so the wrapper signatures are consistent. 
- Include the local `lake-manifest.json` pin update so the tree remains buildable in this environment; proofs and behavior are unchanged.

### Testing
- Ran `lake build` and the project built successfully (build completed; 8214 jobs), so the refactor did not break the checked files. 
- The build emitted some existing linter warnings about `simpa` and a few `sorry` placeholders but no new errors were introduced. 
- Verified the modified files compile: `TNLean.MPS.FundamentalTheorem.Full` and `TNLean.MPS.CanonicalForm.Assembly` were rebuilt successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0345b69c48324ae571a64f145cb21)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes theorem statement types by introducing a shared `abbrev`; proof bodies still delegate to the same underlying theorems. Main risk is minor breakage for downstream code that pattern-matches on the old explicit existential shape or relies on definitional equality.
> 
> **Overview**
> Introduces `ProportionalMPVPermutationConclusion` in `FundamentalTheorem/Full.lean` to capture the repeated proportional-MPV FT conclusion (block-count equality + permutation + per-block dimension equality + `GaugePhaseEquiv`).
> 
> Updates the proportional fundamental-theorem wrapper theorems (including the auto/coefficient-convergence wrapper and `weakFundamentalTheorem_conditional`) to return this alias instead of restating the full nested existential proposition.
> 
> Bumps the pinned `Gametheory` dependency revision in `lake-manifest.json` to keep the workspace buildable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94f6a19db204ec0e4eb97097b72e2d2d25686645. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->