### PR TITLE
fix(ci): repair docs and blueprint sync workflow

### DIFF
--- a/.github/workflows/docs-blueprint-sync.lock.yml
+++ b/.github/workflows/docs-blueprint-sync.lock.yml
@@ -129,6 +129,10 @@ jobs:
           cat << 'GH_AW_PROMPT_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
+          In GitHub Copilot CLI, these safe-output tools may be exposed with a `safeoutputs-` prefix
+          (for example `safeoutputs-create_pull_request`, `safeoutputs-missing_tool`,
+          `safeoutputs-missing_data`, or `safeoutputs-noop`). Use the exact runtime tool name if the
+          unprefixed name is unavailable, and do not emit raw JSON as plain text.
           GH_AW_PROMPT_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat << 'GH_AW_PROMPT_EOF'
@@ -270,6 +274,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 50
       - name: Create gh-aw temp directory
         run: bash ${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Configure gh CLI for GitHub Enterprise


### PR DESCRIPTION
Fixes #687.

## Problem
- The latest Docs & Blueprint Sync run opened another `[aw] Docs & Blueprint Sync failed` issue because the agent produced no safe outputs.
- In run `24660844775`, the Copilot session repeatedly tried `create_pull_request`, got `Tool 'create_pull_request' does not exist`, and never emitted a valid safe output.
- The same run's MCP logs showed that the runtime had actually registered the tools as `safeoutputs-create_pull_request`, `safeoutputs-missing_tool`, `safeoutputs-missing_data`, and `safeoutputs-noop`.
- The agent checkout was also depth-1, which conflicts with the prompt's instruction to inspect recent commit history.

## Fix
- Clarify in the Docs & Blueprint Sync workflow prompt that, in GitHub Copilot CLI, safe-output tools may be exposed with the `safeoutputs-` prefix and must be invoked by their exact runtime names rather than emitted as raw JSON.
- Increase the agent checkout depth to `50` so the workflow can inspect recent repository history as intended.

## Verification
- Inspected the failing workflow logs for runs `24660844775` and `24559367851` and confirmed the safe-output name mismatch (`Tool 'create_pull_request' does not exist` vs registered `safeoutputs-create_pull_request` / `safeoutputs-noop`).
- Parsed `.github/workflows/docs-blueprint-sync.lock.yml` locally with Ruby's YAML parser.
- Verified that the diff only touches `.github/workflows/docs-blueprint-sync.lock.yml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts the agent prompt and git checkout depth; main impact is on automation behavior if the tool naming guidance is wrong.
> 
> **Overview**
> Fixes the `Docs & Blueprint Sync` workflow by clarifying in the agent prompt that safe-output tools may be exposed with a `safeoutputs-` prefix (and must be invoked by the exact runtime tool name, not emitted as raw JSON).
> 
> Also increases the agent job `actions/checkout` depth to `50` so the workflow can inspect recent commit history when generating sync updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b2ffefe06f89d1ed2102ad05c88233f47e0986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->