### PR TITLE
refactor(MPS/Periodic/ZGauge): trim unused imports

### DIFF
--- a/TNLean/MPS/Periodic/ZGauge.lean
+++ b/TNLean/MPS/Periodic/ZGauge.lean
@@ -1,10 +1,9 @@
 /-
-Copyright (c) 2025 TNLean contributors. All rights reserved.
+Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Algebra.ScalarPowerSumIdentity
-
-import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Complex.Basic
+import Mathlib.Data.Matrix.Basic
 
 /-!
 # Periodic Z-gauge helpers
@@ -16,7 +15,7 @@ the Gemma split between the general fundamental-theorem stack and the periodic
 §3–§4 infrastructure.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix
 
 namespace MPSTensor
 
@@ -35,7 +34,7 @@ theorem zGaugeEntry_pow_eq_one_of_pow_eq
 theorem zGaugeEntry_mul_right {μ ν : ℂ} (hν : ν ≠ 0) :
     zGaugeEntry μ ν * ν = μ := by
   dsimp [zGaugeEntry]
-  field_simp [hν]
+  rw [div_eq_mul_inv, mul_assoc, inv_mul_cancel₀ hν, mul_one]
 
 section ZGaugeDiagonal
 


### PR DESCRIPTION
## Summary
- replace the transitive `TNLean.Algebra.ScalarPowerSumIdentity` import with the direct
  `Mathlib.Data.Complex.Basic` and `Mathlib.Data.Matrix.Basic` imports actually used by
  `TNLean/MPS/Periodic/ZGauge.lean`
- drop the unused `Mathlib.Data.Fintype.BigOperators` import and `BigOperators` scoped opening
- bump the file header year to 2026 and rewrite `zGaugeEntry_mul_right` so the file does not
  rely on extra tactic imports

## Testing
- `lake env lean TNLean/MPS/Periodic/ZGauge.lean`
- `lake build TNLean.MPS.Periodic.ZGauge`
- full `lake build` succeeds
- `rg -n "sorry|axiom" TNLean/MPS/Periodic/ZGauge.lean` returns no matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to import/scoping cleanup and a small proof rewrite with identical statement, with no behavioral or API changes expected.
> 
> **Overview**
> Updates `TNLean/MPS/Periodic/ZGauge.lean` to use direct `Mathlib` imports (`Complex`/`Matrix`) and removes unused `BigOperators` scoping, reducing transitive dependencies.
> 
> Also rewrites `zGaugeEntry_mul_right` from a `field_simp`-based proof to an explicit `div_eq_mul_inv`/`inv_mul_cancel₀` calculation, and bumps the header year to 2026.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6705feed361d4c48de9b84a1161a039757e463b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->