### PR TITLE
fix(ci): rename `codex` label to `ai-generated` for source-agnostic AI tagging

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -170,7 +170,7 @@ jobs:
             - If there's a Cursor Bugbot `> [!NOTE]` block at the end, preserve it
               verbatim after the `Addresses` line (separated by blank lines).
             - Remove any "Generated with [Claude Code]" lines — redundant with the
-              `codex` label and branch name.
+              `ai-generated` label and branch name.
             - Fold `## Summary` / `## Test plan` content into the matching template
               sections, then remove those non-standard headings.
             - When filling in Motivation, reference the linked issue context if
@@ -179,7 +179,7 @@ jobs:
 
             ─── STEP 5: APPLY LABELS ───
             Collect labels to apply (see docs/CONTRIBUTING.md §4 for full taxonomy):
-              a. Always add `codex` (means "AI-generated" per label taxonomy).
+              a. Always add `ai-generated` (means "Created or modified by an AI coding agent" per label taxonomy).
               b. Copy ALL labels from the linked issue (from Step 2).
               c. Infer additional area labels from changed files:
                  - Only `.tex` files → add `documentation`

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -170,7 +170,7 @@ jobs:
             - If there's a Cursor Bugbot `> [!NOTE]` block at the end, preserve it
               verbatim after the `Addresses` line (separated by blank lines).
             - Remove any "Generated with [Claude Code]" lines — redundant with the
-              `claude`/`codex` label and branch name.
+              branch name.
             - Fold `## Summary` / `## Test plan` content into the matching template
               sections, then remove those non-standard headings.
             - When filling in Motivation, reference the linked issue context if
@@ -179,15 +179,12 @@ jobs:
 
             ─── STEP 5: APPLY LABELS ───
             Collect labels to apply (see docs/CONTRIBUTING.md §4 for full taxonomy):
-              a. Check the branch prefix: if the branch starts with `codex/`,
-                 add the `codex` label. If it starts with `claude/`, add the
-                 `claude` label. These indicate which AI agent authored the PR.
-              b. Copy ALL labels from the linked issue (from Step 2).
-              c. Infer additional area labels from changed files:
+              a. Copy ALL labels from the linked issue (from Step 2).
+              b. Infer additional area labels from changed files:
                  - Only `.tex` files → add `documentation`
                  - Only `.yml` under `.github/` → add `ci`
                  - New `.lean` files with definitions → add `formalization`
-              d. Infer topic labels from file paths if not already covered by
+              c. Infer topic labels from file paths if not already covered by
                  issue labels:
                  - `MPS/ParentHamiltonian/` → `parent-hamiltonian`
                  - `MPS/Symmetry/` → `symmetry-SPT`

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -170,7 +170,7 @@ jobs:
             - If there's a Cursor Bugbot `> [!NOTE]` block at the end, preserve it
               verbatim after the `Addresses` line (separated by blank lines).
             - Remove any "Generated with [Claude Code]" lines — redundant with the
-              `codex` label and branch name.
+              `claude`/`codex` label and branch name.
             - Fold `## Summary` / `## Test plan` content into the matching template
               sections, then remove those non-standard headings.
             - When filling in Motivation, reference the linked issue context if
@@ -179,7 +179,9 @@ jobs:
 
             ─── STEP 5: APPLY LABELS ───
             Collect labels to apply (see docs/CONTRIBUTING.md §4 for full taxonomy):
-              a. Always add `codex` (means "AI-generated" per label taxonomy).
+              a. Check the branch prefix: if the branch starts with `codex/`,
+                 add the `codex` label. If it starts with `claude/`, add the
+                 `claude` label. These indicate which AI agent authored the PR.
               b. Copy ALL labels from the linked issue (from Step 2).
               c. Infer additional area labels from changed files:
                  - Only `.tex` files → add `documentation`

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -170,7 +170,7 @@ jobs:
             - If there's a Cursor Bugbot `> [!NOTE]` block at the end, preserve it
               verbatim after the `Addresses` line (separated by blank lines).
             - Remove any "Generated with [Claude Code]" lines — redundant with the
-              `ai-generated` label and branch name.
+              `codex` label and branch name.
             - Fold `## Summary` / `## Test plan` content into the matching template
               sections, then remove those non-standard headings.
             - When filling in Motivation, reference the linked issue context if
@@ -179,7 +179,7 @@ jobs:
 
             ─── STEP 5: APPLY LABELS ───
             Collect labels to apply (see docs/CONTRIBUTING.md §4 for full taxonomy):
-              a. Always add `ai-generated` (means "Created or modified by an AI coding agent" per label taxonomy).
+              a. Always add `codex` (means "AI-generated" per label taxonomy).
               b. Copy ALL labels from the linked issue (from Step 2).
               c. Infer additional area labels from changed files:
                  - Only `.tex` files → add `documentation`

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -112,7 +112,7 @@ jobs:
             **Paper**: `0802.0447`, `1606.00608`, `1708.00029`, `1804.04964`, `2011.12127`
             **Topic**: `parent-hamiltonian`, `correlation-decay`, `symmetry-SPT`,
               `rfp-mpdo`, `algebraic-FT`, `wolf-ch1` through `wolf-ch7`
-            **Workflow**: `tracking`, `blueprint-sync`, `codex`, `automation`
+            **Workflow**: `tracking`, `blueprint-sync`, `ai-generated`, `automation`
             **Follow-ups**: use `follow-up` label (create it if it doesn't exist)
 
             ### Issue Linking

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -112,7 +112,7 @@ jobs:
             **Paper**: `0802.0447`, `1606.00608`, `1708.00029`, `1804.04964`, `2011.12127`
             **Topic**: `parent-hamiltonian`, `correlation-decay`, `symmetry-SPT`,
               `rfp-mpdo`, `algebraic-FT`, `wolf-ch1` through `wolf-ch7`
-            **Workflow**: `tracking`, `blueprint-sync`, `codex`, `automation`
+            **Workflow**: `tracking`, `blueprint-sync`, `codex`, `claude`, `automation`
             **Follow-ups**: use `follow-up` label (create it if it doesn't exist)
 
             ### Issue Linking

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -112,7 +112,7 @@ jobs:
             **Paper**: `0802.0447`, `1606.00608`, `1708.00029`, `1804.04964`, `2011.12127`
             **Topic**: `parent-hamiltonian`, `correlation-decay`, `symmetry-SPT`,
               `rfp-mpdo`, `algebraic-FT`, `wolf-ch1` through `wolf-ch7`
-            **Workflow**: `tracking`, `blueprint-sync`, `codex`, `claude`, `automation`
+            **Workflow**: `tracking`, `blueprint-sync`, `automation`
             **Follow-ups**: use `follow-up` label (create it if it doesn't exist)
 
             ### Issue Linking

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -112,7 +112,7 @@ jobs:
             **Paper**: `0802.0447`, `1606.00608`, `1708.00029`, `1804.04964`, `2011.12127`
             **Topic**: `parent-hamiltonian`, `correlation-decay`, `symmetry-SPT`,
               `rfp-mpdo`, `algebraic-FT`, `wolf-ch1` through `wolf-ch7`
-            **Workflow**: `tracking`, `blueprint-sync`, `ai-generated`, `automation`
+            **Workflow**: `tracking`, `blueprint-sync`, `codex`, `automation`
             **Follow-ups**: use `follow-up` label (create it if it doesn't exist)
 
             ### Issue Linking

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -207,7 +207,7 @@ needs `\lean{}` / `\leanok` tags.
 |------------------|------------------------------------------------|
 | `tracking`       | Tracking issue for a formalization area         |
 | `blueprint-sync` | Blueprint out of sync with Lean code            |
-| `ai-generated`   | Created or modified by an AI coding agent       |
+| `codex`          | Created or modified by an AI coding agent       |
 | `automation`     | Automated documentation/sync PR                 |
 
 ### Standard GitHub labels

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -207,8 +207,6 @@ needs `\lean{}` / `\leanok` tags.
 |------------------|------------------------------------------------|
 | `tracking`       | Tracking issue for a formalization area         |
 | `blueprint-sync` | Blueprint out of sync with Lean code            |
-| `codex`          | Created or modified by OpenAI Codex              |
-| `claude`         | Created or modified by Claude                    |
 | `automation`     | Automated documentation/sync PR                 |
 
 ### Standard GitHub labels

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -207,7 +207,8 @@ needs `\lean{}` / `\leanok` tags.
 |------------------|------------------------------------------------|
 | `tracking`       | Tracking issue for a formalization area         |
 | `blueprint-sync` | Blueprint out of sync with Lean code            |
-| `codex`          | Created or modified by an AI coding agent       |
+| `codex`          | Created or modified by OpenAI Codex              |
+| `claude`         | Created or modified by Claude                    |
 | `automation`     | Automated documentation/sync PR                 |
 
 ### Standard GitHub labels

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -207,7 +207,7 @@ needs `\lean{}` / `\leanok` tags.
 |------------------|------------------------------------------------|
 | `tracking`       | Tracking issue for a formalization area         |
 | `blueprint-sync` | Blueprint out of sync with Lean code            |
-| `codex`          | Created or modified by an AI coding agent       |
+| `ai-generated`   | Created or modified by an AI coding agent       |
 | `automation`     | Automated documentation/sync PR                 |
 
 ### Standard GitHub labels


### PR DESCRIPTION
The PR cleanup workflow was applying the `codex` label to all AI-generated
PRs, including those from Claude branches. This was confusing since "codex"
implies OpenAI Codex specifically. Renamed to `ai-generated` across the
workflow instructions and label taxonomy docs.

https://claude.ai/code/session_011GPEqw6BYqV4gFtt5cQjkf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates workflow prompts/docs for label taxonomy and PR-cleanup labeling guidance, with no code or CI execution logic changes.
> 
> **Overview**
> Updates the AI automation guidance to stop using the `codex` workflow label: `pr-cleanup.yml` no longer instructs always adding `codex`, `tracking-issue-sync.yml` removes `codex` from the documented taxonomy, and `docs/CONTRIBUTING.md` drops `codex` from the workflow labels table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eb9803107c8a87ddd661bfd76759a682d2f4382. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->