### PR TITLE
[1804.04964 5b] Add MPS symmetry definitions and twisted-tensor lemmas

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -96,6 +96,7 @@ import TNLean.Spectral.CrossCorrelation
 
 -- Layer 3: MPS core
 import TNLean.MPS.Defs
+import TNLean.MPS.Symmetry.Defs
 import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.TensorEquality

--- a/TNLean/MPS/Symmetry/Defs.lean
+++ b/TNLean/MPS/Symmetry/Defs.lean
@@ -1,0 +1,69 @@
+import TNLean.MPS.FundamentalTheorem.Basic
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {G : Type*} {d D : ℕ}
+
+/-- Tensor twisted by physical action of `g ∈ G`. -/
+noncomputable def twistedTensor (A : MPSTensor d D)
+    (U : G → Matrix (Fin d) (Fin d) ℂ) (g : G) : MPSTensor d D :=
+  fun i => ∑ j : Fin d, U g i j • A j
+
+/-- MPS is `G`-symmetric under on-site representation `U`. -/
+def IsOnSiteSymmetric (A : MPSTensor d D)
+    (U : G → Matrix (Fin d) (Fin d) ℂ) : Prop :=
+  ∀ g : G, SameMPV A (twistedTensor A U g)
+
+lemma twistedTensor_one (A : MPSTensor d D)
+    (U : G → Matrix (Fin d) (Fin d) ℂ) [Monoid G] (hU1 : U 1 = 1) :
+    twistedTensor A U 1 = A := by
+  ext i a b
+  simp [twistedTensor, hU1, Matrix.one_apply]
+
+lemma twistedTensor_mul (A : MPSTensor d D)
+    (U : G → Matrix (Fin d) (Fin d) ℂ) [Monoid G]
+    (hUmul : ∀ g h : G, U (g * h) = U g * U h)
+    (g h : G) :
+    twistedTensor A U (g * h) = twistedTensor (twistedTensor A U h) U g := by
+  ext i a b
+  simp only [twistedTensor, hUmul, Matrix.mul_apply]
+  calc
+    ((∑ x : Fin d, (∑ y : Fin d, U g i y * U h y x) • A x) a b)
+        = ∑ x : Fin d, (∑ y : Fin d, U g i y * U h y x) * A x a b := by
+            simp [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+    _ = ∑ x : Fin d, ∑ y : Fin d, (U g i y * U h y x) * A x a b := by
+          simp [Finset.sum_mul]
+    _ = ∑ y : Fin d, ∑ x : Fin d, (U g i y * U h y x) * A x a b := by
+          simpa using (Finset.sum_comm :
+            (∑ x : Fin d, ∑ y : Fin d, (U g i y * U h y x) * A x a b) =
+              ∑ y : Fin d, ∑ x : Fin d, (U g i y * U h y x) * A x a b)
+    _ = ∑ y : Fin d, U g i y * (∑ x : Fin d, U h y x * A x a b) := by
+          simp [Finset.mul_sum, mul_assoc]
+    _ = ((∑ y : Fin d, U g i y • ∑ x : Fin d, U h y x • A x) a b) := by
+          simp [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+
+lemma mpv_twistedTensor_eq_trace_evalWord (A : MPSTensor d D)
+    (U : G → Matrix (Fin d) (Fin d) ℂ) (g : G) {N : ℕ}
+    (σ : Fin N → Fin d) :
+    mpv (twistedTensor A U g) σ =
+      Matrix.trace (evalWord (twistedTensor A U g) (List.ofFn σ)) := by
+  simp [mpv, coeff]
+
+lemma sameMPV_twistedTensor_iff_gaugeEquiv (A : MPSTensor d D)
+    (hA : IsInjective A) (U : G → Matrix (Fin d) (Fin d) ℂ) (g : G) :
+    SameMPV A (twistedTensor A U g) ↔ GaugeEquiv A (twistedTensor A U g) := by
+  constructor
+  · intro hSame
+    exact fundamentalTheorem_singleBlock hA hSame
+  · intro hGauge
+    exact GaugeEquiv.sameMPV hGauge
+
+lemma gaugeEquiv_twistedTensor_of_injective (A : MPSTensor d D)
+    (hA : IsInjective A) (U : G → Matrix (Fin d) (Fin d) ℂ)
+    (hSymm : IsOnSiteSymmetric A U) (g : G) :
+    GaugeEquiv A (twistedTensor A U g) := by
+  exact (sameMPV_twistedTensor_iff_gaugeEquiv A hA U g).1 (hSymm g)
+
+end MPSTensor


### PR DESCRIPTION
### Motivation
- Provide the basic objects and lemmas needed to reason about on-site group symmetries of MPS: a `twistedTensor` produced by a physical on-site representation and the predicate `IsOnSiteSymmetric` that an MPS is symmetric under that action. 
- Expose the bridge from MPV equality to gauge equivalence for injective tensors so the Fundamental Theorem can be used in later symmetry/SPT developments.

### Description
- Added new module `TNLean/MPS/Symmetry/Defs.lean` that defines `twistedTensor` and `IsOnSiteSymmetric` and lives in the `MPSTensor` namespace. 
- Implemented core lemmas: `twistedTensor_one` (identity twist), `twistedTensor_mul` (composition law for twisting), and `mpv_twistedTensor_eq_trace_evalWord` (MPV expressed via `evalWord` for a twisted tensor). 
- Connected MPV equality to gauge equivalence for injective tensors via `sameMPV_twistedTensor_iff_gaugeEquiv` and provided `gaugeEquiv_twistedTensor_of_injective` which uses `fundamentalTheorem_singleBlock`. 
- Re-exported the new module from the project root by adding `import TNLean.MPS.Symmetry.Defs` to `TNLean.lean` so downstream builds see the new definitions. 
- Made small instance-scope adjustments on group/monoid assumptions in the lemmas so the proofs are provable in the existing library context.

### Testing
- Type-checked the new module with `lake env lean TNLean/MPS/Symmetry/Defs.lean`, which succeeded. 
- Built the module with `lake build TNLean.MPS.Symmetry.Defs`, which succeeded. 
- Performed a full project build with `lake build TNLean`, which completed successfully (build warnings only; no new errors or `sorry` in the added module).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c80278f083248348378504233053)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean module and a root re-export with no changes to existing logic; main risk is proof/API breakage for downstream users relying on import surfaces or lemma names.
> 
> **Overview**
> Adds first-class support for *on-site group symmetries* of MPS by introducing `MPSTensor.twistedTensor` (physical action twist) and the predicate `IsOnSiteSymmetric`.
> 
> Proves core algebraic/bridge lemmas for the new construction: identity and composition laws (`twistedTensor_one`, `twistedTensor_mul`), an MPV-to-`evalWord` trace rewriting lemma for twisted tensors, and an injective-tensor bridge from `SameMPV` to `GaugeEquiv` specialized to `twistedTensor` (via `fundamentalTheorem_singleBlock`).
> 
> Re-exports the new module from `TNLean.lean` (`import TNLean.MPS.Symmetry.Defs`) so downstream imports see the new symmetry API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3773379f56059983243faaedc8fca4990f59dcf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs #76