### PR TITLE
[follow-up] Add SameState→SameMPV bridge API for n ≥ 3 chains

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -101,6 +101,7 @@ import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.FundamentalTheorem
+import TNLean.MPS.Chain.SameStateBridge
 import TNLean.MPS.Chain.NormalFT
 import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.MPS.Overlap.CastLemmas

--- a/TNLean/MPS/Chain/SameStateBridge.lean
+++ b/TNLean/MPS/Chain/SameStateBridge.lean
@@ -1,0 +1,64 @@
+import TNLean.MPS.Chain.FundamentalTheorem
+
+/-!
+# SameState → SameMPV bridge interface for injective chains
+
+This file provides an API boundary for the blocking step used in
+[arXiv:1804.04964](https://arxiv.org/abs/1804.04964):
+for chains of length `n ≥ 3`, equality of the physical chain state (`SameState`)
+should imply all-length mixed-word trace equality of the combined tensors
+(`SameMPV` on `chainCombinedTensor`).
+
+The full blocking proof is not formalized yet in this repository; instead,
+we package it as a reusable hypothesis `SameStateBridgeHyp`. The theorem
+`sameMPV_chainCombined_of_sameState` is the direct bridge lemma under that
+hypothesis, and `fundamentalTheorem_injective_chain_of_sameState` is the
+corresponding endpoint that feeds into the existing chain FT.
+-/
+
+open scoped Matrix
+
+namespace MPSChainTensor
+
+open MPSTensor
+
+variable {d D n : ℕ}
+
+/-- Abstract blocking bridge hypothesis for chains of fixed length `n`.
+
+When `3 ≤ n`, chain-state equality at that length implies `SameMPV` for the
+combined tensors. This matches the bridge step used between the paper's
+`SameState` assumption and the repository's current `SameMPV`-based chain FT.
+-/
+def SameStateBridgeHyp (d D n : ℕ) : Prop :=
+  ∀ (A B : MPSChainTensor d D n),
+    3 ≤ n →
+      SameState A B →
+        SameMPV (chainCombinedTensor A) (chainCombinedTensor B)
+
+/-- Bridge lemma: under `SameStateBridgeHyp`, `SameState` at length `n ≥ 3`
+implies `SameMPV` for the combined tensors. -/
+theorem sameMPV_chainCombined_of_sameState
+    (hBridge : SameStateBridgeHyp d D n)
+    (A B : MPSChainTensor d D n)
+    (hn : 3 ≤ n)
+    (hSame : SameState A B) :
+    SameMPV (chainCombinedTensor A) (chainCombinedTensor B) :=
+  hBridge A B hn hSame
+
+/-- Chain FT endpoint using `SameState` plus the blocking bridge hypothesis.
+
+This is a convenience wrapper around `fundamentalTheorem_injective_chain`.
+It exposes the paper-style `SameState` input while keeping the current
+`SameMPV`-based core theorem unchanged. -/
+theorem fundamentalTheorem_injective_chain_of_sameState
+    (hBridge : SameStateBridgeHyp d D n)
+    (A B : MPSChainTensor d D n)
+    (hn : 3 ≤ n)
+    (hA : IsInjective A)
+    (hSame : SameState A B) :
+    GaugeEquiv A B := by
+  apply fundamentalTheorem_injective_chain A B hA
+  exact sameMPV_chainCombined_of_sameState hBridge A B hn hSame
+
+end MPSChainTensor


### PR DESCRIPTION
### Motivation
- The chain-level fundamental theorem currently requires `SameMPV` (all-length mixed-word trace agreement) on the combined tensor, while the paper assumption is the weaker fixed-length `SameState` for chains with `n ≥ 3`, so an explicit bridge point is needed to accept the paper-style hypothesis without changing the core theorem.

### Description
- Added `TNLean/MPS/Chain/SameStateBridge.lean` which defines `SameStateBridgeHyp (d D n)` as an abstract blocking hypothesis that for `3 ≤ n` turns `SameState` into `SameMPV` for `chainCombinedTensor`.
- Implemented `sameMPV_chainCombined_of_sameState` (the bridge lemma under `SameStateBridgeHyp`) and `fundamentalTheorem_injective_chain_of_sameState` (a convenience wrapper that consumes the bridge and calls the existing `fundamentalTheorem_injective_chain`).
- Wired the new module into the top-level imports by adding `import TNLean.MPS.Chain.SameStateBridge` to `TNLean.lean` so the API is available project-wide.

### Testing
- Ran `lake build TNLean.MPS.Chain.SameStateBridge` which completed successfully.
- The new file type-checks and integrates with the existing chain FT API (the bridge is an interface-only addition and uses no `sorry` or `axiom`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a19002308324b0a2667bde4e0f27)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new interface-level hypothesis and wrapper theorems without changing existing fundamental theorem logic or proof obligations.
> 
> **Overview**
> Adds a new `SameStateBridge` module that introduces `SameStateBridgeHyp` as an abstract blocking assumption turning `SameState` (for `n ≥ 3`) into `SameMPV` on `chainCombinedTensor`, plus a small wrapper theorem `fundamentalTheorem_injective_chain_of_sameState` that feeds this into the existing injective chain FT.
> 
> Exports this new API from `TNLean.lean` so downstream users can invoke the chain fundamental theorem starting from the paper-style `SameState` assumption when supplying the bridge hypothesis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2c8d8eef5d07cc5ad35b8a61fa930ac2f020ce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->