### PR TITLE
Scaffold OnSiteSymmetry and index-permutation TwistedTensor definitions

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -125,6 +125,7 @@ import TNLean.MPS.FundamentalTheorem.Basic
 import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.MPS.FundamentalTheorem.Applications
 -- Symmetry
+import TNLean.MPS.Symmetry.OnSiteSymmetry
 import TNLean.MPS.Symmetry.Defs
 
 -- Layer 5: Multi-block

--- a/TNLean/MPS/Symmetry/OnSiteSymmetry.lean
+++ b/TNLean/MPS/Symmetry/OnSiteSymmetry.lean
@@ -1,0 +1,39 @@
+import TNLean.MPS.Defs
+
+open scoped Matrix
+
+/-- On-site symmetry data on a physical index `Fin d`.
+
+`u` is the (matrix-valued) representation data and `σ` is the induced
+permutation action on physical indices. -/
+structure OnSiteSymmetry (G : Type*) [Group G] (d : ℕ) where
+  u : G → Matrix (Fin d) (Fin d) ℂ
+  σ : G → Fin d → Fin d
+
+namespace MPSTensor
+
+variable {G : Type*} [Group G] {d D : ℕ}
+
+/-- Twist an MPS tensor by permuting the physical index with `σ_g`.
+
+Concretely, `(TwistedTensor S A g) i = A (σ_g(i))`. -/
+def TwistedTensor (S : OnSiteSymmetry G d) (A : MPSTensor d D) (g : G) : MPSTensor d D :=
+  fun i => A (S.σ g i)
+
+@[simp] lemma TwistedTensor_apply (S : OnSiteSymmetry G d) (A : MPSTensor d D) (g : G) (i : Fin d) :
+    TwistedTensor S A g i = A (S.σ g i) := rfl
+
+@[simp] lemma TwistedTensor_one (S : OnSiteSymmetry G d) (A : MPSTensor d D)
+    (hσ1 : S.σ 1 = id) :
+    TwistedTensor S A 1 = A := by
+  funext i
+  simp [TwistedTensor, hσ1]
+
+@[simp] lemma TwistedTensor_mul (S : OnSiteSymmetry G d) (A : MPSTensor d D)
+    (g h : G)
+    (hσmul : ∀ i : Fin d, S.σ (g * h) i = S.σ h (S.σ g i)) :
+    TwistedTensor S A (g * h) = TwistedTensor S (TwistedTensor S A h) g := by
+  funext i
+  simp [TwistedTensor, hσmul]
+
+end MPSTensor


### PR DESCRIPTION
### Motivation
- Provide a minimal, dependency-light scaffold for on-site symmetry data and the twisted-tensor construction needed for MPS symmetry work. 
- Expose a simple, easy-to-reuse representation of the physical-index action (`σ`) alongside the matrix-valued data (`u`) so downstream lemmas can be added incrementally.

### Description
- Added `TNLean/MPS/Symmetry/OnSiteSymmetry.lean` which defines `OnSiteSymmetry (G : Type*) [Group G] (d : ℕ)` bundling `u : G → Matrix (Fin d) (Fin d) ℂ` and `σ : G → Fin d → Fin d`.
- Introduced `MPSTensor.TwistedTensor (S : OnSiteSymmetry G d) (A : MPSTensor d D) (g : G)` defined by permuting the physical index: `(TwistedTensor S A g) i = A (S.σ g i)`.
- Added basic `@[simp]` lemmas `TwistedTensor_apply`, `TwistedTensor_one` (requires `S.σ 1 = id`), and `TwistedTensor_mul` (requires a hypothesis expressing composition of `σ`).
- Exported the new module from the project root by adding `import TNLean.MPS.Symmetry.OnSiteSymmetry` to `TNLean.lean` so the definitions are on the public import surface.

### Testing
- Ran `lake env lean TNLean/MPS/Symmetry/OnSiteSymmetry.lean` which succeeded.
- Built the new module with `lake build TNLean.MPS.Symmetry.OnSiteSymmetry` which succeeded.
- Built the whole project with `lake build TNLean` which completed successfully (repository-wide linter/sorry warnings outside this change remain as before).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c427a55b048324ac6b8131212efc01)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new, dependency-light symmetry data structure and simple `MPSTensor` index-permutation helper with basic simp lemmas, without altering existing core logic.
> 
> **Overview**
> Adds a new `OnSiteSymmetry` scaffold that bundles on-site symmetry data (`u`) with an induced physical-index action (`σ`).
> 
> Introduces `MPSTensor.TwistedTensor`, which applies a symmetry element by permuting the physical index, plus basic `@[simp]` lemmas for application, identity, and composition (under explicit hypotheses on `σ`). The new module is re-exported from `TNLean.lean` to make it part of the public import surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29e1038117911cbf45d9692986a402be8b182f28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->