### PR TITLE
[PEPS follow-up] Rename Tensor accessor to avoid shadowing

### DIFF
--- a/TNLean/PEPS/Defs.lean
+++ b/TNLean/PEPS/Defs.lean
@@ -43,7 +43,7 @@ instance instFintypeIncidentEdge (G : SimpleGraph V) [DecidableRel G.Adj] (v : V
 virtual bond dimensions. -/
 structure Tensor (G : SimpleGraph V) [DecidableRel G.Adj] (d : ℕ) where
   bondDim : Edge G → ℕ
-  tensor : (v : V) → ((ie : IncidentEdge G v) → Fin (bondDim ie.1)) → Fin d → ℂ
+  component : (v : V) → ((ie : IncidentEdge G v) → Fin (bondDim ie.1)) → Fin d → ℂ
 
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 
@@ -58,7 +58,7 @@ instance instFintypeVirtualConfig (A : Tensor G d) : Fintype (VirtualConfig A) :
 contracting all virtual indices. -/
 noncomputable def stateCoeff (A : Tensor G d) (σ : V → Fin d) : ℂ :=
   ∑ η : VirtualConfig A,
-    ∏ v : V, A.tensor v (fun ie => η ie.1) (σ v)
+    ∏ v : V, A.component v (fun ie => η ie.1) (σ v)
 
 /-- Two PEPS tensors represent the same state when all coefficients agree. -/
 def SameState (A B : Tensor G d) : Prop :=
@@ -67,7 +67,7 @@ def SameState (A B : Tensor G d) : Prop :=
 /-- Vertex-wise injectivity: each local tensor map (virtual → physical data) is
 injective. This is a basic exploratory surrogate for PEPS injectivity. -/
 def IsVertexInjective (A : Tensor G d) : Prop :=
-  ∀ v : V, Function.Injective (A.tensor v)
+  ∀ v : V, Function.Injective (A.component v)
 
 end PEPS
 end TNLean


### PR DESCRIPTION
### Motivation
- Avoid the `Tensor`/`tensor` naming shadow by renaming the accessor so field names do not collide with the structure name and improve downstream readability and style.

### Description
- Renamed the `Tensor` field `tensor` to `component` in `TNLean/PEPS/Defs.lean` and updated all in-file references (notably in `stateCoeff` and `IsVertexInjective`), committed the change and created a follow-up PR.

### Testing
- Ran `lake build TNLean` (which includes `TNLean.PEPS.Defs`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c449c0f3c48324b7da4d8c24c02912)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename-only change, but it will break downstream code that still references `A.tensor` until updated.
> 
> **Overview**
> Renames the `Tensor` structure accessor from `tensor` to `component` to avoid name shadowing and improve readability.
> 
> Updates in-file usages accordingly, including PEPS contraction in `stateCoeff` and the injectivity predicate `IsVertexInjective`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e58679f90091b5e4918f8671e9c3977f6453dd72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->