### PR TITLE
refactor(blueprint): move residual Gemma periodic FT into ch11b (#708)

### DIFF
--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -16,9 +16,9 @@ The theorems in Sections~\ref{sec:assembly_weak}--\ref{sec:assembly_equal}
 follow the approach of \cite{Cirac2017MPDO_AnnPhys}:
 they first block the tensor to remove non-trivial periodicity, then
 apply the aperiodic fundamental theorem.
-Section~\ref{sec:periodic_ft} outlines the stronger
+Chapter~\ref{ch:periodic_ft_apps} records the stronger
 ``irreducible form'' framework of \cite{DeLasCuevas2017Irreducible},
-which gives a fundamental theorem valid for periodic tensors directly,
+which gives a Fundamental Theorem valid for periodic tensors directly,
 with an extra $Z$-gauge degree of freedom.
 
 \section{Weak Fundamental Theorem}%
@@ -142,7 +142,8 @@ distinct weight norms).
 	Theorem~\ref{thm:bnt_perm_prop} is formulated in that abstract form.
 \end{remark}
 
-\begin{theorem}[Fundamental Theorem for normal canonical form in the proportional case]\label{thm:ft_proportional_nt}
+\begin{theorem}[Fundamental Theorem for normal canonical form in the proportional case]%
+\label{thm:ft_proportional_nt}
 		\lean{MPSTensor.fundamentalTheorem_proportionalMPV_normalCFBNT}\leanok
 		\uses{def:normal_cf_bnt, def:gauge_phase_equiv}
 		Let $A_{\mathrm{tot}}$ and $B_{\mathrm{tot}}$ be MPS tensors
@@ -219,7 +220,8 @@ distinct weight norms).
 	a global gauge equivalence.
 \end{proof}
 
-\begin{theorem}[Fundamental Theorem --- equal MPV case with explicit coefficients]\label{thm:ft_equal_explicit}
+\begin{theorem}[Fundamental Theorem --- equal MPV case with explicit coefficients]%
+\label{thm:ft_equal_explicit}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_full}
 	\leanok
 	\uses{def:cf_bnt, def:gauge_equiv}
@@ -302,7 +304,8 @@ distinct weight norms).
 	Definition~\ref{def:bnt}) directly.
 \end{remark}
 
-\begin{theorem}[Fundamental Theorem --- equal MPV case, common block structure]\label{thm:ft_equal_same_structure}
+\begin{theorem}[Fundamental Theorem --- equal MPV case, common block structure]%
+\label{thm:ft_equal_same_structure}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_CFBNT}
 	\leanok
 	\uses{def:cf_bnt, def:gauge_equiv}
@@ -394,7 +397,8 @@ single weighted block.
 \label{thm:route_b_equal}
 	\lean{MPSTensor.SectorWeightData.weight_multiset_eq_of_sameMPV_bnt}
 	\leanok
-	\uses{thm:coeff_eventually_eq, thm:geom_extrapolation, thm:power_sum_multiset, def:paper_sector_data, def:bnt}
+	\uses{thm:coeff_eventually_eq, thm:geom_extrapolation,
+			thm:power_sum_multiset, def:paper_sector_data, def:bnt}
 	Let $S$ and $T$ be two sector data over the same basis with
 	the same multiplicities ($r_j^S = r_j^T$ for all~$j$).
 	If the basis is eventually linearly independent and the total MPVs
@@ -439,346 +443,4 @@ single weighted block.
 	(a)~the proportional FT for block matching and gauge-phase equivalences,
 	(b)~phase absorption into weights, and
 	(c)~global gauge construction via permutation and cast transport.
-\end{remark}
-
-\section{Periodic Fundamental Theorem (de las Cuevas--Cirac--Schuch--Pérez-García)}%
-\label{sec:periodic_ft}
-
-The theorems in the preceding sections all require that each block has a
-\emph{primitive} transfer map, i.e.\ peripheral spectrum exactly $\{1\}$.
-This is achieved by blocking the original tensor by a common period.
-The paper \cite{DeLasCuevas2017Irreducible} develops a framework that
-avoids this blocking step, giving a fundamental theorem that applies
-directly to periodic tensors.
-
-\subsection{Irreducible form}
-
-The periodic-tensor and irreducible-form definitions are stated in
-Chapter~\ref{ch:periodic_ft_apps}
-(Definitions~\ref{def:periodic_tensor} and~\ref{def:irreducible_form}).
-
-\begin{remark}[Relation to normal canonical form]\notready
-	\label{rem:irr_form_vs_ncf}
-	Every tensor in normal canonical form
-	(Definition~\ref{def:is_normal_canonical_form})
-	is in irreducible form with all periods equal to~$1$.
-	The irreducible form is strictly more general: it accommodates
-	blocks such as the antiferromagnet, which are $2$-periodic.
-
-	The arguments in this chapter work exclusively with period-$1$ blocks,
-	obtained by a blocking step. A direct treatment of the irreducible form of
-	\cite{DeLasCuevas2017Irreducible} would require:
-	\begin{enumerate}
-		\item a definition of $m$-periodic irreducible tensors and
-		      their cyclic-sector decomposition (see below),
-		\item the off-diagonal structure of a periodic block's transfer
-		      matrix (the cyclic permutation of sectors), and
-		\item the notion of equivalence between periodic blocks that
-		      accounts for the $Z$-gauge freedom described below.
-	\end{enumerate}
-\end{remark}
-
-\subsection{Common-period blocking lemmas}
-
-\begin{definition}[LCM period for a finite block family]
-	\label{def:lcm_period}
-	\lean{MPSTensor.lcmPeriod}
-	\leanok
-	Given a finite family of blocking periods $(p_i)$ indexed by a finite set,
-	their least common multiple serves as the shared blocking period.
-\end{definition}
-
-\begin{definition}[Common-period blocked family]
-	\label{def:common_period_blocking}
-	\lean{MPSTensor.commonPeriodBlocking}
-	\leanok
-	\uses{def:lcm_period, def:blocked_tensor}
-	Given a finite family of tensors $(B_i)$ with designated periods $(p_i)$,
-	block each $B_i$ to the shared period $\operatorname{lcm}(p_i)$, so
-	every block lives in the same physical space.
-\end{definition}
-
-\begin{theorem}[Common-period blocking preserves transfer-map primitivity]
-	\label{thm:common_period_blocking_primitive}
-	\lean{MPSTensor.isPrimitive_transferMap_commonPeriodBlocking}
-	\leanok
-	\uses{def:common_period_blocking, thm:iterated_blocking_transfer, thm:primitive_blocking_divisible}
-	If each tensor $B_i$ has a primitive transfer map after blocking by its own
-	positive period $p_i$, then blocking the entire family to the common
-	LCM period preserves primitivity of each member's transfer map.
-\end{theorem}
-
-\begin{proof}\leanok
-	Each $p_i$ divides $\operatorname{lcm}(p_i)$.
-	Apply the divisibility monotonicity theorem for primitive blocked transfer maps
-	to each family member separately.
-\end{proof}
-
-\subsection{The \texorpdfstring{$Z$}{Z}-gauge degree of freedom}
-
-The \(Z\)-gauge definitions and lemmas are stated in
-Chapter~\ref{ch:periodic_ft_apps}
-(Definitions~\ref{def:z_gauge_entry}, \ref{def:z_gauge_diagonal},
-\ref{def:z_gauge_equiv}; Lemmas~\ref{lem:z_gauge_entry_pow},
-\ref{lem:z_gauge_entry_mul}, \ref{lem:z_gauge_diagonal_pow},
-\ref{lem:z_gauge_diagonal_mul}; and
-Remark~\ref{rem:z_gauge_trivial_period1}).
-
-\subsection{Statement of the periodic Fundamental Theorem}
-
-The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducible}.
-
-\begin{theorem}[Periodic Fundamental Theorem]\notready
-	\label{thm:periodic_ft}
-	\lean{MPSTensor.zgauge_construction, MPSTensor.equalCase_zgauge_pipeline, MPSTensor.fundamentalTheorem_periodic_equalCase_matching, MPSTensor.fundamentalTheorem_periodic_equalCase}
-	\uses{def:irreducible_form, def:z_gauge_equiv}
-	Let $A$ and $B$ be MPS tensors in irreducible form,
-	with bases of periodic blocks
-	$\{A_j\}_{j \in J}$ and $\{B_k\}_{k \in K}$ respectively.
-	Suppose that $\mathcal{V}(A) = \mathcal{V}(B)$
-	(equal MPV families for all lengths $N$).
-
-	Then $|J| = |K|$ and there is a bijection $\pi : J \to K$
-	such that $A_j$ and $B_{\pi(j)}$ are $m_j$-periodic for the same
-	period $m_j$.
-	Moreover, for each $j \in J$ there exists:
-	\begin{enumerate}
-		\item an invertible matrix $Y_j$ of size $D_j \times D_{\pi(j)}$,
-		      and
-		\item a diagonal unitary matrix $Z_j$ of size $D_j \times D_j$
-		      satisfying $Z_j^{m_j} = \Id$ and
-		      $[A_j^i, Z_j] = 0$ for all~$i$,
-	\end{enumerate}
-	such that
-	\[
-		Z_j\, A_j^i = Y_j\, B_{\pi(j)}^i\, Y_j^{-1}
-		\quad\text{for all physical indices } i.
-	\]
-	For each periodic block, the extra freedom is encoded by
-	\[
-		\TNPeriodicGauge{m_j}{Z_j}{m_j}
-	\]
-	rather than by an ordinary aperiodic gauge alone: the operator $Z_j$
-	sits on the closing virtual bond and satisfies $Z_j^{m_j}=\Id$.
-	Equivalently, setting $Y = \bigoplus_j Y_j \otimes \Id_{r_j}$
-	and $Z = \bigoplus_j Z_j \otimes \Id_{r_j}$, one has
-	$Z A^i = Y B^i Y^{-1}$ for all $i$,
-	with $[A^i, Z] = 0$ and $\mathcal{V}(A) = \mathcal{V}(ZA)$.
-
-	\noindent\emph{Remark.}
-	The proof is conditional on the periodic-overlap dichotomy
-	(Proposition~3.3 of~\cite{DeLasCuevas2017Irreducible}),
-	which remains to be proved.
-\end{theorem}
-
-\subsection{Periodic overlap dichotomy (Proposition 3.3)}
-
-\begin{definition}[Cyclic sector decomposition]%
-	\label{def:cyclic_sector_decomp}
-	\lean{MPSTensor.IsCyclicSectorDecomp}
-	\leanok
-	\uses{def:periodic_tensor}
-	A family of compressed sector tensors
-	$(C_k)_{k=0}^{m-1}$ on corner bond spaces forms a \emph{cyclic sector
-	decomposition} of the blocked tensor $A^{(m)}$ if there exist orthogonal
-	projections $P_0,\dotsc,P_{m-1}$ on the ambient bond space such that
-	$\sum_k P_k = \Id$, the projections satisfy the cyclic-shift relation
-	$E^\dagger(P_{k+1}) = P_k$, each $P_k$ commutes with every blocked letter
-	$P_k A^{(m)}_i = A^{(m)}_i P_k$,
-	$V^{(N)}(C_k)_\sigma = \tr(P_k (A^{(m)})^\sigma)$ for every word~$\sigma$,
-	and each block carries a $\ast$-algebra isomorphism
-	$\varphi_k : M_{\dim C_k}(\mathbb{C}) \xrightarrow{\sim}
-		P_k \cdot M_D(\mathbb{C}) \cdot P_k$
-	(multiplicative and adjoint-preserving) intertwining the compressed adjoint
-	transfer map with the sector adjoint transfer map on the corner of~$P_k$.
-\end{definition}
-
-\begin{definition}[One-site corner transition]%
-	\label{def:corner_transition}
-	\lean{MPSTensor.cornerTransition}
-	\leanok
-	\uses{def:cyclic_sector_decomp}
-	For a cyclic projection family $(P_k)_{k \in \mathrm{Fin}\,m}$ on the
-	ambient bond algebra of an MPS tensor $A$, the \emph{one-site corner
-	transition} at sector $k$ is the family of per-site matrices
-	\[
-		\tau_k(A)^i := P_k \cdot A^i \cdot P_{k+1}, \qquad i \in \mathrm{Fin}\,d,
-	\]
-	where the index $k+1$ is taken cyclically in $\mathrm{Fin}\,m$.
-\end{definition}
-
-\begin{definition}[Staircase evaluation]%
-	\label{def:corner_eval_word}
-	\lean{MPSTensor.cornerEvalWord}
-	\leanok
-	\uses{def:corner_transition}
-	For a word $w = (w_0,\dotsc,w_{L-1})$ on the physical index alphabet and
-	a starting sector $u$, the \emph{staircase evaluation} at $u$ is
-	\[
-		\mathrm{cornerEvalWord}(A, P, u, w)
-		:= P_u \cdot A^{w_0} \cdot P_{u+1} \cdot A^{w_1} \cdot P_{u+2}
-			\cdots A^{w_{L-1}} \cdot P_{u+L},
-	\]
-	defined recursively by
-	$\mathrm{cornerEvalWord}(A, P, u, \varepsilon) = P_u$ and
-	$\mathrm{cornerEvalWord}(A, P, u, i \cdot w) =
-	 P_u \cdot A^i \cdot \mathrm{cornerEvalWord}(A, P, u+1, w)$.
-\end{definition}
-
-\begin{definition}[Cyclic staircase product on blocked indices (Eq. A.8)]%
-	\label{def:blocked_corner_transition_tensor}
-	\lean{MPSTensor.blockedCornerTransitionTensor}
-	\leanok
-	\uses{def:corner_eval_word}
-	The \emph{blocked corner transition tensor} at sector $u$ is the
-	MPS tensor on blocked physical indices defined by
-	$i \mapsto \mathrm{cornerEvalWord}(A, P, u, w_i)$, where $w_i$ is the
-	length-$m$ physical word associated to the blocked index $i$. For a
-	blocked index $i$ with word $(i_0,\dotsc,i_{m-1})$ this returns the
-	ambient-algebra matrix
-	\[
-		P_u \cdot A^{i_0} \cdot P_{u+1} \cdot A^{i_1} \cdot P_{u+2}
-			\cdots P_{u+m-1} \cdot A^{i_{m-1}} \cdot P_u.
-	\]
-	This is the ambient matrix-algebra representative of the compressed
-	blocked sector tensor $C_u$ in a cyclic sector decomposition; the
-	identification with $C_u$ through the compression isometry $\varphi_u$
-	is Equation A.8 of~\cite{DeLasCuevas2017Irreducible}.
-\end{definition}
-
-\begin{theorem}[Self-overlap along period multiples]\label{thm:periodic_self_overlap_tendsto}
-	\lean{MPSTensor.periodicSelfOverlap_tendsto}
-	\notready
-	\uses{def:periodic_tensor}
-	If $A$ is $m$-periodic, then the self-overlap along multiples of $m$
-	converges to $m$ (the period, viewed as a scalar).
-\end{theorem}
-
-\begin{theorem}[Different periods imply asymptotic orthogonality]\label{thm:periodic_overlap_zero_ne_period}
-	\lean{MPSTensor.periodicOverlap_tendsto_zero_of_ne_period}
-	\leanok
-	\uses{def:periodic_tensor}
-	If $A$ and $B$ are periodic with different periods, then
-	$\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$.
-\end{theorem}
-\begin{proof}\leanok
-	Split on whether the bond dimensions agree. If not, dimension mismatch
-	gives decay. If $D_1 = D_2$, suppose for contradiction that $A$ and $B$
-	are gauge-phase equivalent; Perron--Frobenius eigenvalue uniqueness
-	(Wolf Theorem~6.3) then forces equal periods, contradicting the hypothesis.
-	Hence the tensors are not gauge-phase equivalent, and the overlap decays.
-\end{proof}
-
-\begin{lemma}[Sector-block normality for periodic tensors]\label{lem:sector_blocked_normal_periodic}
-	\lean{MPSTensor.sectorBlocked_isNormal_of_isPeriodic}
-	\leanok
-	\uses{def:periodic_tensor, def:cyclic_sector_decomp}
-	For a periodic tensor equipped with a cyclic sector decomposition,
-	each nonzero blocked sector tensor is normal.
-\end{lemma}
-
-\begin{theorem}[No sector match implies asymptotic orthogonality]\label{thm:periodic_overlap_zero_no_sector_match}
-	\lean{MPSTensor.periodicOverlap_tendsto_zero_of_no_sector_match}
-	\notready
-	\uses{def:periodic_tensor, lem:sector_blocked_normal_periodic}
-	If two periodic tensors with the same period admit no gauge-phase
-	matching sector pair after blocking, then their overlap tends to zero.
-\end{theorem}
-
-\begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}
-	\lean{MPSTensor.sectorMatch_propagation}
-	\notready
-	\uses{def:periodic_tensor}
-	A single gauge-phase match between blocked sectors propagates to all
-	cyclic translates of that sector pair.
-\end{lemma}
-
-\begin{lemma}[Per-site proportionality from blocked sector match]\label{lem:sector_tensor_proportional_blocked_match}
-	\lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
-	\notready
-	\uses{lem:sector_match_propagation}
-	If all aligned blocked sectors match up to gauge and phase, then the
-	original tensors are related by repeated-block proportionality.
-\end{lemma}
-
-\begin{theorem}[Sector match yields repeated-block equivalence]\label{thm:periodic_overlap_gauge_equiv_sector_match}
-	\lean{MPSTensor.periodicOverlap_gaugeEquiv_of_sector_match}
-	\notready
-	\uses{lem:sector_match_propagation, lem:sector_tensor_proportional_blocked_match}
-	For periodic tensors of the same period, existence of one matching
-	sector pair implies repeated-block equivalence.
-\end{theorem}
-
-\begin{theorem}[Different bond dimensions imply asymptotic orthogonality]\label{thm:periodic_overlap_zero_ne_dim}
-	\lean{MPSTensor.periodicOverlap_tendsto_zero_of_ne_dim}
-	\leanok
-	\uses{def:periodic_tensor}
-	If two periodic tensors have different bond dimensions, then
-	$\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$.
-\end{theorem}
-
-\begin{theorem}[Periodic overlap dichotomy]\label{thm:periodic_overlap_dichotomy}
-	\lean{MPSTensor.periodicOverlapDichotomy}
-	\notready
-	\uses{thm:periodic_overlap_zero_ne_period, thm:periodic_overlap_zero_no_sector_match, thm:periodic_overlap_zero_ne_dim, thm:periodic_overlap_gauge_equiv_sector_match}
-	Let $A$ and $B$ be periodic tensors. Then at least one of the following
-	alternatives holds:
-	\begin{enumerate}
-		\item $\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$;
-		\item $A$ and $B$ are equivalent up to repeated blocks.
-	\end{enumerate}
-\end{theorem}
-
-\begin{theorem}[Eventual linear independence of a periodic basis]\label{thm:periodic_basis_eventually_li}
-	\lean{MPSTensor.periodicBasis_eventuallyLinearlyIndependent}
-	\notready
-	\uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
-	For a finite family of pairwise non-equivalent periodic tensors whose
-	periods divide a common integer $p$, there is $N_0$ such that for every
-	$N \ge N_0$ the vectors $\{\ket{V^{(pN)}(A_j)}\}_j$ are linearly independent.
-\end{theorem}
-
-\begin{remark}[Comparison with the 1606.00608 approach]\notready
-	\label{rem:periodic_vs_blocking_ft}
-	Theorem~\ref{thm:periodic_ft} and the equal-MPV Fundamental Theorem
-	(Theorem~\ref{thm:ft_equal}) both characterize the gauge freedom
-	between two tensors with equal MPV families, but they do so at
-	different levels:
-
-	\begin{enumerate}
-		\item \emph{Blocking approach} (Theorem~\ref{thm:ft_equal},
-		      following \cite{Cirac2017MPDO_AnnPhys}):
-		      Block both $A$ and $B$ by a common period $p$ so that all
-		      blocks of $A^{[p]}$ and $B^{[p]}$ are primitive
-		      ($1$-periodic). Apply the aperiodic fundamental theorem to
-		      the blocked tensors. The conclusion is that $A^{[p]}$ and
-		      $B^{[p]}$ are gauge equivalent. The $Z$-gauge freedom
-		      does not appear because blocking absorbs the periodicity.
-
-		\item \emph{Periodic approach} (Theorem~\ref{thm:periodic_ft},
-		      following \cite{DeLasCuevas2017Irreducible}):
-		      Work directly with the periodic blocks of $A$ and $B$.
-		      The conclusion includes an extra $Z$-gauge transformation
-		      reflecting the non-trivial phase ambiguity that arises for
-		      periodic blocks. The $Z$ matrix satisfies $Z^m = \Id$ and
-		      commutes with all Kraus operators; it is invisible to the
-		      MPV family because it only introduces $m$-th roots of unity
-		      in the trace.
-	\end{enumerate}
-
-	In this chapter only the blocking approach is developed. A direct periodic
-	approach would require the irreducible-form and $Z$-gauge theory
-	outlined in Remark~\ref{rem:irr_form_vs_ncf}.
-\end{remark}
-
-\begin{remark}[Proportional periodic FT]\notready
-	\label{rem:periodic_ft_proportional}
-	\lean{MPSTensor.fundamentalTheorem_periodic_proportional}
-	There is also a proportional-case version of the periodic Fundamental Theorem
-	(Theorem~3.4, ``proportional case'', in \cite{DeLasCuevas2017Irreducible}):
-	if $\mathcal{V}(A) = \lambda_N \mathcal{V}(B)$ for scalars $\lambda_N$ with
-	$\lambda_N \to \lambda \neq 0$, then the bases of periodic tensors of $A$
-	and $B$ are equivalent (up to the same gauge and $Z$ freedom as above).
-	This extends Theorems~\ref{thm:ft_proportional}
-	and~\ref{thm:ft_proportional_nt} to the periodic setting.
 \end{remark}

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -1,6 +1,6 @@
 %% =========================================================
 %% Chapter: Periodic MPS — irreducible form and the periodic
-%% Fundamental Theorem.  Mirrors §4 of arXiv:1708.00029
+%% Fundamental Theorem.  Mirrors §3--4 of arXiv:1708.00029
 %% (de las Cuevas--Schuch--Pérez-García--Cirac).
 %% =========================================================
 
@@ -483,11 +483,13 @@ The following is Theorem~3.8 (``equal case'') of
     $\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$.
 \end{theorem}
 \begin{proof}\leanok
-    Split on whether the bond dimensions agree. If not, dimension mismatch
-    gives decay. If $D_1 = D_2$, suppose for contradiction that $A$ and $B$
-    are gauge-phase equivalent; Perron--Frobenius eigenvalue uniqueness
-    (Wolf Theorem~6.3) then forces equal periods, contradicting the hypothesis.
-    Hence the tensors are not gauge-phase equivalent, and the overlap decays.
+    \uses{thm:periodic_overlap_zero_ne_dim}
+    Split on whether the bond dimensions agree. If not, the claim follows
+    from Theorem~\ref{thm:periodic_overlap_zero_ne_dim}. If $D_1 = D_2$,
+    suppose for contradiction that $A$ and $B$ are gauge-phase equivalent;
+    Perron--Frobenius eigenvalue uniqueness (Wolf Theorem~6.3) then forces
+    equal periods, contradicting the hypothesis. Hence the tensors are not
+    gauge-phase equivalent, and the overlap decays.
 \end{proof}
 
 \begin{lemma}[Sector-block normality for periodic tensors]\label{lem:sector_blocked_normal_periodic}

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -1,16 +1,18 @@
 %% =========================================================
-%% Chapter: Periodic MPS — applications of the irreducible-form
+%% Chapter: Periodic MPS — irreducible form and the periodic
 %% Fundamental Theorem.  Mirrors §4 of arXiv:1708.00029
 %% (de las Cuevas--Schuch--Pérez-García--Cirac).
 %% =========================================================
 
-\chapter{Periodic MPS: physical symmetries and refinement}\label{ch:periodic_ft_apps}
+\chapter{Periodic MPS: irreducible form and the periodic Fundamental Theorem}%
+\label{ch:periodic_ft_apps}
 
-This chapter records the two applications of the periodic equal-case
-Fundamental Theorem of MPS (Theorem~\ref{thm:periodic_ft}) developed in
-\cite{DeLasCuevas2017Irreducible}: the symmetry corollary lifting a
-physical on-site symmetry of a tensor in irreducible form to a virtual
-$Z$-gauge, and the equivalence between $p$-refinability of the
+This chapter records the irreducible-form framework of
+\cite{DeLasCuevas2017Irreducible}: the periodic equal-case
+Fundamental Theorem of MPS (Theorem~\ref{thm:periodic_ft}), the
+periodic-overlap dichotomy on which it rests, the symmetry corollary
+lifting a physical on-site symmetry of a tensor in irreducible form to a
+virtual $Z$-gauge, and the equivalence between $p$-refinability of the
 matrix-product-vector family and $p$-divisibility of the transfer map.
 
 \section{Periodic irreducible form and physical-index rotation}%
@@ -45,6 +47,27 @@ matrix-product-vector family and $p$-divisibility of the transfer map.
     (Definition~\ref{def:is_normal_canonical_form}),
     which requires the stronger condition that every block is $1$-periodic.
 \end{definition}
+
+\begin{remark}[Relation to normal canonical form]\notready
+    \label{rem:irr_form_vs_ncf}
+    Every tensor in normal canonical form
+    (Definition~\ref{def:is_normal_canonical_form})
+    is in irreducible form with all periods equal to~$1$.
+    The irreducible form is strictly more general: it accommodates
+    blocks such as the antiferromagnet, which are $2$-periodic.
+
+    Chapter~\ref{ch:assembly} works with period-$1$ blocks obtained by
+    a blocking step. The present chapter records the direct periodic
+    treatment of \cite{DeLasCuevas2017Irreducible}, which requires:
+    \begin{enumerate}
+        \item the definition of $m$-periodic irreducible tensors and
+              their cyclic-sector decomposition,
+        \item the off-diagonal structure of a periodic block's transfer
+              matrix (the cyclic permutation of sectors), and
+        \item an equivalence notion for periodic blocks that
+              incorporates the $Z$-gauge freedom described below.
+    \end{enumerate}
+\end{remark}
 
 \begin{definition}[Physical-index rotation]%
     \label{def:rotate_physical}
@@ -222,7 +245,8 @@ matrix-product-vector family and $p$-divisibility of the transfer map.
     \]
 \end{definition}
 
-\begin{lemma}[Diagonal \(Z\)-gauge has finite order under matched powers]\label{lem:z_gauge_diagonal_pow}
+\begin{lemma}[Diagonal \(Z\)-gauge has finite order under matched powers]%
+    \label{lem:z_gauge_diagonal_pow}
     \lean{MPSTensor.zGaugeDiagonal_pow_eq_one}
     \leanok
     \uses{def:z_gauge_diagonal, lem:z_gauge_entry_pow}
@@ -271,6 +295,320 @@ matrix-product-vector family and $p$-divisibility of the transfer map.
     (Definition~\ref{def:gauge_equiv}).
     The $Z$-gauge is therefore a genuine new degree of freedom
     that appears only for $m > 1$.
+\end{remark}
+
+\section{Periodic Fundamental Theorem}%
+\label{sec:periodic_ft}
+
+The paper \cite{DeLasCuevas2017Irreducible} avoids the common-period
+blocking step of Chapter~\ref{ch:assembly}, giving a Fundamental
+Theorem that applies directly to periodic tensors.
+
+\subsection{Common-period blocking lemmas}
+
+\begin{definition}[LCM period for a finite block family]
+    \label{def:lcm_period}
+    \lean{MPSTensor.lcmPeriod}
+    \leanok
+    Given a finite family of blocking periods $(p_i)$ indexed by a finite set,
+    their least common multiple serves as the shared blocking period.
+\end{definition}
+
+\begin{definition}[Common-period blocked family]
+    \label{def:common_period_blocking}
+    \lean{MPSTensor.commonPeriodBlocking}
+    \leanok
+    \uses{def:lcm_period, def:blocked_tensor}
+    Given a finite family of tensors $(B_i)$ with designated periods $(p_i)$,
+    block each $B_i$ to the shared period $\operatorname{lcm}(p_i)$, so
+    every block lives in the same physical space.
+\end{definition}
+
+\begin{theorem}[Common-period blocking preserves transfer-map primitivity]
+    \label{thm:common_period_blocking_primitive}
+    \lean{MPSTensor.isPrimitive_transferMap_commonPeriodBlocking}
+    \leanok
+    \uses{def:common_period_blocking, thm:iterated_blocking_transfer,
+          thm:primitive_blocking_divisible}
+    If each tensor $B_i$ has a primitive transfer map after blocking by its own
+    positive period $p_i$, then blocking the entire family to the common
+    LCM period preserves primitivity of each member's transfer map.
+\end{theorem}
+
+\begin{proof}\leanok
+    Each $p_i$ divides $\operatorname{lcm}(p_i)$.
+    Apply the divisibility monotonicity theorem for primitive blocked transfer maps
+    to each family member separately.
+\end{proof}
+
+\subsection{Statement of the periodic Fundamental Theorem}
+
+The following is Theorem~3.8 (``equal case'') of
+\cite{DeLasCuevas2017Irreducible}.
+
+\begin{theorem}[Periodic Fundamental Theorem]\notready
+    \label{thm:periodic_ft}
+    \lean{MPSTensor.zgauge_construction, MPSTensor.equalCase_zgauge_pipeline,
+          MPSTensor.fundamentalTheorem_periodic_equalCase_matching,
+          MPSTensor.fundamentalTheorem_periodic_equalCase}
+    \uses{def:irreducible_form, def:z_gauge_equiv}
+    Let $A$ and $B$ be MPS tensors in irreducible form,
+    with bases of periodic blocks
+    $\{A_j\}_{j \in J}$ and $\{B_k\}_{k \in K}$ respectively.
+    Suppose that $\mathcal{V}(A) = \mathcal{V}(B)$
+    (equal MPV families for all lengths $N$).
+
+    Then $|J| = |K|$ and there is a bijection $\pi : J \to K$
+    such that $A_j$ and $B_{\pi(j)}$ are $m_j$-periodic for the same
+    period $m_j$.
+    Moreover, for each $j \in J$ there exists:
+    \begin{enumerate}
+        \item an invertible matrix $Y_j$ of size $D_j \times D_{\pi(j)}$,
+              and
+        \item a diagonal unitary matrix $Z_j$ of size $D_j \times D_j$
+              satisfying $Z_j^{m_j} = \Id$ and
+              $[A_j^i, Z_j] = 0$ for all~$i$,
+    \end{enumerate}
+    such that
+    \[
+        Z_j\, A_j^i = Y_j\, B_{\pi(j)}^i\, Y_j^{-1}
+        \quad\text{for all physical indices } i.
+    \]
+    For each periodic block, the extra freedom is encoded by
+    \[
+        \TNPeriodicGauge{m_j}{Z_j}{m_j}
+    \]
+    rather than by an ordinary aperiodic gauge alone: the operator $Z_j$
+    sits on the closing virtual bond and satisfies $Z_j^{m_j}=\Id$.
+    Equivalently, setting $Y = \bigoplus_j Y_j \otimes \Id_{r_j}$
+    and $Z = \bigoplus_j Z_j \otimes \Id_{r_j}$, one has
+    $Z A^i = Y B^i Y^{-1}$ for all $i$,
+    with $[A^i, Z] = 0$ and $\mathcal{V}(A) = \mathcal{V}(ZA)$.
+
+    \noindent\emph{Remark.}
+    The proof is conditional on the periodic-overlap dichotomy
+    (Proposition~3.3 of~\cite{DeLasCuevas2017Irreducible}),
+    which remains to be proved.
+\end{theorem}
+
+\subsection{Periodic overlap dichotomy (Proposition 3.3)}
+
+\begin{definition}[Cyclic sector decomposition]%
+    \label{def:cyclic_sector_decomp}
+    \lean{MPSTensor.IsCyclicSectorDecomp}
+    \leanok
+    \uses{def:periodic_tensor}
+    A family of compressed sector tensors
+    $(C_k)_{k=0}^{m-1}$ on corner bond spaces forms a \emph{cyclic sector
+    decomposition} of the blocked tensor $A^{(m)}$ if there exist orthogonal
+    projections $P_0,\dotsc,P_{m-1}$ on the ambient bond space such that
+    $\sum_k P_k = \Id$, the projections satisfy the cyclic-shift relation
+    $E^\dagger(P_{k+1}) = P_k$, each $P_k$ commutes with every blocked letter
+    $P_k A^{(m)}_i = A^{(m)}_i P_k$,
+    $V^{(N)}(C_k)_\sigma = \tr(P_k (A^{(m)})^\sigma)$ for every word~$\sigma$,
+    and each block carries a $\ast$-algebra isomorphism
+    $\varphi_k : M_{\dim C_k}(\mathbb{C}) \xrightarrow{\sim}
+        P_k \cdot M_D(\mathbb{C}) \cdot P_k$
+    (multiplicative and adjoint-preserving) intertwining the compressed adjoint
+    transfer map with the sector adjoint transfer map on the corner of~$P_k$.
+\end{definition}
+
+\begin{definition}[One-site corner transition]%
+    \label{def:corner_transition}
+    \lean{MPSTensor.cornerTransition}
+    \leanok
+    \uses{def:cyclic_sector_decomp}
+    For a cyclic projection family $(P_k)_{k \in \mathrm{Fin}\,m}$ on the
+    ambient bond algebra of an MPS tensor $A$, the \emph{one-site corner
+    transition} at sector $k$ is the family of per-site matrices
+    \[
+        \tau_k(A)^i := P_k \cdot A^i \cdot P_{k+1}, \qquad i \in \mathrm{Fin}\,d,
+    \]
+    where the index $k+1$ is taken cyclically in $\mathrm{Fin}\,m$.
+\end{definition}
+
+\begin{definition}[Staircase evaluation]%
+    \label{def:corner_eval_word}
+    \lean{MPSTensor.cornerEvalWord}
+    \leanok
+    \uses{def:corner_transition}
+    For a word $w = (w_0,\dotsc,w_{L-1})$ on the physical index alphabet and
+    a starting sector $u$, the \emph{staircase evaluation} at $u$ is
+    \[
+        \mathrm{cornerEvalWord}(A, P, u, w)
+        := P_u \cdot A^{w_0} \cdot P_{u+1} \cdot A^{w_1} \cdot P_{u+2}
+            \cdots A^{w_{L-1}} \cdot P_{u+L},
+    \]
+    defined recursively by
+    $\mathrm{cornerEvalWord}(A, P, u, \varepsilon) = P_u$ and
+    $\mathrm{cornerEvalWord}(A, P, u, i \cdot w) =
+     P_u \cdot A^i \cdot \mathrm{cornerEvalWord}(A, P, u+1, w)$.
+\end{definition}
+
+\begin{definition}[Cyclic staircase product on blocked indices (Eq. A.8)]%
+    \label{def:blocked_corner_transition_tensor}
+    \lean{MPSTensor.blockedCornerTransitionTensor}
+    \leanok
+    \uses{def:corner_eval_word}
+    The \emph{blocked corner transition tensor} at sector $u$ is the
+    MPS tensor on blocked physical indices defined by
+    $i \mapsto \mathrm{cornerEvalWord}(A, P, u, w_i)$, where $w_i$ is the
+    length-$m$ physical word associated to the blocked index $i$. For a
+    blocked index $i$ with word $(i_0,\dotsc,i_{m-1})$ this returns the
+    ambient-algebra matrix
+    \[
+        P_u \cdot A^{i_0} \cdot P_{u+1} \cdot A^{i_1} \cdot P_{u+2}
+            \cdots P_{u+m-1} \cdot A^{i_{m-1}} \cdot P_u.
+    \]
+    This is the ambient matrix-algebra representative of the compressed
+    blocked sector tensor $C_u$ in a cyclic sector decomposition; the
+    identification with $C_u$ through the compression isometry $\varphi_u$
+    is Equation A.8 of~\cite{DeLasCuevas2017Irreducible}.
+\end{definition}
+
+\begin{theorem}[Self-overlap along period multiples]\label{thm:periodic_self_overlap_tendsto}
+    \lean{MPSTensor.periodicSelfOverlap_tendsto}
+    \notready
+    \uses{def:periodic_tensor}
+    If $A$ is $m$-periodic, then the self-overlap along multiples of $m$
+    converges to $m$ (the period, viewed as a scalar).
+\end{theorem}
+
+\begin{theorem}[Different periods imply asymptotic orthogonality]%
+    \label{thm:periodic_overlap_zero_ne_period}
+    \lean{MPSTensor.periodicOverlap_tendsto_zero_of_ne_period}
+    \leanok
+    \uses{def:periodic_tensor}
+    If $A$ and $B$ are periodic with different periods, then
+    $\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$.
+\end{theorem}
+\begin{proof}\leanok
+    Split on whether the bond dimensions agree. If not, dimension mismatch
+    gives decay. If $D_1 = D_2$, suppose for contradiction that $A$ and $B$
+    are gauge-phase equivalent; Perron--Frobenius eigenvalue uniqueness
+    (Wolf Theorem~6.3) then forces equal periods, contradicting the hypothesis.
+    Hence the tensors are not gauge-phase equivalent, and the overlap decays.
+\end{proof}
+
+\begin{lemma}[Sector-block normality for periodic tensors]\label{lem:sector_blocked_normal_periodic}
+    \lean{MPSTensor.sectorBlocked_isNormal_of_isPeriodic}
+    \leanok
+    \uses{def:periodic_tensor, def:cyclic_sector_decomp}
+    For a periodic tensor equipped with a cyclic sector decomposition,
+    each nonzero blocked sector tensor is normal.
+\end{lemma}
+
+\begin{theorem}[No sector match implies asymptotic orthogonality]%
+    \label{thm:periodic_overlap_zero_no_sector_match}
+    \lean{MPSTensor.periodicOverlap_tendsto_zero_of_no_sector_match}
+    \notready
+    \uses{def:periodic_tensor, lem:sector_blocked_normal_periodic}
+    If two periodic tensors with the same period admit no gauge-phase
+    matching sector pair after blocking, then their overlap tends to zero.
+\end{theorem}
+
+\begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}
+    \lean{MPSTensor.sectorMatch_propagation}
+    \notready
+    \uses{def:periodic_tensor}
+    A single gauge-phase match between blocked sectors propagates to all
+    cyclic translates of that sector pair.
+\end{lemma}
+
+\begin{lemma}[Per-site proportionality from blocked sector match]%
+    \label{lem:sector_tensor_proportional_blocked_match}
+    \lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
+    \notready
+    \uses{lem:sector_match_propagation}
+    If all aligned blocked sectors match up to gauge and phase, then the
+    original tensors are related by repeated-block proportionality.
+\end{lemma}
+
+\begin{theorem}[Sector match yields repeated-block equivalence]%
+    \label{thm:periodic_overlap_gauge_equiv_sector_match}
+    \lean{MPSTensor.periodicOverlap_gaugeEquiv_of_sector_match}
+    \notready
+    \uses{lem:sector_match_propagation, lem:sector_tensor_proportional_blocked_match}
+    For periodic tensors of the same period, existence of one matching
+    sector pair implies repeated-block equivalence.
+\end{theorem}
+
+\begin{theorem}[Different bond dimensions imply asymptotic orthogonality]%
+    \label{thm:periodic_overlap_zero_ne_dim}
+    \lean{MPSTensor.periodicOverlap_tendsto_zero_of_ne_dim}
+    \leanok
+    \uses{def:periodic_tensor}
+    If two periodic tensors have different bond dimensions, then
+    $\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$.
+\end{theorem}
+
+\begin{theorem}[Periodic overlap dichotomy]\label{thm:periodic_overlap_dichotomy}
+    \lean{MPSTensor.periodicOverlapDichotomy}
+    \notready
+    \uses{thm:periodic_overlap_zero_ne_period,
+          thm:periodic_overlap_zero_no_sector_match,
+          thm:periodic_overlap_zero_ne_dim,
+          thm:periodic_overlap_gauge_equiv_sector_match}
+    Let $A$ and $B$ be periodic tensors. Then at least one of the following
+    alternatives holds:
+    \begin{enumerate}
+        \item $\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$;
+        \item $A$ and $B$ are equivalent up to repeated blocks.
+    \end{enumerate}
+\end{theorem}
+
+\begin{theorem}[Eventual linear independence of a periodic basis]%
+    \label{thm:periodic_basis_eventually_li}
+    \lean{MPSTensor.periodicBasis_eventuallyLinearlyIndependent}
+    \notready
+    \uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
+    For a finite family of pairwise non-equivalent periodic tensors whose
+    periods divide a common integer $p$, there is $N_0$ such that for every
+    $N \ge N_0$ the vectors $\{\ket{V^{(pN)}(A_j)}\}_j$ are linearly independent.
+\end{theorem}
+
+\begin{remark}[Comparison with the 1606.00608 approach]\notready
+    \label{rem:periodic_vs_blocking_ft}
+    Theorem~\ref{thm:periodic_ft} and the equal-MPV Fundamental Theorem
+    (Theorem~\ref{thm:ft_equal}) both characterize the gauge freedom
+    between two tensors with equal MPV families, but they do so at
+    different levels:
+
+    \begin{enumerate}
+        \item \emph{Blocking approach} (Theorem~\ref{thm:ft_equal},
+              following \cite{Cirac2017MPDO_AnnPhys}):
+              Block both $A$ and $B$ by a common period $p$ so that all
+              blocks of $A^{[p]}$ and $B^{[p]}$ are primitive
+              ($1$-periodic). Apply the aperiodic fundamental theorem to
+              the blocked tensors. The conclusion is that $A^{[p]}$ and
+              $B^{[p]}$ are gauge equivalent. The $Z$-gauge freedom
+              does not appear because blocking absorbs the periodicity.
+
+        \item \emph{Periodic approach} (Theorem~\ref{thm:periodic_ft},
+              following \cite{DeLasCuevas2017Irreducible}):
+              Work directly with the periodic blocks of $A$ and $B$.
+              The conclusion includes an extra $Z$-gauge transformation
+              reflecting the non-trivial phase ambiguity that arises for
+              periodic blocks. The $Z$ matrix satisfies $Z^m = \Id$ and
+              commutes with all Kraus operators; it is invisible to the
+              MPV family because it only introduces $m$-th roots of unity
+              in the trace.
+    \end{enumerate}
+
+    Chapter~\ref{ch:assembly} develops the blocking approach, while the
+    present chapter records the direct periodic alternative.
+\end{remark}
+
+\begin{remark}[Proportional periodic FT]\notready
+    \label{rem:periodic_ft_proportional}
+    \lean{MPSTensor.fundamentalTheorem_periodic_proportional}
+    There is also a proportional-case version of the periodic Fundamental Theorem
+    (Theorem~3.4, ``proportional case'', in \cite{DeLasCuevas2017Irreducible}):
+    if $\mathcal{V}(A) = \lambda_N \mathcal{V}(B)$ for scalars $\lambda_N$ with
+    $\lambda_N \to \lambda \neq 0$, then the bases of periodic tensors of $A$
+    and $B$ are equivalent (up to the same gauge and $Z$ freedom as above).
+    This extends Theorems~\ref{thm:ft_proportional}
+    and~\ref{thm:ft_proportional_nt} to the periodic setting.
 \end{remark}
 
 \section{Physical symmetries on periodic MPS}\label{sec:periodic_symmetry}


### PR DESCRIPTION
## Summary
- move the remaining Gemma / DlCCSPG17 periodic-FT material from `blueprint/src/chapter/ch11_assembly.tex` into `blueprint/src/chapter/ch11b_periodic_ft.tex`
- keep the moved labels (`sec:periodic_ft`, `thm:periodic_ft`, `thm:periodic_overlap_dichotomy`, etc.) unchanged so cross-references stay stable
- trim `ch11_assembly.tex` back to a forward reference to Chapter `ch:periodic_ft_apps`
- update the ch11b chapter title/preamble so it matches the broadened scope after the move

## Source-location note
Issue #708 points to `blueprint/src/chapter/ch14_parent_hamiltonian.tex`, but on current `main` that file no longer contains the Gemma section. The residual periodic-FT material was actually still living in `blueprint/src/chapter/ch11_assembly.tex` (the `Periodic Fundamental Theorem` section), as documented in the scouting comment on #708.

## Files changed
- `blueprint/src/chapter/ch11_assembly.tex`
- `blueprint/src/chapter/ch11b_periodic_ft.tex`

No other blueprint chapter needed ref/label repair.

## Verification
- `cd .worktrees/issue-708 && lake build TNLean`
- `cd .worktrees/issue-708/blueprint && leanblueprint web`
- `cd .worktrees/issue-708/blueprint && leanblueprint checkdecls`

## PDF note
I also attempted `cd .worktrees/issue-708/blueprint && leanblueprint pdf`, but the job did not complete within the tool wall-time: the captured log ends with `latexmk` receiving `SIGTERM`, with no blueprint-specific LaTeX error appearing before termination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure blueprint/LaTeX refactor that mainly relocates text while keeping labels stable; risk is limited to broken references or build regressions from the move.
> 
> **Overview**
> Moves the entire `\section{Periodic Fundamental Theorem}` (including overlap dichotomy material and related definitions/lemmas) out of `ch11_assembly.tex` into `ch11b_periodic_ft.tex`, leaving `ch11_assembly.tex` as a blocking-based treatment with a forward reference to Chapter `ch:periodic_ft_apps`.
> 
> Updates the periodic chapter’s title/preamble to reflect the expanded scope (now explicitly covering irreducible form + the periodic FT), and makes small LaTeX hygiene tweaks (label formatting/line wrapping and minor wording/capitalization) while preserving existing labels for cross-references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d22d8e187392121cfd55fd417117611f2bc511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->