### PR TITLE
refactor(Channel/Determinant): tighten namespace and import hygiene

### DIFF
--- a/TNLean/Channel/Determinant/Basic.lean
+++ b/TNLean/Channel/Determinant/Basic.lean
@@ -3,20 +3,12 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
-import Mathlib.Algebra.Central.Matrix
-import Mathlib.Analysis.Complex.Polynomial.Basic
-import Mathlib.Analysis.InnerProductSpace.Adjoint
-import Mathlib.Analysis.InnerProductSpace.Positive
-import Mathlib.Analysis.InnerProductSpace.Trace
-import Mathlib.Analysis.MeanInequalities
 import Mathlib.LinearAlgebra.Determinant
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
-import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.StdBasis
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.Matrix.Trace
-import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.LinearAlgebra.UnitaryGroup
 
 /-!

--- a/TNLean/Channel/Determinant/Bound.lean
+++ b/TNLean/Channel/Determinant/Bound.lean
@@ -247,7 +247,7 @@ private theorem positiveTracePreserving_eigenvalue_norm_le_one [NeZero d]
         _ = 1 * Matrix.trace z := by simp only [one_mul]
     simp only [hμ_eq, one_mem, CStarRing.norm_of_mem_unitary, Std.le_refl]
 
-namespace ChannelDeterminant
+namespace ChannelDeterminant.Internal
 
 /-- If every factor in a finite product has norm at most `1`, then the product also has norm at
 most `1`. -/
@@ -267,7 +267,7 @@ lemma norm_prod_le_one_of_forall_mem'
         _ ≤ 1 * 1 := by gcongr; exact ih hs'
         _ = 1 := by norm_num
 
-end ChannelDeterminant
+end ChannelDeterminant.Internal
 
 /-- Eigenvalues of a positive trace-preserving map on `M_d(ℂ)` determine roots of the
 characteristic polynomial with norm ≤ 1, so the determinant (= product of roots) has norm ≤ 1. -/
@@ -276,7 +276,7 @@ private lemma channelDet_norm_le_one_of_eigenvalues_bounded
     ‖channelDet T‖ ≤ 1 := by
   calc ‖channelDet T‖ = ‖(channelMatrix T).det‖ := rfl
     _ = ‖(channelMatrix T).charpoly.roots.prod‖ := by rw [Matrix.det_eq_prod_roots_charpoly]
-    _ ≤ 1 := ChannelDeterminant.norm_prod_le_one_of_forall_mem' _ hroot_le
+    _ ≤ 1 := ChannelDeterminant.Internal.norm_prod_le_one_of_forall_mem' _ hroot_le
 
 /-- Wolf Thm. 6.1(1): for a positive trace-preserving map on `M_d(ℂ)`, the channel
 determinant satisfies `|det T| ≤ 1`. -/

--- a/TNLean/Channel/Determinant/HeisenbergDual.lean
+++ b/TNLean/Channel/Determinant/HeisenbergDual.lean
@@ -20,7 +20,7 @@ that the Heisenberg dual is multiplicative.
 
 ## Main statements
 
-* `ChannelDeterminant.heisenberg_dual_multiplicative` — determinant
+* `ChannelDeterminant.Internal.heisenberg_dual_multiplicative` — determinant
   saturation forces the Heisenberg dual to be multiplicative on all matrices.
 
 ## References
@@ -56,7 +56,7 @@ section WolfStatements
 
 variable {T : MatrixEnd d}
 
-namespace ChannelDeterminant
+namespace ChannelDeterminant.Internal
 
 private theorem heisenberg_dual_det_eq_one [NeZero d]
     {T : MatrixEnd d} (hdet : ‖channelDet T‖ = 1)
@@ -305,6 +305,6 @@ theorem heisenberg_dual_multiplicative [NeZero d]
     _ = (K a)ᴴ * M * K a * ∑ b : Fin r, (K b)ᴴ * N * K b := by
         rw [show Td N = ∑ b : Fin r, (K b)ᴴ * N * K b from hTd N]
 
-end ChannelDeterminant
+end ChannelDeterminant.Internal
 
 end WolfStatements

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -17,15 +17,15 @@ Hilbert--Schmidt norm computations; and an AM--GM argument upgrades
 
 ## Main statements
 
-* `ChannelDeterminant.channel_all_eigenvalues_norm_one` — determinant
+* `ChannelDeterminant.Internal.channel_all_eigenvalues_norm_one` — determinant
   saturation forces every eigenvalue of a CPTP map to lie on the unit circle.
-* `ChannelDeterminant.stdBasis_conjTranspose_eq_swap` — conjugate transpose
-  swaps the indices of a matrix-unit basis element.
-* `ChannelDeterminant.sum_stdBasis_mul_conjTranspose` — the standard basis
-  satisfies `∑_{ij} E_{ij} E_{ij}^† = d • 1`.
-* `ChannelDeterminant.eq_zero_of_nonneg_of_sum_le_zero` — a finite nonnegative
-  family with total sum at most `0` vanishes termwise.
-* `ChannelDeterminant.channelDet_norm_one_hs_norm_ge` — determinant
+* `ChannelDeterminant.Internal.stdBasis_conjTranspose_eq_swap` — conjugate
+  transpose swaps the indices of a matrix-unit basis element.
+* `ChannelDeterminant.Internal.sum_stdBasis_mul_conjTranspose` — the standard
+  basis satisfies `∑_{ij} E_{ij} E_{ij}^† = d • 1`.
+* `ChannelDeterminant.Internal.eq_zero_of_nonneg_of_sum_le_zero` — a finite
+  nonnegative family with total sum at most `0` vanishes termwise.
+* `ChannelDeterminant.Internal.channelDet_norm_one_hs_norm_ge` — determinant
   saturation gives the AM--GM lower bound on the Hilbert--Schmidt norm.
 
 ## References
@@ -63,7 +63,7 @@ variable {T : MatrixEnd d}
 
 /-! ### Helper lemmas for the forward direction of Wolf Thm 6.1(2) -/
 
-namespace ChannelDeterminant
+namespace ChannelDeterminant.Internal
 
 /-- Product of norms = 1 with each factor ≤ 1 implies each factor = 1. -/
 private lemma norm_eq_one_of_prod_norm_eq_one
@@ -322,6 +322,6 @@ lemma channelDet_norm_one_hs_norm_ge [NeZero d]
             Φ (Matrix.stdBasis ℂ (Fin d) (Fin d) ij))).re := hA_hs
 
 
-end ChannelDeterminant
+end ChannelDeterminant.Internal
 
 end WolfStatements

--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -176,7 +176,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
     (hT : IsChannel T) (hdet : ‖channelDet T‖ = 1) :
     ∃ U : Matrix.unitaryGroup (Fin d) ℂ, T = unitaryChannel U := by
   classical
-  have hall := ChannelDeterminant.channel_all_eigenvalues_norm_one (d := d) hT hdet
+  have hall := ChannelDeterminant.Internal.channel_all_eigenvalues_norm_one (d := d) hT hdet
   obtain ⟨r, K, hK⟩ := hT.cp
   have hK_tp : ∑ i : Fin r, (K i)ᴴ * K i = 1 :=
     kraus_sum_conjTranspose_mul_of_tp K T hK hT.tp
@@ -198,7 +198,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
       conjTranspose_conjTranspose]
   -- Td is multiplicative
   have hMul :=
-    ChannelDeterminant.heisenberg_dual_multiplicative hT hdet hall K hK hK_tp Td hTd_def
+    ChannelDeterminant.Internal.heisenberg_dual_multiplicative hT hdet hall K hK hK_tp Td hTd_def
   have hTd_ne : Td ≠ 0 := by
     intro h
     have := congr_fun (congr_arg DFunLike.coe h) 1


### PR DESCRIPTION
## Summary
- move the split-only determinant helper lemmas into `ChannelDeterminant.Internal`
- update the determinant submodules to use the internal helper namespace
- trim `Basic.lean` imports down to the imports actually needed by the basic determinant API

## Details
This follow-up keeps the public `TNLean.Channel.Determinant` API unchanged while tightening the hygiene left by #695:

- `norm_prod_le_one_of_forall_mem'` now lives in `ChannelDeterminant.Internal` in `Bound.lean`
- the Hilbert--Schmidt helper lemmas and the Heisenberg-dual multiplicativity lemma now live in `ChannelDeterminant.Internal`
- `UnitaryCharacterization.lean` now refers to the internal helper namespace
- `Basic.lean` drops the downstream-only imports that were no longer needed after the split

I also checked for in-tree downstream callers before changing the helper namespace; none were found outside `TNLean/Channel/Determinant/`.

## Verification
- `lake env lean TNLean/Channel/Determinant/Basic.lean`
- `lake env lean TNLean/Channel/Determinant/Bound.lean`
- `lake env lean TNLean/Channel/Determinant/HilbertSchmidt.lean`
- `lake env lean TNLean/Channel/Determinant/HeisenbergDual.lean`
- `lake env lean TNLean/Channel/Determinant/UnitaryCharacterization.lean`
- `lake env lean TNLean/Channel/Determinant.lean`
- `lake build TNLean.Channel.Determinant.Basic TNLean.Channel.Determinant.Bound TNLean.Channel.Determinant.HilbertSchmidt TNLean.Channel.Determinant.HeisenbergDual TNLean.Channel.Determinant.UnitaryCharacterization TNLean.Channel.Determinant`
- `lake build`
- `rg -n "sorry|axiom" TNLean/Channel/Determinant.lean TNLean/Channel/Determinant/*.lean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily moves helper lemmas into an `Internal` namespace and trims unused imports; main risk is broken downstream references if any external code relied on the previously-public lemma names.
> 
> **Overview**
> Trims `Determinant/Basic.lean` imports to only those needed for the core determinant/unitary-channel API.
> 
> Moves several proof-helper lemmas/theorems used only within the determinant-rigidity development into `ChannelDeterminant.Internal` (including product-norm and determinant-saturation helpers, plus the Heisenberg-dual multiplicativity result), and updates local callers (e.g. `Bound.lean` and `UnitaryCharacterization.lean`) to reference the new internal namespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216ad5401ccc0612ff4b1b14856604ba0407c4f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->