### PR TITLE
[Follow-up] Clarify Prop 7.3 is fully proved without placeholders

### DIFF
--- a/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
@@ -19,6 +19,9 @@ Euler step approximation.
 
 * `cp_semigroup_implies_ccp_generator` — **Prop 7.3** direction 1→2.
 * `cp_semigroup_iff_ccp_generator` — **Prop 7.3**: CP semigroup ↔ CCP generator.
+
+All Prop 7.3 statements in this file are proved constructively in Lean without
+`sorry`/`axiom` placeholders.
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal MatrixOrder


### PR DESCRIPTION
### Motivation
- Make explicit in the source that Proposition 7.3 (`cp_semigroup_implies_ccp_generator`, `ccp_generator_implies_cp_semigroup`, `cp_semigroup_iff_ccp_generator`) is fully formalized in Lean and does not rely on `sorry`/`axiom` placeholders.

### Description
- Add a short module-level note to `TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean` stating that all Prop 7.3 statements in the file are proved constructively without `sorry`/`axiom`.

### Testing
- Built the target module successfully with `lake build TNLean.Channel.Semigroup.LindbladForm.EulerStep` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a18b31ec8324b47c9648ad5110b1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change adding a documentation note; no logic, proof, or API behavior is modified.
> 
> **Overview**
> Adds a module-level note in `TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean` explicitly stating that all Wolf Proposition 7.3 results in the file are fully formalized in Lean without any `sorry`/`axiom` placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ca03d6386461914097915c9fd2333bd953b9ad3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->