### PR TITLE
doc(audits): #612 algebra-structure coefficients blocker report

### DIFF
--- a/audits/2026-04-21_issue612_algebra_structure_blocker.md
+++ b/audits/2026-04-21_issue612_algebra_structure_blocker.md
@@ -1,0 +1,142 @@
+# Issue #612 blocker report — algebra-structure coefficients
+
+Date: 2026-04-20
+Branch: `feat/612-algebra-structure-coeffs`
+Target issue: #612
+
+## Outcome
+
+I did **not** change `TNLean/MPS/MPDO/AlgebraStructure.lean`.
+The current algebra-structure side is still a scaffold on `main`, and replacing it
+by a paper-faithful definition would require new support-algebra infrastructure that
+is not yet present in the repository.
+
+## Current state on `main`
+
+The file `TNLean/MPS/MPDO/AlgebraStructure.lean` still exposes a vacuous
+compatibility predicate:
+
+- `MPOTensor.AlgebraStructureData.CompatibleWith _ _ : Prop := True`
+- `MPOTensor.IsRFP_MPDO_via_algebra_scaffold M := ∃ data, data.CompatibleWith M`
+
+So the current algebra-structure predicate is satisfied by every MPO tensor and
+cannot yet serve as a mathematical formulation of Theorem IV.13(ii) from
+arXiv:1606.00608 §4.5.
+
+The blueprint already states this honestly: the §4.5 algebra-structure entry in
+`blueprint/src/chapter/ch02b_mpdo.tex` marks the predicate as provisional and notes
+that the compatibility relation is trivial.
+
+## The merged #611 API that one would naturally transfer from
+
+PR #665 (#611) added the transfer-map-level fusion formulation in
+`TNLean/MPS/MPDO/FusionIsometries.lean`. For each blocked size `n`, it provides
+`MPOTensor.FusionIsometryData M n` consisting of:
+
+- a support subspace
+  `supportAlgebra : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)`;
+- a forward map
+  `T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] supportAlgebra`;
+- a backward map
+  `S : supportAlgebra →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ`;
+- the retract identity
+  `T ∘ₗ S = LinearMap.id`;
+- the characteristic identity
+  `S ∘ₗ T = blockedTransferMap M n`.
+
+This is strong enough to prove
+`MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP`, because an idempotent blocked
+transfer map factors through its range and conversely any such retract makes the
+blocked transfer map idempotent.
+
+## Why this is still not enough for the algebra-structure side
+
+The paper's algebra-structure formulation is not just a retract through a subspace.
+It needs a genuine algebra object at each blocked size, together with multiplication
+coefficients `c_{αβγ}^{(L)}` and compatibility across blocking levels.
+
+The natural route from the merged fusion API would be to define a projected product
+on the range of `blockedTransferMap M n` by
+
+`a ⋆ b := T (S a * S b)`.
+
+However, the current `supportAlgebra` in `FusionIsometryData` is only a
+`Submodule`, not a `Subalgebra` / `StarSubalgebra`, and the existing API does not
+prove that this projected product is associative or unital.
+
+There is already an abstract conditional-expectation interface in
+`TNLean/Channel/FixedPoint/ConditionalExpectation.lean`, but it assumes a
+pre-existing `StarSubalgebra`. What is missing here is precisely the theorem that
+upgrades the range of the blocked transfer map to such an algebraic object.
+
+## Concrete missing pieces
+
+To replace `CompatibleWith := True` by a paper-faithful condition, the repository
+still needs the following infrastructure.
+
+### 1. Choi–Effros identity for the blocked transfer-map idempotent
+
+If we write `E_n := blockedTransferMap M n`, then the projected multiplication on
+`range(E_n)` should be controlled by the Choi–Effros identities
+
+- `E_n (E_n x * y) = E_n (x * y)`;
+- `E_n (x * E_n y) = E_n (x * y)`.
+
+Equivalently, one wants the standard form
+
+`E_n (E_n x * E_n y) = E_n (x * y)`.
+
+Without these identities there is no sound route to an associative multiplication
+on the support object extracted from the fusion datum.
+
+### 2. Packaging the range as an algebra / support-algebra object
+
+Once the projected product is available, the range of `E_n` must be packaged as an
+actual algebraic object, ideally something like a `StarSubalgebra` or a dedicated
+support-algebra structure carrying:
+
+- carrier subspace;
+- multiplication;
+- unit;
+- closure proofs;
+- associativity and unit laws;
+- the relation to `E_n` as the corresponding projection / conditional expectation.
+
+At present, `FusionIsometryData.supportAlgebra` is only a `Submodule`, so the
+necessary algebraic laws cannot even be stated in the right form.
+
+### 3. Basis-coordinate extraction for the coefficients
+
+Theorem IV.13(ii) is phrased in terms of structure coefficients
+`c_{αβγ}^{(L)}` and the idempotence relation
+
+`m_γ = Σ_{α,β} c_{αβγ}^{(1)} m_α m_β`.
+
+After the support algebras are available, one still needs a finite-basis / block
+API extracting the coordinates of the multiplication map in that basis and proving
+that they match the coefficient formulas coming from the blocked MPO operators.
+Only then can `AlgebraStructureData.CompatibleWith` be replaced by something that
+actually reflects the paper.
+
+## Conclusion
+
+Issue #612 is blocked not by a local proof gap in `AlgebraStructure.lean`, but by a
+missing layer between the current fusion retracts and the paper's support-algebra
+formulation. The correct next step is to build that missing layer first, and only
+then return to the algebra-structure coefficients themselves.
+
+## Recommended follow-up issue
+
+Suggested title:
+
+> **Choi–Effros/support-algebra API for `blockedTransferMap` idempotents**
+
+Suggested scope:
+
+1. For an idempotent blocked transfer map `E_n`, prove the Choi–Effros product
+   identities needed on `range(E_n)`.
+2. Package `range(E_n)` as a `StarSubalgebra`-like support algebra with projected
+   multiplication.
+3. Expose the bridge from `FusionIsometryData` to that support algebra.
+4. Only after this, return to issue #612 and define the algebra-structure
+   coefficients and compatibility predicate in a non-vacuous way.


### PR DESCRIPTION
## Status: DRAFT blocker report

Closes (partial/blocker): #612

### Summary

This draft PR does **not** change the Lean algebra-structure formulation. It adds a blocker audit after re-reading the current scaffold in `TNLean/MPS/MPDO/AlgebraStructure.lean`, the merged fusion-side API in `TNLean/MPS/MPDO/FusionIsometries.lean`, and the paper discussion in arXiv:1606.00608 §4.5 / Appendix C.4.

The current conclusion is that issue #612 is blocked on three missing infrastructure pieces:

1. **Choi–Effros identities for `blockedTransferMap` idempotents**
   needed to define the projected product on the support object extracted from the fusion retract.
2. **Support-algebra packaging of `range(blockedTransferMap M n)`**
   as an algebraic object (not merely a `Submodule`), with multiplication, unit, and closure laws.
3. **Basis-coordinate extraction for the structure coefficients**
   so that the multiplication data can be expressed as the coefficients `c_{αβγ}^{(L)}` from Theorem IV.13(ii).

### Audit note

- `audits/2026-04-21_issue612_algebra_structure_blocker.md`

### Current repository state preserved

- `AlgebraStructureData.CompatibleWith := True` remains unchanged.
- `IsRFP_MPDO_via_algebra_scaffold` remains the existing provisional/vacuous predicate.
- No new `sorry` or `axiom` is introduced.

### Recommended next step

Open a follow-up issue in the narrower scope:

**Choi–Effros/support-algebra API for `blockedTransferMap` idempotents**

That issue should construct the algebra object carried by the range of an idempotent blocked transfer map and expose the bridge from `FusionIsometryData` to that algebraic structure. Only after that should #612 be resumed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding an audit note; no Lean code, proofs, or APIs are modified.
> 
> **Overview**
> Adds an audit write-up (`audits/2026-04-21_issue612_algebra_structure_blocker.md`) documenting why issue #612’s algebra-structure coefficients work is currently blocked.
> 
> The note records that `AlgebraStructure.lean` remains a *vacuous scaffold* (`CompatibleWith := True`) and identifies missing prerequisites (Choi–Effros identities for `blockedTransferMap` idempotents, packaging the range as a support algebra, and basis/coordinate extraction) plus a recommended follow-up issue scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0216d0b2b7993650dfa4df7f27ec68a481a25038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->