### PR TITLE
[follow-up] Apply review nits from cleanup PR across listed Lean files

### DIFF
--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -1337,6 +1337,7 @@ theorem isPrimitive_restriction_of_cyclic_decomp
     (hcorner_fix k)
     (hcorner_ne k)
     (huniq k)
+
 section PermutationBlockStructure
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
@@ -1355,7 +1356,6 @@ theorem preserves_corner_pow_orderOf_of_perm_decomp
     (hMulLeft : ∀ k : ι, ∀ X : MatrixAlg D, T (P k * X) = T (P k) * T X)
     (hMulRight : ∀ k : ι, ∀ X : MatrixAlg D, T (X * P k) = T X * T (P k)) :
     ∀ k : ι, PreservesCorner (P k) (T ^ orderOf σ) := by
-  let _ := (inferInstance : DecidableEq ι)
   have hstep :
       ∀ n : ℕ, ∀ k : ι, ∀ X : MatrixAlg D,
         (T ^ n) (P ((σ ^ n) k) * X * P ((σ ^ n) k)) =
@@ -1386,12 +1386,10 @@ theorem preserves_corner_pow_orderOf_of_perm_decomp
           _ = P k * ((T ^ n) (T X)) * P k := ih k (T X)
           _ = P k * ((T ^ (n + 1)) X) * P k := by simp [pow_succ]
   intro k X
-  have horder_pos : 0 < orderOf σ := orderOf_pos σ
   have hmain :
       (T ^ orderOf σ) (P ((σ ^ orderOf σ) k) * X * P ((σ ^ orderOf σ) k)) =
         P k * ((T ^ orderOf σ) X) * P k := hstep (orderOf σ) k X
-  have hσ : (σ ^ orderOf σ) = 1 := by
-    exact pow_orderOf_eq_one σ
+  have hσ : (σ ^ orderOf σ) = 1 := pow_orderOf_eq_one σ
   have hmk : (T ^ orderOf σ) (P k * X * P k) = P k * ((T ^ orderOf σ) X) * P k := by
     simpa [hσ] using hmain
   calc

--- a/TNLean/Channel/Semigroup/ProductFormula.lean
+++ b/TNLean/Channel/Semigroup/ProductFormula.lean
@@ -22,6 +22,9 @@ needed for finite-dimensional product-formula arguments on `End(M_D(ℂ))`.
 These lemmas are enough to support later completion of a full Lie--Trotter
 convergence theorem, but that convergence statement itself is not yet included
 here.
+
+* `norm_trotter_pow_sub_exp_le_of_quadratic_step` — global error from a quadratic one-step bound
+* `lie_trotter_suzuki_bound_of_step` — Wolf/Suzuki-style explicit global constant
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal MatrixOrder
@@ -237,7 +240,7 @@ theorem norm_trotter_pow_sub_exp_le_of_quadratic_step [NeZero D]
     rw [← Real.exp_add]
     dsimp [s]
     congr 1
-    norm_num [Nat.cast_add]
+    push_cast
     field_simp [hcast_pos.ne']
     ring
   calc
@@ -266,9 +269,17 @@ theorem lie_trotter_suzuki_bound_of_step [NeZero D]
       - expSemigroupCLM (A + B) t‖
       ≤ ((2 * t ^ 2 / (n + 1)) * (‖A‖ + ‖B‖) ^ 2) *
           Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := by
-  simpa [mul_assoc, mul_left_comm, mul_comm, div_eq_mul_inv] using
+  have hquad :=
     norm_trotter_pow_sub_exp_le_of_quadratic_step (A := A) (B := B) (t := t) (n := n) ht
       (C := 2 * (‖A‖ + ‖B‖) ^ 2) hstep
+  calc
+    ‖(expSemigroupCLM A (t / (n + 1)) * expSemigroupCLM B (t / (n + 1))) ^ (n + 1)
+      - expSemigroupCLM (A + B) t‖
+        ≤ (2 * (‖A‖ + ‖B‖) ^ 2 * t ^ 2 / (n + 1)) *
+            Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := hquad
+    _ = ((2 * t ^ 2 / (n + 1)) * (‖A‖ + ‖B‖) ^ 2) *
+          Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := by
+            ring
 
 end ProductFormulaHelpers
 

--- a/TNLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/TNLean/Channel/Semigroup/RelaxationConditions.lean
@@ -45,15 +45,5 @@ theorem not_isReducibleQDS_of_no_blockUpperTriangular_lindblad
   intro hReducible
   exact hNoBlockUT (wolf_prop_7_6_three_implies_four hGKSL hReducible)
 
-/--
-Rephrasing of `not_isReducibleQDS_of_no_blockUpperTriangular_lindblad` with
-the assumptions in the opposite order.
--/
-theorem no_blockUpperTriangular_lindblad_implies_not_isReducibleQDS
-    {L : Mat →ₗ[ℂ] Mat}
-    (hNoBlockUT : ¬ HasBlockUpperTriangularLindblad L)
-    (hGKSL : IsGKSLGenerator L) :
-    ¬ IsReducibleQDS L :=
-  not_isReducibleQDS_of_no_blockUpperTriangular_lindblad hGKSL hNoBlockUT
 
 end -- noncomputable section

--- a/TNLean/Channel/Semigroup/Resolvent.lean
+++ b/TNLean/Channel/Semigroup/Resolvent.lean
@@ -21,24 +21,17 @@ variable {D : ℕ}
 private abbrev CLM (D : ℕ) :=
   Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ
 
-/-- Resolvent of a semigroup generator (`R(z,L) = (z • 1 - L)⁻¹`). -/
-abbrev generatorResolventCLM (L : CLM D) (z : ℂ) : CLM D :=
-  resolvent L z
-
-@[simp] theorem generatorResolventCLM_eq_mathlib (L : CLM D) (z : ℂ) :
-    generatorResolventCLM L z = resolvent L z := rfl
-
 /-- Neumann-series specialization at `z = 1`:
 if `‖L‖ < 1`, then `R(1,L) = ∑ₙ L^n`. -/
-theorem generatorResolventCLM_one_neumann
+theorem resolvent_one_neumann
     (L : CLM D) (hL : ‖L‖ < 1) :
-    generatorResolventCLM L (1 : ℂ) = ∑' n : ℕ, L ^ n := by
-  simpa [generatorResolventCLM, resolvent, Algebra.algebraMap_eq_smul_one, one_smul] using
+    resolvent L (1 : ℂ) = ∑' n : ℕ, L ^ n := by
+  simpa [resolvent, Algebra.algebraMap_eq_smul_one, one_smul] using
     (NormedRing.inverse_one_sub L hL)
 
 /-- Euler resolvent step `(λ R(λ,L))`. -/
 def eulerResolventStep (L : CLM D) (lam : ℂ) : CLM D :=
-  lam • generatorResolventCLM L lam
+  lam • resolvent L lam
 
 /-- Finite-`n` Euler approximation term `((n/t)R(n/t,L))^n`. -/
 def eulerResolventApprox (L : CLM D) (t : ℝ) (n : ℕ) : CLM D :=

--- a/TNLean/MPS/Chain/NormalFT.lean
+++ b/TNLean/MPS/Chain/NormalFT.lean
@@ -4,10 +4,9 @@ import TNLean.MPS.Chain.FundamentalTheorem
 /-!
 # Fundamental theorem endpoint for normal MPS via blocking
 
-This module packages a blocked-chain endpoint. The theorem
-`fundamentalTheorem_normal` is stated in terms of project normality
-(`MPSTensor.IsNormal`) together with a common blocking length `L` that makes
-both tensors `L`-block injective.
+This module packages a blocked-chain endpoint for blocked chains.
+The theorem `fundamentalTheorem_normal` concludes gauge equivalence of the
+constant `L`-blocked chains associated to the original tensors.
 -/
 
 open scoped Matrix
@@ -18,7 +17,7 @@ variable {d D : ℕ}
 
 /-- Bridge between project `N`-block injectivity and injectivity of the physically
 blocked tensor `blockTensor A N`. -/
-lemma IsNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
+lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
     IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by
   classical
   have hRange :
@@ -63,27 +62,20 @@ lemma blockedChain_isInjective (A : MPSTensor d D) (L n : ℕ)
     IsInjective (blockedChain A L n) := by
   intro k
   simpa [blockedChain] using
-    (MPSTensor.IsNBlkInjective_iff_blockTensor_isInjective A L).1 hA
+    (MPSTensor.isNBlkInjective_iff_blockTensor_isInjective A L).1 hA
 
 /-- Fundamental theorem endpoint for normal tensors at a common blocking length.
 
-The assumptions `hA_normal` and `hB_normal` make the normality intent explicit,
-while `hA_block`/`hB_block` choose a common witness `L` used in the blocked-chain
-reduction to the injective-chain theorem. -/
+The conclusion is about the constant chains of `L`-blocked tensors;
+`hA_block` picks the common witness `L` used in the reduction to the
+injective-chain theorem. -/
 theorem fundamentalTheorem_normal
     (A B : MPSTensor d D) (L n : ℕ)
-    (hA_normal : MPSTensor.IsNormal A)
-    (hB_normal : MPSTensor.IsNormal B)
     (hA_block : MPSTensor.IsNBlkInjective A L)
-    (_hB_block : MPSTensor.IsNBlkInjective B L)
     (hMPV : MPSTensor.SameMPV
       (MPSTensor.chainCombinedTensor (blockedChain A L n))
       (MPSTensor.chainCombinedTensor (blockedChain B L n))) :
     GaugeEquiv (blockedChain A L n) (blockedChain B L n) := by
-  -- The common block-injectivity witnesses imply project normality; keep these
-  -- as explicit `have`s so the theorem genuinely uses the `IsNormal` hypotheses.
-  have _ : MPSTensor.IsNormal A := hA_normal
-  have _ : MPSTensor.IsNormal B := hB_normal
   exact fundamentalTheorem_injective_chain
     (blockedChain A L n)
     (blockedChain B L n)


### PR DESCRIPTION
### Motivation
- Apply small, targeted fixes requested in the review list to remove fragile proofs, trivial wrappers, redundant re-exports, and unused assumptions across several Lean files.
- Make proofs and names robust to Mathlib/linters by avoiding fragile `simpa`/`norm_num` usage and following Mathlib naming conventions.

### Description
- `TNLean/Channel/Semigroup/ProductFormula.lean`: updated module docstring to list `norm_trotter_pow_sub_exp_le_of_quadratic_step` and `lie_trotter_suzuki_bound_of_step`, replaced the `norm_num [Nat.cast_add]` step with `push_cast; field_simp [hcast_pos.ne']; ring`, and rewrote the final `simpa` reliance in `lie_trotter_suzuki_bound_of_step` into an explicit `have` + `calc` + `ring` step to avoid a fragile simp set.
- `TNLean/Channel/Semigroup/Resolvent.lean`: removed the trivial `generatorResolventCLM` `abbrev` and its `@[simp]` `rfl` lemma, inlined Mathlib's `resolvent` usage, and renamed the Neumann theorem to `resolvent_one_neumann` while updating `eulerResolventStep` to use `resolvent` directly.
- `TNLean/Channel/Semigroup/RelaxationConditions.lean`: deleted the trivial argument-reordering wrapper theorem `no_blockUpperTriangular_lindblad_implies_not_isReducibleQDS` and kept the primary theorem only.
- `TNLean/MPS/Chain/NormalFT.lean`: renamed `IsNBlkInjective_iff_blockTensor_isInjective` to `isNBlkInjective_iff_blockTensor_isInjective` and updated its call site, removed unused hypotheses/bindings (`hA_normal`, `hB_normal`, `_hB_block`) and the corresponding `have` lines from `fundamentalTheorem_normal`, and clarified the docstring to state the conclusion concerns constant `L`-blocked chains.
- `TNLean/Channel/Peripheral/CyclicDecomposition.lean`: added the requested blank line before `section PermutationBlockStructure`, removed the redundant `let _ := (inferInstance : DecidableEq ι)`, removed the unused `have horder_pos`, and replaced the proof `have hσ := by exact pow_orderOf_eq_one σ` with the direct term `have hσ : (σ ^ orderOf σ) = 1 := pow_orderOf_eq_one σ`.

### Testing
- Ran repository-wide searches to confirm the removed wrappers/theorems were not referenced (`rg` for the affected identifiers) and updated call sites accordingly, which returned the expected matches.
- Built the modified targets with `lake build TNLean.Channel.Semigroup.ProductFormula TNLean.Channel.Semigroup.Resolvent TNLean.Channel.Semigroup.RelaxationConditions TNLean.MPS.Chain.NormalFT TNLean.Channel.Peripheral.CyclicDecomposition`, and the build completed successfully with only existing linter warnings; no new errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17654b42083248ba4a564999232b7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are proof-robustness cleanups (simp/cast steps), small naming/doc tweaks, and removal of redundant wrappers/assumptions without altering core statements.
> 
> **Overview**
> Applies review-driven Lean cleanup across channel and MPS modules: simplifies proofs to be less fragile (e.g., replacing `norm_num`/`simpa`-heavy steps with explicit `push_cast`/`field_simp`/`calc`), and removes unused locals.
> 
> Eliminates redundant API surface by inlining `resolvent` (dropping `generatorResolventCLM`), deleting a trivial argument-reordering theorem in relaxation conditions, and tightening `fundamentalTheorem_normal` by dropping unused hypotheses; also aligns lemma naming with Mathlib conventions and makes a small permutation-corner lemma proof tidier.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 002c110d60a7b00325d048cbf070f738ef9f559b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs #120