### PR TITLE
feat(MPS/ParentHamiltonian): prove groundSpace_extend_right_of_isNBlkInjective (#703)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -161,6 +161,7 @@ import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
+import TNLean.MPS.ParentHamiltonian.SuffixWindow
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 import TNLean.MPS.ParentHamiltonian.DegenerateGS

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -162,6 +162,7 @@ import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
+import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 import TNLean.MPS.ParentHamiltonian.DegenerateGS

--- a/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
+++ b/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.SuffixWindow
+
+/-!
+# Right-extension for block-injective parent-Hamiltonian ground spaces
+
+This file proves the open-chain grow-back step from [CPGSV21, §IV.C].
+Starting from the compatibility family extracted by
+`MPSTensor.exists_left_tail_compatibility`, we show that block injectivity forces
+all boundary matrices `Z j` to share a common right factor. This yields the
+open-chain extension theorem `groundSpace_extend_right_of_isNBlkInjective`.
+
+## Main results
+
+- `MPSTensor.exists_right_factor_of_evalWord_compatibility` — common right-factor
+  extraction from universal word compatibility
+- `MPSTensor.groundSpace_extend_right_of_isNBlkInjective` — if the long left
+  window and the suffix window both lie in the ground space, then the whole
+  state lies in the ground space
+
+## References
+
+* [CPGSV21] arXiv:2011.12127, lines 2049–2078
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Letter compatibility extends to every nonempty word by multiplying the
+corresponding boundary matrix on the right by the remaining suffix product. -/
+private theorem exists_evalWord_factor_of_letter_compatibility {A : MPSTensor d D}
+    {Z : Fin d → Matrix (Fin D) (Fin D) ℂ}
+    (hCompat : ∀ i : Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      ∀ j : Fin d, Z j * A i = A j * Y)
+    (w : List (Fin d)) (hw : w ≠ []) :
+    ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      ∀ j : Fin d, Z j * evalWord A w = A j * Y := by
+  cases w with
+  | nil => cases hw rfl
+  | cons i w =>
+      obtain ⟨Y, hY⟩ := hCompat i
+      refine ⟨Y * evalWord A w, ?_⟩
+      intro j
+      calc
+        Z j * evalWord A (i :: w)
+            = Z j * (A i * evalWord A w) := by simp [evalWord]
+        _ = (Z j * A i) * evalWord A w := by rw [Matrix.mul_assoc]
+        _ = (A j * Y) * evalWord A w := by rw [hY j]
+        _ = A j * (Y * evalWord A w) := by rw [Matrix.mul_assoc]
+
+/-- If the compatibility identity is available for every single physical letter,
+then block injectivity yields a common right factor. -/
+private theorem exists_right_factor_of_letter_compatibility [NeZero D]
+    {A : MPSTensor d D} {L₀ : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {Z : Fin d → Matrix (Fin D) (Fin D) ℂ}
+    (hCompat : ∀ i : Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      ∀ j : Fin d, Z j * A i = A j * Y) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ, ∀ j : Fin d, Z j = A j * X := by
+  have hBlkInj : IsInjective (blockTensor A L₀) :=
+    (isNBlkInjective_iff_blockTensor_isInjective A L₀).mp hInj
+  obtain ⟨c, hc⟩ := hBlkInj.exists_decomposition (1 : Matrix (Fin D) (Fin D) ℂ)
+  have hBlockCompat : ∀ i : Fin (blockPhysDim d L₀),
+      ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+        ∀ j : Fin d, Z j * blockTensor A L₀ i = A j * Y := by
+    intro i
+    have hword : wordOfBlock d L₀ i ≠ [] := by
+      intro hnil
+      have hlen : 0 = L₀ := by
+        simpa [hnil] using (length_wordOfBlock d L₀ i)
+      omega
+    obtain ⟨Y, hY⟩ :=
+      exists_evalWord_factor_of_letter_compatibility (A := A) hCompat (wordOfBlock d L₀ i) hword
+    refine ⟨Y, ?_⟩
+    intro j
+    simpa [blockTensor] using hY j
+  choose Y hY using hBlockCompat
+  let X : Matrix (Fin D) (Fin D) ℂ := ∑ i, c i • Y i
+  refine ⟨X, ?_⟩
+  intro j
+  calc
+    Z j = Z j * (1 : Matrix (Fin D) (Fin D) ℂ) := by simp
+    _ = Z j * ∑ i, c i • blockTensor A L₀ i := by rw [hc]
+    _ = ∑ i, c i • (Z j * blockTensor A L₀ i) := by
+          simp [Finset.mul_sum]
+    _ = ∑ i, c i • (A j * Y i) := by
+          refine Finset.sum_congr rfl ?_
+          intro i _
+          rw [hY i j]
+    _ = A j * ∑ i, c i • Y i := by
+          simp [Finset.mul_sum]
+    _ = A j * X := by rfl
+
+/-- The positive-length case of the grow-back theorem.  Compatibility for words
+of length `K + 1` reduces to the single-letter case by stripping the first
+letter and applying the induction hypothesis to the matrices `Z j * A i`. -/
+private theorem exists_right_factor_of_evalWord_compatibility_succ [NeZero D]
+    {A : MPSTensor d D} {L₀ : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) :
+    ∀ K : ℕ, ∀ {Z : Fin d → Matrix (Fin D) (Fin D) ℂ},
+      (∀ σ : Fin (K + 1) → Fin d, ∃ Yσ : Matrix (Fin D) (Fin D) ℂ,
+        ∀ j : Fin d, Z j * evalWord A (List.ofFn σ) = A j * Yσ) →
+      ∃ X : Matrix (Fin D) (Fin D) ℂ, ∀ j : Fin d, Z j = A j * X
+  | 0, Z, hCompat =>
+      have hCompat1 : ∀ i : Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+          ∀ j : Fin d, Z j * A i = A j * Y := by
+        intro i
+        let σ : Fin 1 → Fin d := fun _ => i
+        obtain ⟨Y, hY⟩ := hCompat σ
+        refine ⟨Y, ?_⟩
+        intro j
+        simpa [σ, evalWord] using hY j
+      exists_right_factor_of_letter_compatibility hInj hL₀ hCompat1
+  | K + 1, Z, hCompat =>
+      have hCompat1 : ∀ i : Fin d, ∃ X : Matrix (Fin D) (Fin D) ℂ,
+          ∀ j : Fin d, Z j * A i = A j * X := by
+        intro i
+        let Zi : Fin d → Matrix (Fin D) (Fin D) ℂ := fun j => Z j * A i
+        have hCompatZi : ∀ σ : Fin (K + 1) → Fin d,
+            ∃ Yσ : Matrix (Fin D) (Fin D) ℂ,
+              ∀ j : Fin d, Zi j * evalWord A (List.ofFn σ) = A j * Yσ := by
+          intro σ
+          obtain ⟨Yσ, hYσ⟩ := hCompat (Fin.cons i σ)
+          refine ⟨Yσ, ?_⟩
+          intro j
+          simpa [Zi, evalWord_ofFn_cons, Matrix.mul_assoc] using hYσ j
+        obtain ⟨X, hX⟩ :=
+          exists_right_factor_of_evalWord_compatibility_succ hInj hL₀ K hCompatZi
+        exact ⟨X, hX⟩
+      exists_right_factor_of_letter_compatibility hInj hL₀ hCompat1
+
+/-- If a family of boundary matrices satisfies the compatibility identity
+`Z j * A^σ = A j * Y_σ` for every length-`K` word `σ`, then all `Z j` share a
+common right factor. -/
+theorem exists_right_factor_of_evalWord_compatibility [NeZero D]
+    {A : MPSTensor d D} {K L₀ : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {Z : Fin d → Matrix (Fin D) (Fin D) ℂ}
+    (hCompat : ∀ σ : Fin K → Fin d, ∃ Yσ : Matrix (Fin D) (Fin D) ℂ,
+      ∀ j : Fin d, Z j * evalWord A (List.ofFn σ) = A j * Yσ) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ, ∀ j : Fin d, Z j = A j * X := by
+  cases K with
+  | zero =>
+      let σ : Fin 0 → Fin d := Fin.elim0
+      obtain ⟨Y, hY⟩ := hCompat σ
+      refine ⟨Y, ?_⟩
+      intro j
+      simpa [σ, evalWord] using hY j
+  | succ K =>
+      exact exists_right_factor_of_evalWord_compatibility_succ hInj hL₀ K hCompat
+
+/-- If two adjacent open-chain windows satisfy the ground-space condition at the
+injectivity length `L₀ + 1`, then the full `(K + L₀ + 1)`-site state is itself
+in the open-chain ground space. -/
+theorem groundSpace_extend_right_of_isNBlkInjective
+    [NeZero D] {A : MPSTensor d D} {K L₀ : ℕ} (hInj : IsNBlkInjective A L₀)
+    (hL₀ : 0 < L₀) (hK : 0 < K) {ψ : NSiteSpace d (K + L₀ + 1)}
+    (hLeft : InLeftGround A (K + L₀) ψ)
+    (hTail : InTailGround A K (L₀ + 1) ψ) :
+    ψ ∈ groundSpace A (K + L₀ + 1) := by
+  have hKL₀ : 0 < K + L₀ := by
+    omega
+  obtain ⟨Z, Y, hZ, _hY, hCompat⟩ :=
+    exists_left_tail_compatibility (A := A) hInj hLeft hTail
+  obtain ⟨X, hX⟩ :=
+    exists_right_factor_of_evalWord_compatibility (A := A) hInj hL₀
+      (Z := Z) (fun σ => ⟨Y σ, fun j => hCompat j σ⟩)
+  have hSlices : ∀ j : Fin d,
+      restrictLast ψ j = restrictLast (groundSpaceMap A (K + L₀ + 1) X) j := by
+    intro j
+    rw [hZ j, hX j]
+    exact (restrictLast_groundSpaceMap (A := A) (L := K + L₀) (j := j) (X := X)).symm
+  have hψ : ψ = groundSpaceMap A (K + L₀ + 1) X := by
+    ext τ
+    have hτ := congrArg (fun ξ => ξ (Fin.init τ)) (hSlices (τ (Fin.last _)))
+    simpa [restrictLast_apply, Fin.snoc_init_self] using hτ
+  rw [groundSpace, LinearMap.mem_range]
+  exact ⟨X, hψ.symm⟩
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
+++ b/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
@@ -161,12 +161,10 @@ injectivity length `L₀ + 1`, then the full `(K + L₀ + 1)`-site state is itse
 in the open-chain ground space. -/
 theorem groundSpace_extend_right_of_isNBlkInjective
     [NeZero D] {A : MPSTensor d D} {K L₀ : ℕ} (hInj : IsNBlkInjective A L₀)
-    (hL₀ : 0 < L₀) (hK : 0 < K) {ψ : NSiteSpace d (K + L₀ + 1)}
+    (hL₀ : 0 < L₀) {ψ : NSiteSpace d (K + L₀ + 1)}
     (hLeft : InLeftGround A (K + L₀) ψ)
     (hTail : InTailGround A K (L₀ + 1) ψ) :
     ψ ∈ groundSpace A (K + L₀ + 1) := by
-  have hKL₀ : 0 < K + L₀ := by
-    omega
   obtain ⟨Z, Y, hZ, _hY, hCompat⟩ :=
     exists_left_tail_compatibility (A := A) hInj hLeft hTail
   obtain ⟨X, hX⟩ :=

--- a/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import TNLean.MPS.Chain.BlockedChainFT
 import Mathlib.Data.Fin.Tuple.Basic
 
 /-!
@@ -79,8 +80,7 @@ produces the expected boundary matrix `A j * X`. -/
     (j : Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
     restrictLast (groundSpaceMap A (L + 1) X) j = groundSpaceMap A L (A j * X) := by
   ext σ
-  change Matrix.trace (evalWord A (List.ofFn (Fin.snoc σ j)) * X) =
-    Matrix.trace (evalWord A (List.ofFn σ) * (A j * X))
+  simp only [restrictLast_apply, groundSpaceMap_apply]
   rw [evalWord_ofFn_snoc]
   simp [Matrix.mul_assoc]
 
@@ -89,24 +89,14 @@ injective. -/
 theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ}
     (hwordL : wordSpan A L = ⊤) :
     Function.Injective (groundSpaceMap A L) := by
-  have hker : (groundSpaceMap A L).ker = ⊥ := by
-    apply (LinearMap.ker_eq_bot').2
-    intro X hX
-    have hφ :
-        (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
-      apply LinearMap.ext_on_range
-        (v := fun σ : Fin L → Fin d => evalWord A (List.ofFn σ))
-      · simpa [wordSpan] using hwordL
-      · intro σ
-        simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
-          congrArg (fun ψ => ψ σ) hX
-    exact trace_mul_right_eq_zero fun N => by
-      have hNX : Matrix.trace (N * X) = 0 := by
-        simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
-      calc
-        Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
-        _ = 0 := hNX
-  exact LinearMap.ker_eq_bot.mp hker
+  have hBlkInj : IsInjective (blockTensor A L) := by
+    exact (isNBlkInjective_iff_blockTensor_isInjective A L).mp
+      ((wordSpan_eq_top_iff_isNBlkInjective A L).mp hwordL)
+  intro X Y hXY
+  apply groundSpaceMap_injective hBlkInj (show 0 < 1 by omega)
+  ext σ
+  have hXY' := congrArg (fun ψ => ψ (decodeBlock d L (σ 0))) hXY
+  simpa [groundSpaceMap_apply, blockTensor, wordOfBlock, decodeBlock] using hXY'
 
 /-- Block injectivity at length `L` implies injectivity of `groundSpaceMap A L`. -/
 theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D} {L : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import Mathlib.Data.Fin.Tuple.Basic
+
+/-!
+# Suffix-window restrictions for parent-Hamiltonian ground spaces
+
+This file introduces restriction maps obtained by fixing a prefix and reading the
+last `L` sites of a state on `K + L` sites. It records the resulting matrix
+identities needed for the open-chain range-reduction argument in
+[CPGSV21, §IV.C].
+
+## Main results
+
+- `MPSTensor.tailRestrictₗ` — fix a prefix and restrict to the suffix window
+- `Fin.snoc_append` — compatibility of `Fin.snoc` with `Fin.append`
+- `MPSTensor.tailRestrictₗ_groundSpaceMap` — suffix restriction preserves the
+  ground-space form
+- `MPSTensor.groundSpace_inTailGround` — a ground-space state restricts to
+  ground-space states on every suffix slice
+- `MPSTensor.exists_left_tail_compatibility` — extract matrices satisfying
+  `Z j * evalWord A (List.ofFn u) = A j * Y u`
+
+## References
+
+* [CPGSV21] arXiv:2011.12127, lines 2049–2078
+-/
+
+open scoped Matrix
+
+namespace Fin
+
+variable {d K L : ℕ}
+
+/-- Appending a prefix commutes with adding a final site by `Fin.snoc`. -/
+theorem snoc_append (u : Fin K → Fin d) (σ : Fin L → Fin d) (j : Fin d) :
+    (Fin.snoc (Fin.append u σ) j : Fin (K + L + 1) → Fin d) =
+      Fin.append u (Fin.snoc σ j) := by
+  simpa using (Fin.append_snoc u σ j).symm
+
+end Fin
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Suffix restriction: fixing a prefix `u : Fin K → Fin d` and keeping the last
+`L` sites of a state on `K + L` sites. -/
+def tailRestrictₗ {d K L : ℕ} (u : Fin K → Fin d) :
+    NSiteSpace d (K + L) →ₗ[ℂ] NSiteSpace d L where
+  toFun ψ := fun σ => ψ (Fin.append u σ)
+  map_add' ψ₁ ψ₂ := by
+    ext σ
+    simp
+  map_smul' c ψ := by
+    ext σ
+    simp
+
+@[simp] theorem tailRestrictₗ_apply {d K L : ℕ} (u : Fin K → Fin d)
+    (ψ : NSiteSpace d (K + L)) (σ : Fin L → Fin d) :
+    tailRestrictₗ u ψ σ = ψ (Fin.append u σ) :=
+  rfl
+
+/-- Restricting the last site after fixing a prefix is the same as first
+restricting the last site and then fixing the prefix. -/
+@[simp] theorem tailRestrictₗ_restrictLast {d K L : ℕ} (u : Fin K → Fin d)
+    (ψ : NSiteSpace d (K + L + 1)) (j : Fin d) :
+    restrictLast (tailRestrictₗ u ψ) j = tailRestrictₗ u (restrictLast ψ j) := by
+  ext σ
+  simp [Fin.snoc_append]
+
+/-- Restricting a ground-space vector of length `L + 1` by fixing the last site
+produces the expected boundary matrix `A j * X`. -/
+@[simp] theorem restrictLast_groundSpaceMap (A : MPSTensor d D) {L : ℕ}
+    (j : Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
+    restrictLast (groundSpaceMap A (L + 1) X) j = groundSpaceMap A L (A j * X) := by
+  ext σ
+  change Matrix.trace (evalWord A (List.ofFn (Fin.snoc σ j)) * X) =
+    Matrix.trace (evalWord A (List.ofFn σ) * (A j * X))
+  rw [evalWord_ofFn_snoc]
+  simp [Matrix.mul_assoc]
+
+/-- If the length-`L` word span is all of `M_D`, then `groundSpaceMap A L` is
+injective. -/
+theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ}
+    (hwordL : wordSpan A L = ⊤) :
+    Function.Injective (groundSpaceMap A L) := by
+  have hker : (groundSpaceMap A L).ker = ⊥ := by
+    apply (LinearMap.ker_eq_bot').2
+    intro X hX
+    have hφ :
+        (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
+      apply LinearMap.ext_on_range
+        (v := fun σ : Fin L → Fin d => evalWord A (List.ofFn σ))
+      · simpa [wordSpan] using hwordL
+      · intro σ
+        simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
+          congrArg (fun ψ => ψ σ) hX
+    exact trace_mul_right_eq_zero fun N => by
+      have hNX : Matrix.trace (N * X) = 0 := by
+        simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
+      calc
+        Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
+        _ = 0 := hNX
+  exact LinearMap.ker_eq_bot.mp hker
+
+/-- Block injectivity at length `L` implies injectivity of `groundSpaceMap A L`. -/
+theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D} {L : ℕ}
+    (hInj : IsNBlkInjective A L) :
+    Function.Injective (groundSpaceMap A L) :=
+  groundSpaceMap_injective_of_wordSpan_eq_top
+    ((wordSpan_eq_top_iff_isNBlkInjective A L).mpr hInj)
+
+/-- Restricting a ground-space vector to a suffix slice preserves the ground-space
+form, with the prefix word moved to the right boundary matrix by trace cyclicity. -/
+@[simp] theorem tailRestrictₗ_groundSpaceMap (A : MPSTensor d D) {K L : ℕ}
+    (u : Fin K → Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
+    tailRestrictₗ u (groundSpaceMap A (K + L) X) =
+      groundSpaceMap A L (X * evalWord A (List.ofFn u)) := by
+  ext σ
+  calc
+    tailRestrictₗ u (groundSpaceMap A (K + L) X) σ
+        = Matrix.trace (evalWord A (List.ofFn (Fin.append u σ)) * X) := by
+            simp [groundSpaceMap_apply]
+    _ = Matrix.trace (evalWord A (List.ofFn σ) * (X * evalWord A (List.ofFn u))) := by
+          rw [List.ofFn_fin_append, evalWord_append]
+          symm
+          simpa [Matrix.mul_assoc] using
+            (Matrix.trace_mul_cycle'
+              (evalWord A (List.ofFn σ))
+              X
+              (evalWord A (List.ofFn u)))
+    _ = groundSpaceMap A L (X * evalWord A (List.ofFn u)) σ := by
+          simp [groundSpaceMap_apply]
+
+/-- A state on `K + L` sites lies in the tail ground condition if every fixed
+prefix gives an `L`-site ground-space vector. -/
+def InTailGround (A : MPSTensor d D) (K L : ℕ) (ψ : NSiteSpace d (K + L)) : Prop :=
+  ∀ u : Fin K → Fin d, tailRestrictₗ u ψ ∈ groundSpace A L
+
+/-- A ground-space vector restricts to a ground-space vector on every suffix
+slice. -/
+theorem groundSpace_inTailGround (A : MPSTensor d D) (K L : ℕ)
+    {ψ : NSiteSpace d (K + L)} (hψ : ψ ∈ groundSpace A (K + L)) :
+    InTailGround A K L ψ := by
+  intro u
+  rw [groundSpace, LinearMap.mem_range] at hψ ⊢
+  obtain ⟨X, rfl⟩ := hψ
+  refine ⟨X * evalWord A (List.ofFn u), ?_⟩
+  exact (tailRestrictₗ_groundSpaceMap (A := A) u X).symm
+
+/-- From the long left-window condition and the suffix-window condition, extract
+boundary matrices satisfying the common overlap identity
+`Z j * evalWord A (List.ofFn u) = A j * Y u`. -/
+theorem exists_left_tail_compatibility {A : MPSTensor d D} {K L₀ : ℕ}
+    (hInj : IsNBlkInjective A L₀) {ψ : NSiteSpace d (K + L₀ + 1)}
+    (hLeft : InLeftGround A (K + L₀) ψ)
+    (hTail : InTailGround A K (L₀ + 1) ψ) :
+    ∃ Z : Fin d → Matrix (Fin D) (Fin D) ℂ,
+      ∃ Y : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ,
+        (∀ j : Fin d, restrictLast ψ j = groundSpaceMap A (K + L₀) (Z j)) ∧
+        (∀ u : Fin K → Fin d, tailRestrictₗ u ψ = groundSpaceMap A (L₀ + 1) (Y u)) ∧
+        (∀ (j : Fin d) (u : Fin K → Fin d),
+          Z j * evalWord A (List.ofFn u) = A j * Y u) := by
+  have hLeft' :
+      ∀ j : Fin d, ∃ Z : Matrix (Fin D) (Fin D) ℂ,
+        restrictLast ψ j = groundSpaceMap A (K + L₀) Z := by
+    intro j
+    have hj := hLeft j
+    rw [groundSpace, LinearMap.mem_range] at hj
+    rcases hj with ⟨Z, hZ⟩
+    exact ⟨Z, hZ.symm⟩
+  choose Z hZ using hLeft'
+  have hTail' :
+      ∀ u : Fin K → Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+        tailRestrictₗ u ψ = groundSpaceMap A (L₀ + 1) Y := by
+    intro u
+    have hu := hTail u
+    rw [groundSpace, LinearMap.mem_range] at hu
+    rcases hu with ⟨Y, hY⟩
+    exact ⟨Y, hY.symm⟩
+  choose Y hY using hTail'
+  have hCompat : ∀ (j : Fin d) (u : Fin K → Fin d),
+      Z j * evalWord A (List.ofFn u) = A j * Y u := by
+    intro j u
+    apply groundSpaceMap_injective_of_isNBlkInjective hInj
+    have hLeftSlice :
+        tailRestrictₗ u (restrictLast ψ j) =
+          groundSpaceMap A L₀ (Z j * evalWord A (List.ofFn u)) := by
+      rw [hZ j]
+      exact tailRestrictₗ_groundSpaceMap (A := A) u (Z j)
+    have hTailSlice :
+        tailRestrictₗ u (restrictLast ψ j) = groundSpaceMap A L₀ (A j * Y u) := by
+      calc
+        tailRestrictₗ u (restrictLast ψ j)
+            = restrictLast (tailRestrictₗ u ψ) j := by
+                exact (tailRestrictₗ_restrictLast (u := u) (ψ := ψ) (j := j)).symm
+        _ = restrictLast (groundSpaceMap A (L₀ + 1) (Y u)) j := by
+              rw [hY u]
+        _ = groundSpaceMap A L₀ (A j * Y u) := by
+              exact restrictLast_groundSpaceMap (A := A) (j := j) (X := Y u)
+    exact hLeftSlice.symm.trans hTailSlice
+  exact ⟨Z, Y, hZ, hY, hCompat⟩
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -411,6 +411,53 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:ground_space_intersection} at each step.
 \end{proof}
 
+\begin{definition}[Suffix restriction]\label{def:tail_restrict_parent}
+    \lean{MPSTensor.tailRestrictₗ}
+    \leanok
+    Fix a prefix $u : \Fin K \to \Fin d$. The suffix restriction of an
+    $(K+L)$-site state $\psi$ is the $L$-site state given by
+    \[
+        (\operatorname{tailRestrict}_u \psi)(\sigma) = \psi(u,\sigma).
+    \]
+\end{definition}
+
+\begin{definition}[Suffix ground membership]\label{def:in_tail_ground}
+    \lean{MPSTensor.InTailGround}
+    \leanok
+    \uses{def:tail_restrict_parent, def:ground_space_parent}
+    A state $\psi$ on $K+L$ sites lies in the suffix ground condition if every
+    fixed prefix $u$ gives a suffix state in $G_L(A)$.
+\end{definition}
+
+\begin{lemma}[Left-tail compatibility]\label{lem:left_tail_compatibility}
+    \lean{MPSTensor.exists_left_tail_compatibility}
+    \leanok
+    \uses{def:in_left_ground, def:in_tail_ground, def:ground_space_parent}
+    Assume $\psi$ on $K+L_0+1$ sites satisfies the left ground condition on the
+    first $K+L_0$ sites and the suffix ground condition on every fixed prefix of
+    length $K$. Then there exist matrices $(Z_j)_j$ and $(Y_u)_u$ such that
+    \[
+        \psi(\sigma,j) = \tr(A^\sigma Z_j), \qquad
+        \psi(u,\tau) = \tr(A^\tau Y_u),
+    \]
+    and for all $j$ and $u$,
+    \[
+        Z_j A^u = A_j Y_u.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Choose $Z_j$ from the long left-window condition and $Y_u$ from the suffix
+    ground condition. Restricting the suffix state at its last site gives the
+    boundary matrix $A_j Y_u$, while first fixing the last site and then taking
+    the suffix gives $Z_j A^u$. The two restrictions are the same because
+    appending the fixed prefix and then the last letter gives the same
+    configuration as appending the last letter to the suffix and then placing
+    the prefix in front. Injectivity of $\Gamma_{L_0}$, obtained from
+    $L_0$-block injectivity, yields $Z_j A^u = A_j Y_u$.
+\end{proof}
+
 \begin{definition}[MPV submodule]\label{def:mpv_submodule}
     \lean{MPSTensor.mpvSubmodule}
     \leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -476,6 +476,56 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $L_0$-block injectivity, yields $Z_j A^u = A_j Y_u$.
 \end{proof}
 
+\begin{theorem}[Common right factor from word compatibility]%
+    \label{thm:right_factor_word_compatibility}
+    \lean{MPSTensor.exists_right_factor_of_evalWord_compatibility}
+    \leanok
+    \uses{def:l_blk_injective}
+    Assume $A$ is $L_0$-block injective with $L_0 > 0$. If matrices $(Z_j)_j$
+    satisfy
+    \[
+        Z_j A^\sigma = A_j Y_\sigma
+    \]
+    for every word $\sigma$ of length $K$, then there exists a matrix $X$ such
+    that $Z_j = A_j X$ for all $j$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For $K = 1$, the hypothesis gives $Z_j A_i = A_j Y_i$ for every letter $i$.
+    Every blocked word of length $L_0$ is nonempty, so this identity extends to
+    the coefficients of the blocked tensor $A^{[L_0]}$. Since $A^{[L_0]}$ is
+    injective, the identity matrix is a linear combination of those blocked
+    coefficients, and substituting this decomposition yields $Z_j = A_j X$ for a
+    common matrix $X$. For larger $K$, strip the first letter: for each $i$, the
+    matrices $Z_j A_i$ satisfy the same compatibility hypothesis with words of
+    length $K - 1$, so the induction hypothesis reduces the problem to the case
+    $K = 1$.
+\end{proof}
+
+\begin{theorem}[Open-chain right extension at the injectivity length]%
+    \label{thm:ground_space_extend_right_block_injective}
+    \lean{MPSTensor.groundSpace_extend_right_of_isNBlkInjective}
+    \leanok
+    \uses{def:in_left_ground, def:in_tail_ground, def:ground_space_parent}
+    Assume $A$ is $L_0$-block injective with $L_0 > 0$ and $K > 0$. If an
+    element $\psi$ on $K + L_0 + 1$ sites satisfies the left ground condition on
+    the first $K + L_0$ sites and the suffix ground condition on every prefix of
+    length $K$, then $\psi \in G_{K + L_0 + 1}(A)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:left_tail_compatibility} produces matrices $(Z_j)_j$ and
+    $(Y_u)_u$ with $Z_j A^u = A_j Y_u$ for every prefix word $u$ of length $K$.
+    Theorem~\ref{thm:right_factor_word_compatibility} gives a common right factor
+    $X$ such that $Z_j = A_j X$ for all $j$. Therefore each last-site restriction
+    of $\psi$ agrees with the corresponding last-site restriction of the ground-
+    space vector determined by $X$. Since every configuration is obtained by
+    adjoining its final letter to its initial $(K + L_0)$-tuple, the two states
+    coincide, so $\psi$ lies in $G_{K + L_0 + 1}(A)$.
+\end{proof}
+
 \begin{definition}[MPV submodule]\label{def:mpv_submodule}
     \lean{MPSTensor.mpvSubmodule}
     \leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -508,8 +508,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.groundSpace_extend_right_of_isNBlkInjective}
     \leanok
     \uses{def:in_left_ground, def:in_tail_ground, def:ground_space_parent}
-    Assume $A$ is $L_0$-block injective with $L_0 > 0$ and $K > 0$. If an
-    element $\psi$ on $K + L_0 + 1$ sites satisfies the left ground condition on
+    Assume $A$ is $L_0$-block injective with $L_0 > 0$. If an element $\psi$
+    on $K + L_0 + 1$ sites satisfies the left ground condition on
     the first $K + L_0$ sites and the suffix ground condition on every prefix of
     length $K$, then $\psi \in G_{K + L_0 + 1}(A)$.
 \end{theorem}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -429,6 +429,24 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     fixed prefix $u$ gives a suffix state in $G_L(A)$.
 \end{definition}
 
+\begin{lemma}[Ground-space suffix restriction]\label{lem:ground_space_in_tail_ground}
+    \lean{MPSTensor.groundSpace_inTailGround}
+    \leanok
+    \uses{def:in_tail_ground, def:ground_space_parent}
+    If $\psi \in G_{K+L}(A)$, then every fixed-prefix suffix restriction of
+    $\psi$ lies in $G_L(A)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Write $\psi(\rho) = \tr(A^\rho X)$ for a boundary matrix $X$. Fixing a
+    prefix $u$ gives
+    \[
+        \psi(u,\sigma) = \tr(A^u A^\sigma X) = \tr(A^\sigma X A^u),
+    \]
+    so the suffix restriction again has the form of a ground-space vector.
+\end{proof}
+
 \begin{lemma}[Left-tail compatibility]\label{lem:left_tail_compatibility}
     \lean{MPSTensor.exists_left_tail_compatibility}
     \leanok


### PR DESCRIPTION
## Summary
- temporarily carry the suffix-window API from #707 on top of `main` so the #703 proof verifies from a `main`-based branch
- add `TNLean/MPS/ParentHamiltonian/ExtendRight.lean` with the grow-back theorem `MPSTensor.exists_right_factor_of_evalWord_compatibility`
- prove `MPSTensor.groundSpace_extend_right_of_isNBlkInjective` from `exists_left_tail_compatibility` plus the common right-factor theorem
- sync `blueprint/src/chapter/ch14_parent_hamiltonian.tex` with entries for the common-right-factor theorem and the open-chain extension theorem
- import the new module from `TNLean.lean`

## Context
This addresses #703 and unblocks the open-chain half of the range-reduction plan for #588.
Because `main` does not yet contain the suffix-window layer from #707, this branch temporarily carries the same Lean-side API (`SuffixWindow.lean` + blueprint/TNLean import) so the new theorem verifies honestly from a branch created off `origin/main`.

## Verification
- `lake env lean TNLean/MPS/ParentHamiltonian/SuffixWindow.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/ExtendRight.lean`
- `lake build TNLean.MPS.ParentHamiltonian.SuffixWindow`
- `lake build TNLean.MPS.ParentHamiltonian.ExtendRight`
- `lake env lean TNLean.lean`
- `lake build`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new foundational Lean theorems and APIs used in later parent-Hamiltonian range-reduction proofs; risk is mainly proof fragility/regressions from new dependencies and lemma statements, not runtime behavior.
> 
> **Overview**
> Adds the missing *suffix-window* layer for open-chain range-reduction, introducing `tailRestrictₗ`, `InTailGround`, and compatibility lemmas that relate suffix restrictions and last-site restrictions to `groundSpaceMap`.
> 
> Builds on this to prove the open-chain “grow-back” step: `exists_right_factor_of_evalWord_compatibility` (extracting a common right factor from word-level compatibility under `IsNBlkInjective`) and `groundSpace_extend_right_of_isNBlkInjective` (showing a `K+L₀+1`-site state is in `groundSpace` from adjacent left/tail ground conditions). Root imports and the blueprint chapter are updated to expose and document these new results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf10d987ddf756bfba188ff5ae5bfa239745d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->