### PR TITLE
[Wolf Ch5] Add Wolf Thm 5.5/5.6 aliases in Schwarz modules

### DIFF
--- a/TNLean/Channel/Schwarz/SchwarzNormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzNormal.lean
@@ -17,6 +17,8 @@ operators and states the abstract positive-map version of Wolf Proposition 5.1.
 * `KadisonSchwarz.kadison_schwarz_normal_cp`: Kadison–Schwarz restricted to normal inputs
 * `KadisonSchwarz.kadison_schwarz_normal_cp_le`: Loewner-order form of the above
 * `KadisonSchwarz.schwarz_inequality_normal_operator`: Wolf Prop. 5.1 for positive maps
+* This normal-input inequality is reused in the formal proofs of Wolf Thms. 5.5
+  and 5.6 in `SchwarzSubnormal.lean`.
 
 ## References
 

--- a/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
@@ -22,6 +22,7 @@ that appear in Wolf's notes.
 * `KadisonSchwarz.kadison_schwarz_commuting_dominant_cp_of_two_sided_bound`
 * `KadisonSchwarz.kadison_schwarz_commuting_dominant_cp`
 * `KadisonSchwarz.schwarz_inequality_commuting_dominant_operator`
+* `KadisonSchwarz.wolf_thm_5_5` / `KadisonSchwarz.wolf_thm_5_6` (named aliases)
 
 The key new result is `commuting_dominant_right_bound`: if `D ≥ 0` commutes with
 `A` and dominates `A† A`, then it also dominates `A A†`.  The proof uses the
@@ -385,6 +386,16 @@ theorem schwarz_inequality_subnormal_operator
     topLeft_schwarz_of_normal_extension (D := D) T hPos hSub
       (Matrix.fromBlocks A B 0 C) hNormal
 
+/-- Named alias for Wolf Thm. 5.5 (subnormal-input Schwarz inequality). -/
+theorem wolf_thm_5_5
+    (T : Mat →ₗ[ℂ] Mat)
+    (hPos : IsPositiveMap T)
+    (hSub : T 1 ≤ (1 : Mat))
+    (A : Mat)
+    (hSubnormal : IsSubnormal A) :
+    T (Aᴴ) * T A ≤ T (Aᴴ * A) ∧ T A * T (Aᴴ) ≤ T (Aᴴ * A) :=
+  schwarz_inequality_subnormal_operator (D := D) T hPos hSub A hSubnormal
+
 /-- Linear-map wrapper for the canonical adjoint Kraus map.
 
 This bundles `KadisonSchwarz.krausAdjointMap` from `KadisonSchwarz.lean` as a
@@ -699,5 +710,17 @@ theorem schwarz_inequality_commuting_dominant_operator
   exact ⟨le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).1,
          le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).2⟩
 
-end KadisonSchwarz
+/-- Named alias for Wolf Thm. 5.6 (commuting-dominant Schwarz inequality). -/
+theorem wolf_thm_5_6
+    (T : Mat →ₗ[ℂ] Mat)
+    (hPos : IsPositiveMap T)
+    (hSub : T 1 ≤ (1 : Mat))
+    (A Dom : Mat)
+    (hDomPos : Dom.PosSemidef)
+    (hComm : Commute Dom A)
+    (hDom : Aᴴ * A ≤ Dom) :
+    T (Aᴴ) * T A ≤ T Dom ∧ T A * T (Aᴴ) ≤ T Dom :=
+  schwarz_inequality_commuting_dominant_operator
+    (D := D) T hPos hSub A Dom hDomPos hComm hDom
 
+end KadisonSchwarz


### PR DESCRIPTION
### Motivation

- Make Wolf Theorems 5.5 and 5.6 explicitly discoverable in the formalization by providing named theorem aliases and clearer module docs. 
- Improve documentation linkage so the normal-input Schwarz inequality (`Prop. 5.1`) is clearly identified as a core ingredient for the subnormal/commuting-dominant results.

### Description

- Added `KadisonSchwarz.wolf_thm_5_5` as a named alias of `schwarz_inequality_subnormal_operator` in `TNLean/Channel/Schwarz/SchwarzSubnormal.lean`.
- Added `KadisonSchwarz.wolf_thm_5_6` as a named alias of `schwarz_inequality_commuting_dominant_operator` in `TNLean/Channel/Schwarz/SchwarzSubnormal.lean`.
- Updated the module-level declaration list in `TNLean/Channel/Schwarz/SchwarzSubnormal.lean` to include the new aliases so they appear in generated docs/navigation.
- Added a short note in `TNLean/Channel/Schwarz/SchwarzNormal.lean` that the normal-input inequality is reused by the Wolf Thm. 5.5/5.6 development.

### Testing

- Ran `lake build TNLean.Channel.Schwarz.SchwarzNormal TNLean.Channel.Schwarz.SchwarzSubnormal` and the build completed successfully.
- Verified the changes are purely naming/documentation (no new `sorry`/`axiom` introduced) and the existing proofs still compile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a1899a4083248f2cec071f2cde39)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and adding theorem aliases that reuse existing proofs without modifying underlying logic.
> 
> **Overview**
> Adds discoverable named theorems `KadisonSchwarz.wolf_thm_5_5` and `KadisonSchwarz.wolf_thm_5_6` as aliases for the existing subnormal and commuting-dominant Schwarz inequalities, and lists them in the module docs.
> 
> Updates `SchwarzNormal.lean` documentation to explicitly note that the normal-input Schwarz inequality is reused to prove Wolf Thms. 5.5/5.6 in `SchwarzSubnormal.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f9582552accd7cfdaa47243c2e789ad3137245. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#120