### PR TITLE
fix(blueprint): sync Ch8 canonical statements with Lean formalization

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -67,17 +67,20 @@ and~\cite[Ch.~6]{Wolf2012Quantum}.
 \begin{theorem}[Global gauge from block gauge]\label{thm:multi_block_global}
 	\lean{MPSTensor.fundamentalTheorem_multiBlock_global}
 	\leanok
-	\uses{def:tensor_from_blocks, def:gauge_equiv}
-	If each pair $(A_k, B_k)$ is gauge equivalent
-	($B_k^i = X_k A_k^i X_k^{-1}$),
-	then the block-diagonal tensors are gauge equivalent
-	via the block-diagonal matrix $X = \bigoplus_k X_k$.
+	\uses{def:tensor_from_blocks, def:injective, def:same_mpv, thm:multi_block_ft}
+	If all block tensors $A_k$ are injective and each pair
+	$(A_k, B_k)$ has the same MPV family,
+	then the block-diagonal tensors
+	$\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
+	are gauge equivalent.
 \end{theorem}
 
-\begin{proof}\leanok
-	Block-diagonal conjugation: $X (\bigoplus_k \mu_k A_k^i) X^{-1}
-		= \bigoplus_k \mu_k X_k A_k^i X_k^{-1}
-		= \bigoplus_k \mu_k B_k^i$.
+\begin{proof}
+	\leanok
+	\uses{thm:multi_block_ft}
+	Apply Theorem~\ref{thm:multi_block_ft} blockwise to obtain
+	gauge equivalences for each $(A_k,B_k)$, then assemble them into
+	a global gauge equivalence for the block-diagonal tensors.
 \end{proof}
 
 \section{Transfer map normalization}
@@ -258,10 +261,10 @@ and~\cite[Ch.~6]{Wolf2012Quantum}.
 \begin{definition}[Irreducible tensor]\label{def:irreducible_tensor}
 	\lean{MPSTensor.IsIrreducibleTensor}
 	\leanok
-	\uses{def:transfer_map, def:irreducible_cp}
+	\uses{def:has_inv_proj}
 	An MPS tensor~$A$ is \emph{irreducible}
-	if its transfer map $\E_A$ is irreducible in the sense of
-	Definition~\ref{def:irreducible_cp}.
+	if it has no nontrivial invariant orthogonal projection, i.e.,
+	$\neg\,\mathrm{HasInvariantProj}(A)$.
 \end{definition}
 
 \begin{theorem}[Irreducible block decomposition]\label{thm:irred_decomp}


### PR DESCRIPTION
### Motivation

- Align Chapter 8 blueprint statements and `\uses{...}` annotations with the actual Lean declarations to avoid misleading blueprint–Lean mismatches.
- Resolve two specific mismatches where the blueprint text described different hypotheses/definitions than Lean's formalization.

### Description

- Update `thm:multi_block_global` in `blueprint/src/chapter/ch08_canonical.tex` to require per-block `IsInjective` and per-block `SameMPV` hypotheses and state the global gauge-equivalence conclusion to match `MPSTensor.fundamentalTheorem_multiBlock_global` in Lean. 
- Adjust the theorem `\uses{...}` list to `\uses{def:tensor_from_blocks, def:injective, def:same_mpv, thm:multi_block_ft}` and replace the proof sketch with a blockwise assembly referencing `thm:multi_block_ft`.
- Update `def:irreducible_tensor` in `blueprint/src/chapter/ch08_canonical.tex` to match Lean's `MPSTensor.IsIrreducibleTensor := ¬ HasInvariantProj A` and change its `\uses{...}` to `\uses{def:has_inv_proj}`.

### Testing

- Ran the sync checker `python3 scripts/blueprint_lean_sync.py --root .`, which completed successfully and shows Chapter 8 fully synced (Ch8: 46/46), while reporting unrelated pre-existing sync items elsewhere (e.g., ch13) that were not changed by this PR.
- Verified the modified file diffs include only the intended changes to `blueprint/src/chapter/ch08_canonical.tex` and that the updated blueprint entries now correspond to the Lean declarations referenced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42c1ca2b483249fed042a058e789e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/blueprint-only edits that tighten theorem/definition statements and `\uses{...}` annotations to match existing Lean declarations; no executable code changes.
> 
> **Overview**
> **Syncs Chapter 8 blueprint statements with Lean.** Updates `thm:multi_block_global` to require per-block injectivity and per-block same-MPV hypotheses (and adjusts its `\uses{...}` + proof sketch to reference `thm:multi_block_ft`) so the global gauge-equivalence claim matches `MPSTensor.fundamentalTheorem_multiBlock_global`.
> 
> Redefines `def:irreducible_tensor` in terms of the absence of a nontrivial invariant projection (`¬ HasInvariantProj A`) and updates its `\uses{...}` accordingly, matching `MPSTensor.IsIrreducibleTensor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a153e3a5372fd1c14054db4c0a4652db9294a4f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->