### PR TITLE
Add uniqueness scaffold for traceless Lindblad decompositions (Wolf Prop 7.4 item 2)

### DIFF
--- a/TNLean/Channel/Semigroup/LindbladForm.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm.lean
@@ -7,3 +7,5 @@ import TNLean.Channel.Semigroup.LindbladForm.ChoiCCP
 import TNLean.Channel.Semigroup.LindbladForm.EulerStep
 import TNLean.Channel.Semigroup.LindbladForm.TraceBridge
 import TNLean.Channel.Semigroup.LindbladForm.GKSLTheorem
+import TNLean.Channel.Semigroup.LindbladForm.Uniqueness
+

--- a/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Semigroup.LindbladForm.Basic
+import TNLean.Channel.ChoiJamiolkowski
+
+/-!
+# Lindblad Form — Uniqueness of traceless GKSL decompositions
+
+This file formalizes the uniqueness direction of Wolf Proposition 7.4 (item 2):
+if two Lindblad / generator decompositions define the same generator and both
+use traceless Kraus operators, then
+
+* the dissipative CP parts coincide, and
+* the drift matrices agree up to an imaginary scalar multiple of the identity.
+-/
+
+open scoped Matrix ComplexOrder BigOperators NNReal MatrixOrder
+open Matrix
+
+noncomputable section
+
+-- Local instances needed for NormedAddCommGroup on Matrix (for CLM infrastructure)
+attribute [local instance] Matrix.linftyOpNormedRing
+attribute [local instance] Matrix.linftyOpNormedAlgebra
+
+variable {D : ℕ}
+
+section LindbladForms
+
+/-- Predicate: all Kraus operators in a Lindblad form are traceless. -/
+def LindbladForm.HasTracelessKraus (F : LindbladForm D) : Prop :=
+  ∀ j : Fin F.r, trace (F.L j) = 0
+
+/--
+If two Lindblad forms induce the same generator and both Kraus families are
+traceless, then their CP parts in Wolf's `(φ, κ)` decomposition agree.
+
+This is the Choi-projection uniqueness step in Wolf Prop. 7.4 (item 2).
+-/
+theorem generatorDecomp_traceless_unique_phi
+    (F F' : LindbladForm D)
+    (hL : F.toLinearMap = F'.toLinearMap)
+    (htr : F.HasTracelessKraus)
+    (htr' : F'.HasTracelessKraus) :
+    F.toGeneratorDecomp.φ = F'.toGeneratorDecomp.φ := by
+  -- Proof strategy (Wolf): compare projected Choi matrices and use Choi injectivity.
+  -- Infrastructure for the final projection/orthogonality argument is developed in
+  -- `ChoiJamiolkowski` and related Lindblad files.
+  sorry
+
+/--
+If two Lindblad forms induce the same generator and both Kraus families are
+traceless, then their drift matrices differ only by an imaginary scalar:
+`κ' = κ + i λ 𝟙` for some `λ : ℝ`.
+
+This is the Hamiltonian uniqueness modulo global energy shift in Wolf Prop. 7.4
+(item 2).
+-/
+theorem generatorDecomp_traceless_unique_kappa_modPhase
+    (F F' : LindbladForm D)
+    (hL : F.toLinearMap = F'.toLinearMap)
+    (htr : F.HasTracelessKraus)
+    (htr' : F'.HasTracelessKraus) :
+    ∃ l : ℝ,
+      F'.toGeneratorDecomp.κ =
+        F.toGeneratorDecomp.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+  -- Proof strategy (Wolf): after identifying `φ = φ'`, the residual map is
+  -- `ρ ↦ -(Δκ)ρ - ρ(Δκ)†`; equality to zero forces `Δκ` to be a scalar multiple
+  -- of identity, and trace/Hermiticity constraints force that scalar to be purely
+  -- imaginary.
+  sorry
+
+/-- Combined uniqueness statement for traceless Lindblad decompositions. -/
+theorem generatorDecomp_traceless_unique
+    (F F' : LindbladForm D)
+    (hL : F.toLinearMap = F'.toLinearMap)
+    (htr : F.HasTracelessKraus)
+    (htr' : F'.HasTracelessKraus) :
+    F.toGeneratorDecomp.φ = F'.toGeneratorDecomp.φ ∧
+    ∃ l : ℝ,
+      F'.toGeneratorDecomp.κ =
+        F.toGeneratorDecomp.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+  refine ⟨generatorDecomp_traceless_unique_phi F F' hL htr htr', ?_⟩
+  exact generatorDecomp_traceless_unique_kappa_modPhase F F' hL htr htr'
+
+end LindbladForms
+
+end -- noncomputable section


### PR DESCRIPTION
### Motivation

- Formalize the uniqueness direction of Wolf Prop. 7.4 (item 2): when two GKSL generator decompositions use traceless Kraus operators, the CP (dissipative) parts must agree and the drift matrices agree up to an imaginary scalar multiple of the identity. 
- Expose the statement shape and lemma names so the Choi-projection / orthogonality proof and the Schur-type scalar argument can be implemented in follow-up commits.

### Description

- Add a new module `TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean` that declares the predicate `LindbladForm.HasTracelessKraus` and three theorems: `generatorDecomp_traceless_unique_phi`, `generatorDecomp_traceless_unique_kappa_modPhase`, and the combined `generatorDecomp_traceless_unique` which packages the two facts together. 
- Wire the new module into the public Lindblad surface by importing `TNLean.Channel.Semigroup.LindbladForm.Uniqueness` from `TNLean/Channel/Semigroup/LindbladForm.lean` so the new statements are available with the standard Lindblad imports. 
- The new file provides proof scaffolding aligned with Wolf's plan (Choi projection uniqueness and scalar-difference for κ); two proof bodies are left as `sorry` placeholders so the API and interfaces are available while the technical Choi-orthogonality steps are completed later.

### Testing

- Ran `lake build` to validate the change and module integration; the full build completed successfully (`Build completed successfully (8218 jobs).`).
- `lake build` reported warnings for `sorry` in the newly added theorems in `TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean`, which is expected for this scaffold state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0650aace083249f5ef26598055ed9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk because this primarily adds new lemma statements and a predicate, but it introduces `sorry`-backed theorems that can mask gaps until proofs are completed.
> 
> **Overview**
> Adds `LindbladForm.HasTracelessKraus` and a new `Uniqueness` module that states the Wolf Prop. 7.4(2) uniqueness results for traceless GKSL/Lindblad decompositions: equality of the CP part `φ` and drift `κ` uniqueness up to an imaginary scalar multiple of the identity.
> 
> Wires this module into `TNLean.Channel.Semigroup.LindbladForm` via a new import so the statements are available from the standard Lindblad entrypoint; the two main proofs are left as `sorry` placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c19a7a85598a2518d97c943c6690481bdd224798. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->