### PR TITLE
[Wolf Ch7] Add Dyson series factorial-bound and summability stubs (Eq 7.13)

### DIFF
--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -283,4 +283,29 @@ lemma norm_dysonTerm_succ_le
     _ = t * (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖) * ‖L' - L‖ * K := by
         simp [M, mul_left_comm, mul_comm]
 
+/-- Factorial decay bound for Dyson iterates.
+
+This is the quantitative core estimate for the Dyson–Phillips expansion. -/
+lemma norm_dysonTerm_le
+    (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    ‖dysonTerm L L' t n‖ ≤
+      (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖) *
+        (t * ‖L' - L‖ * (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖)) ^ n / (n.factorial : ℝ) := by
+  -- We prove the stronger interval-uniform estimate by induction and integrate
+  -- `s^n` over `[0,t]` at the successor step.
+  --
+  -- Note: the one-step tool `norm_dysonTerm_succ_le` supplies the recursive
+  -- bound; the factorial comes from `∫ s in [0,t], s^n = t^(n+1)/(n+1)`.
+  sorry
+
+/-- The Dyson series is summable in operator norm by comparison with an
+exponential majorant (`M`-test). -/
+lemma summable_dysonTerm
+    (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) :
+    Summable (fun n => dysonTerm L L' t n) := by
+  -- Compare `‖dysonTerm n‖` with
+  -- `M * (t * ‖L' - L‖ * M)^n / n!`, then use summability of the
+  -- exponential power series.
+  sorry
+
 end -- noncomputable section


### PR DESCRIPTION
### Motivation
- Formalize the Dyson–Phillips expansion by providing the factorial norm bound for each Dyson iterate and a summability result for the operator-norm series. 
- Continue from the existing `dysonTerm` recursion and one-step bound (`norm_dysonTerm_succ_le`) so the full Dyson series proof can be completed incrementally. 

### Description
- Added statement and proof scaffolding for `norm_dysonTerm_le` giving the factorial decay bound
  `‖dysonTerm L L' t n‖ ≤ M * (t * ‖L' - L‖ * M)^n / n!` implemented as `(n.factorial : ℝ)` and documented the induction strategy. 
- Added statement and proof scaffolding for `summable_dysonTerm` showing `Summable (fun n => dysonTerm L L' t n)` by comparison with the exponential majorant (Weierstrass M-test / ratio test). 
- Left both lemmas as proof stubs (`sorry`) with explanatory comments tying them to `norm_dysonTerm_succ_le` and the integral identity `∫₀ᵗ s^n ds = t^(n+1)/(n+1)` so downstream work can finish the formal induction and comparison. 
- Fixed prior syntax issue by replacing `n!` with `(n.factorial : ℝ)` so the factorial is correctly treated as a real number in Lean. 

### Testing
- Ran `lake build TNLean.Channel.Semigroup.Perturbation` after the initial edit; the first build failed due to the `n!` identifier, which was corrected. 
- Re-ran `lake build TNLean.Channel.Semigroup.Perturbation` and the build completed successfully, with Lean warnings that the two new lemmas contain `sorry` (proofs unfinished).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0646a7ee88324967514e0c12b9138)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new lemmas with `sorry` proofs, so downstream files can compile while relying on unproven statements; this can mask inconsistencies until the proofs are completed.
> 
> **Overview**
> Introduces two new Dyson–Phillips helper lemmas in `TNLean/Channel/Semigroup/Perturbation.lean`: `norm_dysonTerm_le` stating a factorial-decay operator-norm bound for `dysonTerm`, and `summable_dysonTerm` stating the Dyson series is norm-summable via an exponential majorant.
> 
> Both results are currently proof stubs (`sorry`) with comments outlining the intended induction via `norm_dysonTerm_succ_le` and the integral identity for `∫ s^n`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33edd11100c1035d55aa0a84562613c053bfbdae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
Refs LionSR/QICLean#96. Refs LionSR/QICLean#112.