### PR TITLE
[Issue #120] Apply remaining cleanup nits from PRs #99/#104/#107/#109/#111

### DIFF
--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -1337,6 +1337,7 @@ theorem isPrimitive_restriction_of_cyclic_decomp
     (hcorner_fix k)
     (hcorner_ne k)
     (huniq k)
+
 section PermutationBlockStructure
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
@@ -1355,7 +1356,6 @@ theorem preserves_corner_pow_orderOf_of_perm_decomp
     (hMulLeft : ∀ k : ι, ∀ X : MatrixAlg D, T (P k * X) = T (P k) * T X)
     (hMulRight : ∀ k : ι, ∀ X : MatrixAlg D, T (X * P k) = T X * T (P k)) :
     ∀ k : ι, PreservesCorner (P k) (T ^ orderOf σ) := by
-  let _ := (inferInstance : DecidableEq ι)
   have hstep :
       ∀ n : ℕ, ∀ k : ι, ∀ X : MatrixAlg D,
         (T ^ n) (P ((σ ^ n) k) * X * P ((σ ^ n) k)) =
@@ -1386,12 +1386,10 @@ theorem preserves_corner_pow_orderOf_of_perm_decomp
           _ = P k * ((T ^ n) (T X)) * P k := ih k (T X)
           _ = P k * ((T ^ (n + 1)) X) * P k := by simp [pow_succ]
   intro k X
-  have horder_pos : 0 < orderOf σ := orderOf_pos σ
   have hmain :
       (T ^ orderOf σ) (P ((σ ^ orderOf σ) k) * X * P ((σ ^ orderOf σ) k)) =
         P k * ((T ^ orderOf σ) X) * P k := hstep (orderOf σ) k X
-  have hσ : (σ ^ orderOf σ) = 1 := by
-    exact pow_orderOf_eq_one σ
+  have hσ : (σ ^ orderOf σ) = 1 := pow_orderOf_eq_one σ
   have hmk : (T ^ orderOf σ) (P k * X * P k) = P k * ((T ^ orderOf σ) X) * P k := by
     simpa [hσ] using hmain
   calc

--- a/TNLean/Channel/Semigroup/ProductFormula.lean
+++ b/TNLean/Channel/Semigroup/ProductFormula.lean
@@ -16,6 +16,9 @@ needed for finite-dimensional product-formula arguments on `End(M_D(ℂ))`.
 * `norm_exp_le_real_exp_norm` — `‖exp x‖ ≤ exp ‖x‖`
 * `norm_expSemigroupCLM_le` — `‖exp(tA)‖ ≤ exp(t‖A‖)` for `t ≥ 0`
 * `norm_trotter_step_le` — norm bound for one Lie--Trotter step
+* `norm_trotter_pow_sub_exp_le_of_quadratic_step` —
+  global `O(1/n)` bound from a quadratic step defect
+* `lie_trotter_suzuki_bound_of_step` — Suzuki/Wolf-style specialization of the quadratic-step bound
 * `expSemigroupCLM_mul_comm` — `exp(tA)` commutes with `A`
 * `expSemigroupCLM_pow_eq` — powers of `exp(tA)` collapse to one exponential
 
@@ -237,7 +240,7 @@ theorem norm_trotter_pow_sub_exp_le_of_quadratic_step [NeZero D]
     rw [← Real.exp_add]
     dsimp [s]
     congr 1
-    norm_num [Nat.cast_add]
+    push_cast
     field_simp [hcast_pos.ne']
     ring
   calc
@@ -266,9 +269,18 @@ theorem lie_trotter_suzuki_bound_of_step [NeZero D]
       - expSemigroupCLM (A + B) t‖
       ≤ ((2 * t ^ 2 / (n + 1)) * (‖A‖ + ‖B‖) ^ 2) *
           Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := by
-  simpa [mul_assoc, mul_left_comm, mul_comm, div_eq_mul_inv] using
+  have hquad :=
     norm_trotter_pow_sub_exp_le_of_quadratic_step (A := A) (B := B) (t := t) (n := n) ht
       (C := 2 * (‖A‖ + ‖B‖) ^ 2) hstep
+  calc
+    ‖(expSemigroupCLM A (t / (n + 1)) * expSemigroupCLM B (t / (n + 1))) ^ (n + 1)
+      - expSemigroupCLM (A + B) t‖
+        ≤ ((2 * (‖A‖ + ‖B‖) ^ 2) * t ^ 2 / (n + 1)) *
+            Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := by
+              simpa using hquad
+    _ = ((2 * t ^ 2 / (n + 1)) * (‖A‖ + ‖B‖) ^ 2) *
+          Real.exp ((((n + 2 : ℕ) : ℝ) / (n + 1)) * t * (‖A‖ + ‖B‖)) := by
+            ring
 
 end ProductFormulaHelpers
 

--- a/TNLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/TNLean/Channel/Semigroup/RelaxationConditions.lean
@@ -45,15 +45,4 @@ theorem not_isReducibleQDS_of_no_blockUpperTriangular_lindblad
   intro hReducible
   exact hNoBlockUT (wolf_prop_7_6_three_implies_four hGKSL hReducible)
 
-/--
-Rephrasing of `not_isReducibleQDS_of_no_blockUpperTriangular_lindblad` with
-the assumptions in the opposite order.
--/
-theorem no_blockUpperTriangular_lindblad_implies_not_isReducibleQDS
-    {L : Mat →ₗ[ℂ] Mat}
-    (hNoBlockUT : ¬ HasBlockUpperTriangularLindblad L)
-    (hGKSL : IsGKSLGenerator L) :
-    ¬ IsReducibleQDS L :=
-  not_isReducibleQDS_of_no_blockUpperTriangular_lindblad hGKSL hNoBlockUT
-
 end -- noncomputable section

--- a/TNLean/Channel/Semigroup/Resolvent.lean
+++ b/TNLean/Channel/Semigroup/Resolvent.lean
@@ -23,7 +23,7 @@ private abbrev CLM (D : ℕ) :=
 
 /-- Neumann-series specialization at `z = 1`:
 if `‖L‖ < 1`, then `R(1,L) = ∑ₙ L^n`. -/
-theorem generatorResolventCLM_one_neumann
+theorem resolvent_one_neumann
     (L : CLM D) (hL : ‖L‖ < 1) :
     resolvent L (1 : ℂ) = ∑' n : ℕ, L ^ n := by
   simpa [resolvent, Algebra.algebraMap_eq_smul_one, one_smul] using

--- a/TNLean/Channel/Semigroup/Resolvent.lean
+++ b/TNLean/Channel/Semigroup/Resolvent.lean
@@ -21,24 +21,17 @@ variable {D : ℕ}
 private abbrev CLM (D : ℕ) :=
   Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ
 
-/-- Resolvent of a semigroup generator (`R(z,L) = (z • 1 - L)⁻¹`). -/
-abbrev generatorResolventCLM (L : CLM D) (z : ℂ) : CLM D :=
-  resolvent L z
-
-@[simp] theorem generatorResolventCLM_eq_mathlib (L : CLM D) (z : ℂ) :
-    generatorResolventCLM L z = resolvent L z := rfl
-
 /-- Neumann-series specialization at `z = 1`:
 if `‖L‖ < 1`, then `R(1,L) = ∑ₙ L^n`. -/
 theorem generatorResolventCLM_one_neumann
     (L : CLM D) (hL : ‖L‖ < 1) :
-    generatorResolventCLM L (1 : ℂ) = ∑' n : ℕ, L ^ n := by
-  simpa [generatorResolventCLM, resolvent, Algebra.algebraMap_eq_smul_one, one_smul] using
+    resolvent L (1 : ℂ) = ∑' n : ℕ, L ^ n := by
+  simpa [resolvent, Algebra.algebraMap_eq_smul_one, one_smul] using
     (NormedRing.inverse_one_sub L hL)
 
 /-- Euler resolvent step `(λ R(λ,L))`. -/
 def eulerResolventStep (L : CLM D) (lam : ℂ) : CLM D :=
-  lam • generatorResolventCLM L lam
+  lam • resolvent L lam
 
 /-- Finite-`n` Euler approximation term `((n/t)R(n/t,L))^n`. -/
 def eulerResolventApprox (L : CLM D) (t : ℝ) (n : ℕ) : CLM D :=

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -45,13 +45,6 @@ lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) 
   · intro h
     exact hSpan.symm.trans h
 
-/-- Deprecated compatibility alias for
-`isNBlkInjective_iff_blockTensor_isInjective`. -/
-@[deprecated isNBlkInjective_iff_blockTensor_isInjective (since := "2026-03-24")]
-lemma IsNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
-    IsNBlkInjective A N ↔ IsInjective (blockTensor A N) :=
-  isNBlkInjective_iff_blockTensor_isInjective A N
-
 end MPSTensor
 
 namespace MPSChainTensor


### PR DESCRIPTION
### Motivation
- Make several proofs robust against Mathlib/leanci bumps by replacing fragile `norm_num`/`simpa` usage with explicit `push_cast`/`field_simp`/`calc`/`ring` patterns.
- Remove trivial wrappers, dead `@[simp]` lemmas and redundant reorders to reduce maintenance surface and duplicate definitions.
- Tighten APIs and names to Mathlib conventions by removing unused hypotheses and fixing lemma casing and docstrings.
- Apply small style/whitespace fixes requested by previous reviews so the codebase stays consistent.

### Description
- ProductFormula.lean: added the two missing theorem names to the module docstring, replaced `norm_num [Nat.cast_add]` with `push_cast; field_simp [hcast_pos.ne']; ring`, and replaced the fragile `simpa [...]` endpoint in the Suzuki bound with an explicit `have` + `calc` + `ring` sequence.
- Resolvent.lean: inlined Mathlib's `resolvent` use, removed the trivial `generatorResolventCLM` abbrev and its dead `@[simp]` lemma, and updated `eulerResolventStep` / the Neumann specialization to call `resolvent` directly.
- RelaxationConditions.lean: removed the trivial argument-reordering theorem `no_blockUpperTriangular_lindblad_implies_not_isReducibleQDS`, keeping the single canonical formulation.
- BlockedChainFT.lean & CyclicDecomposition.lean: removed the deprecated uppercase compatibility alias for the block-injectivity lemma, removed redundant `inferInstance : DecidableEq` and an unused `have horder_pos`, switched `pow_orderOf_eq_one` to direct term mode, and added the requested blank line before `section PermutationBlockStructure`.
- This changeset is intended to be minimal and focused on the review nits; Closes #120.

### Testing
- Ran textual checks for the targeted symbols with `rg` to confirm removals/renames; the expected matches were updated accordingly and no unexpected leftover symbols remained.
- Built the affected modules with `lake build TNLean.Channel.Semigroup.ProductFormula TNLean.Channel.Semigroup.Resolvent TNLean.Channel.Semigroup.RelaxationConditions TNLean.MPS.Chain.BlockedChainFT TNLean.Channel.Peripheral.CyclicDecomposition`, and the build completed successfully.
- The build emitted only pre-existing warnings (style/linter notes and existing `sorry` markers elsewhere) and no new failures were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3c423da7883248c9c4d4ff0243d00)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mainly proof-robustness tweaks and removal of redundant helper lemmas/abbrevs; the only functional change is eliminating deprecated/duplicate API surface, which could break downstream code still using the removed names.
> 
> **Overview**
> **Maintenance cleanup across several Lean modules.** Proofs in `ProductFormula.lean` and `CyclicDecomposition.lean` are made less fragile (e.g., replacing `norm_num`/implicit instances with explicit `push_cast`/`field_simp`/`calc` steps and removing unused locals).
> 
> **API surface is reduced.** `Resolvent.lean` drops the `generatorResolventCLM` wrapper in favor of direct `resolvent` use (renaming the Neumann lemma to `resolvent_one_neumann` and updating Euler-step definitions), `RelaxationConditions.lean` removes a trivial argument-reordering lemma, and `BlockedChainFT.lean` removes a deprecated compatibility alias.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ad31a91c0bdebcb7c8c71ec47eb37f7bb5e33e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->