### PR TITLE
fix(MPS/CanonicalForm): discharge sorry in IsCyclicSectorDecomp witness extraction

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -837,8 +837,12 @@ theorem transferMap_adjoint_blocked_eq_pow
 
 For an irreducible TP tensor `A` of period `m`, after blocking by `m`, the blocked tensor
 `blockTensor A m` admits a sector decomposition into `m` TP blocks via the cyclic
-spectral projections. Each sector is left-canonical and the direct-sum tensor is
-`SameMPV₂`-equivalent to the blocked tensor. -/
+spectral projections. Returns:
+- `blocks k`: TP sector tensors (each left-canonical),
+- `P k`: orthogonal projections forming a partition of unity (`∑ P k = 1`),
+- commutation: each `P k` commutes with every blocked letter,
+- trace relation: `mpv (blocks k) σ = (P k * evalWord (blockTensor A m) σ).trace`,
+- MPV equivalence: the direct-sum tensor is `SameMPV₂`-equivalent to the blocked tensor. -/
 theorem exists_cyclic_sector_decomp_after_blocking
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -716,7 +716,7 @@ private lemma cyclicShift_succ {m : ℕ} [NeZero m] (k : Fin m) (n : ℕ) :
 
 /-- Iterating the cyclic relation `E†(P(k+1)) = P_k` exactly `m` times gives
 `(E†)^m (P_k) = P_k`. -/
-private theorem adjointTransferMap_pow_fixes_cyclic_projection
+theorem adjointTransferMap_pow_fixes_cyclic_projection
     {d D m : ℕ} [NeZero m]
     (K : Fin d → MatrixAlg D)
     (P : Fin m → MatrixAlg D)
@@ -791,7 +791,7 @@ This is proved by passing to Frobenius adjoints. First,
 family `blockTensor A m`. Second, `transferMap (blockTensor A m) = (transferMap A)^m` by
 `transferMap_blockTensor`. Finally, adjoint commutes with powers, so
 `((transferMap A)^m).adjoint = ((transferMap A).adjoint)^m`. -/
-private theorem transferMap_adjoint_blocked_eq_pow
+theorem transferMap_adjoint_blocked_eq_pow
     {d D : ℕ} (A : MPSTensor d D) (m : ℕ) (X : MatrixAlg D) :
     transferMap (d := blockPhysDim d m) (D := D) (fun j => (blockTensor A m j)ᴴ) X =
       ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) X := by
@@ -850,9 +850,16 @@ theorem exists_cyclic_sector_decomp_after_blocking
     {γ : ℂ} (hγprim : IsPrimitiveRoot γ m)
     (hperiph : peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
       Set.range (fun j : Fin m => γ ^ (j : ℕ))) :
-    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+      (P : Fin m → MatrixAlg D),
       (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
-      SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) := by
+      SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) ∧
+      (∀ k, IsOrthogonalProjection (P k)) ∧
+      (∑ k : Fin m, P k = 1) ∧
+      (∀ k (i : Fin (blockPhysDim d m)),
+        P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
+      (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+        mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace) := by
   -- Step 1: Get cyclic decomposition data
   let K : Fin d → MatrixAlg D := fun i => (A i)ᴴ
   have hUnital : IsUnitalKraus (d := d) (D := D) K := by
@@ -876,8 +883,16 @@ theorem exists_cyclic_sector_decomp_after_blocking
       (blockTensor A m i)ᴴ * blockTensor A m i = 1 :=
     leftCanonical_blockTensor (d := d) (D := D) (A := A) (L := m) hTP
   -- Step 5: Apply the CyclicSectors decomposition
-  exact exists_blockDecomp_of_adjoint_fixed_projections
+  obtain ⟨dim, blocks, hLC, hMPV_hTrace⟩ := exists_blockDecomp_of_adjoint_fixed_projections
     (blockTensor A m) P hPproj hPsum hTP_blocked hFix
+  obtain ⟨hMPV, hTrace⟩ := hMPV_hTrace
+  -- Step 6: Derive commutation from the adjoint fix property
+  have hComm : ∀ k (i : Fin (blockPhysDim d m)),
+      P k * (blockTensor A m) i = (blockTensor A m) i * P k := by
+    intro k i
+    exact commutes_letters_of_adjoint_fixed_projection
+      (blockTensor A m) hTP_blocked (hP := hPproj k) (hFix := hFix k) i
+  exact ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hComm, hTrace⟩
 
 end CyclicSectorBridge
 
@@ -970,7 +985,7 @@ theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
     rw [hperiph_set]; ext x; simp [Set.mem_range, eq_comm]
   -- Apply exists_cyclic_sector_decomp_after_blocking.
   haveI : NeZero m := ⟨by omega⟩
-  obtain ⟨dim, blocks, hTP_blocks, hSame⟩ :=
+  obtain ⟨dim, blocks, _, hTP_blocks, hSame, _, _, _, _⟩ :=
     exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim
       hperiph_range
   exact ⟨m, hm_pos, dim, blocks, hTP_blocks, hSame⟩

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -523,7 +523,9 @@ theorem exists_blockDecomp_of_commuting_projections
     (hComm : ∀ k : Fin m, ∀ i : Fin d, P k * A i = A i * P k) :
     ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k)),
       (∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1) ∧
-      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) := by
+      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
+      (∀ k (N : ℕ) (σ : Fin N → Fin d),
+        mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace) := by
   -- For each k, sector tensor P_k * A_i is P_k-supported
   have hSectorSupp : ∀ k i, P k * (P k * A i) * P k = P k * A i := by
     intro k i
@@ -535,16 +537,22 @@ theorem exists_blockDecomp_of_commuting_projections
     have hterm : ∀ i, (P k * A i)ᴴ * (P k * A i) = (A i)ᴴ * A i * P k := by
       intro i
       rw [Matrix.conjTranspose_mul, Matrix.mul_assoc]
-      -- Goal: (A i)ᴴ * ((P k)ᴴ * (P k * A i)) = (A i)ᴴ * A i * P k
       rw [← Matrix.mul_assoc (P k)ᴴ (P k) (A i), (hPproj k).1.eq, (hPproj k).2]
-      -- Goal: (A i)ᴴ * (P k * A i) = (A i)ᴴ * A i * P k
       rw [hComm k i, ← Matrix.mul_assoc]
     simp_rw [hterm, ← Finset.sum_mul, hLeft, Matrix.one_mul]
   -- Apply compression to each sector
   choose dim blocks hDim hTPblocks hMPVblocks using fun k =>
     exists_compressedTensor_of_supported_projection
       (fun i => P k * A i) (P k) (hPproj k) (hSectorSupp k) (hSectorTP k)
-  refine ⟨dim, blocks, hTPblocks, ?_⟩
+  -- Per-sector trace relation: mpv(blocks k) σ = tr(P_k · evalWord A σ)
+  have hSectorTrace : ∀ k (N : ℕ) (σ : Fin N → Fin d),
+      mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace := by
+    intro k N σ
+    rw [hMPVblocks k N σ]
+    congr 1
+    exact left_mul_evalWord_leftSectorTensor_of_commutes (P k) A (hPproj k).2 (hComm k) _
+  refine ⟨dim, blocks, hTPblocks, ?_, hSectorTrace⟩
+  -- SameMPV₂ follows from summing per-sector traces over the projection partition
   intro N σ
   rw [mpv_toTensorFromBlocks_eq_sum]; simp only [one_pow, one_smul]
   simp only [mpv, coeff]
@@ -553,27 +561,7 @@ theorem exists_blockDecomp_of_commuting_projections
   rw [show (1 : MatrixAlg D) = ∑ k : Fin m, P k from hPsum.symm]
   rw [Finset.sum_mul, Matrix.trace_sum]
   congr 1; ext k
-  -- Need: tr(P k * evalWord A w) = mpv(blocks k) σ
-  -- hMPVblocks k says: mpv(blocks k) σ = tr(P k * evalWord (fun i => P k * A i) w)
-  -- But evalWord(P k * A_i)(w) = evalWord A_i (w) when P_k commutes with A_i, because
-  -- P_k * A_i₁ * P_k * A_i₂ * ... = P_k * A_i₁ * A_i₂ * ... (using P² = P and commutation)
-  -- Actually, evalWord(P k * A)(w) ≠ P k * evalWord A w in general!
-  -- evalWord(P k * A)(j :: w) = (P k * A j) * evalWord(P k * A)(w)
-  -- For non-empty w with P² = P and P Ai = Ai P:
-  -- evalWord(P * A)(w) = P * A_j * P * ... * P * A_jn
-  -- Using PA = AP: = P^n * A_j * ... * A_jn = P * evalWord A w
-  -- The sector trace can be computed using the left-sector tensor, even for the empty word.
-  have htrace_sector :
-      (P k * evalWord A (List.ofFn σ)).trace =
-        (P k * evalWord (leftSectorTensor (P k) A) (List.ofFn σ)).trace := by
-    congr 1
-    exact
-      (left_mul_evalWord_leftSectorTensor_of_commutes (P k) A (hPproj k).2 (hComm k) _).symm
-  rw [htrace_sector]
-  -- leftSectorTensor (P k) A = fun i => P k * A i by definition
-  change (P k * evalWord (fun i => P k * A i) (List.ofFn σ)).trace =
-      ((blocks k).evalWord (List.ofFn σ)).trace
-  rw [← hMPVblocks k N σ, mpv, coeff]
+  exact (hSectorTrace k N σ).symm
 
 end CommutingProjectionDecomposition
 
@@ -613,7 +601,9 @@ theorem exists_blockDecomp_of_adjoint_fixed_projections
     (hFix : ∀ k : Fin m, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) = P k) :
     ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k)),
       (∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1) ∧
-      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) := by
+      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
+      (∀ k (N : ℕ) (σ : Fin N → Fin d),
+        mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace) := by
   have hComm : ∀ k : Fin m, ∀ i : Fin d, P k * A i = A i * P k := by
     intro k i
     exact commutes_letters_of_adjoint_fixed_projection

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -189,19 +189,10 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
           _ = (ω ^ m) ^ (j : ℕ) := by rw [pow_mul]
           _ = 1 := by simp [hωprim.pow_eq_one]
       simpa [hperiph_roots] using hpow
-  obtain ⟨dim, blocks, hLC, hMPV⟩ := exists_cyclic_sector_decomp_after_blocking
-    A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
-  exact ⟨dim, blocks, hLC, hMPV, by
-    -- The projections P are produced internally by
-    -- `exists_cyclic_decomposition_of_irreducible_schwarz` inside
-    -- `exists_cyclic_sector_decomp_after_blocking`, but are not exposed in
-    -- its return type. Closing this sorry requires either:
-    --   (a) making `transferMap_adjoint_blocked_eq_pow` and
-    --       `adjointTransferMap_pow_fixes_cyclic_projection` public in Assembly.lean, or
-    --   (b) duplicating ~80 lines of proof to re-derive the blocked fixed-point
-    --       property from scratch.
-    -- Both options exceed the scope of this statement-refactoring PR.
-    sorry⟩
+  obtain ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hComm, hTrace⟩ :=
+    exists_cyclic_sector_decomp_after_blocking
+      A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
+  exact ⟨dim, blocks, hLC, hMPV, P, hPproj, hPsum, hComm, hTrace⟩
 
 /-! ## Self-overlap (first paragraph of Appendix A) -/
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1045,6 +1045,9 @@ The following results separate the zero blocks from the
 	Then there exist left-canonical blocks $(C_k)_{k=1}^m$
 	with unit weights such that $A$ generates the same MPV family
 	as $\bigoplus_{k=1}^m C_k$.
+	Moreover, each sector satisfies the per-sector trace relation
+	$\operatorname{mpv}(C_k, \sigma) = \operatorname{tr}(P_k \cdot A^{i_1} \cdots A^{i_N})$
+	for every word $\sigma = (i_1, \dots, i_N)$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1067,7 +1070,8 @@ The following results separate the zero blocks from the
 	that are fixed by the adjoint transfer map:
 	$\E_A^\dagger(P_k) = P_k$ for every $k$.
 	Then the same block decomposition conclusion holds as in
-	Theorem~\ref{thm:blockdecomp_commuting_projs}.
+	Theorem~\ref{thm:blockdecomp_commuting_projs}, including the
+	per-sector trace relation.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
### Motivation

- Discharge the `sorry` in `exists_cyclic_sector_decomp_after_blocking_of_isPeriodic` introduced during the compressed corner API refactor (#453), where cyclic spectral projections `P` were produced internally but not exposed in the return type.
- Follows resolution path (a) from the issue: make internal helpers public and thread projections through the API, improving the surface for downstream use.

### Description

- **`TNLean/MPS/CanonicalForm/Assembly.lean`**: Make `adjointTransferMap_pow_fixes_cyclic_projection` and `transferMap_adjoint_blocked_eq_pow` public.
- **`TNLean/MPS/CanonicalForm/CyclicSectors.lean`**: Extend `exists_blockDecomp_of_commuting_projections` and `exists_blockDecomp_of_adjoint_fixed_projections` to return the per-sector trace relation.
- **`TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean`**: Expand `exists_cyclic_sector_decomp_after_blocking` return type to expose projections `P` with orthogonality, partition, commutation, and trace properties; discharge the sorry by constructing `IsCyclicSectorDecomp` from the exposed data.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #457

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes theorem visibility and strengthens several key decomposition theorem return types, requiring downstream updates and potentially breaking proofs that pattern-match on the old signatures.
> 
> **Overview**
> Discharges the remaining `sorry` in periodic cyclic-sector witness extraction by **threading the cyclic spectral projections `P` through the cyclic-sector decomposition API** and returning their key properties (orthogonal projection, partition of unity, commutation with blocked letters, and a per-sector trace/MPV identity).
> 
> Makes the helper lemmas `adjointTransferMap_pow_fixes_cyclic_projection` and `transferMap_adjoint_blocked_eq_pow` public, extends `exists_blockDecomp_of_commuting_projections`/`exists_blockDecomp_of_adjoint_fixed_projections` to also return the per-sector trace relation, updates `exists_cyclic_sector_decomp_after_blocking` accordingly, and updates `FundamentalTheorem/PeriodicOverlap.lean` to use the enriched result instead of the previous placeholder proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee808a852f2648d432022b1fce6df264723b3136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->