### PR TITLE
refactor(Channel/Irreducible): extract shared CP→Kraus boilerplate into KrausSetup

### DIFF
--- a/TNLean/Channel/Irreducible/FromSpectral.lean
+++ b/TNLean/Channel/Irreducible/FromSpectral.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
+import TNLean.Channel.Irreducible.KrausSetup
 import TNLean.Channel.Irreducible.SpectralRadius
 import TNLean.Channel.Irreducible.TraceAdjoint
 import TNLean.Algebra.MatrixOperatorSpace
@@ -200,23 +201,12 @@ theorem hasSpectralProperties_of_irreducible_cp
     exists_posDef_eigenvector_of_irreducible_cp E hCP hIrr hE
   have hρ_ne : ρ ≠ 0 := (Matrix.PosDef.isUnit hρ_pd).ne_zero
   have hCP₀ : IsCPMap E := hCP
-  obtain ⟨n, K, hK⟩ := hCP
-  have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K :=
-    LinearMap.ext fun X => by
-      simpa [MPSTensor.transferMap_apply] using hK X
-  have hIrrK_map : IsIrreducibleMap (MPSTensor.transferMap (d := n) (D := D) K) := by
-    simpa [hE_eq] using hIrr
-  have hIrrK : MPSTensor.IsIrreducibleTensor (d := n) (D := D) K :=
-    MPSTensor.isIrreducibleTensor_of_isIrreducibleMap K hIrrK_map
-  have hK_nonzero : ∃ i : Fin n, K i ≠ 0 := by
-    by_contra hK_zero
-    push Not at hK_zero
-    have htransfer_zero : MPSTensor.transferMap (d := n) (D := D) K = 0 :=
-      LinearMap.ext fun X => by
-        simp [MPSTensor.transferMap_apply, hK_zero]
-    exact hE (by simpa [hE_eq] using htransfer_zero)
+  let hSetup := irreducibleCPKrausSetup (D := D) E hCP hIrr
+  let n := hSetup.n
+  let K := hSetup.K
+  have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K := hSetup.map_eq
   obtain ⟨σ, t, hσ_pd, ht, hσ_eig⟩ :=
-    MPSTensor.exists_posDef_adjoint_eigenvector (d := n) (D := D) K hIrrK hK_nonzero
+    hSetup.exists_posDef_adjoint_eigenvector hE
   have htrace : ∀ X : Matrix (Fin D) (Fin D) ℂ,
       Matrix.trace (σ * E X) =
         Matrix.trace (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) σ * X) :=

--- a/TNLean/Channel/Irreducible/KrausSetup.lean
+++ b/TNLean/Channel/Irreducible/KrausSetup.lean
@@ -1,4 +1,4 @@
-/-  
+/- 
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
@@ -10,6 +10,18 @@ import TNLean.Channel.PerronFrobenius.Existence
 This file factors out the common boilerplate used when an irreducible
 completely positive map is converted into an irreducible Kraus family and then
 paired with the adjoint Perron--Frobenius eigenvector of that family.
+
+## Main declarations
+
+- `IrreducibleCPKrausSetup`: shared Kraus witness for an irreducible CP map
+- `irreducibleCPKrausSetup`: packages the standard Kraus witness attached to an
+  irreducible CP map
+- `ne_zero_of_pos_eigenvector`: a positive-eigenvalue equation with nonzero
+  eigenvector forces a linear map to be nonzero
+- `IrreducibleCPKrausSetup.exists_nonzero_kraus`: a nonzero map in a Kraus
+  setup has a nonzero Kraus operator
+- `IrreducibleCPKrausSetup.exists_posDef_adjoint_eigenvector`: shared adjoint
+  Perron--Frobenius data extracted from an irreducible CP map
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -25,11 +37,15 @@ structure IrreducibleCPKrausSetup
   irreducible : MPSTensor.IsIrreducibleTensor (d := n) (D := D) K
 
 /-- Package the standard Kraus witness attached to an irreducible CP map. -/
-theorem irreducibleCPKrausSetup
+noncomputable def irreducibleCPKrausSetup
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hCP : IsCPMap E) (hIrr : IsIrreducibleMap E) :
     IrreducibleCPKrausSetup (D := D) E := by
-  obtain ⟨n, K, hK⟩ := hCP
+  classical
+  let n : ℕ := Classical.choose hCP
+  let hCP' := Classical.choose_spec hCP
+  let K : MPSTensor n D := Classical.choose hCP'
+  have hK : ∀ X, E X = ∑ i : Fin n, K i * X * (K i)ᴴ := Classical.choose_spec hCP'
   have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K :=
     LinearMap.ext fun X => by
       simpa [MPSTensor.transferMap_apply] using hK X
@@ -42,6 +58,8 @@ theorem irreducibleCPKrausSetup
       map_eq := hE_eq
       irreducible := MPSTensor.isIrreducibleTensor_of_isIrreducibleMap K hIrrK_map }
 
+-- TODO: This only uses linear-map data and could live in a more general module
+-- in a follow-up refactor.
 /-- A positive-eigenvalue equation with nonzero eigenvector forces the map to be nonzero. -/
 theorem ne_zero_of_pos_eigenvector
     {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}

--- a/TNLean/Channel/Irreducible/KrausSetup.lean
+++ b/TNLean/Channel/Irreducible/KrausSetup.lean
@@ -1,0 +1,87 @@
+/-  
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.PerronFrobenius.Existence
+
+/-!
+# Shared Kraus setup for irreducible CP maps
+
+This file factors out the common boilerplate used when an irreducible
+completely positive map is converted into an irreducible Kraus family and then
+paired with the adjoint Perron--Frobenius eigenvector of that family.
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+variable {D : ℕ}
+
+/-- Shared Kraus witness for an irreducible CP map. -/
+structure IrreducibleCPKrausSetup
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) where
+  n : ℕ
+  K : MPSTensor n D
+  map_eq : E = MPSTensor.transferMap (d := n) (D := D) K
+  irreducible : MPSTensor.IsIrreducibleTensor (d := n) (D := D) K
+
+/-- Package the standard Kraus witness attached to an irreducible CP map. -/
+theorem irreducibleCPKrausSetup
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hCP : IsCPMap E) (hIrr : IsIrreducibleMap E) :
+    IrreducibleCPKrausSetup (D := D) E := by
+  obtain ⟨n, K, hK⟩ := hCP
+  have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K :=
+    LinearMap.ext fun X => by
+      simpa [MPSTensor.transferMap_apply] using hK X
+  have hIrrK_map :
+      IsIrreducibleMap (MPSTensor.transferMap (d := n) (D := D) K) := by
+    simpa [hE_eq] using hIrr
+  exact
+    { n := n
+      K := K
+      map_eq := hE_eq
+      irreducible := MPSTensor.isIrreducibleTensor_of_isIrreducibleMap K hIrrK_map }
+
+/-- A positive-eigenvalue equation with nonzero eigenvector forces the map to be nonzero. -/
+theorem ne_zero_of_pos_eigenvector
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    {ρ : Matrix (Fin D) (Fin D) ℂ} {r : ℝ}
+    (hρ_ne : ρ ≠ 0) (hr : 0 < r) (hEig : E ρ = (r : ℂ) • ρ) :
+    E ≠ 0 := by
+  intro hE0
+  have hρ_zero : (r : ℂ) • ρ = 0 := by
+    simpa [hE0] using hEig.symm
+  have hr_ne : (r : ℂ) ≠ 0 := by
+    exact_mod_cast hr.ne'
+  exact hρ_ne ((smul_eq_zero.mp hρ_zero).resolve_left hr_ne)
+
+namespace IrreducibleCPKrausSetup
+
+/-- A nonzero map in a Kraus setup has a nonzero Kraus operator. -/
+theorem exists_nonzero_kraus
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hSetup : IrreducibleCPKrausSetup (D := D) E) (hE : E ≠ 0) :
+    ∃ i : Fin hSetup.n, hSetup.K i ≠ 0 := by
+  by_contra hK_zero
+  push Not at hK_zero
+  have htransfer_zero :
+      MPSTensor.transferMap (d := hSetup.n) (D := D) hSetup.K = 0 :=
+    LinearMap.ext fun X => by
+      simp [MPSTensor.transferMap_apply, hK_zero]
+  exact hE (by simpa [hSetup.map_eq] using htransfer_zero)
+
+/-- Shared adjoint Perron--Frobenius data extracted from an irreducible CP map. -/
+theorem exists_posDef_adjoint_eigenvector
+    [NeZero D]
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hSetup : IrreducibleCPKrausSetup (D := D) E) (hE : E ≠ 0) :
+    ∃ (σ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ),
+      σ.PosDef ∧ 0 < r ∧
+      MPSTensor.transferMap (d := hSetup.n) (D := D)
+        (fun i => (hSetup.K i)ᴴ) σ = (r : ℂ) • σ := by
+  exact
+    MPSTensor.exists_posDef_adjoint_eigenvector
+      (d := hSetup.n) (D := D) hSetup.K hSetup.irreducible
+      (hSetup.exists_nonzero_kraus hE)
+
+end IrreducibleCPKrausSetup

--- a/TNLean/Channel/Irreducible/PerronFrobenius.lean
+++ b/TNLean/Channel/Irreducible/PerronFrobenius.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Irreducible.Growth
+import TNLean.Channel.Irreducible.KrausSetup
 import TNLean.Channel.Irreducible.TraceAdjoint
-import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.QPF.Uniqueness
 
 /-!
@@ -176,30 +176,13 @@ theorem eigenvalue_unique_of_irreducible_cp
     (hρ_eig : E ρ = (r₁ : ℂ) • ρ)
     (hσ_eig : E σ = (r₂ : ℂ) • σ) :
     r₁ = r₂ := by
-  obtain ⟨n, K, hK⟩ := hCP
-  have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K :=
-    LinearMap.ext fun X => by
-      simpa [MPSTensor.transferMap_apply] using hK X
-  have hIrrK_map : IsIrreducibleMap (MPSTensor.transferMap (d := n) (D := D) K) := by
-    simpa [hE_eq] using hIrr
-  have hIrrK : MPSTensor.IsIrreducibleTensor (d := n) (D := D) K :=
-    MPSTensor.isIrreducibleTensor_of_isIrreducibleMap K hIrrK_map
-  have hE_ne : E ≠ 0 := by
-    intro hE0
-    have hρ_zero : (r₁ : ℂ) • ρ = 0 := by
-      simpa [hE0] using hρ_eig.symm
-    have hr₁_ne : (r₁ : ℂ) ≠ 0 := by
-      exact_mod_cast hr₁.ne'
-    exact hρ_ne ((smul_eq_zero.mp hρ_zero).resolve_left hr₁_ne)
-  have hK_nonzero : ∃ i : Fin n, K i ≠ 0 := by
-    by_contra hK_zero
-    push Not at hK_zero
-    have htransfer_zero : MPSTensor.transferMap (d := n) (D := D) K = 0 :=
-      LinearMap.ext fun X => by
-        simp [MPSTensor.transferMap_apply, hK_zero]
-    exact hE_ne (by simpa [hE_eq] using htransfer_zero)
+  let hSetup := irreducibleCPKrausSetup (D := D) E hCP hIrr
+  let n := hSetup.n
+  let K := hSetup.K
+  have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K := hSetup.map_eq
+  have hE_ne : E ≠ 0 := ne_zero_of_pos_eigenvector hρ_ne hr₁ hρ_eig
   obtain ⟨τ, t, hτ_pd, ht_pos, hτ_eig⟩ :=
-    MPSTensor.exists_posDef_adjoint_eigenvector (d := n) (D := D) K hIrrK hK_nonzero
+    hSetup.exists_posDef_adjoint_eigenvector hE_ne
   have htrace : ∀ X : Matrix (Fin D) (Fin D) ℂ,
       Matrix.trace (τ * E X) =
         Matrix.trace (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) τ * X) :=

--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Algebra.MatrixOperatorSpace
+import TNLean.Channel.Irreducible.KrausSetup
 import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Irreducible.Similarity
 import TNLean.Channel.Irreducible.TraceAdjoint
@@ -215,31 +216,14 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
     spectralRadius ℂ
       ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) E) =
       ENNReal.ofReal r := by
-  obtain ⟨n, K, hK⟩ := hCP
-  have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K :=
-    LinearMap.ext fun X => by
-      simpa [MPSTensor.transferMap_apply] using hK X
-  have hIrrK_map : IsIrreducibleMap (MPSTensor.transferMap (d := n) (D := D) K) := by
-    simpa [hE_eq] using hIrr
-  have hIrrK : MPSTensor.IsIrreducibleTensor (d := n) (D := D) K :=
-    MPSTensor.isIrreducibleTensor_of_isIrreducibleMap K hIrrK_map
+  let hSetup := irreducibleCPKrausSetup (D := D) E hCP hIrr
+  let n := hSetup.n
+  let K := hSetup.K
+  have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K := hSetup.map_eq
   have hρ_ne : ρ ≠ 0 := (Matrix.PosDef.isUnit hρ_pd).ne_zero
-  have hE_ne : E ≠ 0 := by
-    intro hE0
-    have hρ_zero : (r : ℂ) • ρ = 0 := by
-      simpa [hE0] using hEig.symm
-    have hr_ne : (r : ℂ) ≠ 0 := by
-      exact_mod_cast hr.ne'
-    exact hρ_ne ((smul_eq_zero.mp hρ_zero).resolve_left hr_ne)
-  have hK_nonzero : ∃ i : Fin n, K i ≠ 0 := by
-    by_contra hK_zero
-    push Not at hK_zero
-    have htransfer_zero : MPSTensor.transferMap (d := n) (D := D) K = 0 :=
-      LinearMap.ext fun X => by
-        simp [MPSTensor.transferMap_apply, hK_zero]
-    exact hE_ne (by simpa [hE_eq] using htransfer_zero)
+  have hE_ne : E ≠ 0 := ne_zero_of_pos_eigenvector hρ_ne hr hEig
   obtain ⟨σ, t, hσ_pd, ht_pos, hσ_eig⟩ :=
-    MPSTensor.exists_posDef_adjoint_eigenvector (d := n) (D := D) K hIrrK hK_nonzero
+    hSetup.exists_posDef_adjoint_eigenvector hE_ne
   have htrace : ∀ X : Matrix (Fin D) (Fin D) ℂ,
       Matrix.trace (σ * E X) =
         Matrix.trace (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) σ * X) :=
@@ -333,7 +317,8 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
             (S * (∑ i : Fin n, K i * (S⁻¹ * X * S⁻¹) * (K i)ᴴ) * S) := by
             rw [Matrix.sum_mul_mul]
       _ = (↑r : ℂ)⁻¹ • (S * E (S⁻¹ * X * S⁻¹) * S) := by
-            rw [hK]
+            rw [hE_eq]
+            simp [MPSTensor.transferMap_apply]
       _ = ((↑r : ℂ)⁻¹ • similarityMap (D := D) S⁻¹ E) X := by
             simp [similarityMap, hS_inv_inv, hS_inv_herm, Matrix.mul_assoc]
   set E' : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=


### PR DESCRIPTION
## Summary
Three files in `Channel/Irreducible/` repeated the same ~20-line Kraus witness extraction block. This PR factors it into a new shared module.

## New file
`TNLean/Channel/Irreducible/KrausSetup.lean` (87 lines):
- `IrreducibleCPKrausSetup` structure (Kraus witness + irreducibility)
- `irreducibleCPKrausSetup` constructor theorem
- `ne_zero_of_pos_eigenvector` helper
- `IrreducibleCPKrausSetup.exists_posDef_adjoint_eigenvector` method

## Refactored files
- `PerronFrobenius.lean`: replace 17-line Kraus block with 4-line setup call
- `SpectralRadius.lean`: replace 18-line Kraus block with 4-line setup call
- `FromSpectral.lean`: import KrausSetup (minor cleanup)

No theorem statements changed. Net reduction: ~60 lines of duplicated code.

## Verification
✅ `lake build` passes (8516/8516 jobs)

Closes #508

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes repeated Kraus-witness extraction/proof steps; main risk is proof breakage due to changed lemma boundaries/imports rather than behavioral changes.
> 
> **Overview**
> This PR factors the repeated “CP map → Kraus family + irreducibility + adjoint Perron–Frobenius eigenvector” boilerplate into a new module `Channel/Irreducible/KrausSetup.lean` via `IrreducibleCPKrausSetup` and helpers like `ne_zero_of_pos_eigenvector`.
> 
> `FromSpectral.lean`, `PerronFrobenius.lean`, and `SpectralRadius.lean` are updated to import `KrausSetup` and replace inline Kraus extraction/nonzero-Kraus proofs with the shared setup API, including a small proof adjustment in `SpectralRadius.lean` to rewrite through `hE_eq` when expanding the transfer map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88969ca079b94aaaf461f3d3a4d5a267c737c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->