### PR TITLE
feat(ParentHamiltonian): partial proof of degenerate ground space equals BNT span (#195)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
+++ b/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
@@ -131,11 +131,27 @@ The periodic parent-Hamiltonian ground space of a canonical-form/BNT tensor
 equals the span of the individual BNT block MPV states.
 
 TODO(#195): prove by combining `bnt_mem_groundSpace` (⊇ direction) with
-block-injective uniqueness from `UniqueGroundState` (⊆ direction). -/
+blockwise decomposition / uniqueness for the assembled tensor (⊆ direction).
+At present the reverse inclusion still needs a periodic-chain theorem showing
+that a state whose cyclic windows lie in the block-diagonal local ground space
+decomposes globally into block components, together with the normal/blockwise
+unique-ground-state reduction from `UniqueGroundState`. -/
 theorem parentHamiltonian_gs_eq_bnt_span
     (A : (j : Fin r) → MPSTensor d (dim j))
     (hCF : IsCanonicalFormBNT μ A) {L N : ℕ} (hL : 1 < L) (hN : N ≥ L + 1) :
     parentHamiltonianGroundSpace (μ := μ) A L N = bntSpan A N := by
-  sorry
+  apply le_antisymm
+  · -- TODO(#195): reverse inclusion.
+    -- The missing step is to decompose any
+    -- `ψ ∈ parentHamiltonianGroundSpace (μ := μ) A L N`
+    -- into block components coming from the local block-diagonal structure of
+    -- `toTensorFromBlocks μ A`, then apply injective uniqueness to each block.
+    -- This currently depends on periodic-chain block decomposition machinery
+    -- that is not yet available upstream.
+    sorry
+  · rw [bntSpan, Submodule.span_le]
+    intro ψ hψ
+    obtain ⟨j, rfl⟩ := Set.mem_range.mp hψ
+    exact bnt_mem_groundSpace A hCF hL hN j
 
 end MPSTensor

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -43,12 +43,14 @@ private noncomputable abbrev endEquivMatrixCLM (m n : ℕ) :
 @[reducible] noncomputable def instGCNormedAddCommGroupMatrixCLM (m n : ℕ) :
     NormedAddCommGroup
       (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=
-  ContinuousLinearMap.toNormedAddCommGroup
+  by infer_instance
 
 @[reducible] noncomputable def instGCNormedRingMatrixCLM (m n : ℕ) :
     NormedRing
       (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=
-  ContinuousLinearMap.toNormedRing
+  by
+    letI := instGCNormedAddCommGroupMatrixCLM m n
+    infer_instance
 
 @[reducible] noncomputable def instGCNormedAlgebraMatrixCLM (m n : ℕ) :
     NormedAlgebra ℂ


### PR DESCRIPTION
## What changed

This updates `TNLean/MPS/ParentHamiltonian/DegenerateGS.lean` to make the current state of `parentHamiltonian_gs_eq_bnt_span` explicit, and includes a CI-unblocking fix in `TNLean/Spectral/GaugeConstruction.lean`.

### `DegenerateGS.lean`

- proved the easy inclusion `bntSpan A N ≤ parentHamiltonianGroundSpace (μ := μ) A L N` directly inside the theorem via `Submodule.span_le` and `bnt_mem_groundSpace`
- replaced the bare top-level `sorry` with a `le_antisymm` proof skeleton
- documented the exact missing reverse-inclusion step in the theorem comment and in the remaining proof TODO

### `GaugeConstruction.lean`

- reverted `instGCNormedAddCommGroupMatrixCLM` and `instGCNormedRingMatrixCLM` to their known-working `infer_instance` form to unblock CI (pre-existing issue from `main` after PR #540 merge; see [bot-fix comment](https://github.com/LionSR/TNLean/pull/551#issuecomment-4219271940) for details)

## Why

Issue #195 asks for the full identification of the degenerate parent-Hamiltonian ground space with the span of the BNT block states. While working through the file and the surrounding parent-Hamiltonian / assembly machinery, the blocker turned out to be structural rather than local:

- we still need a periodic-chain theorem that decomposes a state with cyclic windows in the block-diagonal local ground space into global block components
- that decomposition then needs to be paired with the blockwise uniqueness reduction from `UniqueGroundState`

So this PR lands the completed ⊇ direction and leaves a single, targeted `sorry` on the missing ⊆ direction instead of a fully opaque placeholder.

## Impact

This narrows the remaining work on #195 substantially:

- the theorem now exposes the exact reverse inclusion that is missing
- the already-proved inclusion is part of the theorem body, not just available separately
- follow-up work can focus on the periodic block-decomposition lemma / normal-chain bridge without re-deriving the easy half

## Validation

- `lake build` passes (CI-verified)
- the `DegenerateGS.lean` file contains exactly one remaining `sorry`, at the intended top-level blocker site
- the `GaugeConstruction.lean` change restores the working form from before the auto-fix regression