### PR TITLE
[Wolf Ch2] Clarify Stinespring module docs and add proof comment

### DIFF
--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -16,6 +16,7 @@ for an explicit isometry `V` constructed from the Kraus operators.
 
 * `stinespringV`: the Stinespring isometry `V = ∑ⱼ Kⱼ ⊗ |j⟩`, a `(D·r) × D`
   matrix satisfying `V(i, j) k = (Kⱼ)_{ik}`
+* `stinespringV_apply`: coordinate formula for `stinespringV`
 
 ## Main results (Wolf Thm 2.2)
 
@@ -77,7 +78,11 @@ theorem stinespringV_isometry_iff_kraus_normalized {r : ℕ}
   `T*(A) = V† (A ⊗ 𝟙_r) V`
 
 where `V` is the Stinespring isometry. This matches the Kraus form
-`T*(A) = ∑ⱼ Kⱼ† A Kⱼ`. -/
+`T*(A) = ∑ⱼ Kⱼ† A Kⱼ`.
+
+The `A` factor appears between a conjugate-transposed and non-transposed Kraus
+operator because this is the Heisenberg action (`T*` on observables), i.e. the
+adjoint of the Schrödinger map used on states. -/
 theorem stinespring_dual_representation {r : ℕ}
     (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (A : Matrix (Fin D) (Fin D) ℂ) :
     (stinespringV K)ᴴ *
@@ -103,5 +108,6 @@ theorem stinespring_schrodinger_representation {r : ℕ}
     (∑ l : Fin r, K l * X * (K l)ᴴ) i j =
     ∑ k : Fin r,
       (stinespringV K * X * (stinespringV K)ᴴ) (i, k) (j, k) := by
+  -- Conjugation trick: rewrite the adjoint-side Kraus family as `fun l => (K l)ᴴ`.
   simp only [Matrix.mul_apply, Matrix.sum_apply,
     stinespringV_apply, Matrix.conjTranspose_apply]


### PR DESCRIPTION
### Motivation
* Address reviewer polish requests for the Stinespring file by making the module overview match exported identifiers and by adding small explanatory comments to reduce cognitive friction when reading the Heisenberg/Schrödinger statements and proofs.

### Description
* Updated the module-level docstring to list `stinespringV_apply` under “Main definitions”, expanded the `stinespring_dual_representation` doc comment to explain the Heisenberg vs Schrödinger asymmetry, and added an inline one-line proof comment in `stinespring_schrodinger_representation` to document the conjugation trick (`fun l => (K l)ᴴ`).

### Testing
* Ran `lake build TNLean.Channel.Stinespring`, which completed successfully.  
* Ran `rg -n "sorry|axiom" TNLean/Channel/Stinespring.lean`, which reported `No sorry/axiom found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1aa91e26c83248062c2867873b0be)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc/comment-only changes in `TNLean/Channel/Stinespring.lean` with no modifications to definitions or proofs, so behavioral risk is minimal.
> 
> **Overview**
> Updates `TNLean/Channel/Stinespring.lean` documentation to better match exported identifiers by listing `stinespringV_apply` in the module overview.
> 
> Clarifies the `stinespring_dual_representation` docstring by explicitly relating the theorem to the Kraus form and explaining the Heisenberg vs Schrödinger operator ordering, and adds a brief inline comment in `stinespring_schrodinger_representation` noting the conjugation trick used in the proof.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1101e2e9946c0c5c0a1cc94847855642e568ca12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#121