### PR TITLE
feat(Channel/Schwarz): partial proofs for n-positivity hierarchy

### DIFF
--- a/TNLean/Channel/Schwarz/PositiveMapProperties.lean
+++ b/TNLean/Channel/Schwarz/PositiveMapProperties.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
+import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unital
 
 /-!
@@ -29,18 +30,36 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
+attribute [local instance] Matrix.instL2OpNormedAddCommGroup
+attribute [local instance] Matrix.instL2OpNormedRing
+attribute [local instance] Matrix.instL2OpNormedAlgebra
+
+noncomputable local instance matrixCStarAlgebra (m : Type*) [Fintype m] [DecidableEq m] :
+    CStarAlgebra (Matrix m m ℂ) where
+  toNormedRing := Matrix.instL2OpNormedRing
+  toStarRing := inferInstance
+  toCompleteSpace := inferInstance
+  toCStarRing := Matrix.instCStarRing
+  toNormedAlgebra := Matrix.instL2OpNormedAlgebra
+  toStarModule := inferInstance
+
 /-- A positive map is monotone for the matrix Loewner order. -/
 theorem IsPositiveMap.map_le_map
-    {T : Mat →ₗ[ℂ] Mat} {A B : Mat}
+    {m : Type*} [Finite m]
+    {T : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ} {A B : Matrix m m ℂ}
     (hT : IsPositiveMap T) (hAB : A ≤ B) : T A ≤ T B := by
+  classical
+  letI := Fintype.ofFinite m
   rw [Matrix.le_iff] at hAB ⊢
   simpa [map_sub] using hT (B - A) hAB
 
 /-- Positive maps preserve adjoints. -/
 theorem IsPositiveMap.map_conjTranspose
-    {m : Type*} [Fintype m] [DecidableEq m]
+    {m : Type*} [Finite m]
     {T : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ} (hT : IsPositiveMap T) (A : Matrix m m ℂ) :
     T Aᴴ = (T A)ᴴ := by
+  classical
+  letI := Fintype.ofFinite m
   let B : Matrix m m ℂ := (1 / 2 : ℝ) • (A + Aᴴ)
   let C : Matrix m m ℂ := (1 / 2 : ℝ) • (Complex.I • (Aᴴ - A))
   have hB : B.IsHermitian := by
@@ -77,6 +96,48 @@ theorem IsPositiveMap.map_conjTranspose
     simp
   rw [hAstar_decomp, hTA_decomp]
   simp [sub_eq_add_neg, hTB.eq, hTC.eq, Matrix.conjTranspose_add, Matrix.conjTranspose_smul]
+
+/-- A block diagonal matrix is PSD iff its diagonal blocks are PSD. -/
+theorem Matrix.PosSemidef.fromBlocks_diag
+    {m o : Type*} [Finite m] [Finite o]
+    {A : Matrix m m ℂ} {D : Matrix o o ℂ}
+    (hA : A.PosSemidef) (hD : D.PosSemidef) :
+    (Matrix.fromBlocks A 0 0 D : Matrix (m ⊕ o) (m ⊕ o) ℂ).PosSemidef := by
+  classical
+  letI := Fintype.ofFinite m
+  letI := Fintype.ofFinite o
+  letI : CStarAlgebra (Matrix m m ℂ) := matrixCStarAlgebra m
+  letI : CStarAlgebra (Matrix o o ℂ) := matrixCStarAlgebra o
+  obtain ⟨CA, hCA⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
+    ((Matrix.nonneg_iff_posSemidef).mpr hA)
+  obtain ⟨CD, hCD⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
+    ((Matrix.nonneg_iff_posSemidef).mpr hD)
+  have hCA' : A = CA * CAᴴ := by
+    simpa [Matrix.star_eq_conjTranspose] using hCA
+  have hCD' : D = CD * CDᴴ := by
+    simpa [Matrix.star_eq_conjTranspose] using hCD
+  let C : Matrix (m ⊕ o) (m ⊕ o) ℂ := Matrix.fromBlocks CA 0 0 CD
+  have hC : Matrix.fromBlocks A 0 0 D = C * Cᴴ := by
+    simp [C, hCA', hCD', Matrix.fromBlocks_multiply, Matrix.fromBlocks_conjTranspose]
+  rw [hC]
+  exact Matrix.posSemidef_self_mul_conjTranspose C
+
+/-- Reindexing commutes with the conjugate transpose of a matrix. -/
+theorem Matrix.reindex_conjTranspose {m o : Type*}
+    (e : m ≃ o) (M : Matrix m m ℂ) :
+    Matrix.reindex e e Mᴴ = (Matrix.reindex e e M)ᴴ := by
+  ext i j
+  simp [Matrix.reindex_apply, Matrix.conjTranspose_apply, Matrix.submatrix_apply]
+
+/-- Reindexing preserves positive semidefiniteness. -/
+theorem Matrix.PosSemidef.reindex
+    {m o : Type*} [Finite m] [Finite o] {M : Matrix m m ℂ}
+    (hM : M.PosSemidef) (e : m ≃ o) :
+    (Matrix.reindex e e M).PosSemidef := by
+  classical
+  letI := Fintype.ofFinite m
+  letI := Fintype.ofFinite o
+  simpa [Matrix.reindex_apply] using hM.submatrix e.symm
 
 /-- If `T` is positive and subunital, then it preserves order intervals `[a • 1, b • 1]`
 whenever `0 ∈ [a,b]`. -/

--- a/TNLean/Channel/Schwarz/PositiveMapProperties.lean
+++ b/TNLean/Channel/Schwarz/PositiveMapProperties.lean
@@ -38,10 +38,11 @@ theorem IsPositiveMap.map_le_map
 
 /-- Positive maps preserve adjoints. -/
 theorem IsPositiveMap.map_conjTranspose
-    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (A : Mat) :
+    {m : Type*} [Fintype m] [DecidableEq m]
+    {T : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ} (hT : IsPositiveMap T) (A : Matrix m m ℂ) :
     T Aᴴ = (T A)ᴴ := by
-  let B : Mat := (1 / 2 : ℝ) • (A + Aᴴ)
-  let C : Mat := (1 / 2 : ℝ) • (Complex.I • (Aᴴ - A))
+  let B : Matrix m m ℂ := (1 / 2 : ℝ) • (A + Aᴴ)
+  let C : Matrix m m ℂ := (1 / 2 : ℝ) • (Complex.I • (Aᴴ - A))
   have hB : B.IsHermitian := by
     ext i j
     simp [B, add_comm]

--- a/TNLean/Channel/Schwarz/PositiveMapProperties.lean
+++ b/TNLean/Channel/Schwarz/PositiveMapProperties.lean
@@ -97,7 +97,7 @@ theorem IsPositiveMap.map_conjTranspose
   rw [hAstar_decomp, hTA_decomp]
   simp [sub_eq_add_neg, hTB.eq, hTC.eq, Matrix.conjTranspose_add, Matrix.conjTranspose_smul]
 
-/-- A block diagonal matrix is PSD iff its diagonal blocks are PSD. -/
+/-- A block diagonal matrix with PSD diagonal blocks is PSD. -/
 theorem Matrix.PosSemidef.fromBlocks_diag
     {m o : Type*} [Finite m] [Finite o]
     {A : Matrix m m ℂ} {D : Matrix o o ℂ}

--- a/TNLean/Channel/Schwarz/PositiveMapProperties.lean
+++ b/TNLean/Channel/Schwarz/PositiveMapProperties.lean
@@ -100,9 +100,9 @@ theorem IsPositiveMap.map_conjTranspose
 /-- A block diagonal matrix with PSD diagonal blocks is PSD. -/
 theorem Matrix.PosSemidef.fromBlocks_diag
     {m o : Type*} [Finite m] [Finite o]
-    {A : Matrix m m ℂ} {D : Matrix o o ℂ}
-    (hA : A.PosSemidef) (hD : D.PosSemidef) :
-    (Matrix.fromBlocks A 0 0 D : Matrix (m ⊕ o) (m ⊕ o) ℂ).PosSemidef := by
+    {A : Matrix m m ℂ} {B : Matrix o o ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    (Matrix.fromBlocks A 0 0 B : Matrix (m ⊕ o) (m ⊕ o) ℂ).PosSemidef := by
   classical
   letI := Fintype.ofFinite m
   letI := Fintype.ofFinite o
@@ -110,34 +110,17 @@ theorem Matrix.PosSemidef.fromBlocks_diag
   letI : CStarAlgebra (Matrix o o ℂ) := matrixCStarAlgebra o
   obtain ⟨CA, hCA⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
     ((Matrix.nonneg_iff_posSemidef).mpr hA)
-  obtain ⟨CD, hCD⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
-    ((Matrix.nonneg_iff_posSemidef).mpr hD)
+  obtain ⟨CB, hCB⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
+    ((Matrix.nonneg_iff_posSemidef).mpr hB)
   have hCA' : A = CA * CAᴴ := by
     simpa [Matrix.star_eq_conjTranspose] using hCA
-  have hCD' : D = CD * CDᴴ := by
-    simpa [Matrix.star_eq_conjTranspose] using hCD
-  let C : Matrix (m ⊕ o) (m ⊕ o) ℂ := Matrix.fromBlocks CA 0 0 CD
-  have hC : Matrix.fromBlocks A 0 0 D = C * Cᴴ := by
-    simp [C, hCA', hCD', Matrix.fromBlocks_multiply, Matrix.fromBlocks_conjTranspose]
+  have hCB' : B = CB * CBᴴ := by
+    simpa [Matrix.star_eq_conjTranspose] using hCB
+  let C : Matrix (m ⊕ o) (m ⊕ o) ℂ := Matrix.fromBlocks CA 0 0 CB
+  have hC : Matrix.fromBlocks A 0 0 B = C * Cᴴ := by
+    simp [C, hCA', hCB', Matrix.fromBlocks_multiply, Matrix.fromBlocks_conjTranspose]
   rw [hC]
   exact Matrix.posSemidef_self_mul_conjTranspose C
-
-/-- Reindexing commutes with the conjugate transpose of a matrix. -/
-theorem Matrix.reindex_conjTranspose {m o : Type*}
-    (e : m ≃ o) (M : Matrix m m ℂ) :
-    Matrix.reindex e e Mᴴ = (Matrix.reindex e e M)ᴴ := by
-  ext i j
-  simp [Matrix.reindex_apply, Matrix.conjTranspose_apply, Matrix.submatrix_apply]
-
-/-- Reindexing preserves positive semidefiniteness. -/
-theorem Matrix.PosSemidef.reindex
-    {m o : Type*} [Finite m] [Finite o] {M : Matrix m m ℂ}
-    (hM : M.PosSemidef) (e : m ≃ o) :
-    (Matrix.reindex e e M).PosSemidef := by
-  classical
-  letI := Fintype.ofFinite m
-  letI := Fintype.ofFinite o
-  simpa [Matrix.reindex_apply] using hM.submatrix e.symm
 
 /-- If `T` is positive and subunital, then it preserves order intervals `[a • 1, b • 1]`
 whenever `0 ∈ [a,b]`. -/

--- a/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
@@ -275,7 +275,7 @@ private theorem topLeft_schwarz_of_normal_extension
     have hM' : (Matrix.reindex e.symm e.symm M).PosSemidef := by
       simpa [Matrix.reindex_apply] using hM.submatrix e
     have hSM : (S (Matrix.reindex e.symm e.symm M)).PosSemidef := hPosS _ hM'
-    simpa using hSM.reindex e
+    simpa [Matrix.reindex_apply] using hSM.submatrix e.symm
   have hSubSf : Sf 1 ≤ (1 : Matrix (Fin (D + E)) (Fin (D + E)) ℂ) := by
     rw [Matrix.le_iff] at hSubS ⊢
     have hEq :
@@ -283,28 +283,28 @@ private theorem topLeft_schwarz_of_normal_extension
           Matrix.reindex e e ((1 : Matrix (Fin D ⊕ Fin E) (Fin D ⊕ Fin E) ℂ) - S 1) := by
       ext i j
       simp [Sf, ρ, Matrix.reindexLinearEquiv_apply, Matrix.one_apply]
-    simpa [hEq] using hSubS.reindex e
+    simpa [hEq, Matrix.reindex_apply] using hSubS.submatrix e.symm
   have hNormalf : Nfᴴ * Nf = Nf * Nfᴴ := by
     change (Matrix.reindex e e N)ᴴ * Matrix.reindex e e N =
       Matrix.reindex e e N * (Matrix.reindex e e N)ᴴ
     calc
       (Matrix.reindex e e N)ᴴ * Matrix.reindex e e N =
           Matrix.reindex e e Nᴴ * Matrix.reindex e e N := by
-            rw [Matrix.reindex_conjTranspose e N]
+            rw [Matrix.conjTranspose_reindex]
       _ = Matrix.reindex e e (Nᴴ * N) := by
         convert (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e Nᴴ N) using 1
       _ = Matrix.reindex e e (N * Nᴴ) := by rw [hNormal]
       _ = Matrix.reindex e e N * Matrix.reindex e e Nᴴ := by
         convert (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e N Nᴴ).symm using 1
       _ = Matrix.reindex e e N * (Matrix.reindex e e N)ᴴ := by
-        rw [Matrix.reindex_conjTranspose e N]
+        rw [Matrix.conjTranspose_reindex]
   have hLeftf : (Sf (Nfᴴ * Nf) - Sf Nfᴴ * Sf Nf).PosSemidef :=
     schwarz_inequality_normal_operator (D := D + E) Sf hPosSf hSubSf Nf hNormalf
   have hLeftSum : (S (Nᴴ * N) - S Nᴴ * S N).PosSemidef := by
     have h :
         ((S (Nᴴ * N)).submatrix e.symm e.symm -
           (S Nᴴ * S N).submatrix e.symm e.symm).PosSemidef := by
-      simpa [Sf, Nf, ρ, Matrix.reindex_conjTranspose e N,
+      simpa [Sf, Nf, ρ, Matrix.conjTranspose_reindex e e N,
         Matrix.reindexLinearEquiv_apply, Matrix.reindexLinearEquiv_mul,
         Matrix.submatrix_sub] using hLeftf
     simpa [Matrix.submatrix_submatrix, Matrix.submatrix_sub] using h.submatrix e
@@ -317,7 +317,7 @@ private theorem topLeft_schwarz_of_normal_extension
     have h :
         ((S (N * Nᴴ)).submatrix e.symm e.symm -
           (S N * S Nᴴ).submatrix e.symm e.symm).PosSemidef := by
-      simpa [Sf, Nf, ρ, Matrix.reindex_conjTranspose e N,
+      simpa [Sf, Nf, ρ, Matrix.conjTranspose_reindex e e N,
         Matrix.reindexLinearEquiv_apply, Matrix.reindexLinearEquiv_mul,
         conjTranspose_conjTranspose, Matrix.submatrix_sub] using hRightf
     simpa [Matrix.submatrix_submatrix, Matrix.submatrix_sub] using h.submatrix e

--- a/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Schwarz.SchwarzNormal
+import TNLean.Channel.Schwarz.PositiveMapProperties
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Commute
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order
 import Mathlib.Analysis.SpecificLimits.Basic
@@ -197,42 +198,6 @@ def IsSubnormal (A : Mat) : Prop :=
         let N : Matrix (Fin D ⊕ Fin E) (Fin D ⊕ Fin E) ℂ := Matrix.fromBlocks A B 0 C
         Nᴴ * N = N * Nᴴ
 
-private lemma posSemidef_fromBlocks_diag {E : ℕ}
-    {X : Mat} {Y : Matrix (Fin E) (Fin E) ℂ}
-    (hX : X.PosSemidef) (hY : Y.PosSemidef) :
-    (Matrix.fromBlocks X 0 0 Y : Matrix (Fin D ⊕ Fin E) (Fin D ⊕ Fin E) ℂ).PosSemidef := by
-  letI : CStarAlgebra (Matrix (Fin E) (Fin E) ℂ) :=
-    { toNormedRing := Matrix.instL2OpNormedRing
-      toStarRing := inferInstance
-      toCompleteSpace := inferInstance
-      toCStarRing := Matrix.instCStarRing
-      toNormedAlgebra := Matrix.instL2OpNormedAlgebra
-      toStarModule := inferInstance }
-  obtain ⟨CX, hCX⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
-    ((Matrix.nonneg_iff_posSemidef).mpr hX)
-  obtain ⟨CY, hCY⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
-    ((Matrix.nonneg_iff_posSemidef).mpr hY)
-  have hCX' : X = CX * CXᴴ := by
-    simpa [Matrix.star_eq_conjTranspose] using hCX
-  have hCY' : Y = CY * CYᴴ := by
-    simpa [Matrix.star_eq_conjTranspose] using hCY
-  let C : Matrix (Fin D ⊕ Fin E) (Fin D ⊕ Fin E) ℂ := Matrix.fromBlocks CX 0 0 CY
-  have hC : Matrix.fromBlocks X 0 0 Y = C * Cᴴ := by
-    simp [C, hCX', hCY', Matrix.fromBlocks_multiply, Matrix.fromBlocks_conjTranspose]
-  rw [hC]
-  exact Matrix.posSemidef_self_mul_conjTranspose C
-
-private lemma reindex_conjTranspose {m n : Type*}
-    (e : m ≃ n) (M : Matrix m m ℂ) :
-    Matrix.reindex e e Mᴴ = (Matrix.reindex e e M)ᴴ := by
-  ext i j
-  simp [Matrix.reindex_apply, Matrix.conjTranspose_apply, Matrix.submatrix_apply]
-
-private lemma posSemidef_reindex {m n : Type*} {M : Matrix m m ℂ}
-    (hM : M.PosSemidef) (e : m ≃ n) :
-    (Matrix.reindex e e M).PosSemidef := by
-  simpa [Matrix.reindex_apply] using hM.submatrix e.symm
-
 private noncomputable def nwExtendLinearMap (T : Mat →ₗ[ℂ] Mat) (E : ℕ) :
     Matrix (Fin D ⊕ Fin E) (Fin D ⊕ Fin E) ℂ →ₗ[ℂ]
       Matrix (Fin D ⊕ Fin E) (Fin D ⊕ Fin E) ℂ where
@@ -254,7 +219,7 @@ private lemma nwExtendLinearMap_isPositiveMap (T : Mat →ₗ[ℂ] Mat)
     (hPos : IsPositiveMap T) (E : ℕ) :
     IsPositiveMap (nwExtendLinearMap (D := D) T E) := by
   intro M hM
-  refine posSemidef_fromBlocks_diag ?_ Matrix.PosSemidef.zero
+  refine Matrix.PosSemidef.fromBlocks_diag ?_ Matrix.PosSemidef.zero
   exact hPos _ (by simpa [Matrix.toBlocks₁₁, Matrix.submatrix_apply] using hM.submatrix Sum.inl)
 
 private lemma nwExtendLinearMap_subunital (T : Mat →ₗ[ℂ] Mat)
@@ -266,7 +231,7 @@ private lemma nwExtendLinearMap_subunital (T : Mat →ₗ[ℂ] Mat)
     simpa [Matrix.le_iff] using hSub
   have hDiag :
       (Matrix.fromBlocks (1 - T 1) 0 0 (1 : Matrix (Fin E) (Fin E) ℂ)).PosSemidef :=
-    posSemidef_fromBlocks_diag (D := D) (E := E) hTop Matrix.PosSemidef.one
+    Matrix.PosSemidef.fromBlocks_diag hTop Matrix.PosSemidef.one
   have hOne11 : (1 : Matrix (Fin D ⊕ Fin E) (Fin D ⊕ Fin E) ℂ).toBlocks₁₁ = (1 : Mat) := by
     ext i j
     simp [Matrix.toBlocks₁₁, Matrix.one_apply]
@@ -310,7 +275,7 @@ private theorem topLeft_schwarz_of_normal_extension
     have hM' : (Matrix.reindex e.symm e.symm M).PosSemidef := by
       simpa [Matrix.reindex_apply] using hM.submatrix e
     have hSM : (S (Matrix.reindex e.symm e.symm M)).PosSemidef := hPosS _ hM'
-    simpa using posSemidef_reindex hSM e
+    simpa using hSM.reindex e
   have hSubSf : Sf 1 ≤ (1 : Matrix (Fin (D + E)) (Fin (D + E)) ℂ) := by
     rw [Matrix.le_iff] at hSubS ⊢
     have hEq :
@@ -318,28 +283,28 @@ private theorem topLeft_schwarz_of_normal_extension
           Matrix.reindex e e ((1 : Matrix (Fin D ⊕ Fin E) (Fin D ⊕ Fin E) ℂ) - S 1) := by
       ext i j
       simp [Sf, ρ, Matrix.reindexLinearEquiv_apply, Matrix.one_apply]
-    simpa [hEq] using posSemidef_reindex hSubS e
+    simpa [hEq] using hSubS.reindex e
   have hNormalf : Nfᴴ * Nf = Nf * Nfᴴ := by
     change (Matrix.reindex e e N)ᴴ * Matrix.reindex e e N =
       Matrix.reindex e e N * (Matrix.reindex e e N)ᴴ
     calc
       (Matrix.reindex e e N)ᴴ * Matrix.reindex e e N =
           Matrix.reindex e e Nᴴ * Matrix.reindex e e N := by
-            rw [reindex_conjTranspose e N]
+            rw [Matrix.reindex_conjTranspose e N]
       _ = Matrix.reindex e e (Nᴴ * N) := by
         convert (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e Nᴴ N) using 1
       _ = Matrix.reindex e e (N * Nᴴ) := by rw [hNormal]
       _ = Matrix.reindex e e N * Matrix.reindex e e Nᴴ := by
         convert (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e N Nᴴ).symm using 1
       _ = Matrix.reindex e e N * (Matrix.reindex e e N)ᴴ := by
-        rw [reindex_conjTranspose e N]
+        rw [Matrix.reindex_conjTranspose e N]
   have hLeftf : (Sf (Nfᴴ * Nf) - Sf Nfᴴ * Sf Nf).PosSemidef :=
     schwarz_inequality_normal_operator (D := D + E) Sf hPosSf hSubSf Nf hNormalf
   have hLeftSum : (S (Nᴴ * N) - S Nᴴ * S N).PosSemidef := by
     have h :
         ((S (Nᴴ * N)).submatrix e.symm e.symm -
           (S Nᴴ * S N).submatrix e.symm e.symm).PosSemidef := by
-      simpa [Sf, Nf, ρ, reindex_conjTranspose e N,
+      simpa [Sf, Nf, ρ, Matrix.reindex_conjTranspose e N,
         Matrix.reindexLinearEquiv_apply, Matrix.reindexLinearEquiv_mul,
         Matrix.submatrix_sub] using hLeftf
     simpa [Matrix.submatrix_submatrix, Matrix.submatrix_sub] using h.submatrix e
@@ -352,7 +317,7 @@ private theorem topLeft_schwarz_of_normal_extension
     have h :
         ((S (N * Nᴴ)).submatrix e.symm e.symm -
           (S N * S Nᴴ).submatrix e.symm e.symm).PosSemidef := by
-      simpa [Sf, Nf, ρ, reindex_conjTranspose e N,
+      simpa [Sf, Nf, ρ, Matrix.reindex_conjTranspose e N,
         Matrix.reindexLinearEquiv_apply, Matrix.reindexLinearEquiv_mul,
         conjTranspose_conjTranspose, Matrix.submatrix_sub] using hRightf
     simpa [Matrix.submatrix_submatrix, Matrix.submatrix_sub] using h.submatrix e
@@ -533,7 +498,7 @@ private lemma intertwine_sqrt_of_mul_eq
       simp [M, J, Matrix.fromBlocks_multiply]
   have hM_nonneg : (0 : Matrix (Fin D ⊕ Fin D) (Fin D ⊕ Fin D) ℂ) ≤ M := by
     rw [Matrix.nonneg_iff_posSemidef]
-    exact posSemidef_fromBlocks_diag (D := D) (E := D)
+    exact Matrix.PosSemidef.fromBlocks_diag
       ((Matrix.nonneg_iff_posSemidef).mp hP) ((Matrix.nonneg_iff_posSemidef).mp hQ)
   have hSJ : Commute (CFC.sqrt M) J := (Commute.cfcₙ_nnreal hMJ NNReal.sqrt)
   have hSK : Commute (CFC.sqrt M) K := (Commute.cfcₙ_nnreal hMK NNReal.sqrt)

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -115,8 +115,30 @@ were not provable, the definition of `IsNPositiveMap` would be wrong.
 The proof embeds `M_n ⊗ M_k ↪ M_n ⊗ M_{k+1}` via padding with zeros. -/
 theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (h : IsNPositiveMap (k + 1) E) : IsNPositiveMap k E := by
-  -- TODO (#22): embed (n × Fin k) ↪ (n × Fin (k+1)) via padding, apply h
-  sorry
+  intro X hX
+  -- Embed X into the larger space (n × Fin (k+1)) by padding with zeros
+  let emb : Fin k → Fin (k + 1) := Fin.castSucc
+  let X' : Matrix (n × Fin (k + 1)) (n × Fin (k + 1)) ℂ :=
+    Matrix.of fun ip jq =>
+      if h₁ : ip.2.val < k then
+        if h₂ : jq.2.val < k then
+          X (ip.1, ⟨ip.2.val, h₁⟩) (jq.1, ⟨jq.2.val, h₂⟩)
+        else 0
+      else 0
+  -- X' is PSD: for any v, v†X'v = w†Xw where w is the restriction of v
+  have hX' : X'.PosSemidef := by
+    constructor
+    · intro ip jq
+      simp only [X', Matrix.of_apply, Matrix.conjTranspose_apply, starRingEnd_apply]
+      split <;> split <;> simp_all [hX.1]
+    · intro v
+      simp only [X', Matrix.of_apply, Matrix.dotProduct, Matrix.mulVec,
+        Finset.sum_apply]
+      sorry -- TODO (#280): inner product calculation for padded matrix
+  -- Apply (k+1)-positivity
+  have hY' := h X' hX'
+  -- Extract the k-block from the result
+  sorry -- TODO (#280): extract principal submatrix from ampliation result
 
 /-- CP maps are 2-positive. -/
 theorem IsCPMap.is2PositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
@@ -125,12 +147,34 @@ theorem IsCPMap.is2PositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
 
 /-- 2-positive maps are positive.
 
-Apply the definition with `k = 1` embedded into `k = 2` (or directly:
-2-positive ⊇ 1-positive = positive). -/
+Apply the definition with `k = 1` embedded into `k = 2`: given PSD `X`,
+embed it as `diag(X, 0)` in `M_n ⊗ M_2`, apply 2-positivity to get PSD
+output, then extract the (0,0)-block which equals `E(X)`. -/
 theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (h : Is2PositiveMap E) : IsPositiveMap E := by
-  -- TODO (#22): embed M_n ↪ M_n ⊗ M_2 via diag(X, 0) and apply 2-positivity
-  sorry
+  intro X hX
+  -- Embed X as the (0,0) block of a (n × Fin 2) × (n × Fin 2) PSD matrix
+  let X' : Matrix (n × Fin 2) (n × Fin 2) ℂ :=
+    Matrix.of fun ip jq =>
+      if ip.2 = 0 ∧ jq.2 = 0 then X ip.1 jq.1 else 0
+  have hX' : X'.PosSemidef := by
+    constructor
+    · -- Hermiticity: X'ᴴ = X'
+      intro ip jq
+      simp only [X', Matrix.of_apply, Matrix.conjTranspose_apply, starRingEnd_apply]
+      split
+      · next h => rw [h.1, h.2]; simp [hX.1]
+      · next h₁ =>
+        split
+        · next h₂ => simp only [star_zero]; rw [h₂.1, h₂.2] at h₁; exact absurd ⟨h₂.2, h₂.1⟩ h₁
+        · simp [star_zero]
+    · -- Inner product: v†X'v ≥ 0
+      intro v
+      sorry -- TODO (#280): v†X'v = w†Xw where w i = v (i, 0), then use hX
+  -- Apply 2-positivity to X'
+  have hY' := h X' hX'
+  -- The (0,0)-block of the result is E(X), which is PSD as a principal submatrix
+  sorry -- TODO (#280): extract E(X) as principal submatrix of PSD ampliation
 
 /-! ## Kadison–Schwarz for 2-positive maps -/
 

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -103,63 +103,6 @@ private lemma posSemidef_reindex {m o : Type*}
     (Matrix.reindex e e M).PosSemidef := by
   simpa [Matrix.reindex_apply] using hM.submatrix e.symm
 
-private noncomputable def finSuccBlockEquiv (α : Type*) (k : ℕ) :
-    α × Fin (k + 1) ≃ (α × Fin k) ⊕ α :=
-  (((Equiv.prodCongr (Equiv.refl α)
-      ((finSumFinEquiv : Fin k ⊕ Fin 1 ≃ Fin (k + 1)).symm)).trans
-    (Equiv.prodSumDistrib α (Fin k) (Fin 1))).trans
-    (Equiv.sumCongr (Equiv.refl _) (Equiv.prodUnique α (Fin 1))))
-
-@[simp] private theorem finSuccBlockEquiv_apply_castSucc {α : Type*} (k : ℕ)
-    (a : α) (i : Fin k) :
-    finSuccBlockEquiv α k (a, Fin.castSucc i) = Sum.inl (a, i) := by
-  change Sum.map id Prod.fst
-      ((Equiv.prodSumDistrib α (Fin k) (Fin 1))
-        (a, ((finSumFinEquiv : Fin k ⊕ Fin 1 ≃ Fin (k + 1)).symm (Fin.castSucc i)))) =
-      Sum.inl (a, i)
-  rw [finSumFinEquiv_symm_apply_castSucc]
-  simp
-
-@[simp] private theorem finSuccBlockEquiv_apply_last {α : Type*} (k : ℕ) (a : α) :
-    finSuccBlockEquiv α k (a, Fin.last k) = Sum.inr a := by
-  change Sum.map id Prod.fst
-      ((Equiv.prodSumDistrib α (Fin k) (Fin 1))
-        (a, ((finSumFinEquiv : Fin k ⊕ Fin 1 ≃ Fin (k + 1)).symm (Fin.last k)))) =
-      Sum.inr a
-  rw [finSumFinEquiv_symm_last]
-  simp
-
-private noncomputable def finTwoBlockEquiv (α : Type*) : α × Fin 2 ≃ α ⊕ α :=
-  (finSuccBlockEquiv α 1).trans
-    (Equiv.sumCongr (Equiv.prodUnique α (Fin 1)) (Equiv.refl α))
-
-@[simp] private theorem finTwoBlockEquiv_apply_zero {α : Type*} (a : α) :
-    finTwoBlockEquiv α (a, 0) = Sum.inl a := by
-  change Sum.map Prod.fst id ((finSuccBlockEquiv α 1) (a, 0)) = Sum.inl a
-  rw [show (0 : Fin 2) = Fin.castSucc (0 : Fin 1) by rfl]
-  rw [finSuccBlockEquiv_apply_castSucc (α := α) 1 a (0 : Fin 1)]
-  simp
-
-@[simp] private theorem finTwoBlockEquiv_apply_one {α : Type*} (a : α) :
-    finTwoBlockEquiv α (a, Fin.last 1) = Sum.inr a := by
-  change Sum.map Prod.fst id ((finSuccBlockEquiv α 1) (a, Fin.last 1)) = Sum.inr a
-  rw [finSuccBlockEquiv_apply_last (α := α) 1 a]
-  simp
-
-@[simp] private theorem finTwoBlockEquiv_apply_one' {α : Type*} (a : α) :
-    finTwoBlockEquiv α (a, 1) = Sum.inr a := by
-  simpa using finTwoBlockEquiv_apply_one (α := α) a
-
-@[simp] private theorem finTwoBlockEquiv_symm_apply_left {α : Type*} (a : α) :
-    (finTwoBlockEquiv α).symm (Sum.inl a) = (a, 0) := by
-  apply (finTwoBlockEquiv α).injective
-  simp
-
-@[simp] private theorem finTwoBlockEquiv_symm_apply_right {α : Type*} (a : α) :
-    (finTwoBlockEquiv α).symm (Sum.inr a) = (a, 1) := by
-  apply (finTwoBlockEquiv α).injective
-  simp
-
 /-! ## Definitions of n-positivity -/
 
 /-- A linear map `E : M_n(ℂ) → M_n(ℂ)` is **k-positive** if the ampliation
@@ -267,73 +210,21 @@ The proof embeds `M_n ⊗ M_k ↪ M_n ⊗ M_{k+1}` via padding with zeros. -/
 theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k : ℕ}
     (h : IsNPositiveMap (k + 1) E) : IsNPositiveMap k E := by
   intro X hX
-  -- Embed X into the larger space (n × Fin (k+1)) by padding with zeros
+  let e : n × Fin (k + 1) ≃ (n × Fin k) ⊕ n :=
+    (((Equiv.prodCongr (Equiv.refl n)
+        ((finSumFinEquiv : Fin k ⊕ Fin 1 ≃ Fin (k + 1)).symm)).trans
+      (Equiv.prodSumDistrib n (Fin k) (Fin 1))).trans
+      (Equiv.sumCongr (Equiv.refl _) (Equiv.prodUnique n (Fin 1))))
   let X' : Matrix (n × Fin (k + 1)) (n × Fin (k + 1)) ℂ :=
-    Matrix.of fun ip jq =>
-      if h₁ : ip.2.val < k then
-        if h₂ : jq.2.val < k then
-          X (ip.1, ⟨ip.2.val, h₁⟩) (jq.1, ⟨jq.2.val, h₂⟩)
-        else 0
-      else 0
-  -- X' is PSD: for any v, v†X'v = w†Xw where w is the restriction of v
+    Matrix.reindex e.symm e.symm (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ))
+  have he_castSucc (i : n) (a : Fin k) : e (i, Fin.castSucc a) = Sum.inl (i, a) := by
+    change Sum.map id Prod.fst
+        ((Equiv.prodSumDistrib n (Fin k) (Fin 1))
+          (i, ((finSumFinEquiv : Fin k ⊕ Fin 1 ≃ Fin (k + 1)).symm (Fin.castSucc a)))) =
+        Sum.inl (i, a)
+    rw [finSumFinEquiv_symm_apply_castSucc]
+    simp
   have hX' : X'.PosSemidef := by
-    let e := finSuccBlockEquiv n k
-    have hEq :
-        X' = Matrix.reindex e.symm e.symm
-          (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ)) := by
-      ext ip jq
-      rcases ip with ⟨i, a⟩
-      rcases jq with ⟨j, b⟩
-      by_cases ha : a.val < k
-      · have ha' : a = Fin.castSucc ⟨a.val, ha⟩ := by
-          apply Fin.ext
-          simp
-        by_cases hb : b.val < k
-        · have hb' : b = Fin.castSucc ⟨b.val, hb⟩ := by
-            apply Fin.ext
-            simp
-          have hea : e (i, a) = Sum.inl (i, ⟨a.val, ha⟩) := by
-            cases ha'
-            exact finSuccBlockEquiv_apply_castSucc (α := n) k i ⟨a.val, ha⟩
-          have heb : e (j, b) = Sum.inl (j, ⟨b.val, hb⟩) := by
-            cases hb'
-            exact finSuccBlockEquiv_apply_castSucc (α := n) k j ⟨b.val, hb⟩
-          simp [Matrix.reindex_apply, X', hea, heb, ha, hb]
-        · have hb' : b = Fin.last k := by
-            apply Fin.ext
-            exact le_antisymm (Nat.le_of_lt_succ b.isLt) (not_lt.mp hb)
-          have hea : e (i, a) = Sum.inl (i, ⟨a.val, ha⟩) := by
-            cases ha'
-            exact finSuccBlockEquiv_apply_castSucc (α := n) k i ⟨a.val, ha⟩
-          have heb : e (j, b) = Sum.inr j := by
-            cases hb'
-            exact finSuccBlockEquiv_apply_last (α := n) k j
-          simp [Matrix.reindex_apply, X', hea, heb, ha, hb]
-      · have ha' : a = Fin.last k := by
-          apply Fin.ext
-          exact le_antisymm (Nat.le_of_lt_succ a.isLt) (not_lt.mp ha)
-        by_cases hb : b.val < k
-        · have hb' : b = Fin.castSucc ⟨b.val, hb⟩ := by
-            apply Fin.ext
-            simp
-          have hea : e (i, a) = Sum.inr i := by
-            cases ha'
-            exact finSuccBlockEquiv_apply_last (α := n) k i
-          have heb : e (j, b) = Sum.inl (j, ⟨b.val, hb⟩) := by
-            cases hb'
-            exact finSuccBlockEquiv_apply_castSucc (α := n) k j ⟨b.val, hb⟩
-          simp [Matrix.reindex_apply, X', hea, heb, ha]
-        · have hb' : b = Fin.last k := by
-            apply Fin.ext
-            exact le_antisymm (Nat.le_of_lt_succ b.isLt) (not_lt.mp hb)
-          have hea : e (i, a) = Sum.inr i := by
-            cases ha'
-            exact finSuccBlockEquiv_apply_last (α := n) k i
-          have heb : e (j, b) = Sum.inr j := by
-            cases hb'
-            exact finSuccBlockEquiv_apply_last (α := n) k j
-          simp [Matrix.reindex_apply, X', hea, heb, ha]
-    rw [hEq]
     exact posSemidef_reindex
       (posSemidef_fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))) e.symm
   -- Apply (k+1)-positivity
@@ -342,7 +233,7 @@ theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k :
   let emb : n × Fin k → n × Fin (k + 1) := fun ip => (ip.1, Fin.castSucc ip.2)
   convert hY'.submatrix emb using 1
   ext ip jq
-  simp [emb, X']
+  simp [emb, X', Matrix.reindex_apply, he_castSucc]
 
 /-- CP maps are 2-positive. -/
 theorem IsCPMap.is2PositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
@@ -357,27 +248,29 @@ output, then extract the (0,0)-block which equals `E(X)`. -/
 theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (h : Is2PositiveMap E) : IsPositiveMap E := by
   intro X hX
-  -- Embed X as the (0,0) block of a (n × Fin 2) × (n × Fin 2) PSD matrix
+  let e : n × Fin 2 ≃ n ⊕ n :=
+    (((Equiv.prodCongr (Equiv.refl n)
+        ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm)).trans
+      (Equiv.prodSumDistrib n (Fin 1) (Fin 1))).trans
+      (Equiv.sumCongr (Equiv.prodUnique n (Fin 1)) (Equiv.prodUnique n (Fin 1))))
   let X' : Matrix (n × Fin 2) (n × Fin 2) ℂ :=
-    Matrix.of fun ip jq =>
-      if ip.2 = 0 ∧ jq.2 = 0 then X ip.1 jq.1 else 0
+    Matrix.reindex e.symm e.symm (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ))
+  have he_zero (i : n) : e (i, 0) = Sum.inl i := by
+    change Sum.map Prod.fst Prod.fst
+        ((Equiv.prodSumDistrib n (Fin 1) (Fin 1))
+          (i, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 0))) =
+        Sum.inl i
+    rw [show (0 : Fin 2) = Fin.castSucc (0 : Fin 1) by rfl]
+    rw [finSumFinEquiv_symm_apply_castSucc]
+    simp
   have hX' : X'.PosSemidef := by
-    let e := finTwoBlockEquiv n
-    have hEq :
-        X' = Matrix.reindex e.symm e.symm
-          (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ)) := by
-      ext ip jq
-      rcases ip with ⟨i, a⟩
-      rcases jq with ⟨j, b⟩
-      fin_cases a <;> fin_cases b <;> simp [Matrix.reindex_apply, X', e]
-    rw [hEq]
     exact posSemidef_reindex
       (posSemidef_fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))) e.symm
   -- Apply 2-positivity to X'
   have hY' := h X' hX'
   -- The (0,0)-block of the result is E(X), which is PSD as a principal submatrix
   let emb : n → n × Fin 2 := fun i => (i, 0)
-  simpa [emb, X'] using hY'.submatrix emb
+  simpa [emb, X', Matrix.reindex_apply, he_zero] using hY'.submatrix emb
 
 /-! ## Kadison–Schwarz for 2-positive maps -/
 
@@ -416,7 +309,33 @@ theorem kadison_schwarz_2positive
     (h_unital : KadisonSchwarz.IsUnitalMap E)
     (X : Matrix n n ℂ) :
     (E (Xᴴ * X) - (E X)ᴴ * E X).PosSemidef := by
-  let e := finTwoBlockEquiv n
+  let e : n × Fin 2 ≃ n ⊕ n :=
+    (((Equiv.prodCongr (Equiv.refl n)
+        ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm)).trans
+      (Equiv.prodSumDistrib n (Fin 1) (Fin 1))).trans
+      (Equiv.sumCongr (Equiv.prodUnique n (Fin 1)) (Equiv.prodUnique n (Fin 1))))
+  have he_zero (i : n) : e (i, 0) = Sum.inl i := by
+    change Sum.map Prod.fst Prod.fst
+        ((Equiv.prodSumDistrib n (Fin 1) (Fin 1))
+          (i, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 0))) =
+        Sum.inl i
+    rw [show (0 : Fin 2) = Fin.castSucc (0 : Fin 1) by rfl]
+    rw [finSumFinEquiv_symm_apply_castSucc]
+    simp
+  have he_one (i : n) : e (i, 1) = Sum.inr i := by
+    change Sum.map Prod.fst Prod.fst
+        ((Equiv.prodSumDistrib n (Fin 1) (Fin 1))
+          (i, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 1))) =
+        Sum.inr i
+    rw [show (1 : Fin 2) = Fin.last 1 by rfl]
+    rw [finSumFinEquiv_symm_last]
+    simp
+  have he_symm_left (i : n) : e.symm (Sum.inl i) = (i, 0) := by
+    apply e.injective
+    simp [he_zero]
+  have he_symm_right (i : n) : e.symm (Sum.inr i) = (i, 1) := by
+    apply e.injective
+    simp [he_one]
   let P : Matrix (n ⊕ n) (n ⊕ n) ℂ :=
     Matrix.fromBlocks (Xᴴ * X) Xᴴ X 1
   have hP : P.PosSemidef := by
@@ -436,19 +355,29 @@ theorem kadison_schwarz_2positive
           (((E X)ᴴ)ᴴ) (1 : Matrix n n ℂ) := by
     ext ip jq
     rcases ip with i | i <;> rcases jq with j | j
-    · change E (Matrix.of fun i' j' => (Xᴴ * X) i' j') i j = E (Xᴴ * X) i j
-      rfl
-    · change E (Matrix.of fun i' j' => (starRingEnd ℂ) (X j' i')) i j = (starRingEnd ℂ) (E X j i)
-      rw [show (Matrix.of fun i' j' => (starRingEnd ℂ) (X j' i')) = Xᴴ by
+    · simp only [Matrix.reindex_apply]
+      change E (Matrix.of fun i' j' => P' (i', 0) (j', 0)) i j = E (Xᴴ * X) i j
+      rw [show (Matrix.of fun i' j' => P' (i', 0) (j', 0)) = Xᴴ * X by
         ext a b
-        rfl]
+        simp [P', Matrix.reindex_apply, P, he_zero]]
+    · simp only [Matrix.reindex_apply]
+      change E (Matrix.of fun i' j' => P' (i', 0) (j', 1)) i j = (starRingEnd ℂ) (E X j i)
+      rw [show (Matrix.of fun i' j' => P' (i', 0) (j', 1)) = Xᴴ by
+        ext a b
+        simp [P', Matrix.reindex_apply, P, he_zero, he_one]]
       simpa [Matrix.conjTranspose_apply] using
         congr_fun (congr_fun (IsPositiveMap.map_conjTranspose hPos X) i) j
-    · have hId : (Matrix.of fun i' j' => X i' j') = X := by
+    · simp only [Matrix.reindex_apply]
+      change E (Matrix.of fun i' j' => P' (i', 1) (j', 0)) i j = (((E X)ᴴ)ᴴ) i j
+      rw [show (Matrix.of fun i' j' => P' (i', 1) (j', 0)) = X by
         ext a b
-        rfl
-      simp [Matrix.reindex_apply, P', P, e, hId]
-    · change E (Matrix.of fun i' j' => (1 : Matrix n n ℂ) i' j') i j = (1 : Matrix n n ℂ) i j
+        simp [P', Matrix.reindex_apply, P, he_one, he_zero]]
+      simp [Matrix.conjTranspose_apply]
+    · simp only [Matrix.reindex_apply]
+      change E (Matrix.of fun i' j' => P' (i', 1) (j', 1)) i j = (1 : Matrix n n ℂ) i j
+      rw [show (Matrix.of fun i' j' => P' (i', 1) (j', 1)) = (1 : Matrix n n ℂ) by
+        ext a b
+        simp [P', Matrix.reindex_apply, P, he_one]]
       simpa [KadisonSchwarz.IsUnitalMap] using congr_fun (congr_fun h_unital i) j
   have hBlockPsD :
       (Matrix.fromBlocks (E (Xᴴ * X)) ((E X)ᴴ)

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -131,7 +131,8 @@ theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
   obtain ⟨r, K, hK⟩ := hCP
   let e : n × Fin k ≃ Fin k × n := Equiv.prodComm n (Fin k)
   let Xswap : Matrix (Fin k × n) (Fin k × n) ℂ := Matrix.reindex e e X
-  have hXswap : Xswap.PosSemidef := hX.reindex e
+  have hXswap : Xswap.PosSemidef := by
+    simpa [Xswap, Matrix.reindex_apply] using hX.submatrix e.symm
   let Xblk : Matrix (Fin k) (Fin k) (Matrix n n ℂ) :=
     (Matrix.compRingEquiv (Fin k) n ℂ).symm Xswap
   let D : Fin r → Matrix (Fin k) (Fin k) (Matrix n n ℂ) :=
@@ -179,7 +180,9 @@ theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
       Xblk p q = Matrix.of fun i j => X (i, p) (j, q) := by
     ext i j
     simp [Xblk, Xswap, e, Matrix.reindex_apply]
-  convert hYswap.reindex e.symm using 1
+  have hY : (Matrix.reindex e.symm e.symm (F Yblk)).PosSemidef := by
+    simpa [Matrix.reindex_apply] using hYswap.submatrix e
+  convert hY using 1
   ext ip jq
   rw [hYblk]
   simp only [of_apply, Matrix.reindex_apply, Equiv.symm_symm, Matrix.submatrix_apply]
@@ -210,8 +213,8 @@ theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k :
     rw [finSumFinEquiv_symm_apply_castSucc]
     simp
   have hX' : X'.PosSemidef := by
-    exact (Matrix.PosSemidef.fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))).reindex
-      e.symm
+    simpa [X', Matrix.reindex_apply] using
+      (Matrix.PosSemidef.fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))).submatrix e
   -- Apply (k+1)-positivity
   have hY' := h X' hX'
   -- Extract the k-block from the result
@@ -238,8 +241,8 @@ theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n 
   let X' : Matrix (n × Fin 2) (n × Fin 2) ℂ :=
     Matrix.reindex e.symm e.symm (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ))
   have hX' : X'.PosSemidef := by
-    exact (Matrix.PosSemidef.fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))).reindex
-      e.symm
+    simpa [X', Matrix.reindex_apply] using
+      (Matrix.PosSemidef.fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))).submatrix e
   -- Apply 2-positivity to X'
   have hY' := h X' hX'
   -- The (0,0)-block of the result is E(X), which is PSD as a principal submatrix
@@ -292,9 +295,31 @@ theorem kadison_schwarz_2positive
     simpa [A, P, Matrix.fromBlocks_multiply, Matrix.fromBlocks_conjTranspose]
       using Matrix.posSemidef_self_mul_conjTranspose A
   let P' : Matrix (n × Fin 2) (n × Fin 2) ℂ := Matrix.reindex e.symm e.symm P
-  have hP' : P'.PosSemidef := hP.reindex e.symm
+  have hP' : P'.PosSemidef := by
+    simpa [P', Matrix.reindex_apply] using hP.submatrix e
   have hY' := h2pos P' hP'
   have hPos : IsPositiveMap E := h2pos.isPositiveMap
+  have hP'Block (p q : Fin 2) :
+      Matrix.of (fun i j => P' (i, p) (j, q)) =
+        match p, q with
+        | 0, 0 => Xᴴ * X
+        | 0, 1 => Xᴴ
+        | 1, 0 => X
+        | 1, 1 => (1 : Matrix n n ℂ) := by
+    fin_cases p <;> fin_cases q <;>
+      ext a b <;> simp [P', Matrix.reindex_apply, P, e]
+  have hEBlock (p q : Fin 2) :
+      E (Matrix.of fun i j => P' (i, p) (j, q)) =
+        match p, q with
+        | 0, 0 => E (Xᴴ * X)
+        | 0, 1 => (E X)ᴴ
+        | 1, 0 => ((E X)ᴴ)ᴴ
+        | 1, 1 => (1 : Matrix n n ℂ) := by
+    fin_cases p <;> fin_cases q
+    · simpa using congrArg E (hP'Block 0 0)
+    · exact (congrArg E (hP'Block 0 1)).trans (IsPositiveMap.map_conjTranspose hPos X)
+    · exact (congrArg E (hP'Block 1 0)).trans (by simp)
+    · exact (congrArg E (hP'Block 1 1)).trans (by simpa [KadisonSchwarz.IsUnitalMap] using h_unital)
   have hBlock :
       Matrix.reindex e e
         (Matrix.of fun (ip : n × Fin 2) (jq : n × Fin 2) =>
@@ -303,34 +328,18 @@ theorem kadison_schwarz_2positive
           (((E X)ᴴ)ᴴ) (1 : Matrix n n ℂ) := by
     ext ip jq
     rcases ip with i | i <;> rcases jq with j | j
-    · simp only [Matrix.reindex_apply]
-      change E (Matrix.of fun i' j' => P' (i', 0) (j', 0)) i j = E (Xᴴ * X) i j
-      rw [show (Matrix.of fun i' j' => P' (i', 0) (j', 0)) = Xᴴ * X by
-        ext a b
-        simp [P', Matrix.reindex_apply, P, e]]
-    · simp only [Matrix.reindex_apply]
-      change E (Matrix.of fun i' j' => P' (i', 0) (j', 1)) i j = (starRingEnd ℂ) (E X j i)
-      rw [show (Matrix.of fun i' j' => P' (i', 0) (j', 1)) = Xᴴ by
-        ext a b
-        simp [P', Matrix.reindex_apply, P, e]]
-      simpa [Matrix.conjTranspose_apply] using
-        congr_fun (congr_fun (IsPositiveMap.map_conjTranspose hPos X) i) j
-    · simp only [Matrix.reindex_apply]
-      change E (Matrix.of fun i' j' => P' (i', 1) (j', 0)) i j = (((E X)ᴴ)ᴴ) i j
-      rw [show (Matrix.of fun i' j' => P' (i', 1) (j', 0)) = X by
-        ext a b
-        simp [P', Matrix.reindex_apply, P, e]]
-      simp [Matrix.conjTranspose_apply]
-    · simp only [Matrix.reindex_apply]
-      change E (Matrix.of fun i' j' => P' (i', 1) (j', 1)) i j = (1 : Matrix n n ℂ) i j
-      rw [show (Matrix.of fun i' j' => P' (i', 1) (j', 1)) = (1 : Matrix n n ℂ) by
-        ext a b
-        simp [P', Matrix.reindex_apply, P, e]]
-      simpa [KadisonSchwarz.IsUnitalMap] using congr_fun (congr_fun h_unital i) j
+    · simpa [Matrix.reindex_apply] using congr_fun (congr_fun (hEBlock 0 0) i) j
+    · simpa [Matrix.reindex_apply] using congr_fun (congr_fun (hEBlock 0 1) i) j
+    · simpa [Matrix.reindex_apply] using congr_fun (congr_fun (hEBlock 1 0) i) j
+    · simpa [Matrix.reindex_apply] using congr_fun (congr_fun (hEBlock 1 1) i) j
   have hBlockPsD :
       (Matrix.fromBlocks (E (Xᴴ * X)) ((E X)ᴴ)
         (((E X)ᴴ)ᴴ) (1 : Matrix n n ℂ)).PosSemidef := by
-    simpa [hBlock] using hY'.reindex e
+    have hYsum : (Matrix.reindex e e
+        (Matrix.of fun (ip : n × Fin 2) (jq : n × Fin 2) =>
+          (E (Matrix.of fun i j => P' (i, ip.2) (j, jq.2))) ip.1 jq.1)).PosSemidef := by
+      simpa [Matrix.reindex_apply] using hY'.submatrix e.symm
+    simpa [hBlock] using hYsum
   haveI : Invertible (1 : Matrix n n ℂ) := invertibleOne
   simpa [inv_one, Matrix.mul_assoc, conjTranspose_conjTranspose] using
     (Matrix.PosDef.fromBlocks₂₂ (A := E (Xᴴ * X)) (B := (E X)ᴴ)

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -113,11 +113,10 @@ theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
 This is a basic structural property of the n-positivity hierarchy. If this
 were not provable, the definition of `IsNPositiveMap` would be wrong.
 The proof embeds `M_n ⊗ M_k ↪ M_n ⊗ M_{k+1}` via padding with zeros. -/
-theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k : ℕ}
     (h : IsNPositiveMap (k + 1) E) : IsNPositiveMap k E := by
   intro X hX
   -- Embed X into the larger space (n × Fin (k+1)) by padding with zeros
-  let emb : Fin k → Fin (k + 1) := Fin.castSucc
   let X' : Matrix (n × Fin (k + 1)) (n × Fin (k + 1)) ℂ :=
     Matrix.of fun ip jq =>
       if h₁ : ip.2.val < k then

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -65,25 +65,24 @@ open Matrix Finset
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
+attribute [local instance] Matrix.instL2OpNormedAddCommGroup
+attribute [local instance] Matrix.instL2OpNormedRing
+attribute [local instance] Matrix.instL2OpNormedAlgebra
+
+noncomputable local instance matrixCStarAlgebra (m : Type*) [Fintype m] [DecidableEq m] :
+    CStarAlgebra (Matrix m m ℂ) where
+  toNormedRing := Matrix.instL2OpNormedRing
+  toStarRing := inferInstance
+  toCompleteSpace := inferInstance
+  toCStarRing := Matrix.instCStarRing
+  toNormedAlgebra := Matrix.instL2OpNormedAlgebra
+  toStarModule := inferInstance
+
 private lemma posSemidef_fromBlocks_diag {m o : Type*}
     [Fintype m] [Fintype o] [DecidableEq m] [DecidableEq o]
     {A : Matrix m m ℂ} {D : Matrix o o ℂ}
     (hA : A.PosSemidef) (hD : D.PosSemidef) :
     (Matrix.fromBlocks A 0 0 D : Matrix (m ⊕ o) (m ⊕ o) ℂ).PosSemidef := by
-  letI : CStarAlgebra (Matrix m m ℂ) :=
-    { toNormedRing := Matrix.instL2OpNormedRing
-      toStarRing := inferInstance
-      toCompleteSpace := inferInstance
-      toCStarRing := Matrix.instCStarRing
-      toNormedAlgebra := Matrix.instL2OpNormedAlgebra
-      toStarModule := inferInstance }
-  letI : CStarAlgebra (Matrix o o ℂ) :=
-    { toNormedRing := Matrix.instL2OpNormedRing
-      toStarRing := inferInstance
-      toCompleteSpace := inferInstance
-      toCStarRing := Matrix.instCStarRing
-      toNormedAlgebra := Matrix.instL2OpNormedAlgebra
-      toStarModule := inferInstance }
   obtain ⟨CA, hCA⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
     ((Matrix.nonneg_iff_posSemidef).mpr hA)
   obtain ⟨CD, hCD⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
@@ -240,7 +239,8 @@ theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
   have hDterm (a : Fin r) :
       D a * Xblk * (D a)ᴴ = Matrix.of fun p q => K a * Xblk p q * (K a)ᴴ := by
     ext p q i j
-    simp [D, Matrix.diagonal_mul, Matrix.mul_diagonal, Matrix.mul_assoc, Matrix.star_eq_conjTranspose]
+    simp [D, Matrix.diagonal_mul, Matrix.mul_diagonal,
+      Matrix.mul_assoc, Matrix.star_eq_conjTranspose]
   have hYblk :
       Yblk = Matrix.of fun p q => E (Xblk p q) := by
     ext p q i j
@@ -254,7 +254,7 @@ theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
   convert posSemidef_reindex hYswap e.symm using 1
   ext ip jq
   rw [hYblk]
-  simp [Matrix.reindex_apply, e]
+  simp only [of_apply, Matrix.reindex_apply, Equiv.symm_symm, Matrix.submatrix_apply]
   change E (Matrix.of fun i j => X (i, ip.2) (j, jq.2)) ip.1 jq.1 =
       E (Xblk ip.2 jq.2) ip.1 jq.1
   rw [hXblk_apply ip.2 jq.2]
@@ -459,13 +459,12 @@ theorem kadison_schwarz_2positive
     (Matrix.PosDef.fromBlocks₂₂ (A := E (Xᴴ * X)) (B := (E X)ᴴ)
       (D := (1 : Matrix n n ℂ)) Matrix.PosDef.one).1 hBlockPsD
 
-/-- **Placeholder**: once `kadison_schwarz_2positive` is proved, the existing
-Kraus-based KS inequality becomes a corollary via:
-  `IsCPMap → Is2PositiveMap → kadison_schwarz_2positive`
+/-- The existing Kraus-based Kadison-Schwarz inequality.
 
-Currently this just delegates to the existing direct proof. When the sorry in
-`kadison_schwarz_2positive` is filled, this should be rerouted through the
-2-positive path to demonstrate the logical subsumption. -/
+This theorem still delegates to the direct proof in `KadisonSchwarz.lean`.
+A follow-up cleanup can reroute it through
+`IsCPMap → Is2PositiveMap → kadison_schwarz_2positive`
+to make the logical subsumption explicit. -/
 theorem kadison_schwarz_from_2positive
     {d D : ℕ}
     (K : Fin d → Matrix (Fin D) (Fin D) ℂ)

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
 import TNLean.Channel.Schwarz.KadisonSchwarz
+import TNLean.Channel.Schwarz.PositiveMapProperties
+import Mathlib.Analysis.CStarAlgebra.Matrix
+import Mathlib.Data.Matrix.Composition
 
 /-!
 # 2-Positive maps and the generalized Kadison–Schwarz inequality
@@ -62,6 +65,143 @@ open Matrix Finset
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
+private lemma posSemidef_fromBlocks_diag {m o : Type*}
+    [Fintype m] [Fintype o] [DecidableEq m] [DecidableEq o]
+    {A : Matrix m m ℂ} {D : Matrix o o ℂ}
+    (hA : A.PosSemidef) (hD : D.PosSemidef) :
+    (Matrix.fromBlocks A 0 0 D : Matrix (m ⊕ o) (m ⊕ o) ℂ).PosSemidef := by
+  letI : CStarAlgebra (Matrix m m ℂ) :=
+    { toNormedRing := Matrix.instL2OpNormedRing
+      toStarRing := inferInstance
+      toCompleteSpace := inferInstance
+      toCStarRing := Matrix.instCStarRing
+      toNormedAlgebra := Matrix.instL2OpNormedAlgebra
+      toStarModule := inferInstance }
+  letI : CStarAlgebra (Matrix o o ℂ) :=
+    { toNormedRing := Matrix.instL2OpNormedRing
+      toStarRing := inferInstance
+      toCompleteSpace := inferInstance
+      toCStarRing := Matrix.instCStarRing
+      toNormedAlgebra := Matrix.instL2OpNormedAlgebra
+      toStarModule := inferInstance }
+  obtain ⟨CA, hCA⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
+    ((Matrix.nonneg_iff_posSemidef).mpr hA)
+  obtain ⟨CD, hCD⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
+    ((Matrix.nonneg_iff_posSemidef).mpr hD)
+  have hCA' : A = CA * CAᴴ := by
+    simpa [Matrix.star_eq_conjTranspose] using hCA
+  have hCD' : D = CD * CDᴴ := by
+    simpa [Matrix.star_eq_conjTranspose] using hCD
+  let C : Matrix (m ⊕ o) (m ⊕ o) ℂ := Matrix.fromBlocks CA 0 0 CD
+  have hC : Matrix.fromBlocks A 0 0 D = C * Cᴴ := by
+    simp [C, hCA', hCD', Matrix.fromBlocks_multiply, Matrix.fromBlocks_conjTranspose]
+  rw [hC]
+  exact Matrix.posSemidef_self_mul_conjTranspose C
+
+private lemma posSemidef_reindex {m o : Type*}
+    [Fintype m] [Fintype o] {M : Matrix m m ℂ}
+    (hM : M.PosSemidef) (e : m ≃ o) :
+    (Matrix.reindex e e M).PosSemidef := by
+  simpa [Matrix.reindex_apply] using hM.submatrix e.symm
+
+private noncomputable def finSuccBlockEquiv (α : Type*) (k : ℕ) :
+    α × Fin (k + 1) ≃ (α × Fin k) ⊕ α :=
+  (((Equiv.prodCongr (Equiv.refl α)
+      ((finSumFinEquiv : Fin k ⊕ Fin 1 ≃ Fin (k + 1)).symm)).trans
+    (Equiv.prodSumDistrib α (Fin k) (Fin 1))).trans
+    (Equiv.sumCongr (Equiv.refl _) (Equiv.prodUnique α (Fin 1))))
+
+@[simp] private theorem finSuccBlockEquiv_apply_castSucc {α : Type*} (k : ℕ)
+    (a : α) (i : Fin k) :
+    finSuccBlockEquiv α k (a, Fin.castSucc i) = Sum.inl (a, i) := by
+  change Sum.map id Prod.fst
+      ((Equiv.prodSumDistrib α (Fin k) (Fin 1))
+        (a, ((finSumFinEquiv : Fin k ⊕ Fin 1 ≃ Fin (k + 1)).symm (Fin.castSucc i)))) =
+      Sum.inl (a, i)
+  rw [finSumFinEquiv_symm_apply_castSucc]
+  simp
+
+@[simp] private theorem finSuccBlockEquiv_apply_last {α : Type*} (k : ℕ) (a : α) :
+    finSuccBlockEquiv α k (a, Fin.last k) = Sum.inr a := by
+  change Sum.map id Prod.fst
+      ((Equiv.prodSumDistrib α (Fin k) (Fin 1))
+        (a, ((finSumFinEquiv : Fin k ⊕ Fin 1 ≃ Fin (k + 1)).symm (Fin.last k)))) =
+      Sum.inr a
+  rw [finSumFinEquiv_symm_last]
+  simp
+
+private noncomputable def finTwoBlockEquiv (α : Type*) : α × Fin 2 ≃ α ⊕ α :=
+  (finSuccBlockEquiv α 1).trans
+    (Equiv.sumCongr (Equiv.prodUnique α (Fin 1)) (Equiv.refl α))
+
+@[simp] private theorem finTwoBlockEquiv_apply_zero {α : Type*} (a : α) :
+    finTwoBlockEquiv α (a, 0) = Sum.inl a := by
+  change Sum.map Prod.fst id ((finSuccBlockEquiv α 1) (a, 0)) = Sum.inl a
+  rw [show (0 : Fin 2) = Fin.castSucc (0 : Fin 1) by rfl]
+  rw [finSuccBlockEquiv_apply_castSucc (α := α) 1 a (0 : Fin 1)]
+  simp
+
+@[simp] private theorem finTwoBlockEquiv_apply_one {α : Type*} (a : α) :
+    finTwoBlockEquiv α (a, Fin.last 1) = Sum.inr a := by
+  change Sum.map Prod.fst id ((finSuccBlockEquiv α 1) (a, Fin.last 1)) = Sum.inr a
+  rw [finSuccBlockEquiv_apply_last (α := α) 1 a]
+  simp
+
+@[simp] private theorem finTwoBlockEquiv_apply_one' {α : Type*} (a : α) :
+    finTwoBlockEquiv α (a, 1) = Sum.inr a := by
+  simpa using finTwoBlockEquiv_apply_one (α := α) a
+
+@[simp] private theorem finTwoBlockEquiv_symm_apply_left {α : Type*} (a : α) :
+    (finTwoBlockEquiv α).symm (Sum.inl a) = (a, 0) := by
+  apply (finTwoBlockEquiv α).injective
+  simp
+
+@[simp] private theorem finTwoBlockEquiv_symm_apply_right {α : Type*} (a : α) :
+    (finTwoBlockEquiv α).symm (Sum.inr a) = (a, 1) := by
+  apply (finTwoBlockEquiv α).injective
+  simp
+
+private theorem IsPositiveMap.map_conjTranspose'
+    {m : Type*} [Fintype m] [DecidableEq m]
+    {T : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ} (hT : IsPositiveMap T) (A : Matrix m m ℂ) :
+    T Aᴴ = (T A)ᴴ := by
+  let B : Matrix m m ℂ := (1 / 2 : ℝ) • (A + Aᴴ)
+  let C : Matrix m m ℂ := (1 / 2 : ℝ) • (Complex.I • (Aᴴ - A))
+  have hB : B.IsHermitian := by
+    ext i j
+    simp [B, add_comm]
+  have hC : C.IsHermitian := by
+    ext i j
+    simp [C, sub_eq_add_neg, add_comm]
+  have hmulI (z : ℂ) : Complex.I * ((2 : ℂ)⁻¹ * (Complex.I * z)) = -((2 : ℂ)⁻¹ * z) := by
+    calc
+      Complex.I * ((2 : ℂ)⁻¹ * (Complex.I * z)) = (Complex.I * Complex.I) * ((2 : ℂ)⁻¹ * z) := by
+        ring
+      _ = -((2 : ℂ)⁻¹ * z) := by norm_num [Complex.I_sq]
+  have hIC : Complex.I • C = (1 / 2 : ℝ) • (A - Aᴴ) := by
+    ext i j
+    simp [C, sub_eq_add_neg, mul_add, hmulI, add_comm]
+  have hNegIC : -(Complex.I • C) = (1 / 2 : ℝ) • (Aᴴ - A) := by
+    ext i j
+    simp [C, sub_eq_add_neg, hmulI, add_comm]
+  have hA_decomp : A = B + Complex.I • C := by
+    rw [hIC]
+    ext i j
+    simp [B, sub_eq_add_neg]
+    ring
+  have hAstar_decomp : Aᴴ = B - Complex.I • C := by
+    rw [sub_eq_add_neg, hNegIC]
+    ext i j
+    simp [B, sub_eq_add_neg]
+    ring
+  have hTB : (T B).IsHermitian := hT.map_isHermitian hB
+  have hTC : (T C).IsHermitian := hT.map_isHermitian hC
+  have hTA_decomp : T A = T B + Complex.I • T C := by
+    rw [hA_decomp]
+    simp
+  rw [hAstar_decomp, hTA_decomp]
+  simp [sub_eq_add_neg, hTB.eq, hTC.eq, Matrix.conjTranspose_add, Matrix.conjTranspose_smul]
+
 /-! ## Definitions of n-positivity -/
 
 /-- A linear map `E : M_n(ℂ) → M_n(ℂ)` is **k-positive** if the ampliation
@@ -100,13 +240,65 @@ and `E ⊗ id_k` applied to a PSD matrix yields a PSD matrix (by the same
 Kraus-based argument as `IsCPMap.isPositiveMap`). -/
 theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (hCP : IsCPMap E) (k : ℕ) : IsNPositiveMap k E := by
+  classical
   intro X hX
   obtain ⟨r, K, hK⟩ := hCP
-  -- The ampliation E ⊗ id_k has Kraus operators K_i ⊗ I_k,
-  -- so (E ⊗ id_k)(X) = ∑_i (K_i ⊗ I_k) X (K_i ⊗ I_k)†, which is PSD.
-  -- TODO (#22): block-diagonal Kraus operators on (n × Fin k) space
-  -- TODO (#22): add IsNPositiveMap_congr_perm for future Mathlib upstreaming
-  sorry
+  let e : n × Fin k ≃ Fin k × n := Equiv.prodComm n (Fin k)
+  let Xswap : Matrix (Fin k × n) (Fin k × n) ℂ := Matrix.reindex e e X
+  have hXswap : Xswap.PosSemidef := posSemidef_reindex hX e
+  let Xblk : Matrix (Fin k) (Fin k) (Matrix n n ℂ) :=
+    (Matrix.compRingEquiv (Fin k) n ℂ).symm Xswap
+  let D : Fin r → Matrix (Fin k) (Fin k) (Matrix n n ℂ) :=
+    fun a => Matrix.diagonal fun _ => K a
+  let Yblk : Matrix (Fin k) (Fin k) (Matrix n n ℂ) :=
+    ∑ a, D a * Xblk * (D a)ᴴ
+  let F := Matrix.compRingEquiv (Fin k) n ℂ
+  have hcomp_conjTranspose (M : Matrix (Fin k) (Fin k) (Matrix n n ℂ)) :
+      F Mᴴ = (F M)ᴴ := by
+    ext ip jq
+    rcases ip with ⟨p, i⟩
+    rcases jq with ⟨q, j⟩
+    rfl
+  have hYswap :
+      (F Yblk).PosSemidef := by
+    rw [show F Yblk = ∑ a, F (D a * Xblk * (D a)ᴴ) by
+      simp [Yblk]]
+    refine Matrix.posSemidef_sum (s := Finset.univ)
+      (x := fun a => F (D a * Xblk * (D a)ᴴ)) ?_
+    intro a _
+    let L : Matrix (Fin k × n) (Fin k × n) ℂ := F (D a)
+    have hL :
+        F (D a * Xblk * (D a)ᴴ) = L * Xswap * Lᴴ := by
+      calc
+        F (D a * Xblk * (D a)ᴴ) = F (D a * Xblk) * F ((D a)ᴴ) := by
+          rw [F.map_mul]
+        _ = (F (D a) * F Xblk) * (F (D a))ᴴ := by
+          rw [F.map_mul, hcomp_conjTranspose]
+        _ = L * (Xswap * Lᴴ) := by simp [F, L, Xblk, Matrix.mul_assoc]
+        _ = L * Xswap * Lᴴ := by simp [Matrix.mul_assoc]
+    change (F (D a * Xblk * (D a)ᴴ)).PosSemidef
+    simpa [hL] using hXswap.mul_mul_conjTranspose_same (B := L)
+  have hDterm (a : Fin r) :
+      D a * Xblk * (D a)ᴴ = Matrix.of fun p q => K a * Xblk p q * (K a)ᴴ := by
+    ext p q i j
+    simp [D, Matrix.diagonal_mul, Matrix.mul_diagonal, Matrix.mul_assoc, Matrix.star_eq_conjTranspose]
+  have hYblk :
+      Yblk = Matrix.of fun p q => E (Xblk p q) := by
+    ext p q i j
+    change Yblk p q i j = E (Xblk p q) i j
+    rw [hK (Xblk p q)]
+    simp [Yblk, hDterm, Matrix.sum_apply]
+  have hXblk_apply (p q : Fin k) :
+      Xblk p q = Matrix.of fun i j => X (i, p) (j, q) := by
+    ext i j
+    simp [Xblk, Xswap, e, Matrix.reindex_apply]
+  convert posSemidef_reindex hYswap e.symm using 1
+  ext ip jq
+  rw [hYblk]
+  simp [Matrix.reindex_apply, e]
+  change E (Matrix.of fun i j => X (i, ip.2) (j, jq.2)) ip.1 jq.1 =
+      E (Xblk ip.2 jq.2) ip.1 jq.1
+  rw [hXblk_apply ip.2 jq.2]
 
 /-- **Monotonicity sanity check**: `(k+1)`-positive implies `k`-positive.
 
@@ -126,20 +318,65 @@ theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k :
       else 0
   -- X' is PSD: for any v, v†X'v = w†Xw where w is the restriction of v
   have hX' : X'.PosSemidef := by
-    refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
-    · ext ip jq
-      by_cases hip : ip.2.val < k
-      · by_cases hjq : jq.2.val < k
-        · have hherm :=
-            congr_fun (congr_fun hX.1 (ip.1, ⟨ip.2.val, hip⟩)) (jq.1, ⟨jq.2.val, hjq⟩)
-          simpa [X', hip, hjq, Matrix.conjTranspose_apply] using hherm
-        · simp [X', hip, hjq, Matrix.conjTranspose_apply]
-      · by_cases hjq : jq.2.val < k
-        · simp [X', hip, hjq, Matrix.conjTranspose_apply]
-        · simp [X', hip, hjq, Matrix.conjTranspose_apply]
-    · intro v
-      simp only [X', Matrix.of_apply, dotProduct, Matrix.mulVec]
-      sorry -- TODO (#280): inner product calculation for padded matrix
+    let e := finSuccBlockEquiv n k
+    have hEq :
+        X' = Matrix.reindex e.symm e.symm
+          (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ)) := by
+      ext ip jq
+      rcases ip with ⟨i, a⟩
+      rcases jq with ⟨j, b⟩
+      by_cases ha : a.val < k
+      · have ha' : a = Fin.castSucc ⟨a.val, ha⟩ := by
+          apply Fin.ext
+          simp
+        by_cases hb : b.val < k
+        · have hb' : b = Fin.castSucc ⟨b.val, hb⟩ := by
+            apply Fin.ext
+            simp
+          have hea : e (i, a) = Sum.inl (i, ⟨a.val, ha⟩) := by
+            cases ha'
+            exact finSuccBlockEquiv_apply_castSucc (α := n) k i ⟨a.val, ha⟩
+          have heb : e (j, b) = Sum.inl (j, ⟨b.val, hb⟩) := by
+            cases hb'
+            exact finSuccBlockEquiv_apply_castSucc (α := n) k j ⟨b.val, hb⟩
+          simp [Matrix.reindex_apply, X', hea, heb, ha, hb]
+        · have hb' : b = Fin.last k := by
+            apply Fin.ext
+            exact le_antisymm (Nat.le_of_lt_succ b.isLt) (not_lt.mp hb)
+          have hea : e (i, a) = Sum.inl (i, ⟨a.val, ha⟩) := by
+            cases ha'
+            exact finSuccBlockEquiv_apply_castSucc (α := n) k i ⟨a.val, ha⟩
+          have heb : e (j, b) = Sum.inr j := by
+            cases hb'
+            exact finSuccBlockEquiv_apply_last (α := n) k j
+          simp [Matrix.reindex_apply, X', hea, heb, ha, hb]
+      · have ha' : a = Fin.last k := by
+          apply Fin.ext
+          exact le_antisymm (Nat.le_of_lt_succ a.isLt) (not_lt.mp ha)
+        by_cases hb : b.val < k
+        · have hb' : b = Fin.castSucc ⟨b.val, hb⟩ := by
+            apply Fin.ext
+            simp
+          have hea : e (i, a) = Sum.inr i := by
+            cases ha'
+            exact finSuccBlockEquiv_apply_last (α := n) k i
+          have heb : e (j, b) = Sum.inl (j, ⟨b.val, hb⟩) := by
+            cases hb'
+            exact finSuccBlockEquiv_apply_castSucc (α := n) k j ⟨b.val, hb⟩
+          simp [Matrix.reindex_apply, X', hea, heb, ha]
+        · have hb' : b = Fin.last k := by
+            apply Fin.ext
+            exact le_antisymm (Nat.le_of_lt_succ b.isLt) (not_lt.mp hb)
+          have hea : e (i, a) = Sum.inr i := by
+            cases ha'
+            exact finSuccBlockEquiv_apply_last (α := n) k i
+          have heb : e (j, b) = Sum.inr j := by
+            cases hb'
+            exact finSuccBlockEquiv_apply_last (α := n) k j
+          simp [Matrix.reindex_apply, X', hea, heb, ha]
+    rw [hEq]
+    exact posSemidef_reindex
+      (posSemidef_fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))) e.symm
   -- Apply (k+1)-positivity
   have hY' := h X' hX'
   -- Extract the k-block from the result
@@ -166,20 +403,17 @@ theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n 
     Matrix.of fun ip jq =>
       if ip.2 = 0 ∧ jq.2 = 0 then X ip.1 jq.1 else 0
   have hX' : X'.PosSemidef := by
-    refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
-    · -- Hermiticity: X'ᴴ = X'
+    let e := finTwoBlockEquiv n
+    have hEq :
+        X' = Matrix.reindex e.symm e.symm
+          (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ)) := by
       ext ip jq
-      by_cases h00 : ip.2 = 0 ∧ jq.2 = 0
-      · have hswap : jq.2 = 0 ∧ ip.2 = 0 := ⟨h00.2, h00.1⟩
-        have hherm := congr_fun (congr_fun hX.1 ip.1) jq.1
-        simpa [X', h00, hswap, Matrix.conjTranspose_apply] using hherm
-      · by_cases hswap : jq.2 = 0 ∧ ip.2 = 0
-        · exfalso
-          exact h00 ⟨hswap.2, hswap.1⟩
-        · simp [X', h00, hswap, Matrix.conjTranspose_apply]
-    · -- Inner product: v†X'v ≥ 0
-      intro v
-      sorry -- TODO (#280): v†X'v = w†Xw where w i = v (i, 0), then use hX
+      rcases ip with ⟨i, a⟩
+      rcases jq with ⟨j, b⟩
+      fin_cases a <;> fin_cases b <;> simp [Matrix.reindex_apply, X', e]
+    rw [hEq]
+    exact posSemidef_reindex
+      (posSemidef_fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))) e.symm
   -- Apply 2-positivity to X'
   have hY' := h X' hX'
   -- The (0,0)-block of the result is E(X), which is PSD as a principal submatrix
@@ -223,15 +457,48 @@ theorem kadison_schwarz_2positive
     (h_unital : KadisonSchwarz.IsUnitalMap E)
     (X : Matrix n n ℂ) :
     (E (Xᴴ * X) - (E X)ᴴ * E X).PosSemidef := by
-  -- The proof follows the same Schur complement argument as kadison_schwarz,
-  -- but using 2-positivity instead of Kraus operators.
-  --
-  -- Step 1: The 2×2 block matrix P = [[X†X, X†], [X, I]] is PSD.
-  -- Step 2: Apply E ⊗ id₂ (which preserves PSD-ness by 2-positivity).
-  -- Step 3: The result is [[E(X†X), E(X)†], [E(X), I]] (using unitality for the (2,2) block).
-  -- Step 4: Schur complement: E(X†X) - E(X)† · I⁻¹ · E(X) ≥ 0.
-  -- TODO (#22): factor out Schur complement step from KadisonSchwarz.lean and reuse
-  sorry
+  let e := finTwoBlockEquiv n
+  let P : Matrix (n ⊕ n) (n ⊕ n) ℂ :=
+    Matrix.fromBlocks (Xᴴ * X) Xᴴ X 1
+  have hP : P.PosSemidef := by
+    let A : Matrix (n ⊕ n) (n ⊕ Fin 0) ℂ :=
+      Matrix.fromBlocks Xᴴ 0 1 0
+    simpa [A, P, Matrix.fromBlocks_multiply, Matrix.fromBlocks_conjTranspose]
+      using Matrix.posSemidef_self_mul_conjTranspose A
+  let P' : Matrix (n × Fin 2) (n × Fin 2) ℂ := Matrix.reindex e.symm e.symm P
+  have hP' : P'.PosSemidef := posSemidef_reindex hP e.symm
+  have hY' := h2pos P' hP'
+  have hPos : IsPositiveMap E := h2pos.isPositiveMap
+  have hBlock :
+      Matrix.reindex e e
+        (Matrix.of fun (ip : n × Fin 2) (jq : n × Fin 2) =>
+          (E (Matrix.of fun i j => P' (i, ip.2) (j, jq.2))) ip.1 jq.1) =
+        Matrix.fromBlocks (E (Xᴴ * X)) ((E X)ᴴ)
+          (((E X)ᴴ)ᴴ) (1 : Matrix n n ℂ) := by
+    ext ip jq
+    rcases ip with i | i <;> rcases jq with j | j
+    · change E (Matrix.of fun i' j' => (Xᴴ * X) i' j') i j = E (Xᴴ * X) i j
+      rfl
+    · change E (Matrix.of fun i' j' => (starRingEnd ℂ) (X j' i')) i j = (starRingEnd ℂ) (E X j i)
+      rw [show (Matrix.of fun i' j' => (starRingEnd ℂ) (X j' i')) = Xᴴ by
+        ext a b
+        rfl]
+      simpa [Matrix.conjTranspose_apply] using
+        congr_fun (congr_fun (IsPositiveMap.map_conjTranspose' hPos X) i) j
+    · have hId : (Matrix.of fun i' j' => X i' j') = X := by
+        ext a b
+        rfl
+      simp [Matrix.reindex_apply, P', P, e, hId]
+    · change E (Matrix.of fun i' j' => (1 : Matrix n n ℂ) i' j') i j = (1 : Matrix n n ℂ) i j
+      simpa [KadisonSchwarz.IsUnitalMap] using congr_fun (congr_fun h_unital i) j
+  have hBlockPsD :
+      (Matrix.fromBlocks (E (Xᴴ * X)) ((E X)ᴴ)
+        (((E X)ᴴ)ᴴ) (1 : Matrix n n ℂ)).PosSemidef := by
+    simpa [hBlock] using posSemidef_reindex hY' e
+  haveI : Invertible (1 : Matrix n n ℂ) := invertibleOne
+  simpa [inv_one, Matrix.mul_assoc, conjTranspose_conjTranspose] using
+    (Matrix.PosDef.fromBlocks₂₂ (A := E (Xᴴ * X)) (B := (E X)ᴴ)
+      (D := (1 : Matrix n n ℂ)) Matrix.PosDef.one).1 hBlockPsD
 
 /-- **Placeholder**: once `kadison_schwarz_2positive` is proved, the existing
 Kraus-based KS inequality becomes a corollary via:

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -126,18 +126,27 @@ theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k :
       else 0
   -- X' is PSD: for any v, v†X'v = w†Xw where w is the restriction of v
   have hX' : X'.PosSemidef := by
-    constructor
-    · intro ip jq
-      simp only [X', Matrix.of_apply, Matrix.conjTranspose_apply, starRingEnd_apply]
-      split <;> split <;> simp_all [hX.1]
+    refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
+    · ext ip jq
+      by_cases hip : ip.2.val < k
+      · by_cases hjq : jq.2.val < k
+        · have hherm :=
+            congr_fun (congr_fun hX.1 (ip.1, ⟨ip.2.val, hip⟩)) (jq.1, ⟨jq.2.val, hjq⟩)
+          simpa [X', hip, hjq, Matrix.conjTranspose_apply] using hherm
+        · simp [X', hip, hjq, Matrix.conjTranspose_apply]
+      · by_cases hjq : jq.2.val < k
+        · simp [X', hip, hjq, Matrix.conjTranspose_apply]
+        · simp [X', hip, hjq, Matrix.conjTranspose_apply]
     · intro v
-      simp only [X', Matrix.of_apply, Matrix.dotProduct, Matrix.mulVec,
-        Finset.sum_apply]
+      simp only [X', Matrix.of_apply, dotProduct, Matrix.mulVec]
       sorry -- TODO (#280): inner product calculation for padded matrix
   -- Apply (k+1)-positivity
   have hY' := h X' hX'
   -- Extract the k-block from the result
-  sorry -- TODO (#280): extract principal submatrix from ampliation result
+  let emb : n × Fin k → n × Fin (k + 1) := fun ip => (ip.1, Fin.castSucc ip.2)
+  convert hY'.submatrix emb using 1
+  ext ip jq
+  simp [emb, X']
 
 /-- CP maps are 2-positive. -/
 theorem IsCPMap.is2PositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
@@ -157,23 +166,25 @@ theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n 
     Matrix.of fun ip jq =>
       if ip.2 = 0 ∧ jq.2 = 0 then X ip.1 jq.1 else 0
   have hX' : X'.PosSemidef := by
-    constructor
+    refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
     · -- Hermiticity: X'ᴴ = X'
-      intro ip jq
-      simp only [X', Matrix.of_apply, Matrix.conjTranspose_apply, starRingEnd_apply]
-      split
-      · next h => rw [h.1, h.2]; simp [hX.1]
-      · next h₁ =>
-        split
-        · next h₂ => simp only [star_zero]; rw [h₂.1, h₂.2] at h₁; exact absurd ⟨h₂.2, h₂.1⟩ h₁
-        · simp [star_zero]
+      ext ip jq
+      by_cases h00 : ip.2 = 0 ∧ jq.2 = 0
+      · have hswap : jq.2 = 0 ∧ ip.2 = 0 := ⟨h00.2, h00.1⟩
+        have hherm := congr_fun (congr_fun hX.1 ip.1) jq.1
+        simpa [X', h00, hswap, Matrix.conjTranspose_apply] using hherm
+      · by_cases hswap : jq.2 = 0 ∧ ip.2 = 0
+        · exfalso
+          exact h00 ⟨hswap.2, hswap.1⟩
+        · simp [X', h00, hswap, Matrix.conjTranspose_apply]
     · -- Inner product: v†X'v ≥ 0
       intro v
       sorry -- TODO (#280): v†X'v = w†Xw where w i = v (i, 0), then use hX
   -- Apply 2-positivity to X'
   have hY' := h X' hX'
   -- The (0,0)-block of the result is E(X), which is PSD as a principal submatrix
-  sorry -- TODO (#280): extract E(X) as principal submatrix of PSD ampliation
+  let emb : n → n × Fin 2 := fun i => (i, 0)
+  simpa [emb, X'] using hY'.submatrix emb
 
 /-! ## Kadison–Schwarz for 2-positive maps -/
 

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -330,12 +330,6 @@ theorem kadison_schwarz_2positive
     rw [show (1 : Fin 2) = Fin.last 1 by rfl]
     rw [finSumFinEquiv_symm_last]
     simp
-  have he_symm_left (i : n) : e.symm (Sum.inl i) = (i, 0) := by
-    apply e.injective
-    simp [he_zero]
-  have he_symm_right (i : n) : e.symm (Sum.inr i) = (i, 1) := by
-    apply e.injective
-    simp [he_one]
   let P : Matrix (n ⊕ n) (n ⊕ n) ℂ :=
     Matrix.fromBlocks (Xᴴ * X) Xᴴ X 1
   have hP : P.PosSemidef := by
@@ -401,6 +395,6 @@ theorem kadison_schwarz_from_2positive
     (X : Matrix (Fin D) (Fin D) ℂ) :
     (KadisonSchwarz.krausMap K (Xᴴ * X) -
       (KadisonSchwarz.krausMap K X)ᴴ * KadisonSchwarz.krausMap K X).PosSemidef :=
-  -- TODO (#22): reroute through kadison_schwarz_2positive once it's proved.
-  -- For now, use the existing direct Kraus-based proof.
+  -- TODO (#22): reroute through kadison_schwarz_2positive via
+  -- IsCPMap → Is2PositiveMap → kadison_schwarz_2positive.
   KadisonSchwarz.kadison_schwarz K h_unital X

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -127,7 +127,6 @@ and `E ⊗ id_k` applied to a PSD matrix yields a PSD matrix (by the same
 Kraus-based argument as `IsCPMap.isPositiveMap`). -/
 theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (hCP : IsCPMap E) (k : ℕ) : IsNPositiveMap k E := by
-  classical
   intro X hX
   obtain ⟨r, K, hK⟩ := hCP
   let e : n × Fin k ≃ Fin k × n := Equiv.prodComm n (Fin k)
@@ -278,7 +277,7 @@ is PSD. The Schur complement of the (2,2)-block `I` gives the result.
 
 This is exactly the same argument as in `KadisonSchwarz.lean`, but the
 hypothesis is weakened from "Kraus representation exists" to "2-positive". -/
-  theorem kadison_schwarz_2positive
+theorem kadison_schwarz_2positive
     (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ)
     (h2pos : Is2PositiveMap E)
     (h_unital : KadisonSchwarz.IsUnitalMap E)

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -65,43 +65,29 @@ open Matrix Finset
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
-attribute [local instance] Matrix.instL2OpNormedAddCommGroup
-attribute [local instance] Matrix.instL2OpNormedRing
-attribute [local instance] Matrix.instL2OpNormedAlgebra
+private noncomputable def finTwoSumEquiv (α : Type*) : α × Fin 2 ≃ α ⊕ α :=
+  (((Equiv.prodCongr (Equiv.refl α)
+      ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm)).trans
+    (Equiv.prodSumDistrib α (Fin 1) (Fin 1))).trans
+    (Equiv.sumCongr (Equiv.prodUnique α (Fin 1)) (Equiv.prodUnique α (Fin 1))))
 
-noncomputable local instance matrixCStarAlgebra (m : Type*) [Fintype m] [DecidableEq m] :
-    CStarAlgebra (Matrix m m ℂ) where
-  toNormedRing := Matrix.instL2OpNormedRing
-  toStarRing := inferInstance
-  toCompleteSpace := inferInstance
-  toCStarRing := Matrix.instCStarRing
-  toNormedAlgebra := Matrix.instL2OpNormedAlgebra
-  toStarModule := inferInstance
+@[simp] private theorem finTwoSumEquiv_apply_zero {α : Type*} (a : α) :
+    finTwoSumEquiv α (a, 0) = Sum.inl a := by
+  change Sum.map Prod.fst Prod.fst
+      ((Equiv.prodSumDistrib α (Fin 1) (Fin 1))
+        (a, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 0))) = Sum.inl a
+  rw [show (0 : Fin 2) = Fin.castSucc (0 : Fin 1) by rfl]
+  rw [finSumFinEquiv_symm_apply_castSucc]
+  simp
 
-private lemma posSemidef_fromBlocks_diag {m o : Type*}
-    [Fintype m] [Fintype o] [DecidableEq m] [DecidableEq o]
-    {A : Matrix m m ℂ} {D : Matrix o o ℂ}
-    (hA : A.PosSemidef) (hD : D.PosSemidef) :
-    (Matrix.fromBlocks A 0 0 D : Matrix (m ⊕ o) (m ⊕ o) ℂ).PosSemidef := by
-  obtain ⟨CA, hCA⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
-    ((Matrix.nonneg_iff_posSemidef).mpr hA)
-  obtain ⟨CD, hCD⟩ := CStarAlgebra.nonneg_iff_eq_mul_star_self.mp
-    ((Matrix.nonneg_iff_posSemidef).mpr hD)
-  have hCA' : A = CA * CAᴴ := by
-    simpa [Matrix.star_eq_conjTranspose] using hCA
-  have hCD' : D = CD * CDᴴ := by
-    simpa [Matrix.star_eq_conjTranspose] using hCD
-  let C : Matrix (m ⊕ o) (m ⊕ o) ℂ := Matrix.fromBlocks CA 0 0 CD
-  have hC : Matrix.fromBlocks A 0 0 D = C * Cᴴ := by
-    simp [C, hCA', hCD', Matrix.fromBlocks_multiply, Matrix.fromBlocks_conjTranspose]
-  rw [hC]
-  exact Matrix.posSemidef_self_mul_conjTranspose C
-
-private lemma posSemidef_reindex {m o : Type*}
-    [Fintype m] [Fintype o] {M : Matrix m m ℂ}
-    (hM : M.PosSemidef) (e : m ≃ o) :
-    (Matrix.reindex e e M).PosSemidef := by
-  simpa [Matrix.reindex_apply] using hM.submatrix e.symm
+@[simp] private theorem finTwoSumEquiv_apply_one {α : Type*} (a : α) :
+    finTwoSumEquiv α (a, 1) = Sum.inr a := by
+  change Sum.map Prod.fst Prod.fst
+      ((Equiv.prodSumDistrib α (Fin 1) (Fin 1))
+        (a, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 1))) = Sum.inr a
+  rw [show (1 : Fin 2) = Fin.last 1 by rfl]
+  rw [finSumFinEquiv_symm_last]
+  simp
 
 /-! ## Definitions of n-positivity -/
 
@@ -146,7 +132,7 @@ theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
   obtain ⟨r, K, hK⟩ := hCP
   let e : n × Fin k ≃ Fin k × n := Equiv.prodComm n (Fin k)
   let Xswap : Matrix (Fin k × n) (Fin k × n) ℂ := Matrix.reindex e e X
-  have hXswap : Xswap.PosSemidef := posSemidef_reindex hX e
+  have hXswap : Xswap.PosSemidef := hX.reindex e
   let Xblk : Matrix (Fin k) (Fin k) (Matrix n n ℂ) :=
     (Matrix.compRingEquiv (Fin k) n ℂ).symm Xswap
   let D : Fin r → Matrix (Fin k) (Fin k) (Matrix n n ℂ) :=
@@ -194,7 +180,7 @@ theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
       Xblk p q = Matrix.of fun i j => X (i, p) (j, q) := by
     ext i j
     simp [Xblk, Xswap, e, Matrix.reindex_apply]
-  convert posSemidef_reindex hYswap e.symm using 1
+  convert hYswap.reindex e.symm using 1
   ext ip jq
   rw [hYblk]
   simp only [of_apply, Matrix.reindex_apply, Equiv.symm_symm, Matrix.submatrix_apply]
@@ -225,8 +211,8 @@ theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k :
     rw [finSumFinEquiv_symm_apply_castSucc]
     simp
   have hX' : X'.PosSemidef := by
-    exact posSemidef_reindex
-      (posSemidef_fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))) e.symm
+    exact (Matrix.PosSemidef.fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))).reindex
+      e.symm
   -- Apply (k+1)-positivity
   have hY' := h X' hX'
   -- Extract the k-block from the result
@@ -249,28 +235,17 @@ theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n 
     (h : Is2PositiveMap E) : IsPositiveMap E := by
   intro X hX
   let e : n × Fin 2 ≃ n ⊕ n :=
-    (((Equiv.prodCongr (Equiv.refl n)
-        ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm)).trans
-      (Equiv.prodSumDistrib n (Fin 1) (Fin 1))).trans
-      (Equiv.sumCongr (Equiv.prodUnique n (Fin 1)) (Equiv.prodUnique n (Fin 1))))
+    finTwoSumEquiv n
   let X' : Matrix (n × Fin 2) (n × Fin 2) ℂ :=
     Matrix.reindex e.symm e.symm (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ))
-  have he_zero (i : n) : e (i, 0) = Sum.inl i := by
-    change Sum.map Prod.fst Prod.fst
-        ((Equiv.prodSumDistrib n (Fin 1) (Fin 1))
-          (i, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 0))) =
-        Sum.inl i
-    rw [show (0 : Fin 2) = Fin.castSucc (0 : Fin 1) by rfl]
-    rw [finSumFinEquiv_symm_apply_castSucc]
-    simp
   have hX' : X'.PosSemidef := by
-    exact posSemidef_reindex
-      (posSemidef_fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))) e.symm
+    exact (Matrix.PosSemidef.fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))).reindex
+      e.symm
   -- Apply 2-positivity to X'
   have hY' := h X' hX'
   -- The (0,0)-block of the result is E(X), which is PSD as a principal submatrix
   let emb : n → n × Fin 2 := fun i => (i, 0)
-  simpa [emb, X', Matrix.reindex_apply, he_zero] using hY'.submatrix emb
+  simpa [emb, X', Matrix.reindex_apply] using hY'.submatrix emb
 
 /-! ## Kadison–Schwarz for 2-positive maps -/
 
@@ -303,33 +278,13 @@ is PSD. The Schur complement of the (2,2)-block `I` gives the result.
 
 This is exactly the same argument as in `KadisonSchwarz.lean`, but the
 hypothesis is weakened from "Kraus representation exists" to "2-positive". -/
-theorem kadison_schwarz_2positive
+  theorem kadison_schwarz_2positive
     (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ)
     (h2pos : Is2PositiveMap E)
     (h_unital : KadisonSchwarz.IsUnitalMap E)
     (X : Matrix n n ℂ) :
     (E (Xᴴ * X) - (E X)ᴴ * E X).PosSemidef := by
-  let e : n × Fin 2 ≃ n ⊕ n :=
-    (((Equiv.prodCongr (Equiv.refl n)
-        ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm)).trans
-      (Equiv.prodSumDistrib n (Fin 1) (Fin 1))).trans
-      (Equiv.sumCongr (Equiv.prodUnique n (Fin 1)) (Equiv.prodUnique n (Fin 1))))
-  have he_zero (i : n) : e (i, 0) = Sum.inl i := by
-    change Sum.map Prod.fst Prod.fst
-        ((Equiv.prodSumDistrib n (Fin 1) (Fin 1))
-          (i, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 0))) =
-        Sum.inl i
-    rw [show (0 : Fin 2) = Fin.castSucc (0 : Fin 1) by rfl]
-    rw [finSumFinEquiv_symm_apply_castSucc]
-    simp
-  have he_one (i : n) : e (i, 1) = Sum.inr i := by
-    change Sum.map Prod.fst Prod.fst
-        ((Equiv.prodSumDistrib n (Fin 1) (Fin 1))
-          (i, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 1))) =
-        Sum.inr i
-    rw [show (1 : Fin 2) = Fin.last 1 by rfl]
-    rw [finSumFinEquiv_symm_last]
-    simp
+  let e : n × Fin 2 ≃ n ⊕ n := finTwoSumEquiv n
   let P : Matrix (n ⊕ n) (n ⊕ n) ℂ :=
     Matrix.fromBlocks (Xᴴ * X) Xᴴ X 1
   have hP : P.PosSemidef := by
@@ -338,7 +293,7 @@ theorem kadison_schwarz_2positive
     simpa [A, P, Matrix.fromBlocks_multiply, Matrix.fromBlocks_conjTranspose]
       using Matrix.posSemidef_self_mul_conjTranspose A
   let P' : Matrix (n × Fin 2) (n × Fin 2) ℂ := Matrix.reindex e.symm e.symm P
-  have hP' : P'.PosSemidef := posSemidef_reindex hP e.symm
+  have hP' : P'.PosSemidef := hP.reindex e.symm
   have hY' := h2pos P' hP'
   have hPos : IsPositiveMap E := h2pos.isPositiveMap
   have hBlock :
@@ -353,30 +308,30 @@ theorem kadison_schwarz_2positive
       change E (Matrix.of fun i' j' => P' (i', 0) (j', 0)) i j = E (Xᴴ * X) i j
       rw [show (Matrix.of fun i' j' => P' (i', 0) (j', 0)) = Xᴴ * X by
         ext a b
-        simp [P', Matrix.reindex_apply, P, he_zero]]
+        simp [P', Matrix.reindex_apply, P, e]]
     · simp only [Matrix.reindex_apply]
       change E (Matrix.of fun i' j' => P' (i', 0) (j', 1)) i j = (starRingEnd ℂ) (E X j i)
       rw [show (Matrix.of fun i' j' => P' (i', 0) (j', 1)) = Xᴴ by
         ext a b
-        simp [P', Matrix.reindex_apply, P, he_zero, he_one]]
+        simp [P', Matrix.reindex_apply, P, e]]
       simpa [Matrix.conjTranspose_apply] using
         congr_fun (congr_fun (IsPositiveMap.map_conjTranspose hPos X) i) j
     · simp only [Matrix.reindex_apply]
       change E (Matrix.of fun i' j' => P' (i', 1) (j', 0)) i j = (((E X)ᴴ)ᴴ) i j
       rw [show (Matrix.of fun i' j' => P' (i', 1) (j', 0)) = X by
         ext a b
-        simp [P', Matrix.reindex_apply, P, he_one, he_zero]]
+        simp [P', Matrix.reindex_apply, P, e]]
       simp [Matrix.conjTranspose_apply]
     · simp only [Matrix.reindex_apply]
       change E (Matrix.of fun i' j' => P' (i', 1) (j', 1)) i j = (1 : Matrix n n ℂ) i j
       rw [show (Matrix.of fun i' j' => P' (i', 1) (j', 1)) = (1 : Matrix n n ℂ) by
         ext a b
-        simp [P', Matrix.reindex_apply, P, he_one]]
+        simp [P', Matrix.reindex_apply, P, e]]
       simpa [KadisonSchwarz.IsUnitalMap] using congr_fun (congr_fun h_unital i) j
   have hBlockPsD :
       (Matrix.fromBlocks (E (Xᴴ * X)) ((E X)ᴴ)
         (((E X)ᴴ)ᴴ) (1 : Matrix n n ℂ)).PosSemidef := by
-    simpa [hBlock] using posSemidef_reindex hY' e
+    simpa [hBlock] using hY'.reindex e
   haveI : Invertible (1 : Matrix n n ℂ) := invertibleOne
   simpa [inv_one, Matrix.mul_assoc, conjTranspose_conjTranspose] using
     (Matrix.PosDef.fromBlocks₂₂ (A := E (Xᴴ * X)) (B := (E X)ᴴ)

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -161,47 +161,6 @@ private noncomputable def finTwoBlockEquiv (α : Type*) : α × Fin 2 ≃ α ⊕
   apply (finTwoBlockEquiv α).injective
   simp
 
-private theorem IsPositiveMap.map_conjTranspose'
-    {m : Type*} [Fintype m] [DecidableEq m]
-    {T : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ} (hT : IsPositiveMap T) (A : Matrix m m ℂ) :
-    T Aᴴ = (T A)ᴴ := by
-  let B : Matrix m m ℂ := (1 / 2 : ℝ) • (A + Aᴴ)
-  let C : Matrix m m ℂ := (1 / 2 : ℝ) • (Complex.I • (Aᴴ - A))
-  have hB : B.IsHermitian := by
-    ext i j
-    simp [B, add_comm]
-  have hC : C.IsHermitian := by
-    ext i j
-    simp [C, sub_eq_add_neg, add_comm]
-  have hmulI (z : ℂ) : Complex.I * ((2 : ℂ)⁻¹ * (Complex.I * z)) = -((2 : ℂ)⁻¹ * z) := by
-    calc
-      Complex.I * ((2 : ℂ)⁻¹ * (Complex.I * z)) = (Complex.I * Complex.I) * ((2 : ℂ)⁻¹ * z) := by
-        ring
-      _ = -((2 : ℂ)⁻¹ * z) := by norm_num [Complex.I_sq]
-  have hIC : Complex.I • C = (1 / 2 : ℝ) • (A - Aᴴ) := by
-    ext i j
-    simp [C, sub_eq_add_neg, mul_add, hmulI, add_comm]
-  have hNegIC : -(Complex.I • C) = (1 / 2 : ℝ) • (Aᴴ - A) := by
-    ext i j
-    simp [C, sub_eq_add_neg, hmulI, add_comm]
-  have hA_decomp : A = B + Complex.I • C := by
-    rw [hIC]
-    ext i j
-    simp [B, sub_eq_add_neg]
-    ring
-  have hAstar_decomp : Aᴴ = B - Complex.I • C := by
-    rw [sub_eq_add_neg, hNegIC]
-    ext i j
-    simp [B, sub_eq_add_neg]
-    ring
-  have hTB : (T B).IsHermitian := hT.map_isHermitian hB
-  have hTC : (T C).IsHermitian := hT.map_isHermitian hC
-  have hTA_decomp : T A = T B + Complex.I • T C := by
-    rw [hA_decomp]
-    simp
-  rw [hAstar_decomp, hTA_decomp]
-  simp [sub_eq_add_neg, hTB.eq, hTC.eq, Matrix.conjTranspose_add, Matrix.conjTranspose_smul]
-
 /-! ## Definitions of n-positivity -/
 
 /-- A linear map `E : M_n(ℂ) → M_n(ℂ)` is **k-positive** if the ampliation
@@ -484,7 +443,7 @@ theorem kadison_schwarz_2positive
         ext a b
         rfl]
       simpa [Matrix.conjTranspose_apply] using
-        congr_fun (congr_fun (IsPositiveMap.map_conjTranspose' hPos X) i) j
+        congr_fun (congr_fun (IsPositiveMap.map_conjTranspose hPos X) i) j
     · have hId : (Matrix.of fun i' j' => X i' j') = X := by
         ext a b
         rfl


### PR DESCRIPTION
### Motivation

- Continues discharging `sorry` stubs from PR LionSR/TNLean#270, as tracked in LionSR/TNLean#280
- Structures the proofs for n-positivity monotonicity and the 2-positive → positive implication (Wolf Ch5, Kadison 1952, Choi 1974)

### Description

- **`TNLean/Channel/Schwarz/TwoPositive.lean`**: replace two top-level `sorry`s with structured proof scaffolding
  - `IsNPositiveMap.mono`: embeds a `k`-block matrix into the `(k+1)`-indexed space by zero-padding, proves Hermiticity, and sets up applying `(k+1)`-positivity before extracting the principal `k`-submatrix
  - `Is2PositiveMap.isPositiveMap`: embeds a PSD matrix as the `(0,0)` block of a 2×2 block matrix, proves Hermiticity, applies 2-positivity
- Remaining `sorry` stubs are isolated to inner product calculations and submatrix PSD extraction steps

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build
- Remaining `sorry` stubs are expected; proof obligations are well-scoped

---
Addresses LionSR/TNLean#280

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: adds new noncomputable matrix `CStarAlgebra` instances and refactors positivity lemmas to more generic index types, which may affect typeclass resolution and downstream proofs even though changes are theorem-level.
> 
> **Overview**
> **Extends the Schwarz/positivity toolkit and discharges key `sorry`s in the n-positivity hierarchy.**
> 
> Adds `PositiveMapProperties` support for arbitrary finite matrix index types (not just `Fin D`), including `IsPositiveMap.map_le_map`, `IsPositiveMap.map_conjTranspose`, and a reusable lemma `Matrix.PosSemidef.fromBlocks_diag` for PSD block-diagonals.
> 
> In `TwoPositive.lean`, replaces previous stubs with concrete proofs that CP implies `IsNPositiveMap`, that `(k+1)`-positivity implies `k`-positivity (`IsNPositiveMap.mono`), that 2-positivity implies positivity, and provides a full proof of `kadison_schwarz_2positive` via a 2×2 block PSD argument and Schur complement.
> 
> Updates `SchwarzSubnormal.lean` to import `PositiveMapProperties`, delete local duplicate lemmas, and use Mathlib’s `Matrix.conjTranspose_reindex`/principal-submatrix facts in the reindexing steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67eac71d4921765bb98067db0bb75c16e23874a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->