### PR TITLE
feat(Channel/Semigroup/Primitivity): prove fraction-slice primitivity lemmas

### DIFF
--- a/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
@@ -16,15 +16,7 @@ attribute [local instance] Matrix.linftyOpNormedAlgebra
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-/-! ## Prop 7.5: Irreducibility implies primitivity for QDS
-
-### Note on `sorry` placeholders
-
-The 13 `sorry` placeholders in this file were originally declared as `axiom`s,
-which bypass Lean's proof-tracking system. They have been converted to
-`theorem ... := by sorry` so that `#print axioms` honestly reports the gaps.
-Each placeholder has a `TODO` docstring describing the missing proof argument.
--/
+/-! ## Prop 7.5: Irreducibility implies primitivity for QDS -/
 
 theorem primitive_channel_pow_tendsto_zero_of_trace_zero [NeZero D]
     (E : Mat →ₗ[ℂ] Mat) (hE : IsChannel E) (hIrr : IsIrreducibleMap E)
@@ -388,19 +380,17 @@ theorem fixedPoint_eq_trace_smul_at_irreducible_time
       (by rw [Matrix.trace_sub, Matrix.trace_smul, hσ_mem.2, smul_eq_mul,
                mul_one, sub_self]))
 
-/-- **TODO**: Prove eigenvector with nonzero trace for fraction slices.
-Currently a `sorry` placeholder. -/
+/-- A fraction slice has a peripheral eigenvector with nonzero trace. -/
 theorem exists_trace_ne_zero_eigenvector_of_fraction_slice
     [NeZero D]
     (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    {t₀ u : ℝ} {N : ℕ}
-    (hTt₀_eq_pow : T t₀ = (T u) ^ N)
+    {t₀ u : ℝ}
+    (hTt₀_eq_pow : T t₀ = (T u) ^ Nat.factorial (Module.finrank ℂ Mat))
     (hTu_ch : IsChannel (T u))
     (hTu_irr : IsIrreducibleMap (T u))
-    (σ : Mat) (hσ_mem : σ ∈ densityMatrices D) (hσ_pd : σ.PosDef)
+    (σ : Mat) (hσ_pd : σ.PosDef)
     (hTu_fix : T u σ = σ)
     (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ)
-    (hN_fac : N = Nat.factorial (Module.finrank ℂ Mat))
     {μ : ℂ}
     (hμ_eig : Module.End.HasEigenvalue (T u) μ)
     (hμ_norm : ‖μ‖ = 1) :
@@ -415,61 +405,58 @@ theorem exists_trace_ne_zero_eigenvector_of_fraction_slice
   have hX_eig : T u X = μ • X := Module.End.mem_eigenspace_iff.mp hXev.1
   have hp_dvd : p ∣ Nat.factorial (Module.finrank ℂ Mat) := Nat.dvd_factorial hp_pos hp_le
   obtain ⟨k, hk⟩ := hp_dvd
-  have hμN : μ ^ N = 1 := by
-    rw [hN_fac, hk, pow_mul, hμp, one_pow]
+  have hμN : μ ^ Nat.factorial (Module.finrank ℂ Mat) = 1 := by
+    rw [hk, pow_mul, hμp, one_pow]
   refine ⟨X, hX_ne, hX_eig, ?_⟩
   by_contra htrX
   have hX_fix_t₀ : T t₀ X = X := by
     calc
-      T t₀ X = ((T u) ^ N) X := by rw [hTt₀_eq_pow]
-      _ = μ ^ N • X := pow_apply_eigenvector (T u) X μ N hX_eig
+      T t₀ X = ((T u) ^ Nat.factorial (Module.finrank ℂ Mat)) X := by rw [hTt₀_eq_pow]
+      _ = μ ^ Nat.factorial (Module.finrank ℂ Mat) • X := by
+        exact pow_apply_eigenvector (T u) X μ (Nat.factorial (Module.finrank ℂ Mat)) hX_eig
       _ = X := by simpa [hμN]
   have hX_span : X = Matrix.trace X • σ := hfixed_1d X hX_fix_t₀
   have : X = 0 := by simpa [htrX] using hX_span
   exact hX_ne this
 
-/-- **TODO**: Prove peripheral eigenvalue equals 1 in fraction slice.
-Currently a `sorry` placeholder. -/
+/-- Peripheral eigenvalues of a fraction slice are equal to `1`. -/
 theorem peripheral_eq_one_of_fraction_slice
     [NeZero D]
     (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    {t₀ u : ℝ} {N : ℕ}
-    (hTt₀_eq_pow : T t₀ = (T u) ^ N)
+    {t₀ u : ℝ}
+    (hTt₀_eq_pow : T t₀ = (T u) ^ Nat.factorial (Module.finrank ℂ Mat))
     (hTu_ch : IsChannel (T u))
     (hTu_irr : IsIrreducibleMap (T u))
-    (σ : Mat) (hσ_mem : σ ∈ densityMatrices D) (hσ_pd : σ.PosDef)
+    (σ : Mat) (hσ_pd : σ.PosDef)
     (hTu_fix : T u σ = σ)
     (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ)
-    (hN_fac : N = Nat.factorial (Module.finrank ℂ Mat))
     {μ : ℂ}
     (hμ_eig : Module.End.HasEigenvalue (T u) μ)
     (hμ_norm : ‖μ‖ = 1) :
     μ = 1 := by
   obtain ⟨X, _, hX_eig, htrX_ne⟩ :=
     exists_trace_ne_zero_eigenvector_of_fraction_slice
-      T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_mem hσ_pd hTu_fix hfixed_1d hN_fac hμ_eig hμ_norm
+      T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_pd hTu_fix hfixed_1d hμ_eig hμ_norm
   exact eigenvalue_eq_one_of_trace_preserving_eigenvector
     (T u) hTu_ch.tp hX_eig htrX_ne
 
-/-- **TODO**: Prove primitivity from fraction slice hypotheses.
-Currently a `sorry` placeholder. -/
+/-- Fraction-slice hypotheses imply primitivity of the slice. -/
 theorem primitive_of_fraction_slice
     [NeZero D]
     (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    {t₀ u : ℝ} {N : ℕ}
-    (hTt₀_eq_pow : T t₀ = (T u) ^ N)
+    {t₀ u : ℝ}
+    (hTt₀_eq_pow : T t₀ = (T u) ^ Nat.factorial (Module.finrank ℂ Mat))
     (hTu_ch : IsChannel (T u))
     (hTu_irr : IsIrreducibleMap (T u))
     (σ : Mat) (hσ_mem : σ ∈ densityMatrices D) (hσ_pd : σ.PosDef)
     (hTu_fix : T u σ = σ)
-    (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ)
-    (hN_fac : N = Nat.factorial (Module.finrank ℂ Mat)) :
+    (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ) :
     IsPrimitive (T u) := by
   have hσ_ne := ne_zero_of_mem_densityMatrices' hσ_mem
   exact isPrimitive_of_unique_norm_one (T u) σ hTu_fix hσ_ne
     (fun μ hμ_eig hμ_norm =>
       peripheral_eq_one_of_fraction_slice
-        T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_mem hσ_pd hTu_fix hfixed_1d hN_fac hμ_eig hμ_norm)
+        T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_pd hTu_fix hfixed_1d hμ_eig hμ_norm)
 
 theorem irreducible_of_fraction_slice
     (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -549,8 +536,7 @@ theorem exists_irreducible_fraction_slice
   have hTu_irr : IsIrreducibleMap (T u) := irreducible_of_fraction_slice T hTt₀_eq_pow hirr
   exact ⟨u, hu_pos, hu_nonneg, hTt₀_eq_pow, hTu_ch, hTu_irr, hTu_fix⟩
 
-/-- **TODO**: Prove fixed points have trace scalar form.
-Currently a `sorry` placeholder. -/
+/-- For a primitive fraction slice, fixed points are trace multiples of `σ`. -/
 theorem fixedPoint_eq_trace_smul_of_primitive_slice
     [NeZero D]
     (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -579,8 +565,7 @@ theorem fixedPoint_eq_trace_smul_of_primitive_slice
       L T hT hexp u hu_nonneg s hs hdecay hτ_fix'
   exact sub_eq_zero.mp hzero
 
-/-- **TODO**: Prove that a primitive fraction slice exists.
-Currently a `sorry` placeholder. -/
+/-- There exists a primitive slice at a positive rational fraction of `t₀`. -/
 theorem exists_primitive_fraction_slice
     [NeZero D]
     (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -594,11 +579,9 @@ theorem exists_primitive_fraction_slice
       T u σ = σ ∧ IsPrimitive (T u) := by
   obtain ⟨u, hu_pos, hu_nonneg, hTt₀_eq_pow, hTu_ch, hTu_irr, hTu_fix⟩ :=
     exists_irreducible_fraction_slice T hT t₀ ht₀ hirr σ hσ_fix_all
-  have hN_fac : Nat.factorial (Module.finrank ℂ Mat) =
-      Nat.factorial (Module.finrank ℂ Mat) := rfl
   refine ⟨u, hu_pos, hu_nonneg, hTu_ch, hTu_irr, hTu_fix, ?_⟩
   exact primitive_of_fraction_slice
-    T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_mem hσ_pd hTu_fix hfixed_1d hN_fac
+    T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_mem hσ_pd hTu_fix hfixed_1d
 
 theorem irreducible_all_of_irreducible_time
     [NeZero D]

--- a/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
@@ -400,11 +400,33 @@ theorem exists_trace_ne_zero_eigenvector_of_fraction_slice
     (σ : Mat) (hσ_mem : σ ∈ densityMatrices D) (hσ_pd : σ.PosDef)
     (hTu_fix : T u σ = σ)
     (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ)
+    (hN_fac : N = Nat.factorial (Module.finrank ℂ Mat))
     {μ : ℂ}
     (hμ_eig : Module.End.HasEigenvalue (T u) μ)
     (hμ_norm : ‖μ‖ = 1) :
     ∃ X : Mat, X ≠ 0 ∧ T u X = μ • X ∧ Matrix.trace X ≠ 0 := by
-  sorry
+  have hμ_periph : μ ∈ peripheralEigenvalues (T u) := ⟨hμ_eig, hμ_norm⟩
+  have hpow_closed := peripheral_powers_closed_of_irreducible_channel_with_fixed
+    (T u) hTu_ch hTu_irr σ hσ_pd hTu_fix hμ_periph
+  obtain ⟨p, hp_pos, hp_le, hμp⟩ :=
+    bounded_root_of_peripheral_closed_powers (T u) μ hμ_periph hpow_closed
+  obtain ⟨X, hXev⟩ := hμ_eig.exists_hasEigenvector
+  have hX_ne : X ≠ 0 := hXev.2
+  have hX_eig : T u X = μ • X := Module.End.mem_eigenspace_iff.mp hXev.1
+  have hp_dvd : p ∣ Nat.factorial (Module.finrank ℂ Mat) := Nat.dvd_factorial hp_pos hp_le
+  obtain ⟨k, hk⟩ := hp_dvd
+  have hμN : μ ^ N = 1 := by
+    rw [hN_fac, hk, pow_mul, hμp, one_pow]
+  refine ⟨X, hX_ne, hX_eig, ?_⟩
+  by_contra htrX
+  have hX_fix_t₀ : T t₀ X = X := by
+    calc
+      T t₀ X = ((T u) ^ N) X := by rw [hTt₀_eq_pow]
+      _ = μ ^ N • X := pow_apply_eigenvector (T u) X μ N hX_eig
+      _ = X := by simpa [hμN]
+  have hX_span : X = Matrix.trace X • σ := hfixed_1d X hX_fix_t₀
+  have : X = 0 := by simpa [htrX] using hX_span
+  exact hX_ne this
 
 /-- **TODO**: Prove peripheral eigenvalue equals 1 in fraction slice.
 Currently a `sorry` placeholder. -/
@@ -418,11 +440,16 @@ theorem peripheral_eq_one_of_fraction_slice
     (σ : Mat) (hσ_mem : σ ∈ densityMatrices D) (hσ_pd : σ.PosDef)
     (hTu_fix : T u σ = σ)
     (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ)
+    (hN_fac : N = Nat.factorial (Module.finrank ℂ Mat))
     {μ : ℂ}
     (hμ_eig : Module.End.HasEigenvalue (T u) μ)
     (hμ_norm : ‖μ‖ = 1) :
     μ = 1 := by
-  sorry
+  obtain ⟨X, _, hX_eig, htrX_ne⟩ :=
+    exists_trace_ne_zero_eigenvector_of_fraction_slice
+      T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_mem hσ_pd hTu_fix hfixed_1d hN_fac hμ_eig hμ_norm
+  exact eigenvalue_eq_one_of_trace_preserving_eigenvector
+    (T u) hTu_ch.tp hX_eig htrX_ne
 
 /-- **TODO**: Prove primitivity from fraction slice hypotheses.
 Currently a `sorry` placeholder. -/
@@ -435,9 +462,14 @@ theorem primitive_of_fraction_slice
     (hTu_irr : IsIrreducibleMap (T u))
     (σ : Mat) (hσ_mem : σ ∈ densityMatrices D) (hσ_pd : σ.PosDef)
     (hTu_fix : T u σ = σ)
-    (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ) :
+    (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ)
+    (hN_fac : N = Nat.factorial (Module.finrank ℂ Mat)) :
     IsPrimitive (T u) := by
-  sorry
+  have hσ_ne := ne_zero_of_mem_densityMatrices' hσ_mem
+  exact isPrimitive_of_unique_norm_one (T u) σ hTu_fix hσ_ne
+    (fun μ hμ_eig hμ_norm =>
+      peripheral_eq_one_of_fraction_slice
+        T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_mem hσ_pd hTu_fix hfixed_1d hN_fac hμ_eig hμ_norm)
 
 theorem irreducible_of_fraction_slice
     (T : ℝ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -535,7 +567,17 @@ theorem fixedPoint_eq_trace_smul_of_primitive_slice
     (s : ℝ) (hs : 0 < s)
     {τ : Mat} (hτ_fix : T s τ = τ) :
     τ = Matrix.trace τ • σ := by
-  sorry
+  have hτ_tr0 : Matrix.trace (τ - Matrix.trace τ • σ) = 0 := by
+    rw [Matrix.trace_sub, Matrix.trace_smul, hσ_mem.2, smul_eq_mul, mul_one, sub_self]
+  have hτ_fix' : T s (τ - Matrix.trace τ • σ) = τ - Matrix.trace τ • σ := by
+    rw [map_sub, map_smul, hτ_fix, hσ_fix_all s (le_of_lt hs)]
+  have hdecay :=
+    trace_zero_fixedPoint_tendsto_zero_of_primitive_slice
+      T hT σ hσ_mem u hu_nonneg hTu_ch hTu_irr hTu_fix hTu_prim hτ_tr0
+  have hzero :=
+    fixedPoint_eq_zero_of_trace_zero_of_primitive_slice
+      L T hT hexp u hu_nonneg s hs hdecay hτ_fix'
+  exact sub_eq_zero.mp hzero
 
 /-- **TODO**: Prove that a primitive fraction slice exists.
 Currently a `sorry` placeholder. -/
@@ -550,7 +592,13 @@ theorem exists_primitive_fraction_slice
     (hfixed_1d : ∀ X : Matrix (Fin D) (Fin D) ℂ, T t₀ X = X → X = Matrix.trace X • σ) :
     ∃ u : ℝ, 0 < u ∧ 0 ≤ u ∧ IsChannel (T u) ∧ IsIrreducibleMap (T u) ∧
       T u σ = σ ∧ IsPrimitive (T u) := by
-  sorry
+  obtain ⟨u, hu_pos, hu_nonneg, hTt₀_eq_pow, hTu_ch, hTu_irr, hTu_fix⟩ :=
+    exists_irreducible_fraction_slice T hT t₀ ht₀ hirr σ hσ_fix_all
+  have hN_fac : Nat.factorial (Module.finrank ℂ Mat) =
+      Nat.factorial (Module.finrank ℂ Mat) := rfl
+  refine ⟨u, hu_pos, hu_nonneg, hTu_ch, hTu_irr, hTu_fix, ?_⟩
+  exact primitive_of_fraction_slice
+    T hTt₀_eq_pow hTu_ch hTu_irr σ hσ_mem hσ_pd hTu_fix hfixed_1d hN_fac
 
 theorem irreducible_all_of_irreducible_time
     [NeZero D]

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -710,12 +710,45 @@ which shows that such generators have the standard Lindblad form.
 %% ---------------------------------------------------------
 
 %% Wolf §7.1, Prop 7.5
-\begin{remark}[Remaining gap in the semigroup irreducible/primitive equivalence]\notready
-    To obtain the semigroup analogue of the irreducible/primitive
-    equivalence, it remains to pass from the qualitative spectral
-    theory of a single time slice to a uniform statement for the whole
-    semigroup.
+\begin{remark}[Fraction-slice bridge for Proposition~7.5]\leanok
+    The fraction-slice component of the argument is now formalized in
+    Lean.  Starting from one irreducible time $t_0$, we construct a
+    positive slice $u=t_0/N$ with
+    $T_{t_0}=(T_u)^N$, prove peripheral eigenvalue collapse at time~$u$,
+    and deduce primitivity of $T_u$.
 \end{remark}
+
+\begin{theorem}[Fraction-slice eigenvector has nonzero trace]
+    \lean{exists_trace_ne_zero_eigenvector_of_fraction_slice}\leanok
+    Under the fraction-slice hypotheses
+    $T_{t_0} = (T_u)^{(\dim \MN{D})!}$, if
+    $\mu$ is a peripheral eigenvalue of $T_u$, then $T_u$ admits a
+    $\mu$-eigenvector with nonzero trace.
+\end{theorem}
+
+\begin{theorem}[Fraction-slice peripheral collapse]
+    \lean{peripheral_eq_one_of_fraction_slice}\leanok
+    Under the same hypotheses, every peripheral eigenvalue of $T_u$
+    equals $1$.
+\end{theorem}
+
+\begin{theorem}[Fraction-slice primitivity]
+    \lean{primitive_of_fraction_slice}\leanok
+    Under the same hypotheses, $T_u$ is primitive.
+\end{theorem}
+
+\begin{theorem}[Primitive-slice fixed points are trace-scalars]
+    \lean{fixedPoint_eq_trace_smul_of_primitive_slice}\leanok
+    If $T_u$ is primitive and $\sigma$ is the common fixed density, then
+    every fixed point of any positive-time slice $T_s$ has the form
+    $\tau = \tr(\tau)\,\sigma$.
+\end{theorem}
+
+\begin{theorem}[Existence of a primitive fraction slice]
+    \lean{exists_primitive_fraction_slice}\leanok
+    If $T_{t_0}$ is irreducible for some $t_0>0$, then there exists a
+    fraction slice $u \in (0,t_0]$ such that $T_u$ is primitive.
+\end{theorem}
 
 
 \begin{theorem}[Prop.~7.5: Irreducible semigroup implies primitive]


### PR DESCRIPTION
### Motivation

- Discharge the remaining `sorry` placeholders implementing the fraction-slice portion of Proposition 7.5 so that rational-time slices inherit primitivity from an irreducible time slice (see LionSR/QICLean#106).
- Use existing peripheral-spectrum and fixed-point machinery to avoid introducing new axioms and to connect this sub-case to the rest of the primitivity pipeline.

### Description

- Implemented proofs for five theorems in `TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean`: `exists_trace_ne_zero_eigenvector_of_fraction_slice`, `peripheral_eq_one_of_fraction_slice`, `primitive_of_fraction_slice`, `fixedPoint_eq_trace_smul_of_primitive_slice`, and `exists_primitive_fraction_slice`.
- The fraction-slice eigenvector proof uses `peripheral_powers_closed_of_irreducible_channel_with_fixed` + `bounded_root_of_peripheral_closed_powers` to extract a bounded-order peripheral root and then rules out trace-zero by the 1D fixed-point hypothesis at `t₀`.
- The peripheral-to-1 step uses `eigenvalue_eq_one_of_trace_preserving_eigenvector`, and primitivity is concluded via `isPrimitive_of_unique_norm_one` applied to the unique density fixed point; fixed-point scalar form is obtained via decay + residual-time-zero elimination (`trace_zero_fixedPoint_tendsto_zero_of_primitive_slice` and `fixedPoint_eq_zero_of_trace_zero_of_primitive_slice`).
- Added an explicit factorial witness argument `hN_fac : N = Nat.factorial (Module.finrank ℂ Mat)` in the fraction-slice lemmas to make the bounded-root divisibility step explicit and instantiated it in `exists_primitive_fraction_slice`.

### Testing

- Ran `lake build TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean` and the file built successfully (no proof failures).
- Checked for remaining `sorry` placeholders with `rg -n "sorry" TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean` and found no proof `sorry`s (only informational docstring mentions).

---
Addresses LionSR/QICLean#106

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: replaces multiple `sorry` placeholders with nontrivial spectral/fixed-point proofs, which may introduce subtle dependency or lemma-assumption mismatches. Scope is limited to mathematical formalization and blueprint documentation updates.
> 
> **Overview**
> Implements full Lean proofs for the previously-placeholder fraction-slice lemmas in `IrreducibleAnalysis.lean`, showing that if `T t₀ = (T u)^( (finrank Mat)! )` and `T u` is an irreducible channel with a fixed `σ`, then **peripheral eigenvalues at time `u` collapse to `1`** and `T u` is **primitive**.
> 
> Adds supporting results connecting primitivity to fixed-point structure (fixed points of any positive slice are `trace`-multiples of `σ`) and proves `exists_primitive_fraction_slice`, constructing a positive rational `u` from an irreducible `t₀`. Updates the blueprint (`ch12_semigroup.tex`) to mark the fraction-slice bridge as `leanok` and to include new theorems corresponding to these formalized steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fe3241cfaa8cb4c8cb6662c8d0a9e16567f4f77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->