### PR TITLE
refactor(MPS/FundamentalTheorem/PeriodicOverlap): factor sectorBlocked normality via bridge lemma

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -363,6 +363,51 @@ theorem periodicOverlap_tendsto_zero_of_ne_period
 
 /-! ## Case 2: Same period, no sector match → orthogonal (Appendix A, second case) -/
 
+/-- **Structural bridge** for Case 3 of Proposition 3.3 (arXiv:1708.00029):
+each nonzero compressed sector block `blocks u` arising from a cyclic sector
+decomposition of a periodic irreducible tensor has both a primitive transfer
+map and is tensor-irreducible.
+
+This is the still-missing identification
+
+  `transferMap (blocks u) ≃ cornerRestriction (P u) ((transferMap Aᴴ)^m)`
+
+threaded through the compression spectral isometry produced by
+`exists_compressedTensor_of_supported_projection` in
+`TNLean/MPS/CanonicalForm/CyclicSectors.lean`. Once that identification is in
+place, primitivity follows from `isPrimitive_restriction_of_cyclic_decomp` in
+`TNLean/Channel/Peripheral/CyclicDecomposition.lean` (which is unconditional),
+and corner irreducibility transports to `IsIrreducibleTensor (blocks u)` via
+the adjoint-side identification together with
+`MPS/Irreducible/Adjoint.lean`.
+
+See issue #450 for the recommended split: (i) close the MPS-level `hLift`
+in `SectorIrreducibility.lean` to expose corner irreducibility of `(E†)^m`,
+(ii) prove `compressedTensor_transferMap_conj` (the compressed ↔ cornerRestriction
+identification), (iii) combine with this helper to discharge
+`sectorBlocked_isNormal_of_isPeriodic`.
+
+Kept as an explicit named sublemma so downstream consumers (`Case 2`,
+`Case 3`) and subsequent PRs can target its statement directly. -/
+private lemma primitive_and_irreducible_sectorBlocks_of_cyclicDecomp
+    [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
+    (hP : IsPeriodic m A)
+    {dim : Fin m → ℕ}
+    (blocks :
+      (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+    (hBlocks_lc :
+      ∀ k, ∑ i : Fin (blockPhysDim d m),
+        (blocks k i)ᴴ * blocks k i = 1)
+    (hBlocks_mpv :
+      SameMPV₂ (blockTensor A m)
+        (toTensorFromBlocks (μ := fun _ => 1) blocks))
+    (hCyclic : IsCyclicSectorDecomp A blocks)
+    (u : Fin m) (hNonzero : dim u ≠ 0) :
+    _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d m) (D := dim u) (blocks u))
+      ∧ IsIrreducibleTensor (blocks u) := by
+  sorry
+
 /-- Case-2 helper for the compressed blocked sector tensors.
 
 The intended mathematical content is Lemma 2.4: after blocking by the period,
@@ -394,7 +439,17 @@ lemma sectorBlocked_isNormal_of_isPeriodic
     (hCyclic : IsCyclicSectorDecomp A blocks)
     (u : Fin m) (hNonzero : dim u ≠ 0) :
     IsNormal (blocks u) := by
-  sorry
+  -- The compressed sector `blocks u` is TP (`hBlocks_lc u`). The structural
+  -- bridge `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp` packages
+  -- primitivity of its transfer map together with tensor-irreducibility; once
+  -- both are in hand, `isNormal_of_tp_primitive_irreducible` concludes.
+  haveI : NeZero (dim u) := ⟨hNonzero⟩
+  obtain ⟨hPrim, hIrr⟩ :=
+    primitive_and_irreducible_sectorBlocks_of_cyclicDecomp
+      A hP blocks hBlocks_lc hBlocks_mpv hCyclic u hNonzero
+  exact
+    isNormal_of_tp_primitive_irreducible
+      (D := dim u) (blocks u) (hBlocks_lc u) hPrim hIrr
 
 /-- Same-period / no-match statement using compressed sector tensors.
 

--- a/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean
@@ -388,8 +388,10 @@ identification), (iii) combine with this helper to discharge
 `sectorBlocked_isNormal_of_isPeriodic`.
 
 Kept as an explicit named sublemma so downstream consumers (`Case 2`,
-`Case 3`) and subsequent PRs can target its statement directly. -/
-private lemma primitive_and_irreducible_sectorBlocks_of_cyclicDecomp
+`Case 3`) and subsequent PRs can target its statement directly — the
+declaration is intentionally non-`private` so that follow-up modules
+(e.g. a dedicated `SectorIrreducibility` bridge) can reference it. -/
+lemma primitive_and_irreducible_sectorBlocks_of_cyclicDecomp
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A)
     {dim : Fin m → ℕ}


### PR DESCRIPTION
### Motivation

- Continues formalization of Proposition 3.3 Case 3 from arXiv:1708.00029 (see #450).
- Relocates an anonymous `sorry` inside `sectorBlocked_isNormal_of_isPeriodic` into a crisply-scoped, well-named helper so downstream PRs can target the missing structural step directly.
- Net `sorry` count is unchanged; this refactor sets up the three-PR split recommended in #450.

### Description

- `TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean`:
  - Introduces a private helper `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp` exposing the missing identification
    `transferMap (blocks u) ≃ cornerRestriction (P u) ((transferMap Aᴴ)^m)`,
    together with its primitivity and tensor-irreducibility consequences.
  - Refactors `sectorBlocked_isNormal_of_isPeriodic` to derive `IsNormal (blocks u)` by instantiating `NeZero (dim u)`, invoking the new helper, and finishing via `isNormal_of_tp_primitive_irreducible`.
- The helper retains a `sorry` for the structural bridge itself; downstream PRs (`hLift` completion in `SectorIrreducibility`, compressed ↔ `cornerRestriction` identification in `CyclicSectors`) can now target this named lemma directly.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate the build.
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/PeriodicOverlap.lean` — net count unchanged by this PR.

---
Addresses #450

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the proof structure for `sectorBlocked_isNormal_of_isPeriodic` and introduces a new (currently `sorry`-backed) bridge lemma that downstream Case 2/3 results will rely on.
>
> **Overview**
> Adds a new internal helper lemma, `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`, intended to package the missing identification needed to show each nonzero compressed cyclic sector block has a *primitive* transfer map and is *tensor-irreducible*.
>
> Refactors `sectorBlocked_isNormal_of_isPeriodic` to remove its `sorry` and instead derive `IsNormal (blocks u)` by instantiating `NeZero (dim u)`, invoking the new bridge lemma to obtain primitivity/irreducibility, and finishing via `isNormal_of_tp_primitive_irreducible`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6bba3a9da34f46e77f4f279725d81c7aa9da87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors a key proof step in periodic overlap Case 2/3 helpers; while behavior is unchanged, the new lemma (still `sorry`-backed) becomes a central dependency for future correctness of sector normality arguments.
> 
> **Overview**
> Adds a new non-`private` bridge lemma `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp` (currently `sorry`) intended to expose the missing structural identification needed to show each nonzero cyclic sector block has a *primitive* transfer map and is *tensor-irreducible*.
> 
> Refactors `sectorBlocked_isNormal_of_isPeriodic` to remove its local `sorry` and instead: instantiate `NeZero (dim u)`, call the new bridge lemma to obtain primitivity/irreducibility, and conclude `IsNormal (blocks u)` via `isNormal_of_tp_primitive_irreducible`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1960f02f578f4b2554c0d2adb394ecf27614a94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->