### PR TITLE
style(lean): cleanup pass on Channel/Irreducible modules

### DIFF
--- a/TNLean/Channel/Irreducible/Basic.lean
+++ b/TNLean/Channel/Irreducible/Basic.lean
@@ -43,11 +43,11 @@ def IsOrthogonalProjection (P : Matrix (Fin D) (Fin D) ℂ) : Prop :=
 
 /-- The zero matrix is an orthogonal projection. -/
 lemma isOrthogonalProjection_zero : IsOrthogonalProjection (0 : Matrix (Fin D) (Fin D) ℂ) :=
-  ⟨Matrix.isHermitian_zero, by simp⟩
+  ⟨Matrix.isHermitian_zero, by simp only [Matrix.zero_mul]⟩
 
 /-- The identity matrix is an orthogonal projection. -/
 lemma isOrthogonalProjection_one : IsOrthogonalProjection (1 : Matrix (Fin D) (Fin D) ℂ) :=
-  ⟨Matrix.isHermitian_one, by simp⟩
+  ⟨Matrix.isHermitian_one, by simp only [Matrix.one_mul]⟩
 
 /-- An orthogonal projection is positive semidefinite. -/
 theorem isOrthogonalProjection_posSemidef {P : Matrix (Fin D) (Fin D) ℂ}
@@ -152,7 +152,7 @@ lemma eq_zero_of_sum_mul_conjTranspose_eq_zero {ι : Type*} [Fintype ι]
     intro k c
     have h_diag_eq : ∑ k' : ι, (B k' * (B k')ᴴ) c c = 0 := by
       have := congr_fun (congr_fun h c) c
-      simpa [Matrix.sum_apply, Matrix.zero_apply] using this
+      simpa only [Matrix.sum_apply, Matrix.zero_apply] using this
     simp_rw [diagonal_mul_conjTranspose_eq_normSq_sum] at h_diag_eq ⊢
     have h_nonneg : ∀ k', (0 : ℝ) ≤ ∑ x, Complex.normSq (B k' c x) :=
       fun k' => Finset.sum_nonneg (fun x _ => Complex.normSq_nonneg _)

--- a/TNLean/Channel/Irreducible/Ergodicity.lean
+++ b/TNLean/Channel/Irreducible/Ergodicity.lean
@@ -52,7 +52,7 @@ private lemma IsChannel.iter_mem_densityMatrices
     (hE : IsChannel E) {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hρ : ρ ∈ densityMatrices D) (n : ℕ) : (E ^ n) ρ ∈ densityMatrices D := by
   induction n with
-  | zero => simpa [pow_zero] using hρ
+  | zero => simpa only [pow_zero] using hρ
   | succ n ih =>
       change (E ^ (n + 1)) ρ ∈ densityMatrices D
       rw [pow_succ']
@@ -141,7 +141,7 @@ theorem IsChannel.exists_unique_density_fixedPoint_of_irreducible
     densityMatrices_isCompact.tendsto_subseq hces_mem
   have hσ_lim : σ ∈ densityMatrices D ∧ E σ = σ :=
     IsChannel.cesaroMean_subseq_limit_fixedPoint (E := E) hE hρ₀
-      hφ_mono.tendsto_atTop (by simpa [Function.comp] using hφ_tendsto)
+      hφ_mono.tendsto_atTop (by simpa only [Function.comp] using hφ_tendsto)
   have hσ_mem : σ ∈ densityMatrices D := hσ_lim.1
   have hσ_fix : E σ = σ := hσ_lim.2
   have hσ_ne : σ ≠ 0 := ne_zero_of_mem_densityMatrices (D := D) hσ_mem
@@ -186,7 +186,7 @@ theorem IsChannel.cesaroMean_tendsto_of_irreducible
       hns.comp hφ_mono.tendsto_atTop
     have ha_lim : a ∈ densityMatrices D ∧ E a = a :=
       IsChannel.cesaroMean_subseq_limit_fixedPoint (E := E) hE hρ hψ_tendsto
-        (by simpa [Function.comp] using hφ_tendsto)
+        (by simpa only [Function.comp] using hφ_tendsto)
     have ha_eq : a = σ := hσ_unique a ha_lim.1 ha_lim.2
     exact ⟨φ, by simpa [Function.comp, ha_eq] using hφ_tendsto⟩
   exact ⟨σ, hσ_mem, hσ_pd, hσ_fix, hσ_unique, h_tendsto⟩

--- a/TNLean/Channel/Irreducible/KrausSetup.lean
+++ b/TNLean/Channel/Irreducible/KrausSetup.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
@@ -47,10 +47,10 @@ noncomputable def irreducibleCPKrausSetup
   have hK : ∀ X, E X = ∑ i : Fin n, K i * X * (K i)ᴴ := Classical.choose_spec hCP'
   have hE_eq : E = MPSTensor.transferMap (d := n) (D := D) K :=
     LinearMap.ext fun X => by
-      simpa [MPSTensor.transferMap_apply] using hK X
+      simpa only [MPSTensor.transferMap_apply] using hK X
   have hIrrK_map :
       IsIrreducibleMap (MPSTensor.transferMap (d := n) (D := D) K) := by
-    simpa [hE_eq] using hIrr
+    simpa only [hE_eq] using hIrr
   exact
     { n := n
       K := K
@@ -70,7 +70,7 @@ theorem exists_nonzero_kraus
       MPSTensor.transferMap (d := hSetup.n) (D := D) hSetup.K = 0 :=
     LinearMap.ext fun X => by
       simp [MPSTensor.transferMap_apply, hK_zero]
-  exact hE (by simpa [hSetup.map_eq] using htransfer_zero)
+  exact hE (by simpa only [hSetup.map_eq] using htransfer_zero)
 
 /-- Shared adjoint Perron--Frobenius data extracted from an irreducible CP map. -/
 theorem exists_posDef_adjoint_eigenvector

--- a/TNLean/Channel/Irreducible/TraceAdjoint.lean
+++ b/TNLean/Channel/Irreducible/TraceAdjoint.lean
@@ -1,4 +1,4 @@
-/-  
+/-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
@@ -32,7 +32,7 @@ lemma trace_mul_transferMap_adjoint
     Matrix.trace (ρ * E X)
         = Matrix.trace (ρ * MPSTensor.transferMap (d := n) (D := D) K X) := by rw [hE_eq]
     _ = Matrix.trace (Kraus.adjointMap K ρ * X) := by
-          simpa [Kraus.map, MPSTensor.transferMap_apply] using
+          simpa only [Kraus.map, MPSTensor.transferMap_apply] using
             (Kraus.trace_mul_map_eq_trace_adjointMap_mul (K := K) ρ X)
     _ = Matrix.trace
           (MPSTensor.transferMap (d := n) (D := D) (fun i => (K i)ᴴ) ρ * X) := by


### PR DESCRIPTION
## Summary
- tighten low-risk simplification steps in the Channel/Irreducible cleanup target set without changing any statements, names, imports, or placeholders
- clean four modules surgically and leave the two already-pristine modules unchanged
- verify the full six-file target set plus a full project build

## Per-file changes
- 
  - replaced two bare  projection closers with 
  - tightened one  trace-entry rewrite to 
- 
  - tightened three  uses to  where the simp set is small and explicit
  - left the more delicate eigenvalue/trace  steps unchanged after compile checking
- 
  - tightened the Kraus packaging / irreducibility transport rewrites to 
  - cleaned the file header whitespace
- 
  - no source changes; file was already compile-clean and the remaining proof steps were already appropriately explicit
- 
  - tightened the adjoint trace-pairing rewrite to 
  - cleaned the file header whitespace
- 
  - no source changes; file was already compile-clean and further tightening looked like gratuitous churn

## Verification
- Current branch: HEAD
Using cache (Azure) from origin: leanprover-community/mathlib4
No files to download
Already decompressed 8232 file(s)
- targeted bootstrap build for the worktree-local  oleans:
  - ⚠ [2920/3040] Replayed TNLean.Algebra.MatrixOperatorSpace
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [DecidableEq n] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [Fintype n] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
Build completed successfully (8319 jobs).
-  on all six target files
-  count clean on all six target files
- full ⚠ [8288/8474] Replayed TNLean.Algebra.MatrixOperatorSpace
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [DecidableEq n] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [Fintype n] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8337/8557] Replayed TNLean.Channel.KrausFreedom
warning: TNLean/Channel/KrausFreedom.lean:126:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option synthInstance.maxHeartbeats 16000000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
⚠ [8364/8557] Replayed TNLean.Channel.FixedPoint.WedderburnDecomp
warning: TNLean/Channel/FixedPoint/WedderburnDecomp.lean:86:7: declaration uses `sorry`
⚠ [8413/8557] Replayed TNLean.MPS.ParentHamiltonian.WrappingWindow
warning: TNLean/MPS/ParentHamiltonian/WrappingWindow.lean:182:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option maxHeartbeats 800000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
warning: TNLean/MPS/ParentHamiltonian/WrappingWindow.lean:262:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option maxHeartbeats 800000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
⚠ [8414/8557] Replayed TNLean.MPS.ParentHamiltonian.UniqueGroundState
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:356:8: declaration uses `sorry`
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:375:8: declaration uses `sorry`
⚠ [8440/8557] Replayed TNLean.MPS.ParentHamiltonian.Martingale
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:219:8: declaration uses `sorry`
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:267:8: declaration uses `sorry`
⚠ [8486/8557] Replayed TNLean.PEPS.FundamentalTheorem
warning: TNLean/PEPS/FundamentalTheorem.lean:498:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:523:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:557:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:586:8: declaration uses `sorry`
⚠ [8515/8557] Replayed TNLean.MPS.FundamentalTheorem.EqualProportional
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:438:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:449:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:459:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:464:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
⚠ [8517/8557] Replayed TNLean.MPS.ParentHamiltonian.DegenerateGS
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:132:8: declaration uses `sorry`
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:181:8: declaration uses `sorry`
⚠ [8529/8557] Replayed TNLean.MPS.Periodic.Overlap
warning: TNLean/MPS/Periodic/Overlap.lean:222:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:475:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:604:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:653:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:898:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1078:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1153:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1272:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1315:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1379:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1469:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1604:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1658:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1716:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1772:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1836:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1862:8: declaration uses `sorry`
Build completed successfully (8557 jobs). succeeded

## Notes
- Fresh-worktree gotcha reproduced here: before building any local  target,  failed with . A targeted ⚠ [8286/8512] Replayed TNLean.Channel.KrausFreedom
warning: TNLean/Channel/KrausFreedom.lean:126:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option synthInstance.maxHeartbeats 16000000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
⚠ [8290/8512] Replayed TNLean.Algebra.MatrixOperatorSpace
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [DecidableEq n] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [Fintype n] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8385/8557] Replayed TNLean.Channel.FixedPoint.WedderburnDecomp
warning: TNLean/Channel/FixedPoint/WedderburnDecomp.lean:86:7: declaration uses `sorry`
⚠ [8423/8557] Replayed TNLean.MPS.ParentHamiltonian.WrappingWindow
warning: TNLean/MPS/ParentHamiltonian/WrappingWindow.lean:182:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option maxHeartbeats 800000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
warning: TNLean/MPS/ParentHamiltonian/WrappingWindow.lean:262:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option maxHeartbeats 800000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
⚠ [8424/8557] Replayed TNLean.MPS.ParentHamiltonian.UniqueGroundState
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:356:8: declaration uses `sorry`
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:375:8: declaration uses `sorry`
⚠ [8442/8557] Replayed TNLean.MPS.ParentHamiltonian.Martingale
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:219:8: declaration uses `sorry`
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:267:8: declaration uses `sorry`
⚠ [8486/8557] Replayed TNLean.PEPS.FundamentalTheorem
warning: TNLean/PEPS/FundamentalTheorem.lean:498:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:523:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:557:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:586:8: declaration uses `sorry`
⚠ [8515/8557] Replayed TNLean.MPS.FundamentalTheorem.EqualProportional
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:438:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:449:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:459:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:464:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
⚠ [8517/8557] Replayed TNLean.MPS.ParentHamiltonian.DegenerateGS
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:132:8: declaration uses `sorry`
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:181:8: declaration uses `sorry`
⚠ [8529/8557] Replayed TNLean.MPS.Periodic.Overlap
warning: TNLean/MPS/Periodic/Overlap.lean:222:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:475:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:604:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:653:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:898:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1078:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1153:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1272:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1315:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1379:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1469:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1604:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1658:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1716:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1772:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1836:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap.lean:1862:8: declaration uses `sorry`
Build completed successfully (8557 jobs). fixed the local oleans, after which all six  checks succeeded.
- Full build warnings were pre-existing and outside the scope of this cleanup pass (e.g. existing  warnings and the unrelated  unused-instance warning).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk proof-maintenance changes: replaces broad `simp/simpa` with `simp only/simpa only` in a few lemmas and fixes header whitespace, without changing statements or dependencies.
> 
> **Overview**
> **Proof cleanup in `Channel/Irreducible` modules.** Several lemmas now use more explicit simplification (`simp only`/`simpa only`) for projection facts, diagonal/trace entry rewrites, Cesàro/compactness subsequence plumbing, and Kraus packaging/transport identities.
> 
> Also normalizes comment header formatting in `KrausSetup.lean` and `TraceAdjoint.lean`; no declarations, signatures, or imports are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae4691d6f19c36f73ea9a0dd372e3f068a925e29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->