### PR TITLE
feat(MPS/ParentHamiltonian): transport ES ground space to kernel (#460)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -206,6 +206,33 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
   let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
   e.symm.toLinearMap.comp ((parentHamiltonian A L N).comp e.toLinearMap)
 
+/-- The transported parent-Hamiltonian ground space is exactly the kernel of the
+transported parent Hamiltonian. -/
+theorem parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES
+    (A : MPSTensor d D) (L N : ℕ) :
+    parentHamiltonianGroundSpaceES A L N =
+      LinearMap.ker (parentHamiltonianES A L N) := by
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  ext v
+  constructor
+  · intro hv
+    rw [parentHamiltonianGroundSpaceES, Submodule.mem_map] at hv
+    obtain ⟨w, hw, rfl⟩ := hv
+    rw [LinearMap.mem_ker] at hw ⊢
+    simpa [parentHamiltonianES, e] using congrArg e.symm hw
+  · intro hv
+    rw [LinearMap.mem_ker] at hv
+    rw [parentHamiltonianGroundSpaceES, Submodule.mem_map]
+    refine ⟨e v, ?_, by simp [e]⟩
+    rw [LinearMap.mem_ker]
+    have hv' := congrArg e hv
+    simpa [parentHamiltonianES, e] using hv'
+
+@[simp] theorem mem_parentHamiltonianGroundSpaceES_iff
+    (A : MPSTensor d D) (L N : ℕ) (v : EuclideanSpace ℂ (Cfg d N)) :
+    v ∈ parentHamiltonianGroundSpaceES A L N ↔ parentHamiltonianES A L N v = 0 := by
+  rw [parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES, LinearMap.mem_ker]
+
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
 /- Scout report (2026-04-19, Layer 4 KL martingale).
@@ -244,11 +271,13 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
   -- Missing bridge: the MPS-specific Friedrichs-angle estimate for adjacent
-  -- local ground spaces, the finite-overlap row-sum bound, positivity of the
-  -- transported parent Hamiltonian, and the identification of
-  -- `parentHamiltonianGroundSpaceES` with `LinearMap.ker (parentHamiltonianES A L N)`.
-  -- Once formalized, this should feed the resulting quadratic-form inequality
-  -- into `FrustrationFree.spectralGap_of_martingale`.
+  -- local ground spaces, the finite-overlap row-sum bound, and positivity of
+  -- the transported parent Hamiltonian. The kernel identification needed for
+  -- the final martingale application is now available as
+  -- `parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES`.
+  -- Once the remaining analytic inputs are formalized, this should feed the
+  -- resulting quadratic-form inequality into
+  -- `FrustrationFree.spectralGap_of_martingale`.
   sorry
 
 /--

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -247,19 +247,19 @@ Kastoryano–Lucia-style angle-to-anticommutator bound. This is a real blocker
 for quantitative overlap constants.
 2. **Row-sum bound mapping:** the combinatorial part is already available from
 locality (`localTerm`, `parentHamiltonian`) and finite range: each window
-overlaps at most `2 * (L - 1)` neighbors. Missing is the analytic bridge from
-overlap-angle constants to operator-inequality coefficients `cᵢⱼ`.
+overlaps at most `2 * (L - 1)` neighbors. Missing is the analytic implication
+from overlap-angle constants to operator-inequality coefficients `cᵢⱼ`.
 3. **Sorry dependency split:** `parentHamiltonian_gapped` is downstream-only and
-dischargeable immediately once the bridge theorem below is proved. The bridge
-`parentHamiltonianES_gap_bound_of_friedrichs` still depends on missing
-Friedrichs-angle infrastructure; this is the blocker and should not be replaced
-with axioms or unrelated sorrys. -/
-/-- Friedrichs-angle and row-sum bridge for the MPS parent Hamiltonian.
+dischargeable immediately once the Friedrichs-angle theorem below is proved.
+The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends on
+missing Friedrichs-angle infrastructure; this is the blocker and should not be
+replaced with axioms or unrelated sorrys. -/
+/-- Friedrichs-angle and row-sum estimate for the MPS parent Hamiltonian.
 
 This is the remaining MPS-specific martingale estimate: it should produce a
 specific uniform positive lower bound for the transported parent Hamiltonian
 from the intersection property and finite-overlap geometry. The concrete
-constant is intentionally part of this bridge statement, so the public
+constant is intentionally part of this theorem statement, so the public
 `parentHamiltonian_gapped` theorem only has to package it as an existential
 spectral gap. -/
 theorem parentHamiltonianES_gap_bound_of_friedrichs
@@ -270,11 +270,11 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
-  -- Missing bridge: the MPS-specific Friedrichs-angle estimate for adjacent
-  -- local ground spaces, the finite-overlap row-sum bound, and positivity of
-  -- the transported parent Hamiltonian. The kernel identification needed for
-  -- the final martingale application is now available as
-  -- `parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES`.
+  -- Remaining obligations: the MPS-specific Friedrichs-angle estimate for
+  -- adjacent local ground spaces, the finite-overlap row-sum bound, and
+  -- positivity of the transported parent Hamiltonian. The kernel
+  -- identification needed for the final martingale application is now
+  -- available as `parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES`.
   -- Once the remaining analytic inputs are formalized, this should feed the
   -- resulting quadratic-form inequality into
   -- `FrustrationFree.spectralGap_of_martingale`.
@@ -309,7 +309,7 @@ the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`. The `LinearMap.IsPosi
 hypothesis required by `FrustrationFree.spectralGap_of_martingale` is
 automatic here because `H_N = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
 
-The proof below invokes the MPS-specific bridge
+The proof below invokes the MPS-specific Friedrichs-angle theorem
 `parentHamiltonianES_gap_bound_of_friedrichs`, whose proof is the remaining
 Friedrichs-angle and row-sum obligation. -/
 theorem parentHamiltonian_gapped
@@ -318,7 +318,7 @@ theorem parentHamiltonian_gapped
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
-  -- PROOF STRUCTURE: see bridge lemma
+  -- PROOF STRUCTURE: see the Friedrichs-angle theorem
   -- `parentHamiltonianES_gap_bound_of_friedrichs` for the planned proof route.
   -- Currently sorry-backed pending discharge of
   -- `parentHamiltonianES_gap_bound_of_friedrichs`.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -976,14 +976,14 @@ For MPS parent Hamiltonians, the spectral gap follows from a martingale
 criterion due to Kastoryano and
 Lucia~\cite{Kastoryano2018Martingale}.
 
-\begin{lemma}[Euclidean transport of the parent ground space]
-    \label{lem:parent_ground_space_es_kernel}
+\begin{theorem}[Euclidean transport of the parent ground space]
+    \label{thm:parent_ground_space_es_kernel}
     \lean{MPSTensor.parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES}
     \leanok
     Under the canonical $\ell^2$ transport of the $N$-site state space, the
     transported parent ground space is exactly the kernel of the transported
     parent Hamiltonian.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -976,6 +976,23 @@ For MPS parent Hamiltonians, the spectral gap follows from a martingale
 criterion due to Kastoryano and
 Lucia~\cite{Kastoryano2018Martingale}.
 
+\begin{lemma}[Euclidean transport of the parent ground space]
+    \label{lem:parent_ground_space_es_kernel}
+    \lean{MPSTensor.parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES}
+    \leanok
+    Under the canonical $\ell^2$ transport of the $N$-site state space, the
+    transported parent ground space is exactly the kernel of the transported
+    parent Hamiltonian.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is an immediate unraveling of the definitions: both constructions are
+    obtained from the same parent Hamiltonian by conjugating with the canonical
+    identification between the site space and its Euclidean-space avatar, so the
+    transported ground space is precisely the transported kernel.
+\end{proof}
+
 \begin{lemma}[Quadratic form to norm bound]\label{lem:quadratic_form_to_norm_bound}
     \lean{FrustrationFree.spectralGap_of_martingale}
     \leanok


### PR DESCRIPTION
## Summary
- add `MPSTensor.parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES` in `TNLean/MPS/ParentHamiltonian/Martingale.lean`
- add the simp wrapper `MPSTensor.mem_parentHamiltonianGroundSpaceES_iff`
- sync the parent-Hamiltonian blueprint chapter with a new `\leanok` Euclidean-transport lemma entry
- narrow the remaining martingale blocker comment so it reflects that the kernel-identification step is now formalized

## Scope
This is a **partial-progress infrastructure PR** for #460. It does **not** discharge the remaining `sorry`s in:
- `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`
- `MPSTensor.parentHamiltonian_gapped`
- `MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition`

What it does land is the clean transport theorem needed by the martingale endpoint:
under the canonical `WithLp` / `EuclideanSpace` identification, the transported parent ground space is exactly the kernel of the transported parent Hamiltonian. This removes one of the previously-audited blockers and leaves the remaining gap explicitly analytic: positivity packaging for the transported local terms plus the Friedrichs-angle / row-sum estimate.

## Verification
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/DegenerateGS.lean`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale TNLean.MPS.ParentHamiltonian.DegenerateGS`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/ParentHamiltonian/Martingale.lean TNLean/MPS/ParentHamiltonian/DegenerateGS.lean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

## Remaining blocker after this PR
The martingale side is now reduced to the genuinely missing quantitative input: a formal Friedrichs-angle / anti-commutator estimate for overlapping local terms together with a positivity package for the transported Hamiltonian.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive proof/lemma and documentation updates; no changes to core definitions or the still-sorry-backed spectral-gap arguments.
> 
> **Overview**
> Proves that the `EuclideanSpace`-transported parent-Hamiltonian ground space `parentHamiltonianGroundSpaceES` is exactly `LinearMap.ker (parentHamiltonianES ...)`, and adds a `[simp]` lemma `mem_parentHamiltonianGroundSpaceES_iff` to rewrite membership as `parentHamiltonianES v = 0`.
> 
> Updates martingale-method documentation/comments (including the remaining-blocker note) to reflect that the kernel-identification step is now formalized, and syncs the blueprint by adding a new `\leanok` theorem entry for this transport-to-kernel result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8a2ff9017f6b43c1e019b556b1900a15c841e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->