### PR TITLE
ci(tracking): replace tracking-issue-sync with project-aware issue tracker

### DIFF
--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -1,64 +1,184 @@
-name: Tracking Issue Sync
+name: Issue Tracker
 
 on:
   issues:
-    types: [closed, reopened, labeled]
+    types: [closed]
   pull_request:
-    types: [closed, reopened]
+    types: [closed, opened, edited, labeled, review_requested]
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
-  group: tracking-issue-sync
+  group: issue-tracker-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
-  sync:
+  track:
+    # Skip: closed-but-not-completed issues, closed-but-not-merged PRs
     if: |
-      (github.event.action == 'closed' || github.event.action == 'reopened') ||
-      (github.event.action == 'labeled' && github.event.label.name == 'tracking')
+      (github.event_name == 'issues' && github.event.issue.state_reason == 'completed') ||
+      (github.event_name == 'pull_request' && (github.event.action != 'closed' || github.event.pull_request.merged == true)) ||
+      github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
       pull-requests: read
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
-      - name: Sync tracking issues
+      - name: Run Claude Code
+        id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            EVENT: ${{ github.event_name }}
-            ACTION: ${{ github.event.action }}
-            REPO: ${{ github.repository }}
-            NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-            TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
-            MERGED: ${{ github.event.pull_request.merged }}
-            LABEL: ${{ github.event.label.name }}
-
-            You manage tracking issues in this repo. Tracking issues have the "tracking" label and contain checklists like `- [ ] #123`.
-
-            **If ACTION is "labeled" and LABEL is "tracking":**
-            - Read the issue body, find all `#N` references in checklist items
-            - Add the "tracked" label to each referenced issue: `gh issue edit N --add-label tracked`
-
-            **If ACTION is "closed" or "reopened":**
-            - Find tracking issues that reference #NUMBER:
-              `gh issue list --label tracking --state all --json number,body --limit 50`
-            - For each tracking issue containing `#NUMBER` in a checklist:
-              - If the item was closed (issues) or merged (PRs): check the box `[x]`
-              - If closed but not merged (PR): uncheck `[ ]`
-              - If reopened: uncheck `[ ]`
-              - Update the body: `gh issue edit <tracker> --body "..."`
-            - Post a short progress comment: `gh issue comment <tracker> --body "..."`
-              Include: what happened, progress (X/Y done), what remains
-            - If all tasks complete: add "all-resolved" label
-            - If not all complete: remove "all-resolved" label (ignore errors)
-
           claude_args: |
-            --model claude-sonnet-4-6
-            --allowedTools "Bash(gh issue:*),Bash(gh pr:*)"
+            --model claude-opus-4-6
+            --allowedTools "mcp__github__*" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)"
+
+          prompt: |
+            You are the issue tracker agent for this repository. A GitHub event just
+            occurred. Determine what happened and take the appropriate actions.
+
+            Use the GitHub MCP tools (not gh CLI) for all GitHub operations.
+
+            ## Event Context
+
+            - **Event**: ${{ github.event_name }} / ${{ github.event.action }}
+            - **Repository**: ${{ github.repository }}
+            - **Triggered by**: ${{ github.event.sender.login }}
+
+            ${{ github.event_name == 'issues' && format('- **Issue number**: #{0}', github.event.issue.number) || '' }}
+            ${{ github.event_name == 'issues' && format('- **Issue title**: {0}', github.event.issue.title) || '' }}
+            ${{ github.event_name == 'issues' && format('- **Issue labels**: {0}', join(github.event.issue.labels.*.name, ', ')) || '' }}
+
+            ${{ github.event_name != 'issues' && format('- **PR number**: #{0}', github.event.pull_request.number) || '' }}
+            ${{ github.event_name != 'issues' && format('- **PR title**: {0}', github.event.pull_request.title) || '' }}
+            ${{ github.event_name != 'issues' && format('- **PR labels**: {0}', join(github.event.pull_request.labels.*.name, ', ')) || '' }}
+            ${{ github.event_name != 'issues' && format('- **PR state**: {0}', github.event.pull_request.state) || '' }}
+            ${{ github.event_name != 'issues' && format('- **PR draft**: {0}', github.event.pull_request.draft) || '' }}
+            ${{ github.event_name != 'issues' && format('- **Author**: {0}', github.event.pull_request.user.login) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Merged by**: {0}', github.event.pull_request.merged_by.login) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Base branch**: {0}', github.event.pull_request.base.ref) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Head branch**: {0}', github.event.pull_request.head.ref) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Base SHA**: {0}', github.event.pull_request.base.sha) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Head SHA**: {0}', github.event.pull_request.head.sha) || '' }}
+            ${{ github.event_name == 'pull_request_review' && format('- **Review state**: {0}', github.event.review.state) || '' }}
+            ${{ github.event_name == 'pull_request_review' && format('- **Reviewer**: {0}', github.event.review.user.login) || '' }}
+
+            ---
+
+            ## What To Do
+
+            Based on the event, follow the appropriate playbook below.
+
+            ### Finding Tracking Issues
+
+            For all playbooks, you'll need to find tracking issues. These are open issues
+            that have a "tracking" label, or titles starting with "Tracking:", "Epic:",
+            or "Meta:", and contain task lists (checkboxes `- [ ]` / `- [x]`).
+
+            ---
+
+            ### Playbook A: Issue Closed as Completed
+
+            **When**: `issues` / `closed` with state_reason `completed`
+
+            1. Find tracking issues that reference the closed issue (by `#number`,
+               URL, or title keyword in task list items)
+            2. Check off matching items: `- [ ]` → `- [x]`
+            3. Comment: "✅ #N (title) has been resolved. Updated checklist."
+            4. If ALL items are now checked, suggest closing the tracking issue
+
+            ---
+
+            ### Playbook B: PR Merged
+
+            **When**: `pull_request` / `closed` with `merged == true`
+
+            Do TWO things:
+
+            **B1 — Update tracking checklists** (same as Playbook A but for the PR):
+            1. Find tracking issues referencing this PR
+            2. Check off matching items
+            3. Comment with resolution summary
+
+            **B2 — Scan for follow-ups**:
+            1. Read the PR body, comments, review threads, and linked issues via MCP tools
+            2. Get the code diff: `git diff <base-sha>..<head-sha>`
+            3. Search the diff for new TODO/FIXME/HACK/XXX/WORKAROUND markers
+
+            Identify actionable follow-ups. **Prioritize human reviewer suggestions** —
+            comments from real people (not bots) carry the most weight. Bot accounts
+            typically have `[bot]` in their username or are known services (dependabot,
+            renovate, copilot, cursor, codex, etc.).
+
+            Look for:
+            - Human reviewer feedback that was acknowledged but deferred (highest priority)
+            - Explicit TODOs or deferred scope ("out of scope", "follow-up", "separate PR",
+              "later", "Phase 2")
+            - New TODO/FIXME/HACK comments in the diff (not pre-existing ones)
+            - Unresolved review threads or open questions
+            - Roadmap implications for tracked work
+
+            Do NOT create issues for:
+            - Work already completed in this PR
+            - Pre-existing TODOs not introduced by this PR
+            - Nitpick-level comments (style, naming)
+            - Speculative future work not discussed in the PR
+            - Bot suggestions already addressed or dismissed
+
+            For each genuine follow-up, create an issue:
+            - **Title**: Short, imperative (e.g. "Add error handling for X")
+            - **Body**:
+              ```
+              ## Context
+              Follow-up from #<PR-number> (<PR title>).
+
+              <Why this work is needed>
+
+              ## Details
+              <What needs to be done>
+
+              ## References
+              - PR: #<PR-number>
+              - <Related issues or review comments>
+              ```
+            - **Labels**: "follow-up" plus any relevant labels ("bug", "enhancement",
+              "tech-debt", "documentation")
+
+            Then add new issues to relevant tracking issue checklists:
+            - Append `- [ ] #<issue> - <title>` to the relevant section
+            - Comment: "📋 Added follow-up issues from #<PR>: #<issue1>, #<issue2>, ..."
+
+            **Be conservative.** Only create issues for genuine, actionable follow-ups.
+            When in doubt, skip it. False positives create noise.
+
+            ---
+
+            ### Playbook C: PR Activity (opened, edited, labeled, review submitted)
+
+            **When**: Any PR event that isn't a merge/close
+
+            This is lightweight — most events need no action.
+
+            1. Find tracking issues referencing this PR or related issues
+            2. Only act if the event is meaningful for tracking:
+               - PR opened for a tracked task → comment "🔄 #<PR> opened to address this"
+               - PR approved → comment "✅ #<PR> approved, ready to merge"
+               - Changes requested → comment "⚠️ Changes requested on #<PR>"
+            3. Skip everything else silently (edits, labels, etc. are usually not worth a comment)
+
+            ---
+
+            ## Final Report
+
+            Summarize what you did:
+            - Which playbook(s) you followed
+            - What tracking issues were updated
+            - What follow-up issues were created (if any)
+            - Or note that no action was needed

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       (github.event_name == 'issues' && (github.event.issue.state_reason == 'completed' || github.event.action == 'reopened')) ||
       (github.event_name == 'pull_request' && (github.event.action != 'closed' || github.event.pull_request.merged == true)) ||
-      github.event_name == 'pull_request_review'
+      (github.event_name == 'pull_request_review' && github.event.review.state != 'commented')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -2,7 +2,7 @@ name: Issue Tracker
 
 on:
   issues:
-    types: [closed]
+    types: [closed, reopened]
   pull_request:
     types: [closed, opened]
   pull_request_review:
@@ -16,7 +16,7 @@ jobs:
   track:
     # Skip: closed-but-not-completed issues, closed-but-not-merged PRs
     if: |
-      (github.event_name == 'issues' && github.event.issue.state_reason == 'completed') ||
+      (github.event_name == 'issues' && (github.event.issue.state_reason == 'completed' || github.event.action == 'reopened')) ||
       (github.event_name == 'pull_request' && (github.event.action != 'closed' || github.event.pull_request.merged == true)) ||
       github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
           allowed_bots: '*'
           claude_args: |
             --model claude-opus-4-6
-            --allowedTools "mcp__github__*" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)"
+            --allowedTools "mcp__github__*,Bash(git diff *),Bash(git log *),Bash(git show *)"
 
           prompt: |
             You are the issue tracker agent for the TNLean repository — a Lean 4
@@ -156,6 +156,19 @@ jobs:
             4. If ALL items are now checked:
                - Add the `all-resolved` label
                - Comment: "🎉 All tasks complete — this tracking issue can be closed."
+
+            ---
+
+            ### Playbook A2: Issue Reopened
+
+            **When**: `issues` / `reopened`
+
+            1. Search for tracking issues (label `tracking`) that reference
+               the reopened issue by `#number` in their tasklist
+            2. For each match, uncheck the item: `- [x] #N` → `- [ ] #N`
+            3. Remove the `all-resolved` label if present (ignore errors)
+            4. Comment on the tracking issue:
+               "🔄 #N (*title*) has been reopened. Unchecked in tasklist. [X/Y tasks complete]"
 
             ---
 

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [closed]
   pull_request:
-    types: [closed, opened, edited, labeled, review_requested]
+    types: [closed, opened]
   pull_request_review:
     types: [submitted]
 
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: '*'
           claude_args: |
             --model claude-opus-4-6
             --allowedTools "mcp__github__*" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)"
@@ -111,18 +112,31 @@ jobs:
             **Workflow**: `tracking`, `blueprint-sync`, `codex`, `automation`
             **Follow-ups**: use `follow-up` label (create it if it doesn't exist)
 
-            ### PR Title Format
-
-            PRs follow conventional-commit style: `type(scope): description`
-            Types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
-            Scope: shortened module path (e.g., `MPS/Symmetry`, `Channel`,
-            `blueprint`, `PEPS`)
-
             ### Issue Linking
 
             PRs use `Addresses #N` (keeps issue open) or `Closes #N` (auto-closes).
             Check the PR body footer and branch name (`claude/issue-N-*`,
             `codex/issue-N-*`) to find linked issues.
+
+            ---
+
+            ## Other Workflows (Avoid Duplication)
+
+            This repository has several other automation workflows. Be aware of
+            them so you do not post duplicate comments or take redundant actions:
+
+            - **PR Cleanup** (`pr-cleanup.yml`): When a PR opens from a `claude/*`
+              or `codex/*` branch, this workflow already comments on the linked
+              issue ("🤖 PR #X has been opened to address this issue"). Do NOT
+              duplicate that comment for AI-generated PRs.
+            - **Claude Code Review** (`claude-code-review.yml`): Posts inline code
+              review comments on PRs. This workflow handles code quality — you
+              handle tracking metadata only.
+            - **Daily Standup** (`daily-standup.yml`): Creates daily summary issues.
+              These are separate from follow-up issues you may create.
+            - **CI/Blueprint Auto-Fix** workflows: May push fix commits that
+              trigger PR events. Treat these as normal activity — no special
+              handling needed.
 
             ---
 
@@ -231,24 +245,27 @@ jobs:
 
             ---
 
-            ### Playbook C: PR Activity (opened, edited, labeled, review submitted)
+            ### Playbook C: PR Opened or Review Submitted
 
-            **When**: Any PR event that isn't a merge/close
+            **When**: PR opened (not a merge), or a review is submitted
 
             This is lightweight — most events need no action.
 
             1. Find the linked issue from the PR body (`Addresses #N`) or
                branch name (`*/issue-N-*`)
             2. Find tracking issues referencing that linked issue or the PR
-            3. Only act if the event is meaningful for tracking:
-               - PR opened for a tracked task →
-                 comment "🔄 #<PR> opened to address #<issue>"
-               - PR approved (review state `approved`) →
+            3. Only act if the event is meaningful for tracking AND has not
+               already been handled by another workflow:
+               - **PR opened for a tracked task** — but ONLY if the branch
+                 does NOT start with `claude/` or `codex/` (the PR Cleanup
+                 workflow already comments on those). For human-authored PRs,
+                 comment on the tracking issue:
+                 "🔄 #<PR> opened to address #<issue>"
+               - **Review approved** (review state `approved`) →
                  comment "✅ #<PR> approved, ready to merge"
-               - Changes requested (review state `changes_requested`) →
+               - **Changes requested** (review state `changes_requested`) →
                  comment "⚠️ Changes requested on #<PR> by @<reviewer>"
-            4. Skip everything else silently (edits, labels, draft changes,
-               `review_requested` are usually not worth a comment)
+            4. Skip everything else silently
 
             ---
 

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -9,7 +9,7 @@ on:
     types: [submitted]
 
 concurrency:
-  group: issue-tracker-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: issue-tracker
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -14,11 +14,14 @@ concurrency:
 
 jobs:
   track:
-    # Skip: closed-but-not-completed issues, closed-but-not-merged PRs
+    # Skip: forks (no secrets), closed-but-not-completed issues, closed-but-not-merged PRs
     if: |
-      (github.event_name == 'issues' && (github.event.issue.state_reason == 'completed' || github.event.action == 'reopened')) ||
-      (github.event_name == 'pull_request' && (github.event.action != 'closed' || github.event.pull_request.merged == true)) ||
-      (github.event_name == 'pull_request_review' && github.event.review.state != 'commented')
+      !github.event.pull_request.head.repo.fork &&
+      (
+        (github.event_name == 'issues' && (github.event.issue.state_reason == 'completed' || github.event.action == 'reopened')) ||
+        (github.event_name == 'pull_request' && (github.event.action != 'closed' || github.event.pull_request.merged == true)) ||
+        (github.event_name == 'pull_request_review' && github.event.review.state != 'commented')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -189,7 +192,12 @@ jobs:
 
             **B2 — Scan for follow-ups**:
             1. Read the PR body, comments, and review threads via MCP tools
-            2. Get the code diff: `git diff <base-sha>..<head-sha>`
+            2. Get the code diff using the MCP tool:
+               `mcp__github__pull_request_read` with method `get_diff`.
+               This is preferred over `git diff` because squash merges may
+               not have the PR head SHA available locally.
+               Fall back to `git diff <base-sha>..<head-sha>` only if the
+               MCP diff is unavailable.
             3. Search the diff for new `sorry` markers (the Lean equivalent of
                TODO — these are unfinished proof obligations), as well as
                TODO/FIXME/HACK/XXX/WORKAROUND comments

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -41,7 +41,9 @@ jobs:
             --allowedTools "mcp__github__*" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)"
 
           prompt: |
-            You are the issue tracker agent for this repository. A GitHub event just
+            You are the issue tracker agent for the TNLean repository — a Lean 4
+            formalization of results in quantum information theory (MPS, quantum
+            channels, Wielandt theory, PEPS) built on Mathlib. A GitHub event just
             occurred. Determine what happened and take the appropriate actions.
 
             Use the GitHub MCP tools (not gh CLI) for all GitHub operations.
@@ -72,27 +74,74 @@ jobs:
 
             ---
 
+            ## Project Conventions
+
+            Before taking any action, read `docs/CONTRIBUTING.md` for the full
+            conventions. Key points summarized here:
+
+            ### Tracking Issues
+
+            Tracking issues have the `tracking` label and use **native GitHub
+            tasklist blocks**:
+
+            ````markdown
+            ```[tasklist]
+            ### Tasks
+            - [ ] #101
+            - [ ] #102
+            ```
+            ````
+
+            Each `- [ ]` line contains *only* an issue reference (`#N`) — no
+            descriptions on the same line. When checking items off, preserve
+            this format exactly.
+
+            When all items are checked, add the `all-resolved` label.
+            When items are unchecked, remove the `all-resolved` label (ignore
+            errors if it doesn't exist).
+
+            ### Label Taxonomy
+
+            Use the project's established labels (see `docs/CONTRIBUTING.md` §4):
+
+            **Area**: `formalization`, `infrastructure`, `documentation`, `ci`, `cleanup`
+            **Paper**: `0802.0447`, `1606.00608`, `1708.00029`, `1804.04964`, `2011.12127`
+            **Topic**: `parent-hamiltonian`, `correlation-decay`, `symmetry-SPT`,
+              `rfp-mpdo`, `algebraic-FT`, `wolf-ch1` through `wolf-ch7`
+            **Workflow**: `tracking`, `blueprint-sync`, `codex`, `automation`
+            **Follow-ups**: use `follow-up` label (create it if it doesn't exist)
+
+            ### PR Title Format
+
+            PRs follow conventional-commit style: `type(scope): description`
+            Types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
+            Scope: shortened module path (e.g., `MPS/Symmetry`, `Channel`,
+            `blueprint`, `PEPS`)
+
+            ### Issue Linking
+
+            PRs use `Addresses #N` (keeps issue open) or `Closes #N` (auto-closes).
+            Check the PR body footer and branch name (`claude/issue-N-*`,
+            `codex/issue-N-*`) to find linked issues.
+
+            ---
+
             ## What To Do
 
             Based on the event, follow the appropriate playbook below.
-
-            ### Finding Tracking Issues
-
-            For all playbooks, you'll need to find tracking issues. These are open issues
-            that have a "tracking" label, or titles starting with "Tracking:", "Epic:",
-            or "Meta:", and contain task lists (checkboxes `- [ ]` / `- [x]`).
-
-            ---
 
             ### Playbook A: Issue Closed as Completed
 
             **When**: `issues` / `closed` with state_reason `completed`
 
-            1. Find tracking issues that reference the closed issue (by `#number`,
-               URL, or title keyword in task list items)
-            2. Check off matching items: `- [ ]` → `- [x]`
-            3. Comment: "✅ #N (title) has been resolved. Updated checklist."
-            4. If ALL items are now checked, suggest closing the tracking issue
+            1. Search for tracking issues (label `tracking`, state `open`) that
+               reference the closed issue by `#number` in their tasklist
+            2. For each match, update the body: `- [ ] #N` → `- [x] #N`
+            3. Comment on the tracking issue:
+               "✅ #N (*title*) has been resolved. Updated checklist. [X/Y tasks complete]"
+            4. If ALL items are now checked:
+               - Add the `all-resolved` label
+               - Comment: "🎉 All tasks complete — this tracking issue can be closed."
 
             ---
 
@@ -102,61 +151,83 @@ jobs:
 
             Do TWO things:
 
-            **B1 — Update tracking checklists** (same as Playbook A but for the PR):
-            1. Find tracking issues referencing this PR
-            2. Check off matching items
-            3. Comment with resolution summary
+            **B1 — Update tracking checklists**:
+            1. Find the issue(s) this PR addresses:
+               - Check PR body for `Addresses #N`, `Closes #N`, `Fixes #N`
+               - Check branch name for `*/issue-{N}-*` pattern
+            2. Find tracking issues referencing either the PR (`#PR`) or the
+               linked issue(s) (`#N`)
+            3. Check off matching items in the tasklist
+            4. Comment with resolution summary including the PR title
 
             **B2 — Scan for follow-ups**:
-            1. Read the PR body, comments, review threads, and linked issues via MCP tools
+            1. Read the PR body, comments, and review threads via MCP tools
             2. Get the code diff: `git diff <base-sha>..<head-sha>`
-            3. Search the diff for new TODO/FIXME/HACK/XXX/WORKAROUND markers
+            3. Search the diff for new `sorry` markers (the Lean equivalent of
+               TODO — these are unfinished proof obligations), as well as
+               TODO/FIXME/HACK/XXX/WORKAROUND comments
 
-            Identify actionable follow-ups. **Prioritize human reviewer suggestions** —
-            comments from real people (not bots) carry the most weight. Bot accounts
-            typically have `[bot]` in their username or are known services (dependabot,
-            renovate, copilot, cursor, codex, etc.).
+            Identify actionable follow-ups. **Prioritize human reviewer
+            suggestions** — comments from real people (not bots) carry the most
+            weight. Bot accounts typically have `[bot]` in their username or are
+            known services (dependabot, renovate, copilot, cursor, codex, etc.).
 
             Look for:
-            - Human reviewer feedback that was acknowledged but deferred (highest priority)
-            - Explicit TODOs or deferred scope ("out of scope", "follow-up", "separate PR",
+            - Human reviewer feedback that was acknowledged but deferred
+              (highest priority)
+            - New `sorry` markers introduced in `.lean` files (these are proof
+              obligations that need to be discharged)
+            - Explicit deferred scope ("out of scope", "follow-up", "separate PR",
               "later", "Phase 2")
             - New TODO/FIXME/HACK comments in the diff (not pre-existing ones)
+            - Missing `\lean{}` / `\leanok` blueprint tags for newly formalized
+              definitions or theorems (check if `.tex` files were updated)
             - Unresolved review threads or open questions
-            - Roadmap implications for tracked work
 
             Do NOT create issues for:
             - Work already completed in this PR
-            - Pre-existing TODOs not introduced by this PR
-            - Nitpick-level comments (style, naming)
+            - Pre-existing TODOs/sorrys not introduced by this PR
+            - Nitpick-level review comments (style, naming preferences)
             - Speculative future work not discussed in the PR
             - Bot suggestions already addressed or dismissed
 
-            For each genuine follow-up, create an issue:
-            - **Title**: Short, imperative (e.g. "Add error handling for X")
+            For each genuine follow-up, create an issue with:
+            - **Title**: Short, imperative, mathematically precise
+              (e.g., "Discharge sorry in TransferMatrix.injective_iff",
+              "Add blueprint tags for MPS.CanonicalForm definitions")
             - **Body**:
-              ```
+              ```markdown
               ## Context
+
               Follow-up from #<PR-number> (<PR title>).
 
-              <Why this work is needed>
+              <Why this work is needed — reference the mathematical content>
 
               ## Details
-              <What needs to be done>
+
+              <What needs to be done — be specific about which declarations,
+              files, or proof obligations are involved>
 
               ## References
+
               - PR: #<PR-number>
-              - <Related issues or review comments>
+              - <Related issues, review comments, or arXiv references>
               ```
-            - **Labels**: "follow-up" plus any relevant labels ("bug", "enhancement",
-              "tech-debt", "documentation")
+            - **Labels**: `follow-up` plus relevant labels from the taxonomy:
+              - Copy the PR's area/paper/topic labels
+              - Add `formalization` for sorry-related follow-ups
+              - Add `blueprint-sync` for missing blueprint tags
+              - Add `bug` if the follow-up is a correctness issue
+              - Add `cleanup` or `documentation` as appropriate
 
             Then add new issues to relevant tracking issue checklists:
-            - Append `- [ ] #<issue> - <title>` to the relevant section
+            - Append `- [ ] #<issue>` on a new line inside the tasklist block
             - Comment: "📋 Added follow-up issues from #<PR>: #<issue1>, #<issue2>, ..."
 
-            **Be conservative.** Only create issues for genuine, actionable follow-ups.
-            When in doubt, skip it. False positives create noise.
+            **Be conservative.** This is a mathematical formalization project —
+            only create issues for genuine, actionable follow-ups. A new `sorry`
+            with an explicit justification in the PR description is fine to
+            skip. When in doubt, skip it. False positives create noise.
 
             ---
 
@@ -166,12 +237,18 @@ jobs:
 
             This is lightweight — most events need no action.
 
-            1. Find tracking issues referencing this PR or related issues
-            2. Only act if the event is meaningful for tracking:
-               - PR opened for a tracked task → comment "🔄 #<PR> opened to address this"
-               - PR approved → comment "✅ #<PR> approved, ready to merge"
-               - Changes requested → comment "⚠️ Changes requested on #<PR>"
-            3. Skip everything else silently (edits, labels, etc. are usually not worth a comment)
+            1. Find the linked issue from the PR body (`Addresses #N`) or
+               branch name (`*/issue-N-*`)
+            2. Find tracking issues referencing that linked issue or the PR
+            3. Only act if the event is meaningful for tracking:
+               - PR opened for a tracked task →
+                 comment "🔄 #<PR> opened to address #<issue>"
+               - PR approved (review state `approved`) →
+                 comment "✅ #<PR> approved, ready to merge"
+               - Changes requested (review state `changes_requested`) →
+                 comment "⚠️ Changes requested on #<PR> by @<reviewer>"
+            4. Skip everything else silently (edits, labels, draft changes,
+               `review_requested` are usually not worth a comment)
 
             ---
 
@@ -179,6 +256,7 @@ jobs:
 
             Summarize what you did:
             - Which playbook(s) you followed
-            - What tracking issues were updated
-            - What follow-up issues were created (if any)
+            - What tracking issues were updated (with before/after task counts)
+            - What follow-up issues were created (if any), with numbers and titles
+            - Whether `all-resolved` was added to any tracking issue
             - Or note that no action was needed

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -306,7 +306,7 @@ The following workflows run automatically:
 |----------|---------|-------------|
 | **Lean CI** (`lean_action_ci.yml`) | Push to `main`, PRs touching `.lean`/`lakefile.toml`/`lean-toolchain` | Runs `lake build` with Mathlib cache |
 | **Claude Code Review** (`claude-code-review.yml`) | PR opened/synced/reopened touching `.lean`, `.tex`, `lakefile.toml`, `lean-toolchain` | Automated review for sorrys, Mathlib style, type safety, performance, modularity, documentation |
-| **Tracking Issue Sync** (`tracking-issue-sync.yml`) | Issue closed/reopened, PR closed/reopened | Updates checkboxes in tracking issues; adds `all-resolved` label when complete |
+| **Issue Tracker** (`tracking-issue-sync.yml`) | Issue closed, PR merged/opened/reviewed | Updates tracking-issue checkboxes, scans merged PRs for follow-ups (deferred review feedback, new `sorry` markers, missing blueprint tags), creates follow-up issues with `follow-up` label, adds `all-resolved` when all tasks complete |
 | **Blueprint Lint** (`lint-blueprint.yml`) | PRs touching blueprint files | Validates LaTeX blueprint for broken labels and references |
 | **Docs & Blueprint Sync** (`docs-blueprint-sync.lock.yml`) | Daily (weekdays) + manual dispatch | Detects stale documentation and opens a sync PR if needed |
 | **Lean Audit** (`lean-audit.yml`) | On demand | Audits Lean code for style and correctness |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -306,7 +306,7 @@ The following workflows run automatically:
 |----------|---------|-------------|
 | **Lean CI** (`lean_action_ci.yml`) | Push to `main`, PRs touching `.lean`/`lakefile.toml`/`lean-toolchain` | Runs `lake build` with Mathlib cache |
 | **Claude Code Review** (`claude-code-review.yml`) | PR opened/synced/reopened touching `.lean`, `.tex`, `lakefile.toml`, `lean-toolchain` | Automated review for sorrys, Mathlib style, type safety, performance, modularity, documentation |
-| **Issue Tracker** (`tracking-issue-sync.yml`) | Issue closed, PR merged/opened/reviewed | Updates tracking-issue checkboxes, scans merged PRs for follow-ups (deferred review feedback, new `sorry` markers, missing blueprint tags), creates follow-up issues with `follow-up` label, adds `all-resolved` when all tasks complete |
+| **Issue Tracker** (`tracking-issue-sync.yml`) | Issue closed/reopened; PR merged/opened; review submitted | Updates tracking-issue checkboxes (checks on close, unchecks on reopen), scans merged PRs for follow-ups (deferred review feedback, new `sorry` markers, missing blueprint tags), creates follow-up issues with `follow-up` label, adds `all-resolved` when all tasks complete |
 | **Blueprint Lint** (`lint-blueprint.yml`) | PRs touching blueprint files | Validates LaTeX blueprint for broken labels and references |
 | **Docs & Blueprint Sync** (`docs-blueprint-sync.lock.yml`) | Daily (weekdays) + manual dispatch | Detects stale documentation and opens a sync PR if needed |
 | **Lean Audit** (`lean-audit.yml`) | On demand | Audits Lean code for style and correctness |


### PR DESCRIPTION
### Motivation

- The existing `tracking-issue-sync.yml` was a minimal workflow (Claude Sonnet + `gh` CLI) that only toggled checkboxes on issue close/reopen — it didn't understand the project's Markdown checklist format, label taxonomy, blueprint system, or PR conventions
- Need an issue tracker that scans merged PRs for actionable follow-ups (deferred review feedback, new `sorry` markers, missing blueprint tags) and creates issues automatically

### Description

- Rewrites `.github/workflows/tracking-issue-sync.yml` as a comprehensive issue tracker with four playbooks:
  - **Playbook A** (issue closed as completed): checks off Markdown checklist entries, adds `all-resolved` when complete
  - **Playbook A2** (issue reopened): unchecks checklist entries, removes `all-resolved`
  - **Playbook B** (PR merged): updates tracking checklists + scans diff/comments for follow-ups (new `sorry` markers, missing `\lean{}`/`\leanok` tags, deferred reviewer feedback, TODO/FIXME), creates follow-up issues with inherited labels
  - **Playbook C** (PR opened/review submitted): lightweight tracking comments for meaningful events only; skips AI-generated PRs (handled by `pr-cleanup.yml`)
- Upgrades to Claude Opus with MCP GitHub tools (replacing Sonnet + `gh` CLI)
- Uses MCP `get_diff` for PR diffs (handles squash merges where head SHA isn't in local refs), with `git diff` as fallback
- Agent reads `docs/CONTRIBUTING.md` before acting, ensuring alignment with label taxonomy and conventions
- Prompt includes "Other Workflows" section to prevent duplicate comments with `pr-cleanup.yml`, `claude-code-review.yml`, `daily-standup.yml`
- `fetch-depth: 0` for git history access; `allowed_bots: '*'` so bot-triggered events don't fail
- Global concurrency group (`issue-tracker`, `cancel-in-progress: false`) to serialize tracking-issue body writes and prevent race conditions
- Fork guard: skips PR/review events from forks (no access to `CLAUDE_CODE_OAUTH_TOKEN`)
- Filters out `commented` review events (most frequent, always no-op) to avoid wasteful Claude invocations
- Understands `Addresses #N` / `Closes #N` linking and `claude/issue-N-*` / `codex/issue-N-*` branch naming
- Updates `docs/CONTRIBUTING.md` §7 to document the expanded workflow behavior and triggers

### Testing

- YAML syntax validated by CI (`build` check passed)
- `track` job fails on this PR because the workflow on `main` lacks `allowed_bots: '*'` — expected, resolves on merge
- Workflow will activate on next issue close/reopen, PR merge, PR open, or review event

---
