### PR TITLE
refactor(Algebra): move positive-eigenvector nonvanishing lemma

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -24,6 +24,7 @@ import TNLean.Algebra.BlockPermutation
 import TNLean.Algebra.SkolemNoether
 import TNLean.Algebra.GramMatrixLI
 import TNLean.Algebra.HermitianHelpers
+import TNLean.Algebra.LinearMapAux
 import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.Algebra.BurnsideMatrix

--- a/TNLean/Algebra/LinearMapAux.lean
+++ b/TNLean/Algebra/LinearMapAux.lean
@@ -17,7 +17,7 @@ theory.
 
 - `LinearMap.ne_zero_of_eigenvector`: a nonzero eigenvector for a nonzero
   eigenvalue forces a linear map to be nonzero
-- `ne_zero_of_pos_eigenvector`: a positive-eigenvalue equation with nonzero
+- `LinearMap.ne_zero_of_pos_eigenvector`: a positive-eigenvalue equation with nonzero
   eigenvector forces a linear map to be nonzero
 -/
 
@@ -34,7 +34,7 @@ theorem LinearMap.ne_zero_of_eigenvector
   exact hρ_ne ((eq_zero_or_eq_zero_of_smul_eq_zero hρ_zero).resolve_left hμ_ne)
 
 /-- A positive-eigenvalue equation with nonzero eigenvector forces a linear map to be nonzero. -/
-theorem ne_zero_of_pos_eigenvector
+theorem LinearMap.ne_zero_of_pos_eigenvector
     {M : Type*}
     [AddCommMonoid M] [Module ℂ M] [NoZeroSMulDivisors ℂ M]
     {E : M →ₗ[ℂ] M} {ρ : M} {r : ℝ}

--- a/TNLean/Algebra/LinearMapAux.lean
+++ b/TNLean/Algebra/LinearMapAux.lean
@@ -1,0 +1,43 @@
+/- 
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.Module.Basic
+import Mathlib.Algebra.Module.LinearMap.Basic
+import Mathlib.Algebra.NoZeroSMulDivisors.Defs
+import Mathlib.Data.Complex.Basic
+
+/-!
+# Auxiliary linear-map lemmas
+
+General-purpose linear-map lemmas that are not specific to any chapter's
+theory.
+
+## Main results
+
+- `LinearMap.ne_zero_of_eigenvector`: a nonzero eigenvector for a nonzero
+  eigenvalue forces a linear map to be nonzero
+- `ne_zero_of_pos_eigenvector`: a positive-eigenvalue equation with nonzero
+  eigenvector forces a linear map to be nonzero
+-/
+
+/-- A nonzero eigenvector for a nonzero eigenvalue forces a linear map to be nonzero. -/
+theorem LinearMap.ne_zero_of_eigenvector
+    {R M : Type*}
+    [Semiring R] [AddCommMonoid M] [Module R M] [NoZeroSMulDivisors R M]
+    {E : M →ₗ[R] M} {ρ : M} {μ : R}
+    (hρ_ne : ρ ≠ 0) (hμ_ne : μ ≠ 0) (hEig : E ρ = μ • ρ) :
+    E ≠ 0 := by
+  intro hE0
+  have hρ_zero : μ • ρ = 0 := by
+    simpa [hE0] using hEig.symm
+  exact hρ_ne ((eq_zero_or_eq_zero_of_smul_eq_zero hρ_zero).resolve_left hμ_ne)
+
+/-- A positive-eigenvalue equation with nonzero eigenvector forces a linear map to be nonzero. -/
+theorem ne_zero_of_pos_eigenvector
+    {M : Type*}
+    [AddCommMonoid M] [Module ℂ M] [NoZeroSMulDivisors ℂ M]
+    {E : M →ₗ[ℂ] M} {ρ : M} {r : ℝ}
+    (hρ_ne : ρ ≠ 0) (hr : 0 < r) (hEig : E ρ = (r : ℂ) • ρ) :
+    E ≠ 0 := by
+  exact LinearMap.ne_zero_of_eigenvector hρ_ne (by exact_mod_cast hr.ne') hEig

--- a/TNLean/Channel/Irreducible/KrausSetup.lean
+++ b/TNLean/Channel/Irreducible/KrausSetup.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.Algebra.LinearMapAux
 import TNLean.Channel.PerronFrobenius.Existence
 
 /-!
@@ -16,8 +17,6 @@ paired with the adjoint Perron--Frobenius eigenvector of that family.
 - `IrreducibleCPKrausSetup`: shared Kraus witness for an irreducible CP map
 - `irreducibleCPKrausSetup`: packages the standard Kraus witness attached to an
   irreducible CP map
-- `ne_zero_of_pos_eigenvector`: a positive-eigenvalue equation with nonzero
-  eigenvector forces a linear map to be nonzero
 - `IrreducibleCPKrausSetup.exists_nonzero_kraus`: a nonzero map in a Kraus
   setup has a nonzero Kraus operator
 - `IrreducibleCPKrausSetup.exists_posDef_adjoint_eigenvector`: shared adjoint
@@ -57,21 +56,6 @@ noncomputable def irreducibleCPKrausSetup
       K := K
       map_eq := hE_eq
       irreducible := MPSTensor.isIrreducibleTensor_of_isIrreducibleMap K hIrrK_map }
-
--- TODO: This only uses linear-map data and could live in a more general module
--- in a follow-up refactor.
-/-- A positive-eigenvalue equation with nonzero eigenvector forces the map to be nonzero. -/
-theorem ne_zero_of_pos_eigenvector
-    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    {ρ : Matrix (Fin D) (Fin D) ℂ} {r : ℝ}
-    (hρ_ne : ρ ≠ 0) (hr : 0 < r) (hEig : E ρ = (r : ℂ) • ρ) :
-    E ≠ 0 := by
-  intro hE0
-  have hρ_zero : (r : ℂ) • ρ = 0 := by
-    simpa [hE0] using hEig.symm
-  have hr_ne : (r : ℂ) ≠ 0 := by
-    exact_mod_cast hr.ne'
-  exact hρ_ne ((smul_eq_zero.mp hρ_zero).resolve_left hr_ne)
 
 namespace IrreducibleCPKrausSetup
 

--- a/TNLean/Channel/Irreducible/PerronFrobenius.lean
+++ b/TNLean/Channel/Irreducible/PerronFrobenius.lean
@@ -180,7 +180,7 @@ theorem eigenvalue_unique_of_irreducible_cp
   let n := hSetup.n
   let K := hSetup.K
   have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K := hSetup.map_eq
-  have hE_ne : E ≠ 0 := ne_zero_of_pos_eigenvector hρ_ne hr₁ hρ_eig
+  have hE_ne : E ≠ 0 := LinearMap.ne_zero_of_pos_eigenvector hρ_ne hr₁ hρ_eig
   obtain ⟨τ, t, hτ_pd, ht_pos, hτ_eig⟩ :=
     hSetup.exists_posDef_adjoint_eigenvector hE_ne
   have htrace : ∀ X : Matrix (Fin D) (Fin D) ℂ,

--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -221,7 +221,7 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
   let K := hSetup.K
   have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K := hSetup.map_eq
   have hρ_ne : ρ ≠ 0 := (Matrix.PosDef.isUnit hρ_pd).ne_zero
-  have hE_ne : E ≠ 0 := ne_zero_of_pos_eigenvector hρ_ne hr hEig
+  have hE_ne : E ≠ 0 := LinearMap.ne_zero_of_pos_eigenvector hρ_ne hr hEig
   obtain ⟨σ, t, hσ_pd, ht_pos, hσ_eig⟩ :=
     hSetup.exists_posDef_adjoint_eigenvector hE_ne
   have htrace : ∀ X : Matrix (Fin D) (Fin D) ℂ,


### PR DESCRIPTION
## Summary
Move `ne_zero_of_pos_eigenvector` out of `TNLean/Channel/Irreducible/KrausSetup.lean` into a reusable algebra helper module.

## What Changed
- added `TNLean/Algebra/LinearMapAux.lean`
- moved `ne_zero_of_pos_eigenvector` there and factored out a more general core lemma `LinearMap.ne_zero_of_eigenvector`
- updated `KrausSetup.lean` to import the new helper, dropped the local copy, and removed the stale TODO/doc entry
- re-exported the new helper from `TNLean.lean`

## Why
The lemma only depends on linear-map/eigenvector data, so it is better placed in a general algebra module than in a channel-specific file.

## Validation
- `lake build TNLean.Algebra.LinearMapAux`
- `lake build TNLean.Channel.Irreducible.KrausSetup`
- `rg -n "ne_zero_of_pos_eigenvector" TNLean --glob '*.lean'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that relocates and generalizes an existing lemma; main risk is minor breakage from changed imports/namespaces rather than behavior changes.
> 
> **Overview**
> Moves the previously channel-local lemma about **nonzero eigenvectors implying a linear map is nonzero** into a new general-purpose module `TNLean.Algebra.LinearMapAux`, and factors out a more general `LinearMap.ne_zero_of_eigenvector`.
> 
> Updates irreducible-channel proofs to use `LinearMap.ne_zero_of_pos_eigenvector`, removes the duplicate local lemma from `KrausSetup.lean`, and re-exports the new helper from the root `TNLean.lean` import surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40adf5b321bed28501d536af441522ce95b5e13b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->