### PR TITLE
feat(MPS/Symmetry): scaffold OnSiteSymmetry and TwistedTensor definitions

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -127,6 +127,7 @@ import TNLean.MPS.FundamentalTheorem.Applications
 -- Symmetry
 import TNLean.MPS.Symmetry.Defs
 import TNLean.MPS.Symmetry.GaugeUniqueness
+import TNLean.MPS.Symmetry.OnSiteSymmetry
 
 -- Layer 5: Multi-block
 import TNLean.MPS.Core.MultiBlock

--- a/TNLean/MPS/Symmetry/OnSiteSymmetry.lean
+++ b/TNLean/MPS/Symmetry/OnSiteSymmetry.lean
@@ -1,0 +1,42 @@
+import TNLean.MPS.Defs
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {G : Type*} [Group G] {d D : ℕ}
+
+/-- On-site symmetry data on the physical index:
+`u` is a (not-yet-constrained) matrix-valued map and `σ` is the physical-index action. -/
+structure OnSiteSymmetry (G : Type*) [Group G] (d : ℕ) where
+  u : G → Matrix (Fin d) (Fin d) ℂ
+  σ : G → Fin d → Fin d
+
+/-- Tensor twisted by the physical permutation action `σ` at group element `g`.
+
+This is the index-permutation twist `A^{σ_g}` defined by
+`(TwistedTensor S A g) i = A (S.σ g i)`. -/
+def TwistedTensor (S : OnSiteSymmetry G d) (A : MPSTensor d D) (g : G) : MPSTensor d D :=
+  fun i => A (S.σ g i)
+
+@[simp] lemma TwistedTensor_apply (S : OnSiteSymmetry G d)
+    (A : MPSTensor d D) (g : G) (i : Fin d) :
+    TwistedTensor S A g i = A (S.σ g i) := rfl
+
+/-- Twisting by the identity is trivial when `σ 1 = id`. -/
+@[simp] lemma TwistedTensor_one (S : OnSiteSymmetry G d)
+    (hσ1 : S.σ 1 = id) (A : MPSTensor d D) :
+    TwistedTensor S A 1 = A := by
+  funext i
+  simp [TwistedTensor, hσ1]
+
+/-- Composition law for permutation twists:
+if `σ (g * h) = σ g ∘ σ h`, then twisting by `g*h` equals twisting by `g` then `h`. -/
+lemma TwistedTensor_mul (S : OnSiteSymmetry G d)
+    (hσmul : ∀ g h : G, S.σ (g * h) = S.σ g ∘ S.σ h)
+    (A : MPSTensor d D) (g h : G) :
+    TwistedTensor S A (g * h) = TwistedTensor S (TwistedTensor S A g) h := by
+  funext i
+  simp [TwistedTensor, hσmul, Function.comp]
+
+end MPSTensor


### PR DESCRIPTION
## Summary
- Add `OnSiteSymmetry` structure bundling group action `u` and physical permutation `σ`
- Add `TwistedTensor` definition with simp lemmas for identity and composition
- Recreated from closed #254 (lost during rebase)

## Test plan
- [x] `lake build TNLean.MPS.Symmetry.OnSiteSymmetry` passes

Addresses #157.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new, self-contained symmetry scaffold module and re-exports it, without altering existing symmetry or MPS logic.
> 
> **Overview**
> Adds a new `TNLean.MPS.Symmetry.OnSiteSymmetry` module that introduces an `OnSiteSymmetry` record (group-indexed `u` matrices plus a physical-index permutation `σ`) and a `TwistedTensor` definition implementing the `σ`-based index twist, with simp lemmas for identity and composition.
> 
> Updates the root `TNLean.lean` import surface to re-export this new symmetry scaffold.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e927818cf9d8887e039ccbc50f29172bc51716b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->