### PR TITLE
feat(Channel/Peripheral): add CycleStructure for Wolf Thm 6.16

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -273,6 +273,7 @@ import TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan
 import TNLean.Wielandt.QuantumWielandt
 
 import TNLean.Channel.Peripheral.CyclicDecomposition
+import TNLean.Channel.Peripheral.Cycles
 
 -- Public documentation index modules
 import TNLean.Channel.WolfChapter2Index

--- a/TNLean/Channel/Peripheral/Cycles.lean
+++ b/TNLean/Channel/Peripheral/Cycles.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Peripheral.CyclicDecomposition
+
+/-!
+# Wolf Theorem 6.16 — block-permutation cycle structure
+
+This file packages the *block-permutation* side of
+Wolf, *Quantum Channels & Operations*, Theorem 6.16, on top of the existing
+cyclic-decomposition infrastructure.
+
+Thm. 6.16 describes the asymptotic dynamics of a general trace-preserving
+positive Schwarz map `T` as acting on a direct sum of equal-size blocks by
+conjugation with a unitary followed by a permutation of the blocks.  Concretely
+
+  T(X) = 0 ⊕ ⊕ₖ U_k · X_{π(k)} · U_k† ⊗ ρ_k
+
+for a suitable permutation `π`.
+
+The current file isolates and formalizes the *block-permutation* data
+(the projection family together with the permutation `π`) as a reusable
+structure `CycleStructure T`.  All results below are sorry-free.
+
+The remaining *existence* direction of Thm. 6.16 — that every TP positive
+Schwarz map admits such a block-permutation decomposition on its asymptotic
+image — relies on Wolf Thm. 6.14 (Wedderburn decomposition of the
+fixed-point algebra, issues #27/#360) and is left to future work.
+
+## Main definitions
+
+* `CycleStructure T` — bundled block-permutation data for `T`: a finite
+  family of orthogonal projections `P : ι → M_D(ℂ)`, a permutation
+  `σ : Equiv.Perm ι`, the block-permutation compatibility
+  `T (P (σ k)) = P k`, and the multiplicative-domain factorisation
+  properties `T (P k · X) = T (P k) · T X` and `T (X · P k) = T X · T (P k)`.
+
+## Main results
+
+* `CycleStructure.map_proj_pow` — `T^n (P (σ^n k)) = P k`.
+
+* `CycleStructure.preserves_corner_pow_orderOf` — `T ^ orderOf σ` preserves
+  each corner `P k · M_D(ℂ) · P k`.  This is the corner-preservation half
+  of Wolf Thm. 6.16 in its permutation-of-blocks form and is the basis for
+  descending the dynamics of `T ^ orderOf σ` to each block.
+
+* `CycleStructure.ofPermDecomp` — convenient constructor from raw
+  permutation-decomposition data.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Thm. 6.16, §6.5]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset Complex
+
+variable {D : ℕ}
+
+/-- Bundled data for the **block-permutation form** of Wolf Theorem 6.16.
+
+A `CycleStructure T` records a finite family of orthogonal projections
+`P : ι → M_D(ℂ)` on equal-size blocks together with a permutation
+`σ : Equiv.Perm ι` and the compatibility conditions that govern the
+permutation dynamics of `T` on the corresponding corners:
+
+* `permute` — `T` permutes the projections via `σ`, i.e. `T (P (σ k)) = P k`.
+  This captures the block-permutation action of `T` on the Wedderburn
+  decomposition of the asymptotic image.
+* `mulLeft` / `mulRight` — each `P k` lies in the multiplicative domain
+  of `T` (abstract Schwarz-map consequence).
+
+This is the block-permutation data appearing in the asymptotic image of a
+general trace-preserving positive Schwarz map, after the Wedderburn /
+cyclic-sector decomposition has been carried out. -/
+structure CycleStructure (T : MatrixEnd D) where
+  /-- Finite index type for the blocks. -/
+  ι : Type
+  /-- `ι` is finite. -/
+  [fintype : Fintype ι]
+  /-- `ι` has decidable equality. -/
+  [decidableEq : DecidableEq ι]
+  /-- The family of block projections. -/
+  P : ι → MatrixAlg D
+  /-- Each `P k` is an orthogonal projection. -/
+  isProj : ∀ k : ι, IsOrthogonalProjection (P k)
+  /-- The block-permuting automorphism on block indices. -/
+  σ : Equiv.Perm ι
+  /-- `T` sends the block indexed by `σ k` back to the block indexed by `k`. -/
+  permute : ∀ k : ι, T (P (σ k)) = P k
+  /-- Each `P k` lies in the left multiplicative domain of `T`. -/
+  mulLeft : ∀ k : ι, ∀ X : MatrixAlg D, T (P k * X) = T (P k) * T X
+  /-- Each `P k` lies in the right multiplicative domain of `T`. -/
+  mulRight : ∀ k : ι, ∀ X : MatrixAlg D, T (X * P k) = T X * T (P k)
+
+namespace CycleStructure
+
+attribute [instance] fintype decidableEq
+
+variable {T : MatrixEnd D}
+
+/-- The `n`-th iterate of `T` sends the projection labelled by `σ^n k`
+back to `P k`.  This is the permutation-of-blocks analogue of the
+single-cycle result `(T ^ n) (P (cyclicIndex k n)) = P k` used in the
+irreducible case of Wolf Thm. 6.6. -/
+theorem map_proj_pow (C : CycleStructure T) (n : ℕ) (k : C.ι) :
+    (T ^ n) (C.P ((C.σ ^ n) k)) = C.P k := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      calc
+        (T ^ (n + 1)) (C.P ((C.σ ^ (n + 1)) k))
+            = (T ^ n) (T (C.P ((C.σ ^ (n + 1)) k))) := by
+                simp [pow_succ]
+        _ = (T ^ n) (T (C.P (C.σ ((C.σ ^ n) k)))) := by
+                simp [pow_succ']
+        _ = (T ^ n) (C.P ((C.σ ^ n) k)) := by
+                rw [C.permute ((C.σ ^ n) k)]
+        _ = C.P k := ih
+
+/-- After `orderOf σ` applications of `T`, each projection `P k` returns
+to itself. -/
+theorem pow_orderOf_apply_proj (C : CycleStructure T) (k : C.ι) :
+    (T ^ orderOf C.σ) (C.P k) = C.P k := by
+  have hmain : (T ^ orderOf C.σ) (C.P ((C.σ ^ orderOf C.σ) k)) = C.P k :=
+    C.map_proj_pow (orderOf C.σ) k
+  have hσ : (C.σ ^ orderOf C.σ) = 1 := pow_orderOf_eq_one C.σ
+  simpa [hσ] using hmain
+
+/-- **Wolf Theorem 6.16 — corner preservation.**
+
+The `orderOf σ`-th iterate of `T` preserves each corner
+`P k · M_D(ℂ) · P k`.  This is the fundamental corner-preservation half
+of Wolf Thm. 6.16 in its permutation-of-blocks form and is what allows
+one to descend the dynamics of `T ^ orderOf σ` to each block.
+
+It is obtained by specialising the generic permutation-decomposition
+lemma `preserves_corner_pow_orderOf_of_perm_decomp` to the bundled data
+`C`. -/
+theorem preserves_corner_pow_orderOf (C : CycleStructure T) (k : C.ι) :
+    PreservesCorner (C.P k) (T ^ orderOf C.σ) :=
+  preserves_corner_pow_orderOf_of_perm_decomp
+    (σ := C.σ) (P := C.P) C.isProj C.permute C.mulLeft C.mulRight k
+
+/-- Convenient constructor from raw permutation-decomposition data.
+
+This exposes the hypotheses of `preserves_corner_pow_orderOf_of_perm_decomp`
+as a bundled `CycleStructure`. -/
+def ofPermDecomp
+    {T : MatrixEnd D} {ι : Type} [Fintype ι] [DecidableEq ι]
+    (σ : Equiv.Perm ι) (P : ι → MatrixAlg D)
+    (hPproj : ∀ k : ι, IsOrthogonalProjection (P k))
+    (hperm : ∀ k : ι, T (P (σ k)) = P k)
+    (hMulLeft : ∀ k : ι, ∀ X : MatrixAlg D, T (P k * X) = T (P k) * T X)
+    (hMulRight : ∀ k : ι, ∀ X : MatrixAlg D, T (X * P k) = T X * T (P k)) :
+    CycleStructure T where
+  ι := ι
+  P := P
+  isProj := hPproj
+  σ := σ
+  permute := hperm
+  mulLeft := hMulLeft
+  mulRight := hMulRight
+
+end CycleStructure

--- a/TNLean/Channel/Peripheral/Cycles.lean
+++ b/TNLean/Channel/Peripheral/Cycles.lean
@@ -74,9 +74,9 @@ permutation dynamics of `T` on the corresponding corners:
 This is the block-permutation data appearing in the asymptotic image of a
 general trace-preserving positive Schwarz map, after the Wedderburn /
 cyclic-sector decomposition has been carried out. -/
-structure CycleStructure (T : MatrixEnd D) where
+structure CycleStructure.{u} (T : MatrixEnd D) where
   /-- Finite index type for the blocks. -/
-  ι : Type*
+  ι : Type u
   /-- `ι` is finite. -/
   [fintype : Fintype ι]
   /-- `ι` has decidable equality. -/

--- a/TNLean/Channel/Peripheral/Cycles.lean
+++ b/TNLean/Channel/Peripheral/Cycles.lean
@@ -76,7 +76,7 @@ general trace-preserving positive Schwarz map, after the Wedderburn /
 cyclic-sector decomposition has been carried out. -/
 structure CycleStructure (T : MatrixEnd D) where
   /-- Finite index type for the blocks. -/
-  ι : Type
+  ι : Type*
   /-- `ι` is finite. -/
   [fintype : Fintype ι]
   /-- `ι` has decidable equality. -/
@@ -148,7 +148,7 @@ theorem preserves_corner_pow_orderOf (C : CycleStructure T) (k : C.ι) :
 This exposes the hypotheses of `preserves_corner_pow_orderOf_of_perm_decomp`
 as a bundled `CycleStructure`. -/
 def ofPermDecomp
-    {T : MatrixEnd D} {ι : Type} [Fintype ι] [DecidableEq ι]
+    {T : MatrixEnd D} {ι : Type*} [Fintype ι] [DecidableEq ι]
     (σ : Equiv.Perm ι) (P : ι → MatrixAlg D)
     (hPproj : ∀ k : ι, IsOrthogonalProjection (P k))
     (hperm : ∀ k : ι, T (P (σ k)) = P k)

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -284,12 +284,28 @@ The general irreducible case with period `h > 1` requires Wedderburn blocks
 
 ## §6.5 Cycles and recurrences
 
-### Wolf Theorem 6.16 (Structure of cycles)
+### Wolf Theorem 6.16 (Structure of cycles) — PARTIALLY FORMALIZED
 
-* Partially formalized in `TNLean.Channel.Peripheral.CyclicDecomposition`.
-* Reusable infrastructure for the multi-cycle direction:
-  `preserves_corner_pow_orderOf_of_perm_decomp` (permutation-of-blocks iterate
-  preserves each corner after `orderOf` steps).
+* Reusable infrastructure for the permutation-of-blocks direction lives in
+  `TNLean.Channel.Peripheral.CyclicDecomposition` and
+  `TNLean.Channel.Peripheral.Cycles`:
+  - `preserves_corner_pow_orderOf_of_perm_decomp` — permutation-of-blocks
+    iterate preserves each corner after `orderOf σ` steps.
+  - `CycleStructure T` — bundled block-permutation data: a finite family of
+    orthogonal projections `P : ι → M_D(ℂ)`, a permutation `σ : Equiv.Perm ι`,
+    the compatibility `T (P (σ k)) = P k`, and the multiplicative-domain
+    factorisations `T (P k * X) = T (P k) * T X` and `T (X * P k) = T X * T (P k)`.
+  - `CycleStructure.map_proj_pow` — `T^n (P (σ^n k)) = P k`.
+  - `CycleStructure.pow_orderOf_apply_proj` — `(T ^ orderOf σ) (P k) = P k`.
+  - `CycleStructure.preserves_corner_pow_orderOf` — `T ^ orderOf σ` preserves
+    each corner `P k · M_D(ℂ) · P k`, the corner-preservation half of
+    Thm. 6.16 in its permutation-of-blocks form.
+  - `CycleStructure.ofPermDecomp` — constructor from raw permutation data.
+
+* The remaining **existence direction** — that every trace-preserving positive
+  Schwarz map admits a `CycleStructure` on its asymptotic image, with the
+  blocks coming from the Wedderburn decomposition of the fixed-point algebra
+  — depends on Wolf Thm. 6.14 (issues #27 / #360) and is left to future work.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Continues formalization of Wolf Chapter 6, advancing Thm. 6.16 (full cycle structure beyond the irreducible Schwarz case) — see LionSR/QICLean#40.
- Provides a reusable infrastructure package for the block-permutation data that underlies the general multi-cycle decomposition, building on the existing irreducible / cyclic-sector framework.

### Description

- Adds `TNLean/Channel/Peripheral/Cycles.lean` introducing the `CycleStructure T` record, which bundles Wolf Thm. 6.16's block-permutation hypotheses: a finite family of orthogonal projections `P : ι → M_D(ℂ)`, a permutation `σ : Equiv.Perm ι`, compatibility `T (P (σ k)) = P k`, and the multiplicative-domain factorisation identities.
- Derives sorry-free consequences:
  - `CycleStructure.map_proj_pow` — `T^n (P (σ^n k)) = P k`
  - `CycleStructure.pow_orderOf_apply_proj` — `(T ^ orderOf σ) (P k) = P k`
  - `CycleStructure.preserves_corner_pow_orderOf` — corner preservation via `preserves_corner_pow_orderOf_of_perm_decomp`
  - `CycleStructure.ofPermDecomp` — constructor from raw permutation data
- Updates `TNLean/Channel/WolfChapter6Index.lean` to document the new `CycleStructure` API and record the remaining blocker (Wolf Thm. 6.14 / Wedderburn decomposition, tracked in LionSR/QICLean#39 and LionSR/QICLean#126) for the full existence direction.
- Exports the new module from `TNLean.lean`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate `lake build`.
- New module is sorry-free; verify with `rg -n "sorry|axiom" TNLean/Channel/Peripheral/Cycles.lean || true`.

---
Addresses LionSR/QICLean#40

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR mostly adds a new sorry-free Lean module and updates exports/docs, without changing existing proofs or core semantics. Main risk is minor breakage for downstream imports due to the new root-level re-export.
> 
> **Overview**
> Introduces `TNLean.Channel.Peripheral.Cycles` with a new `CycleStructure T` structure bundling a finite projection family `P`, a block permutation `σ`, and multiplicative-domain factorization hypotheses for Wolf Thm. 6.16’s block-permutation form.
> 
> Adds sorry-free lemmas on this bundle, including `CycleStructure.map_proj_pow`, `CycleStructure.pow_orderOf_apply_proj`, and `CycleStructure.preserves_corner_pow_orderOf` (via `preserves_corner_pow_orderOf_of_perm_decomp`), plus a convenience constructor `CycleStructure.ofPermDecomp`. Re-exports the module from `TNLean.lean` and updates `WolfChapter6Index` documentation to reference the new API and note the remaining existence-direction dependency on Wolf Thm. 6.14.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a2534627a098cbedf4dc8135df302d0b99ec50e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->