### PR TITLE
Add daily standup summary GitHub Action

### DIFF
--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -44,15 +44,15 @@ jobs:
               per_page: 50
             });
 
-            // Recently closed issues
+            // Recently closed issues (exclude standup issues to avoid self-referential reporting)
             const closedIssues = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:closed closed:>=${sinceDate}`,
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:closed closed:>=${sinceDate} -label:standup`,
               per_page: 50
             });
 
-            // Recently opened issues
+            // Recently opened issues (exclude standup issues)
             const openedIssues = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open created:>=${sinceDate}`,
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open created:>=${sinceDate} -label:standup`,
               per_page: 50
             });
 
@@ -114,7 +114,7 @@ jobs:
                 title: p.title,
                 user: p.user.login,
                 labels: p.labels.map(l => l.name),
-                draft: p.draft
+                draft: p.pull_request?.draft ?? false
               })),
               closedIssues: closedIssues.data.items.map(i => ({
                 number: i.number,
@@ -177,7 +177,7 @@ jobs:
             If no such issue exists, use mcp__github__issue_write to create a GitHub
             issue with the title: "Daily Standup — ${{ steps.date.outputs.today }}" and
             label it "standup". Use mcp__github__get_label to check if the label exists
-            first, and create it if needed.
+            first, and use Bash(gh label create *) to create it if needed.
 
             The issue body MUST follow this structure:
 
@@ -215,4 +215,4 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-6
-            --allowed-tools "Read,Glob,Grep,Bash(git log *),Bash(git diff *),Bash(git show *),mcp__github__search_issues,mcp__github__issue_write,mcp__github__issue_read,mcp__github__add_issue_comment,mcp__github__get_label,mcp__github__list_issues,mcp__github__search_pull_requests,mcp__github__list_pull_requests,mcp__github__pull_request_read,mcp__github__list_commits"
+            --allowed-tools "Read,Glob,Grep,Bash(git log *),Bash(git diff *),Bash(git show *),Bash(gh label create *),mcp__github__search_issues,mcp__github__issue_write,mcp__github__issue_read,mcp__github__add_issue_comment,mcp__github__get_label,mcp__github__list_issues,mcp__github__search_pull_requests,mcp__github__list_pull_requests,mcp__github__pull_request_read,mcp__github__list_commits"

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -20,43 +20,49 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Compute today's date
+        id: date
+        run: echo "today=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+
       - name: Gather recent activity
         id: activity
         uses: actions/github-script@v7
         with:
           script: |
             const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+            const sinceDate = since.split('T')[0];
 
             // Merged PRs in the last 24 hours
             const mergedPRs = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged merged:>=${since}`,
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged merged:>=${sinceDate}`,
               per_page: 50
             });
 
             // Open PRs with recent activity
             const activePRs = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open updated:>=${since}`,
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open updated:>=${sinceDate}`,
               per_page: 50
             });
 
             // Recently closed issues
             const closedIssues = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:closed closed:>=${since}`,
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:closed closed:>=${sinceDate}`,
               per_page: 50
             });
 
             // Recently opened issues
             const openedIssues = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open created:>=${since}`,
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open created:>=${sinceDate}`,
               per_page: 50
             });
 
-            // Recent commits on main
+            // Recent commits on the default branch
             let recentCommits = [];
             try {
               const commits = await github.rest.repos.listCommits({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
+                sha: 'main',
                 since: since,
                 per_page: 50
               });
@@ -67,6 +73,7 @@ jobs:
                 date: c.commit.author.date
               }));
             } catch (e) {
+              core.warning(`Failed to fetch commits: ${e.message}`);
               recentCommits = [];
             }
 
@@ -89,7 +96,9 @@ jobs:
                     author: c.user.login
                   });
                 }
-              } catch (e) { /* skip */ }
+              } catch (e) {
+                core.warning(`Failed to fetch review comments for PR #${pr.number}: ${e.message}`);
+              }
             }
 
             return {
@@ -130,7 +139,7 @@ jobs:
             (${{ github.repository }}), a Lean 4 formalization project for quantum
             information theory (Matrix Product States, Wielandt theory, quantum channels).
 
-            Today's date: ${{ github.event.schedule && 'scheduled run' || 'manual trigger' }}
+            Today's date: ${{ steps.date.outputs.today }}
             Activity window: last 24 hours (since ${{ fromJSON(steps.activity.outputs.result).since }})
 
             === REPOSITORY ACTIVITY DATA ===
@@ -159,8 +168,15 @@ jobs:
             context, you may read files referenced in PRs/commits (use Read/Glob/Grep).
             Look at git log and diff for the last 24 hours to understand what changed.
 
-            Create a GitHub issue with the title: "Daily Standup — <today's date YYYY-MM-DD>"
-            and label it "standup". Create the label first if it does not exist.
+            Before creating any issue, use "Bash(gh issue list *)" to check whether a
+            standup issue for today's date already exists (filter by title
+            "Daily Standup — ${{ steps.date.outputs.today }}" and/or the "standup" label).
+            If such an issue exists, DO NOT create a new one — instead, update or comment
+            on the existing issue as appropriate.
+
+            If no such issue exists, create a GitHub issue with the title:
+            "Daily Standup — ${{ steps.date.outputs.today }}" and label it "standup".
+            Create the label first if it does not exist.
 
             The issue body MUST follow this structure:
 

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -77,9 +77,20 @@ jobs:
               recentCommits = [];
             }
 
-            // PR review comments in the last 24 hours
+            // PR review comments in the last 24 hours (from both open and merged PRs)
             let reviewComments = [];
-            for (const pr of activePRs.data.items.slice(0, 10)) {
+            const allRecentPRs = [
+              ...activePRs.data.items.slice(0, 10),
+              ...mergedPRs.data.items.slice(0, 10)
+            ];
+            // Deduplicate by PR number
+            const seenPRs = new Set();
+            const uniquePRs = allRecentPRs.filter(pr => {
+              if (seenPRs.has(pr.number)) return false;
+              seenPRs.add(pr.number);
+              return true;
+            });
+            for (const pr of uniquePRs.slice(0, 15)) {
               try {
                 const comments = await github.rest.pulls.listReviewComments({
                   owner: context.repo.owner,

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Gather recent activity
         id: activity
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -135,9 +135,24 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are generating a daily standup summary for the TNLean repository
-            (${{ github.repository }}), a Lean 4 formalization project for quantum
-            information theory (Matrix Product States, Wielandt theory, quantum channels).
+            You are a pure mathematician and Lean 4 formalization expert writing a daily
+            standup summary for the TNLean repository (${{ github.repository }}).
+
+            TNLean is a formalization of results in quantum information theory, grounded
+            in the rigorous mathematical framework of operator algebras, tensor products,
+            and finite-dimensional Hilbert spaces. The project covers:
+            - The Fundamental Theorem of Matrix Product States (MPS) and their canonical forms
+            - Quantum Wielandt theory (convergence of quantum channel iterations)
+            - Quantum channel theory following Wolf's "Quantum Channels & Operations"
+            - Spectral theory, PEPS, and algebraic foundations in Mathlib
+
+            Write with the voice of a working mathematician: precise, structurally aware,
+            and attentive to the logical dependencies between results. When discussing
+            proofs, note the key lemmas invoked, the mathematical content of what was
+            shown, and any `sorry` eliminations (which represent open proof obligations
+            finally discharged). Distinguish between scaffolding (imports, refactors,
+            API lemmas) and substantive mathematical progress (new theorems, completed
+            proofs, resolved conjectures).
 
             Today's date: ${{ steps.date.outputs.today }}
             Activity window: last 24 hours (since ${{ fromJSON(steps.activity.outputs.result).since }})
@@ -165,8 +180,9 @@ jobs:
             === INSTRUCTIONS ===
 
             Analyze the activity above and produce a standup summary. For additional
-            context, you may read files referenced in PRs/commits (use Read/Glob/Grep).
-            Look at git log and diff for the last 24 hours to understand what changed.
+            context, read the actual Lean source files changed (use Read/Glob/Grep) to
+            understand the mathematical content of proofs, not just commit messages.
+            Use git log and git diff for the last 24 hours to see what changed in detail.
 
             Before creating any issue, use the mcp__github__search_issues tool to check
             whether a standup issue for today's date already exists (search for
@@ -181,37 +197,54 @@ jobs:
 
             The issue body MUST follow this structure:
 
-            ## What Was Accomplished
-            - Summarize merged PRs, closed issues, and key commits
-            - Note who contributed what
-            - Highlight proof completions, new formalizations, or `sorry` eliminations
+            ## Theorems & Proofs
+            - What mathematical results were proved, completed, or advanced?
+            - Which `sorry` obligations were discharged, and what was the proof strategy?
+            - Note the key Mathlib lemmas or tactics that made proofs go through
+            - Identify any new definitions, structures, or type classes introduced
+            - Reference the relevant mathematical context (e.g., "proved that the
+              transfer matrix of an injective MPS has full rank, completing Lemma 3.2
+              of the blueprint")
 
-            ## Lessons Learned
-            - Extract insights from PR review discussions
-            - Note any tricky proof strategies that worked (or didn't)
-            - Document Lean/Mathlib patterns discovered
+            ## Proof Engineering & Refactors
+            - API lemmas, simp lemmas, or coercions added to smooth future work
+            - Import restructuring, namespace changes, or Mathlib alignment
+            - Performance improvements (proof term simplification, reducing heartbeats)
 
-            ## Insights Gained
-            - Architectural or structural observations about the codebase
-            - Connections between different formalization areas
-            - Dependency or tooling observations
+            ## Mathematical Insights
+            - Observations about proof structure or formalization strategy
+            - Connections discovered between different parts of the formalization
+            - Cases where the formal proof revealed subtleties not apparent on paper
+            - Mathlib gaps identified or upstream contributions prepared
 
-            ## Key Points for Discussion
-            - Open questions from PR reviews or issues
-            - Blockers or areas needing help
-            - Decisions that need team input
-            - Upcoming work based on newly opened issues
+            ## Open Problems & Discussion Points
+            - Proof obligations (`sorry`) that remain and what approaches are being considered
+            - Mathematical questions arising from the formalization
+            - Decisions on proof strategy that need input (e.g., "should we formalize
+              the spectral theorem via Mathlib's eigenvalue API or build directly?")
+            - Dependencies between open tasks
 
-            ## Activity Stats
+            ## Activity Summary
             - PRs merged / opened / in review
             - Issues closed / opened
-            - Number of commits
+            - Commits to main
+            - Current `sorry` count trend if observable
 
             Guidelines:
-            - Be concise but informative — this is a quick catch-up document
-            - Use PR/issue numbers as references (e.g., #123)
-            - If there was no activity, say so briefly and skip empty sections
-            - Focus on substance over ceremony
+            - Be precise and mathematically literate — this is for a team of
+              mathematicians and formalization experts
+            - Use proper mathematical terminology (e.g., "completely positive map"
+              not "channel function", "tensor product" not "combined space")
+            - Reference PR/issue numbers (e.g., #123) and file paths where relevant
+            - If there was no activity, state so briefly
+            - Prioritize mathematical substance over engineering details
+            - Demand clarity: every claim should be specific and verifiable. Do not
+              write vague summaries like "progress was made on MPS theory". Instead,
+              state exactly which lemma was proved, what it says, and why it matters.
+            - Write the issue as a self-contained document. The reader has no context
+              about how you investigated — they only see the final summary. Do not
+              include your reasoning process, tool calls, or analysis steps. Present
+              only polished conclusions.
 
           claude_args: |
             --model claude-opus-4-6

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -29,7 +29,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+            // On Monday (day 1), look back 72 hours to capture weekend activity.
+            // On other weekdays, look back 24 hours.
+            const now = new Date();
+            const hoursBack = now.getUTCDay() === 1 ? 72 : 24;
+            const since = new Date(Date.now() - hoursBack * 60 * 60 * 1000).toISOString();
             const sinceDate = since.split('T')[0];
 
             // Merged PRs in the last 24 hours

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -214,4 +214,4 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-6
-            --allowed-tools "Read,Glob,Grep,Bash(git log *),Bash(git diff *),Bash(git show *),Bash(gh issue create *),Bash(gh issue list *),Bash(gh label create *),Bash(gh pr list *),Bash(gh pr view *)"
+            --allowed-tools "Read,Glob,Grep,Bash(git log *),Bash(git diff *),Bash(git show *),Bash(gh issue create *),Bash(gh issue list *),Bash(gh issue edit *),Bash(gh issue comment *),Bash(gh label create *),Bash(gh pr list *),Bash(gh pr view *)"

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -1,0 +1,201 @@
+name: Daily Standup Summary
+
+on:
+  schedule:
+    - cron: "0 8 * * 1-5"  # Weekdays at 08:00 UTC
+  workflow_dispatch:         # Manual trigger for on-demand summaries
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+  id-token: write
+
+jobs:
+  daily-standup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Gather recent activity
+        id: activity
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+            // Merged PRs in the last 24 hours
+            const mergedPRs = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged merged:>=${since}`,
+              per_page: 50
+            });
+
+            // Open PRs with recent activity
+            const activePRs = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open updated:>=${since}`,
+              per_page: 50
+            });
+
+            // Recently closed issues
+            const closedIssues = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:closed closed:>=${since}`,
+              per_page: 50
+            });
+
+            // Recently opened issues
+            const openedIssues = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open created:>=${since}`,
+              per_page: 50
+            });
+
+            // Recent commits on main
+            let recentCommits = [];
+            try {
+              const commits = await github.rest.repos.listCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                since: since,
+                per_page: 50
+              });
+              recentCommits = commits.data.map(c => ({
+                sha: c.sha.substring(0, 7),
+                message: c.commit.message.split('\n')[0],
+                author: c.commit.author.name,
+                date: c.commit.author.date
+              }));
+            } catch (e) {
+              recentCommits = [];
+            }
+
+            // PR review comments in the last 24 hours
+            let reviewComments = [];
+            for (const pr of activePRs.data.items.slice(0, 10)) {
+              try {
+                const comments = await github.rest.pulls.listReviewComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  since: since,
+                  per_page: 20
+                });
+                for (const c of comments.data) {
+                  reviewComments.push({
+                    pr: pr.number,
+                    prTitle: pr.title,
+                    body: c.body.substring(0, 300),
+                    author: c.user.login
+                  });
+                }
+              } catch (e) { /* skip */ }
+            }
+
+            return {
+              since,
+              mergedPRs: mergedPRs.data.items.map(p => ({
+                number: p.number,
+                title: p.title,
+                user: p.user.login,
+                labels: p.labels.map(l => l.name)
+              })),
+              activePRs: activePRs.data.items.map(p => ({
+                number: p.number,
+                title: p.title,
+                user: p.user.login,
+                labels: p.labels.map(l => l.name),
+                draft: p.draft
+              })),
+              closedIssues: closedIssues.data.items.map(i => ({
+                number: i.number,
+                title: i.title,
+                labels: i.labels.map(l => l.name)
+              })),
+              openedIssues: openedIssues.data.items.map(i => ({
+                number: i.number,
+                title: i.title,
+                labels: i.labels.map(l => l.name)
+              })),
+              recentCommits,
+              reviewComments: reviewComments.slice(0, 30)
+            };
+
+      - name: Generate standup summary with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are generating a daily standup summary for the TNLean repository
+            (${{ github.repository }}), a Lean 4 formalization project for quantum
+            information theory (Matrix Product States, Wielandt theory, quantum channels).
+
+            Today's date: ${{ github.event.schedule && 'scheduled run' || 'manual trigger' }}
+            Activity window: last 24 hours (since ${{ fromJSON(steps.activity.outputs.result).since }})
+
+            === REPOSITORY ACTIVITY DATA ===
+
+            MERGED PULL REQUESTS:
+            ${{ toJSON(fromJSON(steps.activity.outputs.result).mergedPRs) }}
+
+            ACTIVE (OPEN) PULL REQUESTS:
+            ${{ toJSON(fromJSON(steps.activity.outputs.result).activePRs) }}
+
+            CLOSED ISSUES:
+            ${{ toJSON(fromJSON(steps.activity.outputs.result).closedIssues) }}
+
+            NEWLY OPENED ISSUES:
+            ${{ toJSON(fromJSON(steps.activity.outputs.result).openedIssues) }}
+
+            RECENT COMMITS ON MAIN:
+            ${{ toJSON(fromJSON(steps.activity.outputs.result).recentCommits) }}
+
+            PR REVIEW COMMENTS (sample):
+            ${{ toJSON(fromJSON(steps.activity.outputs.result).reviewComments) }}
+
+            === INSTRUCTIONS ===
+
+            Analyze the activity above and produce a standup summary. For additional
+            context, you may read files referenced in PRs/commits (use Read/Glob/Grep).
+            Look at git log and diff for the last 24 hours to understand what changed.
+
+            Create a GitHub issue with the title: "Daily Standup — <today's date YYYY-MM-DD>"
+            and label it "standup". Create the label first if it does not exist.
+
+            The issue body MUST follow this structure:
+
+            ## What Was Accomplished
+            - Summarize merged PRs, closed issues, and key commits
+            - Note who contributed what
+            - Highlight proof completions, new formalizations, or `sorry` eliminations
+
+            ## Lessons Learned
+            - Extract insights from PR review discussions
+            - Note any tricky proof strategies that worked (or didn't)
+            - Document Lean/Mathlib patterns discovered
+
+            ## Insights Gained
+            - Architectural or structural observations about the codebase
+            - Connections between different formalization areas
+            - Dependency or tooling observations
+
+            ## Key Points for Discussion
+            - Open questions from PR reviews or issues
+            - Blockers or areas needing help
+            - Decisions that need team input
+            - Upcoming work based on newly opened issues
+
+            ## Activity Stats
+            - PRs merged / opened / in review
+            - Issues closed / opened
+            - Number of commits
+
+            Guidelines:
+            - Be concise but informative — this is a quick catch-up document
+            - Use PR/issue numbers as references (e.g., #123)
+            - If there was no activity, say so briefly and skip empty sections
+            - Focus on substance over ceremony
+
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowed-tools "Read,Glob,Grep,Bash(git log *),Bash(git diff *),Bash(git show *),Bash(gh issue create *),Bash(gh issue list *),Bash(gh label create *),Bash(gh pr list *),Bash(gh pr view *)"

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -213,5 +213,5 @@ jobs:
             - Focus on substance over ceremony
 
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-opus-4-6
             --allowed-tools "Read,Glob,Grep,Bash(git log *),Bash(git diff *),Bash(git show *),Bash(gh issue create *),Bash(gh issue list *),Bash(gh label create *),Bash(gh pr list *),Bash(gh pr view *)"

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -36,7 +36,7 @@ jobs:
             const since = new Date(Date.now() - hoursBack * 60 * 60 * 1000).toISOString();
             const sinceDate = since.split('T')[0];
 
-            // Merged PRs in the last 24 hours
+            // Merged PRs in the lookback window
             const mergedPRs = await github.rest.search.issuesAndPullRequests({
               q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged merged:>=${sinceDate}`,
               per_page: 50
@@ -118,6 +118,7 @@ jobs:
 
             return {
               since,
+              hoursBack,
               mergedPRs: mergedPRs.data.items.map(p => ({
                 number: p.number,
                 title: p.title,
@@ -170,7 +171,7 @@ jobs:
             proofs, resolved conjectures).
 
             Today's date: ${{ steps.date.outputs.today }}
-            Activity window: last 24 hours (since ${{ fromJSON(steps.activity.outputs.result).since }})
+            Activity window: last ${{ fromJSON(steps.activity.outputs.result).hoursBack }} hours (since ${{ fromJSON(steps.activity.outputs.result).since }})
 
             === REPOSITORY ACTIVITY DATA ===
 
@@ -197,7 +198,7 @@ jobs:
             Analyze the activity above and produce a standup summary. For additional
             context, read the actual Lean source files changed (use Read/Glob/Grep) to
             understand the mathematical content of proofs, not just commit messages.
-            Use git log and git diff for the last 24 hours to see what changed in detail.
+            Use git log and git diff for the activity window above to see what changed in detail.
 
             Before creating any issue, use the mcp__github__search_issues tool to check
             whether a standup issue for today's date already exists (search for

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -168,15 +168,16 @@ jobs:
             context, you may read files referenced in PRs/commits (use Read/Glob/Grep).
             Look at git log and diff for the last 24 hours to understand what changed.
 
-            Before creating any issue, use "Bash(gh issue list *)" to check whether a
-            standup issue for today's date already exists (filter by title
-            "Daily Standup — ${{ steps.date.outputs.today }}" and/or the "standup" label).
-            If such an issue exists, DO NOT create a new one — instead, update or comment
-            on the existing issue as appropriate.
+            Before creating any issue, use the mcp__github__search_issues tool to check
+            whether a standup issue for today's date already exists (search for
+            "Daily Standup — ${{ steps.date.outputs.today }}" with the "standup" label).
+            If such an issue exists, DO NOT create a new one — instead, use
+            mcp__github__add_issue_comment to update the existing issue.
 
-            If no such issue exists, create a GitHub issue with the title:
-            "Daily Standup — ${{ steps.date.outputs.today }}" and label it "standup".
-            Create the label first if it does not exist.
+            If no such issue exists, use mcp__github__issue_write to create a GitHub
+            issue with the title: "Daily Standup — ${{ steps.date.outputs.today }}" and
+            label it "standup". Use mcp__github__get_label to check if the label exists
+            first, and create it if needed.
 
             The issue body MUST follow this structure:
 
@@ -214,4 +215,4 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-6
-            --allowed-tools "Read,Glob,Grep,Bash(git log *),Bash(git diff *),Bash(git show *),Bash(gh issue create *),Bash(gh issue list *),Bash(gh issue edit *),Bash(gh issue comment *),Bash(gh label create *),Bash(gh pr list *),Bash(gh pr view *)"
+            --allowed-tools "Read,Glob,Grep,Bash(git log *),Bash(git diff *),Bash(git show *),mcp__github__search_issues,mcp__github__issue_write,mcp__github__issue_read,mcp__github__add_issue_comment,mcp__github__get_label,mcp__github__list_issues,mcp__github__search_pull_requests,mcp__github__list_pull_requests,mcp__github__pull_request_read,mcp__github__list_commits"


### PR DESCRIPTION
## Summary
- Adds a new scheduled GitHub Actions workflow that runs weekdays at 08:00 UTC (with manual dispatch option)
- Uses `anthropic/claude-code-action@v1` with Claude Opus to analyze the last 24 hours of repo activity and generate a standup summary issue
- Collects merged PRs, active PRs, closed/opened issues, recent commits, and review comments via GitHub API before passing to Claude
- Uses native GitHub MCP tools (`mcp__github__*`) for issue creation, search, and comments

## How It Works

1. **Date step** — Computes today's UTC date for consistent issue titles
2. **Data gathering step** — Uses `actions/github-script@v8` to query the GitHub API for all activity in the past 24 hours (merged PRs, open PRs, closed issues, new issues, commits on `main`, review comments). Uses YYYY-MM-DD format for search qualifiers and `core.warning()` for error visibility
3. **Claude analysis step** — Passes the gathered data to Claude Code Action, which can also read files and git history for additional context
4. **Output** — Claude creates a GitHub issue labeled `standup` (via MCP tools) with sections:
   - What Was Accomplished
   - Lessons Learned
   - Insights Gained
   - Key Points for Discussion
   - Activity Stats

## Key Design Decisions
- **Model:** Claude Opus 4.6 (per user request)
- **Auth:** Uses existing `CLAUDE_CODE_OAUTH_TOKEN` secret
- **MCP tools:** Uses native `mcp__github__*` tools instead of `gh` CLI for structured API access
- **Duplicate guard:** Claude checks for existing standup issue before creating a new one
- **Error observability:** API failures logged via `core.warning()` instead of silent catch blocks
- **Branch targeting:** Commits explicitly fetched from `main`

## Test plan
- [ ] Trigger manually via `workflow_dispatch` to verify end-to-end
- [ ] Confirm the standup issue is created with correct label and formatting
- [ ] Verify it handles quiet days (no activity) gracefully
- [ ] Verify duplicate guard works on re-runs

https://claude.ai/code/session_015AznWvHjdzpQ2U59WEm6DS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a scheduled GitHub Action that can create/update issues using an OAuth secret; misconfiguration could spam issues or expose more repo metadata than intended via the AI prompt.
> 
> **Overview**
> Introduces a new scheduled workflow (`.github/workflows/daily-standup.yml`) that runs weekdays (and via manual dispatch) to post a *daily standup* GitHub issue.
> 
> The job collects recent repo activity (merged/active PRs, opened/closed issues excluding `standup`, recent `main` commits, and sample PR review comments) via `actions/github-script`, then calls `anthropics/claude-code-action@v1` to generate the standup content and create/update the dated issue using GitHub MCP tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 510c8b3983d988737e27736166f0f9eb0ab1c6e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->