### PR TITLE
feat(MPS/MPDO): fusion isometries for §4.5 general MPDO RFP (#611)

### DIFF
--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -2,10 +2,13 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.Algebra.Module.Submodule.LinearMap
+import TNLean.MPS.Core.BlockingTransfer
+import TNLean.MPS.MPDO.PureRecovery
 import TNLean.MPS.MPDO.RFP
 
 /-!
-# Fusion-isometry formulation of the MPDO renormalization fixed point
+# Fusion-isometry formulations of the MPDO renormalization fixed point
 
 This file records the **fusion-isometry** side of the equivalence stated in
 arXiv:1606.00608 §4.5 (Cirac–Pérez-García–Schuch–Verstraete). In the notation
@@ -17,38 +20,47 @@ Iterated applications of `T` and `S` reproduce the doubled-tensor transfer-map
 dynamics underlying the provisional `MPOTensor.IsRFP` predicate in
 `TNLean/MPS/MPDO/RFP.lean`.
 
-The development of the support-algebra API, blocked tensor powers, and
-trace-preserving completely positive blocking maps required for the full
-statement is deferred. In the present formulation:
+Two layers coexist in this file.
 
-* the physical space at blocked size `n` and the support algebra at blocked
-  size `n` are both represented by `Matrix (Fin D) (Fin D) ℂ`, a stand-in for
-  the genuine objects;
-* the idempotence and compatibility conditions in `FusionIsometry` are stated
-  as general linear-algebraic hypotheses, weaker than the paper's identities
-  on a genuine support algebra;
-* `IsRFP_MPDO_via_fusion_scaffold` asserts the existence, at every blocked
-  size, of a fusion isometry related to the tensor `M` by the relation
-  `FusionIsometry.CompatibleWith`. The latter is currently the trivial
-  proposition `True`, so the predicate as a whole is satisfied by every
-  `M`. The `_scaffold` suffix marks the predicate to prevent its use in
-  nontrivial reasoning until the relation is tightened.
+1. **Provisional shell layer** (`FusionIsometry`, `FusionIsometry.CompatibleWith`,
+   `IsRFP_MPDO_via_fusion_scaffold`): kept for downstream compatibility. The
+   physical space at blocked size `n` and the support algebra at blocked size
+   `n` are both represented by `Matrix (Fin D) (Fin D) ℂ`, a stand-in for the
+   genuine objects; the compatibility predicate is currently the trivial
+   proposition `True`, so `IsRFP_MPDO_via_fusion_scaffold` as a whole is
+   satisfied by every `M`. The `_scaffold` suffix marks the predicate to
+   prevent its use in nontrivial reasoning until the relation is tightened.
+2. **Transfer-map-level layer** (`blockedTransferMap`, `FusionIsometryData`,
+   `IsRFP_MPDO_via_fusion`): formalizes the transfer-map content already
+   supported by the current repository. Here a fusion-isometry datum at
+   blocked size `n` is a retract factorization of the blocked transfer map
+   through a support subspace of bond-space matrices. Concretely, if `Eₙ`
+   denotes the blocked transfer map of `M`, then `FusionIsometryData M n`
+   packages a support subspace `𝒜ₙ`, a forward map `Tₙ : phys → 𝒜ₙ`, and a
+   backward map `Sₙ : 𝒜ₙ → phys` with `Tₙ ∘ Sₙ = id_{𝒜ₙ}` and `Sₙ ∘ Tₙ = Eₙ`.
+   The retract identity forces `Eₙ^2 = Eₙ`; conversely any idempotent blocked
+   transfer map factors through its range. This yields an honest equivalence
+   between the current provisional predicate `MPOTensor.IsRFP` and the
+   transfer-map-level fusion formulation.
 
 ## Main declarations
 
-* `FusionIsometry`: a pair `(T, S)` of linear maps at a fixed blocked size,
-  together with an idempotence condition for `S ∘ₗ T` and a pointwise
-  identity-on-support condition for `T ∘ₗ S`.
-* `FusionIsometry.CompatibleWith`: relation between a fusion isometry and an
-  MPO tensor, currently the trivial proposition `True`.
-* `IsRFP_MPDO_via_fusion_scaffold`: the provisional RFP predicate built from a
-  family of fusion isometries related to the tensor by `CompatibleWith`. The
-  `_scaffold` suffix marks that the relation `CompatibleWith` is currently
-  `True` and the predicate consequently vacuous.
+* Provisional shell declarations: `FusionIsometry`, `FusionIsometry.CompatibleWith`,
+  `IsRFP_MPDO_via_fusion_scaffold`.
+* `blockedTransferMap`: the transfer map of the `n`-site blocked doubled-index
+  MPS tensor.
+* `FusionIsometryData`: retract data whose characteristic identity is the
+  blocked transfer map.
+* `IsRFP_MPDO_via_fusion`: existence of such data for every positive blocked
+  size.
+* `isRFP_MPDO_via_fusion_iff_isRFP`: equivalence with the current provisional
+  MPDO RFP predicate.
+* `MPSTensor.toMPOTensor_isRFP_MPDO_via_fusion_iff_isRFP`: pure-state recovery
+  for the diagonal MPO embedding.
 
 ## References
 
-* [CPGSV17] arXiv:1606.00608, §4.5 and Appendix C.3
+* [CPGSV17] arXiv:1606.00608, §4.5 and Appendix C.4
   (Cirac–Pérez-García–Schuch–Verstraete, Ann. Phys. 378, 100–149).
 -/
 
@@ -75,8 +87,7 @@ stand-in. -/
 abbrev FusionSupportAlgebra (D : ℕ) : Type :=
   Matrix (Fin D) (Fin D) ℂ
 
-/-- A **fusion isometry** at blocked size `n` for an MPO tensor of bond
-dimension `D`.
+/-- A provisional fusion-isometry package at blocked size `n`.
 
 In arXiv:1606.00608 §4.5 the corresponding object is a pair of linear maps
 `T_n : (ℂ^d)^{⊗ n} → 𝒜_n` and `S_n : 𝒜_n → (ℂ^d)^{⊗ n}` realising a splitting
@@ -166,4 +177,185 @@ longer trivial. -/
 def IsRFP_MPDO_via_fusion_scaffold (M : MPOTensor d D) : Prop :=
   ∀ n : ℕ, ∃ F : FusionIsometry d D n, F.CompatibleWith M
 
+/-! ## Transfer-map-level fusion data -/
+
+/-- The blocked transfer map of an MPO tensor, obtained by viewing `M` as a
+Doubled-index MPS tensor and blocking `n` physical sites. -/
+noncomputable def blockedTransferMap (M : MPOTensor d D) (n : ℕ) :
+    FusionPhysicalSpace D →ₗ[ℂ] FusionPhysicalSpace D :=
+  MPSTensor.transferMap
+    (d := MPSTensor.blockPhysDim (d * d) n) (D := D)
+    (MPSTensor.blockTensor (d := d * d) (D := D) M.toMPSTensor n)
+
+/-- Blocking an MPO tensor in the doubled-index MPS picture raises the transfer
+map to the corresponding power. -/
+@[simp] theorem blockedTransferMap_eq_pow (M : MPOTensor d D) (n : ℕ) :
+    blockedTransferMap M n = (transferMap M) ^ n := by
+  simpa [blockedTransferMap] using
+    (MPSTensor.transferMap_blockTensor (A := M.toMPSTensor) (L := n))
+
+/-- At blocked size `1`, the blocked transfer map is the original transfer map. -/
+@[simp] theorem blockedTransferMap_one (M : MPOTensor d D) :
+    blockedTransferMap M 1 = transferMap M := by
+  rw [blockedTransferMap_eq_pow (M := M), pow_one]
+
+/-- Transfer-map-level fusion-isometry data at blocked size `n`.
+
+This is the part of the paper's fusion-isometry picture that can already be
+expressed with the current infrastructure: a support subspace of bond-space
+matrices together with a retract whose characteristic map is the blocked
+transfer map. The actual Hilbert-space isometry statement is deferred until the
+support-algebra API is available. -/
+structure FusionIsometryData (M : MPOTensor d D) (n : ℕ) where
+  /-- The support subspace through which the blocked transfer map factors. -/
+  supportAlgebra : Submodule ℂ (FusionPhysicalSpace D)
+  /-- Forward map `T_n : phys → 𝒜_n`. -/
+  T : FusionPhysicalSpace D →ₗ[ℂ] supportAlgebra
+  /-- Backward map `S_n : 𝒜_n → phys`. -/
+  S : supportAlgebra →ₗ[ℂ] FusionPhysicalSpace D
+  /-- The retract identity `T_n ∘ S_n = id_{𝒜_n}`. -/
+  hTS : T ∘ₗ S = LinearMap.id
+  /-- The characteristic identity `S_n ∘ T_n = E_n` for the blocked transfer
+  map `E_n`. -/
+  hST : S ∘ₗ T = blockedTransferMap M n
+
+namespace FusionIsometryData
+
+variable {M : MPOTensor d D} {n : ℕ}
+
+/-- Any transfer-map-level fusion-isometry datum forces the blocked transfer map
+at the same size to be idempotent. -/
+theorem blockedTransferMap_idempotent (F : FusionIsometryData M n) :
+    blockedTransferMap M n ∘ₗ blockedTransferMap M n = blockedTransferMap M n := by
+  calc
+    blockedTransferMap M n ∘ₗ blockedTransferMap M n
+        = (F.S ∘ₗ F.T) ∘ₗ (F.S ∘ₗ F.T) := by rw [F.hST]
+    _ = F.S ∘ₗ (F.T ∘ₗ F.S) ∘ₗ F.T := by simp [LinearMap.comp_assoc]
+    _ = F.S ∘ₗ LinearMap.id ∘ₗ F.T := by rw [F.hTS]
+    _ = F.S ∘ₗ F.T := by simp
+    _ = blockedTransferMap M n := F.hST
+
+/-- An idempotent blocked transfer map yields a canonical fusion-isometry datum
+by factoring through its range. -/
+noncomputable def ofBlockedTransferMapIdempotent
+    (hE : blockedTransferMap M n ∘ₗ blockedTransferMap M n = blockedTransferMap M n) :
+    FusionIsometryData M n where
+  supportAlgebra := (blockedTransferMap M n).range
+  T := LinearMap.codRestrict (blockedTransferMap M n).range (blockedTransferMap M n)
+    (fun x => by exact ⟨x, rfl⟩)
+  S := (blockedTransferMap M n).range.subtype
+  hTS := by
+    apply LinearMap.ext
+    intro x
+    rcases x with ⟨x, hx⟩
+    rcases hx with ⟨y, rfl⟩
+    apply Subtype.ext
+    change blockedTransferMap M n (blockedTransferMap M n y) = blockedTransferMap M n y
+    simpa [LinearMap.comp_apply] using congrArg (fun f => f y) hE
+  hST := by
+    exact LinearMap.subtype_comp_codRestrict
+      (blockedTransferMap M n)
+      (blockedTransferMap M n).range
+      (fun x => by exact ⟨x, rfl⟩)
+
+/-- A level-`1` fusion-isometry datum implies the provisional MPDO RFP
+condition. -/
+theorem isRFP (F : FusionIsometryData M 1) : IsRFP M := by
+  simpa [IsRFP] using F.blockedTransferMap_idempotent
+
+end FusionIsometryData
+
+private theorem pow_succ_eq_self_of_idempotent
+    {V : Type*} [AddCommMonoid V] [Module ℂ V] (E : V →ₗ[ℂ] V)
+    (hE : E * E = E) :
+    ∀ n : ℕ, E ^ (n + 1) = E
+  | 0 => by simp
+  | k + 1 => by
+      calc
+        E ^ ((k + 1) + 1) = E ^ (k + 1) * E := by rw [pow_succ]
+        _ = E * E := by rw [pow_succ_eq_self_of_idempotent E hE k]
+        _ = E := hE
+
+/-- If `M` is already an MPDO renormalization fixed point, then every positive
+blocked transfer map coincides with the original transfer map. -/
+theorem blockedTransferMap_eq_transferMap_of_isRFP {M : MPOTensor d D}
+    (hM : IsRFP M) {n : ℕ} (hn : 0 < n) :
+    blockedTransferMap M n = transferMap M := by
+  rcases Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hn) with ⟨k, rfl⟩
+  rw [blockedTransferMap_eq_pow]
+  have hM' : transferMap M ∘ₗ transferMap M = transferMap M := hM
+  have hIdem : transferMap M * transferMap M = transferMap M := by
+    apply LinearMap.ext
+    intro X
+    simpa [LinearMap.comp_apply] using congrArg (fun f => f X) hM'
+  exact pow_succ_eq_self_of_idempotent (transferMap M) hIdem k
+
+/-- Under the provisional MPDO RFP condition, every positive blocked transfer
+map is idempotent. -/
+theorem blockedTransferMap_idempotent_of_isRFP {M : MPOTensor d D}
+    (hM : IsRFP M) {n : ℕ} (hn : 0 < n) :
+    blockedTransferMap M n ∘ₗ blockedTransferMap M n = blockedTransferMap M n := by
+  have hEq : blockedTransferMap M n = transferMap M :=
+    blockedTransferMap_eq_transferMap_of_isRFP hM hn
+  have hComp : blockedTransferMap M n ∘ₗ blockedTransferMap M n =
+      transferMap M ∘ₗ transferMap M := by
+    simpa using congrArg (fun f => f ∘ₗ f) hEq
+  calc
+    blockedTransferMap M n ∘ₗ blockedTransferMap M n = transferMap M ∘ₗ transferMap M := hComp
+    _ = transferMap M := hM
+    _ = blockedTransferMap M n := hEq.symm
+
+/-- Transfer-map-level fusion-isometry formulation of the provisional MPDO RFP
+condition.
+
+For every positive blocked size `n`, the blocked transfer map of `M` factors as
+`S_n ∘ T_n` through some support subspace `𝒜_n`, with `T_n ∘ S_n = id_{𝒜_n}`. -/
+def IsRFP_MPDO_via_fusion (M : MPOTensor d D) : Prop :=
+  ∀ n : ℕ, 0 < n → Nonempty (FusionIsometryData M n)
+
+/-- The transfer-map-level fusion formulation implies the provisional MPDO RFP
+condition. -/
+theorem isRFP_of_isRFP_MPDO_via_fusion {M : MPOTensor d D}
+    (hM : IsRFP_MPDO_via_fusion M) : IsRFP M := by
+  obtain ⟨F⟩ := hM 1 Nat.one_pos
+  exact F.isRFP
+
+/-- An MPDO renormalization fixed point admits transfer-map-level fusion data
+at every positive blocking size. -/
+theorem isRFP_MPDO_via_fusion_of_isRFP {M : MPOTensor d D}
+    (hM : IsRFP M) : IsRFP_MPDO_via_fusion M := by
+  intro n hn
+  exact ⟨FusionIsometryData.ofBlockedTransferMapIdempotent
+    (M := M)
+    (n := n)
+    (blockedTransferMap_idempotent_of_isRFP hM hn)⟩
+
+/-- Transfer-map-level fusion data is equivalent to the current provisional
+mixed-state RFP predicate. -/
+theorem isRFP_MPDO_via_fusion_iff_isRFP (M : MPOTensor d D) :
+    IsRFP_MPDO_via_fusion M ↔ IsRFP M := by
+  constructor
+  · exact isRFP_of_isRFP_MPDO_via_fusion
+  · exact isRFP_MPDO_via_fusion_of_isRFP
+
+/-- The transfer-map-level fusion formulation agrees with the pure-state RFP
+condition for the doubled-index MPS tensor. -/
+theorem isRFP_MPDO_via_fusion_iff_toMPSTensor_isRFP (M : MPOTensor d D) :
+    IsRFP_MPDO_via_fusion M ↔ MPSTensor.IsRFP M.toMPSTensor := by
+  rw [isRFP_MPDO_via_fusion_iff_isRFP, isRFP_iff_toMPSTensor_isRFP]
+
 end MPOTensor
+
+namespace MPSTensor
+
+open MPOTensor
+
+variable {d D : ℕ}
+
+/-- For a pure MPS embedded diagonally as an MPO, the transfer-map-level
+fusion formulation recovers the original pure-state RFP condition. -/
+theorem toMPOTensor_isRFP_MPDO_via_fusion_iff_isRFP (A : MPSTensor d D) :
+    MPOTensor.IsRFP_MPDO_via_fusion A.toMPOTensor ↔ IsRFP A := by
+  rw [MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP, toMPOTensor_isRFP_iff_isRFP]
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -266,30 +266,13 @@ theorem isRFP (F : FusionIsometryData M 1) : IsRFP M := by
 
 end FusionIsometryData
 
-private theorem pow_succ_eq_self_of_idempotent
-    {V : Type*} [AddCommMonoid V] [Module ℂ V] (E : V →ₗ[ℂ] V)
-    (hE : E * E = E) :
-    ∀ n : ℕ, E ^ (n + 1) = E
-  | 0 => by simp only [Nat.zero_add, pow_one]
-  | k + 1 => by
-      calc
-        E ^ ((k + 1) + 1) = E ^ (k + 1) * E := by rw [pow_succ]
-        _ = E * E := by rw [pow_succ_eq_self_of_idempotent E hE k]
-        _ = E := hE
-
 /-- If `M` is already an MPDO renormalization fixed point, then every positive
 blocked transfer map coincides with the original transfer map. -/
 theorem blockedTransferMap_eq_transferMap_of_isRFP {M : MPOTensor d D}
     (hM : IsRFP M) {n : ℕ} (hn : 0 < n) :
     blockedTransferMap M n = transferMap M := by
-  rcases Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hn) with ⟨k, rfl⟩
-  rw [blockedTransferMap_eq_pow]
-  have hM' : transferMap M ∘ₗ transferMap M = transferMap M := hM
-  have hIdem : transferMap M * transferMap M = transferMap M := by
-    apply LinearMap.ext
-    intro X
-    simpa only [LinearMap.comp_apply] using congrArg (fun f => f X) hM'
-  exact pow_succ_eq_self_of_idempotent (transferMap M) hIdem k
+  have hIdem : IsIdempotentElem (transferMap M) := hM
+  simpa only [blockedTransferMap_eq_pow] using hIdem.pow_eq (Nat.ne_of_gt hn)
 
 /-- Under the provisional MPDO RFP condition, every positive blocked transfer
 map is idempotent. -/

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -191,7 +191,7 @@ noncomputable def blockedTransferMap (M : MPOTensor d D) (n : ℕ) :
 map to the corresponding power. -/
 @[simp] theorem blockedTransferMap_eq_pow (M : MPOTensor d D) (n : ℕ) :
     blockedTransferMap M n = (transferMap M) ^ n := by
-  simpa [blockedTransferMap] using
+  simpa only [blockedTransferMap, transferMap_eq_toMPSTensor] using
     (MPSTensor.transferMap_blockTensor (A := M.toMPSTensor) (L := n))
 
 /-- At blocked size `1`, the blocked transfer map is the original transfer map. -/
@@ -232,7 +232,8 @@ theorem blockedTransferMap_idempotent (F : FusionIsometryData M n) :
         = (F.S ∘ₗ F.T) ∘ₗ (F.S ∘ₗ F.T) := by rw [F.hST]
     _ = F.S ∘ₗ (F.T ∘ₗ F.S) ∘ₗ F.T := by simp [LinearMap.comp_assoc]
     _ = F.S ∘ₗ LinearMap.id ∘ₗ F.T := by rw [F.hTS]
-    _ = F.S ∘ₗ F.T := by simp
+    _ = F.S ∘ₗ F.T := by
+      simp only [LinearMap.id_comp]
     _ = blockedTransferMap M n := F.hST
 
 /-- An idempotent blocked transfer map yields a canonical fusion-isometry datum
@@ -242,7 +243,7 @@ noncomputable def ofBlockedTransferMapIdempotent
     FusionIsometryData M n where
   supportAlgebra := (blockedTransferMap M n).range
   T := LinearMap.codRestrict (blockedTransferMap M n).range (blockedTransferMap M n)
-    (fun x => by exact ⟨x, rfl⟩)
+    (fun x => ⟨x, rfl⟩)
   S := (blockedTransferMap M n).range.subtype
   hTS := by
     apply LinearMap.ext
@@ -251,17 +252,17 @@ noncomputable def ofBlockedTransferMapIdempotent
     rcases hx with ⟨y, rfl⟩
     apply Subtype.ext
     change blockedTransferMap M n (blockedTransferMap M n y) = blockedTransferMap M n y
-    simpa [LinearMap.comp_apply] using congrArg (fun f => f y) hE
+    simpa only [LinearMap.comp_apply] using congrArg (fun f => f y) hE
   hST := by
     exact LinearMap.subtype_comp_codRestrict
       (blockedTransferMap M n)
       (blockedTransferMap M n).range
-      (fun x => by exact ⟨x, rfl⟩)
+      (fun x => ⟨x, rfl⟩)
 
 /-- A level-`1` fusion-isometry datum implies the provisional MPDO RFP
 condition. -/
 theorem isRFP (F : FusionIsometryData M 1) : IsRFP M := by
-  simpa [IsRFP] using F.blockedTransferMap_idempotent
+  simpa only [IsRFP, blockedTransferMap_one] using F.blockedTransferMap_idempotent
 
 end FusionIsometryData
 
@@ -269,7 +270,7 @@ private theorem pow_succ_eq_self_of_idempotent
     {V : Type*} [AddCommMonoid V] [Module ℂ V] (E : V →ₗ[ℂ] V)
     (hE : E * E = E) :
     ∀ n : ℕ, E ^ (n + 1) = E
-  | 0 => by simp
+  | 0 => by simp only [Nat.zero_add, pow_one]
   | k + 1 => by
       calc
         E ^ ((k + 1) + 1) = E ^ (k + 1) * E := by rw [pow_succ]
@@ -287,7 +288,7 @@ theorem blockedTransferMap_eq_transferMap_of_isRFP {M : MPOTensor d D}
   have hIdem : transferMap M * transferMap M = transferMap M := by
     apply LinearMap.ext
     intro X
-    simpa [LinearMap.comp_apply] using congrArg (fun f => f X) hM'
+    simpa only [LinearMap.comp_apply] using congrArg (fun f => f X) hM'
   exact pow_succ_eq_self_of_idempotent (transferMap M) hIdem k
 
 /-- Under the provisional MPDO RFP condition, every positive blocked transfer
@@ -299,7 +300,7 @@ theorem blockedTransferMap_idempotent_of_isRFP {M : MPOTensor d D}
     blockedTransferMap_eq_transferMap_of_isRFP hM hn
   have hComp : blockedTransferMap M n ∘ₗ blockedTransferMap M n =
       transferMap M ∘ₗ transferMap M := by
-    simpa using congrArg (fun f => f ∘ₗ f) hEq
+    exact congrArg (fun f => f ∘ₗ f) hEq
   calc
     blockedTransferMap M n ∘ₗ blockedTransferMap M n = transferMap M ∘ₗ transferMap M := hComp
     _ = transferMap M := hM

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -489,41 +489,83 @@ legs cyclically and taking the resulting trace.
 
 \section{\S4.5 Fusion isometries}
 
-Following \cite[\S4.5]{Cirac2017MPDO_AnnPhys}, Theorem~IV.13 characterises
-renormalization-fixed-point MPDOs through two equivalent structures: a family
-of fusion isometries splitting the support algebra at every blocking size, and
-a tower of support algebras equipped with compatible blocking and inclusion
-maps. The next two sections record these structures and their compatibility
-predicates with an MPO tensor.
+Following \cite[\S4.5]{Cirac2017MPDO_AnnPhys}, the current Lean development
+formalizes the transfer-map content of the fusion-isometry picture.
+For each blocked size $n \ge 1$, the doubled-index blocked tensor of an MPO
+has a blocked transfer map $E_n$ acting on bond-space matrices, and the
+support algebra is modeled by a subspace through which $E_n$ factors as a
+retract.
 
-\begin{definition}[Fusion isometry at blocked size]%
+\begin{definition}[Transfer-map fusion-isometry datum]%
     \label{def:mpdo_fusion_isometry}
-    \lean{MPOTensor.FusionIsometry}
+    \lean{MPOTensor.FusionIsometryData}
     \leanok
     \uses{def:mpo_tensor}
-    A \emph{fusion isometry at blocked size $n$} for an MPO tensor consists
-    of a pair of linear maps $(T_n, S_n)$ between the physical space at $n$
-    blocked sites and the support algebra at that size, a predicate
-    $\operatorname{supp}$ cutting out the image subspace of the algebra, and
-    two compatibility conditions: $S_n \circ T_n$ is idempotent on the
-    physical space, and $T_n \circ S_n$ acts as the identity on every element
-    satisfying $\operatorname{supp}$.
+    A \emph{transfer-map fusion-isometry datum} at blocked size $n$ for an
+    MPO tensor consists of a subspace $\mathcal{A}_n \subseteq M_D(\mathbb{C})$
+    together with linear maps
+    $$T_n : M_D(\mathbb{C}) \to \mathcal{A}_n, \qquad
+      S_n : \mathcal{A}_n \to M_D(\mathbb{C})$$
+    such that
+    $$T_n \circ S_n = \operatorname{id}_{\mathcal{A}_n},
+      \qquad S_n \circ T_n = E_n,$$
+    where $E_n$ denotes the blocked transfer map.
 \end{definition}
 
-\begin{definition}[Fusion-isometry RFP predicate (provisional)]%
+\begin{definition}[Fusion-isometry RFP predicate]%
     \label{def:mpdo_rfp_via_fusion}
-    \lean{MPOTensor.IsRFP_MPDO_via_fusion_scaffold}
+    \lean{MPOTensor.IsRFP_MPDO_via_fusion}
+    \leanok
     \uses{def:mpdo_fusion_isometry, def:mpo_tensor}
-    An MPO tensor $M$ satisfies the \emph{fusion-isometry formulation} of
-    the renormalization fixed-point condition when, for every blocked size
-    $n$, there exists a fusion isometry at size $n$ compatible with $M$.
-    The compatibility relation between a fusion isometry and~$M$ is, in this
-    provisional formulation, the trivial relation that holds for every
-    pair; consequently the predicate above holds vacuously of every MPO
-    tensor. The exact compatibility condition of
-    \cite[\S4.5]{Cirac2017MPDO_AnnPhys} is to be substituted in place of
-    the trivial relation in subsequent work.
+    An MPO tensor $M$ satisfies the \emph{fusion-isometry formulation} of the
+    renormalization fixed-point condition when for every blocked size $n \ge 1$
+    there exists transfer-map fusion-isometry data for the blocked transfer
+    map $E_n$.
 \end{definition}
+
+\begin{theorem}[Fusion-isometry data imply the provisional MPDO RFP condition]%
+    \label{thm:mpdo_rfp_of_fusion}
+    \lean{MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
+    \leanok
+    \uses{def:mpdo_rfp_via_fusion}
+    The fusion-isometry formulation implies the current predicate
+    \lean{MPOTensor.IsRFP}.
+\end{theorem}
+\begin{proof}\leanok
+Apply the definition at blocked size $n = 1$.
+If $E_1 = S_1 \circ T_1$ and $T_1 \circ S_1 = \operatorname{id}$, then
+$$E_1^2 = S_1 T_1 S_1 T_1 = S_1 (T_1 S_1) T_1 = S_1 T_1 = E_1.$$
+Since $E_1$ is the original transfer map, this is exactly
+\lean{MPOTensor.IsRFP}.
+\end{proof}
+
+\begin{theorem}[Transfer-map fusion criterion for MPDO RFP]%
+    \label{thm:mpdo_rfp_via_fusion_iff}
+    \lean{MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP}
+    \leanok
+    \uses{def:mpdo_rfp_via_fusion}
+    The fusion-isometry formulation is equivalent to
+    \lean{MPOTensor.IsRFP}.
+\end{theorem}
+\begin{proof}\leanok
+The forward implication is Theorem~\ref{thm:mpdo_rfp_of_fusion}.
+Conversely, if the transfer map $E$ is idempotent, then every positive blocked
+transfer map equals $E$ and therefore factors through its range.
+This range-factorization gives the required fusion-isometry data.
+\end{proof}
+
+\begin{corollary}[Pure-state recovery]%
+    \label{cor:mpdo_fusion_pure_recovery}
+    \lean{MPSTensor.toMPOTensor_isRFP_MPDO_via_fusion_iff_isRFP}
+    \leanok
+    \uses{thm:mpdo_rfp_via_fusion_iff}
+    For the diagonal MPO associated to a pure MPS tensor, the fusion-isometry
+    formulation reduces to the usual pure-state RFP condition.
+\end{corollary}
+\begin{proof}\leanok
+Combine Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} with the diagonal pure-state
+recovery theorem for the provisional MPO predicate.
+\end{proof}
 
 \section{\S4.5 Algebra structure}
 


### PR DESCRIPTION
## Motivation\n\nIssue #611 asks for the fusion-isometry side of the §4.5 MPDO-RFP story. The old  surface on  was still vacuous: its compatibility predicate was , the resulting RFP predicate held for every MPO tensor, and there was no honest bridge back to the current provisional predicate .\n\n## What this PR does\n\nThis PR keeps the provisional shell declarations for downstream compatibility, but adds an honest transfer-map-level formalization that is already supported by the current repository:\n\n-  packages the blocked transfer map obtained from the doubled-index MPS tensor;\n-  packages a support subspace , maps , , the retract identity , and the characteristic identity ;\n-  asks for such data at every positive blocked size;\n-  proves the sufficient direction;\n-  and  prove the converse/equivalence by factoring an idempotent blocked transfer map through its range;\n-  gives the pure-state recovery for the diagonal MPO embedding.\n\nSo the PR closes the non-vacuous transfer-map part of #611 without touching the algebra-structure side of #612.\n\n## Blueprint\n\nUpdated  so the §4.5 fusion section now documents the honest declarations above, including the equivalence theorem and the pure-state recovery corollary.\n\n## Testing\n\n- Current branch: HEAD
Using cache (Azure) from origin: leanprover-community/mathlib4
No files to download
Already decompressed 8232 file(s)\n- \n- ⚠ [2932/3025] Replayed TNLean.Channel.KrausFreedom
warning: TNLean/Channel/KrausFreedom.lean:126:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option synthInstance.maxHeartbeats 16000000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
Build completed successfully (8338 jobs).\n- ⚠ [8287/8447] Replayed TNLean.Algebra.MatrixOperatorSpace
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [DecidableEq n] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [Fintype n] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8322/8557] Replayed TNLean.Channel.KrausFreedom
warning: TNLean/Channel/KrausFreedom.lean:126:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option synthInstance.maxHeartbeats 16000000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
⚠ [8359/8557] Replayed TNLean.Channel.FixedPoint.WedderburnDecomp
warning: TNLean/Channel/FixedPoint/WedderburnDecomp.lean:86:7: declaration uses `sorry`
⚠ [8413/8557] Replayed TNLean.MPS.ParentHamiltonian.WrappingWindow
warning: TNLean/MPS/ParentHamiltonian/WrappingWindow.lean:182:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option maxHeartbeats 800000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
warning: TNLean/MPS/ParentHamiltonian/WrappingWindow.lean:262:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option maxHeartbeats 800000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
⚠ [8414/8557] Replayed TNLean.MPS.ParentHamiltonian.UniqueGroundState
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:356:8: declaration uses `sorry`
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:375:8: declaration uses `sorry`
⚠ [8440/8557] Replayed TNLean.MPS.ParentHamiltonian.Martingale
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:219:8: declaration uses `sorry`
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:267:8: declaration uses `sorry`
⚠ [8484/8557] Replayed TNLean.PEPS.FundamentalTheorem
warning: TNLean/PEPS/FundamentalTheorem.lean:498:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:523:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:557:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:586:8: declaration uses `sorry`
⚠ [8514/8557] Replayed TNLean.MPS.FundamentalTheorem.EqualProportional
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:438:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:449:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:459:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:464:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
⚠ [8516/8557] Replayed TNLean.MPS.ParentHamiltonian.DegenerateGS
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:132:8: declaration uses `sorry`
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:181:8: declaration uses `sorry`
⚠ [8528/8557] Replayed TNLean.MPS.Periodic.Overlap
warning: TNLean/MPS/Periodic/Overlap.lean:222:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:475:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:604:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:653:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:898:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1078:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1153:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1272:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1315:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1379:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1469:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1604:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1658:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1716:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1772:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1836:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1862:8: declaration uses `sorry`
Build completed successfully (8557 jobs).\n- plasTeX version 3.1\n- \n\nRefs #611

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new core definitions and proofs connecting fusion-isometry data to `MPOTensor.IsRFP`, including new factorization constructions through `LinearMap.range`; risk is mainly from subtle Lean/library interactions and proof obligations around blocking/transfer-map identities.
> 
> **Overview**
> Implements a *non-vacuous* fusion-isometry formulation of MPDO renormalization fixed points at the transfer-map level.
> 
> `FusionIsometries.lean` now defines `blockedTransferMap` for blocked doubled-index tensors, introduces `FusionIsometryData` as a retract factorization `E_n = S_n ∘ T_n` through a `Submodule`, and defines `IsRFP_MPDO_via_fusion` requiring such data for all `n > 0`. It proves `IsRFP_MPDO_via_fusion ↔ MPOTensor.IsRFP` by (1) deriving idempotence from retract data and (2) constructing data from an idempotent map via its `range`, and adds the corresponding pure-state recovery lemma for diagonal `MPSTensor.toMPOTensor`.
> 
> Updates the blueprint §4.5 fusion-isometries section to document the new `FusionIsometryData`/`IsRFP_MPDO_via_fusion` definitions, the implication/equivalence theorems, and the pure-state recovery corollary, while keeping the older `_scaffold` shell for compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41307ad6d651fbacddfe8495667ca4279f1129bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->