### PR TITLE
ci(tracking-issue-sync): add follow-up suggestions to tracking/issue comments

### DIFF
--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -167,10 +167,13 @@ jobs:
             1. Search for open tracking issues (label `tracking`) whose
                tasklist contains `#N` (the closed issue number).
             2. For each match, update the body: `- [ ] #N` → `- [x] #N`
-            3. Comment on the tracking issue:
+            3. Suggest next steps (see §5 below).
+            4. Comment on the tracking issue:
                "✅ #N (*title*) has been resolved. Updated checklist.
-               [X/Y tasks complete]"
-            4. Apply the `all-resolved` rule (see Key Rules §2).
+               [X/Y tasks complete]
+
+               **Suggested next:** <one-line recommendation from §5>"
+            5. Apply the `all-resolved` rule (see Key Rules §2).
 
             ---
 
@@ -203,13 +206,23 @@ jobs:
             2. **Find tracking issues** (label `tracking`) whose body
                references the PR number, or whose tasklist references any
                linked issue number.
-            3. **Comment on each tracking issue** with a summary: the PR
-               title, what it accomplished, and current task progress.
-            4. **Comment on each linked issue that stays open** (i.e., the
+            3. Suggest next steps for each tracking issue (see §5 below).
+            4. **Comment on each tracking issue** with a summary: the PR
+               title, what it accomplished, current task progress, and a
+               follow-up suggestion. Example:
+               "📦 PR #X (*title*) merged. <what was done>. [X/Y tasks
+               complete]
+
+               **Suggested next:** <one-line recommendation from §5>"
+            5. **Comment on each linked issue that stays open** (i.e., the
                PR used `Addresses` or `Partially addresses`). Summarize
-               what the PR accomplished and what remains. Example:
+               what the PR accomplished and what remains. Include a
+               follow-up suggestion for what to tackle next on that issue.
+               Example:
                "📦 PR #X (*title*) has been merged. <what was done>.
-               Remaining: <what's left>."
+               Remaining: <what's left>.
+
+               **Suggested next step:** <concrete action for this issue>"
 
             Do NOT comment on issues that will be auto-closed by the PR
             (`Closes`/`Fixes`) — the auto-close fires Playbook A, which
@@ -295,6 +308,43 @@ jobs:
                - **Changes requested** (state `changes_requested`):
                  "⚠️ Changes requested on #<PR> by @<reviewer>"
             4. Skip everything else silently.
+
+            ---
+
+            ## §5 — Follow-up Suggestions
+
+            When a playbook asks you to "suggest next steps", generate a
+            brief, actionable recommendation for what to work on next.
+
+            **How to choose a suggestion:**
+
+            1. Read the tracking issue body to find **remaining unchecked
+               tasks** (`- [ ] #N`).
+            2. For each unchecked task, read the issue to check its
+               **dependencies** (look for "Depends on", "Blocked by",
+               "Dependencies" sections, or references to other issues).
+            3. Recommend a task whose dependencies are all resolved
+               (checked in the tracking issue or closed). If multiple
+               tasks are unblocked, prefer:
+               - Tasks explicitly marked as high-priority or foundational
+               - Tasks that unblock the most other tasks
+               - Tasks with lower estimated difficulty
+            4. If **no tasks are unblocked** (all have open dependencies),
+               say so and recommend the dependency that should be tackled
+               first.
+            5. If **all tasks are complete**, suggest closing the tracking
+               issue.
+
+            **Format:** Keep it to 1–2 sentences. Be specific — reference
+            the issue number and title. Example:
+            "**Suggested next:** #138 (*Discharge sorry in
+            OperatorMonotone.lean*) — all dependencies resolved, and it
+            is the last remaining task."
+
+            **For linked issues** (B1 step 5), suggest the concrete next
+            action for that specific issue based on the PR diff and what
+            remains (e.g., "Next: discharge the remaining 2 sorrys in
+            `Foo.lean`, which depend on `bar_lemma` from Mathlib.").
 
             ---
 

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -368,21 +368,6 @@ jobs:
               Example: "Next: discharge the remaining 2 sorrys in
               `Foo.lean`, which depend on `bar_lemma` from Mathlib."
 
-            ### Mathlib scouting
-
-            The Mathlib Scout workflow (`mathlib-scout.yml`) automatically
-            posts a scouting report on new `formalization` issues. When
-            suggesting a next task, check whether the recommended issue
-            already has a Mathlib scouting report comment. If it does not,
-            append a note: "💡 Consider adding the `formalization` label
-            to trigger a Mathlib scouting report first." This is especially
-            valuable for issues that pre-date the scout workflow or that
-            were created without the `formalization` label.
-
-            When B2 creates follow-up issues for sorry discharges or new
-            formalization work, ensure they get the `formalization` label
-            so the scout runs automatically.
-
             ### Format
 
             Keep suggestions to 1–2 sentences. Be specific — reference

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -183,7 +183,8 @@ jobs:
             **When**: `issues` / `reopened`
 
             1. Search for tracking issues (label `tracking`, **any state**
-               — a closed tracking issue still needs its checkbox fixed).
+               — a closed tracking issue still needs its checkbox fixed)
+               whose tasklist contains `#N` (the reopened issue number).
             2. For each match, uncheck: `- [x] #N` → `- [ ] #N`
             3. Apply the `all-resolved` rule (see Key Rules §2).
             4. Read the reopened issue to understand why it was reopened
@@ -412,7 +413,7 @@ jobs:
             OperatorMonotone.lean*) — all dependencies resolved and
             it is the last Ch5 task; completing it would let #21
             (Wolf Ch5 Tracking) close. Consider a Mathlib rescouting
-            report first — the Lowner's theorem API may have landed
+            report first — the Loewner's theorem API may have landed
             since the last Mathlib bump."
 
             ---

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -331,7 +331,11 @@ jobs:
             ## §5 — Follow-up Suggestions
 
             When a playbook asks you to "suggest next steps", generate a
-            brief, actionable recommendation for what to work on next.
+            brief, actionable recommendation. Think beyond the immediate
+            next task — consider what this completion unblocks downstream,
+            how it fits into the broader formalization roadmap, and whether
+            preparatory work (scouting, blueprint review) would de-risk
+            the next step.
 
             ### Tracking-issue variant (Playbooks A, A2, B1, B2)
 
@@ -353,6 +357,9 @@ jobs:
                first.
             5. If **all tasks are complete**, suggest closing the tracking
                issue.
+            6. Note downstream impact: briefly mention what completing
+               the suggested task would unblock (other tasks, other
+               tracking issues, or milestones in the broader project).
 
             ### Linked-issue variant (Playbooks A2, B1 step 5)
 
@@ -368,13 +375,45 @@ jobs:
               Example: "Next: discharge the remaining 2 sorrys in
               `Foo.lean`, which depend on `bar_lemma` from Mathlib."
 
+            ### Scouting and source review
+
+            For tasks that are mathematically complex or involve new
+            Mathlib API surface, suggest preparatory scouting before
+            diving into the proof:
+
+            - **Mathlib scouting**: If the recommended issue involves
+              heavy Mathlib dependencies and does not already have a
+              Mathlib scouting report in its comments, suggest running
+              one (the Mathlib Scout workflow triggers on issues with
+              the `formalization` label). Rescouting may also be
+              warranted when Mathlib has been bumped since the last
+              report — new lemmas may simplify the approach.
+            - **Blueprint / paper review**: If the task formalizes a
+              specific theorem or section from a paper, suggest
+              reviewing the corresponding blueprint LaTeX source
+              (`blueprint/src/chapter/*.tex`) to check the proof
+              sketch, `\lean{}` / `\leanok` status, and any gap
+              annotations. The paper's original proof structure often
+              reveals dependencies or intermediate lemmas that are
+              not yet tracked as issues.
+
+            Skip scouting suggestions for straightforward tasks
+            (cleanup, simple sorry discharges with known proof paths,
+            infrastructure work).
+
             ### Format
 
-            Keep suggestions to 1–2 sentences. Be specific — reference
-            issue numbers and titles. Example:
+            Keep the primary suggestion to 1–2 sentences. Be specific
+            — reference issue numbers and titles. Add a brief
+            downstream note and scouting hint only when warranted.
+
+            Example:
             "**Suggested next:** #138 (*Discharge sorry in
-            OperatorMonotone.lean*) — all dependencies resolved, and it
-            is the last remaining task."
+            OperatorMonotone.lean*) — all dependencies resolved and
+            it is the last Ch5 task; completing it would let #21
+            (Wolf Ch5 Tracking) close. Consider a Mathlib rescouting
+            report first — the Lowner's theorem API may have landed
+            since the last Mathlib bump."
 
             ---
 

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -185,9 +185,14 @@ jobs:
                whose tasklist contains `#N` (the reopened issue number).
             2. For each match, uncheck: `- [x] #N` → `- [ ] #N`
             3. Apply the `all-resolved` rule (see Key Rules §2).
-            4. Comment on the tracking issue:
+            4. Read the reopened issue to understand why it was reopened
+               (check recent comments, linked PRs). Suggest what needs
+               to happen to re-resolve it (see §5, linked-issue variant).
+            5. Comment on the tracking issue:
                "🔄 #N (*title*) has been reopened. Unchecked in tasklist.
-               [X/Y tasks complete]"
+               [X/Y tasks complete]
+
+               **Suggested next:** <why it was reopened + what to do>"
 
             ---
 
@@ -282,6 +287,8 @@ jobs:
             Then add each new issue to relevant tracking issue checklists:
             - Append `- [ ] #<issue>` inside the tasklist block
             - Comment: "📋 Added follow-up issues from #<PR>: #<issue1>, …"
+            - If multiple follow-ups were created, suggest which one to
+              tackle first (see §5, tracking-issue variant).
 
             **Be conservative.** Only create issues for genuine, actionable
             follow-ups. When in doubt, skip. False positives create noise.
@@ -316,13 +323,15 @@ jobs:
             When a playbook asks you to "suggest next steps", generate a
             brief, actionable recommendation for what to work on next.
 
-            **How to choose a suggestion:**
+            ### Tracking-issue variant (Playbooks A, A2, B1, B2)
 
             1. Read the tracking issue body to find **remaining unchecked
                tasks** (`- [ ] #N`).
-            2. For each unchecked task, read the issue to check its
-               **dependencies** (look for "Depends on", "Blocked by",
-               "Dependencies" sections, or references to other issues).
+            2. Check dependencies. First look at the tracking issue body
+               itself — it often lists a suggested order or dependency
+               notes. If that's sufficient, use it. Otherwise, read the
+               unchecked issues to check their **dependencies** ("Depends
+               on", "Blocked by", or references to other open issues).
             3. Recommend a task whose dependencies are all resolved
                (checked in the tracking issue or closed). If multiple
                tasks are unblocked, prefer:
@@ -335,16 +344,27 @@ jobs:
             5. If **all tasks are complete**, suggest closing the tracking
                issue.
 
-            **Format:** Keep it to 1–2 sentences. Be specific — reference
-            the issue number and title. Example:
+            ### Linked-issue variant (Playbooks A2, B1 step 5)
+
+            For a specific issue (not the tracking issue), suggest the
+            concrete next action based on available context:
+            - **After a PR merges** (B1): look at what the PR changed,
+              what remains in the issue scope, and what specific files,
+              declarations, or proof obligations to tackle next.
+            - **After a reopen** (A2): look at recent comments or the
+              close/reopen history to understand what broke or changed,
+              and suggest how to re-resolve it.
+            - Be specific about files, declarations, or proof steps.
+              Example: "Next: discharge the remaining 2 sorrys in
+              `Foo.lean`, which depend on `bar_lemma` from Mathlib."
+
+            ### Format
+
+            Keep suggestions to 1–2 sentences. Be specific — reference
+            issue numbers and titles. Example:
             "**Suggested next:** #138 (*Discharge sorry in
             OperatorMonotone.lean*) — all dependencies resolved, and it
             is the last remaining task."
-
-            **For linked issues** (B1 step 5), suggest the concrete next
-            action for that specific issue based on the PR diff and what
-            remains (e.g., "Next: discharge the remaining 2 sorrys in
-            `Foo.lean`, which depend on `bar_lemma` from Mathlib.").
 
             ---
 

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -164,16 +164,17 @@ jobs:
 
             **When**: `issues` / `closed` with state_reason `completed`
 
-            1. Search for open tracking issues (label `tracking`) whose
+            1. Search for **open** tracking issues (label `tracking`) whose
                tasklist contains `#N` (the closed issue number).
             2. For each match, update the body: `- [ ] #N` → `- [x] #N`
-            3. Suggest next steps (see §5 below).
-            4. Comment on the tracking issue:
+            3. Apply the `all-resolved` rule (see Key Rules §2).
+            4. Suggest next steps (see §5 below).
+            5. Comment on the tracking issue (check recent comments first
+               to avoid duplicates — Key Rules §3):
                "✅ #N (*title*) has been resolved. Updated checklist.
                [X/Y tasks complete]
 
                **Suggested next:** <one-line recommendation from §5>"
-            5. Apply the `all-resolved` rule (see Key Rules §2).
 
             ---
 
@@ -181,14 +182,15 @@ jobs:
 
             **When**: `issues` / `reopened`
 
-            1. Search for tracking issues (label `tracking`, **any state**)
-               whose tasklist contains `#N` (the reopened issue number).
+            1. Search for tracking issues (label `tracking`, **any state**
+               — a closed tracking issue still needs its checkbox fixed).
             2. For each match, uncheck: `- [x] #N` → `- [ ] #N`
             3. Apply the `all-resolved` rule (see Key Rules §2).
             4. Read the reopened issue to understand why it was reopened
                (check recent comments, linked PRs). Suggest what needs
                to happen to re-resolve it (see §5, linked-issue variant).
-            5. Comment on the tracking issue:
+            5. Comment on the tracking issue (check recent comments first
+               to avoid duplicates — Key Rules §3):
                "🔄 #N (*title*) has been reopened. Unchecked in tasklist.
                [X/Y tasks complete]
 
@@ -208,19 +210,21 @@ jobs:
             1. **Find linked issues.** Check the PR body for `Addresses #N`,
                `Partially addresses #N`, `Closes #N`, `Fixes #N`. Also check
                the branch name for `*/issue-{N}-*`.
-            2. **Find tracking issues** (label `tracking`) whose body
-               references the PR number, or whose tasklist references any
-               linked issue number.
+            2. **Find tracking issues** (label `tracking`, **open**) whose
+               body references the PR number, or whose tasklist references
+               any linked issue number.
             3. Suggest next steps for each tracking issue (see §5 below).
-            4. **Comment on each tracking issue** with a summary: the PR
-               title, what it accomplished, current task progress, and a
-               follow-up suggestion. Example:
+            4. **Comment on each tracking issue** (check recent comments
+               first to avoid duplicates — Key Rules §3) with a summary:
+               the PR title, what it accomplished, current task progress,
+               and a follow-up suggestion. Example:
                "📦 PR #X (*title*) merged. <what was done>. [X/Y tasks
                complete]
 
                **Suggested next:** <one-line recommendation from §5>"
             5. **Comment on each linked issue that stays open** (i.e., the
-               PR used `Addresses` or `Partially addresses`). Summarize
+               PR used `Addresses` or `Partially addresses`). Check recent
+               comments first to avoid duplicates (Key Rules §3). Summarize
                what the PR accomplished and what remains. Include a
                follow-up suggestion for what to tackle next on that issue.
                Example:
@@ -284,9 +288,14 @@ jobs:
               copied from the PR. Add `formalization` for sorry follow-ups,
               `blueprint-sync` for missing tags, `bug` for correctness issues.
 
-            Then add each new issue to relevant tracking issue checklists:
+            Then add each new issue to the relevant **open** tracking
+            issue checklists:
             - Append `- [ ] #<issue>` inside the tasklist block
-            - Comment: "📋 Added follow-up issues from #<PR>: #<issue1>, …"
+            - If the tracking issue had the `all-resolved` label, remove
+              it (new unchecked items mean it's no longer all-resolved).
+            - Comment (check recent comments first — Key Rules §3):
+              "📋 Added follow-up issues from #<PR>: #<issue1>, …
+              [X/Y tasks complete]"
             - If multiple follow-ups were created, suggest which one to
               tackle first (see §5, tracking-issue variant).
 
@@ -304,7 +313,8 @@ jobs:
             This is lightweight — most events need no action.
 
             1. Find the linked issue from the PR body or branch name.
-            2. Find tracking issues referencing that issue or the PR.
+            2. Find **open** tracking issues (label `tracking`) referencing
+               that issue or the PR.
             3. Only act if meaningful AND not already handled by another
                workflow. All comments go on the **tracking issue**:
                - **PR opened** — only for branches that do NOT start with
@@ -358,6 +368,21 @@ jobs:
               Example: "Next: discharge the remaining 2 sorrys in
               `Foo.lean`, which depend on `bar_lemma` from Mathlib."
 
+            ### Mathlib scouting
+
+            The Mathlib Scout workflow (`mathlib-scout.yml`) automatically
+            posts a scouting report on new `formalization` issues. When
+            suggesting a next task, check whether the recommended issue
+            already has a Mathlib scouting report comment. If it does not,
+            append a note: "💡 Consider adding the `formalization` label
+            to trigger a Mathlib scouting report first." This is especially
+            valuable for issues that pre-date the scout workflow or that
+            were created without the `formalization` label.
+
+            When B2 creates follow-up issues for sorry discharges or new
+            formalization work, ensure they get the `formalization` label
+            so the scout runs automatically.
+
             ### Format
 
             Keep suggestions to 1–2 sentences. Be specific — reference
@@ -375,5 +400,7 @@ jobs:
             - What tracking issues were updated (with task counts)
             - What linked issues were commented on
             - What follow-up issues were created (if any)
+            - What was suggested as next steps
             - Whether `all-resolved` was added/removed
+            - Whether any comments were skipped to avoid duplication
             - Or note that no action was needed


### PR DESCRIPTION
### Motivation

- The tracking-issue-sync workflow posts comments on tracking and linked issues when PRs merge, but does not suggest what to work on next.
- Adding dependency-aware next-step recommendations helps contributors quickly identify the highest-impact follow-up task after each merge.

### Description

- Modified `.github/workflows/tracking-issue-sync.yml` (+141 / −20 lines):
  - Enhanced Playbooks A and B1 to include actionable next-step suggestions in issue comments.
  - Added §5 with dependency-aware heuristics for choosing the best next task to recommend (downstream impact, scouting, blueprint review).
  - Balanced follow-up suggestions across all playbooks (A, A2, B1, B2, C).
  - Consistent tracking-issue search scope (open vs any state, documented).
  - Added `all-resolved` label removal in B2 when new unchecked items are appended.
  - Added duplicate-comment checks in every commenting step.
  - Added task counts `[X/Y]` in B2 comments to match other playbooks.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- Workflow changes are YAML-only; functional testing requires triggering the workflow on issue close/reopen/PR merge events.

---
No linked issue found — this PR enhances CI automation. Author should link an issue if one exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `tracking-issue-sync` workflow’s playbook/prompt instructions, which can materially alter bot commenting behavior and create noise if the new guidance produces incorrect or duplicate messages, but it does not touch repo code or secrets handling.
> 
> **Overview**
> Updates `.github/workflows/tracking-issue-sync.yml` to expand the issue-tracker agent playbooks with **dependency-aware “Suggested next” recommendations** that are included in tracking/linked-issue comments for issue close/reopen and PR-merge events.
> 
> Tightens playbook rules around when to search **open vs any-state** tracking issues, adds explicit **duplicate-comment avoidance** guidance across comment steps, and clarifies follow-up issue creation behavior (including removing `all-resolved` when new unchecked follow-ups are appended) plus extra final-report fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc4283af0214a68fe22e6c40204c1bf9ba02897b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->