### PR TITLE
fix(PiAlgebra/BlockSeparation): update stale module path in docstring

### DIFF
--- a/TNLean/PiAlgebra/BlockSeparation.lean
+++ b/TNLean/PiAlgebra/BlockSeparation.lean
@@ -173,7 +173,7 @@ Accordingly, this file currently only provides the trustworthy helper lemmas
 and `sameMPV₂_repeated_word`.
 
 A checked counterexample to the naive full separation statement is retained in
-`TNLean.Scratch.BlockSepCounterexample`.
+`TNLean.Archive.BlockSepCounterexample`.
 
 For end-to-end results from `SameMPV₂`, use
 `fundamentalTheorem_multiBlock_fromSameMPV₂` (in


### PR DESCRIPTION
### Motivation

- The docstring in `BlockSeparation.lean` referenced the counterexample module at its old location (`TNLean.Scratch.BlockSepCounterexample`), which was moved to `TNLean.Archive.BlockSepCounterexample`. Partially addresses the audit tracked in #334.

### Description

- Updated module path reference in the docstring of `TNLean/PiAlgebra/BlockSeparation.lean` from `TNLean.Scratch.BlockSepCounterexample` to `TNLean.Archive.BlockSepCounterexample`.
- Comment-only change; no effect on compiled code or proof logic.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Partially addresses #334

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a comment-only change that updates a module path reference with no effect on compiled code or proof logic.
> 
> **Overview**
> Updates the `BlockSeparation.lean` status docstring to reference the counterexample module at its current location, changing `TNLean.Scratch.BlockSepCounterexample` to `TNLean.Archive.BlockSepCounterexample`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a32c92748dda65426bd4f7e38cafd0181b2393bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->