### PR TITLE
fix(blueprint): add missing Lean tag for conditional expectation in Ch6

### DIFF
--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -545,6 +545,7 @@ canonical-form separation arguments.
 
 \begin{theorem}[Scalar map is a conditional expectation]
     \label{thm:scalar_conditional_expectation_isConditionalExpectation}
+    \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
     \leanok
     \uses{def:is_conditional_expectation, def:scalar_conditional_expectation,
           def:tp_kraus,


### PR DESCRIPTION
### Motivation

- The blueprint theorem `thm:scalar_conditional_expectation_isConditionalExpectation` in Ch6 had `\leanok` but was missing the corresponding `\lean{}` declaration reference, leaving the blueprint out of sync with the formalized Lean code.

### Description

- Added `\lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}` tag to `blueprint/src/chapter/ch06_spectral.tex`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) and Blueprint Lint (`lint-blueprint.yml`) to validate the change.

---
Addresses #323

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a missing `\lean{...}` tag; no mathematical statements or code behavior are altered.
> 
> **Overview**
> Adds the missing Lean declaration reference `\lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}` to the theorem *"Scalar map is a conditional expectation"* in `ch06_spectral.tex`, aligning the blueprint with the corresponding formalized result.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 976ef151613586404c7e203f8891a0be4d93ab46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->