### PR TITLE
[PR #201 follow-up] Adjust placeholders and TODOs for parent Hamiltonian

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -106,6 +106,8 @@ import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Overlap.Basic
+import TNLean.MPS.ParentHamiltonian.GroundSpace
+import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Core.BlockingTransfer
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -1,0 +1,41 @@
+import TNLean.MPS.ParentHamiltonian.GroundSpace
+
+/-!
+# Parent-Hamiltonian definitions (placeholder layer)
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Placeholder parent interaction on `L` sites.
+
+TODO(parent-hamiltonian): replace this zero operator by the orthogonal projector onto
+`(groundSpace A L)ᗮ` once the analytic construction is implemented.
+TODO(parent-hamiltonian): update downstream lemmas (`localTerm`, `parentHamiltonian`) to use the
+nontrivial local interaction and restore any appropriate `[simp]` attributes then.
+-/
+noncomputable def parentInteraction (A : MPSTensor d D) (L : ℕ) :
+    NSiteSpace d L →ₗ[ℂ] NSiteSpace d L := 0
+
+/-- Placeholder translated local term. -/
+noncomputable def localTerm (A : MPSTensor d D) (L N i : ℕ) :
+    NSiteSpace d N →ₗ[ℂ] NSiteSpace d N := 0
+
+/-- Placeholder parent Hamiltonian. -/
+noncomputable def parentHamiltonian (A : MPSTensor d D) (L N : ℕ) :
+    NSiteSpace d N →ₗ[ℂ] NSiteSpace d N := 0
+
+lemma localTerm_apply (A : MPSTensor d D) (L N i : ℕ) (ψ : NSiteSpace d N) :
+    localTerm (d := d) (D := D) A L N i ψ = 0 := by
+  simp [localTerm]
+
+lemma parentHamiltonian_apply (A : MPSTensor d D) (L N : ℕ) (ψ : NSiteSpace d N) :
+    parentHamiltonian (d := d) (D := D) A L N ψ = 0 := by
+  simp [parentHamiltonian]
+
+/-- Placeholder frustration-free predicate. -/
+def IsFrustrationFree (A : MPSTensor d D) (L N : ℕ) (ψ : NSiteSpace d N) : Prop :=
+  ∀ i ∈ Finset.range N, localTerm (d := d) (D := D) A L N i ψ = 0
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
@@ -1,0 +1,32 @@
+import TNLean.MPS.Defs
+import TNLean.MPS.Overlap.Basic
+
+
+/-!
+# Ground space placeholders
+
+Scaffolding for parent-Hamiltonian ground-space development.
+-/
+
+namespace MPSTensor
+
+open scoped BigOperators
+
+/-- `N`-site physical configurations, reusing the project-wide `Cfg` abbreviation. -/
+abbrev NSiteCfg (d N : ℕ) := Cfg d N
+
+/-- `N`-site coefficient-function space. -/
+abbrev NSiteSpace (d N : ℕ) := NSiteCfg d N → ℂ
+
+variable {d D : ℕ}
+
+/-- Placeholder map whose eventual image will define the ground space. -/
+noncomputable def groundSpaceMap (A : MPSTensor d D) (L : ℕ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] NSiteSpace d L := 0
+
+/-- Placeholder definition of the local ground space. -/
+noncomputable def groundSpace (A : MPSTensor d D) (L : ℕ) :
+    Submodule ℂ (NSiteSpace d L) :=
+  LinearMap.range (groundSpaceMap (d := d) (D := D) A L)
+
+end MPSTensor


### PR DESCRIPTION
### Motivation
- Fix review concerns in the parent-Hamiltonian scaffolding by avoiding overly-strong `simp` behavior on placeholder zero operators, making placeholder state discoverable by grep, and aligning the N-site space naming with existing conventions.

### Description
- Add `TNLean/MPS/ParentHamiltonian/GroundSpace.lean` introducing `NSiteCfg`/`NSiteSpace` defined via the existing `Cfg` abbreviation and placeholder `groundSpaceMap`/`groundSpace` definitions.
- Add `TNLean/MPS/ParentHamiltonian/Defs.lean` providing placeholder definitions `parentInteraction`, `localTerm`, and `parentHamiltonian` with explicit `TODO(parent-hamiltonian)` comments noting the intended orthogonal-projector replacement for `parentInteraction := 0`.
- Keep `localTerm_apply` and `parentHamiltonian_apply` as plain lemmas (no `@[simp]` attributes) to avoid premature simplification of real implementations.
- Wire the new modules into the root import surface by adding imports for `TNLean.MPS.ParentHamiltonian.GroundSpace` and `TNLean.MPS.ParentHamiltonian.Defs` in `TNLean.lean` so the targets build.

### Testing
- Ran `lake build TNLean.MPS.ParentHamiltonian.Defs` which completed successfully in this environment.
- Ran `lake build TNLean` which completed successfully in this environment with pre-existing linter/warning and `sorry` messages elsewhere in the repository that are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c277a4bca483248339a1079f25d890)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new placeholder (zero) definitions and wires them into the root import surface; no existing logic is modified beyond new imports.
> 
> **Overview**
> Adds an initial *scaffolding layer* for parent-Hamiltonian development: introduces `NSiteCfg`/`NSiteSpace` plus placeholder `groundSpaceMap` and `groundSpace` definitions.
> 
> Defines placeholder (currently zero) operators `parentInteraction`, `localTerm`, and `parentHamiltonian`, along with non-`simp` apply lemmas and an `IsFrustrationFree` predicate, and re-exports these new modules from `TNLean.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e30bc1e3c4e420417e83c34b4d069739b01ad849. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->