### PR TITLE
feat(Channel/FixedPoint): add weighted fixed-point algebra corollary (#27)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -98,6 +98,7 @@ import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp
+import TNLean.Channel.FixedPoint.Corollaries
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Irreducible.Growth

--- a/TNLean/Channel/FixedPoint/Corollaries.lean
+++ b/TNLean/Channel/FixedPoint/Corollaries.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.Algebra
+import TNLean.Channel.FixedPoint.CanonicalGauge
+import TNLean.MPS.Core.TPGauge
+
+/-!
+# Corollaries on weighted fixed-point algebras
+
+This file proves Wolf Corollary 6.7 for the Schrödinger-picture fixed-point
+space of a trace-preserving Kraus map.
+
+Given a positive-definite fixed point $\rho$ of the map
+$T(X) = \sum_i K_i X K_i^\dagger$, the similarity-transformed Kraus family
+$\rho^{-1/2} K_i \rho^{1/2}$ is unital. Applying Wolf Theorem 6.12 to that
+unital family shows that the conjugated fixed-point space
+$\rho^{-1/2} \Fix(T) \rho^{-1/2}$ is a `StarSubalgebra` of `M_D(\mathbb{C})`.
+
+## Main declarations
+
+* `Kraus.rightCanonicalGauge`: the Kraus family `ρ^{-1/2} K_i ρ^{1/2}`.
+* `Kraus.weightedFixedPointsStarSubalgebra`: Wolf Corollary 6.7.
+* `Kraus.mem_weightedFixedPointsStarSubalgebra_iff`: membership is equivalent
+  to saying that `ρ^{1/2} X ρ^{1/2}` is fixed by the original map.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Cor. 6.7, §6.4]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder TNMatrixCFC BigOperators
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The right-canonical gauge `ρ^{-1/2} K_i ρ^{1/2}` attached to a positive
+fixed point `ρ`. -/
+noncomputable def rightCanonicalGauge (K : Fin d → Mat) (ρ : Mat) : Fin d → Mat :=
+  fun i => (CFC.sqrt ρ)⁻¹ * K i * CFC.sqrt ρ
+
+/-- The Kraus map of the right-canonical gauge is the similarity transform of
+`map K` by `ρ^{1/2}`. -/
+theorem map_rightCanonicalGauge
+    (K : Fin d → Mat) (ρ : Mat) (X : Mat) :
+    map (rightCanonicalGauge K ρ) X =
+      (CFC.sqrt ρ)⁻¹ * map K (CFC.sqrt ρ * X * CFC.sqrt ρ) * (CFC.sqrt ρ)⁻¹ := by
+  set S : Mat := CFC.sqrt ρ
+  have hS_herm : Sᴴ = S := by
+    simpa [S] using MPSTensor.conjTranspose_cfc_sqrt (D := D) ρ
+  calc
+    map (rightCanonicalGauge K ρ) X
+        = ∑ i : Fin d, (S⁻¹ * K i * S) * X * (S⁻¹ * K i * S)ᴴ := by
+            simp [map, rightCanonicalGauge, S]
+    _ = ∑ i : Fin d, S⁻¹ * (K i * (S * X * S) * (K i)ᴴ) * S⁻¹ := by
+          refine Finset.sum_congr rfl ?_
+          intro i _
+          rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+            Matrix.conjTranspose_nonsing_inv]
+          simp [Matrix.mul_assoc, hS_herm]
+    _ = (∑ i : Fin d, S⁻¹ * (K i * (S * X * S) * (K i)ᴴ)) * S⁻¹ := by
+          rw [← Finset.sum_mul]
+    _ = S⁻¹ * (∑ i : Fin d, K i * (S * X * S) * (K i)ᴴ) * S⁻¹ := by
+          rw [← Finset.mul_sum]
+    _ = S⁻¹ * map K (S * X * S) * S⁻¹ := by
+          simp [map, Matrix.mul_assoc, S]
+
+/-- A matrix is fixed by the right-canonical gauge exactly when its conjugate by
+`ρ^{1/2}` is fixed by the original map. -/
+theorem map_rightCanonicalGauge_eq_iff
+    (K : Fin d → Mat) {ρ : Mat} (hρ : ρ.PosDef) (X : Mat) :
+    map (rightCanonicalGauge K ρ) X = X ↔
+      map K (CFC.sqrt ρ * X * CFC.sqrt ρ) = CFC.sqrt ρ * X * CFC.sqrt ρ := by
+  set S : Mat := CFC.sqrt ρ
+  have hS_det : IsUnit S.det := by
+    simpa [S] using MPSTensor.isUnit_det_cfc_sqrt_of_posDef (D := D) ρ hρ
+  have hSinv_mul : S⁻¹ * S = 1 := Matrix.nonsing_inv_mul S hS_det
+  have hSmul_inv : S * S⁻¹ = 1 := Matrix.mul_nonsing_inv S hS_det
+  have hmap : map (rightCanonicalGauge K ρ) X = S⁻¹ * map K (S * X * S) * S⁻¹ := by
+    simpa [S] using map_rightCanonicalGauge (K := K) ρ X
+  constructor
+  · intro h
+    have h2 : S⁻¹ * map K (S * X * S) = X * S := by
+      calc
+        S⁻¹ * map K (S * X * S)
+            = (S⁻¹ * map K (S * X * S)) * (S⁻¹ * S) := by rw [hSinv_mul, Matrix.mul_one]
+        _ = ((S⁻¹ * map K (S * X * S)) * S⁻¹) * S := by simp [Matrix.mul_assoc]
+        _ = X * S := by rw [← hmap, h]
+    have h3 : map K (S * X * S) = S * (X * S) := by
+      calc
+        map K (S * X * S) = (S * S⁻¹) * map K (S * X * S) := by rw [hSmul_inv, Matrix.one_mul]
+        _ = S * (S⁻¹ * map K (S * X * S)) := by simp [Matrix.mul_assoc]
+        _ = S * (X * S) := by rw [h2]
+    simpa [Matrix.mul_assoc] using h3
+  · intro h
+    calc
+      map (rightCanonicalGauge K ρ) X = S⁻¹ * map K (S * X * S) * S⁻¹ := hmap
+      _ = S⁻¹ * (S * X * S) * S⁻¹ := by rw [h]
+      _ = (S⁻¹ * S) * X * (S * S⁻¹) := by simp [Matrix.mul_assoc]
+      _ = X := by simp [hSinv_mul, hSmul_inv]
+/-- The right-canonical gauge is unital when `ρ` is a fixed point of the
+original Schrödinger map. -/
+theorem isUnital_rightCanonicalGauge
+    (K : Fin d → Mat) {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) :
+    IsUnital (rightCanonicalGauge K ρ) := by
+  set S : Mat := CFC.sqrt ρ
+  have hS_det : S.det ≠ 0 := by
+    exact (MPSTensor.isUnit_det_cfc_sqrt_of_posDef (D := D) ρ hρ).ne_zero
+  have hS_herm : Sᴴ = S := by
+    simpa [S] using MPSTensor.conjTranspose_cfc_sqrt (D := D) ρ
+  have hSS : S * Sᴴ = ρ := by
+    calc
+      S * Sᴴ = S * S := by rw [hS_herm]
+      _ = ρ := by
+            simpa [S] using MPSTensor.cfc_sqrt_mul_self_of_posDef (D := D) ρ hρ
+  have hρ_fix_transfer : MPSTensor.transferMap (d := d) (D := D) K ρ = ρ := by
+    simpa [map, MPSTensor.transferMap_apply] using hρ_fix
+  simpa [IsUnital, rightCanonicalGauge, S, hS_herm, Matrix.mul_assoc] using
+    (gauged_unital (A := K) (S := S) (ρ := ρ) hS_det hSS hρ_fix_transfer)
+
+/-- The original positive-definite fixed point `ρ` is fixed by the adjoint map
+of the right-canonical gauge whenever `K` is trace-preserving. -/
+theorem adjointMap_rightCanonicalGauge_fixedPoint
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ : ρ.PosDef) :
+    adjointMap (rightCanonicalGauge K ρ) ρ = ρ := by
+  set S : Mat := CFC.sqrt ρ
+  have hGauge : rightCanonicalGauge K ρ = fun i => S⁻¹ * K i * S := by
+    ext i
+    simp [rightCanonicalGauge, S]
+  have hS_det : IsUnit S.det := by
+    simpa [S] using MPSTensor.isUnit_det_cfc_sqrt_of_posDef (D := D) ρ hρ
+  have hS_herm : Sᴴ = S := by
+    simpa [S] using MPSTensor.conjTranspose_cfc_sqrt (D := D) ρ
+  have hSS : S * S = ρ := by
+    simpa [S] using MPSTensor.cfc_sqrt_mul_self_of_posDef (D := D) ρ hρ
+  have hSinv_mul : S⁻¹ * S = 1 := Matrix.nonsing_inv_mul S hS_det
+  have hSmul_inv : S * S⁻¹ = 1 := Matrix.mul_nonsing_inv S hS_det
+  rw [hGauge]
+  have h_term :
+      ∀ i : Fin d,
+        (S⁻¹ * K i * S)ᴴ * (S * S) * (S⁻¹ * K i * S) = S * (K i)ᴴ * K i * S := by
+    intro i
+    calc
+      (S⁻¹ * K i * S)ᴴ * (S * S) * (S⁻¹ * K i * S)
+          = Sᴴ * (K i)ᴴ * (Sᴴ)⁻¹ * (S * S) * S⁻¹ * K i * S := by
+              rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+                Matrix.conjTranspose_nonsing_inv]
+              simp [Matrix.mul_assoc]
+      _ = S * (K i)ᴴ * K i * S := by
+            rw [hS_herm]
+            simp [Matrix.mul_assoc, hSinv_mul, hSmul_inv]
+  have hcalc : adjointMap (fun i => S⁻¹ * K i * S) (S * S) = S * S := by
+    calc
+      adjointMap (fun i => S⁻¹ * K i * S) (S * S)
+          = ∑ i : Fin d, (S⁻¹ * K i * S)ᴴ * (S * S) * (S⁻¹ * K i * S) := by
+              simp [adjointMap]
+      _ = ∑ i : Fin d, S * (K i)ᴴ * K i * S := by
+            exact Finset.sum_congr rfl (fun i _ => h_term i)
+      _ = (∑ i : Fin d, S * ((K i)ᴴ * K i)) * S := by
+            simp [Matrix.mul_assoc, Finset.sum_mul]
+      _ = S * (∑ i : Fin d, (K i)ᴴ * K i) * S := by
+            simp [Finset.mul_sum]
+      _ = S * S := by rw [h_tp, Matrix.mul_one]
+  simpa [hSS] using hcalc
+
+/-- **Wolf Corollary 6.7**.
+
+If `T(X) = ∑ i, K_i X K_i†` is trace-preserving and `ρ > 0` is a fixed point of
+`T`, then `ρ^{-1/2} Fix(T) ρ^{-1/2}` is a `*`-subalgebra of `M_D(ℂ)`. -/
+noncomputable def weightedFixedPointsStarSubalgebra
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat}
+    (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) :
+    StarSubalgebra ℂ Mat :=
+  fixedPointsStarSubalgebra
+    (K := rightCanonicalGauge K ρ)
+    (h_unital := isUnital_rightCanonicalGauge (K := K) hρ hρ_fix)
+    (ρ := ρ) hρ
+    (adjointMap_rightCanonicalGauge_fixedPoint (K := K) h_tp hρ)
+
+@[simp] theorem mem_weightedFixedPointsStarSubalgebra_iff
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat}
+    (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) (X : Mat) :
+    X ∈ weightedFixedPointsStarSubalgebra (K := K) h_tp hρ hρ_fix ↔
+      map K (CFC.sqrt ρ * X * CFC.sqrt ρ) = CFC.sqrt ρ * X * CFC.sqrt ρ := by
+  change map (rightCanonicalGauge K ρ) X = X ↔
+    map K (CFC.sqrt ρ * X * CFC.sqrt ρ) = CFC.sqrt ρ * X * CFC.sqrt ρ
+  exact map_rightCanonicalGauge_eq_iff (K := K) (ρ := ρ) hρ X
+
+end Kraus

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -6,6 +6,8 @@ import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.ConditionalExpectation
 import TNLean.Channel.FixedPoint.StationarySupport
+import TNLean.Channel.FixedPoint.WedderburnDecomp
+import TNLean.Channel.FixedPoint.Corollaries
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Irreducible.Growth
@@ -238,25 +240,46 @@ In `TNLean.Channel.FixedPoint.Algebra`:
 * `IsChannel.posSemidef_parts_of_hermitian_fixedPoint` — `TNLean.Channel.FixedPoint.Cesaro`
 * Numbered wrapper: `IsChannel.wolf_prop_6_8` — `TNLean.Channel.WolfChapter6Wrappers`
 
+### Wolf Corollary 6.6 (projected support corner) — NOT YET FORMALIZED
+
+The intended statement is that the corner
+`{Y ∈ Q M_D(ℂ) Q | Q T*(Y) Q = Y}` forms a `*`-algebra.
+
+Current blocker: the repository exposes the corner only as the `Submodule`
+`cornerSubmodule Q`, not yet as a unital `*`-algebra with unit `Q`, so the
+corner-fixed-point statement is not yet packaged at the right algebraic level.
+
 ### Wolf Theorem 6.14 (Wedderburn decomposition of fixed-point algebra) — PARTIALLY FORMALIZED
 
 In `TNLean.Channel.FixedPoint.WedderburnDecomp`:
 
+* `Kraus.starSubalgebra_isSemisimpleRing` — every finite-dimensional
+  `*`-subalgebra of `M_D(ℂ)` is semisimple.
 * `Kraus.FixedPointAlgebra` — type alias for the carrier of the
   adjoint-fixed-point `StarSubalgebra`.
-* `Kraus.fixedPointAlgebra_isSemisimpleRing` — the fixed-point algebra is
-  semisimple (sorry — needs Jacobson radical argument for `*`-algebras).
+* `Kraus.fixedPointAlgebra_isSemisimpleRing` — the adjoint-fixed-point
+  algebra is semisimple.
 * `Kraus.fixedPointAlgebra_wedderburnArtin` — abstract Wedderburn--Artin:
-  `Fix(T*) ≃ₐ[ℂ] Π i, M_{d_i}(ℂ)` (sorry — depends on semisimplicity).
-* `Kraus.IsWedderburnBlockDecomp` — bundled data for the concrete
-  block-diagonal form `U(⊕_k M_{d_k} ⊗ 1_{m_k})U†` (Wolf Eq. 1.39).
-* `Kraus.adjointFixedPoints_wedderburnDecomp` — the fixed-point algebra
-  admits a Wedderburn block decomposition (sorry — depends on concrete
-  embedding construction).
+  `Fix(T*) ≃ₐ[ℂ] Π i, M_{d_i}(ℂ)`.
+* `Kraus.IsWedderburnBlockDecomp` — bundled decomposition data consisting of
+  block sizes, multiplicities, an ambient-dimension bound, and an algebra
+  isomorphism to a product of full matrix algebras.
+* `Kraus.adjointFixedPoints_wedderburnDecomp` — existence of this
+  decomposition data for the adjoint-fixed-point algebra.
 
-The concrete unitary embedding (Wolf Eq. 1.39) and the conditional
-expectation with density operators ρ_k (Wolf Eq. 1.40, full Thm 6.14)
-are deferred to future work.
+What is still missing for the full Wolf statement is the concrete unitary
+realization `Fix(T*) = U (0 ⊕ ⊕_k M_{d_k} ⊗ 1_{m_k}) U†` and the density-block
+refinement with matrices `ρ_k`.
+
+### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED
+
+In `TNLean.Channel.FixedPoint.Corollaries`:
+
+* `Kraus.rightCanonicalGauge` — the gauged family `ρ^{-1/2} K_i ρ^{1/2}`.
+* `Kraus.weightedFixedPointsStarSubalgebra` — if `T(ρ) = ρ` with `ρ > 0`,
+  then `ρ^{-1/2} Fix(T) ρ^{-1/2}` is a `StarSubalgebra`.
+* `Kraus.mem_weightedFixedPointsStarSubalgebra_iff` — membership is
+  equivalent to saying that `ρ^{1/2} X ρ^{1/2}` is fixed by the original map.
 
 ### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — PARTIALLY FORMALIZED
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -247,7 +247,7 @@ The intended statement is that the corner
 
 Current blocker: the repository exposes the corner only as the `Submodule`
 `cornerSubmodule Q`, not yet as a unital `*`-algebra with unit `Q`, so the
-corner-fixed-point statement is not yet packaged at the right algebraic level.
+corner-fixed-point statement is not yet formulated at the right algebraic level.
 
 ### Wolf Theorem 6.14 (Wedderburn decomposition of fixed-point algebra) — PARTIALLY FORMALIZED
 

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1039,8 +1039,9 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     \uses{thm:fixedPointAlgebra_wedderburnArtin}
     Apply the abstract Wedderburn decomposition
     (Theorem~\ref{thm:fixedPointAlgebra_wedderburnArtin}).
-    The remaining integers $m_k$ and the dimension bound are recorded in the
-    bundled decomposition data attached to the fixed-point algebra.
+    Since the adjoint-fixed-point algebra is realized as a subalgebra of the
+    ambient matrix algebra $\MN{D}$, this realization also yields
+    multiplicities $m_k$ and the bound $\sum_k d_k m_k \le D$.
 \end{proof}
 
 \begin{remark}[Pending part of Wolf Thm.~6.14]

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1018,19 +1018,68 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     semisimple algebras over an algebraically closed field.
 \end{proof}
 
-\begin{theorem}[Fixed-point algebra admits Wedderburn block decomposition]%
+\begin{theorem}[Wedderburn data with ambient dimension bound]%
     \label{thm:adjointFixedPoints_wedderburnDecomp}
     \lean{Kraus.adjointFixedPoints_wedderburnDecomp}
-    \notready
+    \leanok
     \uses{thm:fixedPointAlgebra_wedderburnArtin}
-    The adjoint-fixed-point $*$-subalgebra admits a concrete Wedderburn
-    block decomposition inside the ambient matrix algebra (Wolf Eq.~1.39).
+    There exist integers $n$, block sizes $d_1,\dots,d_n \ge 1$,
+    multiplicities $m_1,\dots,m_n \ge 1$, and a $\C$-algebra isomorphism from
+    the adjoint-fixed-point $*$-subalgebra to
+    \[
+        \prod_{k=1}^{n} M_{d_k}(\C)
+    \]
+    such that
+    \[
+        \sum_{k=1}^{n} d_k m_k \le D.
+    \]
 \end{theorem}
 \begin{proof}
-    \notready
-    Follows immediately from the general result that every
-    $*$-subalgebra of $M_D(\mathbb{C})$ admits a Wedderburn block
-    decomposition, applied to the adjoint-fixed-point algebra.
+    \leanok
+    \uses{thm:fixedPointAlgebra_wedderburnArtin}
+    Apply the abstract Wedderburn decomposition
+    (Theorem~\ref{thm:fixedPointAlgebra_wedderburnArtin}).
+    The remaining integers $m_k$ and the dimension bound are recorded in the
+    bundled decomposition data attached to the fixed-point algebra.
+\end{proof}
+
+\begin{remark}[Pending part of Wolf Thm.~6.14]
+    The stronger ambient statement that the adjoint-fixed-point algebra is
+    unitarily conjugate to
+    \[
+        0 \oplus \bigoplus_k M_{d_k}(\C) \otimes \Id_{m_k}
+    \]
+    together with the density-block form $M_{d_k}(\C) \otimes \rho_k$ is not
+    yet formalized.
+\end{remark}
+
+\begin{theorem}[Wolf Cor.~6.7]%
+    \label{thm:weightedFixedPointsStarSubalgebra}
+    \lean{Kraus.weightedFixedPointsStarSubalgebra}
+    \leanok
+    \uses{def:tp_kraus, thm:fixedPointsStarSubalgebra}
+    Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving, and let
+    $\rho > 0$ satisfy $T(\rho) = \rho$. If
+    \[
+        F_T := \{X \in \MN{D} \mid T(X) = X\},
+    \]
+    then $\rho^{-1/2} F_T \rho^{-1/2}$ is a $*$-subalgebra of $\MN{D}$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:fixedPointsStarSubalgebra}
+    Set $B_i = \rho^{-1/2} K_i \rho^{1/2}$. The equation $T(\rho) = \rho$
+    implies that the family $\{B_i\}$ is unital, and trace preservation of $T$
+    implies that $\rho$ is a positive-definite fixed point of the adjoint map
+    of the gauged family. Apply Theorem~\ref{thm:fixedPointsStarSubalgebra}
+    to $B$. The identity
+    \[
+        \sum_i B_i X B_i^\dagger = X
+        \iff
+        T(\rho^{1/2} X \rho^{1/2}) = \rho^{1/2} X \rho^{1/2}
+    \]
+    identifies the fixed points of the gauged map with
+    $\rho^{-1/2} F_T \rho^{-1/2}$.
 \end{proof}
 
 \section{Additional Wolf Chapter~6 equivalences}


### PR DESCRIPTION
## Summary
- add `TNLean/Channel/FixedPoint/Corollaries.lean` with Wolf Cor. 6.7 as the weighted fixed-point `*`-algebra `ρ^{-1/2} Fix(T) ρ^{-1/2}`
- expose the right-canonical gauged Kraus family and the membership equivalence relating the gauged fixed points to the original Schrödinger fixed points
- sync the Chapter 6 index and blueprint so the Wedderburn section reflects the current partial status honestly and records the new Cor. 6.7 theorem

## Main declarations
- `Kraus.rightCanonicalGauge`
- `Kraus.map_rightCanonicalGauge`
- `Kraus.map_rightCanonicalGauge_eq_iff`
- `Kraus.isUnital_rightCanonicalGauge`
- `Kraus.adjointMap_rightCanonicalGauge_fixedPoint`
- `Kraus.weightedFixedPointsStarSubalgebra`
- `Kraus.mem_weightedFixedPointsStarSubalgebra_iff`

## Residual blockers
- **Wolf Cor. 6.6** is still open: the repository currently exposes the support corner only as `cornerSubmodule Q`, not yet as a unital `*`-algebra with unit `Q`.
- **Wolf Thm. 6.14** remains partial: `WedderburnDecomp.lean` already gives semisimplicity, the abstract product decomposition, and a weaker ambient-dimension decomposition datum, but not yet the concrete unitary realization `U (0 ⊕ ⊕_k M_{d_k} ⊗ 1_{m_k}) U†` or the density-block refinement `ρ_k`.

## Verification
- `cd .worktrees/issue-27 && lake env lean TNLean/Channel/FixedPoint/Corollaries.lean`
- `cd .worktrees/issue-27 && lake env lean TNLean/Channel/WolfChapter6Index.lean`
- `cd .worktrees/issue-27 && lake env lean TNLean.lean`
- `cd .worktrees/issue-27 && lake build`
- `cd .worktrees/issue-27 && rg -n "sorry|axiom" TNLean/Channel/FixedPoint/Corollaries.lean TNLean/Channel/WolfChapter6Index.lean TNLean.lean blueprint/src/chapter/ch06_spectral.tex`
- `cd .worktrees/issue-27/blueprint && leanblueprint web && leanblueprint checkdecls`

Note: the `rg` check still finds the pre-existing comment `TNLean.lean:71` mentioning sanctioned entropy axioms; the new fixed-point corollary file itself is free of `sorry`/`axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new theorems/modules and documentation with minimal impact on existing definitions; risk is mainly around proof brittleness/maintenance in the new Lean developments.
> 
> **Overview**
> Adds a new fixed-point corollary module proving **Wolf Corollary 6.7**: for a trace-preserving Kraus map with a positive-definite Schrödinger fixed point `ρ`, the conjugated space `ρ^{-1/2} Fix(T) ρ^{-1/2}` forms a `StarSubalgebra`.
> 
> The PR introduces `Kraus.rightCanonicalGauge` and supporting lemmas connecting its Kraus map to a similarity transform of `map K`, proves the gauge is unital and that `ρ` remains a fixed point of the gauged adjoint map under trace-preservation, and provides a simp lemma characterizing membership in the new subalgebra.
> 
> It wires the new module into the library import surface (`TNLean.lean`), updates the Chapter 6 index to document the new result and clarify Wedderburn formalization status, and syncs the blueprint text to mark the Wedderburn “data with dimension bound” theorem as `leanok` and add the new Cor. 6.7 statement/proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67cd6b5afaeac9ab32c1d4d1e54bcf8e88eb9150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->