### PR TITLE
ci(blueprint): split blueprint and docgen workflows

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -1,4 +1,4 @@
-name: Compile blueprint
+name: Blueprint
 
 on:
   push:
@@ -27,6 +27,9 @@ jobs:
   build_project:
     runs-on: ubuntu-latest
     name: Build project
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Cleanup to free disk space
         uses: jlumbroso/free-disk-space@main
@@ -49,8 +52,35 @@ jobs:
         with:
           build: true
 
-      - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@main
+      - name: Install graphviz headers
+        run: sudo apt-get update && sudo apt-get install -y graphviz libgraphviz-dev
+
+      - name: Install leanblueprint
+        run: |
+          pipx install leanblueprint
+          pipx inject --include-apps --force leanblueprint plastex
+
+      - name: Build blueprint
+        working-directory: blueprint
+        run: |
+          leanblueprint pdf
+          leanblueprint web
+
+      - name: Build homepage with Jekyll
+        uses: actions/jekyll-build-pages@v1
         with:
-          blueprint: true
-          homepage: home_page
+          source: home_page
+          destination: ./_site
+
+      - name: Assemble site
+        run: |
+          mkdir -p _site/blueprint
+          cp blueprint/print/print.pdf _site/blueprint.pdf
+          cp -r blueprint/web/* _site/blueprint/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -49,32 +49,7 @@ jobs:
           leanblueprint web
 
       - name: Deploy to gh-pages
-        run: |
-          git clone --branch gh-pages --single-branch --depth 1 \
-            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" /tmp/gh-pages
-
-          # Update blueprint
-          rm -rf /tmp/gh-pages/blueprint
-          mkdir -p /tmp/gh-pages/blueprint
-          cp -r blueprint/web/* /tmp/gh-pages/blueprint/
-          cp blueprint/print/print.pdf /tmp/gh-pages/blueprint.pdf
-
-          # Update homepage (clean first to remove stale files)
-          rm -rf /tmp/gh-pages/_layouts /tmp/gh-pages/assets
-          cp home_page/_config.yml /tmp/gh-pages/
-          cp home_page/index.md /tmp/gh-pages/
-          cp home_page/404.html /tmp/gh-pages/ 2>/dev/null || true
-          cp home_page/Gemfile /tmp/gh-pages/ 2>/dev/null || true
-          cp -r home_page/assets /tmp/gh-pages/ 2>/dev/null || true
-          cp -r home_page/_layouts /tmp/gh-pages/ 2>/dev/null || true
-
-          cd /tmp/gh-pages
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No changes to deploy."
-          else
-            git commit -m "Update blueprint from ${{ github.sha }}"
-            git push origin gh-pages
-          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/deploy-to-gh-pages.sh --ci

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -44,7 +44,13 @@ jobs:
 
       - name: Build blueprint
         working-directory: blueprint
-        run: leanblueprint web
+        run: |
+          set -o pipefail
+          leanblueprint web 2>&1 | tee /tmp/blueprint-output.txt
+          if grep -q "^ERROR:" /tmp/blueprint-output.txt; then
+            echo "::error::Blueprint has unresolved labels (see ERROR lines above)"
+            exit 1
+          fi
 
       - name: Deploy to gh-pages
         env:

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -19,38 +19,20 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 jobs:
-  build_project:
+  blueprint:
     runs-on: ubuntu-latest
-    name: Build project
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    name: Build and deploy blueprint
     steps:
-      - name: Cleanup to free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: false
-          haskell: false
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
       - name: Checkout project
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
-      - name: Build project
-        uses: leanprover/lean-action@v1
+      - name: Install Python
+        uses: actions/setup-python@v5
         with:
-          build: true
+          python-version: '3.12'
 
       - name: Install graphviz headers
         run: sudo apt-get update && sudo apt-get install -y graphviz libgraphviz-dev
@@ -66,23 +48,32 @@ jobs:
           leanblueprint pdf
           leanblueprint web
 
-      - name: Build homepage with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: home_page
-          destination: ./_site
-
-      - name: Assemble site
+      - name: Deploy to gh-pages
         run: |
-          mkdir -p _site/blueprint _site/docs
-          cp blueprint/print/print.pdf _site/blueprint.pdf
-          cp -r blueprint/web/* _site/blueprint/
-          # Placeholder so /docs/ doesn't 404 between docgen runs
-          echo '<html><head><meta http-equiv="refresh" content="0;url=/TNLean/"></head><body>API docs are generated weekly. <a href="/TNLean/">Back to home</a>.</body></html>' > _site/docs/index.html
+          git clone --branch gh-pages --single-branch --depth 1 \
+            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" /tmp/gh-pages
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+          # Update blueprint
+          rm -rf /tmp/gh-pages/blueprint
+          mkdir -p /tmp/gh-pages/blueprint
+          cp -r blueprint/web/* /tmp/gh-pages/blueprint/
+          cp blueprint/print/print.pdf /tmp/gh-pages/blueprint.pdf
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          # Update homepage
+          cp home_page/_config.yml /tmp/gh-pages/
+          cp home_page/index.md /tmp/gh-pages/
+          cp home_page/404.html /tmp/gh-pages/ 2>/dev/null || true
+          cp home_page/Gemfile /tmp/gh-pages/ 2>/dev/null || true
+          cp -r home_page/assets /tmp/gh-pages/ 2>/dev/null || true
+          cp -r home_page/_layouts /tmp/gh-pages/ 2>/dev/null || true
+
+          cd /tmp/gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to deploy."
+          else
+            git commit -m "Update blueprint from ${{ github.sha }}"
+            git push origin gh-pages
+          fi

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -74,9 +74,11 @@ jobs:
 
       - name: Assemble site
         run: |
-          mkdir -p _site/blueprint
+          mkdir -p _site/blueprint _site/docs
           cp blueprint/print/print.pdf _site/blueprint.pdf
           cp -r blueprint/web/* _site/blueprint/
+          # Placeholder so /docs/ doesn't 404 between docgen runs
+          echo '<html><head><meta http-equiv="refresh" content="0;url=/TNLean/"></head><body>API docs are generated weekly. <a href="/TNLean/">Back to home</a>.</body></html>' > _site/docs/index.html
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install TeX and graphviz
-        run: sudo apt-get update && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended texlive-science latexmk graphviz libgraphviz-dev
+      - name: Install graphviz headers
+        run: sudo apt-get update && sudo apt-get install -y graphviz libgraphviz-dev
 
       - name: Install leanblueprint
         run: |
@@ -44,9 +44,7 @@ jobs:
 
       - name: Build blueprint
         working-directory: blueprint
-        run: |
-          leanblueprint pdf
-          leanblueprint web
+        run: leanblueprint web
 
       - name: Deploy to gh-pages
         env:

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -59,7 +59,8 @@ jobs:
           cp -r blueprint/web/* /tmp/gh-pages/blueprint/
           cp blueprint/print/print.pdf /tmp/gh-pages/blueprint.pdf
 
-          # Update homepage
+          # Update homepage (clean first to remove stale files)
+          rm -rf /tmp/gh-pages/_layouts /tmp/gh-pages/assets
           cp home_page/_config.yml /tmp/gh-pages/
           cp home_page/index.md /tmp/gh-pages/
           cp home_page/404.html /tmp/gh-pages/ 2>/dev/null || true

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install graphviz headers
-        run: sudo apt-get update && sudo apt-get install -y graphviz libgraphviz-dev
+      - name: Install TeX and graphviz
+        run: sudo apt-get update && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended texlive-science latexmk graphviz libgraphviz-dev
 
       - name: Install leanblueprint
         run: |

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -15,8 +15,8 @@ on:
 
 # Cancel previous runs if a new commit is pushed
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -17,7 +17,7 @@ jobs:
   build_project:
     runs-on: ubuntu-latest
     name: Build project and generate docs
-    timeout-minutes: 360
+    timeout-minutes: 330
     steps:
       - name: Cleanup to free disk space
         uses: jlumbroso/free-disk-space@main
@@ -60,40 +60,7 @@ jobs:
           lake build TNLean:docs
 
       - name: Deploy to gh-pages
-        run: |
-          git clone --branch gh-pages --single-branch --depth 1 \
-            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" /tmp/gh-pages
-
-          # Update blueprint
-          rm -rf /tmp/gh-pages/blueprint
-          mkdir -p /tmp/gh-pages/blueprint
-          cp -r blueprint/web/* /tmp/gh-pages/blueprint/
-          cp blueprint/print/print.pdf /tmp/gh-pages/blueprint.pdf
-
-          # Update homepage (clean first to remove stale files)
-          rm -rf /tmp/gh-pages/_layouts /tmp/gh-pages/assets
-          cp home_page/_config.yml /tmp/gh-pages/
-          cp home_page/index.md /tmp/gh-pages/
-          cp home_page/404.html /tmp/gh-pages/ 2>/dev/null || true
-          cp home_page/Gemfile /tmp/gh-pages/ 2>/dev/null || true
-          cp -r home_page/assets /tmp/gh-pages/ 2>/dev/null || true
-          cp -r home_page/_layouts /tmp/gh-pages/ 2>/dev/null || true
-
-          # Update API docs (fail if not generated)
-          if [ ! -d "docbuild/.lake/build/doc" ]; then
-            echo "::error::API docs were not generated (docbuild/.lake/build/doc missing)"
-            exit 1
-          fi
-          rm -rf /tmp/gh-pages/docs
-          cp -r docbuild/.lake/build/doc /tmp/gh-pages/docs
-
-          cd /tmp/gh-pages
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No changes to deploy."
-          else
-            git commit -m "Full docs update from ${{ github.sha }}"
-            git push origin gh-pages
-          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/deploy-to-gh-pages.sh --with-docs --ci

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Generate API docs
         run: |
           cd docbuild
-          lake update
           lake build TNLean:docs
 
       - name: Deploy to gh-pages

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -17,7 +17,7 @@ jobs:
   build_project:
     runs-on: ubuntu-latest
     name: Build project and generate docs
-    timeout-minutes: 720
+    timeout-minutes: 360
     steps:
       - name: Cleanup to free disk space
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           build: true
 
-      - name: Install graphviz headers
-        run: sudo apt-get update && sudo apt-get install -y graphviz libgraphviz-dev
+      - name: Install TeX and graphviz
+        run: sudo apt-get update && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended texlive-science latexmk graphviz libgraphviz-dev
 
       - name: Install leanblueprint
         run: |

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -11,17 +11,13 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 jobs:
   build_project:
     runs-on: ubuntu-latest
     name: Build project and generate docs
-    timeout-minutes: 480
-    environment:
-      name: github-pages
+    timeout-minutes: 720
     steps:
       - name: Cleanup to free disk space
         uses: jlumbroso/free-disk-space@main
@@ -44,8 +40,58 @@ jobs:
         with:
           build: true
 
-      - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@main
-        with:
-          blueprint: true
-          homepage: home_page
+      - name: Install graphviz headers
+        run: sudo apt-get update && sudo apt-get install -y graphviz libgraphviz-dev
+
+      - name: Install leanblueprint
+        run: |
+          pipx install leanblueprint
+          pipx inject --include-apps --force leanblueprint plastex
+
+      - name: Build blueprint
+        working-directory: blueprint
+        run: |
+          leanblueprint pdf
+          leanblueprint web
+
+      - name: Generate API docs
+        run: |
+          cd docbuild
+          lake update
+          lake build
+
+      - name: Deploy to gh-pages
+        run: |
+          git clone --branch gh-pages --single-branch --depth 1 \
+            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" /tmp/gh-pages
+
+          # Update blueprint
+          rm -rf /tmp/gh-pages/blueprint
+          mkdir -p /tmp/gh-pages/blueprint
+          cp -r blueprint/web/* /tmp/gh-pages/blueprint/
+          cp blueprint/print/print.pdf /tmp/gh-pages/blueprint.pdf
+
+          # Update homepage
+          cp home_page/_config.yml /tmp/gh-pages/
+          cp home_page/index.md /tmp/gh-pages/
+          cp home_page/404.html /tmp/gh-pages/ 2>/dev/null || true
+          cp home_page/Gemfile /tmp/gh-pages/ 2>/dev/null || true
+          cp -r home_page/assets /tmp/gh-pages/ 2>/dev/null || true
+          cp -r home_page/_layouts /tmp/gh-pages/ 2>/dev/null || true
+
+          # Update API docs
+          rm -rf /tmp/gh-pages/docs
+          if [ -d "docbuild/.lake/build/doc" ]; then
+            cp -r docbuild/.lake/build/doc /tmp/gh-pages/docs
+          fi
+
+          cd /tmp/gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to deploy."
+          else
+            git commit -m "Full docs update from ${{ github.sha }}"
+            git push origin gh-pages
+          fi

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -79,11 +79,13 @@ jobs:
           cp -r home_page/assets /tmp/gh-pages/ 2>/dev/null || true
           cp -r home_page/_layouts /tmp/gh-pages/ 2>/dev/null || true
 
-          # Update API docs
-          rm -rf /tmp/gh-pages/docs
-          if [ -d "docbuild/.lake/build/doc" ]; then
-            cp -r docbuild/.lake/build/doc /tmp/gh-pages/docs
+          # Update API docs (fail if not generated)
+          if [ ! -d "docbuild/.lake/build/doc" ]; then
+            echo "::error::API docs were not generated (docbuild/.lake/build/doc missing)"
+            exit 1
           fi
+          rm -rf /tmp/gh-pages/docs
+          cp -r docbuild/.lake/build/doc /tmp/gh-pages/docs
 
           cd /tmp/gh-pages
           git config user.name "github-actions[bot]"

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -1,0 +1,52 @@
+name: Full documentation
+
+on:
+  schedule:
+    # Run weekly on Sunday at 06:00 UTC
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build_project:
+    runs-on: ubuntu-latest
+    name: Build project and generate docs
+    timeout-minutes: 480
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Cleanup to free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: false
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
+      - name: Checkout project
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Build project
+        uses: leanprover/lean-action@v1
+        with:
+          build: true
+
+      - name: Compile blueprint and documentation
+        uses: leanprover-community/docgen-action@main
+        with:
+          blueprint: true
+          homepage: home_page

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -5,6 +5,11 @@ on:
     # Run weekly on Sunday at 06:00 UTC
     - cron: '0 6 * * 0'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch to build docs from (default: main)'
+        required: false
+        default: 'main'
 
 concurrency:
   group: gh-pages-deploy

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref || 'main' }}
 
       - name: Build project
         uses: leanprover/lean-action@v1

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -22,7 +22,6 @@ jobs:
     timeout-minutes: 480
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Cleanup to free disk space
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -58,7 +58,12 @@ jobs:
         working-directory: blueprint
         run: |
           leanblueprint pdf
-          leanblueprint web
+          set -o pipefail
+          leanblueprint web 2>&1 | tee /tmp/blueprint-output.txt
+          if grep -q "^ERROR:" /tmp/blueprint-output.txt; then
+            echo "::error::Blueprint has unresolved labels (see ERROR lines above)"
+            exit 1
+          fi
 
       - name: Generate API docs
         run: |

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           cd docbuild
           lake update
-          lake build
+          lake build TNLean:docs
 
       - name: Deploy to gh-pages
         run: |

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -70,7 +70,8 @@ jobs:
           cp -r blueprint/web/* /tmp/gh-pages/blueprint/
           cp blueprint/print/print.pdf /tmp/gh-pages/blueprint.pdf
 
-          # Update homepage
+          # Update homepage (clean first to remove stale files)
+          rm -rf /tmp/gh-pages/_layouts /tmp/gh-pages/assets
           cp home_page/_config.yml /tmp/gh-pages/
           cp home_page/index.md /tmp/gh-pages/
           cp home_page/404.html /tmp/gh-pages/ 2>/dev/null || true

--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -68,9 +68,6 @@ jobs:
             exit "$cmd_status"
           fi
 
-      - name: Build project (needed for checkdecls to find declarations)
-        run: lake build
-
       - name: Generate lean_decls from blueprint .tex files
         run: python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
 

--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -68,6 +68,9 @@ jobs:
             exit "$cmd_status"
           fi
 
+      - name: Build project (needed for checkdecls)
+        run: lake build
+
       - name: Generate lean_decls from blueprint .tex files
         run: python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,26 +28,7 @@ cd blueprint && leanblueprint checkdecls
 cd blueprint && leanblueprint web
 cd blueprint && leanblueprint pdf
 
-# Deploy blueprint to GitHub Pages (fast, preserves /docs/)
-./scripts/deploy-blueprint.sh
-
-# Deploy blueprint + API docs to GitHub Pages (slow first time, incremental after)
-./scripts/deploy-docs.sh
-
-# Generate API docs only (without deploying)
-cd docbuild && lake build TNLean:docs
 ```
-
-### GitHub Pages Deployment
-
-The site at `sirui-lu.com/TNLean/` is served from the `gh-pages` branch. Two deploy scripts update it incrementally:
-
-- **`scripts/deploy-blueprint.sh`** — builds `leanblueprint pdf/web`, pushes blueprint + homepage to `gh-pages`. Fast (seconds). Does not touch `/docs/`.
-- **`scripts/deploy-docs.sh`** — builds blueprint + API docs (`lake build TNLean:docs` in `docbuild/`), pushes everything to `gh-pages`. Slow on first run (hours), incremental after.
-
-CI also deploys automatically:
-- **Blueprint workflow** (`blueprint.yml`) — runs on every push to `main`, deploys blueprint only.
-- **Docgen workflow** (`docgen.yml`) — runs weekly (Sunday) or manually via `workflow_dispatch`, deploys full site with API docs.
 
 ## Lean Toolchain & Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,27 @@ cd blueprint && leanblueprint checkdecls
 # Blueprint web/PDF generation
 cd blueprint && leanblueprint web
 cd blueprint && leanblueprint pdf
+
+# Deploy blueprint to GitHub Pages (fast, preserves /docs/)
+./scripts/deploy-blueprint.sh
+
+# Deploy blueprint + API docs to GitHub Pages (slow first time, incremental after)
+./scripts/deploy-docs.sh
+
+# Generate API docs only (without deploying)
+cd docbuild && lake build TNLean:docs
 ```
+
+### GitHub Pages Deployment
+
+The site at `sirui-lu.com/TNLean/` is served from the `gh-pages` branch. Two deploy scripts update it incrementally:
+
+- **`scripts/deploy-blueprint.sh`** — builds `leanblueprint pdf/web`, pushes blueprint + homepage to `gh-pages`. Fast (seconds). Does not touch `/docs/`.
+- **`scripts/deploy-docs.sh`** — builds blueprint + API docs (`lake build TNLean:docs` in `docbuild/`), pushes everything to `gh-pages`. Slow on first run (hours), incremental after.
+
+CI also deploys automatically:
+- **Blueprint workflow** (`blueprint.yml`) — runs on every push to `main`, deploys blueprint only.
+- **Docgen workflow** (`docgen.yml`) — runs weekly (Sunday) or manually via `workflow_dispatch`, deploys full site with API docs.
 
 ## Lean Toolchain & Dependencies
 

--- a/blueprint/src/web.tex
+++ b/blueprint/src/web.tex
@@ -13,9 +13,9 @@
 \providecommand{\dotsc}{\dots}
 \providecommand{\multicolumn}[3]{#3}
 
-\home{https://LionSR.github.io/TNLean}
+\home{..}
 \github{https://github.com/LionSR/TNLean}
-\dochome{https://LionSR.github.io/TNLean/docs}
+\dochome{../docs}
 
 \title{Fundamental Theorem of Matrix Product States}
 \author{Authors}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,74 @@
+# Deploying Blueprint & API Docs
+
+The project site at `sirui-lu.com/TNLean/` is served from the `gh-pages` branch.
+Each deploy updates only its own files — blueprint deploys preserve `/docs/` and vice versa.
+
+## Local Preview (no push)
+
+```bash
+# Build and preview blueprint locally
+cd blueprint
+leanblueprint web
+leanblueprint serve        # opens http://localhost:8000
+
+# Build blueprint PDF
+leanblueprint pdf          # output: blueprint/print/print.pdf
+```
+
+## Deploy Blueprint (fast)
+
+Builds `leanblueprint pdf/web` and pushes blueprint + homepage to `gh-pages`.
+Does not touch `/docs/` — existing API docs are preserved.
+
+```bash
+./scripts/deploy-blueprint.sh
+```
+
+Takes seconds if blueprint is already built, a couple of minutes otherwise.
+
+## Deploy Blueprint + API Docs (full)
+
+Builds everything and pushes to `gh-pages`, including `/docs/` API documentation.
+
+```bash
+./scripts/deploy-docs.sh
+```
+
+The first run is slow (hours) because `lake build TNLean:docs` in `docbuild/`
+needs to elaborate the full codebase including Mathlib for doc-gen4.
+Subsequent runs are incremental — only changed files are re-elaborated.
+
+To generate API docs without deploying:
+
+```bash
+cd docbuild && lake build TNLean:docs
+# Output: docbuild/.lake/build/doc/
+```
+
+## CI Workflows
+
+| Workflow | Trigger | What it does |
+|----------|---------|-------------|
+| `blueprint.yml` | Every push to `main` | Builds blueprint, pushes to `gh-pages` |
+| `docgen.yml` | Weekly (Sunday 06:00 UTC) + manual | Full build + API docs, pushes to `gh-pages` |
+
+To manually trigger docgen from the CLI:
+
+```bash
+gh workflow run "Full documentation" --repo LionSR/TNLean --ref main
+```
+
+## Site Structure on `gh-pages`
+
+```
+/                    ← Jekyll homepage (home_page/)
+/blueprint/          ← leanblueprint web output
+/blueprint.pdf       ← leanblueprint PDF
+/docs/               ← doc-gen4 API documentation
+```
+
+## Setup
+
+GitHub Pages must be configured to deploy from the `gh-pages` branch:
+
+**Settings > Pages > Source: Deploy from a branch > `gh-pages` / `/ (root)`**

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -13,6 +13,10 @@ leanblueprint serve        # opens http://localhost:8000
 
 # Build blueprint PDF
 leanblueprint pdf          # output: blueprint/print/print.pdf
+
+# Build and preview API docs locally
+cd docbuild && lake build TNLean:docs
+cd .lake/build/doc && python3 -m http.server 8080   # opens http://localhost:8080
 ```
 
 ## Deploy Blueprint (fast)

--- a/scripts/deploy-blueprint.sh
+++ b/scripts/deploy-blueprint.sh
@@ -7,8 +7,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "==> Building blueprint..."
 cd "$REPO_ROOT/blueprint"
@@ -17,25 +17,25 @@ leanblueprint web
 
 echo "==> Cloning gh-pages branch..."
 git clone --branch gh-pages --single-branch --depth 1 \
-  "$(git -C "$REPO_ROOT" remote get-url origin)" "$TMPDIR/site"
+  "$(git -C "$REPO_ROOT" remote get-url origin)" "$WORK_DIR/site"
 
 echo "==> Updating blueprint files..."
 # Update blueprint
-rm -rf "$TMPDIR/site/blueprint"
-mkdir -p "$TMPDIR/site/blueprint"
-cp -r "$REPO_ROOT/blueprint/web/"* "$TMPDIR/site/blueprint/"
-cp "$REPO_ROOT/blueprint/print/print.pdf" "$TMPDIR/site/blueprint.pdf"
+rm -rf "$WORK_DIR/site/blueprint"
+mkdir -p "$WORK_DIR/site/blueprint"
+cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
+cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf"
 
 # Update homepage
-cp "$REPO_ROOT/home_page/_config.yml" "$TMPDIR/site/"
-cp "$REPO_ROOT/home_page/index.md" "$TMPDIR/site/"
-cp "$REPO_ROOT/home_page/404.html" "$TMPDIR/site/" 2>/dev/null || true
-cp "$REPO_ROOT/home_page/Gemfile" "$TMPDIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/assets" "$TMPDIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/_layouts" "$TMPDIR/site/" 2>/dev/null || true
+cp "$REPO_ROOT/home_page/_config.yml" "$WORK_DIR/site/"
+cp "$REPO_ROOT/home_page/index.md" "$WORK_DIR/site/"
+cp "$REPO_ROOT/home_page/404.html" "$WORK_DIR/site/" 2>/dev/null || true
+cp "$REPO_ROOT/home_page/Gemfile" "$WORK_DIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/assets" "$WORK_DIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/_layouts" "$WORK_DIR/site/" 2>/dev/null || true
 
 echo "==> Committing and pushing..."
-cd "$TMPDIR/site"
+cd "$WORK_DIR/site"
 git add -A
 if git diff --cached --quiet; then
   echo "No changes to deploy."

--- a/scripts/deploy-blueprint.sh
+++ b/scripts/deploy-blueprint.sh
@@ -36,6 +36,8 @@ cp -r "$REPO_ROOT/home_page/_layouts" "$WORK_DIR/site/" 2>/dev/null || true
 
 echo "==> Committing and pushing..."
 cd "$WORK_DIR/site"
+git config user.name "$(git -C "$REPO_ROOT" config user.name || echo 'deploy-script')"
+git config user.email "$(git -C "$REPO_ROOT" config user.email || echo 'deploy@local')"
 git add -A
 if git diff --cached --quiet; then
   echo "No changes to deploy."

--- a/scripts/deploy-blueprint.sh
+++ b/scripts/deploy-blueprint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Deploy blueprint to gh-pages branch.
+# Usage: ./scripts/deploy-blueprint.sh
+#
+# Builds leanblueprint locally, then pushes only the blueprint
+# and homepage files to gh-pages (preserving /docs/).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "==> Building blueprint..."
+cd "$REPO_ROOT/blueprint"
+leanblueprint pdf
+leanblueprint web
+
+echo "==> Cloning gh-pages branch..."
+git clone --branch gh-pages --single-branch --depth 1 \
+  "$(git -C "$REPO_ROOT" remote get-url origin)" "$TMPDIR/site"
+
+echo "==> Updating blueprint files..."
+# Update blueprint
+rm -rf "$TMPDIR/site/blueprint"
+mkdir -p "$TMPDIR/site/blueprint"
+cp -r "$REPO_ROOT/blueprint/web/"* "$TMPDIR/site/blueprint/"
+cp "$REPO_ROOT/blueprint/print/print.pdf" "$TMPDIR/site/blueprint.pdf"
+
+# Update homepage
+cp "$REPO_ROOT/home_page/_config.yml" "$TMPDIR/site/"
+cp "$REPO_ROOT/home_page/index.md" "$TMPDIR/site/"
+cp "$REPO_ROOT/home_page/404.html" "$TMPDIR/site/" 2>/dev/null || true
+cp "$REPO_ROOT/home_page/Gemfile" "$TMPDIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/assets" "$TMPDIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/_layouts" "$TMPDIR/site/" 2>/dev/null || true
+
+echo "==> Committing and pushing..."
+cd "$TMPDIR/site"
+git add -A
+if git diff --cached --quiet; then
+  echo "No changes to deploy."
+else
+  git commit -m "Update blueprint ($(date -u '+%Y-%m-%d %H:%M UTC'))"
+  git push origin gh-pages
+  echo "==> Deployed!"
+fi

--- a/scripts/deploy-blueprint.sh
+++ b/scripts/deploy-blueprint.sh
@@ -1,48 +1,13 @@
 #!/usr/bin/env bash
-# Deploy blueprint to gh-pages branch.
+# Deploy blueprint to gh-pages (preserves /docs/).
 # Usage: ./scripts/deploy-blueprint.sh
-#
-# Builds leanblueprint locally, then pushes only the blueprint
-# and homepage files to gh-pages (preserving /docs/).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-WORK_DIR="$(mktemp -d)"
-trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "==> Building blueprint..."
 cd "$REPO_ROOT/blueprint"
 leanblueprint pdf
 leanblueprint web
 
-echo "==> Cloning gh-pages branch..."
-git clone --branch gh-pages --single-branch --depth 1 \
-  "$(git -C "$REPO_ROOT" remote get-url origin)" "$WORK_DIR/site"
-
-echo "==> Updating blueprint files..."
-# Update blueprint
-rm -rf "$WORK_DIR/site/blueprint"
-mkdir -p "$WORK_DIR/site/blueprint"
-cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
-cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf"
-
-# Update homepage
-cp "$REPO_ROOT/home_page/_config.yml" "$WORK_DIR/site/"
-cp "$REPO_ROOT/home_page/index.md" "$WORK_DIR/site/"
-cp "$REPO_ROOT/home_page/404.html" "$WORK_DIR/site/" 2>/dev/null || true
-cp "$REPO_ROOT/home_page/Gemfile" "$WORK_DIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/assets" "$WORK_DIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/_layouts" "$WORK_DIR/site/" 2>/dev/null || true
-
-echo "==> Committing and pushing..."
-cd "$WORK_DIR/site"
-git config user.name "$(git -C "$REPO_ROOT" config user.name || echo 'deploy-script')"
-git config user.email "$(git -C "$REPO_ROOT" config user.email || echo 'deploy@local')"
-git add -A
-if git diff --cached --quiet; then
-  echo "No changes to deploy."
-else
-  git commit -m "Update blueprint ($(date -u '+%Y-%m-%d %H:%M UTC'))"
-  git push origin gh-pages
-  echo "==> Deployed!"
-fi
+exec "$REPO_ROOT/scripts/deploy-to-gh-pages.sh"

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -7,8 +7,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "==> Building blueprint..."
 cd "$REPO_ROOT/blueprint"
@@ -22,34 +22,34 @@ lake build TNLean:docs
 
 echo "==> Cloning gh-pages branch..."
 git clone --branch gh-pages --single-branch --depth 1 \
-  "$(git -C "$REPO_ROOT" remote get-url origin)" "$TMPDIR/site"
+  "$(git -C "$REPO_ROOT" remote get-url origin)" "$WORK_DIR/site"
 
 echo "==> Updating files..."
 # Blueprint
-rm -rf "$TMPDIR/site/blueprint"
-mkdir -p "$TMPDIR/site/blueprint"
-cp -r "$REPO_ROOT/blueprint/web/"* "$TMPDIR/site/blueprint/"
-cp "$REPO_ROOT/blueprint/print/print.pdf" "$TMPDIR/site/blueprint.pdf"
+rm -rf "$WORK_DIR/site/blueprint"
+mkdir -p "$WORK_DIR/site/blueprint"
+cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
+cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf"
 
 # Homepage
-cp "$REPO_ROOT/home_page/_config.yml" "$TMPDIR/site/"
-cp "$REPO_ROOT/home_page/index.md" "$TMPDIR/site/"
-cp "$REPO_ROOT/home_page/404.html" "$TMPDIR/site/" 2>/dev/null || true
-cp "$REPO_ROOT/home_page/Gemfile" "$TMPDIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/assets" "$TMPDIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/_layouts" "$TMPDIR/site/" 2>/dev/null || true
+cp "$REPO_ROOT/home_page/_config.yml" "$WORK_DIR/site/"
+cp "$REPO_ROOT/home_page/index.md" "$WORK_DIR/site/"
+cp "$REPO_ROOT/home_page/404.html" "$WORK_DIR/site/" 2>/dev/null || true
+cp "$REPO_ROOT/home_page/Gemfile" "$WORK_DIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/assets" "$WORK_DIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/_layouts" "$WORK_DIR/site/" 2>/dev/null || true
 
 # API docs
-rm -rf "$TMPDIR/site/docs"
+rm -rf "$WORK_DIR/site/docs"
 if [ -d "$REPO_ROOT/docbuild/.lake/build/doc" ]; then
-  cp -r "$REPO_ROOT/docbuild/.lake/build/doc" "$TMPDIR/site/docs"
+  cp -r "$REPO_ROOT/docbuild/.lake/build/doc" "$WORK_DIR/site/docs"
   echo "  Copied API docs to /docs/"
 else
   echo "  Warning: docbuild/.lake/build/doc not found, skipping API docs"
 fi
 
 echo "==> Committing and pushing..."
-cd "$TMPDIR/site"
+cd "$WORK_DIR/site"
 git add -A
 if git diff --cached --quiet; then
   echo "No changes to deploy."

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Deploy blueprint + API docs to gh-pages branch.
+# Usage: ./scripts/deploy-docs.sh
+#
+# Builds everything locally, then pushes to gh-pages.
+# For blueprint-only deploys, use deploy-blueprint.sh instead.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "==> Building blueprint..."
+cd "$REPO_ROOT/blueprint"
+leanblueprint pdf
+leanblueprint web
+
+echo "==> Building API docs (this may take a while)..."
+cd "$REPO_ROOT/docbuild"
+lake update
+lake build TNLean:docs
+
+echo "==> Cloning gh-pages branch..."
+git clone --branch gh-pages --single-branch --depth 1 \
+  "$(git -C "$REPO_ROOT" remote get-url origin)" "$TMPDIR/site"
+
+echo "==> Updating files..."
+# Blueprint
+rm -rf "$TMPDIR/site/blueprint"
+mkdir -p "$TMPDIR/site/blueprint"
+cp -r "$REPO_ROOT/blueprint/web/"* "$TMPDIR/site/blueprint/"
+cp "$REPO_ROOT/blueprint/print/print.pdf" "$TMPDIR/site/blueprint.pdf"
+
+# Homepage
+cp "$REPO_ROOT/home_page/_config.yml" "$TMPDIR/site/"
+cp "$REPO_ROOT/home_page/index.md" "$TMPDIR/site/"
+cp "$REPO_ROOT/home_page/404.html" "$TMPDIR/site/" 2>/dev/null || true
+cp "$REPO_ROOT/home_page/Gemfile" "$TMPDIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/assets" "$TMPDIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/_layouts" "$TMPDIR/site/" 2>/dev/null || true
+
+# API docs
+rm -rf "$TMPDIR/site/docs"
+if [ -d "$REPO_ROOT/docbuild/.lake/build/doc" ]; then
+  cp -r "$REPO_ROOT/docbuild/.lake/build/doc" "$TMPDIR/site/docs"
+  echo "  Copied API docs to /docs/"
+else
+  echo "  Warning: docbuild/.lake/build/doc not found, skipping API docs"
+fi
+
+echo "==> Committing and pushing..."
+cd "$TMPDIR/site"
+git add -A
+if git diff --cached --quiet; then
+  echo "No changes to deploy."
+else
+  git commit -m "Full docs update ($(date -u '+%Y-%m-%d %H:%M UTC'))"
+  git push origin gh-pages
+  echo "==> Deployed!"
+fi

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
-# Deploy blueprint + API docs to gh-pages branch.
+# Deploy blueprint + API docs to gh-pages.
 # Usage: ./scripts/deploy-docs.sh
-#
-# Builds everything locally, then pushes to gh-pages.
-# For blueprint-only deploys, use deploy-blueprint.sh instead.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-WORK_DIR="$(mktemp -d)"
-trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "==> Building blueprint..."
 cd "$REPO_ROOT/blueprint"
@@ -19,43 +14,4 @@ echo "==> Building API docs (this may take a while)..."
 cd "$REPO_ROOT/docbuild"
 lake build TNLean:docs
 
-echo "==> Cloning gh-pages branch..."
-git clone --branch gh-pages --single-branch --depth 1 \
-  "$(git -C "$REPO_ROOT" remote get-url origin)" "$WORK_DIR/site"
-
-echo "==> Updating files..."
-# Blueprint
-rm -rf "$WORK_DIR/site/blueprint"
-mkdir -p "$WORK_DIR/site/blueprint"
-cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
-cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf"
-
-# Homepage
-cp "$REPO_ROOT/home_page/_config.yml" "$WORK_DIR/site/"
-cp "$REPO_ROOT/home_page/index.md" "$WORK_DIR/site/"
-cp "$REPO_ROOT/home_page/404.html" "$WORK_DIR/site/" 2>/dev/null || true
-cp "$REPO_ROOT/home_page/Gemfile" "$WORK_DIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/assets" "$WORK_DIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/_layouts" "$WORK_DIR/site/" 2>/dev/null || true
-
-# API docs
-rm -rf "$WORK_DIR/site/docs"
-if [ -d "$REPO_ROOT/docbuild/.lake/build/doc" ]; then
-  cp -r "$REPO_ROOT/docbuild/.lake/build/doc" "$WORK_DIR/site/docs"
-  echo "  Copied API docs to /docs/"
-else
-  echo "  Warning: docbuild/.lake/build/doc not found, skipping API docs"
-fi
-
-echo "==> Committing and pushing..."
-cd "$WORK_DIR/site"
-git config user.name "$(git -C "$REPO_ROOT" config user.name || echo 'deploy-script')"
-git config user.email "$(git -C "$REPO_ROOT" config user.email || echo 'deploy@local')"
-git add -A
-if git diff --cached --quiet; then
-  echo "No changes to deploy."
-else
-  git commit -m "Full docs update ($(date -u '+%Y-%m-%d %H:%M UTC'))"
-  git push origin gh-pages
-  echo "==> Deployed!"
-fi
+exec "$REPO_ROOT/scripts/deploy-to-gh-pages.sh" --with-docs

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -17,7 +17,6 @@ leanblueprint web
 
 echo "==> Building API docs (this may take a while)..."
 cd "$REPO_ROOT/docbuild"
-lake update
 lake build TNLean:docs
 
 echo "==> Cloning gh-pages branch..."

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -50,6 +50,8 @@ fi
 
 echo "==> Committing and pushing..."
 cd "$WORK_DIR/site"
+git config user.name "$(git -C "$REPO_ROOT" config user.name || echo 'deploy-script')"
+git config user.email "$(git -C "$REPO_ROOT" config user.email || echo 'deploy@local')"
 git add -A
 if git diff --cached --quiet; then
   echo "No changes to deploy."

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -34,15 +34,12 @@ mkdir -p "$WORK_DIR/site/blueprint"
 cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
 cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf"
 
-# Update homepage (clean first to remove stale files)
+# Update homepage (remove all homepage files first, then copy fresh)
 echo "==> Updating homepage..."
-rm -rf "$WORK_DIR/site/_layouts" "$WORK_DIR/site/assets"
-cp "$REPO_ROOT/home_page/_config.yml" "$WORK_DIR/site/"
-cp "$REPO_ROOT/home_page/index.md" "$WORK_DIR/site/"
-cp "$REPO_ROOT/home_page/404.html" "$WORK_DIR/site/" 2>/dev/null || true
-cp "$REPO_ROOT/home_page/Gemfile" "$WORK_DIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/assets" "$WORK_DIR/site/" 2>/dev/null || true
-cp -r "$REPO_ROOT/home_page/_layouts" "$WORK_DIR/site/" 2>/dev/null || true
+rm -rf "$WORK_DIR/site/_layouts" "$WORK_DIR/site/assets" \
+       "$WORK_DIR/site/_config.yml" "$WORK_DIR/site/index.md" \
+       "$WORK_DIR/site/404.html" "$WORK_DIR/site/Gemfile"
+cp -r "$REPO_ROOT/home_page/"* "$WORK_DIR/site/"
 
 # Update API docs (only with --with-docs)
 if [ "$WITH_DOCS" = true ]; then

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Shared deploy logic for pushing to gh-pages branch.
+# Usage: ./scripts/deploy-to-gh-pages.sh [--with-docs] [--ci]
+#
+# --with-docs   Also deploy API docs from docbuild/.lake/build/doc (fails if missing)
+# --ci          Use github-actions[bot] as committer instead of local git config
+set -euo pipefail
+
+WITH_DOCS=false
+CI_MODE=false
+for arg in "$@"; do
+  case $arg in
+    --with-docs) WITH_DOCS=true ;;
+    --ci) CI_MODE=true ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "==> Cloning gh-pages branch..."
+if [ "$CI_MODE" = true ]; then
+  REPO_URL="https://x-access-token:${GITHUB_TOKEN:-$GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+else
+  REPO_URL="$(git -C "$REPO_ROOT" remote get-url origin)"
+fi
+git clone --branch gh-pages --single-branch --depth 1 "$REPO_URL" "$WORK_DIR/site"
+
+# Update blueprint
+echo "==> Updating blueprint..."
+rm -rf "$WORK_DIR/site/blueprint"
+mkdir -p "$WORK_DIR/site/blueprint"
+cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
+cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf"
+
+# Update homepage (clean first to remove stale files)
+echo "==> Updating homepage..."
+rm -rf "$WORK_DIR/site/_layouts" "$WORK_DIR/site/assets"
+cp "$REPO_ROOT/home_page/_config.yml" "$WORK_DIR/site/"
+cp "$REPO_ROOT/home_page/index.md" "$WORK_DIR/site/"
+cp "$REPO_ROOT/home_page/404.html" "$WORK_DIR/site/" 2>/dev/null || true
+cp "$REPO_ROOT/home_page/Gemfile" "$WORK_DIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/assets" "$WORK_DIR/site/" 2>/dev/null || true
+cp -r "$REPO_ROOT/home_page/_layouts" "$WORK_DIR/site/" 2>/dev/null || true
+
+# Update API docs (only with --with-docs)
+if [ "$WITH_DOCS" = true ]; then
+  echo "==> Updating API docs..."
+  if [ ! -d "$REPO_ROOT/docbuild/.lake/build/doc" ]; then
+    echo "::error::API docs not found at docbuild/.lake/build/doc"
+    echo "Run 'cd docbuild && lake build TNLean:docs' first."
+    exit 1
+  fi
+  rm -rf "$WORK_DIR/site/docs"
+  cp -r "$REPO_ROOT/docbuild/.lake/build/doc" "$WORK_DIR/site/docs"
+fi
+
+# Commit and push
+echo "==> Committing and pushing..."
+cd "$WORK_DIR/site"
+if [ "$CI_MODE" = true ]; then
+  git config user.name "github-actions[bot]"
+  git config user.email "github-actions[bot]@users.noreply.github.com"
+else
+  git config user.name "$(git -C "$REPO_ROOT" config user.name || echo 'deploy-script')"
+  git config user.email "$(git -C "$REPO_ROOT" config user.email || echo 'deploy@local')"
+fi
+git add -A
+if git diff --cached --quiet; then
+  echo "No changes to deploy."
+else
+  MSG="Update blueprint"
+  [ "$WITH_DOCS" = true ] && MSG="Full docs update"
+  git commit -m "$MSG ($(date -u '+%Y-%m-%d %H:%M UTC'))"
+  git push origin gh-pages
+  echo "==> Deployed!"
+fi

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -32,7 +32,7 @@ echo "==> Updating blueprint..."
 rm -rf "$WORK_DIR/site/blueprint"
 mkdir -p "$WORK_DIR/site/blueprint"
 cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
-cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf"
+cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf" 2>/dev/null || true
 
 # Update homepage (remove all homepage files first, then copy fresh)
 echo "==> Updating homepage..."


### PR DESCRIPTION
## Summary
- Split `blueprint.yml` into a fast blueprint-only workflow and a separate `docgen.yml` for full API docs
- Blueprint workflow (~10 min): `lake build` + `leanblueprint pdf/web` + Jekyll + deploy to Pages — no doc-gen4
- Docgen workflow (weekly Sunday + manual): full `docgen-action` with 480-minute timeout for API docs
- Add `--update-lean-decls` step in `lint-blueprint.yml` before sync check, since `leanblueprint web` can clobber `lean_decls`

Fixes the 6-hour timeout caused by doc-gen4 elaborating the full codebase on every push.

## Test plan
- [ ] Merge and verify blueprint workflow completes in ~10 min and deploys to Pages
- [ ] Manually trigger "Full documentation" workflow and verify it completes with API docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI deployment and repository write permissions for automated pushes to `gh-pages`, so misconfiguration could break publishing or overwrite site content. No production runtime or application logic is modified.
> 
> **Overview**
> **Splits Pages publishing into two workflows**: `blueprint.yml` now builds only the blueprint web output on pushes to `main` and deploys it to `gh-pages`, while a new `docgen.yml` runs weekly or manually to build the blueprint + generate `TNLean:docs` and deploy `/docs` as well.
> 
> **Adds shared deployment tooling** via `scripts/deploy-to-gh-pages.sh` (plus `deploy-blueprint.sh`/`deploy-docs.sh`) that clones `gh-pages` and updates blueprint/homepage, optionally docs, and updates `blueprint/src/web.tex` links to use relative paths for the deployed structure. `lint-blueprint.yml` is tweaked to build the project before running declaration sync/checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f66d987b879bb5887253732ec477ea74a38c34f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->