### PR TITLE
doc(blueprint): TN diagram review — correctness & paper alignment

### DIFF
--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -285,16 +285,11 @@ on the bond space.
 \begin{proof}\leanok\uses{lem:gauge_equiv_twisted}
     The physical action is transferred to the virtual level by the same
     local move that replaces the twisted tensor by a gauge-conjugated one:
-    % TODO(maintainer): \TNPermutationTwist is designed for physical-index
-    % relabellings (where the arrow label $\sigma_g$ is a permutation acting
-    % on indices). Here the physical action is a general linear combination
-    % $\widetilde{A}_g^{\,i} = \sum_j U(g)_{ij}\, A^j$, so labelling the
-    % left leg "U(g)" is a convention mismatch with the macro's intent.
-    % Consider adding a dedicated \TNLinearTwist macro (tensor with a red
-    % operator dot on the physical leg, analogous to the LHS of
-    % \TNCondCOne) to replace the use below.
+    % Diagram fix (#401): use a physical-leg operator insertion for the
+    % linear twist \widetilde{A}_g^{\,i} = \sum_j U(g)_{ij}\, A^j rather
+    % than the relabelling-only permutation-twist glyph.
     \[
-        \TNPermutationTwist{U(g)}{i}
+        \TNLinearTwist{U(g)}{i}
         \qquad\leadsto\qquad
         \TNGaugeConjugation{X(g)}{i}{X(g)^{-1}}
     \]
@@ -653,10 +648,12 @@ acts first on the index.
     $(A^{\sigma_{gh}})^i = A^{\sigma(g)(\sigma(h)(i))} = ((A^{\sigma_g})^{\sigma_h})^i$.
     Diagrammatically this is just two consecutive relabellings of the same
     local tensor:
+    % Diagram fix (#401): label the two arrows by \sigma_h and \sigma_g so
+    % the relabelling order matches the composition \sigma(g) \circ \sigma(h).
     \[
-        \TNPermutationTwist{i}{\sigma(h)(i)}
+        \TNPermutationTwistLabeled{i}{\sigma(h)(i)}{\sigma_h}
         \qquad
-        \TNPermutationTwist{\sigma(h)(i)}{\sigma(g)(\sigma(h)(i))}
+        \TNPermutationTwistLabeled{\sigma(h)(i)}{\sigma(g)(\sigma(h)(i))}{\sigma_g}
     \]
 \end{proof}
 

--- a/blueprint/src/macros/common.tex
+++ b/blueprint/src/macros/common.tex
@@ -22,6 +22,7 @@
 \newcommand{\R}{\mathbb{R}}
 \newcommand{\N}{\mathbb{N}}
 \newcommand{\Z}{\mathbb{Z}}
+\newcommand{\Fin}[1]{\{0,\ldots,#1{-}1\}}
 
 % -- Dirac notation (manual; braket package not available in plasTeX) ------
 \newcommand{\ket}[1]{|#1\rangle}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -233,20 +233,39 @@
   \end{tikzpicture}%
 }
 
-\newcommand{\TNPermutationTwist}[2]{%
+% Fix (#401): use a dedicated physical-leg operator insertion for
+% general linear twists, and keep permutation twists for index relabellings.
+\newcommand{\TNLinearTwist}[2]{%
+  \begin{tikzpicture}[tn picture]
+    \TN@tensordot{tnA}{(0,0)}
+    \TN@leftleg{tnA}{0.65}
+    \TN@rightleg{tnA}{0.65}
+    \TN@opdotleft{tnu}{(0,0.64)}{#1}
+    \draw[tn phys leg] (tnA.north) -- (tnu.south);
+    \node at ($(tnu.north)+(0,0.18)$) {$#2$};
+  \end{tikzpicture}%
+}
+
+% Fix (#401): make the relabelling arrow explicit so multi-step
+% permutation diagrams can distinguish \sigma_h from \sigma_g.
+\newcommand{\TNPermutationTwistLabeled}[3]{%
   \begin{tikzpicture}[tn picture]
     \TN@tensordot{tnL}{(0,0)}
     \TN@leftleg{tnL}{0.65}
     \TN@rightleg{tnL}{0.65}
     \TN@upleg{tnL}{\TN@physleglen}
     \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
-    \node at (1.55,0) {$\xrightarrow{\ \sigma_g\ }$};
+    \node at (1.55,0) {$\xrightarrow{\ #3\ }$};
     \TN@tensordot{tnR}{(3.30,0)}
     \TN@leftleg{tnR}{0.65}
     \TN@rightleg{tnR}{0.65}
     \TN@upleg{tnR}{\TN@physleglen}
     \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
   \end{tikzpicture}%
+}
+
+\newcommand{\TNPermutationTwist}[2]{%
+  \TNPermutationTwistLabeled{#1}{#2}{\sigma_g}%
 }
 
 \newcommand{\TNTwistedTransfer}[1]{%

--- a/blueprint/src/macros/tn_web.tex
+++ b/blueprint/src/macros/tn_web.tex
@@ -95,11 +95,15 @@
 
 % Fix (#401): use a physical-leg operator insertion for general
 % linear twists, and reserve permutation twists for relabellings.
+% The operator dot sits in the tensor column (on the physical leg),
+% with #1 as a side-label, matching the \TNCondCOne convention and
+% the print version in tn_print.tex.
 \newcommand{\TNLinearTwist}[2]{%
   \begin{array}{ccc}
     && #2 \\
-    #1 && \vert \\
-    \textcolor{red}{\bullet} && \vert \\
+    && \vert \\
+    #1 && \textcolor{red}{\bullet} \\
+    && \vert \\
     && \bullet
   \end{array}%
 }

--- a/blueprint/src/macros/tn_web.tex
+++ b/blueprint/src/macros/tn_web.tex
@@ -93,12 +93,29 @@
   \end{array}%
 }
 
-\newcommand{\TNPermutationTwist}[2]{%
+% Fix (#401): use a physical-leg operator insertion for general
+% linear twists, and reserve permutation twists for relabellings.
+\newcommand{\TNLinearTwist}[2]{%
+  \begin{array}{ccc}
+    && #2 \\
+    #1 && \vert \\
+    \textcolor{red}{\bullet} && \vert \\
+    && \bullet
+  \end{array}%
+}
+
+% Fix (#401): make the relabelling arrow explicit so multi-step
+% permutation diagrams can distinguish \sigma_h from \sigma_g.
+\newcommand{\TNPermutationTwistLabeled}[3]{%
   \begin{array}{ccccc}
     #1 &&&& #2 \\
     \vert &&&& \vert \\
-    \bullet && \xrightarrow{\ \sigma_g\ } && \bullet
+    \bullet && \xrightarrow{\ #3\ } && \bullet
   \end{array}%
+}
+
+\newcommand{\TNPermutationTwist}[2]{%
+  \TNPermutationTwistLabeled{#1}{#2}{\sigma_g}%
 }
 
 \newcommand{\TNTwistedTransfer}[1]{%


### PR DESCRIPTION
### Motivation
- Close the remaining tensor-network diagram accuracy items from #401 after the earlier physical-realisation cleanup.
- Align the symmetry-chapter diagrams with the conventions in Molnar (arXiv:1804.04964) and the RMP review (arXiv:2011.12127): general physical actions should be drawn as operators on physical legs, while permutation arrows should be reserved for actual index relabellings.
- Keep the blueprint PDF/web builds green after the diagram updates.

### Description
- `blueprint/src/macros/tn_print.tex`
  - added `% Fix (#401): ...` commented `\TNLinearTwist` for a red operator inserted on the physical leg, matching the linear twist $\widetilde{A}_g^{\,i} = \sum_j U(g)_{ij}\,A^j$;
  - added `\TNPermutationTwistLabeled` so permutation-relabelling proofs can show the actual arrow labels `\sigma_h` and `\sigma_g`, while keeping `\TNPermutationTwist` as the default wrapper.
- `blueprint/src/macros/tn_web.tex`
  - mirrored both new public macros in the plasTeX-safe fallback notation.
- `blueprint/src/chapter/ch13b_symmetry.tex`
  - replaced the misleading `\TNPermutationTwist{U(g)}{i}` picture in the virtual-symmetry equation by `\TNLinearTwist{U(g)}{i}`;
  - corrected the two-step permutation-composition picture so the first relabelling arrow is `\sigma_h` and the second is `\sigma_g`, matching the composition order $\sigma(g) \circ \sigma(h)$;
  - added brief `% Diagram fix (#401): ...` comments at both changed diagram sites.
- `blueprint/src/macros/common.tex`
  - defined `\Fin{n}` as $\{0,\ldots,n-1\}$ to unblock the existing PDF build path hit during verification in `ch06_spectral.tex`.
- Diagram-by-diagram rationale:
  - **Virtual symmetry equation**: the old glyph suggested permutation relabelling, but the formula is a linear combination over physical indices; the new diagram shows the operator on the physical leg.
  - **Permutation-composition proof**: the contraction pattern was already correct, but the hard-coded arrow label obscured the actual order of relabelling; the new labelled helper makes the order explicit.

### Testing
- `cd blueprint && rm -f src/print.aux print/print.aux print.aux print/print.out print/print.toc print/print.log print/print.pdf print/print.fls print/print.fdb_latexmk print/print.synctex* && leanblueprint pdf`
- `cd blueprint && pdfinfo print/print.pdf`
  - verified regenerated PDF has `170` pages
- `rg -n '^!|Undefined control sequence|Runaway argument|LaTeX Error|Emergency stop|Fatal error' blueprint/print/print.log`
  - no matches
- `cd blueprint && leanblueprint web`

---
Closes #401.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to LaTeX blueprint macros and diagram call sites, with no impact on executable code; main risk is minor PDF/web rendering regressions due to macro updates.
> 
> **Overview**
> Updates the symmetry chapter tensor-network diagrams to distinguish **general linear physical actions** from **pure index relabellings**.
> 
> Introduces a new `\TNLinearTwist` macro (print and web) for operator insertions on the physical leg, adds `\TNPermutationTwistLabeled` to allow explicit arrow labels in multi-step permutation proofs, and keeps `\TNPermutationTwist` as a wrapper with the default `\sigma_g` label.
> 
> Fixes the affected chapter diagrams to use `\TNLinearTwist{U(g)}{i}` in the virtual symmetry equation and to label the two-step permutation composition arrows as `\sigma_h` then `\sigma_g`. Adds `\Fin{n}` to `common.tex` to unblock an existing usage in `ch06_spectral.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3f4608f43d0120171d43a4f87fd06ca7399a90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->