### PR TITLE
[Wolf Ch6] Add exponential irreducibility equivalence (Thm 6.2 item 3)

### DIFF
--- a/TNLean/Channel/Irreducible/Growth.lean
+++ b/TNLean/Channel/Irreducible/Growth.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.Irreducible.Basic
+import TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression
 import TNLean.Channel.Schwarz.Basic
 
 import Mathlib.Analysis.Normed.Algebra.Exponential
@@ -928,5 +929,75 @@ theorem exp_posDef_of_irreducible_cp
     rw [Matrix.posDef_iff_dotProduct_mulVec]
     exact ⟨h_exp_psd.isHermitian, hq_pos⟩
   simpa [Φ] using hfinal
+
+/-- **Wolf Theorem 6.2, item 3 (equivalence form)**:
+for CP maps on `M_D(ℂ)`, irreducibility is equivalent to strict positivity of
+the exponential action on every nonzero PSD input at every positive time. -/
+theorem irreducible_iff_exp_posDef_forall
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hCP : IsCPMap E) :
+    IsIrreducibleMap E ↔
+      ∀ t : ℝ, 0 < t →
+      ∀ A : Matrix (Fin D) (Fin D) ℂ, A.PosSemidef → A ≠ 0 →
+        ((NormedSpace.exp
+          ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+            ((t : ℂ) • E))) A).PosDef := by
+  constructor
+  · intro hIrr t ht A hA hA_ne
+    exact exp_posDef_of_irreducible_cp E hCP hIrr A hA hA_ne ht
+  · intro hExp
+    intro P hP hInv
+    by_cases hP0 : P = 0
+    · exact Or.inl hP0
+    · right
+      have hsemigroup_inv :
+          ∀ t : ℝ, 0 ≤ t → ∀ X : Matrix (Fin D) (Fin D) ℂ,
+            P * (expSemigroup E t (P * X * P)) * P = expSemigroup E t (P * X * P) :=
+        semigroup_preserves_compression_of_generator (hP := hP) (hgen := hInv)
+      have hPP : P * P = P := hP.2
+      have hPherm : Pᴴ = P := hP.1.eq
+      have hA_psd : (P * Pᴴ).PosSemidef :=
+        Matrix.posSemidef_self_mul_conjTranspose P
+      have hA_ne : P * Pᴴ ≠ 0 := by
+        rw [hPherm, hPP]
+        exact hP0
+      have hExpPD :
+          ((NormedSpace.exp
+            ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+              ((1 : ℂ) • E))) (P * Pᴴ)).PosDef :=
+        hExp 1 zero_lt_one (P * Pᴴ) hA_psd hA_ne
+      have hExp_compressed :
+          P * (expSemigroup E 1 (P * Pᴴ)) * P = expSemigroup E 1 (P * Pᴴ) := by
+        simpa [hPherm, hPP] using hsemigroup_inv 1 (show (0 : ℝ) ≤ 1 by norm_num) Pᴴ
+      have h_left_zero : (1 - P) * expSemigroup E 1 (P * Pᴴ) = 0 := by
+        calc
+          (1 - P) * expSemigroup E 1 (P * Pᴴ)
+              = (1 - P) * (P * expSemigroup E 1 (P * Pᴴ) * P) := by rw [hExp_compressed]
+          _ = ((1 - P) * P) * expSemigroup E 1 (P * Pᴴ) * P := by noncomm_ring
+          _ = 0 := by
+              have hsub : (1 - P) * P = 0 := by
+                rw [sub_mul, one_mul, hPP, sub_self]
+              rw [hsub, zero_mul, zero_mul]
+      have h_eval :
+          expSemigroup E 1 (P * Pᴴ) =
+            (NormedSpace.exp
+              ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+                ((1 : ℂ) • E))) (P * Pᴴ) := by
+        simpa [expSemigroupCLM] using
+          congrArg (fun F => F (P * Pᴴ)) (expSemigroup_toCLM (L := E) 1)
+      have hExp_unit : IsUnit (expSemigroup E 1 (P * Pᴴ)) :=
+        Matrix.PosDef.isUnit (by simpa [h_eval] using hExpPD)
+      rcases hExp_unit with ⟨u, hu⟩
+      let U : Matrix (Fin D) (Fin D) ℂ := ↑u
+      have hU : U = expSemigroup E 1 (P * Pᴴ) := by simpa [U] using hu
+      have hu_inv : (expSemigroup E 1 (P * Pᴴ)) * U⁻¹ = 1 := by
+        rw [← hU]
+        simpa [U] using Units.val_mul_inv u
+      have hsub : 1 - P = 0 := by
+        have hmul0 := congrArg (fun Z => Z * U⁻¹) h_left_zero
+        have hmul0' : (1 - P) * ((expSemigroup E 1 (P * Pᴴ)) * U⁻¹) = 0 := by
+          simpa [Matrix.mul_assoc] using hmul0
+        simpa [hu_inv] using hmul0'
+      exact (sub_eq_zero.mp hsub).symm
 
 end Exponential


### PR DESCRIPTION
### Motivation
- Close the gap in the formalization of Wolf §6.2 by proving the exponential characterization (item 3) as an equivalence for CP maps on `M_D(ℂ)` instead of only one direction. 
- The converse direction requires semigroup/exp infrastructure so the semigroup compression bridge is reused. 
- Maintain a fully constructive development (no `sorry` or `axiom`).

### Description
- Imported `TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression` to access `semigroup_preserves_compression_of_generator` and bridge generator-level compression to the exponential semigroup.
- Added `irreducible_iff_exp_posDef_forall` which states `IsIrreducibleMap E ↔ ∀ t>0, ∀ A ≥ 0, A ≠ 0 → exp(tE)(A) .PosDef` and packages the two implications.
- Forward implication is discharged via the existing `exp_posDef_of_irreducible_cp` lemma; the converse constructs the PSD test input `P * Pᴴ` for a candidate invariant projection `P`, uses semigroup compression to show `expSemigroup E 1` preserves the compression, and combines positivity (hence invertibility) of `expSemigroup E 1 (P * Pᴴ)` with annihilation of `(1 - P)` to force `P = 1`.
- Reused existing lemmas about PosDef → `IsUnit`, compression identities, and the `expSemigroup`/`NormedSpace.exp` connection.

### Testing
- Ran typechecking on the modified file with `lake env lean TNLean/Channel/Irreducible/Growth.lean`, which completed successfully (the file typechecks); only non-fatal linter suggestions/warnings were emitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1ad5d29fc8324b78c7bc7bc69d3b4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a substantial new Lean proof tying irreducibility to exponential positivity and introduces a new dependency on semigroup compression lemmas; risk is mainly proof fragility/typeclass/lemma dependencies rather than runtime behavior.
> 
> **Overview**
> Adds the missing converse direction of Wolf Thm 6.2(3) by introducing `irreducible_iff_exp_posDef_forall`, stating `IsIrreducibleMap E` iff `exp(t•E)` sends every nonzero PSD matrix to a `PosDef` matrix for all `t > 0`.
> 
> To prove the converse, it imports `TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression` and uses `semigroup_preserves_compression_of_generator` plus the `expSemigroup`/`NormedSpace.exp` bridge to turn positivity at `t = 1` for the test input `P * Pᴴ` into invertibility, forcing any invariant projection `P` to be `0` or `1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ef0a8e07b42e6eddeaa8a4df27017b29c6d663d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#122