### PR TITLE
[1804.04964 5c] Add blocked normal-chain Fundamental Theorem wrapper

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -99,6 +99,7 @@ import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.FundamentalTheorem
+import TNLean.MPS.Chain.NormalFT
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Overlap.Basic

--- a/TNLean/MPS/Chain/NormalFT.lean
+++ b/TNLean/MPS/Chain/NormalFT.lean
@@ -1,0 +1,71 @@
+import TNLean.MPS.Chain.FundamentalTheorem
+import TNLean.MPS.Core.Blocking
+
+/-!
+# Fundamental Theorem for normal MPS chains via blocking
+
+This file packages the standard blocking reduction for the chain Fundamental
+Theorem: if a common blocking length `L` makes both tensors injective, then the
+injective chain theorem applies to the blocked tensors.
+
+At this stage the equality hypothesis is still the strong `SameMPV` condition
+on the combined blocked-chain tensors (all lengths / mixed words), matching the
+current `fundamentalTheorem_injective_chain` interface.
+-/
+
+open scoped Matrix
+
+namespace MPSChainTensor
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Normality witness used in the chain-level blocking reduction:
+there exists a blocking length whose blocked tensor is injective. -/
+def IsNormal (A : MPSTensor d D) : Prop :=
+  ∃ L : ℕ, MPSTensor.IsInjective (MPSTensor.blockTensor (d := d) (D := D) A L)
+
+@[simp] lemma isNormal_iff (A : MPSTensor d D) :
+    IsNormal A ↔ ∃ L : ℕ, MPSTensor.IsInjective (MPSTensor.blockTensor A L) :=
+  Iff.rfl
+
+/-- Translation-invariant chain obtained by repeating the blocked tensor
+`blockTensor A L` on all `N` sites. -/
+noncomputable def blockedChain (A : MPSTensor d D) (L N : ℕ) :
+    MPSChainTensor (MPSTensor.blockPhysDim d L) D N :=
+  fun _ => MPSTensor.blockTensor (d := d) (D := D) A L
+
+lemma blockedChain_isInjective (A : MPSTensor d D) (L N : ℕ)
+    (hA : MPSTensor.IsInjective (MPSTensor.blockTensor (d := d) (D := D) A L)) :
+    MPSChainTensor.IsInjective (blockedChain (d := d) (D := D) A L N) := by
+  intro k
+  simpa [blockedChain] using hA
+
+/-- **Fundamental theorem for normal tensors (blocked form).**
+
+If a common blocking length `L` makes both tensors injective, then the blocked
+chains are gauge equivalent whenever the combined blocked tensors satisfy
+`SameMPV`. This is exactly the injective-chain theorem applied to `blockedChain`.
+-/
+theorem fundamentalTheorem_normal
+    (A B : MPSTensor d D) (L N : ℕ)
+    (hA_normal : IsNormal A) (hB_normal : IsNormal B)
+    (hA_block : MPSTensor.IsInjective (MPSTensor.blockTensor (d := d) (D := D) A L))
+    (_hB_block : MPSTensor.IsInjective (MPSTensor.blockTensor (d := d) (D := D) B L))
+    (hMPV : MPSTensor.SameMPV
+      (MPSTensor.chainCombinedTensor (blockedChain (d := d) (D := D) A L N))
+      (MPSTensor.chainCombinedTensor (blockedChain (d := d) (D := D) B L N))) :
+    MPSChainTensor.GaugeEquiv
+      (blockedChain (d := d) (D := D) A L N)
+      (blockedChain (d := d) (D := D) B L N) := by
+  -- Keep the normality assumptions explicit in the theorem interface.
+  let _hA : IsNormal A := hA_normal
+  let _hB : IsNormal B := hB_normal
+  exact MPSChainTensor.fundamentalTheorem_injective_chain
+    (A := blockedChain (d := d) (D := D) A L N)
+    (B := blockedChain (d := d) (D := D) B L N)
+    (hA := blockedChain_isInjective (d := d) (D := D) A L N hA_block)
+    (hMPV := hMPV)
+
+end MPSTensor
+end MPSChainTensor


### PR DESCRIPTION
### Motivation
- Provide the standard blocking reduction that extends the chain Fundamental Theorem to "normal" MPS by blocking physical sites until injectivity holds and then applying the injective-chain FT.
- Expose a chain-facing endpoint that admits a common blocking length `L` so downstream code can layer the length-threshold bridge later.

### Description
- Add `TNLean/MPS/Chain/NormalFT.lean` implementing `IsNormal` (exists `L` with `MPSTensor.blockTensor A L` injective), `blockedChain`, `blockedChain_isInjective`, and `fundamentalTheorem_normal` which applies `fundamentalTheorem_injective_chain` to the blocked translation-invariant chains. 
- Re-export the new module from the root import surface by importing `TNLean.MPS.Chain.NormalFT` in `TNLean.lean`.
- Silence a local linter warning by renaming the unused `B`-block hypothesis parameter to `_hB_block` in the new file.

### Testing
- Ran `lake build` and the project built successfully; the build emitted unrelated linter warnings and a couple of pre-existing `sorry` usages but completed (no new failures). 
- Ran `lake build TNLean.MPS.Chain.NormalFT TNLean` which also succeeded and verified the new module typechecks and integrates with the existing FT machinery.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c06b31ee2c832491ab328490c75f15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new wrapper theorem/module and re-exports it without changing existing proofs or behavior; risk is mainly around interface assumptions (blocking length/injectivity) and downstream compilation dependencies.
> 
> **Overview**
> Adds `TNLean.MPS.Chain.NormalFT`, packaging a blocking-based wrapper (`fundamentalTheorem_normal`) that reduces the *normal* chain case to the existing injective-chain fundamental theorem by constructing a translation-invariant `blockedChain` and carrying injectivity through blocking.
> 
> Updates the root `TNLean.lean` import surface to re-export this new module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b049d256475ca2f6cc7f7336ae00342945505bdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
Refs #36. Refs #11.