### PR TITLE
ci(blueprint): add continue-on-error to PR warning step

### DIFF
--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -81,6 +81,7 @@ jobs:
 
       - name: Warn on changed Lean declarations missing blueprint entries
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         run: |
           python3 - <<'PY'
           import subprocess


### PR DESCRIPTION
### Motivation
Fixes #542. The blueprint coverage warning step is intended to be non-blocking (advisory only), but a missing `continue-on-error: true` means any exception in the Python script or git operations will fail the step and skip the downstream `checkdecls` validation.

### Changes
- Add `continue-on-error: true` to the "Warn on changed Lean declarations missing blueprint entries" step in `lint-blueprint.yml`

### Testing
One-line fix; verified by reading the workflow syntax.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it prevents advisory warnings from failing the job, with no impact to build or runtime code.
> 
> **Overview**
> Updates the `lint-blueprint` GitHub Actions workflow to mark the PR-only step "Warn on changed Lean declarations missing blueprint entries" as `continue-on-error: true`, so failures in that advisory check don’t fail the job or block downstream validation (e.g., `checkdecls`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109141d9a78c5148f402981083542b8a129040ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->