### PR TITLE
refactor(Entropy): drop manual trace hypothesis on SSA corollaries

### DIFF
--- a/TNLean/Entropy/MutualInformation.lean
+++ b/TNLean/Entropy/MutualInformation.lean
@@ -56,7 +56,10 @@ tripartite mutual information `I(A:C) = S(ρ_A) + S(ρ_C) − S(ρ_AC)`.
 
 We state this corollary in the same tripartite form used by
 `subadditivity_ssa_trivial_B` to avoid any reshuffling of indices; it
-is the version directly consumed by MPDO RFP applications. -/
+is the version directly consumed by MPDO RFP applications. The
+middle-subsystem trace hypothesis is discharged inside
+`subadditivity_ssa_trivial_B` via `Matrix.traceAC_ABC_trace`, so the
+caller only supplies the full-system density-matrix witness. -/
 
 section Nonnegativity
 
@@ -68,14 +71,13 @@ form: `S(ρ_AB) + S(ρ_BC) − S(ρ_ABC) ≥ 0`. Direct corollary of
 theorem mutualInformation_ssa_trivial_B_nonneg
     (ρ_ABC : Matrix (Fin dA × Fin 1 × Fin dC)
       (Fin dA × Fin 1 × Fin dC) ℂ)
-    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
-    (h_mid_trace : (traceAC_ABC ρ_ABC).trace = 1) :
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :
     0 ≤ Entropy.vonNeumannEntropy (traceC_ABC ρ_ABC)
           (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
         + Entropy.vonNeumannEntropy (traceA_ABC ρ_ABC)
             (traceA_ABC_isHermitian hρ_dm.1.isHermitian)
         - Entropy.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian := by
-  have h := subadditivity_ssa_trivial_B ρ_ABC hρ_dm h_mid_trace
+  have h := subadditivity_ssa_trivial_B ρ_ABC hρ_dm
   linarith
 
 end Nonnegativity

--- a/TNLean/Entropy/StrongSubadditivity.lean
+++ b/TNLean/Entropy/StrongSubadditivity.lean
@@ -35,14 +35,17 @@ axiomatization of SSA is introduced.
 * `Entropy.strongSubadditivity_rearranged` — the algebraic
   rearrangement `S(ρ_ABC) − S(ρ_AB) ≤ S(ρ_BC) − S(ρ_B)` (the
   conditional-entropy form), proved from SSA alone.
+* `Matrix.traceA_ABC_trace`, `Matrix.traceC_ABC_trace`,
+  `Matrix.traceAC_ABC_trace` — total-trace preservation for the
+  tripartite partial traces. These are used below to derive the trace
+  of a reduced state from `ρ_ABC.trace = 1` without an auxiliary
+  caller-supplied hypothesis.
 * `Entropy.subadditivity_ssa_trivial_B` — subadditivity
   `S(ρ_ABC) ≤ S(ρ_AB) + S(ρ_BC)` in the tripartite form with
   trivial middle subsystem (`dB = 1`). The middle factor contributes
   zero entropy (by the `Fin 1` lemma above), so SSA specializes to
-  this inequality once we know `(ρ_B) = (traceAC ρ_ABC)` has trace 1.
-  We state it with the trace assumption as an explicit hypothesis to
-  keep the derivation elementary. Downstream code supplies that
-  hypothesis from the full-system trace condition.
+  this inequality; the trace of `(traceAC_ABC ρ_ABC)` equals
+  `ρ_ABC.trace = 1` by `Matrix.traceAC_ABC_trace`.
 
 ## TODO
 
@@ -68,6 +71,65 @@ A review with conditions for equality", JMP 43, 4358 (2002).
 
 open scoped Matrix ComplexOrder
 open Matrix Finset Real
+
+/-! ## Trace preservation for the tripartite partial traces
+
+The following three lemmas record that the tripartite partial traces
+`traceA_ABC`, `traceC_ABC`, `traceAC_ABC` (defined in
+`TNLean.Analysis.Entropy`) preserve the total trace of the underlying
+state. They let downstream SSA corollaries derive the auxiliary
+`trace = 1` hypothesis on a reduced state from the full-system
+`ρ.trace = 1` hypothesis, without the caller needing to re-prove it. -/
+
+namespace Matrix
+
+variable {dA dB dC : ℕ}
+
+/-- Total-trace preservation for the tripartite partial trace `traceA_ABC`:
+`tr(tr_A ρ) = tr ρ`. -/
+theorem traceA_ABC_trace
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    (Matrix.traceA_ABC ρ).trace = ρ.trace := by
+  simp only [Matrix.trace, Matrix.diag, Matrix.traceA_ABC]
+  rw [Finset.sum_comm]
+  exact (Fintype.sum_prod_type
+    (fun x : Fin dA × (Fin dB × Fin dC) => ρ x x)).symm
+
+/-- Total-trace preservation for the tripartite partial trace `traceC_ABC`:
+`tr(tr_C ρ) = tr ρ`. -/
+theorem traceC_ABC_trace
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    (Matrix.traceC_ABC ρ).trace = ρ.trace := by
+  simp only [Matrix.trace, Matrix.diag, Matrix.traceC_ABC]
+  rw [Fintype.sum_prod_type
+    (fun ab : Fin dA × Fin dB => ∑ c, ρ (ab.1, ab.2, c) (ab.1, ab.2, c))]
+  rw [show (∑ x : Fin dA × Fin dB × Fin dC, ρ x x)
+        = ∑ a : Fin dA, ∑ bc : Fin dB × Fin dC, ρ (a, bc) (a, bc) from
+      Fintype.sum_prod_type
+        (fun x : Fin dA × (Fin dB × Fin dC) => ρ x x)]
+  refine Finset.sum_congr rfl fun a _ => ?_
+  exact (Fintype.sum_prod_type
+    (fun bc : Fin dB × Fin dC => ρ (a, bc) (a, bc))).symm
+
+/-- Total-trace preservation for the tripartite partial trace `traceAC_ABC`:
+`tr(tr_{AC} ρ) = tr ρ`. -/
+theorem traceAC_ABC_trace
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    (Matrix.traceAC_ABC ρ).trace = ρ.trace := by
+  simp only [Matrix.trace, Matrix.diag, Matrix.traceAC_ABC]
+  rw [Finset.sum_comm]
+  rw [show (∑ x : Fin dA × Fin dB × Fin dC, ρ x x)
+        = ∑ a : Fin dA, ∑ bc : Fin dB × Fin dC, ρ (a, bc) (a, bc) from
+      Fintype.sum_prod_type
+        (fun x : Fin dA × (Fin dB × Fin dC) => ρ x x)]
+  refine Finset.sum_congr rfl fun a _ => ?_
+  exact (Fintype.sum_prod_type
+    (fun bc : Fin dB × Fin dC => ρ (a, bc) (a, bc))).symm
+
+end Matrix
 
 namespace Entropy
 
@@ -167,9 +229,9 @@ middle subsystem contributes zero entropy, so SSA reduces to the
 classical subadditivity `S(ρ_AC) ≤ S(ρ_A) + S(ρ_C)` on bipartite
 states lifted through the trivial middle factor.
 
-To keep the derivation elementary, we require the trace of the
-partial-trace `ρ_B = traceAC_ABC ρ_ABC` explicitly as a hypothesis;
-this is always satisfied when `ρ_ABC` has trace 1. -/
+The trace of `ρ_B = traceAC_ABC ρ_ABC` is derived internally from
+`ρ_ABC.trace = 1` via the trace-preservation lemma
+`Matrix.traceAC_ABC_trace`; no auxiliary hypothesis is required. -/
 
 section Subadditivity
 
@@ -181,22 +243,20 @@ trivial middle subsystem).
 For a density matrix `ρ_ABC` on `A ⊗ 1 ⊗ C`, SSA reduces to
 `S(ρ_ABC) ≤ S(ρ_AB) + S(ρ_BC)` because the `Fin 1`-indexed middle
 reduced state contributes zero entropy (see
-`vonNeumannEntropy_eq_zero_of_fin_one`).
-
-The second hypothesis `h_mid_trace` records that `(ρ_B)` has unit
-trace; this follows from `trace ρ_ABC = 1` by a short direct
-computation left to the caller. -/
+`vonNeumannEntropy_eq_zero_of_fin_one`). The middle reduced state
+has unit trace by `Matrix.traceAC_ABC_trace`. -/
 theorem subadditivity_ssa_trivial_B
     (ρ_ABC : Matrix (Fin dA × Fin 1 × Fin dC)
       (Fin dA × Fin 1 × Fin dC) ℂ)
-    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
-    (h_mid_trace : (traceAC_ABC ρ_ABC).trace = 1) :
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :
     Entropy.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
     ≤ Entropy.vonNeumannEntropy (traceC_ABC ρ_ABC)
           (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
       + Entropy.vonNeumannEntropy (traceA_ABC ρ_ABC)
           (traceA_ABC_isHermitian hρ_dm.1.isHermitian) := by
   have hSSA := strongSubadditivity ρ_ABC hρ_dm
+  have h_mid_trace : (traceAC_ABC ρ_ABC).trace = 1 := by
+    rw [Matrix.traceAC_ABC_trace]; exact hρ_dm.2
   have h_mid_zero :
       Entropy.vonNeumannEntropy (traceAC_ABC ρ_ABC)
           (traceAC_ABC_isHermitian hρ_dm.1.isHermitian) = 0 :=


### PR DESCRIPTION
### Motivation

- Tighten the SSA corollary API in `TNLean/Entropy/`: callers previously had to
  supply a redundant `(traceAC_ABC ρ).trace = 1` hypothesis on top of the density-matrix
  witness, which is derivable from `ρ.trace = 1`.
- Provide reusable partial-trace preservation lemmas for tripartite states, filling
  a small gap in the entropy infrastructure toward #239.

### Description

- `TNLean/Entropy/StrongSubadditivity.lean`: added three `Matrix` lemmas
  `traceA_ABC_trace`, `traceC_ABC_trace`, `traceAC_ABC_trace` stating that the
  tripartite partial traces preserve the total trace.
- `TNLean/Entropy/StrongSubadditivity.lean`: `subadditivity_ssa_trivial_B` now
  derives `(traceAC_ABC ρ).trace = 1` internally via `traceAC_ABC_trace`, so the
  caller-supplied hypothesis is dropped. Updated docstring/comments accordingly.
- `TNLean/Entropy/MutualInformation.lean`: `mutualInformation_ssa_trivial_B_nonneg`
  updated to the tightened hypothesis surface (only the density-matrix witness
  `hρ_dm : ρ.PosSemidef ∧ ρ.trace = 1`).
- No new `sorry`s, no new axioms; the SSA/Klein-inequality blocker for fully
  closing #239 is untouched -- this is a surface-tightening change only.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate `lake build TNLean`.
- No new `sorry`/`axiom` introduced (verify with
  `rg -n "sorry|axiom" TNLean/Entropy/StrongSubadditivity.lean TNLean/Entropy/MutualInformation.lean`).

---
Addresses #239

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: proof-only Lean changes that add trace-preservation lemmas and simplify theorem hypotheses; potential impact is limited to callers of the updated theorem signatures.
> 
> **Overview**
> Simplifies SSA-derived subadditivity and mutual-information nonnegativity results by **removing the extra caller-supplied reduced-state trace hypothesis**; `subadditivity_ssa_trivial_B` now derives `tr(traceAC_ABC ρ)=1` directly from `ρ.trace = 1`.
> 
> Adds three `Matrix` lemmas (`traceA_ABC_trace`, `traceC_ABC_trace`, `traceAC_ABC_trace`) stating that tripartite partial traces preserve total trace, and updates documentation/comments to reflect the new internal discharge of the trace condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 011dda691c56a75275f75ba5ee7d3b72fb6fa24d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->