### PR TITLE
fix(blueprint): correct cross-references in Ch15 spectral gap section

### DIFF
--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -201,8 +201,8 @@ mixed transfer power.
 
 The spectral-gap proofs use the Frobenius (Hilbert--Schmidt) norm
 as the natural norm for the finite-dimensional matrix algebra.
-We write $\|{\cdot}\|_F$ throughout; this coincides with the
-Hilbert--Schmidt norm $\|{\cdot}\|_{HS}$ on finite-dimensional spaces.
+We write $\|{\cdot}\|_F$ for this norm; it coincides with, and we use it
+interchangeably with, the Hilbert--Schmidt norm $\|{\cdot}\|_{\mathrm{HS}}$ on finite-dimensional spaces.
 We record the squared version and an isometric embedding into
 Euclidean space.
 

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -201,6 +201,8 @@ mixed transfer power.
 
 The spectral-gap proofs use the Frobenius (Hilbert--Schmidt) norm
 as the natural norm for the finite-dimensional matrix algebra.
+We write $\|{\cdot}\|_F$ throughout; this coincides with the
+Hilbert--Schmidt norm $\|{\cdot}\|_{HS}$ on finite-dimensional spaces.
 We record the squared version and an isometric embedding into
 Euclidean space.
 
@@ -228,7 +230,6 @@ Euclidean space.
 \begin{definition}[Euclidean-space embedding]\label{def:mat_to_es}
     \lean{MPSTensor.matToES}
     \leanok
-    \uses{def:frob_sq}
     The map $\mathrm{vec} : M_{m \times n}(\C) \to \C^{mn}$ that
     flattens matrix entries is an isometric embedding with respect
     to the Frobenius norm: $\|\mathrm{vec}(X)\|^2 = \|X\|_F^2$.

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -94,12 +94,13 @@ their spectral decomposition, and quantitative bounds on decay rates.
 
 \begin{remark}[Spectral hypothesis and the spectral gap]%
     \label{rem:spectral_hypothesis}
-    \uses{thm:correlator_exponential_bound, thm:spectral_gap}
+    \uses{thm:correlator_exponential_bound, thm:trace_pow_one}
     The hypothesis ``$|\lambda_2| < 1$'' in
     Theorem~\ref{thm:correlator_exponential_bound} is precisely the
     \emph{spectral gap} condition for the transfer map $\E_A$.
-    For injective tensors, the strict spectral gap is established in
-    Theorem~\ref{thm:spectral_gap} (Chapter~\ref{ch:spectral});
+    For primitive channels, the complementary spectral gap
+    $\rho(\E_A - P) < 1$ is established in
+    Theorem~\ref{thm:trace_pow_one} (Chapter~\ref{ch:spectral});
     for irreducible trace-preserving tensors, the analogous result is
     Theorem~\ref{thm:spectral_gap_irr_tp}.
     Thus the exponential decay of connected correlations follows
@@ -133,15 +134,16 @@ their spectral decomposition, and quantitative bounds on decay rates.
 \section{Quantitative spectral gap bounds}
 
 The spectral gap theorems in Chapter~\ref{ch:spectral} establish
-$\rho(F_{AB}) < 1$ qualitatively.  This section records the
-\emph{quantitative} refinements that give explicit constants and rates.
+$\rho(\E_A - P) < 1$ for primitive channels qualitatively.  This section
+records the \emph{quantitative} refinements that give explicit constants
+and rates for the single-tensor transfer map $\E_A$.
 All three results below are stubs in the formalization (TODO~\#22).
 
 \begin{theorem}[Exponential convergence of primitive channels]%
     \label{thm:exponential_convergence_primitive}
     \lean{MPSTensor.exponential_convergence_of_primitive}
     \notready
-    \uses{thm:spectral_gap, def:fixed_point_proj,
+    \uses{thm:trace_pow_one, def:fixed_point_proj,
           thm:primitive_overlap}
     Let $A$ be a primitive trace-preserving MPS tensor with positive
     definite fixed point $\rho$ and fixed-point projection
@@ -153,7 +155,7 @@ All three results below are stubs in the formalization (TODO~\#22).
         \;\le\; C\,(1-\delta)^n\,\|X\|.
     \]
     The spectral gap $\delta$ exists by primitivity
-    (Theorem~\ref{thm:spectral_gap} applied to the complementary map).
+    (Theorem~\ref{thm:trace_pow_one}, the complementary spectral gap).
 \end{theorem}
 
 \begin{theorem}[Correlation length bound]\label{thm:correlation_length_bound}
@@ -178,7 +180,7 @@ All three results below are stubs in the formalization (TODO~\#22).
     \label{thm:spectral_gap_wielandt}
     \lean{MPSTensor.spectral_gap_from_wielandt}
     \notready
-    \uses{thm:spectral_gap, thm:wielandt_bound}
+    \uses{thm:trace_pow_one, thm:wielandt_bound}
     For an injective trace-preserving MPS tensor, there exists
     $\delta > 0$ such that every eigenvalue $\mu \neq 1$ of the
     transfer map satisfies $|\mu| \le 1 - \delta$.

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -94,13 +94,13 @@ their spectral decomposition, and quantitative bounds on decay rates.
 
 \begin{remark}[Spectral hypothesis and the spectral gap]%
     \label{rem:spectral_hypothesis}
-    \uses{thm:correlator_exponential_bound, thm:trace_pow_one}
+    \uses{thm:correlator_exponential_bound, thm:primitive_compl_lt_one}
     The hypothesis ``$|\lambda_2| < 1$'' in
     Theorem~\ref{thm:correlator_exponential_bound} is precisely the
     \emph{spectral gap} condition for the transfer map $\E_A$.
     For primitive channels, the complementary spectral gap
     $\rho(\E_A - P) < 1$ is established in
-    Theorem~\ref{thm:trace_pow_one} (Chapter~\ref{ch:spectral});
+    Theorem~\ref{thm:primitive_compl_lt_one} (Chapter~\ref{ch:channels});
     for irreducible trace-preserving tensors, the analogous result is
     Theorem~\ref{thm:spectral_gap_irr_tp}.
     Thus the exponential decay of connected correlations follows
@@ -133,7 +133,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
 
 \section{Quantitative spectral gap bounds}
 
-The spectral gap theorems in Chapter~\ref{ch:spectral} establish
+The spectral gap theorems in Chapter~\ref{ch:channels} establish
 $\rho(\E_A - P) < 1$ for primitive channels qualitatively.  This section
 records the \emph{quantitative} refinements that give explicit constants
 and rates for the single-tensor transfer map $\E_A$.
@@ -143,7 +143,7 @@ All three results below are stubs in the formalization (TODO~\#22).
     \label{thm:exponential_convergence_primitive}
     \lean{MPSTensor.exponential_convergence_of_primitive}
     \notready
-    \uses{thm:trace_pow_one, def:fixed_point_proj,
+    \uses{thm:primitive_compl_lt_one, def:fixed_point_proj,
           thm:primitive_overlap}
     Let $A$ be a primitive trace-preserving MPS tensor with positive
     definite fixed point $\rho$ and fixed-point projection
@@ -155,7 +155,7 @@ All three results below are stubs in the formalization (TODO~\#22).
         \;\le\; C\,(1-\delta)^n\,\|X\|.
     \]
     The spectral gap $\delta$ exists by primitivity
-    (Theorem~\ref{thm:trace_pow_one}, the complementary spectral gap).
+    (Theorem~\ref{thm:primitive_compl_lt_one}, the complementary spectral gap).
 \end{theorem}
 
 \begin{theorem}[Correlation length bound]\label{thm:correlation_length_bound}
@@ -180,7 +180,7 @@ All three results below are stubs in the formalization (TODO~\#22).
     \label{thm:spectral_gap_wielandt}
     \lean{MPSTensor.spectral_gap_from_wielandt}
     \notready
-    \uses{thm:trace_pow_one, thm:wielandt_bound}
+    \uses{thm:primitive_compl_lt_one, thm:wielandt_bound}
     For an injective trace-preserving MPS tensor, there exists
     $\delta > 0$ such that every eigenvalue $\mu \neq 1$ of the
     transfer map satisfies $|\mu| \le 1 - \delta$.


### PR DESCRIPTION
### Motivation

- Blueprint cross-references in Ch15 correlations incorrectly cite `thm:spectral_gap` (mixed-transfer operator result) in contexts about the single-tensor transfer map `E_A` and its complementary spectral gap, see #350.

### Description

- Replace `thm:spectral_gap` with `thm:trace_pow_one` in `rem:spectral_hypothesis`, `thm:exponential_convergence_primitive`, and `thm:spectral_gap_wielandt` in `blueprint/src/chapter/ch15_correlations.tex`
- Fix section intro to reference `E_A` and `ρ(E_A - P) < 1` instead of `ρ(F_AB) < 1`
- Add note that `‖·‖_F = ‖·‖_HS` in `blueprint/src/chapter/ch06_spectral.tex`
- Remove spurious `\uses{def:frob_sq}` from `def:mat_to_es`

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- Blueprint Lint (`lint-blueprint.yml`) validates LaTeX references.

---
Addresses #350

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update: adjusts LaTeX cross-references and wording around spectral-gap results without changing any Lean or runtime code.
> 
> **Overview**
> Updates Chapter 15 correlation notes to cite the *primitive complementary spectral gap* result (`\rho(\E_A - P) < 1`) from the channels chapter, and rewrites the quantitative spectral-gap section intro and theorem `\uses{}` dependencies to consistently refer to the single-tensor transfer map rather than the mixed-transfer operator.
> 
> Clarifies in Chapter 6 that the Frobenius norm notation `\|\cdot\|_F` is used interchangeably with the Hilbert–Schmidt norm `\|\cdot\|_{\mathrm{HS}}`, and removes an unnecessary `\uses{def:frob_sq}` tag from the matrix-vectorization embedding definition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 665763caae10f4e4c92a2e833ac1d547fa9fecca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->