### PR TITLE
feat(MPDO): add ZCL, PRFP, and general RFP definitions (#235)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -207,6 +207,9 @@ import TNLean.PiAlgebra.GlobalSymmetry
 -- Layer 3b: MPO / MPDO / LPDO foundations
 import TNLean.MPS.MPDO.Defs
 -- import TNLean.MPS.MPDO.VerticalCF  -- scaffold with sorry; excluded until proofs are complete
+import TNLean.MPS.MPDO.ZCL
+import TNLean.MPS.MPDO.PRFP
+import TNLean.MPS.MPDO.RFP
 
 -- MPS examples
 import TNLean.MPS.Examples.AKLT

--- a/TNLean/MPS/MPDO/PRFP.lean
+++ b/TNLean/MPS/MPDO/PRFP.lean
@@ -1,0 +1,91 @@
+/- 
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.MPDO.ZCL
+import TNLean.MPS.RFP.Defs
+
+/-!
+# Purification RFP for LPDO tensors
+
+This file packages the local purification data used by `MPOTensor.IsLPDO` and
+defines the mixed-state purification RFP condition from arXiv:1606.00608,
+Definition 4.3.
+
+## Main definitions
+
+* `MPOTensor.IsLPDOWitness`: a packaged LPDO witness for a fixed purifying
+  tensor family and bond-space equivalence.
+* `MPOTensor.purifyingMPSTensor`: the doubled-index MPS tensor associated to
+  a purifying family `A`.
+* `MPOTensor.IsPRFP`: an MPO tensor admits an LPDO witness whose purifying MPS
+  tensor is a pure-state RFP.
+
+## References
+
+* [CPGSV17] arXiv:1606.00608, §4.3
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A packaged witness for the LPDO relation of `M` with a fixed purifying
+family `A` and bond-space identification `e`. This isolates the witness data
+from `IsLPDO` so it can be reused in purification-RFP statements. -/
+def IsLPDOWitness {dK D' : ℕ} (M : MPOTensor d D)
+    (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
+    (e : Fin D ≃ Fin D' × Fin D') : Prop :=
+  ∀ i j : Fin d, M i j = (∑ k : Fin dK,
+    (A i k) ⊗ₖ ((A j k).map (starRingEnd ℂ))).submatrix ↑e ↑e
+
+/-- The MPS tensor obtained by bundling the physical and ancilla indices of a
+purifying family `A`. -/
+def purifyingMPSTensor {dK D' : ℕ}
+    (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ) : MPSTensor (d * dK) D' :=
+  fun ik => A ik.divNat ik.modNat
+
+@[simp] lemma purifyingMPSTensor_apply {dK D' : ℕ}
+    (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ) (ik : Fin (d * dK)) :
+    purifyingMPSTensor A ik = A ik.divNat ik.modNat :=
+  rfl
+
+/-- Repackaging `IsLPDO` in terms of `IsLPDOWitness`. -/
+theorem isLPDO_iff_exists_witness (M : MPOTensor d D) :
+    IsLPDO M ↔
+      ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
+        (e : Fin D ≃ Fin D' × Fin D'),
+        IsLPDOWitness M A e := by
+  simp [IsLPDO, IsLPDOWitness]
+
+/-- An LPDO has a **purification RFP** when it admits a local purification
+whose purifying MPS tensor is a pure-state RFP.
+
+See arXiv:1606.00608, Definition 4.3. -/
+def IsPRFP (M : MPOTensor d D) : Prop :=
+  ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
+    (e : Fin D ≃ Fin D' × Fin D'),
+    IsLPDOWitness M A e ∧ MPSTensor.IsRFP (purifyingMPSTensor A)
+
+/-- A purification-RFP tensor is, in particular, an LPDO. -/
+theorem IsPRFP.isLPDO {M : MPOTensor d D} (h : IsPRFP M) : IsLPDO M := by
+  rcases h with ⟨dK, D', A, e, hWitness, _hRFP⟩
+  exact ⟨dK, D', A, e, hWitness⟩
+
+/-- For an LPDO, PRFP should imply MPO ZCL: idempotence of the purifying MPS
+transfer map is expected to descend to the induced MPO transfer map.
+
+TODO: formalize the transfer-map correspondence between an LPDO witness
+`IsLPDOWitness M A e` and the MPO transfer map of `M`, then transport
+`MPSTensor.IsRFP (purifyingMPSTensor A)` across that correspondence. -/
+theorem IsPRFP.isZCL {M : MPOTensor d D} (h : IsPRFP M) : IsZCL M := by
+  rcases h with ⟨dK, D', A, e, hWitness, hRFP⟩
+  -- TODO: show that the MPO transfer map induced by `hWitness` is the channel
+  -- obtained from the purifying MPS tensor `purifyingMPSTensor A`.
+  -- Then `hRFP` yields the required idempotence for `transferMap M`.
+  sorry
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/PRFP.lean
+++ b/TNLean/MPS/MPDO/PRFP.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.Defs
-import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.RFP.Defs
 
 /-!
@@ -75,17 +74,15 @@ theorem IsPRFP.isLPDO {M : MPOTensor d D} (h : IsPRFP M) : IsLPDO M := by
   rcases h with ⟨dK, D', A, e, hWitness, _hRFP⟩
   exact ⟨dK, D', A, e, hWitness⟩
 
-/-- For an LPDO, PRFP should imply MPO ZCL: idempotence of the purifying MPS
-transfer map is expected to descend to the induced MPO transfer map.
+/-!
+### Future work
 
-TODO: formalize the transfer-map correspondence between an LPDO witness
-`IsLPDOWitness M A e` and the MPO transfer map of `M`, then transport
-`MPSTensor.IsRFP (purifyingMPSTensor A)` across that correspondence. -/
-theorem IsPRFP.isZCL {M : MPOTensor d D} (h : IsPRFP M) : IsZCL M := by
-  rcases h with ⟨dK, D', A, e, hWitness, hRFP⟩
-  -- TODO: show that the MPO transfer map induced by `hWitness` is the channel
-  -- obtained from the purifying MPS tensor `purifyingMPSTensor A`.
-  -- Then `hRFP` yields the required idempotence for `transferMap M`.
-  sorry
+`IsPRFP.isZCL`: for an LPDO, PRFP should imply MPO ZCL. The proof requires
+formalizing the transfer-map correspondence between an LPDO witness
+`IsLPDOWitness M A e` and the MPO transfer map of `M`, then transporting
+`MPSTensor.IsRFP (purifyingMPSTensor A)` across that correspondence. This
+implication is intentionally not exported until the proof is completed, to
+keep the development sound.
+-/
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -1,0 +1,63 @@
+/- 
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.ZCL
+
+/-!
+# General MPDO renormalization fixed point
+
+This file introduces a provisional mixed-state RFP definition for MPO tensors,
+following the transfer-map aspect of arXiv:1606.00608, Definition 4.1.
+
+The full definition in the paper is phrased using trace-preserving completely
+positive blocking and unblocking maps. In this first pass we package the
+transfer-map idempotence condition, which is the part already supported by the
+current infrastructure.
+
+## Main definitions
+
+* `MPOTensor.IsRFP`: provisional mixed-state RFP condition via idempotent
+  transfer map.
+* `MPOTensor.isRFP_iff_isZCL`: this provisional RFP condition coincides with
+  `MPOTensor.IsZCL`.
+
+## References
+
+* [CPGSV17] arXiv:1606.00608, §4.1
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A provisional mixed-state **renormalization fixed point** condition:
+the MPO transfer map is idempotent.
+
+This captures the transfer-map fixed-point equation from
+arXiv:1606.00608, Definition 4.1, but does not yet encode the explicit
+trace-preserving completely positive blocking and unblocking maps from the
+paper.
+
+TODO: strengthen this definition to the full `T`/`S` formulation. -/
+def IsRFP (M : MPOTensor d D) : Prop :=
+  transferMap M ∘ₗ transferMap M = transferMap M
+
+/-- In the current development, the provisional mixed-state RFP condition is
+definitionally the same as MPO ZCL. -/
+theorem isRFP_iff_isZCL (M : MPOTensor d D) : IsRFP M ↔ IsZCL M :=
+  Iff.rfl
+
+/-- The provisional mixed-state RFP condition implies MPO ZCL. -/
+theorem IsRFP.isZCL {M : MPOTensor d D} (h : IsRFP M) : IsZCL M :=
+  h
+
+/-- The provisional mixed-state RFP condition is equivalent to the pure-state
+RFP condition for the doubled-index MPS tensor. -/
+theorem isRFP_iff_toMPSTensor_isRFP (M : MPOTensor d D) :
+    IsRFP M ↔ MPSTensor.IsRFP (M.toMPSTensor) := by
+  simpa [IsRFP, MPOTensor.IsZCL] using isZCL_iff_toMPSTensor_isRFP M
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -7,18 +7,17 @@ import TNLean.MPS.MPDO.ZCL
 /-!
 # General MPDO renormalization fixed point
 
-This file introduces a provisional mixed-state RFP definition for MPO tensors,
-following the transfer-map aspect of arXiv:1606.00608, Definition 4.1.
+This file records consequences of the provisional mixed-state RFP definition for
+MPO tensors, following the transfer-map aspect of arXiv:1606.00608,
+Definition 4.1.
 
 The full definition in the paper is phrased using trace-preserving completely
-positive blocking and unblocking maps. In this first pass we package the
-transfer-map idempotence condition, which is the part already supported by the
-current infrastructure.
+positive blocking and unblocking maps. In this first pass `MPOTensor.IsRFP`
+packages the transfer-map idempotence condition, which is the part already
+supported by the current infrastructure.
 
-## Main definitions
+## Main results
 
-* `MPOTensor.IsRFP`: provisional mixed-state RFP condition via idempotent
-  transfer map.
 * `MPOTensor.isRFP_iff_isZCL`: this provisional RFP condition coincides with
   `MPOTensor.IsZCL`.
 

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -41,6 +41,10 @@ arXiv:1606.00608, Definition 4.1, but does not yet encode the explicit
 trace-preserving completely positive blocking and unblocking maps from the
 paper.
 
+For tensors already put into canonical form, compare `MPOTensor.IsZCL` in
+`TNLean/MPS/MPDO/ZCL.lean`: in that setting this provisional fixed-point
+condition matches the corresponding zero-correlation-length condition.
+
 TODO: strengthen this definition to the full `T`/`S` formulation. -/
 def IsRFP (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -33,22 +33,6 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- A provisional mixed-state **renormalization fixed point** condition:
-the MPO transfer map is idempotent.
-
-This captures the transfer-map fixed-point equation from
-arXiv:1606.00608, Definition 4.1, but does not yet encode the explicit
-trace-preserving completely positive blocking and unblocking maps from the
-paper.
-
-For tensors already put into canonical form, compare `MPOTensor.IsZCL` in
-`TNLean/MPS/MPDO/ZCL.lean`: in that setting this provisional fixed-point
-condition matches the corresponding zero-correlation-length condition.
-
-TODO: strengthen this definition to the full `T`/`S` formulation. -/
-def IsRFP (M : MPOTensor d D) : Prop :=
-  transferMap M ∘ₗ transferMap M = transferMap M
-
 /-- In the current development, the provisional mixed-state RFP condition is
 definitionally the same as MPO ZCL. -/
 theorem isRFP_iff_isZCL (M : MPOTensor d D) : IsRFP M ↔ IsZCL M :=

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -33,7 +33,11 @@ idempotent:
 `E_M ∘ E_M = E_M`.
 
 This is the mixed-state analogue of `MPSTensor.IsRFP`. See
-arXiv:1606.00608, Definition 4.2. -/
+arXiv:1606.00608, Definition 4.2.
+
+Note: `MPOTensor.IsRFP` is currently definitionally equal to this condition
+but is expected to be strengthened to the full blocking/unblocking
+formulation from arXiv:1606.00608, Definition 4.1. -/
 def IsZCL (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M
 

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -1,0 +1,47 @@
+/- 
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.RFP.Defs
+
+/-!
+# Zero correlation length for MPO tensors
+
+Definitions of zero-correlation-length conditions for mixed-state tensor
+networks, following arXiv:1606.00608, Definition 4.2.
+
+## Main definitions
+
+* `MPOTensor.IsZCL`: the MPO transfer map is idempotent.
+* `MPOTensor.isZCL_iff_toMPSTensor_isRFP`: this condition is equivalent to the
+  pure-state RFP condition for the doubled-index MPS tensor.
+
+## References
+
+* [CPGSV17] arXiv:1606.00608, §4.2
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- An MPO tensor has **zero correlation length** when its transfer map is
+idempotent:
+`E_M ∘ E_M = E_M`.
+
+This is the mixed-state analogue of `MPSTensor.IsRFP`. See
+arXiv:1606.00608, Definition 4.2. -/
+def IsZCL (M : MPOTensor d D) : Prop :=
+  transferMap M ∘ₗ transferMap M = transferMap M
+
+/-- ZCL for an MPO tensor is equivalent to the pure-state RFP condition for
+the doubled-index MPS tensor `M.toMPSTensor`. Both statements assert
+idempotence of the same transfer map. -/
+theorem isZCL_iff_toMPSTensor_isRFP (M : MPOTensor d D) :
+    IsZCL M ↔ MPSTensor.IsRFP (M.toMPSTensor) := by
+  simp [IsZCL, MPSTensor.IsRFP]
+
+end MPOTensor

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -355,7 +355,7 @@ theorem gauged_intertwining_core
       refine ⟨Sblock, hSblock_unit, ?_⟩
       simp [rhoT, Sblock, Matrix.star_eq_conjTranspose, Matrix.fromBlocks_conjTranspose,
         Matrix.fromBlocks_multiply]
-    exact Matrix.IsStrictlyPositive.posDef hrhoT_strict
+    exact Matrix.isStrictlyPositive_iff_posDef.mp hrhoT_strict
   have hrhoT_fix : Kraus.adjointMap K rhoT = rhoT := by
     have hAblock : ∑ i : Fin d, (A' i)ᴴ * (SAᴴ * SA) * (A' i) = SAᴴ * SA := by
       have hterm :

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -126,6 +126,39 @@ legs cyclically and taking the resulting trace.
     so $\E_M(X) \ge 0$ whenever $X \ge 0$.
 \end{proof}
 
+\section{Zero correlation length}
+
+\begin{definition}[Zero correlation length for MPO tensors]%
+    \label{def:mpo_is_zcl}
+    \lean{MPOTensor.IsZCL}
+    \leanok
+    \uses{def:mpo_transfer_map}
+    An MPO tensor $M$ has \emph{zero correlation length} when its transfer map
+    is idempotent:
+    \[
+        \E_M \circ \E_M = \E_M.
+    \]
+    This is the mixed-state analogue of the renormalization fixed-point
+    condition for MPS tensors; see \cite[Definition~4.2]{Cirac2021Matrix}.
+\end{definition}
+
+\begin{theorem}[MPO ZCL iff doubled-index MPS RFP]%
+    \label{thm:mpo_is_zcl_iff_to_mps_rfp}
+    \lean{MPOTensor.isZCL_iff_toMPSTensor_isRFP}
+    \leanok
+    \uses{def:mpo_is_zcl, def:mpo_to_mps, def:is_rfp, lem:mpo_transfer_eq_mps}
+    An MPO tensor has zero correlation length if and only if its doubled-index
+    MPS view is a renormalization fixed point.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By Lemma~\ref{lem:mpo_transfer_eq_mps}, the transfer map of $M$ agrees with
+    the transfer map of its doubled-index MPS view. Thus
+    $\E_M \circ \E_M = \E_M$ holds exactly when the transfer map of
+    $M.\mathrm{toMPSTensor}$ is idempotent, which is the RFP condition.
+\end{proof}
+
 \section{MPDOs and LPDOs}
 
 \begin{definition}[MPDO]\label{def:mpdo}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -226,6 +226,41 @@ legs cyclically and taking the resulting trace.
     Hence $\rho^{(N)}(M) = \sum_\kappa \ketbra{\psi_\kappa}{\psi_\kappa} \ge 0$.
 \end{proof}
 
+\section{Purification RFP}
+
+\begin{definition}[Purifying MPS tensor]\label{def:purifying_mps_tensor}
+    \lean{MPOTensor.purifyingMPSTensor}
+    \leanok
+    \uses{def:mpo_tensor}
+    Given a purifying family
+    $A^{(i,k)} \in \MN{D'}$ for $i \in \{0,\ldots,d{-}1\}$ and
+    $k \in \{0,\ldots,d_K{-}1\}$, the \emph{purifying MPS tensor} is the
+    MPS tensor with physical dimension $d \cdot d_K$ and bond dimension $D'$
+    obtained by bundling the pair $(i,k)$ into a single index.
+\end{definition}
+
+\begin{definition}[Purification RFP]\label{def:is_prfp}
+    \lean{MPOTensor.IsPRFP}
+    \leanok
+    \uses{def:lpdo, def:purifying_mps_tensor, def:is_rfp}
+    An MPO tensor $M$ has a \emph{purification RFP} if it admits an LPDO
+    witness whose purifying MPS tensor is a pure-state renormalization
+    fixed point.
+    This is \cite[Definition~4.3]{Cirac2021Matrix}.
+\end{definition}
+
+\begin{theorem}[Purification RFP implies LPDO]\label{thm:prfp_is_lpdo}
+    \lean{MPOTensor.IsPRFP.isLPDO}
+    \leanok
+    \uses{def:is_prfp, def:lpdo}
+    A purification-RFP tensor is, in particular, an LPDO.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The PRFP condition provides an LPDO witness by construction.
+\end{proof}
+
 \section{Pure-state recovery inside the MPO formalism}
 
 \begin{definition}[MPDO renormalization fixed point]\label{def:is_rfp_mpdo}
@@ -238,6 +273,36 @@ legs cyclically and taking the resulting trace.
         \E_M \circ \E_M = \E_M.
     \]
 \end{definition}
+
+\begin{theorem}[MPDO RFP iff MPO ZCL]\label{thm:is_rfp_iff_is_zcl}
+    \lean{MPOTensor.isRFP_iff_isZCL}
+    \leanok
+    \uses{def:is_rfp_mpdo, def:mpo_is_zcl}
+    The provisional MPDO renormalization fixed-point condition is equivalent to
+    the zero-correlation-length condition for MPO tensors.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Both conditions assert $\E_M \circ \E_M = \E_M$; they are definitionally
+    identical.
+\end{proof}
+
+\begin{theorem}[MPDO RFP iff doubled-index MPS RFP]\label{thm:is_rfp_iff_to_mps_rfp}
+    \lean{MPOTensor.isRFP_iff_toMPSTensor_isRFP}
+    \leanok
+    \uses{def:is_rfp_mpdo, def:mpo_to_mps, def:is_rfp, def:mpo_is_zcl,
+        thm:mpo_is_zcl_iff_to_mps_rfp}
+    The provisional MPDO RFP condition is equivalent to the pure-state RFP
+    condition for the doubled-index MPS tensor.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpo_is_zcl_iff_to_mps_rfp}
+    Unfold the MPDO RFP condition to its definitional equivalent, MPO ZCL,
+    then apply Theorem~\ref{thm:mpo_is_zcl_iff_to_mps_rfp}.
+\end{proof}
 
 \begin{definition}[Diagonal pure-state embedding as an MPO]\label{def:to_mpo_tensor}
     \lean{MPSTensor.toMPOTensor}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -619,7 +619,6 @@ interaction projectors commute with each other.
 \end{definition}
 
 \begin{theorem}[RFP implies NNCPH]\label{thm:rfp_implies_nncph}
-    \lean{MPSTensor.rfp_implies_nncph}
     \notready
     \uses{def:is_rfp, def:is_nncph, def:normal}
     If $A$ is a normal renormalization fixed point in left-canonical form,


### PR DESCRIPTION
## Summary

Adds the first mixed-state RFP API surface for issue #235.

- add `TNLean.MPS.MPDO.ZCL` with `MPOTensor.IsZCL` and the doubled-index equivalence to `MPSTensor.IsRFP`
- add `TNLean.MPS.MPDO.PRFP` with packaged LPDO witness data, `purifyingMPSTensor`, `IsPRFP`, and the basic `IsPRFP.isLPDO` theorem
- add `TNLean.MPS.MPDO.RFP` with a provisional transfer-map-based mixed-state `IsRFP` plus bridges to `IsZCL` and pure-state `IsRFP`
- re-export the new modules from `TNLean.lean`

## Notes

- `MPOTensor.IsPRFP.isZCL` is left as an explicit `sorry` with a TODO explaining the missing purification-to-transfer correspondence.
- The mixed-state `IsRFP` definition is intentionally a first-pass transfer-map formulation, with a TODO to strengthen it to the full blocking/unblocking CPM statement from arXiv:1606.00608 Definition 4.1.

## Validation

- direct `lake env lean ... -o ... -i ...` compilation succeeded for:
  - `TNLean/MPS/MPDO/ZCL.lean`
  - `TNLean/MPS/MPDO/PRFP.lean`
  - `TNLean/MPS/MPDO/RFP.lean`
- `lake build TNLean.MPS.MPDO.ZCL` currently gets blocked by a pre-existing failure on `main` in `TNLean/Spectral/GaugeConstruction.lean` (missing `NormedAddCommGroup` / `SeminormedRing` instances for matrix continuous linear maps), which is unrelated to this diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean modules and documentation around MPDO/MPO predicates and equivalence lemmas, with only a small compatibility tweak in an unrelated spectral proof.
> 
> **Overview**
> Adds an initial mixed-state fixed-point API for MPO tensors: `MPOTensor.IsZCL` (transfer-map idempotence) plus equivalence theorems relating MPO ZCL / provisional `MPOTensor.IsRFP` / pure-state `MPSTensor.IsRFP` via the doubled-index `toMPSTensor` view.
> 
> Introduces purification-RFP support for LPDOs by packaging LPDO witness data (`IsLPDOWitness`), defining `purifyingMPSTensor`, and defining `MPOTensor.IsPRFP` with the basic consequence `IsPRFP → IsLPDO`. These new MPDO modules are re-exported from `TNLean.lean`, and the blueprint is updated with the corresponding definitions/theorems.
> 
> Also updates `GaugeConstruction.lean` to use `Matrix.isStrictlyPositive_iff_posDef` instead of the older lemma name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34d840452160e5e7272e6ccd42f51cce09bd7c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->