### PR TITLE
feat(correlations): add blueprint cross-refs to ch14 and correlationLength_pos

### DIFF
--- a/TNLean/MPS/Core/Correlations.lean
+++ b/TNLean/MPS/Core/Correlations.lean
@@ -99,4 +99,11 @@ theorem connectedCorrelator_bound
 noncomputable def correlationLength (lam₂ : ℂ) : ℝ :=
   -1 / Real.log ‖lam₂‖
 
+/-- The correlation length is positive when `0 < ‖λ₂‖ < 1`. -/
+theorem correlationLength_pos {lam₂ : ℂ} (h0 : 0 < ‖lam₂‖) (h1 : ‖lam₂‖ < 1) :
+    0 < correlationLength lam₂ := by
+  unfold correlationLength
+  rw [neg_div, neg_pos]
+  exact div_neg_of_pos_of_neg one_pos (Real.log_neg h0 h1)
+
 end MPSTensor

--- a/blueprint/lean_decls
+++ b/blueprint/lean_decls
@@ -160,6 +160,7 @@ MPSTensor.connectedCorrelator
 MPSTensor.connectedCorrelator_bound
 MPSTensor.connectedCorrelator_eq_sum
 MPSTensor.correlationLength
+MPSTensor.correlationLength_pos
 MPSTensor.cross_correlation_tendsto_zero
 MPSTensor.cumulativeSpan
 MPSTensor.cumulativeSpan_eq_top

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -9,8 +9,8 @@ transfer map.
 When the MPS tensor generates a parent Hamiltonian
 (Chapter~\ref{ch:parent_hamiltonian}), the correlator quantifies spatial
 correlations in the ground state.  The exponential decay rate is set by the
-spectral gap of the transfer map established in
-Chapter~\ref{ch:spectral}.
+spectral properties of the transfer map, i.e.\ by the modulus of its
+subleading eigenvalues.
 
 \section{Connected correlators from the transfer map}
 
@@ -19,8 +19,8 @@ Chapter~\ref{ch:spectral}.
     \leanok
     \uses{def:transfer_map, thm:qpf}
     Fix an MPS tensor $A$ and a right fixed point $\rho^R$ of its transfer map
-    (whose existence and uniqueness for injective $A$ is guaranteed by
-    the quantum Perron--Frobenius theorem, Theorem~\ref{thm:qpf}).
+    (whose existence, and uniqueness up to scaling under the hypotheses of
+    Theorem~\ref{thm:qpf}, are guaranteed by the quantum Perron--Frobenius theorem).
     For a local observable $X \in \MN{D}$ define
     \[
         \langle X_0 \rangle := \tr(X\rho^R).
@@ -73,7 +73,7 @@ Chapter~\ref{ch:spectral}.
 \begin{theorem}[Exponential decay bound]\label{thm:correlator_exponential_bound}
     \lean{MPSTensor.connectedCorrelator_bound}
     \leanok
-    \uses{thm:correlator_sum_exponentials, thm:spectral_gap}
+    \uses{thm:correlator_sum_exponentials}
     If $|\lambda_j| \le |\lambda_2| < 1$ for all subleading eigenvalues, then
     there exists $C_{XY}\ge 0$ such that
     \[
@@ -98,7 +98,7 @@ Chapter~\ref{ch:spectral}.
 \begin{lemma}[Correlation length is positive]\label{lem:correlation_length_pos}
     \lean{MPSTensor.correlationLength_pos}
     \leanok
-    \uses{def:correlation_length, thm:spectral_gap}
+    \uses{def:correlation_length}
     If $|\lambda_2| < 1$ and $\lambda_2 \ne 0$, then $\xi > 0$.
 \end{lemma}
 

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -6,23 +6,31 @@ The key mechanism is spectral: after removing the leading eigenvalue
 contribution, the connected part is governed by subleading eigenvalues of the
 transfer map.
 
+When the MPS tensor generates a parent Hamiltonian
+(Chapter~\ref{ch:parent_hamiltonian}), the correlator quantifies spatial
+correlations in the ground state.  The exponential decay rate is set by the
+spectral gap of the transfer map established in
+Chapter~\ref{ch:spectral}.
+
 \section{Connected correlators from the transfer map}
 
-\begin{definition}[One-point expectation]
+\begin{definition}[One-point expectation]\label{def:one_point_expectation}
     \lean{MPSTensor.onePointExpectation}
     \leanok
-    \uses{def:transfer_map}
-    Fix an MPS tensor $A$ and a right fixed point $\rho^R$ of its transfer map.
+    \uses{def:transfer_map, thm:qpf}
+    Fix an MPS tensor $A$ and a right fixed point $\rho^R$ of its transfer map
+    (whose existence and uniqueness for injective $A$ is guaranteed by
+    the quantum Perron--Frobenius theorem, Theorem~\ref{thm:qpf}).
     For a local observable $X \in \MN{D}$ define
     \[
         \langle X_0 \rangle := \tr(X\rho^R).
     \]
 \end{definition}
 
-\begin{definition}[Two-point expectation at distance $n$]
+\begin{definition}[Two-point expectation at distance $n$]\label{def:two_point_expectation}
     \lean{MPSTensor.twoPointExpectation}
     \leanok
-    \uses{def:transfer_map}
+    \uses{def:transfer_map, def:one_point_expectation}
     For observables $X,Y \in \MN{D}$ and $n\ge 0$,
     \[
         \langle X_0 Y_n \rangle
@@ -32,10 +40,10 @@ transfer map.
     $Y$ and take the trace.
 \end{definition}
 
-\begin{definition}[Connected correlator]
+\begin{definition}[Connected correlator]\label{def:connected_correlator}
     \lean{MPSTensor.connectedCorrelator}
     \leanok
-    \uses{def:transfer_map}
+    \uses{def:two_point_expectation, def:one_point_expectation}
     The connected two-point function is
     \[
         C(X,Y;n) := \langle X_0Y_n\rangle - \langle X_0\rangle\langle Y_0\rangle.
@@ -44,10 +52,10 @@ transfer map.
 
 \section{Spectral expansion and exponential decay}
 
-\begin{theorem}[Sum of exponentials]
+\begin{theorem}[Sum of exponentials]\label{thm:correlator_sum_exponentials}
     \lean{MPSTensor.connectedCorrelator_eq_sum}
     \leanok
-    \uses{def:transfer_map}
+    \uses{def:connected_correlator, thm:spectral_radius_le_one, thm:qpf}
     For a normal MPS, the connected correlator admits a spectral expansion of
     the form
     \[
@@ -62,10 +70,10 @@ transfer map.
     Apply spectral decomposition to $\E_A^n$.
 \end{proof}
 
-\begin{theorem}[Exponential decay bound]
+\begin{theorem}[Exponential decay bound]\label{thm:correlator_exponential_bound}
     \lean{MPSTensor.connectedCorrelator_bound}
     \leanok
-    \uses{thm:spectral_radius_le_one}
+    \uses{thm:correlator_sum_exponentials, thm:spectral_gap}
     If $|\lambda_j| \le |\lambda_2| < 1$ for all subleading eigenvalues, then
     there exists $C_{XY}\ge 0$ such that
     \[
@@ -77,17 +85,44 @@ transfer map.
     Combine the sum-of-exponentials expansion with the triangle inequality.
 \end{proof}
 
-\begin{definition}[Correlation length]
+\begin{definition}[Correlation length]\label{def:correlation_length}
     \lean{MPSTensor.correlationLength}
     \leanok
+    \uses{thm:correlator_exponential_bound}
     The correlation length associated with $\lambda_2$ is
     \[
         \xi := -\frac{1}{\log|\lambda_2|}.
     \]
 \end{definition}
 
-\begin{remark}
-    \uses{thm:spectral_radius_le_one}
+\begin{lemma}[Correlation length is positive]\label{lem:correlation_length_pos}
+    \lean{MPSTensor.correlationLength_pos}
+    \leanok
+    \uses{def:correlation_length, thm:spectral_gap}
+    If $|\lambda_2| < 1$ and $\lambda_2 \ne 0$, then $\xi > 0$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Since $0 < |\lambda_2| < 1$, we have $\log|\lambda_2| < 0$, so
+    $\xi = -1/\log|\lambda_2| > 0$.
+\end{proof}
+
+\section{Relation to parent Hamiltonians}
+
+\begin{remark}\label{rem:correlations_parent_hamiltonian}
+    \uses{def:parent_hamiltonian, lem:parent_hamiltonian_annihilates,
+          def:correlation_length, thm:correlator_exponential_bound}
+    When the MPS tensor $A$ generates a parent Hamiltonian $H_N(A,L)$
+    (Definition~\ref{def:parent_hamiltonian}) whose ground state is the
+    matrix product vector (Lemma~\ref{lem:parent_hamiltonian_annihilates}),
+    the exponential decay bound
+    (Theorem~\ref{thm:correlator_exponential_bound}) shows that ground-state
+    correlations decay with a finite correlation length $\xi$.
+\end{remark}
+
+\begin{remark}\label{rem:zero_correlation_length}
+    \uses{thm:spectral_radius_le_one, def:correlation_length}
     The identity $\E^2=\E$ is equivalent to vanishing subleading spectrum;
     equivalently, $\xi=0$ and connected correlations vanish at nonzero
     separation.


### PR DESCRIPTION
Add proper `\uses{}` cross-references in blueprint ch15 to ch14 (parent Hamiltonian), ch05 (QPF), and ch06 (spectral gap). Add `correlationLength_pos` lemma with full proof.

Closes #194

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small standalone lemma about `correlationLength` positivity and updates blueprint documentation/cross-references without changing core correlation definitions or bounds.
> 
> **Overview**
> Adds a new Lean theorem `MPSTensor.correlationLength_pos` proving `correlationLength lam₂ > 0` under `0 < ‖lam₂‖ < 1`, and registers it in `blueprint/lean_decls`.
> 
> Updates `ch15_correlations.tex` to add labels and `\uses{}` cross-references (to QPF/spectral results and parent-Hamiltonian material), and extends the chapter with a short lemma/proof and remarks relating the decay bound to parent Hamiltonians.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 187259c06dfca657d68e6baa4bc92cf2df93ea42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->