### PR TITLE
[blueprint-sync] ch06: Add stationary-support section after Props 6.9-6.11 merges

### DIFF
--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -462,6 +462,95 @@ canonical-form separation arguments.
     Theorem~\ref{thm:qpf}.
 \end{remark}
 
+\section{Stationary support (Wolf \S6.4)}
+
+This section records the channel-side support-projection infrastructure
+behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
+The formalized results are in
+\texttt{TNLean/Channel/FixedPoint/StationarySupport.lean}.
+
+\begin{theorem}[Support projection invariance (Wolf Lemma~6.4)]%
+    \label{thm:support_proj_fixed}
+    \lean{Channel.support_proj_fixed}
+    \leanok
+    \uses{def:channel}
+    Let $E$ be a quantum channel and $\rho \ge 0$ a positive
+    semidefinite fixed point ($E(\rho) = \rho$).
+    Let $P$ denote the support projection of~$\rho$.
+    Then
+    \[
+        P \, E(P X P) \, P = E(P X P)
+    \]
+    for all $X \in \MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write $E$ in Kraus form $E(X) = \sum_i K_i X K_i^\dagger$.
+    From $E(\rho) = \rho$ and $\rho \ge 0$ one deduces
+    $(\Id - P) K_i P = 0$ for all~$i$, i.e.\ each Kraus operator
+    maps the range of~$P$ into itself.
+    The identity then follows by expanding the Kraus sum and
+    using $K_i P = P K_i P$.
+\end{proof}
+
+\begin{definition}[Stationary state]\label{def:stationaryState}
+    \lean{Channel.stationaryState}
+    \leanok
+    \uses{def:channel, def:irreducible_cp}
+    For an irreducible channel $E$ on $\MN{D}$ (with $D \ge 1$),
+    the \emph{stationary state} is the unique density-matrix fixed
+    point $\rho_\infty$ satisfying $E(\rho_\infty) = \rho_\infty$,
+    $\rho_\infty > 0$, and $\tr(\rho_\infty) = 1$.
+    Uniqueness follows from the quantum Perron--Frobenius theorem
+    (Theorem~\ref{thm:qpf}).
+\end{definition}
+
+\begin{definition}[Stationary support]\label{def:stationarySupport}
+    \lean{Channel.stationarySupport}
+    \leanok
+    \uses{def:stationaryState}
+    The \emph{stationary support} of an irreducible channel~$E$
+    is the support projection of the stationary state
+    (Definition~\ref{def:stationaryState}).
+\end{definition}
+
+\begin{theorem}[Prop.~6.9: stationary support is full]%
+    \label{thm:stationarySupport_eq_one}
+    \lean{Channel.stationarySupport_eq_one}
+    \leanok
+    \uses{def:stationarySupport, def:irreducible_cp}
+    For an irreducible channel~$E$, the stationary support equals
+    the identity: $\mathrm{supp}(\rho_\infty) = \Id$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:support_proj_fixed}
+    The support projection $P$ of $\rho_\infty$ is an orthogonal
+    projection satisfying $P E(PXP) P = E(PXP)$ for all~$X$
+    (Theorem~\ref{thm:support_proj_fixed}).
+    By irreducibility, $P = 0$ or $P = \Id$.
+    Since $\rho_\infty \neq 0$, we have $P \neq 0$, so $P = \Id$.
+\end{proof}
+
+\begin{remark}[Props.~6.10--6.11: non-trivial formulations]%
+    \label{rem:stationary_support_todo}
+    The original Lean declarations \texttt{irreducible\_iff\_support\_full}
+    and \texttt{stationary\_support\_minimal} were removed in PR~\#102
+    because their previous formulations were vacuous (they followed
+    trivially from the irreducibility hypothesis alone).
+    The correct non-trivial statements are:
+    \begin{itemize}
+        \item \textbf{Prop.~6.10} (converse of Prop.~6.9):
+            if the support projection of \emph{every} PSD fixed point
+            is full, then the channel is irreducible.
+        \item \textbf{Prop.~6.11}: minimality of the stationary support
+            among invariant projections, without assuming irreducibility.
+    \end{itemize}
+    These remain TODO in the formalization.
+\end{remark}
+
 \section{Primitive overlap convergence (spectral-gap form)}
 
 The theorems in this section are stated directly in terms of the


### PR DESCRIPTION
Sync blueprint ch06_spectral.tex with recent Lean merges:

- Add new section 'Stationary support (Wolf S6.4)'
- Add support projection invariance (Wolf Lemma 6.4, `support_proj_fixed`) with `\leanok`
- Add stationary state definition (`stationaryState`) with `\leanok`
- Add stationary support definition (`stationarySupport`) with `\leanok`
- Add Prop 6.9: stationary support is full (`stationarySupport_eq_one`) with `\leanok`
- Add remark noting Props 6.10-6.11 vacuous formulations were removed (PR LionSR/TNLean#102) and correct versions are TODO

Refs LionSR/QICLean#119

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint-only LaTeX additions documenting stationary-support lemmas/definitions; no executable code changes, so risk is limited to documentation consistency and cross-references.
> 
> **Overview**
> Adds a new **“Stationary support (Wolf §6.4)”** section to `ch06_spectral.tex`, syncing the blueprint with recent Lean developments.
> 
> The section introduces `Channel.support_proj_fixed` (support-projection invariance for PSD fixed points), defines `Channel.stationaryState` and `Channel.stationarySupport`, and states/proves Prop. 6.9 (`Channel.stationarySupport_eq_one`) that an irreducible channel’s stationary support is full. It also notes that prior Lean formulations of Props. 6.10–6.11 were removed as vacuous and records the intended non-trivial statements as TODOs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd020ce551f1f337be114577b2bec007ce4442df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->