### PR TITLE
feat(MPS/FundamentalTheorem): prove finite-length MPV propagation for injective tensors

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -35,7 +35,7 @@ uniquely, because word products of length `≥ 1` span `M_D(ℂ)` (by injectivit
 and the trace agreements of length `≥ N₀` pin down the action of `T`.
 
 This requires a non-trivial inductive argument that interleaves the linear
-extension construction with the trace pairing, which we leave as a `sorry`.
+extension construction with the trace pairing.
 
 ## Strengthening relative to the literature
 
@@ -90,33 +90,195 @@ lemma SameMPVFrom.trace_evalWord_of_length_ge
   simp only [mpv, coeff, List.ofFn_get] at this
   exact this
 
+/-! ## Helper: word span for injective tensors -/
+
+/-- For an injective tensor, `wordSpan A n = ⊤` for all `n ≥ 1`.
+
+Base: `wordSpan A 1 = span(range A) = ⊤`. Step: right-multiply each generator
+by the A-decomposition of `1` to embed `wordSpan A n` into `wordSpan A (n+1)`. -/
+private theorem wordSpan_eq_top_of_isInjective
+    {A : MPSTensor d D} (hA : IsInjective A)
+    {n : ℕ} (hn : 1 ≤ n) : wordSpan A n = ⊤ := by
+  classical
+  obtain ⟨c, hc⟩ := hA.exists_decomposition 1
+  induction n with
+  | zero => omega
+  | succ n ih =>
+    rcases n.eq_zero_or_pos with rfl | hn'
+    · -- Base case: wordSpan A 1 = span(range A) = ⊤
+      rw [eq_top_iff, ← hA.span_eq_top]
+      apply Submodule.span_le.mpr
+      rintro _ ⟨i, rfl⟩
+      have : A i = evalWord A [i] := by simp
+      rw [this]; exact evalWord_mem_wordSpan A [i]
+    · -- Inductive step: wordSpan A n ≤ wordSpan A (n+1)
+      rw [eq_top_iff, ← ih hn']
+      apply Submodule.span_le.mpr
+      rintro _ ⟨σ, rfl⟩
+      have key : evalWord A (List.ofFn σ) =
+          ∑ i, c i • evalWord A (List.ofFn σ ++ [i]) := by
+        conv_lhs => rw [show evalWord A (List.ofFn σ) = evalWord A (List.ofFn σ) * 1
+          from (mul_one _).symm, hc, Finset.mul_sum]
+        simp only [Algebra.mul_smul_comm, evalWord_append, evalWord_cons,
+          evalWord_nil, mul_one]
+      dsimp only
+      rw [key]
+      exact Submodule.sum_mem _ fun i _ =>
+        Submodule.smul_mem _ _ (by
+          have := evalWord_mem_wordSpan A (List.ofFn σ ++ [i])
+          rwa [show (List.ofFn σ ++ [i]).length = n + 1 from by simp] at this)
+
 /-! ## Main results -/
 
 /-- **Finite-length agreement implies full agreement** for injective tensors.
 
-The proof requires showing that trace agreements on words of length `≥ N₀`
-determine the linear extension `T` with `T(A i) = B i` uniquely.
+**Proof**: For `N₀ ≥ 1`, let `1 = Σ cᵢ Aⁱ` (by injectivity) and `S = Σ cᵢ Bⁱ`.
 
-**Proof outline** (not yet formalized):
-1. By injectivity, `{A i}` spans `M_D(ℂ)`, so any linear map on `M_D(ℂ)` is
-   determined by its values on `{A i}`.
-2. The map `Φ_A : M ↦ (i ↦ tr(M · A i))` is injective (by
-   `traceMulRightPi_ker_eq_bot`).
-3. For words `w` of length `n ≥ N₀ - 1`, the `SameMPVFrom` hypothesis gives
-   `tr(evalWord A (w ++ [i])) = tr(evalWord B (w ++ [i]))` for all extensions.
-4. Since `evalWord A (w ++ [i]) = evalWord A w * A i` and similarly for `B`,
-   the injectivity of `Φ_A` applied to `evalWord A w - T(evalWord A w)` (where
-   `T` is the linear extension from `A` to `B`) shows `T` agrees with the
-   `B`-evaluation on long words.
-5. By multiplicativity of `T` (from the existing linear extension proof) and
-   downward induction, agreement propagates to all word lengths. -/
+1. Show `wordSpan B N₀ = ⊤` via the composition identity
+   `traceMulRightPi A ∘ lcA = traceMulRightPi B ∘ lcB` (at word level `N₀`),
+   using trace agreement at length `N₀ + 1` and the finrank transfer
+   `ker_bot_of_range_le`.
+2. Show `S = 1` by trace nondegeneracy on `wordSpan B N₀ = ⊤`:
+   for `|v| = N₀`, the identity `tr(v_B · S) = tr(v_A) = tr(v_B)` gives
+   `tr(M(S−1)) = 0` for all `M`.
+3. Step down: for `|w| < N₀`, use `tr(w_A) = Σ cᵢ tr((w++[i])_A)` and
+   `tr(w_B) = Σ cᵢ tr((w++[i])_B)` (the latter by `S = 1`), plus the
+   inductive hypothesis at length `|w|+1`. -/
 theorem sameMPV_of_sameMPVFrom_of_injective [NeZero D]
     {A B : MPSTensor d D}
     (hA : IsInjective A)
     {N₀ : ℕ} (hFrom : SameMPVFrom N₀ A B) :
     SameMPV A B := by
-  -- TODO (#22): downward induction via trace pairing injectivity (traceMulRightPi_ker_eq_bot)
-  sorry
+  -- Handle N₀ = 0 trivially.
+  rcases N₀.eq_zero_or_pos with rfl | hN₀
+  · exact sameMPVFrom_zero_iff.mp hFrom
+  -- N₀ ≥ 1. Set up decomposition.
+  classical
+  obtain ⟨c, hc⟩ := hA.exists_decomposition 1
+  -- ── Step 1: wordSpan B N₀ = ⊤ (composition identity) ──
+  have hWB : wordSpan B N₀ = ⊤ := by
+    let genA := fun σ : Fin N₀ → Fin d => evalWord A (List.ofFn σ)
+    let genB := fun σ : Fin N₀ → Fin d => evalWord B (List.ofFn σ)
+    let lcA := Fintype.linearCombination ℂ genA
+    let lcB := Fintype.linearCombination ℂ genB
+    let ΦA := traceMulRightPi (d := d) (D := D) A
+    let ΦB := traceMulRightPi (d := d) (D := D) B
+    have hSurjA : Function.Surjective lcA :=
+      (span_range_eq_top_iff_surjective_fintypeLinearCombination ℂ genA).mp
+        (wordSpan_eq_top_of_isInjective hA hN₀)
+    -- Composition identity: Φ_A ∘ lc_A = Φ_B ∘ lc_B
+    have hComp : (ΦA ∘ₗ lcA) = (ΦB ∘ₗ lcB) := by
+      apply LinearMap.ext; intro α; apply funext; intro j
+      change Matrix.trace (lcA α * A j) = Matrix.trace (lcB α * B j)
+      simp only [lcA, lcB, Fintype.linearCombination_apply, Finset.sum_mul,
+        smul_mul_assoc, Matrix.trace_sum, Matrix.trace_smul, smul_eq_mul]
+      apply Finset.sum_congr rfl; intro σ _
+      conv_lhs => rw [show evalWord A (List.ofFn σ) * A j =
+          evalWord A (List.ofFn σ ++ [j]) from by
+        rw [show A j = evalWord A [j] from by simp, ← evalWord_append]]
+      conv_rhs => rw [show evalWord B (List.ofFn σ) * B j =
+          evalWord B (List.ofFn σ ++ [j]) from by
+        rw [show B j = evalWord B [j] from by simp, ← evalWord_append]]
+      have key := hFrom.trace_evalWord_of_length_ge
+        (show N₀ ≤ (List.ofFn σ ++ [j]).length by simp)
+      rw [key]
+    -- Range inclusion → ker Φ_B = ⊥
+    have hRange : ΦA.range ≤ ΦB.range := by
+      rw [show ΦA.range = (ΦA ∘ₗ lcA).range from by
+        simp [LinearMap.range_comp, LinearMap.range_eq_top.2 hSurjA], hComp]
+      exact LinearMap.range_comp_le_range lcB ΦB
+    have hKerΦB : ΦB.ker = ⊥ :=
+      ker_bot_of_range_le ΦA ΦB (traceMulRightPi_ker_eq_bot hA) hRange
+    -- Equal kernels → equal range dimensions → lc_B surjective
+    have hKerEq : lcA.ker = lcB.ker := by
+      ext α; constructor
+      · intro hα
+        have h1 : (ΦA ∘ₗ lcA) α = (ΦB ∘ₗ lcB) α := congrFun (congrArg DFunLike.coe hComp) α
+        simp only [LinearMap.comp_apply, LinearMap.mem_ker.mp hα, map_zero] at h1
+        exact LinearMap.mem_ker.mpr (LinearMap.ker_eq_bot'.mp hKerΦB _ h1.symm)
+      · intro hα
+        have h1 : (ΦA ∘ₗ lcA) α = (ΦB ∘ₗ lcB) α := congrFun (congrArg DFunLike.coe hComp) α
+        simp only [LinearMap.comp_apply, LinearMap.mem_ker.mp hα, map_zero] at h1
+        exact LinearMap.mem_ker.mpr
+          (LinearMap.ker_eq_bot'.mp (traceMulRightPi_ker_eq_bot hA) _ h1)
+    have hSurjB : Function.Surjective lcB := by
+      rw [← LinearMap.range_eq_top]
+      have hRkA := LinearMap.finrank_range_add_finrank_ker lcA
+      have hRkB := LinearMap.finrank_range_add_finrank_ker lcB
+      rw [LinearMap.range_eq_top.mpr hSurjA, hKerEq] at hRkA
+      apply Submodule.eq_top_of_finrank_eq
+      have := finrank_top (R := ℂ) (M := Matrix (Fin D) (Fin D) ℂ)
+      omega
+    exact (span_range_eq_top_iff_surjective_fintypeLinearCombination ℂ genB).mpr hSurjB
+  -- ── Step 2: S = 1 (trace nondegeneracy) ──
+  set S := ∑ i, c i • B i
+  have hS : S = 1 := by
+    suffices h : S - 1 = 0 from sub_eq_zero.mp h
+    apply trace_mul_right_eq_zero; intro N
+    -- The linear functional tr((S−1) · _) vanishes on wordSpan B N₀ = ⊤
+    have hf : (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
+        (LinearMap.mulLeft ℂ (S - 1)) = 0 := by
+      apply LinearMap.ext_on_range
+        (v := fun σ : Fin N₀ → Fin d => evalWord B (List.ofFn σ))
+        (hv := hWB)
+      intro σ
+      simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
+        Matrix.traceLinearMap_apply, LinearMap.zero_apply, sub_mul, map_sub,
+        one_mul]
+      -- Goal: tr(S · evalWord B (List.ofFn σ)) - tr(evalWord B (List.ofFn σ)) = 0
+      -- Both sides equal tr(evalWord A (List.ofFn σ))
+      have h_SN : Matrix.trace (S * evalWord B (List.ofFn σ)) =
+          Matrix.trace (evalWord A (List.ofFn σ)) := by
+        show Matrix.trace ((∑ i, c i • B i) * evalWord B (List.ofFn σ)) = _
+        rw [Finset.sum_mul]
+        simp only [smul_mul_assoc, Matrix.trace_sum, Matrix.trace_smul,
+          smul_eq_mul, ← evalWord_cons]
+        have : Matrix.trace (evalWord A (List.ofFn σ)) =
+            ∑ i, c i * Matrix.trace (evalWord A (i :: List.ofFn σ)) := by
+          conv_lhs => rw [show evalWord A (List.ofFn σ) = 1 * evalWord A (List.ofFn σ)
+            from (one_mul _).symm, hc, Finset.sum_mul]
+          simp only [smul_mul_assoc, Matrix.trace_sum, Matrix.trace_smul,
+            smul_eq_mul, ← evalWord_cons]
+        rw [this]; apply Finset.sum_congr rfl; intro i _; congr 1
+        exact (hFrom.trace_evalWord_of_length_ge (w := i :: List.ofFn σ) (by simp)).symm
+      rw [h_SN, (hFrom.trace_evalWord_of_length_ge (show N₀ ≤ (List.ofFn σ).length by simp)).symm,
+        sub_self]
+    simpa [Matrix.traceLinearMap_apply, LinearMap.mulLeft_apply]
+      using congrFun (congrArg DFunLike.coe hf) N
+  -- ── Step 3: SameMPV by downward induction ──
+  suffices h_all : ∀ w : List (Fin d),
+      Matrix.trace (evalWord A w) = Matrix.trace (evalWord B w) by
+    intro N σ; simpa [mpv, coeff] using h_all (List.ofFn σ)
+  -- Induction on k = N₀ − |w|
+  suffices h_k : ∀ k, ∀ w : List (Fin d), w.length + k = N₀ →
+      Matrix.trace (evalWord A w) = Matrix.trace (evalWord B w) by
+    intro w
+    by_cases hle : N₀ ≤ w.length
+    · exact hFrom.trace_evalWord_of_length_ge hle
+    · exact h_k (N₀ - w.length) w (by omega)
+  intro k; induction k with
+  | zero => exact fun w hw => hFrom.trace_evalWord_of_length_ge (by omega)
+  | succ k ih =>
+    intro w hw
+    -- Decompose using A: tr(w_A) = Σ cᵢ tr((w++[i])_A)
+    have hA_sum : Matrix.trace (evalWord A w) =
+        ∑ i : Fin d, c i * Matrix.trace (evalWord A (w ++ [i])) := by
+      conv_lhs => rw [show evalWord A w = evalWord A w * 1 from (mul_one _).symm, hc,
+        Finset.mul_sum]
+      simp only [Algebra.mul_smul_comm, Matrix.trace_sum, Matrix.trace_smul, smul_eq_mul]
+      apply Finset.sum_congr rfl; intro i _; congr 1
+      rw [show A i = evalWord A [i] from by simp, ← evalWord_append]
+    -- Decompose using B (S = 1): tr(w_B) = Σ cᵢ tr((w++[i])_B)
+    have hB_sum : Matrix.trace (evalWord B w) =
+        ∑ i : Fin d, c i * Matrix.trace (evalWord B (w ++ [i])) := by
+      conv_lhs => rw [show evalWord B w = evalWord B w * 1 from (mul_one _).symm,
+        show (1 : Matrix (Fin D) (Fin D) ℂ) = S from hS.symm, Finset.mul_sum]
+      simp only [Algebra.mul_smul_comm, Matrix.trace_sum, Matrix.trace_smul, smul_eq_mul]
+      apply Finset.sum_congr rfl; intro i _; congr 1
+      rw [show B i = evalWord B [i] from by simp, ← evalWord_append]
+    rw [hA_sum, hB_sum]
+    apply Finset.sum_congr rfl; intro i _; congr 1
+    exact ih (w ++ [i]) (by simp; omega)
 
 /-- **Strengthened single-block Fundamental Theorem (finite-length version).**
 

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -430,6 +430,69 @@ Lemma~\ref{lem:tensor_proportional} yields the main theorem of
     full generality.
 \end{remark}
 
+\subsection{Finite-length MPV agreement}
+
+\begin{definition}[Finite-length MPV agreement]\label{def:same_mpv_from}
+    \lean{MPSTensor.SameMPVFrom}
+    \leanok
+    \uses{def:same_mpv}
+    Two tensors $A$ and $B$ of the same bond dimension satisfy
+    \emph{$\mathrm{SameMPVFrom}(N_0)$} if they generate the same MPV
+    family for all system sizes $N \ge N_0$:
+    \[
+        \mathrm{mpv}(A, \sigma) = \mathrm{mpv}(B, \sigma)
+        \qquad \text{for all } N \ge N_0,\;\sigma \in [d]^N.
+    \]
+\end{definition}
+
+\begin{theorem}[Finite-length agreement implies full agreement]%
+    \label{thm:sameMPV_of_sameMPVFrom}
+    \lean{MPSTensor.sameMPV_of_sameMPVFrom_of_injective}
+    \leanok
+    \uses{def:same_mpv_from, def:injective, def:same_mpv}
+    Let $A$ be an injective tensor and $B$ a tensor of the same bond
+    dimension.  If $\mathrm{SameMPVFrom}(N_0, A, B)$ holds for some
+    $N_0$, then $\mathrm{SameMPV}(A, B)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:same_mpv_from, def:injective}
+    Write $1 = \sum_i c_i A^i$ (by injectivity) and set
+    $S = \sum_i c_i B^i$.
+    \begin{enumerate}
+        \item Show $\mathrm{wordSpan}(B, N_0) = \MN{D}$ via the
+              composition identity
+              $\Phi_A \circ \ell_A = \Phi_B \circ \ell_B$
+              (from trace agreement at length $N_0 + 1$)
+              and a finrank transfer argument.
+        \item Derive $S = 1$ by trace nondegeneracy: for every
+              $M \in \MN{D}$, $\tr(M(S - 1)) = 0$.
+        \item Downward induction on $k = N_0 - |w|$: decompose
+              $\tr(w_A)$ and $\tr(w_B)$ using $1 = \sum c_i A^i$
+              and $S = 1$ respectively, then apply the inductive
+              hypothesis at length $|w| + 1$.
+    \end{enumerate}
+\end{proof}
+
+\begin{theorem}[Strengthened single-block FT (finite-length)]%
+    \label{thm:ft_singleBlock_finiteLength}
+    \lean{MPSTensor.fundamentalTheorem_singleBlock_finiteLength}
+    \leanok
+    \uses{thm:sameMPV_of_sameMPVFrom, thm:ft_single, def:gauge_equiv}
+    If $A$ is injective and $A$, $B$ agree on all MPV coefficients for
+    system sizes $N \ge N_0$ (for any threshold $N_0$), then $A$ and $B$
+    are gauge equivalent.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:sameMPV_of_sameMPVFrom, thm:ft_single}
+    Apply Theorem~\ref{thm:sameMPV_of_sameMPVFrom} to obtain
+    $\mathrm{SameMPV}(A, B)$, then invoke the single-block FT
+    (Theorem~\ref{thm:ft_single}).
+\end{proof}
+
 %% ---------------------------------------------------------
 \section{Corollaries}%
 \label{sec:ft_corollaries}


### PR DESCRIPTION
### Motivation

- Continues formalization of the algebraic Fundamental Theorem (Ch13), see #330.
- Removes `sorry` from `sameMPV_of_sameMPVFrom_of_injective` and `fundamentalTheorem_singleBlock_finiteLength`, closing proof gaps in the finite-length FT step.

### Description

- **Modified:** `TNLean/MPS/FundamentalTheorem/FiniteLength.lean` (+181 / −19)
- Added helper `wordSpan_eq_top_of_isInjective`, deriving `wordSpan B N₀ = ⊤` via a `traceMulRightPi` composition identity plus `ker_bot_of_range_le`.
- Proved normalization `S = 1` using trace pairing nondegeneracy.
- Performed downward induction to extend trace agreement from lengths ≥ N₀ to all word lengths, making `fundamentalTheorem_singleBlock_finiteLength` sorry-free.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #330

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it replaces a `sorry` with a nontrivial Lean proof that manipulates linear maps, kernels/ranges, and finrank arguments; small mistakes could break downstream theorems even though it’s proof-only and not runtime code.
> 
> **Overview**
> Proves that **finite-length MPV agreement** (`SameMPVFrom N₀`) for injective tensors propagates to full `SameMPV`, removing the previous `sorry` in `sameMPV_of_sameMPVFrom_of_injective`.
> 
> The new proof adds a helper `wordSpan_eq_top_of_isInjective`, derives `wordSpan B N₀ = ⊤` via a `traceMulRightPi` composition identity and a kernel/range finrank transfer, proves the normalization `S = 1` by trace nondegeneracy, and then uses **downward induction on word length** to extend trace agreement from lengths `≥ N₀` to all words.
> 
> Updates the blueprint (Ch13) to document `SameMPVFrom` and the new finite-length implication theorem, and thereby makes `fundamentalTheorem_singleBlock_finiteLength` fully `sorry`-free by chaining the new result into the existing single-block FT.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b0bdccf384adc83d388e9c8b72e837cba268c5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->