### PR TITLE
feat(MPS/Periodic): add periodic alias layer and Equivalence instances

### DIFF
--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -54,6 +54,8 @@ theorem SameState.trans {A B C : PeriodicMPSTensor (d := d) (D := D) m}
 
 instance instEquivalenceSameState :
     Equivalence (SameState (d := d) (D := D) (m := m)) where
+  -- `Equivalence` is a structure (not a class): this is a convenience bundle,
+  -- not intended to be found via typeclass search.
   refl := SameState.refl
   symm := SameState.symm
   trans := SameState.trans
@@ -72,6 +74,8 @@ theorem GaugeEquiv.trans {A B C : PeriodicMPSTensor (d := d) (D := D) m}
 
 instance instEquivalenceGaugeEquiv :
     Equivalence (GaugeEquiv (d := d) (D := D) (m := m)) where
+  -- `Equivalence` is a structure (not a class): this is a convenience bundle,
+  -- not intended to be found via typeclass search.
   refl := GaugeEquiv.refl
   symm := GaugeEquiv.symm
   trans := GaugeEquiv.trans

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -1,4 +1,5 @@
 import TNLean.MPS.Irreducible.FormII
+import TNLean.MPS.Chain.Defs
 import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Channel.Peripheral.CyclicDecomposition
 import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
@@ -15,6 +16,67 @@ used by the periodic form theory (arXiv:1708.00029, §2.1).
 namespace MPSTensor
 
 variable {d D : ℕ}
+
+/-- Period-`m` periodic-chain tensor (site-dependent tensor family on `Fin m`). -/
+abbrev PeriodicMPSTensor (m : ℕ) := MPSChainTensor d D m
+
+namespace PeriodicMPSTensor
+
+variable {m : ℕ}
+
+/-- Interpret a translation-invariant local tensor as a periodic chain of length `m`. -/
+abbrev toChain (A : MPSTensor d D) : PeriodicMPSTensor (d := d) (D := D) m :=
+  fun _ => A
+
+/-- Coefficient of a periodic chain at configuration `σ`. -/
+abbrev coeff (A : PeriodicMPSTensor (d := d) (D := D) m) (σ : Fin m → Fin d) : ℂ :=
+  MPSChainTensor.coeff A σ
+
+/-- Equality of periodic-chain states at fixed period `m`. -/
+abbrev SameState (A B : PeriodicMPSTensor (d := d) (D := D) m) : Prop :=
+  MPSChainTensor.SameState A B
+
+/-- Cyclic gauge equivalence of periodic chains at fixed period `m`. -/
+abbrev GaugeEquiv (A B : PeriodicMPSTensor (d := d) (D := D) m) : Prop :=
+  MPSChainTensor.GaugeEquiv A B
+
+theorem SameState.refl (A : PeriodicMPSTensor (d := d) (D := D) m) : SameState A A :=
+  MPSChainTensor.SameState.refl A
+
+theorem SameState.symm {A B : PeriodicMPSTensor (d := d) (D := D) m}
+    (h : SameState A B) : SameState B A :=
+  MPSChainTensor.SameState.symm h
+
+theorem SameState.trans {A B C : PeriodicMPSTensor (d := d) (D := D) m}
+    (hAB : SameState A B) (hBC : SameState B C) :
+    SameState A C :=
+  MPSChainTensor.SameState.trans hAB hBC
+
+instance instEquivalenceSameState :
+    Equivalence (SameState (d := d) (D := D) (m := m)) where
+  refl := SameState.refl
+  symm := SameState.symm
+  trans := SameState.trans
+
+theorem GaugeEquiv.refl (A : PeriodicMPSTensor (d := d) (D := D) m) : GaugeEquiv A A :=
+  MPSChainTensor.GaugeEquiv.refl A
+
+theorem GaugeEquiv.symm {A B : PeriodicMPSTensor (d := d) (D := D) m}
+    (h : GaugeEquiv A B) : GaugeEquiv B A :=
+  MPSChainTensor.GaugeEquiv.symm h
+
+theorem GaugeEquiv.trans {A B C : PeriodicMPSTensor (d := d) (D := D) m}
+    (hAB : GaugeEquiv A B) (hBC : GaugeEquiv B C) :
+    GaugeEquiv A C :=
+  MPSChainTensor.GaugeEquiv.trans hAB hBC
+
+instance instEquivalenceGaugeEquiv :
+    Equivalence (GaugeEquiv (d := d) (D := D) (m := m)) where
+  refl := GaugeEquiv.refl
+  symm := GaugeEquiv.symm
+  trans := GaugeEquiv.trans
+
+end PeriodicMPSTensor
 
 /-- Left-canonical (trace-preserving) condition for an MPS tensor. -/
 def IsLeftCanonical (A : MPSTensor d D) : Prop :=


### PR DESCRIPTION
### Motivation
- Provide a small periodic-chain alias surface so periodic-form developments can use chain infrastructure via a periodic namespace. 
- Address the reviewer request to avoid redundant `@[simp]` on abbrev-equal definitions and to consider relation-class support for the periodic relations. 
- Ensure the change sits cleanly on top of current `main` (fresh follow-up for PR #95).

### Description
- Import `TNLean.MPS.Chain.Defs` and add a `PeriodicMPSTensor` abbrev plus a `PeriodicMPSTensor` namespace with `toChain`, `coeff`, `SameState`, and `GaugeEquiv` forwarding to the chain-level API in `TNLean/MPS/Periodic/Defs.lean`.
- Forward the standard relation lemmas `refl/symm/trans` for both `SameState` and `GaugeEquiv` and provide `Equivalence` instances `instEquivalenceSameState` and `instEquivalenceGaugeEquiv` so the relations integrate with Lean's relation classes.
- Avoid introducing redundant `@[simp]` declarations on abbrev/definitionally-equal lemmas and do not add any `sorry` or `axiom`.

### Testing
- Ran `lake env lean TNLean/MPS/Periodic/Defs.lean`, which completed (with lint hints) successfully.
- Ran `lake build TNLean.MPS.Periodic.Defs`, which built successfully (warnings noted) and returned success.
- Ran `lake build TNLean` (full project build), which completed successfully though the build output lists pre-existing warnings in unrelated files and linter hints in `Defs.lean`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2461d51548324bae25d9cbeff3a99)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive and mostly definitional forwarding plus relation instances, with no modifications to core tensor/transfer-map logic.
> 
> **Overview**
> Introduces a `PeriodicMPSTensor` abbrev (periodic chain as `MPSChainTensor ... m`) and a `PeriodicMPSTensor` namespace that forwards `toChain`, `coeff`, `SameState`, and `GaugeEquiv` to the chain-level API.
> 
> Adds `refl`/`symm`/`trans` lemmas and convenience `Equivalence` bundles for `SameState` and `GaugeEquiv`, so periodic relations can be used with standard relation tooling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5913aa4ecfc206dc3027afef0053a6e29d547980. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->