### PR TITLE
feat(Channel/Schwarz): add Matrix.diagonal_jensen_of_convexOn

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -68,6 +68,7 @@ import TNLean.Axioms.OperatorConvexity
 import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import TNLean.Channel.Schwarz.Douglas
+import TNLean.Channel.Schwarz.DiagonalJensen
 import TNLean.Channel.Schwarz.OperatorConvexity
 import TNLean.Channel.Schwarz.OperatorMonotone
 import TNLean.Channel.Schwarz.AndoLieb

--- a/TNLean/Channel/Schwarz/DiagonalJensen.lean
+++ b/TNLean/Channel/Schwarz/DiagonalJensen.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
+import Mathlib.Analysis.Convex.Jensen
+import Mathlib.LinearAlgebra.Matrix.PosDef
+import Mathlib.Analysis.Matrix.PosDef
+
+/-!
+# Diagonal Jensen inequality for positive semidefinite matrices
+
+This file proves the **diagonal Jensen inequality** for a convex function
+applied to a positive semidefinite matrix via the Hermitian continuous
+functional calculus.
+
+## Main result
+
+* `Matrix.diagonal_jensen_of_convexOn`: for a convex `f : ℝ → ℝ` on
+  `[0, ∞)`, a positive semidefinite matrix `A`, and a unit vector
+  `v` (`star v ⬝ᵥ v = 1`):
+
+    `f ((star v ⬝ᵥ (A *ᵥ v)).re) ≤ (star v ⬝ᵥ (f(A) *ᵥ v)).re`,
+
+  where `f(A)` is computed via `Matrix.IsHermitian.cfc`.
+
+## Proof sketch
+
+Write `A = U * diagonal (λ) * Uᴴ` by the spectral theorem, and set
+`w = Uᴴ *ᵥ v`. Since `U` is unitary, `∑ i, |w i|² = ‖v‖² = 1`, so the
+family `p i := |w i|²` is a probability distribution over `Fin D`. The
+eigenvalues `λ i` of the PSD matrix `A` lie in `[0, ∞)`. A direct
+computation gives
+
+  `(star v ⬝ᵥ (A *ᵥ v)).re = ∑ i, p i * λ i`,
+  `(star v ⬝ᵥ (f(A) *ᵥ v)).re = ∑ i, p i * f (λ i)`,
+
+so the scalar Jensen inequality `ConvexOn.map_sum_le` applied to the
+weights `p` and points `λ` yields the conclusion.
+
+This helper is a prerequisite for the trace convexity axioms
+`trace_rpow_concave_axiom` and `trace_rpow_convex_axiom` in
+`TNLean.Axioms.OperatorConvexity`.
+
+## References
+
+* Bhatia, *Matrix Analysis*, Ch. V (matrix Jensen inequality).
+-/
+
+open scoped Matrix ComplexOrder
+open Finset Matrix
+
+noncomputable section
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- **Diagonal Jensen inequality** for a convex function on a positive
+semidefinite matrix.
+
+For `f : ℝ → ℝ` convex on `[0, ∞)`, `A` positive semidefinite, and `v` a
+unit vector (`star v ⬝ᵥ v = 1`):
+
+  `f ((star v ⬝ᵥ (A *ᵥ v)).re) ≤ (star v ⬝ᵥ (f(A) *ᵥ v)).re`,
+
+where `f(A)` is computed via `Matrix.IsHermitian.cfc`.
+
+The proof reduces to the scalar Jensen inequality
+`ConvexOn.map_sum_le` applied to the eigenvalues of `A` with weights
+`|Uᴴ *ᵥ v i|²`. -/
+theorem diagonal_jensen_of_convexOn
+    [DecidableEq (Fin D)]
+    {f : ℝ → ℝ} (hf : ConvexOn ℝ (Set.Ici (0 : ℝ)) f)
+    {A : Matrix (Fin D) (Fin D) ℂ} (hA : A.PosSemidef)
+    {v : Fin D → ℂ} (hv : star v ⬝ᵥ v = (1 : ℂ)) :
+    f ((star v ⬝ᵥ (A *ᵥ v)).re) ≤ (star v ⬝ᵥ (hA.1.cfc f *ᵥ v)).re := by
+  classical
+  -- Spectral data for `A`.
+  set hH : A.IsHermitian := hA.1 with hH_def
+  set U : Matrix (Fin D) (Fin D) ℂ := (↑hH.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)
+    with hU_def
+  set μ : Fin D → ℝ := hH.eigenvalues with hμ_def
+  set w : Fin D → ℂ := Uᴴ *ᵥ v with hw_def
+  set p : Fin D → ℝ := fun i => Complex.normSq (w i) with hp_def
+  -- Unitarity of `U`: `U * Uᴴ = 1` and `Uᴴ * U = 1`.
+  have hUUH : U * Uᴴ = 1 := by
+    rw [← Matrix.star_eq_conjTranspose]
+    exact Unitary.mul_star_self_of_mem hH.eigenvectorUnitary.prop
+  have hUHU : Uᴴ * U = 1 := by
+    rw [← Matrix.star_eq_conjTranspose]
+    exact Matrix.UnitaryGroup.star_mul_self hH.eigenvectorUnitary
+  -- Key computational lemma: for any `g : Fin D → ℂ`,
+  --   `star v ⬝ᵥ ((U * diagonal g * Uᴴ) *ᵥ v) = ∑ i, g i * (star (w i) * w i)`.
+  have hQ : ∀ g : Fin D → ℂ,
+      star v ⬝ᵥ ((U * Matrix.diagonal g * Uᴴ) *ᵥ v)
+        = ∑ i, g i * (star (w i) * w i) := by
+    intro g
+    have hvU : star v ᵥ* U = star w := by
+      change star v ᵥ* U = star (Uᴴ *ᵥ v)
+      rw [Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
+    have hmul :
+        (U * Matrix.diagonal g * Uᴴ) *ᵥ v
+          = U *ᵥ (Matrix.diagonal g *ᵥ (Uᴴ *ᵥ v)) := by
+      rw [mul_assoc, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
+    rw [hmul]
+    rw [show (U *ᵥ (Matrix.diagonal g *ᵥ (Uᴴ *ᵥ v)))
+          = U *ᵥ (Matrix.diagonal g *ᵥ w) from rfl]
+    rw [Matrix.dotProduct_mulVec, hvU]
+    -- `star w ⬝ᵥ (diagonal g *ᵥ w) = ∑ i, star (w i) * (g i * w i)`.
+    simp only [dotProduct, Matrix.mulVec_diagonal, Pi.star_apply]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    ring
+  -- `star (w i) * w i = ↑(p i)` (Complex norm-square identity).
+  have h_normSq : ∀ i, star (w i) * w i = ((p i : ℝ) : ℂ) := by
+    intro i
+    have := Complex.normSq_eq_conj_mul_self (z := w i)
+    -- `(normSq (w i) : ℂ) = conj (w i) * w i = star (w i) * w i`.
+    simpa [hp_def, Complex.star_def] using this.symm
+  -- Spectral form of `A`.
+  have hA_spec : A = U * Matrix.diagonal (fun i => ((μ i : ℂ))) * Uᴴ := by
+    have h := hH.spectral_theorem
+    simpa [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose,
+      hU_def, hμ_def] using h
+  -- Spectral form of `hH.cfc f`.
+  have hfA_spec : hH.cfc f
+      = U * Matrix.diagonal (fun i => ((f (μ i) : ℂ))) * Uᴴ := by
+    unfold IsHermitian.cfc
+    rw [Unitary.conjStarAlgAut_apply, ← Matrix.star_eq_conjTranspose]
+    rfl
+  -- `⟨v, A v⟩` as a complex sum of `μ i * p i`.
+  have h_vAv : star v ⬝ᵥ (A *ᵥ v)
+      = ∑ i, ((μ i : ℂ) * ((p i : ℝ) : ℂ)) := by
+    rw [hA_spec, hQ]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [h_normSq i]
+  -- `⟨v, f(A) v⟩` as a complex sum of `f(μ i) * p i`.
+  have h_vfAv : star v ⬝ᵥ (hH.cfc f *ᵥ v)
+      = ∑ i, (((f (μ i) : ℝ) : ℂ) * ((p i : ℝ) : ℂ)) := by
+    rw [hfA_spec, hQ]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [h_normSq i]
+  -- Real parts: `(star v ⬝ᵥ (A *ᵥ v)).re = ∑ i, μ i * p i`.
+  have h_vAv_re : (star v ⬝ᵥ (A *ᵥ v)).re = ∑ i, μ i * p i := by
+    rw [h_vAv]
+    rw [show (∑ i, ((μ i : ℂ) * ((p i : ℝ) : ℂ)))
+          = (((∑ i, μ i * p i) : ℝ) : ℂ) by push_cast; rfl]
+    simp
+  have h_vfAv_re : (star v ⬝ᵥ (hH.cfc f *ᵥ v)).re = ∑ i, f (μ i) * p i := by
+    rw [h_vfAv]
+    rw [show (∑ i, (((f (μ i) : ℝ) : ℂ) * ((p i : ℝ) : ℂ)))
+          = (((∑ i, f (μ i) * p i) : ℝ) : ℂ) by push_cast; rfl]
+    simp
+  -- `∑ i, p i = 1` (unit vector + unitarity).
+  have hp_sum : ∑ i, p i = 1 := by
+    -- `∑ i, (p i : ℂ) = star w ⬝ᵥ w = star v ⬝ᵥ v = 1`.
+    have hstar_w : star w = star v ᵥ* U := by
+      change star (Uᴴ *ᵥ v) = star v ᵥ* U
+      rw [Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
+    have hww : star w ⬝ᵥ w = (1 : ℂ) := by
+      rw [hstar_w]
+      calc (star v ᵥ* U) ⬝ᵥ w
+          = star v ⬝ᵥ (U *ᵥ w) := by rw [← Matrix.dotProduct_mulVec]
+        _ = star v ⬝ᵥ (U *ᵥ (Uᴴ *ᵥ v)) := rfl
+        _ = star v ⬝ᵥ ((U * Uᴴ) *ᵥ v) := by rw [Matrix.mulVec_mulVec]
+        _ = star v ⬝ᵥ ((1 : Matrix (Fin D) (Fin D) ℂ) *ᵥ v) := by rw [hUUH]
+        _ = star v ⬝ᵥ v := by rw [Matrix.one_mulVec]
+        _ = 1 := hv
+    have hsum_c : (∑ i, ((p i : ℝ) : ℂ)) = (1 : ℂ) := by
+      rw [← hww]
+      simp only [dotProduct, Pi.star_apply]
+      refine Finset.sum_congr rfl (fun i _ => (h_normSq i).symm)
+    exact_mod_cast hsum_c
+  -- Eigenvalues are nonneg: `μ i ∈ [0, ∞)`.
+  have hμ_nonneg : ∀ i, μ i ∈ Set.Ici (0 : ℝ) := fun i => hA.eigenvalues_nonneg i
+  -- Apply scalar Jensen.
+  have hp_nn : ∀ i ∈ (Finset.univ : Finset (Fin D)), 0 ≤ p i :=
+    fun i _ => Complex.normSq_nonneg _
+  have hmem : ∀ i ∈ (Finset.univ : Finset (Fin D)),
+      μ i ∈ Set.Ici (0 : ℝ) := fun i _ => hμ_nonneg i
+  have hjensen := hf.map_sum_le (t := Finset.univ) hp_nn hp_sum hmem
+  simp only [smul_eq_mul] at hjensen
+  rw [h_vAv_re, h_vfAv_re]
+  -- Match `∑ p i * μ i` with `∑ μ i * p i` (and similarly for `f`).
+  have eq1 : ∑ i, p i * μ i = ∑ i, μ i * p i :=
+    Finset.sum_congr rfl (fun i _ => mul_comm _ _)
+  have eq2 : ∑ i, p i * f (μ i) = ∑ i, f (μ i) * p i :=
+    Finset.sum_congr rfl (fun i _ => mul_comm _ _)
+  rw [← eq1, ← eq2]
+  exact hjensen
+
+end Matrix
+
+end

--- a/TNLean/Channel/Schwarz/DiagonalJensen.lean
+++ b/TNLean/Channel/Schwarz/DiagonalJensen.lean
@@ -28,7 +28,7 @@ functional calculus.
 
 Write `A = U * diagonal (λ) * Uᴴ` by the spectral theorem, and set
 `w = Uᴴ *ᵥ v`. Since `U` is unitary, `∑ i, |w i|² = ‖v‖² = 1`, so the
-family `p i := |w i|²` is a probability distribution over `Fin D`. The
+family `p i := |w i|²` is a probability distribution over `n`. The
 eigenvalues `λ i` of the PSD matrix `A` lie in `[0, ∞)`. A direct
 computation gives
 
@@ -54,7 +54,7 @@ noncomputable section
 
 namespace Matrix
 
-variable {D : ℕ}
+variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- **Diagonal Jensen inequality** for a convex function on a positive
 semidefinite matrix.
@@ -70,29 +70,24 @@ The proof reduces to the scalar Jensen inequality
 `ConvexOn.map_sum_le` applied to the eigenvalues of `A` with weights
 `|Uᴴ *ᵥ v i|²`. -/
 theorem diagonal_jensen_of_convexOn
-    [DecidableEq (Fin D)]
     {f : ℝ → ℝ} (hf : ConvexOn ℝ (Set.Ici (0 : ℝ)) f)
-    {A : Matrix (Fin D) (Fin D) ℂ} (hA : A.PosSemidef)
-    {v : Fin D → ℂ} (hv : star v ⬝ᵥ v = (1 : ℂ)) :
+    {A : Matrix n n ℂ} (hA : A.PosSemidef)
+    {v : n → ℂ} (hv : star v ⬝ᵥ v = (1 : ℂ)) :
     f ((star v ⬝ᵥ (A *ᵥ v)).re) ≤ (star v ⬝ᵥ (hA.1.cfc f *ᵥ v)).re := by
   classical
   -- Spectral data for `A`.
-  set hH : A.IsHermitian := hA.1 with hH_def
-  set U : Matrix (Fin D) (Fin D) ℂ := (↑hH.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)
-    with hU_def
-  set μ : Fin D → ℝ := hH.eigenvalues with hμ_def
-  set w : Fin D → ℂ := Uᴴ *ᵥ v with hw_def
-  set p : Fin D → ℝ := fun i => Complex.normSq (w i) with hp_def
-  -- Unitarity of `U`: `U * Uᴴ = 1` and `Uᴴ * U = 1`.
+  set hH : A.IsHermitian := hA.1
+  set U : Matrix n n ℂ := (↑hH.eigenvectorUnitary : Matrix n n ℂ) with hU_def
+  set μ : n → ℝ := hH.eigenvalues with hμ_def
+  set w : n → ℂ := Uᴴ *ᵥ v
+  set p : n → ℝ := fun i => Complex.normSq (w i) with hp_def
+  -- Unitarity of `U`: `U * Uᴴ = 1`.
   have hUUH : U * Uᴴ = 1 := by
     rw [← Matrix.star_eq_conjTranspose]
     exact Unitary.mul_star_self_of_mem hH.eigenvectorUnitary.prop
-  have hUHU : Uᴴ * U = 1 := by
-    rw [← Matrix.star_eq_conjTranspose]
-    exact Matrix.UnitaryGroup.star_mul_self hH.eigenvectorUnitary
-  -- Key computational lemma: for any `g : Fin D → ℂ`,
+  -- Key computational lemma: for any `g : n → ℂ`,
   --   `star v ⬝ᵥ ((U * diagonal g * Uᴴ) *ᵥ v) = ∑ i, g i * (star (w i) * w i)`.
-  have hQ : ∀ g : Fin D → ℂ,
+  have hQ : ∀ g : n → ℂ,
       star v ⬝ᵥ ((U * Matrix.diagonal g * Uᴴ) *ᵥ v)
         = ∑ i, g i * (star (w i) * w i) := by
     intro g
@@ -163,7 +158,7 @@ theorem diagonal_jensen_of_convexOn
           = star v ⬝ᵥ (U *ᵥ w) := by rw [← Matrix.dotProduct_mulVec]
         _ = star v ⬝ᵥ (U *ᵥ (Uᴴ *ᵥ v)) := rfl
         _ = star v ⬝ᵥ ((U * Uᴴ) *ᵥ v) := by rw [Matrix.mulVec_mulVec]
-        _ = star v ⬝ᵥ ((1 : Matrix (Fin D) (Fin D) ℂ) *ᵥ v) := by rw [hUUH]
+        _ = star v ⬝ᵥ ((1 : Matrix n n ℂ) *ᵥ v) := by rw [hUUH]
         _ = star v ⬝ᵥ v := by rw [Matrix.one_mulVec]
         _ = 1 := hv
     have hsum_c : (∑ i, ((p i : ℝ) : ℂ)) = (1 : ℂ) := by
@@ -174,9 +169,9 @@ theorem diagonal_jensen_of_convexOn
   -- Eigenvalues are nonneg: `μ i ∈ [0, ∞)`.
   have hμ_nonneg : ∀ i, μ i ∈ Set.Ici (0 : ℝ) := fun i => hA.eigenvalues_nonneg i
   -- Apply scalar Jensen.
-  have hp_nn : ∀ i ∈ (Finset.univ : Finset (Fin D)), 0 ≤ p i :=
+  have hp_nn : ∀ i ∈ (Finset.univ : Finset n), 0 ≤ p i :=
     fun i _ => Complex.normSq_nonneg _
-  have hmem : ∀ i ∈ (Finset.univ : Finset (Fin D)),
+  have hmem : ∀ i ∈ (Finset.univ : Finset n),
       μ i ∈ Set.Ici (0 : ℝ) := fun i _ => hμ_nonneg i
   have hjensen := hf.map_sum_le (t := Finset.univ) hp_nn hp_sum hmem
   simp only [smul_eq_mul] at hjensen

--- a/TNLean/Channel/Schwarz/DiagonalJensen.lean
+++ b/TNLean/Channel/Schwarz/DiagonalJensen.lean
@@ -98,10 +98,7 @@ theorem diagonal_jensen_of_convexOn
         (U * Matrix.diagonal g * Uᴴ) *ᵥ v
           = U *ᵥ (Matrix.diagonal g *ᵥ (Uᴴ *ᵥ v)) := by
       rw [mul_assoc, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
-    rw [hmul]
-    rw [show (U *ᵥ (Matrix.diagonal g *ᵥ (Uᴴ *ᵥ v)))
-          = U *ᵥ (Matrix.diagonal g *ᵥ w) from rfl]
-    rw [Matrix.dotProduct_mulVec, hvU]
+    rw [hmul, Matrix.dotProduct_mulVec, hvU]
     -- `star w ⬝ᵥ (diagonal g *ᵥ w) = ∑ i, star (w i) * (g i * w i)`.
     simp only [dotProduct, Matrix.mulVec_diagonal, Pi.star_apply]
     refine Finset.sum_congr rfl (fun i _ => ?_)
@@ -135,17 +132,11 @@ theorem diagonal_jensen_of_convexOn
     rw [hfA_spec, hQ]
     refine Finset.sum_congr rfl (fun i _ => ?_)
     rw [h_normSq i]
-  -- Real parts: `(star v ⬝ᵥ (A *ᵥ v)).re = ∑ i, μ i * p i`.
-  have h_vAv_re : (star v ⬝ᵥ (A *ᵥ v)).re = ∑ i, μ i * p i := by
-    rw [h_vAv]
-    rw [show (∑ i, ((μ i : ℂ) * ((p i : ℝ) : ℂ)))
-          = (((∑ i, μ i * p i) : ℝ) : ℂ) by push_cast; rfl]
-    simp
-  have h_vfAv_re : (star v ⬝ᵥ (hH.cfc f *ᵥ v)).re = ∑ i, f (μ i) * p i := by
-    rw [h_vfAv]
-    rw [show (∑ i, (((f (μ i) : ℝ) : ℂ) * ((p i : ℝ) : ℂ)))
-          = (((∑ i, f (μ i) * p i) : ℝ) : ℂ) by push_cast; rfl]
-    simp
+  -- Real parts.
+  have h_vAv_re : (star v ⬝ᵥ (A *ᵥ v)).re = ∑ i, p i * μ i := by
+    rw [h_vAv]; simp [mul_comm]
+  have h_vfAv_re : (star v ⬝ᵥ (hH.cfc f *ᵥ v)).re = ∑ i, p i * f (μ i) := by
+    rw [h_vfAv]; simp [mul_comm]
   -- `∑ i, p i = 1` (unit vector + unitarity).
   have hp_sum : ∑ i, p i = 1 := by
     -- `∑ i, (p i : ℂ) = star w ⬝ᵥ w = star v ⬝ᵥ v = 1`.
@@ -176,12 +167,6 @@ theorem diagonal_jensen_of_convexOn
   have hjensen := hf.map_sum_le (t := Finset.univ) hp_nn hp_sum hmem
   simp only [smul_eq_mul] at hjensen
   rw [h_vAv_re, h_vfAv_re]
-  -- Match `∑ p i * μ i` with `∑ μ i * p i` (and similarly for `f`).
-  have eq1 : ∑ i, p i * μ i = ∑ i, μ i * p i :=
-    Finset.sum_congr rfl (fun i _ => mul_comm _ _)
-  have eq2 : ∑ i, p i * f (μ i) = ∑ i, f (μ i) * p i :=
-    Finset.sum_congr rfl (fun i _ => mul_comm _ _)
-  rw [← eq1, ← eq2]
   exact hjensen
 
 end Matrix

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -732,11 +732,41 @@ currently taken as assumptions pending upstream formalization of operator
 concavity and convexity for real powers $x\mapsto x^p$ on the Loewner
 order, together with operator concavity of the matrix logarithm.
 
+\subsection{Diagonal Jensen inequality}
+
+\begin{lemma}[Diagonal Jensen inequality]\label{lem:diagonal_jensen_of_convexOn}
+    \lean{Matrix.diagonal_jensen_of_convexOn}
+    \leanok
+    Let $f:\R\to\R$ be convex on $[0,\infty)$, let $A$ be a positive
+    semidefinite matrix indexed by a finite type $n$, and let $v\in\C^n$
+    satisfy $\langle v,v\rangle=1$. Then
+    \[
+        f\!\bigl(\Re\langle v, A v\rangle\bigr)
+        \;\le\;
+        \Re\langle v, f(A)\,v\rangle,
+    \]
+    where $f(A)$ is defined by the Hermitian continuous functional calculus.
+\end{lemma}
+
+\begin{proof}\leanok
+    Write $A=U\,\operatorname{diag}(\mu)\,U^{\ast}$ by the spectral
+    theorem and set $w=U^{\ast}v$. Since $U$ is unitary,
+    $p_i:=\lvert w_i\rvert^2$ satisfies $\sum_i p_i=\lVert v\rVert^2=1$,
+    so $(p_i)$ is a probability distribution on $n$. The eigenvalues
+    $\mu_i$ lie in $[0,\infty)$ because $A$ is positive semidefinite.
+    A direct computation yields
+    $\Re\langle v,Av\rangle=\sum_i p_i\mu_i$ and
+    $\Re\langle v,f(A)v\rangle=\sum_i p_i f(\mu_i)$, so the scalar Jensen
+    inequality applied to the weights $(p_i)$ and points $(\mu_i)$ gives
+    the conclusion. See Bhatia, \emph{Matrix Analysis}, Ch.~V.
+\end{proof}
+
 \subsection{Trace concavity and convexity of matrix powers}
 
 \begin{theorem}[Trace concavity of real powers]\label{thm:trace_rpow_concave_axiom}
     \lean{trace_rpow_concave_axiom}
     \notready
+    \uses{lem:diagonal_jensen_of_convexOn}
     For $p\in[0,1]$, PSD matrices $A_1,A_2$, and $t\in[0,1]$:
     \[
         t\,\Re\tr(A_1^p)+(1-t)\,\Re\tr(A_2^p)
@@ -763,6 +793,7 @@ order, together with operator concavity of the matrix logarithm.
 \begin{theorem}[Trace convexity of real powers]\label{thm:trace_rpow_convex_axiom}
     \lean{trace_rpow_convex_axiom}
     \notready
+    \uses{lem:diagonal_jensen_of_convexOn}
     For $p\in[1,2]$, PSD matrices $A_1,A_2$, and $t\in[0,1]$:
     \[
         \Re\tr\!\bigl((tA_1+(1-t)A_2)^p\bigr)


### PR DESCRIPTION
### Motivation

- Prerequisite helper for LionSR/QICLean#29 (Wolf Ch5 trace convexity); sibling to LionSR/TNLean#591's `trace_cfc_eq_sum`.
- Supplies the diagonal-element Jensen inequality needed to reduce `trace_rpow_{concave,convex}_axiom` in `TNLean/Axioms/OperatorConvexity.lean` to a short proof.

### Description

- New module `TNLean/Channel/Schwarz/DiagonalJensen.lean` proving `Matrix.diagonal_jensen_of_convexOn`: for a PSD matrix `A`, a unit vector `v`, and a convex `f` on `[0, ∞)`,
  `f ((star v ⬝ᵥ (A *ᵥ v)).re) ≤ (star v ⬝ᵥ (hA.1.cfc f *ᵥ v)).re`.
- Proof reduces via the spectral theorem to the scalar Jensen inequality `ConvexOn.map_sum_le` applied to the eigenvalues of `A` with probability weights `|Uᴴ *ᵥ v i|²`.
- Exposes the lemma on the public import surface by adding `import TNLean.Channel.Schwarz.DiagonalJensen` to `TNLean.lean`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/TNLean#592

> [!NOTE]
> **Medium Risk**
> Adds a new nontrivial Lean proof using spectral decomposition and Jensen's inequality; risk is mainly build/maintenance (dependency and proof fragility), not runtime behavior.
>
> **Overview**
> Introduces a new `TNLean.Channel.Schwarz.DiagonalJensen` module proving `Matrix.diagonal_jensen_of_convexOn`, a diagonal Jensen inequality for convex `f` on `[0,∞)` applied to a PSD matrix via Hermitian continuous functional calculus.
>
> Exposes this lemma on the public import surface by adding `import TNLean.Channel.Schwarz.DiagonalJensen` to `TNLean.lean`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecc4e0dabc393395100e2f1b0593a1bc39ac3c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a nontrivial new Lean proof based on spectral decomposition and convexity/Jensen lemmas, which may be somewhat fragile to upstream Mathlib changes but does not affect runtime behavior.
> 
> **Overview**
> Introduces `TNLean.Channel.Schwarz.DiagonalJensen`, proving `Matrix.diagonal_jensen_of_convexOn`: for PSD `A`, unit `v`, and `f` convex on `[0,∞)`, the scalar inequality `f(Re⟪v,Av⟫) ≤ Re⟪v,f(A)v⟫` where `f(A)` is via Hermitian CFC.
> 
> Exports the new lemma from the root `TNLean.lean` import surface, and updates the Chapter 5 blueprint to document the lemma and record it as a dependency for the (still-axiomatized) trace power concavity/convexity statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf2042041c9d252c91435c6f07562bf42c00686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->