### PR TITLE
doc(blueprint): fix false-green leanok on periodic basis theorem

### DIFF
--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -765,7 +765,8 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 \end{theorem}
 
 \begin{theorem}[Eventual linear independence of a periodic basis]\label{thm:periodic_basis_eventually_li}
-	\lean{MPSTensor.periodicBasis_eventuallyLinearlyIndependent}\leanok
+	\lean{MPSTensor.periodicBasis_eventuallyLinearlyIndependent}
+	\notready
 	\uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
 	For a finite family of pairwise non-equivalent periodic tensors whose
 	periods divide a common integer $p$, there is $N_0$ such that for every


### PR DESCRIPTION
### Motivation
Addresses part of #328 (Ch11 audit). The theorem `periodicBasis_eventuallyLinearlyIndependent` was tagged `\leanok` in the blueprint, but it transitively depends on sorry'd `periodicOverlapDichotomy` and `periodicSelfOverlap_tendsto`. The Lean declaration compiles (its body uses the sorry'd results at runtime), so `checkdecls` doesn't flag it, but the proof is not actually complete.

### Changes
- Replace `\leanok` with `\notready` on `thm:periodic_basis_eventually_li`
- Remove `\leanok` from its proof block if present

### Blueprint integrity
This correctly reflects the dependency chain: a result depending on sorry'd lemmas cannot be marked proven.
