### PR TITLE
feat(MPS/CanonicalForm): add cyclic sector decomposition bridge

### DIFF
--- a/TNLean/Channel/Peripheral/GroupStructure.lean
+++ b/TNLean/Channel/Peripheral/GroupStructure.lean
@@ -323,23 +323,23 @@ The proof strategy uses Mathlib's `rootsOfUnity.isCyclic`:
    `CyclicDecomposition.lean`.
 -/
 
-/-- **The peripheral eigenvalues form a cyclic group** (Wolf Thm 6.6).
+/-- **The peripheral eigenvalues form a cyclic group** (Wolf Thm 6.6, without divisibility).
 
-Combines `peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint`
-(peripheral eigenvalues are roots of unity) with Mathlib's
-`rootsOfUnity.isCyclic` (finite subgroups of `ℂ*` are cyclic). -/
-theorem peripheral_eigenvalues_form_cyclic_group
+The peripheral eigenvalues form a finite subset of `ℂ`, contain `1`, and are
+closed under multiplication and inversion, so they form a finite subgroup of
+`ℂˣ`, which is cyclic. This lemma extracts the cyclic structure without
+requiring `IsTPKraus` (the divisibility `m ∣ D` needs trace-preservation
+separately; see `peripheral_eigenvalues_form_cyclic_group`). -/
+theorem peripheral_eigenvalues_cyclic_structure
     {r : ℕ} [NeZero D]
     (K : Fin r → MatrixAlg D)
     (hUnital : KadisonSchwarz.IsUnitalKraus (d := r) (D := D) K)
-    (hTP : KadisonSchwarz.IsTPKraus (d := r) (D := D) K)
     (ρ : MatrixAlg D) (hρ : ρ.PosDef)
     (hρfix : Kraus.adjointMap K ρ = ρ)
     (hIrr : IsIrreducibleMap (MPSTensor.transferMap (d := r) (D := D) K)) :
     ∃ (m : ℕ) (γ : ℂ),
       0 < m ∧
       IsPrimitiveRoot γ m ∧
-      m ∣ D ∧
       peripheralEigenvalues (MPSTensor.transferMap (d := r) (D := D) K) =
         {z : ℂ | ∃ k : Fin m, z = γ ^ (k : ℕ)} := by
   classical
@@ -455,17 +455,40 @@ theorem peripheral_eigenvalues_form_cyclic_group
       have : ((g ^ (k : ℕ)).val : ℂ) ∈ peripheralEigenvalues E := hgk_sub
       simp only [SubgroupClass.coe_pow, Units.val_pow_eq_pow_val] at this
       exact this
-  -- Step 7: m ∣ D via cyclic decomposition
+  exact ⟨m, γ, hm_pos, hγ_prim, hset_eq⟩
+
+/-- **The peripheral eigenvalues form a cyclic group** (Wolf Thm 6.6).
+
+Combines `peripheral_eigenvalues_cyclic_structure` (cyclic group without
+trace-preservation) with `channel_period_divides_dim` to additionally
+establish `m ∣ D`. -/
+theorem peripheral_eigenvalues_form_cyclic_group
+    {r : ℕ} [NeZero D]
+    (K : Fin r → MatrixAlg D)
+    (hUnital : KadisonSchwarz.IsUnitalKraus (d := r) (D := D) K)
+    (hTP : KadisonSchwarz.IsTPKraus (d := r) (D := D) K)
+    (ρ : MatrixAlg D) (hρ : ρ.PosDef)
+    (hρfix : Kraus.adjointMap K ρ = ρ)
+    (hIrr : IsIrreducibleMap (MPSTensor.transferMap (d := r) (D := D) K)) :
+    ∃ (m : ℕ) (γ : ℂ),
+      0 < m ∧
+      IsPrimitiveRoot γ m ∧
+      m ∣ D ∧
+      peripheralEigenvalues (MPSTensor.transferMap (d := r) (D := D) K) =
+        {z : ℂ | ∃ k : Fin m, z = γ ^ (k : ℕ)} := by
+  obtain ⟨m, γ, hm_pos, hγ_prim, hset_eq⟩ :=
+    peripheral_eigenvalues_cyclic_structure K hUnital ρ hρ hρfix hIrr
+  -- m ∣ D via cyclic decomposition
   have hm_dvd : m ∣ D := by
     -- γ is a peripheral eigenvalue (it's γ^1)
-    have hγ_mem : γ ∈ peripheralEigenvalues E := by
+    have hγ_mem : γ ∈ peripheralEigenvalues (MPSTensor.transferMap (d := r) (D := D) K) := by
       rw [hset_eq]
       by_cases hm1 : m = 1
       · have hγ1 : γ = 1 := by have := hγ_prim.pow_eq_one; rw [hm1] at this; simpa using this
         exact ⟨⟨0, by omega⟩, by simp [hγ1]⟩
       · exact ⟨⟨1, by omega⟩, by simp⟩
     -- Convert set representation to Set.range form
-    have hperiph_range : peripheralEigenvalues E =
+    have hperiph_range : peripheralEigenvalues (MPSTensor.transferMap (d := r) (D := D) K) =
         Set.range (fun j : Fin m => γ ^ (j : ℕ)) := by
       rw [hset_eq]; ext x; simp [Set.mem_range, eq_comm]
     haveI : NeZero m := ⟨by omega⟩

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -8,6 +8,7 @@ import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Core.BlockingTransfer
 import TNLean.MPS.FundamentalTheorem.Full
 import TNLean.Channel.Peripheral.CyclicDecomposition
+import TNLean.Channel.Peripheral.GroupStructure
 import TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 import TNLean.Wielandt.RectangularSpan.Basic
@@ -70,15 +71,26 @@ full `IsNormalCanonicalForm` from arbitrary input is:
 Both gaps are addressed by the paper's cyclic sector decomposition, which
 decomposes each periodic block into primitive sectors before blocking.
 
-### Possible resolutions
+### Progress on cyclic sector decomposition (#242)
 
-1. **Cyclic sector decomposition** (paper §2.3): decompose each periodic block into
-   primitive cyclic sectors. This is the mathematically correct approach (~800-1200 LOC).
+The per-block bridge is now complete:
 
-2. **Direct route for the primitive case**: If a block happens to already be primitive
-   (period 1), then `p = 1` suffices and `isIrreducibleTensor_blockTensor_one`
-   gives irreducibility directly. The
-   `exists_normalCanonicalForm_of_primitive_blockDecomp` theorem handles this.
+* `exists_cyclic_sector_decomp_of_irr_tp`: For each irreducible TP block,
+  derives all channel-level hypotheses automatically and produces cyclic
+  sector blocks via `exists_cyclic_sector_decomp_after_blocking`.
+
+Remaining work for the full pipeline integration:
+
+* **Common period assembly**: Combining per-block cyclic sectors into a
+  single global decomposition with a common blocking period. Requires
+  iterated-blocking infrastructure (`blockTensor (blockTensor A p) q ≃
+  blockTensor A (p * q)`).
+
+* **Sector irreducibility**: Each cyclic sector should inherit irreducibility
+  from `isIrreducible_restriction_of_cyclic_decomp`. The orbit-sum lift from
+  corner restriction to compressed tensor is not yet formalized.
+
+* **BNT grouping** (#243): Weight norm separation after sector decomposition.
 
 ## References
 
@@ -865,6 +877,198 @@ theorem exists_cyclic_sector_decomp_after_blocking
     (blockTensor A m) P hPproj hPsum hTP_blocked hFix
 
 end CyclicSectorBridge
+
+/-!
+## Bridge: MPS hypotheses → cyclic sector decomposition
+
+For an irreducible TP tensor, all channel-level hypotheses needed by
+`exists_cyclic_sector_decomp_after_blocking` can be derived automatically:
+
+1. `IsIrreducibleTensor A` → `IsIrreducibleMap (transferMap (fun i => (A i)ᴴ))`
+2. TP + irreducible → ∃ ρ.PosDef fixed by `transferMap A` = `Kraus.adjointMap K`
+3. `peripheral_eigenvalues_form_cyclic_group` → `(m, γ, IsPrimitiveRoot γ m, periph = {γ^k})`
+4. Feed all into `exists_cyclic_sector_decomp_after_blocking`
+-/
+
+section CyclicSectorFromMPS
+
+open KadisonSchwarz
+
+/-- **Bridge: irreducible TP tensor → cyclic sector decomposition.**
+
+For an irreducible TP tensor `A` with `0 < D`, there exists a period `m > 0`
+such that after blocking by `m`, the blocked tensor admits a decomposition
+into `m` left-canonical (TP) blocks via cyclic spectral projections.
+
+This bridges the MPS-level hypotheses (`IsIrreducibleTensor` + TP) to the
+channel-level cyclic decomposition, deriving all intermediate hypotheses
+(`ρ.PosDef`, `Kraus.adjointMap` fixed point, `IsIrreducibleMap`, peripheral
+spectrum structure) automatically.
+
+The proof follows the same pattern as
+`exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor` in
+`BlockingViaAdjoint.lean`, but uses `peripheral_eigenvalues_form_cyclic_group`
+from `GroupStructure.lean` (proved in #353) to obtain the explicit cyclic
+structure needed by `exists_cyclic_sector_decomp_after_blocking`. -/
+theorem exists_cyclic_sector_decomp_of_irr_tp
+    {d D : ℕ} [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A) :
+    ∃ (m : ℕ) (_ : 0 < m)
+      (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
+      (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
+      SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) := by
+  classical
+  have hDpos : 0 < D := NeZero.pos D
+  -- Step 1: Conjugate-transposed Kraus family K i = (A i)ᴴ.
+  let K : MPSTensor d D := fun i => (A i)ᴴ
+  have hTP' : IsTPKraus (d := d) (D := D) A := by
+    simpa [IsTPKraus] using hTP
+  have h_unitalK : IsUnitalKraus (d := d) (D := D) K :=
+    isUnitalKraus_conjTranspose (d := d) (D := D) (K := A) hTP'
+  -- Step 2: Irreducibility of transferMap K from tensor irreducibility.
+  have hIrrK : IsIrreducibleMap (transferMap (d := d) (D := D) K) :=
+    isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor (d := d) (D := D) A hIrr
+  -- Step 3: PosDef fixed point ρ of transferMap A.
+  have hCh : IsChannel (transferMap (d := d) (D := D) A) :=
+    transferMap_isChannel (d := d) (D := D) A (by simpa using hTP)
+  obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
+    hCh.exists_posSemidef_fixedPoint (E := transferMap (d := d) (D := D) A) hDpos
+  have hIrrAmap : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+    isIrreducibleCP_transferMap_of_isIrreducibleTensor (d := d) (D := D) A hIrr
+  have hρ_pd : ρ.PosDef :=
+    posSemidef_fixedPoint_isPosDef_of_irreducible (A := A) (d := d) (D := D)
+      hIrrAmap ρ hρ_psd hρ_ne hρ_fix
+  -- Step 4: ρ is fixed by Kraus.adjointMap K (= transferMap A).
+  have h_adjfix : Kraus.adjointMap K ρ = ρ := by
+    simpa [K, Kraus.adjointMap, transferMap_apply, Matrix.conjTranspose_conjTranspose,
+      Matrix.mul_assoc] using hρ_fix
+  -- Step 5: Peripheral eigenvalues are roots of unity; extract cyclic structure.
+  -- We build the cyclic group structure from first principles using the same
+  -- ingredients as `peripheral_eigenvalues_form_cyclic_group`, but without
+  -- needing `IsTPKraus K` (which would require `IsUnitalKraus A`).
+  -- The key ingredients: peripheral eigenvalues are roots of unity (from
+  -- `peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint`),
+  -- and they form a subgroup of ℂˣ (from closure under mul/inv).
+  set E := transferMap (d := d) (D := D) K with hE_def
+  have hfin : (peripheralEigenvalues E).Finite := peripheralEigenvalues_finite (f := E)
+  -- 1 ∈ peripheral (from unitality of K)
+  have hE_unital : E 1 = 1 := by
+    simp only [hE_def, MPSTensor.transferMap_apply]
+    exact krausMap_one_of_unital K h_unitalK
+  have hone_mem : (1 : ℂ) ∈ peripheralEigenvalues E :=
+    one_mem_peripheralEigenvalues E 1 hE_unital one_ne_zero
+  -- Nonzero
+  have hne_zero : ∀ μ : ℂ, μ ∈ peripheralEigenvalues E → μ ≠ 0 := by
+    intro μ ⟨_, hμ_norm⟩
+    exact norm_ne_zero_iff.mp (by rw [hμ_norm]; exact one_ne_zero)
+  -- Closure under mul and inv (from PeripheralSpectrum)
+  have hmul_closed : ∀ μ ν : ℂ, μ ∈ peripheralEigenvalues E → ν ∈ peripheralEigenvalues E →
+      μ * ν ∈ peripheralEigenvalues E :=
+    fun μ ν hμ hν =>
+      PeripheralSpectrum.peripheral_eigenvalues_closed_under_mul K h_unitalK ρ hρ_pd h_adjfix
+        hIrrK hμ hν
+  have hinv_closed : ∀ μ : ℂ, μ ∈ peripheralEigenvalues E →
+      μ⁻¹ ∈ peripheralEigenvalues E :=
+    fun μ hμ =>
+      PeripheralSpectrum.peripheral_eigenvalues_closed_under_inv K h_unitalK ρ hρ_pd h_adjfix
+        hIrrK hμ
+  -- Build the subgroup of ℂˣ
+  let periphSubgroup : Subgroup ℂˣ :=
+    { carrier := {u : ℂˣ | (u : ℂ) ∈ peripheralEigenvalues E}
+      one_mem' := by change ((1 : ℂˣ) : ℂ) ∈ peripheralEigenvalues E; simpa using hone_mem
+      mul_mem' := fun {a b} (ha : (a : ℂ) ∈ peripheralEigenvalues E)
+          (hb : (b : ℂ) ∈ peripheralEigenvalues E) => by
+        change (↑(a * b) : ℂ) ∈ peripheralEigenvalues E
+        rw [Units.val_mul]
+        exact hmul_closed _ _ ha hb
+      inv_mem' := fun {a} (ha : (a : ℂ) ∈ peripheralEigenvalues E) => by
+        change (↑(a⁻¹) : ℂ) ∈ peripheralEigenvalues E
+        rw [Units.val_inv_eq_inv_val]
+        exact hinv_closed _ ha }
+  haveI hFinS : Finite ↥periphSubgroup := by
+    have : Set.Finite {u : ℂˣ | (u : ℂ) ∈ peripheralEigenvalues E} := by
+      have hinj : Set.InjOn Units.val (Units.val ⁻¹' (peripheralEigenvalues E)) :=
+        fun _ _ _ _ h => Units.val_injective h
+      exact hfin.preimage hinj
+    exact this.to_subtype
+  haveI : IsCyclic ↥periphSubgroup := subgroup_units_cyclic periphSubgroup
+  obtain ⟨g, hg_order⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp ‹IsCyclic ↥periphSubgroup›
+  set m := Nat.card ↥periphSubgroup with hm_def
+  set γ := (g.val : ℂ) with hγ_def
+  have hm_pos : 0 < m := Nat.card_pos
+  -- IsPrimitiveRoot γ m
+  have hγ_prim : IsPrimitiveRoot γ m := by
+    constructor
+    · have hgm : g ^ m = 1 := by rw [← hg_order]; exact pow_orderOf_eq_one g
+      change (g.val : ℂ) ^ m = 1
+      have : ((g ^ m : ↥periphSubgroup).val : ℂ) = ((1 : ↥periphSubgroup).val : ℂ) :=
+        congr_arg (fun x => ((x : ↥periphSubgroup).val : ℂ)) hgm
+      simp only [SubgroupClass.coe_pow, OneMemClass.coe_one] at this
+      exact this
+    · intro l hl
+      have hunits : g.val ^ l = 1 := by
+        apply Units.val_injective; push_cast; exact hl
+      have hgroup : g ^ l = 1 := by
+        apply Subtype.val_injective; exact hunits
+      rw [← hg_order]
+      exact orderOf_dvd_of_pow_eq_one hgroup
+  -- Peripheral eigenvalues = {γ^k | k ∈ Fin m}
+  have hperiph_set : peripheralEigenvalues E =
+      {z : ℂ | ∃ k : Fin m, z = γ ^ (k : ℕ)} := by
+    ext μ; constructor
+    · intro hμ
+      have hμ_ne := hne_zero μ hμ
+      set u : ℂˣ := Units.mk0 μ hμ_ne with hu_def
+      have hu_mem : u ∈ periphSubgroup := by
+        change (u : ℂ) ∈ peripheralEigenvalues E
+        simp only [hu_def, Units.val_mk0]; exact hμ
+      have hg_top : Subgroup.zpowers g = ⊤ :=
+        Subgroup.eq_top_of_card_eq _ (by rw [Nat.card_zpowers, hg_order])
+      have hu_zpow : (⟨u, hu_mem⟩ : ↥periphSubgroup) ∈ Subgroup.zpowers g := by
+        rw [hg_top]; exact Subgroup.mem_top _
+      obtain ⟨z, hz⟩ := hu_zpow
+      have hg_eq : (⟨u, hu_mem⟩ : ↥periphSubgroup) = g ^ z := hz.symm
+      have hg_mod : g ^ z = g ^ (z % ↑m).toNat := by
+        have hm_ne : (m : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (by omega)
+        conv_lhs => rw [← zpow_mod_orderOf g z, hg_order]
+        rw [show z % ↑m = ↑(z % ↑m).toNat from
+          (Int.toNat_of_nonneg (Int.emod_nonneg z hm_ne)).symm, zpow_natCast]
+        rfl
+      have hz_val : u = g.val ^ (z % ↑m).toNat := by
+        have : (⟨u, hu_mem⟩ : ↥periphSubgroup).val = (g ^ (z % ↑m).toNat).val := by
+          rw [hg_eq, hg_mod]
+        simpa using this
+      have hk_lt : (z % ↑m).toNat < m := by
+        have hm_ne : (m : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (by omega)
+        have h1 := Int.emod_lt_of_pos z (by omega : (0 : ℤ) < m)
+        omega
+      refine ⟨⟨(z % ↑m).toNat, hk_lt⟩, ?_⟩
+      simp only [hγ_def]
+      calc μ = (u : ℂ) := by simp [hu_def]
+        _ = (g.val ^ (z % ↑m).toNat : ℂˣ).val := by rw [hz_val]
+        _ = ((g.val : ℂ)) ^ (z % ↑m).toNat := by push_cast; rfl
+    · rintro ⟨k, rfl⟩
+      have hgk_sub : (g ^ (k : ℕ)).val ∈ periphSubgroup := by
+        exact (g ^ (k : ℕ)).property
+      change ((g.val : ℂ)) ^ (k : ℕ) ∈ peripheralEigenvalues E
+      have : ((g ^ (k : ℕ)).val : ℂ) ∈ peripheralEigenvalues E := hgk_sub
+      simp only [SubgroupClass.coe_pow, Units.val_pow_eq_pow_val] at this
+      exact this
+  -- Step 6: Convert set representation to range form.
+  have hperiph_range :
+      peripheralEigenvalues (transferMap (d := d) (D := D) K) =
+        Set.range (fun j : Fin m => γ ^ (j : ℕ)) := by
+    rw [hperiph_set]; ext x; simp [Set.mem_range, eq_comm]
+  -- Step 7: Apply exists_cyclic_sector_decomp_after_blocking.
+  haveI : NeZero m := ⟨by omega⟩
+  obtain ⟨dim, blocks, hTP_blocks, hSame⟩ :=
+    exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim
+      hperiph_range
+  exact ⟨m, hm_pos, dim, blocks, hTP_blocks, hSame⟩
+
+end CyclicSectorFromMPS
 
 /-!
 ## Fundamental Theorem of MPS (arXiv:1606.00608, after blocking)

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -75,7 +75,7 @@ decomposes each periodic block into primitive sectors before blocking.
 
 The per-block bridge is now complete:
 
-* `exists_cyclic_sector_decomp_of_irr_tp`: For each irreducible TP block,
+* `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`: For each irreducible TP block,
   derives all channel-level hypotheses automatically and produces cyclic
   sector blocks via `exists_cyclic_sector_decomp_after_blocking`.
 
@@ -907,10 +907,10 @@ spectrum structure) automatically.
 
 The proof follows the same pattern as
 `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor` in
-`BlockingViaAdjoint.lean`, but uses `peripheral_eigenvalues_form_cyclic_group`
-from `GroupStructure.lean` (proved in #353) to obtain the explicit cyclic
-structure needed by `exists_cyclic_sector_decomp_after_blocking`. -/
-theorem exists_cyclic_sector_decomp_of_irr_tp
+`BlockingViaAdjoint.lean`, but re-derives the cyclic peripheral-spectrum
+structure directly and feeds it into
+`exists_cyclic_sector_decomp_after_blocking`. -/
+theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -944,118 +944,10 @@ theorem exists_cyclic_sector_decomp_of_irr_tp
   have h_adjfix : Kraus.adjointMap K ρ = ρ := by
     simpa [K, Kraus.adjointMap, transferMap_apply, Matrix.conjTranspose_conjTranspose,
       Matrix.mul_assoc] using hρ_fix
-  -- Step 5: Peripheral eigenvalues are roots of unity; extract cyclic structure.
-  -- We build the cyclic group structure from first principles using the same
-  -- ingredients as `peripheral_eigenvalues_form_cyclic_group`, but without
-  -- needing `IsTPKraus K` (which would require `IsUnitalKraus A`).
-  -- The key ingredients: peripheral eigenvalues are roots of unity (from
-  -- `peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint`),
-  -- and they form a subgroup of ℂˣ (from closure under mul/inv).
-  set E := transferMap (d := d) (D := D) K with hE_def
-  have hfin : (peripheralEigenvalues E).Finite := peripheralEigenvalues_finite (f := E)
-  -- 1 ∈ peripheral (from unitality of K)
-  have hE_unital : E 1 = 1 := by
-    simp only [hE_def, MPSTensor.transferMap_apply]
-    exact krausMap_one_of_unital K h_unitalK
-  have hone_mem : (1 : ℂ) ∈ peripheralEigenvalues E :=
-    one_mem_peripheralEigenvalues E 1 hE_unital one_ne_zero
-  -- Nonzero
-  have hne_zero : ∀ μ : ℂ, μ ∈ peripheralEigenvalues E → μ ≠ 0 := by
-    intro μ ⟨_, hμ_norm⟩
-    exact norm_ne_zero_iff.mp (by rw [hμ_norm]; exact one_ne_zero)
-  -- Closure under mul and inv (from PeripheralSpectrum)
-  have hmul_closed : ∀ μ ν : ℂ, μ ∈ peripheralEigenvalues E → ν ∈ peripheralEigenvalues E →
-      μ * ν ∈ peripheralEigenvalues E :=
-    fun μ ν hμ hν =>
-      PeripheralSpectrum.peripheral_eigenvalues_closed_under_mul K h_unitalK ρ hρ_pd h_adjfix
-        hIrrK hμ hν
-  have hinv_closed : ∀ μ : ℂ, μ ∈ peripheralEigenvalues E →
-      μ⁻¹ ∈ peripheralEigenvalues E :=
-    fun μ hμ =>
-      PeripheralSpectrum.peripheral_eigenvalues_closed_under_inv K h_unitalK ρ hρ_pd h_adjfix
-        hIrrK hμ
-  -- Build the subgroup of ℂˣ
-  let periphSubgroup : Subgroup ℂˣ :=
-    { carrier := {u : ℂˣ | (u : ℂ) ∈ peripheralEigenvalues E}
-      one_mem' := by change ((1 : ℂˣ) : ℂ) ∈ peripheralEigenvalues E; simpa using hone_mem
-      mul_mem' := fun {a b} (ha : (a : ℂ) ∈ peripheralEigenvalues E)
-          (hb : (b : ℂ) ∈ peripheralEigenvalues E) => by
-        change (↑(a * b) : ℂ) ∈ peripheralEigenvalues E
-        rw [Units.val_mul]
-        exact hmul_closed _ _ ha hb
-      inv_mem' := fun {a} (ha : (a : ℂ) ∈ peripheralEigenvalues E) => by
-        change (↑(a⁻¹) : ℂ) ∈ peripheralEigenvalues E
-        rw [Units.val_inv_eq_inv_val]
-        exact hinv_closed _ ha }
-  haveI hFinS : Finite ↥periphSubgroup := by
-    have : Set.Finite {u : ℂˣ | (u : ℂ) ∈ peripheralEigenvalues E} := by
-      have hinj : Set.InjOn Units.val (Units.val ⁻¹' (peripheralEigenvalues E)) :=
-        fun _ _ _ _ h => Units.val_injective h
-      exact hfin.preimage hinj
-    exact this.to_subtype
-  haveI : IsCyclic ↥periphSubgroup := subgroup_units_cyclic periphSubgroup
-  obtain ⟨g, hg_order⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp ‹IsCyclic ↥periphSubgroup›
-  set m := Nat.card ↥periphSubgroup with hm_def
-  set γ := (g.val : ℂ) with hγ_def
-  have hm_pos : 0 < m := Nat.card_pos
-  -- IsPrimitiveRoot γ m
-  have hγ_prim : IsPrimitiveRoot γ m := by
-    constructor
-    · have hgm : g ^ m = 1 := by rw [← hg_order]; exact pow_orderOf_eq_one g
-      change (g.val : ℂ) ^ m = 1
-      have : ((g ^ m : ↥periphSubgroup).val : ℂ) = ((1 : ↥periphSubgroup).val : ℂ) :=
-        congr_arg (fun x => ((x : ↥periphSubgroup).val : ℂ)) hgm
-      simp only [SubgroupClass.coe_pow, OneMemClass.coe_one] at this
-      exact this
-    · intro l hl
-      have hunits : g.val ^ l = 1 := by
-        apply Units.val_injective; push_cast; exact hl
-      have hgroup : g ^ l = 1 := by
-        apply Subtype.val_injective; exact hunits
-      rw [← hg_order]
-      exact orderOf_dvd_of_pow_eq_one hgroup
-  -- Peripheral eigenvalues = {γ^k | k ∈ Fin m}
-  have hperiph_set : peripheralEigenvalues E =
-      {z : ℂ | ∃ k : Fin m, z = γ ^ (k : ℕ)} := by
-    ext μ; constructor
-    · intro hμ
-      have hμ_ne := hne_zero μ hμ
-      set u : ℂˣ := Units.mk0 μ hμ_ne with hu_def
-      have hu_mem : u ∈ periphSubgroup := by
-        change (u : ℂ) ∈ peripheralEigenvalues E
-        simp only [hu_def, Units.val_mk0]; exact hμ
-      have hg_top : Subgroup.zpowers g = ⊤ :=
-        Subgroup.eq_top_of_card_eq _ (by rw [Nat.card_zpowers, hg_order])
-      have hu_zpow : (⟨u, hu_mem⟩ : ↥periphSubgroup) ∈ Subgroup.zpowers g := by
-        rw [hg_top]; exact Subgroup.mem_top _
-      obtain ⟨z, hz⟩ := hu_zpow
-      have hg_eq : (⟨u, hu_mem⟩ : ↥periphSubgroup) = g ^ z := hz.symm
-      have hg_mod : g ^ z = g ^ (z % ↑m).toNat := by
-        have hm_ne : (m : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (by omega)
-        conv_lhs => rw [← zpow_mod_orderOf g z, hg_order]
-        rw [show z % ↑m = ↑(z % ↑m).toNat from
-          (Int.toNat_of_nonneg (Int.emod_nonneg z hm_ne)).symm, zpow_natCast]
-        rfl
-      have hz_val : u = g.val ^ (z % ↑m).toNat := by
-        have : (⟨u, hu_mem⟩ : ↥periphSubgroup).val = (g ^ (z % ↑m).toNat).val := by
-          rw [hg_eq, hg_mod]
-        simpa using this
-      have hk_lt : (z % ↑m).toNat < m := by
-        have hm_ne : (m : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (by omega)
-        have h1 := Int.emod_lt_of_pos z (by omega : (0 : ℤ) < m)
-        omega
-      refine ⟨⟨(z % ↑m).toNat, hk_lt⟩, ?_⟩
-      simp only [hγ_def]
-      calc μ = (u : ℂ) := by simp [hu_def]
-        _ = (g.val ^ (z % ↑m).toNat : ℂˣ).val := by rw [hz_val]
-        _ = ((g.val : ℂ)) ^ (z % ↑m).toNat := by push_cast; rfl
-    · rintro ⟨k, rfl⟩
-      have hgk_sub : (g ^ (k : ℕ)).val ∈ periphSubgroup := by
-        exact (g ^ (k : ℕ)).property
-      change ((g.val : ℂ)) ^ (k : ℕ) ∈ peripheralEigenvalues E
-      have : ((g ^ (k : ℕ)).val : ℂ) ∈ peripheralEigenvalues E := hgk_sub
-      simp only [SubgroupClass.coe_pow, Units.val_pow_eq_pow_val] at this
-      exact this
+  -- Step 5: Extract cyclic peripheral structure via
+  -- `peripheral_eigenvalues_cyclic_structure` from `GroupStructure.lean`.
+  obtain ⟨m, γ, hm_pos, hγ_prim, hperiph_set⟩ :=
+    PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure K h_unitalK ρ hρ_pd h_adjfix hIrrK
   -- Step 6: Convert set representation to range form.
   have hperiph_range :
       peripheralEigenvalues (transferMap (d := d) (D := D) K) =

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -886,13 +886,53 @@ For an irreducible TP tensor, all channel-level hypotheses needed by
 
 1. `IsIrreducibleTensor A` → `IsIrreducibleMap (transferMap (fun i => (A i)ᴴ))`
 2. TP + irreducible → ∃ ρ.PosDef fixed by `transferMap A` = `Kraus.adjointMap K`
-3. `peripheral_eigenvalues_form_cyclic_group` → `(m, γ, IsPrimitiveRoot γ m, periph = {γ^k})`
+3. `peripheral_eigenvalues_cyclic_structure` → `(m, γ, IsPrimitiveRoot γ m, periph = {γ^k})`
 4. Feed all into `exists_cyclic_sector_decomp_after_blocking`
 -/
 
 section CyclicSectorFromMPS
 
 open KadisonSchwarz
+
+/-- From an irreducible TP tensor, derive the conjugate-transposed Kraus family `K`,
+its unitality and irreducibility, and a `PosDef` fixed point `ρ` of `Kraus.adjointMap K`.
+
+This bundles the common setup shared by `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
+and `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`. -/
+theorem conjTranspose_kraus_setup
+    {d D : ℕ} [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A) :
+    ∃ (K : MPSTensor d D)
+      (_ : IsUnitalKraus (d := d) (D := D) K)
+      (_ : IsIrreducibleMap (transferMap (d := d) (D := D) K))
+      (ρ : Matrix (Fin D) (Fin D) ℂ)
+      (_ : ρ.PosDef)
+      (_ : Kraus.adjointMap K ρ = ρ),
+      K = fun i => (A i)ᴴ := by
+  classical
+  have hDpos : 0 < D := NeZero.pos D
+  let K : MPSTensor d D := fun i => (A i)ᴴ
+  have hTP' : IsTPKraus (d := d) (D := D) A := by
+    simpa [IsTPKraus] using hTP
+  have h_unitalK : IsUnitalKraus (d := d) (D := D) K :=
+    isUnitalKraus_conjTranspose (d := d) (D := D) (K := A) hTP'
+  have hIrrK : IsIrreducibleMap (transferMap (d := d) (D := D) K) :=
+    isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor (d := d) (D := D) A hIrr
+  have hCh : IsChannel (transferMap (d := d) (D := D) A) :=
+    transferMap_isChannel (d := d) (D := D) A (by simpa using hTP)
+  obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
+    hCh.exists_posSemidef_fixedPoint (E := transferMap (d := d) (D := D) A) hDpos
+  have hIrrAmap : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+    isIrreducibleCP_transferMap_of_isIrreducibleTensor (d := d) (D := D) A hIrr
+  have hρ_pd : ρ.PosDef :=
+    posSemidef_fixedPoint_isPosDef_of_irreducible (A := A) (d := d) (D := D)
+      hIrrAmap ρ hρ_psd hρ_ne hρ_fix
+  have h_adjfix : Kraus.adjointMap K ρ = ρ := by
+    simpa [K, Kraus.adjointMap, transferMap_apply, Matrix.conjTranspose_conjTranspose,
+      Matrix.mul_assoc] using hρ_fix
+  exact ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩
 
 /-- **Bridge: irreducible TP tensor → cyclic sector decomposition.**
 
@@ -903,13 +943,7 @@ into `m` left-canonical (TP) blocks via cyclic spectral projections.
 This bridges the MPS-level hypotheses (`IsIrreducibleTensor` + TP) to the
 channel-level cyclic decomposition, deriving all intermediate hypotheses
 (`ρ.PosDef`, `Kraus.adjointMap` fixed point, `IsIrreducibleMap`, peripheral
-spectrum structure) automatically.
-
-The proof follows the same pattern as
-`exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor` in
-`BlockingViaAdjoint.lean`, but re-derives the cyclic peripheral-spectrum
-structure directly and feeds it into
-`exists_cyclic_sector_decomp_after_blocking`. -/
+spectrum structure) automatically via `conjTranspose_kraus_setup`. -/
 theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)
@@ -919,41 +953,19 @@ theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
       (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
       (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
       SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) := by
-  classical
-  have hDpos : 0 < D := NeZero.pos D
-  -- Step 1: Conjugate-transposed Kraus family K i = (A i)ᴴ.
-  let K : MPSTensor d D := fun i => (A i)ᴴ
-  have hTP' : IsTPKraus (d := d) (D := D) A := by
-    simpa [IsTPKraus] using hTP
-  have h_unitalK : IsUnitalKraus (d := d) (D := D) K :=
-    isUnitalKraus_conjTranspose (d := d) (D := D) (K := A) hTP'
-  -- Step 2: Irreducibility of transferMap K from tensor irreducibility.
-  have hIrrK : IsIrreducibleMap (transferMap (d := d) (D := D) K) :=
-    isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor (d := d) (D := D) A hIrr
-  -- Step 3: PosDef fixed point ρ of transferMap A.
-  have hCh : IsChannel (transferMap (d := d) (D := D) A) :=
-    transferMap_isChannel (d := d) (D := D) A (by simpa using hTP)
-  obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
-    hCh.exists_posSemidef_fixedPoint (E := transferMap (d := d) (D := D) A) hDpos
-  have hIrrAmap : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
-    isIrreducibleCP_transferMap_of_isIrreducibleTensor (d := d) (D := D) A hIrr
-  have hρ_pd : ρ.PosDef :=
-    posSemidef_fixedPoint_isPosDef_of_irreducible (A := A) (d := d) (D := D)
-      hIrrAmap ρ hρ_psd hρ_ne hρ_fix
-  -- Step 4: ρ is fixed by Kraus.adjointMap K (= transferMap A).
-  have h_adjfix : Kraus.adjointMap K ρ = ρ := by
-    simpa [K, Kraus.adjointMap, transferMap_apply, Matrix.conjTranspose_conjTranspose,
-      Matrix.mul_assoc] using hρ_fix
-  -- Step 5: Extract cyclic peripheral structure via
+  -- Use shared setup to get conjugate Kraus family and PosDef fixed point.
+  obtain ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
+    conjTranspose_kraus_setup A hTP hIrr
+  -- Extract cyclic peripheral structure via
   -- `peripheral_eigenvalues_cyclic_structure` from `GroupStructure.lean`.
   obtain ⟨m, γ, hm_pos, hγ_prim, hperiph_set⟩ :=
-    PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure K h_unitalK ρ hρ_pd h_adjfix hIrrK
-  -- Step 6: Convert set representation to range form.
+    PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure _ h_unitalK ρ hρ_pd h_adjfix hIrrK
+  -- Convert set representation to range form.
   have hperiph_range :
-      peripheralEigenvalues (transferMap (d := d) (D := D) K) =
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
         Set.range (fun j : Fin m => γ ^ (j : ℕ)) := by
     rw [hperiph_set]; ext x; simp [Set.mem_range, eq_comm]
-  -- Step 7: Apply exists_cyclic_sector_decomp_after_blocking.
+  -- Apply exists_cyclic_sector_decomp_after_blocking.
   haveI : NeZero m := ⟨by omega⟩
   obtain ⟨dim, blocks, hTP_blocks, hSame⟩ :=
     exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -884,11 +884,33 @@ This section records declaration wrappers used in cross-chapter references.
 
 \section{Peripheral eigenvalue group structure (Wolf Thm.~6.6)}
 
+\begin{theorem}[Peripheral eigenvalues: cyclic structure]%
+    \label{thm:peripheral_cyclic_structure}
+    \lean{PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure}
+    \leanok
+    \uses{thm:ks_peripheral}
+    Let $E$ be an irreducible unital Schwarz map on $\MN{D}$ with a
+    positive-definite adjoint fixed point (trace-preservation is \emph{not}
+    required).
+    Then there exist $m \ge 1$ and a primitive $m$-th root of unity
+    $\gamma$ such that the peripheral eigenvalues of $E$ are exactly
+    $\{1, \gamma, \gamma^2, \ldots, \gamma^{m-1}\}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The peripheral eigenvalues form a finite subset of $\C$,
+    contain $1$, and are closed under multiplication and inversion,
+    so they form a finite subgroup of $\C^\times$.
+    By Mathlib's \texttt{subgroup\_units\_cyclic}, this subgroup is cyclic.
+    The generator $\gamma$ has order $m = |\text{peripheral spectrum}|$.
+\end{proof}
+
 \begin{theorem}[Peripheral eigenvalues form a cyclic group]%
     \label{thm:peripheral_cyclic_group}
     \lean{PeripheralSpectrum.peripheral_eigenvalues_form_cyclic_group}
     \leanok
-    \uses{thm:ks_peripheral}
+    \uses{thm:peripheral_cyclic_structure}
     Let $E$ be an irreducible unital trace-preserving Schwarz map on
     $\MN{D}$ with a positive-definite adjoint fixed point.
     Then there exist $m \ge 1$ and a primitive $m$-th root of unity
@@ -898,14 +920,11 @@ This section records declaration wrappers used in cross-chapter references.
 
 \begin{proof}
     \leanok
-    The peripheral eigenvalues are roots of unity (by
-    \texttt{peripheral\_isRootOfUnity}) and hence embed into a finite
-    subgroup of $\C^\times$.  By Mathlib's
-    \texttt{subgroup\_units\_cyclic}, this subgroup is cyclic.
-    The generator $\gamma$ has order $m = |\text{peripheral spectrum}|$.
-    Divisibility $m \mid D$ follows from the cyclic decomposition:
-    $m$ mutually orthogonal projections summing to $\Id$ each have
-    equal trace (by trace preservation), so
+    \uses{thm:peripheral_cyclic_structure}
+    Apply Theorem~\ref{thm:peripheral_cyclic_structure} for the cyclic
+    structure.  Divisibility $m \mid D$ follows from the cyclic
+    decomposition: $m$ mutually orthogonal projections summing to $\Id$
+    each have equal trace (by trace preservation), so
     $m \cdot \tr(P_0) = D$ with $\tr(P_0) \in \N$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1036,6 +1036,28 @@ The following results separate the zero blocks from the
 	Apply Theorem~\ref{thm:blockdecomp_commuting_projs}.
 \end{proof}
 
+\begin{theorem}[Cyclic sector decomposition for irreducible TP tensors]%
+	\label{thm:cyclic_sector_decomp_irr_tp}
+	\lean{MPSTensor.exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor}
+	\leanok
+	\uses{def:irreducible_tensor, thm:blockdecomp_adjoint_fixed}
+	Let $A$ be a left-canonical MPS tensor with irreducible transfer map.
+	Then there exist $m \ge 1$ and left-canonical blocks
+	$(C_k)_{k=1}^m$ such that the $m$-blocked tensor $A^{[m]}$
+	decomposes as $\bigoplus_{k=1}^m C_k$ (with unit weights).
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:blockdecomp_adjoint_fixed}
+	Derive the conjugate-transposed Kraus family $K_i = (A^i)^\dagger$,
+	its unitality and irreducibility, and a positive-definite fixed point
+	$\rho$ of the transfer map.
+	Apply the cyclic structure theorem
+	(peripheral eigenvalues form a cyclic group of order~$m$)
+	to obtain $m$ cyclic spectral projections.
+	Feed into Theorem~\ref{thm:blockdecomp_adjoint_fixed}.
+\end{proof}
+
 \section{Reduction to primitive blocks}%
 \label{sec:assembly_pipeline}
 


### PR DESCRIPTION
### Motivation

- Completes the per-block integration step for the Ch8 canonical form reduction pipeline (see #242).
- After blocking by common period, `blockTensor` may fail to be irreducible. The missing bridge connects channel-level cyclic decomposition to MPS-level block decomposition.

### Description

- Add `exists_cyclic_sector_decomp_of_irr_tp` in `TNLean/MPS/CanonicalForm/Assembly.lean` — bridge theorem that derives all channel-level hypotheses from `IsIrreducibleTensor` + TP and invokes `exists_cyclic_sector_decomp_after_blocking` automatically.
- Proof uses peripheral eigenvalue closure lemmas from `GroupStructure.lean` (#353) to construct the full cyclic group structure needed for the decomposition.
- Import `TNLean.Channel.Peripheral.GroupStructure` added.
- Updated `Assembly.lean` documentation to reflect new progress.
- Sorry-free: no new sorrys introduced.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #242

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to refactoring of a core peripheral-spectrum theorem (splitting out a new lemma and changing dependencies) and adding a new cross-layer bridge theorem that other proofs may start relying on.
> 
> **Overview**
> **Adds a new per-block bridge for cyclic sector decomposition.** `Assembly.lean` now derives the needed channel-level hypotheses (unital conjugate-transposed Kraus family, irreducible transfer map, and a `PosDef` adjoint fixed point) and proves `MPSTensor.exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`, which produces an `m`-blocking and a decomposition into `m` left-canonical sector blocks `SameMPV₂`-equivalent to `blockTensor A m`.
> 
> **Refactors peripheral-spectrum cyclicity to decouple trace-preservation.** `GroupStructure.lean` splits the previous statement into `PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure` (cyclic generator/set characterization without needing `IsTPKraus`) and a rebuilt `peripheral_eigenvalues_form_cyclic_group` that reintroduces the `m ∣ D` divisibility step using trace-preservation.
> 
> Blueprint chapters `ch06_spectral.tex` and `ch08_canonical.tex` are updated to document the new cyclic-structure theorem and the new cyclic-sector bridge theorem.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9118c76352b90962e1c55d6ae35a9e7ec68476bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->