### PR TITLE
doc(blueprint): restore GaugeEquiv.refl/symm/trans in lean_decls

### DIFF
--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -297,8 +297,9 @@ non-translation-invariant chains.
 
 \begin{lemma}[Cyclic gauge equivalence is an equivalence relation]
     \label{lem:chain_gauge_equiv_equivalence}
-    \lean{MPSChainTensor.GaugeEquiv.refl, MPSChainTensor.GaugeEquiv.symm,
-          MPSChainTensor.GaugeEquiv.trans}
+    \lean{MPSChainTensor.GaugeEquiv.refl}
+    \lean{MPSChainTensor.GaugeEquiv.symm}
+    \lean{MPSChainTensor.GaugeEquiv.trans}
     \leanok
     \uses{def:non_ti_chain}
     On fixed-length periodic chains, cyclic gauge equivalence is reflexive,


### PR DESCRIPTION
## Summary
- split the cyclic gauge-equivalence `\lean{}` annotation in `ch03_single.tex` so all three declarations are discovered by the blueprint sync tooling
- restore `MPSChainTensor.GaugeEquiv.refl`, `.symm`, and `.trans` in the generated `blueprint/lean_decls` output on current `main`
- keep the fix on the blueprint source side, since `blueprint/lean_decls` is now generated and gitignored

## Verification
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "theorem GaugeEquiv\.(refl|symm|trans)|MPSChainTensor\.GaugeEquiv" TNLean/MPS/Chain/Defs.lean`
- `grep "MPSChainTensor.GaugeEquiv.refl\|MPSChainTensor.GaugeEquiv.symm\|MPSChainTensor.GaugeEquiv.trans" blueprint/src/chapter/*.tex`

Closes #487.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that affects blueprint-to-Lean declaration discovery tooling, not runtime/library logic.
> 
> **Overview**
> Updates `ch03_single.tex` to split the combined `\lean{...}` annotation for `MPSChainTensor.GaugeEquiv.refl/symm/trans` into three separate `\lean{}` lines so the blueprint sync tooling discovers all three declarations and regenerates `lean_decls` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit addd7819715c3260abd3eac0700d90fa522e85d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->