### PR TITLE
feat(ParentHamiltonian): close 2 sorrys in UniqueGroundState

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -2,8 +2,8 @@
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
-import TNLean.MPS.ParentHamiltonian.Defs
 
 /-!
 # Unique ground state for injective MPS parent Hamiltonians
@@ -111,11 +111,8 @@ theorem mpv_mem_chainGroundSpace (A : MPSTensor d D) (L N : ℕ)
   rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩]
   simp only [Submodule.mem_iInf, Submodule.mem_comap]
   intro i τ
-  -- We need: cyclicRestrictₗ hN L i τ (mpv A) ∈ groundSpace A L
-  -- This follows from trace cyclicity: rotating the N-site product to start
-  -- at the window position gives evalWord(σ-part) * evalWord(outside-part).
-  rw [groundSpace, LinearMap.mem_range]
-  sorry
+  simpa [cyclicRestrictₗ_apply, cyclicCfg, replaceWindow] using
+    mpv_window_mem_groundSpace A L N hLN i τ
 
 /-! ### Unique ground state -/
 
@@ -178,7 +175,17 @@ step; the remaining ingredient is the periodic boundary argument. -/
 theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjective A)
     {L N : ℕ} (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N) :
     HasUniqueGroundState (chainGroundSpace A L N) := by
-  sorry
+  rw [HasUniqueGroundState, chainGroundSpace_eq_mpvSubmodule hA hN hL hLN]
+  have hmpv : (mpv A : NSiteSpace d N) ≠ 0 := by
+    intro hzero
+    have hEq :
+        groundSpaceMap A N (1 : Matrix (Fin D) (Fin D) ℂ) =
+          groundSpaceMap A N (0 : Matrix (Fin D) (Fin D) ℂ) := by
+      simpa [mpv_eq_groundSpaceMap_one A N] using hzero
+    have h10 : (1 : Matrix (Fin D) (Fin D) ℂ) = 0 :=
+      (groundSpaceMap_injective hA (by omega : 0 < N)) hEq
+    exact one_ne_zero h10
+  simpa [mpvSubmodule] using finrank_span_singleton (K := ℂ) hmpv
 
 /-- **Unique ground state for `N`-block-injective tensors on `2N` sites**.
 


### PR DESCRIPTION
## Summary

Closes 2 of 5 `sorry`s in `UniqueGroundState.lean`.

### Changes

1. **`mpv_mem_chainGroundSpace`**: closed by importing `TNLean.MPS.ParentHamiltonian.Basic` and reusing the existing `mpv_window_mem_groundSpace` lemma (`cyclicCfg` matches `replaceWindow` definitionally).

2. **`groundSpace_unique_periodic`**: closed by reducing to `chainGroundSpace_eq_mpvSubmodule`, proving `mpv ≠ 0` via `groundSpaceMap_injective`, then applying `finrank_span_singleton`.

### Remaining sorrys (3)

- `chainGroundSpace_eq_mpvSubmodule` — blocked on periodic-boundary/intersection reduction
- `parentHamiltonian_unique_gs_injective` — blocked on block-injectivity bridge
- `parentHamiltonian_unique_gs_normal` — blocked on normal-form range-reduction

### Verification

`lake env lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean` passes with only 3 sorry warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Lean proof scripts and imports, reusing existing lemmas without altering core definitions or runtime behavior.
> 
> **Overview**
> Closes two `sorry`s in `UniqueGroundState.lean` by reusing existing infrastructure.
> 
> `mpv_mem_chainGroundSpace` is now proven by importing `ParentHamiltonian.Basic` and dispatching to `mpv_window_mem_groundSpace` (via definitional equalities around `cyclicCfg`/`replaceWindow`). `groundSpace_unique_periodic` is completed by rewriting with `chainGroundSpace_eq_mpvSubmodule`, proving `mpv ≠ 0` using `groundSpaceMap_injective`, and concluding `finrank = 1` via `finrank_span_singleton`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b503f00f7ec8ee0ff5103267004fcf5a8bdd956e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->