### PR TITLE
[Wolf Ch2] Polish Stinespring documentation wording

### DIFF
--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -16,6 +16,7 @@ for an explicit isometry `V` constructed from the Kraus operators.
 
 * `stinespringV`: the Stinespring isometry `V = ∑ⱼ Kⱼ ⊗ |j⟩`, a `(D·r) × D`
   matrix satisfying `V(i, j) k = (Kⱼ)_{ik}`
+* `stinespringV_apply`: entrywise evaluation lemma for `stinespringV`
 
 ## Main results (Wolf Thm 2.2)
 
@@ -77,7 +78,9 @@ theorem stinespringV_isometry_iff_kraus_normalized {r : ℕ}
   `T*(A) = V† (A ⊗ 𝟙_r) V`
 
 where `V` is the Stinespring isometry. This matches the Kraus form
-`T*(A) = ∑ⱼ Kⱼ† A Kⱼ`. -/
+`T*(A) = ∑ⱼ Kⱼ† A Kⱼ`.
+In this file, `T*` is the Heisenberg dual acting on observables, while the
+Schrödinger map uses adjoints in the opposite order. -/
 theorem stinespring_dual_representation {r : ℕ}
     (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (A : Matrix (Fin D) (Fin D) ℂ) :
     (stinespringV K)ᴴ *
@@ -103,5 +106,7 @@ theorem stinespring_schrodinger_representation {r : ℕ}
     (∑ l : Fin r, K l * X * (K l)ᴴ) i j =
     ∑ k : Fin r,
       (stinespringV K * X * (stinespringV K)ᴴ) (i, k) (j, k) := by
+  -- Use `fun l => (K l)ᴴ` inside `stinespringV` so the partial trace reproduces
+  -- the Schrödinger Kraus expansion with factors `K l * X * (K l)ᴴ`.
   simp only [Matrix.mul_apply, Matrix.sum_apply,
     stinespringV_apply, Matrix.conjTranspose_apply]


### PR DESCRIPTION
### Motivation
- Improve clarity and discoverability in `TNLean/Channel/Stinespring.lean` by listing the entrywise lemma and clarifying Heisenberg vs Schrödinger-picture comments as requested by review feedback.

### Description
- Updated the module-level docstring to list `stinespringV_apply`, expanded the `stinespring_dual_representation` doc comment to explain the Heisenberg/Schrödinger adjoint-ordering asymmetry, and added a one-line in-proof comment in `stinespring_schrodinger_representation` describing the conjugation viewpoint (`fun l => (K l)ᴴ`).

### Testing
- Built the file with `lake build TNLean.Channel.Stinespring` which succeeded, and checked `TNLean/Channel/Stinespring.lean` for `sorry`, `axiom`, or `simpa` via `rg -n "sorry|axiom|simpa" TNLean/Channel/Stinespring.lean`, which found none.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c467fd0883248e938a3c97f056c0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates (plus an explanatory in-proof comment) with no changes to definitions, statements, or proofs, so behavioral risk is minimal.
> 
> **Overview**
> Improves `TNLean/Channel/Stinespring.lean` documentation for the Stinespring dilation theorem by **listing `stinespringV_apply` in the module overview** and clarifying the **Heisenberg vs Schrödinger picture** wording in `stinespring_dual_representation`.
> 
> Adds a short explanatory comment in `stinespring_schrodinger_representation` to highlight how the Kraus/adjoint ordering corresponds to using `stinespringV` in the partial-trace expression.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fec5d56dd859a067171f2f2a3d9514b9cee5f55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#121