### PR TITLE
chore(MPS/Periodic): sharpen #609 full-cycle contraction blocker

### DIFF
--- a/TNLean/MPS/Periodic/Overlap.lean
+++ b/TNLean/MPS/Periodic/Overlap.lean
@@ -1832,15 +1832,23 @@ lemma sectorMatch_propagation
   -- `sectorGaugePhaseEquiv_succ_of_cyclicTransport`.
   sorry
 
-/-- Missing blocked-to-unblocked gauge bridge for the periodic-overlap Case 3.
+/-- Missing full-cycle contraction step for periodic-overlap Case 3.
 
-This is the precise API gap in Eqs. A.14-A.18 of arXiv:1708.00029.  The
-available cyclic-sector decomposition only exposes the compressed blocked
-tensors through projection trace identities.  To finish the bridge, the API
-must also provide one-site transition tensors between consecutive cyclic
-sectors, identify their `m`-fold cyclic products with `blocksA` and `blocksB`,
-and then telescope the sector phases extracted by injectivity contraction into
-a single global gauge with a unit-modulus scalar. -/
+At this point the sector transport has already been abstracted into
+`hBlockMatch`, so the remaining gap is no longer the Eq. A.8 staircase
+identification.  What is still needed from Eqs. A.14-A.18 of
+arXiv:1708.00029 is the contraction argument around the whole cycle:
+for each sector `u`, normality gives a repetition length after which
+`blocksA u` is injective, and one should use a right inverse from
+`decompositionMap` to contract the repeated blocked products and recover
+per-site proportionality with a single telescoped phase.
+
+The current chain library provides `decompositionMap` /
+`exists_rightInverse` in `MPS/Chain/OneSidedInverse.lean` and the two-site
+proportionality theorem `tensor_proportional` in
+`MPS/Chain/TensorEquality.lean`, but it does not yet provide the `m`-factor
+cyclic contraction theorem needed to pass from `hBlockMatch` to a global
+`RepeatedBlocks` witness. -/
 private lemma repeatedBlocks_of_blockedSectorGaugePhase
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]
@@ -1875,6 +1883,12 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
     (hNondeg : ∀ u, dimA u ≠ 0)
     (hNormal : ∀ u, IsNormal (blocksA u)) :
     RepeatedBlocks A B := by
+  -- Missing ingredient: a reusable `m`-factor cyclic contraction theorem,
+  -- built from `decompositionMap`, that upgrades the per-sector blocked
+  -- gauge data in `hBlockMatch` to one global phase and one global gauge.
+  -- The current library only provides the two-site theorem
+  -- `tensor_proportional`, so the full-cycle step from Eqs. A.14-A.18 of
+  -- arXiv:1708.00029 still has to be formalized separately.
   sorry
 
 /-- **Per-site proportionality** (Eq. A.14 of arXiv:1708.00029):


### PR DESCRIPTION
## Summary

- sharpen the target note on `repeatedBlocks_of_blockedSectorGaugePhase` in `TNLean/MPS/Periodic/Overlap.lean`
- record the current precise blocker for #609: the missing full-cycle `Ω_u` contraction / phase-telescoping theorem from Appendix A.14–A.18
- point to the existing inputs already on `main`: `decompositionMap` / `exists_rightInverse` in `MPS/Chain/OneSidedInverse.lean` and the two-site theorem `tensor_proportional` in `MPS/Chain/TensorEquality.lean`

## Why no proof landed

The present lemma already assumes `hBlockMatch`, so the sector-transport and staircase-identification work has been abstracted away. After re-reading the theorem statement, `Overlap.lean`, `CornerTransition.lean`, `OneSidedInverse.lean`, `TensorEquality.lean`, and Appendix A of `Papers/1708.00029/main.tex`, the remaining missing ingredient for this theorem itself is the contraction step around the full cycle:

- from `hNormal`, each `blocksA u` becomes injective after some repetition;
- one then needs an `m`-factor cyclic contraction theorem, built from `decompositionMap`, to contract the repeated blocked products and extract per-site proportionality with one telescoped phase;
- the current library only provides the two-site theorem `tensor_proportional`, which is not enough to finish the full-cycle argument in a small local patch.

So this PR is a focused blocker report for #609 rather than a fake proof.

## Verification

- `lake env lean TNLean/MPS/Periodic/Overlap.lean`
- `lake build`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`

Closes none. Refs #609.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only changes that do not affect definitions, statements, or proofs (still `sorry`).
> 
> **Overview**
> Updates the documentation on `repeatedBlocks_of_blockedSectorGaugePhase` to reframe the outstanding gap as the *full-cycle contraction/phase-telescoping* step (Appendix A.14–A.18), not the earlier cyclic transport/staircase identification.
> 
> Adds explicit inline notes that the missing piece is an `m`-factor cyclic contraction theorem built from `decompositionMap`/`exists_rightInverse`, and that the current library only provides the two-site `tensor_proportional`, leaving the lemma `sorry` pending that new result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0eb8b089f7722c08ffc91173a454c65bf5f7f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->