### PR TITLE
refactor(1708.00029): enrich IsCyclicSectorDecomp with cyclic shift

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -863,6 +863,7 @@ theorem exists_cyclic_sector_decomp_after_blocking
       SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) ∧
       (∀ k, IsOrthogonalProjection (P k)) ∧
       (∑ k : Fin m, P k = 1) ∧
+      (∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) ∧
       (∀ k (i : Fin (blockPhysDim d m)),
         P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
       (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
@@ -899,7 +900,7 @@ theorem exists_cyclic_sector_decomp_after_blocking
     intro k i
     exact commutes_letters_of_adjoint_fixed_projection
       (blockTensor A m) hTP_blocked (hP := hPproj k) (hFix := hFix k) i
-  exact ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hComm, hTrace⟩
+  exact ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace⟩
 
 end CyclicSectorBridge
 
@@ -952,7 +953,7 @@ theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
     rw [hperiph_set]; ext x; simp [Set.mem_range, eq_comm]
   -- Apply exists_cyclic_sector_decomp_after_blocking.
   haveI : NeZero m := ⟨by omega⟩
-  obtain ⟨dim, blocks, _, hTP_blocks, hSame, _, _, _, _⟩ :=
+  obtain ⟨dim, blocks, _, hTP_blocks, hSame, _, _, _, _, _⟩ :=
     exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim
       hperiph_range
   exact ⟨m, hm_pos, dim, blocks, hTP_blocks, hSame⟩

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -843,6 +843,7 @@ For an irreducible TP tensor `A` of period `m`, after blocking by `m`, the block
 spectral projections. Returns:
 - `blocks k`: TP sector tensors (each left-canonical),
 - `P k`: orthogonal projections forming a partition of unity (`∑ P k = 1`),
+- cyclic shift: `transferMap (fun i => (A i)ᴴ) (P (k+1)) = P k`,
 - commutation: each `P k` commutes with every blocked letter,
 - trace relation: `mpv (blocks k) σ = (P k * evalWord (blockTensor A m) σ).trace`,
 - MPV equivalence: the direct-sum tensor is `SameMPV₂`-equivalent to the blocked tensor. -/

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -104,6 +104,7 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
   ∃ (P : Fin m → Matrix (Fin D) (Fin D) ℂ),
     (∀ k, IsOrthogonalProjection (P k)) ∧
     (∑ k : Fin m, P k = 1) ∧
+    (∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) ∧
     (∀ k (i : Fin (blockPhysDim d m)),
       P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
     (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
@@ -190,10 +191,10 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
           _ = (ω ^ m) ^ (j : ℕ) := by rw [pow_mul]
           _ = 1 := by simp [hωprim.pow_eq_one]
       simpa [hperiph_roots] using hpow
-  obtain ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hComm, hTrace⟩ :=
+  obtain ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hCyclic, hComm, hTrace⟩ :=
     exists_cyclic_sector_decomp_after_blocking
       A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
-  exact ⟨dim, blocks, hLC, hMPV, P, hPproj, hPsum, hComm, hTrace⟩
+  exact ⟨dim, blocks, hLC, hMPV, P, hPproj, hPsum, hCyclic, hComm, hTrace⟩
 
 /-! ## Self-overlap (first paragraph of Appendix A) -/
 

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -692,7 +692,8 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	$(C_k)_{k=0}^{m-1}$ on corner bond spaces forms a \emph{cyclic sector
 	decomposition} of the blocked tensor $A^{(m)}$ if there exist orthogonal
 	projections $P_0,\dotsc,P_{m-1}$ on the ambient bond space such that
-	$\sum_k P_k = \Id$, each $P_k$ commutes with every blocked letter
+	$\sum_k P_k = \Id$, the projections satisfy the cyclic-shift relation
+	$E^\dagger(P_{k+1}) = P_k$, each $P_k$ commutes with every blocked letter
 	$P_k A^{(m)}_i = A^{(m)}_i P_k$, and
 	$V^{(N)}(C_k)_\sigma = \tr(P_k (A^{(m)})^\sigma)$ for every word~$\sigma$.
 \end{definition}


### PR DESCRIPTION
## Motivation
Prerequisite for closing the remaining 6 sorrys in PeriodicOverlap.lean (Gemma paper, Proposition 3.3).

Multiple codex agents independently identified that `IsCyclicSectorDecomp` was missing the cyclic shift relation `E†(P(k+1)) = P(k)`, which is needed for:
- Sector normality proof (`sectorBlocked_isNormal_of_isPeriodic`)
- Sector match propagation (`sectorMatch_propagation`)
- Self-overlap limit (`periodicSelfOverlap_tendsto`)

## Changes
- **Assembly.lean**: `exists_cyclic_sector_decomp_after_blocking` now returns the cyclic shift relation, threaded from the `hcyclic` witness of `exists_cyclic_decomposition_of_irreducible_schwarz`.
- **PeriodicOverlap.lean**: `IsCyclicSectorDecomp` includes the cyclic-shift field. `exists_cyclic_sector_decomp_after_blocking_of_isPeriodic` passes it through.
- **Assembly.lean**: `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` updated to destructure the extra field.

## Verification
```
lake env lean TNLean/MPS/CanonicalForm/Assembly.lean  # ✓
lake env lean TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean  # ✓
```

No new sorrys. All existing sorry warnings unchanged.

## Next steps (documented)
The cyclic shift is necessary but not sufficient for sector normality. The remaining bridge is: **identifying the compressed sector transfer map with the ambient cyclic corner restriction**. Specifically, we need:
1. `IsIrreducibleOnCorner P_u ((E†)^m)` — sector irreducibility via orbit-sum lift (`SectorIrreducibility.lean` has the sublemmas)
2. Transport from corner irreducibility to `IsIrreducibleTensor (blocks u)`
3. `IsPrimitive (transferMap (blocks u))` — sector primitivity

Partially addresses #81, #448, #450.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the statement/return tuple of core decomposition theorems and `IsCyclicSectorDecomp`, requiring downstream proof updates; logic is mostly threading an existing `hcyclic` witness so behavioral risk is limited to interface breakage/proof soundness.
> 
> **Overview**
> **Enriches cyclic sector decomposition statements with the missing cyclic-shift property** `E†(P (k+1)) = P k`.
> 
> `exists_cyclic_sector_decomp_after_blocking` (in `Assembly.lean`) now returns this shift relation (threaded from `exists_cyclic_decomposition_of_irreducible_schwarz`), and callers are updated to destructure/pass the extra field. `PeriodicOverlap.lean` similarly extends `IsCyclicSectorDecomp` with the shift law and propagates it through `exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`. The blueprint definition in `ch11_assembly.tex` is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28af7b82171d161f9aa9bfd4332c88cd29eea3d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->