### PR TITLE
fix(mps/symmetry): remove vacuous twistedTensor_mul and add TODO for proper proof

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -103,6 +103,7 @@ import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.FundamentalTheorem
 import TNLean.MPS.Chain.BlockedChainFT
 import TNLean.MPS.Chain.TranslationInvariance
+import TNLean.MPS.Chain.SymmetricMPS
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Overlap.Basic

--- a/TNLean/MPS/Chain/SymmetricMPS.lean
+++ b/TNLean/MPS/Chain/SymmetricMPS.lean
@@ -1,0 +1,33 @@
+import TNLean.MPS.Defs
+
+/-!
+# Symmetry helpers for MPS tensors
+
+This file introduces the tensor obtained by twisting a physical index with a
+matrix representation and proves the basic composition laws.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {G : Type*} [Monoid G]
+variable {d D : ℕ}
+
+/-- Twist an MPS tensor `A` by a physical action `U(g)` on the local index:
+`(twistedTensor U A g) i = ∑ j, U(g)ᵢⱼ • A j`. -/
+def twistedTensor (U : G →* Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) (g : G) :
+    MPSTensor d D :=
+  fun i => ∑ j, U g i j • A j
+
+@[simp] lemma twistedTensor_one
+    (U : G →* Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) :
+    twistedTensor U A 1 = A := by
+  ext i a b
+  simp [twistedTensor, Matrix.one_apply]
+
+-- TODO (#197 follow-up): add a non-vacuous proof of the composition law
+-- `twistedTensor U A (g * h) = twistedTensor U (twistedTensor U A h) g`
+-- directly from `Matrix.mul_apply`, avoiding circular assumptions.
+
+end MPSTensor

--- a/TNLean/MPS/Chain/SymmetricMPS.lean
+++ b/TNLean/MPS/Chain/SymmetricMPS.lean
@@ -1,4 +1,4 @@
-import Mathlib.Algebra.BigOperators.Basic
+import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.Group.Hom.Defs
 import Mathlib.Data.Matrix.Basic
 import TNLean.MPS.Defs

--- a/TNLean/MPS/Chain/SymmetricMPS.lean
+++ b/TNLean/MPS/Chain/SymmetricMPS.lean
@@ -1,10 +1,14 @@
+import Mathlib.Algebra.BigOperators.Basic
+import Mathlib.Algebra.Group.Hom.Defs
+import Mathlib.Data.Matrix.Basic
 import TNLean.MPS.Defs
 
 /-!
 # Symmetry helpers for MPS tensors
 
 This file introduces the tensor obtained by twisting a physical index with a
-matrix representation and proves the basic composition laws.
+matrix representation and proves the identity law. The composition law is left
+as a TODO.
 -/
 
 open scoped Matrix BigOperators


### PR DESCRIPTION
### Motivation

- Provide a small symmetry helper for MPS tensors (the `twistedTensor` construction) while avoiding keeping a lemma that was found to be vacuous/circular. 
- Replace the problematic `twistedTensor_mul` lemma with an explicit TODO so the composition law is only reintroduced after a direct, non-circular proof from `Matrix.mul_apply`.

### Description

- Add `TNLean/MPS/Chain/SymmetricMPS.lean` that defines `twistedTensor (U : G →* Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) g` as `fun i => ∑ j, U g i j • A j` and prove `@[simp] lemma twistedTensor_one` directly from the definition. 
- Remove the vacuous `twistedTensor_mul` statement/proof and replace it with a `TODO` comment requesting a proper proof derived from `Matrix.mul_apply`. 
- Export the new helper module by adding `import TNLean.MPS.Chain.SymmetricMPS` to the root import surface (`TNLean.lean`). 
- No `sorry`/`axiom` were introduced in this change.

### Testing

- Ran `lake build TNLean.MPS.Chain.SymmetricMPS TNLean`, which completed successfully and built the project targets including the new module. 
- The build log contains the full project build (no new `sorry` warnings introduced by this change) and the specific target `TNLean.MPS.Chain.SymmetricMPS` was built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24c54471c8324bea0f708968c495c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, self-contained MPS symmetry helper and a single `simp` lemma, plus a root re-export, without changing existing core logic.
> 
> **Overview**
> Adds a new `MPSTensor.twistedTensor` construction to “twist” an MPS tensor’s physical index by a monoid action `U : G →* Matrix (Fin d) (Fin d) ℂ`, and proves the identity law `twistedTensor_one`.
> 
> Exposes the new helper via the root `TNLean.lean` import surface, and leaves the intended composition law as an explicit TODO rather than providing a (previously problematic) lemma.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d306ef321115b75102d9f369e0b79e94e8cc9a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->