### PR TITLE
ci(workflows): add leanprover skills plugin to Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'claude,chatgpt-codex-connector'
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
+          plugin_marketplaces: |
+            https://github.com/anthropics/claude-code.git
+            https://github.com/leanprover/skills.git
+          plugins: |
+            code-review@claude-code-plugins
+            lean@leanprover
           prompt: |
             Review this Lean 4 pull request: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,16 +55,11 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # Load Lean skills from the official leanprover skills repository
+          plugin_marketplaces: 'https://github.com/leanprover/skills.git'
+          plugins: 'lean@leanprover'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
           claude_args: |
             --model claude-opus-4-6
             --allowed-tools "Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(gh pr:*),Bash(gh issue:*),Bash(leanblueprint *)"
             --append-system-prompt "This is a Lean 4 / Mathlib repository. Prefer minimal diffs. Before changing theorem statements, first try to complete the proof using existing lemmas. Validate with: lake build. Do not leave unrelated new sorrys."
-
-          # TODO: Explore adding MCP servers (e.g. sequential-thinking for complex proofs)


### PR DESCRIPTION
### Motivation

- The Claude GitHub Actions workflows (`claude.yml` and `claude-code-review.yml`) lack Lean-specific tooling, limiting Claude's ability to assist with proof-related tasks in this Lean 4 project.

### Description

- Add the official [leanprover/skills](https://github.com/leanprover/skills) plugin to both `claude.yml` and `claude-code-review.yml` workflows.
- This gives Claude access to 9 Lean-specific skills: `lean-proof`, `lean-setup`, `lean-bisect`, `lean-mwe`, `lean-pr`, `mathlib-build`, `mathlib-pr`, `mathlib-review`, `nightly-testing`.
- Remove stale TODO comment and commented-out examples from `claude.yml`.
- Files modified: `.github/workflows/claude.yml`, `.github/workflows/claude-code-review.yml`.

### Testing

- Trigger `claude.yml` by mentioning `@claude` on an issue or PR and verify skills are loaded.
- Open a PR touching `.lean` files and verify `claude-code-review.yml` loads both the code-review and lean plugins.
- Confirm existing code-review plugin in review workflow still works alongside the new lean plugin.

---
*(No linked issue found — the author should link one if applicable.)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions configuration for Claude, changing which plugins are loaded; no product code or data/auth logic is touched.
> 
> **Overview**
> **Enhances the Claude GitHub Actions workflows with Lean-specific tooling.** The PR updates `claude-code-review.yml` to load the official `leanprover/skills` marketplace alongside the existing code-review plugin, enabling both `code-review@claude-code-plugins` and `lean@leanprover` during automated PR reviews.
> 
> It also updates `claude.yml` to load the `lean@leanprover` plugin for on-demand `@claude` runs and cleans up workflow comments/formatting (including a small YAML/newline adjustment around `--append-system-prompt`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 673d4477bae3b5858cb5b45eb343e18aaa7c6104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->