### PR TITLE
[1804.04964 5c] Fix normal-chain FT review feedback

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -101,6 +101,7 @@ import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.FundamentalTheorem
+import TNLean.MPS.Chain.NormalFT
 import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking

--- a/TNLean/MPS/Chain/NormalFT.lean
+++ b/TNLean/MPS/Chain/NormalFT.lean
@@ -1,0 +1,55 @@
+import TNLean.MPS.Chain.FundamentalTheorem
+import TNLean.MPS.Core.Blocking
+
+/-!
+# Blocked-chain endpoint for normal tensors
+
+This module packages the existing injective chain Fundamental Theorem so it can
+be applied to chains obtained by physically blocking a single-site tensor.
+
+The project-level normality predicate is `MPSTensor.IsNormal` in
+`TNLean/MPS/Defs.lean` (eventual block injectivity via `IsNBlkInjective`).
+No duplicate normality definition is introduced here.
+-/
+
+open scoped Matrix
+
+namespace MPSChainTensor
+
+variable {d D : ℕ}
+
+/-- Repeat the `L`-blocked tensor across a chain of length `n`. -/
+noncomputable def blockedChain (A : MPSTensor d D) (L n : ℕ) :
+    MPSChainTensor (MPSTensor.blockPhysDim d L) D n :=
+  fun _ => MPSTensor.blockTensor (d := d) (D := D) A L
+
+/-- If the blocked single tensor is injective, the corresponding constant chain
+is injective at every site. -/
+theorem blockedChain_isInjective (A : MPSTensor d D) (L n : ℕ)
+    (hA_block : MPSTensor.IsInjective (MPSTensor.blockTensor (d := d) (D := D) A L)) :
+    IsInjective (blockedChain (d := d) (D := D) A L n) := by
+  intro k
+  simpa [blockedChain] using hA_block
+
+/-- Blocked normal-chain endpoint: apply the injective chain FT to blocked
+constant chains.
+
+`hA_block` is the needed block-injectivity hypothesis for the chosen
+blocking length `L`; separate normality hypotheses are redundant in this
+endpoint theorem. -/
+theorem fundamentalTheorem_normal
+    (A B : MPSTensor d D) (L n : ℕ)
+    (hA_block : MPSTensor.IsInjective (MPSTensor.blockTensor (d := d) (D := D) A L))
+    (hMPV : MPSTensor.SameMPV
+      (MPSTensor.chainCombinedTensor (blockedChain (d := d) (D := D) A L n))
+      (MPSTensor.chainCombinedTensor (blockedChain (d := d) (D := D) B L n))) :
+    GaugeEquiv (blockedChain (d := d) (D := D) A L n)
+      (blockedChain (d := d) (D := D) B L n) := by
+  -- The underlying chain FT only needs injectivity of the left chain.
+  exact fundamentalTheorem_injective_chain
+    (A := blockedChain (d := d) (D := D) A L n)
+    (B := blockedChain (d := d) (D := D) B L n)
+    (hA := blockedChain_isInjective (d := d) (D := D) A L n hA_block)
+    (hMPV := hMPV)
+
+end MPSChainTensor


### PR DESCRIPTION
### Motivation
- Provide a focused blocked-chain endpoint that reuses the existing project normality predicate instead of duplicating it, and align the API with the injective-chain FT so the review issues are resolved.
- Remove unused and redundant hypotheses that caused review complaints and potential unused-variable errors in the new module.

### Description
- Added `TNLean/MPS/Chain/NormalFT.lean` which defines `blockedChain`, proves `blockedChain_isInjective`, and exposes `fundamentalTheorem_normal` that delegates to `fundamentalTheorem_injective_chain` for blocked constant chains.
- Do not redefine `IsNormal` in the new file; the module uses the existing `MPSTensor.IsNormal` from `TNLean/MPS/Defs.lean` and documents that choice in the header comments.
- Removed the unused right-side blocked-injectivity hypothesis and redundant normality hypotheses from the endpoint signature so the theorem now only requires the needed left-side block-injectivity (`hA_block`) and the `SameMPV` hypothesis.
- Re-exported the new module by adding `import TNLean.MPS.Chain.NormalFT` to `TNLean.lean` so the module is available via the root import surface.

### Testing
- Ran `lake env lean TNLean/MPS/Chain/NormalFT.lean` which completed successfully.
- Built the module with `lake build TNLean.MPS.Chain.NormalFT` which completed successfully.
- No `sorry` were introduced and the change was committed (`git` updates include the new file and the `TNLean.lean` import).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1549f43b08324989db8d5cc1df7b3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small wrapper module and a root import, without changing existing proofs or core definitions.
> 
> **Overview**
> Adds a new Lean module `TNLean/MPS/Chain/NormalFT.lean` that packages a *blocked constant-chain* construction (`blockedChain`) and a derived endpoint theorem `fundamentalTheorem_normal`, which reduces the blocked-chain case to the existing `fundamentalTheorem_injective_chain` using only a left-side block-injectivity hypothesis.
> 
> Re-exports this new endpoint by adding `import TNLean.MPS.Chain.NormalFT` to the root `TNLean.lean` import surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8dd11d90dd97b6c4b54e24d1bfff9a498f87eab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->