### PR TITLE
[Wolf Ch6] Clarify Thm 6.8 conjunction-vs-equivalence statement

### DIFF
--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -148,6 +148,12 @@ Other items: PARTIALLY via spectral gap infrastructure in `TNLean.Spectral.*`.
 
 * `IsPrimitivePaper` — `TNLean.Wielandt.Primitivity.PaperDefinitions`
   (item 3: `Kₘ = M_d(ℂ)` for `m ≥ q`)
+* Pairwise Proposition 3 equivalences (in `TNLean.Wielandt.Primitivity.Equivalence`):
+  `primitivePaper_iff_hasEventuallyFullKrausRank`,
+  `primitivePaper_iff_stronglyIrreducible`,
+  `hasEventuallyFullKrausRank_iff_stronglyIrreducible`
+* Packaged conjunction form (also in `TNLean.Wielandt.Primitivity.Equivalence`):
+  `wolf_theorem_6_8_four_characterizations`
 
 ### Wolf Theorem 6.9 (Quantum Wielandt inequality)
 

--- a/TNLean/Wielandt/Primitivity/Equivalence.lean
+++ b/TNLean/Wielandt/Primitivity/Equivalence.lean
@@ -226,6 +226,28 @@ theorem hasEventuallyFullKrausRank_iff_stronglyIrreducible [NeZero D]
   ⟨fun hB => isStronglyIrreduciblePaper_of_hasEventuallyFullKrausRank A hNorm hB,
    fun hC => prop3_cb A hNorm hC⟩
 
+/-- **Wolf Theorem 6.8 (packaged form)**: paper primitivity is equivalent to the
+conjunction of eventual full Kraus rank, normality, and strong irreducibility.
+
+This theorem is intentionally stated as a single `↔` with a conjunction on the
+right. The pairwise equivalences are available separately as:
+`primitivePaper_iff_hasEventuallyFullKrausRank`,
+`primitivePaper_iff_stronglyIrreducible`, and
+`hasEventuallyFullKrausRank_iff_stronglyIrreducible`.
+-/
+theorem wolf_theorem_6_8_four_characterizations [NeZero D]
+    (A : MPSTensor d D)
+    (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    IsPrimitivePaper A ↔
+      (HasEventuallyFullKrausRank A ∧ IsNormal A ∧ IsStronglyIrreduciblePaper A) := by
+  constructor
+  · intro hPrim
+    refine ⟨hasEventuallyFullKrausRank_of_isPrimitivePaper A hNorm hPrim, ?_, ?_⟩
+    · exact isNormal_of_isPrimitivePaper A hNorm hPrim
+    · exact (primitivePaper_iff_stronglyIrreducible A hNorm).mp hPrim
+  · intro hAll
+    exact (primitivePaper_iff_hasEventuallyFullKrausRank A hNorm).mpr hAll.1
+
 /-! ## Peripheral primitivity (intermediate result) -/
 
 /-- **Proposition 3 (a)→(c), intermediate step**: paper primitivity implies


### PR DESCRIPTION
### Motivation
- Bugbot flagged that `wolf_theorem_6_8_four_characterizations` could be misread as claiming pairwise equivalence among four predicates while its type actually states `IsPrimitivePaper A ↔ (HasEventuallyFullKrausRank A ∧ IsNormal A ∧ IsStronglyIrreduciblePaper A)`.
- The intent is to remove ambiguity by providing an explicit packaged-conjunction theorem and pointing readers to the established pairwise `↔` lemmas for the usual equivalence view.

### Description
- Added `wolf_theorem_6_8_four_characterizations` in `TNLean/Wielandt/Primitivity/Equivalence.lean` with the type `IsPrimitivePaper A ↔ (HasEventuallyFullKrausRank A ∧ IsNormal A ∧ IsStronglyIrreduciblePaper A)` and a docstring explaining it is a packaged conjunction form (not a set of new pairwise `↔`).
- Clarified the theorem docstring to reference the existing pairwise equivalences `primitivePaper_iff_hasEventuallyFullKrausRank`, `primitivePaper_iff_stronglyIrreducible`, and `hasEventuallyFullKrausRank_iff_stronglyIrreducible`.
- Updated `TNLean/Channel/WolfChapter6Index.lean` to list both the pairwise Proposition 3 equivalences and the packaged `wolf_theorem_6_8_four_characterizations` entry.
- No `sorry` or `axiom` were introduced in these changes.

### Testing
- Ran `lake build TNLean.Wielandt.Primitivity.Equivalence` which completed successfully.
- Ran `lake build TNLean.Channel.WolfChapter6Index` which completed successfully and preserved a pre-existing linter warning in `TNLean/Channel/FixedPoint/StationarySupport.lean`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b8554138832499e30eea9d7f3817)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new wrapper theorem and documentation/index references without changing core proofs or algorithms. Main risk is only downstream breakage if external code depended on older theorem naming/availability, but existing lemmas remain unchanged.
> 
> **Overview**
> Adds `wolf_theorem_6_8_four_characterizations`, a *packaged* `↔` statement for Wolf Theorem 6.8/Prop. 3 that relates `IsPrimitivePaper` to the conjunction `HasEventuallyFullKrausRank ∧ IsNormal ∧ IsStronglyIrreduciblePaper`, with a docstring explicitly pointing readers to the existing pairwise `↔` lemmas.
> 
> Updates the Wolf Chapter 6 index (`WolfChapter6Index.lean`) to list both the pairwise equivalences and the new packaged-conjunction theorem to avoid misreading it as “all pairwise equivalent”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42e733cfd74556d85c26e747f91b8bd7a4813707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#64