### PR TITLE
fix(blueprint): mark kappa uniqueness as not-ready in Ch12

### DIFF
--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -502,7 +502,7 @@ which shows that such generators have the standard Lindblad form.
 
 \begin{theorem}[Prop.~7.4, item 2: drift uniqueness modulo phase]
     \label{thm:generatorDecomp_traceless_unique_kappa}
-    \lean{generatorDecomp_traceless_unique_kappa_modPhase}\leanok
+    \lean{generatorDecomp_traceless_unique_kappa_modPhase}\notready
     \uses{def:lindblad_form, def:has_traceless_kraus, def:generator_decomp,
           thm:generatorDecomp_traceless_unique_phi}
     If two Lindblad forms $F, F'$ induce the same generator and


### PR DESCRIPTION
### Motivation

- The blueprint theorem `generatorDecomp_traceless_unique_kappa_modPhase` (drift uniqueness modulo phase) was tagged `\leanok` but the corresponding Lean proof at `Uniqueness.lean:75` still contains `sorry`, see #329.

### Description

- Update `blueprint/src/chapter/ch12_semigroup.tex`: change `\leanok` to `\notready` for the kappa uniqueness theorem to reflect the actual proof status.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #329

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts blueprint readiness metadata for a theorem, with no impact on implementation or mathematical statements.
> 
> **Overview**
> Marks the Chapter 12 blueprint theorem `generatorDecomp_traceless_unique_kappa_modPhase` (drift uniqueness modulo phase) as `\notready` instead of `\leanok`, reflecting that the corresponding Lean proof is not yet complete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37a7cc5a84d17dafa93164a67197e6815ee4fd69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->