### PR TITLE
[1708.00029 3/5] Add periodic tensor aliases for overlap dichotomy

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -95,6 +95,7 @@ import TNLean.Spectral.CrossCorrelation
 -- Layer 3: MPS core
 import TNLean.MPS.Defs
 import TNLean.MPS.Chain.Defs
+import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Chain.AlgebraIsomorphism

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Chain.Defs
+
+/-!
+# Periodic MPS definitions
+
+This module provides a lightweight vocabulary layer for **periodic**
+(translation-covariant up to a period) MPS data.
+
+The current formal overlap machinery for normal tensors is developed in
+`TNLean/MPS/Overlap/*`, while chain-level equalities live in
+`TNLean/MPS/Chain/Defs`.  The present file intentionally stays minimal and
+sorry-free: it introduces aliases and coercion-free wrappers used by the
+periodic-overlap development.
+-/
+
+open scoped Matrix
+
+/-- A periodic MPS with physical dimension `d`, bond dimension `D`, and period `m`.
+
+Concretely this is an `m`-tuple of local tensors indexed cyclically by `Fin m`. -/
+abbrev PeriodicMPSTensor (d D m : ℕ) := Fin m → MPSTensor d D
+
+namespace PeriodicMPSTensor
+
+variable {d D m : ℕ}
+
+/-- Interpret a periodic tensor as a fixed-length chain tensor of length `m`. -/
+abbrev toChain (A : PeriodicMPSTensor d D m) : MPSChainTensor d D m := A
+
+/-- Configuration coefficient for one full period. -/
+abbrev coeff (A : PeriodicMPSTensor d D m) (σ : Fin m → Fin d) : ℂ :=
+  MPSChainTensor.coeff A σ
+
+/-- Equality of the generated `m`-site periodic-chain states. -/
+abbrev SameState (A B : PeriodicMPSTensor d D m) : Prop :=
+  MPSChainTensor.SameState A B
+
+/-- Cyclic gauge equivalence for period-`m` tensors. -/
+abbrev GaugeEquiv (A B : PeriodicMPSTensor d D m) : Prop :=
+  MPSChainTensor.GaugeEquiv A B
+
+@[simp] lemma coeff_def (A : PeriodicMPSTensor d D m) (σ : Fin m → Fin d) :
+    coeff A σ = Matrix.trace (MPSChainTensor.eval A σ) := rfl
+
+@[simp] lemma sameState_iff_chain (A B : PeriodicMPSTensor d D m) :
+    SameState A B ↔ MPSChainTensor.SameState A B := Iff.rfl
+
+@[simp] lemma gaugeEquiv_iff_chain (A B : PeriodicMPSTensor d D m) :
+    GaugeEquiv A B ↔ MPSChainTensor.GaugeEquiv A B := Iff.rfl
+
+lemma SameState.refl (A : PeriodicMPSTensor d D m) : SameState A A :=
+  MPSChainTensor.SameState.refl A
+
+lemma SameState.symm {A B : PeriodicMPSTensor d D m} (h : SameState A B) :
+    SameState B A :=
+  MPSChainTensor.SameState.symm h
+
+lemma SameState.trans {A B C : PeriodicMPSTensor d D m}
+    (hAB : SameState A B) (hBC : SameState B C) :
+    SameState A C :=
+  MPSChainTensor.SameState.trans hAB hBC
+
+lemma GaugeEquiv.refl (A : PeriodicMPSTensor d D m) : GaugeEquiv A A :=
+  MPSChainTensor.GaugeEquiv.refl A
+
+lemma GaugeEquiv.symm {A B : PeriodicMPSTensor d D m} (h : GaugeEquiv A B) :
+    GaugeEquiv B A :=
+  MPSChainTensor.GaugeEquiv.symm h
+
+lemma GaugeEquiv.trans {A B C : PeriodicMPSTensor d D m}
+    (hAB : GaugeEquiv A B) (hBC : GaugeEquiv B C) :
+    GaugeEquiv A C :=
+  MPSChainTensor.GaugeEquiv.trans hAB hBC
+
+end PeriodicMPSTensor


### PR DESCRIPTION
### Motivation
- Provide a small, coercion-free periodic namespace used by the periodic overlap / Proposition 3.3 work so periodic tensors can reuse existing chain-level infrastructure without introducing `sorry`.

### Description
- Add `TNLean/MPS/Periodic/Defs.lean` which defines `PeriodicMPSTensor (d D m : ℕ) := Fin m → MPSTensor d D` and lightweight wrappers `toChain`, `coeff`, `SameState`, and `GaugeEquiv` for reusing `MPSChainTensor` APIs.
- Export basic `@[simp]` lemmas (`coeff_def`, `sameState_iff_chain`, `gaugeEquiv_iff_chain`) and forward the standard `refl/symm/trans` lemmas for `SameState` and `GaugeEquiv` from `MPSChainTensor`.
- Wire the new module into the root import surface by adding `import TNLean.MPS.Periodic.Defs` in `TNLean.lean` so downstream modules can import the periodic vocabulary.

### Testing
- Ran `lake env lean TNLean/MPS/Periodic/Defs.lean` and it loaded successfully. (success)
- Ran `lake build TNLean.MPS.Periodic.Defs` and the new module built successfully. (success)
- Ran `lake build TNLean` and the full library build completed successfully; the build output contained existing unrelated warnings and pre-existing `sorry` uses in other modules but no new `sorry` introduced by this change. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c073e5f77c8324b6f22850cbcd48c9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean module of `abbrev`-based wrappers and simp lemmas, plus a single root import, without changing existing logic or proofs.
> 
> **Overview**
> Adds a new lightweight periodic MPS vocabulary module `TNLean.MPS.Periodic.Defs` defining `PeriodicMPSTensor` (`Fin m → MPSTensor`) and coercion-free wrappers (`toChain`, `coeff`, `SameState`, `GaugeEquiv`) that reuse existing `MPSChainTensor` APIs.
> 
> Exposes a few `@[simp]` bridging lemmas plus forwarded `refl/symm/trans` lemmas for `SameState`/`GaugeEquiv`, and wires the module into the public import surface by adding `import TNLean.MPS.Periodic.Defs` to `TNLean.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee4cfc86386f759d6b4cca13f841353d120d43a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
Refs #81. Refs #78.