### PR TITLE
[1804.04964][Layer 2] Add projective representation + cocycle identity scaffolding

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -28,6 +28,7 @@ import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.MatrixFrobenius
+import TNLean.Algebra.ProjectiveRepresentation
 
 -- Layer 1: Generic convex/topological infrastructure
 import TNLean.Topology.ConvexProjection

--- a/TNLean/Algebra/ProjectiveRepresentation.lean
+++ b/TNLean/Algebra/ProjectiveRepresentation.lean
@@ -1,0 +1,145 @@
+import Mathlib.Data.Complex.Basic
+import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+
+/-!
+# Projective representations and concrete `U(1)`-valued 2-cocycles
+
+This file introduces a concrete notion of projective representation for matrix-valued
+virtual symmetries:
+
+* `ScalarCocycle G` is a function `G × G → ℂˣ` (implemented as `Units ℂ`).
+* `ProjectiveRepresentation ω` is a map `X : G → GL(D, ℂ)` satisfying
+  `X g * X h = ω g h • X (g * h)` at the matrix level.
+* `ProjectiveRepresentation.cocycle_of_assoc` derives the standard 2-cocycle identity
+  from associativity of matrix multiplication.
+
+This is the concrete multiplicative cocycle used in MPS/SPT arguments.
+-/
+
+open scoped Matrix
+
+namespace TNLean
+namespace Algebra
+
+/-- A concrete multiplicative scalar 2-cochain on a group. -/
+abbrev ScalarCocycle (G : Type*) := G → G → Units ℂ
+
+section Group
+
+variable {G : Type*} [Group G]
+variable {D : ℕ}
+
+/-- A matrix-valued projective representation with factor system `ω`. -/
+structure ProjectiveRepresentation (ω : ScalarCocycle G) where
+  /-- Virtual action on the bond space. -/
+  X : G → GL (Fin D) ℂ
+  /-- Multiplication law up to the scalar cocycle. -/
+  map_mul' :
+    ∀ g h : G,
+      ((X g : Matrix (Fin D) (Fin D) ℂ) * (X h : Matrix (Fin D) (Fin D) ℂ)) =
+        (ω g h : ℂ) • (X (g * h) : Matrix (Fin D) (Fin D) ℂ)
+
+namespace ProjectiveRepresentation
+
+variable {ω : ScalarCocycle G} (ρ : ProjectiveRepresentation (D := D) ω)
+
+/-- The projective multiplication law, restated as a lemma. -/
+lemma map_mul (g h : G) :
+    ((ρ.X g : Matrix (Fin D) (Fin D) ℂ) * (ρ.X h : Matrix (Fin D) (Fin D) ℂ)) =
+      (ω g h : ℂ) • (ρ.X (g * h) : Matrix (Fin D) (Fin D) ℂ) :=
+  ρ.map_mul' g h
+
+/-- Left-associated triple product in terms of the cocycle. -/
+lemma mul_assoc_left_scalar (g h k : G) :
+    (((ρ.X g : Matrix (Fin D) (Fin D) ℂ) * (ρ.X h : Matrix (Fin D) (Fin D) ℂ)) *
+        (ρ.X k : Matrix (Fin D) (Fin D) ℂ)) =
+      ((ω g h : ℂ) * (ω (g * h) k : ℂ)) •
+        (ρ.X ((g * h) * k) : Matrix (Fin D) (Fin D) ℂ) := by
+  calc
+    (((ρ.X g : Matrix (Fin D) (Fin D) ℂ) * (ρ.X h : Matrix (Fin D) (Fin D) ℂ)) *
+        (ρ.X k : Matrix (Fin D) (Fin D) ℂ))
+        = ((ω g h : ℂ) • (ρ.X (g * h) : Matrix (Fin D) (Fin D) ℂ)) *
+            (ρ.X k : Matrix (Fin D) (Fin D) ℂ) := by rw [map_mul]
+    _ = (ω g h : ℂ) •
+          (((ρ.X (g * h) : Matrix (Fin D) (Fin D) ℂ) *
+            (ρ.X k : Matrix (Fin D) (Fin D) ℂ))) := by
+            simp
+    _ = (ω g h : ℂ) • ((ω (g * h) k : ℂ) •
+          (ρ.X ((g * h) * k) : Matrix (Fin D) (Fin D) ℂ)) := by rw [map_mul]
+    _ = ((ω g h : ℂ) * (ω (g * h) k : ℂ)) •
+          (ρ.X ((g * h) * k) : Matrix (Fin D) (Fin D) ℂ) := by simp [mul_smul]
+
+/-- Right-associated triple product in terms of the cocycle. -/
+lemma mul_assoc_right_scalar (g h k : G) :
+    ((ρ.X g : Matrix (Fin D) (Fin D) ℂ) *
+        ((ρ.X h : Matrix (Fin D) (Fin D) ℂ) * (ρ.X k : Matrix (Fin D) (Fin D) ℂ))) =
+      ((ω g (h * k) : ℂ) * (ω h k : ℂ)) •
+        (ρ.X (g * (h * k)) : Matrix (Fin D) (Fin D) ℂ) := by
+  calc
+    ((ρ.X g : Matrix (Fin D) (Fin D) ℂ) *
+        ((ρ.X h : Matrix (Fin D) (Fin D) ℂ) * (ρ.X k : Matrix (Fin D) (Fin D) ℂ)))
+        = (ρ.X g : Matrix (Fin D) (Fin D) ℂ) *
+            ((ω h k : ℂ) • (ρ.X (h * k) : Matrix (Fin D) (Fin D) ℂ)) := by rw [map_mul]
+    _ = (ω h k : ℂ) •
+          ((ρ.X g : Matrix (Fin D) (Fin D) ℂ) *
+            (ρ.X (h * k) : Matrix (Fin D) (Fin D) ℂ)) := by
+            simp
+    _ = (ω h k : ℂ) • ((ω g (h * k) : ℂ) •
+          (ρ.X (g * (h * k)) : Matrix (Fin D) (Fin D) ℂ)) := by rw [map_mul]
+    _ = ((ω g (h * k) : ℂ) * (ω h k : ℂ)) •
+          (ρ.X (g * (h * k)) : Matrix (Fin D) (Fin D) ℂ) := by
+          simp [smul_smul, mul_comm]
+
+/-- Scalar cancellation on an invertible matrix (requires a nonempty index set). -/
+lemma smul_eq_smul_cancel {a b : ℂ} {M : Matrix (Fin D) (Fin D) ℂ}
+    (hD : 0 < D) (hM : IsUnit M) (h : a • M = b • M) : a = b := by
+  rcases Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hD) with ⟨n, rfl⟩
+  rcases hM with ⟨U, rfl⟩
+  have h' : a • (1 : Matrix (Fin (Nat.succ n)) (Fin (Nat.succ n)) ℂ) =
+      b • (1 : Matrix (Fin (Nat.succ n)) (Fin (Nat.succ n)) ℂ) := by
+    simpa [smul_mul_assoc, Matrix.mul_smul, Matrix.mul_assoc] using
+      congrArg (fun T => T * ((↑U⁻¹ : Matrix (Fin (Nat.succ n)) (Fin (Nat.succ n)) ℂ))) h
+  have h00 := congrArg (fun T => T 0 0) h'
+  simpa using h00
+
+/-- Associativity forces the cocycle condition (for `D > 0`). -/
+theorem cocycle_of_assoc (ρ : ProjectiveRepresentation (D := D) ω) (hD : 0 < D) (g h k : G) :
+    (ω g h : ℂ) * (ω (g * h) k : ℂ) = (ω g (h * k) : ℂ) * (ω h k : ℂ) := by
+  have hAssoc :
+      (((ρ.X g : Matrix (Fin D) (Fin D) ℂ) * (ρ.X h : Matrix (Fin D) (Fin D) ℂ)) *
+          (ρ.X k : Matrix (Fin D) (Fin D) ℂ)) =
+        ((ρ.X g : Matrix (Fin D) (Fin D) ℂ) *
+          ((ρ.X h : Matrix (Fin D) (Fin D) ℂ) * (ρ.X k : Matrix (Fin D) (Fin D) ℂ))) := by
+    simp [Matrix.mul_assoc]
+  have hLeft := ρ.mul_assoc_left_scalar g h k
+  have hRight := ρ.mul_assoc_right_scalar g h k
+  have hScalars :
+      ((ω g h : ℂ) * (ω (g * h) k : ℂ)) •
+          (ρ.X ((g * h) * k) : Matrix (Fin D) (Fin D) ℂ) =
+        ((ω g (h * k) : ℂ) * (ω h k : ℂ)) •
+          (ρ.X (g * (h * k)) : Matrix (Fin D) (Fin D) ℂ) := by
+    calc
+      ((ω g h : ℂ) * (ω (g * h) k : ℂ)) •
+          (ρ.X ((g * h) * k) : Matrix (Fin D) (Fin D) ℂ)
+          = (((ρ.X g : Matrix (Fin D) (Fin D) ℂ) * (ρ.X h : Matrix (Fin D) (Fin D) ℂ)) *
+              (ρ.X k : Matrix (Fin D) (Fin D) ℂ)) := hLeft.symm
+      _ = ((ρ.X g : Matrix (Fin D) (Fin D) ℂ) *
+            ((ρ.X h : Matrix (Fin D) (Fin D) ℂ) * (ρ.X k : Matrix (Fin D) (Fin D) ℂ))) :=
+            hAssoc
+      _ = ((ω g (h * k) : ℂ) * (ω h k : ℂ)) •
+            (ρ.X (g * (h * k)) : Matrix (Fin D) (Fin D) ℂ) := hRight
+  have hScalars' :
+      ((ω g h : ℂ) * (ω (g * h) k : ℂ)) •
+          (ρ.X ((g * h) * k) : Matrix (Fin D) (Fin D) ℂ) =
+        ((ω g (h * k) : ℂ) * (ω h k : ℂ)) •
+          (ρ.X ((g * h) * k) : Matrix (Fin D) (Fin D) ℂ) := by
+    simpa [mul_assoc] using hScalars
+  exact smul_eq_smul_cancel (D := D) hD (hM := by
+      refine ⟨ρ.X ((g * h) * k), rfl⟩) hScalars'
+
+end ProjectiveRepresentation
+
+end Group
+
+end Algebra
+end TNLean


### PR DESCRIPTION
### Motivation
- Provide the Layer 2 algebraic foundation for SPT formalization by introducing a concrete, matrix-level notion of projective representation and the associated multiplicative 2-cocycle. 
- Enable later extraction of the virtual symmetry `X(g)` from the Fundamental Theorem (Layer 1) and reasoning about the cocycle identity `ω(g,h)ω(gh,k)=ω(g,hk)ω(h,k)` used in SPT classification.

### Description
- Added a new module `TNLean/Algebra/ProjectiveRepresentation.lean` defining `ScalarCocycle` (type `G → G → Units ℂ`) and the `ProjectiveRepresentation` structure with the matrix-level law `X g * X h = ω g h • X (g * h)`.
- Implemented helper lemmas `map_mul`, `mul_assoc_left_scalar`, and `mul_assoc_right_scalar` that expand triple products in terms of the cocycle scalars. 
- Added `smul_eq_smul_cancel` to cancel scalar factors on an invertible matrix when `0 < D`, and proved `cocycle_of_assoc` which derives the 2-cocycle identity from associativity. 
- Exposed the new module at the top-level import surface by adding `import TNLean.Algebra.ProjectiveRepresentation` to `TNLean.lean`.

### Testing
- Ran `lake build TNLean.Algebra.ProjectiveRepresentation`, which completed successfully. 
- Ran `lake build TNLean` (full project build), which completed successfully (the build emitted unrelated pre-existing warnings but finished without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c070ca3fc08324b640813cc2ff823a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Introduces new definitions/lemmas and a new root import without changing existing logic; risk is mainly build/import-surface impact and potential naming/API churn.
> 
> **Overview**
> Adds `TNLean.Algebra.ProjectiveRepresentation`, defining `ScalarCocycle` and `ProjectiveRepresentation` (a `G → GL(Fin D, ℂ)` action with multiplication twisted by a scalar cocycle).
> 
> Proves supporting lemmas to expand triple products and a `cocycle_of_assoc` theorem showing associativity forces the multiplicative 2-cocycle identity (using a scalar-cancellation lemma for `D > 0`). The module is now re-exported from the top-level `TNLean.lean` import surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c73adcb87a23f4ff13ea2dda5cd8ef61c44de30e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->