### PR TITLE
refactor(Entropy): unify vonNeumannEntropy namespace in SSA corollaries

### DIFF
--- a/TNLean/Entropy/MutualInformation.lean
+++ b/TNLean/Entropy/MutualInformation.lean
@@ -70,11 +70,11 @@ theorem mutualInformation_ssa_trivial_B_nonneg
       (Fin dA × Fin 1 × Fin dC) ℂ)
     (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
     (h_mid_trace : (traceAC_ABC ρ_ABC).trace = 1) :
-    0 ≤ _root_.vonNeumannEntropy (traceC_ABC ρ_ABC)
+    0 ≤ Entropy.vonNeumannEntropy (traceC_ABC ρ_ABC)
           (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
-        + _root_.vonNeumannEntropy (traceA_ABC ρ_ABC)
+        + Entropy.vonNeumannEntropy (traceA_ABC ρ_ABC)
             (traceA_ABC_isHermitian hρ_dm.1.isHermitian)
-        - _root_.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian := by
+        - Entropy.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian := by
   have h := subadditivity_ssa_trivial_B ρ_ABC hρ_dm h_mid_trace
   linarith
 

--- a/TNLean/Entropy/StrongSubadditivity.lean
+++ b/TNLean/Entropy/StrongSubadditivity.lean
@@ -115,22 +115,14 @@ theorem strongSubadditivity_rearranged
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
     (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :
-    _root_.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
-      - _root_.vonNeumannEntropy (traceC_ABC ρ_ABC)
+    Entropy.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
+      - Entropy.vonNeumannEntropy (traceC_ABC ρ_ABC)
           (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
-    ≤ _root_.vonNeumannEntropy (traceA_ABC ρ_ABC)
+    ≤ Entropy.vonNeumannEntropy (traceA_ABC ρ_ABC)
           (traceA_ABC_isHermitian hρ_dm.1.isHermitian)
-      - _root_.vonNeumannEntropy (traceAC_ABC ρ_ABC)
+      - Entropy.vonNeumannEntropy (traceAC_ABC ρ_ABC)
           (traceAC_ABC_isHermitian hρ_dm.1.isHermitian) := by
-  have h :
-      _root_.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
-        + _root_.vonNeumannEntropy (traceAC_ABC ρ_ABC)
-            (traceAC_ABC_isHermitian hρ_dm.1.isHermitian)
-      ≤ _root_.vonNeumannEntropy (traceC_ABC ρ_ABC)
-            (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
-        + _root_.vonNeumannEntropy (traceA_ABC ρ_ABC)
-            (traceA_ABC_isHermitian hρ_dm.1.isHermitian) := by
-    simpa [Entropy.vonNeumannEntropy] using strongSubadditivity ρ_ABC hρ_dm
+  have h := strongSubadditivity ρ_ABC hρ_dm
   linarith
 
 end StrongSubadditivity
@@ -199,22 +191,14 @@ theorem subadditivity_ssa_trivial_B
       (Fin dA × Fin 1 × Fin dC) ℂ)
     (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
     (h_mid_trace : (traceAC_ABC ρ_ABC).trace = 1) :
-    _root_.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
-    ≤ _root_.vonNeumannEntropy (traceC_ABC ρ_ABC)
+    Entropy.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
+    ≤ Entropy.vonNeumannEntropy (traceC_ABC ρ_ABC)
           (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
-      + _root_.vonNeumannEntropy (traceA_ABC ρ_ABC)
+      + Entropy.vonNeumannEntropy (traceA_ABC ρ_ABC)
           (traceA_ABC_isHermitian hρ_dm.1.isHermitian) := by
-  have hSSA :
-      _root_.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
-        + _root_.vonNeumannEntropy (traceAC_ABC ρ_ABC)
-            (traceAC_ABC_isHermitian hρ_dm.1.isHermitian)
-      ≤ _root_.vonNeumannEntropy (traceC_ABC ρ_ABC)
-            (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
-        + _root_.vonNeumannEntropy (traceA_ABC ρ_ABC)
-            (traceA_ABC_isHermitian hρ_dm.1.isHermitian) := by
-    simpa [Entropy.vonNeumannEntropy] using strongSubadditivity ρ_ABC hρ_dm
+  have hSSA := strongSubadditivity ρ_ABC hρ_dm
   have h_mid_zero :
-      _root_.vonNeumannEntropy (traceAC_ABC ρ_ABC)
+      Entropy.vonNeumannEntropy (traceAC_ABC ρ_ABC)
           (traceAC_ABC_isHermitian hρ_dm.1.isHermitian) = 0 :=
     vonNeumannEntropy_eq_zero_of_fin_one _
       (traceAC_ABC_isHermitian hρ_dm.1.isHermitian) h_mid_trace


### PR DESCRIPTION
### Motivation

- Follow-up from #643, which standardized `Entropy.strongSubadditivity` on `Entropy.vonNeumannEntropy` but left the downstream corollaries on the `_root_` spelling. This meant the `Entropy.*` API disagreed with itself on surface spelling and required a `simpa [Entropy.vonNeumannEntropy]` shim to bridge the two.
- Completes Option A from #648 — finish the rename so the whole `Entropy.*` surface uses the namespaced spelling consistently.

### Description

- `TNLean/Entropy/StrongSubadditivity.lean`: flip `strongSubadditivity_rearranged` and `subadditivity_ssa_trivial_B` (and the `h_mid_zero` helper) from `_root_.vonNeumannEntropy` to `Entropy.vonNeumannEntropy`. The inner `have` shims collapse to direct applications of `strongSubadditivity` (no more `simpa [Entropy.vonNeumannEntropy]`), while the same `linarith`-based derivations conclude the proofs.
- `TNLean/Entropy/MutualInformation.lean`: update `mutualInformation_ssa_trivial_B_nonneg` to consume the namespaced corollaries.
- No axiom/logic changes; purely a namespace/notation cleanup in theorem statements and proofs.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Closes #648

> [!NOTE]
> **Low Risk**
> Low risk: this is a namespace/notation cleanup in theorem statements and proofs, with no changes to underlying axioms or logic beyond replacing `_root_` references and simplifying `simpa` steps.
>
> **Overview**
> Standardizes `vonNeumannEntropy` usage in `StrongSubadditivity.lean` and `MutualInformation.lean` by replacing `_root_.vonNeumannEntropy` references with `Entropy.vonNeumannEntropy` across SSA corollaries and the mutual-information nonnegativity lemma.
>
> Simplifies proofs of `strongSubadditivity_rearranged` and `subadditivity_ssa_trivial_B` by using the namespaced `strongSubadditivity` result directly (dropping intermediate `simpa [Entropy.vonNeumannEntropy]` rewrites) while keeping the same `linarith`-based derivations.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd9b90ab3befc0a49cded66a8aacfdcc3a6f585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>