### PR TITLE
feat(Channel/Schwarz): add operator Jensen inequality and prove Wolf Cor 5.2

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -56,7 +56,9 @@ import TNLean.Axioms.BrouwerFixedPoint
 import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import TNLean.Channel.Schwarz.Douglas
+import TNLean.Channel.Schwarz.OperatorConvexity
 import TNLean.Channel.Schwarz.OperatorMonotone
+import TNLean.Channel.Schwarz.AndoLieb
 import TNLean.Channel.Schwarz.PositiveOnAbelian
 import TNLean.Channel.Schwarz.SchwarzNormal
 import TNLean.Channel.Schwarz.SchwarzSubnormal

--- a/TNLean/Channel/Schwarz/AndoLieb.lean
+++ b/TNLean/Channel/Schwarz/AndoLieb.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.CStarAlgebra.Matrix
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
+import Mathlib.LinearAlgebra.Matrix.Trace
+
+/-!
+# Ando--Lieb theorem and trace convexity/concavity
+
+This file states the Ando--Lieb (Lieb concavity) theorem and its trace
+convexity/concavity consequences for matrix power functions.
+
+## Main results (sorry placeholders)
+
+* `trace_rpow_concaveOn` — `A ↦ Re Tr(A ^ p)` is concave on PSD
+  matrices for `p ∈ [0, 1]`.
+* `trace_rpow_convexOn` — `A ↦ Re Tr(A ^ p)` is convex on PSD
+  matrices for `p ∈ [1, 2]`.
+* `lieb_concavity` — For `s ∈ [0, 1]` and fixed `K`, the map
+  `(A, B) ↦ Tr(K† A^s K B^{1−s})` is jointly concave on PD matrices.
+
+### Status
+
+All results are `sorry` placeholders. The Ando--Lieb theorem is the
+hardest piece in this chapter: it requires the integral representation
+`A^s B^{1-s} = (sin πs / π) ∫₀^∞ t^{s-1} A (A + tB)⁻¹ B dt`
+and resolvent monotonicity, which require new integration infrastructure
+beyond what Mathlib currently provides.
+
+The trace convexity/concavity results can alternatively be derived from
+operator convexity/concavity of `rpow` (see `OperatorConvexity.lean`)
+composed with the linearity of trace.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Ch. 5]
+* [T. Ando, *Concavity of certain maps on positive definite matrices*, 1979]
+* [E. H. Lieb, *Convex trace functions and the Wigner--Yanase--Dyson
+  conjecture*, 1973]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+private local instance : NormedRing Mat := Matrix.instL2OpNormedRing
+private local instance : NormedAlgebra ℂ Mat := Matrix.instL2OpNormedAlgebra
+private local instance : CStarRing Mat := Matrix.instCStarRing
+private local instance : PartialOrder Mat := Matrix.instPartialOrder
+private local instance : StarOrderedRing Mat := Matrix.instStarOrderedRing
+private local instance : NonnegSpectrumClass ℝ Mat :=
+  Matrix.instNonnegSpectrumClass
+private local instance : CStarAlgebra Mat := CStarAlgebra.mk
+
+/-! ## Trace convexity and concavity of matrix powers -/
+
+/-- **Trace concavity of `rpow`** for `p ∈ [0, 1]`.
+
+For PSD matrices `A₁, A₂` and `t ∈ [0, 1]`:
+  `t · Re Tr(A₁ ^ p) + (1 − t) · Re Tr(A₂ ^ p) ≤
+     Re Tr((t • A₁ + (1 − t) • A₂) ^ p)`.
+
+**TODO**: follows from operator concavity of `rpow` (a Mathlib TODO)
+composed with linearity and monotonicity of trace. -/
+theorem trace_rpow_concave
+    {p : ℝ} (hp : p ∈ Set.Icc (0 : ℝ) 1)
+    {A₁ A₂ : Mat} (hA₁ : 0 ≤ A₁) (hA₂ : 0 ≤ A₂)
+    {t : ℝ} (ht : t ∈ Set.Icc (0 : ℝ) 1) :
+    t * (trace (A₁ ^ p)).re + (1 - t) * (trace (A₂ ^ p)).re ≤
+      (trace ((t • A₁ + (1 - t) • A₂) ^ p)).re := by
+  sorry
+
+/-- **Trace convexity of `rpow`** for `p ∈ [1, 2]`.
+
+For PSD matrices `A₁, A₂` and `t ∈ [0, 1]`:
+  `Re Tr((t • A₁ + (1 − t) • A₂) ^ p) ≤
+     t · Re Tr(A₁ ^ p) + (1 − t) · Re Tr(A₂ ^ p)`.
+
+**TODO**: follows from operator convexity of `rpow` (a Mathlib TODO)
+composed with linearity and monotonicity of trace. -/
+theorem trace_rpow_convex
+    {p : ℝ} (hp : p ∈ Set.Icc (1 : ℝ) 2)
+    {A₁ A₂ : Mat} (hA₁ : 0 ≤ A₁) (hA₂ : 0 ≤ A₂)
+    {t : ℝ} (ht : t ∈ Set.Icc (0 : ℝ) 1) :
+    (trace ((t • A₁ + (1 - t) • A₂) ^ p)).re ≤
+      t * (trace (A₁ ^ p)).re + (1 - t) * (trace (A₂ ^ p)).re := by
+  sorry
+
+/-! ## Lieb concavity theorem -/
+
+/-- **Lieb concavity theorem** (Ando--Lieb).
+
+For `s ∈ [0, 1]`, any matrix `K`, and PD matrices `A₁, A₂, B₁, B₂`:
+  `t · Re Tr(K† A₁^s K B₁^{1−s}) + (1 − t) · Re Tr(K† A₂^s K B₂^{1−s}) ≤
+     Re Tr(K† (t A₁ + (1−t) A₂)^s K (t B₁ + (1−t) B₂)^{1−s})`.
+
+This is equivalent to joint concavity of `(A, B) ↦ Tr(K† A^s K B^{1−s})`.
+
+**TODO**: Requires the integral representation of `A^s B^{1−s}` and
+resolvent monotonicity, which are not yet in Mathlib. This is the hardest
+result in Wolf Chapter 5. -/
+theorem lieb_concavity
+    {s : ℝ} (hs : s ∈ Set.Icc (0 : ℝ) 1)
+    {A₁ A₂ B₁ B₂ K : Mat}
+    (hA₁ : A₁.PosDef) (hA₂ : A₂.PosDef)
+    (hB₁ : B₁.PosDef) (hB₂ : B₂.PosDef)
+    {t : ℝ} (ht : t ∈ Set.Icc (0 : ℝ) 1) :
+    t * (trace (Kᴴ * A₁ ^ s * K * B₁ ^ (1 - s))).re +
+      (1 - t) * (trace (Kᴴ * A₂ ^ s * K * B₂ ^ (1 - s))).re ≤
+    (trace (Kᴴ * (t • A₁ + (1 - t) • A₂) ^ s * K *
+      (t • B₁ + (1 - t) • B₂) ^ (1 - s))).re := by
+  sorry
+
+end

--- a/TNLean/Channel/Schwarz/AndoLieb.lean
+++ b/TNLean/Channel/Schwarz/AndoLieb.lean
@@ -15,9 +15,9 @@ convexity/concavity consequences for matrix power functions.
 
 ## Main results (sorry placeholders)
 
-* `trace_rpow_concaveOn` — `A ↦ Re Tr(A ^ p)` is concave on PSD
+* `trace_rpow_concave` — `A ↦ Re Tr(A ^ p)` is concave on PSD
   matrices for `p ∈ [0, 1]`.
-* `trace_rpow_convexOn` — `A ↦ Re Tr(A ^ p)` is convex on PSD
+* `trace_rpow_convex` — `A ↦ Re Tr(A ^ p)` is convex on PSD
   matrices for `p ∈ [1, 2]`.
 * `lieb_concavity` — For `s ∈ [0, 1]` and fixed `K`, the map
   `(A, B) ↦ Tr(K† A^s K B^{1−s})` is jointly concave on PD matrices.
@@ -51,14 +51,20 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-private local instance : NormedRing Mat := Matrix.instL2OpNormedRing
-private local instance : NormedAlgebra ℂ Mat := Matrix.instL2OpNormedAlgebra
-private local instance : CStarRing Mat := Matrix.instCStarRing
-private local instance : PartialOrder Mat := Matrix.instPartialOrder
-private local instance : StarOrderedRing Mat := Matrix.instStarOrderedRing
-private local instance : NonnegSpectrumClass ℝ Mat :=
+private local instance instAndoLiebNormedRing : NormedRing Mat :=
+  Matrix.instL2OpNormedRing
+private local instance instAndoLiebNormedAlgebra : NormedAlgebra ℂ Mat :=
+  Matrix.instL2OpNormedAlgebra
+private local instance instAndoLiebCStarRing : CStarRing Mat :=
+  Matrix.instCStarRing
+private local instance instAndoLiebPartialOrder : PartialOrder Mat :=
+  Matrix.instPartialOrder
+private local instance instAndoLiebStarOrderedRing : StarOrderedRing Mat :=
+  Matrix.instStarOrderedRing
+private local instance instAndoLiebNonnegSpectrumClass : NonnegSpectrumClass ℝ Mat :=
   Matrix.instNonnegSpectrumClass
-private local instance : CStarAlgebra Mat := CStarAlgebra.mk
+private local instance instAndoLiebCStarAlgebra : CStarAlgebra Mat :=
+  CStarAlgebra.mk
 
 /-! ## Trace convexity and concavity of matrix powers -/
 

--- a/TNLean/Channel/Schwarz/OperatorConvexity.lean
+++ b/TNLean/Channel/Schwarz/OperatorConvexity.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Schwarz.PositiveMapProperties
+import Mathlib.Analysis.CStarAlgebra.Matrix
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Order
+
+/-!
+# Operator Jensen inequality for positive subunital maps
+
+This file states the **operator Jensen inequality** (also known as the
+Choi--Davis--Jensen or Hansen--Pedersen inequality) specialized to the
+functions `x ↦ x ^ p` and `log`, for positive subunital maps on matrices.
+
+### Background
+
+A function `f : ℝ → ℝ` is *operator convex* on `s ⊆ ℝ` when, for every
+dimension `n`, all `n × n` Hermitian matrices `A`, `B` with spectra in `s`,
+and every `t ∈ [0, 1]`:
+
+  `f(t A + (1 − t) B) ≤ t f(A) + (1 − t) f(B)`
+
+in the Loewner order, where `f` is applied via the continuous functional
+calculus. *Operator concavity* reverses the inequality.
+
+The **operator Jensen inequality** for a positive subunital map `T`
+(`T(1) ≤ 1`) then says:
+
+* **convex** `f`: `f(T(A)) ≤ T(f(A))`;
+* **concave** `f`: `T(f(A)) ≤ f(T(A))`.
+
+### Status
+
+The three Jensen instances below are `sorry` placeholders. Their proofs
+require:
+
+1. Operator concavity of `x ↦ x ^ p` for `p ∈ [0, 1]` — listed as a
+   Mathlib TODO in `CFC.Rpow.Order`.
+2. Operator convexity of `x ↦ x ^ p` for `p ∈ [1, 2]` — likewise a TODO.
+3. Operator concavity of `log` — listed as a TODO in `CFC.ExpLog.Order`.
+4. The general Jensen inequality for positive maps — absent from Mathlib.
+
+These are consumed by the Corollary 5.2 proofs in `OperatorMonotone.lean`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Thm. 5.1]
+* [F. Hansen, G. K. Pedersen, *Jensen's operator inequality*, 2003]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+private local instance : NormedRing Mat := Matrix.instL2OpNormedRing
+private local instance : NormedAlgebra ℂ Mat := Matrix.instL2OpNormedAlgebra
+private local instance : CStarRing Mat := Matrix.instCStarRing
+private local instance : PartialOrder Mat := Matrix.instPartialOrder
+private local instance : StarOrderedRing Mat := Matrix.instStarOrderedRing
+private local instance : NonnegSpectrumClass ℝ Mat :=
+  Matrix.instNonnegSpectrumClass
+private local instance : CStarAlgebra Mat := CStarAlgebra.mk
+
+/-- **Operator Jensen for concave `rpow`** (Wolf Thm. 5.1 applied to
+`x ↦ x ^ p` for `p ∈ [0, 1]`).
+
+For a positive subunital map `T` and `p ∈ [0, 1]`:
+  `T(A ^ p) ≤ (T A) ^ p`.
+
+This follows from operator concavity of `x ↦ x ^ p` on `[0, ∞)` for
+`p ∈ [0, 1]`, combined with the concave version of the operator Jensen
+inequality for positive subunital maps.
+
+**TODO**: prove operator concavity of `x ↦ x ^ p` for `p ∈ [0, 1]`
+(see Mathlib `CFC.Rpow.Order` TODO) and the general operator Jensen
+inequality for positive maps. -/
+theorem IsPositiveMap.rpow_concave_jensen
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
+    {p : ℝ} (hp : p ∈ Set.Icc (0 : ℝ) 1) {A : Mat} (hA : 0 ≤ A) :
+    T (A ^ p) ≤ (T A) ^ p := by
+  sorry
+
+/-- **Operator Jensen for convex `rpow`** (Wolf Thm. 5.1 applied to
+`x ↦ x ^ p` for `p ∈ [1, 2]`).
+
+For a positive subunital map `T` and `p ∈ [1, 2]`:
+  `(T A) ^ p ≤ T(A ^ p)`.
+
+This follows from operator convexity of `x ↦ x ^ p` on `[0, ∞)` for
+`p ∈ [1, 2]`, combined with the convex version of the operator Jensen
+inequality for positive subunital maps.
+
+**TODO**: prove operator convexity of `x ↦ x ^ p` for `p ∈ [1, 2]`
+(see Mathlib `CFC.Rpow.Order` TODO) and the general operator Jensen
+inequality for positive maps. -/
+theorem IsPositiveMap.rpow_convex_jensen
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
+    {p : ℝ} (hp : p ∈ Set.Icc (1 : ℝ) 2) {A : Mat} (hA : 0 ≤ A) :
+    (T A) ^ p ≤ T (A ^ p) := by
+  sorry
+
+/-- **Operator Jensen for concave `log`** (Wolf Thm. 5.1 applied to `log`).
+
+For a positive subunital map `T` and positive-definite `A`:
+  `T(log A) ≤ log(T A)`.
+
+This follows from operator concavity of `log` on `(0, ∞)`, combined
+with the concave version of the operator Jensen inequality for positive
+subunital maps.
+
+**TODO**: prove operator concavity of `log` (see Mathlib `CFC.ExpLog.Order`
+TODO) and the general operator Jensen inequality for positive maps. -/
+theorem IsPositiveMap.log_concave_jensen
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
+    {A : Mat} (hA : A.PosDef) :
+    T (CFC.log A) ≤ CFC.log (T A) := by
+  sorry
+
+end

--- a/TNLean/Channel/Schwarz/OperatorConvexity.lean
+++ b/TNLean/Channel/Schwarz/OperatorConvexity.lean
@@ -32,6 +32,9 @@ The **operator Jensen inequality** for a positive subunital map `T`
 * **convex** `f`: `f(T(A)) ≤ T(f(A))`;
 * **concave** `f`: `T(f(A)) ≤ f(T(A))`.
 
+Note: the `log` variant requires unitality (`T(1) = 1`), not merely
+subunitality, because `log` is unbounded below.
+
 ### Status
 
 The three Jensen instances below are `sorry` placeholders. Their proofs
@@ -60,14 +63,20 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-private local instance : NormedRing Mat := Matrix.instL2OpNormedRing
-private local instance : NormedAlgebra ℂ Mat := Matrix.instL2OpNormedAlgebra
-private local instance : CStarRing Mat := Matrix.instCStarRing
-private local instance : PartialOrder Mat := Matrix.instPartialOrder
-private local instance : StarOrderedRing Mat := Matrix.instStarOrderedRing
-private local instance : NonnegSpectrumClass ℝ Mat :=
+private local instance instOperatorConvexityNormedRing : NormedRing Mat :=
+  Matrix.instL2OpNormedRing
+private local instance instOperatorConvexityNormedAlgebra : NormedAlgebra ℂ Mat :=
+  Matrix.instL2OpNormedAlgebra
+private local instance instOperatorConvexityCStarRing : CStarRing Mat :=
+  Matrix.instCStarRing
+private local instance instOperatorConvexityPartialOrder : PartialOrder Mat :=
+  Matrix.instPartialOrder
+private local instance instOperatorConvexityStarOrderedRing : StarOrderedRing Mat :=
+  Matrix.instStarOrderedRing
+private local instance instOperatorConvexityNonnegSpectrumClass : NonnegSpectrumClass ℝ Mat :=
   Matrix.instNonnegSpectrumClass
-private local instance : CStarAlgebra Mat := CStarAlgebra.mk
+private local instance instOperatorConvexityCStarAlgebra : CStarAlgebra Mat :=
+  CStarAlgebra.mk
 
 /-- **Operator Jensen for concave `rpow`** (Wolf Thm. 5.1 applied to
 `x ↦ x ^ p` for `p ∈ [0, 1]`).
@@ -109,17 +118,18 @@ theorem IsPositiveMap.rpow_convex_jensen
 
 /-- **Operator Jensen for concave `log`** (Wolf Thm. 5.1 applied to `log`).
 
-For a positive subunital map `T` and positive-definite `A`:
+For a positive **unital** map `T` and positive-definite `A`:
   `T(log A) ≤ log(T A)`.
 
 This follows from operator concavity of `log` on `(0, ∞)`, combined
 with the concave version of the operator Jensen inequality for positive
-subunital maps.
+unital maps. Note: unlike the `rpow` variants, the `log` Jensen inequality
+requires unitality (`T 1 = 1`), not merely subunitality (`T 1 ≤ 1`).
 
 **TODO**: prove operator concavity of `log` (see Mathlib `CFC.ExpLog.Order`
 TODO) and the general operator Jensen inequality for positive maps. -/
 theorem IsPositiveMap.log_concave_jensen
-    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hUnit : T 1 = (1 : Mat))
     {A : Mat} (hA : A.PosDef) :
     T (CFC.log A) ≤ CFC.log (T A) := by
   sorry

--- a/TNLean/Channel/Schwarz/OperatorMonotone.lean
+++ b/TNLean/Channel/Schwarz/OperatorMonotone.lean
@@ -2,10 +2,11 @@
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Channel.Schwarz.PositiveMapProperties
+import TNLean.Channel.Schwarz.OperatorConvexity
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Order
 
@@ -13,20 +14,20 @@ import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Ord
 # Operator-monotone corollaries for subunital positive maps
 
 Mathlib already proves operator monotonicity of `x ↦ x^p` for `p ∈ [0,1]` and of
-`log`. To derive Wolf Corollary 5.2 from these ingredients, one also needs the
-positive-map Jensen inequality from Wolf Theorem 5.13. That intermediate result is
-not yet formalized in TNLean, so this file does two things:
+`log`. This file records those matrix-specialized lemmas and proves Wolf
+Corollary 5.2 from the operator Jensen inequality
+(`OperatorConvexity.lean`).
 
-* it records the directly available matrix monotonicity lemmas for `rpow` and `log`;
-* it registers the three matrix statements of Wolf Corollary 5.2 as
-  statement-only placeholders, ready to be upgraded to proved theorems once the
-  Jensen infrastructure is available.
+### Proof strategy for Corollary 5.2
 
-### Note on `sorry` placeholders
+Each item reduces to an instance of the operator Jensen inequality applied
+to `A ^ p` with a suitable exponent:
 
-The 3 `sorry` placeholders below were originally declared as `axiom`s,
-which bypass Lean's proof-tracking system. They have been converted to
-`theorem ... := by sorry` so that `#print axioms` honestly reports the gaps.
+* **Item 1** (`p ≥ 1`): Jensen for concave `x ↦ x^{1/p}` applied to `A^p`,
+  using `(A^p)^{1/p} = A` (CFC power composition).
+* **Item 2** (`p ∈ [1/2, 1]`): Jensen for convex `x ↦ x^{1/p}` applied
+  to `A^p`, using the same power composition.
+* **Item 3** (`log`): Direct from Jensen for concave `log`.
 
 ## References
 
@@ -73,35 +74,72 @@ theorem matrix_log_le_log
 
 /-- Wolf Cor. 5.2(1) in matrix form.
 
-**TODO**: The proof needs the operator-monotone Jensen inequality for positive
-subunital maps (Wolf Thm. 5.13), which is not yet in Mathlib.
-Currently a `sorry` placeholder. -/
+For a positive subunital map `T`, `p ≥ 1`, and `A ≥ 0`:
+  `T(A) ≤ (T(A ^ p)) ^ (1/p)`.
+
+Proof: apply the concave Jensen inequality (from `OperatorConvexity.lean`)
+with exponent `1/p ∈ (0, 1]` to the matrix `A ^ p`, then simplify
+`(A^p)^{1/p} = A` using the CFC power composition law. -/
 theorem IsPositiveMap.cor52_item1_rpow_of_subunital
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
     {p : ℝ} (hp : 1 ≤ p) {A : Mat} (hA : 0 ≤ A) :
     T A ≤ (T (A ^ p)) ^ (1 / p) := by
-  sorry
+  have hp_pos : (0 : ℝ) < p := lt_of_lt_of_le one_pos hp
+  have hp_nn : (0 : ℝ) ≤ p := hp_pos.le
+  have h1p_nn : (0 : ℝ) ≤ 1 / p := div_nonneg zero_le_one hp_nn
+  have h1p_le1 : 1 / p ≤ 1 := by rwa [div_le_one₀ hp_pos]
+  -- (A ^ p) ^ (1 / p) = A via CFC power composition
+  have hcomp : (A ^ p) ^ (1 / p) = A := by
+    rw [CFC.rpow_rpow_of_exponent_nonneg A p (1 / p) hp_nn h1p_nn]
+    rw [show p * (1 / p) = (1 : ℝ) from by field_simp [ne_of_gt hp_pos]]
+    exact CFC.rpow_one A
+  -- Concave Jensen for rpow with exponent 1/p ∈ [0, 1] applied to A ^ p
+  have hJ : T ((A ^ p) ^ (1 / p)) ≤ (T (A ^ p)) ^ (1 / p) :=
+    hT.rpow_concave_jensen hSub ⟨h1p_nn, h1p_le1⟩ CFC.rpow_nonneg
+  rw [hcomp] at hJ
+  exact hJ
 
 /-- Wolf Cor. 5.2(2) in matrix form.
 
-**TODO**: The proof needs the operator-monotone Jensen inequality for positive
-subunital maps (Wolf Thm. 5.13), which is not yet in Mathlib.
-Currently a `sorry` placeholder. -/
+For a positive subunital map `T`, `p ∈ [1/2, 1]`, and positive-definite `A`:
+  `(T(A ^ p)) ^ (1/p) ≤ T(A)`.
+
+Proof: apply the convex Jensen inequality (from `OperatorConvexity.lean`)
+with exponent `1/p ∈ [1, 2]` to the matrix `A ^ p`, then simplify
+`(A^p)^{1/p} = A` using the CFC power composition law. -/
 theorem IsPositiveMap.cor52_item2_rpow_of_subunital
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
     {p : ℝ} (hp : p ∈ Set.Icc (1 / 2 : ℝ) 1) {A : Mat} (hA : A.PosDef) :
     (T (A ^ p)) ^ (1 / p) ≤ T A := by
-  sorry
+  have hp_pos : (0 : ℝ) < p := by linarith [hp.1]
+  have hp_nn : (0 : ℝ) ≤ p := hp_pos.le
+  have h1p_nn : (0 : ℝ) ≤ 1 / p := div_nonneg zero_le_one hp_nn
+  have h1p_ge1 : 1 ≤ 1 / p := by rw [le_div_iff₀ hp_pos]; linarith [hp.2]
+  have h1p_le2 : 1 / p ≤ 2 := by rw [div_le_iff₀ hp_pos]; linarith [hp.1]
+  have hA_nn : (0 : Mat) ≤ A := by
+    rw [Matrix.le_iff]; simpa using hA.posSemidef
+  -- (A ^ p) ^ (1 / p) = A via CFC power composition
+  have hcomp : (A ^ p) ^ (1 / p) = A := by
+    rw [CFC.rpow_rpow_of_exponent_nonneg A p (1 / p) hp_nn h1p_nn (ha₂ := hA_nn)]
+    rw [show p * (1 / p) = (1 : ℝ) from by field_simp [ne_of_gt hp_pos]]
+    exact CFC.rpow_one A (ha := hA_nn)
+  -- Convex Jensen for rpow with exponent 1/p ∈ [1, 2] applied to A ^ p
+  have hJ : (T (A ^ p)) ^ (1 / p) ≤ T ((A ^ p) ^ (1 / p)) :=
+    hT.rpow_convex_jensen hSub ⟨h1p_ge1, h1p_le2⟩ CFC.rpow_nonneg
+  rw [hcomp] at hJ
+  exact hJ
 
 /-- Wolf Cor. 5.2(3) in matrix form.
 
-**TODO**: The proof needs the operator-monotone Jensen inequality for positive
-subunital maps (Wolf Thm. 5.13) applied to `log`, which is not yet in Mathlib.
-Currently a `sorry` placeholder. -/
+For a positive subunital map `T` and positive-definite `A`:
+  `T(log A) ≤ log(T A)`.
+
+This is a direct instance of the concave Jensen inequality for `log`
+(from `OperatorConvexity.lean`). -/
 theorem IsPositiveMap.cor52_item3_log_of_subunital
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
     {A : Mat} (hA : A.PosDef) :
-    T (CFC.log A) ≤ CFC.log (T A) := by
-  sorry
+    T (CFC.log A) ≤ CFC.log (T A) :=
+  hT.log_concave_jensen hSub hA
 
 end

--- a/TNLean/Channel/Schwarz/OperatorMonotone.lean
+++ b/TNLean/Channel/Schwarz/OperatorMonotone.lean
@@ -18,6 +18,11 @@ Mathlib already proves operator monotonicity of `x ↦ x^p` for `p ∈ [0,1]` an
 Corollary 5.2 from the operator Jensen inequality
 (`OperatorConvexity.lean`).
 
+**Status note:** The Cor. 5.2 theorems in this file depend on Jensen-type lemmas
+imported from `OperatorConvexity.lean` that are currently `sorry` placeholders.
+They should be understood as conditional on those axioms and are not yet fully
+verified Lean theorems.
+
 ### Proof strategy for Corollary 5.2
 
 Each item reduces to an instance of the operator Jensen inequality applied
@@ -90,9 +95,9 @@ theorem IsPositiveMap.cor52_item1_rpow_of_subunital
   have h1p_le1 : 1 / p ≤ 1 := by rwa [div_le_one₀ hp_pos]
   -- (A ^ p) ^ (1 / p) = A via CFC power composition
   have hcomp : (A ^ p) ^ (1 / p) = A := by
-    rw [CFC.rpow_rpow_of_exponent_nonneg A p (1 / p) hp_nn h1p_nn]
+    rw [CFC.rpow_rpow_of_exponent_nonneg A p (1 / p) hp_nn h1p_nn (ha₂ := hA)]
     rw [show p * (1 / p) = (1 : ℝ) from by field_simp [ne_of_gt hp_pos]]
-    exact CFC.rpow_one A
+    exact CFC.rpow_one A (ha := hA)
   -- Concave Jensen for rpow with exponent 1/p ∈ [0, 1] applied to A ^ p
   have hJ : T ((A ^ p) ^ (1 / p)) ≤ (T (A ^ p)) ^ (1 / p) :=
     hT.rpow_concave_jensen hSub ⟨h1p_nn, h1p_le1⟩ CFC.rpow_nonneg
@@ -131,15 +136,16 @@ theorem IsPositiveMap.cor52_item2_rpow_of_subunital
 
 /-- Wolf Cor. 5.2(3) in matrix form.
 
-For a positive subunital map `T` and positive-definite `A`:
+For a positive **unital** map `T` and positive-definite `A`:
   `T(log A) ≤ log(T A)`.
 
 This is a direct instance of the concave Jensen inequality for `log`
-(from `OperatorConvexity.lean`). -/
+(from `OperatorConvexity.lean`). Note: requires unitality (`T 1 = 1`),
+not merely subunitality. -/
 theorem IsPositiveMap.cor52_item3_log_of_subunital
-    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hUnit : T 1 = (1 : Mat))
     {A : Mat} (hA : A.PosDef) :
     T (CFC.log A) ≤ CFC.log (T A) :=
-  hT.log_concave_jensen hSub hA
+  hT.log_concave_jensen hUnit hA
 
 end


### PR DESCRIPTION
### Motivation

- Continues formalization of Wolf Chapter 5 operator convexity/monotonicity block, see LionSR/QICLean#29.
- Corollary 5.2 items 1–3 existed as axioms in `OperatorMonotone.lean`; the Ando–Lieb and trace-convexity results were entirely absent.

### Description

- **`OperatorConvexity.lean`** (new): States the operator Jensen inequality (Choi–Davis–Jensen / Hansen–Pedersen) for positive subunital maps, specialized to `rpow` and `log` (sorry placeholders pending upstream Mathlib support).
- **`OperatorMonotone.lean`** (modified): Proves Cor 5.2 items 1–3 from Jensen instances via CFC power composition (`rpow_rpow_of_exponent_nonneg`), replacing 3 application-level sorrys with 3 more fundamental Jensen sorrys.
- **`AndoLieb.lean`** (new): Ando–Lieb (Lieb concavity) theorem and trace convexity/concavity stubs for matrix power functions (sorry placeholders).
- **`TNLean.lean`** (modified): Exposes new modules.
- Sorry summary: 3 Jensen sorrys (`OperatorConvexity`) + 3 Ando–Lieb/trace sorrys (`AndoLieb`). The 3 Cor 5.2 sorrys in `OperatorMonotone` are now fully proved modulo Jensen.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/QICLean#29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new foundational theorems that are currently `sorry` placeholders and rewires downstream results to depend on them, so correctness hinges on later filling these proof gaps. Also changes assumptions for the `log` corollary from subunital to unital, which may affect downstream users.
> 
> **Overview**
> Adds two new Schwarz-chapter modules: `OperatorConvexity.lean` declaring operator Jensen inequalities for positive (sub)unital maps specialized to `rpow`/`log` (**currently `sorry` placeholders**), and `AndoLieb.lean` adding placeholders for trace convexity/concavity of matrix powers and the Ando–Lieb (Lieb concavity) theorem.
> 
> Updates `OperatorMonotone.lean` to *actually derive* Wolf Corollary 5.2 items (1)–(3) from the new Jensen statements using CFC power-composition lemmas, and tightens item (3) to require unitality (`T 1 = 1`). `TNLean.lean` now re-exports the two new modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49b7c6ad892072e30886d62d8ed749571dce542c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->