### PR TITLE
[PR #165 follow-up] BlockedChainFT style cleanups and term-mode endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Done in Lean today:
 - the cumulative `D²` Wielandt bound for the project's `IsNormal` notion
 - periodic tensor definitions for the irreducible-form theory (`IsPeriodic`, `IsIrreducibleForm`, `ZGaugeEquiv`, `RepeatedBlocks`)
 - translation-invariance corollary for injective MPS chains (`ti_tensors_collapse_to_single_gauge`)
-- blocked normal-chain FT endpoint via `IsNBlkInjective` bridge (`IsNBlkInjective_iff_blockTensor_isInjective`)
+- blocked normal-chain FT endpoint via `IsNBlkInjective` bridge (`isNBlkInjective_iff_blockTensor_isInjective`)
 
 Still not assembled end-to-end:
 

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -45,6 +45,13 @@ lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) 
   · intro h
     exact hSpan.symm.trans h
 
+/-- Deprecated compatibility alias for
+`isNBlkInjective_iff_blockTensor_isInjective`. -/
+@[deprecated isNBlkInjective_iff_blockTensor_isInjective (since := "2026-03-24")]
+lemma IsNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
+    IsNBlkInjective A N ↔ IsInjective (blockTensor A N) :=
+  isNBlkInjective_iff_blockTensor_isInjective A N
+
 end MPSTensor
 
 namespace MPSChainTensor

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -7,9 +7,10 @@ import TNLean.MPS.Chain.FundamentalTheorem
 This module packages a blocked-chain endpoint. The theorem
 `fundamentalTheorem_blockedChain` is stated for blocked chains built from a
 common blocking length `L`.
--/
 
-open scoped Matrix
+Design note: we keep the endpoint in explicit-assumption style (`L`, `hA_block`,
+`hMPV`) so downstream uses can choose blocking witnesses locally.
+-/
 
 namespace MPSTensor
 
@@ -17,7 +18,7 @@ variable {d D : ℕ}
 
 /-- Bridge between project `N`-block injectivity and injectivity of the physically
 blocked tensor `blockTensor A N`. -/
-lemma IsNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
+lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
     IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by
   classical
   have hRange :
@@ -37,7 +38,7 @@ lemma IsNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) 
           (Set.range fun i : Fin (blockPhysDim d N) =>
             evalWord A (List.ofFn (decodeBlock d N i))) =
         Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) := by
-    simpa [hRange]
+    simp [hRange]
   constructor
   · intro h
     exact hSpan.trans h
@@ -62,7 +63,7 @@ lemma blockedChain_isInjective (A : MPSTensor d D) (L n : ℕ)
     IsInjective (blockedChain A L n) := by
   intro k
   simpa [blockedChain] using
-    (MPSTensor.IsNBlkInjective_iff_blockTensor_isInjective A L).1 hA
+    (MPSTensor.isNBlkInjective_iff_blockTensor_isInjective A L).1 hA
 
 /-- Fundamental theorem endpoint for blocked chains at a common blocking length.
 
@@ -74,8 +75,8 @@ theorem fundamentalTheorem_blockedChain
     (hMPV : MPSTensor.SameMPV
       (MPSTensor.chainCombinedTensor (blockedChain A L n))
       (MPSTensor.chainCombinedTensor (blockedChain B L n))) :
-    GaugeEquiv (blockedChain A L n) (blockedChain B L n) := by
-  exact fundamentalTheorem_injective_chain
+    GaugeEquiv (blockedChain A L n) (blockedChain B L n) :=
+  fundamentalTheorem_injective_chain
     (blockedChain A L n)
     (blockedChain B L n)
     (blockedChain_isInjective A L n hA_block)


### PR DESCRIPTION
### Motivation
- Align `BlockedChainFT` with project naming and style conventions for lemmas and theorems.
- Keep the endpoint theorem in explicit-assumption form so callers may choose blocking witnesses locally.
- Fix a small linter/style nit (`simpa` → `simp`) and remove an unnecessary `open scoped` directive.

### Description
- Removed `open scoped Matrix` from `TNLean/MPS/Chain/BlockedChainFT.lean` and added a short design note about keeping the endpoint in explicit-assumption style.
- Renamed `IsNBlkInjective_iff_blockTensor_isInjective` to `isNBlkInjective_iff_blockTensor_isInjective` and updated the call site in `blockedChain_isInjective` to use the new name.
- Converted the endpoint theorem `fundamentalTheorem_blockedChain` from a `by exact` style proof to a direct term-mode definition.
- Replaced an unnecessary `simpa` with `simp` in the span equality proof to satisfy the linter.

### Testing
- Ran `rg -n "\bsorry\b|\baxiom\b" TNLean/MPS/Chain/BlockedChainFT.lean` and found no `sorry` or `axiom` usages.
- Ran `rg -n "by exact" TNLean/MPS/Chain/BlockedChainFT.lean` and confirmed there are no remaining `by exact` occurrences.
- Built the target with `lake build TNLean.MPS.Chain.BlockedChainFT` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c278912b5883248b3aefc5cbce1b1c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: these are naming/style cleanups and proof refactors around the blocked-chain FT endpoint, with a deprecated alias to preserve compatibility.
> 
> **Overview**
> Updates the blocked-chain fundamental-theorem endpoint to match project naming/style: renames `IsNBlkInjective_iff_blockTensor_isInjective` to `isNBlkInjective_iff_blockTensor_isInjective`, adds a deprecated alias, and updates the one call site.
> 
> Also cleans up `TNLean/MPS/Chain/BlockedChainFT.lean` by removing an unused `open scoped Matrix`, adding a short design note, switching a `simpa` to `simp`, and rewriting `fundamentalTheorem_blockedChain` as a direct term-mode definition. The README status line is adjusted to reference the new lemma name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 991e3a96eb7d90d2f148eb26c93eba38cd7ef6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->