### PR TITLE
fix(MPS/ParentHamiltonian): discharge wrapper sorry for normal chain GS

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -376,12 +376,13 @@ theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N) :
     chainGroundSpace A L N = mpvSubmodule A N := by
-  -- PROOF STRUCTURE: see bridge lemma
-  -- `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` for the
-  -- planned proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
-  sorry
+  apply le_antisymm
+  · exact chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
+      hA hInj hN hL hLN
+  · intro ψ hψ
+    rw [mpvSubmodule, Submodule.mem_span_singleton] at hψ
+    obtain ⟨c, rfl⟩ := hψ
+    exact Submodule.smul_mem _ c (mpv_mem_chainGroundSpace A L N (by omega) hLN)
 
 /-- **Unique ground state on the periodic chain** for injective MPS.
 


### PR DESCRIPTION
### Motivation

- Close the top-level theorem `chainGroundSpace_eq_mpvSubmodule_normal` so the wrapper-level `sorry` is removed and downstream uniqueness corollaries can be stated without that top-level admission.
- Single highest-leverage open obligation in the parent-Hamiltonian track; unblocks spectral-gap and degenerate-ground-space follow-ups (see #588).

### Description

- Implemented `chainGroundSpace_eq_mpvSubmodule_normal` by `le_antisymm`: the `≤` direction delegates to the existing bridge lemma `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`, and the `≥` direction is completed by the MPV-span inclusion using `mpv_mem_chainGroundSpace`, so the wrapper `sorry` is eliminated.
- The bridge lemma `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` remains as the single unresolved `sorry` in this file and is the correct target for the subsequent range-reduction work.

### Testing

- Ran `lake env lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`, which succeeds (emits a warning that a declaration uses `sorry`).
- Ran `rg -n "sorry|axiom" TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`, which reports the remaining `sorry` at the bridge lemma (`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`).

---
Addresses #588

> [!NOTE]
> **Low Risk**
> Low risk: this is a small Lean proof refactor that replaces a top-level `sorry` with a structured `le_antisymm` proof, without changing definitions or computational behavior (still relies on the existing sorry-backed bridge lemma).
>
> **Overview**
> Closes the top-level theorem `chainGroundSpace_eq_mpvSubmodule_normal` by replacing the placeholder `sorry` with a `le_antisymm` proof.
>
> The `≤` direction is delegated to `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`, and the `≥` direction is proved by showing any element of `mpvSubmodule` is a scalar multiple of `mpv` and using `mpv_mem_chainGroundSpace` plus closure under scalar multiplication.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b143b1830e0dc8f5ed4e5edc7351b8290401a92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>