### PR TITLE
ci(claude): use BOT_PAT for checkout so pushes re-trigger workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          token: ${{ secrets.BOT_PAT || github.token }}
+          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Set up Lean toolchain and cache
         uses: leanprover/lean-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          token: ${{ secrets.BOT_PAT || github.token }}
 
       - name: Set up Lean toolchain and cache
         uses: leanprover/lean-action@v1


### PR DESCRIPTION
### Motivation

- The `@claude` handler in `claude.yml` pushes code using the checkout token. Without `BOT_PAT`, pushes use `GITHUB_TOKEN` which doesn't trigger downstream workflows (`pull_request: synchronize`). This broke the review loop for `@claude`-initiated fixes on PRs — confirmed on PR #307 where the modularity fix push didn't re-trigger the review.

### Description

- Add `token: ${{ secrets.BOT_PAT || github.token }}` to the checkout step in `.github/workflows/claude.yml`, matching the pattern already used in `pr-review-auto-fix.yml`.

### Testing

- After merge, `@claude fix` on a PR should push with `BOT_PAT`, re-triggering `claude-code-review` via `synchronize` event.

---
No linked issue found — author should link one manually if applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Actions checkout authentication in `claude.yml` to prefer `secrets.BOT_PAT`, which affects how pushes are attributed and whether downstream workflows re-trigger. Risk is limited to CI behavior but involves credential selection in an automated workflow.
> 
> **Overview**
> Updates the `claude.yml` GitHub Action to checkout with `token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}` instead of the default token.
> 
> This makes `@claude`-initiated commits/pushes use the bot PAT when available, so subsequent CI workflows can be triggered by those pushes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f5780ee80eead0c4405892a84a1f95f1bec4812. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->