### PR TITLE
doc(blueprint): clarify semigroup wording for #515

### DIFF
--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -925,8 +925,8 @@ which shows that such generators have the standard Lindblad form.
 \begin{proof}\leanok
     \uses{thm:irreducible_semigroup_implies_primitive}
     Forward: apply Theorem~\ref{thm:irreducible_semigroup_implies_primitive}.
-    Reverse: take $t_0 = 1$ (or any positive time); primitivity
-    implies irreducibility by definition.
+    Reverse: take $t_0 = 1$ (or any positive time); the right-hand side
+    already includes irreducibility of $T_t$ for every $t>0$.
 \end{proof}
 
 %% ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix the incorrect proof-sketch sentence in `ch12_semigroup.tex` that said primitivity implies irreducibility "by definition"
- clarify the reverse implication to match the Lean statement: the right-hand side already assumes irreducibility for every positive time
- document the issue-#515 audit outcome for the requested chapters

## Audit notes
- `ch08_canonical.tex`: no source change needed on current `main`. The suggested `grep -c "sorry" TNLean/MPS/CanonicalForm/EqualNormBridge.lean` is a false positive from a docstring mention of the word "sorry", not an unfinished declaration.
- `ch15_correlations.tex`: no source change needed on current `main`. The previously flagged "not yet formalized" wording is already absent.

## Why
Issue #515 called out a correctness problem in the semigroup chapter: the proof sketch claimed that primitivity implies irreducibility by definition. The Lean development instead proves the semigroup result in the opposite direction, so the blueprint prose should not state the reverse implication.

## Validation
- `rg -n "primitivity implies irreducibility by definition|not yet formalized|is not formalized|currently unproven|TODO|FIXME|axiom placeholder" blueprint/src/chapter/ch12_semigroup.tex blueprint/src/chapter/ch15_correlations.tex blueprint/src/chapter/ch08_canonical.tex`
- `git diff --check`

Closes #515

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change correcting a proof sketch sentence; no code or formal statements are modified.
> 
> **Overview**
> Corrects the proof sketch for `Prop.~7.5`/`thm:qds_irreducible_iff_primitive` in `ch12_semigroup.tex` by replacing the inaccurate claim that primitivity implies irreducibility “by definition” with wording that the theorem’s RHS already assumes irreducibility for all `t > 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57d5c04e79b1d0acafc3649b5ed4c29b9b42be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->