### PR TITLE
refactor(MPS/MPDO): close remaining Section 4.5 scaffold integrity items

### DIFF
--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -39,9 +39,9 @@ Two layers coexist in this file.
    packages a support subspace `𝒜ₙ`, a forward map `Tₙ : phys → 𝒜ₙ`, and a
    backward map `Sₙ : 𝒜ₙ → phys` with `Tₙ ∘ Sₙ = id_{𝒜ₙ}` and `Sₙ ∘ Tₙ = Eₙ`.
    The retract identity forces `Eₙ^2 = Eₙ`; conversely any idempotent blocked
-   transfer map factors through its range. This yields an honest equivalence
-   between the current provisional predicate `MPOTensor.IsRFP` and the
-   transfer-map-level fusion formulation.
+   transfer map factors through its range. This yields an equivalence between
+   the current provisional predicate `MPOTensor.IsRFP` and the transfer-map-
+   level fusion formulation.
 
 ## Main declarations
 

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -39,9 +39,9 @@ Two layers coexist in this file.
    packages a support subspace `𝒜ₙ`, a forward map `Tₙ : phys → 𝒜ₙ`, and a
    backward map `Sₙ : 𝒜ₙ → phys` with `Tₙ ∘ Sₙ = id_{𝒜ₙ}` and `Sₙ ∘ Tₙ = Eₙ`.
    The retract identity forces `Eₙ^2 = Eₙ`; conversely any idempotent blocked
-   transfer map factors through its range. This yields an equivalence between
-   the current provisional predicate `MPOTensor.IsRFP` and the transfer-map-
-   level fusion formulation.
+   transfer map factors through its range. This yields an equivalence
+   between the current provisional predicate `MPOTensor.IsRFP` and the
+   transfer-map-level fusion formulation.
 
 ## Main declarations
 


### PR DESCRIPTION
Closes #625.

## Summary

This PR finishes the remaining audit/cleanup on current `main` after merged PRs #659 and #665.

- audits the former item-1 circularity targets and confirms the old wrappers are gone:
  - `isRFP_MPDO_via_fusion_iff_RFP_MPDO` — absent
  - `rfp_mpdo_fusion_iff_algebra` — absent
  - `rfp_mpdo_three_way` — absent
  - `IsRFP_MPDO_via_algebra` — absent (the remaining provisional declaration is explicitly renamed to `IsRFP_MPDO_via_algebra_scaffold`)
- confirms the current fusion formulation is the honest transfer-map-level API from #665:
  - `MPOTensor.IsRFP_MPDO_via_fusion`
  - `MPOTensor.isRFP_of_isRFP_MPDO_via_fusion`
  - `MPOTensor.isRFP_MPDO_via_fusion_of_isRFP`
  - `MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP`
- confirms item 5 is now in the right state in the blueprint:
  - `def:mpdo_rfp_via_fusion` keeps `\leanok` because it now points to the honest predicate
  - `def:mpdo_rfp_via_algebra` has no `\leanok` and still points to the explicitly provisional `_scaffold` declaration
- confirms item 6 remains resolved: `FusionIsometry.level` and `AlgebraStructureData.A` are absent on current `main`
- applies the one remaining file-local cleanup found during the audit: removes the word "honest" from the `FusionIsometries.lean` module docstring so the Lean comments stay aligned with the style cleanup requested in #625

The deeper algebra-structure compatibility work remains tracked by #612; this PR does not change the provisional `_scaffold` declaration.

## Validation

- `lake env lean TNLean/MPS/MPDO/FusionIsometries.lean`
- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `rg -n "sorry|axiom" TNLean/MPS/MPDO/FusionIsometries.lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake build`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only tweaks documentation wording in a module docstring and does not change any definitions, theorems, or proofs.
> 
> **Overview**
> Updates the `FusionIsometries.lean` module docstring to remove the word **"honest"**, reframing the statement about the equivalence between the provisional `MPOTensor.IsRFP` predicate and the transfer-map-level fusion formulation without changing any code or behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbb1f3c5333dfcd8bb3684b512a6d0ed65e3bb39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->