### PR TITLE
[1804.04964] Clarify injectivity hypothesis in chain FT docstring

### DIFF
--- a/TNLean/MPS/Chain/FundamentalTheorem.lean
+++ b/TNLean/MPS/Chain/FundamentalTheorem.lean
@@ -53,6 +53,9 @@ theorem fundamentalTheorem_injective_chain
     (hMPV : MPSTensor.SameMPV (MPSTensor.chainCombinedTensor A)
       (MPSTensor.chainCombinedTensor B)) :
     GaugeEquiv A B := by
+  /- Note: this formulation only assumes injectivity of `A`. The proof applies
+  the single-block theorem to `chainCombinedTensor A`; no separate injectivity
+  hypothesis on `B` is required. -/
   rcases n with _ | n
   · -- n = 0: no sites, gauge equivalence is vacuously true.
     exact ⟨Fin.elim0, fun k => k.elim0⟩


### PR DESCRIPTION
### Motivation
- Remove ambiguity about an apparently unused hypothesis in `fundamentalTheorem_injective_chain` by documenting that only the injectivity of `A` is needed because the single-block FT is applied to `chainCombinedTensor A`.

### Description
- Add an in-proof explanatory comment to `fundamentalTheorem_injective_chain` in `TNLean/MPS/Chain/FundamentalTheorem.lean` noting that the proof uses injectivity of `A` (via `chainCombinedTensor A`) and does not require a separate injectivity hypothesis on `B`.

### Testing
- Ran `lake env lean TNLean/MPS/Chain/FundamentalTheorem.lean`, which succeeded.
- Ran `lake build TNLean.MPS.Chain.FundamentalTheorem`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c4693ad4832498e35b977339a94c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds an explanatory comment and does not change any proof terms or theorem statements.
> 
> **Overview**
> Adds an in-proof note in `fundamentalTheorem_injective_chain` clarifying that the chain Fundamental Theorem only requires injectivity of `A`, since the proof applies the single-block theorem to `chainCombinedTensor A` and does not need a separate injectivity hypothesis for `B`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19748468e21afa7d6adc29edd137edc4a4e6fd32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs #11