### PR TITLE
feat(MPS/Periodic): discharge compressedTensor_adjointTransferMap_cornerBridge

### DIFF
--- a/TNLean/Channel/Peripheral/Conjugation.lean
+++ b/TNLean/Channel/Peripheral/Conjugation.lean
@@ -33,6 +33,18 @@ lemma hasEigenvalue_conj_iff
   -- Conjugation does not change the characteristic polynomial.
   simp [LinearEquiv.charpoly_conj S E]
 
+/-- Cross-space variant of `hasEigenvalue_conj_iff`: eigenvalues of a linear
+endomorphism are invariant under conjugation by a linear equivalence between
+potentially different finite-dimensional spaces. -/
+lemma hasEigenvalue_conj_iff_cross
+    {V W : Type*} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
+    [AddCommGroup W] [Module ℂ W] [FiniteDimensional ℂ W]
+    (e : V ≃ₗ[ℂ] W) (f : V →ₗ[ℂ] V) (μ : ℂ) :
+    Module.End.HasEigenvalue (e.conj f) μ ↔ Module.End.HasEigenvalue f μ := by
+  rw [Module.End.hasEigenvalue_iff_isRoot_charpoly (f := e.conj f) (μ := μ),
+    Module.End.hasEigenvalue_iff_isRoot_charpoly (f := f) (μ := μ)]
+  simp [LinearEquiv.charpoly_conj e f]
+
 end Module.End
 
 section
@@ -55,5 +67,32 @@ theorem IsPrimitive.conj_iff
     (S : V ≃ₗ[ℂ] V) (E : V →ₗ[ℂ] V) :
     _root_.IsPrimitive (S.conj E) ↔ _root_.IsPrimitive E := by
   simp [_root_.IsPrimitive, peripheralEigenvalues_conj (S := S) (E := E)]
+
+end
+
+section
+
+variable {V W : Type*} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
+  [AddCommGroup W] [Module ℂ W] [FiniteDimensional ℂ W]
+
+/-- Cross-space variant of `peripheralEigenvalues_conj`: peripheral eigenvalues
+of a linear endomorphism are invariant under conjugation by a linear equivalence
+between finite-dimensional spaces. -/
+lemma peripheralEigenvalues_conj_cross
+    (e : V ≃ₗ[ℂ] W) (f : V →ₗ[ℂ] V) :
+    peripheralEigenvalues (e.conj f) = peripheralEigenvalues f := by
+  ext μ
+  constructor
+  · rintro ⟨hμ, hnorm⟩
+    exact ⟨(Module.End.hasEigenvalue_conj_iff_cross e f μ).1 hμ, hnorm⟩
+  · rintro ⟨hμ, hnorm⟩
+    exact ⟨(Module.End.hasEigenvalue_conj_iff_cross e f μ).2 hμ, hnorm⟩
+
+/-- Cross-space variant of `IsPrimitive.conj_iff`: primitivity is invariant
+under conjugation by a linear equivalence between finite-dimensional spaces. -/
+theorem IsPrimitive.conj_iff_cross
+    (e : V ≃ₗ[ℂ] W) (f : V →ₗ[ℂ] V) :
+    _root_.IsPrimitive (e.conj f) ↔ _root_.IsPrimitive f := by
+  simp [_root_.IsPrimitive, peripheralEigenvalues_conj_cross (e := e) (f := f)]
 
 end

--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -169,7 +169,7 @@ lemma cornerCompressionExpand_mem
     _ = Umat * Y_D * Umatᴴ := by rw [hPdiag_Y]
 
 /-- Conjugate-transpose intertwining for the shared corner-compression map:
-`expand Mᴴ = (expand M)ᴴ`. This is the star-preservation identity of the
+`(expand M)ᴴ = expand Mᴴ`. This is the star-preservation identity of the
 compression isometry; together with `cornerCompressionExpand_mul` it makes the
 image of the compression a ∗-subalgebra of the ambient corner. -/
 lemma cornerCompressionExpand_conjTranspose

--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -168,6 +168,94 @@ lemma cornerCompressionExpand_mem
     _ = Umat * (Pdiag * Y_D * Pdiag) * Umatᴴ := by rw [hU'U]; simp
     _ = Umat * Y_D * Umatᴴ := by rw [hPdiag_Y]
 
+/-- Conjugate-transpose intertwining for the shared corner-compression map:
+`expand Mᴴ = (expand M)ᴴ`. This is the star-preservation identity of the
+compression isometry; together with `cornerCompressionExpand_mul` it makes the
+image of the compression a ∗-subalgebra of the ambient corner. -/
+lemma cornerCompressionExpand_conjTranspose
+    {D n : ℕ} (Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
+    (M : Matrix (Fin n) (Fin n) ℂ) :
+    (cornerCompressionExpand Umat eST eS M)ᴴ =
+      cornerCompressionExpand Umat eST eS Mᴴ := by
+  rw [cornerCompressionExpand_apply Umat eST eS M,
+    cornerCompressionExpand_apply Umat eST eS Mᴴ]
+  simp only [Matrix.reindexLinearEquiv_apply]
+  rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+    Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+  congr 1
+  rw [Matrix.conjTranspose_reindex, Matrix.fromBlocks_conjTranspose,
+    Matrix.conjTranspose_zero, Matrix.conjTranspose_zero,
+    Matrix.conjTranspose_zero, Matrix.conjTranspose_reindex]
+
+/-- Multiplicativity of the shared corner-compression map:
+`expand (M₁ * M₂) = expand M₁ * expand M₂`.  Uses the isometry identity
+`Umatᴴ * Umat = 1` to collapse the middle factor of the product. -/
+lemma cornerCompressionExpand_mul
+    {D n : ℕ} (Umat : MatrixAlg D)
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T]
+    (eST : Fin D ≃ S ⊕ T) (eS : S ≃ Fin n)
+    (hU'U : Umatᴴ * Umat = 1)
+    (M₁ M₂ : Matrix (Fin n) (Fin n) ℂ) :
+    cornerCompressionExpand Umat eST eS (M₁ * M₂) =
+      cornerCompressionExpand Umat eST eS M₁ *
+        cornerCompressionExpand Umat eST eS M₂ := by
+  rw [cornerCompressionExpand_apply Umat eST eS (M₁ * M₂),
+    cornerCompressionExpand_apply Umat eST eS M₁,
+    cornerCompressionExpand_apply Umat eST eS M₂]
+  simp only [Matrix.reindexLinearEquiv_apply]
+  set Y₁ : MatrixAlg D :=
+    Matrix.reindex eST.symm eST.symm
+      (Matrix.fromBlocks (Matrix.reindex eS.symm eS.symm M₁)
+        (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ))
+  set Y₂ : MatrixAlg D :=
+    Matrix.reindex eST.symm eST.symm
+      (Matrix.fromBlocks (Matrix.reindex eS.symm eS.symm M₂)
+        (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ))
+  have hY₁Y₂ :
+      Matrix.reindex eST.symm eST.symm
+          (Matrix.fromBlocks
+            (Matrix.reindex eS.symm eS.symm (M₁ * M₂))
+            (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) =
+        Y₁ * Y₂ := by
+    have hReindexMul :
+        Matrix.reindex eS.symm eS.symm M₁ *
+            Matrix.reindex eS.symm eS.symm M₂ =
+          Matrix.reindex eS.symm eS.symm (M₁ * M₂) := by
+      simpa using
+        Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+          eS.symm eS.symm eS.symm M₁ M₂
+    have hFromBlocksMul :
+        Matrix.fromBlocks (Matrix.reindex eS.symm eS.symm M₁)
+            (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) *
+          Matrix.fromBlocks (Matrix.reindex eS.symm eS.symm M₂)
+            (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) =
+          Matrix.fromBlocks
+            (Matrix.reindex eS.symm eS.symm M₁ *
+              Matrix.reindex eS.symm eS.symm M₂)
+            (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) := by
+      simp [Matrix.fromBlocks_multiply]
+    have hReindexMul2 :
+        Y₁ * Y₂ =
+          Matrix.reindex eST.symm eST.symm
+            (Matrix.fromBlocks (Matrix.reindex eS.symm eS.symm M₁)
+              (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) *
+            Matrix.fromBlocks (Matrix.reindex eS.symm eS.symm M₂)
+              (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) := by
+      simpa [Y₁, Y₂] using
+        (Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+          eST.symm eST.symm eST.symm _ _).symm
+    rw [hReindexMul2, hFromBlocksMul, hReindexMul]
+  rw [hY₁Y₂]
+  calc
+    Umat * (Y₁ * Y₂) * Umatᴴ
+        = Umat * Y₁ * (Umatᴴ * Umat) * Y₂ * Umatᴴ := by
+          rw [hU'U]
+          simp [Matrix.mul_assoc]
+    _ = Umat * Y₁ * Umatᴴ * (Umat * Y₂ * Umatᴴ) := by
+          simp [Matrix.mul_assoc]
+
 /-- Shared corner-compression builder landing in `cornerSubmodule P`. -/
 noncomputable def cornerCompressionLinearMap
     {D n : ℕ} (P Pdiag Umat : MatrixAlg D)

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -846,6 +846,10 @@ theorem exists_cyclic_sector_decomp_after_blocking
             (fun i => (blocks k i)ᴴ) X)).1 =
           transferMap (d := blockPhysDim d m) (D := D)
             (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1)) ∧
+      (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ) ∧
       (∀ k, dim k ≠ 0) := by
   -- Step 1: Get cyclic decomposition data
   let K : Fin d → MatrixAlg D := fun i => (A i)ᴴ
@@ -872,7 +876,7 @@ theorem exists_cyclic_sector_decomp_after_blocking
   -- Step 5: Apply the CyclicSectors decomposition
   obtain ⟨dim, blocks, φ, hLC, hMPV_hTrace⟩ := exists_blockDecomp_of_adjoint_fixed_projections
     (blockTensor A m) P hPproj hPsum hTP_blocked hFix
-  obtain ⟨hMPV, hTrace, hIntertwine⟩ := hMPV_hTrace
+  obtain ⟨hMPV, hTrace, hIntertwine, hMul, hStar⟩ := hMPV_hTrace
   -- Step 6: Derive commutation from the adjoint fix property
   have hComm : ∀ k (i : Fin (blockPhysDim d m)),
       P k * (blockTensor A m) i = (blockTensor A m) i * P k := by
@@ -921,7 +925,7 @@ theorem exists_cyclic_sector_decomp_after_blocking
       rw [← h0, Matrix.trace_one, Fintype.card_fin, hk, Nat.cast_zero]
     exact (isOrthogonalProjection_posSemidef (hPproj k)).trace_eq_zero_iff.mp htrace_zero
   exact ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace, hIntertwine,
-    hNondeg⟩
+    hMul, hStar, hNondeg⟩
 
 end CyclicSectorBridge
 

--- a/TNLean/MPS/CanonicalForm/CyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors.lean
@@ -152,7 +152,10 @@ theorem exists_compressedTensor_of_supported_projection
         mpv C σ = Matrix.trace (P * evalWord A (List.ofFn σ))) ∧
       (∀ X : Matrix (Fin n) (Fin n) ℂ,
         (φ (transferMap (d := d) (D := n) (fun i => (C i)ᴴ) X)).1 =
-          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1)) := by
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1)) ∧
+      (∀ X Y : Matrix (Fin n) (Fin n) ℂ,
+        (φ (X * Y)).1 = (φ X).1 * (φ Y).1) ∧
+      (∀ X : Matrix (Fin n) (Fin n) ℂ, (φ Xᴴ).1 = ((φ X).1)ᴴ) := by
   classical
   -- Spectral diagonalization of P
   let hHerm : P.IsHermitian := hP.1
@@ -322,7 +325,7 @@ theorem exists_compressedTensor_of_supported_projection
   let cornerEmbed : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
     cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0_def
       hP_decomp hPdiag_UPU hPdiag_std_lin hPdiag_back hU'U hUU
-  refine ⟨n, C, cornerEmbed, ?_, ?_, ?_, ?_⟩
+  refine ⟨n, C, cornerEmbed, ?_, ?_, ?_, ?_, ?_, ?_⟩
   -- (1) Trace identity: n = tr P
   · exact htrace
   -- (2) TP condition: ∑ C_i† C_i = 1
@@ -616,6 +619,14 @@ theorem exists_compressedTensor_of_supported_projection
         _ = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by
               rw [hU'U]; noncomm_ring
     rw [hLHS, hRHS]
+  -- (5) Multiplicativity: (φ (X * Y)).1 = (φ X).1 * (φ Y).1.
+  · intro X Y
+    change expand (X * Y) = expand X * expand Y
+    exact cornerCompressionExpand_mul Umat eST eS hU'U X Y
+  -- (6) Star-preservation: (φ Xᴴ).1 = ((φ X).1)ᴴ.
+  · intro X
+    change expand Xᴴ = (expand X)ᴴ
+    exact (cornerCompressionExpand_conjTranspose Umat eST eS X).symm
 
 end Compression
 
@@ -635,7 +646,7 @@ theorem exists_compressedTensor_of_supported_projection_pos_mpv
       ((n : ℂ) = Matrix.trace P) ∧
       (∑ i : Fin d, (C i)ᴴ * C i = 1) ∧
       (∀ {N : ℕ}, 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = mpv C σ) := by
-  obtain ⟨dim, C, _φ, hdim, hCtp, hCmpv, _hIntertwine⟩ :=
+  obtain ⟨dim, C, _φ, hdim, hCtp, hCmpv, _hIntertwine, _hMul, _hStar⟩ :=
     exists_compressedTensor_of_supported_projection A P hP hSupp hTP
   refine ⟨dim, C, hdim, hCtp, ?_⟩
   have hleft : ∀ i : Fin d, P * A i = A i := by
@@ -706,7 +717,11 @@ theorem exists_blockDecomp_of_commuting_projections
         (φ k (transferMap (d := d) (D := dim k)
             (fun i => (blocks k i)ᴴ) X)).1 =
           transferMap (d := d) (D := D)
-            (fun i => (P k * A i)ᴴ) ((φ k X).1)) := by
+            (fun i => (P k * A i)ᴴ) ((φ k X).1)) ∧
+      (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ) := by
   -- For each k, sector tensor P_k * A_i is P_k-supported
   have hSectorSupp : ∀ k i, P k * (P k * A i) * P k = P k * A i := by
     intro k i
@@ -722,7 +737,7 @@ theorem exists_blockDecomp_of_commuting_projections
       rw [hComm k i, ← Matrix.mul_assoc]
     simp_rw [hterm, ← Finset.sum_mul, hLeft, Matrix.one_mul]
   -- Apply compression to each sector
-  choose dim blocks φ hDim hTPblocks hMPVblocks hIntertwine using fun k =>
+  choose dim blocks φ hDim hTPblocks hMPVblocks hIntertwine hMul hStar using fun k =>
     exists_compressedTensor_of_supported_projection
       (fun i => P k * A i) (P k) (hPproj k) (hSectorSupp k) (hSectorTP k)
   -- Per-sector trace relation: mpv(blocks k) σ = tr(P_k · evalWord A σ)
@@ -732,7 +747,7 @@ theorem exists_blockDecomp_of_commuting_projections
     rw [hMPVblocks k N σ]
     congr 1
     exact left_mul_evalWord_leftSectorTensor_of_commutes (P k) A (hPproj k).2 (hComm k) _
-  refine ⟨dim, blocks, φ, hTPblocks, ?_, hSectorTrace, hIntertwine⟩
+  refine ⟨dim, blocks, φ, hTPblocks, ?_, hSectorTrace, hIntertwine, hMul, hStar⟩
   -- SameMPV₂ follows from summing per-sector traces over the projection partition
   intro N σ
   rw [mpv_toTensorFromBlocks_eq_sum]; simp only [one_pow, one_smul]
@@ -794,7 +809,11 @@ theorem exists_blockDecomp_of_adjoint_fixed_projections
         (φ k (transferMap (d := d) (D := dim k)
             (fun i => (blocks k i)ᴴ) X)).1 =
           transferMap (d := d) (D := D)
-            (fun i => (P k * A i)ᴴ) ((φ k X).1)) := by
+            (fun i => (P k * A i)ᴴ) ((φ k X).1)) ∧
+      (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ) := by
   have hComm : ∀ k : Fin m, ∀ i : Fin d, P k * A i = A i * P k := by
     intro k i
     exact commutes_letters_of_adjoint_fixed_projection

--- a/TNLean/MPS/Periodic/Overlap.lean
+++ b/TNLean/MPS/Periodic/Overlap.lean
@@ -102,14 +102,15 @@ The per-sector trace relation ties each compressed block `blocks k` back to the
 projection `P k` via `mpv (blocks k) σ = tr(P k · evalWord(blockTensor A m)(σ))`,
 which is the defining property of `exists_compressedTensor_of_supported_projection`.
 
-Also carries per-sector compression linear equivalences
-`φ k : M_{dim k}(ℂ) ≃ₗ[ℂ] cornerSubmodule (P k)` and the intertwining identity relating
-the compressed adjoint transfer map to the sector adjoint transfer map on the corner
-of `P k`. Returning each `φ k` as a `LinearEquiv` lets downstream consumers
-(see `compressedTensor_adjointTransferMap_cornerBridge`) transport corner-level
-irreducibility / primitivity results back to the compressed matrix algebra via
-conjugation.  The underlying linear map is an isometry for the canonical inner products;
-that property is witnessed separately where needed. -/
+Also carries per-sector compression `∗`-algebra isomorphisms
+`φ k : M_{dim k}(ℂ) ≃ₗ[ℂ] cornerSubmodule (P k)` that are multiplicative and
+`∗`-preserving, together with the intertwining identity relating the compressed
+adjoint transfer map to the sector adjoint transfer map on the corner of `P k`.
+Exposing `φ k` as a `LinearEquiv` with mul/star compatibility lets downstream
+consumers (see `compressedTensor_adjointTransferMap_cornerBridge`) transport
+corner-level irreducibility / primitivity results back to the compressed matrix
+algebra via conjugation.  The underlying linear map is an isometry for the
+canonical inner products; that property is witnessed separately where needed. -/
 def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
     {dim : Fin m → ℕ}
     (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)) : Prop :=

--- a/TNLean/MPS/Periodic/Overlap.lean
+++ b/TNLean/MPS/Periodic/Overlap.lean
@@ -461,20 +461,20 @@ private lemma cornerRestriction_primitive_and_irreducible_of_cyclicDecomp
       hIrr P hPproj hPsum (by simpa [T] using hCyclic) (by simpa [T] using hLift) u
   exact ⟨hInv, by simpa [T] using hCornerPrim, by simpa [T] using hCornerIrr⟩
 
-/-- **Missing compression-transfer bridge.**
+/-- **Compression-transfer bridge.**
 
-This is the precise local API needed from
-`exists_compressedTensor_of_supported_projection`: if `C` is the sector tensor
-obtained by compressing a `P`-supported tensor `B`, then the adjoint transfer
-map of `C` is the matrix representative of the corner restriction of the
-ambient adjoint transfer map of `B`.
+Given a `∗`-algebra compression equivalence `φ : M_n(ℂ) ≃ₗ[ℂ] cornerSubmodule P`
+intertwining the compressed adjoint transfer map (of `C`) with the
+`P·B`-adjoint transfer map on the corner (`hIntertwine`), and preserving both
+multiplication (`hMul`) and the adjoint (`hStar`), primitivity and
+irreducibility of the corner restriction of the ambient `T = transferMap Bᴴ`
+transport to primitivity and irreducibility of `transferMap Cᴴ`.
 
-The current compression theorem exposes only the trace identity
-`mpv C = tr(P · word(B))`.  The proof of this lemma should expose the
-spectral compression isometry used in `CyclicSectors.lean` and show that it
-intertwines the two adjoint transfer maps; irreducibility then follows because
-that isometry identifies orthogonal projections in `M_n(ℂ)` with orthogonal
-subprojections of `P`.
+The proof uses `hMul` / `hStar` to lift orthogonal projections on
+`M_n(ℂ)` to corner projections `Q = (φ Q').1 ≤ P`, transports
+`PreservesCorner` across `φ` via the intertwining identity, and applies
+`IsPrimitive.conj_iff_cross` to move primitivity across the cross-space
+conjugation `cornerRestriction P T = φ.conj (transferMap Cᴴ)`.
 -/
 private lemma compressedTensor_adjointTransferMap_cornerBridge
     {r D n : ℕ} [NeZero n]
@@ -484,10 +484,6 @@ private lemma compressedTensor_adjointTransferMap_cornerBridge
     (hT :
       transferMap (d := r) (D := D) (fun i => (B i)ᴴ) = T)
     (hPproj : IsOrthogonalProjection P)
-    (_hComm : ∀ i : Fin r, P * B i = B i * P)
-    (_hTrace :
-      ∀ (N : ℕ) (σ : Fin N → Fin r),
-        mpv C σ = (P * evalWord B (List.ofFn σ)).trace)
     (hIntertwine : ∀ X : Matrix (Fin n) (Fin n) ℂ,
       (φ (transferMap (d := r) (D := n) (fun i => (C i)ᴴ) X)).1 =
         transferMap (d := r) (D := D) (fun i => (P * B i)ᴴ) ((φ X).1))
@@ -648,14 +644,16 @@ private lemma compressedTensor_adjointTransferMap_cornerBridge
       exact hQP_eq
   exact ⟨hPrim_F_C, hIrr⟩
 
-/-- The missing compressed-sector identification.
+/-- **Per-sector compressed-block bridge.**
 
-For a cyclic sector decomposition, the adjoint transfer map of the compressed
-block `blocks u` should be linearly conjugate to the corner restriction of the
-ambient `m`-step adjoint transfer map on `P u · M_D(ℂ) · P u`. We only expose
-the transported primitive and irreducible consequences here; the explicit
-conjugating linear equivalence is not needed by the current callers and is
-expensive for Lean to elaborate as part of a `sorry` placeholder. -/
+For a cyclic sector decomposition with per-sector `∗`-algebra compression
+equivalences `φ k : M_{dim k}(ℂ) ≃ₗ[ℂ] cornerSubmodule (P k)` that are
+multiplicative (`hMul`), `∗`-preserving (`hStar`), and intertwine the
+compressed adjoint transfer map with the `P k · blockTensor`-adjoint transfer
+map on the corner (`hIntertwine`): primitivity and irreducibility on the
+corner of `P u` (for the ambient `m`-step adjoint transfer map
+`(transferMap Aᴴ) ^ m`) transport along `φ u` to primitivity and
+irreducibility of the compressed block `blocks u`. -/
 private lemma compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     {dim : Fin m → ℕ}
@@ -665,12 +663,6 @@ private lemma compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp
     {φ : (k : Fin m) →
       Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)}
     (hPproj : ∀ k, IsOrthogonalProjection (P k))
-    (hComm :
-      ∀ k (i : Fin (blockPhysDim d m)),
-        P k * (blockTensor A m) i = (blockTensor A m) i * P k)
-    (hTrace :
-      ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
-        mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace)
     (hIntertwine :
       ∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
         (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
@@ -712,7 +704,7 @@ private lemma compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp
   exact
     compressedTensor_adjointTransferMap_cornerBridge
       (B := blockTensor A m) (C := blocks u) (P := P u) (T := T) (φ := φ u)
-      hT (hPproj u) (hComm u) (hTrace u) (hIntertwine u) (hMul u) (hStar u)
+      hT (hPproj u) (hIntertwine u) (hMul u) (hStar u)
       hInv hCornerPrim hCornerIrr
 
 private lemma adjointTransferMap_primitive_and_irreducible_sectorBlock_of_cyclicDecomp
@@ -741,7 +733,7 @@ private lemma adjointTransferMap_primitive_and_irreducible_sectorBlock_of_cyclic
       A hP blocks hBlocks_lc hBlocks_mpv hPproj hPsum hCyclicP hComm hTrace u hNonzero
   exact
     compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp
-      A blocks (φ := φ) hPproj hComm hTrace hIntertwine hMul hStar u hNonzero
+      A blocks (φ := φ) hPproj hIntertwine hMul hStar u hNonzero
       hInv hCornerPrim hCornerIrr
 
 /-- **Structural bridge** for Case 3 of Proposition 3.3 (arXiv:1708.00029):

--- a/TNLean/MPS/Periodic/Overlap.lean
+++ b/TNLean/MPS/Periodic/Overlap.lean
@@ -127,7 +127,11 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
       (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
           (fun i => (blocks k i)ᴴ) X)).1 =
         transferMap (d := blockPhysDim d m) (D := D)
-          (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1))
+          (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1)) ∧
+    (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+      (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+    (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+      (φ k Xᴴ).1 = ((φ k X).1)ᴴ)
 
 private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
@@ -214,9 +218,9 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
   obtain ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hCyclic, hComm, hTraceNondeg⟩ :=
     exists_cyclic_sector_decomp_after_blocking
       A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
-  obtain ⟨hTrace, hIntertwine, hNondeg⟩ := hTraceNondeg
+  obtain ⟨hTrace, hIntertwine, hMul, hStar, hNondeg⟩ := hTraceNondeg
   exact ⟨dim, blocks, hLC, hMPV,
-    ⟨P, φ, hPproj, hPsum, hCyclic, hComm, hTrace, hIntertwine⟩, hNondeg⟩
+    ⟨P, φ, hPproj, hPsum, hCyclic, hComm, hTrace, hIntertwine, hMul, hStar⟩, hNondeg⟩
 
 
 private lemma hLift_cyclicDecomp_mps_of_fixUpgrade_missingBridge
@@ -476,13 +480,21 @@ private lemma compressedTensor_adjointTransferMap_cornerBridge
     {r D n : ℕ} [NeZero n]
     (B : MPSTensor r D) (C : MPSTensor r n) (P : MatrixAlg D)
     (T : MatrixEnd D)
+    (φ : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P)
     (hT :
       transferMap (d := r) (D := D) (fun i => (B i)ᴴ) = T)
     (hPproj : IsOrthogonalProjection P)
-    (hComm : ∀ i : Fin r, P * B i = B i * P)
-    (hTrace :
+    (_hComm : ∀ i : Fin r, P * B i = B i * P)
+    (_hTrace :
       ∀ (N : ℕ) (σ : Fin N → Fin r),
         mpv C σ = (P * evalWord B (List.ofFn σ)).trace)
+    (hIntertwine : ∀ X : Matrix (Fin n) (Fin n) ℂ,
+      (φ (transferMap (d := r) (D := n) (fun i => (C i)ᴴ) X)).1 =
+        transferMap (d := r) (D := D) (fun i => (P * B i)ᴴ) ((φ X).1))
+    (hMul : ∀ X Y : Matrix (Fin n) (Fin n) ℂ,
+      (φ (X * Y)).1 = (φ X).1 * (φ Y).1)
+    (hStar : ∀ X : Matrix (Fin n) (Fin n) ℂ,
+      (φ Xᴴ).1 = ((φ X).1)ᴴ)
     (hInv : PreservesCorner P T)
     (hCornerPrim :
       _root_.IsPrimitive (cornerRestriction P T hInv))
@@ -491,7 +503,150 @@ private lemma compressedTensor_adjointTransferMap_cornerBridge
       (transferMap (d := r) (D := n) (fun i => (C i)ᴴ)) ∧
       IsIrreducibleMap
         (transferMap (d := r) (D := n) (fun i => (C i)ᴴ)) := by
-  sorry
+  classical
+  set F_C : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] Matrix (Fin n) (Fin n) ℂ :=
+    transferMap (d := r) (D := n) (fun i => (C i)ᴴ) with hF_C_def
+  have hPherm : Pᴴ = P := hPproj.1.eq
+  -- On the corner, the ambient `T` and the `P*B`-adjoint transfer map agree.
+  have hTeq :
+      ∀ Y : MatrixAlg D, P * Y * P = Y →
+        transferMap (d := r) (D := D) (fun i => (P * B i)ᴴ) Y = T Y := by
+    intro Y hY
+    have hstep :
+        transferMap (d := r) (D := D) (fun i => (P * B i)ᴴ) Y =
+          transferMap (d := r) (D := D) (fun i => (B i)ᴴ) Y := by
+      simp only [transferMap_apply]
+      refine Finset.sum_congr rfl ?_
+      intro i _
+      have hPBi : ((P * B i)ᴴ) = (B i)ᴴ * P := by
+        rw [Matrix.conjTranspose_mul, hPherm]
+      rw [hPBi, Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, hPherm]
+      calc
+        (B i)ᴴ * P * Y * (P * B i)
+            = (B i)ᴴ * (P * Y * P) * B i := by
+              simp [Matrix.mul_assoc]
+        _ = (B i)ᴴ * Y * B i := by rw [hY]
+    rw [hstep, hT]
+  -- `cornerRestriction P T hInv = φ.conj F_C`.
+  have hConj :
+      cornerRestriction P T hInv = φ.conj F_C := by
+    refine LinearMap.ext ?_
+    intro Y
+    refine Subtype.ext ?_
+    change T Y.1 = (φ.conj F_C Y).1
+    rw [LinearEquiv.conj_apply_apply]
+    have hkey := hIntertwine (φ.symm Y)
+    have hφsy : (φ (φ.symm Y)).1 = Y.1 :=
+      congrArg Subtype.val (LinearEquiv.apply_symm_apply φ Y)
+    rw [hφsy] at hkey
+    rw [hkey]
+    exact (hTeq Y.1 Y.2).symm
+  -- Primitivity: transport from the corner via cross-space conjugation.
+  have hPrim_F_C : _root_.IsPrimitive F_C :=
+    (IsPrimitive.conj_iff_cross (e := φ) (f := F_C)).mp (hConj ▸ hCornerPrim)
+  -- Irreducibility: map orthogonal projections `Q'` in `M_n(ℂ)` to corner projections.
+  -- `(φ 1).1 = P` since `(φ 1).1` is the identity of `cornerSubmodule P`.
+  have hφ1_eq_P : (φ 1).1 = P := by
+    have hPcorn : P * P * P = P := by rw [hPproj.2, hPproj.2]
+    set Yinv : Matrix (Fin n) (Fin n) ℂ := φ.symm ⟨P, hPcorn⟩
+    have hφYinv : (φ Yinv).1 = P :=
+      congrArg Subtype.val (LinearEquiv.apply_symm_apply φ ⟨P, hPcorn⟩)
+    have hPleft : (φ 1).1 * P = P := by
+      have hmul := hMul 1 Yinv
+      rw [one_mul, hφYinv] at hmul
+      exact hmul.symm
+    calc
+      (φ 1).1 = P * (φ 1).1 * P := ((φ 1).2).symm
+      _ = P * ((φ 1).1 * P) := by simp [Matrix.mul_assoc]
+      _ = P * P := by rw [hPleft]
+      _ = P := hPproj.2
+  have hIrr : IsIrreducibleMap F_C := by
+    intro Q' hQ'proj hQ'preserves
+    set Q : MatrixAlg D := (φ Q').1 with hQ_def
+    have hQ_corner : P * Q * P = Q := (φ Q').2
+    have hQherm : Qᴴ = Q := by
+      have hstar := hStar Q'
+      rw [hQ'proj.1.eq] at hstar
+      exact hstar.symm
+    have hQidem : Q * Q = Q := by
+      have h1 := hMul Q' Q'
+      rw [hQ'proj.2] at h1
+      exact h1.symm
+    have hQP : Q * P = Q := by
+      calc Q * P = P * Q * P * P := by rw [hQ_corner]
+        _ = P * Q * (P * P) := by simp [Matrix.mul_assoc]
+        _ = P * Q * P := by rw [hPproj.2]
+        _ = Q := hQ_corner
+    have hPQ : P * Q = Q := by
+      calc P * Q = P * (P * Q * P) := by rw [hQ_corner]
+        _ = (P * P) * Q * P := by simp [Matrix.mul_assoc]
+        _ = P * Q * P := by rw [hPproj.2]
+        _ = Q := hQ_corner
+    have hQproj : IsOrthogonalProjection Q := ⟨hQherm, hQidem⟩
+    -- PreservesCorner Q T: use `hIntertwine`, `hMul`, and Q'-invariance of F_C.
+    have hQinv : PreservesCorner Q T := by
+      intro Y
+      set W : MatrixAlg D := P * Y * P with hW_def
+      have hW_corner : P * W * P = W := by
+        change P * (P * Y * P) * P = P * Y * P
+        calc
+          P * (P * Y * P) * P = (P * P) * Y * (P * P) := by simp [Matrix.mul_assoc]
+          _ = P * Y * P := by rw [hPproj.2]
+      have hQYQ_eq : Q * Y * Q = Q * W * Q := by
+        calc Q * Y * Q
+            = (Q * P) * Y * (P * Q) := by rw [hQP, hPQ]
+          _ = Q * (P * Y * P) * Q := by simp [Matrix.mul_assoc]
+          _ = Q * W * Q := rfl
+      set W' : Matrix (Fin n) (Fin n) ℂ := φ.symm ⟨W, hW_corner⟩
+      have hφW' : (φ W').1 = W :=
+        congrArg Subtype.val (LinearEquiv.apply_symm_apply φ ⟨W, hW_corner⟩)
+      set Z' : Matrix (Fin n) (Fin n) ℂ := Q' * W' * Q' with hZ'_def
+      have hQWQ_φZ' : Q * W * Q = (φ Z').1 := by
+        have hZ'assoc : Z' = Q' * (W' * Q') := by
+          simp [hZ'_def, Matrix.mul_assoc]
+        calc
+          Q * W * Q = (φ Q').1 * W * (φ Q').1 := rfl
+          _ = (φ Q').1 * (φ W').1 * (φ Q').1 := by rw [hφW']
+          _ = (φ Q').1 * ((φ W').1 * (φ Q').1) := by simp [Matrix.mul_assoc]
+          _ = (φ Q').1 * (φ (W' * Q')).1 := by rw [hMul W' Q']
+          _ = (φ (Q' * (W' * Q'))).1 := by rw [hMul Q' (W' * Q')]
+          _ = (φ Z').1 := by rw [← hZ'assoc]
+      have hQYQ_φZ' : Q * Y * Q = (φ Z').1 := hQYQ_eq.trans hQWQ_φZ'
+      -- F_C Z' ∈ corner(Q') by Q'-invariance of F_C.
+      have hF_C_fix : Q' * F_C Z' * Q' = F_C Z' := by
+        have := hQ'preserves W'
+        simpa [hZ'_def, hF_C_def] using this
+      -- Transport Q'-invariance of F_C via φ.
+      have hφF_C_fix : (φ (F_C Z')).1 = Q * (φ (F_C Z')).1 * Q := by
+        have key : (φ (Q' * F_C Z' * Q')).1 = Q * (φ (F_C Z')).1 * Q := by
+          calc
+            (φ (Q' * F_C Z' * Q')).1
+                = (φ (Q' * (F_C Z' * Q'))).1 := by rw [Matrix.mul_assoc]
+              _ = (φ Q').1 * (φ (F_C Z' * Q')).1 := hMul _ _
+              _ = (φ Q').1 * ((φ (F_C Z')).1 * (φ Q').1) := by rw [hMul (F_C Z') Q']
+              _ = Q * (φ (F_C Z')).1 * Q := by simp [hQ_def, Matrix.mul_assoc]
+        rw [hF_C_fix] at key
+        exact key
+      -- `T ((φ Z').1) = (φ (F_C Z')).1`.
+      have hTφZ' : T ((φ Z').1) = (φ (F_C Z')).1 := by
+        have hZ'corner : P * (φ Z').1 * P = (φ Z').1 := (φ Z').2
+        have hIw := (hIntertwine Z').symm
+        rw [hTeq _ hZ'corner] at hIw
+        exact hIw
+      rw [hQYQ_φZ', hTφZ']
+      exact hφF_C_fix.symm
+    rcases hCornerIrr Q hQproj hQP hPQ hQinv with hQ0 | hQP_eq
+    · left
+      apply φ.injective
+      apply Subtype.ext
+      simp only [map_zero, Submodule.coe_zero]
+      exact hQ0
+    · right
+      apply φ.injective
+      apply Subtype.ext
+      rw [hφ1_eq_P]
+      exact hQP_eq
+  exact ⟨hPrim_F_C, hIrr⟩
 
 /-- The missing compressed-sector identification.
 
@@ -507,6 +662,8 @@ private lemma compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp
     (blocks :
       (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
     {P : Fin m → MatrixAlg D}
+    {φ : (k : Fin m) →
+      Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)}
     (hPproj : ∀ k, IsOrthogonalProjection (P k))
     (hComm :
       ∀ k (i : Fin (blockPhysDim d m)),
@@ -514,6 +671,18 @@ private lemma compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp
     (hTrace :
       ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
         mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace)
+    (hIntertwine :
+      ∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := blockPhysDim d m) (D := D)
+            (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1))
+    (hMul :
+      ∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1)
+    (hStar :
+      ∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ)
     (u : Fin m) (hNonzero : dim u ≠ 0)
     (hInv :
       PreservesCorner (P u)
@@ -542,8 +711,9 @@ private lemma compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp
     exact transferMap_adjoint_blocked_eq_pow A m X
   exact
     compressedTensor_adjointTransferMap_cornerBridge
-      (B := blockTensor A m) (C := blocks u) (P := P u) (T := T)
-      hT (hPproj u) (hComm u) (hTrace u) hInv hCornerPrim hCornerIrr
+      (B := blockTensor A m) (C := blocks u) (P := P u) (T := T) (φ := φ u)
+      hT (hPproj u) (hComm u) (hTrace u) (hIntertwine u) (hMul u) (hStar u)
+      hInv hCornerPrim hCornerIrr
 
 private lemma adjointTransferMap_primitive_and_irreducible_sectorBlock_of_cyclicDecomp
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
@@ -565,13 +735,14 @@ private lemma adjointTransferMap_primitive_and_irreducible_sectorBlock_of_cyclic
       ∧ IsIrreducibleMap
         (transferMap (d := blockPhysDim d m) (D := dim u)
           (fun i => (blocks u i)ᴴ)) := by
-  obtain ⟨P, _φ, hPproj, hPsum, hCyclicP, hComm, hTrace, _hIntertwine⟩ := hCyclic
+  obtain ⟨P, φ, hPproj, hPsum, hCyclicP, hComm, hTrace, hIntertwine, hMul, hStar⟩ := hCyclic
   obtain ⟨hInv, hCornerPrim, hCornerIrr⟩ :=
     cornerRestriction_primitive_and_irreducible_of_cyclicDecomp
       A hP blocks hBlocks_lc hBlocks_mpv hPproj hPsum hCyclicP hComm hTrace u hNonzero
   exact
     compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp
-      A blocks hPproj hComm hTrace u hNonzero hInv hCornerPrim hCornerIrr
+      A blocks (φ := φ) hPproj hComm hTrace hIntertwine hMul hStar u hNonzero
+      hInv hCornerPrim hCornerIrr
 
 /-- **Structural bridge** for Case 3 of Proposition 3.3 (arXiv:1708.00029):
 each nonzero compressed sector block `blocks u` arising from a cyclic sector
@@ -705,7 +876,8 @@ private lemma sectorBlocks_not_gaugePhaseEquiv_of_ne
     ¬ GaugePhaseEquiv
       (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim) (blocks u))
       (blocks v) := by
-  obtain ⟨P, _φ, hPproj, hPsum, hCyclicP, hComm, hTrace, _hIntertwine⟩ := hCyclic
+  obtain ⟨P, _φ, hPproj, hPsum, hCyclicP, hComm, hTrace, _hIntertwine, _hMul, _hStar⟩ :=
+    hCyclic
   have hPairwise : Pairwise fun i j : Fin m => P i * P j = 0 :=
     pairwise_mul_zero_of_orthogonalProjection_sum_one P hPproj hPsum
   have hOrth : P u * P v = 0 := hPairwise huv
@@ -1431,7 +1603,8 @@ private lemma sectorDim_ne_zero_succ_of_cyclicSectorDecomp
     {u : Fin m} (hNondeg : dim u ≠ 0) :
     dim (u + 1) ≠ 0 := by
   classical
-  obtain ⟨P, _φ, hPproj, _hPsum, hShift, _hComm, hTrace, _hIntertwine⟩ := hCyclic
+  obtain ⟨P, _φ, hPproj, _hPsum, hShift, _hComm, hTrace, _hIntertwine, _hMul, _hStar⟩ :=
+    hCyclic
   intro hzero
   have htrace_succ :
       Matrix.trace (P (u + 1)) = 0 := by

--- a/TNLean/MPS/Periodic/Overlap.lean
+++ b/TNLean/MPS/Periodic/Overlap.lean
@@ -516,7 +516,8 @@ private lemma compressedTensor_adjointTransferMap_cornerBridge
       intro i _
       have hPBi : ((P * B i)ᴴ) = (B i)ᴴ * P := by
         rw [Matrix.conjTranspose_mul, hPherm]
-      rw [hPBi, Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, hPherm]
+      simp only [Matrix.conjTranspose_conjTranspose]
+      rw [hPBi]
       calc
         (B i)ᴴ * P * Y * (P * B i)
             = (B i)ᴴ * (P * Y * P) * B i := by

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1037,15 +1037,18 @@ The following results separate the zero blocks from the
 	$\sum_i (A^i)^\dagger A^i = P$ for an orthogonal projection $P$,
 	and suppose $P A^i P = A^i$ for every~$i$.
 	Then there exist a left-canonical tensor $C$ of bond dimension
-	$n = \tr(P)$ and a linear equivalence
-	$\varphi : M_n(\mathbb{C}) \xrightarrow{\sim} P \cdot M_D(\mathbb{C}) \cdot P$ with
+	$n = \tr(P)$ and a $\ast$-algebra isomorphism
+	$\varphi : M_n(\mathbb{C}) \xrightarrow{\sim} P \cdot M_D(\mathbb{C}) \cdot P$
+	(preserving both multiplication and adjoint) with
 	\[
 		V^{(N)}(C)_\sigma = \tr\!\bigl(P \cdot A^\sigma\bigr),
 		\qquad
 		\varphi\!\bigl(\E_{C^\dagger}(X)\bigr)
 			= \E_{A^\dagger}\!\bigl(\varphi(X)\bigr)
 	\]
-	for every~$\sigma$ and every $X \in M_n(\mathbb{C})$.
+	for every~$\sigma$ and every $X \in M_n(\mathbb{C})$, together with
+	$\varphi(XY) = \varphi(X)\varphi(Y)$ and
+	$\varphi(X^\dagger) = \varphi(X)^\dagger$.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -696,11 +696,11 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 	$E^\dagger(P_{k+1}) = P_k$, each $P_k$ commutes with every blocked letter
 	$P_k A^{(m)}_i = A^{(m)}_i P_k$,
 	$V^{(N)}(C_k)_\sigma = \tr(P_k (A^{(m)})^\sigma)$ for every word~$\sigma$,
-	and each block carries a compression linear equivalence
+	and each block carries a $\ast$-algebra isomorphism
 	$\varphi_k : M_{\dim C_k}(\mathbb{C}) \xrightarrow{\sim}
 		P_k \cdot M_D(\mathbb{C}) \cdot P_k$
-	intertwining the compressed adjoint transfer map with the sector adjoint
-	transfer map on the corner of~$P_k$.
+	(multiplicative and adjoint-preserving) intertwining the compressed adjoint
+	transfer map with the sector adjoint transfer map on the corner of~$P_k$.
 \end{definition}
 
 \begin{definition}[One-site corner transition]%


### PR DESCRIPTION
### Motivation

- One of three Tier-A private bridge lemmas blocking every Case-0/1/2/3 top-level theorem of Prop 3.3 in arXiv:1708.00029 Appendix A (see #607).
- Discharging it unlocks `periodicSelfOverlap_tendsto`, `periodicOverlap_tendsto_zero_of_ne_period`, `periodicOverlap_tendsto_zero_of_no_sector_match`, and `periodicOverlap_gaugeEquiv_of_sector_match`, all feeding `periodicOverlapDichotomy`.

### Description

- `TNLean/MPS/Periodic/Overlap.lean`: discharge the Tier-A `sorry` in `compressedTensor_adjointTransferMap_cornerBridge` and its sector-level twin `compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp`; proof uses Hermiticity of `P`, the intertwining hypothesis `hIntertwine` to get `cornerRestriction P T hInv = φ.conj F_C`, and lifts a projection `Q'` on `Mat(Fin n, ℂ)` to `Q = (φ Q').1` on `corner P` for irreducibility transport.
- `TNLean/Channel/Peripheral/Conjugation.lean`: add `IsPrimitive.conj_iff_cross` for primitivity transport across the cross-space conjugation.
- `TNLean/Channel/Peripheral/CyclicDecomposition.lean`: extend `IsCyclicSectorDecomp` with `hMul` and `hStar` fields exposing the compression isometry `φ` as a `∗`-ring intertwiner, plus matching star/mul lemmas for the shared corner-compression expansion.
- `TNLean/MPS/CanonicalForm/CyclicSectors.lean`, `TNLean/MPS/CanonicalForm/Assembly.lean`: propagate the new `hMul`/`hStar` fields through the decomposition records and bridge lemmas; update unpacking sites to destructure all ten fields.
- No new `sorry` or `axiom` introduced.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate `lake build`.
- `rg -n "sorry|axiom" TNLean/MPS/Periodic/Overlap.lean` should show the two targeted sorrys gone.

---
Closes #607

> [!NOTE]
> **Medium Risk**
> Moderate risk because it extends several dependent lemma signatures (threading new `φ` algebraic properties) and adds a large new proof that transports primitivity/irreducibility across a corner-compression equivalence, which may break downstream theorems if assumptions don't line up.
>
> **Overview**
> Implements the previously `sorry`-stubbed bridge `compressedTensor_adjointTransferMap_cornerBridge` by proving that the compressed sector's adjoint transfer map is conjugate (via the compression equivalence `φ`) to the corner restriction of the ambient adjoint transfer map, and then transporting *primitivity* and *irreducibility* across that conjugation.
>
> To support this, the PR strengthens the cyclic-sector decomposition API to also return that `φ` is multiplicative and ∗-preserving, adds corresponding star/mul lemmas for the shared corner-compression expansion, and introduces cross-space conjugation invariance lemmas for eigenvalues/peripheral spectrum/primitivity. Call sites in canonical-form assembly and periodic overlap are updated to thread the new `hMul`/`hStar` data through the decomposition records and bridge lemmas.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3881c7430fe1512772232e9d0d33ebc9e166d65b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: adds a substantial new Lean proof transporting primitivity/irreducibility across a corner-compression conjugation, and threads new `hMul`/`hStar` assumptions through several dependent decomposition lemmas, which may break downstream proof obligations if any callers relied on the weaker interface.
> 
> **Overview**
> **Discharges the previously `sorry`-stubbed compression-transfer bridge** in `MPS/Periodic/Overlap.lean` by proving `compressedTensor_adjointTransferMap_cornerBridge`, showing the compressed adjoint transfer map is conjugate (via the compression equivalence `φ`) to the ambient corner restriction and transporting *primitivity* and *irreducibility* across that conjugation.
> 
> **Strengthens the cyclic-sector decomposition API** so the compression equivalences `φ` are exposed as `∗`-compatible algebra morphisms: adds cross-space conjugation invariance lemmas (`hasEigenvalue`/`peripheralEigenvalues`/`IsPrimitive`) in `Channel/Peripheral/Conjugation.lean`, adds `cornerCompressionExpand` star/mul lemmas in `Channel/Peripheral/CyclicDecomposition.lean`, and propagates new `hMul`/`hStar` fields through `MPS/CanonicalForm/CyclicSectors.lean`, `MPS/CanonicalForm/Assembly.lean`, and periodic overlap definitions/uses.
> 
> Updates the blueprint text to describe `φ` as a `∗`-algebra isomorphism (mul + adjoint preserving) in the corresponding theorems/definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e578d25c338881696ac6f2e9779d8a22d9357e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->