### PR TITLE
[follow-up] Rephrase Stinespring in-proof comment for entrywise-matching wording

### DIFF
--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -106,7 +106,6 @@ theorem stinespring_schrodinger_representation {r : ℕ}
     (∑ l : Fin r, K l * X * (K l)ᴴ) i j =
     ∑ k : Fin r,
       (stinespringV K * X * (stinespringV K)ᴴ) (i, k) (j, k) := by
-  -- Use `fun l => (K l)ᴴ` inside `stinespringV` so the partial trace reproduces
-  -- the Schrödinger Kraus expansion with factors `K l * X * (K l)ᴴ`.
+  -- Unfold stinespringV and match matrix entries on both sides.
   simp only [Matrix.mul_apply, Matrix.sum_apply,
     stinespringV_apply, Matrix.conjTranspose_apply]


### PR DESCRIPTION
### Motivation
- Tweak an in-proof comment in `TNLean/Channel/Stinespring.lean` to more accurately describe the proof step as unfolding `stinespringV` and matching matrix entries rather than implying an explicit substitution.

### Description
- Replace the two-line comment inside `stinespring_schrodinger_representation` with the single line `-- Unfold stinespringV and match matrix entries on both sides.` without changing any proof terms.

### Testing
- Ran `git diff -- TNLean/Channel/Stinespring.lean` and `git diff --check`, both of which completed successfully and show only the intended comment change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28676f3248324bb208311f0b576db)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only change with no modifications to proof terms or behavior.
> 
> **Overview**
> Updates a single in-proof comment in `stinespring_schrodinger_representation` (`TNLean/Channel/Stinespring.lean`) to more accurately describe the proof approach as *unfolding `stinespringV` and matching matrix entries*, without changing any Lean code or proof steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61e224c2e38266dec8f4db80e7a8ca2b1ebefada. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->