### PR TITLE
style(lean): post-merge cleanup pass on POVM/Kraus/Periodic/Full modules

### DIFF
--- a/TNLean/Channel/KrausUnitaryFreedom.lean
+++ b/TNLean/Channel/KrausUnitaryFreedom.lean
@@ -45,7 +45,7 @@ theorem kraus_isometry_freedom_iff
         ∀ α, B α = ∑ j, V α j • A j := by
   refine ⟨fun h => kraus_rectangular_freedom' B A h hCard, ?_⟩
   rintro ⟨V, hV, hBA⟩
-  exact kraus_same_map_of_isometry_combination B A V hV hBA
+  exact kraus_same_map_of_isometry_combination (K := B) (K' := A) (W := V) hV hBA
 
 /-- **Wolf Thm. 2.18 (unitary form)**: if two Kraus families have the same
 finite index type, then they define the same completely positive map if and only

--- a/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
+++ b/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
@@ -240,7 +240,7 @@ theorem preserves_corner_pow_period (M : MultiCycleDecomposition T)
   intro X
   have hmk : (T ^ M.period c) (M.P c k * X * M.P c k) =
       M.P c k * ((T ^ M.period c) X) * M.P c k := by
-    simpa using hstep (M.period c) k X
+    simpa only [shiftIndex_period] using hstep (M.period c) k X
   calc
     M.P c k * (T ^ M.period c) (M.P c k * X * M.P c k) * M.P c k
         = M.P c k * (M.P c k * ((T ^ M.period c) X) * M.P c k) * M.P c k := by rw [hmk]

--- a/TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean
@@ -233,7 +233,7 @@ lemma blocks_match_of_sameMPV₂_CFBNT
     have hmpv2 : ∀ (N : ℕ) (σ : Fin N → Fin d),
         mpv (B (fA j1)) σ = ζ2 ^ N * mpv (A j2) σ := by
       intro N σ
-      rw [show fA j1 = fA j2 from hfj]
+      rw [hfj]
       rw [mpv_eq_pow_mul_of_gaugePhase _ _ X2 ζ2 hX2 N σ,
           mpv_cast_dim (hfA_dim j2)]
     have hBB_norm_tendsto :
@@ -278,8 +278,7 @@ lemma blocks_match_of_sameMPV₂_CFBNT
         intro σ; rw [hA1_eq σ, ← hmpv1 N σ, hA2_eq σ, ← hmpv2 N σ]
       simp_rw [hStep1]
       simp only [star_mul, star_pow, RCLike.star_def, starRingEnd_self_apply]
-      rw [show ((starRingEnd ℂ) ζ1 * ζ2) ^ N =
-          (starRingEnd ℂ) ζ1 ^ N * ζ2 ^ N from mul_pow _ _ _]
+      rw [mul_pow]
       rw [Finset.mul_sum]
       congr 1; ext σ; ring
     -- Norm of phase factor is 1.
@@ -297,7 +296,8 @@ lemma blocks_match_of_sameMPV₂_CFBNT
           ‖mpvOverlap (d := d) (B (fA j1)) (B (fA j1)) N‖) =
           fun N => 1 * ‖mpvOverlap (d := d) (B (fA j1)) (B (fA j1)) N‖ := by
         ext N; rw [norm_pow, hNormζ, one_pow]
-      rw [this]; simpa using hBB_norm_tendsto
+      rw [this]
+      simpa only [one_mul] using hBB_norm_tendsto
     have hCross_norm_zero :
         Tendsto (fun N => ‖mpvOverlap (d := d) (A j1) (A j2) N‖) atTop (nhds 0) := by
       convert (hA_cross j1 j2 hne).norm using 1; simp only [norm_zero]
@@ -336,7 +336,7 @@ lemma blocks_match_of_sameMPV₂_CFBNT
     have hmpv2 : ∀ (N : ℕ) (σ : Fin N → Fin d),
         mpv (B k2) σ = ω2 ^ N * mpv (A (gB k1)) σ := by
       intro N σ
-      rw [show gB k1 = gB k2 from hgk] at hmpv1 ⊢
+      rw [hgk] at hmpv1 ⊢
       rw [mpv_eq_pow_mul_of_gaugePhase _ _ Y2 ω2 hY2 N σ,
           mpv_cast_dim (hgB_dim k2)]
     have hAA_norm :
@@ -385,7 +385,8 @@ lemma blocks_match_of_sameMPV₂_CFBNT
           ‖mpvOverlap (d := d) (A (gB k1)) (A (gB k1)) N‖) =
           fun N => 1 * ‖mpvOverlap (d := d) (A (gB k1)) (A (gB k1)) N‖ := by
         ext N; rw [norm_pow, hNormω, one_pow]
-      rw [this]; simpa using hAA_norm
+      rw [this]
+      simpa only [one_mul] using hAA_norm
     have hCross_norm_zero :
         Tendsto (fun N => ‖mpvOverlap (d := d) (B k1) (B k2) N‖) atTop (nhds 0) := by
       convert (hB_cross k1 k2 hne).norm using 1; simp only [norm_zero]

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -232,7 +232,7 @@ lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
     have hall_inner : ∀ j, Tendsto (fun N => mpvInner (d := d) (B b0) (A j) N)
         atTop (nhds 0) := by
       intro j
-      simpa using tendsto_inner_zero_swap (d := d) (A j) (B b0) (hall j)
+      exact tendsto_inner_zero_swap (d := d) (A j) (B b0) (hall j)
     have h_eq := normalized_identity (B b0) (μB b0) hμB_ne
     have hLHS : Tendsto (fun N => ∑ j, (μA j / μB b0) ^ N *
         mpvInner (d := d) (B b0) (A j) N) atTop (nhds 0) := by
@@ -331,8 +331,7 @@ lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
           star ((starRingEnd ℂ ζ2) ^ N * mpv (B k) σ) := by
         intro σ; rw [hA1_eq σ, ← hmpv1 N σ, hA2_eq σ, ← hmpv2 N σ]
       simp_rw [hStep]; simp only [star_mul, star_pow, RCLike.star_def, starRingEnd_self_apply]
-      rw [show ((starRingEnd ℂ) ζ1 * ζ2) ^ N =
-          (starRingEnd ℂ) ζ1 ^ N * ζ2 ^ N from mul_pow _ _ _]
+      rw [mul_pow]
       rw [Finset.mul_sum]; congr 1; ext σ; ring
     have hNormζ : ‖starRingEnd ℂ ζ1 * ζ2‖ = 1 := by
       rw [norm_mul, RCLike.norm_conj, hζ1_norm, hζ2_norm, mul_one]
@@ -347,7 +346,8 @@ lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
           ‖mpvOverlap (d := d) (B k) (B k) N‖) =
           fun N => 1 * ‖mpvOverlap (d := d) (B k) (B k) N‖ := by
         ext N; rw [norm_pow, hNormζ, one_pow]
-      rw [this]; simpa using hBB_norm
+      rw [this]
+      simpa only [one_mul] using hBB_norm
     have hCross_norm_zero :
         Tendsto (fun N => ‖mpvOverlap (d := d) (A j₁) (A j₂) N‖) atTop (nhds 0) := by
       convert (hA_cross j₁ j₂ hne).norm using 1; simp only [norm_zero]
@@ -419,7 +419,8 @@ lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
           ‖mpvOverlap (d := d) (A j) (A j) N‖) =
           fun N => 1 * ‖mpvOverlap (d := d) (A j) (A j) N‖ := by
         ext N; rw [norm_pow, hNormω, one_pow]
-      rw [this]; simpa using hAA_norm
+      rw [this]
+      simpa only [one_mul] using hAA_norm
     have hCross_norm_zero :
         Tendsto (fun N => ‖mpvOverlap (d := d) (B k₁) (B k₂) N‖) atTop (nhds 0) := by
       convert (hB_cross k₁ k₂ hne).norm using 1; simp only [norm_zero]
@@ -485,7 +486,7 @@ lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
       have hInner_other : ∀ j, j ≠ j₁ →
           Tendsto (fun N => mpvInner (d := d) (B b0) (A j) N) atTop (nhds 0) := by
         intro j hj
-        simpa using tendsto_inner_zero_swap (d := d) (A j) (B b0) (huniq j hj)
+        exact tendsto_inner_zero_swap (d := d) (A j) (B b0) (huniq j hj)
       have h_eq := normalized_identity (B b0) (μB b0) hμB_ne
       have hRHS_one : Tendsto (fun N => ∑ k, (μB k / μB b0) ^ N *
           mpvInner (d := d) (B b0) (B k) N) atTop (nhds 1) :=

--- a/TNLean/MPS/Periodic/CornerTransition.lean
+++ b/TNLean/MPS/Periodic/CornerTransition.lean
@@ -224,7 +224,7 @@ lemma blockedCornerTransitionTensor_proj_left
     (u : Fin m) (i : Fin (blockPhysDim d m)) :
     P u * blockedCornerTransitionTensor A P u i =
       blockedCornerTransitionTensor A P u i := by
-  simpa [blockedCornerTransitionTensor]
+  simpa only [blockedCornerTransitionTensor]
     using cornerEvalWord_proj_left (A := A) (P := P) hProj u (wordOfBlock d m i)
 
 end MPSTensor


### PR DESCRIPTION
## Summary
- focused low-risk Mathlib-style cleanup pass on the recent POVM/Kraus/Periodic/Full modules
- kept theorem/definition statements, names, imports, and existing `sorry` surface unchanged
- verified all eight requested target files with `lake env lean`
- rechecked line length on all eight targets: `0` lines over `100` characters
- ran `lake exe cache get` and a full `lake build` in the worktree

## Files touched
- `TNLean/Channel/KrausUnitaryFreedom.lean`
  - made the concluding `kraus_same_map_of_isometry_combination` call use named arguments for readability/robustness
- `TNLean/MPS/Periodic/CornerTransition.lean`
  - tightened the final wrapper proof to `simpa only [blockedCornerTransitionTensor]`
- `TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean`
  - replaced two ad hoc equality rewrites by direct `rw [h]`
  - replaced one `show ... from mul_pow` rewrite by `rw [mul_pow]`
  - tightened two normalization steps to `simpa only [one_mul]`
- `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
  - replaced two exact-type `simpa` wrappers by `exact`
  - replaced one `show ... from mul_pow` rewrite by `rw [mul_pow]`
  - tightened two normalization steps to `simpa only [one_mul]`
- `TNLean/Channel/Peripheral/MultiCycleDecomposition.lean`
  - tightened one wrapper proof to `simpa only [shiftIndex_period]`

## Verified but left unchanged
These files already looked clean for a low-risk post-merge polish pass, so I verified them and left them out of the commit:
- `TNLean/Channel/POVM.lean`
- `TNLean/MPS/Periodic/ProjectiveRep.lean`
- `TNLean/MPS/FundamentalTheorem/Full/Helpers.lean`

## Blueprint / informal consistency spot-check
Searched the matching blueprint sections in:
- `blueprint/src/chapter/ch04_channels.tex`
- `blueprint/src/chapter/ch06_spectral.tex`
- `blueprint/src/chapter/ch11_assembly.tex`
- `blueprint/src/chapter/ch11b_periodic_ft.tex`

No Lean/LaTeX statement drift was introduced in the touched area.

## Verification
- per-file: `lake env lean <file>` succeeds for all 8 requested targets
- full build: `lake exe cache get && lake build` succeeds
- the full build still reports only pre-existing out-of-scope warnings / admitted declarations elsewhere in the repo (for example `Periodic/Overlap`, ParentHamiltonian, PEPS, and a few older lint warnings outside this PR’s scope)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk stylistic proof maintenance (named arguments, tighter `simpa`/`rw` usage) with no changes to theorem statements or core logic; main risk is only potential proof fragility/regression if upstream lemma behavior changes.
> 
> **Overview**
> Performs a Mathlib-style cleanup pass across several Lean proof files, keeping all theorem/definition statements unchanged.
> 
> Key changes tighten proof scripts for robustness/readability: uses named arguments in `kraus_same_map_of_isometry_combination`, replaces ad-hoc `show ... from ...` rewrites with direct `rw` (e.g. `rw [h]`, `rw [mul_pow]`), and narrows `simpa` steps via `simpa only [...]`/`exact` (including `shiftIndex_period`, `blockedCornerTransitionTensor`, and normalization `one_mul` simplifications).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189229efcb88463a938d974d4db7edf2f247dea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->