### PR TITLE
doc(Channel/Peripheral): add namespace docstring to PeripheralSpectrum

### DIFF
--- a/TNLean/Channel/Peripheral/GroupStructure.lean
+++ b/TNLean/Channel/Peripheral/GroupStructure.lean
@@ -49,6 +49,15 @@ variable {D : ℕ}
 
 namespace PeripheralSpectrum
 
+/-! ### `PeripheralSpectrum` namespace
+
+Provides the core results establishing group structure on peripheral eigenvalues:
+* Closure under multiplication and inversion
+* Cyclic group structure (Wolf Theorem 6.6)
+* Multiplicity-one for each peripheral eigenvalue
+* Period-divides-dimension bound
+-/
+
 /-! ## Closure under multiplication -/
 
 /-- **Peripheral eigenvalues are closed under multiplication.**


### PR DESCRIPTION
### Motivation

- Issue #311 requests a module-level docstring for the `PeripheralSpectrum` namespace in `GroupStructure.lean` to summarize its main results.

### Description

- Modified `TNLean/Channel/Peripheral/GroupStructure.lean` to add a `/-! ... -/` namespace docstring at the top of the `PeripheralSpectrum` namespace.
- The docstring summarizes: closure of peripheral eigenvalues under multiplication and inversion, cyclic group structure (Wolf Theorem 6.6), multiplicity-one result, and period-divides-dimension bound.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #311

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a `/-! ... -/` namespace docstring; no proofs or definitions are modified.
> 
> **Overview**
> Adds a short `/-! ... -/` docstring at the top of the `PeripheralSpectrum` namespace in `GroupStructure.lean` to describe the file's main theorems (closure under multiplication/inversion, cyclic group structure, multiplicity-one, and the period-divides-dimension bound).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaa622b772f9e159ec3e8e6b44dcd44b05308af9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->