### PR TITLE
refactor(MPS/FundamentalTheorem): factor out repeated block-matching witness type

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -138,6 +138,19 @@ The theorem takes convergent coefficient data as explicit hypotheses.
 This is the Stage B low-risk interface: it packages only the hypotheses actually used by the
 proportional-MPV argument, and leaves the legacy `IsCanonicalFormBNT` wrapper theorem below
 unchanged. -/
+abbrev BlockPermutationGaugeWitness
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k)) : Prop :=
+  ∃ _h : rA = rB,
+    ∃ perm : Fin rA ≃ Fin rB,
+      ∀ j : Fin rA,
+        ∃ hdim : dimA j = dimB (perm j),
+          GaugePhaseEquiv (d := d)
+            (cast (congr_arg (MPSTensor d) hdim) (A j))
+            (B (perm j))
+
 theorem fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -173,13 +186,7 @@ theorem fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    BlockPermutationGaugeWitness (d := d) A B :=
   fundamentalTheorem_of_separated_CFBNT_data A B
     hA_inj hA_left hA_overlap hA_blocks
     hB_inj hB_left hB_overlap hB_blocks
@@ -226,13 +233,7 @@ theorem fundamentalTheorem_proportionalMPV_CFBNT
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    BlockPermutationGaugeWitness (d := d) A B :=
   fundamentalTheorem_of_IsCanonicalFormBNT A B hA hB A_total B_total aCoeff bCoeff aLim bLim c
     cLim hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
 
@@ -269,13 +270,7 @@ theorem fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    BlockPermutationGaugeWitness (d := d) A B :=
   fundamentalTheorem_of_separated_normalCFBNT_data A B
     hA_ncf hA_blocks hB_ncf hB_blocks
     A_total B_total aCoeff bCoeff aLim bLim c cLim
@@ -308,13 +303,7 @@ theorem fundamentalTheorem_proportionalMPV_normalCFBNT
     (hProp : ∀ N (σ : Fin N → Fin d), mpv A_total σ = c N * mpv B_total σ)
     (hc : Tendsto c atTop (nhds cLim))
     (hcLim_ne : cLim ≠ 0) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    BlockPermutationGaugeWitness (d := d) A B :=
   fundamentalTheorem_of_IsNormalCanonicalFormBNT A B hA hB
     A_total B_total aCoeff bCoeff aLim bLim c cLim
     hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
@@ -1604,13 +1593,7 @@ private lemma blocks_match_of_sameMPV₂_CFBNT
     (hA : IsCanonicalFormBNT μA A)
     (hB : IsCanonicalFormBNT μB B)
     (hEqual : SameMPV₂ (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) := by
+    BlockPermutationGaugeWitness (d := d) A B := by
   have hμA_ne := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero
   have hμB_ne := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero
   obtain ⟨N0A, hLIA⟩ := hA.isBNT.eventually_li
@@ -1902,8 +1885,9 @@ private lemma blocks_match_of_sameMPV₂_CFBNT
   let perm : Fin rA ≃ Fin rA := Equiv.ofBijective fA hfA_bij
   refine ⟨perm, fun j => ?_⟩
   have hpj : perm j = fA j := Equiv.ofBijective_apply fA hfA_bij j
-  rw [hpj]
-  exact ⟨hfA_dim j, hfA_gpe j⟩
+  refine ⟨?_, ?_⟩
+  · simpa [hpj] using hfA_dim j
+  · simpa [hpj] using hfA_gpe j
 
 /-- **Self-contained equal-case Fundamental Theorem for heterogeneous CF-BNT**
 ([CPSV21, Corollary IV.5] / [CPSV17, Theorem 4.4 + equal-case corollary]).
@@ -1948,13 +1932,7 @@ theorem fundamentalTheorem_equalMPV_CFBNT_hetero
     (hA : IsCanonicalFormBNT μA A)
     (hB : IsCanonicalFormBNT μB B)
     (hEqual : SameMPV₂ (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
-    ∃ _h : rA = rB,
-      ∃ perm : Fin rA ≃ Fin rB,
-        ∀ j : Fin rA,
-          ∃ hdim : dimA j = dimB (perm j),
-            GaugePhaseEquiv (d := d)
-              (cast (congr_arg (MPSTensor d) hdim) (A j))
-              (B (perm j)) :=
+    BlockPermutationGaugeWitness (d := d) A B :=
   blocks_match_of_sameMPV₂_CFBNT A B hA hB hEqual
 
 end HeteroEqualCase


### PR DESCRIPTION
### Motivation
- Reduce large repeated existential return types describing block-count equality, a permutation, dimension matches, and per-block `GaugePhaseEquiv` that occurred in multiple `fundamentalTheorem_*` statements to make the code more maintainable and avoid duplication.
- Make local proof code clearer by using a single shared alias for the common witness shape.

### Description
- Introduced `abbrev BlockPermutationGaugeWitness` in `TNLean/MPS/FundamentalTheorem/Full.lean` to capture the repeated existential conclusion `(rA = rB, perm : Fin rA ≃ Fin rB, per-block dim equality and GaugePhaseEquiv)`.
- Replaced the repeated long existential return types on several theorems (`fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data`, `fundamentalTheorem_proportionalMPV_CFBNT`, `fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data`, `fundamentalTheorem_proportionalMPV_normalCFBNT`, `blocks_match_of_sameMPV₂_CFBNT`, and `fundamentalTheorem_equalMPV_CFBNT_hetero`) with the new `BlockPermutationGaugeWitness` abbrev.
- Updated the local permutation witness construction to avoid dependent-transport issues by using `simpa [hpj]` to discharge the dependent goals when building the per-block data.
- Change is localized to `TNLean/MPS/FundamentalTheorem/Full.lean` and preserves the original theorem statements' semantics while removing duplication.

### Testing
- Ran `lake build TNLean.MPS.FundamentalTheorem.Full` and the target built successfully (module-level build passed).
- Ran full `lake build` and the repository build completed successfully (existing unrelated linter warnings and `sorry` occurrences remained unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c055c8bfb48324bd42ddb9313ddae7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: only factors a repeated existential conclusion into `BlockPermutationGaugeWitness` and makes minor proof-term adjustments, with no change to hypotheses or underlying theorems.
> 
> **Overview**
> Introduces `BlockPermutationGaugeWitness` as a shared alias for the common “block counts match + permutation + per-block dim equality + `GaugePhaseEquiv`” witness.
> 
> Updates multiple proportional- and equal-MPV fundamental theorem statements (and the private `blocks_match_of_sameMPV₂_CFBNT` proof) to return this abbrev, plus a small proof-term tweak (`simpa [hpj]`) when extracting the per-block dimension and gauge-phase data from the constructed permutation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af6b29f76a6a6f4723a4fca7c4af3fa1251fca94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->