### PR TITLE
doc(MPS/Chain): clarify SymmetricMPS docstring and add `twistedTensor` identity lemma

### DIFF
--- a/TNLean/MPS/Chain/SymmetricMPS.lean
+++ b/TNLean/MPS/Chain/SymmetricMPS.lean
@@ -1,0 +1,27 @@
+import TNLean.MPS.Defs
+
+/-!
+# Symmetry helpers for chain MPS tensors
+
+This module defines the symmetry-twisted tensor construction `twistedTensor` and
+proves the identity law `twistedTensor_one`.
+
+TODO: add a direct proof of the composition law (`twistedTensor_mul`).
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSChainTensor
+
+variable {d D : ℕ}
+
+/-- Twist an MPS tensor by an on-site matrix action on the physical index. -/
+def twistedTensor (U : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) : MPSTensor d D :=
+  fun i => ∑ j, U i j • A j
+
+@[simp] lemma twistedTensor_one (A : MPSTensor d D) :
+    twistedTensor (1 : Matrix (Fin d) (Fin d) ℂ) A = A := by
+  funext i
+  simp [twistedTensor, Matrix.one_apply]
+
+end MPSChainTensor

--- a/TNLean/MPS/Chain/SymmetricMPS.lean
+++ b/TNLean/MPS/Chain/SymmetricMPS.lean
@@ -11,7 +11,7 @@ TODO: add a direct proof of the composition law (`twistedTensor_mul`).
 
 open scoped Matrix BigOperators
 
-namespace MPSChainTensor
+namespace MPSTensor
 
 variable {d D : ℕ}
 
@@ -24,4 +24,4 @@ def twistedTensor (U : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) : MPSTens
   funext i
   simp [twistedTensor, Matrix.one_apply]
 
-end MPSChainTensor
+end MPSTensor


### PR DESCRIPTION
### Motivation
- The `SymmetricMPS` module docstring claimed multiple composition laws but only the identity law was implemented, so the module documentation needed to be corrected to reflect the actual content.

### Description
- Add `TNLean/MPS/Chain/SymmetricMPS.lean` which defines `twistedTensor`, proves the identity law `@[simp] twistedTensor_one`, and records a `TODO` to implement the composition law `twistedTensor_mul` directly.

### Testing
- Ran `lake build TNLean.MPS.Chain.SymmetricMPS` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2774c1aec8324b8cd26599ba20db1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small new helper definition and a `@[simp]` lemma without touching existing logic; main risk is only potential simp-rewrite interactions.
> 
> **Overview**
> Adds a new `TNLean/MPS/Chain/SymmetricMPS.lean` module introducing `MPSTensor.twistedTensor`, which applies an on-site matrix action to the physical index via a finite sum.
> 
> Proves the identity law `@[simp] twistedTensor_one` showing twisting by the identity matrix returns the original tensor, and updates the module docstring to match the implemented laws (with a TODO for the missing composition lemma).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc79478e41fb0a685f73239bda65bc4a3ca00a02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->