### PR TITLE
feat(Wolf Ch6): package Wolf Theorem 6.8 equivalences with snake_case wrappers

### DIFF
--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -150,12 +150,12 @@ Other items: PARTIALLY via spectral gap infrastructure in `TNLean.Spectral.*`.
 * `IsPrimitivePaper` — `TNLean.Wielandt.Primitivity.PaperDefinitions`
   (item 3: `Kₘ = M_d(ℂ)` for `m ≥ q`)
 * Pairwise equivalences from Proposition 3 assembly:
-  * `primitivePaper_iff_hasEventuallyFullKrausRank`
-  * `primitivePaper_iff_stronglyIrreducible`
+  * `primitivePaper_iff_hasEventuallyFullKrausRank` / `primitivePaper_iff_stronglyIrreducible`
+    (in `TNLean.Wielandt.Primitivity.Equivalence`)
   * `hasEventuallyFullKrausRank_iff_isNormal`
-  (in `TNLean.Wielandt.Primitivity.Equivalence`)
+    (in `TNLean.Wielandt.Primitivity.PaperDefinitions`)
 * Packaged Wolf-facing wrappers:
-  * `wolf_theorem_6_8_krausSpan`
+  * `wolf_theorem_6_8_kraus_span`
   * `wolf_theorem_6_8_conjunction`
   (in `TNLean.Wielandt.Primitivity.Equivalence`)
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -155,8 +155,8 @@ Other items: PARTIALLY via spectral gap infrastructure in `TNLean.Spectral.*`.
   * `hasEventuallyFullKrausRank_iff_isNormal`
   (in `TNLean.Wielandt.Primitivity.Equivalence`)
 * Packaged Wolf-facing wrappers:
-  * `primitivePaper_iff_krausSpan_top`
-  * `wolf_theorem_6_8_four_characterizations`
+  * `wolf_theorem_6_8_krausSpan`
+  * `wolf_theorem_6_8_conjunction`
   (in `TNLean.Wielandt.Primitivity.Equivalence`)
 
 ### Wolf Theorem 6.9 (Quantum Wielandt inequality)

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -15,6 +15,7 @@ import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.Channel.Irreducible.Similarity
 import TNLean.QPF.Assembly
+import TNLean.Wielandt.Primitivity.Equivalence
 
 /-!
 # Wolf Chapter 6 — Spectral Properties: Public Theorem Index
@@ -148,6 +149,15 @@ Other items: PARTIALLY via spectral gap infrastructure in `TNLean.Spectral.*`.
 
 * `IsPrimitivePaper` — `TNLean.Wielandt.Primitivity.PaperDefinitions`
   (item 3: `Kₘ = M_d(ℂ)` for `m ≥ q`)
+* Pairwise equivalences from Proposition 3 assembly:
+  * `primitivePaper_iff_hasEventuallyFullKrausRank`
+  * `primitivePaper_iff_stronglyIrreducible`
+  * `hasEventuallyFullKrausRank_iff_isNormal`
+  (in `TNLean.Wielandt.Primitivity.Equivalence`)
+* Packaged Wolf-facing wrappers:
+  * `primitivePaper_iff_krausSpan_top`
+  * `wolf_theorem_6_8_four_characterizations`
+  (in `TNLean.Wielandt.Primitivity.Equivalence`)
 
 ### Wolf Theorem 6.9 (Quantum Wielandt inequality)
 

--- a/TNLean/Wielandt/Primitivity/Equivalence.lean
+++ b/TNLean/Wielandt/Primitivity/Equivalence.lean
@@ -226,6 +226,44 @@ theorem hasEventuallyFullKrausRank_iff_stronglyIrreducible [NeZero D]
   ⟨fun hB => isStronglyIrreduciblePaper_of_hasEventuallyFullKrausRank A hNorm hB,
    fun hC => prop3_cb A hNorm hC⟩
 
+/-! ## Wolf Theorem 6.8 packaged forms -/
+
+/-- **Wolf Theorem 6.8 (Kraus-span form)**:
+paper primitivity is equivalent to eventual full Kraus-word span.
+
+This is a naming wrapper around `primitivePaper_iff_hasEventuallyFullKrausRank`,
+matching Wolf's Chapter 6 wording ("the Kraus operators eventually span all
+matrices"). -/
+theorem primitivePaper_iff_krausSpan_top [NeZero D]
+    (A : MPSTensor d D)
+    (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    IsPrimitivePaper A ↔ HasEventuallyFullKrausRank A :=
+  primitivePaper_iff_hasEventuallyFullKrausRank A hNorm
+
+/-- **Wolf Theorem 6.8 (packaged conjunction form)**:
+paper primitivity is equivalent to the conjunction of eventual full Kraus rank,
+normality, and strong irreducibility.
+
+This theorem is intentionally stated as
+`IsPrimitivePaper A ↔ (HasEventuallyFullKrausRank A ∧ IsNormal A ∧ IsStronglyIrreduciblePaper A)`.
+For explicit pairwise equivalences, use:
+`primitivePaper_iff_hasEventuallyFullKrausRank`,
+`primitivePaper_iff_stronglyIrreducible`, and
+`hasEventuallyFullKrausRank_iff_isNormal`. -/
+theorem wolf_theorem_6_8_four_characterizations [NeZero D]
+    (A : MPSTensor d D)
+    (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    IsPrimitivePaper A ↔
+      (HasEventuallyFullKrausRank A ∧ IsNormal A ∧ IsStronglyIrreduciblePaper A) := by
+  constructor
+  · intro hPrim
+    refine ⟨?_, ?_, ?_⟩
+    · exact hasEventuallyFullKrausRank_of_isPrimitivePaper A hNorm hPrim
+    · exact isNormal_of_isPrimitivePaper A hNorm hPrim
+    · exact (primitivePaper_iff_stronglyIrreducible A hNorm).mp hPrim
+  · intro h
+    exact (primitivePaper_iff_hasEventuallyFullKrausRank A hNorm).mpr h.1
+
 /-! ## Peripheral primitivity (intermediate result) -/
 
 /-- **Proposition 3 (a)→(c), intermediate step**: paper primitivity implies

--- a/TNLean/Wielandt/Primitivity/Equivalence.lean
+++ b/TNLean/Wielandt/Primitivity/Equivalence.lean
@@ -234,7 +234,7 @@ paper primitivity is equivalent to eventual full Kraus-word span.
 This is a naming wrapper around `primitivePaper_iff_hasEventuallyFullKrausRank`,
 matching Wolf's Chapter 6 wording ("the Kraus operators eventually span all
 matrices"). -/
-theorem wolf_theorem_6_8_krausSpan [NeZero D]
+theorem wolf_theorem_6_8_kraus_span [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     IsPrimitivePaper A ↔ HasEventuallyFullKrausRank A :=

--- a/TNLean/Wielandt/Primitivity/Equivalence.lean
+++ b/TNLean/Wielandt/Primitivity/Equivalence.lean
@@ -234,7 +234,7 @@ paper primitivity is equivalent to eventual full Kraus-word span.
 This is a naming wrapper around `primitivePaper_iff_hasEventuallyFullKrausRank`,
 matching Wolf's Chapter 6 wording ("the Kraus operators eventually span all
 matrices"). -/
-theorem primitivePaper_iff_krausSpan_top [NeZero D]
+theorem wolf_theorem_6_8_krausSpan [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     IsPrimitivePaper A ↔ HasEventuallyFullKrausRank A :=
@@ -250,7 +250,7 @@ For explicit pairwise equivalences, use:
 `primitivePaper_iff_hasEventuallyFullKrausRank`,
 `primitivePaper_iff_stronglyIrreducible`, and
 `hasEventuallyFullKrausRank_iff_isNormal`. -/
-theorem wolf_theorem_6_8_four_characterizations [NeZero D]
+theorem wolf_theorem_6_8_conjunction [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     IsPrimitivePaper A ↔
@@ -262,6 +262,7 @@ theorem wolf_theorem_6_8_four_characterizations [NeZero D]
     · exact isNormal_of_isPrimitivePaper A hNorm hPrim
     · exact (primitivePaper_iff_stronglyIrreducible A hNorm).mp hPrim
   · intro h
+    -- any single conjunct suffices; we use h.1
     exact (primitivePaper_iff_hasEventuallyFullKrausRank A hNorm).mpr h.1
 
 /-! ## Peripheral primitivity (intermediate result) -/


### PR DESCRIPTION
### Motivation
- Clarify and surface the Wolf Chapter 6.8 Kraus-span characterization of primitive CP maps to remove ambiguity about the “four characterizations” phrasing. 
- Provide Wolf-facing wrappers and index entries to improve discoverability and align naming with the paper/Wolf wording.

### Description
- Added `primitivePaper_iff_krausSpan_top` in `TNLean/Wielandt/Primitivity/Equivalence.lean` as a Wolf-facing wrapper around the existing Proposition 3 equivalence `(IsPrimitivePaper ↔ HasEventuallyFullKrausRank)`. 
- Added `wolf_theorem_6_8_four_characterizations` in the same file, stated explicitly as a conjunction-form equivalence `IsPrimitivePaper A ↔ (HasEventuallyFullKrausRank A ∧ IsNormal A ∧ IsStronglyIrreduciblePaper A)` and documented that pairwise `↔` lemmas exist for explicit equivalences. 
- Updated `TNLean/Channel/WolfChapter6Index.lean` to import `TNLean.Wielandt.Primitivity.Equivalence` and to list both the pairwise Proposition 3 equivalences and the new packaged Wolf-facing wrappers for Theorem 6.8.

### Testing
- Ran `lake build TNLean.Wielandt.Primitivity.Equivalence` which completed successfully. 
- Ran `lake build TNLean.Channel.WolfChapter6Index` which completed successfully and emitted a pre-existing linter warning in `TNLean/Channel/FixedPoint/StationarySupport.lean`. 
- Verified touched files do not introduce `sorry` or `axiom` via automated grep checks, with no matches found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24c93a0408324bd5b01cb6a5045c5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds theorem-name wrappers and index/documentation updates without changing underlying primitivity proofs or logic.
> 
> **Overview**
> Surfaces Wolf Theorem 6.8 more directly by adding two Wolf-facing wrapper theorems in `TNLean.Wielandt.Primitivity.Equivalence`: `wolf_theorem_6_8_kraus_span` (aliasing `IsPrimitivePaper ↔ HasEventuallyFullKrausRank`) and `wolf_theorem_6_8_conjunction` (packaging primitivity as a conjunction with normality and strong irreducibility).
> 
> Updates the Wolf Chapter 6 index (`TNLean.Channel.WolfChapter6Index`) to import `TNLean.Wielandt.Primitivity.Equivalence` and to list both the existing pairwise equivalences and the new packaged Theorem 6.8 statements for discoverability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 730bc9b63ad44d92981f6a213b157b999a97b03c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->