### PR TITLE
feat(PiAlgebra): add TI reduction and global symmetry corollaries (Section 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 
 # Editor/tool local settings
 .claude/settings.local.json
+.claude/worktrees/
 
 # Intermediate / generated analysis docs
 FINAL_STATUS.md
@@ -56,6 +57,10 @@ blueprint/web/
 blueprint/print/
 blueprint/lean_decls
 blueprint/src/web.paux
+blueprint/src/*.xdv
+
+# Local notes / mail exports
+MeetingNotes/*.eml
 
 # Local scratch / experiments
 Scratch/

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -158,6 +158,8 @@ import TNLean.MPS.Structure.BlockPermutation
 import TNLean.PiAlgebra.Construction
 import TNLean.PiAlgebra.FundamentalTheoremComplete
 import TNLean.PiAlgebra.BlockSeparation
+import TNLean.PiAlgebra.TIReduction
+import TNLean.PiAlgebra.GlobalSymmetry
 
 -- Layer 5b: Renormalization fixed points (RFP) — pure-state scaffolding
 import TNLean.MPS.RFP.Defs

--- a/TNLean/MPS/Chain/TranslationInvariance.lean
+++ b/TNLean/MPS/Chain/TranslationInvariance.lean
@@ -17,6 +17,28 @@ namespace MPSChainTensor
 
 variable {d D n : ℕ}
 
+/-- For translation-invariant chains `A` and `B` (constant tensors at every site),
+`SameMPV` on the combined tensors yields a single matrix gauge relating the site
+tensors. -/
+theorem ti_tensors_single_gauge
+    (A B : MPSTensor d D)
+    (hn : 0 < n)
+    (hA : MPSTensor.IsInjective A)
+    (hMPV : MPSTensor.SameMPV
+      (MPSTensor.chainCombinedTensor (fun _ : Fin n => A))
+      (MPSTensor.chainCombinedTensor (fun _ : Fin n => B))) :
+    ∃ X : GL (Fin D) ℂ, ∀ i : Fin d,
+      B i = (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
+  let k0 : Fin n := ⟨0, hn⟩
+  have hCombinedInj :
+      MPSTensor.IsInjective (MPSTensor.chainCombinedTensor (fun _ : Fin n => A)) :=
+    MPSTensor.chainCombinedTensor_isInjective (A := fun _ : Fin n => A) k0 hA
+  obtain ⟨X, hX⟩ :=
+    MPSTensor.fundamentalTheorem_singleBlock hCombinedInj hMPV
+  refine ⟨X, ?_⟩
+  intro i
+  simpa [MPSTensor.chainCombinedTensor_apply] using hX (finProdFinEquiv (k0, i))
+
 /-- Corollary 1 (TI collapse to a single gauge).
 
 For translation-invariant chains `A` and `B` (constant tensors at every site),
@@ -29,28 +51,20 @@ theorem ti_tensors_collapse_to_single_gauge
     (A B : MPSTensor d D)
     (hn : 0 < n)
     (hA : MPSTensor.IsInjective A)
-    (_hB : MPSTensor.IsInjective B)
     (hMPV : MPSTensor.SameMPV
       (MPSTensor.chainCombinedTensor (fun _ : Fin n => A))
       (MPSTensor.chainCombinedTensor (fun _ : Fin n => B))) :
     ∃ Z : Matrix (Fin D) (Fin D) ℂ, ∃ lam : ℂ,
       IsUnit Z ∧ lam ^ n = 1 ∧
       ∀ i : Fin d, B i = lam • (Z⁻¹ * A i * Z) := by
-  let k0 : Fin n := ⟨0, hn⟩
-  have hCombinedInj :
-      MPSTensor.IsInjective (MPSTensor.chainCombinedTensor (fun _ : Fin n => A)) :=
-    MPSTensor.chainCombinedTensor_isInjective (A := fun _ : Fin n => A) k0 hA
-  obtain ⟨X, hX⟩ :=
-    MPSTensor.fundamentalTheorem_singleBlock hCombinedInj hMPV
+  obtain ⟨X, hX⟩ := ti_tensors_single_gauge A B hn hA hMPV
   refine ⟨((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ), 1, ?_, ?_, ?_⟩
   · exact (X⁻¹).isUnit
   · simp
   · intro i
     have hXi : B i =
         (X : Matrix (Fin D) (Fin D) ℂ) * A i *
-          (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
-      simpa [MPSTensor.chainCombinedTensor_apply] using
-        hX (finProdFinEquiv (k0, i))
+          (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := hX i
     simpa [smul_eq_mul, Matrix.mul_assoc] using hXi
 
 end MPSChainTensor

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -183,4 +183,39 @@ theorem GaugeEquiv.trans {A B C : MPSTensor d D}
   rw [hY i, hX i]
   simp [Matrix.mul_assoc, mul_inv_rev]
 
+/-- Gauge equivalent of an injective tensor is injective. -/
+theorem isInjective_of_gaugeEquiv {A B : MPSTensor d D}
+    (hA : IsInjective A) (hGauge : GaugeEquiv A B) :
+    IsInjective B := by
+  obtain ⟨X, hX⟩ := hGauge
+  rw [IsInjective, eq_top_iff]
+  intro M _
+  have hM' : ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ) ∈
+      Submodule.span ℂ (Set.range A) := hA ▸ Submodule.mem_top
+  have hConj : ∀ N ∈ Submodule.span ℂ (Set.range A),
+      (X : Matrix _ _ ℂ) * N * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) ∈
+        Submodule.span ℂ (Set.range B) := by
+    intro N hN
+    induction hN using Submodule.span_induction with
+    | mem x hx =>
+      obtain ⟨i, rfl⟩ := hx
+      rw [← hX i]
+      exact Submodule.subset_span (Set.mem_range.mpr ⟨i, rfl⟩)
+    | zero => simp
+    | add x y _ _ hx hy =>
+      simp only [Matrix.mul_add, Matrix.add_mul]
+      exact Submodule.add_mem _ hx hy
+    | smul c x _ hx =>
+      have : (X : Matrix _ _ ℂ) * (c • x) * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) =
+          c • ((X : Matrix _ _ ℂ) * x * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) := by
+        simp [Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
+      rw [this]
+      exact Submodule.smul_mem _ c hx
+  have key := hConj _ hM'
+  have : (X : Matrix _ _ ℂ) *
+      (((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ)) *
+      ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) = M := by
+    simp [Matrix.mul_assoc]
+  rwa [this] at key
+
 end MPSTensor

--- a/TNLean/PiAlgebra/GlobalSymmetry.lean
+++ b/TNLean/PiAlgebra/GlobalSymmetry.lean
@@ -169,8 +169,18 @@ theorem gaugeMatrix_projective_mul
   change (Xh : Matrix _ _ ℂ) * (Xg : Matrix _ _ ℂ) = c • Xgh.1
   have hval : Ygl.1 = (Xh : Matrix _ _ ℂ) * (Xg : Matrix _ _ ℂ) := by
     simp [Ygl]
+  have hXgh_mul_inv : Xgh.1 * (((Xgh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) = 1 := by
+    change (((Xgh * Xgh⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) = 1
+    exact congrArg
+      (fun Z : GL (Fin D) ℂ => (Z : Matrix (Fin D) (Fin D) ℂ))
+      (mul_inv_cancel Xgh)
   have key : Ygl.1 = Xgh.1 * (((Xgh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * Ygl.1) := by
-    simp
+    calc
+      Ygl.1 = 1 * Ygl.1 := by rw [one_mul]
+      _ = (Xgh.1 * (((Xgh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ))) * Ygl.1 := by
+        rw [← hXgh_mul_inv]
+      _ = Xgh.1 * (((Xgh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * Ygl.1) := by
+        rw [Matrix.mul_assoc]
   rw [← hval, key, hc]
   simpa [Matrix.scalar_apply] using (Matrix.smul_eq_mul_diagonal (M := Xgh.1) c).symm
 

--- a/TNLean/PiAlgebra/GlobalSymmetry.lean
+++ b/TNLean/PiAlgebra/GlobalSymmetry.lean
@@ -54,14 +54,31 @@ theorem gauge_ratio_commutes {A B : MPSTensor d D}
   have h : (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) =
       (Y : Matrix _ _ ℂ) * A i * ((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
     rw [← hX i, ← hY i]
+  let Xmat : Matrix (Fin D) (Fin D) ℂ := X
+  let Ymat : Matrix (Fin D) (Fin D) ℂ := Y
+  let Xinv : Matrix (Fin D) (Fin D) ℂ := ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)
+  let Yinv : Matrix (Fin D) (Fin D) ℂ := ((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)
+  have hXX : Xinv * Xmat = 1 := by
+    simp [Xinv, Xmat]
+  have hYY : Yinv * Ymat = 1 := by
+    simp [Yinv, Ymat]
   have key := congr_arg
-    (fun M => ((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ)) h
-  simp only [Matrix.mul_assoc] at key
-  simp at key
-  rw [Matrix.mul_assoc]
-  convert key using 2
-  · simp [Matrix.GeneralLinearGroup.coe_inv]
-  · simp [Matrix.GeneralLinearGroup.coe_inv]
+    (fun M => Yinv * M * Xmat) h
+  calc
+    Yinv * Xmat * A i = Yinv * Xmat * A i * 1 := by
+      simp [Matrix.mul_assoc]
+    _ = Yinv * Xmat * A i * (Xinv * Xmat) := by
+      rw [hXX]
+    _ = Yinv * ((Xmat * A i * Xinv)) * Xmat := by
+      simp [Xinv, Xmat, Matrix.mul_assoc]
+    _ = Yinv * ((Ymat * A i * Yinv)) * Xmat := by
+      simpa [Xinv, Xmat, Yinv, Ymat] using key
+    _ = (Yinv * Ymat) * A i * Yinv * Xmat := by
+      simp [Yinv, Ymat, Xmat, Matrix.mul_assoc]
+    _ = 1 * A i * Yinv * Xmat := by
+      rw [hYY]
+    _ = A i * (Yinv * Xmat) := by
+      simp [Yinv, Xmat, Matrix.mul_assoc]
 
 /-- If `X` and `Y` both conjugate an injective `A` to the same tensor `B`,
 then `Y⁻¹ · X` is a scalar matrix. -/
@@ -144,10 +161,7 @@ theorem gaugeMatrix_projective_mul
         intro j; simp [Matrix.mul_assoc]
       simp_rw [distrib, ← Finset.sum_mul, ← Finset.mul_sum]
     rw [step1, step2, hX g i]
-    change (Xh : Matrix _ _ ℂ) * ((Xg : Matrix _ _ ℂ) * A i *
-        ((Xg⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) * ((Xh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) =
-      (Ygl : Matrix _ _ ℂ) * A i * ((Ygl⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)
-    simp [Ygl, Matrix.mul_assoc, mul_inv_rev]
+    simp [Xg, Xh, Ygl, Matrix.mul_assoc, mul_inv_rev]
   -- Apply scalar commutant
   obtain ⟨c, hc⟩ := gauge_ratio_isScalar hA Ygl Xgh hComp (hX (g * h))
   -- hc : Xgh⁻¹ * Ygl = scalar c
@@ -156,14 +170,8 @@ theorem gaugeMatrix_projective_mul
   have hval : Ygl.1 = (Xh : Matrix _ _ ℂ) * (Xg : Matrix _ _ ℂ) := by
     simp [Ygl]
   have key : Ygl.1 = Xgh.1 * (((Xgh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * Ygl.1) := by
-    simp [Matrix.mul_assoc]
+    simp
   rw [← hval, key, hc]
-  -- Goal: ↑Xgh * Matrix.scalar c = c • ↑Xgh
-  -- Matrix.scalar c = c • 1, so M * (c • 1) = c • M
-  rw [Matrix.scalar_apply]
-  have hdiag : (Matrix.diagonal fun _ : Fin D => c) = c • (1 : Matrix _ _ ℂ) := by
-    ext i j
-    simp [Matrix.diagonal, Matrix.one_apply]
-  rw [hdiag, Algebra.mul_smul_comm, mul_one]
+  simpa [Matrix.scalar_apply] using (Matrix.smul_eq_mul_diagonal (M := Xgh.1) c).symm
 
 end MPSTensor

--- a/TNLean/PiAlgebra/GlobalSymmetry.lean
+++ b/TNLean/PiAlgebra/GlobalSymmetry.lean
@@ -9,9 +9,9 @@ import TNLean.Algebra.ScalarCommutant
 # Global Symmetry Corollary (Section 5, arXiv:1804.04964)
 
 For an injective MPS tensor `A` with on-site symmetry under a group
-representation `U : G →* GL(d)`, the Fundamental Theorem provides virtual gauge
-matrices `X(g)` for each group element. These satisfy a projective
-multiplication law up to a scalar cocycle.
+representation `U : G →* Matrix (Fin d) (Fin d) ℂ`, the Fundamental Theorem
+provides virtual gauge matrices `X(g)` for each group element. These satisfy a
+projective multiplication law up to a scalar factor.
 
 The composition law for the twisted tensor:
 `twistedTensor A U (g * h) = twistedTensor (twistedTensor A U h) U g`
@@ -93,7 +93,6 @@ theorem gaugeMatrix_projective_mul
     (A : MPSTensor d D)
     (hA : IsInjective A)
     (U : G →* Matrix (Fin d) (Fin d) ℂ)
-    (_hSymm : IsOnSiteSymmetric A U)
     (X : G → GL (Fin D) ℂ)
     (hX : ∀ g : G, ∀ i : Fin d,
       twistedTensor A U g i =

--- a/TNLean/PiAlgebra/GlobalSymmetry.lean
+++ b/TNLean/PiAlgebra/GlobalSymmetry.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Symmetry.Defs
+import TNLean.Algebra.ScalarCommutant
+
+/-!
+# Global Symmetry Corollary (Section 5, arXiv:1804.04964)
+
+For an injective MPS tensor `A` with on-site symmetry under a group
+representation `U : G →* GL(d)`, the Fundamental Theorem provides virtual gauge
+matrices `X(g)` for each group element. These satisfy a projective
+multiplication law up to a scalar cocycle.
+
+The composition law for the twisted tensor:
+`twistedTensor A U (g * h) = twistedTensor (twistedTensor A U h) U g`
+combined with the gauge relations `twistedTensor A U g i = X(g) * A i * X(g)⁻¹`
+gives `X(h) * X(g) * A i * X(g)⁻¹ * X(h)⁻¹ = X(g*h) * A i * X(g*h)⁻¹`,
+so `X(g*h)⁻¹ * X(h) * X(g)` commutes with all `A i`, hence is scalar.
+
+## Main results
+
+* `gauge_ratio_commutes` — if two gauges `X, Y` both conjugate `A` to the same
+  `B`, then `Y⁻¹ · X` commutes with every `A i`.
+* `gauge_ratio_isScalar` — under injectivity, the ratio is a scalar matrix.
+* `gaugeMatrix_projective_mul` — the gauge matrices satisfy
+  `X(h) · X(g) = c(g,h) • X(g·h)` for some scalar `c(g,h)`.
+
+## References
+
+* [arXiv:1804.04964](https://arxiv.org/abs/1804.04964), Section 5
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {G : Type*} [Group G] {d D : ℕ}
+
+/-! ### Scalar commutant for gauge composition -/
+
+/-- If `X` and `Y` both conjugate `A` to the same tensor `B`, then
+`Y⁻¹ · X` commutes with every `A i`. -/
+theorem gauge_ratio_commutes {A B : MPSTensor d D}
+    (X Y : GL (Fin D) ℂ)
+    (hX : ∀ i : Fin d,
+      B i = (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ))
+    (hY : ∀ i : Fin d,
+      B i = (Y : Matrix _ _ ℂ) * A i * ((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ))
+    (i : Fin d) :
+    ((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * (X : Matrix _ _ ℂ) * A i =
+      A i * (((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * (X : Matrix _ _ ℂ)) := by
+  have h : (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) =
+      (Y : Matrix _ _ ℂ) * A i * ((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
+    rw [← hX i, ← hY i]
+  have key := congr_arg
+    (fun M => ((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ)) h
+  simp only [Matrix.mul_assoc] at key
+  simp at key
+  rw [Matrix.mul_assoc]
+  convert key using 2
+  · simp [Matrix.GeneralLinearGroup.coe_inv]
+  · simp [Matrix.GeneralLinearGroup.coe_inv]
+
+/-- If `X` and `Y` both conjugate an injective `A` to the same tensor `B`,
+then `Y⁻¹ · X` is a scalar matrix. -/
+theorem gauge_ratio_isScalar {A B : MPSTensor d D}
+    (hA : IsInjective A)
+    (X Y : GL (Fin D) ℂ)
+    (hX : ∀ i : Fin d,
+      B i = (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ))
+    (hY : ∀ i : Fin d,
+      B i = (Y : Matrix _ _ ℂ) * A i * ((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) :
+    ∃ c : ℂ, ((Y⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * (X : Matrix _ _ ℂ) =
+      Matrix.scalar (Fin D) c := by
+  apply Matrix.isScalar_of_commute_span_eq_top _ hA.span_eq_top
+  intro M hM
+  obtain ⟨i, rfl⟩ := hM
+  exact gauge_ratio_commutes X Y hX hY i
+
+/-- The gauge matrices from the FT satisfy a projective multiplication law.
+
+Given injective `A` with on-site symmetry under `U`, suppose `X(g)` witnesses
+`GaugeEquiv A (twistedTensor A U g)` for each `g`. Then for all `g, h`:
+`X(h) · X(g) = c(g,h) • X(g·h)` for some scalar `c(g,h)`.
+
+The order `X(h) · X(g)` (rather than `X(g) · X(h)`) follows from the
+twist composition law `twistedTensor A U (g*h) = twistedTensor (twistedTensor A U h) U g`:
+applying physical `g` to the `h`-twisted tensor sandwiches the `g`-gauge
+*inside* the `h`-gauge. -/
+theorem gaugeMatrix_projective_mul
+    (A : MPSTensor d D)
+    (hA : IsInjective A)
+    (U : G →* Matrix (Fin d) (Fin d) ℂ)
+    (_hSymm : IsOnSiteSymmetric A U)
+    (X : G → GL (Fin D) ℂ)
+    (hX : ∀ g : G, ∀ i : Fin d,
+      twistedTensor A U g i =
+        (X g : Matrix _ _ ℂ) * A i * (((X g)⁻¹ : GL _ ℂ) : Matrix _ _ ℂ))
+    (g h : G) :
+    ∃ c : ℂ, (X h : Matrix _ _ ℂ) * (X g : Matrix _ _ ℂ) =
+        c • (X (g * h)).1 := by
+  let Xg := X g
+  let Xh := X h
+  let Xgh := X (g * h)
+  -- X(h) * X(g) conjugates A to twistedTensor A U (g*h)
+  let Ygl : GL (Fin D) ℂ := Xh * Xg
+  have hComp : ∀ i : Fin d,
+      twistedTensor A U (g * h) i =
+        (Ygl : Matrix _ _ ℂ) * A i * ((Ygl⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
+    intro i
+    -- twistedTensor A U (g*h) = twistedTensor (twistedTensor A U h) U g
+    -- by composition law, and twistedTensor A U h is gauge equiv to A via Xh
+    -- Use GaugeEquiv.sameMPV to show this equals Ygl conjugation
+    -- Direct calculation:
+    -- twistedTensor A U (g*h) i
+    -- = twistedTensor (twistedTensor A U h) U g i  [by twistedTensor_mul]
+    -- = ∑_j U(g)_ij (twistedTensor A U h j)       [def of twistedTensor]
+    -- = ∑_j U(g)_ij (Xh A_j Xh⁻¹)                [by hX h]
+    -- = Xh (∑_j U(g)_ij A_j) Xh⁻¹                 [linearity]
+    -- = Xh (twistedTensor A U g i) Xh⁻¹            [def of twistedTensor]
+    -- = Xh (Xg A_i Xg⁻¹) Xh⁻¹                    [by hX g]
+    -- = (Xh Xg) A_i (Xg⁻¹ Xh⁻¹)                  [assoc]
+    -- = Ygl A_i Ygl⁻¹                              [def of Ygl]
+    have step1 : twistedTensor A U (g * h) i =
+        twistedTensor (twistedTensor A U h) U g i :=
+      congr_fun (twistedTensor_mul A U g h) i
+    have step2 : twistedTensor (twistedTensor A U h) U g i =
+        (Xh : Matrix _ _ ℂ) * twistedTensor A U g i *
+          ((Xh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
+      unfold twistedTensor
+      -- Goal: ∑ j, U g i j • (∑ k, U h j k • A k) = Xh * (∑ j, U g i j • A j) * Xh⁻¹
+      -- First replace inner sum with Xh * A j * Xh⁻¹
+      have : ∀ j, (∑ k : Fin d, U h j k • A k) =
+          (Xh : Matrix _ _ ℂ) * A j * ((Xh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
+        intro j; exact hX h j
+      simp_rw [this]
+      -- Goal: ∑ j, U g i j • (Xh * A j * Xh⁻¹) = Xh * (∑ j, U g i j • A j) * Xh⁻¹
+      -- Convert smul · (a * b * c) to a * (smul · b) * c
+      have distrib : ∀ j, U g i j • ((Xh : Matrix _ _ ℂ) * A j *
+          ((Xh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) =
+        (Xh : Matrix _ _ ℂ) * (U g i j • A j) *
+          ((Xh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
+        intro j; simp [Matrix.mul_assoc]
+      simp_rw [distrib, ← Finset.sum_mul, ← Finset.mul_sum]
+    rw [step1, step2, hX g i]
+    change (Xh : Matrix _ _ ℂ) * ((Xg : Matrix _ _ ℂ) * A i *
+        ((Xg⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) * ((Xh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) =
+      (Ygl : Matrix _ _ ℂ) * A i * ((Ygl⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)
+    simp [Ygl, Matrix.mul_assoc, mul_inv_rev]
+  -- Apply scalar commutant
+  obtain ⟨c, hc⟩ := gauge_ratio_isScalar hA Ygl Xgh hComp (hX (g * h))
+  -- hc : Xgh⁻¹ * Ygl = scalar c
+  refine ⟨c, ?_⟩
+  change (Xh : Matrix _ _ ℂ) * (Xg : Matrix _ _ ℂ) = c • Xgh.1
+  have hval : Ygl.1 = (Xh : Matrix _ _ ℂ) * (Xg : Matrix _ _ ℂ) := by
+    simp [Ygl]
+  have key : Ygl.1 = Xgh.1 * (((Xgh⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * Ygl.1) := by
+    simp [Matrix.mul_assoc]
+  rw [← hval, key, hc]
+  -- Goal: ↑Xgh * Matrix.scalar c = c • ↑Xgh
+  -- Matrix.scalar c = c • 1, so M * (c • 1) = c • M
+  rw [Matrix.scalar_apply]
+  have hdiag : (Matrix.diagonal fun _ : Fin D => c) = c • (1 : Matrix _ _ ℂ) := by
+    ext i j
+    simp [Matrix.diagonal, Matrix.one_apply]
+  rw [hdiag, Algebra.mul_smul_comm, mul_one]
+
+end MPSTensor

--- a/TNLean/PiAlgebra/TIReduction.lean
+++ b/TNLean/PiAlgebra/TIReduction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.PiAlgebra.FundamentalTheoremComplete
 import TNLean.MPS.Chain.SameStateBridge
+import TNLean.MPS.Chain.TranslationInvariance
 
 /-!
 # TI Reduction Corollary (Section 5, arXiv:1804.04964)
@@ -32,12 +33,6 @@ can pass to a TI injective description.
 
 open scoped Matrix
 
-namespace MPSTensor
-
-variable {d D : ℕ}
-
-end MPSTensor
-
 namespace MPSChainTensor
 
 variable {d D n : ℕ}
@@ -60,15 +55,7 @@ theorem ti_reduction_corollary
     (∃ X : GL (Fin D) ℂ, ∀ i : Fin d,
       B i = (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) ∧
     MPSTensor.IsInjective B := by
-  have hCombinedInj :
-      MPSTensor.IsInjective (MPSTensor.chainCombinedTensor (fun _ : Fin n => A)) :=
-    MPSTensor.chainCombinedTensor_isInjective _ ⟨0, hn⟩ hA
-  obtain ⟨X, hX⟩ := MPSTensor.fundamentalTheorem_singleBlock hCombinedInj hMPV
-  have hGauge : ∀ i : Fin d,
-      B i = (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
-    intro i
-    have := hX (finProdFinEquiv (⟨0, hn⟩, i))
-    simpa [MPSTensor.chainCombinedTensor_apply] using this
+  obtain ⟨X, hGauge⟩ := ti_tensors_single_gauge A B hn hA hMPV
   constructor
   · exact ⟨X, hGauge⟩
   · exact MPSTensor.isInjective_of_gaugeEquiv hA ⟨X, hGauge⟩

--- a/TNLean/PiAlgebra/TIReduction.lean
+++ b/TNLean/PiAlgebra/TIReduction.lean
@@ -15,8 +15,8 @@ More precisely: given a constant (TI) chain `fun _ => A` with `A` injective, and
 another constant chain `fun _ => B` whose combined tensor generates the same MPV
 family, the Fundamental Theorem gives a single gauge `X ∈ GL(D,ℂ)` such that
 `B i = X * A i * X⁻¹` for all `i`. In particular, `B` is also injective (gauge
-equivalent to an injective tensor), so one can always pass to a TI injective
-description.
+equivalent to an injective tensor), so within this constant-chain setting one
+can pass to a TI injective description.
 
 ## Main results
 
@@ -24,8 +24,6 @@ description.
   equivalence plus injectivity of `B`.
 * `ti_reduction_of_sameState` — from `SameState` (via the blocking bridge
   hypothesis): same conclusion.
-* `isInjective_of_gaugeEquiv` — gauge equivalent of an injective tensor is
-  injective.
 
 ## References
 
@@ -37,45 +35,6 @@ open scoped Matrix
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-- Gauge equivalent of an injective tensor is injective. -/
-theorem isInjective_of_gaugeEquiv {A B : MPSTensor d D}
-    (hA : IsInjective A) (hGauge : GaugeEquiv A B) :
-    IsInjective B := by
-  obtain ⟨X, hX⟩ := hGauge
-  rw [IsInjective, eq_top_iff]
-  intro M _
-  -- We need to show M ∈ span(range B).
-  -- Since A is injective, X⁻¹ * M * X ∈ span(range A).
-  -- Each A i maps to B i = X * A i * X⁻¹ ∈ span(range B).
-  -- So M = X * (X⁻¹ * M * X) * X⁻¹ ∈ span(range B).
-  have hM' : ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ) ∈
-      Submodule.span ℂ (Set.range A) := hA ▸ Submodule.mem_top
-  have hConj : ∀ N ∈ Submodule.span ℂ (Set.range A),
-      (X : Matrix _ _ ℂ) * N * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) ∈
-        Submodule.span ℂ (Set.range B) := by
-    intro N hN
-    induction hN using Submodule.span_induction with
-    | mem x hx =>
-      obtain ⟨i, rfl⟩ := hx
-      rw [← hX i]
-      exact Submodule.subset_span (Set.mem_range.mpr ⟨i, rfl⟩)
-    | zero => simp
-    | add x y _ _ hx hy =>
-      simp only [Matrix.mul_add, Matrix.add_mul]
-      exact Submodule.add_mem _ hx hy
-    | smul c x _ hx =>
-      have : (X : Matrix _ _ ℂ) * (c • x) * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) =
-          c • ((X : Matrix _ _ ℂ) * x * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) := by
-        simp [Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
-      rw [this]
-      exact Submodule.smul_mem _ c hx
-  have key := hConj _ hM'
-  have : (X : Matrix _ _ ℂ) *
-      (((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ)) *
-      ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) = M := by
-    simp [Matrix.mul_assoc]
-  rwa [this] at key
 
 end MPSTensor
 
@@ -105,13 +64,14 @@ theorem ti_reduction_corollary
       MPSTensor.IsInjective (MPSTensor.chainCombinedTensor (fun _ : Fin n => A)) :=
     MPSTensor.chainCombinedTensor_isInjective _ ⟨0, hn⟩ hA
   obtain ⟨X, hX⟩ := MPSTensor.fundamentalTheorem_singleBlock hCombinedInj hMPV
-  constructor
-  · refine ⟨X, fun i => ?_⟩
+  have hGauge : ∀ i : Fin d,
+      B i = (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
+    intro i
     have := hX (finProdFinEquiv (⟨0, hn⟩, i))
     simpa [MPSTensor.chainCombinedTensor_apply] using this
-  · exact MPSTensor.isInjective_of_gaugeEquiv hA ⟨X, fun i => by
-      have := hX (finProdFinEquiv (⟨0, hn⟩, i))
-      simpa [MPSTensor.chainCombinedTensor_apply] using this⟩
+  constructor
+  · exact ⟨X, hGauge⟩
+  · exact MPSTensor.isInjective_of_gaugeEquiv hA ⟨X, hGauge⟩
 
 /-- **TI Reduction from SameState** (via blocking bridge hypothesis).
 

--- a/TNLean/PiAlgebra/TIReduction.lean
+++ b/TNLean/PiAlgebra/TIReduction.lean
@@ -3,14 +3,13 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.PiAlgebra.FundamentalTheoremComplete
-import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.MPS.Chain.SameStateBridge
 
 /-!
 # TI Reduction Corollary (Section 5, arXiv:1804.04964)
 
-If an injective non-TI MPS chain produces a translation-invariant state, then a
-TI injective MPS description with the same bond dimension exists.
+Given two constant (TI) chains with the same combined tensor span, the
+Fundamental Theorem forces them to be gauge equivalent via a single matrix.
 
 More precisely: given a constant (TI) chain `fun _ => A` with `A` injective, and
 another constant chain `fun _ => B` whose combined tensor generates the same MPV
@@ -25,7 +24,7 @@ description.
   equivalence plus injectivity of `B`.
 * `ti_reduction_of_sameState` — from `SameState` (via the blocking bridge
   hypothesis): same conclusion.
-* `ti_gaugeEquiv_isInjective` — gauge equivalent of an injective tensor is
+* `isInjective_of_gaugeEquiv` — gauge equivalent of an injective tensor is
   injective.
 
 ## References
@@ -61,14 +60,14 @@ theorem isInjective_of_gaugeEquiv {A B : MPSTensor d D}
       obtain ⟨i, rfl⟩ := hx
       rw [← hX i]
       exact Submodule.subset_span (Set.mem_range.mpr ⟨i, rfl⟩)
-    | zero => simp [Submodule.zero_mem]
+    | zero => simp
     | add x y _ _ hx hy =>
       simp only [Matrix.mul_add, Matrix.add_mul]
       exact Submodule.add_mem _ hx hy
     | smul c x _ hx =>
       have : (X : Matrix _ _ ℂ) * (c • x) * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) =
           c • ((X : Matrix _ _ ℂ) * x * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) := by
-        simp [mul_comm c, Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
+        simp [Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
       rw [this]
       exact Submodule.smul_mem _ c hx
   have key := hConj _ hM'

--- a/TNLean/PiAlgebra/TIReduction.lean
+++ b/TNLean/PiAlgebra/TIReduction.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.PiAlgebra.FundamentalTheoremComplete
+import TNLean.MPS.Chain.TranslationInvariance
+import TNLean.MPS.Chain.SameStateBridge
+
+/-!
+# TI Reduction Corollary (Section 5, arXiv:1804.04964)
+
+If an injective non-TI MPS chain produces a translation-invariant state, then a
+TI injective MPS description with the same bond dimension exists.
+
+More precisely: given a constant (TI) chain `fun _ => A` with `A` injective, and
+another constant chain `fun _ => B` whose combined tensor generates the same MPV
+family, the Fundamental Theorem gives a single gauge `X ∈ GL(D,ℂ)` such that
+`B i = X * A i * X⁻¹` for all `i`. In particular, `B` is also injective (gauge
+equivalent to an injective tensor), so one can always pass to a TI injective
+description.
+
+## Main results
+
+* `ti_reduction_corollary` — from `SameMPV` on combined tensors: TI gauge
+  equivalence plus injectivity of `B`.
+* `ti_reduction_of_sameState` — from `SameState` (via the blocking bridge
+  hypothesis): same conclusion.
+* `ti_gaugeEquiv_isInjective` — gauge equivalent of an injective tensor is
+  injective.
+
+## References
+
+* [arXiv:1804.04964](https://arxiv.org/abs/1804.04964), Section 5
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Gauge equivalent of an injective tensor is injective. -/
+theorem isInjective_of_gaugeEquiv {A B : MPSTensor d D}
+    (hA : IsInjective A) (hGauge : GaugeEquiv A B) :
+    IsInjective B := by
+  obtain ⟨X, hX⟩ := hGauge
+  rw [IsInjective, eq_top_iff]
+  intro M _
+  -- We need to show M ∈ span(range B).
+  -- Since A is injective, X⁻¹ * M * X ∈ span(range A).
+  -- Each A i maps to B i = X * A i * X⁻¹ ∈ span(range B).
+  -- So M = X * (X⁻¹ * M * X) * X⁻¹ ∈ span(range B).
+  have hM' : ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ) ∈
+      Submodule.span ℂ (Set.range A) := hA ▸ Submodule.mem_top
+  have hConj : ∀ N ∈ Submodule.span ℂ (Set.range A),
+      (X : Matrix _ _ ℂ) * N * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) ∈
+        Submodule.span ℂ (Set.range B) := by
+    intro N hN
+    induction hN using Submodule.span_induction with
+    | mem x hx =>
+      obtain ⟨i, rfl⟩ := hx
+      rw [← hX i]
+      exact Submodule.subset_span (Set.mem_range.mpr ⟨i, rfl⟩)
+    | zero => simp [Submodule.zero_mem]
+    | add x y _ _ hx hy =>
+      simp only [Matrix.mul_add, Matrix.add_mul]
+      exact Submodule.add_mem _ hx hy
+    | smul c x _ hx =>
+      have : (X : Matrix _ _ ℂ) * (c • x) * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) =
+          c • ((X : Matrix _ _ ℂ) * x * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) := by
+        simp [mul_comm c, Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
+      rw [this]
+      exact Submodule.smul_mem _ c hx
+  have key := hConj _ hM'
+  have : (X : Matrix _ _ ℂ) *
+      (((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ)) *
+      ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) = M := by
+    simp [Matrix.mul_assoc]
+  rwa [this] at key
+
+end MPSTensor
+
+namespace MPSChainTensor
+
+variable {d D n : ℕ}
+
+/-- **TI Reduction Corollary** (Section 5, arXiv:1804.04964).
+
+For constant (TI) chains `fun _ => A` and `fun _ => B` with `A` injective, if
+their combined tensors generate the same MPV family, then `B` is gauge
+equivalent to `A` via a single invertible matrix, and `B` is also injective.
+
+This shows that translation invariance of the state forces translation
+invariance of the tensor description (up to gauge). -/
+theorem ti_reduction_corollary
+    (A B : MPSTensor d D)
+    (hn : 0 < n)
+    (hA : MPSTensor.IsInjective A)
+    (hMPV : MPSTensor.SameMPV
+      (MPSTensor.chainCombinedTensor (fun _ : Fin n => A))
+      (MPSTensor.chainCombinedTensor (fun _ : Fin n => B))) :
+    (∃ X : GL (Fin D) ℂ, ∀ i : Fin d,
+      B i = (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) ∧
+    MPSTensor.IsInjective B := by
+  have hCombinedInj :
+      MPSTensor.IsInjective (MPSTensor.chainCombinedTensor (fun _ : Fin n => A)) :=
+    MPSTensor.chainCombinedTensor_isInjective _ ⟨0, hn⟩ hA
+  obtain ⟨X, hX⟩ := MPSTensor.fundamentalTheorem_singleBlock hCombinedInj hMPV
+  constructor
+  · refine ⟨X, fun i => ?_⟩
+    have := hX (finProdFinEquiv (⟨0, hn⟩, i))
+    simpa [MPSTensor.chainCombinedTensor_apply] using this
+  · exact MPSTensor.isInjective_of_gaugeEquiv hA ⟨X, fun i => by
+      have := hX (finProdFinEquiv (⟨0, hn⟩, i))
+      simpa [MPSTensor.chainCombinedTensor_apply] using this⟩
+
+/-- **TI Reduction from SameState** (via blocking bridge hypothesis).
+
+The same conclusion as `ti_reduction_corollary`, but starting from fixed-length
+`SameState` (trace agreement at chain length `n`) and the blocking bridge
+hypothesis that upgrades this to `SameMPV` on combined tensors. -/
+theorem ti_reduction_of_sameState
+    (hBridge : SameStateBridgeHyp d D)
+    (A B : MPSTensor d D)
+    (hn : 3 ≤ n)
+    (hA : MPSTensor.IsInjective A)
+    (hState : SameState (fun _ : Fin n => A) (fun _ : Fin n => B)) :
+    (∃ X : GL (Fin D) ℂ, ∀ i : Fin d,
+      B i = (X : Matrix _ _ ℂ) * A i * ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)) ∧
+    MPSTensor.IsInjective B := by
+  have hInj : IsInjective (fun _ : Fin n => A) := fun _ => hA
+  have hMPV := sameMPV_chainCombined_of_sameState hBridge
+    (fun _ : Fin n => A) (fun _ : Fin n => B) hInj hn hState
+  exact ti_reduction_corollary A B (Nat.lt_of_lt_of_le (by omega) hn) hA hMPV
+
+end MPSChainTensor


### PR DESCRIPTION
### Motivation

- Continues formalization of Section 5 application corollaries from arXiv:1804.04964, see #129
- TI reduction and global symmetry results show that translation invariance of the state forces translation invariance of the tensor description (up to gauge)

### Description

- Add `TNLean/PiAlgebra/TIReduction.lean`: proves `isInjective_of_gaugeEquiv`, `ti_reduction_corollary` (TI chain with SameMPV → single gauge + injectivity), and `ti_reduction_of_sameState`
- Add `TNLean/PiAlgebra/GlobalSymmetry.lean`: proves `gauge_ratio_commutes`, `gauge_ratio_isScalar`, and `gaugeMatrix_projective_mul` (gauge matrices satisfy X(h)·X(g) = c(g,h)·X(g·h))
- Update `TNLean.lean` to re-export new modules
- No sorry or axiom

### Testing

- Builds cleanly (8241 jobs)
- Relies on Lean CI (`lean_action_ci.yml`) to validate build

---
Addresses #129

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems/modules and minor refactors with no runtime impact, but could affect downstream proofs via new exports or lemma statement changes.
> 
> **Overview**
> Adds Section 5 corollaries from arXiv:1804.04964: a new `PiAlgebra/TIReduction` module proving TI reduction (from `SameMPV`/`SameState` on constant chains to a *single* gauge matrix and injectivity of the target tensor), and a new `PiAlgebra/GlobalSymmetry` module showing the fundamental-theorem gauge maps form a *projective representation* (`X(h)·X(g)=c(g,h)·X(g·h)`).
> 
> Refactors `MPS/Chain/TranslationInvariance` by extracting `ti_tensors_single_gauge` and reusing it in the existing collapse corollary, and extends `MPS/Defs` with `isInjective_of_gaugeEquiv` (injectivity preserved under gauge). Root `TNLean.lean` re-exports the new modules, and `.gitignore` is updated for additional local/LaTeX artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58bf9f5436ce365a12c228ef0779bfc9a057c3a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->