### PR TITLE
feat(Algebra): add scalar commutant lemma (center of M_n = scalars)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -29,6 +29,7 @@ import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.MatrixFrobenius
 import TNLean.Algebra.ProjectiveRepresentation
+import TNLean.Algebra.ScalarCommutant
 
 -- Layer 1: Generic convex/topological infrastructure
 import TNLean.Topology.ConvexProjection

--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Data.Matrix.Basis
+
+/-!
+# Scalar commutant lemma: center of M_n(R) = R·1
+
+If a matrix `Z` commutes with every element of a spanning set of `M_n(R)`,
+then `Z` is a scalar matrix. This is the algebraic fact that the center
+of the full matrix algebra over a commutative ring is trivial.
+
+## Main results
+
+* `Matrix.commute_span_top_isScalar`: if `Z` commutes with a spanning set,
+  then `Z = scalar n c` for some `c`.
+-/
+
+open scoped Matrix
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+  {R : Type*} [CommSemiring R]
+
+/-- A matrix that commutes with a spanning set of `M_n(R)` lies in the center,
+hence is a scalar matrix. -/
+theorem commute_span_top_isScalar
+    (Z : Matrix n n R)
+    {S : Set (Matrix n n R)}
+    (hS : Submodule.span R S = ⊤)
+    (hZ : ∀ M ∈ S, Z * M = M * Z) :
+    ∃ c : R, Z = Matrix.scalar n c := by
+  have hcomm_all : ∀ M : Matrix n n R, Z * M = M * Z := by
+    intro M
+    have hM : M ∈ Submodule.span R S := hS ▸ Submodule.mem_top
+    induction hM using Submodule.span_induction with
+    | mem x hx => exact hZ x hx
+    | zero => simp
+    | add x y _ _ hx hy => rw [mul_add, add_mul, hx, hy]
+    | smul r x _ hx =>
+      simp only [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, hx]
+  have hcenter : Z ∈ Set.center (Matrix n n R) := by
+    rw [Set.mem_center_iff]
+    exact {
+      comm := fun a => show Z * a = a * Z from hcomm_all a
+      left_assoc := fun b c => (mul_assoc Z b c).symm
+      right_assoc := fun a b => mul_assoc a b Z
+    }
+  rw [center_eq_scalar_image] at hcenter
+  obtain ⟨c, _, rfl⟩ := hcenter
+  exact ⟨c, rfl⟩
+
+end Matrix

--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -13,7 +13,7 @@ of the full matrix algebra over a commutative ring is trivial.
 
 ## Main results
 
-* `Matrix.commute_span_top_isScalar`: if `Z` commutes with a spanning set,
+* `Matrix.isScalar_of_commute_span_eq_top`: if `Z` commutes with a spanning set,
   then `Z = scalar n c` for some `c`.
 -/
 
@@ -26,7 +26,7 @@ variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- A matrix that commutes with a spanning set of `M_n(R)` lies in the center,
 hence is a scalar matrix. -/
-theorem commute_span_top_isScalar
+theorem isScalar_of_commute_span_eq_top
     (Z : Matrix n n R)
     {S : Set (Matrix n n R)}
     (hS : Submodule.span R S = ⊤)
@@ -44,7 +44,7 @@ theorem commute_span_top_isScalar
   have hcenter : Z ∈ Set.center (Matrix n n R) := by
     rw [Set.mem_center_iff]
     exact {
-      comm := fun a => show Z * a = a * Z from hcomm_all a
+      comm := fun a => hcomm_all a
       left_assoc := fun b c => (mul_assoc Z b c).symm
       right_assoc := fun a b => mul_assoc a b Z
     }

--- a/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
@@ -36,13 +36,13 @@ private lemma trace_ne_zero_of_proj_ne_zero'
     {P : Mat} (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
     Matrix.trace P ≠ 0 := by
   intro htr
-  exact hP_ne ((orthogonalProjection_posSemidef hP).trace_eq_zero_iff.1 htr)
+  exact hP_ne ((isOrthogonalProjection_posSemidef hP).trace_eq_zero_iff.1 htr)
 
 /-- `P / tr(P)` is a density matrix. -/
 private lemma normalizedProj_mem_densityMatrices'
     {P : Mat} (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
     ((trace P)⁻¹ • P) ∈ densityMatrices D := by
-  have hP_psd := orthogonalProjection_posSemidef hP
+  have hP_psd := isOrthogonalProjection_posSemidef hP
   have htrP_ne := trace_ne_zero_of_proj_ne_zero' hP hP_ne
   exact ⟨hP_psd.smul (inv_nonneg_of_nonneg hP_psd.trace_nonneg),
     by simp [Matrix.trace_smul, htrP_ne]⟩


### PR DESCRIPTION
## Summary
- Add `Matrix.isScalar_of_commute_span_eq_top`: a matrix commuting with a spanning set of M_n(R) is scalar
- Uses Mathlib's `center_eq_scalar_image` for the center characterization
- Proof lifts commutativity from generators to all matrices via `Submodule.span_induction`

## Motivation
This is the critical-path bottleneck for the symmetry/SPT chain (#154). It unblocks:
- #156 (gauge uniqueness)
- #158 (virtual representation theorem)
- #159 (cocycle coboundary)
- #160 (string order)

Closes #155