### PR TITLE
[PR #123 follow-up] Rename NormalFT → BlockedChainFT and remove unused blocked-chain hypothesis

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -101,7 +101,7 @@ import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.FundamentalTheorem
-import TNLean.MPS.Chain.NormalFT
+import TNLean.MPS.Chain.BlockedChainFT
 import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -2,12 +2,11 @@ import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Chain.FundamentalTheorem
 
 /-!
-# Fundamental theorem endpoint for normal MPS via blocking
+# Fundamental theorem endpoint for blocked chains
 
 This module packages a blocked-chain endpoint. The theorem
-`fundamentalTheorem_normal` is stated in terms of project normality
-(`MPSTensor.IsNormal`) together with a common blocking length `L` that makes
-both tensors `L`-block injective.
+`fundamentalTheorem_blockedChain` is stated for blocked chains built from a
+common blocking length `L`.
 -/
 
 open scoped Matrix
@@ -65,25 +64,17 @@ lemma blockedChain_isInjective (A : MPSTensor d D) (L n : ℕ)
   simpa [blockedChain] using
     (MPSTensor.IsNBlkInjective_iff_blockTensor_isInjective A L).1 hA
 
-/-- Fundamental theorem endpoint for normal tensors at a common blocking length.
+/-- Fundamental theorem endpoint for blocked chains at a common blocking length.
 
-The assumptions `hA_normal` and `hB_normal` make the normality intent explicit,
-while `hA_block`/`hB_block` choose a common witness `L` used in the blocked-chain
+The hypothesis `hA_block` chooses a witness `L` used in the blocked-chain
 reduction to the injective-chain theorem. -/
-theorem fundamentalTheorem_normal
+theorem fundamentalTheorem_blockedChain
     (A B : MPSTensor d D) (L n : ℕ)
-    (hA_normal : MPSTensor.IsNormal A)
-    (hB_normal : MPSTensor.IsNormal B)
     (hA_block : MPSTensor.IsNBlkInjective A L)
-    (_hB_block : MPSTensor.IsNBlkInjective B L)
     (hMPV : MPSTensor.SameMPV
       (MPSTensor.chainCombinedTensor (blockedChain A L n))
       (MPSTensor.chainCombinedTensor (blockedChain B L n))) :
     GaugeEquiv (blockedChain A L n) (blockedChain B L n) := by
-  -- The common block-injectivity witnesses imply project normality; keep these
-  -- as explicit `have`s so the theorem genuinely uses the `IsNormal` hypotheses.
-  have _ : MPSTensor.IsNormal A := hA_normal
-  have _ : MPSTensor.IsNormal B := hB_normal
   exact fundamentalTheorem_injective_chain
     (blockedChain A L n)
     (blockedChain B L n)


### PR DESCRIPTION
### Motivation
- Address the Claude review on PR #123 by tightening the blocked-chain endpoint API to only require hypotheses actually used in the proof and to align names/docstrings with the blocked-chain terminology.
- Remove an unused `_hB_block` hypothesis and obsolete `IsNormal` placeholders that over-constrained the theorem signature.
- Keep changes minimal and localized to the blocked-chain endpoint module and top-level import.

### Description
- Renamed `TNLean/MPS/Chain/NormalFT.lean` to `TNLean/MPS/Chain/BlockedChainFT.lean` and updated the top-level import in `TNLean.lean` to `import TNLean.MPS.Chain.BlockedChainFT`.
- Renamed the endpoint theorem from `fundamentalTheorem_normal` to `fundamentalTheorem_blockedChain` and changed its signature to remove `hA_normal`, `hB_normal`, and the unused `_hB_block` parameter so it now requires only `hA_block` and the `hMPV` hypothesis.
- Updated the module- and theorem-level docstrings to describe a blocked-chain endpoint and to reflect the new theorem name and API.
- Left the bridging lemma `IsNBlkInjective_iff_blockTensor_isInjective`, `blockedChain` definition, and `blockedChain_isInjective` unchanged and used them to call `fundamentalTheorem_injective_chain` in the tightened theorem.

### Testing
- Ran `rg` checks to verify references and renames (`rg -n "MPS\.Chain\.NormalFT|NormalFT\.lean|fundamentalTheorem_blockedChain" /workspace/TNLean`) and confirmed matches updated as expected, which succeeded.
- Built the affected target with `lake build TNLean.MPS.Chain.BlockedChainFT TNLean` and executed a full `lake build TNLean`, both of which completed successfully (build finished with warnings but no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1aabcb2cc8324ac516f1876724155)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly renaming and removing unused hypotheses; the proof still delegates to `fundamentalTheorem_injective_chain` with unchanged core logic.
> 
> **Overview**
> Updates the public import surface to use `TNLean.MPS.Chain.BlockedChainFT` instead of the old `NormalFT` module.
> 
> Renames the endpoint theorem to `fundamentalTheorem_blockedChain` and simplifies its signature by removing the `IsNormal` assumptions and the unused `_hB_block` hypothesis, leaving only the `hA_block` witness and `SameMPV` premise to derive `GaugeEquiv` for the blocked chains.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c229f6e82b99ab8fc0e5fec41f0d9d2ccad04cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->