### PR TITLE
Allow claude and chatgpt-codex-connector bots in workflows

### DIFF
--- a/.github/workflows/ci-failure-auto-fix.yml
+++ b/.github/workflows/ci-failure-auto-fix.yml
@@ -120,7 +120,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'claude'
+          allowed_bots: 'claude,chatgpt-codex-connector'
           prompt: |
             The Lean CI build failed. Your task is to fix the build errors.
 

--- a/.github/workflows/ci-failure-auto-fix.yml
+++ b/.github/workflows/ci-failure-auto-fix.yml
@@ -120,6 +120,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude'
           prompt: |
             The Lean CI build failed. Your task is to fix the build errors.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'claude'
+          allowed_bots: 'claude,chatgpt-codex-connector'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'claude'
+          allowed_bots: 'claude,chatgpt-codex-connector'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,6 +46,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
@@ -36,13 +36,13 @@ private lemma trace_ne_zero_of_proj_ne_zero'
     {P : Mat} (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
     Matrix.trace P ≠ 0 := by
   intro htr
-  exact hP_ne ((orthogonalProjection_posSemidef hP).trace_eq_zero_iff.1 htr)
+  exact hP_ne ((isOrthogonalProjection_posSemidef hP).trace_eq_zero_iff.1 htr)
 
 /-- `P / tr(P)` is a density matrix. -/
 private lemma normalizedProj_mem_densityMatrices'
     {P : Mat} (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
     ((trace P)⁻¹ • P) ∈ densityMatrices D := by
-  have hP_psd := orthogonalProjection_posSemidef hP
+  have hP_psd := isOrthogonalProjection_posSemidef hP
   have htrP_ne := trace_ne_zero_of_proj_ne_zero' hP hP_ne
   exact ⟨hP_psd.smul (inv_nonneg_of_nonneg hP_psd.trace_nonneg),
     by simp [Matrix.trace_smul, htrP_ne]⟩


### PR DESCRIPTION
## Summary
- Add `allowed_bots: 'claude,chatgpt-codex-connector'` to all three Claude Code workflow files
- This allows both the **Claude** bot and the **ChatGPT Codex Connector** bot to trigger workflow runs
- Affected workflows:
  - `claude.yml` (main Claude Code action)
  - `claude-code-review.yml` (PR review)
  - `ci-failure-auto-fix.yml` (auto-fix CI failures)

## Why
Both AI coding agents (Claude and Codex) are used in this repository. Without `allowed_bots`, events from these bot accounts are ignored by the `claude-code-action`, preventing cross-agent collaboration (e.g., Codex tagging `@claude` for help).

https://claude.ai/code/session_013AyYjxTn9NE4fEmyPTeE4k