### PR TITLE
ci(workflows): use BOT_PAT token with GITHUB_TOKEN fallback

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -77,7 +77,7 @@ jobs:
           (github.event_name == 'issues' ||
            (github.event_name == 'issue_comment' && !github.event.issue.pull_request))
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_PAT || github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/pr-review-auto-fix.yml
+++ b/.github/workflows/pr-review-auto-fix.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check for auto-fix label
         id: label
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           LABELS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.labels[].name')
@@ -57,7 +57,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 10
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Attach to PR branch
         run: |


### PR DESCRIPTION
### Motivation

- Enable workflows to use a bot personal access token (BOT_PAT) when available, so that pushes and PR creations re-trigger downstream workflows (GITHUB_TOKEN events are silently ignored by GitHub)
- Maintain backward compatibility by falling back to GITHUB_TOKEN if BOT_PAT is not configured

### Description

- `.github/workflows/pr-review-auto-fix.yml`: update `GH_TOKEN` and `token` inputs to use `secrets.BOT_PAT || secrets.GITHUB_TOKEN`
- `.github/workflows/claude.yml`: update `GH_TOKEN` environment variable to use `secrets.BOT_PAT || secrets.GITHUB_TOKEN`

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- No functional changes when `BOT_PAT` is unset; existing GITHUB_TOKEN behavior preserved.

---
No linked issue found — author should link one manually if applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change limited to GitHub Actions token selection; behavior should remain the same when `secrets.BOT_PAT` is unset, with only potential impact being permission/rate-limit differences when it is set.
> 
> **Overview**
> Updates GitHub Actions workflows to prefer a dedicated bot PAT when available. Specifically, `claude.yml` and `pr-review-auto-fix.yml` now use `secrets.BOT_PAT` (falling back to the default token) for `GH_TOKEN`/checkout authentication, enabling higher rate limits or broader permissions without breaking repos that don't configure the secret.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff1b33cc1602b1e2540091ae909fc6c029d9d2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->