### PR TITLE
[Wolf Ch5] Fix Schwarz doc/style: move note, use aliases

### DIFF
--- a/TNLean/Channel/Schwarz/SchwarzNormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzNormal.lean
@@ -18,6 +18,11 @@ operators and states the abstract positive-map version of Wolf Proposition 5.1.
 * `KadisonSchwarz.kadison_schwarz_normal_cp_le`: Loewner-order form of the above
 * `KadisonSchwarz.schwarz_inequality_normal_operator`: Wolf Prop. 5.1 for positive maps
 
+## Notes
+
+The normal-input inequality from this file is reused by the subnormal and
+commuting-dominant developments in `TNLean/Channel/Schwarz/SchwarzSubnormal.lean`.
+
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 5.1][Wolf2012QChannels]

--- a/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
@@ -18,10 +18,12 @@ that appear in Wolf's notes.
 
 * `KadisonSchwarz.IsSubnormal`
 * `KadisonSchwarz.schwarz_inequality_subnormal_operator`
+* `KadisonSchwarz.wolf_subnormal_schwarz_inequality` (alias)
 * `KadisonSchwarz.commuting_dominant_right_bound`
 * `KadisonSchwarz.kadison_schwarz_commuting_dominant_cp_of_two_sided_bound`
 * `KadisonSchwarz.kadison_schwarz_commuting_dominant_cp`
 * `KadisonSchwarz.schwarz_inequality_commuting_dominant_operator`
+* `KadisonSchwarz.wolf_commuting_dominant_schwarz_inequality` (alias)
 
 The key new result is `commuting_dominant_right_bound`: if `D ≥ 0` commutes with
 `A` and dominates `A† A`, then it also dominates `A A†`.  The proof uses the
@@ -385,6 +387,8 @@ theorem schwarz_inequality_subnormal_operator
     topLeft_schwarz_of_normal_extension (D := D) T hPos hSub
       (Matrix.fromBlocks A B 0 C) hNormal
 
+alias wolf_subnormal_schwarz_inequality := schwarz_inequality_subnormal_operator
+
 /-- Linear-map wrapper for the canonical adjoint Kraus map.
 
 This bundles `KadisonSchwarz.krausAdjointMap` from `KadisonSchwarz.lean` as a
@@ -699,5 +703,7 @@ theorem schwarz_inequality_commuting_dominant_operator
   exact ⟨le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).1,
          le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).2⟩
 
-end KadisonSchwarz
+alias wolf_commuting_dominant_schwarz_inequality :=
+  schwarz_inequality_commuting_dominant_operator
 
+end KadisonSchwarz


### PR DESCRIPTION
### Motivation

* Conform module doc formatting to Mathlib conventions by removing a cross-reference bullet and placing it in prose.
* Replace manual duplication of theorem statements with Lean `alias` so Wolf-facing names do not duplicate proofs.
* Avoid citation-indexed theorem names and prefer descriptive aliases for discoverability and style.
* Ensure file-end formatting (trailing newline and tidy `end` placement) is correct.

### Description

* Moved the cross-reference about reuse of the normal-input inequality into a `## Notes` prose section in `TNLean/Channel/Schwarz/SchwarzNormal.lean`.
* Introduced Mathlib-style aliases in `TNLean/Channel/Schwarz/SchwarzSubnormal.lean`: `wolf_subnormal_schwarz_inequality := schwarz_inequality_subnormal_operator` and `wolf_commuting_dominant_schwarz_inequality := schwarz_inequality_commuting_dominant_operator` so the Wolf-facing names are lightweight aliases rather than duplicated theorem bodies.
* Updated the file top-level declarations list in `SchwarzSubnormal.lean` to advertise the new alias names for documentation/navigation while keeping the original descriptive theorem identifiers.
* Fixed an initially incorrect alias direction and ensured files end cleanly with the `end KadisonSchwarz` and a trailing newline.

### Testing

* Ran `lake build TNLean.Channel.Schwarz.SchwarzNormal TNLean.Channel.Schwarz.SchwarzSubnormal`, which initially failed due to a syntax error from an incorrect `alias` direction, and then succeeded after correcting the alias syntax.
* Final `lake build TNLean.Channel.Schwarz.SchwarzNormal TNLean.Channel.Schwarz.SchwarzSubnormal` completed successfully and built both modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1aa9dde348324b5068b5626071b5d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only documentation tweaks and `alias` additions/placement changes; no proofs or core logic are modified.
> 
> **Overview**
> Updates module documentation in `SchwarzNormal.lean` by adding a *Notes* section describing downstream reuse.
> 
> In `SchwarzSubnormal.lean`, introduces Wolf-facing names as Lean `alias`es (`wolf_subnormal_schwarz_inequality`, `wolf_commuting_dominant_schwarz_inequality`) and advertises them in the module header, while tidying end-of-namespace/file formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b780afbe2b0ab30f4db175c405fd24d45f9e55bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#120