### PR TITLE
Extract orthogonal projection PSD lemma

### DIFF
--- a/TNLean/Channel/Irreducible/FromSpectral.lean
+++ b/TNLean/Channel/Irreducible/FromSpectral.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Irreducible.Ergodicity
+import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Irreducible.SpectralRadius
 import TNLean.Channel.Irreducible.TraceAdjoint
 

--- a/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression
+import TNLean.Channel.Irreducible.Basic
 
 /-!
 # Subsequence Analysis: (4) → (2) via Cesàro + subsequences
@@ -30,24 +31,18 @@ local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
 /-! ## (4) → (2): Block-upper-triangular → rank-deficient kernel element -/
 
-/-- An orthogonal projection is PSD: `P = P * P = P * Pᴴ` is a sum of PSD terms. -/
-private lemma orthogonalProjection_posSemidef'
-    {P : Mat} (hP : IsOrthogonalProjection P) : P.PosSemidef := by
-  have : P = Pᴴ * P := by rw [hP.1, hP.2]
-  rw [this]; exact P.posSemidef_conjTranspose_mul_self
-
 /-- A nonzero orthogonal projection has nonzero trace. -/
 private lemma trace_ne_zero_of_proj_ne_zero'
     {P : Mat} (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
     Matrix.trace P ≠ 0 := by
   intro htr
-  exact hP_ne ((orthogonalProjection_posSemidef' hP).trace_eq_zero_iff.1 htr)
+  exact hP_ne ((orthogonalProjection_posSemidef hP).trace_eq_zero_iff.1 htr)
 
 /-- `P / tr(P)` is a density matrix. -/
 private lemma normalizedProj_mem_densityMatrices'
     {P : Mat} (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
     ((trace P)⁻¹ • P) ∈ densityMatrices D := by
-  have hP_psd := orthogonalProjection_posSemidef' hP
+  have hP_psd := orthogonalProjection_posSemidef hP
   have htrP_ne := trace_ne_zero_of_proj_ne_zero' hP hP_ne
   exact ⟨hP_psd.smul (inv_nonneg_of_nonneg hP_psd.trace_nonneg),
     by simp [Matrix.trace_smul, htrP_ne]⟩

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -206,7 +206,13 @@ end SupportProjLemmas
 
 section FixedPointInvariant
 
-/-- Adjoint identity for dot product: `star x ⬝ᵥ (M *ᵥ y) = star (Mᴴ *ᵥ x) ⬝ᵥ y`. -/
+/-- Adjoint identity for dot product: `star x ⬝ᵥ (M *ᵥ y) = star (Mᴴ *ᵥ x) ⬝ᵥ y`.
+
+This helper is intentionally kept local to this file: unlike
+`orthogonalProjection_posSemidef` in `Irreducible/Basic`, this is a small linear-algebra
+rewrite used only in the fixed-point support-projection argument below, and exporting it
+would add API surface without a second in-repo call site.
+-/
 private lemma dotProduct_mulVec_conjTranspose
     (M : Matrix (Fin D) (Fin D) ℂ)
     (x y : Fin D → ℂ) :


### PR DESCRIPTION
### Motivation
- Factor out the small, commonly used fact that an orthogonal projection is positive semidefinite so it can be reused/upstreamed and to address a reviewer suggestion.

### Description
- Add `orthogonalProjection_posSemidef` to `TNLean/Channel/Irreducible/Basic.lean`, proving `IsOrthogonalProjection P → P.PosSemidef`.

### Testing
- Ran `lake env lean TNLean/Channel/Irreducible/Basic.lean`, which typechecked successfully.
- Ran `rg -n "sorry|axiom" TNLean/Channel/Irreducible/Basic.lean || true` to verify no `sorry`/`axiom` were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c27741c81c83249be23d9c4ea0de16)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small lemma extraction and import rewiring, with no changes to core algorithms beyond reusing the new proof in a couple of existing theorems.
> 
> **Overview**
> Adds `isOrthogonalProjection_posSemidef` to `TNLean/Channel/Irreducible/Basic.lean`, exposing the fact that an `IsOrthogonalProjection` matrix is `PosSemidef`.
> 
> Updates downstream proofs (notably `Semigroup/ReducibleQDS/SubsequenceAnalysis.lean`) to drop their local PSD projection lemma and rely on the new shared lemma, and adjusts imports (e.g. `Irreducible/FromSpectral.lean`) accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beebb0e38414daa29b939ca45a2dd3012f44ec40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
Addresses #205