### PR TITLE
[Wolf Ch2] Add existential Stinespring dilation theorems

### DIFF
--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -164,7 +164,8 @@ theorem exists_stinespring_dilation
     ∃ (r : ℕ) (K : Fin r → Matrix (Fin D) (Fin D) ℂ),
       ∀ A, E A = (stinespringV K)ᴴ * stinespringPi (r := r) A * stinespringV K := by
   rcases hE with ⟨r, K, hK⟩
-  -- Conjugating `K` converts Schrödinger-form Kraus terms into the Heisenberg-form witness.
+  -- We return `fun j => (K j)ᴴ` so the witness matches the Heisenberg identity
+  -- `Φ(X) = ∑ j, Kⱼᴴ * X * Kⱼ` rather than the Schrödinger Kraus orientation.
   refine ⟨r, fun j => (K j)ᴴ, ?_⟩
   intro A
   calc

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
+import TNLean.Channel.KrausRepresentation
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!
@@ -109,3 +110,77 @@ theorem stinespring_schrodinger_representation {r : ℕ}
   -- Unfold stinespringV and match matrix entries on both sides.
   simp only [Matrix.mul_apply, Matrix.sum_apply,
     stinespringV_apply, Matrix.conjTranspose_apply]
+
+/-! ### `π` as a concrete `*`-representation and existential Stinespring statements -/
+
+/-- The concrete representation `π(A) = A ⊗ 𝟙_r` used in the finite-dimensional
+Stinespring construction. -/
+noncomputable def stinespringPi {r : ℕ}
+    (A : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (Fin D × Fin r) (Fin D × Fin r) ℂ :=
+  kroneckerMap (· * ·) A (1 : Matrix (Fin r) (Fin r) ℂ)
+
+@[simp]
+theorem stinespringPi_apply {r : ℕ}
+    (A : Matrix (Fin D) (Fin D) ℂ) (i j : Fin D) (a b : Fin r) :
+    stinespringPi (r := r) A (i, a) (j, b) = A i j * (1 : Matrix (Fin r) (Fin r) ℂ) a b := rfl
+
+@[simp]
+theorem stinespringPi_one {r : ℕ} :
+    stinespringPi (D := D) (r := r) (1 : Matrix (Fin D) (Fin D) ℂ) = 1 := by
+  simpa [stinespringPi] using
+    (Matrix.one_kronecker_one (m := Fin D) (n := Fin r) (α := ℂ))
+
+@[simp]
+theorem stinespringPi_mul {r : ℕ}
+    (A B : Matrix (Fin D) (Fin D) ℂ) :
+    stinespringPi (r := r) (A * B) = stinespringPi (r := r) A * stinespringPi (r := r) B := by
+  simpa [stinespringPi] using
+    (Matrix.mul_kronecker_mul (A := A) (B := B)
+      (A' := (1 : Matrix (Fin r) (Fin r) ℂ)) (B' := (1 : Matrix (Fin r) (Fin r) ℂ)))
+
+@[simp]
+theorem stinespringPi_conjTranspose {r : ℕ}
+    (A : Matrix (Fin D) (Fin D) ℂ) :
+    (stinespringPi (r := r) A)ᴴ = stinespringPi (r := r) Aᴴ := by
+  simpa [stinespringPi] using
+    (Matrix.conjTranspose_kronecker (x := A) (y := (1 : Matrix (Fin r) (Fin r) ℂ)))
+
+/-- **Stinespring dilation (existential form, Wolf Thm 2.2)**:
+every CP map `E` admits an ancilla dimension `r`, a Kraus family `K`,
+and the concrete `*`-representation `π(A) = A ⊗ 𝟙_r` such that
+`E(A) = V† π(A) V` with `V = stinespringV K`. -/
+theorem exists_stinespring_dilation
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hE : IsCPMap E) :
+    ∃ (r : ℕ) (K : Fin r → Matrix (Fin D) (Fin D) ℂ),
+      ∀ A, E A = (stinespringV K)ᴴ * stinespringPi (r := r) A * stinespringV K := by
+  rcases hE with ⟨r, K, hK⟩
+  refine ⟨r, fun j => (K j)ᴴ, ?_⟩
+  intro A
+  calc
+    E A = ∑ i : Fin r, K i * A * (K i)ᴴ := hK A
+    _ = ∑ i : Fin r, ((K i)ᴴ)ᴴ * A * (K i)ᴴ := by
+      simp [Matrix.conjTranspose_conjTranspose]
+    _ = (stinespringV (fun j => (K j)ᴴ))ᴴ * stinespringPi (r := r) A *
+          stinespringV (fun j => (K j)ᴴ) :=
+      (stinespring_dual_representation (K := fun j => (K j)ᴴ) (A := A)).symm
+
+/-- **Stinespring dilation with isometry (TP case)**:
+if `E` is CP and trace-preserving, the Stinespring witness can be chosen so that
+`V†V = 𝟙`, i.e. `V` is an isometry, and `E` is recovered by partial trace:
+`E(ρ)_{ij} = ∑ₖ (VρV†)_{(i,k),(j,k)}`. -/
+theorem exists_stinespring_isometry_of_tp
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hEcp : IsCPMap E) (hEtp : IsTracePreservingMap E) :
+    ∃ (r : ℕ) (K : Fin r → Matrix (Fin D) (Fin D) ℂ),
+      (∀ A i j, (E A) i j =
+        ∑ k : Fin r, (stinespringV K * A * (stinespringV K)ᴴ) (i, k) (j, k)) ∧
+      (stinespringV K)ᴴ * stinespringV K = 1 := by
+  rcases hEcp with ⟨r, K, hK⟩
+  refine ⟨r, K, ?_, ?_⟩
+  · intro A i j
+    rw [hK A]
+    exact stinespring_schrodinger_representation (K := K) (X := A) (i := i) (j := j)
+  · rw [stinespringV_conjTranspose_mul]
+    exact kraus_sum_conjTranspose_mul_of_tp K E hK hEtp

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -139,15 +139,17 @@ theorem stinespringPi_mul {r : ℕ}
     (A B : Matrix (Fin D) (Fin D) ℂ) :
     stinespringPi (r := r) (A * B) = stinespringPi (r := r) A * stinespringPi (r := r) B := by
   unfold stinespringPi
-  simpa using Matrix.mul_kronecker_mul (A := A) (B := B)
-    (A' := (1 : Matrix (Fin r) (Fin r) ℂ)) (B' := (1 : Matrix (Fin r) (Fin r) ℂ))
+  convert Matrix.mul_kronecker_mul (A := A) (B := B)
+      (A' := (1 : Matrix (Fin r) (Fin r) ℂ)) (B' := (1 : Matrix (Fin r) (Fin r) ℂ)) using 1
+  simp
 
 @[simp]
 theorem stinespringPi_conjTranspose {r : ℕ}
     (A : Matrix (Fin D) (Fin D) ℂ) :
     (stinespringPi (r := r) A)ᴴ = stinespringPi (r := r) Aᴴ := by
   unfold stinespringPi
-  simpa using Matrix.conjTranspose_kronecker (x := A) (y := (1 : Matrix (Fin r) (Fin r) ℂ))
+  convert Matrix.conjTranspose_kronecker (x := A) (y := (1 : Matrix (Fin r) (Fin r) ℂ)) using 1
+  simp
 
 /-- **Stinespring dilation (existential form, Wolf Thm 2.2)**:
 every CP map `E` admits an ancilla dimension `r`, a Kraus family `K`,

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -154,7 +154,10 @@ theorem stinespringPi_conjTranspose {r : ℕ}
 /-- **Stinespring dilation (existential form, Wolf Thm 2.2)**:
 every CP map `E` admits an ancilla dimension `r`, a Kraus family `K`,
 and the concrete `*`-representation `π(A) = A ⊗ 𝟙_r` such that
-`E(A) = V† π(A) V` with `V = stinespringV K`. -/
+`E(A) = V† π(A) V` with `V = stinespringV K`.
+
+Convention: the returned witness `K` is in the Heisenberg orientation
+(i.e. conjugated relative to a Schrödinger-form Kraus family). -/
 theorem exists_stinespring_dilation
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hE : IsCPMap E) :

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -88,6 +88,7 @@ Schrödinger map uses adjoints in the opposite order. -/
 theorem stinespring_dual_representation {r : ℕ}
     (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (A : Matrix (Fin D) (Fin D) ℂ) :
     (stinespringV K)ᴴ *
+      -- This is `stinespringPi A` (defined below); kept inline to avoid forward reference.
       (kroneckerMap (· * ·) A (1 : Matrix (Fin r) (Fin r) ℂ)) *
       stinespringV K =
       ∑ j : Fin r, (K j)ᴴ * A * K j := by

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -18,6 +18,7 @@ for an explicit isometry `V` constructed from the Kraus operators.
 * `stinespringV`: the Stinespring isometry `V = ∑ⱼ Kⱼ ⊗ |j⟩`, a `(D·r) × D`
   matrix satisfying `V(i, j) k = (Kⱼ)_{ik}`
 * `stinespringV_apply`: entrywise evaluation lemma for `stinespringV`
+* `stinespringPi`: the concrete finite-dimensional representation `π(A) = A ⊗ 𝟙_r`
 
 ## Main results (Wolf Thm 2.2)
 
@@ -25,6 +26,8 @@ for an explicit isometry `V` constructed from the Kraus operators.
 * `stinespringV_isometry_iff_kraus_normalized` — `V†V = 𝟙` ↔ `∑ⱼ Kⱼ†Kⱼ = 𝟙`
 * `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` (Heisenberg picture)
 * `stinespring_schrodinger_representation` — `T(ρ) = tr_r(VρV†)` (Schrödinger picture)
+* `exists_stinespring_dilation` — existential Heisenberg-form dilation witness for CP maps
+* `exists_stinespring_isometry_of_cptp` — existential isometric dilation witness for CPTP maps
 
 ## References
 
@@ -128,23 +131,23 @@ theorem stinespringPi_apply {r : ℕ}
 @[simp]
 theorem stinespringPi_one {r : ℕ} :
     stinespringPi (D := D) (r := r) (1 : Matrix (Fin D) (Fin D) ℂ) = 1 := by
-  simpa [stinespringPi] using
-    (Matrix.one_kronecker_one (m := Fin D) (n := Fin r) (α := ℂ))
+  unfold stinespringPi
+  exact Matrix.one_kronecker_one (m := Fin D) (n := Fin r) (α := ℂ)
 
 @[simp]
 theorem stinespringPi_mul {r : ℕ}
     (A B : Matrix (Fin D) (Fin D) ℂ) :
     stinespringPi (r := r) (A * B) = stinespringPi (r := r) A * stinespringPi (r := r) B := by
-  simpa [stinespringPi] using
-    (Matrix.mul_kronecker_mul (A := A) (B := B)
-      (A' := (1 : Matrix (Fin r) (Fin r) ℂ)) (B' := (1 : Matrix (Fin r) (Fin r) ℂ)))
+  unfold stinespringPi
+  simpa using Matrix.mul_kronecker_mul (A := A) (B := B)
+    (A' := (1 : Matrix (Fin r) (Fin r) ℂ)) (B' := (1 : Matrix (Fin r) (Fin r) ℂ))
 
 @[simp]
 theorem stinespringPi_conjTranspose {r : ℕ}
     (A : Matrix (Fin D) (Fin D) ℂ) :
     (stinespringPi (r := r) A)ᴴ = stinespringPi (r := r) Aᴴ := by
-  simpa [stinespringPi] using
-    (Matrix.conjTranspose_kronecker (x := A) (y := (1 : Matrix (Fin r) (Fin r) ℂ)))
+  unfold stinespringPi
+  simpa using Matrix.conjTranspose_kronecker (x := A) (y := (1 : Matrix (Fin r) (Fin r) ℂ))
 
 /-- **Stinespring dilation (existential form, Wolf Thm 2.2)**:
 every CP map `E` admits an ancilla dimension `r`, a Kraus family `K`,
@@ -156,6 +159,7 @@ theorem exists_stinespring_dilation
     ∃ (r : ℕ) (K : Fin r → Matrix (Fin D) (Fin D) ℂ),
       ∀ A, E A = (stinespringV K)ᴴ * stinespringPi (r := r) A * stinespringV K := by
   rcases hE with ⟨r, K, hK⟩
+  -- Conjugating `K` converts Schrödinger-form Kraus terms into the Heisenberg-form witness.
   refine ⟨r, fun j => (K j)ᴴ, ?_⟩
   intro A
   calc
@@ -166,11 +170,14 @@ theorem exists_stinespring_dilation
           stinespringV (fun j => (K j)ᴴ) :=
       (stinespring_dual_representation (K := fun j => (K j)ᴴ) (A := A)).symm
 
-/-- **Stinespring dilation with isometry (TP case)**:
+/-- **Stinespring dilation with isometry (CPTP case)**:
 if `E` is CP and trace-preserving, the Stinespring witness can be chosen so that
 `V†V = 𝟙`, i.e. `V` is an isometry, and `E` is recovered by partial trace:
-`E(ρ)_{ij} = ∑ₖ (VρV†)_{(i,k),(j,k)}`. -/
-theorem exists_stinespring_isometry_of_tp
+`E(ρ)_{ij} = ∑ₖ (VρV†)_{(i,k),(j,k)}`.
+
+Unlike `exists_stinespring_dilation` (Heisenberg picture, conjugated Kraus witness),
+this theorem keeps the original Schrödinger-picture Kraus family. -/
+theorem exists_stinespring_isometry_of_cptp
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hEcp : IsCPMap E) (hEtp : IsTracePreservingMap E) :
     ∃ (r : ℕ) (K : Fin r → Matrix (Fin D) (Fin D) ℂ),

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -164,8 +164,8 @@ theorem exists_stinespring_dilation
     ∃ (r : ℕ) (K : Fin r → Matrix (Fin D) (Fin D) ℂ),
       ∀ A, E A = (stinespringV K)ᴴ * stinespringPi (r := r) A * stinespringV K := by
   rcases hE with ⟨r, K, hK⟩
-  -- We return `fun j => (K j)ᴴ` so the witness matches the Heisenberg identity
-  -- `Φ(X) = ∑ j, Kⱼᴴ * X * Kⱼ` rather than the Schrödinger Kraus orientation.
+  -- Witness convention: we return the conjugate-transposed family `fun j => (K j)ᴴ`
+  -- so the theorem matches the Heisenberg-form identity `Φ(X) = ∑ j, Kⱼᴴ * X * Kⱼ`.
   refine ⟨r, fun j => (K j)ᴴ, ?_⟩
   intro A
   calc


### PR DESCRIPTION
## Summary
Add existential Stinespring dilation theorems for CP and CPTP maps.

### Main results
- `exists_stinespring_dilation`: every CP map admits a Stinespring dilation `E(A) = V† π(A) V` with `π(A) = stinespringPi A` and `V = stinespringV K`
- `exists_stinespring_isometry_of_cptp`: the CPTP case where `V` is an isometry (`V†V = 1`)

### Supporting definitions
- `stinespringPi`: the `*`-representation `A ↦ A ⊗ 𝟙_r`
- Simp lemmas for `stinespringPi` (apply, one, mul, conjTranspose)

Closes LionSR/QICLean#121

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive Lean theorems/lemmas with minimal impact on existing behavior; main risk is downstream proof breakage due to new import dependencies or statement conventions (Heisenberg vs Schrödinger orientation).
> 
> **Overview**
> Adds a concrete Stinespring `*`-representation `stinespringPi(A) = A ⊗ 𝟙_r` (with simp lemmas for `apply`/`one`/`mul`/`conjTranspose`) and imports `KrausRepresentation` to reuse normalization results.
> 
> Introduces two new existential theorems: `exists_stinespring_dilation` (CP maps admit a Heisenberg-form dilation `E A = V† π(A) V`, returning a conjugate-transposed Kraus witness) and `exists_stinespring_isometry_of_cptp` (CPTP maps admit a dilation where `V` is an isometry and `E` is expressed via the partial-trace entry formula).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4b94182e6d98d06d53fcbc3f8ef37627da60af5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->