### PR TITLE
[Wolf Ch6] Add exponential irreducibility equivalence (Thm 6.2 item 3) v2

### DIFF
--- a/TNLean/Channel/Irreducible/Basic.lean
+++ b/TNLean/Channel/Irreducible/Basic.lean
@@ -49,6 +49,14 @@ lemma isOrthogonalProjection_zero : IsOrthogonalProjection (0 : Matrix (Fin D) (
 lemma isOrthogonalProjection_one : IsOrthogonalProjection (1 : Matrix (Fin D) (Fin D) ℂ) :=
   ⟨Matrix.isHermitian_one, by simp⟩
 
+/-- An orthogonal projection is positive semidefinite. -/
+theorem isOrthogonalProjection_posSemidef {P : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsOrthogonalProjection P) :
+    P.PosSemidef := by
+  have hPP : P = Pᴴ * P := by rw [hP.1, hP.2]
+  rw [hPP]
+  exact P.posSemidef_conjTranspose_mul_self
+
 /-! ### Irreducibility of CP maps -/
 
 /-- A CP map `E` is *irreducible* if the only orthogonal projections `P` satisfying

--- a/TNLean/Channel/Irreducible/FromSpectral.lean
+++ b/TNLean/Channel/Irreducible/FromSpectral.lean
@@ -56,28 +56,6 @@ private noncomputable def sandwichLinearMap
   map_smul' a X := by
     simp [Matrix.mul_assoc]
 
-private lemma dotProduct_mulVec_conjTranspose
-    (M : Matrix (Fin D) (Fin D) ℂ)
-    (x y : Fin D → ℂ) :
-    star x ⬝ᵥ (M *ᵥ y) = star (Mᴴ *ᵥ x) ⬝ᵥ y := by
-  rw [Matrix.dotProduct_mulVec, Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
-
-private lemma orthogonalProjection_posSemidef
-    {P : Matrix (Fin D) (Fin D) ℂ}
-    (hP : IsOrthogonalProjection P) :
-    P.PosSemidef := by
-  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg hP.1 ?_
-  intro x
-  have h₁ : star x ⬝ᵥ (P *ᵥ x) = star (P *ᵥ x) ⬝ᵥ x := by
-    simpa [hP.1.eq] using (dotProduct_mulVec_conjTranspose P x x)
-  have h₂ : star (P *ᵥ x) ⬝ᵥ x = star (P *ᵥ x) ⬝ᵥ (P *ᵥ x) := by
-    simpa [hP.1.eq, hP.2, Matrix.mulVec_mulVec] using
-      (dotProduct_mulVec_conjTranspose P (P *ᵥ x) x).symm
-  calc
-    0 ≤ star (P *ᵥ x) ⬝ᵥ (P *ᵥ x) := dotProduct_star_self_nonneg _
-    _ = star (P *ᵥ x) ⬝ᵥ x := h₂.symm
-    _ = star x ⬝ᵥ (P *ᵥ x) := h₁.symm
-
 private lemma isOrthogonalProjection_one_sub
     {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) :
@@ -94,7 +72,7 @@ private lemma trace_ne_zero_of_orthogonalProjection_ne_zero
     {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
     Matrix.trace P ≠ 0 := by
-  have hP_psd : P.PosSemidef := orthogonalProjection_posSemidef hP
+  have hP_psd : P.PosSemidef := isOrthogonalProjection_posSemidef hP
   intro htr
   exact hP_ne ((hP_psd.trace_eq_zero_iff).1 htr)
 
@@ -111,7 +89,7 @@ private lemma normalizedProjection_mem_densityMatrices
     {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
     (((Matrix.trace P)⁻¹) • P) ∈ densityMatrices D := by
-  have hP_psd : P.PosSemidef := orthogonalProjection_posSemidef hP
+  have hP_psd : P.PosSemidef := isOrthogonalProjection_posSemidef hP
   have htrP_ne : Matrix.trace P ≠ 0 := trace_ne_zero_of_orthogonalProjection_ne_zero hP hP_ne
   refine ⟨?_, ?_⟩
   · exact hP_psd.smul (inv_nonneg_of_nonneg hP_psd.trace_nonneg)

--- a/TNLean/Channel/Irreducible/Growth.lean
+++ b/TNLean/Channel/Irreducible/Growth.lean
@@ -930,14 +930,6 @@ theorem exp_posDef_of_irreducible_cp
     exact ⟨h_exp_psd.isHermitian, hq_pos⟩
   simpa [Φ] using hfinal
 
-/-- An orthogonal projection is positive semidefinite. -/
-theorem IsOrthogonalProjection.posSemidef {P : Matrix (Fin D) (Fin D) ℂ}
-    (hP : IsOrthogonalProjection P) :
-    P.PosSemidef := by
-  have hPP : P = Pᴴ * P := by rw [hP.1, hP.2]
-  rw [hPP]
-  exact P.posSemidef_conjTranspose_mul_self
-
 /-- **Wolf Theorem 6.2, item 3 (equivalence form)**:
 for a completely positive map `E`, irreducibility is equivalent to strict
 positivity of the exponential semigroup on every nonzero PSD input:
@@ -957,7 +949,7 @@ theorem irreducible_iff_exp_posDef_forall
     intro P hP hP_inv
     by_cases hP0 : P = 0
     · exact Or.inl hP0
-    · have hP_psd : P.PosSemidef := hP.posSemidef
+    · have hP_psd : P.PosSemidef := isOrthogonalProjection_posSemidef hP
       have hsemigroup_inv :
           ∀ t : ℝ, 0 ≤ t → ∀ X : Matrix (Fin D) (Fin D) ℂ,
             P * expSemigroup E t (P * X * P) * P = expSemigroup E t (P * X * P) :=

--- a/TNLean/Channel/Irreducible/Growth.lean
+++ b/TNLean/Channel/Irreducible/Growth.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Schwarz.Basic
+import TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression
 
 import Mathlib.Analysis.Normed.Algebra.Exponential
 import Mathlib.Tactic.NoncommRing
@@ -928,5 +929,53 @@ theorem exp_posDef_of_irreducible_cp
     rw [Matrix.posDef_iff_dotProduct_mulVec]
     exact ⟨h_exp_psd.isHermitian, hq_pos⟩
   simpa [Φ] using hfinal
+
+/-- **Wolf Theorem 6.2, item 3 (equivalence form)**:
+for a completely positive map `E`, irreducibility is equivalent to strict
+positivity of the exponential semigroup on every nonzero PSD input:
+`exp(tE)(A)` is positive definite for all `t > 0` and all `A ≥ 0`, `A ≠ 0`. -/
+theorem irreducible_iff_exp_posDef_forall
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hCP : IsCPMap E) :
+    IsIrreducibleMap E ↔
+      ∀ t : ℝ, 0 < t → ∀ A : Matrix (Fin D) (Fin D) ℂ, A.PosSemidef → A ≠ 0 →
+        ((NormedSpace.exp
+          ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+            ((t : ℂ) • E))) A).PosDef := by
+  constructor
+  · intro hIrr t ht A hA hA_ne
+    exact exp_posDef_of_irreducible_cp E hCP hIrr A hA hA_ne ht
+  · intro hExp
+    intro P hP hP_inv
+    by_cases hP0 : P = 0
+    · exact Or.inl hP0
+    · have hP_psd : P.PosSemidef := by
+        have hPP : P = Pᴴ * P := by rw [hP.1, hP.2]
+        rw [hPP]
+        exact P.posSemidef_conjTranspose_mul_self
+      have hsemigroup_inv :
+          ∀ t : ℝ, 0 ≤ t → ∀ X : Matrix (Fin D) (Fin D) ℂ,
+            P * expSemigroup E t (P * X * P) * P = expSemigroup E t (P * X * P) :=
+        semigroup_preserves_compression_of_generator hP (by simpa using hP_inv)
+      have hP_exp_pd : (expSemigroup E 1 P).PosDef := by
+        simpa [expSemigroup, expSemigroupCLM, one_smul] using
+          hExp 1 zero_lt_one P hP_psd hP0
+      have hcompress_at_one :
+          P * expSemigroup E 1 P * P = expSemigroup E 1 P := by
+        simpa [hP.2] using hsemigroup_inv 1 zero_le_one 1
+      have h_exp_zero_on_compl :
+          (1 - P) * expSemigroup E 1 P = 0 := by
+        calc
+          (1 - P) * expSemigroup E 1 P
+              = (1 - P) * (P * expSemigroup E 1 P * P) := by rw [hcompress_at_one]
+          _ = ((1 - P) * P) * (expSemigroup E 1 P * P) := by simp [Matrix.mul_assoc]
+          _ = 0 := by rw [sub_mul, one_mul, hP.2, sub_self, Matrix.zero_mul]
+      have h_compl_eq_zero : 1 - P = 0 := by
+        rcases Matrix.PosDef.isUnit hP_exp_pd with ⟨U, hU⟩
+        have hzero : (1 - P) * (↑U : Matrix (Fin D) (Fin D) ℂ) = 0 := by
+          simpa [hU] using h_exp_zero_on_compl
+        have hzero' := congrArg (fun M => M * ((↑U⁻¹ : Matrix (Fin D) (Fin D) ℂ))) hzero
+        simpa [Matrix.mul_assoc] using hzero'
+      exact Or.inr (by simpa [eq_comm] using sub_eq_zero.mp h_compl_eq_zero)
 
 end Exponential

--- a/TNLean/Channel/Irreducible/Growth.lean
+++ b/TNLean/Channel/Irreducible/Growth.lean
@@ -953,8 +953,7 @@ theorem irreducible_iff_exp_posDef_forall
       have hsemigroup_inv :
           ∀ t : ℝ, 0 ≤ t → ∀ X : Matrix (Fin D) (Fin D) ℂ,
             P * expSemigroup E t (P * X * P) * P = expSemigroup E t (P * X * P) :=
-        -- This `simpa` is exactly the definitional unfolding of
-        -- `GeneratorPreservesCompression E P`.
+        -- unfold `GeneratorPreservesCompression E P`
         semigroup_preserves_compression_of_generator hP (by simpa using hP_inv)
       have hP_exp_pd : (expSemigroup E 1 P).PosDef := by
         simpa [expSemigroup, expSemigroupCLM, one_smul] using
@@ -973,11 +972,8 @@ theorem irreducible_iff_exp_posDef_forall
         rcases Matrix.PosDef.isUnit hP_exp_pd with ⟨U, hU⟩
         have hzero : (1 - P) * (↑U : Matrix (Fin D) (Fin D) ℂ) = 0 := by
           simpa [hU] using h_exp_zero_on_compl
-        have hzero' : (1 - P) * (↑U : Matrix (Fin D) (Fin D) ℂ) =
-            0 * (↑U : Matrix (Fin D) (Fin D) ℂ) := by
-          simpa [zero_mul] using hzero
         have hU_unit : IsUnit (↑U : Matrix (Fin D) (Fin D) ℂ) := ⟨U, rfl⟩
-        exact IsUnit.mul_right_cancel hU_unit hzero'
+        exact IsUnit.mul_right_cancel hU_unit (by simpa [zero_mul] using hzero)
       exact Or.inr (by simpa [eq_comm] using sub_eq_zero.mp h_compl_eq_zero)
 
 end Exponential

--- a/TNLean/Channel/Irreducible/Growth.lean
+++ b/TNLean/Channel/Irreducible/Growth.lean
@@ -930,6 +930,14 @@ theorem exp_posDef_of_irreducible_cp
     exact ⟨h_exp_psd.isHermitian, hq_pos⟩
   simpa [Φ] using hfinal
 
+/-- An orthogonal projection is positive semidefinite. -/
+theorem IsOrthogonalProjection.posSemidef {P : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsOrthogonalProjection P) :
+    P.PosSemidef := by
+  have hPP : P = Pᴴ * P := by rw [hP.1, hP.2]
+  rw [hPP]
+  exact P.posSemidef_conjTranspose_mul_self
+
 /-- **Wolf Theorem 6.2, item 3 (equivalence form)**:
 for a completely positive map `E`, irreducibility is equivalent to strict
 positivity of the exponential semigroup on every nonzero PSD input:
@@ -949,13 +957,12 @@ theorem irreducible_iff_exp_posDef_forall
     intro P hP hP_inv
     by_cases hP0 : P = 0
     · exact Or.inl hP0
-    · have hP_psd : P.PosSemidef := by
-        have hPP : P = Pᴴ * P := by rw [hP.1, hP.2]
-        rw [hPP]
-        exact P.posSemidef_conjTranspose_mul_self
+    · have hP_psd : P.PosSemidef := hP.posSemidef
       have hsemigroup_inv :
           ∀ t : ℝ, 0 ≤ t → ∀ X : Matrix (Fin D) (Fin D) ℂ,
             P * expSemigroup E t (P * X * P) * P = expSemigroup E t (P * X * P) :=
+        -- This `simpa` is exactly the definitional unfolding of
+        -- `GeneratorPreservesCompression E P`.
         semigroup_preserves_compression_of_generator hP (by simpa using hP_inv)
       have hP_exp_pd : (expSemigroup E 1 P).PosDef := by
         simpa [expSemigroup, expSemigroupCLM, one_smul] using
@@ -974,8 +981,11 @@ theorem irreducible_iff_exp_posDef_forall
         rcases Matrix.PosDef.isUnit hP_exp_pd with ⟨U, hU⟩
         have hzero : (1 - P) * (↑U : Matrix (Fin D) (Fin D) ℂ) = 0 := by
           simpa [hU] using h_exp_zero_on_compl
-        have hzero' := congrArg (fun M => M * ((↑U⁻¹ : Matrix (Fin D) (Fin D) ℂ))) hzero
-        simpa [Matrix.mul_assoc] using hzero'
+        have hzero' : (1 - P) * (↑U : Matrix (Fin D) (Fin D) ℂ) =
+            0 * (↑U : Matrix (Fin D) (Fin D) ℂ) := by
+          simpa [zero_mul] using hzero
+        have hU_unit : IsUnit (↑U : Matrix (Fin D) (Fin D) ℂ) := ⟨U, rfl⟩
+        exact IsUnit.mul_right_cancel hU_unit hzero'
       exact Or.inr (by simpa [eq_comm] using sub_eq_zero.mp h_compl_eq_zero)
 
 end Exponential

--- a/TNLean/Channel/Irreducible/Similarity.lean
+++ b/TNLean/Channel/Irreducible/Similarity.lean
@@ -34,28 +34,6 @@ noncomputable def similarityMap (C : Matrix (Fin D) (Fin D) ℂ)
   map_smul' a X := by
     simp [Matrix.mul_assoc]
 
-private lemma dotProduct_mulVec_conjTranspose
-    (M : Matrix (Fin D) (Fin D) ℂ)
-    (x y : Fin D → ℂ) :
-    star x ⬝ᵥ (M *ᵥ y) = star (Mᴴ *ᵥ x) ⬝ᵥ y := by
-  rw [Matrix.dotProduct_mulVec, Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
-
-private lemma orthogonalProjection_posSemidef
-    {Q : Matrix (Fin D) (Fin D) ℂ}
-    (hQ : IsOrthogonalProjection Q) :
-    Q.PosSemidef := by
-  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg hQ.1 ?_
-  intro x
-  have h₁ : star x ⬝ᵥ (Q *ᵥ x) = star (Q *ᵥ x) ⬝ᵥ x := by
-    simpa [hQ.1.eq] using (dotProduct_mulVec_conjTranspose Q x x)
-  have h₂ : star (Q *ᵥ x) ⬝ᵥ x = star (Q *ᵥ x) ⬝ᵥ (Q *ᵥ x) := by
-    simpa [hQ.1.eq, hQ.2, Matrix.mulVec_mulVec] using
-      (dotProduct_mulVec_conjTranspose Q (Q *ᵥ x) x).symm
-  calc
-    0 ≤ star (Q *ᵥ x) ⬝ᵥ (Q *ᵥ x) := dotProduct_star_self_nonneg _
-    _ = star (Q *ᵥ x) ⬝ᵥ x := h₂.symm
-    _ = star x ⬝ᵥ (Q *ᵥ x) := h₁.symm
-
 private noncomputable def supportInv
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef) :
     Matrix (Fin D) (Fin D) ℂ :=
@@ -206,7 +184,7 @@ theorem isIrreducibleMap_similarity
     IsIrreducibleMap (similarityMap (D := D) C E) := by
   classical
   intro Q hQ_proj hQ_inv
-  have hQ_psd : Q.PosSemidef := orthogonalProjection_posSemidef hQ_proj
+  have hQ_psd : Q.PosSemidef := isOrthogonalProjection_posSemidef hQ_proj
   let R : Matrix (Fin D) (Fin D) ℂ := C * Q * Cᴴ
   have hR_psd : R.PosSemidef := by
     simpa [R, Matrix.mul_assoc] using hQ_psd.mul_mul_conjTranspose_same C


### PR DESCRIPTION
### Motivation
- Complete the formalization of Wolf Theorem 6.2 item 3 by proving the missing equivalence that a CP map `E` is irreducible iff `exp(tE)(A)` is positive definite for all `t > 0` and all nonzero `A ≥ 0`.
- Use the semigroup/Generator compression bridge so the reverse implication can be obtained from generator-level compression hypotheses.

### Description
- Added import `TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression` to access the lemma lifting generator compression to semigroup compression. 
- Added theorem `irreducible_iff_exp_posDef_forall` stating `IsIrreducibleMap E ↔ ∀ t > 0, ∀ A ≥ 0, A ≠ 0 → exp(tE)(A).PosDef` and documented it as Wolf Thm 6.2 item 3 in equivalence form.
- The forward implication reuses the existing `exp_posDef_of_irreducible_cp`, while the reverse implication converts a nontrivial invariant projection into semigroup compression at `t = 1`, applies the hypothesis to `A = P`, and cancels with the invertibility/unit property of the positive-definite output to force `P = 1`.

### Testing
- Ran `lake env lean TNLean/Channel/Irreducible/Growth.lean` and the file typechecked successfully (with a single non-fatal style suggestion reported). 
- Scanned the modified file for placeholders with `rg` and confirmed no `sorry`/`axiom` occur in `TNLean/Channel/Irreducible/Growth.lean`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c46e0acc8324b3fe0d09af4418f4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems/lemmas and refactors duplicated proofs without changing any runtime behavior.
> 
> **Overview**
> Formalizes Wolf Thm 6.2(3) as a new equivalence `irreducible_iff_exp_posDef_forall`, showing `IsIrreducibleMap E` iff `exp(t•E)` sends every nonzero PSD matrix to a positive-definite one (for all `t > 0`).
> 
> Introduces a shared lemma `isOrthogonalProjection_posSemidef` in `Irreducible/Basic.lean` and replaces duplicated local PSD proofs in `FromSpectral.lean` and `Similarity.lean` with this lemma. The reverse direction of the new equivalence bridges generator-level compression to semigroup compression via the new `GeneratorCompression` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecaaaea32dce632a0f93915169cb3659a569522b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs LionSR/QICLean#122