### PR TITLE
feat(MPS/ParentHamiltonian): add commuting parent Hamiltonians and decorrelation theorem

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -127,6 +127,8 @@ import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
+import TNLean.MPS.ParentHamiltonian.Commuting
+import TNLean.MPS.ParentHamiltonian.Decorrelation
 
 -- Layer 4: Fundamental theorem (single block)
 import TNLean.MPS.Structure.LinearExtension

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.Defs
+import TNLean.MPS.RFP.Defs
+
+/-!
+# Commuting parent Hamiltonians
+
+This file defines commuting parent Hamiltonians and nearest-neighbor commuting
+parent Hamiltonians (NNCPH), and states their connection to the renormalization
+fixed point (RFP) property.
+
+## Main definitions
+
+* `MPSTensor.IsCommutingParentHam A L N` — the local terms of the parent
+  Hamiltonian on `N` sites with block length `L` mutually commute.
+* `MPSTensor.IsNNCPH A N` — nearest-neighbor commuting parent Hamiltonian
+  (`L = 2`).
+
+## Main results
+
+* `MPSTensor.rfp_implies_nncph` — RFP ⟹ NNCPH (sorry, pending structural
+  form from #233)
+* `MPSTensor.nncph_implies_rfp` — NNCPH ⟹ RFP (sorry, gated on [Beigi])
+
+## References
+
+* arXiv:1606.00608, §3.3 Definition 3.9, Theorem 3.10
+* [Beigi–Shor–Whalen, CMP 2012] — ground-space characterization for
+  commuting nearest-neighbor Hamiltonians in 1D
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A parent Hamiltonian has **commuting** local terms when all translated
+interaction projectors commute with each other.
+
+See arXiv:1606.00608, Definition 3.9. -/
+def IsCommutingParentHam (A : MPSTensor d D) (L N : ℕ) : Prop :=
+  ∀ i j : Fin N,
+    localTerm A L N i * localTerm A L N j = localTerm A L N j * localTerm A L N i
+
+/-- **Nearest-neighbor commuting parent Hamiltonian** (NNCPH): a commuting
+parent Hamiltonian with block length `L = 2`.
+
+See arXiv:1606.00608, Definition 3.9. -/
+def IsNNCPH (A : MPSTensor d D) (N : ℕ) : Prop :=
+  IsCommutingParentHam A 2 N
+
+/-- NNCPH is a special case of commuting parent Hamiltonian. -/
+theorem IsNNCPH.isCommutingParentHam {A : MPSTensor d D} {N : ℕ} (h : IsNNCPH A N) :
+    IsCommutingParentHam A 2 N :=
+  h
+
+/-- The commuting condition is trivially true for any single local term. -/
+theorem isCommutingParentHam_self (A : MPSTensor d D) (L N : ℕ) (i : Fin N) :
+    localTerm A L N i * localTerm A L N i = localTerm A L N i * localTerm A L N i :=
+  rfl
+
+/-- The commuting condition is symmetric: if `h i j` holds, then `h j i` holds. -/
+theorem IsCommutingParentHam.symm {A : MPSTensor d D} {L N : ℕ}
+    (h : IsCommutingParentHam A L N) (i j : Fin N) :
+    localTerm A L N j * localTerm A L N i = localTerm A L N i * localTerm A L N j :=
+  (h i j).symm
+
+/-- If the parent Hamiltonian commutes, then the Hamiltonian commutes with each
+local term. -/
+theorem IsCommutingParentHam.ham_comm_localTerm {A : MPSTensor d D} {L N : ℕ}
+    (h : IsCommutingParentHam A L N) (i : Fin N) :
+    parentHamiltonian A L N * localTerm A L N i =
+      localTerm A L N i * parentHamiltonian A L N := by
+  simp only [parentHamiltonian, Finset.sum_mul, Finset.mul_sum, localTerm]
+
+/-- **RFP ⟹ NNCPH** (Theorem 3.10 (i) ⟹ (iii)):
+If a tensor is an RFP, then its parent Hamiltonian with `L = 2` has
+commuting local terms.
+
+The proof follows from the structural form of RFP tensors (Theorem 3.11,
+issue #233): RFP tensors generate product-of-entangled-pair states whose
+parent Hamiltonians obviously commute.
+
+TODO: complete once the structural form theorem is available from #233. -/
+theorem rfp_implies_nncph {A : MPSTensor d D} (N : ℕ)
+    (hRFP : IsRFP A) : IsNNCPH A N := by
+  sorry
+
+/-- **NNCPH ⟹ RFP** (Theorem 3.10 (iii) ⟹ (i)):
+If a tensor has a nearest-neighbor commuting parent Hamiltonian, then it
+is a renormalization fixed point.
+
+This uses the result of Beigi–Shor–Whalen (CMP 2012) that ground spaces
+of commuting nearest-neighbor Hamiltonians in 1D with finite degeneracy
+are spanned by states that are locally orthogonal — hence RFP by the
+structural form characterization (Theorem 3.11).
+
+TODO: complete once [Beigi] is formalized. -/
+theorem nncph_implies_rfp {A : MPSTensor d D} {N : ℕ}
+    (hNN : IsNNCPH A N) : IsRFP A := by
+  sorry
+
+/-- **RFP ⟺ NNCPH** (Theorem 3.10 (i) ⟺ (iii)):
+A tensor is an RFP if and only if its parent Hamiltonian with `L = 2`
+has commuting local terms. -/
+theorem rfp_iff_nncph (A : MPSTensor d D) (N : ℕ) :
+    IsRFP A ↔ IsNNCPH A N :=
+  ⟨rfp_implies_nncph N, fun h => nncph_implies_rfp h⟩
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -31,8 +31,6 @@ fixed point (RFP) property.
   commuting nearest-neighbor Hamiltonians in 1D
 -/
 
-open scoped BigOperators
-
 namespace MPSTensor
 
 variable {d D : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -21,8 +21,8 @@ fixed point (RFP) property.
 
 ## Main results
 
-* `MPSTensor.isNNCPH_of_isRFP` — RFP ⟹ NNCPH (vacuously true while
-  `localTerm` is the zero placeholder)
+* `MPSTensor.isNNCPH_of_isRFP` — RFP ⟹ NNCPH (currently vacuously true
+  because `parentInteraction` simplifies to zero; see advisory below)
 
 ## References
 
@@ -63,14 +63,15 @@ theorem IsCommutingParentHam.symm {A : MPSTensor d D} {L N : ℕ}
     localTerm A L N j * localTerm A L N i = localTerm A L N i * localTerm A L N j :=
   (h i j).symm
 
-/-- **PLACEHOLDER — VACUOUSLY TRUE**: If the parent Hamiltonian commutes, then
-the Hamiltonian commutes with each local term.
+/-- If the parent Hamiltonian commutes, then the Hamiltonian commutes with
+each local term.
 
-This lemma compiles without `sorry` but is currently **vacuously true** because
-`localTerm` is a zero placeholder (see `Defs.lean`). The proof does not use
-the commutativity hypothesis `h` and must be completely rewritten once
-`localTerm` is implemented with its real definition. Do **not** cite this as
-a proven result. -/
+**Advisory**: this lemma is currently **vacuously true** because
+`parentInteraction A L` simplifies to zero under `simp` (a pre-existing bug
+in how `starProjection` interacts with `WithLp.linearEquiv`), making
+`localTerm = 0`. The proof does not use the commutativity hypothesis `_h`
+and must be rewritten once `parentInteraction` is fixed. Do **not** cite
+this as a proven result. -/
 theorem IsCommutingParentHam.ham_comm_localTerm {A : MPSTensor d D} {L N : ℕ}
     (_h : IsCommutingParentHam A L N) (i : Fin N) :
     parentHamiltonian A L N * localTerm A L N i =
@@ -81,16 +82,14 @@ theorem IsCommutingParentHam.ham_comm_localTerm {A : MPSTensor d D} {L N : ℕ}
   --   congr 1; ext j; exact _h j i
   simp only [parentHamiltonian, Finset.sum_mul, Finset.mul_sum, localTerm]
 
-/-- **PLACEHOLDER — VACUOUSLY TRUE**: **RFP ⟹ NNCPH** (Theorem 3.10
-(i) ⟹ (iii)): If a tensor is an RFP, then its parent Hamiltonian with
-`L = 2` has commuting local terms.
+/-- **RFP ⟹ NNCPH** (Theorem 3.10 (i) ⟹ (iii)): If a tensor is an RFP,
+then its parent Hamiltonian with `L = 2` has commuting local terms.
 
-This lemma compiles without `sorry` but is currently **vacuously true** because
-`localTerm` is a zero placeholder (see `Defs.lean`). With `localTerm := 0`,
-the commuting condition reduces to `0 * 0 = 0 * 0`, which holds trivially.
-
-Once `localTerm` is implemented with its true definition, this lemma must
-be rewritten to use the structural form of RFP tensors (Theorem 3.11,
+**Advisory**: this lemma is currently **vacuously true** because
+`parentInteraction A L` simplifies to zero under `simp` (a pre-existing bug),
+so `localTerm = 0` and the commuting condition reduces to `0 * 0 = 0 * 0`.
+The `_hRFP` hypothesis is unused. Once `parentInteraction` is fixed, this
+must be rewritten to use the structural form of RFP tensors (Theorem 3.11,
 issue #233). Do **not** cite this as a proven result. -/
 theorem isNNCPH_of_isRFP {A : MPSTensor d D} (N : ℕ)
     (_hRFP : IsRFP A) : IsNNCPH A N := by

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -21,7 +21,7 @@ fixed point (RFP) property.
 
 ## Main results
 
-* `MPSTensor.rfp_implies_nncph` — RFP ⟹ NNCPH (vacuously true while
+* `MPSTensor.isNNCPH_of_isRFP` — RFP ⟹ NNCPH (vacuously true while
   `localTerm` is the zero placeholder)
 
 ## References
@@ -31,7 +31,7 @@ fixed point (RFP) property.
   commuting nearest-neighbor Hamiltonians in 1D
 -/
 
-open scoped Matrix BigOperators
+open scoped BigOperators
 
 namespace MPSTensor
 
@@ -92,7 +92,7 @@ the commuting condition reduces to `0 * 0 = 0 * 0`, which holds trivially.
 Once `localTerm` is implemented with its true definition, this lemma must
 be rewritten to use the structural form of RFP tensors (Theorem 3.11,
 issue #233). Do **not** cite this as a proven result. -/
-theorem rfp_implies_nncph {A : MPSTensor d D} (N : ℕ)
+theorem isNNCPH_of_isRFP {A : MPSTensor d D} (N : ℕ)
     (_hRFP : IsRFP A) : IsNNCPH A N := by
   intro i j
   simp [localTerm]

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -21,9 +21,8 @@ fixed point (RFP) property.
 
 ## Main results
 
-* `MPSTensor.rfp_implies_nncph` — RFP ⟹ NNCPH (sorry, pending structural
-  form from #233)
-* `MPSTensor.nncph_implies_rfp` — NNCPH ⟹ RFP (sorry, gated on [Beigi])
+* `MPSTensor.rfp_implies_nncph` — RFP ⟹ NNCPH (vacuously true while
+  `localTerm` is the zero placeholder)
 
 ## References
 
@@ -58,57 +57,44 @@ theorem IsNNCPH.isCommutingParentHam {A : MPSTensor d D} {N : ℕ} (h : IsNNCPH 
     IsCommutingParentHam A 2 N :=
   h
 
-/-- The commuting condition is trivially true for any single local term. -/
-theorem isCommutingParentHam_self (A : MPSTensor d D) (L N : ℕ) (i : Fin N) :
-    localTerm A L N i * localTerm A L N i = localTerm A L N i * localTerm A L N i :=
-  rfl
-
 /-- The commuting condition is symmetric: if `h i j` holds, then `h j i` holds. -/
 theorem IsCommutingParentHam.symm {A : MPSTensor d D} {L N : ℕ}
     (h : IsCommutingParentHam A L N) (i j : Fin N) :
     localTerm A L N j * localTerm A L N i = localTerm A L N i * localTerm A L N j :=
   (h i j).symm
 
-/-- If the parent Hamiltonian commutes, then the Hamiltonian commutes with each
-local term. -/
+/-- **PLACEHOLDER — VACUOUSLY TRUE**: If the parent Hamiltonian commutes, then
+the Hamiltonian commutes with each local term.
+
+This lemma compiles without `sorry` but is currently **vacuously true** because
+`localTerm` is a zero placeholder (see `Defs.lean`). The proof does not use
+the commutativity hypothesis `h` and must be completely rewritten once
+`localTerm` is implemented with its real definition. Do **not** cite this as
+a proven result. -/
 theorem IsCommutingParentHam.ham_comm_localTerm {A : MPSTensor d D} {L N : ℕ}
-    (h : IsCommutingParentHam A L N) (i : Fin N) :
+    (_h : IsCommutingParentHam A L N) (i : Fin N) :
     parentHamiltonian A L N * localTerm A L N i =
       localTerm A L N i * parentHamiltonian A L N := by
+  -- TODO(parent-hamiltonian): proof is vacuous while localTerm = 0; must use
+  -- `_h` once real definition lands. Intended proof structure:
+  --   simp [parentHamiltonian, Finset.sum_mul, Finset.mul_sum]
+  --   congr 1; ext j; exact _h j i
   simp only [parentHamiltonian, Finset.sum_mul, Finset.mul_sum, localTerm]
 
-/-- **RFP ⟹ NNCPH** (Theorem 3.10 (i) ⟹ (iii)):
-If a tensor is an RFP, then its parent Hamiltonian with `L = 2` has
-commuting local terms.
+/-- **PLACEHOLDER — VACUOUSLY TRUE**: **RFP ⟹ NNCPH** (Theorem 3.10
+(i) ⟹ (iii)): If a tensor is an RFP, then its parent Hamiltonian with
+`L = 2` has commuting local terms.
 
-The proof follows from the structural form of RFP tensors (Theorem 3.11,
-issue #233): RFP tensors generate product-of-entangled-pair states whose
-parent Hamiltonians obviously commute.
+This lemma compiles without `sorry` but is currently **vacuously true** because
+`localTerm` is a zero placeholder (see `Defs.lean`). With `localTerm := 0`,
+the commuting condition reduces to `0 * 0 = 0 * 0`, which holds trivially.
 
-TODO: complete once the structural form theorem is available from #233. -/
+Once `localTerm` is implemented with its true definition, this lemma must
+be rewritten to use the structural form of RFP tensors (Theorem 3.11,
+issue #233). Do **not** cite this as a proven result. -/
 theorem rfp_implies_nncph {A : MPSTensor d D} (N : ℕ)
-    (hRFP : IsRFP A) : IsNNCPH A N := by
-  sorry
-
-/-- **NNCPH ⟹ RFP** (Theorem 3.10 (iii) ⟹ (i)):
-If a tensor has a nearest-neighbor commuting parent Hamiltonian, then it
-is a renormalization fixed point.
-
-This uses the result of Beigi–Shor–Whalen (CMP 2012) that ground spaces
-of commuting nearest-neighbor Hamiltonians in 1D with finite degeneracy
-are spanned by states that are locally orthogonal — hence RFP by the
-structural form characterization (Theorem 3.11).
-
-TODO: complete once [Beigi] is formalized. -/
-theorem nncph_implies_rfp {A : MPSTensor d D} {N : ℕ}
-    (hNN : IsNNCPH A N) : IsRFP A := by
-  sorry
-
-/-- **RFP ⟺ NNCPH** (Theorem 3.10 (i) ⟺ (iii)):
-A tensor is an RFP if and only if its parent Hamiltonian with `L = 2`
-has commuting local terms. -/
-theorem rfp_iff_nncph (A : MPSTensor d D) (N : ℕ) :
-    IsRFP A ↔ IsNNCPH A N :=
-  ⟨rfp_implies_nncph N, fun h => nncph_implies_rfp h⟩
+    (_hRFP : IsRFP A) : IsNNCPH A N := by
+  intro i j
+  simp [localTerm]
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -39,52 +39,14 @@ and is deferred.
 -/
 
 /-!
-### Auxiliary lemmas for commuting projectors
+### Auxiliary lemma for commuting projectors
 
-These lemmas are used in the proof of Proposition D.3 and may be
-useful elsewhere.
+The key cancellation lemma used in the proof of Proposition D.3.
 -/
 
 section CommutingProjectors
 
 variable {E : Type*} [AddCommGroup E] [Module ℂ E]
-
-/-- If two idempotent linear maps commute, their composition is idempotent. -/
-theorem comp_idempotent_of_comm_of_idempotent
-    {P Q : E →ₗ[ℂ] E}
-    (hP : P ∘ₗ P = P)
-    (hQ : Q ∘ₗ Q = Q)
-    (hcomm : P ∘ₗ Q = Q ∘ₗ P) :
-    (P ∘ₗ Q) ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q := by
-  -- Pointwise: P(Q(P(Qx))) = P(Qx)
-  ext x; simp only [LinearMap.comp_apply]
-  -- Use hcomm pointwise: P(Qy) = Q(Py)
-  have hPQ : ∀ y, P (Q y) = Q (P y) := LinearMap.ext_iff.mp hcomm
-  -- Use hQ pointwise: Q(Qy) = Qy
-  have hQQ : ∀ y, Q (Q y) = Q y := LinearMap.ext_iff.mp hQ
-  -- Use hP pointwise: P(Py) = Py
-  have hPP : ∀ y, P (P y) = P y := LinearMap.ext_iff.mp hP
-  -- P(Q(P(Qx)))
-  --   = Q(P(P(Qx)))    by hPQ
-  --   = Q(P(Qx))        by hPP
-  --   = P(Q(Qx))        by hPQ⁻¹
-  --   = P(Qx)            by hQQ
-  rw [hPQ, hPP, ← hPQ, hQQ]
-
-/-- If `P` is idempotent, then `P ∘ (P ∘ Q) = P ∘ Q`. -/
-theorem left_absorb_of_comm_idempotent
-    {P Q : E →ₗ[ℂ] E}
-    (hP : P ∘ₗ P = P) :
-    P ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q := by
-  rw [← LinearMap.comp_assoc, hP]
-
-/-- If `Q` is idempotent and `P ∘ Q = Q ∘ P`, then `Q ∘ (P ∘ Q) = P ∘ Q`. -/
-theorem right_absorb_of_comm_idempotent
-    {P Q : E →ₗ[ℂ] E}
-    (hQ : Q ∘ₗ Q = Q)
-    (hcomm : P ∘ₗ Q = Q ∘ₗ P) :
-    Q ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q := by
-  rw [← LinearMap.comp_assoc, ← hcomm, LinearMap.comp_assoc, hQ]
 
 /-- For commuting idempotents, `Q ∘ (1 - P ∘ Q) ∘ P = 0`. This is the
 key cancellation used in the "only if" direction of Prop D.3:
@@ -179,22 +141,6 @@ def HasCommutingParentHam (P_K : E →ₗ[ℂ] E) : Prop :=
     -- P_K projects onto the intersection: P_AX ∘ P_XB = P_K
     P_AX ∘ₗ P_XB = P_K
 
-/-- If `P_AX` is idempotent and `P_AX ∘ P_XB = P_K`, then `P_AX ∘ P_K = P_K`
-(the left witness absorbs `P_K`). -/
-theorem left_absorb_of_idem_intersection {P_K P_AX P_XB : E →ₗ[ℂ] E}
-    (hAX : P_AX ∘ₗ P_AX = P_AX) (hK : P_AX ∘ₗ P_XB = P_K) :
-    P_AX ∘ₗ P_K = P_K := by
-  rw [← hK, ← LinearMap.comp_assoc, hAX]
-
-/-- If `P_XB` is idempotent, `P_AX ∘ P_XB = P_XB ∘ P_AX`, and
-`P_AX ∘ P_XB = P_K`, then `P_XB ∘ P_K = P_K` (the right witness
-absorbs `P_K`). -/
-theorem right_absorb_of_idem_intersection {P_K P_AX P_XB : E →ₗ[ℂ] E}
-    (hXB : P_XB ∘ₗ P_XB = P_XB) (hcomm : P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX)
-    (hK : P_AX ∘ₗ P_XB = P_K) :
-    P_XB ∘ₗ P_K = P_K := by
-  rw [← hK, ← LinearMap.comp_assoc, ← hcomm, LinearMap.comp_assoc, hXB]
-
 /-- **Proposition D.3, backward direction** (arXiv:1606.00608, Appendix D, §D.2):
 If a subspace K has a commuting parent Hamiltonian decomposition
 `P_K = P_AX ∘ P_XB` with `[P_AX, P_XB] = 0`, and observables on region A
@@ -262,5 +208,6 @@ theorem commutingHam_isDecorrelated
   -- Goal: P_AX (O_A (P_XB (P_AX (O_B (P_XB x)) - P_AX (P_XB (P_AX (O_B (P_XB x))))))) = 0
   -- Step 3: Apply key cancellation (P_XB kills the middle)
   rw [key_pw, map_zero, map_zero]
+
 
 end AbstractDecorrelation

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -19,16 +19,16 @@ and is deferred.
 
 ## Main definitions
 
-* `IsDecorrelated` — regions A and B are decorrelated w.r.t. a subspace K
-  when `P_K O_A (1 - P_K) O_B P_K = 0` for all observables O_A, O_B on
-  the respective regions.
-* `HasCommutingParentHam` — a subspace K equals the intersection of two
-  local kernels `K_AX ⊗ H_B ∩ H_A ⊗ K_XB` where the corresponding
+* `Decorrelation.IsDecorrelated` — regions A and B are decorrelated w.r.t. a
+  subspace K when `P_K O_A (1 - P_K) O_B P_K = 0` for all observables
+  O_A, O_B on the respective regions.
+* `Decorrelation.HasCommutingParentHam` — a subspace K equals the intersection
+  of two local kernels `K_AX ⊗ H_B ∩ H_A ⊗ K_XB` where the corresponding
   projectors commute.
 
 ## Main results
 
-* `commutingHam_isDecorrelated` — commuting parent Hamiltonian →
+* `Decorrelation.commutingHam_isDecorrelated` — commuting parent Hamiltonian →
   decorrelation (Proposition D.3, backward direction)
 
 ## References
@@ -47,6 +47,8 @@ The key cancellation lemma used in the proof of Proposition D.3.
 section CommutingProjectors
 
 variable {E : Type*} [AddCommGroup E] [Module ℂ E]
+
+namespace LinearMap
 
 /-- For commuting idempotents, `Q ∘ (1 - P ∘ Q) ∘ P = 0`. This is the
 key cancellation used in the "only if" direction of Prop D.3:
@@ -78,6 +80,8 @@ theorem comp_complement_comm_zero
   --   rewrite P(Px) using hPP
   rw [hPP]
 
+end LinearMap
+
 end CommutingProjectors
 
 /-!
@@ -95,6 +99,8 @@ finite-dimensional inner product space.
 section AbstractDecorrelation
 
 variable {E : Type*} [AddCommGroup E] [Module ℂ E]
+
+namespace Decorrelation
 
 /-- **Decorrelation**: given an idempotent endomorphism `P_K` (projecting onto a
 subspace K) and families of operators `O_A` and `O_B` representing observables
@@ -130,16 +136,19 @@ See arXiv:1606.00608, Appendix D, §D.2, Definition D.2.
 TODO(tensor-product): add locality constraints requiring `P_AX` to act on
 `H_A ⊗ H_X` and `P_XB` to act on `H_X ⊗ H_B`. Without these, the predicate
 is trivially satisfiable by `P_AX = P_XB = P_K`. -/
-def HasCommutingParentHam (P_K : E →ₗ[ℂ] E) : Prop :=
-  ∃ P_AX P_XB : E →ₗ[ℂ] E,
-    -- P_AX, P_XB are idempotent (projectors)
-    P_AX ∘ₗ P_AX = P_AX ∧
-    P_XB ∘ₗ P_XB = P_XB ∧
-    -- The complementary projectors commute: [1 - P_AX, 1 - P_XB] = 0,
-    -- equivalently [P_AX, P_XB] = 0
-    P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX ∧
-    -- P_K projects onto the intersection: P_AX ∘ P_XB = P_K
-    P_AX ∘ₗ P_XB = P_K
+structure HasCommutingParentHam (P_K : E →ₗ[ℂ] E) where
+  /-- Projector onto the AX region. -/
+  P_AX : E →ₗ[ℂ] E
+  /-- Projector onto the XB region. -/
+  P_XB : E →ₗ[ℂ] E
+  /-- `P_AX` is idempotent. -/
+  hAX_idem : P_AX ∘ₗ P_AX = P_AX
+  /-- `P_XB` is idempotent. -/
+  hXB_idem : P_XB ∘ₗ P_XB = P_XB
+  /-- The projectors commute: `[P_AX, P_XB] = 0`. -/
+  hcomm : P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX
+  /-- `P_K` is the intersection projector: `P_AX ∘ P_XB = P_K`. -/
+  hK : P_AX ∘ₗ P_XB = P_K
 
 /-- **Proposition D.3, backward direction** (arXiv:1606.00608, Appendix D, §D.2):
 If a subspace K has a commuting parent Hamiltonian decomposition
@@ -154,8 +163,8 @@ A-observables commute with the XB-projector and vice versa.
 ## Proof outline
 
 The key identity is `P_XB ∘ (1 - P_AX ∘ P_XB) ∘ P_AX = 0` (see
-`comp_complement_comm_zero`). Using the commutation hypotheses to slide
-`O_A` past `P_XB` and `O_B` past `P_AX`, the five-fold composition
+`LinearMap.comp_complement_comm_zero`). Using the commutation hypotheses to
+slide `O_A` past `P_XB` and `O_B` past `P_AX`, the five-fold composition
 `P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K` factors as
 `P_AX ∘ O_A ∘ [P_XB ∘ (1 - P_AX ∘ P_XB) ∘ P_AX] ∘ O_B ∘ P_XB = 0`.
 
@@ -182,7 +191,7 @@ theorem commutingHam_isDecorrelated
   -- Substitute P_K = P_AX ∘ P_XB
   rw [← hK]
   -- Key cancellation: P_XB ∘ (id - P_AX ∘ P_XB) ∘ P_AX = 0
-  have key := comp_complement_comm_zero hAX_idem hXB_idem hcomm
+  have key := LinearMap.comp_complement_comm_zero hAX_idem hXB_idem hcomm
   -- Extract pointwise commutativity
   have hA : ∀ y, O_A (P_XB y) = P_XB (O_A y) :=
     LinearMap.ext_iff.mp (hA_comm O_A hOA)
@@ -209,27 +218,22 @@ theorem commutingHam_isDecorrelated
   -- Step 3: Apply key cancellation (P_XB kills the middle)
   rw [key_pw, map_zero, map_zero]
 
-
 /-- Convenience wrapper that consumes `HasCommutingParentHam` directly.
 
-The witnessing projectors `P_AX`, `P_XB` are extracted from the existential
-via `Exists.choose`; the locality hypotheses are stated in terms of these
-chosen witnesses. See `commutingHam_isDecorrelated` for the version with
-explicit witnesses. -/
+The witnessing projectors `P_AX`, `P_XB` are extracted from the structure
+fields. See `commutingHam_isDecorrelated` for the version with explicit
+witnesses. -/
 theorem HasCommutingParentHam.isDecorrelated
     {P_K : E →ₗ[ℂ] E}
     (hCPH : HasCommutingParentHam P_K)
     (ObsA ObsB : Set (E →ₗ[ℂ] E))
-    (hA_comm : ∀ O_A ∈ ObsA,
-      O_A ∘ₗ hCPH.choose_spec.choose = hCPH.choose_spec.choose ∘ₗ O_A)
-    (hB_comm : ∀ O_B ∈ ObsB,
-      O_B ∘ₗ hCPH.choose = hCPH.choose ∘ₗ O_B) :
-    IsDecorrelated P_K ObsA ObsB := by
-  exact commutingHam_isDecorrelated P_K hCPH.choose hCPH.choose_spec.choose
-    hCPH.choose_spec.choose_spec.1
-    hCPH.choose_spec.choose_spec.2.1
-    hCPH.choose_spec.choose_spec.2.2.1
-    hCPH.choose_spec.choose_spec.2.2.2
+    (hA_comm : ∀ O_A ∈ ObsA, O_A ∘ₗ hCPH.P_XB = hCPH.P_XB ∘ₗ O_A)
+    (hB_comm : ∀ O_B ∈ ObsB, O_B ∘ₗ hCPH.P_AX = hCPH.P_AX ∘ₗ O_B) :
+    IsDecorrelated P_K ObsA ObsB :=
+  commutingHam_isDecorrelated P_K hCPH.P_AX hCPH.P_XB
+    hCPH.hAX_idem hCPH.hXB_idem hCPH.hcomm hCPH.hK
     ObsA ObsB hA_comm hB_comm
+
+end Decorrelation
 
 end AbstractDecorrelation

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -49,7 +49,7 @@ useful elsewhere.
 
 section CommutingProjectors
 
-variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+variable {E : Type*} [AddCommGroup E] [Module ℂ E]
 
 /-- If two idempotent linear maps commute, their composition is idempotent. -/
 theorem comp_idempotent_of_comm_of_idempotent
@@ -77,9 +77,7 @@ theorem comp_idempotent_of_comm_of_idempotent
 `P ∘ R = R`. -/
 theorem left_absorb_of_comm_idempotent
     {P Q : E →ₗ[ℂ] E}
-    (hP : P ∘ₗ P = P)
-    (_hQ : Q ∘ₗ Q = Q)
-    (_hcomm : P ∘ₗ Q = Q ∘ₗ P) :
+    (hP : P ∘ₗ P = P) :
     P ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q := by
   rw [← LinearMap.comp_assoc, hP]
 
@@ -87,7 +85,6 @@ theorem left_absorb_of_comm_idempotent
 `Q ∘ R = R`. -/
 theorem right_absorb_of_comm_idempotent
     {P Q : E →ₗ[ℂ] E}
-    (_hP : P ∘ₗ P = P)
     (hQ : Q ∘ₗ Q = Q)
     (hcomm : P ∘ₗ Q = Q ∘ₗ P) :
     Q ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q := by

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -210,4 +210,26 @@ theorem commutingHam_isDecorrelated
   rw [key_pw, map_zero, map_zero]
 
 
+/-- Convenience wrapper that consumes `HasCommutingParentHam` directly.
+
+The witnessing projectors `P_AX`, `P_XB` are extracted from the existential
+via `Exists.choose`; the locality hypotheses are stated in terms of these
+chosen witnesses. See `commutingHam_isDecorrelated` for the version with
+explicit witnesses. -/
+theorem HasCommutingParentHam.isDecorrelated
+    {P_K : E →ₗ[ℂ] E}
+    (hCPH : HasCommutingParentHam P_K)
+    (ObsA ObsB : Set (E →ₗ[ℂ] E))
+    (hA_comm : ∀ O_A ∈ ObsA,
+      O_A ∘ₗ hCPH.choose_spec.choose = hCPH.choose_spec.choose ∘ₗ O_A)
+    (hB_comm : ∀ O_B ∈ ObsB,
+      O_B ∘ₗ hCPH.choose = hCPH.choose ∘ₗ O_B) :
+    IsDecorrelated P_K ObsA ObsB := by
+  exact commutingHam_isDecorrelated P_K hCPH.choose hCPH.choose_spec.choose
+    hCPH.choose_spec.choose_spec.1
+    hCPH.choose_spec.choose_spec.2.1
+    hCPH.choose_spec.choose_spec.2.2.1
+    hCPH.choose_spec.choose_spec.2.2.2
+    ObsA ObsB hA_comm hB_comm
+
 end AbstractDecorrelation

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -2,7 +2,8 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+import Mathlib.Data.Complex.Basic
+import Mathlib.LinearAlgebra.Projection
 
 /-!
 # Decorrelation and commuting parent Hamiltonians
@@ -12,8 +13,8 @@ respect to two disjoint regions, and proves the backward direction of the
 decorrelation–commuting-parent-Hamiltonian equivalence: a commuting parent
 Hamiltonian implies decorrelation when observables respect locality.
 
-This is the backward direction of Proposition D.1 from arXiv:1606.00608,
-Appendix D.2. The forward direction requires tensor-product infrastructure
+This is the backward direction of Proposition D.3 from arXiv:1606.00608,
+Appendix D, §D.2. The forward direction requires tensor-product infrastructure
 and is deferred.
 
 ## Main definitions
@@ -28,19 +29,19 @@ and is deferred.
 ## Main results
 
 * `commutingHam_isDecorrelated` — commuting parent Hamiltonian →
-  decorrelation (Proposition D.1, backward direction)
+  decorrelation (Proposition D.3, backward direction)
 
 ## References
 
-* arXiv:1606.00608, Appendix D.2 (lines 2181–2290)
+* arXiv:1606.00608, Appendix D, §D.2 (lines 2181–2290). The definitions
+  are numbered D.1 (decorrelated) and D.2 (parent commuting Hamiltonian);
+  the equivalence proposition is D.3.
 -/
-
-open scoped BigOperators
 
 /-!
 ### Auxiliary lemmas for commuting projectors
 
-These lemmas are used in the proof of Proposition D.1 and may be
+These lemmas are used in the proof of Proposition D.3 and may be
 useful elsewhere.
 -/
 
@@ -86,7 +87,7 @@ theorem right_absorb_of_comm_idempotent
   rw [← LinearMap.comp_assoc, ← hcomm, LinearMap.comp_assoc, hQ]
 
 /-- For commuting idempotents, `Q ∘ (1 - P ∘ Q) ∘ P = 0`. This is the
-key cancellation used in the "only if" direction of Prop D.1:
+key cancellation used in the "only if" direction of Prop D.3:
 `P_XB ∘ P_K^⊥ ∘ P_AX = 0`. -/
 theorem comp_complement_comm_zero
     {P Q : E →ₗ[ℂ] E}
@@ -131,14 +132,14 @@ finite-dimensional inner product space.
 
 section AbstractDecorrelation
 
-variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E] [FiniteDimensional ℂ E]
+variable {E : Type*} [AddCommGroup E] [Module ℂ E]
 
 /-- **Decorrelation**: given an idempotent endomorphism `P_K` (projecting onto a
 subspace K) and families of operators `O_A` and `O_B` representing observables
 on regions A and B, regions A and B are **decorrelated** w.r.t. K when
 `P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K = 0` for all observables `O_A`, `O_B`.
 
-See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1. -/
+See arXiv:1606.00608, Appendix D, §D.2, Definition D.1. -/
 def IsDecorrelated (P_K : E →ₗ[ℂ] E)
     (ObsA ObsB : Set (E →ₗ[ℂ] E)) : Prop :=
   ∀ O_A ∈ ObsA, ∀ O_B ∈ ObsB,
@@ -162,7 +163,7 @@ satisfies this predicate for any idempotent `P_K`; non-trivial content
 arises only when combined with locality constraints (see
 `commutingHam_isDecorrelated`).
 
-See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1.
+See arXiv:1606.00608, Appendix D, §D.2, Definition D.2.
 
 TODO(tensor-product): add locality constraints requiring `P_AX` to act on
 `H_A ⊗ H_X` and `P_XB` to act on `H_X ⊗ H_B`. Without these, the predicate
@@ -178,27 +179,23 @@ def HasCommutingParentHam (P_K : E →ₗ[ℂ] E) : Prop :=
     -- P_K projects onto the intersection: P_AX ∘ P_XB = P_K
     P_AX ∘ₗ P_XB = P_K
 
-omit [FiniteDimensional ℂ E] in
-/-- If `P_K` has a commuting parent Hamiltonian with witnesses `P_AX`, `P_XB`,
-then `P_AX ∘ P_K = P_K` (the left witness absorbs `P_K`). -/
-theorem HasCommutingParentHam.left_absorb {P_K : E →ₗ[ℂ] E}
-    (h : HasCommutingParentHam P_K) :
-    ∃ P_AX P_XB : E →ₗ[ℂ] E, P_AX ∘ₗ P_XB = P_K ∧ P_AX ∘ₗ P_K = P_K := by
-  obtain ⟨P_AX, P_XB, hAX, _, _, hK⟩ := h
-  exact ⟨P_AX, P_XB, hK, by rw [← hK, ← LinearMap.comp_assoc, hAX]⟩
+/-- If `P_AX` is idempotent and `P_AX ∘ P_XB = P_K`, then `P_AX ∘ P_K = P_K`
+(the left witness absorbs `P_K`). -/
+theorem left_absorb_of_idem_intersection {P_K P_AX P_XB : E →ₗ[ℂ] E}
+    (hAX : P_AX ∘ₗ P_AX = P_AX) (hK : P_AX ∘ₗ P_XB = P_K) :
+    P_AX ∘ₗ P_K = P_K := by
+  rw [← hK, ← LinearMap.comp_assoc, hAX]
 
-omit [FiniteDimensional ℂ E] in
-/-- If `P_K` has a commuting parent Hamiltonian with witnesses `P_AX`, `P_XB`,
-then `P_XB ∘ P_K = P_K` (the right witness absorbs `P_K`). -/
-theorem HasCommutingParentHam.right_absorb {P_K : E →ₗ[ℂ] E}
-    (h : HasCommutingParentHam P_K) :
-    ∃ P_AX P_XB : E →ₗ[ℂ] E, P_AX ∘ₗ P_XB = P_K ∧ P_XB ∘ₗ P_K = P_K := by
-  obtain ⟨P_AX, P_XB, _, hXB, hcomm, hK⟩ := h
-  exact ⟨P_AX, P_XB, hK, by rw [← hK, ← LinearMap.comp_assoc, ← hcomm,
-    LinearMap.comp_assoc, hXB]⟩
+/-- If `P_XB` is idempotent, `P_AX ∘ P_XB = P_XB ∘ P_AX`, and
+`P_AX ∘ P_XB = P_K`, then `P_XB ∘ P_K = P_K` (the right witness
+absorbs `P_K`). -/
+theorem right_absorb_of_idem_intersection {P_K P_AX P_XB : E →ₗ[ℂ] E}
+    (hXB : P_XB ∘ₗ P_XB = P_XB) (hcomm : P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX)
+    (hK : P_AX ∘ₗ P_XB = P_K) :
+    P_XB ∘ₗ P_K = P_K := by
+  rw [← hK, ← LinearMap.comp_assoc, ← hcomm, LinearMap.comp_assoc, hXB]
 
-omit [FiniteDimensional ℂ E] in
-/-- **Proposition D.1, backward direction** (arXiv:1606.00608, Appendix D.2):
+/-- **Proposition D.3, backward direction** (arXiv:1606.00608, Appendix D, §D.2):
 If a subspace K has a commuting parent Hamiltonian decomposition
 `P_K = P_AX ∘ P_XB` with `[P_AX, P_XB] = 0`, and observables on region A
 commute with `P_XB` while observables on region B commute with `P_AX`, then
@@ -224,7 +221,7 @@ In this abstract (non-tensor-product) setting, `HasCommutingParentHam` is
 trivially satisfiable by `P_AX = P_XB = P_K`, so an abstract iff would be
 vacuous. The forward direction is deferred to the tensor-product setting.
 
-See arXiv:1606.00608, Appendix D.2, Proposition D.1. -/
+See arXiv:1606.00608, Appendix D, §D.2, Proposition D.3. -/
 theorem commutingHam_isDecorrelated
     (P_K P_AX P_XB : E →ₗ[ℂ] E)
     (hAX_idem : P_AX ∘ₗ P_AX = P_AX)

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -11,11 +11,13 @@ import Mathlib.LinearAlgebra.Projection
 # Decorrelation and commuting parent Hamiltonians
 
 This file defines the notion of **decorrelation** for a subspace with
-respect to two disjoint regions, and proves the dimension-independent
-equivalence: a subspace corresponds to a commuting parent Hamiltonian
-if and only if the two regions are decorrelated.
+respect to two disjoint regions, and proves the backward direction of the
+decorrelation–commuting-parent-Hamiltonian equivalence: a commuting parent
+Hamiltonian implies decorrelation when observables respect locality.
 
-This is Proposition D.1 from arXiv:1606.00608, Appendix D.2.
+This is the backward direction of Proposition D.1 from arXiv:1606.00608,
+Appendix D.2. The forward direction requires tensor-product infrastructure
+and is deferred.
 
 ## Main definitions
 
@@ -28,8 +30,8 @@ This is Proposition D.1 from arXiv:1606.00608, Appendix D.2.
 
 ## Main results
 
-* `decorrelated_iff_commutingHam` — decorrelation ⟺ commuting parent
-  Hamiltonian (Proposition D.1)
+* `commutingHam_isDecorrelated` — commuting parent Hamiltonian →
+  decorrelation (Proposition D.1, backward direction)
 
 ## References
 
@@ -37,122 +39,6 @@ This is Proposition D.1 from arXiv:1606.00608, Appendix D.2.
 -/
 
 open scoped BigOperators
-
-/-!
-### Abstract operator-algebraic formulation
-
-We work in an abstract setting with finite-dimensional Hilbert spaces
-`H_A`, `H_X`, `H_B` and a subspace `K ≤ H_A ⊗ H_X ⊗ H_B`.
-
-Since the full formalization of the tensor product of Hilbert spaces is
-not yet available in Mathlib, we state the main definitions and the
-equivalence theorem using abstract idempotent endomorphisms on a
-finite-dimensional inner product space.
--/
-
-section AbstractDecorrelation
-
-variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E] [FiniteDimensional ℂ E]
-
-/-- **Decorrelation**: given an idempotent endomorphism `P_K` (projecting onto a
-subspace K) and families of operators `O_A` and `O_B` representing observables
-on regions A and B, regions A and B are **decorrelated** w.r.t. K when
-`P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K = 0` for all observables `O_A`, `O_B`.
-
-See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1. -/
-def IsDecorrelated (P_K : E →ₗ[ℂ] E)
-    (ObsA ObsB : Set (E →ₗ[ℂ] E)) : Prop :=
-  ∀ O_A ∈ ObsA, ∀ O_B ∈ ObsB,
-    P_K ∘ₗ O_A ∘ₗ (LinearMap.id - P_K) ∘ₗ O_B ∘ₗ P_K = 0
-
-/-- **Commuting parent Hamiltonian structure**: a subspace (given by its
-idempotent endomorphism `P_K`) corresponds to a commuting parent Hamiltonian
-if there exist idempotent endomorphisms `P_AX` and `P_XB` (acting on regions
-AX and XB respectively) that commute and whose intersection recovers `P_K`.
-
-Formally: `[Q_AX, Q_XB] = 0` where `Q = 1 - P`, and
-`K = (K_AX ⊗ H_B) ∩ (H_A ⊗ K_XB)`, which in projector language means
-`P_AX ∘ P_XB = P_K`.
-
-Note: this definition only requires idempotence and commutativity, not
-orthogonality / self-adjointness. Locality (that `P_AX` acts on the AX
-tensor factor and `P_XB` on XB) is not enforced in this abstract setting;
-it will be added once tensor-product Hilbert space infrastructure is
-available.
-
-See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1. -/
-def HasCommutingParentHam (P_K : E →ₗ[ℂ] E) : Prop :=
-  ∃ P_AX P_XB : E →ₗ[ℂ] E,
-    -- P_AX, P_XB are idempotent (projectors)
-    P_AX ∘ₗ P_AX = P_AX ∧
-    P_XB ∘ₗ P_XB = P_XB ∧
-    -- The complementary projectors commute: [1 - P_AX, 1 - P_XB] = 0,
-    -- equivalently [P_AX, P_XB] = 0
-    P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX ∧
-    -- P_K projects onto the intersection: P_AX ∘ P_XB = P_K
-    P_AX ∘ₗ P_XB = P_K ∧
-    -- P_K is contained in both: P_α ∘ P_K = P_K
-    P_AX ∘ₗ P_K = P_K ∧
-    P_XB ∘ₗ P_K = P_K
-
-set_option linter.unusedSectionVars false in
-/-- **Proposition D.1** (arXiv:1606.00608, Appendix D.2):
-A subspace K_{AXB} corresponds to a commuting parent Hamiltonian
-if and only if regions A and B are decorrelated w.r.t. K.
-
-## Current limitations
-
-The `hA_comm` and `hB_comm` hypotheses are stronger than the mathematical
-statement requires: they demand commutation with *every* linear map, not
-just the witnessing projector from the commuting-parent-Hamiltonian
-decomposition. In a tensor-product setting, observables on region A would
-only need to commute with operators on the complementary region XB.
-
-These hypotheses will be tightened to commutation with specific witnessing
-projectors once tensor-product Hilbert space infrastructure is available
-in Mathlib.
-
-## Proof outline
-
-**(→ IsDecorrelated → HasCommutingParentHam):**
-We exhibit the trivial witness `P_AX = P_XB = P_K`.
-
-**(← HasCommutingParentHam → IsDecorrelated):**
-Since `O_B` commutes with `P_K` (by `hB_comm`), we have
-`(1 - P_K) ∘ O_B ∘ P_K = 0` by idempotence of `P_K`, which kills the
-entire five-fold composition.
--/
-theorem decorrelated_iff_commutingHam
-    (P_K : E →ₗ[ℂ] E)
-    (hP_idem : P_K ∘ₗ P_K = P_K)
-    (ObsA ObsB : Set (E →ₗ[ℂ] E))
-    (_hA_comm : ∀ O_A ∈ ObsA, ∀ P_XB : E →ₗ[ℂ] E,
-      P_XB ∘ₗ O_A = O_A ∘ₗ P_XB)
-    (hB_comm : ∀ O_B ∈ ObsB, ∀ P_AX : E →ₗ[ℂ] E,
-      P_AX ∘ₗ O_B = O_B ∘ₗ P_AX) :
-    IsDecorrelated P_K ObsA ObsB ↔ HasCommutingParentHam P_K := by
-  constructor
-  · -- (→) IsDecorrelated → HasCommutingParentHam
-    -- Witness: P_AX = P_XB = P_K. All six conditions follow from hP_idem.
-    intro _
-    exact ⟨P_K, P_K, hP_idem, hP_idem, rfl, hP_idem, hP_idem, hP_idem⟩
-  · -- (←) HasCommutingParentHam → IsDecorrelated
-    -- Key: (id - P_K) ∘ O_B ∘ P_K = 0, since O_B commutes with P_K
-    -- (from hB_comm) and P_K is idempotent.
-    intro _ O_A _ O_B hO_B
-    -- O_B commutes with every operator, in particular P_K
-    have hOB_PK : P_K ∘ₗ O_B = O_B ∘ₗ P_K := hB_comm O_B hO_B P_K
-    -- Extract pointwise versions
-    have hPQ : ∀ y, P_K (O_B y) = O_B (P_K y) := LinearMap.ext_iff.mp hOB_PK
-    have hPP : ∀ y, P_K (P_K y) = P_K y := LinearMap.ext_iff.mp hP_idem
-    -- Show the five-fold composition is zero pointwise
-    ext x
-    simp only [LinearMap.comp_apply, LinearMap.sub_apply, LinearMap.id_apply,
-      LinearMap.zero_apply]
-    -- Goal: P_K (O_A (O_B (P_K x) - P_K (O_B (P_K x)))) = 0
-    rw [hPQ (P_K x), hPP, sub_self, map_zero, map_zero]
-
-end AbstractDecorrelation
 
 /-!
 ### Auxiliary lemmas for commuting projectors
@@ -238,3 +124,150 @@ theorem comp_complement_comm_zero
   rw [hPP]
 
 end CommutingProjectors
+
+/-!
+### Abstract operator-algebraic formulation
+
+We work in an abstract setting with finite-dimensional Hilbert spaces
+`H_A`, `H_X`, `H_B` and a subspace `K ≤ H_A ⊗ H_X ⊗ H_B`.
+
+Since the full formalization of the tensor product of Hilbert spaces is
+not yet available in Mathlib, we state the main definitions and the
+equivalence theorem using abstract idempotent endomorphisms on a
+finite-dimensional inner product space.
+-/
+
+section AbstractDecorrelation
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E] [FiniteDimensional ℂ E]
+
+/-- **Decorrelation**: given an idempotent endomorphism `P_K` (projecting onto a
+subspace K) and families of operators `O_A` and `O_B` representing observables
+on regions A and B, regions A and B are **decorrelated** w.r.t. K when
+`P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K = 0` for all observables `O_A`, `O_B`.
+
+See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1. -/
+def IsDecorrelated (P_K : E →ₗ[ℂ] E)
+    (ObsA ObsB : Set (E →ₗ[ℂ] E)) : Prop :=
+  ∀ O_A ∈ ObsA, ∀ O_B ∈ ObsB,
+    P_K ∘ₗ O_A ∘ₗ (LinearMap.id - P_K) ∘ₗ O_B ∘ₗ P_K = 0
+
+/-- **Commuting parent Hamiltonian structure**: a subspace (given by its
+idempotent endomorphism `P_K`) corresponds to a commuting parent Hamiltonian
+if there exist idempotent endomorphisms `P_AX` and `P_XB` (acting on regions
+AX and XB respectively) that commute and whose intersection recovers `P_K`.
+
+Formally: `[Q_AX, Q_XB] = 0` where `Q = 1 - P`, and
+`K = (K_AX ⊗ H_B) ∩ (H_A ⊗ K_XB)`, which in projector language means
+`P_AX ∘ P_XB = P_K`.
+
+Note: this definition only requires idempotence and commutativity, not
+orthogonality / self-adjointness. Locality (that `P_AX` acts on the AX
+tensor factor and `P_XB` on XB) is not enforced in this abstract setting;
+it will be added once tensor-product Hilbert space infrastructure is
+available. In particular, the trivial witness `P_AX = P_XB = P_K` always
+satisfies this predicate for any idempotent `P_K`; non-trivial content
+arises only when combined with locality constraints (see
+`commutingHam_isDecorrelated`).
+
+See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1. -/
+def HasCommutingParentHam (P_K : E →ₗ[ℂ] E) : Prop :=
+  ∃ P_AX P_XB : E →ₗ[ℂ] E,
+    -- P_AX, P_XB are idempotent (projectors)
+    P_AX ∘ₗ P_AX = P_AX ∧
+    P_XB ∘ₗ P_XB = P_XB ∧
+    -- The complementary projectors commute: [1 - P_AX, 1 - P_XB] = 0,
+    -- equivalently [P_AX, P_XB] = 0
+    P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX ∧
+    -- P_K projects onto the intersection: P_AX ∘ P_XB = P_K
+    P_AX ∘ₗ P_XB = P_K
+
+omit [FiniteDimensional ℂ E] in
+/-- If `P_K` has a commuting parent Hamiltonian with witnesses `P_AX`, `P_XB`,
+then `P_AX ∘ P_K = P_K` (the left witness absorbs `P_K`). -/
+theorem HasCommutingParentHam.left_absorb {P_K : E →ₗ[ℂ] E}
+    (h : HasCommutingParentHam P_K) :
+    ∃ P_AX P_XB : E →ₗ[ℂ] E, P_AX ∘ₗ P_XB = P_K ∧ P_AX ∘ₗ P_K = P_K := by
+  obtain ⟨P_AX, P_XB, hAX, _, _, hK⟩ := h
+  exact ⟨P_AX, P_XB, hK, by rw [← hK, ← LinearMap.comp_assoc, hAX]⟩
+
+omit [FiniteDimensional ℂ E] in
+/-- If `P_K` has a commuting parent Hamiltonian with witnesses `P_AX`, `P_XB`,
+then `P_XB ∘ P_K = P_K` (the right witness absorbs `P_K`). -/
+theorem HasCommutingParentHam.right_absorb {P_K : E →ₗ[ℂ] E}
+    (h : HasCommutingParentHam P_K) :
+    ∃ P_AX P_XB : E →ₗ[ℂ] E, P_AX ∘ₗ P_XB = P_K ∧ P_XB ∘ₗ P_K = P_K := by
+  obtain ⟨P_AX, P_XB, _, hXB, hcomm, hK⟩ := h
+  exact ⟨P_AX, P_XB, hK, by rw [← hK, ← LinearMap.comp_assoc, ← hcomm,
+    LinearMap.comp_assoc, hXB]⟩
+
+omit [FiniteDimensional ℂ E] in
+/-- **Proposition D.1, backward direction** (arXiv:1606.00608, Appendix D.2):
+If a subspace K has a commuting parent Hamiltonian decomposition
+`P_K = P_AX ∘ P_XB` with `[P_AX, P_XB] = 0`, and observables on region A
+commute with `P_XB` while observables on region B commute with `P_AX`, then
+regions A and B are decorrelated w.r.t. K.
+
+The commutation hypotheses are scoped to the *specific* witnessing projectors
+`P_AX` and `P_XB`, not all linear maps. This captures the locality structure:
+A-observables commute with the XB-projector and vice versa.
+
+## Proof outline
+
+The key identity is `P_XB ∘ (1 - P_AX ∘ P_XB) ∘ P_AX = 0` (see
+`comp_complement_comm_zero`). Using the commutation hypotheses to slide
+`O_A` past `P_XB` and `O_B` past `P_AX`, the five-fold composition
+`P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K` factors as
+`P_AX ∘ O_A ∘ [P_XB ∘ (1 - P_AX ∘ P_XB) ∘ P_AX] ∘ O_B ∘ P_XB = 0`.
+
+## Note on the forward direction
+
+The converse (IsDecorrelated → HasCommutingParentHam) requires constructing
+*local* projectors `P_AX` and `P_XB` on the AX and XB tensor factors.
+In this abstract (non-tensor-product) setting, `HasCommutingParentHam` is
+trivially satisfiable by `P_AX = P_XB = P_K`, so an abstract iff would be
+vacuous. The forward direction is deferred to the tensor-product setting.
+
+See arXiv:1606.00608, Appendix D.2, Proposition D.1. -/
+theorem commutingHam_isDecorrelated
+    (P_K P_AX P_XB : E →ₗ[ℂ] E)
+    (hAX_idem : P_AX ∘ₗ P_AX = P_AX)
+    (hXB_idem : P_XB ∘ₗ P_XB = P_XB)
+    (hcomm : P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX)
+    (hK : P_AX ∘ₗ P_XB = P_K)
+    (ObsA ObsB : Set (E →ₗ[ℂ] E))
+    (hA_comm : ∀ O_A ∈ ObsA, O_A ∘ₗ P_XB = P_XB ∘ₗ O_A)
+    (hB_comm : ∀ O_B ∈ ObsB, O_B ∘ₗ P_AX = P_AX ∘ₗ O_B) :
+    IsDecorrelated P_K ObsA ObsB := by
+  intro O_A hOA O_B hOB
+  -- Substitute P_K = P_AX ∘ P_XB
+  rw [← hK]
+  -- Key cancellation: P_XB ∘ (id - P_AX ∘ P_XB) ∘ P_AX = 0
+  have key := comp_complement_comm_zero hAX_idem hXB_idem hcomm
+  -- Extract pointwise commutativity
+  have hA : ∀ y, O_A (P_XB y) = P_XB (O_A y) :=
+    LinearMap.ext_iff.mp (hA_comm O_A hOA)
+  have hB : ∀ y, O_B (P_AX y) = P_AX (O_B y) :=
+    LinearMap.ext_iff.mp (hB_comm O_B hOB)
+  -- Pointwise key: P_XB (P_AX w - P_AX (P_XB (P_AX w))) = 0
+  have key_pw : ∀ w, P_XB (P_AX w - P_AX (P_XB (P_AX w))) = 0 := by
+    intro w
+    have h := LinearMap.ext_iff.mp key w
+    simp only [LinearMap.comp_apply, LinearMap.sub_apply, LinearMap.id_apply,
+      LinearMap.zero_apply] at h
+    exact h
+  -- Work pointwise
+  ext x
+  simp only [LinearMap.comp_apply, LinearMap.sub_apply, LinearMap.id_apply,
+    LinearMap.zero_apply]
+  -- Goal: P_AX (P_XB (O_A (O_B (P_AX (P_XB x)) - P_AX (P_XB (O_B (P_AX (P_XB x))))))) = 0
+  -- Step 1: Slide O_B past P_AX using hB
+  rw [hB (P_XB x)]
+  -- Goal: P_AX (P_XB (O_A (P_AX (O_B (P_XB x)) - P_AX (P_XB (P_AX (O_B (P_XB x))))))) = 0
+  -- Step 2: Slide P_XB past O_A using hA (reversed)
+  rw [(hA _).symm]
+  -- Goal: P_AX (O_A (P_XB (P_AX (O_B (P_XB x)) - P_AX (P_XB (P_AX (O_B (P_XB x))))))) = 0
+  -- Step 3: Apply key cancellation (P_XB kills the middle)
+  rw [key_pw, map_zero, map_zero]
+
+end AbstractDecorrelation

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -2,10 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.InnerProductSpace.Basic
-import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.Projection.Basic
-import Mathlib.LinearAlgebra.Projection
 
 /-!
 # Decorrelation and commuting parent Hamiltonians
@@ -73,16 +70,14 @@ theorem comp_idempotent_of_comm_of_idempotent
   --   = P(Qx)            by hQQ
   rw [hPQ, hPP, ← hPQ, hQQ]
 
-/-- If `P` and `Q` are commuting idempotents and `R = P ∘ Q`, then
-`P ∘ R = R`. -/
+/-- If `P` is idempotent, then `P ∘ (P ∘ Q) = P ∘ Q`. -/
 theorem left_absorb_of_comm_idempotent
     {P Q : E →ₗ[ℂ] E}
     (hP : P ∘ₗ P = P) :
     P ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q := by
   rw [← LinearMap.comp_assoc, hP]
 
-/-- If `P` and `Q` are commuting idempotents and `R = P ∘ Q`, then
-`Q ∘ R = R`. -/
+/-- If `Q` is idempotent and `P ∘ Q = Q ∘ P`, then `Q ∘ (P ∘ Q) = P ∘ Q`. -/
 theorem right_absorb_of_comm_idempotent
     {P Q : E →ₗ[ℂ] E}
     (hQ : Q ∘ₗ Q = Q)

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -170,7 +170,11 @@ satisfies this predicate for any idempotent `P_K`; non-trivial content
 arises only when combined with locality constraints (see
 `commutingHam_isDecorrelated`).
 
-See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1. -/
+See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1.
+
+TODO(tensor-product): add locality constraints requiring `P_AX` to act on
+`H_A ⊗ H_X` and `P_XB` to act on `H_X ⊗ H_B`. Without these, the predicate
+is trivially satisfiable by `P_AX = P_XB = P_K`. -/
 def HasCommutingParentHam (P_K : E →ₗ[ℂ] E) : Prop :=
   ∃ P_AX P_XB : E →ₗ[ℂ] E,
     -- P_AX, P_XB are idempotent (projectors)

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -1,0 +1,212 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.Adjoint
+import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+import Mathlib.LinearAlgebra.Projection
+
+/-!
+# Decorrelation and commuting parent Hamiltonians
+
+This file defines the notion of **decorrelation** for a subspace with
+respect to two disjoint regions, and proves the dimension-independent
+equivalence: a subspace corresponds to a commuting parent Hamiltonian
+if and only if the two regions are decorrelated.
+
+This is Proposition D.1 from arXiv:1606.00608, Appendix D.2.
+
+## Main definitions
+
+* `IsDecorrelated` — regions A and B are decorrelated w.r.t. a subspace K
+  when `P_K O_A (1 - P_K) O_B P_K = 0` for all observables O_A, O_B on
+  the respective regions.
+* `HasCommutingParentHam` — a subspace K equals the intersection of two
+  local kernels `K_AX ⊗ H_B ∩ H_A ⊗ K_XB` where the corresponding
+  projectors commute.
+
+## Main results
+
+* `decorrelated_iff_commutingHam` — decorrelation ⟺ commuting parent
+  Hamiltonian (Proposition D.1)
+
+## References
+
+* arXiv:1606.00608, Appendix D.2 (lines 2181–2290)
+-/
+
+open scoped BigOperators
+
+/-!
+### Abstract operator-algebraic formulation
+
+We work in an abstract setting with finite-dimensional Hilbert spaces
+`H_A`, `H_X`, `H_B` and a subspace `K ≤ H_A ⊗ H_X ⊗ H_B`.
+
+Since the full formalization of the tensor product of Hilbert spaces is
+not yet available in Mathlib, we state the main definitions and the
+equivalence theorem using abstract orthogonal projectors on a
+finite-dimensional inner product space.
+-/
+
+section AbstractDecorrelation
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E] [FiniteDimensional ℂ E]
+
+/-- **Decorrelation**: given an orthogonal projection `P_K` (projecting onto a
+subspace K) and families of operators `O_A` and `O_B` representing observables
+on regions A and B, regions A and B are **decorrelated** w.r.t. K when
+`P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K = 0` for all observables `O_A`, `O_B`.
+
+See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1. -/
+def IsDecorrelated (P_K : E →ₗ[ℂ] E)
+    (ObsA ObsB : Set (E →ₗ[ℂ] E)) : Prop :=
+  ∀ O_A ∈ ObsA, ∀ O_B ∈ ObsB,
+    P_K ∘ₗ O_A ∘ₗ (LinearMap.id - P_K) ∘ₗ O_B ∘ₗ P_K = 0
+
+/-- **Commuting parent Hamiltonian structure**: a subspace (given by its
+orthogonal projector `P_K`) corresponds to a commuting parent Hamiltonian
+if there exist projectors `P_AX` and `P_XB` (acting on regions AX and XB
+respectively) that commute and whose intersection recovers `P_K`.
+
+Formally: `[Q_AX, Q_XB] = 0` where `Q = 1 - P`, and
+`K = (K_AX ⊗ H_B) ∩ (H_A ⊗ K_XB)`, which in projector language means
+`P_AX ∘ P_XB = P_K`.
+
+See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1. -/
+def HasCommutingParentHam (P_K : E →ₗ[ℂ] E) : Prop :=
+  ∃ P_AX P_XB : E →ₗ[ℂ] E,
+    -- P_AX, P_XB are idempotent (projectors)
+    P_AX ∘ₗ P_AX = P_AX ∧
+    P_XB ∘ₗ P_XB = P_XB ∧
+    -- The complementary projectors commute: [1 - P_AX, 1 - P_XB] = 0,
+    -- equivalently [P_AX, P_XB] = 0
+    P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX ∧
+    -- P_K projects onto the intersection: P_AX ∘ P_XB = P_K
+    P_AX ∘ₗ P_XB = P_K ∧
+    -- P_K is contained in both: P_α ∘ P_K = P_K
+    P_AX ∘ₗ P_K = P_K ∧
+    P_XB ∘ₗ P_K = P_K
+
+/-- **Proposition D.1** (arXiv:1606.00608, Appendix D.2):
+A subspace K_{AXB} corresponds to a commuting parent Hamiltonian
+if and only if regions A and B are decorrelated w.r.t. K.
+
+The proof proceeds in two directions:
+
+**(⟸ decorrelated ⟹ commuting Ham):**
+Define `P_AX`, `P_XB` as the support projectors of the partial traces of K.
+The decorrelation condition forces `P_AX ∘ P_XB = P_XB ∘ P_AX = P_K`,
+hence the complementary projectors `Q = 1 - P` commute and
+`K = (K_AX ⊗ H_B) ∩ (H_A ⊗ K_XB)`.
+
+**(⟹ commuting Ham ⟹ decorrelated):**
+From `[P_AX, P_XB] = 0` we get `P_AX ∘ P_XB = P_K`.
+Then `P_XB ∘ (1 - P_K) ∘ P_AX = P_XB ∘ P_AX - P_K = 0`,
+so for any `O_A` on A (commuting with `P_XB`) and `O_B` on B
+(commuting with `P_AX`):
+`P_K O_A (1 - P_K) O_B P_K = P_K P_XB O_A (1 - P_K) O_B P_AX P_K`
+`= P_K O_A P_XB (1 - P_K) P_AX O_B P_K = 0`.
+
+TODO: complete the proof once tensor-product Hilbert space infrastructure
+is available. The key missing piece is the ability to express that `O_A`
+commutes with `P_XB` (because they act on different tensor factors).
+-/
+theorem decorrelated_iff_commutingHam
+    (P_K : E →ₗ[ℂ] E)
+    (hP_idem : P_K ∘ₗ P_K = P_K)
+    (ObsA ObsB : Set (E →ₗ[ℂ] E))
+    (hA_comm : ∀ O_A ∈ ObsA, ∀ P_XB : E →ₗ[ℂ] E,
+      P_XB ∘ₗ O_A = O_A ∘ₗ P_XB)
+    (hB_comm : ∀ O_B ∈ ObsB, ∀ P_AX : E →ₗ[ℂ] E,
+      P_AX ∘ₗ O_B = O_B ∘ₗ P_AX) :
+    IsDecorrelated P_K ObsA ObsB ↔ HasCommutingParentHam P_K := by
+  sorry
+
+end AbstractDecorrelation
+
+/-!
+### Auxiliary lemmas for commuting projectors
+
+These lemmas are used in the proof of Proposition D.1 and may be
+useful elsewhere.
+-/
+
+section CommutingProjectors
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+
+/-- If two idempotent linear maps commute, their composition is idempotent. -/
+theorem comp_idempotent_of_comm_of_idempotent
+    {P Q : E →ₗ[ℂ] E}
+    (hP : P ∘ₗ P = P)
+    (hQ : Q ∘ₗ Q = Q)
+    (hcomm : P ∘ₗ Q = Q ∘ₗ P) :
+    (P ∘ₗ Q) ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q := by
+  -- Pointwise: P(Q(P(Qx))) = P(Qx)
+  ext x; simp only [LinearMap.comp_apply]
+  -- Use hcomm pointwise: P(Qy) = Q(Py)
+  have hPQ : ∀ y, P (Q y) = Q (P y) := LinearMap.ext_iff.mp hcomm
+  -- Use hQ pointwise: Q(Qy) = Qy
+  have hQQ : ∀ y, Q (Q y) = Q y := LinearMap.ext_iff.mp hQ
+  -- Use hP pointwise: P(Py) = Py
+  have hPP : ∀ y, P (P y) = P y := LinearMap.ext_iff.mp hP
+  -- P(Q(P(Qx)))
+  --   = Q(P(P(Qx)))    by hPQ
+  --   = Q(P(Qx))        by hPP
+  --   = P(Q(Qx))        by hPQ⁻¹
+  --   = P(Qx)            by hQQ
+  rw [hPQ, hPP, ← hPQ, hQQ]
+
+/-- If `P` and `Q` are commuting idempotents and `R = P ∘ Q`, then
+`P ∘ R = R`. -/
+theorem left_absorb_of_comm_idempotent
+    {P Q : E →ₗ[ℂ] E}
+    (hP : P ∘ₗ P = P)
+    (_hQ : Q ∘ₗ Q = Q)
+    (_hcomm : P ∘ₗ Q = Q ∘ₗ P) :
+    P ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q := by
+  rw [← LinearMap.comp_assoc, hP]
+
+/-- If `P` and `Q` are commuting idempotents and `R = P ∘ Q`, then
+`Q ∘ R = R`. -/
+theorem right_absorb_of_comm_idempotent
+    {P Q : E →ₗ[ℂ] E}
+    (_hP : P ∘ₗ P = P)
+    (hQ : Q ∘ₗ Q = Q)
+    (hcomm : P ∘ₗ Q = Q ∘ₗ P) :
+    Q ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q := by
+  rw [← LinearMap.comp_assoc, ← hcomm, LinearMap.comp_assoc, hQ]
+
+/-- For commuting idempotents, `Q ∘ (1 - P ∘ Q) ∘ P = 0`. This is the
+key cancellation used in the "only if" direction of Prop D.1:
+`P_XB ∘ P_K^⊥ ∘ P_AX = 0`. -/
+theorem comp_complement_comm_zero
+    {P Q : E →ₗ[ℂ] E}
+    (hP : P ∘ₗ P = P)
+    (hQ : Q ∘ₗ Q = Q)
+    (hcomm : P ∘ₗ Q = Q ∘ₗ P) :
+    Q ∘ₗ (LinearMap.id - P ∘ₗ Q) ∘ₗ P = 0 := by
+  -- Q ∘ (id - PQ) ∘ P = Q∘P - Q∘(PQ)∘P = QP - (Q∘P∘Q)∘P
+  -- We work pointwise.
+  ext x
+  simp only [LinearMap.comp_apply, LinearMap.sub_apply, LinearMap.id_apply,
+    LinearMap.zero_apply]
+  -- Goal: Q (P x - P (Q (P x))) = 0
+  have hPQ : ∀ y, P (Q y) = Q (P y) := LinearMap.ext_iff.mp hcomm
+  have hQQ : ∀ y, Q (Q y) = Q y := LinearMap.ext_iff.mp hQ
+  have hPP : ∀ y, P (P y) = P y := LinearMap.ext_iff.mp hP
+  rw [map_sub]
+  -- Goal: Q (P x) - Q (P (Q (P x))) = 0
+  suffices h : Q (P (Q (P x))) = Q (P x) by rw [h, sub_self]
+  -- Q(P(Q(Px)))
+  --   rewrite inner P(Q(Px)) using hPQ: P(Q(Px)) = Q(P(Px))
+  rw [hPQ (P x)]
+  --   Q(Q(P(Px)))
+  rw [hQQ]
+  --   Q(P(Px))
+  --   rewrite P(Px) using hPP
+  rw [hPP]
+
+end CommutingProjectors

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -46,7 +46,7 @@ We work in an abstract setting with finite-dimensional Hilbert spaces
 
 Since the full formalization of the tensor product of Hilbert spaces is
 not yet available in Mathlib, we state the main definitions and the
-equivalence theorem using abstract orthogonal projectors on a
+equivalence theorem using abstract idempotent endomorphisms on a
 finite-dimensional inner product space.
 -/
 
@@ -54,7 +54,7 @@ section AbstractDecorrelation
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E] [FiniteDimensional ℂ E]
 
-/-- **Decorrelation**: given an orthogonal projection `P_K` (projecting onto a
+/-- **Decorrelation**: given an idempotent endomorphism `P_K` (projecting onto a
 subspace K) and families of operators `O_A` and `O_B` representing observables
 on regions A and B, regions A and B are **decorrelated** w.r.t. K when
 `P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K = 0` for all observables `O_A`, `O_B`.
@@ -66,13 +66,19 @@ def IsDecorrelated (P_K : E →ₗ[ℂ] E)
     P_K ∘ₗ O_A ∘ₗ (LinearMap.id - P_K) ∘ₗ O_B ∘ₗ P_K = 0
 
 /-- **Commuting parent Hamiltonian structure**: a subspace (given by its
-orthogonal projector `P_K`) corresponds to a commuting parent Hamiltonian
-if there exist projectors `P_AX` and `P_XB` (acting on regions AX and XB
-respectively) that commute and whose intersection recovers `P_K`.
+idempotent endomorphism `P_K`) corresponds to a commuting parent Hamiltonian
+if there exist idempotent endomorphisms `P_AX` and `P_XB` (acting on regions
+AX and XB respectively) that commute and whose intersection recovers `P_K`.
 
 Formally: `[Q_AX, Q_XB] = 0` where `Q = 1 - P`, and
 `K = (K_AX ⊗ H_B) ∩ (H_A ⊗ K_XB)`, which in projector language means
 `P_AX ∘ P_XB = P_K`.
+
+Note: this definition only requires idempotence and commutativity, not
+orthogonality / self-adjointness. Locality (that `P_AX` acts on the AX
+tensor factor and `P_XB` on XB) is not enforced in this abstract setting;
+it will be added once tensor-product Hilbert space infrastructure is
+available.
 
 See arXiv:1606.00608, Appendix D.2, Definition before Proposition D.1. -/
 def HasCommutingParentHam (P_K : E →ₗ[ℂ] E) : Prop :=
@@ -89,40 +95,62 @@ def HasCommutingParentHam (P_K : E →ₗ[ℂ] E) : Prop :=
     P_AX ∘ₗ P_K = P_K ∧
     P_XB ∘ₗ P_K = P_K
 
+set_option linter.unusedSectionVars false in
 /-- **Proposition D.1** (arXiv:1606.00608, Appendix D.2):
 A subspace K_{AXB} corresponds to a commuting parent Hamiltonian
 if and only if regions A and B are decorrelated w.r.t. K.
 
-The proof proceeds in two directions:
+## Current limitations
 
-**(⟸ decorrelated ⟹ commuting Ham):**
-Define `P_AX`, `P_XB` as the support projectors of the partial traces of K.
-The decorrelation condition forces `P_AX ∘ P_XB = P_XB ∘ P_AX = P_K`,
-hence the complementary projectors `Q = 1 - P` commute and
-`K = (K_AX ⊗ H_B) ∩ (H_A ⊗ K_XB)`.
+The `hA_comm` and `hB_comm` hypotheses are stronger than the mathematical
+statement requires: they demand commutation with *every* linear map, not
+just the witnessing projector from the commuting-parent-Hamiltonian
+decomposition. In a tensor-product setting, observables on region A would
+only need to commute with operators on the complementary region XB.
 
-**(⟹ commuting Ham ⟹ decorrelated):**
-From `[P_AX, P_XB] = 0` we get `P_AX ∘ P_XB = P_K`.
-Then `P_XB ∘ (1 - P_K) ∘ P_AX = P_XB ∘ P_AX - P_K = 0`,
-so for any `O_A` on A (commuting with `P_XB`) and `O_B` on B
-(commuting with `P_AX`):
-`P_K O_A (1 - P_K) O_B P_K = P_K P_XB O_A (1 - P_K) O_B P_AX P_K`
-`= P_K O_A P_XB (1 - P_K) P_AX O_B P_K = 0`.
+These hypotheses will be tightened to commutation with specific witnessing
+projectors once tensor-product Hilbert space infrastructure is available
+in Mathlib.
 
-TODO: complete the proof once tensor-product Hilbert space infrastructure
-is available. The key missing piece is the ability to express that `O_A`
-commutes with `P_XB` (because they act on different tensor factors).
+## Proof outline
+
+**(→ IsDecorrelated → HasCommutingParentHam):**
+We exhibit the trivial witness `P_AX = P_XB = P_K`.
+
+**(← HasCommutingParentHam → IsDecorrelated):**
+Since `O_B` commutes with `P_K` (by `hB_comm`), we have
+`(1 - P_K) ∘ O_B ∘ P_K = 0` by idempotence of `P_K`, which kills the
+entire five-fold composition.
 -/
 theorem decorrelated_iff_commutingHam
     (P_K : E →ₗ[ℂ] E)
     (hP_idem : P_K ∘ₗ P_K = P_K)
     (ObsA ObsB : Set (E →ₗ[ℂ] E))
-    (hA_comm : ∀ O_A ∈ ObsA, ∀ P_XB : E →ₗ[ℂ] E,
+    (_hA_comm : ∀ O_A ∈ ObsA, ∀ P_XB : E →ₗ[ℂ] E,
       P_XB ∘ₗ O_A = O_A ∘ₗ P_XB)
     (hB_comm : ∀ O_B ∈ ObsB, ∀ P_AX : E →ₗ[ℂ] E,
       P_AX ∘ₗ O_B = O_B ∘ₗ P_AX) :
     IsDecorrelated P_K ObsA ObsB ↔ HasCommutingParentHam P_K := by
-  sorry
+  constructor
+  · -- (→) IsDecorrelated → HasCommutingParentHam
+    -- Witness: P_AX = P_XB = P_K. All six conditions follow from hP_idem.
+    intro _
+    exact ⟨P_K, P_K, hP_idem, hP_idem, rfl, hP_idem, hP_idem, hP_idem⟩
+  · -- (←) HasCommutingParentHam → IsDecorrelated
+    -- Key: (id - P_K) ∘ O_B ∘ P_K = 0, since O_B commutes with P_K
+    -- (from hB_comm) and P_K is idempotent.
+    intro _ O_A _ O_B hO_B
+    -- O_B commutes with every operator, in particular P_K
+    have hOB_PK : P_K ∘ₗ O_B = O_B ∘ₗ P_K := hB_comm O_B hO_B P_K
+    -- Extract pointwise versions
+    have hPQ : ∀ y, P_K (O_B y) = O_B (P_K y) := LinearMap.ext_iff.mp hOB_PK
+    have hPP : ∀ y, P_K (P_K y) = P_K y := LinearMap.ext_iff.mp hP_idem
+    -- Show the five-fold composition is zero pointwise
+    ext x
+    simp only [LinearMap.comp_apply, LinearMap.sub_apply, LinearMap.id_apply,
+      LinearMap.zero_apply]
+    -- Goal: P_K (O_A (O_B (P_K x) - P_K (O_B (P_K x)))) = 0
+    rw [hPQ (P_K x), hPP, sub_self, map_zero, map_zero]
 
 end AbstractDecorrelation
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -449,7 +449,7 @@ interaction projectors commute with each other.
 
 This section develops the abstract operator-algebraic formulation of
 decorrelation and its connection to commuting parent Hamiltonians, following
-Appendix~D.2 of~\cite{Cirac2021Matrix}.
+Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
 
 \begin{definition}[Decorrelation]\label{def:is_decorrelated}
   \lean{IsDecorrelated}
@@ -479,8 +479,8 @@ Appendix~D.2 of~\cite{Cirac2021Matrix}.
   $P_K = P_{AX} \circ P_{XB}$ with $[P_{AX}, P_{XB}] = 0$, and
   $A$-observables commute with $P_{XB}$ while $B$-observables commute
   with $P_{AX}$, then regions $A$ and $B$ are decorrelated w.r.t.\ $K$.
-  This is the backward direction of Proposition~D.1
-  from~\cite{Cirac2021Matrix}, Appendix~D.2.
+  This is the backward direction of Proposition~D.3
+  from~\cite{Cirac2021Matrix}, Appendix~D, \S D.2.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -474,7 +474,7 @@ Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
   \label{thm:commuting_ham_is_decorrelated}
   \lean{commutingHam_isDecorrelated}
   \leanok
-  \uses{def:is_decorrelated, def:has_commuting_parent_ham}
+  \uses{def:is_decorrelated}
   If a subspace $K$ has a commuting parent Hamiltonian decomposition
   $P_K = P_{AX} \circ P_{XB}$ with $[P_{AX}, P_{XB}] = 0$, and
   $A$-observables commute with $P_{XB}$ while $B$-observables commute

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -452,7 +452,7 @@ decorrelation and its connection to commuting parent Hamiltonians, following
 Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
 
 \begin{definition}[Decorrelation]\label{def:is_decorrelated}
-  \lean{IsDecorrelated}
+  \lean{Decorrelation.IsDecorrelated}
   \leanok
   Given an idempotent endomorphism $P_K$ and sets of observables
   $\mathcal{O}_A$, $\mathcal{O}_B$, regions $A$ and $B$ are
@@ -462,7 +462,7 @@ Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
 \end{definition}
 
 \begin{definition}[Commuting parent Hamiltonian structure]\label{def:has_commuting_parent_ham}
-  \lean{HasCommutingParentHam}
+  \lean{Decorrelation.HasCommutingParentHam}
   \leanok
   A subspace $K$ (given by its idempotent endomorphism $P_K$) has a
   \emph{commuting parent Hamiltonian structure} if there exist idempotent
@@ -472,7 +472,7 @@ Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
 
 \begin{theorem}[Commuting parent Hamiltonian implies decorrelation]%
   \label{thm:commuting_ham_is_decorrelated}
-  \lean{commutingHam_isDecorrelated}
+  \lean{Decorrelation.commutingHam_isDecorrelated}
   \leanok
   \uses{def:is_decorrelated, def:has_commuting_parent_ham}
   If a subspace $K$ has a commuting parent Hamiltonian decomposition
@@ -492,7 +492,7 @@ Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
 
 \begin{theorem}[Commuting parent Hamiltonian implies decorrelation (bundled)]%
   \label{thm:has_commuting_parent_ham_is_decorrelated}
-  \lean{HasCommutingParentHam.isDecorrelated}
+  \lean{Decorrelation.HasCommutingParentHam.isDecorrelated}
   \leanok
   \uses{thm:commuting_ham_is_decorrelated, def:has_commuting_parent_ham, def:is_decorrelated}
   Convenience wrapper: if $P_K$ satisfies \texttt{HasCommutingParentHam}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -439,8 +439,8 @@ interaction projectors commute with each other.
   If $A$ is a renormalization fixed point (RFP), then its parent
   Hamiltonian with $L = 2$ has commuting local terms.
   \textbf{Note:} the Lean proof is currently vacuously true because
-  \texttt{localTerm} is a zero placeholder; do not cite this as a proven
-  result.
+  \texttt{parentInteraction} simplifies to zero (a pre-existing bug); do
+  not cite this as a proven result.
   See \cite[Theorem~3.10]{Cirac2021Matrix}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -409,6 +409,87 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
   in normal form, the interaction range can be reduced to $L_0 + 1$.
 \end{theorem}
 
+\section{Commuting parent Hamiltonians}\label{sec:commuting_parent_ham}
+
+A parent Hamiltonian has \emph{commuting} local terms when all translated
+interaction projectors commute with each other.
+
+\begin{definition}[Commuting parent Hamiltonian]\label{def:is_commuting_parent_ham}
+  \lean{MPSTensor.IsCommutingParentHam}
+  \leanok
+  \uses{def:local_term_parent}
+  The parent Hamiltonian with block length~$L$ on $N$ sites has
+  \emph{commuting} local terms if
+  $h_i h_j = h_j h_i$ for all $i,j \in \{0,\dots,N{-}1\}$.
+  See \cite[Definition~3.9]{Cirac2021Matrix}.
+\end{definition}
+
+\begin{definition}[Nearest-neighbor commuting parent Hamiltonian]\label{def:is_nncph}
+  \lean{MPSTensor.IsNNCPH}
+  \leanok
+  \uses{def:is_commuting_parent_ham}
+  A \emph{nearest-neighbor commuting parent Hamiltonian} (NNCPH) is a
+  commuting parent Hamiltonian with block length $L = 2$.
+  See \cite[Definition~3.9]{Cirac2021Matrix}.
+\end{definition}
+
+\begin{theorem}[RFP implies NNCPH]\label{thm:rfp_implies_nncph}
+  \lean{MPSTensor.isNNCPH_of_isRFP}
+  \uses{def:is_nncph}
+  If $A$ is a renormalization fixed point (RFP), then its parent
+  Hamiltonian with $L = 2$ has commuting local terms.
+  \textbf{Note:} the Lean proof is currently vacuously true because
+  \texttt{localTerm} is a zero placeholder; do not cite this as a proven
+  result.
+  See \cite[Theorem~3.10]{Cirac2021Matrix}.
+\end{theorem}
+
+\section{Decorrelation and commuting parent Hamiltonians}%
+\label{sec:decorrelation}
+
+This section develops the abstract operator-algebraic formulation of
+decorrelation and its connection to commuting parent Hamiltonians, following
+Appendix~D.2 of~\cite{Cirac2021Matrix}.
+
+\begin{definition}[Decorrelation]\label{def:is_decorrelated}
+  \lean{IsDecorrelated}
+  \leanok
+  Given an idempotent endomorphism $P_K$ and sets of observables
+  $\mathcal{O}_A$, $\mathcal{O}_B$, regions $A$ and $B$ are
+  \emph{decorrelated} w.r.t.\ $K$ when
+  $P_K \circ O_A \circ (1 - P_K) \circ O_B \circ P_K = 0$
+  for all $O_A \in \mathcal{O}_A$, $O_B \in \mathcal{O}_B$.
+\end{definition}
+
+\begin{definition}[Commuting parent Hamiltonian structure]\label{def:has_commuting_parent_ham}
+  \lean{HasCommutingParentHam}
+  \leanok
+  A subspace $K$ (given by its idempotent endomorphism $P_K$) has a
+  \emph{commuting parent Hamiltonian structure} if there exist idempotent
+  endomorphisms $P_{AX}$ and $P_{XB}$ that commute and satisfy
+  $P_{AX} \circ P_{XB} = P_K$.
+\end{definition}
+
+\begin{theorem}[Commuting parent Hamiltonian implies decorrelation]%
+  \label{thm:commuting_ham_is_decorrelated}
+  \lean{commutingHam_isDecorrelated}
+  \leanok
+  \uses{def:is_decorrelated, def:has_commuting_parent_ham}
+  If a subspace $K$ has a commuting parent Hamiltonian decomposition
+  $P_K = P_{AX} \circ P_{XB}$ with $[P_{AX}, P_{XB}] = 0$, and
+  $A$-observables commute with $P_{XB}$ while $B$-observables commute
+  with $P_{AX}$, then regions $A$ and $B$ are decorrelated w.r.t.\ $K$.
+  This is the backward direction of Proposition~D.1
+  from~\cite{Cirac2021Matrix}, Appendix~D.2.
+\end{theorem}
+
+\begin{proof}
+  \leanok
+  The key identity is $P_{XB} \circ (1 - P_{AX} \circ P_{XB}) \circ P_{AX} = 0$.
+  Using the commutation hypotheses to slide $O_A$ past $P_{XB}$ and $O_B$
+  past $P_{AX}$, the five-fold composition factors through this zero term.
+\end{proof}
+
 \section{Spectral gap}\label{sec:spectral_gap}
 
 A frustration-free Hamiltonian is \emph{gapped} if the first excited

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -474,7 +474,7 @@ Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
   \label{thm:commuting_ham_is_decorrelated}
   \lean{commutingHam_isDecorrelated}
   \leanok
-  \uses{def:is_decorrelated}
+  \uses{def:is_decorrelated, def:has_commuting_parent_ham}
   If a subspace $K$ has a commuting parent Hamiltonian decomposition
   $P_K = P_{AX} \circ P_{XB}$ with $[P_{AX}, P_{XB}] = 0$, and
   $A$-observables commute with $P_{XB}$ while $B$-observables commute
@@ -489,6 +489,17 @@ Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
   Using the commutation hypotheses to slide $O_A$ past $P_{XB}$ and $O_B$
   past $P_{AX}$, the five-fold composition factors through this zero term.
 \end{proof}
+
+\begin{theorem}[Commuting parent Hamiltonian implies decorrelation (bundled)]%
+  \label{thm:has_commuting_parent_ham_is_decorrelated}
+  \lean{HasCommutingParentHam.isDecorrelated}
+  \leanok
+  \uses{thm:commuting_ham_is_decorrelated, def:has_commuting_parent_ham, def:is_decorrelated}
+  Convenience wrapper: if $P_K$ satisfies \texttt{HasCommutingParentHam}
+  and observables respect locality, then regions $A$ and $B$ are
+  decorrelated w.r.t.\ $K$. Delegates to
+  Theorem~\ref{thm:commuting_ham_is_decorrelated}.
+\end{theorem}
 
 \section{Spectral gap}\label{sec:spectral_gap}
 


### PR DESCRIPTION
### Motivation

- Continues formalization of MPDO RFP theory (arXiv:1606.00608 §3.3, Appendix D §D.2), see #234.
- Defines commuting and nearest-neighbor commuting parent Hamiltonians, connecting them to the RFP characterization (Thm 3.10).
- Introduces an abstract decorrelation framework and proves the backward direction of the decorrelation–commuting-Hamiltonian equivalence (Prop D.3).

### Description

- Add `TNLean/MPS/ParentHamiltonian/Commuting.lean`: `IsCommutingParentHam`, `IsNNCPH` (Def 3.9), `isNNCPH_of_isRFP` (Thm 3.10, vacuously true while `localTerm = 0`), and basic API lemmas (`symm`, `ham_comm_localTerm`).
- Add `TNLean/MPS/ParentHamiltonian/Decorrelation.lean`: `IsDecorrelated` (Def D.1), `HasCommutingParentHam` (Def D.2), `commutingHam_isDecorrelated` (Prop D.3 backward direction, fully proved), and auxiliary lemmas for commuting idempotents (`comp_idempotent_of_comm_of_idempotent`, `comp_complement_comm_zero`, `left_absorb_of_idem_intersection`, `right_absorb_of_idem_intersection`).
- Update `TNLean.lean` root import to include new modules.
- Update `blueprint/src/chapter/ch14_parent_hamiltonian.tex` with entries for all 6 new declarations.

### Sorry status

**Zero `sorry`s.** Two results (`isNNCPH_of_isRFP`, `ham_comm_localTerm`) are marked **PLACEHOLDER — VACUOUSLY TRUE** because `localTerm` is a zero placeholder. They compile without `sorry` but must be rewritten once `localTerm` gets its real definition.

### Follow-ups needed when `localTerm` is real

- Rewrite `ham_comm_localTerm` to actually use the commutativity hypothesis `h`.
- Rewrite `isNNCPH_of_isRFP` to use the structural form of RFP tensors (Thm 3.11, #233).
- Add `nncph_implies_rfp` with `2 ≤ N` hypothesis (currently omitted — mathematically unprovable with placeholder `localTerm`; false for `N = 0` without the bound).
- Add tensor-product locality constraints to `HasCommutingParentHam` to prevent trivial `P_AX = P_XB = P_K` witnesses.
- Prove the forward direction of Prop D.3 (decorrelated → commuting parent Hamiltonian) in the tensor-product setting.

### Testing

- `lake build` passes with zero errors and zero `sorry`s.

---
Addresses #234

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive Lean formalization, but it extends the public import surface and introduces theorems that currently typecheck vacuously due to existing zero placeholders, which could mislead downstream users if cited.
> 
> **Overview**
> Adds new Parent Hamiltonian theory modules: `Commuting.lean` introduces predicates for commuting local terms (`IsCommutingParentHam`) and the nearest-neighbor special case (`IsNNCPH`), plus lemmas relating them and a stated `IsRFP → IsNNCPH` implication (explicitly marked *vacuously true* while `localTerm`/`parentInteraction` remain zero placeholders).
> 
> Adds `Decorrelation.lean` with an abstract (non-tensor-product) formulation of decorrelation (`IsDecorrelated`) and a commuting-parent-Hamiltonian decomposition witness (`HasCommutingParentHam`), and proves the backward direction “commuting parent Hamiltonian + locality-style commutation of observables ⇒ decorrelation” via a new cancellation lemma for commuting idempotents. Root exports (`TNLean.lean`) and the blueprint chapter are updated to document and re-export these additions, including notes about the vacuous placeholder results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5548b660438a048f231b414fca5411e122bc972b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->