### PR TITLE
doc(blueprint): clean source refs from outline headings

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -502,7 +502,7 @@ legs cyclically and taking the resulting trace.
     vertical canonical-form decomposition.
 \end{proof}
 
-\section{\S4.5 Fusion isometries}
+\section{Fusion isometries}
 
 Following \cite[\S4.5]{Cirac2017MPDO_AnnPhys}, the current Lean development
 formalizes the transfer-map content of the fusion-isometry picture.
@@ -582,7 +582,7 @@ Combine Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} with the diagonal pure-state
 recovery theorem for the provisional MPO predicate.
 \end{proof}
 
-\section{\S4.5 Algebra structure}
+\section{Algebra structure}
 
 \begin{definition}[Algebra-structure data for an MPDO]%
     \label{def:mpdo_algebra_structure_data}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -870,7 +870,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \end{definition}
 
 %% =========================================================
-\section{Choi--Jamio\l{}kowski isomorphism (Wolf Prop.~2.1)}
+\section{Choi--Jamio\l{}kowski isomorphism}
 \label{sec:choi_jamiolkowski}
 %% =========================================================
 
@@ -985,7 +985,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \end{proof}
 
 %% =========================================================
-\section{Kraus representation theorem (Wolf Thm.~2.1)}
+\section{Kraus representation theorem}
 \label{sec:kraus_representation}
 %% =========================================================
 
@@ -1224,7 +1224,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \end{proof}
 
 %% =========================================================
-\section{Stinespring dilation (Wolf Thm.~2.2)}
+\section{Stinespring dilation}
 \label{sec:stinespring}
 %% =========================================================
 
@@ -1359,7 +1359,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \end{proof}
 
 %% =========================================================
-\section{POVMs and Naimark dilation (Wolf Thm.~2.6)}
+\section{POVMs and Naimark dilation}
 \label{sec:povm_naimark}
 %% =========================================================
 
@@ -1673,7 +1673,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 %% The following sections will not be needed for the fundamental theorem of the matrix product states.
 
 %% =========================================================
-\section{Determinant of a quantum channel (Wolf \S6.1.1)}
+\section{Determinant of a quantum channel}
 \label{sec:channel_determinant}
 %% =========================================================
 
@@ -1768,7 +1768,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \end{proof}
 
 %% =========================================================
-\section{Fixed-point algebra (Wolf Thms.~6.12--6.13)}
+\section{Fixed-point algebra}
 \label{sec:fixed_point_algebra}
 %% =========================================================
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -661,7 +661,7 @@ convenience.
     resulting inequalities back into spectral bounds.
 \end{proof}
 
-\subsection{Wolf Example 5.3}
+\subsection{A positive Schwarz map that is not completely positive}
 
 \begin{example}[Wolf Example 5.3 map]\label{def:wolf_example53}
     \lean{wolfExample53}

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -733,7 +733,7 @@ the Perron--Frobenius fixed point.
     Theorem~\ref{thm:overlap_trace_rect}.
 \end{proof}
 
-\section{Conditional expectation from a faithful fixed point (Wolf Thm.~6.15)}
+\section{Conditional expectation from a faithful fixed point}
 
 \begin{definition}[Conditional expectation]\label{def:is_conditional_expectation}
     \lean{Kraus.IsConditionalExpectation}
@@ -873,7 +873,7 @@ the Perron--Frobenius fixed point.
     = \operatorname{tr}(\sigma X)$.
 \end{proof}
 
-\section{Stationary support (Wolf \S6.4)}
+\section{Stationary support}
 
 This section records the support-projection theory
 behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
@@ -977,7 +977,7 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     These statements are deferred in the present chapter.
 \end{remark}
 
-\section{Wedderburn decomposition of the fixed-point algebra (Wolf Thm.~6.14)}
+\section{Wedderburn decomposition of the fixed-point algebra}
 
 \begin{theorem}[Fixed-point algebra is semisimple]%
     \label{thm:fixedPointAlgebra_isSemisimpleRing}
@@ -1083,9 +1083,9 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     $\rho^{-1/2} F_T \rho^{-1/2}$.
 \end{proof}
 
-\section{Additional Wolf Chapter~6 equivalences}
+\section{Further irreducibility, primitivity, and fixed-point criteria}
 
-This section records several equivalences from Wolf's Chapter~6 that are
+This section records several criteria and equivalences from Wolf's Chapter~6 that are
 used later.
 
 \begin{theorem}[Wolf Thm.~6.2(3): exponential positivity condition]%
@@ -1139,7 +1139,7 @@ used later.
     expectation onto the adjoint fixed-point $*$-subalgebra.
 \end{theorem}
 
-\section{Multi-cycle block-permutation data (Wolf Thm.~6.16)}
+\section{Multi-cycle block-permutation data}
 
 \begin{definition}[Block-permutation data]
     \label{def:cycle_structure}
@@ -1228,7 +1228,7 @@ used later.
     resulting map forgets the explicit cycle-indexing.
 \end{definition}
 
-\section{Peripheral eigenvalue group structure (Wolf Thm.~6.6)}
+\section{Peripheral eigenvalue group structure}
 
 \begin{lemma}[Peripheral eigenvectors are invertible]%
     \label{lem:isUnit_peripheral_eigenvector}

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -557,7 +557,7 @@ The results follow~\cite{Sanz2010Quantum}.
     The quantitative bound is not on the fundamental-theorem critical path.
 \end{remark}
 
-\section{Lemma~2(b): fixed-length matrix spanning}\label{sec:lemma2b}
+\section{Fixed-length matrix spanning}\label{sec:lemma2b}
 
 The preceding sections establish the cumulative-spanning part of the
 Lemma~2(a) argument from~\cite{Sanz2010Quantum}:

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -285,7 +285,7 @@ $p$-divisibility of the transfer map.
     that appears only for $m > 1$.
 \end{remark}
 
-\section{Periodic Fundamental Theorem (de las Cuevas--Cirac--Schuch--Pérez-García)}%
+\section{Periodic Fundamental Theorem}%
 \label{sec:periodic_ft}
 
 The theorems in Chapter~\ref{ch:assembly} all require that each block has a
@@ -381,7 +381,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     which remains to be proved.
 \end{theorem}
 
-\subsection{Periodic overlap dichotomy (Proposition 3.3)}
+\subsection{Periodic overlap dichotomy}
 
 \begin{definition}[Cyclic sector decomposition]%
     \label{def:cyclic_sector_decomp}

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -609,7 +609,7 @@ which shows that such generators have the standard Lindblad form.
     yields the standard dissipator terms.
 \end{proof}
 
-\subsection{Prop.~7.2: Characterization of conditional complete positivity}
+\subsection{Characterization of conditional complete positivity}
 
 \begin{theorem}[Prop.~7.2, direction 1$\to$2]
     \label{thm:ccp_implies_choi_projected}
@@ -651,7 +651,7 @@ which shows that such generators have the standard Lindblad form.
     $(\kappa \otimes \Id)\ket{\Omega} = \ket{\psi}$ defines $\kappa$.
 \end{proof}
 
-\subsection{Prop.~7.3: CP semigroups and CCP generators}
+\subsection{CP semigroups and CCP generators}
 
 \begin{theorem}[Prop.~7.3: CP semigroup implies CCP generator]
     \label{thm:cp_semigroup_implies_ccp}
@@ -703,7 +703,7 @@ which shows that such generators have the standard Lindblad form.
     and~\ref{thm:ccp_implies_cp_semigroup}.
 \end{proof}
 
-\subsection{Prop.~7.4: Freedom in generator representation}
+\subsection{Freedom in generator representation}
 
 \begin{theorem}[Traceless Kraus operators exist]
     \label{thm:exists_traceless_kraus_shift}
@@ -731,7 +731,7 @@ which shows that such generators have the standard Lindblad form.
     Direct algebraic expansion.
 \end{proof}
 
-\subsection{Prop.~7.4 item 2: Uniqueness of the traceless Lindblad form}
+\subsection{Uniqueness of the traceless Lindblad form}
 
 \begin{definition}[Traceless Kraus operators]\label{def:has_traceless_kraus}
     \lean{LindbladForm.HasTracelessKraus}\leanok
@@ -827,7 +827,7 @@ which shows that such generators have the standard Lindblad form.
     from the right.
 \end{proof}
 
-\subsection{Thm.~7.1: The GKSL/Lindblad theorem}
+\subsection{GKSL/Lindblad theorem}
 
 \begin{definition}[GKSL generator]\label{def:is_gksl_generator}
     \lean{IsGKSLGenerator}\leanok
@@ -1751,7 +1751,7 @@ The four equivalent reducibility conditions of
 
 %% Wolf Cor. 7.2 — sufficient conditions for non-reducibility
 
-\subsection{Cor.~7.2: Sufficient conditions for non-reducibility}
+\subsection{Sufficient conditions for non-reducibility}
 \label{sec:cor_7_2_sufficient_conditions}
 
 \begin{definition}[Lindblad span]\label{def:lindblad_span}


### PR DESCRIPTION
### Motivation

- Blueprint outline headings should read as mathematical titles first rather than chapter-source citations, section numbers, or theorem labels.
- Bibliographic references and source numbering still belong in local prose, theorem titles, and statements, but they clutter the chapter outline and TOC when placed in section headings.

### Description

- Remove source-labeled section headings from `blueprint/src/chapter/ch04_channels.tex`.
- Clean the same outline-heading pattern in related blueprint chapters:
  - `ch02b_mpdo.tex`
  - `ch05_schwarz.tex`
  - `ch06_spectral.tex`
  - `ch07_wielandt.tex`
  - `ch11b_periodic_ft.tex`
  - `ch12_semigroup.tex`
- Keep citations and source references in nearby prose/theorem titles where they are actually used.
- Leave descriptive non-source parentheticals unchanged when they describe mathematical content rather than bibliography or source numbering.

### Testing

- `PATH="$HOME/.local/pipx/venvs/leanblueprint/bin:$PATH" ~/.local/bin/leanblueprint web`

---
Closes LionSR/QICLean#147

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure LaTeX documentation edits to section/subsection titles with no impact on Lean code, logic, or data handling.
> 
> **Overview**
> Removes source-citation/theorem-number prefixes from multiple LaTeX outline headings so the TOC and chapter structure read as *math-first* titles.
> 
> This is a documentation-only change across the blueprint chapters (e.g. `ch02b_mpdo`, `ch04_channels`, `ch05_schwarz`, `ch06_spectral`, `ch07_wielandt`, `ch11b_periodic_ft`, `ch12_semigroup`), keeping the underlying citations in nearby prose/theorem statements while simplifying `\section`/`\subsection` names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac8ead6de28b3cc6d49a137f6e9d5ae82bc31f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->