### PR TITLE
[blueprint-sync] ch12: Update semigroup chapter after sorry closures and new theorems

### DIFF
--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -324,6 +324,37 @@ which shows that such generators have the standard Lindblad form.
     form equals a generator decomposition with $\phi$ CP.
 \end{proof}
 
+\begin{definition}[Commutator form of Lindblad equation]\label{def:commutator_form}
+    \lean{LindbladForm.commutatorForm}\leanok
+    \uses{def:lindblad_form}
+    The \emph{commutator form} of the Lindblad equation writes
+    the generator as
+    \[
+        L(\rho)
+        = i[\rho, H]
+        + \tfrac{1}{2}\sum_{j}
+          \bigl([L_j,\,\rho L_j^\dagger]
+                + [L_j\rho,\,L_j^\dagger]\bigr),
+    \]
+    where $[A,B] = AB - BA$.
+    This is \cite[Eq.~(7.22)]{Wolf2012Quantum}.
+\end{definition}
+
+\begin{theorem}[Commutator form equals standard Lindblad form]
+    \label{thm:commutatorForm_eq_toLinearMap}
+    \lean{LindbladForm.commutatorForm_eq_toLinearMap}\leanok
+    \uses{def:commutator_form, def:lindblad_form}
+    The commutator form (Definition~\ref{def:commutator_form}) defines
+    the same linear map as the standard Lindblad form
+    (Definition~\ref{def:lindblad_form}).
+\end{theorem}
+
+\begin{proof}\leanok
+    Expanding the commutator brackets
+    $[L_j, \rho L_j^\dagger]$ and $[L_j\rho, L_j^\dagger]$
+    yields the standard dissipator terms.
+\end{proof}
+
 \subsection{Prop.~7.2: Characterization of conditional complete positivity}
 
 \begin{theorem}[Prop.~7.2, direction 1$\to$2]
@@ -444,6 +475,65 @@ which shows that such generators have the standard Lindblad form.
 \begin{proof}
     \leanok
     Direct algebraic expansion.
+\end{proof}
+
+\subsection{Prop.~7.4 item 2: Uniqueness of the traceless Lindblad form}
+
+\begin{definition}[Traceless Kraus operators]\label{def:has_traceless_kraus}
+    \lean{LindbladForm.HasTracelessKraus}\leanok
+    \uses{def:lindblad_form}
+    A Lindblad form has \emph{traceless Kraus operators} if
+    $\tr(L_j) = 0$ for every $j$.
+\end{definition}
+
+\begin{theorem}[Prop.~7.4, item 2: CP-part uniqueness]
+    \label{thm:generatorDecomp_traceless_unique_phi}
+    \lean{generatorDecomp_traceless_unique_phi}\notready
+    \uses{def:lindblad_form, def:has_traceless_kraus, def:generator_decomp}
+    If two Lindblad forms $F, F'$ induce the same generator and
+    both have traceless Kraus operators, then their CP parts agree:
+    $\phi = \phi'$.
+    This is part of \cite[Prop.~7.4, item~2]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\notready
+    Compare projected Choi matrices and use Choi injectivity.
+\end{proof}
+
+\begin{theorem}[Prop.~7.4, item 2: drift uniqueness modulo phase]
+    \label{thm:generatorDecomp_traceless_unique_kappa}
+    \lean{generatorDecomp_traceless_unique_kappa_modPhase}\notready
+    \uses{def:lindblad_form, def:has_traceless_kraus, def:generator_decomp}
+    If two Lindblad forms $F, F'$ induce the same generator and
+    both have traceless Kraus operators, then their drift matrices
+    differ by an imaginary scalar: $\kappa' = \kappa + i\lambda\,\Id$
+    for some $\lambda \in \R$.
+    This is part of \cite[Prop.~7.4, item~2]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\notready
+    After identifying $\phi = \phi'$, the residual map is
+    $\rho \mapsto -(\Delta\kappa)\rho - \rho(\Delta\kappa)^\dagger$;
+    equality to zero forces $\Delta\kappa$ to be a scalar multiple
+    of the identity, and the Hermiticity/trace constraints force that
+    scalar to be purely imaginary.
+\end{proof}
+
+\begin{theorem}[Prop.~7.4, item 2: combined uniqueness]
+    \label{thm:generatorDecomp_traceless_unique}
+    \lean{generatorDecomp_traceless_unique}\notready
+    \uses{thm:generatorDecomp_traceless_unique_phi,
+          thm:generatorDecomp_traceless_unique_kappa}
+    If two Lindblad forms $F, F'$ induce the same generator and
+    both have traceless Kraus operators, then $\phi = \phi'$ and
+    $\kappa' = \kappa + i\lambda\,\Id$ for some $\lambda \in \R$.
+\end{theorem}
+
+\begin{proof}\notready
+    \uses{thm:generatorDecomp_traceless_unique_phi,
+          thm:generatorDecomp_traceless_unique_kappa}
+    Combine Theorems~\ref{thm:generatorDecomp_traceless_unique_phi}
+    and~\ref{thm:generatorDecomp_traceless_unique_kappa}.
 \end{proof}
 
 \subsection{Trace-annihilation and trace preservation}
@@ -616,10 +706,11 @@ which shows that such generators have the standard Lindblad form.
 
 %% Wolf §7.1, Prop 7.5
 \begin{remark}[Status note]\notready
-    The Lean declarations for Proposition~7.5 and the
-    Proposition~7.6 implication (4)$\to$(2) are currently implemented via
+    The Lean declarations for Proposition~7.5 are currently implemented via
     axioms to keep CI/elaboration time manageable; accordingly these results are
     marked \texttt{notready} in the blueprint until full proofs are restored.
+    The Proposition~7.6 implication (4)$\to$(2) sorry was closed in PR~\#85,
+    so the full equivalence chain is now complete.
 \end{remark}
 
 
@@ -823,7 +914,7 @@ The four equivalent reducibility conditions of
 
 \begin{theorem}[Prop.~7.6, (4)$\to$(2)]
     \label{thm:blockUpperTriangular_implies_rankDeficient}
-    \lean{hasRankDeficientKernelElement_of_hasBlockUpperTriangularLindblad}\notready
+    \lean{hasRankDeficientKernelElement_of_hasBlockUpperTriangularLindblad}\leanok
     \uses{def:has_block_upper_triangular_lindblad,
           def:has_rank_deficient_kernel_element, def:is_gksl_generator}
     If the Lindblad data of a GKSL generator are block-upper-triangular
@@ -834,7 +925,7 @@ The four equivalent reducibility conditions of
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     The block-upper-triangular structure implies $L$ preserves the
     compression $P M_d(\C) P$.
     Therefore the semigroup $e^{tL}$ also preserves $P M_d(\C) P$
@@ -848,7 +939,7 @@ The four equivalent reducibility conditions of
 
 \begin{theorem}[Prop.~7.6: Full equivalence]
     \label{thm:wolf_prop_7_6_full}
-    \lean{wolf_prop_7_6_full_equivalence}\notready
+    \lean{wolf_prop_7_6_full_equivalence}\leanok
     \uses{def:is_gksl_generator, def:has_rank_deficient_fixed_density,
           def:has_rank_deficient_kernel_element,
           def:has_invariant_compression,
@@ -864,7 +955,7 @@ The four equivalent reducibility conditions of
     This is \cite[Prop.~7.6]{Wolf2012Quantum}.
 \end{theorem}
 
-\begin{proof}\notready
+\begin{proof}\leanok
     \uses{thm:wolf_prop_7_6_one_iff_two,
           thm:wolf_prop_7_6_one_implies_three,
           thm:wolf_prop_7_6_three_iff_four,


### PR DESCRIPTION
Sync blueprint ch12_semigroup.tex with recent Lean merges:

- Add commutator form definition and equivalence theorem (`commutatorForm`, `commutatorForm_eq_toLinearMap`) with `\leanok`
- Add Prop 7.4 item 2 uniqueness theorems (`generatorDecomp_traceless_unique_phi`, `_kappa`, combined) with `\notready` (2 sorry remain)
- Update Prop 7.6 (4)→(2) from `\notready` to `\leanok` (sorry closed in PR LionSR/TNLean#85)
- Update Prop 7.6 full equivalence from `\notready` to `\leanok`
- Update status remark to reflect that (4)→(2) is now proved

Refs LionSR/QICLean#102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the semigroup blueprint: adds a few new statements and updates Lean proof-status annotations, without altering executable code or runtime behavior.
> 
> **Overview**
> Adds a new **commutator-form presentation** of the Lindblad generator (`commutatorForm`) and a `\leanok` theorem showing it matches the standard Lindblad linear map.
> 
> Extends Prop.~7.4 coverage with a new **“traceless Kraus operators”** condition and (currently `\notready`) uniqueness theorems for the CP part and drift term (plus a combined statement).
> 
> Updates the Prop.~7.6 section to reflect recently closed sorries: marks (4)$\to$(2) and the full equivalence theorem as `\leanok`, and adjusts the status remark accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c64e97aec1a30c694df864142b6371d1f34000a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->