### PR TITLE
feat(MPS/CanonicalForm): prove 3 orbit-sum lift sublemmas (#431)

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -28,13 +28,7 @@ irreducibility.
   hypothesis required by
   `Channel.Peripheral.CyclicDecomposition.isIrreducible_restriction_of_cyclic_decomp`.
 
-What still remains for the full orbit-sum lift is the genuinely missing part:
-showing that, for a cyclic sector subprojection `Q`, the orbit iterates
-`T^[l](Q)` stay orthogonal projections in the shifted sectors. Once those
-sublemmas are available, the wrapper theorem here immediately yields sector
-irreducibility for the MPS adjoint transfer map.
-
-Concretely, the missing MPS/channel lemmas are the following three pieces:
+The orbit-sum lift sublemmas completing the `hLift` construction are:
 
 * `orbit_iterate_supported_on_shifted_sector`:
   `T^[l](Q)` lies in the expected cyclic sector;
@@ -42,6 +36,9 @@ Concretely, the missing MPS/channel lemmas are the following three pieces:
   `T^[l](Q)` is again an orthogonal projection;
 * `orbitSumProjection_eq_one_of_full_sector`:
   for `Q = P_k`, the orbit sum is the full identity.
+
+Together with the orbit-sum fixed-point calculation and the MPS wrapper,
+these yield sector irreducibility for the MPS adjoint transfer map.
 -/
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -205,6 +205,175 @@ theorem orbitSumProjection_fixed_of_pow_fix
           simpa [f] using
             (Fin.sum_univ_eq_sum_range (fun n : ℕ => (T ^ n) Q) m).symm
 
+/-- If `Q` is supported on the cyclic sector `P k`, then its `l`-th orbit iterate is supported
+on the shifted sector `P (k - l)`.
+
+The proof is a direct induction on `l`, using the same left/right multiplicative-domain
+identities that appear in `preserves_corner_pow_of_cyclic_decomp`. -/
+theorem orbit_iterate_supported_on_shifted_sector
+    [NeZero m]
+    {T : MatrixEnd D}
+    (P : Fin m → MatrixAlg D)
+    (hcyclic : ∀ k : Fin m, T (P (k + 1)) = P k)
+    (hMulLeft : ∀ k : Fin m, ∀ X : MatrixAlg D, T (P k * X) = T (P k) * T X)
+    (hMulRight : ∀ k : Fin m, ∀ X : MatrixAlg D, T (X * P k) = T X * T (P k))
+    {k : Fin m} {Q : MatrixAlg D}
+    (hQP : Q * P k = Q)
+    (hPQ : P k * Q = Q) :
+    ∀ l : Fin m,
+      ((T ^ (l : ℕ)) Q) * P (k - l) = ((T ^ (l : ℕ)) Q) ∧
+      P (k - l) * ((T ^ (l : ℕ)) Q) = ((T ^ (l : ℕ)) Q) := by
+  suffices hmain :
+      ∀ n : ℕ, ∀ hn : n < m,
+        ((T ^ n) Q) * P (k - ⟨n, hn⟩) = ((T ^ n) Q) ∧
+        P (k - ⟨n, hn⟩) * ((T ^ n) Q) = ((T ^ n) Q) by
+    intro l
+    simpa using hmain (l : ℕ) l.is_lt
+  intro n
+  induction n with
+  | zero =>
+      intro _hn
+      simpa using And.intro hQP hPQ
+  | succ n ih =>
+      intro hn1
+      have hn : n < m := Nat.lt_of_succ_lt hn1
+      let j : Fin m := k - ⟨n, hn⟩
+      have hsupp := ih hn
+      have hright_j : ((T ^ n) Q) * P j = ((T ^ n) Q) := by
+        simpa [j] using hsupp.1
+      have hleft_j : P j * ((T ^ n) Q) = ((T ^ n) Q) := by
+        simpa [j] using hsupp.2
+      have hcyclic_j : T (P j) = P (j - 1) := by
+        simpa [j] using hcyclic (j - 1)
+      have hright :
+          ((T ^ (n + 1)) Q) * P (j - 1) = ((T ^ (n + 1)) Q) := by
+        calc
+          ((T ^ (n + 1)) Q) * P (j - 1)
+              = T (((T ^ n) Q)) * P (j - 1) := by
+                  simp [pow_succ']
+          _ = T (((T ^ n) Q)) * T (P j) := by rw [hcyclic_j]
+          _ = T (((T ^ n) Q) * P j) := by
+                rw [← hMulRight j ((T ^ n) Q)]
+          _ = T (((T ^ n) Q)) := by rw [hright_j]
+          _ = ((T ^ (n + 1)) Q) := by
+                simp [pow_succ']
+      have hleft :
+          P (j - 1) * ((T ^ (n + 1)) Q) = ((T ^ (n + 1)) Q) := by
+        calc
+          P (j - 1) * ((T ^ (n + 1)) Q)
+              = T (P j) * T (((T ^ n) Q)) := by
+                  rw [hcyclic_j]
+                  simp [pow_succ']
+          _ = T (P j * ((T ^ n) Q)) := by
+                rw [← hMulLeft j ((T ^ n) Q)]
+          _ = T (((T ^ n) Q)) := by rw [hleft_j]
+          _ = ((T ^ (n + 1)) Q) := by
+                simp [pow_succ']
+      have hsucc_fin : (⟨n, hn⟩ : Fin m) + 1 = ⟨n + 1, hn1⟩ := by
+        ext
+        simp [Fin.val_add, Nat.mod_eq_of_lt hn1]
+      have hshift : j - 1 = k - ⟨n + 1, hn1⟩ := by
+        calc
+          j - 1 = k - (⟨n, hn⟩ : Fin m) - 1 := by rfl
+          _ = k - ((⟨n, hn⟩ : Fin m) + 1) := by abel
+          _ = k - ⟨n + 1, hn1⟩ := by rw [hsucc_fin]
+      simpa [hshift] using And.intro hright hleft
+
+/-- Iterating a one-step projection-preservation statement along the cyclic sectors.
+
+For a general linear map, corner preservation alone does not imply that the image of an
+orthogonal projection is again an orthogonal projection. The hypothesis `hProjStep` isolates the
+one-step input actually needed for the orbit induction. -/
+theorem orbit_iterate_isOrthogonalProjection
+    [NeZero m]
+    {T : MatrixEnd D}
+    (P : Fin m → MatrixAlg D)
+    (hcyclic : ∀ k : Fin m, T (P (k + 1)) = P k)
+    (hMulLeft : ∀ k : Fin m, ∀ X : MatrixAlg D, T (P k * X) = T (P k) * T X)
+    (hMulRight : ∀ k : Fin m, ∀ X : MatrixAlg D, T (X * P k) = T X * T (P k))
+    (hProjStep :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        IsOrthogonalProjection X →
+        X * P k = X →
+        P k * X = X →
+        IsOrthogonalProjection (T X))
+    {k : Fin m} {Q : MatrixAlg D}
+    (hQproj : IsOrthogonalProjection Q)
+    (hQP : Q * P k = Q)
+    (hPQ : P k * Q = Q) :
+    ∀ l : Fin m, IsOrthogonalProjection ((T ^ (l : ℕ)) Q) := by
+  have hsupp :=
+    orbit_iterate_supported_on_shifted_sector
+      (P := P) hcyclic hMulLeft hMulRight (k := k) (Q := Q) hQP hPQ
+  suffices hmain : ∀ n : ℕ, ∀ hn : n < m, IsOrthogonalProjection ((T ^ n) Q) by
+    intro l
+    simpa using hmain (l : ℕ) l.is_lt
+  intro n
+  induction n with
+  | zero =>
+      intro _hn
+      simpa using hQproj
+  | succ n ih =>
+      intro hn1
+      have hn : n < m := Nat.lt_of_succ_lt hn1
+      have hproj_n : IsOrthogonalProjection ((T ^ n) Q) := ih hn
+      have hsupp_n := hsupp ⟨n, hn⟩
+      simpa [pow_succ'] using
+        hProjStep (k - ⟨n, hn⟩) ((T ^ n) Q) hproj_n hsupp_n.1 hsupp_n.2
+
+/-- The orbit sum of a full cyclic sector projection is the identity. -/
+theorem orbitSumProjection_eq_one_of_full_sector
+    [NeZero m]
+    {T : MatrixEnd D}
+    (P : Fin m → MatrixAlg D)
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hcyclic : ∀ k : Fin m, T (P (k + 1)) = P k)
+    (k : Fin m) :
+    orbitSumProjection (D := D) (m := m) T (P k) = 1 := by
+  have hiter :
+      ∀ l : Fin m, (T ^ (l : ℕ)) (P k) = P (k - l) := by
+    suffices hmain :
+        ∀ n : ℕ, ∀ hn : n < m,
+          (T ^ n) (P k) = P (k - ⟨n, hn⟩) by
+      intro l
+      simpa using hmain (l : ℕ) l.is_lt
+    intro n
+    induction n with
+    | zero =>
+        intro _hn
+        simp
+    | succ n ih =>
+        intro hn1
+        have hn : n < m := Nat.lt_of_succ_lt hn1
+        let j : Fin m := k - ⟨n, hn⟩
+        have hcyclic_j : T (P j) = P (j - 1) := by
+          simpa [j] using hcyclic (j - 1)
+        have hsucc_fin : (⟨n, hn⟩ : Fin m) + 1 = ⟨n + 1, hn1⟩ := by
+          ext
+          simp [Fin.val_add, Nat.mod_eq_of_lt hn1]
+        have hshift : j - 1 = k - ⟨n + 1, hn1⟩ := by
+          calc
+            j - 1 = k - (⟨n, hn⟩ : Fin m) - 1 := by rfl
+            _ = k - ((⟨n, hn⟩ : Fin m) + 1) := by abel
+            _ = k - ⟨n + 1, hn1⟩ := by rw [hsucc_fin]
+        calc
+          (T ^ (n + 1)) (P k) = T ((T ^ n) (P k)) := by
+              simp [pow_succ']
+          _ = T (P j) := by rw [ih hn]
+          _ = P (j - 1) := hcyclic_j
+          _ = P (k - ⟨n + 1, hn1⟩) := by rw [hshift]
+  calc
+    orbitSumProjection (D := D) (m := m) T (P k)
+        = ∑ l : Fin m, P (k - l) := by
+            refine Finset.sum_congr rfl ?_
+            intro l _
+            exact hiter l
+    _ = ∑ j : Fin m, P j := by
+          refine Fintype.sum_equiv (Equiv.subLeft k) (fun l : Fin m => P (k - l)) P ?_
+          intro l
+          simp [Equiv.subLeft_apply]
+    _ = 1 := hPsum
+
 /-- MPS-specialized wrapper: once the orbit-sum lift is constructed in the
 shape required by `isIrreducible_restriction_of_cyclic_decomp`, sector
 irreducibility follows immediately. -/

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1158,6 +1158,66 @@ The following results separate the zero blocks from the
 	$T^{m-1}(Q) \mapsto T^m(Q) = Q$ back to the first.
 \end{proof}
 
+\begin{lemma}[Orbit iterate supported on shifted sector]%
+	\label{lem:orbit_iterate_shifted_sector}
+	\lean{orbit_iterate_supported_on_shifted_sector}
+	\leanok
+	\uses{lem:orbit_sum_fixed}
+	Let $(P_k)_{k=1}^m$ be orthogonal projections with cyclic shift
+	$T(P_{k+1}) = P_k$, and suppose $T$ is multiplicative on each sector
+	corner.
+	If $Q$ is supported on sector $P_k$ (i.e.\ $QP_k = Q = P_k Q$), then
+	for each $0 \le l < m$ the iterate $T^l(Q)$ is supported on the
+	shifted sector $P_{k-l}$.
+\end{lemma}
+
+\begin{proof}\leanok
+	Induction on $l$.  The base case is the hypothesis $QP_k = Q = P_k Q$.
+	For the inductive step, the multiplicative-domain identities and the
+	cyclic shift relation $T(P_j) = P_{j-1}$ transfer the support from
+	sector $P_j$ to sector $P_{j-1}$.
+\end{proof}
+
+\begin{lemma}[Orbit iterate preserves orthogonal projection]%
+	\label{lem:orbit_iterate_proj}
+	\lean{orbit_iterate_isOrthogonalProjection}
+	\leanok
+	\uses{lem:orbit_iterate_shifted_sector}
+	Under the same cyclic shift and multiplicative-domain hypotheses as
+	Lemma~\ref{lem:orbit_iterate_shifted_sector}, suppose additionally
+	that $T$ maps every orthogonal projection supported on a single
+	sector to an orthogonal projection.
+	If $Q$ is an orthogonal projection supported on $P_k$, then
+	$T^l(Q)$ is an orthogonal projection for each $0 \le l < m$.
+\end{lemma}
+
+\begin{proof}\leanok
+	\uses{lem:orbit_iterate_shifted_sector}
+	Induction on $l$.  The base case is the hypothesis on $Q$.
+	At each step, Lemma~\ref{lem:orbit_iterate_shifted_sector}
+	guarantees that $T^n(Q)$ is supported on a single sector,
+	so the one-step preservation hypothesis applies.
+\end{proof}
+
+\begin{lemma}[Orbit sum of a full sector projection]%
+	\label{lem:orbit_sum_full_sector}
+	\lean{orbitSumProjection_eq_one_of_full_sector}
+	\leanok
+	\uses{lem:orbit_sum_fixed}
+	Let $(P_k)_{k=1}^m$ be orthogonal projections with
+	$\sum_k P_k = \Id$ and cyclic shift $T(P_{k+1}) = P_k$.
+	Then for every sector index $k$,
+	\[
+		\sum_{l=0}^{m-1} T^l(P_k) \;=\; \Id.
+	\]
+\end{lemma}
+
+\begin{proof}\leanok
+	By induction, $T^l(P_k) = P_{k-l}$ for each $l$.
+	The orbit sum therefore runs over all distinct sectors, and the
+	reindexing $l \mapsto k - l$ recovers $\sum_j P_j = \Id$.
+\end{proof}
+
 \begin{theorem}[Sector irreducibility from orbit-sum lift]%
 	\label{thm:sector_irred_orbit_lift}
 	\lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1160,9 +1160,8 @@ The following results separate the zero blocks from the
 
 \begin{lemma}[Orbit iterate supported on shifted sector]%
 	\label{lem:orbit_iterate_shifted_sector}
-	\lean{orbit_iterate_supported_on_shifted_sector}
+	\lean{MPSTensor.orbit_iterate_supported_on_shifted_sector}
 	\leanok
-	\uses{lem:orbit_sum_fixed}
 	Let $(P_k)_{k=1}^m$ be orthogonal projections with cyclic shift
 	$T(P_{k+1}) = P_k$, and suppose $T$ is multiplicative on each sector
 	corner.
@@ -1180,7 +1179,7 @@ The following results separate the zero blocks from the
 
 \begin{lemma}[Orbit iterate preserves orthogonal projection]%
 	\label{lem:orbit_iterate_proj}
-	\lean{orbit_iterate_isOrthogonalProjection}
+	\lean{MPSTensor.orbit_iterate_isOrthogonalProjection}
 	\leanok
 	\uses{lem:orbit_iterate_shifted_sector}
 	Under the same cyclic shift and multiplicative-domain hypotheses as
@@ -1201,7 +1200,7 @@ The following results separate the zero blocks from the
 
 \begin{lemma}[Orbit sum of a full sector projection]%
 	\label{lem:orbit_sum_full_sector}
-	\lean{orbitSumProjection_eq_one_of_full_sector}
+	\lean{MPSTensor.orbitSumProjection_eq_one_of_full_sector}
 	\leanok
 	\uses{lem:orbit_sum_fixed}
 	Let $(P_k)_{k=1}^m$ be orthogonal projections with


### PR DESCRIPTION
### Motivation
Follow-up from #430. Closes #431.

### Description
Proves the 3 orbit-sum lift sublemmas needed to complete the `hLift` construction for sector irreducibility:

1. **`orbit_iterate_supported_on_shifted_sector`**: For cyclic projections with `T(P(k+1)) = P(k)`, the orbit iterate `T^l(Q)` supported on sector `P(k)` lands on sector `P(k-l)`.

2. **`orbit_iterate_isOrthogonalProjection`**: Under a one-step projection-preservation hypothesis, `T^l(Q)` remains an orthogonal projection by induction.

3. **`orbitSumProjection_eq_one_of_full_sector`**: The orbit sum `∑_l T^l(P_k) = 1` via cyclic reindexing of the `∑ P_j = 1` condition.

**Note on theorem 2**: The original issue asked for corner-preservation as a sufficient hypothesis, but that is mathematically too weak for general linear channels. The theorem instead takes an explicit `hProjStep` hypothesis that `T` preserves orthogonal projections within each sector corner. This is the correct input for the induction.

All 3 proofs are sorry-free. Locally verified: 0 errors, 0 warnings.

### Files changed
- `TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean lemmas/proofs and corresponding blueprint documentation, without changing existing APIs or computational behavior.
> 
> **Overview**
> Adds three sorry-free Lean lemmas needed to complete the orbit-sum lift used in cyclic-sector irreducibility: support of orbit iterates on shifted sectors (`orbit_iterate_supported_on_shifted_sector`), preservation of `IsOrthogonalProjection` along iterates under an explicit one-step hypothesis (`orbit_iterate_isOrthogonalProjection`), and the full-sector orbit-sum identity (`orbitSumProjection_eq_one_of_full_sector`).
> 
> Updates the blueprint text to document these new results and connect them to the existing orbit-sum fixed-point lemma and the sector-irreducibility wrapper theorem.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65637329577ace976d16178fca772622cf7ad3be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->