### PR TITLE
chore(Lean): replace banned terms in Lean docstrings

### DIFF
--- a/TNLean/Algebra/BlockTriangularTrace.lean
+++ b/TNLean/Algebra/BlockTriangularTrace.lean
@@ -7,7 +7,7 @@ import Mathlib.Logic.Equiv.Fin.Basic
 /-!
 # Block-triangular trace invariance for MPS tensors
 
-This file packages the observation that strict upper-right blocks do not affect
+This file records the observation that strict upper-right blocks do not affect
 word traces of block upper-triangular tensors. It defines block-sum and
 reindexing helpers and proves `sameMPV_upperFin_diagFin`, reducing an
 upper-triangular tensor to its block-diagonal part.
@@ -69,7 +69,7 @@ lemma trace_fromBlocks_upper (X : Matrix (Fin n) (Fin n) ℂ)
 
 /-- For any word `w`, evaluating `upperSum` gives an upper-triangular block matrix.
 
-We package the (inessential) upper-right block into an auxiliary recursion `UR`. -/
+We record the (inessential) upper-right block in an auxiliary recursion `UR`. -/
 lemma evalWord_upperSum_is_fromBlocks
     (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
     (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -74,7 +74,7 @@ decomposes each periodic block into primitive sectors before blocking.
 
 ### Progress on cyclic sector decomposition (#242)
 
-The per-block bridge is now complete:
+The per-block reduction step is now complete:
 
 * `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`: For each irreducible TP block,
   derives all channel-level hypotheses automatically and produces cyclic
@@ -229,7 +229,7 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
 ## Conditional normal canonical form
 
 If the blocked weights happen to have pairwise distinct norms, and the blocked
-blocks are irreducible, then the data can be packaged as `IsNormalCanonicalForm`
+blocks are irreducible, then the data yields `IsNormalCanonicalForm`
 after sorting by weight norm.
 
 This is a conditional theorem: the two extra hypotheses are genuine conditions
@@ -317,7 +317,7 @@ For a single block that is TP, has a primitive transfer map, AND is irreducible
 3. `IsPrimitiveMPS A ρ` + `ρ.PosDef`
    → `isNormal_of_isPrimitiveMPS_with_posDef` → `IsNormal A`
 
-We package this chain as a single theorem.
+We record this chain as a single theorem.
 -/
 
 /-- **TP + primitive + irreducible → IsNormal** (per-block chain).
@@ -674,7 +674,7 @@ The cyclic decomposition from `CyclicDecomposition.lean` produces projections `P
 - `∀ k, IsOrthogonalProjection (P k)` and `∑ k, P k = 1`
 - `E†(P(k+1)) = P k` (cyclic), hence `(E†)^m (P k) = P k`
 
-The key bridge: `(E†)^m = transferMap (fun j => (blockTensor A m j)ᴴ)` because the
+The key identity is `(E†)^m = transferMap (fun j => (blockTensor A m j)ᴴ)` because the
 adjoint of the blocked transfer map equals the m-th iterate of the adjoint transfer map.
 This is proved by a tuple-reversal bijection: summing `A_w†·X·A_w` over all length-`m`
 words `w` gives the same result regardless of whether `A_w` or `A_{rev(w)}` is used.
@@ -688,7 +688,7 @@ words `w` gives the same result regardless of whether `A_w` or `A_{rev(w)}` is u
 5. Apply `exists_blockDecomp_of_adjoint_fixed_projections` from `CyclicSectors.lean`
 -/
 
-section CyclicSectorBridge
+section CyclicSectorDecomposition
 
 
 open KadisonSchwarz
@@ -897,10 +897,10 @@ theorem exists_cyclic_sector_decomp_after_blocking
       (blockTensor A m) hTP_blocked (hP := hPproj k) (hFix := hFix k) i
   exact ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hComm, hTrace⟩
 
-end CyclicSectorBridge
+end CyclicSectorDecomposition
 
 /-!
-## Bridge: MPS hypotheses → cyclic sector decomposition
+## From MPS hypotheses to cyclic sector decomposition
 
 For an irreducible TP tensor, all channel-level hypotheses needed by
 `exists_cyclic_sector_decomp_after_blocking` can be derived automatically:
@@ -918,7 +918,7 @@ open KadisonSchwarz
 /-- From an irreducible TP tensor, derive the conjugate-transposed Kraus family `K`,
 its unitality and irreducibility, and a `PosDef` fixed point `ρ` of `Kraus.adjointMap K`.
 
-This bundles the common setup shared by `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
+This records the common setup shared by `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
 and `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`. -/
 theorem conjTranspose_kraus_setup
     {d D : ℕ} [NeZero D]
@@ -955,13 +955,13 @@ theorem conjTranspose_kraus_setup
       Matrix.mul_assoc] using hρ_fix
   exact ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩
 
-/-- **Bridge: irreducible TP tensor → cyclic sector decomposition.**
+/-- **Irreducible TP tensor yields a cyclic sector decomposition.**
 
 For an irreducible TP tensor `A` with `0 < D`, there exists a period `m > 0`
 such that after blocking by `m`, the blocked tensor admits a decomposition
 into `m` left-canonical (TP) blocks via cyclic spectral projections.
 
-This bridges the MPS-level hypotheses (`IsIrreducibleTensor` + TP) to the
+This carries the MPS-level hypotheses (`IsIrreducibleTensor` + TP) to the
 channel-level cyclic decomposition, deriving all intermediate hypotheses
 (`ρ.PosDef`, `Kraus.adjointMap` fixed point, `IsIrreducibleMap`, peripheral
 spectrum structure) automatically via `conjTranspose_kraus_setup`. -/
@@ -1058,7 +1058,7 @@ additionally satisfy:
 
 then the block structures match up to permutation and gauge-phase equivalence.
 
-This theorem packages the structural content of arXiv:1606.00608, Theorem 1,
+This theorem records the structural content of arXiv:1606.00608, Theorem 1,
 connecting the reduction output to the fundamental theorem conclusion. -/
 theorem fundamentalTheorem_after_blocking_1606_structural
     {d D₁ D₂ : ℕ}

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -13,15 +13,15 @@ open scoped Matrix BigOperators
 open Filter
 
 /-!
-# Equal-norm bridge: from BNT properties to BNT grouping hypotheses
+# Equal-norm connection: from BNT properties to BNT grouping hypotheses
 
-This file bridges the gap between the BNT overlap/spectral theory and the
+This file relates the BNT overlap/spectral theory to the
 BNT grouping theorem (`exists_bnt_grouping`), which requires `hDimEq` and `hMPVEq`
 for equal-norm blocks.
 
 ## Background (Issue #243)
 
-The existence reduction pipeline (`Assembly.lean`) produces TP + primitive blocks with
+The existence reduction chain (`Assembly.lean`) produces TP + primitive blocks with
 nonzero weights.  The BNT grouping theorem groups blocks by weight norm into a
 `SectorDecomposition`, but requires two hypotheses for equal-norm blocks:
 
@@ -234,7 +234,7 @@ theorem exists_bnt_grouping_of_gaugePhaseEquiv
 /-- **From TP + primitive + irreducible blocks to BNT-grouped
 `SectorDecomposition`.**
 
-This theorem connects the output of the existence reduction
+This theorem relates the output of the existence reduction
 (`exists_tp_primitive_blockDecomp_after_blocking` in `Assembly.lean`) to a
 `SectorDecomposition` with strictly decreasing BNT-level norms.
 

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -4,7 +4,7 @@ import TNLean.MPS.Chain.FundamentalTheorem
 /-!
 # Fundamental theorem endpoint for blocked chains
 
-This module packages a blocked-chain endpoint. The theorem
+This module gives a blocked-chain endpoint. The theorem
 `fundamentalTheorem_blockedChain` is stated for blocked chains built from a
 common blocking length `L`.
 
@@ -16,7 +16,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Bridge between project `N`-block injectivity and injectivity of the physically
+/-- Equivalence between project `N`-block injectivity and injectivity of the physically
 blocked tensor `blockTensor A N`. -/
 lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
     IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by

--- a/TNLean/MPS/Core/Correlations.lean
+++ b/TNLean/MPS/Core/Correlations.lean
@@ -14,7 +14,7 @@ import Mathlib.Analysis.SpecialFunctions.Log.Basic
 
 This file defines connected correlations for a (normalized) MPS tensor
 in the thermodynamic limit. We express one-point and two-point
-observables through the transfer map `transferMap`, and package the standard
+observables through the transfer map `transferMap`, and record the standard
 sum-of-exponentials / exponential-decay statements in a form that later
 results use.
 

--- a/TNLean/MPS/Core/TPGauge.lean
+++ b/TNLean/MPS/Core/TPGauge.lean
@@ -118,7 +118,7 @@ theorem tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint
 
 /-- The gauge-transformed tensor `tpGauge A ρ` is gauge-equivalent to `A` (hence has the same MPV).
 
-We package this as a `GaugeEquiv` witness. -/
+We record this as a `GaugeEquiv` witness. -/
 theorem gaugeEquiv_tpGauge (A : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
     GaugeEquiv (d := d) (D := D) A (tpGauge (d := d) (D := D) A ρ) := by
   classical

--- a/TNLean/MPS/Overlap/CastDecay.lean
+++ b/TNLean/MPS/Overlap/CastDecay.lean
@@ -9,7 +9,7 @@ import TNLean.Spectral.SpectralGapNT
 /-!
 # Cast-aware overlap-decay helpers
 
-This module packages the recurring pattern where an equal-dimension hypothesis is used to cast the
+This module records the recurring pattern where an equal-dimension hypothesis is used to cast the
 left tensor before applying an overlap-decay theorem, and the resulting limit is transported back to
 the original uncasted overlap.
 -/

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -39,7 +39,7 @@ variable {d D : ℕ}
 
 /-! ## Two-block block-diagonal constructor
 
-We package the `r = 2` special case of `toTensorFromBlocks` with weights `μ ≡ 1` into a dedicated
+We record the `r = 2` special case of `toTensorFromBlocks` with weights `μ ≡ 1` in a dedicated
 constructor. This keeps statements readable and avoids elaboration timeouts from large dependent
 `Fin.cases` terms.
 -/

--- a/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
+++ b/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
@@ -131,7 +131,7 @@ end SingleBlockSeparation
 
 /-! ### Compatibility wrappers exposing the `SameMPV₂` + separation interface
 
-These theorems package the complete construction
+These theorems present the complete construction
 `SameMPV₂` → per-block `SameMPV` (via `hSep`) → per-block `GaugeEquiv`
 → global `GaugeEquiv` → block-permutation decomposition.
 

--- a/TNLean/Topology/ConvexProjection.lean
+++ b/TNLean/Topology/ConvexProjection.lean
@@ -8,7 +8,7 @@ import Mathlib.Topology.MetricSpace.Lipschitz
 /-!
 # Nearest-point projection onto a complete convex set
 
-This file packages the Hilbert projection theorem from Mathlib into a reusable
+This file records the Hilbert projection theorem from Mathlib as a reusable
 nearest-point projection on a nonempty complete convex set in a real inner
 product space, together with uniqueness, nonexpansiveness, and continuity.
 -/

--- a/TNLean/Topology/TendstoHelpers.lean
+++ b/TNLean/Topology/TendstoHelpers.lean
@@ -9,7 +9,7 @@ import Mathlib.Topology.Separation.Hausdorff
 # Small helpers about `Filter.Tendsto`
 
 This file contains a uniqueness-of-limits helper for later compactness and
-convergence arguments. The theorem `Filter.Tendsto.ne_nhds` packages the
+convergence arguments. The theorem `Filter.Tendsto.ne_nhds` records the
 standard T2-space fact that a nontrivial filter cannot tend simultaneously to
 two distinct points.
 -/


### PR DESCRIPTION
Replace banned terms in docstrings/comments across 11 files per the style guide. Doc/comment-only changes, no proof modifications. All files verified with lake env lean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring/comment wording updates only; no definitions, proofs, or behavior changes, so risk is limited to documentation accuracy/clarity.
> 
> **Overview**
> Updates documentation across multiple Lean modules to comply with style guidance by replacing terms like *package/bridge/pipeline* with alternative phrasing (e.g., *record/present/relate/connection/equivalence*).
> 
> No functional changes: imports, definitions, lemma statements, and proofs remain unchanged; only comment/docstring text is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a74084f2d619610607f8e8508868fb0aeefc282a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->