### PR TITLE
refactor(Channel): extract lower-zero invariance lemma

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -128,6 +128,7 @@ import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Overlap.Basic
 import TNLean.MPS.Core.Transfer
+import TNLean.MPS.Core.OrthogonalProjectionInvariance
 import TNLean.MPS.Core.BlockingTransfer
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.MPS.FundamentalTheorem.TransferNormalization

--- a/TNLean/Channel/FixedPoint/StationarySupport.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupport.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
+import TNLean.MPS.Core.OrthogonalProjectionInvariance
 import TNLean.MPS.Irreducible.FixedPointProjection
 
 /-!
@@ -37,55 +38,6 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-/-- If each Kraus operator `K i` is block-upper-triangular with respect to an
-orthogonal projection `P`, then the transfer map preserves the compression
-`P M_D P`. -/
--- Intentionally public so `ReducibleQDS.FixedDensity` can reuse this helper
--- instead of carrying a second local copy of the same proof.
-lemma lowerZero_implies_invariance
-    {r : ℕ} (K : Fin r → Mat) {P : Mat}
-    (hP : IsOrthogonalProjection P)
-    (hLower : ∀ i : Fin r, (1 - P) * K i * P = 0) :
-    ∀ X : Mat,
-      P * MPSTensor.transferMap (d := r) (D := D) K (P * X * P) * P =
-        MPSTensor.transferMap (d := r) (D := D) K (P * X * P) := by
-  intro X
-  have hP_herm : Pᴴ = P := hP.1
-  have hAP : ∀ i : Fin r, K i * P = P * K i * P := by
-    intro i
-    have hkey : K i * P - P * K i * P = 0 := by
-      have h : (1 - P) * K i * P = K i * P - P * K i * P := by
-        noncomm_ring
-      rw [← h]
-      exact hLower i
-    exact eq_of_sub_eq_zero hkey
-  have hPAd : ∀ i : Fin r, P * (K i)ᴴ = P * (K i)ᴴ * P := by
-    intro i
-    have hct : P * (K i)ᴴ * (1 - P) = 0 := by
-      have h := congrArg Matrix.conjTranspose (hLower i)
-      simp only [Matrix.conjTranspose_zero, Matrix.conjTranspose_mul,
-        Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hP_herm] at h
-      simpa [Matrix.mul_assoc] using h
-    have hkey : P * (K i)ᴴ - P * (K i)ᴴ * P = 0 := by
-      have h : P * (K i)ᴴ * (1 - P) = P * (K i)ᴴ - P * (K i)ᴴ * P := by
-        noncomm_ring
-      rwa [← h]
-    exact eq_of_sub_eq_zero hkey
-  simp only [MPSTensor.transferMap_apply]
-  rw [Finset.mul_sum, Finset.sum_mul]
-  apply Finset.sum_congr rfl
-  intro i _
-  have h1 : K i * (P * X * P) * (K i)ᴴ =
-      (K i * P) * X * (P * (K i)ᴴ) := by
-    noncomm_ring
-  have h2 : (K i * P) * X * (P * (K i)ᴴ) =
-      (P * K i * P) * X * (P * (K i)ᴴ * P) := by
-    conv_lhs => rw [hAP i, hPAd i]
-  have h3 : (P * K i * P) * X * (P * (K i)ᴴ * P) =
-      P * (K i * (P * X * P) * (K i)ᴴ) * P := by
-    noncomm_ring
-  exact ((h1.trans h2).trans h3).symm
-
 /-- Lemma 6.4 (support projection of a fixed PSD point is invariant under the
 corner action). -/
 theorem support_proj_fixed
@@ -114,7 +66,7 @@ theorem support_proj_fixed
         (d := r) (D := D) K ρ hρ_psd hρ_fix')
   intro X
   rw [hE_eq_transfer]
-  simpa [P] using lowerZero_implies_invariance (D := D) K hP_data.1 hP_data.2 X
+  simpa [P] using MPSTensor.lowerZero_implies_invariance K P hP_data.1 hP_data.2 X
 
 /-- Chosen stationary state of an irreducible channel. -/
 noncomputable def stationaryState
@@ -220,9 +172,6 @@ were vacuous/trivial. They should be replaced by:
 * a non-vacuous Prop. 6.9 equivalence (irreducibility ↔ full support of
   stationary states), and
 * Prop. 6.10 minimality of stationary support without assuming irreducibility.
-* TODO: if we want to also deduplicate the near-copy in
-  `MPS/Irreducible/FormII.lean`, extract `lowerZero_implies_invariance` to a
-  lighter shared helper rather than adding cross-layer imports.
 -/
 
 end Channel

--- a/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
@@ -3,9 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Semigroup.ReducibleQDS.Defs
--- `ReducibleQDS.Defs` does not already import `StationarySupport`, so this is
--- the direct import needed to reuse `Channel.lowerZero_implies_invariance`.
-import TNLean.Channel.FixedPoint.StationarySupport
+import TNLean.MPS.Core.OrthogonalProjectionInvariance
 
 /-!
 # Fixed Density ↔ Kernel Element (Wolf Prop 7.6, (1) ↔ (2)) and (1) → (3)
@@ -90,7 +88,7 @@ private theorem invariantCompression_of_supportProj_fixed_by_channel
   refine ⟨hP_data.1, ?_⟩
   intro X
   rw [hE_eq_transfer]
-  exact Channel.lowerZero_implies_invariance (D := D) K hP_data.1 hP_data.2 X
+  exact MPSTensor.lowerZero_implies_invariance K P hP_data.1 hP_data.2 X
 
 private lemma not_posDef_of_proj_sandwich_eq_self
     {P ρ : Mat}

--- a/TNLean/MPS/Core/OrthogonalProjectionInvariance.lean
+++ b/TNLean/MPS/Core/OrthogonalProjectionInvariance.lean
@@ -1,0 +1,65 @@
+import TNLean.MPS.Core.Transfer
+import TNLean.Channel.Irreducible.Basic
+
+/-!
+# Orthogonal-projection invariance for transfer maps
+
+This module provides a lightweight bridge from the Kraus-operator condition
+`(1 - P) * A i * P = 0` to invariance of the compressed algebra under the
+transfer map of an MPS tensor.
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+open Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- If each Kraus operator `A i` is block-upper-triangular with respect to an
+orthogonal projection `P`, then the transfer map preserves the compression
+`P M_D P`. -/
+lemma lowerZero_implies_invariance
+    (A : MPSTensor d D) (P : Matrix (Fin D) (Fin D) ℂ)
+    (hProj : IsOrthogonalProjection P)
+    (hLower : ∀ i : Fin d, (1 - P) * A i * P = 0) :
+    ∀ X, P * transferMap (d := d) (D := D) A (P * X * P) * P =
+      transferMap (d := d) (D := D) A (P * X * P) := by
+  intro X
+  have hPH : Pᴴ = P := hProj.1.eq
+  have hAP : ∀ i : Fin d, A i * P = P * A i * P := by
+    intro i
+    have hkey : A i * P - P * A i * P = 0 := by
+      have h : (1 - P) * A i * P = A i * P - P * A i * P := by
+        noncomm_ring
+      rw [← h]
+      exact hLower i
+    exact eq_of_sub_eq_zero hkey
+  have hPAd : ∀ i : Fin d, P * (A i)ᴴ = P * (A i)ᴴ * P := by
+    intro i
+    have hct : P * (A i)ᴴ * (1 - P) = 0 := by
+      have h := congrArg Matrix.conjTranspose (hLower i)
+      simp only [Matrix.conjTranspose_zero, Matrix.conjTranspose_mul,
+        Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hPH] at h
+      simpa [Matrix.mul_assoc] using h
+    have hkey : P * (A i)ᴴ - P * (A i)ᴴ * P = 0 := by
+      have h : P * (A i)ᴴ * (1 - P) = P * (A i)ᴴ - P * (A i)ᴴ * P := by
+        noncomm_ring
+      rwa [← h]
+    exact eq_of_sub_eq_zero hkey
+  simp only [transferMap_apply]
+  rw [Finset.mul_sum, Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro i _
+  have h1 : A i * (P * X * P) * (A i)ᴴ =
+      (A i * P) * X * (P * (A i)ᴴ) := by
+    noncomm_ring
+  have h2 : (A i * P) * X * (P * (A i)ᴴ) =
+      (P * A i * P) * X * (P * (A i)ᴴ * P) := by
+    conv_lhs => rw [hAP i, hPAd i]
+  have h3 : (P * A i * P) * X * (P * (A i)ᴴ * P) =
+      P * (A i * (P * X * P) * (A i)ᴴ) * P := by
+    noncomm_ring
+  exact ((h1.trans h2).trans h3).symm
+
+end MPSTensor

--- a/TNLean/MPS/Core/OrthogonalProjectionInvariance.lean
+++ b/TNLean/MPS/Core/OrthogonalProjectionInvariance.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
 import TNLean.MPS.Core.Transfer
 import TNLean.Channel.Irreducible.Basic
 

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.MPS.Core.OrthogonalProjectionInvariance
 import TNLean.QPF.Assembly
 import Mathlib.LinearAlgebra.Matrix.IsDiag
 
@@ -111,62 +112,6 @@ theorem isIrreducibleCP_transferMap_of_isIrreducibleTensor
   push Not at h_neither
   obtain ⟨hP0, hP1⟩ := h_neither
   exact hIrr ⟨P, hProj, hP0, hP1, hLower⟩
-
-/-- The "lower-zero" condition on Kraus operators implies the invariance condition
-for the transfer map.  This is the converse direction of `invariance_implies_lowerZero`.
-
-Given an orthogonal projection `P` with `(1 - P) * A i * P = 0` for all `i`,
-we show `P * E(P X P) * P = E(P X P)` for all `X`, where `E = transferMap A`.
-
-**Proof.**  From `(1 - P) * Aᵢ * P = 0` we obtain `Aᵢ * P = P * Aᵢ * P`.
-Taking conjugate transposes gives `P * Aᵢ† = P * Aᵢ† * P`.
-Then each Kraus term `Aᵢ (PXP) Aᵢ†` simplifies to
-`P * (Aᵢ (PXP) Aᵢ†) * P` using idempotence `P * P = P`,
-so the whole transfer-map image is sandwiched by `P`. -/
-lemma lowerZero_implies_invariance
-    (A : MPSTensor d D) (P : Matrix (Fin D) (Fin D) ℂ)
-    (hProj : IsOrthogonalProjection P)
-    (hLower : ∀ i : Fin d, (1 - P) * A i * P = 0) :
-    ∀ X, P * transferMap (d := d) (D := D) A (P * X * P) * P =
-         transferMap (d := d) (D := D) A (P * X * P) := by
-  intro X
-  -- Key identities from the projection and lower-zero conditions
-  have hPH : Pᴴ = P := hProj.1.eq
-  -- From (1-P)*Aᵢ*P = 0: Aᵢ*P = P*Aᵢ*P
-  have hAP : ∀ i : Fin d, A i * P = P * A i * P := by
-    intro i
-    have key : A i * P - P * A i * P = 0 := by
-      have h : (1 - P) * A i * P = A i * P - P * A i * P := by noncomm_ring
-      rw [← h]; exact hLower i
-    exact eq_of_sub_eq_zero key
-  -- Conjugate transpose: P*Aᵢ†*(1-P) = 0, hence P*Aᵢ† = P*Aᵢ†*P
-  have hPAd : ∀ i : Fin d, P * (A i)ᴴ = P * (A i)ᴴ * P := by
-    intro i
-    have h2 : P * (A i)ᴴ * (1 - P) = 0 := by
-      have h3 := congr_arg Matrix.conjTranspose (hLower i)
-      simp only [Matrix.conjTranspose_zero, Matrix.conjTranspose_mul,
-        Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hPH] at h3
-      -- h3 : P * ((A i)ᴴ * (1 - P)) = 0, need P * (A i)ᴴ * (1 - P) = 0
-      rwa [Matrix.mul_assoc]
-    have key : P * (A i)ᴴ - P * (A i)ᴴ * P = 0 := by
-      have : P * (A i)ᴴ * (1 - P) = P * (A i)ᴴ - P * (A i)ᴴ * P := by noncomm_ring
-      rwa [← this]
-    exact eq_of_sub_eq_zero key
-  -- Now show each Kraus term is sandwiched by P
-  -- Goal: P * E(PXP) * P = E(PXP), suffices to show per summand
-  simp only [transferMap_apply]
-  rw [Finset.mul_sum, Finset.sum_mul]
-  congr 1; ext1 i
-  -- Goal: P * (Aᵢ * (PXP) * Aᵢ†) * P = Aᵢ * (PXP) * Aᵢ†
-  -- Strategy: both sides equal (P*Aᵢ*P)*X*(P*Aᵢ†*P) by ring identity + hAP + hPAd
-  have step1 : A i * (P * X * P) * (A i)ᴴ =
-      (A i * P) * X * (P * (A i)ᴴ) := by noncomm_ring
-  have step2 : (A i * P) * X * (P * (A i)ᴴ) =
-      (P * A i * P) * X * (P * (A i)ᴴ * P) := by
-    conv_lhs => rw [hAP i, hPAd i]
-  have step3 : (P * A i * P) * X * (P * (A i)ᴴ * P) =
-      P * (A i * (P * X * P) * (A i)ᴴ) * P := by noncomm_ring
-  exact ((step1.trans step2).trans step3).symm
 
 /-- **Irreducible CP map ⇒ irreducible tensor.**
 


### PR DESCRIPTION
## Summary
- extract `MPSTensor.lowerZero_implies_invariance` into a new lightweight shared module at `TNLean/MPS/Core/OrthogonalProjectionInvariance.lean`
- update `StationarySupport` and `ReducibleQDS.FixedDensity` to import the shared helper instead of the heavier stationary-support module path
- remove the duplicate proof from `MPS/Irreducible/FormII.lean` and delete the extraction TODO from `StationarySupport`

## Why
`ReducibleQDS.FixedDensity` only needs the invariance helper, but previously had to reach it through the heavier `StationarySupport` import path. The shared module keeps the helper close to `transferMap` and allows the MPS-side duplicate in `FormII` to reuse the same proof.

## Validation
- `lake env lean TNLean/MPS/Core/OrthogonalProjectionInvariance.lean`
- `lake env lean TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean`
- `lake env lean TNLean/MPS/Irreducible/FormII.lean`
- `lake build TNLean.Channel.FixedPoint.StationarySupport`
- `rg "lowerZero_implies_invariance" TNLean/ --glob '*.lean' | grep -v Archive | grep -v Scratch`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves an existing proof into a shared module and updates imports/call sites; behavior/theorems should be unchanged aside from potential dependency/import ripple if the new module boundary is wrong.
> 
> **Overview**
> Extracts the projection-invariance helper into a new lightweight module `MPS/Core/OrthogonalProjectionInvariance.lean` as `MPSTensor.lowerZero_implies_invariance`.
> 
> Updates channel- and semigroup-side proofs (`FixedPoint/StationarySupport`, `Semigroup/ReducibleQDS/FixedDensity`) and the MPS irreducibility bridge (`MPS/Irreducible/FormII`) to import and use the shared lemma, removing duplicate/local copies and simplifying the previous import path. The root `TNLean.lean` export list is updated to include the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15d5f7e96bb5bdcaba5fab50b010c73e9cfc5a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->