### PR TITLE
feat(Wolf Ch2): add orthonormal-frame converse for Kraus unitary freedom

### DIFF
--- a/TNLean/Channel/KrausRepresentation.lean
+++ b/TNLean/Channel/KrausRepresentation.lean
@@ -166,3 +166,38 @@ theorem kraus_same_map_of_exists_unitary_combination
       ∑ l : Fin r, K' l * X * (K' l)ᴴ := by
   rcases hU with ⟨U, hKU⟩
   exact kraus_same_map_of_unitaryGroup_combination K K' U hKU
+
+/-- A converse-style uniqueness lemma for the Kraus transition matrix:
+if two same-size Kraus families are related by a mixing matrix `U`, and both
+families are Hilbert–Schmidt orthonormal, then `U` is unitary.
+
+This isolates the linear-algebraic core used in Wolf Thm. 2.1 item 4:
+orthonormal Kraus decompositions have unitary change-of-coordinates. -/
+theorem kraus_transition_unitary_of_hs_orthonormal
+    {r : ℕ}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (K' : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (U : Matrix (Fin r) (Fin r) ℂ)
+    (hK : ∀ j, K j = ∑ l, U j l • K' l)
+    (horthK : ∀ i j : Fin r,
+      trace ((K j)ᴴ * K i) = if i = j then 1 else 0)
+    (horthK' : ∀ i j : Fin r,
+      trace ((K' j)ᴴ * K' i) = if i = j then 1 else 0) :
+    Uᴴ * U = 1 := by
+  have hUUh : U * Uᴴ = 1 := by
+    ext i j
+    have hleft : trace ((K j)ᴴ * K i) = if i = j then 1 else 0 := horthK i j
+    have hright :
+        trace ((K j)ᴴ * K i)
+          = ∑ l : Fin r, U i l * (starRingEnd ℂ) (U j l) := by
+      rw [hK i, hK j]
+      simp [Matrix.conjTranspose_sum, Matrix.conjTranspose_smul, Matrix.sum_mul, Matrix.mul_sum,
+        Matrix.trace_sum, mul_comm, horthK']
+    have h_entry : (U * Uᴴ) i j = if i = j then 1 else 0 := by
+      calc
+        (U * Uᴴ) i j = ∑ l : Fin r, U i l * (Uᴴ) l j := by simp [Matrix.mul_apply]
+        _ = ∑ l : Fin r, U i l * (starRingEnd ℂ) (U j l) := by simp [Matrix.conjTranspose_apply]
+        _ = trace ((K j)ᴴ * K i) := hright.symm
+        _ = if i = j then 1 else 0 := hleft
+    simpa [Matrix.one_apply] using h_entry
+  exact (mul_eq_one_comm).1 hUUh

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -37,6 +37,8 @@ representations of quantum channels.
   - `kraus_same_map_of_unitary_combination` — unitary freedom (sufficient direction) ✅
   - `kraus_same_map_of_unitaryGroup_combination` / `kraus_same_map_of_exists_unitary_combination`
     — bundled/existential unitary-witness wrappers for reuse in the converse roadmap ✅
+  - `kraus_transition_unitary_of_hs_orthonormal`
+    — converse linear-algebra core: orthonormal Kraus frames force unitary transition ✅
 
 * **Thm 2.2** (Stinespring dilation):
   - `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` ✅


### PR DESCRIPTION
### Motivation
- Advance the missing converse direction of Kraus unitary freedom (Wolf Thm. 2.1 item 4) by closing the linear-algebra core that shows a transition matrix is unitary when it relates two Hilbert–Schmidt–orthonormal Kraus frames.
- Isolate the finite-dimensional orthonormality argument so it can be reused when assembling the full converse proof from Choi/Stinespring data.

### Description
- Add `kraus_transition_unitary_of_hs_orthonormal` in `TNLean/Channel/KrausRepresentation.lean`, which proves that if `K, K' : Fin r → M_D(ℂ)` satisfy `K j = ∑ₗ U j l • K' l` and both families are Hilbert–Schmidt orthonormal (`trace ((K j)ᴴ * K i) = δ_{i,j}` and likewise for `K'`), then `Uᴴ * U = 1`.
- The proof derives `U * Uᴴ = 1` entrywise by expanding traces under the mixing relation and orthonormality, then converts to `Uᴴ * U = 1` using `mul_eq_one_comm`.
- Update `TNLean/Channel/WolfChapter2Index.lean` to list the new lemma under Thm 2.1 coverage as converse linear-algebra infrastructure.

### Testing
- Ran `lake env lean TNLean/Channel/KrausRepresentation.lean` and `lake env lean TNLean/Channel/WolfChapter2Index.lean`, both succeeded with no new errors.
- Ran a full `lake build` which completed successfully and included the new files in the build graph.
- The build shows only pre-existing warnings (including unrelated `sorry` usages elsewhere); there are no new `sorry` placeholders introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1ad612294832482c2b466c59964eb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new standalone Lean theorem and a documentation/index entry without changing existing definitions or proofs that other code depends on.
> 
> **Overview**
> Adds `kraus_transition_unitary_of_hs_orthonormal`, a converse-style lemma showing that a mixing matrix relating two same-size Hilbert–Schmidt orthonormal Kraus families must be unitary (`Uᴴ * U = 1`).
> 
> Updates the Chapter 2 index to list this new lemma as infrastructure toward the converse direction of Kraus unitary freedom (Wolf Thm. 2.1 item 4).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 586785257979a3936153729cfbbdf2c7e01af2cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#118