### PR TITLE
feat(Channel/Semigroup): add factorial-majorant summability lemma for Dyson terms

### DIFF
--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -293,4 +293,12 @@ lemma summable_dysonTerm_of_factorial_bound
   simpa [mul_div_assoc, mul_comm, mul_left_comm, mul_assoc] using
     (Real.summable_pow_div_factorial (t * ‖L' - L‖ * M)).mul_left M
 
+/-- Consumer lemma for the Dyson-series convergence pipeline:
+`factorial bound → summable Dyson terms`. -/
+lemma dysonSeries_summable
+    (L L' : CLM D) {t M : ℝ}
+    (hbound : ∀ n, ‖dysonTerm L L' t n‖ ≤ M * ((t * ‖L' - L‖ * M) ^ n / (Nat.factorial n))) :
+    Summable (fun n => dysonTerm L L' t n) :=
+  summable_dysonTerm_of_factorial_bound (L := L) (L' := L') hbound
+
 end -- noncomputable section

--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -287,18 +287,10 @@ lemma norm_dysonTerm_succ_le
 This packages the M-test step independently of the inductive norm proof. -/
 lemma summable_dysonTerm_of_factorial_bound
     (L L' : CLM D) {t M : ℝ}
-    (hbound : ∀ n, ‖dysonTerm L L' t n‖ ≤ M * ((t * ‖L' - L‖ * M) ^ n / (Nat.factorial n))) :
+    (hbound : ∀ n, ‖dysonTerm L L' t n‖ ≤ M * ((t * ‖L' - L‖ * M) ^ n / ↑(n.factorial))) :
     Summable (fun n => dysonTerm L L' t n) := by
   refine Summable.of_norm_bounded ?_ hbound
   simpa [mul_div_assoc, mul_comm, mul_left_comm, mul_assoc] using
     (Real.summable_pow_div_factorial (t * ‖L' - L‖ * M)).mul_left M
-
-/-- Consumer lemma for the Dyson-series convergence pipeline:
-`factorial bound → summable Dyson terms`. -/
-lemma dysonSeries_summable
-    (L L' : CLM D) {t M : ℝ}
-    (hbound : ∀ n, ‖dysonTerm L L' t n‖ ≤ M * ((t * ‖L' - L‖ * M) ^ n / (Nat.factorial n))) :
-    Summable (fun n => dysonTerm L L' t n) :=
-  summable_dysonTerm_of_factorial_bound (L := L) (L' := L') hbound
 
 end -- noncomputable section

--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -293,4 +293,8 @@ lemma summable_dysonTerm_of_factorial_bound
   simpa [mul_div_assoc, mul_comm, mul_left_comm, mul_assoc] using
     (Real.summable_pow_div_factorial (t * ‖L' - L‖ * M)).mul_left M
 
+-- TODO(#14): combine `norm_dysonTerm_zero_le`/`norm_dysonTerm_succ_le` into a factorial
+-- majorant theorem and apply `summable_dysonTerm_of_factorial_bound` in the final
+-- Dyson-series convergence/identity statement.
+
 end -- noncomputable section

--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -283,4 +283,14 @@ lemma norm_dysonTerm_succ_le
     _ = t * (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖) * ‖L' - L‖ * K := by
         simp [M, mul_left_comm, mul_comm]
 
+/-- Summability criterion for Dyson terms from a factorial majorant.
+This packages the M-test step independently of the inductive norm proof. -/
+lemma summable_dysonTerm_of_factorial_bound
+    (L L' : CLM D) {t M : ℝ}
+    (hbound : ∀ n, ‖dysonTerm L L' t n‖ ≤ M * ((t * ‖L' - L‖ * M) ^ n / (Nat.factorial n))) :
+    Summable (fun n => dysonTerm L L' t n) := by
+  refine Summable.of_norm_bounded ?_ hbound
+  simpa [mul_div_assoc, mul_comm, mul_left_comm, mul_assoc] using
+    (Real.summable_pow_div_factorial (t * ‖L' - L‖ * M)).mul_left M
+
 end -- noncomputable section

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -179,6 +179,24 @@ and proves the GKSL theorem.
     (Theorem~\ref{thm:duhamel_formula_ch12}).
 \end{proof}
 
+\begin{lemma}[Dyson-series summability from factorial majorant]
+    \label{lem:summable_dyson_factorial_ch12}
+    \lean{summable_dysonTerm_of_factorial_bound}\leanok
+    \uses{thm:perturbation_bound_ch12}
+    Assume a factorial majorant of Dyson--Phillips iterates:
+    \[
+      \|\mathrm{dysonTerm}_n(t)\|
+      \le M\,\frac{(t\,\|L'-L\|\,M)^n}{n!}.
+    \]
+    Then the Dyson series is summable in operator norm.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is the Weierstrass M-test step, using the scalar convergence of
+    $\sum_n a^n/n!$ and lifting via norm-bounded summability.
+\end{proof}
+
 %% ---------------------------------------------------------
 \section{GKSL/Lindblad generators}
 \label{sec:gksl_generators}

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -182,7 +182,6 @@ and proves the GKSL theorem.
 \begin{lemma}[Dyson-series summability from factorial majorant]
     \label{lem:summable_dyson_factorial_ch12}
     \lean{summable_dysonTerm_of_factorial_bound}\leanok
-    \uses{thm:perturbation_bound_ch12}
     Assume a factorial majorant of Dyson--Phillips iterates:
     \[
       \|\mathrm{dysonTerm}_n(t)\|


### PR DESCRIPTION
### Motivation

- The Dyson–Phillips iterates are already defined and a one-step inductive norm estimate exists, but the formal Weierstrass M-test step turning a factorial majorant into operator-norm summability was missing.
- Closes the gap between the factorial norm bound and `Summable` for CLM-valued Dyson terms, continuing formalization of Wolf Ch7 Dyson series (Eq. 7.13), see LionSR/QICLean#96.

### Description

- Add `summable_dysonTerm_of_factorial_bound` in `TNLean/Channel/Semigroup/Perturbation.lean` which proves `Summable (fun n => dysonTerm L L' t n)` from an assumed bound `‖dysonTerm L L' t n‖ ≤ M * ((t * ‖L' - L‖ * M) ^ n / n!)`.
- The proof lifts the scalar summability `Real.summable_pow_div_factorial` to CLM-valued summability using `Summable.of_norm_bounded`.
- The lemma packages the Weierstrass M-test step so downstream proofs (factorial bound → summability → Dyson series identity) can be composed cleanly.

### Testing

- Ran `lake build TNLean.Channel.Semigroup.Perturbation` which completed successfully for the updated file.
- Ran repository searches to locate Dyson-related declarations to ensure the lemma integrates with existing `dysonTerm`, `dysonTerm_zero`, `dysonTerm_succ`, `norm_dysonTerm_zero_le`, and `norm_dysonTerm_succ_le` definitions and lemmas.

---
Addresses LionSR/QICLean#96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a self-contained Lean lemma and corresponding blueprint text without changing existing definitions or core semigroup/perturbation theorems.
> 
> **Overview**
> Adds `summable_dysonTerm_of_factorial_bound`, a reusable lemma proving operator-valued Dyson terms are `Summable` when a factorial-style norm bound is provided (formalizing the Weierstrass M-test via `Real.summable_pow_div_factorial` and `Summable.of_norm_bounded`).
> 
> Updates the chapter 12 blueprint to document this new summability lemma and its proof idea, and adds a TODO to later connect the existing inductive norm bounds to this packaged summability step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3b36f2ff334d40f2f311160a7398565e636c654. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->