### PR TITLE
fix(MPS/ParentHamiltonian): package parentHamiltonian_gapped (#460)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -166,8 +166,6 @@ import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
-import TNLean.MPS.ParentHamiltonian.SuffixWindow
-import TNLean.MPS.ParentHamiltonian.OpenChainRangeReduction
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 import TNLean.MPS.ParentHamiltonian.DegenerateGS
 import TNLean.Axioms.Beigi

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -61,7 +61,8 @@ concrete Friedrichs-angle/row-sum lower bound that
   for a `LinearMap.IsPositive` operator `H` implies the norm bound
   `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
-  parent Hamiltonians on injective tensors (deferred).
+  parent Hamiltonians on injective tensors, obtained from the packaged
+  Friedrichs-angle bound.
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -101,9 +102,9 @@ geometry (Friedrichs angle on overlapping local ground spaces plus
 the row-sum bound) produces the operator inequality `H² ≥ γ H` for the
 PSD operator `H`, the norm lower bound — and hence the spectral gap
 for eigenvectors of `H` — follows by the spectral theorem. This lemma
-packages the final spectral-theorem step; the MPS-specific derivation
-of the quadratic-form hypothesis is the remaining obligation inside
-`MPSTensor.parentHamiltonian_gapped`. -/
+packages the final spectral-theorem step; the remaining MPS-specific
+quadratic-form input is recorded separately in
+`MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`. -/
 theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 < γ)
     {H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι} (hH : H.IsPositive)
     (hOpIneq : ∀ v, γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
@@ -249,11 +250,11 @@ for quantitative overlap constants.
 locality (`localTerm`, `parentHamiltonian`) and finite range: each window
 overlaps at most `2 * (L - 1)` neighbors. Missing is the analytic implication
 from overlap-angle constants to operator-inequality coefficients `cᵢⱼ`.
-3. **Sorry dependency split:** `parentHamiltonian_gapped` is downstream-only and
-dischargeable immediately once the Friedrichs-angle theorem below is proved.
-The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends on
-missing Friedrichs-angle infrastructure; this is the blocker and should not be
-replaced with axioms or unrelated sorrys. -/
+3. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
+existential wrapper, now proved by packaging the Friedrichs-angle theorem
+below. The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends
+on missing Friedrichs-angle infrastructure; this is the blocker and should not
+be replaced with axioms or unrelated sorrys. -/
 /-- Friedrichs-angle and row-sum estimate for the MPS parent Hamiltonian.
 
 This is the remaining MPS-specific martingale estimate: it should produce a
@@ -318,10 +319,9 @@ theorem parentHamiltonian_gapped
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
-  -- PROOF STRUCTURE: see the Friedrichs-angle theorem
-  -- `parentHamiltonianES_gap_bound_of_friedrichs` for the planned proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `parentHamiltonianES_gap_bound_of_friedrichs`.
-  sorry
+  rcases parentHamiltonianES_gap_bound_of_friedrichs A hA L hL with ⟨hγ, hgap⟩
+  refine ⟨(1 : ℝ) / (4 * (L : ℝ)), hγ, ?_⟩
+  intro N hLN v hv
+  exact hgap N hLN v hv
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -38,7 +38,7 @@ Kastoryano–Lucia 2018 (arXiv:1705.09491), Nachtergaele 1996
    gives `γ ‖v‖ ≤ ‖H v‖` for `v ⊥ ker H`.
 
 The last step — the implication from the quadratic-form inequality
-`H² ≥ γ H` to the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` — is packaged
+`H² ≥ γ H` to the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ` — is recorded
 as the abstract lemma `FrustrationFree.spectralGap_of_martingale` below.
 Its hypothesis is the quadratic-form inequality (in inner-product form),
 and its proof is the spectral-theorem argument: diagonalising the
@@ -50,7 +50,7 @@ vanish on `(ker H)ᗮ`) then yields `γ² ‖v‖² ≤ ‖H v‖²`.
 
 The MPS-specific step (producing the finite-overlap estimate for
 `parentHamiltonianES A L N`) is the remaining obligation of
-`MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`, which packages a
+`MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`, which records a
 concrete Friedrichs-angle/row-sum lower bound that
 `MPSTensor.parentHamiltonian_gapped` turns into the existential gap statement.
 
@@ -61,8 +61,9 @@ concrete Friedrichs-angle/row-sum lower bound that
   for a `LinearMap.IsPositive` operator `H` implies the norm bound
   `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
-  parent Hamiltonians on injective tensors, obtained from the packaged
-  Friedrichs-angle bound.
+  parent Hamiltonians on injective tensors, obtained from the
+  Friedrichs-angle bound recorded in
+  `parentHamiltonianES_gap_bound_of_friedrichs`.
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -102,7 +103,7 @@ geometry (Friedrichs angle on overlapping local ground spaces plus
 the row-sum bound) produces the operator inequality `H² ≥ γ H` for the
 PSD operator `H`, the norm lower bound — and hence the spectral gap
 for eigenvectors of `H` — follows by the spectral theorem. This lemma
-packages the final spectral-theorem step; the remaining MPS-specific
+provides the final spectral-theorem step; the remaining MPS-specific
 quadratic-form input is recorded separately in
 `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`. -/
 theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 < γ)
@@ -243,7 +244,7 @@ theorem parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES
 orthogonal-projection infrastructure (for example
 `Mathlib.Analysis.InnerProductSpace.Projection.Basic` and
 `Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional`, exposing
-`Submodule.starProjection` and `orthogonalProjection`) but not a packaged
+`Submodule.starProjection` and `orthogonalProjection`) but not a ready-made
 Kastoryano–Lucia-style angle-to-anticommutator bound. This is a real blocker
 for quantitative overlap constants.
 2. **Row-sum bound mapping:** the combinatorial part is already available from
@@ -251,7 +252,7 @@ locality (`localTerm`, `parentHamiltonian`) and finite range: each window
 overlaps at most `2 * (L - 1)` neighbors. Missing is the analytic implication
 from overlap-angle constants to operator-inequality coefficients `cᵢⱼ`.
 3. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
-existential wrapper, now proved by packaging the Friedrichs-angle theorem
+existential wrapper, now proved by applying the Friedrichs-angle theorem
 below. The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends
 on missing Friedrichs-angle infrastructure; this is the blocker and should not
 be replaced with axioms or unrelated sorrys. -/
@@ -261,7 +262,7 @@ This is the remaining MPS-specific martingale estimate: it should produce a
 specific uniform positive lower bound for the transported parent Hamiltonian
 from the intersection property and finite-overlap geometry. The concrete
 constant is intentionally part of this theorem statement, so the public
-`parentHamiltonian_gapped` theorem only has to package it as an existential
+`parentHamiltonian_gapped` theorem only has to re-express it as an existential
 spectral gap. -/
 theorem parentHamiltonianES_gap_bound_of_friedrichs
     (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (_hL : 1 < L) :
@@ -319,9 +320,7 @@ theorem parentHamiltonian_gapped
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
-  rcases parentHamiltonianES_gap_bound_of_friedrichs A hA L hL with ⟨hγ, hgap⟩
-  refine ⟨(1 : ℝ) / (4 * (L : ℝ)), hγ, ?_⟩
-  intro N hLN v hv
-  exact hgap N hLN v hv
+  obtain ⟨hγ, hgap⟩ := parentHamiltonianES_gap_bound_of_friedrichs A hA L hL
+  exact ⟨(1 : ℝ) / (4 * (L : ℝ)), hγ, hgap⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1635,7 +1635,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}
     \lean{MPSTensor.parentHamiltonian_gapped}
-    \notready
+    \leanok
     \uses{thm:friedrichs_gap_bound}
     For an injective tensor $A$ and a range $L > 1$, there exists $\gamma > 0$ such that
     for every $N \ge 2L$ and every vector
@@ -1648,7 +1648,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     This follows immediately from Theorem~\ref{thm:friedrichs_gap_bound} by taking as
     $\gamma$ the explicit constant produced there, which yields the required existential
     spectral-gap constant.


### PR DESCRIPTION
## Summary
- discharge `MPSTensor.parentHamiltonian_gapped` in `TNLean/MPS/ParentHamiltonian/Martingale.lean` by packaging the existing Friedrichs-angle theorem `parentHamiltonianES_gap_bound_of_friedrichs`
- update the surrounding martingale module docs/comments so they no longer describe `parentHamiltonian_gapped` as deferred
- remove duplicate / conflicting parent-Hamiltonian root imports in `TNLean.lean` (`SuffixWindow` duplicated; `OpenChainRangeReduction` duplicated the newer `ExtendRight` theorem surface and broke the root build)

## Verification
- `lake lean TNLean/MPS/ParentHamiltonian/Martingale.lean`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `lake build TNLean.MPS.ParentHamiltonian.DegenerateGS`
- `lake lean TNLean.lean`
- `lake build`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `rg -n "\\bsorry\\b|\\baxiom\\b" TNLean/MPS/ParentHamiltonian/Martingale.lean TNLean/MPS/ParentHamiltonian/DegenerateGS.lean TNLean.lean`

## Closed sorrys
- `TNLean/MPS/ParentHamiltonian/Martingale.lean`: `parentHamiltonian_gapped`

## Remaining obligations (honest stop)
- `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs` remains the real martingale/Friedrichs-angle analytic blocker.
- `MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition` in `DegenerateGS.lean` remains blocked on the periodic block-decomposition bridge (the same dependency chain discussed around #588 / #195).

Refs #460 #195 #386 #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this mainly removes a `sorry` by wiring `parentHamiltonian_gapped` to an existing gap-bound lemma and adjusts imports/docs; functional behavior is unchanged beyond build/import surface.
> 
> **Overview**
> `MPSTensor.parentHamiltonian_gapped` is no longer `sorry`-backed; it is now proved by directly packaging the explicit gap constant and bound returned by `parentHamiltonianES_gap_bound_of_friedrichs`.
> 
> Documentation around the martingale method is updated to reflect this dependency split, and the blueprint marks `thm:parent_hamiltonian_gapped` as `\leanok`. The root `TNLean.lean` import surface is cleaned up by removing duplicate/conflicting parent-Hamiltonian imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19258e969c9d94fd02da01d4d7020f06ad5d5d7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->