### PR TITLE
feat(MPS/FundamentalTheorem): periodic overlap dichotomy (1708.00029 3/5)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -846,7 +846,8 @@ spectral projections. Returns:
 - cyclic shift: `transferMap (fun i => (A i)ᴴ) (P (k+1)) = P k`,
 - commutation: each `P k` commutes with every blocked letter,
 - trace relation: `mpv (blocks k) σ = (P k * evalWord (blockTensor A m) σ).trace`,
-- MPV equivalence: the direct-sum tensor is `SameMPV₂`-equivalent to the blocked tensor. -/
+- MPV equivalence: the direct-sum tensor is `SameMPV₂`-equivalent to the blocked tensor,
+- nondegeneracy: every sector dimension is positive (`∀ k, dim k ≠ 0`). -/
 theorem exists_cyclic_sector_decomp_after_blocking
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -868,7 +868,8 @@ theorem exists_cyclic_sector_decomp_after_blocking
       (∀ k (i : Fin (blockPhysDim d m)),
         P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
       (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
-        mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace) := by
+        mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace) ∧
+      (∀ k, dim k ≠ 0) := by
   -- Step 1: Get cyclic decomposition data
   let K : Fin d → MatrixAlg D := fun i => (A i)ᴴ
   have hUnital : IsUnitalKraus (d := d) (D := D) K := by
@@ -901,7 +902,48 @@ theorem exists_cyclic_sector_decomp_after_blocking
     intro k i
     exact commutes_letters_of_adjoint_fixed_projection
       (blockTensor A m) hTP_blocked (hP := hPproj k) (hFix := hFix k) i
-  exact ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace⟩
+  -- Step 7: Nondegeneracy — all projections are nonzero, hence all sector dimensions > 0
+  have hNondeg : ∀ k, dim k ≠ 0 := by
+    -- First: all projections are nonzero (cyclic propagation from hcyclic + hPsum)
+    have hPne : ∀ k, P k ≠ 0 := by
+      by_contra! h
+      obtain ⟨k₀, hk₀⟩ := h
+      -- If P(j+1) = 0 then P(j) = E†(P(j+1)) = E†(0) = 0
+      have hback : ∀ j : Fin m, P (j + 1) = 0 → P j = 0 := fun j hj => by
+        rw [show P j = transferMap K (P (j + 1)) from (hcyclic j).symm, hj, map_zero]
+      -- Every j is zero: induct on backward distance (k₀ - j).val
+      have hall : ∀ j : Fin m, P j = 0 := by
+        suffices hs : ∀ n : ℕ, n < m → ∀ j : Fin m,
+            (k₀ - j).val = n → P j = 0 by
+          intro j; exact hs _ (k₀ - j).isLt j rfl
+        intro n
+        induction n with
+        | zero =>
+          intro _ j hj
+          have : k₀ - j = 0 := by
+            ext; simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod,
+              Fin.val_eq_zero_iff] at hj ⊢; exact hj
+          have : k₀ = j := sub_eq_zero.mp this
+          subst this; exact hk₀
+        | succ n ih =>
+          intro hd j hj
+          apply hback j
+          apply ih (by omega) (j + 1)
+          have h_eq : k₀ - (j + 1) = (k₀ - j) - 1 := by abel
+          rw [h_eq, Fin.val_sub_one_of_ne_zero (by intro h; simp [h] at hj)]
+          omega
+      -- Contradiction: ∑ P_k = 0 ≠ 1
+      exact absurd (show (∑ k, P k) = 0 from Finset.sum_eq_zero (fun k _ => hall k))
+        (by rw [hPsum]; exact one_ne_zero)
+    -- Second: dim k ≠ 0 follows from P k ≠ 0 via the trace relation
+    intro k hk
+    apply hPne k
+    have h0 := hTrace k 0 Fin.elim0
+    simp only [mpv, coeff, List.ofFn_zero, evalWord_nil, Matrix.mul_one] at h0
+    have htrace_zero : (P k).trace = 0 := by
+      rw [← h0, Matrix.trace_one, Fintype.card_fin, hk, Nat.cast_zero]
+    exact (isOrthogonalProjection_posSemidef (hPproj k)).trace_eq_zero_iff.mp htrace_zero
+  exact ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace, hNondeg⟩
 
 end CyclicSectorBridge
 

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -116,7 +116,8 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
       (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
       SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) ∧
-      IsCyclicSectorDecomp A blocks := by
+      IsCyclicSectorDecomp A blocks ∧
+      (∀ k, dim k ≠ 0) := by
   obtain ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
     conjTranspose_kraus_setup A hP.leftCanonical hP.irreducible
   obtain ⟨ω, hωprim⟩ := hP.primitiveRoot
@@ -191,10 +192,10 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
           _ = (ω ^ m) ^ (j : ℕ) := by rw [pow_mul]
           _ = 1 := by simp [hωprim.pow_eq_one]
       simpa [hperiph_roots] using hpow
-  obtain ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hCyclic, hComm, hTrace⟩ :=
+  obtain ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hCyclic, hComm, hTrace, hNondeg⟩ :=
     exists_cyclic_sector_decomp_after_blocking
       A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
-  exact ⟨dim, blocks, hLC, hMPV, P, hPproj, hPsum, hCyclic, hComm, hTrace⟩
+  exact ⟨dim, blocks, hLC, hMPV, ⟨P, hPproj, hPsum, hCyclic, hComm, hTrace⟩, hNondeg⟩
 
 /-! ## Self-overlap (first paragraph of Appendix A) -/
 
@@ -621,6 +622,7 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
     (hA_cyclic : IsCyclicSectorDecomp A blocksA)
     (hB_cyclic : IsCyclicSectorDecomp B blocksB)
+    (hNondegA : ∀ u, dimA u ≠ 0)
     (hSomeMatch : ∃ (u₀ v₀ : Fin m) (hdim : dimA u₀ = dimB v₀),
       dimA u₀ ≠ 0 ∧ GaugePhaseEquiv
         (cast (congr_arg
@@ -628,9 +630,34 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
           (blocksA u₀))
         (blocksB v₀)) :
     RepeatedBlocks A B := by
-  -- Use translation propagation to get matching for all sectors,
-  -- then apply per-site proportionality extraction.
-  sorry
+  -- Step 1: Extract the matching witness
+  obtain ⟨u₀, v₀, hdim₀, hNondeg₀, hGPE₀⟩ := hSomeMatch
+  -- Step 2: Translation propagation (#4) → matching for all offsets
+  have hPropag := sectorMatch_propagation A B hA.leftCanonical hB.leftCanonical
+    blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
+    hA_cyclic hB_cyclic hdim₀ hNondeg₀ hGPE₀
+  -- Step 3: Reindex with q = v₀ - u₀ to get matching for all sector pairs
+  set q : Fin m := v₀ - u₀ with q_def
+  have hBlockMatch : ∀ u : Fin m,
+      ∃ (hdim : dimA u = dimB (u + q)),
+        GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim)
+            (blocksA u))
+          (blocksB (u + q)) := by
+    intro u
+    have hl := hPropag (u - u₀)
+    have h1 : u₀ + (u - u₀) = u := by abel
+    have h2 : v₀ + (u - u₀) = u + q := by rw [q_def]; abel
+    rw [h1, h2] at hl
+    exact hl
+  -- Step 4: Normality for all sectors from #2
+  have hNormal : ∀ u, IsNormal (blocksA u) :=
+    fun u => sectorBlocked_isNormal_of_isPeriodic A hA blocksA
+      hA_blocks_lc hA_mpv hA_cyclic u (hNondegA u)
+  -- Step 5: Per-site proportionality extraction (#5) → RepeatedBlocks
+  exact sectorTensor_proportional_of_blockedMatch A B hA.leftCanonical hB.leftCanonical
+    blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
+    hA_cyclic hB_cyclic q hBlockMatch hNondegA hNormal
 
 /-- When `D₁ ≠ D₂`, no `RepeatedBlocks` relation can hold (the types don't
 match), so the overlap must decay. This covers the `D₁ ≠ D₂` subcase of
@@ -679,36 +706,28 @@ theorem periodicOverlapDichotomy
     case pos =>
       subst hdim
       -- Same period, same bond dimension.
-      -- Extract compressed cyclic-sector blocks from IsPeriodic
-      -- (via exists_cyclic_sector_decomp_after_blocking_of_isPeriodic).
-      -- Case split on whether any compressed sector pair matches:
-      --   • No match → periodicOverlap_tendsto_zero_of_no_sector_match
-      --   • Some match → sectorMatch_propagation (using hA.leftCanonical,
-      --     hB.leftCanonical for unit-modulus phases), then
-      --     sectorTensor_proportional_of_blockedMatch → RepeatedBlocks
-      haveI : NeZero m_a := NeZero.of_pos hA.period_pos
-      obtain ⟨dimA, blocksA, hA_blocks_lc, hA_mpv, hA_cyclic⟩ :=
+      haveI : NeZero m_a := ⟨Nat.pos_iff_ne_zero.mp hA.period_pos⟩
+      -- Extract compressed cyclic-sector blocks from IsPeriodic.
+      obtain ⟨dimA, blocksA, hA_blocks_lc, hA_mpv, hA_cyclic, hA_nondeg⟩ :=
         exists_cyclic_sector_decomp_after_blocking_of_isPeriodic A hA
-      obtain ⟨dimB, blocksB, hB_blocks_lc, hB_mpv, hB_cyclic⟩ :=
+      obtain ⟨dimB, blocksB, hB_blocks_lc, hB_mpv, hB_cyclic, _⟩ :=
         exists_cyclic_sector_decomp_after_blocking_of_isPeriodic B hB
-      by_cases hSomeMatch :
-          ∃ (u₀ v₀ : Fin m_a) (hdim : dimA u₀ = dimB v₀),
-            dimA u₀ ≠ 0 ∧ GaugePhaseEquiv
-              (cast (congr_arg
-                (MPSTensor (blockPhysDim d m_a)) hdim)
-                (blocksA u₀))
-              (blocksB v₀)
-      · refine Or.inr ⟨rfl, ?_⟩
-        simpa using
+      -- Case split on whether any compressed sector pair matches.
+      by_cases hMatch : ∃ (u₀ v₀ : Fin m_a) (hdim : dimA u₀ = dimB v₀),
+          dimA u₀ ≠ 0 ∧ GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor (blockPhysDim d m_a)) hdim)
+              (blocksA u₀))
+            (blocksB v₀)
+      · -- Some match → gauge-equivalent (Case 3).
+        exact Or.inr ⟨rfl,
           periodicOverlap_gaugeEquiv_of_sector_match A B hA hB
-            blocksA blocksB hA_blocks_lc hB_blocks_lc
-            hA_mpv hB_mpv hA_cyclic hB_cyclic hSomeMatch
-      · refine Or.inl ?_
-        refine periodicOverlap_tendsto_zero_of_no_sector_match A B hA hB
-          blocksA blocksB hA_blocks_lc hB_blocks_lc
-          hA_mpv hB_mpv hA_cyclic hB_cyclic ?_
-        intro u v hdim hNonzero hGauge
-        exact hSomeMatch ⟨u, v, hdim, hNonzero, hGauge⟩
+            blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
+            hA_cyclic hB_cyclic hA_nondeg hMatch⟩
+      · -- No match → orthogonal (Case 2).
+        push Not at hMatch
+        exact Or.inl (periodicOverlap_tendsto_zero_of_no_sector_match A B hA hB
+          blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
+          hA_cyclic hB_cyclic hMatch)
 
 /-- **Eventual linear independence** (Corollary of Proposition 3.3):
 Given a family of periodic tensors `{A_j}` whose periods all divide a common

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -595,8 +595,9 @@ structure via `IsCyclicSectorDecomp`. Global nondegeneracy
 (`hNondegA : ∀ u, dimA u ≠ 0`) ensures every sector of `A` has
 positive bond dimension, which is needed for normality of each sector
 tensor. The `hSomeMatch` witness provides a single matching sector pair
-`(u₀, v₀)` with compatible dimensions, from which translation
-propagation extends the match to all sectors.
+`(u₀, v₀)` with compatible dimensions (the nondegeneracy of `dimA u₀`
+follows from `hNondegA`), from which translation propagation extends the
+match to all sectors.
 
 This is Eq. (A.17)–(A.18) of arXiv:1708.00029. -/
 theorem periodicOverlap_gaugeEquiv_of_sector_match
@@ -624,18 +625,18 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
     (hB_cyclic : IsCyclicSectorDecomp B blocksB)
     (hNondegA : ∀ u, dimA u ≠ 0)
     (hSomeMatch : ∃ (u₀ v₀ : Fin m) (hdim : dimA u₀ = dimB v₀),
-      dimA u₀ ≠ 0 ∧ GaugePhaseEquiv
+      GaugePhaseEquiv
         (cast (congr_arg
           (MPSTensor (blockPhysDim d m)) hdim)
           (blocksA u₀))
         (blocksB v₀)) :
     RepeatedBlocks A B := by
   -- Step 1: Extract the matching witness
-  obtain ⟨u₀, v₀, hdim₀, hNondeg₀, hGPE₀⟩ := hSomeMatch
+  obtain ⟨u₀, v₀, hdim₀, hGPE₀⟩ := hSomeMatch
   -- Step 2: Translation propagation (#4) → matching for all offsets
   have hPropag := sectorMatch_propagation A B hA.leftCanonical hB.leftCanonical
     blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
-    hA_cyclic hB_cyclic hdim₀ hNondeg₀ hGPE₀
+    hA_cyclic hB_cyclic hdim₀ (hNondegA u₀) hGPE₀
   -- Step 3: Reindex with q = v₀ - u₀ to get matching for all sector pairs
   set q : Fin m := v₀ - u₀ with q_def
   have hBlockMatch : ∀ u : Fin m,
@@ -719,17 +720,10 @@ theorem periodicOverlapDichotomy
               (blocksA u₀))
             (blocksB v₀)
       · -- Some match → gauge-equivalent (Case 3).
-        have hMatch' : ∃ (u₀ v₀ : Fin m_a) (hdim : dimA u₀ = dimB v₀),
-            dimA u₀ ≠ 0 ∧ GaugePhaseEquiv
-              (cast (congr_arg (MPSTensor (blockPhysDim d m_a)) hdim)
-                (blocksA u₀))
-              (blocksB v₀) := by
-          rcases hMatch with ⟨u₀, v₀, hdim, hGauge⟩
-          exact ⟨u₀, v₀, hdim, hA_nondeg u₀, hGauge⟩
         exact Or.inr ⟨rfl,
           periodicOverlap_gaugeEquiv_of_sector_match A B hA hB
             blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
-            hA_cyclic hB_cyclic hA_nondeg hMatch'⟩
+            hA_cyclic hB_cyclic hA_nondeg hMatch⟩
       · -- No match → orthogonal (Case 2).
         have hNoMatch : ∀ u v (hdim : dimA u = dimB v),
             dimA u ≠ 0 →

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -585,18 +585,18 @@ lemma sectorTensor_proportional_of_blockedMatch
   sorry
 
 /-- **Case 3: a matching sector implies gauge equivalence**. If two periodic tensors have
-the same period and
-a compressed sector match exists, then they are related by a gauge
+the same period and a compressed sector match exists, then they are related by a gauge
 transformation with a unit-modulus phase: `A^i = e^{iξ} U B^i U†`.
 
 The hypotheses describe compressed sector decompositions: `blocksA`/`blocksB` are
 the cyclic-sector tensors on corner bond spaces, tied back to the
 original blocked tensors via `SameMPV₂` and to the cyclic orbit
-structure via `IsCyclicSectorDecomp`. The `hSomeMatch` witness
-provides a single matching sector pair `(u₀, v₀)` with compatible
-dimensions and nonzero bond dimension (`dimA u₀ ≠ 0`), which excludes
-the degenerate case where a zero-dimensional `GaugePhaseEquiv` holds
-vacuously.
+structure via `IsCyclicSectorDecomp`. Global nondegeneracy
+(`hNondegA : ∀ u, dimA u ≠ 0`) ensures every sector of `A` has
+positive bond dimension, which is needed for normality of each sector
+tensor. The `hSomeMatch` witness provides a single matching sector pair
+`(u₀, v₀)` with compatible dimensions, from which translation
+propagation extends the match to all sectors.
 
 This is Eq. (A.17)–(A.18) of arXiv:1708.00029. -/
 theorem periodicOverlap_gaugeEquiv_of_sector_match
@@ -714,20 +714,34 @@ theorem periodicOverlapDichotomy
         exists_cyclic_sector_decomp_after_blocking_of_isPeriodic B hB
       -- Case split on whether any compressed sector pair matches.
       by_cases hMatch : ∃ (u₀ v₀ : Fin m_a) (hdim : dimA u₀ = dimB v₀),
-          dimA u₀ ≠ 0 ∧ GaugePhaseEquiv
+          GaugePhaseEquiv
             (cast (congr_arg (MPSTensor (blockPhysDim d m_a)) hdim)
               (blocksA u₀))
             (blocksB v₀)
       · -- Some match → gauge-equivalent (Case 3).
+        have hMatch' : ∃ (u₀ v₀ : Fin m_a) (hdim : dimA u₀ = dimB v₀),
+            dimA u₀ ≠ 0 ∧ GaugePhaseEquiv
+              (cast (congr_arg (MPSTensor (blockPhysDim d m_a)) hdim)
+                (blocksA u₀))
+              (blocksB v₀) := by
+          rcases hMatch with ⟨u₀, v₀, hdim, hGauge⟩
+          exact ⟨u₀, v₀, hdim, hA_nondeg u₀, hGauge⟩
         exact Or.inr ⟨rfl,
           periodicOverlap_gaugeEquiv_of_sector_match A B hA hB
             blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
-            hA_cyclic hB_cyclic hA_nondeg hMatch⟩
+            hA_cyclic hB_cyclic hA_nondeg hMatch'⟩
       · -- No match → orthogonal (Case 2).
-        push Not at hMatch
+        have hNoMatch : ∀ u v (hdim : dimA u = dimB v),
+            dimA u ≠ 0 →
+            ¬ GaugePhaseEquiv
+              (cast (congr_arg (MPSTensor (blockPhysDim d m_a)) hdim)
+                (blocksA u))
+              (blocksB v) := by
+          intro u v hdim _ hGauge
+          exact hMatch ⟨u, v, hdim, hGauge⟩
         exact Or.inl (periodicOverlap_tendsto_zero_of_no_sector_match A B hA hB
           blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
-          hA_cyclic hB_cyclic hMatch)
+          hA_cyclic hB_cyclic hNoMatch)
 
 /-- **Eventual linear independence** (Corollary of Proposition 3.3):
 Given a family of periodic tensors `{A_j}` whose periods all divide a common


### PR DESCRIPTION
### Motivation

- Formalizes Proposition 3.3 of arXiv:1708.00029 (periodic overlap dichotomy), the core technical result for extending the Fundamental Theorem from normal to periodic tensors, see #81.

### Description

- **`TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean`**: Close 2 of 7 sorrys:
  - `periodicOverlapDichotomy`: full case-split proof covering different periods, different bond dimensions, and same period with/without sector match.
  - `periodicOverlap_gaugeEquiv_of_sector_match`: assembly proof combining `sectorMatch_propagation`, `sectorBlocked_isNormal_of_isPeriodic`, and `sectorTensor_proportional_of_blockedMatch` via `Fin m` reindexing.
- **`TNLean/MPS/CanonicalForm/Assembly.lean`**: Strengthen `exists_cyclic_sector_decomp_after_blocking` to additionally prove nondegeneracy (`∀ k, dim k ≠ 0`), with a new proof that cyclic projections cannot be zero. Update downstream callers.
- Remaining 5 sorrys require sector irreducibility infrastructure not yet formalized.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes theorem signatures/return types and adds nontrivial Lean proof logic that downstream lemmas now rely on for nondegeneracy and sector-match reasoning.
> 
> **Overview**
> **Cyclic sector decomposition is strengthened**: `exists_cyclic_sector_decomp_after_blocking` now additionally proves *nondegeneracy* (`∀ k, dim k ≠ 0`) and includes a new argument showing cyclic spectral projections cannot be zero.
> 
> **Periodic overlap case logic is updated accordingly**: the helper `exists_cyclic_sector_decomp_after_blocking_of_isPeriodic` returns the new nondegeneracy proof, `periodicOverlap_gaugeEquiv_of_sector_match` is filled in by assembling propagation/reindexing/normality and no longer requires a per-witness `dimA u₀ ≠ 0` premise, and `periodicOverlapDichotomy`’s same-period match/no-match split is refactored to use the new nondegeneracy output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba6dfac5f85739d2f4ab14dd52fe30aa20285a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->