### PR TITLE
ci: add blueprint-Lean synchronization workflow

### DIFF
--- a/.github/workflows/blueprint-lean-sync.md
+++ b/.github/workflows/blueprint-lean-sync.md
@@ -1,0 +1,157 @@
+---
+name: Blueprint ↔ Lean Sync
+description: Weekly workflow to detect blueprint .tex annotations that are out of sync with the Lean source code and open a PR with fixes.
+on:
+  schedule: weekly on monday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+engine: copilot
+strict: true
+timeout-minutes: 30
+
+network:
+  allowed:
+    - defaults
+    - github
+
+tools:
+  github:
+    toolsets: [default, pull_requests]
+  bash:
+    - "git status"
+    - "git diff --name-only"
+    - "git log --name-only --pretty=format:"
+    - "git log --oneline"
+    - "ls"
+    - "find blueprint -type f"
+    - "find TNLean -type f -name *.lean"
+    - "grep -rn *"
+    - "sed -n *"
+    - "python3 *"
+    - "wc -l *"
+    - "cat *"
+  edit:
+
+safe-outputs:
+  create-pull-request:
+    title-prefix: "[blueprint-sync] "
+    labels: [blueprint, automation]
+    if-no-changes: "warn"
+    expires: 7d
+  noop:
+  missing-data:
+---
+
+# Blueprint ↔ Lean Sync
+
+Keep the blueprint `.tex` annotations (`\lean{}`, `\leanok`) in sync with the actual Lean 4 source code in `TNLean/`.
+
+## Background
+
+This project uses the **leanblueprint** system. Each theorem/definition/lemma in the blueprint `.tex` files (under `blueprint/src/chapter/`) can carry:
+
+- `\lean{FullyQualifiedName}` — links the statement to a Lean declaration.
+- `\leanok` — asserts the statement (or proof) has been formalized in Lean.
+- `\uses{label1, label2}` — declares dependencies on other blueprint items.
+
+The file `blueprint/lean_decls` lists all declaration names referenced from `.tex` files.
+
+## Goal
+
+Detect and fix mismatches between the blueprint annotations and the Lean source tree, then open a pull request with only those fixes.
+
+## Required process
+
+### Step 1: Run the sync checker
+
+```bash
+python3 scripts/blueprint_lean_sync.py --root . --report /tmp/sync_report.json
+```
+
+Review the output carefully. It will report:
+- Blueprint `\lean{X}` refs whose Lean declaration cannot be found.
+- `\leanok` tags on items whose declaration is missing from Lean source.
+- Stale entries in `blueprint/lean_decls`.
+- Blueprint refs missing from `lean_decls`.
+
+### Step 2: Investigate each mismatch
+
+For each reported issue, determine the root cause:
+
+1. **Renamed declaration**: The Lean decl was renamed but the `.tex` wasn't updated.
+   - Search for likely matches: `grep -rn "partial_old_name" TNLean/`
+   - Update the `\lean{OldName}` to `\lean{NewName}` in the `.tex` file.
+
+2. **Moved to different namespace**: The declaration moved namespaces.
+   - Search broadly: `grep -rn "short_name" TNLean/`
+   - Update the fully-qualified name in `\lean{}`.
+
+3. **Deleted declaration**: The Lean declaration was intentionally removed.
+   - Remove the `\lean{}` and `\leanok` annotations from the `.tex` file.
+   - If the entire blueprint item is obsolete, note it but do NOT delete the math content.
+
+4. **Multi-declaration references**: Some `\lean{}` tags list multiple declarations separated by commas (e.g., `\lean{Foo, Bar}`). Each must be checked individually.
+
+5. **lean_decls drift**: If the `.tex` refs are correct but `lean_decls` is stale:
+   - Run `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
+
+### Step 3: Verify fixes
+
+After making changes, re-run the sync checker to confirm all issues are resolved:
+
+```bash
+python3 scripts/blueprint_lean_sync.py --root . --ci
+```
+
+### Step 4: Check for new formalizations
+
+Look at recent commits (last 14 days) that added new Lean declarations:
+
+```bash
+git log --since="14 days ago" --name-only --pretty=format: -- 'TNLean/**/*.lean' | sort -u
+```
+
+For each new `.lean` file or significantly changed file, check if corresponding blueprint items should gain `\leanok` or `\lean{}` annotations. Specifically:
+
+- If a blueprint item has `\lean{X}` but no `\leanok`, and the Lean declaration `X` now exists and is fully proven (not `sorry`), add `\leanok`.
+- If a new Lean declaration matches a blueprint item that has no `\lean{}` yet, add the `\lean{NewDecl}` annotation.
+
+To check for `sorry` in declarations:
+```bash
+grep -n "sorry" TNLean/path/to/file.lean
+```
+
+## Scope rules
+
+- Only modify files under `blueprint/src/chapter/` and `blueprint/lean_decls`.
+- Do NOT modify Lean source files.
+- Do NOT change mathematical content in `.tex` files — only update `\lean{}`, `\leanok`, and `\uses{}` annotations.
+- Preserve the existing `.tex` formatting and style exactly.
+
+## Pull request requirements
+
+When you make updates, create a PR that includes:
+
+- A summary table of sync issues found and how each was resolved
+- Which `.tex` files were modified
+- Whether `lean_decls` was updated
+- The current formalization progress (from the sync checker output)
+
+## Safety and quality constraints
+
+- Never add `\leanok` unless you have confirmed the Lean declaration exists AND does not contain `sorry`.
+- Never remove mathematical content from `.tex` files.
+- When unsure about a rename, prefer leaving the annotation as-is and noting it in the PR description rather than guessing.
+- If too many issues exist to safely resolve in one PR, fix the clear cases and note the ambiguous ones.
+- If information is missing to make a safe update, call `missing-data`.
+
+**Important**: If no action is needed after completing your analysis, you **MUST** call the `noop` safe-output tool with a brief explanation. Failing to call any safe-output tool is the most common cause of safe-output workflow failures.
+
+```json
+{"noop": {"message": "No action needed: blueprint annotations are in sync with Lean source code."}}
+```

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""
+r"""
 Blueprint ↔ Lean code synchronisation checker.
 
 Parses the blueprint .tex files for \lean{DeclName} and \leanok annotations,
@@ -30,12 +30,15 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 _LEAN_DECL_RE = re.compile(
-    r"^\s*(?:@\[.*?\]\s*)?(?:noncomputable\s+)?(?:protected\s+)?(?:private\s+)?(?:def|theorem|lemma|abbrev|instance|class|structure|inductive|axiom|opaque)\s+([\w.'+]+)",
+    r"^\s*(?:@\[.*?\]\s*)?(?:(?:noncomputable|protected|private)\s+)*(?:def|theorem|lemma|abbrev|instance|class|structure|inductive|axiom|opaque)\s+([\w.'+]+)",
     re.MULTILINE,
 )
 
 _NAMESPACE_OPEN_RE = re.compile(r"^\s*namespace\s+([\w.]+)", re.MULTILINE)
-_SECTION_OPEN_RE = re.compile(r"^\s*(?:noncomputable\s+)?section\s+([\w.]+)", re.MULTILINE)
+_SECTION_OPEN_RE = re.compile(
+    r"^\s*(?:(?:noncomputable|private|protected|local)\s+)*section\s+([\w.]+)",
+    re.MULTILINE,
+)
 _NAMESPACE_CLOSE_RE = re.compile(r"^\s*end\s+([\w.]+)", re.MULTILINE)
 
 _TEX_LEAN_RE = re.compile(r"\\lean\{([^}]+)\}")
@@ -238,6 +241,7 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
             # Inside a proof block: detect \leanok on its own line
             if in_proof and current_proof and _TEX_LEANOK_RE.search(line):
                 current_proof["has_leanok"] = True
+                continue
 
             # Proof end
             m = _TEX_PROOF_END_RE.search(line)

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""
+Blueprint ↔ Lean code synchronisation checker.
+
+Parses the blueprint .tex files for \lean{DeclName} and \leanok annotations,
+then greps the Lean source tree for matching declarations.  Reports:
+
+  1. Blueprint references whose Lean declaration cannot be found.
+  2. \leanok tags on items whose declaration is missing from the Lean source.
+  3. lean_decls entries that don't appear in any .tex file (stale entries).
+  4. \lean{} refs that are not listed in lean_decls (missing entries).
+  5. Summary statistics (formalization progress per chapter).
+
+Exit code 0  → everything in sync.
+Exit code 1  → mismatches found (details on stdout / in report file).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Lean declaration keywords that start a new declaration
+_LEAN_DECL_KW = r"(?:def|theorem|lemma|abbrev|instance|class|structure|inductive|noncomputable\s+def|noncomputable\s+abbrev|protected\s+def|private\s+def|@\[.*?\]\s*(?:def|theorem|lemma|abbrev|instance|class|structure|inductive))"
+
+_LEAN_DECL_RE = re.compile(
+    r"^\s*(?:@\[.*?\]\s*)?(?:noncomputable\s+)?(?:protected\s+)?(?:private\s+)?(?:def|theorem|lemma|abbrev|instance|class|structure|inductive)\s+([\w.]+)",
+    re.MULTILINE,
+)
+
+_NAMESPACE_OPEN_RE = re.compile(r"^\s*namespace\s+([\w.]+)", re.MULTILINE)
+_NAMESPACE_CLOSE_RE = re.compile(r"^\s*end\s+([\w.]+)", re.MULTILINE)
+
+_TEX_LEAN_RE = re.compile(r"\\lean\{([^}]+)\}")
+_TEX_LEANOK_RE = re.compile(r"\\leanok")
+_TEX_ENV_BEGIN_RE = re.compile(
+    r"\\begin\{(definition|theorem|lemma|proposition|corollary|remark|example)\}"
+    r"(?:\[.*?\])?"
+    r"(?:\\label\{([^}]+)\})?"
+)
+_TEX_ENV_END_RE = re.compile(
+    r"\\end\{(definition|theorem|lemma|proposition|corollary|remark|example)\}"
+)
+_TEX_PROOF_BEGIN_RE = re.compile(r"\\begin\{proof\}")
+_TEX_PROOF_END_RE = re.compile(r"\\end\{proof\}")
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BlueprintEntry:
+    """A single blueprint environment that references a Lean declaration."""
+    file: str
+    line: int
+    env_type: str          # definition, theorem, lemma, …
+    label: str | None
+    lean_decl: str         # the \lean{X} name
+    has_leanok: bool       # whether \leanok appears on the statement
+    proof_has_leanok: bool  # whether the proof block has \leanok
+
+
+@dataclass
+class LeanDecl:
+    """A Lean declaration found in the source tree."""
+    file: str
+    line: int
+    fqn: str  # fully-qualified name including namespace
+
+
+@dataclass
+class SyncReport:
+    """Aggregated sync report."""
+    blueprint_entries: list[BlueprintEntry] = field(default_factory=list)
+    lean_decls: dict[str, LeanDecl] = field(default_factory=dict)
+    # Problems
+    missing_in_lean: list[BlueprintEntry] = field(default_factory=list)
+    leanok_but_missing: list[BlueprintEntry] = field(default_factory=list)
+    stale_lean_decls: list[str] = field(default_factory=list)
+    missing_from_lean_decls_file: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not (
+            self.missing_in_lean
+            or self.leanok_but_missing
+            or self.stale_lean_decls
+            or self.missing_from_lean_decls_file
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parse Lean source tree
+# ---------------------------------------------------------------------------
+
+def collect_lean_decls(lean_root: Path) -> dict[str, LeanDecl]:
+    """Walk all .lean files and return {fqn: LeanDecl}."""
+    decls: dict[str, LeanDecl] = {}
+
+    for lean_file in sorted(lean_root.rglob("*.lean")):
+        text = lean_file.read_text(errors="replace")
+        lines = text.splitlines()
+
+        # Track namespace stack
+        ns_stack: list[str] = []
+
+        for i, line in enumerate(lines, 1):
+            # Namespace open
+            m = _NAMESPACE_OPEN_RE.match(line)
+            if m:
+                ns_stack.append(m.group(1))
+                continue
+
+            # Namespace close
+            m = _NAMESPACE_CLOSE_RE.match(line)
+            if m:
+                closed = m.group(1)
+                # Pop matching namespace(s)
+                if ns_stack and ns_stack[-1] == closed:
+                    ns_stack.pop()
+                elif ns_stack:
+                    # Try to find it further up
+                    for j in range(len(ns_stack) - 1, -1, -1):
+                        if ns_stack[j] == closed:
+                            ns_stack = ns_stack[:j]
+                            break
+                continue
+
+            # Declaration
+            m = _LEAN_DECL_RE.match(line)
+            if m:
+                short_name = m.group(1)
+                # If the short name already contains dots, it's already qualified
+                if "." in short_name:
+                    fqn = short_name
+                else:
+                    prefix = ".".join(ns_stack) + "." if ns_stack else ""
+                    fqn = prefix + short_name
+                rel = str(lean_file.relative_to(lean_root.parent))
+                decls[fqn] = LeanDecl(file=rel, line=i, fqn=fqn)
+
+    return decls
+
+
+# ---------------------------------------------------------------------------
+# Parse blueprint .tex files
+# ---------------------------------------------------------------------------
+
+def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
+    """Parse all chapter .tex files for \\lean{} and \\leanok."""
+    entries: list[BlueprintEntry] = []
+    chapter_dir = blueprint_src / "chapter"
+    if not chapter_dir.exists():
+        return entries
+
+    for tex_file in sorted(chapter_dir.glob("*.tex")):
+        text = tex_file.read_text(errors="replace")
+        lines = text.splitlines()
+
+        # State machine: track current environment
+        env_stack: list[dict] = []
+        in_proof = False
+        current_proof: dict | None = None
+
+        for i, line in enumerate(lines, 1):
+            # Check for environment begin
+            m = _TEX_ENV_BEGIN_RE.search(line)
+            if m:
+                env = {
+                    "type": m.group(1),
+                    "label": m.group(2),
+                    "file": str(tex_file.relative_to(blueprint_src.parent)),
+                    "line": i,
+                    "lean_decls": [],
+                    "has_leanok": bool(_TEX_LEANOK_RE.search(line)),
+                }
+                env_stack.append(env)
+                # Check rest of line for \lean{} and \leanok
+                for lm in _TEX_LEAN_RE.finditer(line):
+                    env["lean_decls"].append(lm.group(1))
+                continue
+
+            # Check for environment end
+            m = _TEX_ENV_END_RE.search(line)
+            if m and env_stack:
+                env = env_stack.pop()
+                for decl in env["lean_decls"]:
+                    entries.append(BlueprintEntry(
+                        file=env["file"],
+                        line=env["line"],
+                        env_type=env["type"],
+                        label=env["label"],
+                        lean_decl=decl,
+                        has_leanok=env["has_leanok"],
+                        proof_has_leanok=False,
+                    ))
+                continue
+
+            # Proof begin
+            m = _TEX_PROOF_BEGIN_RE.search(line)
+            if m:
+                in_proof = True
+                current_proof = {
+                    "has_leanok": bool(_TEX_LEANOK_RE.search(line)),
+                }
+                continue
+
+            # Proof end
+            m = _TEX_PROOF_END_RE.search(line)
+            if m and in_proof:
+                # Attach proof leanok to last entry if applicable
+                if entries and current_proof and current_proof["has_leanok"]:
+                    entries[-1] = BlueprintEntry(
+                        file=entries[-1].file,
+                        line=entries[-1].line,
+                        env_type=entries[-1].env_type,
+                        label=entries[-1].label,
+                        lean_decl=entries[-1].lean_decl,
+                        has_leanok=entries[-1].has_leanok,
+                        proof_has_leanok=True,
+                    )
+                in_proof = False
+                current_proof = None
+                continue
+
+            # Inside an environment: collect \lean{} and \leanok
+            if env_stack:
+                for lm in _TEX_LEAN_RE.finditer(line):
+                    env_stack[-1]["lean_decls"].append(lm.group(1))
+                if _TEX_LEANOK_RE.search(line):
+                    env_stack[-1]["has_leanok"] = True
+
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Read lean_decls file
+# ---------------------------------------------------------------------------
+
+def read_lean_decls_file(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {line.strip() for line in path.read_text().splitlines() if line.strip()}
+
+
+# ---------------------------------------------------------------------------
+# Run sync check
+# ---------------------------------------------------------------------------
+
+def run_sync(
+    root: Path,
+    *,
+    report_file: Path | None = None,
+    update_lean_decls: bool = False,
+) -> SyncReport:
+    lean_root = root / "TNLean"
+    blueprint_src = root / "blueprint" / "src"
+    lean_decls_path = root / "blueprint" / "lean_decls"
+
+    report = SyncReport()
+
+    # 1. Collect Lean declarations
+    print("Scanning Lean source tree …")
+    report.lean_decls = collect_lean_decls(lean_root)
+    print(f"  Found {len(report.lean_decls)} declarations in Lean source")
+
+    # 2. Collect blueprint entries
+    print("Scanning blueprint .tex files …")
+    report.blueprint_entries = collect_blueprint_entries(blueprint_src)
+    print(f"  Found {len(report.blueprint_entries)} \\lean{{}} references in blueprint")
+
+    # 3. Cross-reference
+    blueprint_decl_names: set[str] = set()
+    for entry in report.blueprint_entries:
+        blueprint_decl_names.add(entry.lean_decl)
+        if entry.lean_decl not in report.lean_decls:
+            report.missing_in_lean.append(entry)
+            if entry.has_leanok:
+                report.leanok_but_missing.append(entry)
+
+    # 4. Check lean_decls file
+    existing_lean_decls = read_lean_decls_file(lean_decls_path)
+    for name in sorted(existing_lean_decls - blueprint_decl_names):
+        report.stale_lean_decls.append(name)
+    for name in sorted(blueprint_decl_names - existing_lean_decls):
+        report.missing_from_lean_decls_file.append(name)
+
+    # 5. Optionally update lean_decls
+    if update_lean_decls:
+        sorted_decls = sorted(blueprint_decl_names)
+        lean_decls_path.write_text("\n".join(sorted_decls) + "\n")
+        print(f"  Updated {lean_decls_path} with {len(sorted_decls)} entries")
+
+    # 6. Print report
+    _print_report(report, root)
+
+    # 7. Write JSON report
+    if report_file:
+        _write_json_report(report, report_file, root)
+
+    return report
+
+
+def _chapter_stats(report: SyncReport) -> dict[str, dict]:
+    """Per-chapter formalization progress."""
+    stats: dict[str, dict] = {}
+    for entry in report.blueprint_entries:
+        chapter = entry.file
+        if chapter not in stats:
+            stats[chapter] = {
+                "total": 0,
+                "formalized": 0,
+                "proof_formalized": 0,
+                "missing_lean": 0,
+            }
+        s = stats[chapter]
+        s["total"] += 1
+        found = entry.lean_decl in report.lean_decls
+        if entry.has_leanok and found:
+            s["formalized"] += 1
+        if entry.proof_has_leanok and found:
+            s["proof_formalized"] += 1
+        if not found:
+            s["missing_lean"] += 1
+    return stats
+
+
+def _print_report(report: SyncReport, root: Path) -> None:
+    print()
+    print("=" * 70)
+    print("  BLUEPRINT ↔ LEAN SYNC REPORT")
+    print("=" * 70)
+
+    # Per-chapter stats
+    stats = _chapter_stats(report)
+    print()
+    print("Per-chapter formalization progress:")
+    print(f"  {'Chapter':<50} {'Done':>5} / {'Total':>5}  {'%':>6}")
+    print("  " + "-" * 68)
+    total_done = 0
+    total_all = 0
+    for chapter in sorted(stats):
+        s = stats[chapter]
+        pct = 100 * s["formalized"] / s["total"] if s["total"] else 0
+        short = chapter.replace("blueprint/src/chapter/", "")
+        print(f"  {short:<50} {s['formalized']:>5} / {s['total']:>5}  {pct:>5.1f}%")
+        total_done += s["formalized"]
+        total_all += s["total"]
+    pct = 100 * total_done / total_all if total_all else 0
+    print("  " + "-" * 68)
+    print(f"  {'TOTAL':<50} {total_done:>5} / {total_all:>5}  {pct:>5.1f}%")
+
+    # Missing in Lean
+    if report.missing_in_lean:
+        print()
+        print(f"Blueprint refs with NO matching Lean declaration ({len(report.missing_in_lean)}):")
+        seen: set[str] = set()
+        for entry in report.missing_in_lean:
+            if entry.lean_decl not in seen:
+                seen.add(entry.lean_decl)
+                ok_tag = " [has \\leanok!]" if entry.has_leanok else ""
+                print(f"  ✗ {entry.lean_decl}{ok_tag}")
+                print(f"    {entry.file}:{entry.line} ({entry.env_type})")
+
+    # leanok but missing
+    if report.leanok_but_missing:
+        print()
+        print(f"WARNING: \\leanok on items whose Lean decl is MISSING ({len(report.leanok_but_missing)}):")
+        seen2: set[str] = set()
+        for entry in report.leanok_but_missing:
+            if entry.lean_decl not in seen2:
+                seen2.add(entry.lean_decl)
+                print(f"  ⚠ {entry.lean_decl}  ({entry.file}:{entry.line})")
+
+    # Stale lean_decls
+    if report.stale_lean_decls:
+        print()
+        print(f"Stale entries in lean_decls (not in any .tex) ({len(report.stale_lean_decls)}):")
+        for name in report.stale_lean_decls:
+            print(f"  − {name}")
+
+    # Missing from lean_decls
+    if report.missing_from_lean_decls_file:
+        print()
+        print(f"Blueprint refs missing from lean_decls file ({len(report.missing_from_lean_decls_file)}):")
+        for name in report.missing_from_lean_decls_file:
+            print(f"  + {name}")
+
+    # Summary
+    print()
+    if report.ok:
+        print("✓ Blueprint and Lean code are in sync.")
+    else:
+        problems = (
+            len(report.missing_in_lean)
+            + len(report.stale_lean_decls)
+            + len(report.missing_from_lean_decls_file)
+        )
+        print(f"✗ Found {problems} sync issue(s). See details above.")
+    print()
+
+
+def _write_json_report(report: SyncReport, path: Path, root: Path) -> None:
+    data = {
+        "sync_ok": report.ok,
+        "total_blueprint_refs": len(report.blueprint_entries),
+        "total_lean_decls": len(report.lean_decls),
+        "missing_in_lean": [
+            {"decl": e.lean_decl, "file": e.file, "line": e.line, "has_leanok": e.has_leanok}
+            for e in report.missing_in_lean
+        ],
+        "leanok_but_missing": [
+            {"decl": e.lean_decl, "file": e.file, "line": e.line}
+            for e in report.leanok_but_missing
+        ],
+        "stale_lean_decls": report.stale_lean_decls,
+        "missing_from_lean_decls_file": report.missing_from_lean_decls_file,
+        "chapter_stats": _chapter_stats(report),
+    }
+    path.write_text(json.dumps(data, indent=2) + "\n")
+    print(f"JSON report written to {path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check synchronisation between blueprint .tex and Lean source."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Repository root (default: auto-detected)",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Write JSON report to this file",
+    )
+    parser.add_argument(
+        "--update-lean-decls",
+        action="store_true",
+        help="Rewrite blueprint/lean_decls from current .tex refs",
+    )
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="Exit with code 1 on mismatches (for CI)",
+    )
+    args = parser.parse_args()
+
+    report = run_sync(
+        args.root,
+        report_file=args.report,
+        update_lean_decls=args.update_lean_decls,
+    )
+
+    if args.ci and not report.ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -30,11 +30,12 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 _LEAN_DECL_RE = re.compile(
-    r"^\s*(?:@\[.*?\]\s*)?(?:noncomputable\s+)?(?:protected\s+)?(?:private\s+)?(?:def|theorem|lemma|abbrev|instance|class|structure|inductive)\s+([\w.]+)",
+    r"^\s*(?:@\[.*?\]\s*)?(?:noncomputable\s+)?(?:protected\s+)?(?:private\s+)?(?:def|theorem|lemma|abbrev|instance|class|structure|inductive|axiom|opaque)\s+([\w.'+]+)",
     re.MULTILINE,
 )
 
 _NAMESPACE_OPEN_RE = re.compile(r"^\s*namespace\s+([\w.]+)", re.MULTILINE)
+_SECTION_OPEN_RE = re.compile(r"^\s*section\s+([\w.]+)", re.MULTILINE)
 _NAMESPACE_CLOSE_RE = re.compile(r"^\s*end\s+([\w.]+)", re.MULTILINE)
 
 _TEX_LEAN_RE = re.compile(r"\\lean\{([^}]+)\}")
@@ -108,8 +109,9 @@ def collect_lean_decls(lean_root: Path) -> dict[str, LeanDecl]:
         text = lean_file.read_text(errors="replace")
         lines = text.splitlines()
 
-        # Track namespace stack
+        # Track namespace and section stacks separately
         ns_stack: list[str] = []
+        section_stack: list[str] = []
 
         for i, line in enumerate(lines, 1):
             # Namespace open
@@ -118,15 +120,24 @@ def collect_lean_decls(lean_root: Path) -> dict[str, LeanDecl]:
                 ns_stack.append(m.group(1))
                 continue
 
-            # Namespace close
+            # Section open (tracked to avoid confusing `end Section` with namespace close)
+            m = _SECTION_OPEN_RE.match(line)
+            if m:
+                section_stack.append(m.group(1))
+                continue
+
+            # Namespace/section close
             m = _NAMESPACE_CLOSE_RE.match(line)
             if m:
                 closed = m.group(1)
-                # Pop matching namespace(s)
+                # Check if this closes a section first
+                if section_stack and section_stack[-1] == closed:
+                    section_stack.pop()
+                    continue
+                # Otherwise pop matching namespace
                 if ns_stack and ns_stack[-1] == closed:
                     ns_stack.pop()
                 elif ns_stack:
-                    # Try to find it further up
                     for j in range(len(ns_stack) - 1, -1, -1):
                         if ns_stack[j] == closed:
                             ns_stack = ns_stack[:j]

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -11,8 +11,8 @@ then greps the Lean source tree for matching declarations.  Reports:
   4. \lean{} refs that are not listed in lean_decls (missing entries).
   5. Summary statistics (formalization progress per chapter).
 
-Exit code 0  → everything in sync.
-Exit code 1  → mismatches found (details on stdout / in report file).
+Exit code 0  → everything in sync (or --ci not passed).
+Exit code 1  → mismatches found AND --ci flag is active.
 """
 
 from __future__ import annotations
@@ -35,7 +35,7 @@ _LEAN_DECL_RE = re.compile(
 )
 
 _NAMESPACE_OPEN_RE = re.compile(r"^\s*namespace\s+([\w.]+)", re.MULTILINE)
-_SECTION_OPEN_RE = re.compile(r"^\s*section\s+([\w.]+)", re.MULTILINE)
+_SECTION_OPEN_RE = re.compile(r"^\s*(?:noncomputable\s+)?section\s+([\w.]+)", re.MULTILINE)
 _NAMESPACE_CLOSE_RE = re.compile(r"^\s*end\s+([\w.]+)", re.MULTILINE)
 
 _TEX_LEAN_RE = re.compile(r"\\lean\{([^}]+)\}")
@@ -220,7 +220,10 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                     ))
                 env["_entry_start"] = env_entry_start
                 env["_entry_end"] = len(entries)
-                last_env = env
+                # Only track as last_env if it produced lean entries, so an
+                # intervening remark without \lean{} doesn't steal the proof.
+                if env_entry_start < len(entries):
+                    last_env = env
                 continue
 
             # Proof begin
@@ -292,6 +295,11 @@ def run_sync(
     lean_root = root / "TNLean"
     blueprint_src = root / "blueprint" / "src"
     lean_decls_path = root / "blueprint" / "lean_decls"
+
+    if not lean_root.is_dir():
+        raise FileNotFoundError(f"Lean source directory not found: {lean_root}")
+    if not blueprint_src.is_dir():
+        raise FileNotFoundError(f"Blueprint source directory not found: {blueprint_src}")
 
     report = SyncReport()
 

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -30,9 +30,6 @@ from pathlib import Path
 # Helpers
 # ---------------------------------------------------------------------------
 
-# Lean declaration keywords that start a new declaration
-_LEAN_DECL_KW = r"(?:def|theorem|lemma|abbrev|instance|class|structure|inductive|noncomputable\s+def|noncomputable\s+abbrev|protected\s+def|private\s+def|@\[.*?\]\s*(?:def|theorem|lemma|abbrev|instance|class|structure|inductive))"
-
 _LEAN_DECL_RE = re.compile(
     r"^\s*(?:@\[.*?\]\s*)?(?:noncomputable\s+)?(?:protected\s+)?(?:private\s+)?(?:def|theorem|lemma|abbrev|instance|class|structure|inductive)\s+([\w.]+)",
     re.MULTILINE,
@@ -172,6 +169,7 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
         env_stack: list[dict] = []
         in_proof = False
         current_proof: dict | None = None
+        last_env: dict | None = None  # last closed environment
 
         for i, line in enumerate(lines, 1):
             # Check for environment begin
@@ -188,13 +186,17 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                 env_stack.append(env)
                 # Check rest of line for \lean{} and \leanok
                 for lm in _TEX_LEAN_RE.finditer(line):
-                    env["lean_decls"].append(lm.group(1))
+                    for decl in lm.group(1).split(","):
+                        decl = decl.strip()
+                        if decl:
+                            env["lean_decls"].append(decl)
                 continue
 
             # Check for environment end
             m = _TEX_ENV_END_RE.search(line)
             if m and env_stack:
                 env = env_stack.pop()
+                env_entry_start = len(entries)
                 for decl in env["lean_decls"]:
                     entries.append(BlueprintEntry(
                         file=env["file"],
@@ -205,6 +207,9 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                         has_leanok=env["has_leanok"],
                         proof_has_leanok=False,
                     ))
+                env["_entry_start"] = env_entry_start
+                env["_entry_end"] = len(entries)
+                last_env = env
                 continue
 
             # Proof begin
@@ -219,17 +224,19 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
             # Proof end
             m = _TEX_PROOF_END_RE.search(line)
             if m and in_proof:
-                # Attach proof leanok to last entry if applicable
-                if entries and current_proof and current_proof["has_leanok"]:
-                    entries[-1] = BlueprintEntry(
-                        file=entries[-1].file,
-                        line=entries[-1].line,
-                        env_type=entries[-1].env_type,
-                        label=entries[-1].label,
-                        lean_decl=entries[-1].lean_decl,
-                        has_leanok=entries[-1].has_leanok,
-                        proof_has_leanok=True,
-                    )
+                # Attach proof leanok to all entries from the preceding environment
+                if current_proof and current_proof["has_leanok"] and last_env:
+                    for idx in range(last_env["_entry_start"], last_env["_entry_end"]):
+                        e = entries[idx]
+                        entries[idx] = BlueprintEntry(
+                            file=e.file,
+                            line=e.line,
+                            env_type=e.env_type,
+                            label=e.label,
+                            lean_decl=e.lean_decl,
+                            has_leanok=e.has_leanok,
+                            proof_has_leanok=True,
+                        )
                 in_proof = False
                 current_proof = None
                 continue
@@ -237,7 +244,10 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
             # Inside an environment: collect \lean{} and \leanok
             if env_stack:
                 for lm in _TEX_LEAN_RE.finditer(line):
-                    env_stack[-1]["lean_decls"].append(lm.group(1))
+                    for decl in lm.group(1).split(","):
+                        decl = decl.strip()
+                        if decl:
+                            env_stack[-1]["lean_decls"].append(decl)
                 if _TEX_LEANOK_RE.search(line):
                     env_stack[-1]["has_leanok"] = True
 
@@ -353,7 +363,7 @@ def _print_report(report: SyncReport, root: Path) -> None:
     for chapter in sorted(stats):
         s = stats[chapter]
         pct = 100 * s["formalized"] / s["total"] if s["total"] else 0
-        short = chapter.replace("blueprint/src/chapter/", "")
+        short = chapter.replace("src/chapter/", "")
         print(f"  {short:<50} {s['formalized']:>5} / {s['total']:>5}  {pct:>5.1f}%")
         total_done += s["formalized"]
         total_all += s["total"]

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -138,14 +137,15 @@ def collect_lean_decls(lean_root: Path) -> dict[str, LeanDecl]:
             m = _LEAN_DECL_RE.match(line)
             if m:
                 short_name = m.group(1)
-                # If the short name already contains dots, it's already qualified
-                if "." in short_name:
-                    fqn = short_name
-                else:
-                    prefix = ".".join(ns_stack) + "." if ns_stack else ""
-                    fqn = prefix + short_name
+                prefix = ".".join(ns_stack) + "." if ns_stack else ""
+                fqn = prefix + short_name
                 rel = str(lean_file.relative_to(lean_root.parent))
                 decls[fqn] = LeanDecl(file=rel, line=i, fqn=fqn)
+                # Also store without namespace prefix if the name already
+                # contains dots (e.g. `Foo.bar` at top level), so both
+                # the bare dotted name and the fully-qualified name match.
+                if "." in short_name and fqn != short_name:
+                    decls[short_name] = LeanDecl(file=rel, line=i, fqn=fqn)
 
     return decls
 
@@ -220,6 +220,10 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                     "has_leanok": bool(_TEX_LEANOK_RE.search(line)),
                 }
                 continue
+
+            # Inside a proof block: detect \leanok on its own line
+            if in_proof and current_proof and _TEX_LEANOK_RE.search(line):
+                current_proof["has_leanok"] = True
 
             # Proof end
             m = _TEX_PROOF_END_RE.search(line)


### PR DESCRIPTION
## Summary

- Adds a **weekly `gh-aw` automated workflow** (`.github/workflows/blueprint-lean-sync.md`) that detects mismatches between blueprint `.tex` annotations (`\lean{}`, `\leanok`) and actual Lean declarations, then opens a PR with fixes
- Adds a **Python sync checker script** (`scripts/blueprint_lean_sync.py`) that cross-references all blueprint refs against the Lean source tree

### What the workflow does

1. Runs `scripts/blueprint_lean_sync.py` to detect: blueprint `\lean{X}` refs with no matching Lean declaration, stale `\leanok` tags, `lean_decls` drift, and new formalizations missing annotations
2. Investigates each mismatch (renamed decls, moved namespaces, deletions)
3. Fixes `.tex` annotations and `lean_decls` — never touches Lean source or math content
4. Opens a PR with a summary table of changes

### Current sync status (from test run)

- **385** blueprint refs across 13 chapters
- **92.5%** formalization progress (356/385 items with `\leanok`)
- **21** refs where Lean declaration wasn't found by name (likely namespace/rename drift)

## Test plan

- [x] Ran `python3 scripts/blueprint_lean_sync.py --root .` locally — produces correct report
- [ ] Verify `gh aw compile` generates the `.lock.yml` after merge
- [ ] Trigger workflow manually via `workflow_dispatch` to confirm end-to-end

https://claude.ai/code/session_01J1hGkHHJPJK7gDNM9YRRYt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new scheduled automation that can open PRs and relies on regex-based parsing of Lean/TeX, so false positives/negatives or overly-broad tool permissions could create noisy or incorrect sync PRs.
> 
> **Overview**
> Adds a new weekly automated workflow (`.github/workflows/blueprint-lean-sync.md`) that runs a sync process and can open labeled PRs (or `noop`/`missing-data`) to keep blueprint annotations aligned with the Lean code.
> 
> Introduces `scripts/blueprint_lean_sync.py`, a CLI that scans `TNLean/**/*.lean` for declarations (tracking namespaces/sections), parses `blueprint/src/chapter/*.tex` for `\lean{}` and statement/proof `\leanok`, and reports mismatches plus `blueprint/lean_decls` drift; it can optionally rewrite `blueprint/lean_decls` and fail CI via `--ci`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40806a3bf28864d68333ed59fe8425b09e405720. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
Addresses #116