### PR TITLE
feat(Channel/Semigroup): close hermitian_span_trivial_commutant sorry (#280)

### DIFF
--- a/TNLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/TNLean/Channel/Semigroup/RelaxationConditions.lean
@@ -124,7 +124,7 @@ private theorem lower_left_block_vanishes_on_lindbladSpan
       rw [Matrix.mul_add, Matrix.add_mul, hA, hB]
       simp
   | smul c A _ hA =>
-      rw [smul_mul_assoc, Matrix.mul_smul_comm, hA, smul_zero]
+      rw [mul_smul_comm, smul_mul_assoc, hA, smul_zero]
 
 private theorem not_isNontrivialProjection_of_eq_smul_one
     {P : Mat} (hP_nt : IsNontrivialProjection P) {c : ℂ}

--- a/TNLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/TNLean/Channel/Semigroup/RelaxationConditions.lean
@@ -87,14 +87,13 @@ private theorem lindblad_block_of_generatorPreservesCompression
     exact sub_eq_zero.mp hQ_LP
   have hsum_zero :
       ∑ j : Fin F.r, ((1 - P) * F.L j * P) * ((1 - P) * F.L j * P)ᴴ = 0 := by
+    have hPP' : P * (1 - P) = 0 := by
+      rw [mul_sub, mul_one, hPP, sub_self]
     suffices hLHS :
         ∑ j : Fin F.r, ((1 - P) * F.L j * P) * ((1 - P) * F.L j * P)ᴴ =
         (1 - P) * (∑ j : Fin F.r, F.L j * P * (F.L j)ᴴ) * (1 - P) by
       rw [hLHS, hQ_phi_eq_Q_kappa]
-      simp only [Matrix.mul_assoc]
-      rw [show κ * P * (1 - P) = κ * (P * (1 - P)) by simp only [Matrix.mul_assoc]]
-      rw [show P * (1 - P) = 0 by rw [mul_sub, mul_one, hPP, sub_self]]
-      simp
+      simp [Matrix.mul_assoc, hPP']
     rw [mul_sum, Finset.sum_mul]
     apply Finset.sum_congr rfl
     intro j _
@@ -115,23 +114,24 @@ private theorem lower_left_block_vanishes_on_lindbladSpan
     (hblock : ∀ j : Fin F.r, (1 - P) * F.L j * P = 0) :
     ∀ A : Mat, A ∈ lindbladSpan F → (1 - P) * A * P = 0 := by
   intro A hA
-  refine Submodule.span_induction hA ?_ ?_ ?_ ?_
-  · intro B hB
-    rcases hB with ⟨j, rfl⟩
-    exact hblock j
-  · simp
-  · intro A B hA hB
-    rw [Matrix.mul_add, Matrix.add_mul, hA, hB]
-    simp
-  · intro c A hA
-    rw [smul_mul_assoc, Matrix.mul_smul_comm, hA, smul_zero]
+  induction hA using Submodule.span_induction with
+  | mem B hB =>
+      rcases hB with ⟨j, rfl⟩
+      exact hblock j
+  | zero =>
+      simp
+  | add A B _ _ hA hB =>
+      rw [Matrix.mul_add, Matrix.add_mul, hA, hB]
+      simp
+  | smul c A _ hA =>
+      rw [smul_mul_assoc, Matrix.mul_smul_comm, hA, smul_zero]
 
 private theorem not_isNontrivialProjection_of_eq_smul_one
     {P : Mat} (hP_nt : IsNontrivialProjection P) {c : ℂ}
     (hP : P = c • (1 : Mat)) : False := by
   by_cases hD : D = 0
   · subst hD
-    exact hP_nt.2 (Subsingleton.elim _ _)
+    exact hP_nt.2.1 (Subsingleton.elim _ _)
   · haveI : NeZero D := ⟨hD⟩
     have hIdem : (c • (1 : Mat)) * (c • (1 : Mat)) = c • (1 : Mat) := by
       simpa [hP] using hP_nt.1.2
@@ -147,8 +147,8 @@ private theorem not_isNontrivialProjection_of_eq_smul_one
       · exact Or.inl hc0
       · exact Or.inr (sub_eq_zero.mp hc1)
     rcases hc01 with hc0 | hc1
-    · exact hP_nt.2 (by rw [hP, hc0, zero_smul])
-    · exact hP_nt.3 (by rw [hP, hc1, one_smul])
+    · exact hP_nt.2.1 (by rw [hP, hc0, zero_smul])
+    · exact hP_nt.2.2 (by rw [hP, hc1, one_smul])
 
 /--
 Condition (1): full algebra generation forbids block-upper-triangular
@@ -183,6 +183,8 @@ theorem hermitian_span_trivial_commutant_implies_no_blockUpperTriangular
   have hblock_span : ∀ A : Mat, A ∈ lindbladSpan F → (1 - P) * A * P = 0 :=
     lower_left_block_vanishes_on_lindbladSpan F hblock
   have hP_herm : Pᴴ = P := hP_nt.1.1
+  have hP_add_compl : P + (1 - P) = (1 : Mat) := by
+    abel
   have hcommP : ∀ j : Fin F.r, P * F.L j = F.L j * P := by
     intro j
     have hLj_mem : F.L j ∈ lindbladSpan F := by
@@ -197,14 +199,14 @@ theorem hermitian_span_trivial_commutant_implies_no_blockUpperTriangular
       calc
         P * F.L j = P * F.L j * 1 := by simp
         _ = P * F.L j * (P + (1 - P)) := by
-          rw [show (1 : Mat) = P + (1 - P) by abel]
+          rw [hP_add_compl]
         _ = P * F.L j * P + P * F.L j * (1 - P) := by rw [Matrix.mul_add]
         _ = P * F.L j * P := by rw [hPAQ, add_zero]
     have hright : F.L j * P = P * F.L j * P := by
       calc
         F.L j * P = 1 * (F.L j * P) := by simp
         _ = (P + (1 - P)) * (F.L j * P) := by
-          rw [show (1 : Mat) = P + (1 - P) by abel]
+          rw [hP_add_compl]
         _ = P * (F.L j * P) + (1 - P) * (F.L j * P) := by rw [Matrix.add_mul]
         _ = P * F.L j * P + (1 - P) * F.L j * P := by simp [Matrix.mul_assoc]
         _ = P * F.L j * P := by rw [hblock j, add_zero]

--- a/TNLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/TNLean/Channel/Semigroup/RelaxationConditions.lean
@@ -56,6 +56,100 @@ orthonormal-basis representation (Wolf §7.1). -/
 def kossakowskiRank (L : Mat →ₗ[ℂ] Mat) : ℕ :=
   sInf {n : ℕ | ∃ F : LindbladForm D, F.toLinearMap = L ∧ F.r = n}
 
+private theorem lindblad_block_of_generatorPreservesCompression
+    {P : Mat} (hP : IsOrthogonalProjection P) (F : LindbladForm D)
+    (hgen : GeneratorPreservesCompression F.toLinearMap P) :
+    ∀ j : Fin F.r, (1 - P) * F.L j * P = 0 := by
+  have hPP : P * P = P := hP.2
+  have hP_herm : Pᴴ = P := hP.1
+  have hQP : (1 - P) * P = 0 := by rw [sub_mul, one_mul, hPP, sub_self]
+  have hLP_compress : P * F.toLinearMap P * P = F.toLinearMap P := by
+    have h1 := hgen 1
+    simp only [mul_one] at h1
+    rwa [hPP] at h1
+  have hQ_LP : (1 - P) * F.toLinearMap P = 0 := by
+    calc
+      (1 - P) * F.toLinearMap P = (1 - P) * (P * F.toLinearMap P * P) := by
+        rw [hLP_compress]
+      _ = ((1 - P) * P) * (F.toLinearMap P * P) := by
+        simp only [Matrix.mul_assoc]
+      _ = 0 := by rw [hQP, Matrix.zero_mul]
+  set κ : Mat := F.toGeneratorDecomp.κ
+  have hQ_phi_eq_Q_kappa :
+      (1 - P) * (∑ j : Fin F.r, F.L j * P * (F.L j)ᴴ) = (1 - P) * (κ * P) := by
+    rw [F.toLinearMap_eq_generatorDecomp] at hQ_LP
+    simp only [GeneratorDecomp.toLinearMap_apply] at hQ_LP
+    rw [Matrix.mul_sub, Matrix.mul_sub] at hQ_LP
+    have hQPκ : (1 - P) * (P * F.toGeneratorDecomp.κᴴ) = 0 := by
+      rw [← Matrix.mul_assoc, hQP, Matrix.zero_mul]
+    rw [hQPκ, sub_zero] at hQ_LP
+    change (1 - P) * (∑ j : Fin F.r, F.L j * P * (F.L j)ᴴ) = (1 - P) * (κ * P)
+    exact sub_eq_zero.mp hQ_LP
+  have hsum_zero :
+      ∑ j : Fin F.r, ((1 - P) * F.L j * P) * ((1 - P) * F.L j * P)ᴴ = 0 := by
+    suffices hLHS :
+        ∑ j : Fin F.r, ((1 - P) * F.L j * P) * ((1 - P) * F.L j * P)ᴴ =
+        (1 - P) * (∑ j : Fin F.r, F.L j * P * (F.L j)ᴴ) * (1 - P) by
+      rw [hLHS, hQ_phi_eq_Q_kappa]
+      simp only [Matrix.mul_assoc]
+      rw [show κ * P * (1 - P) = κ * (P * (1 - P)) by simp only [Matrix.mul_assoc]]
+      rw [show P * (1 - P) = 0 by rw [mul_sub, mul_one, hPP, sub_self]]
+      simp
+    rw [mul_sum, Finset.sum_mul]
+    apply Finset.sum_congr rfl
+    intro j _
+    calc
+      ((1 - P) * F.L j * P) * ((1 - P) * F.L j * P)ᴴ
+          = (1 - P) * (F.L j * (P * (P * ((F.L j)ᴴ * (1 - P))))) := by
+              simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_sub,
+                Matrix.conjTranspose_one, hP_herm, Matrix.mul_assoc]
+      _ = (1 - P) * (F.L j * (P * ((F.L j)ᴴ * (1 - P)))) := by
+              congr 2
+              rw [← Matrix.mul_assoc, hPP]
+      _ = (1 - P) * (F.L j * P * (F.L j)ᴴ) * (1 - P) := by
+              simp [Matrix.mul_assoc]
+  exact eq_zero_of_sum_mul_conjTranspose_eq_zero _ hsum_zero
+
+private theorem lower_left_block_vanishes_on_lindbladSpan
+    {P : Mat} (F : LindbladForm D)
+    (hblock : ∀ j : Fin F.r, (1 - P) * F.L j * P = 0) :
+    ∀ A : Mat, A ∈ lindbladSpan F → (1 - P) * A * P = 0 := by
+  intro A hA
+  refine Submodule.span_induction hA ?_ ?_ ?_ ?_
+  · intro B hB
+    rcases hB with ⟨j, rfl⟩
+    exact hblock j
+  · simp
+  · intro A B hA hB
+    rw [Matrix.mul_add, Matrix.add_mul, hA, hB]
+    simp
+  · intro c A hA
+    rw [smul_mul_assoc, Matrix.mul_smul_comm, hA, smul_zero]
+
+private theorem not_isNontrivialProjection_of_eq_smul_one
+    {P : Mat} (hP_nt : IsNontrivialProjection P) {c : ℂ}
+    (hP : P = c • (1 : Mat)) : False := by
+  by_cases hD : D = 0
+  · subst hD
+    exact hP_nt.2 (Subsingleton.elim _ _)
+  · haveI : NeZero D := ⟨hD⟩
+    have hIdem : (c • (1 : Mat)) * (c • (1 : Mat)) = c • (1 : Mat) := by
+      simpa [hP] using hP_nt.1.2
+    have hc : c * c = c := by
+      have h00 := congrFun (congrFun hIdem 0) 0
+      simpa using h00
+    have hc01 : c = 0 ∨ c = 1 := by
+      have hfac : c * (c - 1) = 0 := by
+        calc
+          c * (c - 1) = c * c - c := by ring
+          _ = 0 := by rw [hc, sub_self]
+      rcases mul_eq_zero.mp hfac with hc0 | hc1
+      · exact Or.inl hc0
+      · exact Or.inr (sub_eq_zero.mp hc1)
+    rcases hc01 with hc0 | hc1
+    · exact hP_nt.2 (by rw [hP, hc0, zero_smul])
+    · exact hP_nt.3 (by rw [hP, hc1, one_smul])
+
 /--
 Condition (1): full algebra generation forbids block-upper-triangular
 Lindblad decompositions.
@@ -79,7 +173,44 @@ theorem hermitian_span_trivial_commutant_implies_no_blockUpperTriangular
     (hHerm : IsLindbladSpanHermitianClosed F)
     (hComm : HasLindbladSpanTrivialCommutant F) :
     ¬ HasBlockUpperTriangularLindblad F.toLinearMap := by
-  sorry
+  intro hBlock
+  obtain ⟨P, hP_nt, hT⟩ :=
+    hasInvariantCompression_of_hasBlockUpperTriangularLindblad hBlock
+  have hgen : GeneratorPreservesCompression F.toLinearMap P :=
+    generatorPreservesCompression_of_semigroupPreservesCompression hP_nt.1 hT
+  have hblock : ∀ j : Fin F.r, (1 - P) * F.L j * P = 0 :=
+    lindblad_block_of_generatorPreservesCompression hP_nt.1 F hgen
+  have hblock_span : ∀ A : Mat, A ∈ lindbladSpan F → (1 - P) * A * P = 0 :=
+    lower_left_block_vanishes_on_lindbladSpan F hblock
+  have hP_herm : Pᴴ = P := hP_nt.1.1
+  have hcommP : ∀ j : Fin F.r, P * F.L j = F.L j * P := by
+    intro j
+    have hLj_mem : F.L j ∈ lindbladSpan F := by
+      exact Submodule.subset_span ⟨j, rfl⟩
+    have hLj_star_mem : (F.L j)ᴴ ∈ lindbladSpan F := hHerm _ hLj_mem
+    have hPAQ : P * F.L j * (1 - P) = 0 := by
+      have hct := congrArg Matrix.conjTranspose (hblock_span _ hLj_star_mem)
+      simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_sub,
+        Matrix.conjTranspose_one, Matrix.conjTranspose_zero, hP_herm] at hct
+      simpa [Matrix.mul_assoc] using hct
+    have hleft : P * F.L j = P * F.L j * P := by
+      calc
+        P * F.L j = P * F.L j * 1 := by simp
+        _ = P * F.L j * (P + (1 - P)) := by
+          rw [show (1 : Mat) = P + (1 - P) by abel]
+        _ = P * F.L j * P + P * F.L j * (1 - P) := by rw [Matrix.mul_add]
+        _ = P * F.L j * P := by rw [hPAQ, add_zero]
+    have hright : F.L j * P = P * F.L j * P := by
+      calc
+        F.L j * P = 1 * (F.L j * P) := by simp
+        _ = (P + (1 - P)) * (F.L j * P) := by
+          rw [show (1 : Mat) = P + (1 - P) by abel]
+        _ = P * (F.L j * P) + (1 - P) * (F.L j * P) := by rw [Matrix.add_mul]
+        _ = P * F.L j * P + (1 - P) * F.L j * P := by simp [Matrix.mul_assoc]
+        _ = P * F.L j * P := by rw [hblock j, add_zero]
+    exact hleft.trans hright.symm
+  obtain ⟨c, hP_scalar⟩ := hComm P hcommP
+  exact not_isNontrivialProjection_of_eq_smul_one hP_nt hP_scalar
 
 /--
 Condition (3): Kossakowski rank `> d² − d` forbids block-upper-triangular

--- a/TNLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/TNLean/Channel/Semigroup/RelaxationConditions.lean
@@ -166,8 +166,6 @@ theorem full_algebra_generation_implies_no_blockUpperTriangular
 Condition (2): Hermitian closure of the Lindblad span together with trivial
 commutant forbids block-upper-triangular Lindblad decompositions.
 -/
--- TODO: prove that Hermitian closure + trivial commutant forbids
--- block-upper-triangular decompositions — see Wolf Cor. 7.2(2).
 theorem hermitian_span_trivial_commutant_implies_no_blockUpperTriangular
     (F : LindbladForm D)
     (hHerm : IsLindbladSpanHermitianClosed F)

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -1156,6 +1156,12 @@ The four equivalent reducibility conditions of
     then the QDS is not reducible.
     This is \cite[Cor.~7.2, condition~2]{Wolf2012Quantum}.
 \end{theorem}
+\begin{proof}\leanok
+    Extract a nontrivial invariant projection from a hypothetical
+    block-upper-triangular decomposition, show it commutes with the
+    Lindblad span by Hermitian closure, and derive a contradiction
+    with the trivial commutant hypothesis.
+\end{proof}
 
 \begin{theorem}[Cor.~7.2(3): large Kossakowski rank implies non-reducibility]
     \label{thm:not_isReducible_of_kossakowski_rank_ge}

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -1147,7 +1147,7 @@ The four equivalent reducibility conditions of
 
 \begin{theorem}[Cor.~7.2(2): Hermitian span + trivial commutant implies non-reducibility]
     \label{thm:not_isReducible_of_hermitian_span_trivial_commutant}
-    \lean{not_isReducible_of_hermitian_span_trivial_commutant}\notready
+    \lean{not_isReducible_of_hermitian_span_trivial_commutant}\leanok
     \uses{def:is_gksl_generator, def:is_lindblad_span_hermitian_closed,
           def:has_lindblad_span_trivial_commutant,
           def:has_block_upper_triangular_lindblad,


### PR DESCRIPTION
Partially addresses #280.

Closes 1 of 3 remaining sorrys in `RelaxationConditions.lean`:

**`hermitian_span_trivial_commutant_implies_no_blockUpperTriangular`** (Wolf Cor 7.2(2)): proves that Hermitian closure of the Lindblad span together with trivial commutant forbids block-upper-triangular Lindblad decompositions.

### Remaining sorrys (2)
- Theorem (1) `full_algebra_generation_implies_no_blockUpperTriangular`: blocked on missing API for transporting `Algebra.adjoin` across Lindblad representations
- Theorem (3) `large_kossakowski_rank_implies_no_blockUpperTriangular`: blocked on missing `kossakowskiRank` ↔ minimal Lindblad length API

### Issue #280 overall: 11/13 sorrys now closed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Lean proof code and supporting private lemmas without changing runtime behavior or public APIs, though it may affect downstream proof dependencies and compilation time.
> 
> **Overview**
> Closes the remaining `sorry` for Wolf Corollary 7.2(2) by proving `hermitian_span_trivial_commutant_implies_no_blockUpperTriangular` in `RelaxationConditions.lean`.
> 
> The proof introduces private lemmas to (1) derive block-vanishing `(1 - P) * Lⱼ * P = 0` from `GeneratorPreservesCompression`, (2) extend that vanishing property from generators to the full `lindbladSpan`, and (3) rule out nontrivial projections that are scalar multiples of the identity, yielding the contradiction with the *trivial commutant* hypothesis.
> 
> The blueprint (`ch12_semigroup.tex`) is updated to mark the corresponding theorem `leanok` and adds a short proof sketch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0be0192aa48ab487891074e7bd95b02ae5a85974. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->