### PR TITLE
feat(1708.00029): add Z-gauge construction lemmas for periodic FT equal case

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -556,4 +556,56 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition
     _ = mpv (SectorDecomposition.mk g dim basis T).toTensor σ := hEqual N σ
     _ = ∑ j, T.coeff N j * mpv (basis j) σ := hQ
 
+/-- Entrywise ratio used in the periodic Z-gauge construction. -/
+noncomputable def zGaugeEntry (μ ν : ℂ) : ℂ := μ / ν
+
+/-- If `μ^m = ν^m` and `ν ≠ 0`, then `(μ/ν)^m = 1`. -/
+theorem zGaugeEntry_pow_eq_one_of_pow_eq
+    {m : ℕ} {μ ν : ℂ} (hpow : μ ^ m = ν ^ m) (hν : ν ≠ 0) :
+    (zGaugeEntry μ ν) ^ m = 1 := by
+  dsimp [zGaugeEntry]
+  rw [div_pow, hpow, div_self]
+  exact pow_ne_zero m hν
+
+/-- The ratio defining the Z-gauge rescales `ν` back to `μ`. -/
+theorem zGaugeEntry_mul_right {μ ν : ℂ} (hν : ν ≠ 0) :
+    zGaugeEntry μ ν * ν = μ := by
+  dsimp [zGaugeEntry]
+  field_simp [hν]
+
+section ZGaugeDiagonal
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- Diagonal matrix implementing the periodic Z-gauge from a matched list of weights. -/
+noncomputable def zGaugeDiagonal (μ ν : n → ℂ) : Matrix n n ℂ :=
+  Matrix.diagonal (fun i => zGaugeEntry (μ i) (ν i))
+
+/-- If matched weights have equal `m`-th powers and the denominator weights are nonzero, then
+the associated Z-gauge diagonal satisfies `Z^m = 1`. -/
+theorem zGaugeDiagonal_pow_eq_one
+    (m : ℕ) (μ ν : n → ℂ)
+    (hpow : ∀ i, μ i ^ m = ν i ^ m)
+    (hν : ∀ i, ν i ≠ 0) :
+    zGaugeDiagonal (n := n) μ ν ^ m = 1 := by
+  ext i j
+  by_cases hij : i = j
+  · subst hij
+    simp [zGaugeDiagonal, Matrix.diagonal_pow,
+      zGaugeEntry_pow_eq_one_of_pow_eq (hpow i) (hν i)]
+  · simp [zGaugeDiagonal, Matrix.diagonal_pow, hij]
+
+/-- Pointwise form of `Z * diag(ν) = diag(μ)` for the periodic Z-gauge. -/
+theorem zGaugeDiagonal_mul_diagonal
+    (μ ν : n → ℂ)
+    (hν : ∀ i, ν i ≠ 0) :
+    zGaugeDiagonal (n := n) μ ν * Matrix.diagonal ν = Matrix.diagonal μ := by
+  ext i j
+  by_cases hij : i = j
+  · subst hij
+    simp [zGaugeDiagonal, zGaugeEntry_mul_right (hν i)]
+  · simp [zGaugeDiagonal, hij]
+
+end ZGaugeDiagonal
+
 end MPSTensor


### PR DESCRIPTION
### Motivation
- Provide the missing algebraic ingredients for the periodic equal-case assembly (Theorem 3.8 step 5): construct the diagonal Z-gauge from matched multiplicity weights and prove the elementary identities needed to assemble the global `Z` in the periodic Fundamental Theorem.

### Description
- Add small, fully-proved lemmas and definitions to `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`: `zGaugeEntry` (entrywise ratio), `zGaugeEntry_pow_eq_one_of_pow_eq`, `zGaugeEntry_mul_right`, `zGaugeDiagonal`, `zGaugeDiagonal_pow_eq_one` (gives `Z^m = 1` under matched `m`-th powers and nonzero denominators), and `zGaugeDiagonal_mul_diagonal` (`Z * diag(ν) = diag(μ)`).

### Testing
- Ran `lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean` and the file type-checked with no errors; there are no new `sorry` usages (verified with `rg -n "sorry" TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c073f1470c8324b9bd28095862cdfd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean definitions/lemmas around complex division and diagonal matrices; no behavioral changes to existing theorems, but proofs rely on nonzero assumptions and matrix power simp lemmas.
> 
> **Overview**
> Adds **periodic Z-gauge helper definitions and lemmas** to `SectorDecomposition.lean`.
> 
> Introduces `zGaugeEntry := μ/ν` with proofs that it (1) satisfies `(μ/ν)^m = 1` when `μ^m = ν^m` and `ν ≠ 0`, and (2) rescales back via `zGaugeEntry μ ν * ν = μ`. Builds `zGaugeDiagonal` as a diagonal matrix of these entries and proves `zGaugeDiagonal^m = 1` under pointwise `m`-th power matching plus nonzero denominators, and `zGaugeDiagonal * diag(ν) = diag(μ)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df22c77f86da632d11a19897e8de43325658fe4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
Refs #82. Refs #78.