### PR TITLE
refactor: deduplicate irreducible trace adjoint helper

### DIFF
--- a/TNLean/Channel/Irreducible/FromSpectral.lean
+++ b/TNLean/Channel/Irreducible/FromSpectral.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.SpectralRadius
+import TNLean.Channel.Irreducible.TraceAdjoint
 
 /-!
 # Irreducibility from spectral properties (Wolf Theorem 6.4)
@@ -54,25 +55,6 @@ private noncomputable def sandwichLinearMap
     simp [Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc]
   map_smul' a X := by
     simp [Matrix.mul_assoc]
-
-private lemma trace_mul_transferMap_adjoint
-    {n : ℕ}
-    (K : MPSTensor n D)
-    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K)
-    (ρ X : Matrix (Fin D) (Fin D) ℂ) :
-    Matrix.trace (ρ * E X) =
-      Matrix.trace (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) :=
-  calc
-    Matrix.trace (ρ * E X)
-        = Matrix.trace (ρ * MPSTensor.transferMap (d := n) (D := D) K X) := by rw [hE_eq]
-    _ = Matrix.trace (Kraus.adjointMap K ρ * X) := by
-          simpa [Kraus.map, MPSTensor.transferMap_apply] using
-            (Kraus.trace_mul_map_eq_trace_adjointMap_mul (K := K) ρ X)
-    _ = Matrix.trace
-          (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) := by
-          simp [Kraus.adjointMap, MPSTensor.transferMap_apply,
-            Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
 
 private lemma dotProduct_mulVec_conjTranspose
     (M : Matrix (Fin D) (Fin D) ℂ)

--- a/TNLean/Channel/Irreducible/PerronFrobenius.lean
+++ b/TNLean/Channel/Irreducible/PerronFrobenius.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Irreducible.Growth
+import TNLean.Channel.Irreducible.TraceAdjoint
 import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.QPF.Uniqueness
 
@@ -34,34 +35,6 @@ open scoped Matrix MatrixOrder Pointwise ComplexOrder BigOperators
 open Matrix Finset
 
 variable {D : ℕ}
-
-/-! ## Shared trace helper -/
-
-/-- The adjoint trace-pairing identity
-`tr(ρ * E(X)) = tr(E†(ρ) * X)`, expressed via the conjugate-transposed Kraus
-family.
-
-Used in the dual-map proof of
-`eigenvalue_unique_of_irreducible_cp`. -/
-private lemma trace_mul_transferMap_adjoint
-    {n : ℕ}
-    (K : MPSTensor n D)
-    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K)
-    (ρ X : Matrix (Fin D) (Fin D) ℂ) :
-    Matrix.trace (ρ * E X) =
-      Matrix.trace (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) :=
-  calc
-    Matrix.trace (ρ * E X)
-        = Matrix.trace (ρ * MPSTensor.transferMap (d := n) (D := D) K X) := by rw [hE_eq]
-    _ = Matrix.trace (Kraus.adjointMap K ρ * X) := by
-          simpa [Kraus.map, MPSTensor.transferMap_apply] using
-            (Kraus.trace_mul_map_eq_trace_adjointMap_mul (K := K) ρ X)
-    _ = Matrix.trace
-          (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) := by
-          simp [Kraus.adjointMap, MPSTensor.transferMap_apply,
-            Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
-
 
 /-! ## PSD eigenvector → PosDef (Wolf 6.3(2), upgrade) -/
 

--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Irreducible.Similarity
+import TNLean.Channel.Irreducible.TraceAdjoint
 import TNLean.MPS.Core.TPGauge
 import TNLean.Spectral.SpectralGap
 
@@ -47,32 +48,6 @@ noncomputable instance : NormedAlgebra ℂ (Matrix (Fin D) (Fin D) ℂ) :=
   Matrix.linftyOpNormedAlgebra
 
 /-! ## Private infrastructure -/
-
-/-- The adjoint trace-pairing identity
-`tr(ρ * E(X)) = tr(E†(ρ) * X)`, expressed via the conjugate-transposed Kraus
-family.
-
-Used in the proof of
-`spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp`. -/
-private lemma trace_mul_transferMap_adjoint
-    {n : ℕ}
-    (K : MPSTensor n D)
-    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K)
-    (ρ X : Matrix (Fin D) (Fin D) ℂ) :
-    Matrix.trace (ρ * E X) =
-      Matrix.trace (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) :=
-  calc
-    Matrix.trace (ρ * E X)
-        = Matrix.trace (ρ * MPSTensor.transferMap (d := n) (D := D) K X) := by rw [hE_eq]
-    _ = Matrix.trace (Kraus.adjointMap K ρ * X) := by
-          simpa [Kraus.map, MPSTensor.transferMap_apply] using
-            (Kraus.trace_mul_map_eq_trace_adjointMap_mul (K := K) ρ X)
-    _ = Matrix.trace
-          (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) := by
-          simp [Kraus.adjointMap, MPSTensor.transferMap_apply,
-            Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
-
 
 /-! ## Spectral radius identity (Wolf 6.3(4)) -/
 

--- a/TNLean/Channel/Irreducible/TraceAdjoint.lean
+++ b/TNLean/Channel/Irreducible/TraceAdjoint.lean
@@ -1,0 +1,40 @@
+/-  
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Schwarz.Basic
+import TNLean.MPS.Core.Transfer
+
+/-!
+# Shared trace-adjoint helper for irreducible-channel developments
+
+This file factors out a common trace-pairing identity used in multiple
+irreducibility proofs.
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+open Matrix Finset
+
+variable {D : ℕ}
+
+/-- The adjoint trace-pairing identity
+`tr(ρ * E(X)) = tr(E†(ρ) * X)`, expressed via the conjugate-transposed Kraus
+family for an `MPSTensor` transfer map. -/
+lemma trace_mul_transferMap_adjoint
+    {n : ℕ}
+    (K : MPSTensor n D)
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K)
+    (ρ X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (ρ * E X) =
+      Matrix.trace (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) := by
+  calc
+    Matrix.trace (ρ * E X)
+        = Matrix.trace (ρ * MPSTensor.transferMap (d := n) (D := D) K X) := by rw [hE_eq]
+    _ = Matrix.trace (Kraus.adjointMap K ρ * X) := by
+          simpa [Kraus.map, MPSTensor.transferMap_apply] using
+            (Kraus.trace_mul_map_eq_trace_adjointMap_mul (K := K) ρ X)
+    _ = Matrix.trace
+          (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) := by
+          simp [Kraus.adjointMap, MPSTensor.transferMap_apply,
+            Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]


### PR DESCRIPTION
### Motivation
- Several irreducibility-related files contained an identical private lemma `trace_mul_transferMap_adjoint`, causing code duplication and making maintenance harder.

### Description
- Added a new shared helper module `TNLean/Channel/Irreducible/TraceAdjoint.lean` containing the common `trace_mul_transferMap_adjoint` lemma.
- Updated `TNLean/Channel/Irreducible/PerronFrobenius.lean` to import and use the shared helper instead of a private copy.
- Updated `TNLean/Channel/Irreducible/SpectralRadius.lean` to import and use the shared helper instead of a private copy.
- Updated `TNLean/Channel/Irreducible/FromSpectral.lean` to import and use the shared helper instead of a private copy.

### Testing
- Ran `lake build`, which completed successfully and rebuilt the affected modules including `TNLean.Channel.Irreducible.TraceAdjoint`, `PerronFrobenius`, `SpectralRadius`, and `FromSpectral` (pre-existing warnings/sorries were unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0345b69c48324ae571a64f145cb21)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only moves an existing lemma into a shared module and updates imports/usages, with no changes to proof logic beyond symbol resolution.
> 
> **Overview**
> Refactors irreducibility proofs to **deduplicate the trace/adjoint pairing lemma** by introducing `TNLean/Channel/Irreducible/TraceAdjoint.lean` exporting `trace_mul_transferMap_adjoint`.
> 
> Updates `FromSpectral.lean`, `PerronFrobenius.lean`, and `SpectralRadius.lean` to import this new module and removes their previous private copies of the same lemma.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7619be6024dca3f69acd0c5a0950c5e438845b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->