### PR TITLE
fix(blueprint/ch08): rename duplicate labels (#740)

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1152,7 +1152,7 @@ The following results separate the zero blocks from the
 \end{proof}
 
 \begin{definition}[Common-period blocking of a block family]%
-	\label{def:common_period_blocking}
+	\label{def:common_period_blocking_ch8}
 	\lean{MPSTensor.commonPeriodBlocking}
 	\leanok
 	\uses{def:blocked_tensor}
@@ -1162,10 +1162,10 @@ The following results separate the zero blocks from the
 \end{definition}
 
 \begin{theorem}[Primitivity of the common-period blocking]%
-	\label{thm:common_period_blocking_primitive}
+	\label{thm:common_period_blocking_primitive_ch8}
 	\lean{MPSTensor.isPrimitive_transferMap_commonPeriodBlocking}
 	\leanok
-	\uses{def:common_period_blocking, thm:primitive_blocking_divisible}
+	\uses{def:common_period_blocking_ch8, thm:primitive_blocking_divisible}
 	Suppose each $B_k$ has positive bond dimension and each blocked transfer map
 	$\E_{B_k^{[p_k]}}$ is primitive.
 	Then every member of the common-period blocked family also has primitive
@@ -1182,13 +1182,13 @@ The following results separate the zero blocks from the
 	\label{thm:common_period_blocking_apply}
 	\lean{MPSTensor.commonPeriodBlocking_apply}
 	\leanok
-	\uses{def:common_period_blocking}
+	\uses{def:common_period_blocking_ch8}
 	Each block of the common-period blocking is exactly the corresponding tensor
 	blocked at the common least common multiple.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{def:common_period_blocking}
+	\uses{def:common_period_blocking_ch8}
 	This is the definition of the common-period blocking.
 \end{proof}
 
@@ -1986,7 +1986,7 @@ The following results separate the zero blocks from the
 \end{proof}
 
 \begin{theorem}[Conditional block matching after blocking]%
-	\label{thm:weak_ft_conditional}
+	\label{thm:weak_ft_conditional_ch8}
 	\lean{MPSTensor.weakFundamentalTheorem_conditional}
 	\leanok
 	\uses{def:is_normal_canonical_form}


### PR DESCRIPTION
## Summary
- rename the three duplicate Chapter 8 labels introduced by the recent Ch8 audit
- update the local `\uses{...}` citations in `blueprint/src/chapter/ch08_canonical.tex`
- keep the pre-existing Chapter 11 / 11b labels unchanged

## Label map
- `def:common_period_blocking` → `def:common_period_blocking_ch8`
- `thm:common_period_blocking_primitive` → `thm:common_period_blocking_primitive_ch8`
- `thm:weak_ft_conditional` → `thm:weak_ft_conditional_ch8`

## Verification
- `cd .worktrees/issue-740-duplicate-labels/blueprint && leanblueprint web`
- `cd .worktrees/issue-740-duplicate-labels/blueprint && leanblueprint checkdecls`
- `cd .worktrees/issue-740-duplicate-labels && rg -n '\\(label|ref|uses)\{(def:common_period_blocking|thm:common_period_blocking_primitive|thm:weak_ft_conditional)\}' blueprint/src/chapter/ch08_canonical.tex`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that renames LaTeX labels and updates local `\uses{...}` references; main risk is broken cross-references if any external `\ref` still targets the old labels.
> 
> **Overview**
> Renames three Chapter 8 LaTeX labels to avoid duplicates by suffixing them with `_ch8` (e.g., `def:common_period_blocking_ch8`, `thm:common_period_blocking_primitive_ch8`, `thm:weak_ft_conditional_ch8`).
> 
> Updates the corresponding local `\uses{...}` citations to point at the renamed labels while leaving the surrounding statements unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1afa0412dd4dd9c6c00ae3b54d6c06f7fba398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->