### PR TITLE
[Wolf Ch2] Add trace-pairing basis expansion (Props 2.5-2.6)

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
+import TNLean.Algebra.TracePairing
 import TNLean.MPS.Core.Transfer
 import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.Data.Matrix.Basis
@@ -45,6 +46,65 @@ open scoped Matrix BigOperators Kronecker
 open Matrix Finset
 
 variable {D : ℕ}
+
+section TracePairingExpansion
+
+/-!
+## Wolf Props. 2.5–2.6: expansion in a trace-orthonormal operator basis
+
+This section gives the abstract transfer-matrix representation with respect to
+an arbitrary operator basis `σ` that is self-dual for the trace pairing, i.e.
+
+`X = ∑ j, tr(σ_j * X) • σ_j`.
+
+Then every linear map `T` admits coefficients `tᵢⱼ = tr(σᵢ * T(σⱼ))` such that
+
+`T(ρ) = ∑ i j, tᵢⱼ • σᵢ • tr(σⱼ * ρ)`.
+-/
+
+/-- A family `σ` is self-dual for the trace pairing if every matrix expands as
+`X = ∑ j, tr(σ_j * X) • σ_j`. -/
+def TracePairingSelfDualBasis (σ : Fin (D * D) → Matrix (Fin D) (Fin D) ℂ) : Prop :=
+  ∀ X : Matrix (Fin D) (Fin D) ℂ, X = ∑ j : Fin (D * D), Matrix.trace (σ j * X) • σ j
+
+theorem channel_expand_tracePairing
+    (σ : Fin (D * D) → Matrix (Fin D) (Fin D) ℂ)
+    (hσ : TracePairingSelfDualBasis (D := D) σ)
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    ∃ t : Fin (D * D) → Fin (D * D) → ℂ,
+      ∀ ρ : Matrix (Fin D) (Fin D) ℂ,
+        T ρ = ∑ i : Fin (D * D), ∑ j : Fin (D * D),
+          t i j • (Matrix.trace (σ j * ρ) • σ i) := by
+  refine ⟨fun i j => Matrix.trace (σ i * T (σ j)), ?_⟩
+  intro ρ
+  calc
+    T ρ = T (∑ j : Fin (D * D), Matrix.trace (σ j * ρ) • σ j) := by
+      conv_lhs => rw [hσ ρ]
+    _ = ∑ j : Fin (D * D), Matrix.trace (σ j * ρ) • T (σ j) := by
+      simp [map_sum, map_smul]
+    _ = ∑ j : Fin (D * D), Matrix.trace (σ j * ρ) •
+        (∑ i : Fin (D * D), Matrix.trace (σ i * T (σ j)) • σ i) := by
+      refine Finset.sum_congr rfl (fun j _ => ?_)
+      exact congrArg (fun X => Matrix.trace (σ j * ρ) • X) (hσ (T (σ j)))
+    _ = ∑ i : Fin (D * D), ∑ j : Fin (D * D),
+        (Matrix.trace (σ i * T (σ j))) • (Matrix.trace (σ j * ρ) • σ i) := by
+      calc
+        ∑ j : Fin (D * D), Matrix.trace (σ j * ρ) •
+            (∑ i : Fin (D * D), Matrix.trace (σ i * T (σ j)) • σ i)
+            =
+            ∑ j : Fin (D * D), ∑ i : Fin (D * D),
+              (Matrix.trace (σ j * ρ) * Matrix.trace (σ i * T (σ j))) • σ i := by
+              simp [smul_sum, smul_smul]
+        _ = ∑ i : Fin (D * D), ∑ j : Fin (D * D),
+              (Matrix.trace (σ j * ρ) * Matrix.trace (σ i * T (σ j))) • σ i := by
+            rw [Finset.sum_comm]
+        _ = ∑ i : Fin (D * D), ∑ j : Fin (D * D),
+              (Matrix.trace (σ i * T (σ j))) • (Matrix.trace (σ j * ρ) • σ i) := by
+            refine Finset.sum_congr rfl (fun i _ => ?_)
+            refine Finset.sum_congr rfl (fun j _ => ?_)
+            simp [smul_smul, mul_comm]
+
+end TracePairingExpansion
 
 /-! ### The transfer matrix -/
 


### PR DESCRIPTION
### Motivation
- Capture Wolf §2.2 Prop. 2.5–2.6 style expansion of a channel in an operator basis that is self-dual for the trace pairing. 
- Reuse the existing trace-pairing infrastructure so the expansion and the canonical coefficients are expressed via `trace` without introducing `sorry`/`axiom`.

### Description
- Import `TNLean.Algebra.TracePairing` into `TNLean/Channel/TransferMatrix.lean` so the transfer-matrix material can use the trace-pairing tools. 
- Add `TracePairingSelfDualBasis` which packages the hypothesis that a family `σ : Fin (D*D) → Matrix (Fin D) (Fin D) ℂ` expands all matrices by `X = ∑_j tr(σ_j * X) • σ_j`.
- Add `channel_expand_tracePairing` which constructs coefficients `t : Fin (D*D) → Fin (D*D) → ℂ` with the canonical choice `t i j = tr(σ_i * T (σ_j))` and proves `T ρ = ∑_{i,j} t i j • (tr(σ_j * ρ) • σ_i)` for any linear map `T`.
- The new proof is fully constructive and does not introduce `sorry` or new axioms.

### Testing
- Ran file elaboration check with `lake env lean TNLean/Channel/TransferMatrix.lean` and the file elaborated (Lean checked) with only a minor `simp`-argument linter warning; no errors remained.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1ad63b1588324baccc7b25e048644)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new lemmas/definitions in `TransferMatrix.lean` and a new import, without changing existing transfer-matrix definitions or proofs.
> 
> **Overview**
> Adds a new *trace-pairing basis expansion* section to `TNLean/Channel/TransferMatrix.lean`, formalizing Wolf Props. 2.5–2.6 for an arbitrary operator family `σ` that is self-dual under the trace pairing.
> 
> Introduces `TracePairingSelfDualBasis` and proves `channel_expand_tracePairing`, constructing the canonical coefficients `t i j = tr(σ i * T (σ j))` and deriving the corresponding double-sum expansion for any linear map `T`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2162b40291e1a49844696115b4b54ac1ea01ef30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#123