### PR TITLE
[follow-up] Remove redundant TI theorem and add EquivalentBlocks ↔ GaugeEquiv lemma

### DIFF
--- a/TNLean/MPS/Chain/TranslationInvariance.lean
+++ b/TNLean/MPS/Chain/TranslationInvariance.lean
@@ -4,7 +4,7 @@ import TNLean.MPS.Chain.FundamentalTheorem
 # Translation-invariance corollaries for injective MPS chains
 
 This file packages the translation-invariant specialization of the chain
-fundamental theorem as two corollaries.
+fundamental theorem as a corollary.
 
 Because `fundamentalTheorem_injective_chain` currently yields a uniform gauge,
 the translation-invariant collapse can be witnessed with scalar `λ = 1`.
@@ -52,23 +52,5 @@ theorem ti_tensors_collapse_to_single_gauge
       simpa [MPSTensor.chainCombinedTensor_apply] using
         hX (finProdFinEquiv (k0, i))
     simpa [smul_eq_mul, Matrix.mul_assoc] using hXi
-
-/-- Corollary 2 (gauge periodicity).
-
-Any witness produced by `ti_tensors_collapse_to_single_gauge` satisfies the
-root-of-unity condition `lam ^ n = 1`. -/
-theorem ti_gauge_periodicity
-    (A B : MPSTensor d D)
-    (hn : 0 < n)
-    (hA : MPSTensor.IsInjective A)
-    (hB : MPSTensor.IsInjective B)
-    (hMPV : MPSTensor.SameMPV
-      (MPSTensor.chainCombinedTensor (fun _ : Fin n => A))
-      (MPSTensor.chainCombinedTensor (fun _ : Fin n => B))) :
-    ∃ lam : ℂ, lam ^ n = 1 := by
-  rcases ti_tensors_collapse_to_single_gauge
-      (A := A) (B := B) hn hA hB hMPV with
-    ⟨_, lam, _, hlam, _⟩
-  exact ⟨lam, hlam⟩
 
 end MPSChainTensor

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -132,6 +132,29 @@ theorem EquivalentBlocks.to_repeatedBlocks {A B : MPSTensor d D}
   intro i
   simpa [hY i]
 
+/-- `EquivalentBlocks` is equivalent to ordinary `GaugeEquiv`. -/
+theorem equivalentBlocks_iff_gaugeEquiv {A B : MPSTensor d D} :
+    EquivalentBlocks A B ↔ GaugeEquiv A B := by
+  constructor
+  · intro h
+    rcases h with ⟨Y, hY⟩
+    refine ⟨Y⁻¹, ?_⟩
+    intro i
+    have hYi := hY i
+    apply_fun (fun M =>
+      (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * M *
+        (Y : Matrix (Fin D) (Fin D) ℂ))) at hYi
+    simpa [Matrix.mul_assoc] using hYi.symm
+  · intro h
+    rcases h with ⟨X, hX⟩
+    refine ⟨X⁻¹, ?_⟩
+    intro i
+    have hXi := hX i
+    apply_fun (fun M =>
+      (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * M *
+        (X : Matrix (Fin D) (Fin D) ℂ))) at hXi
+    simpa [Matrix.mul_assoc] using hXi.symm
+
 /-- Symmetry of repeated blocks. -/
 theorem RepeatedBlocks.symm {A B : MPSTensor d D}
     (h : RepeatedBlocks A B) : RepeatedBlocks B A := by


### PR DESCRIPTION
### Motivation
- Eliminate a redundant/vacuous translation-invariance corollary that duplicates information already returned by the stronger collapse theorem. 
- Provide a Mathlib-style lowerCamelCase bridge lemma equating `EquivalentBlocks` and `GaugeEquiv` to clean up the periodic API and make the intent explicit.

### Description
- Deleted `ti_gauge_periodicity` from `TNLean/MPS/Chain/TranslationInvariance.lean` and revised the module docstring to reflect there is a single corollary (`ti_tensors_collapse_to_single_gauge`).
- Added `equivalentBlocks_iff_gaugeEquiv` (lowerCamelCase) to `TNLean/MPS/Periodic/Defs.lean` proving the equivalence between `EquivalentBlocks A B` and `GaugeEquiv A B` in both directions.
- No `sorry` were introduced and the new lemma is proved by inverting the provided gauge witnesses and applying conjugation/simp arguments.

### Testing
- Ran `lake env lean TNLean/MPS/Chain/TranslationInvariance.lean` which succeeded with zero errors.
- Ran `lake env lean TNLean/MPS/Periodic/Defs.lean` which succeeded with zero errors and produced only existing linter suggestions about `simpa` usage.
- Verified no `sorry` occurrences were added during these edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1653c4f248324b78ac9f2d33db1b0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant theorem and adds a small bridging lemma between two existing equivalence predicates, without changing core definitions or algorithms.
> 
> **Overview**
> Simplifies the translation-invariance corollaries by updating `TranslationInvariance.lean`’s docstring and **removing** the redundant `ti_gauge_periodicity` theorem (its conclusion already follows from `ti_tensors_collapse_to_single_gauge`).
> 
> Extends the periodic API with `equivalentBlocks_iff_gaugeEquiv` in `Periodic/Defs.lean`, providing a bidirectional lemma that `EquivalentBlocks A B` is logically equivalent to `GaugeEquiv A B` via inversion/conjugation of the gauge witness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b822aeae945c0d7cc647d10c77568e6313d410a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->