### PR TITLE
doc(blueprint): expand Ch15 correlations with spectral gap connection

### DIFF
--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -197,6 +197,54 @@ mixed transfer power.
     $A^\sigma (B^\sigma)^\dagger$.
 \end{proof}
 
+\section{Frobenius norm infrastructure}
+
+The spectral-gap proofs use the Frobenius (Hilbert--Schmidt) norm
+as the natural norm for the finite-dimensional matrix algebra.
+We record the squared version and an isometric embedding into
+Euclidean space.
+
+\begin{definition}[Frobenius norm squared]\label{def:frob_sq}
+    \lean{MPSTensor.frobSq}
+    \leanok
+    For a (possibly rectangular) matrix $X \in M_{m \times n}(\C)$,
+    the \emph{Frobenius norm squared} is
+    \[
+        \|X\|_F^2 := \sum_{i=0}^{m-1}\sum_{j=0}^{n-1} |X_{ij}|^2.
+    \]
+\end{definition}
+
+\begin{lemma}[Trace formula for Frobenius norm]\label{lem:frob_sq_trace}
+    \lean{MPSTensor.frobSq_trace}
+    \leanok
+    \uses{def:frob_sq}
+    $\|X\|_F^2 = \operatorname{Re}\tr(X^\dagger X)$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand the matrix product and trace entry by entry.
+\end{proof}
+
+\begin{definition}[Euclidean-space embedding]\label{def:mat_to_es}
+    \lean{MPSTensor.matToES}
+    \leanok
+    \uses{def:frob_sq}
+    The map $\mathrm{vec} : M_{m \times n}(\C) \to \C^{mn}$ that
+    flattens matrix entries is an isometric embedding with respect
+    to the Frobenius norm: $\|\mathrm{vec}(X)\|^2 = \|X\|_F^2$.
+\end{definition}
+
+\begin{lemma}[Norm of embedded matrix]\label{lem:norm_mat_to_es}
+    \lean{MPSTensor.norm_matToES_sq}
+    \leanok
+    \uses{def:mat_to_es, def:frob_sq}
+    $\|\mathrm{vec}(X)\|^2 = \|X\|_F^2$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand both sides as sums over entries and use $|z|^2 = \bar{z}z$.
+\end{proof}
+
 \section{Eigenvalue bound and spectral gap}
 
 The eigenvalue bound comes from a uniform Frobenius-norm estimate
@@ -461,6 +509,135 @@ canonical-form separation arguments.
     In particular this applies to the distinguished QPF fixed point from
     Theorem~\ref{thm:qpf}.
 \end{remark}
+
+\section{Spectral gap under irreducible-TP hypotheses}
+
+The preceding spectral-gap results require \emph{injectivity} of both
+tensors.  The following variants weaken this to \emph{irreducibility}
+combined with trace-preserving normalization
+($\sum_i (A^i)^\dagger A^i = \Id$), following Cirac et
+al.~\cite{Cirac2017MatrixProductUnitaries}.  The argument replaces the
+Kraus-commutation step with a Cauchy--Schwarz rigidity argument for
+the Perron--Frobenius fixed point.
+
+\begin{theorem}[Gauge-equivalence from irreducible-TP spectral
+    radius]\label{thm:modulus_one_gauge_irr_tp}
+    \lean{MPSTensor.modulus_one_eigenvalue_implies_gauge_of_irreducible_TP}
+    \leanok
+    \uses{def:mixed_transfer, def:gauge_phase_equiv,
+          def:irreducible_tensor, thm:eigenvalue_bound}
+    Let $A, B$ be irreducible trace-preserving normalized MPS tensors
+    of bond dimension~$D$.
+    If $\rho(F_{AB}) \ge 1$, then $A$ and $B$ are gauge-phase equivalent.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:spectral_radius_le_one, thm:eigenvalue_bound, thm:qpf}
+    Choose a modulus-one eigenvector as in
+    Theorem~\ref{thm:modulus_one_gauge}.
+    Instead of requiring injectivity to deduce invertibility of the
+    intertwiner, one uses the Perron--Frobenius fixed points
+    (Theorem~\ref{thm:qpf}), which are positive definite under
+    irreducibility.
+    The Kadison--Schwarz--Cauchy--Schwarz chain then yields a
+    positive-definite intertwiner, and the Skolem--Noether argument
+    concludes as before.
+\end{proof}
+
+\begin{theorem}[Strict spectral gap (irreducible-TP)]%
+    \label{thm:spectral_gap_irr_tp}
+    \lean{MPSTensor.spectralRadius_mixedTransfer_lt_one_of_irreducible_TP}
+    \leanok
+    \uses{def:gauge_phase_equiv, def:irreducible_tensor,
+          def:mixed_transfer}
+    Let $A, B$ be irreducible trace-preserving normalized MPS tensors
+    of the same bond dimension that are not gauge-phase equivalent.
+    Then $\rho(F_{AB}) < 1$.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:spectral_radius_le_one,
+    thm:modulus_one_gauge_irr_tp}
+    Contrapositive of
+    Theorem~\ref{thm:modulus_one_gauge_irr_tp}, combined with
+    $\rho(F_{AB}) \le 1$
+    (Theorem~\ref{thm:spectral_radius_le_one}).
+\end{proof}
+
+\begin{theorem}[Transfer power decay (irreducible-TP)]%
+    \label{thm:transfer_pow_zero_irr_tp}
+    \lean{MPSTensor.mixedTransfer_pow_tendsto_zero_of_irreducible_TP}
+    \leanok
+    \uses{def:mixed_transfer, def:gauge_phase_equiv,
+          def:irreducible_tensor}
+    Under the hypotheses of
+    Theorem~\ref{thm:spectral_gap_irr_tp},
+    $F_{AB}^n(X) \to 0$ for every $X \in \MN{D}$.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:spectral_gap_irr_tp}
+    By the Gelfand formula,
+    $\rho(F_{AB}) < 1$ implies $\|F_{AB}^n\|_{\mathrm{op}} \to 0$.
+\end{proof}
+
+\begin{theorem}[Overlap decay (irreducible-TP)]%
+    \label{thm:overlap_decay_irr_tp}
+    \lean{MPSTensor.mpvOverlap_tendsto_zero_of_irreducible_TP}
+    \leanok
+    \uses{def:mpv_overlap, def:gauge_phase_equiv,
+          def:irreducible_tensor}
+    Let $A, B$ be irreducible trace-preserving normalized tensors of
+    the same bond dimension that are not gauge-phase equivalent.
+    Then $O_{AB}(N) \to 0$ as $N \to \infty$.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:spectral_gap_irr_tp, thm:overlap_trace}
+    Combine the spectral gap
+    (Theorem~\ref{thm:spectral_gap_irr_tp})
+    with the overlap--trace identity
+    (Theorem~\ref{thm:overlap_trace}).
+\end{proof}
+
+\begin{theorem}[Rectangular spectral gap (irreducible-TP)]%
+    \label{thm:spectral_gap_rect_irr_tp}
+    \lean{MPSTensor.mixedTransferSpectralRadius₂_lt_one_of_dim_ne_of_irreducible_TP}
+    \leanok
+    \uses{def:mixed_transfer_rect, def:irreducible_tensor}
+    Let $A$ (bond dimension $D_1$) and $B$ (bond dimension $D_2$) be
+    irreducible trace-preserving normalized tensors with
+    $D_1 \neq D_2$.
+    Then $\rho(F_{AB}^{\mathrm{rect}}) < 1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:eigenvalue_bound}
+    Assume for contradiction that $\rho = 1$.
+    Choose a modulus-one eigenvector $X \in M_{D_1 \times D_2}(\C)$.
+    The Cauchy--Schwarz rigidity argument produces an intertwiner
+    $X'$ with $A'^i X' = X' B'^i$ for all~$i$.
+    Since $\{B'^i\}$ spans $M_{D_2}(\C)$ (irreducibility), the kernel
+    of $X'$ is a $B'$-invariant subspace, forced to be $\{0\}$;
+    similarly for $X'^\dagger$.
+    This gives $D_1 = D_2$, contradicting the hypothesis.
+\end{proof}
+
+\begin{theorem}[Rectangular overlap decay (irreducible-TP)]%
+    \label{thm:overlap_decay_rect_irr_tp}
+    \lean{MPSTensor.mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP}
+    \leanok
+    \uses{def:mpv_overlap, def:irreducible_tensor}
+    If $D_1 \neq D_2$ and both tensors are irreducible and
+    trace-preserving normalized, then
+    $O_{AB}(N) \to 0$ as $N \to \infty$.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:spectral_gap_rect_irr_tp,
+    thm:overlap_trace_rect}
+    Combine
+    Theorem~\ref{thm:spectral_gap_rect_irr_tp} with
+    Theorem~\ref{thm:overlap_trace_rect}.
+\end{proof}
 
 \section{Conditional expectation from a faithful fixed point (Wolf Thm.~6.15)}
 

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -12,6 +12,13 @@ correlations in the ground state.  The exponential decay rate is set by the
 spectral properties of the transfer map, i.e.\ by the modulus of its
 subleading eigenvalues.
 
+The spectral analysis of the transfer map and the mixed transfer operator,
+including the eigenvalue bound $\rho(F_{AB}) \le 1$, the strict spectral
+gap $\rho(F_{AB}) < 1$ for non-equivalent blocks, and the resulting
+overlap decay, is developed in Chapter~\ref{ch:spectral}.  This chapter
+focuses on the \emph{correlator} side: one-point and two-point expectations,
+their spectral decomposition, and quantitative bounds on decay rates.
+
 \section{Connected correlators from the transfer map}
 
 \begin{definition}[One-point expectation]\label{def:one_point_expectation}
@@ -85,6 +92,21 @@ subleading eigenvalues.
     Combine the sum-of-exponentials expansion with the triangle inequality.
 \end{proof}
 
+\begin{remark}[Spectral hypothesis and the spectral gap]%
+    \label{rem:spectral_hypothesis}
+    \uses{thm:correlator_exponential_bound, thm:spectral_gap}
+    The hypothesis ``$|\lambda_2| < 1$'' in
+    Theorem~\ref{thm:correlator_exponential_bound} is precisely the
+    \emph{spectral gap} condition for the transfer map $\E_A$.
+    For injective tensors, the strict spectral gap is established in
+    Theorem~\ref{thm:spectral_gap} (Chapter~\ref{ch:spectral});
+    for irreducible trace-preserving tensors, the analogous result is
+    Theorem~\ref{thm:spectral_gap_irr_tp}.
+    Thus the exponential decay of connected correlations follows
+    directly from the block separation theory once the spectral
+    decomposition is in hand.
+\end{remark}
+
 \begin{definition}[Correlation length]\label{def:correlation_length}
     \lean{MPSTensor.correlationLength}
     \leanok
@@ -107,6 +129,79 @@ subleading eigenvalues.
     Since $0 < |\lambda_2| < 1$, we have $\log|\lambda_2| < 0$, so
     $\xi = -1/\log|\lambda_2| > 0$.
 \end{proof}
+
+\section{Quantitative spectral gap bounds}
+
+The spectral gap theorems in Chapter~\ref{ch:spectral} establish
+$\rho(F_{AB}) < 1$ qualitatively.  This section records the
+\emph{quantitative} refinements that give explicit constants and rates.
+All three results below are stubs in the formalization (TODO~\#22).
+
+\begin{theorem}[Exponential convergence of primitive channels]%
+    \label{thm:exponential_convergence_primitive}
+    \lean{MPSTensor.exponential_convergence_of_primitive}
+    \notready
+    \uses{thm:spectral_gap, def:fixed_point_proj,
+          thm:primitive_overlap}
+    Let $A$ be a primitive trace-preserving MPS tensor with positive
+    definite fixed point $\rho$ and fixed-point projection
+    $P(X) = \frac{\tr(X)}{\tr(\rho)}\rho$.
+    Then there exist $C > 0$ and $0 < \delta \le 1$ such that for all
+    $n \ge 0$ and $X \in \MN{D}$,
+    \[
+        \|\E_A^n(X) - P(X)\|
+        \;\le\; C\,(1-\delta)^n\,\|X\|.
+    \]
+    The spectral gap $\delta$ exists by primitivity
+    (Theorem~\ref{thm:spectral_gap} applied to the complementary map).
+\end{theorem}
+
+\begin{theorem}[Correlation length bound]\label{thm:correlation_length_bound}
+    \lean{MPSTensor.correlation_length_bound}
+    \notready
+    \uses{def:correlation_length, thm:exponential_convergence_primitive,
+          def:injective}
+    For an injective trace-preserving MPS tensor, there exist
+    $C > 0$ and $\xi > 0$ such that for all $n \ge 0$ and all
+    traceless $X \in \MN{D}$ (i.e.\ $\tr(X) = 0$),
+    \[
+        \|\E_A^n(X)\|
+        \;\le\; C\,e^{-n/\xi}\,\|X\|.
+    \]
+    Traceless matrices lie in $\ker P$, where $P$ is the fixed-point
+    projection.  Since $\E_A - P$ has spectral radius strictly less
+    than~$1$, the Gelfand formula gives exponential decay at rate
+    $\xi = -1/\log\rho(\E_A - P)$.
+\end{theorem}
+
+\begin{theorem}[Spectral gap from the Wielandt bound]%
+    \label{thm:spectral_gap_wielandt}
+    \lean{MPSTensor.spectral_gap_from_wielandt}
+    \notready
+    \uses{thm:spectral_gap, thm:wielandt_bound}
+    For an injective trace-preserving MPS tensor, there exists
+    $\delta > 0$ such that every eigenvalue $\mu \neq 1$ of the
+    transfer map satisfies $|\mu| \le 1 - \delta$.
+
+    The proof combines: injectivity implies primitivity (via the
+    Wielandt bound, Theorem~\ref{thm:wielandt_bound}), primitivity
+    implies a spectral gap on the complementary map, and the finite
+    number of eigenvalues gives a uniform bound.
+\end{theorem}
+
+\begin{remark}[Status of quantitative bounds]\label{rem:quantitative_status}
+    \uses{thm:exponential_convergence_primitive,
+          thm:correlation_length_bound,
+          thm:spectral_gap_wielandt}
+    The three theorems above are formalized as stubs (with
+    \texttt{sorry}) in \texttt{TNLean/Spectral/QuantitativeGap.lean},
+    tagged TODO~\#22.
+    The qualitative results they refine --- spectral gap existence,
+    overlap decay, and correlation convergence --- are fully proved in
+    Chapter~\ref{ch:spectral}.
+    Discharging the sorrys requires extracting explicit constants from
+    the Jordan normal form and the Wielandt-bound argument.
+\end{remark}
 
 \section{Relation to parent Hamiltonians}
 


### PR DESCRIPTION
### Motivation

- Continues audit of Ch15 (Correlations), which was skeletal at ~5 KB despite 11 Lean files in `Spectral/`, see LionSR/TNLean#332.
- Connects correlator decay theorems to the spectral gap machinery formalized in Ch6.

### Description

- **`blueprint/src/chapter/ch06_spectral.tex`**: add Frobenius norm infrastructure section (`def:frob_sq`, trace identity, isometric `vec` embedding); add irreducible-TP spectral gap section (6 theorems: gauge-equivalence from radius-1, strict gap, power/overlap decay, rectangular-dimension separation).
- **`blueprint/src/chapter/ch15_correlations.tex`**: expand from ~5 KB to ~9 KB; add quantitative spectral gap section (3 `\notready` stubs from `QuantitativeGap.lean`: exponential convergence, correlation length bound, Wielandt-based spectral gap — all TODO); add cross-references tying correlator theorems to Ch6 spectral gap results; add remark on how the spectral hypothesis in the exponential decay bound is discharged by Ch6.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- Blueprint lint (`lint-blueprint.yml`) validates LaTeX label/reference integrity.

---
Addresses LionSR/TNLean#332

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/blueprint-only changes: adds new LaTeX sections/theorems and cross-references without modifying executable code, though it introduces new formalization hooks/labels that could affect downstream references.
> 
> **Overview**
> Adds Frobenius/Hilbert–Schmidt norm infrastructure to the spectral-gap chapter (`def:frob_sq`, trace identity, and an isometric `vec` embedding) to support upcoming norm-based estimates.
> 
> Extends the spectral-gap/block-separation results with a new *irreducible + trace-preserving* variant suite (gauge-equivalence from radius-1, strict spectral gap, transfer/overlap decay, and rectangular-dimension separation), mirroring the existing injective case.
> 
> Updates the correlations chapter intro/remarks to explicitly tie the correlator decay hypothesis to the spectral-gap theorems (including the new `thm:spectral_gap_irr_tp`) and adds a new section of **quantitative gap** statements marked `\notready`/TODO with pointers to `TNLean/Spectral/QuantitativeGap.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9362a9214729769c5d173d5d319e412dba9b1642. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->