### PR TITLE
feat(Channel/Semigroup): prove residual time zero point

### DIFF
--- a/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
@@ -292,8 +292,8 @@ theorem residualSlice_limit_zero_of_fixedPoint
     exact hsub_decay.congr' (Filter.Eventually.of_forall (fun k => hres_eq (φ k)))
   exact tendsto_nhds_unique hsub_res hsub_res_zero
 
-/-- **TODO**: Prove that a zero point exists in slice times.
-Currently a `sorry` placeholder. -/
+/-- A zero point exists among residual slice times: by compactness of `[0, s]` there is a
+convergent subsequence of residual times whose limit satisfies `T a δ = 0`. -/
 theorem exists_residual_time_eq_zero_of_fixedPoint
     [NeZero D]
     (T : ℝ → Mat →ₗ[ℂ] Mat)
@@ -304,7 +304,9 @@ theorem exists_residual_time_eq_zero_of_fixedPoint
     (hδ_decay : Filter.Tendsto (fun n : ℕ => T ((n : ℝ) * u) δ) Filter.atTop (nhds 0))
     (hδ_fix : T s δ = δ) :
     ∃ a ∈ Set.Icc 0 s, T a δ = 0 := by
-  sorry
+  obtain ⟨a, ha_mem, φ, hφtendsto⟩ := exists_residualSlice_subseq_tendsto u s hs
+  exact ⟨a, ha_mem, residualSlice_limit_zero_of_fixedPoint T hT u hs hδ_decay
+    (residualSlice_apply_eq_of_fixedPoint T hT u _hu_nonneg s hs hδ_fix) ha_mem φ hφtendsto⟩
 
 theorem eq_zero_of_expSemigroup_apply_eq_zero
     (L : Mat →ₗ[ℂ] Mat) {a : ℝ} {δ : Mat}

--- a/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
@@ -292,13 +292,13 @@ theorem residualSlice_limit_zero_of_fixedPoint
     exact hsub_decay.congr' (Filter.Eventually.of_forall (fun k => hres_eq (φ k)))
   exact tendsto_nhds_unique hsub_res hsub_res_zero
 
-/-- A zero point exists among residual slice times: by compactness of `[0, s]` there is a
-convergent subsequence of residual times whose limit satisfies `T a δ = 0`. -/
+/-- By compactness of `[0, s]`, the residual slice times admit a convergent subsequence
+whose limit `a` satisfies `T a δ = 0`. -/
 theorem exists_residual_time_eq_zero_of_fixedPoint
     [NeZero D]
     (T : ℝ → Mat →ₗ[ℂ] Mat)
     (hT : IsQuantumDynSemigroup T)
-    (u : ℝ) (_hu_nonneg : 0 ≤ u)
+    (u : ℝ) (hu_nonneg : 0 ≤ u)
     (s : ℝ) (hs : 0 < s)
     {δ : Mat}
     (hδ_decay : Filter.Tendsto (fun n : ℕ => T ((n : ℝ) * u) δ) Filter.atTop (nhds 0))
@@ -306,7 +306,7 @@ theorem exists_residual_time_eq_zero_of_fixedPoint
     ∃ a ∈ Set.Icc 0 s, T a δ = 0 := by
   obtain ⟨a, ha_mem, φ, hφtendsto⟩ := exists_residualSlice_subseq_tendsto u s hs
   exact ⟨a, ha_mem, residualSlice_limit_zero_of_fixedPoint T hT u hs hδ_decay
-    (residualSlice_apply_eq_of_fixedPoint T hT u _hu_nonneg s hs hδ_fix) ha_mem φ hφtendsto⟩
+    (residualSlice_apply_eq_of_fixedPoint T hT u hu_nonneg s hs hδ_fix) ha_mem φ hφtendsto⟩
 
 theorem eq_zero_of_expSemigroup_apply_eq_zero
     (L : Mat →ₗ[ℂ] Mat) {a : ℝ} {δ : Mat}


### PR DESCRIPTION
### Motivation

- Discharges sorry LionSR/TNLean#8 (`exists_residual_time_eq_zero_of_fixedPoint`) in the IrreducibleAnalysis formalization, continuing the Wolf Ch 7 semigroup structure work (see LionSR/QICLean#105).

### Description

- Modified `TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean`: replaced the `sorry` in `exists_residual_time_eq_zero_of_fixedPoint` with a constructive proof composing three existing lemmas — compactness gives a convergent subsequence of residual slice times (`exists_residualSlice_subseq_tendsto`), the fixed-point assumption relates iterated applications to residual slice time (`residualSlice_apply_eq_of_fixedPoint`), and limit uniqueness yields `T a δ = 0` (`residualSlice_limit_zero_of_fixedPoint`).
- Updated the theorem's docstring to describe the compactness-based argument.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/QICLean#105

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this change only replaces a `sorry` with a Lean proof and updates documentation, without altering executable logic or APIs.
> 
> **Overview**
> Removes the `sorry` placeholder in `exists_residual_time_eq_zero_of_fixedPoint` by providing a complete proof that extracts a convergent subsequence of residual slice times (compactness of `[0,s]`) and uses fixed-point/limit-uniqueness lemmas to conclude `∃ a ∈ [0,s], T a δ = 0`.
> 
> Also updates the theorem’s docstring and makes the nonnegativity assumption on `u` explicit in the proof composition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90c593df38ab33e80cd312020533f33e707ff9e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->