### PR TITLE
feat(MPDO): add pure-case MPO embedding and recovery theorem (#235)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -216,6 +216,7 @@ import TNLean.MPS.Examples.ZMod2
 -- Layer 5b: Renormalization fixed points (RFP) — pure-state scaffolding
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.RFP.ZeroCorrelationLength
+import TNLean.MPS.MPDO.PureRecovery
 import TNLean.MPS.RFP.StructuralForm
 import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Assembly

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Defs
 import TNLean.MPS.Core.Transfer
-import TNLean.MPS.RFP.ZeroCorrelationLength
 import Mathlib.LinearAlgebra.Matrix.PosDef
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 
@@ -36,6 +35,7 @@ Verstraete):
 * `MPOTensor.IsHermitian`: local hermiticity predicate on the tensor.
 * `MPOTensor.IsMPDO`: global positivity predicate.
 * `MPOTensor.IsLPDO`: local purification predicate.
+* `MPOTensor.IsRFP`: renormalization fixed-point predicate.
 * `MPOTensor.toMPSTensor`: view an MPO tensor as an MPS tensor with doubled
   physical index `Fin (d * d)`.
 
@@ -277,56 +277,11 @@ theorem IsLPDO.isMPDO {M : MPOTensor d D} (h : IsLPDO M) : IsMPDO M := by
   -- Push σ τ application inside the sum on the RHS, expand vecMulVec
   erw [Fintype.sum_apply σ, Fintype.sum_apply τ]; congr 1
 
-/-! ### Pure-state recovery inside the MPO formalism -/
+/-! ### MPDO renormalization fixed points -/
 
 /-- An MPO tensor is an MPDO renormalization fixed point when its transfer map
-is idempotent. This is the direct mixed-state analogue of `MPSTensor.IsRFP`. -/
-def IsRFP_MPDO (M : MPOTensor d D) : Prop :=
+is idempotent. -/
+def IsRFP (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M
 
 end MPOTensor
-
-namespace MPSTensor
-
-open MPOTensor
-
-variable {d D : ℕ}
-
-/-- Embed a pure MPS tensor as a diagonal MPO with trivial bra structure:
-`M^{ij} = δ_{ij} A^i`. -/
-def toMPOTensor (A : MPSTensor d D) : MPOTensor d D :=
-  fun i j => if i = j then A i else 0
-
-@[simp] lemma toMPOTensor_apply_same (A : MPSTensor d D) (i : Fin d) :
-    A.toMPOTensor i i = A i := by
-  simp [toMPOTensor]
-
-@[simp] lemma toMPOTensor_apply_ne (A : MPSTensor d D) {i j : Fin d}
-    (hij : i ≠ j) :
-    A.toMPOTensor i j = 0 := by
-  simp [toMPOTensor, hij]
-
-/-- The transfer map of the diagonal pure-state embedding is exactly the
-original MPS transfer map. -/
-@[simp] theorem toMPOTensor_transferMap (A : MPSTensor d D) :
-    MPOTensor.transferMap A.toMPOTensor = transferMap A := by
-  classical
-  ext X
-  rw [MPOTensor.transferMap_apply, transferMap_apply]
-  simp [toMPOTensor]
-
-/-- For a pure MPS viewed as a diagonal MPO, MPDO-RFP is exactly the original
-pure-state RFP condition. -/
-theorem toMPOTensor_isRFP_MPDO_iff_isRFP (A : MPSTensor d D) :
-    MPOTensor.IsRFP_MPDO A.toMPOTensor ↔ IsRFP A := by
-  rw [MPOTensor.IsRFP_MPDO, IsRFP, toMPOTensor_transferMap]
-
-/-- For a pure MPS embedded as a diagonal MPO, the MPDO RFP condition reduces
-to the pure-state zero-correlation-length condition via
-`MPSTensor.zcl_iff_idempotent_transfer`. -/
-theorem toMPOTensor_isRFP_MPDO_iff_isZCL (A : MPSTensor d D) :
-    MPOTensor.IsRFP_MPDO A.toMPOTensor ↔ IsZCL A := by
-  rw [toMPOTensor_isRFP_MPDO_iff_isRFP]
-  exact (zcl_iff_idempotent_transfer A).symm
-
-end MPSTensor

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Defs
 import TNLean.MPS.Core.Transfer
+import TNLean.MPS.RFP.ZeroCorrelationLength
 import Mathlib.LinearAlgebra.Matrix.PosDef
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 
@@ -276,4 +277,56 @@ theorem IsLPDO.isMPDO {M : MPOTensor d D} (h : IsLPDO M) : IsMPDO M := by
   -- Push σ τ application inside the sum on the RHS, expand vecMulVec
   erw [Fintype.sum_apply σ, Fintype.sum_apply τ]; congr 1
 
+/-! ### Pure-state recovery inside the MPO formalism -/
+
+/-- An MPO tensor is an MPDO renormalization fixed point when its transfer map
+is idempotent. This is the direct mixed-state analogue of `MPSTensor.IsRFP`. -/
+def IsRFP_MPDO (M : MPOTensor d D) : Prop :=
+  transferMap M ∘ₗ transferMap M = transferMap M
+
 end MPOTensor
+
+namespace MPSTensor
+
+open MPOTensor
+
+variable {d D : ℕ}
+
+/-- Embed a pure MPS tensor as a diagonal MPO with trivial bra structure:
+`M^{ij} = δ_{ij} A^i`. -/
+def toMPOTensor (A : MPSTensor d D) : MPOTensor d D :=
+  fun i j => if i = j then A i else 0
+
+@[simp] lemma toMPOTensor_apply_same (A : MPSTensor d D) (i : Fin d) :
+    A.toMPOTensor i i = A i := by
+  simp [toMPOTensor]
+
+@[simp] lemma toMPOTensor_apply_ne (A : MPSTensor d D) {i j : Fin d}
+    (hij : i ≠ j) :
+    A.toMPOTensor i j = 0 := by
+  simp [toMPOTensor, hij]
+
+/-- The transfer map of the diagonal pure-state embedding is exactly the
+original MPS transfer map. -/
+@[simp] theorem toMPOTensor_transferMap (A : MPSTensor d D) :
+    MPOTensor.transferMap A.toMPOTensor = transferMap A := by
+  classical
+  ext X
+  rw [MPOTensor.transferMap_apply, transferMap_apply]
+  simp [toMPOTensor]
+
+/-- For a pure MPS viewed as a diagonal MPO, MPDO-RFP is exactly the original
+pure-state RFP condition. -/
+theorem toMPOTensor_isRFP_MPDO_iff_isRFP (A : MPSTensor d D) :
+    MPOTensor.IsRFP_MPDO A.toMPOTensor ↔ IsRFP A := by
+  rw [MPOTensor.IsRFP_MPDO, IsRFP, toMPOTensor_transferMap]
+
+/-- For a pure MPS embedded as a diagonal MPO, the MPDO RFP condition reduces
+to the pure-state zero-correlation-length condition via
+`MPSTensor.zcl_iff_idempotent_transfer`. -/
+theorem toMPOTensor_isRFP_MPDO_iff_isZCL (A : MPSTensor d D) :
+    MPOTensor.IsRFP_MPDO A.toMPOTensor ↔ IsZCL A := by
+  rw [toMPOTensor_isRFP_MPDO_iff_isRFP]
+  exact (zcl_iff_idempotent_transfer A).symm
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/PureRecovery.lean
+++ b/TNLean/MPS/MPDO/PureRecovery.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.RFP.ZeroCorrelationLength
+
+/-!
+# Pure-state recovery inside the MPO formalism
+
+This file studies the diagonal embedding of a pure MPS tensor into the MPO
+formalism and shows that the MPDO renormalization fixed-point condition
+recovers the usual pure-state `IsRFP` and `IsZCL` conditions.
+-/
+
+namespace MPSTensor
+
+open MPOTensor
+
+variable {d D : ℕ}
+
+/-- Embed a pure MPS tensor as a diagonal MPO with trivial bra structure:
+`M^{ij} = δ_{ij} A^i`. -/
+def toMPOTensor (A : MPSTensor d D) : MPOTensor d D :=
+  fun i j => if i = j then A i else 0
+
+@[simp] lemma toMPOTensor_apply_same (A : MPSTensor d D) (i : Fin d) :
+    A.toMPOTensor i i = A i := by
+  simp [toMPOTensor]
+
+@[simp] lemma toMPOTensor_apply_ne (A : MPSTensor d D) {i j : Fin d}
+    (hij : i ≠ j) :
+    A.toMPOTensor i j = 0 := by
+  simp [toMPOTensor, hij]
+
+/-- The transfer map of the diagonal pure-state embedding is exactly the
+original MPS transfer map. -/
+@[simp] theorem toMPOTensor_transferMap (A : MPSTensor d D) :
+    MPOTensor.transferMap A.toMPOTensor = transferMap A := by
+  classical
+  ext X
+  rw [MPOTensor.transferMap_apply, transferMap_apply]
+  simp [toMPOTensor]
+
+/-- For a pure MPS viewed as a diagonal MPO, MPDO-RFP is exactly the original
+pure-state RFP condition. -/
+theorem toMPOTensor_isRFP_iff_isRFP (A : MPSTensor d D) :
+    MPOTensor.IsRFP A.toMPOTensor ↔ IsRFP A := by
+  rw [MPOTensor.IsRFP, IsRFP, toMPOTensor_transferMap]
+
+/-- For a pure MPS embedded as a diagonal MPO, the MPDO RFP condition reduces
+to the pure-state zero-correlation-length condition via
+`MPSTensor.zcl_iff_idempotent_transfer`. -/
+theorem toMPOTensor_isRFP_iff_isZCL (A : MPSTensor d D) :
+    MPOTensor.IsRFP A.toMPOTensor ↔ IsZCL A := by
+  rw [toMPOTensor_isRFP_iff_isRFP]
+  exact (zcl_iff_idempotent_transfer A).symm
+
+end MPSTensor

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -50,6 +50,7 @@ private noncomputable abbrev endEquivMatrixCLM (m n : ℕ) :
       (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=
   ContinuousLinearMap.toNormedRing
 
+set_option maxSynthPendingDepth 6 in
 @[reducible] noncomputable def instGCNormedAlgebraMatrixCLM (m n : ℕ) :
     NormedAlgebra ℂ
       (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -196,7 +196,7 @@ legs cyclically and taking the resulting trace.
 \section{Pure-state recovery inside the MPO formalism}
 
 \begin{definition}[MPDO renormalization fixed point]\label{def:is_rfp_mpdo}
-    \lean{MPOTensor.IsRFP_MPDO}
+    \lean{MPOTensor.IsRFP}
     \leanok
     \uses{def:mpo_transfer_map}
     An MPO tensor $M$ is an \emph{MPDO renormalization fixed point} if its
@@ -241,7 +241,7 @@ legs cyclically and taking the resulting trace.
 
 \begin{theorem}[Pure-state recovery of the RFP condition]%
     \label{thm:to_mpo_rfp_iff_rfp}
-    \lean{MPSTensor.toMPOTensor_isRFP_MPDO_iff_isRFP}
+    \lean{MPSTensor.toMPOTensor_isRFP_iff_isRFP}
     \leanok
     \uses{def:is_rfp_mpdo, def:is_rfp, thm:to_mpo_transfer_map}
     For an MPS tensor $A$, its diagonal MPO embedding is MPDO-RFP if and only
@@ -261,7 +261,7 @@ legs cyclically and taking the resulting trace.
 
 \begin{theorem}[Pure-state recovery of zero correlation length]%
     \label{thm:to_mpo_rfp_iff_zcl}
-    \lean{MPSTensor.toMPOTensor_isRFP_MPDO_iff_isZCL}
+    \lean{MPSTensor.toMPOTensor_isRFP_iff_isZCL}
     \leanok
     \uses{thm:to_mpo_rfp_iff_rfp, thm:zcl_iff_idempotent_transfer}
     For an MPS tensor $A$, the diagonal MPO embedding is MPDO-RFP if and only

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -192,3 +192,86 @@ legs cyclically and taking the resulting trace.
     where $\psi_\kappa(\sigma) = \tr(P_\kappa)$.
     Hence $\rho^{(N)}(M) = \sum_\kappa \ketbra{\psi_\kappa}{\psi_\kappa} \ge 0$.
 \end{proof}
+
+\section{Pure-state recovery inside the MPO formalism}
+
+\begin{definition}[MPDO renormalization fixed point]\label{def:is_rfp_mpdo}
+    \lean{MPOTensor.IsRFP_MPDO}
+    \leanok
+    \uses{def:mpo_transfer_map}
+    An MPO tensor $M$ is an \emph{MPDO renormalization fixed point} if its
+    transfer map is idempotent:
+    \[
+        \E_M \circ \E_M = \E_M.
+    \]
+\end{definition}
+
+\begin{definition}[Diagonal pure-state embedding as an MPO]\label{def:to_mpo_tensor}
+    \lean{MPSTensor.toMPOTensor}
+    \leanok
+    \uses{def:mps_tensor, def:mpo_tensor}
+    An MPS tensor $A = \{A^i\}_{i=0}^{d-1}$ determines an MPO tensor by
+    placing $A^i$ on the diagonal in the bra and ket indices:
+    \[
+        M^{ij} = \delta_{ij} A^i.
+    \]
+    Equivalently, $M^{ii} = A^i$ and $M^{ij} = 0$ for $i \ne j$.
+\end{definition}
+
+\begin{theorem}[Transfer map of the diagonal pure-state embedding]%
+    \label{thm:to_mpo_transfer_map}
+    \lean{MPSTensor.toMPOTensor_transferMap}
+    \leanok
+    \uses{def:to_mpo_tensor, def:mpo_transfer_map, def:transfer_map}
+    The transfer map of the diagonal MPO associated to $A$ agrees with the
+    original MPS transfer map:
+    \[
+        \E_{A^{\mathrm{MPO}}} = \E_A.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:to_mpo_tensor, def:mpo_transfer_map, def:transfer_map}
+    In the double sum defining $\E_{A^{\mathrm{MPO}}}$, all off-diagonal terms
+    vanish because $M^{ij} = 0$ for $i \ne j$, while the diagonal terms are
+    exactly $A^i X (A^i)^\dagger$. Thus only the sum over $i$ remains, which
+    is the defining formula for $\E_A$.
+\end{proof}
+
+\begin{theorem}[Pure-state recovery of the RFP condition]%
+    \label{thm:to_mpo_rfp_iff_rfp}
+    \lean{MPSTensor.toMPOTensor_isRFP_MPDO_iff_isRFP}
+    \leanok
+    \uses{def:is_rfp_mpdo, def:is_rfp, thm:to_mpo_transfer_map}
+    For an MPS tensor $A$, its diagonal MPO embedding is MPDO-RFP if and only
+    if $A$ is an RFP:
+    \[
+        A^{\mathrm{MPO}} \text{ is MPDO-RFP} \iff A \text{ is RFP}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:is_rfp_mpdo, def:is_rfp, thm:to_mpo_transfer_map}
+    Both conditions assert idempotence of the corresponding transfer map.
+    Theorem~\ref{thm:to_mpo_transfer_map} identifies those transfer maps, so
+    the two predicates are equivalent.
+\end{proof}
+
+\begin{theorem}[Pure-state recovery of zero correlation length]%
+    \label{thm:to_mpo_rfp_iff_zcl}
+    \lean{MPSTensor.toMPOTensor_isRFP_MPDO_iff_isZCL}
+    \leanok
+    \uses{thm:to_mpo_rfp_iff_rfp, thm:zcl_iff_idempotent_transfer}
+    For an MPS tensor $A$, the diagonal MPO embedding is MPDO-RFP if and only
+    if $A$ has zero correlation length.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:to_mpo_rfp_iff_rfp, thm:zcl_iff_idempotent_transfer}
+    Combine Theorem~\ref{thm:to_mpo_rfp_iff_rfp} with the characterization of
+    zero correlation length by idempotence of the MPS transfer map
+    (Theorem~\ref{thm:zcl_iff_idempotent_transfer}).
+\end{proof}


### PR DESCRIPTION
## Summary
- add `MPOTensor.IsRFP_MPDO` as the mixed-state idempotence condition on the MPO transfer map
- add `MPSTensor.toMPOTensor` for the trivial diagonal embedding of a pure MPS into the MPO formalism
- prove the pure-case recovery lemmas showing the embedded MPO transfer map recovers the original MPS transfer map, hence `IsRFP_MPDO` reduces to pure `IsRFP` and, via the existing theorem, pure `IsZCL`

## Why
This gives the MPDO development a direct bridge back to the existing pure-state RFP/ZCL theory, which is a useful sanity check and a foundation for later mixed-state fixed-point work.

## Validation
- `lake env lean TNLean/MPS/MPDO/Defs.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean definitions/lemmas and documentation around MPDO fixed points, with only a small local typeclass-synthesis option tweak in `Spectral/GaugeConstruction.lean`. Main risk is proof/compilation breakage from the new imports and instance synthesis depth change.
> 
> **Overview**
> Defines `MPOTensor.IsRFP` as idempotence of the MPO transfer map (MPDO renormalization fixed-point condition).
> 
> Adds `MPSTensor.toMPOTensor` (diagonal pure-state embedding into MPOs) and proves the transfer map and fixed-point notions recover the pure-state predicates (`MPOTensor.IsRFP A.toMPOTensor ↔ MPSTensor.IsRFP A` and ↔ `IsZCL A`). This new bridge is re-exported via `TNLean.lean` and documented in the MPDO blueprint chapter.
> 
> Also constrains typeclass search locally by setting `maxSynthPendingDepth` for `instGCNormedAlgebraMatrixCLM` in `Spectral/GaugeConstruction.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d54a37c43a048c9b001c693b2b612f7cd3f63d72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->