### PR TITLE
doc(blueprint): add commuting PH and decorrelation entries (#234)

### DIFF
--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -3,10 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.RFP.Defs
+import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.Channel.FixedPoint.Algebra
-import TNLean.MPS.Core.CPPrimitive
 import TNLean.MPS.BNT.Construction
-import TNLean.MPS.Irreducible.FormII
 
 /-!
 # Structural form of RFP tensors
@@ -19,10 +18,6 @@ that are renormalization fixed points, following arXiv:1606.00608 §3.4
 
 * `rfp_nt_structural`: formalized structural precursor — a **nonzero** normal RFP tensor is
   already injective
-* `rfp_nt_structural_of_leftCanonical`: left-canonical normal RFP tensors are injective
-  without a separate nonzero hypothesis
-* `rfp_nt_cfii_diagonal_fixedPoint`: Appendix B / CFII reduction step — after unitary
-  conjugation, a left-canonical normal RFP tensor has a diagonal positive-definite fixed point
 * `rfp_cf_structural`: each canonical-form block is injective
 * `rfp_bnt_structural`: each BNT block is injective
 
@@ -37,7 +32,7 @@ identification. What *is* formalized here is the span-collapse step:
 RFP tensor is automatically injective.
 -/
 
-open scoped Matrix ComplexOrder
+open scoped Matrix
 
 namespace MPSTensor
 
@@ -160,76 +155,6 @@ theorem rfp_nt_structural (A : MPSTensor d D)
       change evalWord A (List.ofFn σ) ∈ Submodule.span ℂ (Set.range A)
       exact evalWord_mem_span_of_isRFP A hRFP (List.ofFn σ) hσ_ne
     exact le_antisymm le_top htop_le
-
-/-- A left-canonical tensor has a nonzero Kraus operator as soon as `D ≠ 0`. -/
-private theorem exists_nonzero_of_leftCanonical [DecidableEq (Fin D)] [NeZero D]
-    (A : MPSTensor d D)
-    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
-    ∃ i, A i ≠ 0 := by
-  by_contra hA
-  push Not at hA
-  have hsum : ∑ i : Fin d, (A i)ᴴ * A i = 0 := by
-    simp [hA]
-  have h1 : (1 : Mat) = 0 := by
-    rw [hLeft] at hsum
-    exact hsum
-  exact (one_ne_zero : (1 : Mat) ≠ 0) h1
-
-/-- Appendix B precursor without a separate nonzero side condition:
-for a left-canonical normal RFP tensor, the one-site Kraus span is already all of `M_D(ℂ)`. -/
-theorem rfp_nt_structural_of_leftCanonical [DecidableEq (Fin D)] [NeZero D]
-    (A : MPSTensor d D)
-    (hNT : IsNormal A) (hRFP : IsRFP A)
-    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
-    IsInjective A := by
-  exact rfp_nt_structural A hNT hRFP (exists_nonzero_of_leftCanonical A hLeft)
-
-/-- Appendix B / CFII reduction step:
-after unitary conjugation, a left-canonical normal RFP tensor has a diagonal
-positive-definite fixed point for its transfer map. -/
-theorem rfp_nt_cfii_diagonal_fixedPoint [DecidableEq (Fin D)] [NeZero D]
-    (A : MPSTensor d D)
-    (hNT : IsNormal A) (hRFP : IsRFP A)
-    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
-    ∃ (U : Matrix.unitaryGroup (Fin D) ℂ)
-      (Λ : Matrix (Fin D) (Fin D) ℂ),
-        Λ.PosDef ∧ Λ.IsDiag ∧
-        (∑ i : Fin d, ((↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ))ᴴ
-                      * ((↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ)) = 1) ∧
-        transferMap (d := d) (D := D)
-          (fun i => (↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ)) Λ = Λ := by
-  have hInj : IsInjective A := rfp_nt_structural_of_leftCanonical A hNT hRFP hLeft
-  have hIrrMap : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
-    injective_implies_irreducibleCP A hInj
-  have hIrrTensor : IsIrreducibleTensor (d := d) (D := D) A :=
-    isIrreducibleTensor_of_isIrreducibleMap A hIrrMap
-  have hD : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
-  exact exists_unitary_diag_posDef_fixedPoint_of_leftCanonical_of_isIrreducibleTensor
-    (d := d) (D := D) A hLeft hIrrTensor hD
-
-/-- **Lemma B.1** (arXiv:1606.00608, Appendix B): a normal tensor in canonical
-form II that is an RFP should admit the decomposition `A i = X * Λ * U i * X⁻¹`
-with diagonal positive `Λ` and a physical-index isometry `U`.
-
-The current formalization isolates the missing step to the expected gap:
-classifying idempotent irreducible CP maps as rank-one projections and then
-identifying the resulting Kraus family with the canonical `Λ * U i` form via
-Kraus freedom. The injectivity and CFII diagonal-fixed-point reduction are
-already available as `rfp_nt_structural_of_leftCanonical` and
-`rfp_nt_cfii_diagonal_fixedPoint`. -/
-theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
-    (hNT : IsNormal A) (hRFP : IsRFP A)
-    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
-    ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ)
-      (U : MPSTensor d D),
-      X.det ≠ 0 ∧
-      (∀ k, 0 < Λ k) ∧
-      (∑ i : Fin d, (U i)ᴴ * U i = 1) ∧
-      (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
-  -- TODO(#233): use `rfp_nt_cfii_diagonal_fixedPoint` to pass to CFII, prove that the
-  -- idempotent irreducible transfer map is a rank-one projector `X ↦ trace X • ρ`, and
-  -- then apply Kraus freedom in the forward direction to extract the physical-index isometry.
-  sorry
 
 /-- Canonical-form blocks are already injective, so the structural precursor above is automatic. -/
 theorem rfp_cf_structural {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.RFP.Defs
-import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.Channel.FixedPoint.Algebra
+import TNLean.MPS.Core.CPPrimitive
 import TNLean.MPS.BNT.Construction
+import TNLean.MPS.Irreducible.FormII
 
 /-!
 # Structural form of RFP tensors
@@ -18,6 +19,10 @@ that are renormalization fixed points, following arXiv:1606.00608 §3.4
 
 * `rfp_nt_structural`: formalized structural precursor — a **nonzero** normal RFP tensor is
   already injective
+* `rfp_nt_structural_of_leftCanonical`: left-canonical normal RFP tensors are injective
+  without a separate nonzero hypothesis
+* `rfp_nt_cfii_diagonal_fixedPoint`: Appendix B / CFII reduction step — after unitary
+  conjugation, a left-canonical normal RFP tensor has a diagonal positive-definite fixed point
 * `rfp_cf_structural`: each canonical-form block is injective
 * `rfp_bnt_structural`: each BNT block is injective
 
@@ -32,7 +37,7 @@ identification. What *is* formalized here is the span-collapse step:
 RFP tensor is automatically injective.
 -/
 
-open scoped Matrix
+open scoped Matrix ComplexOrder
 
 namespace MPSTensor
 
@@ -155,6 +160,76 @@ theorem rfp_nt_structural (A : MPSTensor d D)
       change evalWord A (List.ofFn σ) ∈ Submodule.span ℂ (Set.range A)
       exact evalWord_mem_span_of_isRFP A hRFP (List.ofFn σ) hσ_ne
     exact le_antisymm le_top htop_le
+
+/-- A left-canonical tensor has a nonzero Kraus operator as soon as `D ≠ 0`. -/
+private theorem exists_nonzero_of_leftCanonical [DecidableEq (Fin D)] [NeZero D]
+    (A : MPSTensor d D)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    ∃ i, A i ≠ 0 := by
+  by_contra hA
+  push Not at hA
+  have hsum : ∑ i : Fin d, (A i)ᴴ * A i = 0 := by
+    simp [hA]
+  have h1 : (1 : Mat) = 0 := by
+    rw [hLeft] at hsum
+    exact hsum
+  exact (one_ne_zero : (1 : Mat) ≠ 0) h1
+
+/-- Appendix B precursor without a separate nonzero side condition:
+for a left-canonical normal RFP tensor, the one-site Kraus span is already all of `M_D(ℂ)`. -/
+theorem rfp_nt_structural_of_leftCanonical [DecidableEq (Fin D)] [NeZero D]
+    (A : MPSTensor d D)
+    (hNT : IsNormal A) (hRFP : IsRFP A)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    IsInjective A := by
+  exact rfp_nt_structural A hNT hRFP (exists_nonzero_of_leftCanonical A hLeft)
+
+/-- Appendix B / CFII reduction step:
+after unitary conjugation, a left-canonical normal RFP tensor has a diagonal
+positive-definite fixed point for its transfer map. -/
+theorem rfp_nt_cfii_diagonal_fixedPoint [DecidableEq (Fin D)] [NeZero D]
+    (A : MPSTensor d D)
+    (hNT : IsNormal A) (hRFP : IsRFP A)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    ∃ (U : Matrix.unitaryGroup (Fin D) ℂ)
+      (Λ : Matrix (Fin D) (Fin D) ℂ),
+        Λ.PosDef ∧ Λ.IsDiag ∧
+        (∑ i : Fin d, ((↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ))ᴴ
+                      * ((↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ)) = 1) ∧
+        transferMap (d := d) (D := D)
+          (fun i => (↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ)) Λ = Λ := by
+  have hInj : IsInjective A := rfp_nt_structural_of_leftCanonical A hNT hRFP hLeft
+  have hIrrMap : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+    injective_implies_irreducibleCP A hInj
+  have hIrrTensor : IsIrreducibleTensor (d := d) (D := D) A :=
+    isIrreducibleTensor_of_isIrreducibleMap A hIrrMap
+  have hD : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
+  exact exists_unitary_diag_posDef_fixedPoint_of_leftCanonical_of_isIrreducibleTensor
+    (d := d) (D := D) A hLeft hIrrTensor hD
+
+/-- **Lemma B.1** (arXiv:1606.00608, Appendix B): a normal tensor in canonical
+form II that is an RFP should admit the decomposition `A i = X * Λ * U i * X⁻¹`
+with diagonal positive `Λ` and a physical-index isometry `U`.
+
+The current formalization isolates the missing step to the expected gap:
+classifying idempotent irreducible CP maps as rank-one projections and then
+identifying the resulting Kraus family with the canonical `Λ * U i` form via
+Kraus freedom. The injectivity and CFII diagonal-fixed-point reduction are
+already available as `rfp_nt_structural_of_leftCanonical` and
+`rfp_nt_cfii_diagonal_fixedPoint`. -/
+theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
+    (hNT : IsNormal A) (hRFP : IsRFP A)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ)
+      (U : MPSTensor d D),
+      X.det ≠ 0 ∧
+      (∀ k, 0 < Λ k) ∧
+      (∑ i : Fin d, (U i)ᴴ * U i = 1) ∧
+      (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
+  -- TODO(#233): use `rfp_nt_cfii_diagonal_fixedPoint` to pass to CFII, prove that the
+  -- idempotent irreducible transfer map is a rank-one projector `X ↦ trace X • ρ`, and
+  -- then apply Kraus freedom in the forward direction to extract the physical-index isometry.
+  sorry
 
 /-- Canonical-form blocks are already injective, so the structural precursor above is automatic. -/
 theorem rfp_cf_structural {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -50,21 +50,21 @@ private noncomputable abbrev endEquivMatrixCLM (m n : ℕ) :
       (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=
   ContinuousLinearMap.toNormedRing
 
+set_option maxSynthPendingDepth 6 in
 @[reducible] noncomputable def instGCNormedAlgebraMatrixCLM (m n : ℕ) :
     NormedAlgebra ℂ
-      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=
-  by
-    letI := instGCNormedAddCommGroupMatrixCLM m n
-    letI := instGCNormedRingMatrixCLM m n
-    infer_instance
+      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) := by
+  letI := instGCNormedRingMatrixCLM m n
+  exact { ContinuousLinearMap.algebra with
+    norm_smul_le := norm_smul_le }
 
+set_option maxSynthPendingDepth 6 in
 @[reducible] def instGCCompleteSpaceMatrixCLM (m n : ℕ) :
     CompleteSpace
-      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=
-  by
-    letI := instGCFiniteDimensionalMatrixCLM m n
-    exact FiniteDimensional.complete ℂ
-      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ)
+      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) := by
+  letI := instGCFiniteDimensionalMatrixCLM m n
+  exact FiniteDimensional.complete ℂ
+    (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ)
 
 namespace MPSTensor
 

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -50,21 +50,21 @@ private noncomputable abbrev endEquivMatrixCLM (m n : ℕ) :
       (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=
   ContinuousLinearMap.toNormedRing
 
-set_option maxSynthPendingDepth 6 in
 @[reducible] noncomputable def instGCNormedAlgebraMatrixCLM (m n : ℕ) :
     NormedAlgebra ℂ
-      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) := by
-  letI := instGCNormedRingMatrixCLM m n
-  exact { ContinuousLinearMap.algebra with
-    norm_smul_le := norm_smul_le }
+      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=
+  by
+    letI := instGCNormedAddCommGroupMatrixCLM m n
+    letI := instGCNormedRingMatrixCLM m n
+    infer_instance
 
-set_option maxSynthPendingDepth 6 in
 @[reducible] def instGCCompleteSpaceMatrixCLM (m n : ℕ) :
     CompleteSpace
-      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) := by
-  letI := instGCFiniteDimensionalMatrixCLM m n
-  exact FiniteDimensional.complete ℂ
-    (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ)
+      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ) :=
+  by
+    letI := instGCFiniteDimensionalMatrixCLM m n
+    exact FiniteDimensional.complete ℂ
+      (Matrix (Fin m) (Fin n) ℂ →L[ℂ] Matrix (Fin m) (Fin n) ℂ)
 
 namespace MPSTensor
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -602,11 +602,11 @@ interaction projectors commute with each other.
 \begin{definition}[Commuting parent Hamiltonian]\label{def:is_commuting_parent_ham}
     \lean{MPSTensor.IsCommutingParentHam}
     \leanok
-    \uses{def:local_term_parent}
+    \uses{def:parent_hamiltonian, def:local_term_parent}
     The parent Hamiltonian with block length~$L$ on $N$ sites has
     \emph{commuting} local terms if
     $h_i h_j = h_j h_i$ for all $i,j \in \{0,\ldots,N{-}1\}$.
-    See Ref.~\cite[Definition~3.9]{Cirac2021Matrix}.
+    See Ref.~\cite[\S~3.3, Definition~3.9]{Cirac2021Matrix}.
 \end{definition}
 
 \begin{definition}[Nearest-neighbor commuting parent Hamiltonian]\label{def:is_nncph}
@@ -615,11 +615,13 @@ interaction projectors commute with each other.
     \uses{def:is_commuting_parent_ham}
     A \emph{nearest-neighbor commuting parent Hamiltonian} (NNCPH) is a
     commuting parent Hamiltonian with block length $L = 2$.
-    See Ref.~\cite[Definition~3.9]{Cirac2021Matrix}.
+    See Ref.~\cite[\S~3.3, Definition~3.9]{Cirac2021Matrix}.
 \end{definition}
 
 \begin{theorem}[RFP implies NNCPH]\label{thm:rfp_implies_nncph}
-    \uses{def:is_nncph}
+    \lean{MPSTensor.rfp_implies_nncph}
+    \notready
+    \uses{def:is_rfp, def:is_nncph}
     If $A$ is a renormalization fixed point (RFP), then its parent
     Hamiltonian with $L = 2$ has commuting local terms.
     \textbf{Status:} A previous proof attempt was found incorrect and removed;
@@ -642,6 +644,7 @@ Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
     \emph{decorrelated} w.r.t.\ $K$ when
     $P_K \circ O_A \circ (1 - P_K) \circ O_B \circ P_K = 0$
     for all $O_A \in \mathcal{O}_A$, $O_B \in \mathcal{O}_B$.
+    See Ref.~\cite[Appendix~D, \S~D.2, Definition~D.1]{Cirac2021Matrix}.
 \end{definition}
 
 \begin{definition}[Commuting parent Hamiltonian structure]\label{def:has_commuting_parent_ham}
@@ -651,6 +654,7 @@ Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
     \emph{commuting parent Hamiltonian structure} if there exist idempotent
     endomorphisms $P_{AX}$ and $P_{XB}$ that commute and satisfy
     $P_{AX} \circ P_{XB} = P_K$.
+    See Ref.~\cite[Appendix~D, \S~D.2, Definition~D.2]{Cirac2021Matrix}.
 \end{definition}
 
 \begin{theorem}[Idempotence of the product projector]%
@@ -815,7 +819,7 @@ Appendix~D, \S D.2 of~\cite{Cirac2021Matrix}.
     $A$-observables commute with $P_{XB}$ while $B$-observables commute
     with $P_{AX}$, then regions $A$ and $B$ are decorrelated w.r.t.\ $K$.
     This is the backward direction of Proposition~D.3
-    from~\cite{Cirac2021Matrix}, Appendix~D, \S D.2.
+    from~\cite[Appendix~D, \S~D.2, Proposition~D.3]{Cirac2021Matrix}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -619,7 +619,6 @@ interaction projectors commute with each other.
 \end{definition}
 
 \begin{theorem}[RFP implies NNCPH]\label{thm:rfp_implies_nncph}
-    \lean{MPSTensor.rfp_implies_nncph}
     \notready
     \uses{def:is_rfp, def:is_nncph}
     If $A$ is a renormalization fixed point (RFP), then its parent


### PR DESCRIPTION
## Summary
- tighten the blueprint entries for `MPSTensor.IsCommutingParentHam` and `MPSTensor.IsNNCPH`
- add explicit Appendix D / Section 3.3 source references for `Decorrelation.IsDecorrelated`, `Decorrelation.HasCommutingParentHam`, and `Decorrelation.commutingHam_isDecorrelated`
- mark the unproved `MPSTensor.rfp_implies_nncph` blueprint entry as `\notready`

## Why
Issue #234 asks for the commuting parent Hamiltonian and decorrelation blueprint entries to reflect the existing formalization, with the proved backward direction of Proposition D.3 marked as formalized and future work clearly marked as not ready.

## Validation
- `leanblueprint checkdecls` initially failed because required `.olean` files were missing
- `lake build` was attempted, but the repository currently fails in `TNLean/Spectral/GaugeConstruction.lean` with unrelated typeclass synthesis errors
- rerunning `leanblueprint checkdecls` after the build attempt still stops on missing `.olean` files because the full build does not complete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Lean typeclass instance construction for `ContinuousLinearMap` endomorphisms, which can affect downstream typeclass synthesis and build stability. Blueprint changes are documentation-only but adjust readiness/traceability of stated results.
> 
> **Overview**
> Updates `TNLean/Spectral/GaugeConstruction.lean` to avoid fragile typeclass inference by providing explicit `NormedAlgebra` and `CompleteSpace` instances for matrix `ContinuousLinearMap` endomorphisms (with a local `maxSynthPendingDepth` tweak).
> 
> Tightens the blueprint (`ch14_parent_hamiltonian.tex`) around commuting parent Hamiltonians and decorrelation by fixing `\uses` dependencies, adding more precise source citations (Section 3.3 / Appendix D.2), and marking `RFP implies NNCPH` as `\notready`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6159d88648442894555d1349cb146e20d1e199de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->