### PR TITLE
feat(MPS/Periodic): discharge sectorBlocked_isNormal_of_isPeriodic (#584)

### DIFF
--- a/TNLean/MPS/Periodic/Overlap.lean
+++ b/TNLean/MPS/Periodic/Overlap.lean
@@ -1276,12 +1276,11 @@ lemma sectorBlocked_isNormal_of_isPeriodic
     (hCyclic : IsCyclicSectorDecomp A blocks)
     (u : Fin m) (hNonzero : dim u ≠ 0) :
     IsNormal (blocks u) := by
-  -- PROOF STRUCTURE: see bridge lemma
-  -- `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp` for the planned
-  -- proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `compressedTensor_adjointTransferMap_cornerBridge`.
-  sorry
+  haveI : NeZero (dim u) := ⟨hNonzero⟩
+  obtain ⟨hPrim, hIrr⟩ :=
+    primitive_and_irreducible_sectorBlocks_of_cyclicDecomp
+      A hP blocks hBlocks_lc hBlocks_mpv hCyclic u hNonzero
+  exact isNormal_of_tp_primitive_irreducible (blocks u) (hBlocks_lc u) hPrim hIrr
 
 /-- Gauge-phase equivalence is preserved by physical blocking.
 

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -671,7 +671,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 
 \begin{lemma}[Sector-block normality for periodic tensors]\label{lem:sector_blocked_normal_periodic}
 	\lean{MPSTensor.sectorBlocked_isNormal_of_isPeriodic}
-	\notready
+	\leanok
 	\uses{def:periodic_tensor, def:cyclic_sector_decomp}
 	For a periodic tensor equipped with a cyclic sector decomposition,
 	each nonzero blocked sector tensor is normal.


### PR DESCRIPTION
## Summary
- discharge `MPSTensor.sectorBlocked_isNormal_of_isPeriodic` in `TNLean/MPS/Periodic/Overlap.lean`
- reuse `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp` together with `isNormal_of_tp_primitive_irreducible`
- sync the existing blueprint entry in `blueprint/src/chapter/ch11_assembly.tex` from `\notready` to `\leanok`

## Verification
- `lake env lean TNLean/MPS/Periodic/Overlap.lean`
- `lake build TNLean.MPS.Periodic.Overlap`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/Periodic/Overlap.lean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

## Notes
- `rg -n "sorry|axiom" TNLean/MPS/Periodic/Overlap.lean` dropped from 27 hits on `origin/main` to 25 hits on this branch; the target theorem is now sorry-free.
- Scope stayed within `TNLean/MPS/Periodic/Overlap.lean` plus the matching blueprint readiness tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only replaces a `sorry` with a constructive Lean proof and updates the blueprint readiness flag, without changing any definitions or runtime behavior.
> 
> **Overview**
> Discharges `MPSTensor.sectorBlocked_isNormal_of_isPeriodic` in `TNLean/MPS/Periodic/Overlap.lean` by replacing the placeholder proof with a derivation that first obtains sector-block primitivity/irreducibility via `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`, then concludes normality using `isNormal_of_tp_primitive_irreducible`.
> 
> Updates the blueprint (`ch11_assembly.tex`) to mark the corresponding lemma as **formalized** (`\leanok`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea115c692c193ca51ab26f44c5b3ad43e6f00f12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->