### PR TITLE
doc(blueprint): move Gemma irreducible-form §14.4 out of ch14 (#708)

### DIFF
--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -403,8 +403,9 @@ The following is Theorem~3.8 (``equal case'') of
     decomposition} of the blocked tensor $A^{(m)}$ if there exist orthogonal
     projections $P_0,\dotsc,P_{m-1}$ on the ambient bond space such that
     $\sum_k P_k = \Id$, the projections satisfy the cyclic-shift relation
-    $E^\dagger(P_{k+1}) = P_k$, each $P_k$ commutes with every blocked letter
-    $P_k A^{(m)}_i = A^{(m)}_i P_k$,
+    $\E_A^\dagger(P_{k+1}) = P_k$ with the index $k+1$ taken cyclically
+    modulo~$m$, each $P_k$ commutes with every blocked letter
+    $P_k A^{(m)}_i = A^{(m)}_i P_k$, and
     $V^{(N)}(C_k)_\sigma = \tr(P_k (A^{(m)})^\sigma)$ for every word~$\sigma$,
     and each block carries a $\ast$-algebra isomorphism
     $\varphi_k : M_{\dim C_k}(\mathbb{C}) \xrightarrow{\sim}


### PR DESCRIPTION
## Summary
- move the remaining periodic equal-case Fundamental Theorem / periodic-overlap material from the chapter-14 assembly file `blueprint/src/chapter/ch11_assembly.tex` into the dedicated Gemma chapter `blueprint/src/chapter/ch11b_periodic_ft.tex`
- preserve the existing labels (`thm:periodic_ft`, the periodic-overlap labels, and the comparison/proportional remarks) while leaving only cross-references behind in `ch11_assembly.tex`
- keep the common-period blocking lemmas in `ch11_assembly.tex`, and update the chapter prose so it points forward to the periodic-FT chapter instead of restating the moved material

Related: #708, #675.

## Testing
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- `rg -n "IsIrreducibleForm|isIrreducibleForm_|ZGaugeEquiv|thm:periodic_ft|periodicOverlapDichotomy|IsCyclicSectorDecomp|cornerTransition|cornerEvalWord|blockedCornerTransitionTensor" blueprint/src/chapter/ch11_assembly.tex`
- `rg -n "IsIrreducibleForm|isIrreducibleForm_|ZGaugeEquiv|thm:periodic_ft|periodicOverlapDichotomy|IsCyclicSectorDecomp|cornerTransition|cornerEvalWord|blockedCornerTransitionTensor" blueprint/src/chapter/ch11b_periodic_ft.tex`
- `lake build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure documentation/LaTeX wording change with no effect on code or formalized statements beyond clearer notation.
> 
> **Overview**
> Clarifies the definition of cyclic sector decomposition in `ch11b_periodic_ft.tex` by making the cyclic-shift condition explicit as `\E_A^\dagger(P_{k+1}) = P_k` with `k+1` taken modulo `m`, and tightening the surrounding phrasing (including an explicit “and” before the final condition).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9464378f3ba510bf5d39af0da4b774d3212eeed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->