### PR TITLE
feat(Channel/Peripheral): close peripheral_eigenvalue_multiplicity_one sorry

### DIFF
--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -183,7 +183,7 @@ private theorem hermitian_fixed_eq_scalar_of_irreducible_unital
     _ = d • 1 + (c0 : ℂ) • 1 := by rw [hd]
     _ = (d + c0) • 1 := by simp [add_smul]
 
-private theorem fixed_eq_scalar_of_irreducible_unital
+theorem fixed_eq_scalar_of_irreducible_unital
     {r D : ℕ} [NeZero D]
     (K : Fin r → MatrixAlg D)
     (hUnital : KadisonSchwarz.IsUnitalKraus (d := r) (D := D) K)

--- a/TNLean/Channel/Peripheral/GroupStructure.lean
+++ b/TNLean/Channel/Peripheral/GroupStructure.lean
@@ -489,10 +489,11 @@ theorem peripheral_eigenvalues_form_cyclic_group
 
 /-- **Each peripheral eigenvalue has multiplicity 1** (Wolf Thm 6.6).
 
-Follows from `fixed_eq_scalar_of_irreducible_unital` in
-`CyclicDecomposition.lean`: if `E(X) = X` with `E` irreducible and unital,
-then `X = c · I`. Applied to `E^m` restricted to a cyclic sector, this
-forces one-dimensional eigenspaces. -/
+Given a peripheral unitary eigenvector `U` with `E(U) = γU`, for any
+`γ`-eigenvector `X` the multiplicative-domain identity gives
+`E(X · U†) = E(X) · E(U†) = X · U†`, so `X · U†` is a fixed point.
+By `fixed_eq_scalar_of_irreducible_unital`, `X · U† = c · I`, hence
+`X = c · U`, and the eigenspace is one-dimensional. -/
 theorem peripheral_eigenvalue_multiplicity_one
     {r : ℕ} [NeZero D]
     (K : Fin r → MatrixAlg D)
@@ -526,11 +527,6 @@ theorem peripheral_eigenvalue_multiplicity_one
     simpa using congrArg Subtype.val hzero
   have hU_map : Kraus.map K (U : MatrixAlg D) = γ • (U : MatrixAlg D) := by
     simpa [Kraus.map, E, MPSTensor.transferMap_apply] using hU
-  have hKSU_map :
-      Kraus.map K ((U : MatrixAlg D)ᴴ * (U : MatrixAlg D)) =
-        (Kraus.map K (U : MatrixAlg D))ᴴ * Kraus.map K (U : MatrixAlg D) := by
-    exact Kraus.ks_equality_of_peripheral_eigenvector_of_fixedPoint
-      K hUnital' hρ hρfix (U : MatrixAlg D) γ hU_map hγ.2
   have hγ_inv : starRingEnd ℂ γ = γ⁻¹ :=
     (Complex.inv_eq_conj hγ.2).symm
   have hUstar_map : Kraus.map K ((U : MatrixAlg D)ᴴ) = γ⁻¹ • ((U : MatrixAlg D)ᴴ) := by

--- a/TNLean/Channel/Peripheral/GroupStructure.lean
+++ b/TNLean/Channel/Peripheral/GroupStructure.lean
@@ -504,8 +504,93 @@ theorem peripheral_eigenvalue_multiplicity_one
     (hγ : γ ∈ peripheralEigenvalues (MPSTensor.transferMap (d := r) (D := D) K)) :
     Module.finrank ℂ
       (Module.End.eigenspace (MPSTensor.transferMap (d := r) (D := D) K) γ) = 1 := by
-  -- Use fixed_eq_scalar_of_irreducible_unital from CyclicDecomposition.lean
-  sorry -- TODO (#22): restrict E^m to cyclic sector, apply scalar-fixed-point lemma
+  classical
+  let E := MPSTensor.transferMap (d := r) (D := D) K
+  obtain ⟨U, hU⟩ := MPSTensor.exists_peripheral_unitary_of_irreducible_schwarz
+    K hUnital ρ hρ hρfix hIrr hγ
+  have hUnital' : Kraus.IsUnital K := by
+    simpa [Kraus.IsUnital, KadisonSchwarz.IsUnitalKraus] using hUnital
+  have hU_mem : (U : MatrixAlg D) ∈ Module.End.eigenspace E γ := by
+    exact (Module.End.mem_eigenspace_iff).2 (by simpa [E] using hU)
+  have hU_star_mul : ((U : MatrixAlg D)ᴴ * (U : MatrixAlg D)) = 1 := by
+    have hstar := Matrix.UnitaryGroup.star_mul_self U
+    rwa [star_eq_conjTranspose] at hstar
+  have hU_mat_ne : (U : MatrixAlg D) ≠ 0 := by
+    intro hU_zero
+    have hUU := hU_star_mul
+    rw [hU_zero] at hUU
+    simp at hUU
+  have hU_ne : (⟨(U : MatrixAlg D), hU_mem⟩ : Module.End.eigenspace E γ) ≠ 0 := by
+    intro hzero
+    apply hU_mat_ne
+    simpa using congrArg Subtype.val hzero
+  have hU_map : Kraus.map K (U : MatrixAlg D) = γ • (U : MatrixAlg D) := by
+    simpa [Kraus.map, E, MPSTensor.transferMap_apply] using hU
+  have hKSU_map :
+      Kraus.map K ((U : MatrixAlg D)ᴴ * (U : MatrixAlg D)) =
+        (Kraus.map K (U : MatrixAlg D))ᴴ * Kraus.map K (U : MatrixAlg D) := by
+    exact Kraus.ks_equality_of_peripheral_eigenvector_of_fixedPoint
+      K hUnital' hρ hρfix (U : MatrixAlg D) γ hU_map hγ.2
+  have hγ_inv : starRingEnd ℂ γ = γ⁻¹ :=
+    (Complex.inv_eq_conj hγ.2).symm
+  have hUstar_map : Kraus.map K ((U : MatrixAlg D)ᴴ) = γ⁻¹ • ((U : MatrixAlg D)ᴴ) := by
+    rw [← Kraus.map_conjTranspose, hU_map, conjTranspose_smul]
+    simp [hγ_inv]
+  have hγinv_norm : ‖γ⁻¹‖ = 1 := by
+    rw [norm_inv, hγ.2, inv_one]
+  have hKSUstar :
+      KadisonSchwarz.krausMap K (((U : MatrixAlg D)ᴴ)ᴴ * (U : MatrixAlg D)ᴴ) =
+        (KadisonSchwarz.krausMap K ((U : MatrixAlg D)ᴴ))ᴴ *
+          KadisonSchwarz.krausMap K ((U : MatrixAlg D)ᴴ) := by
+    have hKSUstar_map :
+        Kraus.map K (((U : MatrixAlg D)ᴴ)ᴴ * (U : MatrixAlg D)ᴴ) =
+          (Kraus.map K ((U : MatrixAlg D)ᴴ))ᴴ *
+            Kraus.map K ((U : MatrixAlg D)ᴴ) := by
+      exact Kraus.ks_equality_of_peripheral_eigenvector_of_fixedPoint
+        K hUnital' hρ hρfix ((U : MatrixAlg D)ᴴ) γ⁻¹ hUstar_map hγinv_norm
+    simpa [Kraus.map, KadisonSchwarz.krausMap] using hKSUstar_map
+  refine finrank_eq_one ⟨(U : MatrixAlg D), hU_mem⟩ hU_ne ?_
+  intro X
+  have hX_eq : E X.1 = γ • X.1 :=
+    (Module.End.mem_eigenspace_iff).1 X.2
+  have hX_map : Kraus.map K X.1 = γ • X.1 := by
+    simpa [Kraus.map, E, MPSTensor.transferMap_apply] using hX_eq
+  have hXUstar_fix_map : Kraus.map K (X.1 * (U : MatrixAlg D)ᴴ) = X.1 * (U : MatrixAlg D)ᴴ := by
+    have hmul :
+        KadisonSchwarz.krausMap K (X.1 * (U : MatrixAlg D)ᴴ) =
+          KadisonSchwarz.krausMap K X.1 *
+            KadisonSchwarz.krausMap K ((U : MatrixAlg D)ᴴ) :=
+      KadisonSchwarz.multiplicative_domain_right K hUnital ((U : MatrixAlg D)ᴴ) hKSUstar X.1
+    have hmul_map :
+        Kraus.map K (X.1 * (U : MatrixAlg D)ᴴ) =
+          Kraus.map K X.1 * Kraus.map K ((U : MatrixAlg D)ᴴ) := by
+      simpa [Kraus.map, KadisonSchwarz.krausMap] using hmul
+    have hγ_ne_zero : γ ≠ 0 := by
+      intro hγ_zero
+      have : ‖(0 : ℂ)‖ = 1 := by simpa [hγ_zero] using hγ.2
+      norm_num at this
+    calc
+      Kraus.map K (X.1 * (U : MatrixAlg D)ᴴ)
+          = Kraus.map K X.1 * Kraus.map K ((U : MatrixAlg D)ᴴ) := hmul_map
+      _ = (γ • X.1) * (γ⁻¹ • ((U : MatrixAlg D)ᴴ)) := by
+            rw [hX_map, hUstar_map]
+      _ = X.1 * (U : MatrixAlg D)ᴴ := by
+            simp [smul_smul, hγ_ne_zero]
+  have hXUstar_fix : E (X.1 * (U : MatrixAlg D)ᴴ) = X.1 * (U : MatrixAlg D)ᴴ := by
+    simpa [Kraus.map, E, MPSTensor.transferMap_apply] using hXUstar_fix_map
+  obtain ⟨c, hc⟩ := MPSTensor.fixed_eq_scalar_of_irreducible_unital
+    (K := K) hUnital hIrr (X.1 * (U : MatrixAlg D)ᴴ) hXUstar_fix
+  have hX_scalar : X.1 = c • (U : MatrixAlg D) := by
+    calc
+      X.1 = X.1 * (1 : MatrixAlg D) := by simp
+      _ = X.1 * (((U : MatrixAlg D)ᴴ) * (U : MatrixAlg D)) := by
+            rw [← hU_star_mul]
+      _ = (X.1 * (U : MatrixAlg D)ᴴ) * (U : MatrixAlg D) := by
+            rw [Matrix.mul_assoc]
+      _ = (c • (1 : MatrixAlg D)) * (U : MatrixAlg D) := by rw [hc]
+      _ = c • (U : MatrixAlg D) := by simp
+  refine ⟨c, ?_⟩
+  exact Subtype.ext hX_scalar.symm
 
 /-- The **period** of the channel divides `D` (the bond dimension).
 

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1096,11 +1096,19 @@ used later in the blueprint.
 \end{theorem}
 
 \begin{theorem}[Peripheral eigenvalue multiplicity one]
+    \label{thm:peripheral_multiplicity_one}
     \lean{PeripheralSpectrum.peripheral_eigenvalue_multiplicity_one}
+    \leanok
     \uses{thm:peripheral_cyclic_group}
     Each peripheral eigenvalue has algebraic multiplicity one.
-    \textbf{Status:} proof pending (\texttt{sorry}).
 \end{theorem}
+\begin{proof}\leanok
+    Given a peripheral unitary eigenvector $U$ for $\gamma$, the
+    multiplicative-domain identity gives $E(X U^\dagger) = X U^\dagger$
+    for any $\gamma$-eigenvector $X$. By the scalar fixed-point lemma
+    for irreducible unital maps, $X U^\dagger = c \cdot I$, hence
+    $X = c \cdot U$ and the eigenspace is one-dimensional.
+\end{proof}
 
 \section{Primitive overlap convergence (spectral-gap form)}
 


### PR DESCRIPTION
## Summary

Closes the last `sorry` in `GroupStructure.lean` — the file is now **sorry-free**.

### Changes

**`peripheral_eigenvalue_multiplicity_one`** (Wolf Thm 6.6): each peripheral eigenvalue of an irreducible unital channel has eigenspace dimension exactly 1.

**Proof**: Uses the peripheral unitary eigenvector `U` for `γ`. For any `γ`-eigenvector `X`, multiplicative domain identities give `E(X·U†) = E(X)·E(U†) = (γX)(γ⁻¹U†) = X·U†`, so `X·U†` is a fixed point. By `fixed_eq_scalar_of_irreducible_unital`, `X·U† = c·I`, hence `X = c·U`.

Also exposes `fixed_eq_scalar_of_irreducible_unital` from `CyclicDecomposition.lean` (was `private`, now public — 1-line change).

### Verification

`lake env lean TNLean/Channel/Peripheral/GroupStructure.lean` passes with **no warnings**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Lean theorem visibility and replacing a `sorry` with a completed proof; main risk is downstream breakage from making a previously `private` lemma public and from proof-term brittleness against future refactors.
> 
> **Overview**
> Completes the previously-`sorry` theorem `peripheral_eigenvalue_multiplicity_one` by formalizing the multiplicative-domain argument: any `γ`-eigenvector is shown to be a scalar multiple of a peripheral unitary eigenvector, yielding `finrank` of the eigenspace equal to `1`.
> 
> Exposes `fixed_eq_scalar_of_irreducible_unital` from `CyclicDecomposition.lean` (removes `private`) so it can be reused by the new proof, and updates the blueprint theorem to `\leanok` with an accompanying proof sketch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b1f557e489dff71202d538c1d02472673dcac0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->