### PR TITLE
fix(MPS/ParentHamiltonian): discharge independent parentHamiltonian_gs_eq_bnt_span sorry

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
+++ b/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
@@ -182,11 +182,12 @@ theorem parentHamiltonian_gs_eq_bnt_span
     (A : (j : Fin r) → MPSTensor d (dim j))
     (hCF : IsCanonicalFormBNT μ A) {L N : ℕ} (hL : 1 < L) (hN : N ≥ L + 1) :
     parentHamiltonianGroundSpace (μ := μ) A L N = bntSpan A N := by
-  -- PROOF STRUCTURE: see bridge lemma
-  -- `parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition` for the
-  -- planned proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition`.
-  sorry
+  apply le_antisymm
+  · exact
+      parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition
+        (μ := μ) A hCF hL hN
+  · refine Submodule.span_le.2 ?_
+    rintro _ ⟨j, rfl⟩
+    exact bnt_mem_groundSpace (μ := μ) A hCF hL hN j
 
 end MPSTensor


### PR DESCRIPTION
### Motivation
- Close the independent top-level `sorry` in the degenerate ground-space theorem so the file contains the full high-level equality statement while the deeper block-decomposition bridge remains to be completed.

### Description
- Replace the `sorry` proof of `parentHamiltonian_gs_eq_bnt_span` with an explicit `le_antisymm` proof that uses the existing bridge lemma for the reverse inclusion.
- Prove the forward inclusion by `Submodule.span_le` and the already-provided `bnt_mem_groundSpace` applied to each BNT generator.
- Leave the bridge lemma `parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition` unchanged (still `sorry`), since it depends on the block-decomposition / `chainGroundSpace_eq_mpvSubmodule_normal` path.

### Testing
- Ran `lake env lean TNLean/MPS/ParentHamiltonian/DegenerateGS.lean` which succeeds and emits the expected warning that the bridge lemma still uses `sorry`.
- Verified with `rg -n "sorry|axiom" TNLean/MPS/ParentHamiltonian/DegenerateGS.lean` that only the bridge `sorry` remains.

---
Addresses #460

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e538b87e008324b360fd04117dba30)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only rewrites a Lean proof to eliminate a top-level `sorry`, without changing any definitions or computational behavior; the result still relies on the existing (still-sorry) bridge lemma for one inclusion.
>
> **Overview**
> Discharges the top-level `sorry` in `parentHamiltonian_gs_eq_bnt_span` by replacing it with a concrete `le_antisymm` proof.
>
> The proof now derives `parentHamiltonianGroundSpace ≤ bntSpan` via `parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition` and proves `bntSpan ≤ parentHamiltonianGroundSpace` by `Submodule.span_le` using `bnt_mem_groundSpace` on each generator.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b671bab9bec7f6b1f3b4816a04f8a587ee2728f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->