### PR TITLE
feat(Channel/FixedPoint): add Choi-Effros identities for idempotent maps (#612)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -95,6 +95,7 @@ import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull
 import TNLean.Channel.Schwarz.TraceCFC
 import TNLean.Channel.FixedPoint.Algebra
+import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp

--- a/TNLean/Channel/FixedPoint/ChoiEffros.lean
+++ b/TNLean/Channel/FixedPoint/ChoiEffros.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.Algebra
+
+/-!
+# Choi--Effros identities from fixed-point multiplicativity
+
+In this file we prove a fixed-point-algebra form of the Choi--Effros projected-product
+identities for an idempotent unital Kraus map whose adjoint map has a positive definite
+fixed point.
+
+## Main results
+
+- `Kraus.choi_effros_left`: if the left factor is already projected, then projecting the
+  right factor does not change the final projected product.
+- `Kraus.choi_effros_right`: the symmetric statement for the right factor.
+- `Kraus.choi_effros_sandwich`: the product of two projected factors is itself fixed.
+- `Kraus.choi_effros_left_eq_right`: the left and right projected-product formulas agree.
+
+The proof is short: idempotence makes `E(X)` and `E(Y)` fixed points, Wolf Theorem 6.12
+places fixed points in the multiplicative domain, and the multiplicative-domain identities
+from Chapter 5 give the projected-product formulas.
+
+This is the version needed later for projected multiplications on ranges of idempotent
+maps. The more general completely positive contractive projection theorem is not
+formalized here.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+private theorem map_fixes_range_of_idempotent
+    (K : Fin d → Mat)
+    (hIdem : mapLM K ∘ₗ mapLM K = mapLM K)
+    (X : Mat) :
+    map K (map K X) = map K X := by
+  have h := congrArg (fun F : Mat →ₗ[ℂ] Mat => F X) hIdem
+  simpa only [LinearMap.comp_apply, mapLM_apply] using h
+
+/-- For an idempotent unital Kraus map with a positive definite adjoint fixed
+point, every projected element lies in the multiplicative domain. -/
+theorem map_mem_multiplicativeDomain_of_idempotent
+    (K : Fin d → Mat) (h_unital : IsUnital K)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ)
+    (hIdem : mapLM K ∘ₗ mapLM K = mapLM K)
+    (X : Mat) :
+    map K X ∈ KadisonSchwarz.multiplicativeDomain K := by
+  have hEX_fix : map K (map K X) = map K X :=
+    map_fixes_range_of_idempotent (K := K) hIdem X
+  have hEX_mem : map K X ∈ fixedPoints K := hEX_fix
+  exact mem_multiplicativeDomain_of_mem_fixedPoints (K := K) h_unital hρ hρ_fix hEX_mem
+
+/-- Left absorption for the projected product attached to an idempotent Kraus map. -/
+theorem choi_effros_left
+    (K : Fin d → Mat) (h_unital : IsUnital K)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ)
+    (hIdem : mapLM K ∘ₗ mapLM K = mapLM K)
+    (X Y : Mat) :
+    map K (map K X * Y) = map K (map K X * map K Y) := by
+  have hEX_md : map K X ∈ KadisonSchwarz.multiplicativeDomain K :=
+    map_mem_multiplicativeDomain_of_idempotent (K := K) h_unital hρ hρ_fix hIdem X
+  calc
+    map K (map K X * Y)
+        = map K (map K X) * map K Y := by
+          simpa only [map, KadisonSchwarz.krausMap] using
+            (KadisonSchwarz.krausMap_mul_right_of_mem_multiplicativeDomain
+              (K := K) hEX_md Y)
+    _ = map K X * map K Y := by
+          rw [map_fixes_range_of_idempotent (K := K) hIdem X]
+    _ = map K (map K X * map K Y) := by
+          symm
+          rw [show map K (map K X * map K Y) =
+              map K (map K X) * map K (map K Y) by
+            simpa only [map, KadisonSchwarz.krausMap] using
+              (KadisonSchwarz.krausMap_mul_right_of_mem_multiplicativeDomain
+                (K := K) hEX_md (map K Y))]
+          rw [map_fixes_range_of_idempotent (K := K) hIdem X,
+            map_fixes_range_of_idempotent (K := K) hIdem Y]
+
+/-- Right absorption for the projected product attached to an idempotent Kraus map. -/
+theorem choi_effros_right
+    (K : Fin d → Mat) (h_unital : IsUnital K)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ)
+    (hIdem : mapLM K ∘ₗ mapLM K = mapLM K)
+    (X Y : Mat) :
+    map K (X * map K Y) = map K (map K X * map K Y) := by
+  have hEY_md : map K Y ∈ KadisonSchwarz.multiplicativeDomain K :=
+    map_mem_multiplicativeDomain_of_idempotent (K := K) h_unital hρ hρ_fix hIdem Y
+  calc
+    map K (X * map K Y)
+        = map K X * map K (map K Y) := by
+          simpa only [map, KadisonSchwarz.krausMap] using
+            (KadisonSchwarz.krausMap_mul_left_of_mem_multiplicativeDomain
+              (K := K) hEY_md X)
+    _ = map K X * map K Y := by
+          rw [map_fixes_range_of_idempotent (K := K) hIdem Y]
+    _ = map K (map K X * map K Y) := by
+          symm
+          rw [show map K (map K X * map K Y) =
+              map K (map K X) * map K (map K Y) by
+            simpa only [map, KadisonSchwarz.krausMap] using
+              (KadisonSchwarz.krausMap_mul_left_of_mem_multiplicativeDomain
+                (K := K) hEY_md (map K X))]
+          rw [map_fixes_range_of_idempotent (K := K) hIdem X,
+            map_fixes_range_of_idempotent (K := K) hIdem Y]
+
+/-- The product of two projected factors is itself fixed. -/
+theorem choi_effros_sandwich
+    (K : Fin d → Mat) (h_unital : IsUnital K)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ)
+    (hIdem : mapLM K ∘ₗ mapLM K = mapLM K)
+    (X Y : Mat) :
+    map K (map K X * map K Y) = map K X * map K Y := by
+  have hEX_md : map K X ∈ KadisonSchwarz.multiplicativeDomain K :=
+    map_mem_multiplicativeDomain_of_idempotent (K := K) h_unital hρ hρ_fix hIdem X
+  rw [show map K (map K X * map K Y) =
+      map K (map K X) * map K (map K Y) by
+    simpa only [map, KadisonSchwarz.krausMap] using
+      (KadisonSchwarz.krausMap_mul_right_of_mem_multiplicativeDomain
+        (K := K) hEX_md (map K Y))]
+  rw [map_fixes_range_of_idempotent (K := K) hIdem X,
+    map_fixes_range_of_idempotent (K := K) hIdem Y]
+
+/-- The left and right projected-product identities agree. -/
+theorem choi_effros_left_eq_right
+    (K : Fin d → Mat) (h_unital : IsUnital K)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ)
+    (hIdem : mapLM K ∘ₗ mapLM K = mapLM K)
+    (X Y : Mat) :
+    map K (map K X * Y) = map K (X * map K Y) := by
+  rw [choi_effros_left (K := K) h_unital hρ hρ_fix hIdem X Y,
+    choi_effros_right (K := K) h_unital hρ hρ_fix hIdem X Y]
+
+end Kraus

--- a/TNLean/Channel/FixedPoint/ChoiEffros.lean
+++ b/TNLean/Channel/FixedPoint/ChoiEffros.lean
@@ -59,6 +59,23 @@ theorem map_mem_multiplicativeDomain_of_idempotent
   have hEX_mem : map K X ∈ fixedPoints K := hEX_fix
   exact mem_multiplicativeDomain_of_mem_fixedPoints (K := K) h_unital hρ hρ_fix hEX_mem
 
+/-- The product of two projected factors is itself fixed. -/
+theorem choi_effros_sandwich
+    (K : Fin d → Mat) (h_unital : IsUnital K)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ)
+    (hIdem : mapLM K ∘ₗ mapLM K = mapLM K)
+    (X Y : Mat) :
+    map K (map K X * map K Y) = map K X * map K Y := by
+  have hEX_md : map K X ∈ KadisonSchwarz.multiplicativeDomain K :=
+    map_mem_multiplicativeDomain_of_idempotent (K := K) h_unital hρ hρ_fix hIdem X
+  rw [show map K (map K X * map K Y) =
+      map K (map K X) * map K (map K Y) by
+    simpa only [map, KadisonSchwarz.krausMap] using
+      (KadisonSchwarz.krausMap_mul_right_of_mem_multiplicativeDomain
+        (K := K) hEX_md (map K Y))]
+  rw [map_fixes_range_of_idempotent (K := K) hIdem X,
+    map_fixes_range_of_idempotent (K := K) hIdem Y]
+
 /-- Left absorption for the projected product attached to an idempotent Kraus map. -/
 theorem choi_effros_left
     (K : Fin d → Mat) (h_unital : IsUnital K)
@@ -76,15 +93,8 @@ theorem choi_effros_left
               (K := K) hEX_md Y)
     _ = map K X * map K Y := by
           rw [map_fixes_range_of_idempotent (K := K) hIdem X]
-    _ = map K (map K X * map K Y) := by
-          symm
-          rw [show map K (map K X * map K Y) =
-              map K (map K X) * map K (map K Y) by
-            simpa only [map, KadisonSchwarz.krausMap] using
-              (KadisonSchwarz.krausMap_mul_right_of_mem_multiplicativeDomain
-                (K := K) hEX_md (map K Y))]
-          rw [map_fixes_range_of_idempotent (K := K) hIdem X,
-            map_fixes_range_of_idempotent (K := K) hIdem Y]
+    _ = map K (map K X * map K Y) :=
+          (choi_effros_sandwich (K := K) h_unital hρ hρ_fix hIdem X Y).symm
 
 /-- Right absorption for the projected product attached to an idempotent Kraus map. -/
 theorem choi_effros_right
@@ -103,32 +113,8 @@ theorem choi_effros_right
               (K := K) hEY_md X)
     _ = map K X * map K Y := by
           rw [map_fixes_range_of_idempotent (K := K) hIdem Y]
-    _ = map K (map K X * map K Y) := by
-          symm
-          rw [show map K (map K X * map K Y) =
-              map K (map K X) * map K (map K Y) by
-            simpa only [map, KadisonSchwarz.krausMap] using
-              (KadisonSchwarz.krausMap_mul_left_of_mem_multiplicativeDomain
-                (K := K) hEY_md (map K X))]
-          rw [map_fixes_range_of_idempotent (K := K) hIdem X,
-            map_fixes_range_of_idempotent (K := K) hIdem Y]
-
-/-- The product of two projected factors is itself fixed. -/
-theorem choi_effros_sandwich
-    (K : Fin d → Mat) (h_unital : IsUnital K)
-    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ)
-    (hIdem : mapLM K ∘ₗ mapLM K = mapLM K)
-    (X Y : Mat) :
-    map K (map K X * map K Y) = map K X * map K Y := by
-  have hEX_md : map K X ∈ KadisonSchwarz.multiplicativeDomain K :=
-    map_mem_multiplicativeDomain_of_idempotent (K := K) h_unital hρ hρ_fix hIdem X
-  rw [show map K (map K X * map K Y) =
-      map K (map K X) * map K (map K Y) by
-    simpa only [map, KadisonSchwarz.krausMap] using
-      (KadisonSchwarz.krausMap_mul_right_of_mem_multiplicativeDomain
-        (K := K) hEX_md (map K Y))]
-  rw [map_fixes_range_of_idempotent (K := K) hIdem X,
-    map_fixes_range_of_idempotent (K := K) hIdem Y]
+    _ = map K (map K X * map K Y) :=
+          (choi_effros_sandwich (K := K) h_unital hρ hρ_fix hIdem X Y).symm
 
 /-- The left and right projected-product identities agree. -/
 theorem choi_effros_left_eq_right

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1504,9 +1504,18 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \begin{proof}\leanok
     \uses{thm:fixedPointsStarSubalgebra, thm:md_characterization}
     Idempotence gives $E(E(X)) = E(X)$, so $E(X)$ is a fixed point.
-    The argument in Theorem~\ref{thm:fixedPointsStarSubalgebra} shows that
-    every fixed point satisfies the Kadison--Schwarz equality, hence lies in
-    the multiplicative domain by Theorem~\ref{thm:md_characterization}.
+    By the argument in Theorem~\ref{thm:fixedPointsStarSubalgebra}, the
+    Kadison--Schwarz gap for the fixed point $E(X)$ vanishes, hence
+    \[
+        E(E(X)^\dagger E(X)) = E(X)^\dagger E(X).
+    \]
+    Fixed points are closed under $\dagger$, so the same argument applied to
+    $E(X)^\dagger$ gives
+    \[
+        E(E(X) E(X)^\dagger) = E(X) E(X)^\dagger.
+    \]
+    Therefore Theorem~\ref{thm:md_characterization} places $E(X)$ in the
+    multiplicative domain.
 \end{proof}
 
 \begin{theorem}[Choi--Effros left absorption]
@@ -1522,8 +1531,10 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \begin{proof}\leanok
     \uses{thm:map_mem_multiplicativeDomain_of_idempotent}
     The previous theorem places $E(X)$ in the multiplicative domain, so
-    $E(E(X) Y) = E(X) E(Y)$. Applying the same multiplicativity to
-    $E(X)$ and $E(Y)$ gives $E(E(X) E(Y)) = E(X) E(Y)$.
+    $E(E(X) Y) = E(E(X)) E(Y) = E(X) E(Y)$.
+    Applying the same multiplicativity to $E(X)$ and $E(Y)$ gives
+    $E(E(X) E(Y)) = E(E(X)) E(E(Y))$, and idempotence rewrites this as
+    $E(X) E(Y)$.
 \end{proof}
 
 \begin{theorem}[Choi--Effros right absorption]
@@ -1538,7 +1549,26 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 
 \begin{proof}\leanok
     \uses{thm:map_mem_multiplicativeDomain_of_idempotent}
-    Apply the previous theorem to $E(Y)$ on the right.
+    The previous theorem places $E(Y)$ in the multiplicative domain, so
+    $E(X E(Y)) = E(X) E(E(Y)) = E(X) E(Y)$.
+    Applying the same multiplicativity to $E(X)$ and $E(Y)$ gives
+    $E(E(X) E(Y)) = E(E(X)) E(E(Y))$, and idempotence rewrites this as
+    $E(X) E(Y)$.
+\end{proof}
+
+\begin{theorem}[Choi--Effros symmetric absorption]
+    \label{thm:choi_effros_left_eq_right}
+    \lean{Kraus.choi_effros_left_eq_right}\leanok
+    \uses{def:kraus_fixed_points, def:unital_kraus}
+    Under the same hypotheses, for all $X, Y \in \MN{D}$,
+    \[
+        E(E(X) Y) = E(X E(Y)).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:choi_effros_left, thm:choi_effros_right}
+    Both sides equal $E(E(X) E(Y))$ by the two preceding theorems.
 \end{proof}
 
 \begin{theorem}[Choi--Effros projected product]
@@ -1554,7 +1584,15 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \begin{proof}\leanok
     \uses{thm:map_mem_multiplicativeDomain_of_idempotent}
     The previous theorem places $E(X)$ and $E(Y)$ in the multiplicative domain.
-    Multiplicativity of $E$ on $E(X)$ then gives the claim.
+    Therefore multiplicativity gives
+    \[
+        E(E(X) E(Y)) = E(E(X)) E(E(Y)).
+    \]
+    Since $E$ is idempotent under the standing hypotheses, $E(E(X)) = E(X)$
+    and $E(E(Y)) = E(Y)$, so
+    \[
+        E(E(X) E(Y)) = E(X) E(Y).
+    \]
 \end{proof}
 
 \begin{definition}[Adjoint fixed points]\label{def:adjoint_fixed_points}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1492,6 +1492,71 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     result from~\S\ref{sec:fixed_point_algebra}.
 \end{remark}
 
+\begin{theorem}[Projected elements lie in the multiplicative domain]
+    \label{thm:map_mem_multiplicativeDomain_of_idempotent}
+    \lean{Kraus.map_mem_multiplicativeDomain_of_idempotent}\leanok
+    \uses{def:kraus_fixed_points, def:unital_kraus}
+    Let $E$ be a unital Kraus map whose adjoint map has a positive definite
+    fixed point, and suppose $E^2 = E$. Then $E(X)$ lies in the multiplicative
+    domain of $E$ for every $X \in \MN{D}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:fixedPointsStarSubalgebra, thm:md_characterization}
+    Idempotence gives $E(E(X)) = E(X)$, so $E(X)$ is a fixed point.
+    The argument in Theorem~\ref{thm:fixedPointsStarSubalgebra} shows that
+    every fixed point satisfies the Kadison--Schwarz equality, hence lies in
+    the multiplicative domain by Theorem~\ref{thm:md_characterization}.
+\end{proof}
+
+\begin{theorem}[Choi--Effros left absorption]
+    \label{thm:choi_effros_left}
+    \lean{Kraus.choi_effros_left}\leanok
+    \uses{def:kraus_fixed_points, def:unital_kraus}
+    Under the same hypotheses, for all $X, Y \in \MN{D}$,
+    \[
+        E(E(X) Y) = E(E(X) E(Y)).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:map_mem_multiplicativeDomain_of_idempotent}
+    The previous theorem places $E(X)$ in the multiplicative domain, so
+    $E(E(X) Y) = E(X) E(Y)$. Applying the same multiplicativity to
+    $E(X)$ and $E(Y)$ gives $E(E(X) E(Y)) = E(X) E(Y)$.
+\end{proof}
+
+\begin{theorem}[Choi--Effros right absorption]
+    \label{thm:choi_effros_right}
+    \lean{Kraus.choi_effros_right}\leanok
+    \uses{def:kraus_fixed_points, def:unital_kraus}
+    Under the same hypotheses, for all $X, Y \in \MN{D}$,
+    \[
+        E(X E(Y)) = E(E(X) E(Y)).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:map_mem_multiplicativeDomain_of_idempotent}
+    Apply the previous theorem to $E(Y)$ on the right.
+\end{proof}
+
+\begin{theorem}[Choi--Effros projected product]
+    \label{thm:choi_effros_sandwich}
+    \lean{Kraus.choi_effros_sandwich}\leanok
+    \uses{def:kraus_fixed_points, def:unital_kraus}
+    Under the same hypotheses, for all $X, Y \in \MN{D}$,
+    \[
+        E(E(X) E(Y)) = E(X) E(Y).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:map_mem_multiplicativeDomain_of_idempotent}
+    The previous theorem places $E(X)$ and $E(Y)$ in the multiplicative domain.
+    Multiplicativity of $E$ on $E(X)$ then gives the claim.
+\end{proof}
+
 \begin{definition}[Adjoint fixed points]\label{def:adjoint_fixed_points}
     \lean{Kraus.adjointFixedPoints}\leanok
     \uses{def:kraus_adjoint_map}


### PR DESCRIPTION
## Summary

This PR adds a fixed-point-algebra form of the Choi–Effros projected-product identities for idempotent unital Kraus maps with a positive definite adjoint fixed point.

It is a prerequisite follow-up for #612 and draft PR #692.

### What lands

- new file `TNLean/Channel/FixedPoint/ChoiEffros.lean`
- new public theorem
  - `Kraus.map_mem_multiplicativeDomain_of_idempotent`
- new projected-product identities
  - `Kraus.choi_effros_left`
  - `Kraus.choi_effros_right`
  - `Kraus.choi_effros_sandwich`
  - `Kraus.choi_effros_left_eq_right`
- root import in `TNLean.lean`
- blueprint entries in `blueprint/src/chapter/ch04_channels.tex`

## Important statement correction

While implementing this, I found that the stronger formulas quoted in the #612 blocker note,

- `E (E x * y) = E (x * y)`
- `E (x * E y) = E (x * y)`

are false in general, even for basic unital CP idempotents (for example the scalar conditional expectation `X ↦ X 0 0 • 1`).

The correct Choi–Effros absorption identities are the projected-product forms proved here:

- `E (E x * y) = E (E x * E y)`
- `E (x * E y) = E (E x * E y)`
- `E (E x * E y) = E x * E y`

This is exactly the form obtained from the multiplicative-domain argument available in the current TNLean library.

## Design note

The developer instructions mentioned `TNLean/Channel/FixedPoint.lean`, but there is no such wrapper file on current `main`, so I imported the new module directly from `TNLean.lean`.

## Verification

In `.worktrees/issue-612-choi-effros` I ran:

- `lake env lean TNLean/Channel/FixedPoint/ChoiEffros.lean`
- `lake build TNLean.Channel.FixedPoint.ChoiEffros`
- `lake build`
- `lake env lean TNLean.lean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

All succeeded. Existing unrelated repo warnings / sorry warnings remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive formalization (new theorems + documentation) with no changes to existing definitions or proofs; main risk is minor lemma misuse impacting downstream proofs that adopt the new identities.
> 
> **Overview**
> Introduces `TNLean.Channel.FixedPoint.ChoiEffros`, proving that for an **idempotent** unital Kraus map with a positive definite adjoint fixed point, every projected element `map K X` lies in the multiplicative domain (`Kraus.map_mem_multiplicativeDomain_of_idempotent`).
> 
> Builds on that to add the Choi–Effros projected-product identities (`Kraus.choi_effros_left`, `Kraus.choi_effros_right`, `Kraus.choi_effros_sandwich`, `Kraus.choi_effros_left_eq_right`), re-exports the module from `TNLean.lean`, and adds corresponding statements/proofs to the Chapter 4 blueprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637ac496ae63e8d06d92df2ea8cfd71170d49850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->