### PR TITLE
feat(MPS/Periodic): Thm 4.1 progress v2 (#622)

### DIFF
--- a/TNLean/MPS/Periodic/Symmetry.lean
+++ b/TNLean/MPS/Periodic/Symmetry.lean
@@ -33,6 +33,11 @@ for periodic MPS in irreducible form.
   Theorem 4.1 (`p`-divisibility of the transfer channel and `p`-refinement of an MPS
   tensor).
 
+* `MPSTensor.pRefinementCanonicalization_pullback_of_irreducibleForm` — the pullback
+  tensor arising from a `p`-refinement witness preserves irreducible form II, so the
+  remaining forward-direction gap is confined to the blocked equal-case / root
+  reconstruction stage.
+
 * `MPSTensor.thm_4_1_p_refinement_forward` — **Theorem 4.1, forward direction**:
   `p`-refinability of `B` implies `p`-divisibility of its transfer map, conditional on a
   canonicalization hypothesis `PRefinementCanonicalization`.
@@ -296,6 +301,178 @@ theorem evalWord_sum_smul_ofFn
         simp [eqv, Fin.consEquiv]
       rw [hprod, hList, evalWord_cons, smul_mul_smul_comm]
 
+private theorem mpv_sum_smul_ofFn
+    {m : ℕ} (B : MPSTensor d D) (W : Matrix (Fin m) (Fin d) ℂ)
+    (N : ℕ) (τ : Fin N → Fin m) :
+    mpv (fun τ' : Fin m => ∑ σ' : Fin d, W τ' σ' • B σ') τ =
+      ∑ σ : Fin N → Fin d,
+        (∏ k : Fin N, W (τ k) (σ k)) * coeff B (List.ofFn σ) := by
+  simp [mpv_eq, coeff_eq, evalWord_sum_smul_ofFn, Matrix.trace_sum, Matrix.trace_smul]
+
+/-- Physical-index mixing by a fixed matrix preserves `SameMPV₂`. -/
+theorem sameMPV₂_sum_smul_ofFn
+    {m D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (W : Matrix (Fin m) (Fin d) ℂ)
+    (hAB : SameMPV₂ A B) :
+    SameMPV₂
+      (fun τ : Fin m => ∑ σ : Fin d, W τ σ • A σ)
+      (fun τ : Fin m => ∑ σ : Fin d, W τ σ • B σ) := by
+  intro N τ
+  calc
+    mpv (fun τ' : Fin m => ∑ σ' : Fin d, W τ' σ' • A σ') τ =
+        ∑ σ : Fin N → Fin d,
+          (∏ k : Fin N, W (τ k) (σ k)) * coeff A (List.ofFn σ) := by
+          exact mpv_sum_smul_ofFn A W N τ
+    _ = ∑ σ : Fin N → Fin d,
+          (∏ k : Fin N, W (τ k) (σ k)) * coeff B (List.ofFn σ) := by
+          refine Finset.sum_congr rfl ?_
+          intro σ _
+          simpa [mpv_eq, coeff_eq] using
+            congrArg
+              (fun z : ℂ => (∏ k : Fin N, W (τ k) (σ k)) * z)
+              (hAB N σ)
+    _ = mpv (fun τ' : Fin m => ∑ σ' : Fin d, W τ' σ' • B σ') τ := by
+          symm
+          exact mpv_sum_smul_ofFn B W N τ
+
+/-- A physical-index isometry preserves left-canonicality. -/
+theorem isLeftCanonical_kraus_isometry
+    {m : ℕ} (B : MPSTensor d D)
+    (W : Matrix (Fin m) (Fin d) ℂ) (hW : Wᴴ * W = 1)
+    (hB : IsLeftCanonical B) :
+    IsLeftCanonical (fun τ : Fin m => ∑ σ : Fin d, W τ σ • B σ) := by
+  let C : MPSTensor m D := fun τ => ∑ σ : Fin d, W τ σ • B σ
+  have hCh : IsChannel (transferMap C) := by
+    have hEq : transferMap C = transferMap B := by
+      simpa [C] using transferMap_kraus_isometry B W hW
+    simpa [hEq] using transferMap_isChannel B hB
+  simpa [C] using
+    kraus_sum_conjTranspose_mul_of_tp C (transferMap C)
+      (fun X => by simp [transferMap_apply]) hCh.tp
+
+/-- A physical-index isometry preserves periodicity and its period. -/
+theorem isPeriodic_kraus_isometry
+    {m p : ℕ} (B : MPSTensor d D)
+    (W : Matrix (Fin m) (Fin d) ℂ) (hW : Wᴴ * W = 1)
+    (hB : IsPeriodic p B) :
+    IsPeriodic p (fun τ : Fin m => ∑ σ : Fin d, W τ σ • B σ) := by
+  let C : MPSTensor m D := fun τ => ∑ σ : Fin d, W τ σ • B σ
+  have hEq : transferMap C = transferMap B := by
+    simpa [C] using transferMap_kraus_isometry B W hW
+  have hIrrMapB : IsIrreducibleMap (transferMap B) :=
+    isIrreducibleMap_of_isIrreducibleTensor B hB.irreducible
+  have hIrrMapC : IsIrreducibleMap (transferMap C) := by
+    simpa [hEq] using hIrrMapB
+  refine ⟨isIrreducibleTensor_of_isIrreducibleMap C hIrrMapC,
+    isLeftCanonical_kraus_isometry B W hW hB.leftCanonical,
+    hB.period_pos, ?_, hB.primitiveRoot⟩
+  simpa [C, hEq] using hB.peripheral_eq
+
+private theorem sameMPV₂_toTensorFromBlocks_sum_smul_ofFn
+    {m r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (W : Matrix (Fin m) (Fin d) ℂ) :
+    SameMPV₂
+      (fun τ : Fin m => ∑ σ : Fin d, W τ σ •
+        toTensorFromBlocks (d := d) (μ := μ) blocks σ)
+      (toTensorFromBlocks (d := m) (μ := μ)
+        (fun k : Fin r => fun τ : Fin m => ∑ σ : Fin d, W τ σ • blocks k σ)) := by
+  intro N τ
+  calc
+    mpv (fun τ' : Fin m => ∑ σ' : Fin d, W τ' σ' •
+        toTensorFromBlocks (d := d) (μ := μ) blocks σ') τ =
+        ∑ σ : Fin N → Fin d,
+          (∏ k : Fin N, W (τ k) (σ k)) *
+            mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+          simpa [mpv_eq, coeff_eq] using
+            mpv_sum_smul_ofFn (B := toTensorFromBlocks (d := d) (μ := μ) blocks) W N τ
+    _ = ∑ σ : Fin N → Fin d,
+          (∏ k : Fin N, W (τ k) (σ k)) *
+            ∑ j : Fin r, (μ j) ^ N * mpv (blocks j) σ := by
+          refine Finset.sum_congr rfl ?_
+          intro σ _
+          rw [mpv_toTensorFromBlocks_eq_sum]
+          simp only [smul_eq_mul]
+    _ = ∑ σ : Fin N → Fin d,
+          ∑ j : Fin r,
+            (∏ k : Fin N, W (τ k) (σ k)) *
+              ((μ j) ^ N * mpv (blocks j) σ) := by
+          simp_rw [Finset.mul_sum]
+    _ = ∑ j : Fin r,
+          ∑ σ : Fin N → Fin d,
+            (∏ k : Fin N, W (τ k) (σ k)) *
+              ((μ j) ^ N * mpv (blocks j) σ) := by
+          rw [Finset.sum_comm]
+    _ = ∑ j : Fin r,
+          (μ j) ^ N *
+            ∑ σ : Fin N → Fin d,
+              (∏ k : Fin N, W (τ k) (σ k)) * mpv (blocks j) σ := by
+          refine Finset.sum_congr rfl ?_
+          intro j _
+          calc
+            ∑ σ : Fin N → Fin d,
+                (∏ k : Fin N, W (τ k) (σ k)) *
+                  ((μ j) ^ N * mpv (blocks j) σ)
+                = ∑ σ : Fin N → Fin d,
+                    (μ j) ^ N *
+                      ((∏ k : Fin N, W (τ k) (σ k)) * mpv (blocks j) σ) := by
+                    refine Finset.sum_congr rfl ?_
+                    intro σ _
+                    simp [mul_assoc, mul_comm]
+            _ = (μ j) ^ N *
+                  ∑ σ : Fin N → Fin d,
+                    (∏ k : Fin N, W (τ k) (σ k)) * mpv (blocks j) σ := by
+                    rw [← Finset.mul_sum]
+    _ = ∑ j : Fin r,
+          (μ j) ^ N *
+            mpv (fun τ' : Fin m => ∑ σ' : Fin d, W τ' σ' • blocks j σ') τ := by
+          refine Finset.sum_congr rfl ?_
+          intro j _
+          congr 1
+          symm
+          simpa [mpv_eq, coeff_eq] using mpv_sum_smul_ofFn (B := blocks j) W N τ
+    _ = mpv (toTensorFromBlocks (d := m) (μ := μ)
+          (fun k : Fin r => fun τ' : Fin m => ∑ σ : Fin d, W τ' σ • blocks k σ)) τ := by
+          symm
+          rw [mpv_toTensorFromBlocks_eq_sum]
+          simp only [smul_eq_mul]
+
+/-- A physical-index isometry preserves irreducible form II. -/
+noncomputable def isIrreducibleForm_kraus_isometry
+    {m : ℕ} (B : MPSTensor d D)
+    (W : Matrix (Fin m) (Fin d) ℂ) (hW : Wᴴ * W = 1)
+    (hB : IsIrreducibleForm B) :
+    IsIrreducibleForm (fun τ : Fin m => ∑ σ : Fin d, W τ σ • B σ) := by
+  refine
+    { r := hB.r
+      dim := hB.dim
+      blocks := fun k : Fin hB.r =>
+        fun τ : Fin m => ∑ σ : Fin d, W τ σ • hB.blocks k σ
+      μ := hB.μ
+      period := hB.period
+      periodic := ?_
+      weight_pos := hB.weight_pos
+      sameMPV := ?_ }
+  · intro k
+    exact isPeriodic_kraus_isometry (B := hB.blocks k) W hW (hB.periodic k)
+  · have hPullbackSame :
+        SameMPV₂
+          (fun τ : Fin m => ∑ σ : Fin d, W τ σ • B σ)
+          (fun τ : Fin m => ∑ σ : Fin d, W τ σ •
+            toTensorFromBlocks (d := d) (μ := hB.μ) hB.blocks σ) :=
+        sameMPV₂_sum_smul_ofFn B
+          (toTensorFromBlocks (d := d) (μ := hB.μ) hB.blocks) W hB.sameMPV
+    have hBlocksSame :
+        SameMPV₂
+          (fun τ : Fin m => ∑ σ : Fin d, W τ σ •
+            toTensorFromBlocks (d := d) (μ := hB.μ) hB.blocks σ)
+          (toTensorFromBlocks (d := m) (μ := hB.μ)
+            (fun k : Fin hB.r => fun τ : Fin m => ∑ σ : Fin d, W τ σ • hB.blocks k σ)) :=
+        sameMPV₂_toTensorFromBlocks_sum_smul_ofFn hB.μ hB.blocks W
+    intro N τ
+    exact (hPullbackSame N τ).trans (hBlocksSame N τ)
+
 /-- **Pullback stage of the forward canonicalization roadmap for Theorem 4.1.**
 
 From a `p`-refinement witness `(A, W)` for `B`, the `W`-pullback tensor
@@ -329,6 +506,31 @@ theorem pRefinementCanonicalization_pullback
     _ = mpv (blockTensor A p) τ := by
           simpa [mpv_eq] using (hCoeff N τ).symm
 
+/-- **Pullback stage with irreducible-form input for Theorem 4.1.**
+
+If the refined tensor `B` is already in irreducible form II, then the pullback
+`C τ := ∑_σ W(τ, σ) • B σ` coming from a `p`-refinement witness is again in
+irreducible form II, has the same transfer map as `B`, and has the same MPV
+family as `blockTensor A p`. This isolates the genuinely new input now
+available on `main`: the first stage of the paper's proof preserves the
+periodic block structure of `B`; the remaining forward-direction gap is the
+blocked equal-case / root-reconstruction stage after this theorem. -/
+theorem pRefinementCanonicalization_pullback_of_irreducibleForm
+    (B : MPSTensor d D) (hB : IsIrreducibleForm B) (p : ℕ)
+    (hRefine : IsPRefinable B p) :
+    ∃ (A : MPSTensor d D)
+      (W : Matrix (Fin (blockPhysDim d p)) (Fin d) ℂ)
+      (_ : IsIrreducibleForm
+        (fun τ : Fin (blockPhysDim d p) => ∑ σ : Fin d, W τ σ • B σ)),
+      Wᴴ * W = 1 ∧
+      transferMap (fun τ : Fin (blockPhysDim d p) => ∑ σ : Fin d, W τ σ • B σ) =
+        transferMap B ∧
+      SameMPV (fun τ : Fin (blockPhysDim d p) => ∑ σ : Fin d, W τ σ • B σ)
+        (blockTensor A p) := by
+  obtain ⟨A, W, hW, hTransfer, hSame⟩ :=
+    pRefinementCanonicalization_pullback B p hRefine
+  exact ⟨A, W, isIrreducibleForm_kraus_isometry B W hW hB, hW, hTransfer, hSame⟩
+
 /-- **Theorem 4.1, forward direction (witness-based form).**
 
 If we can produce a witness `A : MPSTensor d D` for the `p`-refinement of `B`
@@ -361,11 +563,13 @@ left-canonical and produces a matching transfer map under `p`-blocking.
 
 Morally, the canonicalization is produced as follows. Given a witness
 `(A, W)` from `IsPRefinable B p`, form the `W`-pullback tensor
-`C τ := ∑_σ W(τ, σ) · B σ`; the theorem
-`pRefinementCanonicalization_pullback` now packages this first stage, giving
-`E_C = E_B` together with `SameMPV C (blockTensor A p)`. The periodic
-equal-case Fundamental Theorem (Theorem 3.8 of arXiv:1708.00029, available here
-as the hypothesis `PeriodicEqualCaseFT`) then supplies a `Z`-gauge equivalence
+`C τ := ∑_σ W(τ, σ) · B σ`; the theorems
+`pRefinementCanonicalization_pullback` and
+`pRefinementCanonicalization_pullback_of_irreducibleForm` now package this
+first stage, giving `E_C = E_B`, `SameMPV C (blockTensor A p)`, and preserving
+irreducible form II when `B` already has it. The periodic equal-case
+Fundamental Theorem (Theorem 3.8 of arXiv:1708.00029, available here as the
+hypothesis `PeriodicEqualCaseFT`) then supplies a `Z`-gauge equivalence
 between `C` and `blockTensor A p`, which — combined with a unitary
 canonical-form reduction for irreducible form II and Wolf Theorem 2.18 —
 produces the sought left-canonical witness. Formalizing this remaining second

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -469,6 +469,34 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     $\ket{V_{pN}(A)} = W^{\otimes N}\, \ket{V_N(B)}$ for all~$N$.
 \end{definition}
 
+\begin{theorem}[Pullback of a refinement witness]
+    \label{thm:p_refinement_pullback_irreducible_form}
+    \lean{MPSTensor.pRefinementCanonicalization_pullback_of_irreducibleForm}
+    \leanok
+    \uses{def:irreducible_form, def:p_refinable}
+    Let $B$ be an MPS tensor in irreducible form~II. If $B$ is
+    $p$-refinable, then there exist a tensor $A$, an isometry
+    $W : \C^d \to (\C^d)^{\otimes p}$, and the pullback tensor
+    $$
+        C^{\alpha} := \sum_{i=0}^{d-1} W_{\alpha,i} B^i
+        \qquad (\alpha \in \{0,\ldots,d^p-1\})
+    $$
+    such that $C$ is again in irreducible form~II, $\mathcal E_C = \mathcal E_B$,
+    and $C$ has the same MPV family as $A^{[p]}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose $(A,W)$ from the refinement data. The pullback construction gives
+    $\mathcal E_C = \mathcal E_B$ and equality of MPV families between $C$
+    and $A^{[p]}$. To see that $C$ is still in irreducible form~II, transport
+    each periodic block $B_j$ of $B$ through the same physical isometry $W$.
+    The left-canonical normalization is preserved because $W^{\dagger}W = \Id$,
+    while irreducibility and the peripheral spectrum are preserved because the
+    transfer map of each transported block agrees with that of $B_j$.
+    Reassembling these transported blocks with the same weights gives an
+    irreducible-form decomposition of $C$.
+\end{proof}
+
 \begin{theorem}[Thm.~4.1 — $p$-refinability $\iff$ $p$-divisibility]%
     \label{thm:thm_4_1_p_refinement}
     \lean{MPSTensor.thm_4_1_p_refinement}


### PR DESCRIPTION
## Summary

This PR makes honest Lean progress on #622 without claiming that either
`PRefinementCanonicalization` or `PRefinementInverseCanonicalization` is fully discharged.
It sharpens the **forward** side by formalizing a step that the paper treats as immediate:
the physical-index pullback of an irreducible-form-II tensor stays in irreducible form II.

### Lean changes

In `TNLean/MPS/Periodic/Symmetry.lean`:
- added `MPSTensor.sameMPV₂_sum_smul_ofFn`
- added `MPSTensor.isLeftCanonical_kraus_isometry`
- added `MPSTensor.isPeriodic_kraus_isometry`
- added `MPSTensor.isIrreducibleForm_kraus_isometry`
- added `MPSTensor.pRefinementCanonicalization_pullback_of_irreducibleForm`
- updated the forward-canonicalization docstrings to reflect the narrower remaining gap

In the blueprint:
- added a `ch11b_periodic_ft.tex` theorem entry for
  `MPSTensor.pRefinementCanonicalization_pullback_of_irreducibleForm`

## Why this is useful for #622

The existing theorem `pRefinementCanonicalization_pullback` already gave the pullback tensor
$C$ with
- $\mathcal E_C = \mathcal E_B$, and
- `SameMPV C (blockTensor A p)`.

What was still only implicit was that, when $B$ is already in irreducible form II,
this same pullback tensor $C$ also remains in irreducible form II. This PR formalizes exactly
that statement.

So the remaining forward-direction work is now more tightly isolated:
1. an unconditional blocked equal-case FT (`PeriodicEqualCaseFT` still packages this),
2. the blocked-to-unblocked root reconstruction step (still tied to #609 / `repeatedBlocks_of_blockedSectorGaugePhase`),
3. independently, the reverse-direction same-size Kraus-rank reduction packaged by
   `PRefinementInverseCanonicalization`.

This is intended as a genuine continuation of the blocker audit in #693, not a replacement for it.

## Verification

Executed in `.worktrees/issue-622-thm41-v2`:
- `lake env lean TNLean/MPS/Periodic/Symmetry.lean`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/Periodic/Symmetry.lean blueprint/src/chapter/ch11b_periodic_ft.tex`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

Closes part of #622.
Refs: #622, #693.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean lemmas/theorem and blueprint documentation without affecting runtime behavior; main risk is proof maintenance due to additional abstraction around Kraus-isometry pullbacks.
> 
> **Overview**
> Formalizes that the physical-index *pullback* tensor arising from a `p`-refinement witness preserves **irreducible form II**, tightening the forward-direction roadmap for Theorem 4.1.
> 
> Adds supporting lemmas showing that physical-index mixing by an isometry preserves `SameMPV₂`, `IsLeftCanonical`, `IsPeriodic`, and lifts these to an `IsIrreducibleForm` preservation result, then packages this as `pRefinementCanonicalization_pullback_of_irreducibleForm` (alongside the existing pullback result) and updates the forward-canonicalization documentation accordingly.
> 
> Updates the blueprint (`ch11b_periodic_ft.tex`) to include the new pullback/irreducible-form theorem statement and proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c40c403d1047902e181aae7e7ede58ceb5da84c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->