### PR TITLE
blueprint: add missing Lean tags for Wolf Thm. 6.2/6.8/6.15 in ch06_spectral

### DIFF
--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -551,6 +551,58 @@ The formalized results are in
     These remain TODO in the formalization.
 \end{remark}
 
+\section{Additional Wolf Chapter~6 declaration wrappers}
+
+This section records declaration wrappers used in cross-chapter references.
+
+\begin{theorem}[Wolf Thm.~6.2(3): exponential positivity condition]%
+    \label{thm:wolf_6_2_item_3}
+    \lean{exp_posDef_of_irreducible_cp}
+    \leanok
+    \uses{def:irreducible_cp}
+    Let $E$ be an irreducible completely positive map, $A \ge 0$ with
+    $A \neq 0$, and $t > 0$. Then $\exp(tE)(A)$ is positive definite.
+\end{theorem}
+
+\begin{theorem}[Wolf Thm.~6.8: Kraus-span equivalence]%
+    \label{thm:wolf_6_8_kraus_span}
+    \lean{MPSTensor.wolf_theorem_6_8_kraus_span}
+    \leanok
+    \uses{def:primitive}
+    Under normalization, paper primitivity is equivalent to eventual
+    full Kraus rank.
+\end{theorem}
+
+\begin{theorem}[Wolf Thm.~6.8: conjunction wrapper]%
+    \label{thm:wolf_6_8_conjunction}
+    \lean{MPSTensor.wolf_theorem_6_8_conjunction}
+    \leanok
+    \uses{thm:wolf_6_8_kraus_span}
+    Under normalization, paper primitivity is equivalent to the conjunction
+    of eventual full Kraus rank, normality, and strong irreducibility.
+\end{theorem}
+
+\begin{remark}[Wolf Thm.~6.8 pairwise equivalence declarations]
+    \label{rem:wolf_6_8_pairwise}
+    \lean{MPSTensor.primitivePaper_iff_hasEventuallyFullKrausRank}
+    \lean{MPSTensor.primitivePaper_iff_stronglyIrreducible}
+    \lean{MPSTensor.hasEventuallyFullKrausRank_iff_stronglyIrreducible}
+    \lean{MPSTensor.hasEventuallyFullKrausRank_iff_isNormal}
+    \leanok
+    These are the pairwise equivalence declarations referenced by the
+    packaged Wolf Thm.~6.8 wrappers.
+\end{remark}
+
+\begin{theorem}[Wolf Thm.~6.15 (scalar fixed-point algebra case)]
+    \label{thm:wolf_6_15_scalar_conditional_expectation}
+    \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
+    \leanok
+    \uses{def:channel}
+    In the scalar fixed-point algebra setting, the weighted map
+    $X \mapsto \frac{\tr(\rho X)}{\tr(\rho)}\Id$ is a conditional
+    expectation onto the adjoint fixed-point $*$-subalgebra.
+\end{theorem}
+
 \section{Primitive overlap convergence (spectral-gap form)}
 
 The theorems in this section are stated directly in terms of the


### PR DESCRIPTION
### Motivation
- Synchronize `blueprint/src/chapter/ch06_spectral.tex` with recently merged Lean declarations by adding the missing `\lean{}` / `\leanok` tags so cross-chapter references resolve.
- Provide explicit wrapper theorem/remark environments for Wolf Chapter 6 items referenced elsewhere in the text (exponential positivity, primitivity equivalences, and the scalar conditional expectation). 

### Description
- Added a new section in `blueprint/src/chapter/ch06_spectral.tex` titled "Additional Wolf Chapter~6 declaration wrappers" containing theorem/remark environments annotated with `\lean{}` and `\leanok` tags. 
- Added tags for the exponential positivity result `exp_posDef_of_irreducible_cp` (Wolf Thm.~6.2 item 3). 
- Added wrappers and references for Wolf Thm.~6.8 using `MPSTensor.wolf_theorem_6_8_kraus_span` and `MPSTensor.wolf_theorem_6_8_conjunction`, and listed the pairwise equivalence declarations `MPSTensor.primitivePaper_iff_hasEventuallyFullKrausRank`, `MPSTensor.primitivePaper_iff_stronglyIrreducible`, `MPSTensor.hasEventuallyFullKrausRank_iff_stronglyIrreducible`, and `MPSTensor.hasEventuallyFullKrausRank_iff_isNormal`. 
- Added the scalar conditional-expectation wrapper tag `Kraus.scalarConditionalExpectation_isConditionalExpectation` for Wolf Thm.~6.15 (scalar fixed-point algebra case), and documented that requested literal names like `irreducible_iff_exp_posDef_forall` and `conditional_expectation_fixedPoints` were not present verbatim so the actual declaration names were used. 

### Testing
- Verified the inserted tags and contexts with repository searches using `rg -n` and `grep -n` for the relevant declaration names, which located the actual Lean declarations referenced in the new wrappers. 
- Printed the modified region of `blueprint/src/chapter/ch06_spectral.tex` with `sed -n` to confirm the inserted theorem/remark blocks and `\lean{}` / `\leanok` annotations are present. 
- Ran a final `rg -n` check scoped to the modified file to confirm the new labels and Lean tags appear as expected, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d5b2802483248a718a9c071446a6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: blueprint-only LaTeX changes that add theorem/remark wrappers and Lean annotation tags; no code or proof logic is modified.
> 
> **Overview**
> Adds a new section in `ch06_spectral.tex` providing **wrapper theorem/remark environments** for several Wolf Chapter 6 results that are referenced across chapters.
> 
> The new wrappers introduce labels plus `\lean{}`/`\leanok` annotations for Wolf Thm. 6.2(3) (exponential positivity), Wolf Thm. 6.8 (primitivity/Kraus-rank equivalences, including a conjunction wrapper and pairwise equivalence declarations), and Wolf Thm. 6.15 (scalar conditional expectation), improving cross-chapter reference resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1c97bc36398200297fdf3ae0ba65f083bad6989. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->