### PR TITLE
ci(claude): auto-create PR when Claude finishes issue work

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -112,9 +112,7 @@ jobs:
           echo "Creating PR from $BRANCH → main for issue #${ISSUE_NUMBER}"
 
           # Create the PR — pr-cleanup.yml will reformat title/body/labels
-          PR_BODY="Addresses #${ISSUE_NUMBER}
-
-          Auto-created by Claude Code action."
+          PR_BODY=$'Addresses #'"${ISSUE_NUMBER}"$'\n\nAuto-created by Claude Code action.'
 
           gh pr create \
             --repo "$REPO" \

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -85,12 +85,12 @@ jobs:
 
           echo "Looking for branches matching claude/issue-${ISSUE_NUMBER}-*"
 
-          # Find the most recently pushed branch for this issue
-          BRANCH=$(git ls-remote --heads origin "refs/heads/claude/issue-${ISSUE_NUMBER}-*" \
-            | awk '{print $2}' \
-            | sed 's|refs/heads/||' \
-            | sort -t'-' -k4 -r \
-            | head -1)
+          # Fetch matching remote refs so we can sort by committer date
+          git fetch origin --no-tags "refs/heads/claude/issue-${ISSUE_NUMBER}-*:refs/remotes/origin/claude/issue-${ISSUE_NUMBER}-*" 2>/dev/null || true
+
+          # Pick the most recently committed branch
+          BRANCH=$(git for-each-ref --sort=-committerdate --format='%(refname:lstrip=3)' \
+            "refs/remotes/origin/claude/issue-${ISSUE_NUMBER}-*" | head -1)
 
           if [ -z "$BRANCH" ]; then
             echo "No branch found for issue #${ISSUE_NUMBER} — Claude likely just replied without code changes."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -68,3 +68,59 @@ jobs:
             --model claude-opus-4-6
             --allowedTools "Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(gh pr:*),Bash(gh issue:*),Bash(leanblueprint *),mcp__github__*"
             --append-system-prompt "This is a Lean 4 / Mathlib repository. Prefer minimal diffs. Use your judgment on when Mathlib scouting is warranted — it is essential when writing new proofs, closing sorrys, or choosing proof strategies, but unnecessary for cosmetic fixes, docstrings, imports, or renaming. When scouting IS warranted: first read all comments on the issue/PR for existing Mathlib Scouting Reports, then scout Mathlib yourself using exact?, apply?, rw?, simp?, and by grepping Mathlib source files (.lake/packages/mathlib/Mathlib/) for related definitions and theorems. Reuse Mathlib lemmas wherever possible rather than reproving from scratch. If someone explicitly asks you to scout, or if the task has shifted enough that an earlier scouting report may be stale, do a fresh scout and post a new Mathlib Scouting Report comment with sections: Relevant Mathlib definitions, Relevant Mathlib lemmas/theorems, Relevant TNLean definitions, Suggested approach, and Gaps to fill. Before changing theorem statements, first try to complete the proof using existing lemmas. Validate with: lake build. Do not leave unrelated new sorrys. After substantial proof work, include a Mathlib Audit section in your comment listing which Mathlib lemmas/definitions you used or discovered (name, module path, and how it was used). Skip the audit for trivial changes. Always read existing review threads on the PR for context before responding. Reply directly to the review thread that triggered you. Do NOT resolve review threads yourself — leave resolution to humans or the automated review workflow."
+
+      - name: Auto-create PR for completed issue work
+        # Only run for issue events (not PR comments), and only if Claude succeeded
+        if: |
+          always() &&
+          steps.claude.outcome == 'success' &&
+          (github.event_name == 'issues' ||
+           (github.event_name == 'issue_comment' && !github.event.issue.pull_request))
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          echo "Looking for branches matching claude/issue-${ISSUE_NUMBER}-*"
+
+          # Find the most recently pushed branch for this issue
+          BRANCH=$(git ls-remote --heads origin "refs/heads/claude/issue-${ISSUE_NUMBER}-*" \
+            | awk '{print $2}' \
+            | sed 's|refs/heads/||' \
+            | sort -t'-' -k4 -r \
+            | head -1)
+
+          if [ -z "$BRANCH" ]; then
+            echo "No branch found for issue #${ISSUE_NUMBER} — Claude likely just replied without code changes."
+            exit 0
+          fi
+
+          echo "Found branch: $BRANCH"
+
+          # Check if a PR already exists for this branch
+          EXISTING=$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "PR already exists for branch $BRANCH — skipping."
+            exit 0
+          fi
+
+          # Get issue title for the PR
+          ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title')
+
+          echo "Creating PR from $BRANCH → main for issue #${ISSUE_NUMBER}"
+
+          # Create the PR — pr-cleanup.yml will reformat title/body/labels
+          PR_BODY="Addresses #${ISSUE_NUMBER}
+
+          Auto-created by Claude Code action."
+
+          gh pr create \
+            --repo "$REPO" \
+            --head "$BRANCH" \
+            --base main \
+            --title "feat: ${ISSUE_TITLE}" \
+            --body "$PR_BODY"
+
+          echo "PR created successfully."


### PR DESCRIPTION
### Motivation

- Enable automated PR creation when Claude successfully completes work on an issue
- Reduce manual overhead of creating PRs for Claude-generated code changes
- Ensure Claude's work flows seamlessly from issue resolution to PR review

### Description

- Modified `.github/workflows/claude.yml` to add a new post-step that auto-creates a PR when Claude finishes issue work
- Searches for branches matching `claude/issue-{ISSUE_NUMBER}-*` and selects the most recently pushed branch
- Checks if a PR already exists for that branch to avoid duplicates
- Creates a PR titled `feat: {ISSUE_TITLE}` referencing the original issue, then defers to `pr-cleanup.yml` for metadata formatting
- Step is idempotent (skips if PR exists) and graceful (skips if no branch was pushed)

### Testing

- Workflow step includes guards: only runs on `steps.claude.outcome == 'success'`, only for issue events (not PR comments)
- Gracefully exits if no branch is found (Claude replied without code changes)
- Skips PR creation if one already exists for the branch
- Uses `set -euo pipefail` for safe shell execution

---
Addresses #158

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI automation that can create branches/PRs via `gh`, so misfires could spam PRs or target the wrong branch. Guardrails are present (issue-only, success-only, skip if no branch/PR exists) but behavior changes repo-wide.
> 
> **Overview**
> After Claude completes work triggered by an issue, the workflow now **auto-creates a PR** from the most recent `claude/issue-${ISSUE_NUMBER}-*` branch to `main`.
> 
> The new step fetches matching remote branches, skips when no branch or an existing PR is found, and otherwise uses `gh pr create` with a title based on the issue title and a body linking `Addresses #${ISSUE_NUMBER}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f07ef4559312b779aca30cb4b17b09943eb2be0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->