### PR TITLE
feat(Channel/Schwarz): add Matrix.IsHermitian.trace_cfc_eq_sum helper

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -79,6 +79,7 @@ import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull
+import TNLean.Channel.Schwarz.TraceCFC
 import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.StationarySupport

--- a/TNLean/Channel/Schwarz/TraceCFC.lean
+++ b/TNLean/Channel/Schwarz/TraceCFC.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
+
+/-!
+# Trace of the continuous functional calculus on a Hermitian matrix
+
+Small helper lemma used in the `trace_rpow_*` convexity/concavity proofs: the
+(real part of the) trace of `hA.cfc f` equals `∑ i, f (hA.eigenvalues i)`.
+
+The proof combines the unitary-diagonal form of `Matrix.IsHermitian.cfc`
+(see `Mathlib.Analysis.Matrix.HermitianFunctionalCalculus`) with
+`Matrix.trace_mul_cycle` and `Matrix.trace_diagonal`, exactly the pattern used
+by `Matrix.PosSemidef.trace_eq_zero_iff` in Mathlib.
+-/
+
+namespace Matrix
+namespace IsHermitian
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The real part of the trace of `hA.cfc f` is the sum of `f` over the
+eigenvalues of `A`.
+
+This packages the standard calculation
+`trace (U * diagonal (f ∘ λ) * U†) = ∑ i, f (λ i)` obtained from the spectral
+theorem and `trace_mul_cycle`. -/
+theorem trace_cfc_eq_sum {A : Matrix n n ℂ} (hA : A.IsHermitian) (f : ℝ → ℝ) :
+    (Matrix.trace (hA.cfc f)).re = ∑ i, f (hA.eigenvalues i) := by
+  rw [IsHermitian.cfc, Unitary.conjStarAlgAut_apply, trace_mul_cycle,
+    Unitary.coe_star_mul_self, one_mul, trace_diagonal]
+  rw [show (∑ i, (RCLike.ofReal ∘ f ∘ hA.eigenvalues) i : ℂ)
+        = ((∑ i, f (hA.eigenvalues i) : ℝ) : ℂ) by
+      push_cast [Function.comp_apply]; rfl]
+  exact Complex.ofReal_re _
+
+end IsHermitian
+end Matrix

--- a/TNLean/Channel/Schwarz/TraceCFC.lean
+++ b/TNLean/Channel/Schwarz/TraceCFC.lean
@@ -7,8 +7,8 @@ import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
 /-!
 # Trace of the continuous functional calculus on a Hermitian matrix
 
-Small helper lemma used in the `trace_rpow_*` convexity/concavity proofs: the
-(real part of the) trace of `hA.cfc f` equals `∑ i, f (hA.eigenvalues i)`.
+Small helper lemmas used in the `trace_rpow_*` convexity/concavity proofs: the
+trace of `hA.cfc f` equals the sum of `f` over the eigenvalues of `A`.
 
 The proof combines the unitary-diagonal form of `Matrix.IsHermitian.cfc`
 (see `Mathlib.Analysis.Matrix.HermitianFunctionalCalculus`) with
@@ -19,22 +19,25 @@ by `Matrix.PosSemidef.trace_eq_zero_iff` in Mathlib.
 namespace Matrix
 namespace IsHermitian
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {n 𝕜 : Type*} [RCLike 𝕜] [Fintype n] [DecidableEq n]
 
-/-- The real part of the trace of `hA.cfc f` is the sum of `f` over the
-eigenvalues of `A`.
+/-- The trace of `hA.cfc f` is the sum of `f` over the eigenvalues of `A`.
 
 This packages the standard calculation
 `trace (U * diagonal (f ∘ λ) * U†) = ∑ i, f (λ i)` obtained from the spectral
 theorem and `trace_mul_cycle`. -/
-theorem trace_cfc_eq_sum {A : Matrix n n ℂ} (hA : A.IsHermitian) (f : ℝ → ℝ) :
-    (Matrix.trace (hA.cfc f)).re = ∑ i, f (hA.eigenvalues i) := by
+theorem trace_cfc_eq_sum {A : Matrix n n 𝕜} (hA : A.IsHermitian) (f : ℝ → ℝ) :
+    Matrix.trace (hA.cfc f) = ∑ i, ((f (hA.eigenvalues i) : ℝ) : 𝕜) := by
   rw [IsHermitian.cfc, Unitary.conjStarAlgAut_apply, trace_mul_cycle,
     Unitary.coe_star_mul_self, one_mul, trace_diagonal]
-  rw [show (∑ i, (RCLike.ofReal ∘ f ∘ hA.eigenvalues) i : ℂ)
-        = ((∑ i, f (hA.eigenvalues i) : ℝ) : ℂ) by
-      push_cast [Function.comp_apply]; rfl]
-  exact Complex.ofReal_re _
+  simp [Function.comp_apply]
+
+/-- The real part of the trace of `hA.cfc f` is the sum of `f` over the
+eigenvalues of `A`. -/
+theorem trace_cfc_eq_sum_re {A : Matrix n n 𝕜} (hA : A.IsHermitian) (f : ℝ → ℝ) :
+    RCLike.re (Matrix.trace (hA.cfc f)) = ∑ i, f (hA.eigenvalues i) := by
+  rw [trace_cfc_eq_sum hA f]
+  simp [RCLike.ofReal_re]
 
 end IsHermitian
 end Matrix


### PR DESCRIPTION
### Motivation

- Prerequisite helper for LionSR/QICLean#29 (Wolf Ch5 trace convexity). Packages the standard spectral-theorem calculation needed to discharge `trace_rpow_concave_axiom` / `trace_rpow_convex_axiom`.
- The sum-over-eigenvalues step had no clean API; this lemma provides it.

### Description

- Adds new module `TNLean/Channel/Schwarz/TraceCFC.lean` proving `Matrix.IsHermitian.trace_cfc_eq_sum`, which states `(trace (hA.cfc f)).re = ∑ i, f (hA.eigenvalues i)`.
- Proof uses the unitary-diagonal form from Mathlib's `IsHermitian.cfc`, together with `trace_mul_cycle`, `coe_star_mul_self`, and `trace_diagonal`, matching the pattern of `PosSemidef.trace_eq_zero_iff` in Mathlib.
- Exports the module from the root `TNLean.lean` so downstream files can use the lemma (intended for upcoming `trace_rpow_*` convexity/concavity proofs).

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Closes LionSR/TNLean#591
Refs LionSR/QICLean#29

> [!NOTE]
> **Low Risk**
> Low risk: adds a small standalone lemma and a new import, with no changes to existing proofs or behavior beyond exposing the module via `TNLean.lean`.
>
> **Overview**
> Adds a new helper module `TNLean.Channel.Schwarz.TraceCFC` proving `Matrix.IsHermitian.trace_cfc_eq_sum`, relating the real part of `trace (hA.cfc f)` to the sum of `f` over Hermitian eigenvalues.
>
> Exports this module from the root `TNLean.lean` import surface so downstream files can use the lemma (intended for upcoming `trace_rpow_*` convexity/concavity proofs).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7c7d1d0a8eacc52b0f4344b47da35827933957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small standalone lemma module and a root import, without modifying existing channel/proof logic.
> 
> **Overview**
> Adds a new `Channel/Schwarz` helper module `TraceCFC` proving `Matrix.IsHermitian.trace_cfc_eq_sum` and `trace_cfc_eq_sum_re`, relating `trace (hA.cfc f)` (and its real part) to a sum of `f` over the Hermitian eigenvalues via the spectral diagonalization + trace cycling calculation.
> 
> Exports this new module from `TNLean.lean` so downstream proofs (e.g. upcoming `trace_rpow_*` work) can import it from the root surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e21d61b7472196397adc3bf558a8e9d3d307dfb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->