### PR TITLE
Prove `physRealize_mul` for general injective tensors

### DIFF
--- a/TNLean/MPS/Chain/VirtualInsertion.lean
+++ b/TNLean/MPS/Chain/VirtualInsertion.lean
@@ -71,41 +71,34 @@ theorem physRealize_one (A : MPSTensor d D) (hA : IsInjective A)
 
 /-- `physRealize` preserves multiplication. -/
 theorem physRealize_mul (A : MPSTensor d D) (hA : IsInjective A)
-    (hLin : LinearIndependent ℂ A)
     (X Y : Matrix (Fin D) (Fin D) ℂ) :
     physRealize A hA (X * Y) = physRealize A hA X * physRealize A hA Y := by
   ext i k
-  let cXY : Fin d → ℂ := fun k' => physRealize A hA (X * Y) i k'
-  let cProd : Fin d → ℂ := fun k' => (physRealize A hA X * physRealize A hA Y) i k'
-  have hcXY : Fintype.linearCombination ℂ A cXY = A i * (X * Y) := by
-    simpa [cXY, Fintype.linearCombination_apply] using (physRealize_spec A hA (X * Y) i).symm
-  have hcProd : Fintype.linearCombination ℂ A cProd = A i * (X * Y) := by
+  change decompositionMap (A := A) hA (A i * (X * Y)) k =
+    (physRealize A hA X * physRealize A hA Y) i k
+  have hdecomp :
+      decompositionMap (A := A) hA (A i * (X * Y))
+        = ∑ j, (physRealize A hA X) i j • decompositionMap (A := A) hA (A j * Y) := by
     calc
-      Fintype.linearCombination ℂ A cProd
-          = ∑ k', cProd k' • A k' := by simp [Fintype.linearCombination_apply]
-      _ = ∑ k', (∑ j, (physRealize A hA X) i j * (physRealize A hA Y) j k') • A k' := by
-            simp [cProd, Matrix.mul_apply]
-      _ = ∑ k', ∑ j, ((physRealize A hA X) i j * (physRealize A hA Y) j k') • A k' := by
-            simp [Finset.sum_smul]
-      _ = ∑ j, ∑ k', ((physRealize A hA X) i j * (physRealize A hA Y) j k') • A k' := by
-            rw [Finset.sum_comm]
-      _ = ∑ j, (physRealize A hA X) i j • (∑ k', (physRealize A hA Y) j k' • A k') := by
-            refine Finset.sum_congr rfl ?_
-            intro j hj
-            simp [Finset.smul_sum, mul_smul]
-      _ = ∑ j, (physRealize A hA X) i j • (A j * Y) := by
-            refine Finset.sum_congr rfl ?_
-            intro j hj
-            simpa using
-              congrArg (fun M => (physRealize A hA X) i j • M)
-                (physRealize_spec A hA Y j).symm
-      _ = (∑ j, (physRealize A hA X) i j • A j) * Y := by
+      decompositionMap (A := A) hA (A i * (X * Y))
+          = decompositionMap (A := A) hA ((A i * X) * Y) := by
+              simp [Matrix.mul_assoc]
+      _ = decompositionMap (A := A) hA ((∑ j, (physRealize A hA X) i j • A j) * Y) := by
+            rw [← physRealize_spec A hA X i]
+      _ = decompositionMap (A := A) hA (∑ j, (physRealize A hA X) i j • (A j * Y)) := by
             simp [Finset.sum_mul]
-      _ = (A i * X) * Y := by simpa using congrArg (fun M => M * Y) (physRealize_spec A hA X i).symm
-      _ = A i * (X * Y) := by simp [Matrix.mul_assoc]
-  have hcoeff : cXY = cProd :=
-    hLin.fintypeLinearCombination_injective (hcXY.trans hcProd.symm)
-  simpa [cXY, cProd] using congrArg (fun f => f k) hcoeff
+      _ = ∑ j, (physRealize A hA X) i j • decompositionMap (A := A) hA (A j * Y) := by
+            simp
+  calc
+    decompositionMap (A := A) hA (A i * (X * Y)) k
+        = (∑ j, (physRealize A hA X) i j • decompositionMap (A := A) hA (A j * Y)) k := by
+            simpa using congrArg (fun f => f k) hdecomp
+    _ = ∑ j, (physRealize A hA X) i j * (decompositionMap (A := A) hA (A j * Y)) k := by
+          simp
+    _ = ∑ j, (physRealize A hA X) i j * (physRealize A hA Y) j k := by
+          simp [physRealize]
+    _ = (physRealize A hA X * physRealize A hA Y) i k := by
+          simp [Matrix.mul_apply]
 
 /-- Nonzero insertion gives nonzero physical operation. -/
 theorem physRealize_injective (A : MPSTensor d D) (hA : IsInjective A)


### PR DESCRIPTION
### Motivation

- `physRealize_mul` was previously proved only under a `LinearIndependent ℂ A` (basis) hypothesis, but the intended lemma should hold for any injective tensor `A` (i.e. whenever the `A i` span the matrix algebra). 
- The coefficient-uniqueness argument used for the basis case does not apply when `d > D^2`, so the proof needs to rely only on the decomposition/right-inverse structure that exists for any injective `A`.

### Description

- Removed the `LinearIndependent ℂ A` hypothesis from the `physRealize_mul` theorem and generalized the statement to require only `IsInjective A`.
- Rewrote the proof in `TNLean/MPS/Chain/VirtualInsertion.lean` to avoid coefficient-uniqueness: the proof expands `A i * (X * Y)` as `((A i * X) * Y)`, substitutes `physRealize_spec` for the decomposition of `A i * X`, distributes `decompositionMap` over the sum, and evaluates entries to identify the resulting sum with matrix multiplication entrywise. 
- The new argument uses only the linearity/right-inverse properties of `decompositionMap` (from `OneSidedInverse.lean`) and `physRealize_spec`, so it applies to all injective tensors without requiring a basis.

### Testing

- Ran `lake build TNLean.MPS.Chain.VirtualInsertion` and the build completed successfully for the modified target.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4294cba4c83249f150f94d140599f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the statement and proof of `physRealize_mul` by removing the `LinearIndependent` assumption, which may break downstream lemmas relying on the old signature. Proof refactor relies on `decompositionMap` linearity/right-inverse behavior, so errors would surface as theorem failures rather than runtime issues.
> 
> **Overview**
> Generalizes `physRealize_mul` to require only `IsInjective A` (drops the `LinearIndependent`/basis hypothesis).
> 
> Replaces the coefficient-uniqueness proof with a `decompositionMap`-based argument: rewrites `A i * (X * Y)` via associativity, substitutes `physRealize_spec` for the decomposition of `A i * X`, pushes `decompositionMap` through sums/scalars, and matches the resulting coefficients with matrix multiplication entrywise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e46e72f5f9bb73ef02083e232b0380c8766e149f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->