### PR TITLE
doc(blueprint): add Proposition 3.3 periodic overlap entries with Lean tags

### DIFF
--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -622,6 +622,89 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	with $[A^i, Z] = 0$ and $\mathcal{V}(A) = \mathcal{V}(ZA)$.
 \end{theorem}
 
+\subsection{Periodic overlap dichotomy (Proposition 3.3)}
+
+The next ten declarations formalize the overlap dichotomy machinery from
+Appendix~A and Proposition~3.3 of \cite{DeLasCuevas2017Irreducible}.
+At this stage, only the bond-dimension-mismatch lemma is fully proved;
+the remaining declarations are scaffolded with incomplete proofs.
+
+\begin{theorem}[Self-overlap along period multiples]\label{thm:periodic_self_overlap_tendsto}
+	\lean{MPSTensor.periodicSelfOverlap_tendsto}
+	\uses{def:periodic_tensor}
+	If $A$ is $m$-periodic, then the self-overlap along multiples of $m$
+	converges to $m$.
+\end{theorem}
+
+\begin{theorem}[Different periods imply asymptotic orthogonality]\label{thm:periodic_overlap_zero_ne_period}
+	\lean{MPSTensor.periodicOverlap_tendsto_zero_of_ne_period}
+	\uses{def:periodic_tensor}
+	If $A$ and $B$ are periodic with different periods, then
+	$\langle V_N(A), V_N(B)\rangle \to 0$ as $N\to\infty$.
+\end{theorem}
+
+\begin{lemma}[Sector-block normality for periodic tensors]\label{lem:sector_blocked_normal_periodic}
+	\lean{MPSTensor.sectorBlocked_isNormal_of_isPeriodic}
+	\uses{def:periodic_tensor}
+	For a periodic tensor equipped with a cyclic sector decomposition,
+	each nonzero blocked sector tensor is normal.
+\end{lemma}
+
+\begin{theorem}[No sector match implies asymptotic orthogonality]\label{thm:periodic_overlap_zero_no_sector_match}
+	\lean{MPSTensor.periodicOverlap_tendsto_zero_of_no_sector_match}
+	\uses{def:periodic_tensor, lem:sector_blocked_normal_periodic}
+	If two periodic tensors with the same period admit no gauge-phase
+	matching sector pair after blocking, then their overlap tends to zero.
+\end{theorem}
+
+\begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}
+	\lean{MPSTensor.sectorMatch_propagation}
+	\uses{def:periodic_tensor}
+	A single gauge-phase match between blocked sectors propagates to all
+	cyclic translates of that sector pair.
+\end{lemma}
+
+\begin{lemma}[Per-site proportionality from blocked sector match]\label{lem:sector_tensor_proportional_blocked_match}
+	\lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
+	\uses{lem:sector_match_propagation}
+	If all aligned blocked sectors match up to gauge and phase, then the
+	original tensors are related by repeated-block proportionality.
+\end{lemma}
+
+\begin{theorem}[Sector match yields repeated-block equivalence]\label{thm:periodic_overlap_gauge_equiv_sector_match}
+	\lean{MPSTensor.periodicOverlap_gaugeEquiv_of_sector_match}
+	\uses{lem:sector_match_propagation, lem:sector_tensor_proportional_blocked_match}
+	For periodic tensors of the same period, existence of one matching
+	sector pair implies repeated-block equivalence.
+\end{theorem}
+
+\begin{theorem}[Different bond dimensions imply asymptotic orthogonality]\label{thm:periodic_overlap_zero_ne_dim}
+	\lean{MPSTensor.periodicOverlap_tendsto_zero_of_ne_dim}
+	\leanok
+	\uses{def:periodic_tensor}
+	If two periodic tensors have different bond dimensions, then
+	$\langle V_N(A), V_N(B)\rangle \to 0$ as $N\to\infty$.
+\end{theorem}
+
+\begin{theorem}[Periodic overlap dichotomy]\label{thm:periodic_overlap_dichotomy}
+	\lean{MPSTensor.periodicOverlapDichotomy}
+	\uses{thm:periodic_overlap_zero_ne_period, thm:periodic_overlap_zero_no_sector_match, thm:periodic_overlap_zero_ne_dim, thm:periodic_overlap_gauge_equiv_sector_match}
+	Let $A$ and $B$ be periodic tensors. Then exactly one of the following
+	alternatives holds:
+	\begin{enumerate}
+		\item $\langle V_N(A), V_N(B)\rangle \to 0$ as $N\to\infty$;
+		\item $A$ and $B$ are equivalent up to repeated blocks.
+	\end{enumerate}
+\end{theorem}
+
+\begin{theorem}[Eventual linear independence of a periodic basis]\label{thm:periodic_basis_eventually_li}
+	\lean{MPSTensor.periodicBasis_eventuallyLinearlyIndependent}
+	\uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
+	For a finite family of pairwise non-equivalent periodic tensors whose
+	periods divide a common integer $p$, there is $N_0$ such that for every
+	$N \ge N_0$ the vectors $\{V_{pN}(A_j)\}_j$ are linearly independent.
+\end{theorem}
+
 \begin{remark}[Comparison with the 1606.00608 approach]\notready
 	\label{rem:periodic_vs_blocking_ft}
 	Theorem~\ref{thm:periodic_ft} and the equal-MPV Fundamental Theorem

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -633,7 +633,7 @@ the remaining declarations are scaffolded with incomplete proofs.
 	\lean{MPSTensor.periodicSelfOverlap_tendsto}
 	\uses{def:periodic_tensor}
 	If $A$ is $m$-periodic, then the self-overlap along multiples of $m$
-	converges to $m$.
+	converges to $m$ (the period, viewed as a scalar).
 \end{theorem}
 
 \begin{theorem}[Different periods imply asymptotic orthogonality]\label{thm:periodic_overlap_zero_ne_period}
@@ -689,7 +689,7 @@ the remaining declarations are scaffolded with incomplete proofs.
 \begin{theorem}[Periodic overlap dichotomy]\label{thm:periodic_overlap_dichotomy}
 	\lean{MPSTensor.periodicOverlapDichotomy}
 	\uses{thm:periodic_overlap_zero_ne_period, thm:periodic_overlap_zero_no_sector_match, thm:periodic_overlap_zero_ne_dim, thm:periodic_overlap_gauge_equiv_sector_match}
-	Let $A$ and $B$ be periodic tensors. Then exactly one of the following
+	Let $A$ and $B$ be periodic tensors. Then at least one of the following
 	alternatives holds:
 	\begin{enumerate}
 		\item $\langle V_N(A), V_N(B)\rangle \to 0$ as $N\to\infty$;


### PR DESCRIPTION
### Motivation

- The blueprint lacked documentation entries for the ten declarations introduced in `TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean` (Proposition 3.3 / Appendix A), which are needed to link the formalization to the book blueprint.
- Follow-up from #366, where blueprint entries were deferred at merge time (see #393).

### Description

- Added a new subsection `Periodic overlap dichotomy (Proposition 3.3)` to `blueprint/src/chapter/ch11_assembly.tex` with ten blueprint entries corresponding to the declarations from `PeriodicOverlap.lean`.
- Inserted `\lean{...}` tags for: `MPSTensor.periodicSelfOverlap_tendsto`, `MPSTensor.periodicOverlap_tendsto_zero_of_ne_period`, `MPSTensor.sectorBlocked_isNormal_of_isPeriodic`, `MPSTensor.periodicOverlap_tendsto_zero_of_no_sector_match`, `MPSTensor.sectorMatch_propagation`, `MPSTensor.sectorTensor_proportional_of_blockedMatch`, `MPSTensor.periodicOverlap_gaugeEquiv_of_sector_match`, `MPSTensor.periodicOverlap_tendsto_zero_of_ne_dim`, `MPSTensor.periodicOverlapDichotomy`, and `MPSTensor.periodicBasis_eventuallyLinearlyIndependent`.
- Added `\leanok` only for `MPSTensor.periodicOverlap_tendsto_zero_of_ne_dim` (the only declaration without `sorry`); included `\uses{...}` cross-references for dependencies.

### Testing

- Verified presence of the expected `\lean{...}` tags with repository searches (`rg`/`grep`).
- Ran `git diff --check` — no whitespace or diff issues.
- Relies on Lean CI (`lean_action_ci.yml`) and Blueprint Lint (`lint-blueprint.yml`) to validate build.

---
Addresses #393

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only LaTeX changes adding theorem/lemma declarations and cross-references, with no impact on Lean code or runtime behavior.
> 
> **Overview**
> Adds a new **“Periodic overlap dichotomy (Proposition 3.3)”** subsection to `blueprint/src/chapter/ch11_assembly.tex`, introducing ten new theorem/lemma blueprint entries with corresponding `\lean{...}` tags and `\uses{...}` dependency references.
> 
> Marks only `MPSTensor.periodicOverlap_tendsto_zero_of_ne_dim` as `\leanok`, explicitly noting the remaining results are currently scaffolded with incomplete proofs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c0aec6a5fb13e8738b17c13e33e720500d35f2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->