### PR TITLE
Clarify Wolf Corollary 7.2: honest non-reducibility criterion (remove placeholder wrappers)

### DIFF
--- a/TNLean/Channel/Semigroup.lean
+++ b/TNLean/Channel/Semigroup.lean
@@ -9,6 +9,7 @@ import TNLean.Channel.Semigroup.GeneratorDefs
 import TNLean.Channel.Semigroup.LindbladForm
 import TNLean.Channel.Semigroup.KossakowskiForm
 import TNLean.Channel.Semigroup.ReducibleQDS
+import TNLean.Channel.Semigroup.RelaxationConditions
 
 /-!
 # Wolf Chapter 7 — Semigroup Structure: Public Theorem Index
@@ -137,6 +138,7 @@ No new proofs are introduced here; this is a documentation-only index module.
 
 ## Not yet formalized
 
-* Wolf Corollary 7.2 (necessary conditions for relaxation)
+* Wolf Corollary 7.2 (sufficient conditions for relaxation) — PARTIALLY FORMALIZED
+  (`TNLean.Channel.Semigroup.RelaxationConditions`: currently non-reducibility criterion only)
 * Wolf Theorem 7.2 (kernel of Liouvillian)
 -/

--- a/TNLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/TNLean/Channel/Semigroup/RelaxationConditions.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Semigroup.ReducibleQDS
+
+/-!
+# Wolf Corollary 7.2 — Honest partial formalization
+
+This file records the currently proved part of Wolf Corollary 7.2 in a way
+that matches the available infrastructure.
+
+At present, we formalize a **single sufficient criterion for non-reducibility**:
+if a GKSL generator admits no nontrivial block-upper-triangular Lindblad
+representation, then the associated QDS is not reducible.
+
+This does **not** yet formalize full relaxation (primitivity / convergence to a
+unique full-rank stationary state), which additionally depends on the
+irreducibility ↔ primitivity bridge.
+-/
+
+open scoped Matrix ComplexOrder BigOperators NNReal MatrixOrder
+open Matrix Finset
+
+noncomputable section
+
+attribute [local instance] Matrix.linftyOpNormedRing
+attribute [local instance] Matrix.linftyOpNormedAlgebra
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/--
+If a GKSL generator has no block-upper-triangular Lindblad decomposition,
+then the generated quantum dynamical semigroup is not reducible.
+
+This is the contrapositive of Wolf Prop 7.6 `(3) → (4)`.
+-/
+theorem not_isReducibleQDS_of_no_blockUpperTriangular_lindblad
+    {L : Mat →ₗ[ℂ] Mat}
+    (hGKSL : IsGKSLGenerator L)
+    (hNoBlockUT : ¬ HasBlockUpperTriangularLindblad L) :
+    ¬ IsReducibleQDS L := by
+  intro hReducible
+  exact hNoBlockUT (wolf_prop_7_6_three_implies_four hGKSL hReducible)
+
+/--
+Rephrasing of `not_isReducibleQDS_of_no_blockUpperTriangular_lindblad` with
+the assumptions in the opposite order.
+-/
+theorem no_blockUpperTriangular_lindblad_implies_not_isReducibleQDS
+    {L : Mat →ₗ[ℂ] Mat}
+    (hNoBlockUT : ¬ HasBlockUpperTriangularLindblad L)
+    (hGKSL : IsGKSLGenerator L) :
+    ¬ IsReducibleQDS L :=
+  not_isReducibleQDS_of_no_blockUpperTriangular_lindblad hGKSL hNoBlockUT
+
+end -- noncomputable section


### PR DESCRIPTION
### Motivation
- Review feedback pointed out that the three condition structures in the previous PR were mere single-field wrappers around `¬ HasBlockUpperTriangularLindblad` and therefore encoded no real mathematical content. 
- The change replaces those artificial wrappers with a precise, honest statement that matches the current available infrastructure (Prop 7.6) and avoids overstating what is proved about relaxation/primitivity.

### Description
- Added `TNLean/Channel/Semigroup/RelaxationConditions.lean` containing the contrapositive result `not_isReducibleQDS_of_no_blockUpperTriangular_lindblad` and the reordered lemma `no_blockUpperTriangular_lindblad_implies_not_isReducibleQDS` which state that absence of a block-upper-triangular Lindblad form implies the QDS is not reducible.
- Updated `TNLean/Channel/Semigroup.lean` to import the new module and to mark Wolf Corollary 7.2 as partially formalized in the index (explicitly documenting that only the non-reducibility criterion is formalized, not full relaxation/primitivity).
- The new module uses the existing `wolf_prop_7_6_three_implies_four` bridge, applying it by contraposition to make the statement explicit and honest instead of re-encoding it via empty wrappers.

### Testing
- Ran `lake env lean TNLean/Channel/Semigroup/RelaxationConditions.lean` which succeeded. 
- Built the module with `lake build TNLean.Channel.Semigroup.RelaxationConditions` which completed successfully (build replayed existing jobs and finished the new module). 
- Ran `lake env lean TNLean/Channel/Semigroup.lean` (initially errored until the new `.olean` was built) and it succeeded after the build. 
- Verified there are no new `sorry` placeholders in the added file by running `rg -n "sorry" TNLean/Channel/Semigroup/RelaxationConditions.lean TNLean/Channel/Semigroup.lean` which returned no `sorry` in the new module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c165f33d48832484a99f9edf04ff2f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small theorem module and updates the theorem index; no core definitions or algorithms change, and the new proofs are thin wrappers around existing lemmas.
> 
> **Overview**
> Adds `Semigroup/RelaxationConditions.lean`, introducing an explicit non-reducibility criterion: for a GKSL generator `L`, `¬ HasBlockUpperTriangularLindblad L` implies `¬ IsReducibleQDS L` (plus a reordered lemma), proved by contraposition via `wolf_prop_7_6_three_implies_four`.
> 
> Updates `Semigroup.lean` to import this module and to mark Wolf Corollary 7.2 as *partially formalized*, clarifying that only the non-reducibility criterion is currently covered (not full relaxation/primitivity).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3040944d996158e49daf9ecc73c9dfbff7be835. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->