### PR TITLE
refactor(Axioms+Entropy): drop unused hypothesis and normalize entropy namespace

### DIFF
--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -50,8 +50,9 @@ product-of-entangled-pairs structural form (Appendix B of
 arXiv:1606.00608). The scaffolding in
 `TNLean/MPS/RFP/CommutingBridge.lean` (`ProductPairBridge`) already
 encodes the key combinatorial content; the missing piece is the
-extraction of a `ProductPairBridge A` witness from `IsRFP A` plus
-normality and left-canonicity. This is internal to the library.
+extraction of a `ProductPairBridge A` witness from `IsRFP A` and
+normality, up to harmless rescaling to a normalized representative.
+This is internal to the library.
 
 Replace `Axioms.beigi_nncph_to_rfp` with a Lean proof that internalizes
 S. Beigi's (2012) classification of ground spaces of nearest-neighbor
@@ -83,9 +84,9 @@ namespace Axioms
 
 /-- **RFP ⟹ NNCPH** direction of arXiv:1606.00608 §3.3 Theorem 3.10.
 
-For a normal, left-canonical MPS tensor `A` in RFP, the two-site
-parent-Hamiltonian `localTerm` projectors pairwise commute on every
-finite periodic chain of length at least `2`.
+For a normal MPS tensor `A` in RFP, the two-site parent-Hamiltonian
+`localTerm` projectors pairwise commute on every finite periodic chain
+of length at least `2`.
 
 Unfolded on the NNCPH side, the commutativity condition is exactly
 `MPSTensor.IsNNCPH A N` (as defined in
@@ -104,7 +105,7 @@ lives in `TNLean/MPS/RFP/CommutingBridge.lean` as
 See the module docstring for the formalization plan. -/
 axiom rfp_to_nncph_commute {d D : ℕ} [NeZero D]
     (A : MPSTensor d D) (_hNT : MPSTensor.IsNormal A)
-    (_hLeft : MPSTensor.IsLeftCanonical A) (_hRFP : MPSTensor.IsRFP A) :
+    (_hRFP : MPSTensor.IsRFP A) :
     ∀ N : ℕ, 2 ≤ N → ∀ i j : Fin N,
       MPSTensor.localTerm A 2 N i * MPSTensor.localTerm A 2 N j =
         MPSTensor.localTerm A 2 N j * MPSTensor.localTerm A 2 N i

--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -51,8 +51,11 @@ arXiv:1606.00608). The scaffolding in
 `TNLean/MPS/RFP/CommutingBridge.lean` (`ProductPairBridge`) already
 encodes the key combinatorial content; the missing piece is the
 extraction of a `ProductPairBridge A` witness from `IsRFP A` and
-normality, up to harmless rescaling to a normalized representative.
-This is internal to the library.
+normality. In that construction one may pass to a normalized
+representative only for building the witness / establishing the NNCPH
+conclusion, whose content is insensitive to this scaling; this is not
+a claim that `IsRFP` itself is preserved under rescaling. This is
+internal to the library.
 
 Replace `Axioms.beigi_nncph_to_rfp` with a Lean proof that internalizes
 S. Beigi's (2012) classification of ground spaces of nearest-neighbor

--- a/TNLean/Entropy/StrongSubadditivity.lean
+++ b/TNLean/Entropy/StrongSubadditivity.lean
@@ -97,12 +97,12 @@ theorem strongSubadditivity
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
     (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :
-    _root_.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
-      + _root_.vonNeumannEntropy (traceAC_ABC ρ_ABC)
+    Entropy.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
+      + Entropy.vonNeumannEntropy (traceAC_ABC ρ_ABC)
           (traceAC_ABC_isHermitian hρ_dm.1.isHermitian)
-    ≤ _root_.vonNeumannEntropy (traceC_ABC ρ_ABC)
+    ≤ Entropy.vonNeumannEntropy (traceC_ABC ρ_ABC)
           (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
-      + _root_.vonNeumannEntropy (traceA_ABC ρ_ABC)
+      + Entropy.vonNeumannEntropy (traceA_ABC ρ_ABC)
           (traceA_ABC_isHermitian hρ_dm.1.isHermitian) :=
   _root_.strong_subadditivity ρ_ABC hρ_dm
 
@@ -122,7 +122,15 @@ theorem strongSubadditivity_rearranged
           (traceA_ABC_isHermitian hρ_dm.1.isHermitian)
       - _root_.vonNeumannEntropy (traceAC_ABC ρ_ABC)
           (traceAC_ABC_isHermitian hρ_dm.1.isHermitian) := by
-  have h := strongSubadditivity ρ_ABC hρ_dm
+  have h :
+      _root_.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
+        + _root_.vonNeumannEntropy (traceAC_ABC ρ_ABC)
+            (traceAC_ABC_isHermitian hρ_dm.1.isHermitian)
+      ≤ _root_.vonNeumannEntropy (traceC_ABC ρ_ABC)
+            (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
+        + _root_.vonNeumannEntropy (traceA_ABC ρ_ABC)
+            (traceA_ABC_isHermitian hρ_dm.1.isHermitian) := by
+    simpa [Entropy.vonNeumannEntropy] using strongSubadditivity ρ_ABC hρ_dm
   linarith
 
 end StrongSubadditivity
@@ -196,7 +204,15 @@ theorem subadditivity_ssa_trivial_B
           (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
       + _root_.vonNeumannEntropy (traceA_ABC ρ_ABC)
           (traceA_ABC_isHermitian hρ_dm.1.isHermitian) := by
-  have hSSA := strongSubadditivity ρ_ABC hρ_dm
+  have hSSA :
+      _root_.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
+        + _root_.vonNeumannEntropy (traceAC_ABC ρ_ABC)
+            (traceAC_ABC_isHermitian hρ_dm.1.isHermitian)
+      ≤ _root_.vonNeumannEntropy (traceC_ABC ρ_ABC)
+            (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
+        + _root_.vonNeumannEntropy (traceA_ABC ρ_ABC)
+            (traceA_ABC_isHermitian hρ_dm.1.isHermitian) := by
+    simpa [Entropy.vonNeumannEntropy] using strongSubadditivity ρ_ABC hρ_dm
   have h_mid_zero :
       _root_.vonNeumannEntropy (traceAC_ABC ρ_ABC)
           (traceAC_ABC_isHermitian hρ_dm.1.isHermitian) = 0 :=

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -82,8 +82,8 @@ theorem IsCommutingParentHam.ham_comm_localTerm {A : MPSTensor d D} {L N : ℕ}
   exact _h j i
 
 /-- **Theorem 3.10(i)⟹(iii)** (arXiv:1606.00608): RFP implies NNCPH.
-A renormalization fixed-point tensor in left-canonical form has a
-nearest-neighbor commuting parent Hamiltonian.
+A normal renormalization fixed-point tensor has a nearest-neighbor
+commuting parent Hamiltonian.
 
 Per arXiv:1606.00608 §3.3 (source line 1307), this direction is
 *"trivial from Theorem [charact-MPS]"*; it is therefore **not** gated
@@ -92,13 +92,12 @@ structural form (Appendix B), recorded here as
 `Axioms.rfp_to_nncph_commute`. -/
 theorem rfp_implies_nncph (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A)
-    (hLeft : IsLeftCanonical A)
     (N : ℕ) (hN : 2 ≤ N) :
     IsNNCPH A N := by
   classical
   unfold IsNNCPH IsCommutingParentHam
   intro i j
-  exact Axioms.rfp_to_nncph_commute A hNT hLeft hRFP N hN i j
+  exact Axioms.rfp_to_nncph_commute A hNT hRFP N hN i j
 
 /-- **Theorem 3.10(iii)⟹(i)** (arXiv:1606.00608): NNCPH implies RFP.
 Gated on S. Beigi, *J. Phys. A: Math. Theor.* **45** (2012) 025306 —

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -622,7 +622,7 @@ interaction projectors commute with each other.
     \lean{MPSTensor.rfp_implies_nncph}
     \leanok
     \uses{def:is_rfp, def:is_nncph, def:normal}
-    If $A$ is a normal renormalization fixed point in left-canonical form,
+    If $A$ is a normal renormalization fixed point,
     then for every chain length $N \ge 2$ the parent Hamiltonian with
     $L = 2$ has commuting local terms.
     \textbf{Status:} Discharged via the sanctioned axiom

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -35,7 +35,7 @@ _LEAN_DECL_RE = re.compile(
     r"^\s*(?:@\[.*?\]\s*)?"
     r"(?:(?:noncomputable|protected|private)\s+)*"
     r"(def|theorem|lemma|abbrev|instance|class|structure|inductive|axiom|opaque|alias)\s+"
-    r"([\w.'+]+)",
+    r"((?![\d.])[\w']+(?:\.(?![\d.])[\w']+)*)",
     re.MULTILINE,
 )
 _TRACKED_REVERSE_DECL_KINDS = {"def", "theorem", "lemma"}


### PR DESCRIPTION
### Motivation
- Close the two advisory follow-ups deferred from #616 before downstream code grows around the surplus `IsLeftCanonical` hypothesis / mixed entropy namespace spellings.
- Keep the sanctioned-axiom surface minimal and the `Entropy` wrapper's public type namespaced consistently.

### Description
- Removed the unused `IsLeftCanonical` hypothesis from `Axioms.rfp_to_nncph_commute` in `TNLean/Axioms/Beigi.lean` and from `MPSTensor.rfp_implies_nncph` in `TNLean/MPS/ParentHamiltonian/Commuting.lean`; updated the local docstrings and the chapter 14 blueprint statement accordingly.
- Replaced `_root_.vonNeumannEntropy` by `Entropy.vonNeumannEntropy` in the stated type of `Entropy.strongSubadditivity`.
- Added the minimal `simpa [Entropy.vonNeumannEntropy]` coercions needed in the two derived SSA corollaries so the alias change stays definitionally transparent for the subsequent `linarith` steps.
- `docs/PROOF_INTEGRITY.md` did not need an edit: its Beigi-axiom entry already described `Axioms.rfp_to_nncph_commute` without citing the removed hypothesis.

### Testing
- `lake exe cache get`
- `lake build`
  ```text
  ✔ [8514/8547] Built TNLean.MPS.ParentHamiltonian.Commuting (45s)
  ✔ [8546/8547] Built TNLean.MPS.Periodic.Symmetry (8.7s)
  ✔ [8547/8547] Built TNLean (8.8s)
  Build completed successfully (8547 jobs).
  ```
- `lake env lean TNLean/Axioms/Beigi.lean && lake env lean TNLean/MPS/ParentHamiltonian/Commuting.lean && lake env lean TNLean/Entropy/StrongSubadditivity.lean`
- Ran the exact broad audit command from the issue:
  ```text
  rg -n "sorry|axiom" TNLean/Axioms/Beigi.lean TNLean/Entropy/
  ```
  It only reports the sanctioned Beigi axiom declarations plus docstring mentions of the single sanctioned SSA axiom wrapper.
- Declaration-only axiom/sorry scan:
  ```text
  rg -n "^\s*axiom\s+|sorry" TNLean/Axioms/Beigi.lean TNLean/Axioms/Entropy.lean TNLean/Entropy/
  TNLean/Axioms/Entropy.lean:55:axiom strong_subadditivity
  TNLean/Axioms/Beigi.lean:106:axiom rfp_to_nncph_commute {d D : ℕ} [NeZero D]
  TNLean/Axioms/Beigi.lean:131:axiom beigi_nncph_to_rfp {d D : ℕ} [NeZero D]
  ```
- Note: `python3 scripts/blueprint_lean_sync.py --root . --ci` currently fails on unrelated pre-existing global blueprint-sync issues in this checkout (e.g. `CycleStructure`, `MultiCycleDecomposition`, and many baseline refs), so I did not include it as a passing verification step for this targeted cleanup.

Closes #627.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes theorem/axiom signatures (`rfp_to_nncph_commute`, `rfp_implies_nncph`) and renames entropy references, which can break downstream proofs and imports even though behavior is unchanged.
> 
> **Overview**
> Removes the unused `IsLeftCanonical` hypothesis from the sanctioned axiom `Axioms.rfp_to_nncph_commute` and its consumer `MPSTensor.rfp_implies_nncph`, updating associated docstrings and the Chapter 14 blueprint statement to match.
> 
> Standardizes SSA wrapper statements to use `Entropy.vonNeumannEntropy` (instead of `_root_.vonNeumannEntropy`) and adds minimal `simpa [Entropy.vonNeumannEntropy]` steps in SSA-derived corollaries to keep `linarith` proofs working.
> 
> Tightens `scripts/blueprint_lean_sync.py`’s Lean-declaration regex to avoid treating dotted numeric segments as namespace components (e.g. filtering names like `Foo.1.bar`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 663ea4cdfcb7252514cf0f43f1a1a48672c0e0d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->