### PR TITLE
feat(MPS/Periodic): Tier-A bridge sectorGaugePhaseEquiv_succ_of_cyclicTransport

### DIFF
--- a/audits/2026-04-18_issue608_transport_blocker.md
+++ b/audits/2026-04-18_issue608_transport_blocker.md
@@ -1,0 +1,93 @@
+# Issue #608 blocker note — `sectorGaugePhaseEquiv_succ_of_cyclicTransport`
+
+## Scope
+
+Target: the single `sorry` in
+`TNLean/MPS/Periodic/Overlap.lean` for
+`sectorGaugePhaseEquiv_succ_of_cyclicTransport`.
+
+I worked in the isolated worktree branch
+`feat/608-sectorgaugephase-succ` as requested.
+
+## What I verified
+
+- Read `CLAUDE.md`, `docs/PROOF_INTEGRITY.md`, and `docs/style.md`.
+- Fetched the issue body with `gh issue view 608`.
+- Ran `lake exe cache get`.
+- Built the live target module with
+  `lake build TNLean.MPS.Periodic.Overlap`.
+- Confirmed the target `sorry` is still the one at the stated lemma.
+
+## New progress beyond the earlier blocker report
+
+A key part of the earlier "missing API" diagnosis can actually be derived from the
+existing hypotheses.
+
+Let `P : Fin m → MatrixAlg D` be the cyclic projections from `IsCyclicSectorDecomp`.
+From
+
+- orthogonal-projection partition of unity,
+- `hCyclic : transferMap (fun i => (A i)ᴴ) (P (k + 1)) = P k`, and
+- `eq_zero_of_sum_mul_conjTranspose_eq_zero`,
+
+one can prove the one-site support identities
+
+```lean
+P (k + 1) * A i = P (k + 1) * A i * P k
+P (k + 1) * A i = A i * P k
+```
+
+(and similarly for the `B`-side projections).
+
+So the "one-site corner transition" relation is not fundamentally absent from the current
+API; it is derivable.
+
+## Remaining obstruction
+
+The real gap is the next step: turning the given blocked-sector gauge-phase match
+
+```lean
+GaugePhaseEquiv
+  (cast ... (blocksA u))
+  (blocksB v)
+```
+
+into a blocked-sector gauge-phase match at the shifted pair `(u + 1, v + 1)`.
+
+The one-site support identities above let one define the ambient corner transitions
+`P (k + 1) * A i = A i * P k`, and they strongly suggest an MPV/state-level translation
+argument. However, I could not close the theorem from the current hypotheses alone without
+an additional bridge of one of the following forms:
+
+1. **A reblocked translation / fixed-length chain bridge**
+   that converts the sector match at `(u, v)` into a transported
+   proportionality / equality statement for the shifted pair at the level of
+   the induced one-site transition chains; or
+2. **A direct factorization theorem for cyclic products**
+   saying that gauge equivalence of the `m`-step cyclic products of two transition
+   chains yields gauge equivalence of the cyclically shifted `m`-step products.
+
+What I could not derive is an **invertible successor-sector gauge witness** from the
+transported relation on the `m`-fold products. In other words, the sticking point is no
+longer the existence of one-site transitions, but the absence of a proved theorem that
+upgrades the transported blocked-word relation to the `GaugePhaseEquiv` conclusion required
+by the target lemma.
+
+## Why I am not committing a fake proof
+
+Using downstream sorry-backed declarations here would be mathematically circular: the later
+sector-match and repeated-block lemmas are intended to depend on this bridge. I therefore did
+not replace the target `sorry` with a proof that merely hides the gap behind another admitted
+result.
+
+## Suggested next attack
+
+The most promising route now seems to be:
+
+1. package the derived one-site identities `P (k + 1) * A i = A i * P k` and
+   `Q (l + 1) * B i = B i * Q l` as local helpers;
+2. define the induced length-`m` transition chains between consecutive sectors;
+3. prove the fixed-length translation identity on the corresponding chain/state coefficients;
+4. use a dedicated chain/block gauge theorem to recover the successor `GaugePhaseEquiv`.
+
+This note is intended for a draft PR / handoff, not as a merged-code change.

--- a/audits/2026-04-18_issue608_transport_blocker.md
+++ b/audits/2026-04-18_issue608_transport_blocker.md
@@ -44,15 +44,29 @@ API; it is derivable.
 
 ## Remaining obstruction
 
-The real gap is the next step: turning the given blocked-sector gauge-phase match
+The real gap is the next step: turning the given blocked-sector gauge-phase match at
+`(u, v)` into one at the shifted pair `(u + 1, v + 1)`. Concretely, the hypothesis
+`hMatch` of `sectorGaugePhaseEquiv_succ_of_cyclicTransport`
+(`TNLean/MPS/Periodic/Overlap.lean`, around line 1480) has the exact shape
 
 ```lean
-GaugePhaseEquiv
-  (cast ... (blocksA u))
+hMatch : GaugePhaseEquiv
+  (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim) (blocksA u))
   (blocksB v)
 ```
 
-into a blocked-sector gauge-phase match at the shifted pair `(u + 1, v + 1)`.
+where `hdim : dimA u = dimB v` and the `cast` runs along
+`congr_arg (MPSTensor (blockPhysDim d m)) hdim`, rewriting
+`MPSTensor (blockPhysDim d m) (dimA u)` to `MPSTensor (blockPhysDim d m) (dimB v)` so that
+both arguments of `GaugePhaseEquiv` live in the same tensor type. The required conclusion
+is the analogous statement at `(u + 1, v + 1)`:
+
+```lean
+∃ (hdim' : dimA (u + 1) = dimB (v + 1)),
+  GaugePhaseEquiv
+    (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim') (blocksA (u + 1)))
+    (blocksB (v + 1))
+```
 
 The one-site support identities above let one define the ambient corner transitions
 `P (k + 1) * A i = A i * P k`, and they strongly suggest an MPV/state-level translation
@@ -90,4 +104,7 @@ The most promising route now seems to be:
 3. prove the fixed-length translation identity on the corresponding chain/state coefficients;
 4. use a dedicated chain/block gauge theorem to recover the successor `GaugePhaseEquiv`.
 
-This note is intended for a draft PR / handoff, not as a merged-code change.
+This note is merged to `audits/` as a durable handoff record (the documented location for
+such artifacts); it introduces no Lean source changes and does not touch any proof. The
+draft PR itself carries only this file so that the analysis is version-controlled alongside
+the branch that discovered it.


### PR DESCRIPTION
Refs #608.

This is a draft handoff because I could not honestly discharge the target sorry without introducing circular reasoning.

What is included:
- an audit note at ;
- a refined blocker analysis showing that the one-site corner relation is derivable from the current hypotheses;
- the remaining gap is extracting an invertible successor-sector gauge witness from the transported relation on the -fold cyclic products.

Key technical progress documented in the note:
- from , orthogonal-projection partition data, and , one can derive
   and hence ;
- so the real missing bridge is no longer the existence of one-site transitions, but the theorem upgrading the translated blocked-word relation to the required successor .

Verification performed:
- Current branch: HEAD
Using cache (Azure) from origin: leanprover-community/mathlib4
No files to download
Already decompressed 8232 file(s)
- ⚠ [8337/8405] Replayed TNLean.Algebra.MatrixOperatorSpace
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [DecidableEq n] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [Fintype n] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8386/8405] Replayed TNLean.MPS.FundamentalTheorem.EqualProportional
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:438:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:449:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:459:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:464:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
⚠ [8405/8405] Replayed TNLean.MPS.Periodic.Overlap
warning: TNLean/MPS/Periodic/Overlap.lean:205:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:458:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:587:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:636:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:881:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1061:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1136:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1255:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1298:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1362:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1452:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1587:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1641:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1699:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1755:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1819:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1845:8: declaration uses `sorry`
Build completed successfully (8405 jobs).

I did not replace the target  with a proof that depends on downstream sorry-backed declarations, since that would be mathematically circular.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds documentation only and does not modify any Lean code or proofs.
> 
> **Overview**
> Adds an audit handoff note in `audits/2026-04-18_issue608_transport_blocker.md` documenting progress and the remaining blocker for Issue #608 (`sectorGaugePhaseEquiv_succ_of_cyclicTransport`).
> 
> The note records that one-site corner transition identities appear derivable from existing hypotheses, and pinpoints the remaining gap as a missing bridge to lift a sector match at `(u, v)` to `(u+1, v+1)` without relying on downstream `sorry`-backed lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccfe41dba14146867d2d419e0d69bc1115c3842a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->