### PR TITLE
doc(PEPS): clarify remaining FT blockers (#503)

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -9,11 +9,17 @@ import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 -- Provability note: `IsVertexInjective` in `PEPS.Defs` is the
 -- linear-independence formulation `∀ v, LinearIndependent ℂ (A.component v)`
 -- (see issue #633 for the switch away from function-level injectivity, which
--- is strictly weaker).  Linear independence gives each vertex tensor a left
--- inverse on its image and is the correct hypothesis for `gauge_unique_up_to_scalar`.
--- The remaining `sorry`s below still require the virtual-insertion /
--- blocking argument from arXiv:1804.04964 §3 that reduces each star
--- neighbourhood to a 3-site MPS chain; the definition no longer blocks them.
+-- is strictly weaker). Linear independence gives each vertex tensor a left
+-- inverse on its image and removes the old definitional blocker.
+--
+-- The remaining `sorry`s split into two groups:
+-- * `localGauge_exists`, `gaugeConsistency`, and the `hDim` step in
+--   `fundamentalTheorem_PEPS` still require the virtual-insertion / blocking
+--   argument from arXiv:1804.04964 §3 that reduces each star neighbourhood to a
+--   3-site MPS chain.
+-- * `gauge_unique_up_to_scalar` additionally needs statement repair: the
+--   current global-scalar conclusion fails on a connected triangle with bond
+--   dimension `1`.
 
 /-!
 # Fundamental Theorem for injective PEPS (scaffold)
@@ -574,15 +580,13 @@ theorem fundamentalTheorem_PEPS (A B : Tensor G d)
 
 /-! ### Uniqueness (up to scalar) -/
 
-/-- The gauge in the Fundamental Theorem is unique up to a global multiplicative
-scalar. If `X` and `Y` are two gauge families relating the same pair of
-injective PEPS on a connected graph, then `X_e = c · Y_e` for some nonzero
-`c : ℂ` independent of `e`.
+/-- Placeholder uniqueness endpoint for the PEPS Fundamental Theorem.
 
-This is the PEPS analogue of the MPS result that the gauge matrix is unique
-up to scalar (arXiv:1804.04964, Theorem 2, uniqueness clause). The
-connectedness hypothesis is essential: on a disconnected graph, gauges on
-different components can be rescaled independently. -/
+The current statement asks for a single nonzero scalar `c : ℂ` with
+`X_e = c · Y_e` on every edge. The issue-#503 discussion records a connected
+triangle counterexample with bond dimension `1`, so this conclusion is too
+strong as stated. The eventual replacement will need an explicit normalization
+for the edge gauges before one can ask for uniqueness. -/
 theorem gauge_unique_up_to_scalar (A B : Tensor G d)
     (hConn : G.Connected)
     (hA : IsVertexInjective A)
@@ -598,14 +602,16 @@ theorem gauge_unique_up_to_scalar (A B : Tensor G d)
         gaugeVertex A Y v η σ) :
     ∃ (c : ℂ), c ≠ 0 ∧ ∀ (e : Edge G),
       (X e).val = c • (Y e).val := by
-  -- TODO: from hX and hY, gauge(X) = gauge(Y) at every vertex.
-  -- Linear independence (`IsVertexInjective`, issue #633) forces
-  -- `X_e · Y_e⁻¹` to be a scalar at each edge, and connectivity of the graph
-  -- forces the per-edge scalars to agree globally.
-  -- Missing lemma: the per-edge "scalar factor" extraction from equality of
-  -- gauged vertex tensors, and the connectivity propagation.  Both are
-  -- downstream of the paper's §3 virtual-insertion / blocking argument and
-  -- do not require further strengthening of the injectivity hypothesis.
+  -- TODO: the current statement is too strong. The issue-#503 discussion gives
+  -- a connected triangle counterexample with bond dimension `1`, where two
+  -- nontrivial gauge families act trivially on every vertex but are not related
+  -- by one global scalar.
+  --
+  -- The eventual replacement needs two ingredients:
+  -- 1. statement repair, adding the right normalization or cocycle data for the
+  --    edge gauges;
+  -- 2. a uniqueness proof for that corrected statement, downstream of the
+  --    virtual-insertion / blocking argument from arXiv:1804.04964 §3.
   sorry
 
 end PEPS

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1270,6 +1270,15 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     unique up to a global multiplicative scalar.
 \end{theorem}
 
+\begin{remark}
+    The first three PEPS results above still wait for the graph-blocking /
+    virtual-insertion argument of~\cite{Molnar2018NormalPEPS}, §3. For the
+    uniqueness endpoint, the current global-scalar conclusion is too strong:
+    a connected triangle with bond dimension $1$ admits nontrivial edge
+    rescalings whose vertex products are all $1$. A corrected statement will
+    need an explicit normalization of the edge gauges.
+\end{remark}
+
 %% ---------------------------------------------------------
 \section{Closing remarks}%
 \label{sec:closing}


### PR DESCRIPTION
## Summary
- current `main` already has the first two issue-#503 goals (`applyGauge_stateCoeff` and `GaugeEquiv.sameState`) from PR #566, so this branch does **not** close any new PEPS `sorry`
- sharpen the Lean-side blocker notes in `TNLean/PEPS/FundamentalTheorem.lean`
- add a matching blueprint remark in `blueprint/src/chapter/ch13_algebraic_ft.tex`

## Remaining `sorry`s and blockers
1. `localGauge_exists`
2. `gaugeConsistency`
3. the `hDim` subproof inside `fundamentalTheorem_PEPS`

These three still need the graph-blocking / virtual-insertion argument from arXiv:1804.04964 §3, reducing a star neighbourhood to an injective 3-site MPS chain.

4. `gauge_unique_up_to_scalar`

This one has an additional blocker: the **current statement is too strong**. The issue-#503 discussion records a connected triangle counterexample with bond dimension `1`, so the global-scalar conclusion needs statement repair before any proof attempt.

## Verification
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`
- `lake build TNLean.PEPS.FundamentalTheorem`
- `lake build`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust comments and blueprint text; no functional or proof logic is modified.
> 
> **Overview**
> Clarifies the remaining proof blockers in `TNLean/PEPS/FundamentalTheorem.lean`, explicitly grouping which `sorry`s still depend on the virtual-insertion/blocking argument and noting that `gauge_unique_up_to_scalar` additionally needs a *statement fix*.
> 
> Rewords the `gauge_unique_up_to_scalar` documentation to flag a connected-triangle, bond-dimension-`1` counterexample to the current global-scalar uniqueness claim, and mirrors this clarification with a new remark in the blueprint chapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e06f7ca44d23119e4b8cdd5d5455326f3ea43b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->