### PR TITLE
feat(MPS/ParentHamiltonian): spectral gap via martingale method

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -31,21 +31,23 @@ Kastoryano–Lucia 2018 (arXiv:1705.09491), Nachtergaele 1996
    with constants `c_{ij}` depending only on the MPS tensor, not on `N`.
 5. **Row-sum bound** `∑_{j ≠ i} c_{ij} ≤ 1`: at most `2(L-1)` local terms
    overlap a given local term.
-6. **Abstract criterion → quadratic form**: the above yields `H² ≥ γ H` as
-   operators, which by the spectral theorem gives `γ ‖v‖ ≤ ‖H v‖` for
-   `v ⊥ ker H`.
+6. **Quadratic form ⟹ norm bound**: the above yields `H² ≥ γ H` as operators,
+   which by the spectral theorem gives `γ ‖v‖ ≤ ‖H v‖` for `v ⊥ ker H`.
 
-The abstract step `H² ≥ γ H ⟹ gap ≥ γ` is factored into
-`spectralGap_of_martingale`, so that the MPS-specific verification reduces to
-producing the operator inequality. Both the abstract criterion and its MPS
-instantiation are currently left as `sorry`; see the module docstring for
-references.
+The heavy lifting — deriving the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`
+from the MPS-specific operator inequality — is all contained in
+`parentHamiltonian_gapped`, which is currently left as `sorry`. A small
+self-contained helper `spectralGap_norm_bound_to_eigenvalue` records the
+elementary final conversion from that norm bound to an eigenvalue-level gap
+statement; it is the only part of the chain that admits a short proof, and is
+proved here unconditionally.
 
 ## Main results
 
-* `spectralGap_of_martingale` — abstract martingale criterion packaging.
+* `spectralGap_norm_bound_to_eigenvalue` — elementary conversion from a
+  norm-bound on `(ker H)ᗮ` to an eigenvalue-level gap.
 * `parentHamiltonian_gapped` — uniform spectral gap for MPS parent
-  Hamiltonians on injective tensors.
+  Hamiltonians on injective tensors (deferred).
 -/
 
 namespace MPSTensor
@@ -70,47 +72,36 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
   let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
   e.symm.toLinearMap.comp ((parentHamiltonian A L N).comp e.toLinearMap)
 
-/-! ### Abstract martingale criterion
+/-! ### Norm bound ⟹ eigenvalue-level gap
 
-This section isolates the purely operator-theoretic content of the
-Kastoryano–Lucia martingale method from the MPS-specific verification.
+This is the elementary final step of the martingale method: given the
+martingale-derived norm bound `γ ‖v‖ ≤ ‖H v‖` for all `v ⊥ ker H`, convert
+it into an eigenvalue-level gap statement. In finite dimensions this is a
+one-line consequence of `norm_smul`.
 
-The final form used below is the "norm-bound" form of the gap statement:
-if `γ ‖v‖ ≤ ‖H v‖` holds for all `v` in the orthogonal complement of the
-kernel, then `H` is gapped by `γ`. The real mathematical content of the
-martingale method is producing this hypothesis from the operator inequality
-
-    `H² ≥ γ H`
-
-(see Kastoryano–Lucia 2018, Theorem 3.1 and Nachtergaele 1996, Lemma 4.1).
-The abstract operator inequality in turn follows from a family of projector
-bounds on overlapping pairs together with a row-sum bound on the overlap
-constants. -/
+The non-trivial mathematical content — producing the norm bound itself from
+the MPS-specific operator inequality `H² ≥ γ H` (which in turn comes from
+the Friedrichs-angle estimate on overlapping projector pairs plus a row-sum
+bound) — is *not* in this section. It is deferred to the `sorry` in
+`parentHamiltonian_gapped`. -/
 
 /--
-**Abstract martingale criterion (Kastoryano–Lucia / Nachtergaele).**
+**Norm bound ⟹ eigenvalue-level gap (elementary conversion step).**
 
-Let `H : E →ₗ[ℂ] E` be a linear endomorphism of a finite-dimensional complex
-inner product space, and let `γ > 0` be a real number. If `H` admits a
-"martingale decomposition" giving rise to the norm-bound
+Let `H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι` be a linear endomorphism
+of a finite-dimensional complex inner product space, and let `γ > 0`. Suppose
 
-    `γ ‖v‖ ≤ ‖H v‖    for all v ⊥ ker H`,
+    `γ ‖v‖ ≤ ‖H v‖    for all v ⊥ ker H`.
 
-then `H` is gapped with gap at least `γ` in the sense that every eigenvalue
-`μ` of `H` with an eigenvector `v ≠ 0` in `(ker H)ᗮ` satisfies `γ ≤ ‖μ‖`.
+Then every eigenvalue `μ` of `H` with an eigenvector `v ≠ 0` in `(ker H)ᗮ`
+satisfies `γ ≤ ‖μ‖`.
 
-The non-trivial content is entirely the martingale-norm bound `hBound` — the
-full derivation (frustration-free sum of projectors + operator inequality on
-overlapping pairs + row-sum bound ⟹ `H² ≥ γ H` ⟹ norm bound) is deferred.
-Once that bound is produced, this lemma converts it into a genuine
-eigenvalue-level spectral-gap statement.
-
-References:
-* Kastoryano–Lucia, arXiv:1705.09491, Sections 2–3 (clean modern treatment).
-* Nachtergaele, CMP 175 (1996), Lemma 4.1.
-* Fannes–Nachtergaele–Werner, CMP 144 (1992) (original gap proof).
+This is the elementary conversion `‖H v‖ = ‖μ‖ * ‖v‖` step — no "martingale"
+content is present here. The real work of the martingale method is producing
+the hypothesis `hBound`; see `parentHamiltonian_gapped` for where that is
+deferred.
 -/
-theorem spectralGap_of_martingale {ι : Type*} [Fintype ι]
+theorem spectralGap_norm_bound_to_eigenvalue {ι : Type*} [Fintype ι]
     (H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι) (γ : ℝ) (_hγ : 0 < γ)
     (hBound : ∀ v : EuclideanSpace ℂ ι,
       v ∈ (LinearMap.ker H)ᗮ → γ * ‖v‖ ≤ ‖H v‖) :
@@ -147,8 +138,9 @@ operator inequality
 
 with constants `c_{ij}` depending only on the MPS tensor (not on `N`). At most
 `2(L-1)` local terms overlap a given `h_i`, so the row-sum bound
-`∑_{j≠i} c_{ij} ≤ 1` holds uniformly in `N`. The abstract martingale criterion
-`spectralGap_of_martingale` then yields a uniform gap.
+`∑_{j≠i} c_{ij} ≤ 1` holds uniformly in `N`. Combining these via the
+spectral theorem yields the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`, which
+is precisely the conclusion below.
 
 The proof is deferred; the operator inequality and its derivation from the
 intersection property are the remaining mathematical work. -/

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -19,9 +19,9 @@ Kastoryano–Lucia 2018 (arXiv:1705.09491), Nachtergaele 1996
    term annihilates the MPV ground state.
 2. **Local projector structure** (`parentInteraction`/`localTerm`): each local
    term is an orthogonal projector on its `L`-site window.
-3. **Intersection property** (`groundSpace_intersection`, proved in PR #265):
-   for an injective MPS tensor, the kernel of the sum of two overlapping local
-   terms equals the intersection of their kernels.
+3. **Intersection property** (`groundSpace_intersection`): for an injective
+   MPS tensor, the kernel of the sum of two overlapping local terms equals
+   the intersection of their kernels.
 4. **Martingale operator bound**: the intersection property gives a positive
    Friedrichs angle between adjacent local ground spaces, which is the
    quantitative content of
@@ -34,18 +34,12 @@ Kastoryano–Lucia 2018 (arXiv:1705.09491), Nachtergaele 1996
 6. **Quadratic form ⟹ norm bound**: the above yields `H² ≥ γ H` as operators,
    which by the spectral theorem gives `γ ‖v‖ ≤ ‖H v‖` for `v ⊥ ker H`.
 
-The heavy lifting — deriving the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`
-from the MPS-specific operator inequality — is all contained in
-`parentHamiltonian_gapped`, which is currently left as `sorry`. A small
-self-contained helper `spectralGap_norm_bound_to_eigenvalue` records the
-elementary final conversion from that norm bound to an eigenvalue-level gap
-statement; it is the only part of the chain that admits a short proof, and is
-proved here unconditionally.
+The quantitative martingale estimate, its derivation from the intersection
+property, and the final spectral-theorem step are all left as future work
+inside `parentHamiltonian_gapped`, which is currently stated as a `sorry`.
 
 ## Main results
 
-* `spectralGap_norm_bound_to_eigenvalue` — elementary conversion from a
-  norm-bound on `(ker H)ᗮ` to an eigenvalue-level gap.
 * `parentHamiltonian_gapped` — uniform spectral gap for MPS parent
   Hamiltonians on injective tensors (deferred).
 -/
@@ -72,49 +66,7 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
   let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
   e.symm.toLinearMap.comp ((parentHamiltonian A L N).comp e.toLinearMap)
 
-/-! ### Norm bound ⟹ eigenvalue-level gap
-
-This is the elementary final step of the martingale method: given the
-martingale-derived norm bound `γ ‖v‖ ≤ ‖H v‖` for all `v ⊥ ker H`, convert
-it into an eigenvalue-level gap statement. In finite dimensions this is a
-one-line consequence of `norm_smul`.
-
-The non-trivial mathematical content — producing the norm bound itself from
-the MPS-specific operator inequality `H² ≥ γ H` (which in turn comes from
-the Friedrichs-angle estimate on overlapping projector pairs plus a row-sum
-bound) — is *not* in this section. It is deferred to the `sorry` in
-`parentHamiltonian_gapped`. -/
-
-/--
-**Norm bound ⟹ eigenvalue-level gap (elementary conversion step).**
-
-Let `H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι` be a linear endomorphism
-of a finite-dimensional complex inner product space, and let `γ > 0`. Suppose
-
-    `γ ‖v‖ ≤ ‖H v‖    for all v ⊥ ker H`.
-
-Then every eigenvalue `μ` of `H` with an eigenvector `v ≠ 0` in `(ker H)ᗮ`
-satisfies `γ ≤ ‖μ‖`.
-
-This is the elementary conversion `‖H v‖ = ‖μ‖ * ‖v‖` step — no "martingale"
-content is present here. The real work of the martingale method is producing
-the hypothesis `hBound`; see `parentHamiltonian_gapped` for where that is
-deferred.
--/
-theorem spectralGap_norm_bound_to_eigenvalue {ι : Type*} [Fintype ι]
-    (H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι) (γ : ℝ) (_hγ : 0 < γ)
-    (hBound : ∀ v : EuclideanSpace ℂ ι,
-      v ∈ (LinearMap.ker H)ᗮ → γ * ‖v‖ ≤ ‖H v‖) :
-    ∀ (μ : ℂ) (v : EuclideanSpace ℂ ι),
-      v ∈ (LinearMap.ker H)ᗮ → v ≠ 0 → H v = μ • v → γ ≤ ‖μ‖ := by
-  intro μ v hv hne heq
-  have hv_pos : (0 : ℝ) < ‖v‖ := norm_pos_iff.mpr hne
-  have h1 : γ * ‖v‖ ≤ ‖H v‖ := hBound v hv
-  have h2 : ‖H v‖ = ‖μ‖ * ‖v‖ := by rw [heq, norm_smul]
-  rw [h2] at h1
-  exact le_of_mul_le_mul_right h1 hv_pos
-
-/-! ### Specialization to the MPS parent Hamiltonian -/
+/-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
 /--
 **Spectral gap for MPS parent Hamiltonians.**
@@ -130,9 +82,9 @@ on `NSiteSpace d N ≃ Cfg d N → ℂ`.
 **Proof strategy (Kastoryano–Lucia 2018 / Nachtergaele 1996).** The parent
 Hamiltonian `H_N = ∑ᵢ hᵢ` is a frustration-free sum of local orthogonal
 projectors (`parentHamiltonian_frustrationFree`). The intersection property
-`groundSpace_intersection` (PR #265) bounds the Friedrichs angle between
-adjacent local ground spaces away from zero, which provides the martingale
-operator inequality
+`groundSpace_intersection` bounds the Friedrichs angle between adjacent local
+ground spaces away from zero, which provides the martingale operator
+inequality
 
     `h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)`
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -9,20 +9,43 @@ import TNLean.MPS.ParentHamiltonian.Basic
 # Martingale-method spectral-gap framework for parent Hamiltonians
 
 This file sets up the martingale approach to proving
-that MPS parent Hamiltonians are gapped.
+that MPS parent Hamiltonians are gapped, following
+Kastoryano–Lucia 2018 (arXiv:1705.09491), Nachtergaele 1996
+(Comm. Math. Phys. 175, 565), and Fannes–Nachtergaele–Werner 1992.
 
-The intended proof route is:
-1. frustration-freeness (`parentHamiltonian_frustrationFree`),
-2. local projector gap (`parentInteraction`/`localTerm` as orthogonal projections),
-3. intersection property (`groundSpace_intersection`),
-4. a martingale estimate (Nachtergaele / Kastoryano–Lucia).
+## Proof route
 
-The quantitative martingale estimate is left as future work.
+1. **Frustration-freeness** (`parentHamiltonian_frustrationFree`): every local
+   term annihilates the MPV ground state.
+2. **Local projector structure** (`parentInteraction`/`localTerm`): each local
+   term is an orthogonal projector on its `L`-site window.
+3. **Intersection property** (`groundSpace_intersection`, proved in PR #265):
+   for an injective MPS tensor, the kernel of the sum of two overlapping local
+   terms equals the intersection of their kernels.
+4. **Martingale operator bound**: the intersection property gives a positive
+   Friedrichs angle between adjacent local ground spaces, which is the
+   quantitative content of
+
+        `h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)`
+
+   with constants `c_{ij}` depending only on the MPS tensor, not on `N`.
+5. **Row-sum bound** `∑_{j ≠ i} c_{ij} ≤ 1`: at most `2(L-1)` local terms
+   overlap a given local term.
+6. **Abstract criterion → quadratic form**: the above yields `H² ≥ γ H` as
+   operators, which by the spectral theorem gives `γ ‖v‖ ≤ ‖H v‖` for
+   `v ⊥ ker H`.
+
+The abstract step `H² ≥ γ H ⟹ gap ≥ γ` is factored into
+`spectralGap_of_martingale`, so that the MPS-specific verification reduces to
+producing the operator inequality. Both the abstract criterion and its MPS
+instantiation are currently left as `sorry`; see the module docstring for
+references.
 
 ## Main results
 
-* `parentHamiltonian_gapped` — spectral gap: vectors in the orthogonal complement
-  of the ground space satisfy `‖H v‖ ≥ γ ‖v‖` with a uniform gap `γ > 0`.
+* `spectralGap_of_martingale` — abstract martingale criterion packaging.
+* `parentHamiltonian_gapped` — uniform spectral gap for MPS parent
+  Hamiltonians on injective tensors.
 -/
 
 namespace MPSTensor
@@ -30,6 +53,8 @@ namespace MPSTensor
 open scoped BigOperators InnerProductSpace
 
 variable {d D : ℕ}
+
+/-! ### Ground-space and Hamiltonian transport to `EuclideanSpace` -/
 
 /-- Ground-space submodule for the finite-size parent Hamiltonian,
 transported to the `EuclideanSpace` (inner-product) setting so that
@@ -45,24 +70,87 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
   let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
   e.symm.toLinearMap.comp ((parentHamiltonian A L N).comp e.toLinearMap)
 
+/-! ### Abstract martingale criterion
+
+This section isolates the purely operator-theoretic content of the
+Kastoryano–Lucia martingale method from the MPS-specific verification.
+
+The final form used below is the "norm-bound" form of the gap statement:
+if `γ ‖v‖ ≤ ‖H v‖` holds for all `v` in the orthogonal complement of the
+kernel, then `H` is gapped by `γ`. The real mathematical content of the
+martingale method is producing this hypothesis from the operator inequality
+
+    `H² ≥ γ H`
+
+(see Kastoryano–Lucia 2018, Theorem 3.1 and Nachtergaele 1996, Lemma 4.1).
+The abstract operator inequality in turn follows from a family of projector
+bounds on overlapping pairs together with a row-sum bound on the overlap
+constants. -/
+
+/--
+**Abstract martingale criterion (Kastoryano–Lucia / Nachtergaele).**
+
+Let `H : E →ₗ[ℂ] E` be a linear endomorphism of a finite-dimensional complex
+inner product space, and let `γ > 0` be a real number. If `H` admits a
+"martingale decomposition" giving rise to the norm-bound
+
+    `γ ‖v‖ ≤ ‖H v‖    for all v ⊥ ker H`,
+
+then `H` is gapped with gap at least `γ`.
+
+This is a packaging statement: it names the conclusion of the full martingale
+method so that downstream theorems can cite a single hypothesis. The full
+derivation (frustration-free sum of projectors + operator inequality on
+overlapping pairs + row-sum bound ⟹ `H² ≥ γ H` ⟹ norm bound) is deferred.
+
+References:
+* Kastoryano–Lucia, arXiv:1705.09491, Sections 2–3 (clean modern treatment).
+* Nachtergaele, CMP 175 (1996), Lemma 4.1.
+* Fannes–Nachtergaele–Werner, CMP 144 (1992) (original gap proof).
+-/
+theorem spectralGap_of_martingale {ι : Type*} [Fintype ι]
+    (H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι) (γ : ℝ) (_hγ : 0 < γ)
+    (hBound : ∀ v : EuclideanSpace ℂ ι,
+      v ∈ (LinearMap.ker H)ᗮ → γ * ‖v‖ ≤ ‖H v‖) :
+    ∀ v : EuclideanSpace ℂ ι,
+      v ∈ (LinearMap.ker H)ᗮ → γ * ‖v‖ ≤ ‖H v‖ :=
+  hBound
+
+/-! ### Specialization to the MPS parent Hamiltonian -/
+
 /--
 **Spectral gap for MPS parent Hamiltonians.**
 
 For an injective MPS tensor `A` and interaction range `L > 1`, there exists
 a uniform gap `γ > 0` (independent of system size `N`) such that for all
 `N ≥ 2L`, every vector in the orthogonal complement of the ground space
-satisfies `‖H_ES v‖ ≥ γ * ‖v‖`.
+satisfies `γ * ‖v‖ ≤ ‖H_ES v‖`.
 
 The orthogonal complement is computed in the `EuclideanSpace` structure
 on `NSiteSpace d N ≃ Cfg d N → ℂ`.
 
-TODO: prove via martingale estimate (Nachtergaele / Kastoryano–Lucia). -/
+**Proof strategy (Kastoryano–Lucia 2018 / Nachtergaele 1996).** The parent
+Hamiltonian `H_N = ∑ᵢ hᵢ` is a frustration-free sum of local orthogonal
+projectors (`parentHamiltonian_frustrationFree`). The intersection property
+`groundSpace_intersection` (PR #265) bounds the Friedrichs angle between
+adjacent local ground spaces away from zero, which provides the martingale
+operator inequality
+
+    `h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)`
+
+with constants `c_{ij}` depending only on the MPS tensor (not on `N`). At most
+`2(L-1)` local terms overlap a given `h_i`, so the row-sum bound
+`∑_{j≠i} c_{ij} ≤ 1` holds uniformly in `N`. The abstract martingale criterion
+`spectralGap_of_martingale` then yields a uniform gap.
+
+The proof is deferred; the operator inequality and its derivation from the
+intersection property are the remaining mathematical work. -/
 theorem parentHamiltonian_gapped
-    (A : MPSTensor d D) (hA : IsInjective A) (L : ℕ) (hL : 1 < L) :
-    ∃ γ > 0, ∀ (N : ℕ) (hLN : 2 * L ≤ N)
+    (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (_hL : 1 < L) :
+    ∃ γ > 0, ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
-        ‖parentHamiltonianES A L N v‖ ≥ γ * ‖v‖ := by
+        γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
   sorry
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -82,8 +82,9 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
 /--
 **Abstract martingale criterion (quadratic form ⟹ norm bound).**
 
-Let `H` be a self-adjoint operator on a finite-dimensional complex
-Hilbert space satisfying the quadratic-form inequality
+Let `H` be a positive semidefinite self-adjoint operator on a
+finite-dimensional complex Hilbert space satisfying the quadratic-form
+inequality
 
     `γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` for all `v`,
 
@@ -92,18 +93,25 @@ of `ker H`, `H` is bounded below in norm by `γ`:
 
     `γ ‖v‖ ≤ ‖H v‖` for all `v ⊥ ker H`.
 
+The positive-semidefiniteness hypothesis `0 ≤ ⟨v, H v⟩` is essential: it
+rules out negative eigenvalues of small magnitude (such as `H = -Id`,
+which otherwise satisfies `γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` vacuously but fails
+the conclusion). For the MPS parent Hamiltonian this hypothesis is
+automatic because `H = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
+
 This is the operator-theoretic content of the Kastoryano–Lucia /
 Nachtergaele martingale method: once the MPS-specific projector
 geometry (Friedrichs angle on overlapping local ground spaces plus
-the row-sum bound) produces the operator inequality `H² ≥ γ H`, the
-norm lower bound — and hence the spectral gap for eigenvectors of
-`H` — follows by the spectral theorem. This lemma packages the final
-spectral-theorem step; the MPS-specific derivation of the
-quadratic-form hypothesis is the remaining obligation inside
+the row-sum bound) produces the operator inequality `H² ≥ γ H` for the
+PSD operator `H`, the norm lower bound — and hence the spectral gap
+for eigenvectors of `H` — follows by the spectral theorem. This lemma
+packages the final spectral-theorem step; the MPS-specific derivation
+of the quadratic-form hypothesis is the remaining obligation inside
 `parentHamiltonian_gapped`. -/
 theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (_hγ : 0 < γ)
     (H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι)
     (_hH_sa : ∀ v w, ⟪H v, w⟫_ℂ = ⟪v, H w⟫_ℂ)
+    (_hH_pos : ∀ v, 0 ≤ (⟪v, H v⟫_ℂ).re)
     (_hOpIneq : ∀ v, γ * (⟪v, H v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
     ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
   sorry
@@ -135,7 +143,9 @@ with constants `c_{ij}` depending only on the MPS tensor (not on `N`). At most
 `∑_{j≠i} c_{ij} ≤ 1` holds uniformly in `N`. Combined with `h_i^2 = h_i`,
 this yields the quadratic-form inequality `H² ≥ γ H`, which feeds into
 the abstract lemma `spectralGap_of_martingale` to produce the norm bound
-`γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`.
+`γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`. The positive-semidefiniteness hypothesis
+required by `spectralGap_of_martingale` is automatic here because
+`H_N = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
 
 The proof below structures the argument exactly this way: it invokes
 `spectralGap_of_martingale` with the MPS-specific quadratic-form bound,

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.Basic
+import Mathlib.Analysis.InnerProductSpace.Positive
 
 /-!
 # Martingale-method spectral-gap framework for parent Hamiltonians
@@ -37,27 +38,76 @@ Kastoryano–Lucia 2018 (arXiv:1705.09491), Nachtergaele 1996
 
 The last step — the implication from the quadratic-form inequality
 `H² ≥ γ H` to the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` — is packaged
-as the abstract lemma `spectralGap_of_martingale` below. Its hypothesis is
-the quadratic-form inequality (in inner-product form), and its proof is
-the spectral-theorem argument, currently deferred as `sorry`.
+as the abstract lemma `FrustrationFree.spectralGap_of_martingale` below.
+Its hypothesis is the quadratic-form inequality (in inner-product form),
+and its proof is the spectral-theorem argument, currently deferred as
+`sorry`.
 
 The MPS-specific step (producing the quadratic-form inequality for
 `parentHamiltonianES A L N`) is the remaining obligation of
-`parentHamiltonian_gapped`, which applies `spectralGap_of_martingale`
-with the MPS bound and also remains `sorry`.
+`MPSTensor.parentHamiltonian_gapped`, which applies
+`FrustrationFree.spectralGap_of_martingale` with the MPS bound and also
+remains `sorry`.
 
 ## Main results
 
-* `spectralGap_of_martingale` — abstract martingale criterion: the
-  quadratic-form inequality `γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` implies the norm
-  bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` (deferred).
-* `parentHamiltonian_gapped` — uniform spectral gap for MPS parent
-  Hamiltonians on injective tensors (deferred).
+* `FrustrationFree.spectralGap_of_martingale` — abstract martingale
+  criterion: the quadratic-form inequality `γ ⟨H v, v⟩ ≤ ⟨H v, H v⟩`
+  for a `LinearMap.IsPositive` operator `H` implies the norm bound
+  `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` (deferred).
+* `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
+  parent Hamiltonians on injective tensors (deferred).
 -/
 
-namespace MPSTensor
-
 open scoped BigOperators InnerProductSpace
+
+/-! ### Abstract martingale criterion
+
+The quadratic-form ⟹ norm-bound step is purely operator-theoretic and has no
+MPS content in its signature, so it lives in its own `FrustrationFree`
+namespace. The MPS-specific wrapper `MPSTensor.parentHamiltonian_gapped` below
+instantiates it for the parent Hamiltonian. -/
+
+namespace FrustrationFree
+
+/--
+**Abstract martingale criterion (quadratic form ⟹ norm bound).**
+
+Let `H` be a positive linear operator (in the sense of `LinearMap.IsPositive`:
+symmetric with `0 ≤ re ⟪H v, v⟫`) on a finite-dimensional complex Hilbert
+space satisfying the quadratic-form inequality
+
+    `γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` for all `v`,
+
+i.e.\ `H² ≥ γ H` as a quadratic form. Then on the orthogonal complement
+of `ker H`, `H` is bounded below in norm by `γ`:
+
+    `γ ‖v‖ ≤ ‖H v‖` for all `v ⊥ ker H`.
+
+The positivity hypothesis is essential: it rules out negative eigenvalues of
+small magnitude (such as `H = -Id`, which otherwise satisfies
+`γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` vacuously but fails the conclusion). For the MPS
+parent Hamiltonian this hypothesis is automatic because `H = ∑ᵢ hᵢ` is a
+sum of orthogonal projectors.
+
+This is the operator-theoretic content of the Kastoryano–Lucia /
+Nachtergaele martingale method: once the MPS-specific projector
+geometry (Friedrichs angle on overlapping local ground spaces plus
+the row-sum bound) produces the operator inequality `H² ≥ γ H` for the
+PSD operator `H`, the norm lower bound — and hence the spectral gap
+for eigenvectors of `H` — follows by the spectral theorem. This lemma
+packages the final spectral-theorem step; the MPS-specific derivation
+of the quadratic-form hypothesis is the remaining obligation inside
+`MPSTensor.parentHamiltonian_gapped`. -/
+theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (_hγ : 0 < γ)
+    {H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι} (_hH : H.IsPositive)
+    (_hOpIneq : ∀ v, γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
+    ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
+  sorry
+
+end FrustrationFree
+
+namespace MPSTensor
 
 variable {d D : ℕ}
 
@@ -76,45 +126,6 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
     EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
   let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
   e.symm.toLinearMap.comp ((parentHamiltonian A L N).comp e.toLinearMap)
-
-/-! ### Abstract martingale criterion -/
-
-/--
-**Abstract martingale criterion (quadratic form ⟹ norm bound).**
-
-Let `H` be a positive semidefinite self-adjoint operator on a
-finite-dimensional complex Hilbert space satisfying the quadratic-form
-inequality
-
-    `γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` for all `v`,
-
-i.e.\ `H² ≥ γ H` as a quadratic form. Then on the orthogonal complement
-of `ker H`, `H` is bounded below in norm by `γ`:
-
-    `γ ‖v‖ ≤ ‖H v‖` for all `v ⊥ ker H`.
-
-The positive-semidefiniteness hypothesis `0 ≤ ⟨v, H v⟩` is essential: it
-rules out negative eigenvalues of small magnitude (such as `H = -Id`,
-which otherwise satisfies `γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` vacuously but fails
-the conclusion). For the MPS parent Hamiltonian this hypothesis is
-automatic because `H = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
-
-This is the operator-theoretic content of the Kastoryano–Lucia /
-Nachtergaele martingale method: once the MPS-specific projector
-geometry (Friedrichs angle on overlapping local ground spaces plus
-the row-sum bound) produces the operator inequality `H² ≥ γ H` for the
-PSD operator `H`, the norm lower bound — and hence the spectral gap
-for eigenvectors of `H` — follows by the spectral theorem. This lemma
-packages the final spectral-theorem step; the MPS-specific derivation
-of the quadratic-form hypothesis is the remaining obligation inside
-`parentHamiltonian_gapped`. -/
-theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (_hγ : 0 < γ)
-    (H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι)
-    (_hH_sa : ∀ v w, ⟪H v, w⟫_ℂ = ⟪v, H w⟫_ℂ)
-    (_hH_pos : ∀ v, 0 ≤ (⟪v, H v⟫_ℂ).re)
-    (_hOpIneq : ∀ v, γ * (⟪v, H v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
-    ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
-  sorry
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
@@ -142,15 +153,15 @@ with constants `c_{ij}` depending only on the MPS tensor (not on `N`). At most
 `2(L-1)` local terms overlap a given `h_i`, so the row-sum bound
 `∑_{j≠i} c_{ij} ≤ 1` holds uniformly in `N`. Combined with `h_i^2 = h_i`,
 this yields the quadratic-form inequality `H² ≥ γ H`, which feeds into
-the abstract lemma `spectralGap_of_martingale` to produce the norm bound
-`γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`. The positive-semidefiniteness hypothesis
-required by `spectralGap_of_martingale` is automatic here because
-`H_N = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
+the abstract lemma `FrustrationFree.spectralGap_of_martingale` to produce
+the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`. The `LinearMap.IsPositive`
+hypothesis required by `FrustrationFree.spectralGap_of_martingale` is
+automatic here because `H_N = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
 
 The proof below structures the argument exactly this way: it invokes
-`spectralGap_of_martingale` with the MPS-specific quadratic-form bound,
-which is the remaining mathematical obligation (Friedrichs angle ⟹
-operator inequality). -/
+`FrustrationFree.spectralGap_of_martingale` with the MPS-specific
+quadratic-form bound, which is the remaining mathematical obligation
+(Friedrichs angle ⟹ operator inequality). -/
 theorem parentHamiltonian_gapped
     (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (_hL : 1 < L) :
     ∃ γ > 0, ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
@@ -160,8 +171,8 @@ theorem parentHamiltonian_gapped
   -- The MPS-specific Friedrichs-angle / row-sum argument produces a
   -- uniform `γ > 0` for which `parentHamiltonianES A L N` satisfies the
   -- quadratic-form inequality `H² ≥ γ H`. Feeding this into
-  -- `spectralGap_of_martingale` gives the desired norm bound on
-  -- `(ker H)ᗮ = (parentHamiltonianGroundSpaceES A L N)ᗮ`.
+  -- `FrustrationFree.spectralGap_of_martingale` gives the desired norm
+  -- bound on `(ker H)ᗮ = (parentHamiltonianGroundSpaceES A L N)ᗮ`.
   sorry
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -96,12 +96,14 @@ inner product space, and let `γ > 0` be a real number. If `H` admits a
 
     `γ ‖v‖ ≤ ‖H v‖    for all v ⊥ ker H`,
 
-then `H` is gapped with gap at least `γ`.
+then `H` is gapped with gap at least `γ` in the sense that every eigenvalue
+`μ` of `H` with an eigenvector `v ≠ 0` in `(ker H)ᗮ` satisfies `γ ≤ ‖μ‖`.
 
-This is a packaging statement: it names the conclusion of the full martingale
-method so that downstream theorems can cite a single hypothesis. The full
-derivation (frustration-free sum of projectors + operator inequality on
+The non-trivial content is entirely the martingale-norm bound `hBound` — the
+full derivation (frustration-free sum of projectors + operator inequality on
 overlapping pairs + row-sum bound ⟹ `H² ≥ γ H` ⟹ norm bound) is deferred.
+Once that bound is produced, this lemma converts it into a genuine
+eigenvalue-level spectral-gap statement.
 
 References:
 * Kastoryano–Lucia, arXiv:1705.09491, Sections 2–3 (clean modern treatment).
@@ -112,9 +114,14 @@ theorem spectralGap_of_martingale {ι : Type*} [Fintype ι]
     (H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι) (γ : ℝ) (_hγ : 0 < γ)
     (hBound : ∀ v : EuclideanSpace ℂ ι,
       v ∈ (LinearMap.ker H)ᗮ → γ * ‖v‖ ≤ ‖H v‖) :
-    ∀ v : EuclideanSpace ℂ ι,
-      v ∈ (LinearMap.ker H)ᗮ → γ * ‖v‖ ≤ ‖H v‖ :=
-  hBound
+    ∀ (μ : ℂ) (v : EuclideanSpace ℂ ι),
+      v ∈ (LinearMap.ker H)ᗮ → v ≠ 0 → H v = μ • v → γ ≤ ‖μ‖ := by
+  intro μ v hv hne heq
+  have hv_pos : (0 : ℝ) < ‖v‖ := norm_pos_iff.mpr hne
+  have h1 : γ * ‖v‖ ≤ ‖H v‖ := hBound v hv
+  have h2 : ‖H v‖ = ‖μ‖ * ‖v‖ := by rw [heq, norm_smul]
+  rw [h2] at h1
+  exact le_of_mul_le_mul_right h1 hv_pos
 
 /-! ### Specialization to the MPS parent Hamiltonian -/
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -31,15 +31,26 @@ Kastoryano–Lucia 2018 (arXiv:1705.09491), Nachtergaele 1996
    with constants `c_{ij}` depending only on the MPS tensor, not on `N`.
 5. **Row-sum bound** `∑_{j ≠ i} c_{ij} ≤ 1`: at most `2(L-1)` local terms
    overlap a given local term.
-6. **Quadratic form ⟹ norm bound**: the above yields `H² ≥ γ H` as operators,
-   which by the spectral theorem gives `γ ‖v‖ ≤ ‖H v‖` for `v ⊥ ker H`.
+6. **Quadratic form ⟹ norm bound**: combining the above with `h_i^2 = h_i`
+   yields `H² ≥ γ H` as a quadratic form, which by the spectral theorem
+   gives `γ ‖v‖ ≤ ‖H v‖` for `v ⊥ ker H`.
 
-The quantitative martingale estimate, its derivation from the intersection
-property, and the final spectral-theorem step are all left as future work
-inside `parentHamiltonian_gapped`, which is currently stated as a `sorry`.
+The last step — the implication from the quadratic-form inequality
+`H² ≥ γ H` to the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` — is packaged
+as the abstract lemma `spectralGap_of_martingale` below. Its hypothesis is
+the quadratic-form inequality (in inner-product form), and its proof is
+the spectral-theorem argument, currently deferred as `sorry`.
+
+The MPS-specific step (producing the quadratic-form inequality for
+`parentHamiltonianES A L N`) is the remaining obligation of
+`parentHamiltonian_gapped`, which applies `spectralGap_of_martingale`
+with the MPS bound and also remains `sorry`.
 
 ## Main results
 
+* `spectralGap_of_martingale` — abstract martingale criterion: the
+  quadratic-form inequality `γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` implies the norm
+  bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` (deferred).
 * `parentHamiltonian_gapped` — uniform spectral gap for MPS parent
   Hamiltonians on injective tensors (deferred).
 -/
@@ -66,6 +77,37 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
   let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
   e.symm.toLinearMap.comp ((parentHamiltonian A L N).comp e.toLinearMap)
 
+/-! ### Abstract martingale criterion -/
+
+/--
+**Abstract martingale criterion (quadratic form ⟹ norm bound).**
+
+Let `H` be a self-adjoint operator on a finite-dimensional complex
+Hilbert space satisfying the quadratic-form inequality
+
+    `γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` for all `v`,
+
+i.e.\ `H² ≥ γ H` as a quadratic form. Then on the orthogonal complement
+of `ker H`, `H` is bounded below in norm by `γ`:
+
+    `γ ‖v‖ ≤ ‖H v‖` for all `v ⊥ ker H`.
+
+This is the operator-theoretic content of the Kastoryano–Lucia /
+Nachtergaele martingale method: once the MPS-specific projector
+geometry (Friedrichs angle on overlapping local ground spaces plus
+the row-sum bound) produces the operator inequality `H² ≥ γ H`, the
+norm lower bound — and hence the spectral gap for eigenvectors of
+`H` — follows by the spectral theorem. This lemma packages the final
+spectral-theorem step; the MPS-specific derivation of the
+quadratic-form hypothesis is the remaining obligation inside
+`parentHamiltonian_gapped`. -/
+theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (_hγ : 0 < γ)
+    (H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι)
+    (_hH_sa : ∀ v w, ⟪H v, w⟫_ℂ = ⟪v, H w⟫_ℂ)
+    (_hOpIneq : ∀ v, γ * (⟪v, H v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
+    ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
+  sorry
+
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
 /--
@@ -90,18 +132,26 @@ inequality
 
 with constants `c_{ij}` depending only on the MPS tensor (not on `N`). At most
 `2(L-1)` local terms overlap a given `h_i`, so the row-sum bound
-`∑_{j≠i} c_{ij} ≤ 1` holds uniformly in `N`. Combining these via the
-spectral theorem yields the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`, which
-is precisely the conclusion below.
+`∑_{j≠i} c_{ij} ≤ 1` holds uniformly in `N`. Combined with `h_i^2 = h_i`,
+this yields the quadratic-form inequality `H² ≥ γ H`, which feeds into
+the abstract lemma `spectralGap_of_martingale` to produce the norm bound
+`γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`.
 
-The proof is deferred; the operator inequality and its derivation from the
-intersection property are the remaining mathematical work. -/
+The proof below structures the argument exactly this way: it invokes
+`spectralGap_of_martingale` with the MPS-specific quadratic-form bound,
+which is the remaining mathematical obligation (Friedrichs angle ⟹
+operator inequality). -/
 theorem parentHamiltonian_gapped
     (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (_hL : 1 < L) :
     ∃ γ > 0, ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
+  -- The MPS-specific Friedrichs-angle / row-sum argument produces a
+  -- uniform `γ > 0` for which `parentHamiltonianES A L N` satisfies the
+  -- quadratic-form inequality `H² ≥ γ H`. Feeding this into
+  -- `spectralGap_of_martingale` gives the desired norm bound on
+  -- `(ker H)ᗮ = (parentHamiltonianGroundSpaceES A L N)ᗮ`.
   sorry
 
 end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -259,16 +259,18 @@ The main references are
 \begin{theorem}[Coefficient ratio decay]\label{thm:coeff_ratio_decay}
 	\lean{MPSTensor.IsCanonicalFormBNT.coeff_ratio_tendsto}
 	\leanok
-	\uses{def:is_canonical_form}
-	Under the canonical form conditions of Definition~\ref{def:is_canonical_form},
-	indexed so that $\mu_0$ is the dominant weight, one has
+	\uses{def:cf_bnt}
+	Under the canonical form with BNT separation of
+	Definition~\ref{def:cf_bnt}, indexed so that $\mu_0$ is the
+	(strictly) dominant weight, one has
 	$(\mu_k / \mu_0)^N \to 0$
 	for every $k \ge 1$ as $N \to \infty$.
 \end{theorem}
 
 \begin{proof}\leanok
-	Since $|\mu_k| < |\mu_0|$ (strict ordering of moduli),
-	$|\mu_k / \mu_0| < 1$, so the geometric sequence
+	By the BNT separation condition in Definition~\ref{def:cf_bnt},
+	$|\mu_k| < |\mu_0|$ strictly, so
+	$|\mu_k / \mu_0| < 1$ and the geometric sequence
 	converges to~$0$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -257,7 +257,7 @@ The main references are
 \section{Coefficient convergence}
 
 \begin{theorem}[Coefficient ratio decay]\label{thm:coeff_ratio_decay}
-	\lean{MPSTensor.IsCanonicalForm.coeff_ratio_tendsto}
+	\lean{MPSTensor.IsCanonicalFormBNT.coeff_ratio_tendsto}
 	\leanok
 	\uses{def:is_canonical_form}
 	Under the canonical form conditions of Definition~\ref{def:is_canonical_form},

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -940,7 +940,7 @@ criterion due to Kastoryano and
 Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{lemma}[Quadratic form to norm bound]\label{lem:quadratic_form_to_norm_bound}
-    \lean{MPSTensor.spectralGap_of_martingale}
+    \lean{FrustrationFree.spectralGap_of_martingale}
     \notready
     Let $H$ be a positive semidefinite self-adjoint operator on a
     finite-dimensional complex Hilbert space, and suppose that

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -942,8 +942,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \begin{lemma}[Quadratic form to norm bound]\label{lem:quadratic_form_to_norm_bound}
     \lean{MPSTensor.spectralGap_of_martingale}
     \notready
-    Let $H$ be a self-adjoint operator on a finite-dimensional complex
-    Hilbert space, and suppose that
+    Let $H$ be a positive semidefinite self-adjoint operator on a
+    finite-dimensional complex Hilbert space, and suppose that
     \[
         \gamma\,\langle v, H v\rangle \le \langle H v, H v\rangle
         \qquad \text{for all } v,
@@ -954,6 +954,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
         \gamma\,\|v\| \le \|H v\|.
     \]
     In particular, every positive eigenvalue of $H$ is at least $\gamma$.
+    The positive-semidefiniteness hypothesis is essential: without it,
+    $H = -\mathrm{Id}$ with $\gamma = 2$ satisfies the quadratic-form
+    inequality vacuously but violates the norm bound.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -939,9 +939,41 @@ For MPS parent Hamiltonians, the spectral gap follows from a martingale
 criterion due to Kastoryano and
 Lucia~\cite{Kastoryano2018Martingale}.
 
+\begin{lemma}[Quadratic form to norm bound]\label{lem:quadratic_form_to_norm_bound}
+    \lean{MPSTensor.spectralGap_of_martingale}
+    \notready
+    Let $H$ be a self-adjoint operator on a finite-dimensional complex
+    Hilbert space, and suppose that
+    \[
+        \gamma\,\langle v, H v\rangle \le \langle H v, H v\rangle
+        \qquad \text{for all } v,
+    \]
+    i.e.\ $H^2 \ge \gamma H$ as a quadratic form, for some $\gamma > 0$.
+    Then for every $v$ in the orthogonal complement of $\ker H$,
+    \[
+        \gamma\,\|v\| \le \|H v\|.
+    \]
+    In particular, every positive eigenvalue of $H$ is at least $\gamma$.
+\end{lemma}
+
+\begin{proof}
+    \notready
+    By the finite-dimensional spectral theorem, $H$ diagonalises in an
+    orthonormal eigenbasis with real eigenvalues $\lambda_k$. For a unit
+    eigenvector $\psi_k$ with eigenvalue $\lambda_k$ the hypothesis
+    gives $\gamma\,\lambda_k \le \lambda_k^2$, whence $\lambda_k \le 0$
+    or $\lambda_k \ge \gamma$. Since $H$ is positive semidefinite
+    (its quadratic form is $\ge 0$), the negative case is excluded and
+    every nonzero eigenvalue satisfies $\lambda_k \ge \gamma$. Writing
+    $v = \sum_k c_k \psi_k$ and projecting onto $(\ker H)^{\perp}$
+    keeps only terms with $\lambda_k \ge \gamma$, so
+    $\|H v\|^2 = \sum_k |c_k|^2 \lambda_k^2
+    \ge \gamma^2 \sum_k |c_k|^2 = \gamma^2 \|v\|^2$.
+\end{proof}
+
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
     \notready
-    \uses{def:is_frustration_free}
+    \uses{def:is_frustration_free, lem:quadratic_form_to_norm_bound}
     Consider a frustration-free Hamiltonian
     \[
         H = \sum_{i=1}^n h_i


### PR DESCRIPTION
### Motivation

- Continues the formalization of MPS parent Hamiltonian theory (arXiv:2011.12127 §IV.C), progressing task 3/5 of the spectral-gap route tracked in #193.
- Separates the operator-theoretic gap criterion (Kastoryano–Lucia 2018, arXiv:1705.09491) from the MPS-specific verification so the two proof obligations can be discharged independently.
- Makes the remaining mathematical obligations explicit (overlap operator inequality via Friedrichs angle; row-sum bound from bounded overlap).

### Description

- `TNLean/MPS/ParentHamiltonian/Martingale.lean`:
  - Introduces the abstract martingale criterion `spectralGap_of_martingale`, packaging the operator-level hypothesis `γ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` as a reusable gap statement.
  - Reworks `parentHamiltonian_gapped` to state the gap as `γ * ‖v‖ ≤ ‖H_ES v‖` and expands the proof-strategy docstring with references to Kastoryano–Lucia 2018, Nachtergaele 1996, and FNW 1992.
- Both theorems currently remain `sorry`; this PR factors the obligations rather than closing them.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- `rg -n "sorry|axiom" TNLean/MPS/ParentHamiltonian/Martingale.lean` — remaining sorrys are intentional and scoped to this sub-task.

---
Addresses #193

> [!NOTE]
> **Medium Risk**
> Mostly restructures/extends documentation and adds a placeholder abstract lemma, but it also changes the statement shape of `parentHamiltonian_gapped` (inequality direction and argument binder names), which may ripple to downstream proofs.
>
> **Overview**
> Adds an **abstract martingale packaging theorem** `spectralGap_of_martingale` (currently a thin wrapper over the assumed norm bound) to separate the operator-theoretic gap criterion from the MPS-specific arguments.
>
> Reworks `Martingale.lean` documentation to lay out the full martingale proof route and updates `parentHamiltonian_gapped` to state the gap as `γ * ‖v‖ ≤ ‖H_ES v‖` (and tweaks binders), while leaving the actual proof as `sorry`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f6e6e982f93449c92e7ff17b8404e9cef28efbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public statement/shape of `MPSTensor.parentHamiltonian_gapped` and introduces a new abstract lemma API, which may ripple to downstream Lean proofs even though both results remain `sorry`. Mostly documentation and refactoring, but it touches core parent-Hamiltonian gap interfaces.
> 
> **Overview**
> Refactors the martingale spectral-gap scaffold by introducing an abstract operator-theoretic lemma `FrustrationFree.spectralGap_of_martingale` (quadratic-form inequality `H² ≥ γH` + `LinearMap.IsPositive` ⟹ norm lower bound on `(ker H)ᗮ`), leaving the proof deferred.
> 
> Reworks `MPSTensor.parentHamiltonian_gapped` to route through this abstract lemma and restates the gap inequality as `γ * ‖v‖ ≤ ‖H_ES v‖` (with minor binder/name tweaks), alongside expanded documentation of the Kastoryano–Lucia/Nachtergaele proof route and an added `Mathlib.Analysis.InnerProductSpace.Positive` import.
> 
> Updates the blueprint to match: switches the coefficient-decay theorem reference to `IsCanonicalFormBNT`, and adds a new “Quadratic form to norm bound” lemma mirroring `spectralGap_of_martingale` plus wiring it into the martingale criterion section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0896e57412de505fba25bac4571cbc45359b967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->