### PR TITLE
chore(MPS/Periodic): audit unconditional Thm 4.1 blocker (#622)

### DIFF
--- a/audits/2026-04-21_issue622_thm41_unconditional_blocker.md
+++ b/audits/2026-04-21_issue622_thm41_unconditional_blocker.md
@@ -1,0 +1,127 @@
+# Issue #622 blocker audit — unconditional Thm. 4.1
+
+Date: 2026-04-21
+Branch: `feat/622-thm41-unconditional`
+Target file: `TNLean/MPS/Periodic/Symmetry.lean`
+
+## Goal
+
+Remove at least one of the conditional hypotheses
+
+- `MPSTensor.PRefinementCanonicalization`
+- `MPSTensor.PRefinementInverseCanonicalization`
+
+from Theorem 4.1 in `TNLean/MPS/Periodic/Symmetry.lean`, ideally making
+`MPSTensor.thm_4_1_p_refinement` unconditional.
+
+## Current forward-stage state on `main`
+
+The first three forward steps are already formalized by
+`MPSTensor.pRefinementCanonicalization_pullback`:
+
+1. from `IsPRefinable B p`, choose a witness `(A, W)`;
+2. form the pullback tensor
+   `C τ := ∑ σ, W τ σ • B σ`;
+3. prove both
+   - `transferMap C = transferMap B`, and
+   - `SameMPV C (blockTensor A p)`.
+
+So the remaining work is exactly the paper's second stage: turn this blocked
+`SameMPV` relation into a left-canonical root witness whose `p`-blocked transfer
+map is `transferMap B`.
+
+## Why the forward direction is still blocked
+
+There are **two distinct missing bridges**.
+
+### 1. The equal-case periodic FT is still not available unconditionally
+
+The natural next step is to apply the periodic equal-case fundamental theorem to
+`C` and `blockTensor A p`. However the current repository surface is still:
+
+- `MPSTensor.PeriodicEqualCaseFT` in
+  `TNLean/MPS/Periodic/Symmetry.lean` — an abstract `Prop` hypothesis;
+- `MPSTensor.fundamentalTheorem_periodic_equalCase` in
+  `TNLean/MPS/Periodic/FundamentalTheorem.lean` — a **conditional** theorem
+  requiring both
+  - `PeriodicOverlapHypothesis`, and
+  - the per-block power-equality hypothesis `hPowEq`.
+
+Those hypotheses are not derivable here from the current library because the
+underlying overlap infrastructure in `TNLean/MPS/Periodic/Overlap.lean` is still
+admitted. In particular, the current `periodicOverlapDichotomy` proof remains
+blocked by the sector-match transport chain.
+
+Relevant missing declarations in `TNLean/MPS/Periodic/Overlap.lean`:
+
+- `exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicDecomp`
+- `exists_sector_match_of_gaugePhaseEquiv`
+- `periodicOverlapDichotomy`
+
+So there is not yet an unconditional theorem in the repo that turns
+`SameMPV C (blockTensor A p)` plus irreducible-form hypotheses into a blocked
+`ZGaugeEquiv` witness.
+
+### 2. Even granting blocked `Z`-gauge data, the repo still lacks the root-reconstruction step
+
+The paper's proof does not stop at a blocked `Z`-gauge equivalence. One must
+**distribute the blocked `Z`-gauge back to a root tensor** `A'` so that
+`blockTensor A' p = C` (or at least enough to conclude
+`transferMap B = transferMap (blockTensor A' p)` with `A'` left-canonical).
+
+That blocked-to-unblocked transport is precisely the infrastructure still marked
+as missing in `TNLean/MPS/Periodic/Overlap.lean`:
+
+- `sectorGaugePhaseEquiv_succ_of_cyclicTransport`
+- `repeatedBlocks_of_blockedSectorGaugePhase`
+
+The accompanying file `TNLean/MPS/Periodic/CornerTransition.lean` explicitly
+states that the ambient staircase tensors are available there, but that the
+identification with the compressed blocked-sector tensors through the compression
+isometries `φ k` must be supplied by the missing Tier-A bridges in
+`Overlap.lean`.
+
+So the key Eq. A.8 / A.14–A.18 transport step needed to rebuild an unblocked
+root from the blocked `Z`-gauge has not yet been formalized on `main`.
+
+## Why the reverse direction is still blocked
+
+The reverse implication remains blocked by the same-size Kraus-rank reduction
+already packaged as `PRefinementInverseCanonicalization`.
+
+Current repo status:
+
+- `kraus_isometry_freedom_iff` / `kraus_unitary_freedom_iff` are available;
+- they identify Kraus families of the **same completely positive map** up to an
+  isometry;
+- but `IsPDivisibleChannel (transferMap B) p` only provides an abstract root
+  channel with an arbitrary finite Kraus family `K : Fin r → Matrix ...`.
+
+What is still missing is a theorem producing a **`d`-indexed** Kraus family for
+that root, so that the witness fits the current definition
+`IsPRefinable B p : ∃ A : MPSTensor d D, ...`.
+
+I found no theorem in the current channel/Kraus API that supplies this
+cardinality reduction. The missing statement is exactly the one currently
+packaged as
+
+- `MPSTensor.PRefinementInverseCanonicalization`
+  in `TNLean/MPS/Periodic/Symmetry.lean`.
+
+## Conclusion
+
+On the current `main` branch, neither canonicalization hypothesis can be removed
+honestly.
+
+To finish issue #622, the repo first needs:
+
+1. an unconditional blocked equal-case route (or an unconditional replacement for
+   `PeriodicEqualCaseFT`) built on top of the remaining periodic-overlap sector
+   bridges; and
+2. the blocked-to-unblocked cyclic transport needed to absorb the blocked
+   `Z`-gauge into a genuine root tensor; and, independently for the reverse
+   implication,
+3. a same-size Kraus-rank reduction theorem for channel roots.
+
+Because these bridges are still missing, I did **not** edit
+`TNLean/MPS/Periodic/Symmetry.lean` or introduce any placeholder proof.

--- a/audits/2026-04-21_issue622_thm41_unconditional_blocker.md
+++ b/audits/2026-04-21_issue622_thm41_unconditional_blocker.md
@@ -98,8 +98,10 @@ Current repo status:
   channel with an arbitrary finite Kraus family `K : Fin r → Matrix ...`.
 
 What is still missing is a theorem producing a **`d`-indexed** Kraus family for
-that root, so that the witness fits the current definition
-`IsPRefinable B p : ∃ A : MPSTensor d D, ...`.
+that root, so that the witness fits the current definition of
+`IsPRefinable B p`, whose witness includes both a tensor
+`A : MPSTensor d D` and an isometry `W : Matrix ...`, together with the
+required coefficient identity.
 
 I found no theorem in the current channel/Kraus API that supplies this
 cardinality reduction. The missing statement is exactly the one currently


### PR DESCRIPTION
## Summary
- add `audits/2026-04-21_issue622_thm41_unconditional_blocker.md`
- document why `PRefinementCanonicalization` and `PRefinementInverseCanonicalization` cannot yet be removed honestly on current `main`
- keep `TNLean/MPS/Periodic/Symmetry.lean` unchanged rather than introducing a placeholder proof

## What I checked
- read the required project docs, issue #622 history, `TNLean/MPS/Periodic/Symmetry.lean`, and the relevant paper sections
- re-scouted the current Thm. 4.1 infrastructure after PRs #635, #646, #656, and #691
- verified that the forward route reaches the pullback stage `pRefinementCanonicalization_pullback`, but the remaining equal-case / blocked-to-unblocked canonicalization bridges are still missing
- re-checked the reverse route and confirmed the same-size Kraus-rank reduction is still absent

## Blockers recorded in the audit
1. `TNLean/MPS/Periodic/FundamentalTheorem.lean` still exposes only the conditional equal-case FT surface; the unconditional route is blocked by admitted periodic-overlap infrastructure in `TNLean/MPS/Periodic/Overlap.lean`.
2. Even granting blocked `Z`-gauge data, the blocked-to-unblocked transport needed to rebuild a root tensor is still missing (`sectorGaugePhaseEquiv_succ_of_cyclicTransport`, `repeatedBlocks_of_blockedSectorGaugePhase`, and the Eq. A.8 compressed/ambient identification those lemmas depend on).
3. The reverse implication still needs a same-size Kraus-rank reduction theorem beyond the current Wolf Thm. 2.18 API.

## Verification
- audit-only PR; no Lean source files changed
- `git status --short` in the worktree showed only the new audit file before commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that does not modify any Lean source or proof behavior.
> 
> **Overview**
> Adds `audits/2026-04-21_issue622_thm41_unconditional_blocker.md`, an audit write-up for issue #622 explaining the specific missing lemmas/infrastructure that prevent making `MPSTensor.thm_4_1_p_refinement` unconditional (equal-case periodic FT, blocked-to-unblocked transport, and Kraus-rank reduction).
> 
> No functional changes: `TNLean/MPS/Periodic/Symmetry.lean` and other Lean sources are intentionally left untouched (no placeholder proofs introduced).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf985f468146b40772103a48fb329a504ff15ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->