### PR TITLE
[cleanup] Fix post-merge nits from PRs 70, 87, 90

### DIFF
--- a/TNLean/Channel/FixedPoint/StationarySupport.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupport.lean
@@ -206,32 +206,14 @@ theorem stationarySupport_eq_one
     exact hP_ne hP0
   · simpa [P] using hP1
 
-/-- Prop. 6.9 packaged as an `iff`: irreducibility is equivalent to full
-stationary support (for the chosen irreducible witness). -/
-theorem irreducible_iff_support_full
-    {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E) (hD : 0 < D) :
-    IsIrreducibleMap E ↔
-      ∃ hIrr : IsIrreducibleMap E, stationarySupport E hE hIrr hD = 1 := by
-  constructor
-  · intro hIrr
-    exact ⟨hIrr, stationarySupport_eq_one (E := E) hE hIrr hD⟩
-  · rintro ⟨hIrr, _⟩
-    exact hIrr
+/- TODO(#23): Replace with the non-vacuous Wolf Prop. 6.9 statement about
+maximal support of stationary states (Notes/WolfNoteTexSource/ch06_spectral_properties.tex,
+around lines 1220-1260). The previous `irreducible_iff_support_full` theorem
+was vacuous and has been removed.
 
-/-- Prop. 6.10: the stationary support is the minimal nonzero invariant
-projection (under irreducibility every such projection coincides with it). -/
-theorem stationary_support_minimal
-    {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E)
-    (hIrr : IsIrreducibleMap E) (hD : 0 < D)
-    {P : Mat} (hP_proj : IsOrthogonalProjection P)
-    (hP_inv : ∀ X : Mat, P * E (P * X * P) * P = E (P * X * P))
-    (hP_ne : P ≠ 0) :
-    stationarySupport E hE hIrr hD = P := by
-  have hP_zero_or_one : P = 0 ∨ P = 1 := hIrr P hP_proj hP_inv
-  have hP_one : P = 1 := by
-    rcases hP_zero_or_one with hP0 | hP1
-    · exact (hP_ne hP0).elim
-    · exact hP1
-  rw [stationarySupport_eq_one (E := E) hE hIrr hD, hP_one]
+TODO(#23): Replace with the non-vacuous Wolf Prop. 6.10 statement on
+stationary subspaces / sub-harmonic projections (Notes/WolfNoteTexSource/ch06_spectral_properties.tex,
+around lines 1260-1300). The previous `stationary_support_minimal` theorem
+was vacuous under irreducibility and has been removed. -/
 
 end Channel

--- a/TNLean/MPS/Chain/TranslationInvariance.lean
+++ b/TNLean/MPS/Chain/TranslationInvariance.lean
@@ -55,8 +55,8 @@ theorem ti_tensors_collapse_to_single_gauge
 
 /-- Corollary 2 (gauge periodicity).
 
-Any witness produced by `ti_tensors_collapse_to_single_gauge` satisfies the
-root-of-unity condition `lam ^ n = 1`. -/
+There is a gauge witness `Z` and phase `lam` such that `lam` is both
+`n`-periodic and the scalar relating `B` to `A` through that gauge. -/
 theorem ti_gauge_periodicity
     (A B : MPSTensor d D)
     (hn : 0 < n)
@@ -65,10 +65,12 @@ theorem ti_gauge_periodicity
     (hMPV : MPSTensor.SameMPV
       (MPSTensor.chainCombinedTensor (fun _ : Fin n => A))
       (MPSTensor.chainCombinedTensor (fun _ : Fin n => B))) :
-    ∃ lam : ℂ, lam ^ n = 1 := by
+    ∃ Z : Matrix (Fin D) (Fin D) ℂ, ∃ lam : ℂ,
+      IsUnit Z ∧ lam ^ n = 1 ∧
+      ∀ i : Fin d, B i = lam • (Z⁻¹ * A i * Z) := by
   rcases ti_tensors_collapse_to_single_gauge
       (A := A) (B := B) hn hA hB hMPV with
-    ⟨_, lam, _, hlam, _⟩
-  exact ⟨lam, hlam⟩
+    ⟨Z, lam, hZ, hlam, hrel⟩
+  exact ⟨Z, lam, hZ, hlam, hrel⟩
 
 end MPSChainTensor

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -52,6 +52,29 @@ def EquivalentBlocks (A B : MPSTensor d D) : Prop :=
       A i = (Y : Matrix (Fin D) (Fin D) ℂ) * B i *
         (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))
 
+/-- `EquivalentBlocks` is exactly `GaugeEquiv`. -/
+theorem EquivalentBlocks_iff_gaugeEquiv (A B : MPSTensor d D) :
+    EquivalentBlocks A B ↔ GaugeEquiv A B := by
+  constructor
+  · rintro ⟨Y, hY⟩
+    refine ⟨Y⁻¹, ?_⟩
+    intro i
+    have hAi : A i = (Y : Matrix (Fin D) (Fin D) ℂ) * B i *
+        (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := hY i
+    have := congrArg (fun M =>
+      (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * M *
+        (Y : Matrix (Fin D) (Fin D) ℂ))) hAi
+    simpa [Matrix.mul_assoc] using this.symm
+  · rintro ⟨X, hX⟩
+    refine ⟨X⁻¹, ?_⟩
+    intro i
+    have hBi : B i = (X : Matrix (Fin D) (Fin D) ℂ) * A i *
+        (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := hX i
+    have := congrArg (fun M =>
+      (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * M *
+        (X : Matrix (Fin D) (Fin D) ℂ))) hBi
+    simpa [Matrix.mul_assoc] using this.symm
+
 /-- Basis data for periodic tensors in irreducible form.
 
 This is a lightweight container: a family of periodic blocks indexed by `Fin r`,
@@ -81,7 +104,7 @@ structure IsIrreducibleForm (A : MPSTensor d D) where
   /-- Periodicity of each block. -/
   periodic : ∀ k, IsPeriodic (period k) (blocks k)
   /-- Weights are strictly positive real scalars (embedded in `ℂ`). -/
-  weight_pos : ∀ k, 0 < (μ k).re
+  weight_pos : ∀ k, 0 < (μ k).re ∧ (μ k).im = 0
   /-- Reassembled block tensor generates the same MPV family. -/
   sameMPV : SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ) blocks)
 
@@ -179,7 +202,6 @@ theorem ZGaugeEquiv.of_period_one {A B : MPSTensor d D}
 theorem IsPeriodic.period_eq_of_repeatedBlocks
     {m n : ℕ} {A B : MPSTensor d D}
     (hA : IsPeriodic m A) (hB : IsPeriodic n B)
-    (_hRep : RepeatedBlocks A B)
     (hSpec : peripheralEigenvalues (transferMap (d := d) (D := D) A) =
       peripheralEigenvalues (transferMap (d := d) (D := D) B)) :
     m = n := by


### PR DESCRIPTION
### Motivation
- Remove or correct merged artifacts that produced vacuous/meaningless theorems and API nits surfaced in code review and issues for the periodic/irreducible/translation-invariance code paths. 
- Ensure the formal statements match the intended mathematical content (Wolf notes / Prop. 6.9–6.10) or are clearly marked TODO when a correct statement/proof is nontrivial. 
- Tighten APIs so existential witnesses carry the meaningful data (gauge matrix + phase) and types enforce the documented constraints (real positive weights). 

### Description
- Deleted the two vacuous theorems in `TNLean/Channel/FixedPoint/StationarySupport.lean` (`irreducible_iff_support_full` and `stationary_support_minimal`) and replaced them with explicit `TODO` notes pointing to Wolf notes (ch06 spectral properties) and issue `#23` for proper replacement. 
- Strengthened `ti_gauge_periodicity` in `TNLean/MPS/Chain/TranslationInvariance.lean` so the conclusion now existentially returns the gauge matrix `Z` and enforces the relation `∀ i, B i = lam • (Z⁻¹ * A i * Z)` together with `IsUnit Z` and `lam ^ n = 1`, removing the previous vacuous `∃ lam, lam ^ n = 1`. 
- Added a bridge lemma `EquivalentBlocks_iff_gaugeEquiv` in `TNLean/MPS/Periodic/Defs.lean` and proved both directions by explicit inversion/conjugation so callers can use either predicate. 
- Enforced real-positive weights in `IsIrreducibleForm` by strengthening `weight_pos` to `0 < (μ k).re ∧ (μ k).im = 0` in `TNLean/MPS/Periodic/Defs.lean`. 
- Removed the unused hypothesis `_hRep : RepeatedBlocks A B` from `IsPeriodic.period_eq_of_repeatedBlocks` in `TNLean/MPS/Periodic/Defs.lean`. 
- No `sorry` placeholders were introduced. 

### Testing
- Ran `lake env lean TNLean/Channel/FixedPoint/StationarySupport.lean` and it completed with zero errors (only a linter suggestion warning). 
- Ran `lake env lean TNLean/MPS/Chain/TranslationInvariance.lean` and it completed with zero errors. 
- Ran `lake env lean TNLean/MPS/Periodic/Defs.lean` and it completed with zero errors (only linter suggestion warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c15464fbe483248ff95497c1c1b096)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes theorem statements and structure fields (`ti_gauge_periodicity`, `IsIrreducibleForm.weight_pos`), which can break downstream proofs and require updates to callers.
> 
> **Overview**
> Removes two previously-added stationary-support theorems (`irreducible_iff_support_full`, `stationary_support_minimal`) that were deemed vacuous, replacing them with explicit TODOs pointing to the intended nontrivial Wolf Prop. 6.9–6.10 statements.
> 
> Strengthens translation-invariance periodicity: `ti_gauge_periodicity` now returns the actual gauge witness `Z`, the phase `lam`, and the full relation `B i = lam • (Z⁻¹ * A i * Z)` alongside `IsUnit Z` and `lam ^ n = 1`.
> 
> Tightens periodic MPS APIs by adding `EquivalentBlocks_iff_gaugeEquiv`, enforcing weights in `IsIrreducibleForm` to be *real* positive (`0 < re` and `im = 0`), and dropping an unused `RepeatedBlocks` hypothesis from `IsPeriodic.period_eq_of_repeatedBlocks`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7db3332c6897f007519ca3676c74487f46bf79f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->