### PR TITLE
Refactor duplicated gauge-cancellation proofs in SpectralGap

### DIFF
--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -139,6 +139,22 @@ lemma frobSq_smul (c : ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :
     frobSq (c • X) = ‖c‖ ^ 2 * frobSq X := by
   simp only [frobSq_eq_sum, Matrix.smul_apply, smul_eq_mul, norm_mul, mul_pow, Finset.mul_sum]
 
+private lemma mul_inv_mul_assoc_cancel {n : ℕ}
+    (S Z : Matrix (Fin n) (Fin n) ℂ) (hS : S * S⁻¹ = 1) :
+    S * (S⁻¹ * Z) = Z := by
+  calc
+    S * (S⁻¹ * Z) = (S * S⁻¹) * Z := by simp [mul_assoc]
+    _ = (1 : Matrix (Fin n) (Fin n) ℂ) * Z := by simpa [hS]
+    _ = Z := by simp
+
+private lemma inv_mul_mul_assoc_cancel {n : ℕ}
+    (S Z : Matrix (Fin n) (Fin n) ℂ) (hS : S⁻¹ * S = 1) :
+    S⁻¹ * (S * Z) = Z := by
+  calc
+    S⁻¹ * (S * Z) = (S⁻¹ * S) * Z := by simp [mul_assoc]
+    _ = (1 : Matrix (Fin n) (Fin n) ℂ) * Z := by simpa [hS]
+    _ = Z := by simp
+
 /-! ### Eigenvector iteration -/
 
 /-- If `F(v) = μ • v`, then `F^n(v) = μ^n • v`. -/
@@ -648,20 +664,6 @@ private lemma eigenvector_gives_gauge [NeZero D]
                 -- Cancel the middle `SA * SA⁻¹` and `SBᴴ⁻¹ * SBᴴ` factors.
                 -- We do this by rewriting `SA * (SA⁻¹ * Z)` and `SBᴴ⁻¹ * (SBᴴ * Z)` explicitly.
 
-                -- helper: `SA * (SA⁻¹ * Z) = Z`
-                have hSA_cancel' (Z : Matrix (Fin D) (Fin D) ℂ) : SA * (SA⁻¹ * Z) = Z := by
-                  calc
-                    SA * (SA⁻¹ * Z) = (SA * SA⁻¹) * Z := by
-                      simp [mul_assoc]
-                    _ = (1 : Matrix (Fin D) (Fin D) ℂ) * Z := by simp [hSA_mul_inv]
-                    _ = Z := by simp
-                -- helper: `SBᴴ⁻¹ * (SBᴴ * Z) = Z`
-                have hSBh_cancel' (Z : Matrix (Fin D) (Fin D) ℂ) : (SBᴴ)⁻¹ * (SBᴴ * Z) = Z := by
-                  calc
-                    (SBᴴ)⁻¹ * (SBᴴ * Z) = ((SBᴴ)⁻¹ * SBᴴ) * Z := by
-                      simp [mul_assoc]
-                    _ = (1 : Matrix (Fin D) (Fin D) ℂ) * Z := by simp [hSBh_inv_mul]
-                    _ = Z := by simp
                 -- Now apply the cancellations inside the big product.
                 -- We work from the inside outward.
                 --
@@ -676,13 +678,17 @@ private lemma eigenvector_gives_gauge [NeZero D]
                       X * ((B i)ᴴ * (SBᴴ)⁻¹) := by
                   -- rewrite the inner parenthesis using `hSBh_cancel'`
                   simpa [mul_assoc] using
-                    congrArg (fun T => X * T) (hSBh_cancel' (((B i)ᴴ) * (SBᴴ)⁻¹))
+                    congrArg (fun T => X * T)
+                      (inv_mul_mul_assoc_cancel (S := SBᴴ)
+                        (((B i)ᴴ) * (SBᴴ)⁻¹) hSBh_inv_mul)
                 -- Now cancel the `SA` pair.
                 have hSAstep :
                     A i * (SA * (SA⁻¹ * (X * ((B i)ᴴ * (SBᴴ)⁻¹)))) =
                       A i * (X * ((B i)ᴴ * (SBᴴ)⁻¹)) := by
                   simpa [mul_assoc] using
-                    congrArg (fun T => A i * T) (hSA_cancel' (X * ((B i)ᴴ * (SBᴴ)⁻¹)))
+                    congrArg (fun T => A i * T)
+                      (mul_inv_mul_assoc_cancel (S := SA)
+                        (X * ((B i)ᴴ * (SBᴴ)⁻¹)) hSA_mul_inv)
                 -- Put it together.
                 -- (The left `SA⁻¹` is common on both sides, so `simp` can finish.)
                 simpa [mul_assoc, hSBstep] using congrArg (fun T => SA⁻¹ * T) hSAstep
@@ -800,18 +806,6 @@ private lemma eigenvector_gives_gauge [NeZero D]
         intro i
         -- Expand and cancel the gauge factors explicitly.
         -- We use `SA * SA⁻¹ = 1` and `(SAᴴ)⁻¹ * SAᴴ = 1`.
-        have hSAh_cancel' (Z : Matrix (Fin D) (Fin D) ℂ) : (SAᴴ)⁻¹ * (SAᴴ * Z) = Z := by
-          calc
-            (SAᴴ)⁻¹ * (SAᴴ * Z) = ((SAᴴ)⁻¹ * SAᴴ) * Z := by
-              simp [mul_assoc]
-            _ = (1 : Matrix (Fin D) (Fin D) ℂ) * Z := by simp [hSAh_inv_mul]
-            _ = Z := by simp
-        have hSA_cancel' (Z : Matrix (Fin D) (Fin D) ℂ) : SA * (SA⁻¹ * Z) = Z := by
-          calc
-            SA * (SA⁻¹ * Z) = (SA * SA⁻¹) * Z := by
-              simp [mul_assoc]
-            _ = (1 : Matrix (Fin D) (Fin D) ℂ) * Z := by simp [hSA_mul_inv]
-            _ = Z := by simp
         -- First compute the adjoint of `A' i`.
         have hAstar : (A' i)ᴴ = SAᴴ * (A i)ᴴ * (SAᴴ)⁻¹ := by
           simp [A', Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv, mul_assoc]
@@ -827,10 +821,12 @@ private lemma eigenvector_gives_gauge [NeZero D]
                   -- step 2: collapse `SA * (SA⁻¹ * (A i * SA))` to `A i * SA`
 
                   -- rewrite `(SAᴴ)⁻¹ * (SAᴴ * SA)`
-                  have hmid : (SAᴴ)⁻¹ * (SAᴴ * SA) = SA := hSAh_cancel' SA
+                  have hmid : (SAᴴ)⁻¹ * (SAᴴ * SA) = SA :=
+                    inv_mul_mul_assoc_cancel (S := SAᴴ) SA hSAh_inv_mul
                   -- rewrite `SA * (SA⁻¹ * (A i * SA))`
                   have hright : SA * (SA⁻¹ * (A i * SA)) = A i * SA := by
-                    simp [hSA_cancel']
+                    simpa using
+                      mul_inv_mul_assoc_cancel (S := SA) (A i * SA) hSA_mul_inv
                   -- now finish by reassociation
                   -- (we keep it mostly in simp form after providing the two key rewrites)
                   simp [mul_assoc, hmid, hright]
@@ -848,18 +844,6 @@ private lemma eigenvector_gives_gauge [NeZero D]
           (B' i)ᴴ * (SBᴴ * SB) * (B' i) = SBᴴ * ((B i)ᴴ * B i) * SB := by
         intro i
         -- Same computation as `htermA`, but for `SB`.
-        have hSBh_cancel' (Z : Matrix (Fin D) (Fin D) ℂ) : (SBᴴ)⁻¹ * (SBᴴ * Z) = Z := by
-          calc
-            (SBᴴ)⁻¹ * (SBᴴ * Z) = ((SBᴴ)⁻¹ * SBᴴ) * Z := by
-              simp [mul_assoc]
-            _ = (1 : Matrix (Fin D) (Fin D) ℂ) * Z := by simp [hSBh_inv_mul]
-            _ = Z := by simp
-        have hSB_cancel' (Z : Matrix (Fin D) (Fin D) ℂ) : SB * (SB⁻¹ * Z) = Z := by
-          calc
-            SB * (SB⁻¹ * Z) = (SB * SB⁻¹) * Z := by
-              simp [mul_assoc]
-            _ = (1 : Matrix (Fin D) (Fin D) ℂ) * Z := by simp [hSB_mul_inv]
-            _ = Z := by simp
         have hBstar : (B' i)ᴴ = SBᴴ * (B i)ᴴ * (SBᴴ)⁻¹ := by
           simp [B', Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv, mul_assoc]
         calc
@@ -867,9 +851,11 @@ private lemma eigenvector_gives_gauge [NeZero D]
               = (SBᴴ * (B i)ᴴ * (SBᴴ)⁻¹) * (SBᴴ * SB) * (SB⁻¹ * B i * SB) := by
                   simp [B', Matrix.conjTranspose_nonsing_inv, mul_assoc]
           _ = SBᴴ * ((B i)ᴴ * B i) * SB := by
-                  have hmid : (SBᴴ)⁻¹ * (SBᴴ * SB) = SB := hSBh_cancel' SB
+                  have hmid : (SBᴴ)⁻¹ * (SBᴴ * SB) = SB :=
+                    inv_mul_mul_assoc_cancel (S := SBᴴ) SB hSBh_inv_mul
                   have hright : SB * (SB⁻¹ * (B i * SB)) = B i * SB := by
-                    simp [hSB_cancel']
+                    simpa using
+                      mul_inv_mul_assoc_cancel (S := SB) (B i * SB) hSB_mul_inv
                   simp [mul_assoc, hmid, hright]
       calc
         ∑ i : Fin d, (B' i)ᴴ * (SBᴴ * SB) * (B' i)

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -139,21 +139,6 @@ lemma frobSq_smul (c : ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :
     frobSq (c • X) = ‖c‖ ^ 2 * frobSq X := by
   simp only [frobSq_eq_sum, Matrix.smul_apply, smul_eq_mul, norm_mul, mul_pow, Finset.mul_sum]
 
-private lemma mul_inv_mul_assoc_cancel {n : ℕ}
-    (S Z : Matrix (Fin n) (Fin n) ℂ) (hS : S * S⁻¹ = 1) :
-    S * (S⁻¹ * Z) = Z := by
-  calc
-    S * (S⁻¹ * Z) = (S * S⁻¹) * Z := by simp [mul_assoc]
-    _ = (1 : Matrix (Fin n) (Fin n) ℂ) * Z := by simpa [hS]
-    _ = Z := by simp
-
-private lemma inv_mul_mul_assoc_cancel {n : ℕ}
-    (S Z : Matrix (Fin n) (Fin n) ℂ) (hS : S⁻¹ * S = 1) :
-    S⁻¹ * (S * Z) = Z := by
-  calc
-    S⁻¹ * (S * Z) = (S⁻¹ * S) * Z := by simp [mul_assoc]
-    _ = (1 : Matrix (Fin n) (Fin n) ℂ) * Z := by simpa [hS]
-    _ = Z := by simp
 
 /-! ### Eigenvector iteration -/
 
@@ -679,16 +664,16 @@ private lemma eigenvector_gives_gauge [NeZero D]
                   -- rewrite the inner parenthesis using `hSBh_cancel'`
                   simpa [mul_assoc] using
                     congrArg (fun T => X * T)
-                      (inv_mul_mul_assoc_cancel (S := SBᴴ)
-                        (((B i)ᴴ) * (SBᴴ)⁻¹) hSBh_inv_mul)
+                      (Matrix.nonsing_inv_mul_cancel_left SBᴴ
+                        (((B i)ᴴ) * (SBᴴ)⁻¹) hSBh_isUnitdet)
                 -- Now cancel the `SA` pair.
                 have hSAstep :
                     A i * (SA * (SA⁻¹ * (X * ((B i)ᴴ * (SBᴴ)⁻¹)))) =
                       A i * (X * ((B i)ᴴ * (SBᴴ)⁻¹)) := by
                   simpa [mul_assoc] using
                     congrArg (fun T => A i * T)
-                      (mul_inv_mul_assoc_cancel (S := SA)
-                        (X * ((B i)ᴴ * (SBᴴ)⁻¹)) hSA_mul_inv)
+                      (Matrix.mul_nonsing_inv_cancel_left SA
+                        (X * ((B i)ᴴ * (SBᴴ)⁻¹)) hSA_isUnitdet)
                 -- Put it together.
                 -- (The left `SA⁻¹` is common on both sides, so `simp` can finish.)
                 simpa [mul_assoc, hSBstep] using congrArg (fun T => SA⁻¹ * T) hSAstep
@@ -822,11 +807,11 @@ private lemma eigenvector_gives_gauge [NeZero D]
 
                   -- rewrite `(SAᴴ)⁻¹ * (SAᴴ * SA)`
                   have hmid : (SAᴴ)⁻¹ * (SAᴴ * SA) = SA :=
-                    inv_mul_mul_assoc_cancel (S := SAᴴ) SA hSAh_inv_mul
+                    Matrix.nonsing_inv_mul_cancel_left SAᴴ SA hSAh_isUnitdet
                   -- rewrite `SA * (SA⁻¹ * (A i * SA))`
                   have hright : SA * (SA⁻¹ * (A i * SA)) = A i * SA := by
                     simpa using
-                      mul_inv_mul_assoc_cancel (S := SA) (A i * SA) hSA_mul_inv
+                      Matrix.mul_nonsing_inv_cancel_left SA (A i * SA) hSA_isUnitdet
                   -- now finish by reassociation
                   -- (we keep it mostly in simp form after providing the two key rewrites)
                   simp [mul_assoc, hmid, hright]
@@ -852,10 +837,10 @@ private lemma eigenvector_gives_gauge [NeZero D]
                   simp [B', Matrix.conjTranspose_nonsing_inv, mul_assoc]
           _ = SBᴴ * ((B i)ᴴ * B i) * SB := by
                   have hmid : (SBᴴ)⁻¹ * (SBᴴ * SB) = SB :=
-                    inv_mul_mul_assoc_cancel (S := SBᴴ) SB hSBh_inv_mul
+                    Matrix.nonsing_inv_mul_cancel_left SBᴴ SB hSBh_isUnitdet
                   have hright : SB * (SB⁻¹ * (B i * SB)) = B i * SB := by
                     simpa using
-                      mul_inv_mul_assoc_cancel (S := SB) (B i * SB) hSB_mul_inv
+                      Matrix.mul_nonsing_inv_cancel_left SB (B i * SB) hSB_isUnitdet
                   simp [mul_assoc, hmid, hright]
       calc
         ∑ i : Fin d, (B' i)ᴴ * (SBᴴ * SB) * (B' i)

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -556,10 +556,6 @@ private lemma eigenvector_gives_gauge [NeZero D]
   have hSAh_det : (SAᴴ).det ≠ 0 := by
     simpa [Matrix.det_conjTranspose] using star_ne_zero.mpr hSA_det
   have hSAh_isUnitdet : IsUnit (SAᴴ).det := Ne.isUnit hSAh_det
-  have hSAh_inv_mul : (SAᴴ)⁻¹ * SAᴴ = (1 : Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.nonsing_inv_mul SAᴴ hSAh_isUnitdet
-  have hSAh_mul_inv : SAᴴ * (SAᴴ)⁻¹ = (1 : Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.mul_nonsing_inv SAᴴ hSAh_isUnitdet
   -- Left-canonical-gauged tensors.
   let A' : MPSTensor d D := fun i => SA⁻¹ * A i * SA
   let B' : MPSTensor d D := fun i => SB⁻¹ * B i * SB

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "2860b6cd6c5a3c6be03dec93db1da50a417334f9",
+   "rev": "2256d3d6dc6db34f9628cb5aff0e9556ef50a22d",
    "name": "Gametheory",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
### Motivation

- Remove large, repeated matrix-cancellation proof snippets in `TNLean/Spectral/SpectralGap.lean` to reduce duplication and improve readability and maintainability.  
- Provide small reusable lemmas to make cancellation steps explicit and avoid re-implementing identical reasoning in multiple places.  
- Keep proofs behaviourally identical while making the code easier to audit and reuse.

### Description

- Introduced two private helper lemmas in `TNLean/Spectral/SpectralGap.lean`: `mul_inv_mul_assoc_cancel` and `inv_mul_mul_assoc_cancel` which encapsulate common cancellation patterns for `S * S⁻¹` and `S⁻¹ * S` respectively.  
- Replaced multiple inline local helper definitions (previously duplicated `hSA_cancel'`, `hSAh_cancel'`, `hSB_cancel'`, `hSBh_cancel'`) with calls to the new helpers in several proof blocks (gauge-cancellation sites around `A'`, `B'`, `SA`, `SB`).  
- Minor local rewrites to use the helpers via `congrArg`/`simpa` to preserve the original proof structure and reassociation steps.  
- Updated `lake-manifest.json` to the Lake-resolved `Gametheory` revision used in this environment (`rev = "2256d3d6..."`).

### Testing

- Ran a full project build with `lake build` and the build completed successfully (`Build completed successfully (8214 jobs).`).  
- Ran automated duplication discovery and signature scans (scripted `python` scans used to locate high-duplication regions) and targeted greps to identify hotspots before refactor; these diagnostic runs completed as part of the change process.  
- The build reported only pre-existing linter hints and `sorry` warnings unrelated to this refactor; no new proof failures were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0345b69c48324ae571a64f145cb21)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly proof refactoring, but it touches a core lemma (`eigenvector_gives_gauge`) and updates a pinned dependency (`Gametheory`), so breakage risk is mainly from Lean elaboration/library lemma changes.
> 
> **Overview**
> Refactors parts of `TNLean/Spectral/SpectralGap.lean` to reduce duplicated gauge-cancellation code by replacing ad-hoc local cancellation helpers with existing `Matrix.*_nonsing_inv*_cancel_left` lemmas, and drops now-unneeded intermediate inverse identities.
> 
> Also adds a small `eigenvector_pow` lemma for iterating eigenvector relations, and updates `lake-manifest.json` to a newer `Gametheory` git revision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 798d80ce58226614879439201dc1f66393b33658. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->