### PR TITLE
fix(ci): persist-credentials hardening + sorry TODO tags

### DIFF
--- a/.github/workflows/mathlib-scout.yml
+++ b/.github/workflows/mathlib-scout.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Lean toolchain and cache
         uses: leanprover/lean-action@v1

--- a/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean
@@ -46,9 +46,9 @@ theorem generatorDecomp_traceless_unique_phi
     (htr : F.HasTracelessKraus)
     (htr' : F'.HasTracelessKraus) :
     F.toGeneratorDecomp.φ = F'.toGeneratorDecomp.φ := by
-  -- Proof strategy (Wolf): compare projected Choi matrices and use Choi injectivity.
-  -- Infrastructure for the final projection/orthogonality argument is developed in
-  -- `ChoiJamiolkowski` and related Lindblad files.
+  -- TODO (#13): compare projected Choi matrices and use Choi injectivity.
+  -- The projection/orthogonality argument infrastructure is in `ChoiJamiolkowski`
+  -- and related Lindblad files.
   sorry
 
 /--
@@ -68,7 +68,7 @@ theorem generatorDecomp_traceless_unique_kappa_modPhase
     ∃ l : ℝ,
       F'.toGeneratorDecomp.κ =
         F.toGeneratorDecomp.κ + (Complex.I * (l : ℂ)) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
-  -- Proof strategy (Wolf): after identifying `φ = φ'`, the residual map is
+  -- TODO (#13): after identifying `φ = φ'`, the residual map is
   -- `ρ ↦ -(Δκ)ρ - ρ(Δκ)†`; equality to zero forces `Δκ` to be a scalar multiple
   -- of identity, and trace/Hermiticity constraints force that scalar to be purely
   -- imaginary.


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to `mathlib-scout.yml` checkout step (fixes #285)
- Tag `Uniqueness.lean` sorry stubs with `TODO (#13)` for uniform tracking

## Test plan
- [ ] Verify `claude-code-review.yml` triggers on the `.lean` file change
- [ ] Verify `pr-review-auto-fix.yml` triggers after review completes (testing the GraphQL fix from commit 20345fe)
- [ ] Confirm auto-fix picks up unresolved review comments

https://claude.ai/code/session_01YPizSuJanM7rjW1fnFKrBm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI workflow hardening and comment-only changes in Lean proofs; no runtime logic or theorem statements changed.
> 
> **Overview**
> Hardens the `mathlib-scout.yml` GitHub Action by disabling credential persistence on checkout (`persist-credentials: false`).
> 
> Retags the `sorry` proof stubs in `TNLean/Channel/Semigroup/LindbladForm/Uniqueness.lean` with `TODO (#13)` to standardize tracking of unfinished arguments, without changing any definitions or theorem statements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7f522fd431e10b9a3204c5d9cebe41f09c3e335. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->