### PR TITLE
[ci] Add leanblueprint installation to CI workflows

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,8 @@
       "Bash(lake update)",
       "Bash(lake update:*)",
       "Bash(lake env)",
-      "Bash(lake env:*)"
+      "Bash(lake env:*)",
+      "Bash(leanblueprint *)"
     ]
   }
 }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
           build: false
 
       - name: Install leanblueprint
-        run: pip install leanblueprint
+        run: pipx install leanblueprint
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,9 @@ jobs:
           use-mathlib-cache: true
           build: false
 
+      - name: Install leanblueprint
+        run: pip install leanblueprint
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -57,7 +60,7 @@ jobs:
           # claude_args: '--allowed-tools Bash(gh pr:*)'
           claude_args: |
             --model claude-opus-4-6
-            --allowed-tools "Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(gh pr:*),Bash(gh issue:*)"
+            --allowed-tools "Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(gh pr:*),Bash(gh issue:*),Bash(leanblueprint *)"
             --append-system-prompt "This is a Lean 4 / Mathlib repository. Prefer minimal diffs. Before changing theorem statements, first try to complete the proof using existing lemmas. Validate with: lake build. Do not leave unrelated new sorrys."
 
           # TODO: Explore adding MCP servers (e.g. sequential-thinking for complex proofs)

--- a/.github/workflows/lean-audit.yml
+++ b/.github/workflows/lean-audit.yml
@@ -34,7 +34,7 @@ jobs:
           build: false
 
       - name: Install leanblueprint
-        run: pip install leanblueprint
+        run: pipx install leanblueprint
 
       - name: Run Lean Audit
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/lean-audit.yml
+++ b/.github/workflows/lean-audit.yml
@@ -33,6 +33,9 @@ jobs:
           use-mathlib-cache: true
           build: false
 
+      - name: Install leanblueprint
+        run: pip install leanblueprint
+
       - name: Run Lean Audit
         uses: anthropics/claude-code-action@v1
         with:
@@ -50,5 +53,5 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-6
-            --allowed-tools "Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(find *),Bash(wc *)"
+            --allowed-tools "Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(find *),Bash(wc *),Bash(leanblueprint *)"
             --append-system-prompt "This is a Lean 4 / Mathlib formalization project for quantum information theory. Be thorough and precise. Report findings in clean markdown format."


### PR DESCRIPTION
## Summary
- Add `pip install leanblueprint` step to the Claude Code (`claude.yml`) and lean-audit (`lean-audit.yml`) workflows so blueprint commands (`leanblueprint checkdecls`, `leanblueprint web`, etc.) are available during interactive and audit sessions
- Add `Bash(leanblueprint *)` to allowed tools in both workflows and `.claude/settings.json`

## Test plan
- [ ] Verify `claude.yml` workflow installs leanblueprint before running Claude Code
- [ ] Verify `lean-audit.yml` blueprint-check audit can use leanblueprint commands
- [ ] Confirm leanblueprint commands work in local Claude Code sessions

https://claude.ai/code/session_01Tj3jw4tJ8qADXsUiwPvEe7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI/config-only change, but it adds a new external `pipx install` step that could fail or slow workflows if packaging/network issues occur.
> 
> **Overview**
> Adds `leanblueprint` availability to automation by installing it via `pipx` in the `claude.yml` and `lean-audit.yml` GitHub Actions workflows.
> 
> Updates Claude/Lean audit tool allowlists (including `.claude/settings.json` and workflow `--allowed-tools`) to permit running `Bash(leanblueprint *)` during interactive and audit sessions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b181a3a8589c088ba7c5c7abfd2422eaef10429d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->