### PR TITLE
fix(blueprint): link centre-is-scalar lemma to Lean proof in Ch13

### DIFF
--- a/blueprint/lean_decls
+++ b/blueprint/lean_decls
@@ -344,6 +344,7 @@ MPSTensor.zGaugeEntry_mul_right
 MPSTensor.zGaugeEntry_pow_eq_one_of_pow_eq
 MPSTensor.zeroMPSTensor
 Matrix.charpoly_eq_of_forall_trace_pow_eq
+Matrix.isScalar_of_commute_span_eq_top
 Matrix.omegaProj
 Matrix.sum_pow_eq_implies_multiset_eq
 Matrix.tensorMapId

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -198,7 +198,8 @@ operation on the physical indices.
 \end{remark}
 
 \begin{lemma}[Centre of $\MN{D}$]\label{lem:center_scalar}
-    \notready
+    \lean{Matrix.isScalar_of_commute_span_eq_top}
+    \leanok
     If $Z \in \MN{D}$ commutes with every element of $\MN{D}$, then
     $Z = \lambda \Id_D$ for some $\lambda \in \C$.
 \end{lemma}


### PR DESCRIPTION
### Motivation

- The blueprint `lem:center_scalar` in Ch13 (Algebraic FT) was marked `\notready` despite the mathematical content already being proved in `TNLean/Algebra/ScalarCommutant.lean`. Continues audit of Ch13, see #330.

### Description

- Update `blueprint/src/chapter/ch13_algebraic_ft.tex`: replace `\notready` with `\leanok` and add `\lean{Matrix.isScalar_of_commute_span_eq_top}` on `lem:center_scalar`.
- Add `Matrix.isScalar_of_commute_span_eq_top` to `blueprint/lean_decls`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #330

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates blueprint documentation/Lean-declaration index to reference an existing lemma, with no runtime or algorithmic behavior changes.
>
> **Overview**
> Marks the Chapter 13 lemma on the centre of \MN{D} as formally proved by linking it to `Matrix.isScalar_of_commute_span_eq_top` and switching it from `\notready` to `\leanok`.
>
> Adds `Matrix.isScalar_of_commute_span_eq_top` to `blueprint/lean_decls` so it is tracked in the project's Lean declaration inventory.
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f27740a4dabb9e480497df139f281a1e52e71e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->