### PR TITLE
[Wolf Ch7] Add semigroup resolvent definitions and Neumann z=1 lemma

### DIFF
--- a/TNLean/Channel/Semigroup.lean
+++ b/TNLean/Channel/Semigroup.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Semigroup.Basic
 import TNLean.Channel.Semigroup.Perturbation
+import TNLean.Channel.Semigroup.Resolvent
 import TNLean.Channel.Semigroup.Primitivity
 import TNLean.Channel.Semigroup.GeneratorDefs
 import TNLean.Channel.Semigroup.LindbladForm

--- a/TNLean/Channel/Semigroup/Resolvent.lean
+++ b/TNLean/Channel/Semigroup/Resolvent.lean
@@ -18,7 +18,7 @@ namespace TNLean.Channel.Semigroup
 
 variable {D : ℕ}
 
-abbrev CLM (D : ℕ) :=
+private abbrev CLM (D : ℕ) :=
   Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ
 
 /-- Resolvent of a semigroup generator (`R(z,L) = (z • 1 - L)⁻¹`). -/

--- a/TNLean/Channel/Semigroup/Resolvent.lean
+++ b/TNLean/Channel/Semigroup/Resolvent.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Semigroup.Basic
+
+import Mathlib.Algebra.Algebra.Spectrum.Basic
+import Mathlib.Analysis.Normed.Ring.Units
+
+open Matrix
+
+noncomputable section
+
+attribute [local instance] Matrix.linftyOpNormedRing
+attribute [local instance] Matrix.linftyOpNormedAlgebra
+
+namespace TNLean.Channel.Semigroup
+
+variable {D : ℕ}
+
+abbrev CLM (D : ℕ) :=
+  Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ
+
+/-- Resolvent of a semigroup generator (`R(z,L) = (z • 1 - L)⁻¹`). -/
+abbrev generatorResolventCLM (L : CLM D) (z : ℂ) : CLM D :=
+  resolvent L z
+
+@[simp] theorem generatorResolventCLM_eq_mathlib (L : CLM D) (z : ℂ) :
+    generatorResolventCLM L z = resolvent L z := rfl
+
+/-- Neumann-series specialization at `z = 1`:
+if `‖L‖ < 1`, then `R(1,L) = ∑ₙ L^n`. -/
+theorem generatorResolventCLM_one_neumann
+    (L : CLM D) (hL : ‖L‖ < 1) :
+    generatorResolventCLM L (1 : ℂ) = ∑' n : ℕ, L ^ n := by
+  simpa [generatorResolventCLM, resolvent, Algebra.algebraMap_eq_smul_one, one_smul] using
+    (NormedRing.inverse_one_sub L hL)
+
+/-- Euler resolvent step `(λ R(λ,L))`. -/
+def eulerResolventStep (L : CLM D) (lam : ℂ) : CLM D :=
+  lam • generatorResolventCLM L lam
+
+/-- Finite-`n` Euler approximation term `((n/t)R(n/t,L))^n`. -/
+def eulerResolventApprox (L : CLM D) (t : ℝ) (n : ℕ) : CLM D :=
+  (eulerResolventStep L ((n : ℂ) / (t : ℂ))) ^ n
+
+/-- Axiomatized Euler limit statement (Wolf Eq. (7.9)) in the present finite-dimensional setting. -/
+def HasEulerResolventLimit (L : CLM D) (t : ℝ) : Prop :=
+  Filter.Tendsto (fun n : ℕ => eulerResolventApprox L t n) Filter.atTop
+    (nhds (expSemigroupCLM L t))
+
+end TNLean.Channel.Semigroup


### PR DESCRIPTION
Refs LionSR/QICLean#98. Refs LionSR/QICLean#112.

### Motivation
- Introduce the resolvent of a semigroup generator (Wolf Eq. 7.6) and the minimal infrastructure needed to state the Euler resolvent approximation (Wolf Eq. 7.9). 
- Provide a concrete Neumann-series lemma in the convergent `‖L‖ < 1` regime as a first-step operator expansion useful for later Laplace/Euler arguments. 
- Defer contour/Laplace inversion/Post–Widder work (items requiring more integration/contour infrastructure) to follow-ups.

### Description
- Added `TNLean/Channel/Semigroup/Resolvent.lean` which defines `generatorResolventCLM` as an alias to Mathlib's `resolvent` and exposes the bridge lemma `generatorResolventCLM_eq_mathlib`.
- Proved the Neumann-series specialization `generatorResolventCLM_one_neumann` for `z = 1` under the hypothesis `‖L‖ < 1` using `NormedRing.inverse_one_sub`.
- Added Euler-resolvent scaffolding: `eulerResolventStep`, `eulerResolventApprox`, and the axiomatic limit predicate `HasEulerResolventLimit` to state Eq. (7.9) in this finite-dimensional setting.
- Wired the new module into the chapter-level index by importing `TNLean.Channel.Semigroup.Resolvent` from `TNLean/Channel/Semigroup.lean`.
- The change deliberately avoids introducing any `sorry` placeholders and leaves the large-real-`z` Neumann expansion and positivity-transfer equivalences for a later PR.

### Testing
- Ran `lake build TNLean.Channel.Semigroup.Resolvent` and the build completed successfully (module built).
- Ran `lake env lean TNLean/Channel/Semigroup/Resolvent.lean` which returned with exit code 0 (file type-checked).
- Ran `lake env lean TNLean/Channel/Semigroup.lean` which type-checked the umbrella semigroup module that imports the new file; this also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c14fc52ea483248541310cbe0c98f0)