### PR TITLE
[Wolf Ch6] Add numbered wrappers for Props 6.6/6.8 and Thm 6.15

### DIFF
--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -17,6 +17,7 @@ import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.Channel.Irreducible.Similarity
 import TNLean.QPF.Assembly
 import TNLean.Wielandt.Primitivity.Equivalence
+import TNLean.Channel.WolfChapter6Wrappers
 
 /-!
 # Wolf Chapter 6 — Spectral Properties: Public Theorem Index
@@ -125,6 +126,7 @@ Uses Brouwer's fixed-point theorem on density matrices (proved in
 * Full Wolf form `T' = c C⁻¹ T(C · C†) C⁻†`:
   `isIrreducibleMap_full_similarity` (and the stronger
   `isIrreducibleMap_similarity_smul`) — `TNLean.Channel.Irreducible.Similarity`
+* Numbered wrapper: `Kraus.wolf_prop_6_6` — `TNLean.Channel.WolfChapter6Wrappers`
 
 ### Wolf Theorem 6.6 (Peripheral spectrum of irreducible Schwarz maps)
 
@@ -234,6 +236,7 @@ In `TNLean.Channel.FixedPoint.Algebra`:
 ### Wolf Proposition 6.8 (Positive fixed-points)
 
 * `IsChannel.posSemidef_parts_of_hermitian_fixedPoint` — `TNLean.Channel.FixedPoint.Cesaro`
+* Numbered wrapper: `IsChannel.wolf_prop_6_8` — `TNLean.Channel.WolfChapter6Wrappers`
 
 ### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — PARTIALLY FORMALIZED
 
@@ -251,6 +254,8 @@ In `TNLean.Channel.FixedPoint.ConditionalExpectation`:
   `T*(E_σ(X)) = E_σ(X)` when `T` is TP.
 * `Kraus.scalarConditionalExpectation_isConditionalExpectation` —
   bundles everything into `IsConditionalExpectation` for the scalar case.
+* Numbered wrapper: `Kraus.wolf_theorem_6_15_scalar` —
+  `TNLean.Channel.WolfChapter6Wrappers`.
 
 The general irreducible case with period `h > 1` requires Wedderburn blocks
 (Wolf Theorem 6.14, issue #27).

--- a/TNLean/Channel/WolfChapter6Wrappers.lean
+++ b/TNLean/Channel/WolfChapter6Wrappers.lean
@@ -32,7 +32,7 @@ theorem wolf_prop_6_6
     {c : ℝ} (hc : 0 < c)
     {C : Mat} (hC : C.det ≠ 0)
     (hIrr : IsIrreducibleMap E) :
-    IsIrreducibleMap (fullSimilarity c C E) :=
+    IsIrreducibleMap ((c : ℂ) • similarityMap (D := D) C E) :=
   isIrreducibleMap_full_similarity (D := D) hc hC hIrr
 
 /-- Wolf Theorem 6.15 wrapper: scalar fixed-point conditional expectation. -/
@@ -63,7 +63,7 @@ theorem wolf_prop_6_8
     (hXh : X.IsHermitian)
     (hXfix : T X = X) :
     ∃ A B : Matrix (Fin d) (Fin d) ℂ,
-      A.PosSemidef ∧ B.PosSemidef ∧ T A = A ∧ T B = B ∧ X = A - B :=
-  posSemidef_parts_of_hermitian_fixedPoint hT hXh hXfix
+      A.PosSemidef ∧ B.PosSemidef ∧ X = A - B ∧ T A = A ∧ T B = B :=
+  IsChannel.posSemidef_parts_of_hermitian_fixedPoint T hT hXh hXfix
 
 end IsChannel

--- a/TNLean/Channel/WolfChapter6Wrappers.lean
+++ b/TNLean/Channel/WolfChapter6Wrappers.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.FixedPoint.Cesaro
+import TNLean.Channel.FixedPoint.ConditionalExpectation
+import TNLean.Channel.Irreducible.Similarity
+
+/-!
+# Wolf Chapter 6 wrappers for key propositions/theorems
+
+This module provides stable theorem names that mirror Wolf's numbering for
+results already formalized elsewhere:
+
+* Proposition 6.6 (`isIrreducibleMap_full_similarity`)
+* Proposition 6.8 (`IsChannel.posSemidef_parts_of_hermitian_fixedPoint`)
+* Theorem 6.15 (`scalarConditionalExpectation_isConditionalExpectation`)
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {d D : ℕ}
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- Wolf Proposition 6.6 wrapper: full similarity preserves irreducibility. -/
+theorem wolf_prop_6_6
+    [NeZero D]
+    (E : Mat →ₗ[ℂ] Mat)
+    {c : ℝ} (hc : 0 < c)
+    {C : Mat} (hC : C.det ≠ 0)
+    (hIrr : IsIrreducibleMap E) :
+    IsIrreducibleMap (fullSimilarity c C E) :=
+  isIrreducibleMap_full_similarity (D := D) hc hC hIrr
+
+/-- Wolf Theorem 6.15 wrapper: scalar fixed-point conditional expectation. -/
+theorem wolf_theorem_6_15_scalar
+    [NeZero D]
+    (K : Fin d → Mat) (h_tp : IsTP K)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ)
+    (h_scalar : ∀ X : Mat, X ∈ adjointFixedPoints K →
+      ∃ c : ℂ, X = c • (1 : Mat)) :
+    IsConditionalExpectation
+      (scalarConditionalExpectation ρ)
+      (adjointFixedPointsStarSubalgebra K h_tp hρ hρ_fix) :=
+  scalarConditionalExpectation_isConditionalExpectation K h_tp hρ hρ_fix h_scalar
+
+end Kraus
+
+namespace IsChannel
+
+variable {d : ℕ}
+
+/-- Wolf Proposition 6.8 wrapper: Hermitian fixed points decompose into
+positive-semidefinite fixed points. -/
+theorem wolf_prop_6_8
+    [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
+    (hT : IsChannel T)
+    {X : Matrix (Fin d) (Fin d) ℂ}
+    (hXh : X.IsHermitian)
+    (hXfix : T X = X) :
+    ∃ A B : Matrix (Fin d) (Fin d) ℂ,
+      A.PosSemidef ∧ B.PosSemidef ∧ T A = A ∧ T B = B ∧ X = A - B :=
+  posSemidef_parts_of_hermitian_fixedPoint hT hXh hXfix
+
+end IsChannel


### PR DESCRIPTION
### Motivation
- Provide stable, Wolf-numbered theorem names so follow-up work and external references can cite Chapter 6 results consistently.
- Surface already-formalized results (similarity, Hermitian fixed-point decomposition, scalar-case conditional expectation) under the paper numbering without changing proofs.

### Description
- Add `TNLean/Channel/WolfChapter6Wrappers.lean` with three thin wrapper theorems: `Kraus.wolf_prop_6_6`, `IsChannel.wolf_prop_6_8`, and `Kraus.wolf_theorem_6_15_scalar`, which forward to existing declarations.
- Update `TNLean/Channel/WolfChapter6Index.lean` to import the new wrapper module and document the numbered wrappers under Prop. 6.6, Prop. 6.8, and Thm. 6.15.
- No proofs or core APIs were changed; this is a documentation/aliasing layer only.

### Testing
- Built the new wrapper module with `lake build TNLean.Channel.WolfChapter6Wrappers`, which succeeded.
- Built the updated index with `lake build TNLean.Channel.WolfChapter6Index`, which succeeded (repository-wide pre-existing warnings remained unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42c1ef0d08324b8d7bd5be8ace185)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds thin theorem aliases and index references only, without changing underlying proofs or core definitions.
> 
> **Overview**
> Adds a new `TNLean.Channel.WolfChapter6Wrappers` module that exposes Wolf-numbered theorem names (`Kraus.wolf_prop_6_6`, `IsChannel.wolf_prop_6_8`, `Kraus.wolf_theorem_6_15_scalar`) as thin wrappers around existing results.
> 
> Updates `TNLean.Channel.WolfChapter6Index` to import this module and document these numbered wrapper entries under Wolf Prop. 6.6, Prop. 6.8, and Thm. 6.15.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b5184631b6583e82617b22e3eb0a637617a856d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->