### PR TITLE
doc(blueprint/ch09): block-permutation audit sync (#326)

### DIFF
--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -1,20 +1,45 @@
 \chapter{Block Permutation and Separation}\label{ch:block_perm}
 
-This chapter establishes the algebraic structure of
-automorphisms of products of matrix algebras and uses it
-to prove that the same-MPV condition on block-diagonal
-tensors descends to per-block gauge equivalence.
-The results correspond to the canonical form uniqueness
-of~\cite{PerezGarcia2007Matrix} and the block separation
-results of~\cite{Cirac2021Matrix}. The proof technique
-used here---induction on blocks via the spectral
-gap---is the approach adopted in this chapter.
+This chapter records the algebra of block permutations, the product-algebra maps
+built from per-block same-MPV data, the invariant-projection splitting step that
+reduces a tensor to smaller blocks, and the block-separation argument that
+recovers the individual blocks from a block-diagonal same-MPV hypothesis.
+The results correspond to the canonical-form uniqueness
+of~\cite{PerezGarcia2007Matrix} and the block-separation
+results of~\cite{Cirac2021Matrix}.
 
 \section{Block permutation algebra}
+
+\begin{definition}[Block ideal]\label{def:block_ideal}
+    \lean{MPSTensor.blockIdeal}
+    \leanok
+    Let $\{R_k\}_{k=1}^r$ be simple rings.
+    The $k$-th \emph{block ideal} in $\prod_{j=1}^r R_j$ is
+    \[
+        I_k := \{x \in \prod_{j=1}^r R_j : x_j = 0 \text{ for } j \neq k\}.
+    \]
+\end{definition}
+
+\begin{theorem}[Each block ideal is an atom]\label{thm:block_ideal_atom}
+    \lean{MPSTensor.isAtom_blockIdeal}
+    \leanok
+    \uses{def:block_ideal}
+    Each block ideal $I_k$ is an atom in the lattice of two-sided ideals of
+    $\prod_{j=1}^r R_j$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Under the order isomorphism between two-sided ideals of $\prod_{j=1}^r R_j$
+    and products of two-sided ideal lattices, $I_k$ corresponds to the tuple with
+    $\top$ in the $k$-th coordinate and $\bot$ elsewhere. This tuple is an atom,
+    hence so is $I_k$.
+\end{proof}
 
 \begin{theorem}[Ring isomorphisms permute block ideals]\label{thm:ring_perm}
     \lean{MPSTensor.ringEquiv_pi_simple_permutes_blockIdeals}
     \leanok
+    \uses{def:block_ideal}
     Let $\{R_k\}_{k=1}^r$ be simple rings.
     Every ring isomorphism $T : \prod_k R_k \to \prod_k R_k$
     permutes the block ideals:
@@ -24,19 +49,19 @@ gap---is the approach adopted in this chapter.
 
 \begin{proof}
     \leanok
-    Each block ideal $I_k = \{x : x_j = 0 \text{ for } j \neq k\}$
-    is an atom in the lattice of two-sided ideals
-    (since $R_k$ is simple).
-    A ring isomorphism preserves the ideal lattice and hence
-    permutes the atoms.
-    Injectivity of the induced map on atoms gives the
-    permutation~$\pi$.
+    \uses{thm:block_ideal_atom}
+    By Theorem~\ref{thm:block_ideal_atom}, each block ideal is an atom in the
+    lattice of two-sided ideals of $\prod_k R_k$.
+    A ring isomorphism induces an order automorphism of this lattice,
+    so it permutes the atoms. Since the atoms are exactly the block ideals,
+    this gives the required permutation~$\pi$.
 \end{proof}
 
 \begin{remark}[Ring level versus algebra level]\label{rem:ring_vs_alg}
     Theorem~\ref{thm:ring_perm} is a ring-level statement: it only uses the
     ideal structure of $\prod_k R_k$.
-    Theorems~\ref{thm:dim_preserved}
+    Theorems~\ref{thm:dim_preserved},
+    \ref{thm:component_map_bijective},
     and~\ref{thm:pi_auto_decomp} require an upgrade to $\C$-algebra
     automorphisms. The reason is threefold: dimension preservation compares
     the blocks as $\C$-vector spaces; Skolem--Noether applies to the resulting
@@ -61,7 +86,29 @@ gap---is the approach adopted in this chapter.
     induces a $\C$-algebra isomorphism
     $\MN{D_k} \cong \MN{D_{\pi(k)}}$,
     which forces $D_k = D_{\pi(k)}$
-    (by comparing dimensions as $\C$-vector spaces).
+    by comparing dimensions as $\C$-vector spaces.
+\end{proof}
+
+\begin{theorem}[Per-block component maps are bijections]\label{thm:component_map_bijective}
+    \lean{MPSTensor.componentMap_bijective}
+    \leanok
+    \uses{thm:ring_perm}
+    Let $T$ be a ring automorphism of $\prod_{k=1}^r \MN{D_k}$, and let $\pi$
+    be the induced permutation from Theorem~\ref{thm:ring_perm}.
+    For each block index $k$, the map
+    \[
+        M \mapsto T(0,\ldots,0,M,0,\ldots,0)_{\pi(k)}
+    \]
+    from $\MN{D_k}$ to $\MN{D_{\pi(k)}}$ is bijective.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:ring_perm} forces a single-support element in the $k$-th
+    block ideal to remain supported on the $\pi(k)$-th block after applying~$T$.
+    Injectivity follows from injectivity of~$T$.
+    For surjectivity, apply the same argument to $T^{-1}$ and the inverse
+    permutation.
 \end{proof}
 
 \begin{theorem}[Decomposition of automorphisms of $\prod \MN{D_k}$]\label{thm:pi_auto_decomp}
@@ -80,17 +127,19 @@ gap---is the approach adopted in this chapter.
 
 \begin{proof}
     \leanok
-    \uses{thm:ring_perm, thm:dim_preserved, thm:skolem_noether}
+    \uses{thm:ring_perm, thm:dim_preserved, thm:component_map_bijective,
+          thm:skolem_noether}
     Theorem~\ref{thm:ring_perm} gives the permutation $\pi$.
-    Theorem~\ref{thm:dim_preserved} gives $D_{\pi(k)} = D_k$.
-    The restriction of $T$ to the $k$-th block ideal yields a $\C$-algebra
-    isomorphism $\MN{D_k} \cong \MN{D_{\pi(k)}}$; after
-    Theorem~\ref{thm:dim_preserved} identifies the two matrix sizes,
-    Skolem--Noether (Theorem~\ref{thm:skolem_noether}) makes this
-    restriction inner.
+    Theorem~\ref{thm:dim_preserved} identifies the matrix sizes
+    $D_{\pi(k)} = D_k$.
+    For each $k$, Theorem~\ref{thm:component_map_bijective} gives a bijective
+    multiplicative map from $\MN{D_k}$ to $\MN{D_{\pi(k)}}$ extracted from the
+    single-support inputs of~$T$; after reindexing by the dimension equality,
+    this is a $\C$-algebra automorphism of $\MN{D_k}$.
+    Skolem--Noether (Theorem~\ref{thm:skolem_noether}) makes each such
+    automorphism inner.
 
-    This is a standard result in the theory of
-    semisimple algebras;
+    This is a standard result in the theory of semisimple algebras;
     see \cite[§IV.A]{Cirac2021Matrix} for the MPS context.
 \end{proof}
 
@@ -141,14 +190,10 @@ gap---is the approach adopted in this chapter.
     Each $T_k$ exists uniquely and is multiplicative by
     Theorems~\ref{thm:linear_ext} and~\ref{thm:linear_ext_mul}.
     Promotion to algebra homomorphisms
-    (Lemma~\ref{lem:linear_map_to_alg}) and composition into
-    the product gives an algebra automorphism $T$.
-    Theorem~\ref{thm:pi_auto_decomp} decomposes $T$ into
-    a permutation plus per-block inner automorphisms.
-    Because $T$ acts blockwise, it preserves each block ideal,
-    so in this theorem the permutation is actually $\pi = \mathrm{id}$.
-    A nontrivial block permutation only appears after block separation
-    identifies which blocks match globally.
+    (Lemma~\ref{lem:linear_map_to_alg}) and blockwise composition give an
+    algebra automorphism of $\prod_k \MN{D_k}$.
+    Theorem~\ref{thm:pi_auto_decomp} then decomposes this automorphism as a
+    block permutation together with per-block inner automorphisms.
 \end{proof}
 
 \begin{theorem}[Per-block same MPV gives global gauge equivalence]\label{thm:per_block_gauge}
@@ -171,6 +216,95 @@ gap---is the approach adopted in this chapter.
     Global gauge equivalence follows by placing the
     per-block gauge matrices on the block diagonal
     (Theorem~\ref{thm:multi_block_global}).
+\end{proof}
+
+\section{Burnside and invariant projections}
+
+\begin{theorem}[The algebra span reaches a finite cumulative span]\label{thm:algspan_cumulative_span}
+    \lean{MPSTensor.exists_cumulativeSpan_eq_top_of_algSpan_eq_top}
+    \leanok
+    \uses{def:alg_span, def:cumulative_span}
+    If the generated unital algebra satisfies $\algspn(A) = \MN{D}$,
+    then there exists $N$ such that $T_N(A) = \MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Every element of $\algspn(A)$ lies in some cumulative span $T_n(A)$:
+    the generators lie in $T_1(A)$, scalar multiples of the identity lie in
+    $T_0(A)$, and the family $\{T_n(A)\}_{n \ge 0}$ is closed under addition
+    and under multiplication with lengths adding.
+    Since $\MN{D}$ is finite-dimensional, the ascending chain
+    $T_0(A) \subseteq T_1(A) \subseteq \cdots$ stabilizes, so one can choose a
+    single $N$ with $T_N(A) = \MN{D}$.
+\end{proof}
+
+\begin{theorem}[Irreducible action gives an irreducible tensor]\label{thm:irreducible_action_to_tensor}
+    \lean{MPSTensor.isIrreducibleTensor_of_isIrreducibleAction}
+    \leanok
+    \uses{def:irreducible_action, def:irreducible_tensor}
+    If the letters of $A$ act irreducibly on $\C^D$, then $A$ has no nontrivial
+    invariant orthogonal projection.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    If $P$ were a nontrivial invariant orthogonal projection, then its range
+    would be invariant under every letter of $A$.
+    Irreducibility of the action forces this range to be either $0$ or all of
+    $\C^D$, so $P$ must be $0$ or $\Id$, a contradiction.
+\end{proof}
+
+\begin{theorem}[Invariant projection gives a two-block decomposition]\label{thm:lowerzero_two_block}
+    \lean{MPSTensor.exists_twoBlock_decomp_of_lowerZero}
+    \leanok
+    \uses{def:same_mpv2}
+    Suppose $P$ is an orthogonal projection satisfying
+    \[
+        (\Id - P) A^i P = 0 \qquad \text{for all } i.
+    \]
+    Then there exist $n,m$ with $n + m = D$ and MPS tensors $A_1, A_2$ of bond
+    dimensions $n$ and $m$ such that $A$ and the two-block tensor
+    $A_1 \oplus A_2$ generate the same MPV family in the sense of
+    Definition~\ref{def:same_mpv2}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:samempv_unitary}
+    Diagonalize $P$ by a unitary $U$.
+    Since $P^2 = P$, the diagonal form of $P$ has only $0$- and $1$-eigenvalues,
+    so the basis splits as $n + m = D$.
+    Conjugating $A$ by $U$ preserves the MPV family by
+    Theorem~\ref{thm:samempv_unitary}.
+    In this basis the relation $(\Id - P) A^i P = 0$ makes each letter upper
+    block triangular.
+    Discarding the off-diagonal blocks does not change the trace of any word
+    product, so the resulting block-diagonal tensor has the same MPV coefficients.
+    Reindex the two diagonal blocks by $\Fin n$ and $\Fin m$.
+\end{proof}
+
+\begin{theorem}[Nontrivial invariant projection gives strict two-block reduction]
+    \label{thm:lowerzero_two_block_strict}
+    \lean{MPSTensor.exists_twoBlock_decomp_of_lowerZero_strict}
+    \leanok
+    \uses{def:same_mpv2}
+    Under the hypotheses of Theorem~\ref{thm:lowerzero_two_block},
+    assume in addition that $P \neq 0$ and $P \neq \Id$.
+    Then there exist $n,m$ with $n + m = D$, $n < D$, and $m < D$, together
+    with block tensors $A_1, A_2$, such that
+    $A$ and $A_1 \oplus A_2$ generate the same MPV family in the sense of
+    Definition~\ref{def:same_mpv2}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:lowerzero_two_block}
+    Apply Theorem~\ref{thm:lowerzero_two_block}.
+    In the diagonal form of $P$, the $1$-eigenspace is nonempty because
+    $P \neq 0$, and the $0$-eigenspace is nonempty because $P \neq \Id$.
+    Hence both block sizes are positive.
+    Since $n + m = D$, this implies $n < D$ and $m < D$.
 \end{proof}
 
 \section{Block separation}
@@ -224,7 +358,7 @@ We use this notation throughout the block-separation argument.
     (Theorem~\ref{thm:left_canonical_gauge}).
 \end{remark}
 
-\begin{remark}\label{rem:overlap_hypothesis}\leanok
+\begin{remark}[Overlap hypothesis]\label{rem:overlap_hypothesis}
     In the literature~\cite{Cirac2021Matrix},
     condition~(5) is derived from primitivity of the
     transfer map (peripheral spectrum $= \{1\}$).
@@ -247,23 +381,67 @@ We use this notation throughout the block-separation argument.
 \begin{theorem}[Vandermonde separation]\label{thm:vandermonde_sep}
     \lean{MPSTensor.vandermonde_separation}
     \leanok
-    If $\mu_1,\ldots,\mu_r$ are pairwise distinct complex numbers
-    and $\sum_{k=1}^r c_k \mu_k^N = 0$ for
-    $N = 0,1,\ldots,r-1$,
+    \uses{def:canonical_form}
+    Let $C$ be a canonical form with block weights $\mu_1,\ldots,\mu_r$,
+    and assume these weights are pairwise distinct.
+    If $c_1,\ldots,c_r \in \C$ satisfy
+    \[
+        \sum_{k=1}^r c_k \mu_k^N = 0
+        \qquad \text{for } N = 0,1,\ldots,r-1,
+    \]
     then $c_k = 0$ for all~$k$.
 \end{theorem}
 
 \begin{proof}\leanok
-    The coefficient vector $c$ satisfies $V c = 0$
-    where $V$ is the Vandermonde matrix of the $\mu_k$.
-    Injectivity of $\mu$ makes $V$ invertible.
+    The coefficient vector $c$ satisfies $V c = 0$, where $V$ is the
+    Vandermonde matrix of the weights $\mu_k$.
+    Pairwise distinctness makes $V$ invertible, so $c = 0$.
+\end{proof}
+
+\begin{lemma}[Repeated-word evaluation]\label{lem:eval_word_flatten_replicate}
+    \lean{MPSTensor.evalWord_flatten_replicate}
+    \leanok
+    \uses{def:eval_word}
+    For any word $w$ and any $L \ge 0$, the evaluation of $A$ on the $L$-fold
+    concatenation $w^L$ is $(A^w)^L$.
+\end{lemma}
+
+\begin{proof}\leanok
+    By induction on $L$, using the multiplicativity of word evaluation under
+    concatenation.
+\end{proof}
+
+\begin{theorem}[Repeated-word trace identity]\label{thm:repeated_word_trace_identity}
+    \lean{MPSTensor.sameMPV₂_repeated_word}
+    \leanok
+    \uses{def:same_mpv2}
+    If the block-diagonal tensors $\bigoplus_k \mu_k A_k$ and
+    $\bigoplus_k \mu_k B_k$ generate the same MPV family,
+    then for every word $w$ and every $L \ge 0$,
+    \[
+        \sum_k \mu_k^{|w|L}
+        \bigl(\tr((A_k^w)^L) - \tr((B_k^w)^L)\bigr) = 0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:eval_word_flatten_replicate}
+    Apply the block-diagonal same-MPV identity to the word $w^L$ obtained by
+    repeating $w$ exactly $L$ times.
+    The block-diagonal coefficient is a weighted sum over the blocks.
+    Lemma~\ref{lem:eval_word_flatten_replicate} rewrites each block evaluation on
+    $w^L$ as a matrix power, giving the displayed trace identity.
 \end{proof}
 
 \begin{remark}
-    Theorem~\ref{thm:vandermonde_sep} is not used in the proofs given here.
-    It is retained for potential alternative arguments; the proof of
-    Theorem~12.5 uses BNT linear independence (Chapter~11) rather than
-    Newton--Girard identities to match the weight multiset.
+    Theorems~\ref{thm:vandermonde_sep}
+    and~\ref{thm:repeated_word_trace_identity}
+    record an alternative Newton/Vandermonde route.
+    The checked proof chain in this chapter instead continues with the
+    mixed-transfer peeling argument of Lemma~\ref{lem:block_sep_core},
+    and the later BNT weight-matching step uses the linear-independence results
+    from Chapter~\ref{ch:bnt} rather than Newton--Girard identities.
 \end{remark}
 
 \begin{lemma}[Block separation core]\label{lem:block_sep_core}
@@ -376,10 +554,10 @@ We use this notation throughout the block-separation argument.
 \end{proof}
 
 \begin{remark}[Relation to the literature]\label{rem:block_perm_literature}
-    The results of this chapter correspond to the canonical-form uniqueness
-    of~\cite{PerezGarcia2007Matrix} and the block-separation statements
-    of~\cite{Cirac2021Matrix}.
-    The proof technique used here---an induction on the number of blocks
-    driven by the spectral gap of the mixed transfer operators---is the
-    method used here.
+    The block-permutation part follows the decomposition of automorphisms of
+    semisimple matrix algebras used in~\cite[§IV.A]{Cirac2021Matrix}.
+    The separation part follows the induction on blocks from
+    \cite[Appendix~E]{PerezGarcia2007Matrix}; the checked proof here uses
+    overlap bounds and mixed-transfer decay rather than the alternative
+    Newton/Vandermonde route recorded above.
 \end{remark}

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -60,15 +60,16 @@ results of~\cite{Cirac2021Matrix}.
 \begin{remark}[Ring level versus algebra level]\label{rem:ring_vs_alg}
     Theorem~\ref{thm:ring_perm} is a ring-level statement: it only uses the
     ideal structure of $\prod_k R_k$.
-    Theorems~\ref{thm:dim_preserved},
-    \ref{thm:component_map_bijective},
+    Theorem~\ref{thm:component_map_bijective} stays at this ring level: once the
+    block ideals are permuted, one can extract the corresponding single-block
+    maps without using scalar multiplication.
+    Theorems~\ref{thm:dim_preserved}
     and~\ref{thm:pi_auto_decomp} require an upgrade to $\C$-algebra
     automorphisms. The reason is threefold: dimension preservation compares
     the blocks as $\C$-vector spaces; Skolem--Noether applies to the resulting
-    central simple $\C$-algebras; and the per-block maps extracted from $T$
-    must commute with scalar multiplication. Thus the argument separates
-    the ring-level permutation step from the later algebra-level
-    decomposition.
+    central simple $\C$-algebras; and the final per-block maps must commute
+    with scalar multiplication. Thus the argument separates the ring-level
+    permutation step from the later algebra-level decomposition.
 \end{remark}
 
 \begin{theorem}[Dimension preservation]\label{thm:dim_preserved}
@@ -93,11 +94,12 @@ results of~\cite{Cirac2021Matrix}.
     \lean{MPSTensor.componentMap_bijective}
     \leanok
     \uses{thm:ring_perm}
+    Assume $D_k \ge 1$ for all~$k$.
     Let $T$ be a ring automorphism of $\prod_{k=1}^r \MN{D_k}$, and let $\pi$
     be the induced permutation from Theorem~\ref{thm:ring_perm}.
     For each block index $k$, the map
     \[
-        M \mapsto T(0,\ldots,0,M,0,\ldots,0)_{\pi(k)}
+        M \mapsto (T(0,\ldots,0,M,0,\ldots,0))_{\pi(k)}
     \]
     from $\MN{D_k}$ to $\MN{D_{\pi(k)}}$ is bijective.
 \end{theorem}


### PR DESCRIPTION
## Summary
- audit `blueprint/src/chapter/ch09_block_perm.tex` against the current block-permutation / Burnside / block-separation modules on `origin/main`
- add missing chapter-local `\lean{}` / `\leanok` coverage for current public declarations
- fix statement / proof-sketch drift in the Chapter 9 text and remove stale metadata

## Coverage
- before: **13** unique `\lean{}` tags in `ch09_block_perm.tex`
- after: **22** unique `\lean{}` tags in `ch09_block_perm.tex`
- net change: **+9** unique Chapter-9 Lean tags

New Chapter-9 `\lean{}` entries added:
- `MPSTensor.blockIdeal`
- `MPSTensor.isAtom_blockIdeal`
- `MPSTensor.componentMap_bijective`
- `MPSTensor.exists_cumulativeSpan_eq_top_of_algSpan_eq_top`
- `MPSTensor.isIrreducibleTensor_of_isIrreducibleAction`
- `MPSTensor.exists_twoBlock_decomp_of_lowerZero`
- `MPSTensor.exists_twoBlock_decomp_of_lowerZero_strict`
- `MPSTensor.evalWord_flatten_replicate`
- `MPSTensor.sameMPV₂_repeated_word`

## Main blueprint fixes
- add local Chapter-9 coverage for the block-ideal / atom / component-map part of the block-permutation proof
- add the missing Burnside-to-cumulative-span and invariant-projection splitting results now used elsewhere in the current tree
- correct the `piAlgEquiv_decomposition` proof sketch so it no longer claims the permutation is automatically `id`
- align the Vandermonde statement with the actual Lean theorem on `CanonicalForm`
- replace the hard-coded `Theorem 12.5` reference by label-based chapter prose
- remove the stray `\leanok` on `rem:overlap_hypothesis`, which had no corresponding `\lean{}` tag

## Verification
- `cd .worktrees/issue-326-ch9-audit && lake build TNLean`
- `cd .worktrees/issue-326-ch9-audit/blueprint && leanblueprint web`
- `cd .worktrees/issue-326-ch9-audit/blueprint && leanblueprint checkdecls`

## Scope
- docs-only sync
- no Lean source changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change, but it updates several theorem statements/proof sketches and Lean tag mappings, so reviewer should sanity-check that the prose still matches the formalized results and cross-references.
> 
> **Overview**
> Updates Chapter 9’s blueprint to match the current Lean formalization: adds explicit block-ideal/atom lemmas and a ring-level `componentMap_bijective` step, and revises the automorphism decomposition proof sketch to allow a nontrivial block permutation.
> 
> Adds a new *Burnside/invariant-projection* section (finite cumulative span, irreducibility via invariant projections, and two-block decomposition/reduction theorems), and aligns the block-separation ancillary results (Vandermonde statement, repeated-word lemmas) plus cleans up remarks/citations and `\lean{}`/`\leanok` coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce81b6da8cef86140c234eed4cb860be64adb6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->