### PR TITLE
[1708.00029 4/5] Refactor SectorDecomposition proof names

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -496,9 +496,9 @@ theorem weight_multiset_eq_of_sameMPV_bnt
     ∀ j : Fin g,
       Finset.univ.val.map (S.weight j) =
         Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
-  obtain ⟨N0, hN0⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
-  have hAll := eventually_coeff_eq_implies_all_pos_eq S T hCopies hN0
-  exact weight_multiset_eq_of_copies_eq_of_coeff_eq S T hCopies hAll
+  obtain ⟨N0, hCoeffEventuallyEq⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
+  have hCoeffAllPosEq := eventually_coeff_eq_implies_all_pos_eq S T hCopies hCoeffEventuallyEq
+  exact weight_multiset_eq_of_copies_eq_of_coeff_eq S T hCopies hCoeffAllPosEq
 
 end SectorWeightData
 
@@ -548,12 +548,12 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition
         Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
   apply SectorWeightData.weight_multiset_eq_of_sameMPV_bnt basis S T hCopies hLI
   intro N σ
-  have hP := (SectorDecomposition.mk g dim basis S).mpv_toTensor_eq_sum_coeff σ (N := N)
-  have hQ := (SectorDecomposition.mk g dim basis T).mpv_toTensor_eq_sum_coeff σ (N := N)
-  -- hP and hQ unfold to the coefficient expansion; the goal is definitionally equivalent
+  have hExpandS := (SectorDecomposition.mk g dim basis S).mpv_toTensor_eq_sum_coeff σ (N := N)
+  have hExpandT := (SectorDecomposition.mk g dim basis T).mpv_toTensor_eq_sum_coeff σ (N := N)
+  -- These are exactly the coefficient expansions for the two assembled tensors.
   calc ∑ j, S.coeff N j * mpv (basis j) σ
-      = mpv (SectorDecomposition.mk g dim basis S).toTensor σ := hP.symm
+      = mpv (SectorDecomposition.mk g dim basis S).toTensor σ := hExpandS.symm
     _ = mpv (SectorDecomposition.mk g dim basis T).toTensor σ := hEqual N σ
-    _ = ∑ j, T.coeff N j * mpv (basis j) σ := hQ
+    _ = ∑ j, T.coeff N j * mpv (basis j) σ := hExpandT
 
 end MPSTensor


### PR DESCRIPTION
### Motivation
- Improve reviewer-facing readability and naming consistency in the sector-decomposition equal-case proofs by replacing terse local hypothesis names with descriptive identifiers.

### Description
- Rename `hN0` → `hCoeffEventuallyEq` and `hAll` → `hCoeffAllPosEq` in `SectorWeightData.weight_multiset_eq_of_sameMPV_bnt` to clarify their roles as eventual/full coefficient-equality lemmas.
- Rename `hP` → `hExpandS` and `hQ` → `hExpandT` in `fundamentalTheorem_equalMPV_sectorDecomposition` and update the adjacent comment to reflect that these are the coefficient expansions for the assembled tensors.
- These edits are non-functional refactors confined to `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean` and preserve all theorem statements and proofs.

### Testing
- Ran `lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean` which completed successfully. 
- Ran `rg -n "\bsorry\b|\baxiom\b" TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean` and found no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c467c61483249620a472928c3e35)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a proof-only refactor that renames local binders/comments without changing any theorem statements or proof structure.
> 
> **Overview**
> Refactors two equal-case sector-decomposition proofs by renaming short local hypotheses (e.g. `hN0`/`hAll` → `hCoeffEventuallyEq`/`hCoeffAllPosEq`, `hP`/`hQ` → `hExpandS`/`hExpandT`) and slightly updating the adjacent comment.
> 
> No theorem statements or proof steps change; this is purely a readability/naming cleanup in `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 950caad6a6b52085f5f55d290d649a50847822d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Refs #82