### PR TITLE
feat(MPS/RFP): prove RFP structural form and ZCL equivalence

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -271,19 +271,7 @@ theorem isBNT_of_separated_CFBNT_data [∀ k, NeZero (dim k)]
     (hOverlap : HasNormalizedSelfOverlap (d := d) A)
     (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A) :
     IsBNT (toTensorFromBlocks μ A) r dim A where
-  normal := fun j => by
-    refine ⟨1, ?_⟩
-    have hAj_inj := hInj.block_injective j
-    have hkey : ∀ σ : Fin 1 → Fin d, evalWord (A j) (List.ofFn σ) = A j (σ 0) := by
-      intro σ
-      simp [List.ofFn_succ, List.ofFn_zero, evalWord]
-    suffices h : Set.range (fun σ : Fin 1 → Fin d => evalWord (A j) (List.ofFn σ)) =
-        Set.range (A j) by
-      rw [IsNBlkInjective, h]
-      exact hAj_inj
-    ext M
-    simp only [Set.mem_range, hkey]
-    exact ⟨fun ⟨σ, hσ⟩ => ⟨σ 0, hσ⟩, fun ⟨i, hi⟩ => ⟨fun _ => i, hi⟩⟩
+  normal := fun j => (hInj.block_injective j).isNormal
   spans_mpv := spans_mpv_toTensorFromBlocks μ A
   eventually_li :=
     eventually_li_of_overlap_limits A

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -126,6 +126,24 @@ def IsNormal (A : MPSTensor d D) : Prop :=
 @[simp] lemma isNormal_iff (A : MPSTensor d D) :
     IsNormal A ↔ ∃ N, IsNBlkInjective A N := Iff.rfl
 
+/-- Algebraic injectivity (1-block) implies normality (eventual block injectivity).
+This is the trivial direction: injectivity is `IsNBlkInjective 1`. -/
+lemma IsInjective.isNormal {A : MPSTensor d D} (h : IsInjective A) : IsNormal A := by
+  refine ⟨1, ?_⟩
+  unfold IsNBlkInjective
+  have hrange : (Set.range fun σ : Fin 1 → Fin d =>
+      evalWord A (List.ofFn σ)) = Set.range A := by
+    ext M; simp only [Set.mem_range]; constructor
+    · rintro ⟨σ, hσ⟩
+      exact ⟨σ 0, by
+        simp only [List.ofFn_succ, List.ofFn_zero,
+          evalWord_cons, evalWord_nil, mul_one] at hσ; exact hσ⟩
+    · rintro ⟨i, hi⟩
+      exact ⟨fun _ => i, by
+        simp only [List.ofFn_succ, List.ofFn_zero,
+          evalWord_cons, evalWord_nil, mul_one]; exact hi⟩
+  rw [hrange]; exact h
+
 /-! ### Gauge invariance -/
 
 section GaugeInvariance

--- a/TNLean/MPS/RFP/Assembly.lean
+++ b/TNLean/MPS/RFP/Assembly.lean
@@ -18,7 +18,7 @@ equivalence from arXiv:1606.00608, Theorem 3.10 (partial):
 The NNCPH (nearest-neighbour commuting parent Hamiltonian) direction of
 Theorem 3.10 is deferred to a later module.
 
-This is a sorry placeholder.
+This reduces directly to `zcl_iff_idempotent_transfer` (Theorem 3.8).
 -/
 
 open scoped Matrix
@@ -33,12 +33,11 @@ tensor, RFP is equivalent to ZCL.
 The full theorem also includes equivalence with the NNCPH condition; that
 direction is deferred.
 
-TODO: assemble the proof from `zcl_iff_idempotent_transfer` and the
-structural form results. -/
+Proved by `zcl_iff_idempotent_transfer.symm`. -/
 theorem rfp_iff_zcl {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalForm μ A) (k : Fin r) :
-    IsRFP (A k) ↔ IsZCL (A k) := by
-  sorry
+    IsRFP (A k) ↔ IsZCL (A k) :=
+  (zcl_iff_idempotent_transfer μ A hCF k).symm
 
 end MPSTensor

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -37,8 +37,8 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- **Lemma B.1** (arXiv:1606.00608, Appendix B): A normal tensor `A` is RFP
-iff there exist an invertible matrix `X`, a positive diagonal matrix `Λ`
+/-- **Lemma B.1** (arXiv:1606.00608, Appendix B): If a normal tensor `A` is RFP,
+then there exist an invertible matrix `X`, a positive diagonal matrix `Λ`
 with `tr(Λ) = 1`, and an isometry `U` on the physical index such that
 `A i = X * Λ * U i * X⁻¹` for all `i`.
 
@@ -63,10 +63,13 @@ theorem rfp_nt_structural (A : MPSTensor d D)
   sorry
 
 /-- **Theorem 3.11** (arXiv:1606.00608): For a canonical-form tensor that is
-RFP, the full block-diagonal structural form holds:
-`A^i_k = μ_k X_k Λ_k U^i_k X_k⁻¹`
-with `|μ_k| = 1` for `k ≥ 1`, `Λ_k` diagonal positive, `tr(Λ_k) = 1`,
-and `U_k` isometries satisfying the orthogonality condition (eq. 19).
+RFP, each block admits an invertible `X_k`, positive diagonal `Λ_k` with
+`tr(Λ_k) = 1`, and isometries `U_k` from Lemma B.1.
+
+Note: the full structural form in the paper also includes phase weights
+`μ_k` and the representation equation `A^i_k = μ_k X_k Λ_k U^i_k X_k⁻¹`;
+these are already captured by `IsCanonicalForm` and `rfp_nt_structural`
+respectively, so this theorem only re-exports the `X, Λ, U` portion.
 
 Proved by reducing to `rfp_nt_structural`: each CF block is injective
 (from `IsCanonicalForm`), hence normal (via `IsInjective.isNormal`). -/

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -66,10 +66,8 @@ theorem rfp_nt_structural (A : MPSTensor d D)
 RFP, each block admits an invertible `X_k`, positive diagonal `Λ_k` with
 `tr(Λ_k) = 1`, and isometries `U_k` from Lemma B.1.
 
-Note: the full structural form in the paper also includes phase weights
-`μ_k` and the representation equation `A^i_k = μ_k X_k Λ_k U^i_k X_k⁻¹`;
-these are already captured by `IsCanonicalForm` and `rfp_nt_structural`
-respectively, so this theorem only re-exports the `X, Λ, U` portion.
+The conclusion includes the representation equation
+`A^i_k = X_k Λ_k U^i_k X_k⁻¹` from Lemma B.1 for each block `k`.
 
 Proved by reducing to `rfp_nt_structural`: each CF block is injective
 (from `IsCanonicalForm`), hence normal (via `IsInjective.isNormal`). -/
@@ -82,11 +80,12 @@ theorem rfp_cf_structural {r : ℕ} {dim : Fin r → ℕ}
       IsUnit X ∧
       (∀ j, 0 ≤ Λ j) ∧
       (∑ j, (Λ j : ℂ) = 1) ∧
-      (∀ i, (U i).conjTranspose * U i = 1) := by
+      (∀ i, (U i).conjTranspose * U i = 1) ∧
+      ∀ i, A k i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) *
+        U i * Ring.inverse X := by
   intro k
   have hNormal : IsNormal (A k) := (hCF.block_injective k).isNormal
-  obtain ⟨X, Λ, U, hX, hΛ, htr, hU, _⟩ := rfp_nt_structural (A k) hNormal (hRFP k)
-  exact ⟨X, Λ, U, hX, hΛ, htr, hU⟩
+  exact rfp_nt_structural (A k) hNormal (hRFP k)
 
 /-- **Corollary 3.12** (arXiv:1606.00608): The BNT elements of an RFP tensor
 each have the form `A_j^i = X_j Λ_j U^i_j X_j⁻¹` from Lemma B.1.

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -14,13 +14,21 @@ This file states the structural characterisation theorems for MPS tensors
 that are renormalization fixed points, following arXiv:1606.00608 §3.4
 (Cirac–Pérez-García–Schuch–Verstraete) and Appendix B.
 
-## Main results (all `sorry` — statements only)
+## Main results
 
 * **Lemma B.1** (`rfp_nt_structural`): RFP normal tensor implies rank-1 transfer map — `sorry`
-* **Theorem 3.11** (`rfp_cf_structural`): RFP canonical-form block decomposition — `sorry`
-* **Corollary 3.12** (`rfp_bnt_structural`): BNT elements inherit structural form — `sorry`
+* **Theorem 3.11** (`rfp_cf_structural`): RFP canonical-form block decomposition — proved
+  from `rfp_nt_structural`
+* **Corollary 3.12** (`rfp_bnt_structural`): BNT elements inherit structural form — proved
+  from `rfp_nt_structural`
 
-These state the structural characterisation but none are proved yet.
+## Proof strategy
+
+`rfp_cf_structural` and `rfp_bnt_structural` reduce to `rfp_nt_structural` via the bridge
+`IsInjective.isNormal` (each CF/BNT block is injective, hence normal). The remaining sorry
+is concentrated in `rfp_nt_structural`, which requires:
+1. Rank-1 projector characterization of idempotent CP maps (not yet formalized)
+2. Rectangular Kraus freedom theorem (not yet formalized)
 -/
 
 open scoped Matrix
@@ -39,7 +47,8 @@ projector `|R)(L|`; decompose `R = Λ` (diagonal positive), `L = 𝟙`;
 then any Kraus representation giving this CPM is related to the canonical
 one by an isometry `U` (Stinespring).
 
-TODO: prove. -/
+TODO: prove — blocked on (1) rank-1 characterization of idempotent CPTP maps
+and (2) rectangular Kraus freedom theorem. -/
 theorem rfp_nt_structural (A : MPSTensor d D)
     (hNT : IsNormal A) (hRFP : IsRFP A) :
     ∃ (X : Matrix (Fin D) (Fin D) ℂ)
@@ -59,7 +68,8 @@ RFP, the full block-diagonal structural form holds:
 with `|μ_k| = 1` for `k ≥ 1`, `Λ_k` diagonal positive, `tr(Λ_k) = 1`,
 and `U_k` isometries satisfying the orthogonality condition (eq. 19).
 
-TODO: prove. -/
+Proved by reducing to `rfp_nt_structural`: each CF block is injective
+(from `IsCanonicalForm`), hence normal (via `IsInjective.isNormal`). -/
 theorem rfp_cf_structural {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalForm μ A) (hRFP : ∀ k, IsRFP (A k)) :
@@ -70,12 +80,16 @@ theorem rfp_cf_structural {r : ℕ} {dim : Fin r → ℕ}
       (∀ j, 0 ≤ Λ j) ∧
       (∑ j, (Λ j : ℂ) = 1) ∧
       (∀ i, (U i).conjTranspose * U i = 1) := by
-  sorry
+  intro k
+  have hNormal : IsNormal (A k) := (hCF.block_injective k).isNormal
+  obtain ⟨X, Λ, U, hX, hΛ, htr, hU, _⟩ := rfp_nt_structural (A k) hNormal (hRFP k)
+  exact ⟨X, Λ, U, hX, hΛ, htr, hU⟩
 
 /-- **Corollary 3.12** (arXiv:1606.00608): The BNT elements of an RFP tensor
 each have the form `A_j^i = X_j Λ_j U^i_j X_j⁻¹` from Lemma B.1.
 
-TODO: prove from `rfp_nt_structural`. -/
+Proved by reducing to `rfp_nt_structural`: `IsCanonicalFormBNT` extends
+`IsCanonicalForm`, so each block is injective, hence normal. -/
 theorem rfp_bnt_structural {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) (hRFP : ∀ k, IsRFP (A k)) :
@@ -88,6 +102,8 @@ theorem rfp_bnt_structural {r : ℕ} {dim : Fin r → ℕ}
       (∀ i, (U i).conjTranspose * U i = 1) ∧
       ∀ i, A k i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) *
         U i * Ring.inverse X := by
-  sorry
+  intro k
+  have hNormal : IsNormal (A k) := (hCF.toIsCanonicalForm.block_injective k).isNormal
+  exact rfp_nt_structural (A k) hNormal (hRFP k)
 
 end MPSTensor


### PR DESCRIPTION
### Motivation

- Continues formalization of pure-state renormalization fixed points (RFP) from arXiv:1606.00608 §3, see #233.
- Reduces independent `sorry` count in the RFP module from 8 to 5 by wiring existing theorems together.

### Description

- **`TNLean/MPS/Defs.lean`**: Add `IsInjective.isNormal` — 1-block injectivity implies `IsNormal`.
- **`TNLean/MPS/RFP/StructuralForm.lean`**: Prove `rfp_cf_structural` (Thm 3.11) and `rfp_bnt_structural` (Cor 3.12) by reducing to `rfp_nt_structural`.
- **`TNLean/MPS/RFP/Assembly.lean`**: Prove `rfp_iff_zcl` (Thm 3.10) by rewriting as `(zcl_iff_idempotent_transfer …).symm`.
- Remaining `sorry`s: `rfp_nt_structural` (needs rank-1 CP characterisation + Kraus freedom), `IsCID` (needs twoPointCorrelation infrastructure), `zcl_iff_idempotent_transfer` (blocked on IsCID), `rg_flow_converges_of_cf` (convergence theory), `isRFP_iff_kraus_isometry` forward direction (rectangular Kraus freedom).

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #233

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are Lean proof refactors/wiring that remove `sorry`s and add a small lemma (`IsInjective.isNormal`) without altering core definitions or runtime behavior.
> 
> **Overview**
> Proves previously-placeholder RFP results by reusing existing theorems: `rfp_iff_zcl` is now exactly `(zcl_iff_idempotent_transfer …).symm`, and `rfp_cf_structural`/`rfp_bnt_structural` are discharged by reducing each canonical-form/BNT block to the remaining `rfp_nt_structural` lemma.
> 
> Adds the bridge lemma `IsInjective.isNormal` (1-block injectivity ⇒ eventual block injectivity) and uses it to simplify BNT construction (`isBNT_of_separated_CFBNT_data`) by replacing an inlined normality proof with `(hInj.block_injective j).isNormal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93aaf72fd643921cbcf30a4ddb8aceb69a28892e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->