### PR TITLE
[1708.00029 5/5] Add symmetry corollary: physical rotation implies virtual Z-gauge (Cor 4.1)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -113,6 +113,7 @@ import TNLean.MPS.Core.CPPrimitive
 import TNLean.MPS.Structure.LinearExtension
 import TNLean.MPS.FundamentalTheorem.Basic
 import TNLean.MPS.FundamentalTheorem.Proportional
+import TNLean.MPS.FundamentalTheorem.Applications
 
 -- Layer 5: Multi-block
 import TNLean.MPS.Core.MultiBlock

--- a/TNLean/MPS/FundamentalTheorem/Applications.lean
+++ b/TNLean/MPS/FundamentalTheorem/Applications.lean
@@ -7,9 +7,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 # Applications of the (single-block) Fundamental Theorem
 
 This module packages a lightweight symmetry corollary used by the periodic FT
-pipeline: rotating physical indices by a matrix defines a new tensor, and any
-MPV-level symmetry hypothesis can be converted into a virtual gauge statement
-by `fundamentalTheorem_singleBlock`.
+pipeline: rotating physical indices by a matrix defines a new tensor, and for
+an injective tensor `A`, an MPV-level symmetry hypothesis can be converted into
+a virtual gauge statement by `fundamentalTheorem_singleBlock`.
 
 This is the project-level Lean wrapper for the easy part of the arXiv:1708.00029
 §4 application pattern (`Bⁱ := ∑ⱼ uᵢⱼ Aʲ`, then apply FT to `A` and `B`).

--- a/TNLean/MPS/FundamentalTheorem/Applications.lean
+++ b/TNLean/MPS/FundamentalTheorem/Applications.lean
@@ -7,9 +7,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 # Applications of the (single-block) Fundamental Theorem
 
 This module packages a lightweight symmetry corollary used by the periodic FT
-pipeline: rotating physical indices by a unitary matrix defines a new tensor,
-and any MPV-level symmetry hypothesis can be converted into a virtual gauge
-statement by `fundamentalTheorem_singleBlock`.
+pipeline: rotating physical indices by a matrix defines a new tensor, and any
+MPV-level symmetry hypothesis can be converted into a virtual gauge statement
+by `fundamentalTheorem_singleBlock`.
 
 This is the project-level Lean wrapper for the easy part of the arXiv:1708.00029
 §4 application pattern (`Bⁱ := ∑ⱼ uᵢⱼ Aʲ`, then apply FT to `A` and `B`).

--- a/TNLean/MPS/FundamentalTheorem/Applications.lean
+++ b/TNLean/MPS/FundamentalTheorem/Applications.lean
@@ -1,0 +1,52 @@
+import TNLean.MPS.FundamentalTheorem.Basic
+
+/-!
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Applications of the (single-block) Fundamental Theorem
+
+This module packages a lightweight symmetry corollary used by the periodic FT
+pipeline: rotating physical indices by a unitary matrix defines a new tensor,
+and any MPV-level symmetry hypothesis can be converted into a virtual gauge
+statement by `fundamentalTheorem_singleBlock`.
+
+This is the project-level Lean wrapper for the easy part of the arXiv:1708.00029
+§4 application pattern (`Bⁱ := ∑ⱼ uᵢⱼ Aʲ`, then apply FT to `A` and `B`).
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Physical-index rotation of a tensor by a matrix `u` on the physical leg:
+
+`(rotatePhysical u A) i = ∑ j, u i j • A j`.
+-/
+def rotatePhysical (u : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) : MPSTensor d D :=
+  fun i => ∑ j : Fin d, u i j • A j
+
+@[simp] lemma rotatePhysical_apply
+    (u : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) (i : Fin d) :
+    rotatePhysical u A i = ∑ j : Fin d, u i j • A j := rfl
+
+/-- Symmetry-to-virtual-gauge wrapper.
+
+If `A` is injective and has the same MPV family as its physical-leg rotation
+`B = rotatePhysical u A`, then `B` is gauge equivalent to `A`.
+
+This is the formal Lean bridge used in Corollary-4.1 style arguments: the
+nontrivial analytic/group-theoretic part is in the hypothesis
+`SameMPV A (rotatePhysical u A)`, and the conclusion is provided by the
+single-block Fundamental Theorem. -/
+theorem gaugeEquiv_of_sameMPV_rotatePhysical
+    (u : Matrix (Fin d) (Fin d) ℂ)
+    (A : MPSTensor d D)
+    (hA : IsInjective A)
+    (hSym : SameMPV A (rotatePhysical u A)) :
+    GaugeEquiv A (rotatePhysical u A) :=
+  fundamentalTheorem_singleBlock hA hSym
+
+end MPSTensor


### PR DESCRIPTION
### Motivation
- Provide the Corollary-4.1 style bridge from a physical-index symmetry to a virtual gauge statement used by the periodic FT pipeline by formalizing the simple pattern `B^i := ∑_j u_{ij} A^j` and feeding it to the single-block Fundamental Theorem.

### Description
- Add `TNLean/MPS/FundamentalTheorem/Applications.lean` which defines `rotatePhysical` and proves `gaugeEquiv_of_sameMPV_rotatePhysical` using `fundamentalTheorem_singleBlock` (the new theorem states that `SameMPV A (rotatePhysical u A)` and `IsInjective A` imply `GaugeEquiv A (rotatePhysical u A)`).
- Export the new module from the project root by adding `import TNLean.MPS.FundamentalTheorem.Applications` to `TNLean.lean` so the application is on the public import surface.

### Testing
- Ran `lake env lean TNLean/MPS/FundamentalTheorem/Applications.lean` which completed without errors for the new file.
- Ran `lake build TNLean.MPS.FundamentalTheorem.Applications` and the module built successfully (`Built TNLean.MPS.FundamentalTheorem.Applications`).
- Ran `lake env lean TNLean.lean` which failed in this environment due to a missing pre-existing object file (`TNLean.MPS.Chain.AlgebraIsomorphism.olean`) unrelated to the changes in this PR; the new module itself compiles and the focused build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c074031ed483249279c5281c9f2411)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, self-contained wrapper module and re-exports it, with no changes to existing proofs or core logic.
> 
> **Overview**
> Adds `TNLean.MPS.FundamentalTheorem.Applications`, defining `rotatePhysical` (physical-leg action of a matrix on an `MPSTensor`) and proving `gaugeEquiv_of_sameMPV_rotatePhysical`, a corollary that derives `GaugeEquiv A (rotatePhysical u A)` from `IsInjective A` and `SameMPV` via `fundamentalTheorem_singleBlock`.
> 
> Exports this new application module from the root `TNLean.lean` import surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 118e75157fde31cbb2383664b3b2a640ea6f8dda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
Refs #83. Refs #78.