### PR TITLE
doc(Channel/Semigroup): clarify Dyson-Phillips iterates section scope

### DIFF
--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -220,7 +220,10 @@ theorem perturbation_bound_unit_norm
         rw [Real.volume_Icc, ENNReal.toReal_ofReal (by linarith : (0 : ℝ) ≤ t - 0)]
         ring
 
-/-! ## Dyson-Phillips iterates -/
+/-! ## Dyson-Phillips iterates
+
+This section currently provides the recursive iterates and the one-step norm control
+used in later induction arguments. -/
 
 /-- Recursive Dyson-Phillips terms built from the unperturbed semigroup `L`
 and perturbation `L' - L`. -/


### PR DESCRIPTION
### Motivation

- Make the Dyson–Phillips iterates section documentation explicit about what is currently formalized, so future contributors know the current progress toward completing the Dyson series (see LionSR/QICLean#96).

### Description

- Update the `## Dyson-Phillips iterates` section header in `TNLean/Channel/Semigroup/Perturbation.lean` to state that the file currently provides the recursive iterates and the one-step norm control used for later induction arguments.
- No theorem or proof bodies were changed; this is a documentation clarification only.

### Testing

- Ran `rg -n "sorry|axiom" TNLean/Channel/Semigroup/Perturbation.lean` and confirmed no proof holes.
- Built the affected target with `lake build TNLean.Channel.Semigroup.Perturbation` successfully.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/QICLean#96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates section-level documentation/comments and does not modify any Lean statements or proofs.
> 
> **Overview**
> Updates the `## Dyson-Phillips iterates` section header in `TNLean/Channel/Semigroup/Perturbation.lean` to explicitly state that the section currently contains the recursive iterates and the one-step norm estimate used for later induction arguments.
> 
> No functional or proof changes are introduced; this is a documentation-only clarification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 922f63a2d70f32fa062ee3fb3e569a1c0de9f866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->