### PR TITLE
feat(BNT): add equal-norm bridge for BNT grouping (#243)

### DIFF
--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -283,6 +283,90 @@ theorem exists_trivialSectorDecomp_of_sorted_distinct_norms
 
 /-! ### §5. BNT grouping for blocks with possibly equal norms -/
 
+/-- Shared norm-class enumeration used by the BNT grouping constructions. -/
+structure NormClassGroupingData {r : ℕ} (μ : Fin r → ℂ) where
+  g : ℕ
+  vals : Fin g → ℝ
+  vals_strictAnti : StrictAnti vals
+  copies : Fin g → ℕ
+  copies_pos : ∀ j, 0 < copies j
+  enum : (j : Fin g) → Fin (copies j) → Fin r
+  enum_norm : ∀ j q, ‖μ (enum j q)‖ = vals j
+  regroup : ∀ f : Fin r → ℂ, ∑ j : Fin g, ∑ q : Fin (copies j), f (enum j q) = ∑ k : Fin r, f k
+
+/-- Enumerate the norm classes of `μ` in strictly decreasing order of norm. -/
+noncomputable def normClassGroupingData {r : ℕ} (μ : Fin r → ℂ) :
+    NormClassGroupingData μ := by
+  classical
+  let normImage : Finset ℝ := Finset.univ.image (fun k : Fin r => ‖μ k‖)
+  let g := normImage.card
+  let vals : Fin g → ℝ := fun j => normImage.orderEmbOfFin rfl (Fin.rev j)
+  have hvals_anti : StrictAnti vals :=
+    (normImage.orderEmbOfFin rfl).strictMono.comp_strictAnti Fin.rev_strictAnti
+  have hvals_inj : Function.Injective vals := hvals_anti.injective
+  have hvals_mem : ∀ j, vals j ∈ normImage :=
+    fun j => Finset.orderEmbOfFin_mem normImage rfl (Fin.rev j)
+  let normClass : Fin g → Finset (Fin r) :=
+    fun j => Finset.univ.filter (fun k => ‖μ k‖ = vals j)
+  have hClass_nonempty : ∀ j, (normClass j).Nonempty := by
+    intro j
+    have hmem := hvals_mem j
+    simp only [normImage, Finset.mem_image, Finset.mem_univ, true_and] at hmem
+    obtain ⟨k, hk⟩ := hmem
+    exact ⟨k, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hk⟩⟩
+  have hClass_disj :
+      Set.PairwiseDisjoint (↑(Finset.univ : Finset (Fin g)) : Set (Fin g)) normClass := by
+    intro j₁ _ j₂ _ hne
+    apply Finset.disjoint_left.mpr
+    intro k hk1 hk2
+    exact hne (hvals_inj
+      ((Finset.mem_filter.mp hk1).2.symm.trans (Finset.mem_filter.mp hk2).2))
+  have hClass_cover : Finset.biUnion Finset.univ normClass = Finset.univ := by
+    ext k
+    simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, iff_true]
+    have hmem : ‖μ k‖ ∈ normImage :=
+      Finset.mem_image.mpr ⟨k, Finset.mem_univ _, rfl⟩
+    rw [← Finset.image_orderEmbOfFin_univ normImage rfl] at hmem
+    obtain ⟨i, _, hi⟩ := Finset.mem_image.mp hmem
+    refine ⟨Fin.rev i, ?_⟩
+    change k ∈ Finset.univ.filter (fun k => ‖μ k‖ = vals (Fin.rev i))
+    rw [Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    change ‖μ k‖ = normImage.orderEmbOfFin rfl (Fin.rev (Fin.rev i))
+    rw [Fin.rev_rev]
+    exact hi.symm
+  let copiesFn : Fin g → ℕ := fun j => (normClass j).card
+  have hcopies_pos : ∀ j, 0 < copiesFn j :=
+    fun j => Finset.card_pos.mpr (hClass_nonempty j)
+  let enumFn : (j : Fin g) → Fin (copiesFn j) → Fin r :=
+    fun j => (normClass j).orderEmbOfFin rfl
+  have hEnum_norm : ∀ j q, ‖μ (enumFn j q)‖ = vals j := fun j q =>
+    (Finset.mem_filter.mp ((normClass j).orderEmbOfFin_mem rfl q)).2
+  have hRegroup : ∀ (f : Fin r → ℂ),
+      ∑ j : Fin g, ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k : Fin r, f k := by
+    intro f
+    have inner_eq : ∀ j : Fin g,
+        ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k ∈ normClass j, f k := by
+      intro j
+      rw [← Finset.map_orderEmbOfFin_univ (normClass j) rfl, Finset.sum_map]
+      rfl
+    simp_rw [inner_eq]
+    calc ∑ j : Fin g, ∑ k ∈ normClass j, f k
+        = ∑ k ∈ Finset.biUnion Finset.univ normClass, f k :=
+            (Finset.sum_biUnion hClass_disj).symm
+      _ = ∑ k ∈ Finset.univ, f k := by rw [hClass_cover]
+      _ = ∑ k : Fin r, f k := rfl
+  exact {
+    g := g
+    vals := vals
+    vals_strictAnti := hvals_anti
+    copies := copiesFn
+    copies_pos := hcopies_pos
+    enum := enumFn
+    enum_norm := hEnum_norm
+    regroup := hRegroup
+  }
+
 /-- **BNT grouping step (equal-norm case, proved via norm-class enumeration).**
 
 Given a weighted block family `(μ, blocks)` where some blocks may share the same norm
@@ -340,76 +424,18 @@ theorem exists_bnt_grouping
       StrictAnti (fun j : Fin P.basisCount =>
         ‖P.sectors.weight j ⟨0, P.sectors.copies_pos j⟩‖) := by
   classical
-  -- ── Step 1: Set up the norm image and a strictly-decreasing listing ─────
-  -- S = image of ‖μ·‖ in ℝ, g = #S.
-  let normImage : Finset ℝ := Finset.univ.image (fun k : Fin r => ‖μ k‖)
-  let g := normImage.card
-  -- vals j = (j-th largest norm) via orderEmbOfFin ∘ Fin.rev.
-  let vals : Fin g → ℝ := fun j => normImage.orderEmbOfFin rfl (Fin.rev j)
-  have hvals_anti : StrictAnti vals :=
-    (normImage.orderEmbOfFin rfl).strictMono.comp_strictAnti Fin.rev_strictAnti
-  have hvals_inj : Function.Injective vals := hvals_anti.injective
-  have hvals_mem : ∀ j, vals j ∈ normImage :=
-    fun j => Finset.orderEmbOfFin_mem normImage rfl (Fin.rev j)
-  -- ── Step 2: Norm classes ──────────────────────────────────────────────────
-  -- normClass j = {k | ‖μ k‖ = vals j}.
-  let normClass : Fin g → Finset (Fin r) :=
-    fun j => Finset.univ.filter (fun k => ‖μ k‖ = vals j)
-  -- Each class is nonempty (vals j is in the image of ‖μ·‖).
-  have hClass_nonempty : ∀ j, (normClass j).Nonempty := by
-    intro j
-    have hmem := hvals_mem j
-    simp only [normImage, Finset.mem_image, Finset.mem_univ, true_and] at hmem
-    obtain ⟨k, hk⟩ := hmem
-    -- hk : ‖μ k‖ = vals j, which is exactly what normClass j requires.
-    exact ⟨k, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hk⟩⟩
-  -- Classes are pairwise disjoint (different j → different norm value).
-  have hClass_disj :
-      Set.PairwiseDisjoint (↑(Finset.univ : Finset (Fin g)) : Set (Fin g)) normClass := by
-    intro j₁ _ j₂ _ hne
-    apply Finset.disjoint_left.mpr
-    intro k hk1 hk2
-    exact hne (hvals_inj
-      ((Finset.mem_filter.mp hk1).2.symm.trans (Finset.mem_filter.mp hk2).2))
-  -- Classes cover Fin r (every k has ‖μ k‖ = vals j for some j).
-  have hClass_cover : Finset.biUnion Finset.univ normClass = Finset.univ := by
-    ext k
-    simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, iff_true]
-    have hmem : ‖μ k‖ ∈ normImage :=
-      Finset.mem_image.mpr ⟨k, Finset.mem_univ _, rfl⟩
-    rw [← Finset.image_orderEmbOfFin_univ normImage rfl] at hmem
-    obtain ⟨i, _, hi⟩ := Finset.mem_image.mp hmem
-    -- Provide j = Fin.rev i and prove k ∈ normClass (Fin.rev i).
-    refine ⟨Fin.rev i, ?_⟩
-    change k ∈ Finset.univ.filter (fun k => ‖μ k‖ = vals (Fin.rev i))
-    rw [Finset.mem_filter]
-    refine ⟨Finset.mem_univ _, ?_⟩
-    -- vals (Fin.rev i) = orderEmbOfFin rfl (Fin.rev (Fin.rev i)) = orderEmbOfFin rfl i = ‖μ k‖.
-    change ‖μ k‖ = normImage.orderEmbOfFin rfl (Fin.rev (Fin.rev i))
-    rw [Fin.rev_rev]
-    exact hi.symm
-  -- ── Step 3: Enumeration ───────────────────────────────────────────────────
-  let copiesFn : Fin g → ℕ := fun j => (normClass j).card
-  have hcopies_pos : ∀ j, 0 < copiesFn j :=
-    fun j => Finset.card_pos.mpr (hClass_nonempty j)
-  -- enumFn j : Fin (copiesFn j) ↪o Fin r, image = normClass j.
-  let enumFn : (j : Fin g) → Fin (copiesFn j) → Fin r :=
-    fun j => (normClass j).orderEmbOfFin rfl
-  have hEnum_norm : ∀ j q, ‖μ (enumFn j q)‖ = vals j := fun j q =>
-    (Finset.mem_filter.mp ((normClass j).orderEmbOfFin_mem rfl q)).2
-  -- Representative = the 0th element in each class.
-  let reprFn : Fin g → Fin r := fun j => enumFn j ⟨0, hcopies_pos j⟩
-  have hRepr_norm : ∀ j, ‖μ (reprFn j)‖ = vals j :=
-    fun j => hEnum_norm j ⟨0, hcopies_pos j⟩
-  -- ── Step 4: Build the SectorDecomposition ────────────────────────────────
-  let sectors : SectorWeightData g := {
-    copies         := copiesFn
-    copies_pos     := hcopies_pos
-    weight         := fun j q => μ (enumFn j q)
-    weight_ne_zero := fun j q => hμne (enumFn j q)
+  let classes := normClassGroupingData μ
+  let reprFn : Fin classes.g → Fin r := fun j => classes.enum j ⟨0, classes.copies_pos j⟩
+  have hRepr_norm : ∀ j, ‖μ (reprFn j)‖ = classes.vals j :=
+    fun j => classes.enum_norm j ⟨0, classes.copies_pos j⟩
+  let sectors : SectorWeightData classes.g := {
+    copies         := classes.copies
+    copies_pos     := classes.copies_pos
+    weight         := fun j q => μ (classes.enum j q)
+    weight_ne_zero := fun j q => hμne (classes.enum j q)
   }
   let P : SectorDecomposition d := {
-    basisCount := g
+    basisCount := classes.g
     basisDim   := fun j => dim (reprFn j)
     basis      := fun j => blocks (reprFn j)
     sectors    := sectors
@@ -418,23 +444,6 @@ theorem exists_bnt_grouping
   · -- ── SameMPV₂ proof ──────────────────────────────────────────────────────
     -- We show mpv P.toTensor σ = mpv (toTensorFromBlocks μ blocks) σ for all N, σ.
     intro N σ
-    -- Helper: regroup a double sum ∑ j ∑ q, f (enumFn j q) into ∑ k : Fin r, f k.
-    have hRegroup : ∀ (f : Fin r → ℂ),
-        ∑ j : Fin g, ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k : Fin r, f k := by
-      intro f
-      -- Inner sum: ∑ q, f (enumFn j q) = ∑ k ∈ normClass j, f k.
-      have inner_eq : ∀ j : Fin g,
-          ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k ∈ normClass j, f k := by
-        intro j
-        rw [← Finset.map_orderEmbOfFin_univ (normClass j) rfl, Finset.sum_map]
-        rfl
-      simp_rw [inner_eq]
-      -- Sum over j then over normClass j = sum over biUnion = sum over Fin r.
-      calc ∑ j : Fin g, ∑ k ∈ normClass j, f k
-          = ∑ k ∈ Finset.biUnion Finset.univ normClass, f k :=
-              (Finset.sum_biUnion hClass_disj).symm
-        _ = ∑ k ∈ Finset.univ, f k := by rw [hClass_cover]
-        _ = ∑ k : Fin r, f k := rfl
     -- Main calculation using the decomposition formula.
     calc mpv P.toTensor σ
         -- Expand via sector decomposition formula.
@@ -442,22 +451,22 @@ theorem exists_bnt_grouping
             ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
             P.mpv_toTensor_eq_sum_sectors σ
       -- Unfold P fields (definitional equalities via let-bindings).
-      _ = ∑ j : Fin g,
-            ∑ q : Fin (copiesFn j),
-              (μ (enumFn j q)) ^ N * mpv (blocks (reprFn j)) σ := rfl
+      _ = ∑ j : Fin classes.g,
+            ∑ q : Fin (classes.copies j),
+              (μ (classes.enum j q)) ^ N * mpv (blocks (reprFn j)) σ := rfl
       -- Replace mpv (blocks (reprFn j)) by mpv (blocks (enumFn j q)) using hMPVEq.
-      _ = ∑ j : Fin g,
-            ∑ q : Fin (copiesFn j),
-              (μ (enumFn j q)) ^ N * mpv (blocks (enumFn j q)) σ := by
+      _ = ∑ j : Fin classes.g,
+            ∑ q : Fin (classes.copies j),
+              (μ (classes.enum j q)) ^ N * mpv (blocks (classes.enum j q)) σ := by
               refine Finset.sum_congr rfl (fun j _ =>
                 Finset.sum_congr rfl (fun q _ => ?_))
               congr 1
               -- Both reprFn j and enumFn j q have norm vals j.
-              exact hMPVEq (reprFn j) (enumFn j q)
-                (hRepr_norm j |>.trans (hEnum_norm j q).symm) N σ
+              exact hMPVEq (reprFn j) (classes.enum j q)
+                (hRepr_norm j |>.trans (classes.enum_norm j q).symm) N σ
       -- Regroup the double sum over (j, q) into a single sum over Fin r.
       _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ :=
-            hRegroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
+            classes.regroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
       -- Recognize as mpv of toTensorFromBlocks.
       _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
               symm
@@ -466,8 +475,10 @@ theorem exists_bnt_grouping
     -- P.sectors.weight j ⟨0, _⟩ = μ (enumFn j ⟨0, _⟩) (definitional), with norm vals j.
     intro i j hij
     -- Unfold definitionally: P.sectors.weight j q = μ (enumFn j q).
-    change ‖μ (enumFn j ⟨0, hcopies_pos j⟩)‖ < ‖μ (enumFn i ⟨0, hcopies_pos i⟩)‖
-    rw [hEnum_norm j ⟨0, hcopies_pos j⟩, hEnum_norm i ⟨0, hcopies_pos i⟩]
-    exact hvals_anti hij
+    change ‖μ (classes.enum j ⟨0, classes.copies_pos j⟩)‖ <
+      ‖μ (classes.enum i ⟨0, classes.copies_pos i⟩)‖
+    rw [classes.enum_norm j ⟨0, classes.copies_pos j⟩,
+      classes.enum_norm i ⟨0, classes.copies_pos i⟩]
+    exact classes.vals_strictAnti hij
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.MPS.Overlap.CastLemmas
+import TNLean.MPS.Overlap.PeripheralToSpectralGap
 import TNLean.MPS.Structure.PrimitivityBridge
 
 open scoped Matrix BigOperators
@@ -121,11 +122,12 @@ theorem gaugePhaseEquiv_of_equal_norm_blocks
     (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
     (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
     (hμne : ∀ k, μ k ≠ 0)
-    (hDim : ∀ k, 0 < dim k)
     (j k : Fin r) (hjk : j ≠ k) (hNorm : ‖μ j‖ = ‖μ k‖) :
     ∃ hdim : dim j = dim k,
       GaugePhaseEquiv (d := d)
         (cast (congr_arg (MPSTensor d) hdim) (blocks j)) (blocks k) := by
+  -- TODO(#243): prove the proportionality step needed to upgrade equal-norm
+  -- TP-normalized irreducible primitive blocks to gauge-phase equivalence.
   sorry
 
 /-! ### §2. Norm of gauge phase is one -/
@@ -144,7 +146,7 @@ theorem norm_gaugePhase_eq_one_of_irr_TP_primitive
     (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
     (hA_prim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
     (hB_prim : _root_.IsPrimitive (transferMap (d := d) (D := D) B))
-    (X : GL (Fin D) ℂ) (ζ : ℂ) (_hζne : ζ ≠ 0)
+    (X : GL (Fin D) ℂ) (ζ : ℂ)
     (hX : ∀ i : Fin d,
       B i = ζ • ((X : Matrix (Fin D) (Fin D) ℂ) * A i *
         ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) :
@@ -156,14 +158,8 @@ theorem norm_gaugePhase_eq_one_of_irr_TP_primitive
   -- Self-overlap of B scales from self-overlap of A.
   have hScale : ∀ N,
       mpvOverlap (d := d) B B N =
-        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N := by
-    intro N
-    simp only [mpvOverlap]
-    rw [Finset.mul_sum]
-    congr 1; ext σ
-    rw [hmpv N σ]
-    simp [star_mul, mul_pow, star_pow]
-    ring
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N :=
+    mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := A) (B := B) (ζ := ζ) hmpv
   -- Both blocks have self-overlap → 1 (from primitivity).
   have hA_pf : HasPrimitiveFixedPoint A :=
     hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hA_irr hA_norm hA_prim
@@ -201,8 +197,6 @@ theorem exists_bnt_grouping_of_gaugePhaseEquiv
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
     (hμne : ∀ k, μ k ≠ 0)
-    -- Equal-norm blocks have the same dimension.
-    (_hDimEq : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ → dim j = dim k)
     -- Equal-norm blocks are gauge-phase equivalent with unit-norm phase.
     (hGPE : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ →
       ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧
@@ -213,78 +207,32 @@ theorem exists_bnt_grouping_of_gaugePhaseEquiv
       StrictAnti (fun j : Fin P.basisCount =>
         ‖P.sectors.weight j ⟨0, P.sectors.copies_pos j⟩‖) := by
   classical
-  -- ── Step 1: Set up the norm image and a strictly-decreasing listing ─────
-  let normImage : Finset ℝ := Finset.univ.image (fun k : Fin r => ‖μ k‖)
-  let g := normImage.card
-  let vals : Fin g → ℝ := fun j => normImage.orderEmbOfFin rfl (Fin.rev j)
-  have hvals_anti : StrictAnti vals :=
-    (normImage.orderEmbOfFin rfl).strictMono.comp_strictAnti Fin.rev_strictAnti
-  have hvals_inj : Function.Injective vals := hvals_anti.injective
-  have hvals_mem : ∀ j, vals j ∈ normImage :=
-    fun j => Finset.orderEmbOfFin_mem normImage rfl (Fin.rev j)
-  -- ── Step 2: Norm classes ──────────────────────────────────────────────────
-  let normClass : Fin g → Finset (Fin r) :=
-    fun j => Finset.univ.filter (fun k => ‖μ k‖ = vals j)
-  have hClass_nonempty : ∀ j, (normClass j).Nonempty := by
-    intro j
-    have hmem := hvals_mem j
-    simp only [normImage, Finset.mem_image, Finset.mem_univ, true_and] at hmem
-    obtain ⟨k, hk⟩ := hmem
-    exact ⟨k, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hk⟩⟩
-  have hClass_disj :
-      Set.PairwiseDisjoint (↑(Finset.univ : Finset (Fin g)) : Set (Fin g)) normClass := by
-    intro j₁ _ j₂ _ hne
-    apply Finset.disjoint_left.mpr
-    intro k hk1 hk2
-    exact hne (hvals_inj
-      ((Finset.mem_filter.mp hk1).2.symm.trans (Finset.mem_filter.mp hk2).2))
-  have hClass_cover : Finset.biUnion Finset.univ normClass = Finset.univ := by
-    ext k
-    simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, iff_true]
-    have hmem : ‖μ k‖ ∈ normImage :=
-      Finset.mem_image.mpr ⟨k, Finset.mem_univ _, rfl⟩
-    rw [← Finset.image_orderEmbOfFin_univ normImage rfl] at hmem
-    obtain ⟨i, _, hi⟩ := Finset.mem_image.mp hmem
-    refine ⟨Fin.rev i, ?_⟩
-    change k ∈ Finset.univ.filter (fun k => ‖μ k‖ = vals (Fin.rev i))
-    rw [Finset.mem_filter]
-    refine ⟨Finset.mem_univ _, ?_⟩
-    change ‖μ k‖ = normImage.orderEmbOfFin rfl (Fin.rev (Fin.rev i))
-    rw [Fin.rev_rev]
-    exact hi.symm
-  -- ── Step 3: Enumeration ───────────────────────────────────────────────────
-  let copiesFn : Fin g → ℕ := fun j => (normClass j).card
-  have hcopies_pos : ∀ j, 0 < copiesFn j :=
-    fun j => Finset.card_pos.mpr (hClass_nonempty j)
-  let enumFn : (j : Fin g) → Fin (copiesFn j) → Fin r :=
-    fun j => (normClass j).orderEmbOfFin rfl
-  have hEnum_norm : ∀ j q, ‖μ (enumFn j q)‖ = vals j := fun j q =>
-    (Finset.mem_filter.mp ((normClass j).orderEmbOfFin_mem rfl q)).2
-  let reprFn : Fin g → Fin r := fun j => enumFn j ⟨0, hcopies_pos j⟩
-  have hRepr_norm : ∀ j, ‖μ (reprFn j)‖ = vals j :=
-    fun j => hEnum_norm j ⟨0, hcopies_pos j⟩
-  -- ── Step 4: Extract gauge-phase data ──────────────────────────────────────
+  let classes := normClassGroupingData μ
+  let reprFn : Fin classes.g → Fin r := fun j => classes.enum j ⟨0, classes.copies_pos j⟩
+  have hRepr_norm : ∀ j, ‖μ (reprFn j)‖ = classes.vals j :=
+    fun j => classes.enum_norm j ⟨0, classes.copies_pos j⟩
+  -- ── Step 1: Extract gauge-phase data for each norm class ─────────────────
   have hGPE_repr : ∀ j q,
       ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧ ∀ (N : ℕ) (σ : Fin N → Fin d),
-        mpv (blocks (enumFn j q)) σ = ζ ^ N * mpv (blocks (reprFn j)) σ :=
-    fun j q => hGPE (reprFn j) (enumFn j q)
-      (hRepr_norm j |>.trans (hEnum_norm j q).symm)
-  let ζFn : (j : Fin g) → Fin (copiesFn j) → ℂ :=
+        mpv (blocks (classes.enum j q)) σ = ζ ^ N * mpv (blocks (reprFn j)) σ :=
+    fun j q => hGPE (reprFn j) (classes.enum j q)
+      (hRepr_norm j |>.trans (classes.enum_norm j q).symm)
+  let ζFn : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
     fun j q => (hGPE_repr j q).choose
   have hζ_ne : ∀ j q, ζFn j q ≠ 0 := fun j q => (hGPE_repr j q).choose_spec.1
   have hζ_norm : ∀ j q, ‖ζFn j q‖ = 1 := fun j q => (hGPE_repr j q).choose_spec.2.1
-  have hζ_mpv : ∀ j (q : Fin (copiesFn j)) (N : ℕ) (σ : Fin N → Fin d),
-      mpv (blocks (enumFn j q)) σ = (ζFn j q) ^ N * mpv (blocks (reprFn j)) σ :=
+  have hζ_mpv : ∀ j (q : Fin (classes.copies j)) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (blocks (classes.enum j q)) σ = (ζFn j q) ^ N * mpv (blocks (reprFn j)) σ :=
     fun j q N σ => (hGPE_repr j q).choose_spec.2.2 N σ
-  -- ── Step 5: Build the SectorDecomposition ────────────────────────────────
-  let sectors : SectorWeightData g := {
-    copies         := copiesFn
-    copies_pos     := hcopies_pos
-    weight         := fun j q => ζFn j q * μ (enumFn j q)
-    weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j q) (hμne (enumFn j q))
+  -- ── Step 2: Build the SectorDecomposition ────────────────────────────────
+  let sectors : SectorWeightData classes.g := {
+    copies         := classes.copies
+    copies_pos     := classes.copies_pos
+    weight         := fun j q => ζFn j q * μ (classes.enum j q)
+    weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j q) (hμne (classes.enum j q))
   }
   let P : SectorDecomposition d := {
-    basisCount := g
+    basisCount := classes.g
     basisDim   := fun j => dim (reprFn j)
     basis      := fun j => blocks (reprFn j)
     sectors    := sectors
@@ -292,30 +240,16 @@ theorem exists_bnt_grouping_of_gaugePhaseEquiv
   refine ⟨P, ?_, ?_⟩
   · -- ── SameMPV₂ proof ──────────────────────────────────────────────────────
     intro N σ
-    have hRegroup : ∀ (f : Fin r → ℂ),
-        ∑ j : Fin g, ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k : Fin r, f k := by
-      intro f
-      have inner_eq : ∀ j : Fin g,
-          ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k ∈ normClass j, f k := by
-        intro j
-        rw [← Finset.map_orderEmbOfFin_univ (normClass j) rfl, Finset.sum_map]
-        rfl
-      simp_rw [inner_eq]
-      calc ∑ j : Fin g, ∑ k ∈ normClass j, f k
-          = ∑ k ∈ Finset.biUnion Finset.univ normClass, f k :=
-              (Finset.sum_biUnion hClass_disj).symm
-        _ = ∑ k ∈ Finset.univ, f k := by rw [hClass_cover]
-        _ = ∑ k : Fin r, f k := rfl
     calc mpv P.toTensor σ
         = ∑ j : Fin P.basisCount,
             ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
             P.mpv_toTensor_eq_sum_sectors σ
-      _ = ∑ j : Fin g,
-            ∑ q : Fin (copiesFn j),
-              (ζFn j q * μ (enumFn j q)) ^ N * mpv (blocks (reprFn j)) σ := rfl
-      _ = ∑ j : Fin g,
-            ∑ q : Fin (copiesFn j),
-              (μ (enumFn j q)) ^ N * mpv (blocks (enumFn j q)) σ := by
+      _ = ∑ j : Fin classes.g,
+            ∑ q : Fin (classes.copies j),
+              (ζFn j q * μ (classes.enum j q)) ^ N * mpv (blocks (reprFn j)) σ := rfl
+      _ = ∑ j : Fin classes.g,
+            ∑ q : Fin (classes.copies j),
+              (μ (classes.enum j q)) ^ N * mpv (blocks (classes.enum j q)) σ := by
               refine Finset.sum_congr rfl (fun j _ =>
                 Finset.sum_congr rfl (fun q _ => ?_))
               rw [mul_pow]
@@ -325,17 +259,18 @@ theorem exists_bnt_grouping_of_gaugePhaseEquiv
               rw [hζ_mpv j q N σ]
               ring
       _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ :=
-            hRegroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
+            classes.regroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
       _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
               symm
               simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
   · -- ── StrictAnti proof ────────────────────────────────────────────────────
     intro i j hij
-    change ‖ζFn j ⟨0, hcopies_pos j⟩ * μ (enumFn j ⟨0, hcopies_pos j⟩)‖ <
-      ‖ζFn i ⟨0, hcopies_pos i⟩ * μ (enumFn i ⟨0, hcopies_pos i⟩)‖
+    change ‖ζFn j ⟨0, classes.copies_pos j⟩ * μ (classes.enum j ⟨0, classes.copies_pos j⟩)‖ <
+      ‖ζFn i ⟨0, classes.copies_pos i⟩ * μ (classes.enum i ⟨0, classes.copies_pos i⟩)‖
     simp only [norm_mul, hζ_norm, one_mul]
-    rw [hEnum_norm j ⟨0, hcopies_pos j⟩, hEnum_norm i ⟨0, hcopies_pos i⟩]
-    exact hvals_anti hij
+    rw [classes.enum_norm j ⟨0, classes.copies_pos j⟩,
+      classes.enum_norm i ⟨0, classes.copies_pos i⟩]
+    exact classes.vals_strictAnti hij
 
 /-! ### §4. Pipeline connection -/
 
@@ -356,8 +291,7 @@ theorem exists_sectorDecomp_of_tp_primitive_irr_blocks
     (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
     (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
     (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
-    (hμne : ∀ k, μ k ≠ 0)
-    (hDim : ∀ k, 0 < dim k) :
+    (hμne : ∀ k, μ k ≠ 0) :
     ∃ P : SectorDecomposition d,
       SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
       StrictAnti (fun j : Fin P.basisCount =>
@@ -368,14 +302,8 @@ theorem exists_sectorDecomp_of_tp_primitive_irr_blocks
         GaugePhaseEquiv (d := d)
           (cast (congr_arg (MPSTensor d) hdim) (blocks j)) (blocks k) := by
     intro j k hjk hNorm
-    exact gaugePhaseEquiv_of_equal_norm_blocks μ blocks hTP hIrr hPrim hμne hDim j k hjk hNorm
-  -- Step 2: Derive the dimension equality hypothesis for all equal-norm blocks.
-  have hDimEq : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ → dim j = dim k := by
-    intro j k hNorm
-    by_cases hjk : j = k
-    · exact congr_arg dim hjk
-    · exact (hGPE_raw j k hjk hNorm).choose
-  -- Step 3: Derive GPE data with unit-norm phase for the grouping theorem.
+    exact gaugePhaseEquiv_of_equal_norm_blocks μ blocks hTP hIrr hPrim hμne j k hjk hNorm
+  -- Step 2: Derive GPE data with unit-norm phase for the grouping theorem.
   have hGPEζ : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ →
       ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧
         ∀ (N : ℕ) (σ : Fin N → Fin d),
@@ -406,9 +334,9 @@ theorem exists_sectorDecomp_of_tp_primitive_irr_blocks
           (hTP k)
           ((isPrimitive_transferMap_cast_dim hdim (blocks j)).mpr (hPrim j))
           (hPrim k)
-          X ζ hζne hX
+          X ζ hX
       exact ⟨ζ, hζne, hζ_norm, hmpv⟩
-  -- Step 4: Apply the gauge-phase-aware BNT grouping theorem.
-  exact exists_bnt_grouping_of_gaugePhaseEquiv μ blocks hμne hDimEq hGPEζ
+  -- Step 3: Apply the gauge-phase-aware BNT grouping theorem.
+  exact exists_bnt_grouping_of_gaugePhaseEquiv μ blocks hμne hGPEζ
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -1,0 +1,414 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.BNTGrouping
+import TNLean.MPS.FundamentalTheorem.Proportional
+import TNLean.MPS.Overlap.CastLemmas
+import TNLean.MPS.Structure.PrimitivityBridge
+
+open scoped Matrix BigOperators
+open Filter
+
+/-!
+# Equal-norm bridge: from BNT properties to BNT grouping hypotheses
+
+This file bridges the gap between the BNT overlap/spectral theory and the
+BNT grouping theorem (`exists_bnt_grouping`), which requires `hDimEq` and `hMPVEq`
+for equal-norm blocks.
+
+## Background (Issue #243)
+
+The existence reduction pipeline (`Assembly.lean`) produces TP + primitive blocks with
+nonzero weights.  The BNT grouping theorem groups blocks by weight norm into a
+`SectorDecomposition`, but requires two hypotheses for equal-norm blocks:
+
+* `hDimEq`: equal-norm blocks have the same bond dimension.
+* `hMPVEq`: equal-norm blocks have `SameMPV₂`.
+
+In the BNT theory (CPGSV17, §2.3), two blocks from the same decomposition with the same
+weight norm are gauge-phase equivalent.  Gauge-phase equivalence gives `dim j = dim k`
+and `mpv(B)(σ) = ζ^N * mpv(A)(σ)` with `‖ζ‖ = 1`.
+
+## Strategy: gauge-phase-aware BNT grouping
+
+Instead of deriving `SameMPV₂` (which requires `ζ = 1` exactly), we provide a variant
+of the BNT grouping theorem (`exists_bnt_grouping_of_gaugePhaseEquiv`) that accepts
+gauge-phase equivalence data and absorbs the gauge phase into the sector weights.
+
+For block k gauge-phase equivalent to representative block j via `(X, ζ)`:
+- `mpv(blocks k)(σ) = ζ^N * mpv(blocks j)(σ)`
+- Contribution to total: `(μ_k)^N * mpv(blocks k)(σ) = (ζ * μ_k)^N * mpv(blocks j)(σ)`
+- Effective sector weight: `ζ * μ_k`, with `‖ζ * μ_k‖ = ‖μ_k‖` (since `‖ζ‖ = 1`)
+
+## Main results
+
+* `exists_bnt_grouping_of_gaugePhaseEquiv` — BNT grouping theorem taking gauge-phase
+  equivalence data (rather than `SameMPV₂`) for equal-norm blocks.  The gauge phases
+  are absorbed into the sector weights.  **Fully proved.**
+
+* `norm_gaugePhase_eq_one_of_irr_TP_primitive` — The gauge phase between two
+  TP-normalized irreducible primitive blocks has unit norm.  **Fully proved.**
+
+* `gaugePhaseEquiv_of_equal_norm_blocks` — Equal-norm blocks from the same TP +
+  primitive + irreducible decomposition are gauge-phase equivalent.  **Contains one
+  sorry** (the internal proportionality argument, see §1).
+
+* `exists_sectorDecomp_of_tp_primitive_irr_blocks` — Pipeline endpoint connecting
+  the reduction output to a BNT-grouped `SectorDecomposition`.  **Proved modulo
+  the sorry in `gaugePhaseEquiv_of_equal_norm_blocks`.**
+
+## Remaining gap
+
+The one remaining `sorry` is in `gaugePhaseEquiv_of_equal_norm_blocks` (§1).
+See its docstring for the precise mathematical argument needed.
+
+## References
+
+- [CPGSV17, Definition 2.6, Proposition 2.7]: BNT minimality and grouping.
+- [CPGSV17, §2.3]: Equal-norm blocks are gauge-phase equivalent.
+- GitHub issue #243: BNT grouping for weight norm separation.
+-/
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-! ### Auxiliary cast lemma -/
+
+/-- Casting the bond dimension preserves the primitivity of the transfer map. -/
+private lemma isPrimitive_transferMap_cast_dim {d D₁ D₂ : ℕ} (h : D₁ = D₂)
+    (A : MPSTensor d D₁) :
+    _root_.IsPrimitive (transferMap (d := d) (D := D₂)
+      (cast (congr_arg (MPSTensor d) h) A)) ↔
+    _root_.IsPrimitive (transferMap (d := d) (D := D₁) A) := by
+  subst h; rfl
+
+/-! ### §1. Gauge-phase equivalence from equal norms (key gap) -/
+
+/-- **Equal-norm blocks from the same BNT decomposition are gauge-phase equivalent.**
+
+Given a family of TP + primitive + irreducible blocks with nonzero weights,
+two blocks j, k with `‖μ j‖ = ‖μ k‖` and `j ≠ k` must be gauge-phase equivalent.
+
+**Paper argument (CPGSV17, §2.3 / Appendix A):**
+1. Both blocks contribute at the same rate `‖μ‖^N` in the BNT expansion.
+2. Taking the overlap of the full tensor with block k isolates the contribution
+   of blocks with non-decaying overlaps.
+3. At the level of individual blocks, `‖μ j‖ = ‖μ k‖` and the asymptotic
+   orthonormality of the BNT family forces the overlaps to satisfy a matrix
+   identity whose only solution (given primitivity) is proportional MPVs.
+4. `gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one_of_irreducible_TP`
+   converts proportional MPVs to gauge-phase equivalence.
+
+Step 3 requires spectral analysis of the joint transfer map for blocks j and k,
+which is not yet formalized.  Specifically, one needs:
+- From `‖μ j‖ = ‖μ k‖`, the N-th powers `(μ j)^N` and `(μ k)^N` have the same
+  absolute growth rate.
+- BNT linear independence (from `isBNT_of_separated_CFBNT_data`) implies that
+  if the coefficient ratio `(μ j / μ k)^N` does not converge, then the overlaps
+  between blocks j and k must still be controlled by the spectral gap of the
+  joint transfer map.
+- The resulting proportionality is then fed to the existing
+  `gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one_of_irreducible_TP`.
+
+NOTE: This sorry represents the key mathematical gap identified in issue #243. -/
+theorem gaugePhaseEquiv_of_equal_norm_blocks
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hDim : ∀ k, 0 < dim k)
+    (j k : Fin r) (hjk : j ≠ k) (hNorm : ‖μ j‖ = ‖μ k‖) :
+    ∃ hdim : dim j = dim k,
+      GaugePhaseEquiv (d := d)
+        (cast (congr_arg (MPSTensor d) hdim) (blocks j)) (blocks k) := by
+  sorry
+
+/-! ### §2. Norm of gauge phase is one -/
+
+/-- The gauge phase ζ in a gauge-phase equivalence between two TP-normalized
+irreducible blocks with primitive transfer maps satisfies `‖ζ‖ = 1`.
+
+This follows from `norm_eq_one_of_selfOverlap_scale`: self-overlap scaling
+under gauge-phase transform forces the phase to have unit modulus. -/
+theorem norm_gaugePhase_eq_one_of_irr_TP_primitive
+    {D : ℕ} [NeZero D]
+    (A B : MPSTensor d D)
+    (hA_irr : IsIrreducibleTensor A)
+    (hB_irr : IsIrreducibleTensor B)
+    (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
+    (hA_prim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
+    (hB_prim : _root_.IsPrimitive (transferMap (d := d) (D := D) B))
+    (X : GL (Fin D) ℂ) (ζ : ℂ) (_hζne : ζ ≠ 0)
+    (hX : ∀ i : Fin d,
+      B i = ζ • ((X : Matrix (Fin D) (Fin D) ℂ) * A i *
+        ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) :
+    ‖ζ‖ = 1 := by
+  -- From hX, mpv B σ = ζ^N * mpv A σ for all N, σ.
+  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv B σ = ζ ^ N * mpv A σ :=
+    mpv_eq_pow_mul_of_gaugePhase A B X ζ hX
+  -- Self-overlap of B scales from self-overlap of A.
+  have hScale : ∀ N,
+      mpvOverlap (d := d) B B N =
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N := by
+    intro N
+    simp only [mpvOverlap]
+    rw [Finset.mul_sum]
+    congr 1; ext σ
+    rw [hmpv N σ]
+    simp [star_mul, mul_pow, star_pow]
+    ring
+  -- Both blocks have self-overlap → 1 (from primitivity).
+  have hA_pf : HasPrimitiveFixedPoint A :=
+    hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hA_irr hA_norm hA_prim
+  have hB_pf : HasPrimitiveFixedPoint B :=
+    hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible B hB_irr hB_norm hB_prim
+  have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) atTop (nhds 1) := by
+    convert hA_pf.overlap_tendsto_one.norm using 1; simp
+  have hBB : Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) atTop (nhds 1) := by
+    convert hB_pf.overlap_tendsto_one.norm using 1; simp
+  exact norm_eq_one_of_selfOverlap_scale hAA hBB hScale
+
+/-! ### §3. BNT grouping with gauge-phase equivalence -/
+
+/-- **BNT grouping step with gauge-phase equivalence for equal-norm blocks.**
+
+This is a variant of `exists_bnt_grouping` that takes gauge-phase equivalence data
+(rather than `SameMPV₂`) for equal-norm blocks.  The gauge phases are absorbed into
+the sector weights, preserving norm-class membership since `‖ζ‖ = 1`.
+
+Given a weighted block family `(μ, blocks)` where some blocks may share the same norm
+`‖μ j‖ = ‖μ k‖`, and given that equal-norm blocks are gauge-phase equivalent with
+unit-norm phases, there exists a `SectorDecomposition P` with:
+
+1. `SameMPV₂ P.toTensor (toTensorFromBlocks μ blocks)`.
+2. `StrictAnti` on the BNT-level norms (one norm value per group).
+
+**Proof**: The construction is identical to `exists_bnt_grouping` (§5 of
+`BNTGrouping.lean`), except that the sector weight for copy q of group j is
+`ζ_{j,q} * μ_{enum(j,q)}` where `ζ_{j,q}` is the gauge phase relating
+`blocks(enum(j,q))` to `blocks(repr(j))`.  The `SameMPV₂` identity uses the
+factorization `(ζ * μ)^N = ζ^N * μ^N` to replace `mpv(blocks(repr j))` with
+`mpv(blocks(enum j q))`. -/
+theorem exists_bnt_grouping_of_gaugePhaseEquiv
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hμne : ∀ k, μ k ≠ 0)
+    -- Equal-norm blocks have the same dimension.
+    (_hDimEq : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ → dim j = dim k)
+    -- Equal-norm blocks are gauge-phase equivalent with unit-norm phase.
+    (hGPE : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ →
+      ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (blocks k) σ = ζ ^ N * mpv (blocks j) σ) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      StrictAnti (fun j : Fin P.basisCount =>
+        ‖P.sectors.weight j ⟨0, P.sectors.copies_pos j⟩‖) := by
+  classical
+  -- ── Step 1: Set up the norm image and a strictly-decreasing listing ─────
+  let normImage : Finset ℝ := Finset.univ.image (fun k : Fin r => ‖μ k‖)
+  let g := normImage.card
+  let vals : Fin g → ℝ := fun j => normImage.orderEmbOfFin rfl (Fin.rev j)
+  have hvals_anti : StrictAnti vals :=
+    (normImage.orderEmbOfFin rfl).strictMono.comp_strictAnti Fin.rev_strictAnti
+  have hvals_inj : Function.Injective vals := hvals_anti.injective
+  have hvals_mem : ∀ j, vals j ∈ normImage :=
+    fun j => Finset.orderEmbOfFin_mem normImage rfl (Fin.rev j)
+  -- ── Step 2: Norm classes ──────────────────────────────────────────────────
+  let normClass : Fin g → Finset (Fin r) :=
+    fun j => Finset.univ.filter (fun k => ‖μ k‖ = vals j)
+  have hClass_nonempty : ∀ j, (normClass j).Nonempty := by
+    intro j
+    have hmem := hvals_mem j
+    simp only [normImage, Finset.mem_image, Finset.mem_univ, true_and] at hmem
+    obtain ⟨k, hk⟩ := hmem
+    exact ⟨k, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hk⟩⟩
+  have hClass_disj :
+      Set.PairwiseDisjoint (↑(Finset.univ : Finset (Fin g)) : Set (Fin g)) normClass := by
+    intro j₁ _ j₂ _ hne
+    apply Finset.disjoint_left.mpr
+    intro k hk1 hk2
+    exact hne (hvals_inj
+      ((Finset.mem_filter.mp hk1).2.symm.trans (Finset.mem_filter.mp hk2).2))
+  have hClass_cover : Finset.biUnion Finset.univ normClass = Finset.univ := by
+    ext k
+    simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, iff_true]
+    have hmem : ‖μ k‖ ∈ normImage :=
+      Finset.mem_image.mpr ⟨k, Finset.mem_univ _, rfl⟩
+    rw [← Finset.image_orderEmbOfFin_univ normImage rfl] at hmem
+    obtain ⟨i, _, hi⟩ := Finset.mem_image.mp hmem
+    refine ⟨Fin.rev i, ?_⟩
+    change k ∈ Finset.univ.filter (fun k => ‖μ k‖ = vals (Fin.rev i))
+    rw [Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    change ‖μ k‖ = normImage.orderEmbOfFin rfl (Fin.rev (Fin.rev i))
+    rw [Fin.rev_rev]
+    exact hi.symm
+  -- ── Step 3: Enumeration ───────────────────────────────────────────────────
+  let copiesFn : Fin g → ℕ := fun j => (normClass j).card
+  have hcopies_pos : ∀ j, 0 < copiesFn j :=
+    fun j => Finset.card_pos.mpr (hClass_nonempty j)
+  let enumFn : (j : Fin g) → Fin (copiesFn j) → Fin r :=
+    fun j => (normClass j).orderEmbOfFin rfl
+  have hEnum_norm : ∀ j q, ‖μ (enumFn j q)‖ = vals j := fun j q =>
+    (Finset.mem_filter.mp ((normClass j).orderEmbOfFin_mem rfl q)).2
+  let reprFn : Fin g → Fin r := fun j => enumFn j ⟨0, hcopies_pos j⟩
+  have hRepr_norm : ∀ j, ‖μ (reprFn j)‖ = vals j :=
+    fun j => hEnum_norm j ⟨0, hcopies_pos j⟩
+  -- ── Step 4: Extract gauge-phase data ──────────────────────────────────────
+  have hGPE_repr : ∀ j q,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧ ∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv (blocks (enumFn j q)) σ = ζ ^ N * mpv (blocks (reprFn j)) σ :=
+    fun j q => hGPE (reprFn j) (enumFn j q)
+      (hRepr_norm j |>.trans (hEnum_norm j q).symm)
+  let ζFn : (j : Fin g) → Fin (copiesFn j) → ℂ :=
+    fun j q => (hGPE_repr j q).choose
+  have hζ_ne : ∀ j q, ζFn j q ≠ 0 := fun j q => (hGPE_repr j q).choose_spec.1
+  have hζ_norm : ∀ j q, ‖ζFn j q‖ = 1 := fun j q => (hGPE_repr j q).choose_spec.2.1
+  have hζ_mpv : ∀ j (q : Fin (copiesFn j)) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (blocks (enumFn j q)) σ = (ζFn j q) ^ N * mpv (blocks (reprFn j)) σ :=
+    fun j q N σ => (hGPE_repr j q).choose_spec.2.2 N σ
+  -- ── Step 5: Build the SectorDecomposition ────────────────────────────────
+  let sectors : SectorWeightData g := {
+    copies         := copiesFn
+    copies_pos     := hcopies_pos
+    weight         := fun j q => ζFn j q * μ (enumFn j q)
+    weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j q) (hμne (enumFn j q))
+  }
+  let P : SectorDecomposition d := {
+    basisCount := g
+    basisDim   := fun j => dim (reprFn j)
+    basis      := fun j => blocks (reprFn j)
+    sectors    := sectors
+  }
+  refine ⟨P, ?_, ?_⟩
+  · -- ── SameMPV₂ proof ──────────────────────────────────────────────────────
+    intro N σ
+    have hRegroup : ∀ (f : Fin r → ℂ),
+        ∑ j : Fin g, ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k : Fin r, f k := by
+      intro f
+      have inner_eq : ∀ j : Fin g,
+          ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k ∈ normClass j, f k := by
+        intro j
+        rw [← Finset.map_orderEmbOfFin_univ (normClass j) rfl, Finset.sum_map]
+        rfl
+      simp_rw [inner_eq]
+      calc ∑ j : Fin g, ∑ k ∈ normClass j, f k
+          = ∑ k ∈ Finset.biUnion Finset.univ normClass, f k :=
+              (Finset.sum_biUnion hClass_disj).symm
+        _ = ∑ k ∈ Finset.univ, f k := by rw [hClass_cover]
+        _ = ∑ k : Fin r, f k := rfl
+    calc mpv P.toTensor σ
+        = ∑ j : Fin P.basisCount,
+            ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
+            P.mpv_toTensor_eq_sum_sectors σ
+      _ = ∑ j : Fin g,
+            ∑ q : Fin (copiesFn j),
+              (ζFn j q * μ (enumFn j q)) ^ N * mpv (blocks (reprFn j)) σ := rfl
+      _ = ∑ j : Fin g,
+            ∑ q : Fin (copiesFn j),
+              (μ (enumFn j q)) ^ N * mpv (blocks (enumFn j q)) σ := by
+              refine Finset.sum_congr rfl (fun j _ =>
+                Finset.sum_congr rfl (fun q _ => ?_))
+              rw [mul_pow]
+              -- Goal: ζFn j q ^ N * μ(enum j q) ^ N * mpv(blocks(repr j)) σ
+              --     = μ(enum j q) ^ N * mpv(blocks(enum j q)) σ
+              -- Use: mpv(blocks(enum j q)) = ζFn j q ^ N * mpv(blocks(repr j))
+              rw [hζ_mpv j q N σ]
+              ring
+      _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ :=
+            hRegroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+              symm
+              simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
+  · -- ── StrictAnti proof ────────────────────────────────────────────────────
+    intro i j hij
+    change ‖ζFn j ⟨0, hcopies_pos j⟩ * μ (enumFn j ⟨0, hcopies_pos j⟩)‖ <
+      ‖ζFn i ⟨0, hcopies_pos i⟩ * μ (enumFn i ⟨0, hcopies_pos i⟩)‖
+    simp only [norm_mul, hζ_norm, one_mul]
+    rw [hEnum_norm j ⟨0, hcopies_pos j⟩, hEnum_norm i ⟨0, hcopies_pos i⟩]
+    exact hvals_anti hij
+
+/-! ### §4. Pipeline connection -/
+
+/-- **Pipeline endpoint: from TP + primitive + irreducible blocks to BNT-grouped
+`SectorDecomposition`.**
+
+This theorem connects the output of the existence reduction pipeline
+(`exists_tp_primitive_blockDecomp_after_blocking` in `Assembly.lean`) to a
+`SectorDecomposition` with strictly decreasing BNT-level norms.
+
+The one `sorry` is in `gaugePhaseEquiv_of_equal_norm_blocks`, which establishes
+that equal-norm blocks from the same decomposition are gauge-phase equivalent.
+Once that theorem is proved, this pipeline connection becomes sorry-free. -/
+theorem exists_sectorDecomp_of_tp_primitive_irr_blocks
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hDim : ∀ k, 0 < dim k) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      StrictAnti (fun j : Fin P.basisCount =>
+        ‖P.sectors.weight j ⟨0, P.sectors.copies_pos j⟩‖) := by
+  -- Step 1: Derive gauge-phase equivalence for equal-norm blocks.
+  have hGPE_raw : ∀ j k : Fin r, j ≠ k → ‖μ j‖ = ‖μ k‖ →
+      ∃ hdim : dim j = dim k,
+        GaugePhaseEquiv (d := d)
+          (cast (congr_arg (MPSTensor d) hdim) (blocks j)) (blocks k) := by
+    intro j k hjk hNorm
+    exact gaugePhaseEquiv_of_equal_norm_blocks μ blocks hTP hIrr hPrim hμne hDim j k hjk hNorm
+  -- Step 2: Derive the dimension equality hypothesis for all equal-norm blocks.
+  have hDimEq : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ → dim j = dim k := by
+    intro j k hNorm
+    by_cases hjk : j = k
+    · exact congr_arg dim hjk
+    · exact (hGPE_raw j k hjk hNorm).choose
+  -- Step 3: Derive GPE data with unit-norm phase for the grouping theorem.
+  have hGPEζ : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ →
+      ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (blocks k) σ = ζ ^ N * mpv (blocks j) σ := by
+    intro j k hNorm
+    by_cases hjk : j = k
+    · -- Self-case: ζ = 1.
+      subst hjk
+      exact ⟨1, one_ne_zero, norm_one, fun N σ => by simp⟩
+    · -- Different blocks: use gauge-phase equivalence data.
+      obtain ⟨hdim, X, ζ, hζne, hX⟩ := hGPE_raw j k hjk hNorm
+      have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (blocks k) σ = ζ ^ N * mpv (blocks j) σ := by
+        intro N σ
+        rw [mpv_eq_pow_mul_of_gaugePhase
+          (A := cast (congr_arg (MPSTensor d) hdim) (blocks j))
+          (B := blocks k) X ζ hX N σ,
+          mpv_cast_dim hdim (blocks j) N σ]
+      -- Show ‖ζ‖ = 1 using the overlap analysis.
+      -- Cast blocks j to have dimension dim k (using hdim).
+      have hζ_norm : ‖ζ‖ = 1 := by
+        exact norm_gaugePhase_eq_one_of_irr_TP_primitive
+          (cast (congr_arg (MPSTensor d) hdim) (blocks j))
+          (blocks k)
+          ((isIrreducibleTensor_cast_dim hdim (blocks j)).mpr (hIrr j))
+          (hIrr k)
+          ((leftCanonical_cast_dim hdim (blocks j)).mpr (hTP j))
+          (hTP k)
+          ((isPrimitive_transferMap_cast_dim hdim (blocks j)).mpr (hPrim j))
+          (hPrim k)
+          X ζ hζne hX
+      exact ⟨ζ, hζne, hζ_norm, hmpv⟩
+  -- Step 4: Apply the gauge-phase-aware BNT grouping theorem.
+  exact exists_bnt_grouping_of_gaugePhaseEquiv μ blocks hμne hDimEq hGPEζ
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.MPS.Overlap.CastLemmas
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
 import TNLean.MPS.Structure.PrimitivityBridge
 
 open scoped Matrix BigOperators
@@ -130,48 +129,7 @@ theorem gaugePhaseEquiv_of_equal_norm_blocks
   -- TP-normalized irreducible primitive blocks to gauge-phase equivalence.
   sorry
 
-/-! ### §2. Norm of gauge phase is one -/
-
-/-- The gauge phase ζ in a gauge-phase equivalence between two TP-normalized
-irreducible blocks with primitive transfer maps satisfies `‖ζ‖ = 1`.
-
-This follows from `norm_eq_one_of_selfOverlap_scale`: self-overlap scaling
-under gauge-phase transform forces the phase to have unit modulus. -/
-theorem norm_gaugePhase_eq_one_of_irr_TP_primitive
-    {D : ℕ} [NeZero D]
-    (A B : MPSTensor d D)
-    (hA_irr : IsIrreducibleTensor A)
-    (hB_irr : IsIrreducibleTensor B)
-    (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
-    (hA_prim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
-    (hB_prim : _root_.IsPrimitive (transferMap (d := d) (D := D) B))
-    (X : GL (Fin D) ℂ) (ζ : ℂ)
-    (hX : ∀ i : Fin d,
-      B i = ζ • ((X : Matrix (Fin D) (Fin D) ℂ) * A i *
-        ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) :
-    ‖ζ‖ = 1 := by
-  -- From hX, mpv B σ = ζ^N * mpv A σ for all N, σ.
-  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv B σ = ζ ^ N * mpv A σ :=
-    mpv_eq_pow_mul_of_gaugePhase A B X ζ hX
-  -- Self-overlap of B scales from self-overlap of A.
-  have hScale : ∀ N,
-      mpvOverlap (d := d) B B N =
-        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N :=
-    mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := A) (B := B) (ζ := ζ) hmpv
-  -- Both blocks have self-overlap → 1 (from primitivity).
-  have hA_pf : HasPrimitiveFixedPoint A :=
-    hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hA_irr hA_norm hA_prim
-  have hB_pf : HasPrimitiveFixedPoint B :=
-    hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible B hB_irr hB_norm hB_prim
-  have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) atTop (nhds 1) := by
-    convert hA_pf.overlap_tendsto_one.norm using 1; simp
-  have hBB : Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) atTop (nhds 1) := by
-    convert hB_pf.overlap_tendsto_one.norm using 1; simp
-  exact norm_eq_one_of_selfOverlap_scale hAA hBB hScale
-
-/-! ### §3. BNT grouping with gauge-phase equivalence -/
+/-! ### §2. BNT grouping with gauge-phase equivalence -/
 
 /-- **BNT grouping step with gauge-phase equivalence for equal-norm blocks.**
 
@@ -272,7 +230,7 @@ theorem exists_bnt_grouping_of_gaugePhaseEquiv
       classes.enum_norm i ⟨0, classes.copies_pos i⟩]
     exact classes.vals_strictAnti hij
 
-/-! ### §4. Pipeline connection -/
+/-! ### §3. Pipeline connection -/
 
 /-- **Pipeline endpoint: from TP + primitive + irreducible blocks to BNT-grouped
 `SectorDecomposition`.**

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Defs
 import TNLean.MPS.Overlap.Basic
+import TNLean.MPS.Overlap.PeripheralToSpectralGap
 import TNLean.Spectral.MPVOverlapDecay
 import TNLean.Spectral.SpectralGapNT
 import TNLean.Topology.TendstoHelpers
@@ -128,6 +129,40 @@ theorem norm_eq_one_of_selfOverlap_scale
         with ⟨n, hn1, hn2⟩
       exact not_lt_of_ge hn1 hn2
   nlinarith [norm_nonneg ζ]
+
+/-- The gauge phase `ζ` in a gauge-phase equivalence between two TP-normalized irreducible
+primitive blocks has unit norm. -/
+theorem norm_gaugePhase_eq_one_of_irr_TP_primitive
+    {D : ℕ} [NeZero D]
+    (A B : MPSTensor d D)
+    (hA_irr : IsIrreducibleTensor A)
+    (hB_irr : IsIrreducibleTensor B)
+    (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
+    (hA_prim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
+    (hB_prim : _root_.IsPrimitive (transferMap (d := d) (D := D) B))
+    (X : GL (Fin D) ℂ) (ζ : ℂ)
+    (hX : ∀ i : Fin d,
+      B i = ζ • ((X : Matrix (Fin D) (Fin D) ℂ) * A i *
+        ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) :
+    ‖ζ‖ = 1 := by
+  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ :=
+    mpv_eq_pow_mul_of_gaugePhase A B X ζ hX
+  have hScale : ∀ N,
+      mpvOverlap (d := d) B B N =
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N :=
+    mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := A) (B := B) (ζ := ζ) hmpv
+  have hA_pf : HasPrimitiveFixedPoint A :=
+    hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hA_irr hA_norm hA_prim
+  have hB_pf : HasPrimitiveFixedPoint B :=
+    hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible B hB_irr hB_norm hB_prim
+  have hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1) := by
+    convert hA_pf.overlap_tendsto_one.norm using 1
+    simp
+  have hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds 1) := by
+    convert hB_pf.overlap_tendsto_one.norm using 1
+    simp
+  exact norm_eq_one_of_selfOverlap_scale hAA hBB hScale
 
 /-! ## Easy direction: gauge-phase ⇒ proportional MPV -/
 


### PR DESCRIPTION
## Summary

- Add `EqualNormBridge.lean` with gauge-phase-aware BNT grouping that bridges the gap between the existence reduction pipeline and the BNT grouping theorem
- Key insight: absorb gauge phases into sector weights (preserving norms since ‖ζ‖ = 1) rather than requiring SameMPV₂ for equal-norm blocks
- Isolates the remaining gap to a single theorem: `gaugePhaseEquiv_of_equal_norm_blocks`

## Test plan

- [x] `lake build` succeeds (1 expected sorry)
- [ ] Verify no unrelated sorrys introduced

Closes #243 (partially)

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new canonical-form bridging theorems and refactors core grouping proof; while largely proof-only, it introduces a new lemma with an explicit `sorry` and changes how sector weights are constructed for equal-norm cases, which could affect downstream canonical-form proofs.
> 
> **Overview**
> Introduces shared `NormClassGroupingData`/`normClassGroupingData` in `BNTGrouping.lean` and refactors `exists_bnt_grouping` to reuse this enumeration/regrouping logic instead of inlining the construction.
> 
> Adds `EqualNormBridge.lean`, providing a gauge-phase-aware grouping theorem `exists_bnt_grouping_of_gaugePhaseEquiv` that absorbs per-block gauge phases into sector weights (preserving strict norm ordering) and a pipeline endpoint `exists_sectorDecomp_of_tp_primitive_irr_blocks` connecting TP+primitive+irreducible blocks to a grouped `SectorDecomposition`; this connection is currently blocked by a single new `sorry` in `gaugePhaseEquiv_of_equal_norm_blocks`.
> 
> Extends `FundamentalTheorem/Proportional.lean` with `norm_gaugePhase_eq_one_of_irr_TP_primitive` (and supporting imports) to show gauge phases have unit norm under TP/irreducible/primitive assumptions, used by the new bridge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab4eb18b9bf85683e7dcdb23756ca339181e8da8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->