### PR TITLE
fix(PiAlgebra/BlockSeparation): update stale module reference in docstring

### DIFF
--- a/TNLean/PiAlgebra/BlockSeparation.lean
+++ b/TNLean/PiAlgebra/BlockSeparation.lean
@@ -173,7 +173,7 @@ Accordingly, this file currently only provides the trustworthy helper lemmas
 and `sameMPV₂_repeated_word`.
 
 A checked counterexample to the naive full separation statement is retained in
-`TNLean.Scratch.BlockSepCounterexample`.
+`TNLean.Archive.BlockSepCounterexample`.
 
 For end-to-end results from `SameMPV₂`, use
 `fundamentalTheorem_multiBlock_fromSameMPV₂` (in


### PR DESCRIPTION
### Motivation

- The docstring in `PiAlgebra/BlockSeparation.lean` referenced
  `TNLean.Scratch.BlockSepCounterexample`, but the module was moved to
  `TNLean.Archive.BlockSepCounterexample`. Fixes the stale pointer as part
  of the cross-cutting audit (#334).

### Description

- Updated module reference in the docstring of `TNLean/PiAlgebra/BlockSeparation.lean`
  from `TNLean.Scratch.BlockSepCounterexample` to `TNLean.Archive.BlockSepCounterexample`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Partially addresses #334

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates documentation text to point to the renamed/moved counterexample module, with no changes to proofs or behavior.
> 
> **Overview**
> Updates `PiAlgebra/BlockSeparation.lean` documentation to reference the counterexample module at `TNLean.Archive.BlockSepCounterexample` instead of `TNLean.Scratch.BlockSepCounterexample`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a32c92748dda65426bd4f7e38cafd0181b2393bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->