### PR TITLE
feat(MPS): add iterated blocking compatibility and cyclic sector assembly

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.NormalReduction
 import TNLean.MPS.CanonicalForm.CyclicSectors
+import TNLean.MPS.CanonicalForm.CyclicSectorAssembly
 import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Core.BlockingTransfer
 import TNLean.MPS.FundamentalTheorem.Full
@@ -81,10 +82,12 @@ The per-block bridge is now complete:
 
 Remaining work for the full pipeline integration:
 
-* **Common period assembly**: Combining per-block cyclic sectors into a
-  single global decomposition with a common blocking period. Requires
-  iterated-blocking infrastructure (`blockTensor (blockTensor A p) q ≃
-  blockTensor A (p * q)`).
+* **Common period assembly**: The shared-period helper layer is now available
+  via `lcmPeriod`, `commonPeriodBlocking`,
+  `isPrimitive_transferMap_commonPeriodBlocking`, and
+  `transferMap_blockTensor_blockTensor`. What still remains is the full
+  sector-level assembly theorem that packages the cyclic decomposition data
+  into a single global direct-sum decomposition.
 
 * **Sector irreducibility**: Each cyclic sector should inherit irreducibility
   from `isIrreducible_restriction_of_cyclic_decomp`. The orbit-sum lift from

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -85,7 +85,7 @@ Remaining work for the full pipeline integration:
 * **Common period assembly**: The shared-period helper layer is now available
   via `lcmPeriod`, `commonPeriodBlocking`,
   `isPrimitive_transferMap_commonPeriodBlocking`, and
-  `transferMap_blockTensor_blockTensor`. What still remains is the full
+  `transferMap_blockTensor_mul`. What still remains is the full
   sector-level assembly theorem that packages the cyclic decomposition data
   into a single global direct-sum decomposition.
 

--- a/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
@@ -37,7 +37,8 @@ noncomputable def commonPeriodBlocking
 /-- If each block has a primitive transfer map at its own period, then blocking the whole family
 to the common LCM period preserves that primitivity witness for every member. -/
 theorem isPrimitive_transferMap_commonPeriodBlocking
-    {dim : Fin k → ℕ} [∀ i, NeZero (dim i)]
+    {dim : Fin k → ℕ}
+    (hDim : ∀ i, 0 < dim i)
     (blocks : (i : Fin k) → MPSTensor d (dim i)) (periods : Fin k → ℕ)
     (hPeriodsPos : ∀ i, 0 < periods i)
     (hPrim : ∀ i,
@@ -48,23 +49,21 @@ theorem isPrimitive_transferMap_commonPeriodBlocking
       _root_.IsPrimitive
         (transferMap (d := blockPhysDim d (lcmPeriod periods)) (D := dim i)
           (commonPeriodBlocking (d := d) blocks periods i)) := by
+  intro i
+  letI : NeZero (dim i) := ⟨Nat.ne_of_gt (hDim i)⟩
   have hlcmPos : 0 < lcmPeriod periods := by
     have hne : lcmPeriod periods ≠ 0 := by
       refine Finset.lcm_ne_zero_iff.2 ?_
-      intro i _
-      exact Nat.ne_of_gt (hPeriodsPos i)
+      intro j _
+      exact Nat.ne_of_gt (hPeriodsPos j)
     exact Nat.pos_of_ne_zero hne
-  intro i
   have hi_dvd : periods i ∣ lcmPeriod periods := Finset.dvd_lcm (Finset.mem_univ i)
-  obtain ⟨m, hm⟩ := hi_dvd
-  have hm_pos : 0 < m := by
-    have hmul : 0 < periods i * m := by simpa [hm] using hlcmPos
-    exact Nat.pos_of_mul_pos_left hmul
-  rw [show commonPeriodBlocking (d := d) blocks periods i =
-      blockTensor (d := d) (D := dim i) (blocks i) (lcmPeriod periods) from rfl, hm]
-  rw [← transferMap_blockTensor_blockTensor (A := blocks i) (m := periods i) (n := m)]
-  rw [transferMap_blockTensor]
-  exact isPrimitive_pow_of_isPrimitive _ m hm_pos (hPrim i)
+  simpa [commonPeriodBlocking] using
+    isPrimitive_transferMap_blockTensor_of_dvd
+      (d := d) (D := dim i)
+      (A := blocks i)
+      (p := periods i) (q := lcmPeriod periods)
+      hi_dvd hlcmPos (hPrim i)
 
 /-- The common-period blocked family has the expected physical dimension. -/
 theorem commonPeriodBlocking_apply

--- a/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
@@ -1,12 +1,12 @@
-import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Core.BlockingInfrastructure
 
 /-!
 # Common-period assembly helpers for cyclic-sector blocks
 
-This file provides lightweight definitions used to align periodic blocks to a
-single global period.
+This file provides lightweight helpers used to align periodic blocks to a
+single global period and to transport per-block primitivity witnesses to that
+common blocking level.
 -/
 
 namespace MPSTensor
@@ -20,29 +20,43 @@ noncomputable def lcmPeriod (periods : Fin k → ℕ) : ℕ :=
 /-- Block each family member to the common `lcmPeriod`.
 
 This keeps a uniform physical dimension across the assembled family. The
-periodicity witness is carried as input because this is the intended API point
-for cyclic-sector assembly.
+resulting family is the basic input for common-period cyclic-sector assembly.
 -/
 noncomputable def commonPeriodBlocking
-    (blocks : Fin k → MPSTensor d D) (periods : Fin k → ℕ)
-    (_hPeriodic : ∀ i, IsPeriodic (periods i) (blocks i)) :
+    (blocks : Fin k → MPSTensor d D) (periods : Fin k → ℕ) :
     Fin k → MPSTensor (blockPhysDim d (lcmPeriod periods)) D :=
   fun i => blockTensor (d := d) (D := D) (blocks i) (lcmPeriod periods)
 
-/-- Blocking a sector-irreducible witness transfers to any multiple period. -/
-def IsSectorIrreducible (A : MPSTensor d D) (p : ℕ) (_u : Fin p) : Prop :=
-  _root_.IsPrimitive
-    (transferMap (d := blockPhysDim d p) (D := D) (blockTensor (d := d) (D := D) A p))
+/-- If each block has a primitive transfer map at its own period, then blocking the whole family
+to the common LCM period preserves that primitivity witness for every member. -/
+theorem isPrimitive_transferMap_commonPeriodBlocking
+    [NeZero D]
+    (blocks : Fin k → MPSTensor d D) (periods : Fin k → ℕ)
+    (hPeriodsPos : ∀ i, 0 < periods i)
+    (hPrim : ∀ i,
+      _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d (periods i)) (D := D)
+          (blockTensor (d := d) (D := D) (blocks i) (periods i)))) :
+    ∀ i,
+      _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d (lcmPeriod periods)) (D := D)
+          (commonPeriodBlocking (d := d) (D := D) blocks periods i)) := by
+  have hlcmPos : 0 < lcmPeriod periods := by
+    have hne : lcmPeriod periods ≠ 0 := by
+      refine Finset.lcm_ne_zero_iff.2 ?_
+      intro i _
+      exact Nat.ne_of_gt (hPeriodsPos i)
+    exact Nat.pos_of_ne_zero hne
+  intro i
+  have hi_dvd : periods i ∣ lcmPeriod periods := Finset.dvd_lcm (Finset.mem_univ i)
+  simpa [commonPeriodBlocking, lcmPeriod] using
+    isPrimitive_transferMap_blockTensor_of_dvd
+      (A := blocks i) (p := periods i) (q := lcmPeriod periods) hi_dvd hlcmPos (hPrim i)
 
-theorem sectorIrreducible_of_blocked
-    (A : MPSTensor d D) {p : ℕ} [NeZero D] (u : Fin p)
-    (hIrr : IsSectorIrreducible (d := d) (D := D) A p u) (m : ℕ) (hm : 0 < m) :
-    IsSectorIrreducible (d := d) (D := D)
-      A (p * m) ⟨0, Nat.mul_pos (Nat.zero_lt_of_lt u.is_lt) hm⟩ := by
-  dsimp [IsSectorIrreducible] at hIrr ⊢
-  have hp : 0 < p := Nat.zero_lt_of_lt u.is_lt
-  have hpm : 0 < p * m := Nat.mul_pos hp hm
-  exact isPrimitive_transferMap_blockTensor_of_dvd
-    (A := A) (p := p) (q := p * m) (dvd_mul_right p m) hpm hIrr
+/-- The common-period blocked family has the expected physical dimension. -/
+theorem commonPeriodBlocking_apply
+    (blocks : Fin k → MPSTensor d D) (periods : Fin k → ℕ) (i : Fin k) :
+    commonPeriodBlocking (d := d) (D := D) blocks periods i =
+      blockTensor (d := d) (D := D) (blocks i) (lcmPeriod periods) := rfl
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
@@ -1,0 +1,48 @@
+import TNLean.MPS.Periodic.Defs
+import TNLean.MPS.Core.Blocking
+import TNLean.MPS.Core.BlockingInfrastructure
+
+/-!
+# Common-period assembly helpers for cyclic-sector blocks
+
+This file provides lightweight definitions used to align periodic blocks to a
+single global period.
+-/
+
+namespace MPSTensor
+
+variable {d D k : ℕ}
+
+/-- LCM of a finite family of periods indexed by `Fin k`. -/
+noncomputable def lcmPeriod (periods : Fin k → ℕ) : ℕ :=
+  Finset.univ.lcm periods
+
+/-- Block each family member to the common `lcmPeriod`.
+
+This keeps a uniform physical dimension across the assembled family. The
+periodicity witness is carried as input because this is the intended API point
+for cyclic-sector assembly.
+-/
+noncomputable def commonPeriodBlocking
+    (blocks : Fin k → MPSTensor d D) (periods : Fin k → ℕ)
+    (_hPeriodic : ∀ i, IsPeriodic (periods i) (blocks i)) :
+    Fin k → MPSTensor (blockPhysDim d (lcmPeriod periods)) D :=
+  fun i => blockTensor (d := d) (D := D) (blocks i) (lcmPeriod periods)
+
+/-- Blocking a sector-irreducible witness transfers to any multiple period. -/
+def IsSectorIrreducible (A : MPSTensor d D) (p : ℕ) (_u : Fin p) : Prop :=
+  _root_.IsPrimitive
+    (transferMap (d := blockPhysDim d p) (D := D) (blockTensor (d := d) (D := D) A p))
+
+theorem sectorIrreducible_of_blocked
+    (A : MPSTensor d D) {p : ℕ} [NeZero D] (u : Fin p)
+    (hIrr : IsSectorIrreducible (d := d) (D := D) A p u) (m : ℕ) (hm : 0 < m) :
+    IsSectorIrreducible (d := d) (D := D)
+      A (p * m) ⟨0, Nat.mul_pos (Nat.zero_lt_of_lt u.is_lt) hm⟩ := by
+  dsimp [IsSectorIrreducible] at hIrr ⊢
+  have hp : 0 < p := Nat.zero_lt_of_lt u.is_lt
+  have hpm : 0 < p * m := Nat.mul_pos hp hm
+  exact isPrimitive_transferMap_blockTensor_of_dvd
+    (A := A) (p := p) (q := p * m) (dvd_mul_right p m) hpm hIrr
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Core.BlockingInfrastructure
 
@@ -11,7 +16,7 @@ common blocking level.
 
 namespace MPSTensor
 
-variable {d D k : ℕ}
+variable {d k : ℕ}
 
 /-- LCM of a finite family of periods indexed by `Fin k`. -/
 noncomputable def lcmPeriod (periods : Fin k → ℕ) : ℕ :=
@@ -19,28 +24,30 @@ noncomputable def lcmPeriod (periods : Fin k → ℕ) : ℕ :=
 
 /-- Block each family member to the common `lcmPeriod`.
 
-This keeps a uniform physical dimension across the assembled family. The
+This keeps a uniform physical dimension across the assembled family while
+allowing the bond dimension to vary with the index. The
 resulting family is the basic input for common-period cyclic-sector assembly.
 -/
 noncomputable def commonPeriodBlocking
-    (blocks : Fin k → MPSTensor d D) (periods : Fin k → ℕ) :
-    Fin k → MPSTensor (blockPhysDim d (lcmPeriod periods)) D :=
-  fun i => blockTensor (d := d) (D := D) (blocks i) (lcmPeriod periods)
+    {dim : Fin k → ℕ}
+    (blocks : (i : Fin k) → MPSTensor d (dim i)) (periods : Fin k → ℕ) :
+    (i : Fin k) → MPSTensor (blockPhysDim d (lcmPeriod periods)) (dim i) :=
+  fun i => blockTensor (d := d) (D := dim i) (blocks i) (lcmPeriod periods)
 
 /-- If each block has a primitive transfer map at its own period, then blocking the whole family
 to the common LCM period preserves that primitivity witness for every member. -/
 theorem isPrimitive_transferMap_commonPeriodBlocking
-    [NeZero D]
-    (blocks : Fin k → MPSTensor d D) (periods : Fin k → ℕ)
+    {dim : Fin k → ℕ} [∀ i, NeZero (dim i)]
+    (blocks : (i : Fin k) → MPSTensor d (dim i)) (periods : Fin k → ℕ)
     (hPeriodsPos : ∀ i, 0 < periods i)
     (hPrim : ∀ i,
       _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d (periods i)) (D := D)
-          (blockTensor (d := d) (D := D) (blocks i) (periods i)))) :
+        (transferMap (d := blockPhysDim d (periods i)) (D := dim i)
+          (blockTensor (d := d) (D := dim i) (blocks i) (periods i)))) :
     ∀ i,
       _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d (lcmPeriod periods)) (D := D)
-          (commonPeriodBlocking (d := d) (D := D) blocks periods i)) := by
+        (transferMap (d := blockPhysDim d (lcmPeriod periods)) (D := dim i)
+          (commonPeriodBlocking (d := d) blocks periods i)) := by
   have hlcmPos : 0 < lcmPeriod periods := by
     have hne : lcmPeriod periods ≠ 0 := by
       refine Finset.lcm_ne_zero_iff.2 ?_
@@ -49,14 +56,21 @@ theorem isPrimitive_transferMap_commonPeriodBlocking
     exact Nat.pos_of_ne_zero hne
   intro i
   have hi_dvd : periods i ∣ lcmPeriod periods := Finset.dvd_lcm (Finset.mem_univ i)
-  simpa [commonPeriodBlocking, lcmPeriod] using
-    isPrimitive_transferMap_blockTensor_of_dvd
-      (A := blocks i) (p := periods i) (q := lcmPeriod periods) hi_dvd hlcmPos (hPrim i)
+  obtain ⟨m, hm⟩ := hi_dvd
+  have hm_pos : 0 < m := by
+    have hmul : 0 < periods i * m := by simpa [hm] using hlcmPos
+    exact Nat.pos_of_mul_pos_left hmul
+  rw [show commonPeriodBlocking (d := d) blocks periods i =
+      blockTensor (d := d) (D := dim i) (blocks i) (lcmPeriod periods) from rfl, hm]
+  rw [← transferMap_blockTensor_blockTensor (A := blocks i) (m := periods i) (n := m)]
+  rw [transferMap_blockTensor]
+  exact isPrimitive_pow_of_isPrimitive _ m hm_pos (hPrim i)
 
 /-- The common-period blocked family has the expected physical dimension. -/
 theorem commonPeriodBlocking_apply
-    (blocks : Fin k → MPSTensor d D) (periods : Fin k → ℕ) (i : Fin k) :
-    commonPeriodBlocking (d := d) (D := D) blocks periods i =
-      blockTensor (d := d) (D := D) (blocks i) (lcmPeriod periods) := rfl
+    {dim : Fin k → ℕ}
+    (blocks : (i : Fin k) → MPSTensor d (dim i)) (periods : Fin k → ℕ) (i : Fin k) :
+    commonPeriodBlocking (d := d) blocks periods i =
+      blockTensor (d := d) (D := dim i) (blocks i) (lcmPeriod periods) := rfl
 
 end MPSTensor

--- a/TNLean/MPS/Core/BlockingTransfer.lean
+++ b/TNLean/MPS/Core/BlockingTransfer.lean
@@ -87,4 +87,16 @@ theorem transferMap_blockTensor_fixedPoint
   -- Now rewrite the blocked transfer map as an iterate.
   simpa [transferMap_blockTensor_apply (A := A) (L := L) (X := X)] using hpow
 
+/-- Iterated physical blocking is compatible with one-shot blocking by the multiplied period,
+at the transfer-map level. -/
+theorem blockTensor_blockTensor
+    (A : MPSTensor d D) (m n : ℕ) :
+    transferMap (d := blockPhysDim (blockPhysDim d m) n) (D := D)
+        (blockTensor (d := blockPhysDim d m) (D := D)
+          (blockTensor (d := d) (D := D) A m) n) =
+      transferMap (d := blockPhysDim d (m * n)) (D := D)
+        (blockTensor (d := d) (D := D) A (m * n)) := by
+  rw [transferMap_blockTensor, transferMap_blockTensor, transferMap_blockTensor]
+  simp [pow_mul]
+
 end MPSTensor

--- a/TNLean/MPS/Core/BlockingTransfer.lean
+++ b/TNLean/MPS/Core/BlockingTransfer.lean
@@ -88,8 +88,9 @@ theorem transferMap_blockTensor_fixedPoint
   simpa [transferMap_blockTensor_apply (A := A) (L := L) (X := X)] using hpow
 
 /-- Iterated physical blocking is compatible with one-shot blocking by the multiplied period,
-at the transfer-map level. -/
-theorem transferMap_blockTensor_blockTensor
+at the transfer-map level:
+`transferMap(block(block(A, m), n)) = transferMap(block(A, m * n))`. -/
+theorem transferMap_blockTensor_mul
     (A : MPSTensor d D) (m n : ℕ) :
     transferMap (d := blockPhysDim (blockPhysDim d m) n) (D := D)
         (blockTensor (d := blockPhysDim d m) (D := D)

--- a/TNLean/MPS/Core/BlockingTransfer.lean
+++ b/TNLean/MPS/Core/BlockingTransfer.lean
@@ -89,7 +89,7 @@ theorem transferMap_blockTensor_fixedPoint
 
 /-- Iterated physical blocking is compatible with one-shot blocking by the multiplied period,
 at the transfer-map level. -/
-theorem blockTensor_blockTensor
+theorem transferMap_blockTensor_blockTensor
     (A : MPSTensor d D) (m n : ℕ) :
     transferMap (d := blockPhysDim (blockPhysDim d m) n) (D := D)
         (blockTensor (d := blockPhysDim d m) (D := D)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -953,6 +953,24 @@ The following results separate the zero blocks from the
 	Apply Theorem~\ref{thm:primitive_pow} with $\E = \E_{A^{[p]}}$.
 \end{proof}
 
+\begin{theorem}[Iterated blocking multiplies periods at the transfer-map level]%
+	\label{thm:iterated_blocking_transfer}
+	\lean{MPSTensor.transferMap_blockTensor_blockTensor}
+	\leanok
+	\uses{def:blocked_tensor}
+	For any MPS tensor $A$ and integers $m,n \ge 0$,
+	\[
+		\E_{(A^{[m]})^{[n]}} = \E_{A^{[mn]}}.
+	\]
+\end{theorem}
+
+\begin{proof}\leanok
+	Rewrite the outer blocked transfer map as the $n$-th power of
+	$\E_{A^{[m]}}$, then rewrite $\E_{A^{[m]}}$ as $\E_A^m$.
+	This gives $(\E_A^m)^n$, which simplifies to $\E_A^{mn}$.
+	Finally rewrite $\E_A^{mn}$ back as the transfer map of $A^{[mn]}$.
+\end{proof}
+
 \begin{theorem}[Common blocking period for a block family]%
 	\label{thm:common_blocking_period}
 	\lean{MPSTensor.exists_common_blocking_all_primitive}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -955,7 +955,7 @@ The following results separate the zero blocks from the
 
 \begin{theorem}[Iterated blocking multiplies periods at the transfer-map level]%
 	\label{thm:iterated_blocking_transfer}
-	\lean{MPSTensor.transferMap_blockTensor_blockTensor}
+	\lean{MPSTensor.transferMap_blockTensor_mul}
 	\leanok
 	\uses{def:blocked_tensor}
 	For any MPS tensor $A$ and integers $m,n \ge 0$,

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -493,7 +493,7 @@ directly to periodic tensors.
 	\lean{MPSTensor.lcmPeriod}
 	\leanok
 	Given a finite family of blocking periods $(p_i)$ indexed by a finite set,
-	\texttt{lcmPeriod} is their least common multiple.
+	their least common multiple serves as the shared blocking period.
 \end{definition}
 
 \begin{definition}[Common-period blocked family]
@@ -502,8 +502,8 @@ directly to periodic tensors.
 	\leanok
 	\uses{def:lcm_period, def:blocked_tensor}
 	Given a finite family of tensors $(B_i)$ with designated periods $(p_i)$,
-	\texttt{commonPeriodBlocking} blocks each $B_i$ to the shared period
-	$\operatorname{lcm}(p_i)$, so every block lives in the same physical space.
+	block each $B_i$ to the shared period $\operatorname{lcm}(p_i)$, so
+	every block lives in the same physical space.
 \end{definition}
 
 \begin{theorem}[Common-period blocking preserves transfer-map primitivity]
@@ -512,9 +512,8 @@ directly to periodic tensors.
 	\leanok
 	\uses{def:common_period_blocking, thm:iterated_blocking_transfer, thm:primitive_blocking_divisible}
 	If each tensor $B_i$ has a primitive transfer map after blocking by its own
-	positive period $p_i$, then every tensor in the family
-	\texttt{commonPeriodBlocking} applied to $(B_i)$ and $(p_i)$ also has
-	primitive transfer maps blockwise.
+	positive period $p_i$, then blocking the entire family to the common
+	LCM period preserves primitivity of each member's transfer map.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -510,7 +510,7 @@ directly to periodic tensors.
 	\label{thm:common_period_blocking_primitive}
 	\lean{MPSTensor.isPrimitive_transferMap_commonPeriodBlocking}
 	\leanok
-	\uses{def:common_period_blocking}
+	\uses{def:common_period_blocking, thm:primitive_blocking_divisible}
 	If each tensor $B_i$ has a primitive transfer map after blocking by its own
 	positive period $p_i$, then every tensor in the family
 	\texttt{commonPeriodBlocking} applied to $(B_i)$ and $(p_i)$ also has

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -486,6 +486,43 @@ directly to periodic tensors.
 	\end{enumerate}
 \end{remark}
 
+\subsection{Common-period assembly helpers}
+
+\begin{definition}[LCM period for a finite block family]
+	\label{def:lcm_period}
+	\lean{MPSTensor.lcmPeriod}
+	\leanok
+	Given a finite family of blocking periods $(p_i)$ indexed by a finite set,
+	\texttt{lcmPeriod} is their least common multiple.
+\end{definition}
+
+\begin{definition}[Common-period blocked family]
+	\label{def:common_period_blocking}
+	\lean{MPSTensor.commonPeriodBlocking}
+	\leanok
+	\uses{def:lcm_period, def:blocked_tensor}
+	Given a finite family of tensors $(B_i)$ with designated periods $(p_i)$,
+	\texttt{commonPeriodBlocking} blocks each $B_i$ to the shared period
+	$\operatorname{lcm}(p_i)$, so every block lives in the same physical space.
+\end{definition}
+
+\begin{theorem}[Common-period blocking preserves transfer-map primitivity]
+	\label{thm:common_period_blocking_primitive}
+	\lean{MPSTensor.isPrimitive_transferMap_commonPeriodBlocking}
+	\leanok
+	\uses{def:common_period_blocking}
+	If each tensor $B_i$ has a primitive transfer map after blocking by its own
+	positive period $p_i$, then every tensor in the family
+	\texttt{commonPeriodBlocking} applied to $(B_i)$ and $(p_i)$ also has
+	primitive transfer maps blockwise.
+\end{theorem}
+
+\begin{proof}\leanok
+	Each $p_i$ divides $\operatorname{lcm}(p_i)$.
+	Apply the divisibility monotonicity theorem for primitive blocked transfer maps
+	to each family member separately.
+\end{proof}
+
 \subsection{The \texorpdfstring{$Z$}{Z}-gauge degree of freedom}
 
 \begin{definition}[Entrywise periodic \(Z\)-gauge ratio]\label{def:z_gauge_entry}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -510,7 +510,7 @@ directly to periodic tensors.
 	\label{thm:common_period_blocking_primitive}
 	\lean{MPSTensor.isPrimitive_transferMap_commonPeriodBlocking}
 	\leanok
-	\uses{def:common_period_blocking, thm:primitive_blocking_divisible}
+	\uses{def:common_period_blocking, thm:iterated_blocking_transfer, thm:primitive_blocking_divisible}
 	If each tensor $B_i$ has a primitive transfer map after blocking by its own
 	positive period $p_i$, then every tensor in the family
 	\texttt{commonPeriodBlocking} applied to $(B_i)$ and $(p_i)$ also has


### PR DESCRIPTION
### Motivation

- Provide iterated-blocking compatibility needed to re-block decompositions to a common period for cyclic-sector assembly (Gap 1 from #397).
- Offer lightweight helpers to re-block families of periodic blocks to their LCM period and to lift sector-irreducibility across multiples of a period.

### Description

- Added `theorem blockTensor_blockTensor` in `TNLean/MPS/Core/BlockingTransfer.lean` proving at the transfer-map level that `transferMap (blockTensor (blockTensor A m) n) = transferMap (blockTensor A (m * n))` by rewriting with `transferMap_blockTensor` and `pow_mul`.
- Introduced `TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean` providing `lcmPeriod`, `commonPeriodBlocking` (blocks a family to the LCM period), and a minimal `IsSectorIrreducible` predicate plus `sectorIrreducible_of_blocked` which lifts primitivity of a blocked transfer map from period `p` to any multiple `p * m` via `isPrimitive_transferMap_blockTensor_of_dvd`.
- Reused existing lemmas (`transferMap_blockTensor`, `isPrimitive_transferMap_blockTensor_of_dvd`) and adjusted local hypotheses/instances (`[NeZero D]`, explicit `0 < m`) to make the new statements type-check and import cleanly.

### Testing

- Performed Lean compilation of the affected targets with `lake build TNLean.MPS.Core.BlockingTransfer TNLean.MPS.CanonicalForm.CyclicSectorAssembly`, and both targets compiled successfully.
- The new file and the modified file were included in a subsequent successful `lake build` of the consuming module.

---
Addresses #397

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean lemmas/helpers and documentation without changing existing APIs’ behavior, but could surface downstream proof breakages due to new imports/rewrites.
> 
> **Overview**
> Adds a new `CyclicSectorAssembly` helper module to align a finite family of periodic blocks to a shared LCM period (`lcmPeriod`, `commonPeriodBlocking`) and to lift per-block primitivity proofs to that common blocking (`isPrimitive_transferMap_commonPeriodBlocking`).
> 
> Extends `BlockingTransfer` with `transferMap_blockTensor_mul`, showing iterated physical blocking matches direct blocking by the multiplied period at the transfer-map level, and wires these helpers into the canonical-form assembly docs and blueprint (including new theorems/definitions documenting the common-period workflow).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80b92450ce4a223201773c40de80432c799f836a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->