### PR TITLE
doc(blueprint): clarify formalization status and add web macros to hide metadata

### DIFF
--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -633,11 +633,9 @@ The formalized results are in
 
 \begin{remark}[Props.~6.10--6.11: non-trivial formulations]%
     \label{rem:stationary_support_todo}
-    The original Lean declarations \texttt{irreducible\_iff\_support\_full}
-    and \texttt{stationary\_support\_minimal} were removed in PR~\#102
-    because their previous formulations were vacuous (they followed
+    Earlier formulations of these statements were vacuous (they followed
     trivially from the irreducibility hypothesis alone).
-    The correct non-trivial statements are:
+    The correct non-trivial formulations are:
     \begin{itemize}
         \item \textbf{Prop.~6.10} (converse of Prop.~6.9):
             if the support projection of \emph{every} PSD fixed point

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -686,7 +686,7 @@ which shows that such generators have the standard Lindblad form.
           \bigr).
     \]
     In Wolf's formula one takes $\{F_k\}$ to be a basis of traceless matrices;
-    the Lean structure keeps only the algebraic data needed for the conversion to
+    here we keep only the algebraic data needed for the conversion to
     Lindblad form.
 \end{definition}
 
@@ -712,11 +712,10 @@ which shows that such generators have the standard Lindblad form.
 
 %% Wolf §7.1, Prop 7.5
 \begin{remark}[Status note]\notready
-    The Lean declarations for Proposition~7.5 are currently implemented via
+    The declarations for Proposition~7.5 are currently implemented via
     axioms to keep CI/elaboration time manageable; accordingly, these results are
     marked \texttt{notready} in the blueprint until full proofs are restored.
-    The Proposition~7.6 implication (4)$\to$(2) sorry was closed in PR~\#85,
-    so the full equivalence chain is now complete.
+    For Proposition~7.6, the implication chain is complete.
 \end{remark}
 
 

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -188,10 +188,9 @@ operation on the physical indices.
     all of $\MN{D}$.
 \end{proof}
 
-\begin{remark}[Lean formalisation note]
+\begin{remark}[Blocking formulation note]
     \label{rem:blocking_vs_combined}
-    The Lean proof uses a combined tensor approach
-    (\lean{MPSTensor.chainCombinedTensor_isInjective}) rather than
+    The proof uses a combined tensor approach rather than
     literal tensor blocking: it shows that if any site tensor is injective,
     the combined tensor (union of all site matrices) spans $\MN{D}$.
     This serves the same role in the chain fundamental theorem proof.
@@ -394,24 +393,20 @@ Lemma~\ref{lem:tensor_proportional} yields the main theorem of
     of Lemma~\ref{lem:virtual_bond_gauge}.
 \end{proof}
 
-\begin{remark}[Stronger hypothesis in the Lean formalisation]
+\begin{remark}[Stronger hypothesis in the current formulation]
     \label{rem:ft_chain_sameMPV}
     \uses{thm:fundamentalTheorem_injective_chain}
-    The Lean theorem \lean{MPSChainTensor.fundamentalTheorem_injective_chain}
-    assumes \texttt{SameMPV} on the combined tensor (trace agreement for
-    mixed-site words of \emph{all} lengths), which is stronger than the
-    paper's \texttt{SameState} (trace agreement at a single chain length
-    $n \ge 3$).
+    The current theorem statement assumes trace agreement for mixed-site
+    words of \emph{all} lengths on the combined tensor, which is stronger
+    than the paper's fixed-length hypothesis (trace agreement at a single
+    chain length $n \ge 3$).
     The paper bridges this gap via a blocking argument requiring $n \ge 3$.
-    This bridging step is now packaged as an abstract interface
-    \lean{MPSChainTensor.SameStateBridgeHyp}: a \texttt{structure} that
+    This bridging step is now packaged as an abstract interface that
     encapsulates the blocking hypothesis.
-    Given this bridge, the theorem
-    \lean{MPSChainTensor.fundamentalTheorem_injective_chain_of_sameState}
-    delivers the chain FT endpoint under the weaker \texttt{SameState}
-    hypothesis; however, the actual proof that \texttt{SameState} implies
-    \texttt{SameMPV} (i.e.\ the content of the bridge) has not yet been
-    established in the formalization.
+    Given this bridge, one obtains the chain FT endpoint under the weaker
+    fixed-length hypothesis; however, the actual proof that fixed-length
+    agreement implies all-length mixed-word agreement (i.e.\ the content of
+    the bridge) has not yet been established in the formalization.
 \end{remark}
 
 \begin{remark}[Relationship to the translation-invariant all-sizes theorem]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3,8 +3,8 @@
 This chapter introduces the local ground-space construction and the parent
 interaction for translation-invariant periodic MPS.
 We follow the standard setup from
-\cite{Cirac2021Matrix, PerezGarcia2007Matrix} and align the Lean definitions
-with the project convention that the $N$-site Hilbert space is represented as
+\cite{Cirac2021Matrix, PerezGarcia2007Matrix} and use the project convention
+that the $N$-site Hilbert space is represented as
 coefficient functions
 \[
   \{0,\dots,d{-}1\}^N \to \C,
@@ -96,9 +96,7 @@ $A^{\sigma(0)}\cdots A^{\sigma(L-1)}$.
 \section{Parent interaction and chain Hamiltonian}\label{sec:parent_interaction_defs}
 
 Conceptually, the parent interaction at range $L$ is the orthogonal projector
-onto $G_L(A)^\perp$. In the current Lean installment, the chain-level operator
-API is introduced first, and the concrete projector implementation is deferred
-to a follow-up PR.
+onto $G_L(A)^\perp$.
 
 \begin{definition}[Parent interaction]\label{def:parent_interaction}
   \lean{MPSTensor.parentInteraction}
@@ -108,8 +106,8 @@ to a follow-up PR.
     h_L(A) := \Pi_{G_L(A)^\perp},
   \]
   on the local $L$-site space.
-  \textbf{Note:} the Lean definition is currently a zero placeholder;
-  \texttt{\textbackslash leanok} will be added once the projector is implemented.
+  \textbf{Note:} this object is currently recorded as a placeholder pending
+  the explicit projector construction.
 \end{definition}
 
 For a periodic chain of length $N$, the parent Hamiltonian is the sum of
@@ -121,7 +119,7 @@ translated copies of the local interaction.
   For each site index $i \in \{0,\dots,N{-}1\}$, the translated local term
   $h_i$ embeds the parent interaction into the full $N$-site space at
   position~$i$ (with periodic boundary conditions).
-  \textbf{Note:} the Lean definition is currently a zero placeholder.
+  \textbf{Note:} this object is currently recorded as a placeholder.
 \end{definition}
 
 \begin{definition}[Parent Hamiltonian]\label{def:parent_hamiltonian}

--- a/blueprint/src/macros/web.tex
+++ b/blueprint/src/macros/web.tex
@@ -3,11 +3,3 @@
 % version in macros/print.tex.
 % Typically the printed version could have more fancy decorations.
 % This will probably be a very short file.
-
-% Keep blueprint prose purely mathematical in the web rendering:
-% hide formalization metadata tags and status badges.
-\newcommand{\lean}[1]{}
-\newcommand{\discussion}[1]{}
-\newcommand{\leanok}{}
-\newcommand{\mathlibok}{}
-\newcommand{\notready}{}

--- a/blueprint/src/macros/web.tex
+++ b/blueprint/src/macros/web.tex
@@ -1,5 +1,13 @@
-% In this file you should put macros to be used only by
+% In this file you should put macros to be used only by
 % the web version. Of course they should have a corresponding
 % version in macros/print.tex.
 % Typically the printed version could have more fancy decorations.
 % This will probably be a very short file.
+
+% Keep blueprint prose purely mathematical in the web rendering:
+% hide formalization metadata tags and status badges.
+\newcommand{\lean}[1]{}
+\newcommand{\discussion}[1]{}
+\newcommand{\leanok}{}
+\newcommand{\mathlibok}{}
+\newcommand{\notready}{}


### PR DESCRIPTION
### Motivation

- Improve clarity of blueprint prose so readers can distinguish proven results from TODO/placeholder items across several chapters.
- Soften Lean-internal language in parent-Hamiltonian documentation and mark placeholders pending projector construction.
- Hide formalization metadata badges (`\lean`, `\leanok`, etc.) from the published web rendering.

### Description

- Reword remarks and theorem exposition in `ch06_spectral.tex`, `ch12_semigroup.tex`, `ch13_algebraic_ft.tex`, and `ch14_parent_hamiltonian.tex` to clarify placeholder/TODO status and improve informal explanations.
- Make parent-interaction and translated local-term objects in `ch14_parent_hamiltonian.tex` explicitly described as placeholders pending projector construction.
- Update chain/blocking/FT remarks in `ch13_algebraic_ft.tex` to describe the stronger combined-tensor hypothesis without exposing Lean identifiers.
- Add web-only macro definitions in `macros/web.tex` (`\lean`, `\discussion`, `\leanok`, `\mathlibok`, `\notready`) as no-ops for the web build.
- Minor whitespace/newline fixes and editorial tweaks.

### Testing

- Local LaTeX build of modified blueprint chapters via `make` compiled successfully.
- Web macros integrate without compile errors in the web build.
- No formal-proof sources were changed; no Lean proof rebuilds triggered.

---
*No linked issue found — this PR does not reference an existing issue. Consider linking one if applicable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits across several blueprint chapters plus minor LaTeX hygiene (newlines/whitespace), with no changes to Lean or computational code paths.
> 
> **Overview**
> Clarifies blueprint prose around **formalization status and TODOs**: rewords remarks in `ch06_spectral.tex`, `ch12_semigroup.tex`, and `ch13_algebraic_ft.tex` to better describe which statements are vacuous/TODO, which results are axiom-backed, and where the current statements are stronger than the paper (without referencing Lean internals).
> 
> Tightens `ch14_parent_hamiltonian.tex` language to explicitly mark `parentInteraction`/`localTerm` as placeholders pending an explicit projector construction, and applies small editorial cleanups (including missing trailing newlines and comment whitespace, e.g. `macros/web.tex`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe0bf369bdbbf0d337c0ca848bd582e14da34ec5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->