### PR TITLE
doc(blueprint): add TikZ diagrams to PEPS section

### DIFF
--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1136,6 +1136,10 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     For an edge $e = (u,w)$ with $u < w$ and gauge $X_e \in \mathrm{GL}(D_e)$,
     the gauge matrix applied at vertex $v$ is $X_e$ if $v = u$ and
     $(X_e^{-1})^\top$ if $v = w$.
+    Diagrammatically, the ordered edge carries opposite endpoint actions:
+    \[
+        \TNPEPSEdgeGaugeOrientation
+    \]
 \end{definition}
 
 \begin{definition}[Gauge vertex action]%
@@ -1147,6 +1151,11 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     $A^X_v(\eta, \sigma)
         = \sum_{\eta'} (\prod_{ie} M_{ie}(\eta(ie), \eta'(ie)))
         A_v(\eta', \sigma)$.
+    In tensor-network notation, one inserts the appropriate gauge matrix on
+    each incident virtual leg of the local tensor:
+    \[
+        \TNPEPSGaugeVertexAction
+    \]
 \end{definition}
 
 \begin{definition}[Apply gauge]%
@@ -1174,6 +1183,10 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \notready
     \uses{def:applyGauge}
     Applying a gauge to a PEPS tensor preserves the state coefficients.
+    Along each internal edge, the two endpoint insertions cancel:
+    \[
+        \TNPEPSGaugeCancellation
+    \]
 \end{theorem}
 
 \begin{theorem}[Gauge equivalence implies same state]%
@@ -1201,6 +1214,11 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \uses{def:gaugeVertex, def:localTensorEval}
     At a single vertex, vertex-injectivity of both tensors and the
     same-state condition force a local gauge relation.
+    Schematically, injectivity on the star neighbourhood provides a left
+    inverse that isolates the local edge gauges:
+    \[
+        \TNPEPSLocalGaugeExtraction
+    \]
 \end{theorem}
 
 \begin{theorem}[Gauge consistency]%
@@ -1210,6 +1228,11 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \uses{thm:localGauge_exists, def:gaugeVertex}
     Local gauges extracted at adjacent vertices are consistent across
     shared edges, yielding a global gauge family.
+    On a shared edge, the two neighbouring local extractions match as one
+    edge gauge:
+    \[
+        \TNPEPSGlobalConsistency
+    \]
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for injective PEPS]%

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -485,7 +485,7 @@
     \TN@tensordot{tnU}{(0,0)}
     \TN@tensordot{tnW}{(3.30,0)}
     \TN@opdotabove{tnXl}{(1.00,0)}{X_e}
-    \TN@opdotabove{tnXr}{(2.30,0)}{X_e^{-1}}
+    \TN@opdotabove{tnXr}{(2.30,0)}{(X_e^{-1})^\top}
     \draw[tn leg] (tnU.east) -- (tnXl.west);
     \draw[tn leg] (tnXl.east) -- (tnXr.west);
     \draw[tn leg] (tnXr.east) -- (tnW.west);
@@ -506,6 +506,10 @@
     \draw[tn leg] (tnV.east) -- (tnR.west);
     \draw[tn leg] ($(tnV.south)-(0.2,0)$) -- (tnDL.north);
     \draw[tn leg] ($(tnV.south)+(0.2,0)$) -- (tnDR.north);
+    \draw[tn leg] (tnL.west) -- ++(-0.42,0);
+    \draw[tn leg] (tnR.east) -- ++(0.42,0);
+    \draw[tn leg] (tnDL.south) -- ++(-0.30,-0.42);
+    \draw[tn leg] (tnDR.south) -- ++(0.30,-0.42);
     \TN@upleg{tnV}{0.54}
     \TN@uplabel{tnV}{0.80}{\sigma}
     \node at ($(tnV.south)+(0,-1.45)$) {$A_v \mapsto A_v^X$};
@@ -521,13 +525,13 @@
     \draw[tn leg] (tnL.east) -- (tnX.west);
     \draw[tn leg] (tnX.east) -- (tnXt.west);
     \draw[tn leg] (tnXt.east) -- (tnR.west);
-    \node at ($(tnX.north)+(0,0.28)$) {$X_e(i,j)$};
-    \node at ($(tnXt.north)+(0,0.28)$) {$(X_e^{-1})(j,k)$};
+    \node at ($(tnX.north)+(0,0.28)$) {$X_e(j,i)$};
+    \node at ($(tnXt.north)+(0,0.28)$) {$((X_e^{-1})^\top)(j,k)$};
     \node at (4.20,0) {$=$};
     \TN@tensordot{tnL2}{(5.15,0)}
     \TN@tensordot{tnR2}{(6.65,0)}
     \draw[tn leg] (tnL2.east) -- (tnR2.west);
-    \node at (5.90,0.54) {$\sum_j X_e(i,j)\,(X_e^{-1})(j,k) = \delta(i,k)$};
+    \node at (5.90,0.54) {$\sum_j X_e(j,i)\,((X_e^{-1})^\top)(j,k) = \delta(i,k)$};
   \end{tikzpicture}%
 }
 
@@ -570,7 +574,7 @@
     \draw[tn leg] (tnU.south) -- ++(-0.55,-0.68);
     \draw[tn leg] (tnW.south) -- ++(0.55,-0.68);
     \TN@opdotabove{tnXl}{(1.02,0)}{X_e}
-    \TN@opdotabove{tnXr}{(2.33,0)}{X_e^{-1}}
+    \TN@opdotabove{tnXr}{(2.33,0)}{(X_e^{-1})^\top}
     \draw[tn leg] (tnU.east) -- (tnXl.west);
     \draw[tn leg] (tnXl.east) -- (tnXr.west);
     \draw[tn leg] (tnXr.east) -- (tnW.west);

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -485,7 +485,7 @@
     \TN@tensordot{tnU}{(0,0)}
     \TN@tensordot{tnW}{(3.30,0)}
     \TN@opdotabove{tnXl}{(1.00,0)}{X_e}
-    \TN@opdotabove{tnXr}{(2.30,0)}{(X_e^{-1})^\top}
+    \TN@opdotabove{tnXr}{(2.30,0)}{X_e^{-1}}
     \draw[tn leg] (tnU.east) -- (tnXl.west);
     \draw[tn leg] (tnXl.east) -- (tnXr.west);
     \draw[tn leg] (tnXr.east) -- (tnW.west);
@@ -504,8 +504,8 @@
     \TN@opdotbelow{tnDR}{(0.78,-0.92)}{M_{ve_4}}
     \draw[tn leg] (tnL.east) -- (tnV.west);
     \draw[tn leg] (tnV.east) -- (tnR.west);
-    \draw[tn leg] (tnV.south) -- (tnDL.north);
-    \draw[tn leg] (tnV.south) -- (tnDR.north);
+    \draw[tn leg] ($(tnV.south)-(0.2,0)$) -- (tnDL.north);
+    \draw[tn leg] ($(tnV.south)+(0.2,0)$) -- (tnDR.north);
     \TN@upleg{tnV}{0.54}
     \TN@uplabel{tnV}{0.80}{\sigma}
     \node at ($(tnV.south)+(0,-1.45)$) {$A_v \mapsto A_v^X$};
@@ -521,13 +521,13 @@
     \draw[tn leg] (tnL.east) -- (tnX.west);
     \draw[tn leg] (tnX.east) -- (tnXt.west);
     \draw[tn leg] (tnXt.east) -- (tnR.west);
-    \node at ($(tnX.north)+(0,0.28)$) {$X(i,j)$};
-    \node at ($(tnXt.north)+(0,0.28)$) {$(X^{-1})^\top(j,k)$};
+    \node at ($(tnX.north)+(0,0.28)$) {$X_e(i,j)$};
+    \node at ($(tnXt.north)+(0,0.28)$) {$(X_e^{-1})(j,k)$};
     \node at (4.20,0) {$=$};
     \TN@tensordot{tnL2}{(5.15,0)}
     \TN@tensordot{tnR2}{(6.65,0)}
     \draw[tn leg] (tnL2.east) -- (tnR2.west);
-    \node at (5.90,0.54) {$\delta(i,k)$};
+    \node at (5.90,0.54) {$\sum_j X_e(i,j)\,(X_e^{-1})(j,k) = \delta(i,k)$};
   \end{tikzpicture}%
 }
 
@@ -538,8 +538,8 @@
     \TN@uplabel{tnLv}{0.76}{\sigma}
     \draw[tn leg] (tnLv.west) -- ++(-0.90,0);
     \draw[tn leg] (tnLv.east) -- ++(0.90,0);
-    \draw[tn leg] (tnLv.south) -- ++(-0.72,-0.82);
-    \draw[tn leg] (tnLv.south) -- ++(0.72,-0.82);
+    \draw[tn leg] ($(tnLv.south)-(0.2,0)$) -- ++(-0.72,-0.82);
+    \draw[tn leg] ($(tnLv.south)+(0.2,0)$) -- ++(0.72,-0.82);
     \node at (0,-1.42) {$\mathrm{star}(v)$};
     \node at (2.85,0) {$\xrightarrow[\text{left inverse}]{\text{injective}}$};
     \TN@tensordot{tnRv}{(5.70,0)}
@@ -553,8 +553,8 @@
     \draw[tn leg] (tnRl.east) -- (tnRv.west);
     \draw[tn leg] (tnRv.east) -- (tnRr.west);
     \draw[tn leg] (tnRr.east) -- ++(0.42,0);
-    \draw[tn leg] (tnRv.south) -- (tnRdl.north);
-    \draw[tn leg] (tnRv.south) -- (tnRdr.north);
+    \draw[tn leg] ($(tnRv.south)-(0.2,0)$) -- (tnRdl.north);
+    \draw[tn leg] ($(tnRv.south)+(0.2,0)$) -- (tnRdr.north);
     \node at (5.70,-1.42) {$\text{local edge gauges}$};
   \end{tikzpicture}%
 }
@@ -570,7 +570,7 @@
     \draw[tn leg] (tnU.south) -- ++(-0.55,-0.68);
     \draw[tn leg] (tnW.south) -- ++(0.55,-0.68);
     \TN@opdotabove{tnXl}{(1.02,0)}{X_e}
-    \TN@opdotabove{tnXr}{(2.33,0)}{(X_e^{-1})^\top}
+    \TN@opdotabove{tnXr}{(2.33,0)}{X_e^{-1}}
     \draw[tn leg] (tnU.east) -- (tnXl.west);
     \draw[tn leg] (tnXl.east) -- (tnXr.west);
     \draw[tn leg] (tnXr.east) -- (tnW.west);

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -478,6 +478,108 @@
   \end{tikzpicture}%
 }
 
+% ---------- PEPS diagrams ----------
+
+\newcommand{\TNPEPSEdgeGaugeOrientation}{%
+  \begin{tikzpicture}[tn picture]
+    \TN@tensordot{tnU}{(0,0)}
+    \TN@tensordot{tnW}{(3.30,0)}
+    \TN@opdotabove{tnXl}{(1.00,0)}{X_e}
+    \TN@opdotabove{tnXr}{(2.30,0)}{(X_e^{-1})^\top}
+    \draw[tn leg] (tnU.east) -- (tnXl.west);
+    \draw[tn leg] (tnXl.east) -- (tnXr.west);
+    \draw[tn leg] (tnXr.east) -- (tnW.west);
+    \node at (1.65,0.72) {$e = (u,w)$};
+    \node at ($(tnU.south)+(0,-0.28)$) {$u$};
+    \node at ($(tnW.south)+(0,-0.28)$) {$w$};
+  \end{tikzpicture}%
+}
+
+\newcommand{\TNPEPSGaugeVertexAction}{%
+  \begin{tikzpicture}[tn picture]
+    \TN@tensordot{tnV}{(0,0)}
+    \TN@opdotleft{tnL}{(-1.05,0)}{M_{ve_1}}
+    \TN@opdotright{tnR}{(1.05,0)}{M_{ve_2}}
+    \TN@opdotbelow{tnDL}{(-0.78,-0.92)}{M_{ve_3}}
+    \TN@opdotbelow{tnDR}{(0.78,-0.92)}{M_{ve_4}}
+    \draw[tn leg] (tnL.east) -- (tnV.west);
+    \draw[tn leg] (tnV.east) -- (tnR.west);
+    \draw[tn leg] (tnV.south) -- (tnDL.north);
+    \draw[tn leg] (tnV.south) -- (tnDR.north);
+    \TN@upleg{tnV}{0.54}
+    \TN@uplabel{tnV}{0.80}{\sigma}
+    \node at ($(tnV.south)+(0,-1.45)$) {$A_v \mapsto A_v^X$};
+  \end{tikzpicture}%
+}
+
+\newcommand{\TNPEPSGaugeCancellation}{%
+  \begin{tikzpicture}[tn picture]
+    \TN@tensordot{tnL}{(0,0)}
+    \TN@opdot{tnX}{(0.92,0)}
+    \TN@opdot{tnXt}{(2.18,0)}
+    \TN@tensordot{tnR}{(3.10,0)}
+    \draw[tn leg] (tnL.east) -- (tnX.west);
+    \draw[tn leg] (tnX.east) -- (tnXt.west);
+    \draw[tn leg] (tnXt.east) -- (tnR.west);
+    \node at ($(tnX.north)+(0,0.28)$) {$X(i,j)$};
+    \node at ($(tnXt.north)+(0,0.28)$) {$(X^{-1})^\top(j,k)$};
+    \node at (4.20,0) {$=$};
+    \TN@tensordot{tnL2}{(5.15,0)}
+    \TN@tensordot{tnR2}{(6.65,0)}
+    \draw[tn leg] (tnL2.east) -- (tnR2.west);
+    \node at (5.90,0.54) {$\delta(i,k)$};
+  \end{tikzpicture}%
+}
+
+\newcommand{\TNPEPSLocalGaugeExtraction}{%
+  \begin{tikzpicture}[tn picture]
+    \TN@tensordot{tnLv}{(0,0)}
+    \TN@upleg{tnLv}{0.50}
+    \TN@uplabel{tnLv}{0.76}{\sigma}
+    \draw[tn leg] (tnLv.west) -- ++(-0.90,0);
+    \draw[tn leg] (tnLv.east) -- ++(0.90,0);
+    \draw[tn leg] (tnLv.south) -- ++(-0.72,-0.82);
+    \draw[tn leg] (tnLv.south) -- ++(0.72,-0.82);
+    \node at (0,-1.42) {$\mathrm{star}(v)$};
+    \node at (2.85,0) {$\xrightarrow[\text{left inverse}]{\text{injective}}$};
+    \TN@tensordot{tnRv}{(5.70,0)}
+    \TN@upleg{tnRv}{0.50}
+    \TN@uplabel{tnRv}{0.76}{\sigma}
+    \TN@opdot{tnRl}{(4.62,0)}
+    \TN@opdot{tnRr}{(6.78,0)}
+    \TN@opdot{tnRdl}{(4.95,-0.86)}
+    \TN@opdot{tnRdr}{(6.45,-0.86)}
+    \draw[tn leg] (tnRl.west) -- ++(-0.42,0);
+    \draw[tn leg] (tnRl.east) -- (tnRv.west);
+    \draw[tn leg] (tnRv.east) -- (tnRr.west);
+    \draw[tn leg] (tnRr.east) -- ++(0.42,0);
+    \draw[tn leg] (tnRv.south) -- (tnRdl.north);
+    \draw[tn leg] (tnRv.south) -- (tnRdr.north);
+    \node at (5.70,-1.42) {$\text{local edge gauges}$};
+  \end{tikzpicture}%
+}
+
+\newcommand{\TNPEPSGlobalConsistency}{%
+  \begin{tikzpicture}[tn picture]
+    \TN@tensordot{tnU}{(0,0)}
+    \TN@tensordot{tnW}{(3.35,0)}
+    \TN@upleg{tnU}{0.44}
+    \TN@upleg{tnW}{0.44}
+    \draw[tn leg] (tnU.west) -- ++(-0.70,0);
+    \draw[tn leg] (tnW.east) -- ++(0.70,0);
+    \draw[tn leg] (tnU.south) -- ++(-0.55,-0.68);
+    \draw[tn leg] (tnW.south) -- ++(0.55,-0.68);
+    \TN@opdotabove{tnXl}{(1.02,0)}{X_e}
+    \TN@opdotabove{tnXr}{(2.33,0)}{(X_e^{-1})^\top}
+    \draw[tn leg] (tnU.east) -- (tnXl.west);
+    \draw[tn leg] (tnXl.east) -- (tnXr.west);
+    \draw[tn leg] (tnXr.east) -- (tnW.west);
+    \node at (1.67,0.78) {$\text{shared edge } e$};
+    \node at ($(tnU.south)+(0,-0.28)$) {$u$};
+    \node at ($(tnW.south)+(0,-0.28)$) {$w$};
+  \end{tikzpicture}%
+}
+
 % ---------- Compatibility wrappers ----------
 
 \newcommand{\TNMPOCellDiagram}[3]{%

--- a/blueprint/src/macros/tn_web.tex
+++ b/blueprint/src/macros/tn_web.tex
@@ -220,6 +220,41 @@
   \end{array}%
 }
 
+\newcommand{\TNPEPSEdgeGaugeOrientation}{%
+  \begin{array}{c}
+    \text{edge } e = (u,w) \text{ oriented by } u < w \\
+    u \; \text{---} \; X_e \; \text{---} \; (X_e^{-1})^\top \; \text{---} \; w
+  \end{array}%
+}
+
+\newcommand{\TNPEPSGaugeVertexAction}{%
+  \begin{array}{c}
+    \text{one gauge matrix } M_{ve} \text{ is inserted on each incident virtual leg of } A_v \\
+    A_v \mapsto A_v^X
+  \end{array}%
+}
+
+\newcommand{\TNPEPSGaugeCancellation}{%
+  \begin{array}{c}
+    X(i,j)\,(X^{-1})^\top(j,k) = \delta(i,k) \\
+    \text{so the two edge gauges cancel on an internal contraction}
+  \end{array}%
+}
+
+\newcommand{\TNPEPSLocalGaugeExtraction}{%
+  \begin{array}{c}
+    \text{injectivity on } \mathrm{star}(v) \text{ gives a left inverse} \\
+    \text{which isolates the local edge gauges around } v
+  \end{array}%
+}
+
+\newcommand{\TNPEPSGlobalConsistency}{%
+  \begin{array}{c}
+    \text{local gauges extracted at } u \text{ and } w \text{ agree on the shared edge } e \\
+    \text{and define one global edge gauge family}
+  \end{array}%
+}
+
 \newcommand{\TNMPOCellDiagram}[3]{%
   \TNMPOCell{#1}{#2}{#3}%
 }

--- a/blueprint/src/macros/tn_web.tex
+++ b/blueprint/src/macros/tn_web.tex
@@ -223,7 +223,7 @@
 \newcommand{\TNPEPSEdgeGaugeOrientation}{%
   \begin{array}{c}
     \text{edge } e = (u,w) \text{ oriented by } u < w \\
-    u \; \text{---} \; X_e \; \text{---} \; X_e^{-1} \; \text{---} \; w
+    u \; \text{---} \; X_e \; \text{---} \; (X_e^{-1})^T \; \text{---} \; w
   \end{array}%
 }
 
@@ -236,8 +236,8 @@
 
 \newcommand{\TNPEPSGaugeCancellation}{%
   \begin{array}{c}
-    \sum_j X_e(i,j)\,(X_e^{-1})(j,k) = \delta(i,k) \\
-    \text{so the two edge gauges cancel on an internal contraction}
+    \sum_j X_e(j,i)\,((X_e^{-1})^T)(j,k) = \delta(i,k) \\
+    \text{so the two edge gauges cancel on the shared edge index}
   \end{array}%
 }
 
@@ -251,6 +251,7 @@
 \newcommand{\TNPEPSGlobalConsistency}{%
   \begin{array}{c}
     \text{local gauges extracted at } u \text{ and } w \text{ agree on the shared edge } e \\
+    u \; \text{---} \; X_e \; \text{---} \; (X_e^{-1})^T \; \text{---} \; w \\
     \text{and define one global edge gauge family}
   \end{array}%
 }

--- a/blueprint/src/macros/tn_web.tex
+++ b/blueprint/src/macros/tn_web.tex
@@ -223,7 +223,7 @@
 \newcommand{\TNPEPSEdgeGaugeOrientation}{%
   \begin{array}{c}
     \text{edge } e = (u,w) \text{ oriented by } u < w \\
-    u \; \text{---} \; X_e \; \text{---} \; (X_e^{-1})^\top \; \text{---} \; w
+    u \; \text{---} \; X_e \; \text{---} \; X_e^{-1} \; \text{---} \; w
   \end{array}%
 }
 
@@ -236,7 +236,7 @@
 
 \newcommand{\TNPEPSGaugeCancellation}{%
   \begin{array}{c}
-    X(i,j)\,(X^{-1})^\top(j,k) = \delta(i,k) \\
+    \sum_j X_e(i,j)\,(X_e^{-1})(j,k) = \delta(i,k) \\
     \text{so the two edge gauges cancel on an internal contraction}
   \end{array}%
 }


### PR DESCRIPTION
Add 5 TikZ diagrams illustrating the PEPS fundamental theorem section: edge gauge orientation, vertex gauge action, gauge cancellation, local extraction, and global consistency. Reference: arXiv:1804.04964 Figures 1-3.

Closes #504

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes adding new LaTeX/TikZ macros and referencing them; primary risk is LaTeX build/rendering issues if macros conflict or TikZ compilation fails.
> 
> **Overview**
> Adds **five new PEPS gauge diagrams** and embeds them into the PEPS Fundamental Theorem section (`ch13_algebraic_ft.tex`) to visually explain edge orientation, vertex gauge action, cancellation on internal edges, local gauge extraction, and global consistency.
> 
> Introduces corresponding `\TNPEPS...` macros in both the print TikZ implementation (`tn_print.tex`) and the web-safe fallback (`tn_web.tex`) so the same diagram API renders across outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afd30f655ca41aff25e9869edf1c8f4172b48166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->