### PR TITLE
[Follow-up to PR 91] Add periodic blocking helper API for orbit sums and gcd sectors

### DIFF
--- a/TNLean/MPS/Irreducible/PeriodicBlocking.lean
+++ b/TNLean/MPS/Irreducible/PeriodicBlocking.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Peripheral.CyclicDecomposition
+
+open scoped BigOperators
+
+/-!
+# Periodic-sector blocking helpers
+
+This module records lightweight definitions used by periodic-sector arguments:
+
+* the gcd-based block count/period for blocking by an arbitrary `p`;
+* a concrete orbit-sum projection builder (`∑ l, T^[l](Q)`);
+* bundled predicates describing non-repetition before/after blocking.
+-/
+
+namespace MPSTensor
+
+/-! ## GCD blocking numerics (Lemma 2.5 bookkeeping) -/
+
+/-- Number of periodic blocks after blocking period-`m` data by `p`: `gcd(m,p)`. -/
+def periodicBlockCount (m p : ℕ) : ℕ := Nat.gcd m p
+
+/-- Period of each blocked sector: `m / gcd(m,p)`. -/
+def periodicBlockPeriod (m p : ℕ) : ℕ := m / periodicBlockCount m p
+
+@[simp] theorem periodicBlockCount_comm (m p : ℕ) :
+    periodicBlockCount m p = periodicBlockCount p m := by
+  simp [periodicBlockCount, Nat.gcd_comm]
+
+@[simp] theorem periodicBlockCount_self (m : ℕ) :
+    periodicBlockCount m m = m := by
+  simp [periodicBlockCount]
+
+theorem periodicBlockCount_dvd_left (m p : ℕ) :
+    periodicBlockCount m p ∣ m := by
+  simpa [periodicBlockCount] using Nat.gcd_dvd_left m p
+
+theorem periodicBlockPeriod_mul_count (m p : ℕ) :
+    periodicBlockPeriod m p * periodicBlockCount m p = m := by
+  have hdiv : periodicBlockCount m p ∣ m := periodicBlockCount_dvd_left m p
+  simpa [periodicBlockPeriod, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+    Nat.div_mul_cancel hdiv
+
+/-! ## Orbit-sum projection builder (Lemma 2.4 lift pattern) -/
+
+/-- Orbit sum `R = ∑_{l < m} (T^[l]) Q` used in the cyclic-sector lift. -/
+noncomputable def orbitSumProjection {D m : ℕ} (T : MatrixEnd D) (Q : MatrixAlg D) :
+    MatrixAlg D :=
+  ∑ l : Fin m, (T ^ (l : ℕ)) Q
+
+/-! ## Non-repetition predicates for sectors -/
+
+/-- Pairwise non-repetition for a family of sector projections. -/
+def NonrepeatingSectors {D m : ℕ} (P : Fin m → MatrixAlg D) : Prop :=
+  Pairwise fun i j => P i ≠ P j
+
+/-- Sector index map used by blocking with arbitrary `p`. -/
+def blockedSectorIndex {m : ℕ} [NeZero m] (p : ℕ) (α : ℕ) (k : ℕ) : Fin m :=
+  ⟨(α + p * k) % m, Nat.mod_lt _ (Nat.pos_of_ne_zero (NeZero.ne m))⟩
+
+/-- Blocked sector projection `P̃_α = ∑_k P_[α+pk mod m]` with `k < m / gcd(m,p)`. -/
+noncomputable def blockedSectorProjection {D m : ℕ} [NeZero m]
+    (P : Fin m → MatrixAlg D) (p : ℕ) (α : ℕ) : MatrixAlg D :=
+  ∑ k : Fin (periodicBlockPeriod m p), P (blockedSectorIndex (m := m) p α k)
+
+/-- Pairwise non-repetition predicate for blocked sectors. -/
+def NonrepeatingBlockedSectors {D m : ℕ} [NeZero m]
+    (P : Fin m → MatrixAlg D) (p : ℕ) : Prop :=
+  Pairwise fun α β : Fin (periodicBlockCount m p) =>
+    blockedSectorProjection (m := m) P p α ≠ blockedSectorProjection (m := m) P p β
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -1,4 +1,5 @@
 import TNLean.MPS.Irreducible.FormII
+import TNLean.MPS.Irreducible.PeriodicBlocking
 import TNLean.MPS.Chain.Defs
 import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Channel.Peripheral.CyclicDecomposition


### PR DESCRIPTION
### Motivation

- Provide the concrete helper API pieces needed to close the remaining hypothesis in the cyclic-sector infrastructure: a concrete orbit-sum witness for the `hLift` shape, non-repetition index arithmetic for cyclic sectors, and gcd-based blocking numerics for blocking by an arbitrary `p` (paper Lemmas 2.4–2.6).

### Description

- Added a new helper module `TNLean/MPS/Irreducible/PeriodicBlocking.lean` exposing `periodicBlockCount`, `periodicBlockPeriod`, arithmetic lemmas, an orbit-sum constructor `orbitSumProjection` (defined as `∑ l, (T ^ l) Q`), and predicates/constructors for blocked-sector projections (`blockedSectorIndex`, `blockedSectorProjection`) and non-repetition (`NonrepeatingSectors`, `NonrepeatingBlockedSectors`).
- Wired the new module into the periodic API by importing `TNLean.MPS.Irreducible.PeriodicBlocking` from `TNLean/MPS/Periodic/Defs.lean` so the new definitions are available to the cyclic-sector and blocking infrastructure.
- Small implementation fixes: marked the orbit-sum and blocked-projection definitions `noncomputable`, and replaced a division lemma with `Nat.div_mul_cancel` to satisfy the proof checker.
- Committed the new file and the import change as `feat(mps): add periodic blocking helpers for irreducible sectors` on the `work` branch.

### Testing

- Ran `lake env lean TNLean/MPS/Irreducible/PeriodicBlocking.lean` which typechecked successfully. (✅)
- Built `TNLean.MPS.Irreducible.PeriodicBlocking` and `TNLean.MPS.Periodic.Defs` with `lake build` which completed successfully; existing unrelated linter/style warnings in other modules were emitted but did not block the build. (✅)
- Commit recorded locally and follow-up PR metadata prepared via the `make_pr` tool. (✅)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42922ac98832488f22d7287438296)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean helper module with small arithmetic lemmas and projection constructors, plus a single import to expose them; no existing core logic is refactored.
> 
> **Overview**
> Adds `TNLean/MPS/Irreducible/PeriodicBlocking.lean`, a helper API for periodic-sector blocking: gcd-based block numerics (`periodicBlockCount`/`periodicBlockPeriod` with basic lemmas), an orbit-sum projection constructor `orbitSumProjection`, and definitions/predicates for blocked-sector indexing/projections (`blockedSectorIndex`, `blockedSectorProjection`, `NonrepeatingSectors`, `NonrepeatingBlockedSectors`).
> 
> Updates `TNLean/MPS/Periodic/Defs.lean` to import the new module so these utilities are available to the periodic MPS definitions layer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 206ee5874ad78b6c40db7102a431c9ad0f6309d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->