### PR TITLE
Remove vacuous stationary-support theorems and add TODO for Wolf Prop 6.10

### DIFF
--- a/TNLean/Channel/FixedPoint/StationarySupport.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupport.lean
@@ -22,9 +22,8 @@ Propositions 6.9--6.11).
   point of an irreducible channel.
 * `stationarySupport_eq_one`: for an irreducible channel, the stationary support
   is full (`= 1`).
-* `irreducible_iff_support_full`: packaging of the previous statement as an iff.
-* `stationary_support_minimal`: every nonzero invariant projection equals the
-  stationary support.
+* TODO (#23): formalize Wolf Prop. 6.10 stationary-subspace invariance
+  without irreducibility.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -206,32 +205,11 @@ theorem stationarySupport_eq_one
     exact hP_ne hP0
   · simpa [P] using hP1
 
-/-- Prop. 6.9 packaged as an `iff`: irreducibility is equivalent to full
-stationary support (for the chosen irreducible witness). -/
-theorem irreducible_iff_support_full
-    {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E) (hD : 0 < D) :
-    IsIrreducibleMap E ↔
-      ∃ hIrr : IsIrreducibleMap E, stationarySupport E hE hIrr hD = 1 := by
-  constructor
-  · intro hIrr
-    exact ⟨hIrr, stationarySupport_eq_one (E := E) hE hIrr hD⟩
-  · rintro ⟨hIrr, _⟩
-    exact hIrr
-
-/-- Prop. 6.10: the stationary support is the minimal nonzero invariant
-projection (under irreducibility every such projection coincides with it). -/
-theorem stationary_support_minimal
-    {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E)
-    (hIrr : IsIrreducibleMap E) (hD : 0 < D)
-    {P : Mat} (hP_proj : IsOrthogonalProjection P)
-    (hP_inv : ∀ X : Mat, P * E (P * X * P) * P = E (P * X * P))
-    (hP_ne : P ≠ 0) :
-    stationarySupport E hE hIrr hD = P := by
-  have hP_zero_or_one : P = 0 ∨ P = 1 := hIrr P hP_proj hP_inv
-  have hP_one : P = 1 := by
-    rcases hP_zero_or_one with hP0 | hP1
-    · exact (hP_ne hP0).elim
-    · exact hP1
-  rw [stationarySupport_eq_one (E := E) hE hIrr hD, hP_one]
+/- TODO (#23): Formalize Wolf Prop 6.10 (stationary subspace invariance)
+   without the irreducibility hypothesis. The correct statement is:
+   if sigma is a PSD fixed point of a channel E, then its support
+   projection Q satisfies: for every density operator rho <= Q,
+   E(rho) <= Q. See Notes/WolfNoteTexSource/ch06_spectral_properties.tex
+   lines 1240-1260. -/
 
 end Channel


### PR DESCRIPTION
### Motivation
- Two theorems in the stationary-support module were vacuously true (they existentially re-stated their hypothesis) and were flagged by review as misleading and incorrect.
- Replace the broken / vacuous statements with an explicit TODO so the file accurately records the intended non-trivial Wolf Prop. 6.10 goal without introducing any `sorry` placeholders.

### Description
- Removed the vacuous theorems `irreducible_iff_support_full` and `stationary_support_minimal` from `TNLean/Channel/FixedPoint/StationarySupport.lean` and left the surrounding correct lemmas intact (e.g. `support_proj_fixed`, `stationaryState`, `stationarySupport`, `stationarySupport_eq_one`).
- Updated the module header `Main declarations` list in `TNLean/Channel/FixedPoint/StationarySupport.lean` to stop claiming the removed theorems are formalized and to track the remaining work as TODO `#23`.
- Added a single TODO comment in `TNLean/Channel/FixedPoint/StationarySupport.lean` documenting the intended non-vacuous formulation of Wolf Prop. 6.10 and pointing to `Notes/WolfNoteTexSource/ch06_spectral_properties.tex` (lines 1240–1260) for the source statement.

### Testing
- Ran `lake env lean TNLean/Channel/FixedPoint/StationarySupport.lean`, which completes with 0 errors and a single non-blocking linter suggestion about `simpa` vs `simp`.
- No additional automated tests were required or run for this minimal refactor; existing lemmas in the file continue to typecheck under the same environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c164aa22708324a18e050733404998)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes unused/vacuous theorems and only updates documentation/comments; no functional proofs are changed beyond deleting these declarations, though any downstream code depending on the removed theorems would need updating.
> 
> **Overview**
> Removes the two stationary-support theorems `irreducible_iff_support_full` and `stationary_support_minimal` from `TNLean/Channel/FixedPoint/StationarySupport.lean` after identifying them as vacuous/misleading.
> 
> Updates the module’s “Main declarations” list accordingly and adds a single TODO (#23) documenting the intended non-vacuous statement of Wolf Prop. 6.10 (stationary-subspace invariance without irreducibility), with a pointer to the source notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 609a648d0635df3a7900ad8f7a1ce3a645661411. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->