### PR TITLE
feat(MPS/Periodic): advance periodic overlap proof bridges

### DIFF
--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -452,6 +452,61 @@ theorem exists_compressedTensor_of_supported_projection
 
 end Compression
 
+section CompressionPositiveMPV
+
+/-- A supported-projection compression preserves MPVs at all positive lengths.
+
+This is the usable replacement for a heterogeneous `SameMPV₂` statement: compression changes the
+`N = 0` coefficient from `trace 1 = D` to `trace P`, so exact all-length equality is false in
+general, but every positive-length MPV is preserved. -/
+theorem exists_compressedTensor_of_supported_projection_pos_mpv
+    (A : MPSTensor d D) (P : MatrixAlg D)
+    (hP : IsOrthogonalProjection P)
+    (hSupp : ∀ i : Fin d, P * A i * P = A i)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = P) :
+    ∃ (n : ℕ) (C : MPSTensor d n),
+      ((n : ℂ) = Matrix.trace P) ∧
+      (∑ i : Fin d, (C i)ᴴ * C i = 1) ∧
+      (∀ {N : ℕ}, 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = mpv C σ) := by
+  obtain ⟨n, C, hn, hCtp, hCmpv⟩ :=
+    exists_compressedTensor_of_supported_projection A P hP hSupp hTP
+  refine ⟨n, C, hn, hCtp, ?_⟩
+  have hleft : ∀ i : Fin d, P * A i = A i := by
+    intro i
+    calc
+      P * A i = P * (P * A i * P) := by rw [hSupp i]
+      _ = (P * P) * A i * P := by simp [Matrix.mul_assoc]
+      _ = P * A i * P := by rw [hP.2]
+      _ = A i := by simpa [Matrix.mul_assoc] using hSupp i
+  have hword :
+      ∀ {w : List (Fin d)}, w ≠ [] → P * evalWord A w = evalWord A w := by
+    intro w hw
+    cases w with
+    | nil =>
+        cases hw rfl
+    | cons i w =>
+        calc
+          P * evalWord A (i :: w) = P * (A i * evalWord A w) := by rfl
+          _ = (P * A i) * evalWord A w := by rw [Matrix.mul_assoc]
+          _ = A i * evalWord A w := by rw [hleft i]
+          _ = evalWord A (i :: w) := by rfl
+  intro N hN σ
+  cases N with
+  | zero =>
+      cases Nat.not_lt_zero _ hN
+  | succ n =>
+      have hPw :
+          P * evalWord A (List.ofFn σ) = evalWord A (List.ofFn σ) := by
+        apply hword
+        simp
+      calc
+        mpv A σ = Matrix.trace (evalWord A (List.ofFn σ)) := by rfl
+        _ = Matrix.trace (P * evalWord A (List.ofFn σ)) := by
+              exact congrArg Matrix.trace hPw.symm
+        _ = mpv C σ := (hCmpv (N := n.succ) σ).symm
+
+end CompressionPositiveMPV
+
 section CommutingProjectionDecomposition
 
 variable {m : ℕ}

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -468,9 +468,9 @@ theorem exists_compressedTensor_of_supported_projection_pos_mpv
       ((n : ℂ) = Matrix.trace P) ∧
       (∑ i : Fin d, (C i)ᴴ * C i = 1) ∧
       (∀ {N : ℕ}, 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = mpv C σ) := by
-  obtain ⟨n, C, hn, hCtp, hCmpv⟩ :=
+  obtain ⟨dim, C, hdim, hCtp, hCmpv⟩ :=
     exists_compressedTensor_of_supported_projection A P hP hSupp hTP
-  refine ⟨n, C, hn, hCtp, ?_⟩
+  refine ⟨dim, C, hdim, hCtp, ?_⟩
   have hleft : ∀ i : Fin d, P * A i = A i := by
     intro i
     calc
@@ -494,7 +494,7 @@ theorem exists_compressedTensor_of_supported_projection_pos_mpv
   cases N with
   | zero =>
       cases Nat.not_lt_zero _ hN
-  | succ n =>
+  | succ n' =>
       have hPw :
           P * evalWord A (List.ofFn σ) = evalWord A (List.ofFn σ) := by
         apply hword
@@ -503,7 +503,7 @@ theorem exists_compressedTensor_of_supported_projection_pos_mpv
         mpv A σ = Matrix.trace (evalWord A (List.ofFn σ)) := by rfl
         _ = Matrix.trace (P * evalWord A (List.ofFn σ)) := by
               exact congrArg Matrix.trace hPw.symm
-        _ = mpv C σ := (hCmpv (N := n.succ) σ).symm
+        _ = mpv C σ := (hCmpv (N := n'.succ) σ).symm
 
 end CompressionPositiveMPV
 

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -58,8 +58,17 @@ assemble the global gauge unitary.
 
 ## Status
 
-The main theorems in this file are currently stated with `sorry` proofs.
-This module serves as a skeleton / proof sketch and should not yet be
+The main theorems in this file are currently stated with `sorry` proofs, and
+some of the same-period statements are intentionally **provisional**. The live
+cyclic-sector API in `CanonicalForm/CyclicSectors.lean` and
+`CanonicalForm/Assembly.lean` naturally produces **compressed sector tensors**
+living on the corner bond spaces, whereas several statements below are still
+phrased in terms of the ambient tensors `leftSectorTensor (P u) (blockTensor A m)`.
+That ambient formulation is convenient for the paper sketch, but it is stronger
+than the currently formalized infrastructure and is the main blocker for the
+first unfinished proofs in Case 2.
+
+This module therefore serves as a skeleton / proof sketch and should not yet be
 relied on as a completed formalization of Proposition 3.3.
 
 ## References
@@ -115,9 +124,16 @@ theorem periodicOverlap_tendsto_zero_of_ne_period
 
 /-! ## Case 2: Same period, no sector match → orthogonal (Appendix A, second case) -/
 
-/-- Two-sided sector restriction is "normal" when the original blocked tensor has
-the appropriate cyclic-sector structure. This packages the consequence of
-Lemma 2.4: each `P_u A^(m)` is a normal tensor.
+/-- Provisional Case-2 helper for the blocked sector tensors.
+
+The intended mathematical content is Lemma 2.4: after blocking by the period,
+each cyclic sector is a normal tensor. In the current file this statement is
+still phrased for the ambient tensor `leftSectorTensor (P u) (blockTensor A m)`.
+However, the live API more naturally gives a **compressed** tensor on the corner
+bond space via `exists_compressedTensor_of_supported_projection`, together with
+primitivity / irreducibility data for the corner restriction of the blocked
+transfer map. Future proof work should likely reformulate this lemma using that
+compressed sector tensor rather than the ambient one.
 
 The nontriviality hypothesis `P u ≠ 0` is required because the zero projector
 would yield the zero tensor, which is not normal (it cannot be block-injective).
@@ -139,9 +155,13 @@ lemma sectorBlocked_isNormal_of_isPeriodic
     IsNormal (leftSectorTensor (P u) (blockTensor A m)) := by
   sorry
 
-/-- If two periodic tensors have the same period `m` but no sector pair
-`(P_u A^(m), Q_v B^(m))` is gauge-phase equivalent, then their overlap
-decays to zero.
+/-- Provisional same-period / no-match statement.
+
+If two periodic tensors have the same period `m` but no sector pair matches,
+their overlap should decay to zero. As above, the current statement uses the
+ambient sector tensors `leftSectorTensor (P u) (blockTensor A m)`. The live
+cyclic-sector machinery instead produces compressed sector tensors, and the
+eventual proof will likely be cleaner when stated for those compressed blocks.
 
 The hypotheses require that `PA` and `QB` form genuine cyclic-sector
 decompositions: completeness (they sum to 1), mutual orthogonality, and

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -9,6 +9,7 @@ import TNLean.MPS.FundamentalTheorem.Full
 import TNLean.MPS.Chain.OneSidedInverse
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.CanonicalForm.CyclicSectors
+import TNLean.MPS.CanonicalForm.Assembly
 import TNLean.Spectral.SpectralGapNT
 
 import TNLean.Algebra.GramMatrixLI
@@ -84,6 +85,90 @@ open Filter Matrix
 namespace MPSTensor
 
 variable {d D : ℕ}
+
+private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
+    [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
+    (hP : IsPeriodic m A) :
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
+      (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
+      SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) := by
+  obtain ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
+    conjTranspose_kraus_setup A hP.leftCanonical hP.irreducible
+  obtain ⟨ω, hωprim⟩ := hP.primitiveRoot
+  have hM : (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := by
+    classical
+    simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ))
+  letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM
+  letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixSeminormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM.posSemidef
+  letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace (n := Fin D) (𝕜 := ℂ) 1 hM.posSemidef
+  have hAdj :
+      transferMap (d := d) (D := D) (fun i => (A i)ᴴ) =
+        (transferMap (d := d) (D := D) A).adjoint := by
+    simpa using transferMap_conjTranspose_eq_adjoint (d := d) (D := D) (A := A)
+  have hperiph_roots :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+        {μ : ℂ | μ ^ m = 1} := by
+    ext μ
+    constructor
+    · intro hμ
+      have hEigAdj :
+          Module.End.HasEigenvalue ((transferMap (d := d) (D := D) A).adjoint) μ := by
+        simpa [hAdj] using hμ.1
+      have hEig :
+          Module.End.HasEigenvalue (transferMap (d := d) (D := D) A) (star μ) :=
+        (Module.End.hasEigenvalue_adjoint_iff
+          (E := transferMap (d := d) (D := D) A) (μ := star μ)).2 <| by
+            simpa [star_star] using hEigAdj
+      have hNorm : ‖star μ‖ = 1 := by
+        simpa [norm_star] using hμ.2
+      have hStarMem :
+          star μ ∈ peripheralEigenvalues (transferMap (d := d) (D := D) A) :=
+        ⟨hEig, hNorm⟩
+      have hpowStar : (star μ) ^ m = 1 := by
+        simpa [hP.peripheral_eq] using hStarMem
+      have hpow : μ ^ m = 1 := by
+        have := congrArg star hpowStar
+        simpa using this
+      exact hpow
+    · intro hμ
+      have hpowStar : (star μ) ^ m = 1 := by
+        have := congrArg star hμ
+        simpa using this
+      have hStarMem :
+          star μ ∈ peripheralEigenvalues (transferMap (d := d) (D := D) A) := by
+        simpa [hP.peripheral_eq] using hpowStar
+      have hEigAdj :
+          Module.End.HasEigenvalue ((transferMap (d := d) (D := D) A).adjoint) μ :=
+        by
+          simpa [star_star] using
+            (Module.End.hasEigenvalue_adjoint_iff
+              (E := transferMap (d := d) (D := D) A) (μ := star μ)).1 hStarMem.1
+      have hNorm : ‖μ‖ = 1 := by
+        simpa [norm_star] using hStarMem.2
+      exact ⟨by simpa [hAdj] using hEigAdj, hNorm⟩
+  have hperiph_range :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+        Set.range (fun j : Fin m => ω ^ (j : ℕ)) := by
+    ext μ
+    constructor
+    · intro hμ
+      have hpow : μ ^ m = 1 := by
+        simpa [hperiph_roots] using hμ
+      obtain ⟨i, hi, hωi⟩ := hωprim.eq_pow_of_pow_eq_one hpow
+      exact ⟨⟨i, hi⟩, by simpa using hωi⟩
+    · rintro ⟨j, rfl⟩
+      have hpow : (ω ^ (j : ℕ)) ^ m = 1 := by
+        calc
+          (ω ^ (j : ℕ)) ^ m = ω ^ ((j : ℕ) * m) := by rw [pow_mul]
+          _ = ω ^ (m * (j : ℕ)) := by rw [Nat.mul_comm]
+          _ = (ω ^ m) ^ (j : ℕ) := by rw [pow_mul]
+          _ = 1 := by simp [hωprim.pow_eq_one]
+      simpa [hperiph_roots] using hpow
+  exact exists_cyclic_sector_decomp_after_blocking
+    A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
 
 /-! ## Self-overlap (first paragraph of Appendix A) -/
 

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -141,8 +141,7 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
           star μ ∈ peripheralEigenvalues (transferMap (d := d) (D := D) A) := by
         simpa [hP.peripheral_eq] using hpowStar
       have hEigAdj :
-          Module.End.HasEigenvalue ((transferMap (d := d) (D := D) A).adjoint) μ :=
-        by
+          Module.End.HasEigenvalue ((transferMap (d := d) (D := D) A).adjoint) μ := by
           simpa [star_star] using
             (Module.End.hasEigenvalue_adjoint_iff
               (E := transferMap (d := d) (D := D) A) (μ := star μ)).1 hStarMem.1

--- a/TNLean/MPS/Overlap/Basic.lean
+++ b/TNLean/MPS/Overlap/Basic.lean
@@ -65,4 +65,18 @@ lemma mpvOverlap_eq_star_mpvInner {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B 
   -- Expand `mpvInner` as a sum, then take `star` termwise.
   simp [mpvOverlap, mpvInner_eq_sum, star_sum, mul_comm]
 
+/-- Positive-length MPV equality on both sides upgrades to positive-length overlap equality. -/
+theorem mpvOverlap_eq_of_pos_mpv_eq
+    {d D₁ D₁' D₂ D₂' : ℕ}
+    {A : MPSTensor d D₁} {A' : MPSTensor d D₁'}
+    {B : MPSTensor d D₂} {B' : MPSTensor d D₂'}
+    (hA : ∀ {N : ℕ}, 0 < N → ∀ σ : Cfg d N, mpv A σ = mpv A' σ)
+    (hB : ∀ {N : ℕ}, 0 < N → ∀ σ : Cfg d N, mpv B σ = mpv B' σ) :
+    ∀ {N : ℕ}, 0 < N → mpvOverlap (d := d) A B N = mpvOverlap (d := d) A' B' N := by
+  intro N hN
+  simp only [mpvOverlap]
+  refine Finset.sum_congr rfl ?_
+  intro σ _
+  rw [hA hN σ, hB hN σ]
+
 end MPSTensor

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -52,7 +52,8 @@ boundary conditions (PBC).
     $A^{w_1 \cdot w_2} = A^{w_1} \, A^{w_2}$.
 \end{lemma}
 
-\begin{proof}\leanok\uses{def:eval_word}
+\begin{proof}\leanok
+    \uses{def:eval_word}
     Immediate from the definition of $A^w$.
 \end{proof}
 
@@ -217,7 +218,8 @@ boundary conditions (PBC).
     where $|w|$ is the length of~$w$.
 \end{lemma}
 
-\begin{proof}\leanok\uses{def:eval_word}
+\begin{proof}\leanok
+    \uses{def:eval_word}
     Induction on $w$: the base case gives $\zeta^0 = 1$,
     and each step picks up one factor of $\zeta$.
 \end{proof}
@@ -252,7 +254,8 @@ boundary conditions (PBC).
     \]
 \end{lemma}
 
-\begin{proof}\leanok\uses{def:eval_word}
+\begin{proof}\leanok
+    \uses{def:eval_word}
     Induction on the word length, using $X X^{-1} = \Id$.
 \end{proof}
 
@@ -264,8 +267,7 @@ boundary conditions (PBC).
     MPV family.
 \end{theorem}
 
-\begin{proof}
-    \leanok
+\begin{proof}\leanok
     \uses{lem:eval_word_gauge}
     Let $B^i = X A^i X^{-1}$.
     By Lemma~\ref{lem:eval_word_gauge}, $B^w = X \, A^w \, X^{-1}$
@@ -390,8 +392,7 @@ boundary conditions (PBC).
     \]
 \end{theorem}
 
-\begin{proof}
-    \leanok
+\begin{proof}\leanok
     \uses{def:block_diagonal_tensor, def:mpv, lem:eval_word_smul}
     For each physical index~$i$, the block-diagonal tensor
     $A^i = \bigoplus_k \mu_k A_k^i$ is a block-diagonal matrix.
@@ -434,7 +435,8 @@ boundary conditions (PBC).
     \]
 \end{lemma}
 
-\begin{proof}\leanok\uses{lem:eval_word_append}
+\begin{proof}\leanok
+    \uses{lem:eval_word_append}
     Induct on the blocked word $w$ and split off the first block word.
     Lemma~\ref{lem:eval_word_append} turns concatenation of blocks into
     multiplication of the corresponding evaluations.
@@ -456,7 +458,8 @@ boundary conditions (PBC).
     \]
 \end{lemma}
 
-\begin{proof}\leanok\uses{def:blocked_tensor, def:mpv, lem:eval_word_block}
+\begin{proof}\leanok
+    \uses{def:blocked_tensor, def:mpv, lem:eval_word_block}
     Concatenate the block words and apply the blocked word evaluation
     lemma (Lemma~\ref{lem:eval_word_block}).
 \end{proof}
@@ -470,8 +473,7 @@ boundary conditions (PBC).
     also generate the same MPV family.
 \end{theorem}
 
-\begin{proof}
-    \leanok
+\begin{proof}\leanok
     \uses{lem:mpv_block}
     By Lemma~\ref{lem:mpv_block},
     each MPV coefficient of the blocked tensor $A^{[L]}$ equals
@@ -539,7 +541,8 @@ boundary conditions (PBC).
     $O_{AB}(N) = \overline{\braket{V^{(N)}(A)}{V^{(N)}(B)}}$.
 \end{lemma}
 
-\begin{proof}\leanok\uses{def:mpv_overlap, def:mpv_inner}
+\begin{proof}\leanok
+    \uses{def:mpv_overlap, def:mpv_inner}
     The overlap sums $V_\sigma \, \overline{W_\sigma}$
     while the inner product sums $\overline{V_\sigma} \, W_\sigma$.
     Complex conjugation swaps these.
@@ -553,7 +556,8 @@ boundary conditions (PBC).
     and all $\sigma$, then $O_{AC}(N) = O_{BC}(N)$ for all
     positive $N$ and any third tensor $C$.
 \end{lemma}
-\begin{proof}\leanok\uses{def:mpv_overlap}
+\begin{proof}\leanok
+    \uses{def:mpv_overlap}
     Direct pointwise rewriting: if the MPV coefficients agree for
     all positive chain lengths, the overlap sums are identical.
 \end{proof}

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -544,3 +544,12 @@ boundary conditions (PBC).
     while the inner product sums $\overline{V_\sigma} \, W_\sigma$.
     Complex conjugation swaps these.
 \end{proof}
+
+\begin{lemma}[Overlap determined by positive-length MPV]%
+    \label{lem:overlap_eq_of_pos_mpv}
+    \lean{MPSTensor.mpvOverlap_eq_of_pos_mpv_eq}\leanok
+    \uses{def:mpv_overlap}
+    If $V^{(N)}(A)_\sigma = V^{(N)}(B)_\sigma$ for all $N > 0$
+    and all $\sigma$, then $O_{AC}(N) = O_{BC}(N)$ for all
+    positive $N$ and any third tensor $C$.
+\end{lemma}

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -553,3 +553,7 @@ boundary conditions (PBC).
     and all $\sigma$, then $O_{AC}(N) = O_{BC}(N)$ for all
     positive $N$ and any third tensor $C$.
 \end{lemma}
+egin{proof}\leanok
+    Direct pointwise rewriting: if the MPV coefficients agree for
+    all positive chain lengths, the overlap sums are identical.
+\end{proof}

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -553,7 +553,7 @@ boundary conditions (PBC).
     and all $\sigma$, then $O_{AC}(N) = O_{BC}(N)$ for all
     positive $N$ and any third tensor $C$.
 \end{lemma}
-egin{proof}\leanok
+\begin{proof}\leanok\uses{def:mpv_overlap}
     Direct pointwise rewriting: if the MPV coefficients agree for
     all positive chain lengths, the overlap sums are identical.
 \end{proof}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1024,6 +1024,12 @@ The following results separate the zero blocks from the
 	compressed tensor $C$ additionally satisfies
 	$V^{(N)}(C)_\sigma = V^{(N)}(A)_\sigma$ for all positive chain
 	lengths $N > 0$.
+\begin{proof}\leanok\uses{thm:compressed_sector}
+    For $N > 0$ the word $A^{i_1} \cdots A^{i_N}$ is nonempty, so $P$
+    acts as the identity on the left by idempotence and the support
+    hypothesis.  The MPV identity then follows from trace cyclicity
+    via Theorem~\ref{thm:compressed_sector}.
+\end{proof}
 \end{corollary}
 
 \begin{theorem}[Block decomposition from commuting projections]%

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1024,13 +1024,14 @@ The following results separate the zero blocks from the
 	compressed tensor $C$ additionally satisfies
 	$V^{(N)}(C)_\sigma = V^{(N)}(A)_\sigma$ for all positive chain
 	lengths $N > 0$.
-\begin{proof}\leanok\uses{thm:compressed_sector}
+\end{corollary}
+\begin{proof}\leanok
+    \uses{thm:compressed_sector}
     For $N > 0$ the word $A^{i_1} \cdots A^{i_N}$ is nonempty, so $P$
     acts as the identity on the left by idempotence and the support
     hypothesis.  The MPV identity then follows from trace cyclicity
     via Theorem~\ref{thm:compressed_sector}.
 \end{proof}
-\end{corollary}
 
 \begin{theorem}[Block decomposition from commuting projections]%
 	\label{thm:blockdecomp_commuting_projs}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1016,6 +1016,16 @@ The following results separate the zero blocks from the
 	the MPV identity follows from trace cyclicity.
 \end{proof}
 
+\begin{corollary}[Compression preserves positive-length MPV coefficients]%
+	\label{cor:compressed_sector_pos_mpv}
+	\lean{MPSTensor.exists_compressedTensor_of_supported_projection_pos_mpv}\leanok
+	\uses{thm:compressed_sector}
+	Under the hypotheses of Theorem~\ref{thm:compressed_sector}, the
+	compressed tensor $C$ additionally satisfies
+	$V^{(N)}(C)_\sigma = V^{(N)}(A)_\sigma$ for all positive chain
+	lengths $N > 0$.
+\end{corollary}
+
 \begin{theorem}[Block decomposition from commuting projections]%
 	\label{thm:blockdecomp_commuting_projs}
 	\lean{MPSTensor.exists_blockDecomp_of_commuting_projections}


### PR DESCRIPTION
## What changed
This PR now contains real proof progress on the periodic-overlap development, not just status notes.

It currently includes:
- a proof of the blocked cyclic-sector decomposition bridge in `TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean`
- a new positive-length compression lemma in `TNLean/MPS/CanonicalForm/CyclicSectors.lean`
- a positive-length overlap transport lemma in `TNLean/MPS/Overlap/Basic.lean`
- updated module documentation in `PeriodicOverlap.lean` describing the ambient-vs-compressed sector mismatch that still blocks the remaining same-period proofs

## Why it changed
The original blocker for the remaining `PeriodicOverlap` proofs was that the live cyclic-sector API naturally produces compressed corner-sector tensors, while the provisional Case 2 statements are still phrased using ambient `leftSectorTensor ...` objects.

The new lemmas make that mismatch smaller in practice:
- we can now derive blocked cyclic-sector decompositions directly from `IsPeriodic`
- we can now transport MPVs and overlaps across compression for all positive lengths, which is the form the periodic overlap arguments actually use

## Impact
This does not finish issue #82 yet, but it converts the branch from a documentation-only draft into a genuine proof-unblocking PR.

Concretely, it removes one of the main API mismatches in the same-period argument and leaves the next remaining work concentrated in `PeriodicOverlap.lean`.

## Root cause
`SameMPV₂` remembers the `N = 0` sector, while compression changes the zero-length coefficient from `trace 1 = D` to `trace P`. So the right bridge for cyclic sectors is not an all-length equality statement, but a positive-length MPV/overlap preservation statement.

## Validation
- `lake build TNLean.MPS.Overlap.Basic`
- `lake build TNLean.MPS.CanonicalForm.CyclicSectors`
- `lake build TNLean.MPS.FundamentalTheorem.PeriodicOverlap`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new lemmas that change the available equivalence/transport APIs around compression and periodic cyclic-sector decomposition; while proof-only, they touch core canonical-form and periodic-overlap scaffolding and could subtly affect downstream theorem dependencies.
> 
> **Overview**
> Advances the periodic-overlap development by adding proof bridges that avoid the `N = 0` mismatch introduced by sector compression.
> 
> Introduces `exists_compressedTensor_of_supported_projection_pos_mpv` (compression preserves MPV coefficients for all *positive* lengths) and a companion `mpvOverlap_eq_of_pos_mpv_eq` lemma to transport overlap equality from positive-length MPV equality. In `PeriodicOverlap.lean`, adds a private lemma deriving a blocked cyclic-sector decomposition directly from `IsPeriodic` (via the cyclic-sector/assembly APIs) and updates module docs to clarify the remaining ambient-vs-compressed sector mismatch. Blueprint chapters are updated to document these new lemmas/corollaries and minor proof markup cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 632cc41272a6dd96c22fd829a1742e45eb5ff35c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->