### PR TITLE
feat(MPS/Symmetry): virtual representation theorem for injective MPS

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -134,6 +134,7 @@ import TNLean.MPS.FundamentalTheorem.FiniteLength
 import TNLean.MPS.Symmetry.Defs
 import TNLean.MPS.Symmetry.GaugeUniqueness
 import TNLean.MPS.Symmetry.OnSiteSymmetry
+import TNLean.MPS.Symmetry.VirtualRepresentation
 
 -- Layer 5: Multi-block
 import TNLean.MPS.Core.MultiBlock

--- a/TNLean/MPS/Symmetry/VirtualRepresentation.lean
+++ b/TNLean/MPS/Symmetry/VirtualRepresentation.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Symmetry.Defs
+import TNLean.Algebra.ProjectiveRepresentation
+import TNLean.Algebra.ScalarCommutant
+
+/-!
+# Virtual representation theorem for injective MPS
+
+If an injective MPS tensor `A` is on-site symmetric under a group representation `U`,
+then the virtual gauge matrices `X(g)` obtained from the single-block Fundamental Theorem
+form a **projective representation** of `G` on the bond space.
+
+## Main results
+
+* `MPSTensor.gaugeEquiv_unique_up_to_scalar`: gauge uniqueness — for injective `A`, any two
+  gauge matrices relating the same pair of tensors differ by a scalar factor.
+* `MPSTensor.virtual_rep_of_symmetric_injective`: the main theorem — the virtual gauges
+  satisfy a projective multiplication law with a scalar 2-cochain `ω`.
+
+## Convention note
+
+The natural law from `twistedTensor_mul` (which says `twist(g*h) = twist_g ∘ twist_h`)
+gives `X(h) * X(g) = ω(h,g) • X(g * h)`. To obtain the standard projective
+representation law `V(g) * V(h) = ω'(g,h) • V(g * h)`, one defines `V(g) = X(g⁻¹)`.
+
+## References
+
+* Pérez-García et al., *Matrix Product State Representations*, arXiv:0608197
+* Pérez-García et al., *Characterizing symmetries in an MPS*, arXiv:0802.0447 (PRL)
+* Cirac et al., *MPS and PEPS*, arXiv:2011.12127, Section III.A
+* Molnár, *The frustration-free Hamiltonian…*, arXiv:1804.04964, Section 5
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### GL coercion helpers -/
+
+private lemma GL_inv_mul (X : GL (Fin D) ℂ) :
+    ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+      (X : Matrix (Fin D) (Fin D) ℂ) = 1 :=
+  show (X⁻¹ * X : GL (Fin D) ℂ).val = 1 by simp
+
+private lemma GL_mul_inv (X : GL (Fin D) ℂ) :
+    (X : Matrix (Fin D) (Fin D) ℂ) *
+      ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) = 1 :=
+  show (X * X⁻¹ : GL (Fin D) ℂ).val = 1 by simp
+
+/-! ### Gauge uniqueness for injective tensors -/
+
+/-- If `A` is injective and both `X₁` and `X₂` satisfy the gauge equivalence
+`B i = X * A i * X⁻¹`, then `X₁` and `X₂` differ by a scalar factor. -/
+theorem gaugeEquiv_unique_up_to_scalar
+    {A B : MPSTensor d D}
+    (hA : IsInjective A)
+    {X₁ X₂ : GL (Fin D) ℂ}
+    (h₁ : ∀ i : Fin d, B i = X₁ * A i * (X₁⁻¹ : GL (Fin D) ℂ))
+    (h₂ : ∀ i : Fin d, B i = X₂ * A i * (X₂⁻¹ : GL (Fin D) ℂ)) :
+    ∃ c : ℂ, (X₁ : Matrix (Fin D) (Fin D) ℂ) =
+      c • (X₂ : Matrix (Fin D) (Fin D) ℂ) := by
+  -- Write x₁, x₂ for the matrix coercions for clarity
+  set x₁ : Matrix (Fin D) (Fin D) ℂ := (X₁ : Matrix (Fin D) (Fin D) ℂ)
+  set x₂ : Matrix (Fin D) (Fin D) ℂ := (X₂ : Matrix (Fin D) (Fin D) ℂ)
+  set x₁' : Matrix (Fin D) (Fin D) ℂ := ((X₁⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+  set x₂' : Matrix (Fin D) (Fin D) ℂ := ((X₂⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+  set z : Matrix (Fin D) (Fin D) ℂ := x₂' * x₁
+  have hx₁inv : x₁' * x₁ = 1 := GL_inv_mul X₁
+  have hx₂inv : x₂' * x₂ = 1 := GL_inv_mul X₂
+  have hZcomm : ∀ i : Fin d, z * A i = A i * z := by
+    intro i
+    have heq : x₁ * A i * x₁' = x₂ * A i * x₂' := by rw [← h₁ i, ← h₂ i]
+    have lhs : z * A i = x₂' * (x₁ * A i * x₁') * x₁ := by
+      change x₂' * x₁ * A i = x₂' * (x₁ * A i * x₁') * x₁
+      simp only [Matrix.mul_assoc]
+      conv_rhs => rw [hx₁inv, Matrix.mul_one]
+    have rhs : x₂' * (x₂ * A i * x₂') * x₁ = A i * z := by
+      change x₂' * (x₂ * A i * x₂') * x₁ = A i * (x₂' * x₁)
+      simp only [Matrix.mul_assoc]
+      conv_lhs => rw [← Matrix.mul_assoc x₂' x₂, hx₂inv, Matrix.one_mul]
+    rw [lhs, heq, rhs]
+  obtain ⟨c, hc⟩ := Matrix.isScalar_of_commute_span_eq_top z hA.span_eq_top
+    (fun M hM => by obtain ⟨i, rfl⟩ := hM; exact hZcomm i)
+  refine ⟨c, ?_⟩
+  have hx₁_eq : x₁ = x₂ * z := by
+    calc x₁ = 1 * x₁ := by rw [Matrix.one_mul]
+      _ = (x₂ * x₂') * x₁ := by
+          rw [show x₂ * x₂' = (1 : Matrix (Fin D) (Fin D) ℂ) from by
+            calc x₂ * x₂' = x₂ * x₂' := rfl
+              _ = 1 := GL_mul_inv X₂]
+      _ = x₂ * z := by rw [Matrix.mul_assoc]
+  rw [hx₁_eq, hc]
+  ext p q
+  simp [Matrix.scalar_apply, Matrix.mul_apply, Matrix.smul_apply, Matrix.diagonal_apply,
+    Finset.sum_ite_eq', Finset.mem_univ, mul_comm]
+
+/-! ### Virtual representation theorem -/
+
+section VirtualRep
+
+variable {G : Type*} [Group G]
+
+/-- Twisting commutes with virtual conjugation. -/
+private lemma twistedTensor_gaugeEquiv
+    (A : MPSTensor d D) (U : G →* Matrix (Fin d) (Fin d) ℂ)
+    (Y : GL (Fin D) ℂ) (g : G) :
+    ∀ i : Fin d,
+      twistedTensor (fun j =>
+        (Y : Matrix (Fin D) (Fin D) ℂ) * A j *
+          ((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) U g i =
+        (Y : Matrix (Fin D) (Fin D) ℂ) * twistedTensor A U g i *
+          ((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+  intro i
+  simp only [twistedTensor]
+  rw [Finset.mul_sum, Finset.sum_mul]
+  congr 1; ext j
+  simp [Matrix.mul_assoc]
+
+/-- The product `X(h) * X(g)` intertwines `A` with `twist(g * h)`. -/
+private lemma gauge_product_intertwines
+    (A : MPSTensor d D) (U : G →* Matrix (Fin d) (Fin d) ℂ)
+    (X : G → GL (Fin D) ℂ)
+    (hX : ∀ g i, twistedTensor A U g i =
+      (X g : Matrix (Fin D) (Fin D) ℂ) * A i *
+        ((X g)⁻¹ : GL (Fin D) ℂ))
+    (g h : G) (i : Fin d) :
+    twistedTensor A U (g * h) i =
+      ((X h * X g : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * A i *
+        (((X h * X g)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+  rw [twistedTensor_mul]
+  conv_lhs =>
+    rw [show twistedTensor A U h = fun j =>
+      (X h : Matrix (Fin D) (Fin D) ℂ) * A j *
+        ((X h)⁻¹ : GL (Fin D) ℂ) from funext (hX h)]
+  rw [twistedTensor_gaugeEquiv A U (X h) g i, hX g i]
+  simp only [Matrix.GeneralLinearGroup.coe_mul, Matrix.GeneralLinearGroup.coe_inv,
+    mul_inv_rev, Matrix.mul_assoc]
+
+/-- **Virtual representation theorem for injective MPS with on-site symmetry.**
+
+If an injective MPS tensor `A` is symmetric under on-site action of a group `G`,
+then there exist:
+- a family of invertible virtual matrices `X : G → GL(D, ℂ)`,
+- a scalar 2-cochain `ω : G → G → ℂ`,
+
+such that:
+1. each `X(g)` intertwines `A` with the `g`-twisted tensor, and
+2. `X(h) * X(g) = ω(h,g) • X(g * h)` — the projective multiplication law. -/
+theorem virtual_rep_of_symmetric_injective
+    (A : MPSTensor d D)
+    (hA : IsInjective A)
+    (U : G →* Matrix (Fin d) (Fin d) ℂ)
+    (hSymm : IsOnSiteSymmetric A U) :
+    ∃ (X : G → GL (Fin D) ℂ),
+      (∀ g i, twistedTensor A U g i =
+        (X g : Matrix (Fin D) (Fin D) ℂ) * A i *
+          ((X g)⁻¹ : GL (Fin D) ℂ)) ∧
+      ∃ (ω : G → G → ℂ),
+        ∀ g h : G,
+          ((X h : Matrix (Fin D) (Fin D) ℂ) *
+            (X g : Matrix (Fin D) (Fin D) ℂ)) =
+            ω h g • (X (g * h) : Matrix (Fin D) (Fin D) ℂ) := by
+  have hGauge : ∀ g : G, GaugeEquiv A (twistedTensor A U g) :=
+    gaugeEquiv_twistedTensor_of_injective A hA U hSymm
+  choose X hX using fun g => (hGauge g)
+  refine ⟨X, hX, ?_⟩
+  have hProd : ∀ g h : G, ∀ i : Fin d,
+      twistedTensor A U (g * h) i =
+        ((X h * X g : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * A i *
+          (((X h * X g)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=
+    fun g h => gauge_product_intertwines A U X hX g h
+  have hScalar : ∀ g h : G, ∃ c : ℂ,
+      ((X h * X g : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) =
+        c • (X (g * h) : Matrix (Fin D) (Fin D) ℂ) :=
+    fun g h => gaugeEquiv_unique_up_to_scalar hA (hProd g h) (hX (g * h))
+  choose ω hω using fun h g => hScalar g h
+  refine ⟨ω, fun g h => ?_⟩
+  rw [show (X h : Matrix (Fin D) (Fin D) ℂ) * (X g : Matrix (Fin D) (Fin D) ℂ) =
+    ((X h * X g : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+    from (Matrix.GeneralLinearGroup.coe_mul (X h) (X g)).symm]
+  exact hω h g
+
+end VirtualRep
+
+end MPSTensor

--- a/TNLean/MPS/Symmetry/VirtualRepresentation.lean
+++ b/TNLean/MPS/Symmetry/VirtualRepresentation.lean
@@ -3,28 +3,28 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Symmetry.Defs
+import TNLean.MPS.Symmetry.GaugeUniqueness
 import TNLean.Algebra.ProjectiveRepresentation
-import TNLean.Algebra.ScalarCommutant
 
 /-!
 # Virtual representation theorem for injective MPS
 
 If an injective MPS tensor `A` is on-site symmetric under a group representation `U`,
-then the virtual gauge matrices `X(g)` obtained from the single-block Fundamental Theorem
-form a **projective representation** of `G` on the bond space.
+then the virtual gauge matrices extracted from the single-block Fundamental Theorem
+can be reindexed by inversion to produce a genuine projective representation on the
+bond space.
 
 ## Main results
 
-* `MPSTensor.gaugeEquiv_unique_up_to_scalar`: gauge uniqueness — for injective `A`, any two
-  gauge matrices relating the same pair of tensors differ by a scalar factor.
 * `MPSTensor.virtual_rep_of_symmetric_injective`: the main theorem — the virtual gauges
-  satisfy a projective multiplication law with a scalar 2-cochain `ω`.
+  define a unit-valued scalar cocycle `ω` and a `ProjectiveRepresentation` on the bond
+  space.
 
 ## Convention note
 
 The natural law from `twistedTensor_mul` (which says `twist(g*h) = twist_g ∘ twist_h`)
-gives `X(h) * X(g) = ω(h,g) • X(g * h)`. To obtain the standard projective
-representation law `V(g) * V(h) = ω'(g,h) • V(g * h)`, one defines `V(g) = X(g⁻¹)`.
+gives `X(h) * X(g) = ω(h,g) • X(g * h)`. The theorem below packages this into the
+standard projective representation law by defining `V(g) = X(g⁻¹)`.
 
 ## References
 
@@ -40,65 +40,6 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ### GL coercion helpers -/
-
-private lemma GL_inv_mul (X : GL (Fin D) ℂ) :
-    ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
-      (X : Matrix (Fin D) (Fin D) ℂ) = 1 :=
-  show (X⁻¹ * X : GL (Fin D) ℂ).val = 1 by simp
-
-private lemma GL_mul_inv (X : GL (Fin D) ℂ) :
-    (X : Matrix (Fin D) (Fin D) ℂ) *
-      ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) = 1 :=
-  show (X * X⁻¹ : GL (Fin D) ℂ).val = 1 by simp
-
-/-! ### Gauge uniqueness for injective tensors -/
-
-/-- If `A` is injective and both `X₁` and `X₂` satisfy the gauge equivalence
-`B i = X * A i * X⁻¹`, then `X₁` and `X₂` differ by a scalar factor. -/
-theorem gaugeEquiv_unique_up_to_scalar
-    {A B : MPSTensor d D}
-    (hA : IsInjective A)
-    {X₁ X₂ : GL (Fin D) ℂ}
-    (h₁ : ∀ i : Fin d, B i = X₁ * A i * (X₁⁻¹ : GL (Fin D) ℂ))
-    (h₂ : ∀ i : Fin d, B i = X₂ * A i * (X₂⁻¹ : GL (Fin D) ℂ)) :
-    ∃ c : ℂ, (X₁ : Matrix (Fin D) (Fin D) ℂ) =
-      c • (X₂ : Matrix (Fin D) (Fin D) ℂ) := by
-  -- Write x₁, x₂ for the matrix coercions for clarity
-  set x₁ : Matrix (Fin D) (Fin D) ℂ := (X₁ : Matrix (Fin D) (Fin D) ℂ)
-  set x₂ : Matrix (Fin D) (Fin D) ℂ := (X₂ : Matrix (Fin D) (Fin D) ℂ)
-  set x₁' : Matrix (Fin D) (Fin D) ℂ := ((X₁⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-  set x₂' : Matrix (Fin D) (Fin D) ℂ := ((X₂⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-  set z : Matrix (Fin D) (Fin D) ℂ := x₂' * x₁
-  have hx₁inv : x₁' * x₁ = 1 := GL_inv_mul X₁
-  have hx₂inv : x₂' * x₂ = 1 := GL_inv_mul X₂
-  have hZcomm : ∀ i : Fin d, z * A i = A i * z := by
-    intro i
-    have heq : x₁ * A i * x₁' = x₂ * A i * x₂' := by rw [← h₁ i, ← h₂ i]
-    have lhs : z * A i = x₂' * (x₁ * A i * x₁') * x₁ := by
-      change x₂' * x₁ * A i = x₂' * (x₁ * A i * x₁') * x₁
-      simp only [Matrix.mul_assoc]
-      conv_rhs => rw [hx₁inv, Matrix.mul_one]
-    have rhs : x₂' * (x₂ * A i * x₂') * x₁ = A i * z := by
-      change x₂' * (x₂ * A i * x₂') * x₁ = A i * (x₂' * x₁)
-      simp only [Matrix.mul_assoc]
-      conv_lhs => rw [← Matrix.mul_assoc x₂' x₂, hx₂inv, Matrix.one_mul]
-    rw [lhs, heq, rhs]
-  obtain ⟨c, hc⟩ := Matrix.isScalar_of_commute_span_eq_top z hA.span_eq_top
-    (fun M hM => by obtain ⟨i, rfl⟩ := hM; exact hZcomm i)
-  refine ⟨c, ?_⟩
-  have hx₁_eq : x₁ = x₂ * z := by
-    calc x₁ = 1 * x₁ := by rw [Matrix.one_mul]
-      _ = (x₂ * x₂') * x₁ := by
-          rw [show x₂ * x₂' = (1 : Matrix (Fin D) (Fin D) ℂ) from by
-            calc x₂ * x₂' = x₂ * x₂' := rfl
-              _ = 1 := GL_mul_inv X₂]
-      _ = x₂ * z := by rw [Matrix.mul_assoc]
-  rw [hx₁_eq, hc]
-  ext p q
-  simp [Matrix.scalar_apply, Matrix.mul_apply, Matrix.smul_apply, Matrix.diagonal_apply,
-    Finset.sum_ite_eq', Finset.mem_univ, mul_comm]
-
 /-! ### Virtual representation theorem -/
 
 section VirtualRep
@@ -109,16 +50,17 @@ variable {G : Type*} [Group G]
 private lemma twistedTensor_gaugeEquiv
     (A : MPSTensor d D) (U : G →* Matrix (Fin d) (Fin d) ℂ)
     (Y : GL (Fin D) ℂ) (g : G) :
-    ∀ i : Fin d,
-      twistedTensor (fun j =>
-        (Y : Matrix (Fin D) (Fin D) ℂ) * A j *
-          ((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) U g i =
+    twistedTensor (fun j =>
+      (Y : Matrix (Fin D) (Fin D) ℂ) * A j *
+        ((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) U g =
+      fun i =>
         (Y : Matrix (Fin D) (Fin D) ℂ) * twistedTensor A U g i *
           ((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
-  intro i
+  funext i
   simp only [twistedTensor]
   rw [Finset.mul_sum, Finset.sum_mul]
-  congr 1; ext j
+  congr 1
+  ext j
   simp [Matrix.mul_assoc]
 
 /-- The product `X(h) * X(g)` intertwines `A` with `twist(g * h)`. -/
@@ -137,7 +79,9 @@ private lemma gauge_product_intertwines
     rw [show twistedTensor A U h = fun j =>
       (X h : Matrix (Fin D) (Fin D) ℂ) * A j *
         ((X h)⁻¹ : GL (Fin D) ℂ) from funext (hX h)]
-  rw [twistedTensor_gaugeEquiv A U (X h) g i, hX g i]
+  rw [twistedTensor_gaugeEquiv A U (X h) g]
+  simp only
+  rw [hX g i]
   simp only [Matrix.GeneralLinearGroup.coe_mul, Matrix.GeneralLinearGroup.coe_inv,
     mul_inv_rev, Matrix.mul_assoc]
 
@@ -145,45 +89,47 @@ private lemma gauge_product_intertwines
 
 If an injective MPS tensor `A` is symmetric under on-site action of a group `G`,
 then there exist:
-- a family of invertible virtual matrices `X : G → GL(D, ℂ)`,
-- a scalar 2-cochain `ω : G → G → ℂ`,
+- a unit-valued scalar cocycle `ω : ScalarCocycle G`,
+- a projective representation `ρ` of `G` on the bond space,
 
 such that:
-1. each `X(g)` intertwines `A` with the `g`-twisted tensor, and
-2. `X(h) * X(g) = ω(h,g) • X(g * h)` — the projective multiplication law. -/
+1. `ρ.X (g⁻¹)` intertwines `A` with the `g`-twisted tensor, and
+2. `ρ.map_mul'` is the standard projective multiplication law. -/
 theorem virtual_rep_of_symmetric_injective
     (A : MPSTensor d D)
     (hA : IsInjective A)
     (U : G →* Matrix (Fin d) (Fin d) ℂ)
     (hSymm : IsOnSiteSymmetric A U) :
-    ∃ (X : G → GL (Fin D) ℂ),
-      (∀ g i, twistedTensor A U g i =
-        (X g : Matrix (Fin D) (Fin D) ℂ) * A i *
-          ((X g)⁻¹ : GL (Fin D) ℂ)) ∧
-      ∃ (ω : G → G → ℂ),
-        ∀ g h : G,
-          ((X h : Matrix (Fin D) (Fin D) ℂ) *
-            (X g : Matrix (Fin D) (Fin D) ℂ)) =
-            ω h g • (X (g * h) : Matrix (Fin D) (Fin D) ℂ) := by
+    ∃ ω : TNLean.Algebra.ScalarCocycle G,
+      ∃ ρ : TNLean.Algebra.ProjectiveRepresentation (D := D) ω,
+        ∀ g i, twistedTensor A U g i =
+          (ρ.X (g⁻¹) : Matrix (Fin D) (Fin D) ℂ) * A i *
+            (((ρ.X (g⁻¹))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
   have hGauge : ∀ g : G, GaugeEquiv A (twistedTensor A U g) :=
     gaugeEquiv_twistedTensor_of_injective A hA U hSymm
   choose X hX using fun g => (hGauge g)
-  refine ⟨X, hX, ?_⟩
   have hProd : ∀ g h : G, ∀ i : Fin d,
       twistedTensor A U (g * h) i =
         ((X h * X g : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * A i *
           (((X h * X g)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=
     fun g h => gauge_product_intertwines A U X hX g h
-  have hScalar : ∀ g h : G, ∃ c : ℂ,
-      ((X h * X g : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) =
-        c • (X (g * h) : Matrix (Fin D) (Fin D) ℂ) :=
-    fun g h => gaugeEquiv_unique_up_to_scalar hA (hProd g h) (hX (g * h))
-  choose ω hω using fun h g => hScalar g h
-  refine ⟨ω, fun g h => ?_⟩
-  rw [show (X h : Matrix (Fin D) (Fin D) ℂ) * (X g : Matrix (Fin D) (Fin D) ℂ) =
-    ((X h * X g : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-    from (Matrix.GeneralLinearGroup.coe_mul (X h) (X g)).symm]
-  exact hω h g
+  have hScalar : ∀ g h : G, ∃ u : Units ℂ,
+      (X h : Matrix (Fin D) (Fin D) ℂ) * (X g : Matrix (Fin D) (Fin D) ℂ) =
+        (u : ℂ) • (X (g * h) : Matrix (Fin D) (Fin D) ℂ) := by
+    intro g h
+    rcases gauge_unique_up_to_scalar hA (hX (g * h)) (hProd g h) with ⟨u, hu⟩
+    refine ⟨u, ?_⟩
+    simpa [Matrix.GeneralLinearGroup.coe_mul] using hu
+  choose ω hω using fun g h => hScalar (h⁻¹) (g⁻¹)
+  let ρ : TNLean.Algebra.ProjectiveRepresentation (D := D) ω := {
+    X := fun g => X (g⁻¹)
+    map_mul' := by
+      intro g h
+      simpa [mul_inv_rev] using hω g h
+  }
+  refine ⟨ω, ρ, ?_⟩
+  intro g i
+  simpa [ρ] using hX g i
 
 end VirtualRep
 

--- a/TNLean/MPS/Symmetry/VirtualRepresentation.lean
+++ b/TNLean/MPS/Symmetry/VirtualRepresentation.lean
@@ -40,9 +40,14 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+private abbrev invMat (Y : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ :=
+  ((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+
 /-! ### Virtual representation theorem -/
 
 section VirtualRep
+
+open TNLean.Algebra
 
 variable {G : Type*} [Group G]
 
@@ -51,11 +56,9 @@ private lemma twistedTensor_gaugeEquiv
     (A : MPSTensor d D) (U : G →* Matrix (Fin d) (Fin d) ℂ)
     (Y : GL (Fin D) ℂ) (g : G) :
     twistedTensor (fun j =>
-      (Y : Matrix (Fin D) (Fin D) ℂ) * A j *
-        ((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) U g =
+      (Y : Matrix (Fin D) (Fin D) ℂ) * A j * invMat Y) U g =
       fun i =>
-        (Y : Matrix (Fin D) (Fin D) ℂ) * twistedTensor A U g i *
-          ((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+        (Y : Matrix (Fin D) (Fin D) ℂ) * twistedTensor A U g i * invMat Y := by
   funext i
   simp only [twistedTensor]
   rw [Finset.mul_sum, Finset.sum_mul]
@@ -68,22 +71,19 @@ private lemma gauge_product_intertwines
     (A : MPSTensor d D) (U : G →* Matrix (Fin d) (Fin d) ℂ)
     (X : G → GL (Fin D) ℂ)
     (hX : ∀ g i, twistedTensor A U g i =
-      (X g : Matrix (Fin D) (Fin D) ℂ) * A i *
-        ((X g)⁻¹ : GL (Fin D) ℂ))
+      (X g : Matrix (Fin D) (Fin D) ℂ) * A i * invMat (X g))
     (g h : G) (i : Fin d) :
     twistedTensor A U (g * h) i =
       ((X h * X g : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * A i *
-        (((X h * X g)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+        invMat (X h * X g) := by
   rw [twistedTensor_mul]
   conv_lhs =>
     rw [show twistedTensor A U h = fun j =>
-      (X h : Matrix (Fin D) (Fin D) ℂ) * A j *
-        ((X h)⁻¹ : GL (Fin D) ℂ) from funext (hX h)]
+      (X h : Matrix (Fin D) (Fin D) ℂ) * A j * invMat (X h) from funext (hX h)]
   rw [twistedTensor_gaugeEquiv A U (X h) g]
   simp only
   rw [hX g i]
-  simp only [Matrix.GeneralLinearGroup.coe_mul, Matrix.GeneralLinearGroup.coe_inv,
-    mul_inv_rev, Matrix.mul_assoc]
+  simp only [invMat, Matrix.GeneralLinearGroup.coe_mul, mul_inv_rev, Matrix.mul_assoc]
 
 /-- **Virtual representation theorem for injective MPS with on-site symmetry.**
 
@@ -100,11 +100,11 @@ theorem virtual_rep_of_symmetric_injective
     (hA : IsInjective A)
     (U : G →* Matrix (Fin d) (Fin d) ℂ)
     (hSymm : IsOnSiteSymmetric A U) :
-    ∃ ω : TNLean.Algebra.ScalarCocycle G,
-      ∃ ρ : TNLean.Algebra.ProjectiveRepresentation (D := D) ω,
+    ∃ ω : ScalarCocycle G,
+      ∃ ρ : ProjectiveRepresentation (D := D) ω,
         ∀ g i, twistedTensor A U g i =
           (ρ.X (g⁻¹) : Matrix (Fin D) (Fin D) ℂ) * A i *
-            (((ρ.X (g⁻¹))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+            invMat (ρ.X (g⁻¹)) := by
   have hGauge : ∀ g : G, GaugeEquiv A (twistedTensor A U g) :=
     gaugeEquiv_twistedTensor_of_injective A hA U hSymm
   choose X hX using fun g => (hGauge g)
@@ -121,7 +121,7 @@ theorem virtual_rep_of_symmetric_injective
     refine ⟨u, ?_⟩
     simpa [Matrix.GeneralLinearGroup.coe_mul] using hu
   choose ω hω using fun g h => hScalar (h⁻¹) (g⁻¹)
-  let ρ : TNLean.Algebra.ProjectiveRepresentation (D := D) ω := {
+  let ρ : ProjectiveRepresentation (D := D) ω := {
     X := fun g => X (g⁻¹)
     map_mul' := by
       intro g h
@@ -130,6 +130,26 @@ theorem virtual_rep_of_symmetric_injective
   refine ⟨ω, ρ, ?_⟩
   intro g i
   simpa [ρ] using hX g i
+
+/-- For positive bond dimension, the factor system obtained from
+`virtual_rep_of_symmetric_injective` satisfies the 2-cocycle identity. -/
+theorem virtual_rep_of_symmetric_injective_cocycle
+    (A : MPSTensor d D)
+    (hA : IsInjective A)
+    (U : G →* Matrix (Fin d) (Fin d) ℂ)
+    (hSymm : IsOnSiteSymmetric A U)
+    (hD : 0 < D) :
+    ∃ ω : ScalarCocycle G,
+      ∃ ρ : ProjectiveRepresentation (D := D) ω,
+        (∀ g i, twistedTensor A U g i =
+          (ρ.X (g⁻¹) : Matrix (Fin D) (Fin D) ℂ) * A i * invMat (ρ.X (g⁻¹))) ∧
+        ∀ g h k : G,
+          (ω g h : ℂ) * (ω (g * h) k : ℂ) =
+            (ω g (h * k) : ℂ) * (ω h k : ℂ) := by
+  rcases virtual_rep_of_symmetric_injective A hA U hSymm with ⟨ω, ρ, hρ⟩
+  refine ⟨ω, ρ, hρ, ?_⟩
+  intro g h k
+  exact ρ.cocycle_of_assoc (D := D) hD g h k
 
 end VirtualRep
 

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -541,6 +541,144 @@ Lemma~\ref{lem:tensor_proportional} yields the main theorem of
     $B^i = \lambda\, V^{-1}\, A^i\, V$ for all~$i$.
 \end{proof}
 
+\subsection{Virtual representation theorem}
+
+With a full group of on-site symmetries (rather than just a single
+unitary), the individual gauges can be assembled into a projective
+representation on the bond space.
+
+\begin{definition}[Twisted tensor]\label{def:twisted_tensor}
+    \lean{MPSTensor.twistedTensor}
+    \leanok
+    \uses{def:mps_tensor}
+    Given a group representation $U : G \to \GL_d(\C)$ on the physical
+    index, the \emph{$g$-twisted tensor} is
+    \[
+        \widetilde{A}_g^i \;:=\; \sum_{j=0}^{d-1} U(g)_{ij}\, A^j
+        \qquad \text{for each } i \in \{0,\ldots,d{-}1\}.
+    \]
+\end{definition}
+
+\begin{definition}[On-site symmetry]\label{def:on_site_symmetric}
+    \lean{MPSTensor.IsOnSiteSymmetric}
+    \leanok
+    \uses{def:twisted_tensor, def:same_mpv}
+    A tensor $A$ is \emph{on-site symmetric} under a group
+    representation $U : G \to \GL_d(\C)$ if $\mc{V}(A) = \mc{V}(\widetilde{A}_g)$
+    for every $g \in G$.
+\end{definition}
+
+\begin{lemma}[Functoriality of twisting]\label{lem:twisted_tensor_mul}
+    \lean{MPSTensor.twistedTensor_mul}
+    \leanok
+    \uses{def:twisted_tensor}
+    The twisted tensor satisfies the composition law
+    \[
+        \widetilde{A}_{gh} \;=\; \widetilde{(\widetilde{A}_h)}_g,
+    \]
+    i.e.\ twisting by $gh$ is the same as first twisting by~$h$
+    and then by~$g$.
+\end{lemma}
+
+\begin{proof}\leanok\uses{def:twisted_tensor}
+    Expanding both sides using $U(gh) = U(g)\, U(h)$, then swapping
+    the order of summation.
+\end{proof}
+
+\begin{lemma}[Gauge uniqueness up to scalar]\label{lem:gauge_unique_up_to_scalar}
+    \lean{MPSTensor.gauge_unique_up_to_scalar}
+    \leanok
+    \uses{def:injective, def:gauge_equiv, lem:center_scalar}
+    Let $A$ be an injective tensor.
+    If $X, Y \in \GL_D(\C)$ both satisfy
+    $B^i = X\, A^i\, X^{-1} = Y\, A^i\, Y^{-1}$
+    for all~$i$, then there exists a nonzero scalar $u \in \C^{\times}$
+    such that $Y = u \cdot X$.
+\end{lemma}
+
+\begin{proof}\leanok\uses{def:injective, lem:center_scalar}
+    The matrix $Z = Y^{-1} X$ commutes with every $A^i$.
+    Since $A$ is injective, $\{A^i\}$ spans $\MN{D}$, so $Z$
+    lies in the centre of $\MN{D}$.
+    By Lemma~\ref{lem:center_scalar}, $Z$ is a scalar matrix.
+    Since $Z$ is invertible, that scalar is nonzero, and
+    $Y = u \cdot X$.
+\end{proof}
+
+\begin{theorem}[Virtual representation theorem for injective MPS]%
+    \label{thm:virtual_rep_injective}
+    \lean{MPSTensor.virtual_rep_of_symmetric_injective}
+    \leanok
+    \uses{def:injective, def:on_site_symmetric,
+          lem:gauge_unique_up_to_scalar, lem:twisted_tensor_mul}
+    Let $A$ be an injective MPS tensor that is on-site symmetric
+    under a group representation $U : G \to \GL_d(\C)$.
+    Then there exist:
+    \begin{enumerate}
+        \item a unit-valued 2-cochain
+              $\omega : G \times G \to \C^{\times}$, and
+        \item a map $\rho : G \to \GL_D(\C)$ satisfying
+              \[
+                  \rho(g)\, \rho(h) = \omega(g,h)\, \rho(gh)
+                  \qquad \text{for all } g, h \in G,
+              \]
+    \end{enumerate}
+    such that, defining the gauge matrices $X(g) := \rho(g^{-1})$,
+    one has
+    \[
+        \widetilde{A}_g^i \;=\; X(g)\, A^i\, X(g)^{-1}
+        \qquad \text{for every } g \in G,\; i \in \{0,\ldots,d{-}1\}.
+    \]
+    In particular, $\rho$ is a projective representation of $G$ on the
+    bond space $\C^D$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:on_site_symmetric, lem:gauge_unique_up_to_scalar,
+          lem:twisted_tensor_mul}
+    Since $A$ is injective and on-site symmetric, each twisted tensor
+    $\widetilde{A}_g$ is gauge equivalent to~$A$
+    (Corollary~\ref{cor:symmetry_virtual_gauge}).
+    Choose $X(g) \in \GL_D(\C)$ with
+    $\widetilde{A}_g^i = X(g)\, A^i\, X(g)^{-1}$ for all~$i$.
+
+    By functoriality (Lemma~\ref{lem:twisted_tensor_mul}), the product
+    $X(h)\, X(g)$ also intertwines $A$ with $\widetilde{A}_{gh}$.
+    Since $X(gh)$ does the same, gauge uniqueness
+    (Lemma~\ref{lem:gauge_unique_up_to_scalar}) gives a unit scalar
+    $\omega'(h,g)$ with $X(h)\, X(g) = \omega'(h,g)\, X(gh)$.
+
+    Defining $\rho(g) := X(g^{-1})$ converts this to the standard law:
+    $\rho(g)\, \rho(h) = \omega(g,h)\, \rho(gh)$
+    where $\omega(g,h) := \omega'(h^{-1}, g^{-1})$.
+\end{proof}
+
+\begin{corollary}[2-cocycle identity for the factor system]%
+    \label{cor:virtual_rep_cocycle}
+    \lean{MPSTensor.virtual_rep_of_symmetric_injective_cocycle}
+    \leanok
+    \uses{thm:virtual_rep_injective}
+    If $D > 0$, the factor system $\omega$ from
+    Theorem~\ref{thm:virtual_rep_injective} satisfies the
+    2-cocycle identity:
+    \[
+        \omega(g, h)\, \omega(gh, k)
+        = \omega(g, hk)\, \omega(h, k)
+        \qquad \text{for all } g, h, k \in G.
+    \]
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:virtual_rep_injective}
+    Follows from associativity of $\GL_D(\C)$: expanding
+    $\rho(g)\,(\rho(h)\,\rho(k))$ and $(\rho(g)\,\rho(h))\,\rho(k)$
+    using the projective multiplication law and comparing the
+    scalar factors. The hypothesis $D > 0$ ensures $\GL_D(\C)$ has
+    faithful matrix entries.
+\end{proof}
+
 \subsection{Normal MPS (blocked injectivity)}
 
 \begin{corollary}[Normal MPS Fundamental Theorem]%


### PR DESCRIPTION
Adds the virtual representation theorem: if an injective MPS tensor is on-site symmetric under a group representation, then the gauge matrices form a projective representation on the bond space.

Closes #158

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new symmetry theorem module and blueprint documentation, with only a single additional root import and no changes to existing proofs or core definitions.
> 
> **Overview**
> Adds a new Lean module `MPS/Symmetry/VirtualRepresentation.lean` proving the *virtual representation theorem* for injective on-site symmetric MPS: the extracted virtual gauges assemble into a `ProjectiveRepresentation` with a unit-valued factor system `ω`, plus a corollary deriving the 2-cocycle identity when `0 < D`.
> 
> Exports the new module from `TNLean.lean`, and extends the blueprint (`ch13_algebraic_ft.tex`) with a new “Virtual representation theorem” subsection that introduces the twisted tensor/on-site symmetry setup and states the corresponding theorem and cocycle corollary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9a99aec7c62e080ae806b4276384b24da536c48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->