### PR TITLE
feat(Algebra/CocycleCohomology): add H² quotient, ProjectivelyEquivalent, and blueprint entries

### DIFF
--- a/TNLean/Algebra/CocycleCohomology.lean
+++ b/TNLean/Algebra/CocycleCohomology.lean
@@ -53,6 +53,10 @@ i.e., `ω₁(g,h) = φ(g) * φ(h) * φ(g*h)⁻¹ * ω₂(g,h)` for some `φ : G 
 def ScalarCocycle.CohomologousTo (ω₁ ω₂ : ScalarCocycle G) : Prop :=
   ∃ φ : G → Units ℂ, ∀ g h, ω₁ g h = φ g * φ h * (φ (g * h))⁻¹ * ω₂ g h
 
+/-- Multiplicative 2-cocycle condition. -/
+def ScalarCocycle.IsCocycle (ω : ScalarCocycle G) : Prop :=
+  ∀ g h k : G, ω g h * ω (g * h) k = ω g (h * k) * ω h k
+
 /-! ### Equivalence relation -/
 
 namespace ScalarCocycle.CohomologousTo
@@ -99,26 +103,34 @@ scoped instance scalarCocycleSetoid : Setoid (ScalarCocycle G) where
 /-- A canonical (non-scoped) name for the cohomology setoid on scalar cocycles. -/
 instance ScalarCocycle.instSetoid : Setoid (ScalarCocycle G) := scalarCocycleSetoid
 
+/-- Cohomology setoid restricted to genuine cocycles. -/
+instance ScalarCocycle.IsCocycle.instSetoid :
+    Setoid {ω : ScalarCocycle G // ScalarCocycle.IsCocycle ω} where
+  r ω₁ ω₂ := ScalarCocycle.CohomologousTo ω₁.1 ω₂.1
+  iseqv := ⟨
+    fun ω => ScalarCocycle.CohomologousTo.refl ω.1,
+    fun h => ScalarCocycle.CohomologousTo.symm h,
+    fun h₁₂ h₂₃ => ScalarCocycle.CohomologousTo.trans h₁₂ h₂₃⟩
+
 /-- The second cohomology quotient `H²(G, U(1))` modelled by scalar 2-cocycles. -/
-def H2 (G : Type*) [Group G] := Quotient (ScalarCocycle.instSetoid (G := G))
+def H2 (G : Type*) [Group G] :=
+  Quotient (ScalarCocycle.IsCocycle.instSetoid (G := G))
 
 /-- Projective-equivalence at the level of factor-system cohomology classes. -/
 def ProjectivelyEquivalent
-    {ω₁ ω₂ : ScalarCocycle G}
-    (ρ₁ : ProjectiveRepresentation (D := D) ω₁)
-    (ρ₂ : ProjectiveRepresentation (D := D) ω₂) : Prop :=
+    {D₁ D₂ : ℕ} {ω₁ ω₂ : ScalarCocycle G}
+    (ρ₁ : ProjectiveRepresentation (D := D₁) ω₁)
+    (ρ₂ : ProjectiveRepresentation (D := D₂) ω₂) : Prop :=
   ScalarCocycle.CohomologousTo (ρ₁.cocycle_of) (ρ₂.cocycle_of)
 
 /-- Two projective representations are projectively equivalent iff their cocycles are
 cohomologous (after identifying the explicit cocycle names). -/
 theorem projRep_equiv_iff_cohomologous
-    {ω₁ ω₂ : ScalarCocycle G}
-    (ρ₁ : ProjectiveRepresentation (D := D) ω₁)
-    (ρ₂ : ProjectiveRepresentation (D := D) ω₂)
-    (hω₁ : ρ₁.cocycle_of = ω₁)
-    (hω₂ : ρ₂.cocycle_of = ω₂) :
+    {D₁ D₂ : ℕ} {ω₁ ω₂ : ScalarCocycle G}
+    (ρ₁ : ProjectiveRepresentation (D := D₁) ω₁)
+    (ρ₂ : ProjectiveRepresentation (D := D₂) ω₂) :
     ProjectivelyEquivalent ρ₁ ρ₂ ↔ ScalarCocycle.CohomologousTo ω₁ ω₂ := by
-  simpa [ProjectivelyEquivalent, hω₁, hω₂]
+  rfl
 
 /-- A cocycle is a coboundary iff it is cohomologous to the trivial cocycle `fun _ _ => 1`. -/
 lemma ScalarCocycle.isCoboundary_iff_cohomologousTo_one (ω : ScalarCocycle G) :

--- a/TNLean/Algebra/CocycleCohomology.lean
+++ b/TNLean/Algebra/CocycleCohomology.lean
@@ -61,7 +61,8 @@ i.e., `ω₁(g,h) = φ(g) * φ(h) * φ(g*h)⁻¹ * ω₂(g,h)` for some `φ : G 
 def ScalarCocycle.CohomologousTo (ω₁ ω₂ : ScalarCocycle G) : Prop :=
   ∃ φ : G → Units ℂ, ∀ g h, ω₁ g h = φ g * φ h * (φ (g * h))⁻¹ * ω₂ g h
 
-/-- Multiplicative 2-cocycle condition. -/
+/-- A scalar 2-cochain `ω : G → G → ℂˣ` satisfies the multiplicative 2-cocycle condition if
+`ω g h * ω (g * h) k = ω g (h * k) * ω h k` for all `g h k : G`. -/
 def ScalarCocycle.IsCocycle (ω : ScalarCocycle G) : Prop :=
   ∀ g h k : G, ω g h * ω (g * h) k = ω g (h * k) * ω h k
 
@@ -129,7 +130,7 @@ def ProjectivelyEquivalent
   ScalarCocycle.CohomologousTo (ρ₁.cocycle) (ρ₂.cocycle)
 
 /-- Two projective representations are projectively equivalent iff their cocycles are
-cohomologous (after identifying the explicit cocycle names). -/
+cohomologous. -/
 theorem projRep_equiv_iff_cohomologous
     {D₁ D₂ : ℕ} {ω₁ ω₂ : ScalarCocycle G}
     (ρ₁ : ProjectiveRepresentation (D := D₁) ω₁)

--- a/TNLean/Algebra/CocycleCohomology.lean
+++ b/TNLean/Algebra/CocycleCohomology.lean
@@ -16,6 +16,12 @@ and establishes the `H²(G, U(1))` cohomology class as a well-defined quotient.
   `ω(g,h) = φ(g) * φ(h) * φ(g*h)⁻¹` for some `φ : G → ℂˣ`
 * `ScalarCocycle.CohomologousTo` : two cocycles are cohomologous if their ratio
   is a coboundary
+* `ScalarCocycle.IsCocycle` : the multiplicative 2-cocycle condition
+* `H2` : the second cohomology quotient `H²(G, U(1))` over genuine cocycles
+* `ProjectiveRepresentation.cocycle` : the cocycle attached to a projective
+  representation
+* `ProjectivelyEquivalent` : two projective representations are projectively
+  equivalent when their factor systems are cohomologous
 
 ## Main results
 
@@ -23,6 +29,8 @@ and establishes the `H²(G, U(1))` cohomology class as a well-defined quotient.
   relation
 * `ScalarCocycle.isCoboundary_iff_cohomologousTo_one` : a cocycle is a coboundary
   iff it is cohomologous to the trivial cocycle
+* `projRep_equiv_iff_cohomologous` : projective equivalence iff cocycles are
+  cohomologous
 
 ## References
 
@@ -38,7 +46,7 @@ variable {G : Type*} [Group G]
 variable {D : ℕ}
 
 /-- The cocycle attached to a projective representation. -/
-abbrev ProjectiveRepresentation.cocycle_of {ω : ScalarCocycle G}
+abbrev ProjectiveRepresentation.cocycle {ω : ScalarCocycle G}
     (_ρ : ProjectiveRepresentation (D := D) ω) : ScalarCocycle G := ω
 
 /-! ### Coboundary and cohomologous definitions -/
@@ -100,9 +108,6 @@ scoped instance scalarCocycleSetoid : Setoid (ScalarCocycle G) where
   r := ScalarCocycle.CohomologousTo
   iseqv := ScalarCocycle.CohomologousTo.equivalence
 
-/-- A canonical (non-scoped) name for the cohomology setoid on scalar cocycles. -/
-instance ScalarCocycle.instSetoid : Setoid (ScalarCocycle G) := scalarCocycleSetoid
-
 /-- Cohomology setoid restricted to genuine cocycles. -/
 instance ScalarCocycle.IsCocycle.instSetoid :
     Setoid {ω : ScalarCocycle G // ScalarCocycle.IsCocycle ω} where
@@ -121,7 +126,7 @@ def ProjectivelyEquivalent
     {D₁ D₂ : ℕ} {ω₁ ω₂ : ScalarCocycle G}
     (ρ₁ : ProjectiveRepresentation (D := D₁) ω₁)
     (ρ₂ : ProjectiveRepresentation (D := D₂) ω₂) : Prop :=
-  ScalarCocycle.CohomologousTo (ρ₁.cocycle_of) (ρ₂.cocycle_of)
+  ScalarCocycle.CohomologousTo (ρ₁.cocycle) (ρ₂.cocycle)
 
 /-- Two projective representations are projectively equivalent iff their cocycles are
 cohomologous (after identifying the explicit cocycle names). -/

--- a/TNLean/Algebra/CocycleCohomology.lean
+++ b/TNLean/Algebra/CocycleCohomology.lean
@@ -35,6 +35,11 @@ and establishes the `H²(G, U(1))` cohomology class as a well-defined quotient.
 namespace TNLean.Algebra
 
 variable {G : Type*} [Group G]
+variable {D : ℕ}
+
+/-- The cocycle attached to a projective representation. -/
+abbrev ProjectiveRepresentation.cocycle_of {ω : ScalarCocycle G}
+    (_ρ : ProjectiveRepresentation (D := D) ω) : ScalarCocycle G := ω
 
 /-! ### Coboundary and cohomologous definitions -/
 
@@ -90,6 +95,30 @@ end ScalarCocycle.CohomologousTo
 scoped instance scalarCocycleSetoid : Setoid (ScalarCocycle G) where
   r := ScalarCocycle.CohomologousTo
   iseqv := ScalarCocycle.CohomologousTo.equivalence
+
+/-- A canonical (non-scoped) name for the cohomology setoid on scalar cocycles. -/
+instance ScalarCocycle.instSetoid : Setoid (ScalarCocycle G) := scalarCocycleSetoid
+
+/-- The second cohomology quotient `H²(G, U(1))` modelled by scalar 2-cocycles. -/
+def H2 (G : Type*) [Group G] := Quotient (ScalarCocycle.instSetoid (G := G))
+
+/-- Projective-equivalence at the level of factor-system cohomology classes. -/
+def ProjectivelyEquivalent
+    {ω₁ ω₂ : ScalarCocycle G}
+    (ρ₁ : ProjectiveRepresentation (D := D) ω₁)
+    (ρ₂ : ProjectiveRepresentation (D := D) ω₂) : Prop :=
+  ScalarCocycle.CohomologousTo (ρ₁.cocycle_of) (ρ₂.cocycle_of)
+
+/-- Two projective representations are projectively equivalent iff their cocycles are
+cohomologous (after identifying the explicit cocycle names). -/
+theorem projRep_equiv_iff_cohomologous
+    {ω₁ ω₂ : ScalarCocycle G}
+    (ρ₁ : ProjectiveRepresentation (D := D) ω₁)
+    (ρ₂ : ProjectiveRepresentation (D := D) ω₂)
+    (hω₁ : ρ₁.cocycle_of = ω₁)
+    (hω₂ : ρ₂.cocycle_of = ω₂) :
+    ProjectivelyEquivalent ρ₁ ρ₂ ↔ ScalarCocycle.CohomologousTo ω₁ ω₂ := by
+  simpa [ProjectivelyEquivalent, hω₁, hω₂]
 
 /-- A cocycle is a coboundary iff it is cohomologous to the trivial cocycle `fun _ _ => 1`. -/
 lemma ScalarCocycle.isCoboundary_iff_cohomologousTo_one (ω : ScalarCocycle G) :

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -402,6 +402,45 @@ make this precise and establish the quotient $H^2(G,\mathrm{U}(1))$.
     $\omega_2(g,h) = f(g)\,f(h)\,f(gh)^{-1}\,\omega_1(g,h)$.
 \end{proof}
 
+\begin{definition}[Second cohomology quotient]\label{def:h2_u1}
+    \lean{TNLean.Algebra.H2}
+    \leanok
+    \uses{def:cohomologous_to}
+    The second cohomology set is the quotient
+    \[
+        H^2(G,\mathrm{U}(1))
+        := Z^2(G,\mathrm{U}(1))/{\sim},
+    \]
+    where $\sim$ is the coboundary-equivalence relation.
+\end{definition}
+
+\begin{definition}[Projective equivalence]\label{def:projectively_equivalent}
+    \lean{TNLean.Algebra.ProjectivelyEquivalent}
+    \leanok
+    \uses{def:projective_rep, def:cohomologous_to}
+    Two projective representations are \emph{projectively equivalent}
+    when their factor systems are cohomologous.
+\end{definition}
+
+\begin{theorem}[Projective equivalence and cohomologous cocycles]%
+    \label{thm:projrep_equiv_iff_cohomologous}
+    \lean{TNLean.Algebra.projRep_equiv_iff_cohomologous}
+    \leanok
+    \uses{def:projectively_equivalent, def:cohomologous_to}
+    Let $\rho_1,\rho_2$ be projective representations with factor systems
+    $\omega_1,\omega_2$. Then
+    \[
+      \rho_1 \sim_{\mathrm{proj}} \rho_2
+      \iff
+      \omega_1 \sim \omega_2.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok\uses{def:projectively_equivalent}
+    This is immediate from the definition of projective equivalence as
+    cohomology-class equality for factor systems.
+\end{proof}
+
 \section{Permutation-Based Physical Symmetry}
 
 The linear-combination twist $\widetilde{A}_g^i = \sum_j U(g)_{ij}\, A^j$

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -402,10 +402,21 @@ make this precise and establish the quotient $H^2(G,\mathrm{U}(1))$.
     $\omega_2(g,h) = f(g)\,f(h)\,f(gh)^{-1}\,\omega_1(g,h)$.
 \end{proof}
 
+\begin{definition}[Multiplicative 2-cocycle condition]\label{def:is_cocycle}
+    \lean{TNLean.Algebra.ScalarCocycle.IsCocycle}
+    \leanok
+    A scalar 2-cochain $\omega\colon G\times G\to\mathrm{U}(1)$ is a
+    \emph{2-cocycle} if it satisfies
+    \[
+        \omega(g,h)\,\omega(gh,k) = \omega(g,hk)\,\omega(h,k)
+        \qquad\text{for all } g,h,k\in G.
+    \]
+\end{definition}
+
 \begin{definition}[Second cohomology quotient]\label{def:h2_u1}
     \lean{TNLean.Algebra.H2}
     \leanok
-    \uses{def:cohomologous_to}
+    \uses{def:cohomologous_to, def:is_cocycle}
     The second cohomology set is the quotient
     \[
         H^2(G,\mathrm{U}(1))


### PR DESCRIPTION
### Motivation

- Continue formalization of projective representations and 2-cocycles, see #77.
- Complete the projective-representation layer by connecting projective-equivalence to cocycle cohomology and exposing an `H²` quotient for `U(1)`-valued scalar cocycles.
- Provide the missing glue declarations so the existing coboundary/cohomologous infrastructure can be referenced from the blueprint and other modules.

### Description

- In `TNLean/Algebra/CocycleCohomology.lean`:
  - Added `ProjectiveRepresentation.cocycle_of` (accessor abbrev) to identify the factor system attached to a `ProjectiveRepresentation` and work with it as a `ScalarCocycle`.
  - Added `ScalarCocycle.instSetoid` (canonical setoid alias) and the quotient type `H2 (G : Type*) [Group G]` modelling `H²(G, U(1))`.
  - Added `ProjectivelyEquivalent` (projective-equivalence via cocycle cohomology) and the connecting theorem `projRep_equiv_iff_cohomologous` reducing to `ScalarCocycle.CohomologousTo`.
- In `blueprint/src/chapter/ch13b_symmetry.tex`:
  - Added textbook-style entries for `H²(G, U(1))`, projective equivalence, and the correspondence theorem with `\lean{...}` and `\leanok` tags.

### Testing

- `lake build TNLean.Algebra.CocycleCohomology` completed successfully (sorry-free).
- Non-fatal linter suggestion only (prefer `simp` over `simpa`); no errors.

---
Addresses #77

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new Lean definitions and trivial glue lemmas/types; risk is low aside from potential downstream breakage from new setoid/quotient interfaces.
> 
> **Overview**
> Introduces `ScalarCocycle.IsCocycle`, a cocycle-restricted cohomology `Setoid`, and the quotient type `H2` to model `H²(G, U(1))` as cohomology classes of genuine 2-cocycles.
> 
> Adds lightweight glue between `ProjectiveRepresentation` and its factor system via `ProjectiveRepresentation.cocycle`, defines `ProjectivelyEquivalent` as cohomology of factor systems, and provides `projRep_equiv_iff_cohomologous` (by `rfl`) to relate it directly to `ScalarCocycle.CohomologousTo`.
> 
> Updates the blueprint (`ch13b_symmetry.tex`) with new definitions/theorem statements for the cocycle condition, `H²` quotient, and projective equivalence, annotated with corresponding `\lean{...}` references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068d1f673da022ebe5532c8c04acf3ff698ee493. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->