### PR TITLE
doc(blueprint): add §14.3–14.5 ground state uniqueness, spectral gap, BNT

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -169,16 +169,17 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Closure under extension]\label{lem:ground_space_mono}
   \notready
-  \uses{def:ground_space_parent}
-  For every $L \ge 1$,
+  \uses{def:ground_space_parent, def:l_blk_injective}
+  Let $A$ be $L$-block injective (i.e.\ $\Gamma_L$ is injective).
+  Then there is a well-defined embedding
   \[
     G_L(A) \hookrightarrow G_{L+1}(A)
   \]
-  via a natural embedding that extends a coefficient function on $L$ sites to
+  that extends a coefficient function on $L$ sites to
   $L{+}1$ sites by one site on the right.
-  Concretely, if $\phi \in G_L(A)$ with $\phi(\sigma) = \tr(A^\sigma X)$
-  for a unique $X$ (which requires $\Gamma_L$ to be injective, e.g.\ when
-  $A$ is $L$-block injective), then $\tilde\phi \in G_{L+1}(A)$ with
+  Concretely, since $\Gamma_L$ is injective, every $\phi \in G_L(A)$
+  has a unique preimage $X$ with $\phi(\sigma) = \tr(A^\sigma X)$,
+  and the extension is $\tilde\phi \in G_{L+1}(A)$ with
   \[
     \tilde\phi(\sigma,j) = \tr(A^\sigma A^j X).
   \]
@@ -189,7 +190,7 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   \uses{def:ground_space_parent}
   \notready
   If $\phi = \Gamma_L(X)$ then $\tilde\phi = \Gamma_{L+1}(X)$.
-  When $\Gamma_L$ is injective, $X$ is uniquely determined by $\phi$,
+  By $L$-block injectivity, $X$ is uniquely determined by $\phi$,
   so the extension map is well-defined and independent of choices.
 \end{proof}
 
@@ -267,7 +268,8 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}
-  \uses{lem:ground_space_intersection, lem:ground_space_mono}
+  \uses{lem:ground_space_intersection, lem:ground_space_mono,
+        lem:parent_hamiltonian_annihilates}
   \notready
   Normality gives injectivity of $A^{[L_0]}$.
   The interaction range $L_0{+}1$ provides enough overlap ($L_0$ sites)
@@ -338,20 +340,24 @@ Lucia~\cite{Kastoryano2018Martingale}.
   Definition~\ref{def:parent_interaction}.  Let $h_L(A) := \Pi_{G_L(A)^\perp}$
   be the $L$-site parent interaction, and for each chain length and site $i$
   let $h_i$ denote its translate as in Definition~\ref{def:local_term_parent}.
-  Then the adjacent interaction terms $h_i$ and $h_{i+1}$ satisfy the
-  martingale condition of Theorem~\ref{thm:martingale_criterion} with constants
-  $c_{ij}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
+  Then for every pair of overlapping terms $h_i$ and $h_j$ with
+  $0 < |i - j| < L$ (i.e.\ whose $L$-site supports share at least one site),
+  the martingale condition of Theorem~\ref{thm:martingale_criterion} holds with
+  constants $c_{ij}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
 \end{lemma}
 
 \begin{proof}
   \uses{lem:ground_space_intersection, def:injective}
   \notready
-  Injectivity bounds the angle between $\ker(h_i)$ and $\ker(h_j)$
-  away from zero: the intersection property
-  (Lemma~\ref{lem:ground_space_intersection}) shows that overlapping
-  ground spaces intersect in a controlled way.
+  Two terms $h_i, h_j$ with $0 < |i-j| < L$ have supports overlapping
+  in $L - |i-j|$ sites.  Since $A$ is injective, the intersection property
+  (Lemma~\ref{lem:ground_space_intersection}) bounds the angle between
+  $\ker(h_i)$ and $\ker(h_j)$ away from zero for any such overlap.
+  (When $|i-j| = 1$ the overlap is $L-1$ sites; for larger separations the
+  overlap shrinks but injectivity still controls the intersection.)
   This provides the required lower bound on
-  $h_i h_j + h_j h_i$~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
+  $h_i h_j + h_j h_i$ for every overlapping
+  pair~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -248,15 +248,21 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   Re-interpreting each blocked site as $L_0$ original sites, this
   yields intersection identities for windows whose lengths are
   multiples of $L_0$.  To handle windows at single-site granularity
-  (needed since $N$ may not be divisible by $L_0$), we use
-  Lemma~\ref{lem:ground_space_mono}: closure under extension allows
-  growing a blocked-site window by one \emph{original} site at a time,
-  since $L_0$-block injectivity provides the required left inverse
-  at each step.
+  (needed since $N$ may not be divisible by $L_0$), we first note
+  that $L_0$-block injectivity implies $m$-block injectivity for
+  every $m \ge L_0$: if $\Gamma_{L_0}$ is injective then
+  $\Gamma_m = (\Gamma_{L_0} \otimes \mathrm{id}^{\otimes(m-L_0)})
+  \circ \Delta$ for an appropriate reshuffling $\Delta$, so
+  $\Gamma_m$ inherits injectivity.  In particular, the hypothesis of
+  Lemma~\ref{lem:ground_space_mono} (requiring injectivity of
+  $\Gamma_m$) is satisfied at every window length $m \ge L_0$
+  encountered during the iteration.
   Starting from an $(L_0{+}1)$-site window, iterate: each step
   extends the ground-space window by one original site to the right,
   using either the blocked intersection property (when the window
-  length is a multiple of $L_0$) or the closure lemma (otherwise).
+  length is a multiple of $L_0$) or the closure lemma
+  (Lemma~\ref{lem:ground_space_mono}, whose injectivity hypothesis
+  holds by the observation above).
   After $N - (L_0{+}1)$ iterations the window spans all $N$ sites and
   wraps around the periodic chain.
   Comparing the two descriptions of a ground state on the closed chain
@@ -541,13 +547,14 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   Linearity of the kernel yields the inclusion.
 
   \textbf{$\subseteq$}: Take $\psi \in \ker(H_N)$.
-  The block-diagonal structure of $A$ gives the containment
-  $G_L(A) \subseteq \sum_k G_L(A_k)$: any local ground state of $A$
-  on $L$ sites is a sum of local ground states of the individual
-  blocks, because the off-diagonal blocks vanish in the transfer map
-  (the canonical form ensures that distinct blocks have orthogonal
-  images under $\Gamma_L$ for $L \ge L_0$, so the sum is in fact
-  direct for sufficiently long windows).
+  The block-diagonal structure of $A$ gives, at the interaction
+  range $L_0{+}1$ used in the Hamiltonian, the containment
+  $G_{L_0+1}(A) \subseteq \sum_k G_{L_0+1}(A_k)$: any local ground
+  state of $A$ on $L_0{+}1$ sites is a sum of local ground states of
+  the individual blocks, because the off-diagonal blocks vanish in
+  the transfer map (the canonical form ensures that distinct blocks
+  have orthogonal images under $\Gamma_{L_0+1}$ for
+  $L_0{+}1 \ge L_0$, so the sum is in fact direct).
   Each normal block $A_k$ has injectivity length $L_k \le L_0$, so
   the $L_k$-blocked tensor $A_k^{[L_k]}$ is injective.
   Applying Lemma~\ref{lem:ground_space_intersection} to this injective

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -354,7 +354,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
   be the $L$-site parent interaction, and for each chain length and site $i$
   let $h_i$ denote its translate as in Definition~\ref{def:local_term_parent}.
   Then for every pair of overlapping terms $h_i$ and $h_j$ with
-  $0 < |i - j| < L$ (i.e.\ whose $L$-site supports share at least one site),
+  $0 < d_N(i,j) < L$, where $d_N(i,j) := \min(|i-j|,\, N-|i-j|)$ is the
+  cyclic distance on the ring (i.e.\ whose $L$-site supports share at
+  least one site under periodic boundary conditions),
   the martingale condition of Theorem~\ref{thm:martingale_criterion} holds with
   constants $c_{ij}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
   (When $L = 1$ the interaction terms have disjoint supports, so there are no
@@ -365,8 +367,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \begin{proof}
   \uses{lem:ground_space_intersection, def:injective}
   \notready
-  Two terms $h_i, h_j$ with $0 < |i-j| < L$ have supports overlapping
-  in $L - |i-j|$ sites.  Since $A$ is injective, the intersection property
+  Two terms $h_i, h_j$ with $0 < d_N(i,j) < L$ have supports overlapping
+  in $L - d_N(i,j)$ sites (where $d_N$ is the cyclic distance on
+  the $N$-site ring).  Since $A$ is injective, the intersection property
   (Lemma~\ref{lem:ground_space_intersection}) gives the qualitative identity
   $\ker(h_i) \cap \ker(h_j) = G_{[i,j+L-1]}(A)$.
   Because the local Hilbert space is finite-dimensional, the subspaces
@@ -377,14 +380,14 @@ Lucia~\cite{Kastoryano2018Martingale}.
   Hence the Friedrichs angle $\theta_{|i-j|}$ between $\ker(h_i)$ and
   $\ker(h_j)$ is strictly positive (for the fixed injective tensor
   $A$).  Because the angle depends only on the overlap pattern
-  $|i-j| \in \{1,\dots,L-1\}$ and not on the absolute position,
+  $d_N(i,j) \in \{1,\dots,L-1\}$ and not on the absolute position,
   the number of distinct angles is at most $L-1$.
   Let $\alpha := \max_{1 \le s < L} \cos\theta_s < 1$ be the
   worst-case cosine of the Friedrichs angles.
 
   \textbf{Row-sum bound.}
   Since $L \ge 2$, each site $i$ overlaps with at most $2(L-1)$
-  neighbours (those $j$ with $0 < |i-j| < L$).
+  neighbours (those $j$ with $0 < d_N(i,j) < L$).
   Set $c_{ij} := \tfrac{1}{2(L-1)}$ for every overlapping pair
   and $c_{ij} := 0$ otherwise.
   Then
@@ -411,7 +414,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
   For general $L > 2$, the uniform constants $c_{ij} = \tfrac{1}{2(L-1)}$
   make the condition $\alpha < \tfrac{1}{2(L-1)}$ increasingly restrictive
   as $L$ grows.  A more refined choice of separation-dependent constants
-  $c_{ij} = c_{|i-j|}$ that weight small-separation (large-overlap) pairs
+  $c_{ij} = c_{d_N(i,j)}$ that weight small-separation (large-overlap) pairs
   more heavily can exploit the exponential decay of the Friedrichs cosine
   $\alpha_s$ in $s$ to satisfy the row-sum constraint.
   However, this refinement is not needed for the main result: in

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -349,7 +349,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
   \notready
   \uses{thm:martingale_criterion, def:parent_interaction,
         def:local_term_parent, lem:ground_space_intersection, def:injective}
-  Let $A$ be injective and fix an interaction range $L$ as in
+  Let $A$ be injective and fix an interaction range $L \ge 2$ as in
   Definition~\ref{def:parent_interaction}.  Let $h_L(A) := \Pi_{G_L(A)^\perp}$
   be the $L$-site parent interaction, and for each chain length and site $i$
   let $h_i$ denote its translate as in Definition~\ref{def:local_term_parent}.
@@ -357,6 +357,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
   $0 < |i - j| < L$ (i.e.\ whose $L$-site supports share at least one site),
   the martingale condition of Theorem~\ref{thm:martingale_criterion} holds with
   constants $c_{ij}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
+  (When $L = 1$ the interaction terms have disjoint supports, so there are no
+  overlapping pairs and the spectral gap follows directly without the
+  martingale machinery.)
 \end{lemma}
 
 \begin{proof}
@@ -380,25 +383,38 @@ Lucia~\cite{Kastoryano2018Martingale}.
   worst-case cosine of the Friedrichs angles.
 
   \textbf{Row-sum bound.}
-  Each site $i$ overlaps with at most $2(L-1)$ neighbours
-  (those $j$ with $0 < |i-j| < L$).
+  Since $L \ge 2$, each site $i$ overlaps with at most $2(L-1)$
+  neighbours (those $j$ with $0 < |i-j| < L$).
   Set $c_{ij} := \tfrac{1}{2(L-1)}$ for every overlapping pair
   and $c_{ij} := 0$ otherwise.
   Then
   $\sum_{j \ne i} c_{ij} \le 2(L-1)\cdot\tfrac{1}{2(L-1)} = 1$,
   satisfying the row-sum hypothesis of
   Theorem~\ref{thm:martingale_criterion}.
+
+  \textbf{Positivity of $\gamma$.}
   The Friedrichs angle bound gives, for each overlapping pair,
-  $h_i h_j + h_j h_i \ge -\alpha\,(h_i + h_j)$,
-  so the martingale inequality holds whenever
-  $c_{ij}(1-\gamma) \ge \alpha$, i.e.\
-  $\gamma \le 1 - 2(L-1)\alpha$.
+  $h_i h_j + h_j h_i \ge -\alpha\,(h_i + h_j)$.
+  The martingale inequality holds with
+  $\gamma = 1 - 2(L-1)\alpha$,
+  which requires $c_{ij}(1-\gamma) = \tfrac{\alpha}{1} \cdot 1 = \alpha$
+  (matching the Friedrichs bound exactly when
+  $c_{ij} = \tfrac{1}{2(L-1)}$).
+  Since $\alpha < 1$ (the Friedrichs angle is strictly positive),
+  it remains to show $\gamma > 0$, i.e.\ $\alpha < \tfrac{1}{2(L-1)}$.
   In the blocked picture of
-  Theorem~\ref{thm:parent_hamiltonian_gapped}, $L = 2$ (so the
-  interaction graph has degree~$2$) and the quantitative gap
-  $\gamma > 0$ follows from the Nachtergaele finite-size
-  criterion~\cite{Nachtergaele1996Spectral}; the constants depend
-  only on $A$ and are independent
+  Theorem~\ref{thm:parent_hamiltonian_gapped}, $L = 2$ and each site
+  overlaps with at most $2$ neighbours, so the condition reduces to
+  $\alpha < \tfrac{1}{2}$, which is guaranteed by the
+  Nachtergaele finite-size criterion~\cite{Nachtergaele1996Spectral}
+  applied to the injective blocked tensor.
+  For general $L > 2$, the stronger bound
+  $\alpha < \tfrac{1}{2(L-1)}$ follows from the exponential decay of
+  correlations in the injective MPS transfer operator
+  (the Friedrichs cosine $\alpha_s$ for overlap $L - s$ decays
+  exponentially in $s$, so the sum $2(L-1)\alpha$ remains bounded
+  below $1$).
+  In all cases, the constants depend only on $A$ and are independent
   of~$N$~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -187,7 +187,7 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-  \uses{def:ground_space_parent}
+  \uses{def:ground_space_parent, def:l_blk_injective}
   \notready
   If $\phi = \Gamma_L(X)$ then $\tilde\phi = \Gamma_{L+1}(X)$.
   By $L$-block injectivity, $X$ is uniquely determined by $\phi$,
@@ -364,7 +364,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
   \notready
   \uses{thm:martingale_criterion, lem:martingale_mps,
         def:parent_hamiltonian}
-  For an injective MPS tensor $A$ with injectivity length $L_0$, let
+  For an $L_0$-block injective MPS tensor $A$, let
   $L := L_0 + 1$ be the interaction range.
   There exists $\gamma > 0$ such that for all $N \ge 2L$,
   \[

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -392,6 +392,11 @@ Lucia~\cite{Kastoryano2018Martingale}.
   least one site under periodic boundary conditions),
   the martingale condition of Theorem~\ref{thm:martingale_criterion} holds with
   constants $c_{ij}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
+  \emph{Note:} The proof below fully establishes the martingale constants
+  only for $L = 2$; for $L > 2$ the existence of suitable constants is
+  asserted without complete proof (see the remark at the end of the proof).
+  Only the $L = 2$ case is used in this chapter
+  (Theorem~\ref{thm:parent_hamiltonian_gapped}).
   (When $L = 1$ the interaction terms have disjoint supports, so there are no
   overlapping pairs and the spectral gap follows directly without the
   martingale machinery.)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -397,9 +397,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
   $h_i h_j + h_j h_i \ge -\alpha\,(h_i + h_j)$.
   The martingale inequality holds with
   $\gamma = 1 - 2(L-1)\alpha$,
-  which requires $c_{ij}(1-\gamma) = \tfrac{\alpha}{1} \cdot 1 = \alpha$
-  (matching the Friedrichs bound exactly when
-  $c_{ij} = \tfrac{1}{2(L-1)}$).
+  which requires
+  $c_{ij}(1-\gamma) = \tfrac{1}{2(L-1)} \cdot 2(L-1)\alpha = \alpha$
+  (matching the Friedrichs bound exactly).
   Since $\alpha < 1$ (the Friedrichs angle is strictly positive),
   it remains to show $\gamma > 0$, i.e.\ $\alpha < \tfrac{1}{2(L-1)}$.
   In the blocked picture of
@@ -408,12 +408,15 @@ Lucia~\cite{Kastoryano2018Martingale}.
   $\alpha < \tfrac{1}{2}$, which is guaranteed by the
   Nachtergaele finite-size criterion~\cite{Nachtergaele1996Spectral}
   applied to the injective blocked tensor.
-  For general $L > 2$, the stronger bound
-  $\alpha < \tfrac{1}{2(L-1)}$ follows from the exponential decay of
-  correlations in the injective MPS transfer operator
-  (the Friedrichs cosine $\alpha_s$ for overlap $L - s$ decays
-  exponentially in $s$, so the sum $2(L-1)\alpha$ remains bounded
-  below $1$).
+  For general $L > 2$, the uniform constants $c_{ij} = \tfrac{1}{2(L-1)}$
+  make the condition $\alpha < \tfrac{1}{2(L-1)}$ increasingly restrictive
+  as $L$ grows.  A more refined choice of separation-dependent constants
+  $c_{ij} = c_{|i-j|}$ that weight small-separation (large-overlap) pairs
+  more heavily can exploit the exponential decay of the Friedrichs cosine
+  $\alpha_s$ in $s$ to satisfy the row-sum constraint.
+  However, this refinement is not needed for the main result: in
+  Theorem~\ref{thm:parent_hamiltonian_gapped} below, the argument is
+  applied only with $L = 2$ in the blocked picture.
   In all cases, the constants depend only on $A$ and are independent
   of~$N$~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
 \end{proof}
@@ -441,7 +444,16 @@ Lucia~\cite{Kastoryano2018Martingale}.
   dimension $D$.  Each blocked site represents $L_0$ original sites,
   so the range-$L = 2L_0$ interaction on the original chain corresponds
   exactly to a range-$2$ interaction on the blocked chain (two blocked
-  sites).  The divisibility condition $L_0 \mid N$ ensures the blocking
+  sites).
+  \emph{Remark on interaction range:}
+  Theorem~\ref{thm:unique_gs_injective} establishes ground-state
+  uniqueness at range $L_0{+}1$, whereas here we use range $2L_0$.
+  The ground spaces are nested: increasing the interaction range can
+  only shrink (or preserve) the ground space, so uniqueness at range
+  $L_0{+}1$ implies uniqueness at range $2L_0$.  The larger range is
+  needed here so that, after $L_0$-blocking, each blocked interaction
+  term spans exactly $2$ blocked sites, enabling the martingale
+  machinery with $L = 2$.  The divisibility condition $L_0 \mid N$ ensures the blocking
   is compatible with the periodic chain.
   Apply Lemma~\ref{lem:martingale_mps} to the
   injective tensor $A^{[L_0]}$ with range $2$ to obtain the martingale

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -239,14 +239,16 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   \uses{lem:ground_space_intersection, lem:ground_space_mono,
         lem:parent_hamiltonian_annihilates}
   \notready
-  After blocking $L_0$ sites, $A^{[L_0]}$ is injective.
-  The interaction range $L_0{+}1$ ensures adjacent windows overlap in
-  $L_0$ sites, which is enough for the blocked tensor to be injective
-  on the overlap.
-  Iterate the intersection property
-  (Lemma~\ref{lem:ground_space_intersection}) across the chain: each
-  step extends the ground-space window by one site.
-  After $N - L_0$ iterations the window wraps around the periodic chain.
+  The proof proceeds in unblocked (original-site) coordinates to avoid
+  any divisibility assumption on $N$.
+  Since $A$ is $L_0$-block injective, the map $\Gamma_{L_0}$ is
+  injective, so Lemma~\ref{lem:ground_space_intersection} applies to
+  windows of length $\ge L_0{+}1$.
+  Starting from an $(L_0{+}1)$-site window, iterate the intersection
+  property: each step extends the ground-space window by one original
+  site to the right.
+  After $N - (L_0{+}1)$ iterations the window spans all $N$ sites and
+  wraps around the periodic chain.
   Comparing the two descriptions of a ground state on the closed chain
   shows that the boundary matrix $X$ must commute with every word matrix
   $A^{[L_0],\sigma}$.
@@ -377,7 +379,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
   The intersection identity shows that $\ker(h_i) \cap \ker(h_j)$ is
   exactly $G_{[i,j+L-1]}(A)$; in particular there is no non-trivial
   vector in one kernel that is orthogonal to the other yet lies in both.
-  Hence the Friedrichs angle $\theta_{|i-j|}$ between $\ker(h_i)$ and
+  Hence the Friedrichs angle $\theta_{d_N(i,j)}$ between $\ker(h_i)$ and
   $\ker(h_j)$ is strictly positive (for the fixed injective tensor
   $A$).  Because the angle depends only on the overlap pattern
   $d_N(i,j) \in \{1,\dots,L-1\}$ and not on the absolute position,
@@ -509,9 +511,12 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   (the canonical form ensures that distinct blocks have orthogonal
   images under $\Gamma_L$ for $L \ge L_0$, so the sum is in fact
   direct for sufficiently long windows).
-  Iterating the intersection property
-  (Lemma~\ref{lem:ground_space_intersection}) across the chain for
-  each block $A_k$ independently, and using
+  Each normal block $A_k$ has injectivity length $L_k \le L_0$, so
+  the $L_k$-blocked tensor $A_k^{[L_k]}$ is injective.
+  Applying Lemma~\ref{lem:ground_space_intersection} to this injective
+  blocked tensor (in unblocked coordinates, as in
+  Theorem~\ref{thm:unique_gs_injective}) and iterating across the
+  chain for each block independently, and using
   Theorem~\ref{thm:unique_gs_normal} for each normal block, the
   component of $\psi$ associated with block $A_k$ must be proportional
   to $V^{(N)}(A_k)$.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -364,17 +364,19 @@ Lucia~\cite{Kastoryano2018Martingale}.
   (Lemma~\ref{lem:ground_space_intersection}) gives the qualitative identity
   $\ker(h_i) \cap \ker(h_j) = G_{[i,j+L-1]}(A)$.
   Because the local Hilbert space is finite-dimensional, the subspaces
-  $\ker(h_i)$ and $\ker(h_j)$ live in a fixed finite-dimensional space,
-  and the Friedrichs angle between them is a continuous function of $A$.
-  The intersection identity excludes the degenerate case where the
-  angle is zero (which would require a non-trivial vector in one kernel
-  that is orthogonal to the other yet lies in both), so by
-  compactness (the angle depends continuously on $A$ over a compact
-  parameter space for fixed $d,D$) the angle is bounded away from zero.
-  This lower bound on the angle translates into the required operator
-  inequality $h_i h_j + h_j h_i \ge -c_{ij}(1-\gamma)(h_i + h_j)$
-  for every overlapping
-  pair~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
+  $\ker(h_i)$ and $\ker(h_j)$ live in a fixed finite-dimensional space.
+  The intersection identity shows that $\ker(h_i) \cap \ker(h_j)$ is
+  exactly $G_{[i,j+L-1]}(A)$; in particular there is no non-trivial
+  vector in one kernel that is orthogonal to the other yet lies in both.
+  Hence the Friedrichs angle $\theta$ between $\ker(h_i)$ and
+  $\ker(h_j)$ is strictly positive (for the fixed injective tensor
+  $A$).  Since $\theta > 0$, there exist constants $c_{ij} \ge 0$ and
+  $\gamma > 0$, depending only on $A$ and the pair $(i,j)$, such that
+  $h_i h_j + h_j h_i \ge -c_{ij}(1-\gamma)(h_i + h_j)$.
+  Because the number of distinct overlap patterns is bounded by $L-1$
+  (independent of~$N$), the constants can be chosen uniformly for all
+  overlapping
+  pairs~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}
@@ -382,8 +384,10 @@ Lucia~\cite{Kastoryano2018Martingale}.
   \uses{thm:martingale_criterion, lem:martingale_mps,
         def:parent_hamiltonian}
   For an $L_0$-block injective MPS tensor $A$, let
-  $L := L_0 + 1$ be the interaction range.
-  There exists $\gamma > 0$ such that for all $N \ge 2L$,
+  $L := 2L_0$ be the interaction range (two blocked sites in the
+  $L_0$-blocked picture).
+  There exists $\gamma > 0$ such that for all $N \ge 2L$ with
+  $L_0 \mid N$,
   \[
     \lambda_{\min}^+\bigl(H_N(A,L)\bigr) \ge \gamma,
   \]
@@ -394,12 +398,16 @@ Lucia~\cite{Kastoryano2018Martingale}.
   \uses{thm:martingale_criterion, lem:martingale_mps}
   \notready
   Since $A$ is $L_0$-block injective, the blocked tensor
-  $A^{[L_0]}$ is injective.  The parent interaction for $A$ with range
-  $L = L_0 + 1$ can be expressed in terms of $A^{[L_0]}$ with range $2$
-  (two blocked sites).  Apply Lemma~\ref{lem:martingale_mps} to the
-  injective tensor $A^{[L_0]}$ to obtain the martingale constants
-  $c_{ij}$ and $\gamma > 0$.  These constants depend only on $A^{[L_0]}$
-  (hence only on $A$ and $L_0$), not on $N$.
+  $A^{[L_0]}$ is injective with physical dimension $d^{L_0}$ and bond
+  dimension $D$.  Each blocked site represents $L_0$ original sites,
+  so the range-$L = 2L_0$ interaction on the original chain corresponds
+  exactly to a range-$2$ interaction on the blocked chain (two blocked
+  sites).  The divisibility condition $L_0 \mid N$ ensures the blocking
+  is compatible with the periodic chain.
+  Apply Lemma~\ref{lem:martingale_mps} to the
+  injective tensor $A^{[L_0]}$ with range $2$ to obtain the martingale
+  constants $c_{ij}$ and $\gamma > 0$.  These constants depend only on
+  $A^{[L_0]}$ (hence only on $A$ and $L_0$), not on $N$.
   Theorem~\ref{thm:martingale_criterion} then gives the uniform gap
   $\lambda_{\min}^+(H_N) \ge \gamma$~\cite{Fannes1992Finitely,
   Nachtergaele1996Spectral}.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -241,12 +241,22 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   \notready
   The proof proceeds in unblocked (original-site) coordinates to avoid
   any divisibility assumption on $N$.
-  Since $A$ is $L_0$-block injective, the map $\Gamma_{L_0}$ is
-  injective, so Lemma~\ref{lem:ground_space_intersection} applies to
-  windows of length $\ge L_0{+}1$.
-  Starting from an $(L_0{+}1)$-site window, iterate the intersection
-  property: each step extends the ground-space window by one original
-  site to the right.
+  Since $A$ is $L_0$-block injective, the blocked tensor
+  $A^{[L_0]}$ is injective (Definition~\ref{def:injective}).
+  Lemma~\ref{lem:ground_space_intersection} applies to $A^{[L_0]}$,
+  giving intersection identities for windows of blocked sites.
+  Re-interpreting each blocked site as $L_0$ original sites, this
+  yields intersection identities for windows whose lengths are
+  multiples of $L_0$.  To handle windows at single-site granularity
+  (needed since $N$ may not be divisible by $L_0$), we use
+  Lemma~\ref{lem:ground_space_mono}: closure under extension allows
+  growing a blocked-site window by one \emph{original} site at a time,
+  since $L_0$-block injectivity provides the required left inverse
+  at each step.
+  Starting from an $(L_0{+}1)$-site window, iterate: each step
+  extends the ground-space window by one original site to the right,
+  using either the blocked intersection property (when the window
+  length is a multiple of $L_0$) or the closure lemma (otherwise).
   After $N - (L_0{+}1)$ iterations the window spans all $N$ sites and
   wraps around the periodic chain.
   Comparing the two descriptions of a ground state on the closed chain
@@ -273,7 +283,16 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   \uses{lem:ground_space_intersection, lem:ground_space_mono,
         lem:parent_hamiltonian_annihilates}
   \notready
-  Normality gives injectivity of $A^{[L_0]}$.
+  Normality gives injectivity of $A^{[L_0]}$
+  (Definition~\ref{def:injective}).
+  Since $A^{[L_0]}$ is injective,
+  Lemma~\ref{lem:ground_space_intersection} applies to it directly,
+  providing intersection identities for windows measured in blocked
+  sites.  As in Theorem~\ref{thm:unique_gs_injective}, re-interpret
+  these in original-site coordinates: each blocked site corresponds to
+  $L_0$ original sites, and the closure lemma
+  (Lemma~\ref{lem:ground_space_mono}) extends windows at single-site
+  granularity using the $L_0$-block injectivity.
   The interaction range $L_0{+}1$ provides enough overlap ($L_0$ sites)
   for a single intersection step to grow the window by one site.
   Iterating across the periodic chain of length $N \ge 2(L_0+1)$ ensures
@@ -321,10 +340,16 @@ Lucia~\cite{Kastoryano2018Martingale}.
   sum is $\ge 0$.
   For the overlapping sum, the martingale condition gives
   $h_i h_j + h_j h_i \ge -c_{ij}(1-\gamma)(h_i + h_j)$.
-  Since both sides are symmetric in $i,j$, we may assume
-  $c_{ij} = c_{ji}$ without loss of generality (the same
-  symmetric expression is bounded by the same constant regardless
-  of the ordering of the pair).
+  Since $h_i h_j + h_j h_i$ is symmetric in $i,j$, we may replace
+  $c_{ij}$ and $c_{ji}$ by $\bar{c}_{ij} := \max(c_{ij}, c_{ji})$;
+  the pairwise bounds are preserved.
+  In the MPS application the constants $c_{ij} = 1/(2(L-1))$ depend
+  only on the cyclic distance $d_N(i,j)$ and are therefore already
+  symmetric, so symmetrization does not affect the row-sum bound.
+  (In general, replacing $c$ by the symmetrized $\bar{c}$ may inflate
+  row sums; the abstract statement should either assume symmetric
+  constants or verify that symmetrization preserves the row-sum
+  hypothesis.)
   Summing over unordered pairs $\{i,j\}$:
   \[
     \sum_{\{i,j\},\,\text{overlap}} (h_i h_j + h_j h_i)
@@ -410,9 +435,21 @@ Lucia~\cite{Kastoryano2018Martingale}.
   In the blocked picture of
   Theorem~\ref{thm:parent_hamiltonian_gapped}, $L = 2$ and each site
   overlaps with at most $2$ neighbours, so the condition reduces to
-  $\alpha < \tfrac{1}{2}$, which is guaranteed by the
-  Nachtergaele finite-size criterion~\cite{Nachtergaele1996Spectral}
-  applied to the injective blocked tensor.
+  $\alpha < \tfrac{1}{2}$.  For $L = 2$ with an injective tensor,
+  the two projectors $h_i$ and $h_{i+1}$ act on a finite-dimensional
+  space, and the intersection property
+  (Lemma~\ref{lem:ground_space_intersection}) guarantees that
+  $\ker(h_i) \cap \ker(h_{i+1})$ is exactly $G_{[i,i+2]}(A)$;
+  hence $\|P_i P_{i+1}\| < 1$ (the Friedrichs cosine is strictly
+  less than~1).  On a finite-dimensional space with two projectors,
+  the Friedrichs cosine satisfies the quantitative bound
+  $\alpha \le 1 - c_{\min}$ where $c_{\min} > 0$ depends on the
+  minimal principal angle between the two kernels.  The bound
+  $\alpha < \tfrac{1}{2}$ then follows from the
+  Nachtergaele finite-size criterion~\cite{Nachtergaele1996Spectral},
+  which establishes that the overlap $\|P_i P_{i+1}\|$ for injective
+  MPS is bounded away from $1$ by a constant depending only on the
+  tensor~$A$.
   For general $L > 2$, the uniform constants $c_{ij} = \tfrac{1}{2(L-1)}$
   make the condition $\alpha < \tfrac{1}{2(L-1)}$ increasingly restrictive
   as $L$ grows.  A more refined choice of separation-dependent constants

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -159,5 +159,248 @@ translated copies of the local interaction.
   The MPV state is frustration-free for the parent model.
 \end{lemma}
 
-Sections on injective tensors, gap criteria, and uniqueness of ground states are
-postponed to later installments.
+\section{Uniqueness of the ground state}\label{sec:unique_ground_state}
+
+For an injective MPS tensor, the ground space of the parent Hamiltonian is
+one-dimensional: the MPV is the unique ground state.
+The argument rests on two structural lemmas — closure and intersection —
+which together force the ground space to collapse as the chain length
+grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
+
+\begin{lemma}[Closure under extension]\label{lem:ground_space_mono}
+  \notready
+  \uses{def:ground_space_parent}
+  For every $L \ge 1$,
+  \[
+    G_L(A) \hookrightarrow G_{L+1}(A)
+  \]
+  via the natural embedding that pads a coefficient function on $L$ sites to
+  $L{+}1$ sites by summing over the extra index.
+  Concretely, if $\phi \in G_L(A)$ with $\phi(\sigma) = \tr(A^\sigma X)$, then
+  $\tilde\phi \in G_{L+1}(A)$ with
+  $\tilde\phi(\sigma,j) = \tr(A^\sigma A^j X)$.
+\end{lemma}
+
+\begin{proof}
+  \uses{lem:ground_space_mono}
+  \notready
+  Direct from the definition: if $\phi = \Gamma_L(X)$ then
+  $\tilde\phi = \Gamma_{L+1}(X)$ when the extra site carries a free
+  summation.
+\end{proof}
+
+\begin{lemma}[Intersection property]\label{lem:ground_space_intersection}
+  \notready
+  \uses{def:ground_space_parent, def:injective}
+  Let $A$ be injective (Definition~\ref{def:injective}).
+  For overlapping windows of lengths $L$ starting at adjacent sites,
+  the ground spaces satisfy
+  \[
+    G_{[1,L+1]}(A) \cap G_{[2,L+2]}(A)
+    = G_{[1,L+2]}(A),
+  \]
+  where $G_{[a,b]}$ denotes the ground space on sites $a$ through $b$.
+\end{lemma}
+
+\begin{proof}
+  \uses{lem:ground_space_intersection, def:injective}
+  \notready
+  The inclusion $\supseteq$ follows from
+  Lemma~\ref{lem:ground_space_mono}.
+  For $\subseteq$: take
+  $\phi \in G_{[1,L+1]}(A) \cap G_{[2,L+2]}(A)$.
+  From the first membership, $\phi(\sigma) = \tr(A^\sigma X)$ for some
+  $X \in \MN{D}$.
+  From the second, $\phi(\sigma) = \tr(A^{\sigma'} Y)$ for some $Y$,
+  where $\sigma'$ is the shifted window.
+  On the overlap (sites $2$ through $L{+}1$), injectivity provides a
+  left inverse for the map $X \mapsto \{A^\sigma X\}_\sigma$.
+  This forces $X$ (hence $Y$) to be uniquely determined, and $\phi$
+  extends to $G_{[1,L+2]}(A)$.
+\end{proof}
+
+\begin{theorem}[Unique ground state — injective case]\label{thm:unique_gs_injective}
+  \notready
+  \uses{lem:ground_space_intersection, lem:ground_space_mono,
+        def:parent_hamiltonian, def:injective, def:l_blk_injective}
+  Let $A$ be $L_0$-block injective (Definition~\ref{def:l_blk_injective}).
+  For a periodic chain of length $N \ge 2L_0$, the parent Hamiltonian
+  $H_N(A,L_0)$ has a unique ground state, which is the MPV
+  $\ket{V^{(N)}(A)}$.
+\end{theorem}
+
+\begin{proof}
+  \uses{thm:unique_gs_injective, lem:ground_space_intersection,
+        lem:ground_space_mono, lem:parent_hamiltonian_annihilates}
+  \notready
+  After blocking $L_0$ sites, $A^{[L_0]}$ is injective.
+  Iterate the intersection property
+  (Lemma~\ref{lem:ground_space_intersection}) across the chain: each
+  step extends the ground-space window by one site.
+  After $N - L_0$ iterations the window wraps around the periodic chain.
+  Injectivity forces the boundary matrix $X$ to satisfy
+  $X = A^{[L_0],\sigma} X (A^{[L_0],\sigma'})^{-1}$ for all words,
+  leaving a one-dimensional space.
+  By Lemma~\ref{lem:parent_hamiltonian_annihilates}, the MPV lies in this
+  space.
+\end{proof}
+
+\begin{theorem}[Unique ground state — normal case]\label{thm:unique_gs_normal}
+  \notready
+  \uses{lem:ground_space_intersection, lem:ground_space_mono,
+        def:parent_hamiltonian, def:normal}
+  Let $A$ be normal with injectivity length $L_0$
+  (Definition~\ref{def:normal}).
+  For a periodic chain of length $N \ge L_0 + 1$, the parent Hamiltonian
+  $H_N(A,L_0{+}1)$ has a unique ground state.
+\end{theorem}
+
+\begin{proof}
+  \uses{thm:unique_gs_normal, lem:ground_space_intersection,
+        lem:ground_space_mono}
+  \notready
+  A refined version of the argument for
+  Theorem~\ref{thm:unique_gs_injective}.
+  Normality gives injectivity of $A^{[L_0]}$, and the interaction
+  range $L_0{+}1$ provides enough overlap for a single intersection
+  step to grow the window.
+  The chain wraps in $N - 1$ steps, yielding uniqueness for
+  $N \ge L_0 + 1$~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
+\end{proof}
+
+\section{Spectral gap}\label{sec:spectral_gap}
+
+A frustration-free Hamiltonian is \emph{gapped} if the first excited
+eigenvalue is bounded away from zero uniformly in the chain length $N$.
+For MPS parent Hamiltonians, the spectral gap follows from a martingale
+criterion due to Kastoryano and
+Lucia~\cite{Kastoryano2018Martingale}.
+
+\begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
+  \notready
+  \uses{def:is_frustration_free}
+  Let $H = \sum_{i=1}^n h_i$ be a frustration-free Hamiltonian with
+  projector interaction terms ($h_i^2 = h_i$).
+  Suppose that for every pair of overlapping terms $h_i, h_j$ there
+  exist constants $c_{ij} \ge 0$ and $\gamma > 0$ satisfying
+  \[
+    h_i h_j + h_j h_i
+    \ge -c_{ij}(1-\gamma)(h_i + h_j),
+  \]
+  with $\sum_{j:\,j \ne i} c_{ij} \le 1$ for every $i$.
+  Then the smallest positive eigenvalue of $H$ satisfies
+  $\lambda_{\min}^+(H) \ge \gamma$.
+\end{theorem}
+
+\begin{proof}
+  \uses{thm:martingale_criterion}
+  \notready
+  From $h_i^2 = h_i$,
+  \[
+    H^2 = \sum_i h_i + \sum_{\substack{i < j \\ \text{overlapping}}}
+    (h_i h_j + h_j h_i)
+    + \sum_{\substack{i < j \\ \text{non-overlapping}}}
+    (h_i h_j + h_j h_i).
+  \]
+  Non-overlapping terms commute and each product is PSD, so the last sum
+  is $\ge 0$.
+  The martingale condition bounds the overlapping sum from below:
+  \[
+    \sum_{\text{overlap}} (h_i h_j + h_j h_i)
+    \ge -(1-\gamma) \sum_i \Bigl(\sum_{j \ne i} c_{ij}\Bigr) h_i
+    \ge -(1-\gamma) H.
+  \]
+  Combining: $H^2 \ge H - (1-\gamma)H = \gamma H$.
+  For any eigenvector with $H\psi = \lambda\psi$ and $\lambda > 0$,
+  this gives $\lambda^2 \ge \gamma\lambda$, hence
+  $\lambda \ge \gamma$~\cite{Kastoryano2018Martingale}.
+\end{proof}
+
+\begin{lemma}[Martingale condition for MPS]\label{lem:martingale_mps}
+  \notready
+  \uses{thm:martingale_criterion, def:parent_interaction,
+        lem:ground_space_intersection, def:injective}
+  Let $A$ be injective.
+  The parent interaction terms $h_i = \Pi_{G_L(A)^\perp}$ at adjacent
+  sites satisfy the martingale condition of
+  Theorem~\ref{thm:martingale_criterion} with constants $c_{ij}$ and
+  $\gamma > 0$ depending only on $A$ (not on $N$).
+\end{lemma}
+
+\begin{proof}
+  \uses{lem:martingale_mps, lem:ground_space_intersection, def:injective}
+  \notready
+  Injectivity bounds the angle between $\ker(h_i)$ and $\ker(h_j)$
+  away from zero: the intersection property
+  (Lemma~\ref{lem:ground_space_intersection}) shows that overlapping
+  ground spaces intersect in a controlled way.
+  This provides the required lower bound on
+  $h_i h_j + h_j h_i$~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
+\end{proof}
+
+\begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}
+  \notready
+  \uses{thm:martingale_criterion, lem:martingale_mps,
+        def:parent_hamiltonian}
+  For an injective MPS tensor $A$, there exists $\gamma > 0$ such that
+  for all $N$ sufficiently large,
+  \[
+    \lambda_{\min}^+\bigl(H_N(A,L)\bigr) \ge \gamma,
+  \]
+  i.e.\ the parent Hamiltonian is uniformly gapped.
+\end{theorem}
+
+\begin{proof}
+  \uses{thm:parent_hamiltonian_gapped, thm:martingale_criterion,
+        lem:martingale_mps}
+  \notready
+  Apply Theorem~\ref{thm:martingale_criterion} with the constants from
+  Lemma~\ref{lem:martingale_mps}.
+  Since the constants are independent of $N$, the gap $\gamma$ is
+  uniform~\cite{Fannes1992Finitely, Nachtergaele1996Spectral}.
+\end{proof}
+
+\section{Ground space of non-injective MPS}\label{sec:degenerate_ground_space}
+
+For a general (non-injective) MPS tensor in block-diagonal canonical form,
+the ground space is no longer one-dimensional.
+Instead, it is spanned by the MPVs of the individual normal blocks —
+the basis of normal tensors (BNT) from
+Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
+
+\begin{theorem}[Ground space equals span of BNT]\label{thm:gs_eq_bnt_span}
+  \notready
+  \uses{def:parent_hamiltonian, def:bnt, def:normal_cf_bnt,
+        thm:unique_gs_normal, def:ground_space_parent}
+  Let $A = \bigoplus_{k=1}^g \mu_k A_k$ be in canonical form with BNT
+  separation (Definition~\ref{def:normal_cf_bnt}), where
+  $\{A_1,\ldots,A_g\}$ is a basis of normal tensors
+  (Definition~\ref{def:bnt}).
+  For $N \ge L_0 + 1$ (where $L_0$ is the maximum injectivity length of
+  the blocks), the ground space of the parent Hamiltonian satisfies
+  \[
+    \ker\bigl(H_N(A,L_0{+}1)\bigr)
+    = \spn\bigl\{\ket{V^{(N)}(A_k)} : k = 1,\ldots,g\bigr\}.
+  \]
+\end{theorem}
+
+\begin{proof}
+  \uses{thm:gs_eq_bnt_span, thm:unique_gs_normal,
+        lem:ground_space_intersection, def:bnt}
+  \notready
+  \textbf{$\supseteq$}: Each $A_k$ is normal, so
+  Lemma~\ref{lem:parent_hamiltonian_annihilates} (applied to the
+  block-diagonal structure) gives
+  $H_N(A,L_0{+}1)\ket{V^{(N)}(A_k)} = 0$.
+  Linearity of the kernel yields the inclusion.
+
+  \textbf{$\subseteq$}: Take $\psi \in \ker(H_N)$.
+  The block-diagonal structure of $A$ decomposes the local ground spaces:
+  $G_L(A) = \bigoplus_k G_L(A_k)$ (the off-diagonal blocks do not
+  contribute due to the block structure of the transfer map).
+  Restricting $\psi$ to any injective block $A_k$, the intersection
+  property forces $\psi$ to lie in $\spn\{\ket{V^{(N)}(A_k)}\}$ by
+  Theorem~\ref{thm:unique_gs_normal}.
+  Summing over blocks gives the
+  inclusion~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
+\end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -174,49 +174,54 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   \[
     G_L(A) \hookrightarrow G_{L+1}(A)
   \]
-  via the natural embedding that pads a coefficient function on $L$ sites to
-  $L{+}1$ sites by summing over the extra index.
-  Concretely, if $\phi \in G_L(A)$ with $\phi(\sigma) = \tr(A^\sigma X)$, then
-  $\tilde\phi \in G_{L+1}(A)$ with
-  $\tilde\phi(\sigma,j) = \tr(A^\sigma A^j X)$.
+  via a natural embedding that extends a coefficient function on $L$ sites to
+  $L{+}1$ sites by one site on the right.
+  Concretely, if $\phi \in G_L(A)$ with $\phi(\sigma) = \tr(A^\sigma X)$
+  for a unique $X$ (which requires $\Gamma_L$ to be injective, e.g.\ when
+  $A$ is $L$-block injective), then $\tilde\phi \in G_{L+1}(A)$ with
+  \[
+    \tilde\phi(\sigma,j) = \tr(A^\sigma A^j X).
+  \]
+  A symmetric statement holds for extension by one site on the left.
 \end{lemma}
 
 \begin{proof}
-  \uses{lem:ground_space_mono}
+  \uses{def:ground_space_parent}
   \notready
-  Direct from the definition: if $\phi = \Gamma_L(X)$ then
-  $\tilde\phi = \Gamma_{L+1}(X)$ when the extra site carries a free
-  summation.
+  If $\phi = \Gamma_L(X)$ then $\tilde\phi = \Gamma_{L+1}(X)$.
+  When $\Gamma_L$ is injective, $X$ is uniquely determined by $\phi$,
+  so the extension map is well-defined and independent of choices.
 \end{proof}
 
 \begin{lemma}[Intersection property]\label{lem:ground_space_intersection}
   \notready
   \uses{def:ground_space_parent, def:injective}
   Let $A$ be injective (Definition~\ref{def:injective}).
-  For overlapping windows of lengths $L$ starting at adjacent sites,
+  For overlapping windows of $L{+}1$ sites starting at adjacent positions,
   the ground spaces satisfy
   \[
-    G_{[1,L+1]}(A) \cap G_{[2,L+2]}(A)
-    = G_{[1,L+2]}(A),
+    G_{[0,L]}(A) \cap G_{[1,L+1]}(A)
+    = G_{[0,L+1]}(A),
   \]
-  where $G_{[a,b]}$ denotes the ground space on sites $a$ through $b$.
+  where $G_{[a,b]}$ denotes the ground space on sites $a$ through $b$
+  (a window of $b - a + 1$ sites).
 \end{lemma}
 
 \begin{proof}
-  \uses{lem:ground_space_intersection, def:injective}
+  \uses{lem:ground_space_mono, def:injective}
   \notready
   The inclusion $\supseteq$ follows from
   Lemma~\ref{lem:ground_space_mono}.
   For $\subseteq$: take
-  $\phi \in G_{[1,L+1]}(A) \cap G_{[2,L+2]}(A)$.
+  $\phi \in G_{[0,L]}(A) \cap G_{[1,L+1]}(A)$.
   From the first membership, $\phi(\sigma) = \tr(A^\sigma X)$ for some
   $X \in \MN{D}$.
   From the second, $\phi(\sigma) = \tr(A^{\sigma'} Y)$ for some $Y$,
   where $\sigma'$ is the shifted window.
-  On the overlap (sites $2$ through $L{+}1$), injectivity provides a
+  On the overlap (sites $1$ through $L$), injectivity provides a
   left inverse for the map $X \mapsto \{A^\sigma X\}_\sigma$.
   This forces $X$ (hence $Y$) to be uniquely determined, and $\phi$
-  extends to $G_{[1,L+2]}(A)$.
+  extends to $G_{[0,L+1]}(A)$.
 \end{proof}
 
 \begin{theorem}[Unique ground state — injective case]\label{thm:unique_gs_injective}
@@ -225,22 +230,28 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         def:parent_hamiltonian, def:injective, def:l_blk_injective}
   Let $A$ be $L_0$-block injective (Definition~\ref{def:l_blk_injective}).
   For a periodic chain of length $N \ge 2L_0$, the parent Hamiltonian
-  $H_N(A,L_0)$ has a unique ground state, which is the MPV
-  $\ket{V^{(N)}(A)}$.
+  $H_N(A,L_0{+}1)$ has a unique ground state, which is the MPV
+  $V^{(N)}(A)$.
 \end{theorem}
 
 \begin{proof}
-  \uses{thm:unique_gs_injective, lem:ground_space_intersection,
-        lem:ground_space_mono, lem:parent_hamiltonian_annihilates}
+  \uses{lem:ground_space_intersection, lem:ground_space_mono,
+        lem:parent_hamiltonian_annihilates}
   \notready
   After blocking $L_0$ sites, $A^{[L_0]}$ is injective.
+  The interaction range $L_0{+}1$ ensures adjacent windows overlap in
+  $L_0$ sites, which is enough for the blocked tensor to be injective
+  on the overlap.
   Iterate the intersection property
   (Lemma~\ref{lem:ground_space_intersection}) across the chain: each
   step extends the ground-space window by one site.
   After $N - L_0$ iterations the window wraps around the periodic chain.
-  Injectivity forces the boundary matrix $X$ to satisfy
-  $X = A^{[L_0],\sigma} X (A^{[L_0],\sigma'})^{-1}$ for all words,
-  leaving a one-dimensional space.
+  Comparing the two descriptions of a ground state on the closed chain
+  shows that the boundary matrix $X$ must commute with every word matrix
+  $A^{[L_0],\sigma}$.
+  By injectivity, the matrices $\{A^{[L_0],\sigma}\}$ generate all of
+  $\MN{D}$, so their commutant consists only of scalar multiples of the
+  identity; hence $X$ is scalar and the ground space is one-dimensional.
   By Lemma~\ref{lem:parent_hamiltonian_annihilates}, the MPV lies in this
   space.
 \end{proof}
@@ -251,21 +262,21 @@ grows~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         def:parent_hamiltonian, def:normal}
   Let $A$ be normal with injectivity length $L_0$
   (Definition~\ref{def:normal}).
-  For a periodic chain of length $N \ge L_0 + 1$, the parent Hamiltonian
+  For a periodic chain of length $N \ge 2(L_0 + 1)$, the parent Hamiltonian
   $H_N(A,L_0{+}1)$ has a unique ground state.
 \end{theorem}
 
 \begin{proof}
-  \uses{thm:unique_gs_normal, lem:ground_space_intersection,
-        lem:ground_space_mono}
+  \uses{lem:ground_space_intersection, lem:ground_space_mono}
   \notready
-  A refined version of the argument for
-  Theorem~\ref{thm:unique_gs_injective}.
-  Normality gives injectivity of $A^{[L_0]}$, and the interaction
-  range $L_0{+}1$ provides enough overlap for a single intersection
-  step to grow the window.
-  The chain wraps in $N - 1$ steps, yielding uniqueness for
-  $N \ge L_0 + 1$~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
+  Normality gives injectivity of $A^{[L_0]}$.
+  The interaction range $L_0{+}1$ provides enough overlap ($L_0$ sites)
+  for a single intersection step to grow the window by one site.
+  Iterating across the periodic chain of length $N \ge 2(L_0+1)$ ensures
+  enough room for the windows to wrap around and close, yielding
+  uniqueness by the same commutant argument as in
+  Theorem~\ref{thm:unique_gs_injective}~\cite{Fannes1992Finitely,
+  PerezGarcia2007Matrix}.
 \end{proof}
 
 \section{Spectral gap}\label{sec:spectral_gap}
@@ -293,7 +304,6 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \end{theorem}
 
 \begin{proof}
-  \uses{thm:martingale_criterion}
   \notready
   From $h_i^2 = h_i$,
   \[
@@ -302,11 +312,15 @@ Lucia~\cite{Kastoryano2018Martingale}.
     + \sum_{\substack{i < j \\ \text{non-overlapping}}}
     (h_i h_j + h_j h_i).
   \]
-  Non-overlapping terms commute and each product is PSD, so the last sum
-  is $\ge 0$.
-  The martingale condition bounds the overlapping sum from below:
+  Non-overlapping projectors commute ($h_i h_j = h_j h_i$), so their
+  product $h_i h_j$ is itself a projector and hence PSD; thus the last
+  sum is $\ge 0$.
+  For the overlapping sum, apply the martingale condition to each
+  ordered pair $(i,j)$ with $i < j$. Summing over $i < j$ and using
+  $c_{ij} = c_{ji}$ (which may be assumed WLOG by symmetrising), the
+  bound becomes
   \[
-    \sum_{\text{overlap}} (h_i h_j + h_j h_i)
+    \sum_{i < j,\,\text{overlap}} (h_i h_j + h_j h_i)
     \ge -(1-\gamma) \sum_i \Bigl(\sum_{j \ne i} c_{ij}\Bigr) h_i
     \ge -(1-\gamma) H.
   \]
@@ -319,16 +333,18 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \begin{lemma}[Martingale condition for MPS]\label{lem:martingale_mps}
   \notready
   \uses{thm:martingale_criterion, def:parent_interaction,
-        lem:ground_space_intersection, def:injective}
-  Let $A$ be injective.
-  The parent interaction terms $h_i = \Pi_{G_L(A)^\perp}$ at adjacent
-  sites satisfy the martingale condition of
-  Theorem~\ref{thm:martingale_criterion} with constants $c_{ij}$ and
-  $\gamma > 0$ depending only on $A$ (not on $N$).
+        def:local_term_parent, lem:ground_space_intersection, def:injective}
+  Let $A$ be injective and fix an interaction range $L$ as in
+  Definition~\ref{def:parent_interaction}.  Let $h_L(A) := \Pi_{G_L(A)^\perp}$
+  be the $L$-site parent interaction, and for each chain length and site $i$
+  let $h_i$ denote its translate as in Definition~\ref{def:local_term_parent}.
+  Then the adjacent interaction terms $h_i$ and $h_{i+1}$ satisfy the
+  martingale condition of Theorem~\ref{thm:martingale_criterion} with constants
+  $c_{ij}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
 \end{lemma}
 
 \begin{proof}
-  \uses{lem:martingale_mps, lem:ground_space_intersection, def:injective}
+  \uses{lem:ground_space_intersection, def:injective}
   \notready
   Injectivity bounds the angle between $\ker(h_i)$ and $\ker(h_j)$
   away from zero: the intersection property
@@ -342,8 +358,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
   \notready
   \uses{thm:martingale_criterion, lem:martingale_mps,
         def:parent_hamiltonian}
-  For an injective MPS tensor $A$, there exists $\gamma > 0$ such that
-  for all $N$ sufficiently large,
+  For an injective MPS tensor $A$ with injectivity length $L_0$, let
+  $L := L_0 + 1$ be the interaction range.
+  There exists $\gamma > 0$ such that for all $N \ge 2L$,
   \[
     \lambda_{\min}^+\bigl(H_N(A,L)\bigr) \ge \gamma,
   \]
@@ -351,8 +368,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \end{theorem}
 
 \begin{proof}
-  \uses{thm:parent_hamiltonian_gapped, thm:martingale_criterion,
-        lem:martingale_mps}
+  \uses{thm:martingale_criterion, lem:martingale_mps}
   \notready
   Apply Theorem~\ref{thm:martingale_criterion} with the constants from
   Lemma~\ref{lem:martingale_mps}.
@@ -376,30 +392,30 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   separation (Definition~\ref{def:normal_cf_bnt}), where
   $\{A_1,\ldots,A_g\}$ is a basis of normal tensors
   (Definition~\ref{def:bnt}).
-  For $N \ge L_0 + 1$ (where $L_0$ is the maximum injectivity length of
+  For $N \ge 2(L_0 + 1)$ (where $L_0$ is the maximum injectivity length of
   the blocks), the ground space of the parent Hamiltonian satisfies
   \[
     \ker\bigl(H_N(A,L_0{+}1)\bigr)
-    = \spn\bigl\{\ket{V^{(N)}(A_k)} : k = 1,\ldots,g\bigr\}.
+    = \spn\bigl\{V^{(N)}(A_k) : k = 1,\ldots,g\bigr\}.
   \]
 \end{theorem}
 
 \begin{proof}
-  \uses{thm:gs_eq_bnt_span, thm:unique_gs_normal,
-        lem:ground_space_intersection, def:bnt}
+  \uses{thm:unique_gs_normal, lem:ground_space_intersection, def:bnt,
+        lem:parent_hamiltonian_annihilates}
   \notready
   \textbf{$\supseteq$}: Each $A_k$ is normal, so
   Lemma~\ref{lem:parent_hamiltonian_annihilates} (applied to the
   block-diagonal structure) gives
-  $H_N(A,L_0{+}1)\ket{V^{(N)}(A_k)} = 0$.
+  $H_N(A,L_0{+}1)\,V^{(N)}(A_k) = 0$.
   Linearity of the kernel yields the inclusion.
 
   \textbf{$\subseteq$}: Take $\psi \in \ker(H_N)$.
   The block-diagonal structure of $A$ decomposes the local ground spaces:
   $G_L(A) = \bigoplus_k G_L(A_k)$ (the off-diagonal blocks do not
   contribute due to the block structure of the transfer map).
-  Restricting $\psi$ to any injective block $A_k$, the intersection
-  property forces $\psi$ to lie in $\spn\{\ket{V^{(N)}(A_k)}\}$ by
+  Restricting $\psi$ to any normal block $A_k$, the intersection
+  property forces $\psi$ to lie in $\spn\{V^{(N)}(A_k)\}$ by
   Theorem~\ref{thm:unique_gs_normal}.
   Summing over blocks gives the
   inclusion~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -317,15 +317,25 @@ Lucia~\cite{Kastoryano2018Martingale}.
   Non-overlapping projectors commute ($h_i h_j = h_j h_i$), so their
   product $h_i h_j$ is itself a projector and hence PSD; thus the last
   sum is $\ge 0$.
-  For the overlapping sum, apply the martingale condition to each
-  ordered pair $(i,j)$ with $i < j$. Summing over $i < j$ and using
-  $c_{ij} = c_{ji}$ (which may be assumed WLOG by symmetrising), the
-  bound becomes
+  For the overlapping sum, the martingale condition gives, for each
+  ordered pair $(i,j)$ with $i \ne j$ and overlapping supports,
+  $h_i h_j + h_j h_i \ge -c_{ij}(1-\gamma)(h_i + h_j)$.
+  Since $h_i h_j + h_j h_i$ is symmetric in $i,j$, summing over
+  unordered pairs $\{i,j\}$ yields
   \[
-    \sum_{i < j,\,\text{overlap}} (h_i h_j + h_j h_i)
-    \ge -(1-\gamma) \sum_i \Bigl(\sum_{j \ne i} c_{ij}\Bigr) h_i
-    \ge -(1-\gamma) H.
+    \sum_{\{i,j\},\,\text{overlap}} (h_i h_j + h_j h_i)
+    \ge -\tfrac{1}{2}(1-\gamma) \sum_{\substack{i,j \\ i \ne j,\,\text{overlap}}}
+    (c_{ij} + c_{ji})(h_i + h_j).
   \]
+  Rearranging the right-hand side by collecting terms for each $h_i$:
+  \[
+    = -(1-\gamma) \sum_i \Bigl(\sum_{j \ne i,\,\text{overlap}}
+    c_{ij}\Bigr) h_i
+    \ge -(1-\gamma) H,
+  \]
+  where the last step uses the row-sum hypothesis
+  $\sum_{j \ne i} c_{ij} \le 1$ (applied to the original,
+  unsymmetrised constants).
   Combining: $H^2 \ge H - (1-\gamma)H = \gamma H$.
   For any eigenvector with $H\psi = \lambda\psi$ and $\lambda > 0$,
   this gives $\lambda^2 \ge \gamma\lambda$, hence
@@ -351,12 +361,19 @@ Lucia~\cite{Kastoryano2018Martingale}.
   \notready
   Two terms $h_i, h_j$ with $0 < |i-j| < L$ have supports overlapping
   in $L - |i-j|$ sites.  Since $A$ is injective, the intersection property
-  (Lemma~\ref{lem:ground_space_intersection}) bounds the angle between
-  $\ker(h_i)$ and $\ker(h_j)$ away from zero for any such overlap.
-  (When $|i-j| = 1$ the overlap is $L-1$ sites; for larger separations the
-  overlap shrinks but injectivity still controls the intersection.)
-  This provides the required lower bound on
-  $h_i h_j + h_j h_i$ for every overlapping
+  (Lemma~\ref{lem:ground_space_intersection}) gives the qualitative identity
+  $\ker(h_i) \cap \ker(h_j) = G_{[i,j+L-1]}(A)$.
+  Because the local Hilbert space is finite-dimensional, the subspaces
+  $\ker(h_i)$ and $\ker(h_j)$ live in a fixed finite-dimensional space,
+  and the Friedrichs angle between them is a continuous function of $A$.
+  The intersection identity excludes the degenerate case where the
+  angle is zero (which would require a non-trivial vector in one kernel
+  that is orthogonal to the other yet lies in both), so by
+  compactness (the angle depends continuously on $A$ over a compact
+  parameter space for fixed $d,D$) the angle is bounded away from zero.
+  This lower bound on the angle translates into the required operator
+  inequality $h_i h_j + h_j h_i \ge -c_{ij}(1-\gamma)(h_i + h_j)$
+  for every overlapping
   pair~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
 \end{proof}
 
@@ -376,10 +393,16 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \begin{proof}
   \uses{thm:martingale_criterion, lem:martingale_mps}
   \notready
-  Apply Theorem~\ref{thm:martingale_criterion} with the constants from
-  Lemma~\ref{lem:martingale_mps}.
-  Since the constants are independent of $N$, the gap $\gamma$ is
-  uniform~\cite{Fannes1992Finitely, Nachtergaele1996Spectral}.
+  Since $A$ is $L_0$-block injective, the blocked tensor
+  $A^{[L_0]}$ is injective.  The parent interaction for $A$ with range
+  $L = L_0 + 1$ can be expressed in terms of $A^{[L_0]}$ with range $2$
+  (two blocked sites).  Apply Lemma~\ref{lem:martingale_mps} to the
+  injective tensor $A^{[L_0]}$ to obtain the martingale constants
+  $c_{ij}$ and $\gamma > 0$.  These constants depend only on $A^{[L_0]}$
+  (hence only on $A$ and $L_0$), not on $N$.
+  Theorem~\ref{thm:martingale_criterion} then gives the uniform gap
+  $\lambda_{\min}^+(H_N) \ge \gamma$~\cite{Fannes1992Finitely,
+  Nachtergaele1996Spectral}.
 \end{proof}
 
 \section{Ground space of non-injective MPS}\label{sec:degenerate_ground_space}
@@ -417,12 +440,19 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
   Linearity of the kernel yields the inclusion.
 
   \textbf{$\subseteq$}: Take $\psi \in \ker(H_N)$.
-  The block-diagonal structure of $A$ decomposes the local ground spaces:
-  $G_L(A) = \bigoplus_k G_L(A_k)$ (the off-diagonal blocks do not
-  contribute due to the block structure of the transfer map).
-  Restricting $\psi$ to any normal block $A_k$, the intersection
-  property forces $\psi$ to lie in $\spn\{V^{(N)}(A_k)\}$ by
-  Theorem~\ref{thm:unique_gs_normal}.
-  Summing over blocks gives the
+  The block-diagonal structure of $A$ gives the containment
+  $G_L(A) \subseteq \sum_k G_L(A_k)$: any local ground state of $A$
+  on $L$ sites is a sum of local ground states of the individual
+  blocks, because the off-diagonal blocks vanish in the transfer map
+  (the canonical form ensures that distinct blocks have orthogonal
+  images under $\Gamma_L$ for $L \ge L_0$, so the sum is in fact
+  direct for sufficiently long windows).
+  Iterating the intersection property
+  (Lemma~\ref{lem:ground_space_intersection}) across the chain for
+  each block $A_k$ independently, and using
+  Theorem~\ref{thm:unique_gs_normal} for each normal block, the
+  component of $\psi$ associated with block $A_k$ must be proportional
+  to $V^{(N)}(A_k)$.
+  This gives the
   inclusion~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -317,25 +317,28 @@ Lucia~\cite{Kastoryano2018Martingale}.
   Non-overlapping projectors commute ($h_i h_j = h_j h_i$), so their
   product $h_i h_j$ is itself a projector and hence PSD; thus the last
   sum is $\ge 0$.
-  For the overlapping sum, the martingale condition gives, for each
-  ordered pair $(i,j)$ with $i \ne j$ and overlapping supports,
+  For the overlapping sum, the martingale condition gives
   $h_i h_j + h_j h_i \ge -c_{ij}(1-\gamma)(h_i + h_j)$.
-  Since $h_i h_j + h_j h_i$ is symmetric in $i,j$, summing over
-  unordered pairs $\{i,j\}$ yields
+  Since both sides are symmetric in $i,j$, we may assume
+  $c_{ij} = c_{ji}$ without loss of generality (the same
+  symmetric expression is bounded by the same constant regardless
+  of the ordering of the pair).
+  Summing over unordered pairs $\{i,j\}$:
   \[
     \sum_{\{i,j\},\,\text{overlap}} (h_i h_j + h_j h_i)
-    \ge -\tfrac{1}{2}(1-\gamma) \sum_{\substack{i,j \\ i \ne j,\,\text{overlap}}}
-    (c_{ij} + c_{ji})(h_i + h_j).
+    \ge -(1-\gamma) \sum_{\{i,j\},\,\text{overlap}}
+    c_{ij}(h_i + h_j).
   \]
-  Rearranging the right-hand side by collecting terms for each $h_i$:
+  Collecting terms for each $h_i$ (using $c_{ij} = c_{ji}$, so
+  that summing over unordered pairs containing $i$ gives
+  $\sum_{j \ne i} c_{ij}$):
   \[
     = -(1-\gamma) \sum_i \Bigl(\sum_{j \ne i,\,\text{overlap}}
     c_{ij}\Bigr) h_i
     \ge -(1-\gamma) H,
   \]
   where the last step uses the row-sum hypothesis
-  $\sum_{j \ne i} c_{ij} \le 1$ (applied to the original,
-  unsymmetrised constants).
+  $\sum_{j \ne i} c_{ij} \le 1$.
   Combining: $H^2 \ge H - (1-\gamma)H = \gamma H$.
   For any eigenvector with $H\psi = \lambda\psi$ and $\lambda > 0$,
   this gives $\lambda^2 \ge \gamma\lambda$, hence
@@ -368,15 +371,35 @@ Lucia~\cite{Kastoryano2018Martingale}.
   The intersection identity shows that $\ker(h_i) \cap \ker(h_j)$ is
   exactly $G_{[i,j+L-1]}(A)$; in particular there is no non-trivial
   vector in one kernel that is orthogonal to the other yet lies in both.
-  Hence the Friedrichs angle $\theta$ between $\ker(h_i)$ and
+  Hence the Friedrichs angle $\theta_{|i-j|}$ between $\ker(h_i)$ and
   $\ker(h_j)$ is strictly positive (for the fixed injective tensor
-  $A$).  Since $\theta > 0$, there exist constants $c_{ij} \ge 0$ and
-  $\gamma > 0$, depending only on $A$ and the pair $(i,j)$, such that
-  $h_i h_j + h_j h_i \ge -c_{ij}(1-\gamma)(h_i + h_j)$.
-  Because the number of distinct overlap patterns is bounded by $L-1$
-  (independent of~$N$), the constants can be chosen uniformly for all
-  overlapping
-  pairs~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
+  $A$).  Because the angle depends only on the overlap pattern
+  $|i-j| \in \{1,\dots,L-1\}$ and not on the absolute position,
+  the number of distinct angles is at most $L-1$.
+  Let $\alpha := \max_{1 \le s < L} \cos\theta_s < 1$ be the
+  worst-case cosine of the Friedrichs angles.
+
+  \textbf{Row-sum bound.}
+  Each site $i$ overlaps with at most $2(L-1)$ neighbours
+  (those $j$ with $0 < |i-j| < L$).
+  Set $c_{ij} := \tfrac{1}{2(L-1)}$ for every overlapping pair
+  and $c_{ij} := 0$ otherwise.
+  Then
+  $\sum_{j \ne i} c_{ij} \le 2(L-1)\cdot\tfrac{1}{2(L-1)} = 1$,
+  satisfying the row-sum hypothesis of
+  Theorem~\ref{thm:martingale_criterion}.
+  The Friedrichs angle bound gives, for each overlapping pair,
+  $h_i h_j + h_j h_i \ge -\alpha\,(h_i + h_j)$,
+  so the martingale inequality holds whenever
+  $c_{ij}(1-\gamma) \ge \alpha$, i.e.\
+  $\gamma \le 1 - 2(L-1)\alpha$.
+  In the blocked picture of
+  Theorem~\ref{thm:parent_hamiltonian_gapped}, $L = 2$ (so the
+  interaction graph has degree~$2$) and the quantitative gap
+  $\gamma > 0$ follows from the Nachtergaele finite-size
+  criterion~\cite{Nachtergaele1996Spectral}; the constants depend
+  only on $A$ and are independent
+  of~$N$~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}


### PR DESCRIPTION
### Motivation

- Chapter 14 (Parent Hamiltonian) blueprint was skeletal at only 5 KB, missing major content identified in audit issue #331.
- Lean code in `TNLean/MPS/ParentHamiltonian/` is ahead of the blueprint; sections on uniqueness, spectral gap, and non-injective ground space had no blueprint coverage.

### Description

- Expanded `blueprint/src/chapter/ch14_parent_hamiltonian.tex` with three new sections:
  - §14.3: Uniqueness of the ground state (closure property, intersection property, unique ground state theorems for injective and normal MPS)
  - §14.4: Spectral gap (martingale criterion, verification for MPS, uniform gap theorem)
  - §14.5: Ground space of non-injective MPS (ground space = span of BNT blocks)
- All new results are tagged `\notready` with proof sketches and `\uses` cross-references to ch02 (injectivity, normality), ch10 (BNT), and existing ch14 results.
- No Lean files added or modified.

### Testing

- Relies on Blueprint Lint CI (`lint-blueprint.yml`) to validate LaTeX labels and references.

---
Addresses #331

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation-only (LaTeX blueprint) and do not modify any Lean or executable code paths.
> 
> **Overview**
> Adds substantial new blueprint coverage to `ch14_parent_hamiltonian.tex`, replacing the previous placeholder note with three sections on **(1) injective/normal ground-state uniqueness**, **(2) spectral gap via the Kastoryano–Lucia martingale criterion**, and **(3) the non-injective (BNT) degenerate ground space characterization**.
> 
> The new material introduces labeled lemmas/theorems (`lem:ground_space_mono`, `lem:ground_space_intersection`, `thm:unique_gs_injective`, `thm:unique_gs_normal`, `thm:martingale_criterion`, `lem:martingale_mps`, `thm:parent_hamiltonian_gapped`, `thm:gs_eq_bnt_span`) with `\notready` proof sketches and `\uses` cross-references, aligning the chapter’s narrative with existing formalization work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1318600e08d7f0da65bbecce04653ff1c4d7ba1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->