### PR TITLE
doc(MPS/ParentHamiltonian): add KL martingale scout blocker report

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -208,6 +208,23 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
+/- Scout report (2026-04-19, Layer 4 KL martingale).
+
+1. **Friedrichs-angle surface:** TNLean currently has no dedicated
+`FriedrichsAngle`/principal-angle API in `TNLean/Analysis`. Mathlib provides
+orthogonal-projection infrastructure (`Projection.Basic/FiniteDimensional`,
+`Submodule.starProjection`, `orthogonalProjection`) but not a packaged
+Kastoryano–Lucia-style angle-to-anticommutator bound. This is a real blocker
+for quantitative overlap constants.
+2. **Row-sum bound mapping:** the combinatorial part is already available from
+locality (`localTerm`, `parentHamiltonian`) and finite range: each window
+overlaps at most `2 * (L - 1)` neighbors. Missing is the analytic bridge from
+overlap-angle constants to operator-inequality coefficients `cᵢⱼ`.
+3. **Sorry dependency split:** `parentHamiltonian_gapped` is downstream-only and
+dischargeable immediately once the bridge theorem below is proved. The bridge
+`parentHamiltonianES_gap_bound_of_friedrichs` still depends on missing
+Friedrichs-angle infrastructure; this is the blocker and should not be replaced
+with axioms or unrelated sorrys. -/
 /-- Friedrichs-angle and row-sum bridge for the MPS parent Hamiltonian.
 
 This is the remaining MPS-specific martingale estimate: it should produce a

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -212,8 +212,10 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
 
 1. **Friedrichs-angle surface:** TNLean currently has no dedicated
 `FriedrichsAngle`/principal-angle API in `TNLean/Analysis`. Mathlib provides
-orthogonal-projection infrastructure (`Projection.Basic/FiniteDimensional`,
-`Submodule.starProjection`, `orthogonalProjection`) but not a packaged
+orthogonal-projection infrastructure (for example
+`Mathlib.Analysis.InnerProductSpace.Projection.Basic` and
+`Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional`, exposing
+`Submodule.starProjection` and `orthogonalProjection`) but not a packaged
 Kastoryano–Lucia-style angle-to-anticommutator bound. This is a real blocker
 for quantitative overlap constants.
 2. **Row-sum bound mapping:** the combinatorial part is already available from


### PR DESCRIPTION
### Motivation
- Post a short scout/blocker before writing the KL–martingale proof so the missing analytic infrastructure (Friedrichs-angle → anticommutator bound) is surfaced and proof coding does not introduce axioms or unrelated `sorry`s.

### Description
- Add a concise scout report comment in `TNLean/MPS/ParentHamiltonian/Martingale.lean` immediately above the bridge lemma `parentHamiltonianES_gap_bound_of_friedrichs` explaining that TNLean lacks a dedicated Friedrichs-angle API (Mathlib has projection primitives), the combinatorial row-sum overlap count is available from `localTerm`/`parentHamiltonian`, and that the bridge lemma is currently blocked on the missing angle→operator-inequality machinery; no other proof code was changed.

### Testing
- Ran `lake env lean TNLean/MPS/ParentHamiltonian/Martingale.lean`, which succeeds while reporting the expected `sorry` warnings, and verified outstanding `sorry`s with `rg -n "sorry" TNLean/MPS/ParentHamiltonian/Martingale.lean`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e538c0ee3483249f74b07e7c53eeee)

---
Addresses #193

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds explanatory comments and does not change any definitions, proofs, or runtime behavior.
> 
> **Overview**
> Adds a detailed *scout/blocker report* comment in `TNLean/MPS/ParentHamiltonian/Martingale.lean` immediately before `parentHamiltonianES_gap_bound_of_friedrichs`, documenting the missing Friedrichs-angle/principal-angle infrastructure and the remaining analytic bridge needed to complete the KL martingale spectral-gap proof, while noting that the combinatorial overlap/row-sum part is already available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 542e0efd4e2a63cd16565f8f87c192ba882911e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->