### PR TITLE
doc(MPS/ParentHamiltonian): document degenerate GS ⊆ direction TODO

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
+++ b/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
@@ -158,7 +158,7 @@ Given dependency (1) and (2), the ⊆ direction becomes:
 chainGroundSpace (toTensorFromBlocks μ A) L N
   = ⨆ j, (embed_j) (chainGroundSpace (A j) L N)         -- by (1)
   = ⨆ j, (embed_j) (mpvSubmodule (A j) N)               -- by (2)
-  = Submodule.span ℂ (Set.range fun j => mpv (A j))     -- = bntSpan A N
+  = Submodule.span ℂ (Set.range fun j => (mpv (A j) : NSiteSpace d N))  -- = bntSpan A N
 ```
 where the final step uses that the embedding of a block's MPV into the
 assembled tensor is (up to the μ_j^N scalar) the corresponding BNT MPV. -/

--- a/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
+++ b/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
@@ -132,22 +132,49 @@ equals the span of the individual BNT block MPV states.
 
 TODO(#195): prove by combining `bnt_mem_groundSpace` (⊇ direction) with
 blockwise decomposition / uniqueness for the assembled tensor (⊆ direction).
-At present the reverse inclusion still needs a periodic-chain theorem showing
-that a state whose cyclic windows lie in the block-diagonal local ground space
-decomposes globally into block components, together with the normal/blockwise
-unique-ground-state reduction from `UniqueGroundState`. -/
+
+The ⊆ direction requires *two* upstream dependencies, neither currently
+available:
+
+1. **Block-diagonal periodic-chain ground-space decomposition.** A structural
+   theorem of the form
+   `chainGroundSpace (toTensorFromBlocks μ A) L N = ⨆ j, (embed_j) (chainGroundSpace (A j) L N)`,
+   saying that a state whose cyclic windows all lie in the block-diagonal
+   local ground space decomposes (via projectors onto the virtual-space irrep
+   sectors) into a sum of block components. This is the "projectors commute
+   through the tensor" idea from the proof sketch. No periodic-chain block
+   decomposition infrastructure is available in `MPS/Chain/` or
+   `MPS/Structure/` at present.
+
+2. **Blockwise MPV uniqueness** via `chainGroundSpace_eq_mpvSubmodule_normal`
+   in `UniqueGroundState.lean`, which is itself still a `sorry` pending the
+   normal-form range reduction from `2 L₀` to `L₀ + 1`. Each block of a
+   CF-BNT decomposition is normal and `L₀`-block-injective, so this theorem
+   (once proved) identifies each block's chain ground space with its MPV
+   submodule, i.e. exactly one component of `bntSpan`.
+
+Given dependency (1) and (2), the ⊆ direction becomes:
+```
+chainGroundSpace (toTensorFromBlocks μ A) L N
+  = ⨆ j, (embed_j) (chainGroundSpace (A j) L N)         -- by (1)
+  = ⨆ j, (embed_j) (mpvSubmodule (A j) N)               -- by (2)
+  = Submodule.span ℂ (Set.range fun j => mpv (A j))     -- = bntSpan A N
+```
+where the final step uses that the embedding of a block's MPV into the
+assembled tensor is (up to the μ_j^N scalar) the corresponding BNT MPV. -/
 theorem parentHamiltonian_gs_eq_bnt_span
     (A : (j : Fin r) → MPSTensor d (dim j))
     (hCF : IsCanonicalFormBNT μ A) {L N : ℕ} (hL : 1 < L) (hN : N ≥ L + 1) :
     parentHamiltonianGroundSpace (μ := μ) A L N = bntSpan A N := by
   apply le_antisymm
   · -- TODO(#195): reverse inclusion.
-    -- The missing step is to decompose any
-    -- `ψ ∈ parentHamiltonianGroundSpace (μ := μ) A L N`
-    -- into block components coming from the local block-diagonal structure of
-    -- `toTensorFromBlocks μ A`, then apply injective uniqueness to each block.
-    -- This currently depends on periodic-chain block decomposition machinery
-    -- that is not yet available upstream.
+    -- Requires:
+    --  (1) a periodic-chain block-decomposition theorem identifying
+    --      `chainGroundSpace (toTensorFromBlocks μ A) L N` with the supremum
+    --      of embedded blockwise chain ground spaces (not yet formalized);
+    --  (2) `chainGroundSpace_eq_mpvSubmodule_normal` (currently `sorry`) to
+    --      reduce each block's chain ground space to its MPV submodule.
+    -- See the docstring above for the proof outline.
     sorry
   · rw [bntSpan, Submodule.span_le]
     intro ψ hψ


### PR DESCRIPTION
### Motivation

- Issue #195 asks to prove `parentHamiltonian_gs_eq_bnt_span`, relating the parent-Hamiltonian ground space to the span of BNT states. Before attempting the full proof, the remaining missing pieces for the ⊆ direction need to be spelled out so follow-up work can target them directly.
- Makes the dependency on #192 (unique ground state / intersection property) and on a still-unformalized periodic-chain block decomposition explicit in the source.

### Description

- `TNLean/MPS/ParentHamiltonian/DegenerateGS.lean`: expand the docstring and inline commentary on `parentHamiltonian_gs_eq_bnt_span` to enumerate the two specific missing ingredients for the ⊆ direction:
  1. A periodic-chain block-decomposition theorem for `toTensorFromBlocks μ A` (not yet formalized in `MPS/Chain/` or `MPS/Structure/`).
  2. `chainGroundSpace_eq_mpvSubmodule_normal` in `UniqueGroundState.lean` (currently `sorry`-backed).
- Add a high-level proof skeleton showing how (1) and (2) combine to yield the ⊆ inclusion via the block-diagonal structure of `toTensorFromBlocks`.
- No changes to definitions or lemma statements; the theorem remains `sorry` with an updated proof outline and rationale.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #195

> [!NOTE]
> **Low Risk**
> Documentation-only change: expands commentary around an existing `sorry` proof obligation, with no changes to definitions or lemmas used by the code.
>
> **Overview**
> Clarifies the unfinished `parentHamiltonian_gs_eq_bnt_span` theorem by expanding the docstring and inline comments to spell out the missing ⊆-direction dependencies: a periodic-chain block decomposition for `toTensorFromBlocks` and a blockwise uniqueness result from `UniqueGroundState.lean`.
>
> No functional Lean code changes were made; the theorem remains `sorry` with an updated proof outline and rationale.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d927c4738cc358978e1b66ceed698a827ef000fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes: expands comments and proof outline around an existing `sorry` without altering any definitions or theorem statements, so it should not affect behavior beyond text.
> 
> **Overview**
> Clarifies the unfinished `parentHamiltonian_gs_eq_bnt_span` proof in `DegenerateGS.lean` by expanding the docstring and inline TODO for the missing `⊆` inclusion.
> 
> The new documentation explicitly lists the two upstream results needed (a periodic-chain block-diagonal ground-space decomposition for `toTensorFromBlocks` and `chainGroundSpace_eq_mpvSubmodule_normal` from `UniqueGroundState.lean`) and sketches how they would combine to yield `parentHamiltonianGroundSpace = bntSpan`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1217321a4d9e9294978871bb05cc319c1f9a54e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->