### PR TITLE
refactor(Channel): deduplicate support-projection invariance proof

### DIFF
--- a/TNLean/Channel/FixedPoint/StationarySupport.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupport.lean
@@ -40,6 +40,8 @@ local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 /-- If each Kraus operator `K i` is block-upper-triangular with respect to an
 orthogonal projection `P`, then the transfer map preserves the compression
 `P M_D P`. -/
+-- Intentionally public so `ReducibleQDS.FixedDensity` can reuse this helper
+-- instead of carrying a second local copy of the same proof.
 lemma lowerZero_implies_invariance
     {r : ℕ} (K : Fin r → Mat) {P : Mat}
     (hP : IsOrthogonalProjection P)
@@ -218,6 +220,9 @@ were vacuous/trivial. They should be replaced by:
 * a non-vacuous Prop. 6.9 equivalence (irreducibility ↔ full support of
   stationary states), and
 * Prop. 6.10 minimality of stationary support without assuming irreducibility.
+* TODO: if we want to also deduplicate the near-copy in
+  `MPS/Irreducible/FormII.lean`, extract `lowerZero_implies_invariance` to a
+  lighter shared helper rather than adding cross-layer imports.
 -/
 
 end Channel

--- a/TNLean/Channel/FixedPoint/StationarySupport.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupport.lean
@@ -37,7 +37,10 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-private lemma lowerZero_implies_invariance
+/-- If each Kraus operator `K i` is block-upper-triangular with respect to an
+orthogonal projection `P`, then the transfer map preserves the compression
+`P M_D P`. -/
+lemma lowerZero_implies_invariance
     {r : ℕ} (K : Fin r → Mat) {P : Mat}
     (hP : IsOrthogonalProjection P)
     (hLower : ∀ i : Fin r, (1 - P) * K i * P = 0) :

--- a/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Semigroup.ReducibleQDS.Defs
+-- `ReducibleQDS.Defs` does not already import `StationarySupport`, so this is
+-- the direct import needed to reuse `Channel.lowerZero_implies_invariance`.
 import TNLean.Channel.FixedPoint.StationarySupport
 
 /-!

--- a/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Semigroup.ReducibleQDS.Defs
+import TNLean.Channel.FixedPoint.StationarySupport
 
 /-!
 # Fixed Density ↔ Kernel Element (Wolf Prop 7.6, (1) ↔ (2)) and (1) → (3)
@@ -64,50 +65,6 @@ support of `ρ₀`. Taking the support projection therefore produces a nontrivia
 compression invariant under the whole semigroup.
 -/
 
-private lemma lowerZero_implies_invariance'
-    {r : ℕ} (K : Fin r → Mat) {P : Mat}
-    (hP : IsOrthogonalProjection P)
-    (hLower : ∀ i : Fin r, (1 - P) * K i * P = 0) :
-    ∀ X : Mat,
-      P * MPSTensor.transferMap (d := r) (D := D) K (P * X * P) * P =
-        MPSTensor.transferMap (d := r) (D := D) K (P * X * P) := by
-  intro X
-  have hP_herm : Pᴴ = P := hP.1
-  have hAP : ∀ i : Fin r, K i * P = P * K i * P := by
-    intro i
-    have hkey : K i * P - P * K i * P = 0 := by
-      have h : (1 - P) * K i * P = K i * P - P * K i * P := by
-        noncomm_ring
-      rw [← h]
-      exact hLower i
-    exact eq_of_sub_eq_zero hkey
-  have hPAd : ∀ i : Fin r, P * (K i)ᴴ = P * (K i)ᴴ * P := by
-    intro i
-    have hct : P * (K i)ᴴ * (1 - P) = 0 := by
-      have h := congrArg Matrix.conjTranspose (hLower i)
-      simp only [Matrix.conjTranspose_zero, Matrix.conjTranspose_mul,
-        Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hP_herm] at h
-      simpa [Matrix.mul_assoc]
-    have hkey : P * (K i)ᴴ - P * (K i)ᴴ * P = 0 := by
-      have h : P * (K i)ᴴ * (1 - P) = P * (K i)ᴴ - P * (K i)ᴴ * P := by
-        noncomm_ring
-      rwa [← h]
-    exact eq_of_sub_eq_zero hkey
-  simp only [MPSTensor.transferMap_apply]
-  rw [Finset.mul_sum, Finset.sum_mul]
-  apply Finset.sum_congr rfl
-  intro i _
-  have h1 : K i * (P * X * P) * (K i)ᴴ =
-      (K i * P) * X * (P * (K i)ᴴ) := by
-    noncomm_ring
-  have h2 : (K i * P) * X * (P * (K i)ᴴ) =
-      (P * K i * P) * X * (P * (K i)ᴴ * P) := by
-    conv_lhs => rw [hAP i, hPAd i]
-  have h3 : (P * K i * P) * X * (P * (K i)ᴴ * P) =
-      P * (K i * (P * X * P) * (K i)ᴴ) * P := by
-    noncomm_ring
-  exact ((h1.trans h2).trans h3).symm
-
 private theorem invariantCompression_of_supportProj_fixed_by_channel
     {E : Mat →ₗ[ℂ] Mat} (hE : IsChannel E) {ρ : Mat}
     (hρ_psd : ρ.PosSemidef) (hρ_fix : E ρ = ρ) :
@@ -131,7 +88,7 @@ private theorem invariantCompression_of_supportProj_fixed_by_channel
   refine ⟨hP_data.1, ?_⟩
   intro X
   rw [hE_eq_transfer]
-  exact lowerZero_implies_invariance' (D := D) K hP_data.1 hP_data.2 X
+  exact Channel.lowerZero_implies_invariance (D := D) K hP_data.1 hP_data.2 X
 
 private lemma not_posDef_of_proj_sandwich_eq_self
     {P ρ : Mat}


### PR DESCRIPTION
## Summary
The private lemma `lowerZero_implies_invariance` was duplicated verbatim in `StationarySupport.lean` and `FixedDensity.lean`. This PR makes the FixedPoint version non-private and has the semigroup file import and reuse it.

## Changes
- `TNLean/Channel/FixedPoint/StationarySupport.lean`: `private lemma` → `lemma` (+ docstring)
- `TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean`: remove 40-line duplicate proof, import and delegate to the shared version

Public API gains the intentionally public helper lowerZero_implies_invariance; there are no breaking changes.

## Verification
✅ `lake build` passes (8516/8516 jobs)

Closes #510

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes lemma visibility and reuses the same proof across files; main risk is introducing an extra import/dependency edge that could affect build order.
> 
> **Overview**
> Makes the support-projection invariance helper `lowerZero_implies_invariance` in `Channel/FixedPoint/StationarySupport.lean` **public** and documents its intent for reuse.
> 
> Removes the verbatim duplicate proof from `Channel/Semigroup/ReducibleQDS/FixedDensity.lean`, adds an explicit import of `FixedPoint.StationarySupport`, and delegates to `Channel.lowerZero_implies_invariance` when proving invariant compression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2406e3dec8cb9ca504a7b474d375ecda1a260f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
