### PR TITLE
fix(workflows): port docs-blueprint-sync source changes (#731)

### DIFF
--- a/.github/workflows/docs-blueprint-sync.lock.yml
+++ b/.github/workflows/docs-blueprint-sync.lock.yml
@@ -22,7 +22,7 @@
 #
 # Daily workflow to detect repository documentation and blueprint files that are out of sync with recent code changes and open a PR with updates.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e596595d337862d95dcb07a297d72b536c68ef6707940d5d459d1fe066f4fbc4","compiler_version":"v0.62.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cc5cc8448adbf388781bc46a7a1b2e3306fa48fa85d5f426b8ec322b59343770","compiler_version":"v0.62.5","strict":true,"agent_id":"copilot"}
 
 name: "Docs & Blueprint Sync"
 "on":
@@ -51,7 +51,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw-actions/setup@v0.62.5
+        uses: github/gh-aw-actions/setup@dc50be57c94373431b49d3d0927f318ac2bb5c4c # v0.62.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
       - name: Generate agentic run info
@@ -129,10 +129,6 @@ jobs:
           cat << 'GH_AW_PROMPT_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          In GitHub Copilot CLI, these safe-output tools may be exposed with a `safeoutputs-` prefix
-          (for example `safeoutputs-create_pull_request`, `safeoutputs-missing_tool`,
-          `safeoutputs-missing_data`, or `safeoutputs-noop`). Use the exact runtime tool name if the
-          unprefixed name is unavailable, and do not emit raw JSON as plain text.
           GH_AW_PROMPT_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat << 'GH_AW_PROMPT_EOF'
@@ -163,6 +159,9 @@ jobs:
           {{#if __GH_AW_GITHUB_RUN_ID__ }}
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
+          - **checkouts**: The following repositories have been checked out and are available in the workspace:
+            - `$GITHUB_WORKSPACE` → `__GH_AW_GITHUB_REPOSITORY__` (cwd) [shallow clone, fetch-depth=50]
+            - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
           GH_AW_PROMPT_EOF
@@ -262,7 +261,7 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw-actions/setup@v0.62.5
+        uses: github/gh-aw-actions/setup@dc50be57c94373431b49d3d0927f318ac2bb5c4c # v0.62.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
       - name: Set runtime paths
@@ -901,7 +900,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw-actions/setup@v0.62.5
+        uses: github/gh-aw-actions/setup@dc50be57c94373431b49d3d0927f318ac2bb5c4c # v0.62.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact
@@ -1029,7 +1028,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw-actions/setup@v0.62.5
+        uses: github/gh-aw-actions/setup@dc50be57c94373431b49d3d0927f318ac2bb5c4c # v0.62.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
       - name: Download agent output artifact

--- a/.github/workflows/docs-blueprint-sync.md
+++ b/.github/workflows/docs-blueprint-sync.md
@@ -19,6 +19,9 @@ network:
     - defaults
     - github
 
+checkout:
+  fetch-depth: 50
+
 tools:
   github:
     toolsets: [default, pull_requests]
@@ -92,6 +95,14 @@ If no updates are needed, call `noop` with a short explanation of what you check
 
 **Important**: If no action is needed after completing your analysis, you **MUST** call the `noop` safe-output tool with a brief explanation. Failing to call any safe-output tool is the most common cause of safe-output workflow failures.
 
-```json
-{"noop": {"message": "No action needed: reviewed recent code changes and documentation/blueprint files are already in sync."}}
-```
+In GitHub Copilot CLI, the runtime safe-output tools may appear with a `safeoutputs-`
+prefix (for example `safeoutputs-create_pull_request`, `safeoutputs-missing_tool`,
+`safeoutputs-missing_data`, or `safeoutputs-noop`). Use the exact runtime tool name if the
+unprefixed name is unavailable.
+
+Do **not** emit raw JSON as plain text for safe-output tools. Invoke the tool directly with the
+required fields instead.
+
+Example no-op invocation:
+- Tool: `noop` or `safeoutputs-noop`
+- `message`: `No action needed: reviewed recent code changes and documentation/blueprint files are already in sync.`


### PR DESCRIPTION
## Summary

Port the durable reference fix for the `Docs & Blueprint Sync` automated workflow from the generated lock file back into `.github/workflows/docs-blueprint-sync.md`.

## What changed

### Source workflow (`.github/workflows/docs-blueprint-sync.md`)
- added top-level `checkout:` frontmatter with `fetch-depth: 50`
- added prompt guidance explaining that Copilot CLI may expose safe-output tools with a `safeoutputs-` prefix
- explicitly forbade emitting raw JSON for safe-output tools
- removed the conflicting raw JSON `noop` example and replaced it with a direct tool-invocation example

### Regenerated lock (`.github/workflows/docs-blueprint-sync.lock.yml`)
- recompiled from the updated source with `gh aw compile docs-blueprint-sync`
- preserved the agent checkout behavior `fetch-depth: 50`
- removed the manual lock-only safe-output prompt hack, because that guidance now lives in the runtime-imported source `.md`
- updated compile metadata/frontmatter hash; recompilation also refreshed the standard pinned `github/gh-aw-actions/setup` references emitted by `gh aw` v0.62.5

## Where `fetch-depth` comes from

The agent-job checkout depth is sourced from gh-aw's top-level `checkout:` frontmatter, not from a shared template file. So no shared workflow/template edit was needed here:

```yaml
checkout:
  fetch-depth: 50
```

## Verification

- `gh aw compile docs-blueprint-sync`
- re-ran `gh aw compile docs-blueprint-sync` to confirm the generated lock file is idempotent
- `git diff --check`
- verified relevant outputs:
  - source `.md` now contains the `safeoutputs-` guidance and no raw JSON `noop` example
  - generated lock still uses `fetch-depth: 50` for the agent checkout
  - generated lock still runtime-imports `.github/workflows/docs-blueprint-sync.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it updates the `Docs & Blueprint Sync` automated workflow behavior (checkout depth) and its safe-output prompting, which can affect how automation runs and whether it successfully produces safe-output actions.
> 
> **Overview**
> Aligns the `Docs & Blueprint Sync` automated workflow source (`docs-blueprint-sync.md`) with the generated lock by adding a top-level `checkout.fetch-depth: 50`, ensuring the agent job consistently has sufficient git history.
> 
> Updates the prompt guidance to handle Copilot CLI’s `safeoutputs-` tool name prefix and to *forbid emitting raw JSON* for safe outputs, replacing the old JSON `noop` example with a direct tool-invocation example. Regenerates `docs-blueprint-sync.lock.yml` from the updated source (metadata hash refresh and pins `github/gh-aw-actions/setup` to a commit SHA).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0327f935e020dab660d9cd6895fc3c193e01e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->