### PR TITLE
Follow-up blueprint sync: add periodic-chain aliases and Z-gauge construction lemmas

### DIFF
--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -97,13 +97,9 @@ boundary conditions (PBC).
 \begin{definition}[Periodic-chain tensor alias]\label{def:periodic_mps_tensor}
     \lean{MPSTensor.PeriodicMPSTensor}
     \leanok
-    For a fixed period $m$, \emph{periodic-chain tensors} are represented
-    by the alias
-    \[
-        \texttt{PeriodicMPSTensor}\; d\; D\; m,
-    \]
-    i.e.\ site-dependent tensors on $\Fin m$ with local physical
-    dimension~$d$ and bond dimension~$D$.
+    For a fixed period $m$, a \emph{periodic-chain tensor} is a
+    site-dependent tensor family indexed by $\{0,\ldots,m-1\}$, with
+    local physical dimension~$d$ and bond dimension~$D$.
 \end{definition}
 
 \begin{definition}[Periodic same-state and gauge-equivalence relations]\label{def:periodic_relations}
@@ -113,8 +109,8 @@ boundary conditions (PBC).
     \uses{def:periodic_mps_tensor}
     For periodic-chain tensors $A,B$ at fixed period~$m$:
     \begin{itemize}
-        \item \texttt{SameState} means equality of the induced periodic-chain state;
-        \item \texttt{GaugeEquiv} means cyclic gauge equivalence of the periodic chain.
+        \item equality of the induced periodic-chain states;
+        \item cyclic gauge equivalence.
     \end{itemize}
 \end{definition}
 
@@ -123,8 +119,8 @@ boundary conditions (PBC).
     \lean{MPSTensor.PeriodicMPSTensor.instEquivalenceGaugeEquiv}
     \leanok
     \uses{def:periodic_relations}
-    Both periodic relations above carry bundled \texttt{Equivalence}
-    structures (reflexive, symmetric, transitive).
+    Both periodic relations are equivalence relations (reflexive,
+    symmetric, transitive).
 \end{lemma}
 
 \section{Gauge equivalence and same MPV}

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -92,6 +92,41 @@ boundary conditions (PBC).
     framework appears in Chapter~\ref{ch:channels}.
 \end{remark}
 
+\section{Periodic-chain aliases}
+
+\begin{definition}[Periodic-chain tensor alias]\label{def:periodic_mps_tensor}
+    \lean{MPSTensor.PeriodicMPSTensor}
+    \leanok
+    For a fixed period $m$, \emph{periodic-chain tensors} are represented
+    by the alias
+    \[
+        \texttt{PeriodicMPSTensor}\; d\; D\; m,
+    \]
+    i.e.\ site-dependent tensors on $\Fin m$ with local physical
+    dimension~$d$ and bond dimension~$D$.
+\end{definition}
+
+\begin{definition}[Periodic same-state and gauge-equivalence relations]\label{def:periodic_relations}
+    \lean{MPSTensor.PeriodicMPSTensor.SameState}
+    \lean{MPSTensor.PeriodicMPSTensor.GaugeEquiv}
+    \leanok
+    \uses{def:periodic_mps_tensor}
+    For periodic-chain tensors $A,B$ at fixed period~$m$:
+    \begin{itemize}
+        \item \texttt{SameState} means equality of the induced periodic-chain state;
+        \item \texttt{GaugeEquiv} means cyclic gauge equivalence of the periodic chain.
+    \end{itemize}
+\end{definition}
+
+\begin{lemma}[Equivalence structures for periodic relations]\label{lem:periodic_relation_equivalences}
+    \lean{MPSTensor.PeriodicMPSTensor.instEquivalenceSameState}
+    \lean{MPSTensor.PeriodicMPSTensor.instEquivalenceGaugeEquiv}
+    \leanok
+    \uses{def:periodic_relations}
+    Both periodic relations above carry bundled \texttt{Equivalence}
+    structures (reflexive, symmetric, transitive).
+\end{lemma}
+
 \section{Gauge equivalence and same MPV}
 
 \begin{definition}[Gauge equivalence]\label{def:gauge_equiv}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -483,6 +483,67 @@ directly to periodic tensors.
 
 \subsection{The \texorpdfstring{$Z$}{Z}-gauge degree of freedom}
 
+\begin{definition}[Entrywise periodic \(Z\)-gauge ratio]\label{def:z_gauge_entry}
+	\lean{MPSTensor.zGaugeEntry}
+	\leanok
+	Given complex weights $\mu,\nu$, define the entrywise
+	\(Z\)-gauge ratio by
+	\[
+		z(\mu,\nu) := \mu/\nu.
+	\]
+\end{definition}
+
+\begin{lemma}[Matched powers imply root-of-unity ratio]\label{lem:z_gauge_entry_pow}
+	\lean{MPSTensor.zGaugeEntry_pow_eq_one_of_pow_eq}
+	\leanok
+	\uses{def:z_gauge_entry}
+	If $\mu^m=\nu^m$ and $\nu\neq 0$, then
+	\[
+		z(\mu,\nu)^m = 1.
+	\]
+\end{lemma}
+
+\begin{lemma}[Ratio rescales denominator back to numerator]\label{lem:z_gauge_entry_mul}
+	\lean{MPSTensor.zGaugeEntry_mul_right}
+	\leanok
+	\uses{def:z_gauge_entry}
+	If $\nu\neq 0$, then
+	\[
+		z(\mu,\nu)\,\nu=\mu.
+	\]
+\end{lemma}
+
+\begin{definition}[Diagonal periodic \(Z\)-gauge matrix]\label{def:z_gauge_diagonal}
+	\lean{MPSTensor.zGaugeDiagonal}
+	\leanok
+	\uses{def:z_gauge_entry}
+	For matched weight families $(\mu_i)_i$ and $(\nu_i)_i$ on a finite
+	index type, define the diagonal matrix
+	\[
+		Z := \diag\!\bigl(z(\mu_i,\nu_i)\bigr)_i.
+	\]
+\end{definition}
+
+\begin{lemma}[Diagonal \(Z\)-gauge has finite order under matched powers]\label{lem:z_gauge_diagonal_pow}
+	\lean{MPSTensor.zGaugeDiagonal_pow_eq_one}
+	\leanok
+	\uses{def:z_gauge_diagonal, lem:z_gauge_entry_pow}
+	If $\mu_i^m=\nu_i^m$ and $\nu_i\neq 0$ for all~$i$, then
+	\[
+		Z^m=\Id.
+	\]
+\end{lemma}
+
+\begin{lemma}[Diagonal \(Z\)-gauge transports diagonal weights]\label{lem:z_gauge_diagonal_mul}
+	\lean{MPSTensor.zGaugeDiagonal_mul_diagonal}
+	\leanok
+	\uses{def:z_gauge_diagonal, lem:z_gauge_entry_mul}
+	Under $\nu_i\neq 0$ for all~$i$,
+	\[
+		Z\,\diag(\nu)=\diag(\mu).
+	\]
+\end{lemma}
+
 \begin{definition}[$Z$-gauge equivalence]
 	\label{def:z_gauge_equiv}
 	\lean{MPSTensor.ZGaugeEquiv}


### PR DESCRIPTION
### Motivation

- Synchronize the blueprint chapters with newly-introduced Lean declarations for periodic MPS and the Z-gauge construction so the documentation references match the code.
- Make the blueprint explicitly reference the Lean names used in `TNLean/MPS/Periodic/Defs.lean` and `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean` to support the periodic FT equal-case assembly.

### Description

- Added a new "Periodic-chain aliases" section to `blueprint/src/chapter/ch02_mps.tex` with `\lean{}` + `\leanok` environments for `MPSTensor.PeriodicMPSTensor` and the periodic relations `MPSTensor.PeriodicMPSTensor.SameState`, `MPSTensor.PeriodicMPSTensor.GaugeEquiv`, and the bundled equivalence instances `MPSTensor.PeriodicMPSTensor.instEquivalenceSameState` and `MPSTensor.PeriodicMPSTensor.instEquivalenceGaugeEquiv`.
- Added Z-gauge construction definitions and lemmas to `blueprint/src/chapter/ch11_assembly.tex` with `\lean{}` + `\leanok` for `MPSTensor.zGaugeEntry`, `MPSTensor.zGaugeEntry_pow_eq_one_of_pow_eq`, `MPSTensor.zGaugeEntry_mul_right`, `MPSTensor.zGaugeDiagonal`, `MPSTensor.zGaugeDiagonal_pow_eq_one`, and `MPSTensor.zGaugeDiagonal_mul_diagonal`.
- All additions are documentation/blueprint changes only and forward Lean declaration names into the LaTeX blueprint so the `\lean{}` annotations match the current formalization.

### Testing

- Verified Lean declaration names via `grep -n "abbrev\|def\|theorem\|instance" TNLean/MPS/Periodic/Defs.lean` and `grep -n "def\|theorem" TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean | grep -i "gauge\|zGauge"`, and the expected names were present (succeeded).
- Performed pattern checks in the updated blueprint files with `rg -n "PeriodicMPSTensor|zGaugeEntry|zGaugeDiagonal|instEquivalence" blueprint/src/chapter/ch02_mps.tex blueprint/src/chapter/ch11_assembly.tex` to confirm the new `\lean{}` markers were inserted (succeeded).
- Ran `git diff --check` to ensure there are no trailing whitespace or whitespace errors in the diff (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d5b458b48324bbf6ffb754d564f1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only LaTeX updates that add new definitions/lemmas and `\lean{}` references without changing any executable code or proofs.
> 
> **Overview**
> Adds a new **Periodic-chain aliases** section to `ch02_mps.tex`, introducing `\lean{}` references for `MPSTensor.PeriodicMPSTensor` plus periodic `SameState`/`GaugeEquiv` relations and their `Equivalence` instances.
> 
> Extends `ch11_assembly.tex` with **$Z$-gauge construction** helper definitions/lemmas (`zGaugeEntry`, `zGaugeDiagonal`, and finite-order/transport properties) and fixes the file-ending newline so the blueprint matches the corresponding Lean names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 387713146fe3c17b38be27dac1da8e3d03ef01c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->