### PR TITLE
style(TNLean): fix lint warnings and simplify proofs

### DIFF
--- a/TNLean/Algebra/MatrixOperatorSpace.lean
+++ b/TNLean/Algebra/MatrixOperatorSpace.lean
@@ -44,18 +44,21 @@ attribute [scoped instance]
   Matrix.linftyOpNormedRing
   Matrix.linftyOpNormedAlgebra
 
-instance (n : Type*) [Fintype n] [DecidableEq n] :
-    NormedSpace ℝ (Matrix n n ℂ) :=
+section MatrixInstances
+
+variable (n : Type*) [Fintype n] [DecidableEq n]
+
+instance : NormedSpace ℝ (Matrix n n ℂ) :=
   NormedSpace.restrictScalars ℝ ℂ (Matrix n n ℂ)
 
-instance (n : Type*) [Fintype n] [DecidableEq n] :
-    SMulCommClass ℂ ℝ (Matrix n n ℂ) where
+omit [DecidableEq n] [Fintype n] in
+instance : SMulCommClass ℂ ℝ (Matrix n n ℂ) where
   smul_comm z r A := by
     ext i j
     simp [Complex.real_smul, mul_left_comm, mul_comm]
 
-instance (n : Type*) [Fintype n] [DecidableEq n] :
-    IsScalarTower ℝ ℂ (Matrix n n ℂ) where
+omit [DecidableEq n] [Fintype n] in
+instance : IsScalarTower ℝ ℂ (Matrix n n ℂ) where
   smul_assoc r z A := by
     ext i j
     simp [Complex.real_smul, mul_assoc]
@@ -71,24 +74,24 @@ instance : ContinuousSMul ℝ ℂ :=
 
 abbrev complexContinuousSMulReal : ContinuousSMul ℝ ℂ := inferInstance
 
-instance (n : Type*) [Fintype n] [DecidableEq n] :
-    ContinuousSMul ℝ (Matrix n n ℂ) :=
+omit [DecidableEq n] [Fintype n] in
+instance : ContinuousSMul ℝ (Matrix n n ℂ) :=
   show ContinuousSMul ℝ (RestrictScalars ℝ ℂ (Matrix n n ℂ)) from inferInstance
 
-abbrev matrixContinuousSMulReal (n : Type*) [Fintype n] [DecidableEq n] :
-    ContinuousSMul ℝ (Matrix n n ℂ) := inferInstance
+abbrev matrixContinuousSMulReal : ContinuousSMul ℝ (Matrix n n ℂ) := inferInstance
 
-abbrev matrixScalarTowerRealComplex (n : Type*) [Fintype n] [DecidableEq n] :
-    IsScalarTower ℝ ℂ (Matrix n n ℂ) := inferInstance
+abbrev matrixScalarTowerRealComplex : IsScalarTower ℝ ℂ (Matrix n n ℂ) := inferInstance
 
-instance (n : Type*) [Fintype n] [DecidableEq n] :
-    LinearMap.CompatibleSMul (Matrix n n ℂ) (Matrix n n ℂ) ℝ ℂ :=
+omit [DecidableEq n] [Fintype n] in
+instance : LinearMap.CompatibleSMul (Matrix n n ℂ) (Matrix n n ℂ) ℝ ℂ :=
   LinearMap.IsScalarTower.compatibleSMul
 
-instance (n : Type*) [Fintype n] [DecidableEq n] :
-    LinearMap.CompatibleSMul (Matrix n n ℂ) ℂ ℝ ℂ where
-  map_smul f r A := by
-    exact f.map_smul ((r : ℂ)) A
+omit [DecidableEq n] [Fintype n] in
+instance : LinearMap.CompatibleSMul (Matrix n n ℂ) ℂ ℝ ℂ where
+  map_smul f r A :=
+    f.map_smul (r : ℂ) A
+
+end MatrixInstances
 
 instance (n : Type*) [Fintype n] [DecidableEq n] :
     NormedAddCommGroup (TNLean.MatrixCLM n) :=
@@ -140,16 +143,22 @@ instance (n : Type*) [Fintype n] [DecidableEq n] :
     CompleteSpace (TNLean.MatrixCLM n) :=
   FiniteDimensional.complete ℂ (TNLean.MatrixCLM n)
 
-instance
-    (n m : Type*) [Fintype n] [DecidableEq n] [Fintype m] [DecidableEq m] :
+section MatrixCLMCompatibleSmul
+
+variable (n m : Type*) [Fintype n] [DecidableEq n] [Fintype m] [DecidableEq m]
+
+omit [DecidableEq m] [Fintype m] in
+instance :
     LinearMap.CompatibleSMul (TNLean.MatrixCLM n) (Matrix m m ℂ) ℝ ℂ where
-  map_smul f r A := by
-    exact f.map_smul ((r : ℂ)) A
+  map_smul f r A :=
+    f.map_smul (r : ℂ) A
+
+end MatrixCLMCompatibleSmul
 
 instance (n : Type*) [Fintype n] [DecidableEq n] :
     LinearMap.CompatibleSMul (TNLean.MatrixCLM n) ℂ ℝ ℂ where
-  map_smul f r A := by
-    exact f.map_smul ((r : ℂ)) A
+  map_smul f r A :=
+    f.map_smul (r : ℂ) A
 
 end TNOperatorSpace
 

--- a/TNLean/Algebra/NewtonGirard.lean
+++ b/TNLean/Algebra/NewtonGirard.lean
@@ -66,8 +66,7 @@ private lemma derivative_det_eq_sum (A : Matrix n n R[X]) :
     calc
       derivative (Equiv.Perm.sign σ • ∏ i : n, A (σ i) i)
           = Equiv.Perm.sign σ • derivative (∏ i : n, A (σ i) i) := by
-            simpa using
-              (Polynomial.derivative_smul (Equiv.Perm.sign σ) (∏ i : n, A (σ i) i))
+            simp
       _ = Equiv.Perm.sign σ •
             ∑ j ∈ Finset.univ, (∏ k ∈ Finset.univ.erase j, A (σ k) k) *
               derivative (A (σ j) j) := by

--- a/TNLean/Channel/DensityRetract.lean
+++ b/TNLean/Channel/DensityRetract.lean
@@ -112,7 +112,9 @@ theorem matrixAbs_eq_self_of_posSemidef
 theorem matrixAbs_posSemidef
     (A : Matrix (Fin D) (Fin D) ℂ) :
     (matrixAbs A).PosSemidef := by
-  exact Matrix.nonneg_iff_posSemidef.mp (by simpa [matrixAbs] using (CFC.abs_nonneg A))
+  exact Matrix.nonneg_iff_posSemidef.mp (by
+    change 0 ≤ CFC.abs A
+    simp)
 
 theorem matrixAbs_add_self_posSemidef_of_isHermitian
     {B : Matrix (Fin D) (Fin D) ℂ} (hB : B.IsHermitian) :

--- a/TNLean/Channel/Determinant.lean
+++ b/TNLean/Channel/Determinant.lean
@@ -94,7 +94,7 @@ noncomputable def channelDet (T : MatrixEnd d) : ℂ :=
 /-- `channelDet` agrees with the basis-independent `LinearMap.det`. -/
 theorem channelDet_eq_linearMap_det (T : MatrixEnd d) :
     channelDet T = LinearMap.det T := by
-  unfold channelDet channelMatrix
+  rw [channelDet, channelMatrix]
   exact LinearMap.det_toMatrix (matrixSpaceBasis d) T
 
 /-- Nonzero channel determinant iff the map is a unit in `Module.End`. -/
@@ -209,8 +209,7 @@ private theorem trace_zero_hermitian_eq_smul_density_sub_density [NeZero d]
       simp only [hX_decomp, hQ₁_zero, hQ₂_zero, sub_self]
     let ρ : MatrixAlg d := c⁻¹ • Q₁
     let σ : MatrixAlg d := c⁻¹ • Q₂
-    have hc_inv_nonneg : 0 ≤ c⁻¹ := by
-      simpa only [inv_nonneg] using (inv_nonneg).2 hc_nonneg
+    have hc_inv_nonneg : 0 ≤ c⁻¹ := inv_nonneg.2 hc_nonneg
     have hρ_mem : ρ ∈ densityMatrices d := by
       refine ⟨hQ₁_psd.smul hc_inv_nonneg, ?_⟩
       simp only [trace_smul, smul_eq_mul, ne_eq, hc_ne, not_false_eq_true,
@@ -230,9 +229,8 @@ private theorem positiveTracePreserving_bounded_orbit_of_trace_zero_hermitian [N
     {X : MatrixAlg d} (hX : X.IsHermitian) (htrX : Matrix.trace X = 0) :
     ∃ C : ℝ, ∀ n : ℕ, ‖(T ^ n) X‖ ≤ C := by
   have hmap_density :
-      ∀ ρ : MatrixAlg d, ρ ∈ densityMatrices d → T ρ ∈ densityMatrices d := by
-    intro ρ hρ
-    exact ⟨hPos ρ hρ.1, by rw [hTP ρ, hρ.2]⟩
+      ∀ ρ : MatrixAlg d, ρ ∈ densityMatrices d → T ρ ∈ densityMatrices d :=
+    fun ρ hρ => ⟨hPos ρ hρ.1, by rw [hTP ρ, hρ.2]⟩
   have hiter_density : ∀ n : ℕ, ∀ ρ : MatrixAlg d, ρ ∈ densityMatrices d →
       (T ^ n) ρ ∈ densityMatrices d := by
     intro n

--- a/TNLean/Channel/FixedPoint/StationarySupport.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupport.lean
@@ -133,7 +133,7 @@ private lemma stationaryState_ne_zero
   have htr : Matrix.trace (stationaryState E hE hIrr hD) = 1 :=
     (stationaryState_spec (E := E) hE hIrr hD).1.2
   have : Matrix.trace (stationaryState E hE hIrr hD) = 0 := by
-    simpa [hzero]
+    simp [hzero]
   have h10 : (1 : ℂ) = 0 := by
     calc
       (1 : ℂ) = Matrix.trace (stationaryState E hE hIrr hD) := htr.symm

--- a/TNLean/Channel/Irreducible/Growth.lean
+++ b/TNLean/Channel/Irreducible/Growth.lean
@@ -319,7 +319,6 @@ private lemma mulVecLin_ker_idPlusE_le
     (B + E B).mulVecLin.ker ≤ B.mulVecLin.ker := by
   intro v hv
   rw [LinearMap.mem_ker] at hv ⊢
-  -- hv : (B + E B).mulVecLin v = 0, which is (B + E B) *ᵥ v = 0
   exact Matrix.PosSemidef.mulVec_eq_zero_left hB (hE B hB) v hv
 
 /-- **Strict kernel decrease for irreducible CP maps**:
@@ -341,15 +340,9 @@ theorem mulVecLin_ker_idPlusE_lt_of_not_posDef
   -- From ker(B + E(B)) = ker(B), derive ker(B) ⊆ ker(E(B))
   have hker_sub : ∀ v : Fin D → ℂ, B *ᵥ v = 0 → (E B) *ᵥ v = 0 := by
     intro v hv
-    -- v ∈ ker(B) = ker(B + E(B)), so (B + E(B)) *ᵥ v = 0
     have hv_mem : v ∈ B.mulVecLin.ker := by rwa [LinearMap.mem_ker]
-    rw [← h_eq] at hv_mem
-    rw [LinearMap.mem_ker] at hv_mem
-    -- hv_mem : (B + E B).mulVecLin v = 0, i.e., (B + E B) *ᵥ v = 0
-    -- (B + E B) *ᵥ v = B *ᵥ v + (E B) *ᵥ v = 0 + (E B) *ᵥ v = (E B) *ᵥ v
-    have h_eq' : B *ᵥ v + (E B) *ᵥ v = 0 := by
-      rw [← add_mulVec]; exact hv_mem
-    rwa [hv, zero_add] at h_eq'
+    rw [← h_eq, LinearMap.mem_ker] at hv_mem
+    simpa [add_mulVec, hv] using hv_mem
   exact posDef_of_ker_subset_irreducible_cp E hCP hIrr B hB hBne hker_sub
 
 end KernelDecrease
@@ -378,11 +371,11 @@ private lemma ker_bot_of_posDef
   rw [Submodule.eq_bot_iff]
   intro v hv
   rw [LinearMap.mem_ker] at hv
-  -- hv : B.mulVecLin v = 0, i.e., B *ᵥ v = 0
+  change B *ᵥ v = 0 at hv
   by_contra hne
   obtain ⟨_, hpd⟩ := Matrix.posDef_iff_dotProduct_mulVec.mp hB
   have h_pos : (0 : ℂ) < star v ⬝ᵥ (B *ᵥ v) := hpd hne
-  have h_zero : star v ⬝ᵥ (B *ᵥ v) = 0 := by simp [show B *ᵥ v = 0 from hv]
+  have h_zero : star v ⬝ᵥ (B *ᵥ v) = 0 := by simp [hv]
   linarith
 
 /-- **Wolf Theorem 6.2, item 2 (Growth condition for irreducible CP maps)**:
@@ -404,10 +397,12 @@ theorem growth_posDef_of_irreducible_cp
   have hPos : IsPositiveMap E := hCP.isPositiveMap
   have hT_eq : ∀ X : Matrix (Fin D) (Fin D) ℂ, T X = X + E X :=
     fun X => by simp [T]
-  have hT_psd : ∀ {B : Matrix (Fin D) (Fin D) ℂ}, B.PosSemidef → (T B).PosSemidef :=
-    fun hB => by rw [hT_eq]; exact idPlusE_posSemidef hPos hB
-  have hT_ne : ∀ {B : Matrix (Fin D) (Fin D) ℂ}, B.PosSemidef → B ≠ 0 → T B ≠ 0 :=
-    fun hB hne => by rw [hT_eq]; exact idPlusE_ne_zero hPos hB hne
+  have hT_psd : ∀ {B : Matrix (Fin D) (Fin D) ℂ}, B.PosSemidef → (T B).PosSemidef := by
+    intro B hB
+    simpa [hT_eq B] using idPlusE_posSemidef hPos hB
+  have hT_ne : ∀ {B : Matrix (Fin D) (Fin D) ℂ}, B.PosSemidef → B ≠ 0 → T B ≠ 0 := by
+    intro B hB hne
+    simpa [hT_eq B] using idPlusE_ne_zero hPos hB hne
   -- Induction on n: for PSD nonzero B with finrank(ker B) ≤ n, (T^n)(B) is PD.
   suffices key : ∀ n : ℕ, ∀ B : Matrix (Fin D) (Fin D) ℂ,
       B.PosSemidef → B ≠ 0 →
@@ -435,34 +430,27 @@ theorem growth_posDef_of_irreducible_cp
   intro n
   induction n with
   | zero =>
-    intro B hB hBne hkd
-    -- finrank(ker B) ≤ 0, so = 0, so ker = ⊥, so B is PD
+    intro B hB _ hkd
     have hk0 : Module.finrank ℂ (LinearMap.ker B.mulVecLin) = 0 := Nat.le_zero.mp hkd
-    change ((T ^ 0) B).PosDef
-    simp only [pow_zero]
-    change B.PosDef
-    exact posDef_of_psd_ker_bot hB (Submodule.finrank_eq_zero.mp hk0)
+    simpa [pow_zero] using posDef_of_psd_ker_bot hB (Submodule.finrank_eq_zero.mp hk0)
   | succ n ih =>
     intro B hB hBne hkd
-    -- Use pow_succ to rewrite T^(n+1)(B) = T^n(T(B))
-    show ((T ^ (n + 1)) B).PosDef
     rw [pow_succ, Module.End.mul_apply]
-    -- Goal: ((T ^ n) (T B)).PosDef
     by_cases hBpd : B.PosDef
-    · -- B is PD → T(B) is PD → finrank(ker T(B)) = 0 ≤ n
-      apply ih (T B) (hT_psd hB) (hT_ne hB hBne)
-      have hTBpd : (T B).PosDef := by rw [hT_eq]; exact idPlusE_posDef hPos hBpd
+    · apply ih (T B) (hT_psd hB) (hT_ne hB hBne)
+      have hTBpd : (T B).PosDef := by
+        simpa [hT_eq B] using idPlusE_posDef hPos hBpd
       rw [ker_bot_of_posDef hTBpd]
       simp
-    · -- B is not PD → kernel strictly decreases
-      apply ih (T B) (hT_psd hB) (hT_ne hB hBne)
+    · apply ih (T B) (hT_psd hB) (hT_ne hB hBne)
       have h_lt : (B + E B).mulVecLin.ker < B.mulVecLin.ker :=
         mulVecLin_ker_idPlusE_lt_of_not_posDef E hCP hIrr hB hBne hBpd
       have h_finrank_lt : Module.finrank ℂ (LinearMap.ker (B + E B).mulVecLin) <
           Module.finrank ℂ (LinearMap.ker B.mulVecLin) :=
         Submodule.finrank_lt_finrank_of_lt h_lt
       have hTB : T B = B + E B := hT_eq B
-      rw [hTB]; omega
+      rw [hTB]
+      omega
 
 end Growth
 

--- a/TNLean/Channel/KrausFreedom.lean
+++ b/TNLean/Channel/KrausFreedom.lean
@@ -121,6 +121,8 @@ private abbrev KrausCoeffSpace (r : ℕ) := EuclideanSpace ℂ (Fin r)
 
 private abbrev KrausEntrySpace (D : ℕ) := EuclideanSpace ℂ (Fin D × Fin D)
 
+-- Needed because inferring this `InnerProductSpace` instance triggers a large
+-- typeclass search on `EuclideanSpace` in Lean 4.29.
 set_option synthInstance.maxHeartbeats 16000000 in
 /-- Cached `InnerProductSpace` instance for `EuclideanSpace` to avoid synthesis timeout. -/
 private noncomputable abbrev euclideanIPS (ι : Type*) [Fintype ι] :
@@ -242,8 +244,9 @@ theorem kraus_rectangular_freedom
   -- Key: L sends fA'(v) to fB(v)
   have hL_apply : ∀ v, L_lm ⟨fA' v, LinearMap.mem_range_self fA' v⟩ = fB v := by
     intro v
-    show ((LinearMap.ker fA').liftQ fB hker)
-      (fA'.quotKerEquivRange.symm ⟨fA' v, LinearMap.mem_range_self fA' v⟩) = fB v
+    change ((LinearMap.ker fA').liftQ fB hker)
+        (fA'.quotKerEquivRange.symm ⟨fA' v, LinearMap.mem_range_self fA' v⟩) =
+      fB v
     rw [fA'.quotKerEquivRange_symm_apply_image]
     exact Submodule.liftQ_apply _ _ _
   -- L preserves inner products
@@ -326,8 +329,8 @@ theorem kraus_rectangular_freedom'
       ∑ α : Fin (Fintype.card ι₁), B' α * X * (B' α)ᴴ =
       ∑ j : Fin (Fintype.card ι₂), A' j * X * (A' j)ᴴ := by
     intro X
-    show ∑ α, B (e₁.symm α) * X * (B (e₁.symm α))ᴴ =
-        ∑ j, A (e₂.symm j) * X * (A (e₂.symm j))ᴴ
+    change ∑ α, B (e₁.symm α) * X * (B (e₁.symm α))ᴴ =
+      ∑ j, A (e₂.symm j) * X * (A (e₂.symm j))ᴴ
     rw [e₁.symm.sum_comp (fun i => B i * X * (B i)ᴴ),
         e₂.symm.sum_comp (fun j => A j * X * (A j)ᴴ)]
     exact h X

--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -252,22 +252,39 @@ theorem fixed_eq_scalar_of_irreducible_unital
       (X + Xᴴ) - Complex.I • (Complex.I • (X - Xᴴ)) = (2 : ℂ) • X := by
     calc
       (X + Xᴴ) - Complex.I • (Complex.I • (X - Xᴴ)) = (X + Xᴴ) + (X - Xᴴ) := by
-            simp only [sub_eq_add_neg, smul_add, smul_neg, smul_smul, I_mul_I, neg_smul, one_smul, neg_add_rev, add_right_inj]
+            simp only [
+              sub_eq_add_neg, smul_add, smul_neg, smul_smul, I_mul_I, neg_smul,
+              one_smul, neg_add_rev, add_right_inj
+            ]
             abel
       _ = (2 : ℂ) • X := by
             ext i j
-            simp only [sub_eq_add_neg, add_apply, conjTranspose_apply, RCLike.star_def, neg_apply, add_left_comm, add_assoc, add_neg_cancel, add_zero, smul_apply, smul_eq_mul, two_mul]
+            simp only [
+              sub_eq_add_neg, add_apply, conjTranspose_apply, RCLike.star_def,
+              neg_apply, add_left_comm, add_assoc, add_neg_cancel, add_zero,
+              smul_apply, smul_eq_mul, two_mul
+            ]
   calc
-    X = (1 / 2 : ℂ) • ((2 : ℂ) • X) := by simp only [one_div, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, inv_smul_smul₀]
-    _ = (1 / 2 : ℂ) • ((X + Xᴴ) - Complex.I • (Complex.I • (X - Xᴴ))) := by rw [← hrecon]
+    X = (1 / 2 : ℂ) • ((2 : ℂ) • X) := by
+      simp only [
+        one_div, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, inv_smul_smul₀
+      ]
+    _ = (1 / 2 : ℂ) • ((X + Xᴴ) - Complex.I • (Complex.I • (X - Xᴴ))) := by
+          rw [← hrecon]
     _ = (1 / 2 : ℂ) • ((a • (1 : MatrixAlg D)) - Complex.I • (b • (1 : MatrixAlg D))) := by
           rw [ha, hb]
     _ = ((1 / 2 : ℂ) * (a - Complex.I * b)) • (1 : MatrixAlg D) := by
           ext i j
           by_cases hij : i = j
           · subst hij
-            simp only [one_div, sub_eq_add_neg, smul_apply, add_apply, one_apply_eq, smul_eq_mul, mul_one, neg_apply, mul_comm, mul_left_comm, one_mul]
-          · simp only [one_div, smul_apply, sub_apply, ne_eq, hij, not_false_eq_true, one_apply_ne, smul_eq_mul, mul_zero, sub_self]
+            simp only [
+              one_div, sub_eq_add_neg, smul_apply, add_apply, one_apply_eq, smul_eq_mul,
+              mul_one, neg_apply, mul_comm, mul_left_comm, one_mul
+            ]
+          · simp only [
+              one_div, smul_apply, sub_apply, ne_eq, hij, not_false_eq_true, one_apply_ne,
+              smul_eq_mul, mul_zero, sub_self
+            ]
 
 section PeripheralUnitary
 
@@ -315,7 +332,10 @@ theorem exists_peripheral_unitary_of_irreducible_schwarz
       Kraus.map K (Xᴴ * X) = (Kraus.map K X)ᴴ * Kraus.map K X := hKS_map
       _ = (γ • X)ᴴ * (γ • X) := by rw [hEig_map]
       _ = ((starRingEnd ℂ) γ * γ) • (Xᴴ * X) := by
-            simp only [conjTranspose_smul, RCLike.star_def, Algebra.mul_smul_comm, Algebra.smul_mul_assoc, smul_smul, mul_comm]
+            simp only [
+              conjTranspose_smul, RCLike.star_def, Algebra.mul_smul_comm,
+              Algebra.smul_mul_assoc, smul_smul, mul_comm
+            ]
       _ = Xᴴ * X := by simp only [hγ_starRing_mul, one_smul]
   have hXX_fix : transferMap (d := r) (D := D) K (Xᴴ * X) = Xᴴ * X := by
     simpa [Kraus.map, MPSTensor.transferMap_apply] using hXX_fix_map
@@ -507,11 +527,15 @@ theorem exists_normalized_peripheral_unitary_of_irreducible_schwarz
     calc
       (β • (U : MatrixAlg D))ᴴ * (β • (U : MatrixAlg D)) =
           ((starRingEnd ℂ) β * β) • ((U : MatrixAlg D)ᴴ * (U : MatrixAlg D)) := by
-            simp only [conjTranspose_smul, RCLike.star_def, Algebra.mul_smul_comm, Algebra.smul_mul_assoc, smul_smul, mul_comm]
+            simp only [
+              conjTranspose_smul, RCLike.star_def, Algebra.mul_smul_comm,
+              Algebra.smul_mul_assoc, smul_smul, mul_comm
+            ]
       _ = 1 := by rw [hβ_starRing_mul, hU_star_mul]; simp only [one_smul]⟩, ?_, ?_⟩
   · calc
       transferMap (d := r) (D := D) K (β • (U : MatrixAlg D))
-          = β • transferMap (d := r) (D := D) K (U : MatrixAlg D) := by simp only [map_smul, transferMap_apply]
+          = β • transferMap (d := r) (D := D) K (U : MatrixAlg D) := by
+              simp only [map_smul, transferMap_apply]
       _ = β • (γ • (U : MatrixAlg D)) := by rw [hU]
       _ = γ • (β • (U : MatrixAlg D)) := by simp only [smul_smul, mul_comm]
   · calc
@@ -577,7 +601,10 @@ private lemma pow_oneIdx_of_primitiveRoot {γ : ℂ} (hγprim : IsPrimitiveRoot 
     γ ^ cyclicOneIdx (m := m) = γ := by
   by_cases hm1 : m = 1
   · subst hm1
-    simp only [IsPrimitiveRoot.one_right_iff.mp hγprim, cyclicOneIdx, Fin.isValue, Fin.val_eq_zero, pow_zero]
+    simp only [
+      IsPrimitiveRoot.one_right_iff.mp hγprim, cyclicOneIdx, Fin.isValue, Fin.val_eq_zero,
+      pow_zero
+    ]
   · have hm0 : m ≠ 0 := NeZero.ne m
     have hm_gt : 1 < m := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hm0, hm1⟩
     simp only [cyclicOneIdx, Fin.coe_ofNat_eq_mod, Nat.mod_eq_of_lt hm_gt, pow_one]
@@ -594,6 +621,7 @@ private lemma unitary_pow_oneIdx_of_pow_eq_one
     have hm_gt : 1 < m := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hm0, hm1⟩
     simp only [cyclicOneIdx, Fin.coe_ofNat_eq_mod, Nat.mod_eq_of_lt hm_gt, pow_one]
 
+omit [NeZero m] in
 /-- Finite geometric sums on `Fin m` collapse when the `m`-th power is `1`. -/
 private lemma sum_powers_fin_of_pow_eq_one (x : ℂ) (hxpow : x ^ m = 1) :
     ∑ k : Fin m, x ^ (k : ℕ) = if x = 1 then (m : ℂ) else 0 := by
@@ -729,7 +757,7 @@ private lemma base_cyclic_of_primitiveRoot {γ : ℂ} (hγprim : IsPrimitiveRoot
     simp only [RCLike.star_def, mul_one]
   · have hk_eq : (k : ℕ) + 1 = m := by
       have hle : m ≤ (k : ℕ) + 1 := by
-        exact Nat.le_of_not_gt (show ¬ m > (k : ℕ) + 1 by simpa using hk)
+        exact Nat.le_of_not_gt (by simpa using hk)
       exact le_antisymm (Nat.succ_le_of_lt k.is_lt) hle
     have hval0 : (((k + 1 : Fin m) : ℕ)) = 0 := by
       simp only [Fin.val_add, Fin.coe_ofNat_eq_mod, Nat.add_mod_mod, hk_eq, Nat.mod_self]
@@ -985,6 +1013,7 @@ private lemma left_mul_cyclicProjection_eq {γ : ℂ} (hγprim : IsPrimitiveRoot
     _ = γ ^ (k : ℕ) • cyclicProjection (m := m) (γ := γ) U k := by
           exact cyclic_projection_step3_shifted_sum_eq_smul (m := m) (γ := γ) U k
 
+omit [NeZero m] in
 /-- Each cyclic projection commutes with the generating unitary. -/
 private lemma commute_unitary_cyclicProjection {γ : ℂ}
     (U : Matrix.unitaryGroup (Fin D) ℂ) :
@@ -1049,7 +1078,10 @@ private lemma sum_cyclicProjection_eq_one {γ : ℂ} (hγprim : IsPrimitiveRoot 
             have hm0 : m ≠ 0 := NeZero.ne m
             exact hm (by simp only [mem_range, Nat.pos_of_ne_zero hm0])
     _ = 1 := by
-          simp only [pow_zero, ne_eq, Nat.cast_eq_zero, NeZero.ne m, not_false_eq_true, inv_smul_smul₀]
+          simp only [
+            pow_zero, ne_eq, Nat.cast_eq_zero, NeZero.ne m, not_false_eq_true,
+            inv_smul_smul₀
+          ]
 
 /-- Summing the cyclic projections against their phases reconstructs `U`. -/
 private lemma unitary_eq_sum_cyclicProjection {γ : ℂ} (hγprim : IsPrimitiveRoot γ m)
@@ -1135,12 +1167,16 @@ private lemma unitary_eq_sum_cyclicProjection {γ : ℂ} (hγprim : IsPrimitiveR
           rw [unitary_pow_oneIdx_of_pow_eq_one (m := m) U hUm]
           simp only [ne_eq, Nat.cast_eq_zero, NeZero.ne m, not_false_eq_true, inv_smul_smul₀]
 
+omit [NeZero m] in
 /-- Distinct exponents of a primitive root stay distinct on `Fin m`. -/
 private lemma pow_inj_of_primitiveRoot {γ : ℂ} (hγprim : IsPrimitiveRoot γ m) :
     ∀ {a b : Fin m}, γ ^ (a : ℕ) = γ ^ (b : ℕ) → a = b := by
   intro a b hab
   apply Fin.ext
-  exact hγprim.injOn_pow (by simp only [coe_range, Set.mem_Iio, a.is_lt]) (by simp only [coe_range, Set.mem_Iio, b.is_lt]) hab
+  exact hγprim.injOn_pow
+    (by simp only [coe_range, Set.mem_Iio, a.is_lt])
+    (by simp only [coe_range, Set.mem_Iio, b.is_lt])
+    hab
 
 /-- The product of two cyclic projections is simultaneously a left eigenvector in both indices. -/
 private lemma cyclic_projection_step4_mul_projection_eigen_relations {γ : ℂ}
@@ -1264,7 +1300,7 @@ private lemma unitary_mul_star_cyclicProjection_eq {γ : ℂ} (hγprim : IsPrimi
       congrArg Matrix.conjTranspose
         (right_mul_cyclicProjection_eq (m := m) hγprim U hUm k)
   have hU_mul_star : (U : MatrixAlg D) * (U : MatrixAlg D)ᴴ = 1 := by
-    exact (show (U : MatrixAlg D) * (U : MatrixAlg D)ᴴ = 1 from U.2.2)
+    exact U.2.2
   have hpre :
       (cyclicProjection (m := m) (γ := γ) U k)ᴴ =
         star (γ ^ (k : ℕ)) • ((U : MatrixAlg D) * (cyclicProjection (m := m) (γ := γ) U k)ᴴ) := by
@@ -1289,7 +1325,8 @@ private lemma unitary_mul_star_cyclicProjection_eq {γ : ℂ} (hγprim : IsPrimi
         γ ^ (k : ℕ) • (cyclicProjection (m := m) (γ := γ) U k)ᴴ := by
     calc
       (U : MatrixAlg D) * (cyclicProjection (m := m) (γ := γ) U k)ᴴ =
-          (1 : ℂ) • ((U : MatrixAlg D) * (cyclicProjection (m := m) (γ := γ) U k)ᴴ) := by simp only [one_smul]
+          (1 : ℂ) • ((U : MatrixAlg D) * (cyclicProjection (m := m) (γ := γ) U k)ᴴ) := by
+            simp only [one_smul]
       _ = (γ ^ (k : ℕ) * star (γ ^ (k : ℕ))) •
             ((U : MatrixAlg D) * (cyclicProjection (m := m) (γ := γ) U k)ᴴ) := by
               rw [← hunit]
@@ -1464,7 +1501,10 @@ theorem exists_cyclic_decomposition_of_irreducible_schwarz
     rw [hperiph]
     by_cases hm1 : m = 1
     · subst hm1
-      simp only [IsPrimitiveRoot.one_right_iff.mp hγprim, Fin.val_eq_zero, pow_zero, Set.range_const, Set.mem_singleton_iff]
+      simp only [
+        IsPrimitiveRoot.one_right_iff.mp hγprim, Fin.val_eq_zero, pow_zero, Set.range_const,
+        Set.mem_singleton_iff
+      ]
     · have hm0 : m ≠ 0 := NeZero.ne m
       have hm_gt : 1 < m := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hm0, hm1⟩
       exact ⟨⟨1, hm_gt⟩, by simp only [pow_one]⟩
@@ -1703,6 +1743,7 @@ section PermutationBlockStructure
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
+omit [Fintype ι] [DecidableEq ι] in
 /-- Permutation-based variant of `preserves_corner_pow_of_cyclic_decomp`.
 
 This isolates the part of Wolf Thm. 6.16 that only needs a permutation action on blocks:
@@ -1731,7 +1772,10 @@ theorem preserves_corner_pow_orderOf_of_perm_decomp
         calc
           (T ^ (n + 1)) (P ((σ ^ (n + 1)) k) * X * P ((σ ^ (n + 1)) k))
               = (T ^ n) (T (P ((σ ^ (n + 1)) k) * X * P ((σ ^ (n + 1)) k))) := by
-                  simp only [pow_succ, Equiv.Perm.coe_mul, Function.comp_apply, Module.End.mul_apply]
+                  simp only [
+                    pow_succ, Equiv.Perm.coe_mul, Function.comp_apply,
+                    Module.End.mul_apply
+                  ]
           _ = (T ^ n) (T (P (σ ((σ ^ n) k)) * X * P (σ ((σ ^ n) k)))) := by
                   simp only [pow_succ', Equiv.Perm.coe_mul, Function.comp_apply]
           _ = (T ^ n) (P ((σ ^ n) k) * T X * P ((σ ^ n) k)) := by

--- a/TNLean/Channel/Schwarz/PositiveOnAbelian.lean
+++ b/TNLean/Channel/Schwarz/PositiveOnAbelian.lean
@@ -38,10 +38,10 @@ Euclidean linear map level. -/
 private lemma toEuclideanLin_mul (A B : Matrix (Fin D) (Fin D) ℂ) :
     (Matrix.toEuclideanLin A : EuclideanSpace ℂ (Fin D) →ₗ[ℂ] EuclideanSpace ℂ (Fin D)) *
       Matrix.toEuclideanLin B = Matrix.toEuclideanLin (A * B) := by
-  simp only [Matrix.toEuclideanLin_eq_toLin_orthonormal]
-  exact (Matrix.toLin_mul (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
-    (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
-    (EuclideanSpace.basisFun (Fin D) ℂ).toBasis A B).symm
+  simpa only [Matrix.toEuclideanLin_eq_toLin_orthonormal] using
+    (Matrix.toLin_mul (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
+      (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
+      (EuclideanSpace.basisFun (Fin D) ℂ).toBasis A B).symm
 
 /-- Quadratic-form positivity for a block matrix with matrix entries.
 
@@ -931,9 +931,8 @@ private lemma exists_diagonal_family_of_normal
     fun μ => Klin.restrict (hKinv μ)
   have hKrestr : ∀ μ : Eigenvalues Hlin,
       @LinearMap.IsSymmetric ℂ (Module.End.eigenspace Hlin μ) _ _ _
-        (Klin.restrict (hKinv μ)) := by
-    intro μ
-    exact hKlin.restrict_invariant (hKinv μ)
+        (Klin.restrict (hKinv μ)) :=
+    fun μ => hKlin.restrict_invariant (hKinv μ)
   let bFamily : ∀ μ : Eigenvalues Hlin,
       OrthonormalBasis (Fin (Module.finrank ℂ (Module.End.eigenspace Hlin μ))) ℂ
         (Module.End.eigenspace Hlin μ) :=

--- a/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
@@ -429,7 +429,7 @@ theorem commuting_dominant_right_bound
       rw [Matrix.le_iff]
       simpa only [Complex.coe_smul, sub_zero] using
         (Matrix.PosSemidef.one (n := Fin D) (R := ℂ)).smul hε.le
-  exact commuting_dominant_right_bound_posDef A _ hPD hComm' hDom'
+  simpa using commuting_dominant_right_bound_posDef A _ hPD hComm' hDom'
 
 /-- CP/Kraus version of Wolf Thm. 5.6 under both dominant bounds.
 
@@ -468,7 +468,7 @@ theorem kadison_schwarz_commuting_dominant_cp_of_two_sided_bound
     simpa only [krausAdjointMap_conjTranspose, conjTranspose_conjTranspose] using hKSRight'
   have hDomRightMap : krausAdjointMap K (A * Aᴴ) ≤ krausAdjointMap K Dom := by
     simpa only using hPosT.map_le_map hDomRight
-  exact ⟨hKSLeft.trans hDomLeftMap, hKSRight.trans hDomRightMap⟩
+  refine ⟨hKSLeft.trans hDomLeftMap, hKSRight.trans hDomRightMap⟩
 
 /-- Wolf Thm. 5.6 in the CP/Kraus setting.
 
@@ -485,8 +485,9 @@ theorem kadison_schwarz_commuting_dominant_cp
       krausAdjointMap K A * krausAdjointMap K (Aᴴ) ≤ krausAdjointMap K Dom := by
   have hDomRight : A * Aᴴ ≤ Dom :=
     commuting_dominant_right_bound (A := A) (Dom := Dom) hDomPos hComm hDom
-  exact kadison_schwarz_commuting_dominant_cp_of_two_sided_bound
-    (K := K) h_tp A Dom hDomPos hComm hDom hDomRight
+  simpa using
+    kadison_schwarz_commuting_dominant_cp_of_two_sided_bound
+      (K := K) h_tp A Dom hDomPos hComm hDom hDomRight
 
 private lemma intertwine_sqrt_of_mul_eq
     (P Q A : Mat)

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -120,6 +120,83 @@ def IsNPositiveMap (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : P
 def Is2PositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
   IsNPositiveMap 2 E
 
+private theorem posSemidef_fromBlocks_zero_zero
+    {m o : Type*} {A : Matrix m m ℂ} (hA : A.PosSemidef) :
+    (Matrix.fromBlocks A 0 0 (0 : Matrix o o ℂ)).PosSemidef := by
+  refine ⟨Matrix.IsHermitian.fromBlocks hA.1 (by simp) isHermitian_zero, ?_⟩
+  intro x
+  let fg := Finsupp.sumFinsuppEquivProdFinsupp x
+  let xL : m →₀ ℂ := fg.1
+  let xR : o →₀ ℂ := fg.2
+  have hx : x = Finsupp.sumElim xL xR := by
+    exact (Finsupp.sumFinsuppEquivProdFinsupp.symm_apply_apply x).symm
+  rw [hx, Finsupp.sumElim_eq_add, Finsupp.sum_add_index']
+  · have hRight :
+        (Finsupp.mapDomain Sum.inr xR).sum (fun i xi =>
+            (Finsupp.mapDomain Sum.inl xL + Finsupp.mapDomain Sum.inr xR).sum fun j xj =>
+              star xi * (Matrix.fromBlocks A 0 0 (0 : Matrix o o ℂ)) i j * xj) = 0 := by
+      rw [Finsupp.sum_mapDomain_index]
+      · have hInner (a : o) (x₁ : ℂ) :
+          (Finsupp.mapDomain Sum.inl xL + Finsupp.mapDomain Sum.inr xR).sum (fun j xj =>
+              star x₁ * (Matrix.fromBlocks A 0 0 (0 : Matrix o o ℂ)) (Sum.inr a) j * xj) = 0 := by
+          rw [Finsupp.sum_add_index']
+          · rw [Finsupp.sum_mapDomain_index, Finsupp.sum_mapDomain_index]
+            · simp
+            · intro i
+              simp
+            · intro i u v
+              simp [mul_assoc, mul_add]
+            · intro i
+              simp
+            · intro i u v
+              simp [mul_assoc, mul_add]
+          · intro i
+            simp
+          · intro i u v
+            simp [mul_assoc, mul_add]
+        rw [Finsupp.sum]
+        refine Finset.sum_eq_zero ?_
+        intro a ha
+        exact hInner a (xR a)
+      · intro i
+        simp
+      · intro i u v
+        simp [add_mul, mul_assoc]
+    have hLeft :
+        (Finsupp.mapDomain Sum.inl xL).sum (fun i xi =>
+            (Finsupp.mapDomain Sum.inl xL + Finsupp.mapDomain Sum.inr xR).sum fun j xj =>
+              star xi * (Matrix.fromBlocks A 0 0 (0 : Matrix o o ℂ)) i j * xj) =
+          xL.sum (fun i xi => xL.sum fun j xj => star xi * A i j * xj) := by
+      rw [Finsupp.sum_mapDomain_index]
+      · apply Finsupp.sum_congr
+        intro a x₁
+        rw [Finsupp.sum_add_index']
+        · rw [Finsupp.sum_mapDomain_index, Finsupp.sum_mapDomain_index]
+          · simp [mul_assoc]
+          · intro i
+            simp
+          · intro i u v
+            simp [mul_assoc, mul_add]
+          · intro i
+            simp
+          · intro i u v
+            simp [mul_assoc, mul_add]
+        · intro i
+          simp
+        · intro i u v
+          simp [mul_assoc, mul_add]
+      · intro i
+        simp
+      · intro i u v
+        simp [add_mul, mul_assoc]
+    rw [hLeft, hRight]
+    simpa using hA.2 xL
+  · intro i
+    simp
+  · intro i u v
+    simp [add_mul, mul_assoc]
+
+omit [DecidableEq n] in
 /-- A completely positive map is n-positive for every `n`.
 
 This follows immediately from the definition: CP maps have Kraus representations,
@@ -127,6 +204,7 @@ and `E ⊗ id_k` applied to a PSD matrix yields a PSD matrix (by the same
 Kraus-based argument as `IsCPMap.isPositiveMap`). -/
 theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (hCP : IsCPMap E) (k : ℕ) : IsNPositiveMap k E := by
+  classical
   intro X hX
   obtain ⟨r, K, hK⟩ := hCP
   let e : n × Fin k ≃ Fin k × n := Equiv.prodComm n (Fin k)
@@ -148,8 +226,7 @@ theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     rfl
   have hYswap :
       (F Yblk).PosSemidef := by
-    rw [show F Yblk = ∑ a, F (D a * Xblk * (D a)ᴴ) by
-      simp [Yblk]]
+    rw [show F Yblk = ∑ a, F (D a * Xblk * (D a)ᴴ) by simp [Yblk]]
     refine Matrix.posSemidef_sum (s := Finset.univ)
       (x := fun a => F (D a * Xblk * (D a)ᴴ)) ?_
     intro a _
@@ -190,6 +267,7 @@ theorem IsCPMap.isNPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
       E (Xblk ip.2 jq.2) ip.1 jq.1
   rw [hXblk_apply ip.2 jq.2]
 
+omit [DecidableEq n] [Fintype n] in
 /-- **Monotonicity sanity check**: `(k+1)`-positive implies `k`-positive.
 
 This is a basic structural property of the n-positivity hierarchy. If this
@@ -213,21 +291,23 @@ theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k :
     rw [finSumFinEquiv_symm_apply_castSucc]
     simp
   have hX' : X'.PosSemidef := by
-    simpa [X', Matrix.reindex_apply] using
-      (Matrix.PosSemidef.fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))).submatrix e
-  -- Apply (k+1)-positivity
+    have hdiag : (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ)).PosSemidef :=
+      posSemidef_fromBlocks_zero_zero hX
+    simpa [X', Matrix.reindex_apply] using hdiag.submatrix e
   have hY' := h X' hX'
-  -- Extract the k-block from the result
   let emb : n × Fin k → n × Fin (k + 1) := fun ip => (ip.1, Fin.castSucc ip.2)
   convert hY'.submatrix emb using 1
   ext ip jq
   simp [emb, X', Matrix.reindex_apply, he_castSucc]
 
+omit [DecidableEq n] in
 /-- CP maps are 2-positive. -/
 theorem IsCPMap.is2PositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
-    (hCP : IsCPMap E) : Is2PositiveMap E :=
-  hCP.isNPositiveMap 2
+    (hCP : IsCPMap E) : Is2PositiveMap E := by
+  classical
+  exact hCP.isNPositiveMap 2
 
+omit [DecidableEq n] [Fintype n] in
 /-- 2-positive maps are positive.
 
 Apply the definition with `k = 1` embedded into `k = 2`: given PSD `X`,
@@ -236,16 +316,14 @@ output, then extract the (0,0)-block which equals `E(X)`. -/
 theorem Is2PositiveMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (h : Is2PositiveMap E) : IsPositiveMap E := by
   intro X hX
-  let e : n × Fin 2 ≃ n ⊕ n :=
-    finTwoSumEquiv n
+  let e : n × Fin 2 ≃ n ⊕ n := finTwoSumEquiv n
   let X' : Matrix (n × Fin 2) (n × Fin 2) ℂ :=
     Matrix.reindex e.symm e.symm (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ))
   have hX' : X'.PosSemidef := by
-    simpa [X', Matrix.reindex_apply] using
-      (Matrix.PosSemidef.fromBlocks_diag hX (Matrix.PosSemidef.zero (n := n) (R := ℂ))).submatrix e
-  -- Apply 2-positivity to X'
+    have hdiag : (Matrix.fromBlocks X 0 0 (0 : Matrix n n ℂ)).PosSemidef :=
+      posSemidef_fromBlocks_zero_zero hX
+    simpa [X', Matrix.reindex_apply] using hdiag.submatrix e
   have hY' := h X' hX'
-  -- The (0,0)-block of the result is E(X), which is PSD as a principal submatrix
   let emb : n → n × Fin 2 := fun i => (i, 0)
   simpa [emb, X', Matrix.reindex_apply] using hY'.submatrix emb
 

--- a/TNLean/Channel/Semigroup/LindbladForm/Basic.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/Basic.lean
@@ -182,7 +182,7 @@ theorem LindbladForm.toLinearMap_eq_generatorDecomp (F : LindbladForm D) :
   rw [add_mul, smul_mul_assoc, smul_mul_assoc]
   -- Expand ρκ† = ρ(-iH + ½S) = -iρH + ½ρS
   rw [mul_add, mul_smul_comm, mul_smul_comm, neg_smul]
-  simp only [sub_eq_add_neg, neg_add, neg_neg]
+  simp only [sub_eq_add_neg, neg_add]
   rw [smul_add (Complex.I) (ρ * F.H) (-(F.H * ρ)), smul_neg]
   abel
 

--- a/TNLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
@@ -53,8 +53,7 @@ theorem generator_shift_invariance
   have hmu : star (Complex.I * ↑mu) = (-Complex.I) * ↑mu := by
     simp only [star_mul', Complex.star_def, Complex.conj_I, Complex.conj_ofReal]
   simp only [hmu, RCLike.star_def, one_div, RingHomCompTriple.comp_apply,
-    RingHom.id_apply, star_mul', neg_mul, neg_smul, neg_neg, star_inv₀,
-    star_ofNat]
+    RingHom.id_apply, star_mul', neg_mul, neg_smul, star_inv₀, star_ofNat]
   have hnorm : ∀ i : Fin r, c i * starRingEnd ℂ (c i) = starRingEnd ℂ (c i) * c i := by
     intro i; ring
   simp_rw [hnorm]

--- a/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
@@ -76,7 +76,7 @@ private lemma expSemigroupCLM_mul_comm_local
   unfold expSemigroupCLM
   have hc : Commute ((s : ℂ) • L_CLM) L_CLM := by
     ext X i j
-    simp [ContinuousLinearMap.mul_apply]
+    simp
   exact hc.exp_left.eq
 
 /-- `trace(Lⁿ(ρ)) = 0` for `n ≥ 1` when `L` is trace-annihilating.

--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -136,7 +136,7 @@ theorem duhamel_formula
   -- Simplify f(t) - f(0):
   -- f(t) = expSemigroupCLM L (t - t) * expSemigroupCLM L' t = 1 * T' t = T' t
   -- f(0) = expSemigroupCLM L (t - 0) * expSemigroupCLM L' 0 = T t * 1 = T t
-  simpa [sub_self, sub_zero, expSemigroupCLM_zero, one_mul, mul_one]
+  simp [sub_self, sub_zero, expSemigroupCLM_zero, one_mul, mul_one]
 
 /-! ## Helper for biSup bounds -/
 

--- a/TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean
@@ -151,7 +151,7 @@ theorem generatorPreservesCompression_of_semigroupPreservesCompression
         simp [mul_add, add_mul, Matrix.mul_assoc]
       map_smul' := by
         intro r M
-        simp [Complex.real_smul, Matrix.mul_assoc] }
+        simp [Matrix.mul_assoc] }
   have hcompress_apply : ∀ M : Mat, compress M = P * M * P := fun M => by
     rfl
   -- Build a CLM from compress

--- a/TNLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/TNLean/Channel/Semigroup/RelaxationConditions.lean
@@ -391,7 +391,7 @@ private theorem finrank_traceless_submodule
     rw [this, finrank_top]
     exact Module.finrank_self ℂ
   rw [h_range] at h_rn
-  show Module.finrank ℂ (LinearMap.ker τ) = D * D - 1
+  change Module.finrank ℂ (LinearMap.ker τ) = D * D - 1
   omega
 
 /-- The eigenvalues of an orthogonal projection are all `0` or `1`. -/
@@ -538,8 +538,8 @@ private theorem finrank_range_block_compression_ge
             · obtain ⟨rfl, rfl⟩ := hij
               simp [ha, hb]
             · simp
-          show (1 - P) * ((U : Mat) * E * star (U : Mat) * P) =
-              (U : Mat) * E * star (U : Mat)
+          change (1 - P) * ((U : Mat) * E * star (U : Mat) * P) =
+            (U : Mat) * E * star (U : Mat)
           have h1PU : (1 - P) * (U : Mat) = (U : Mat) * (1 - D₁) := by
             rw [Matrix.sub_mul, Matrix.one_mul, hPU, Matrix.mul_sub, Matrix.mul_one]
           calc
@@ -586,7 +586,7 @@ private theorem finrank_range_block_compression_ge
                (by simpa [S₀] using ha) (by simpa [S₁] using hb)⟩⟩
         have hfam_li : LinearIndependent ℂ fam := by
           apply LinearIndependent.of_comp (LinearMap.range φ).subtype
-          show LinearIndependent ℂ (fun p : ↥S₀ × ↥S₁ => (fam p : Mat))
+          change LinearIndependent ℂ (fun p : ↥S₀ × ↥S₁ => (fam p : Mat))
           have hfam_eq : (fun p : ↥S₀ × ↥S₁ => (fam p : Mat)) =
               (fun M : Mat => (U : Mat) * M * star (U : Mat)) ∘
                 (fun p : ↥S₀ × ↥S₁ => Matrix.single p.1.1 p.2.1 (1 : ℂ)) := by

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -97,7 +97,7 @@ representations of quantum channels.
 | Prop 2.2 (decomp into CP) | Straightforward from CJ |
 | Prop 2.3 (no info w/o disturbance) | Needs pure state uniqueness |
 | Prop 2.4 (equiv of ensembles) | Needs purification/Schmidt decomp |
-| Thm 2.1 item 4 (rectangular Kraus freedom, necessary direction) | `kraus_rectangular_freedom` / `kraus_rectangular_freedom'` — fully proved ✅ |
+| Thm 2.1 item 4 | See `kraus_rectangular_freedom` and `kraus_rectangular_freedom'` ✅ |
 | Thm 2.3 (ordered CP-maps) | Needs Stinespring + contraction |
 | Thm 2.4 (Radon-Nikodym) | Follows from Thm 2.3 |
 | Thm 2.5 (open-system representation) | Embedding into unitary |

--- a/TNLean/MPS/BNT/PermutationRigidity.lean
+++ b/TNLean/MPS/BNT/PermutationRigidity.lean
@@ -398,8 +398,7 @@ private lemma tendsto_norm_selfOverlap_one
     (hSelf :
       Tendsto (fun N => mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ))) :
     Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) atTop (nhds 1) := by
-  convert hSelf.norm using 1
-  simp
+  simpa using hSelf.norm
 
 private lemma tendsto_norm_mpvOverlap_one_of_scaled_self
     {d D₁ D₂ : ℕ}
@@ -410,25 +409,16 @@ private lemma tendsto_norm_mpvOverlap_one_of_scaled_self
     (hScale :
       ∀ N, mpvOverlap (d := d) A B N = s N * mpvOverlap (d := d) B B N) :
     Tendsto (fun N => ‖mpvOverlap (d := d) A B N‖) atTop (nhds 1) := by
-  have heq :
+  have hEq :
       (fun N => ‖mpvOverlap (d := d) A B N‖) =
-        fun N => ‖s N‖ * ‖mpvOverlap (d := d) B B N‖ := by
+        fun N => ‖mpvOverlap (d := d) B B N‖ := by
     ext N
-    rw [hScale N, norm_mul]
-  rw [heq]
-  have heq' :
-      (fun N => ‖s N‖ * ‖mpvOverlap (d := d) B B N‖) =
-        fun N => 1 * ‖mpvOverlap (d := d) B B N‖ := by
-    ext N
-    simp [hs_norm N]
-  rw [heq']
-  simpa only [one_mul] using hSelf
+    rw [hScale N, norm_mul, hs_norm N, one_mul]
+  simpa [hEq] using hSelf
 
 private lemma ne_zero_of_norm_eq_one (ζ : ℂ) (hζ_norm : ‖ζ‖ = 1) : ζ ≠ 0 := by
   intro h0
-  have hnorm : (‖ζ‖ : ℝ) = 0 := by simp [h0]
-  rw [hζ_norm] at hnorm
-  exact one_ne_zero hnorm
+  simp [h0] at hζ_norm
 
 private lemma rightMatching_injective_of_gaugePhaseEquiv
     {d gA gB : ℕ}

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -711,6 +711,13 @@ private lemma cyclicShift_succ {m : ℕ} [NeZero m] (k : Fin m) (n : ℕ) :
   change ((↑k + n) + 1) % m = (((↑k + n) % m) + 1 % m) % m
   exact Nat.add_mod (↑k + n) 1 m
 
+private lemma cyclicShift_succ_left {m : ℕ} [NeZero m] (k : Fin m) (n : ℕ) :
+    cyclicShift k (n + 1) = cyclicShift (k + 1) n := by
+  ext
+  simp [cyclicShift, Fin.val_add]
+  congr 1
+  omega
+
 @[simp] private lemma cyclicShift_self {m : ℕ} [NeZero m] (k : Fin m) :
     cyclicShift k m = k := by
   ext
@@ -725,65 +732,24 @@ theorem adjointTransferMap_pow_fixes_cyclic_projection
     (P : Fin m → MatrixAlg D)
     (hcyclic : ∀ k : Fin m, transferMap (d := d) (D := D) K (P (k + 1)) = P k) :
     ∀ k : Fin m, ((transferMap (d := d) (D := D) K) ^ m) (P k) = P k := by
-  -- Strategy: prove (E†)^n (P (k + n)) = P k for Fin m addition, by induction on n.
-  -- For n = m, k + m = k in Fin m, so (E†)^m (P k) = P k.
-  -- The key is: (E†)^(n+1) (P (k + (n+1))) = E†((E†)^n (P (k + (n+1))))
-  -- = E†((E†)^n (P ((k+1) + n)))     [since k + (n+1) = (k+1) + n in Fin m]
-  -- = E†(P (k+1))                     [by IH with k' = k+1]
-  -- = P k                              [by hcyclic]
-  -- Prove: ∀ n, ∀ k, (E†)^n (P (k + n)) = P k  where n is a Fin m literal.
-  -- We use Nat.rec on n, carrying a proof that the Fin m literal n is (n % m).
-  -- But this is cleaner using hcyclic directly in a simple induction.
-  -- Base: (E†)^0 (P (k + 0)) = P k  ✓
-  -- Step: (E†)^(n+1) (P (k + (n+1)))
-  --     = E†((E†)^n (P (k + (n+1))))     [pow decomp]
-  --     = E†((E†)^n (P ((k+1) + n)))     [Fin m add assoc]
-  --     = E†(P (k+1))                    [IH with k' = k+1]
-  --     = P k                             [hcyclic]
-  -- At n = m: k + m = k in Fin m, so (E†)^m (P k) = P k.
   intro k
-  -- Direct approach: iterate hcyclic m times
-  suffices ∀ n : ℕ, n ≤ m →
-      ∀ (k : Fin m), ((transferMap (d := d) (D := D) K) ^ n)
-        (P ⟨((k : ℕ) + n) % m, Nat.mod_lt _ (Nat.pos_of_ne_zero (NeZero.ne m))⟩) = P k by
-    have h := this m le_rfl k
-    simpa [Nat.add_mod_right, Nat.mod_eq_of_lt k.is_lt] using h
-  intro n
-  induction n with
-  | zero =>
-    intro _ k
-    simp [Nat.mod_eq_of_lt k.is_lt]
-  | succ n ih =>
-    intro hn k
-    have hn' : n ≤ m := Nat.le_of_succ_le hn
-    have hlt : ((k : ℕ) + (n + 1)) % m < m :=
-      Nat.mod_lt _ (Nat.pos_of_ne_zero (NeZero.ne m))
-    -- Decompose the power
-    have hpow : ((transferMap (d := d) (D := D) K) ^ (n + 1))
-        (P ⟨((k : ℕ) + (n + 1)) % m, hlt⟩) =
-        (transferMap (d := d) (D := D) K)
-          (((transferMap (d := d) (D := D) K) ^ n)
-            (P ⟨((k : ℕ) + (n + 1)) % m, hlt⟩)) := by
-      rw [pow_succ']; rfl
-    rw [hpow]
-    -- (k + (n+1)) % m = ((k+1) + n) % m
-    have hmod : ((k : ℕ) + (n + 1)) % m = (((k : ℕ) + 1) + n) % m := by
-      congr 1; omega
-    -- Create the Fin m index for (k+1)
-    set k1 : Fin m := k + 1
-    -- Apply IH with k' = k+1
-    have := ih hn' k1
-    -- ih says: (E†)^n (P ⟨(↑k1 + n) % m, _⟩) = P k1
-    -- We need: (E†)^n (P ⟨((↑k + n + 1)) % m, _⟩) = P k1
-    -- Since (↑k + (n+1)) % m = (↑k1 + n) % m
-    have hval_eq : ((k : ℕ) + (n + 1)) % m = ((k1 : ℕ) + n) % m := by
-      simp [k1, Fin.val_add]; omega
-    have hfin_eq :
-        (⟨((k : ℕ) + (n + 1)) % m, Nat.mod_lt _ (Nat.pos_of_ne_zero (NeZero.ne m))⟩ : Fin m) =
-          ⟨((k1 : ℕ) + n) % m, Nat.mod_lt _ (Nat.pos_of_ne_zero (NeZero.ne m))⟩ := by
-      ext; exact hval_eq
-    rw [hfin_eq, this]
-    exact hcyclic k
+  have hiter :
+      ∀ n : ℕ, ∀ k : Fin m,
+        ((transferMap (d := d) (D := D) K) ^ n) (P (cyclicShift k n)) = P k := by
+    intro n
+    induction n with
+    | zero =>
+        intro k
+        simp
+    | succ n ih =>
+        intro k
+        rw [pow_succ', cyclicShift_succ_left]
+        change
+          transferMap (d := d) (D := D) K
+            (((transferMap (d := d) (D := D) K) ^ n) (P (cyclicShift (k + 1) n))) = P k
+        rw [ih (k + 1)]
+        exact hcyclic k
+  simpa using hiter m k
 
 /-- The adjoint of the blocked transfer map equals the `m`-th iterate of the
 adjoint transfer map:
@@ -911,7 +877,7 @@ theorem exists_cyclic_sector_decomp_after_blocking
       obtain ⟨k₀, hk₀⟩ := h
       -- If P(j+1) = 0 then P(j) = E†(P(j+1)) = E†(0) = 0
       have hback : ∀ j : Fin m, P (j + 1) = 0 → P j = 0 := fun j hj => by
-        rw [show P j = transferMap K (P (j + 1)) from (hcyclic j).symm, hj, map_zero]
+        simpa [hj] using (hcyclic j).symm
       -- Every j is zero: induct on backward distance (k₀ - j).val
       have hall : ∀ j : Fin m, P j = 0 := by
         suffices hs : ∀ n : ℕ, n < m → ∀ j : Fin m,
@@ -934,8 +900,8 @@ theorem exists_cyclic_sector_decomp_after_blocking
           rw [h_eq, Fin.val_sub_one_of_ne_zero (by intro h; simp [h] at hj)]
           omega
       -- Contradiction: ∑ P_k = 0 ≠ 1
-      exact absurd (show (∑ k, P k) = 0 from Finset.sum_eq_zero (fun k _ => hall k))
-        (by rw [hPsum]; exact one_ne_zero)
+      have hsum_zero : ∑ k, P k = 0 := Finset.sum_eq_zero fun k _ => hall k
+      exact absurd hsum_zero (by rw [hPsum]; exact one_ne_zero)
     -- Second: dim k ≠ 0 follows from P k ≠ 0 via the trace relation
     intro k hk
     apply hPne k

--- a/TNLean/MPS/Chain/TensorEquality.lean
+++ b/TNLean/MPS/Chain/TensorEquality.lean
@@ -45,7 +45,7 @@ variable {d D : ℕ}
               simp [sub_mul]
       _ = Matrix.trace (A₁ i * X * A₂ j) - Matrix.trace (B₁ i * X * B₂ j) := by
             rw [hcycA, hcycB]
-      _ = 0 := by simpa [hX]
+      _ = 0 := by simp [hX]
   exact sub_eq_zero.mp hzero
 
 /-- External insertion trace agreement implies equality of the mixed products
@@ -73,7 +73,7 @@ variable {d D : ℕ}
               simp [sub_mul]
       _ = Matrix.trace (A₂ j * Y * A₁ i) - Matrix.trace (B₂ j * Y * B₁ i) := by
             rw [hcycA, hcycB]
-      _ = 0 := by simpa [hY]
+      _ = 0 := by simp [hY]
   exact sub_eq_zero.mp hzero
 
 /-- Lemma 2 of arXiv:1804.04964 (2-site case): two injective tensor pairs that

--- a/TNLean/MPS/Examples/AKLT.lean
+++ b/TNLean/MPS/Examples/AKLT.lean
@@ -124,10 +124,16 @@ theorem aklt_transferMap_one :
   simp only [transferMap_apply, Fin.sum_univ_three, Matrix.add_apply,
     akltTensor_conjTranspose]
   fin_cases i <;> fin_cases j <;>
-    simp [akltTensor, Matrix.mul_apply, Fin.sum_univ_two, smul_eq_mul] <;> (
-    rw [div_mul_div_comm, ← _root_.mul_inv_rev, ofReal_sqrt3_mul_self,
-      ofReal_sqrt2_mul_self]
-    norm_num)
+    simp only [akltTensor, one_div, Complex.ofReal_inv, smul_of, smul_cons,
+      smul_eq_mul, mul_one, mul_zero, Matrix.smul_empty, mul_neg,
+      Fin.zero_eta, Fin.isValue, Fin.mk_one, mul_apply, of_apply, cons_val',
+      cons_val_fin_one, cons_val_zero, cons_val_one, Fin.sum_univ_two,
+      zero_mul, add_zero, zero_add, Complex.ofReal_div, neg_smul, neg_of,
+      neg_cons, neg_zero, Matrix.neg_empty, ne_eq, zero_ne_one, one_ne_zero,
+      not_false_eq_true, one_apply_eq, one_apply_ne, neg_mul, neg_neg] <;> (
+      rw [div_mul_div_comm, ← _root_.mul_inv_rev, ofReal_sqrt3_mul_self,
+        ofReal_sqrt2_mul_self]
+      norm_num)
 
 /-! ### Normality (2-block injectivity) -/
 
@@ -239,7 +245,8 @@ def akltZ2Action :
   map_one' := by simp [toAdd_one]
   map_mul' a b := by
     rcases zmod2_cases a with rfl | rfl <;> rcases zmod2_cases b with rfl | rfl <;>
-      simp [toAdd_ofAdd, zmod2_one_add_one]
+      simp only [one_mul, mul_one, toAdd_one, toAdd_ofAdd, toAdd_mul,
+        zmod2_one_add_one, one_ne_zero, ↓reduceIte]
     ext i j; fin_cases i <;> fin_cases j <;>
       simp [Matrix.mul_apply, Fin.sum_univ_three, Matrix.of_apply,
         Matrix.cons_val_zero, Matrix.cons_val_one]

--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -229,7 +229,7 @@ theorem sameMPV_of_sameMPVFrom_of_injective [NeZero D]
       -- Both sides equal tr(evalWord A (List.ofFn σ))
       have h_SN : Matrix.trace (S * evalWord B (List.ofFn σ)) =
           Matrix.trace (evalWord A (List.ofFn σ)) := by
-        show Matrix.trace ((∑ i, c i • B i) * evalWord B (List.ofFn σ)) = _
+        change Matrix.trace ((∑ i, c i • B i) * evalWord B (List.ofFn σ)) = _
         rw [Finset.sum_mul]
         simp only [smul_mul_assoc, Matrix.trace_sum, Matrix.trace_smul,
           smul_eq_mul, ← evalWord_cons]

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -92,6 +92,27 @@ private lemma mpvOverlap_eq_selfOverlap_of_forall_mpv_eq
   intro N
   simp only [mpvOverlap, h]
 
+/-- Norm-convergence version of normalized self-overlap convergence. -/
+private lemma tendsto_norm_selfOverlap_one
+    {D : ℕ} (A : MPSTensor d D)
+    (hA : Tendsto (fun N => mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ))) :
+    Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) atTop (nhds 1) := by
+  simpa [norm_one] using hA.norm
+
+/-- Swapping a decaying overlap conjugates the corresponding inner product. -/
+private lemma tendsto_inner_zero_swap
+    {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (h : Tendsto (fun N => mpvOverlap (d := d) A B N) atTop (nhds 0)) :
+    Tendsto (fun N => mpvInner (d := d) B A N) atTop (nhds 0) := by
+  have hAB := tendsto_inner_zero A B h
+  have hSwap :
+      (fun N => mpvInner (d := d) B A N) =
+        fun N => star (mpvInner (d := d) A B N) := by
+    ext N
+    simp [mpvInner, inner_conj_symm]
+  rw [hSwap]
+  simpa using hAB.star
+
 /-- **Layer 2: Per-block `SameMPV₂` + block properties → dim equality + GaugePhaseEquiv.**
 
 Given two individual blocks with pointwise-equal MPVs, both injective and left-canonical,
@@ -319,11 +340,7 @@ private lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
     have hall_inner : ∀ j, Tendsto (fun N => mpvInner (d := d) (B b0) (A j) N)
         atTop (nhds 0) := by
       intro j
-      have h1 := tendsto_inner_zero _ _ (hall j)
-      have h2 : (fun N => mpvInner (d := d) (B b0) (A j) N) =
-          (fun N => star (mpvInner (d := d) (A j) (B b0) N)) := by
-        ext N; simp [mpvInner, inner_conj_symm]
-      rw [h2]; simpa using h1.star
+      simpa using tendsto_inner_zero_swap (d := d) (A j) (B b0) (hall j)
     have h_eq := normalized_identity (B b0) (μB b0) hμB_ne
     have hLHS : Tendsto (fun N => ∑ j, (μA j / μB b0) ^ N *
         mpvInner (d := d) (B b0) (A j) N) atTop (nhds 0) := by
@@ -388,14 +405,14 @@ private lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
       rw [mpv_eq_pow_mul_of_gaugePhase _ _ X2 ζ2 hX2 N σ, mpv_cast_dim hdim2]
     -- Norm of phases = 1.
     have hBB_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (B k) (B k) N‖) atTop (nhds 1) := by
-      convert (hB_self k).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (B k) (B k) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (B k) (hB_self k)
     have hAA1_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (A j₁) (A j₁) N‖) atTop (nhds 1) := by
-      convert (hA_self j₁).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (A j₁) (A j₁) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (A j₁) (hA_self j₁)
     have hAA2_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (A j₂) (A j₂) N‖) atTop (nhds 1) := by
-      convert (hA_self j₂).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (A j₂) (A j₂) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (A j₂) (hA_self j₂)
     have hζ1_norm : ‖ζ1‖ = 1 :=
       norm_eq_one_of_selfOverlap_scale hAA1_norm hBB_norm
         (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := A j₁) (B := B k) (ζ := ζ1) hmpv1)
@@ -473,14 +490,14 @@ private lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
         mpv (B k₂) σ = ω2 ^ N * mpv (A j) σ := fun N σ => by
       rw [mpv_eq_pow_mul_of_gaugePhase _ _ Y2 ω2 hY2 N σ, mpv_cast_dim hdim2]
     have hAA_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (A j) (A j) N‖) atTop (nhds 1) := by
-      convert (hA_self j).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (A j) (A j) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (A j) (hA_self j)
     have hBB1_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (B k₁) (B k₁) N‖) atTop (nhds 1) := by
-      convert (hB_self k₁).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (B k₁) (B k₁) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (B k₁) (hB_self k₁)
     have hBB2_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (B k₂) (B k₂) N‖) atTop (nhds 1) := by
-      convert (hB_self k₂).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (B k₂) (B k₂) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (B k₂) (hB_self k₂)
     have hω1_norm : ‖ω1‖ = 1 :=
       norm_eq_one_of_selfOverlap_scale hAA_norm hBB1_norm
         (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := A j) (B := B k₁) (ζ := ω1) hmpv1)
@@ -557,11 +574,11 @@ private lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
           mpv (B b0) σ = ω ^ N * mpv (A j₁) σ := fun N σ => by
         rw [mpv_eq_pow_mul_of_gaugePhase _ _ X ω hX N σ, mpv_cast_dim hdim1]
       have hBB_norm :
-          Tendsto (fun N => ‖mpvOverlap (d := d) (B b0) (B b0) N‖) atTop (nhds 1) := by
-        convert (hB_self b0).norm using 1; simp only [norm_one]
+          Tendsto (fun N => ‖mpvOverlap (d := d) (B b0) (B b0) N‖) atTop (nhds 1) :=
+        tendsto_norm_selfOverlap_one (d := d) (B b0) (hB_self b0)
       have hAA_norm :
-          Tendsto (fun N => ‖mpvOverlap (d := d) (A j₁) (A j₁) N‖) atTop (nhds 1) := by
-        convert (hA_self j₁).norm using 1; simp only [norm_one]
+          Tendsto (fun N => ‖mpvOverlap (d := d) (A j₁) (A j₁) N‖) atTop (nhds 1) :=
+        tendsto_norm_selfOverlap_one (d := d) (A j₁) (hA_self j₁)
       have hω_norm : ‖ω‖ = 1 :=
         norm_eq_one_of_selfOverlap_scale hAA_norm hBB_norm
           (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := A j₁) (B := B b0) (ζ := ω) hmpv)
@@ -576,11 +593,7 @@ private lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
       have hInner_other : ∀ j, j ≠ j₁ →
           Tendsto (fun N => mpvInner (d := d) (B b0) (A j) N) atTop (nhds 0) := by
         intro j hj
-        have h1 := tendsto_inner_zero _ _ (huniq j hj)
-        have h2 : (fun N => mpvInner (d := d) (B b0) (A j) N) =
-            (fun N => star (mpvInner (d := d) (A j) (B b0) N)) := by
-          ext N; simp [mpvInner, inner_conj_symm]
-        rw [h2]; simpa using h1.star
+        simpa using tendsto_inner_zero_swap (d := d) (A j) (B b0) (huniq j hj)
       have h_eq := normalized_identity (B b0) (μB b0) hμB_ne
       have hRHS_one : Tendsto (fun N => ∑ k, (μB k / μB b0) ^ N *
           mpvInner (d := d) (B b0) (B k) N) atTop (nhds 1) :=
@@ -649,8 +662,8 @@ private lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
     simp only [PiLp.smul_apply, smul_eq_mul, mpvState_apply, hmpv_dom]
   have hζ_norm : ‖ζ‖ = 1 :=
     norm_eq_one_of_selfOverlap_scale
-      (by convert (hA_self a0).norm using 1; simp only [norm_one])
-      (by convert (hB_self b0).norm using 1; simp only [norm_one])
+      (tendsto_norm_selfOverlap_one (d := d) (A a0) (hA_self a0))
+      (tendsto_norm_selfOverlap_one (d := d) (B b0) (hB_self b0))
       (mpvOverlap_self_scale_of_mpv_eq_pow_mul
         (A := A a0) (B := B b0) (ζ := ζ) hmpv_dom)
   -- ── Show μA a0 = μB b0 * ζ ──
@@ -1123,14 +1136,15 @@ private lemma blocks_match_of_sameMPV₂_CFBNT
       rw [mpv_eq_pow_mul_of_gaugePhase _ _ X2 ζ2 hX2 N σ,
           mpv_cast_dim (hfA_dim j2)]
     have hBB_norm_tendsto :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (B (fA j1)) (B (fA j1)) N‖) atTop (nhds 1) := by
-      convert (hB_self (fA j1)).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (B (fA j1)) (B (fA j1)) N‖)
+          atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (B (fA j1)) (hB_self (fA j1))
     have hAA1_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (A j1) (A j1) N‖) atTop (nhds 1) := by
-      convert (hA_self j1).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (A j1) (A j1) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (A j1) (hA_self j1)
     have hAA2_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (A j2) (A j2) N‖) atTop (nhds 1) := by
-      convert (hA_self j2).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (A j2) (A j2) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (A j2) (hA_self j2)
     have hζ1_norm : ‖ζ1‖ = 1 :=
       norm_eq_one_of_selfOverlap_scale hAA1_norm hBB_norm_tendsto
         (mpvOverlap_self_scale_of_mpv_eq_pow_mul
@@ -1225,14 +1239,15 @@ private lemma blocks_match_of_sameMPV₂_CFBNT
       rw [mpv_eq_pow_mul_of_gaugePhase _ _ Y2 ω2 hY2 N σ,
           mpv_cast_dim (hgB_dim k2)]
     have hAA_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (A (gB k1)) (A (gB k1)) N‖) atTop (nhds 1) := by
-      convert (hA_self (gB k1)).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (A (gB k1)) (A (gB k1)) N‖)
+          atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (A (gB k1)) (hA_self (gB k1))
     have hBB1_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (B k1) (B k1) N‖) atTop (nhds 1) := by
-      convert (hB_self k1).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (B k1) (B k1) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (B k1) (hB_self k1)
     have hBB2_norm :
-        Tendsto (fun N => ‖mpvOverlap (d := d) (B k2) (B k2) N‖) atTop (nhds 1) := by
-      convert (hB_self k2).norm using 1; simp only [norm_one]
+        Tendsto (fun N => ‖mpvOverlap (d := d) (B k2) (B k2) N‖) atTop (nhds 1) :=
+      tendsto_norm_selfOverlap_one (d := d) (B k2) (hB_self k2)
     have hω1_norm : ‖ω1‖ = 1 :=
       norm_eq_one_of_selfOverlap_scale hAA_norm hBB1_norm
         (mpvOverlap_self_scale_of_mpv_eq_pow_mul

--- a/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
+++ b/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
@@ -163,8 +163,7 @@ private theorem transferMap_fixedPoint_eq_zero_of_trace_eq_zero_of_hermitian_zer
       Matrix.conjTranspose_conjTranspose, add_comm]
   have hY₂_herm : Y₂.IsHermitian := by
     ext i j
-    simp [Y₂, Matrix.IsHermitian, Matrix.conjTranspose_smul,
-      Matrix.conjTranspose_conjTranspose, sub_eq_add_neg]
+    simp [Y₂, sub_eq_add_neg]
     ring
   have hY₁_fix : E Y₁ = Y₁ := by
     simp [E, Y₁, hXfix, hXstar, map_add]

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -305,7 +305,8 @@ theorem chainGroundSpace_eq_mpvSubmodule {A : MPSTensor d D} [NeZero D]
     have hψGS : ψ ∈ groundSpace A N := by
       apply contiguous_mem_groundSpace hA hL hLN
       intro s hs τ
-      rw [← cyclicRestrictₗ_eq_contiguousRestrictₗ hN0 hLN (show (⟨s, by omega⟩ : Fin N).val + L ≤ N from hs)]
+      rw [← cyclicRestrictₗ_eq_contiguousRestrictₗ hN0 hLN
+        (show (⟨s, by omega⟩ : Fin N).val + L ≤ N from hs)]
       exact hψ ⟨s, by omega⟩ τ
     -- Step 2: ψ = groundSpaceMap A N X for some X
     rw [groundSpace, LinearMap.mem_range] at hψGS

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -177,6 +177,8 @@ private theorem init_evalWord_split {A : MPSTensor d D}
 Use `tr(P * Q) = tr(Q * P)` to rotate the wrapping boundary,
 then extract a matrix equation via `groundSpaceMap_injective`. -/
 
+-- Expanding `cyclicCfg` and rotating the trace through the wrapping window produces
+-- large normalization goals, so this proof needs a larger heartbeat budget.
 set_option maxHeartbeats 800000 in
 private theorem wrapping_window_matEq {A : MPSTensor d D} [NeZero D]
     (hA : IsInjective A) {L : ℕ} (hL : 1 < L) {M : ℕ} (hM : 1 ≤ M) (hLN : L ≤ M + 1)
@@ -255,6 +257,8 @@ private theorem wrapping_window_matEq {A : MPSTensor d D} [NeZero D]
 
 Extend from the wrapping window equation to full commutation via spanning. -/
 
+-- The double spanning argument over window tails and complements creates large
+-- `LinearMap.ext_on_range` goals, so we raise the heartbeat budget here as well.
 set_option maxHeartbeats 800000 in
 /-- If `groundSpaceMap A N X` lies in every cyclic window's ground space,
 then `X` commutes with all generators `A_j`.

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -197,7 +197,7 @@ theorem EquivalentBlocks.to_repeatedBlocks {A B : MPSTensor d D}
   rcases h with ⟨Y, hY⟩
   refine ⟨1, Y, by simp, ?_⟩
   intro i
-  simpa [hY i]
+  simp [hY i]
 
 /-- `EquivalentBlocks` is equivalent to ordinary `GaugeEquiv`. -/
 theorem equivalentBlocks_iff_gaugeEquiv {A B : MPSTensor d D} :
@@ -228,9 +228,9 @@ theorem RepeatedBlocks.symm {A B : MPSTensor d D}
   rcases h with ⟨ξ, Y, hξ, hY⟩
   have hξ_ne : ξ ≠ 0 := by
     intro h0
-    have : ‖ξ‖ = 0 := by simpa [h0]
+    have : ‖ξ‖ = 0 := by simp [h0]
     linarith [hξ]
-  refine ⟨ξ⁻¹, Y⁻¹, by simpa [norm_inv] using hξ, ?_⟩
+  refine ⟨ξ⁻¹, Y⁻¹, by simp [norm_inv, hξ], ?_⟩
   intro i
   have hYi := hY i
   apply_fun fun M => (ξ⁻¹ : ℂ) •
@@ -245,7 +245,7 @@ theorem RepeatedBlocks.trans {A B C : MPSTensor d D}
     RepeatedBlocks A C := by
   rcases hAB with ⟨ξ, Y, hξ, hAB⟩
   rcases hBC with ⟨ζ, Z, hζ, hBC⟩
-  refine ⟨ξ * ζ, Y * Z, by simpa [norm_mul, hξ, hζ], ?_⟩
+  refine ⟨ξ * ζ, Y * Z, by simp [hξ, hζ], ?_⟩
   intro i
   rw [hAB i, hBC i]
   simp [Matrix.mul_assoc, smul_smul]

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -96,6 +96,46 @@ lemma mul_self_eq_self_or_eq_one (z : ℂ) (hz : z * z = z) : z = 0 ∨ z = 1 :=
   · right
     exact sub_eq_zero.mp h1
 
+/-- The MPV of a two-block tensor is the sum of the MPVs of its two blocks. -/
+private lemma mpv_twoBlockTensor_eq {n m N : ℕ}
+    (A₁ : MPSTensor d n) (A₂ : MPSTensor d m) (σ : Fin N → Fin d) :
+    mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ =
+      mpv A₁ σ + mpv A₂ σ := by
+  classical
+  have h :=
+    mpv_toTensorFromBlocks_eq_sum (d := d) (r := 2) (dim := ![n, m])
+      (μ := fun _ => (1 : ℂ))
+      (A := twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂) (σ := σ)
+  have h' :
+      mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ =
+        ∑ k : Fin 2,
+          (1 : ℂ) ^ N •
+            mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ k) σ := by
+    simpa [twoBlockTensor] using h
+  calc
+    mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ
+        = ∑ k : Fin 2,
+            (1 : ℂ) ^ N •
+              mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ k) σ := h'
+    _ = ((1 : ℂ) ^ N •
+          mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ 0) σ) +
+          ((1 : ℂ) ^ N •
+            mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ (Fin.succ 0)) σ) := by
+          simp [Fin.sum_univ_succ]
+          rfl
+    _ = mpv A₁ σ + mpv A₂ σ := by
+        have h0 :
+            (1 : ℂ) ^ N •
+                mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ 0) σ =
+              mpv A₁ σ := by
+          simp [twoBlockBlocks]
+        have h1 :
+            (1 : ℂ) ^ N •
+                mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ (Fin.succ 0)) σ =
+              mpv A₂ σ := by
+          simp only [one_pow, one_smul, twoBlockBlocks, Fin.cases_succ, Fin.cases_zero]
+          rfl
+        simp only [h0, h1]
 
 /-! ## Block-diagonal evaluation / trace lemmas -/
 
@@ -532,43 +572,8 @@ theorem exists_twoBlock_decomp_of_lowerZero
       _ = mpv A₁ σ + mpv A₂ σ := by rw [← hmpv₁, ← hmpv₂]
   -- MPV of the explicit block-diagonal tensor is the sum of block MPVs.
   have hmpv_twoBlockTensor :
-      mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ = mpv A₁ σ + mpv A₂ σ := by
-    classical
-    -- Expand the MPV of a block tensor as a sum over blocks.
-    have h :=
-      (mpv_toTensorFromBlocks_eq_sum (d := d) (r := 2) (dim := ![n, m])
-        (μ := fun _ => (1 : ℂ))
-        (A := twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂) (σ := σ))
-    have h' :
-        mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ =
-          ∑ k : Fin 2,
-            (1 : ℂ) ^ N • mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ k) σ := by
-      simpa [twoBlockTensor] using h
-    -- Compute the `Fin 2` sum using `Fin.sum_univ_succ` so the second term is at `Fin.succ 0`.
-    calc
-      mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ
-          = ∑ k : Fin 2,
-              (1 : ℂ) ^ N • mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ k) σ := h'
-      _ = ((1 : ℂ) ^ N • mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ 0) σ) +
-            ((1 : ℂ) ^ N •
-              mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ (Fin.succ 0)) σ) := by
-          simp [Fin.sum_univ_succ]
-          rfl
-      _ = mpv A₁ σ + mpv A₂ σ := by
-          have h0 :
-              (1 : ℂ) ^ N • mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ 0) σ =
-                mpv A₁ σ := by
-            -- Reduce the `Fin.cases` at `0` without rewriting `Fin.succ 0`.
-            simp [twoBlockBlocks]
-          have h1 :
-              (1 : ℂ) ^ N •
-                  mpv (twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂ (Fin.succ 0)) σ =
-                mpv A₂ σ := by
-            simp only [one_pow, one_smul, twoBlockBlocks, Fin.cases_succ, Fin.cases_zero]
-            rfl
-          -- Combine the two identities.
-          -- Avoid rewriting `Fin.succ 0` into `1` (which breaks dependent `Fin.cases` reductions).
-          simp only [h0, h1]
+      mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ = mpv A₁ σ + mpv A₂ σ :=
+    mpv_twoBlockTensor_eq (d := d) (n := n) (m := m) A₁ A₂ σ
   -- Now chain everything.
   calc
     mpv A σ = mpv Aconj σ := hA_Aconj
@@ -663,24 +668,27 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
     simpa [n, m] using hsum.symm.trans hST
   -- ═══ Strict bounds ═══
   -- `S` is nonempty from `P ≠ 0`.
-  have hn_pos : 0 < n := by
-    rw [show n = Fintype.card S from rfl, Fintype.card_pos_iff]
-    by_contra hempty; rw [not_nonempty_iff] at hempty
+  have hS_nonempty : Nonempty S := by
+    by_contra hempty
+    rw [not_nonempty_iff] at hempty
     apply hP0
     have hf_zero : ∀ j, f j = 0 := fun j =>
       (hf01 j).resolve_right (fun h1 => (IsEmpty.false (α := S) ⟨j, h1⟩).elim)
     rw [orthProj_spectral_eq' P hHerm]
-    have hdiag0 : Matrix.diagonal f = 0 := by ext i k; simp [Matrix.diagonal_apply, hf_zero]
+    have hdiag0 : Matrix.diagonal f = 0 := by
+      ext i k
+      simp [Matrix.diagonal_apply, hf_zero]
     rw [hdiag0, Matrix.mul_zero, Matrix.zero_mul]
+  have hn_pos : 0 < n := by
+    simpa [n] using Fintype.card_pos_iff.mpr hS_nonempty
   -- `T` is nonempty from `P ≠ 1`.
-  have hm_pos : 0 < m := by
-    rw [show m = Fintype.card T from rfl, Fintype.card_pos_iff]
-    by_contra hempty; rw [not_nonempty_iff] at hempty
+  have hT_nonempty : Nonempty T := by
+    by_contra hempty
+    rw [not_nonempty_iff] at hempty
     apply hP1
     have hf_one : ∀ j, f j = 1 := fun j =>
       (hf01 j).resolve_left
         (fun h0 =>
-          -- `f j = 0` implies `j ∈ T` (the 0-eigenspace), contradicting `IsEmpty T`.
           (IsEmpty.false (α := T)
             ⟨j, fun (h1 : f j = 1) => absurd (h0.symm.trans h1) zero_ne_one⟩).elim)
     rw [orthProj_spectral_eq' P hHerm]
@@ -688,10 +696,13 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
       ext i k
       simp only [Matrix.diagonal_apply, Matrix.one_apply]
       split_ifs with heq
-      · subst heq; exact hf_one i
+      · subst heq
+        exact hf_one i
       · rfl
     rw [hdiag1, Matrix.mul_one, ← Matrix.star_eq_conjTranspose]
     simp
+  have hm_pos : 0 < m := by
+    simpa [m] using Fintype.card_pos_iff.mpr hT_nonempty
   have hn_lt : n < D := by omega
   have hm_lt : m < D := by omega
   -- ═══ Block decomposition ═══
@@ -807,8 +818,11 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
       _root_.evalWord (fun i => Matrix.reindex eST eST
         ((diagPart Aconj Pdiag) i)) w =
         Matrix.fromBlocks (_root_.evalWord A11raw w) 0 0 (_root_.evalWord A22raw w) := by
-    rw [show (fun i => Matrix.reindex eST eST ((diagPart Aconj Pdiag) i)) =
-        fun i => Matrix.fromBlocks (A11raw i) 0 0 (A22raw i) from funext hLetter_block]
+    have hfun :
+        (fun i => Matrix.reindex eST eST ((diagPart Aconj Pdiag) i)) =
+          fun i => Matrix.fromBlocks (A11raw i) 0 0 (A22raw i) :=
+      funext hLetter_block
+    rw [hfun]
     simpa using evalWord_fromBlocks_diag A11raw A22raw w
   have hTrace_diagPart :
       mpv (diagPart Aconj Pdiag) σ = mpv A₁ σ + mpv A₂ σ := by
@@ -839,21 +853,8 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
             Matrix.trace (_root_.evalWord A22raw w) := htr_blocks
       _ = mpv A₁ σ + mpv A₂ σ := by rw [← hmpv₁, ← hmpv₂]
   have hmpv_twoBlockTensor :
-      mpv (twoBlockTensor A₁ A₂) σ = mpv A₁ σ + mpv A₂ σ := by
-    have h := mpv_toTensorFromBlocks_eq_sum (r := 2) (dim := ![n, m])
-        (μ := fun _ => (1 : ℂ)) (A := twoBlockBlocks A₁ A₂) (σ := σ)
-    have h' : mpv (twoBlockTensor A₁ A₂) σ =
-        ∑ k : Fin 2, (1 : ℂ) ^ N • mpv (twoBlockBlocks A₁ A₂ k) σ := by
-      simpa [twoBlockTensor] using h
-    calc mpv (twoBlockTensor A₁ A₂) σ
-        = ∑ k : Fin 2, (1 : ℂ) ^ N • mpv (twoBlockBlocks A₁ A₂ k) σ := h'
-      _ = ((1 : ℂ) ^ N • mpv (twoBlockBlocks A₁ A₂ 0) σ) +
-            ((1 : ℂ) ^ N • mpv (twoBlockBlocks A₁ A₂ (Fin.succ 0)) σ) := by
-          simp [Fin.sum_univ_succ]
-          rfl
-      _ = mpv A₁ σ + mpv A₂ σ := by
-          simp only [one_pow, one_smul, twoBlockBlocks, Fin.cases_zero, Fin.cases_succ]
-          rfl
+      mpv (twoBlockTensor A₁ A₂) σ = mpv A₁ σ + mpv A₂ σ :=
+    mpv_twoBlockTensor_eq A₁ A₂ σ
   -- Chain all steps.
   calc mpv A σ = mpv Aconj σ := hA_Aconj
     _ = mpv (diagPart Aconj Pdiag) σ := hAconj_diag

--- a/TNLean/MPS/Symmetry/StringOrder.lean
+++ b/TNLean/MPS/Symmetry/StringOrder.lean
@@ -454,10 +454,12 @@ private lemma twistedTransfer_virtual_rep_fixed
       ((ρ.X (g⁻¹) : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
   let V := ((ρ.X (g⁻¹) : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
   let Vinv := (((ρ.X (g⁻¹))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-  have hVinvV : Vinv * V = 1 := by show
-    (((ρ.X g⁻¹)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
-      ((ρ.X g⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) = 1; simp
-  show twistedTransferMap A (U g) V = V
+  have hVinvV : Vinv * V = 1 := by
+    change
+      (((ρ.X g⁻¹)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+        ((ρ.X g⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) = 1
+    simp
+  change twistedTransferMap A (U g) V = V
   rw [twistedTransferMap_apply]
   rw [Finset.sum_comm]
   -- Each inner sum simplifies via virtual rep

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -297,12 +297,14 @@ theorem twistedTPGaugeSetup_hasEigenvalue [NeZero D]
                         simp [Matrix.mul_assoc]
                 _ = setup.S * A i * (V * setup.S) *
                       (setup.S⁻¹ * (setup.B i)ᴴ * setup.S) := by
-                      rw [show setup.S⁻¹ * (setup.S * V * setup.S) = V * setup.S by
+                      have hSV :
+                          setup.S⁻¹ * (setup.S * V * setup.S) = V * setup.S := by
                         calc
                           setup.S⁻¹ * (setup.S * V * setup.S)
                               = (setup.S⁻¹ * setup.S) * V * setup.S := by
-                            simp [Matrix.mul_assoc]
-                          _ = V * setup.S := by simp [setup.hS_inv_mul]]
+                                  simp [Matrix.mul_assoc]
+                          _ = V * setup.S := by simp [setup.hS_inv_mul]
+                      rw [hSV]
                 _ = setup.S * A i * (V * (setup.B i)ᴴ * setup.S) := by
                       calc
                         setup.S * A i * (V * setup.S) *
@@ -577,9 +579,10 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
             = ∑ j : Fin d, ∑ n' : Fin d, (u i j * (starRingEnd ℂ) (u n' j)) • A n' := by
                 refine Finset.sum_congr rfl ?_
                 intro j _
-                rw [show u i j • B j =
-                  u i j • ∑ n' : Fin d, (starRingEnd ℂ) (u n' j) • A n' by
-                    simp [B, twistedMixedCompanion]]
+                have hBj :
+                    B j = ∑ n' : Fin d, (starRingEnd ℂ) (u n' j) • A n' := by
+                  simp [B, twistedMixedCompanion]
+                rw [hBj]
                 simpa [smul_smul, mul_assoc] using
                   (Finset.smul_sum (s := Finset.univ)
                     (f := fun n' : Fin d => (starRingEnd ℂ) (u n' j) • A n')

--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -48,12 +48,11 @@ private lemma sameMPV_of_mpvOverlap_tendsto_one_of_injective
       Filter.Tendsto (fun N => mpvOverlap (d := d) A B N)
         Filter.atTop (nhds (1 : ℂ))) :
     SameMPV A B := by
-  have hGaugePhase :=
-    gaugePhaseEquiv_of_mpvOverlap_tendsto_one
-      (A := A) (B := B) hA_inj hB_inj hA_lc hB_lc hCross
   exact
     sameMPV_of_gaugePhaseEquiv_of_mpvOverlap_tendsto_one
-      (A := A) (B := B) (hSelf := hSelf) (hCross := hCross) hGaugePhase
+      (A := A) (B := B) (hSelf := hSelf) (hCross := hCross)
+      (gaugePhaseEquiv_of_mpvOverlap_tendsto_one
+        (A := A) (B := B) hA_inj hB_inj hA_lc hB_lc hCross)
 
 private lemma sameMPV_of_mpvOverlap_tendsto_one_of_irreducible_TP
     {D : ℕ} [NeZero D] (A B : MPSTensor d D)
@@ -67,12 +66,11 @@ private lemma sameMPV_of_mpvOverlap_tendsto_one_of_irreducible_TP
       Filter.Tendsto (fun N => mpvOverlap (d := d) A B N)
         Filter.atTop (nhds (1 : ℂ))) :
     SameMPV A B := by
-  have hGaugePhase :=
-    gaugePhaseEquiv_of_mpvOverlap_tendsto_one_of_irreducible_TP
-      (A := A) (B := B) hA_irr hB_irr hA_lc hB_lc hCross
   exact
     sameMPV_of_gaugePhaseEquiv_of_mpvOverlap_tendsto_one
-      (A := A) (B := B) (hSelf := hSelf) (hCross := hCross) hGaugePhase
+      (A := A) (B := B) (hSelf := hSelf) (hCross := hCross)
+      (gaugePhaseEquiv_of_mpvOverlap_tendsto_one_of_irreducible_TP
+        (A := A) (B := B) hA_irr hB_irr hA_lc hB_lc hCross)
 
 private theorem leading_block_sameMPV_of_crossOverlap_tendsto_one
     {r : ℕ} {dim : Fin (Nat.succ (Nat.succ r)) → ℕ}
@@ -476,17 +474,7 @@ theorem summed_identity_for_word
     simpa [σ, hlen] using (List.ofFn_getElem (xs := (List.replicate L w).flatten))
   have hsummed := h_summed (M * L) σ
   simp only [mpv, coeff, hofFn, evalWord_flatten_replicate, mul_sub] at hsummed
-  rw [Finset.sum_sub_distrib, sub_eq_zero] at hsummed
-  conv_lhs =>
-    arg 2; ext k
-    rw [show ((μ k) ^ M) ^ L = (μ k) ^ (M * L) from (pow_mul _ _ _).symm]
-  rw [show (∑ k : Fin r, (μ k) ^ (M * L) *
-    (Matrix.trace ((evalWord (A k) w) ^ L) -
-     Matrix.trace ((evalWord (B k) w) ^ L))) =
-    ∑ k : Fin r, (μ k) ^ (M * L) * Matrix.trace ((evalWord (A k) w) ^ L) -
-    ∑ k : Fin r, (μ k) ^ (M * L) * Matrix.trace ((evalWord (B k) w) ^ L)
-    from by rw [← Finset.sum_sub_distrib]; congr 1; ext k; ring]
-  exact sub_eq_zero.mpr hsummed
+  simpa [M, pow_mul, mul_sub] using hsummed
 
 theorem sameMPV_of_charpoly_eq_all_words
     {D : ℕ} [NeZero D]

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -797,9 +797,8 @@ lemma gaugePhaseEquiv_of_mpvOverlap_tendsto_one
     (h : Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop (nhds (1 : ℂ))) :
     GaugePhaseEquiv A B := by
   by_contra hnot
-  have hto0 :=
+  exact (h.ne_nhds one_ne_zero) <|
     mpvOverlap_tendsto_zero (A := A) (B := B) hA_inj hB_inj hA_lc hB_lc hnot
-  exact (h.ne_nhds one_ne_zero) hto0
 
 /-- Irreducible TP analogue of `gaugePhaseEquiv_of_mpvOverlap_tendsto_one`.
 
@@ -816,10 +815,9 @@ lemma gaugePhaseEquiv_of_mpvOverlap_tendsto_one_of_irreducible_TP
     (h : Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop (nhds (1 : ℂ))) :
     GaugePhaseEquiv A B := by
   by_contra hnot
-  have hto0 :=
+  exact (h.ne_nhds one_ne_zero) <|
     mpvOverlap_tendsto_zero_of_irreducible_TP
       (A := A) (B := B) hA_irr hB_irr hA_lc hB_lc hnot
-  exact (h.ne_nhds one_ne_zero) hto0
 
 private lemma mpvOverlap_eq_pow_mul_self_of_mpv_eq_pow_mul
     {D : ℕ} (A B : MPSTensor d D) (ζ : ℂ)
@@ -886,11 +884,7 @@ lemma sameMPV_of_gaugePhaseEquiv_of_mpvOverlap_tendsto_one
   have hζ : ζ = 1 := by
     have := congrArg star hstarζ
     simpa using this
-  have hGauge : GaugeEquiv A B := by
-    refine ⟨X, ?_⟩
-    intro i
-    simp [hζ, hX i]
-  exact GaugeEquiv.sameMPV hGauge
+  exact GaugeEquiv.sameMPV ⟨X, fun i => by simp [hζ, hX i]⟩
 
 end BlockSeparationCoreHelpers
 

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -303,9 +303,8 @@ private lemma canonical_gauge_data_of_injective [NeZero D]
   let S : Matrix (Fin D) (Fin D) ℂ := S0ᴴ
   have hS_unit : IsUnit S := by
     simpa [S, Matrix.star_eq_conjTranspose] using (IsUnit.star hS0_unit)
-  have hS_det : S.det ≠ 0 := by
-    have hdet_unit : IsUnit S.det := (Matrix.isUnit_iff_isUnit_det (A := S)).1 hS_unit
-    exact hdet_unit.ne_zero
+  have hS_det : S.det ≠ 0 :=
+    ((Matrix.isUnit_iff_isUnit_det (A := S)).1 hS_unit).ne_zero
   have hS_mul : S * Sᴴ = ρ := by
     calc
       S * Sᴴ = S0ᴴ * (S0ᴴ)ᴴ := by rfl

--- a/TNLean/Spectral/SpectralGapNT.lean
+++ b/TNLean/Spectral/SpectralGapNT.lean
@@ -313,13 +313,9 @@ private lemma mul_mul_conjTranspose_ne_zero_of_ne_zero {D : ℕ}
       IsUnit.star hS_unit
   intro h0
   apply hM
-  have h1 : M * Sᴴ = 0 := by
-    apply IsUnit.mul_left_cancel hS_unit
-    simpa only [mul_zero, Matrix.mul_assoc] using h0
-  have h2 : M = 0 := by
-    apply IsUnit.mul_right_cancel hSstar_unit
-    simpa only [zero_mul] using h1
-  exact h2
+  apply IsUnit.mul_right_cancel hSstar_unit
+  apply IsUnit.mul_left_cancel hS_unit
+  simpa only [zero_mul, mul_zero, Matrix.mul_assoc] using h0
 
 /-- An irreducible trace-preserving tensor has a nonzero positive fixed point whose
 square-root gauge is invertible. -/

--- a/TNLean/Wielandt/Primitivity/Equivalence.lean
+++ b/TNLean/Wielandt/Primitivity/Equivalence.lean
@@ -27,11 +27,13 @@ The following are equivalent for an MPS tensor `A` with `∑ Aᵢ† Aᵢ = 1`:
 
 ## Directions proved
 
-| Dir | Theorem | File |
-|-----|---------|------|
-| **(b)→(a)** | `isPrimitivePaper_of_hasEventuallyFullKrausRank` | `EasyDirections` |
-| **(a)→(c)** | `isStronglyIrreduciblePaper_of_isPrimitivePaper` | `ImpliesStronglyIrreducibleAux` |
-| **(c)→(b)** | `hasEventuallyFullKrausRank_of_isStronglyIrreduciblePaper` | `StronglyIrreducibleToFullRank` |
+- **(b)→(a)**: `isPrimitivePaper_of_hasEventuallyFullKrausRank`
+  in `EasyDirections`
+- **(a)→(c)**: `isStronglyIrreduciblePaper_of_isPrimitivePaper`
+  in `ImpliesStronglyIrreducibleAux`
+- **(c)→(b)**:
+  `hasEventuallyFullKrausRank_of_isStronglyIrreduciblePaper`
+  in `StronglyIrreducibleToFullRank`
 
 Together these close the cycle **(a) → (c) → (b) → (a)**, establishing the
 full equivalence of all three conditions.

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -323,11 +323,8 @@ theorem perturbation_psd_upper_bound
     (v : Fin D → ℂ) :
     0 ≤ (star v ⬝ᵥ (ρ *ᵥ v)).re + t * (star v ⬝ᵥ (H *ᵥ v)).re := by
   have h := ht_psd.re_dotProduct_nonneg v
-  -- Expand (ρ + t•H) *ᵥ v = ρ *ᵥ v + t • (H *ᵥ v)
-  rw [Matrix.add_mulVec, dotProduct_add] at h
-  -- Need to relate (star v ⬝ᵥ ((↑t • H) *ᵥ v)).re to t * (star v ⬝ᵥ (H *ᵥ v)).re
-  rw [show ((t : ℂ) • H) *ᵥ v = (t : ℂ) • (H *ᵥ v) from Matrix.smul_mulVec _ _ _,
-    dotProduct_smul, smul_eq_mul] at h
+  rw [Matrix.add_mulVec, dotProduct_add, Matrix.smul_mulVec, dotProduct_smul,
+    smul_eq_mul] at h
   have : ((t : ℂ) * (star v ⬝ᵥ H *ᵥ v)).re = t * (star v ⬝ᵥ H *ᵥ v).re := by
     rw [Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im]; ring
   -- h uses RCLike.re while goal uses Complex.re; convert

--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -339,11 +339,10 @@ theorem IsPrimitiveMPS.transferMap_pow_apply_tendsto [NeZero D]
         = ((Pρ + N ^ (n + 1)) : Module.End ℂ _) X := by rw [← h]
       _ = Pρ X + (N ^ (n + 1)) X := LinearMap.add_apply Pρ (N ^ (n + 1)) X
   simp_rw [hdecomp]
-  rw [show Pρ X = (Matrix.trace X / Matrix.trace ρ) • ρ from rfl]
-  -- Need: N^(n+1)(X) → 0
+  change Tendsto (fun n => (Matrix.trace X / Matrix.trace ρ) • ρ + (N ^ (n + 1)) X)
+    atTop (nhds ((Matrix.trace X / Matrix.trace ρ) • ρ))
   suffices h : Tendsto (fun n => (N ^ (n + 1)) X) atTop (nhds 0) by
-    have := h.const_add ((Matrix.trace X / Matrix.trace ρ) • ρ)
-    simp only [add_zero] at this; exact this
+    simpa only [add_zero] using h.const_add ((Matrix.trace X / Matrix.trace ρ) • ρ)
   -- Use complement_pow_tendsto_zero
   have hN_clm : Tendsto (fun n =>
       (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) N) ^ n)
@@ -566,7 +565,7 @@ private theorem rep_eq_zero_iff [NeZero D]
     rw [phi_eq_trace_mul φ N, hrep, zero_mul,
       Matrix.trace_zero, LinearMap.zero_apply]
   · intro hφ; ext i j
-    simp [Matrix.of_apply, show φ = 0 from hφ]
+    simp [Matrix.of_apply, hφ]
 
 /-! #### Lemma A: trace-pairing positivity → full word span -/
 

--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -179,10 +179,8 @@ theorem rectSpan_nilpIndex_eq_range_of_strict_growth
   -- Translate back
   refine ⟨C - a 0, by omega, ?_⟩
   apply rectSpan_eq_range_of_finrank_eq_range
-  -- finrank(rectSpan P A (C - a 0)) = C = finrank(range(mulLeft P))
-  change finrank ℂ (rectSpan P A (C - a 0)) =
+  change a (C - a 0) =
     finrank ℂ (LinearMap.range (LinearMap.mulLeft ℂ P))
-  rw [show finrank ℂ (rectSpan P A (C - a 0)) = a (C - a 0) from rfl]
   rw [hceiling, finrank_range_mulLeft, hrank_eq]
 
 /-! ### Part 3: Unconditional D²-D+1 from strict growth -/
@@ -698,8 +696,8 @@ theorem vecMulVec_eigenvector_pad_wordSpan_add
   induction k with
   | zero => simpa
   | succ k ih =>
-    rw [show n + (k + 1) = (n + k) + 1 from by omega]
-    exact vecMulVec_eigenvector_pad_wordSpan A i₀ hμ heig ih
+    simpa only [Nat.add_assoc] using
+      vecMulVec_eigenvector_pad_wordSpan A i₀ hμ heig ih
 
 /-- **Eigenvector padding monotonicity**: if `vecMulVec φ ψ ∈ wordSpan A n` and `n ≤ m`,
 then `vecMulVec φ ψ ∈ wordSpan A m`. -/

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux.lean
@@ -70,9 +70,9 @@ theorem vecMulVec_mem_range_mulLeft_of_mem_range_toLin
     (P : Matrix (Fin D) (Fin D) ℂ) {φ : Fin D → ℂ}
     (hφ : φ ∈ LinearMap.range (Matrix.toLin' P)) (ψ : Fin D → ℂ) :
     vecMulVec φ ψ ∈ LinearMap.range (LinearMap.mulLeft ℂ P) := by
-  obtain ⟨v, hv⟩ := LinearMap.mem_range.mp hφ
-  rw [show φ = P *ᵥ v from by rw [← Matrix.toLin'_apply]; exact hv.symm]
-  exact ⟨vecMulVec v ψ, by simp [LinearMap.mulLeft_apply, mul_vecMulVec]⟩
+  obtain ⟨v, rfl⟩ := LinearMap.mem_range.mp hφ
+  refine ⟨vecMulVec v ψ, ?_⟩
+  simp only [Matrix.toLin'_apply, LinearMap.mulLeft_apply, mul_vecMulVec]
 
 /-- **Rank-one universality from stabilized rectangular span.**
 
@@ -888,7 +888,7 @@ theorem mulLeft_mem_rectSpan_nilpIndex_succ
   calc (A i₀ ^ r) * (M₀ * M)
       = ((A i₀ ^ r) * M₀) * M := by simp [Matrix.mul_assoc]
     _ = (M₀ * (A i₀ ^ r)) * M := by
-        rw [show (A i₀ ^ r) * M₀ = M₀ * (A i₀ ^ r) from hcomm.symm]
+        simpa [M₀] using congrArg (fun Z => Z * M) hcomm.symm
     _ = M₀ * ((A i₀ ^ r) * M) := by simp [Matrix.mul_assoc]
 
 /-- Every element of `rectSpan ((A i₀)^r) A n` lies in `range(mulLeft ((A i₀)^r))`. -/


### PR DESCRIPTION
## Summary

Comprehensive lint cleanup and proof simplification pass across 40 Lean files, resolving all non-sorry build warnings.

### Lint warnings fixed

| Category | Files | Count |
|----------|-------|-------|
| **longLine** (>100 chars) | CyclicDecomposition, WolfChapter2Index, UniqueGroundState, Equivalence | ~20 |
| **unusedSectionVars** | CyclicDecomposition, TwoPositive, MatrixOperatorSpace | ~12 |
| **style.show** (should be `change`) | KrausFreedom, RelaxationConditions, StringOrder, FiniteLength | 8 |
| **unusedSimpArgs** | LindbladForm/{Basic,TraceBridge,GKSLTheorem}, GeneratorCompression, PeripheralToSpectralGap | 7 |
| **unnecessarySimpa** | NewtonGirard, DensityRetract, StationarySupport, Perturbation, TensorEquality, Periodic/Defs | 7 |
| **flexible simp** | AKLT | 2 |
| **style.maxHeartbeats** | WrappingWindow, KrausFreedom | 3 |

### Proof simplifications (no statement changes)

- **Channel/Irreducible/Growth**: streamlined kernel-transfer and induction steps
- **Channel/Determinant**: simplified `channelDet_eq_linearMap_det`
- **Channel/Schwarz/***: compressed local helper proofs
- **MPS/FundamentalTheorem/Full**: extracted helper lemmas for repeated patterns (`tendsto_norm_selfOverlap_one`, `tendsto_inner_zero_swap`)
- **MPS/CanonicalForm/Assembly**: simplified cyclic projection induction, added `cyclicShift_succ_left` helper
- **MPS/BNT/PermutationRigidity**: shortened norm-limit helpers
- **MPS/Structure/InvariantSubspaceDecomp**: factored repeated two-block MPV computation into `mpv_twoBlockTensor_eq`
- **Wielandt/RectangularSpan/***: simplified range witness destructions
- **Wielandt/Primitivity/***: compressed perturbation rewrites
- **PiAlgebra/CanonicalFormSep***: inlined gauge-phase steps
- **Spectral/SpectralGap***: cleaned determinant and conjugation proofs

### Verification

- All 40 files verified individually with `lake env lean`
- Full `lake build` succeeds (8536 jobs)
- No new `sorry` introduced; no theorem/definition statements changed
- Remaining build warnings are only intentional `sorry` declarations in PeriodicOverlap.lean, ParentHamiltonian files, and WedderburnDecomp.lean

### Related issues

Partially addresses #334 (spaghetti proof refactoring)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly proof-term refactors and lemma extraction with no API or statement changes; the main risk is accidental breakage of typeclass inference due to reorganized instances/scoping.
> 
> **Overview**
> This PR is a broad **lint + proof simplification** pass across many Lean modules, primarily replacing verbose `show`/`exact`/`simpa` chains with `change`/`simp`/`refine`, reformatting long `simp only` blocks, and tightening local rewrites to eliminate style and unused-argument warnings.
> 
> It also **refactors a few recurring proof patterns into local helpers** to reduce duplication and timeouts (e.g., cached Euclidean `InnerProductSpace` inference in `KrausFreedom`, block-PSD padding lemmas used for n-positivity in `TwoPositive`, cyclic-shift induction helper in `MPS/CanonicalForm/Assembly`, and a two-block MPV sum lemma in `InvariantSubspaceDecomp`).
> 
> Finally, some **instance scoping/organization** is cleaned up (notably matrix scalar/continuous-scalar compatibility instances in `MatrixOperatorSpace`) to avoid `unusedSectionVars` and streamline typeclass resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb9d6e359cabe3487e7dc7e822cbd46528847cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->