### PR TITLE
feat(MPS/ParentHamiltonian): add martingale-method scaffold for spectral gap

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -135,6 +135,7 @@ import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation
+import TNLean.MPS.ParentHamiltonian.Martingale
 
 -- Layer 4: Fundamental theorem (single block)
 import TNLean.MPS.Structure.LinearExtension

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.Basic
-import TNLean.MPS.ParentHamiltonian.UniqueGroundState
-import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 
 /-!
 # Martingale-method spectral-gap scaffolding for parent Hamiltonians
@@ -51,9 +49,9 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
 **Spectral gap for MPS parent Hamiltonians.**
 
 For an injective MPS tensor `A` and interaction range `L > 1`, there exists
-a uniform gap `γ > 0` (independent of system size `N`) such that every
-vector in the orthogonal complement of the ground space satisfies
-`‖H_ES v‖ ≥ γ * ‖v‖`.
+a uniform gap `γ > 0` (independent of system size `N`) such that for all
+`N ≥ 2L`, every vector in the orthogonal complement of the ground space
+satisfies `‖H_ES v‖ ≥ γ * ‖v‖`.
 
 The orthogonal complement is computed in the `EuclideanSpace` structure
 on `NSiteSpace d N ≃ Cfg d N → ℂ`.
@@ -61,7 +59,7 @@ on `NSiteSpace d N ≃ Cfg d N → ℂ`.
 TODO: prove via martingale estimate (Nachtergaele / Kastoryano–Lucia). -/
 theorem parentHamiltonian_gapped
     (A : MPSTensor d D) (hA : IsInjective A) (L : ℕ) (hL : 1 < L) :
-    ∃ γ > 0, ∀ (N : ℕ) (hLN : L ≤ N)
+    ∃ γ > 0, ∀ (N : ℕ) (hLN : 2 * L ≤ N)
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ‖parentHamiltonianES A L N v‖ ≥ γ * ‖v‖ := by

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -24,7 +24,7 @@ The final quantitative assembly is left as future work.
 ## Main results
 
 * `parentHamiltonian_gapped` — spectral gap: vectors in the orthogonal complement
-  of the ground space satisfy `⟨v, Hv⟩ ≥ γ ⟨v, v⟩` with a uniform gap `γ > 0`.
+  of the ground space satisfy `‖H v‖ ≥ γ ‖v‖` with a uniform gap `γ > 0`.
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
@@ -16,34 +20,51 @@ The intended proof route is:
 4. a martingale estimate (Nachtergaele / Kastoryano–Lucia).
 
 The final quantitative assembly is left as future work.
+
+## Main results
+
+* `parentHamiltonian_gapped` — spectral gap: vectors in the orthogonal complement
+  of the ground space satisfy `⟨v, Hv⟩ ≥ γ ⟨v, v⟩` with a uniform gap `γ > 0`.
 -/
 
 namespace MPSTensor
 
-open scoped BigOperators
+open scoped BigOperators InnerProductSpace
 
 variable {d D : ℕ}
-variable (L N : ℕ)
 
-/-- Ground-space submodule for the finite-size parent Hamiltonian. -/
-noncomputable def parentHamiltonianGroundSpace (A : MPSTensor d D) : Submodule ℂ (NSiteSpace d N) :=
-  LinearMap.ker (parentHamiltonian A L N)
+/-- Ground-space submodule for the finite-size parent Hamiltonian,
+transported to the `EuclideanSpace` (inner-product) setting so that
+orthogonal complements are available. -/
+noncomputable def parentHamiltonianGroundSpaceES (A : MPSTensor d D)
+    (L N : ℕ) : Submodule ℂ (EuclideanSpace ℂ (Cfg d N)) :=
+  (LinearMap.ker (parentHamiltonian A L N)).map
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm.toLinearMap
+
+/-- The parent Hamiltonian transported to `EuclideanSpace`. -/
+noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
+    EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
+  let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
+  e.symm.toLinearMap.comp ((parentHamiltonian A L N).comp e.toLinearMap)
 
 /--
-A norm-form spectral-gap statement for the parent Hamiltonian.
+**Spectral gap for MPS parent Hamiltonians.**
 
-This is the endpoint produced by the martingale method: vectors orthogonal to the
-ground space are uniformly penalized by the Hamiltonian.
--/
+For an injective MPS tensor `A` and interaction range `L > 1`, there exists
+a uniform gap `γ > 0` (independent of system size `N`) such that every
+vector in the orthogonal complement of the ground space satisfies
+`‖H_ES v‖ ≥ γ * ‖v‖`.
+
+The orthogonal complement is computed in the `EuclideanSpace` structure
+on `NSiteSpace d N ≃ Cfg d N → ℂ`.
+
+TODO: prove via martingale estimate (Nachtergaele / Kastoryano–Lucia). -/
 theorem parentHamiltonian_gapped
-    (A : MPSTensor d D) (hA : IsInjective A) (hL : 1 < L) (hLN : L ≤ N) :
-    ∃ γ > 0, ∀ v, v ∉ parentHamiltonianGroundSpace (L := L) (N := N) A →
-      ‖parentHamiltonian A L N v‖ ≥ γ * ‖v‖ := by
-  -- Ingredients available on `main`:
-  -- * `groundSpace_intersection`
-  -- * frustration-freeness of parent Hamiltonians on MPS vectors
-  -- * projector structure of local terms
-  -- The quantitative martingale estimate still needs to be assembled.
+    (A : MPSTensor d D) (hA : IsInjective A) (L : ℕ) (hL : 1 < L) :
+    ∃ γ > 0, ∀ (N : ℕ) (hLN : L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ‖parentHamiltonianES A L N v‖ ≥ γ * ‖v‖ := by
   sorry
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -1,0 +1,49 @@
+import TNLean.MPS.ParentHamiltonian.Defs
+import TNLean.MPS.ParentHamiltonian.Basic
+import TNLean.MPS.ParentHamiltonian.UniqueGroundState
+import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+
+/-!
+# Martingale-method spectral-gap scaffolding for parent Hamiltonians
+
+This file introduces a first formal scaffold for the martingale approach to proving
+that MPS parent Hamiltonians are gapped.
+
+The intended proof route is:
+1. frustration-freeness (`parentHamiltonian_frustrationFree`),
+2. local projector gap (`parentInteraction`/`localTerm` as orthogonal projections),
+3. intersection property (`groundSpace_intersection`),
+4. a martingale estimate (Nachtergaele / Kastoryano–Lucia).
+
+The final quantitative assembly is left as future work.
+-/
+
+namespace MPSTensor
+
+open scoped BigOperators
+
+variable {d D : ℕ}
+variable (L N : ℕ)
+
+/-- Ground-space submodule for the finite-size parent Hamiltonian. -/
+noncomputable def parentHamiltonianGroundSpace (A : MPSTensor d D) : Submodule ℂ (NSiteSpace d N) :=
+  LinearMap.ker (parentHamiltonian A L N)
+
+/--
+A norm-form spectral-gap statement for the parent Hamiltonian.
+
+This is the endpoint produced by the martingale method: vectors orthogonal to the
+ground space are uniformly penalized by the Hamiltonian.
+-/
+theorem parentHamiltonian_gapped
+    (A : MPSTensor d D) (hA : IsInjective A) (hL : 1 < L) (hLN : L ≤ N) :
+    ∃ γ > 0, ∀ v, v ∉ parentHamiltonianGroundSpace (L := L) (N := N) A →
+      ‖parentHamiltonian A L N v‖ ≥ γ * ‖v‖ := by
+  -- Ingredients available on `main`:
+  -- * `groundSpace_intersection`
+  -- * frustration-freeness of parent Hamiltonians on MPS vectors
+  -- * projector structure of local terms
+  -- The quantitative martingale estimate still needs to be assembled.
+  sorry
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -761,6 +761,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}
+  \lean{MPSTensor.parentHamiltonian_gapped}
   \notready
   \uses{thm:martingale_criterion, lem:martingale_mps,
         def:parent_hamiltonian}


### PR DESCRIPTION
### Motivation

- Provide a formal scaffold for proving a uniform spectral gap for MPS parent Hamiltonians via the martingale method (Kastoryano–Lucia / Nachtergaele), see #193.

### Description

- Add `TNLean/MPS/ParentHamiltonian/Martingale.lean` defining `parentHamiltonianGroundSpace` (as `ker (parentHamiltonian A L N)`) and the scaffold theorem `parentHamiltonian_gapped` capturing the desired norm-form gap inequality (proof left as `sorry`).
- Document the intended assembly from frustration-freeness, local projector gaps, and `groundSpace_intersection`.
- Wire the new module into top-level imports in `TNLean.lean`.

### Testing

- Built the new target with `lake build TNLean.MPS.ParentHamiltonian.Martingale` — completed successfully.
- Built the whole project with `lake build TNLean` — completed successfully (with existing warnings).

---
Addresses #193

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new public theorem `parentHamiltonian_gapped` with a `sorry` proof and re-exports it from `TNLean.lean`, which may affect downstream users relying on proof completeness or API stability.
> 
> **Overview**
> Adds a new `TNLean.MPS.ParentHamiltonian.Martingale` module that (1) transports `parentHamiltonian` and its kernel/ground space into `EuclideanSpace` (`parentHamiltonianES`, `parentHamiltonianGroundSpaceES`) and (2) states the intended uniform spectral-gap inequality as `MPSTensor.parentHamiltonian_gapped` (left as `sorry`).
> 
> Updates `TNLean.lean` to re-export the new module and annotates the corresponding blueprint theorem with a `\lean{MPSTensor.parentHamiltonian_gapped}` link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db06986f78a215116470acdb30c8cd230b326c3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->