### PR TITLE
feat(FundamentalTheorem): close periodicBasis_eventuallyLinearlyIndependent sorry

### DIFF
--- a/TNLean/Algebra/GramMatrixLI.lean
+++ b/TNLean/Algebra/GramMatrixLI.lean
@@ -6,10 +6,14 @@ import Mathlib.Topology.Separation.Basic
 /-!
 # Gram-matrix convergence implies eventual linear independence
 
-This file proves an eventual linear-independence criterion from convergence of
-Gram matrices to the identity. The main theorem
-`eventually_linearIndependent_of_gram_tendsto_id` packages the finite-dimensional
-argument used in the MPDO papers arXiv:1606.00608 and arXiv:1708.00029.
+This file proves eventual linear-independence criteria from convergence of
+Gram matrices. The generalized theorem
+`eventually_linearIndependent_of_gram_tendsto_nondegenerate` handles
+convergence to any matrix with nonzero determinant (e.g. a diagonal matrix
+with positive entries). The special case of convergence to the identity is
+`eventually_linearIndependent_of_gram_tendsto_id`.
+
+Both are used in the MPDO papers arXiv:1606.00608 and arXiv:1708.00029.
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -18,13 +22,45 @@ open Filter
 namespace MPSTensor
 
 /--
-**Lem1 (MPDO 1606.00608 / 1708.00029)**: eventual linear independence from
-Gram-matrix convergence.
+**Generalized Gram-matrix criterion**: eventual linear independence from
+Gram-matrix convergence to any matrix with nonzero determinant.
 
-For a finite family of vectors `v i N` in a complex inner product space,
-if the Gram matrix entries converge `⟪v i N, v j N⟫_ℂ → δ_{ij}` as `N → ∞`,
-then the Gram matrices converge to the identity. Hence for `N` large enough the Gram matrix is
-invertible, and the vectors `{v i N}` are linearly independent.
+If the Gram matrix entries converge `⟪v i N, v j N⟫_ℂ → L i j` as `N → ∞`
+and `L.det ≠ 0`, then for `N` large enough the Gram matrix is invertible and
+the vectors `{v i N}` are linearly independent.
+-/
+theorem eventually_linearIndependent_of_gram_tendsto_nondegenerate
+    {ι : Type} [Fintype ι] [DecidableEq ι]
+    {V : Type} [NormedAddCommGroup V] [InnerProductSpace ℂ V]
+    (v : ι → ℕ → V) (L : Matrix ι ι ℂ) (hL : L.det ≠ 0)
+    (h : ∀ i j, Tendsto (fun N => ⟪v i N, v j N⟫_ℂ) atTop (nhds (L i j))) :
+    ∀ᶠ N in atTop, LinearIndependent ℂ (fun i => v i N) := by
+  let G : ℕ → Matrix ι ι ℂ := fun N i j => ⟪v i N, v j N⟫_ℂ
+  have hG : Tendsto G atTop (nhds L) := by
+    rw [tendsto_pi_nhds]; intro i; rw [tendsto_pi_nhds]; intro j; exact h i j
+  have hdet : Tendsto (fun N => (G N).det) atTop (nhds L.det) :=
+    ((continuous_id.matrix_det).tendsto L).comp hG
+  have hdet_ne : ∀ᶠ N in atTop, (G N).det ≠ 0 := hdet.eventually_ne hL
+  exact hdet_ne.mono fun N hN => by
+    rw [Fintype.linearIndependent_iff]
+    intro c hc
+    have hmul : (G N).mulVec c = 0 := by
+      ext j
+      have key : (G N).mulVec c j = ⟪v j N, ∑ i : ι, c i • v i N⟫_ℂ := by
+        simp only [Matrix.mulVec.eq_1, dotProduct, inner_sum, inner_smul_right]
+        apply Finset.sum_congr rfl; intro i _; ring
+      simp only [key, hc, inner_zero_right, Pi.zero_apply]
+    have hc0 : c = 0 := Matrix.eq_zero_of_mulVec_eq_zero hN hmul
+    intro i; exact congr_fun hc0 i
+
+/--
+**Lem1 (MPDO 1606.00608 / 1708.00029)**: eventual linear independence from
+Gram-matrix convergence to the identity.
+
+Special case of `eventually_linearIndependent_of_gram_tendsto_nondegenerate`
+where the limit matrix is the identity. For a finite family of vectors
+`v i N` in a complex inner product space, if `⟪v i N, v j N⟫_ℂ → δ_{ij}`,
+then for `N` large enough the vectors are linearly independent.
 -/
 theorem eventually_linearIndependent_of_gram_tendsto_id
     {ι : Type} [Finite ι] [DecidableEq ι]
@@ -34,41 +70,7 @@ theorem eventually_linearIndependent_of_gram_tendsto_id
              (nhds (if i = j then (1 : ℂ) else 0))) :
     ∀ᶠ N in atTop, LinearIndependent ℂ (fun i => v i N) := by
   cases nonempty_fintype ι
-  -- Define the Gram matrix G(N)_{ij} = ⟪v_i(N), v_j(N)⟫
-  let G : ℕ → Matrix ι ι ℂ := fun N i j => ⟪v i N, v j N⟫_ℂ
-  -- Step 1: G(N) → 1 (identity matrix) as N → ∞
-  have hG : Tendsto G atTop (nhds (1 : Matrix ι ι ℂ)) := by
-    rw [tendsto_pi_nhds]
-    intro i
-    rw [tendsto_pi_nhds]
-    intro j
-    simp only [Matrix.one_apply]
-    exact h i j
-  -- Step 2: det(G(N)) → det(1) = 1 by continuity of det
-  have hdet : Tendsto (fun N => (G N).det) atTop (nhds (1 : ℂ)) := by
-    have hcont : Continuous (fun M : Matrix ι ι ℂ => M.det) := continuous_id.matrix_det
-    have h1 := (hcont.tendsto (1 : Matrix ι ι ℂ)).comp hG
-    rwa [Function.comp_def, Matrix.det_one] at h1
-  -- Step 3: Eventually det(G(N)) ≠ 0
-  have hdet_ne : ∀ᶠ N in atTop, (G N).det ≠ 0 :=
-    hdet.eventually_ne one_ne_zero
-  -- Step 4: det ≠ 0 implies linear independence
-  exact hdet_ne.mono fun N hN => by
-    rw [Fintype.linearIndependent_iff]
-    intro c hc
-    -- From ∑ c_i • v_i(N) = 0, derive (G N) * c = 0 via inner products
-    have hmul : (G N).mulVec c = 0 := by
-      ext j
-      -- Show (G N).mulVec c j = ⟪v j N, ∑ c_i • v_i(N)⟫ = ⟪v j N, 0⟫ = 0
-      have key : (G N).mulVec c j = ⟪v j N, ∑ i : ι, c i • v i N⟫_ℂ := by
-        simp only [Matrix.mulVec.eq_1, dotProduct, inner_sum, inner_smul_right]
-        apply Finset.sum_congr rfl
-        intro i _
-        ring
-      simp only [key, hc, inner_zero_right, Pi.zero_apply]
-    -- det(G N) ≠ 0 and G N * c = 0 imply c = 0
-    have hc0 : c = 0 := Matrix.eq_zero_of_mulVec_eq_zero hN hmul
-    intro i
-    exact congr_fun hc0 i
+  exact eventually_linearIndependent_of_gram_tendsto_nondegenerate v 1
+    (by simp) (fun i j => by simpa [Matrix.one_apply] using h i j)
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -11,6 +11,7 @@ import TNLean.MPS.Core.Blocking
 import TNLean.MPS.CanonicalForm.CyclicSectors
 import TNLean.Spectral.SpectralGapNT
 
+import TNLean.Algebra.GramMatrixLI
 import Mathlib.Analysis.InnerProductSpace.l2Space
 
 /-!
@@ -416,37 +417,13 @@ theorem periodicBasis_eventuallyLinearlyIndependent
     simp only [v]
     rw [lp.inner_single_left, lp.single_apply_self]
   have hLI_emb : ∀ᶠ N in atTop, LinearIndependent ℂ (fun k => v k N) := by
-    let G : ℕ → Matrix (Fin r) (Fin r) ℂ := fun N i j => ⟪v i N, v j N⟫_ℂ
-    have hG : Tendsto G atTop (nhds (Matrix.diagonal fun k : Fin r => (period k : ℂ))) := by
-      rw [tendsto_pi_nhds]
-      intro i
-      rw [tendsto_pi_nhds]
-      intro j
-      simpa [G, Matrix.diagonal_apply] using hgram i j
-    have hdet : Tendsto (fun N => (G N).det) atTop (nhds (∏ k : Fin r, (period k : ℂ))) := by
-      have hcont : Continuous (fun M : Matrix (Fin r) (Fin r) ℂ => M.det) := continuous_id.matrix_det
-      simpa [Matrix.det_diagonal] using
-        ((hcont.tendsto (Matrix.diagonal fun k : Fin r => (period k : ℂ))).comp hG)
-    have hdet_ne : ∀ᶠ N in atTop, (G N).det ≠ 0 := by
-      apply hdet.eventually_ne
+    refine eventually_linearIndependent_of_gram_tendsto_nondegenerate v
+      (Matrix.diagonal fun k : Fin r => (period k : ℂ)) ?_ ?_
+    · rw [Matrix.det_diagonal]
       exact Finset.prod_ne_zero_iff.mpr fun k _ => by
         exact_mod_cast Nat.ne_of_gt (hPer k).period_pos
-    exact hdet_ne.mono fun N hN => by
-      rw [Fintype.linearIndependent_iff]
-      intro c hc
-      have hmul : (G N).mulVec c = 0 := by
-        ext j
-        have key : (G N).mulVec c j = ⟪v j N, ∑ i : Fin r, c i • v i N⟫_ℂ := by
-          change ∑ i, ⟪v j N, v i N⟫_ℂ * c i = ⟪v j N, ∑ i : Fin r, c i • v i N⟫_ℂ
-          rw [inner_sum]
-          apply Finset.sum_congr rfl
-          intro i _
-          rw [inner_smul_right]
-          ring
-        simp [key, hc]
-      have hc0 : c = 0 := Matrix.eq_zero_of_mulVec_eq_zero hN hmul
-      intro i
-      exact congr_fun hc0 i
+    · intro i j
+      simpa [Matrix.diagonal_apply] using hgram i j
   have hLI : ∀ᶠ N in atTop, LinearIndependent ℂ (fun k => mpvState (A k) (p * N)) := by
     refine hLI_emb.mono ?_
     intro N hN

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -11,6 +11,8 @@ import TNLean.MPS.Core.Blocking
 import TNLean.MPS.CanonicalForm.CyclicSectors
 import TNLean.Spectral.SpectralGapNT
 
+import Mathlib.Analysis.InnerProductSpace.l2Space
+
 /-!
 # Periodic overlap dichotomy (Proposition 3.3, arXiv:1708.00029)
 
@@ -66,7 +68,7 @@ relied on as a completed formalization of Proposition 3.3.
   and Appendix A.
 -/
 
-open scoped Matrix BigOperators ComplexOrder
+open scoped Matrix BigOperators ComplexOrder InnerProductSpace
 open Filter Matrix
 
 namespace MPSTensor
@@ -369,10 +371,92 @@ theorem periodicBasis_eventuallyLinearlyIndependent
         ¬ RepeatedBlocks (cast (congr_arg (MPSTensor d) hdim) (A i)) (A j)) :
     ∃ N₀ : ℕ, ∀ N ≥ N₀,
       LinearIndependent ℂ (fun k => mpvState (A k) (p * N)) := by
-  -- Use the dichotomy: pairwise non-repeated ⟹ pairwise decaying overlap.
-  -- Self-overlaps converge to periods (bounded away from 0).
-  -- By the epsilon-linear-independence lemma (Lemma 3.4 / Lem1 in the paper),
-  -- for N large enough the vectors are linearly independent.
-  sorry
+  classical
+  let V : Type := lp (fun N : ℕ => MPVSpace d (p * N)) 2
+  let v : Fin r → ℕ → V := fun k N => lp.single 2 N (mpvState (A k) (p * N))
+  have hself_overlap : ∀ k,
+      Tendsto (fun N => mpvOverlap (A k) (A k) (p * N)) atTop (nhds (period k : ℂ)) := by
+    intro k
+    rcases hDiv k with ⟨q, hq⟩
+    have hq_pos : 0 < q := by
+      apply Nat.pos_of_ne_zero
+      intro hq0
+      have : p = 0 := by simp [hq, hq0]
+      exact NeZero.ne p this
+    simpa [hq, Nat.mul_assoc] using
+      (periodicSelfOverlap_tendsto (A := A k) (m := period k) (hP := hPer k)).comp
+        (tendsto_id.nsmul_atTop hq_pos)
+  have hcross_overlap : ∀ i j, i ≠ j →
+      Tendsto (fun N => mpvOverlap (A i) (A j) (p * N)) atTop (nhds 0) := by
+    intro i j hij
+    have hbase : Tendsto (fun N => mpvOverlap (A i) (A j) N) atTop (nhds 0) := by
+      rcases periodicOverlapDichotomy (A := A i) (B := A j) (hA := hPer i) (hB := hPer j) with
+        hzero | hrep
+      · exact hzero
+      · rcases hrep with ⟨hdim, hrep⟩
+        exact False.elim (hNonrep i j hij hdim hrep)
+    simpa [nsmul_eq_mul] using
+      hbase.comp (tendsto_id.nsmul_atTop (Nat.pos_of_ne_zero (NeZero.ne p)))
+  have hInnerState : ∀ i j : Fin r,
+      Tendsto (fun N => ⟪mpvState (A i) (p * N), mpvState (A j) (p * N)⟫_ℂ)
+        atTop (nhds (if i = j then (period i : ℂ) else 0)) := by
+    intro i j
+    by_cases hij : i = j
+    · subst j
+      simpa [if_pos rfl, mpvInner, mpvOverlap_eq_star_mpvInner] using
+        (hself_overlap i).star
+    · simpa [if_neg hij, mpvInner, mpvOverlap_eq_star_mpvInner] using
+        (hcross_overlap i j hij).star
+  have hgram : ∀ i j : Fin r,
+      Tendsto (fun N : ℕ => ⟪v i N, v j N⟫_ℂ) atTop
+        (nhds (if i = j then (period i : ℂ) else 0)) := by
+    intro i j
+    refine (hInnerState i j).congr ?_
+    intro N
+    simp only [v]
+    rw [lp.inner_single_left, lp.single_apply_self]
+  have hLI_emb : ∀ᶠ N in atTop, LinearIndependent ℂ (fun k => v k N) := by
+    let G : ℕ → Matrix (Fin r) (Fin r) ℂ := fun N i j => ⟪v i N, v j N⟫_ℂ
+    have hG : Tendsto G atTop (nhds (Matrix.diagonal fun k : Fin r => (period k : ℂ))) := by
+      rw [tendsto_pi_nhds]
+      intro i
+      rw [tendsto_pi_nhds]
+      intro j
+      simpa [G, Matrix.diagonal_apply] using hgram i j
+    have hdet : Tendsto (fun N => (G N).det) atTop (nhds (∏ k : Fin r, (period k : ℂ))) := by
+      have hcont : Continuous (fun M : Matrix (Fin r) (Fin r) ℂ => M.det) := continuous_id.matrix_det
+      simpa [Matrix.det_diagonal] using
+        ((hcont.tendsto (Matrix.diagonal fun k : Fin r => (period k : ℂ))).comp hG)
+    have hdet_ne : ∀ᶠ N in atTop, (G N).det ≠ 0 := by
+      apply hdet.eventually_ne
+      exact Finset.prod_ne_zero_iff.mpr fun k _ => by
+        exact_mod_cast Nat.ne_of_gt (hPer k).period_pos
+    exact hdet_ne.mono fun N hN => by
+      rw [Fintype.linearIndependent_iff]
+      intro c hc
+      have hmul : (G N).mulVec c = 0 := by
+        ext j
+        have key : (G N).mulVec c j = ⟪v j N, ∑ i : Fin r, c i • v i N⟫_ℂ := by
+          change ∑ i, ⟪v j N, v i N⟫_ℂ * c i = ⟪v j N, ∑ i : Fin r, c i • v i N⟫_ℂ
+          rw [inner_sum]
+          apply Finset.sum_congr rfl
+          intro i _
+          rw [inner_smul_right]
+          ring
+        simp [key, hc]
+      have hc0 : c = 0 := Matrix.eq_zero_of_mulVec_eq_zero hN hmul
+      intro i
+      exact congr_fun hc0 i
+  have hLI : ∀ᶠ N in atTop, LinearIndependent ℂ (fun k => mpvState (A k) (p * N)) := by
+    refine hLI_emb.mono ?_
+    intro N hN
+    let fN : MPVSpace d (p * N) →ₗ[ℂ] V :=
+      lp.lsingle (𝕜 := ℂ) (E := fun M : ℕ => MPVSpace d (p * M)) 2 N
+    have hN' :
+        LinearIndependent ℂ (fun k : Fin r => fN (mpvState (A k) (p * N))) := by
+      simpa [v, fN, lp.lsingle_apply] using hN
+    exact LinearIndependent.of_comp fN hN'
+  obtain ⟨N₀, hN₀⟩ := Filter.eventually_atTop.1 hLI
+  exact ⟨N₀, hN₀⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -698,7 +698,7 @@ the remaining declarations are scaffolded with incomplete proofs.
 \end{theorem}
 
 \begin{theorem}[Eventual linear independence of a periodic basis]\label{thm:periodic_basis_eventually_li}
-	\lean{MPSTensor.periodicBasis_eventuallyLinearlyIndependent}
+	\lean{MPSTensor.periodicBasis_eventuallyLinearlyIndependent}\leanok
 	\uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
 	For a finite family of pairwise non-equivalent periodic tensors whose
 	periods divide a common integer $p$, there is $N_0$ such that for every


### PR DESCRIPTION
## Summary

Closes 1 of 9 `sorry`s in `PeriodicOverlap.lean` (the final linear-independence corollary).

### Changes

Proves `periodicBasis_eventuallyLinearlyIndependent` using a diagonal Gram matrix convergence argument:

1. Embed periodic MPS states into `lp` space via `lp.single`
2. Show the Gram matrix `G(N)_{ij} = ⟨v_i(N), v_j(N)⟩` converges to `diag(period_1, ..., period_r)`
3. `det(G(N)) → ∏ period_k ≠ 0`, so `G(N)` is eventually invertible
4. Invertible Gram matrix implies linear independence

### New dependencies

- Adds import `Mathlib.Analysis.InnerProductSpace.l2Space`
- Opens `InnerProductSpace` notation scope

### Remaining sorrys (8)

The remaining 8 sorrys require deep periodic-sector infrastructure:
- `periodicSelfOverlap_tendsto` — spectral/peripheral-eigenvalue argument
- `periodicOverlap_tendsto_zero_of_ne_period` — blocking plus nonrepetition contradiction
- `sectorBlocked_isNormal_of_isPeriodic` — cyclic-sector API
- `periodicOverlap_tendsto_zero_of_no_sector_match` — sector decomposition + decay
- `sectorMatch_propagation` — deep sector theory
- `sectorTensor_proportional_of_blockedMatch` — very deep sector theory
- `periodicOverlap_gaugeEquiv_of_sector_match` — assembly theorem
- `periodicOverlapDichotomy` — assembly theorem

### Verification

`lake env lean TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean` passes with 8 sorry warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to Lean proof development, adding a reusable Gram-matrix linear-independence lemma and using it to discharge an existing `sorry` without affecting runtime behavior.
> 
> **Overview**
> **Closes the `sorry` in `periodicBasis_eventuallyLinearlyIndependent`** by proving eventual linear independence of periodic MPS basis states using Gram-matrix convergence: self-overlaps converge to the period, cross-overlaps tend to `0`, yielding a diagonal limit Gram matrix with nonzero determinant.
> 
> Adds a new generalized lemma `eventually_linearIndependent_of_gram_tendsto_nondegenerate` (plus an `id` specialization) to derive eventual linear independence from Gram matrices converging to any matrix `L` with `L.det ≠ 0`, and wires this into `PeriodicOverlap.lean` via an `lp`/`l2Space` embedding. The blueprint marks the theorem as `\leanok`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf18602e929d63ee9a57556e0e8512b187283a3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->