### PR TITLE
feat(MPS/CanonicalForm): discharge hFixUpgrade, audit hProjStep blocker (#599)

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -6,6 +6,9 @@ import TNLean.MPS.CanonicalForm.CyclicSectors
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.Irreducible.PeriodicBlocking
+import TNLean.QPF.Primitive
+import TNLean.Channel.Schwarz.Basic
+import TNLean.Channel.Semigroup.CPClosure
 
 /-!
 # Sector irreducibility helpers
@@ -371,6 +374,111 @@ theorem orbitSumProjection_eq_one_of_full_sector
           simp [Equiv.subLeft_apply]
     _ = 1 := hPsum
 
+/-- The fixed-point upgrade in `hLift_cyclicDecomp_mps_of_fixUpgrade` is automatic for the
+adjoint transfer map of an irreducible trace-preserving tensor.
+
+If an orthogonal projection `Q` satisfies `PreservesCorner Q ((transferMap A†)^m)`, then
+`((transferMap A†)^m) Q = Q`. The proof uses a positive definite fixed point `ρ` of
+`transferMap A`, the weighted trace identity `tr(ρ E†(X)) = tr(ρ X)`, and the PSD gap
+`Q - E†^[m](Q) = Q * E†^[m](1 - Q) * Q`. -/
+theorem hFixUpgrade_of_peripheral
+    [NeZero D]
+    {A : MPSTensor d D} {m : ℕ}
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleMap (transferMap (d := d) (D := D) A))
+    {Q : MatrixAlg D}
+    (hQproj : IsOrthogonalProjection Q)
+    (hQinv : PreservesCorner Q
+      ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m)) :
+    ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) Q = Q := by
+  classical
+  let E : MatrixEnd D := transferMap (d := d) (D := D) A
+  let T : MatrixEnd D := transferMap (d := d) (D := D) (fun i => (A i)ᴴ)
+  let F : MatrixEnd D := T ^ m
+  have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
+  obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ :=
+    exists_posSemidef_fixedPoint A hTP hDpos
+  have hρ_pd : ρ.PosDef :=
+    posSemidef_fixedPoint_isPosDef_of_irreducible A hIrr ρ hρ_psd hρ_ne hρ_fix
+  have hT_cp : IsCPMap T := by
+    simpa [T, MPSTensor.transferMap_apply, Kraus.map] using
+      transferMap_isCPMap (A := fun i => (A i)ᴴ)
+  have hF_cp : IsCPMap F := by
+    simpa [F] using (IsCPMap.pow (E := T) hT_cp m)
+  have hpow_one : ∀ n : ℕ, (T ^ n) (1 : MatrixAlg D) = 1 := by
+    intro n
+    induction n with
+    | zero =>
+        simp
+    | succ n ih =>
+        rw [pow_succ', Module.End.mul_apply, ih]
+        simpa [T, MPSTensor.transferMap_apply] using hTP
+  have hF_one : F (1 : MatrixAlg D) = 1 := by
+    simpa [F] using hpow_one m
+  have htrace_step :
+      ∀ X : MatrixAlg D, Matrix.trace (ρ * T X) = Matrix.trace (ρ * X) := by
+    intro X
+    calc
+      Matrix.trace (ρ * T X)
+          = Matrix.trace (Kraus.adjointMap (fun i => (A i)ᴴ) ρ * X) := by
+              simpa [T, MPSTensor.transferMap_apply, Kraus.map, Kraus.adjointMap] using
+                (Kraus.trace_mul_map_eq_trace_adjointMap_mul (K := fun i => (A i)ᴴ) ρ X)
+      _ = Matrix.trace (E ρ * X) := by
+            simp [E, MPSTensor.transferMap_apply, Kraus.adjointMap]
+      _ = Matrix.trace (ρ * X) := by rw [hρ_fix]
+  have htrace_pow :
+      ∀ n : ℕ, ∀ X : MatrixAlg D,
+        Matrix.trace (ρ * ((T ^ n) X)) = Matrix.trace (ρ * X) := by
+    intro n
+    induction n with
+    | zero =>
+        intro X
+        simp
+    | succ n ih =>
+        intro X
+        rw [pow_succ', Module.End.mul_apply]
+        calc
+          Matrix.trace (ρ * T ((T ^ n) X)) = Matrix.trace (ρ * ((T ^ n) X)) :=
+            htrace_step ((T ^ n) X)
+          _ = Matrix.trace (ρ * X) := ih X
+  have hFQ_corner : Q * F Q * Q = F Q := by
+    have h := hQinv (1 : MatrixAlg D)
+    simpa [F, Matrix.mul_assoc, hQproj.2] using h
+  have hOneSubQ_proj : IsOrthogonalProjection (1 - Q) :=
+    isOrthogonalProjection_one_sub Q hQproj
+  have hOneSubQ_psd : (1 - Q).PosSemidef := by
+    have hpsd : ((1 - Q) * (1 - Q)ᴴ).PosSemidef :=
+      Matrix.posSemidef_self_mul_conjTranspose (1 - Q)
+    have hEq : (1 - Q) * (1 - Q)ᴴ = 1 - Q := by
+      rw [hOneSubQ_proj.1.eq, hOneSubQ_proj.2]
+    rwa [hEq] at hpsd
+  have hFOneSubQ_psd : (F (1 - Q)).PosSemidef :=
+    hF_cp.isPositiveMap (1 - Q) hOneSubQ_psd
+  have hgap_eq : Q * F (1 - Q) * Q = Q - F Q := by
+    rw [map_sub, hF_one]
+    calc
+      Q * (1 - F Q) * Q = Q * Q - Q * F Q * Q := by
+        simp [Matrix.mul_assoc, mul_sub, sub_mul]
+      _ = Q - F Q := by
+        rw [hQproj.2, hFQ_corner]
+  have hGap_psd : (Q - F Q).PosSemidef := by
+    rw [← hgap_eq]
+    simpa [hQproj.1.eq, Matrix.mul_assoc] using
+      hFOneSubQ_psd.mul_mul_conjTranspose_same (B := Q)
+  have htr_FQ : Matrix.trace (ρ * F Q) = Matrix.trace (ρ * Q) := by
+    simpa [F] using htrace_pow m Q
+  have htr_gap : Matrix.trace (ρ * (Q - F Q)) = 0 := by
+    calc
+      Matrix.trace (ρ * (Q - F Q))
+          = Matrix.trace (ρ * Q) - Matrix.trace (ρ * F Q) := by
+              rw [Matrix.mul_sub, Matrix.trace_sub]
+      _ = 0 := by
+            rw [htr_FQ]
+            simp
+  have hGap_zero : Q - F Q = 0 :=
+    Kraus.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero hGap_psd hρ_pd htr_gap
+  exact (sub_eq_zero.mp hGap_zero).symm
+
 /-- Orbit-sum lift producing the `hLift` hypothesis required by
 `isIrreducible_restriction_of_cyclic_decomp`.
 
@@ -568,6 +676,62 @@ theorem hLift_cyclicDecomp_mps_of_fixUpgrade
       rw [hR1] at this
       simpa [(hPproj k).2] using this.symm
 
+/-- The orbit-sum lift with the `hFixUpgrade` input discharged by
+`hFixUpgrade_of_peripheral`.
+
+This reduces the remaining abstract input to the one-step projection
+preservation statement `hProjStep`. -/
+theorem hLift_cyclicDecomp_mps_of_projStep
+    [NeZero D] [NeZero m]
+    {A : MPSTensor d D}
+    (hIrrAdj :
+      IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)))
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (P : Fin m → MatrixAlg D)
+    (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hcyclic :
+      ∀ k : Fin m,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (hMulLeft :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k * X) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X)
+    (hMulRight :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (X * P k) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k))
+    (hProjStep :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        IsOrthogonalProjection X →
+        X * P k = X → P k * X = X →
+        IsOrthogonalProjection
+          (transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X)) :
+    ∀ k : Fin m, ∀ Q : MatrixAlg D,
+      IsOrthogonalProjection Q →
+      Q * P k = Q → P k * Q = Q →
+      PreservesCorner Q
+        ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) →
+      ∃ R : MatrixAlg D,
+        IsOrthogonalProjection R ∧
+        PreservesCorner R
+          (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ∧
+        (Q = 0 ↔ R = 0) ∧
+        (Q = P k ↔ R = 1) := by
+  have hIrrTensor : IsIrreducibleTensor (d := d) (D := D) A :=
+    isIrreducibleTensor_of_isIrreducibleMap_conjTranspose (A := A) hIrrAdj
+  have hIrr : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+    isIrreducibleCP_transferMap_of_isIrreducibleTensor A hIrrTensor
+  intro k Q hQproj hQP hPQ hQcorner
+  exact
+    hLift_cyclicDecomp_mps_of_fixUpgrade
+      (A := A) (m := m) hTP P hPproj hPsum hcyclic hMulLeft hMulRight hProjStep
+      (fun (_k : Fin m) (Q : MatrixAlg D) hQproj _hQP _hPQ hQinv =>
+        hFixUpgrade_of_peripheral (A := A) (m := m) hTP hIrr hQproj hQinv)
+      k Q hQproj hQP hPQ hQcorner
+
 /-- MPS-specialized wrapper: once the orbit-sum lift is constructed in the
 shape required by `isIrreducible_restriction_of_cyclic_decomp`, sector
 irreducibility follows immediately. -/
@@ -600,6 +764,46 @@ theorem isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift
     isIrreducible_restriction_of_cyclic_decomp
       (T := transferMap (d := d) (D := D) (fun i => (A i)ᴴ))
       hIrr P hPproj hPsum hcyclic hLift
+
+/-- MPS-specialized sector irreducibility, with only the one-step projection-preservation
+input `hProjStep` remaining abstract. -/
+theorem isIrreducibleOnCorner_of_cyclic_decomp_mps_of_projStep
+    [NeZero D] {A : MPSTensor d D}
+    [NeZero m]
+    (hIrr :
+      IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)))
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (P : Fin m → MatrixAlg D)
+    (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hcyclic :
+      ∀ k : Fin m,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (hMulLeft :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k * X) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X)
+    (hMulRight :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (X * P k) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k))
+    (hProjStep :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        IsOrthogonalProjection X →
+        X * P k = X → P k * X = X →
+        IsOrthogonalProjection
+          (transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X)) :
+    ∀ k : Fin m,
+      IsIrreducibleOnCorner
+        (P k) ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) := by
+  exact
+    isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift
+      (A := A) (m := m) hIrr P hPproj hPsum hcyclic
+      (hLift_cyclicDecomp_mps_of_projStep
+        (A := A) (m := m) hIrr hTP P hPproj hPsum hcyclic
+        hMulLeft hMulRight hProjStep)
 
 /-- MPS-specialized sector irreducibility, with the `hLift` input discharged by
 `hLift_cyclicDecomp_mps_of_fixUpgrade`. -/

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -6,7 +6,6 @@ import TNLean.MPS.CanonicalForm.CyclicSectors
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.Irreducible.PeriodicBlocking
-import TNLean.QPF.Primitive
 import TNLean.Channel.Schwarz.Basic
 import TNLean.Channel.Semigroup.CPClosure
 

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -6,7 +6,6 @@ import TNLean.MPS.CanonicalForm.CyclicSectors
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.Irreducible.PeriodicBlocking
-import TNLean.Channel.Schwarz.Basic
 import TNLean.Channel.Semigroup.CPClosure
 
 /-!

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -499,15 +499,16 @@ This assembles the in-file sublemmas
 matching the shape of the `hLift` argument of
 `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift`.
 
-The input `hFixUpgrade` reflects a genuine structural gap: for a general
-unital CP map `S`, `PreservesCorner Q S` does not imply `S Q = Q` — Kadison
-–Schwarz only yields `0 ≤ S Q ≤ Q` with `(S Q)(Q - S Q) ≥ 0`. Closing that
-upgrade requires domain-specific structure of the underlying Kraus operators
-that is not captured by the abstract sublemma signatures; see the
-block-diagonal canonical-form argument in `Papers/1708.00029/main.tex`,
-Lemma `lem:bdcf`. The `hProjStep` input is similarly abstract and expected
-to be discharged from an upstream multiplicative-domain / KS-equality
-argument on the MPS transfer map (same reference). -/
+The input `hFixUpgrade` is abstract only for the theorem signature: in the
+irreducible trace-preserving case it is discharged by
+`hFixUpgrade_of_peripheral`, using a positive definite fixed point of
+`transferMap A` and a weighted-trace argument. The remaining genuine
+structural gap is `hProjStep`: for a general unital CP map, sector support
+`X * P k = X = P k * X` does not imply that `T X` is again an orthogonal
+projection. Closing that step still appears to require the block-diagonal
+canonical-form argument in `Papers/1708.00029/main.tex`, Lemma `lem:bdcf`,
+or an equivalent multiplicative-domain bridge for sector-supported
+projections. -/
 theorem hLift_cyclicDecomp_mps_of_fixUpgrade
     [NeZero m]
     {A : MPSTensor d D}

--- a/audits/2026-04-21_issue599_hProjStep_hFixUpgrade_blocker.md
+++ b/audits/2026-04-21_issue599_hProjStep_hFixUpgrade_blocker.md
@@ -1,0 +1,93 @@
+# Issue #599 blocker report — April 21, 2026
+
+## Outcome
+
+I could **discharge `hFixUpgrade`**, but I could **not** honestly discharge `hProjStep` on current `main`.
+
+### Landed partial progress in `TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`
+
+I added:
+
+- `MPSTensor.hFixUpgrade_of_peripheral`
+- `MPSTensor.hLift_cyclicDecomp_mps_of_projStep`
+- `MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_projStep`
+
+So the remaining abstract input is now only the one-step projection-preservation hypothesis `hProjStep`.
+
+## What works: `hFixUpgrade`
+
+Let
+$$T := \operatorname{transferMap}(A^\dagger), \qquad F := T^m, \qquad E := \operatorname{transferMap}(A).$$
+
+For an irreducible TP tensor $A$, the primal channel $E$ has a positive definite fixed point $\rho$.
+If `PreservesCorner Q F` and `Q` is an orthogonal projection, then:
+
+1. $Q - F(Q) = Q\,F(1-Q)\,Q$, so $Q - F(Q)$ is positive semidefinite.
+2. Weighted trace is invariant: $\operatorname{tr}(\rho F(X)) = \operatorname{tr}(\rho X)$.
+3. Hence $\operatorname{tr}(\rho (Q - F(Q))) = 0$.
+4. Faithfulness of the weighted trace against $\rho > 0$ gives $Q - F(Q) = 0$.
+
+So `F Q = Q` is now formalized without any appeal to `lem:bdcf`.
+
+## Remaining blocker: `hProjStep`
+
+The unresolved goal is still:
+
+> if `X` is an orthogonal projection supported on the cyclic sector `P k`, show that
+> `transferMap (fun i => (A i)ᴴ) X` is again an orthogonal projection.
+
+### What current API already gives
+
+From `TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean` plus the existing cyclic-projection argument, we can prove only
+$$P_k \in \mathrm{MD}(T),$$
+where $\mathrm{MD}(T)$ denotes the multiplicative domain of the adjoint transfer map.
+This is exactly enough to derive the already-existing hypotheses
+
+- `hMulLeft`
+- `hMulRight`
+
+for the sector projections.
+
+### What is still missing
+
+To prove `hProjStep` via Kadison–Schwarz, one needs `X` itself to lie in the multiplicative domain, because projection preservation comes from
+$$T(X^2) = T(X)^2 \quad\text{and}\quad T(X^\dagger) = T(X)^\dagger.$$
+Since $X^2 = X$, this would imply $T(X)^2 = T(X)$.
+
+But current `main` has **no bridge** from
+$$X = P_k X = X P_k$$
+(or even from the stronger hypotheses that $X$ is a projection and is fixed by $T^m$)
+to
+$$X \in \mathrm{MD}(T).$$
+
+Concretely, the missing API is one of the following equivalent-strength statements:
+
+1. **Corner-subalgebra multiplicative-domain closure**
+   ```lean
+   X * P k = X → P k * X = X → X ∈ KadisonSchwarz.multiplicativeDomain K
+   ```
+   for all `X` in the `P k`-corner.
+
+2. **Specialized projection version**
+   sector-supported orthogonal projections (or at least those fixed by `(T^m)`) lie in the multiplicative domain of `T`.
+
+3. **Paper-level `lem:bdcf` fixed-point decomposition**
+   formalize the statement that for a single periodic block,
+   $$\operatorname{Fix}(E_A^m) = \operatorname{span}\{P_u \Lambda_A P_u\}_u,
+   \qquad
+   \operatorname{Fix}(E_A^{*m}) = \operatorname{span}\{P_u\}_u,$$
+   from which the required multiplicative-domain closure on each sector should follow.
+
+## Why I stopped here
+
+With the new weighted-trace argument, `hFixUpgrade` is no longer the blocker. The only remaining obstruction is exactly the missing bridge from **sector support** to **multiplicative-domain membership of the supported projection**. I could not find such an API in Mathlib or in the current TNLean periodic/cyclic-decomposition stack, and I did not want to fake it with a new axiom.
+
+## Recommended next step
+
+Open or repurpose a follow-up issue for the missing bridge, ideally phrased as:
+
+- `sector_supported_projection_mem_multiplicativeDomain`, or
+- the stronger `cornerSubmodule_mem_multiplicativeDomain`, or
+- a direct formalization of `lem:bdcf`.
+
+Once that lands, `hProjStep` should become straightforward, and the remaining abstract hypothesis in the orbit-sum lift will disappear.

--- a/audits/2026-04-21_issue599_hProjStep_hFixUpgrade_blocker.md
+++ b/audits/2026-04-21_issue599_hProjStep_hFixUpgrade_blocker.md
@@ -1,4 +1,6 @@
-# Issue #599 blocker report — April 21, 2026
+# Issue #599 blocker report — April 20, 2026
+
+> File name kept as `2026-04-21_...` to match the explicitly requested audit path for this task.
 
 ## Outcome
 

--- a/audits/2026-04-21_issue599_hProjStep_hFixUpgrade_blocker.md
+++ b/audits/2026-04-21_issue599_hProjStep_hFixUpgrade_blocker.md
@@ -1,4 +1,4 @@
-# Issue #599 blocker report — April 20, 2026
+# Issue #599 blocker report — April 21, 2026
 
 > File name kept as `2026-04-21_...` to match the explicitly requested audit path for this task.
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1311,6 +1311,32 @@ The following results separate the zero blocks from the
 	theorem from spectral theory.
 \end{proof}
 
+\begin{lemma}[Fixed-point upgrade from irreducibility and trace preservation]%
+	\label{lem:fix_upgrade_peripheral}
+	\lean{MPSTensor.hFixUpgrade_of_peripheral}
+	\leanok
+	\uses{thm:psd_fp_exists, thm:psd_fp_pd_irred,
+	      lem:trace_mul_map_eq_trace_adjointMap_mul,
+	      lem:posSemidef_eq_zero_of_posDef_trace_mul_eq_zero}
+	Let $A$ be a left-canonical MPS tensor whose transfer map $\E_A$ is
+	irreducible, and let $Q$ be an orthogonal projection such that the corner
+	$Q \mathcal M_D Q$ is preserved by $((\E_A^\dagger)^m)$. Then
+	$((\E_A^\dagger)^m)(Q) = Q$.
+\end{lemma}
+
+\begin{proof}\leanok
+	\uses{thm:psd_fp_exists, thm:psd_fp_pd_irred,
+	      lem:trace_mul_map_eq_trace_adjointMap_mul,
+	      lem:posSemidef_eq_zero_of_posDef_trace_mul_eq_zero}
+	Let $\rho > 0$ be the distinguished fixed point of $\E_A$. Since
+	$Q \mathcal M_D Q$ is preserved, the difference
+	$Q - (\E_A^\dagger)^m(Q)$ can be rewritten as
+	$Q\,(\E_A^\dagger)^m(\Id - Q)\,Q$, hence it is positive semidefinite.
+	The weighted trace pairing with $\rho$ is invariant under $(\E_A^\dagger)^m$,
+	so this positive semidefinite matrix has weighted trace zero. Faithfulness of
+	the $\rho$-weighted trace therefore forces it to vanish, giving the claim.
+\end{proof}
+
 \begin{lemma}[Orbit-sum construction of the sector lift]%
 	\label{lem:orbit_sum_hLift_construction}
 	\lean{MPSTensor.hLift_cyclicDecomp_mps_of_fixUpgrade}
@@ -1357,6 +1383,27 @@ The following results separate the zero blocks from the
 	Lemma~\ref{lem:orbit_sum_full_sector}.
 \end{proof}
 
+\begin{lemma}[Orbit-sum construction, projection-step variant]%
+	\label{lem:orbit_sum_hLift_proj_step}
+	\lean{MPSTensor.hLift_cyclicDecomp_mps_of_projStep}
+	\leanok
+	\uses{lem:fix_upgrade_peripheral, lem:orbit_sum_hLift_construction}
+	Let $A$ be a left-canonical MPS tensor with irreducible adjoint transfer
+	map, and let $(P_k)_{k=1}^m$ be cyclic orthogonal sector projections.
+	Assume the projection-step hypothesis of
+	Lemma~\ref{lem:orbit_sum_hLift_construction}. Then the orbit-sum lift holds:
+	for every orthogonal subprojection $Q \le P_k$ whose corner is preserved by
+	$(\E_A^\dagger)^m$, there is a global projection $R$ invariant under
+	$\E_A^\dagger$ with the same zero/full-sector tests.
+\end{lemma}
+
+\begin{proof}\leanok
+	\uses{lem:fix_upgrade_peripheral, lem:orbit_sum_hLift_construction}
+	Combine the original orbit-sum construction with
+	Lemma~\ref{lem:fix_upgrade_peripheral}, which supplies the fixed-point
+	upgrade from irreducibility and trace preservation.
+\end{proof}
+
 \begin{theorem}[Sector irreducibility from the orbit-sum construction]%
 	\label{thm:sector_irred_fix_upgrade}
 	\lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_fixUpgrade}
@@ -1373,6 +1420,24 @@ The following results separate the zero blocks from the
 	\uses{thm:sector_irred_orbit_lift, lem:orbit_sum_hLift_construction}
 	Apply Lemma~\ref{lem:orbit_sum_hLift_construction} to obtain the orbit-sum
 	lift, then apply Theorem~\ref{thm:sector_irred_orbit_lift}.
+\end{proof}
+
+\begin{theorem}[Sector irreducibility from the projection-step hypothesis]%
+	\label{thm:sector_irred_proj_step}
+	\lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_projStep}
+	\leanok
+	\uses{thm:sector_irred_orbit_lift, lem:orbit_sum_hLift_proj_step}
+	Let $A$ be a left-canonical MPS tensor with irreducible adjoint transfer
+	map, and let $(P_k)_{k=1}^m$ be cyclic orthogonal sector projections.
+	Assume only the projection-step hypothesis from
+	Lemma~\ref{lem:orbit_sum_hLift_construction}. Then $(\E_A^\dagger)^m$
+	is irreducible on each corner $P_k$.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:sector_irred_orbit_lift, lem:orbit_sum_hLift_proj_step}
+	Apply Lemma~\ref{lem:orbit_sum_hLift_proj_step} and then
+	Theorem~\ref{thm:sector_irred_orbit_lift}.
 \end{proof}
 
 \section{Reduction to primitive blocks}%

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1401,7 +1401,9 @@ The following results separate the zero blocks from the
 	\uses{lem:fix_upgrade_peripheral, lem:orbit_sum_hLift_construction}
 	Combine the original orbit-sum construction with
 	Lemma~\ref{lem:fix_upgrade_peripheral}, which supplies the fixed-point
-	upgrade from irreducibility and trace preservation.
+	upgrade from irreducibility and trace preservation. The irreducibility
+	hypothesis needed there is obtained by transporting irreducibility from the
+	adjoint transfer map to the tensor and then back to the primal transfer map.
 \end{proof}
 
 \begin{theorem}[Sector irreducibility from the orbit-sum construction]%


### PR DESCRIPTION
## Summary

This draft PR makes partial progress on issue #599.

### Lean changes
- add `MPSTensor.hFixUpgrade_of_peripheral` in `TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`
  - discharges the fixed-point-upgrade hypothesis using a positive definite fixed point of `transferMap A`
  - proof route: weighted trace invariance + PSD gap `Q - E†^[m](Q) = Q * E†^[m](1 - Q) * Q`
- add `MPSTensor.hLift_cyclicDecomp_mps_of_projStep`
  - removes the abstract `hFixUpgrade` input, leaving only `hProjStep`
- add `MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_projStep`
  - corresponding corner-irreducibility wrapper with only `hProjStep` remaining abstract
- add blocker audit
  - `audits/2026-04-21_issue599_hProjStep_hFixUpgrade_blocker.md`

### Remaining blocker
The one-step projection-preservation hypothesis `hProjStep` is still not discharged honestly on current `main`.
The current multiplicative-domain API proves only `P k ∈ KadisonSchwarz.multiplicativeDomain K`, which is enough for `hMulLeft` / `hMulRight`, but not the missing bridge
`X * P k = X` and `P k * X = X` ⟹ `X ∈ KadisonSchwarz.multiplicativeDomain K`.
The audit file explains the exact missing bridge and how it relates to `lem:bdcf`.

## Verification
- `lake env lean TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`
- `lake build TNLean.MPS.CanonicalForm.SectorIrreducibility`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

## Scope / non-scope
- touched files:
  - `TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`
  - `audits/2026-04-21_issue599_hProjStep_hFixUpgrade_blocker.md`
- did **not** edit forbidden periodic / MPDO / parent-Hamiltonian files
- issue #599 is **not closed** by this draft PR; the remaining work is exactly `hProjStep`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds nontrivial new Lean proofs and rewires key canonical-form/irreducibility lemmas; risk is mainly proof fragility and downstream breakage from strengthened assumptions/imports, not runtime behavior.
> 
> **Overview**
> **Discharges the previously-abstract `hFixUpgrade` step** in the cyclic-sector irreducibility bridge by adding `MPSTensor.hFixUpgrade_of_peripheral`, showing that for irreducible trace-preserving tensors corner preservation of an orthogonal projection under `((transferMap A†)^m)` implies `((transferMap A†)^m) Q = Q` (via PD fixed point + weighted-trace/PSD-gap argument).
> 
> Adds `hLift_cyclicDecomp_mps_of_projStep` and `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_projStep` wrappers that bake in this upgrade, so the remaining abstract assumption for sector irreducibility proofs is only the one-step projection preservation hypothesis `hProjStep`. Also adds an audit note (`audits/2026-04-21_issue599_hProjStep_hFixUpgrade_blocker.md`) documenting the remaining blocker and proposed follow-up API, and updates the blueprint to reference the new lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55dc3d8c81a2a241ce17f5d1e0c138eb756b13b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->