### PR TITLE
feat(MPS/ParentHamiltonian): prove abstract spectralGap_of_martingale

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.Basic
 import Mathlib.Analysis.InnerProductSpace.Positive
+import Mathlib.Analysis.InnerProductSpace.Spectrum
 
 /-!
 # Martingale-method spectral-gap framework for parent Hamiltonians
@@ -40,13 +41,17 @@ The last step — the implication from the quadratic-form inequality
 `H² ≥ γ H` to the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` — is packaged
 as the abstract lemma `FrustrationFree.spectralGap_of_martingale` below.
 Its hypothesis is the quadratic-form inequality (in inner-product form),
-and its proof is the spectral-theorem argument, currently deferred as
-`sorry`.
+and its proof is the spectral-theorem argument: diagonalising the
+positive symmetric operator `H` in an orthonormal eigenbasis with
+nonnegative eigenvalues `μᵢ`, applying the hypothesis to each eigenvector
+gives `γ μᵢ ≤ μᵢ²`, so every nonzero eigenvalue satisfies `μᵢ ≥ γ`;
+expanding `v` in the basis and discarding the `ker H` components (which
+vanish on `(ker H)ᗮ`) then yields `γ² ‖v‖² ≤ ‖H v‖²`.
 
 The MPS-specific step (producing the quadratic-form inequality for
 `parentHamiltonianES A L N`) is the remaining obligation of
 `MPSTensor.parentHamiltonian_gapped`, which applies
-`FrustrationFree.spectralGap_of_martingale` with the MPS bound and also
+`FrustrationFree.spectralGap_of_martingale` with the MPS bound and
 remains `sorry`.
 
 ## Main results
@@ -54,7 +59,7 @@ remains `sorry`.
 * `FrustrationFree.spectralGap_of_martingale` — abstract martingale
   criterion: the quadratic-form inequality `γ ⟨H v, v⟩ ≤ ⟨H v, H v⟩`
   for a `LinearMap.IsPositive` operator `H` implies the norm bound
-  `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` (deferred).
+  `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors (deferred).
 -/
@@ -99,11 +104,85 @@ for eigenvectors of `H` — follows by the spectral theorem. This lemma
 packages the final spectral-theorem step; the MPS-specific derivation
 of the quadratic-form hypothesis is the remaining obligation inside
 `MPSTensor.parentHamiltonian_gapped`. -/
-theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (_hγ : 0 < γ)
-    {H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι} (_hH : H.IsPositive)
-    (_hOpIneq : ∀ v, γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
+theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 < γ)
+    {H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι} (hH : H.IsPositive)
+    (hOpIneq : ∀ v, γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
     ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
-  sorry
+  classical
+  -- Spectral setup: diagonalise the positive symmetric operator.
+  set n := Fintype.card ι with hn_def
+  have hn : Module.finrank ℂ (EuclideanSpace ℂ ι) = n := by
+    simp [hn_def]
+  have hSym : H.IsSymmetric := hH.isSymmetric
+  set b := hSym.eigenvectorBasis hn with hb_def
+  set μ : Fin n → ℝ := hSym.eigenvalues hn with hμ_def
+  have hμ_nn : ∀ i, 0 ≤ μ i := fun i => hH.nonneg_eigenvalues hn i
+  have hHb : ∀ i, H (b i) = ((μ i : ℂ)) • b i := fun i =>
+    hSym.apply_eigenvectorBasis hn i
+  have hbb : ∀ i j : Fin n, ⟪b i, b j⟫_ℂ = if i = j then (1 : ℂ) else 0 :=
+    orthonormal_iff_ite.mp b.orthonormal
+  -- Apply the operator inequality to each eigenvector: `γ μᵢ ≤ μᵢ²`.
+  have hμ_ineq : ∀ i, γ * μ i ≤ μ i * μ i := by
+    intro i
+    have key := hOpIneq (b i)
+    rw [hHb i] at key
+    have e1 : (⟪((μ i : ℂ)) • b i, b i⟫_ℂ).re = μ i := by
+      rw [inner_smul_left, hbb i i, if_pos rfl, mul_one, Complex.conj_ofReal,
+          Complex.ofReal_re]
+    have e2 : (⟪((μ i : ℂ)) • b i, ((μ i : ℂ)) • b i⟫_ℂ).re = μ i * μ i := by
+      rw [inner_smul_left, inner_smul_right, hbb i i, if_pos rfl, mul_one,
+          Complex.conj_ofReal, ← Complex.ofReal_mul, Complex.ofReal_re]
+    rw [e1, e2] at key
+    exact key
+  -- Combined with `μᵢ ≥ 0`, this gives `μᵢ = 0 ∨ γ ≤ μᵢ` for each `i`.
+  have hμ_alt : ∀ i, μ i = 0 ∨ γ ≤ μ i := by
+    intro i
+    rcases (hμ_nn i).lt_or_eq with hpos | hzero
+    · right
+      have := hμ_ineq i
+      have hpos' : 0 < μ i := hpos
+      nlinarith
+    · left; exact hzero.symm
+  -- Main argument on `v ∈ (ker H)ᗮ`.
+  intro v hv
+  -- Eigenvectors with zero eigenvalue lie in `ker H`, hence are orthogonal to `v`.
+  have hker : ∀ i, μ i = 0 → b i ∈ LinearMap.ker H := by
+    intro i hi
+    rw [LinearMap.mem_ker, hHb i]
+    simp [hi]
+  have hv_perp : ∀ i, μ i = 0 → ⟪b i, v⟫_ℂ = 0 := fun i hi =>
+    Submodule.inner_right_of_mem_orthogonal (hker i hi) hv
+  -- Express `‖v‖²` and `‖Hv‖²` through the eigenvector basis.
+  have hv_sq : ‖v‖ ^ 2 = ∑ i, ‖(b.repr v) i‖ ^ 2 := by
+    have hiso := b.repr.norm_map v
+    rw [← hiso, EuclideanSpace.norm_sq_eq]
+  have hHv_sq : ‖H v‖ ^ 2 = ∑ i, (μ i) ^ 2 * ‖(b.repr v) i‖ ^ 2 := by
+    have hiso := b.repr.norm_map (H v)
+    rw [← hiso, EuclideanSpace.norm_sq_eq]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [hSym.eigenvectorBasis_apply_self_apply hn v i, norm_mul, mul_pow,
+        RCLike.norm_ofReal, sq_abs]
+  -- The quadratic-form bound `γ² ‖v‖² ≤ ‖Hv‖²` is now term-by-term.
+  have h_sq : γ ^ 2 * ‖v‖ ^ 2 ≤ ‖H v‖ ^ 2 := by
+    rw [hv_sq, hHv_sq, Finset.mul_sum]
+    refine Finset.sum_le_sum (fun i _ => ?_)
+    rcases hμ_alt i with hi | hi
+    · have h0 : (b.repr v) i = 0 := by
+        rw [b.repr_apply_apply]
+        exact hv_perp i hi
+      rw [h0, norm_zero]
+      simp
+    · have hγ_sq : γ ^ 2 ≤ (μ i) ^ 2 :=
+        pow_le_pow_left₀ hγ.le hi 2
+      have hnn : (0 : ℝ) ≤ ‖(b.repr v) i‖ ^ 2 := sq_nonneg _
+      exact mul_le_mul_of_nonneg_right hγ_sq hnn
+  -- Take square roots to conclude `γ ‖v‖ ≤ ‖Hv‖`.
+  have h1 : (γ * ‖v‖) ^ 2 ≤ ‖H v‖ ^ 2 := by
+    rw [mul_pow]; exact h_sq
+  have h2 : 0 ≤ γ * ‖v‖ := mul_nonneg hγ.le (norm_nonneg v)
+  have h3 : 0 ≤ ‖H v‖ := norm_nonneg _
+  have hsqrt := Real.sqrt_le_sqrt h1
+  rwa [Real.sqrt_sq h2, Real.sqrt_sq h3] at hsqrt
 
 end FrustrationFree
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -941,7 +941,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{lemma}[Quadratic form to norm bound]\label{lem:quadratic_form_to_norm_bound}
     \lean{FrustrationFree.spectralGap_of_martingale}
-    \notready
+    \leanok
     Let $H$ be a positive semidefinite self-adjoint operator on a
     finite-dimensional complex Hilbert space, and suppose that
     \[
@@ -960,7 +960,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \end{lemma}
 
 \begin{proof}
-    \notready
+    \leanok
     By the finite-dimensional spectral theorem, $H$ diagonalises in an
     orthonormal eigenbasis with real eigenvalues $\lambda_k$. For a unit
     eigenvector $\psi_k$ with eigenvalue $\lambda_k$ the hypothesis


### PR DESCRIPTION
### Motivation

- Closes the abstract spectral-theorem step in the Kastoryano–Lucia / Nachtergaele martingale method, splitting the spectral-gap goal in #460 into its pure linear-algebra piece first.
- Unblocks the MPS-specific wrapper `parentHamiltonian_gapped` (tracked separately), which will become a mechanical application once this abstract criterion is proved.

### Description

- `TNLean/MPS/ParentHamiltonian/Martingale.lean`: replaces the `sorry` in `FrustrationFree.spectralGap_of_martingale` with a full proof using Mathlib's finite-dimensional spectral theorem. Diagonalises the positive operator `H` in an orthonormal eigenbasis via `LinearMap.IsSymmetric.eigenvectorBasis`, uses `LinearMap.IsPositive.nonneg_eigenvalues` for nonnegativity of eigenvalues, derives `γ * μᵢ ≤ μᵢ²` from the hypothesis applied to each eigenvector, and expands `v ⊥ ker H` in the basis to kill zero-eigenvalue components before concluding `γ² ‖v‖² ≤ ‖H v‖²`.
- Adds the import `Mathlib.Analysis.InnerProductSpace.Spectrum` and expands the explanatory comment describing the proof strategy.
- The MPS-specific wrapper `MPSTensor.parentHamiltonian_gapped` remains `sorry` and is tracked separately.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: marks `lem:quadratic_form_to_norm_bound` as `\leanok`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate the build.
- `rg -n "sorry|axiom" TNLean/MPS/ParentHamiltonian/Martingale.lean` should show the abstract `sorry` gone, with only the intentional MPS-wrapper `sorry` remaining.

---
Addresses #585

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a nontrivial Lean proof using spectral decomposition; risk is mainly proof fragility/typeclass/simp changes impacting future Mathlib upgrades, but no runtime/security impact.
>
> **Overview**
> Implements the previously-sketched spectral-theorem step in `FrustrationFree.spectralGap_of_martingale`, replacing a `sorry` with a full eigenbasis/eigenvalue argument to derive the norm lower bound on `(LinearMap.ker H)ᗮ` from the quadratic-form inequality.
>
> Updates documentation accordingly: imports `Mathlib.Analysis.InnerProductSpace.Spectrum`, expands the explanatory comment in `Martingale.lean`, and marks the corresponding blueprint lemma/proof as `\leanok`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8be4d80a75b6297c1bde032dd4fd5747c4f8f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->