### PR TITLE
feat(Channel/Semigroup): prove factorial norm bound and summability for Dyson series

### DIFF
--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -303,7 +303,7 @@ lemma summable_dysonTerm_of_factorial_bound
 /-- Factorial norm bound for Dyson–Phillips iterates (Wolf Eq. 7.13 estimate).
 For `s ∈ [0, t]` and `M = sup_{u ∈ [0,t]} ‖exp(uL)‖`:
 `‖T̃ⁿ(s)‖ ≤ M · (s · ‖Δ‖ · M)ⁿ / n!`. -/
-theorem norm_dysonTerm_le (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) (n : ℕ)
+theorem norm_dysonTerm_le (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) (n : ℕ)
     {s : ℝ} (hs : s ∈ Set.Icc 0 t) :
     ‖dysonTerm L L' s n‖ ≤
       (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖) *
@@ -374,7 +374,7 @@ theorem norm_dysonTerm_le (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) (n : ℕ)
           ring
 
 /-- Factorial norm bound specialised to `s = t`. -/
-theorem norm_dysonTerm_le_at (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+theorem norm_dysonTerm_le_at (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
     ‖dysonTerm L L' t n‖ ≤
       (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖) *
       ((t * ‖L' - L‖ * (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖)) ^ n /
@@ -382,7 +382,7 @@ theorem norm_dysonTerm_le_at (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
   norm_dysonTerm_le L L' ht n (Set.right_mem_Icc.mpr ht)
 
 /-- The Dyson–Phillips series `∑ₙ T̃ⁿ(t)` converges in operator norm. -/
-theorem summable_dysonTerm (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) :
+theorem summable_dysonTerm (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) :
     Summable (fun n => dysonTerm L L' t n) :=
   summable_dysonTerm_of_factorial_bound L L'
     (fun n => norm_dysonTerm_le_at L L' ht n)

--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -11,6 +11,7 @@ import Mathlib.MeasureTheory.Integral.Bochner.Basic
 import Mathlib.MeasureTheory.Integral.Bochner.Set
 import Mathlib.Analysis.ODE.Gronwall
 import Mathlib.Analysis.Calculus.Deriv.Shift
+import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
 
 /-!
 # Perturbation bound for dynamical semigroups — Wolf Lemma 7.1 and Corollary 7.1
@@ -299,8 +300,91 @@ lemma summable_dysonTerm_of_factorial_bound
   simpa [mul_div_assoc, mul_comm, mul_left_comm, mul_assoc] using
     (Real.summable_pow_div_factorial (t * ‖L' - L‖ * M)).mul_left M
 
--- TODO(#14): combine `norm_dysonTerm_zero_le`/`norm_dysonTerm_succ_le` into a factorial
--- majorant theorem and apply `summable_dysonTerm_of_factorial_bound` in the final
--- Dyson-series convergence/identity statement.
+/-- Factorial norm bound for Dyson–Phillips iterates (Wolf Eq. 7.13 estimate).
+For `s ∈ [0, t]` and `M = sup_{u ∈ [0,t]} ‖exp(uL)‖`:
+`‖T̃ⁿ(s)‖ ≤ M · (s · ‖Δ‖ · M)ⁿ / n!`. -/
+theorem norm_dysonTerm_le (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) (n : ℕ)
+    {s : ℝ} (hs : s ∈ Set.Icc 0 t) :
+    ‖dysonTerm L L' s n‖ ≤
+      (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖) *
+      ((s * ‖L' - L‖ * (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖)) ^ n /
+        ↑(n.factorial)) := by
+  induction n generalizing s with
+  | zero =>
+    simp only [dysonTerm_zero, pow_zero, Nat.factorial_zero,
+      Nat.cast_one, div_one, mul_one]
+    exact norm_expSemigroup_le_biSup L ht hs
+  | succ n ih =>
+    rw [dysonTerm_succ]
+    set M := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖ with hM_def
+    have hs0 : (0 : ℝ) ≤ s := hs.1
+    have hst : s ≤ t := hs.2
+    have hM_nn : 0 ≤ M :=
+      le_trans (norm_nonneg _)
+        (norm_expSemigroup_le_biSup L ht (Set.left_mem_Icc.mpr ht))
+    -- Constant factor in the pointwise bound
+    set C : ℝ := M * ‖L' - L‖ * M * (‖L' - L‖ * M) ^ n / ↑(n.factorial)
+      with hC_def
+    -- Pointwise bound: ‖integrand(u)‖ ≤ C · uⁿ for u ∈ [0, s]
+    have hpw : ∀ u ∈ Set.Icc 0 s,
+        ‖expSemigroupCLM L (s - u) * (L' - L) * dysonTerm L L' u n‖ ≤
+          C * u ^ n := by
+      intro u hu
+      have hu_t : u ∈ Set.Icc 0 t := ⟨hu.1, le_trans hu.2 hst⟩
+      have hsu_t : s - u ∈ Set.Icc 0 t :=
+        ⟨sub_nonneg.mpr hu.2, le_trans (sub_le_self s hu.1) hst⟩
+      calc ‖expSemigroupCLM L (s - u) * (L' - L) * dysonTerm L L' u n‖
+          ≤ ‖expSemigroupCLM L (s - u)‖ * ‖L' - L‖ *
+              ‖dysonTerm L L' u n‖ := by
+            calc _ ≤ ‖expSemigroupCLM L (s - u) * (L' - L)‖ *
+                      ‖dysonTerm L L' u n‖ := norm_mul_le _ _
+              _ ≤ _ := mul_le_mul_of_nonneg_right
+                    (norm_mul_le _ _) (norm_nonneg _)
+        _ ≤ M * ‖L' - L‖ *
+              (M * ((u * ‖L' - L‖ * M) ^ n / ↑(n.factorial))) := by
+            apply mul_le_mul
+            · exact mul_le_mul_of_nonneg_right
+                (norm_expSemigroup_le_biSup L ht hsu_t) (norm_nonneg _)
+            · exact ih hu_t
+            · exact norm_nonneg _
+            · exact mul_nonneg hM_nn (norm_nonneg _)
+        _ = C * u ^ n := by simp only [hC_def, mul_pow]; ring
+    -- Convert set integral to interval integral
+    rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hs0]
+    -- Integrability of the bound function
+    have hCu_int : IntervalIntegrable (fun u => C * u ^ n) volume 0 s :=
+      (continuous_const.mul (continuous_pow n)).intervalIntegrable 0 s
+    -- Bound norm of interval integral, then compute
+    calc ‖∫ u in (0 : ℝ)..s, expSemigroupCLM L (s - u) * (L' - L) *
+            dysonTerm L L' u n‖
+        ≤ ∫ u in (0 : ℝ)..s, C * u ^ n :=
+          intervalIntegral.norm_integral_le_of_norm_le hs0
+            (ae_of_all _ fun u hu =>
+              hpw u (Set.Ioc_subset_Icc_self hu)) hCu_int
+      _ = C * (s ^ (n + 1) / ((n : ℝ) + 1)) := by
+          rw [intervalIntegral.integral_const_mul, integral_pow,
+              zero_pow (Nat.succ_ne_zero n), sub_zero]
+      _ = M * ((s * ‖L' - L‖ * M) ^ (n + 1) /
+            ↑((n + 1).factorial)) := by
+          rw [hC_def, Nat.factorial_succ, Nat.cast_mul, Nat.cast_succ]
+          have : (↑(n.factorial) : ℝ) ≠ 0 :=
+            Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero n)
+          have : (↑n : ℝ) + 1 ≠ 0 := by positivity
+          field_simp
+          ring
+
+/-- Factorial norm bound specialised to `s = t`. -/
+theorem norm_dysonTerm_le_at (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) (n : ℕ) :
+    ‖dysonTerm L L' t n‖ ≤
+      (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖) *
+      ((t * ‖L' - L‖ * (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖)) ^ n /
+        ↑(n.factorial)) :=
+  norm_dysonTerm_le L L' ht n (Set.right_mem_Icc.mpr ht)
+
+/-- The Dyson–Phillips series `∑ₙ T̃ⁿ(t)` converges in operator norm. -/
+theorem summable_dysonTerm (L L' : CLM D) {t : ℝ} (ht : 0 ≤ t) :
+    Summable (fun n => dysonTerm L L' t n) :=
+  summable_dysonTerm_of_factorial_bound L L'
+    (fun n => norm_dysonTerm_le_at L L' ht n)
 
 end -- noncomputable section

--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -246,50 +246,6 @@ noncomputable def dysonTerm
       ∫ s in Set.Icc 0 t,
         expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n := rfl
 
-/-- Zeroth Dyson term is controlled by the same compact-interval `iSup` used above. -/
-lemma norm_dysonTerm_zero_le
-    (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) :
-    ‖dysonTerm L L' t 0‖ ≤ ⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖ := by
-  simpa [dysonTerm] using
-    (norm_expSemigroup_le_biSup (L := L) (t := t) ht (x := t) (Set.right_mem_Icc.mpr ht))
-
-/-- One-step norm estimate for the Dyson recursion.
-This is the inductive estimate used to bootstrap higher-order bounds. -/
-lemma norm_dysonTerm_succ_le
-    (L L' : MatrixCLM (Fin D)) {t K : ℝ} (ht : 0 ≤ t) (n : ℕ)
-    (hK : ∀ s ∈ Set.Icc 0 t, ‖dysonTerm L L' s n‖ ≤ K) :
-    ‖dysonTerm L L' t (n + 1)‖ ≤
-      t *
-        (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖) * ‖L' - L‖ * K := by
-  rw [dysonTerm_succ]
-  set M : ℝ := ⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖
-  have hmeas : volume (Set.Icc (0 : ℝ) t) < ⊤ := by
-    rw [Real.volume_Icc]
-    exact ENNReal.ofReal_lt_top
-  have hpointwise : ∀ s ∈ Set.Icc 0 t,
-      ‖expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n‖ ≤ M * ‖L' - L‖ * K := by
-    intro s hs
-    calc ‖expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n‖
-        ≤ ‖expSemigroupCLM L (t - s) * (L' - L)‖ * ‖dysonTerm L L' s n‖ := norm_mul_le _ _
-      _ ≤ ‖expSemigroupCLM L (t - s)‖ * ‖L' - L‖ * ‖dysonTerm L L' s n‖ :=
-          mul_le_mul_of_nonneg_right (norm_mul_le _ _) (norm_nonneg _)
-      _ ≤ M * ‖L' - L‖ * K := by
-          apply mul_le_mul (mul_le_mul_of_nonneg_right ?_ (norm_nonneg _)) ?_
-            (norm_nonneg _) (mul_nonneg ?_ (norm_nonneg _))
-          · exact norm_expSemigroup_le_biSup L ht
-              ⟨sub_nonneg.mpr hs.2, sub_le_self t hs.1⟩
-          · exact hK s hs
-          · exact le_trans (norm_nonneg _)
-              (norm_expSemigroup_le_biSup L ht (Set.left_mem_Icc.mpr ht))
-  calc ‖∫ s in Set.Icc 0 t, expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n‖
-      ≤ M * ‖L' - L‖ * K * (volume (Set.Icc (0 : ℝ) t)).toReal :=
-        norm_setIntegral_le_of_norm_le_const hmeas hpointwise
-    _ = t * M * ‖L' - L‖ * K := by
-        rw [Real.volume_Icc, ENNReal.toReal_ofReal (by linarith : (0 : ℝ) ≤ t - 0)]
-        ring
-    _ = t * (⨆ s ∈ Set.Icc 0 t, ‖expSemigroupCLM L s‖) * ‖L' - L‖ * K := by
-        simp [M, mul_left_comm, mul_comm]
-
 /-- Summability criterion for Dyson terms from a factorial majorant.
 This packages the M-test step independently of the inductive norm proof. -/
 lemma summable_dysonTerm_of_factorial_bound

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -196,6 +196,39 @@ and proves the GKSL theorem.
     $\sum_n a^n/n!$ and lifting via norm-bounded summability.
 \end{proof}
 
+\begin{theorem}[Factorial norm bound for Dyson iterates]
+    \label{thm:norm_dysonTerm_le_ch12}
+    \lean{norm_dysonTerm_le}\leanok
+    For $s \in [0,t]$ and $M = \sup_{u \in [0,t]} \|e^{uL}\|$,
+    \[
+      \|\widetilde{T}^{(n)}_s\|
+      \le M\,\frac{(s\,\|\Delta\|\,M)^n}{n!}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Induction on $n$. The base case uses the semigroup supremum bound.
+    The inductive step bounds the integrand pointwise by
+    $M\|\Delta\| \cdot M(u\|\Delta\|M)^n/n!$ and integrates
+    $\int_0^s u^n\,du = s^{n+1}/(n+1)$, recovering the factorial.
+\end{proof}
+
+\begin{corollary}[Dyson series summability]
+    \label{cor:summable_dysonTerm_ch12}
+    \lean{summable_dysonTerm}\leanok
+    The Dyson--Phillips series $\sum_n \widetilde{T}^{(n)}_t$
+    converges in operator norm for every $t \ge 0$.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    Compose the factorial norm bound
+    (Theorem~\ref{thm:norm_dysonTerm_le_ch12}) with the
+    Weierstrass M-test step
+    (Lemma~\ref{lem:summable_dyson_factorial_ch12}).
+\end{proof}
+
 %% ---------------------------------------------------------
 \section{GKSL/Lindblad generators}
 \label{sec:gksl_generators}

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -199,6 +199,7 @@ and proves the GKSL theorem.
 \begin{theorem}[Factorial norm bound for Dyson iterates]
     \label{thm:norm_dysonTerm_le_ch12}
     \lean{norm_dysonTerm_le}\leanok
+    \uses{def:exp_semigroup_ch12}
     For $s \in [0,t]$ and $M = \sup_{u \in [0,t]} \|e^{uL}\|$,
     \[
       \|\widetilde{T}^{(n)}_s\|
@@ -208,6 +209,7 @@ and proves the GKSL theorem.
 
 \begin{proof}
     \leanok
+    \uses{def:exp_semigroup_ch12}
     Induction on $n$. The base case uses the semigroup supremum bound.
     The inductive step bounds the integrand pointwise by
     $M\|\Delta\| \cdot M(u\|\Delta\|M)^n/n!$ and integrates
@@ -217,12 +219,14 @@ and proves the GKSL theorem.
 \begin{corollary}[Dyson series summability]
     \label{cor:summable_dysonTerm_ch12}
     \lean{summable_dysonTerm}\leanok
+    \uses{thm:norm_dysonTerm_le_ch12}
     The Dyson--Phillips series $\sum_n \widetilde{T}^{(n)}_t$
     converges in operator norm for every $t \ge 0$.
 \end{corollary}
 
 \begin{proof}
     \leanok
+    \uses{thm:norm_dysonTerm_le_ch12, lem:summable_dyson_factorial_ch12}
     Compose the factorial norm bound
     (Theorem~\ref{thm:norm_dysonTerm_le_ch12}) with the
     Weierstrass M-test step


### PR DESCRIPTION
### Motivation

- Continues formalization of Wolf Ch7 Dyson–Phillips series (Eq. 7.13), see LionSR/QICLean#96.
- Items 1–3 of the issue (factorial norm bound, summability, composed summability) remain to be proved after the recursive definition and Duhamel formula were established.
- **Replaces LionSR/TNLean#441** (rebased onto 4.29, fixed `CLM D` → `MatrixCLM (Fin D)` type error).

### Description

- Prove `norm_dysonTerm_le`: factorial norm bound `‖T̃ⁿ(s)‖ ≤ M·(s·‖Δ‖·M)ⁿ/n!` by induction, using pointwise integrand bounds and `∫₀ˢ uⁿ du = sⁿ⁺¹/(n+1)` via Mathlib's `integral_pow`
- Prove `norm_dysonTerm_le_at`: specialization at `s = t`
- Prove `summable_dysonTerm`: Dyson–Phillips series converges in operator norm for all `t ≥ 0`, composing the factorial bound with `summable_dysonTerm_of_factorial_bound`
- Update blueprint entries in `blueprint/src/chapter/ch12_semigroup.tex`

### Changes from LionSR/TNLean#441

- Rebased onto main (post Lean 4.29 / Mathlib 4.29.0 upgrade via LionSR/TNLean#445)
- Resolved import conflict (kept both `Calculus.Deriv.Shift` + `SpecialFunctions.Integrals.Basic`)
- Fixed type error: `CLM D` → `MatrixCLM (Fin D)` in 3 theorem signatures (`norm_dysonTerm_le`, `norm_dysonTerm_le_at`, `summable_dysonTerm`) — `CLM` was a private abbrev in a different file

### Testing

- [x] Conflict-free against main
- [ ] Full `lake build` in CI
- [ ] `leanblueprint checkdecls` passes

---
Addresses LionSR/QICLean#96
Replaces LionSR/TNLean#441

https://claude.ai/code/session_01UbMHjYpWaC2rc21c4aX8LB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems and a Mathlib import to support an integral identity, without changing existing semantics outside proof obligations.
> 
> **Overview**
> Adds a formal **factorial norm bound** for Dyson–Phillips iterates (`norm_dysonTerm_le` plus the `s=t` specialization) and uses it to prove **operator-norm summability** of the Dyson series (`summable_dysonTerm`) via the existing factorial-majorant M-test lemma.
> 
> Removes the earlier ad-hoc `0`/`succ` norm estimate lemmas, and updates the blueprint to document the new theorem and corollary. Also adds a Mathlib import for special-function integrals to use `integral_pow` in the inductive step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b28e7375fe667f74a3aa1b25e03e28e7372de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->