### PR TITLE
doc(blueprint): tighten TN physical-realisation diagram and flag twist mismatch

### DIFF
--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -285,6 +285,14 @@ on the bond space.
 \begin{proof}\leanok\uses{lem:gauge_equiv_twisted}
     The physical action is transferred to the virtual level by the same
     local move that replaces the twisted tensor by a gauge-conjugated one:
+    % TODO(maintainer): \TNPermutationTwist is designed for physical-index
+    % relabellings (where the arrow label $\sigma_g$ is a permutation acting
+    % on indices). Here the physical action is a general linear combination
+    % $\widetilde{A}_g^{\,i} = \sum_j U(g)_{ij}\, A^j$, so labelling the
+    % left leg "U(g)" is a convention mismatch with the macro's intent.
+    % Consider adding a dedicated \TNLinearTwist macro (tensor with a red
+    % operator dot on the physical leg, analogous to the LHS of
+    % \TNCondCOne) to replace the use below.
     \[
         \TNPermutationTwist{U(g)}{i}
         \qquad\leadsto\qquad

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -220,14 +220,14 @@
   \begin{tikzpicture}[tn picture]
     \TN@tensordot{tnA1}{(0,0)}
     \draw[tn leg] (tnA1.west) -- ++(-0.65,0);
-    \draw[tn leg] (tnA1.east) -- ++(0.65,0);
     \TN@upleg{tnA1}{\TN@physleglen}
     \TN@opdotabove{tnX}{(0.78,0)}{#1}
+    \draw[tn leg] (tnA1.east) -- (tnX.west);
+    \draw[tn leg] (tnX.east) -- ++(0.22,0);
     \node at (1.78,0) {$=$};
     \TN@tensordot{tnA2}{(2.65,0)}
     \draw[tn leg] (tnA2.west) -- ++(-0.65,0);
     \draw[tn leg] (tnA2.east) -- ++(0.65,0);
-    \TN@upleg{tnA2}{\TN@physleglen}
     \TN@opdotleft{tnO}{(2.65,0.74)}{#2}
     \draw[tn phys leg] (tnA2.north) -- (tnO.south);
   \end{tikzpicture}%


### PR DESCRIPTION
### Motivation

- Follow-up to #401 (review TN diagrams for mathematical accuracy and alignment with reference papers).
- In `\TNPhysicalRealization`, the right virtual leg is drawn past the `X` operator dot instead of through it, so the dot visually floats off the bond.
- The `\TNPermutationTwist{U(g)}{i}` usage in the virtual-symmetry-eq proof reuses a macro designed for physical-index relabellings (arrow labelled `sigma_g`), but the twist there is a general linear combination, so the leg label `U(g)` conflicts with the macro's intent.

### Description

- `blueprint/src/macros/tn_print.tex`: route the right virtual leg of the LHS of `\TNPhysicalRealization` through the `X` operator dot so the dot sits on the bond; drop a redundant `\TN@upleg` on the RHS that was fully covered by the explicit phys-leg draw to the `O_A(X)` dot.
- `blueprint/src/chapter/ch13b_symmetry.tex`: add a `% TODO` comment flagging the `\TNPermutationTwist{U(g)}{i}` usage and suggesting a dedicated `\TNLinearTwist` macro, left for maintainer decision rather than silently changing the rendering.

### Testing

- Blueprint-only change; relies on Blueprint Lint (`lint-blueprint.yml`) CI to validate LaTeX labels and references.

---
Addresses #401

> [!NOTE]
> **Low Risk**
> Documentation/TikZ macro tweaks only; main risk is minor diagram layout/regression in rendered PDF output.
> 
> **Overview**
> Adds an inline maintainer TODO in `ch13b_symmetry.tex` noting that `\TNPermutationTwist` is being used to depict a *linear* physical action `U(g)` (not a permutation), and suggests introducing a dedicated macro for this case.
> 
> Updates the `\TNPhysicalRealization` TikZ macro to draw the right virtual leg through an explicit operator dot `#1` (instead of a single long leg), adjusting the diagram's geometry to better match the intended operator insertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7595a873e2430018380e2fbafc3fdec47fc13b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>