### PR TITLE
doc(blueprint): clean Lean jargon and software language from 8 chapters

### DIFF
--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -350,7 +350,7 @@ boundary conditions (PBC).
 \end{definition}
 
 \begin{remark}\label{rem:cf_injective_vs_normal}\leanok
-    Here we use the block-injective (biCF-style) canonical form:
+    Here we use the block-injective canonical form:
     each block is injective in the sense of
     Definition~\ref{def:injective}.
     This is stronger than the NT-block canonical form of

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1,7 +1,7 @@
 %% =========================================================
 %% Chapter: Matrix Product Operators and Density Operators
 %% Introduces MPO and LPDO notation for the blueprint and records the
-%% formalized conversion between local MPO data and the associated MPS view.
+%% correspondence between local MPO data and the associated MPS view.
 %% =========================================================
 
 \chapter{Matrix Product Operators and Density Operators}\label{ch:mpdo}

--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -255,7 +255,7 @@ the full MPV family for all system sizes.
 The alternative algebraic proof of \cite{Molnar2018NormalPEPS} instead keeps a
 fixed periodic chain length and allows the local tensors to vary from site to
 site.
-The first step is therefore a separate data layer for finite
+The first step is therefore a separate setup for finite
 non-translation-invariant chains.
 
 \begin{definition}[Periodic non-TI chain data]\label{def:non_ti_chain}

--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -54,7 +54,7 @@ and~\cite{Evans1978Spectral}.
 	injectivity.
 \end{proof}
 
-\begin{theorem}[PSD fixed point is PD --- irreducible version]\label{thm:psd_fp_pd_irred}
+\begin{theorem}[PSD fixed point is positive definite --- irreducible version]\label{thm:psd_fp_pd_irred}
 	\lean{MPSTensor.posSemidef_fixedPoint_isPosDef_of_irreducible}
 	\leanok
 	\uses{def:irreducible_cp, def:transfer_map}
@@ -181,7 +181,7 @@ and~\cite{Evans1978Spectral}.
 	which is a positive CP map.
 	The Perron--Frobenius existence theorem
 	(Theorem~\ref{thm:pf_eigenvector_existence}) together with the
-	irreducible PSD-to-PosDef upgrade
+	irreducible positive-definiteness upgrade
 	(Theorem~\ref{thm:psd_fp_pd_irred}) gives a positive definite
 	eigenvector $\tau > 0$ with eigenvalue $t > 0$:
 	$E^\dagger(\tau) = t\,\tau$.
@@ -397,7 +397,7 @@ follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
 	each $(A^i)^\dagger = 0$ and hence each $A^i = 0$.
 \end{proof}
 
-\begin{theorem}[PosDef adjoint eigenvector for irreducible tensors]%
+\begin{theorem}[Positive-definite adjoint eigenvector for irreducible tensors]%
 	\label{thm:posDef_adjoint_eigenvector}
 	\lean{MPSTensor.exists_posDef_adjoint_eigenvector}
 	\leanok
@@ -440,7 +440,7 @@ follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
 	since irreducibility of $\E_A$ transfers to the
 	adjoint and is preserved under scaling).
 	Since $\E_T$ is irreducible with a PSD fixed point,
-	the PSD-to-PosDef upgrade
+	the positive-definiteness upgrade
 	(Theorem~\ref{thm:psd_fp_pd_irred})
 	gives $\sigma_0$ positive definite.
 \end{proof}

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -995,7 +995,7 @@ spectral gap. It is connected to normality through the following results.
     (Chapter~\ref{ch:canonical}, \S\ref{subsec:burnside_bridge})
     and Theorem~\ref{thm:algspan_to_normal}, one obtains
     \[
-        \text{primitive} + \rho\text{ PosDef}
+        \text{primitive} + \rho \text{ positive definite}
         \;\Rightarrow\;
         \text{irreducible}
         \;\Rightarrow\;
@@ -1013,7 +1013,7 @@ spectral gap. It is connected to normality through the following results.
 
 \subsection{Primitive implies irreducible}\label{subsec:prim_implies_irred}
 
-\begin{theorem}[Primitive with PosDef fixed point implies irreducible tensor]%
+\begin{theorem}[Primitive with positive-definite fixed point implies irreducible tensor]%
     \label{thm:primitive_implies_irreducible}
     \lean{MPSTensor.isIrreducibleTensor_of_isPrimitiveMPS_of_posDef}
     \leanok
@@ -1066,7 +1066,7 @@ Definition~\ref{def:primitive_mps} directly to normality
 using the convergence of the transfer-map iterates to the
 projection onto the fixed-point subspace.
 
-\begin{theorem}[Primitive MPS with PosDef fixed point has irreducible transfer map]%
+\begin{theorem}[Primitive MPS with positive-definite fixed point has irreducible transfer map]%
     \label{thm:irreducible_map_from_primitive}
     \lean{MPSTensor.isIrreducibleMap_of_isPrimitiveMPS_of_posDef}
     \leanok
@@ -1092,7 +1092,7 @@ projection onto the fixed-point subspace.
     irreducibility applies.
 \end{proof}
 
-\begin{theorem}[Primitive MPS with PosDef fixed point is strongly irreducible]%
+\begin{theorem}[Primitive MPS with positive-definite fixed point is strongly irreducible]%
     \label{thm:strongly_irred_from_primitive}
     \lean{MPSTensor.isStronglyIrreduciblePaper_of_isPrimitiveMPS_of_posDef}
     \leanok
@@ -1113,7 +1113,7 @@ projection onto the fixed-point subspace.
     (Theorem~\ref{thm:prim_overlap_one}).
 \end{proof}
 
-\begin{theorem}[Primitive MPS with PosDef fixed point is normal]%
+\begin{theorem}[Primitive MPS with positive-definite fixed point is normal]%
     \label{thm:normal_from_primitive_posdef}
     \lean{MPSTensor.isNormal_of_isPrimitiveMPS_with_posDef}
     \leanok

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -113,15 +113,15 @@ gap---is the approach adopted in this chapter.
     \lean{MPSTensor.piAlgEquiv}
     \leanok
     \uses{def:per_block_linear_ext}
-    The \emph{product algebra automorphism} is the blockwise assembled map
+    The \emph{product algebra automorphism} is the blockwise map
     $T:\prod_k\MN{D_k}\to\prod_k\MN{D_k}$ defined by
     $T(M)_k := T_k(M_k)$.
     Theorem~\ref{thm:pi_linear_ext} shows that each $T_k$ is a
-    $\C$-algebra homomorphism and that this assembled map is indeed a
+    $\C$-algebra homomorphism and that this map is a
     $\C$-algebra automorphism.
 \end{definition}
 
-\begin{theorem}[Per-block linear extensions assemble]\label{thm:pi_linear_ext}
+\begin{theorem}[Per-block linear extensions define a product algebra automorphism]\label{thm:pi_linear_ext}
     \lean{MPSTensor.piAlgEquiv_decomposition}
     \leanok
     \uses{def:injective, def:per_block_linear_ext}
@@ -129,7 +129,7 @@ gap---is the approach adopted in this chapter.
     $D_k$ for $k = 1, \ldots, r$, and suppose the per-block
     same-MPV condition holds.
     Then the per-block linear extensions $T_k : A_k^i \mapsto B_k^i$
-    assemble into an algebra automorphism of $\prod_k \MN{D_k}$,
+    define an algebra automorphism of $\prod_k \MN{D_k}$,
     which decomposes as a permutation $\pi$ with
     $D_{\pi(k)} = D_k$ and per-block conjugation matrices $X_k$.
 \end{theorem}
@@ -145,7 +145,7 @@ gap---is the approach adopted in this chapter.
     the product gives an algebra automorphism $T$.
     Theorem~\ref{thm:pi_auto_decomp} decomposes $T$ into
     a permutation plus per-block inner automorphisms.
-    Because $T$ is assembled blockwise, it preserves each block ideal,
+    Because $T$ acts blockwise, it preserves each block ideal,
     so in this theorem the permutation is actually $\pi = \mathrm{id}$.
     A nontrivial block permutation only appears after block separation
     identifies which blocks match globally.
@@ -167,8 +167,8 @@ gap---is the approach adopted in this chapter.
     \uses{thm:ft_single, thm:multi_block_global}
     Per-block gauge equivalence follows from the single-block
     FT (Theorem~\ref{thm:ft_single}) applied to each block.
-    Global gauge equivalence follows by assembling the
-    per-block gauge matrices into a block-diagonal matrix
+    Global gauge equivalence follows by placing the
+    per-block gauge matrices on the block diagonal
     (Theorem~\ref{thm:multi_block_global}).
 \end{proof}
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -176,7 +176,7 @@ The main references are
 
 \begin{remark}\label{rem:bnt_perm_prop_canonical}
 	In the canonical-form application, the abstract data above come from
-	block-diagonal assemblies
+	block-diagonal tensors
 	\[
 		A_{\mathrm{tot}} = \bigoplus_{j=1}^{g_A} \mu_j A_j,
 		\qquad
@@ -194,7 +194,7 @@ The main references are
 	constant $c_N$.
 	Definition~\ref{def:cf_bnt} supplies injectivity, TP normalization,
 	and the within-family overlap limits, so the theorem isolates the
-	abstract permutation argument from this canonical-form packaging.
+	abstract permutation argument from this canonical-form setting.
 \end{remark}
 
 \begin{theorem}[Permutation rigidity with asymptotically orthonormal overlaps]\label{thm:bnt_perm_simple}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -282,8 +282,8 @@ distinct weight norms).
 		\mu_j^A = \mu_{\pi(j)}^B \zeta_j.
 	\]
 	Thus the phase factors can be absorbed into the weights, and the
-	resulting blockwise conjugacies assemble to a gauge equivalence of the reindexed
-	weighted block-diagonal tensors.
+	resulting blockwise conjugacies combine to give a gauge equivalence of the
+	reindexed weighted block-diagonal tensors.
 \end{proof}
 
 \begin{theorem}[Fundamental Theorem --- equal MPV case, common block structure]\label{thm:ft_equal_same_structure}
@@ -327,8 +327,10 @@ single weighted block.
 	A \emph{sector datum} over $g$ basis blocks specifies:
 	multiplicities $r_j > 0$, sector weights
 	$\mu_{j,q} \neq 0$ for $q \in \{1,\dotsc,r_j\}$, and the
-	\emph{sector coefficient}
-	$\mathrm{coeff}(N,j) := \sum_{q=1}^{r_j} \mu_{j,q}^N$.
+	\emph{sector coefficients}
+	\[
+		c_j^{(N)} := \sum_{q=1}^{r_j} \mu_{j,q}^N.
+	\]
 	A \emph{sector decomposition} consists of the basis blocks
 	$(A_j)_{j=1}^g$ together with their sector data.
 \end{definition}
@@ -338,11 +340,11 @@ single weighted block.
 	\lean{MPSTensor.SectorDecomposition.mpv_toTensor_eq_sum_coeff}
 	\leanok
 	\uses{def:paper_sector_data}
-	For a sector decomposition $P$, the MPV of the associated tensor
-	satisfies
+	For a sector decomposition with associated tensor $A_{\mathrm{tot}}$,
+	the MPV satisfies
 	\[
-		V^{(N)}(P.\mathrm{toTensor})_\sigma
-		= \sum_{j=1}^{g} \mathrm{coeff}(N,j) \cdot V^{(N)}(A_j)_\sigma.
+		V^{(N)}(A_{\mathrm{tot}})_\sigma
+		= \sum_{j=1}^{g} c_j^{(N)} V^{(N)}(A_j)_\sigma.
 	\]
 \end{theorem}
 
@@ -351,9 +353,10 @@ single weighted block.
 	\lean{MPSTensor.SectorWeightData.coeff_eventually_eq_of_sameMPV}
 	\leanok
 	\uses{def:paper_sector_data, def:bnt}
-	If two sector data $S, T$ over the same basis produce equal total MPVs
+	If two sector data $S, T$ over the same basis, with coefficient arrays
+	$c_{S,j}^{(N)}$ and $c_{T,j}^{(N)}$, produce equal total MPVs
 	and the basis is eventually linearly independent (the BNT property),
-	then $S.\mathrm{coeff}(N,j) = T.\mathrm{coeff}(N,j)$ for all
+	then $c_{S,j}^{(N)} = c_{T,j}^{(N)}$ for all
 	sufficiently large $N$.
 \end{theorem}
 
@@ -392,8 +395,8 @@ single weighted block.
 		      (Theorem~\ref{thm:power_sum_multiset}).
 	\end{enumerate}
 	At the level of block contributions, one compares the weighted sector sums
-	$\sum_j \mathrm{coeff}_A(N,j)\,V^{(N)}(A_j)$ and
-	$\sum_j \mathrm{coeff}_B(N,j)\,V^{(N)}(B_j)$, with the coefficients
+	$\sum_j c_{A,j}^{(N)} V^{(N)}(A_j)$ and
+	$\sum_j c_{B,j}^{(N)} V^{(N)}(B_j)$, with the coefficients
 	now aggregated over the multiplicity layers.
 \end{theorem}
 
@@ -674,8 +677,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	projections $P_0,\dotsc,P_{m-1}$ on the ambient bond space such that
 	$\sum_k P_k = \Id$, each $P_k$ commutes with every blocked letter
 	$P_k A^{(m)}_i = A^{(m)}_i P_k$, and
-	$V^{(N)}(C_k)(\sigma) = \operatorname{tr}(P_k \cdot
-	\operatorname{evalWord}(A^{(m)}, \sigma))$ for every word~$\sigma$.
+	$V^{(N)}(C_k)_\sigma = \tr(P_k (A^{(m)})^\sigma)$ for every word~$\sigma$.
 \end{definition}
 
 \begin{theorem}[Self-overlap along period multiples]\label{thm:periodic_self_overlap_tendsto}
@@ -691,7 +693,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	\leanok
 	\uses{def:periodic_tensor}
 	If $A$ and $B$ are periodic with different periods, then
-	$\langle V_N(A), V_N(B)\rangle \to 0$ as $N\to\infty$.
+	$\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$.
 \end{theorem}
 \begin{proof}\leanok
 	Split on whether the bond dimensions agree. If not, dimension mismatch
@@ -746,7 +748,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	\leanok
 	\uses{def:periodic_tensor}
 	If two periodic tensors have different bond dimensions, then
-	$\langle V_N(A), V_N(B)\rangle \to 0$ as $N\to\infty$.
+	$\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$.
 \end{theorem}
 
 \begin{theorem}[Periodic overlap dichotomy]\label{thm:periodic_overlap_dichotomy}
@@ -756,7 +758,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	Let $A$ and $B$ be periodic tensors. Then at least one of the following
 	alternatives holds:
 	\begin{enumerate}
-		\item $\langle V_N(A), V_N(B)\rangle \to 0$ as $N\to\infty$;
+		\item $\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$;
 		\item $A$ and $B$ are equivalent up to repeated blocks.
 	\end{enumerate}
 \end{theorem}
@@ -766,7 +768,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	\uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
 	For a finite family of pairwise non-equivalent periodic tensors whose
 	periods divide a common integer $p$, there is $N_0$ such that for every
-	$N \ge N_0$ the vectors $\{V_{pN}(A_j)\}_j$ are linearly independent.
+	$N \ge N_0$ the vectors $\{\ket{V^{(pN)}(A_j)}\}_j$ are linearly independent.
 \end{theorem}
 
 \begin{remark}[Comparison with the 1606.00608 approach]\notready

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -329,8 +329,9 @@ single weighted block.
 	$\mu_{j,q} \neq 0$ for $q \in \{1,\dotsc,r_j\}$, and the
 	\emph{sector coefficients}
 	\[
-		c_j^{(N)} := \sum_{q=1}^{r_j} \mu_{j,q}^N.
+		c_{S,j}^{(N)} := \sum_{q=1}^{r_j} \mu_{j,q}^N
 	\]
+	for a sector datum $S$.
 	A \emph{sector decomposition} consists of the basis blocks
 	$(A_j)_{j=1}^g$ together with their sector data.
 \end{definition}
@@ -340,11 +341,11 @@ single weighted block.
 	\lean{MPSTensor.SectorDecomposition.mpv_toTensor_eq_sum_coeff}
 	\leanok
 	\uses{def:paper_sector_data}
-	For a sector decomposition with associated tensor $A_{\mathrm{tot}}$,
+	For a sector decomposition $S$ with associated tensor $A_{\mathrm{tot}}$,
 	the MPV satisfies
 	\[
 		V^{(N)}(A_{\mathrm{tot}})_\sigma
-		= \sum_{j=1}^{g} c_j^{(N)} V^{(N)}(A_j)_\sigma.
+		= \sum_{j=1}^{g} c_{S,j}^{(N)} V^{(N)}(A_j)_\sigma.
 	\]
 \end{theorem}
 


### PR DESCRIPTION
## Summary
Remove banned terms and Lean-specific jargon from blueprint prose per the style guide (`docs/blueprint_style_guide.md`).

## Changes by chapter

| Chapter | Fix |
|---------|-----|
| ch02_mps | remove 'biCF-style' abbreviation |
| ch02b_mpdo | 'formalized conversion' → 'correspondence' |
| ch03_single | 'data layer' → 'setup' |
| ch05_qpf | expand 'PosDef/PD' → 'positive definite' in theorem titles |
| ch07_wielandt | expand 'PosDef' → 'positive definite' in titles/prose |
| ch09_block_perm | 'assembled map' → 'blockwise map', 'assemble' → 'define' |
| ch10_bnt | 'assemblies' → 'tensors', 'packaging' → 'setting' |
| ch11_assembly | replace Lean-style `P.toTensor`/`S.coeff`/`evalWord` notation with standard math; 'assemble' → 'combine' |

All edits are prose-only, conservative, and limited to clear style guide violations.

## Verification
✅ LaTeX compiles cleanly

Partial fix for #498

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are prose-only LaTeX edits (terminology/notation/theorem titles) with no impact on formal statements or code, aside from potential minor cross-reference/title consistency issues.
> 
> **Overview**
> Cleans up blueprint prose across multiple chapters to follow the style guide by removing Lean-/software-flavored wording and abbreviations (e.g., dropping “biCF-style”, replacing “formalized conversion”/“data layer”/“packaging”/“assemble” phrasing).
> 
> Standardizes mathematical wording and notation, notably expanding `PosDef/PD` to “positive definite” in theorem titles/prose and replacing Lean-like function-call notation (`P.toTensor`, `S.coeff`, `evalWord`) with conventional formula notation for sector coefficients and MPV decompositions, plus minor readability tweaks (e.g., `\braket{V^{(N)}(A)}{V^{(N)}(B)}` in overlap statements).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 417a7c7be4d0d7cf50dce0e3aa6bdbc0fb71a896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->