### PR TITLE
feat(Channel/Peripheral): multi-cycle block-permutation data for Wolf Thm 6.16

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -290,6 +290,7 @@ import TNLean.Wielandt.QuantumWielandt
 
 import TNLean.Channel.Peripheral.CyclicDecomposition
 import TNLean.Channel.Peripheral.Cycles
+import TNLean.Channel.Peripheral.MultiCycleDecomposition
 
 -- Public documentation index modules
 import TNLean.Channel.WolfChapter2Index

--- a/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
+++ b/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
@@ -7,23 +7,30 @@ import TNLean.Channel.Peripheral.Cycles
 /-!
 # Multi-cycle block-permutation decompositions
 
-This file lifts the single-cycle block-permutation data packaged by
-`TNLean.Channel.Peripheral.Cycles` to the general multi-cycle form that
-underlies the asymptotic-image side of
+This file packages an explicit multi-cycle refinement of the
+block-permutation infrastructure developed in
+`TNLean.Channel.Peripheral.Cycles`, in the form needed for the
+asymptotic-image side of
 Wolf, *Quantum Channels & Operations*, Theorem 6.16.
 
 Concretely, Wolf Thm. 6.16 describes the asymptotic dynamics of a general
 trace-preserving positive Schwarz map `T` as a permutation of Wedderburn
-blocks, with each block transported by a unitary.  The permutation need not
-be a single cycle: in general it is a disjoint union of cycles with
-(possibly) distinct periods, one cycle per Wedderburn block-size class.
+blocks, with each block transported by a unitary.  Such a permutation may
+already be represented abstractly by the `CycleStructure` bundled data of
+`TNLean.Channel.Peripheral.Cycles`, whose underlying permutation `σ` is
+allowed to have multiple disjoint cycles.  The present file refines that
+view by choosing an *explicit* cycle-index type `ι`, a per-cycle period
+`period : ι → ℕ`, and the corresponding projection families, recording the
+disjoint-union-of-cycles structure as separate data.
 
-The present file isolates the *multi-cycle* algebraic infrastructure, on top
-of the single-cycle corner-preservation proof pattern from
-`preserves_corner_pow_of_cyclic_decomp`.  The *existence direction* —
-that every TP positive Schwarz map admits such a decomposition on its
-asymptotic image — depends on Wolf Thm. 6.14 (Wedderburn decomposition of
-the fixed-point algebra, issues #27/#360) and is left to future work.
+The corner-preservation proofs reuse the per-orbit proof pattern of
+`preserves_corner_pow_of_cyclic_decomp` from
+`TNLean.Channel.Peripheral.CyclicDecomposition`, adapted to the setting
+where the per-cycle projections do not sum to the identity.  The
+*existence direction* — that every TP positive Schwarz map admits such a
+decomposition on its asymptotic image — depends on Wolf Thm. 6.14
+(Wedderburn decomposition of the fixed-point algebra, issues #27/#360)
+and is left to future work.
 
 ## Main definitions
 
@@ -67,10 +74,12 @@ element of the cycle-index type `ι` — together with:
 * the multiplicative-domain factorisations `T (P c k * X) = T (P c k) * T X`
   and `T (X * P c k) = T X * T (P c k)`.
 
-This generalises the single-cycle bundled data of
-`TNLean.Channel.Peripheral.Cycles.CycleStructure`: a `CycleStructure`
-corresponds to the special case `ι = Unit` (single cycle, period equal to
-`orderOf σ`).
+This refines the bundled permutation data of
+`TNLean.Channel.Peripheral.Cycles.CycleStructure`: a
+`MultiCycleDecomposition` chooses an explicit cycle-index type together
+with per-cycle periods and projection families for the underlying
+permutation structure, while `toCycleStructure` forgets that extra
+organisation.
 
 In Wolf's Thm. 6.16, the cycle-index `ι` runs over the equivalence classes
 of Wedderburn blocks that share both a common multiplicity and a common
@@ -143,7 +152,7 @@ end CyclicShift
 section PreservesCornerHelper
 
 /-- Corner preservation is stable under taking powers. -/
-private lemma preservesCorner_pow {S : MatrixEnd D} {P : MatrixAlg D}
+private lemma preserves_corner_pow {S : MatrixEnd D} {P : MatrixAlg D}
     (hP : IsOrthogonalProjection P) (hPS : PreservesCorner P S) (n : ℕ) :
     PreservesCorner P (S ^ n) := by
   induction n with
@@ -160,14 +169,6 @@ private lemma preservesCorner_pow {S : MatrixEnd D} {P : MatrixAlg D}
       intro X
       have hSform : S (P * X * P) = P * S (P * X * P) * P := (hPS X).symm
       have : P * ((S ^ n) (S (P * X * P))) * P = (S ^ n) (S (P * X * P)) := by
-        have hS_corner_form :
-            S (P * X * P) = P * (P * S (P * X * P) * P) * P := by
-          calc
-            S (P * X * P) = P * S (P * X * P) * P := hSform
-            _ = (P * P) * S (P * X * P) * (P * P) := by
-                simp only [hP.2]
-            _ = P * (P * S (P * X * P) * P) * P := by
-                simp only [Matrix.mul_assoc]
         calc
           P * ((S ^ n) (S (P * X * P))) * P
               = P * ((S ^ n) (P * S (P * X * P) * P)) * P := by rw [← hSform]
@@ -183,14 +184,14 @@ end PreservesCornerHelper
 
 section PerCycle
 
-/-- **Single-cycle corner preservation.**
+/-- **Per-cycle corner preservation.**
 
 In cycle `c`, the channel's `period c`-th iterate preserves each corner
-`P c k · M_D(ℂ) · P c k`.  The proof follows the single-cycle proof
-pattern from `preserves_corner_pow_of_cyclic_decomp`, *without* the
-sum-to-one hypothesis on the sector projections (which is not available
-in the multi-cycle setting, where the per-cycle projections typically do
-not sum to the identity).
+`P c k · M_D(ℂ) · P c k`.  The proof follows the per-orbit proof pattern
+from `preserves_corner_pow_of_cyclic_decomp`, *without* the sum-to-one
+hypothesis on the sector projections (which is not available in the
+multi-cycle setting, where the per-cycle projections typically do not
+sum to the identity).
 
 Per Wolf Thm. 6.16 §6.5, this is the per-cycle restriction of the block
 permutation back to its own orbit: after `period c` applications of `T`,
@@ -265,7 +266,7 @@ theorem preserves_corner_pow_of_dvd (M : MultiCycleDecomposition T)
   have hPowEq : (T ^ N) = (T ^ M.period c) ^ q := by
     rw [← pow_mul, ← hq]
   rw [hPowEq]
-  exact preservesCorner_pow (M.isProj c k)
+  exact preserves_corner_pow (M.isProj c k)
     (M.preserves_corner_pow_period c k) q
 
 end PerCycle

--- a/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
+++ b/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
@@ -1,0 +1,330 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Peripheral.Cycles
+
+/-!
+# Multi-cycle block-permutation decompositions
+
+This file lifts the single-cycle block-permutation data packaged by
+`TNLean.Channel.Peripheral.Cycles` to the general multi-cycle form that
+underlies the asymptotic-image side of
+Wolf, *Quantum Channels & Operations*, Theorem 6.16.
+
+Concretely, Wolf Thm. 6.16 describes the asymptotic dynamics of a general
+trace-preserving positive Schwarz map `T` as a permutation of Wedderburn
+blocks, with each block transported by a unitary.  The permutation need not
+be a single cycle: in general it is a disjoint union of cycles with
+(possibly) distinct periods, one cycle per Wedderburn block-size class.
+
+The present file isolates the *multi-cycle* algebraic infrastructure, on top
+of the single-cycle corner-preservation proof pattern from
+`preserves_corner_pow_of_cyclic_decomp`.  The *existence direction* —
+that every TP positive Schwarz map admits such a decomposition on its
+asymptotic image — depends on Wolf Thm. 6.14 (Wedderburn decomposition of
+the fixed-point algebra, issues #27/#360) and is left to future work.
+
+## Main definitions
+
+* `MultiCycleDecomposition T` — bundled data for a multi-cycle
+  block-permutation decomposition of `T`: a finite family of cycles indexed
+  by `ι`, a per-cycle period `period : ι → ℕ` (each nonzero), a projection
+  family `P : (c : ι) → Fin (period c) → MatrixAlg D`, per-cycle cyclic
+  action `T (P c (k + 1)) = P c k`, and the multiplicative-domain
+  factorisations on each `P c k`.
+
+## Main results
+
+* `MultiCycleDecomposition.preserves_corner_pow_period` — single-cycle
+  corner preservation: `T^(period c)` preserves each corner
+  `P c k · M_D(ℂ) · P c k`.
+
+* `MultiCycleDecomposition.preserves_corner_pow_of_dvd` — common-period
+  corner preservation: whenever `period c ∣ N` for every cycle `c`,
+  `T^N` preserves every corner of the decomposition.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Thm. 6.16, §6.5]
+-/
+
+open scoped Matrix BigOperators
+open Matrix Finset
+
+variable {D : ℕ}
+
+/-- Bundled data for a **multi-cycle block-permutation decomposition** of a
+matrix endomorphism `T`.
+
+A `MultiCycleDecomposition T` records a finite family of cycles — one per
+element of the cycle-index type `ι` — together with:
+
+* a per-cycle `period c : ℕ` with `NeZero (period c)`;
+* a projection family `P c : Fin (period c) → MatrixAlg D` of orthogonal
+  projections (one family per cycle);
+* the cyclic action `T (P c (k + 1)) = P c k` *within* each cycle;
+* the multiplicative-domain factorisations `T (P c k * X) = T (P c k) * T X`
+  and `T (X * P c k) = T X * T (P c k)`.
+
+This generalises the single-cycle bundled data of
+`TNLean.Channel.Peripheral.Cycles.CycleStructure`: a `CycleStructure`
+corresponds to the special case `ι = Unit` (single cycle, period equal to
+`orderOf σ`).
+
+In Wolf's Thm. 6.16, the cycle-index `ι` runs over the equivalence classes
+of Wedderburn blocks that share both a common multiplicity and a common
+period under the block permutation.  The existence of this data on the
+asymptotic image of an arbitrary TP positive Schwarz map depends on the
+Wedderburn decomposition of the fixed-point algebra (Wolf Thm. 6.14) and is
+deferred. -/
+structure MultiCycleDecomposition.{u} (T : MatrixEnd D) where
+  /-- Finite index type for the cycles. -/
+  ι : Type u
+  /-- `ι` is finite. -/
+  [fintype : Fintype ι]
+  /-- `ι` has decidable equality. -/
+  [decidableEq : DecidableEq ι]
+  /-- The period of each cycle. -/
+  period : ι → ℕ
+  /-- Each cycle has nonzero period. -/
+  nePeriod : ∀ c : ι, NeZero (period c)
+  /-- The family of block projections inside each cycle. -/
+  P : (c : ι) → Fin (period c) → MatrixAlg D
+  /-- Each projection is an orthogonal projection. -/
+  isProj : ∀ (c : ι) (k : Fin (period c)), IsOrthogonalProjection (P c k)
+  /-- `T` cyclically permutes the projections inside each cycle. -/
+  cyclic : ∀ (c : ι) (k : Fin (period c)), T (P c (k + 1)) = P c k
+  /-- Each `P c k` lies in the left multiplicative domain of `T`. -/
+  mulLeft : ∀ (c : ι) (k : Fin (period c)) (X : MatrixAlg D),
+    T (P c k * X) = T (P c k) * T X
+  /-- Each `P c k` lies in the right multiplicative domain of `T`. -/
+  mulRight : ∀ (c : ι) (k : Fin (period c)) (X : MatrixAlg D),
+    T (X * P c k) = T X * T (P c k)
+
+namespace MultiCycleDecomposition
+
+attribute [instance] fintype decidableEq
+
+variable {T : MatrixEnd D}
+
+/-- Per-cycle period is nonzero. -/
+instance instNeZeroPeriod (M : MultiCycleDecomposition T) (c : M.ι) :
+    NeZero (M.period c) :=
+  M.nePeriod c
+
+section CyclicShift
+
+/-- The cyclic-shift index: an explicit `Fin m` representative of `k + n`,
+constructed from `⟨((k : ℕ) + n) % m, _⟩`.  Mirrors the `cyclicIndex` helper
+used inside `preserves_corner_pow_of_cyclic_decomp`. -/
+private def shiftIndex {m : ℕ} [NeZero m] (k : Fin m) (n : ℕ) : Fin m :=
+  ⟨((k : ℕ) + n) % m, Nat.mod_lt _ (Nat.pos_of_ne_zero (NeZero.ne m))⟩
+
+@[simp] private lemma shiftIndex_zero {m : ℕ} [NeZero m] (k : Fin m) :
+    shiftIndex k 0 = k := by
+  ext
+  simp only [shiftIndex, add_zero, Nat.mod_eq_of_lt k.is_lt, Fin.eta]
+
+private lemma shiftIndex_succ {m : ℕ} [NeZero m] (k : Fin m) (n : ℕ) :
+    shiftIndex k (n + 1) = shiftIndex k n + 1 := by
+  ext
+  change (((k : ℕ) + n) + 1) % m = ((((k : ℕ) + n) % m) + 1 % m) % m
+  exact Nat.add_mod ((k : ℕ) + n) 1 m
+
+@[simp] private lemma shiftIndex_period {m : ℕ} [NeZero m] (k : Fin m) :
+    shiftIndex k m = k := by
+  ext
+  change ((k : ℕ) + m) % m = k
+  rw [Nat.add_mod_right, Nat.mod_eq_of_lt k.is_lt]
+
+end CyclicShift
+
+section PreservesCornerHelper
+
+/-- Corner preservation is stable under taking powers. -/
+private lemma preservesCorner_pow {S : MatrixEnd D} {P : MatrixAlg D}
+    (hP : IsOrthogonalProjection P) (hPS : PreservesCorner P S) (n : ℕ) :
+    PreservesCorner P (S ^ n) := by
+  induction n with
+  | zero =>
+      intro X
+      have hIdem : P * P = P := hP.2
+      change P * ((1 : MatrixEnd D) (P * X * P)) * P = (1 : MatrixEnd D) (P * X * P)
+      simp only [Module.End.one_apply]
+      calc
+        P * (P * X * P) * P = (P * P) * X * (P * P) := by
+              simp only [Matrix.mul_assoc]
+        _ = P * X * P := by rw [hIdem]
+  | succ n ih =>
+      intro X
+      have hSform : S (P * X * P) = P * S (P * X * P) * P := (hPS X).symm
+      have : P * ((S ^ n) (S (P * X * P))) * P = (S ^ n) (S (P * X * P)) := by
+        have hS_corner_form :
+            S (P * X * P) = P * (P * S (P * X * P) * P) * P := by
+          calc
+            S (P * X * P) = P * S (P * X * P) * P := hSform
+            _ = (P * P) * S (P * X * P) * (P * P) := by
+                simp only [hP.2]
+            _ = P * (P * S (P * X * P) * P) * P := by
+                simp only [Matrix.mul_assoc]
+        calc
+          P * ((S ^ n) (S (P * X * P))) * P
+              = P * ((S ^ n) (P * S (P * X * P) * P)) * P := by rw [← hSform]
+          _ = (S ^ n) (P * S (P * X * P) * P) := ih (S (P * X * P))
+          _ = (S ^ n) (S (P * X * P)) := by rw [← hSform]
+      calc
+        P * ((S ^ (n + 1)) (P * X * P)) * P
+            = P * ((S ^ n) (S (P * X * P))) * P := by simp [pow_succ]
+        _ = (S ^ n) (S (P * X * P)) := this
+        _ = (S ^ (n + 1)) (P * X * P) := by simp [pow_succ]
+
+end PreservesCornerHelper
+
+section PerCycle
+
+/-- **Single-cycle corner preservation.**
+
+In cycle `c`, the channel's `period c`-th iterate preserves each corner
+`P c k · M_D(ℂ) · P c k`.  The proof follows the single-cycle proof
+pattern from `preserves_corner_pow_of_cyclic_decomp`, *without* the
+sum-to-one hypothesis on the sector projections (which is not available
+in the multi-cycle setting, where the per-cycle projections typically do
+not sum to the identity).
+
+Per Wolf Thm. 6.16 §6.5, this is the per-cycle restriction of the block
+permutation back to its own orbit: after `period c` applications of `T`,
+each cycle returns to itself. -/
+theorem preserves_corner_pow_period (M : MultiCycleDecomposition T)
+    (c : M.ι) (k : Fin (M.period c)) :
+    PreservesCorner (M.P c k) (T ^ M.period c) := by
+  -- main lemma: `T^n` applied to the `(k + n)`-shifted corner lands in the `k`-corner.
+  have hstep :
+      ∀ n : ℕ, ∀ (j : Fin (M.period c)) (X : MatrixAlg D),
+        (T ^ n) (M.P c (shiftIndex j n) * X * M.P c (shiftIndex j n)) =
+          M.P c j * ((T ^ n) X) * M.P c j := by
+    intro n
+    induction n with
+    | zero =>
+        intro j X
+        simp only [pow_zero, shiftIndex_zero, Module.End.one_apply]
+    | succ n ih =>
+        intro j X
+        calc
+          (T ^ (n + 1))
+              (M.P c (shiftIndex j (n + 1)) * X * M.P c (shiftIndex j (n + 1)))
+              = (T ^ n)
+                  (T (M.P c (shiftIndex j (n + 1)) * X * M.P c (shiftIndex j (n + 1)))) := by
+                  simp only [pow_succ, Module.End.mul_apply]
+          _ = (T ^ n)
+                (T (M.P c (shiftIndex j n + 1) * X * M.P c (shiftIndex j n + 1))) := by
+                  rw [shiftIndex_succ j n]
+          _ = (T ^ n) (M.P c (shiftIndex j n) * T X * M.P c (shiftIndex j n)) := by
+                  congr 1
+                  calc
+                    T (M.P c (shiftIndex j n + 1) * X * M.P c (shiftIndex j n + 1))
+                        = T (M.P c (shiftIndex j n + 1) * X) *
+                            T (M.P c (shiftIndex j n + 1)) := by
+                              exact M.mulRight c (shiftIndex j n + 1)
+                                (M.P c (shiftIndex j n + 1) * X)
+                    _ = (T (M.P c (shiftIndex j n + 1)) * T X) *
+                          T (M.P c (shiftIndex j n + 1)) := by
+                            rw [M.mulLeft c (shiftIndex j n + 1) X]
+                    _ = M.P c (shiftIndex j n) * T X * M.P c (shiftIndex j n) := by
+                            rw [M.cyclic c (shiftIndex j n)]
+          _ = M.P c j * ((T ^ n) (T X)) * M.P c j := ih j (T X)
+          _ = M.P c j * ((T ^ (n + 1)) X) * M.P c j := by
+                  simp only [pow_succ, Module.End.mul_apply]
+  -- specialise `hstep` at `n = period c` using `shiftIndex k (period c) = k`
+  intro X
+  have hmk : (T ^ M.period c) (M.P c k * X * M.P c k) =
+      M.P c k * ((T ^ M.period c) X) * M.P c k := by
+    simpa using hstep (M.period c) k X
+  calc
+    M.P c k * (T ^ M.period c) (M.P c k * X * M.P c k) * M.P c k
+        = M.P c k * (M.P c k * ((T ^ M.period c) X) * M.P c k) * M.P c k := by rw [hmk]
+    _ = (M.P c k * M.P c k) * ((T ^ M.period c) X) * (M.P c k * M.P c k) := by
+          simp only [Matrix.mul_assoc]
+    _ = M.P c k * ((T ^ M.period c) X) * M.P c k := by
+          simp only [(M.isProj c k).2, Matrix.mul_assoc]
+    _ = (T ^ M.period c) (M.P c k * X * M.P c k) := by rw [hmk]
+
+/-- **Common-period corner preservation.**
+
+Whenever `N` is divisible by every per-cycle period, `T^N` preserves each
+corner of the decomposition.
+
+In Wolf's Thm. 6.16, `N` is the global period (= LCM of per-cycle periods),
+after which the whole block permutation returns to the identity and the
+channel acts diagonally on each block. -/
+theorem preserves_corner_pow_of_dvd (M : MultiCycleDecomposition T)
+    {N : ℕ} (hN : ∀ c : M.ι, M.period c ∣ N)
+    (c : M.ι) (k : Fin (M.period c)) :
+    PreservesCorner (M.P c k) (T ^ N) := by
+  obtain ⟨q, hq⟩ := hN c
+  have hPowEq : (T ^ N) = (T ^ M.period c) ^ q := by
+    rw [← pow_mul, ← hq]
+  rw [hPowEq]
+  exact preservesCorner_pow (M.isProj c k)
+    (M.preserves_corner_pow_period c k) q
+
+end PerCycle
+
+section CycleStructureInterop
+
+/-- Total block-index type: `Σ c : ι, Fin (period c)`. -/
+abbrev Idx (M : MultiCycleDecomposition T) : Type _ :=
+  Σ c : M.ι, Fin (M.period c)
+
+/-- Flattened projection family indexed by `Idx`. -/
+def totalProj (M : MultiCycleDecomposition T) : M.Idx → MatrixAlg D :=
+  fun x => M.P x.1 x.2
+
+/-- Flattened permutation: per-cycle cyclic shift `k ↦ k + 1`, combined via
+`Equiv.Perm.sigmaCongrRight`. -/
+noncomputable def totalPerm (M : MultiCycleDecomposition T) :
+    Equiv.Perm M.Idx :=
+  Equiv.Perm.sigmaCongrRight (fun c : M.ι =>
+    { toFun := fun k => k + 1
+      invFun := fun k => k - 1
+      left_inv := by intro k; simp
+      right_inv := by intro k; simp })
+
+@[simp]
+lemma totalPerm_apply (M : MultiCycleDecomposition T) (x : M.Idx) :
+    M.totalPerm x = ⟨x.1, x.2 + 1⟩ := rfl
+
+/-- **Flattening construction.**  A multi-cycle decomposition gives a
+`CycleStructure` on the total block-index type
+`Σ c : M.ι, Fin (M.period c)`.
+
+The permutation is the sigma-product of per-cycle cyclic shifts; the
+projections are the flattened family; the cyclic action on the sigma
+index matches the per-cycle action on each `Fin (period c)`.
+
+This provides an assembly point: given a Wolf Thm. 6.16 Wedderburn-based
+existence result (currently blocked on issues #27/#360), the resulting
+`MultiCycleDecomposition` can be flattened to a `CycleStructure` for use
+with the existing single-cycle infrastructure in
+`TNLean.Channel.Peripheral.Cycles`. -/
+noncomputable def toCycleStructure (M : MultiCycleDecomposition T) :
+    CycleStructure T :=
+  CycleStructure.ofPermDecomp (T := T)
+    (ι := M.Idx) M.totalPerm M.totalProj
+    (by
+      rintro ⟨c, k⟩
+      exact M.isProj c k)
+    (by
+      rintro ⟨c, k⟩
+      change T (M.P c (k + 1)) = M.P c k
+      exact M.cyclic c k)
+    (by
+      rintro ⟨c, k⟩ X
+      exact M.mulLeft c k X)
+    (by
+      rintro ⟨c, k⟩ X
+      exact M.mulRight c k X)
+
+end CycleStructureInterop
+
+end MultiCycleDecomposition

--- a/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
+++ b/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
@@ -43,7 +43,7 @@ and is left to future work.
 
 ## Main results
 
-* `MultiCycleDecomposition.preserves_corner_pow_period` — single-cycle
+* `MultiCycleDecomposition.preserves_corner_pow_period` — per-cycle
   corner preservation: `T^(period c)` preserves each corner
   `P c k · M_D(ℂ) · P c k`.
 
@@ -306,7 +306,7 @@ index matches the per-cycle action on each `Fin (period c)`.
 This provides an assembly point: given a Wolf Thm. 6.16 Wedderburn-based
 existence result (currently blocked on issues #27/#360), the resulting
 `MultiCycleDecomposition` can be flattened to a `CycleStructure` for use
-with the existing single-cycle infrastructure in
+with the existing block-permutation infrastructure in
 `TNLean.Channel.Peripheral.Cycles`. -/
 noncomputable def toCycleStructure (M : MultiCycleDecomposition T) :
     CycleStructure T :=

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -302,9 +302,25 @@ The general irreducible case with period `h > 1` requires Wedderburn blocks
     Thm. 6.16 in its permutation-of-blocks form.
   - `CycleStructure.ofPermDecomp` — constructor from raw permutation data.
 
+* Multi-cycle block-permutation data (disjoint union of cycles with possibly
+  distinct periods) is packaged in `TNLean.Channel.Peripheral.MultiCycleDecomposition`:
+  - `MultiCycleDecomposition T` — bundled data: a finite cycle index `ι`, a
+    per-cycle period `period : ι → ℕ` (each nonzero), a projection family
+    `P : (c : ι) → Fin (period c) → M_D(ℂ)`, the per-cycle cyclic action
+    `T (P c (k + 1)) = P c k`, and the multiplicative-domain factorisations.
+  - `MultiCycleDecomposition.preserves_corner_pow_period` — per-cycle corner
+    preservation: `T ^ (period c)` preserves each corner `P c k · M_D(ℂ) · P c k`.
+  - `MultiCycleDecomposition.preserves_corner_pow_of_dvd` — common-period
+    corner preservation: whenever every `period c` divides `N`, `T ^ N`
+    preserves every corner.
+  - `MultiCycleDecomposition.toCycleStructure` — flattens a multi-cycle
+    decomposition to a single `CycleStructure` on the sigma index
+    `Σ c : ι, Fin (period c)`, using `Equiv.Perm.sigmaCongrRight` of
+    per-cycle cyclic shifts.
+
 * The remaining **existence direction** — that every trace-preserving positive
-  Schwarz map admits a `CycleStructure` on its asymptotic image, with the
-  blocks coming from the Wedderburn decomposition of the fixed-point algebra
+  Schwarz map admits a `MultiCycleDecomposition` on its asymptotic image, with
+  the cycles coming from the Wedderburn decomposition of the fixed-point algebra
   — depends on Wolf Thm. 6.14 (issues #27 / #360) and is left to future work.
 
 ---

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1089,6 +1089,92 @@ used later.
     expectation onto the adjoint fixed-point $*$-subalgebra.
 \end{theorem}
 
+\section{Multi-cycle block-permutation data (Wolf Thm.~6.16)}
+
+\begin{definition}[Single-cycle block-permutation data]
+    \label{def:cycle_structure}
+    \lean{CycleStructure}
+    \leanok
+    Let $T : \MN{D} \to \MN{D}$.  A \emph{single-cycle block-permutation
+    structure} for $T$ consists of a finite index set $\iota$, a family of
+    orthogonal projections $P_k \in \MN{D}$ for $k \in \iota$, and a
+    permutation $\sigma \in \mathrm{Sym}(\iota)$, such that
+    \[
+        T(P_{\sigma(k)}) = P_k,\quad
+        T(P_k X) = T(P_k)\,T(X),\quad
+        T(X P_k) = T(X)\,T(P_k)
+    \]
+    for every $k \in \iota$ and $X \in \MN{D}$.
+\end{definition}
+
+\begin{definition}[Multi-cycle block-permutation data]
+    \label{def:multi_cycle_decomposition}
+    \lean{MultiCycleDecomposition}
+    \leanok
+    A \emph{multi-cycle decomposition} of $T : \MN{D} \to \MN{D}$ records a
+    finite cycle index $\iota$, a per-cycle period
+    $m : \iota \to \mathbb{N}_{>0}$, a projection family
+    $P_{c,k} \in \MN{D}$ for $c \in \iota$ and $k \in \Fin{m(c)}$
+    consisting of orthogonal projections, together with the per-cycle
+    cyclic action
+    \[
+        T(P_{c,k+1}) = P_{c,k}\qquad (k \in \Fin{m(c)},\ c \in \iota)
+    \]
+    and the multiplicative-domain factorisations
+    $T(P_{c,k}\,X) = T(P_{c,k})\,T(X)$ and
+    $T(X\,P_{c,k}) = T(X)\,T(P_{c,k})$.
+\end{definition}
+
+\begin{theorem}[Per-cycle corner preservation]
+    \label{thm:multi_cycle_preserves_corner_pow_period}
+    \lean{MultiCycleDecomposition.preserves_corner_pow_period}
+    \leanok
+    \uses{def:multi_cycle_decomposition}
+    For every cycle $c \in \iota$ and index $k \in \Fin{m(c)}$, the
+    iterate $T^{m(c)}$ preserves the corner $P_{c,k}\,\MN{D}\,P_{c,k}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:multi_cycle_decomposition}
+    By induction on $n$, the $n$-th iterate $T^n$ sends
+    $P_{c,k+n}\,X\,P_{c,k+n}$ to $P_{c,k}\,T^n(X)\,P_{c,k}$, using the
+    multiplicative-domain factorisations and the cyclic action
+    $T(P_{c,j+1}) = P_{c,j}$ at each induction step.  Specialising to
+    $n = m(c)$ and using that the indices $k + m(c) = k$ in $\Fin{m(c)}$
+    yields corner preservation of $T^{m(c)}$.
+\end{proof}
+
+\begin{theorem}[Common-period corner preservation]
+    \label{thm:multi_cycle_preserves_corner_pow_of_dvd}
+    \lean{MultiCycleDecomposition.preserves_corner_pow_of_dvd}
+    \leanok
+    \uses{thm:multi_cycle_preserves_corner_pow_period}
+    If $N \in \mathbb{N}$ is divisible by every per-cycle period $m(c)$,
+    then $T^N$ preserves every corner $P_{c,k}\,\MN{D}\,P_{c,k}$ of the
+    decomposition.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:multi_cycle_preserves_corner_pow_period}
+    Write $N = m(c)\,q$.  Corner preservation is stable under taking
+    powers, so $T^N = (T^{m(c)})^q$ preserves each corner by
+    Theorem~\ref{thm:multi_cycle_preserves_corner_pow_period}.
+\end{proof}
+
+\begin{definition}[Flattening to single-cycle data]
+    \label{def:multi_cycle_to_cycle_structure}
+    \lean{MultiCycleDecomposition.toCycleStructure}
+    \leanok
+    \uses{def:multi_cycle_decomposition, def:cycle_structure}
+    A multi-cycle decomposition gives a single-cycle block-permutation
+    structure on the sigma index $\Sigma_{c \in \iota}\,\Fin{m(c)}$: the
+    permutation is the sigma-product of per-cycle cyclic shifts
+    $k \mapsto k+1$, the projections are $(c, k) \mapsto P_{c,k}$, and
+    the multiplicative-domain factorisations descend componentwise.
+\end{definition}
+
 \section{Peripheral eigenvalue group structure (Wolf Thm.~6.6)}
 
 \begin{lemma}[Peripheral eigenvectors are invertible]%

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1091,14 +1091,15 @@ used later.
 
 \section{Multi-cycle block-permutation data (Wolf Thm.~6.16)}
 
-\begin{definition}[Single-cycle block-permutation data]
+\begin{definition}[Block-permutation data]
     \label{def:cycle_structure}
     \lean{CycleStructure}
     \leanok
-    Let $T : \MN{D} \to \MN{D}$.  A \emph{single-cycle block-permutation
-    structure} for $T$ consists of a finite index set $\iota$, a family of
-    orthogonal projections $P_k \in \MN{D}$ for $k \in \iota$, and a
-    permutation $\sigma \in \mathrm{Sym}(\iota)$, such that
+    Let $T : \MN{D} \to \MN{D}$.  A \emph{block-permutation structure} for
+    $T$ consists of a finite index set $\iota$, a family of orthogonal
+    projections $P_k \in \MN{D}$ for $k \in \iota$, and a permutation
+    $\sigma \in \mathrm{Sym}(\iota)$ (not necessarily a single cycle — in
+    general $\sigma$ may have multiple disjoint cycles), such that
     \[
         T(P_{\sigma(k)}) = P_k,\quad
         T(P_k X) = T(P_k)\,T(X),\quad
@@ -1163,16 +1164,18 @@ used later.
     Theorem~\ref{thm:multi_cycle_preserves_corner_pow_period}.
 \end{proof}
 
-\begin{definition}[Flattening to single-cycle data]
+\begin{definition}[Flattening to single-index block-permutation data]
     \label{def:multi_cycle_to_cycle_structure}
     \lean{MultiCycleDecomposition.toCycleStructure}
     \leanok
     \uses{def:multi_cycle_decomposition, def:cycle_structure}
-    A multi-cycle decomposition gives a single-cycle block-permutation
+    A multi-cycle decomposition gives a single-index block-permutation
     structure on the sigma index $\Sigma_{c \in \iota}\,\Fin{m(c)}$: the
     permutation is the sigma-product of per-cycle cyclic shifts
-    $k \mapsto k+1$, the projections are $(c, k) \mapsto P_{c,k}$, and
-    the multiplicative-domain factorisations descend componentwise.
+    $k \mapsto k+1$ (whose cycle decomposition has one cycle per
+    $c \in \iota$), the projections are $(c, k) \mapsto P_{c,k}$, and the
+    multiplicative-domain factorisations descend componentwise.  The
+    resulting map forgets the explicit cycle-indexing.
 \end{definition}
 
 \section{Peripheral eigenvalue group structure (Wolf Thm.~6.6)}


### PR DESCRIPTION
### Motivation

- Continues formalization of Wolf Ch. 6 peripheral-spectrum theory, extending the existing irreducible / Schwarz-map cyclic-sector framework to Wolf's full Theorem 6.16 (multi-cycle block-permutation structure). See LionSR/QICLean#40.
- The single-cycle case was already covered by `TNLean/Channel/Peripheral/CyclicDecomposition.lean`; this PR introduces the bundled data needed for the general multi-cycle statement.

### Description

- Adds `TNLean/Channel/Peripheral/MultiCycleDecomposition.lean` (+330 lines) introducing `MultiCycleDecomposition T` — bundled data for disjoint unions of block-permutation cycles (per-cycle periods, projection families, cyclic action, and multiplicative-domain factorisations).
- Proves per-cycle corner preservation via `T`-power iterates (`preserves_corner_pow_period`) and the common-period variant (`preserves_corner_pow_of_dvd`).
- Provides `MultiCycleDecomposition.toCycleStructure`, a flattening map (via `Equiv.Perm.sigmaCongrRight`) to reuse the existing single-permutation `CycleStructure` machinery.
- Wires the new module into the public import surface in `TNLean.lean` and updates `TNLean/Channel/WolfChapter6Index.lean` plus `blueprint/src/chapter/ch06_spectral.tex` to reference the new multi-cycle statements.
- The existence direction remains blocked on Wolf Thm 6.14 (tracked by LionSR/QICLean#39 / LionSR/QICLean#126).

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/QICLean#40

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR mostly adds a new Lean module and documentation, with minimal impact beyond a new import and index/blueprint references. Main risk is proof/compilation breakage from the new definitions and lemmas interacting with existing `CycleStructure` utilities.
> 
> **Overview**
> Adds a new `MultiCycleDecomposition` bundle to model *disjoint unions of block-permutation cycles* (per-cycle periods and projection families) for the Wolf Thm. 6.16 asymptotic-image formalization.
> 
> Proves per-cycle and common-period corner preservation lemmas (`preserves_corner_pow_period`, `preserves_corner_pow_of_dvd`) and provides `toCycleStructure` to flatten the multi-cycle data into the existing single-index `CycleStructure` machinery.
> 
> Wires the new module into the public import surface (`TNLean.lean`) and updates the Chapter 6 index and blueprint text to document the new multi-cycle statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7018fadbe84520c5c73f91e1d15d98e4d76467ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->