### PR TITLE
feat(Channel): add POVM, Naimark dilation, and Instrument API

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -54,6 +54,7 @@ import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Stinespring
 import TNLean.Channel.TransferMatrix
+import TNLean.Channel.POVM
 
 -- Layer 2: Quantum entropy infrastructure (depends on Channel.Basic, Channel.PartialTrace)
 import TNLean.Analysis.Entropy

--- a/TNLean/Channel/POVM.lean
+++ b/TNLean/Channel/POVM.lean
@@ -357,6 +357,12 @@ theorem sum_probability (rho : Matrix (Fin D) (Fin D) ℂ) :
     simp [Finset.sum_apply]
   rw [← this, I.tp rho]
 
+/-- Outcome probabilities are non-negative real numbers (in `ℂ` with
+`ComplexOrder`): for any PSD state `ρ`, `0 ≤ I.probability i rho`. -/
+theorem probability_nonneg (i : Fin n) {rho : Matrix (Fin D) (Fin D) ℂ}
+    (hrho : rho.PosSemidef) : 0 ≤ I.probability i rho :=
+  ((I.cp i).isPositiveMap rho hrho).trace_nonneg
+
 /-- The physical **post-measurement state** after outcome `i`: the component
 update normalised by the outcome probability. Only meaningful when the
 probability is nonzero. -/

--- a/TNLean/Channel/POVM.lean
+++ b/TNLean/Channel/POVM.lean
@@ -7,10 +7,9 @@ import TNLean.Channel.Stinespring
 import TNLean.Channel.Semigroup.CPClosure
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
-import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
 
 /-!
-# POVMs, instruments, and the Naimark dilation (Wolf Ch. 2, Thm 2.3 / Neumark)
+# POVMs, instruments, and the Naimark dilation (Wolf Ch. 2, Thm 2.6 / Neumark)
 
 This file defines positive operator-valued measures (POVMs) on `M_D(ℂ)`,
 quantum instruments, and proves the **Naimark extension theorem**: every
@@ -37,14 +36,15 @@ larger (dilated) Hilbert space via an isometry.
 * `POVM.naimarkProjection_hermitian` — `P_iᴴ = P_i`.
 * `POVM.naimarkProjection_orthogonal` — `P_i * P_j = 0` for `i ≠ j`.
 * `POVM.naimark_recovers_povm` — `Vᴴ * P_i * V = E_i` (main Naimark identity).
-* `POVM.exists_naimark_dilation` — the existential form of Wolf Thm 2.3.
-* `POVM.ofProjectiveMeasurement` — converse direction: every isometry + projective
-  measurement yields a POVM via `E_i := Vᴴ P_i V`.
+* `POVM.exists_naimark_dilation` — the existential form of Wolf Thm 2.6.
+* `POVM.ofPSDResolutionOfIdentity` — converse direction: every isometry together
+  with a PSD resolution of identity on the dilated space yields a POVM via
+  `E_i := Vᴴ P_i V`.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Thm 2.3][Wolf2012QChannels]
-  (listed as **Neumark's theorem** / Thm 2.6 in the Wolf Ch.2 index).
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Thm 2.6
+  (Neumark's theorem)][Wolf2012QChannels]
 -/
 
 open scoped Matrix MatrixOrder ComplexOrder TNMatrixCFC
@@ -223,7 +223,7 @@ theorem naimarkProjection_sum_eq_one :
 
 /-! ### Naimark theorem: `Vᴴ * P_i * V = E_i` -/
 
-/-- **Wolf Theorem 2.3 (Naimark / Neumark)**: every POVM `{E_i}` on `ℂ^D` arises
+/-- **Wolf Theorem 2.6 (Naimark / Neumark)**: every POVM `{E_i}` on `ℂ^D` arises
 as `E_i = Vᴴ * P_i * V` for an isometry `V : ℂ^D → ℂ^D ⊗ ℂ^n` and a projective
 measurement `{P_i}` on the dilated space. -/
 theorem naimark_recovers_povm (i : Fin n) :
@@ -262,29 +262,37 @@ theorem naimark_recovers_povm (i : Fin n) :
     rw [hinner, zero_mul]
   · intro h; exact absurd (Finset.mem_univ i) h
 
-/-- **Existential form of Wolf Theorem 2.3**: Naimark dilation exists for every POVM. -/
+/-- **Existential form of Wolf Theorem 2.6**: Naimark dilation exists for every POVM.
+The witnesses `(P i)` form a full projective measurement on the dilation: each is
+self-adjoint and idempotent, pairwise orthogonal, and they sum to the identity. -/
 theorem exists_naimark_dilation :
     ∃ (r : ℕ) (V : Matrix (Fin D × Fin r) (Fin D) ℂ)
       (P : Fin n → Matrix (Fin D × Fin r) (Fin D × Fin r) ℂ),
       Vᴴ * V = 1 ∧
       (∀ i, P i * P i = P i) ∧
       (∀ i, (P i)ᴴ = P i) ∧
+      (∀ i j, i ≠ j → P i * P j = 0) ∧
       (∑ i, P i = 1) ∧
       (∀ i, Vᴴ * P i * V = E.ops i) :=
   ⟨n, E.naimarkIsometry, naimarkProjection, E.naimarkIsometry_isometry,
     naimarkProjection_mul_self, naimarkProjection_hermitian,
+    naimarkProjection_orthogonal,
     naimarkProjection_sum_eq_one, E.naimark_recovers_povm⟩
 
 end POVM
 
-/-! ### Converse: projective measurements on a dilation give POVMs -/
+/-! ### Converse: PSD resolutions of identity on a dilation give POVMs -/
 
 namespace POVM
 
-/-- **Converse of Naimark**: given an isometry `V : ℂ^D → ℂ^d'` and a projective
-measurement `{P_i}` on the dilated space (Hermitian idempotents summing to the
-identity), the pulled-back operators `E_i := Vᴴ * P_i * V` form a POVM. -/
-noncomputable def ofProjectiveMeasurement {D n d' : ℕ}
+/-- **Converse of Naimark (PSD resolution of identity)**: given an isometry
+`V : ℂ^D → ℂ^d'` and a family of positive semidefinite operators `{P_i}` on the
+dilated space summing to the identity, the pulled-back operators
+`E_i := Vᴴ * P_i * V` form a POVM. A projective measurement on the dilation is
+a special case (see `POVM.naimark_recovers_povm` for the canonical Naimark
+instance); the statement here requires only the PSD/sum-to-one structure that
+the proof actually uses. -/
+noncomputable def ofPSDResolutionOfIdentity {D n d' : ℕ}
     (V : Matrix (Fin d') (Fin D) ℂ) (hV : Vᴴ * V = 1)
     (P : Fin n → Matrix (Fin d') (Fin d') ℂ)
     (hPsum : ∑ i, P i = 1)

--- a/TNLean/Channel/POVM.lean
+++ b/TNLean/Channel/POVM.lean
@@ -1,0 +1,360 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Basic
+import TNLean.Channel.Stinespring
+import TNLean.Channel.Semigroup.CPClosure
+import Mathlib.Analysis.CStarAlgebra.Matrix
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
+
+/-!
+# POVMs, instruments, and the Naimark dilation (Wolf Ch. 2, Thm 2.3 / Neumark)
+
+This file defines positive operator-valued measures (POVMs) on `M_D(ℂ)`,
+quantum instruments, and proves the **Naimark extension theorem**: every
+finite-outcome POVM can be realised as a projective measurement on a
+larger (dilated) Hilbert space via an isometry.
+
+## Main definitions
+
+* `POVM D n` — a family of `n` positive-semidefinite `D × D` operators
+  summing to the identity (resolution of identity).
+* `POVM.naimarkKraus` — a Kraus-type square root `M i` with `E i = (M i)ᴴ * M i`,
+  obtained from `CStarAlgebra.nonneg_iff_eq_star_mul_self`.
+* `POVM.naimarkIsometry` — the isometry `V : ℂ^D → ℂ^D ⊗ ℂ^n` built from
+  the Kraus square roots via the Stinespring pattern.
+* `POVM.naimarkProjection i` — the orthogonal projector
+  `P_i = 1_D ⊗ |i⟩⟨i|` on the dilated space.
+* `Instrument D n` — a family of CP maps whose sum is trace-preserving.
+
+## Main results
+
+* `POVM.naimarkIsometry_isometry` — `Vᴴ * V = 𝟙`.
+* `POVM.naimarkProjection_sum_eq_one` — `∑ᵢ P_i = 𝟙` on the dilation.
+* `POVM.naimarkProjection_mul_self` — `P_i * P_i = P_i`.
+* `POVM.naimarkProjection_hermitian` — `P_iᴴ = P_i`.
+* `POVM.naimarkProjection_orthogonal` — `P_i * P_j = 0` for `i ≠ j`.
+* `POVM.naimark_recovers_povm` — `Vᴴ * P_i * V = E_i` (main Naimark identity).
+* `POVM.exists_naimark_dilation` — the existential form of Wolf Thm 2.3.
+* `POVM.ofProjectiveMeasurement` — converse direction: every isometry + projective
+  measurement yields a POVM via `E_i := Vᴴ P_i V`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Thm 2.3][Wolf2012QChannels]
+  (listed as **Neumark's theorem** / Thm 2.6 in the Wolf Ch.2 index).
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder TNMatrixCFC
+open Matrix Finset BigOperators
+
+variable {D n : ℕ}
+
+/-! ### Positive operator-valued measures -/
+
+/-- A **POVM** with `n` outcomes on `M_D(ℂ)`:
+a family of positive-semidefinite operators summing to the identity. -/
+structure POVM (D n : ℕ) where
+  /-- The `n` positive-semidefinite effect operators. -/
+  ops : Fin n → Matrix (Fin D) (Fin D) ℂ
+  /-- Each effect operator is positive semidefinite. -/
+  posSemidef : ∀ i, (ops i).PosSemidef
+  /-- Resolution of the identity: the effects sum to `𝟙`. -/
+  sum_eq_one : ∑ i, ops i = (1 : Matrix (Fin D) (Fin D) ℂ)
+
+namespace POVM
+
+variable (E : POVM D n)
+
+/-- The Kraus-type square root of each POVM effect: an operator `M i`
+satisfying `E i = (M i)ᴴ * M i`, chosen by `CStarAlgebra.nonneg_iff_eq_star_mul_self`. -/
+noncomputable def naimarkKraus (i : Fin n) : Matrix (Fin D) (Fin D) ℂ :=
+  Classical.choose
+    (CStarAlgebra.nonneg_iff_eq_star_mul_self.mp (E.posSemidef i).nonneg)
+
+/-- Defining property of `naimarkKraus`: `E i = (M i)ᴴ * M i`. -/
+theorem naimarkKraus_spec (i : Fin n) :
+    E.ops i = (E.naimarkKraus i)ᴴ * E.naimarkKraus i := by
+  have h := Classical.choose_spec
+    (CStarAlgebra.nonneg_iff_eq_star_mul_self.mp (E.posSemidef i).nonneg)
+  simpa [naimarkKraus, Matrix.star_eq_conjTranspose] using h
+
+/-- `∑ᵢ (M i)ᴴ * M i = 𝟙` — the normalization condition on the Kraus square roots,
+equivalent to the resolution of the identity for the POVM. -/
+theorem sum_naimarkKraus_conjTranspose_mul :
+    ∑ i, (E.naimarkKraus i)ᴴ * E.naimarkKraus i =
+      (1 : Matrix (Fin D) (Fin D) ℂ) := by
+  have : ∑ i, (E.naimarkKraus i)ᴴ * E.naimarkKraus i = ∑ i, E.ops i := by
+    refine Finset.sum_congr rfl ?_
+    intro i _
+    exact (E.naimarkKraus_spec i).symm
+  rw [this, E.sum_eq_one]
+
+/-! ### Naimark isometry -/
+
+/-- The **Naimark isometry** `V : ℂ^D → ℂ^D ⊗ ℂ^n` attached to the POVM,
+built from the Kraus square roots via the Stinespring pattern:
+`V (k, i) j = (M i)_{k, j}`. -/
+noncomputable def naimarkIsometry :
+    Matrix (Fin D × Fin n) (Fin D) ℂ :=
+  stinespringV E.naimarkKraus
+
+/-- `Vᴴ * V = 𝟙`: the Naimark isometry is indeed an isometry. -/
+theorem naimarkIsometry_isometry :
+    (E.naimarkIsometry)ᴴ * E.naimarkIsometry =
+      (1 : Matrix (Fin D) (Fin D) ℂ) := by
+  rw [naimarkIsometry, stinespringV_conjTranspose_mul]
+  exact E.sum_naimarkKraus_conjTranspose_mul
+
+/-! ### Naimark projective measurement -/
+
+/-- The `i`-th **Naimark projector** on the dilated space
+`ℂ^D ⊗ ℂ^n`: `P_i = 𝟙_D ⊗ |i⟩⟨i|`, defined entrywise by
+`P_i ((a, b), (c, d)) = δ_{a, c} · δ_{b, i} · δ_{d, i}`. -/
+noncomputable def naimarkProjection (i : Fin n) :
+    Matrix (Fin D × Fin n) (Fin D × Fin n) ℂ :=
+  fun (p : Fin D × Fin n) (q : Fin D × Fin n) =>
+    if p.1 = q.1 ∧ p.2 = i ∧ q.2 = i then 1 else 0
+
+@[simp]
+theorem naimarkProjection_apply (i : Fin n)
+    (a c : Fin D) (b d : Fin n) :
+    naimarkProjection (D := D) i (a, b) (c, d) =
+      if a = c ∧ b = i ∧ d = i then 1 else 0 := rfl
+
+/-- Naimark projectors are Hermitian. -/
+theorem naimarkProjection_hermitian (i : Fin n) :
+    (naimarkProjection (D := D) i)ᴴ = naimarkProjection i := by
+  ext ⟨a, b⟩ ⟨c, d⟩
+  simp only [Matrix.conjTranspose_apply, naimarkProjection_apply]
+  by_cases hca : c = a
+  · by_cases hdi : d = i
+    · by_cases hbi : b = i
+      · subst hca hdi hbi; simp
+      · simp [hdi, hbi]
+    · by_cases hbi : b = i
+      · simp [hdi, hbi]
+      · simp [hdi, hbi]
+  · have hac : a ≠ c := fun h => hca h.symm
+    simp [hca, hac]
+
+/-- Naimark projectors are idempotent: `P_i * P_i = P_i`. -/
+theorem naimarkProjection_mul_self (i : Fin n) :
+    naimarkProjection (D := D) i * naimarkProjection i =
+      naimarkProjection i := by
+  ext ⟨a, b⟩ ⟨c, d⟩
+  simp only [Matrix.mul_apply, naimarkProjection_apply, Fintype.sum_prod_type]
+  by_cases hbi : b = i
+  · by_cases hdi : d = i
+    · rw [Finset.sum_eq_single a]
+      · rw [Finset.sum_eq_single i]
+        · by_cases hac : a = c
+          · subst hac; simp [hbi, hdi]
+          · simp [hac, hbi, hdi]
+        · intro b' _ hb'i
+          simp [hb'i]
+        · intro h; exact absurd (Finset.mem_univ i) h
+      · intro a' _ ha'a
+        refine Finset.sum_eq_zero ?_
+        intro b' _
+        simp [Ne.symm ha'a]
+      · intro h; exact absurd (Finset.mem_univ a) h
+    · have hfalse : ¬(a = c ∧ b = i ∧ d = i) := fun ⟨_, _, h⟩ => hdi h
+      rw [if_neg hfalse]
+      refine Finset.sum_eq_zero fun a' _ => ?_
+      refine Finset.sum_eq_zero fun b' _ => ?_
+      by_cases hb'i : b' = i
+      · simp [hb'i, hdi]
+      · simp [hb'i]
+  · have hfalse : ¬(a = c ∧ b = i ∧ d = i) := fun ⟨_, h, _⟩ => hbi h
+    rw [if_neg hfalse]
+    refine Finset.sum_eq_zero fun a' _ => ?_
+    refine Finset.sum_eq_zero fun b' _ => ?_
+    simp [hbi]
+
+/-- Distinct Naimark projectors are orthogonal: `P_i * P_j = 0` if `i ≠ j`. -/
+theorem naimarkProjection_orthogonal (i j : Fin n) (hij : i ≠ j) :
+    naimarkProjection (D := D) i * naimarkProjection j = 0 := by
+  ext ⟨a, b⟩ ⟨c, d⟩
+  simp only [Matrix.mul_apply, naimarkProjection_apply, Fintype.sum_prod_type,
+    Matrix.zero_apply]
+  refine Finset.sum_eq_zero ?_
+  intro a' _
+  refine Finset.sum_eq_zero ?_
+  intro b' _
+  -- Either the first factor vanishes (b' ≠ i) or the second vanishes (b' ≠ j);
+  -- these two conditions can never both fail because i ≠ j.
+  by_cases hb'i : b' = i
+  · have hb'j : b' ≠ j := hb'i ▸ hij
+    simp [hb'j]
+  · simp [hb'i]
+
+/-- The Naimark projectors sum to the identity: `∑ᵢ P_i = 𝟙`. -/
+theorem naimarkProjection_sum_eq_one :
+    ∑ i : Fin n, naimarkProjection (D := D) i =
+      (1 : Matrix (Fin D × Fin n) (Fin D × Fin n) ℂ) := by
+  ext ⟨a, b⟩ ⟨c, d⟩
+  rw [Matrix.sum_apply]
+  simp only [naimarkProjection_apply]
+  by_cases hbd : b = d
+  · subst hbd
+    by_cases hac : a = c
+    · subst hac
+      rw [Finset.sum_eq_single b]
+      · simp
+      · intro j _ hjb
+        simp [Ne.symm hjb]
+      · intro h
+        exact absurd (Finset.mem_univ b) h
+    · rw [Matrix.one_apply_ne (by simp [hac])]
+      refine Finset.sum_eq_zero ?_
+      intro j _
+      simp [hac]
+  · rw [Matrix.one_apply_ne (by simp [hbd])]
+    refine Finset.sum_eq_zero ?_
+    intro j _
+    by_cases hbj : b = j
+    · by_cases hdj : d = j
+      · exact absurd (hbj.trans hdj.symm) hbd
+      · simp [hbj, hdj]
+    · simp [hbj]
+
+/-! ### Naimark theorem: `Vᴴ * P_i * V = E_i` -/
+
+/-- **Wolf Theorem 2.3 (Naimark / Neumark)**: every POVM `{E_i}` on `ℂ^D` arises
+as `E_i = Vᴴ * P_i * V` for an isometry `V : ℂ^D → ℂ^D ⊗ ℂ^n` and a projective
+measurement `{P_i}` on the dilated space. -/
+theorem naimark_recovers_povm (i : Fin n) :
+    (E.naimarkIsometry)ᴴ * naimarkProjection (D := D) i *
+        E.naimarkIsometry = E.ops i := by
+  rw [E.naimarkKraus_spec i]
+  ext k l
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    naimarkIsometry, stinespringV_apply,
+    naimarkProjection_apply, Fintype.sum_prod_type]
+  -- LHS: ∑ q1, ∑ q2, (∑ p1, ∑ p2, star(K p2 p1 k) *
+  --                                  [p1=q1 ∧ p2=i ∧ q2=i]) * K q2 q1 l
+  -- RHS: ∑ a, star(K i a k) * K i a l
+  refine Finset.sum_congr rfl ?_
+  intro q1 _
+  rw [Finset.sum_eq_single i]
+  · -- q2 = i: peel inner p1 = q1, then p2 = i.
+    rw [Finset.sum_eq_single q1]
+    · rw [Finset.sum_eq_single i]
+      · simp
+      · intro p2 _ hp2; simp [hp2]
+      · intro h; exact absurd (Finset.mem_univ i) h
+    · intro p1 _ hp1
+      refine Finset.sum_eq_zero fun p2 _ => ?_
+      simp [hp1]
+    · intro h; exact absurd (Finset.mem_univ q1) h
+  · -- q2 ≠ i: the inner sum is 0, so the product with `K q2 q1 l` is 0.
+    intro q2 _ hq2
+    have hinner : (∑ p1 : Fin D, ∑ p2 : Fin n,
+        star (E.naimarkKraus p2 p1 k) *
+          (if p1 = q1 ∧ p2 = i ∧ q2 = i then (1 : ℂ) else 0)) = 0 := by
+      refine Finset.sum_eq_zero fun p1 _ => ?_
+      refine Finset.sum_eq_zero fun p2 _ => ?_
+      rw [if_neg (fun h => hq2 h.2.2)]
+      ring
+    rw [hinner, zero_mul]
+  · intro h; exact absurd (Finset.mem_univ i) h
+
+/-- **Existential form of Wolf Theorem 2.3**: Naimark dilation exists for every POVM. -/
+theorem exists_naimark_dilation :
+    ∃ (r : ℕ) (V : Matrix (Fin D × Fin r) (Fin D) ℂ)
+      (P : Fin n → Matrix (Fin D × Fin r) (Fin D × Fin r) ℂ),
+      Vᴴ * V = 1 ∧
+      (∀ i, P i * P i = P i) ∧
+      (∀ i, (P i)ᴴ = P i) ∧
+      (∑ i, P i = 1) ∧
+      (∀ i, Vᴴ * P i * V = E.ops i) :=
+  ⟨n, E.naimarkIsometry, naimarkProjection, E.naimarkIsometry_isometry,
+    naimarkProjection_mul_self, naimarkProjection_hermitian,
+    naimarkProjection_sum_eq_one, E.naimark_recovers_povm⟩
+
+end POVM
+
+/-! ### Converse: projective measurements on a dilation give POVMs -/
+
+namespace POVM
+
+/-- **Converse of Naimark**: given an isometry `V : ℂ^D → ℂ^d'` and a projective
+measurement `{P_i}` on the dilated space (Hermitian idempotents summing to the
+identity), the pulled-back operators `E_i := Vᴴ * P_i * V` form a POVM. -/
+noncomputable def ofProjectiveMeasurement {D n d' : ℕ}
+    (V : Matrix (Fin d') (Fin D) ℂ) (hV : Vᴴ * V = 1)
+    (P : Fin n → Matrix (Fin d') (Fin d') ℂ)
+    (hPsum : ∑ i, P i = 1)
+    (hPpos : ∀ i, (P i).PosSemidef) :
+    POVM D n where
+  ops i := Vᴴ * P i * V
+  posSemidef i := by
+    -- Vᴴ * (P i) * V = Vᴴ * (P i) * (Vᴴᴴ); apply PSD-sandwich with B := Vᴴ.
+    have := (hPpos i).mul_mul_conjTranspose_same (B := Vᴴ)
+    simpa [Matrix.mul_assoc] using this
+  sum_eq_one := by
+    rw [← Matrix.sum_mul, ← Matrix.mul_sum, hPsum, Matrix.mul_one]
+    exact hV
+
+end POVM
+
+/-! ### Quantum instruments -/
+
+/-- A **quantum instrument** with `n` outcomes: a family of completely positive
+maps whose sum is a quantum channel (trace-preserving). The `i`-th component
+implements the (unnormalised) post-measurement update for outcome `i`. -/
+structure Instrument (D n : ℕ) where
+  /-- The `n` completely-positive component maps. -/
+  maps : Fin n → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ
+  /-- Each component map is completely positive. -/
+  cp : ∀ i, IsCPMap (maps i)
+  /-- The sum of the component maps is trace-preserving. -/
+  tp : IsTracePreservingMap (∑ i, maps i)
+
+namespace Instrument
+
+variable (I : Instrument D n)
+
+/-- The overall quantum channel `∑ᵢ Φᵢ` obtained by averaging over outcomes. -/
+noncomputable def total :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+  ∑ i, I.maps i
+
+/-- The average map of an instrument is a quantum channel (CPTP). -/
+theorem total_isChannel : IsChannel I.total := by
+  refine ⟨?_, I.tp⟩
+  exact Finset.isCPMap_sum (n := Fin D) Finset.univ I.maps (fun i _ => I.cp i)
+
+/-- The (unnormalised) **post-measurement state update** after outcome `i`:
+`ρ ↦ Φ_i(ρ)`. The physical normalised state is `Φ_i(ρ) / tr(Φ_i(ρ))`
+(see `Instrument.probability` and `Instrument.posteriorState`). -/
+noncomputable def update (i : Fin n) (rho : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  I.maps i rho
+
+/-- The probability of observing outcome `i` in state `ρ`: `tr(Φ_i(ρ))`. -/
+noncomputable def probability (i : Fin n) (rho : Matrix (Fin D) (Fin D) ℂ) :
+    ℂ :=
+  Matrix.trace (I.maps i rho)
+
+/-- **Conservation of probability**: for any state `ρ`, the outcome probabilities
+sum to `tr(ρ)`. -/
+theorem sum_probability (rho : Matrix (Fin D) (Fin D) ℂ) :
+    ∑ i, I.probability i rho = Matrix.trace rho := by
+  simp only [probability, ← Matrix.trace_sum]
+  have : (∑ i, I.maps i) rho = ∑ i, I.maps i rho := by
+    simp [Finset.sum_apply]
+  rw [← this, I.tp rho]
+
+/-- The physical **post-measurement state** after outcome `i`: the component
+update normalised by the outcome probability. Only meaningful when the
+probability is nonzero. -/
+noncomputable def posteriorState (i : Fin n)
+    (rho : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  (I.probability i rho)⁻¹ • I.maps i rho
+
+end Instrument

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -9,6 +9,7 @@ import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausFreedom
 import TNLean.Channel.Stinespring
+import TNLean.Channel.POVM
 import TNLean.Channel.TransferMatrix
 
 /-!
@@ -50,6 +51,17 @@ representations of quantum channels.
   - `stinespringV_isometry_iff_kraus_normalized` — `V†V = 𝟙` ↔ TP ✅
   - `stinespring_schrodinger_representation` — `T(ρ) = tr_r(VρV†)` ✅
 
+* **Thm 2.3** (Naimark / Neumark dilation for POVMs):
+  - `POVM` — positive operator-valued measure structure ✅
+  - `POVM.naimarkIsometry_isometry` — `V†V = 𝟙` ✅
+  - `POVM.naimarkProjection_mul_self` / `_hermitian` / `_orthogonal` /
+    `_sum_eq_one` — projective-measurement axioms on the dilation ✅
+  - `POVM.naimark_recovers_povm` — `V† P_i V = E_i` ✅
+  - `POVM.exists_naimark_dilation` — existential Naimark dilation ✅
+  - `POVM.ofProjectiveMeasurement` — converse construction from dilations ✅
+  - `Instrument` — quantum-instrument structure + `total_isChannel`,
+    `sum_probability`, `posteriorState` API ✅
+
 ### §2.2 Transfer matrix
 
 * `transferMatrix` — the `D² × D²` matrix representing `T` in the
@@ -86,6 +98,10 @@ representations of quantum channels.
 | Tensor product of maps | `TensorMap.lean` | `Matrix.tensorMapId` |
 | Choi matrix | `ChoiJamiolkowski.lean` | `ChoiJamiolkowski.choiMatrix` |
 | Stinespring isometry | `Stinespring.lean` | `stinespringV` |
+| POVM | `POVM.lean` | `POVM` |
+| Naimark isometry | `POVM.lean` | `POVM.naimarkIsometry` |
+| Naimark projector | `POVM.lean` | `POVM.naimarkProjection` |
+| Quantum instrument | `POVM.lean` | `Instrument` |
 | Transfer matrix | `TransferMatrix.lean` | `transferMatrix` |
 | Unitary conjugation | `TransferMatrix.lean` | `unitaryConjLM` |
 | Vectorization | `Mathlib.LinearAlgebra.Matrix.Vec` | `Matrix.vec` |
@@ -101,7 +117,6 @@ representations of quantum channels.
 | Thm 2.3 (ordered CP-maps) | Needs Stinespring + contraction |
 | Thm 2.4 (Radon-Nikodym) | Follows from Thm 2.3 |
 | Thm 2.5 (open-system representation) | Embedding into unitary |
-| Thm 2.6 (Neumark's theorem) | POVM embedding |
 | §2.3 Lorentz normal form (existence) | Needs SVD of transfer matrix |
 | §2.3 SVD representation (existence) | Needs Mathlib SVD |
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -51,14 +51,15 @@ representations of quantum channels.
   - `stinespringV_isometry_iff_kraus_normalized` — `V†V = 𝟙` ↔ TP ✅
   - `stinespring_schrodinger_representation` — `T(ρ) = tr_r(VρV†)` ✅
 
-* **Thm 2.3** (Naimark / Neumark dilation for POVMs):
+* **Thm 2.6** (Naimark / Neumark dilation for POVMs):
   - `POVM` — positive operator-valued measure structure ✅
   - `POVM.naimarkIsometry_isometry` — `V†V = 𝟙` ✅
   - `POVM.naimarkProjection_mul_self` / `_hermitian` / `_orthogonal` /
     `_sum_eq_one` — projective-measurement axioms on the dilation ✅
   - `POVM.naimark_recovers_povm` — `V† P_i V = E_i` ✅
   - `POVM.exists_naimark_dilation` — existential Naimark dilation ✅
-  - `POVM.ofProjectiveMeasurement` — converse construction from dilations ✅
+  - `POVM.ofPSDResolutionOfIdentity` — converse construction: PSD resolution
+    of identity on a dilation pulls back to a POVM ✅
   - `Instrument` — quantum-instrument structure + `total_isChannel`,
     `sum_probability`, `posteriorState` API ✅
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1043,6 +1043,174 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \end{proof}
 
 %% =========================================================
+\section{POVMs and Naimark dilation (Wolf Thm.~2.3)}
+\label{sec:povm_naimark}
+%% =========================================================
+
+\begin{definition}[Positive operator-valued measure]\label{def:povm}
+    \lean{POVM}
+    \leanok
+    A \emph{positive operator-valued measure} with $n$ outcomes on $\C^D$
+    is a family $\{E_i\}_{i=1}^n$ of positive semidefinite
+    operators on $\C^D$ satisfying the resolution of identity
+    \[
+        \sum_{i=1}^n E_i = \one_D.
+    \]
+\end{definition}
+
+\begin{definition}[Naimark Kraus square roots]\label{def:naimark_kraus}
+    \lean{POVM.naimarkKraus}
+    \leanok
+    \uses{def:povm}
+    For a POVM $\{E_i\}$, each effect $E_i \ge 0$ admits a square-root
+    factorisation $E_i = M_i^\dagger M_i$ with $M_i \in \MN{D}$. The
+    operators $M_i$ are the \emph{Naimark Kraus square roots}.
+\end{definition}
+
+\begin{definition}[Naimark isometry]\label{def:naimark_isometry}
+    \lean{POVM.naimarkIsometry}
+    \leanok
+    \uses{def:naimark_kraus, def:stinespring_v}
+    The \emph{Naimark isometry} $V : \C^D \to \C^D \otimes \C^n$ of a POVM
+    is the Stinespring-style assembly
+    \[
+        V = \sum_{i=1}^n M_i \otimes |i\rangle,
+        \qquad V_{(a,i),\,k} = (M_i)_{a,k}.
+    \]
+\end{definition}
+
+\begin{definition}[Naimark projective measurement]\label{def:naimark_projection}
+    \lean{POVM.naimarkProjection}
+    \leanok
+    The \emph{Naimark projectors} on $\C^D \otimes \C^n$ are
+    \[
+        P_i = \one_D \otimes |i\rangle\langle i|,
+        \qquad (P_i)_{(a,b),(c,d)} = \delta_{a,c}\,\delta_{b,i}\,\delta_{d,i}.
+    \]
+\end{definition}
+
+\begin{theorem}[Naimark isometry condition]\label{thm:naimark_isometry_isometry}
+    \lean{POVM.naimarkIsometry_isometry}
+    \leanok
+    \uses{def:naimark_isometry, def:povm}
+    The Naimark isometry satisfies $V^\dagger V = \one_D$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The Stinespring Gram identity gives
+    $V^\dagger V = \sum_i M_i^\dagger M_i = \sum_i E_i = \one_D$
+    by the resolution of identity.
+\end{proof}
+
+\begin{theorem}[Naimark projectors form a projective measurement]
+    \label{thm:naimark_projection_axioms}
+    \lean{POVM.naimarkProjection_mul_self,
+          POVM.naimarkProjection_hermitian,
+          POVM.naimarkProjection_orthogonal,
+          POVM.naimarkProjection_sum_eq_one}
+    \leanok
+    \uses{def:naimark_projection}
+    The Naimark projectors satisfy $P_i^2 = P_i$, $P_i^\dagger = P_i$,
+    $P_i P_j = 0$ for $i \ne j$, and $\sum_i P_i = \one_{\C^D \otimes \C^n}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Each identity follows from direct entrywise computation using the
+    delta-function form of $(P_i)_{(a,b),(c,d)}$.
+\end{proof}
+
+\begin{theorem}[Thm.~2.3: Naimark dilation]\label{thm:naimark_recovers_povm}
+    \lean{POVM.naimark_recovers_povm}
+    \leanok
+    \uses{def:povm, def:naimark_isometry, def:naimark_projection,
+          thm:naimark_isometry_isometry, thm:naimark_projection_axioms}
+    Every POVM $\{E_i\}_{i=1}^n$ arises as a projective measurement on a
+    dilation: for the isometry $V$ and projectors $P_i$ above,
+    \[
+        E_i = V^\dagger P_i V.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Computing entrywise,
+    $(V^\dagger P_i V)_{k,\ell}
+      = \sum_{a} \overline{(M_i)_{a,k}}\,(M_i)_{a,\ell}
+      = (M_i^\dagger M_i)_{k,\ell}
+      = (E_i)_{k,\ell}$.
+\end{proof}
+
+\begin{theorem}[Existential Naimark dilation]\label{thm:exists_naimark_dilation}
+    \lean{POVM.exists_naimark_dilation}
+    \leanok
+    \uses{thm:naimark_recovers_povm}
+    For every POVM $\{E_i\}$ on $\C^D$ there exist a dilation dimension $r$,
+    an isometry $V : \C^D \to \C^D \otimes \C^r$, and a projective
+    measurement $\{P_i\}$ on the dilation satisfying $E_i = V^\dagger P_i V$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take $r = n$ and the explicit witnesses $V = \sum_i M_i \otimes |i\rangle$
+    and $P_i = \one_D \otimes |i\rangle\langle i|$.
+\end{proof}
+
+\begin{definition}[POVM from a projective measurement on a dilation]
+    \label{def:povm_of_projective_measurement}
+    \lean{POVM.ofProjectiveMeasurement}
+    \leanok
+    Given an isometry $V : \C^D \to \C^{d'}$ with $V^\dagger V = \one_D$
+    and a projective measurement $\{P_i\}_{i=1}^n$ on $\C^{d'}$
+    (positive semidefinite operators summing to the identity), the
+    operators
+    \[
+        E_i := V^\dagger P_i V
+    \]
+    form a POVM.
+\end{definition}
+
+\begin{definition}[Quantum instrument]\label{def:instrument}
+    \lean{Instrument}
+    \leanok
+    \uses{def:cp_map, def:trace_preserving}
+    A \emph{quantum instrument} with $n$ outcomes is a family
+    $\{\Phi_i\}_{i=1}^n$ of completely positive maps on $\MN{D}$ whose
+    sum $\sum_i \Phi_i$ is trace-preserving.
+\end{definition}
+
+\begin{theorem}[Instrument total map is a channel]
+    \label{thm:instrument_total_is_channel}
+    \lean{Instrument.total_isChannel}
+    \leanok
+    \uses{def:instrument, def:channel}
+    The total map $\sum_i \Phi_i$ of an instrument is a quantum channel.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Complete positivity of the sum follows from closure of CP maps under
+    finite addition; trace preservation is built into the definition.
+\end{proof}
+
+\begin{theorem}[Conservation of probability for instruments]
+    \label{thm:instrument_sum_probability}
+    \lean{Instrument.sum_probability}
+    \leanok
+    \uses{def:instrument}
+    For every state $\rho \in \MN{D}$, the outcome probabilities
+    $p_i(\rho) := \operatorname{tr}(\Phi_i(\rho))$ sum to $\operatorname{tr}(\rho)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Linearity of trace and trace preservation of $\sum_i \Phi_i$ give
+    $\sum_i \operatorname{tr}(\Phi_i(\rho)) = \operatorname{tr}\bigl((\sum_i \Phi_i)(\rho)\bigr)
+      = \operatorname{tr}(\rho)$.
+\end{proof}
+
+%% =========================================================
 \subsection{Trace-pairing expansion in transfer-matrix form}
 \label{subsec:trace_pairing_expansion}
 %% =========================================================

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1043,7 +1043,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \end{proof}
 
 %% =========================================================
-\section{POVMs and Naimark dilation (Wolf Thm.~2.3)}
+\section{POVMs and Naimark dilation (Wolf Thm.~2.6)}
 \label{sec:povm_naimark}
 %% =========================================================
 
@@ -1121,7 +1121,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     delta-function form of $(P_i)_{(a,b),(c,d)}$.
 \end{proof}
 
-\begin{theorem}[Thm.~2.3: Naimark dilation]\label{thm:naimark_recovers_povm}
+\begin{theorem}[Thm.~2.6: Naimark dilation]\label{thm:naimark_recovers_povm}
     \lean{POVM.naimark_recovers_povm}
     \leanok
     \uses{def:povm, def:naimark_isometry, def:naimark_projection,
@@ -1157,18 +1157,19 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     and $P_i = \one_D \otimes |i\rangle\langle i|$.
 \end{proof}
 
-\begin{definition}[POVM from a projective measurement on a dilation]
-    \label{def:povm_of_projective_measurement}
-    \lean{POVM.ofProjectiveMeasurement}
+\begin{definition}[POVM from a PSD resolution of identity on a dilation]
+    \label{def:povm_of_psd_resolution_of_identity}
+    \lean{POVM.ofPSDResolutionOfIdentity}
     \leanok
     Given an isometry $V : \C^D \to \C^{d'}$ with $V^\dagger V = \one_D$
-    and a projective measurement $\{P_i\}_{i=1}^n$ on $\C^{d'}$
-    (positive semidefinite operators summing to the identity), the
-    operators
+    and a family $\{P_i\}_{i=1}^n$ of positive semidefinite operators on
+    $\C^{d'}$ summing to the identity, the pulled-back operators
     \[
         E_i := V^\dagger P_i V
     \]
-    form a POVM.
+    form a POVM. In particular, any projective measurement on the
+    dilation (a special case of a PSD resolution of identity) pulls back
+    to a POVM.
 \end{definition}
 
 \begin{definition}[Quantum instrument]\label{def:instrument}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1211,6 +1211,23 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
       = \operatorname{tr}(\rho)$.
 \end{proof}
 
+\begin{theorem}[Non-negativity of instrument probabilities]
+    \label{thm:instrument_probability_nonneg}
+    \lean{Instrument.probability_nonneg}
+    \leanok
+    \uses{def:instrument}
+    If $\rho \in \MN{D}$ is positive semidefinite, then each outcome
+    probability $p_i(\rho) = \operatorname{tr}(\Phi_i(\rho))$ is a
+    non-negative real number.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Each $\Phi_i$ is completely positive, hence positive, so
+    $\Phi_i(\rho)$ is positive semidefinite and its trace is a
+    non-negative real.
+\end{proof}
+
 %% =========================================================
 \subsection{Trace-pairing expansion in transfer-matrix form}
 \label{subsec:trace_pairing_expansion}


### PR DESCRIPTION
### Motivation

- Port Wolf *Quantum Channels & Operations* Theorem 2.3 (Naimark/Neumark dilation) — the last non-trivial gap in the Wolf Ch. 2 formalization (see tracker LionSR/QICLean#15).
- Provide the POVM / quantum-instrument API on top of the dilation theorem, needed for subsequent measurement-theoretic developments.

### Description

- Add `TNLean/Channel/POVM.lean` (new module) containing:
  - `POVM D n`: positive operator-valued measure with resolution of identity.
  - `POVM.naimarkIsometry`: isometry built from Kraus square roots via the Stinespring pattern (`CStarAlgebra.nonneg_iff_eq_star_mul_self`).
  - `POVM.naimarkProjection`: ancilla projectors `1 ⊗ |i⟩⟨i|` with idempotence, hermiticity, orthogonality, and sum-to-identity lemmas.
  - `POVM.naimark_recovers_povm` / `POVM.exists_naimark_dilation`: the main `Vᴴ * Pᵢ * V = Eᵢ` identity and its existential form.
  - `POVM.ofProjectiveMeasurement`: converse POVM construction from a projective measurement.
  - `Instrument D n` with `total_isChannel` (via `Finset.isCPMap_sum`), `sum_probability`, and `posteriorState`.
- Expose the new module via `TNLean.lean` and extend `TNLean/Channel/WolfChapter2Index.lean` to index the new theorem and definitions.
- Update `blueprint/src/chapter/ch04_channels.tex` with a new section for Thm 2.3 and matching `\lean{}` / `\leanok` tags.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate `lake build`.
- Blueprint declarations validated with `leanblueprint checkdecls`.

---
Addresses LionSR/QICLean#131

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces a new, widely re-exported `Channel` module (`TNLean.Channel.POVM`) with substantial new definitions/lemmas that can impact downstream compilation and typeclass/inference behavior, though changes are largely additive and formalization-only.
> 
> **Overview**
> Adds a new `TNLean.Channel.POVM` module defining finite-outcome `POVM` and `Instrument` structures and proving Naimark’s dilation theorem via an explicitly constructed isometry/projective measurement (`naimarkIsometry`, `naimarkProjection`, and `Vᴴ * P i * V = E i`), plus a converse construction `ofPSDResolutionOfIdentity`.
> 
> Re-exports the new module from `TNLean.lean`, extends `WolfChapter2Index.lean` to index Wolf Thm 2.6 coverage, and updates the blueprint (`ch04_channels.tex`) with a matching POVM/Naimark/Instrument section and Lean cross-references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc0c40a9512078f632212da7e8483a11853f4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->