### PR TITLE
doc(blueprint): add last-update date stamp to blueprint and home page

### DIFF
--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -13,6 +13,7 @@
 \title{Fundamental Theorem of Matrix Product States\\
   \large A Formalization Blueprint}
 \author{Authors}
+\date{Last update: \today}
 
 \begin{document}
 \maketitle

--- a/blueprint/src/web.tex
+++ b/blueprint/src/web.tex
@@ -13,6 +13,7 @@
 
 \title{Fundamental Theorem of Matrix Product States}
 \author{Authors}
+\date{Last update: \today}
 
 \begin{document}
 \maketitle

--- a/home_page/_layouts/default.html
+++ b/home_page/_layouts/default.html
@@ -43,6 +43,7 @@
       <span class="site-footer-owner"><a href="{{ site.github.repository_url }}">{{ site.github.repository_name }}</a>
         is maintained by Sirui Lu/Erickson Tjoa.</span>
       {% endif %}
+      <span class="site-footer-credits">Last update: {{ site.time | date: "%B %d, %Y" }}</span>
     </footer>
   </main>
 </body>


### PR DESCRIPTION
### Motivation

- Blueprint and home page lack visible last-update metadata, making it hard to tell when documentation was last compiled

### Description

- `blueprint/src/print.tex`: add `\date{Last update: \today}` to print preamble
- `blueprint/src/web.tex`: add `\date{Last update: \today}` to web preamble
- `home_page/_layouts/default.html`: add last-update date to home page footer

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- LaTeX compilation will automatically populate `\today` with the current date when documents are built.

---
Addresses — _no linked issue found; please link one manually if applicable._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a `\date{Last update: \today}` field to LaTeX metadata, affecting title-page output but not document content or build logic.
> 
> **Overview**
> Both LaTeX entrypoints (`blueprint/src/print.tex` and `blueprint/src/web.tex`) now include `\date{Last update: \today}` so the generated title page shows the compilation date for print and web outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24bdae1baed0fb35a945189578dca93d97e37ae7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->