### PR TITLE
Update Claude Code action plugin configuration

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,5 +56,5 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-6
-            --allowed-tools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *)"
+            --allowedTools "Read" "Glob" "Grep" "Bash(gh pr diff:*)" "Bash(gh pr view:*)" "Bash(gh pr comment:*)" "Bash(lake build)" "Bash(lake exe cache get)" "Bash(lake update)" "Bash(lake env)" "Bash(lean *)" "Bash(elan *)" "Bash(grep *)"
             --append-system-prompt "This is a Lean 4 / Mathlib formalization project for quantum information theory (MPS tensors, quantum channels, Wielandt theorem). Review with mathematical rigor. Flag any sorry that is not clearly marked as a known TODO."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,5 +56,5 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-6
-            --allowedTools "Read" "Glob" "Grep" "Bash(gh pr diff:*)" "Bash(gh pr view:*)" "Bash(gh pr comment:*)" "Bash(lake build)" "Bash(lake exe cache get)" "Bash(lake update)" "Bash(lake env)" "Bash(lean *)" "Bash(elan *)" "Bash(grep *)"
+            --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *)"
             --append-system-prompt "This is a Lean 4 / Mathlib formalization project for quantum information theory (MPS tensors, quantum channels, Wielandt theorem). Review with mathematical rigor. Flag any sorry that is not clearly marked as a known TODO."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'anthropics/claude-code'
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@anthropics-claude-code'
           prompt: |
             Review this Lean 4 pull request: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@anthropics-claude-code'
+          plugins: 'code-review@claude-code-plugins'
           prompt: |
             Review this Lean 4 pull request: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## Summary
Updated the Claude Code GitHub Action workflow to use the correct plugin marketplace URL and plugin identifier for the code review functionality.

## Key Changes
- Changed `plugin_marketplaces` from `'anthropics/claude-code'` to `'https://github.com/anthropics/claude-code.git'` to use the full Git repository URL
- Updated `plugins` identifier from `'code-review@anthropics-claude-code'` to `'code-review@claude-code-plugins'` to match the correct plugin namespace

## Details
These changes ensure the workflow correctly references the Claude Code plugin marketplace and uses the proper plugin identifier for the code review action. The full Git URL provides explicit repository resolution, and the updated plugin identifier aligns with the actual plugin namespace in the marketplace.

https://claude.ai/code/session_01FKqYxWwFBwx4p3tstPT1aj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only workflow change that just updates Claude Code plugin resolution and an input flag name; main risk is the review job failing if identifiers/flags are incorrect.
> 
> **Overview**
> Updates the `Claude Code Review` GitHub Actions workflow to use a git URL for `plugin_marketplaces` and a new `code-review` plugin identifier.
> 
> Also renames the Claude action CLI flag from `--allowed-tools` to `--allowedTools` so the workflow passes the expected parameter name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d797b2f15ce43a90f3854af1d5ada50ad8d571df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->