### PR TITLE
refactor(Channel): remove sorry import contamination from WolfChapter6Index

### DIFF
--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -6,7 +6,6 @@ import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.ConditionalExpectation
 import TNLean.Channel.FixedPoint.StationarySupport
-import TNLean.Channel.FixedPoint.WedderburnDecomp
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Irreducible.Growth


### PR DESCRIPTION
## Summary
Remove the import of `TNLean.Channel.FixedPoint.WedderburnDecomp` from the documentation-only index file `WolfChapter6Index.lean`. This module has 3 sorrys that unnecessarily contaminate the import graph. The Wedderburn reference is kept in the doc comment.

## Changes
- `TNLean/Channel/WolfChapter6Index.lean`: remove 1 import line

## Verification
✅ `lake build` passes (8516/8516 jobs)

Closes LionSR/QICLean#146

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single import from a documentation-only index module, reducing propagation of `sorry`-containing dependencies without changing any runtime/proof logic.
> 
> **Overview**
> Removes the `TNLean.Channel.FixedPoint.WedderburnDecomp` import from the documentation-only `WolfChapter6Index.lean`, preventing its `sorry`-containing theorems from contaminating downstream imports while keeping the Wedderburn references in the doc index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b7e4119c5e94c1a2f0b8834334ec99aa1d13f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->