### PR TITLE
Blueprint: address v4 review comments for chapters 10-14

### DIFF
--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -670,8 +670,8 @@ a positive-definite fixed point, peripheral spectrum `{1}`, and is irreducible
    (`isIrreducibleCP_transferMap_of_isIrreducibleTensor`).
 
 This packaged strong-irreducibility statement is exactly the input later fed
-into Proposition 3(c)→(b): peripheral spectrum `{1}` supplies the aperiodicity
-used by the irreducibility-to-normality endpoint.
+into Proposition 3(c)→(b), which yields eventual full Kraus rank (hence
+normality) directly, without passing through an aperiodicity argument.
 
 Paper: Proposition 3 (a)⟹(c) of arXiv:0909.5347.
 This is the full paper-facing (a)→(c) direction. -/

--- a/TNLean/Wielandt/QuantumWielandt.lean
+++ b/TNLean/Wielandt/QuantumWielandt.lean
@@ -66,9 +66,9 @@ If `A` satisfies the spectral-gap predicate `IsPrimitiveMPS A ρ` and the fixed
 point `ρ` is positive definite, then `A` is normal.
 
 The proof factors through strong irreducibility: from `IsPrimitiveMPS + ρ.PosDef`
-one gets `IsStronglyIrreduciblePaper A`, which gives peripheral spectrum `{1}`
-(hence aperiodicity) together with irreducibility, and the Proposition 3(c)→(b)
-backend then yields eventual full Kraus rank.
+one gets `IsStronglyIrreduciblePaper A` (i.e., primitive in Wolf's sense), and
+Wolf's primitivity equivalence (`wolf_theorem_6_8_conjunction`) identifies this
+directly with eventual full Kraus rank, hence normality.
 
 No aperiodicity hypothesis is needed. -/
 theorem isNormal_of_isPrimitiveMPS_of_posDef

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -546,6 +546,17 @@ The results follow~\cite{Sanz2010Quantum}.
     \end{enumerate}
 \end{proof}
 
+\begin{remark}[Quantitative vs.\ qualitative content of Theorem~\ref{thm:wielandt_general}]%
+    \leanok
+    The quantitative bound
+    $\iota(A) \le (D^2 - d' + 1)\cdot D^2$
+    is cited from \cite[Theorem~1, case~(1)]{Sanz2010Quantum}.
+    The blueprint's own lemmas prove the qualitative conclusion used on the
+    fundamental-theorem route, namely Theorem~\ref{thm:wielandt_lemma2b}:
+    there exists $N$ with $S_N(A) = \MN{D}$.
+    The quantitative bound is not on the fundamental-theorem critical path.
+\end{remark}
+
 \section{Lemma~2(b): fixed-length matrix spanning}\label{sec:lemma2b}
 
 The preceding sections establish the cumulative-spanning part of the
@@ -1131,14 +1142,12 @@ projection onto the fixed-point subspace.
 
 \begin{proof}
     \leanok
-    \uses{thm:strongly_irred_from_primitive}
+    \uses{thm:strongly_irred_from_primitive, thm:wolf_6_8_conjunction}
     By Theorem~\ref{thm:strongly_irred_from_primitive},
-    $A$ is strongly irreducible.
-    The implication from strong irreducibility to normality proceeds as
-    follows: strong irreducibility gives peripheral spectrum $\{1\}$,
-    hence the aperiodicity condition $\Id \in S_1(A)$.
-    Combined with irreducibility, Theorem~\ref{thm:irred_tensor_aperiodic_normal}
-    then yields normality.
+    $A$ is strongly irreducible, i.e.\ primitive in Wolf's sense.
+    Under normalization, Theorem~\ref{thm:wolf_6_8_conjunction}
+    identifies this primitivity condition directly with normality
+    (equivalently, eventual full Kraus rank).
 \end{proof}
 
 \section{Cumulative span to word span}\label{sec:cumspan_to_wordspan}
@@ -1156,11 +1165,13 @@ The gap is closed by an aperiodicity hypothesis.
     $\sum_i (A^i)^\dagger A^i = \Id$ does \emph{not} imply
     $\Id \in S_1(A)$; it only gives a quadratic identity among the
     Kraus operators.
+    The aperiodicity condition is kept explicit in this section for
+    generality.
     For the paper-style primitive condition
     (peripheral-spectrum primitivity together with a positive-definite
-    fixed point), one expects aperiodicity to follow from spectral
-    analysis of the transfer map. That implication is not used in the
-    present Wielandt argument, so the condition is kept explicit.
+    fixed point), normality follows directly from Wolf's primitivity
+    equivalence (Theorem~\ref{thm:wolf_6_8_conjunction}) without passing
+    through aperiodicity.
 \end{remark}
 
 \begin{remark}[Counterexample: cumulative spanning does not imply normality]%
@@ -1285,12 +1296,11 @@ The gap is closed by an aperiodicity hypothesis.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:strongly_irred_from_primitive, thm:irred_tensor_aperiodic_normal}
+    \uses{thm:strongly_irred_from_primitive, thm:wolf_6_8_conjunction}
     By Theorem~\ref{thm:strongly_irred_from_primitive},
-    $A$ is strongly irreducible. In particular, $A$ is irreducible and the
-    peripheral spectrum of $\E_A$ is $\{1\}$, so $A$ is aperiodic.
-    Theorem~\ref{thm:irred_tensor_aperiodic_normal} then gives normality,
-    hence eventually full Kraus rank.
+    $A$ is strongly irreducible, i.e.\ primitive in Wolf's sense.
+    Under normalization, Theorem~\ref{thm:wolf_6_8_conjunction}
+    therefore gives normality directly, hence eventual full Kraus rank.
 \end{proof}
 
 \begin{remark}[Normal canonical form avoids the aperiodicity step]\label{rem:d1_bypasses_aperiodicity}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -705,7 +705,9 @@ removing it as an independent assumption.
 \begin{proof}\leanok
 		\uses{thm:modulus_one_gauge, thm:psd_fp_exists,
 			thm:psd_fp_pd_irred, thm:right_canonical_gauge}
-		The argument is the same as in Theorem~\ref{thm:modulus_one_gauge},
+		The argument is the same as in Theorem~\ref{thm:modulus_one_gauge}
+		(with the gauging formula given by Theorem~\ref{thm:right_canonical_gauge}
+		directly),
 		but the fixed-point input comes from irreducibility rather than
 		injectivity.
 		Take a modulus-one eigenvector of the mixed transfer map.

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -155,7 +155,8 @@ gap---is the approach adopted in this chapter.
     \lean{MPSTensor.fundamentalTheorem_multiBlock_full}
     \leanok
     \uses{def:injective, def:gauge_equiv, def:tensor_from_blocks}
-    If all block tensors $A_k$ are injective and per-block
+    If all block tensors $A_k$ are injective, and $B_k$ are
+    block tensors of the same bond dimensions such that per-block
     same-MPV holds, then each pair $(A_k, B_k)$ is gauge
     equivalent, and the block-diagonal tensors
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -234,6 +234,12 @@ The main references are
 	gauge-phase equivalence.
 \end{proof}
 
+\begin{remark}
+	Theorem~\ref{thm:bnt_perm_simple} is retained for completeness but is
+	not used in the proofs given here; the proportional version
+	(Theorem~\ref{thm:bnt_perm_prop}) suffices for the Fundamental Theorem.
+\end{remark}
+
 \section{Coefficient convergence}
 
 \begin{theorem}[Coefficient ratio decay]\label{thm:coeff_ratio_decay}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -62,8 +62,11 @@ distinct weight norms).
     (Theorem~\ref{thm:ft_proportional_nt}).
     The normal canonical form data provide the BNT separation
     and overlap convergence hypotheses;
-    the non-degeneracy condition ensures the block matching
-    is well-defined.
+    the non-degeneracy condition (no two distinct blocks in the same
+    family are gauge-phase equivalent) ensures that the permutation
+    $\pi$ produced by Theorem~\ref{thm:ft_proportional_nt} is uniquely
+    determined, so that the per-block gauge equivalences can be
+    assembled consistently.
 \end{proof}
 
 \section{Proportional Fundamental Theorem}%
@@ -114,6 +117,7 @@ distinct weight norms).
 \end{proof}
 
 \begin{remark}[Coefficient arrays for canonical-form decompositions]
+	\label{rem:cf_coeff_arrays}
 	In applications the coefficient arrays in
 	Theorem~\ref{thm:ft_proportional} come from the block-diagonal
 	decomposition itself. If
@@ -200,17 +204,19 @@ distinct weight norms).
 \end{theorem}
 
 \begin{proof}
-	\uses{thm:ft_proportional, thm:mpv_decomposition, thm:power_sum_multiset}
+	\uses{thm:ft_proportional, thm:ft_equal_explicit, thm:mpv_decomposition}
 	Begin by applying Theorem~\ref{thm:ft_proportional} with $c_N = 1$,
 	which yields a
 	permutation of the matched blocks and blockwise gauge-phase equivalences.
 	One then compares the resulting MPV expansions from
-	Theorem~\ref{thm:mpv_decomposition}. In the general equal case the
-	weights occur with multiplicities, so recovering the individual weights
-	requires a power-sum argument such as
-	Theorem~\ref{thm:power_sum_multiset}. After the weights are identified,
-	the phase factors are absorbed into them and the blockwise conjugacies
-	combine to a global gauge equivalence.
+	Theorem~\ref{thm:mpv_decomposition}. The explicit-coefficient version
+	(Theorem~\ref{thm:ft_equal_explicit}) proves gauge equivalence of the
+	reindexed weighted block-diagonal tensors using BNT linear independence.
+	The remaining step combines this with the coefficient-array construction
+	of Remark~\ref{rem:cf_coeff_arrays} and the weight-recovery machinery
+	of \S\ref{sec:route_b}. After the weights are identified, the phase
+	factors are absorbed into them and the blockwise conjugacies combine to
+	a global gauge equivalence.
 \end{proof}
 
 \begin{theorem}[Fundamental Theorem --- equal MPV case with explicit coefficients]\label{thm:ft_equal_explicit}
@@ -286,6 +292,15 @@ distinct weight norms).
 	resulting blockwise conjugacies combine to give a gauge equivalence of the
 	reindexed weighted block-diagonal tensors.
 \end{proof}
+
+\begin{remark}
+	Theorem~\ref{thm:ft_equal_explicit} recovers
+	\textup{[CPGSV21, Corollary~IV.5]} for tensors in canonical form with
+	BNT separation, without assuming common block structure and without
+	Newton--Girard identities. The weight matching uses BNT linear
+	independence (Theorem~\ref{thm:cf_bnt_is_bnt} and
+	Definition~\ref{def:bnt}) directly.
+\end{remark}
 
 \begin{theorem}[Fundamental Theorem --- equal MPV case, common block structure]\label{thm:ft_equal_same_structure}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_CFBNT}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -295,7 +295,7 @@ distinct weight norms).
 
 \begin{remark}
 	Theorem~\ref{thm:ft_equal_explicit} recovers
-	\textup{[CPGSV21, Corollary~IV.5]} for tensors in canonical form with
+	\cite[Corollary~IV.5]{Cirac2021Matrix} for tensors in canonical form with
 	BNT separation, without assuming common block structure and without
 	Newton--Girard identities. The weight matching uses BNT linear
 	independence (Theorem~\ref{thm:cf_bnt_is_bnt} and


### PR DESCRIPTION
## Summary

Addresses reviewer comments from the v4 blueprint review (files in `blueprint/comments20260407/`) for chapters 10 through 14. All edits are proof-text and remark changes — no theorem statements are modified.

## Changes by chapter

### Chapter 10 — Wielandt Bound (`ch07_wielandt.tex`)
- **C10-I1**: Added remark after Thm 10.28 clarifying the quantitative bound ι(A) ≤ (D²−d'+1)·D² is cited from [SPGWC10], while the blueprint proves the qualitative result (Thm 10.40). The quantitative bound is not on the FT critical path.
- **C10-I2**: Replaced the unjustified "peripheral spectrum {1} hence aperiodicity" step in Thms 10.52 and 10.60 proofs with a direct citation to Wolf's primitivity equivalence (`thm:wolf_6_8_conjunction`). Rewrote Remark 10.53 to remove the self-contradiction (previously claimed the implication was "not used" while two theorems used it).

### Chapter 11 — Canonical Form Reduction (`ch08_canonical.tex`)
- **C11-I1**: Clarified Thm 11.32 proof takes the gauging formula from Thm 8.10 directly, avoiding the inherited exponent display bug from Thm 9.16.

### Chapter 12 — Block Permutation (`ch09_block_perm.tex`)
- **10-L2**: Made $B_k$ explicit in Thm 12.8's statement for readability.

### Chapter 13 — Basis of Normal Tensors (`ch10_bnt.tex`)
- **C13-I2**: Added remark that Thm 13.9 is retained for completeness but unused in the current proof chain (the proportional version Thm 13.7 suffices for the FT).
- **C13-I1**: Verified the conjugation bar is already correct in Thm 13.5's proof — no edit needed.

### Chapter 14 — Proof of the Fundamental Theorem (`ch11_assembly.tex`)
- **C14-I1**: Rewrote Thm 14.5 proof sketch to remove the incorrect multiplicity claim; now references Thm 14.6's BNT-LI argument and the weight-recovery machinery.
- **C14-I4**: Added literature-recovery remark after Thm 14.6 explicitly stating it recovers [CPGSV21, Corollary IV.5] without Newton–Girard identities.
- **C14-I5**: Expanded Thm 14.1 proof text to explain exactly what the non-degeneracy hypothesis does (ensures uniqueness of the permutation π).

## Lean docstring updates

Updated two Lean docstrings to match the blueprint's C10-I2 aperiodicity fix:
- `QuantumWielandt.lean`: `isNormal_of_isPrimitiveMPS_of_posDef` — removed stale reference to "hence aperiodicity"; now says the proof uses `wolf_theorem_6_8_conjunction` directly.
- `ImpliesStronglyIrreducibleAux.lean`: `isStronglyIrreduciblePaper_of_isPrimitivePaper` — removed claim that "aperiodicity" is "used by the irreducibility-to-normality endpoint"; now says Prop 3(c)→(b) yields normality directly without aperiodicity.

These are doc-only Lean changes — no proof terms modified.

## What is NOT changed
- No theorem statements modified (blueprint or Lean)
- No Lean proof terms modified
- C14-I2 (AI language in §14.1), C14-I6 (§14.4.2 title), C14-I7 (§14.4.5 wording): verified these phrases are already resolved in the current source
- C11-I2 (`thm:normal_from_primitive`): declaration-only in ch08_canonical.tex, no proof text to edit
- C14-I8 (strictly-decreasing-moduli architectural issue): documented in review, requires separate design discussion

## Review files
- `blueprint/comments20260407/blueprint_chapter10_v4_review.md`
- `blueprint/comments20260407/blueprint_chapter11_v4_review.md`
- `blueprint/comments20260407/blueprint_chapter12_v4_review.md`
- `blueprint/comments20260407/blueprint_chapter13_v4_review.md`
- `blueprint/comments20260407/blueprint_chapter14_v4_review.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/proof-text edits and a few blueprint remark/wording clarifications; no Lean proof terms or theorem statements change.
> 
> **Overview**
> Updates the blueprint writeup to address review comments, mainly by **removing an unsupported “peripheral spectrum ⇒ aperiodicity” step** and instead citing Wolf’s primitivity equivalence (`thm:wolf_6_8_conjunction`) to derive normality/eventual full Kraus rank directly.
> 
> Adds/adjusts explanatory remarks and proof text for clarity (e.g., quantitative vs qualitative Wielandt bounds, explicit gauging reference, non-degeneracy/permutation uniqueness, and equal-MPV proof sketch cleanup), plus minor statement readability tweaks. Corresponding Lean changes are **docstring-only** updates in `ImpliesStronglyIrreducibleAux.lean` and `QuantumWielandt.lean` to match the revised proof route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4b7c9f82fe41431170641c8111f0bf6f25afc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->