### PR TITLE
ci: use custom token for auto-fix pushes to trigger review loop

### DIFF
--- a/.github/workflows/_ci-auto-fix-shared.yml
+++ b/.github/workflows/_ci-auto-fix-shared.yml
@@ -59,7 +59,9 @@ jobs:
         with:
           ref: ${{ inputs.head_sha }}
           fetch-depth: 10
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a non-GITHUB_TOKEN so the push triggers pull_request:synchronize,
+          # which re-triggers CI and review workflows for the fix loop.
+          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Attach to PR branch
         run: |

--- a/.github/workflows/pr-review-auto-fix.yml
+++ b/.github/workflows/pr-review-auto-fix.yml
@@ -26,17 +26,39 @@ jobs:
   check-label:
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.pull_requests[0] &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       has_label: ${{ steps.label.outputs.has_label }}
+      pr_number: ${{ steps.find_pr.outputs.pr_number }}
     steps:
+      - name: Find PR number from head branch
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          # workflow_run.pull_requests[] can be empty in many edge cases.
+          # Fall back to searching for an open PR from the head branch.
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::notice::pull_requests array was empty, looking up PR by branch"
+            PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?state=open&head=${{ github.repository_owner }}:${HEAD_BRANCH}&per_page=1" --jq '.[0].number // empty')
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::warning::No open PR found for branch ${HEAD_BRANCH}. Skipping."
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Resolved PR #${PR_NUMBER} for branch ${HEAD_BRANCH}"
+            echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check for auto-fix label
+        if: steps.find_pr.outputs.pr_number != ''
         id: label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
         run: |
           LABELS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.labels[].name')
           if echo "$LABELS" | grep -q '^auto-fix-claude$'; then
@@ -48,7 +70,7 @@ jobs:
 
   auto-fix-review:
     needs: check-label
-    if: needs.check-label.outputs.has_label == 'true'
+    if: needs.check-label.outputs.has_label == 'true' && needs.check-label.outputs.pr_number != ''
     runs-on: ubuntu-latest
 
     steps:
@@ -113,7 +135,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const prNumber = ${{ github.event.workflow_run.pull_requests[0].number }};
+            const prNumber = ${{ needs.check-label.outputs.pr_number }};
             // Use GraphQL to get unresolved review threads with full
             // conversation context (REST API doesn't expose resolved status).
             const query = `query($owner: String!, $repo: String!, $pr: Int!) {
@@ -200,7 +222,7 @@ jobs:
           prompt: |
             The automated code review found issues in this PR. Your task is to fix them.
 
-            PR Number: ${{ github.event.workflow_run.pull_requests[0].number }}
+            PR Number: ${{ needs.check-label.outputs.pr_number }}
             Branch: ${{ github.event.workflow_run.head_branch }}
             Repository: ${{ github.repository }}
             Review-fix iteration: ${{ steps.guard.outputs.next_iteration }} (combined bot-fix cap: ${{ steps.guard.outputs.max_iterations }})

--- a/.github/workflows/pr-review-auto-fix.yml
+++ b/.github/workflows/pr-review-auto-fix.yml
@@ -57,7 +57,9 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 10
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a non-GITHUB_TOKEN so the push triggers pull_request:synchronize,
+          # which re-triggers claude-code-review and continues the fix loop.
+          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Attach to PR branch
         run: |

--- a/.github/workflows/pr-review-auto-fix.yml
+++ b/.github/workflows/pr-review-auto-fix.yml
@@ -26,39 +26,17 @@ jobs:
   check-label:
     if: |
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0] &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       has_label: ${{ steps.label.outputs.has_label }}
-      pr_number: ${{ steps.find_pr.outputs.pr_number }}
     steps:
-      - name: Find PR number from head branch
-        id: find_pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          # workflow_run.pull_requests[] can be empty in many edge cases.
-          # Fall back to searching for an open PR from the head branch.
-          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
-          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
-            echo "::notice::pull_requests array was empty, looking up PR by branch"
-            PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?state=open&head=${{ github.repository_owner }}:${HEAD_BRANCH}&per_page=1" --jq '.[0].number // empty')
-          fi
-          if [ -z "$PR_NUMBER" ]; then
-            echo "::warning::No open PR found for branch ${HEAD_BRANCH}. Skipping."
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Resolved PR #${PR_NUMBER} for branch ${HEAD_BRANCH}"
-            echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Check for auto-fix label
-        if: steps.find_pr.outputs.pr_number != ''
         id: label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           LABELS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.labels[].name')
           if echo "$LABELS" | grep -q '^auto-fix-claude$'; then
@@ -70,7 +48,7 @@ jobs:
 
   auto-fix-review:
     needs: check-label
-    if: needs.check-label.outputs.has_label == 'true' && needs.check-label.outputs.pr_number != ''
+    if: needs.check-label.outputs.has_label == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -135,7 +113,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const prNumber = ${{ needs.check-label.outputs.pr_number }};
+            const prNumber = ${{ github.event.workflow_run.pull_requests[0].number }};
             // Use GraphQL to get unresolved review threads with full
             // conversation context (REST API doesn't expose resolved status).
             const query = `query($owner: String!, $repo: String!, $pr: Int!) {
@@ -222,7 +200,7 @@ jobs:
           prompt: |
             The automated code review found issues in this PR. Your task is to fix them.
 
-            PR Number: ${{ needs.check-label.outputs.pr_number }}
+            PR Number: ${{ github.event.workflow_run.pull_requests[0].number }}
             Branch: ${{ github.event.workflow_run.head_branch }}
             Repository: ${{ github.repository }}
             Review-fix iteration: ${{ steps.guard.outputs.next_iteration }} (combined bot-fix cap: ${{ steps.guard.outputs.max_iterations }})


### PR DESCRIPTION
### Motivation

- The auto-fix workflows use `GITHUB_TOKEN`, which does not trigger `pull_request:synchronize` events when pushing fixes (GitHub anti-recursion policy)
- This prevents CI and review workflows from re-running after fixes are applied, breaking the review→fix→review loop
- Using a custom token (`GH_AW_GITHUB_TOKEN`) allows pushes to properly trigger workflow re-runs

### Description

- `.github/workflows/_ci-auto-fix-shared.yml`: change checkout token to `GH_AW_GITHUB_TOKEN` with fallback to `GITHUB_TOKEN`
- `.github/workflows/pr-review-auto-fix.yml`: change checkout token to `GH_AW_GITHUB_TOKEN` with fallback to `GITHUB_TOKEN`

### Testing

- Relies on CI execution when the custom token is configured in repository secrets to validate fix-loop behavior.

---
*No linked issue found. Author should link one manually if applicable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that alters which token `actions/checkout` uses; behavior depends on the presence/scopes of the new secret and could affect whether pushes trigger downstream workflows.
> 
> **Overview**
> Updates the two auto-fix workflows (shared CI auto-fix and PR review auto-fix) to use `secrets.GH_AW_GITHUB_TOKEN` (with fallback to `secrets.GITHUB_TOKEN`) for `actions/checkout`.
> 
> This is intended to ensure bot pushes from these workflows trigger `pull_request:synchronize`, allowing CI and automated review workflows to re-run and continue the fix loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f4b419ece23a6a81f45280b398f9256b14522ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->