### PR TITLE
[Wolf Ch5] Fix Schwarz docs: use module cross-ref and add theorem aliases

### DIFF
--- a/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
@@ -18,10 +18,12 @@ that appear in Wolf's notes.
 
 * `KadisonSchwarz.IsSubnormal`
 * `KadisonSchwarz.schwarz_inequality_subnormal_operator`
+* `KadisonSchwarz.wolf_theorem_5_5`
 * `KadisonSchwarz.commuting_dominant_right_bound`
 * `KadisonSchwarz.kadison_schwarz_commuting_dominant_cp_of_two_sided_bound`
 * `KadisonSchwarz.kadison_schwarz_commuting_dominant_cp`
 * `KadisonSchwarz.schwarz_inequality_commuting_dominant_operator`
+* `KadisonSchwarz.wolf_theorem_5_6`
 
 The key new result is `commuting_dominant_right_bound`: if `D ≥ 0` commutes with
 `A` and dominates `A† A`, then it also dominates `A A†`.  The proof uses the
@@ -385,13 +387,16 @@ theorem schwarz_inequality_subnormal_operator
     topLeft_schwarz_of_normal_extension (D := D) T hPos hSub
       (Matrix.fromBlocks A B 0 C) hNormal
 
+/-- Alias for `schwarz_inequality_subnormal_operator` matching Wolf Theorem 5.5. -/
+alias wolf_theorem_5_5 := schwarz_inequality_subnormal_operator
+
 /-- Linear-map wrapper for the canonical adjoint Kraus map.
 
 This bundles `KadisonSchwarz.krausAdjointMap` from `KadisonSchwarz.lean` as a
 linear map. It is convenient for reusing the generic positivity/monotonicity
 API from `PositiveMapProperties`.
 
-Note: `TNLean/Channel/Semigroup/Generator.lean` contains an older duplicate
+Note: `TNLean.Channel.Semigroup.Generator` contains an older duplicate
 formula with the same name; inside `namespace KadisonSchwarz`, this wrapper
 intentionally uses the canonical Schwarz-side definition. -/
 noncomputable def krausAdjointMapLinear (K : Fin d → Mat) : Mat →ₗ[ℂ] Mat where
@@ -699,5 +704,7 @@ theorem schwarz_inequality_commuting_dominant_operator
   exact ⟨le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).1,
          le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).2⟩
 
-end KadisonSchwarz
+/-- Alias for `schwarz_inequality_commuting_dominant_operator` matching Wolf Theorem 5.6. -/
+alias wolf_theorem_5_6 := schwarz_inequality_commuting_dominant_operator
 
+end KadisonSchwarz


### PR DESCRIPTION
### Motivation

* Address Claude review nits on the Schwarz Chapter 5 files to improve documentation style and discoverability of the Wolf theorem names.
* Make the in-module cross-reference follow the module-name backtick convention and expose the Wolf theorem names as aliases so they appear in generated docs.

### Description

* Replace a file-path cross-reference with a module-name cross-reference in backticks: `TNLean.Channel.Semigroup.Generator` (was `TNLean/Channel/Semigroup/Generator.lean`).
* Add brief docstringed alias declarations to expose the Wolf theorem names without duplicating proofs by introducing `wolf_theorem_5_5 := schwarz_inequality_subnormal_operator` and `wolf_theorem_5_6 := schwarz_inequality_commuting_dominant_operator` in `TNLean/Channel/Schwarz/SchwarzSubnormal.lean`.
* Update the module `## Main declarations` list to include `KadisonSchwarz.wolf_theorem_5_5` and `KadisonSchwarz.wolf_theorem_5_6` for discoverability and clearer mapping to Wolf Thms. 5.5/5.6.

### Testing

* Ran `lake build TNLean.Channel.Schwarz.SchwarzSubnormal TNLean.Channel.Schwarz.SchwarzNormal` and the build completed successfully for both targets.
* No `sorry` or `axiom` were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c46e4c648324b97cba92f4b95abf)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and `alias` declarations, with no modifications to core proof logic or data handling.
> 
> **Overview**
> Improves discoverability of Wolf Chapter 5 results by adding docstringed aliases `wolf_theorem_5_5` and `wolf_theorem_5_6` for the existing Schwarz inequality theorems, and listing them in the module’s **Main declarations**.
> 
> Cleans up a documentation reference by switching from a file-path mention to a module-name backticked cross-reference (`TNLean.Channel.Semigroup.Generator`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d24103a5875b126c807f16bdc2c03b85bd143fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#120