### PR TITLE
chore(Channel/Schwarz): audit false corner-support multiplicative-domain claim (#599)

### DIFF
--- a/audits/2026-04-21_issue599_corner_multiplicativeDomain_counterexample.md
+++ b/audits/2026-04-21_issue599_corner_multiplicativeDomain_counterexample.md
@@ -1,0 +1,117 @@
+# Issue #599 follow-up — corner-support to multiplicative-domain is false as stated
+
+## Outcome
+
+I did **not** add a theorem to `TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean`.
+After inspecting the current multiplicative-domain API and testing the proposed
+statement in a scratch file, I found that the intended theorem is **false even
+for unital selfadjoint TP Kraus maps**.
+
+So the obstruction on PR #696 is **not** a missing Lean lemma of the exact form
+
+```lean
+P * X = X → X * P = X → X ∈ KadisonSchwarz.multiplicativeDomain K
+```
+
+with `P ∈ MD(T)` fixed by `T`. One needs a stronger hypothesis describing the
+**fixed-point algebra inside the corner**, not just corner support.
+
+## Explicit counterexample
+
+Take the dephasing channel on `M₂(ℂ)` with Kraus family
+
+$$K_0 = E_{00}, \qquad K_1 = E_{11},$$
+
+so
+
+$$T(X) = K_0 X K_0^\dagger + K_1 X K_1^\dagger$$
+
+is the diagonal conditional expectation.
+
+Set
+
+$$P := 1, \qquad X := E_{01}.$$
+
+Then:
+
+1. `P` is an orthogonal projection.
+2. `T(P) = P`.
+3. `P ∈ KadisonSchwarz.multiplicativeDomain K` by
+   `KadisonSchwarz.one_mem_multiplicativeDomain`.
+4. `P * X = X = X * P`.
+
+But `X` is **not** in the multiplicative domain, because
+
+$$T(XX^\dagger) = T(E_{00}) = E_{00},$$
+while
+$$T(X)T(X)^\dagger = 0.$$
+
+Hence
+
+$$T(XX^\dagger) \ne T(X)T(X)^\dagger,$$
+
+so `X ∉ KadisonSchwarz.rightMultiplicativeDomain K`, therefore
+`X ∉ KadisonSchwarz.multiplicativeDomain K`.
+
+This already refutes the proposed theorem in the strongest possible way:
+choosing `P = 1` makes the corner condition vacuous, so the statement would
+force `MD(T) = M₂(ℂ)` for every unital CP map.
+
+## Checked scratch formalization
+
+I verified the concrete counterexample in the worktree-local scratch file
+
+```text
+Scratch/Issue599Counterexample.lean
+```
+
+with
+
+```bash
+cd .worktrees/issue-599-mult-domain && lake env lean Scratch/Issue599Counterexample.lean
+```
+
+The scratch file proves:
+
+- `dephasingKraus_unital : KadisonSchwarz.IsUnitalKraus dephasingKraus`
+- `offDiag_not_mem_multiplicativeDomain :
+    E01 ∉ KadisonSchwarz.multiplicativeDomain dephasingKraus`
+- the support equalities `1 * E01 = E01` and `E01 * 1 = E01`
+
+I am **not** committing that scratch file, since the correct deliverable here is
+an audit, not a new negative theorem in the library.
+
+## What current TNLean already proves nearby
+
+There is already a valid fixed-point-to-multiplicative-domain result:
+
+- `Kraus.mem_multiplicativeDomain_of_mem_fixedPoints`
+- `Kraus.fixedPoints_in_multiplicativeDomain`
+
+in `TNLean/Channel/FixedPoint/Algebra.lean`.
+
+So if an element is an actual fixed point of the channel (under the usual
+faithful invariant-state hypotheses), then multiplicative-domain membership is
+available. What fails is the attempted shortcut from **corner support alone**.
+
+## Implication for PR #696 / issue #599
+
+The remaining gap for `hProjStep` cannot be closed by a theorem whose only new
+input is
+
+- `P ∈ MD(T)`,
+- `T(P) = P`, and
+- `P X = X = X P`.
+
+That theorem is false.
+
+The right next target has to involve one of the following stronger statements:
+
+1. a description of the fixed points of the sector-restricted map,
+2. a sectorwise fixed-point decomposition of Wolf-type `Fix(T^m)` / `Fix((T^*)^m)`, or
+3. a theorem identifying the corner dynamics with a genuine `*`-homomorphism or
+   conditional expectation on the relevant fixed-point algebra.
+
+In other words: for #599 the missing ingredient is a **fixed-point-algebra
+statement**, not a pure multiplicative-domain closure statement for corner
+support.


### PR DESCRIPTION
## Summary

Follow-up to issue #599 and draft PR #696.

I investigated the proposed Schwarz-side theorem that a corner-supported matrix
`X` should lie in the multiplicative domain once the supporting projection `P`
is fixed and already lies in the multiplicative domain. After checking the
existing TNLean / Mathlib API and testing the claim in a scratch file, the
result is:

- the proposed theorem is **false as stated**;
- the obstruction on #696 is therefore **not** a missing lemma of that exact form;
- the correct next target for `hProjStep` has to be a **fixed-point algebra** statement,
  not a pure corner-support statement.

This PR records the diagnosis in:

- `audits/2026-04-21_issue599_corner_multiplicativeDomain_counterexample.md`

## Main finding

The counterexample is the $2 \times 2$ dephasing channel
$T(X) = E_{00} X E_{00} + E_{11} X E_{11}$.
Taking $P = 1$ and $X = E_{01}$ gives:

- `P` is an orthogonal projection,
- `T(P) = P`,
- `P ∈ KadisonSchwarz.multiplicativeDomain K`,
- `P * X = X = X * P`,
- but `X ∉ KadisonSchwarz.multiplicativeDomain K` because
  $T(XX^\dagger) = E_{00} \neq 0 = T(X)T(X)^\dagger$.

So corner support alone cannot imply multiplicative-domain membership.

## Scratch verification

I checked the concrete counterexample locally in an uncommitted scratch file:

- `Scratch/Issue599Counterexample.lean`

with

```bash
cd .worktrees/issue-599-mult-domain && lake env lean Scratch/Issue599Counterexample.lean
```

## Verification

- `cd .worktrees/issue-599-mult-domain && lake env lean Scratch/Issue599Counterexample.lean`
- `cd .worktrees/issue-599-mult-domain && lake build`

The full build succeeds; only the repository's pre-existing warnings / admitted declarations remain.

## Relation to #696

This does **not** unblock #696 directly. Instead it refines the blocker:
`hProjStep` needs a stronger input describing the fixed-point algebra on each
sector (for example a Wolf-style fixed-point decomposition of `Fix(T^m)` /
`Fix((T^*)^m)`), not just a theorem saying `P X = X = X P` forces
`X ∈ MD(T)`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an audit markdown note only; no Lean code or runtime behavior changes, so risk is limited to documentation accuracy.
> 
> **Overview**
> Records an audit for issue #599 explaining that the proposed lemma “corner support (`P*X=X=X*P`) plus `P` fixed and in `MD(T)` implies `X ∈ MD(T)`” is **false**, and therefore is not the blocker for PR #696.
> 
> Adds a concrete `M₂(ℂ)` dephasing-channel counterexample (with `P = 1`, `X = E_{01}`) and points future work toward stronger *fixed-point algebra* hypotheses rather than a pure multiplicative-domain closure statement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af793fc6696736fa5f811c4d11be1062768786fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->