### PR TITLE
fix(MPS/FundamentalTheorem): clean Helpers docs and remove dead private lemmas

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
@@ -8,21 +8,20 @@ import TNLean.MPS.FundamentalTheorem.OverlapConvergenceAux
 /-!
 # Helpers for the heterogeneous equal-case fundamental theorem
 
-This module collects small helper lemmas used by the two core private lemmas
+This module collects small helper lemmas used by the two core lemmas
 `exists_nondecaying_overlap_of_sameMPV₂_CFBNT`
 (`TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap`) and
 `blocks_match_of_sameMPV₂_CFBNT` (`TNLean.MPS.FundamentalTheorem.Full.BlocksMatch`)
 that together prove the self-contained equal-case fundamental theorem
 `fundamentalTheorem_equalMPV_CFBNT_hetero` in `TNLean.MPS.FundamentalTheorem.Full`.
 
-## Main statements
+## Main public statements
 
 * `tendsto_norm_selfOverlap_one`: normed form of a self-overlap tending to `1`.
 * `tendsto_inner_zero_swap`: swapping a decaying overlap conjugates the inner product.
-* `mpvOverlap_eq_selfOverlap_of_forall_mpv_eq`: pointwise equal MPVs imply cross-overlap
-  equals self-overlap of the first tensor.
-* `gaugePhaseEquiv_of_block_sameMPV₂`: per-block `SameMPV₂` combined with block properties
-  yields dimension equality and `GaugePhaseEquiv` (Layer 2 of the proof architecture).
+
+Additional internal helper lemmas in this file support the private proof architecture
+used by the full heterogeneous equal-case theorem, but are not exported by this module.
 
 ## References
 
@@ -45,14 +44,6 @@ variable {d : ℕ}
 
 /-! ## Helpers for the heterogeneous equal-case fundamental theorem -/
 
-/-- Overlap of two blocks with pointwise-equal MPVs equals the self-overlap of the first. -/
-private lemma mpvOverlap_eq_selfOverlap_of_forall_mpv_eq
-    {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (h : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv A σ = mpv B σ) :
-    ∀ N, mpvOverlap (d := d) A B N = mpvOverlap (d := d) A A N := by
-  intro N
-  simp only [mpvOverlap, h]
-
 /-- Norm-convergence version of normalized self-overlap convergence. -/
 lemma tendsto_norm_selfOverlap_one
     {D : ℕ} (A : MPSTensor d D)
@@ -73,44 +64,5 @@ lemma tendsto_inner_zero_swap
     simp [mpvInner, inner_conj_symm]
   rw [hSwap]
   simpa using hAB.star
-
-/-- **Layer 2: Per-block `SameMPV₂` + block properties → dim equality + GaugePhaseEquiv.**
-
-Given two individual blocks with pointwise-equal MPVs, both injective and left-canonical,
-and with the first block's self-overlap tending to 1:
-1. The cross-overlap equals the self-overlap (→ 1), hence does not decay to 0.
-2. Dimension mismatch would force overlap → 0 (`mpvOverlap_tendsto_zero_of_dim_ne`).
-   Contradiction ⟹ dimensions match.
-3. Non-gauge-phase-equivalence would force overlap → 0
-   (`mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left`).
-   Contradiction ⟹ gauge-phase equivalent. -/
-private lemma gaugePhaseEquiv_of_block_sameMPV₂
-    {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hA_inj : IsInjective A) (hB_inj : IsInjective B)
-    (hA_norm : (∑ i : Fin d, (A i)ᴴ * (A i)) = 1)
-    (hB_norm : (∑ i : Fin d, (B i)ᴴ * (B i)) = 1)
-    (hA_self : Tendsto (fun N => mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ)))
-    (hSameMPV : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv A σ = mpv B σ) :
-    ∃ hdim : D₁ = D₂,
-      GaugePhaseEquiv (d := d)
-        (cast (congr_arg (MPSTensor d) hdim) A) B := by
-  -- Cross-overlap = self-overlap → 1.
-  have hOvEq := mpvOverlap_eq_selfOverlap_of_forall_mpv_eq A B hSameMPV
-  have hOvOne : Tendsto (fun N => mpvOverlap (d := d) A B N) atTop (nhds (1 : ℂ)) :=
-    hA_self.congr (fun N => (hOvEq N).symm)
-  have hOvNot0 : ¬ Tendsto (fun N => mpvOverlap (d := d) A B N) atTop (nhds 0) :=
-    fun h0 => one_ne_zero (tendsto_nhds_unique hOvOne h0)
-  -- Dim equality by contradiction.
-  have hdim : D₁ = D₂ := by
-    by_contra hne
-    exact hOvNot0
-      (mpvOverlap_tendsto_zero_of_dim_ne A B hA_inj hB_inj hA_norm hB_norm hne)
-  refine ⟨hdim, ?_⟩
-  -- GaugePhaseEquiv by contradiction.
-  by_contra hNotGPE
-  exact hOvNot0
-    (mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left
-      hdim A B hA_inj hB_inj hA_norm hB_norm hNotGPE)
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
@@ -15,13 +15,13 @@ This module collects small helper lemmas used by the two core lemmas
 that together prove the self-contained equal-case fundamental theorem
 `fundamentalTheorem_equalMPV_CFBNT_hetero` in `TNLean.MPS.FundamentalTheorem.Full`.
 
-## Main public statements
+## Main statements
 
 * `tendsto_norm_selfOverlap_one`: normed form of a self-overlap tending to `1`.
 * `tendsto_inner_zero_swap`: swapping a decaying overlap conjugates the inner product.
 
-Additional internal helper lemmas in this file support the private proof architecture
-used by the full heterogeneous equal-case theorem, but are not exported by this module.
+This file currently consists of these two public helper lemmas used by the full
+heterogeneous equal-case theorem.
 
 ## References
 


### PR DESCRIPTION
### Motivation

- Address reviewer comments about inaccurate docstrings and preserved dead private helpers in `Full/Helpers.lean` that confused the public-facing documentation and review threads. 
- Reduce noise that may interfere with blueprint cross-references and to make the module surface reflect actual exported lemmas.

### Description

- Update the module docstring in `TNLean/MPS/FundamentalTheorem/Full/Helpers.lean` to advertise only the actual public helpers and to clarify that other small helpers are internal. 
- Delete two unused private helper lemmas: `mpvOverlap_eq_selfOverlap_of_forall_mpv_eq` and `gaugePhaseEquiv_of_block_sameMPV₂`. 
- Keep the public API of `fundamentalTheorem_equalMPV_CFBNT_hetero` unchanged and retain remaining helper lemmas (`tendsto_norm_selfOverlap_one`, `tendsto_inner_zero_swap`) used by the proof stack. 

### Testing

- Searched the repository for references to the removed lemmas with `rg` and found no callers, so removal is safe. 
- Ran `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/Helpers.lean` and `lake build`, both succeeded and the full project build completed successfully. 
- Attempted `cd blueprint && leanblueprint checkdecls` and `leanblueprint web` as requested, but `leanblueprint` is not installed in this environment so those blueprint checks could not be executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f89dcea88324b15ec52db34f8b65)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes unused private lemmas and cleans documentation without changing exported theorems or proof behavior.
> 
> **Overview**
> Cleans up `Full/Helpers.lean` to reflect the actual public surface: the module docs now only advertise `tendsto_norm_selfOverlap_one` and `tendsto_inner_zero_swap` and clarify their role in the heterogeneous equal-case fundamental theorem.
> 
> Deletes two dead `private` helper lemmas (`mpvOverlap_eq_selfOverlap_of_forall_mpv_eq` and `gaugePhaseEquiv_of_block_sameMPV₂`) that had no callers, reducing noise in the proof stack and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebca5efc73a0f80cefa442dd699007ab57252bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->