### PR TITLE
doc(blueprint): normalize PEPS transpose notation in web TN diagrams (#401)

### DIFF
--- a/blueprint/src/macros/tn_web.tex
+++ b/blueprint/src/macros/tn_web.tex
@@ -223,7 +223,7 @@
 \newcommand{\TNPEPSEdgeGaugeOrientation}{%
   \begin{array}{c}
     \text{edge } e = (u,w) \text{ oriented by } u < w \\
-    u \; \text{---} \; X_e \; \text{---} \; (X_e^{-1})^T \; \text{---} \; w
+    u \; \text{---} \; X_e \; \text{---} \; (X_e^{-1})^\top \; \text{---} \; w
   \end{array}%
 }
 
@@ -236,7 +236,7 @@
 
 \newcommand{\TNPEPSGaugeCancellation}{%
   \begin{array}{c}
-    \sum_j X_e(j,i)\,((X_e^{-1})^T)(j,k) = \delta(i,k) \\
+    \sum_j X_e(j,i)\,((X_e^{-1})^\top)(j,k) = \delta(i,k) \\
     \text{so the two edge gauges cancel on the shared edge index}
   \end{array}%
 }
@@ -251,7 +251,7 @@
 \newcommand{\TNPEPSGlobalConsistency}{%
   \begin{array}{c}
     \text{local gauges extracted at } u \text{ and } w \text{ agree on the shared edge } e \\
-    u \; \text{---} \; X_e \; \text{---} \; (X_e^{-1})^T \; \text{---} \; w \\
+    u \; \text{---} \; X_e \; \text{---} \; (X_e^{-1})^\top \; \text{---} \; w \\
     \text{and define one global edge gauge family}
   \end{array}%
 }


### PR DESCRIPTION
## Summary
- reviewed the tensor-network diagrams used across the blueprint chapters and the PEPS additions from PR #530 for index orientation, notation, and surrounding references
- found the diagrammatics mathematically consistent overall on `main`
- normalized the PEPS web fallback macros to use `^\top` instead of `^T` so the web output matches the print TikZ macros and chapter prose

## Why
Issue #401 asked for a mathematical accuracy review of the TN diagrams. The substantive PEPS gauge-orientation and cancellation issues from the earlier PR cycle are already fixed on `main`; the remaining inconsistency was notation drift between the print and web renderings of the same PEPS diagrams.

## Impact
- keeps the PEPS edge-gauge and cancellation notation consistent across blueprint outputs
- avoids presenting two different transpose conventions for the same diagrams
- leaves the underlying mathematical content unchanged

## Validation
- reviewed the chapter call sites for the TN macros in `ch02_mps.tex`, `ch02b_mpdo.tex`, `ch03_single.tex`, `ch08_canonical.tex`, `ch11_assembly.tex`, `ch13_algebraic_ft.tex`, `ch13b_symmetry.tex`, and `ch14_parent_hamiltonian.tex`
- `rg -n "\^T" blueprint/src/macros/tn_web.tex blueprint/src/macros/tn_print.tex blueprint/src/chapter/ch13_algebraic_ft.tex`
- `git diff --check`
- `cd blueprint && leanblueprint web`  
  Build completed successfully; existing warnings remained about missing `web.bbl` and two unresolved empty labels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely documentation/LaTeX macro notation changes, with no impact on computation or build logic beyond rendering the transpose symbol.
> 
> **Overview**
> Normalizes the PEPS web fallback tensor-network macros in `tn_web.tex` to render transpose as `^\top` (replacing `^T`) in the edge-gauge orientation, cancellation identity, and global consistency diagrams.
> 
> This aligns web-rendered TN diagrams with the print-side macros and avoids mixed transpose notation across outputs, without changing the underlying mathematical content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e739619d8c97d0b8648aad543ddfdf6b9b50c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->