### PR TITLE
feat(MPS/ParentHamiltonian): commuting parent Hamiltonians and decorrelation (#234)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.Periodic.Defs
+import TNLean.MPS.RFP.CommutingBridge
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.RFP.StructuralForm
 import TNLean.Axioms.Beigi
@@ -25,6 +26,8 @@ parent Hamiltonians (NNCPH).
 
 * `MPSTensor.IsCommutingParentHam.ham_comm_localTerm` — if local terms commute,
   the full Hamiltonian commutes with each local term.
+* `MPSTensor.ProductPairBridge.isNNCPH` — the product-pair witness packages
+  the NNCPH conclusion once the local-projector family is available.
 * `MPSTensor.rfp_implies_nncph` — scaffold for the RFP `⟹` NNCPH direction of
   Theorem 3.10.
 * `MPSTensor.nncph_implies_rfp` — scaffold for the NNCPH `⟹` RFP direction of
@@ -63,6 +66,18 @@ def IsNNCPH (A : MPSTensor d D) (N : ℕ) : Prop :=
 theorem IsNNCPH.isCommutingParentHam {A : MPSTensor d D} {N : ℕ} (h : IsNNCPH A N) :
     IsCommutingParentHam A 2 N :=
   h
+
+/-- A product-pair local-projector witness yields NNCPH on the same finite chain. -/
+theorem HasProductPairLocalProjectors.isNNCPH {A : MPSTensor d D} {N : ℕ}
+    (hPair : HasProductPairLocalProjectors A N) :
+    IsNNCPH A N :=
+  hPair.commuting_twoSite_localTerms
+
+/-- A product-pair witness on all finite chains yields NNCPH on each chain. -/
+theorem ProductPairBridge.isNNCPH {A : MPSTensor d D} (hBridge : ProductPairBridge A)
+    (N : ℕ) :
+    IsNNCPH A N :=
+  (hBridge.localProjectors N).isNNCPH
 
 /-- The commuting condition is symmetric: if `h i j` holds, then `h j i` holds. -/
 theorem IsCommutingParentHam.symm {A : MPSTensor d D} {L N : ℕ}

--- a/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
+++ b/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
@@ -1,0 +1,116 @@
+# Issue #234 audit — remaining commuting-parent-Hamiltonian and decorrelation gaps
+
+## Scope of this audit
+
+Issue #234 is no longer missing its basic surface.
+On current `main`, the repository already contains:
+
+- `TNLean/MPS/ParentHamiltonian/Commuting.lean` with
+  - `MPSTensor.IsCommutingParentHam`
+  - `MPSTensor.IsNNCPH`
+  - `MPSTensor.rfp_implies_nncph`
+  - `MPSTensor.nncph_implies_rfp`
+- `TNLean/MPS/ParentHamiltonian/Decorrelation.lean` with the backward decorrelation theorem
+  `Decorrelation.commutingHam_isDecorrelated`
+- `TNLean/MPS/RFP/Decorrelation.lean` with the abstract
+  commuting-idempotent algebra and the extended
+  `HasCommutingParentHam` / `IsDecorrelated` API
+- `TNLean/Axioms/Beigi.lean`, which records the two sanctioned axioms
+  currently used by the Theorem 3.10 wrappers.
+
+So the honest remaining work for #234 is **not** “define commuting parent Hamiltonians.”
+It is the pair of deeper follow-up gaps described below.
+
+## Small formal progress landed in this branch
+
+This branch adds two theorem wrappers to `TNLean/MPS/ParentHamiltonian/Commuting.lean`:
+
+- `MPSTensor.HasProductPairLocalProjectors.isNNCPH`
+- `MPSTensor.ProductPairBridge.isNNCPH`
+
+These results are immediate from the already-proved unfolded commutation theorem in
+`TNLean/MPS/RFP/CommutingBridge.lean`, but they matter conceptually: they isolate the internal
+`RFP ⟹ NNCPH` task to **constructing the product-pair witness**, rather than reproving the NNCPH
+wrapper each time.
+
+In other words, the non-axiomatic part of the forward direction now factors as
+
+1. extract product-pair data from the Appendix B structural form;
+2. apply `ProductPairBridge.isNNCPH`.
+
+## Gap 1 — replacing `Axioms.rfp_to_nncph_commute`
+
+The forward direction of Theorem 3.10 is currently discharged by the sanctioned axiom
+`Axioms.rfp_to_nncph_commute`.
+
+After the new wrappers above, the missing internal theorem is more precise:
+
+> from the current RFP structural results, construct a `ProductPairBridge A`
+> (or at least `HasProductPairLocalProjectors A N` for each finite `N`).
+
+### What is already available
+
+- `TNLean/MPS/RFP/StructuralFull.lean` proves the full Appendix B structural form
+  `rfp_nt_structural_full`.
+- `TNLean/MPS/RFP/CommutingBridge.lean` packages the chain-level data needed to conclude NNCPH,
+  and now `Commuting.lean` exposes the final wrapper `ProductPairBridge.isNNCPH`.
+
+### What is still missing
+
+A theorem of the following shape is not present:
+
+- **target shape**: `IsRFP A` + normality (+ the normalization data needed to invoke the Appendix B
+  form) `→ ProductPairBridge A`
+
+Concretely, the missing work is to turn the structural decomposition
+$$A_i = X \, \Lambda \, U_i \, X^{-1}$$
+into
+
+- an explicit repeated two-site amplitude on even chains, and
+- a family of chain-level projectors whose values are exactly the nearest-neighbor `localTerm`s.
+
+This is a genuine chain-space construction problem on `NSiteSpace d N`; it is **not** a remaining
+issue about the NNCPH definition itself.
+
+## Gap 2 — the forward decorrelation theorem is blocked on tensor locality
+
+`Decorrelation.commutingHam_isDecorrelated` proves the backward implication
+(commuting parent Hamiltonian `⟹` decorrelation) in the current abstract setting.
+
+The converse is still unavailable for a good reason: the present abstract predicate
+`Decorrelation.HasCommutingParentHam` deliberately omits tensor-locality constraints. Because of
+that omission, the file also contains the trivial witness
+`Decorrelation.HasCommutingParentHam.ofIdem`, showing that any idempotent projector admits a formal
+`HasCommutingParentHam` witness if one ignores locality.
+
+Therefore an abstract theorem of the form
+
+- `IsDecorrelated P_K ObsA ObsB → HasCommutingParentHam P_K`
+
+would be mathematically vacuous on the current API.
+
+### Exact missing infrastructure
+
+A non-vacuous forward proof needs tensor-product locality data that the current `NSiteSpace` model
+still does not expose:
+
+1. a tensor-factor / local-support API for `H_A ⊗ H_X ⊗ H_B` inside `NSiteSpace`;
+2. partial traces onto the `AX` and `XB` regions (or an equivalent support-projection API);
+3. support projectors of those partial traces;
+4. a refined `HasCommutingParentHam` predicate asserting that the witnesses really act on `AX` and
+   `XB`, not just on the ambient space.
+
+Only after those four pieces exist does the forward direction of Proposition D.3 become
+non-vacuous.
+
+## Practical conclusion
+
+Issue #234 should remain open, but its remaining content is now sharply separated:
+
+1. **internal forward direction**: replace `Axioms.rfp_to_nncph_commute` by constructing
+   `ProductPairBridge A` from the Appendix B structural form;
+2. **tensor-local decorrelation direction**: strengthen the decorrelation API with genuine locality
+   data, then prove the forward implication.
+
+The present branch reduces the first item to a single concrete extraction problem and records that
+reduction in both Lean and the blueprint.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -871,9 +871,11 @@ interaction projectors commute with each other.
     \lean{MPSTensor.productPairState}
     \lean{MPSTensor.HasProductPairMPV}
     \lean{MPSTensor.HasProductPairLocalProjectors}
+    \lean{MPSTensor.HasProductPairLocalProjectors.isNNCPH}
     \lean{MPSTensor.ProductPairBridge}
     \lean{MPSTensor.ProductPairBridge.localTerm_idempotent}
     \lean{MPSTensor.ProductPairBridge.commuting_twoSite_localTerms}
+    \lean{MPSTensor.ProductPairBridge.isNNCPH}
     \leanok
     For an even chain of length $2N$, \texttt{productPairWindow} extracts the
     $p$-th adjacent two-site word from a configuration. Given a fixed two-site
@@ -887,8 +889,10 @@ interaction projectors commute with each other.
     \texttt{ProductPairBridge.commuting\_twoSite\_localTerms} then shows that
     these local terms commute for every chain length $N$, while
     \texttt{ProductPairBridge.localTerm\_idempotent} records their idempotence.
-    This is the formal bridge needed between the Appendix~B product-of-pairs
-    structure and the future proof of Theorem~\ref{thm:rfp_implies_nncph}.
+    Consequently the same data yields the nearest-neighbor commuting condition
+    on every finite chain. This isolates the remaining proof of
+    Theorem~\ref{thm:rfp_implies_nncph} to the extraction of such data from the
+    Appendix~B structural form.
 \end{remark}
 
 \begin{theorem}[NNCPH implies RFP]\label{thm:nncph_implies_rfp}


### PR DESCRIPTION
## Summary

- add `MPSTensor.HasProductPairLocalProjectors.isNNCPH`
- add `MPSTensor.ProductPairBridge.isNNCPH`
- sync the Chapter 14 product-pair remark with the new NNCPH wrappers
- add `audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md`, narrowing the remaining #234 work to two concrete gaps:
  1. extracting product-pair data from the Appendix B structural form in order to replace `Axioms.rfp_to_nncph_commute`
  2. adding tensor-locality infrastructure before the forward decorrelation direction can be stated non-vacuously

## Why this route

Current `main` already has the surface declarations for issue #234:

- `MPSTensor.IsCommutingParentHam`
- `MPSTensor.IsNNCPH`
- `MPSTensor.rfp_implies_nncph`
- `MPSTensor.nncph_implies_rfp`
- `Decorrelation.commutingHam_isDecorrelated`

So the remaining gap is deeper than missing definitions. This PR takes the honest next step: it isolates the non-axiomatic `RFP ⟹ NNCPH` work to the extraction of a `ProductPairBridge` witness, and records the still-blocked tensor-local forward decorrelation direction in a focused audit.

## Verification

- `cd .worktrees/issue-234-commuting-ph && lake env lean TNLean/MPS/ParentHamiltonian/Commuting.lean`
- `cd .worktrees/issue-234-commuting-ph && lake build`
- `cd .worktrees/issue-234-commuting-ph && rg -n "sorry" TNLean/MPS/ParentHamiltonian/Commuting.lean audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md || true`
- `cd .worktrees/issue-234-commuting-ph && rg -n "^axiom " TNLean/MPS/ParentHamiltonian/Commuting.lean || true`
- `cd .worktrees/issue-234-commuting-ph/blueprint && leanblueprint web`
- `cd .worktrees/issue-234-commuting-ph/blueprint && leanblueprint checkdecls`

Part of #234 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds thin theorem wrappers and documentation/audit notes; minimal logical surface area change beyond a new import dependency.
> 
> **Overview**
> Adds an explicit bridge from product-pair projector witnesses to the NN commuting parent Hamiltonian predicate by importing `MPS/RFP/CommutingBridge` and exposing `HasProductPairLocalProjectors.isNNCPH` and `ProductPairBridge.isNNCPH` in `ParentHamiltonian/Commuting.lean`.
> 
> Updates the blueprint Chapter 14 remark to reference the new NNCPH wrappers, and adds an audit note (`audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md`) that narrows the remaining #234 work to (1) extracting a `ProductPairBridge` from Appendix B structural form to replace the `rfp_to_nncph` axiom, and (2) adding tensor-locality infrastructure needed for a non-vacuous forward decorrelation direction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aecbf3570c06d5cdcc232cf443379afb8473e414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->