### PR TITLE
[Wolf Ch7] Add quadratic one-step Lie-Trotter defect bridge (Eq 7.28)

### DIFF
--- a/TNLean/Channel/Semigroup/ProductFormula.lean
+++ b/TNLean/Channel/Semigroup/ProductFormula.lean
@@ -200,6 +200,76 @@ theorem norm_trotter_pow_sub_exp_le_of_step [NeZero D]
           gcongr
     _ = ((n + 1 : ℕ) : ℝ) * Real.exp (t * (‖A‖ + ‖B‖)) * δ := by rw [hMpow]
 
+/-- If the one-step defect has a quadratic mesh bound, the global Trotter error is `O(1/n)`. -/
+theorem norm_trotter_pow_sub_exp_le_of_quadratic_step [NeZero D]
+    (A B : CLM D) (t : ℝ) (n : ℕ) (ht : 0 ≤ t) {C : ℝ}
+    (hstep :
+      ‖expSemigroupCLM A (t / (n + 1)) * expSemigroupCLM B (t / (n + 1))
+        - expSemigroupCLM (A + B) (t / (n + 1))‖
+        ≤ C * (t / (n + 1)) ^ 2 * Real.exp ((t / (n + 1)) * (‖A‖ + ‖B‖))) :
+    ‖(expSemigroupCLM A (t / (n + 1)) * expSemigroupCLM B (t / (n + 1))) ^ (n + 1)
+      - expSemigroupCLM (A + B) t‖
+      ≤ (C * t ^ 2 / (n + 1)) *
+          Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := by
+  let s : ℝ := t / (n + 1)
+  have hs : 0 ≤ s := by
+    dsimp [s]
+    positivity
+  have hmain := norm_trotter_pow_sub_exp_le_of_step
+      (A := A) (B := B) (t := t) (n := n) ht (δ := C * s ^ 2 * Real.exp (s * (‖A‖ + ‖B‖)))
+      (by simpa [s] using hstep)
+  have hcast_pos : (0 : ℝ) < (n + 1) := by positivity
+  have hfac :
+      ((n + 1 : ℕ) : ℝ) * (C * s ^ 2 * Real.exp (s * (‖A‖ + ‖B‖))) =
+        (C * t ^ 2 / (n + 1)) * Real.exp (s * (‖A‖ + ‖B‖)) := by
+    have hrat : ((n + 1 : ℕ) : ℝ) * (C * s ^ 2) = C * t ^ 2 / (n + 1) := by
+      dsimp [s]
+      field_simp [hcast_pos.ne']
+      rw [Nat.cast_add, Nat.cast_one]
+      ring
+    calc
+      ((n + 1 : ℕ) : ℝ) * (C * s ^ 2 * Real.exp (s * (‖A‖ + ‖B‖)))
+          = (((n + 1 : ℕ) : ℝ) * (C * s ^ 2)) * Real.exp (s * (‖A‖ + ‖B‖)) := by ring
+      _ = (C * t ^ 2 / (n + 1)) * Real.exp (s * (‖A‖ + ‖B‖)) := by rw [hrat]
+  have hexp :
+      Real.exp (t * (‖A‖ + ‖B‖)) * Real.exp (s * (‖A‖ + ‖B‖)) =
+        Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := by
+    rw [← Real.exp_add]
+    dsimp [s]
+    congr 1
+    norm_num [Nat.cast_add]
+    field_simp [hcast_pos.ne']
+    ring
+  calc
+    ‖(expSemigroupCLM A (t / (n + 1)) * expSemigroupCLM B (t / (n + 1))) ^ (n + 1)
+      - expSemigroupCLM (A + B) t‖
+        ≤ ((n + 1 : ℕ) : ℝ) * Real.exp (t * (‖A‖ + ‖B‖)) *
+            (C * s ^ 2 * Real.exp (s * (‖A‖ + ‖B‖))) := hmain
+    _ = Real.exp (t * (‖A‖ + ‖B‖)) *
+          (((n + 1 : ℕ) : ℝ) * (C * s ^ 2 * Real.exp (s * (‖A‖ + ‖B‖)))) := by ring
+    _ = Real.exp (t * (‖A‖ + ‖B‖)) *
+          ((C * t ^ 2 / (n + 1)) * Real.exp (s * (‖A‖ + ‖B‖))) := by rw [hfac]
+    _ = (C * t ^ 2 / (n + 1)) *
+          (Real.exp (t * (‖A‖ + ‖B‖)) * Real.exp (s * (‖A‖ + ‖B‖))) := by ring
+    _ = (C * t ^ 2 / (n + 1)) *
+          Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := by rw [hexp]
+
+/-- Suzuki/Wolf-style global bound from a one-step constant `2*(‖A‖+‖B‖)^2`. -/
+theorem lie_trotter_suzuki_bound_of_step [NeZero D]
+    (A B : CLM D) (t : ℝ) (n : ℕ) (ht : 0 ≤ t)
+    (hstep :
+      ‖expSemigroupCLM A (t / (n + 1)) * expSemigroupCLM B (t / (n + 1))
+        - expSemigroupCLM (A + B) (t / (n + 1))‖
+        ≤ (2 * (‖A‖ + ‖B‖) ^ 2) * (t / (n + 1)) ^ 2 *
+            Real.exp ((t / (n + 1)) * (‖A‖ + ‖B‖))) :
+    ‖(expSemigroupCLM A (t / (n + 1)) * expSemigroupCLM B (t / (n + 1))) ^ (n + 1)
+      - expSemigroupCLM (A + B) t‖
+      ≤ ((2 * t ^ 2 / (n + 1)) * (‖A‖ + ‖B‖) ^ 2) *
+          Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := by
+  simpa [mul_assoc, mul_left_comm, mul_comm, div_eq_mul_inv] using
+    norm_trotter_pow_sub_exp_le_of_quadratic_step (A := A) (B := B) (t := t) (n := n) ht
+      (C := 2 * (‖A‖ + ‖B‖) ^ 2) hstep
+
 end ProductFormulaHelpers
 
 end -- noncomputable section


### PR DESCRIPTION
### Motivation
- Provide the algebraic bridge that upgrades a quadratic one-step defect estimate at mesh `s = t/(n+1)` into the global O(1/n) Suzuki/Wolf Lie–Trotter error bound, isolating the remaining work to proving the single-step Taylor/BCH-style estimate.

### Description
- Added `norm_trotter_pow_sub_exp_le_of_quadratic_step` which converts a one-step hypothesis of the form `‖exp(A s) exp(B s) - exp((A+B) s)‖ ≤ C * s^2 * exp(s(‖A‖+‖B‖))` (with `s = t/(n+1)`) into a global bound `≤ (C * t^2 / (n+1)) * exp(((n+2)/(n+1)) * t * (‖A‖+‖B‖))` for the `(n+1)`-fold product minus `exp(t(A+B))`.
- Added `lie_trotter_suzuki_bound_of_step`, a convenience specialization using `C = 2*(‖A‖+‖B‖)^2` so the Wolf/Suzuki-form bound follows immediately once the local step estimate is proved.
- The new lemmas reuse the existing telescope/amplification lemma `norm_trotter_pow_sub_exp_le_of_step` and perform the algebraic simplifications of the prefactors and exponential factors to produce the final displayed RHS.
- No `sorry` placeholders were introduced; the changes are fully constructive and type-checked in the file.

### Testing
- Ran `lake env lean TNLean/Channel/Semigroup/ProductFormula.lean` and the file type-checked successfully.
- Ran `lake build TNLean.Channel.Semigroup.ProductFormula` and the package built successfully (all jobs passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c14fb1a2cc83248070ee7dc68a0293)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean theorems and algebraic rewrites around existing Lie–Trotter bounds; no production/runtime behavior changes, with risk mainly limited to proof maintenance and downstream lemma dependencies.
> 
> **Overview**
> Adds `norm_trotter_pow_sub_exp_le_of_quadratic_step`, upgrading a **quadratic one-step defect** hypothesis at mesh `t/(n+1)` into an explicit **global `O(1/n)` Lie–Trotter error bound** with simplified prefactors and combined exponential terms.
> 
> Adds `lie_trotter_suzuki_bound_of_step`, a convenience specialization that plugs in the standard constant `2*(‖A‖+‖B‖)^2` to directly obtain a Suzuki/Wolf-style global estimate from the corresponding step bound.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 113682bd078ff5cd2ccfa95ab4cd21fac93d02ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->