### PR TITLE
feat(MPS/ParentHamiltonian): add suffix-window API for range reduction (#699)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -161,6 +161,7 @@ import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
+import TNLean.MPS.ParentHamiltonian.SuffixWindow
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 import TNLean.MPS.ParentHamiltonian.DegenerateGS

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -29,6 +29,8 @@ of the parent Hamiltonian (see `UniqueGroundState.lean`).
 
 * `MPSTensor.groundSpace_inLeftGround` — forward direction, left window
 * `MPSTensor.groundSpace_inRightGround` — forward direction, right window
+* `MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top` — injectivity from
+  full word span at length `L`
 * `MPSTensor.groundSpaceMap_injective` — injectivity for injective tensors
 * `MPSTensor.groundSpace_finrank_eq` — dimension equals `D²`
 * `MPSTensor.groundSpace_intersection` — the intersection property
@@ -166,37 +168,14 @@ theorem groundSpace_inRightGround (A : MPSTensor d D) (L : ℕ)
 
 /-! ### Injectivity of the ground-space map -/
 
-/-- For an injective tensor, `groundSpaceMap A L` is injective for any `L ≥ 1`.
-
-**Proof sketch**: It suffices to show `groundSpaceMap A L X = 0 → X = 0`.
-If `tr(A^σ · X) = 0` for all words `σ` of length `L`, and the set `{A^σ}`
-spans `M_D(ℂ)` (which holds for `L ≥ 1` by the injectivity hypothesis),
-then nondegeneracy of the trace pairing gives `X = 0`. -/
-theorem groundSpaceMap_injective {A : MPSTensor d D} (hA : IsInjective A)
-    {L : ℕ} (hL : 0 < L) :
+/-- If the length-`L` word span is all of `M_D(ℂ)`, then `groundSpaceMap A L`
+is injective. -/
+theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ}
+    (hwordL : wordSpan A L = ⊤) :
     Function.Injective (groundSpaceMap A L) := by
   have hker : (groundSpaceMap A L).ker = ⊥ := by
     apply (LinearMap.ker_eq_bot').2
     intro X hX
-    have hword1 : wordSpan A 1 = ⊤ := by
-      have hRange :
-          Set.range (fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ)) = Set.range A := by
-        ext M
-        constructor
-        · rintro ⟨σ, rfl⟩
-          exact ⟨σ 0, by simp [evalWord]⟩
-        · rintro ⟨i, rfl⟩
-          exact ⟨fun _ => i, by simp [evalWord]⟩
-      change Submodule.span ℂ (Set.range fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ)) = ⊤
-      rw [hRange]
-      exact hA
-    have hone : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A 1 := by
-      rw [hword1]
-      exact Submodule.mem_top
-    have hwordL : wordSpan A L = ⊤ := by
-      have hmono : wordSpan A 1 ≤ wordSpan A L :=
-        wordSpan_mono'_of_one_mem_wordSpan_one A hone (by omega)
-      exact eq_top_iff.mpr (by simpa [hword1] using hmono)
     have hφ :
         (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
       apply LinearMap.ext_on_range
@@ -212,6 +191,35 @@ theorem groundSpaceMap_injective {A : MPSTensor d D} (hA : IsInjective A)
         Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
         _ = 0 := hNX
   exact LinearMap.ker_eq_bot.mp hker
+
+/-- For an injective tensor, `groundSpaceMap A L` is injective for any `L ≥ 1`.
+
+**Proof sketch**: injectivity gives `wordSpan A 1 = ⊤`; since `1 ∈ wordSpan A 1`,
+monotonicity of word spans yields `wordSpan A L = ⊤` for all `L ≥ 1`, and the
+previous theorem applies. -/
+theorem groundSpaceMap_injective {A : MPSTensor d D} (hA : IsInjective A)
+    {L : ℕ} (hL : 0 < L) :
+    Function.Injective (groundSpaceMap A L) := by
+  have hword1 : wordSpan A 1 = ⊤ := by
+    have hRange :
+        Set.range (fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ)) = Set.range A := by
+      ext M
+      constructor
+      · rintro ⟨σ, rfl⟩
+        exact ⟨σ 0, by simp [evalWord]⟩
+      · rintro ⟨i, rfl⟩
+        exact ⟨fun _ => i, by simp [evalWord]⟩
+    change Submodule.span ℂ (Set.range fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ)) = ⊤
+    rw [hRange]
+    exact hA
+  have hone : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A 1 := by
+    rw [hword1]
+    exact Submodule.mem_top
+  have hwordL : wordSpan A L = ⊤ := by
+    have hmono : wordSpan A 1 ≤ wordSpan A L :=
+      wordSpan_mono'_of_one_mem_wordSpan_one A hone (by omega)
+    exact eq_top_iff.mpr (by simpa [hword1] using hmono)
+  exact groundSpaceMap_injective_of_wordSpan_eq_top hwordL
 
 /-- For an injective tensor, the ground space has dimension exactly `D²` for `L ≥ 1`.
 

--- a/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import TNLean.MPS.Chain.BlockedChainFT
 import Mathlib.Data.Fin.Tuple.Basic
 
 /-!
@@ -79,8 +80,7 @@ produces the expected boundary matrix `A j * X`. -/
     (j : Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
     restrictLast (groundSpaceMap A (L + 1) X) j = groundSpaceMap A L (A j * X) := by
   ext σ
-  change Matrix.trace (evalWord A (List.ofFn (Fin.snoc σ j)) * X) =
-    Matrix.trace (evalWord A (List.ofFn σ) * (A j * X))
+  simp only [restrictLast_apply, groundSpaceMap_apply]
   rw [evalWord_ofFn_snoc]
   simp [Matrix.mul_assoc]
 
@@ -89,24 +89,14 @@ injective. -/
 theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ}
     (hwordL : wordSpan A L = ⊤) :
     Function.Injective (groundSpaceMap A L) := by
-  have hker : (groundSpaceMap A L).ker = ⊥ := by
-    apply (LinearMap.ker_eq_bot').2
-    intro X hX
-    have hφ :
-        (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
-      apply LinearMap.ext_on_range
-        (v := fun σ : Fin L → Fin d => evalWord A (List.ofFn σ))
-      · simpa [wordSpan] using hwordL
-      · intro σ
-        simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
-          congrArg (fun ψ => ψ σ) hX
-    exact trace_mul_right_eq_zero fun N => by
-      have hNX : Matrix.trace (N * X) = 0 := by
-        simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
-      calc
-        Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
-        _ = 0 := hNX
-  exact LinearMap.ker_eq_bot.mp hker
+  have hBlkInj : IsInjective (blockTensor A L) := by
+    exact (isNBlkInjective_iff_blockTensor_isInjective A L).mp
+      ((wordSpan_eq_top_iff_isNBlkInjective A L).mp hwordL)
+  intro X Y hXY
+  apply groundSpaceMap_injective hBlkInj (show 0 < 1 by omega)
+  ext σ
+  have hXY' := congrArg (fun ψ => ψ (decodeBlock d L (σ 0))) hXY
+  simpa [groundSpaceMap_apply, blockTensor, wordOfBlock, decodeBlock] using hXY'
 
 /-- Block injectivity at length `L` implies injectivity of `groundSpaceMap A L`. -/
 theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D} {L : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
-import TNLean.MPS.Chain.BlockedChainFT
 import Mathlib.Data.Fin.Tuple.Basic
 
 /-!
@@ -83,20 +82,6 @@ produces the expected boundary matrix `A j * X`. -/
   simp only [restrictLast_apply, groundSpaceMap_apply]
   rw [evalWord_ofFn_snoc]
   simp [Matrix.mul_assoc]
-
-/-- If the length-`L` word span is all of `M_D`, then `groundSpaceMap A L` is
-injective. -/
-theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ}
-    (hwordL : wordSpan A L = ⊤) :
-    Function.Injective (groundSpaceMap A L) := by
-  have hBlkInj : IsInjective (blockTensor A L) := by
-    exact (isNBlkInjective_iff_blockTensor_isInjective A L).mp
-      ((wordSpan_eq_top_iff_isNBlkInjective A L).mp hwordL)
-  intro X Y hXY
-  apply groundSpaceMap_injective hBlkInj (show 0 < 1 by omega)
-  ext σ
-  have hXY' := congrArg (fun ψ => ψ (decodeBlock d L (σ 0))) hXY
-  simpa [groundSpaceMap_apply, blockTensor, wordOfBlock, decodeBlock] using hXY'
 
 /-- Block injectivity at length `L` implies injectivity of `groundSpaceMap A L`. -/
 theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D} {L : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import Mathlib.Data.Fin.Tuple.Basic
+
+/-!
+# Suffix-window restrictions for parent-Hamiltonian ground spaces
+
+This file introduces restriction maps obtained by fixing a prefix and reading the
+last `L` sites of a state on `K + L` sites. It records the resulting matrix
+identities needed for the open-chain range-reduction argument in
+[CPGSV21, §IV.C].
+
+## Main results
+
+- `MPSTensor.tailRestrictₗ` — fix a prefix and restrict to the suffix window
+- `Fin.snoc_append` — compatibility of `Fin.snoc` with `Fin.append`
+- `MPSTensor.tailRestrictₗ_groundSpaceMap` — suffix restriction preserves the
+  ground-space form
+- `MPSTensor.groundSpace_inTailGround` — a ground-space state restricts to
+  ground-space states on every suffix slice
+- `MPSTensor.exists_left_tail_compatibility` — extract matrices satisfying
+  `Z j * evalWord A (List.ofFn u) = A j * Y u`
+
+## References
+
+* [CPGSV21] arXiv:2011.12127, lines 2049–2078
+-/
+
+open scoped Matrix
+
+namespace Fin
+
+variable {d K L : ℕ}
+
+/-- Appending a prefix commutes with adding a final site by `Fin.snoc`. -/
+theorem snoc_append (u : Fin K → Fin d) (σ : Fin L → Fin d) (j : Fin d) :
+    (Fin.snoc (Fin.append u σ) j : Fin (K + L + 1) → Fin d) =
+      Fin.append u (Fin.snoc σ j) := by
+  simpa using (Fin.append_snoc u σ j).symm
+
+end Fin
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Suffix restriction: fixing a prefix `u : Fin K → Fin d` and keeping the last
+`L` sites of a state on `K + L` sites. -/
+def tailRestrictₗ {d K L : ℕ} (u : Fin K → Fin d) :
+    NSiteSpace d (K + L) →ₗ[ℂ] NSiteSpace d L where
+  toFun ψ := fun σ => ψ (Fin.append u σ)
+  map_add' ψ₁ ψ₂ := by
+    ext σ
+    simp
+  map_smul' c ψ := by
+    ext σ
+    simp
+
+@[simp] theorem tailRestrictₗ_apply {d K L : ℕ} (u : Fin K → Fin d)
+    (ψ : NSiteSpace d (K + L)) (σ : Fin L → Fin d) :
+    tailRestrictₗ u ψ σ = ψ (Fin.append u σ) :=
+  rfl
+
+/-- Restricting the last site after fixing a prefix is the same as first
+restricting the last site and then fixing the prefix. -/
+@[simp] theorem tailRestrictₗ_restrictLast {d K L : ℕ} (u : Fin K → Fin d)
+    (ψ : NSiteSpace d (K + L + 1)) (j : Fin d) :
+    restrictLast (tailRestrictₗ u ψ) j = tailRestrictₗ u (restrictLast ψ j) := by
+  ext σ
+  simp [Fin.snoc_append]
+
+/-- Restricting a ground-space vector of length `L + 1` by fixing the last site
+produces the expected boundary matrix `A j * X`. -/
+@[simp] theorem restrictLast_groundSpaceMap (A : MPSTensor d D) {L : ℕ}
+    (j : Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
+    restrictLast (groundSpaceMap A (L + 1) X) j = groundSpaceMap A L (A j * X) := by
+  ext σ
+  change Matrix.trace (evalWord A (List.ofFn (Fin.snoc σ j)) * X) =
+    Matrix.trace (evalWord A (List.ofFn σ) * (A j * X))
+  rw [evalWord_ofFn_snoc]
+  simp [Matrix.mul_assoc]
+
+/-- If the length-`L` word span is all of `M_D`, then `groundSpaceMap A L` is
+injective. -/
+theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ}
+    (hwordL : wordSpan A L = ⊤) :
+    Function.Injective (groundSpaceMap A L) := by
+  have hker : (groundSpaceMap A L).ker = ⊥ := by
+    apply (LinearMap.ker_eq_bot').2
+    intro X hX
+    have hφ :
+        (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
+      apply LinearMap.ext_on_range
+        (v := fun σ : Fin L → Fin d => evalWord A (List.ofFn σ))
+      · simpa [wordSpan] using hwordL
+      · intro σ
+        simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
+          congrArg (fun ψ => ψ σ) hX
+    exact trace_mul_right_eq_zero fun N => by
+      have hNX : Matrix.trace (N * X) = 0 := by
+        simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
+      calc
+        Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
+        _ = 0 := hNX
+  exact LinearMap.ker_eq_bot.mp hker
+
+/-- Block injectivity at length `L` implies injectivity of `groundSpaceMap A L`. -/
+theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D} {L : ℕ}
+    (hInj : IsNBlkInjective A L) :
+    Function.Injective (groundSpaceMap A L) :=
+  groundSpaceMap_injective_of_wordSpan_eq_top
+    ((wordSpan_eq_top_iff_isNBlkInjective A L).mpr hInj)
+
+/-- Restricting a ground-space vector to a suffix slice preserves the ground-space
+form, with the prefix word moved to the right boundary matrix by trace cyclicity. -/
+@[simp] theorem tailRestrictₗ_groundSpaceMap (A : MPSTensor d D) {K L : ℕ}
+    (u : Fin K → Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
+    tailRestrictₗ u (groundSpaceMap A (K + L) X) =
+      groundSpaceMap A L (X * evalWord A (List.ofFn u)) := by
+  ext σ
+  calc
+    tailRestrictₗ u (groundSpaceMap A (K + L) X) σ
+        = Matrix.trace (evalWord A (List.ofFn (Fin.append u σ)) * X) := by
+            simp [groundSpaceMap_apply]
+    _ = Matrix.trace (evalWord A (List.ofFn σ) * (X * evalWord A (List.ofFn u))) := by
+          rw [List.ofFn_fin_append, evalWord_append]
+          symm
+          simpa [Matrix.mul_assoc] using
+            (Matrix.trace_mul_cycle'
+              (evalWord A (List.ofFn σ))
+              X
+              (evalWord A (List.ofFn u)))
+    _ = groundSpaceMap A L (X * evalWord A (List.ofFn u)) σ := by
+          simp [groundSpaceMap_apply]
+
+/-- A state on `K + L` sites lies in the tail ground condition if every fixed
+prefix gives an `L`-site ground-space vector. -/
+def InTailGround (A : MPSTensor d D) (K L : ℕ) (ψ : NSiteSpace d (K + L)) : Prop :=
+  ∀ u : Fin K → Fin d, tailRestrictₗ u ψ ∈ groundSpace A L
+
+/-- A ground-space vector restricts to a ground-space vector on every suffix
+slice. -/
+theorem groundSpace_inTailGround (A : MPSTensor d D) (K L : ℕ)
+    {ψ : NSiteSpace d (K + L)} (hψ : ψ ∈ groundSpace A (K + L)) :
+    InTailGround A K L ψ := by
+  intro u
+  rw [groundSpace, LinearMap.mem_range] at hψ ⊢
+  obtain ⟨X, rfl⟩ := hψ
+  refine ⟨X * evalWord A (List.ofFn u), ?_⟩
+  exact (tailRestrictₗ_groundSpaceMap (A := A) u X).symm
+
+/-- From the long left-window condition and the suffix-window condition, extract
+boundary matrices satisfying the common overlap identity
+`Z j * evalWord A (List.ofFn u) = A j * Y u`. -/
+theorem exists_left_tail_compatibility {A : MPSTensor d D} {K L₀ : ℕ}
+    (hInj : IsNBlkInjective A L₀) {ψ : NSiteSpace d (K + L₀ + 1)}
+    (hLeft : InLeftGround A (K + L₀) ψ)
+    (hTail : InTailGround A K (L₀ + 1) ψ) :
+    ∃ Z : Fin d → Matrix (Fin D) (Fin D) ℂ,
+      ∃ Y : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ,
+        (∀ j : Fin d, restrictLast ψ j = groundSpaceMap A (K + L₀) (Z j)) ∧
+        (∀ u : Fin K → Fin d, tailRestrictₗ u ψ = groundSpaceMap A (L₀ + 1) (Y u)) ∧
+        (∀ (j : Fin d) (u : Fin K → Fin d),
+          Z j * evalWord A (List.ofFn u) = A j * Y u) := by
+  have hLeft' :
+      ∀ j : Fin d, ∃ Z : Matrix (Fin D) (Fin D) ℂ,
+        restrictLast ψ j = groundSpaceMap A (K + L₀) Z := by
+    intro j
+    have hj := hLeft j
+    rw [groundSpace, LinearMap.mem_range] at hj
+    rcases hj with ⟨Z, hZ⟩
+    exact ⟨Z, hZ.symm⟩
+  choose Z hZ using hLeft'
+  have hTail' :
+      ∀ u : Fin K → Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+        tailRestrictₗ u ψ = groundSpaceMap A (L₀ + 1) Y := by
+    intro u
+    have hu := hTail u
+    rw [groundSpace, LinearMap.mem_range] at hu
+    rcases hu with ⟨Y, hY⟩
+    exact ⟨Y, hY.symm⟩
+  choose Y hY using hTail'
+  have hCompat : ∀ (j : Fin d) (u : Fin K → Fin d),
+      Z j * evalWord A (List.ofFn u) = A j * Y u := by
+    intro j u
+    apply groundSpaceMap_injective_of_isNBlkInjective hInj
+    have hLeftSlice :
+        tailRestrictₗ u (restrictLast ψ j) =
+          groundSpaceMap A L₀ (Z j * evalWord A (List.ofFn u)) := by
+      rw [hZ j]
+      exact tailRestrictₗ_groundSpaceMap (A := A) u (Z j)
+    have hTailSlice :
+        tailRestrictₗ u (restrictLast ψ j) = groundSpaceMap A L₀ (A j * Y u) := by
+      calc
+        tailRestrictₗ u (restrictLast ψ j)
+            = restrictLast (tailRestrictₗ u ψ) j := by
+                exact (tailRestrictₗ_restrictLast (u := u) (ψ := ψ) (j := j)).symm
+        _ = restrictLast (groundSpaceMap A (L₀ + 1) (Y u)) j := by
+              rw [hY u]
+        _ = groundSpaceMap A L₀ (A j * Y u) := by
+              exact restrictLast_groundSpaceMap (A := A) (j := j) (X := Y u)
+    exact hLeftSlice.symm.trans hTailSlice
+  exact ⟨Z, Y, hZ, hY, hCompat⟩
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -411,6 +411,53 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:ground_space_intersection} at each step.
 \end{proof}
 
+\begin{definition}[Suffix restriction]\label{def:tail_restrict_parent}
+    \lean{MPSTensor.tailRestrictₗ}
+    \leanok
+    Fix a prefix $u : \Fin K \to \Fin d$. The suffix restriction of an
+    $(K+L)$-site state $\psi$ is the $L$-site state given by
+    \[
+        (\operatorname{tailRestrict}_u \psi)(\sigma) = \psi(u,\sigma).
+    \]
+\end{definition}
+
+\begin{definition}[Suffix ground membership]\label{def:in_tail_ground}
+    \lean{MPSTensor.InTailGround}
+    \leanok
+    \uses{def:tail_restrict_parent, def:ground_space_parent}
+    A state $\psi$ on $K+L$ sites lies in the suffix ground condition if every
+    fixed prefix $u$ gives a suffix state in $G_L(A)$.
+\end{definition}
+
+\begin{lemma}[Left-tail compatibility]\label{lem:left_tail_compatibility}
+    \lean{MPSTensor.exists_left_tail_compatibility}
+    \leanok
+    \uses{def:in_left_ground, def:in_tail_ground, def:ground_space_parent}
+    Assume $\psi$ on $K+L_0+1$ sites satisfies the left ground condition on the
+    first $K+L_0$ sites and the suffix ground condition on every fixed prefix of
+    length $K$. Then there exist matrices $(Z_j)_j$ and $(Y_u)_u$ such that
+    \[
+        \psi(\sigma,j) = \tr(A^\sigma Z_j), \qquad
+        \psi(u,\tau) = \tr(A^\tau Y_u),
+    \]
+    and for all $j$ and $u$,
+    \[
+        Z_j A^u = A_j Y_u.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Choose $Z_j$ from the long left-window condition and $Y_u$ from the suffix
+    ground condition. Restricting the suffix state at its last site gives the
+    boundary matrix $A_j Y_u$, while first fixing the last site and then taking
+    the suffix gives $Z_j A^u$. The two restrictions are the same because
+    appending the fixed prefix and then the last letter gives the same
+    configuration as appending the last letter to the suffix and then placing
+    the prefix in front. Injectivity of $\Gamma_{L_0}$, obtained from
+    $L_0$-block injectivity, yields $Z_j A^u = A_j Y_u$.
+\end{proof}
+
 \begin{definition}[MPV submodule]\label{def:mpv_submodule}
     \lean{MPSTensor.mpvSubmodule}
     \leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -306,6 +306,21 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \subsection{Injectivity of the ground-space map}
 
+\begin{lemma}[Ground-space map injectivity from full word span]%
+    \label{lem:ground_space_map_injective_word_span}
+    \lean{MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top}
+    \leanok
+    \uses{def:ground_space_map, def:word_span}
+    If $S_L(A) = \MN{D}$, then $\Gamma_L$ is injective.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    If $\Gamma_L(X) = 0$, then $\tr(A^\sigma X) = 0$ for every length-$L$ word
+    $\sigma$. Since the products $\{A^\sigma\}_\sigma$ span $\MN{D}$,
+    nondegeneracy of the trace pairing gives $X = 0$.
+\end{proof}
+
 \begin{theorem}[Ground-space map injectivity]\label{thm:ground_space_map_injective}
     \lean{MPSTensor.groundSpaceMap_injective}
     \leanok
@@ -315,9 +330,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    If $\Gamma_L(X) = 0$ then $\tr(A^\sigma X) = 0$ for every length-$L$ word
-    $\sigma$. Since $A$ is injective, the products $\{A^\sigma\}_\sigma$ span
-    $\MN{D}$, so the trace pairing gives $X = 0$.
+    Injectivity gives $S_1(A) = \MN{D}$. Hence $\Id \in S_1(A)$, so the word
+    spans remain equal to $\MN{D}$ for all lengths $L \ge 1$. Lemma~
+    \ref{lem:ground_space_map_injective_word_span} then gives injectivity of
+    $\Gamma_L$.
 \end{proof}
 
 \begin{theorem}[Ground-space dimension]\label{thm:ground_space_finrank_eq}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -429,6 +429,24 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     fixed prefix $u$ gives a suffix state in $G_L(A)$.
 \end{definition}
 
+\begin{lemma}[Ground-space suffix restriction]\label{lem:ground_space_in_tail_ground}
+    \lean{MPSTensor.groundSpace_inTailGround}
+    \leanok
+    \uses{def:in_tail_ground, def:ground_space_parent}
+    If $\psi \in G_{K+L}(A)$, then every fixed-prefix suffix restriction of
+    $\psi$ lies in $G_L(A)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Write $\psi(\rho) = \tr(A^\rho X)$ for a boundary matrix $X$. Fixing a
+    prefix $u$ gives
+    \[
+        \psi(u,\sigma) = \tr(A^u A^\sigma X) = \tr(A^\sigma X A^u),
+    \]
+    so the suffix restriction again has the form of a ground-space vector.
+\end{proof}
+
 \begin{lemma}[Left-tail compatibility]\label{lem:left_tail_compatibility}
     \lean{MPSTensor.exists_left_tail_compatibility}
     \leanok


### PR DESCRIPTION
## Summary

This PR adds the suffix-window reindexing layer isolated in issue #699, without touching the periodic reintegration work tracked by draft PR #701.

### What lands
- new file `TNLean/MPS/ParentHamiltonian/SuffixWindow.lean`
- new suffix restriction map `MPSTensor.tailRestrictₗ`
- new reindexing lemma `Fin.snoc_append`
- interaction lemmas:
  - `MPSTensor.tailRestrictₗ_restrictLast`
  - `MPSTensor.restrictLast_groundSpaceMap`
  - `MPSTensor.tailRestrictₗ_groundSpaceMap`
- new suffix-window predicate `MPSTensor.InTailGround`
- forward lemma `MPSTensor.groundSpace_inTailGround`
- block-injective injectivity helper `MPSTensor.groundSpaceMap_injective_of_isNBlkInjective`
- packaged overlap theorem `MPSTensor.exists_left_tail_compatibility`

The last theorem is the exact matrix identity extracted in the #701 audit: from the long left-window condition and the fixed-prefix suffix-window condition, we obtain matrices `Z_j`, `Y_u` with
`Z j * evalWord A (List.ofFn u) = A j * Y u`.

### What is still blocked
This PR does **not** add
`groundSpace_extend_right_of_isNBlkInjective`.

After the new compatibility theorem, the remaining open-chain step is the common right-factor theorem:
- from the extracted data `∀ j u, Z_j * A^u = A_j * Y_u`, prove `∃ X, ∀ j, Z_j = A_j * X`;
- then reconstruct `ψ` from `X`.

That is the last missing algebra step before the separate periodic follow-up from #701:
- `chainGroundSpace A L N ≤ chainGroundSpace A (L₀ + 1) N`
- the block-injective wrapping theorem.

## Blueprint
- added a short suffix-window subsection in `blueprint/src/chapter/ch14_parent_hamiltonian.tex`
  for `tailRestrictₗ`, `InTailGround`, and `exists_left_tail_compatibility`

## Verification
- `cd .worktrees/issue-699-suffix-window && lake env lean TNLean/MPS/ParentHamiltonian/SuffixWindow.lean`
- `cd .worktrees/issue-699-suffix-window && lake build TNLean.MPS.ParentHamiltonian.SuffixWindow`
- `cd .worktrees/issue-699-suffix-window && lake build`
- `cd .worktrees/issue-699-suffix-window && lake env lean TNLean.lean`
- `cd .worktrees/issue-699-suffix-window/blueprint && leanblueprint web && leanblueprint checkdecls`
- `cd .worktrees/issue-699-suffix-window && python3 - <<'PY' ...` line-length scan on `SuffixWindow.lean` (`0` lines over 100)
- `cd .worktrees/issue-699-suffix-window && rg -n "sorry|axiom" TNLean/MPS/ParentHamiltonian/SuffixWindow.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new lemmas/modules and lightly refactors a proof without changing existing definitions or core logic; risk is mainly around proof breakage/compatibility in downstream imports.
> 
> **Overview**
> Adds a new suffix-window restriction API for parent-Hamiltonian ground spaces via `MPSTensor.tailRestrictₗ`, plus supporting reindexing/interaction lemmas and a new predicate `InTailGround` with a forward restriction theorem.
> 
> Introduces `MPSTensor.exists_left_tail_compatibility`, packaging the key overlap matrix identity needed for open-chain range reduction, and refactors `groundSpaceMap` injectivity by splitting out `groundSpaceMap_injective_of_wordSpan_eq_top` (also adding a block-injective helper `groundSpaceMap_injective_of_isNBlkInjective`). Documentation/exports are updated by importing `SuffixWindow` in `TNLean.lean` and extending the blueprint with the new suffix-window section and injectivity lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64c303a151396db1478ac182d3f7152e05deb9e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->