### PR TITLE
feat(Spectral): discharge spectral_gap_from_wielandt in QuantitativeGap

### DIFF
--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -29,7 +29,7 @@ a lower bound on `1 - ρ`).
 * `exponential_convergence_of_primitive` — for a primitive TP channel,
   `‖E^n(X) - P(X)‖ ≤ C · (1-δ)^n · ‖X‖` (convergence to fixed-point projection)
 * `correlation_length_bound` — exponential decay of traceless iterates
-* `spectral_gap_from_wielandt` — explicit spectral gap `δ > 0` with
+* `spectral_gap_of_injective` — explicit spectral gap `δ > 0` with
   all non-unit eigenvalues satisfying `|μ| ≤ 1 - δ`
 
 ## Strengthening relative to the literature
@@ -119,18 +119,20 @@ theorem correlation_length_bound [NeZero D]
   -- TODO (#22): ξ = -1/log(ρ₂) where ρ₂ is second-largest eigenvalue modulus
   sorry
 
-/-! ## Explicit gap from Wielandt bound -/
+/-! ## Explicit gap from injectivity -/
 
-/-- **Spectral gap from the Wielandt bound** (existential version).
+/-- **Spectral gap from injectivity** (existential version).
 
 For an injective TP-normalized MPS tensor, all eigenvalues of the transfer
 map other than 1 have modulus strictly less than 1, with a uniform gap.
 
-The existential bound `∃ δ > 0` follows from: injectivity implies primitivity
-(by the Wielandt bound), primitivity implies spectral gap
-(by `compl_eigenvalue_norm_lt_one_of_primitive`), and in finite dimensions
-the maximum over finitely many eigenvalues gives a uniform bound. -/
-theorem spectral_gap_from_wielandt [NeZero D]
+The existential bound `∃ δ > 0` follows from: injectivity implies
+`HasEventuallyFullKrausRank` (at index 1), which implies primitivity
+(via `IsPrimitivePaper → IsPeripherallyPrimitive`), primitivity implies
+spectral gap (by `compl_eigenvalue_norm_lt_one_of_primitive`), and in
+finite dimensions the maximum over finitely many eigenvalues gives a
+uniform bound. -/
+theorem spectral_gap_of_injective [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hA : IsInjective A) :
@@ -141,30 +143,22 @@ theorem spectral_gap_from_wielandt [NeZero D]
   set E := transferMap (d := d) (D := D) A
   -- Step 1: IsInjective → IsPrimitive (transferMap A)
   -- Chain: IsInjective → HasEventuallyFullKrausRank → IsPrimitivePaper → IsPeripherallyPrimitive
+  have hWord : wordSpan A 1 = Submodule.span ℂ (Set.range A) := by
+    simp only [wordSpan]
+    congr 1; ext y; constructor
+    · rintro ⟨σ, rfl⟩; exact ⟨σ 0, by simp [evalWord]⟩
+    · rintro ⟨i, rfl⟩; exact ⟨fun _ => i, by simp [evalWord]⟩
   have hFullKraus : HasEventuallyFullKrausRank A := by
-    refine ⟨1, ?_⟩
-    -- wordSpan A 1 = span of {evalWord A [i] | i : Fin d} = span of {A i | i} = ⊤
-    rw [eq_top_iff]
-    intro x _
-    rw [wordSpan]
-    -- range A ⊆ range (fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ))
-    -- since span(range A) = ⊤ by IsInjective
-    have hle : Submodule.span ℂ (Set.range A) ≤
-        Submodule.span ℂ (Set.range fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ)) := by
-      apply Submodule.span_mono
-      intro y hy
-      obtain ⟨i, rfl⟩ := hy
-      exact ⟨fun _ => i, by simp [evalWord]⟩
-    exact hle (hA ▸ Submodule.mem_top)
+    exact ⟨1, by rw [hWord, hA]⟩
   have hPrimPaper : IsPrimitivePaper A :=
     isPrimitivePaper_of_hasEventuallyFullKrausRank A hFullKraus
   have hPrim : _root_.IsPrimitive E :=
     isPeripherallyPrimitive_of_isPrimitivePaper A hNorm hPrimPaper
   -- Step 2: every eigenvalue has ‖μ‖ ≤ 1
+  have hE_eq : E = mixedTransferMap A A := (mixedTransferMap_self A).symm
   have hbound : ∀ μ : ℂ, Module.End.HasEigenvalue E μ → ‖μ‖ ≤ 1 := by
     intro μ hμ
-    exact eigenvalue_norm_le_one A A hNorm hNorm μ
-      (by rwa [show E = mixedTransferMap A A from (mixedTransferMap_self A).symm] at hμ)
+    exact eigenvalue_norm_le_one A A hNorm hNorm μ (hE_eq ▸ hμ)
   -- Step 3: non-1 eigenvalues have ‖μ‖ < 1 (from IsPrimitive + eigenvalue bound)
   have hlt : ∀ μ : ℂ, Module.End.HasEigenvalue E μ → μ ≠ 1 → ‖μ‖ < 1 := by
     intro μ hμ hne

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Spectral.SpectralGap
 import TNLean.Channel.Peripheral.Spectrum
+import TNLean.Wielandt.Primitivity.EasyDirections
+import TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducible
+import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 
 /-!
 # Quantitative spectral gap bounds for MPS transfer operators
@@ -74,8 +77,24 @@ theorem exponential_convergence_of_primitive [NeZero D]
         ‖((transferMap (d := d) (D := D) A)^[n]) X -
           fixedPointProj ρ (ne_of_gt hρ_pd.trace_pos) X‖ ≤
           C * (1 - δ) ^ n * ‖X‖ := by
-  -- TODO (#22): use compl_eigenvalue_norm_lt_one_of_primitive for spectral gap,
-  -- then pow_tendsto_zero_of_spectralRadius_lt_one for exponential convergence
+  -- TODO (#22): Two adapter lemmas needed before this can be wired:
+  --
+  -- (1) `huniq_fp`: the hypothesis `IsPrimitive (transferMap A)` does NOT directly
+  --     give unique trace-zero fixed points. The abstract
+  --     `compl_eigenvalue_norm_lt_one_of_primitive` requires
+  --     `huniq_fp : ∀ X, E X = X → trace X = 0 → X = 0` as a parameter.
+  --     For channels (CPTP maps), this follows from primitivity + CP structure, but
+  --     the adapter `channel_primitive_implies_unique_trace_zero_fixedPoint` is not yet
+  --     formalized. The existing `transferMap_fixedPoint_eq_zero_of_trace_eq_zero` in
+  --     `PeripheralToSpectralGap.lean` requires `IsInjective A`, which is stronger than
+  --     `IsPrimitive (transferMap A)`.
+  --
+  -- (2) Geometric bound from spectral radius: once `spectralRadius(E - P) < 1` is
+  --     established, converting to `∃ C r, ‖(E-P)^n‖ ≤ C * r^n` requires a
+  --     lemma `geometric_bound_of_spectralRadius_lt_one`:
+  --       spectralRadius T < 1 → ∃ C r, 0 < C ∧ 0 < r ∧ r < 1 ∧ ∀ n, ‖T^n‖ ≤ C * r^n
+  --     The Gelfand formula gives this eventually; packaging for all n requires
+  --     a finite correction factor.
   sorry
 
 /-- **Correlation length bound.**
@@ -118,8 +137,62 @@ theorem spectral_gap_from_wielandt [NeZero D]
     ∃ (δ : ℝ), 0 < δ ∧
       ∀ (μ : ℂ), Module.End.HasEigenvalue (transferMap (d := d) (D := D) A) μ →
         μ ≠ 1 → ‖μ‖ ≤ 1 - δ := by
-  -- TODO (#22): combine injective_implies_irreducibleCP + isPrimitive +
-  -- compl_eigenvalue_norm_lt_one_of_primitive + finite eigenvalue max
-  sorry
+  classical
+  set E := transferMap (d := d) (D := D) A
+  -- Step 1: IsInjective → IsPrimitive (transferMap A)
+  -- Chain: IsInjective → HasEventuallyFullKrausRank → IsPrimitivePaper → IsPeripherallyPrimitive
+  have hFullKraus : HasEventuallyFullKrausRank A := by
+    refine ⟨1, ?_⟩
+    -- wordSpan A 1 = span of {evalWord A [i] | i : Fin d} = span of {A i | i} = ⊤
+    rw [eq_top_iff]
+    intro x _
+    rw [wordSpan]
+    -- range A ⊆ range (fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ))
+    -- since span(range A) = ⊤ by IsInjective
+    have hle : Submodule.span ℂ (Set.range A) ≤
+        Submodule.span ℂ (Set.range fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ)) := by
+      apply Submodule.span_mono
+      intro y hy
+      obtain ⟨i, rfl⟩ := hy
+      exact ⟨fun _ => i, by simp [evalWord]⟩
+    exact hle (hA ▸ Submodule.mem_top)
+  have hPrimPaper : IsPrimitivePaper A :=
+    isPrimitivePaper_of_hasEventuallyFullKrausRank A hFullKraus
+  have hPrim : _root_.IsPrimitive E :=
+    isPeripherallyPrimitive_of_isPrimitivePaper A hNorm hPrimPaper
+  -- Step 2: every eigenvalue has ‖μ‖ ≤ 1
+  have hbound : ∀ μ : ℂ, Module.End.HasEigenvalue E μ → ‖μ‖ ≤ 1 := by
+    intro μ hμ
+    exact eigenvalue_norm_le_one A A hNorm hNorm μ
+      (by rwa [show E = mixedTransferMap A A from (mixedTransferMap_self A).symm] at hμ)
+  -- Step 3: non-1 eigenvalues have ‖μ‖ < 1 (from IsPrimitive + eigenvalue bound)
+  have hlt : ∀ μ : ℂ, Module.End.HasEigenvalue E μ → μ ≠ 1 → ‖μ‖ < 1 := by
+    intro μ hμ hne
+    exact lt_of_le_of_ne (hbound μ hμ) fun h => hne (hPrim.unique_peripheral μ hμ h)
+  -- Step 4: uniform gap from finite eigenvalue set
+  -- The eigenvalue set is finite (roots of minimal polynomial in finite dimensions)
+  have hfin : Set.Finite {μ : ℂ | Module.End.HasEigenvalue E μ} :=
+    Module.End.finite_hasEigenvalue E
+  let S := {μ : ℂ | Module.End.HasEigenvalue E μ ∧ μ ≠ 1}
+  have hSfin : S.Finite := hfin.subset fun μ hμ => hμ.1
+  by_cases hS : S.Nonempty
+  · -- Nonempty: take δ = 1 - max{‖μ‖ | μ ∈ S}
+    let norms := hSfin.toFinset.image (fun μ => ‖μ‖)
+    have hnorms_ne : norms.Nonempty := by
+      obtain ⟨μ₀, hμ₀⟩ := hS
+      exact ⟨‖μ₀‖, Finset.mem_image.mpr ⟨μ₀, hSfin.mem_toFinset.mpr hμ₀, rfl⟩⟩
+    set r := norms.max' hnorms_ne with r_def
+    have hr_lt : r < 1 := by
+      rw [r_def, Finset.max'_lt_iff]
+      intro x hx
+      obtain ⟨μ, hμS, rfl⟩ := Finset.mem_image.mp hx
+      exact hlt μ (hSfin.mem_toFinset.mp hμS).1 (hSfin.mem_toFinset.mp hμS).2
+    refine ⟨1 - r, by linarith, fun μ hμ hne => ?_⟩
+    have hμS : μ ∈ S := ⟨hμ, hne⟩
+    have hμ_norm_mem : ‖μ‖ ∈ norms :=
+      Finset.mem_image.mpr ⟨μ, hSfin.mem_toFinset.mpr hμS, rfl⟩
+    linarith [Finset.le_max' norms ‖μ‖ hμ_norm_mem]
+  · -- Empty: no non-1 eigenvalues, δ = 1 works vacuously
+    exact ⟨1, one_pos, fun μ hμ hne => absurd ⟨μ, hμ, hne⟩ hS⟩
 
 end MPSTensor

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -6,7 +6,6 @@ import TNLean.Spectral.SpectralGap
 import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Wielandt.Primitivity.EasyDirections
 import TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducible
-import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 
 /-!
 # Quantitative spectral gap bounds for MPS transfer operators
@@ -119,6 +118,21 @@ theorem correlation_length_bound [NeZero D]
   -- TODO (#22): ξ = -1/log(ρ₂) where ρ₂ is second-largest eigenvalue modulus
   sorry
 
+/-! ## Helper lemmas -/
+
+/-- The word span at length 1 equals the span of the Kraus operators. -/
+theorem wordSpan_one_eq_span_range (A : MPSTensor d D) :
+    wordSpan A 1 = Submodule.span ℂ (Set.range A) := by
+  simp only [wordSpan]
+  congr 1; ext y; constructor
+  · rintro ⟨σ, rfl⟩; exact ⟨σ 0, by simp [evalWord]⟩
+  · rintro ⟨i, rfl⟩; exact ⟨fun _ => i, by simp [evalWord]⟩
+
+/-- An injective MPS tensor has eventually full Kraus rank (at index 1). -/
+theorem hasEventuallyFullKrausRank_of_injective (A : MPSTensor d D)
+    (hA : IsInjective A) : HasEventuallyFullKrausRank A :=
+  ⟨1, by rw [wordSpan_one_eq_span_range, hA]⟩
+
 /-! ## Explicit gap from injectivity -/
 
 /-- **Spectral gap from injectivity** (existential version).
@@ -139,54 +153,20 @@ theorem spectral_gap_of_injective [NeZero D]
     ∃ (δ : ℝ), 0 < δ ∧
       ∀ (μ : ℂ), Module.End.HasEigenvalue (transferMap (d := d) (D := D) A) μ →
         μ ≠ 1 → ‖μ‖ ≤ 1 - δ := by
-  classical
   set E := transferMap (d := d) (D := D) A
   -- Step 1: IsInjective → IsPrimitive (transferMap A)
-  -- Chain: IsInjective → HasEventuallyFullKrausRank → IsPrimitivePaper → IsPeripherallyPrimitive
-  have hWord : wordSpan A 1 = Submodule.span ℂ (Set.range A) := by
-    simp only [wordSpan]
-    congr 1; ext y; constructor
-    · rintro ⟨σ, rfl⟩; exact ⟨σ 0, by simp [evalWord]⟩
-    · rintro ⟨i, rfl⟩; exact ⟨fun _ => i, by simp [evalWord]⟩
-  have hFullKraus : HasEventuallyFullKrausRank A := by
-    exact ⟨1, by rw [hWord, hA]⟩
-  have hPrimPaper : IsPrimitivePaper A :=
-    isPrimitivePaper_of_hasEventuallyFullKrausRank A hFullKraus
   have hPrim : _root_.IsPrimitive E :=
-    isPeripherallyPrimitive_of_isPrimitivePaper A hNorm hPrimPaper
+    isPeripherallyPrimitive_of_isPrimitivePaper A hNorm
+      (isPrimitivePaper_of_hasEventuallyFullKrausRank A
+        (hasEventuallyFullKrausRank_of_injective A hA))
   -- Step 2: every eigenvalue has ‖μ‖ ≤ 1
   have hE_eq : E = mixedTransferMap A A := (mixedTransferMap_self A).symm
   have hbound : ∀ μ : ℂ, Module.End.HasEigenvalue E μ → ‖μ‖ ≤ 1 := by
     intro μ hμ
     exact eigenvalue_norm_le_one A A hNorm hNorm μ (hE_eq ▸ hμ)
-  -- Step 3: non-1 eigenvalues have ‖μ‖ < 1 (from IsPrimitive + eigenvalue bound)
-  have hlt : ∀ μ : ℂ, Module.End.HasEigenvalue E μ → μ ≠ 1 → ‖μ‖ < 1 := by
-    intro μ hμ hne
-    exact lt_of_le_of_ne (hbound μ hμ) fun h => hne (hPrim.unique_peripheral μ hμ h)
-  -- Step 4: uniform gap from finite eigenvalue set
-  -- The eigenvalue set is finite (roots of minimal polynomial in finite dimensions)
-  have hfin : Set.Finite {μ : ℂ | Module.End.HasEigenvalue E μ} :=
-    Module.End.finite_hasEigenvalue E
-  let S := {μ : ℂ | Module.End.HasEigenvalue E μ ∧ μ ≠ 1}
-  have hSfin : S.Finite := hfin.subset fun μ hμ => hμ.1
-  by_cases hS : S.Nonempty
-  · -- Nonempty: take δ = 1 - max{‖μ‖ | μ ∈ S}
-    let norms := hSfin.toFinset.image (fun μ => ‖μ‖)
-    have hnorms_ne : norms.Nonempty := by
-      obtain ⟨μ₀, hμ₀⟩ := hS
-      exact ⟨‖μ₀‖, Finset.mem_image.mpr ⟨μ₀, hSfin.mem_toFinset.mpr hμ₀, rfl⟩⟩
-    set r := norms.max' hnorms_ne with r_def
-    have hr_lt : r < 1 := by
-      rw [r_def, Finset.max'_lt_iff]
-      intro x hx
-      obtain ⟨μ, hμS, rfl⟩ := Finset.mem_image.mp hx
-      exact hlt μ (hSfin.mem_toFinset.mp hμS).1 (hSfin.mem_toFinset.mp hμS).2
-    refine ⟨1 - r, by linarith, fun μ hμ hne => ?_⟩
-    have hμS : μ ∈ S := ⟨hμ, hne⟩
-    have hμ_norm_mem : ‖μ‖ ∈ norms :=
-      Finset.mem_image.mpr ⟨μ, hSfin.mem_toFinset.mpr hμS, rfl⟩
-    linarith [Finset.le_max' norms ‖μ‖ hμ_norm_mem]
-  · -- Empty: no non-1 eigenvalues, δ = 1 works vacuously
-    exact ⟨1, one_pos, fun μ hμ hne => absurd ⟨μ, hμ, hne⟩ hS⟩
+  -- Step 3: non-1 eigenvalues have ‖μ‖ < 1, then extract uniform gap
+  exact uniform_spectral_gap_of_finite_lt_one (Module.End.finite_hasEigenvalue E)
+    fun μ hμ hne => lt_of_le_of_ne (hbound μ hμ)
+      fun h => hne (hPrim.unique_peripheral μ hμ h)
 
 end MPSTensor

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -11,6 +11,7 @@ import Mathlib.Data.Matrix.Block
 import Mathlib.Analysis.Normed.Algebra.GelfandFormula
 import Mathlib.Analysis.SpecificLimits.Normed
 import Mathlib.LinearAlgebra.Eigenspace.Basic
+import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 
 /-!
 # Spectral gap for the mixed transfer operator
@@ -1108,3 +1109,39 @@ theorem mixedTransfer_pow_tendsto_zero
 end SpectralConvergence
 
 end MPSTensor
+
+/-! ## Uniform spectral gap from finite eigenvalue set -/
+
+/-- **Uniform spectral gap from finitely many eigenvalues with modulus < 1.**
+
+If an endomorphism has finitely many eigenvalues, and every eigenvalue `μ ≠ 1` satisfies
+`‖μ‖ < 1`, then there exists a uniform gap `δ > 0` such that `‖μ‖ ≤ 1 - δ` for all
+non-unit eigenvalues. This is a general finite-dimensional argument via `Finset.max'`. -/
+theorem uniform_spectral_gap_of_finite_lt_one
+    {K V : Type*} [NormedField K] [AddCommGroup V] [Module K V]
+    {E : V →ₗ[K] V}
+    (hfin : Set.Finite {μ : K | Module.End.HasEigenvalue E μ})
+    (hlt : ∀ μ, Module.End.HasEigenvalue E μ → μ ≠ 1 → ‖μ‖ < 1) :
+    ∃ δ > 0, ∀ μ, Module.End.HasEigenvalue E μ → μ ≠ 1 → ‖μ‖ ≤ 1 - δ := by
+  classical
+  let S := {μ : K | Module.End.HasEigenvalue E μ ∧ μ ≠ 1}
+  have hSfin : S.Finite := hfin.subset fun μ hμ => hμ.1
+  by_cases hS : S.Nonempty
+  · -- Nonempty: take δ = 1 - max{‖μ‖ | μ ∈ S}
+    let norms := hSfin.toFinset.image (fun μ => ‖μ‖)
+    have hnorms_ne : norms.Nonempty := by
+      obtain ⟨μ₀, hμ₀⟩ := hS
+      exact ⟨‖μ₀‖, Finset.mem_image.mpr ⟨μ₀, hSfin.mem_toFinset.mpr hμ₀, rfl⟩⟩
+    set r := norms.max' hnorms_ne with r_def
+    have hr_lt : r < 1 := by
+      rw [r_def, Finset.max'_lt_iff]
+      intro x hx
+      obtain ⟨μ, hμS, rfl⟩ := Finset.mem_image.mp hx
+      exact hlt μ (hSfin.mem_toFinset.mp hμS).1 (hSfin.mem_toFinset.mp hμS).2
+    refine ⟨1 - r, by linarith, fun μ hμ hne => ?_⟩
+    have hμS : μ ∈ S := ⟨hμ, hne⟩
+    have hμ_norm_mem : ‖μ‖ ∈ norms :=
+      Finset.mem_image.mpr ⟨μ, hSfin.mem_toFinset.mpr hμS, rfl⟩
+    linarith [Finset.le_max' norms ‖μ‖ hμ_norm_mem]
+  · -- Empty: no non-1 eigenvalues, δ = 1 works vacuously
+    exact ⟨1, one_pos, fun μ hμ hne => absurd ⟨μ, hμ, hne⟩ hS⟩

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -176,19 +176,20 @@ All three results below are stubs in the formalization (TODO~\#22).
     $\xi = -1/\log\rho(\E_A - P)$.
 \end{theorem}
 
-\begin{theorem}[Spectral gap from the Wielandt bound]%
+\begin{theorem}[Spectral gap from injectivity]%
     \label{thm:spectral_gap_wielandt}
-    \lean{MPSTensor.spectral_gap_from_wielandt}
+    \lean{MPSTensor.spectral_gap_of_injective}
     \notready
     \uses{thm:primitive_compl_lt_one, thm:wielandt_bound}
     For an injective trace-preserving MPS tensor, there exists
     $\delta > 0$ such that every eigenvalue $\mu \neq 1$ of the
     transfer map satisfies $|\mu| \le 1 - \delta$.
 
-    The proof combines: injectivity implies primitivity (via the
-    Wielandt bound, Theorem~\ref{thm:wielandt_bound}), primitivity
-    implies a spectral gap on the complementary map, and the finite
-    number of eigenvalues gives a uniform bound.
+    The proof combines: injectivity implies \texttt{HasEventuallyFullKrausRank}
+    (at index~1), which implies primitivity (via
+    \texttt{IsPrimitivePaper} $\to$ \texttt{IsPeripherallyPrimitive}),
+    primitivity implies a spectral gap on the complementary map, and the
+    finite number of eigenvalues gives a uniform bound.
 \end{theorem}
 
 \begin{remark}[Status of quantitative bounds]\label{rem:quantitative_status}

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -137,7 +137,8 @@ The spectral gap theorems in Chapter~\ref{ch:channels} establish
 $\rho(\E_A - P) < 1$ for primitive channels qualitatively.  This section
 records the \emph{quantitative} refinements that give explicit constants
 and rates for the single-tensor transfer map $\E_A$.
-All three results below are stubs in the formalization (TODO~\#22).
+Two of the three results below are stubs in the formalization (TODO~\#22);
+the spectral gap from injectivity is fully proved.
 
 \begin{theorem}[Exponential convergence of primitive channels]%
     \label{thm:exponential_convergence_primitive}
@@ -179,8 +180,7 @@ All three results below are stubs in the formalization (TODO~\#22).
 \begin{theorem}[Spectral gap from injectivity]%
     \label{thm:spectral_gap_wielandt}
     \lean{MPSTensor.spectral_gap_of_injective}
-    \notready
-    \uses{thm:primitive_compl_lt_one, thm:wielandt_bound}
+    \uses{thm:spectral_gap, thm:wielandt_bound}
     For an injective trace-preserving MPS tensor, there exists
     $\delta > 0$ such that every eigenvalue $\mu \neq 1$ of the
     transfer map satisfies $|\mu| \le 1 - \delta$.
@@ -194,11 +194,10 @@ All three results below are stubs in the formalization (TODO~\#22).
 
 \begin{remark}[Status of quantitative bounds]\label{rem:quantitative_status}
     \uses{thm:exponential_convergence_primitive,
-          thm:correlation_length_bound,
-          thm:spectral_gap_wielandt}
-    The three theorems above are formalized as stubs (with
+          thm:correlation_length_bound}
+    Two of the three theorems above are formalized as stubs (with
     \texttt{sorry}) in \texttt{TNLean/Spectral/QuantitativeGap.lean},
-    tagged TODO~\#22.
+    tagged TODO~\#22; the spectral gap from injectivity is fully proved.
     The qualitative results they refine --- spectral gap existence,
     overlap decay, and correlation convergence --- are fully proved in
     Chapter~\ref{ch:spectral}.

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -180,17 +180,20 @@ the spectral gap from injectivity is fully proved.
 \begin{theorem}[Spectral gap from injectivity]%
     \label{thm:spectral_gap_wielandt}
     \lean{MPSTensor.spectral_gap_of_injective}
+    \leanok
     \uses{thm:spectral_gap, thm:wielandt_bound}
     For an injective trace-preserving MPS tensor, there exists
     $\delta > 0$ such that every eigenvalue $\mu \neq 1$ of the
     transfer map satisfies $|\mu| \le 1 - \delta$.
-
+\end{theorem}
+\begin{proof}
+    \leanok
     The proof combines: injectivity implies \texttt{HasEventuallyFullKrausRank}
     (at index~1), which implies primitivity (via
     \texttt{IsPrimitivePaper} $\to$ \texttt{IsPeripherallyPrimitive}),
     primitivity implies a spectral gap on the complementary map, and the
     finite number of eigenvalues gives a uniform bound.
-\end{theorem}
+\end{proof}
 
 \begin{remark}[Status of quantitative bounds]\label{rem:quantitative_status}
     \uses{thm:exponential_convergence_primitive,


### PR DESCRIPTION
### Motivation

- Continues formalization of spectral gap theory for MPS correlations, see LionSR/TNLean#332.
- The `spectral_gap_from_wielandt` lemma in `QuantitativeGap.lean` was left as a `sorry`; this PR discharges it by wiring the chain `IsInjective → HasEventuallyFullKrausRank → IsPrimitivePaper → IsPrimitive(transferMap)`.

### Description

- **Modified:** `TNLean/Spectral/QuantitativeGap.lean` (+78 −5)
- Proves `spectral_gap_from_wielandt` by establishing that all non-unit eigenvalues have modulus ≤ 1−δ for some uniform δ > 0, using primitivity of the transfer map derived from `IsInjective`.
- Key proof ingredients: `wordSpan`, `isPrimitivePaper_of_hasEventuallyFullKrausRank`, `isPeripherallyPrimitive_of_isPrimitivePaper`, `eigenvalue_norm_le_one`, `IsPrimitive.unique_peripheral`, `Module.End.finite_hasEigenvalue`, and `Finset.max'`.
- Documents the 2 remaining adapter lemmas needed for `exponential_convergence_of_primitive`.
- Reduces sorry count in `QuantitativeGap.lean` from 3 to 2.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/TNLean#332

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean-proof-only changes that add lemmas and discharge a `sorry`; main risk is downstream breakage from strengthened dependencies/imports rather than runtime behavior.
> 
> **Overview**
> Discharges the previously-sorry quantitative result by proving `MPSTensor.spectral_gap_of_injective`: from `IsInjective` it derives primitivity of `transferMap`, shows all eigenvalues have norm `≤ 1`, then uses a new finite-dimensional lemma to extract a uniform `δ > 0` with `‖μ‖ ≤ 1 - δ` for every eigenvalue `μ ≠ 1`.
> 
> Adds helper lemmas connecting `wordSpan` at length 1 to the Kraus-operator span and to `HasEventuallyFullKrausRank`, plus the general-purpose `uniform_spectral_gap_of_finite_lt_one` in `SpectralGap.lean` (with a new Mathlib import). Updates the blueprint text to mark the injectivity spectral-gap theorem as `leanok` and notes the remaining two quantitative stubs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b00b24ca09283d084ced8f644de19c52797c767. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->