### PR TITLE
[1804.04964] Add SameState-to-SameMPV bridge with injectivity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -103,7 +103,6 @@ import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.FundamentalTheorem
 import TNLean.MPS.Chain.BlockedChainFT
 import TNLean.MPS.Chain.SameStateBridge
-import TNLean.MPS.Chain.NormalFT
 import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.MPS.Chain.SymmetricMPS
 import TNLean.MPS.Overlap.CastLemmas

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -102,6 +102,8 @@ import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.FundamentalTheorem
 import TNLean.MPS.Chain.BlockedChainFT
+import TNLean.MPS.Chain.SameStateBridge
+import TNLean.MPS.Chain.NormalFT
 import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.MPS.Chain.SymmetricMPS
 import TNLean.MPS.Overlap.CastLemmas

--- a/TNLean/MPS/Chain/SameStateBridge.lean
+++ b/TNLean/MPS/Chain/SameStateBridge.lean
@@ -11,7 +11,6 @@ This file records that blocking step as an explicit hypothesis object and
 provides convenience lemmas/theorems that consume it.
 -/
 
-open scoped Matrix
 
 namespace MPSChainTensor
 
@@ -21,6 +20,8 @@ variable {d D n : ℕ}
 
 If `A` is injective and two chains agree at fixed length `n ≥ 3` (`SameState`),
 then their combined tensors satisfy `SameMPV`. -/
+/- Design note: this is a `structure` (rather than a `class`) so callers pass
+   this bridge assumption explicitly instead of relying on instance search. -/
 structure SameStateBridgeHyp (d D : ℕ) : Prop where
   sameMPV_of_sameState :
     ∀ ⦃n : ℕ⦄ (A B : MPSChainTensor d D n),
@@ -52,8 +53,8 @@ theorem fundamentalTheorem_injective_chain_of_sameState
     (hA : IsInjective A)
     (hn : 3 ≤ n)
     (hState : SameState A B) :
-    GaugeEquiv A B := by
-  exact fundamentalTheorem_injective_chain A B hA
+    GaugeEquiv A B :=
+  fundamentalTheorem_injective_chain A B hA
     (sameMPV_chainCombined_of_sameState hBridge A B hA hn hState)
 
 end MPSChainTensor

--- a/TNLean/MPS/Chain/SameStateBridge.lean
+++ b/TNLean/MPS/Chain/SameStateBridge.lean
@@ -1,0 +1,59 @@
+import TNLean.MPS.Chain.FundamentalTheorem
+
+/-!
+# SameState to SameMPV bridge interface for injective chains
+
+The paper's blocking argument (for chain length `n ≥ 3`) upgrades a fixed-length
+`SameState` hypothesis to the all-length mixed-word trace agreement `SameMPV`
+needed by `fundamentalTheorem_injective_chain`.
+
+This file records that blocking step as an explicit hypothesis object and
+provides convenience lemmas/theorems that consume it.
+-/
+
+open scoped Matrix
+
+namespace MPSChainTensor
+
+variable {d D n : ℕ}
+
+/-- Abstract hypothesis for the paper's blocking step:
+
+If `A` is injective and two chains agree at fixed length `n ≥ 3` (`SameState`),
+then their combined tensors satisfy `SameMPV`. -/
+structure SameStateBridgeHyp (d D : ℕ) : Prop where
+  sameMPV_of_sameState :
+    ∀ ⦃n : ℕ⦄ (A B : MPSChainTensor d D n),
+      IsInjective A →
+      3 ≤ n →
+      SameState A B →
+      MPSTensor.SameMPV (MPSTensor.chainCombinedTensor A)
+        (MPSTensor.chainCombinedTensor B)
+
+/-- Bridge lemma interface:
+from fixed-length `SameState` (`n ≥ 3`) and injectivity of `A`, obtain `SameMPV`
+for combined tensors using a supplied blocking hypothesis. -/
+theorem sameMPV_chainCombined_of_sameState
+    (hBridge : SameStateBridgeHyp d D)
+    (A B : MPSChainTensor d D n)
+    (hA : IsInjective A)
+    (hn : 3 ≤ n)
+    (hState : SameState A B) :
+    MPSTensor.SameMPV (MPSTensor.chainCombinedTensor A)
+      (MPSTensor.chainCombinedTensor B) :=
+  hBridge.sameMPV_of_sameState A B hA hn hState
+
+/-- Paper-style chain endpoint:
+assuming the blocking bridge hypothesis, fixed-length `SameState` at `n ≥ 3`
+implies cyclic gauge equivalence for injective `A`. -/
+theorem fundamentalTheorem_injective_chain_of_sameState
+    (hBridge : SameStateBridgeHyp d D)
+    (A B : MPSChainTensor d D n)
+    (hA : IsInjective A)
+    (hn : 3 ≤ n)
+    (hState : SameState A B) :
+    GaugeEquiv A B := by
+  exact fundamentalTheorem_injective_chain A B hA
+    (sameMPV_chainCombined_of_sameState hBridge A B hA hn hState)
+
+end MPSChainTensor


### PR DESCRIPTION
### Motivation
- The original bridge quantified over all chains without assuming injectivity of `A`, which made the blocking implication (from `SameState` at length `n ≥ 3` to `SameMPV`) unprovable; the paper’s blocking argument requires injectivity. 
- Introduce an explicit injectivity precondition so the formal bridge matches the paper assumptions and can be used to recover the paper-style FT endpoint.

### Description
- Added `TNLean/MPS/Chain/SameStateBridge.lean` which defines the abstract bridge `structure` `SameStateBridgeHyp` that requires `IsInjective A`, `3 ≤ n`, and `SameState A B` to conclude `MPSTensor.SameMPV (MPSTensor.chainCombinedTensor A) (MPSTensor.chainCombinedTensor B)`.
- Exported a small API: `sameMPV_chainCombined_of_sameState` that applies the bridge, and `fundamentalTheorem_injective_chain_of_sameState` which consumes the bridge plus `SameState` to call the existing `fundamentalTheorem_injective_chain` and produce `GaugeEquiv`.
- Wired the new module into the project root import surface by adding `import TNLean.MPS.Chain.SameStateBridge` to `TNLean.lean`.

### Testing
- Ran `lake build TNLean.MPS.Chain.SameStateBridge` which completed successfully.
- Ran `lake build TNLean` which completed successfully (noting ordinary linter warnings elsewhere); both builds passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1aaa737b48324ad97c8c9ac1df284)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean module and re-export import without changing existing proofs or core logic; impact is limited to new APIs and a broader root import surface.
> 
> **Overview**
> Adds an explicit *blocking bridge* hypothesis (`SameStateBridgeHyp`) that, for injective chains with `n ≥ 3`, upgrades a fixed-length `SameState` assumption to `SameMPV` on `chainCombinedTensor`.
> 
> Provides small convenience theorems (`sameMPV_chainCombined_of_sameState` and `fundamentalTheorem_injective_chain_of_sameState`) to feed this bridge into `fundamentalTheorem_injective_chain`, and re-exports the new module from `TNLean.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24534392d5b71395361ef934ecdeb564b36da7a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs #127