### PR TITLE
Remove vacuous stationary-support theorems and add TODOs

### DIFF
--- a/TNLean/Channel/FixedPoint/StationarySupport.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupport.lean
@@ -22,9 +22,10 @@ Propositions 6.9--6.11).
   point of an irreducible channel.
 * `stationarySupport_eq_one`: for an irreducible channel, the stationary support
   is full (`= 1`).
-* `irreducible_iff_support_full`: packaging of the previous statement as an iff.
-* `stationary_support_minimal`: every nonzero invariant projection equals the
-  stationary support.
+* TODO (Wolf Prop. 6.9): upgrade to the non-vacuous equivalence between
+  irreducibility and full support of stationary states.
+* TODO (Wolf Prop. 6.10): formalize minimality of stationary support without an
+  irreducibility hypothesis.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -206,32 +207,14 @@ theorem stationarySupport_eq_one
     exact hP_ne hP0
   · simpa [P] using hP1
 
-/-- Prop. 6.9 packaged as an `iff`: irreducibility is equivalent to full
-stationary support (for the chosen irreducible witness). -/
-theorem irreducible_iff_support_full
-    {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E) (hD : 0 < D) :
-    IsIrreducibleMap E ↔
-      ∃ hIrr : IsIrreducibleMap E, stationarySupport E hE hIrr hD = 1 := by
-  constructor
-  · intro hIrr
-    exact ⟨hIrr, stationarySupport_eq_one (E := E) hE hIrr hD⟩
-  · rintro ⟨hIrr, _⟩
-    exact hIrr
-
-/-- Prop. 6.10: the stationary support is the minimal nonzero invariant
-projection (under irreducibility every such projection coincides with it). -/
-theorem stationary_support_minimal
-    {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E)
-    (hIrr : IsIrreducibleMap E) (hD : 0 < D)
-    {P : Mat} (hP_proj : IsOrthogonalProjection P)
-    (hP_inv : ∀ X : Mat, P * E (P * X * P) * P = E (P * X * P))
-    (hP_ne : P ≠ 0) :
-    stationarySupport E hE hIrr hD = P := by
-  have hP_zero_or_one : P = 0 ∨ P = 1 := hIrr P hP_proj hP_inv
-  have hP_one : P = 1 := by
-    rcases hP_zero_or_one with hP0 | hP1
-    · exact (hP_ne hP0).elim
-    · exact hP1
-  rw [stationarySupport_eq_one (E := E) hE hIrr hD, hP_one]
+/-
+TODO (Wolf Props. 6.9–6.10):
+The original declarations `irreducible_iff_support_full` and
+`stationary_support_minimal` were removed because their previous formulations
+were vacuous/trivial. They should be replaced by:
+* a non-vacuous Prop. 6.9 equivalence (irreducibility ↔ full support of
+  stationary states), and
+* Prop. 6.10 minimality of stationary support without assuming irreducibility.
+-/
 
 end Channel

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -174,10 +174,11 @@ In `TNLean.Channel.FixedPoint.StationarySupport`:
   invariant under the compressed channel action.
 * `Channel.stationarySupport` — support projection of the unique density-matrix
   fixed point of an irreducible channel.
-* `Channel.stationarySupport_eq_one` / `Channel.irreducible_iff_support_full`
-  — irreducible channels have full stationary support.
-* `Channel.stationary_support_minimal` — every nonzero invariant projection
-  coincides with the stationary support.
+* `Channel.stationarySupport_eq_one` — irreducible channels have full
+  stationary support.
+* TODO: non-vacuous formalizations of Wolf Prop. 6.9 and Prop. 6.10
+  (`irreducible_iff_support_full`, `stationary_support_minimal`) remain to be
+  reinstated.
 
 ### Wolf Theorem 6.12 (Fixed points form a *-algebra) — FORMALIZED
 


### PR DESCRIPTION
### Motivation

- Code review flagged two declarations in `TNLean/Channel/FixedPoint/StationarySupport.lean` as vacuous (`irreducible_iff_support_full` and `stationary_support_minimal`) because their statements quantified their own hypotheses and were therefore trivial.  
- The change conservatively follows the requested review option (b): remove the vacuous statements and leave clear TODO notes describing the intended non-trivial Wolf Prop. 6.9/6.10 formulations for later rework.

### Description

- Removed the vacuous theorem declarations `irreducible_iff_support_full` and `stationary_support_minimal` from `TNLean/Channel/FixedPoint/StationarySupport.lean` and replaced them with an explicit `TODO` block explaining the intended non-vacuous statements.  
- Adjusted the module-level documentation in `TNLean/Channel/FixedPoint/StationarySupport.lean` so the exported "Main declarations" list no longer claims those two theorems are formalized.  
- Updated `TNLean/Channel/WolfChapter6Index.lean` to reflect the TODO status (keeps `Channel.stationarySupport_eq_one` intact).  
- Preserved the existing correct lemmas and definitions (`support_proj_fixed`, `stationaryState`, `stationarySupport`, `stationarySupport_eq_one`, etc.).

### Testing

- Ran `lake env lean TNLean/Channel/FixedPoint/StationarySupport.lean`, which completed with 0 errors and a single non-blocking linter warning (`try 'simp' instead of 'simpa'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c15d68e7f083249c4d7d1dcb221e45)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes two previously exported theorems (`irreducible_iff_support_full`, `stationary_support_minimal`), which could break downstream proofs that referenced them, though no in-repo uses remain.
> 
> **Overview**
> Removes the vacuous stationary-support theorems `Channel.irreducible_iff_support_full` and `Channel.stationary_support_minimal` from `FixedPoint/StationarySupport.lean`, and replaces them with explicit TODO notes describing the intended non-trivial Wolf Prop. 6.9/6.10 statements.
> 
> Updates the documentation in `StationarySupport.lean` and the Chapter 6 index (`WolfChapter6Index.lean`) to stop advertising these results as formalized while keeping `Channel.stationarySupport_eq_one` as the remaining Prop. 6.9 artifact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc1245fc66e062a26d7185cd03a6653cb984eb26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->