### PR TITLE
feat(TNLean): close Wedderburn, unique-ground-state, and dichotomy sorrys

### DIFF
--- a/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
+++ b/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
@@ -214,13 +214,111 @@ structure IsWedderburnBlockDecomp
 /-- Every finite-dimensional `*`-subalgebra of `M_D(ℂ)` admits a Wedderburn
 block decomposition (Wolf Eq. 1.39).
 
-**Status**: sorry — requires bridging abstract Wedderburn--Artin to concrete
-block-diagonal embedding. See `fixedPointAlgebra_wedderburnArtin` for the
-abstract version. -/
+The current `IsWedderburnBlockDecomp` structure records the abstract
+Wedderburn--Artin product decomposition, multiplicities set to `1`, and the
+ambient dimension bound. The unitary block-diagonal intertwiner is still
+deferred in the structure TODO above. -/
 theorem starSubalgebra_hasWedderburnBlockDecomp
     (S : StarSubalgebra ℂ Mat) :
-    Nonempty (IsWedderburnBlockDecomp S) :=
-  sorry
+    Nonempty (IsWedderburnBlockDecomp S) := by
+  classical
+  letI : IsSemisimpleRing S := starSubalgebra_isSemisimpleRing S
+  letI : FiniteDimensional ℂ S :=
+    FiniteDimensional.finiteDimensional_subalgebra S.toSubalgebra
+  rcases IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed ℂ S with
+    ⟨n, blockDim, hblockDim, ⟨e⟩⟩
+  refine ⟨
+    { numBlocks := n
+      blockDim := blockDim
+      multDim := fun _ => 1
+      blockDim_pos := fun i => Nat.pos_of_neZero (blockDim i)
+      multDim_pos := fun _ => by norm_num
+      dim_le := ?_
+      algEquiv := e }⟩
+  let V := Fin D → ℂ
+  let φ : S →ₐ[ℂ] Module.End ℂ V :=
+    (Matrix.toLinAlgEquiv' :
+      Mat ≃ₐ[ℂ] Module.End ℂ V).toAlgHom.comp S.subtype.toAlgHom
+  let ι := Sigma fun i : Fin n => Fin (blockDim i)
+  let diagUnit (a : ι) : Π i : Fin n,
+      Matrix (Fin (blockDim i)) (Fin (blockDim i)) ℂ :=
+    Pi.single a.1 (Matrix.single a.2 a.2 (1 : ℂ))
+  let q (a : ι) : S := e.symm (diagUnit a)
+  have hq_mul_self (a : ι) : q a * q a = q a := by
+    rcases a with ⟨j, a⟩
+    apply e.injective
+    ext i r c
+    by_cases hij : i = j
+    · subst i
+      simp [q, diagUnit]
+    · simp [q, diagUnit, Pi.single_eq_of_ne hij]
+  have hq_mul_zero (a b : ι) (hab : a ≠ b) : q a * q b = 0 := by
+    rcases a with ⟨ia, a⟩
+    rcases b with ⟨ib, b⟩
+    apply e.injective
+    ext i r c
+    by_cases hiia : i = ia
+    · subst i
+      by_cases hiaib : ia = ib
+      · subst ib
+        have hab' : a ≠ b := by
+          intro h
+          exact hab (by cases h; rfl)
+        simp [q, diagUnit, hab']
+      · simp [q, diagUnit, hiaib]
+    · simp [q, diagUnit, Pi.single_eq_of_ne hiia]
+  have hq_ne_zero (a : ι) : q a ≠ 0 := by
+    intro hq0
+    have hdiag0 : diagUnit a = 0 := by
+      calc
+        diagUnit a = e (q a) := by simp [q]
+        _ = e 0 := by rw [hq0]
+        _ = 0 := by simp
+    rcases a with ⟨i, a⟩
+    have hentry : diagUnit ⟨i, a⟩ i a a = 1 := by
+      simp [diagUnit]
+    rw [hdiag0] at hentry
+    simp at hentry
+  have hφ_inj : Function.Injective φ := by
+    intro x y h
+    apply Subtype.ext
+    apply (Matrix.toLinAlgEquiv' : Mat ≃ₐ[ℂ] Module.End ℂ V).injective
+    exact h
+  have hφq_ne_zero (a : ι) : φ (q a) ≠ 0 := fun h =>
+    hq_ne_zero a (hφ_inj (by simpa using h))
+  have hφq_exists (a : ι) : ∃ w : V, φ (q a) w ≠ 0 := by
+    by_contra h
+    push Not at h
+    exact hφq_ne_zero a (LinearMap.ext h)
+  choose w hw using hφq_exists
+  let v (a : ι) : V := φ (q a) (w a)
+  have hv_ne_zero (a : ι) : v a ≠ 0 := by
+    simpa [v] using hw a
+  have hφ_v_self (a : ι) : φ (q a) (v a) = v a := by
+    simp [v, ← Module.End.mul_apply, ← map_mul, hq_mul_self]
+  have hφ_v_zero (a b : ι) (hab : a ≠ b) : φ (q a) (v b) = 0 := by
+    simp [v, ← Module.End.mul_apply, ← map_mul, hq_mul_zero a b hab]
+  have hv_li : LinearIndependent ℂ v := by
+    rw [Fintype.linearIndependent_iff]
+    intro g hg a
+    have happ : φ (q a) (∑ b, g b • v b) = 0 := by
+      rw [hg]
+      simp
+    have happ' : (∑ b, g b • φ (q a) (v b)) = 0 := by
+      simpa [map_sum] using happ
+    have hsum : (∑ b, g b • φ (q a) (v b)) = g a • v a := by
+      rw [Finset.sum_eq_single a]
+      · simp [hφ_v_self]
+      · intro b _ hb
+        simp [hφ_v_zero a b hb.symm]
+      · intro ha
+        exact (ha (Finset.mem_univ a)).elim
+    have hga : g a • v a = 0 := by
+      rw [← hsum, happ']
+    exact (smul_eq_zero.mp hga).resolve_right (hv_ne_zero a)
+  have hcard_le : Fintype.card ι ≤ Module.finrank ℂ V :=
+    hv_li.fintype_card_le_finrank
+  simpa [ι, V] using hcard_le
 
 /-- **Wolf Theorem 6.14** (Heisenberg picture, abstract form).
 
@@ -230,8 +328,7 @@ Wedderburn block decomposition.
 Combined with `fixedPointAlgebra_wedderburnArtin`, this gives:
 `Fix(T*) ≅ ⊕_k M_{d_k}(ℂ)` (abstract) and `Fix(T*) = U(⊕_k M_{d_k} ⊗ 1_{m_k})U†`
 (concrete).
-
-**Status**: sorry — follows from `starSubalgebra_hasWedderburnBlockDecomp`. -/
+-/
 theorem adjointFixedPoints_wedderburnDecomp
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat}
     (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) :

--- a/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
+++ b/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
@@ -231,7 +231,7 @@ theorem starSubalgebra_hasWedderburnBlockDecomp
     { numBlocks := n
       blockDim := blockDim
       multDim := fun _ => 1
-      blockDim_pos := fun i => Nat.pos_of_neZero (blockDim i)
+      blockDim_pos := fun i => haveI := hblockDim i; Nat.pos_of_neZero (blockDim i)
       multDim_pos := fun _ => by norm_num
       dim_le := ?_
       algEquiv := e }⟩

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -685,7 +685,29 @@ theorem periodicOverlapDichotomy
       --   • Some match → sectorMatch_propagation (using hA.leftCanonical,
       --     hB.leftCanonical for unit-modulus phases), then
       --     sectorTensor_proportional_of_blockedMatch → RepeatedBlocks
-      sorry
+      haveI : NeZero m_a := NeZero.of_pos hA.period_pos
+      obtain ⟨dimA, blocksA, hA_blocks_lc, hA_mpv, hA_cyclic⟩ :=
+        exists_cyclic_sector_decomp_after_blocking_of_isPeriodic A hA
+      obtain ⟨dimB, blocksB, hB_blocks_lc, hB_mpv, hB_cyclic⟩ :=
+        exists_cyclic_sector_decomp_after_blocking_of_isPeriodic B hB
+      by_cases hSomeMatch :
+          ∃ (u₀ v₀ : Fin m_a) (hdim : dimA u₀ = dimB v₀),
+            dimA u₀ ≠ 0 ∧ GaugePhaseEquiv
+              (cast (congr_arg
+                (MPSTensor (blockPhysDim d m_a)) hdim)
+                (blocksA u₀))
+              (blocksB v₀)
+      · refine Or.inr ⟨rfl, ?_⟩
+        simpa using
+          periodicOverlap_gaugeEquiv_of_sector_match A B hA hB
+            blocksA blocksB hA_blocks_lc hB_blocks_lc
+            hA_mpv hB_mpv hA_cyclic hB_cyclic hSomeMatch
+      · refine Or.inl ?_
+        refine periodicOverlap_tendsto_zero_of_no_sector_match A B hA hB
+          blocksA blocksB hA_blocks_lc hB_blocks_lc
+          hA_mpv hB_mpv hA_cyclic hB_cyclic ?_
+        intro u v hdim hNonzero hGauge
+        exact hSomeMatch ⟨u, v, hdim, hNonzero, hGauge⟩
 
 /-- **Eventual linear independence** (Corollary of Proposition 3.3):
 Given a family of periodic tensors `{A_j}` whose periods all divide a common

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -414,18 +414,15 @@ If `A` is normal and `L₀`-block-injective with `L₀ > 0`, the interaction ran
 can be reduced from `2L₀` to `L₀ + 1`. The chain ground space with window
 `L₀ + 1` on `N ≥ L₀ + 1` sites has a unique ground state.
 
-**Proof sketch**: Rewrite via `chainGroundSpace_eq_mpvSubmodule_normal` (sorry'd),
-then use `mpv_ne_zero_of_isNBlkInjective` to show the MPV submodule is 1D. -/
--- TODO(parent-hamiltonian): remove sorry once `chainGroundSpace_eq_mpvSubmodule_normal`
--- is proved. The reduction is:
---   rw [HasUniqueGroundState,
---     chainGroundSpace_eq_mpvSubmodule_normal hA hInj (by omega) (by omega) hN]
---   have hmpv := mpv_ne_zero_of_isNBlkInjective hInj hL₀ hN
---   simpa [mpvSubmodule] using finrank_span_singleton (K := ℂ) hmpv
+The proof rewrites via `chainGroundSpace_eq_mpvSubmodule_normal`, then uses
+`mpv_ne_zero_of_isNBlkInjective` to show the MPV submodule is 1D. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :
     HasUniqueGroundState (chainGroundSpace A (L₀ + 1) N) := by
-  sorry
+  rw [HasUniqueGroundState,
+    chainGroundSpace_eq_mpvSubmodule_normal hA hInj (by omega) (by omega) hN]
+  have hmpv := mpv_ne_zero_of_isNBlkInjective hInj hL₀ hN
+  simpa [mpvSubmodule] using finrank_span_singleton (K := ℂ) hmpv
 
 end MPSTensor

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -979,11 +979,17 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
 \begin{theorem}[Fixed-point algebra admits Wedderburn block decomposition]%
     \label{thm:adjointFixedPoints_wedderburnDecomp}
     \lean{Kraus.adjointFixedPoints_wedderburnDecomp}
-    \notready
+    \leanok
     \uses{thm:fixedPointAlgebra_wedderburnArtin}
     The adjoint-fixed-point $*$-subalgebra admits a concrete Wedderburn
     block decomposition inside the ambient matrix algebra (Wolf Eq.~1.39).
 \end{theorem}
+\begin{proof}
+    \leanok
+    Follows immediately from the general result that every
+    $*$-subalgebra of $M_D(\mathbb{C})$ admits a Wedderburn block
+    decomposition, applied to the adjoint-fixed-point algebra.
+\end{proof}
 
 \section{Additional Wolf Chapter~6 equivalences}
 

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -979,13 +979,13 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
 \begin{theorem}[Fixed-point algebra admits Wedderburn block decomposition]%
     \label{thm:adjointFixedPoints_wedderburnDecomp}
     \lean{Kraus.adjointFixedPoints_wedderburnDecomp}
-    \leanok
+    \notready
     \uses{thm:fixedPointAlgebra_wedderburnArtin}
     The adjoint-fixed-point $*$-subalgebra admits a concrete Wedderburn
     block decomposition inside the ambient matrix algebra (Wolf Eq.~1.39).
 \end{theorem}
 \begin{proof}
-    \leanok
+    \notready
     Follows immediately from the general result that every
     $*$-subalgebra of $M_D(\mathbb{C})$ admits a Wedderburn block
     decomposition, applied to the adjoint-fixed-point algebra.


### PR DESCRIPTION
## Motivation
Closes sorrys in three files, reducing the total sorry count.

## Changes

### 1. `starSubalgebra_hasWedderburnBlockDecomp` (WedderburnDecomp.lean)
**Closes the last sorry in WedderburnDecomp.lean** (Issue LionSR/QICLean#126).

Uses Mathlib's abstract Wedderburn-Artin theorem (`IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`) for finite-dimensional semisimple algebras over ℂ. Builds the `IsWedderburnBlockDecomp` witness with multiplicities 1 and proves the ambient dimension bound `∑ blockDim i ≤ D` via linear independence of diagonal matrix unit images in `ℂ^D`.

This also closes `adjointFixedPoints_wedderburnDecomp` which was a direct corollary.

### 2. `parentHamiltonian_unique_gs_normal` (UniqueGroundState.lean)
**Closes 1 sorry** (Issue LionSR/TNLean#460).

Follows the proof sketch in the comments: rewrite via `chainGroundSpace_eq_mpvSubmodule_normal`, then use `mpv_ne_zero_of_isNBlkInjective` + `finrank_span_singleton`.

Note: this theorem depends on the still-sorry'd `chainGroundSpace_eq_mpvSubmodule_normal`, so the Lean warning persists.

### 3. `periodicOverlapDichotomy` (PeriodicOverlap.lean)
**Closes 1 sorry in the main dichotomy theorem** (Issue LionSR/TNLean#81, Proposition 3.3 of arXiv:1708.00029).

Wiring proof: extract cyclic sector decompositions for both tensors, case-split on sector matching using classical decidability, and dispatch to the helper lemmas. The helpers themselves are still sorry'd.

## Verification
All three files compile:
```
lake env lean TNLean/Channel/FixedPoint/WedderburnDecomp.lean  # ✓
lake env lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean  # ✓
lake env lean TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean  # ✓
```

## Sorry impact
- WedderburnDecomp.lean: 1 → 0 sorrys (file sorry-free!)
- UniqueGroundState.lean: 2 → 1 sorry
- PeriodicOverlap.lean: 7 → 6 sorrys

Partially addresses LionSR/TNLean#81, LionSR/QICLean#126, LionSR/TNLean#460.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: this replaces `sorry` placeholders with nontrivial Lean proof terms and classical case splits, which may be brittle to future Mathlib/API changes despite not affecting runtime behavior.
> 
> **Overview**
> Eliminates several major `sorry`s by providing concrete Lean proofs/wiring in three theorem-heavy areas.
> 
> In `WedderburnDecomp.lean`, `starSubalgebra_hasWedderburnBlockDecomp` is fully proved using Mathlib’s semisimple Wedderburn–Artin `algEquiv`, fixes multiplicities to `1`, and derives the ambient dimension bound via a linear-independence argument; `adjointFixedPoints_wedderburnDecomp` becomes an immediate corollary.
> 
> In `UniqueGroundState.lean`, `parentHamiltonian_unique_gs_normal` is implemented by rewriting the chain ground space to the MPV span and concluding 1D via `mpv_ne_zero_of_isNBlkInjective`.
> 
> In `PeriodicOverlap.lean`, the final “same period & same bond dimension” branch of `periodicOverlapDichotomy` is wired up by extracting cyclic-sector decompositions, splitting on existence of a matching sector, and dispatching to the existing helper lemmas. The blueprint adds a brief (still `\notready`) proof explanation for the Wedderburn decomposition theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd2e4713dadccb0076bfb514596a2401a6ba367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->