### PR TITLE
feat(MPS/RFP): prove rg_flow_converges_of_cf (Appendix B convergence)

### DIFF
--- a/TNLean/MPS/RFP/Convergence.lean
+++ b/TNLean/MPS/RFP/Convergence.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.BNT.Construction
 import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.QuantitativeGap
 import TNLean.MPS.RFP.Defs
 
 /-!
@@ -28,7 +29,7 @@ converges to an idempotent (the RFP).
 TODO: formalize the convergence in operator norm.
 -/
 
-open scoped Matrix
+open scoped Matrix ComplexOrder
 
 namespace MPSTensor
 
@@ -40,7 +41,12 @@ iterated blocking `E^{2^n}` converges to an idempotent transfer map.
 The convergence is entry-wise on the `D² × D²` transfer matrix space:
 `∀ ρ, (E^{2^n}) ρ → E_∞ ρ` where `E_∞ ∘ E_∞ = E_∞`.
 
-TODO: prove. -/
+The proof uses the spectral gap: for each block `k`, injectivity implies
+primitivity of the transfer map, giving `E^n = P + N^n` where `P` is the
+fixed-point projection (idempotent) and `N = E - P` has spectral radius `< 1`.
+The exponential bound `‖E^n X - P X‖ ≤ C(1-δ)^n ‖X‖` from
+`exponential_convergence_of_primitive` then gives pointwise convergence
+`E^n X → P X`, and composing with `2^n → ∞` yields the result. -/
 theorem rg_flow_converges_of_cf {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalForm μ A) (k : Fin r) :
@@ -52,6 +58,50 @@ theorem rg_flow_converges_of_cf {r : ℕ} {dim : Fin r → ℕ}
           (fun n : ℕ => ((transferMap (A k) ^ (2 ^ n : ℕ) : _) ρ))
           Filter.atTop
           (nhds (E_infty ρ)) := by
-  sorry
+  classical
+  have hInj := hCF.block_injective k
+  have hNorm := hCF.leftCanonical k
+  -- Obtain the unique positive-definite fixed point (quantum Perron-Frobenius).
+  obtain ⟨ρ₀, hufp⟩ := injective_transfer_unique_fixed_point' (A k) hInj hNorm
+  -- Handle the degenerate dim k = 0 case (0×0 matrices are a subsingleton).
+  by_cases hDk : dim k = 0
+  · haveI : IsEmpty (Fin (dim k)) := by rw [hDk]; exact Fin.isEmpty
+    have heq : ∀ (a b : Matrix (Fin (dim k)) (Fin (dim k)) ℂ), a = b :=
+      fun a b => funext fun i => IsEmpty.elim ‹_› i
+    exact ⟨0, LinearMap.ext fun x => heq _ _, fun x =>
+      tendsto_const_nhds.congr fun _ => heq _ _⟩
+  · -- Main case: dim k ≥ 1.
+    haveI : NeZero (dim k) := ⟨hDk⟩
+    have htr : Matrix.trace ρ₀ ≠ 0 := ne_of_gt hufp.pos_def.trace_pos
+    -- The witness is the rank-one fixed-point projection P(X) = (tr X / tr ρ₀) • ρ₀.
+    refine ⟨fixedPointProj ρ₀ htr,
+      fixedPointProj_mul_self (ρ := ρ₀) (htr := htr), fun X => ?_⟩
+    -- Exponential convergence bound from QuantitativeGap.
+    obtain ⟨C, δ, hC, hδ, hδ1, hbound⟩ :=
+      exponential_convergence_of_primitive (A k) hNorm hInj ρ₀ hufp.pos_def hufp.fixed
+    -- Step 1: E^n X → P X for all n (not just 2^n).
+    have h_allN : Filter.Tendsto (fun n => (transferMap (A k) ^ n) X)
+        Filter.atTop (nhds (fixedPointProj ρ₀ htr X)) := by
+      -- Norm bound: ‖(E^n) X - P X‖ ≤ C · (1-δ)^n · ‖X‖.
+      have h_norm_bound : ∀ n, ‖(transferMap (A k) ^ n) X - fixedPointProj ρ₀ htr X‖ ≤
+          C * (1 - δ) ^ n * ‖X‖ := fun n => by
+        rw [Module.End.pow_apply]; exact hbound n X
+      -- The bounding sequence C · (1-δ)^n · ‖X‖ → 0.
+      have h_rate : Filter.Tendsto (fun n => C * (1 - δ) ^ n * ‖X‖)
+          Filter.atTop (nhds 0) := by
+        have h_pow := tendsto_pow_atTop_nhds_zero_of_lt_one
+          (by linarith : (0 : ℝ) ≤ 1 - δ)
+          (by linarith : 1 - δ < 1)
+        have h_mul := h_pow.const_mul (C * ‖X‖)
+        simp only [mul_zero] at h_mul
+        exact h_mul.congr fun n => by ring
+      -- Squeeze: difference → 0, hence E^n X → P X.
+      have h_zero := squeeze_zero_norm h_norm_bound h_rate
+      have h_add := h_zero.add (tendsto_const_nhds (x := fixedPointProj ρ₀ htr X))
+      simp only [sub_add_cancel, zero_add] at h_add
+      exact h_add
+    -- Step 2: compose with the subsequence 2^n → ∞.
+    exact h_allN.comp
+      (tendsto_pow_atTop_atTop_of_one_lt (show (1 : ℕ) < 2 by norm_num))
 
 end MPSTensor

--- a/TNLean/MPS/RFP/Convergence.lean
+++ b/TNLean/MPS/RFP/Convergence.lean
@@ -66,10 +66,8 @@ theorem rg_flow_converges_of_cf {r : ℕ} {dim : Fin r → ℕ}
   -- Handle the degenerate dim k = 0 case (0×0 matrices are a subsingleton).
   by_cases hDk : dim k = 0
   · haveI : IsEmpty (Fin (dim k)) := by rw [hDk]; exact Fin.isEmpty
-    have heq : ∀ (a b : Matrix (Fin (dim k)) (Fin (dim k)) ℂ), a = b :=
-      fun a b => funext fun i => IsEmpty.elim ‹_› i
-    exact ⟨0, LinearMap.ext fun x => heq _ _, fun x =>
-      tendsto_const_nhds.congr fun _ => heq _ _⟩
+    refine ⟨0, LinearMap.ext fun x => Subsingleton.elim _ _, fun x => ?_⟩
+    exact tendsto_const_nhds.congr fun _ => Subsingleton.elim _ _
   · -- Main case: dim k ≥ 1.
     haveI : NeZero (dim k) := ⟨hDk⟩
     have htr : Matrix.trace ρ₀ ≠ 0 := ne_of_gt hufp.pos_def.trace_pos

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -264,7 +264,7 @@ All three quantitative results below are now fully proved.
     \lean{MPSTensor.rg_flow_converges_of_cf}
     \leanok
     \uses{def:is_canonical_form, def:transfer_map, def:fixed_point_proj,
-          thm:exponential_convergence_of_primitive}
+          thm:exponential_convergence_primitive}
     For a tensor in canonical form with blocks $(A_k)$ and weights $(\mu_k)$,
     the iterated blocking $\E_{A_k}^{2^n}$ converges pointwise to an
     idempotent linear map $\E_\infty$ as $n\to\infty$.
@@ -277,7 +277,7 @@ All three quantitative results below are now fully proved.
     primitive channel with a unique positive-definite fixed point $\rho_0$.
     The exponential convergence bound
     $\lVert \E^n(X) - P(X)\rVert \le C(1-\delta)^n \lVert X\rVert$
-    (Theorem~\ref{thm:exponential_convergence_of_primitive}) then gives
+    (Theorem~\ref{thm:exponential_convergence_primitive}) then gives
     pointwise convergence $\E^n(X)\to P(X)$, and composing with the
     subsequence $2^n\to\infty$ yields the result.
     The witness $\E_\infty = P$ is the rank-one fixed-point projection,

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -259,6 +259,31 @@ All three quantitative results below are now fully proved.
     See \cite[Definition~3.5]{Cirac2021Matrix}.
 \end{definition}
 
+\begin{theorem}[RG flow convergence for canonical-form tensors]%
+    \label{thm:rg_flow_converges_of_cf}
+    \lean{MPSTensor.rg_flow_converges_of_cf}
+    \leanok
+    \uses{def:is_canonical_form, def:transfer_map, def:fixed_point_proj,
+          thm:exponential_convergence_of_primitive}
+    For a tensor in canonical form with blocks $(A_k)$ and weights $(\mu_k)$,
+    the iterated blocking $\E_{A_k}^{2^n}$ converges pointwise to an
+    idempotent linear map $\E_\infty$ as $n\to\infty$.
+    That is, there exists $\E_\infty$ with $\E_\infty^2 = \E_\infty$ such that
+    $\E_{A_k}^{2^n}(\rho) \to \E_\infty(\rho)$ for all density matrices $\rho$.
+    This is \cite[Appendix~B]{Cirac2021Matrix}.
+\end{theorem}
+\begin{proof}\leanok
+    Each block is injective and left-canonical, so its transfer map is a
+    primitive channel with a unique positive-definite fixed point $\rho_0$.
+    The exponential convergence bound
+    $\lVert \E^n(X) - P(X)\rVert \le C(1-\delta)^n \lVert X\rVert$
+    (Theorem~\ref{thm:exponential_convergence_of_primitive}) then gives
+    pointwise convergence $\E^n(X)\to P(X)$, and composing with the
+    subsequence $2^n\to\infty$ yields the result.
+    The witness $\E_\infty = P$ is the rank-one fixed-point projection,
+    which is idempotent.
+\end{proof}
+
 \begin{remark}\label{rem:zero_correlation_length}
     \uses{thm:spectral_radius_le_one, def:correlation_length, def:is_rfp}
     The identity $\E^2=\E$ is equivalent to vanishing subleading spectrum;


### PR DESCRIPTION
### Motivation

- Complete the proof of `rg_flow_converges_of_cf` in `RFP/Convergence.lean`, which states that iterated blocking E^{2^n} converges to an idempotent for canonical-form tensors (see #468).
- Part of the MPDO RFP formalization (arXiv:1606.00608, Appendix B convergence).

### Description

- **`TNLean/MPS/RFP/Convergence.lean`**: Replace `sorry` with an explicit convergence proof using the quantitative spectral gap bound `exponential_convergence_of_primitive` and the fixed-point projection `fixedPointProj`. Includes a dedicated `dim k = 0` edge-case. Imports `TNLean.Spectral.QuantitativeGap` and opens `ComplexOrder`.
- **`blueprint/src/chapter/ch15_correlations.tex`**: Add the corresponding RG-flow convergence theorem entry and proof sketch.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #468

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR replaces a `sorry` with a Lean proof using existing spectral-gap lemmas and adds matching blueprint documentation, without changing runtime behavior.
> 
> **Overview**
> Proves `MPSTensor.rg_flow_converges_of_cf` by replacing the placeholder with a full Lean argument: obtain the unique positive-definite fixed point, define the limiting idempotent as `fixedPointProj`, use `exponential_convergence_of_primitive` to show `E^n X → P X`, then restrict to the subsequence `2^n` (including an explicit `dim k = 0` edge case). 
> 
> Updates the blueprint (`ch15_correlations.tex`) with a new theorem statement and proof sketch documenting the RG-flow convergence result and its reliance on the quantitative spectral gap bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a7f6839f8afd03fda45c2dc842edc171c05248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->