### PR TITLE
[1804.04964] Add foundational PEPS definitions on finite graphs

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -96,6 +96,7 @@ import TNLean.Spectral.CrossCorrelation
 
 -- Layer 3: MPS core
 import TNLean.MPS.Defs
+import TNLean.PEPS.Defs
 import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.TensorEquality

--- a/TNLean/PEPS/Defs.lean
+++ b/TNLean/PEPS/Defs.lean
@@ -1,0 +1,72 @@
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Data.Complex.Basic
+import Mathlib.Data.Fintype.BigOperators
+
+/-!
+# Basic PEPS definitions on finite simple graphs
+
+This file sets up a minimal Lean 4 interface for PEPS on a finite graph:
+
+* a vertex-local tensor with one physical index and one virtual index per incident edge,
+* the PEPS state coefficient obtained by contracting all virtual indices,
+* vertexwise injectivity as injectivity of the local virtual-to-physical map.
+-/
+
+open scoped BigOperators
+
+/-- Undirected edges of a simple graph, as a finite index type. -/
+abbrev Edge {n : ℕ} (G : SimpleGraph (Fin n)) : Type :=
+  {e : Sym2 (Fin n) // e ∈ G.edgeSet}
+
+/-- Edges incident to a fixed vertex `v`. -/
+abbrev IncidentEdge {n : ℕ} (G : SimpleGraph (Fin n)) (v : Fin n) : Type :=
+  {e : Edge G // v ∈ (e.1 : Sym2 (Fin n))}
+
+/-- Minimal PEPS data on `SimpleGraph (Fin n)` with physical dimension `d`.
+
+Bond dimensions are allowed to vary by edge. -/
+structure PEPS (n d : ℕ) where
+  G : SimpleGraph (Fin n)
+  /-- Bond dimension on each undirected edge. -/
+  bondDim : Edge G → ℕ
+  /-- A local PEPS tensor at vertex `v`: virtual indices on incident edges,
+  and one physical index in `Fin d`. -/
+  tensor : (v : Fin n) → ((ie : IncidentEdge G v) → Fin (bondDim ie.1)) → Fin d → ℂ
+
+namespace PEPS
+
+variable {n d : ℕ}
+
+noncomputable instance instFintypeEdge (A : PEPS n d) : Fintype (Edge A.G) :=
+  Fintype.ofFinite (Edge A.G)
+
+/-- A global assignment of all virtual indices (one per edge). -/
+abbrev VirtualConfig (A : PEPS n d) : Type :=
+  (e : Edge A.G) → Fin (A.bondDim e)
+
+noncomputable instance instFintypeVirtualConfig (A : PEPS n d) :
+    Fintype (VirtualConfig A) := by
+  classical
+  infer_instance
+
+/-- The local virtual-to-physical map at vertex `v`. -/
+def vertexMap (A : PEPS n d) (v : Fin n) :
+    ((ie : IncidentEdge A.G v) → Fin (A.bondDim ie.1)) → (Fin d → ℂ) :=
+  fun ξ i => A.tensor v ξ i
+
+/-- Coefficient of the PEPS state on a physical basis configuration `σ`.
+
+This is the contraction of all virtual indices along edges: sum over global
+virtual assignments, product of local tensor entries. -/
+noncomputable def stateCoeff (A : PEPS n d) (σ : Fin n → Fin d) : ℂ :=
+  ∑ ξ : VirtualConfig A, ∏ v : Fin n, A.tensor v (fun ie => ξ ie.1) (σ v)
+
+/-- Two PEPS define the same state if all computational-basis coefficients agree. -/
+def SameState (A B : PEPS n d) : Prop :=
+  ∀ σ : Fin n → Fin d, stateCoeff A σ = stateCoeff B σ
+
+/-- Vertexwise injectivity: each local virtual-to-physical map is injective. -/
+def IsInjective (A : PEPS n d) : Prop :=
+  ∀ v : Fin n, Function.Injective (vertexMap A v)
+
+end PEPS


### PR DESCRIPTION
### Motivation

- Provide a minimal Lean4/Mathlib interface for PEPS (graph-based tensor networks) as a stepping stone toward formalizing the Fundamental Theorem for injective PEPS (arXiv:1804.04964, Thm.2).
- Support arbitrary simple graphs `SimpleGraph (Fin n)` with per-edge bond dimensions so future PEPS machinery (contraction, gauges, injectivity proofs) can be developed analogously to the existing MPS code.

### Description

- Add a new exploratory module `TNLean/PEPS/Defs.lean` defining `PEPS (n d : ℕ)` with fields `G : SimpleGraph (Fin n)`, `bondDim : Edge G → ℕ`, and `tensor : (v : Fin n) → ((ie : IncidentEdge G v) → Fin (bondDim ie.1)) → Fin d → ℂ`.
- Introduce helper types `Edge` and `IncidentEdge` for undirected edges and vertex-incident edges, a global `VirtualConfig`, the local `vertexMap`, the contracted coefficient `stateCoeff`, and predicates `SameState` and `IsInjective` (vertexwise injectivity of `vertexMap`).
- Add noncomputable `Fintype` instances so finite sums/products over virtual configurations are well-typed, and use `BigOperators` for the contraction expression.
- Re-export the new module by adding `import TNLean.PEPS.Defs` to `TNLean.lean` so the PEPS definitions are available from the root import surface.

### Testing

- Ran `lake build TNLean.PEPS.Defs`, which completed successfully after iterative fixes to imports and finiteness instances.
- Ran `lake build TNLean`, which completed successfully (full project build passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1ad5c4060832487ceb1399227f789)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new Lean definitions/types plus a root `import`, with no changes to existing MPS/channel logic; risk is limited to potential import/compile surface-area impacts.
> 
> **Overview**
> Adds a new `TNLean/PEPS/Defs.lean` module introducing foundational PEPS data on finite simple graphs: `PEPS` with per-edge bond dimensions, local vertex tensors, a global virtual configuration type, and the contracted coefficient `stateCoeff` (sum over virtual assignments, product over vertices).
> 
> Defines basic equivalence/predicate helpers (`SameState`, vertexwise `IsInjective`) and the required `Fintype` instances to make the finite contraction well-typed, and re-exports these definitions by importing `TNLean.PEPS.Defs` from `TNLean.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18074bf82d9cf5d3f5a3920ded01ef1a3b409eeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs #128