### PR TITLE
refactor(MPS/CanonicalForm): expose compression isometry φ (#618 Stage 2)

### DIFF
--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -175,7 +175,6 @@ noncomputable def cornerCompressionLinearMap
     (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
     (P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ)
     (hP0 : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
-    (_hn : (n : ℂ) = Matrix.trace P)
     (hP_decomp : P = Umat * Pdiag * Umatᴴ)
     (hPdiag_back : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag)
     (hU'U : Umatᴴ * Umat = 1) :
@@ -326,7 +325,6 @@ noncomputable def cornerCompressionLinearEquiv
     (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
     (P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ)
     (hP0 : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
-    (hn : (n : ℂ) = Matrix.trace P)
     (hP_decomp : P = Umat * Pdiag * Umatᴴ)
     (hPdiag_UPU : Pdiag = Umatᴴ * P * Umat)
     (hPdiag_std : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0)
@@ -334,7 +332,7 @@ noncomputable def cornerCompressionLinearEquiv
     (hU'U : Umatᴴ * Umat = 1) (hUU : Umat * Umatᴴ = 1) :
     Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
   let toLM :=
-    cornerCompressionLinearMap (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0 hn
+    cornerCompressionLinearMap (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0
       hP_decomp hPdiag_back hU'U
   { toLM with
     invFun := fun X => cornerCompressionInvFun Umat eST eS X.1
@@ -349,20 +347,19 @@ noncomputable def cornerCompressionLinearEquiv
       exact cornerCompressionExpand_invFun (P := P) (Pdiag := Pdiag) Umat eST eS P0
         hP0 hPdiag_UPU hPdiag_std hU'U hUU X }
 
-@[simp] lemma cornerCompressionLinearEquiv_apply_coe
+lemma cornerCompressionLinearEquiv_apply_coe
     {D n : ℕ} (P Pdiag Umat : MatrixAlg D)
     {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
     (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
     (P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ)
     (hP0 : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
-    (hn : (n : ℂ) = Matrix.trace P)
     (hP_decomp : P = Umat * Pdiag * Umatᴴ)
     (hPdiag_UPU : Pdiag = Umatᴴ * P * Umat)
     (hPdiag_std : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0)
     (hPdiag_back : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag)
     (hU'U : Umatᴴ * Umat = 1) (hUU : Umat * Umatᴴ = 1)
     (M : Matrix (Fin n) (Fin n) ℂ) :
-    ((cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0 hn
+    ((cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0
         hP_decomp hPdiag_UPU hPdiag_std hPdiag_back hU'U hUU M : cornerSubmodule P) :
       MatrixAlg D) =
       cornerCompressionExpand Umat eST eS M := rfl
@@ -489,7 +486,7 @@ private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
   -- Package the compression as a `LinearEquiv` using the shared
   -- `cornerCompressionLinearEquiv` builder.
   exact cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0
-    rfl htrace hP_decomp rfl hPdiag_std hPdiag_back hU'U hUU
+    rfl hP_decomp rfl hPdiag_std hPdiag_back hU'U hUU
 
 /-- The rank of an orthogonal projection `P : M_D(ℂ)`, defined so that
 `cornerSubmoduleMatrixLinearEquiv` produces an isometry `M_{cornerRank P hP}(ℂ) ≃ₗ

--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -347,23 +347,6 @@ noncomputable def cornerCompressionLinearEquiv
       exact cornerCompressionExpand_invFun (P := P) (Pdiag := Pdiag) Umat eST eS P0
         hP0 hPdiag_UPU hPdiag_std hU'U hUU X }
 
-lemma cornerCompressionLinearEquiv_apply_coe
-    {D n : ℕ} (P Pdiag Umat : MatrixAlg D)
-    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
-    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
-    (P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ)
-    (hP0 : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
-    (hP_decomp : P = Umat * Pdiag * Umatᴴ)
-    (hPdiag_UPU : Pdiag = Umatᴴ * P * Umat)
-    (hPdiag_std : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0)
-    (hPdiag_back : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag)
-    (hU'U : Umatᴴ * Umat = 1) (hUU : Umat * Umatᴴ = 1)
-    (M : Matrix (Fin n) (Fin n) ℂ) :
-    ((cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0
-        hP_decomp hPdiag_UPU hPdiag_std hPdiag_back hU'U hUU M : cornerSubmodule P) :
-      MatrixAlg D) =
-      cornerCompressionExpand Umat eST eS M := rfl
-
 /-- **Compression isometry for a projection (existence form).**
 
 Given an orthogonal projection `P : M_D(ℂ)` of rank `n = trace P`, there is a linear

--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -89,6 +89,108 @@ def IsIrreducibleOnCorner {D : ℕ} (P : MatrixAlg D) (T : MatrixEnd D) : Prop :
     PreservesCorner Q T →
     Q = 0 ∨ Q = P
 
+/-- Shared ambient compression map used to represent `M_n(ℂ)` inside a projection corner. -/
+noncomputable def cornerCompressionExpand
+    {D n : ℕ} (Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n) :
+    Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] MatrixAlg D :=
+  let fromBlocksTL : Matrix S S ℂ →ₗ[ℂ] Matrix (S ⊕ T) (S ⊕ T) ℂ :=
+    { toFun := fun M => Matrix.fromBlocks M 0 0 0
+      map_add' := fun M₁ M₂ => by
+        ext i j; cases i <;> cases j <;> simp [Matrix.fromBlocks, Matrix.add_apply]
+      map_smul' := fun c M => by
+        ext i j; cases i <;> cases j <;> simp [Matrix.fromBlocks, Matrix.smul_apply] }
+  let conjUmat : MatrixAlg D →ₗ[ℂ] MatrixAlg D :=
+    { toFun := fun Y => Umat * Y * Umatᴴ
+      map_add' := fun Y₁ Y₂ => by simp [Matrix.mul_add, Matrix.add_mul]
+      map_smul' := fun c Y => by simp }
+  conjUmat ∘ₗ
+    (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm).toLinearMap ∘ₗ
+    fromBlocksTL ∘ₗ
+    (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm).toLinearMap
+
+lemma cornerCompressionExpand_apply
+    {D n : ℕ} (Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
+    (M : Matrix (Fin n) (Fin n) ℂ) :
+    cornerCompressionExpand Umat eST eS M =
+      Umat *
+        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
+          (Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
+            (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) * Umatᴴ := rfl
+
+lemma cornerCompressionExpand_mem
+    {D n : ℕ} (P Pdiag Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
+    (P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ)
+    (hP0 : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
+    (hP_decomp : P = Umat * Pdiag * Umatᴴ)
+    (hPdiag_back : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag)
+    (hU'U : Umatᴴ * Umat = 1) :
+    ∀ M : Matrix (Fin n) (Fin n) ℂ,
+      P * cornerCompressionExpand Umat eST eS M * P =
+        cornerCompressionExpand Umat eST eS M := by
+  intro M
+  rw [cornerCompressionExpand_apply Umat eST eS M]
+  set Y_ST : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
+    Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
+      (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)
+  set Y_D : MatrixAlg D := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST
+  have hP0_Y : P0 * Y_ST * P0 = Y_ST := by
+    rw [hP0]
+    simp [Y_ST, Matrix.fromBlocks_multiply]
+  have hPdiag_Y : Pdiag * Y_D * Pdiag = Y_D := by
+    calc
+      Pdiag * Y_D * Pdiag
+          = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 *
+              Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST *
+              Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 := by
+            rw [hPdiag_back]
+      _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (P0 * Y_ST) *
+              Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 := by
+            rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+              eST.symm eST.symm eST.symm P0 Y_ST]
+      _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (P0 * Y_ST * P0) := by
+            rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+              eST.symm eST.symm eST.symm (P0 * Y_ST) P0]
+      _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST := by rw [hP0_Y]
+      _ = Y_D := rfl
+  change P * (Umat * Y_D * Umatᴴ) * P = Umat * Y_D * Umatᴴ
+  calc
+    P * (Umat * Y_D * Umatᴴ) * P
+        = (Umat * Pdiag * Umatᴴ) * (Umat * Y_D * Umatᴴ) *
+            (Umat * Pdiag * Umatᴴ) := by rw [← hP_decomp]
+    _ = Umat * (Pdiag * (Umatᴴ * Umat) * Y_D * (Umatᴴ * Umat) * Pdiag) * Umatᴴ := by
+          simp [Matrix.mul_assoc]
+    _ = Umat * (Pdiag * Y_D * Pdiag) * Umatᴴ := by rw [hU'U]; simp
+    _ = Umat * Y_D * Umatᴴ := by rw [hPdiag_Y]
+
+/-- Shared corner-compression builder landing in `cornerSubmodule P`. -/
+noncomputable def cornerCompressionLinearMap
+    {D n : ℕ} (P Pdiag Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
+    (P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ)
+    (hP0 : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
+    (_hn : (n : ℂ) = Matrix.trace P)
+    (hP_decomp : P = Umat * Pdiag * Umatᴴ)
+    (hPdiag_back : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag)
+    (hU'U : Umatᴴ * Umat = 1) :
+    Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] cornerSubmodule P :=
+  { toFun := fun M =>
+      ⟨cornerCompressionExpand Umat eST eS M,
+        cornerCompressionExpand_mem (P := P) (Pdiag := Pdiag) Umat eST eS P0
+          hP0 hP_decomp hPdiag_back hU'U M⟩
+    map_add' := fun M₁ M₂ => by
+      apply Subtype.ext
+      exact (cornerCompressionExpand Umat eST eS).map_add M₁ M₂
+    map_smul' := fun c M => by
+      apply Subtype.ext
+      exact (cornerCompressionExpand Umat eST eS).map_smul c M }
+
 /-- **Compression isometry for a projection (existence form).**
 
 Given an orthogonal projection `P : M_D(ℂ)` of rank `n = trace P`, there is a linear
@@ -194,66 +296,31 @@ private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
             · subst h; simpa [p, P0] using hfT t
             · simp [P0, Matrix.fromBlocks_apply₂₂, h]
   -- Forward and inverse maps for the compression equiv.
-  let toFun : Matrix (Fin n) (Fin n) ℂ → MatrixAlg D := fun M =>
-    Umat *
-      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
-        (Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
-          (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) * Umatᴴ
+  have hP_decomp : P = Umat * Pdiag * Umatᴴ := by
+    change P = Umat * (Umatᴴ * P * Umat) * Umatᴴ
+    calc
+      P = (Umat * Umatᴴ) * P * (Umat * Umatᴴ) := by rw [hUU]; simp
+      _ = Umat * (Umatᴴ * P * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
+  have hPdiag_back :
+      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag := by
+    have h := congrArg
+      (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm) hPdiag_std
+    have hid := (Matrix.reindexLinearEquiv_comp_apply (R := ℂ) (A := ℂ)
+      eST eST eST.symm eST.symm Pdiag)
+    rw [Equiv.self_trans_symm, Matrix.reindexLinearEquiv_refl_refl,
+      LinearEquiv.refl_apply] at hid
+    exact h.symm.trans hid
+  have hP0_def : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ) := rfl
+  let toFun : Matrix (Fin n) (Fin n) ℂ → MatrixAlg D :=
+    cornerCompressionExpand Umat eST eS
   let invFun : MatrixAlg D → Matrix (Fin n) (Fin n) ℂ := fun X =>
     Matrix.reindexLinearEquiv ℂ ℂ eS eS
       ((Matrix.reindexLinearEquiv ℂ ℂ eST eST (Umatᴴ * X * Umat)).toBlocks₁₁)
   -- `toFun` lands in the corner submodule.
   have hFwdMem : ∀ M, P * toFun M * P = toFun M := by
     intro M
-    -- Write `P = Umat * Pdiag * Umatᴴ`.
-    have hP_decomp : P = Umat * Pdiag * Umatᴴ := by
-      change P = Umat * (Umatᴴ * P * Umat) * Umatᴴ
-      calc
-        P = (Umat * Umatᴴ) * P * (Umat * Umatᴴ) := by rw [hUU]; simp
-        _ = Umat * (Umatᴴ * P * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
-    -- Let `Y_D` be the reindexed block matrix (before conjugation by `Umat`).
-    set Y_ST : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-      Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
-        (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) with hY_ST_def
-    set Y_D : MatrixAlg D := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST with hY_D_def
-    have hP0_Y : P0 * Y_ST * P0 = Y_ST := by
-      simp [P0, Y_ST, Matrix.fromBlocks_multiply]
-    -- Transport the corner relation back through the reindex.
-    have hPdiag_Y : Pdiag * Y_D * Pdiag = Y_D := by
-      have hPdiag_back :
-          Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag := by
-        have h := congrArg
-          (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm) hPdiag_std
-        have hid := (Matrix.reindexLinearEquiv_comp_apply (R := ℂ) (A := ℂ)
-          eST eST eST.symm eST.symm Pdiag)
-        rw [Equiv.self_trans_symm, Matrix.reindexLinearEquiv_refl_refl,
-          LinearEquiv.refl_apply] at hid
-        exact h.symm.trans hid
-      calc
-        Pdiag * Y_D * Pdiag
-            = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 *
-                Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST *
-                Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 := by
-              rw [hPdiag_back]
-        _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (P0 * Y_ST) *
-                Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 := by
-              rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-                eST.symm eST.symm eST.symm P0 Y_ST]
-        _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (P0 * Y_ST * P0) := by
-              rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-                eST.symm eST.symm eST.symm (P0 * Y_ST) P0]
-        _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST := by rw [hP0_Y]
-        _ = Y_D := rfl
-    -- Lift to `P * (Umat * Y_D * Umatᴴ) * P = Umat * Y_D * Umatᴴ`.
-    change P * (Umat * Y_D * Umatᴴ) * P = Umat * Y_D * Umatᴴ
-    calc
-      P * (Umat * Y_D * Umatᴴ) * P
-          = (Umat * Pdiag * Umatᴴ) * (Umat * Y_D * Umatᴴ) *
-              (Umat * Pdiag * Umatᴴ) := by rw [← hP_decomp]
-      _ = Umat * (Pdiag * (Umatᴴ * Umat) * Y_D * (Umatᴴ * Umat) * Pdiag) * Umatᴴ := by
-            simp [Matrix.mul_assoc]
-      _ = Umat * (Pdiag * Y_D * Pdiag) * Umatᴴ := by rw [hU'U]; simp
-      _ = Umat * Y_D * Umatᴴ := by rw [hPdiag_Y]
+    exact cornerCompressionExpand_mem (P := P) (Pdiag := Pdiag) Umat eST eS P0
+      hP0_def hP_decomp hPdiag_back hU'U M
   -- Compute `invFun (toFun M) = M`.
   have hLeftInv : ∀ M, invFun (toFun M) = M := by
     intro M
@@ -277,6 +344,7 @@ private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
       rfl
     change invFun (toFun M) = M
     simp only [invFun, toFun]
+    rw [cornerCompressionExpand_apply Umat eST eS M]
     rw [show Umatᴴ * (Umat *
         Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST * Umatᴴ) * Umat = Y_D from by
           simpa [hY_D_def] using hcollapse]
@@ -342,6 +410,7 @@ private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
       exact (hkey.trans (Matrix.fromBlocks_toBlocks Y_ST)).symm
     change toFun (invFun X.1) = X.1
     simp only [invFun, toFun]
+    rw [cornerCompressionExpand_apply Umat eST eS (invFun X.1)]
     -- invFun X.1 = reindex eS eS Y_ST.toBlocks₁₁
     -- toFun (reindex eS eS Y_ST.toBlocks₁₁) = Umat * reindex eST.symm eST.symm
     --   (fromBlocks (reindex eS.symm eS.symm (reindex eS eS Y_ST.toBlocks₁₁)) 0 0 0) * Umatᴴ

--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -191,6 +191,182 @@ noncomputable def cornerCompressionLinearMap
       apply Subtype.ext
       exact (cornerCompressionExpand Umat eST eS).map_smul c M }
 
+/-- Inverse direction of the shared corner compression:
+`X ↦ reindex eS eS ((reindex eST eST (Umatᴴ * X * Umat)).toBlocks₁₁)`.
+Together with `cornerCompressionExpand` this pairs up into the `LinearEquiv`
+`cornerCompressionLinearEquiv`. -/
+noncomputable def cornerCompressionInvFun
+    {D n : ℕ} (Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n) :
+    MatrixAlg D → Matrix (Fin n) (Fin n) ℂ := fun X =>
+  Matrix.reindexLinearEquiv ℂ ℂ eS eS
+    ((Matrix.reindexLinearEquiv ℂ ℂ eST eST (Umatᴴ * X * Umat)).toBlocks₁₁)
+
+lemma cornerCompressionInvFun_expand
+    {D n : ℕ} (Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
+    (hU'U : Umatᴴ * Umat = 1)
+    (M : Matrix (Fin n) (Fin n) ℂ) :
+    cornerCompressionInvFun Umat eST eS (cornerCompressionExpand Umat eST eS M) = M := by
+  set Y_ST : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
+    Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
+      (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)
+  set Y_D : MatrixAlg D := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST with hY_D_def
+  have hcollapse : Umatᴴ * (Umat * Y_D * Umatᴴ) * Umat = Y_D := by
+    calc
+      Umatᴴ * (Umat * Y_D * Umatᴴ) * Umat
+          = (Umatᴴ * Umat) * Y_D * (Umatᴴ * Umat) := by simp [Matrix.mul_assoc]
+      _ = Y_D := by rw [hU'U]; simp
+  have hreindex_Y :
+      Matrix.reindexLinearEquiv ℂ ℂ eST eST Y_D = Y_ST := by
+    change Matrix.reindexLinearEquiv ℂ ℂ eST eST
+        (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST) = Y_ST
+    rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.symm_trans_self,
+      Matrix.reindexLinearEquiv_refl_refl]
+    rfl
+  simp only [cornerCompressionInvFun]
+  rw [cornerCompressionExpand_apply Umat eST eS M]
+  rw [show Umatᴴ * (Umat *
+      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST * Umatᴴ) * Umat = Y_D from by
+        simpa [hY_D_def] using hcollapse]
+  rw [hreindex_Y]
+  have htoBlocks :
+      Y_ST.toBlocks₁₁ = Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M := by
+    simp [Y_ST, Matrix.toBlocks_fromBlocks₁₁]
+  rw [htoBlocks]
+  change Matrix.reindexLinearEquiv ℂ ℂ eS eS
+    (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M) = M
+  rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.symm_trans_self,
+    Matrix.reindexLinearEquiv_refl_refl]
+  rfl
+
+lemma cornerCompressionExpand_invFun
+    {D n : ℕ} (P Pdiag Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
+    (P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ)
+    (hP0 : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
+    (hPdiag_UPU : Pdiag = Umatᴴ * P * Umat)
+    (hPdiag_std : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0)
+    (_hU'U : Umatᴴ * Umat = 1) (hUU : Umat * Umatᴴ = 1)
+    (X : cornerSubmodule P) :
+    cornerCompressionExpand Umat eST eS (cornerCompressionInvFun Umat eST eS X.1) = X.1 := by
+  set Y : MatrixAlg D := Umatᴴ * X.1 * Umat
+  set Y_ST : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
+    Matrix.reindexLinearEquiv ℂ ℂ eST eST Y
+  have hPXP : P * X.1 * P = X.1 := X.2
+  have hPdiagY : Pdiag * Y * Pdiag = Y := by
+    rw [hPdiag_UPU]
+    change (Umatᴴ * P * Umat) * (Umatᴴ * X.1 * Umat) * (Umatᴴ * P * Umat) =
+      Umatᴴ * X.1 * Umat
+    calc
+      (Umatᴴ * P * Umat) * (Umatᴴ * X.1 * Umat) * (Umatᴴ * P * Umat)
+          = Umatᴴ * (P * (Umat * Umatᴴ) * X.1 * (Umat * Umatᴴ) * P) * Umat := by
+              simp [Matrix.mul_assoc]
+      _ = Umatᴴ * (P * X.1 * P) * Umat := by rw [hUU]; simp
+      _ = Umatᴴ * X.1 * Umat := by rw [hPXP]
+  have hP0_YST : P0 * Y_ST * P0 = Y_ST := by
+    have hp0_eq : P0 = Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag := hPdiag_std.symm
+    rw [hp0_eq]
+    change Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag *
+        Matrix.reindexLinearEquiv ℂ ℂ eST eST Y *
+        Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag =
+      Matrix.reindexLinearEquiv ℂ ℂ eST eST Y
+    rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+          eST eST eST Pdiag Y,
+        Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+          eST eST eST (Pdiag * Y) Pdiag, hPdiagY]
+  have hY_ST_block :
+      Y_ST = Matrix.fromBlocks Y_ST.toBlocks₁₁ (0 : Matrix S T ℂ)
+        (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) := by
+    have hkey : Matrix.fromBlocks Y_ST.toBlocks₁₁ (0 : Matrix S T ℂ)
+        (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) =
+        Matrix.fromBlocks Y_ST.toBlocks₁₁ Y_ST.toBlocks₁₂
+          Y_ST.toBlocks₂₁ Y_ST.toBlocks₂₂ := by
+      rw [(Matrix.fromBlocks_toBlocks Y_ST).symm] at hP0_YST
+      simp only [hP0, Matrix.fromBlocks_multiply, Matrix.one_mul, Matrix.mul_one,
+        Matrix.zero_mul, Matrix.mul_zero, add_zero] at hP0_YST
+      exact hP0_YST
+    exact (hkey.trans (Matrix.fromBlocks_toBlocks Y_ST)).symm
+  simp only [cornerCompressionInvFun]
+  rw [cornerCompressionExpand_apply Umat eST eS]
+  have hround :
+      Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm
+        (Matrix.reindexLinearEquiv ℂ ℂ eS eS Y_ST.toBlocks₁₁) = Y_ST.toBlocks₁₁ := by
+    rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
+      Matrix.reindexLinearEquiv_refl_refl]
+    rfl
+  rw [hround]
+  rw [show Matrix.fromBlocks Y_ST.toBlocks₁₁ (0 : Matrix S T ℂ)
+        (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) = Y_ST from hY_ST_block.symm]
+  have hround₂ :
+      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST = Y := by
+    change Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
+      (Matrix.reindexLinearEquiv ℂ ℂ eST eST Y) = Y
+    rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
+      Matrix.reindexLinearEquiv_refl_refl]
+    rfl
+  rw [hround₂]
+  change Umat * (Umatᴴ * X.1 * Umat) * Umatᴴ = X.1
+  calc
+    Umat * (Umatᴴ * X.1 * Umat) * Umatᴴ
+        = (Umat * Umatᴴ) * X.1 * (Umat * Umatᴴ) := by simp [Matrix.mul_assoc]
+    _ = X.1 := by rw [hUU]; simp
+
+/-- Shared corner-compression **linear equivalence**, promoting
+`cornerCompressionLinearMap` to `Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P`
+using `cornerCompressionInvFun` as the inverse.  The forward direction is the
+linear map built from the spectral diagonalisation of `P`; the inverse strips
+the ambient unitary conjugation and extracts the top-left `S × S` block. -/
+noncomputable def cornerCompressionLinearEquiv
+    {D n : ℕ} (P Pdiag Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
+    (P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ)
+    (hP0 : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
+    (hn : (n : ℂ) = Matrix.trace P)
+    (hP_decomp : P = Umat * Pdiag * Umatᴴ)
+    (hPdiag_UPU : Pdiag = Umatᴴ * P * Umat)
+    (hPdiag_std : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0)
+    (hPdiag_back : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag)
+    (hU'U : Umatᴴ * Umat = 1) (hUU : Umat * Umatᴴ = 1) :
+    Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
+  let toLM :=
+    cornerCompressionLinearMap (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0 hn
+      hP_decomp hPdiag_back hU'U
+  { toLM with
+    invFun := fun X => cornerCompressionInvFun Umat eST eS X.1
+    left_inv := fun M => by
+      change cornerCompressionInvFun Umat eST eS
+        (cornerCompressionExpand Umat eST eS M) = M
+      exact cornerCompressionInvFun_expand Umat eST eS hU'U M
+    right_inv := fun X => by
+      apply Subtype.ext
+      change cornerCompressionExpand Umat eST eS
+        (cornerCompressionInvFun Umat eST eS X.1) = X.1
+      exact cornerCompressionExpand_invFun (P := P) (Pdiag := Pdiag) Umat eST eS P0
+        hP0 hPdiag_UPU hPdiag_std hU'U hUU X }
+
+@[simp] lemma cornerCompressionLinearEquiv_apply_coe
+    {D n : ℕ} (P Pdiag Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
+    (P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ)
+    (hP0 : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
+    (hn : (n : ℂ) = Matrix.trace P)
+    (hP_decomp : P = Umat * Pdiag * Umatᴴ)
+    (hPdiag_UPU : Pdiag = Umatᴴ * P * Umat)
+    (hPdiag_std : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0)
+    (hPdiag_back : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag)
+    (hU'U : Umatᴴ * Umat = 1) (hUU : Umat * Umatᴴ = 1)
+    (M : Matrix (Fin n) (Fin n) ℂ) :
+    ((cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0 hn
+        hP_decomp hPdiag_UPU hPdiag_std hPdiag_back hU'U hUU M : cornerSubmodule P) :
+      MatrixAlg D) =
+      cornerCompressionExpand Umat eST eS M := rfl
+
 /-- **Compression isometry for a projection (existence form).**
 
 Given an orthogonal projection `P : M_D(ℂ)` of rank `n = trace P`, there is a linear
@@ -310,166 +486,10 @@ private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
     rw [Equiv.self_trans_symm, Matrix.reindexLinearEquiv_refl_refl,
       LinearEquiv.refl_apply] at hid
     exact h.symm.trans hid
-  have hP0_def : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ) := rfl
-  let toFun : Matrix (Fin n) (Fin n) ℂ → MatrixAlg D :=
-    cornerCompressionExpand Umat eST eS
-  let invFun : MatrixAlg D → Matrix (Fin n) (Fin n) ℂ := fun X =>
-    Matrix.reindexLinearEquiv ℂ ℂ eS eS
-      ((Matrix.reindexLinearEquiv ℂ ℂ eST eST (Umatᴴ * X * Umat)).toBlocks₁₁)
-  -- `toFun` lands in the corner submodule.
-  have hFwdMem : ∀ M, P * toFun M * P = toFun M := by
-    intro M
-    exact cornerCompressionExpand_mem (P := P) (Pdiag := Pdiag) Umat eST eS P0
-      hP0_def hP_decomp hPdiag_back hU'U M
-  -- Compute `invFun (toFun M) = M`.
-  have hLeftInv : ∀ M, invFun (toFun M) = M := by
-    intro M
-    set Y_ST : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-      Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
-        (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) with hY_ST_def
-    set Y_D : MatrixAlg D := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST with hY_D_def
-    -- `Umatᴴ * (Umat * Y_D * Umatᴴ) * Umat = Y_D`.
-    have hcollapse : Umatᴴ * (Umat * Y_D * Umatᴴ) * Umat = Y_D := by
-      calc
-        Umatᴴ * (Umat * Y_D * Umatᴴ) * Umat
-            = (Umatᴴ * Umat) * Y_D * (Umatᴴ * Umat) := by simp [Matrix.mul_assoc]
-        _ = Y_D := by rw [hU'U]; simp
-    -- `reindex eST eST Y_D = Y_ST`.
-    have hreindex_Y :
-        Matrix.reindexLinearEquiv ℂ ℂ eST eST Y_D = Y_ST := by
-      change Matrix.reindexLinearEquiv ℂ ℂ eST eST
-          (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST) = Y_ST
-      rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.symm_trans_self,
-        Matrix.reindexLinearEquiv_refl_refl]
-      rfl
-    change invFun (toFun M) = M
-    simp only [invFun, toFun]
-    rw [cornerCompressionExpand_apply Umat eST eS M]
-    rw [show Umatᴴ * (Umat *
-        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST * Umatᴴ) * Umat = Y_D from by
-          simpa [hY_D_def] using hcollapse]
-    rw [hreindex_Y]
-    -- `Y_ST.toBlocks₁₁ = reindex eS.symm eS.symm M`.
-    have htoBlocks :
-        Y_ST.toBlocks₁₁ = Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M := by
-      simp [Y_ST, Matrix.toBlocks_fromBlocks₁₁]
-    rw [htoBlocks]
-    -- `reindex eS eS (reindex eS.symm eS.symm M) = M`.
-    change Matrix.reindexLinearEquiv ℂ ℂ eS eS
-      (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M) = M
-    rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.symm_trans_self,
-      Matrix.reindexLinearEquiv_refl_refl]
-    rfl
-  -- Compute `toFun (invFun X) = X` for `X` in the corner.
-  have hRightInv : ∀ (X : cornerSubmodule P), (⟨toFun (invFun X.1), hFwdMem _⟩ : cornerSubmodule P)
-      = X := by
-    intro X
-    apply Subtype.ext
-    change toFun (invFun X.1) = X.1
-    set Y : MatrixAlg D := Umatᴴ * X.1 * Umat with hY_def
-    set Y_ST : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-      Matrix.reindexLinearEquiv ℂ ℂ eST eST Y with hY_ST_def
-    -- Corner relation for `X.1`.
-    have hPXP : P * X.1 * P = X.1 := by
-      have hX_mem : P * X.1 * P = X.1 := X.2
-      exact hX_mem
-    -- Pdiag * Y * Pdiag = Y.
-    have hPdiagY : Pdiag * Y * Pdiag = Y := by
-      change (Umatᴴ * P * Umat) * (Umatᴴ * X.1 * Umat) * (Umatᴴ * P * Umat) =
-        Umatᴴ * X.1 * Umat
-      calc
-        (Umatᴴ * P * Umat) * (Umatᴴ * X.1 * Umat) * (Umatᴴ * P * Umat)
-            = Umatᴴ * (P * (Umat * Umatᴴ) * X.1 * (Umat * Umatᴴ) * P) * Umat := by
-                simp [Matrix.mul_assoc]
-        _ = Umatᴴ * (P * X.1 * P) * Umat := by rw [hUU]; simp
-        _ = Umatᴴ * X.1 * Umat := by rw [hPXP]
-    -- P0 * Y_ST * P0 = Y_ST.
-    have hP0_YST : P0 * Y_ST * P0 = Y_ST := by
-      have hp0_eq : P0 = Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag := hPdiag_std.symm
-      rw [hp0_eq]
-      change Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag *
-          Matrix.reindexLinearEquiv ℂ ℂ eST eST Y *
-          Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag =
-        Matrix.reindexLinearEquiv ℂ ℂ eST eST Y
-      rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-            eST eST eST Pdiag Y,
-          Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-            eST eST eST (Pdiag * Y) Pdiag, hPdiagY]
-    -- From `P0 * Y_ST * P0 = Y_ST`, deduce `Y_ST = fromBlocks Y_ST.toBlocks₁₁ 0 0 0`.
-    have hY_ST_block :
-        Y_ST = Matrix.fromBlocks Y_ST.toBlocks₁₁ (0 : Matrix S T ℂ)
-          (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) := by
-      have hkey : Matrix.fromBlocks Y_ST.toBlocks₁₁ (0 : Matrix S T ℂ)
-          (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) =
-          Matrix.fromBlocks Y_ST.toBlocks₁₁ Y_ST.toBlocks₁₂
-            Y_ST.toBlocks₂₁ Y_ST.toBlocks₂₂ := by
-        rw [(Matrix.fromBlocks_toBlocks Y_ST).symm] at hP0_YST
-        simp only [P0, Matrix.fromBlocks_multiply, Matrix.one_mul, Matrix.mul_one,
-          Matrix.zero_mul, Matrix.mul_zero, add_zero] at hP0_YST
-        exact hP0_YST
-      exact (hkey.trans (Matrix.fromBlocks_toBlocks Y_ST)).symm
-    change toFun (invFun X.1) = X.1
-    simp only [invFun, toFun]
-    rw [cornerCompressionExpand_apply Umat eST eS (invFun X.1)]
-    -- invFun X.1 = reindex eS eS Y_ST.toBlocks₁₁
-    -- toFun (reindex eS eS Y_ST.toBlocks₁₁) = Umat * reindex eST.symm eST.symm
-    --   (fromBlocks (reindex eS.symm eS.symm (reindex eS eS Y_ST.toBlocks₁₁)) 0 0 0) * Umatᴴ
-    have hround :
-        Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm
-          (Matrix.reindexLinearEquiv ℂ ℂ eS eS Y_ST.toBlocks₁₁) = Y_ST.toBlocks₁₁ := by
-      change Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm
-        (Matrix.reindexLinearEquiv ℂ ℂ eS eS Y_ST.toBlocks₁₁) = Y_ST.toBlocks₁₁
-      rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
-        Matrix.reindexLinearEquiv_refl_refl]
-      rfl
-    rw [hround]
-    -- Now the fromBlocks expression equals Y_ST.
-    rw [show Matrix.fromBlocks Y_ST.toBlocks₁₁ (0 : Matrix S T ℂ)
-          (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) = Y_ST from hY_ST_block.symm]
-    -- reindex eST.symm eST.symm Y_ST = Y.
-    have hround₂ :
-        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST = Y := by
-      change Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
-        (Matrix.reindexLinearEquiv ℂ ℂ eST eST Y) = Y
-      rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
-        Matrix.reindexLinearEquiv_refl_refl]
-      rfl
-    rw [hround₂]
-    -- Umat * (Umatᴴ * X * Umat) * Umatᴴ = X.
-    change Umat * (Umatᴴ * X.1 * Umat) * Umatᴴ = X.1
-    calc
-      Umat * (Umatᴴ * X.1 * Umat) * Umatᴴ
-          = (Umat * Umatᴴ) * X.1 * (Umat * Umatᴴ) := by simp [Matrix.mul_assoc]
-      _ = X.1 := by rw [hUU]; simp
-  -- Structured linear-map version of `toFun` via composition of Mathlib linear
-  -- maps: `reindexLinearEquiv`, top-left embedding `fromBlocks · 0 0 0`, then
-  -- `reindexLinearEquiv`, then conjugation `X ↦ Umat * X * Umatᴴ`.  This lets
-  -- `map_add'` / `map_smul'` for the `LinearEquiv` reduce to its built-in
-  -- `LinearMap.map_add` / `LinearMap.map_smul`.
-  let fromBlocksTL : Matrix S S ℂ →ₗ[ℂ] Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-    { toFun := fun M => Matrix.fromBlocks M 0 0 0
-      map_add' := fun A B => by
-        ext i j; cases i <;> cases j <;>
-          simp [Matrix.fromBlocks, Matrix.add_apply]
-      map_smul' := fun c A => by
-        ext i j; cases i <;> cases j <;>
-          simp [Matrix.fromBlocks, Matrix.smul_apply] }
-  let conjUnitary : MatrixAlg D →ₗ[ℂ] MatrixAlg D :=
-    { toFun := fun X => Umat * X * Umatᴴ
-      map_add' := fun X Y => by rw [Matrix.mul_add, Matrix.add_mul]
-      map_smul' := fun c X => by simp }
-  let toFunLM : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] MatrixAlg D :=
-    conjUnitary ∘ₗ (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm).toLinearMap
-      ∘ₗ fromBlocksTL
-        ∘ₗ (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm).toLinearMap
-  -- Package as `LinearEquiv`.
-  refine
-    { toFun := fun M => ⟨toFun M, hFwdMem M⟩,
-      map_add' := fun M₁ M₂ => Subtype.ext (toFunLM.map_add M₁ M₂)
-      map_smul' := fun c M => Subtype.ext (toFunLM.map_smul c M)
-      invFun := fun X => invFun X.1
-      left_inv := hLeftInv
-      right_inv := fun X => hRightInv X }
+  -- Package the compression as a `LinearEquiv` using the shared
+  -- `cornerCompressionLinearEquiv` builder.
+  exact cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0
+    rfl htrace hP_decomp rfl hPdiag_std hPdiag_back hU'U hUU
 
 /-- The rank of an orthogonal projection `P : M_D(ℂ)`, defined so that
 `cornerSubmoduleMatrixLinearEquiv` produces an isometry `M_{cornerRank P hP}(ℂ) ≃ₗ

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -809,8 +809,9 @@ For an irreducible TP tensor `A` of period `m`, after blocking by `m`, the block
 spectral projections. Returns:
 - `blocks k`: TP sector tensors (each left-canonical),
 - `P k`: orthogonal projections forming a partition of unity (`∑ P k = 1`),
-- compression isometries `φ k : M_{dim k}(ℂ) →ₗ cornerSubmodule (P k)` and the intertwining
-  identity bridging the compressed adjoint transfer map and the sector adjoint transfer map,
+- compression linear equivalences `φ k : M_{dim k}(ℂ) ≃ₗ[ℂ] cornerSubmodule (P k)` together
+  with the intertwining identity bridging the compressed adjoint transfer map and the sector
+  adjoint transfer map,
 - cyclic shift: `transferMap (fun i => (A i)ᴴ) (P (k+1)) = P k`,
 - commutation: each `P k` commutes with every blocked letter,
 - trace relation: `mpv (blocks k) σ = (P k * evalWord (blockTensor A m) σ).trace`,
@@ -830,7 +831,7 @@ theorem exists_cyclic_sector_decomp_after_blocking
     ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
       (P : Fin m → MatrixAlg D)
       (φ : (k : Fin m) →
-        Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] cornerSubmodule (P k)),
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
       (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
       SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) ∧
       (∀ k, IsOrthogonalProjection (P k)) ∧

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -809,6 +809,8 @@ For an irreducible TP tensor `A` of period `m`, after blocking by `m`, the block
 spectral projections. Returns:
 - `blocks k`: TP sector tensors (each left-canonical),
 - `P k`: orthogonal projections forming a partition of unity (`∑ P k = 1`),
+- compression isometries `φ k : M_{dim k}(ℂ) →ₗ cornerSubmodule (P k)` and the intertwining
+  identity bridging the compressed adjoint transfer map and the sector adjoint transfer map,
 - cyclic shift: `transferMap (fun i => (A i)ᴴ) (P (k+1)) = P k`,
 - commutation: each `P k` commutes with every blocked letter,
 - trace relation: `mpv (blocks k) σ = (P k * evalWord (blockTensor A m) σ).trace`,
@@ -826,7 +828,9 @@ theorem exists_cyclic_sector_decomp_after_blocking
     (hperiph : peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
       Set.range (fun j : Fin m => γ ^ (j : ℕ))) :
     ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
-      (P : Fin m → MatrixAlg D),
+      (P : Fin m → MatrixAlg D)
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] cornerSubmodule (P k)),
       (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
       SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) ∧
       (∀ k, IsOrthogonalProjection (P k)) ∧
@@ -836,6 +840,11 @@ theorem exists_cyclic_sector_decomp_after_blocking
         P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
       (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
         mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := blockPhysDim d m) (D := D)
+            (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1)) ∧
       (∀ k, dim k ≠ 0) := by
   -- Step 1: Get cyclic decomposition data
   let K : Fin d → MatrixAlg D := fun i => (A i)ᴴ
@@ -860,9 +869,9 @@ theorem exists_cyclic_sector_decomp_after_blocking
       (blockTensor A m i)ᴴ * blockTensor A m i = 1 :=
     leftCanonical_blockTensor (d := d) (D := D) (A := A) (L := m) hTP
   -- Step 5: Apply the CyclicSectors decomposition
-  obtain ⟨dim, blocks, hLC, hMPV_hTrace⟩ := exists_blockDecomp_of_adjoint_fixed_projections
+  obtain ⟨dim, blocks, φ, hLC, hMPV_hTrace⟩ := exists_blockDecomp_of_adjoint_fixed_projections
     (blockTensor A m) P hPproj hPsum hTP_blocked hFix
-  obtain ⟨hMPV, hTrace⟩ := hMPV_hTrace
+  obtain ⟨hMPV, hTrace, hIntertwine⟩ := hMPV_hTrace
   -- Step 6: Derive commutation from the adjoint fix property
   have hComm : ∀ k (i : Fin (blockPhysDim d m)),
       P k * (blockTensor A m) i = (blockTensor A m) i * P k := by
@@ -910,7 +919,8 @@ theorem exists_cyclic_sector_decomp_after_blocking
     have htrace_zero : (P k).trace = 0 := by
       rw [← h0, Matrix.trace_one, Fintype.card_fin, hk, Nat.cast_zero]
     exact (isOrthogonalProjection_posSemidef (hPproj k)).trace_eq_zero_iff.mp htrace_zero
-  exact ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace, hNondeg⟩
+  exact ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace, hIntertwine,
+    hNondeg⟩
 
 end CyclicSectorBridge
 
@@ -963,7 +973,7 @@ theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
     rw [hperiph_set]; ext x; simp [Set.mem_range, eq_comm]
   -- Apply exists_cyclic_sector_decomp_after_blocking.
   haveI : NeZero m := ⟨by omega⟩
-  obtain ⟨dim, blocks, _, hTP_blocks, hSame, _, _, _, _, _⟩ :=
+  obtain ⟨dim, blocks, _, _, hTP_blocks, hSame, _, _, _, _, _, _, _⟩ :=
     exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim
       hperiph_range
   exact ⟨m, hm_pos, dim, blocks, hTP_blocks, hSame⟩

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -312,7 +312,7 @@ theorem exists_compressedTensor_of_supported_projection
   have hPdiag_std_lin : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0 := hPdiag_std
   let cornerEmbed : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
     cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0_def
-      htrace hP_decomp hPdiag_UPU hPdiag_std_lin hPdiag_back hU'U hUU
+      hP_decomp hPdiag_UPU hPdiag_std_lin hPdiag_back hU'U hUU
   refine ⟨n, C, cornerEmbed, ?_, ?_, ?_, ?_⟩
   -- (1) Trace identity: n = tr P
   · exact htrace

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -122,17 +122,21 @@ private lemma evalWord_conj_unitary
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.
 
-Exposes the **compression isometry** `φ : M_n(ℂ) →ₗ cornerSubmodule P` together with the
-**intertwining identity** `(φ (transferMap Cᴴ X)).1 = transferMap Aᴴ ((φ X).1)`. This packages
-the spectral compression used in the proof so downstream callers can transport the corner
-restriction of the adjoint transfer map into the compressed matrix algebra. -/
+Exposes the **compression linear equivalence** `φ : M_n(ℂ) ≃ₗ[ℂ] cornerSubmodule P`
+together with the **intertwining identity**
+`(φ (transferMap Cᴴ X)).1 = transferMap Aᴴ ((φ X).1)`.  The underlying linear map is the
+spectral corner-compression built from `Matrix.IsHermitian.eigenvectorUnitary`; exposing it
+as a `LinearEquiv` lets downstream callers transport the corner restriction of the adjoint
+transfer map into the compressed matrix algebra (and transport corner-level irreducibility
+back via conjugation).  The linear map is an isometry for the canonical inner products; the
+isometry property is witnessed separately where needed. -/
 theorem exists_compressedTensor_of_supported_projection
     (A : MPSTensor d D) (P : MatrixAlg D)
     (hP : IsOrthogonalProjection P)
     (hSupp : ∀ i : Fin d, P * A i * P = A i)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = P) :
     ∃ (n : ℕ) (C : MPSTensor d n)
-      (φ : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] cornerSubmodule P),
+      (φ : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P),
       ((n : ℂ) = Matrix.trace P) ∧
       (∑ i : Fin d, (C i)ᴴ * C i = 1) ∧
       (∀ (N : ℕ) (σ : Fin N → Fin d),
@@ -185,12 +189,13 @@ theorem exists_compressedTensor_of_supported_projection
   let eS : S ≃ Fin n := Fintype.equivFin S
   -- Conjugated tensor
   let B : MPSTensor d D := fun i => Umatᴴ * A i * Umat
-  -- Algebra isomorphism for reindexing
-  let φ : MatrixAlg D ≃ₐ[ℂ] Matrix (S ⊕ T) (S ⊕ T) ℂ := Matrix.reindexAlgEquiv ℂ ℂ eST
+  -- Algebra isomorphism for reindexing (renamed to avoid clashing with the
+  -- returned `φ` below).
+  let rAlg : MatrixAlg D ≃ₐ[ℂ] Matrix (S ⊕ T) (S ⊕ T) ℂ := Matrix.reindexAlgEquiv ℂ ℂ eST
   let P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
     Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ)
   -- Pdiag in S⊕T basis
-  have hPdiag_std : φ Pdiag = P0 := by
+  have hPdiag_std : rAlg Pdiag = P0 := by
     change Matrix.reindex eST eST Pdiag = P0
     rw [hPdiag_eq, show Matrix.reindex eST eST (Matrix.diagonal f) =
         Matrix.diagonal (f ∘ eST.symm) from by simp [Matrix.reindex_apply]]
@@ -227,13 +232,13 @@ theorem exists_compressedTensor_of_supported_projection
         _ = Umatᴴ * (P * A i * P) * Umat := by rw [hUU, Matrix.mul_one, Matrix.mul_one]
     rw [hkey, hSupp i]
   -- Block structure
-  let X : Fin d → Matrix (S ⊕ T) (S ⊕ T) ℂ := fun i => φ (B i)
+  let X : Fin d → Matrix (S ⊕ T) (S ⊕ T) ℂ := fun i => rAlg (B i)
   let B11 : Fin d → Matrix S S ℂ := fun i => (X i).toBlocks₁₁
   have hX_block : ∀ i : Fin d,
       X i = Matrix.fromBlocks (B11 i) 0 0 (0 : Matrix T T ℂ) := by
     intro i
     have hsupp_block : P0 * X i * P0 = X i := by
-      have := congrArg φ (hBsupp i)
+      have := congrArg rAlg (hBsupp i)
       simp only [map_mul, hPdiag_std] at this
       exact this
     rw [(Matrix.fromBlocks_toBlocks (X i)).symm]
@@ -303,9 +308,11 @@ theorem exists_compressedTensor_of_supported_projection
             (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) * Umatᴴ := by
     intro M
     exact cornerCompressionExpand_apply Umat eST eS M
-  let cornerEmbed : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] cornerSubmodule P :=
-    cornerCompressionLinearMap (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0_def
-      htrace hP_decomp hPdiag_back hU'U
+  have hPdiag_UPU : Pdiag = Umatᴴ * P * Umat := rfl
+  have hPdiag_std_lin : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0 := hPdiag_std
+  let cornerEmbed : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
+    cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0_def
+      htrace hP_decomp hPdiag_UPU hPdiag_std_lin hPdiag_back hU'U hUU
   refine ⟨n, C, cornerEmbed, ?_, ?_, ?_, ?_⟩
   -- (1) Trace identity: n = tr P
   · exact htrace
@@ -338,22 +345,19 @@ theorem exists_compressedTensor_of_supported_projection
     have hTPblock : ∑ i : Fin d, (B11 i)ᴴ * B11 i = (1 : Matrix S S ℂ) := by
       -- φ(∑ B_i† B_i) = ∑ φ(B_i† * B_i) = ∑ (X_i)† (X_i) = P0
       -- But we also need φ(B_i†) = (X_i)†
-      have hφ_ct : ∀ i, φ ((B i)ᴴ) = (X i)ᴴ := by
+      have hφ_ct : ∀ i, rAlg ((B i)ᴴ) = (X i)ᴴ := by
         intro i; ext a b
-        simp [φ, X, Matrix.reindex_apply, Matrix.conjTranspose_apply,
+        simp [rAlg, X, Matrix.reindex_apply, Matrix.conjTranspose_apply,
           Matrix.submatrix_apply, Matrix.reindexAlgEquiv]
       -- h : ∑ (X_i)† * X_i = P0
       have h : ∑ i : Fin d, (X i)ᴴ * X i = P0 := by
-        have h0 := congrArg φ hTPB
+        have h0 := congrArg rAlg hTPB
         rw [map_sum] at h0
         simp only [map_mul] at h0
-        -- h0 : ∑ φ (B i)ᴴ * φ (B i) = φ Pdiag
-        -- φ (B i)ᴴ is actually φ((B i)ᴴ) after map_mul, which equals (X i)ᴴ by hφ_ct
-        -- Actually hφ_ct says φ (B i)ᴴ = (X i)ᴴ where φ (B i) = X i
-        -- So φ (B i)ᴴ = (X i)ᴴ, and φ (B i) = X i
-        simp only [show ∀ i, φ (B i) = X i from fun i => rfl] at h0
-        -- Now need: φ (B i)ᴴ = (X i)ᴴ... but after map_mul, what does h0 look like?
-        -- Let me just use the fact that φ preserves star/conjTranspose
+        -- h0 : ∑ rAlg (B i)ᴴ * rAlg (B i) = rAlg Pdiag
+        -- rAlg (B i)ᴴ is actually rAlg((B i)ᴴ) after map_mul, which equals (X i)ᴴ by hφ_ct
+        simp only [show ∀ i, rAlg (B i) = X i from fun i => rfl] at h0
+        -- Now use the fact that rAlg preserves star/conjTranspose
         rw [hPdiag_std] at h0
         convert h0 using 1
       -- Substitute block form X_i = fromBlocks(B11_i, 0, 0, 0)
@@ -414,18 +418,18 @@ theorem exists_compressedTensor_of_supported_projection
       -- Reindex RHS to S⊕T
       have htrace_reindex :
           Matrix.trace (Pdiag * evalWord B w) =
-            Matrix.trace (φ (Pdiag * evalWord B w)) := by
+            Matrix.trace (rAlg (Pdiag * evalWord B w)) := by
         change Matrix.trace (Pdiag * evalWord B w) =
           Matrix.trace (Matrix.reindex eST eST (Pdiag * evalWord B w))
         rw [Matrix.trace_reindex]
       rw [htrace_reindex]
       rw [map_mul, hPdiag_std]
-      -- φ(evalWord B w) = evalWord X w
-      have hφ_eval : φ (evalWord B w) = _root_.evalWord X w := by
+      -- rAlg(evalWord B w) = evalWord X w
+      have hφ_eval : rAlg (evalWord B w) = _root_.evalWord X w := by
         change Matrix.reindex eST eST (evalWord B w) = _root_.evalWord X w
         have h := evalWord_reindex_fin (e := eST) (A := B) w
         rw [show (fun i => Matrix.reindex eST eST (B i)) = X from by
-          ext i; simp [φ, X]] at h
+          ext i; simp [rAlg, X]] at h
         exact h.symm
       rw [hφ_eval]
       -- Now: tr(P0 * evalWord X w) = tr(evalWord B11 w)
@@ -677,9 +681,11 @@ variable {m : ℕ}
 then it decomposes into compressed sectors whose direct-sum tensor is `SameMPV₂`-equivalent to the
 original tensor.
 
-Exposes per-sector compression isometries `φ k : M_{dim k}(ℂ) →ₗ cornerSubmodule (P k)` and the
-intertwining identity tying the compressed adjoint transfer map to the sector adjoint transfer
-map on the corner of `P k`. -/
+Exposes per-sector compression linear equivalences
+`φ k : M_{dim k}(ℂ) ≃ₗ[ℂ] cornerSubmodule (P k)` and the intertwining identity tying the
+compressed adjoint transfer map to the sector adjoint transfer map on the corner of `P k`.
+Returning a `LinearEquiv` lets downstream consumers transport corner-level irreducibility /
+primitivity structure across the compression. -/
 theorem exists_blockDecomp_of_commuting_projections
     (A : MPSTensor d D)
     (P : Fin m → MatrixAlg D)
@@ -689,7 +695,7 @@ theorem exists_blockDecomp_of_commuting_projections
     (hComm : ∀ k : Fin m, ∀ i : Fin d, P k * A i = A i * P k) :
     ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k))
       (φ : (k : Fin m) →
-        Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] cornerSubmodule (P k)),
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
       (∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1) ∧
       SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
       (∀ k (N : ℕ) (σ : Fin N → Fin d),
@@ -777,7 +783,7 @@ theorem exists_blockDecomp_of_adjoint_fixed_projections
     (hFix : ∀ k : Fin m, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) = P k) :
     ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k))
       (φ : (k : Fin m) →
-        Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] cornerSubmodule (P k)),
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
       (∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1) ∧
       SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
       (∀ k (N : ℕ) (σ : Fin N → Fin d),

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -609,10 +609,9 @@ theorem exists_compressedTensor_of_supported_projection
       calc
         (Umat * (B i)ᴴ * Umatᴴ) * (Umat * G * Umatᴴ) * (Umat * B i * Umatᴴ)
             = Umat * (B i)ᴴ * (Umatᴴ * Umat) * G * (Umatᴴ * Umat) * B i * Umatᴴ := by
-              simp [Matrix.mul_assoc]
-        _ = Umat * (B i)ᴴ * G * B i * Umatᴴ := by
-              rw [hU'U]; simp [Matrix.mul_assoc]
-        _ = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by simp [Matrix.mul_assoc]
+              noncomm_ring
+        _ = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by
+              rw [hU'U]; noncomm_ring
     rw [hLHS, hRHS]
 
 end Compression

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -260,33 +260,6 @@ theorem exists_compressedTensor_of_supported_projection
     rw [h12, h21, h22]
   -- Compressed tensor
   let C : MPSTensor d n := fun i => Matrix.reindex eS eS (B11 i)
-  -- Spectral compression isometry `φ : M_n(ℂ) →ₗ cornerSubmodule P`. Constructed from the
-  -- spectral diagonalization by reindexing `M_n(ℂ) → M_S(ℂ)`, embedding as the top-left
-  -- block `fromBlocks · 0 0 0`, reindexing back to `M_D(ℂ)` via `eST.symm`, and finally
-  -- conjugating by `Umat`.
-  let fromBlocksTL : Matrix S S ℂ →ₗ[ℂ] Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-    { toFun := fun M => Matrix.fromBlocks M 0 0 0
-      map_add' := fun M₁ M₂ => by
-        ext i j; cases i <;> cases j <;>
-          simp [Matrix.fromBlocks, Matrix.add_apply]
-      map_smul' := fun c M => by
-        ext i j; cases i <;> cases j <;>
-          simp [Matrix.fromBlocks, Matrix.smul_apply] }
-  let conjUmat : MatrixAlg D →ₗ[ℂ] MatrixAlg D :=
-    { toFun := fun Y => Umat * Y * Umatᴴ
-      map_add' := fun Y₁ Y₂ => by simp [Matrix.mul_add, Matrix.add_mul]
-      map_smul' := fun c Y => by simp }
-  let expand : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] MatrixAlg D :=
-    conjUmat ∘ₗ
-      (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm).toLinearMap ∘ₗ
-      fromBlocksTL ∘ₗ
-      (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm).toLinearMap
-  have hexpand_def : ∀ M : Matrix (Fin n) (Fin n) ℂ,
-      expand M = Umat *
-        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
-          (Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
-            (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) * Umatᴴ :=
-    fun _ => rfl
   -- `P = Umat * Pdiag * Umatᴴ`.
   have hP_decomp : P = Umat * Pdiag * Umatᴴ := by
     change P = Umat * (Umatᴴ * P * Umat) * Umatᴴ
@@ -304,55 +277,10 @@ theorem exists_compressedTensor_of_supported_projection
     rw [Equiv.self_trans_symm, Matrix.reindexLinearEquiv_refl_refl,
       LinearEquiv.refl_apply] at hid
     exact h.symm.trans hid
-  -- `expand M ∈ cornerSubmodule P`, i.e. `P * expand M * P = expand M`.
-  have hexpand_mem : ∀ M : Matrix (Fin n) (Fin n) ℂ, P * expand M * P = expand M := by
-    intro M
-    rw [hexpand_def]
-    set Y_ST : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-      Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
-        (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) with hY_ST_def
-    set Y_D : MatrixAlg D :=
-      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST with hY_D_def
-    have hP0_Y : P0 * Y_ST * P0 = Y_ST := by
-      simp [P0, Y_ST, Matrix.fromBlocks_multiply]
-    have hPdiag_Y : Pdiag * Y_D * Pdiag = Y_D := by
-      calc
-        Pdiag * Y_D * Pdiag
-            = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 *
-                Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST *
-                Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 := by
-              rw [hPdiag_back]
-        _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (P0 * Y_ST) *
-                Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 := by
-              rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-                eST.symm eST.symm eST.symm P0 Y_ST]
-        _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (P0 * Y_ST * P0) := by
-              rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-                eST.symm eST.symm eST.symm (P0 * Y_ST) P0]
-        _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST := by rw [hP0_Y]
-    change P * (Umat * Y_D * Umatᴴ) * P = Umat * Y_D * Umatᴴ
-    calc
-      P * (Umat * Y_D * Umatᴴ) * P
-          = (Umat * Pdiag * Umatᴴ) * (Umat * Y_D * Umatᴴ) *
-              (Umat * Pdiag * Umatᴴ) := by rw [← hP_decomp]
-      _ = Umat * (Pdiag * (Umatᴴ * Umat) * Y_D * (Umatᴴ * Umat) * Pdiag) * Umatᴴ := by
-            simp [Matrix.mul_assoc]
-      _ = Umat * (Pdiag * Y_D * Pdiag) * Umatᴴ := by rw [hU'U]; simp
-      _ = Umat * Y_D * Umatᴴ := by rw [hPdiag_Y]
-  -- Package `expand` as a linear map into the corner submodule.
-  let cornerEmbed : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] cornerSubmodule P :=
-    { toFun := fun M => ⟨expand M, hexpand_mem M⟩
-      map_add' := fun M₁ M₂ => by
-        apply Subtype.ext
-        change expand (M₁ + M₂) = expand M₁ + expand M₂
-        exact expand.map_add M₁ M₂
-      map_smul' := fun c M => by
-        apply Subtype.ext
-        change expand (c • M) = c • expand M
-        exact expand.map_smul c M }
-  refine ⟨n, C, cornerEmbed, ?_, ?_, ?_, ?_⟩
-  -- (1) Trace identity: n = tr P
-  · show (n : ℂ) = Matrix.trace P
+  let expand : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] MatrixAlg D :=
+    cornerCompressionExpand Umat eST eS
+  have hP0_def : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ) := rfl
+  have htrace : (n : ℂ) = Matrix.trace P := by
     have : Matrix.trace P = Matrix.trace Pdiag := by
       change Matrix.trace P = Matrix.trace (Umatᴴ * P * Umat)
       rw [trace_conj]
@@ -368,6 +296,19 @@ theorem exists_compressedTensor_of_supported_projection
     congr 1
     change n = (Finset.univ.filter p).card
     exact Fintype.card_subtype p
+  have hexpand_def : ∀ M : Matrix (Fin n) (Fin n) ℂ,
+      expand M = Umat *
+        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
+          (Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
+            (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) * Umatᴴ := by
+    intro M
+    exact cornerCompressionExpand_apply Umat eST eS M
+  let cornerEmbed : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] cornerSubmodule P :=
+    cornerCompressionLinearMap (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0_def
+      htrace hP_decomp hPdiag_back hU'U
+  refine ⟨n, C, cornerEmbed, ?_, ?_, ?_, ?_⟩
+  -- (1) Trace identity: n = tr P
+  · exact htrace
   -- (2) TP condition: ∑ C_i† C_i = 1
   · show ∑ i : Fin d, (C i)ᴴ * C i = 1
     -- First: ∑ B_i† B_i = Pdiag
@@ -584,10 +525,10 @@ theorem exists_compressedTensor_of_supported_projection
     intro i _
     -- Per-letter: expand ((C i)ᴴ * Z * C i) = (A i)ᴴ * expand Z * A i.
     -- Abbreviations for readability.
-    set M' : Matrix S S ℂ := Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm Z with hM'_def
+    set M' : Matrix S S ℂ := Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm Z
     set F : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
       Matrix.fromBlocks M' (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) with hF_def
-    set G : MatrixAlg D := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm F with hG_def
+    set G : MatrixAlg D := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm F
     -- `expand Z = Umat * G * Umatᴴ`.
     have hexpand_Z : expand Z = Umat * G * Umatᴴ := hexpand_def Z
     -- `A i = Umat * B i * Umatᴴ` and `(A i)ᴴ = Umat * (B i)ᴴ * Umatᴴ`.

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -121,17 +121,25 @@ private lemma evalWord_conj_unitary
 
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.
--/
+
+Exposes the **compression isometry** `φ : M_n(ℂ) →ₗ cornerSubmodule P` together with the
+**intertwining identity** `(φ (transferMap Cᴴ X)).1 = transferMap Aᴴ ((φ X).1)`. This packages
+the spectral compression used in the proof so downstream callers can transport the corner
+restriction of the adjoint transfer map into the compressed matrix algebra. -/
 theorem exists_compressedTensor_of_supported_projection
     (A : MPSTensor d D) (P : MatrixAlg D)
     (hP : IsOrthogonalProjection P)
     (hSupp : ∀ i : Fin d, P * A i * P = A i)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = P) :
-    ∃ (n : ℕ) (C : MPSTensor d n),
+    ∃ (n : ℕ) (C : MPSTensor d n)
+      (φ : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] cornerSubmodule P),
       ((n : ℂ) = Matrix.trace P) ∧
       (∑ i : Fin d, (C i)ᴴ * C i = 1) ∧
       (∀ (N : ℕ) (σ : Fin N → Fin d),
-        mpv C σ = Matrix.trace (P * evalWord A (List.ofFn σ))) := by
+        mpv C σ = Matrix.trace (P * evalWord A (List.ofFn σ))) ∧
+      (∀ X : Matrix (Fin n) (Fin n) ℂ,
+        (φ (transferMap (d := d) (D := n) (fun i => (C i)ᴴ) X)).1 =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1)) := by
   classical
   -- Spectral diagonalization of P
   let hHerm : P.IsHermitian := hP.1
@@ -252,7 +260,97 @@ theorem exists_compressedTensor_of_supported_projection
     rw [h12, h21, h22]
   -- Compressed tensor
   let C : MPSTensor d n := fun i => Matrix.reindex eS eS (B11 i)
-  refine ⟨n, C, ?_, ?_, ?_⟩
+  -- Spectral compression isometry `φ : M_n(ℂ) →ₗ cornerSubmodule P`. Constructed from the
+  -- spectral diagonalization by reindexing `M_n(ℂ) → M_S(ℂ)`, embedding as the top-left
+  -- block `fromBlocks · 0 0 0`, reindexing back to `M_D(ℂ)` via `eST.symm`, and finally
+  -- conjugating by `Umat`.
+  let fromBlocksTL : Matrix S S ℂ →ₗ[ℂ] Matrix (S ⊕ T) (S ⊕ T) ℂ :=
+    { toFun := fun M => Matrix.fromBlocks M 0 0 0
+      map_add' := fun M₁ M₂ => by
+        ext i j; cases i <;> cases j <;>
+          simp [Matrix.fromBlocks, Matrix.add_apply]
+      map_smul' := fun c M => by
+        ext i j; cases i <;> cases j <;>
+          simp [Matrix.fromBlocks, Matrix.smul_apply] }
+  let conjUmat : MatrixAlg D →ₗ[ℂ] MatrixAlg D :=
+    { toFun := fun Y => Umat * Y * Umatᴴ
+      map_add' := fun Y₁ Y₂ => by simp [Matrix.mul_add, Matrix.add_mul]
+      map_smul' := fun c Y => by simp }
+  let expand : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] MatrixAlg D :=
+    conjUmat ∘ₗ
+      (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm).toLinearMap ∘ₗ
+      fromBlocksTL ∘ₗ
+      (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm).toLinearMap
+  have hexpand_def : ∀ M : Matrix (Fin n) (Fin n) ℂ,
+      expand M = Umat *
+        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
+          (Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
+            (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) * Umatᴴ :=
+    fun _ => rfl
+  -- `P = Umat * Pdiag * Umatᴴ`.
+  have hP_decomp : P = Umat * Pdiag * Umatᴴ := by
+    change P = Umat * (Umatᴴ * P * Umat) * Umatᴴ
+    calc
+      P = (Umat * Umatᴴ) * P * (Umat * Umatᴴ) := by rw [hUU]; simp
+      _ = Umat * (Umatᴴ * P * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
+  -- `reindexLinearEquiv eST.symm eST.symm P0 = Pdiag`.
+  have hPdiag_back :
+      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag := by
+    have hstd : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0 := hPdiag_std
+    have h := congrArg
+      (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm) hstd
+    have hid := Matrix.reindexLinearEquiv_comp_apply (R := ℂ) (A := ℂ)
+      eST eST eST.symm eST.symm Pdiag
+    rw [Equiv.self_trans_symm, Matrix.reindexLinearEquiv_refl_refl,
+      LinearEquiv.refl_apply] at hid
+    exact h.symm.trans hid
+  -- `expand M ∈ cornerSubmodule P`, i.e. `P * expand M * P = expand M`.
+  have hexpand_mem : ∀ M : Matrix (Fin n) (Fin n) ℂ, P * expand M * P = expand M := by
+    intro M
+    rw [hexpand_def]
+    set Y_ST : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
+      Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
+        (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) with hY_ST_def
+    set Y_D : MatrixAlg D :=
+      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST with hY_D_def
+    have hP0_Y : P0 * Y_ST * P0 = Y_ST := by
+      simp [P0, Y_ST, Matrix.fromBlocks_multiply]
+    have hPdiag_Y : Pdiag * Y_D * Pdiag = Y_D := by
+      calc
+        Pdiag * Y_D * Pdiag
+            = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 *
+                Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST *
+                Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 := by
+              rw [hPdiag_back]
+        _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (P0 * Y_ST) *
+                Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 := by
+              rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+                eST.symm eST.symm eST.symm P0 Y_ST]
+        _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (P0 * Y_ST * P0) := by
+              rw [Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+                eST.symm eST.symm eST.symm (P0 * Y_ST) P0]
+        _ = Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST := by rw [hP0_Y]
+    change P * (Umat * Y_D * Umatᴴ) * P = Umat * Y_D * Umatᴴ
+    calc
+      P * (Umat * Y_D * Umatᴴ) * P
+          = (Umat * Pdiag * Umatᴴ) * (Umat * Y_D * Umatᴴ) *
+              (Umat * Pdiag * Umatᴴ) := by rw [← hP_decomp]
+      _ = Umat * (Pdiag * (Umatᴴ * Umat) * Y_D * (Umatᴴ * Umat) * Pdiag) * Umatᴴ := by
+            simp [Matrix.mul_assoc]
+      _ = Umat * (Pdiag * Y_D * Pdiag) * Umatᴴ := by rw [hU'U]; simp
+      _ = Umat * Y_D * Umatᴴ := by rw [hPdiag_Y]
+  -- Package `expand` as a linear map into the corner submodule.
+  let cornerEmbed : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] cornerSubmodule P :=
+    { toFun := fun M => ⟨expand M, hexpand_mem M⟩
+      map_add' := fun M₁ M₂ => by
+        apply Subtype.ext
+        change expand (M₁ + M₂) = expand M₁ + expand M₂
+        exact expand.map_add M₁ M₂
+      map_smul' := fun c M => by
+        apply Subtype.ext
+        change expand (c • M) = c • expand M
+        exact expand.map_smul c M }
+  refine ⟨n, C, cornerEmbed, ?_, ?_, ?_, ?_⟩
   -- (1) Trace identity: n = tr P
   · show (n : ℂ) = Matrix.trace P
     have : Matrix.trace P = Matrix.trace Pdiag := by
@@ -475,6 +573,102 @@ theorem exists_compressedTensor_of_supported_projection
         = Matrix.trace (_root_.evalWord B11 w) := hmpv_C
       _ = Matrix.trace (Pdiag * evalWord B w) := htr_key
       _ = Matrix.trace (P * evalWord A (List.ofFn σ)) := htr_conj
+  -- (4) Intertwining identity:
+  --     (φ (transferMap (C†) Z)).1 = transferMap (A†) ((φ Z).1)
+  · intro Z
+    change expand (transferMap (d := d) (D := n) (fun j => (C j)ᴴ) Z) =
+      transferMap (d := d) (D := D) (fun j => (A j)ᴴ) (expand Z)
+    simp only [transferMap_apply, Matrix.conjTranspose_conjTranspose]
+    rw [map_sum]
+    refine Finset.sum_congr rfl ?_
+    intro i _
+    -- Per-letter: expand ((C i)ᴴ * Z * C i) = (A i)ᴴ * expand Z * A i.
+    -- Abbreviations for readability.
+    set M' : Matrix S S ℂ := Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm Z with hM'_def
+    set F : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
+      Matrix.fromBlocks M' (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) with hF_def
+    set G : MatrixAlg D := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm F with hG_def
+    -- `expand Z = Umat * G * Umatᴴ`.
+    have hexpand_Z : expand Z = Umat * G * Umatᴴ := hexpand_def Z
+    -- `A i = Umat * B i * Umatᴴ` and `(A i)ᴴ = Umat * (B i)ᴴ * Umatᴴ`.
+    have hA_i : A i = Umat * B i * Umatᴴ := by
+      change A i = Umat * (Umatᴴ * A i * Umat) * Umatᴴ
+      calc
+        A i = (Umat * Umatᴴ) * A i * (Umat * Umatᴴ) := by rw [hUU]; simp
+        _ = Umat * (Umatᴴ * A i * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
+    have hA_i_ct : (A i)ᴴ = Umat * (B i)ᴴ * Umatᴴ := by
+      rw [hA_i, Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+        Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+    -- `reindex eS.symm eS.symm (C i) = B11 i`.
+    have hExM_C : Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i) = B11 i := by
+      change Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm
+        (Matrix.reindexLinearEquiv ℂ ℂ eS eS (B11 i)) = B11 i
+      rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
+        Matrix.reindexLinearEquiv_refl_refl]
+      rfl
+    -- `reindex eST.symm eST.symm (X i) = B i`.
+    have hExST_X : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (X i) = B i := by
+      have hXi_eq : X i = Matrix.reindexLinearEquiv ℂ ℂ eST eST (B i) := rfl
+      rw [hXi_eq, Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
+        Matrix.reindexLinearEquiv_refl_refl]
+      rfl
+    -- Reduction: reindex eS.symm eS.symm ((C i)ᴴ * Z * C i) = (B11 i)ᴴ * M' * B11 i.
+    have hExM_letter :
+        Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm ((C i)ᴴ * Z * C i) =
+          (B11 i)ᴴ * M' * B11 i := by
+      rw [← Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+            eS.symm eS.symm eS.symm ((C i)ᴴ * Z) (C i),
+          ← Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+            eS.symm eS.symm eS.symm ((C i)ᴴ) Z]
+      have hCt_reindex :
+          Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm ((C i)ᴴ) = (B11 i)ᴴ := by
+        change Matrix.reindex eS.symm eS.symm ((C i)ᴴ) = (B11 i)ᴴ
+        rw [← Matrix.conjTranspose_reindex]
+        change (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i))ᴴ = (B11 i)ᴴ
+        rw [hExM_C]
+      rw [hCt_reindex, hExM_C]
+    -- Block identity: fromBlocks ((B11 i)ᴴ * M' * B11 i) 0 0 0 = (X i)ᴴ * F * X i.
+    have hF_letter :
+        Matrix.fromBlocks ((B11 i)ᴴ * M' * B11 i) (0 : Matrix S T ℂ)
+            (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) =
+          (X i)ᴴ * F * X i := by
+      rw [hX_block i, hF_def]
+      rw [show (Matrix.fromBlocks (B11 i) (0 : Matrix S T ℂ)
+              (0 : Matrix T S ℂ) (0 : Matrix T T ℂ))ᴴ =
+            Matrix.fromBlocks (B11 i)ᴴ (0 : Matrix S T ℂ)
+              (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) from by
+          simp [Matrix.fromBlocks_conjTranspose]]
+      simp [Matrix.fromBlocks_multiply]
+    -- Compute LHS = Umat * ((B i)ᴴ * G * B i) * Umatᴴ.
+    have hLHS :
+        expand ((C i)ᴴ * Z * C i) = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by
+      rw [hexpand_def ((C i)ᴴ * Z * C i)]
+      congr 1
+      congr 1
+      rw [hExM_letter, hF_letter]
+      rw [← Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+            eST.symm eST.symm eST.symm ((X i)ᴴ * F) (X i),
+          ← Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+            eST.symm eST.symm eST.symm ((X i)ᴴ) F]
+      have hXct_reindex :
+          Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm ((X i)ᴴ) = (B i)ᴴ := by
+        change Matrix.reindex eST.symm eST.symm ((X i)ᴴ) = (B i)ᴴ
+        rw [← Matrix.conjTranspose_reindex]
+        change (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (X i))ᴴ = (B i)ᴴ
+        rw [hExST_X]
+      rw [hXct_reindex, hExST_X]
+    -- Compute RHS = Umat * ((B i)ᴴ * G * B i) * Umatᴴ.
+    have hRHS :
+        (A i)ᴴ * expand Z * A i = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by
+      rw [hexpand_Z, hA_i_ct, hA_i]
+      calc
+        (Umat * (B i)ᴴ * Umatᴴ) * (Umat * G * Umatᴴ) * (Umat * B i * Umatᴴ)
+            = Umat * (B i)ᴴ * (Umatᴴ * Umat) * G * (Umatᴴ * Umat) * B i * Umatᴴ := by
+              simp [Matrix.mul_assoc]
+        _ = Umat * (B i)ᴴ * G * B i * Umatᴴ := by
+              rw [hU'U]; simp [Matrix.mul_assoc]
+        _ = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by simp [Matrix.mul_assoc]
+    rw [hLHS, hRHS]
 
 end Compression
 
@@ -494,7 +688,7 @@ theorem exists_compressedTensor_of_supported_projection_pos_mpv
       ((n : ℂ) = Matrix.trace P) ∧
       (∑ i : Fin d, (C i)ᴴ * C i = 1) ∧
       (∀ {N : ℕ}, 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = mpv C σ) := by
-  obtain ⟨dim, C, hdim, hCtp, hCmpv⟩ :=
+  obtain ⟨dim, C, _φ, hdim, hCtp, hCmpv, _hIntertwine⟩ :=
     exists_compressedTensor_of_supported_projection A P hP hSupp hTP
   refine ⟨dim, C, hdim, hCtp, ?_⟩
   have hleft : ∀ i : Fin d, P * A i = A i := by
@@ -530,7 +724,7 @@ theorem exists_compressedTensor_of_supported_projection_pos_mpv
         mpv A σ = Matrix.trace (evalWord A (List.ofFn σ)) := by rfl
         _ = Matrix.trace (P * evalWord A (List.ofFn σ)) := by
               exact congrArg Matrix.trace hPw.symm
-        _ = mpv C σ := (hCmpv (N := n'.succ) σ).symm
+        _ = mpv C σ := (hCmpv n'.succ σ).symm
 
 end CompressionPositiveMPV
 
@@ -540,7 +734,11 @@ variable {m : ℕ}
 
 /-- If a left-canonical tensor commutes with a family of orthogonal projections summing to `1`,
 then it decomposes into compressed sectors whose direct-sum tensor is `SameMPV₂`-equivalent to the
-original tensor. -/
+original tensor.
+
+Exposes per-sector compression isometries `φ k : M_{dim k}(ℂ) →ₗ cornerSubmodule (P k)` and the
+intertwining identity tying the compressed adjoint transfer map to the sector adjoint transfer
+map on the corner of `P k`. -/
 theorem exists_blockDecomp_of_commuting_projections
     (A : MPSTensor d D)
     (P : Fin m → MatrixAlg D)
@@ -548,11 +746,18 @@ theorem exists_blockDecomp_of_commuting_projections
     (hPsum : ∑ k : Fin m, P k = 1)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hComm : ∀ k : Fin m, ∀ i : Fin d, P k * A i = A i * P k) :
-    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k)),
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k))
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] cornerSubmodule (P k)),
       (∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1) ∧
       SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
       (∀ k (N : ℕ) (σ : Fin N → Fin d),
-        mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace) := by
+        mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := d) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := d) (D := D)
+            (fun i => (P k * A i)ᴴ) ((φ k X).1)) := by
   -- For each k, sector tensor P_k * A_i is P_k-supported
   have hSectorSupp : ∀ k i, P k * (P k * A i) * P k = P k * A i := by
     intro k i
@@ -568,7 +773,7 @@ theorem exists_blockDecomp_of_commuting_projections
       rw [hComm k i, ← Matrix.mul_assoc]
     simp_rw [hterm, ← Finset.sum_mul, hLeft, Matrix.one_mul]
   -- Apply compression to each sector
-  choose dim blocks hDim hTPblocks hMPVblocks using fun k =>
+  choose dim blocks φ hDim hTPblocks hMPVblocks hIntertwine using fun k =>
     exists_compressedTensor_of_supported_projection
       (fun i => P k * A i) (P k) (hPproj k) (hSectorSupp k) (hSectorTP k)
   -- Per-sector trace relation: mpv(blocks k) σ = tr(P_k · evalWord A σ)
@@ -578,7 +783,7 @@ theorem exists_blockDecomp_of_commuting_projections
     rw [hMPVblocks k N σ]
     congr 1
     exact left_mul_evalWord_leftSectorTensor_of_commutes (P k) A (hPproj k).2 (hComm k) _
-  refine ⟨dim, blocks, hTPblocks, ?_, hSectorTrace⟩
+  refine ⟨dim, blocks, φ, hTPblocks, ?_, hSectorTrace, hIntertwine⟩
   -- SameMPV₂ follows from summing per-sector traces over the projection partition
   intro N σ
   rw [mpv_toTensorFromBlocks_eq_sum]; simp only [one_pow, one_smul]
@@ -629,11 +834,18 @@ theorem exists_blockDecomp_of_adjoint_fixed_projections
     (hPsum : ∑ k : Fin m, P k = 1)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hFix : ∀ k : Fin m, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) = P k) :
-    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k)),
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k))
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] cornerSubmodule (P k)),
       (∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1) ∧
       SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
       (∀ k (N : ℕ) (σ : Fin N → Fin d),
-        mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace) := by
+        mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := d) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := d) (D := D)
+            (fun i => (P k * A i)ᴴ) ((φ k X).1)) := by
   have hComm : ∀ k : Fin m, ∀ i : Fin d, P k * A i = A i * P k := by
     intro k i
     exact commutes_letters_of_adjoint_fixed_projection

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -95,6 +95,15 @@ section Compression
 
 variable {P : MatrixAlg D}
 
+/-- Conjugate transpose commutes with `Matrix.reindexLinearEquiv` on square matrices when both
+index equivalences agree. -/
+private lemma reindexLinearEquiv_conjTranspose
+    {α β : Type*} (e : α ≃ β) (M : Matrix α α ℂ) :
+    Matrix.reindexLinearEquiv ℂ ℂ e e Mᴴ =
+      (Matrix.reindexLinearEquiv ℂ ℂ e e M)ᴴ := by
+  change Matrix.reindex e e Mᴴ = (Matrix.reindex e e M)ᴴ
+  rw [Matrix.conjTranspose_reindex]
+
 /-- Word evaluation of the unitary-conjugated tensor. -/
 private lemma evalWord_conj_unitary
     (A : MPSTensor d D) (U : Matrix.unitaryGroup (Fin D) ℂ) :
@@ -567,10 +576,7 @@ theorem exists_compressedTensor_of_supported_projection
             eS.symm eS.symm eS.symm ((C i)ᴴ) Z]
       have hCt_reindex :
           Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm ((C i)ᴴ) = (B11 i)ᴴ := by
-        change Matrix.reindex eS.symm eS.symm ((C i)ᴴ) = (B11 i)ᴴ
-        rw [← Matrix.conjTranspose_reindex]
-        change (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i))ᴴ = (B11 i)ᴴ
-        rw [hExM_C]
+        rw [reindexLinearEquiv_conjTranspose, hExM_C]
       rw [hCt_reindex, hExM_C]
     -- Block identity: fromBlocks ((B11 i)ᴴ * M' * B11 i) 0 0 0 = (X i)ᴴ * F * X i.
     have hF_letter :
@@ -597,10 +603,7 @@ theorem exists_compressedTensor_of_supported_projection
             eST.symm eST.symm eST.symm ((X i)ᴴ) F]
       have hXct_reindex :
           Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm ((X i)ᴴ) = (B i)ᴴ := by
-        change Matrix.reindex eST.symm eST.symm ((X i)ᴴ) = (B i)ᴴ
-        rw [← Matrix.conjTranspose_reindex]
-        change (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (X i))ᴴ = (B i)ᴴ
-        rw [hExST_X]
+        rw [reindexLinearEquiv_conjTranspose, hExST_X]
       rw [hXct_reindex, hExST_X]
     -- Compute RHS = Umat * ((B i)ᴴ * G * B i) * Umatᴴ.
     have hRHS :

--- a/TNLean/MPS/Periodic/Overlap.lean
+++ b/TNLean/MPS/Periodic/Overlap.lean
@@ -102,18 +102,20 @@ The per-sector trace relation ties each compressed block `blocks k` back to the
 projection `P k` via `mpv (blocks k) σ = tr(P k · evalWord(blockTensor A m)(σ))`,
 which is the defining property of `exists_compressedTensor_of_supported_projection`.
 
-Also carries per-sector compression isometries
-`φ k : M_{dim k}(ℂ) →ₗ cornerSubmodule (P k)` and the intertwining identity relating
+Also carries per-sector compression linear equivalences
+`φ k : M_{dim k}(ℂ) ≃ₗ[ℂ] cornerSubmodule (P k)` and the intertwining identity relating
 the compressed adjoint transfer map to the sector adjoint transfer map on the corner
-of `P k`. These witnesses are exposed so downstream consumers (see
-`compressedTensor_adjointTransferMap_cornerBridge`) can transport corner-level
-irreducibility results to the compressed matrix algebra. -/
+of `P k`. Returning each `φ k` as a `LinearEquiv` lets downstream consumers
+(see `compressedTensor_adjointTransferMap_cornerBridge`) transport corner-level
+irreducibility / primitivity results back to the compressed matrix algebra via
+conjugation.  The underlying linear map is an isometry for the canonical inner products;
+that property is witnessed separately where needed. -/
 def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
     {dim : Fin m → ℕ}
     (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)) : Prop :=
   ∃ (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
     (φ : (k : Fin m) →
-      Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] cornerSubmodule (P k)),
+      Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
     (∀ k, IsOrthogonalProjection (P k)) ∧
     (∑ k : Fin m, P k = 1) ∧
     (∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) ∧

--- a/TNLean/MPS/Periodic/Overlap.lean
+++ b/TNLean/MPS/Periodic/Overlap.lean
@@ -100,18 +100,32 @@ commutation with the blocked letters.
 
 The per-sector trace relation ties each compressed block `blocks k` back to the
 projection `P k` via `mpv (blocks k) σ = tr(P k · evalWord(blockTensor A m)(σ))`,
-which is the defining property of `exists_compressedTensor_of_supported_projection`. -/
+which is the defining property of `exists_compressedTensor_of_supported_projection`.
+
+Also carries per-sector compression isometries
+`φ k : M_{dim k}(ℂ) →ₗ cornerSubmodule (P k)` and the intertwining identity relating
+the compressed adjoint transfer map to the sector adjoint transfer map on the corner
+of `P k`. These witnesses are exposed so downstream consumers (see
+`compressedTensor_adjointTransferMap_cornerBridge`) can transport corner-level
+irreducibility results to the compressed matrix algebra. -/
 def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
     {dim : Fin m → ℕ}
     (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)) : Prop :=
-  ∃ (P : Fin m → Matrix (Fin D) (Fin D) ℂ),
+  ∃ (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (φ : (k : Fin m) →
+      Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] cornerSubmodule (P k)),
     (∀ k, IsOrthogonalProjection (P k)) ∧
     (∑ k : Fin m, P k = 1) ∧
     (∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) ∧
     (∀ k (i : Fin (blockPhysDim d m)),
       P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
     (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
-      mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace)
+      mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace) ∧
+    (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+      (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
+          (fun i => (blocks k i)ᴴ) X)).1 =
+        transferMap (d := blockPhysDim d m) (D := D)
+          (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1))
 
 private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
@@ -195,11 +209,12 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
           _ = (ω ^ m) ^ (j : ℕ) := by rw [pow_mul]
           _ = 1 := by simp [hωprim.pow_eq_one]
       simpa [hperiph_roots] using hpow
-  obtain ⟨dim, blocks, P, hLC, hMPV, hPproj, hPsum, hCyclic, hComm, hTraceNondeg⟩ :=
+  obtain ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hCyclic, hComm, hTraceNondeg⟩ :=
     exists_cyclic_sector_decomp_after_blocking
       A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
-  obtain ⟨hTrace, hNondeg⟩ := hTraceNondeg
-  exact ⟨dim, blocks, hLC, hMPV, ⟨P, hPproj, hPsum, hCyclic, hComm, hTrace⟩, hNondeg⟩
+  obtain ⟨hTrace, hIntertwine, hNondeg⟩ := hTraceNondeg
+  exact ⟨dim, blocks, hLC, hMPV,
+    ⟨P, φ, hPproj, hPsum, hCyclic, hComm, hTrace, hIntertwine⟩, hNondeg⟩
 
 
 private lemma hLift_cyclicDecomp_mps_of_fixUpgrade_missingBridge
@@ -548,7 +563,7 @@ private lemma adjointTransferMap_primitive_and_irreducible_sectorBlock_of_cyclic
       ∧ IsIrreducibleMap
         (transferMap (d := blockPhysDim d m) (D := dim u)
           (fun i => (blocks u i)ᴴ)) := by
-  obtain ⟨P, hPproj, hPsum, hCyclicP, hComm, hTrace⟩ := hCyclic
+  obtain ⟨P, _φ, hPproj, hPsum, hCyclicP, hComm, hTrace, _hIntertwine⟩ := hCyclic
   obtain ⟨hInv, hCornerPrim, hCornerIrr⟩ :=
     cornerRestriction_primitive_and_irreducible_of_cyclicDecomp
       A hP blocks hBlocks_lc hBlocks_mpv hPproj hPsum hCyclicP hComm hTrace u hNonzero
@@ -688,7 +703,7 @@ private lemma sectorBlocks_not_gaugePhaseEquiv_of_ne
     ¬ GaugePhaseEquiv
       (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim) (blocks u))
       (blocks v) := by
-  obtain ⟨P, hPproj, hPsum, hCyclicP, hComm, hTrace⟩ := hCyclic
+  obtain ⟨P, _φ, hPproj, hPsum, hCyclicP, hComm, hTrace, _hIntertwine⟩ := hCyclic
   have hPairwise : Pairwise fun i j : Fin m => P i * P j = 0 :=
     pairwise_mul_zero_of_orthogonalProjection_sum_one P hPproj hPsum
   have hOrth : P u * P v = 0 := hPairwise huv
@@ -1414,7 +1429,7 @@ private lemma sectorDim_ne_zero_succ_of_cyclicSectorDecomp
     {u : Fin m} (hNondeg : dim u ≠ 0) :
     dim (u + 1) ≠ 0 := by
   classical
-  obtain ⟨P, hPproj, _hPsum, hShift, _hComm, hTrace⟩ := hCyclic
+  obtain ⟨P, _φ, hPproj, _hPsum, hShift, _hComm, hTrace, _hIntertwine⟩ := hCyclic
   intro hzero
   have htrace_succ :
       Matrix.trace (P (u + 1)) = 0 := by

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1036,12 +1036,16 @@ The following results separate the zero blocks from the
 	Let $A$ be an MPS tensor satisfying
 	$\sum_i (A^i)^\dagger A^i = P$ for an orthogonal projection $P$,
 	and suppose $P A^i P = A^i$ for every~$i$.
-	Then there exists a left-canonical tensor $C$ of bond dimension
-	$n = \tr(P)$ with
+	Then there exist a left-canonical tensor $C$ of bond dimension
+	$n = \tr(P)$ and a linear map
+	$\varphi : M_n(\mathbb{C}) \to P \cdot M_D(\mathbb{C}) \cdot P$ with
 	\[
-		V^{(N)}(C)_\sigma = \tr\!\bigl(P \cdot A^\sigma\bigr)
+		V^{(N)}(C)_\sigma = \tr\!\bigl(P \cdot A^\sigma\bigr),
+		\qquad
+		\varphi\!\bigl(\E_{C^\dagger}(X)\bigr)
+			= \E_{A^\dagger}\!\bigl(\varphi(X)\bigr)
 	\]
-	for every~$\sigma$.
+	for every~$\sigma$ and every $X \in M_n(\mathbb{C})$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1084,7 +1088,10 @@ The following results separate the zero blocks from the
 	as $\bigoplus_{k=1}^m C_k$.
 	Moreover, each sector satisfies the per-sector trace relation
 	$V^{(N)}(C_k)(\sigma) = \operatorname{tr}(P_k \cdot A^{i_1} \cdots A^{i_N})$
-	for every word $\sigma = (i_1, \dots, i_N)$.
+	for every word $\sigma = (i_1, \dots, i_N)$, and each block carries a
+	compression isometry $\varphi_k$ into the corner $P_k \cdot M_D(\mathbb{C}) \cdot P_k$
+	intertwining the compressed adjoint transfer map with the sector adjoint
+	transfer map.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1037,8 +1037,8 @@ The following results separate the zero blocks from the
 	$\sum_i (A^i)^\dagger A^i = P$ for an orthogonal projection $P$,
 	and suppose $P A^i P = A^i$ for every~$i$.
 	Then there exist a left-canonical tensor $C$ of bond dimension
-	$n = \tr(P)$ and a linear map
-	$\varphi : M_n(\mathbb{C}) \to P \cdot M_D(\mathbb{C}) \cdot P$ with
+	$n = \tr(P)$ and a linear equivalence
+	$\varphi : M_n(\mathbb{C}) \xrightarrow{\sim} P \cdot M_D(\mathbb{C}) \cdot P$ with
 	\[
 		V^{(N)}(C)_\sigma = \tr\!\bigl(P \cdot A^\sigma\bigr),
 		\qquad
@@ -1089,7 +1089,9 @@ The following results separate the zero blocks from the
 	Moreover, each sector satisfies the per-sector trace relation
 	$V^{(N)}(C_k)(\sigma) = \operatorname{tr}(P_k \cdot A^{i_1} \cdots A^{i_N})$
 	for every word $\sigma = (i_1, \dots, i_N)$, and each block carries a
-	compression isometry $\varphi_k$ into the corner $P_k \cdot M_D(\mathbb{C}) \cdot P_k$
+	compression linear equivalence
+	$\varphi_k : M_{\dim C_k}(\mathbb{C}) \xrightarrow{\sim}
+		P_k \cdot M_D(\mathbb{C}) \cdot P_k$
 	intertwining the compressed adjoint transfer map with the sector adjoint
 	transfer map.
 \end{theorem}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -694,8 +694,12 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	projections $P_0,\dotsc,P_{m-1}$ on the ambient bond space such that
 	$\sum_k P_k = \Id$, the projections satisfy the cyclic-shift relation
 	$E^\dagger(P_{k+1}) = P_k$, each $P_k$ commutes with every blocked letter
-	$P_k A^{(m)}_i = A^{(m)}_i P_k$, and
-	$V^{(N)}(C_k)_\sigma = \tr(P_k (A^{(m)})^\sigma)$ for every word~$\sigma$.
+	$P_k A^{(m)}_i = A^{(m)}_i P_k$,
+	$V^{(N)}(C_k)_\sigma = \tr(P_k (A^{(m)})^\sigma)$ for every word~$\sigma$,
+	and each block carries a compression isometry
+	$\varphi_k : M_{\dim C_k}(\mathbb{C}) \to P_k \cdot M_D(\mathbb{C}) \cdot P_k$
+	intertwining the compressed adjoint transfer map with the sector adjoint
+	transfer map on the corner of~$P_k$.
 \end{definition}
 
 \begin{theorem}[Self-overlap along period multiples]\label{thm:periodic_self_overlap_tendsto}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -696,8 +696,9 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	$E^\dagger(P_{k+1}) = P_k$, each $P_k$ commutes with every blocked letter
 	$P_k A^{(m)}_i = A^{(m)}_i P_k$,
 	$V^{(N)}(C_k)_\sigma = \tr(P_k (A^{(m)})^\sigma)$ for every word~$\sigma$,
-	and each block carries a compression isometry
-	$\varphi_k : M_{\dim C_k}(\mathbb{C}) \to P_k \cdot M_D(\mathbb{C}) \cdot P_k$
+	and each block carries a compression linear equivalence
+	$\varphi_k : M_{\dim C_k}(\mathbb{C}) \xrightarrow{\sim}
+		P_k \cdot M_D(\mathbb{C}) \cdot P_k$
 	intertwining the compressed adjoint transfer map with the sector adjoint
 	transfer map on the corner of~$P_k$.
 \end{definition}


### PR DESCRIPTION
### Motivation

- Stage 2 of the three-stage #618 refactor (Stage 1 landed in #621). The cyclic-sector compression API only returned a trace identity, which is strictly weaker (by Specht's theorem) than what downstream Tier-A bridges (#607, #608, #609) need to conclude primitivity and irreducibility of `transferMap Cᴴ`.
- Exposing the per-sector compression isometry `φ` together with the explicit intertwining identity unblocks Stage 3 corner-bridge work (#624) and the Tier-A bridges.

### Description

- `TNLean/MPS/CanonicalForm/CyclicSectors.lean`: `exists_compressedTensor_of_supported_projection` now returns `φ : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] cornerSubmodule P` together with the intertwining identity `(φ ∘ transferMap (fun i ↦ (C i)ᴴ)) X = transferMap (fun i ↦ (A i)ᴴ) ((φ X).1)`.
- Propagated the enriched signature through `_pos_mpv`, `exists_blockDecomp_of_commuting_projections`, and `exists_blockDecomp_of_adjoint_fixed_projections`.
- `TNLean/MPS/Periodic/Overlap.lean`: extended `IsCyclicSectorDecomp` and `exists_cyclic_sector_decomp_after_blocking` to thread the new `φ` and intertwining data; updated consumers.
- `TNLean/MPS/CanonicalForm/Assembly.lean`: updated callers of the upgraded API.
- `blueprint/src/chapter/ch08_canonical.tex` and `blueprint/src/chapter/ch11_assembly.tex`: documented the new `φ` and intertwining guarantees.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate `lake build TNLean`.
- `rg -n "sorry|axiom" TNLean/MPS/CanonicalForm/CyclicSectors.lean TNLean/MPS/CanonicalForm/Assembly.lean TNLean/MPS/Periodic/Overlap.lean` to confirm no new `sorry` or `axiom`.

---
Addresses #623

> [!NOTE]
> **Medium Risk**
> Updates several core decomposition theorems to return additional witnesses (`φ` maps and an intertwining lemma), which is a broad API/signature change that can break downstream Lean proofs even though the mathematical content is additive.
>
> **Overview**
> This PR **extends the cyclic-sector compression/decomposition APIs** to expose a per-sector compression isometry `φ` into `cornerSubmodule P` and an explicit *intertwining identity* relating the compressed adjoint `transferMap` to the corresponding corner/sector adjoint `transferMap`.
>
> It threads these new witnesses through the main construction chain (`exists_compressedTensor_of_supported_projection` → block decompositions → `exists_cyclic_sector_decomp_after_blocking` and `IsCyclicSectorDecomp`), updating callers accordingly, and updates the blueprint text to document the new `φ`/intertwining guarantees.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a47c535074863143cacbd24c79bdc611fe33e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to broad Lean API/signature changes across core compression/decomposition theorems, which can break downstream proofs despite being logically additive.
> 
> **Overview**
> Adds reusable corner-compression infrastructure (`cornerCompressionExpand` + `cornerCompressionLinearEquiv`) and refactors projection-corner isometries to use this shared `LinearEquiv` builder.
> 
> Extends the cyclic-sector compression/decomposition APIs to *return per-sector compression equivalences* `φ : M_n(ℂ) ≃ₗ[ℂ] cornerSubmodule P` and a new *intertwining identity* relating compressed vs corner/sector adjoint `transferMap`s; threads these new witnesses through `exists_compressedTensor_of_supported_projection`, block decomposition theorems, `exists_cyclic_sector_decomp_after_blocking`, and `IsCyclicSectorDecomp`, updating all callers.
> 
> Updates the blueprint tex to document the new `φ` and intertwining guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3114ce033d31d5bf4ce1f3a8c528761622c0f760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->