### PR TITLE
feat(MPS/CanonicalForm): sector irreducibility scaffold and reduction (#81)

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.CyclicSectors
+import TNLean.MPS.Irreducible.FormII
+import TNLean.MPS.Irreducible.Adjoint
+import TNLean.MPS.Irreducible.PeriodicBlocking
+
+/-!
+# Sector irreducibility helpers
+
+This file isolates the remaining channel-to-MPS bridge for cyclic-sector
+irreducibility.
+
+At present it provides:
+
+* a reusable orthogonality lemma for orthogonal projections summing to `1`;
+* a corner-preservation lemma for adjoint transfer maps fixed on an orthogonal
+  projection;
+* the easy orbit-sum fixed-point calculation `T (∑ₗ T^[l](Q)) = ∑ₗ T^[l](Q)`;
+* an MPS-level wrapper reducing sector irreducibility to the `hLift`
+  hypothesis required by
+  `Channel.Peripheral.CyclicDecomposition.isIrreducible_restriction_of_cyclic_decomp`.
+
+What still remains for the full orbit-sum lift is the genuinely missing part:
+showing that, for a cyclic sector subprojection `Q`, the orbit iterates
+`T^[l](Q)` stay orthogonal projections in the shifted sectors. Once those
+sublemmas are available, the wrapper theorem here immediately yields sector
+irreducibility for the MPS adjoint transfer map.
+
+Concretely, the missing MPS/channel lemmas are the following three pieces:
+
+* `orbit_iterate_supported_on_shifted_sector`:
+  `T^[l](Q)` lies in the expected cyclic sector;
+* `orbit_iterate_isOrthogonalProjection`:
+  `T^[l](Q)` is again an orthogonal projection;
+* `orbitSumProjection_eq_one_of_full_sector`:
+  for `Q = P_k`, the orbit sum is the full identity.
+-/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+open Matrix Finset Complex
+
+namespace MPSTensor
+
+variable {d D m : ℕ}
+
+/-- Orthogonal projections summing to `1` are pairwise orthogonal. -/
+theorem pairwise_mul_zero_of_orthogonalProjection_sum_one
+    (P : Fin m → MatrixAlg D)
+    (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1) :
+    Pairwise fun i j : Fin m => P i * P j = 0 := by
+  intro i j hij
+  have hsum_i : ∑ k : Fin m, P i * P k * P i = P i := by
+    calc
+      ∑ k : Fin m, P i * P k * P i
+          = P i * (∑ k : Fin m, P k) * P i := by
+              simp [Finset.mul_sum, Finset.sum_mul, Matrix.mul_assoc]
+      _ = P i * 1 * P i := by rw [hPsum]
+      _ = P i := by simp [Matrix.mul_assoc, (hPproj i).2]
+  have hsum_erase : ∑ k in Finset.univ.erase i, P i * P k * P i = 0 := by
+    rw [Finset.sum_erase_add _ (Finset.mem_univ i)] at hsum_i
+    have hiii : P i * P i * P i = P i := by
+      simp [Matrix.mul_assoc, (hPproj i).2]
+    rw [hiii] at hsum_i
+    exact add_right_cancel (by simpa using hsum_i)
+  let B : Fin m → MatrixAlg D := fun k => if k = i then 0 else P i * P k
+  have hsum_B : ∑ k : Fin m, B k * (B k)ᴴ = 0 := by
+    classical
+    rw [Finset.sum_erase_add _ (Finset.mem_univ i)]
+    have hzero_i : B i * (B i)ᴴ = 0 := by simp [B]
+    rw [hzero_i, add_zero]
+    calc
+      ∑ k in Finset.univ.erase i, B k * (B k)ᴴ
+          = ∑ k in Finset.univ.erase i, P i * P k * P i := by
+              refine Finset.sum_congr rfl ?_
+              intro k hk
+              have hki : k ≠ i := by
+                exact Finset.mem_erase.mp hk |>.1
+              simp [B, hki, Matrix.mul_assoc, (hPproj i).1.eq, (hPproj k).1.eq, (hPproj k).2]
+      _ = 0 := hsum_erase
+  have hB_zero := eq_zero_of_sum_mul_conjTranspose_eq_zero B hsum_B
+  have hPiPj : P i * P j = 0 := by
+    by_cases hji : j = i
+    · exact False.elim (hij hji.symm)
+    · simpa [B, hji] using hB_zero j
+  exact hPiPj
+
+/-- If an orthogonal projection is fixed by the adjoint transfer map of a TP
+tensor, then the corresponding corner is invariant. -/
+theorem preservesCorner_of_adjoint_fixed_projection
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    {P : MatrixAlg D}
+    (hP : IsOrthogonalProjection P)
+    (hFix : transferMap (d := d) (D := D) (fun i => (A i)ᴴ) P = P) :
+    PreservesCorner P (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) := by
+  have hComm : ∀ i : Fin d, P * A i = A i * P :=
+    commutes_letters_of_adjoint_fixed_projection (A := A) hTP (hP := hP) hFix
+  have hCommAdj : ∀ i : Fin d, P * (A i)ᴴ = (A i)ᴴ * P := by
+    intro i
+    have h := congrArg Matrix.conjTranspose (hComm i)
+    simpa [Matrix.conjTranspose_mul] using h.symm
+  intro X
+  simp only [transferMap_apply, Finset.mul_sum, Finset.sum_mul]
+  congr 1
+  ext i
+  calc
+    P * ((A i)ᴴ * (P * X * P) * A i) * P
+        = (P * (A i)ᴴ) * (P * X * P) * (A i * P) := by
+            simp [Matrix.mul_assoc]
+    _ = ((A i)ᴴ * P) * (P * X * P) * (P * A i) := by
+          rw [hCommAdj i, hComm i]
+    _ = (A i)ᴴ * (P * X * P) * A i := by
+          simp [Matrix.mul_assoc, (hP.2)]
+
+/-- The orbit sum `∑ₗ T^[l](Q)` is fixed by `T` as soon as `Q` is fixed by
+`T^[m]`. -/
+theorem orbitSumProjection_fixed_of_pow_fix
+    [NeZero m]
+    {T : MatrixEnd D} {Q : MatrixAlg D}
+    (hQfix : (T ^ m) Q = Q) :
+    T (orbitSumProjection (D := D) (m := m) T Q) =
+      orbitSumProjection (D := D) (m := m) T Q := by
+  classical
+  have hm_pos : 0 < m := Nat.pos_of_ne_zero (NeZero.ne m)
+  let f : ℕ → MatrixAlg D := fun n => (T ^ n) Q
+  have hm_pred_succ : (m - 1) + 1 = m := Nat.sub_add_cancel (Nat.succ_le_of_lt hm_pos)
+  have hdecomp_left :
+      Finset.sum (Finset.range (m - 1)) (fun j : ℕ => f (j + 1)) + f 0 =
+        Finset.sum (Finset.range m) (fun j : ℕ => f j) := by
+    simpa [hm_pred_succ, f] using
+      (Finset.sum_range_succ' (fun j : ℕ => f j) (m - 1)).symm
+  have hdecomp_right :
+      Finset.sum (Finset.range (m - 1)) (fun j : ℕ => f (j + 1)) + f m =
+        Finset.sum (Finset.range m) (fun j : ℕ => f (j + 1)) := by
+    simpa [hm_pred_succ, f] using
+      (Finset.sum_range_succ' (fun j : ℕ => f (j + 1)) (m - 1)).symm
+  have hshift :
+      Finset.sum (Finset.range m) (fun j : ℕ => f (j + 1)) =
+        Finset.sum (Finset.range m) (fun j : ℕ => f j) := by
+    rw [← hdecomp_left, ← hdecomp_right, hQfix]
+    simp [f]
+  calc
+    ∑ l : Fin m, T (((T ^ (l : ℕ)) Q))
+        = ∑ l : Fin m, (T ^ ((l : ℕ) + 1)) Q := by
+            congr 1
+            ext l
+            simp [pow_succ']
+    _ = ∑ j in Finset.range m, f (j + 1) := by
+          simp [Fin.sum_univ_eq_sum_range, f]
+    _ = ∑ j in Finset.range m, f j := hshift
+    _ = ∑ l : Fin m, (T ^ (l : ℕ)) Q := by
+          simp [Fin.sum_univ_eq_sum_range, f]
+
+/-- MPS-specialized wrapper: once the orbit-sum lift is constructed in the
+shape required by `isIrreducible_restriction_of_cyclic_decomp`, sector
+irreducibility follows immediately. -/
+theorem isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift
+    {A : MPSTensor d D}
+    [NeZero m]
+    (hIrr :
+      IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)))
+    (P : Fin m → MatrixAlg D)
+    (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hcyclic :
+      ∀ k : Fin m,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (hLift :
+      ∀ k : Fin m, ∀ Q : MatrixAlg D,
+        IsOrthogonalProjection Q →
+        Q * P k = Q →
+        P k * Q = Q →
+        PreservesCorner Q ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) →
+        ∃ R : MatrixAlg D,
+          IsOrthogonalProjection R ∧
+          PreservesCorner R (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ∧
+          (Q = 0 ↔ R = 0) ∧
+          (Q = P k ↔ R = 1)) :
+    ∀ k : Fin m,
+      IsIrreducibleOnCorner
+        (P k) ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) := by
+  exact
+    isIrreducible_restriction_of_cyclic_decomp
+      (T := transferMap (d := d) (D := D) (fun i => (A i)ᴴ))
+      hIrr P hPproj hPsum hcyclic hLift
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -62,27 +62,38 @@ theorem pairwise_mul_zero_of_orthogonalProjection_sum_one
           = P i * (∑ k : Fin m, P k) * P i := by
               simp [Finset.mul_sum, Finset.sum_mul, Matrix.mul_assoc]
       _ = P i * 1 * P i := by rw [hPsum]
-      _ = P i := by simp [Matrix.mul_assoc, (hPproj i).2]
-  have hsum_erase : ∑ k in Finset.univ.erase i, P i * P k * P i = 0 := by
-    rw [Finset.sum_erase_add _ (Finset.mem_univ i)] at hsum_i
+      _ = P i := by simp [(hPproj i).2]
+  have hsum_erase : ∑ k ∈ Finset.univ.erase i, P i * P k * P i = 0 := by
+    rw [← Finset.sum_erase_add Finset.univ (fun k => P i * P k * P i) (Finset.mem_univ i)] at hsum_i
     have hiii : P i * P i * P i = P i := by
-      simp [Matrix.mul_assoc, (hPproj i).2]
+      simp [(hPproj i).2]
     rw [hiii] at hsum_i
-    exact add_right_cancel (by simpa [zero_add] using hsum_i)
+    simpa using hsum_i
   let B : Fin m → MatrixAlg D := fun k => if k = i then 0 else P i * P k
   have hsum_B : ∑ k : Fin m, B k * (B k)ᴴ = 0 := by
     classical
-    rw [Finset.sum_erase_add _ (Finset.mem_univ i)]
+    rw [← Finset.sum_erase_add Finset.univ (fun k => B k * (B k)ᴴ) (Finset.mem_univ i)]
     have hzero_i : B i * (B i)ᴴ = 0 := by simp [B]
     rw [hzero_i, add_zero]
     calc
-      ∑ k in Finset.univ.erase i, B k * (B k)ᴴ
-          = ∑ k in Finset.univ.erase i, P i * P k * P i := by
+      ∑ k ∈ Finset.univ.erase i, B k * (B k)ᴴ
+          = ∑ k ∈ Finset.univ.erase i, P i * P k * P i := by
               refine Finset.sum_congr rfl ?_
               intro k hk
               have hki : k ≠ i := by
                 exact Finset.mem_erase.mp hk |>.1
-              simp [B, hki, Matrix.mul_assoc, (hPproj i).1.eq, (hPproj k).1.eq, (hPproj k).2]
+              calc
+                B k * (B k)ᴴ = (P i * P k) * ((P i * P k)ᴴ) := by
+                  simp [B, hki]
+                _ = P i * P k * P i := by
+                  calc
+                    (P i * P k) * ((P i * P k)ᴴ)
+                        = P i * (P k * (P k * P i)) := by
+                            simp [Matrix.conjTranspose_mul, Matrix.mul_assoc, (hPproj i).1.eq,
+                              (hPproj k).1.eq]
+                    _ = P i * ((P k * P k) * P i) := by simp [Matrix.mul_assoc]
+                    _ = P i * (P k * P i) := by rw [(hPproj k).2]
+                    _ = P i * P k * P i := by simp [Matrix.mul_assoc]
       _ = 0 := hsum_erase
   have hB_zero := eq_zero_of_sum_mul_conjTranspose_eq_zero B hsum_B
   have hPiPj : P i * P j = 0 := by
@@ -105,19 +116,29 @@ theorem preservesCorner_of_adjoint_fixed_projection
   have hCommAdj : ∀ i : Fin d, P * (A i)ᴴ = (A i)ᴴ * P := by
     intro i
     have h := congrArg Matrix.conjTranspose (hComm i)
-    simpa [Matrix.conjTranspose_mul] using h.symm
+    simpa [Matrix.conjTranspose_mul, hP.1.eq] using h.symm
   intro X
-  simp only [transferMap_apply, Finset.mul_sum, Finset.sum_mul]
-  congr 1
-  ext i
+  simp only [transferMap_apply, Finset.mul_sum, Finset.sum_mul,
+    Matrix.conjTranspose_conjTranspose]
+  refine Finset.sum_congr rfl ?_
+  intro i _
   calc
     P * ((A i)ᴴ * (P * X * P) * A i) * P
         = (P * (A i)ᴴ) * (P * X * P) * (A i * P) := by
             simp [Matrix.mul_assoc]
     _ = ((A i)ᴴ * P) * (P * X * P) * (P * A i) := by
           rw [hCommAdj i, ← hComm i]
+    _ = (A i)ᴴ * ((P * P) * X * P) * (P * A i) := by
+          simp [Matrix.mul_assoc]
+    _ = (A i)ᴴ * (P * X * P) * (P * A i) := by
+          simp [Matrix.mul_assoc, hP.2]
     _ = (A i)ᴴ * (P * X * P) * A i := by
-          simp [Matrix.mul_assoc, (hP.2)]
+          calc
+            (A i)ᴴ * (P * X * P) * (P * A i)
+                = (A i)ᴴ * ((P * X * P) * P) * A i := by
+                    simp [Matrix.mul_assoc]
+            _ = (A i)ᴴ * (P * X * P) * A i := by
+                    simp [Matrix.mul_assoc, hP.2]
 
 /-- The orbit sum `∑ₗ T^[l](Q)` is fixed by `T` as soon as `Q` is fixed by
 `T^[m]`. -/
@@ -144,19 +165,25 @@ theorem orbitSumProjection_fixed_of_pow_fix
   have hshift :
       Finset.sum (Finset.range m) (fun j : ℕ => f (j + 1)) =
         Finset.sum (Finset.range m) (fun j : ℕ => f j) := by
-    rw [← hdecomp_left, ← hdecomp_right, hQfix]
-    simp [f]
+    rw [← hdecomp_left, ← hdecomp_right]
+    simp [f, hQfix]
+  change T (∑ l : Fin m, (T ^ (l : ℕ)) Q) = ∑ l : Fin m, (T ^ (l : ℕ)) Q
   calc
-    ∑ l : Fin m, T (((T ^ (l : ℕ)) Q))
-        = ∑ l : Fin m, (T ^ ((l : ℕ) + 1)) Q := by
-            congr 1
-            ext l
+    T (∑ l : Fin m, (T ^ (l : ℕ)) Q)
+        = ∑ l : Fin m, T (((T ^ (l : ℕ)) Q)) := by
+            rw [map_sum]
+    _ = ∑ l : Fin m, (T ^ ((l : ℕ) + 1)) Q := by
+            refine Finset.sum_congr rfl ?_
+            intro l _
             simp [pow_succ']
-    _ = ∑ j in Finset.range m, f (j + 1) := by
-          simp [Fin.sum_univ_eq_sum_range, f]
-    _ = ∑ j in Finset.range m, f j := hshift
+    _ = ∑ j ∈ Finset.range m, f (j + 1) := by
+          simpa [f] using
+            (Fin.sum_univ_eq_sum_range (fun n : ℕ => (T ^ (n + 1)) Q) m)
+    _ = ∑ j ∈ Finset.range m, f j := by
+          simpa using hshift
     _ = ∑ l : Fin m, (T ^ (l : ℕ)) Q := by
-          simp [Fin.sum_univ_eq_sum_range, f]
+          simpa [f] using
+            (Fin.sum_univ_eq_sum_range (fun n : ℕ => (T ^ n) Q) m).symm
 
 /-- MPS-specialized wrapper: once the orbit-sum lift is constructed in the
 shape required by `isIrreducible_restriction_of_cyclic_decomp`, sector

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -13,11 +13,16 @@ import TNLean.MPS.Irreducible.PeriodicBlocking
 This file isolates the remaining channel-to-MPS bridge for cyclic-sector
 irreducibility.
 
-At present it provides:
+## General results (outside `MPSTensor` namespace)
 
-* a reusable orthogonality lemma for orthogonal projections summing to `1`;
-* a corner-preservation lemma for adjoint transfer maps fixed on an orthogonal
-  projection;
+* `pairwise_mul_zero_of_orthogonalProjection_sum_one`: orthogonal projections
+  summing to `1` are pairwise orthogonal (`P_i P_j = 0` for `i ≠ j`).
+* `preservesCorner_of_adjoint_fixed_projection`: if an orthogonal projection is
+  fixed by the adjoint transfer map of a TP tensor, then the corresponding
+  corner algebra is invariant.
+
+## MPS-specific results
+
 * the easy orbit-sum fixed-point calculation `T (∑ₗ T^[l](Q)) = ∑ₗ T^[l](Q)`;
 * an MPS-level wrapper reducing sector irreducibility to the `hLift`
   hypothesis required by
@@ -37,19 +42,21 @@ Concretely, the missing MPS/channel lemmas are the following three pieces:
   `T^[l](Q)` is again an orthogonal projection;
 * `orbitSumProjection_eq_one_of_full_sector`:
   for `Q = P_k`, the orbit sum is the full identity.
-
-TODO: sync the four theorems in this file with blueprint `\lean{...}` /
-`\notready` tags.
 -/
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 open Matrix Finset Complex
 
-namespace MPSTensor
+/-! ### Orthogonal-projection pairwise orthogonality -/
 
-variable {d D m : ℕ}
+variable {D m : ℕ}
 
-/-- Orthogonal projections summing to `1` are pairwise orthogonal. -/
+/-- If a finite family of orthogonal projections sums to the identity, then
+distinct projections are orthogonal: `P i * P j = 0` for `i ≠ j`.
+
+This is a standard fact about orthogonal decompositions of the identity. The
+proof sandwiches the sum between `P i` to isolate the diagonal, then extracts
+each off-diagonal term via positivity (`B B* = 0 → B = 0`). -/
 theorem pairwise_mul_zero_of_orthogonalProjection_sum_one
     (P : Fin m → MatrixAlg D)
     (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
@@ -102,23 +109,32 @@ theorem pairwise_mul_zero_of_orthogonalProjection_sum_one
     · simpa [B, hji] using hB_zero j
   exact hPiPj
 
-/-- If an orthogonal projection is fixed by the adjoint transfer map of a TP
-tensor, then the corresponding corner is invariant. -/
+/-! ### Corner preservation from adjoint fixed projections -/
+
+variable {d : ℕ}
+
+/-- If an orthogonal projection `P` is fixed by the adjoint transfer map
+`T†(·) = ∑ᵢ Aᵢ† · Aᵢ` of a TP tensor, then `T†` preserves the corner
+algebra `P · M_D(ℂ) · P`.
+
+The proof derives `[P, Aᵢ] = 0` from
+`MPSTensor.commutes_letters_of_adjoint_fixed_projection`, then threads the
+idempotent relation `P² = P` through the corner sandwich. -/
 theorem preservesCorner_of_adjoint_fixed_projection
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     {P : MatrixAlg D}
     (hP : IsOrthogonalProjection P)
-    (hFix : transferMap (d := d) (D := D) (fun i => (A i)ᴴ) P = P) :
-    PreservesCorner P (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) := by
+    (hFix : MPSTensor.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) P = P) :
+    PreservesCorner P (MPSTensor.transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) := by
   have hComm : ∀ i : Fin d, P * A i = A i * P :=
-    commutes_letters_of_adjoint_fixed_projection (A := A) hTP (hP := hP) hFix
+    MPSTensor.commutes_letters_of_adjoint_fixed_projection (A := A) hTP (hP := hP) hFix
   have hCommAdj : ∀ i : Fin d, P * (A i)ᴴ = (A i)ᴴ * P := by
     intro i
     have h := congrArg Matrix.conjTranspose (hComm i)
     simpa [Matrix.conjTranspose_mul, hP.1.eq] using h.symm
   intro X
-  simp only [transferMap_apply, Finset.mul_sum, Finset.sum_mul,
+  simp only [MPSTensor.transferMap_apply, Finset.mul_sum, Finset.sum_mul,
     Matrix.conjTranspose_conjTranspose]
   refine Finset.sum_congr rfl ?_
   intro i _
@@ -139,6 +155,10 @@ theorem preservesCorner_of_adjoint_fixed_projection
                     simp [Matrix.mul_assoc]
             _ = (A i)ᴴ * (P * X * P) * A i := by
                     simp [Matrix.mul_assoc, hP.2]
+
+namespace MPSTensor
+
+variable {d D m : ℕ}
 
 /-- The orbit sum `∑ₗ T^[l](Q)` is fixed by `T` as soon as `Q` is fixed by
 `T^[m]`. -/

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -37,6 +37,9 @@ Concretely, the missing MPS/channel lemmas are the following three pieces:
   `T^[l](Q)` is again an orthogonal projection;
 * `orbitSumProjection_eq_one_of_full_sector`:
   for `Q = P_k`, the orbit sum is the full identity.
+
+TODO: sync the four theorems in this file with blueprint `\lean{...}` /
+`\notready` tags.
 -/
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
@@ -65,7 +68,7 @@ theorem pairwise_mul_zero_of_orthogonalProjection_sum_one
     have hiii : P i * P i * P i = P i := by
       simp [Matrix.mul_assoc, (hPproj i).2]
     rw [hiii] at hsum_i
-    exact add_right_cancel (by simpa using hsum_i)
+    exact add_right_cancel (by simpa [zero_add] using hsum_i)
   let B : Fin m → MatrixAlg D := fun k => if k = i then 0 else P i * P k
   have hsum_B : ∑ k : Fin m, B k * (B k)ᴴ = 0 := by
     classical
@@ -112,7 +115,7 @@ theorem preservesCorner_of_adjoint_fixed_projection
         = (P * (A i)ᴴ) * (P * X * P) * (A i * P) := by
             simp [Matrix.mul_assoc]
     _ = ((A i)ᴴ * P) * (P * X * P) * (P * A i) := by
-          rw [hCommAdj i, hComm i]
+          rw [hCommAdj i, ← hComm i]
     _ = (A i)ᴴ * (P * X * P) * A i := by
           simp [Matrix.mul_assoc, (hP.2)]
 
@@ -137,7 +140,7 @@ theorem orbitSumProjection_fixed_of_pow_fix
       Finset.sum (Finset.range (m - 1)) (fun j : ℕ => f (j + 1)) + f m =
         Finset.sum (Finset.range m) (fun j : ℕ => f (j + 1)) := by
     simpa [hm_pred_succ, f] using
-      (Finset.sum_range_succ' (fun j : ℕ => f (j + 1)) (m - 1)).symm
+      (Finset.sum_range_succ (fun j : ℕ => f (j + 1)) (m - 1)).symm
   have hshift :
       Finset.sum (Finset.range m) (fun j : ℕ => f (j + 1)) =
         Finset.sum (Finset.range m) (fun j : ℕ => f j) := by

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1088,6 +1088,80 @@ The following results separate the zero blocks from the
 	Feed into Theorem~\ref{thm:blockdecomp_adjoint_fixed}.
 \end{proof}
 
+\subsection{Sector irreducibility helpers}%
+\label{sec:sector_irreducibility_helpers}
+
+\begin{lemma}[Pairwise orthogonality from projection sum]%
+	\label{lem:pairwise_ortho_proj_sum}
+	\lean{pairwise_mul_zero_of_orthogonalProjection_sum_one}
+	\leanok
+	Let $(P_k)_{k=1}^m$ be orthogonal projections summing to the identity:
+	$\sum_k P_k = \Id$.
+	Then for $i \neq j$ we have $P_i P_j = 0$.
+\end{lemma}
+
+\begin{proof}\leanok
+	Sandwich the sum between $P_i$ to get
+	$\sum_k P_i P_k P_i = P_i$.
+	Since the $i$-th summand equals $P_i$ by idempotence,
+	all other summands vanish.
+	Positivity ($B B^* = 0 \Rightarrow B = 0$) then gives
+	$P_i P_k = 0$ for each $k \neq i$.
+\end{proof}
+
+\begin{lemma}[Corner preservation from adjoint-fixed projection]%
+	\label{lem:corner_preserv_adjoint_fixed}
+	\lean{preservesCorner_of_adjoint_fixed_projection}
+	\leanok
+	\uses{thm:kraus_commute}
+	Let $A$ be a left-canonical MPS tensor and let $P$ be an orthogonal
+	projection fixed by $\E_A^\dagger$.
+	Then $\E_A^\dagger$ preserves the corner algebra
+	$P \cdot M_D(\mathbb{C}) \cdot P$.
+\end{lemma}
+
+\begin{proof}\leanok
+	\uses{thm:kraus_commute}
+	The fixed-point condition and the Kadison--Schwarz equality
+	imply $[P, A_i] = 0$ for every Kraus operator.
+	Thread the idempotent relation $P^2 = P$ through the corner sandwich.
+\end{proof}
+
+\begin{lemma}[Orbit-sum fixed point]%
+	\label{lem:orbit_sum_fixed}
+	\lean{MPSTensor.orbitSumProjection_fixed_of_pow_fix}
+	\leanok
+	Let $T$ be a linear endomorphism and $Q$ a matrix satisfying $T^m(Q) = Q$.
+	Then the orbit sum $\sum_{l=0}^{m-1} T^l(Q)$ is a fixed point of $T$.
+\end{lemma}
+
+\begin{proof}\leanok
+	Telescoping: $T$ shifts each summand $T^l(Q) \mapsto T^{l+1}(Q)$
+	and the periodicity condition $T^m(Q) = Q$ wraps the last term
+	$T^{m-1}(Q) \mapsto T^m(Q) = Q$ back to the first.
+\end{proof}
+
+\begin{theorem}[Sector irreducibility from orbit-sum lift]%
+	\label{thm:sector_irred_orbit_lift}
+	\lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift}
+	\leanok
+	\uses{thm:cyclic_sector_decomp_irr_tp}
+	Let $A$ be a left-canonical MPS tensor with irreducible adjoint transfer
+	map, and let $(P_k)_{k=1}^m$ be the cyclic sector projections.
+	Suppose the orbit-sum lift hypothesis holds: for every sector $k$ and
+	every subprojection $Q \le P_k$ fixed by $(\E_A^\dagger)^m$, there exists
+	a global projection $R$ that is invariant under $\E_A^\dagger$ and
+	faithfully reflects triviality ($Q = 0 \Leftrightarrow R = 0$,
+	$Q = P_k \Leftrightarrow R = \Id$).
+	Then $(\E_A^\dagger)^m$ is irreducible on each corner $P_k$.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:cyclic_sector_decomp_irr_tp}
+	Direct application of the cyclic-decomposition irreducibility
+	theorem from spectral theory.
+\end{proof}
+
 \section{Reduction to primitive blocks}%
 \label{sec:assembly_pipeline}
 


### PR DESCRIPTION
## Context

Sector irreducibility is the **single highest-leverage missing piece** in the TNLean formalization — it unblocks 4 of 8 sorrys in PeriodicOverlap.lean (Issue #81).

The gap: each cyclic sector of a blocked periodic MPS tensor should be irreducible. The abstract theorem `isIrreducible_restriction_of_cyclic_decomp` in CyclicDecomposition.lean provides this **conditionally** on a `hLift` hypothesis (orbit-sum lift from corner subprojections to full-space projections).

## What this PR adds

New file `TNLean/MPS/CanonicalForm/SectorIrreducibility.lean` (191 lines) with:

1. **`pairwise_mul_zero_of_orthogonalProjection_sum_one`** — orthogonal projections summing to 1 are pairwise orthogonal
2. **`preservesCorner_of_adjoint_fixed_projection`** — adjoint-fixed projection preserves corners for transfer maps
3. **`orbitSumProjection_fixed_of_pow_fix`** — orbit sum R = Σ T^l(Q) is T-invariant
4. **`isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift`** — wrapper reducing MPS sector irreducibility to hLift

## Remaining sublemmas (3)

The exact obligations needed to complete the proof:
- `orbit_iterate_supported_on_shifted_sector`: T^l(Q) is supported on sector P_{k+l}
- `orbit_iterate_isOrthogonalProjection`: T^l(Q) remains an orthogonal projection
- `orbitSumProjection_eq_one_of_full_sector`: R = 1 when Q = P_k

## Impact

Once the 3 sublemmas are proved, this enables:
- `sectorBlocked_isNormal_of_isPeriodic` (PeriodicOverlap sorry #3)
- `periodicOverlap_tendsto_zero_of_no_sector_match` (sorry #4)
- `periodicOverlapDichotomy` (sorry #8)
- Indirectly: `periodicSelfOverlap_tendsto` (sorry #1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems and blueprint exposition without changing existing definitions or proof behavior elsewhere, though it may affect downstream compilation dependencies.
> 
> **Overview**
> Adds a new `SectorIrreducibility.lean` helper module to scaffold the remaining proof of cyclic-sector irreducibility for MPS adjoint transfer maps.
> 
> The file introduces lemmas for (1) pairwise orthogonality when orthogonal projections sum to `1`, (2) corner-algebra preservation when an orthogonal projection is fixed by the adjoint transfer map of a TP tensor, and (3) an orbit-sum fixed-point calculation `T (∑ l, T^l(Q)) = ∑ l, T^l(Q)` under `T^m(Q)=Q`. It also adds an MPS-level wrapper theorem that reduces sector irreducibility on each corner to the existing channel-level `isIrreducible_restriction_of_cyclic_decomp` via an `hLift` hypothesis.
> 
> Updates the blueprint (`ch08_canonical.tex`) with a new subsection documenting these lemmas/theorem and their role in the sector-irreducibility pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6006289aed675bc669b63fa11f0dfa90aaee6095. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->