### PR TITLE
refactor(MPS/CanonicalForm): drop unused _hDimEq from exists_bnt_grouping

### DIFF
--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -61,10 +61,13 @@ for the equal-norm case.
 ### §4 BNT grouping for possibly-equal norms (proved via norm-class enumeration)
 
 * `exists_bnt_grouping` — For blocks with possibly equal norms, given that equal-norm
-  blocks have the same dimension and the same MPV function (consequences of BNT
-  uniqueness, not yet fully formalized), there exists a `SectorDecomposition` whose
-  assembled tensor is `SameMPV₂`-equivalent to the original and whose BNT-level norms
-  are strictly decreasing.  The proof constructs a SectorDecomposition from norm-class enumeration.
+  blocks have the same MPV function (a consequence of BNT uniqueness), there exists a
+  `SectorDecomposition` whose assembled tensor is `SameMPV₂`-equivalent to the original
+  and whose BNT-level norms are strictly decreasing.  The proof constructs a
+  `SectorDecomposition` from norm-class enumeration and uses the representative block's
+  dimension for the sector `basisDim`.  A same-dimension hypothesis is not needed: the
+  choice of representative fixes the sector's bond dimension regardless of other
+  equal-norm blocks.
 
 ## References
 
@@ -369,27 +372,30 @@ noncomputable def normClassGroupingData {r : ℕ} (μ : Fin r → ℂ) :
 /-- **BNT grouping step (equal-norm case, proved via norm-class enumeration).**
 
 Given a weighted block family `(μ, blocks)` where some blocks may share the same norm
-`‖μ j‖ = ‖μ k‖`, and given that equal-norm blocks share the same dimension and the
-same MPV function (hypotheses that follow from BNT uniqueness in the full
-formalization), there exists a `SectorDecomposition P` with:
+`‖μ j‖ = ‖μ k‖`, and given that equal-norm blocks share the same MPV function
+(a hypothesis that follows from BNT uniqueness in the full formalization), there exists
+a `SectorDecomposition P` with:
 
 1. `SameMPV₂ P.toTensor (toTensorFromBlocks μ blocks)`.
 2. `StrictAnti` on the BNT-level norms (one norm value per group).
 
 **Hypotheses**:
 - `hμne`: all weights are nonzero.
-- `hDimEq`: equal-norm blocks have the same bond dimension (so that `P.basisDim j`
-  is well-defined as `dim (repr j)` for any representative of norm class `j`).
 - `hMPVEq`: equal-norm blocks have the same MPV function, i.e., `SameMPV₂ (blocks j) (blocks k)`.
   This is needed so `P.basis j` (a single tensor) can stand in for all blocks in
   norm class `j`.
 
-**Why these hypotheses arise in the full theory**:
+Note that no equal-dimension hypothesis is needed: the sector's bond dimension is
+fixed by the chosen representative `reprFn j`, and other members of the same norm
+class may have different dimensions — their MPV values are matched via `hMPVEq`,
+which uses the heterogeneous `SameMPV₂` to accommodate different bond dimensions.
+
+**Why `hMPVEq` arises in the full theory**:
 In the BNT theory (CPGSV17, §2.3), two blocks with the same weight norm are
-gauge-phase equivalent, hence have the same MPV and the same bond dimension.  In the
-existence reduction, these properties would be derived after applying the BNT uniqueness
-theorem.  Since BNT uniqueness is not yet fully formalized, the hypotheses are stated
-explicitly.
+gauge-phase equivalent, hence have the same MPV.  In the existence reduction, this
+property would be derived after applying the BNT uniqueness theorem.  The derivation
+of `hMPVEq` from blocked `SameMPV₂` data is the subject of `EqualNormBridge.lean`
+and downstream theorems (see `exists_sectorDecomp_of_tp_primitive_irr_blocks`).
 
 **Proof:**
 1. Let `S = Finset.univ.image (‖μ ·‖)`, `g = S.card`.
@@ -398,8 +404,7 @@ explicitly.
    - `repr j ∈ Fin r`: pick any block with `‖μ (repr j)‖ = v_j`.
    - `classOf j = {k | ‖μ k‖ = v_j}`, `copies j = #classOf j ≥ 1`.
    - Enumerate class: `enum j : Fin (copies j) → Fin r`.
-   - `P.basis j = blocks (repr j)`, `P.basisDim j = dim (repr j) = dim k` for all
-     `k ∈ classOf j` (well-defined by `hDimEq`).
+   - `P.basis j = blocks (repr j)`, `P.basisDim j = dim (repr j)`.
    - `P.weight j q = μ (enum j q)`.
 4. **SameMPV₂**:
    `mpv P.toTensor σ = ∑ j ∑ q, (weight j q)^N · mpv (basis j) σ`
@@ -414,8 +419,6 @@ theorem exists_bnt_grouping
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
     (hμne : ∀ k, μ k ≠ 0)
-    -- Equal-norm blocks have the same bond dimension.
-    (_hDimEq : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ → dim j = dim k)
     -- Equal-norm blocks have the same MPV function (use SameMPV₂ to allow different dims).
     (hMPVEq : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ → SameMPV₂ (blocks j) (blocks k)) :
     ∃ P : SectorDecomposition d,

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -16,17 +16,19 @@ open Filter
 # Equal-norm connection: from BNT properties to BNT grouping hypotheses
 
 This file relates the BNT overlap/spectral theory to the
-BNT grouping theorem (`exists_bnt_grouping`), which requires `hDimEq` and `hMPVEq`
+BNT grouping theorem (`exists_bnt_grouping`), which requires `hMPVEq`
 for equal-norm blocks.
 
 ## Background (Issue #243)
 
 The existence reduction chain (`Assembly.lean`) produces TP + primitive blocks with
 nonzero weights.  The BNT grouping theorem groups blocks by weight norm into a
-`SectorDecomposition`, but requires two hypotheses for equal-norm blocks:
+`SectorDecomposition`, and requires one hypothesis for equal-norm blocks:
 
-* `hDimEq`: equal-norm blocks have the same bond dimension.
 * `hMPVEq`: equal-norm blocks have `SameMPV₂`.
+
+The grouped sector's bond dimension is fixed by the chosen representative of each
+norm class, so no separate equal-dimension hypothesis is needed.
 
 ## Strategy: gauge-phase-aware BNT grouping
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1454,7 +1454,8 @@ The following results separate the zero blocks from the
 	\label{thm:bnt_grouping}
 	\lean{MPSTensor.exists_bnt_grouping}\leanok
 	\uses{def:norm_class_grouping, thm:bnt_trivial_sector}
-	If equal-norm blocks have equal bond dimensions and represent the same MPS family, then one obtains a sector decomposition whose sector norms are strictly decreasing.
+	If equal-norm blocks represent the same MPS family, then one obtains a sector
+	decomposition whose sector norms are strictly decreasing.
 \end{theorem}
 
 \subsection{Equal-Norm Blocks}


### PR DESCRIPTION
### Motivation

- This PR lands only the unused-hypothesis cleanup requested in #652's second sharpening addendum: the `_hDimEq` hypothesis on `exists_bnt_grouping` was never referenced in the proof body, since `classes.enum` fixes a representative per norm class and the sector's `basisDim` is defined as `dim (reprFn j)`.
- Removing the unused parameter clarifies that only `hMPVEq` (heterogeneous `SameMPV₂`) is required for this grouping construction.
- This PR does **not** yet discharge `hMPVEq` from `SameMPV₂`, and it does **not** modify `fundamentalTheorem_after_blocking_1606_structural`; those broader Gap §1 steps remain open in #652.

### Description

- `TNLean/MPS/CanonicalForm/BNTGrouping.lean`: drop the `_hDimEq` explicit hypothesis from `exists_bnt_grouping`.
- `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`: sync the module docstring with the new signature, removing the stale `hDimEq` discussion and explaining why no separate equal-dimension hypothesis is needed.
- `blueprint/src/chapter/ch08_canonical.tex`: sync the blueprint statement of `\lean{MPSTensor.exists_bnt_grouping}` with the Lean theorem's actual hypotheses.
- No changes to `Assembly.lean`; the broader Gap §1 work remains tracked in #652.
- No new `sorry` or `axiom` introduced.

### Testing

- `lake exe cache get`
- `lake env lean TNLean/MPS/CanonicalForm/EqualNormBridge.lean`
- `lake build TNLean.MPS.CanonicalForm.BNTGrouping`
- `lake build`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

---
Part of #652

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the statement/signature of `exists_bnt_grouping`, potentially breaking downstream lemmas and requiring updates to proofs that previously relied on equal-norm dimension equality.
> 
> **Overview**
> Updates the BNT equal-norm grouping theorem (`exists_bnt_grouping`) to *no longer require* an equal-bond-dimension hypothesis for equal-norm blocks, relying solely on the `SameMPV₂` hypothesis to relate blocks within a norm class.
> 
> The construction now fixes each sector's `basisDim` and `basis` using the chosen representative block of each norm class, and the docstrings/proof sketch are adjusted to explain that heterogeneous `SameMPV₂` allows grouping even when equal-norm blocks have different dimensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8475018ddbc12f99c68ef3271e4e0b6abed50ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public theorem signature of `exists_bnt_grouping`, which can break downstream lemmas/proofs that still pass or rely on the removed equal-dimension assumption.
> 
> **Overview**
> **Simplifies the BNT equal-norm grouping theorem API.** `exists_bnt_grouping` no longer requires an equal-bond-dimension hypothesis for equal-norm blocks, relying only on the heterogeneous `SameMPV₂` assumption and defining each sector’s `basisDim` from the chosen representative.
> 
> Documentation is updated to match this change in `EqualNormBridge.lean` and the blueprint theorem statement, clarifying that dimension agreement is not needed for the grouping construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0925bc1b31fa0284bd5a439e5e24369400bc4e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->