### PR TITLE
MPS: gauge uniqueness for injective tensors (up to scalar)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -126,6 +126,7 @@ import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.MPS.FundamentalTheorem.Applications
 -- Symmetry
 import TNLean.MPS.Symmetry.Defs
+import TNLean.MPS.Symmetry.GaugeUniqueness
 
 -- Layer 5: Multi-block
 import TNLean.MPS.Core.MultiBlock

--- a/TNLean/MPS/Symmetry/GaugeUniqueness.lean
+++ b/TNLean/MPS/Symmetry/GaugeUniqueness.lean
@@ -1,0 +1,96 @@
+import TNLean.MPS.FundamentalTheorem.Basic
+import TNLean.MPS.Chain.OneSidedInverse
+import TNLean.Algebra.ScalarCommutant
+
+/-!
+# Gauge uniqueness for injective MPS tensors
+
+If two invertible gauges `X` and `Y` both map an injective tensor `A` to the same
+`B`, then `Y` is a nonzero scalar multiple of `X`.
+
+This is the scalar-commutant input needed to make the symmetry gauge
+well-defined up to phase.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- If two gauges send the same injective tensor `A` to the same tensor `B`,
+then they differ by a nonzero scalar. -/
+theorem gauge_unique_up_to_scalar {A B : MPSTensor d D} (hA : IsInjective A)
+    {X Y : GL (Fin D) ℂ}
+    (hX : ∀ i, B i = X * A i * X⁻¹)
+    (hY : ∀ i, B i = Y * A i * Y⁻¹) :
+    ∃ u : Units ℂ,
+      (Y : Matrix (Fin D) (Fin D) ℂ) = (u : ℂ) • (X : Matrix (Fin D) (Fin D) ℂ) := by
+  classical
+  cases D with
+  | zero =>
+      refine ⟨1, ?_⟩
+      exact Subsingleton.elim _ _
+  | succ D' =>
+      let Z : GL (Fin (Nat.succ D')) ℂ := X⁻¹ * Y
+      have hcommA : ∀ i : Fin d,
+          (Z : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A i
+            = A i * (Z : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+        intro i
+        have hXY :
+            (X : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A i *
+              ((X⁻¹ : GL (Fin (Nat.succ D')) ℂ) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)
+              =
+            (Y : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A i *
+              ((Y⁻¹ : GL (Fin (Nat.succ D')) ℂ) :
+                Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+          rw [← hX i, hY i]
+        have hXY' := congrArg
+          (fun M : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ =>
+            ((X⁻¹ : GL (Fin (Nat.succ D')) ℂ) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * M *
+              (Y : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)) hXY
+        simpa [Z, Matrix.mul_assoc] using hXY'.symm
+      have hscalar := Matrix.isScalar_of_commute_span_eq_top
+        (Z := (Z : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ))
+        hA.span_eq_top (fun M hM => by
+          rcases hM with ⟨i, rfl⟩
+          exact hcommA i)
+      rcases hscalar with ⟨c, hc⟩
+      have hc_ne : c ≠ 0 := by
+        intro hc0
+        have hZ0 : (Z : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) = 0 := by
+          simpa [hc0] using hc
+        have hmul :
+            (Z : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
+                (((Z⁻¹ : GL (Fin (Nat.succ D')) ℂ) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)) = 1 := by
+          simp
+        rw [hZ0, zero_mul] at hmul
+        exact (one_ne_zero : (1 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) ≠ 0) hmul.symm
+      refine ⟨Units.mk0 c hc_ne, ?_⟩
+      calc
+        (Y : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)
+            = (X : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
+                (Z : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+              simp [Z]
+        _ = (X : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * Matrix.scalar (Fin (Nat.succ D')) c := by
+              simp [hc]
+        _ = (X : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
+              (c • (1 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)) := by
+              rw [Matrix.smul_one_eq_diagonal, Matrix.scalar_apply]
+        _ = c • (X : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+              ext i j
+              simp [Matrix.mul_apply, Matrix.one_apply, mul_comm]
+        _ = ((Units.mk0 c hc_ne : Units ℂ) : ℂ) • (X : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+              simp
+
+/-- A Same-MPV corollary: after obtaining any two gauges from the single-block FT,
+they are unique up to a nonzero scalar. -/
+theorem gauge_unique_up_to_scalar_of_sameMPV {A B : MPSTensor d D}
+    (hA : IsInjective A) (_hAB : SameMPV A B)
+    {X Y : GL (Fin D) ℂ}
+    (hX : ∀ i, B i = X * A i * X⁻¹)
+    (hY : ∀ i, B i = Y * A i * Y⁻¹) :
+    ∃ u : Units ℂ, (Y : Matrix (Fin D) (Fin D) ℂ) = (u : ℂ) • (X : Matrix (Fin D) (Fin D) ℂ) :=
+  gauge_unique_up_to_scalar hA hX hY
+
+end MPSTensor


### PR DESCRIPTION
### Motivation

- Provide the missing uniqueness statement needed for symmetry/projective representation work: when two invertible gauges both conjugate an injective MPS tensor `A` into the same `B`, the gauges must agree up to a nonzero scalar (the projective phase ambiguity). 

### Description

- Add `TNLean/MPS/Symmetry/GaugeUniqueness.lean` which proves `MPSTensor.gauge_unique_up_to_scalar` by setting `Z := X⁻¹ * Y`, showing `Z` commutes with every generator `A i`, applying `Matrix.isScalar_of_commute_span_eq_top` to deduce `Z = c · 1`, showing `c ≠ 0` (since `Z ∈ GL`), and concluding `Y = (Units.mk0 c _) • X` and handling the `D = 0` case separately. 
- Add a small wrapper `MPSTensor.gauge_unique_up_to_scalar_of_sameMPV` for the Same-MPV usage. 
- Export the new module from the root by adding `import TNLean.MPS.Symmetry.GaugeUniqueness` to `TNLean.lean` so the theorem is available from the top-level import surface.
- The proof relies on the scalar-commutant lemma `Matrix.isScalar_of_commute_span_eq_top` and the injectivity/span facts already in the codebase.

### Testing

- Ran `lake build TNLean/MPS/Symmetry/GaugeUniqueness.lean`, which completed successfully after iterative fixes to the proof script. (Success)
- Ran `lake build TNLean.lean` to exercise the full import surface; the build completed successfully with existing preexisting warnings elsewhere in the project, and the new module replayed without failure. (Success, warnings only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c427901f9483248108b147bab2e469)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean proof module and re-export import without altering existing theorems or core logic. Main risk is proof brittleness due to new dependencies and matrix algebra rewrites.
> 
> **Overview**
> Adds a new symmetry lemma `MPSTensor.gauge_unique_up_to_scalar`, proving that two invertible gauges that conjugate an injective MPS tensor `A` to the same `B` must differ by a nonzero scalar, plus a small `SameMPV` wrapper corollary.
> 
> Exposes the result at the library’s top-level by importing `TNLean.MPS.Symmetry.GaugeUniqueness` from `TNLean.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 348cdff669ffa452ad6130cfbfc53bc06be046cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->