### PR TITLE
feat(Wielandt,MPS/FT): remove unused aperiodicity hypothesis, add primitive proportional wrapper

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -123,6 +123,7 @@ import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.Structure.LinearExtension
 import TNLean.MPS.FundamentalTheorem.Basic
 import TNLean.MPS.FundamentalTheorem.Proportional
+import TNLean.MPS.FundamentalTheorem.ProportionalPrimitive
 import TNLean.MPS.FundamentalTheorem.Applications
 -- Symmetry
 import TNLean.MPS.Symmetry.Defs

--- a/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Semigroup.LindbladForm.Basic
 import TNLean.Channel.ChoiJamiolkowski
-import TNLean.Algebra.ScalarCommutant
 
 /-!
 # Lindblad Form — Uniqueness of traceless GKSL decompositions
@@ -47,9 +46,8 @@ theorem generatorDecomp_traceless_unique_phi
     (htr' : F'.HasTracelessKraus) :
     F.toGeneratorDecomp.φ = F'.toGeneratorDecomp.φ := by
   -- Proof strategy (Wolf): compare projected Choi matrices and use Choi injectivity.
-  -- For traceless Kraus operators, choiMatrix(φ) = projectedChoiMatrix(φ) since
-  -- ⟨Ω|τ_φ|Ω⟩ = (1/D)·Σⱼ|tr(Lⱼ)|² = 0 and τ_φ ≥ 0 forces τ_φ|Ω⟩ = 0.
-  -- Then choiMatrix(φ) = projectedChoiMatrix(L) = choiMatrix(φ'), hence φ = φ'.
+  -- Infrastructure for the final projection/orthogonality argument is developed in
+  -- `ChoiJamiolkowski` and related Lindblad files.
   sorry
 
 /--
@@ -59,13 +57,6 @@ traceless, then their drift matrices differ only by an imaginary scalar:
 
 This is the Hamiltonian uniqueness modulo global energy shift in Wolf Prop. 7.4
 (item 2).
-
-The proof proceeds as follows: once `φ = φ'` is known (from
-`generatorDecomp_traceless_unique_phi`), the generator equality forces
-`Δκ ρ + ρ (Δκ)† = 0` for all `ρ`. Setting `ρ = 1` yields `Δκ + (Δκ)† = 0`
-(skew-Hermiticity), which converts the equation to `[Δκ, ρ] = 0`. The scalar
-commutant lemma then gives `Δκ = c · 𝟙`, and skew-Hermiticity forces `c` to
-be purely imaginary.
 -/
 theorem generatorDecomp_traceless_unique_kappa_modPhase
     (F F' : LindbladForm D)
@@ -75,44 +66,10 @@ theorem generatorDecomp_traceless_unique_kappa_modPhase
     ∃ l : ℝ,
       F'.toGeneratorDecomp.κ =
         F.toGeneratorDecomp.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
-  -- Step 1: φ = φ' from the first uniqueness theorem (currently sorry)
-  have hφ := generatorDecomp_traceless_unique_phi F F' hL htr htr'
-  -- Step 2: Generator decompositions define the same linear map
-  have hG : F.toGeneratorDecomp.toLinearMap = F'.toGeneratorDecomp.toLinearMap := by
-    rw [← F.toLinearMap_eq_generatorDecomp, ← F'.toLinearMap_eq_generatorDecomp]; exact hL
-  -- Step 3: Δκ * ρ + ρ * Δκ† = 0 for all ρ
-  set κ := F.toGeneratorDecomp.κ with hκ_def
-  set κ' := F'.toGeneratorDecomp.κ with hκ'_def
-  set Δ := κ' - κ with hΔ_def
-  have hΔ : ∀ ρ : Matrix (Fin D) (Fin D) ℂ, Δ * ρ + ρ * Δᴴ = 0 := by
-    intro ρ
-    have h := LinearMap.ext_iff.mp hG ρ
-    simp only [GeneratorDecomp.toLinearMap_apply] at h
-    -- h : F.φ ρ - κ * ρ - ρ * κᴴ = F'.φ ρ - κ' * ρ - ρ * κ'ᴴ
-    -- Use hφ to unify the φ terms on both sides
-    rw [show F.toGeneratorDecomp.φ = F'.toGeneratorDecomp.φ from hφ] at h
-    -- h : F'.φ ρ - κ * ρ - ρ * κᴴ = F'.φ ρ - κ' * ρ - ρ * κ'ᴴ
-    -- Derive Δ * ρ + ρ * Δᴴ = 0 from h
-    have h0 := sub_eq_zero.mpr h
-    show Δ * ρ + ρ * Δᴴ = 0
-    rw [hΔ_def, conjTranspose_sub, sub_mul, mul_sub]
-    convert h0 using 1; abel
-  -- Step 4: Δ is skew-Hermitian (set ρ = 1)
-  have hskew : Δᴴ = -Δ := by
-    have h1 := hΔ 1; rw [mul_one, one_mul] at h1
-    exact eq_neg_of_add_eq_zero_right h1
-  -- Step 5: Δ commutes with all matrices
-  have hcomm : ∀ M : Matrix (Fin D) (Fin D) ℂ, Δ * M = M * Δ := by
-    intro M
-    have hM := hΔ M
-    rw [hskew, mul_neg, ← sub_eq_add_neg] at hM
-    exact sub_eq_zero.mp hM
-  -- Step 6: Δ is a scalar matrix (center of M_n)
-  obtain ⟨c, hc⟩ := Matrix.isScalar_of_commute_span_eq_top Δ
-    Submodule.span_univ (fun M _ => hcomm M)
-  -- Step 7–8: c is purely imaginary ⟹ extract real scalar
-  -- (Proof: skew-Hermiticity of Δ forces star c = -c,
-  --  hence c.re = 0 and c = I * c.im.)
+  -- Proof strategy (Wolf): after identifying `φ = φ'`, the residual map is
+  -- `ρ ↦ -(Δκ)ρ - ρ(Δκ)†`; equality to zero forces `Δκ` to be a scalar multiple
+  -- of identity, and trace/Hermiticity constraints force that scalar to be purely
+  -- imaginary.
   sorry
 
 /-- Combined uniqueness statement for traceless Lindblad decompositions. -/

--- a/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
@@ -75,30 +75,32 @@ theorem generatorDecomp_traceless_unique_kappa_modPhase
     ∃ l : ℝ,
       F'.toGeneratorDecomp.κ =
         F.toGeneratorDecomp.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
-  -- Step 1: φ = φ' from the first uniqueness theorem
+  -- Step 1: φ = φ' from the first uniqueness theorem (currently sorry)
   have hφ := generatorDecomp_traceless_unique_phi F F' hL htr htr'
   -- Step 2: Generator decompositions define the same linear map
   have hG : F.toGeneratorDecomp.toLinearMap = F'.toGeneratorDecomp.toLinearMap := by
     rw [← F.toLinearMap_eq_generatorDecomp, ← F'.toLinearMap_eq_generatorDecomp]; exact hL
   -- Step 3: Δκ * ρ + ρ * Δκ† = 0 for all ρ
-  set κ := F.toGeneratorDecomp.κ
-  set κ' := F'.toGeneratorDecomp.κ
-  set Δ := κ' - κ
+  set κ := F.toGeneratorDecomp.κ with hκ_def
+  set κ' := F'.toGeneratorDecomp.κ with hκ'_def
+  set Δ := κ' - κ with hΔ_def
   have hΔ : ∀ ρ : Matrix (Fin D) (Fin D) ℂ, Δ * ρ + ρ * Δᴴ = 0 := by
     intro ρ
-    show (κ' - κ) * ρ + ρ * (κ' - κ)ᴴ = 0
-    rw [conjTranspose_sub, sub_mul, mul_sub]
-    -- Goal: κ' * ρ - κ * ρ + (ρ * κ'ᴴ - ρ * κᴴ) = 0
     have h := LinearMap.ext_iff.mp hG ρ
-    simp only [GeneratorDecomp.toLinearMap_apply, hφ] at h
+    simp only [GeneratorDecomp.toLinearMap_apply] at h
+    -- h : F.φ ρ - κ * ρ - ρ * κᴴ = F'.φ ρ - κ' * ρ - ρ * κ'ᴴ
+    -- Use hφ to unify the φ terms on both sides
+    rw [show F.toGeneratorDecomp.φ = F'.toGeneratorDecomp.φ from hφ] at h
     -- h : F'.φ ρ - κ * ρ - ρ * κᴴ = F'.φ ρ - κ' * ρ - ρ * κ'ᴴ
+    -- Derive Δ * ρ + ρ * Δᴴ = 0 from h
     have h0 := sub_eq_zero.mpr h
-    -- h0 : (F'.φ ρ - κ * ρ - ρ * κᴴ) - (F'.φ ρ - κ' * ρ - ρ * κ'ᴴ) = 0
-    -- The F'.φ ρ terms cancel, leaving our goal up to additive rearrangement
+    show Δ * ρ + ρ * Δᴴ = 0
+    rw [hΔ_def, conjTranspose_sub, sub_mul, mul_sub]
     convert h0 using 1; abel
   -- Step 4: Δ is skew-Hermitian (set ρ = 1)
-  have hskew : Δᴴ = -Δ :=
-    eq_neg_of_add_eq_zero_right (by simpa [mul_one, one_mul] using hΔ 1)
+  have hskew : Δᴴ = -Δ := by
+    have h1 := hΔ 1; rw [mul_one, one_mul] at h1
+    exact eq_neg_of_add_eq_zero_right h1
   -- Step 5: Δ commutes with all matrices
   have hcomm : ∀ M : Matrix (Fin D) (Fin D) ℂ, Δ * M = M * Δ := by
     intro M
@@ -108,41 +110,10 @@ theorem generatorDecomp_traceless_unique_kappa_modPhase
   -- Step 6: Δ is a scalar matrix (center of M_n)
   obtain ⟨c, hc⟩ := Matrix.isScalar_of_commute_span_eq_top Δ
     Submodule.span_univ (fun M _ => hcomm M)
-  -- Step 7: c is purely imaginary (from skew-Hermiticity)
-  by_cases hD : D = 0
-  · subst hD; exact ⟨0, Subsingleton.elim _ _⟩
-  · haveI : NeZero D := ⟨hD⟩
-    have hc_skew : starRingEnd ℂ c = -c := by
-      -- Extract from entry (0,0): Δᴴ₀₀ = star(Δ₀₀) = star c, and (-Δ)₀₀ = -c
-      set idx : Fin D := ⟨0, Nat.pos_of_ne_zero hD⟩
-      have h1 := congr_fun (congr_fun hskew idx) idx
-      -- h1 : Δᴴ idx idx = (-Δ) idx idx
-      simp only [conjTranspose_apply, neg_apply] at h1
-      -- h1 : star (Δ idx idx) = -(Δ idx idx)
-      rw [hc] at h1
-      simp only [Matrix.scalar, diagonalRingHom_apply, Pi.constRingHom_apply,
-        diagonal_apply_eq] at h1
-      -- h1 : star c = -c, which is starRingEnd ℂ c = -c
-      exact h1
-    have hre : c.re = 0 := by
-      have h0 : c + conj c = 0 := by
-        show c + starRingEnd ℂ c = 0
-        rw [hc_skew]; abel
-      rw [Complex.add_conj] at h0
-      have h1 : (2 : ℝ) * c.re = 0 := by exact_mod_cast h0
-      linarith
-    -- Step 8: Extract the real scalar l = c.im
-    refine ⟨c.im, ?_⟩
-    have hc_eq : c = Complex.I * (c.im : ℂ) := by
-      ext
-      · simp [hre]
-      · simp
-    show κ' = κ + (Complex.I * ↑c.im) • 1
-    have : κ' = Δ + κ := by simp [Δ]
-    rw [this, hc, ← hc_eq]
-    ext i j
-    simp [Matrix.scalar, Matrix.diagonal, Matrix.one_apply, smul_apply]
-    by_cases h : i = j <;> simp [h]
+  -- Step 7–8: c is purely imaginary ⟹ extract real scalar
+  -- (Proof: skew-Hermiticity of Δ forces star c = -c,
+  --  hence c.re = 0 and c = I * c.im.)
+  sorry
 
 /-- Combined uniqueness statement for traceless Lindblad decompositions. -/
 theorem generatorDecomp_traceless_unique

--- a/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
@@ -107,23 +107,27 @@ theorem generatorDecomp_traceless_unique_kappa_modPhase
     exact sub_eq_zero.mp hM
   -- Step 6: Δ is a scalar matrix (center of M_n)
   obtain ⟨c, hc⟩ := Matrix.isScalar_of_commute_span_eq_top Δ
-    (Submodule.span_univ ℂ) (fun M _ => hcomm M)
+    Submodule.span_univ (fun M _ => hcomm M)
   -- Step 7: c is purely imaginary (from skew-Hermiticity)
   by_cases hD : D = 0
   · subst hD; exact ⟨0, Subsingleton.elim _ _⟩
   · haveI : NeZero D := ⟨hD⟩
     have hc_skew : starRingEnd ℂ c = -c := by
-      have hΔ_conj : Δᴴ = Matrix.scalar (Fin D) (starRingEnd ℂ c) := by
-        rw [hc, diagonal_conjTranspose]; ext; simp [Matrix.scalar]
-      rw [hskew, hc] at hΔ_conj
-      have h_neg : -Matrix.scalar (Fin D) c = Matrix.scalar (Fin D) (-c) := by
-        ext; simp [Matrix.scalar]
-      rw [h_neg] at hΔ_conj
-      have h_inj := congr_fun (congr_fun hΔ_conj ⟨0, Nat.pos_of_ne_zero hD⟩)
-        ⟨0, Nat.pos_of_ne_zero hD⟩
-      simpa [Matrix.scalar, Matrix.diagonal] using h_inj
+      -- Extract from entry (0,0): Δᴴ₀₀ = star(Δ₀₀) = star c, and (-Δ)₀₀ = -c
+      set idx : Fin D := ⟨0, Nat.pos_of_ne_zero hD⟩
+      have h1 := congr_fun (congr_fun hskew idx) idx
+      -- h1 : Δᴴ idx idx = (-Δ) idx idx
+      simp only [conjTranspose_apply, neg_apply] at h1
+      -- h1 : star (Δ idx idx) = -(Δ idx idx)
+      rw [hc] at h1
+      simp only [Matrix.scalar, diagonalRingHom_apply, Pi.constRingHom_apply,
+        diagonal_apply_eq] at h1
+      -- h1 : star c = -c, which is starRingEnd ℂ c = -c
+      exact h1
     have hre : c.re = 0 := by
-      have h0 : c + starRingEnd ℂ c = 0 := by rw [hc_skew]; abel
+      have h0 : c + conj c = 0 := by
+        show c + starRingEnd ℂ c = 0
+        rw [hc_skew]; abel
       rw [Complex.add_conj] at h0
       have h1 : (2 : ℝ) * c.re = 0 := by exact_mod_cast h0
       linarith

--- a/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Semigroup.LindbladForm.Basic
 import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Algebra.ScalarCommutant
 
 /-!
 # Lindblad Form — Uniqueness of traceless GKSL decompositions
@@ -46,8 +47,9 @@ theorem generatorDecomp_traceless_unique_phi
     (htr' : F'.HasTracelessKraus) :
     F.toGeneratorDecomp.φ = F'.toGeneratorDecomp.φ := by
   -- Proof strategy (Wolf): compare projected Choi matrices and use Choi injectivity.
-  -- Infrastructure for the final projection/orthogonality argument is developed in
-  -- `ChoiJamiolkowski` and related Lindblad files.
+  -- For traceless Kraus operators, choiMatrix(φ) = projectedChoiMatrix(φ) since
+  -- ⟨Ω|τ_φ|Ω⟩ = (1/D)·Σⱼ|tr(Lⱼ)|² = 0 and τ_φ ≥ 0 forces τ_φ|Ω⟩ = 0.
+  -- Then choiMatrix(φ) = projectedChoiMatrix(L) = choiMatrix(φ'), hence φ = φ'.
   sorry
 
 /--
@@ -57,6 +59,13 @@ traceless, then their drift matrices differ only by an imaginary scalar:
 
 This is the Hamiltonian uniqueness modulo global energy shift in Wolf Prop. 7.4
 (item 2).
+
+The proof proceeds as follows: once `φ = φ'` is known (from
+`generatorDecomp_traceless_unique_phi`), the generator equality forces
+`Δκ ρ + ρ (Δκ)† = 0` for all `ρ`. Setting `ρ = 1` yields `Δκ + (Δκ)† = 0`
+(skew-Hermiticity), which converts the equation to `[Δκ, ρ] = 0`. The scalar
+commutant lemma then gives `Δκ = c · 𝟙`, and skew-Hermiticity forces `c` to
+be purely imaginary.
 -/
 theorem generatorDecomp_traceless_unique_kappa_modPhase
     (F F' : LindbladForm D)
@@ -66,11 +75,70 @@ theorem generatorDecomp_traceless_unique_kappa_modPhase
     ∃ l : ℝ,
       F'.toGeneratorDecomp.κ =
         F.toGeneratorDecomp.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
-  -- Proof strategy (Wolf): after identifying `φ = φ'`, the residual map is
-  -- `ρ ↦ -(Δκ)ρ - ρ(Δκ)†`; equality to zero forces `Δκ` to be a scalar multiple
-  -- of identity, and trace/Hermiticity constraints force that scalar to be purely
-  -- imaginary.
-  sorry
+  -- Step 1: φ = φ' from the first uniqueness theorem
+  have hφ := generatorDecomp_traceless_unique_phi F F' hL htr htr'
+  -- Step 2: Generator decompositions define the same linear map
+  have hG : F.toGeneratorDecomp.toLinearMap = F'.toGeneratorDecomp.toLinearMap := by
+    rw [← F.toLinearMap_eq_generatorDecomp, ← F'.toLinearMap_eq_generatorDecomp]; exact hL
+  -- Step 3: Δκ * ρ + ρ * Δκ† = 0 for all ρ
+  set κ := F.toGeneratorDecomp.κ
+  set κ' := F'.toGeneratorDecomp.κ
+  set Δ := κ' - κ
+  have hΔ : ∀ ρ : Matrix (Fin D) (Fin D) ℂ, Δ * ρ + ρ * Δᴴ = 0 := by
+    intro ρ
+    show (κ' - κ) * ρ + ρ * (κ' - κ)ᴴ = 0
+    rw [conjTranspose_sub, sub_mul, mul_sub]
+    -- Goal: κ' * ρ - κ * ρ + (ρ * κ'ᴴ - ρ * κᴴ) = 0
+    have h := LinearMap.ext_iff.mp hG ρ
+    simp only [GeneratorDecomp.toLinearMap_apply, hφ] at h
+    -- h : F'.φ ρ - κ * ρ - ρ * κᴴ = F'.φ ρ - κ' * ρ - ρ * κ'ᴴ
+    have h0 := sub_eq_zero.mpr h
+    -- h0 : (F'.φ ρ - κ * ρ - ρ * κᴴ) - (F'.φ ρ - κ' * ρ - ρ * κ'ᴴ) = 0
+    -- The F'.φ ρ terms cancel, leaving our goal up to additive rearrangement
+    convert h0 using 1; abel
+  -- Step 4: Δ is skew-Hermitian (set ρ = 1)
+  have hskew : Δᴴ = -Δ :=
+    eq_neg_of_add_eq_zero_right (by simpa [mul_one, one_mul] using hΔ 1)
+  -- Step 5: Δ commutes with all matrices
+  have hcomm : ∀ M : Matrix (Fin D) (Fin D) ℂ, Δ * M = M * Δ := by
+    intro M
+    have hM := hΔ M
+    rw [hskew, mul_neg, ← sub_eq_add_neg] at hM
+    exact sub_eq_zero.mp hM
+  -- Step 6: Δ is a scalar matrix (center of M_n)
+  obtain ⟨c, hc⟩ := Matrix.isScalar_of_commute_span_eq_top Δ
+    (Submodule.span_univ ℂ) (fun M _ => hcomm M)
+  -- Step 7: c is purely imaginary (from skew-Hermiticity)
+  by_cases hD : D = 0
+  · subst hD; exact ⟨0, Subsingleton.elim _ _⟩
+  · haveI : NeZero D := ⟨hD⟩
+    have hc_skew : starRingEnd ℂ c = -c := by
+      have hΔ_conj : Δᴴ = Matrix.scalar (Fin D) (starRingEnd ℂ c) := by
+        rw [hc, conjTranspose_diagonal]; ext; simp [Matrix.scalar]
+      rw [hskew] at hΔ_conj
+      have h_neg : -Matrix.scalar (Fin D) c = Matrix.scalar (Fin D) (-c) := by
+        ext; simp [Matrix.scalar]
+      rw [hc, h_neg] at hΔ_conj
+      have h_inj := congr_fun (congr_fun hΔ_conj ⟨0, Nat.pos_of_ne_zero hD⟩)
+        ⟨0, Nat.pos_of_ne_zero hD⟩
+      simpa [Matrix.scalar, Matrix.diagonal] using h_inj
+    have hre : c.re = 0 := by
+      have h0 : c + starRingEnd ℂ c = 0 := by rw [hc_skew]; abel
+      rw [Complex.add_conj] at h0
+      have h1 : (2 : ℝ) * c.re = 0 := by exact_mod_cast h0
+      linarith
+    -- Step 8: Extract the real scalar l = c.im
+    refine ⟨c.im, ?_⟩
+    have hc_eq : c = Complex.I * (c.im : ℂ) := by
+      ext
+      · simp [hre]
+      · simp
+    show κ' = κ + (Complex.I * ↑c.im) • 1
+    have : κ' = Δ + κ := by simp [Δ]
+    rw [this, hc, ← hc_eq]
+    ext i j
+    simp [Matrix.scalar, Matrix.diagonal, Matrix.one_apply, smul_apply]
+    split <;> simp
 
 /-- Combined uniqueness statement for traceless Lindblad decompositions. -/
 theorem generatorDecomp_traceless_unique

--- a/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
@@ -114,11 +114,11 @@ theorem generatorDecomp_traceless_unique_kappa_modPhase
   · haveI : NeZero D := ⟨hD⟩
     have hc_skew : starRingEnd ℂ c = -c := by
       have hΔ_conj : Δᴴ = Matrix.scalar (Fin D) (starRingEnd ℂ c) := by
-        rw [hc, conjTranspose_diagonal]; ext; simp [Matrix.scalar]
-      rw [hskew] at hΔ_conj
+        rw [hc, diagonal_conjTranspose]; ext; simp [Matrix.scalar]
+      rw [hskew, hc] at hΔ_conj
       have h_neg : -Matrix.scalar (Fin D) c = Matrix.scalar (Fin D) (-c) := by
         ext; simp [Matrix.scalar]
-      rw [hc, h_neg] at hΔ_conj
+      rw [h_neg] at hΔ_conj
       have h_inj := congr_fun (congr_fun hΔ_conj ⟨0, Nat.pos_of_ne_zero hD⟩)
         ⟨0, Nat.pos_of_ne_zero hD⟩
       simpa [Matrix.scalar, Matrix.diagonal] using h_inj
@@ -138,7 +138,7 @@ theorem generatorDecomp_traceless_unique_kappa_modPhase
     rw [this, hc, ← hc_eq]
     ext i j
     simp [Matrix.scalar, Matrix.diagonal, Matrix.one_apply, smul_apply]
-    split <;> simp
+    by_cases h : i = j <;> simp [h]
 
 /-- Combined uniqueness statement for traceless Lindblad decompositions. -/
 theorem generatorDecomp_traceless_unique

--- a/TNLean/MPS/FundamentalTheorem/ProportionalPrimitive.lean
+++ b/TNLean/MPS/FundamentalTheorem/ProportionalPrimitive.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.Proportional
+import TNLean.MPS.Structure.PrimitivityBridge
+import TNLean.Wielandt.Primitivity.ImpliesIrreducible
+
+/-!
+# Proportional Fundamental Theorem — Primitive convenience wrappers
+
+This file provides strengthened versions of the proportional single-block
+Fundamental Theorem that take `IsPrimitiveMPS` hypotheses directly, eliminating
+the need to separately supply normalization and overlap-convergence conditions.
+
+## Main results
+
+* `gaugePhaseEquiv_of_proportionalMPV₂_of_isPrimitiveMPS`: if both tensors
+  have primitive transfer maps with positive-definite fixed points and their MPV
+  families are proportional, then the tensors are gauge-phase equivalent.
+
+## Strengthening over the literature
+
+The standard statement (arXiv:2011.12127, Theorem 4.4) requires the user to
+separately verify left-canonicality, self-overlap convergence, and
+irreducibility.  Since `IsPrimitiveMPS` packages all of these (primitivity
+implies irreducibility, left-canonicality is built in, and the spectral gap
+gives overlap convergence), the wrapper here reduces the hypothesis count from
+7 to 4.
+
+## References
+
+- Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product States and Projected
+  Entangled Pair States*, arXiv:2011.12127, Theorem 4.4
+-/
+
+open scoped Matrix BigOperators
+open Filter
+
+namespace MPSTensor
+
+variable {d D : ℕ} [NeZero D]
+
+/-- **Proportional Fundamental Theorem (primitive convenience form).**
+
+If `A` and `B` both have primitive transfer maps with positive-definite fixed
+points and their MPV families are proportional, then they are gauge-phase
+equivalent: `B i = ζ • X * A i * X⁻¹` for some nonzero `ζ` and invertible `X`.
+
+This eliminates the separate normalization, overlap-convergence, and
+irreducibility hypotheses by extracting them from `IsPrimitiveMPS`. -/
+theorem gaugePhaseEquiv_of_proportionalMPV₂_of_isPrimitiveMPS
+    (A B : MPSTensor d D)
+    {ρA ρB : Matrix (Fin D) (Fin D) ℂ}
+    (hA : IsPrimitiveMPS A ρA) (hA_pd : ρA.PosDef)
+    (hB : IsPrimitiveMPS B ρB) (hB_pd : ρB.PosDef)
+    (hProp : ProportionalMPV₂ (d := d) A B) :
+    GaugePhaseEquiv A B :=
+  gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one_of_irreducible_TP A B
+    (isIrreducibleTensor_of_isPrimitiveMPS_of_posDef hA hA_pd)
+    (isIrreducibleTensor_of_isPrimitiveMPS_of_posDef hB hB_pd)
+    hA.norm hB.norm
+    hA.overlap_tendsto_one hB.overlap_tendsto_one
+    hProp
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/ProportionalPrimitive.lean
+++ b/TNLean/MPS/FundamentalTheorem/ProportionalPrimitive.lean
@@ -34,7 +34,7 @@ gives overlap convergence), the wrapper here reduces the hypothesis count from
   Entangled Pair States*, arXiv:2011.12127, Theorem 4.4
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder
 open Filter
 
 namespace MPSTensor

--- a/TNLean/Wielandt/QuantumWielandt.lean
+++ b/TNLean/Wielandt/QuantumWielandt.lean
@@ -12,10 +12,9 @@ import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
 /-!
 # Quantum Wielandt primitive-to-normal packaging under `PosDef`
 
-This file packages the current primitive-to-normal bridge around
-`isNormal_of_isPrimitiveMPS_of_posDef`, together with a legacy exact-word-span
-witness theorem whose public statement still carries an explicit aperiodicity
-argument.
+This file packages the primitive-to-normal bridge
+`isNormal_of_isPrimitiveMPS_of_posDef`, together with an exact-word-span
+witness theorem that additionally requires aperiodicity.
 
 ## Proof route for normality
 
@@ -29,25 +28,20 @@ argument.
 The `(a)→(c)` part is provided by `ImpliesStronglyIrreducible.lean`, while the
 `(c)→(b)` part is provided by `Primitivity/StronglyIrreducibleToFullRank.lean`.
 
-## The aperiodicity hypothesis
+## Aperiodicity
 
-The theorem `isNormal_of_isPrimitiveMPS_of_posDef` itself no longer uses an
-aperiodicity assumption. The extra argument `hAper : 1 ∈ wordSpan A 1` survives
-only in the legacy witness theorem
-`wordSpan_eq_top_eventually_of_isPrimitiveMPS_of_posDef_of_aperiodic`, where it
-upgrades `IsNormal A` to monotone exact-length word spans.
+The main theorem `isNormal_of_isPrimitiveMPS_of_posDef` requires only
+`IsPrimitiveMPS A ρ` and `ρ.PosDef` — no aperiodicity assumption. Strong
+irreducibility already packages peripheral spectrum `{1}`.
 
-Conceptually, this matches Proposition 3: strong irreducibility packages
-irreducibility together with peripheral spectrum `{1}`. That peripheral
-condition is the source of the aperiodicity used by the
-`CumulativeToWordSpan.lean` endpoint.
+The witness theorem
+`wordSpan_eq_top_eventually_of_isPrimitiveMPS_of_posDef_of_aperiodic` takes an
+additional `hAper : 1 ∈ wordSpan A 1` to upgrade `IsNormal A` to monotone
+exact-length word spans.
 
-Within TNLean this auxiliary packaging is currently standalone: the
-normal/canonical-form reduction in `TNLean.MPS.*` does not import it directly.
-
-This module is intentionally auxiliary rather than the default paper-facing
-endpoint. Downstream users who only need Proposition 3 / Theorem 1 wrappers
-should prefer `Primitivity/Equivalence.lean` and `PaperResults/WielandtInequality.lean`.
+This module is intentionally auxiliary. Downstream users who only need
+Proposition 3 / Theorem 1 wrappers should prefer
+`Primitivity/Equivalence.lean` and `PaperResults/WielandtInequality.lean`.
 
 ## References
 
@@ -71,17 +65,16 @@ variable {d D : ℕ} [NeZero D]
 If `A` satisfies the spectral-gap predicate `IsPrimitiveMPS A ρ` and the fixed
 point `ρ` is positive definite, then `A` is normal.
 
-Conceptually, the proof factors through strong irreducibility. From
-`IsPrimitiveMPS + ρ.PosDef` one gets `IsStronglyIrreduciblePaper A`; this gives
-peripheral spectrum `{1}` (hence aperiodicity) together with irreducibility, and
-the Proposition 3(c)→(b) backend then yields eventual full Kraus rank. The
-extra aperiodicity argument `hAper` is kept only for backward compatibility with
-the older API of this file and is not used by the proof term. -/
+The proof factors through strong irreducibility: from `IsPrimitiveMPS + ρ.PosDef`
+one gets `IsStronglyIrreduciblePaper A`, which gives peripheral spectrum `{1}`
+(hence aperiodicity) together with irreducibility, and the Proposition 3(c)→(b)
+backend then yields eventual full Kraus rank.
+
+No aperiodicity hypothesis is needed. -/
 theorem isNormal_of_isPrimitiveMPS_of_posDef
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hPrim : IsPrimitiveMPS A ρ)
-    (hPD : ρ.PosDef)
-    (_hAper : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A 1) :
+    (hPD : ρ.PosDef) :
     IsNormal A := by
   exact isNormal_of_isPrimitiveMPS_with_posDef hPrim hPD
 
@@ -97,7 +90,7 @@ theorem wordSpan_eq_top_eventually_of_isPrimitiveMPS_of_posDef_of_aperiodic
     (hPD : ρ.PosDef)
     (hAper : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A 1) :
     ∃ N : ℕ, ∀ n : ℕ, N ≤ n → wordSpan A n = ⊤ := by
-  obtain ⟨N, hN⟩ := isNormal_of_isPrimitiveMPS_of_posDef hPrim hPD hAper
+  obtain ⟨N, hN⟩ := isNormal_of_isPrimitiveMPS_of_posDef hPrim hPD
   rw [← wordSpan_eq_top_iff_isNBlkInjective] at hN
   refine ⟨N, fun n hn => ?_⟩
   exact eq_top_iff.mpr <| by

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1258,20 +1258,24 @@ The gap is closed by an aperiodicity hypothesis.
     aperiodicity hypothesis, $A$ is normal.
 \end{proof}
 
-\begin{theorem}[Primitive + positive definite fixed point + aperiodicity imply normality]%
+\begin{theorem}[Primitive + positive definite fixed point imply normality]%
     \label{thm:primitive_posDef_aperiodic_normal}
     \lean{MPSTensor.isNormal_of_isPrimitiveMPS_of_posDef}
     \leanok
-    \uses{def:primitive_mps, def:normal, def:word_span}
-    If $A$ is a primitive MPS tensor with fixed point $\rho$,
-    $\rho$ is positive definite, and $\Id \in S_1(A)$, then $A$ is normal.
+    \uses{def:primitive_mps, def:normal}
+    If $A$ is a primitive MPS tensor with fixed point $\rho$ and
+    $\rho$ is positive definite, then $A$ is normal.
+    No aperiodicity assumption is needed.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:primitive_implies_irreducible, thm:irred_tensor_aperiodic_normal}
-    By Theorem~\ref{thm:primitive_implies_irreducible},
-    $A$ is an irreducible tensor.
-    Apply Theorem~\ref{thm:irred_tensor_aperiodic_normal}.
+    \uses{thm:primitive_implies_strongly_irreducible, thm:strongly_irred_to_full_rank}
+    The proof factors through strong irreducibility: from
+    $\mathrm{IsPrimitiveMPS}(A,\rho)$ and $\rho \succ 0$ one gets
+    $\mathrm{IsStronglyIrreduciblePaper}(A)$, which packages peripheral
+    spectrum $\{1\}$ (hence aperiodicity) together with irreducibility.
+    The Proposition~3\,(c)$\to$(b) backend then yields eventual full Kraus
+    rank, giving normality without a separate aperiodicity hypothesis.
 \end{proof}
 
 \begin{remark}[The normal-canonical route bypasses the aperiodicity bridge]\label{rem:d1_bypasses_aperiodicity}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -471,6 +471,29 @@ For Burnside-style arguments it is more natural to work with invariant
 	Chapter~\ref{ch:spectral}.
 \end{proof}
 
+\begin{theorem}[Proportional MPV + primitive implies gauge-phase equivalence]%
+	\label{thm:proportional_ft_primitive}
+	\lean{MPSTensor.gaugePhaseEquiv_of_proportionalMPV₂_of_isPrimitiveMPS}
+	\leanok
+	\uses{def:gauge_phase_equiv, def:primitive_mps, thm:proportional_ft}
+	Let $A$ and $B$ be MPS tensors with primitive transfer maps
+	$E_A, E_B$ and positive definite fixed points $\rho_A, \rho_B$.
+	If $A$ and $B$ generate proportional MPV families, then
+	$A$ and $B$ are gauge-phase equivalent.
+	This is a strengthened convenience form of Theorem~\ref{thm:proportional_ft}:
+	primitivity supplies left-canonicality, irreducibility, and overlap
+	convergence, reducing the hypothesis count from seven to four.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:proportional_ft, thm:primitive_implies_irreducible}
+	From $\mathrm{IsPrimitiveMPS}$, extract left-canonical normalization
+	($\sum_i (A^i)^\dagger A^i = \Id$), overlap convergence
+	($O_{AA}(N) \to 1$), and irreducibility
+	(Theorem~\ref{thm:primitive_implies_irreducible}).
+	Apply Theorem~\ref{thm:proportional_ft}.
+\end{proof}
+
 \section{Canonical form from peripheral primitivity}
 
 The canonical form predicate

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -502,8 +502,9 @@ which shows that such generators have the standard Lindblad form.
 
 \begin{theorem}[Prop.~7.4, item 2: drift uniqueness modulo phase]
     \label{thm:generatorDecomp_traceless_unique_kappa}
-    \lean{generatorDecomp_traceless_unique_kappa_modPhase}\notready
-    \uses{def:lindblad_form, def:has_traceless_kraus, def:generator_decomp}
+    \lean{generatorDecomp_traceless_unique_kappa_modPhase}\leanok
+    \uses{def:lindblad_form, def:has_traceless_kraus, def:generator_decomp,
+          thm:generatorDecomp_traceless_unique_phi}
     If two Lindblad forms $F, F'$ induce the same generator and
     both have traceless Kraus operators, then their drift matrices
     differ by an imaginary scalar: $\kappa' = \kappa + i\lambda\,\Id$
@@ -511,12 +512,17 @@ which shows that such generators have the standard Lindblad form.
     This is part of \cite[Prop.~7.4, item~2]{Wolf2012Quantum}.
 \end{theorem}
 
-\begin{proof}\notready
-    After identifying $\phi = \phi'$, the residual map is
-    $\rho \mapsto -(\Delta\kappa)\rho - \rho(\Delta\kappa)^\dagger$;
-    equality to zero forces $\Delta\kappa$ to be a scalar multiple
-    of the identity, and the Hermiticity/trace constraints force that
-    scalar to be purely imaginary.
+\begin{proof}\leanok
+    \uses{thm:generatorDecomp_traceless_unique_phi}
+    After identifying $\phi = \phi'$
+    (Theorem~\ref{thm:generatorDecomp_traceless_unique_phi}),
+    the generator equality forces
+    $\Delta\kappa \cdot \rho + \rho \cdot (\Delta\kappa)^\dagger = 0$
+    for all~$\rho$. Setting $\rho = \Id$ gives $\Delta\kappa + (\Delta\kappa)^\dagger = 0$
+    (skew-Hermiticity), which converts the equation to
+    $[\Delta\kappa, \rho] = 0$ for all~$\rho$.
+    The scalar commutant lemma gives $\Delta\kappa = c \cdot \Id$,
+    and skew-Hermiticity forces $c = i\lambda$ for some $\lambda \in \R$.
 \end{proof}
 
 \begin{theorem}[Prop.~7.4, item 2: combined uniqueness]

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -512,7 +512,7 @@ which shows that such generators have the standard Lindblad form.
     This is part of \cite[Prop.~7.4, item~2]{Wolf2012Quantum}.
 \end{theorem}
 
-\begin{proof}\leanok
+\begin{proof}\notready
     \uses{thm:generatorDecomp_traceless_unique_phi}
     After identifying $\phi = \phi'$
     (Theorem~\ref{thm:generatorDecomp_traceless_unique_phi}),


### PR DESCRIPTION
## Summary

- **Quantum Wielandt**: Remove unused aperiodicity hypothesis `_hAper` from `isNormal_of_isPrimitiveMPS_of_posDef` — the proof already derives normality via strong irreducibility without it
- **Proportional FT**: Add `gaugePhaseEquiv_of_proportionalMPV₂_of_isPrimitiveMPS` convenience wrapper reducing hypotheses from 7 to 4 by extracting normalization, irreducibility, and overlap convergence from `IsPrimitiveMPS`
- **Blueprint**: Sync ch07, ch08, ch12 with the above changes. Updated kappa proof sketch in ch12 (Lean proof remains `sorry`/`\notready`)

Note: The Lindblad kappa uniqueness proof (steps 1-6 skeleton) was attempted but reverted due to CI failures. The blueprint proof sketch is updated but the Lean `sorry` remains.

## Test plan
- [ ] CI builds all modified Lean files without errors
- [ ] Blueprint compiles with updated LaTeX
- [ ] No new `sorry` introduced

https://claude.ai/code/session_01D7XyE69hecvEh9n9c5EzTk