### PR TITLE
fix(blueprint): sync Ch8 statements with Lean formalization

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -64,20 +64,20 @@ and~\cite[Ch.~6]{Wolf2012Quantum}.
 	Per-block equality of MPV coefficients gives global equality.
 \end{proof}
 
-\begin{theorem}[Global gauge from block gauge]\label{thm:multi_block_global}
+\begin{theorem}[Global multi-block fundamental theorem]\label{thm:multi_block_global}
 	\lean{MPSTensor.fundamentalTheorem_multiBlock_global}
 	\leanok
-	\uses{def:tensor_from_blocks, def:gauge_equiv}
-	If each pair $(A_k, B_k)$ is gauge equivalent
-	($B_k^i = X_k A_k^i X_k^{-1}$),
-	then the block-diagonal tensors are gauge equivalent
-	via the block-diagonal matrix $X = \bigoplus_k X_k$.
+	\uses{def:tensor_from_blocks, def:injective, def:same_mpv, thm:multi_block_ft}
+	If each block $A_k$ is injective and each pair $(A_k, B_k)$ has
+	$\mathrm{SameMPV}(A_k, B_k)$, then the block-diagonal tensors
+	$\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$ are gauge equivalent.
 \end{theorem}
 
-\begin{proof}\leanok
-	Block-diagonal conjugation: $X (\bigoplus_k \mu_k A_k^i) X^{-1}
-		= \bigoplus_k \mu_k X_k A_k^i X_k^{-1}
-		= \bigoplus_k \mu_k B_k^i$.
+\begin{proof}\leanok\uses{thm:multi_block_ft}
+	Apply the per-block single-block fundamental theorem
+	(Theorem~\ref{thm:multi_block_ft}) to obtain blockwise gauge
+	equivalences from injectivity plus SameMPV, then assemble them into a
+	global gauge for the block-diagonal tensors.
 \end{proof}
 
 \section{Transfer map normalization}
@@ -258,10 +258,10 @@ and~\cite[Ch.~6]{Wolf2012Quantum}.
 \begin{definition}[Irreducible tensor]\label{def:irreducible_tensor}
 	\lean{MPSTensor.IsIrreducibleTensor}
 	\leanok
-	\uses{def:transfer_map, def:irreducible_cp}
+	\uses{def:has_inv_proj}
 	An MPS tensor~$A$ is \emph{irreducible}
-	if its transfer map $\E_A$ is irreducible in the sense of
-	Definition~\ref{def:irreducible_cp}.
+	if it has no nontrivial invariant projection, i.e.
+	$\neg\,\mathrm{HasInvariantProj}(A)$.
 \end{definition}
 
 \begin{theorem}[Irreducible block decomposition]\label{thm:irred_decomp}


### PR DESCRIPTION
### Motivation
- Align Chapter 8 blueprint text with the actual Lean declarations to remove two documented blueprint–Lean statement mismatches.
- Ensure the LaTeX `\lean{}` annotations and `\uses{...}` dependencies accurately reflect the Lean predicates and hypotheses used in the formalization.

### Description
- Update `thm:multi_block_global` to match Lean's `MPSTensor.fundamentalTheorem_multiBlock_global` by requiring per-block `IsInjective` and `SameMPV` hypotheses and by adding `\uses{def:injective, def:same_mpv, thm:multi_block_ft}` and a proof that applies the per-block FT then assembles the global gauge.
- Update `def:irreducible_tensor` to match Lean's `MPSTensor.IsIrreducibleTensor` by defining irreducibility as `¬ HasInvariantProj A` and replacing `\uses{def:transfer_map, def:irreducible_cp}` with `\uses{def:has_inv_proj}`.
- These edits are blueprint/LaTeX-only documentation changes and do not modify any Lean source files or proofs.

### Testing
- Ran the sync checker `python3 scripts/blueprint_lean_sync.py --root .` before and after the edits, and the tool completed successfully with no remaining Ch8 mismatches.
- The sync report shows the overall blueprint–Lean alignment run completed; remaining reported issues are unrelated existing items in other chapters. 
- No Lean compilation or proof changes were necessary because the edits only adjust blueprint text to reflect existing Lean declarations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4293cc6f4832495e1e3794207119b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: LaTeX/blueprint-only statement edits to match existing Lean formalization; no code or proofs are changed, but it may affect readers relying on the prior (incorrect) hypotheses/definitions.
> 
> **Overview**
> Synchronizes Chapter 8 blueprint statements with the Lean declarations.
> 
> Updates `thm:multi_block_global` to the **global multi-block fundamental theorem** formulation: it now requires per-block `injective` + `SameMPV` hypotheses (and updates `\uses{...}` and the proof to derive blockwise gauges via `thm:multi_block_ft` before assembling a global gauge).
> 
> Redefines `def:irreducible_tensor` to match Lean by characterizing irreducibility as `¬ HasInvariantProj(A)` and switches its dependency annotation from transfer-map irreducibility to `def:has_inv_proj`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 076518dd48f3eb42b9d1fada2b6b015c97bed083. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->