### PR TITLE
[PR #196 follow-up] Provide `Equivalence` instances for chain `SameState` and `GaugeEquiv`

### DIFF
--- a/TNLean/MPS/Chain/Defs.lean
+++ b/TNLean/MPS/Chain/Defs.lean
@@ -83,6 +83,12 @@ theorem SameState.trans {A B C : MPSChainTensor d D n}
   intro σ
   exact (hAB σ).trans (hBC σ)
 
+/-- `SameState` is an equivalence relation. -/
+instance instEquivalenceSameState : Equivalence (SameState (d := d) (D := D) (n := n)) where
+  refl := SameState.refl
+  symm := SameState.symm
+  trans := SameState.trans
+
 theorem GaugeEquiv.refl (A : MPSChainTensor d D n) : GaugeEquiv A A := by
   refine ⟨fun _ => 1, ?_⟩
   intro k i
@@ -105,6 +111,12 @@ theorem GaugeEquiv.trans {A B C : MPSChainTensor d D n}
   intro k i
   rw [hY k i, hZ k i]
   simp [Matrix.mul_assoc, mul_inv_rev]
+
+/-- `GaugeEquiv` is an equivalence relation. -/
+instance instEquivalenceGaugeEquiv : Equivalence (GaugeEquiv (d := d) (D := D) (n := n)) where
+  refl := GaugeEquiv.refl
+  symm := GaugeEquiv.symm
+  trans := GaugeEquiv.trans
 
 end MPSChainTensor
 


### PR DESCRIPTION
### Motivation
- Bugbot flagged that the theorem-based `refl`/`symm`/`trans` proofs for chain relations do not participate in typeclass search, so the periodic chain relations should be registered as `Equivalence` instances to enable tactics and APIs that rely on `[Equivalence _]`.

### Description
- Added `instance instEquivalenceSameState : Equivalence (SameState (d := d) (D := D) (n := n))` and `instance instEquivalenceGaugeEquiv : Equivalence (GaugeEquiv (d := d) (D := D) (n := n))` in `TNLean/MPS/Chain/Defs.lean`, reusing the existing `SameState.refl/symm/trans` and `GaugeEquiv.refl/symm/trans` proofs so behavior is unchanged.

### Testing
- Ran `lake env lean TNLean/MPS/Chain/Defs.lean`, `lake build TNLean.MPS.Chain.Defs`, and `lake build TNLean`, and all builds completed successfully (the full `lake build TNLean` reports pre-existing unrelated warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24c5710288324806dbce81445c4b6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds typeclass instances reusing existing `refl`/`symm`/`trans` proofs, with no changes to the underlying definitions or proofs’ logic.
> 
> **Overview**
> Registers the periodic-chain relations `SameState` and `GaugeEquiv` as `Equivalence` typeclass instances, so tactics/APIs that rely on `[Equivalence _]` can use these relations.
> 
> The new instances (`instEquivalenceSameState`, `instEquivalenceGaugeEquiv`) are wired directly to the existing `refl`/`symm`/`trans` theorems, leaving behavior unchanged while improving typeclass search.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cafbb4dd8eaa94b843eee2d4c86717e6e29120c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->