### PR TITLE
feat(MPS/CanonicalForm): close hLift orbit-sum lift hypothesis (#590)

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -601,4 +601,52 @@ theorem isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift
       (T := transferMap (d := d) (D := D) (fun i => (A i)ᴴ))
       hIrr P hPproj hPsum hcyclic hLift
 
+/-- MPS-specialized sector irreducibility, with the `hLift` input discharged by
+`hLift_cyclicDecomp_mps_of_fixUpgrade`. -/
+theorem isIrreducibleOnCorner_of_cyclic_decomp_mps_of_fixUpgrade
+    {A : MPSTensor d D}
+    [NeZero m]
+    (hIrr :
+      IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)))
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (P : Fin m → MatrixAlg D)
+    (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hcyclic :
+      ∀ k : Fin m,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (hMulLeft :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k * X) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X)
+    (hMulRight :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (X * P k) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k))
+    (hProjStep :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        IsOrthogonalProjection X →
+        X * P k = X →
+        P k * X = X →
+        IsOrthogonalProjection
+          (transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X))
+    (hFixUpgrade :
+      ∀ (k : Fin m) (Q : MatrixAlg D),
+        IsOrthogonalProjection Q →
+        Q * P k = Q → P k * Q = Q →
+        PreservesCorner Q
+          ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) →
+        ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) Q = Q) :
+    ∀ k : Fin m,
+      IsIrreducibleOnCorner
+        (P k) ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) := by
+  exact
+    isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift
+      (A := A) (m := m) hIrr P hPproj hPsum hcyclic
+      (hLift_cyclicDecomp_mps_of_fixUpgrade
+        (A := A) (m := m) hTP P hPproj hPsum hcyclic
+        hMulLeft hMulRight hProjStep hFixUpgrade)
+
 end MPSTensor

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1354,6 +1354,24 @@ The following results separate the zero blocks from the
 	Lemma~\ref{lem:orbit_sum_full_sector}.
 \end{proof}
 
+\begin{theorem}[Sector irreducibility from the orbit-sum construction]%
+	\label{thm:sector_irred_fix_upgrade}
+	\lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_fixUpgrade}
+	\leanok
+	\uses{thm:sector_irred_orbit_lift, lem:orbit_sum_hLift_construction}
+	Let $A$ be a left-canonical MPS tensor with irreducible adjoint transfer
+	map, and let $(P_k)_{k=1}^m$ be cyclic orthogonal sector projections.
+	Assume the projection-step and fixed-point-upgrade hypotheses of
+	Lemma~\ref{lem:orbit_sum_hLift_construction}. Then $(\E_A^\dagger)^m$
+	is irreducible on each corner $P_k$.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:sector_irred_orbit_lift, lem:orbit_sum_hLift_construction}
+	Apply Lemma~\ref{lem:orbit_sum_hLift_construction} to obtain the orbit-sum
+	lift, then apply Theorem~\ref{thm:sector_irred_orbit_lift}.
+\end{proof}
+
 \section{Reduction to primitive blocks}%
 \label{sec:reduction_to_normal_form}
 


### PR DESCRIPTION
## Summary
- add `MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_fixUpgrade` in `TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`
- package the existing orbit-sum lift construction with the existing `..._of_hLift` wrapper
- keep the change file-local, with no new `sorry`

## Approach
The new theorem is the missing composition step after PR #597:
1. use `MPSTensor.hLift_cyclicDecomp_mps_of_fixUpgrade` to build the `hLift` witness from the cyclic-sector hypotheses together with `hProjStep` and `hFixUpgrade`;
2. feed that witness directly into `MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift`.

This closes the explicit `hLift` argument at the MPS wrapper level without changing any other files.

## Verification
- `lake exe cache get`
- `lake env lean TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`
- `lake build TNLean.MPS.CanonicalForm.SectorIrreducibility`
- `lake build`

Refs #590

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a new theorem that composes existing lemmas/wrappers and updates the blueprint documentation; it does not change existing proof behavior or core definitions.
> 
> **Overview**
> Adds a new MPS-level theorem `MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_fixUpgrade` that *eliminates the need to supply an explicit* `hLift` witness by composing the existing orbit-sum lift construction (`hLift_cyclicDecomp_mps_of_fixUpgrade`) with the existing sector-irreducibility wrapper (`..._of_hLift`).
> 
> Updates the canonical-form blueprint to state and prove the corresponding “sector irreducibility from the orbit-sum construction” theorem, referencing the new Lean result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b12585cfa0d1ea372849d568922564db0ed39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->