### PR TITLE
feat(MPS/RFP): prove reverse direction of zcl_iff_idempotent_transfer

### DIFF
--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -71,6 +71,44 @@ See arXiv:1606.00608, Definition 3.6. -/
 def IsZCL (A : MPSTensor d D) : Prop :=
   IsLocallyOrthogonal A ∧ IsCID A
 
+/-- **CID implies RFP** (arXiv:1606.00608, Theorem 3.8 reverse direction):
+for a tensor with a PosDef fixed point, correlations independent of distance
+implies the transfer map is idempotent.
+
+The proof uses trace nondegeneracy: IsCID forces `tr(Y · Eⁿ(X · ρR))` to be
+constant in `n` for all `X`, `Y`, so `Eⁿ(X · ρR)` is constant. Since `ρR` is
+PosDef (hence invertible), `X · ρR` ranges over all matrices, giving `E² = E`. -/
+theorem isCID_implies_isRFP
+    (A : MPSTensor d D)
+    (ρR : Matrix (Fin D) (Fin D) ℂ)
+    (hρ_pd : ρR.PosDef)
+    (hρ_fix : transferMap A ρR = ρR)
+    (hCID : IsCID A) : IsRFP A := by
+  classical
+  change transferMap A ∘ₗ transferMap A = transferMap A
+  have hu := hρ_pd.isUnit
+  apply LinearMap.ext; intro Z
+  simp only [LinearMap.comp_apply]
+  -- Write Z = X * ρR using invertibility of ρR (PosDef ⟹ IsUnit)
+  set X := Z * hu.unit⁻¹.val with hX
+  have hZ : Z = X * ρR := by
+    rw [hX, mul_assoc, hu.val_inv_mul, mul_one]
+  rw [hZ]
+  -- By trace nondegeneracy, suffices: E(E(X·ρR)) - E(X·ρR) = 0
+  suffices h_diff : transferMap A (transferMap A (X * ρR)) -
+      transferMap A (X * ρR) = 0 from eq_of_sub_eq_zero h_diff
+  apply trace_mul_right_eq_zero; intro N
+  -- From IsCID with n=2, m=1: correlator equality gives trace equality
+  have h := hCID ρR hρ_pd hρ_fix X N 2 1 (by omega) (by omega)
+  simp only [connectedCorrelator_def, twoPointExpectation_transfer] at h
+  simp only [pow_succ, pow_zero, one_mul, Module.End.mul_apply] at h
+  -- h : tr(N * E(E(X*ρR))) - c = tr(N * E(X*ρR)) - c, so extract equality
+  have heq := sub_left_injective h
+  -- Goal: tr((E(E(X*ρR)) - E(X*ρR)) * N) = 0
+  rw [sub_mul, Matrix.trace_sub,
+    Matrix.trace_mul_comm _ N, Matrix.trace_mul_comm _ N]
+  exact sub_eq_zero.mpr heq
+
 /-- **Theorem 3.8** (arXiv:1606.00608): For an MPS tensor,
 ZCL is equivalent to the transfer map being idempotent (i.e. `IsRFP`).
 

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -86,20 +86,21 @@ theorem isCID_implies_isRFP
     (hCID : IsCID A) : IsRFP A := by
   classical
   change transferMap A ∘ₗ transferMap A = transferMap A
-  have hu := hρ_pd.isUnit
+  obtain ⟨u, rfl⟩ := hρ_pd.isUnit
   apply LinearMap.ext; intro Z
   simp only [LinearMap.comp_apply]
-  -- Write Z = X * ρR using invertibility of ρR (PosDef ⟹ IsUnit)
-  set X := Z * hu.unit⁻¹.val with hX
-  have hZ : Z = X * ρR := by
-    rw [hX, mul_assoc, hu.val_inv_mul, mul_one]
+  -- Write Z = X * ↑u using invertibility of ρR (PosDef ⟹ IsUnit)
+  set X := Z * (↑u⁻¹ : Matrix (Fin D) (Fin D) ℂ) with hX
+  have hZ : Z = X * (u : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [hX, mul_assoc, Units.inv_mul, mul_one]
   rw [hZ]
   -- By trace nondegeneracy, suffices: E(E(X·ρR)) - E(X·ρR) = 0
-  suffices h_diff : transferMap A (transferMap A (X * ρR)) -
-      transferMap A (X * ρR) = 0 from eq_of_sub_eq_zero h_diff
+  suffices h_diff : transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) -
+      transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)) = 0 from
+    eq_of_sub_eq_zero h_diff
   apply trace_mul_right_eq_zero; intro N
   -- From IsCID with n=2, m=1: correlator equality gives trace equality
-  have h := hCID ρR hρ_pd hρ_fix X N 2 1 (by omega) (by omega)
+  have h := hCID ↑u hρ_pd hρ_fix X N 2 1 (by omega) (by omega)
   simp only [connectedCorrelator_def, twoPointExpectation_transfer] at h
   simp only [pow_succ, pow_zero, one_mul, Module.End.mul_apply] at h
   -- h : tr(N * E(E(X*ρR))) - c = tr(N * E(X*ρR)) - c, so extract equality

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -300,6 +300,21 @@ All three quantitative results below are now fully proved.
     separation $n$ for all local observables $X$ and $Y$.
 \end{definition}
 
+\begin{theorem}[CID implies RFP]\label{thm:isCID_implies_isRFP}
+    \lean{MPSTensor.isCID_implies_isRFP}
+    \leanok
+    \uses{def:is_cid, def:is_rfp, def:transfer_map}
+    If an MPS tensor admits a positive definite right fixed point of its
+    transfer map and has correlations independent of distance, then
+    its transfer map is idempotent.
+    This is the reverse direction of \cite[Theorem~3.8]{Cirac2021Matrix}.
+\begin{proof}\leanok
+    Trace nondegeneracy and invertibility of the fixed point reduce
+    idempotence to equality of the connected correlator at separations
+    $n=2$ and $n=1$.
+\end{proof}
+\end{theorem}
+
 \begin{theorem}[Zero correlation length iff idempotent transfer]%
     \label{thm:zcl_iff_idempotent_transfer}
     \lean{MPSTensor.zcl_iff_idempotent_transfer}


### PR DESCRIPTION
### Motivation

- Completes the reverse direction of Theorem 3.8 (arXiv:1606.00608): IsCID → IsRFP for tensors with PosDef fixed point. Forward direction was proved in PR #471; this sorry was left open (see #501, #467, #233).

### Description

- Add `isCID_implies_isRFP` in `TNLean/MPS/RFP/ZeroCorrelationLength.lean`: given a PosDef right fixed point `ρR`, `IsCID` forces `transferMap A` to be idempotent (`E² = E`) via trace nondegeneracy and invertibility of `ρR`.
- Proof uses: IsCID forces `tr(Y · Eⁿ(X · ρR))` to be constant in `n` for all `X`, `Y`; since `ρR` is invertible, `X · ρR` ranges over all matrices, so `E² = E`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #501

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean theorem and blueprint documentation without changing executable logic, though it may affect downstream proofs relying on these lemmas.
> 
> **Overview**
> Proves the missing reverse direction of Cirac et al. Theorem 3.8 by adding `MPSTensor.isCID_implies_isRFP`, showing that *CID plus a positive-definite right fixed point* forces the transfer map to be idempotent (`E² = E`).
> 
> Updates the blueprint to include the corresponding “CID implies RFP” theorem statement and proof sketch, and keeps `zcl_iff_idempotent_transfer` as the main equivalence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4397b1eb9f3b82a1457dbf321ce54e2bcf78505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->