### PR TITLE
ci(review): instruct Claude to resolve its own stale review threads

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,6 +45,7 @@ jobs:
             lean@leanprover
           prompt: |
             Review this Lean 4 pull request: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            Trigger event: ${{ github.event.action }}
 
             Use `gh pr diff ${{ github.event.pull_request.number }}` to see the changes.
 
@@ -76,5 +77,5 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-6
-            --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *)"
+            --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),mcp__github__pull_request_read,mcp__github__resolve_review_thread"
             --append-system-prompt "This is a Lean 4 / Mathlib formalization project for quantum information theory (MPS tensors, quantum channels, Wielandt theorem). Review with mathematical rigor. Flag any sorry that is not clearly marked as a known TODO."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,5 +77,5 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-6
-            --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),mcp__github__pull_request_read,mcp__github__resolve_review_thread"
+            --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),mcp__github__*"
             --append-system-prompt "This is a Lean 4 / Mathlib formalization project for quantum information theory (MPS tensors, quantum channels, Wielandt theorem). Review with mathematical rigor. Flag any sorry that is not clearly marked as a known TODO."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,6 +59,14 @@ jobs:
             For each issue found, post an inline comment on the relevant line using the GitHub CLI.
             At the end, post a summary comment on the PR with your overall assessment.
 
+            **Resolving previous review comments:**
+            When this review is triggered by a `synchronize` event (new push to the PR), before posting new comments:
+            1. List all existing review threads on this PR using the GitHub MCP tools.
+            2. For each unresolved review thread that was authored by you (the bot), check whether the new changes address the issue raised in that comment.
+            3. If a previous comment has been addressed by the new commits, resolve that review thread using the `mcp__github__resolve_review_thread` tool.
+            4. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.
+            This prevents stale bot comments from accumulating across review cycles.
+
           claude_args: |
             --model claude-opus-4-6
             --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,12 +59,19 @@ jobs:
             For each issue found, post an inline comment on the relevant line using the GitHub CLI.
             At the end, post a summary comment on the PR with your overall assessment.
 
+            **Reading existing review threads:**
+            Before posting new comments, read all existing review threads on this PR using the GitHub MCP tools.
+            This includes threads from previous review cycles and any replies from @claude or human reviewers.
+            Use this context to:
+            - Avoid re-raising issues that have already been discussed, acknowledged, or fixed.
+            - Understand any ongoing conversation or decisions made in earlier threads.
+
             **Resolving previous review comments:**
-            When this review is triggered by a `synchronize` event (new push to the PR), before posting new comments:
-            1. List all existing review threads on this PR using the GitHub MCP tools.
-            2. For each unresolved review thread that was authored by you (the bot), check whether the new changes address the issue raised in that comment.
-            3. If a previous comment has been addressed by the new commits, resolve that review thread using the `mcp__github__resolve_review_thread` tool.
-            4. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.
+            When this review is triggered by a `synchronize` event (new push to the PR):
+            1. For each unresolved review thread that was authored by you (the bot), check whether the new changes address the issue raised in that comment.
+            2. If a previous comment has been addressed by the new commits, resolve that review thread using the `mcp__github__resolve_review_thread` tool.
+            3. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.
+            4. Only resolve your own (bot) threads — never resolve threads authored by humans.
             This prevents stale bot comments from accumulating across review cycles.
 
           claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -62,4 +62,4 @@ jobs:
           claude_args: |
             --model claude-opus-4-6
             --allowed-tools "Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(gh pr:*),Bash(gh issue:*),Bash(leanblueprint *)"
-            --append-system-prompt "This is a Lean 4 / Mathlib repository. Prefer minimal diffs. Before changing theorem statements, first try to complete the proof using existing lemmas. Validate with: lake build. Do not leave unrelated new sorrys."
+            --append-system-prompt "This is a Lean 4 / Mathlib repository. Prefer minimal diffs. Before changing theorem statements, first try to complete the proof using existing lemmas. Validate with: lake build. Do not leave unrelated new sorrys. When triggered from an inline review comment, reply directly to that review thread with your response or fix. You may also read other inline review threads on the PR for context. However, do NOT resolve review threads yourself — leave resolution to humans or the automated review workflow."


### PR DESCRIPTION
### Motivation

- Stale bot review comments accumulate across successive pushes on a PR, creating noise and making it harder to identify unresolved issues.
- On `synchronize` events the Claude reviewer should automatically resolve its own threads that have been addressed by the new push.

### Description

- Modified `.github/workflows/claude-code-review.yml` to add instructions for the Claude reviewer to enumerate its own unresolved review threads on synchronize events, check them against the latest changes, and resolve addressed threads via `mcp__github__resolve_review_thread`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- Behavioral verification requires triggering a `synchronize` event on a PR with existing Claude review threads.

---
*No linked issue found. The author should link or create an issue if one applies.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the GitHub Action reviewer’s tool permissions to include `mcp__github__*` and instructs it to resolve its own threads on `synchronize`, which could unintentionally close the wrong bot threads if the thread-scoping logic is imperfect. Changes are limited to CI workflow behavior (no production/runtime code).
> 
> **Overview**
> Updates the Claude review workflow to **read existing PR review threads** before commenting and, on `synchronize` events, **automatically resolve previously-unresolved bot-authored threads** when the new commits address the raised issue (via `mcp__github__resolve_review_thread`).
> 
> Broadens the reviewer action’s allowed tool set to include `mcp__github__*`, and clarifies the interactive `claude.yml` system prompt to reply in-line when triggered from review comments while **not** resolving threads (leaving that to the automated review workflow).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d62d2e35b1d683d42cd816c9d47c6dc3a66d3fa2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->