### PR TITLE
feat(Wolf Ch2): add trace-pairing coefficients for transfer matrices

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Channel.Basic
 import TNLean.MPS.Core.Transfer
 import Mathlib.LinearAlgebra.Matrix.Vec
+import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Data.Matrix.Basis
 
 /-!
@@ -45,6 +46,57 @@ open scoped Matrix BigOperators Kronecker
 open Matrix Finset
 
 variable {D : ℕ}
+
+/-! ### Basis expansion via trace-pairing coefficients -/
+
+section TracePairingExpansion
+
+variable {ι : Type*} [Fintype ι]
+
+/-- A basis is `trace`-self-dual when its coordinate functionals are given by
+`X ↦ trace (σ i * X)`. -/
+def TracePairingSelfDualBasis
+    (σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)) : Prop :=
+  ∀ i X, σ.repr X i = Matrix.trace (σ i * X)
+
+/-- Canonical trace-pairing coefficients of a linear map in a self-dual basis. -/
+noncomputable def tracePairingCoeff
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)) (i j : ι) : ℂ :=
+  Matrix.trace (σ i * T (σ j))
+
+/-- Expansion of any linear map in a trace-pairing self-dual basis:
+`T(ρ) = ∑ᵢ ∑ⱼ tᵢⱼ • (trace (σⱼ ρ) • σᵢ)` with
+`tᵢⱼ = trace (σᵢ * T(σⱼ))`. -/
+theorem linearMap_expand_tracePairing
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ))
+    (hσ : TracePairingSelfDualBasis σ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    T ρ = ∑ i, ∑ j, tracePairingCoeff (D := D) T σ i j •
+      (Matrix.trace (σ j * ρ) • σ i) := by
+  have hT : ∀ j : ι, T (σ j) = ∑ i, σ.repr (T (σ j)) i • σ i := by
+    intro j
+    simp [σ.sum_repr]
+  rw [← σ.sum_repr ρ]
+  simp_rw [map_sum, LinearMap.map_smul]
+  have hExpand :
+      ∑ j, σ.repr ρ j • T (σ j) =
+        ∑ j, σ.repr ρ j • (∑ i, σ.repr (T (σ j)) i • σ i) := by
+    refine Finset.sum_congr rfl ?_
+    intro j hj
+    nth_rewrite 1 [hT j]
+    rfl
+  rw [hExpand]
+  simp_rw [smul_sum, smul_smul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl ?_
+  intro i hi
+  refine Finset.sum_congr rfl ?_
+  intro j hj
+  simp [tracePairingCoeff, hσ i (T (σ j)), hσ j ρ, mul_comm]
+
+end TracePairingExpansion
 
 /-! ### The transfer matrix -/
 


### PR DESCRIPTION
### Motivation
- Address the reviewer request to avoid an existential-style coefficient API and provide a named, canonical coefficient for the trace-pairing expansion. 
- Make the expansion generic (work for any linear map `T`) instead of channel-prefixed APIs so the development is reusable. 
- Ensure no unused project-local import (`TNLean.Algebra.TracePairing`) was introduced while adding only the required matrix-trace support. 

### Description
- Added `Mathlib.LinearAlgebra.Matrix.Trace` import and did not add `TNLean.Algebra.TracePairing`, keeping imports minimal. 
- Introduced `TracePairingSelfDualBasis` as a reusable `Module.Basis` property equating coordinates with the trace pairing. 
- Added a canonical coefficient definition `tracePairingCoeff (T σ i j) := trace (σ i * T (σ j))` and the expansion theorem `linearMap_expand_tracePairing` that proves `T ρ = ∑ i, ∑ j, t_{ij} • (trace (σ_j * ρ) • σ_i)`. 
- Implemented the expansion proof using `Module.Basis.sum_repr` and finite-sum rewriting without inserting `sorry` or `axiom`. 

### Testing
- Ran `lake env lean TNLean/Channel/TransferMatrix.lean` which completed successfully for the modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b85605a48324b0a06f151ddc1ea6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new definitions/lemmas and a Mathlib `Matrix.Trace` import without changing existing transfer-matrix behavior or core channel logic.
> 
> **Overview**
> Adds a small trace-pairing layer to `TransferMatrix.lean`: introduces `TracePairingSelfDualBasis`, a canonical coefficient definition `tracePairingCoeff`, and proves `linearMap_expand_tracePairing` giving an explicit double-sum expansion of `T ρ` in such a basis.
> 
> Updates imports to include `Mathlib.LinearAlgebra.Matrix.Trace` to support the new trace-based statements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1d5be084ae0298f589eed642fa6e8650323ce16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#123