### PR TITLE
feat(Channel/Semigroup): formalize Dyson series identity (Wolf Eq. 7.13)

### DIFF
--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -485,9 +485,6 @@ theorem norm_dysonRemainder_le (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ 
     have hM_nn : 0 ≤ M :=
       le_trans (norm_nonneg _)
         (norm_expSemigroup_le_biSup L ht (Set.left_mem_Icc.mpr ht))
-    have hM'_nn : 0 ≤ M' :=
-      le_trans (norm_nonneg _)
-        (norm_expSemigroup_le_biSup L' ht (Set.left_mem_Icc.mpr ht))
     -- Pointwise bound on the integrand
     set C : ℝ := M * ‖L' - L‖ * M' * (‖L' - L‖ * M) ^ N / ↑(N.factorial) with hC_def
     have hpw : ∀ u ∈ Set.Icc 0 s,

--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -9,9 +9,11 @@ import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import Mathlib.MeasureTheory.Integral.Bochner.Basic
 import Mathlib.MeasureTheory.Integral.Bochner.Set
+import Mathlib.MeasureTheory.Integral.DominatedConvergence
 import Mathlib.Analysis.ODE.Gronwall
 import Mathlib.Analysis.Calculus.Deriv.Shift
 import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+import Mathlib.Analysis.Normed.Group.InfiniteSum
 
 /-!
 # Perturbation bound for dynamical semigroups — Wolf Lemma 7.1 and Corollary 7.1
@@ -342,5 +344,260 @@ theorem summable_dysonTerm (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) :
     Summable (fun n => dysonTerm L L' t n) :=
   summable_dysonTerm_of_factorial_bound L L'
     (fun n => norm_dysonTerm_le_at L L' ht n)
+
+/-! ## Continuity of Dyson iterates -/
+
+/-- The `(n+1)`-th Dyson term vanishes for non-positive time. -/
+private lemma dysonTerm_succ_nonpos (L L' : MatrixCLM (Fin D)) (n : ℕ) {t : ℝ}
+    (ht : t ≤ 0) : dysonTerm L L' t (n + 1) = 0 := by
+  rw [dysonTerm_succ]
+  apply setIntegral_measure_zero
+  rw [Real.volume_Icc, ENNReal.ofReal_eq_zero]
+  linarith
+
+/-- For `t ≥ 0`, the set integral `∫ s in Icc 0 t` equals the interval integral `∫ s in 0..t`. -/
+private lemma setIntegral_Icc_eq_intervalIntegral {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] {f : ℝ → E} {t : ℝ} (ht : 0 ≤ t) :
+    ∫ s in Set.Icc 0 t, f s = ∫ s in (0 : ℝ)..t, f s := by
+  rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le ht]
+
+/-- Each Dyson iterate `t ↦ T̃ⁿ(t)` is continuous in the time parameter. -/
+theorem dysonTerm_continuous (L L' : MatrixCLM (Fin D)) (n : ℕ) :
+    Continuous (fun t => dysonTerm L L' t n) := by
+  induction n with
+  | zero => exact expSemigroupCLM_continuous L
+  | succ n ih =>
+    -- The interval integral version G(t) = ∫₀ᵗ T_{t-s} Δ T̃ⁿ(s) ds is globally continuous.
+    set g : ℝ → ℝ → MatrixCLM (Fin D) :=
+      fun t s => expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n
+    have hg_cont : Continuous g.uncurry := by
+      apply Continuous.mul
+      · apply Continuous.mul
+        · exact (expSemigroupCLM_continuous L).comp (continuous_fst.sub continuous_snd)
+        · exact continuous_const
+      · exact ih.comp continuous_snd
+    have hG_cont : Continuous (fun t : ℝ => ∫ s in (0 : ℝ)..t, g t s) :=
+      intervalIntegral.continuous_parametric_intervalIntegral_of_continuous hg_cont continuous_id
+    -- On Ici 0: dysonTerm agrees with the interval integral (hence continuous there).
+    have h_Ici : ContinuousOn (fun t => dysonTerm L L' t (n + 1)) (Set.Ici 0) := by
+      apply ContinuousOn.congr hG_cont.continuousOn
+      intro t ht
+      dsimp only
+      rw [dysonTerm_succ, setIntegral_Icc_eq_intervalIntegral ht]
+    -- On Iic 0: dysonTerm is 0 (hence continuous there).
+    have h_Iic : ContinuousOn (fun t => dysonTerm L L' t (n + 1)) (Set.Iic 0) := by
+      apply ContinuousOn.congr continuousOn_const
+      intro t ht
+      exact dysonTerm_succ_nonpos L L' n ht
+    -- Paste: Ici 0 ∪ Iic 0 = univ, both are closed.
+    rw [← continuousOn_univ, ← Set.Ici_union_Iic (a := (0 : ℝ))]
+    exact h_Ici.union_of_isClosed h_Iic isClosed_Ici isClosed_Iic
+
+/-! ## Integrability of Dyson integrands -/
+
+/-- The integrand `s ↦ T_{t−s} Δ T̃ⁿ(s)` is integrable on `[0, t]`. -/
+private lemma integrableOn_dyson_integrand (L L' : MatrixCLM (Fin D)) (n : ℕ) {t : ℝ}
+    (ht : 0 ≤ t) :
+    IntegrableOn
+      (fun s => expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n)
+      (Set.Icc 0 t) := by
+  apply ContinuousOn.integrableOn_Icc
+  apply ContinuousOn.mul
+  · apply ContinuousOn.mul
+    · exact ((expSemigroupCLM_continuous L).comp
+        (continuous_const.sub continuous_id)).continuousOn
+    · exact continuousOn_const
+  · exact (dysonTerm_continuous L L' n).continuousOn
+
+/-- The integrand from the Duhamel formula is integrable on `[0, t]`. -/
+private lemma integrableOn_duhamel_integrand (L L' : MatrixCLM (Fin D)) {t : ℝ}
+    (ht : 0 ≤ t) :
+    IntegrableOn
+      (fun s => expSemigroupCLM L (t - s) * (L' - L) * expSemigroupCLM L' s)
+      (Set.Icc 0 t) := by
+  apply ContinuousOn.integrableOn_Icc
+  apply ContinuousOn.mul
+  · apply ContinuousOn.mul
+    · exact ((expSemigroupCLM_continuous L).comp
+        (continuous_const.sub continuous_id)).continuousOn
+    · exact continuousOn_const
+  · exact (expSemigroupCLM_continuous L').continuousOn
+
+/-- The integrand for the remainder is integrable on `[0, t]`. -/
+private lemma integrableOn_remainder_integrand (L L' : MatrixCLM (Fin D)) (N : ℕ)
+    {t : ℝ} (ht : 0 ≤ t) :
+    IntegrableOn
+      (fun s => expSemigroupCLM L (t - s) * (L' - L) *
+        (expSemigroupCLM L' s - ∑ n ∈ Finset.range N, dysonTerm L L' s n))
+      (Set.Icc 0 t) := by
+  apply ContinuousOn.integrableOn_Icc
+  apply ContinuousOn.mul
+  · apply ContinuousOn.mul
+    · exact ((expSemigroupCLM_continuous L).comp
+        (continuous_const.sub continuous_id)).continuousOn
+    · exact continuousOn_const
+  · exact ((expSemigroupCLM_continuous L').sub
+      (continuous_finset_sum _ fun n _ => dysonTerm_continuous L L' n)).continuousOn
+
+/-! ## Dyson series identity (Wolf Eq. 7.13) -/
+
+/-- Integral representation of the Dyson series remainder:
+`T'_t − ∑_{n<N+1} T̃ⁿ(t) = ∫₀ᵗ T_{t−s} Δ (T'_s − ∑_{n<N} T̃ⁿ(s)) ds`. -/
+private theorem dysonRemainder_integral_eq (L L' : MatrixCLM (Fin D))
+    {t : ℝ} (ht : 0 ≤ t) (N : ℕ) :
+    expSemigroupCLM L' t - ∑ n ∈ Finset.range (N + 1), dysonTerm L L' t n =
+      ∫ s in Set.Icc 0 t, expSemigroupCLM L (t - s) * (L' - L) *
+        (expSemigroupCLM L' s - ∑ n ∈ Finset.range N, dysonTerm L L' s n) := by
+  induction N with
+  | zero =>
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add,
+      dysonTerm_zero, sub_zero]
+    exact duhamel_formula L L' t ht
+  | succ N ihN =>
+    -- Expand the partial sum: range(N+2) = range(N+1) ∪ {N+1}
+    rw [Finset.sum_range_succ]
+    -- T'_t - (∑_{n<N+1} + T̃^{N+1}) = (T'_t - ∑_{n<N+1}) - T̃^{N+1}
+    have hkey : expSemigroupCLM L' t -
+        (∑ n ∈ Finset.range (N + 1), dysonTerm L L' t n + dysonTerm L L' t (N + 1)) =
+        (expSemigroupCLM L' t - ∑ n ∈ Finset.range (N + 1), dysonTerm L L' t n) -
+        dysonTerm L L' t (N + 1) := by abel
+    rw [hkey, ihN]
+    -- RHS of IH is ∫ T Δ R_N, and T̃^{N+1} = ∫ T Δ T̃ᴺ
+    rw [dysonTerm_succ]
+    -- Need: ∫ T Δ R_N - ∫ T Δ T̃ᴺ = ∫ T Δ (R_N - T̃ᴺ)
+    -- where R_N(s) = T'_s - ∑_{n<N} T̃ⁿ(s)
+    -- and R_{N+1}(s) = T'_s - ∑_{n<N+1} T̃ⁿ(s) = R_N(s) - T̃ᴺ(s)
+    rw [← MeasureTheory.integral_sub
+      (integrableOn_remainder_integrand L L' N ht)
+      (integrableOn_dyson_integrand L L' N ht)]
+    congr 1; ext s
+    simp only [Finset.sum_range_succ, mul_sub, mul_add, sub_sub]
+
+/-- **Factorial norm bound on the Dyson series remainder.**
+For `s ∈ [0,t]`, `M = sup_{u ∈ [0,t]} ‖T_u‖`, `M' = sup_{u ∈ [0,t]} ‖T'_u‖`:
+`‖T'_s − ∑_{n<N} T̃ⁿ(s)‖ ≤ M' · (s · ‖Δ‖ · M)^N / N!`. -/
+theorem norm_dysonRemainder_le (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) (N : ℕ)
+    {s : ℝ} (hs : s ∈ Set.Icc 0 t) :
+    ‖expSemigroupCLM L' s - ∑ n ∈ Finset.range N, dysonTerm L L' s n‖ ≤
+      (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L' u‖) *
+      ((s * ‖L' - L‖ * (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖)) ^ N /
+        ↑(N.factorial)) := by
+  induction N generalizing s with
+  | zero =>
+    simp only [Finset.range_zero, Finset.sum_empty, sub_zero, pow_zero,
+      Nat.factorial_zero, Nat.cast_one, div_one, mul_one]
+    exact norm_expSemigroup_le_biSup L' ht hs
+  | succ N ihN =>
+    have hrep := dysonRemainder_integral_eq L L' hs.1 N
+    rw [hrep]
+    set M := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖ with hM_def
+    set M' := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L' u‖ with hM'_def
+    have hs0 : (0 : ℝ) ≤ s := hs.1
+    have hst : s ≤ t := hs.2
+    have hM_nn : 0 ≤ M :=
+      le_trans (norm_nonneg _)
+        (norm_expSemigroup_le_biSup L ht (Set.left_mem_Icc.mpr ht))
+    have hM'_nn : 0 ≤ M' :=
+      le_trans (norm_nonneg _)
+        (norm_expSemigroup_le_biSup L' ht (Set.left_mem_Icc.mpr ht))
+    -- Pointwise bound on the integrand
+    set C : ℝ := M * ‖L' - L‖ * M' * (‖L' - L‖ * M) ^ N / ↑(N.factorial) with hC_def
+    have hpw : ∀ u ∈ Set.Icc 0 s,
+        ‖expSemigroupCLM L (s - u) * (L' - L) *
+          (expSemigroupCLM L' u - ∑ n ∈ Finset.range N, dysonTerm L L' u n)‖ ≤
+          C * u ^ N := by
+      intro u hu
+      have hu_t : u ∈ Set.Icc 0 t := ⟨hu.1, le_trans hu.2 hst⟩
+      have hsu_t : s - u ∈ Set.Icc 0 t :=
+        ⟨sub_nonneg.mpr hu.2, le_trans (sub_le_self s hu.1) hst⟩
+      calc ‖expSemigroupCLM L (s - u) * (L' - L) *
+              (expSemigroupCLM L' u - ∑ n ∈ Finset.range N, dysonTerm L L' u n)‖
+          ≤ ‖expSemigroupCLM L (s - u)‖ * ‖L' - L‖ *
+              ‖expSemigroupCLM L' u - ∑ n ∈ Finset.range N, dysonTerm L L' u n‖ := by
+            calc _ ≤ ‖expSemigroupCLM L (s - u) * (L' - L)‖ * ‖_‖ := norm_mul_le _ _
+              _ ≤ _ := mul_le_mul_of_nonneg_right (norm_mul_le _ _) (norm_nonneg _)
+        _ ≤ M * ‖L' - L‖ *
+              (M' * ((u * ‖L' - L‖ * M) ^ N / ↑(N.factorial))) := by
+            apply mul_le_mul
+            · exact mul_le_mul_of_nonneg_right
+                (norm_expSemigroup_le_biSup L ht hsu_t) (norm_nonneg _)
+            · exact ihN hu_t
+            · exact norm_nonneg _
+            · exact mul_nonneg hM_nn (norm_nonneg _)
+        _ = C * u ^ N := by simp only [hC_def, mul_pow]; ring
+    -- Convert set integral to interval integral
+    rw [setIntegral_Icc_eq_intervalIntegral hs0]
+    -- Integrability of the bound function
+    have hCu_int : IntervalIntegrable (fun u => C * u ^ N) volume 0 s :=
+      (continuous_const.mul (continuous_pow N)).intervalIntegrable 0 s
+    -- Bound the norm of the integral
+    calc ‖∫ u in (0 : ℝ)..s, expSemigroupCLM L (s - u) * (L' - L) *
+            (expSemigroupCLM L' u - ∑ n ∈ Finset.range N, dysonTerm L L' u n)‖
+        ≤ ∫ u in (0 : ℝ)..s, C * u ^ N :=
+          intervalIntegral.norm_integral_le_of_norm_le hs0
+            (ae_of_all _ fun u hu =>
+              hpw u (Set.Ioc_subset_Icc_self hu)) hCu_int
+      _ = C * (s ^ (N + 1) / ((N : ℝ) + 1)) := by
+          rw [intervalIntegral.integral_const_mul, integral_pow,
+              zero_pow (Nat.succ_ne_zero N), sub_zero]
+      _ = M' * ((s * ‖L' - L‖ * M) ^ (N + 1) / ↑((N + 1).factorial)) := by
+          rw [hC_def, Nat.factorial_succ, Nat.cast_mul, Nat.cast_succ]
+          have : (↑(N.factorial) : ℝ) ≠ 0 :=
+            Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero N)
+          have : (↑N : ℝ) + 1 ≠ 0 := by positivity
+          field_simp
+          ring
+
+/-- **Dyson series identity** (Wolf Eq. 7.13):
+the Dyson–Phillips series `∑ₙ T̃⁽ⁿ⁾(t)` equals the perturbed semigroup `T'_t`.
+This completes the Dyson–Phillips expansion for matrix semigroups. -/
+theorem dyson_series_eq (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) :
+    HasSum (fun n => dysonTerm L L' t n) (expSemigroupCLM L' t) := by
+  -- The partial sums converge to the tsum (by summability).
+  -- We show they also converge to T'_t, then use uniqueness of limits.
+  have hS := summable_dysonTerm L L' ht
+  -- Summable norms (for hasSum_iff_tendsto_nat)
+  have hSn : Summable (fun n => ‖dysonTerm L L' t n‖) :=
+    .of_nonneg_of_le (fun n => norm_nonneg _)
+      (fun n => norm_dysonTerm_le_at L L' ht n)
+      ((Real.summable_pow_div_factorial
+        (t * ‖L' - L‖ * (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖))).mul_left
+        (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖))
+  rw [hasSum_iff_tendsto_nat_of_summable_norm hSn]
+  -- Show partial sums converge to T'_t:
+  -- ‖T'_t - ∑_{n<N} T̃ⁿ(t)‖ ≤ M' · (t·‖Δ‖·M)^N / N! → 0
+  rw [Metric.tendsto_atTop]
+  intro ε hε
+  set c := t * ‖L' - L‖ * (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖) with hc_def
+  set M' := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L' u‖ with hM'_def
+  -- c^N / N! → 0
+  have h_tend : Filter.Tendsto (fun N => M' * (c ^ N / ↑(N.factorial)))
+      Filter.atTop (nhds 0) := by
+    rw [show (0 : ℝ) = M' * 0 from (mul_zero _).symm]
+    exact Filter.Tendsto.mul tendsto_const_nhds
+      (FloorSemiring.tendsto_pow_div_factorial_atTop c)
+  rw [Metric.tendsto_atTop] at h_tend
+  obtain ⟨N₀, hN₀⟩ := h_tend ε hε
+  refine ⟨N₀, fun N hN => ?_⟩
+  rw [dist_comm, dist_eq_norm]
+  calc ‖expSemigroupCLM L' t - ∑ n ∈ Finset.range N, dysonTerm L L' t n‖
+      ≤ M' * (c ^ N / ↑(N.factorial)) :=
+        norm_dysonRemainder_le L L' ht N (Set.right_mem_Icc.mpr ht)
+    _ = |M' * (c ^ N / ↑(N.factorial)) - 0| := by
+        rw [sub_zero, abs_of_nonneg]
+        have hc_nn : 0 ≤ c := mul_nonneg (mul_nonneg ht (norm_nonneg _))
+          (le_trans (norm_nonneg _)
+            (norm_expSemigroup_le_biSup L ht (Set.left_mem_Icc.mpr ht)))
+        exact mul_nonneg
+          (le_trans (norm_nonneg _)
+            (norm_expSemigroup_le_biSup L' ht (Set.left_mem_Icc.mpr ht)))
+          (div_nonneg (pow_nonneg hc_nn _) (Nat.cast_nonneg' _))
+    _ = dist (M' * (c ^ N / ↑(N.factorial))) 0 := (Real.dist_eq _ _).symm
+    _ < ε := hN₀ N hN
+
+/-- The tsum of the Dyson–Phillips series equals the perturbed semigroup. -/
+theorem tsum_dysonTerm_eq (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) :
+    ∑' n, dysonTerm L L' t n = expSemigroupCLM L' t :=
+  (dyson_series_eq L L' ht).tsum_eq
 
 end -- noncomputable section

--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -16,12 +16,16 @@ import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
 import Mathlib.Analysis.Normed.Group.InfiniteSum
 
 /-!
-# Perturbation bound for dynamical semigroups — Wolf Lemma 7.1 and Corollary 7.1
+# Perturbation theory for dynamical semigroups — Wolf §7.1
 
 ## Main results
 
 * `duhamel_formula` — **Lemma 7.1** (Duhamel/perturbation integral formula)
 * `perturbation_bound` — **Corollary 7.1** (perturbation of generators)
+* `dysonTerm_continuous` — continuity of each Dyson iterate in the time parameter
+* `norm_dysonRemainder_le` — factorial norm bound on the Dyson partial-sum remainder
+* `dyson_series_eq` — **Eq. 7.13** (Dyson–Phillips series = perturbed semigroup)
+* `tsum_dysonTerm_eq` — tsum form of the Dyson series identity
 
 ## References
 
@@ -409,20 +413,6 @@ private lemma integrableOn_dyson_integrand (L L' : MatrixCLM (Fin D)) (n : ℕ) 
     · exact continuousOn_const
   · exact (dysonTerm_continuous L L' n).continuousOn
 
-/-- The integrand from the Duhamel formula is integrable on `[0, t]`. -/
-private lemma integrableOn_duhamel_integrand (L L' : MatrixCLM (Fin D)) {t : ℝ}
-    (ht : 0 ≤ t) :
-    IntegrableOn
-      (fun s => expSemigroupCLM L (t - s) * (L' - L) * expSemigroupCLM L' s)
-      (Set.Icc 0 t) := by
-  apply ContinuousOn.integrableOn_Icc
-  apply ContinuousOn.mul
-  · apply ContinuousOn.mul
-    · exact ((expSemigroupCLM_continuous L).comp
-        (continuous_const.sub continuous_id)).continuousOn
-    · exact continuousOn_const
-  · exact (expSemigroupCLM_continuous L').continuousOn
-
 /-- The integrand for the remainder is integrable on `[0, t]`. -/
 private lemma integrableOn_remainder_integrand (L L' : MatrixCLM (Fin D)) (N : ℕ)
     {t : ℝ} (ht : 0 ≤ t) :
@@ -490,8 +480,8 @@ theorem norm_dysonRemainder_le (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ 
   | succ N ihN =>
     have hrep := dysonRemainder_integral_eq L L' hs.1 N
     rw [hrep]
-    set M := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖ with hM_def
-    set M' := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L' u‖ with hM'_def
+    set M := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖
+    set M' := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L' u‖
     have hs0 : (0 : ℝ) ≤ s := hs.1
     have hst : s ≤ t := hs.2
     have hM_nn : 0 ≤ M :=
@@ -555,7 +545,6 @@ theorem dyson_series_eq (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) :
     HasSum (fun n => dysonTerm L L' t n) (expSemigroupCLM L' t) := by
   -- The partial sums converge to the tsum (by summability).
   -- We show they also converge to T'_t, then use uniqueness of limits.
-  have hS := summable_dysonTerm L L' ht
   -- Summable norms (for hasSum_iff_tendsto_nat)
   have hSn : Summable (fun n => ‖dysonTerm L L' t n‖) :=
     .of_nonneg_of_le (fun n => norm_nonneg _)
@@ -568,8 +557,8 @@ theorem dyson_series_eq (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ t) :
   -- ‖T'_t - ∑_{n<N} T̃ⁿ(t)‖ ≤ M' · (t·‖Δ‖·M)^N / N! → 0
   rw [Metric.tendsto_atTop]
   intro ε hε
-  set c := t * ‖L' - L‖ * (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖) with hc_def
-  set M' := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L' u‖ with hM'_def
+  set c := t * ‖L' - L‖ * (⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L u‖)
+  set M' := ⨆ u ∈ Set.Icc 0 t, ‖expSemigroupCLM L' u‖
   -- c^N / N! → 0
   have h_tend : Filter.Tendsto (fun N => M' * (c ^ N / ↑(N.factorial)))
       Filter.atTop (nhds 0) := by

--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -389,10 +389,8 @@ theorem dysonTerm_continuous (L L' : MatrixCLM (Fin D)) (n : ℕ) :
       dsimp only
       rw [dysonTerm_succ, setIntegral_Icc_eq_intervalIntegral ht]
     -- On Iic 0: dysonTerm is 0 (hence continuous there).
-    have h_Iic : ContinuousOn (fun t => dysonTerm L L' t (n + 1)) (Set.Iic 0) := by
-      apply ContinuousOn.congr continuousOn_const
-      intro t ht
-      exact dysonTerm_succ_nonpos L L' n ht
+    have h_Iic : ContinuousOn (fun t => dysonTerm L L' t (n + 1)) (Set.Iic 0) :=
+      continuousOn_const.congr fun _ ht => dysonTerm_succ_nonpos L L' n ht
     -- Paste: Ici 0 ∪ Iic 0 = univ, both are closed.
     rw [← continuousOn_univ, ← Set.Ici_union_Iic (a := (0 : ℝ))]
     exact h_Ici.union_of_isClosed h_Iic isClosed_Ici isClosed_Iic
@@ -401,7 +399,7 @@ theorem dysonTerm_continuous (L L' : MatrixCLM (Fin D)) (n : ℕ) :
 
 /-- The integrand `s ↦ T_{t−s} Δ T̃ⁿ(s)` is integrable on `[0, t]`. -/
 private lemma integrableOn_dyson_integrand (L L' : MatrixCLM (Fin D)) (n : ℕ) {t : ℝ}
-    (ht : 0 ≤ t) :
+    (_ : 0 ≤ t) :
     IntegrableOn
       (fun s => expSemigroupCLM L (t - s) * (L' - L) * dysonTerm L L' s n)
       (Set.Icc 0 t) := by
@@ -415,7 +413,7 @@ private lemma integrableOn_dyson_integrand (L L' : MatrixCLM (Fin D)) (n : ℕ) 
 
 /-- The integrand for the remainder is integrable on `[0, t]`. -/
 private lemma integrableOn_remainder_integrand (L L' : MatrixCLM (Fin D)) (N : ℕ)
-    {t : ℝ} (ht : 0 ≤ t) :
+    {t : ℝ} (_ : 0 ≤ t) :
     IntegrableOn
       (fun s => expSemigroupCLM L (t - s) * (L' - L) *
         (expSemigroupCLM L' s - ∑ n ∈ Finset.range N, dysonTerm L L' s n))

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -298,6 +298,20 @@ and proves the GKSL theorem.
     the sum via uniqueness of limits.
 \end{proof}
 
+\begin{corollary}[Tsum form of the Dyson series]
+    \label{cor:tsum_dysonTerm_eq_ch12}
+    \lean{tsum_dysonTerm_eq}\leanok
+    \uses{thm:dyson_series_eq_ch12}
+    $\sum_{n=0}^{\infty} \widetilde{T}^{(n)}_t = e^{tL'}$
+    (tsum form).
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:dyson_series_eq_ch12}
+    Immediate from Theorem~\ref{thm:dyson_series_eq_ch12}.
+\end{proof}
+
 %% ---------------------------------------------------------
 \section{GKSL/Lindblad generators}
 \label{sec:gksl_generators}

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -233,6 +233,71 @@ and proves the GKSL theorem.
     (Lemma~\ref{lem:summable_dyson_factorial_ch12}).
 \end{proof}
 
+\begin{theorem}[Continuity of Dyson iterates]
+    \label{thm:dysonTerm_continuous_ch12}
+    \lean{dysonTerm_continuous}\leanok
+    \uses{def:exp_semigroup_ch12}
+    Each Dyson iterate $t \mapsto \widetilde{T}^{(n)}_t$ is continuous
+    in the time parameter.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:exp_semigroup_ch12}
+    By induction on $n$. The base case is continuity of the matrix
+    exponential. For the inductive step, the parametric integral
+    $t\mapsto \int_0^t e^{(t-s)L}\,\Delta\,\widetilde{T}^{(n)}_s\,ds$
+    is continuous by the continuous-parameter primitive theorem;
+    the pasting lemma extends this to all of $\mathbb{R}$ since
+    $\widetilde{T}^{(n+1)}_t = 0$ for $t \le 0$.
+\end{proof}
+
+\begin{theorem}[Factorial bound on the Dyson remainder]
+    \label{thm:norm_dysonRemainder_le_ch12}
+    \lean{norm_dysonRemainder_le}\leanok
+    \uses{thm:duhamel_formula_ch12, thm:norm_dysonTerm_le_ch12}
+    For $s \in [0,t]$, $M = \sup_{u \in [0,t]}\|e^{uL}\|$,
+    and $M' = \sup_{u \in [0,t]}\|e^{uL'}\|$:
+    \[
+      \bigl\|T'_s - \textstyle\sum_{n < N}\widetilde{T}^{(n)}_s\bigr\|
+      \le M'\,\frac{(s\,\|\Delta\|\,M)^N}{N!}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:duhamel_formula_ch12, thm:norm_dysonTerm_le_ch12,
+          thm:dysonTerm_continuous_ch12}
+    Induction on $N$. The base case is the semigroup supremum bound.
+    The inductive step uses the telescoping remainder identity
+    $R_{N+1}(s) = \int_0^s e^{(s-u)L}\,\Delta\,R_N(u)\,du$
+    (derived from the Duhamel formula), bounds the integrand
+    pointwise, and integrates to recover the factorial.
+\end{proof}
+
+\begin{theorem}[Dyson series identity {\cite[Eq.~(7.13)]{Wolf2012Quantum}}]
+    \label{thm:dyson_series_eq_ch12}
+    \lean{dyson_series_eq}\leanok
+    \uses{thm:norm_dysonRemainder_le_ch12, cor:summable_dysonTerm_ch12}
+    For $t \ge 0$, the Dyson--Phillips series equals the perturbed
+    semigroup:
+    \[
+      \sum_{n=0}^{\infty} \widetilde{T}^{(n)}_t = e^{tL'}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:norm_dysonRemainder_le_ch12, cor:summable_dysonTerm_ch12}
+    The partial-sum remainder
+    $\|e^{tL'} - \sum_{n<N}\widetilde{T}^{(n)}_t\|
+    \le M'\,(t\|\Delta\|M)^N/N!$
+    tends to zero as $N \to \infty$, since $c^N/N! \to 0$ for any
+    constant $c$. Together with the summability of the series
+    (Corollary~\ref{cor:summable_dysonTerm_ch12}), this identifies
+    the sum via uniqueness of limits.
+\end{proof}
+
 %% ---------------------------------------------------------
 \section{GKSL/Lindblad generators}
 \label{sec:gksl_generators}


### PR DESCRIPTION
### Motivation

- Formalize the Dyson-Phillips series expansion (Wolf Eq. 7.13) for perturbed matrix semigroups, see LionSR/QICLean#96.
- The single-step Duhamel formula and perturbation bound were already in place; this completes the full series convergence proof.

### Description

- Extend `TNLean/Channel/Semigroup/Perturbation.lean` with:
  - `dysonTerm_continuous`: each Dyson iterate is continuous in time
  - Integrability lemmas for Dyson/Duhamel/remainder integrands
  - Telescoping integral identity for the remainder
  - `norm_dysonRemainder_le`: factorial norm bound on the partial-sum remainder
  - `dyson_series_eq`: `HasSum` characterization (the main theorem)
  - `tsum_dysonTerm_eq`: tsum form of the identity
- Update `blueprint/src/chapter/ch12_semigroup.tex` with corresponding entries and proof sketches.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/QICLean#96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this adds substantial new Lean proof machinery (continuity/integrability/limit arguments) and new Mathlib dependencies, which may be brittle to library changes and could impact downstream compilation.
> 
> **Overview**
> Formalizes the full Dyson–Phillips perturbation theory conclusion for matrix semigroups by proving the Dyson series converges to the perturbed semigroup (`dyson_series_eq`) and exposing the corresponding `tsum` statement.
> 
> To support this, it adds continuity of each Dyson iterate (`dysonTerm_continuous`), integrability lemmas for Dyson/remainder integrands, a telescoping integral identity for the partial-sum remainder, and a factorial norm bound on that remainder (`norm_dysonRemainder_le`). The blueprint chapter is updated with matching theorems and proof sketches, and the Lean file pulls in additional Mathlib imports needed for dominated convergence and infinite sums.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a65b0727dbf9fc854bbd7b904a51b5d63eabc25b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->