### PR TITLE
fix(ci): enable review thread resolution via GraphQL queries

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -76,7 +76,7 @@ jobs:
             When this review is triggered by a `synchronize` event (new push to the PR):
             1. First, fetch all review threads **with their GraphQL node IDs** using `gh api graphql`.
                The `get_review_comments` MCP method does NOT return thread IDs, so you MUST use GraphQL.
-            2. For each unresolved thread authored by you (the bot) or by `copilot-pull-request-reviewer[bot]`, `cursor[bot]`, or `chatgpt-codex-connector`,
+            2. For each unresolved thread authored by you (the bot) or by `copilot-pull-request-reviewer[bot]`, `cursor[bot]`, or `chatgpt-codex-connector[bot]`,
                check whether the new changes address the issue raised in that comment.
             3. If a previous comment has been addressed by the new commits, resolve it using `mcp__github__resolve_review_thread` with the GraphQL thread `id`.
             4. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -76,7 +76,7 @@ jobs:
             When this review is triggered by a `synchronize` event (new push to the PR):
             1. First, fetch all review threads **with their GraphQL node IDs** using `gh api graphql`.
                The `get_review_comments` MCP method does NOT return thread IDs, so you MUST use GraphQL.
-            2. For each unresolved thread authored by you (the bot) or by `copilot-pull-request-reviewer` or `cursor`,
+            2. For each unresolved thread authored by you (the bot) or by `copilot-pull-request-reviewer[bot]`, `cursor[bot]`, or `chatgpt-codex-connector`,
                check whether the new changes address the issue raised in that comment.
             3. If a previous comment has been addressed by the new commits, resolve it using `mcp__github__resolve_review_thread` with the GraphQL thread `id`.
             4. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.
@@ -85,7 +85,7 @@ jobs:
 
             **Example: How to fetch thread IDs and resolve them**
 
-            Step 1 — Query thread IDs via GraphQL (handles pagination with `after` cursor):
+            Step 1 — Query thread IDs via GraphQL (returns up to 100 threads; see Step 3 for pagination):
             ```bash
             gh api graphql -f query='
             {

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -65,12 +65,15 @@ jobs:
             For each issue found, post an inline comment on the relevant line using the GitHub CLI.
             At the end, post a summary comment on the PR with your overall assessment.
 
-            **Reading existing review threads:**
-            Before posting new comments, read all existing review threads on this PR using the GitHub MCP tools.
-            This includes threads from previous review cycles and any replies from @claude or human reviewers.
+            **Reading existing feedback:**
+            Before posting new comments, read ALL existing feedback on this PR using the GitHub MCP tools:
+            1. Read **inline review threads** via `get_review_comments` — these are code-level comments from previous review cycles.
+            2. Read **PR conversation comments** via `get_comments` — bots and humans often post feedback, summaries,
+               and discussion directly on the PR thread (not as inline review comments). These are equally important.
+            This includes threads from previous review cycles and any replies from @claude, other bots, or human reviewers.
             Use this context to:
-            - Avoid re-raising issues that have already been discussed, acknowledged, or fixed.
-            - Understand any ongoing conversation or decisions made in earlier threads.
+            - Avoid re-raising issues that have already been discussed, acknowledged, or fixed in either location.
+            - Understand any ongoing conversation or decisions made in earlier threads or PR comments.
 
             **Resolving previous review comments:**
             When this review is triggered by a `synchronize` event (new push to the PR):

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -79,9 +79,10 @@ jobs:
             When this review is triggered by a `synchronize` event (new push to the PR):
             1. First, fetch all review threads **with their GraphQL node IDs** using `gh api graphql`.
                The `get_review_comments` MCP method does NOT return thread IDs, so you MUST use GraphQL.
-            2. For each unresolved thread where the author login starts with `claude`, `copilot-pull-request-reviewer`, `cursor`, or `chatgpt-codex-connector`
+            2. For each unresolved thread where the author login starts with `claude` or `copilot-pull-request-reviewer`
                (note: GitHub may append `[bot]` to app logins — match the base name as a prefix to handle both forms),
                check whether the new changes address the issue raised in that comment.
+               Do NOT resolve threads from `cursor`/Bugbot or `chatgpt-codex-connector`/Codex — those bots manage their own thread resolution.
             3. If a previous comment has been addressed by the new commits, resolve it using `mcp__github__resolve_review_thread` with the GraphQL thread `id`.
             4. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.
             5. Only resolve bot threads — never resolve threads authored by human reviewers.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -74,13 +74,64 @@ jobs:
 
             **Resolving previous review comments:**
             When this review is triggered by a `synchronize` event (new push to the PR):
-            1. For each unresolved review thread that was authored by you (the bot), check whether the new changes address the issue raised in that comment.
-            2. If a previous comment has been addressed by the new commits, resolve that review thread using the `mcp__github__resolve_review_thread` tool.
-            3. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.
-            4. Only resolve your own (bot) threads — never resolve threads authored by humans.
+            1. First, fetch all review threads **with their GraphQL node IDs** using `gh api graphql`.
+               The `get_review_comments` MCP method does NOT return thread IDs, so you MUST use GraphQL.
+            2. For each unresolved thread authored by you (the bot) or by `copilot-pull-request-reviewer` or `cursor`,
+               check whether the new changes address the issue raised in that comment.
+            3. If a previous comment has been addressed by the new commits, resolve it using `mcp__github__resolve_review_thread` with the GraphQL thread `id`.
+            4. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.
+            5. Only resolve bot threads — never resolve threads authored by human reviewers.
             This prevents stale bot comments from accumulating across review cycles.
+
+            **Example: How to fetch thread IDs and resolve them**
+
+            Step 1 — Query thread IDs via GraphQL (handles pagination with `after` cursor):
+            ```bash
+            gh api graphql -f query='
+            {
+              repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") {
+                pullRequest(number: ${{ github.event.pull_request.number }}) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      id
+                      isResolved
+                      isOutdated
+                      comments(first: 1) {
+                        nodes {
+                          author { login }
+                          body
+                        }
+                      }
+                    }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              }
+            }'
+            ```
+            This returns thread objects with `id` fields like `"PRRT_kwDON..."`. Use pagination if `hasNextPage` is true.
+
+            Step 2 — For each unresolved bot thread whose issue is now fixed, resolve it:
+            ```
+            mcp__github__resolve_review_thread(threadId: "PRRT_kwDON...")
+            ```
+
+            Step 3 — If there are more than 100 threads, paginate:
+            ```bash
+            gh api graphql -f query='
+            {
+              repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") {
+                pullRequest(number: ${{ github.event.pull_request.number }}) {
+                  reviewThreads(first: 100, after: "CURSOR_FROM_PREVIOUS_PAGE") {
+                    nodes { id isResolved isOutdated comments(first: 1) { nodes { author { login } body } } }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              }
+            }'
+            ```
 
           claude_args: |
             --model claude-opus-4-6
-            --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),mcp__github__*"
+            --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api graphql:*),Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),mcp__github__*"
             --append-system-prompt "This is a Lean 4 / Mathlib formalization project for quantum information theory (MPS tensors, quantum channels, Wielandt theorem). Review with mathematical rigor. Flag any sorry that is not clearly marked as a known TODO."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -76,7 +76,8 @@ jobs:
             When this review is triggered by a `synchronize` event (new push to the PR):
             1. First, fetch all review threads **with their GraphQL node IDs** using `gh api graphql`.
                The `get_review_comments` MCP method does NOT return thread IDs, so you MUST use GraphQL.
-            2. For each unresolved thread authored by you (the bot) or by `copilot-pull-request-reviewer[bot]`, `cursor[bot]`, or `chatgpt-codex-connector[bot]`,
+            2. For each unresolved thread where the author login starts with `claude`, `copilot-pull-request-reviewer`, `cursor`, or `chatgpt-codex-connector`
+               (note: GitHub may append `[bot]` to app logins — match the base name as a prefix to handle both forms),
                check whether the new changes address the issue raised in that comment.
             3. If a previous comment has been addressed by the new commits, resolve it using `mcp__github__resolve_review_thread` with the GraphQL thread `id`.
             4. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -79,10 +79,10 @@ jobs:
             When this review is triggered by a `synchronize` event (new push to the PR):
             1. First, fetch all review threads **with their GraphQL node IDs** using `gh api graphql`.
                The `get_review_comments` MCP method does NOT return thread IDs, so you MUST use GraphQL.
-            2. For each unresolved thread where the author login starts with `claude` or `copilot-pull-request-reviewer`
+            2. For each unresolved thread where the author login starts with `claude`, `copilot-pull-request-reviewer`, or `chatgpt-codex-connector`
                (note: GitHub may append `[bot]` to app logins — match the base name as a prefix to handle both forms),
                check whether the new changes address the issue raised in that comment.
-               Do NOT resolve threads from `cursor`/Bugbot or `chatgpt-codex-connector`/Codex — those bots manage their own thread resolution.
+               Do NOT resolve threads from `cursor`/Bugbot — that bot manages its own thread resolution.
             3. If a previous comment has been addressed by the new commits, resolve it using `mcp__github__resolve_review_thread` with the GraphQL thread `id`.
             4. If a previous comment is still relevant (the issue was NOT fixed), leave it unresolved.
             5. Only resolve bot threads — never resolve threads authored by human reviewers.


### PR DESCRIPTION
### Motivation

- The `get_review_comments` MCP method does not return GraphQL thread IDs (`PRRT_...`), which are required by the `mcp__github__resolve_review_thread` tool.
- This prevents the code review bot from properly resolving stale comments across review cycles.

### Description

- Updated `.github/workflows/claude-code-review.yml` to improve review thread resolution:
  - Enhanced instructions to explicitly require fetching thread IDs via GraphQL queries before attempting resolution.
  - Expanded bot scope to include resolving threads from `copilot-pull-request-reviewer` and `cursor` in addition to the bot's own threads.
  - Added detailed examples showing how to query review threads with GraphQL node IDs using `gh api graphql`, including pagination handling.
  - Updated allowed tools to include `Bash(gh api graphql:*)` so the bot can execute GraphQL queries.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- Workflow configuration change will be validated when the bot next processes a pull request with previous review comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/workflow-only change that updates review bot instructions and permissions; main risk is misconfiguration causing the review action to fail or resolve unintended bot threads.
> 
> **Overview**
> Updates the `claude-code-review.yml` workflow to make bot comment cleanup actually work by **requiring GraphQL queries (`gh api graphql`) to fetch review thread IDs** before calling `mcp__github__resolve_review_thread`, with an included example and pagination guidance.
> 
> Also expands the review instructions to read both inline review threads and top-level PR conversation comments, tightens rules around which *bot-authored* threads may be auto-resolved, and adds `Bash(gh api graphql:*)` to the action’s allowed tool list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f2edc76806436c0152c4f7f0ab6eda5cc68add1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->