### PR TITLE
RFP: add `IsRFP.idempotent` and expose kraus-isometry theorem name

### DIFF
--- a/TNLean/MPS/RFP/Defs.lean
+++ b/TNLean/MPS/RFP/Defs.lean
@@ -30,6 +30,11 @@ See arXiv:1606.00608, Definition 3.2. -/
 def IsRFP (A : MPSTensor d D) : Prop :=
   transferMap A ∘ₗ transferMap A = transferMap A
 
+/-- The idempotence equation packaged as a projection lemma. -/
+theorem IsRFP.idempotent {A : MPSTensor d D} (h : IsRFP A) :
+    transferMap A ∘ₗ transferMap A = transferMap A :=
+  h
+
 /-- The RFP condition is equivalent to a Kraus-level condition: there exists
 an isometry `V : Fin d × Fin d → Fin d → ℂ` (i.e. a `(d²×d)` matrix) such
 that `A i₁ * A i₂ = ∑ j, V (i₁, i₂) j • A j` for all `i₁ i₂`.
@@ -38,12 +43,21 @@ are related by an isometry on the physical index.
 See arXiv:1606.00608, Theorem 3.1.
 
 TODO: prove the equivalence. -/
-theorem isRFP_iff_kraus (A : MPSTensor d D) :
+theorem isRFP_iff_kraus_isometry (A : MPSTensor d D) :
     IsRFP A ↔
       ∃ V : Matrix (Fin d × Fin d) (Fin d) ℂ,
         V.conjTranspose * V = 1 ∧
         ∀ i₁ i₂ : Fin d,
           A i₁ * A i₂ = ∑ j : Fin d, V (i₁, i₂) j • A j := by
   sorry
+
+/-- Backwards-compatible name for `isRFP_iff_kraus_isometry`. -/
+theorem isRFP_iff_kraus (A : MPSTensor d D) :
+    IsRFP A ↔
+      ∃ V : Matrix (Fin d × Fin d) (Fin d) ℂ,
+        V.conjTranspose * V = 1 ∧
+        ∀ i₁ i₂ : Fin d,
+          A i₁ * A i₂ = ∑ j : Fin d, V (i₁, i₂) j • A j :=
+  isRFP_iff_kraus_isometry A
 
 end MPSTensor


### PR DESCRIPTION
### Motivation

- Provide a small convenience/projection lemma for the RFP predicate so callers can obtain the idempotence equation directly via `IsRFP.idempotent`.
- Expose the intended Kraus-level reformulation under the requested name so downstream work can reference `isRFP_iff_kraus_isometry` while preserving the old name for compatibility.

### Description

- Added `theorem IsRFP.idempotent {A : MPSTensor d D} (h : IsRFP A) : transferMap A ∘ₗ transferMap A = transferMap A` in `TNLean/MPS/RFP/Defs.lean`.
- Renamed the scaffold theorem to `theorem isRFP_iff_kraus_isometry (A : MPSTensor d D) : ...` keeping the existing statement shape and leaving the proof as a `sorry` placeholder.
- Added a backwards-compatible alias `theorem isRFP_iff_kraus (A : MPSTensor d D) := isRFP_iff_kraus_isometry A` so existing references remain valid.

### Testing

- Ran `lake build TNLean.MPS.RFP.Defs`, which completed successfully but emitted a warning due to the `sorry` in the Kraus theorem.
- Ran `lake build TNLean.MPS.RFP.ZeroCorrelationLength`, which also completed successfully but reports existing `sorry` placeholders in `ZeroCorrelationLength.lean` and the Kraus theorem.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42794161c8324921ae98fb7b426b7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a convenience lemma and renames/aliases a theorem without changing any proved logic (the Kraus equivalence remains a `sorry`).
> 
> **Overview**
> Adds `IsRFP.idempotent` as a small projection lemma so callers can directly extract the transfer-map idempotence equation from `IsRFP`.
> 
> Renames the (still unproved) Kraus-level equivalence statement to `isRFP_iff_kraus_isometry` and reintroduces `isRFP_iff_kraus` as a backwards-compatible alias to preserve downstream references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9a0ddcf6f4865f50794241f9a33a63a9c9726ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->