### PR TITLE
style(TNLean): simplify proofs across round 2

### DIFF
--- a/TNLean/Channel/ChoiJamiolkowski.lean
+++ b/TNLean/Channel/ChoiJamiolkowski.lean
@@ -112,11 +112,8 @@ theorem choiMatrix_apply
 @[simp] theorem choiMatrix_neg
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     choiMatrix (-T) = -choiMatrix T := by
-  rw [show -T = (-1 : ℂ) • T by
-    ext X i j
-    simp]
-  rw [choiMatrix_smul]
-  simp
+  rw [← neg_one_smul ℂ T, choiMatrix_smul]
+  exact neg_one_smul ℂ (choiMatrix T)
 
 theorem choiMatrix_sub
     (T S : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
@@ -137,11 +134,8 @@ theorem choiMatrix_sub
 @[simp] theorem projectedChoiMatrix_neg
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     projectedChoiMatrix (-T) = -projectedChoiMatrix T := by
-  rw [show -T = (-1 : ℂ) • T by
-    ext X i j
-    simp]
-  rw [projectedChoiMatrix_smul]
-  simp
+  rw [← neg_one_smul ℂ T, projectedChoiMatrix_smul]
+  exact neg_one_smul ℂ (projectedChoiMatrix T)
 
 theorem projectedChoiMatrix_sub
     (T S : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
@@ -341,7 +335,7 @@ theorem cp_iff_choi_posSemidef [NeZero D] :
       have hsqrt : (((D : ℝ).sqrt : ℂ)) ≠ 0 :=
         Complex.ofReal_ne_zero.mpr <| Real.sqrt_ne_zero'.2 (by exact_mod_cast hDpos)
       simp [hsqrt]
-    have hstarc : star c = c := by dsimp [c]; simp
+    have hstarc : star c = c := by simp [c]
     have hαne : c * star c ≠ 0 := by simpa [hstarc] using mul_ne_zero hc hc
     let K : Fin r → Matrix (Fin D) (Fin D) ℂ := fun m a b => v m (a, b) / c
     let S : Matrix (Fin D) (Fin D) ℂ → Matrix (Fin D) (Fin D) ℂ :=
@@ -453,7 +447,7 @@ theorem choiMatrix_isHermitian_iff_hermiticityPreserving [NeZero D] :
   classical
   let c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
   have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
-  have hstarc : star c = c := by dsimp [c]; simp
+  have hstarc : star c = c := by simp [c]
   have hαne : c * star c ≠ 0 := by
     have hc : c ≠ 0 := by
       dsimp [c]
@@ -529,8 +523,7 @@ theorem choiMatrix_injective [NeZero D] :
   let c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
   have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
   have hstarc : star c = c := by
-    dsimp [c]
-    simp
+    simp [c]
   have hαne : c * star c ≠ 0 := by
     have hc : c ≠ 0 := by
       dsimp [c]
@@ -597,8 +590,7 @@ theorem exists_cpMap_of_choi_posSemidef [NeZero D]
       Complex.ofReal_ne_zero.mpr <| Real.sqrt_ne_zero'.2 (by exact_mod_cast hDpos)
     simp [hsqrt]
   have hstarc : star c = c := by
-    dsimp [c]
-    simp
+    simp [c]
   let K : Fin r → Matrix (Fin D) (Fin D) ℂ := fun m a b => v m (a, b) / c
   let T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
     { toFun := fun X => ∑ m : Fin r, K m * X * (K m)ᴴ

--- a/TNLean/Channel/FixedPoint/Algebra.lean
+++ b/TNLean/Channel/FixedPoint/Algebra.lean
@@ -102,13 +102,12 @@ theorem ks_equality_of_mem_fixedPoints
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ)
     {X : Mat} (hX : X ∈ fixedPoints K) :
     map K (Xᴴ * X) = Xᴴ * X := by
-  have hXeq : map K X = X := by
-    simpa [fixedPoints] using hX
+  have hXeq : map K X = X := hX
   have hX' : map K X = (1 : ℂ) • X := by
-    simpa using hXeq
+    simpa only [one_smul] using hXeq
   have hKS : map K (Xᴴ * X) = (map K X)ᴴ * map K X :=
     ks_equality_of_peripheral_eigenvector_of_fixedPoint K h_unital hρ hρ_fix X 1 hX'
-      (by simp)
+      (by simpa only using (norm_one : ‖(1 : ℂ)‖ = 1))
   rw [hXeq] at hKS
   exact hKS
 
@@ -182,8 +181,8 @@ noncomputable def fixedPointsStarSubalgebra
     simp [map]
   add_mem' := by
     intro X Y hX hY
-    have hXeq : map K X = X := by simpa [fixedPoints] using hX
-    have hYeq : map K Y = Y := by simpa [fixedPoints] using hY
+    have hXeq : map K X = X := hX
+    have hYeq : map K Y = Y := hY
     change map K (X + Y) = X + Y
     rw [map_add, hXeq, hYeq]
   one_mem' := by
@@ -286,9 +285,8 @@ noncomputable def fixedPoints_starSubalgebra
     (X : Mat) :
     X ∈ fixedPoints_starSubalgebra (K := K) h_tp hρ hρ_fix ↔
       X ∈ adjointFixedPoints K := by
-  change X ∈ adjointFixedPointsStarSubalgebra (K := K) h_tp hρ hρ_fix ↔
-    X ∈ adjointFixedPoints K
-  simp
+  simpa only using
+    (mem_adjointFixedPointsStarSubalgebra (K := K) h_tp hρ hρ_fix X)
 
 /-- **Wolf Thm 6.13** with the prompt's naming convention.
 
@@ -482,9 +480,8 @@ theorem adjointFixedPointsStarSubalgebra_eq_krausCommutantStarSubalgebra
   · exact le_krausCommutantStarSubalgebra_of_le_adjointFixedPoints (K := K) h_tp
       (fun {X} hX => by simpa using hX)
   · intro X hX
-    have hfix : X ∈ adjointFixedPoints K :=
-      mem_adjointFixedPoints_of_mem_krausCommutant (K := K) h_tp hX
-    simpa using hfix
+    exact (mem_adjointFixedPointsStarSubalgebra (K := K) h_tp hρ hρ_fix X).2
+      (mem_adjointFixedPoints_of_mem_krausCommutant (K := K) h_tp hX)
 
 end Commutant
 

--- a/TNLean/Channel/Irreducible/FromSpectral.lean
+++ b/TNLean/Channel/Irreducible/FromSpectral.lean
@@ -337,8 +337,7 @@ theorem isIrreducibleMap_of_channel_posDef_fixedPoint_unique
   have hc_ne : c ≠ 0 := by
     intro hc
     apply hσ_ne
-    rw [hσ_eq, hc]
-    simp
+    simp [hσ_eq, hc]
   have hρ_corner_scaled : c • (P * ρ * P) = c • ρ := by
     simpa [hσ_eq, Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_assoc] using hσ_corner
   have hρ_corner : P * ρ * P = ρ := by
@@ -399,7 +398,7 @@ theorem isIrreducibleMap_of_hasSpectralProperties
     simpa [hS_def] using (CFC.isUnit_sqrt_iff σ hσ_nonneg).2 (Matrix.PosDef.isUnit hσ_pd)
   have hS_inv_inv : S⁻¹⁻¹ = S := by
     letI := hS_unit.invertible
-    simp
+    exact Matrix.inv_inv_of_invertible S
   have hS_inv_herm : (S⁻¹)ᴴ = S⁻¹ := by
     simpa [hS_herm] using Matrix.conjTranspose_nonsing_inv S
   set A' : MPSTensor n D := fun i => d • K i with hA'_def

--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -268,7 +268,7 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
     simpa [hS_def] using (CFC.isUnit_sqrt_iff σ hσ_nonneg).2 (Matrix.PosDef.isUnit hσ_pd)
   have hS_inv_inv : S⁻¹⁻¹ = S := by
     letI := hS_unit.invertible
-    simp
+    exact Matrix.inv_inv_of_invertible S
   have hS_inv_herm : (S⁻¹)ᴴ = S⁻¹ := by
     simpa [hS_herm] using Matrix.conjTranspose_nonsing_inv S
   set A' : MPSTensor n D := fun i => d • K i with hA'_def
@@ -372,10 +372,10 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
     exact hHas.mem_spectrum
   have h1_le : (1 : ENNReal) ≤ spectralRadius ℂ
       ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) E') := by
-    have h1 : (1 : ENNReal) = (‖(1 : ℂ)‖₊ : ENNReal) := by simp
-    rw [h1]
-    exact @le_iSup₂ ENNReal ℂ (· ∈ spectrum ℂ _) _
-      (fun k _ => (‖k‖₊ : ENNReal)) 1 h1_spec
+    rw [spectralRadius]
+    simpa using
+      (@le_iSup₂ ENNReal ℂ (· ∈ spectrum ℂ _) _
+        (fun k _ => (‖k‖₊ : ENNReal)) 1 h1_spec)
   have hrad'_eq : spectralRadius ℂ
       ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) E') = 1 :=
     le_antisymm hrad'_le h1_le
@@ -436,8 +436,7 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
     have hr_nonpos : r ≤ 0 := by
       simpa [ENNReal.ofReal_eq_zero] using hzero
     exact (not_le_of_gt hr) hr_nonpos
-  have hr_enn_ne_top : ENNReal.ofReal r ≠ ∞ := by
-    simp
+  have hr_enn_ne_top : ENNReal.ofReal r ≠ ∞ := ENNReal.ofReal_ne_top
   calc
     spectralRadius ℂ
         ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) E)
@@ -447,7 +446,7 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
                 symm
                 rw [← mul_assoc, ENNReal.mul_inv_cancel hr_enn_ne_zero hr_enn_ne_top, one_mul]
     _ = ENNReal.ofReal r * 1 := by rw [hscaled_one]
-    _ = ENNReal.ofReal r := by simp
+    _ = ENNReal.ofReal r := by rw [mul_one]
 
 /-- **Real-valued spectral-radius identity** (Wolf Thm 6.3(4), real form).
 

--- a/TNLean/Channel/Peripheral/GroupStructure.lean
+++ b/TNLean/Channel/Peripheral/GroupStructure.lean
@@ -79,8 +79,7 @@ private lemma trace_transferMap_of_tp
     Matrix.trace (MPSTensor.transferMap (d := r) (D := D) K X) = Matrix.trace X := by
   simp only [MPSTensor.transferMap_apply, Matrix.trace_sum]
   conv_lhs => arg 2; ext i; rw [Matrix.trace_mul_cycle]
-  rw [← Matrix.trace_sum, ← Finset.sum_mul,
-    show ∑ i : Fin r, (K i)ᴴ * K i = 1 from hTP, one_mul]
+  rw [← Matrix.trace_sum, ← Finset.sum_mul, hTP, one_mul]
 
 /-- The trace of an orthogonal projection (Hermitian idempotent matrix) over `ℂ` is a natural
 number — it equals the number of unit eigenvalues. -/
@@ -417,9 +416,10 @@ theorem peripheral_eigenvalues_cyclic_structure
       have hg_eq : (⟨u, hu_mem⟩ : ↥periphSubgroup) = g ^ z := hz.symm
       have hg_mod : g ^ z = g ^ (z % ↑m).toNat := by
         have hm_ne : (m : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (by omega)
+        have hmod_cast : z % ↑m = ↑(z % ↑m).toNat := by
+          exact (Int.toNat_of_nonneg (Int.emod_nonneg z hm_ne)).symm
         conv_lhs => rw [← zpow_mod_orderOf g z, hg_order]
-        rw [show z % ↑m = ↑(z % ↑m).toNat from
-          (Int.toNat_of_nonneg (Int.emod_nonneg z hm_ne)).symm, zpow_natCast]
+        rw [hmod_cast, zpow_natCast]
         rfl
       have hz_val : u = g.val ^ (z % ↑m).toNat := by
         have : (⟨u, hu_mem⟩ : ↥periphSubgroup).val = (g ^ (z % ↑m).toNat).val := by

--- a/TNLean/Channel/Semigroup/Basic.lean
+++ b/TNLean/Channel/Semigroup/Basic.lean
@@ -171,10 +171,8 @@ theorem expSemigroupCLM_zero
     expSemigroupCLM L 0 = 1 := by
   have hz : (0 : ℂ) • L = (0 : MatrixCLM (Fin D)) := by
     ext X i j
-    simp
-  rw [expSemigroupCLM, Complex.ofReal_zero]
-  rw [hz]
-  simp
+    simp only [zero_smul, ContinuousLinearMap.zero_apply, Matrix.zero_apply]
+  simp [expSemigroupCLM, hz]
 
 /-! ### Continuity of the exponential semigroup -/
 
@@ -244,7 +242,9 @@ theorem hasDerivAt_expSemigroup_apply
     hasDerivAt_expSemigroupCLM (endEquiv L) t
   let evalXₗ : MatrixCLM (Fin D) →ₗ[ℝ] Matrix (Fin D) (Fin D) ℂ :=
     { toFun := fun T => T X
-      map_add' := by intro T₁ T₂; simp
+      map_add' := by
+        intro T₁ T₂
+        simp only [ContinuousLinearMap.add_apply]
       map_smul' := by
         intro r T
         change ((r • T) X) = r • (T X)
@@ -304,9 +304,8 @@ theorem expSemigroup_isContinuousDynSemigroup
     IsContinuousDynSemigroup (expSemigroup L) where
   semigroup := expSemigroup_isDynSemigroup L
   continuous := by
-    show Continuous (fun t => endEquiv (expSemigroup L t))
-    simp only [expSemigroup_toCLM]
-    exact expSemigroupCLM_continuous (endEquiv L)
+    simpa only [expSemigroup_toCLM] using
+      expSemigroupCLM_continuous (endEquiv L)
 
 /-! ## Proposition 7.1: Continuous semigroup → exp(tL) -/
 
@@ -382,11 +381,10 @@ private theorem continuous_semigroup_hasDerivWithinAt_zero
           (x := (1 : MatrixCLM (Fin D)) - (δ / 2)⁻¹ • P (δ / 2))
           hnear)
     -- Step 6: (δ/2) • 1 is a unit (algebraMap of nonzero scalar)
-    have hu2 : IsUnit ((δ/2) • (1 : Matrix (Fin D) (Fin D) ℂ →L[ℂ]
+    have hu2 : IsUnit ((δ / 2) • (1 : Matrix (Fin D) (Fin D) ℂ →L[ℂ]
         Matrix (Fin D) (Fin D) ℂ)) := by
-      rw [show (δ/2) • (1 : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ) =
-          algebraMap ℝ _ (δ/2) from (Algebra.algebraMap_eq_smul_one _).symm]
-      exact (IsUnit.mk0 (δ/2) (ne_of_gt hε_pos)).map (algebraMap ℝ _)
+      change IsUnit (algebraMap ℝ (MatrixCLM (Fin D)) (δ / 2))
+      exact (IsUnit.mk0 (δ / 2) (ne_of_gt hε_pos)).map (algebraMap ℝ _)
     -- Step 7: P(δ/2) = (δ/2 • 1) * ((δ/2)⁻¹ • P(δ/2))
     have hfact : P (δ/2) = (δ/2) • (1 : Matrix (Fin D) (Fin D) ℂ →L[ℂ] _) *
         ((δ/2)⁻¹ • P (δ/2)) := by
@@ -510,11 +508,12 @@ theorem continuousDynSemigroup_eq_exp
     fun t => endEquiv (T t) with hS_def
   -- Properties of S
   have hS_zero : S 0 = 1 := by
-    change endEquiv (T 0) = 1; rw [hT.semigroup.zero]; exact map_one endEquiv
+    simpa [S] using congrArg endEquiv hT.semigroup.zero
   have hS_add : ∀ t s, 0 ≤ t → 0 ≤ s → S (t + s) = S t * S s := by
     intro t s ht hs
     change endEquiv (T (t + s)) = endEquiv (T t) * endEquiv (T s)
-    rw [hT.semigroup.comp t s ht hs]; exact map_mul endEquiv (T t) (T s)
+    rw [hT.semigroup.comp t s ht hs]
+    exact map_mul endEquiv (T t) (T s)
   have hS_cont : Continuous S := hT.continuous
   -- Key lemma: S is right-differentiable at 0 with some derivative L_CLM
   obtain ⟨L_CLM, hL_deriv⟩ := continuous_semigroup_hasDerivWithinAt_zero S hS_zero hS_add hS_cont
@@ -554,7 +553,7 @@ theorem continuousDynSemigroup_eq_exp
     fun v (hv : u ≤ v) => show 0 ≤ v - u from sub_nonneg.mpr hv
   have hcomp : HasDerivWithinAt (fun v => S (v - u)) L_CLM (Set.Ici u) u := by
     have hL_at : HasDerivWithinAt S L_CLM (Set.Ici 0) (u - u) := by
-      convert hL_deriv using 2; simp
+      simpa only [sub_self] using hL_deriv
     have := HasDerivWithinAt.scomp (h := fun v => v - u)
       (g₁ := S) (g₁' := L_CLM) (t' := Set.Ici 0)
       u hL_at h_sub h_maps
@@ -591,25 +590,13 @@ theorem generator_unique
   -- Both have derivatives at 0
   have hd1 : HasDerivWithinAt
       (fun t : ℝ => expSemigroupCLM (endEquiv L) t) (endEquiv L) (Set.Ici 0) 0 := by
-    have hd1' : HasDerivAt (fun t : ℝ => expSemigroupCLM (endEquiv L) t) (endEquiv L) 0 :=
-      hasDerivAt_expSemigroupCLM_zero (endEquiv L)
-    exact HasDerivAt.hasDerivWithinAt
-      (𝕜 := ℝ)
-      (s := Set.Ici (0 : ℝ))
-      (f := fun t : ℝ => expSemigroupCLM (endEquiv L) t)
-      (f' := endEquiv L) (x := 0) hd1'
+    simpa using (hasDerivAt_expSemigroupCLM_zero (endEquiv L)).hasDerivWithinAt
   -- Congr: since the functions agree on Ici 0, f₂ also has derivative L within Ici 0
   have hd2 : HasDerivWithinAt (fun t : ℝ => expSemigroupCLM (endEquiv L) t) (endEquiv L')
       (Set.Ici 0) 0 := by
     have hd2' : HasDerivWithinAt
         (fun t : ℝ => expSemigroupCLM (endEquiv L') t) (endEquiv L') (Set.Ici 0) 0 := by
-      have hd2'' : HasDerivAt (fun t : ℝ => expSemigroupCLM (endEquiv L') t) (endEquiv L') 0 :=
-        hasDerivAt_expSemigroupCLM_zero (endEquiv L')
-      exact HasDerivAt.hasDerivWithinAt
-        (𝕜 := ℝ)
-        (s := Set.Ici (0 : ℝ))
-        (f := fun t : ℝ => expSemigroupCLM (endEquiv L') t)
-        (f' := endEquiv L') (x := 0) hd2''
+      simpa using (hasDerivAt_expSemigroupCLM_zero (endEquiv L')).hasDerivWithinAt
     exact hd2'.congr (fun x hx => hCLM x hx) (by simpa using hCLM 0 (by simp))
   -- Ici 0 has unique differentials at 0
   exact (uniqueDiffWithinAt_Ici 0).eq_deriv _ hd1 hd2

--- a/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
@@ -231,7 +231,8 @@ private theorem eulerStep_apply (G : GeneratorDecomp D) (s : ℝ) (ρ : sgMat D)
     Fin.default_eq_zero, Fin.isValue, Finset.sum_const, Finset.card_singleton, one_smul,
     sub_eq_add_neg]
   have hconj : (1 + -(s • G.κ))ᴴ = 1 + -(s • G.κᴴ) := by
-    simp
+    simp only [Matrix.conjTranspose_add, Matrix.conjTranspose_neg,
+      Matrix.conjTranspose_smul, Matrix.conjTranspose_one, star_trivial]
   calc
     (1 + -(s • G.κ)) * ρ * (1 + -(s • G.κ))ᴴ + s • G.φ ρ =
         (1 + -(s • G.κ)) * ρ * (1 + -(s • G.κᴴ)) + s • G.φ ρ := by
@@ -240,9 +241,9 @@ private theorem eulerStep_apply (G : GeneratorDecomp D) (s : ℝ) (ρ : sgMat D)
           simp only [Matrix.mul_add, add_mul, Matrix.mul_one, Matrix.one_mul, smul_mul_assoc,
             mul_assoc, neg_mul, mul_neg]
           have hρκ : ρ * (s • G.κᴴ) = s • (ρ * G.κᴴ) := by
-            simp
+            simp only [mul_smul_comm]
           have hκρκ : G.κ * (s • (ρ * G.κᴴ)) = s • (G.κ * (ρ * G.κᴴ)) := by
-            simp
+            simp only [mul_smul_comm]
           rw [hρκ, hκρκ]
           have hrhs :
               ρ + s • (G.φ ρ + -(G.κ * ρ) + -(ρ * G.κᴴ)) + (s * s) • (G.κ * (ρ * G.κᴴ)) =
@@ -368,7 +369,9 @@ private theorem norm_eulerStep_toCLM_le [NeZero D]
 private theorem norm_pow_sub_pow_le [NeZero D]
     {A B : sgCLM D} {M : ℝ} (hM : 1 ≤ M) (hA : ‖A‖ ≤ M) (hB : ‖B‖ ≤ M) :
     ∀ m : ℕ, ‖A ^ m - B ^ m‖ ≤ (m : ℝ) * M ^ m * ‖A - B‖
-  | 0 => by simp
+  | 0 => by
+      simp only [pow_zero, sub_self, norm_zero, Nat.cast_zero, zero_mul]
+      exact le_rfl
   | m + 1 => by
       have hm := norm_pow_sub_pow_le hM hA hB m
       have hsplit : A ^ (m + 1) - B ^ (m + 1) = A ^ m * (A - B) + (A ^ m - B ^ m) * B := by

--- a/TNLean/Channel/Semigroup/LiouvillianKernel.lean
+++ b/TNLean/Channel/Semigroup/LiouvillianKernel.lean
@@ -187,7 +187,7 @@ theorem trace_mul_toAdjointLinearMap_eq_trace_toLinearMap_mul
     _ = (-Complex.I) • (Aᴴ * F.H - F.H * Aᴴ) := by
             rw [← neg_smul]
     _ = star Complex.I • (Aᴴ * F.H - F.H * Aᴴ) := by
-            simp
+            simp only [Complex.star_def, Complex.conj_I]
 
 /-- The commutant of the Hamiltonian, the Lindblad operators, and their adjoints. -/
 def commutant (F : LindbladForm D) : Set Mat :=
@@ -229,7 +229,8 @@ private theorem adjointDissipator_eq_zero_of_commute {Lop A : Mat}
   change M - (1 / 2 : ℂ) • M - (1 / 2 : ℂ) • M = 0
   calc
     M - (1 / 2 : ℂ) • M - (1 / 2 : ℂ) • M
-        = ((1 : ℂ) • M - (1 / 2 : ℂ) • M) - (1 / 2 : ℂ) • M := by simp
+        = ((1 : ℂ) • M - (1 / 2 : ℂ) • M) - (1 / 2 : ℂ) • M := by
+          simp only [one_smul]
     _ = (((1 : ℂ) - (1 / 2 : ℂ)) • M) - (1 / 2 : ℂ) • M := by
           rw [← sub_smul]
     _ = (((1 : ℂ) - (1 / 2 : ℂ) - (1 / 2 : ℂ)) • M) := by
@@ -246,13 +247,12 @@ theorem mem_adjointKernel_of_mem_commutant (F : LindbladForm D) {A : Mat}
   rw [adjointKernel, Set.mem_setOf_eq, toAdjointLinearMap_apply]
   have hHterm : Complex.I • (F.H * A - A * F.H) = 0 := by
     rw [← hH]
-    simp
+    simp only [sub_self, smul_zero]
   have hsum : ∑ j : Fin F.r, adjointDissipator (F.L j) A = 0 := by
     refine Finset.sum_eq_zero ?_
     intro j _hj
     exact adjointDissipator_eq_zero_of_commute (hL j).1 (hL j).2
-  rw [hHterm, hsum]
-  simp
+  simp only [hHterm, hsum, zero_add]
 
 /-- Wolf Theorem 7.2, easy direction as a set inclusion. -/
 theorem commutant_subset_adjointKernel (F : LindbladForm D) :

--- a/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
@@ -127,7 +127,9 @@ theorem expSemigroup_apply_eigenvector
         c u • (μ • g u) + (-(c u * μ)) • g u
             = (c u * μ) • g u + (-(c u * μ)) • g u := by
                 simp [smul_smul]
-        _ = 0 := by simp
+        _ = 0 := by
+              rw [neg_smul]
+              exact add_neg_cancel ((c u * μ) • g u)
     simpa [hz, smul_smul, mul_assoc] using hf.deriv
   have hconst := is_const_of_deriv_eq_zero hdiff hderiv 0 t
   have hft0 : f 0 = X := by
@@ -141,14 +143,13 @@ theorem expSemigroup_apply_eigenvector
     exact Complex.exp_ne_zero _
   have hmain : c t • expSemigroup L t X = c t • (Complex.exp ((t : ℂ) * μ) • X) := by
     calc
-      c t • expSemigroup L t X = f t := by simp [f, g]
+      c t • expSemigroup L t X = f t := by rfl
       _ = X := hfteq
       _ = c t • (Complex.exp ((t : ℂ) * μ) • X) := by
         dsimp [c]
         rw [smul_smul]
         have : Complex.exp (-((t : ℂ) * μ)) * Complex.exp ((t : ℂ) * μ) = 1 := by
-          rw [← Complex.exp_add]
-          simp
+          rw [← Complex.exp_add, neg_add_cancel, Complex.exp_zero]
         rw [this, one_smul]
   have hcancel := congrArg ((c t)⁻¹ • ·) hmain
   simpa [c, smul_smul, inv_mul_cancel₀ hct_ne, one_smul,

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -259,9 +259,8 @@ theorem transferMatrix_tp_iff
   constructor
   · intro htp k l
     simp only [transferMatrix_apply]
-    change ∑ i, (T (Matrix.single k l 1)) i i = _
-    rw [show ∑ i, (T (Matrix.single k l 1)) i i =
-        Matrix.trace (T (Matrix.single k l 1)) from rfl, htp]
+    change Matrix.trace (T (Matrix.single k l 1)) = _
+    rw [htp]
     by_cases hkl : k = l
     · subst hkl; rw [if_pos rfl]; exact Matrix.trace_single_eq_same k (1 : ℂ)
     · rw [Matrix.trace_single_eq_of_ne k l (1 : ℂ) hkl, if_neg hkl]
@@ -389,7 +388,8 @@ theorem transferMatrix_unitaryConj (U : Matrix (Fin D) (Fin D) ℂ) :
 theorem unitaryConjLM_isCPMap (U : Matrix (Fin D) (Fin D) ℂ) :
     IsCPMap (unitaryConjLM U) :=
   ⟨1, fun _ : Fin 1 => U, fun X => by
-    show unitaryConjLM U X = _; rw [unitaryConjLM_apply]; simp only [Fin.sum_univ_one]⟩
+    change U * X * Uᴴ = _
+    simp only [Fin.sum_univ_one]⟩
 
 /-- Unitary conjugation by a unitary matrix is trace-preserving. -/
 theorem unitaryConjLM_isTP_of_unitary (U : Matrix (Fin D) (Fin D) ℂ)

--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -193,8 +193,7 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
       have hterm : ∀ k : Fin g,
           Tendsto (fun N => (GA N)⁻¹ i k * v N k) atTop (nhds (0 : ℂ)) := by
         intro k
-        have := (hGA_inv_entry i k).mul (hall_inner k)
-        simp only [mul_zero] at this; exact this
+        simpa only [mul_zero] using (hGA_inv_entry i k).mul (hall_inner k)
       have hsum : Tendsto (fun N => ∑ k : Fin g, (GA N)⁻¹ i k * v N k) atTop (nhds (0 : ℂ)) := by
         simpa only [Finset.sum_const_zero] using
           tendsto_finset_sum Finset.univ (fun k _ => hterm k)
@@ -218,8 +217,8 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
       have hprod : ∀ i : Fin g,
           Tendsto (fun N => starRingEnd ℂ (u N i) * v N i) atTop (nhds (0 : ℂ)) := by
         intro i
-        have := (hu_tendsto_zero i).star.mul (hall_inner i)
-        simp only [star_zero, zero_mul] at this; exact this
+        simpa only [star_zero, zero_mul] using
+          (hu_tendsto_zero i).star.mul (hall_inner i)
       have hsum : Tendsto (fun N => ∑ i : Fin g, starRingEnd ℂ (u N i) * v N i)
           atTop (nhds (0 : ℂ)) := by
         simpa only [Finset.sum_const_zero] using
@@ -295,15 +294,15 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
     -- Self-overlap of A(f j1) in norm → 1.
     have hAA_norm_tendsto :
         Tendsto (fun N => ‖mpvOverlap (d := d) (A (f j1)) (A (f j1)) N‖) atTop (nhds 1) := by
-      convert (hA_self (f j1)).norm using 1; simp only [norm_one]
+      simpa only [norm_one] using (hA_self (f j1)).norm
     --
     -- BB overlap norms → 1.
     have hBB1_norm :
         Tendsto (fun N => ‖mpvOverlap (d := d) (B j1) (B j1) N‖) atTop (nhds 1) := by
-      convert (hB_self j1).norm using 1; simp only [norm_one]
+      simpa only [norm_one] using (hB_self j1).norm
     have hBB2_norm :
         Tendsto (fun N => ‖mpvOverlap (d := d) (B j2) (B j2) N‖) atTop (nhds 1) := by
-      convert (hB_self j2).norm using 1; simp only [norm_one]
+      simpa only [norm_one] using (hB_self j2).norm
     --
     have hζ1_norm : ‖ζ1‖ = 1 :=
       norm_eq_one_of_selfOverlap_scale hAA_norm_tendsto hBB1_norm
@@ -347,7 +346,7 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
     --
     have hCross_norm_zero :
         Tendsto (fun N => ‖mpvOverlap (d := d) (B j1) (B j2) N‖) atTop (nhds 0) := by
-      convert h_cross.norm using 1; simp only [norm_zero]
+      simpa only [norm_zero] using h_cross.norm
     --
     exact zero_ne_one (tendsto_nhds_unique hCross_norm_zero hCross_norm_one)
   --
@@ -361,7 +360,7 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
   refine ⟨e.symm, fun j => ?_⟩
   have hfe : f (e.symm j) = j := Equiv.ofBijective_apply_symm_apply f hf_bij j
   have hdim : dimA j = dimB (e.symm j) := by
-    have := hf_dim (e.symm j); rw [hfe] at this; exact this
+    simpa [hfe] using hf_dim (e.symm j)
   exact ⟨hdim, gaugePhaseEquiv_cast_idx A B hfe (hf_dim (e.symm j)) (hf_gauge (e.symm j))⟩
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -278,8 +278,7 @@ theorem exists_trivialSectorDecomp_of_sorted_distinct_norms
     intro i j hij
     change ‖P.sectors.weight j ⟨0, P.sectors.copies_pos j⟩‖ <
       ‖P.sectors.weight i ⟨0, P.sectors.copies_pos i⟩‖
-    simp only [P, sectors]
-    exact hAnti hij
+    simpa only [P, sectors] using hAnti hij
 
 /-! ### §5. BNT grouping for blocks with possibly equal norms -/
 

--- a/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
@@ -54,11 +54,11 @@ lemma charpoly_conjTranspose (M : Matrix n n ℂ) :
     --
     -- and `starRingEnd` acts as complex conjugation.
     change star (M j i) = starRingEnd ℂ (M j i)
-    simp
+    simp only [starRingEnd_apply]
   -- Use transpose- and map-compatibility of `charpoly`.
   calc
     (Mᴴ).charpoly = ((M.map (starRingEnd ℂ))ᵀ).charpoly := by
-      simp [h]
+      simp only [h]
     _ = (M.map (starRingEnd ℂ)).charpoly :=
       Matrix.charpoly_transpose (M := M.map (starRingEnd ℂ))
     _ = M.charpoly.map (starRingEnd ℂ) :=
@@ -86,10 +86,10 @@ theorem Module.End.hasEigenvalue_adjoint_iff (E : V →ₗ[ℂ] V) (μ : ℂ) :
     stdOrthonormalBasis ℂ V
   -- Rewrite both characteristic polynomials as matrix characteristic polynomials.
   have hE : (LinearMap.toMatrix v.toBasis v.toBasis E).charpoly = E.charpoly := by
-    simp
+    simpa only using (LinearMap.charpoly_toMatrix (f := E) v.toBasis)
   have hEadj :
       (LinearMap.toMatrix v.toBasis v.toBasis E.adjoint).charpoly = E.adjoint.charpoly := by
-    simp
+    simpa only using (LinearMap.charpoly_toMatrix (f := E.adjoint) v.toBasis)
   -- The matrix of the adjoint is the conjugate transpose of the matrix.
   have hMatAdj :
       LinearMap.toMatrix v.toBasis v.toBasis E.adjoint =
@@ -103,11 +103,14 @@ theorem Module.End.hasEigenvalue_adjoint_iff (E : V →ₗ[ℂ] V) (μ : ℂ) :
     -- We rewrite it symmetrically below.)
     calc
       E.adjoint.charpoly
-          = (LinearMap.toMatrix v.toBasis v.toBasis E.adjoint).charpoly := by simp [hEadj]
-        _ = ((LinearMap.toMatrix v.toBasis v.toBasis E)ᴴ).charpoly := by simp [hMatAdj]
-        _ = (LinearMap.toMatrix v.toBasis v.toBasis E).charpoly.map (starRingEnd ℂ) :=
-            Matrix.charpoly_conjTranspose (M := LinearMap.toMatrix v.toBasis v.toBasis E)
-        _ = E.charpoly.map (starRingEnd ℂ) := by simp [hE]
+          = (LinearMap.toMatrix v.toBasis v.toBasis E.adjoint).charpoly := by
+              exact hEadj.symm
+      _ = ((LinearMap.toMatrix v.toBasis v.toBasis E)ᴴ).charpoly := by
+            rw [hMatAdj]
+      _ = (LinearMap.toMatrix v.toBasis v.toBasis E).charpoly.map (starRingEnd ℂ) := by
+            exact Matrix.charpoly_conjTranspose (M := LinearMap.toMatrix v.toBasis v.toBasis E)
+      _ = E.charpoly.map (starRingEnd ℂ) := by
+            rw [hE]
   -- Now compare roots using `Polynomial.isRoot_map_iff`.
   -- `starRingEnd ℂ` is injective.
   simp [hchar]

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -43,7 +43,8 @@ lemma commutes_evalWord_of_commutes_letters
     ∀ w : List (Fin d), P * evalWord A w = evalWord A w * P := by
   intro w
   induction w with
-  | nil => simp [evalWord]
+  | nil =>
+      simp only [evalWord, Matrix.one_mul, Matrix.mul_one]
   | cons i w ih =>
       simp only [evalWord]
       calc P * (A i * evalWord A w)
@@ -60,12 +61,13 @@ lemma left_mul_evalWord_leftSectorTensor_of_commutes
       P * evalWord (leftSectorTensor P A) w = P * evalWord A w := by
   intro w
   induction w with
-  | nil => simp [evalWord]
+  | nil =>
+      simp only [evalWord]
   | cons i w ih =>
       simp only [leftSectorTensor, evalWord]
       calc P * (P * A i * evalWord (leftSectorTensor P A) w)
           = P * P * A i * evalWord (leftSectorTensor P A) w := by
-            simp [Matrix.mul_assoc]
+            simp only [Matrix.mul_assoc]
         _ = P * A i * evalWord (leftSectorTensor P A) w := by rw [hPidem]
         _ = A i * (P * evalWord (leftSectorTensor P A) w) := by
             rw [← Matrix.mul_assoc, hComm i, Matrix.mul_assoc]
@@ -81,7 +83,9 @@ lemma leftSectorTensor_supported
     ∀ i : Fin d, P * leftSectorTensor P A i * P = leftSectorTensor P A i := by
   intro i
   simp only [leftSectorTensor]
-  calc P * (P * A i) * P = P * P * A i * P := by simp [Matrix.mul_assoc]
+  calc
+    P * (P * A i) * P = P * P * A i * P := by
+      simp only [Matrix.mul_assoc]
     _ = P * A i * P := by rw [hPidem]
     _ = P * A i := by rw [hComm i, Matrix.mul_assoc, hPidem]
 
@@ -102,7 +106,7 @@ private lemma evalWord_conj_unitary
   | nil =>
       have hUU : (↑U : MatrixAlg D)ᴴ * (↑U : MatrixAlg D) = 1 := by
         simpa [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U
-      simp [evalWord, hUU]
+      simp only [evalWord, hUU, Matrix.mul_one]
   | cons i w ih =>
       have hUU : (↑U : MatrixAlg D) * (↑U : MatrixAlg D)ᴴ = 1 := by
         simpa [Matrix.star_eq_conjTranspose] using Unitary.mul_star_self_of_mem U.prop
@@ -113,7 +117,7 @@ private lemma evalWord_conj_unitary
           = (↑U : MatrixAlg D)ᴴ * A i * ((↑U : MatrixAlg D) * (↑U : MatrixAlg D)ᴴ) *
               evalWord A w * (↑U : MatrixAlg D) := by noncomm_ring
         _ = (↑U : MatrixAlg D)ᴴ * (A i * evalWord A w) * (↑U : MatrixAlg D) := by
-              simp [hUU, Matrix.mul_assoc]
+              simp only [Matrix.mul_assoc, hUU, Matrix.one_mul]
 
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.
@@ -148,8 +152,10 @@ theorem exists_compressedTensor_of_supported_projection
     simpa [Pdiag, f, Unitary.conjStarAlgAut_star_apply] using h
   have hPdiag_idem : Pdiag * Pdiag = Pdiag := by
     change Umatᴴ * P * Umat * (Umatᴴ * P * Umat) = Umatᴴ * P * Umat
-    calc Umatᴴ * P * Umat * (Umatᴴ * P * Umat)
-        = Umatᴴ * (P * (Umat * Umatᴴ) * P) * Umat := by simp [Matrix.mul_assoc]
+    calc
+      Umatᴴ * P * Umat * (Umatᴴ * P * Umat)
+          = Umatᴴ * (P * (Umat * Umatᴴ) * P) * Umat := by
+              simp only [Matrix.mul_assoc]
       _ = Umatᴴ * (P * P) * Umat := by rw [hUU, Matrix.mul_one]
       _ = Umatᴴ * P * Umat := by rw [hP.2]
   have hf01 : ∀ j : Fin D, f j = 0 ∨ f j = 1 := by
@@ -157,7 +163,8 @@ theorem exists_compressedTensor_of_supported_projection
     have hDiag_idem : Matrix.diagonal f * Matrix.diagonal f = Matrix.diagonal f := by
       simpa [hPdiag_eq] using hPdiag_idem
     have hfun : (fun k => f k * f k) = f := by
-      apply Matrix.diagonal_injective; simpa [Matrix.diagonal_mul_diagonal] using hDiag_idem
+      apply Matrix.diagonal_injective
+      simpa [Matrix.diagonal_mul_diagonal] using hDiag_idem
     exact mul_self_eq_self_or_eq_one (f j) (congrFun hfun j)
   -- Index splitting
   let p : Fin D → Prop := fun j => f j = 1
@@ -179,26 +186,36 @@ theorem exists_compressedTensor_of_supported_projection
     change Matrix.reindex eST eST Pdiag = P0
     rw [hPdiag_eq, show Matrix.reindex eST eST (Matrix.diagonal f) =
         Matrix.diagonal (f ∘ eST.symm) from by simp [Matrix.reindex_apply]]
-    ext x y; cases x with
-    | inl s => cases y with
-      | inl s' => by_cases h : s = s'
-                  · subst h; simpa [p, P0] using s.2
-                  · simp [P0, Matrix.fromBlocks_apply₁₁, h]
-      | inr t => simp [P0, Matrix.fromBlocks_apply₁₂]
-    | inr t => cases y with
-      | inl s => simp [P0, Matrix.fromBlocks_apply₂₁]
-      | inr t' => by_cases h : t = t'
-                  · subst h; simpa [p, P0] using hfT t
-                  · simp [P0, Matrix.fromBlocks_apply₂₂, h]
+    ext x y
+    cases x with
+    | inl s =>
+        cases y with
+        | inl s' =>
+            by_cases h : s = s'
+            · subst h
+              simpa [p, P0] using s.2
+            · simp [P0, Matrix.fromBlocks_apply₁₁, h]
+        | inr t =>
+            simp [P0, Matrix.fromBlocks_apply₁₂]
+    | inr t =>
+        cases y with
+        | inl s =>
+            simp [P0, Matrix.fromBlocks_apply₂₁]
+        | inr t' =>
+            by_cases h : t = t'
+            · subst h
+              simpa [p, P0] using hfT t
+            · simp [P0, Matrix.fromBlocks_apply₂₂, h]
   -- B_i is Pdiag-supported
   have hBsupp : ∀ i : Fin d, Pdiag * B i * Pdiag = B i := by
     intro i
     have hkey : Pdiag * B i * Pdiag = Umatᴴ * (P * A i * P) * Umat := by
       change Umatᴴ * P * Umat * (Umatᴴ * A i * Umat) * (Umatᴴ * P * Umat) =
           Umatᴴ * (P * A i * P) * Umat
-      calc Umatᴴ * P * Umat * (Umatᴴ * A i * Umat) * (Umatᴴ * P * Umat)
-          = Umatᴴ * (P * (Umat * Umatᴴ) * A i * (Umat * Umatᴴ) * P) * Umat := by
-            simp [Matrix.mul_assoc]
+      calc
+        Umatᴴ * P * Umat * (Umatᴴ * A i * Umat) * (Umatᴴ * P * Umat)
+            = Umatᴴ * (P * (Umat * Umatᴴ) * A i * (Umat * Umatᴴ) * P) * Umat := by
+                simp only [Matrix.mul_assoc]
         _ = Umatᴴ * (P * A i * P) * Umat := by rw [hUU, Matrix.mul_one, Matrix.mul_one]
     rw [hkey, hSupp i]
   -- Block structure
@@ -208,7 +225,9 @@ theorem exists_compressedTensor_of_supported_projection
       X i = Matrix.fromBlocks (B11 i) 0 0 (0 : Matrix T T ℂ) := by
     intro i
     have hsupp_block : P0 * X i * P0 = X i := by
-      have := congrArg φ (hBsupp i); simp only [map_mul, hPdiag_std] at this; exact this
+      have := congrArg φ (hBsupp i)
+      simp only [map_mul, hPdiag_std] at this
+      exact this
     rw [(Matrix.fromBlocks_toBlocks (X i)).symm]
     rw [(Matrix.fromBlocks_toBlocks (X i)).symm] at hsupp_block
     simp only [P0, Matrix.fromBlocks_multiply, Matrix.one_mul, Matrix.mul_one,
@@ -218,17 +237,17 @@ theorem exists_compressedTensor_of_supported_projection
     have h12 : (X i).toBlocks₁₂ = 0 := by
       ext s t
       have h := extract (Sum.inl s) (Sum.inr t)
-      simp [Matrix.fromBlocks] at h
+      simp only [Matrix.fromBlocks_apply₁₂] at h
       exact h.symm
     have h21 : (X i).toBlocks₂₁ = 0 := by
       ext t s
       have h := extract (Sum.inr t) (Sum.inl s)
-      simp [Matrix.fromBlocks] at h
+      simp only [Matrix.fromBlocks_apply₂₁] at h
       exact h.symm
     have h22 : (X i).toBlocks₂₂ = 0 := by
       ext t t'
       have h := extract (Sum.inr t) (Sum.inr t')
-      simp [Matrix.fromBlocks] at h
+      simp only [Matrix.fromBlocks_apply₂₂] at h
       exact h.symm
     rw [h12, h21, h22]
   -- Compressed tensor
@@ -241,7 +260,9 @@ theorem exists_compressedTensor_of_supported_projection
       rw [trace_conj]
     rw [this, hPdiag_eq, Matrix.trace_diagonal]
     have hfsum : ∑ j : Fin D, f j = ∑ j : Fin D, if p j then (1 : ℂ) else 0 := by
-      congr 1; ext j; show f j = if p j then 1 else 0
+      congr 1
+      ext j
+      show f j = if p j then 1 else 0
       by_cases hp : p j
       · simp [hp, show f j = 1 from hp]
       · simp [hp, show f j = 0 from (hf01 j).resolve_right hp]
@@ -264,9 +285,10 @@ theorem exists_compressedTensor_of_supported_projection
           rw [Matrix.mul_assoc]
         rw [hconj]
         -- U† A† U * U† A U = U† A† (UU†) A U = U† (A† A) U
-        calc Umatᴴ * (A i)ᴴ * Umat * (Umatᴴ * A i * Umat)
-            = Umatᴴ * ((A i)ᴴ * (Umat * Umatᴴ) * A i) * Umat := by
-              simp [Matrix.mul_assoc]
+        calc
+          Umatᴴ * (A i)ᴴ * Umat * (Umatᴴ * A i * Umat)
+              = Umatᴴ * ((A i)ᴴ * (Umat * Umatᴴ) * A i) * Umat := by
+                  simp only [Matrix.mul_assoc]
           _ = Umatᴴ * ((A i)ᴴ * A i) * Umat := by rw [hUU, Matrix.mul_one]
       simp_rw [hterm]
       -- ∑ i, U† ((A i)† A i) U = U† (∑ (A i)† A i) U = U† P U = Pdiag
@@ -322,8 +344,10 @@ theorem exists_compressedTensor_of_supported_projection
         (Matrix.reindex eS eS (B11 i))ᴴ * Matrix.reindex eS eS (B11 i) =
           Matrix.reindex eS eS ((B11 i)ᴴ * B11 i)
       rw [show (Matrix.reindex eS eS (B11 i))ᴴ = Matrix.reindex eS eS ((B11 i)ᴴ) from by
-        ext a b; simp [Matrix.reindex_apply, Matrix.conjTranspose_apply, Matrix.submatrix_apply]]
-      simp [Matrix.reindex_apply, Matrix.submatrix_mul_equiv]
+        ext a b
+        simp only [Matrix.reindex_apply, Matrix.conjTranspose_apply,
+          Matrix.submatrix_apply]]
+      simp only [Matrix.reindex_apply, Matrix.submatrix_mul_equiv]
     simp_rw [hterm]
     -- ∑ reindex eS eS (f i) = reindex eS eS (∑ f i)
     ext a b
@@ -441,8 +465,10 @@ theorem exists_compressedTensor_of_supported_projection
       set M := evalWord A (List.ofFn σ)
       -- U†PU * U†MU = U†P(UU†)MU = U†(PM)U, tr = tr(PM) by trace_conj
       have hprod : Umatᴴ * P * Umat * (Umatᴴ * M * Umat) = Umatᴴ * (P * M) * Umat := by
-        calc Umatᴴ * P * Umat * (Umatᴴ * M * Umat)
-            = Umatᴴ * (P * (Umat * Umatᴴ) * M) * Umat := by simp [Matrix.mul_assoc]
+        calc
+          Umatᴴ * P * Umat * (Umatᴴ * M * Umat)
+              = Umatᴴ * (P * (Umat * Umatᴴ) * M) * Umat := by
+                  simp only [Matrix.mul_assoc]
           _ = Umatᴴ * (P * M) * Umat := by rw [hUU, Matrix.mul_one]
       rw [hprod, trace_conj]
     calc mpv C σ
@@ -475,7 +501,7 @@ theorem exists_compressedTensor_of_supported_projection_pos_mpv
     intro i
     calc
       P * A i = P * (P * A i * P) := by rw [hSupp i]
-      _ = (P * P) * A i * P := by simp [Matrix.mul_assoc]
+      _ = (P * P) * A i * P := by simp only [Matrix.mul_assoc]
       _ = P * A i * P := by rw [hP.2]
       _ = A i := by simpa [Matrix.mul_assoc] using hSupp i
   have hword :
@@ -498,7 +524,8 @@ theorem exists_compressedTensor_of_supported_projection_pos_mpv
       have hPw :
           P * evalWord A (List.ofFn σ) = evalWord A (List.ofFn σ) := by
         apply hword
-        simp
+        simpa only [List.ofFn_succ] using
+          (List.cons_ne_nil (σ 0) (List.ofFn fun i => σ i.succ))
       calc
         mpv A σ = Matrix.trace (evalWord A (List.ofFn σ)) := by rfl
         _ = Matrix.trace (P * evalWord A (List.ofFn σ)) := by
@@ -583,10 +610,13 @@ theorem commutes_letters_of_adjoint_fixed_projection
     simpa [K, KadisonSchwarz.krausMap, MPSTensor.transferMap_apply] using hFix
   have hEq : krausMap K (Pᴴ * P) = (krausMap K P)ᴴ * krausMap K P := by
     calc
-      krausMap K (Pᴴ * P) = krausMap K P := by simp [(hP.1.eq), (hP.2)]
+      krausMap K (Pᴴ * P) = krausMap K P := by
+        simp only [hP.1.eq, hP.2]
       _ = P := hKFix
-      _ = Pᴴ * P := by simp [(hP.1.eq), (hP.2)]
-      _ = (krausMap K P)ᴴ * krausMap K P := by simp [hKFix]
+      _ = Pᴴ * P := by
+        simp only [hP.1.eq, hP.2]
+      _ = (krausMap K P)ᴴ * krausMap K P := by
+        simp only [hKFix]
   intro i
   have hComm := KadisonSchwarz.kraus_commute_of_ks_equality (K := K) hUnitalK P hEq i
   simpa [K, hKFix] using hComm

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -118,10 +118,10 @@ theorem exists_CFII_data_of_TP_of_isIrreducibleTensor
         (fun i =>
           (↑U : Matrix (Fin D) (Fin D) ℂ)ᴴ * A i * (↑U : Matrix (Fin D) (Fin D) ℂ)) := by
     -- Existing lemma is stated with `star` rather than `ᴴ`.
-    simpa [Matrix.star_eq_conjTranspose] using sameMPV_conj_unitary (d := d) (D := D) A U
+    simpa only [Matrix.star_eq_conjTranspose] using
+      sameMPV_conj_unitary (d := d) (D := D) A U
   -- Assemble the packaged data under the `let B := ...` binder.
-  -- The goal is definitionally a conjunction about the explicit conjugated tensor.
-  simpa using And.intro hSame (And.intro hΛ_pd (And.intro hΛ_diag (And.intro hTP_conj hΛ_fix)))
+  exact ⟨hSame, hΛ_pd, hΛ_diag, hTP_conj, hΛ_fix⟩
 
 
 /-!
@@ -202,7 +202,7 @@ theorem evalWord_eq_zero_of_all_zero (A : MPSTensor d D)
   | nil =>
       exact (hw rfl).elim
   | cons i w =>
-      simp [evalWord, hzero i]
+      simp only [evalWord, hzero i, zero_mul]
 
 /-- An all-zero tensor contributes zero to the MPV for every positive system size. -/
 theorem mpv_eq_zero_of_all_zero (A : MPSTensor d D)
@@ -212,11 +212,11 @@ theorem mpv_eq_zero_of_all_zero (A : MPSTensor d D)
   have hw : List.ofFn σ ≠ [] := by
     intro hnil
     have hlen : N = 0 := by
-      simpa using congrArg List.length hnil
+      simpa [List.length_ofFn] using congrArg List.length hnil
     exact (Nat.ne_of_gt hN) hlen
   unfold mpv coeff
   rw [evalWord_eq_zero_of_all_zero (A := A) hzero (w := List.ofFn σ) hw]
-  simp
+  simp only [Matrix.trace_zero]
 
 /-- If an irreducible tensor has bond dimension at least `2`, then some Kraus operator is
 nonzero. -/
@@ -493,12 +493,12 @@ theorem exists_irreducible_blockDecomp_liveBlocks (A : MPSTensor d D) :
     have hA : mpv A σ = ∑ k : Fin r₀, mpv (blocks₀ k) σ := by
       have h := hSame₀ N σ
       rw [h, mpv_toTensorFromBlocks_eq_sum]
-      simp
+      simp only [one_pow, one_smul]
     -- Expand the live-block toTensorFromBlocks.
     have hLive : mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ =
         ∑ j : Fin r, mpv (newBlocks j) σ := by
       rw [mpv_toTensorFromBlocks_eq_sum]
-      simp
+      simp only [one_pow, one_smul]
     -- Split the original sum into live and zero parts.
     have hDisj : Disjoint liveSet zeroSet := by
       simp only [liveSet_def, zeroSet_def]

--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -350,7 +350,8 @@ private theorem common_blocking_primitive
         (∀ j k, j ≠ k → ‖μ2 j‖ ≠ ‖μ2 k‖) ∧
         (∀ k, μ2 k ≠ 0) ∧
         (∀ k, 0 < dim2 k) := by
-  refine ⟨1, by simp, r1, dim1, μ1, (fun k => blockTensor (d := d) (D := dim1 k) (blocks1 k) 1), ?_⟩
+  refine ⟨1, Nat.one_pos, r1, dim1, μ1,
+    (fun k => blockTensor (d := d) (D := dim1 k) (blocks1 k) 1), ?_⟩
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · intro N σ
     let σ' : Fin N → Fin d := fun n => singleBlockEquiv d (σ n)

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -138,20 +138,20 @@ theorem preservesCorner_of_adjoint_fixed_projection
   calc
     P * ((A i)ᴴ * (P * X * P) * A i) * P
         = (P * (A i)ᴴ) * (P * X * P) * (A i * P) := by
-            simp [Matrix.mul_assoc]
+            simp only [Matrix.mul_assoc]
     _ = ((A i)ᴴ * P) * (P * X * P) * (P * A i) := by
           rw [hCommAdj i, ← hComm i]
     _ = (A i)ᴴ * ((P * P) * X * P) * (P * A i) := by
-          simp [Matrix.mul_assoc]
+          simp only [Matrix.mul_assoc]
     _ = (A i)ᴴ * (P * X * P) * (P * A i) := by
-          simp [Matrix.mul_assoc, hP.2]
+          simp only [Matrix.mul_assoc, hP.2]
     _ = (A i)ᴴ * (P * X * P) * A i := by
           calc
             (A i)ᴴ * (P * X * P) * (P * A i)
                 = (A i)ᴴ * ((P * X * P) * P) * A i := by
-                    simp [Matrix.mul_assoc]
+                    simp only [Matrix.mul_assoc]
             _ = (A i)ᴴ * (P * X * P) * A i := by
-                    simp [Matrix.mul_assoc, hP.2]
+                    simp only [Matrix.mul_assoc, hP.2]
 
 namespace MPSTensor
 
@@ -475,7 +475,8 @@ theorem hLift_cyclicDecomp_mps_of_fixUpgrade
       _ = ((T ^ (l : ℕ)) Q) * (P (k - l) * P (k - l')) *
             ((T ^ (l' : ℕ)) Q) := by simp only [mul_assoc]
       _ = ((T ^ (l : ℕ)) Q) * 0 * ((T ^ (l' : ℕ)) Q) := by rw [hP0]
-      _ = 0 := by simp
+      _ = 0 := by
+            simp only [Matrix.mul_zero, Matrix.zero_mul]
   -- The orbit-sum projection (shared Hermitian/idempotent proof, reused
   -- both as the `hLift` projection conjunct and as the `hP` argument of
   -- `preservesCorner_of_adjoint_fixed_projection`).
@@ -525,8 +526,7 @@ theorem hLift_cyclicDecomp_mps_of_fixUpgrade
         exact absurd (Finset.mem_univ (0 : Fin m)) hmem
     refine ⟨?_, ?_⟩
     · intro hQ0
-      simp only [orbitSumProjection, hQ0]
-      simp
+      simp only [orbitSumProjection, hQ0, map_zero, Finset.sum_const_zero]
     · intro hR0
       have := hRQ
       rw [hR0] at this
@@ -554,7 +554,8 @@ theorem hLift_cyclicDecomp_mps_of_fixUpgrade
           _ = (P k * P (k - l)) * ((T ^ (l : ℕ)) Q) * P k := by
                 rw [← mul_assoc (P k) (P (k - l)) ((T ^ (l : ℕ)) Q)]
           _ = 0 * ((T ^ (l : ℕ)) Q) * P k := by rw [hP0]
-          _ = 0 := by simp
+          _ = 0 := by
+                simp only [Matrix.zero_mul]
       · intro hmem
         exact absurd (Finset.mem_univ (0 : Fin m)) hmem
     refine ⟨?_, ?_⟩

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -343,7 +343,7 @@ theorem fundamentalTheorem_equalMPV_full
   have hProp : ∀ N (σ : Fin N → Fin d),
       mpv (toTensorFromBlocks μA A) σ = (1 : ℂ) * mpv (toTensorFromBlocks μB B) σ := by
     intro N σ
-    simpa using hEqual N σ
+    simpa only [one_mul] using hEqual N σ
   obtain ⟨_hcount, perm, hperm⟩ :=
     fundamentalTheorem_proportionalMPV_CFBNT A B hA hB
       (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)
@@ -378,7 +378,8 @@ theorem fundamentalTheorem_equalMPV_full
         _ = ∑ k : Fin rB, (μB k) ^ N * mpv (B k) σ := by
               simpa only [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μB B σ
         _ = ∑ j : Fin rA, (μB (perm j)) ^ N * mpv (B (perm j)) σ := by
-              simpa using (Equiv.sum_comp perm (fun k : Fin rB => (μB k) ^ N * mpv (B k) σ)).symm
+              exact
+                (Equiv.sum_comp perm (fun k : Fin rB => (μB k) ^ N * mpv (B k) σ)).symm
         _ = ∑ j : Fin rA, (μB (perm j) * ζ j) ^ N * mpv (A j) σ := by
               refine Finset.sum_congr rfl ?_
               intro j _
@@ -434,7 +435,7 @@ theorem fundamentalTheorem_equalMPV_full
                 Acast j i *
                 (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
                   Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ)) := by
-            simp [Bweighted, Acast, hX j i, smul_smul, mul_comm, mul_assoc]
+            simpa only [Bweighted, Acast, hX j i, smul_smul, mul_comm, mul_assoc]
       _ = (μA j) •
             ((X j : Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) *
               Acast j i *
@@ -445,8 +446,8 @@ theorem fundamentalTheorem_equalMPV_full
             Aweighted j i *
             (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
               Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) := by
-            simp [Aweighted, Acast, Algebra.mul_smul_comm, Algebra.smul_mul_assoc,
-              Matrix.mul_assoc]
+            simpa only [Aweighted, Acast, Algebra.mul_smul_comm,
+              Algebra.smul_mul_assoc, Matrix.mul_assoc]
   refine ⟨perm, hdim, ?_⟩
   have hGaugeWeighted :=
     gaugeEquiv_toTensorFromBlocks_of_blockConj (d := d) (μ := fun _ : Fin rA => (1 : ℂ))
@@ -455,12 +456,12 @@ theorem fundamentalTheorem_equalMPV_full
       toTensorFromBlocks μA (fun j => cast (congr_arg (MPSTensor d) (hdim j)) (A j)) =
         toTensorFromBlocks (fun _ : Fin rA => (1 : ℂ)) Aweighted := by
     ext i
-    simp [toTensorFromBlocks, Aweighted, Acast]
+    simpa only [toTensorFromBlocks, Aweighted, Acast, one_smul]
   have hB_tot :
       toTensorFromBlocks (fun j => μB (perm j)) (fun j => B (perm j)) =
         toTensorFromBlocks (fun _ : Fin rA => (1 : ℂ)) Bweighted := by
     ext i
-    simp [toTensorFromBlocks, Bweighted]
+    simpa only [toTensorFromBlocks, Bweighted, one_smul]
   rw [hA_tot, hB_tot]
   exact hGaugeWeighted
 

--- a/TNLean/MPS/FundamentalTheorem/Periodic.lean
+++ b/TNLean/MPS/FundamentalTheorem/Periodic.lean
@@ -264,7 +264,7 @@ theorem fundamentalTheorem_periodic_proportional
   have hfA_bij : Function.Bijective fA :=
     ⟨hfA_inj, Finite.injective_iff_surjective.mp hfA_inj⟩
   exact ⟨Equiv.ofBijective fA hfA_bij, fun j => by
-    simpa [Equiv.ofBijective_apply] using hfA_rep j⟩
+    simpa only [Equiv.ofBijective_apply] using hfA_rep j⟩
 
 /-- **Theorem 3.4 (Periodic FT, proportional case) from `IsPeriodic` data.**
 
@@ -469,7 +469,7 @@ theorem fundamentalTheorem_periodic_equalCase
       (fun _ : Fin 1 => hA.μ j) (fun _ : Fin 1 => hB.μ (perm j))
       (fun _ => hμB_ne (perm j))
       (fun _ => hPow_period)
-      (fun k hk => by simp [hPowEqJ k hk])
+      (fun k hk => by simp only [Fin.sum_univ_one, hPowEqJ k hk])
   refine ⟨Z, hZpow, hZmul, ?_⟩
   -- Convert Finset.univ.val.map to multiset singleton equality.
   simp only [Finset.univ_unique] at hMultiset

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -167,7 +167,7 @@ lemma supportProj_mul (hρ_psd : ρ.PosSemidef) :
     ext i
     simp only [sgn, Pi.mul_apply]
     split
-    · simp
+    · simp only [one_mul]
     · rename_i hi
       push Not at hi
       -- PSD implies eigenvalues are nonnegative, so `¬(0 < λ)` forces `λ = 0`.
@@ -258,7 +258,7 @@ private lemma ker_invariant_under_adjoint
         ∑ j : Fin d,
             RCLike.re (star ((A j)ᴴ *ᵥ x) ⬝ᵥ (ρ *ᵥ ((A j)ᴴ *ᵥ x))) = 0 := by
       rw [← map_sum, ← hsum, hqf]
-      simp
+      exact Complex.zero_re
     have hre :=
         (Finset.sum_eq_zero_iff_of_nonneg (fun j _ => hρ_psd.re_dotProduct_nonneg _)).mp
           h_sum_zero i (Finset.mem_univ _)
@@ -299,7 +299,7 @@ theorem lowerZero_of_posSemidef_fixedPoint
             simp [Matrix.mulVec_mulVec, Matrix.mul_assoc]
       _ = 0 := by
             rw [hv]
-            simp
+            simp only [Matrix.mulVec_zero]
   -- Kernel inclusion: `ker ρ ⊆ ker P` (spectral argument).
   have ker_ρ_sub_ker_P : ∀ v, ρ *ᵥ v = 0 → P *ᵥ v = 0 := by
     intro v hv
@@ -321,7 +321,7 @@ theorem lowerZero_of_posSemidef_fixedPoint
         exact hρv
       have : Uᴴ *ᵥ (U *ᵥ (Λ *ᵥ w)) = 0 := by
         rw [hUΛw]
-        simp
+        simp only [Matrix.mulVec_zero]
       rwa [Matrix.mulVec_mulVec, hUU, Matrix.one_mulVec] at this
     have h_comp : ∀ j, (↑(hH.eigenvalues j) : ℂ) * w j = 0 := fun j => by
       have := congrFun hΛw j
@@ -346,7 +346,7 @@ theorem lowerZero_of_posSemidef_fixedPoint
     have : (U * Matrix.diagonal s * Uᴴ) *ᵥ v = U *ᵥ (Matrix.diagonal s *ᵥ w) := by
       rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec]
     rw [this, hSw]
-    simp
+    simp only [Matrix.mulVec_zero]
   -- Complement-zero (invariance) statement.
   have h_complement_zero : ∀ i : Fin d, (1 - P) * A i * P = 0 := by
     intro i
@@ -450,18 +450,12 @@ theorem supportProj_ne_one_of_not_posDef
     have step1 : Uᴴ * (U * Matrix.diagonal sgn * Uᴴ) * U = Uᴴ * 1 * U := by
       -- Apply the congruence `M ↦ Uᴴ * M * U` to the equality `h`.
       simpa using congrArg (fun M => Uᴴ * M * U) h
-    -- Simplify using unitarity: `Uᴴ * U = 1` and `U * Uᴴ = 1`.
-    have hUU' : U * Uᴴ = 1 := by
-      -- `U` is unitary, so `U * Uᴴ = 1`.
-      simpa [U, Matrix.star_eq_conjTranspose] using
-        (Unitary.mul_star_self_of_mem (hH.eigenvectorUnitary).prop)
     -- Reassociate to expose the unitary cancellations.
     have step2 : (Uᴴ * U) * Matrix.diagonal sgn * (Uᴴ * U) = Uᴴ * U := by
       -- LHS: rewrite `Uᴴ * (U * diag(sgn) * Uᴴ) * U`.
       -- RHS: rewrite `Uᴴ * 1 * U`.
       simpa [Matrix.mul_assoc] using step1
     -- Now cancel `Uᴴ * U = 1`.
-    -- (Note: `hUU'` is not needed, but keeping it local avoids universe inference issues.)
     simpa [hUU] using step2
   -- Extract `sgn i = 1` from the diagonal-entry equality.
   have hSgn_i : sgn i = 1 := by

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -49,7 +49,7 @@ private lemma ofReal_re_eq_self_of_pos {z : ℂ} (hz : 0 < z) :
   have hz_im : z.im = 0 := by
     simpa using h.2.symm
   refine Complex.ext ?_ ?_
-  · simp
+  · rfl
   · simp [hz_im]
 
 private lemma sum_single_diag_const (c : ℂ) :
@@ -67,7 +67,7 @@ private lemma matrixUnits_map (X : Mat) :
           refine Finset.sum_congr rfl ?_
           rintro ⟨j, i⟩ _
           rw [Matrix.conjTranspose_single, star_one, Matrix.single_mul_mul_single]
-          simp
+          simp only [one_mul, mul_one]
     _ = ∑ j : Fin D, ∑ i : Fin D, Matrix.single j j (X i i) := by
           rw [Fintype.sum_prod_type]
     _ = ∑ j : Fin D, Matrix.single j j (∑ i : Fin D, X i i) := by
@@ -147,7 +147,7 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
     ext i j
     by_cases hij : i = j
     · subst hij
-      simp
+      rw [Matrix.diagonal_apply, if_pos rfl]
     · simpa [hij] using hρ_diag hij
   have hρdiag_pos : ∀ k : Fin D, 0 < ρ k k := by
     have hdiag_pd : (Matrix.diagonal (fun k => ρ k k) : Mat).PosDef := by
@@ -294,7 +294,7 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
       _ = L * (((Matrix.trace Y) / (D : ℂ)) • (1 : Mat)) * L := by
             rw [hE_map Y]
       _ = (Matrix.trace Y / (D : ℂ)) • (L * L) := by
-            simp
+            rw [Matrix.mul_smul, Matrix.mul_one, smul_mul_assoc]
       _ = (Matrix.trace Y / (D : ℂ)) • ((((D : ℂ) / Matrix.trace ρ)) • ρ) := by
             rw [hL_sq]
       _ = (Matrix.trace Y / Matrix.trace ρ) • ρ := by
@@ -308,7 +308,7 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
   have hRangeCard : D * D ≤ (Set.range B).toFinset.card := by
     have hspan_finrank : Module.finrank ℂ ↥(Submodule.span ℂ (Set.range B)) = D * D := by
       rw [hB_inj, finrank_top, Module.finrank_matrix]
-      simp
+      simp [Fintype.card_fin]
     have hspan_le :
         Module.finrank ℂ ↥(Submodule.span ℂ (Set.range B)) ≤
           (Set.range B).toFinset.card :=
@@ -316,8 +316,7 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
     exact hspan_finrank.symm.le.trans hspan_le
   have hrange_card_le : (Set.range B).toFinset.card ≤ d := by
     have hs : Finset.univ.image B = (Set.range B).toFinset := by
-      ext M
-      simp
+      exact (Set.toFinset_range (f := B)).symm
     rw [← hs]
     simpa using (Finset.card_image_le (s := Finset.univ) (f := B))
   have hCard : Fintype.card (Fin D × Fin D) ≤ Fintype.card (Fin d) := by
@@ -367,9 +366,10 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
               refine Finset.sum_congr rfl ?_
               intro q _
               rw [hV_entry]
-              simp
+              by_cases hpq : p = q <;> simp [hpq]
       _ = ∑ p : Fin D × Fin D, (E p)ᴴ * E p := by
-              simp
+              simp only [ite_smul, one_smul, zero_smul, Finset.sum_ite_eq,
+                Finset.mem_univ, ↓reduceIte]
       _ = 1 := hE_left
   have hB_fact : ∀ i : Fin d, B i = L * U i := by
     intro i

--- a/TNLean/MPS/Symmetry/StringOrderDefs.lean
+++ b/TNLean/MPS/Symmetry/StringOrderDefs.lean
@@ -97,11 +97,11 @@ lemma transferMap_twistedMixedCompanion_eq (A : MPSTensor d D)
     (hu : u * uᴴ = 1)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     transferMap (twistedMixedCompanion A u) X = transferMap A X := by
-  simpa [transferMap_apply] using
+  simpa only [transferMap_apply] using
     kraus_same_map_of_unitary_combination (twistedMixedCompanion A u) A uᴴ
-      (by simpa using hu)
+      (by simpa only [Matrix.conjTranspose_conjTranspose] using hu)
       (fun j => by
-        simp [twistedMixedCompanion, Matrix.conjTranspose_apply])
+        simp only [twistedMixedCompanion, Matrix.conjTranspose_apply, starRingEnd_apply])
       X
 
 /-! ### Iterated twisted transfer map -/
@@ -150,7 +150,8 @@ private lemma stringOrderParam_eq_trace_mixedTransfer (A : MPSTensor d D)
     stringOrderParam A u Λ L =
       Matrix.trace
         (Λ * (((mixedTransferMap A (twistedMixedCompanion A u)) ^ L) 1)) := by
-  simp [stringOrderParam, twistedTransferIter, twistedTransferMap_eq_mixedTransfer]
+  simp only [stringOrderParam, twistedTransferIter,
+    twistedTransferMap_eq_mixedTransfer]
 
 /-- For a unital transfer map and trace-one boundary state, the untwisted string
 order parameter is constantly `1`. -/
@@ -164,12 +165,12 @@ private lemma stringOrderParam_one_eq_one
       ((transferMap A) ^ L) (1 : Matrix (Fin D) (Fin D) ℂ) = 1 := by
     induction L with
     | zero =>
-        simp
+        rfl
     | succ n ih =>
         calc
           ((transferMap A) ^ (n + 1)) (1 : Matrix (Fin D) (Fin D) ℂ)
               = transferMap A (((transferMap A) ^ n) 1) := by
-                  simp [pow_succ']
+                  simp only [pow_succ', Module.End.mul_apply]
           _ = transferMap A 1 := by rw [ih]
           _ = 1 := hNorm
   have htwisted_pow_one :
@@ -177,8 +178,9 @@ private lemma stringOrderParam_one_eq_one
     have htwisted_eq : twistedTransferMap A 1 = transferMap A := by
       ext X i j
       exact congrArg (fun M => M i j) (twistedTransferMap_one (A := A) X)
-    simpa [htwisted_eq] using hpow_one
-  simp [stringOrderParam, twistedTransferIter, htwisted_pow_one, hΛtr]
+    simpa only [htwisted_eq] using hpow_one
+  simp only [stringOrderParam, twistedTransferIter, htwisted_pow_one, hΛtr,
+    Matrix.mul_one]
 
 /-! ### Boundary string order and local symmetry -/
 
@@ -201,7 +203,7 @@ private lemma stringOrderBoundaryParam_one_one (A : MPSTensor d D)
     (u : Matrix (Fin d) (Fin d) ℂ)
     (Λ : Matrix (Fin D) (Fin D) ℂ) (L : ℕ) :
     stringOrderBoundaryParam A u Λ 1 1 L = stringOrderParam A u Λ L := by
-  simp [stringOrderBoundaryParam, stringOrderParam]
+  simp only [stringOrderBoundaryParam, stringOrderParam, Matrix.mul_one]
 
 /-- If the continuous linear operator underlying the twisted transfer map has
 spectral radius `< 1`, then every virtual-boundary string-order sequence tends
@@ -221,15 +223,14 @@ lemma stringOrderBoundaryParam_tendsto_zero_of_spectralRadius_lt_one
     (Module.End.toContinuousLinearMap V) (twistedTransferMap A u)
   haveI : FiniteDimensional ℂ (V →L[ℂ] V) :=
     (Module.End.toContinuousLinearMap V).toLinearEquiv.finiteDimensional
-  have hpow : Filter.Tendsto (fun L => F' ^ L) Filter.atTop (nhds 0) :=
-    by
-      let hFinite : FiniteDimensional ℂ (V →L[ℂ] V) :=
-        (Module.End.toContinuousLinearMap V).toLinearEquiv.finiteDimensional
-      letI : FiniteDimensional ℂ (V →L[ℂ] V) := hFinite
-      let hComplete : CompleteSpace (V →L[ℂ] V) := FiniteDimensional.complete ℂ (V →L[ℂ] V)
-      exact @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
-        inferInstance hComplete inferInstance F' <| by
-          simpa [F'] using hsr
+  have hpow : Filter.Tendsto (fun L => F' ^ L) Filter.atTop (nhds 0) := by
+    let hFinite : FiniteDimensional ℂ (V →L[ℂ] V) :=
+      (Module.End.toContinuousLinearMap V).toLinearEquiv.finiteDimensional
+    letI : FiniteDimensional ℂ (V →L[ℂ] V) := hFinite
+    let hComplete : CompleteSpace (V →L[ℂ] V) := FiniteDimensional.complete ℂ (V →L[ℂ] V)
+    exact @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
+      inferInstance hComplete inferInstance F' <| by
+        simpa only [F'] using hsr
   have hEval := (ContinuousLinearMap.apply ℂ V Y).continuous.tendsto (0 : V →L[ℂ] V)
   rw [map_zero] at hEval
   have hIter0 :
@@ -250,10 +251,10 @@ lemma stringOrderBoundaryParam_tendsto_zero_of_spectralRadius_lt_one
   have hφ_cont : Continuous φ := LinearMap.continuous_of_finiteDimensional φ
   have hφ0 :
       Filter.Tendsto (fun L => φ (((twistedTransferMap A u) ^ L) Y))
-        Filter.atTop (nhds 0) := by
-    rw [show (0 : ℂ) = φ 0 by simp]
-    exact hφ_cont.continuousAt.tendsto.comp hIter0
-  simpa [stringOrderBoundaryParam, twistedTransferIter, φ, Matrix.mul_assoc] using hφ0
+        Filter.atTop (nhds (φ 0)) :=
+    hφ_cont.continuousAt.tendsto.comp hIter0
+  simpa only [map_zero, stringOrderBoundaryParam, twistedTransferIter, φ,
+    Matrix.mul_assoc] using hφ0
 
 /-- Local symmetry in the virtual FCS language of the paper: there is a unitary
 virtual intertwiner satisfying the phased covariance relation and preserving the
@@ -292,7 +293,7 @@ lemma not_tendsto_zero_of_hasStringOrder
   intro hzero
   have hsmall :
       ∀ᶠ L in Filter.atTop, ‖stringOrderBoundaryParam A u Λ X Y L‖ < c :=
-    hzero.norm.eventually (Iio_mem_nhds (by simpa using hc))
+    hzero.norm.eventually (Iio_mem_nhds (by simpa only [norm_zero] using hc))
   rcases Filter.eventually_atTop.1 hsmall with ⟨L₀, hL₀⟩
   have hge := hbound L₀
   exact not_lt_of_ge hge (hL₀ L₀ le_rfl)
@@ -408,8 +409,9 @@ theorem condC1_imp_condC2
     simp_rw [hc]
   simp_rw [step1]
   -- Step 2: Use C1: V * A_i * V† = ∑_j u_{ij} • A_j
-  simp_rw [show ∀ i, V * A i * Vᴴ = ∑ j : Fin d, u i j • A j
-    from fun i => (hC1 i).symm]
+  have hC1' : ∀ i, V * A i * Vᴴ = ∑ j : Fin d, u i j • A j :=
+    fun i => (hC1 i).symm
+  simp_rw [hC1']
   -- Step 3: Apply unitary Kraus mixing
   exact unitary_kraus_mixing A u hu (V * X * Vᴴ)
 
@@ -440,18 +442,19 @@ theorem condC2_imp_condC1_of_injective
             have hVV : V * (Vᴴ * X * V) * Vᴴ = X := by
               calc
                 V * (Vᴴ * X * V) * Vᴴ = (V * Vᴴ) * X * (V * Vᴴ) := by
-                  simp [Matrix.mul_assoc]
-                _ = X := by simp [hV]
+                  simp only [Matrix.mul_assoc]
+                _ = X := by
+                  simp only [hV, Matrix.one_mul, Matrix.mul_one]
             have hC2' : transferMap A X =
                 V * transferMap A (Vᴴ * X * V) * Vᴴ := by
-              simpa [hVV] using hC2 (Vᴴ * X * V)
+              simpa only [hVV] using hC2 (Vᴴ * X * V)
             exact hC2'.symm
   rcases kraus_rectangular_freedom B A
-      (fun X => by simpa [transferMap_apply] using hB_eq X)
+      (fun X => by simpa only [transferMap_apply] using hB_eq X)
       (Nat.le_refl d) with ⟨u, hu, huK⟩
   refine ⟨u, mul_eq_one_comm.mp hu, ?_⟩
   intro i
-  simpa [B] using (huK i).symm
+  simpa only [B] using (huK i).symm
 
 end ConditionEquivalences
 

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -127,7 +127,7 @@ theorem ker_all_of_inj {D₁ D₂ : ℕ}
       obtain ⟨k, rfl⟩ := hy
       exact h k v hv
   | zero =>
-      simp
+      simp only [Matrix.conjTranspose_zero, Matrix.zero_mulVec, Matrix.mulVec_zero]
   | add a b _ _ ha hb =>
       rw [Matrix.conjTranspose_add, Matrix.add_mulVec, Matrix.mulVec_add, ha, hb, add_zero]
   | smul c a _ ha =>
@@ -152,9 +152,9 @@ theorem injective_of_ker_all [NeZero D₂]
       simp only [Matrix.mulVec, Matrix.vecMulVec, Matrix.of_apply, dotProduct]
       conv_lhs => arg 2; ext j; rw [mul_assoc]
       rw [Finset.sum_eq_single k]
-      · simp [c, hk]
+      · simp only [c, if_true, inv_mul_cancel₀ hk, mul_one]
       · intro j _ hjk
-        simp [c, hjk]
+        simp only [c, if_neg hjk, zero_mul, mul_zero]
       · intro hk_abs
         exact absurd (Finset.mem_univ k) hk_abs
     rw [← hMv]
@@ -165,9 +165,9 @@ theorem injective_of_ker_all [NeZero D₂]
     have : (X *ᵥ (fun k => if k = j then 1 else 0)) i = X i j := by
       simp only [Matrix.mulVec, dotProduct]
       rw [Finset.sum_eq_single j]
-      · simp
+      · simp only [if_true, mul_one]
       · intro b _ hbj
-        simp [hbj]
+        simp only [if_neg hbj, mul_zero]
       · intro hj
         exact absurd (Finset.mem_univ j) hj
     rw [show (0 : Matrix (Fin D₁) (Fin D₂) ℂ) i j = 0 from rfl]
@@ -205,9 +205,13 @@ theorem isInjective_conjugate {D : ℕ}
       ext Y
       constructor
       · rintro ⟨X0, ⟨i, rfl⟩, rfl⟩
-        exact ⟨i, by simp [φ, gaugeTensor, Matrix.mul_assoc]⟩
+        refine ⟨i, ?_⟩
+        simp only [φ, gaugeTensor, LinearMap.comp_apply, LinearMap.mulRight_apply,
+          LinearMap.mulLeft_apply, Matrix.mul_assoc]
       · rintro ⟨i, rfl⟩
-        refine ⟨T i, ⟨i, rfl⟩, by simp [φ, gaugeTensor, Matrix.mul_assoc]⟩
+        refine ⟨T i, ⟨i, rfl⟩, ?_⟩
+        simp only [φ, gaugeTensor, LinearMap.comp_apply, LinearMap.mulRight_apply,
+          LinearMap.mulLeft_apply, Matrix.mul_assoc]
     calc
       Submodule.span ℂ (Set.range (gaugeTensor S T))
           = Submodule.map φ (Submodule.span ℂ (Set.range T)) := by
@@ -227,13 +231,13 @@ lemma smul_mul_conjTranspose_of_norm_eq_one {m n : ℕ}
     (μ • N) * (μ • N)ᴴ = N * Nᴴ := by
   have hμ_star_mul : star μ * μ = 1 := by
     rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
-    simp [Complex.normSq_eq_norm_sq, hμ]
-  have hμ_starRing_mul : ((starRingEnd ℂ) μ) * μ = 1 := by
-    simpa [Complex.star_def] using hμ_star_mul
+    simp only [Complex.normSq_eq_norm_sq, hμ, one_pow, Complex.ofReal_one]
   calc
-    (μ • N) * (μ • N)ᴴ = (((starRingEnd ℂ) μ) * μ) • (N * Nᴴ) := by
-      simp [Matrix.conjTranspose_smul, smul_smul, mul_comm]
-    _ = N * Nᴴ := by simp [hμ_starRing_mul]
+    (μ • N) * (μ • N)ᴴ = (star μ * μ) • (N * Nᴴ) := by
+      simp only [Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+    _ = N * Nᴴ := by
+      rw [hμ_star_mul]
+      simp only [one_smul]
 
 /-- Shared block-KS core: transporting a modulus-one mixed-transfer eigenvector to canonical
 gauges produces Kraus-level intertwining relations for the gauged tensors. -/
@@ -293,13 +297,14 @@ theorem gauged_intertwining_core
           A' i * X' * (B' i)ᴴ = SA⁻¹ * (A i * X * (B i)ᴴ) * (SBᴴ)⁻¹ := by
       intro i
       have hBstar : (B' i)ᴴ = SBᴴ * (B i)ᴴ * (SBᴴ)⁻¹ := by
-        simp [B', Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
+        change (SB⁻¹ * B i * SB)ᴴ = SBᴴ * (B i)ᴴ * (SBᴴ)⁻¹
+        simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
           Matrix.mul_assoc]
       calc
         A' i * X' * (B' i)ᴴ
             = (SA⁻¹ * A i * SA) * (SA⁻¹ * X * (SBᴴ)⁻¹) *
                 (SBᴴ * (B i)ᴴ * (SBᴴ)⁻¹) := by
-                simp [A', X', hBstar]
+                simp only [A', gaugeTensor, X', gaugeEigenvector, hBstar]
         _ = SA⁻¹ * (A i * X * (B i)ᴴ) * (SBᴴ)⁻¹ := by
             simp only [Matrix.mul_assoc]
             rw [Matrix.mul_nonsing_inv_cancel_left _ _ hSA_u,
@@ -311,12 +316,12 @@ theorem gauged_intertwining_core
       (f := fun i : Fin d => A i * X * (B i)ᴴ) (M := SA⁻¹)]
     rw [hFXsum]
     have h1 : SA⁻¹ * (μ • X) = μ • (SA⁻¹ * X) := by
-      simp [Matrix.mul_smul]
+      simp only [Matrix.mul_smul]
     rw [h1]
     have h2 : (μ • (SA⁻¹ * X)) * (SBᴴ)⁻¹ = μ • ((SA⁻¹ * X) * (SBᴴ)⁻¹) := by
-      simp [Matrix.smul_mul]
+      simp only [Matrix.smul_mul]
     rw [h2]
-    simp [X']
+    simp only [X', gaugeEigenvector]
   let K : Fin d → Matrix (Fin D₁ ⊕ Fin D₂) (Fin D₁ ⊕ Fin D₂) ℂ :=
     fun i => Matrix.fromBlocks (A' i) 0 0 (B' i)
   let M : Matrix (Fin D₁ ⊕ Fin D₂) (Fin D₁ ⊕ Fin D₂) ℂ :=
@@ -339,7 +344,11 @@ theorem gauged_intertwining_core
           Matrix.fromBlocks_conjTranspose]
     rw [hmap, hFX']
     change Matrix.fromBlocks 0 (μ • X') 0 0 = μ • Matrix.fromBlocks 0 X' 0 0
-    simp [Matrix.fromBlocks_smul]
+    simpa [zero_smul] using
+      (Matrix.fromBlocks_smul μ
+        (0 : Matrix (Fin D₁) (Fin D₁) ℂ) X'
+        (0 : Matrix (Fin D₂) (Fin D₁) ℂ)
+        (0 : Matrix (Fin D₂) (Fin D₂) ℂ)).symm
   let rhoT : Matrix (Fin D₁ ⊕ Fin D₂) (Fin D₁ ⊕ Fin D₂) ℂ :=
     Matrix.fromBlocks (SAᴴ * SA) 0 0 (SBᴴ * SB)
   have hrhoT_pd : rhoT.PosDef := by
@@ -365,7 +374,11 @@ theorem gauged_intertwining_core
         calc
           (A' i)ᴴ * (SAᴴ * SA) * (A' i)
               = (SAᴴ * (A i)ᴴ * (SAᴴ)⁻¹) * (SAᴴ * SA) * (SA⁻¹ * A i * SA) := by
-                  simp [A', Matrix.conjTranspose_nonsing_inv, Matrix.mul_assoc]
+                  change
+                    (SA⁻¹ * A i * SA)ᴴ * (SAᴴ * SA) * (SA⁻¹ * A i * SA) =
+                      (SAᴴ * (A i)ᴴ * (SAᴴ)⁻¹) * (SAᴴ * SA) * (SA⁻¹ * A i * SA)
+                  simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
+                    Matrix.mul_assoc]
           _ = SAᴴ * ((A i)ᴴ * A i) * SA := by
               simp only [Matrix.mul_assoc]
               rw [Matrix.nonsing_inv_mul_cancel_left _ _ hSAh_u,
@@ -379,7 +392,11 @@ theorem gauged_intertwining_core
         calc
           (B' i)ᴴ * (SBᴴ * SB) * (B' i)
               = (SBᴴ * (B i)ᴴ * (SBᴴ)⁻¹) * (SBᴴ * SB) * (SB⁻¹ * B i * SB) := by
-                  simp [B', Matrix.conjTranspose_nonsing_inv, Matrix.mul_assoc]
+                  change
+                    (SB⁻¹ * B i * SB)ᴴ * (SBᴴ * SB) * (SB⁻¹ * B i * SB) =
+                      (SBᴴ * (B i)ᴴ * (SBᴴ)⁻¹) * (SBᴴ * SB) * (SB⁻¹ * B i * SB)
+                  simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
+                    Matrix.mul_assoc]
           _ = SBᴴ * ((B i)ᴴ * B i) * SB := by
               simp only [Matrix.mul_assoc]
               rw [Matrix.nonsing_inv_mul_cancel_left _ _ hSBh_u,
@@ -416,7 +433,7 @@ theorem gauged_intertwining_core
         simpa using (Kraus.map_conjTranspose (K := K) M).symm
       _ = (μ • M)ᴴ := by rw [hEigM]
       _ = (starRingEnd ℂ μ) • Mᴴ := by
-        simp [Matrix.conjTranspose_smul]
+        simp only [Matrix.conjTranspose_smul, starRingEnd_apply]
   have hKS_Ms : Kraus.map K (Mᴴᴴ * Mᴴ) = (Kraus.map K Mᴴ)ᴴ * Kraus.map K Mᴴ :=
     Kraus.ks_equality_of_peripheral_eigenvector_of_fixedPoint
       K hK_unital hrhoT_pd hrhoT_fix Mᴴ (starRingEnd ℂ μ) hEigMstar hμ_conj
@@ -467,23 +484,23 @@ theorem self_mul_conjTranspose_fixed_of_intertwining
       simpa [smul_mul_assoc] using hInter i
     calc
       A i * (X * Xᴴ) * (A i)ᴴ = (A i * X) * (A i * X)ᴴ := by
-        simp [Matrix.mul_assoc, Matrix.conjTranspose_mul]
+        simp only [Matrix.mul_assoc, Matrix.conjTranspose_mul]
       _ = (μ • (X * B i)) * (μ • (X * B i))ᴴ := by
-        simp [hAX]
+        simp only [hAX]
       _ = (X * B i) * (X * B i)ᴴ := by
         simpa using smul_mul_conjTranspose_of_norm_eq_one μ hμ (X * B i)
       _ = X * (B i * (B i)ᴴ) * Xᴴ := by
-        simp [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+        simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
   calc
     transferMap A (X * Xᴴ) = ∑ i : Fin d, A i * (X * Xᴴ) * (A i)ᴴ := by
-      simp [transferMap_apply]
+      simp only [transferMap_apply]
     _ = ∑ i : Fin d, X * (B i * (B i)ᴴ) * Xᴴ := by
-      simp [hterm]
+      simp only [hterm]
     _ = X * (∑ i : Fin d, B i * (B i)ᴴ) * Xᴴ := by
       simpa using
         (Matrix.sum_mul_mul (L := X) (R := Xᴴ) (M := fun i : Fin d => B i * (B i)ᴴ))
     _ = X * Xᴴ := by
-      simp [hB_unital]
+      simp only [hB_unital, Matrix.mul_one]
 
 /-- Transport a fixed point of the gauged transfer map back to the original tensor. -/
 theorem ungauge_transfer_fixedPoint
@@ -503,29 +520,29 @@ theorem ungauge_transfer_fixedPoint
       (Matrix.mul_nonsing_inv_cancel_left (A := S) (B := A i * S) hS).symm
   have hShAiH : ∀ i : Fin d, Sᴴ * (A i)ᴴ = (A' i)ᴴ * Sᴴ := by
     intro i
-    simp [A', Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
-      Matrix.mul_assoc, hSh_inv_mul]
+    simpa only [Matrix.conjTranspose_mul] using
+      congrArg Matrix.conjTranspose (hAiS i)
   have hterm :
       ∀ i : Fin d,
         A i * (S * σ * Sᴴ) * (A i)ᴴ = S * (A' i * σ * (A' i)ᴴ) * Sᴴ := by
     intro i
     calc
       A i * (S * σ * Sᴴ) * (A i)ᴴ = (A i * S) * σ * (Sᴴ * (A i)ᴴ) := by
-        simp [Matrix.mul_assoc]
+        simp only [Matrix.mul_assoc]
       _ = (S * A' i) * σ * ((A' i)ᴴ * Sᴴ) := by
         rw [hAiS i, hShAiH i]
       _ = S * (A' i * σ * (A' i)ᴴ) * Sᴴ := by
-        simp [Matrix.mul_assoc]
+        simp only [Matrix.mul_assoc]
   calc
     transferMap A (S * σ * Sᴴ) = ∑ i : Fin d, A i * (S * σ * Sᴴ) * (A i)ᴴ := by
-      simp [transferMap_apply]
+      simp only [transferMap_apply]
     _ = ∑ i : Fin d, S * (A' i * σ * (A' i)ᴴ) * Sᴴ := by
-      simp [hterm]
+      simp only [hterm]
     _ = S * (∑ i : Fin d, A' i * σ * (A' i)ᴴ) * Sᴴ := by
       simpa using
         (Matrix.sum_mul_mul (L := S) (R := Sᴴ) (M := fun i : Fin d => A' i * σ * (A' i)ᴴ))
     _ = S * transferMap A' σ * Sᴴ := by
-      simp [A', transferMap_apply]
+      simp only [A', transferMap_apply]
     _ = S * σ * Sᴴ := by rw [hσ]
 
 /-- Cancel an invertible gauge from a scalar identity `S * σ * Sᴴ = c • (S * Sᴴ)`. -/
@@ -543,15 +560,17 @@ theorem ungauge_scalar_of_conjugated_scalar
     Matrix.mul_nonsing_inv Sᴴ hSh_u
   have hcancel := congrArg (fun T => S⁻¹ * T * (Sᴴ)⁻¹) hσ
   calc
-    σ = (S⁻¹ * S) * σ := by simp [hS_inv_mul]
-    _ = S⁻¹ * (S * σ) := by simp [Matrix.mul_assoc]
+    σ = (S⁻¹ * S) * σ := by
+      simp only [hS_inv_mul, one_mul]
+    _ = S⁻¹ * (S * σ) := by
+      simp only [Matrix.mul_assoc]
     _ = S⁻¹ * (S * σ * Sᴴ) * (Sᴴ)⁻¹ := by
-      simp [Matrix.mul_assoc, hSh_mul_inv]
+      simp only [Matrix.mul_assoc, hSh_mul_inv, mul_one]
     _ = S⁻¹ * (c • (S * Sᴴ)) * (Sᴴ)⁻¹ := hcancel
     _ = c • (S⁻¹ * (S * Sᴴ) * (Sᴴ)⁻¹) := by
-      simp [Matrix.mul_assoc]
+      simp only [Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_assoc]
     _ = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
-      simp [Matrix.mul_assoc, hS_inv_mul, hSh_mul_inv]
+      simp only [Matrix.mul_assoc, hS_inv_mul, hSh_mul_inv, mul_one]
 
 /-- A scalar identity `X * Xᴴ = c I` with `c ≠ 0` yields invertibility of `X`. -/
 theorem isUnit_det_of_self_mul_conjTranspose_scalar [NeZero D]
@@ -562,11 +581,11 @@ theorem isUnit_det_of_self_mul_conjTranspose_scalar [NeZero D]
   have hX_right_inv : X * (c⁻¹ • Xᴴ) = 1 := by
     calc
       X * (c⁻¹ • Xᴴ) = c⁻¹ • (X * Xᴴ) := by
-        simp
+        simp only [Matrix.mul_smul]
       _ = c⁻¹ • (c • (1 : Matrix (Fin D) (Fin D) ℂ)) := by
         rw [hXXh]
       _ = 1 := by
-        simp [hc]
+        simp only [smul_smul, inv_mul_cancel₀ hc, one_smul]
   exact Matrix.isUnit_det_of_right_inverse hX_right_inv
 
 /-- Generic square endgame: once the gauged intertwiner is invertible, it upgrades to
@@ -585,25 +604,26 @@ theorem gaugePhaseEquiv_of_gauged_intertwining [NeZero D]
   have hSB_u : IsUnit SB.det := Ne.isUnit hSB_det
   have hμ_ne0 : μ ≠ 0 := by
     intro h0
-    have : (‖μ‖ : ℝ) = 0 := by simp [h0]
+    have : (‖μ‖ : ℝ) = 0 := by
+      simp only [h0, norm_zero]
     linarith [hμ, this]
   have hper : ∀ i : Fin d, B' i = μ⁻¹ • (X'⁻¹ * A' i * X') := by
     intro i
     have hAX : A' i * X' = μ • X' * B' i := by
       simpa [A', B', gaugeTensor] using hInter i
     have : X'⁻¹ * (A' i * X') = X'⁻¹ * (μ • X' * B' i) := by
-      simp [hAX]
+      rw [hAX]
     have : X'⁻¹ * A' i * X' = μ • B' i := by
       rw [← Matrix.mul_assoc] at this
       rw [this, smul_mul_assoc, mul_smul_comm,
         Matrix.nonsing_inv_mul_cancel_left _ _ hX'_u]
     have hμinv : μ⁻¹ * μ = (1 : ℂ) := by
-      simp [hμ_ne0]
+      exact inv_mul_cancel₀ hμ_ne0
     calc
       B' i = μ⁻¹ • (μ • B' i) := by
-        simp [smul_smul, hμinv]
+        simp only [smul_smul, hμinv, one_smul]
       _ = μ⁻¹ • (X'⁻¹ * A' i * X') := by
-        simp [this]
+        rw [this]
   let Ymat : Matrix (Fin D) (Fin D) ℂ := SB * X'⁻¹ * SA⁻¹
   let Yinv : Matrix (Fin D) (Fin D) ℂ := SA * X' * SB⁻¹
   have hYmul : Ymat * Yinv = 1 := by
@@ -661,7 +681,7 @@ theorem dim_eq_of_gauged_intertwining [NeZero D₁] [NeZero D₂]
   have hker_X : ∀ k : Fin d, ∀ v, X *ᵥ v = 0 → X *ᵥ ((B k)ᴴ *ᵥ v) = 0 := by
     intro k v hv
     have : X *ᵥ ((B k)ᴴ *ᵥ v) = (X * (B k)ᴴ) *ᵥ v := by
-      simp [Matrix.mulVec_mulVec]
+      simp only [Matrix.mulVec_mulVec]
     rw [this, hInter1 k, Matrix.smul_mulVec, ← Matrix.mulVec_mulVec,
       hv, Matrix.mulVec_zero, smul_zero]
   have h_D₂_le : D₂ ≤ D₁ :=
@@ -680,7 +700,7 @@ theorem dim_eq_of_gauged_intertwining [NeZero D₁] [NeZero D₂]
   have hker_Xh : ∀ k : Fin d, ∀ v, Xᴴ *ᵥ v = 0 → Xᴴ *ᵥ ((A k)ᴴ *ᵥ v) = 0 := by
     intro k v hv
     have : Xᴴ *ᵥ ((A k)ᴴ *ᵥ v) = (Xᴴ * (A k)ᴴ) *ᵥ v := by
-      simp [Matrix.mulVec_mulVec]
+      simp only [Matrix.mulVec_mulVec]
     rw [this, hInter2h k, Matrix.smul_mulVec, ← Matrix.mulVec_mulVec,
       hv, Matrix.mulVec_zero, smul_zero]
   have h_D₁_le : D₁ ≤ D₂ :=

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -255,7 +255,8 @@ theorem exponential_convergence_of_primitive [NeZero D]
       (A := A) hNorm hPrim ρ hρ_pd.posSemidef
       (by
         intro hρ0
-        have htr0 : Matrix.trace ρ = 0 := by simp [hρ0]
+        have htr0 : Matrix.trace ρ = 0 := by
+          simp [hρ0]
         exact (ne_of_gt hρ_pd.trace_pos) htr0)
       hρ_fix huniq_fp
   rcases geometric_apply_bound_of_spectralRadius_lt_one (T := Φ N) hgap with
@@ -298,7 +299,7 @@ theorem exponential_convergence_of_primitive [NeZero D]
       _ = ‖(P + N ^ n) X - P X‖ := by rw [hpowEq]
       _ = ‖(N ^ n) X‖ := by
         change ‖P X + (N ^ n) X - P X‖ = ‖(N ^ n) X‖
-        simp
+        simp only [add_sub_cancel_left]
       _ ≤ C₀ * r ^ n * ‖X‖ := hgeomN n
       _ ≤ C * r ^ n * ‖X‖ := by
         gcongr
@@ -372,7 +373,7 @@ theorem correlation_length_bound [NeZero D]
   have hPX : P X = 0 := by
     change (Matrix.trace X / Matrix.trace ρ) • ρ = 0
     rw [htrX]
-    simp
+    simp only [zero_div, zero_smul]
   by_cases hn : n = 0
   · subst hn
     have hC_ge_one : 1 ≤ C := by

--- a/TNLean/Wielandt/RankOne/BoundedWord.lean
+++ b/TNLean/Wielandt/RankOne/BoundedWord.lean
@@ -49,7 +49,7 @@ lemma biRectSpan_eq_map_comp
       Submodule.map ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q))
         (wordSpan B n) := by
   -- `Submodule.map_comp` is stated for semilinear maps; specialize to linear maps.
-  simpa [biRectSpan, LinearMap.comp_apply] using
+  simpa only [biRectSpan, LinearMap.comp_apply] using
     (Submodule.map_comp (f := (LinearMap.mulRight ℂ Q)) (g := (LinearMap.mulLeft ℂ P))
       (p := wordSpan B n)).symm
 
@@ -72,13 +72,13 @@ private theorem mem_biRectSpan_iff
     rcases Submodule.mem_map.mp hM with ⟨X, hX, rfl⟩
     rcases Submodule.mem_map.mp hX with ⟨Y, hY, rfl⟩
     refine ⟨Y, hY, ?_⟩
-    simp [LinearMap.mulLeft_apply, LinearMap.mulRight_apply, Matrix.mul_assoc]
+    simp only [LinearMap.mulLeft_apply, LinearMap.mulRight_apply, Matrix.mul_assoc]
   · rintro ⟨X, hX, hM⟩
     rw [← hM]
     refine Submodule.mem_map.mpr ?_
     refine ⟨X * Q, ?_, ?_⟩
-    · exact Submodule.mem_map.mpr ⟨X, hX, by simp [LinearMap.mulRight_apply]⟩
-    · simp [LinearMap.mulLeft_apply, Matrix.mul_assoc]
+    · exact Submodule.mem_map.mpr ⟨X, hX, by simp only [LinearMap.mulRight_apply]⟩
+    · simp only [LinearMap.mulLeft_apply, Matrix.mul_assoc]
 
 /-- `biRectSpan` always lives in the range of the two-sided multiplication map. -/
 theorem biRectSpan_le_range
@@ -88,7 +88,7 @@ theorem biRectSpan_le_range
   intro M hM
   rcases (mem_biRectSpan_iff (d := d) (D := D) P Q B).mp hM with ⟨X, _, hX⟩
   exact ⟨X, by
-    simpa [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
+    simpa only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
       Matrix.mul_assoc] using hX⟩
 
 /-- Converting a bi-rectangular span element back into a bounded word span,
@@ -106,7 +106,7 @@ theorem biRectSpan_le_wordSpan
   have hPYQ : (P * Y) * Q ∈ wordSpan B ((m₁ + n) + m₂) := by
     exact (wordSpan_mul_le B (m₁ + n) m₂) (Submodule.mul_mem_mul hPY hQ)
   rw [← hM]
-  simpa [Matrix.mul_assoc, Nat.add_assoc] using hPYQ
+  simpa only [Matrix.mul_assoc, Nat.add_assoc] using hPYQ
 
 /-- Two-sided cumulative bi-rectangular span: image of `cumulativeSpan B n` under
 right-multiplication by `Q` followed by left-multiplication by `P`. -/
@@ -122,7 +122,7 @@ lemma cumulativeBiRectSpan_eq_map_comp
     cumulativeBiRectSpan (d := d) (D := D) P Q B n =
       Submodule.map ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q))
         (cumulativeSpan B n) := by
-  simpa [cumulativeBiRectSpan, LinearMap.comp_apply] using
+  simpa only [cumulativeBiRectSpan, LinearMap.comp_apply] using
     (Submodule.map_comp (f := (LinearMap.mulRight ℂ Q)) (g := (LinearMap.mulLeft ℂ P))
       (p := cumulativeSpan B n)).symm
 
@@ -172,7 +172,7 @@ theorem mul_mem_cumulativeSpan_of_mem_wordSpan_left
     have hprod : P * evalWord B w ∈ wordSpan B (m + w.length) := by
       exact (wordSpan_mul_le B m w.length) (Submodule.mul_mem_mul hP hw')
     exact (wordSpan_le_cumulativeSpan B (by omega)) hprod
-  exact hmap (Submodule.mem_map.mpr ⟨X, hX, by simp [LinearMap.mulLeft_apply]⟩)
+  exact hmap (Submodule.mem_map.mpr ⟨X, hX, by simp only [LinearMap.mulLeft_apply]⟩)
 
 /-- Right multiplication by an exact-length word-span element raises cumulative length
 by the corresponding offset. -/
@@ -280,7 +280,7 @@ theorem biRectSpan_finrank_le
     _ = Fintype.card (Fin D) * Fintype.card (Fin D) * Module.finrank ℂ ℂ :=
           Module.finrank_matrix ℂ ℂ _ _
     _ = D * D * 1 := by
-          simp [Fintype.card_fin, Module.finrank_self]
+          simp only [Fintype.card_fin, Module.finrank_self, mul_one]
     _ = D ^ 2 := by ring
 
 /-!
@@ -308,16 +308,16 @@ lemma vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow
     disjoint_ker_range_pow (D := D) (f := f)
   have hv' : v ∈ LinearMap.range (f ^ D) := by
     -- `Matrix.toLin' (M^D) = (Matrix.toLin' M)^D`.
-    simpa [f, Matrix.toLin'_pow] using hv
+    simpa only [f, Matrix.toLin'_pow] using hv
   have hker : v ∈ LinearMap.ker f := by
     -- `M *ᵥ v = 0` means `f v = 0`.
     refine LinearMap.mem_ker.mpr ?_
-    simpa [f, Matrix.toLin'_apply] using hMv
+    simpa only [f, Matrix.toLin'_apply] using hMv
   -- Use disjointness: `ker f ⊓ range (f^D) = ⊥`.
   have hinter : (LinearMap.ker f ⊓ LinearMap.range (f ^ D)) = ⊥ := hdisj.eq_bot
   have hvInf : v ∈ (LinearMap.ker f ⊓ LinearMap.range (f ^ D)) := ⟨hker, hv'⟩
   have : v ∈ (⊥ : Submodule ℂ (Fin D → ℂ)) := by
-    simpa [hinter] using hvInf
+    simpa only [hinter] using hvInf
   simpa using this
 
 /-- Matrix-level injectivity on the range of left multiplication by `M^D`.
@@ -365,7 +365,7 @@ lemma matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulRight_pow
     refine (LinearMap.mem_range).2 ?_
     refine ⟨Yᵀ, ?_⟩
     -- `(Mᵀ)^D * Yᵀ = (Y * (M^D))ᵀ`.
-    simp [LinearMap.mulLeft_apply, Matrix.transpose_mul, Matrix.transpose_pow]
+    simp only [LinearMap.mulLeft_apply, Matrix.transpose_mul, Matrix.transpose_pow]
   have hMX' : (Mᵀ) * (Y * (M ^ D))ᵀ = 0 := by
     -- Transpose the equation `Y * (M^D) * M = 0`.
     have : ((Y * (M ^ D)) * M)ᵀ = 0 := by
@@ -376,7 +376,7 @@ lemma matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulRight_pow
       (M := Mᵀ) (X := (Y * (M ^ D))ᵀ) hX' hMX'
   have hX0 : Y * (M ^ D) = 0 := by
     simpa using congrArg Matrix.transpose hXt
-  simp [hX0]
+  simpa only [hX0]
 
 end WielandtRankOne
 
@@ -410,24 +410,28 @@ theorem mulLeft_mem_biRectSpan_pow_succ
   set M0 : Matrix (Fin D) (Fin D) ℂ := B i₀
   have hcomm : M0 * (M0 ^ D) = (M0 ^ D) * M0 := by
     calc
-      M0 * (M0 ^ D) = M0 ^ (D + 1) := by simp [pow_succ']
-      _ = (M0 ^ D) * M0 := by simp [pow_succ]
+      M0 * (M0 ^ D) = M0 ^ (D + 1) := by rw [pow_succ']
+      _ = (M0 ^ D) * M0 := by rw [pow_succ]
   have hM0 : M0 ∈ wordSpan B 1 := by
-    simpa [M0, evalWord] using (evalWord_mem_wordSpan B ([i₀] : List (Fin d)))
+    simpa only [M0, evalWord, Matrix.mul_one] using
+      (evalWord_mem_wordSpan B ([i₀] : List (Fin d)))
   have hY' : M0 * Y ∈ wordSpan B (n + 1) := by
     have : M0 * Y ∈ (wordSpan B 1) * (wordSpan B n) :=
       Submodule.mul_mem_mul hM0 hY
-    simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using (wordSpan_mul_le B 1 n) this
+    simpa only [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
+      (wordSpan_mul_le B 1 n) this
   refine (mem_biRectSpan_iff (d := d) (D := D)
     (P0 (B := B) (i₀ := i₀)) (Q0 (B := B) (i₁ := i₁)) B).mpr ?_
   refine ⟨M0 * Y, hY', ?_⟩
   rw [← hX]
   calc
     (B i₀ ^ D) * (M0 * Y) * (B i₁ ^ D)
-        = ((B i₀ ^ D) * M0) * Y * (B i₁ ^ D) := by simp [Matrix.mul_assoc]
+        = ((B i₀ ^ D) * M0) * Y * (B i₁ ^ D) := by
+            simp only [Matrix.mul_assoc]
     _ = (M0 * (B i₀ ^ D)) * Y * (B i₁ ^ D) := by
-        simpa [M0] using congrArg (fun Z => Z * Y * (B i₁ ^ D)) hcomm.symm
-    _ = M0 * ((B i₀ ^ D) * Y * (B i₁ ^ D)) := by simp [Matrix.mul_assoc]
+        simpa only [M0] using congrArg (fun Z => Z * Y * (B i₁ ^ D)) hcomm.symm
+    _ = M0 * ((B i₀ ^ D) * Y * (B i₁ ^ D)) := by
+        simp only [Matrix.mul_assoc]
 
 /-- Linear map sending level `n` to level `n+1` by left multiplication with `B i₀`. -/
 noncomputable def biRectSpanLeftStep (n : ℕ) :
@@ -437,10 +441,12 @@ noncomputable def biRectSpanLeftStep (n : ℕ) :
     (i₀ := i₀) (i₁ := i₁) n x.2⟩
   map_add' x y := by
     ext i j
-    simp [Matrix.mul_add]
+    simpa using congrArg (fun M : Matrix (Fin D) (Fin D) ℂ => M i j)
+      (Matrix.mul_add (B i₀) x.1 y.1)
   map_smul' a x := by
     ext i j
-    simp
+    exact congrArg (fun M : Matrix (Fin D) (Fin D) ℂ => M i j)
+      (Matrix.mul_smul (B i₀) a x.1)
 
 /-- The left-step map is injective: multiplication by `B i₀` is injective on the range of
 left multiplication by `((B i₀)^D)`. -/
@@ -457,17 +463,17 @@ theorem biRectSpanLeftStep_injective (n : ℕ) :
       (P0 (B := B) (i₀ := i₀)) (Q0 (B := B) (i₁ := i₁)) B).mp hX with ⟨Z, _, hZ⟩
     refine (LinearMap.mem_range).2 ?_
     refine ⟨Z * Q0 (B := B) (i₁ := i₁), ?_⟩
-    simpa [P0, Q0, LinearMap.mulLeft_apply, Matrix.mul_assoc] using hZ
+    simpa only [P0, Q0, LinearMap.mulLeft_apply, Matrix.mul_assoc] using hZ
   intro x y hxy
   have hmat : (B i₀) * x.1 = (B i₀) * y.1 := congrArg Subtype.val hxy
   have hz : (B i₀) * (x.1 - y.1) = 0 := by
-    simpa [Matrix.mul_sub, sub_eq_zero] using hmat
+    simpa only [Matrix.mul_sub, sub_eq_zero] using hmat
   have hzRange : (x.1 - y.1) ∈ LinearMap.range (LinearMap.mulLeft ℂ ((B i₀) ^ D)) :=
     Submodule.sub_mem _ (hRange x.2) (hRange y.2)
   have hzero : x.1 - y.1 = 0 :=
     WielandtRankOne.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow (D := D)
       (M := B i₀) (X := x.1 - y.1) hzRange hz
-  exact Subtype.ext <| by simpa [sub_eq_zero] using hzero
+  exact Subtype.ext <| by simpa only [sub_eq_zero] using hzero
 
 /-- Finrank is nondecreasing along the sequence `n ↦ biRectSpan ((B i₀)^D) ((B i₁)^D) B n`. -/
 theorem biRectSpan_finrank_mono (n : ℕ) :

--- a/TNLean/Wielandt/RankOne/Construction.lean
+++ b/TNLean/Wielandt/RankOne/Construction.lean
@@ -44,13 +44,13 @@ theorem ofFn_reverse {n : ℕ} {α : Type*} (f : Fin n → α) :
     (List.ofFn f).reverse = List.ofFn (f ∘ Fin.rev) := by
   calc
     (List.ofFn f).reverse = (List.map f (List.finRange n)).reverse := by
-      simp [List.ofFn_eq_map]
+      simp only [List.ofFn_eq_map]
     _ = List.map f (List.finRange n).reverse := by
-      simp [List.map_reverse]
+      simp only [List.map_reverse]
     _ = List.map f (List.map Fin.rev (List.finRange n)) := by
-      simp [List.finRange_reverse]
+      simp only [List.finRange_reverse]
     _ = List.map (f ∘ Fin.rev) (List.finRange n) := by
-      simp [List.map_map]
+      simp only [List.map_map]
     _ = List.ofFn (f ∘ Fin.rev) := by
       simp [List.ofFn_eq_map]
 
@@ -101,7 +101,7 @@ theorem IsNBlkInjective_transposeTensor
       -- Use `evalWord_transpose` with the reversed word.
       have hrev : ((σ ∘ Fin.rev) ∘ Fin.rev) = σ := by
         funext i
-        simp [Function.comp]
+        simpa only [Function.comp] using congrArg σ (Fin.rev_rev i)
       -- `(evalWord A (ofFn (σ ∘ rev)))ᵀ = evalWord (transposeTensor A) (ofFn σ)`
       -- by word reversal.
       have htrans :=
@@ -273,7 +273,7 @@ theorem rowSpreadSpan_eq_vectorSpreadSpan_transpose
       (A := A) (ψ := ψ) (σ := (σ ∘ Fin.rev))
     have hrev : ((σ ∘ Fin.rev) ∘ Fin.rev) = σ := by
       funext i
-      simp [Function.comp]
+      simpa only [Function.comp] using congrArg σ (Fin.rev_rev i)
     simpa [htrans, hrev] using h
 
 /-- Mapping `wordSpan` along `M ↦ ψ ᵥ* M` yields `rowSpreadSpan`. -/

--- a/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
@@ -67,7 +67,8 @@ theorem wordSpan_finrank_le (A : MPSTensor d D) (n : ℕ) :
         Submodule.finrank_le _
     _ = Fintype.card (Fin D) * Fintype.card (Fin D) *
         Module.finrank ℂ ℂ := Module.finrank_matrix ℂ ℂ _ _
-    _ = D * D * 1 := by simp [Fintype.card_fin, Module.finrank_self]
+    _ = D * D * 1 := by
+          simp only [Fintype.card_fin, Module.finrank_self, mul_one]
     _ = D ^ 2 := by ring
 
 /-! ## Left multiplication maps S_n into S_{n+1} -/
@@ -99,19 +100,23 @@ theorem mulLeft_pow_image_wordSpan_le (A : MPSTensor d D)
     Submodule.map (LinearMap.mulLeft ℂ (A i₀ ^ k)) (wordSpan A n) ≤
       wordSpan A (n + k) := by
   induction k with
-  | zero => simp [Submodule.map_id]
+  | zero =>
+      simpa only [pow_zero, LinearMap.mulLeft_one, Submodule.map_id, Nat.add_zero] using
+        (le_rfl : wordSpan A n ≤ wordSpan A n)
   | succ k ih =>
-    rw [show n + (k + 1) = (n + k) + 1 from by omega]
-    calc Submodule.map (LinearMap.mulLeft ℂ (A i₀ ^ (k + 1))) (wordSpan A n)
-        = Submodule.map (LinearMap.mulLeft ℂ (A i₀))
-            (Submodule.map (LinearMap.mulLeft ℂ (A i₀ ^ k)) (wordSpan A n)) := by
-          rw [← Submodule.map_comp]; congr 1; ext x
-          simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
-            pow_succ', ← Matrix.mul_assoc]
-      _ ≤ Submodule.map (LinearMap.mulLeft ℂ (A i₀)) (wordSpan A (n + k)) :=
-          Submodule.map_mono ih
-      _ ≤ wordSpan A ((n + k) + 1) :=
-          mulLeft_image_wordSpan_le_succ A i₀ (n + k)
+      simpa [Nat.add_assoc] using
+        calc Submodule.map (LinearMap.mulLeft ℂ (A i₀ ^ (k + 1))) (wordSpan A n)
+            = Submodule.map (LinearMap.mulLeft ℂ (A i₀))
+                (Submodule.map (LinearMap.mulLeft ℂ (A i₀ ^ k)) (wordSpan A n)) := by
+              rw [← Submodule.map_comp]
+              congr 1
+              ext x
+              simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
+                pow_succ', ← Matrix.mul_assoc]
+          _ ≤ Submodule.map (LinearMap.mulLeft ℂ (A i₀)) (wordSpan A (n + k)) :=
+              Submodule.map_mono ih
+          _ ≤ wordSpan A ((n + k) + 1) :=
+              mulLeft_image_wordSpan_le_succ A i₀ (n + k)
 
 /-! ## S_{n+1} = span{A_i} * S_n -/
 
@@ -131,7 +136,7 @@ theorem wordSpan_succ_eq_mul_left (A : MPSTensor d D) (n : ℕ) :
       apply Submodule.subset_span
       refine ⟨fun _ => j, ?_⟩
       simp only [List.ofFn, Fin.foldr_succ, Fin.foldr_zero]
-      simp [evalWord]
+      simp only [evalWord, Matrix.mul_one]
     calc (Submodule.span ℂ (Set.range A)) * wordSpan A n
         ≤ wordSpan A 1 * wordSpan A n :=
           mul_le_mul' hS1 (le_refl _)
@@ -187,13 +192,15 @@ theorem wordSpan_finrank_mono_of_isUnit' (A : MPSTensor d D)
     Module.finrank ℂ (wordSpan A n) := by
   obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le h
   induction k with
-  | zero => simp
+  | zero =>
+      simpa only [Nat.add_zero] using
+        (le_rfl : Module.finrank ℂ (wordSpan A m) ≤ Module.finrank ℂ (wordSpan A m))
   | succ k ih =>
-    calc Module.finrank ℂ (wordSpan A m)
-        ≤ Module.finrank ℂ (wordSpan A (m + k)) := ih (by omega)
-      _ ≤ Module.finrank ℂ (wordSpan A (m + (k + 1))) := by
-          rw [show m + (k + 1) = (m + k) + 1 from by omega]
-          exact wordSpan_finrank_mono_of_isUnit A i₀ hU (m + k)
+      calc Module.finrank ℂ (wordSpan A m)
+          ≤ Module.finrank ℂ (wordSpan A (m + k)) := ih (by omega)
+        _ ≤ Module.finrank ℂ (wordSpan A (m + (k + 1))) := by
+            simpa [Nat.add_assoc] using
+              wordSpan_finrank_mono_of_isUnit A i₀ hU (m + k)
 
 /-! ## Permanence of fullness -/
 
@@ -214,9 +221,7 @@ theorem wordSpan_eq_top_of_ge_of_isUnit (A : MPSTensor d D)
     obtain ⟨u, hu⟩ := hPow
     refine ⟨(↑u⁻¹ : Matrix (Fin D) (Fin D) ℂ) * y, ?_⟩
     simp only [LinearMap.mulLeft_apply, ← Matrix.mul_assoc]
-    rw [← hu, show (u : Matrix (Fin D) (Fin D) ℂ) * ↑u⁻¹ = 1 from
-      Units.mul_inv u]
-    simp
+    rw [← hu, Units.mul_inv, one_mul]
   calc ⊤ = Submodule.map (LinearMap.mulLeft ℂ (A i₀ ^ (m - N))) ⊤ := by
           rw [Submodule.map_top]
           exact (LinearMap.range_eq_top.mpr hSurj).symm
@@ -233,7 +238,7 @@ private theorem evalWord_ofFn_one (A : MPSTensor d D) (σ : Fin 1 → Fin d) :
   have h : List.ofFn σ = [σ 0] := by
     apply List.ext_getElem <;> simp
   rw [h]
-  simp [evalWord]
+  simp only [evalWord, Matrix.mul_one]
 
 private theorem gen_mem_wordSpan_one (A : MPSTensor d D) (j : Fin d) :
     A j ∈ wordSpan A 1 :=
@@ -247,7 +252,8 @@ private theorem finrank_top_matrix :
           simp
     _ = Fintype.card (Fin D) * Fintype.card (Fin D) *
         Module.finrank ℂ ℂ := Module.finrank_matrix ℂ ℂ _ _
-    _ = D * D * 1 := by simp [Fintype.card_fin, Module.finrank_self]
+    _ = D * D * 1 := by
+          simp only [Fintype.card_fin, Module.finrank_self, mul_one]
     _ = D ^ 2 := by ring
 
 private theorem finrank_eq_finrank_map_mulRight_of_isUnit
@@ -257,7 +263,7 @@ private theorem finrank_eq_finrank_map_mulRight_of_isUnit
       Module.finrank ℂ (Submodule.map (LinearMap.mulRight ℂ b) S) := by
   have hinj : Function.Injective (LinearMap.mulRight ℂ b) := by
     intro x y hxy
-    exact hU.mul_left_injective (by simpa [LinearMap.mulRight_apply] using hxy)
+    exact hU.mul_left_injective (by simpa only [LinearMap.mulRight_apply] using hxy)
   let e := Submodule.equivMapOfInjective (LinearMap.mulRight ℂ b) hinj S
   exact LinearEquiv.finrank_eq e
 
@@ -327,7 +333,7 @@ private theorem mul_map_mulRight_le_map_mulRight_mul
   · intro u hu y hy
     rcases Submodule.mem_map.mp hy with ⟨s, hs, rfl⟩
     exact Submodule.mem_map.mpr ⟨u * s, Submodule.mul_mem_mul hu hs, by
-      simp [LinearMap.mulRight_apply, Matrix.mul_assoc]⟩
+      simp only [LinearMap.mulRight_apply, Matrix.mul_assoc]⟩
   · intro x y hx hy
     exact Submodule.add_mem _ hx hy
 
@@ -340,7 +346,7 @@ private theorem map_mulRight_map_mulRight
   simp only [← Submodule.map_comp]
   congr 1
   ext x
-  simp [LinearMap.comp_apply, LinearMap.mulRight_apply, Matrix.mul_assoc]
+  simp only [LinearMap.comp_apply, LinearMap.mulRight_apply, Matrix.mul_assoc]
 
 /-- If `dim(S_r) = dim(S_{r+1})`, then every later word span is absorbed into
 the right-multiplication image of `S_r` by powers of the invertible generator.
@@ -359,31 +365,31 @@ theorem wordSpan_le_mulRight_pow_image (A : MPSTensor d D)
       intro X hX
       refine Submodule.mem_map.mpr ⟨X, ?_, ?_⟩
       · simpa using hX
-      · simp [pow_zero]
+      · simp only [pow_zero, LinearMap.mulRight_apply, Matrix.mul_one]
   | succ k ih =>
-      rw [show r + (k + 1) = (r + k) + 1 by omega]
-      calc
-        wordSpan A ((r + k) + 1)
-            = (Submodule.span ℂ (Set.range A)) * wordSpan A (r + k) := by
-                rw [wordSpan_succ_eq_mul_left A (r + k)]
-        _ ≤ (Submodule.span ℂ (Set.range A)) *
-              Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ k)) (wordSpan A r) :=
-              mul_le_mul' le_rfl ih
-        _ ≤ Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ k))
-              ((Submodule.span ℂ (Set.range A)) * wordSpan A r) :=
-              mul_map_mulRight_le_map_mulRight_mul
-                (U := Submodule.span ℂ (Set.range A))
-                (S := wordSpan A r) (b := A i₀ ^ k)
-        _ = Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ k))
-              (wordSpan A (r + 1)) := by
-              rw [← wordSpan_succ_eq_mul_left A r]
-        _ = Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ k))
-              (Submodule.map (LinearMap.mulRight ℂ (A i₀)) (wordSpan A r)) := by
-              rw [hbase]
-        _ = Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ (k + 1)))
-              (wordSpan A r) := by
-              rw [map_mulRight_map_mulRight (A i₀) (A i₀ ^ k) (wordSpan A r)]
-              simp [pow_succ']
+      simpa [Nat.add_assoc] using
+        calc
+          wordSpan A ((r + k) + 1)
+              = (Submodule.span ℂ (Set.range A)) * wordSpan A (r + k) := by
+                  rw [wordSpan_succ_eq_mul_left A (r + k)]
+          _ ≤ (Submodule.span ℂ (Set.range A)) *
+                Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ k)) (wordSpan A r) :=
+                mul_le_mul' le_rfl ih
+          _ ≤ Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ k))
+                ((Submodule.span ℂ (Set.range A)) * wordSpan A r) :=
+                mul_map_mulRight_le_map_mulRight_mul
+                  (U := Submodule.span ℂ (Set.range A))
+                  (S := wordSpan A r) (b := A i₀ ^ k)
+          _ = Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ k))
+                (wordSpan A (r + 1)) := by
+                rw [← wordSpan_succ_eq_mul_left A r]
+          _ = Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ k))
+                (Submodule.map (LinearMap.mulRight ℂ (A i₀)) (wordSpan A r)) := by
+                rw [hbase]
+          _ = Submodule.map (LinearMap.mulRight ℂ (A i₀ ^ (k + 1)))
+                (wordSpan A r) := by
+                rw [map_mulRight_map_mulRight (A i₀) (A i₀ ^ k) (wordSpan A r)]
+                rw [pow_succ']
 
 private theorem wordSpan_finrank_constant_of_finrank_eq
     (A : MPSTensor d D) (i₀ : Fin d) (hU : IsUnit (A i₀))
@@ -471,7 +477,7 @@ theorem wordSpan_eq_top_of_isNormal_of_isUnit (A : MPSTensor d D)
   change wordSpan A k = ⊤
   by_contra htop
   have hkraus_le : krausRank A ≤ D ^ 2 := by
-    simpa [krausRank] using wordSpan_finrank_le A 1
+    simpa only [krausRank] using wordSpan_finrank_le A 1
   have hk_pos : 1 ≤ k := by
     dsimp [k]
     omega
@@ -486,7 +492,9 @@ theorem wordSpan_eq_top_of_isNormal_of_isUnit (A : MPSTensor d D)
     intro t ht
     induction t with
     | zero =>
-        simp [krausRank]
+        simpa only [krausRank, Nat.add_zero, Nat.zero_add] using
+          (le_rfl : Module.finrank ℂ (wordSpan A 1) ≤
+            Module.finrank ℂ (wordSpan A 1))
     | succ t ih =>
         have htle : t ≤ k - 1 := by omega
         have ih' := ih htle
@@ -526,8 +534,7 @@ theorem iIndex_le_of_isNormal_of_isUnit (A : MPSTensor d D)
     (i₀ : Fin d) (hU : IsUnit (A i₀)) (hN : IsNormal A) :
     iIndex A ≤ D ^ 2 - krausRank A + 1 := by
   rw [iIndex]
-  exact Nat.sInf_le (show D ^ 2 - krausRank A + 1 ∈
-      {n : ℕ | wordSpan A n = ⊤} from
-    wordSpan_eq_top_of_isNormal_of_isUnit A i₀ hU hN)
+  exact Nat.sInf_le <| by
+    exact wordSpan_eq_top_of_isNormal_of_isUnit A i₀ hU hN
 
 end MPSTensor

--- a/TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
+++ b/TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
@@ -67,7 +67,11 @@ private theorem cumulativeSpan_dim_growth
         Module.finrank ℂ (cumulativeSpan A 0) + k := by
   intro k
   induction k with
-  | zero => right; simp
+  | zero =>
+      right
+      simpa only [Nat.add_zero, ge_iff_le] using
+        (le_rfl : Module.finrank ℂ (cumulativeSpan A 0) ≤
+          Module.finrank ℂ (cumulativeSpan A 0))
   | succ k ih =>
     rcases ih with ⟨j, hj, hstab⟩ | hgrow
     · left; exact ⟨j, by omega, hstab⟩
@@ -226,7 +230,11 @@ private theorem cumulativeSpan_dim_growth_from_one
         Module.finrank ℂ (cumulativeSpan A 1) + k := by
   intro k
   induction k with
-  | zero => right; simp
+  | zero =>
+      right
+      simpa only [Nat.add_zero, ge_iff_le] using
+        (le_rfl : Module.finrank ℂ (cumulativeSpan A 1) ≤
+          Module.finrank ℂ (cumulativeSpan A 1))
   | succ k ih =>
     rcases ih with ⟨j, hj1, hjk, hstab⟩ | hgrow
     · left; exact ⟨j, hj1, by omega, hstab⟩
@@ -237,9 +245,11 @@ private theorem cumulativeSpan_dim_growth_from_one
         have hlt : cumulativeSpan A (1 + k) <
             cumulativeSpan A (1 + k + 1) :=
           lt_of_le_of_ne (cumulativeSpan_mono A (1 + k)) hstab
-        have hstrict := cumulativeSpan_finrank_strict_mono A hlt
-        change Module.finrank ℂ (cumulativeSpan A (1 + (k + 1))) ≥ _
-        rw [show 1 + (k + 1) = 1 + k + 1 from by omega]
+        have hstrict :
+            Module.finrank ℂ (cumulativeSpan A (1 + k)) <
+              Module.finrank ℂ (cumulativeSpan A (1 + (k + 1))) := by
+          simpa only [Nat.add_assoc] using
+            cumulativeSpan_finrank_strict_mono A hlt
         omega
 
 /-- The key step helper for the sharp bound: if `IsNormal` and
@@ -264,7 +274,8 @@ theorem cumulativeSpan_eq_top_of_isNormal_sharp [NeZero D]
           Submodule.finrank_le _
       _ = Fintype.card (Fin D) * Fintype.card (Fin D) *
           Module.finrank ℂ ℂ := Module.finrank_matrix ℂ ℂ _ _
-      _ = D * D * 1 := by simp [Fintype.card_fin, Module.finrank_self]
+      _ = D * D * 1 := by
+            simp only [Fintype.card_fin, Module.finrank_self, mul_one]
       _ = D ^ 2 := by ring
   -- The bound n we aim for
   set n := D ^ 2 - r + 1 with hn_def
@@ -340,7 +351,8 @@ theorem cumulativeSpan_eq_top_of_isNormal_sharp [NeZero D]
         calc Module.finrank ℂ (cumulativeSpan A n) = D ^ 2 := h_eq
           _ = D * D * 1 := by ring
           _ = Fintype.card (Fin D) * Fintype.card (Fin D) *
-              Module.finrank ℂ ℂ := by simp [Fintype.card_fin, Module.finrank_self]
+              Module.finrank ℂ ℂ := by
+                simp only [Fintype.card_fin, Module.finrank_self, mul_one]
           _ = Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) :=
               (Module.finrank_matrix ℂ ℂ _ _).symm
       exact hne this
@@ -386,8 +398,7 @@ private theorem wordSpan_zero_ne_top (A : MPSTensor d D)
   intro h
   -- wordSpan A 0 = ℂ ∙ 1 has finrank 1
   have h1 : Module.finrank ℂ (wordSpan A 0) = 1 := by
-    rw [wordSpan_zero, finrank_span_singleton
-      (show (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 from one_ne_zero)]
+    rw [wordSpan_zero, finrank_span_singleton one_ne_zero]
   -- But wordSpan A 0 = ⊤ has finrank D² ≥ 4
   rw [h, finrank_top] at h1
   simp only [Module.finrank_matrix, Fintype.card_fin,
@@ -437,7 +448,10 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
     apply Submodule.span_le.mpr
     rintro M ⟨σ, rfl⟩
     apply Submodule.subset_span
-    exact ⟨List.ofFn σ, by simp, by simp, rfl⟩
+    exact ⟨List.ofFn σ,
+      by simpa only [List.length_ofFn] using (le_rfl : 1 ≤ 1),
+      by simpa only [List.length_ofFn] using (le_rfl : 1 ≤ 1),
+      rfl⟩
   -- Step 2: V is monotone
   have hV_mono : ∀ {a b : ℕ}, a ≤ b → V a ≤ V b := by
     intro a b hab
@@ -455,8 +469,11 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
             rintro M ⟨σ, rfl⟩
             apply Submodule.subset_span
             exact ⟨List.ofFn σ,
-              show 1 ≤ (List.ofFn σ).length by simp,
-              show (List.ofFn σ).length ≤ n + 1 by simp, rfl⟩
+              by
+                simpa only [List.length_ofFn] using
+                  Nat.succ_le_succ (Nat.zero_le n),
+              by simpa only [List.length_ofFn] using (le_rfl : n + 1 ≤ n + 1),
+              rfl⟩
           _ = V n := heq.symm
     -- Left multiplication by A_i sends V n into V n
     have hleft : ∀ (i : Fin d) (x : Matrix (Fin D) (Fin D) ℂ),
@@ -464,7 +481,7 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
       intro i x hx
       -- suffices to check on generators
       suffices hmul : Submodule.map (LinearMap.mulLeft ℂ (A i)) (V n) ≤ V n by
-        exact hmul ⟨x, hx, by simp [LinearMap.mulLeft_apply]⟩
+        exact hmul ⟨x, hx, by simp only [LinearMap.mulLeft_apply]⟩
       rw [Submodule.map_le_iff_le_comap]
       apply Submodule.span_le.mpr
       rintro M ⟨w, hw1, hw2, rfl⟩
@@ -474,8 +491,11 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
       change evalWord A (i :: w) ∈ V n
       by_cases hle : w.length + 1 ≤ n
       · exact Submodule.subset_span ⟨i :: w,
-          show 1 ≤ (i :: w).length by simp,
-          show (i :: w).length ≤ n by simp; omega, rfl⟩
+          by
+            simpa only [List.length_cons] using
+              Nat.succ_le_succ (Nat.zero_le w.length),
+          by simpa only [List.length_cons] using hle,
+          rfl⟩
       · -- |i :: w| = |w| + 1 > n, so |w| = n, |i :: w| = n + 1
         have : evalWord A (i :: w) ∈ wordSpan A (n + 1) := by
           have hlen : (i :: w).length = n + 1 := by simp [List.length_cons]; omega
@@ -497,18 +517,18 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
           by_cases hw' : w = []
           · subst hw'; simp only [evalWord, mul_one]
             -- A i has length 1 ≤ n (since n ≥ 1)
-            have : A i ∈ V n := by
-              have := evalWord_mem_wordSpan A ([i] : List (Fin d))
-              simp [evalWord] at this
-              apply Submodule.subset_span
-              exact ⟨[i], by simp,
-                by simpa only [List.length_cons, List.length_nil, zero_add] using hn,
-                by simp [evalWord]⟩
-            exact this
+            exact Submodule.subset_span ⟨[i],
+              by
+                simpa only [List.length_cons, List.length_nil, zero_add] using
+                  (le_rfl : 1 ≤ 1),
+              by simpa only [List.length_cons, List.length_nil, zero_add] using hn,
+              by simp only [evalWord, Matrix.mul_one]⟩
           · have hw1' : 1 ≤ w.length := by
               cases w with
               | nil => contradiction
-              | cons _ _ => simp
+              | cons _ t =>
+                  simpa only [List.length_cons] using
+                    Nat.succ_le_succ (Nat.zero_le t.length)
             by_cases hw3 : w.length ≤ n
             · -- |w| ≤ n, so evalWord A w ∈ V n directly
               exact hleft i _ (Submodule.subset_span ⟨w, hw1', hw3, rfl⟩)
@@ -543,7 +563,8 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
       calc r ≤ Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) :=
             Submodule.finrank_le _
         _ = D * D * 1 := by
-            simp [Module.finrank_matrix, Fintype.card_fin, Module.finrank_self]
+            simp only [Module.finrank_matrix, Fintype.card_fin,
+              Module.finrank_self, mul_one]
         _ = D ^ 2 := by ring
     -- We need to show the dimension grows to D²
     -- If bound ≥ 1 (which it is when D ≥ 2 and r ≤ D²):
@@ -556,8 +577,9 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
       rcases h (D ^ 2 - r) le_rfl with htop | hge
       · -- V (1 + (D²-r)) = ⊤, so V bound = ⊤
         have : V bound = ⊤ := hbn ▸ htop
-        rw [this]
-        simp [Module.finrank_matrix, Fintype.card_fin, Module.finrank_self]
+        rw [this, finrank_top]
+        simp only [Module.finrank_matrix, Fintype.card_fin,
+          Module.finrank_self, mul_one]
         ring_nf; omega
       · -- dim(V (1 + (D²-r))) ≥ r + (D²-r) = D²
         have : Module.finrank ℂ (V bound) ≥ D ^ 2 := by
@@ -579,13 +601,17 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
       have hk' : k ≤ D ^ 2 - r := by omega
       rcases ih hk' with htop | hge
       · left
-        exact eq_top_iff.mpr (htop ▸ hV_mono (by omega))
+        exact eq_top_iff.mpr <| htop ▸
+          hV_mono (a := 1 + k) (b := 1 + (k + 1)) (by omega)
       · by_cases hne : V (1 + k) = ⊤
-        · left; exact eq_top_iff.mpr (hne ▸ hV_mono (by omega))
+        · left
+          exact eq_top_iff.mpr <| hne ▸
+            hV_mono (a := 1 + k) (b := 1 + (k + 1)) (by omega)
         · right
           have hgr := hV_growth (1 + k) (by omega) hne
-          have hle := Submodule.finrank_mono
-            (hV_mono (show 1 + k + 1 ≤ 1 + (k + 1) from by omega))
+          have hstep_le : V (1 + k + 1) ≤ V (1 + (k + 1)) :=
+            hV_mono (a := 1 + k + 1) (b := 1 + (k + 1)) (by omega)
+          have hle := Submodule.finrank_mono hstep_le
           omega
   -- Step 6: V bound = ⊤
   have hV_top : V bound = ⊤ := by
@@ -598,14 +624,16 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
           ≤ Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) :=
             Submodule.finrank_le _
         _ = D * D * 1 := by
-            simp [Module.finrank_matrix, Fintype.card_fin, Module.finrank_self]
+            simp only [Module.finrank_matrix, Fintype.card_fin,
+              Module.finrank_self, mul_one]
         _ = D ^ 2 := by ring
     have h_ge := hV_dim
     have h_eq : Module.finrank ℂ (V bound) = D ^ 2 := by omega
     calc Module.finrank ℂ (V bound) = D ^ 2 := h_eq
       _ = D * D * 1 := by ring
       _ = Fintype.card (Fin D) * Fintype.card (Fin D) *
-          Module.finrank ℂ ℂ := by simp [Fintype.card_fin, Module.finrank_self]
+          Module.finrank ℂ ℂ := by
+            simp only [Fintype.card_fin, Module.finrank_self, mul_one]
       _ = Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) :=
           (Module.finrank_matrix ℂ ℂ _ _).symm
   -- Step 7: trace vanishes on V bound but tr(I) ≠ 0


### PR DESCRIPTION
## Summary

Second round of deep cleanup, targeting **28 additional files** not covered by PR #603. Focus: squeezing bare `simp` to explicit `simp only [...]`, fixing long lines, and simplifying proofs.

### Bare simp squeezing highlights

| File | Before → After |
|------|---------------|
| GaugeConstruction | 59 → 10 |
| ChoiJamiolkowski | 33 → 4 |
| CyclicSectors | 30 → ~5 |
| SectorIrreducibility | 27 → 0 |
| FixedPointProjection | 26 → 0 |
| FromSpectral | 23 → 0 |
| SpectralRadius | 23 → 0 |
| StructuralFull | 29 → 0 |
| TransferMatrix | 22 → ~3 |
| LiouvillianKernel | 20 → ~5 |
| RankOne/Construction | 20 → ~5 |
| StringOrderDefs | 15 → ~3 |
| + 16 more files | various |

### Long line fixes

| File | Before → After |
|------|---------------|
| PermutationRigidityPrimitive | 23 → 0 |
| EulerStep | 9 → 0 |
| Semigroup/Basic | 7 → 0 |
| FixedPointProjection | 6 → 0 |
| + 10 more files | various |

### Proof simplifications (no statement changes)

- **FixedPointProjection**: simplified kernel/mulVec steps, removed unused helper
- **PermutationRigidityPrimitive**: compressed limit proofs to direct `simpa only`
- **StructuralFull**: explicit Kraus-isometry diagonal pick-out via `ite_smul`/`Finset.sum_ite_eq`
- **StringOrderDefs**: factored twisted-companion proof, named helper `hC1'`
- **BlockingViaAdjoint**: explicit `LinearMap.charpoly_toMatrix` bridge
- **NonzeroTraceProduct**: tightened local simp calls, removed dead `have`
- **Semigroup/Basic**: explicit CLM evaluation, `change` for scalar-unit rewrite
- **GroupStructure/TransferMatrix**: `show` → `change` for goal-modifying uses

### Verification

- All 28 files verified individually with `lake env lean`
- Full `lake build` succeeds (8536 jobs)
- No new `sorry` introduced; no theorem/definition statements changed
- Blueprint spot-checked against relevant chapters — no statement drift

### Related issues

Further addresses #334 (spaghetti proof refactoring)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only/style refactors (mostly `simp`/rewrites) with no API or statement changes; main risk is accidental proof fragility/regressions from over-specialized simp sets.
> 
> **Overview**
> Performs a broad proof-cleanup pass across ~28 Lean files, primarily replacing broad `simp` with explicit `simp only [...]`, introducing small named intermediate lemmas, and refactoring `rw/show`/`convert` steps into more direct `change`/`simpa`/`exact` patterns.
> 
> A few proofs are made more robust/readable by using more specific library lemmas (e.g., `Matrix.inv_inv_of_invertible`, `ENNReal.ofReal_ne_top`) and by expanding previously implicit simplifications in algebraic/trace/spectral-radius arguments; theorems/definitions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e92b2cd60b3d1794886cbb51a9e0710b3d0e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->