### PR TITLE
feat(Analysis/Entropy): add von Neumann entropy, SSA, and mutual information

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -57,7 +57,7 @@ import TNLean.Channel.TransferMatrix
 
 -- Layer 2a: Density-matrix Brouwer fixed-point theorem used in Perron--Frobenius existence
 import TNLean.Axioms.BrouwerFixedPoint
--- Layer 0b: Axiomatized entropy inequalities (strong subadditivity)
+-- Layer 2a: Axiomatized entropy inequalities (strong subadditivity)
 import TNLean.Axioms.Entropy
 
 -- Layer 2b: Quantum channels (general theory)

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -57,6 +57,8 @@ import TNLean.Channel.TransferMatrix
 
 -- Layer 2a: Density-matrix Brouwer fixed-point theorem used in Perron--Frobenius existence
 import TNLean.Axioms.BrouwerFixedPoint
+-- Layer 0b: Axiomatized entropy inequalities (strong subadditivity)
+import TNLean.Axioms.Entropy
 
 -- Layer 2b: Quantum channels (general theory)
 import TNLean.Channel.Schwarz.KadisonSchwarz

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -35,7 +35,6 @@ import TNLean.Algebra.CocycleCohomology
 
 -- Layer 0b: General analysis
 import TNLean.Analysis.ConvergenceHelpers
-import TNLean.Analysis.Entropy
 
 -- Layer 1: Generic convex/topological infrastructure
 import TNLean.Topology.ConvexProjection
@@ -54,6 +53,9 @@ import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Stinespring
 import TNLean.Channel.TransferMatrix
+
+-- Layer 2: Quantum entropy infrastructure (depends on Channel.Basic, Channel.PartialTrace)
+import TNLean.Analysis.Entropy
 
 -- Layer 2a: Density-matrix Brouwer fixed-point theorem used in Perron--Frobenius existence
 import TNLean.Axioms.BrouwerFixedPoint

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -35,7 +35,6 @@ import TNLean.Algebra.CocycleCohomology
 
 -- Layer 0b: General analysis
 import TNLean.Analysis.ConvergenceHelpers
-import TNLean.Analysis.Entropy
 
 -- Layer 1: Generic convex/topological infrastructure
 import TNLean.Topology.ConvexProjection

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -35,6 +35,7 @@ import TNLean.Algebra.CocycleCohomology
 
 -- Layer 0b: General analysis
 import TNLean.Analysis.ConvergenceHelpers
+import TNLean.Analysis.Entropy
 
 -- Layer 1: Generic convex/topological infrastructure
 import TNLean.Topology.ConvexProjection

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -24,6 +24,10 @@ the basic quantum entropy infrastructure needed for MPDO / RFP applications.
 ## Main results
 
 * `vonNeumannEntropy_nonneg`: `S(ρ) ≥ 0` for density matrices
+* `traceA_ABC_isHermitian`, `traceC_ABC_isHermitian`, `traceAC_ABC_isHermitian`:
+  tripartite partial traces preserve Hermiticity
+* `Matrix.traceLeft_isHermitian`, `Matrix.traceRight_isHermitian`:
+  bipartite partial traces preserve Hermiticity
 
 ## Status
 
@@ -191,7 +195,67 @@ noncomputable def traceAC_ABC
     Matrix (Fin dB) (Fin dB) ℂ :=
   fun b₁ b₂ => ∑ a : Fin dA, ∑ c : Fin dC, ρ (a, b₁, c) (a, b₂, c)
 
+/-! ### Hermiticity preservation for partial traces -/
+
+/-- Partial trace over A preserves Hermiticity. -/
+theorem traceA_ABC_isHermitian
+    {ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    (hρ : ρ.IsHermitian) : (traceA_ABC ρ).IsHermitian := by
+  apply Matrix.IsHermitian.ext
+  intro bc₁ bc₂
+  simp only [traceA_ABC, star_sum]
+  exact Finset.sum_congr rfl fun a _ => hρ.apply (a, bc₁) (a, bc₂)
+
+/-- Partial trace over C preserves Hermiticity. -/
+theorem traceC_ABC_isHermitian
+    {ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    (hρ : ρ.IsHermitian) : (traceC_ABC ρ).IsHermitian := by
+  apply Matrix.IsHermitian.ext
+  intro ab₁ ab₂
+  simp only [traceC_ABC, star_sum]
+  exact Finset.sum_congr rfl fun c _ =>
+    hρ.apply (ab₁.1, ab₁.2, c) (ab₂.1, ab₂.2, c)
+
+/-- Partial trace over AC preserves Hermiticity. -/
+theorem traceAC_ABC_isHermitian
+    {ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    (hρ : ρ.IsHermitian) : (traceAC_ABC ρ).IsHermitian := by
+  apply Matrix.IsHermitian.ext
+  intro b₁ b₂
+  simp only [traceAC_ABC, star_sum]
+  exact Finset.sum_congr rfl fun a _ =>
+    Finset.sum_congr rfl fun c _ => hρ.apply (a, b₁, c) (a, b₂, c)
+
 end TripartiteTrace
+
+/-! ## Bipartite partial trace Hermiticity preservation -/
+
+section BipartiteHermiticity
+
+variable {dA dB : ℕ}
+
+/-- `Matrix.traceLeft` (partial trace over A) preserves Hermiticity. -/
+theorem Matrix.traceLeft_isHermitian
+    {ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
+    (hρ : ρ.IsHermitian) : (Matrix.traceLeft ρ).IsHermitian := by
+  apply Matrix.IsHermitian.ext
+  intro b₁ b₂
+  simp only [Matrix.traceLeft, star_sum]
+  exact Finset.sum_congr rfl fun a _ => hρ.apply (a, b₁) (a, b₂)
+
+/-- `Matrix.traceRight` (partial trace over B) preserves Hermiticity. -/
+theorem Matrix.traceRight_isHermitian
+    {ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
+    (hρ : ρ.IsHermitian) : (Matrix.traceRight ρ).IsHermitian := by
+  apply Matrix.IsHermitian.ext
+  intro a₁ a₂
+  simp only [Matrix.traceRight, star_sum]
+  exact Finset.sum_congr rfl fun b _ => hρ.apply (a₁, b) (a₂, b)
+
+end BipartiteHermiticity
 
 /-! ## SSA equality condition
 
@@ -207,18 +271,16 @@ section SSAEquality
 variable {dA dB dC : ℕ}
 
 /-- Predicate asserting that equality holds in strong subadditivity for a
-tripartite state `ρ_ABC`. -/
+tripartite state `ρ_ABC`. Hermiticity of reduced states is derived
+automatically from `hρ_ABC` via partial-trace preservation lemmas. -/
 def IsSSAEquality
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
-    (hρ_ABC : ρ_ABC.IsHermitian)
-    (hρ_B : (traceAC_ABC ρ_ABC).IsHermitian)
-    (hρ_AB : (traceC_ABC ρ_ABC).IsHermitian)
-    (hρ_BC : (traceA_ABC ρ_ABC).IsHermitian) : Prop :=
+    (hρ_ABC : ρ_ABC.IsHermitian) : Prop :=
   vonNeumannEntropy ρ_ABC hρ_ABC
-    + vonNeumannEntropy (traceAC_ABC ρ_ABC) hρ_B
-  = vonNeumannEntropy (traceC_ABC ρ_ABC) hρ_AB
-    + vonNeumannEntropy (traceA_ABC ρ_ABC) hρ_BC
+    + vonNeumannEntropy (traceAC_ABC ρ_ABC) (traceAC_ABC_isHermitian hρ_ABC)
+  = vonNeumannEntropy (traceC_ABC ρ_ABC) (traceC_ABC_isHermitian hρ_ABC)
+    + vonNeumannEntropy (traceA_ABC ρ_ABC) (traceA_ABC_isHermitian hρ_ABC)
 
 end SSAEquality
 
@@ -232,14 +294,14 @@ variable {dA dB : ℕ}
 
 `I(A:B) = S(ρ_A) + S(ρ_B) - S(ρ_AB)`
 
-Measures the total correlations (classical + quantum) between A and B. -/
+Measures the total correlations (classical + quantum) between A and B.
+Hermiticity of reduced states is derived from `hρ_AB` via partial-trace
+preservation lemmas. -/
 noncomputable def mutualInformation
     (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
-    (hρ_AB : ρ_AB.IsHermitian)
-    (hρ_A : (Matrix.traceRight ρ_AB).IsHermitian)
-    (hρ_B : (Matrix.traceLeft ρ_AB).IsHermitian) : ℝ :=
-  vonNeumannEntropy (Matrix.traceRight ρ_AB) hρ_A
-    + vonNeumannEntropy (Matrix.traceLeft ρ_AB) hρ_B
+    (hρ_AB : ρ_AB.IsHermitian) : ℝ :=
+  vonNeumannEntropy (Matrix.traceRight ρ_AB) (Matrix.traceRight_isHermitian hρ_AB)
+    + vonNeumannEntropy (Matrix.traceLeft ρ_AB) (Matrix.traceLeft_isHermitian hρ_AB)
     - vonNeumannEntropy ρ_AB hρ_AB
 
 end MutualInformation

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -27,13 +27,9 @@ the basic quantum entropy infrastructure needed for MPDO / RFP applications.
 
 ## Status
 
-The following results are **not proved** in this module:
-* `vonNeumannEntropy_le_log_dim` — `sorry` placeholder (Jensen's inequality
-  via `ConcaveOn.le_map_sum` applied to `concaveOn_negMulLog`).
-
-The axiomatized strong subadditivity and derived subadditivity live in
-`TNLean.Axioms.Entropy`, which is **not** re-exported from `TNLean.lean`.
-See issue #239 for the deferred proof plan.
+All results in this module are fully proved. The axiomatized strong
+subadditivity lives in `TNLean.Axioms.Entropy`, which is **not** re-exported
+from `TNLean.lean`. See issue #239 for the deferred proof plan.
 
 ## Implementation notes
 
@@ -116,11 +112,9 @@ theorem vonNeumannEntropy_nonneg
 
 /-- Von Neumann entropy is bounded above by `log D`.
 
-By Jensen's inequality applied to the concave function `negMulLog`, the entropy
-is maximized when all eigenvalues are equal to `1/D` (maximally mixed state),
-giving `S(ρ) ≤ D · negMulLog(1/D) = log D`.
-
-TODO: Prove via `ConcaveOn.le_map_sum` applied to `concaveOn_negMulLog`. -/
+Proved via Jensen's inequality (`ConcaveOn.le_map_sum` applied to
+`concaveOn_negMulLog`): the entropy is maximized when all eigenvalues
+are equal to `1/D`, giving `S(ρ) ≤ D · negMulLog(1/D) = log D`. -/
 theorem vonNeumannEntropy_le_log_dim
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
     (hD : 0 < D) :

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -1,0 +1,332 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.Analysis.Matrix.Spectrum
+import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+import TNLean.Channel.Basic
+import TNLean.Channel.PartialTrace
+
+/-!
+# Von Neumann entropy, strong subadditivity, and mutual information
+
+This file defines the von Neumann entropy for density matrices and develops
+the basic quantum entropy infrastructure needed for MPDO / RFP applications.
+
+## Main definitions
+
+* `vonNeumannEntropy`: `S(ρ) = ∑ᵢ negMulLog(λᵢ)` where `λᵢ` are eigenvalues
+* `mutualInformation`: `I(A:B) = S(ρ_A) + S(ρ_B) - S(ρ_AB)`
+
+## Main results
+
+* `vonNeumannEntropy_nonneg`: `S(ρ) ≥ 0` for density matrices
+* `vonNeumannEntropy_le_log_dim`: `S(ρ) ≤ log D` for `D × D` density matrices
+* `strong_subadditivity`: `S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)` (axiom)
+* `subadditivity`: `S(ρ_AB) ≤ S(ρ_A) + S(ρ_B)` (axiom)
+* `mutualInformation_nonneg`: `I(A:B) ≥ 0`
+
+## Implementation notes
+
+Strong subadditivity (SSA) and subadditivity are axiomatized following Option B
+from issue #239. The full proof from Klein's inequality and Lieb concavity is
+deferred; the axioms are marked with TODOs for future replacement.
+
+The entropy definition uses the eigenvalue-based formula via
+`Matrix.IsHermitian.eigenvalues` and Mathlib's `Real.negMulLog`. The index
+type `n` is kept polymorphic (`[Fintype n] [DecidableEq n]`) so that von
+Neumann entropy can be applied to matrices indexed by product types arising
+from partial traces.
+
+Tripartite partial traces are defined directly as matrix entry sums, avoiding
+dependence on the bipartite `Matrix.traceLeft`/`Matrix.traceRight` which are
+specialized to `Fin d × Fin d'` indices.
+
+## References
+
+* Lieb, Ruskai, "Proof of the strong subadditivity of quantum-mechanical
+  entropy", JMP 14, 1938 (1973)
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*][Wolf2012QChannels]
+* arXiv:1606.00608 §4.4
+-/
+
+open scoped Matrix ComplexOrder
+open Matrix Finset Real
+
+/-! ## Von Neumann entropy -/
+
+section VonNeumannEntropy
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Von Neumann entropy** of a Hermitian matrix.
+
+For a Hermitian matrix `ρ` with eigenvalues `λᵢ`, the von Neumann entropy is
+`S(ρ) = ∑ᵢ negMulLog(λᵢ) = -∑ᵢ λᵢ log(λᵢ)`.
+
+When `ρ` is a density matrix (PSD with trace 1), this gives the standard
+quantum entropy `S(ρ) = -tr(ρ log ρ)`. -/
+noncomputable def vonNeumannEntropy
+    (ρ : Matrix n n ℂ) (hρ : ρ.IsHermitian) : ℝ :=
+  ∑ i, negMulLog (hρ.eigenvalues i)
+
+end VonNeumannEntropy
+
+/-! ### Basic properties for `Fin D` density matrices -/
+
+section VonNeumannEntropyFinD
+
+variable {D : ℕ}
+
+/-- The eigenvalues of a density matrix sum to 1 (real version). -/
+theorem densityMatrix_eigenvalues_sum_one [DecidableEq (Fin D)]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D) :
+    ∑ i : Fin D, hρ.1.isHermitian.eigenvalues i = 1 := by
+  have h := hρ.1.isHermitian.trace_eq_sum_eigenvalues
+  have h_tr := hρ.2
+  have key : (∑ i : Fin D, (hρ.1.isHermitian.eigenvalues i : ℂ)) = 1 :=
+    h ▸ h_tr
+  exact_mod_cast key
+
+/-- The eigenvalues of a density matrix lie in `[0, 1]`. -/
+theorem densityMatrix_eigenvalues_le_one [DecidableEq (Fin D)]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
+    (i : Fin D) : hρ.1.isHermitian.eigenvalues i ≤ 1 := by
+  have h_nonneg := hρ.1.eigenvalues_nonneg
+  have h_sum := densityMatrix_eigenvalues_sum_one hρ
+  nlinarith [Finset.single_le_sum (f := fun j => hρ.1.isHermitian.eigenvalues j)
+    (fun j _ => h_nonneg j) (Finset.mem_univ i)]
+
+/-- Von Neumann entropy is nonneg for density matrices.
+
+Each eigenvalue `λᵢ` of a density matrix satisfies `0 ≤ λᵢ ≤ 1`, and
+`negMulLog` is nonneg on `[0, 1]`. -/
+theorem vonNeumannEntropy_nonneg [DecidableEq (Fin D)]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D) :
+    0 ≤ vonNeumannEntropy ρ hρ.1.isHermitian := by
+  apply Finset.sum_nonneg
+  intro i _
+  exact negMulLog_nonneg (hρ.1.eigenvalues_nonneg i)
+    (densityMatrix_eigenvalues_le_one hρ i)
+
+/-- Von Neumann entropy is bounded above by `log D`.
+
+By Jensen's inequality applied to the concave function `negMulLog`, the entropy
+is maximized when all eigenvalues are equal to `1/D` (maximally mixed state),
+giving `S(ρ) ≤ D · negMulLog(1/D) = log D`.
+
+TODO: Prove via `ConcaveOn.le_map_sum` applied to `concaveOn_negMulLog`. -/
+theorem vonNeumannEntropy_le_log_dim [DecidableEq (Fin D)]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
+    (hD : 0 < D) :
+    vonNeumannEntropy ρ hρ.1.isHermitian ≤ Real.log D := by
+  sorry
+
+end VonNeumannEntropyFinD
+
+/-! ## Tripartite partial traces
+
+Partial traces for tripartite systems `A ⊗ B ⊗ C`, defined directly via
+summation over the traced-out indices. The tripartite state is indexed by
+`Fin dA × Fin dB × Fin dC` (right-associated: `Fin dA × (Fin dB × Fin dC)`). -/
+
+section TripartiteTrace
+
+variable {dA dB dC : ℕ}
+
+/-- Partial trace over A: `ρ_BC = tr_A(ρ_ABC)`.
+
+`(traceA_ABC ρ) (b₁, c₁) (b₂, c₂) = ∑ a, ρ (a, b₁, c₁) (a, b₂, c₂)` -/
+noncomputable def traceA_ABC
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    Matrix (Fin dB × Fin dC) (Fin dB × Fin dC) ℂ :=
+  fun bc₁ bc₂ => ∑ a : Fin dA, ρ (a, bc₁) (a, bc₂)
+
+/-- Partial trace over C: `ρ_AB = tr_C(ρ_ABC)`.
+
+`(traceC_ABC ρ) (a₁, b₁) (a₂, b₂) = ∑ c, ρ (a₁, b₁, c) (a₂, b₂, c)` -/
+noncomputable def traceC_ABC
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ :=
+  fun ab₁ ab₂ => ∑ c : Fin dC, ρ (ab₁.1, ab₁.2, c) (ab₂.1, ab₂.2, c)
+
+/-- Partial trace over AC: `ρ_B = tr_AC(ρ_ABC)`.
+
+`(traceAC_ABC ρ) b₁ b₂ = ∑ a, ∑ c, ρ (a, b₁, c) (a, b₂, c)` -/
+noncomputable def traceAC_ABC
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    Matrix (Fin dB) (Fin dB) ℂ :=
+  fun b₁ b₂ => ∑ a : Fin dA, ∑ c : Fin dC, ρ (a, b₁, c) (a, b₂, c)
+
+end TripartiteTrace
+
+/-! ## Strong subadditivity (axiom)
+
+Strong subadditivity is axiomatized as described in issue #239 (Option B).
+The full proof via Klein's inequality and joint convexity of relative entropy
+is deferred.
+
+TODO: Replace this axiom with a proof from Klein's inequality and
+Lieb concavity (Lieb–Ruskai 1973). This requires:
+1. Quantum relative entropy `D(ρ‖σ) = tr(ρ(log ρ - log σ))`
+2. Klein's inequality: `D(ρ‖σ) ≥ 0`
+3. Joint convexity of relative entropy
+4. Monotonicity of relative entropy under partial trace -/
+
+section StrongSubadditivity
+
+variable {dA dB dC : ℕ}
+
+/-- **Strong subadditivity** (Lieb–Ruskai 1973).
+
+For a tripartite density matrix `ρ_ABC` on `A ⊗ B ⊗ C`:
+  `S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)`
+
+This is axiomatized; see the module docstring for the deferred proof plan.
+
+References:
+* Lieb, Ruskai, JMP 14, 1938 (1973) -/
+axiom strong_subadditivity
+    [DecidableEq (Fin dA × Fin dB × Fin dC)]
+    [DecidableEq (Fin dA × Fin dB)]
+    [DecidableEq (Fin dB × Fin dC)]
+    [DecidableEq (Fin dB)]
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_ABC : ρ_ABC.IsHermitian)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hρ_B : (traceAC_ABC ρ_ABC).IsHermitian)
+    (hρ_AB : (traceC_ABC ρ_ABC).IsHermitian)
+    (hρ_BC : (traceA_ABC ρ_ABC).IsHermitian) :
+    vonNeumannEntropy ρ_ABC hρ_ABC
+      + vonNeumannEntropy (traceAC_ABC ρ_ABC) hρ_B
+    ≤ vonNeumannEntropy (traceC_ABC ρ_ABC) hρ_AB
+      + vonNeumannEntropy (traceA_ABC ρ_ABC) hρ_BC
+
+end StrongSubadditivity
+
+/-! ## Subadditivity (axiom)
+
+Subadditivity follows from strong subadditivity with a trivial system C
+(dimension 1). We axiomatize it separately for ergonomic use with bipartite
+states.
+
+TODO: Prove from `strong_subadditivity` by specializing `dC = 1`. -/
+
+section Subadditivity
+
+variable {dA dB : ℕ}
+
+/-- **Subadditivity** of von Neumann entropy.
+
+For a bipartite density matrix `ρ_AB` on `A ⊗ B`:
+  `S(ρ_AB) ≤ S(ρ_A) + S(ρ_B)` -/
+axiom subadditivity
+    [DecidableEq (Fin dA × Fin dB)]
+    [DecidableEq (Fin dA)] [DecidableEq (Fin dB)]
+    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρ_AB : ρ_AB.IsHermitian)
+    (hρ_dm : ρ_AB.PosSemidef ∧ ρ_AB.trace = 1)
+    (hρ_A : (Matrix.traceRight ρ_AB).IsHermitian)
+    (hρ_B : (Matrix.traceLeft ρ_AB).IsHermitian) :
+    vonNeumannEntropy ρ_AB hρ_AB
+    ≤ vonNeumannEntropy (Matrix.traceRight ρ_AB) hρ_A
+      + vonNeumannEntropy (Matrix.traceLeft ρ_AB) hρ_B
+
+end Subadditivity
+
+/-! ## SSA equality condition
+
+The Hayashi (2003) characterization of equality in strong subadditivity is
+defined as a predicate. The characterization theorem (equality ↔ recovery map
+condition) is axiomatized.
+
+TODO: Replace with a proof following Hayashi, "Quantum Information: An
+Introduction", Springer 2006, Theorem 5.24. -/
+
+section SSAEquality
+
+variable {dA dB dC : ℕ}
+
+/-- Predicate asserting that equality holds in strong subadditivity for a
+tripartite state `ρ_ABC`. -/
+def IsSSAEquality
+    [DecidableEq (Fin dA × Fin dB × Fin dC)]
+    [DecidableEq (Fin dA × Fin dB)]
+    [DecidableEq (Fin dB × Fin dC)]
+    [DecidableEq (Fin dB)]
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_ABC : ρ_ABC.IsHermitian)
+    (hρ_B : (traceAC_ABC ρ_ABC).IsHermitian)
+    (hρ_AB : (traceC_ABC ρ_ABC).IsHermitian)
+    (hρ_BC : (traceA_ABC ρ_ABC).IsHermitian) : Prop :=
+  vonNeumannEntropy ρ_ABC hρ_ABC
+    + vonNeumannEntropy (traceAC_ABC ρ_ABC) hρ_B
+  = vonNeumannEntropy (traceC_ABC ρ_ABC) hρ_AB
+    + vonNeumannEntropy (traceA_ABC ρ_ABC) hρ_BC
+
+end SSAEquality
+
+/-! ## Mutual information -/
+
+section MutualInformation
+
+variable {dA dB : ℕ}
+
+/-- **Quantum mutual information** between subsystems A and B.
+
+`I(A:B) = S(ρ_A) + S(ρ_B) - S(ρ_AB)`
+
+Measures the total correlations (classical + quantum) between A and B. -/
+noncomputable def mutualInformation
+    [DecidableEq (Fin dA × Fin dB)]
+    [DecidableEq (Fin dA)] [DecidableEq (Fin dB)]
+    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρ_AB : ρ_AB.IsHermitian)
+    (hρ_A : (Matrix.traceRight ρ_AB).IsHermitian)
+    (hρ_B : (Matrix.traceLeft ρ_AB).IsHermitian) : ℝ :=
+  vonNeumannEntropy (Matrix.traceRight ρ_AB) hρ_A
+    + vonNeumannEntropy (Matrix.traceLeft ρ_AB) hρ_B
+    - vonNeumannEntropy ρ_AB hρ_AB
+
+/-- Mutual information is nonneg: `I(A:B) ≥ 0`.
+
+This follows directly from subadditivity: `S(ρ_AB) ≤ S(ρ_A) + S(ρ_B)`. -/
+theorem mutualInformation_nonneg
+    [DecidableEq (Fin dA × Fin dB)]
+    [DecidableEq (Fin dA)] [DecidableEq (Fin dB)]
+    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρ_AB : ρ_AB.IsHermitian)
+    (hρ_dm : ρ_AB.PosSemidef ∧ ρ_AB.trace = 1)
+    (hρ_A : (Matrix.traceRight ρ_AB).IsHermitian)
+    (hρ_B : (Matrix.traceLeft ρ_AB).IsHermitian) :
+    0 ≤ mutualInformation ρ_AB hρ_AB hρ_A hρ_B := by
+  unfold mutualInformation
+  linarith [subadditivity ρ_AB hρ_AB hρ_dm hρ_A hρ_B]
+
+/-- **Area law** for mutual information of MPDO states.
+
+For an MPDO with bond dimension `D`, the mutual information across any cut
+satisfies `I(A:B) ≤ 4 * log D`.
+
+TODO: Prove from the bond-dimension structure of MPDO transfer matrices.
+
+References:
+* arXiv:1606.00608 §4.4 -/
+theorem mutualInformation_area_law
+    [DecidableEq (Fin dA × Fin dB)]
+    [DecidableEq (Fin dA)] [DecidableEq (Fin dB)]
+    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρ_AB : ρ_AB.IsHermitian)
+    (hρ_A : (Matrix.traceRight ρ_AB).IsHermitian)
+    (hρ_B : (Matrix.traceLeft ρ_AB).IsHermitian)
+    (bondDim : ℕ) (hD : 0 < bondDim) :
+    mutualInformation ρ_AB hρ_AB hρ_A hρ_B ≤ 4 * Real.log bondDim := by
+  sorry
+
+end MutualInformation

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -24,7 +24,6 @@ the basic quantum entropy infrastructure needed for MPDO / RFP applications.
 ## Main results
 
 * `vonNeumannEntropy_nonneg`: `S(ρ) ≥ 0` for density matrices
-* `mutualInformation_nonneg`: `I(A:B) ≥ 0` (requires `TNLean.Axioms.Entropy`)
 
 ## Status
 
@@ -126,7 +125,38 @@ theorem vonNeumannEntropy_le_log_dim
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
     (hD : 0 < D) :
     vonNeumannEntropy ρ hρ.1.isHermitian ≤ Real.log D := by
-  sorry
+  have hJensen := Real.concaveOn_negMulLog.le_map_sum
+      (t := (Finset.univ : Finset (Fin D)))
+      (w := fun _ : Fin D => ((D : ℝ)⁻¹))
+      (p := fun i : Fin D => hρ.1.isHermitian.eigenvalues i)
+      (by
+        intro i hi
+        positivity)
+      (by
+        simp [hD.ne'])
+      (by
+        intro i hi
+        exact hρ.1.eigenvalues_nonneg i)
+  have hsum : ∑ i : Fin D, hρ.1.isHermitian.eigenvalues i = 1 :=
+    densityMatrix_eigenvalues_sum_one hρ
+  have havg :
+      ∑ i : Fin D, (D : ℝ)⁻¹ * hρ.1.isHermitian.eigenvalues i = (D : ℝ)⁻¹ := by
+    rw [← Finset.mul_sum]
+    simp [hsum]
+  have hscaled :
+      ((D : ℝ)⁻¹) * vonNeumannEntropy ρ hρ.1.isHermitian ≤
+      Real.negMulLog ((D : ℝ)⁻¹) := by
+    simpa [vonNeumannEntropy, Finset.mul_sum, Finset.sum_mul, havg, mul_assoc, mul_left_comm,
+      mul_comm] using hJensen
+  have hD' : (0 : ℝ) < D := by exact_mod_cast hD
+  have hmul := mul_le_mul_of_nonneg_left hscaled (le_of_lt hD')
+  have hentropy :
+      vonNeumannEntropy ρ hρ.1.isHermitian ≤
+      (D : ℝ) * Real.negMulLog ((D : ℝ)⁻¹) := by
+    simpa [hD.ne', mul_assoc, inv_mul_cancel₀, one_mul] using hmul
+  have hlog : (D : ℝ) * Real.negMulLog ((D : ℝ)⁻¹) = Real.log D := by
+    simp [Real.negMulLog, hD.ne', Real.log_inv]
+  simpa [hlog] using hentropy
 
 end VonNeumannEntropyFinD
 

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -9,7 +9,7 @@ import TNLean.Channel.Basic
 import TNLean.Channel.PartialTrace
 
 /-!
-# Von Neumann entropy, strong subadditivity, and mutual information
+# Von Neumann entropy, partial traces, and mutual information
 
 This file defines the von Neumann entropy for density matrices and develops
 the basic quantum entropy infrastructure needed for MPDO / RFP applications.
@@ -17,21 +17,26 @@ the basic quantum entropy infrastructure needed for MPDO / RFP applications.
 ## Main definitions
 
 * `vonNeumannEntropy`: `S(ρ) = ∑ᵢ negMulLog(λᵢ)` where `λᵢ` are eigenvalues
+* `traceA_ABC`, `traceC_ABC`, `traceAC_ABC`: tripartite partial traces
 * `mutualInformation`: `I(A:B) = S(ρ_A) + S(ρ_B) - S(ρ_AB)`
+* `IsSSAEquality`: predicate for equality in strong subadditivity
 
 ## Main results
 
 * `vonNeumannEntropy_nonneg`: `S(ρ) ≥ 0` for density matrices
-* `vonNeumannEntropy_le_log_dim`: `S(ρ) ≤ log D` for `D × D` density matrices
-* `strong_subadditivity`: `S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)` (axiom)
-* `subadditivity`: `S(ρ_AB) ≤ S(ρ_A) + S(ρ_B)` (axiom)
-* `mutualInformation_nonneg`: `I(A:B) ≥ 0`
+* `mutualInformation_nonneg`: `I(A:B) ≥ 0` (requires `TNLean.Axioms.Entropy`)
+
+## Status
+
+The following results are **not proved** in this module:
+* `vonNeumannEntropy_le_log_dim` — `sorry` placeholder (Jensen's inequality
+  via `ConcaveOn.le_map_sum` applied to `concaveOn_negMulLog`).
+
+The axiomatized strong subadditivity and derived subadditivity live in
+`TNLean.Axioms.Entropy`, which is **not** re-exported from `TNLean.lean`.
+See issue #239 for the deferred proof plan.
 
 ## Implementation notes
-
-Strong subadditivity (SSA) and subadditivity are axiomatized following Option B
-from issue #239. The full proof from Klein's inequality and Lieb concavity is
-deferred; the axioms are marked with TODOs for future replacement.
 
 The entropy definition uses the eigenvalue-based formula via
 `Matrix.IsHermitian.eigenvalues` and Mathlib's `Real.negMulLog`. The index
@@ -80,7 +85,7 @@ section VonNeumannEntropyFinD
 variable {D : ℕ}
 
 /-- The eigenvalues of a density matrix sum to 1 (real version). -/
-theorem densityMatrix_eigenvalues_sum_one [DecidableEq (Fin D)]
+theorem densityMatrix_eigenvalues_sum_one
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D) :
     ∑ i : Fin D, hρ.1.isHermitian.eigenvalues i = 1 := by
   have h := hρ.1.isHermitian.trace_eq_sum_eigenvalues
@@ -90,7 +95,7 @@ theorem densityMatrix_eigenvalues_sum_one [DecidableEq (Fin D)]
   exact_mod_cast key
 
 /-- The eigenvalues of a density matrix lie in `[0, 1]`. -/
-theorem densityMatrix_eigenvalues_le_one [DecidableEq (Fin D)]
+theorem densityMatrix_eigenvalues_le_one
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
     (i : Fin D) : hρ.1.isHermitian.eigenvalues i ≤ 1 := by
   have h_nonneg := hρ.1.eigenvalues_nonneg
@@ -102,7 +107,7 @@ theorem densityMatrix_eigenvalues_le_one [DecidableEq (Fin D)]
 
 Each eigenvalue `λᵢ` of a density matrix satisfies `0 ≤ λᵢ ≤ 1`, and
 `negMulLog` is nonneg on `[0, 1]`. -/
-theorem vonNeumannEntropy_nonneg [DecidableEq (Fin D)]
+theorem vonNeumannEntropy_nonneg
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D) :
     0 ≤ vonNeumannEntropy ρ hρ.1.isHermitian := by
   apply Finset.sum_nonneg
@@ -117,7 +122,7 @@ is maximized when all eigenvalues are equal to `1/D` (maximally mixed state),
 giving `S(ρ) ≤ D · negMulLog(1/D) = log D`.
 
 TODO: Prove via `ConcaveOn.le_map_sum` applied to `concaveOn_negMulLog`. -/
-theorem vonNeumannEntropy_le_log_dim [DecidableEq (Fin D)]
+theorem vonNeumannEntropy_le_log_dim
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
     (hD : 0 < D) :
     vonNeumannEntropy ρ hρ.1.isHermitian ≤ Real.log D := by
@@ -164,86 +169,11 @@ noncomputable def traceAC_ABC
 
 end TripartiteTrace
 
-/-! ## Strong subadditivity (axiom)
-
-Strong subadditivity is axiomatized as described in issue #239 (Option B).
-The full proof via Klein's inequality and joint convexity of relative entropy
-is deferred.
-
-TODO: Replace this axiom with a proof from Klein's inequality and
-Lieb concavity (Lieb–Ruskai 1973). This requires:
-1. Quantum relative entropy `D(ρ‖σ) = tr(ρ(log ρ - log σ))`
-2. Klein's inequality: `D(ρ‖σ) ≥ 0`
-3. Joint convexity of relative entropy
-4. Monotonicity of relative entropy under partial trace -/
-
-section StrongSubadditivity
-
-variable {dA dB dC : ℕ}
-
-/-- **Strong subadditivity** (Lieb–Ruskai 1973).
-
-For a tripartite density matrix `ρ_ABC` on `A ⊗ B ⊗ C`:
-  `S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)`
-
-This is axiomatized; see the module docstring for the deferred proof plan.
-
-References:
-* Lieb, Ruskai, JMP 14, 1938 (1973) -/
-axiom strong_subadditivity
-    [DecidableEq (Fin dA × Fin dB × Fin dC)]
-    [DecidableEq (Fin dA × Fin dB)]
-    [DecidableEq (Fin dB × Fin dC)]
-    [DecidableEq (Fin dB)]
-    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
-      (Fin dA × Fin dB × Fin dC) ℂ)
-    (hρ_ABC : ρ_ABC.IsHermitian)
-    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
-    (hρ_B : (traceAC_ABC ρ_ABC).IsHermitian)
-    (hρ_AB : (traceC_ABC ρ_ABC).IsHermitian)
-    (hρ_BC : (traceA_ABC ρ_ABC).IsHermitian) :
-    vonNeumannEntropy ρ_ABC hρ_ABC
-      + vonNeumannEntropy (traceAC_ABC ρ_ABC) hρ_B
-    ≤ vonNeumannEntropy (traceC_ABC ρ_ABC) hρ_AB
-      + vonNeumannEntropy (traceA_ABC ρ_ABC) hρ_BC
-
-end StrongSubadditivity
-
-/-! ## Subadditivity (axiom)
-
-Subadditivity follows from strong subadditivity with a trivial system C
-(dimension 1). We axiomatize it separately for ergonomic use with bipartite
-states.
-
-TODO: Prove from `strong_subadditivity` by specializing `dC = 1`. -/
-
-section Subadditivity
-
-variable {dA dB : ℕ}
-
-/-- **Subadditivity** of von Neumann entropy.
-
-For a bipartite density matrix `ρ_AB` on `A ⊗ B`:
-  `S(ρ_AB) ≤ S(ρ_A) + S(ρ_B)` -/
-axiom subadditivity
-    [DecidableEq (Fin dA × Fin dB)]
-    [DecidableEq (Fin dA)] [DecidableEq (Fin dB)]
-    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
-    (hρ_AB : ρ_AB.IsHermitian)
-    (hρ_dm : ρ_AB.PosSemidef ∧ ρ_AB.trace = 1)
-    (hρ_A : (Matrix.traceRight ρ_AB).IsHermitian)
-    (hρ_B : (Matrix.traceLeft ρ_AB).IsHermitian) :
-    vonNeumannEntropy ρ_AB hρ_AB
-    ≤ vonNeumannEntropy (Matrix.traceRight ρ_AB) hρ_A
-      + vonNeumannEntropy (Matrix.traceLeft ρ_AB) hρ_B
-
-end Subadditivity
-
 /-! ## SSA equality condition
 
 The Hayashi (2003) characterization of equality in strong subadditivity is
 defined as a predicate. The characterization theorem (equality ↔ recovery map
-condition) is axiomatized.
+condition) is deferred.
 
 TODO: Replace with a proof following Hayashi, "Quantum Information: An
 Introduction", Springer 2006, Theorem 5.24. -/
@@ -255,10 +185,6 @@ variable {dA dB dC : ℕ}
 /-- Predicate asserting that equality holds in strong subadditivity for a
 tripartite state `ρ_ABC`. -/
 def IsSSAEquality
-    [DecidableEq (Fin dA × Fin dB × Fin dC)]
-    [DecidableEq (Fin dA × Fin dB)]
-    [DecidableEq (Fin dB × Fin dC)]
-    [DecidableEq (Fin dB)]
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
     (hρ_ABC : ρ_ABC.IsHermitian)
@@ -284,8 +210,6 @@ variable {dA dB : ℕ}
 
 Measures the total correlations (classical + quantum) between A and B. -/
 noncomputable def mutualInformation
-    [DecidableEq (Fin dA × Fin dB)]
-    [DecidableEq (Fin dA)] [DecidableEq (Fin dB)]
     (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
     (hρ_AB : ρ_AB.IsHermitian)
     (hρ_A : (Matrix.traceRight ρ_AB).IsHermitian)
@@ -293,40 +217,5 @@ noncomputable def mutualInformation
   vonNeumannEntropy (Matrix.traceRight ρ_AB) hρ_A
     + vonNeumannEntropy (Matrix.traceLeft ρ_AB) hρ_B
     - vonNeumannEntropy ρ_AB hρ_AB
-
-/-- Mutual information is nonneg: `I(A:B) ≥ 0`.
-
-This follows directly from subadditivity: `S(ρ_AB) ≤ S(ρ_A) + S(ρ_B)`. -/
-theorem mutualInformation_nonneg
-    [DecidableEq (Fin dA × Fin dB)]
-    [DecidableEq (Fin dA)] [DecidableEq (Fin dB)]
-    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
-    (hρ_AB : ρ_AB.IsHermitian)
-    (hρ_dm : ρ_AB.PosSemidef ∧ ρ_AB.trace = 1)
-    (hρ_A : (Matrix.traceRight ρ_AB).IsHermitian)
-    (hρ_B : (Matrix.traceLeft ρ_AB).IsHermitian) :
-    0 ≤ mutualInformation ρ_AB hρ_AB hρ_A hρ_B := by
-  unfold mutualInformation
-  linarith [subadditivity ρ_AB hρ_AB hρ_dm hρ_A hρ_B]
-
-/-- **Area law** for mutual information of MPDO states.
-
-For an MPDO with bond dimension `D`, the mutual information across any cut
-satisfies `I(A:B) ≤ 4 * log D`.
-
-TODO: Prove from the bond-dimension structure of MPDO transfer matrices.
-
-References:
-* arXiv:1606.00608 §4.4 -/
-theorem mutualInformation_area_law
-    [DecidableEq (Fin dA × Fin dB)]
-    [DecidableEq (Fin dA)] [DecidableEq (Fin dB)]
-    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
-    (hρ_AB : ρ_AB.IsHermitian)
-    (hρ_A : (Matrix.traceRight ρ_AB).IsHermitian)
-    (hρ_B : (Matrix.traceLeft ρ_AB).IsHermitian)
-    (bondDim : ℕ) (hD : 0 < bondDim) :
-    mutualInformation ρ_AB hρ_AB hρ_A hρ_B ≤ 4 * Real.log bondDim := by
-  sorry
 
 end MutualInformation

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -32,8 +32,8 @@ the basic quantum entropy infrastructure needed for MPDO / RFP applications.
 ## Status
 
 All results in this module are fully proved. The axiomatized strong
-subadditivity lives in `TNLean.Axioms.Entropy`, which is **not** re-exported
-from `TNLean.lean`. See issue #239 for the deferred proof plan.
+subadditivity lives in `TNLean.Axioms.Entropy`, which is imported from
+`TNLean.lean` for CI validation. See issue #239 for the deferred proof plan.
 
 ## Implementation notes
 
@@ -84,7 +84,7 @@ section VonNeumannEntropyFinD
 variable {D : ℕ}
 
 /-- The eigenvalues of a density matrix sum to 1 (real version). -/
-theorem densityMatrix_eigenvalues_sum_one
+theorem densityMatrices_eigenvalues_sum_one
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D) :
     ∑ i : Fin D, hρ.1.isHermitian.eigenvalues i = 1 := by
   have h := hρ.1.isHermitian.trace_eq_sum_eigenvalues
@@ -94,11 +94,11 @@ theorem densityMatrix_eigenvalues_sum_one
   exact_mod_cast key
 
 /-- The eigenvalues of a density matrix lie in `[0, 1]`. -/
-theorem densityMatrix_eigenvalues_le_one
+theorem densityMatrices_eigenvalues_le_one
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
     (i : Fin D) : hρ.1.isHermitian.eigenvalues i ≤ 1 := by
   have h_nonneg := hρ.1.eigenvalues_nonneg
-  have h_sum := densityMatrix_eigenvalues_sum_one hρ
+  have h_sum := densityMatrices_eigenvalues_sum_one hρ
   nlinarith [Finset.single_le_sum (f := fun j => hρ.1.isHermitian.eigenvalues j)
     (fun j _ => h_nonneg j) (Finset.mem_univ i)]
 
@@ -112,7 +112,7 @@ theorem vonNeumannEntropy_nonneg
   apply Finset.sum_nonneg
   intro i _
   exact negMulLog_nonneg (hρ.1.eigenvalues_nonneg i)
-    (densityMatrix_eigenvalues_le_one hρ i)
+    (densityMatrices_eigenvalues_le_one hρ i)
 
 /-- Von Neumann entropy is bounded above by `log D`.
 
@@ -136,7 +136,7 @@ theorem vonNeumannEntropy_le_log_dim
         intro i hi
         exact hρ.1.eigenvalues_nonneg i)
   have hsum : ∑ i : Fin D, hρ.1.isHermitian.eigenvalues i = 1 :=
-    densityMatrix_eigenvalues_sum_one hρ
+    densityMatrices_eigenvalues_sum_one hρ
   have havg :
       ∑ i : Fin D, (D : ℝ)⁻¹ * hρ.1.isHermitian.eigenvalues i = (D : ℝ)⁻¹ := by
     rw [← Finset.mul_sum]
@@ -167,6 +167,8 @@ summation over the traced-out indices. The tripartite state is indexed by
 section TripartiteTrace
 
 variable {dA dB dC : ℕ}
+
+namespace Matrix
 
 /-- Partial trace over A: `ρ_BC = tr_A(ρ_ABC)`.
 
@@ -228,6 +230,8 @@ theorem traceAC_ABC_isHermitian
   simp only [traceAC_ABC, star_sum]
   exact Finset.sum_congr rfl fun a _ =>
     Finset.sum_congr rfl fun c _ => hρ.apply (a, b₁, c) (a, b₂, c)
+
+end Matrix
 
 end TripartiteTrace
 

--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -46,20 +46,21 @@ For a tripartite density matrix `ρ_ABC` on `A ⊗ B ⊗ C`:
   `S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)`
 
 This is axiomatized; see the module docstring for the deferred proof plan.
+Hermiticity of reduced states is derived via `traceA_ABC_isHermitian` etc.
+from `hρ_dm.1.isHermitian`.
 
 References:
 * Lieb, Ruskai, JMP 14, 1938 (1973) -/
 axiom strong_subadditivity
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
-    (hρ_ABC : ρ_ABC.IsHermitian)
-    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
-    (hρ_B : (traceAC_ABC ρ_ABC).IsHermitian)
-    (hρ_AB : (traceC_ABC ρ_ABC).IsHermitian)
-    (hρ_BC : (traceA_ABC ρ_ABC).IsHermitian) :
-    vonNeumannEntropy ρ_ABC hρ_ABC
-      + vonNeumannEntropy (traceAC_ABC ρ_ABC) hρ_B
-    ≤ vonNeumannEntropy (traceC_ABC ρ_ABC) hρ_AB
-      + vonNeumannEntropy (traceA_ABC ρ_ABC) hρ_BC
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :
+    vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
+      + vonNeumannEntropy (traceAC_ABC ρ_ABC)
+          (traceAC_ABC_isHermitian hρ_dm.1.isHermitian)
+    ≤ vonNeumannEntropy (traceC_ABC ρ_ABC)
+          (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
+      + vonNeumannEntropy (traceA_ABC ρ_ABC)
+          (traceA_ABC_isHermitian hρ_dm.1.isHermitian)
 
 end StrongSubadditivity

--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Analysis.Entropy
+
+/-!
+# Axiomatized entropy inequalities
+
+This module isolates the axiom for **strong subadditivity** (Lieb–Ruskai 1973)
+so that it does not pollute the stable import surface `TNLean.lean`.
+
+## Status
+
+* `strong_subadditivity` is an **axiom** (proof deferred; see TODO below).
+* `subadditivity` is **derived** from `strong_subadditivity` with `dC = 1`.
+
+## TODO
+
+Replace `strong_subadditivity` with a proof from Klein's inequality and
+Lieb concavity (Lieb–Ruskai 1973). This requires:
+1. Quantum relative entropy `D(ρ‖σ) = tr(ρ(log ρ - log σ))`
+2. Klein's inequality: `D(ρ‖σ) ≥ 0`
+3. Joint convexity of relative entropy
+4. Monotonicity of relative entropy under partial trace
+
+## References
+
+* Lieb, Ruskai, "Proof of the strong subadditivity of quantum-mechanical
+  entropy", JMP 14, 1938 (1973)
+-/
+
+open scoped Matrix ComplexOrder
+open Matrix Finset Real
+
+/-! ## Strong subadditivity (axiom) -/
+
+section StrongSubadditivity
+
+variable {dA dB dC : ℕ}
+
+/-- **Strong subadditivity** (Lieb–Ruskai 1973).
+
+For a tripartite density matrix `ρ_ABC` on `A ⊗ B ⊗ C`:
+  `S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)`
+
+This is axiomatized; see the module docstring for the deferred proof plan.
+
+References:
+* Lieb, Ruskai, JMP 14, 1938 (1973) -/
+axiom strong_subadditivity
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_ABC : ρ_ABC.IsHermitian)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hρ_B : (traceAC_ABC ρ_ABC).IsHermitian)
+    (hρ_AB : (traceC_ABC ρ_ABC).IsHermitian)
+    (hρ_BC : (traceA_ABC ρ_ABC).IsHermitian) :
+    vonNeumannEntropy ρ_ABC hρ_ABC
+      + vonNeumannEntropy (traceAC_ABC ρ_ABC) hρ_B
+    ≤ vonNeumannEntropy (traceC_ABC ρ_ABC) hρ_AB
+      + vonNeumannEntropy (traceA_ABC ρ_ABC) hρ_BC
+
+end StrongSubadditivity

--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -8,7 +8,8 @@ import TNLean.Analysis.Entropy
 # Axiomatized entropy inequalities
 
 This module isolates the axiom for **strong subadditivity** (Lieb–Ruskai 1973)
-so that it does not pollute the stable import surface `TNLean.lean`.
+so that the axiom is clearly separated from the proved results.
+It is imported from the root `TNLean.lean` so that CI validates it.
 
 ## Status
 

--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -13,7 +13,8 @@ so that it does not pollute the stable import surface `TNLean.lean`.
 ## Status
 
 * `strong_subadditivity` is an **axiom** (proof deferred; see TODO below).
-* `subadditivity` is **derived** from `strong_subadditivity` with `dC = 1`.
+* A `subadditivity` result can be derived from `strong_subadditivity` by
+  specializing `dC = 1`; this is left for downstream modules.
 
 ## TODO
 

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -107,6 +107,21 @@ finite-dimensional quantum systems.
     \]
 \end{definition}
 
+\begin{lemma}[Partial trace preserves Hermiticity]\label{lem:trace_isHermitian}
+    \lean{traceA_ABC_isHermitian}
+    \leanok
+    \uses{def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
+    If $\rho_{ABC}$ is Hermitian, then $\tr_A(\rho_{ABC})$,
+    $\tr_C(\rho_{ABC})$, and $\tr_{AC}(\rho_{ABC})$ are all Hermitian.
+    The same holds for bipartite partial traces $\tr_A(\rho_{AB})$ and
+    $\tr_B(\rho_{AB})$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Follows from $\overline{\rho_{ji}} = \rho_{ij}$ applied entry-wise
+    inside the summation defining each partial trace.
+\end{proof}
+
 \section{Strong subadditivity}
 
 \begin{theorem}[Strong subadditivity]\label{thm:strong_subadditivity}

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -58,12 +58,19 @@ finite-dimensional quantum systems.
 
 \begin{theorem}[Entropy upper bound]\label{thm:entropy_le_log_dim}
     \lean{vonNeumannEntropy_le_log_dim}
+    \leanok
     \uses{def:von_neumann_entropy}
     For a density matrix $\rho \in \MN{D}$ with $D \ge 1$,
     \[
         S(\rho) \le \log D.
     \]
 \end{theorem}
+
+\begin{proof}\leanok
+    By Jensen's inequality applied to the concave function $-x \log x$,
+    the entropy is maximized when all eigenvalues equal $1/D$.
+    \uses{lem:density_eigenvalues_sum, thm:density_eigenvalues_le_one}
+\end{proof}
 
 \section{Tripartite partial traces}
 

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -125,6 +125,7 @@ finite-dimensional quantum systems.
 \section{Strong subadditivity}
 
 \begin{theorem}[Strong subadditivity]\label{thm:strong_subadditivity}
+    \lean{strong_subadditivity}
     \uses{def:von_neumann_entropy, def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
     For a tripartite density matrix $\rho_{ABC}$,
     \[

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -110,7 +110,6 @@ finite-dimensional quantum systems.
 \section{Strong subadditivity}
 
 \begin{theorem}[Strong subadditivity]\label{thm:strong_subadditivity}
-    \lean{strong_subadditivity}
     \uses{def:von_neumann_entropy, def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
     For a tripartite density matrix $\rho_{ABC}$,
     \[

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -35,7 +35,7 @@ finite-dimensional quantum systems.
 \end{proof}
 
 \begin{lemma}[Eigenvalue sum]\label{lem:density_eigenvalues_sum}
-    \lean{densityMatrix_eigenvalues_sum_one}
+    \lean{densityMatrices_eigenvalues_sum_one}
     \leanok
     The eigenvalues of a density matrix sum to $1$.
 \end{lemma}
@@ -45,7 +45,7 @@ finite-dimensional quantum systems.
 \end{proof}
 
 \begin{theorem}[Eigenvalue bound]\label{thm:density_eigenvalues_le_one}
-    \lean{densityMatrix_eigenvalues_le_one}
+    \lean{densityMatrices_eigenvalues_le_one}
     \leanok
     \uses{lem:density_eigenvalues_sum}
     Each eigenvalue of a density matrix lies in $[0, 1]$.
@@ -75,7 +75,7 @@ finite-dimensional quantum systems.
 \section{Tripartite partial traces}
 
 \begin{definition}[Partial trace over $A$]\label{def:traceA_ABC}
-    \lean{traceA_ABC}
+    \lean{Matrix.traceA_ABC}
     \leanok
     For a tripartite matrix $\rho_{ABC}$ on
     $\mathbb{C}^{d_A} \otimes \mathbb{C}^{d_B} \otimes \mathbb{C}^{d_C}$,
@@ -87,7 +87,7 @@ finite-dimensional quantum systems.
 \end{definition}
 
 \begin{definition}[Partial trace over $C$]\label{def:traceC_ABC}
-    \lean{traceC_ABC}
+    \lean{Matrix.traceC_ABC}
     \leanok
     The partial trace over $C$:
     \[
@@ -97,7 +97,7 @@ finite-dimensional quantum systems.
 \end{definition}
 
 \begin{definition}[Partial trace over $AC$]\label{def:traceAC_ABC}
-    \lean{traceAC_ABC}
+    \lean{Matrix.traceAC_ABC}
     \leanok
     The partial trace over $A$ and $C$:
     \[
@@ -108,7 +108,7 @@ finite-dimensional quantum systems.
 \end{definition}
 
 \begin{lemma}[Partial trace preserves Hermiticity]\label{lem:trace_isHermitian}
-    \lean{traceA_ABC_isHermitian}
+    \lean{Matrix.traceA_ABC_isHermitian}
     \leanok
     \uses{def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
     If $\rho_{ABC}$ is Hermitian, then $\tr_A(\rho_{ABC})$,

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -1,0 +1,137 @@
+%% =========================================================
+%% Chapter: Quantum Entropy
+%% Von Neumann entropy, strong subadditivity, and mutual information.
+%% =========================================================
+
+\chapter{Quantum Entropy}\label{ch:entropy}
+
+This chapter develops the von Neumann entropy and its basic properties for
+finite-dimensional quantum systems.
+
+\section{Von Neumann entropy}
+
+\begin{definition}[Von Neumann entropy]\label{def:von_neumann_entropy}
+    \lean{vonNeumannEntropy}
+    \leanok
+    For a Hermitian matrix $\rho \in \MN{D}$ with eigenvalues
+    $\lambda_0, \ldots, \lambda_{D-1}$, the \emph{von Neumann entropy} is
+    \[
+        S(\rho) = -\sum_{i=0}^{D-1} \lambda_i \log \lambda_i,
+    \]
+    where $0 \log 0 := 0$.
+\end{definition}
+
+\begin{theorem}[Entropy is non-negative]\label{thm:entropy_nonneg}
+    \lean{vonNeumannEntropy_nonneg}
+    \leanok
+    \uses{def:von_neumann_entropy}
+    For any density matrix $\rho$, $S(\rho) \ge 0$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Each eigenvalue $\lambda_i$ of a density matrix satisfies
+    $0 \le \lambda_i \le 1$, and $-x \log x \ge 0$ on $[0, 1]$.
+    \uses{thm:density_eigenvalues_le_one}
+\end{proof}
+
+\begin{lemma}[Eigenvalue sum]\label{lem:density_eigenvalues_sum}
+    \lean{densityMatrix_eigenvalues_sum_one}
+    \leanok
+    The eigenvalues of a density matrix sum to $1$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Follows from $\tr(\rho) = \sum_i \lambda_i = 1$.
+\end{proof}
+
+\begin{theorem}[Eigenvalue bound]\label{thm:density_eigenvalues_le_one}
+    \lean{densityMatrix_eigenvalues_le_one}
+    \leanok
+    \uses{lem:density_eigenvalues_sum}
+    Each eigenvalue of a density matrix lies in $[0, 1]$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Non-negativity comes from positive semidefiniteness. The upper bound
+    follows because the eigenvalues are non-negative and sum to $1$.
+\end{proof}
+
+\begin{theorem}[Entropy upper bound]\label{thm:entropy_le_log_dim}
+    \lean{vonNeumannEntropy_le_log_dim}
+    \uses{def:von_neumann_entropy}
+    For a density matrix $\rho \in \MN{D}$ with $D \ge 1$,
+    \[
+        S(\rho) \le \log D.
+    \]
+\end{theorem}
+
+\section{Tripartite partial traces}
+
+\begin{definition}[Partial trace over $A$]\label{def:traceA_ABC}
+    \lean{traceA_ABC}
+    \leanok
+    For a tripartite matrix $\rho_{ABC}$ on
+    $\mathbb{C}^{d_A} \otimes \mathbb{C}^{d_B} \otimes \mathbb{C}^{d_C}$,
+    the partial trace over $A$ is
+    \[
+        (\tr_A \rho_{ABC})_{(b_1, c_1)(b_2, c_2)}
+        = \sum_{a=0}^{d_A - 1} (\rho_{ABC})_{(a, b_1, c_1)(a, b_2, c_2)}.
+    \]
+\end{definition}
+
+\begin{definition}[Partial trace over $C$]\label{def:traceC_ABC}
+    \lean{traceC_ABC}
+    \leanok
+    The partial trace over $C$:
+    \[
+        (\tr_C \rho_{ABC})_{(a_1, b_1)(a_2, b_2)}
+        = \sum_{c=0}^{d_C - 1} (\rho_{ABC})_{(a_1, b_1, c)(a_2, b_2, c)}.
+    \]
+\end{definition}
+
+\begin{definition}[Partial trace over $AC$]\label{def:traceAC_ABC}
+    \lean{traceAC_ABC}
+    \leanok
+    The partial trace over $A$ and $C$:
+    \[
+        (\tr_{AC} \rho_{ABC})_{b_1 b_2}
+        = \sum_{a=0}^{d_A - 1} \sum_{c=0}^{d_C - 1}
+          (\rho_{ABC})_{(a, b_1, c)(a, b_2, c)}.
+    \]
+\end{definition}
+
+\section{Strong subadditivity}
+
+\begin{theorem}[Strong subadditivity]\label{thm:strong_subadditivity}
+    \lean{strong_subadditivity}
+    \uses{def:von_neumann_entropy, def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
+    For a tripartite density matrix $\rho_{ABC}$,
+    \[
+        S(\rho_{ABC}) + S(\rho_B)
+        \le S(\rho_{AB}) + S(\rho_{BC}).
+    \]
+\end{theorem}
+
+\begin{definition}[SSA equality]\label{def:ssa_equality}
+    \lean{IsSSAEquality}
+    \leanok
+    \uses{thm:strong_subadditivity}
+    A tripartite density matrix $\rho_{ABC}$ satisfies
+    \emph{SSA equality} if
+    \[
+        S(\rho_{ABC}) + S(\rho_B) = S(\rho_{AB}) + S(\rho_{BC}).
+    \]
+\end{definition}
+
+\section{Mutual information}
+
+\begin{definition}[Mutual information]\label{def:mutual_information}
+    \lean{mutualInformation}
+    \leanok
+    \uses{def:von_neumann_entropy}
+    The \emph{quantum mutual information} of a bipartite state
+    $\rho_{AB}$ is
+    \[
+        I(A{:}B) = S(\rho_A) + S(\rho_B) - S(\rho_{AB}).
+    \]
+\end{definition}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -3,6 +3,7 @@
 \input{chapter/ch02b_mpdo}
 \input{chapter/ch03_single}
 \input{chapter/ch04_channels}
+\input{chapter/ch04b_entropy}
 \input{chapter/ch05_schwarz}
 \input{chapter/ch05_qpf}
 \input{chapter/ch06_spectral}


### PR DESCRIPTION
### Motivation

- Builds quantum entropy infrastructure needed by RFP/MPDO 4/5 (#236) and other downstream work.
- Von Neumann entropy, strong subadditivity, and mutual information are currently a Mathlib gap — none are available.
- See #239 for full design discussion and approach options.

### Description

- Add new module `TNLean/Analysis/Entropy.lean` (332 lines) defining:
  - `vonNeumannEntropy` via Hermitian eigenvalues and `negMulLog`
  - `vonNeumannEntropy_nonneg` for density matrices
  - Tripartite partial traces (`traceA_ABC`, `traceC_ABC`, `traceAC_ABC`)
  - `mutualInformation` and `mutualInformation_nonneg`
  - `IsSSAEquality` predicate for SSA equality condition
- Strong subadditivity and subadditivity are introduced as `axiom`s (Option B from #239), marked with TODO comments for future replacement with proofs from Klein's inequality and Lieb concavity.
- `vonNeumannEntropy_le_log_dim` and `mutualInformation_area_law` left as `sorry` placeholders.
- Re-export new module from `TNLean.lean`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #239

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces a new globally-imported `axiom strong_subadditivity`, which can affect proof soundness/consistency for any downstream developments relying on `TNLean.lean`. The rest is new entropy/partial-trace definitions and lemmas that may require careful review for mathematical correctness.
> 
> **Overview**
> Adds `TNLean.Analysis.Entropy` with a definition of `vonNeumannEntropy` (via Hermitian eigenvalues and `negMulLog`), basic bounds for density matrices (`vonNeumannEntropy_nonneg`, `vonNeumannEntropy_le_log_dim`), tripartite partial trace operators (`traceA_ABC`, `traceC_ABC`, `traceAC_ABC`) and Hermiticity-preservation lemmas, plus `mutualInformation` and an `IsSSAEquality` predicate.
> 
> Introduces `TNLean.Axioms.Entropy` containing an `axiom strong_subadditivity` built on the new entropy/partial-trace API, and re-exports both modules from `TNLean.lean`.
> 
> Extends the blueprint by adding a new “Quantum Entropy” chapter and including it in `blueprint/src/content.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dd358e56d74f2f64f0f08b8b10bdc29f25a802f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->