### PR TITLE
chore(Lean): clean stale sorry mentions and banned terms in docstrings

### DIFF
--- a/TNLean/Algebra/BurnsideMatrix.lean
+++ b/TNLean/Algebra/BurnsideMatrix.lean
@@ -26,7 +26,7 @@ project rather than imported from Mathlib.
 * `MPSTensor.IsInvariantSubmodule A W`: `W ≤ (Fin D → ℂ)` is invariant under all `A i`.
 * `MPSTensor.IsIrreducibleAction A`: no nontrivial invariant submodule.
 
-## Main results (all sorry-free)
+## Main results
 
 ### Part 1: Algebra span and cumulative span
 

--- a/TNLean/Channel/Schwarz/PositiveOnAbelian.lean
+++ b/TNLean/Channel/Schwarz/PositiveOnAbelian.lean
@@ -19,11 +19,11 @@ later for the normal-operator Schwarz inequality. The key definition
 `IsPositiveOnCommuting` is phrased in terms of quadratic forms of block matrices
 whose images under the map commute pairwise.
 
-The main amplification theorem is currently left as a placeholder
-`quadraticForm_nonneg_of_isPositiveMap_of_commuting_images` with a
-`-- Wolf Prop 1.6` marker. The surrounding algebraic helper lemmas about the
-normal generators `{A, Aᴴ, Aᴴ * A, 1}` are proved and are intended to support
-later refinements toward Wolf Proposition 5.1.
+The main amplification theorem
+`quadraticForm_nonneg_of_isPositiveMap_of_commuting_images` is proved here,
+with a `-- Wolf Prop 1.6` marker. The surrounding algebraic helper lemmas
+about the normal generators `{A, Aᴴ, Aᴴ * A, 1}` are intended to support later
+refinements toward Wolf Proposition 5.1.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators TNMatrixCFC

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -20,7 +20,7 @@ This file is an **intermediate construction for the early arbitrary-input part**
 canonical-form construction for MPS tensors from Cirac–Pérez-García–Schuch–Verstraete,
 arXiv:1606.00608.
 
-We currently have (sorry-free) components for:
+We currently have the following components:
 
 * §2.3: iterated invariant-projection splitting → irreducible block decomposition.
 * Appendix A (PF / TP gauge): irreducible + nonzero Kraus operator → Perron--Frobenius
@@ -271,7 +271,7 @@ theorem isIrreducibleTensor_allZero_dim_le_one
 
 
 /-!
-## Honest arbitrary-input continuations (still far from the endpoint)
+## Unconditional arbitrary-input continuations (still far from the endpoint)
 
 The last unconditional arbitrary-input step currently available here is the blockwise PF / TP-gauge
 continuation below: after decomposing `A` into irreducible blocks, one may continue on each block
@@ -293,7 +293,7 @@ Remaining gap for a full end-to-end canonical-form existence theorem:
   the later normal-canonical-form packaging lemmas and the downstream `IsCanonicalForm` builders.
 -/
 
-/-- **Honest TP-gauge continuation for the 1606 reduction (1606.00608 §2.3 + App. A).**
+/-- **Unconditional TP-gauge continuation for the 1606 reduction (1606.00608 §2.3 + App. A).**
 
 From an arbitrary tensor `A` we produce an irreducible block decomposition. Moreover, for each
 resulting block, if one separately knows that the block has some nonzero Kraus operator, then the

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -299,7 +299,7 @@ theorem ker_all_of_inj {D₁ D₂ : ℕ}
 
 /-- If X ≠ 0 and ker(X) is invariant under all matrices, then det(X) ≠ 0.
 
-Fully proved (no sorry). The idea: pick v ≠ 0 with Xv = 0, map v to
+The idea: pick v ≠ 0 with Xv = 0, map v to
 any w via a rank-1 matrix M with Mv = w, then Xw = X(Mv) = 0, so X = 0. -/
 private lemma det_ne_zero_of_ker_all [NeZero D]
     (X : Matrix (Fin D) (Fin D) ℂ)
@@ -340,7 +340,7 @@ private lemma det_ne_zero_of_ker_all [NeZero D]
   exact hX h_X_zero
 
 -- From hFX and X invertible, derive ∑ (X⁻¹ A_i X) * B_i† = μ • 1
--- Fully proved (no sorry).
+-- Algebraic conjugation step used below.
 private lemma sum_conj_mul_conjTranspose [NeZero D]
     (A B : MPSTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) (μ : ℂ)
     (hFX : mixedTransferMap A B X = μ • X)
@@ -355,7 +355,7 @@ private lemma sum_conj_mul_conjTranspose [NeZero D]
   convert key using 1; congr 1; ext i; simp [Matrix.mul_assoc]
 
 -- If ∑ Rᵢ† Rᵢ = 0 then each Rᵢ = 0.
--- Fully proved (no sorry). Uses PSD trace argument.
+-- Uses the PSD trace argument to show each summand vanishes.
 private lemma each_zero_of_sum_conjTranspose_mul_self_zero
     (R : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (h : ∑ i : Fin d, (R i)ᴴ * R i = 0) :

--- a/TNLean/Wielandt/PaperResults/MatrixSpanExistence.lean
+++ b/TNLean/Wielandt/PaperResults/MatrixSpanExistence.lean
@@ -26,8 +26,8 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
 ## Quantitative status
 
 These wrappers are intentionally **coarse existential** statements. They use the
-backend theorem `wielandt_lemma2b`, which produces a sorry-free witness `N`
-without claiming the paper's exact bound.
+backend theorem `wielandt_lemma2b`, which produces a witness `N` without
+claiming the paper's exact bound.
 
 They record only the qualitative conclusion `∃ N, S_N(A) = M_D(ℂ)`. In
 particular, they do **not** track the explicit `D²` blocked noninvertible bound

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -347,7 +347,7 @@ This combines the rank-one extraction with the blocked assembly theorem.
   blocked-tensor full-span witness `wordSpan B N₀ = ⊤`; the blocked assembly then
   produces `wordSpan A ((4D - 2 + N₀) * N₀) = ⊤`.
 
-The bound `N = (4D - 2 + N₀) * N₀` is coarse but sorry-free. -/
+The bound `N = (4D - 2 + N₀) * N₀` is coarse. -/
 theorem wielandt_lemma2b [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     ∃ N : ℕ, wordSpan A N = ⊤ := by

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -234,7 +234,7 @@ theorem wielandt_chain [NeZero D]
 
 /-- **Summary of what's proven and what remains.**
 
-### Proven (sorry-free):
+### Proven:
 1. `cumulativeSpan_eq_top`: T_{D²}(A) = M_D(ℂ) for normal A
 2. `exists_nonzero_trace_word`: Lemma 1 — ∃ word with nonzero trace, length ≤ D²
 3. `exists_eigenvector_of_trace_ne_zero`: Nonzero trace → eigenvalue/eigenvector


### PR DESCRIPTION
Update 7 files with stale 'sorry' mentions in docstrings (no actual sorrys remain). Also fix banned term 'Honest' → 'Unconditional' in Existence.lean per style guide. Doc/comment-only changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only edits that adjust wording (removing stale “sorry-free” claims and replacing banned terminology) without changing definitions or proofs.
> 
> **Overview**
> Updates documentation across several Lean files to reflect current proof status and style: removes stale references to “sorry-free”/placeholders, clarifies that `quadraticForm_nonneg_of_isPositiveMap_of_commuting_images` is now proved, and replaces the banned term *Honest* with *Unconditional* in canonical-form narrative.
> 
> No functional code changes are introduced; this PR is strictly comment/docstring cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632a60479f593eaad5eb619d8ea4fccd2f933583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->