### PR TITLE
refactor(Channel/Determinant): tighten namespace and import hygiene

### DIFF
--- a/TNLean/Channel/Determinant/Basic.lean
+++ b/TNLean/Channel/Determinant/Basic.lean
@@ -3,20 +3,12 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
-import Mathlib.Algebra.Central.Matrix
-import Mathlib.Analysis.Complex.Polynomial.Basic
-import Mathlib.Analysis.InnerProductSpace.Adjoint
-import Mathlib.Analysis.InnerProductSpace.Positive
-import Mathlib.Analysis.InnerProductSpace.Trace
-import Mathlib.Analysis.MeanInequalities
 import Mathlib.LinearAlgebra.Determinant
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
-import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.StdBasis
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.Matrix.Trace
-import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.LinearAlgebra.UnitaryGroup
 
 /-!
@@ -28,9 +20,12 @@ API used in Wolf's determinant-rigidity argument.
 
 ## Main definitions
 
-* `MatrixAlg`, `MatrixEnd` — the ambient matrix algebra and its endomorphisms.
-* `MatrixBasisIndex`, `matrixSpaceBasis` — linear-algebra models for the
-  standard matrix basis.
+* `ChannelDeterminant.Internal.MatrixAlg`,
+  `ChannelDeterminant.Internal.MatrixEnd` — shared internal models for the
+  ambient matrix algebra and its endomorphisms.
+* `ChannelDeterminant.Internal.MatrixBasisIndex`,
+  `ChannelDeterminant.Internal.matrixSpaceBasis` — shared internal linear-algebra
+  scaffolding for the standard matrix basis.
 * `channelMatrix`, `channelDet` — the matrix representation of a channel and its
   determinant.
 * `unitaryChannel` — conjugation by a unitary matrix.
@@ -58,21 +53,41 @@ open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker Matrix.Norms.
 open Matrix
 
 variable {d : ℕ}
+
+namespace ChannelDeterminant
+namespace Internal
+
 /-- The ambient matrix algebra `M_d(ℂ)`. -/
-private abbrev MatrixAlg (d : ℕ) := Matrix (Fin d) (Fin d) ℂ
+abbrev MatrixAlg (d : ℕ) := Matrix (Fin d) (Fin d) ℂ
 
 /-- Endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := MatrixAlg d →ₗ[ℂ] MatrixAlg d
+abbrev MatrixEnd (d : ℕ) := MatrixAlg d →ₗ[ℂ] MatrixAlg d
 
 /-- Index type for the standard basis of `M_d(ℂ)`.
 
 We use `Fin d × Fin d × Unit`, which has cardinality $d^2$. -/
-private abbrev MatrixBasisIndex (d : ℕ) := Fin d × Fin d × Unit
+abbrev MatrixBasisIndex (d : ℕ) := Fin d × Fin d × Unit
 
 /-- The standard basis of `M_d(ℂ)` coming from matrix units. -/
-private noncomputable def matrixSpaceBasis (d : ℕ) :
+noncomputable def matrixSpaceBasis (d : ℕ) :
     Module.Basis (MatrixBasisIndex d) ℂ (MatrixAlg d) :=
   Module.Basis.matrix (Fin d) (Fin d) (Module.Basis.singleton Unit ℂ)
+
+end Internal
+end ChannelDeterminant
+
+/-- File-local alias for the shared internal matrix-algebra model. -/
+private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
+
+/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
+private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
+
+/-- File-local alias for the shared basis index type. -/
+private abbrev MatrixBasisIndex (d : ℕ) := ChannelDeterminant.Internal.MatrixBasisIndex d
+
+/-- File-local alias for the shared standard basis of `M_d(ℂ)`. -/
+private noncomputable abbrev matrixSpaceBasis (d : ℕ) :=
+  ChannelDeterminant.Internal.matrixSpaceBasis d
 
 section Determinant
 

--- a/TNLean/Channel/Determinant/Bound.lean
+++ b/TNLean/Channel/Determinant/Bound.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Determinant.Basic
 import TNLean.Channel.Peripheral.IrreducibleChannel
+import Mathlib.Analysis.Complex.Polynomial.Basic
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
 
 /-!
 # Determinant bounds for positive trace-preserving maps
@@ -36,21 +38,18 @@ open Matrix
 
 variable {d : ℕ}
 
-/-- The ambient matrix algebra `M_d(ℂ)`. -/
-private abbrev MatrixAlg (d : ℕ) := Matrix (Fin d) (Fin d) ℂ
+/-- File-local alias for the shared internal matrix-algebra model. -/
+private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
 
-/-- Endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := MatrixAlg d →ₗ[ℂ] MatrixAlg d
+/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
+private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
 
-/-- Index type for the standard basis of `M_d(ℂ)`.
+/-- File-local alias for the shared basis index type. -/
+private abbrev MatrixBasisIndex (d : ℕ) := ChannelDeterminant.Internal.MatrixBasisIndex d
 
-We use `Fin d × Fin d × Unit`, which has cardinality $d^2$. -/
-private abbrev MatrixBasisIndex (d : ℕ) := Fin d × Fin d × Unit
-
-/-- The standard basis of `M_d(ℂ)` coming from matrix units. -/
-private noncomputable def matrixSpaceBasis (d : ℕ) :
-    Module.Basis (MatrixBasisIndex d) ℂ (MatrixAlg d) :=
-  Module.Basis.matrix (Fin d) (Fin d) (Module.Basis.singleton Unit ℂ)
+/-- File-local alias for the shared standard basis of `M_d(ℂ)`. -/
+private noncomputable abbrev matrixSpaceBasis (d : ℕ) :=
+  ChannelDeterminant.Internal.matrixSpaceBasis d
 
 section WolfStatements
 
@@ -248,6 +247,7 @@ private theorem positiveTracePreserving_eigenvalue_norm_le_one [NeZero d]
     simp only [hμ_eq, one_mem, CStarRing.norm_of_mem_unitary, Std.le_refl]
 
 namespace ChannelDeterminant
+namespace Internal
 
 /-- If every factor in a finite product has norm at most `1`, then the product also has norm at
 most `1`. -/
@@ -267,6 +267,7 @@ lemma norm_prod_le_one_of_forall_mem'
         _ ≤ 1 * 1 := by gcongr; exact ih hs'
         _ = 1 := by norm_num
 
+end Internal
 end ChannelDeterminant
 
 /-- Eigenvalues of a positive trace-preserving map on `M_d(ℂ)` determine roots of the
@@ -276,7 +277,7 @@ private lemma channelDet_norm_le_one_of_eigenvalues_bounded
     ‖channelDet T‖ ≤ 1 := by
   calc ‖channelDet T‖ = ‖(channelMatrix T).det‖ := rfl
     _ = ‖(channelMatrix T).charpoly.roots.prod‖ := by rw [Matrix.det_eq_prod_roots_charpoly]
-    _ ≤ 1 := ChannelDeterminant.norm_prod_le_one_of_forall_mem' _ hroot_le
+    _ ≤ 1 := ChannelDeterminant.Internal.norm_prod_le_one_of_forall_mem' _ hroot_le
 
 /-- Wolf Thm. 6.1(1): for a positive trace-preserving map on `M_d(ℂ)`, the channel
 determinant satisfies `|det T| ≤ 1`. -/

--- a/TNLean/Channel/Determinant/HeisenbergDual.lean
+++ b/TNLean/Channel/Determinant/HeisenbergDual.lean
@@ -20,7 +20,7 @@ that the Heisenberg dual is multiplicative.
 
 ## Main statements
 
-* `ChannelDeterminant.heisenberg_dual_multiplicative` — determinant
+* `ChannelDeterminant.Internal.heisenberg_dual_multiplicative` — determinant
   saturation forces the Heisenberg dual to be multiplicative on all matrices.
 
 ## References
@@ -36,27 +36,25 @@ open Matrix
 
 variable {d : ℕ}
 
-/-- The ambient matrix algebra `M_d(ℂ)`. -/
-private abbrev MatrixAlg (d : ℕ) := Matrix (Fin d) (Fin d) ℂ
+/-- File-local alias for the shared internal matrix-algebra model. -/
+private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
 
-/-- Endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := MatrixAlg d →ₗ[ℂ] MatrixAlg d
+/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
+private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
 
-/-- Index type for the standard basis of `M_d(ℂ)`.
+/-- File-local alias for the shared basis index type. -/
+private abbrev MatrixBasisIndex (d : ℕ) := ChannelDeterminant.Internal.MatrixBasisIndex d
 
-We use `Fin d × Fin d × Unit`, which has cardinality $d^2$. -/
-private abbrev MatrixBasisIndex (d : ℕ) := Fin d × Fin d × Unit
-
-/-- The standard basis of `M_d(ℂ)` coming from matrix units. -/
-private noncomputable def matrixSpaceBasis (d : ℕ) :
-    Module.Basis (MatrixBasisIndex d) ℂ (MatrixAlg d) :=
-  Module.Basis.matrix (Fin d) (Fin d) (Module.Basis.singleton Unit ℂ)
+/-- File-local alias for the shared standard basis of `M_d(ℂ)`. -/
+private noncomputable abbrev matrixSpaceBasis (d : ℕ) :=
+  ChannelDeterminant.Internal.matrixSpaceBasis d
 
 section WolfStatements
 
 variable {T : MatrixEnd d}
 
 namespace ChannelDeterminant
+namespace Internal
 
 private theorem heisenberg_dual_det_eq_one [NeZero d]
     {T : MatrixEnd d} (hdet : ‖channelDet T‖ = 1)
@@ -305,6 +303,7 @@ theorem heisenberg_dual_multiplicative [NeZero d]
     _ = (K a)ᴴ * M * K a * ∑ b : Fin r, (K b)ᴴ * N * K b := by
         rw [show Td N = ∑ b : Fin r, (K b)ᴴ * N * K b from hTd N]
 
+end Internal
 end ChannelDeterminant
 
 end WolfStatements

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -3,6 +3,11 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Determinant.Bound
+import Mathlib.Analysis.Complex.Polynomial.Basic
+import Mathlib.Analysis.InnerProductSpace.Positive
+import Mathlib.Analysis.InnerProductSpace.Trace
+import Mathlib.Analysis.MeanInequalities
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
 
 /-!
 # Hilbert--Schmidt helper lemmas for determinant saturation
@@ -17,15 +22,15 @@ Hilbert--Schmidt norm computations; and an AM--GM argument upgrades
 
 ## Main statements
 
-* `ChannelDeterminant.channel_all_eigenvalues_norm_one` — determinant
+* `ChannelDeterminant.Internal.channel_all_eigenvalues_norm_one` — determinant
   saturation forces every eigenvalue of a CPTP map to lie on the unit circle.
-* `ChannelDeterminant.stdBasis_conjTranspose_eq_swap` — conjugate transpose
-  swaps the indices of a matrix-unit basis element.
-* `ChannelDeterminant.sum_stdBasis_mul_conjTranspose` — the standard basis
-  satisfies `∑_{ij} E_{ij} E_{ij}^† = d • 1`.
-* `ChannelDeterminant.eq_zero_of_nonneg_of_sum_le_zero` — a finite nonnegative
-  family with total sum at most `0` vanishes termwise.
-* `ChannelDeterminant.channelDet_norm_one_hs_norm_ge` — determinant
+* `ChannelDeterminant.Internal.stdBasis_conjTranspose_eq_swap` — conjugate
+  transpose swaps the indices of a matrix-unit basis element.
+* `ChannelDeterminant.Internal.sum_stdBasis_mul_conjTranspose` — the standard
+  basis satisfies `∑_{ij} E_{ij} E_{ij}^† = d • 1`.
+* `ChannelDeterminant.Internal.eq_zero_of_nonneg_of_sum_le_zero` — a finite
+  nonnegative family with total sum at most `0` vanishes termwise.
+* `ChannelDeterminant.Internal.channelDet_norm_one_hs_norm_ge` — determinant
   saturation gives the AM--GM lower bound on the Hilbert--Schmidt norm.
 
 ## References
@@ -41,21 +46,18 @@ open Matrix
 
 variable {d : ℕ}
 
-/-- The ambient matrix algebra `M_d(ℂ)`. -/
-private abbrev MatrixAlg (d : ℕ) := Matrix (Fin d) (Fin d) ℂ
+/-- File-local alias for the shared internal matrix-algebra model. -/
+private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
 
-/-- Endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := MatrixAlg d →ₗ[ℂ] MatrixAlg d
+/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
+private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
 
-/-- Index type for the standard basis of `M_d(ℂ)`.
+/-- File-local alias for the shared basis index type. -/
+private abbrev MatrixBasisIndex (d : ℕ) := ChannelDeterminant.Internal.MatrixBasisIndex d
 
-We use `Fin d × Fin d × Unit`, which has cardinality $d^2$. -/
-private abbrev MatrixBasisIndex (d : ℕ) := Fin d × Fin d × Unit
-
-/-- The standard basis of `M_d(ℂ)` coming from matrix units. -/
-private noncomputable def matrixSpaceBasis (d : ℕ) :
-    Module.Basis (MatrixBasisIndex d) ℂ (MatrixAlg d) :=
-  Module.Basis.matrix (Fin d) (Fin d) (Module.Basis.singleton Unit ℂ)
+/-- File-local alias for the shared standard basis of `M_d(ℂ)`. -/
+private noncomputable abbrev matrixSpaceBasis (d : ℕ) :=
+  ChannelDeterminant.Internal.matrixSpaceBasis d
 
 section WolfStatements
 
@@ -64,6 +66,7 @@ variable {T : MatrixEnd d}
 /-! ### Helper lemmas for the forward direction of Wolf Thm 6.1(2) -/
 
 namespace ChannelDeterminant
+namespace Internal
 
 /-- Product of norms = 1 with each factor ≤ 1 implies each factor = 1. -/
 private lemma norm_eq_one_of_prod_norm_eq_one
@@ -322,6 +325,7 @@ lemma channelDet_norm_one_hs_norm_ge [NeZero d]
             Φ (Matrix.stdBasis ℂ (Fin d) (Fin d) ij))).re := hA_hs
 
 
+end Internal
 end ChannelDeterminant
 
 end WolfStatements

--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Determinant.HeisenbergDual
 import TNLean.Algebra.SkolemNoether
+import Mathlib.Algebra.Central.Matrix
+import Mathlib.LinearAlgebra.Matrix.Vec
 
 /-!
 # Unitary characterization of determinant saturation
@@ -40,11 +42,11 @@ open Matrix
 
 variable {d : ℕ}
 
-/-- The ambient matrix algebra `M_d(ℂ)`. -/
-private abbrev MatrixAlg (d : ℕ) := Matrix (Fin d) (Fin d) ℂ
+/-- File-local alias for the shared internal matrix-algebra model. -/
+private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
 
-/-- Endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := MatrixAlg d →ₗ[ℂ] MatrixAlg d
+/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
+private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
 
 /-- Column-stacking vectorization as a linear equivalence. -/
 private noncomputable def matrixVecLinearEquiv (d : ℕ) :
@@ -176,7 +178,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
     (hT : IsChannel T) (hdet : ‖channelDet T‖ = 1) :
     ∃ U : Matrix.unitaryGroup (Fin d) ℂ, T = unitaryChannel U := by
   classical
-  have hall := ChannelDeterminant.channel_all_eigenvalues_norm_one (d := d) hT hdet
+  have hall := ChannelDeterminant.Internal.channel_all_eigenvalues_norm_one (d := d) hT hdet
   obtain ⟨r, K, hK⟩ := hT.cp
   have hK_tp : ∑ i : Fin r, (K i)ᴴ * K i = 1 :=
     kraus_sum_conjTranspose_mul_of_tp K T hK hT.tp
@@ -198,7 +200,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
       conjTranspose_conjTranspose]
   -- Td is multiplicative
   have hMul :=
-    ChannelDeterminant.heisenberg_dual_multiplicative hT hdet hall K hK hK_tp Td hTd_def
+    ChannelDeterminant.Internal.heisenberg_dual_multiplicative hT hdet hall K hK hK_tp Td hTd_def
   have hTd_ne : Td ≠ 0 := by
     intro h
     have := congr_fun (congr_arg DFunLike.coe h) 1


### PR DESCRIPTION
## Summary
- move the shared determinant scaffolding into `ChannelDeterminant.Internal` in `Basic.lean` and replace the repeated full copies in the downstream determinant files by small file-local aliases
- move the seven split-only helper declarations under `ChannelDeterminant.Internal`, restoring the intended non-root namespace surface while keeping the internal cross-file API available
- prune `Basic.lean`'s import graph and add the needed direct downstream imports in `Bound.lean`, `HilbertSchmidt.lean`, and `UnitaryCharacterization.lean`

## Notes
- The earlier wrapper / Heisenberg-dual wording fixes from #695 are already present on `origin/main`, and `extract_unitary_from_inner_form`'s docstring already matches the implemented `V := (√c)⁻¹ • P`, `U := Vᴴ` construction there, so this PR focuses on the remaining namespace/import hygiene work only.

Follow-up from #695.
Closes #705.

## Verification
- `lake build TNLean.Channel.Determinant`
- `lake env lean TNLean/Channel/Determinant/Basic.lean`
- `lake env lean TNLean/Channel/Determinant/Bound.lean`
- `lake env lean TNLean/Channel/Determinant/HilbertSchmidt.lean`
- `lake env lean TNLean/Channel/Determinant/HeisenbergDual.lean`
- `lake env lean TNLean/Channel/Determinant/UnitaryCharacterization.lean`
- `lake env lean TNLean/Channel/Determinant.lean`
- `lake build`
- `rg -n "eq_zero_of_nonneg_of_sum_le_zero|channel_all_eigenvalues_norm_one|stdBasis_conjTranspose_eq_swap|sum_stdBasis_mul_conjTranspose|channelDet_norm_one_hs_norm_ge|heisenberg_dual_multiplicative|norm_prod_le_one_of_forall_mem'" TNLean/`
- `rg -n "sorry|axiom" TNLean/Channel/Determinant.lean TNLean/Channel/Determinant/*.lean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: mostly namespace moves, local aliases, and import graph adjustments with no algorithmic changes, but it can break downstream proofs if any reference updates were missed.
> 
> **Overview**
> Centralizes the shared `M_d(ℂ)`/endomorphism/basis scaffolding in `Basic.lean` under `ChannelDeterminant.Internal` and replaces repeated per-file copies in `Bound.lean`, `HilbertSchmidt.lean`, and `HeisenbergDual.lean` with small file-local aliases.
> 
> Moves previously root-level helper results (e.g. `norm_prod_le_one_of_forall_mem'`, `channel_all_eigenvalues_norm_one`, `heisenberg_dual_multiplicative`, and related Hilbert–Schmidt lemmas) into `ChannelDeterminant.Internal`, updating call sites (notably `UnitaryCharacterization.lean`) accordingly.
> 
> Prunes `Basic.lean`’s heavy imports and adds the necessary direct Mathlib imports in downstream modules (`Bound.lean`, `HilbertSchmidt.lean`, `UnitaryCharacterization.lean`) to keep dependencies explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddb231f6481b9d822b42f61137ef1f887b212f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->