### PR TITLE
feat(MPS/ParentHamiltonian): add orthogonal projector and site embedding

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -58,34 +58,34 @@ complement sites — exactly the structure of `groundSpaceMap A L`.
 Dependencies: needs round-trip / decomposition lemmas for `extractWindow`/`replaceWindow`
 relating `List.ofFn (replaceWindow L i σ τ)` to `List.ofFn τ` and complement indices.
 Requires `L ≤ N` hypothesis (or `N`-periodicity argument). -/
-lemma mpv_window_mem_groundSpace (A : MPSTensor d D) (L N : ℕ)
+lemma mpv_window_mem_groundSpace (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N)
     (i : Fin N) (σ : Cfg d N) :
-    (fun τ => mpv A (replaceWindow L i σ τ)) ∈ groundSpace A L := by
+    (fun τ => mpv A (replaceWindow L hLN i σ τ)) ∈ groundSpace A L := by
   sorry
 
 /-- Each local term annihilates the MPV state. -/
-lemma localTerm_annihilates_mpv (A : MPSTensor d D) (L N : ℕ) (i : Fin N) :
+lemma localTerm_annihilates_mpv (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
     localTerm A L N i (mpv A) = 0 := by
   ext σ
-  simp only [localTerm, LinearMap.pi_apply, LinearMap.comp_apply, LinearMap.proj_apply,
-    Pi.zero_apply]
-  have hmem := mpv_window_mem_groundSpace A L N i σ
+  simp only [localTerm, hLN, ↓reduceDIte, LinearMap.pi_apply, LinearMap.comp_apply,
+    LinearMap.proj_apply, Pi.zero_apply]
+  have hmem := mpv_window_mem_groundSpace A L N hLN i σ
   have hkill := parentInteraction_apply_mem_groundSpace A L _ hmem
-  change (parentInteraction A L (fun τ => mpv A (replaceWindow L i σ τ)))
+  change (parentInteraction A L (fun τ => mpv A (replaceWindow L hLN i σ τ)))
     (extractWindow L i σ) = 0
   rw [hkill]
   rfl
 
 /-- The parent Hamiltonian annihilates the MPV state: `H_N |ψ(A)⟩ = 0`. -/
-lemma parentHamiltonian_annihilates (A : MPSTensor d D) (L N : ℕ) :
+lemma parentHamiltonian_annihilates (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) :
     parentHamiltonian A L N (mpv A) = 0 := by
   simp only [parentHamiltonian, LinearMap.sum_apply]
-  exact Finset.sum_eq_zero fun i _ => localTerm_annihilates_mpv A L N i
+  exact Finset.sum_eq_zero fun i _ => localTerm_annihilates_mpv A L N hLN i
 
 /-- The parent Hamiltonian model is frustration-free on the MPV state:
 each local term individually annihilates `mpv A`. -/
-lemma parentHamiltonian_frustrationFree (A : MPSTensor d D) (L N : ℕ) :
+lemma parentHamiltonian_frustrationFree (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) :
     IsFrustrationFree A L N (mpv A) :=
-  fun i => localTerm_annihilates_mpv A L N i
+  fun i => localTerm_annihilates_mpv A L N hLN i
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -22,57 +22,87 @@ onto `(groundSpace A L)ᗮ`, so it kills everything in `groundSpace A L`. -/
 lemma parentInteraction_apply_mem_groundSpace (A : MPSTensor d D) (L : ℕ)
     (v : NSiteSpace d L) (hv : v ∈ groundSpace A L) :
     parentInteraction A L v = 0 := by
-  -- v ∈ groundSpace means e.symm v ∈ groundSpaceES
   have hmem : (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm v ∈ groundSpaceES A L := by
     simp only [groundSpaceES, Submodule.mem_map]
     exact ⟨v, hv, rfl⟩
-  -- The starProjection of Vᗮ kills elements of V:
-  -- Uᗮ.starProjection = 1 - U.starProjection, and U.starProjection fixes members of U.
   have hkill : (groundSpaceES A L)ᗮ.starProjection
       ((WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm v) = 0 := by
     rw [Submodule.starProjection_orthogonal']
     simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.one_apply]
     rw [sub_eq_zero]
     exact (Submodule.starProjection_eq_self_iff.mpr hmem).symm
-  -- parentInteraction unfolds to e ∘ starProjection.toLinearMap ∘ e⁻¹
   change (WithLp.linearEquiv 2 ℂ (NSiteSpace d L))
     ((groundSpaceES A L)ᗮ.starProjection
       ((WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm v)) = 0
   rw [hkill, map_zero]
 
+/-! ### Cyclic trace invariance -/
+
+/-- Trace of evalWord is invariant under cyclic swap of concatenated words. -/
+private lemma trace_evalWord_append_comm (A : MPSTensor d D) (w₁ w₂ : List (Fin d)) :
+    Matrix.trace (evalWord A (w₁ ++ w₂)) = Matrix.trace (evalWord A (w₂ ++ w₁)) := by
+  rw [evalWord_append, evalWord_append, Matrix.trace_mul_comm]
+
+/-! ### MPS window membership -/
+
 /-- The MPS state restricted to any window of `L` sites lies in `groundSpace A L`.
 
 The witness is the "complement matrix": the product of `A`-matrices on sites
-outside the `L`-site window, cyclically ordered starting from `i + L`:
-`X = evalWord A [σ(i+L), σ(i+L+1), …, σ(i-1)]` (indices mod `N`).
-
-Then `groundSpaceMap A L X τ = tr(evalWord A (List.ofFn τ) * X)`, and we need
-this to equal `mpv A (replaceWindow L hLN i σ τ) = tr(evalWord A (List.ofFn (replaceWindow …)))`.
-
-**Status: sorry** — The remaining proof obligation is:
-```
-tr(evalWord A (List.ofFn τ) * complementMatrix) = tr(evalWord A (List.ofFn (replaceWindow …)))
-```
-which follows from:
-1. `List.ofFn (replaceWindow L hLN i σ τ)` decomposes as `before_σ ++ List.ofFn τ ++ after_σ`
-   (non-wrapping case; wrapping case needs periodic reindexing).
-2. `evalWord_append` factors the matrix product into three pieces.
-3. `Matrix.trace_mul_cycle` rewrites `tr(before * window * after)` as
-   `tr(window * after * before)`.
-4. `after ++ before` is exactly the complement list. -/
+outside the `L`-site window, cyclically ordered starting from `i + L`. The proof
+uses trace cyclicity to rotate the full `N`-site product so that the window
+indices come first, matching the `groundSpaceMap` definition. -/
 lemma mpv_window_mem_groundSpace (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N)
     (i : Fin N) (σ : Cfg d N) :
     (fun τ => mpv A (replaceWindow L hLN i σ τ)) ∈ groundSpace A L := by
   rw [groundSpace, LinearMap.mem_range]
-  -- Witness: product of A-matrices on complement sites (i+L to i-1 cyclically)
+  have hN : 0 < N := Nat.lt_of_lt_of_le (Fin.pos i) le_rfl
   refine ⟨evalWord A (List.ofFn fun (j : Fin (N - L)) =>
-    σ ⟨(i.val + L + j.val) % N, Nat.mod_lt _ (by have := i.isLt; omega)⟩), ?_⟩
+    σ ⟨(i.val + L + j.val) % N, Nat.mod_lt _ (by omega)⟩), ?_⟩
   ext τ
   simp only [groundSpaceMap_apply, mpv, coeff]
-  -- Remaining: tr(evalWord A (List.ofFn τ) * complementMatrix)
-  --          = tr(evalWord A (List.ofFn (replaceWindow L hLN i σ τ)))
-  -- Requires list decomposition + trace cyclicity (see docstring).
-  sorry
+  rw [← evalWord_append]
+  -- Goal: tr(evalWord A (List.ofFn τ ++ compList))
+  --     = tr(evalWord A (List.ofFn (replaceWindow L hLN i σ τ)))
+  set compList := List.ofFn fun (j : Fin (N - L)) =>
+    σ ⟨(i.val + L + j.val) % N, Nat.mod_lt _ (by omega)⟩
+  -- Rotate the RHS by i positions using trace cyclicity
+  suffices hlist :
+      (List.ofFn (replaceWindow L hLN i σ τ)).rotate i.val =
+      List.ofFn τ ++ compList by
+    have hle : i.val ≤ (List.ofFn (replaceWindow L hLN i σ τ)).length := by
+      simp [List.length_ofFn]
+    rw [← hlist, List.rotate_eq_drop_append_take hle,
+        trace_evalWord_append_comm, List.take_append_drop]
+  -- Prove the rotated list equals τ ++ complement elementwise
+  apply List.ext_getElem
+  · have : compList.length = N - L := by simp [compList, List.length_ofFn]
+    simp only [List.length_rotate, List.length_append, List.length_ofFn]
+    omega
+  · intro k hk1 hk2
+    have hkN : k < N := by simp only [List.length_rotate, List.length_ofFn] at hk1; exact hk1
+    simp only [List.getElem_rotate, List.getElem_ofFn, List.length_ofFn]
+    -- Unfold replaceWindow at position ⟨(k + i) % N, _⟩
+    change (if h : ((k + i.val) % N + N - i.val) % N < L
+      then τ ⟨((k + i.val) % N + N - i.val) % N, h⟩
+      else σ ⟨(k + i.val) % N, Nat.mod_lt _ hN⟩) = _
+    -- The offset always equals k (regardless of wrapping)
+    have hoffset : ((k + i.val) % N + N - i.val) % N = k := by
+      rcases lt_or_ge (k + i.val) N with h | h
+      · rw [Nat.mod_eq_of_lt h, show k + i.val + N - i.val = k + N from by omega,
+            Nat.add_mod_right, Nat.mod_eq_of_lt hkN]
+      · rw [Nat.mod_eq_sub_mod h, Nat.mod_eq_of_lt (by omega : k + i.val - N < N),
+            show k + i.val - N + N - i.val = k from by omega, Nat.mod_eq_of_lt hkN]
+    rw [hoffset]
+    by_cases hkL : k < L
+    · -- Window part → τ
+      rw [dif_pos hkL, List.getElem_append_left (by simp only [List.length_ofFn]; exact hkL),
+          List.getElem_ofFn]
+    · -- Complement part → σ
+      rw [dif_neg hkL, List.getElem_append_right (by simp; omega), List.getElem_ofFn]
+      simp only [List.length_ofFn]
+      congr 1; apply Fin.ext
+      change (k + i.val) % N = (i.val + L + (k - L)) % N
+      rw [show i.val + L + (k - L) = k + i.val from by omega]
 
 /-- Each local term annihilates the MPV state. -/
 lemma localTerm_annihilates_mpv (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :

--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -41,26 +41,37 @@ lemma parentInteraction_apply_mem_groundSpace (A : MPSTensor d D) (L : ℕ)
   rw [hkill, map_zero]
 
 /-- The MPS state restricted to any window of `L` sites lies in `groundSpace A L`.
-This is because `mpv A (replaceWindow L i σ τ)` has the form
-`tr(evalWord A (List.ofFn τ) * X)` where `X` is the product of matrices on the
-complement sites — exactly the structure of `groundSpaceMap A L`.
 
-**Status: sorry** — Proof strategy (trace cyclicity argument):
-1. Show `List.ofFn (replaceWindow L i σ τ)` decomposes into window and complement
-   segments via `List.ofFn_fin_append` / periodic reindexing.
-2. Apply `evalWord_append` to factor the matrix product into window × complement.
-3. Use `Matrix.trace_mul_comm` (trace cyclicity) to rewrite
-   `tr(M_before * M_window * M_after)` as `tr(M_window * M_after * M_before)`.
-4. Identify the result as `groundSpaceMap A L X τ` where
-   `X = evalWord A (complement_after) * evalWord A (complement_before)`.
-5. Conclude via `LinearMap.mem_range`.
+The witness is the "complement matrix": the product of `A`-matrices on sites
+outside the `L`-site window, cyclically ordered starting from `i + L`:
+`X = evalWord A [σ(i+L), σ(i+L+1), …, σ(i-1)]` (indices mod `N`).
 
-Dependencies: needs round-trip / decomposition lemmas for `extractWindow`/`replaceWindow`
-relating `List.ofFn (replaceWindow L i σ τ)` to `List.ofFn τ` and complement indices.
-Requires `L ≤ N` hypothesis (or `N`-periodicity argument). -/
+Then `groundSpaceMap A L X τ = tr(evalWord A (List.ofFn τ) * X)`, and we need
+this to equal `mpv A (replaceWindow L hLN i σ τ) = tr(evalWord A (List.ofFn (replaceWindow …)))`.
+
+**Status: sorry** — The remaining proof obligation is:
+```
+tr(evalWord A (List.ofFn τ) * complementMatrix) = tr(evalWord A (List.ofFn (replaceWindow …)))
+```
+which follows from:
+1. `List.ofFn (replaceWindow L hLN i σ τ)` decomposes as `before_σ ++ List.ofFn τ ++ after_σ`
+   (non-wrapping case; wrapping case needs periodic reindexing).
+2. `evalWord_append` factors the matrix product into three pieces.
+3. `Matrix.trace_mul_cycle` rewrites `tr(before * window * after)` as
+   `tr(window * after * before)`.
+4. `after ++ before` is exactly the complement list. -/
 lemma mpv_window_mem_groundSpace (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N)
     (i : Fin N) (σ : Cfg d N) :
     (fun τ => mpv A (replaceWindow L hLN i σ τ)) ∈ groundSpace A L := by
+  rw [groundSpace, LinearMap.mem_range]
+  -- Witness: product of A-matrices on complement sites (i+L to i-1 cyclically)
+  refine ⟨evalWord A (List.ofFn fun (j : Fin (N - L)) =>
+    σ ⟨(i.val + L + j.val) % N, Nat.mod_lt _ (by have := i.isLt; omega)⟩), ?_⟩
+  ext τ
+  simp only [groundSpaceMap_apply, mpv, coeff]
+  -- Remaining: tr(evalWord A (List.ofFn τ) * complementMatrix)
+  --          = tr(evalWord A (List.ofFn (replaceWindow L hLN i σ τ)))
+  -- Requires list decomposition + trace cyclicity (see docstring).
   sorry
 
 /-- Each local term annihilates the MPV state. -/

--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -8,7 +8,7 @@ It therefore annihilates any vector in the ground space. The MPS state `mpv A`
 lies in the ground space at every window, which gives frustration-freeness.
 -/
 
-open scoped Matrix BigOperators
+open scoped BigOperators
 
 namespace MPSTensor
 
@@ -43,7 +43,21 @@ lemma parentInteraction_apply_mem_groundSpace (A : MPSTensor d D) (L : ℕ)
 /-- The MPS state restricted to any window of `L` sites lies in `groundSpace A L`.
 This is because `mpv A (replaceWindow L i σ τ)` has the form
 `tr(evalWord A (List.ofFn τ) * X)` where `X` is the product of matrices on the
-complement sites — exactly the structure of `groundSpaceMap A L`. -/
+complement sites — exactly the structure of `groundSpaceMap A L`.
+
+**Status: sorry** — Proof strategy (trace cyclicity argument):
+1. Show `List.ofFn (replaceWindow L i σ τ)` decomposes into window and complement
+   segments via `List.ofFn_fin_append` / periodic reindexing.
+2. Apply `evalWord_append` to factor the matrix product into window × complement.
+3. Use `Matrix.trace_mul_comm` (trace cyclicity) to rewrite
+   `tr(M_before * M_window * M_after)` as `tr(M_window * M_after * M_before)`.
+4. Identify the result as `groundSpaceMap A L X τ` where
+   `X = evalWord A (complement_after) * evalWord A (complement_before)`.
+5. Conclude via `LinearMap.mem_range`.
+
+Dependencies: needs round-trip / decomposition lemmas for `extractWindow`/`replaceWindow`
+relating `List.ofFn (replaceWindow L i σ τ)` to `List.ofFn τ` and complement indices.
+Requires `L ≤ N` hypothesis (or `N`-periodicity argument). -/
 lemma mpv_window_mem_groundSpace (A : MPSTensor d D) (L N : ℕ)
     (i : Fin N) (σ : Cfg d N) :
     (fun τ => mpv A (replaceWindow L i σ τ)) ∈ groundSpace A L := by

--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -31,6 +31,8 @@ lemma parentInteraction_apply_mem_groundSpace (A : MPSTensor d D) (L : ℕ)
     simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.one_apply]
     rw [sub_eq_zero]
     exact (Submodule.starProjection_eq_self_iff.mpr hmem).symm
+  -- Unfold `parentInteraction` to expose the equiv ∘ projection ∘ equiv⁻¹ structure.
+  -- This `change` is definitional; update it if `parentInteraction` is refactored.
   change (WithLp.linearEquiv 2 ℂ (NSiteSpace d L))
     ((groundSpaceES A L)ᗮ.starProjection
       ((WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm v)) = 0

--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -3,34 +3,75 @@ import TNLean.MPS.ParentHamiltonian.Defs
 /-!
 # Basic parent-Hamiltonian properties
 
-Initial API lemmas: the MPV is annihilated by the parent Hamiltonian and the
-model is frustration-free on that state.
+The parent interaction is the orthogonal projector onto `(groundSpace A L)ᗮ`.
+It therefore annihilates any vector in the ground space. The MPS state `mpv A`
+lies in the ground space at every window, which gives frustration-freeness.
 -/
+
+open scoped Matrix BigOperators
 
 namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- **PLACEHOLDER — VACUOUSLY TRUE**: The parent Hamiltonian annihilates the MPV state.
+/-! ### Key lemma: parent interaction kills ground space elements -/
 
-This lemma compiles without `sorry` but is currently **vacuously true** because
-`parentInteraction` and `localTerm` are zero placeholders (see `Defs.lean`).
-The proof is literally `0 = 0` and must be completely rewritten once the real
-projector and embedding implementations replace the zero definitions. Do **not**
-cite this as a proven result. -/
+/-- The parent interaction annihilates any vector in the ground space.
+This is the core property: `parentInteraction A L` is the orthogonal projector
+onto `(groundSpace A L)ᗮ`, so it kills everything in `groundSpace A L`. -/
+lemma parentInteraction_apply_mem_groundSpace (A : MPSTensor d D) (L : ℕ)
+    (v : NSiteSpace d L) (hv : v ∈ groundSpace A L) :
+    parentInteraction A L v = 0 := by
+  -- v ∈ groundSpace means e.symm v ∈ groundSpaceES
+  have hmem : (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm v ∈ groundSpaceES A L := by
+    simp only [groundSpaceES, Submodule.mem_map]
+    exact ⟨v, hv, rfl⟩
+  -- The starProjection of Vᗮ kills elements of V:
+  -- Uᗮ.starProjection = 1 - U.starProjection, and U.starProjection fixes members of U.
+  have hkill : (groundSpaceES A L)ᗮ.starProjection
+      ((WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm v) = 0 := by
+    rw [Submodule.starProjection_orthogonal']
+    simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.one_apply]
+    rw [sub_eq_zero]
+    exact (Submodule.starProjection_eq_self_iff.mpr hmem).symm
+  -- parentInteraction unfolds to e ∘ starProjection.toLinearMap ∘ e⁻¹
+  change (WithLp.linearEquiv 2 ℂ (NSiteSpace d L))
+    ((groundSpaceES A L)ᗮ.starProjection
+      ((WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm v)) = 0
+  rw [hkill, map_zero]
+
+/-- The MPS state restricted to any window of `L` sites lies in `groundSpace A L`.
+This is because `mpv A (replaceWindow L i σ τ)` has the form
+`tr(evalWord A (List.ofFn τ) * X)` where `X` is the product of matrices on the
+complement sites — exactly the structure of `groundSpaceMap A L`. -/
+lemma mpv_window_mem_groundSpace (A : MPSTensor d D) (L N : ℕ)
+    (i : Fin N) (σ : Cfg d N) :
+    (fun τ => mpv A (replaceWindow L i σ τ)) ∈ groundSpace A L := by
+  sorry
+
+/-- Each local term annihilates the MPV state. -/
+lemma localTerm_annihilates_mpv (A : MPSTensor d D) (L N : ℕ) (i : Fin N) :
+    localTerm A L N i (mpv A) = 0 := by
+  ext σ
+  simp only [localTerm, LinearMap.pi_apply, LinearMap.comp_apply, LinearMap.proj_apply,
+    Pi.zero_apply]
+  have hmem := mpv_window_mem_groundSpace A L N i σ
+  have hkill := parentInteraction_apply_mem_groundSpace A L _ hmem
+  change (parentInteraction A L (fun τ => mpv A (replaceWindow L i σ τ)))
+    (extractWindow L i σ) = 0
+  rw [hkill]
+  rfl
+
+/-- The parent Hamiltonian annihilates the MPV state: `H_N |ψ(A)⟩ = 0`. -/
 lemma parentHamiltonian_annihilates (A : MPSTensor d D) (L N : ℕ) :
     parentHamiltonian A L N (mpv A) = 0 := by
-  simp [parentHamiltonian, localTerm]
+  simp only [parentHamiltonian, LinearMap.sum_apply]
+  exact Finset.sum_eq_zero fun i _ => localTerm_annihilates_mpv A L N i
 
-/-- **PLACEHOLDER — VACUOUSLY TRUE**: The parent Hamiltonian model is frustration-free
-on the MPV state.
-
-This lemma compiles without `sorry` but is currently **vacuously true** because
-`localTerm` is a zero placeholder (see `Defs.lean`). Do **not** cite this as a
-proven result. -/
+/-- The parent Hamiltonian model is frustration-free on the MPV state:
+each local term individually annihilates `mpv A`. -/
 lemma parentHamiltonian_frustrationFree (A : MPSTensor d D) (L N : ℕ) :
-    IsFrustrationFree A L N (mpv A) := by
-  intro i
-  simp [localTerm]
+    IsFrustrationFree A L N (mpv A) :=
+  fun i => localTerm_annihilates_mpv A L N i
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -38,10 +38,11 @@ variable {d D : ℕ}
 
 /-! ### Transport between `NSiteSpace` and `EuclideanSpace`
 
-`NSiteSpace d L = Cfg d L → ℂ` and `EuclideanSpace ℂ (Cfg d L) = PiLp 2 (fun _ => ℂ)`
-are definitionally the same type with the same module structure. We use
-`WithLp.linearEquiv` to transport the ground space to `EuclideanSpace`, where
-Mathlib provides `InnerProductSpace` and orthogonal projection. -/
+`NSiteSpace d L = Cfg d L → ℂ` and `EuclideanSpace ℂ (Cfg d L)` is the same underlying
+function space equipped with the ℓ²-structure via `WithLp 2` (concretely,
+`EuclideanSpace ℂ (Cfg d L) = WithLp 2 (Cfg d L → ℂ)`). We use
+`WithLp.linearEquiv` to transport the ground space to `EuclideanSpace`, where Mathlib
+provides `InnerProductSpace` and orthogonal projection. -/
 
 /-- The ground space of `A` on `L` sites, viewed as a submodule of
 `EuclideanSpace ℂ (Cfg d L)` (same underlying submodule, different typeclass
@@ -65,15 +66,23 @@ noncomputable def parentInteraction (A : MPSTensor d D) (L : ℕ) :
 
 /-! ### Window extraction and replacement (periodic boundary conditions) -/
 
-/-- Extract `L` consecutive site values from an `N`-site configuration `σ`,
-starting at position `i` with periodic boundary conditions. -/
-def extractWindow (L : ℕ) {N : ℕ} (i : Fin N) (σ : Cfg d N) : Cfg d L :=
+/-- Extract `L` consecutive values from an `N`-periodic sequence `σ`,
+starting at position `i` with periodic boundary conditions.
+
+Note: when `L > N`, indices wrap and may revisit the same positions. The
+intended use case is `L ≤ N` (e.g., the window size is at most the chain
+length). -/
+def extractWindow (L : ℕ) {N : ℕ} {α : Type*} (i : Fin N) (σ : Fin N → α) : Fin L → α :=
   have hN : 0 < N := i.val.zero_le.trans_lt i.isLt
   fun j => σ ⟨(i.val + j.val) % N, Nat.mod_lt _ hN⟩
 
-/-- Replace `L` consecutive site values in an `N`-site configuration `σ`,
-starting at position `i`, with values from `τ` (periodic boundary conditions). -/
-def replaceWindow (L : ℕ) {N : ℕ} (i : Fin N) (σ : Cfg d N) (τ : Cfg d L) : Cfg d N :=
+/-- Replace `L` consecutive values in an `N`-periodic sequence `σ`,
+starting at position `i`, with values from `τ` (periodic boundary conditions).
+
+Note: when `L > N`, positions beyond index `N-1` in `τ` are silently
+ignored because `offset` is always `< N`. The intended use case is `L ≤ N`. -/
+def replaceWindow (L : ℕ) {N : ℕ} {α : Type*} (i : Fin N) (σ : Fin N → α) (τ : Fin L → α) :
+    Fin N → α :=
   fun k =>
     let offset := (k.val + N - i.val) % N
     if h : offset < L then τ ⟨offset, h⟩ else σ k
@@ -95,7 +104,7 @@ noncomputable def localTerm (A : MPSTensor d D) (L N : ℕ) (i : Fin N) :
     (LinearMap.proj (extractWindow L i σ) : NSiteSpace d L →ₗ[ℂ] ℂ).comp
       ((parentInteraction A L).comp
         (LinearMap.pi fun τ =>
-          (LinearMap.proj (replaceWindow (d := d) L i σ τ) : NSiteSpace d N →ₗ[ℂ] ℂ)))
+          (LinearMap.proj (replaceWindow L i σ τ) : NSiteSpace d N →ₗ[ℂ] ℂ)))
 
 /-- Parent Hamiltonian on an `N`-site periodic chain:
 sum of translated local interaction terms. -/

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -82,13 +82,31 @@ variable {N : ℕ}
 starting at position `i`, with values from `τ` (periodic boundary conditions).
 
 Requires `L ≤ N` to ensure the `L`-site window is represented faithfully. -/
-def replaceWindow (L : ℕ) (hLN : L ≤ N) {α : Type*}
+def replaceWindow (L : ℕ) (_hLN : L ≤ N) {α : Type*}
     (i : Fin N) (σ : Fin N → α) (τ : Fin L → α) :
     Fin N → α :=
   fun k =>
-    let _hLN : L ≤ N := hLN
     let offset := (k.val + N - i.val) % N
     if h : offset < L then τ ⟨offset, h⟩ else σ k
+
+private lemma offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
+    ((a + b) % N + N - a) % N = b := by
+  rcases lt_or_ge (a + b) N with hab | hab
+  · rw [Nat.mod_eq_of_lt hab, show a + b + N - a = b + N from by omega,
+      Nat.add_mod_right, Nat.mod_eq_of_lt hb]
+  · rw [Nat.mod_eq_sub_mod hab, Nat.mod_eq_of_lt (by omega : a + b - N < N),
+      show a + b - N + N - a = b from by omega, Nat.mod_eq_of_lt hb]
+
+/-- Extracting a window after replacing it recovers the replacement values. -/
+@[simp] lemma extractWindow_replaceWindow (L : ℕ) (hLN : L ≤ N) {α : Type*}
+    (i : Fin N) (σ : Fin N → α) (τ : Fin L → α) :
+    extractWindow L i (replaceWindow L hLN i σ τ) = τ := by
+  funext ⟨j, hj⟩
+  unfold extractWindow replaceWindow
+  have key : ((i.val + j) % N + N - i.val) % N = j :=
+    offset_mod_eq i.isLt (Nat.lt_of_lt_of_le hj hLN)
+  rw [dif_pos (show ((i.val + j) % N + N - i.val) % N < L by rw [key]; exact hj)]
+  exact congr_arg τ (Fin.ext key)
 
 /-! ### Local term (site embedding) -/
 

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -114,6 +114,9 @@ private lemma offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
 `parentInteraction A L` at site `i`, acting on the window
 `{i, i+1, …, i+L-1 mod N}` and as identity on the complement.
 
+When `L > N` the definition returns `0`; all lemmas in `Basic.lean`
+carry the hypothesis `hLN : L ≤ N` so this branch is never reached.
+
 For `f : NSiteSpace d N` and output configuration `σ`:
 ```
 (localTerm A L N i f)(σ) = (parentInteraction A L (fun τ ↦ f (replaceWindow L i σ τ)))

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -1,14 +1,33 @@
 import TNLean.MPS.ParentHamiltonian.GroundSpace
 
+import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+
 /-!
 # Parent interaction and parent Hamiltonian (definitions)
 
 This file introduces the parent interaction projector, translated local terms,
 and the finite-chain parent Hamiltonian.
 
-**Warning**: `parentInteraction` and `localTerm` are currently **zero
-placeholders**. All downstream results (annihilation, frustration-freeness)
-are vacuously true until the real projector/embedding definitions are added.
+## Main definitions
+
+* `MPSTensor.parentInteraction A L` — the orthogonal projector onto `(groundSpace A L)ᗮ`,
+  as a linear map on `NSiteSpace d L`. This is a PSD operator whose kernel is the
+  ground space `G_L(A)`.
+
+* `MPSTensor.extractWindow L i σ` — extracts `L` consecutive site values from an `N`-site
+  configuration `σ` starting at position `i` (with periodic boundary conditions).
+
+* `MPSTensor.replaceWindow L i σ τ` — replaces the `L` consecutive site values in `σ`
+  starting at position `i` with values from `τ`.
+
+* `MPSTensor.localTerm A L N i` — the parent interaction embedded at site `i` on the
+  `N`-site periodic chain, acting as `parentInteraction` on the window
+  `{i, i+1, …, i+L-1 mod N}` and as the identity on the complement.
+
+* `MPSTensor.parentHamiltonian A L N` — the parent Hamiltonian `H = ∑ᵢ hᵢ`.
+
+* `MPSTensor.IsFrustrationFree A L N ψ` — frustration-freeness: every local term
+  annihilates `ψ`.
 -/
 
 open scoped Matrix BigOperators
@@ -17,29 +36,66 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- **ZERO PLACEHOLDER** — Parent interaction on `L` consecutive sites.
+/-! ### Transport between `NSiteSpace` and `EuclideanSpace`
 
-**Warning**: This is currently defined as **zero**. The real definition should be the
-orthogonal projector onto `groundSpace A L`ᗮ. Any theorem downstream of this
-definition (e.g. `parentHamiltonian_annihilates`, `parentHamiltonian_frustrationFree`)
-is **vacuously true** until this placeholder is replaced.
+`NSiteSpace d L = Cfg d L → ℂ` and `EuclideanSpace ℂ (Cfg d L) = PiLp 2 (fun _ => ℂ)`
+are definitionally the same type with the same module structure. We use
+`WithLp.linearEquiv` to transport the ground space to `EuclideanSpace`, where
+Mathlib provides `InnerProductSpace` and orthogonal projection. -/
 
-TODO(parent-hamiltonian): replace with the orthogonal projector. -/
-noncomputable def parentInteraction (_A : MPSTensor d D) (L : ℕ) :
+/-- The ground space of `A` on `L` sites, viewed as a submodule of
+`EuclideanSpace ℂ (Cfg d L)` (same underlying submodule, different typeclass
+instances for inner product). -/
+noncomputable def groundSpaceES (A : MPSTensor d D) (L : ℕ) :
+    Submodule ℂ (EuclideanSpace ℂ (Cfg d L)) :=
+  (groundSpace A L).map (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm.toLinearMap
+
+/-! ### Parent interaction -/
+
+/-- Parent interaction on `L` consecutive sites: the orthogonal projector onto
+`(groundSpace A L)ᗮ` in the `L`-site Hilbert space.
+
+Mathematically, `parentInteraction A L = 𝟙 - P_{G_L(A)}`, where `P_{G_L(A)}` is the
+orthogonal projector onto the ground space. This is a PSD operator with
+`ker(parentInteraction A L) = groundSpace A L`. -/
+noncomputable def parentInteraction (A : MPSTensor d D) (L : ℕ) :
     NSiteSpace d L →ₗ[ℂ] NSiteSpace d L :=
-  0
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d L)
+  e.toLinearMap.comp ((groundSpaceES A L)ᗮ.starProjection.toLinearMap.comp e.symm.toLinearMap)
 
-/-- **ZERO PLACEHOLDER** — Translated local term on an `N`-site periodic chain.
+/-! ### Window extraction and replacement (periodic boundary conditions) -/
 
-**Warning**: This is currently defined as **zero**. The real definition should embed
-`parentInteraction A L` at site `i` on the periodic chain. Any theorem
-downstream of this definition is **vacuously true** until this placeholder
-is replaced.
+/-- Extract `L` consecutive site values from an `N`-site configuration `σ`,
+starting at position `i` with periodic boundary conditions. -/
+def extractWindow (L : ℕ) {N : ℕ} (i : Fin N) (σ : Cfg d N) : Cfg d L :=
+  have hN : 0 < N := i.val.zero_le.trans_lt i.isLt
+  fun j => σ ⟨(i.val + j.val) % N, Nat.mod_lt _ hN⟩
 
-TODO(parent-hamiltonian): replace with the translated embedding. -/
-noncomputable def localTerm (_A : MPSTensor d D) (_L N : ℕ) (_i : Fin N) :
+/-- Replace `L` consecutive site values in an `N`-site configuration `σ`,
+starting at position `i`, with values from `τ` (periodic boundary conditions). -/
+def replaceWindow (L : ℕ) {N : ℕ} (i : Fin N) (σ : Cfg d N) (τ : Cfg d L) : Cfg d N :=
+  fun k =>
+    let offset := (k.val + N - i.val) % N
+    if h : offset < L then τ ⟨offset, h⟩ else σ k
+
+/-! ### Local term (site embedding) -/
+
+/-- Translated local term on an `N`-site periodic chain: embeds
+`parentInteraction A L` at site `i`, acting on the window
+`{i, i+1, …, i+L-1 mod N}` and as identity on the complement.
+
+For `f : NSiteSpace d N` and output configuration `σ`:
+```
+(localTerm A L N i f)(σ) = (parentInteraction A L (fun τ ↦ f (replaceWindow L i σ τ)))
+                             (extractWindow L i σ)
+``` -/
+noncomputable def localTerm (A : MPSTensor d D) (L N : ℕ) (i : Fin N) :
     NSiteSpace d N →ₗ[ℂ] NSiteSpace d N :=
-  0
+  LinearMap.pi fun σ =>
+    (LinearMap.proj (extractWindow L i σ) : NSiteSpace d L →ₗ[ℂ] ℂ).comp
+      ((parentInteraction A L).comp
+        (LinearMap.pi fun τ =>
+          (LinearMap.proj (replaceWindow (d := d) L i σ τ) : NSiteSpace d N →ₗ[ℂ] ℂ)))
 
 /-- Parent Hamiltonian on an `N`-site periodic chain:
 sum of translated local interaction terms. -/

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -30,7 +30,7 @@ and the finite-chain parent Hamiltonian.
   annihilates `ψ`.
 -/
 
-open scoped Matrix BigOperators
+open scoped BigOperators
 
 namespace MPSTensor
 
@@ -76,14 +76,17 @@ def extractWindow (L : ℕ) {N : ℕ} {α : Type*} (i : Fin N) (σ : Fin N → �
   have hN : 0 < N := i.val.zero_le.trans_lt i.isLt
   fun j => σ ⟨(i.val + j.val) % N, Nat.mod_lt _ hN⟩
 
+variable {N : ℕ}
+
 /-- Replace `L` consecutive values in an `N`-periodic sequence `σ`,
 starting at position `i`, with values from `τ` (periodic boundary conditions).
 
-Note: when `L > N`, positions beyond index `N-1` in `τ` are silently
-ignored because `offset` is always `< N`. The intended use case is `L ≤ N`. -/
-def replaceWindow (L : ℕ) {N : ℕ} {α : Type*} (i : Fin N) (σ : Fin N → α) (τ : Fin L → α) :
+Requires `L ≤ N` to ensure the `L`-site window is represented faithfully. -/
+def replaceWindow (L : ℕ) (hLN : L ≤ N) {α : Type*}
+    (i : Fin N) (σ : Fin N → α) (τ : Fin L → α) :
     Fin N → α :=
   fun k =>
+    let _hLN : L ≤ N := hLN
     let offset := (k.val + N - i.val) % N
     if h : offset < L then τ ⟨offset, h⟩ else σ k
 
@@ -100,11 +103,13 @@ For `f : NSiteSpace d N` and output configuration `σ`:
 ``` -/
 noncomputable def localTerm (A : MPSTensor d D) (L N : ℕ) (i : Fin N) :
     NSiteSpace d N →ₗ[ℂ] NSiteSpace d N :=
+  if hLN : L ≤ N then
   LinearMap.pi fun σ =>
     (LinearMap.proj (extractWindow L i σ) : NSiteSpace d L →ₗ[ℂ] ℂ).comp
       ((parentInteraction A L).comp
         (LinearMap.pi fun τ =>
-          (LinearMap.proj (replaceWindow L i σ τ) : NSiteSpace d N →ₗ[ℂ] ℂ)))
+          (LinearMap.proj (replaceWindow L hLN i σ τ) : NSiteSpace d N →ₗ[ℂ] ℂ)))
+  else 0
 
 /-- Parent Hamiltonian on an `N`-site periodic chain:
 sum of translated local interaction terms. -/

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -81,7 +81,11 @@ variable {N : ℕ}
 /-- Replace `L` consecutive values in an `N`-periodic sequence `σ`,
 starting at position `i`, with values from `τ` (periodic boundary conditions).
 
-Requires `L ≤ N` to ensure the `L`-site window is represented faithfully. -/
+Requires `L ≤ N` to ensure the `L`-site window is represented faithfully.
+
+Note: the offset logic mirrors `cyclicCfg` in `CyclicWindow.lean`, but this
+function is type-generic (`α` instead of `Fin d`) and *replaces* a window
+rather than *assembling* a configuration. -/
 def replaceWindow (L : ℕ) (_hLN : L ≤ N) {α : Type*}
     (i : Fin N) (σ : Fin N → α) (τ : Fin L → α) :
     Fin N → α :=
@@ -114,8 +118,10 @@ private lemma offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
 `parentInteraction A L` at site `i`, acting on the window
 `{i, i+1, …, i+L-1 mod N}` and as identity on the complement.
 
-When `L > N` the definition returns `0`; all lemmas in `Basic.lean`
-carry the hypothesis `hLN : L ≤ N` so this branch is never reached.
+**Important:** When `L > N` the definition returns `0`, which makes
+`parentHamiltonian` trivially zero and `IsFrustrationFree` vacuously true.
+All meaningful lemmas in `Basic.lean` carry an explicit `hLN : L ≤ N`
+hypothesis, so this degenerate branch is never reached in verified results.
 
 For `f : NSiteSpace d N` and output configuration `σ`:
 ```

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -95,33 +95,44 @@ $A^{\sigma(0)}\cdots A^{\sigma(L-1)}$.
 
 \section{Parent interaction and chain Hamiltonian}\label{sec:parent_interaction_defs}
 
-Conceptually, the parent interaction at range $L$ is the orthogonal projector
-onto $G_L(A)^\perp$. In the current Lean installment, the chain-level operator
-API is introduced first, and the concrete projector implementation is deferred
-to a follow-up PR.
+The parent interaction at range $L$ is the orthogonal projector
+onto $G_L(A)^\perp$, implemented via the star-projection (orthogonal
+complement projection) in the $L$-site Euclidean space.
 
 \begin{definition}[Parent interaction]\label{def:parent_interaction}
   \lean{MPSTensor.parentInteraction}
+  \leanok
   \uses{def:ground_space_parent}
   The parent interaction at range $L$ is the orthogonal projector
   \[
     h_L(A) := \Pi_{G_L(A)^\perp},
   \]
   on the local $L$-site space.
-  \textbf{Note:} the Lean definition is currently a zero placeholder;
-  \texttt{\textbackslash leanok} will be added once the projector is implemented.
 \end{definition}
+
+\begin{lemma}[Parent interaction kills ground-space elements]\label{lem:parent_interaction_apply_mem_ground_space}
+  \lean{MPSTensor.parentInteraction_apply_mem_groundSpace}
+  \leanok
+  \uses{def:parent_interaction, def:ground_space_parent}
+  For any $v \in G_L(A)$, we have $h_L(A)\,v = 0$.
+\end{lemma}
+
+\begin{proof}
+  \leanok
+  Since $h_L(A)$ is the star-projection onto $G_L(A)^\perp$, it
+  annihilates every element of $G_L(A)$.
+\end{proof}
 
 For a periodic chain of length $N$, the parent Hamiltonian is the sum of
 translated copies of the local interaction.
 
 \begin{definition}[Translated local term]\label{def:local_term_parent}
   \lean{MPSTensor.localTerm}
+  \leanok
   \uses{def:parent_interaction}
   For each site index $i \in \{0,\dots,N{-}1\}$, the translated local term
   $h_i$ embeds the parent interaction into the full $N$-site space at
   position~$i$ (with periodic boundary conditions).
-  \textbf{Note:} the Lean definition is currently a zero placeholder.
 \end{definition}
 
 \begin{definition}[Parent Hamiltonian]\label{def:parent_hamiltonian}
@@ -144,20 +155,61 @@ translated copies of the local interaction.
   \]
 \end{definition}
 
+\begin{lemma}[MPV window membership]\label{lem:mpv_window_mem_ground_space}
+  \lean{MPSTensor.mpv_window_mem_groundSpace}
+  \leanok
+  \uses{def:ground_space_parent, def:mpv}
+  For any window of $L$ consecutive sites starting at position~$i$ in an
+  $N$-site periodic chain ($L \le N$), the restriction of the MPV state to
+  that window lies in $G_L(A)$.
+\end{lemma}
+
+\begin{proof}
+  \leanok
+  The witness is the product of $A$-matrices on the complement sites.
+  Trace cyclicity rotates the full $N$-site product so that window
+  indices come first, matching the ground-space map definition.
+\end{proof}
+
+\begin{lemma}[Local term annihilates the MPV]\label{lem:local_term_annihilates_mpv}
+  \lean{MPSTensor.localTerm_annihilates_mpv}
+  \leanok
+  \uses{def:local_term_parent, def:mpv, lem:mpv_window_mem_ground_space, lem:parent_interaction_apply_mem_ground_space}
+  For each site $i$, $h_i\,V^{(N)}(A) = 0$.
+\end{lemma}
+
+\begin{proof}
+  \leanok
+  Combines MPV window membership with the fact that the parent
+  interaction kills ground-space elements.
+\end{proof}
+
 \begin{lemma}[Parent Hamiltonian annihilates the MPV]\label{lem:parent_hamiltonian_annihilates}
   \lean{MPSTensor.parentHamiltonian_annihilates}
-  \uses{def:parent_hamiltonian, def:mpv}
+  \leanok
+  \uses{def:parent_hamiltonian, def:mpv, lem:local_term_annihilates_mpv}
   For every $N$, the MPV state satisfies
   \[
     H_N(A,L)\,V^{(N)}(A) = 0.
   \]
 \end{lemma}
 
+\begin{proof}
+  \leanok
+  Sum of zeros, since each local term annihilates the MPV.
+\end{proof}
+
 \begin{lemma}[Frustration-freeness of the MPV]\label{lem:parent_hamiltonian_ff}
   \lean{MPSTensor.parentHamiltonian_frustrationFree}
-  \uses{def:is_frustration_free, def:mpv}
+  \leanok
+  \uses{def:is_frustration_free, def:mpv, lem:local_term_annihilates_mpv}
   The MPV state is frustration-free for the parent model.
 \end{lemma}
+
+\begin{proof}
+  \leanok
+  Immediate from \texttt{localTerm\_annihilates\_mpv}.
+\end{proof}
 
 \section{Intersection property and unique ground state}\label{sec:intersection_unique}
 


### PR DESCRIPTION
### Motivation

- Closes the "vacuously true proofs" finding from #331: `parentInteraction` and `localTerm` were zero placeholders, making downstream theorems trivially true.
- Continues formalization of parent Hamiltonian theory (RMP IV.C), see #331 and tracking issue #190.

### Description

- **`TNLean/MPS/ParentHamiltonian/Defs.lean`**: Replace zero-placeholder `parentInteraction` with the orthogonal projector onto `(groundSpace A L)ᗮ` via `Submodule.starProjection` on a `EuclideanSpace` transport (`groundSpaceES`). Add periodic-chain window utilities (`extractWindow`, `replaceWindow`) and define `localTerm` as the embedding of `parentInteraction` onto an `N`-site chain.
- **`TNLean/MPS/ParentHamiltonian/Basic.lean`**: Prove `parentInteraction_apply_mem_groundSpace` (parent interaction annihilates ground space elements). Rework `parentHamiltonian_annihilates` and `parentHamiltonian_frustrationFree` to be real proofs through the new `localTerm` definition.
- One `sorry` remains in `mpv_window_mem_groundSpace` (requires showing the MPS state restricted to any window lies in the ground space via a trace cyclicity argument).

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #331

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces previously-trivial placeholder definitions (`parentInteraction`, `localTerm`) with nontrivial projector/embedding logic that can affect many downstream lemmas and proof obligations.
> 
> **Overview**
> **Implements the parent-Hamiltonian operators for real.** `parentInteraction` is no longer `0`; it is defined as the orthogonal (star) projection onto `(groundSpace A L)ᗮ` by transporting `groundSpace` to `EuclideanSpace` (`groundSpaceES`).
> 
> **Adds periodic-window utilities and a concrete site embedding.** Introduces `extractWindow`/`replaceWindow` (with `extractWindow_replaceWindow` simp lemma) and defines `localTerm` as the action of `parentInteraction` on an `L`-site window of an `N`-site periodic configuration (returning `0` when `L > N`).
> 
> **Upgrades formerly vacuous theorems into real proofs.** `Basic.lean` adds `parentInteraction_apply_mem_groundSpace`, proves MPV-window ground-space membership (`mpv_window_mem_groundSpace`) using trace cyclicity machinery, and derives `localTerm_annihilates_mpv`, `parentHamiltonian_annihilates`, and `parentHamiltonian_frustrationFree` under an explicit `L ≤ N` hypothesis.
> 
> **Docs update.** The blueprint chapter is updated to mark these definitions/lemmas as implemented (`\leanok`) and documents the new key lemmas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80c3b80a2f1730aca730caa8ea2e42a425db5d00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->