### PR TITLE
[cleanup] BlockedChainFT: term-style theorem and remove open scoped

### DIFF
--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -7,9 +7,13 @@ import TNLean.MPS.Chain.FundamentalTheorem
 This module packages a blocked-chain endpoint. The theorem
 `fundamentalTheorem_blockedChain` is stated for blocked chains built from a
 common blocking length `L`.
--/
 
-open scoped Matrix
+## Design note
+
+This endpoint is kept as a theorem with explicit assumptions (rather than
+packaging assumptions in a class) so callers can provide their own blocking
+witnesses and reuse existing hypotheses directly.
+-/
 
 namespace MPSTensor
 
@@ -74,8 +78,8 @@ theorem fundamentalTheorem_blockedChain
     (hMPV : MPSTensor.SameMPV
       (MPSTensor.chainCombinedTensor (blockedChain A L n))
       (MPSTensor.chainCombinedTensor (blockedChain B L n))) :
-    GaugeEquiv (blockedChain A L n) (blockedChain B L n) := by
-  exact fundamentalTheorem_injective_chain
+    GaugeEquiv (blockedChain A L n) (blockedChain B L n) :=
+  fundamentalTheorem_injective_chain
     (blockedChain A L n)
     (blockedChain B L n)
     (blockedChain_isInjective A L n hA_block)


### PR DESCRIPTION
### Motivation

- Address Claude's three review nits in `TNLean/MPS/Chain/BlockedChainFT.lean` to make the endpoint style consistent and to document the design choice.

### Description

- Rewrote `fundamentalTheorem_blockedChain` in term-mode as `:= fundamentalTheorem_injective_chain ...` instead of a `by ... exact ...` proof block.
- Removed the unused `open scoped Matrix` declaration from the module.
- Added a short module-level design note explaining why the blocked-chain endpoint is exposed as an explicit theorem with assumptions rather than packaged in a class.
- Performed small whitespace/formatting cleanup around the updated docstring and theorem.

### Testing

- Ran `lake build TNLean.MPS.Chain.BlockedChainFT` which completed successfully.
- Ran `lake build TNLean` which completed successfully (the build shows unrelated linter warnings but no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c8a6acb48324a9ae929c150a51f6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation and minor proof style refactor in `BlockedChainFT.lean` with no change to the underlying theorem statements or dependencies.
> 
> **Overview**
> Clarifies the `BlockedChainFT` module by removing the unused `open scoped Matrix` and adding a short **design note** explaining why the blocked-chain endpoint is exposed as an explicit theorem with assumptions.
> 
> Refactors `fundamentalTheorem_blockedChain` to term-style (`:= fundamentalTheorem_injective_chain ...`) and does small formatting cleanup, without changing the theorem’s behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42d63469bfab9ba6a46a36c90b0e020de34b783a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs #120