### PR TITLE
[PR #165 follow-up] BlockedChainFT naming/style cleanup

### DIFF
--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -17,7 +17,7 @@ variable {d D : ℕ}
 
 /-- Bridge between project `N`-block injectivity and injectivity of the physically
 blocked tensor `blockTensor A N`. -/
-lemma IsNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
+lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
     IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by
   classical
   have hRange :
@@ -37,7 +37,7 @@ lemma IsNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) 
           (Set.range fun i : Fin (blockPhysDim d N) =>
             evalWord A (List.ofFn (decodeBlock d N i))) =
         Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) := by
-    simpa [hRange]
+    simp [hRange]
   constructor
   · intro h
     exact hSpan.trans h
@@ -62,7 +62,7 @@ lemma blockedChain_isInjective (A : MPSTensor d D) (L n : ℕ)
     IsInjective (blockedChain A L n) := by
   intro k
   simpa [blockedChain] using
-    (MPSTensor.IsNBlkInjective_iff_blockTensor_isInjective A L).1 hA
+    (MPSTensor.isNBlkInjective_iff_blockTensor_isInjective A L).1 hA
 
 /-- Fundamental theorem endpoint for blocked chains at a common blocking length.
 


### PR DESCRIPTION
### Motivation
- Fix minor naming and style nits in `TNLean/MPS/Chain/BlockedChainFT.lean` identified during the PR #165 review to match Mathlib conventions and satisfy linter guidance.
- Keep the change minimal and local so theorem statements and proof structure remain unchanged.

### Description
- Rename lemma `IsNBlkInjective_iff_blockTensor_isInjective` to `isNBlkInjective_iff_blockTensor_isInjective` to follow lowercase naming conventions.
- Update the dependent call site in `blockedChain_isInjective` to use the renamed lemma: `(MPSTensor.isNBlkInjective_iff_blockTensor_isInjective A L).1 hA`.
- Replace a lint-triggering `simpa [hRange]` with `simp [hRange]` in the `Submodule.span` equality proof to satisfy style checks.

### Testing
- Ran `rg -n "IsNBlkInjective_iff_blockTensor_isInjective|isNBlkInjective_iff_blockTensor_isInjective" TNLean` to confirm references and the rename, which succeeded.
- Built the target with `lake build TNLean.MPS.Chain.BlockedChainFT`, which completed successfully.
- Verified no `sorry`/`axiom` were introduced in the modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24c92655c832484e3696e8440fc0a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely local naming/style cleanup in a Lean proof with no semantic changes, aside from updating the single call site to the renamed lemma.
> 
> **Overview**
> Renames the lemma `IsNBlkInjective_iff_blockTensor_isInjective` to `isNBlkInjective_iff_blockTensor_isInjective` in `BlockedChainFT.lean` and updates `blockedChain_isInjective` to use the new name.
> 
> Replaces a lint-triggering `simpa [hRange]` with `simp [hRange]` in the `Submodule.span` equality proof, keeping the theorem statements and proof structure otherwise unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eb484d2fb3ec6fe374ad1e64d9fdc062c536610. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->