### PR TITLE
[PR #200 follow-up] Replace tautological correlator proofs with explicit placeholders

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -211,3 +211,4 @@ import TNLean.Channel.Semigroup.Primitivity
 import TNLean.Channel.Semigroup.LiouvillianKernel
 import TNLean.Channel.Semigroup.ReducibleQDS
 import TNLean.Channel.Determinant
+import TNLean.MPS.ParentHamiltonian.Correlations

--- a/TNLean/MPS/ParentHamiltonian/Correlations.lean
+++ b/TNLean/MPS/ParentHamiltonian/Correlations.lean
@@ -23,8 +23,8 @@ variable {d D : ℕ}
 
 /-- Placeholder one-point expectation value in the thermodynamic limit. -/
 noncomputable def onePointExpectation (_A : MPSTensor d D)
-    (X : Matrix (Fin D) (Fin D) ℂ) : ℂ :=
-  Matrix.trace X
+    (_X : Matrix (Fin D) (Fin D) ℂ) : ℂ :=
+  0
 
 /-- Placeholder two-point expectation value at separation `n`. -/
 noncomputable def twoPointExpectation (_A : MPSTensor d D)
@@ -40,19 +40,19 @@ noncomputable def connectedCorrelator (A : MPSTensor d D)
 theorem connectedCorrelator_eq_sum
     (A : MPSTensor d D)
     (X Y : Matrix (Fin D) (Fin D) ℂ)
-    (n : ℕ)
-    (c lam : Fin (D ^ 2 - 1) → ℂ) :
-    connectedCorrelator A X Y n =
-      ∑ j : Fin (D ^ 2 - 1), c j * (lam j) ^ n := by
+    (n : ℕ) :
+    ∃ c lam : Fin (D ^ 2 - 1) → ℂ,
+      connectedCorrelator A X Y n =
+        ∑ j : Fin (D ^ 2 - 1), c j * (lam j) ^ n := by
   sorry
 
 /-- Exponential decay bound interface for the connected correlator. -/
 theorem connectedCorrelator_bound
     (A : MPSTensor d D)
     (X Y : Matrix (Fin D) (Fin D) ℂ)
-    (n : ℕ)
-    (C_XY lambda2 : ℝ) :
-    ‖connectedCorrelator A X Y n‖ ≤ C_XY * |lambda2| ^ n := by
+    (n : ℕ) :
+    ∃ C_XY lambda2 : ℝ,
+      0 ≤ C_XY ∧ ‖connectedCorrelator A X Y n‖ ≤ C_XY * |lambda2| ^ n := by
   sorry
 
 /-- Correlation length extracted from the subleading transfer eigenvalue. -/

--- a/TNLean/MPS/ParentHamiltonian/Correlations.lean
+++ b/TNLean/MPS/ParentHamiltonian/Correlations.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Core.Transfer
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+
+/-!
+# Exponential decay of connected correlations
+
+This file introduces the connected two-point correlator interface used in the
+parent-Hamiltonian development.
+
+The two key spectral statements are currently left as explicit `sorry`
+placeholders while the full transfer-spectrum proof is being integrated.
+-/
+
+open scoped BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Placeholder one-point expectation value in the thermodynamic limit. -/
+noncomputable def onePointExpectation (_A : MPSTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) : ℂ :=
+  Matrix.trace X
+
+/-- Placeholder two-point expectation value at separation `n`. -/
+noncomputable def twoPointExpectation (_A : MPSTensor d D)
+    (X Y : Matrix (Fin D) (Fin D) ℂ) (_n : ℕ) : ℂ :=
+  Matrix.trace (X * Y)
+
+/-- Connected two-point correlator `⟨X₀ Yₙ⟩ - ⟨X₀⟩⟨Yₙ⟩`. -/
+noncomputable def connectedCorrelator (A : MPSTensor d D)
+    (X Y : Matrix (Fin D) (Fin D) ℂ) (n : ℕ) : ℂ :=
+  twoPointExpectation A X Y n - onePointExpectation A X * onePointExpectation A Y
+
+/-- Spectral decomposition interface for the connected correlator. -/
+theorem connectedCorrelator_eq_sum
+    (A : MPSTensor d D)
+    (X Y : Matrix (Fin D) (Fin D) ℂ)
+    (n : ℕ)
+    (c lam : Fin (D ^ 2 - 1) → ℂ) :
+    connectedCorrelator A X Y n =
+      ∑ j : Fin (D ^ 2 - 1), c j * (lam j) ^ n := by
+  sorry
+
+/-- Exponential decay bound interface for the connected correlator. -/
+theorem connectedCorrelator_bound
+    (A : MPSTensor d D)
+    (X Y : Matrix (Fin D) (Fin D) ℂ)
+    (n : ℕ)
+    (C_XY lambda2 : ℝ) :
+    ‖connectedCorrelator A X Y n‖ ≤ C_XY * |lambda2| ^ n := by
+  sorry
+
+/-- Correlation length extracted from the subleading transfer eigenvalue. -/
+noncomputable def correlationLength (lambda2 : ℝ) : ℝ :=
+  -1 / Real.log |lambda2|
+
+end MPSTensor

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -1,0 +1,35 @@
+\chapter{Exponential Decay of Correlations}\label{ch:correlations}
+
+This chapter states the connected-correlator interfaces used in the parent-Hamiltonian
+pipeline. The corresponding Lean declarations currently exist as explicit placeholders,
+so we intentionally avoid \texttt{\textbackslash leanok} tags for those statements.
+
+\section{Connected correlator}
+
+\begin{definition}[Connected two-point correlator]\label{def:connected_correlator}
+    \lean{MPSTensor.connectedCorrelator}
+    For an MPS tensor $A$ and local observables $X,Y$, define
+    \[
+        C_{X,Y}(n) = \langle X_0 Y_n \rangle - \langle X_0 \rangle\,\langle Y_n \rangle.
+    \]
+\end{definition}
+
+\begin{theorem}[Sum-of-exponentials form]\label{thm:connected_sum}
+    \lean{MPSTensor.connectedCorrelator_eq_sum}
+    The connected correlator can be expanded into a finite sum of exponentials
+    indexed by the non-leading transfer eigenmodes.
+\end{theorem}
+
+\begin{theorem}[Exponential decay bound]\label{thm:connected_bound}
+    \lean{MPSTensor.connectedCorrelator_bound}
+    The connected correlator is bounded by a geometric envelope determined by
+    the subleading transfer eigenvalue modulus.
+\end{theorem}
+
+\begin{definition}[Correlation length]\label{def:correlation_length}
+    \lean{MPSTensor.correlationLength}
+    The correlation length is defined by
+    \[
+        \xi = -\frac{1}{\log |\lambda_2|}.
+    \]
+\end{definition}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -14,4 +14,4 @@
 \input{chapter/ch13_algebraic_ft}
 % --- Parent Hamiltonians & Correlations (planned) ---
 % \input{chapter/ch14_parent_hamiltonian}
-% \input{chapter/ch15_correlations}
+\input{chapter/ch15_correlations}


### PR DESCRIPTION
### Motivation
- Fix critical issues where `connectedCorrelator_eq_sum` and `connectedCorrelator_bound` were tautological (`P → P`) by making the unproved statements explicit placeholders.
- Remove the unused `hA : IsNormal A` hypothesis from the theorem interfaces to silence linter complaints and avoid misleading signatures.
- Avoid misleading `\leanok` blueprint tags for statements that are not actually proved and expose the correlator interface in the build and blueprint.

### Description
- Add `TNLean/MPS/ParentHamiltonian/Correlations.lean` which provides placeholder definitions `onePointExpectation`, `twoPointExpectation`, `connectedCorrelator`, and `correlationLength`, and declares the interfaces `connectedCorrelator_eq_sum` and `connectedCorrelator_bound` with explicit `sorry` bodies to mark them as unproved for now.
- Import `Mathlib.Analysis.SpecialFunctions.Log.Basic` in the new Lean file to provide `Real.log` used by `correlationLength`.
- Add blueprint chapter `blueprint/src/chapter/ch15_correlations.tex` documenting the connected-correlator interfaces and explicitly omitting `\leanok` for the placeholder theorems.
- Enable the new blueprint chapter by uncommenting its `\input` in `blueprint/src/content.tex` and add the new module to the root import surface in `TNLean.lean` so the module is part of the default build target.

### Testing
- Ran `lake build TNLean.MPS.ParentHamiltonian.Correlations` and the target built successfully, with expected warnings that the declarations `connectedCorrelator_eq_sum` and `connectedCorrelator_bound` `use sorry`.
- Ran `lake build TNLean` (full project build) and it completed successfully, with the same expected `sorry` warnings and pre-existing linter warnings elsewhere in the project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c277615c7c8324b223591b818c8b1a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanically (new module + docs wiring), but it introduces new `sorry`-backed theorems that are intentionally unproved and could mislead downstream users if treated as established results.
> 
> **Overview**
> Adds a new `MPSTensor` connected-correlation interface for the parent-Hamiltonian work: placeholder `onePointExpectation`/`twoPointExpectation`, `connectedCorrelator`, a `correlationLength` definition, and two key theorems (`connectedCorrelator_eq_sum`, `connectedCorrelator_bound`) left as explicit `sorry` placeholders.
> 
> Exposes the new module via the root `TNLean.lean` import surface and enables a new blueprint chapter `ch15_correlations` documenting these declarations (explicitly avoiding `\leanok`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4071f740a318eb8b505a6bb2da5fecc4c41649d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->