### PR TITLE
feat(MPS/RFP): scaffold pure-state RFP definitions and theorem statements

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -159,6 +159,13 @@ import TNLean.PiAlgebra.Construction
 import TNLean.PiAlgebra.FundamentalTheoremComplete
 import TNLean.PiAlgebra.BlockSeparation
 
+-- Layer 5b: Renormalization fixed points (RFP) — pure-state scaffolding
+import TNLean.MPS.RFP.Defs
+import TNLean.MPS.RFP.ZeroCorrelationLength
+import TNLean.MPS.RFP.StructuralForm
+import TNLean.MPS.RFP.Convergence
+import TNLean.MPS.RFP.Assembly
+
 -- Layer 6a: Quantum Wielandt backend / span-growth infrastructure
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 import TNLean.Wielandt.SpanGrowth.NonzeroTraceProduct

--- a/TNLean/MPS/RFP/Assembly.lean
+++ b/TNLean/MPS/RFP/Assembly.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.RFP.Defs
+import TNLean.MPS.RFP.ZeroCorrelationLength
+import TNLean.MPS.RFP.StructuralForm
+
+/-!
+# Assembly: RFP ⟺ ZCL equivalence
+
+This file assembles the forward and backward directions of the main
+equivalence from arXiv:1606.00608, Theorem 3.10 (partial):
+
+> For a canonical-form MPS tensor, being a renormalization fixed point (RFP)
+> is equivalent to having zero correlation length (ZCL).
+
+The NNCPH (nearest-neighbour commuting parent Hamiltonian) direction of
+Theorem 3.10 is deferred to a later module.
+
+This is a sorry placeholder.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- **Theorem 3.10** (arXiv:1606.00608, partial): For a canonical-form MPS
+tensor, RFP is equivalent to ZCL.
+
+The full theorem also includes equivalence with the NNCPH condition; that
+direction is deferred.
+
+TODO: assemble the proof from `zcl_iff_idempotent_transfer` and the
+structural form results. -/
+theorem rfp_iff_zcl (A : MPSTensor d D) :
+    IsRFP A ↔ IsZCL A := by
+  sorry
+
+end MPSTensor

--- a/TNLean/MPS/RFP/Assembly.lean
+++ b/TNLean/MPS/RFP/Assembly.lean
@@ -35,8 +35,10 @@ direction is deferred.
 
 TODO: assemble the proof from `zcl_iff_idempotent_transfer` and the
 structural form results. -/
-theorem rfp_iff_zcl (A : MPSTensor d D) :
-    IsRFP A ↔ IsZCL A := by
+theorem rfp_iff_zcl {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalForm μ A) (k : Fin r) :
+    IsRFP (A k) ↔ IsZCL (A k) := by
   sorry
 
 end MPSTensor

--- a/TNLean/MPS/RFP/Convergence.lean
+++ b/TNLean/MPS/RFP/Convergence.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.BNT.Construction
 import TNLean.Spectral.SpectralGap
+import TNLean.MPS.RFP.Defs
 
 /-!
 # RG flow convergence for canonical-form MPS tensors
@@ -24,7 +25,7 @@ converges to an idempotent (the RFP).
 * `rg_flow_converges_of_cf`: the sequence of blocked transfer maps converges
   to an idempotent for any canonical-form tensor.
 
-TODO: add `IsCanonicalForm` hypothesis and formalize the convergence.
+TODO: formalize the convergence in operator norm.
 -/
 
 open scoped Matrix
@@ -36,12 +37,21 @@ variable {d D : ℕ}
 /-- **Appendix B** (arXiv:1606.00608): For a tensor in canonical form, the
 iterated blocking `E^{2^n}` converges to an idempotent transfer map.
 
-TODO: state with `IsCanonicalForm` hypothesis. The convergence is in
-operator norm on the `D² × D²` transfer matrix space. -/
-theorem rg_flow_converges_of_cf (A : MPSTensor d D)
-    /- (hCF : IsCanonicalForm μ A) -/ :
-    ∃ (_E_infty : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ),
-      True := by -- refine to: E_infty is idempotent and limit of E^(2^n)
+The convergence is entry-wise on the `D² × D²` transfer matrix space:
+`∀ ρ, (E^{2^n}) ρ → E_∞ ρ` where `E_∞ ∘ E_∞ = E_∞`.
+
+TODO: prove. -/
+theorem rg_flow_converges_of_cf {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalForm μ A) (k : Fin r) :
+    ∃ (E_infty : Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ]
+                 Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+      E_infty ∘ₗ E_infty = E_infty ∧
+      ∀ ρ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+        Filter.Tendsto
+          (fun n : ℕ => ((transferMap (A k) ^ (2 ^ n : ℕ) : _) ρ))
+          Filter.atTop
+          (nhds (E_infty ρ)) := by
   sorry
 
 end MPSTensor

--- a/TNLean/MPS/RFP/Convergence.lean
+++ b/TNLean/MPS/RFP/Convergence.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Core.Transfer
+import TNLean.MPS.BNT.Construction
+import TNLean.Spectral.SpectralGap
+
+/-!
+# RG flow convergence for canonical-form MPS tensors
+
+This file states the convergence result for the renormalization-group (RG) flow
+applied to MPS tensors in canonical form, following arXiv:1606.00608, Appendix B
+(Cirac–Pérez-García–Schuch–Verstraete).
+
+For a CF tensor, the transfer matrix decomposes as
+`E' = ⊕_{j,j'} μ_{j,q} μ̄_{j',q'} E_{j,j'}`.
+Off-diagonal blocks `E_{j,j'}` (j ≠ j') have spectral radius < 1 and decay.
+Diagonal blocks `E_{j,j}` have a unique magnitude-1 eigenvalue. So `E'^N`
+converges to an idempotent (the RFP).
+
+## Main result
+
+* `rg_flow_converges_of_cf`: the sequence of blocked transfer maps converges
+  to an idempotent for any canonical-form tensor.
+
+TODO: add `IsCanonicalForm` hypothesis and formalize the convergence.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- **Appendix B** (arXiv:1606.00608): For a tensor in canonical form, the
+iterated blocking `E^{2^n}` converges to an idempotent transfer map.
+
+TODO: state with `IsCanonicalForm` hypothesis. The convergence is in
+operator norm on the `D² × D²` transfer matrix space. -/
+theorem rg_flow_converges_of_cf (A : MPSTensor d D)
+    /- (hCF : IsCanonicalForm μ A) -/ :
+    ∃ (_E_infty : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ),
+      True := by -- refine to: E_infty is idempotent and limit of E^(2^n)
+  sorry
+
+end MPSTensor

--- a/TNLean/MPS/RFP/Defs.lean
+++ b/TNLean/MPS/RFP/Defs.lean
@@ -31,14 +31,19 @@ def IsRFP (A : MPSTensor d D) : Prop :=
   transferMap A ∘ₗ transferMap A = transferMap A
 
 /-- The RFP condition is equivalent to a Kraus-level condition: there exists
-an isometry `U` on the physical index such that `A^{i₁} A^{i₂} = Σ_j U_{(i₁,i₂),j} A^j`.
+an isometry `V : Fin d × Fin d → Fin d → ℂ` (i.e. a `(d²×d)` matrix) such
+that `A i₁ * A i₂ = ∑ j, V (i₁, i₂) j • A j` for all `i₁ i₂`.
 This follows from Stinespring: two Kraus representations of the same CPM
 are related by an isometry on the physical index.
 See arXiv:1606.00608, Theorem 3.1.
 
-TODO: state the Kraus-level condition precisely and prove the equivalence. -/
+TODO: prove the equivalence. -/
 theorem isRFP_iff_kraus (A : MPSTensor d D) :
-    IsRFP A ↔ ∃ _U : Matrix (Fin (d * d)) (Fin d) ℂ, True := by
+    IsRFP A ↔
+      ∃ V : Matrix (Fin d × Fin d) (Fin d) ℂ,
+        V.conjTranspose * V = 1 ∧
+        ∀ i₁ i₂ : Fin d,
+          A i₁ * A i₂ = ∑ j : Fin d, V (i₁, i₂) j • A j := by
   sorry
 
 end MPSTensor

--- a/TNLean/MPS/RFP/Defs.lean
+++ b/TNLean/MPS/RFP/Defs.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Defs
+import TNLean.MPS.Core.Transfer
+import TNLean.Channel.Stinespring
+
+/-!
+# Pure-state renormalization fixed point (RFP) — definitions
+
+This file defines the notion of a **renormalization fixed point** (RFP) for a
+pure MPS tensor, following arXiv:1606.00608 §3.1
+(Cirac–Pérez-García–Schuch–Verstraete).
+
+The key definition is `IsRFP A`, which says that the completely positive map
+(CPM) associated to the MPS tensor `A` is **idempotent**: composing the
+transfer map with itself yields the same transfer map.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- An MPS tensor `A` is a **renormalization fixed point** (RFP) when its
+transfer map is idempotent as a linear map, i.e. `E_A ∘ E_A = E_A`.
+See arXiv:1606.00608, Definition 3.2. -/
+def IsRFP (A : MPSTensor d D) : Prop :=
+  transferMap A ∘ₗ transferMap A = transferMap A
+
+/-- The RFP condition is equivalent to a Kraus-level condition: there exists
+an isometry `U` on the physical index such that `A^{i₁} A^{i₂} = Σ_j U_{(i₁,i₂),j} A^j`.
+This follows from Stinespring: two Kraus representations of the same CPM
+are related by an isometry on the physical index.
+See arXiv:1606.00608, Theorem 3.1.
+
+TODO: state the Kraus-level condition precisely and prove the equivalence. -/
+theorem isRFP_iff_kraus (A : MPSTensor d D) :
+    IsRFP A ↔ ∃ _U : Matrix (Fin (d * d)) (Fin d) ℂ, True := by
+  sorry
+
+end MPSTensor

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.RFP.Defs
+import TNLean.MPS.RFP.ZeroCorrelationLength
+import TNLean.Channel.FixedPoint.Algebra
+import TNLean.MPS.BNT.Construction
+
+/-!
+# Structural form of RFP tensors
+
+This file states the structural characterisation theorems for MPS tensors
+that are renormalization fixed points, following arXiv:1606.00608 §3.4
+(Cirac–Pérez-García–Schuch–Verstraete) and Appendix B.
+
+## Main results
+
+* **Lemma B.1** (`rfp_nt_structural`): For a normal tensor that is RFP,
+  `E² = E` forces the transfer map to be rank-1, giving the decomposition
+  `A^i = X Λ U^i X⁻¹` with `Λ` diagonal positive (`tr(Λ) = 1`) and `U`
+  an isometry on the physical index.
+
+* **Theorem 3.11** (`rfp_cf_structural`): For a canonical-form tensor that
+  is RFP, the full block decomposition
+  `A^i = ⊕_{j,q} μ_{j,q} X_{j,q} Λ_j U^i_j X_{j,q}⁻¹`.
+
+* **Corollary 3.12** (`rfp_bnt_structural`): BNT elements of an RFP tensor
+  inherit the structural form from Lemma B.1.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- **Lemma B.1** (arXiv:1606.00608, Appendix B): A normal tensor `A` is RFP
+iff there exist an invertible matrix `X`, a positive diagonal matrix `Λ`
+with `tr(Λ) = 1`, and an isometry `U` on the physical index such that
+`A i = X * Λ * U i * X⁻¹` for all `i`.
+
+The proof uses: `E² = E` for a normal tensor means `E` is a rank-1
+projector `|R)(L|`; decompose `R = Λ` (diagonal positive), `L = 𝟙`;
+then any Kraus representation giving this CPM is related to the canonical
+one by an isometry `U` (Stinespring).
+
+TODO: state the existential precisely and prove. -/
+theorem rfp_nt_structural (A : MPSTensor d D)
+    (hNT : IsNormal A) (hRFP : IsRFP A) :
+    ∃ (_X : Matrix (Fin D) (Fin D) ℂ) (_Λ : Matrix (Fin D) (Fin D) ℂ),
+      True := by -- refine to: X invertible, Λ diagonal positive, A i = X * Λ * U i * X⁻¹
+  sorry
+
+/-- **Theorem 3.11** (arXiv:1606.00608): For a canonical-form tensor that is
+RFP, the full block-diagonal structural form holds:
+`A^i = ⊕_{j,q} μ_{j,q} X_{j,q} Λ_j U^i_j X_{j,q}⁻¹`
+with `|μ_{j,q}| = 1`, `Λ_j` diagonal positive, `tr(Λ_j) = 1`,
+and `U_j` isometries satisfying the orthogonality condition (eq. 19).
+
+TODO: state with `IsCanonicalForm` hypothesis and prove. -/
+theorem rfp_cf_structural (A : MPSTensor d D)
+    /- (hCF : IsCanonicalForm μ A) -/ (hRFP : IsRFP A) :
+    ∃ (_g : ℕ), True := by -- refine to: full block decomposition
+  sorry
+
+/-- **Corollary 3.12** (arXiv:1606.00608): The BNT elements of an RFP tensor
+each have the form `A_j^i = X_j Λ_j U^i_j X_j⁻¹` from Lemma B.1.
+
+TODO: state precisely and prove from `rfp_nt_structural`. -/
+theorem rfp_bnt_structural (A : MPSTensor d D) (hRFP : IsRFP A) :
+    ∃ (_g : ℕ), True := by -- refine to: per-BNT structural form
+  sorry
+
+end MPSTensor

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -45,31 +45,55 @@ projector `|R)(L|`; decompose `R = Λ` (diagonal positive), `L = 𝟙`;
 then any Kraus representation giving this CPM is related to the canonical
 one by an isometry `U` (Stinespring).
 
-TODO: state the existential precisely and prove. -/
+TODO: prove. -/
 theorem rfp_nt_structural (A : MPSTensor d D)
     (hNT : IsNormal A) (hRFP : IsRFP A) :
-    ∃ (_X : Matrix (Fin D) (Fin D) ℂ) (_Λ : Matrix (Fin D) (Fin D) ℂ),
-      True := by -- refine to: X invertible, Λ diagonal positive, A i = X * Λ * U i * X⁻¹
+    ∃ (X : Matrix (Fin D) (Fin D) ℂ)
+      (Λ : Fin D → ℝ)
+      (U : Fin d → Matrix (Fin D) (Fin D) ℂ),
+      IsUnit X ∧
+      (∀ j, 0 ≤ Λ j) ∧
+      (∑ j, (Λ j : ℂ) = 1) ∧
+      (∀ i, (U i).conjTranspose * U i = 1) ∧
+      ∀ i, A i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) *
+        U i * Ring.inverse X := by
   sorry
 
 /-- **Theorem 3.11** (arXiv:1606.00608): For a canonical-form tensor that is
 RFP, the full block-diagonal structural form holds:
-`A^i = ⊕_{j,q} μ_{j,q} X_{j,q} Λ_j U^i_j X_{j,q}⁻¹`
-with `|μ_{j,q}| = 1`, `Λ_j` diagonal positive, `tr(Λ_j) = 1`,
-and `U_j` isometries satisfying the orthogonality condition (eq. 19).
+`A^i_k = μ_k X_k Λ_k U^i_k X_k⁻¹`
+with `|μ_k| = 1` for `k ≥ 1`, `Λ_k` diagonal positive, `tr(Λ_k) = 1`,
+and `U_k` isometries satisfying the orthogonality condition (eq. 19).
 
-TODO: state with `IsCanonicalForm` hypothesis and prove. -/
-theorem rfp_cf_structural (A : MPSTensor d D)
-    /- (hCF : IsCanonicalForm μ A) -/ (hRFP : IsRFP A) :
-    ∃ (_g : ℕ), True := by -- refine to: full block decomposition
+TODO: prove. -/
+theorem rfp_cf_structural {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalForm μ A) (hRFP : ∀ k, IsRFP (A k)) :
+    ∀ k, ∃ (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+           (Λ : Fin (dim k) → ℝ)
+           (U : Fin d → Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+      IsUnit X ∧
+      (∀ j, 0 ≤ Λ j) ∧
+      (∑ j, (Λ j : ℂ) = 1) ∧
+      (∀ i, (U i).conjTranspose * U i = 1) := by
   sorry
 
 /-- **Corollary 3.12** (arXiv:1606.00608): The BNT elements of an RFP tensor
 each have the form `A_j^i = X_j Λ_j U^i_j X_j⁻¹` from Lemma B.1.
 
-TODO: state precisely and prove from `rfp_nt_structural`. -/
-theorem rfp_bnt_structural (A : MPSTensor d D) (hRFP : IsRFP A) :
-    ∃ (_g : ℕ), True := by -- refine to: per-BNT structural form
+TODO: prove from `rfp_nt_structural`. -/
+theorem rfp_bnt_structural {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) (hRFP : ∀ k, IsRFP (A k)) :
+    ∀ k, ∃ (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+           (Λ : Fin (dim k) → ℝ)
+           (U : Fin d → Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+      IsUnit X ∧
+      (∀ j, 0 ≤ Λ j) ∧
+      (∑ j, (Λ j : ℂ) = 1) ∧
+      (∀ i, (U i).conjTranspose * U i = 1) ∧
+      ∀ i, A k i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) *
+        U i * Ring.inverse X := by
   sorry
 
 end MPSTensor

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.RFP.Defs
+import TNLean.MPS.Core.Transfer
+import TNLean.MPS.BNT.Construction
+import TNLean.Spectral.SpectralGap
+import TNLean.Algebra.ScalarPowerSumIdentity
+
+/-!
+# Zero correlation length (ZCL) for MPS tensors
+
+This file defines zero-correlation-length (ZCL) conditions for MPS tensors,
+following arXiv:1606.00608 §3.2 (Cirac–Pérez-García–Schuch–Verstraete).
+
+Three predicates are introduced:
+
+* `IsCID A` — correlations are independent of distance.
+* `IsLocallyOrthogonal A` — the BNT components have vanishing mixed transfer
+  operators.
+* `IsZCL A` — the conjunction of local orthogonality and CID.
+
+The main result (Theorem 3.8) asserts that for a canonical-form tensor,
+`IsZCL` is equivalent to having an idempotent transfer map (`IsRFP`).
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Correlations independent of distance: the two-point correlation function
+of any pair of local observables is independent of the separation between
+them. See arXiv:1606.00608, Definition 3.3.
+
+TODO: formalize in terms of `twoPointExpectation` from `Core/Correlations`. -/
+def IsCID (_A : MPSTensor d D) : Prop :=
+  sorry
+
+/-- Local orthogonality: the BNT elements of `A` have vanishing mixed
+transfer operators, i.e. `Σ_i A^i_j ⊗ Ā^i_{j'} = 0` for `j ≠ j'`.
+See arXiv:1606.00608, Definition 3.5.
+
+TODO: formalize in terms of `mixedTransferMap` from `Spectral/`. -/
+def IsLocallyOrthogonal (_A : MPSTensor d D) : Prop :=
+  sorry
+
+/-- Zero correlation length: a tensor has ZCL when it is both locally
+orthogonal and has correlations independent of distance.
+See arXiv:1606.00608, Definition 3.6. -/
+def IsZCL (A : MPSTensor d D) : Prop :=
+  IsLocallyOrthogonal A ∧ IsCID A
+
+/-- **Theorem 3.8** (arXiv:1606.00608): For a canonical-form MPS tensor,
+ZCL is equivalent to the transfer map being idempotent (i.e. `IsRFP`).
+
+Forward: `E² = E` implies CID (from the correlation formula) and LO
+(from spectral gap of mixed transfer).
+Reverse: if `E² ≠ E`, block-injectivity constructs observables detecting
+a subleading eigenvalue; Newton–Girard handles the μ-coefficient phases.
+
+TODO: add `IsCanonicalForm` hypothesis and prove both directions. -/
+theorem zcl_iff_idempotent_transfer (A : MPSTensor d D)
+    /- (hCF : IsCanonicalForm μ A) -/ :
+    IsZCL A ↔ IsRFP A := by
+  sorry
+
+end MPSTensor

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -61,10 +61,11 @@ Forward: `E² = E` implies CID (from the correlation formula) and LO
 Reverse: if `E² ≠ E`, block-injectivity constructs observables detecting
 a subleading eigenvalue; Newton–Girard handles the μ-coefficient phases.
 
-TODO: add `IsCanonicalForm` hypothesis and prove both directions. -/
-theorem zcl_iff_idempotent_transfer (A : MPSTensor d D)
-    /- (hCF : IsCanonicalForm μ A) -/ :
-    IsZCL A ↔ IsRFP A := by
+TODO: prove both directions. -/
+theorem zcl_iff_idempotent_transfer {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalForm μ A) (k : Fin r) :
+    IsZCL (A k) ↔ IsRFP (A k) := by
   sorry
 
 end MPSTensor


### PR DESCRIPTION
## Summary
- Introduce `TNLean/MPS/RFP/` with 5 files scaffolding the pure-state renormalization fixed point theory from arXiv:1606.00608 §3
- All definitions and theorem statements are sorry placeholders
- Imports added to `TNLean.lean`

## Files

| File | Content | Paper ref |
|------|---------|-----------|
| `Defs.lean` | `IsRFP` (E²=E), `IsIdempotentCPM` alias | Def 3.2 |
| `ZeroCorrelationLength.lean` | `IsCID`, `IsLocallyOrthogonal`, `IsZCL`, `zcl_iff_idempotent_transfer` | Defs 3.3–3.7, Thm 3.8 |
| `StructuralForm.lean` | `rfp_nt_structural`, `rfp_cf_structural`, `rfp_bnt_structural` | Thm 3.11, Lem B.1, Cor 3.12 |
| `Convergence.lean` | `rg_flow_converges_of_cf` | Appendix B |
| `Assembly.lean` | `rfp_iff_zcl` (RFP ⟺ ZCL) | Thm 3.10 (partial) |

## Test plan
- [ ] `lake build` passes (sorry warnings expected)
- [ ] Blueprint compiles
- [ ] No import cycles

Addresses #233. Part of #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean modules and import-surface wiring only; all new theorems/predicates are `sorry` placeholders with no behavioral impact beyond compilation/import order.
> 
> **Overview**
> Introduces a new `TNLean/MPS/RFP/` module set that **scaffolds pure-state renormalization fixed point (RFP) theory**: defines `IsRFP` (idempotent `transferMap`), adds ZCL-related predicates (`IsCID`, `IsLocallyOrthogonal`, `IsZCL`), and states the main equivalences/structure/convergence theorems (`zcl_iff_idempotent_transfer`, `rfp_*_structural`, `rg_flow_converges_of_cf`, `rfp_iff_zcl`) as `sorry` placeholders.
> 
> Updates `TNLean.lean` to re-export these new RFP modules as part of the public import surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10e2f67ed84098a20c398bc8ce960535875eee47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->