### PR TITLE
fix(MPS/MPDO): correct IsLPDO definition and discharge isMPDO sorry

### DIFF
--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.Defs
 import TNLean.MPS.Core.Transfer
 import Mathlib.LinearAlgebra.Matrix.PosDef
+import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!
 # MPO, MPDO, and LPDO — basic definitions
@@ -42,7 +43,7 @@ Verstraete):
 * [ZV04] Zwolak, Vidal, PRL 93, 207205 (2004)
 -/
 
-open scoped Matrix ComplexOrder BigOperators
+open scoped Matrix ComplexOrder BigOperators Kronecker
 open Matrix Finset
 
 /-- A (periodic, translation-invariant) **Matrix Product Operator** tensor:
@@ -163,30 +164,112 @@ def IsMPDO (M : MPOTensor d D) : Prop :=
 /-! ### LPDO: local purification -/
 
 /-- An MPO tensor `M` is an **LPDO** (Locally Purifiable Density Operator) if
-there exists an MPS tensor `A` with an enlarged physical index `Fin d × Fin dK`
-(where `dK` is the Kraus/ancilla dimension) such that
+there exists a purifying MPS tensor `A` with ancilla/Kraus dimension `dK`
+and inner bond dimension `D'`, together with an equivalence
+`Fin D ≃ Fin D' × Fin D'`, such that
 
-  `M^{ij} = ∑_k A^{(i,k)} (A^{(j,k)})†`
+  `M^{ij} = ∑_k A^{(i,k)} ⊗ₖ conj(A^{(j,k)})`
 
-for all physical indices `i, j`. This is the local purification condition
-of Verstraete–Garcia-Ripoll–Cirac (2004).
+where `⊗ₖ` is the Kronecker product and `conj` denotes entrywise complex
+conjugation. This is the local purification condition following
+arXiv:1606.00608 §4.3 (Cirac–Pérez-García–Schuch–Verstraete), using the
+Kronecker product to correctly capture the tensor product structure of the
+purifying space.
 
 Not every MPDO is an LPDO (De las Cuevas et al. 2016). -/
 def IsLPDO (M : MPOTensor d D) : Prop :=
-  ∃ (dK : ℕ) (A : Fin d → Fin dK → Matrix (Fin D) (Fin D) ℂ),
-    ∀ i j : Fin d, M i j = ∑ k : Fin dK, A i k * (A j k)ᴴ
+  ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
+    (e : Fin D ≃ Fin D' × Fin D'),
+    ∀ i j : Fin d, M i j = (∑ k : Fin dK,
+      (A i k) ⊗ₖ ((A j k).map (starRingEnd ℂ))).submatrix ↑e ↑e
 
-/-- An LPDO tensor is automatically Hermitian. -/
-theorem IsLPDO.isHermitian {M : MPOTensor d D} (h : IsLPDO M) :
-    IsHermitian M := by
-  obtain ⟨dK, A, hA⟩ := h
-  intro i j
-  rw [hA i j, hA j i, Matrix.conjTranspose_sum]
-  exact Finset.sum_congr rfl fun k _ => by
-    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+/-- The list product of LPDO tensor entries decomposes via Kronecker products
+of the purifying tensor. This is the key technical lemma for `IsLPDO.isMPDO`:
+the product of Kronecker sums expands as a Kronecker sum of products, using
+the mixed-product property `(A ⊗ B)(C ⊗ D) = (AC) ⊗ (BD)`. -/
+private lemma lpdo_prod_decomp {dK D' : ℕ}
+    (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
+    (e : Fin D ≃ Fin D' × Fin D')
+    {M : MPOTensor d D}
+    (hM : ∀ i j : Fin d, M i j = (∑ k : Fin dK,
+      (A i k) ⊗ₖ ((A j k).map (starRingEnd ℂ))).submatrix ↑e ↑e)
+    {N : ℕ} (σ τ : Fin N → Fin d) :
+    (List.ofFn fun l => M (σ l) (τ l)).prod =
+      (∑ κ : Fin N → Fin dK,
+        (List.ofFn fun l => A (σ l) (κ l)).prod ⊗ₖ
+        ((List.ofFn fun l => A (τ l) (κ l)).prod).map
+          (starRingEnd ℂ)).submatrix ↑e ↑e := by
+  induction N with
+  | zero =>
+    simp only [List.ofFn_zero, List.prod_nil, Fintype.sum_unique]
+    have h1 : (1 : Matrix (Fin D') (Fin D') ℂ).map ⇑(starRingEnd ℂ) = 1 :=
+      (starRingEnd ℂ).mapMatrix.map_one
+    rw [h1, Matrix.kroneckerMap_one_one (· * ·) (fun _ => zero_mul _)
+      (fun _ => mul_zero _) (one_mul 1), Matrix.submatrix_one_equiv]
+  | succ n ih =>
+    simp only [List.ofFn_succ, List.prod_cons]
+    rw [hM (σ 0) (τ 0)]
+    have ih_step := ih (σ ∘ Fin.succ) (τ ∘ Fin.succ)
+    simp only [Function.comp_def] at ih_step
+    rw [ih_step, Matrix.submatrix_mul_equiv _ _ (↑e) e (↑e)]
+    -- Strip the submatrix to work at the (Fin D' × Fin D') level
+    congr 1
+    -- Expand LHS product of sums
+    rw [Finset.sum_mul]
+    simp_rw [Finset.mul_sum]
+    -- Apply mixed product property
+    simp_rw [← Matrix.mul_kronecker_mul]
+    -- Combine the conjugated matrices: map star (A) * map star (B) = map star (A * B)
+    have map_star_mul : ∀ (P Q : Matrix (Fin D') (Fin D') ℂ),
+        P.map ⇑(starRingEnd ℂ) * Q.map ⇑(starRingEnd ℂ) =
+        (P * Q).map ⇑(starRingEnd ℂ) :=
+      fun P Q => ((starRingEnd ℂ).mapMatrix.map_mul P Q).symm
+    simp_rw [map_star_mul]
+    -- Reindex RHS: ∑ κ : Fin(n+1) → Fin dK = ∑ k, ∑ κ'
+    symm
+    rw [show ∀ (F : (Fin (n + 1) → Fin dK) →
+        Matrix (Fin D' × Fin D') (Fin D' × Fin D') ℂ),
+      ∑ κ, F κ = ∑ k : Fin dK, ∑ κ' : Fin n → Fin dK,
+        F (Fin.cons k κ') from fun F => by
+          rw [← Fintype.sum_prod_type']
+          exact ((Fin.consEquiv (fun _ : Fin (n + 1) => Fin dK)).sum_comp F).symm]
+    simp only [Fin.cons_zero, Fin.cons_succ]
 
-/-- **TODO** (part 4/5): LPDO implies MPDO. -/
+/-- **LPDO implies MPDO**: every LPDO tensor generates positive semidefinite
+density operators for all system sizes.
+
+The proof uses the Kronecker product structure: the N-site density matrix
+decomposes as `ρ^{(N)} = ∑_κ |ψ_κ⟩⟨ψ_κ|` where each `ψ_κ` is an MPS
+vector built from the purifying tensor, giving a manifestly PSD sum of
+rank-1 positive semidefinite matrices.
+
+See arXiv:1606.00608, §4.3. -/
 theorem IsLPDO.isMPDO {M : MPOTensor d D} (h : IsLPDO M) : IsMPDO M := by
-  sorry
+  obtain ⟨dK, D', A, e, hM⟩ := h
+  intro N
+  -- Define the MPS coefficient vectors from the purifying tensor
+  set ψ : (Fin N → Fin dK) → (Fin N → Fin d) → ℂ :=
+    fun κ σ => Matrix.trace ((List.ofFn fun l => A (σ l) (κ l)).prod) with hψ
+  -- Show mpo M N = ∑ κ, |ψ_κ⟩⟨ψ_κ|, then conclude PSD
+  suffices hmpo : mpo M N = ∑ κ : Fin N → Fin dK,
+      Matrix.vecMulVec (ψ κ) (star (ψ κ)) by
+    rw [hmpo]
+    exact Matrix.posSemidef_sum _ fun κ _ => Matrix.posSemidef_vecMulVec_self_star _
+  -- Prove the matrix equality entry-by-entry
+  ext σ τ
+  simp only [mpo_apply, mpoMatrixEntry, hψ, evalWord_ofFn]
+  -- Apply the Kronecker product decomposition
+  rw [lpdo_prod_decomp A e hM σ τ]
+  -- trace of submatrix = trace (via equiv reindexing)
+  have trace_sub : ∀ (X : Matrix (Fin D' × Fin D') (Fin D' × Fin D') ℂ),
+      Matrix.trace (X.submatrix (↑e) (↑e)) = Matrix.trace X := by
+    intro X; simp only [Matrix.trace, Matrix.diag, Matrix.submatrix_apply]
+    exact e.sum_comp (fun p => X p p)
+  rw [trace_sub, Matrix.trace_sum]
+  simp_rw [Matrix.trace_kronecker]
+  -- trace of entrywise conjugate = conjugate of trace: trace(A.map star) = star(trace A)
+  simp_rw [← AddMonoidHom.map_trace (starRingEnd ℂ)]
+  -- Push σ τ application inside the sum on the RHS, expand vecMulVec
+  erw [Fintype.sum_apply σ, Fintype.sum_apply τ]; congr 1
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -19,7 +19,9 @@ Verstraete):
 * **MPDO** (Matrix Product Density Operator): an MPO whose operator family
   `mpo M N` is positive semidefinite for every system size `N`.
 * **LPDO** (Locally Purifiable Density Operator): an MPO that admits a
-  local MPS purification `M^{ij} = ∑_k A^{(i,k)} (A^{(j,k)})†`.
+  local purification tensor with Kronecker structure,
+  `M^{ij} = (∑_k A^{(i,k)} ⊗ₖ conj(A^{(j,k)})).submatrix ↑e ↑e`,
+  for an identification `e : Fin D ≃ Fin D' × Fin D'` of the bond index.
 
 ## Main definitions
 
@@ -171,10 +173,11 @@ and inner bond dimension `D'`, together with an equivalence
   `M^{ij} = ∑_k A^{(i,k)} ⊗ₖ conj(A^{(j,k)})`
 
 where `⊗ₖ` is the Kronecker product and `conj` denotes entrywise complex
-conjugation. This is the local purification condition following
-arXiv:1606.00608 §4.3 (Cirac–Pérez-García–Schuch–Verstraete), using the
-Kronecker product to correctly capture the tensor product structure of the
-purifying space.
+conjugation, and where the resulting matrix on `Fin D' × Fin D'` is
+reindexed back to `Fin D` via the chosen equivalence `e` (implemented by
+`.submatrix ↑e ↑e`). This is the local purification condition following
+arXiv:1606.00608 §4.3 (Cirac–Pérez-García–Schuch–Verstraete), where the
+auxiliary purification space factors as a tensor product.
 
 Not every MPDO is an LPDO (De las Cuevas et al. 2016). -/
 def IsLPDO (M : MPOTensor d D) : Prop :=
@@ -226,13 +229,14 @@ private lemma lpdo_prod_decomp {dK D' : ℕ}
       fun P Q => ((starRingEnd ℂ).mapMatrix.map_mul P Q).symm
     simp_rw [map_star_mul]
     -- Reindex RHS: ∑ κ : Fin(n+1) → Fin dK = ∑ k, ∑ κ'
-    symm
-    rw [show ∀ (F : (Fin (n + 1) → Fin dK) →
+    have reindex : ∀ (F : (Fin (n + 1) → Fin dK) →
         Matrix (Fin D' × Fin D') (Fin D' × Fin D') ℂ),
       ∑ κ, F κ = ∑ k : Fin dK, ∑ κ' : Fin n → Fin dK,
-        F (Fin.cons k κ') from fun F => by
+        F (Fin.cons k κ') := fun F => by
           rw [← Fintype.sum_prod_type']
-          exact ((Fin.consEquiv (fun _ : Fin (n + 1) => Fin dK)).sum_comp F).symm]
+          exact ((Fin.consEquiv (fun _ : Fin (n + 1) => Fin dK)).sum_comp F).symm
+    symm
+    rw [reindex]
     simp only [Fin.cons_zero, Fin.cons_succ]
 
 /-- **LPDO implies MPDO**: every LPDO tensor generates positive semidefinite

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -145,14 +145,17 @@ legs cyclically and taking the resulting trace.
     \leanok
     \uses{def:mpo_tensor}
     An MPO tensor is an \emph{LPDO} if there exist an ancilla dimension $d_K$,
-    an inner bond dimension $D'$ with $D = (D')^2$, and matrices
-    $A^{(i,k)} \in \MN{D'}$ such that
+    an inner bond dimension $D'$, an identification of bond indices
+    $e : \Fin D \simeq \Fin {D'} \times \Fin {D'}$ (equivalently, $D$ and $(D')^2$
+    have the same cardinality), and matrices $A^{(i,k)} \in \MN{D'}$ such that
     \[
-        M^{ij} = \sum_{k=0}^{d_K-1} A^{(i,k)} \otimes \overline{A^{(j,k)}}
+        M^{ij}
+        = \Bigl(\sum_{k=0}^{d_K-1} A^{(i,k)} \otimes \overline{A^{(j,k)}}\Bigr)_{e,e}
         \qquad \text{for all } i,j,
     \]
-    where $\otimes$ denotes the Kronecker product and $\overline{(\cdot)}$
-    denotes entrywise complex conjugation.
+    where $\otimes$ denotes the Kronecker product, $\overline{(\cdot)}$
+    denotes entrywise complex conjugation, and $(\cdot)_{e,e}$ denotes
+    reindexing along $e$ from $\Fin {D'} \times \Fin {D'}$ back to $\Fin D$.
     This is the local purification form of \cite[\S4.3]{Cirac2017MPDO_AnnPhys}.
 \end{definition}
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -144,45 +144,43 @@ legs cyclically and taking the resulting trace.
     \lean{MPOTensor.IsLPDO}
     \leanok
     \uses{def:mpo_tensor}
-    An MPO tensor is an \emph{LPDO} if there exist an ancilla dimension $d_K$
-    and matrices $A^{(i,k)} \in \MN{D}$ such that
+    An MPO tensor is an \emph{LPDO} if there exist an ancilla dimension $d_K$,
+    an inner bond dimension $D'$ with $D = (D')^2$, and matrices
+    $A^{(i,k)} \in \MN{D'}$ such that
     \[
-        M^{ij} = \sum_{k=0}^{d_K-1} A^{(i,k)} (A^{(j,k)})^\dagger
-        \qquad \text{for all } i,j.
+        M^{ij} = \sum_{k=0}^{d_K-1} A^{(i,k)} \otimes \overline{A^{(j,k)}}
+        \qquad \text{for all } i,j,
     \]
+    where $\otimes$ denotes the Kronecker product and $\overline{(\cdot)}$
+    denotes entrywise complex conjugation.
     This is the local purification form of \cite[\S4.3]{Cirac2017MPDO_AnnPhys}.
-    Diagrammatically, the local LPDO structure is
-    \[
-        \TNLPDO{A}{A^\dagger}{k}{i}{j}
-    \]
-    where the upper node denotes $A^{(i,k)}$, the lower node denotes
-    $(A^{(j,k)})^\dagger$, the ancilla leg $k$ is contracted vertically,
-    and the left and right outer legs are the MPO virtual legs.
 \end{definition}
 
-\begin{theorem}[LPDOs are Hermitian]\label{thm:lpdo_hermitian}
-    \lean{MPOTensor.IsLPDO.isHermitian}
+\begin{theorem}[LPDOs are MPDOs]\label{thm:lpdo_is_mpdo}
+    \lean{MPOTensor.IsLPDO.isMPDO}
     \leanok
-    \uses{def:lpdo, def:mpo_hermitian}
-    Every LPDO tensor is Hermitian.
+    \uses{def:lpdo, def:mpdo}
+    Every LPDO tensor is an MPDO.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{def:lpdo}
-    Write
-    $M^{ij} = \sum_k A^{(i,k)} (A^{(j,k)})^\dagger$.
-    Then
-    \[
-        (M^{ji})^\dagger
-        = \sum_k \left(A^{(j,k)} (A^{(i,k)})^\dagger\right)^\dagger
-        = \sum_k A^{(i,k)} (A^{(j,k)})^\dagger
-        = M^{ij}.
-    \]
-\end{proof}
-
-\begin{theorem}[LPDOs are MPDOs]\label{thm:lpdo_is_mpdo}\notready
-    \lean{MPOTensor.IsLPDO.isMPDO}
     \uses{def:lpdo, def:mpdo}
-    Every LPDO tensor is an MPDO.
-\end{theorem}
+    By the mixed-product property
+    $(A \otimes B)(C \otimes D) = (AC) \otimes (BD)$, the $N$-site product
+    decomposes as
+    \[
+        M^{\sigma_1 \tau_1} \cdots M^{\sigma_N \tau_N}
+        = \sum_{\kappa} P_\kappa \otimes \overline{Q_\kappa},
+    \]
+    where $P_\kappa = A^{(\sigma_1,\kappa_1)} \cdots A^{(\sigma_N,\kappa_N)}$
+    and $Q_\kappa = A^{(\tau_1,\kappa_1)} \cdots A^{(\tau_N,\kappa_N)}$.
+    Taking the trace and using $\tr(X \otimes Y) = \tr(X)\tr(Y)$,
+    \[
+        \rho^{(N)}(M)_{\sigma,\tau}
+        = \sum_\kappa \tr(P_\kappa)\,\overline{\tr(Q_\kappa)}
+        = \sum_\kappa \psi_\kappa(\sigma)\,\overline{\psi_\kappa(\tau)},
+    \]
+    where $\psi_\kappa(\sigma) = \tr(P_\kappa)$.
+    Hence $\rho^{(N)}(M) = \sum_\kappa \ketbra{\psi_\kappa}{\psi_\kappa} \ge 0$.
+\end{proof}


### PR DESCRIPTION
### Motivation

- The previous `IsLPDO` definition used standard matrix multiplication (`M^{ij} = Σ_k A^{(i,k)} (A^{(j,k)})†`), which does not correctly capture the tensor product structure of the purifying space (arXiv:1606.00608 §4.3).
- The `IsLPDO.isMPDO` theorem was left as a `sorry` stub in #370, tracked by #394.

### Description

- **`TNLean/MPS/MPDO/Defs.lean`**: Redefine `IsLPDO` to use Kronecker product (`⊗ₖ`) with entrywise conjugation and a bond dimension equivalence `Fin D ≃ Fin D' × Fin D'`. Prove `IsLPDO.isMPDO` via the mixed-product property, `trace_kronecker`, and a rank-1 PSD decomposition `ρ = Σ_κ |ψ_κ⟩⟨ψ_κ|`. Remove `IsLPDO.isHermitian` (no longer valid under the corrected definition).
- **`blueprint/src/chapter/ch02b_mpdo.tex`**: Update LPDO definition to match the new Kronecker formulation and document the LPDO→MPDO proof.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #394

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the formal `IsLPDO` predicate and removes a previously available lemma, which may break downstream proofs that relied on the old formulation. Adds a nontrivial new Lean proof of `IsLPDO.isMPDO`, touching core tensor-network correctness but not runtime code.
> 
> **Overview**
> Corrects the formal definition of `MPOTensor.IsLPDO` to match the Kronecker-factorized purification in CPGSV17: LPDOs are now expressed via a purifying tensor over an inner bond `D'`, Kronecker product with entrywise conjugation, and a bond reindexing equivalence `e : Fin D ≃ Fin D' × Fin D'`.
> 
> Discharges the previously `sorry`-stubbed `MPOTensor.IsLPDO.isMPDO` by introducing a Kronecker-product decomposition lemma and proving `mpo M N` is a sum of rank-1 PSD terms `∑ κ |ψ_κ⟩⟨ψ_κ|`. Removes the now-outdated `IsLPDO.isHermitian` theorem and updates the blueprint text to reflect the new LPDO definition and LPDO→MPDO result.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fe372ab9401cef13584c09099e9dafd677882b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->