### PR TITLE
refactor(blueprint): relocate Gemma periodic & rotation entries to ch11b_periodic_ft

### DIFF
--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -453,35 +453,9 @@ directly to periodic tensors.
 
 \subsection{Irreducible form}
 
-\begin{definition}[Periodic tensor]
-	\label{def:periodic_tensor}
-	\lean{MPSTensor.IsPeriodic}
-	\leanok
-	An irreducible MPS tensor $A$ of bond dimension $D$ is
-	\emph{$m$-periodic} (for some $m \ge 1$) if the peripheral spectrum
-	of its transfer map $\E_A$ is exactly the $m$-th roots of unity
-	$\{e^{2\pi i k/m} : 0 \le k < m\}$.
-	A $1$-periodic tensor is exactly an irreducible tensor with
-	primitive transfer map (Definition~\ref{def:primitive_channel}).
-\end{definition}
-
-\begin{definition}[Irreducible form]
-	\label{def:irreducible_form}
-	\lean{MPSTensor.IsIrreducibleForm}
-	\leanok
-	A tensor $A$ is in \emph{irreducible form} if it is block-diagonal
-	\[
-		A^i = \bigoplus_{j \in J} \mu_j\, A_j^i,
-	\]
-	where each block $A_j$ is an $m_j$-periodic tensor,
-	each weight $\mu_j \neq 0$, and the blocks are pairwise
-	non-repeated (no two distinct $j, j'$ have $A_j$ gauge-equivalent
-	to $A_{j'}$).
-	This is the standard form introduced in \cite[\S II]{DeLasCuevas2017Irreducible}.
-	It extends the normal canonical form
-	(Definition~\ref{def:is_normal_canonical_form}),
-	which requires the stronger condition that every block is $1$-periodic.
-\end{definition}
+The periodic-tensor and irreducible-form definitions are stated in
+Chapter~\ref{ch:periodic_ft_apps}
+(Definitions~\ref{def:periodic_tensor} and~\ref{def:irreducible_form}).
 
 \begin{remark}[Relation to normal canonical form]\notready
 	\label{rem:irr_form_vs_ncf}
@@ -542,97 +516,13 @@ directly to periodic tensors.
 
 \subsection{The \texorpdfstring{$Z$}{Z}-gauge degree of freedom}
 
-\begin{definition}[Entrywise periodic \(Z\)-gauge ratio]\label{def:z_gauge_entry}
-	\lean{MPSTensor.zGaugeEntry}
-	\leanok
-	Given complex weights $\mu,\nu$, define the entrywise
-	\(Z\)-gauge ratio by
-	\[
-		z(\mu,\nu) := \mu/\nu.
-	\]
-\end{definition}
-
-\begin{lemma}[Matched powers imply root-of-unity ratio]\label{lem:z_gauge_entry_pow}
-	\lean{MPSTensor.zGaugeEntry_pow_eq_one_of_pow_eq}
-	\leanok
-	\uses{def:z_gauge_entry}
-	If $\mu^m=\nu^m$ and $\nu\neq 0$, then
-	\[
-		z(\mu,\nu)^m = 1.
-	\]
-\end{lemma}
-
-\begin{lemma}[Ratio rescales denominator back to numerator]\label{lem:z_gauge_entry_mul}
-	\lean{MPSTensor.zGaugeEntry_mul_right}
-	\leanok
-	\uses{def:z_gauge_entry}
-	If $\nu\neq 0$, then
-	\[
-		z(\mu,\nu)\,\nu=\mu.
-	\]
-\end{lemma}
-
-\begin{definition}[Diagonal periodic \(Z\)-gauge matrix]\label{def:z_gauge_diagonal}
-	\lean{MPSTensor.zGaugeDiagonal}
-	\leanok
-	\uses{def:z_gauge_entry}
-	For matched weight families $(\mu_i)_i$ and $(\nu_i)_i$ on a finite
-	index type, define the diagonal matrix
-	\[
-		Z := \diag\!\bigl(z(\mu_i,\nu_i)\bigr)_i.
-	\]
-\end{definition}
-
-\begin{lemma}[Diagonal \(Z\)-gauge has finite order under matched powers]\label{lem:z_gauge_diagonal_pow}
-	\lean{MPSTensor.zGaugeDiagonal_pow_eq_one}
-	\leanok
-	\uses{def:z_gauge_diagonal, lem:z_gauge_entry_pow}
-	If $\mu_i^m=\nu_i^m$ and $\nu_i\neq 0$ for all~$i$, then
-	\[
-		Z^m=\Id.
-	\]
-\end{lemma}
-
-\begin{lemma}[Diagonal \(Z\)-gauge transports diagonal weights]\label{lem:z_gauge_diagonal_mul}
-	\lean{MPSTensor.zGaugeDiagonal_mul_diagonal}
-	\leanok
-	\uses{def:z_gauge_diagonal, lem:z_gauge_entry_mul}
-	Under $\nu_i\neq 0$ for all~$i$,
-	\[
-		Z\,\diag(\nu)=\diag(\mu).
-	\]
-\end{lemma}
-
-\begin{definition}[$Z$-gauge equivalence]
-	\label{def:z_gauge_equiv}
-	\lean{MPSTensor.ZGaugeEquiv}
-	\leanok
-	Let $A$ be an $m$-periodic irreducible tensor of bond dimension $D$.
-	A \emph{$Z$-gauge transformation} of $A$ is a diagonal unitary
-	matrix $Z \in \MN{D}$ satisfying:
-	\begin{enumerate}
-		\item $Z$ commutes with every Kraus operator: $[A^i, Z] = 0$
-		      for all physical indices $i$, and
-		\item $Z^m = \Id_D$ (all diagonal entries are $m$-th roots of unity).
-	\end{enumerate}
-	Replacing $A$ by $ZA$ (i.e.\ $A^i \mapsto Z A^i$) leaves the
-	MPV family invariant for lengths $N$ that are multiples of $m$,
-	because the factor $\tr(Z^N) = \tr(\Id) = D$ for $N \equiv 0 \pmod{m}$.
-	Two tensors $A, B$ are \emph{$Z$-gauge equivalent} if there exists
-	an invertible $Y$ and a $Z$-gauge transformation $Z$ for $A$ such that
-	$Z A^i = Y B^i Y^{-1}$ for all~$i$.
-\end{definition}
-
-\begin{remark}[$Z$-gauge is trivial for period-$1$ blocks]
-	\label{rem:z_gauge_trivial_period1}
-	\lean{MPSTensor.ZGaugeEquiv.of_period_one}
-	\leanok
-	When $m = 1$ the condition $Z^1 = \Id$ forces $Z = \Id$,
-	so $Z$-gauge equivalence reduces to ordinary gauge equivalence
-	(Definition~\ref{def:gauge_equiv}).
-	The $Z$-gauge is therefore a genuine new degree of freedom
-	that appears only for $m > 1$.
-\end{remark}
+The \(Z\)-gauge definitions and lemmas are stated in
+Chapter~\ref{ch:periodic_ft_apps}
+(Definitions~\ref{def:z_gauge_entry}, \ref{def:z_gauge_diagonal},
+\ref{def:z_gauge_equiv}; Lemmas~\ref{lem:z_gauge_entry_pow},
+\ref{lem:z_gauge_entry_mul}, \ref{lem:z_gauge_diagonal_pow},
+\ref{lem:z_gauge_diagonal_mul}; and
+Remark~\ref{rem:z_gauge_trivial_period1}).
 
 \subsection{Statement of the periodic Fundamental Theorem}
 

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -13,6 +13,266 @@ physical on-site symmetry of a tensor in irreducible form to a virtual
 $Z$-gauge, and the equivalence between $p$-refinability of the
 matrix-product-vector family and $p$-divisibility of the transfer map.
 
+\section{Periodic irreducible form and physical-index rotation}%
+\label{sec:periodic_irreducible_rotation}
+
+\begin{definition}[Periodic tensor]
+    \label{def:periodic_tensor}
+    \lean{MPSTensor.IsPeriodic}
+    \leanok
+    An irreducible MPS tensor $A$ of bond dimension $D$ is
+    \emph{$m$-periodic} (for some $m \ge 1$) if the peripheral spectrum
+    of its transfer map $\E_A$ is exactly the $m$-th roots of unity
+    $\{e^{2\pi i k/m} : 0 \le k < m\}$.
+    A $1$-periodic tensor is exactly an irreducible tensor with
+    primitive transfer map (Definition~\ref{def:primitive_channel}).
+\end{definition}
+
+\begin{definition}[Irreducible form]
+    \label{def:irreducible_form}
+    \lean{MPSTensor.IsIrreducibleForm}
+    \leanok
+    A tensor $A$ is in \emph{irreducible form} if it is block-diagonal
+    \[
+        A^i = \bigoplus_{j \in J} \mu_j\, A_j^i,
+    \]
+    where each block $A_j$ is an $m_j$-periodic tensor,
+    each weight $\mu_j \neq 0$, and the blocks are pairwise
+    non-repeated (no two distinct $j, j'$ have $A_j$ gauge-equivalent
+    to $A_{j'}$).
+    This is the standard form introduced in \cite[\S II]{DeLasCuevas2017Irreducible}.
+    It extends the normal canonical form
+    (Definition~\ref{def:is_normal_canonical_form}),
+    which requires the stronger condition that every block is $1$-periodic.
+\end{definition}
+
+\begin{definition}[Physical-index rotation]%
+    \label{def:rotate_physical}
+    \lean{MPSTensor.rotatePhysical}
+    \leanok
+    \uses{def:mps_tensor}
+    Given a matrix $u \in M_d(\C)$ and an MPS tensor~$A$,
+    the \emph{physical-index rotation} is the tensor
+    $(A_u)^i := \sum_j u_{ij}\, A^j$.
+\end{definition}
+
+\begin{theorem}[Transfer map preserved by physical rotation]%
+    \label{thm:transfer_map_rotate_physical}
+    \lean{MPSTensor.transferMap_rotatePhysical}
+    \leanok
+    \uses{def:rotate_physical, def:transfer_map}
+    If $u u^\dagger = I$, then the transfer map is invariant under
+    physical-index rotation:
+    $\mathcal{E}_{A_u} = \mathcal{E}_A$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:unitary_kraus_mixing}
+    Unitary freedom of the Kraus representation (Theorem~2.18,
+    Wolf \emph{Quantum Channels \& Operations}).
+\end{proof}
+
+\begin{theorem}[Left-canonical preserved by physical rotation]%
+    \label{thm:left_canonical_rotate_physical}
+    \lean{MPSTensor.isLeftCanonical_rotatePhysical}
+    \leanok
+    \uses{def:rotate_physical}
+    If $u u^\dagger = I$ and $A$ is left-canonical, then
+    $A_u$ is left-canonical.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:rotate_physical}
+    Expand $\sum_i B_i^\dagger B_i$ where $B_i = \sum_j u_{ij} A_j$,
+    swap sums, apply orthogonality $u^\dagger u = I$, and collapse to
+    $\sum_j A_j^\dagger A_j = I$.
+\end{proof}
+
+\begin{theorem}[Irreducibility preserved by physical rotation]%
+    \label{thm:irreducible_tensor_rotate_physical}
+    \lean{MPSTensor.isIrreducibleTensor_rotatePhysical}
+    \leanok
+    \uses{def:rotate_physical}
+    If $u u^\dagger = I$ and $A$ is irreducible, then
+    $A_u$ is irreducible.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:rotate_physical}
+    Contrapositive: any nontrivial invariant projection~$P$ for the
+    rotated tensor yields $(1-P)\, A_k\, P = 0$ for all~$k$ via the
+    orthogonality of~$u$, contradicting irreducibility of~$A$.
+\end{proof}
+
+\begin{theorem}[Periodicity preserved by physical rotation]%
+    \label{thm:periodic_rotate_physical}
+    \lean{MPSTensor.isPeriodic_rotatePhysical}
+    \leanok
+    \uses{def:rotate_physical, thm:transfer_map_rotate_physical,
+        thm:left_canonical_rotate_physical,
+        thm:irreducible_tensor_rotate_physical}
+    If $u u^\dagger = I$ and $A$ is periodic with period~$m$, then
+    $A_u$ is periodic with the same period.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:transfer_map_rotate_physical,
+        thm:left_canonical_rotate_physical,
+        thm:irreducible_tensor_rotate_physical}
+    Assembles transfer-map invariance, left-canonical preservation, and
+    irreducibility preservation.
+\end{proof}
+
+\begin{theorem}[SameMPV preserved by physical rotation]%
+    \label{thm:same_mpv_rotate_physical}
+    \lean{MPSTensor.sameMPV₂_rotatePhysical}
+    \leanok
+    \uses{def:rotate_physical, def:same_mpv}
+    If $\mathcal{V}(A) = \mathcal{V}(B)$, then
+    $\mathcal{V}(A_u) = \mathcal{V}(B_u)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:rotate_physical, def:same_mpv}
+    Induction on the word length with a strengthened hypothesis
+    carrying an arbitrary prefix matrix, reducing each step to the
+    hypothesis via word concatenation.
+\end{proof}
+
+\begin{theorem}[Physical rotation distributes over block assembly]%
+    \label{thm:rotate_physical_blocks}
+    \lean{MPSTensor.rotatePhysical_toTensorFromBlocks}
+    \leanok
+    \uses{def:rotate_physical}
+    The rotated block-diagonal tensor satisfies
+    $(\bigoplus_k \mu_k A_k)_u
+        = \bigoplus_k \mu_k (A_k)_u$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:rotate_physical}
+    Pointwise matrix-entry computation using linearity of
+    the block-diagonal embedding and reindexing.
+\end{proof}
+
+\begin{theorem}[Irreducible form preserved by physical rotation]%
+    \label{thm:irreducible_form_rotate_physical}
+    \lean{MPSTensor.isIrreducibleForm_rotatePhysical}
+    \leanok
+    \uses{def:rotate_physical, def:irreducible_form,
+        thm:periodic_rotate_physical,
+        thm:same_mpv_rotate_physical,
+        thm:rotate_physical_blocks}
+    If $u u^\dagger = I$ and $A$ is in irreducible form~II, then
+    $A_u$ is in irreducible form~II with the same block structure and
+    rotated blocks.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:periodic_rotate_physical,
+        thm:same_mpv_rotate_physical,
+        thm:rotate_physical_blocks}
+    Each block remains periodic by
+    Theorem~\ref{thm:periodic_rotate_physical}, the SameMPV condition
+    transfers via Theorem~\ref{thm:same_mpv_rotate_physical}, and
+    block-assembly compatibility follows from
+    Theorem~\ref{thm:rotate_physical_blocks}.
+\end{proof}
+
+\subsection{The \texorpdfstring{$Z$}{Z}-gauge degree of freedom}
+
+\begin{definition}[Entrywise periodic \(Z\)-gauge ratio]\label{def:z_gauge_entry}
+    \lean{MPSTensor.zGaugeEntry}
+    \leanok
+    Given complex weights $\mu,\nu$, define the entrywise
+    \(Z\)-gauge ratio by
+    \[
+        z(\mu,\nu) := \mu/\nu.
+    \]
+\end{definition}
+
+\begin{lemma}[Matched powers imply root-of-unity ratio]\label{lem:z_gauge_entry_pow}
+    \lean{MPSTensor.zGaugeEntry_pow_eq_one_of_pow_eq}
+    \leanok
+    \uses{def:z_gauge_entry}
+    If $\mu^m=\nu^m$ and $\nu\neq 0$, then
+    \[
+        z(\mu,\nu)^m = 1.
+    \]
+\end{lemma}
+
+\begin{lemma}[Ratio rescales denominator back to numerator]\label{lem:z_gauge_entry_mul}
+    \lean{MPSTensor.zGaugeEntry_mul_right}
+    \leanok
+    \uses{def:z_gauge_entry}
+    If $\nu\neq 0$, then
+    \[
+        z(\mu,\nu)\,\nu=\mu.
+    \]
+\end{lemma}
+
+\begin{definition}[Diagonal periodic \(Z\)-gauge matrix]\label{def:z_gauge_diagonal}
+    \lean{MPSTensor.zGaugeDiagonal}
+    \leanok
+    \uses{def:z_gauge_entry}
+    For matched weight families $(\mu_i)_i$ and $(\nu_i)_i$ on a finite
+    index type, define the diagonal matrix
+    \[
+        Z := \diag\!\bigl(z(\mu_i,\nu_i)\bigr)_i.
+    \]
+\end{definition}
+
+\begin{lemma}[Diagonal \(Z\)-gauge has finite order under matched powers]\label{lem:z_gauge_diagonal_pow}
+    \lean{MPSTensor.zGaugeDiagonal_pow_eq_one}
+    \leanok
+    \uses{def:z_gauge_diagonal, lem:z_gauge_entry_pow}
+    If $\mu_i^m=\nu_i^m$ and $\nu_i\neq 0$ for all~$i$, then
+    \[
+        Z^m=\Id.
+    \]
+\end{lemma}
+
+\begin{lemma}[Diagonal \(Z\)-gauge transports diagonal weights]\label{lem:z_gauge_diagonal_mul}
+    \lean{MPSTensor.zGaugeDiagonal_mul_diagonal}
+    \leanok
+    \uses{def:z_gauge_diagonal, lem:z_gauge_entry_mul}
+    Under $\nu_i\neq 0$ for all~$i$,
+    \[
+        Z\,\diag(\nu)=\diag(\mu).
+    \]
+\end{lemma}
+
+\begin{definition}[$Z$-gauge equivalence]
+    \label{def:z_gauge_equiv}
+    \lean{MPSTensor.ZGaugeEquiv}
+    \leanok
+    Let $A$ be an $m$-periodic irreducible tensor of bond dimension $D$.
+    A \emph{$Z$-gauge transformation} of $A$ is a diagonal unitary
+    matrix $Z \in \MN{D}$ satisfying:
+    \begin{enumerate}
+        \item $Z$ commutes with every Kraus operator: $[A^i, Z] = 0$
+              for all physical indices $i$, and
+        \item $Z^m = \Id_D$ (all diagonal entries are $m$-th roots of unity).
+    \end{enumerate}
+    Replacing $A$ by $ZA$ (i.e.\ $A^i \mapsto Z A^i$) leaves the
+    MPV family invariant for lengths $N$ that are multiples of $m$,
+    because the factor $\tr(Z^N) = \tr(\Id) = D$ for $N \equiv 0 \pmod{m}$.
+    Two tensors $A, B$ are \emph{$Z$-gauge equivalent} if there exists
+    an invertible $Y$ and a $Z$-gauge transformation $Z$ for $A$ such that
+    $Z A^i = Y B^i Y^{-1}$ for all~$i$.
+\end{definition}
+
+\begin{remark}[$Z$-gauge is trivial for period-$1$ blocks]
+    \label{rem:z_gauge_trivial_period1}
+    \lean{MPSTensor.ZGaugeEquiv.of_period_one}
+    \leanok
+    When $m = 1$ the condition $Z^1 = \Id$ forces $Z = \Id$,
+    so $Z$-gauge equivalence reduces to ordinary gauge equivalence
+    (Definition~\ref{def:gauge_equiv}).
+    The $Z$-gauge is therefore a genuine new degree of freedom
+    that appears only for $m > 1$.
+\end{remark}
+
 \section{Physical symmetries on periodic MPS}\label{sec:periodic_symmetry}
 
 \begin{theorem}[Cor.~4.1 — Physical symmetry yields a virtual $Z$-gauge]%

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -47,138 +47,15 @@ mechanism, and this chapter develops its symmetry consequences.
     $B^i = \lambda\, V^{-1}\, A^i\, V$ for all~$i$.
 \end{proof}
 
-\begin{definition}[Physical-index rotation]%
-    \label{def:rotate_physical}
-    \lean{MPSTensor.rotatePhysical}
-    \leanok
-    \uses{def:mps_tensor}
-    Given a matrix $u \in M_d(\C)$ and an MPS tensor~$A$,
-    the \emph{physical-index rotation} is the tensor
-    $(A_u)^i := \sum_j u_{ij}\, A^j$.
-\end{definition}
-
-\begin{theorem}[Transfer map preserved by physical rotation]%
-    \label{thm:transfer_map_rotate_physical}
-    \lean{MPSTensor.transferMap_rotatePhysical}
-    \leanok
-    \uses{def:rotate_physical, def:transfer_map}
-    If $u u^\dagger = I$, then the transfer map is invariant under
-    physical-index rotation:
-    $\mathcal{E}_{A_u} = \mathcal{E}_A$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{lem:unitary_kraus_mixing}
-    Unitary freedom of the Kraus representation (Theorem~2.18,
-    Wolf \emph{Quantum Channels \& Operations}).
-\end{proof}
-
-\begin{theorem}[Left-canonical preserved by physical rotation]%
-    \label{thm:left_canonical_rotate_physical}
-    \lean{MPSTensor.isLeftCanonical_rotatePhysical}
-    \leanok
-    \uses{def:rotate_physical}
-    If $u u^\dagger = I$ and $A$ is left-canonical, then
-    $A_u$ is left-canonical.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:rotate_physical}
-    Expand $\sum_i B_i^\dagger B_i$ where $B_i = \sum_j u_{ij} A_j$,
-    swap sums, apply orthogonality $u^\dagger u = I$, and collapse to
-    $\sum_j A_j^\dagger A_j = I$.
-\end{proof}
-
-\begin{theorem}[Irreducibility preserved by physical rotation]%
-    \label{thm:irreducible_tensor_rotate_physical}
-    \lean{MPSTensor.isIrreducibleTensor_rotatePhysical}
-    \leanok
-    \uses{def:rotate_physical}
-    If $u u^\dagger = I$ and $A$ is irreducible, then
-    $A_u$ is irreducible.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:rotate_physical}
-    Contrapositive: any nontrivial invariant projection~$P$ for the
-    rotated tensor yields $(1-P)\, A_k\, P = 0$ for all~$k$ via the
-    orthogonality of~$u$, contradicting irreducibility of~$A$.
-\end{proof}
-
-\begin{theorem}[Periodicity preserved by physical rotation]%
-    \label{thm:periodic_rotate_physical}
-    \lean{MPSTensor.isPeriodic_rotatePhysical}
-    \leanok
-    \uses{def:rotate_physical, thm:transfer_map_rotate_physical,
-        thm:left_canonical_rotate_physical,
-        thm:irreducible_tensor_rotate_physical}
-    If $u u^\dagger = I$ and $A$ is periodic with period~$m$, then
-    $A_u$ is periodic with the same period.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:transfer_map_rotate_physical,
-        thm:left_canonical_rotate_physical,
-        thm:irreducible_tensor_rotate_physical}
-    Assembles transfer-map invariance, left-canonical preservation, and
-    irreducibility preservation.
-\end{proof}
-
-\begin{theorem}[SameMPV preserved by physical rotation]%
-    \label{thm:same_mpv_rotate_physical}
-    \lean{MPSTensor.sameMPV₂_rotatePhysical}
-    \leanok
-    \uses{def:rotate_physical, def:same_mpv}
-    If $\mathcal{V}(A) = \mathcal{V}(B)$, then
-    $\mathcal{V}(A_u) = \mathcal{V}(B_u)$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:rotate_physical, def:same_mpv}
-    Induction on the word length with a strengthened hypothesis
-    carrying an arbitrary prefix matrix, reducing each step to the
-    hypothesis via word concatenation.
-\end{proof}
-
-\begin{theorem}[Physical rotation distributes over block assembly]%
-    \label{thm:rotate_physical_blocks}
-    \lean{MPSTensor.rotatePhysical_toTensorFromBlocks}
-    \leanok
-    \uses{def:rotate_physical}
-    The rotated block-diagonal tensor satisfies
-    $(\bigoplus_k \mu_k A_k)_u
-        = \bigoplus_k \mu_k (A_k)_u$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:rotate_physical}
-    Pointwise matrix-entry computation using linearity of
-    the block-diagonal embedding and reindexing.
-\end{proof}
-
-\begin{theorem}[Irreducible form preserved by physical rotation]%
-    \label{thm:irreducible_form_rotate_physical}
-    \lean{MPSTensor.isIrreducibleForm_rotatePhysical}
-    \leanok
-    \uses{def:rotate_physical, def:irreducible_form,
-        thm:periodic_rotate_physical,
-        thm:same_mpv_rotate_physical,
-        thm:rotate_physical_blocks}
-    If $u u^\dagger = I$ and $A$ is in irreducible form~II, then
-    $A_u$ is in irreducible form~II with the same block structure and
-    rotated blocks.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:periodic_rotate_physical,
-        thm:same_mpv_rotate_physical,
-        thm:rotate_physical_blocks}
-    Each block remains periodic by
-    Theorem~\ref{thm:periodic_rotate_physical}, the SameMPV condition
-    transfers via Theorem~\ref{thm:same_mpv_rotate_physical}, and
-    block-assembly compatibility follows from
-    Theorem~\ref{thm:rotate_physical_blocks}.
-\end{proof}
+For periodic tensors, the physical-index rotation track is developed in
+Chapter~\ref{ch:periodic_ft_apps}: Definition~\ref{def:rotate_physical}
+and Theorems~\ref{thm:transfer_map_rotate_physical},
+\ref{thm:left_canonical_rotate_physical},
+\ref{thm:irreducible_tensor_rotate_physical},
+\ref{thm:periodic_rotate_physical}, \ref{thm:same_mpv_rotate_physical},
+\ref{thm:rotate_physical_blocks}, and
+\ref{thm:irreducible_form_rotate_physical}. We use these results here
+when deriving symmetry consequences, without restating their proofs.
 
 \begin{corollary}[Periodic symmetry yields $\Z$-gauge equivalence]%
     \label{cor:symmetry_periodic_assembly}


### PR DESCRIPTION
### Motivation

- Consolidate Gemma (arXiv:1708.00029) periodic/rotation material into the dedicated `ch11b_periodic_ft.tex` chapter to mirror the Lean-side Gemma split and avoid scattered duplicate blueprint entries.
- Keep the blueprint declarations in a single canonical place so `\lean{...}` tags and narrative cross-references remain coherent across chapters.

### Description

- Moved the periodic-form definitions `IsPeriodic` and `IsIrreducibleForm` from `blueprint/src/chapter/ch11_assembly.tex` into `blueprint/src/chapter/ch11b_periodic_ft.tex` and updated `ch11_assembly.tex` to refer to the new location via cross-reference paragraph.
- Relocated the full `rotatePhysical` track (definition plus preservation lemmas/theorems) from `blueprint/src/chapter/ch13b_symmetry.tex` into `ch11b_periodic_ft.tex`, and replaced the removed blocks in `ch13b_symmetry.tex` with a short paragraph that `\ref`s the moved results so the symmetry prose remains coherent.
- Moved the `zGauge*` / `ZGaugeDiagonal` / `ZGaugeEquiv` definitions and small lemmas into `ch11b_periodic_ft.tex` and replaced their previous occurrences with a cross-reference paragraph in `ch11b_periodic_ft.tex`'s original sister sections, preserving all original `\lean{...}` labels exactly to avoid breaking Lean-Blueprint links.
- This is a blueprint-only refactor with no `.lean` file edits, no theorem statements changed, and no new mathematical content introduced.

### Testing

- Confirmed with `rg` that the migrated `\lean{...}` declarations (`IsPeriodic`, `IsIrreducibleForm`, `rotatePhysical`-track and `zGauge*`) now appear in `blueprint/src/chapter/ch11b_periodic_ft.tex` and are absent as full definitions in `ch11_assembly.tex` and `ch13b_symmetry.tex` where they used to live.
- Ran local text checks (`rg -n "zGauge|rotatePhysical|IsPeriodic|IsIrreducibleForm"`) to validate presence and absence across the three modified chapter files and found the expected results.
- Attempted to run the canonical blueprint validation `cd blueprint && leanblueprint checkdecls` and `python3 -m leanblueprint checkdecls`, but `leanblueprint` is not available in this environment so automated `checkdecls` / `web` validation could not be executed here.
- No Lean checks were performed since no `.lean` files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e538a76e58832482f2e6c8c44151c9)

---
Addresses #675

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only relocates blueprint LaTeX definitions/theorems and replaces them with cross-references, without changing Lean code or mathematical statements; main risk is broken labels/refs or `\lean{}` linkage due to the move.
> 
> **Overview**
> Consolidates the periodic MPS blueprint material by moving the `IsPeriodic`/`IsIrreducibleForm` definitions, the full `rotatePhysical` preservation theorem chain, and the `Z`-gauge definitions/lemmas into `ch11b_periodic_ft.tex`.
> 
> `ch11_assembly.tex` and `ch13b_symmetry.tex` drop the duplicated blocks and instead point to the new canonical location via short cross-reference paragraphs, keeping existing labels and `\lean{...}` tags intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e4038fe6bddd7904706fd8e1e2644e04251772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->