### PR TITLE
feat(MPS/ParentHamiltonian): block-word stripping for normal-range reduction (#704)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -25,7 +25,7 @@ parent-Hamiltonian closure argument for block-injective tensors.
 ## Mathematical content
 
 If words of a fixed length `L` span the full matrix algebra, then the trace map
-`groundSpaceMap A L` is injective.  We use this to package a block-word
+`groundSpaceMap A L` is injective. We use this to formulate a block-word
 compatibility argument: if a family indexed by length-`L₀` words satisfies a
 common right-factor relation after multiplying by every length-`K` suffix, then
 block injectivity at length `L₀` strips the suffix and produces a common right

--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -1,0 +1,264 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import TNLean.MPS.FundamentalTheorem.FiniteLength
+import TNLean.Algebra.TracePairing
+import Mathlib.Data.Fin.Tuple.Basic
+import Mathlib.Data.List.OfFn
+
+/-!
+# Block-word stripping for block-injective parent-Hamiltonian arguments
+
+This file provides the algebraic stripping lemmas needed in the periodic
+parent-Hamiltonian closure argument for block-injective tensors.
+
+## Main results
+
+- `MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top`
+- `MPSTensor.groundSpaceMap_injective_of_isNBlkInjective`
+- `MPSTensor.exists_right_factor_of_block_word_compatibility`
+- `MPSTensor.commutes_block_words_of_commutes_long_words_of_isNBlkInjective`
+
+## Mathematical content
+
+If words of a fixed length `L` span the full matrix algebra, then the trace map
+`groundSpaceMap A L` is injective.  We use this to package a block-word
+compatibility argument: if a family indexed by length-`L₀` words satisfies a
+common right-factor relation after multiplying by every length-`K` suffix, then
+block injectivity at length `L₀` strips the suffix and produces a common right
+factor already at block length `L₀`.
+
+The final theorem applies this stripping mechanism to commutation relations:
+commutation with all words of length `m ≥ L₀` forces commutation with all block
+words of length `L₀`.
+
+## References
+
+* [CPGSV21] arXiv:2011.12127, §IV.C
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- If words of length `L` span the full matrix algebra, then `groundSpaceMap A L`
+has trivial kernel. -/
+theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D}
+    {L : ℕ} (hWord : wordSpan A L = ⊤) :
+    Function.Injective (groundSpaceMap A L) := by
+  have hker : (groundSpaceMap A L).ker = ⊥ := by
+    apply (LinearMap.ker_eq_bot').2
+    intro X hX
+    have hφ :
+        (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
+      apply LinearMap.ext_on_range
+        (v := fun σ : Fin L → Fin d => evalWord A (List.ofFn σ))
+      · simpa [wordSpan] using hWord
+      · intro σ
+        simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
+          congrArg (fun ψ => ψ σ) hX
+    exact trace_mul_right_eq_zero fun N => by
+      have hNX : Matrix.trace (N * X) = 0 := by
+        simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
+      calc
+        Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
+        _ = 0 := hNX
+  exact LinearMap.ker_eq_bot.mp hker
+
+/-- Block injectivity at length `L₀` makes `groundSpaceMap A L₀` injective. -/
+theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D}
+    {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) :
+    Function.Injective (groundSpaceMap A L₀) := by
+  apply groundSpaceMap_injective_of_wordSpan_eq_top
+  exact (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+
+/-- Letter compatibility extends to every nonempty word.  The left family `Z` and
+right family `F` can be indexed by any finite type; only the physical word lies
+in the MPS alphabet. -/
+private theorem exists_evalWord_factor_of_letter_compatibility
+    {A : MPSTensor d D} {α : Type*} {F Z : α → Matrix (Fin D) (Fin D) ℂ}
+    (hCompat : ∀ i : Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      ∀ a : α, Z a * A i = F a * Y)
+    (w : List (Fin d)) (hw : w ≠ []) :
+    ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      ∀ a : α, Z a * evalWord A w = F a * Y := by
+  cases w with
+  | nil => cases hw rfl
+  | cons i w =>
+      obtain ⟨Y, hY⟩ := hCompat i
+      refine ⟨Y * evalWord A w, ?_⟩
+      intro a
+      calc
+        Z a * evalWord A (i :: w)
+            = Z a * (A i * evalWord A w) := by simp [evalWord]
+        _ = (Z a * A i) * evalWord A w := by rw [Matrix.mul_assoc]
+        _ = (F a * Y) * evalWord A w := by rw [hY a]
+        _ = F a * (Y * evalWord A w) := by rw [Matrix.mul_assoc]
+
+/-- If a family indexed by length-`L₀` words is compatible with multiplication by
+single physical letters, then block injectivity strips the letter and produces a
+common right factor already at block length `L₀`. -/
+private theorem exists_right_factor_of_block_letter_compatibility
+    {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {Z : (Fin L₀ → Fin d) → Matrix (Fin D) (Fin D) ℂ}
+    (hCompat : ∀ i : Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      ∀ σ : Fin L₀ → Fin d,
+        Z σ * A i = evalWord A (List.ofFn σ) * Y) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      ∀ σ : Fin L₀ → Fin d, Z σ = evalWord A (List.ofFn σ) * X := by
+  have hCompatBlock : ∀ τ : Fin L₀ → Fin d,
+      ∃ Yτ : Matrix (Fin D) (Fin D) ℂ,
+        ∀ σ : Fin L₀ → Fin d,
+          Z σ * evalWord A (List.ofFn τ) = evalWord A (List.ofFn σ) * Yτ := by
+    intro τ
+    have hw : List.ofFn τ ≠ [] := by
+      intro hnil
+      have hlen : L₀ = 0 := by
+        simpa [List.length_ofFn] using congrArg List.length hnil
+      omega
+    exact exists_evalWord_factor_of_letter_compatibility
+      (A := A) (F := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
+      (Z := Z) hCompat (List.ofFn τ) hw
+  choose Y hY using hCompatBlock
+  let gen : (Fin L₀ → Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+    fun σ => evalWord A (List.ofFn σ)
+  have hSurj : Function.Surjective (Fintype.linearCombination ℂ gen) := by
+    apply (span_range_eq_top_iff_surjective_fintypeLinearCombination ℂ gen).mp
+    simpa [gen, wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+  obtain ⟨c, hc⟩ := hSurj (1 : Matrix (Fin D) (Fin D) ℂ)
+  have hc' : ∑ τ, c τ • gen τ = (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    simpa [Fintype.linearCombination_apply] using hc
+  let X : Matrix (Fin D) (Fin D) ℂ := ∑ τ, c τ • Y τ
+  refine ⟨X, ?_⟩
+  intro σ
+  calc
+    Z σ = Z σ * (1 : Matrix (Fin D) (Fin D) ℂ) := by simp
+    _ = Z σ * ∑ τ, c τ • gen τ := by rw [hc']
+    _ = ∑ τ, c τ • (Z σ * gen τ) := by simp [Finset.mul_sum]
+    _ = ∑ τ, c τ • (gen σ * Y τ) := by
+          refine Finset.sum_congr rfl ?_
+          intro τ _
+          rw [hY τ σ]
+    _ = gen σ * ∑ τ, c τ • Y τ := by simp [Finset.mul_sum]
+    _ = evalWord A (List.ofFn σ) * X := by rfl
+
+/-- Block-word stripping theorem: compatibility with every suffix word of a fixed
+length `K` implies a common right factor already at block length `L₀`. -/
+theorem exists_right_factor_of_block_word_compatibility
+    {A : MPSTensor d D} {K L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {Z : (Fin L₀ → Fin d) → Matrix (Fin D) (Fin D) ℂ}
+    (hCompat : ∀ τ : Fin K → Fin d, ∃ Yτ : Matrix (Fin D) (Fin D) ℂ,
+      ∀ σ : Fin L₀ → Fin d,
+        Z σ * evalWord A (List.ofFn τ) = evalWord A (List.ofFn σ) * Yτ) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      ∀ σ : Fin L₀ → Fin d, Z σ = evalWord A (List.ofFn σ) * X := by
+  induction K generalizing Z with
+  | zero =>
+      let τ0 : Fin 0 → Fin d := Fin.elim0
+      obtain ⟨Y, hY⟩ := hCompat τ0
+      refine ⟨Y, ?_⟩
+      intro σ
+      simpa [τ0, evalWord] using hY σ
+  | succ K ih =>
+      have hCompat1 : ∀ i : Fin d, ∃ Xi : Matrix (Fin D) (Fin D) ℂ,
+          ∀ σ : Fin L₀ → Fin d,
+            Z σ * A i = evalWord A (List.ofFn σ) * Xi := by
+        intro i
+        let Zi : (Fin L₀ → Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+          fun σ => Z σ * A i
+        have hCompatZi : ∀ τ : Fin K → Fin d, ∃ Yτ : Matrix (Fin D) (Fin D) ℂ,
+            ∀ σ : Fin L₀ → Fin d,
+              Zi σ * evalWord A (List.ofFn τ) = evalWord A (List.ofFn σ) * Yτ := by
+          intro τ
+          obtain ⟨Yτ, hYτ⟩ := hCompat (Fin.cons i τ)
+          refine ⟨Yτ, ?_⟩
+          intro σ
+          simpa [Zi, evalWord_ofFn_cons, Matrix.mul_assoc] using hYτ σ
+        obtain ⟨Xi, hXi⟩ := ih hCompatZi
+        exact ⟨Xi, hXi⟩
+      exact exists_right_factor_of_block_letter_compatibility hInj hL₀ hCompat1
+
+/-- If a matrix commutes with all words of some length `m ≥ L₀`, then it already
+commutes with every block word of length `L₀`. -/
+theorem commutes_block_words_of_commutes_long_words_of_isNBlkInjective
+    {A : MPSTensor d D} {L₀ m : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    (hm : L₀ ≤ m) {X : Matrix (Fin D) (Fin D) ℂ}
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X) :
+    ∀ σ : Fin L₀ → Fin d,
+      X * evalWord A (List.ofFn σ) = evalWord A (List.ofFn σ) * X := by
+  let Z : (Fin L₀ → Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+    fun σ => X * evalWord A (List.ofFn σ)
+  have hmEq : L₀ + (m - L₀) = m := by omega
+  have hComm' : ∀ ω : Fin (L₀ + (m - L₀)) → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X := by
+    intro ω
+    let ω' : Fin m → Fin d := fun i => ω (Fin.cast hmEq.symm i)
+    have hω' := hComm ω'
+    have hlist : List.ofFn ω' = List.ofFn ω := by
+      apply List.ext_getElem
+      · simp [ω', hmEq]
+      · intro i h1 h2
+        simp [ω', Fin.cast]
+    simpa [ω', hlist] using hω'
+  have hCompat : ∀ τ : Fin (m - L₀) → Fin d,
+      ∃ Yτ : Matrix (Fin D) (Fin D) ℂ,
+        ∀ σ : Fin L₀ → Fin d,
+          Z σ * evalWord A (List.ofFn τ) = evalWord A (List.ofFn σ) * Yτ := by
+    intro τ
+    refine ⟨evalWord A (List.ofFn τ) * X, ?_⟩
+    intro σ
+    have hστ := hComm' (Fin.append σ τ)
+    rw [List.ofFn_fin_append, evalWord_append, ← Matrix.mul_assoc, Matrix.mul_assoc,
+      Matrix.mul_assoc] at hστ
+    simpa [Z, Matrix.mul_assoc] using hστ
+  obtain ⟨R, hR⟩ :=
+    exists_right_factor_of_block_word_compatibility (A := A) hInj hL₀ (Z := Z) hCompat
+  let gen : (Fin L₀ → Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+    fun σ => evalWord A (List.ofFn σ)
+  have hSurj : Function.Surjective (Fintype.linearCombination ℂ gen) := by
+    apply (span_range_eq_top_iff_surjective_fintypeLinearCombination ℂ gen).mp
+    simpa [gen, wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+  obtain ⟨c, hc⟩ := hSurj (1 : Matrix (Fin D) (Fin D) ℂ)
+  have hc' : ∑ σ, c σ • gen σ = (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    simpa [Fintype.linearCombination_apply] using hc
+  have hXR : X = R := by
+    calc
+      X = X * (1 : Matrix (Fin D) (Fin D) ℂ) := by simp
+      _ = X * ∑ σ, c σ • gen σ := by rw [hc']
+      _ = ∑ σ, c σ • (X * gen σ) := by simp [Finset.mul_sum]
+      _ = ∑ σ, c σ • (gen σ * R) := by
+            refine Finset.sum_congr rfl ?_
+            intro σ _
+            exact congrArg (fun M => c σ • M) (hR σ)
+      _ = (∑ σ, c σ • gen σ) * R := by simp [Finset.sum_mul]
+      _ = R := by rw [hc', one_mul]
+  intro σ
+  simpa [Z, hXR] using hR σ
+
+/-- If a matrix commutes with all words of some length `m ≥ L₀`, then block
+injectivity forces it to commute with every matrix in the ambient algebra. -/
+theorem commutes_all_of_commutes_long_words_of_isNBlkInjective
+    {A : MPSTensor d D} {L₀ m : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    (hm : L₀ ≤ m) {X : Matrix (Fin D) (Fin D) ℂ}
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X) :
+    ∀ M : Matrix (Fin D) (Fin D) ℂ, X * M = M * X := by
+  have hBlock :=
+    commutes_block_words_of_commutes_long_words_of_isNBlkInjective
+      (A := A) hInj hL₀ hm hComm
+  have hφ : LinearMap.mulLeft ℂ X = LinearMap.mulRight ℂ X := by
+    apply LinearMap.ext_on_range
+      (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
+    · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+    · intro σ
+      simpa [LinearMap.mulLeft_apply, LinearMap.mulRight_apply] using hBlock σ
+  intro M
+  simpa [LinearMap.mulLeft_apply, LinearMap.mulRight_apply] using congrArg (fun f => f M) hφ
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Basic
+import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.FundamentalTheorem.FiniteLength
 
@@ -41,6 +42,8 @@ proceeds as follows:
 
 ## Main results
 
+* `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`
+  — block injectivity turns long-word commutation into generator commutation
 * `MPSTensor.boundary_matrix_commutes` — if `groundSpaceMap A N X` lies in
   every cyclic window's ground space, then `X` commutes with all `A_j`.
 
@@ -177,9 +180,9 @@ private theorem init_evalWord_split {A : MPSTensor d D}
 Use `tr(P * Q) = tr(Q * P)` to rotate the wrapping boundary,
 then extract a matrix equation via `groundSpaceMap_injective`. -/
 
+set_option maxHeartbeats 800000 in
 -- Expanding `cyclicCfg` and rotating the trace through the wrapping window produces
 -- large normalization goals, so this proof needs a larger heartbeat budget.
-set_option maxHeartbeats 800000 in
 private theorem wrapping_window_matEq {A : MPSTensor d D} [NeZero D]
     (hA : IsInjective A) {L : ℕ} (hL : 1 < L) {M : ℕ} (hM : 1 ≤ M) (hLN : L ≤ M + 1)
     {X : Matrix (Fin D) (Fin D) ℂ}
@@ -257,9 +260,21 @@ private theorem wrapping_window_matEq {A : MPSTensor d D} [NeZero D]
 
 Extend from the wrapping window equation to full commutation via spanning. -/
 
+/-- If a boundary matrix commutes with all words of some length `m ≥ L₀`, then
+block injectivity forces it to commute with every generator. -/
+theorem boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes
+    {A : MPSTensor d D} {L₀ m : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    (hm : L₀ ≤ m) {X : Matrix (Fin D) (Fin D) ℂ}
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X) :
+    ∀ j : Fin d, X * A j = A j * X := by
+  intro j
+  exact commutes_all_of_commutes_long_words_of_isNBlkInjective
+    (A := A) hInj hL₀ hm hComm (A j)
+
+set_option maxHeartbeats 800000 in
 -- The double spanning argument over window tails and complements creates large
 -- `LinearMap.ext_on_range` goals, so we raise the heartbeat budget here as well.
-set_option maxHeartbeats 800000 in
 /-- If `groundSpaceMap A N X` lies in every cyclic window's ground space,
 then `X` commutes with all generators `A_j`.
 

--- a/audits/2026-04-21_issue704_block_strip_followup.md
+++ b/audits/2026-04-21_issue704_block_strip_followup.md
@@ -1,0 +1,68 @@
+# Issue #704 follow-up after landing the block-word stripping family
+
+Date: 2026-04-21
+Branch: `feat/704-block-word-strip`
+
+## What this branch adds
+
+This branch lands the algebraic block-word stripping family identified by the
+wave-1 audit:
+
+- `MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top`
+- `MPSTensor.groundSpaceMap_injective_of_isNBlkInjective`
+- `MPSTensor.exists_right_factor_of_block_word_compatibility`
+- `MPSTensor.commutes_block_words_of_commutes_long_words_of_isNBlkInjective`
+- `MPSTensor.commutes_all_of_commutes_long_words_of_isNBlkInjective`
+- the WrappingWindow corollary
+  `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`
+
+These theorems prove the exact algebraic reduction
+
+$$
+\text{(commutation on all words of length }m \ge L_0) \implies
+\text{(commutation on all generators)}.
+$$
+
+So the old one-site stripping step has now been replaced by a genuine
+length-$L_0$ stripping theorem family.
+
+## Remaining blocker for the full wrapping theorem
+
+The full target
+
+- `WrappingWindow.boundary_matrix_commutes_of_isNBlkInjective`
+
+is still not landed on this branch.
+
+After the new theorem family, the remaining missing input is sharper than in PR
+#718:
+
+> we still need a wrapped-window comparison theorem that extracts **long-word
+> commutation** from the cyclic ground-space hypothesis.
+
+Concretely, the new theorems finish the argument **once** one has a statement of
+the form
+
+```lean
+∀ ω : Fin m → Fin d,
+  X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X
+```
+
+for some `m ≥ L₀`.
+
+What is still missing in `WrappingWindow.lean` is a block-injective replacement
+for the injective trace-stripping step inside `wrapping_window_matEq` which
+produces that long-word commutation family from the wrapped cyclic-window
+hypothesis.
+
+In other words, this branch removes the algebraic roadblock identified in the
+wave-1 audit, but the periodic-side extraction step still needs one more theorem
+in the wrapping-window analysis itself.
+
+## Practical consequence
+
+This branch is therefore a **real infrastructure PR**, not an issue-closing PR:
+
+- it resolves the abstract block-word stripping gap from audit #718;
+- it narrows the remaining #704 work to a single periodic-side extraction step;
+- it still does **not** close #704 / #588 by itself.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -11,7 +11,8 @@ coefficient functions
 \]
 rather than as an explicit tensor product.
 
-\section{\texorpdfstring{Local ground space $G_L(A)$}{Local ground space G\_L(A)}}\label{sec:ground_space_parent}
+\section{\texorpdfstring{Local ground space $G_L(A)$}{Local ground space G\_L(A)}}%
+\label{sec:ground_space_parent}
 
 Fix an MPS tensor $A = \{A^i\}_{i=0}^{d-1}$ with $A^i \in \MN{D}$ and a block
 length $L \ge 1$.
@@ -118,7 +119,8 @@ onto $G_L(A)^\perp$ in the $L$-site Euclidean space.
     on the local $L$-site space.
 \end{definition}
 
-\begin{lemma}[Parent interaction kills ground-space elements]\label{lem:parent_interaction_apply_mem_ground_space}
+\begin{lemma}[Parent interaction kills ground-space elements]%
+    \label{lem:parent_interaction_apply_mem_ground_space}
     \lean{MPSTensor.parentInteraction_apply_mem_groundSpace}
     \leanok
     \uses{def:parent_interaction, def:ground_space_parent}
@@ -183,7 +185,8 @@ translated copies of the local interaction.
 \begin{lemma}[Local term annihilates the MPV]\label{lem:local_term_annihilates_mpv}
     \lean{MPSTensor.localTerm_annihilates_mpv}
     \leanok
-    \uses{def:local_term_parent, def:mpv, lem:mpv_window_mem_ground_space, lem:parent_interaction_apply_mem_ground_space}
+    \uses{def:local_term_parent, def:mpv, lem:mpv_window_mem_ground_space,
+        lem:parent_interaction_apply_mem_ground_space}
     For each site $i$, $h_i\,V^{(N)}(A) = 0$.
 \end{lemma}
 
@@ -318,6 +321,37 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     If $\Gamma_L(X) = 0$ then $\tr(A^\sigma X) = 0$ for every length-$L$ word
     $\sigma$. Since $A$ is injective, the products $\{A^\sigma\}_\sigma$ span
     $\MN{D}$, so the trace pairing gives $X = 0$.
+\end{proof}
+
+\begin{theorem}[Ground-space map injectivity from word span]
+    \label{thm:ground_space_map_injective_word_span}
+    \lean{MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top}
+    \leanok
+    \uses{def:ground_space_map}
+    If the length-$L$ products $\{A^\sigma : |\sigma| = L\}$ span $\MN{D}$, then
+    $\Gamma_L$ is injective.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    If $\Gamma_L(X) = 0$, then $\tr(A^\sigma X) = 0$ for every word $\sigma$ of
+    length $L$. The spanning hypothesis turns this into $\tr(MX) = 0$ for every
+    $M \in \MN{D}$, and the trace pairing gives $X = 0$.
+\end{proof}
+
+\begin{lemma}[Ground-space map injectivity for block-injective tensors]
+    \label{lem:ground_space_map_injective_blk}
+    \lean{MPSTensor.groundSpaceMap_injective_of_isNBlkInjective}
+    \leanok
+    \uses{thm:ground_space_map_injective_word_span, def:l_blk_injective}
+    If $A$ is $L_0$-block-injective, then $\Gamma_{L_0}$ is injective.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    By definition, $L_0$-block injectivity says precisely that the length-$L_0$
+    products span $\MN{D}$. Apply
+    Theorem~\ref{thm:ground_space_map_injective_word_span}.
 \end{proof}
 
 \begin{theorem}[Ground-space dimension]\label{thm:ground_space_finrank_eq}
@@ -491,6 +525,88 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $N - L_0$, so $A^{w'} A^{u_1} = 0$ by the previous step) and iterating,
     we eventually reach $\tr(A^u) = 0$ for $|u| = L_0$, which gives
     $I = 0$, a contradiction.
+\end{proof}
+
+\subsection{Block-word stripping}
+
+\begin{theorem}[Common right factor from block-word compatibility]
+    \label{thm:block_word_strip_right_factor}
+    \lean{MPSTensor.exists_right_factor_of_block_word_compatibility}
+    \leanok
+    \uses{def:l_blk_injective}
+    Assume $A$ is $L_0$-block-injective with $L_0 > 0$. Let $\{Z_u\}_{|u|=L_0}$
+    be a family indexed by words of length $L_0$. If for some $K \ge 0$ and every
+    suffix word $w$ of length $K$ there exists $Y_w \in \MN{D}$ such that
+    \[
+        Z_u A^w = A^u Y_w
+        \qquad\text{for every word }u\text{ of length }L_0,
+    \]
+    then there exists $X \in \MN{D}$ with $Z_u = A^u X$ for every word $u$ of
+    length $L_0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Induct on $K$. For $K = 0$ the empty suffix gives $Z_u = A^u Y_{\emptyset}$.
+    For the successor step, fix the first physical index and apply the induction
+    hypothesis to the shortened suffix. This reduces the statement to letter
+    compatibility on the right. Extending that letter compatibility to all
+    length-$L_0$ words and decomposing $\Id$ in the spanning family
+    $\{A^u : |u| = L_0\}$ yields a common factor $X$.
+\end{proof}
+
+\begin{theorem}[Block-word commutation from long-word commutation]
+    \label{thm:block_word_strip_commutes}
+    \lean{MPSTensor.commutes_block_words_of_commutes_long_words_of_isNBlkInjective}
+    \leanok
+    \uses{thm:block_word_strip_right_factor, def:l_blk_injective}
+    If $A$ is $L_0$-block-injective with $L_0 > 0$, $m \ge L_0$, and
+    $X \in \MN{D}$ commutes with every length-$m$ product $A^\omega$, then $X$
+    already commutes with every length-$L_0$ product $A^u$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write each length-$m$ word as a concatenation $uw$ with $|u| = L_0$ and
+    $|w| = m - L_0$. The hypothesis gives
+    \[
+        X A^u A^w = A^u A^w X = A^u (A^w X).
+    \]
+    Thus the family $Z_u := X A^u$ satisfies the hypothesis of
+    Theorem~\ref{thm:block_word_strip_right_factor}. One obtains
+    $X A^u = A^u R$ for all $|u| = L_0$. Decomposing $\Id$ in the span of the
+    length-$L_0$ words shows $R = X$, hence $X A^u = A^u X$.
+\end{proof}
+
+\begin{theorem}[Centrality from long-word commutation]
+    \label{thm:block_word_strip_central}
+    \lean{MPSTensor.commutes_all_of_commutes_long_words_of_isNBlkInjective}
+    \leanok
+    \uses{thm:block_word_strip_commutes, def:l_blk_injective}
+    If $A$ is $L_0$-block-injective with $L_0 > 0$, $m \ge L_0$, and
+    $X \in \MN{D}$ commutes with every length-$m$ word product, then $X$
+    commutes with every matrix in $\MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By Theorem~\ref{thm:block_word_strip_commutes}, $X$ commutes with every
+    length-$L_0$ word product. These products span $\MN{D}$ by block
+    injectivity, so linearity gives $XM = MX$ for every $M \in \MN{D}$.
+\end{proof}
+
+\begin{lemma}[Generator commutation from long-word commutation]
+    \label{lem:boundary_matrix_commutes_long_words}
+    \lean{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes}
+    \leanok
+    \uses{thm:block_word_strip_central}
+    Under the hypotheses of Theorem~\ref{thm:block_word_strip_central}, one has
+    $X A^i = A^i X$ for every physical index $i$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply Theorem~\ref{thm:block_word_strip_central} with $M = A^i$.
 \end{proof}
 
 \begin{theorem}[Chain ground space for block-injective tensors]%


### PR DESCRIPTION
## Summary

This PR lands the block-word stripping theorem family identified by audit PR #718.

### Lean additions

- new file `TNLean/MPS/ParentHamiltonian/BlockStrip.lean`
- `MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top`
- `MPSTensor.groundSpaceMap_injective_of_isNBlkInjective`
- `MPSTensor.exists_right_factor_of_block_word_compatibility`
- `MPSTensor.commutes_block_words_of_commutes_long_words_of_isNBlkInjective`
- `MPSTensor.commutes_all_of_commutes_long_words_of_isNBlkInjective`
- WrappingWindow corollary
  `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`

### Blueprint and audit

- synced `blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- added follow-up note `audits/2026-04-21_issue704_block_strip_followup.md`

## What this does

The new theorem family proves the algebraic reduction

$$
\text{(commutation on all words of length } m \ge L_0) \implies
\text{(commutation with all generators).}
$$

So the old missing one-site stripping step now has a genuine length-$L_0$
replacement.

## What remains blocked

This PR does **not** yet prove the full periodic wrapping theorem
`boundary_matrix_commutes_of_isNBlkInjective`.

After landing the block-word stripping family, the remaining missing input is a
wrapped-window comparison theorem that extracts the needed long-word
commutation family from the cyclic ground-space hypothesis in
`WrappingWindow.lean`.

So this PR narrows the remaining #704 / #588 gap to that single periodic-side
extraction step, but it does **not** close #704 by itself.

## Verification

- `cd .worktrees/issue-704-block-strip && lake env lean TNLean/MPS/ParentHamiltonian/BlockStrip.lean`
- `cd .worktrees/issue-704-block-strip && lake env lean TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
- `cd .worktrees/issue-704-block-strip && lake build`
- `cd .worktrees/issue-704-block-strip && rg -n "sorry|axiom" TNLean/MPS/ParentHamiltonian/BlockStrip.lean TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
- `cd .worktrees/issue-704-block-strip/blueprint && leanblueprint web && leanblueprint checkdecls`

## Linked issues

- Related: #704
- Blocked downstream: #588
- Follow-up to audit PR #718
- Closes none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new proof-heavy Lean infrastructure that changes the dependency graph for `WrappingWindow` and adds nontrivial algebraic lemmas; risk is mainly around proof stability/performance (heartbeats) rather than runtime behavior.
> 
> **Overview**
> Adds a new Lean module `ParentHamiltonian/BlockStrip.lean` that formalizes the *block-word stripping* infrastructure: injectivity of `groundSpaceMap` from `wordSpan`/block-injectivity, a general “common right factor” stripping lemma over length-`K` suffixes, and corollaries turning commutation with all long words (`m ≥ L₀`) into commutation with block words and then with all matrices.
> 
> Updates `WrappingWindow.lean` to import this module and introduces `boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`, bridging the new long-word→centrality results to the existing boundary-matrix commutation goal; also adjusts heartbeat limits around the heavy proofs. Documentation is synced by extending the blueprint with the new theorems and adding an audit follow-up note describing remaining work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24d2d46e8fd1a76e2b8e2cf60e09f617e7d4d12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->