### PR TITLE
feat(MPS/Periodic): add CornerTransition.lean — one-site corner transitions + m-fold cyclic-product bridge (#618 Stage 3)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -213,6 +213,7 @@ import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.Periodic.Overlap
+import TNLean.MPS.Periodic.CornerTransition
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Structure.BlockPermutation

--- a/TNLean/MPS/Periodic/CornerTransition.lean
+++ b/TNLean/MPS/Periodic/CornerTransition.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Defs
+import TNLean.MPS.Core.Blocking
+
+/-!
+# One-site corner transitions and cyclic staircase products
+
+For a cyclic family of matrices `P : Fin m → Matrix (Fin D) (Fin D) ℂ` on the
+ambient bond algebra of an MPS tensor `A : MPSTensor d D`, this file defines
+the **one-site corner transitions**
+
+$$\tau_k(A)^i := P_k \cdot A^i \cdot P_{k+1}, \qquad k \in \mathrm{Fin}\,m,$$
+
+together with the associated staircase evaluation of a word at a starting
+sector and the m-fold cyclic staircase product assembled as an MPSTensor on
+blocked physical indices. When `(P_k)` is the cyclic-sector projection family
+of `IsCyclicSectorDecomp` (see `TNLean/MPS/Periodic/Overlap.lean`), the m-fold
+staircase product at sector `u`, evaluated on a blocked physical index, is the
+ambient-algebra representative of the compressed blocked sector tensor
+`blocksA u`. This is the matrix-level content of Eq. A.8 in Appendix A of
+`arXiv:1708.00029`: the identification with the compressed tensor through the
+per-sector compression isometry `φ k` (now exposed by
+`exists_compressedTensor_of_supported_projection`) is carried out in the
+Tier-A bridge lemmas in `MPS/Periodic/Overlap.lean`; this file provides only
+the ambient matrix algebra needed by those bridges.
+
+## Main definitions
+
+* `MPSTensor.cornerTransition A P k` — the single-site corner transition
+  `fun i => P k * A i * P (k + 1)`.
+* `MPSTensor.cornerEvalWord A P u w` — staircase evaluation of a word `w` at
+  starting sector `u`: the alternating product
+  `P u * A(w₀) * P(u+1) * A(w₁) * ⋯ * A(w_{L-1}) * P(u+L)`.
+* `MPSTensor.blockedCornerTransitionTensor A P u` — the m-fold cyclic
+  staircase product assembled as an MPSTensor on blocked physical indices,
+  `fun i => cornerEvalWord A P u (wordOfBlock d m i)`.
+
+## Main statements
+
+* `MPSTensor.cornerTransition_proj_left`,
+  `MPSTensor.cornerTransition_proj_right` — absorption of the source/target
+  projection on the left/right of a transition factor under idempotence.
+* `MPSTensor.cornerTransition_proj_left_other`,
+  `MPSTensor.cornerTransition_proj_right_other` — cross-sector annihilation
+  for an orthogonal projection family.
+* `MPSTensor.cornerEvalWord_proj_left` — head-projection absorption of the
+  staircase evaluation under idempotence of the intermediate projections.
+* `MPSTensor.blockedCornerTransitionTensor_apply` — the m-fold cyclic
+  staircase product as the ambient-algebra form of Eq. A.8.
+
+## References
+
+* De las Cuevas, Cirac, Schuch, Pérez-García, *Irreducible forms of Matrix
+  Product States: Theory and Applications*, arXiv:1708.00029, Appendix A,
+  Equation A.8.
+
+## Tags
+
+MPS, periodic, cyclic sector decomposition, corner transition, staircase
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ## One-site corner transitions -/
+
+/-- One-site corner transition associated to a cyclic projection family
+`P : Fin m → Matrix (Fin D) (Fin D) ℂ`:
+
+$$\tau_k(A)^i := P_k \cdot A^i \cdot P_{k+1}.$$
+
+The projections `P k` are typically the cyclic-sector projections of
+`IsCyclicSectorDecomp`; the definition itself does not require `(P k)` to be
+a projection, and the algebraic identities below isolate the hypotheses
+actually used. -/
+def cornerTransition {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (k : Fin m) :
+    MPSTensor d D :=
+  fun i => P k * A i * P (k + 1)
+
+@[simp] lemma cornerTransition_apply
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (k : Fin m) (i : Fin d) :
+    cornerTransition A P k i = P k * A i * P (k + 1) := rfl
+
+/-- Pointwise equal tensors produce equal corner transitions. -/
+lemma cornerTransition_congr
+    {m : ℕ} [NeZero m] {A B : MPSTensor d D}
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (k : Fin m) (hAB : A = B) :
+    cornerTransition A P k = cornerTransition B P k := by
+  subst hAB; rfl
+
+/-- Left projection absorption: if `P k` is idempotent, then
+`P k · τ_k(A)^i = τ_k(A)^i`. -/
+lemma cornerTransition_proj_left
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (k : Fin m)
+    (hP : P k * P k = P k) (i : Fin d) :
+    P k * cornerTransition A P k i = cornerTransition A P k i := by
+  simp only [cornerTransition_apply, ← Matrix.mul_assoc, hP]
+
+/-- Right projection absorption: if `P (k+1)` is idempotent, then
+`τ_k(A)^i · P (k+1) = τ_k(A)^i`. -/
+lemma cornerTransition_proj_right
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (k : Fin m)
+    (hP : P (k + 1) * P (k + 1) = P (k + 1)) (i : Fin d) :
+    cornerTransition A P k i * P (k + 1) = cornerTransition A P k i := by
+  simp only [cornerTransition_apply, Matrix.mul_assoc, hP]
+
+/-- Cross-sector annihilation on the left: if `P j * P k = 0`, then
+left-multiplying `τ_k(A)^i` by `P j` vanishes. -/
+lemma cornerTransition_proj_left_other
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (k j : Fin m)
+    (hOrth : P j * P k = 0) (i : Fin d) :
+    P j * cornerTransition A P k i = 0 := by
+  simp only [cornerTransition_apply, ← Matrix.mul_assoc, hOrth,
+    Matrix.zero_mul]
+
+/-- Cross-sector annihilation on the right: if `P (k+1) * P j = 0`, then
+right-multiplying `τ_k(A)^i` by `P j` vanishes. -/
+lemma cornerTransition_proj_right_other
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (k j : Fin m)
+    (hOrth : P (k + 1) * P j = 0) (i : Fin d) :
+    cornerTransition A P k i * P j = 0 := by
+  simp only [cornerTransition_apply, Matrix.mul_assoc, hOrth,
+    Matrix.mul_zero]
+
+/-! ## Cyclic staircase evaluation -/
+
+/-- Staircase evaluation of a word at starting sector `u`, recursively
+defined by
+
+$$\mathrm{cornerEvalWord}\,A\,P\,u\,\varepsilon = P_u,\qquad
+  \mathrm{cornerEvalWord}\,A\,P\,u\,(i \cdot w) =
+    P_u \cdot A^i \cdot \mathrm{cornerEvalWord}\,A\,P\,(u+1)\,w.$$
+
+For a word of length `L`, this expands to
+
+$$P_u \cdot A^{w_0} \cdot P_{u+1} \cdot A^{w_1} \cdot P_{u+2} \cdot
+  \ldots \cdot A^{w_{L-1}} \cdot P_{u+L}.$$ -/
+def cornerEvalWord {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) :
+    Fin m → List (Fin d) → Matrix (Fin D) (Fin D) ℂ
+  | u, [] => P u
+  | u, i :: w => P u * A i * cornerEvalWord A P (u + 1) w
+
+@[simp] lemma cornerEvalWord_nil
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (u : Fin m) :
+    cornerEvalWord A P u [] = P u := rfl
+
+@[simp] lemma cornerEvalWord_cons
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (u : Fin m)
+    (i : Fin d) (w : List (Fin d)) :
+    cornerEvalWord A P u (i :: w) =
+      P u * A i * cornerEvalWord A P (u + 1) w := rfl
+
+/-- A single-site staircase evaluation equals the corner transition factor
+`τ_u(A)^i` on the nose. -/
+lemma cornerEvalWord_singleton
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (u : Fin m) (i : Fin d) :
+    cornerEvalWord A P u [i] = cornerTransition A P u i := by
+  simp [cornerEvalWord, cornerTransition]
+
+/-- Head-projection absorption: staircase evaluation starts with `P u` as a
+left factor (under idempotence of `P u`). -/
+lemma cornerEvalWord_proj_left
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (hProj : ∀ k : Fin m, P k * P k = P k) :
+    ∀ (u : Fin m) (w : List (Fin d)),
+      P u * cornerEvalWord A P u w = cornerEvalWord A P u w := by
+  intro u w
+  match w with
+  | [] =>
+      simp [cornerEvalWord, hProj u]
+  | i :: w =>
+      simp only [cornerEvalWord]
+      rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, hProj u]
+
+/-! ## m-fold cyclic staircase product on blocked physical indices -/
+
+/-- The cyclic staircase product at sector `u`, assembled as an MPSTensor on
+blocked physical indices `Fin (blockPhysDim d m)`. For a blocked index `i`
+corresponding to a word `(i_0, i_1, …, i_{m-1})`, this returns the ambient
+matrix
+
+$$P_u \cdot A^{i_0} \cdot P_{u+1} \cdot A^{i_1} \cdot P_{u+2}
+  \cdots P_{u+m-1} \cdot A^{i_{m-1}} \cdot P_{u+m} = P_u \cdot A^{i_0}
+  \cdot P_{u+1} \cdots A^{i_{m-1}} \cdot P_u,$$
+
+using `u + m = u` in `Fin m`. This is the ambient-algebra representative of
+`blocksA u i`; identifying the two via the compression isometry `φ u` from
+`IsCyclicSectorDecomp` is the content of the Tier-A bridge lemmas. -/
+noncomputable def blockedCornerTransitionTensor
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (u : Fin m) :
+    MPSTensor (blockPhysDim d m) D :=
+  fun i => cornerEvalWord A P u (wordOfBlock d m i)
+
+@[simp] lemma blockedCornerTransitionTensor_apply
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (u : Fin m)
+    (i : Fin (blockPhysDim d m)) :
+    blockedCornerTransitionTensor A P u i =
+      cornerEvalWord A P u (wordOfBlock d m i) := rfl
+
+/-- Left projection absorption for the blocked cyclic staircase product. -/
+lemma blockedCornerTransitionTensor_proj_left
+    {m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (hProj : ∀ k : Fin m, P k * P k = P k)
+    (u : Fin m) (i : Fin (blockPhysDim d m)) :
+    P u * blockedCornerTransitionTensor A P u i =
+      blockedCornerTransitionTensor A P u i := by
+  simpa [blockedCornerTransitionTensor]
+    using cornerEvalWord_proj_left (A := A) (P := P) hProj u (wordOfBlock d m i)
+
+end MPSTensor

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -703,6 +703,59 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	transfer map on the corner of~$P_k$.
 \end{definition}
 
+\begin{definition}[One-site corner transition]%
+	\label{def:corner_transition}
+	\lean{MPSTensor.cornerTransition}
+	\leanok
+	\uses{def:cyclic_sector_decomp}
+	For a cyclic projection family $(P_k)_{k \in \mathrm{Fin}\,m}$ on the
+	ambient bond algebra of an MPS tensor $A$, the \emph{one-site corner
+	transition} at sector $k$ is the family of per-site matrices
+	\[
+		\tau_k(A)^i := P_k \cdot A^i \cdot P_{k+1}, \qquad i \in \mathrm{Fin}\,d,
+	\]
+	where the index $k+1$ is taken cyclically in $\mathrm{Fin}\,m$.
+\end{definition}
+
+\begin{definition}[Staircase evaluation]%
+	\label{def:corner_eval_word}
+	\lean{MPSTensor.cornerEvalWord}
+	\leanok
+	\uses{def:corner_transition}
+	For a word $w = (w_0,\dotsc,w_{L-1})$ on the physical index alphabet and
+	a starting sector $u$, the \emph{staircase evaluation} at $u$ is
+	\[
+		\mathrm{cornerEvalWord}(A, P, u, w)
+		:= P_u \cdot A^{w_0} \cdot P_{u+1} \cdot A^{w_1} \cdot P_{u+2}
+			\cdots A^{w_{L-1}} \cdot P_{u+L},
+	\]
+	defined recursively by
+	$\mathrm{cornerEvalWord}(A, P, u, \varepsilon) = P_u$ and
+	$\mathrm{cornerEvalWord}(A, P, u, i \cdot w) =
+	 P_u \cdot A^i \cdot \mathrm{cornerEvalWord}(A, P, u+1, w)$.
+\end{definition}
+
+\begin{definition}[Cyclic staircase product on blocked indices (Eq. A.8)]%
+	\label{def:blocked_corner_transition_tensor}
+	\lean{MPSTensor.blockedCornerTransitionTensor}
+	\leanok
+	\uses{def:corner_eval_word}
+	The \emph{blocked corner transition tensor} at sector $u$ is the
+	MPS tensor on blocked physical indices defined by
+	$i \mapsto \mathrm{cornerEvalWord}(A, P, u, w_i)$, where $w_i$ is the
+	length-$m$ physical word associated to the blocked index $i$. For a
+	blocked index $i$ with word $(i_0,\dotsc,i_{m-1})$ this returns the
+	ambient-algebra matrix
+	\[
+		P_u \cdot A^{i_0} \cdot P_{u+1} \cdot A^{i_1} \cdot P_{u+2}
+			\cdots P_{u+m-1} \cdot A^{i_{m-1}} \cdot P_u.
+	\]
+	This is the ambient matrix-algebra representative of the compressed
+	blocked sector tensor $C_u$ in a cyclic sector decomposition; the
+	identification with $C_u$ through the compression isometry $\varphi_u$
+	is Equation A.8 of~\cite{DeLasCuevas2017Irreducible}.
+\end{definition}
+
 \begin{theorem}[Self-overlap along period multiples]\label{thm:periodic_self_overlap_tendsto}
 	\lean{MPSTensor.periodicSelfOverlap_tendsto}
 	\notready


### PR DESCRIPTION
### Motivation

- Stage 3 of the #618 refactor, explicitly deferred from Stage 1 (#621). Introduces the one-site corner transitions needed to bridge the compressed blocked sector tensor with its ambient matrix-algebra representative.
- Provides the matrix-level content of Eq. A.8 in Appendix A of arXiv:1708.00029, which combined with Stage 2 discharges the Tier-A bridge lemmas (#607/#608/#609).

### Description

- Adds `TNLean/MPS/Periodic/CornerTransition.lean` defining:
  - `cornerTransition`: one-site corner transitions `τ_k(A) i := P k · A i · P (k+1)` for a cyclic projection family `(P_k)_{k : Fin m}`.
  - `cornerEvalWord`: recursive staircase word evaluation.
  - `blockedCornerTransitionTensor`: m-fold cyclic staircase product assembled as an `MPSTensor` on blocked physical indices.
- Structural lemmas: `cornerTransition_proj_left` / `_proj_right` (projection absorption under idempotence), `cornerTransition_proj_left_other` / `_proj_right_other` (cross-sector annihilation under orthogonality), `cornerEvalWord_nil` / `_cons` / `_singleton`, `cornerEvalWord_proj_left` (head-projection absorption), `blockedCornerTransitionTensor_proj_left` (left corner absorption).
- Exports the new module from `TNLean.lean`.
- Blueprint (`blueprint/src/chapter/ch11_assembly.tex`): adds matching `\lean{}` / `\leanok` entries for `cornerTransition`, `cornerEvalWord`, `blockedCornerTransitionTensor`, with the Eq. A.8 citation.
- No new `sorry` / `axiom`.

### Testing

- `lake build` passes locally per the authoring commit.
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
Addresses #624

> [!NOTE]
> **Low Risk**
> Mostly additive: introduces a new periodic MPS helper module and corresponding blueprint documentation; main risk is build/namespace breakage from new exports and proofs relying on matrix algebra simp/assoc rewriting.
> 
> **Overview**
> Adds a new `MPS/Periodic/CornerTransition.lean` module defining the one-site corner transition `cornerTransition`, recursive staircase word evaluation `cornerEvalWord`, and an m-fold cyclic staircase product on blocked indices `blockedCornerTransitionTensor`, plus basic algebraic lemmas (projection absorption/orthogonality) to support later periodic-overlap bridge results.
> 
> Exports the new module from `TNLean.lean` and extends the blueprint (Ch. 11 assembly) with matching definitions and references to Eq. A.8 from arXiv:1708.00029.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7327193863a39eadeb0ff6b41a7a6ee761803fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>