### PR TITLE
Add semigroup resolvent module and Neumann-series lemma

### DIFF
--- a/TNLean/Channel/Semigroup.lean
+++ b/TNLean/Channel/Semigroup.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Semigroup.Basic
 import TNLean.Channel.Semigroup.Perturbation
+import TNLean.Channel.Semigroup.Resolvent
 import TNLean.Channel.Semigroup.Primitivity
 import TNLean.Channel.Semigroup.GeneratorDefs
 import TNLean.Channel.Semigroup.LindbladForm

--- a/TNLean/Channel/Semigroup/Resolvent.lean
+++ b/TNLean/Channel/Semigroup/Resolvent.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Semigroup.Basic
+import Mathlib.Analysis.Normed.Algebra.Spectrum
+
+/-!
+# Resolvent of a semigroup generator (Wolf Eqs. 7.6–7.9)
+
+This file introduces the resolvent notation for semigroup generators, proves the
+Neumann-series identity in the norm-small regime, and records the Euler
+approximation statement as a formal predicate.
+-/
+
+open scoped Matrix Topology
+open Matrix
+
+noncomputable section
+
+variable {D : ℕ}
+
+attribute [local instance] Matrix.linftyOpNormedRing
+attribute [local instance] Matrix.linftyOpNormedAlgebra
+
+abbrev GeneratorCLM (D : ℕ) :=
+  Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ
+
+/-- Resolvent of a semigroup generator, specialized to the CLM algebra.
+(Wolf Eq. 7.6.) -/
+noncomputable def generatorResolvent (L : GeneratorCLM D) (z : ℂ) : GeneratorCLM D :=
+  resolvent L z
+
+set_option maxHeartbeats 1200000 in
+-- The CLM-instance normalization in the geometric-series proof needs extra heartbeats.
+theorem inverse_one_sub_smul_generator_eq_tsum
+    (L : GeneratorCLM D) {z : ℂ} (hz : ‖L‖ < ‖z‖) :
+    Ring.inverse (1 - z⁻¹ • L) = ∑' n : ℕ, (z⁻¹ • L) ^ n := by
+  have hz0 : z ≠ 0 := by
+    intro h0
+    have : ‖z‖ = 0 := by simp [h0]
+    have hz' : ‖L‖ < 0 := by simpa [this] using hz
+    exact (not_lt_of_ge (norm_nonneg L)) hz'
+  have hnorm : ‖(z⁻¹ • L : GeneratorCLM D)‖ < 1 := by
+    rw [norm_smul, norm_inv]
+    have hzpos : 0 < ‖z‖ := norm_pos_iff.mpr hz0
+    have hdiv : ‖L‖ / ‖z‖ < 1 := (div_lt_one hzpos).2 hz
+    simpa [div_eq_mul_inv, mul_comm] using hdiv
+  exact (geom_series_eq_inverse (z⁻¹ • L : GeneratorCLM D) hnorm).symm
+
+/-- Formal statement of Wolf Eq. (7.9): Euler approximation of the semigroup
+from resolvent samples. -/
+def eulerApproximation
+    (L : GeneratorCLM D)
+    (T : ℝ → GeneratorCLM D) : Prop :=
+  ∀ t : ℝ, 0 < t →
+    Filter.Tendsto (fun n : ℕ => (((n : ℂ) / t) • generatorResolvent L ((n : ℂ) / t)) ^ n)
+      Filter.atTop (𝓝 (T t))


### PR DESCRIPTION
### Motivation
- Provide the resolvent infrastructure for semigroup generators (Wolf §7.1, Eqs. 7.6 and 7.9) so downstream development can formalize Laplace/Cauchy representations and positivity-transfer statements.
- Start with the achievable finite-dimensional pieces: connect to Mathlib's `resolvent` and establish the Neumann (geometric) expansion which is concrete and useful for operator estimates.

### Description
- Add new file `TNLean/Channel/Semigroup/Resolvent.lean` defining `generatorResolvent (L, z) := resolvent L z` specialized to the CLM endomorphism algebra. 
- Prove the geometric/Neumann identity `Ring.inverse (1 - z⁻¹ • L) = ∑' n, (z⁻¹ • L)^n` under the norm bound `‖L‖ < ‖z‖` (the core Neumann-series expansion used to expand `R(z,L)`).
- Introduce the predicate `eulerApproximation` that records the Euler-type limit in Wolf Eq. (7.9) as a `Tendsto` property for future proof work.
- Wire the new module into the chapter index by importing `TNLean/Channel/Semigroup/Resolvent` from `TNLean/Channel/Semigroup.lean`.

### Testing
- Ran `lake env lean TNLean/Channel/Semigroup/Resolvent.lean` and the file type-checked successfully.
- Built the module with `lake build TNLean.Channel.Semigroup.Resolvent` which completed successfully.
- Ran `lake env lean TNLean/Channel/Semigroup.lean` to ensure the new import integrates with the semigroup surface and it type-checked successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c15d5d24808324bbaa5191785772c8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new semigroup resolvent module and supporting lemmas without changing existing semantics; main concern is potential compilation time impact from the increased `maxHeartbeats` setting in one proof.
> 
> **Overview**
> Adds a new `Semigroup/Resolvent` module that introduces `generatorResolvent` (a CLM-specialized wrapper around Mathlib’s `resolvent`) and proves a norm-small Neumann/geometric-series identity `Ring.inverse (1 - z⁻¹ • L) = ∑' n, (z⁻¹ • L)^n` under `‖L‖ < ‖z‖`.
> 
> Also records Wolf Eq. (7.9) as a predicate `eulerApproximation` expressing the Euler-type limit via `Filter.Tendsto`, and wires the new module into the public semigroup index by importing it from `Semigroup.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c3b30c0169ce00328518eb8dbaef0f52efc284c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->