### PR TITLE
Rename NormalFT endpoint to fundamentalTheorem_blockedChain

### DIFF
--- a/TNLean/MPS/Chain/NormalFT.lean
+++ b/TNLean/MPS/Chain/NormalFT.lean
@@ -5,9 +5,8 @@ import TNLean.MPS.Chain.FundamentalTheorem
 # Fundamental theorem endpoint for normal MPS via blocking
 
 This module packages a blocked-chain endpoint. The theorem
-`fundamentalTheorem_normal` is stated in terms of project normality
-(`MPSTensor.IsNormal`) together with a common blocking length `L` that makes
-both tensors `L`-block injective.
+`fundamentalTheorem_blockedChain` is stated at a common blocking length `L`
+that makes both tensors `L`-block injective.
 -/
 
 open scoped Matrix
@@ -65,25 +64,18 @@ lemma blockedChain_isInjective (A : MPSTensor d D) (L n : ℕ)
   simpa [blockedChain] using
     (MPSTensor.IsNBlkInjective_iff_blockTensor_isInjective A L).1 hA
 
-/-- Fundamental theorem endpoint for normal tensors at a common blocking length.
+/-- Fundamental theorem endpoint for blocked chains at a common blocking length.
 
-The assumptions `hA_normal` and `hB_normal` make the normality intent explicit,
-while `hA_block`/`hB_block` choose a common witness `L` used in the blocked-chain
-reduction to the injective-chain theorem. -/
-theorem fundamentalTheorem_normal
+The assumptions `hA_block`/`hB_block` choose a common witness `L` used in the
+blocked-chain reduction to the injective-chain theorem. -/
+theorem fundamentalTheorem_blockedChain
     (A B : MPSTensor d D) (L n : ℕ)
-    (hA_normal : MPSTensor.IsNormal A)
-    (hB_normal : MPSTensor.IsNormal B)
     (hA_block : MPSTensor.IsNBlkInjective A L)
     (_hB_block : MPSTensor.IsNBlkInjective B L)
     (hMPV : MPSTensor.SameMPV
       (MPSTensor.chainCombinedTensor (blockedChain A L n))
       (MPSTensor.chainCombinedTensor (blockedChain B L n))) :
     GaugeEquiv (blockedChain A L n) (blockedChain B L n) := by
-  -- The common block-injectivity witnesses imply project normality; keep these
-  -- as explicit `have`s so the theorem genuinely uses the `IsNormal` hypotheses.
-  have _ : MPSTensor.IsNormal A := hA_normal
-  have _ : MPSTensor.IsNormal B := hB_normal
   exact fundamentalTheorem_injective_chain
     (blockedChain A L n)
     (blockedChain B L n)


### PR DESCRIPTION
### Motivation
- The endpoint theorem in `TNLean/MPS/Chain/NormalFT.lean` retained the `_normal` name and `IsNormal` hypotheses despite being stated via a common blocking length, which is misleading. 
- Rename and docstring updates align the API name and documentation with the blocked-chain formulation and remove unused/overly-strong hypotheses.

### Description
- Renamed `fundamentalTheorem_normal` to `fundamentalTheorem_blockedChain` in `TNLean/MPS/Chain/NormalFT.lean` and updated the module-level and theorem docstrings to describe the blocked-chain endpoint. 
- Removed the now-unnecessary `IsNormal` hypotheses and the placeholder `have _ : MPSTensor.IsNormal ...` uses from the theorem signature and proof. 
- Adjusted the theorem signature to keep only the common block-injectivity witnesses and the `SameMPV` hypothesis, and left the proof to call `fundamentalTheorem_injective_chain` with the blocked-chain witnesses. 

### Testing
- Ran `lake build TNLean.MPS.Chain.NormalFT`, which completed successfully with only a linter suggestion (`try 'simp' instead of 'simpa'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c193ed65bc8324bbfb6fddba4ecb0c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a public API change: the theorem is renamed and its signature is weakened/changed, which may break downstream imports or proofs. Proof logic is otherwise unchanged and still reduces to `fundamentalTheorem_injective_chain`.
> 
> **Overview**
> Renames the endpoint theorem in `TNLean/MPS/Chain/NormalFT.lean` from `fundamentalTheorem_normal` to `fundamentalTheorem_blockedChain` and updates module/theorem docstrings to reflect the blocked-chain formulation.
> 
> Removes the `IsNormal` hypotheses and the corresponding placeholder uses from the theorem, leaving only the common `IsNBlkInjective` blocking witnesses and the `SameMPV` assumption before invoking `fundamentalTheorem_injective_chain`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e6afaa1fbd5ac119439b0669e611792183e57e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->