### PR TITLE
ci(github): force JavaScript actions to Node 24

### DIFF
--- a/.github/workflows/_ci-auto-fix-shared.yml
+++ b/.github/workflows/_ci-auto-fix-shared.yml
@@ -50,6 +50,9 @@ on:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   auto-fix:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -24,6 +24,9 @@ permissions:
   issues: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Concurrency is set per-job (not workflow-level) to avoid a problem where
 # adding any unrelated label to a PR would start a no-op run that cancels
 # an in-progress auto-fix via cancel-in-progress.

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation

- Silence the Node.js 20 deprecation warning before the June 2026 forced migration in GitHub Actions
- Ensure consistent runtime environment across all CI workflows

### Description

- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` environment variable in four workflow files:
  - `.github/workflows/_ci-auto-fix-shared.yml`
  - `.github/workflows/auto-fix.yml`
  - `.github/workflows/blueprint.yml`
  - `.github/workflows/lean_action_ci.yml`
- This forces JavaScript-based actions (e.g. `actions/cache@v4` used by `leanprover/lean-action@v1`) to run on Node 24

### Testing

- Relies on CI workflows executing successfully after merge to validate the change

---
*No linked issue — this is a standalone CI maintenance change. Author should link an issue if one exists.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that affects GitHub Actions runtime selection; main risk is unexpected incompatibility in third-party JavaScript actions when forced onto Node 24.
> 
> **Overview**
> Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow level for the CI-related GitHub Actions workflows (auto-fix shared/entrypoint, blueprint build, and Lean CI), forcing JavaScript-based actions in these pipelines to execute under Node 24 instead of the default runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dffc56c13960b73e2387d0222323aa885ffbfc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->