### PR TITLE
doc(blueprint): complete issue 732 style audit fixes

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -288,7 +288,7 @@ legs cyclically and taking the resulting trace.
     \lean{MPOTensor.isRFP_iff_isZCL}
     \leanok
     \uses{def:is_rfp_mpdo, def:mpo_is_zcl}
-    The provisional MPDO renormalization fixed-point condition is equivalent to
+    The MPDO renormalization fixed-point condition is equivalent to
     the zero-correlation-length condition for MPO tensors.
 \end{theorem}
 
@@ -303,7 +303,7 @@ legs cyclically and taking the resulting trace.
     \leanok
     \uses{def:is_rfp_mpdo, def:mpo_to_mps, def:is_rfp, def:mpo_is_zcl,
         thm:mpo_is_zcl_iff_to_mps_rfp}
-    The provisional MPDO RFP condition is equivalent to the pure-state RFP
+    The MPDO renormalization fixed-point condition is equivalent to the pure-state RFP
     condition for the doubled-index MPS tensor.
 \end{theorem}
 
@@ -621,13 +621,12 @@ retract.
     map $E_n$.
 \end{definition}
 
-\begin{theorem}[Fusion-isometry data imply the provisional MPDO RFP condition]%
+\begin{theorem}[Fusion-isometry data imply MPDO RFP]%
     \label{thm:mpdo_rfp_of_fusion}
     \lean{MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
-    The fusion-isometry formulation implies the current predicate
-    \lean{MPOTensor.IsRFP}.
+    The fusion-isometry formulation implies \lean{MPOTensor.IsRFP}.
 \end{theorem}
 \begin{proof}\leanok
 Apply the definition at blocked size $n = 1$.
@@ -662,10 +661,10 @@ This range-factorization gives the required fusion-isometry data.
 \end{corollary}
 \begin{proof}\leanok
 Combine Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} with the diagonal pure-state
-recovery theorem for the provisional MPO predicate.
+recovery theorem for the MPDO renormalization fixed-point condition.
 \end{proof}
 
-\section{Algebra structure}
+\section{Support-algebra structure}
 
 \begin{definition}[Algebra-structure data for an MPDO]%
     \label{def:mpdo_algebra_structure_data}
@@ -681,18 +680,16 @@ recovery theorem for the provisional MPO predicate.
     $\iota_n$.
 \end{definition}
 
-\begin{definition}[Algebra-structure RFP predicate (provisional)]%
+\begin{definition}[Algebra-structure formulation of MPDO RFP]%
     \label{def:mpdo_rfp_via_algebra}
     \lean{MPOTensor.IsRFP_MPDO_via_algebra_scaffold}
     \uses{def:mpdo_algebra_structure_data, def:mpo_tensor}
     An MPO tensor $M$ satisfies the \emph{algebra-structure formulation} of
     the renormalization fixed-point condition when there exist
     algebra-structure data compatible with $M$, in the sense of
-    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}. The compatibility
-    relation between algebra-structure data and~$M$ is, in this provisional
-    formulation, the trivial relation that holds for every pair;
-    consequently the predicate above holds vacuously of every MPO tensor.
-    The exact compatibility condition of
-    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys} is to be substituted
-    in place of the trivial relation in subsequent work.
+    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}. Here compatibility is
+    taken to be the trivial relation that holds for every pair, so this
+    formulation is satisfied by every MPO tensor. The intended compatibility
+    condition is the one appearing in
+    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}.
 \end{definition}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -156,7 +156,8 @@ legs cyclically and taking the resulting trace.
     By Lemma~\ref{lem:mpo_transfer_eq_mps}, the transfer map of $M$ agrees with
     the transfer map of its doubled-index MPS view. Thus
     $\E_M \circ \E_M = \E_M$ holds exactly when the transfer map of
-    $M.\mathrm{toMPSTensor}$ is idempotent, which is the RFP condition.
+    the doubled-index MPS view is idempotent, which is precisely the
+    renormalization fixed-point condition.
 \end{proof}
 
 \section{MPDOs and LPDOs}
@@ -556,7 +557,7 @@ strong subadditivity for a normalized three-site reduced state.
     This is Lemma~L from \cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
     Expanding the hypothesis over a word of length~$L+1$ beginning with the
     fixed site and folding each block contribution into a trace pairing
-    against $\mathrm{insertedTensor}\,W\,A_k$ yields, upon taking the
+    against the corresponding first-site insertion tensor yields, upon taking the
     $Y$\!-$Z$ difference, a tuple of block matrices whose trace pairings
     against every length-$L$ block word vanish. The biCF hypothesis then
     forces each block difference to be zero, and dividing by the nonzero

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -255,8 +255,8 @@ legs cyclically and taking the resulting trace.
     \uses{def:is_prfp, def:mpo_is_zcl}
     The current purification-RFP condition is strictly weaker than MPO zero
     correlation length: there exists an MPO tensor with purification RFP whose
-    transfer map is not idempotent. Equivalently, the implication from the Lean
-    predicate \texttt{IsPRFP} to the predicate \texttt{IsZCL} fails.
+    transfer map is not idempotent. Equivalently, purification RFP does not
+    imply MPO zero correlation length.
 \end{remark}
 
 \begin{theorem}[Purification RFP implies LPDO]\label{thm:prfp_is_lpdo}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -493,7 +493,7 @@ strong subadditivity for a normalized three-site reduced state.
     from \cite[\S4.4]{Cirac2017MPDO_AnnPhys}.
 \end{definition}
 
-\begin{remark}[Finite-length span and selector criteria for the abstract biCF hypothesis]%
+\begin{remark}[Finite-length span and selector criteria for the horizontal canonical-form hypothesis]%
     \label{rem:word_tuple_span_top}
     \lean{MPSTensor.WordTupleSpanTop}
     \lean{MPSTensor.HasBiCF}
@@ -507,34 +507,32 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     Let $(A_k)$ be a family of block tensors, and fix a length $L$.
     Write $A_k^w$ for the length-$L$ word evaluation of $A_k$ along a word $w$.
-    The predicate \texttt{WordTupleSpanTop} says that the tuple-valued evaluations
+    Consider the tuple-valued evaluations
     \[
         w \longmapsto (A_k^w)_k
     \]
-    span the full product algebra of block matrices.
-    The predicate \texttt{HasBiCF} records the corresponding finite-length
-    separation property: there exists $L$ such that if
+    in the direct product of the block matrix algebras.
+    The finite-length spanning hypothesis says that these tuples span the
+    whole product algebra.
+    Equivalently, if matrices $\Delta_k$ satisfy
     \[
         \sum_k \tr(\Delta_k A_k^w) = 0
         \qquad \text{for every word } w \text{ of length } L,
     \]
-    then every block coefficient $\Delta_k$ vanishes.
-    The theorem \texttt{hasBiCF\_of\_wordTupleSpanTop} proves that the
-    spanning condition implies this separation property, by nondegeneracy of the
-    product trace pairing. The packaging theorem
-    \texttt{horizontalCFData\_of\_wordTupleSpanTop} then inserts the resulting
-    biCF witness into \texttt{HorizontalCFData} once injectivity,
-    left-canonicality, and nonzero weights are given.
+    then every $\Delta_k$ vanishes. This is the nondegeneracy statement for
+    the product trace pairing, so a single finite blocking length already
+    separates the blocks by their word evaluations.
 
-    The predicate \texttt{PropBlockInjective} isolates the finite-length content
-    of Proposition~IV.3: after some common blocking length, each block is
-    block-injective, and after a second finite blocking length one can form word
-    combinations which equal the identity on one chosen block and vanish on all
-    others. Concatenating an injective prefix with such a selector suffix yields
-    the product-algebra span condition above. This is formalized by
-    \texttt{wordTupleSpanTop\_of\_propBlockInjective}, and the resulting biCF
-    witness is packaged into horizontal canonical-form data by
-    \texttt{horizontalCFData\_of\_propBlockInjective}.
+    Proposition~IV.3 gives a concrete sufficient criterion for this
+    finite-length separation. After one common blocking length, each block is
+    block-injective; after a further finite blocking length, one can choose
+    linear combinations of words which act as the identity on one selected
+    block and vanish on all the others. Combining an injective prefix with
+    such a selector suffix yields the spanning condition above.
+
+    Once this finite-length separation is available, together with
+    injectivity, left-canonicality, and nonzero weights, one obtains the
+    horizontal canonical-form structure for the MPO.
 \end{remark}
 
 \begin{lemma}[Blockwise equality from agreement on the MPV family]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -587,8 +587,8 @@ strong subadditivity for a normalized three-site reduced state.
 
 \section{Fusion isometries}
 
-Following \cite[\S4.5]{Cirac2017MPDO_AnnPhys}, the current Lean development
-formalizes the transfer-map content of the fusion-isometry picture.
+Following \cite[\S4.5]{Cirac2017MPDO_AnnPhys}, this section records the
+transfer-map content of the fusion-isometry picture.
 For each blocked size $n \ge 1$, the doubled-index blocked tensor of an MPO
 has a blocked transfer map $E_n$ acting on bond-space matrices, and the
 support algebra is modeled by a subspace through which $E_n$ factors as a

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -905,7 +905,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     Apply the identity map in the definition of the Choi matrix.
 \end{proof}
 
-\begin{theorem}[Prop.~2.1: CP iff Choi matrix is PSD]\label{thm:cp_iff_choi_posSemidef}
+\begin{theorem}[Complete positivity iff the Choi matrix is positive semidefinite]\label{thm:cp_iff_choi_posSemidef}
     \lean{ChoiJamiolkowski.cp_iff_choi_posSemidef}
     \leanok
     \uses{def:choi_matrix, def:cp_map}
@@ -928,7 +928,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     matrix units.
 \end{proof}
 
-\begin{theorem}[Prop.~2.1: TP implies partial trace condition]\label{thm:traceLeft_choiMatrix_of_tp}
+\begin{theorem}[Trace preservation implies the partial-trace condition]\label{thm:traceLeft_choiMatrix_of_tp}
     \lean{ChoiJamiolkowski.traceLeft_choiMatrix_of_tp}
     \leanok
     \uses{def:choi_matrix, def:partial_trace, def:trace_preserving}
@@ -948,7 +948,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     Taking the trace gives $\frac{1}{D}\delta_{ij}$.
 \end{proof}
 
-\begin{theorem}[Prop.~2.1: Hermiticity correspondence]\label{thm:choiMatrix_isHermitian_iff_hermiticityPreserving}
+\begin{theorem}[Hermiticity preservation and the Choi matrix]\label{thm:choiMatrix_isHermitian_iff_hermiticityPreserving}
     \lean{ChoiJamiolkowski.choiMatrix_isHermitian_iff_hermiticityPreserving}
     \leanok
     \uses{def:choi_matrix}
@@ -968,7 +968,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     By linearity this extends to all $B$.
 \end{proof}
 
-\begin{theorem}[Prop.~2.1: Trace of Choi matrix for TP map]\label{thm:trace_choiMatrix_of_tp}
+\begin{theorem}[Trace of the Choi matrix of a trace-preserving map]\label{thm:trace_choiMatrix_of_tp}
     \lean{ChoiJamiolkowski.trace_choiMatrix_of_tp}
     \leanok
     \uses{def:choi_matrix, def:trace_preserving, thm:traceLeft_choiMatrix_of_tp}
@@ -989,7 +989,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \label{sec:kraus_representation}
 %% =========================================================
 
-\begin{theorem}[Thm.~2.1: TP implies Kraus normalization]\label{thm:kraus_sum_conjTranspose_mul_of_tp}
+\begin{theorem}[Trace preservation implies Kraus normalization]\label{thm:kraus_sum_conjTranspose_mul_of_tp}
     \lean{kraus_sum_conjTranspose_mul_of_tp}
     \leanok
     \uses{def:cp_map, def:trace_preserving}
@@ -1010,7 +1010,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     $\sum_i K_i^\dagger K_i = \Id$.
 \end{proof}
 
-\begin{theorem}[Thm.~2.1: Kraus normalization implies TP]\label{thm:kraus_tp_of_sum_conjTranspose_mul}
+\begin{theorem}[Kraus normalization implies trace preservation]\label{thm:kraus_tp_of_sum_conjTranspose_mul}
     \lean{kraus_tp_of_sum_conjTranspose_mul}
     \leanok
     \uses{def:cp_map, def:trace_preserving}
@@ -1027,7 +1027,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
        = \operatorname{tr}(X)$.
 \end{proof}
 
-\begin{theorem}[Thm.~2.1: Unitality implies Kraus unital normalization]
+\begin{theorem}[Unitality implies Kraus unital normalization]
     \label{thm:kraus_sum_mul_conjTranspose_of_unital}
     \lean{kraus_sum_mul_conjTranspose_of_unital}
     \leanok
@@ -1042,7 +1042,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     Evaluate the Kraus formula at the identity matrix.
 \end{proof}
 
-\begin{theorem}[Thm.~2.1: Unitary freedom in Kraus operators]\label{thm:kraus_same_map_of_unitary_combination}
+\begin{theorem}[Unitary freedom in Kraus operators]\label{thm:kraus_same_map_of_unitary_combination}
     \lean{kraus_same_map_of_unitary_combination}
     \leanok
     \uses{def:cp_map}
@@ -1082,7 +1082,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     $W^\dagger W = \Id$ to collapse the coefficient matrix.
 \end{proof}
 
-\begin{theorem}[Thm.~2.1: Orthonormal Kraus transition is unitary]\label{thm:kraus_transition_unitary_of_hs_orthonormal}
+\begin{theorem}[The transition matrix of orthonormal Kraus families is unitary]\label{thm:kraus_transition_unitary_of_hs_orthonormal}
     \lean{kraus_transition_unitary_of_hs_orthonormal}
     \leanok
     \uses{def:cp_map}
@@ -1103,7 +1103,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     $U U^\dagger = \Id_r$, hence also $U^\dagger U = \Id_r$.
 \end{proof}
 
-\begin{theorem}[Thm.~2.1: Dual map equality from primal map equality]\label{thm:kraus_dual_eq_of_map_eq}
+\begin{theorem}[Dual map equality from primal map equality]\label{thm:kraus_dual_eq_of_map_eq}
     \lean{kraus_dual_eq_of_map_eq}
     \leanok
     \uses{def:cp_map}
@@ -1124,7 +1124,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     Nondegeneracy of the trace pairing gives the result.
 \end{proof}
 
-\begin{theorem}[Thm.~2.1: Equal Stinespring Gramians]\label{thm:kraus_conjTranspose_mul_eq_of_map_eq}
+\begin{theorem}[Equal Stinespring Gramians]\label{thm:kraus_conjTranspose_mul_eq_of_map_eq}
     \lean{kraus_conjTranspose_mul_eq_of_map_eq}
     \leanok
     \uses{thm:kraus_dual_eq_of_map_eq}
@@ -1137,7 +1137,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     Specialise Theorem~\ref{thm:kraus_dual_eq_of_map_eq} at $Y = \Id$.
 \end{proof}
 
-\begin{theorem}[Thm.~2.1 item 4: Rectangular Kraus freedom (necessary direction)]\label{thm:kraus_rectangular_freedom}
+\begin{theorem}[Rectangular Kraus freedom]\label{thm:kraus_rectangular_freedom}
     \lean{kraus_rectangular_freedom}
     \leanok
     \uses{thm:kraus_dual_eq_of_map_eq, thm:kraus_conjTranspose_mul_eq_of_map_eq}
@@ -1157,7 +1157,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     range, and extend to a full isometry $V$ with $V^\dagger V = \Id_{r_2}$.
 \end{proof}
 
-\begin{theorem}[Thm.~2.1 item 4: Rectangular Kraus freedom (general index variant)]\label{thm:kraus_rectangular_freedom'}
+\begin{theorem}[Rectangular Kraus freedom with general finite index types]\label{thm:kraus_rectangular_freedom'}
     \lean{kraus_rectangular_freedom'}
     \leanok
     \uses{thm:kraus_rectangular_freedom}
@@ -1172,7 +1172,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     Theorem~\ref{thm:kraus_rectangular_freedom}.
 \end{proof}
 
-\begin{theorem}[Wolf Thm.~2.18: Isometric freedom of Kraus representations]
+\begin{theorem}[Isometric freedom of Kraus representations]
     \label{thm:kraus_isometry_freedom_iff}
     \lean{kraus_isometry_freedom_iff}
     \leanok
@@ -1199,7 +1199,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     diagonal.
 \end{proof}
 
-\begin{theorem}[Wolf Thm.~2.18: Unitary freedom of Kraus representations]
+\begin{theorem}[Unitary freedom of Kraus representations]
     \label{thm:kraus_unitary_freedom_iff}
     \lean{kraus_unitary_freedom_iff}
     \leanok
@@ -1287,7 +1287,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     \]
 \end{theorem}
 
-\begin{theorem}[Thm.~2.2: Stinespring dual representation]\label{thm:stinespring_dual_representation}
+\begin{theorem}[Stinespring dual representation]\label{thm:stinespring_dual_representation}
     \lean{stinespring_dual_representation}
     \leanok
     \uses{def:stinespring_v, def:cp_map, thm:stinespring_v_conjTranspose_mul}
@@ -1310,7 +1310,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     $\sum_j K_j^\dagger A K_j$.
 \end{proof}
 
-\begin{theorem}[Thm.~2.2: Isometry condition iff TP]\label{thm:stinespringV_isometry_iff_kraus_normalized}
+\begin{theorem}[The Stinespring isometry condition iff trace preservation]\label{thm:stinespringV_isometry_iff_kraus_normalized}
     \lean{stinespringV_isometry_iff_kraus_normalized}
     \leanok
     \uses{def:stinespring_v, def:trace_preserving}
@@ -1329,7 +1329,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
        = (\sum_j K_j^\dagger K_j)_{ab}$.
 \end{proof}
 
-\begin{theorem}[Thm.~2.2: Stinespring Schr\"odinger representation]\label{thm:stinespring_schrodinger_representation}
+\begin{theorem}[Stinespring Schr\"odinger representation]\label{thm:stinespring_schrodinger_representation}
     \lean{stinespring_schrodinger_representation}
     \leanok
     \uses{def:stinespring_v, def:cp_map, def:partial_trace}
@@ -1479,7 +1479,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     delta-function form of $(P_i)_{(a,b),(c,d)}$.
 \end{proof}
 
-\begin{theorem}[Thm.~2.6: Naimark dilation]\label{thm:naimark_recovers_povm}
+\begin{theorem}[Naimark dilation]\label{thm:naimark_recovers_povm}
     \lean{POVM.naimark_recovers_povm}
     \leanok
     \uses{def:povm, def:naimark_isometry, def:naimark_projection,
@@ -1743,7 +1743,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     $\overline{\det U}^{\,D}(\det U)^D = 1$.
 \end{proof}
 
-\begin{theorem}[Thm.~6.1(1): Determinant bound for positive TP maps]
+\begin{theorem}[Determinant bound for positive trace-preserving maps]
     \label{thm:channelDet_norm_le_one}
     \lean{channelDet_norm_le_one_of_positive_tracePreserving,
           channelDet_norm_le_one_of_channel}\leanok
@@ -1761,7 +1761,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     $|\det T| = \prod_i |\mu_i| \le 1$ follows by induction.
 \end{proof}
 
-\begin{theorem}[Thm.~6.1(2): Determinant one iff unitary channel]
+\begin{theorem}[Determinant one iff the channel is unitary]
     \label{thm:channelDet_norm_eq_one_iff_unitary}
     \lean{channelDet_norm_eq_one_iff_exists_unitaryChannel,
           channelDet_norm_eq_one_iff_exists_unitaryChannel_of_channel}\leanok
@@ -1823,7 +1823,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     multiplicative domain.
 \end{proof}
 
-\begin{theorem}[Thm.~6.12: Fixed points form a $*$-subalgebra]
+\begin{theorem}[Fixed points form a $*$-subalgebra]
     \label{thm:fixedPointsStarSubalgebra}
     \lean{Kraus.fixedPointsStarSubalgebra}\leanok
     \uses{def:kraus_fixed_points, def:kraus_map_channels}
@@ -1964,7 +1964,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     where $E^*(X) = \sum_i K_i^\dagger X K_i$.
 \end{definition}
 
-\begin{theorem}[Thm.~6.12 in the Heisenberg picture]
+\begin{theorem}[Fixed points form a $*$-subalgebra in the Heisenberg picture]
     \label{thm:adjointFixedPointsStarSubalgebra}
     \lean{Kraus.adjointFixedPointsStarSubalgebra, Kraus.fixedPoints_starSubalgebra}\leanok
     \uses{def:adjoint_fixed_points, def:kraus_map_channels}
@@ -1988,7 +1988,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     It is a $*$-subalgebra of $\MN{D}$.
 \end{definition}
 
-\begin{theorem}[Thm.~6.13: Adjoint fixed points = Kraus commutant]
+\begin{theorem}[Adjoint fixed points equal the Kraus commutant]
     \label{thm:adjointFixedPoints_eq_krausCommutant}
     \lean{Kraus.adjointFixedPointsStarSubalgebra_eq_krausCommutantStarSubalgebra}\leanok
     \uses{def:adjoint_fixed_points, def:kraus_commutant, def:kraus_map_channels}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -826,7 +826,9 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     \lean{Matrix.traceLeft, Matrix.traceRight}
     \leanok
     Let $X \in \MN{d \cdot d'}$ be a bipartite matrix indexed by
-    $(\mathrm{Fin}\,d \times \mathrm{Fin}\,d')^2$.
+    \[
+        (\{0,\ldots,d-1\} \times \{0,\ldots,d'-1\})^2.
+    \]
     The \emph{left partial trace} $\operatorname{tr}_A(X)$ and
     \emph{right partial trace} $\operatorname{tr}_B(X)$ are the
     $d' \times d'$ and $d \times d$ matrices defined by
@@ -1162,13 +1164,13 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     \leanok
     \uses{thm:kraus_rectangular_freedom}
     Variant of Theorem~\ref{thm:kraus_rectangular_freedom} with general
-    finite index types $\iota_1, \iota_2$ in place of $\mathrm{Fin}\,r_1,
-    \mathrm{Fin}\,r_2$.
+    finite index sets $\iota_1, \iota_2$ in place of standard index sets of
+    cardinalities $r_1$ and $r_2$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Reindex via equivalences to $\mathrm{Fin}$ and apply
+    Reindex by choosing enumerations of those finite index sets and apply
     Theorem~\ref{thm:kraus_rectangular_freedom}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1430,7 +1430,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     \leanok
     \uses{def:naimark_kraus, def:stinespring_v}
     The \emph{Naimark isometry} $V : \C^D \to \C^D \otimes \C^n$ of a POVM
-    is the Stinespring-style assembly
+    is the Stinespring-type construction
     \[
         V = \sum_{i=1}^n M_i \otimes |i\rangle,
         \qquad V_{(a,i),\,k} = (M_i)_{a,k}.

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1515,7 +1515,7 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     and $P_i = \Id_D \otimes |i\rangle\langle i|$.
 \end{proof}
 
-\begin{definition}[Packaged Naimark dilation]
+\begin{definition}[Naimark dilation as a structure]
     \label{def:is_naimark_dilation}
     \lean{POVM.IsNaimarkDilation}
     \leanok
@@ -1526,13 +1526,13 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     $\{P_i\}$ there such that $E_i = V^\dagger P_i V$ for all $i$.
 \end{definition}
 
-\begin{theorem}[Canonical dilation as a packaged Naimark dilation]
+\begin{theorem}[Canonical dilation satisfies the Naimark dilation axioms]
     \label{thm:is_naimark_dilation_naimark}
     \lean{POVM.isNaimarkDilation_naimark}
     \leanok
     \uses{def:is_naimark_dilation, thm:naimark_recovers_povm}
     The explicit isometry $V = \sum_i M_i \otimes |i\rangle$ and projectors
-    $P_i = \Id_D \otimes |i\rangle\langle i|$ satisfy the packaged axioms
+    $P_i = \Id_D \otimes |i\rangle\langle i|$ satisfy the defining axioms
     of a Naimark dilation.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -175,8 +175,8 @@ finite-dimensional quantum systems.
     holds if and only if $\rho_{ABC}$ admits a quantum Markov decomposition on
     the middle subsystem $B$.
 
-    \textbf{Status:} Taken here as an external input.
-    This is the equality criterion needed
+    This equality criterion is cited here as an input for the later MPDO arguments.
+    It is the equality criterion needed
     by Appendix~C of arXiv:1606.00608. We cite Hayashi,
     \emph{J. Phys. A} 37 (2004) L205--L208, and Ruskai,
     \emph{J. Math. Phys.} 43 (2002) 4358; the structural block-decomposition
@@ -214,24 +214,24 @@ finite-dimensional quantum systems.
     which gives $I(A{:}C) \ge 0$.
 \end{proof}
 
-\section{Entropy restatements}
+\section{Entropy formulations}
 
-This section records the entropy restatements used later in the
+This section records the entropy formulations used later in the
 development: von Neumann entropy, strong subadditivity, quantum Markov
-decomposition, and mutual information. The external inputs are accepted
-as given, while their full proofs are tracked separately in the entropy
-formalization project.
+decomposition, and mutual information. These statements are cited from the
+standard entropy literature and supply the entropy-theoretic input for the
+later MPDO arguments.
 
-\begin{definition}[Restated von Neumann entropy]\label{def:entropy_von_neumann_entropy}
+\begin{definition}[Entropy formulation of von Neumann entropy]\label{def:entropy_von_neumann_entropy}
     \lean{Entropy.vonNeumannEntropy}
     \leanok
     \uses{def:von_neumann_entropy}
-    This restated declaration has the same value
+    This formulation has the same value
     \(S(\rho) = -\sum_i \lambda_i \log \lambda_i\) as in
     Definition~\ref{def:von_neumann_entropy}.
 \end{definition}
 
-\begin{theorem}[Restated strong subadditivity]\label{thm:entropy_strong_subadditivity}
+\begin{theorem}[Entropy formulation of strong subadditivity]\label{thm:entropy_strong_subadditivity}
     \lean{Entropy.strongSubadditivity}
     \leanok
     \uses{def:entropy_von_neumann_entropy, def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
@@ -240,19 +240,19 @@ formalization project.
     \[
         S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC}).
     \]
-    This restatement introduces no new axiom: it records the same
+    This formulation introduces no new axiom: it records the same
     strong-subadditivity input already used above. The underlying
     axiom's
     proof (Lieb--Ruskai 1973) is deferred to the umbrella entropy
     issue.
 \end{theorem}
 
-\begin{definition}[Restated quantum Markov decomposition]
+\begin{definition}[Entropy formulation of quantum Markov decomposition]
     \label{def:entropy_quantum_markov_decomposition}
     \lean{Entropy.QuantumMarkovDecomposition}
     \leanok
     \uses{def:hayashi_markov_decomposition}
-    This is the entropy restatement of the Hayashi Markov
+    This is the entropy formulation of the Hayashi Markov
     decomposition from Definition~\ref{def:hayashi_markov_decomposition}.
 \end{definition}
 
@@ -266,16 +266,16 @@ formalization project.
     subadditivity holds if and only if $\rho_{ABC}$ admits a quantum
     Markov decomposition on the middle subsystem $B$.
 
-    This restatement introduces no new axiom: it records the same
+    This formulation introduces no new axiom: it records the same
     equality criterion as
     Theorem~\ref{thm:hayashi_ssa_equality_characterization}.
 \end{theorem}
 
-\begin{definition}[Restated mutual information]\label{def:entropy_mutual_information}
+\begin{definition}[Entropy formulation of mutual information]\label{def:entropy_mutual_information}
     \lean{Entropy.mutualInformation}
     \leanok
     \uses{def:entropy_von_neumann_entropy}
-    This restated declaration has the same value
+    This formulation has the same value
     \(I(A{:}B) = S(\rho_A) + S(\rho_B) - S(\rho_{AB})\)
     as in Definition~\ref{def:mutual_information}.
 \end{definition}

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -175,8 +175,8 @@ finite-dimensional quantum systems.
     holds if and only if $\rho_{ABC}$ admits a quantum Markov decomposition on
     the middle subsystem $B$.
 
-    \textbf{Status:} Recorded in Lean as a sanctioned external-input axiom in
-    \texttt{TNLean/Axioms/Entropy.lean}. This is the equality criterion needed
+    \textbf{Status:} Recorded in Lean as a sanctioned external-input axiom.
+    This is the equality criterion needed
     by Appendix~C of arXiv:1606.00608. We cite Hayashi,
     \emph{J. Phys. A} 37 (2004) L205--L208, and Ruskai,
     \emph{J. Math. Phys.} 43 (2002) 4358; the structural block-decomposition
@@ -214,27 +214,24 @@ finite-dimensional quantum systems.
     which gives $I(A{:}C) \ge 0$.
 \end{proof}
 
-\section{\texorpdfstring{\texttt{TNLean.Entropy}}{TNLean.Entropy} namespace}
+\section{Entropy-namespace restatements}
 
-The modules in \texttt{TNLean.Entropy} (issue~\#613) place the von
-Neumann entropy and mutual information in the \texttt{Entropy}
-namespace, restate the sanctioned strong-subadditivity axiom there,
-and introduce the name \texttt{QuantumMarkovDecomposition} for the
-Hayashi SSA-equality decomposition. The external inputs are accepted
-as given; their full proofs are tracked separately in the entropy
-umbrella issues.
+This section records the restated entropy declarations used later in the
+development: von Neumann entropy, strong subadditivity, quantum Markov
+decomposition, and mutual information. The external inputs are accepted
+as given, while their full proofs are tracked separately in the entropy
+formalization project.
 
-\begin{definition}[Von Neumann entropy, namespaced]\label{def:entropy_von_neumann_entropy}
+\begin{definition}[Von Neumann entropy in the entropy namespace]\label{def:entropy_von_neumann_entropy}
     \lean{Entropy.vonNeumannEntropy}
     \leanok
     \uses{def:von_neumann_entropy}
-    The namespaced wrapper
-    \(\texttt{Entropy.vonNeumannEntropy}(\rho, h_\rho)\)
-    unfolds to \(S(\rho) = -\sum_i \lambda_i \log \lambda_i\) as in
+    This restated declaration has the same value
+    \(S(\rho) = -\sum_i \lambda_i \log \lambda_i\) as in
     Definition~\ref{def:von_neumann_entropy}.
 \end{definition}
 
-\begin{theorem}[Strong subadditivity, namespaced wrapper]\label{thm:entropy_strong_subadditivity}
+\begin{theorem}[Strong subadditivity in the entropy namespace]\label{thm:entropy_strong_subadditivity}
     \lean{Entropy.strongSubadditivity}
     \leanok
     \uses{def:entropy_von_neumann_entropy, def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
@@ -243,24 +240,20 @@ umbrella issues.
     \[
         S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC}).
     \]
-    In the Lean development, \texttt{Entropy.strongSubadditivity} is a
-    \emph{theorem} wrapper around the single sanctioned SSA axiom
-    \texttt{strong\_subadditivity} of
-    \texttt{TNLean/Axioms/Entropy.lean}; no new axiom is introduced by
-    the \texttt{TNLean.Entropy.*} declarations. The underlying axiom's
+    This restatement introduces no new axiom: it records the same
+    sanctioned strong-subadditivity input already used above. The underlying
+    axiom's
     proof (Lieb--Ruskai 1973) is deferred to the umbrella entropy
     issue.
 \end{theorem}
 
-\begin{definition}[Quantum Markov decomposition, namespaced]
+\begin{definition}[Quantum Markov decomposition in the entropy namespace]
     \label{def:entropy_quantum_markov_decomposition}
     \lean{Entropy.QuantumMarkovDecomposition}
     \leanok
     \uses{def:hayashi_markov_decomposition}
-    The namespaced alias
-    \texttt{Entropy.QuantumMarkovDecomposition} is the name used in the
-    \texttt{Entropy} namespace for the decomposition record of
-    Definition~\ref{def:hayashi_markov_decomposition}.
+    This is the entropy-namespace version of the Hayashi Markov
+    decomposition from Definition~\ref{def:hayashi_markov_decomposition}.
 \end{definition}
 
 \begin{theorem}[SSA equality iff quantum Markov decomposition]
@@ -273,20 +266,16 @@ umbrella issues.
     subadditivity holds if and only if $\rho_{ABC}$ admits a quantum
     Markov decomposition on the middle subsystem $B$.
 
-    In the Lean development, this is a \emph{theorem} wrapper around the
-    sanctioned axiom
-    \texttt{hayashi\_ssa\_equality\_characterization} of
-    \texttt{TNLean/Axioms/Entropy.lean}; no new axiom is introduced by
-    \texttt{TNLean/Entropy/MarkovChain.lean}.
+    This restatement introduces no new axiom: it records the same
+    sanctioned equality criterion as
+    Theorem~\ref{thm:hayashi_ssa_equality_characterization}.
 \end{theorem}
 
-\begin{definition}[Mutual information, namespaced]\label{def:entropy_mutual_information}
+\begin{definition}[Mutual information in the entropy namespace]\label{def:entropy_mutual_information}
     \lean{Entropy.mutualInformation}
     \leanok
     \uses{def:entropy_von_neumann_entropy}
-    The namespaced wrapper
-    \(\texttt{Entropy.mutualInformation}(\rho_{AB}, h_{\rho_{AB}})\)
-    unfolds to
+    This restated declaration has the same value
     \(I(A{:}B) = S(\rho_A) + S(\rho_B) - S(\rho_{AB})\)
     as in Definition~\ref{def:mutual_information}.
 \end{definition}

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -175,7 +175,7 @@ finite-dimensional quantum systems.
     holds if and only if $\rho_{ABC}$ admits a quantum Markov decomposition on
     the middle subsystem $B$.
 
-    \textbf{Status:} Recorded in Lean as a sanctioned external-input axiom.
+    \textbf{Status:} Taken here as an external input.
     This is the equality criterion needed
     by Appendix~C of arXiv:1606.00608. We cite Hayashi,
     \emph{J. Phys. A} 37 (2004) L205--L208, and Ruskai,
@@ -214,15 +214,15 @@ finite-dimensional quantum systems.
     which gives $I(A{:}C) \ge 0$.
 \end{proof}
 
-\section{Entropy-namespace restatements}
+\section{Entropy restatements}
 
-This section records the restated entropy declarations used later in the
+This section records the entropy restatements used later in the
 development: von Neumann entropy, strong subadditivity, quantum Markov
 decomposition, and mutual information. The external inputs are accepted
 as given, while their full proofs are tracked separately in the entropy
 formalization project.
 
-\begin{definition}[Von Neumann entropy in the entropy namespace]\label{def:entropy_von_neumann_entropy}
+\begin{definition}[Restated von Neumann entropy]\label{def:entropy_von_neumann_entropy}
     \lean{Entropy.vonNeumannEntropy}
     \leanok
     \uses{def:von_neumann_entropy}
@@ -231,7 +231,7 @@ formalization project.
     Definition~\ref{def:von_neumann_entropy}.
 \end{definition}
 
-\begin{theorem}[Strong subadditivity in the entropy namespace]\label{thm:entropy_strong_subadditivity}
+\begin{theorem}[Restated strong subadditivity]\label{thm:entropy_strong_subadditivity}
     \lean{Entropy.strongSubadditivity}
     \leanok
     \uses{def:entropy_von_neumann_entropy, def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
@@ -241,18 +241,18 @@ formalization project.
         S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC}).
     \]
     This restatement introduces no new axiom: it records the same
-    sanctioned strong-subadditivity input already used above. The underlying
+    strong-subadditivity input already used above. The underlying
     axiom's
     proof (Lieb--Ruskai 1973) is deferred to the umbrella entropy
     issue.
 \end{theorem}
 
-\begin{definition}[Quantum Markov decomposition in the entropy namespace]
+\begin{definition}[Restated quantum Markov decomposition]
     \label{def:entropy_quantum_markov_decomposition}
     \lean{Entropy.QuantumMarkovDecomposition}
     \leanok
     \uses{def:hayashi_markov_decomposition}
-    This is the entropy-namespace version of the Hayashi Markov
+    This is the entropy restatement of the Hayashi Markov
     decomposition from Definition~\ref{def:hayashi_markov_decomposition}.
 \end{definition}
 
@@ -267,11 +267,11 @@ formalization project.
     Markov decomposition on the middle subsystem $B$.
 
     This restatement introduces no new axiom: it records the same
-    sanctioned equality criterion as
+    equality criterion as
     Theorem~\ref{thm:hayashi_ssa_equality_characterization}.
 \end{theorem}
 
-\begin{definition}[Mutual information in the entropy namespace]\label{def:entropy_mutual_information}
+\begin{definition}[Restated mutual information]\label{def:entropy_mutual_information}
     \lean{Entropy.mutualInformation}
     \leanok
     \uses{def:entropy_von_neumann_entropy}

--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -663,7 +663,7 @@ follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
 
 \section{Spectral characterization of irreducibility}
 
-\begin{definition}[Wolf spectral properties]
+\begin{definition}[Spectral properties]
 	\label{def:has_spectral_properties}
 	\lean{HasSpectralProperties}
 	\leanok
@@ -715,7 +715,7 @@ follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
 	Definition~\ref{def:has_spectral_properties}.
 \end{proof}
 
-\begin{theorem}[Irreducibility iff Wolf's spectral properties]
+\begin{theorem}[Irreducibility iff the spectral properties hold]
 	\label{thm:irred_iff_spectral_properties}
 	\lean{isIrreducibleMap_iff_spectral_properties}
 	\leanok

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -728,9 +728,9 @@ This section collects the operator convexity/concavity results, trace
 inequalities, the operator Jensen inequality for positive maps, and the
 Lieb concavity theorem. These are standard results in matrix analysis
 (Bhatia~Ch.~V, Wolf~Thm.~5.1, Hansen--Pedersen~2003, Lieb~1973). They are
-currently taken as assumptions pending upstream formalization of operator
-concavity and convexity for real powers $x\mapsto x^p$ on the Loewner
-order, together with operator concavity of the matrix logarithm.
+used here as cited inputs, since the corresponding matrix-analysis proofs
+for real powers $x\mapsto x^p$ on the Loewner order and for the matrix
+logarithm are not developed in this chapter.
 
 \subsection{Diagonal Jensen inequality}
 
@@ -828,13 +828,13 @@ order, together with operator concavity of the matrix logarithm.
     This is \cite[Thm.~5.1]{Wolf2012Quantum} for concave~$f(x)=x^p$.
 \end{theorem}
 
-\begin{theorem}[Jensen for concave real powers --- restatement]\label{thm:rpow_concave_jensen}
+\begin{theorem}[Map form of Jensen for concave real powers]\label{thm:rpow_concave_jensen}
     \lean{IsPositiveMap.rpow_concave_jensen}
     \notready
     \uses{thm:posMap_rpow_concave_jensen}
-    Restates Theorem~\ref{thm:posMap_rpow_concave_jensen} for downstream
-    use as a property of a positive map.
-    Axiom-dependent: not fully formalized until
+    This is the corresponding map-form statement of
+    Theorem~\ref{thm:posMap_rpow_concave_jensen}.
+    Its proof is deferred until
     Theorem~\ref{thm:posMap_rpow_concave_jensen} is proved.
 \end{theorem}
 
@@ -853,13 +853,13 @@ order, together with operator concavity of the matrix logarithm.
     This is \cite[Thm.~5.1]{Wolf2012Quantum} for convex~$f(x)=x^p$.
 \end{theorem}
 
-\begin{theorem}[Jensen for convex real powers --- restatement]\label{thm:rpow_convex_jensen}
+\begin{theorem}[Map form of Jensen for convex real powers]\label{thm:rpow_convex_jensen}
     \lean{IsPositiveMap.rpow_convex_jensen}
     \notready
     \uses{thm:posMap_rpow_convex_jensen}
-    Restates Theorem~\ref{thm:posMap_rpow_convex_jensen} for downstream
-    use as a property of a positive map.
-    Axiom-dependent: not fully formalized until
+    This is the corresponding map-form statement of
+    Theorem~\ref{thm:posMap_rpow_convex_jensen}.
+    Its proof is deferred until
     Theorem~\ref{thm:posMap_rpow_convex_jensen} is proved.
 \end{theorem}
 
@@ -879,13 +879,13 @@ order, together with operator concavity of the matrix logarithm.
     Requires unitality ($T(\Id)=\Id$), not merely subunitality.
 \end{theorem}
 
-\begin{theorem}[Jensen for concave log --- restatement]\label{thm:log_concave_jensen}
+\begin{theorem}[Map form of Jensen for the concave logarithm]\label{thm:log_concave_jensen}
     \lean{IsPositiveMap.log_concave_jensen}
     \notready
     \uses{thm:posMap_log_concave_jensen}
-    Restates Theorem~\ref{thm:posMap_log_concave_jensen} for downstream
-    use as a property of a positive map.
-    Axiom-dependent: not fully formalized until
+    This is the corresponding map-form statement of
+    Theorem~\ref{thm:posMap_log_concave_jensen}.
+    Its proof is deferred until
     Theorem~\ref{thm:posMap_log_concave_jensen} is proved.
 \end{theorem}
 
@@ -911,12 +911,13 @@ order, together with operator concavity of the matrix logarithm.
     See Lieb (1973) and Ando (1979).
 \end{theorem}
 
-\begin{theorem}[Lieb concavity --- restatement]\label{thm:lieb_concavity}
+\begin{theorem}[Map form of Lieb concavity]\label{thm:lieb_concavity}
     \lean{lieb_concavity}
     \notready
     \uses{thm:lieb_concavity_axiom}
-    Restates Theorem~\ref{thm:lieb_concavity_axiom} for downstream use.
-    Axiom-dependent: not fully formalized until
+    This is the corresponding map-form statement of
+    Theorem~\ref{thm:lieb_concavity_axiom}.
+    Its proof is deferred until
     Theorem~\ref{thm:lieb_concavity_axiom} is proved.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -474,7 +474,7 @@ convenience.
     The second formulation is just the corresponding Loewner-order reformulation.
 \end{proof}
 
-\begin{theorem}[Prop.~5.1: Schwarz inequality for normal operators]\label{thm:schwarz_normal_operator}
+\begin{theorem}[Schwarz inequality for normal operators]\label{thm:schwarz_normal_operator}
     \lean{KadisonSchwarz.schwarz_inequality_normal_operator}
     \leanok
     \uses{def:positive_map}
@@ -514,7 +514,7 @@ convenience.
 
 \subsection{Schwarz inequality for subnormal and commuting-dominant operators}
 
-\begin{theorem}[Thm.~5.5: Schwarz inequality for subnormal operators]\label{thm:schwarz_subnormal}
+\begin{theorem}[Schwarz inequality for subnormal operators]\label{thm:schwarz_subnormal}
     \lean{KadisonSchwarz.schwarz_inequality_subnormal_operator}
     \leanok
     \uses{def:positive_map}
@@ -539,7 +539,7 @@ convenience.
     $N$, then compress the resulting inequality back to $\C^D$.
 \end{proof}
 
-\begin{theorem}[Thm.~5.6: Schwarz inequality for commuting-dominant operators]\label{thm:schwarz_commuting_dominant}
+\begin{theorem}[Schwarz inequality for commuting-dominant operators]\label{thm:schwarz_commuting_dominant}
     \lean{KadisonSchwarz.schwarz_inequality_commuting_dominant_operator}
     \leanok
     \uses{def:positive_map}
@@ -663,7 +663,7 @@ convenience.
 
 \subsection{A positive Schwarz map that is not completely positive}
 
-\begin{example}[Wolf Example 5.3 map]\label{def:wolf_example53}
+\begin{example}[Example map]\label{def:wolf_example53}
     \lean{wolfExample53}
     \leanok
     Consider the linear map $T : M_2(\C) \to M_2(\C)$ defined by
@@ -673,7 +673,7 @@ convenience.
     This is the map from \cite[Ex.~5.3]{Wolf2012Quantum}.
 \end{example}
 
-\begin{theorem}[Wolf Example 5.3 is positive]\label{thm:wolf_example53_positive}
+\begin{theorem}[The example map is positive]\label{thm:wolf_example53_positive}
     \lean{wolfExample53_isPositive}
     \leanok
     \uses{def:wolf_example53, def:positive_map}
@@ -687,7 +687,7 @@ convenience.
     semidefinite matrices to positive semidefinite matrices.
 \end{proof}
 
-\begin{theorem}[Wolf Example 5.3 satisfies the Schwarz inequality]\label{thm:wolf_example53_schwarz}
+\begin{theorem}[The example map satisfies the Schwarz inequality]\label{thm:wolf_example53_schwarz}
     \lean{wolfExample53_satisfies_schwarz}
     \leanok
     \uses{def:wolf_example53}
@@ -707,7 +707,7 @@ convenience.
     $F(A)$ dominates $\frac12 (A^\dagger A)^T$, hence is positive semidefinite.
 \end{proof}
 
-\begin{theorem}[Wolf Example 5.3 is not completely positive]\label{thm:wolf_example53_not_cp}
+\begin{theorem}[The example map is not completely positive]\label{thm:wolf_example53_not_cp}
     \lean{wolfExample53_not_cp}
     \leanok
     \uses{def:wolf_example53, def:cp_map}

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -663,7 +663,7 @@ convenience.
 
 \subsection{A positive Schwarz map that is not completely positive}
 
-\begin{example}[Example map]\label{def:wolf_example53}
+\begin{example}[Transpose-trace map on $M_2(\C)$]\label{def:wolf_example53}
     \lean{wolfExample53}
     \leanok
     Consider the linear map $T : M_2(\C) \to M_2(\C)$ defined by
@@ -673,7 +673,7 @@ convenience.
     This is the map from \cite[Ex.~5.3]{Wolf2012Quantum}.
 \end{example}
 
-\begin{theorem}[The example map is positive]\label{thm:wolf_example53_positive}
+\begin{theorem}[The transpose-trace map is positive]\label{thm:wolf_example53_positive}
     \lean{wolfExample53_isPositive}
     \leanok
     \uses{def:wolf_example53, def:positive_map}
@@ -687,7 +687,7 @@ convenience.
     semidefinite matrices to positive semidefinite matrices.
 \end{proof}
 
-\begin{theorem}[The example map satisfies the Schwarz inequality]\label{thm:wolf_example53_schwarz}
+\begin{theorem}[The transpose-trace map satisfies the Schwarz inequality]\label{thm:wolf_example53_schwarz}
     \lean{wolfExample53_satisfies_schwarz}
     \leanok
     \uses{def:wolf_example53}
@@ -707,7 +707,7 @@ convenience.
     $F(A)$ dominates $\frac12 (A^\dagger A)^T$, hence is positive semidefinite.
 \end{proof}
 
-\begin{theorem}[The example map is not completely positive]\label{thm:wolf_example53_not_cp}
+\begin{theorem}[The transpose-trace map is not completely positive]\label{thm:wolf_example53_not_cp}
     \lean{wolfExample53_not_cp}
     \leanok
     \uses{def:wolf_example53, def:cp_map}

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -831,7 +831,7 @@ the Perron--Frobenius fixed point.
     $*$-subalgebra.
 \end{theorem}
 
-\begin{theorem}[Wolf Cor.~6.6 --- complete positivity of $E_\sigma$]
+\begin{theorem}[Complete positivity of the scalar conditional expectation]
     \label{thm:scalar_conditional_expectation_isCPMap}
     \lean{Kraus.scalarConditionalExpectation_isCPMap}
     \leanok
@@ -855,7 +855,7 @@ the Perron--Frobenius fixed point.
     $(\operatorname{tr}\sigma)^{-1}$, and therefore completely positive.
 \end{proof}
 
-\begin{theorem}[Wolf Cor.~6.6 --- $\sigma$-trace preservation of $E_\sigma$]
+\begin{theorem}[$\sigma$-trace preservation of the scalar conditional expectation]
     \label{thm:scalar_conditional_expectation_preserves_weighted_trace}
     \lean{Kraus.scalarConditionalExpectation_preserves_weighted_trace}
     \leanok
@@ -900,7 +900,7 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     each Kraus term to the $P$-corner.
 \end{proof}
 
-\begin{theorem}[Support projection invariance (Wolf Lemma~6.4)]%
+\begin{theorem}[Support projection invariance]%
     \label{thm:support_proj_fixed}
     \lean{Channel.support_proj_fixed}
     \leanok
@@ -945,7 +945,7 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     (Definition~\ref{def:stationaryState}).
 \end{definition}
 
-\begin{theorem}[Prop.~6.9: stationary support is full]%
+\begin{theorem}[Stationary support is full]%
     \label{thm:stationarySupport_eq_one}
     \lean{Channel.stationarySupport_eq_one}
     \leanok
@@ -964,7 +964,7 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     Since $\rho_\infty \neq 0$, we have $P \neq 0$, so $P = \Id$.
 \end{proof}
 
-\begin{remark}[Props.~6.10--6.11: non-trivial formulations]%
+\begin{remark}[Remaining stationary-support formulations]%
     \label{rem:stationary_support_todo}
     The non-trivial formulations needed here are:
     \begin{itemize}
@@ -1000,7 +1000,7 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     hence $x^*x = 0$, and the C$^*$-identity gives $x = 0$.
 \end{proof}
 
-\begin{theorem}[Abstract Wedderburn--Artin decomposition (Wolf Thm.~6.14)]%
+\begin{theorem}[Abstract Wedderburn--Artin decomposition]%
     \label{thm:fixedPointAlgebra_wedderburnArtin}
     \lean{Kraus.fixedPointAlgebra_wedderburnArtin}
     \leanok
@@ -1044,7 +1044,7 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     multiplicities $m_k$ and the bound $\sum_k d_k m_k \le D$.
 \end{proof}
 
-\begin{remark}[Pending part of Wolf Thm.~6.14]
+\begin{remark}[Remaining Wedderburn statement]
     The stronger ambient statement that the adjoint-fixed-point algebra is
     unitarily conjugate to
     \[
@@ -1054,7 +1054,7 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     yet formalized.
 \end{remark}
 
-\begin{theorem}[Wolf Cor.~6.7]%
+\begin{theorem}[Weighted fixed points form a $*$-subalgebra]%
     \label{thm:weightedFixedPointsStarSubalgebra}
     \lean{Kraus.weightedFixedPointsStarSubalgebra}
     \leanok
@@ -1083,12 +1083,12 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     $\rho^{-1/2} F_T \rho^{-1/2}$.
 \end{proof}
 
-\section{Further irreducibility, primitivity, and fixed-point criteria}
+\section{Additional Chapter~6 equivalences}
 
 This section records several criteria and equivalences from Wolf's Chapter~6 that are
 used later.
 
-\begin{theorem}[Wolf Thm.~6.2(3): exponential positivity condition]%
+\begin{theorem}[Exponential positivity condition]%
     \label{thm:wolf_6_2_item_3}
     \lean{exp_posDef_of_irreducible_cp}
     \lean{irreducible_iff_exp_posDef_forall}
@@ -1100,7 +1100,7 @@ used later.
     then $E$ is irreducible (full equivalence \lean{irreducible_iff_exp_posDef_forall}).
 \end{theorem}
 
-\begin{theorem}[Wolf Thm.~6.8: Kraus-span equivalence]%
+\begin{theorem}[Kraus-span equivalence]%
     \label{thm:wolf_6_8_kraus_span}
     \lean{MPSTensor.wolf_theorem_6_8_kraus_span}
     \leanok
@@ -1109,7 +1109,7 @@ used later.
     full Kraus rank.
 \end{theorem}
 
-\begin{theorem}[Wolf Thm.~6.8: combined equivalence]%
+\begin{theorem}[Combined primitivity equivalence]%
     \label{thm:wolf_6_8_conjunction}
     \lean{MPSTensor.wolf_theorem_6_8_conjunction}
     \leanok
@@ -1118,7 +1118,7 @@ used later.
     of eventual full Kraus rank, normality, and strong irreducibility.
 \end{theorem}
 
-\begin{remark}[Wolf Thm.~6.8: pairwise equivalences]
+\begin{remark}[Pairwise primitivity equivalences]
     \label{rem:wolf_6_8_pairwise}
     \lean{MPSTensor.primitivePaper_iff_hasEventuallyFullKrausRank}
     \lean{MPSTensor.primitivePaper_iff_stronglyIrreducible}
@@ -1129,7 +1129,7 @@ used later.
     Theorem~6.8.
 \end{remark}
 
-\begin{theorem}[Wolf Thm.~6.15 (scalar fixed-point algebra case)]
+\begin{theorem}[Scalar fixed-point algebra case]
     \label{thm:wolf_6_15_scalar_conditional_expectation}
     \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
     \leanok

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1051,7 +1051,7 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
         0 \oplus \bigoplus_k M_{d_k}(\C) \otimes \Id_{m_k}
     \]
     together with the density-block form $M_{d_k}(\C) \otimes \rho_k$ is not
-    yet formalized.
+    yet included here.
 \end{remark}
 
 \begin{theorem}[Weighted fixed points form a $*$-subalgebra]%
@@ -1083,7 +1083,7 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     $\rho^{-1/2} F_T \rho^{-1/2}$.
 \end{proof}
 
-\section{Additional Chapter~6 equivalences}
+\section{Further irreducibility and primitivity equivalences}
 
 This section records several criteria and equivalences from Wolf's Chapter~6 that are
 used later.

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -674,7 +674,7 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     so $S_n(A^{[L]}) \subseteq S_{nL}(A)$.
 \end{proof}
 
-\begin{remark}[Relation with Lemma~2(b)]\label{rem:lemma2b_status}\leanok
+\begin{remark}[Relation with the rank-one extraction lemma]\label{rem:lemma2b_status}\leanok
     In~\cite{Sanz2010Quantum}, Lemma~2(b) combines a rank-one
     extraction for fixed-length spans with a product
     argument turning fixed-length vector spanning into fixed-length

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1619,7 +1619,7 @@ The following results separate the zero blocks from the
 	of orthogonal sector projections with $\sum_k P_k = \Id$, and set
 	$T = \E_A^\dagger$. Assume two upstream inputs, both discharged from the
 	block-diagonal canonical-form analysis of
-	\cite[Lemma~\texttt{lem:bdcf}]{DeLasCuevas2017Irreducible}:
+	\cite{DeLasCuevas2017Irreducible}:
 	\begin{enumerate}
 		\item \emph{(Projection step.)} For each sector index $k$ and each
 			orthogonal projection $X$ supported on $P_k$, the image $T(X)$

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -748,14 +748,14 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     the Lean development.
 \end{remark}
 
-\begin{theorem}[Bundled projective representation from symmetry]%
+\begin{theorem}[Projective representation and cocycle from symmetry]%
     \label{thm:projectiveRep_of_symmetry}
     \lean{MPSTensor.projectiveRep_of_symmetry}
     \leanok
     \uses{thm:cor_4_1_projective_rep, thm:cor_4_1_projective_rep_cocycle}
     Theorems~\ref{thm:cor_4_1_projective_rep}
-    and~\ref{thm:cor_4_1_projective_rep_cocycle} are packaged into a
-    single high-level statement: from the periodic projective-rigidity
+    and~\ref{thm:cor_4_1_projective_rep_cocycle} combine into a
+    single statement: from the periodic projective-rigidity
     hypothesis (Definition~\ref{def:periodic_projective_rigidity}), one
     obtains a projective representation of $G$ on the bond space whose
     factor system is a genuine $2$-cocycle whenever $D > 0$.

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -608,7 +608,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 
 \section{Physical symmetries on periodic MPS}\label{sec:periodic_symmetry}
 
-\begin{theorem}[Cor.~4.1 — Physical symmetry yields a virtual $Z$-gauge]%
+\begin{theorem}[Physical symmetry yields a virtual $Z$-gauge]%
     \label{cor:cor_4_1_physical_symmetry_zgauge}
     \lean{MPSTensor.cor_4_1_physical_symmetry_zgauge}
     \leanok
@@ -619,7 +619,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     physical leg, acting unitarily ($U(g)\, U(g)^{\dagger} = \Id$).
     Assume moreover the periodic equal-case Fundamental Theorem of MPS
     (Theorem~\ref{thm:periodic_ft}) as an explicit hypothesis on the
-    pair $(d, D)$ — formalised in Lean as the proposition
+    pair $(d, D)$, represented by the proposition
     \lean{MPSTensor.PeriodicEqualCaseFT}\,$d\,D$.
     If $A$ is on-site symmetric under~$U$ — that is, the twisted tensor
     $\widetilde{A}_g$ has the same MPV family as~$A$ for every $g \in G$
@@ -673,7 +673,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     $u$ is an independent analytic input.
 \end{definition}
 
-\begin{theorem}[Cor.~4.1 projective-representation upgrade]%
+\begin{theorem}[Projective-representation upgrade]%
     \label{thm:cor_4_1_projective_rep}
     \lean{MPSTensor.cor_4_1_projective_rep}
     \leanok
@@ -743,9 +743,8 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     The cohomology class of $\omega$ in $H^{2}(G, U(1))$ classifies the
     SPT phase of the symmetric MPS (cf.~Chen--Gu--Wen and
     P\'erez-Garc\'ia et al.).  This classification statement is not
-    formalised at present; only the underlying 2-cocycle identity of
-    Theorem~\ref{thm:cor_4_1_projective_rep_cocycle} is available in
-    the Lean development.
+    formalised at present; here only the underlying 2-cocycle identity of
+    Theorem~\ref{thm:cor_4_1_projective_rep_cocycle} is available.
 \end{remark}
 
 \begin{theorem}[Projective representation and cocycle from symmetry]%
@@ -830,7 +829,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     irreducible-form decomposition of $C$.
 \end{proof}
 
-\begin{theorem}[Thm.~4.1 — $p$-refinability $\iff$ $p$-divisibility]%
+\begin{theorem}[$p$-refinability iff $p$-divisibility]%
     \label{thm:thm_4_1_p_refinement}
     \lean{MPSTensor.thm_4_1_p_refinement}
     \leanok
@@ -854,7 +853,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     yields the full equivalence.
 \end{proof}
 
-\begin{theorem}[Thm.~4.1 forward direction, conditional form]%
+\begin{theorem}[$p$-refinability implies $p$-divisibility under the canonicalization hypothesis]%
     \label{thm:thm_4_1_p_refinement_forward}
     \lean{MPSTensor.thm_4_1_p_refinement_forward}
     \leanok
@@ -875,7 +874,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     $\mathcal{E}_B$ with the $p$-th power of the channel $\mathcal{E}_A$.
 \end{proof}
 
-\begin{theorem}[Thm.~4.1 reverse direction, conditional form]%
+\begin{theorem}[$p$-divisibility implies $p$-refinability under the inverse canonicalization hypothesis]%
     \label{thm:thm_4_1_p_refinement_reverse}
     \lean{MPSTensor.thm_4_1_p_refinement_reverse}
     \leanok

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -150,7 +150,7 @@ $p$-divisibility of the transfer map.
     hypothesis via word concatenation.
 \end{proof}
 
-\begin{theorem}[Physical rotation distributes over block assembly]%
+\begin{theorem}[Physical rotation distributes over block-diagonal composition]%
     \label{thm:rotate_physical_blocks}
     \lean{MPSTensor.rotatePhysical_toTensorFromBlocks}
     \leanok
@@ -186,7 +186,7 @@ $p$-divisibility of the transfer map.
     Each block remains periodic by
     Theorem~\ref{thm:periodic_rotate_physical}, the SameMPV condition
     transfers via Theorem~\ref{thm:same_mpv_rotate_physical}, and
-    block-assembly compatibility follows from
+    block-diagonal compatibility follows from
     Theorem~\ref{thm:rotate_physical_blocks}.
 \end{proof}
 
@@ -378,7 +378,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     \noindent\emph{Remark.}
     The proof is conditional on the periodic-overlap dichotomy
     (Proposition~3.3 of~\cite{DeLasCuevas2017Irreducible}),
-    which remains to be proved.
+    which is left here as a separate hypothesis.
 \end{theorem}
 
 \subsection{Periodic overlap dichotomy}
@@ -619,7 +619,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     physical leg, acting unitarily ($U(g)\, U(g)^{\dagger} = \Id$).
     Assume moreover the periodic equal-case Fundamental Theorem of MPS
     (Theorem~\ref{thm:periodic_ft}) as an explicit hypothesis on the
-    pair $(d, D)$, represented by the proposition
+    pair $(d, D)$, expressed by the hypothesis
     \lean{MPSTensor.PeriodicEqualCaseFT}\,$d\,D$.
     If $A$ is on-site symmetric under~$U$ — that is, the twisted tensor
     $\widetilde{A}_g$ has the same MPV family as~$A$ for every $g \in G$
@@ -743,7 +743,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     The cohomology class of $\omega$ in $H^{2}(G, U(1))$ classifies the
     SPT phase of the symmetric MPS (cf.~Chen--Gu--Wen and
     P\'erez-Garc\'ia et al.).  This classification statement is not
-    formalised at present; here only the underlying 2-cocycle identity of
+    established here; only the underlying 2-cocycle identity of
     Theorem~\ref{thm:cor_4_1_projective_rep_cocycle} is available.
 \end{remark}
 
@@ -845,10 +845,10 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
 
 \begin{proof}\leanok
     \uses{thm:thm_4_1_p_refinement_forward, thm:thm_4_1_p_refinement_reverse}
-    Bundle the forward implication
+    Combine the forward implication
     (Theorem~\ref{thm:thm_4_1_p_refinement_forward}) with the reverse
     implication (Theorem~\ref{thm:thm_4_1_p_refinement_reverse}) into a
-    single biconditional.  Both directions are formalised conditionally
+    single biconditional.  Both directions are stated conditionally
     on their respective canonicalization hypotheses, whose combination
     yields the full equivalence.
 \end{proof}
@@ -869,7 +869,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     $\sum_i (A^i)^\dagger A^i = \Id$ (left-canonical) and
     $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$. The left-canonical property
     makes $\mathcal{E}_A$ a CPTP channel, and the blocking identity
-    $\mathcal{E}_{A^{[p]}} = (\mathcal{E}_A)^p$ (formalised as
+    $\mathcal{E}_{A^{[p]}} = (\mathcal{E}_A)^p$ given by
     \lean{MPSTensor.transferMap_blockTensor}) then identifies
     $\mathcal{E}_B$ with the $p$-th power of the channel $\mathcal{E}_A$.
 \end{proof}
@@ -893,9 +893,8 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     finite Kraus families of the same completely positive map: the
     blocked family $A^{[p]}$ with $d^{p}$ operators and the original
     family $B$ with $d$ operators.  The cardinality comparison
-    $d \le d^{p}$ holds whenever $p \ge 1$, so Wolf
-    Theorem~2.18 (isometric freedom of Kraus representations,
-    formalised as \lean{kraus_isometry_freedom_iff}) supplies an
+    $d \le d^{p}$ holds whenever $p \ge 1$, so the isometric freedom of
+    Kraus representations (\lean{kraus_isometry_freedom_iff}) supplies an
     isometry $V \in M_{d^p \times d}(\C)$ with $V^{\dagger} V = \Id$ and
     $(A^{[p]})^{\alpha} = \sum_{j} V_{\alpha,j}\, B^{j}$.  Expanding
     $\mathrm{coeff}\,(A^{[p]})\,(\mathrm{ofFn}\,\tau)$ by linearity of

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -134,7 +134,7 @@ $p$-divisibility of the transfer map.
     irreducibility preservation.
 \end{proof}
 
-\begin{theorem}[SameMPV preserved by physical rotation]%
+\begin{theorem}[Equality of MPV families preserved by physical rotation]%
     \label{thm:same_mpv_rotate_physical}
     \lean{MPSTensor.sameMPV₂_rotatePhysical}
     \leanok
@@ -184,7 +184,7 @@ $p$-divisibility of the transfer map.
         thm:same_mpv_rotate_physical,
         thm:rotate_physical_blocks}
     Each block remains periodic by
-    Theorem~\ref{thm:periodic_rotate_physical}, the SameMPV condition
+    Theorem~\ref{thm:periodic_rotate_physical}, equality of MPV families
     transfers via Theorem~\ref{thm:same_mpv_rotate_physical}, and
     block-diagonal compatibility follows from
     Theorem~\ref{thm:rotate_physical_blocks}.
@@ -409,13 +409,13 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     \lean{MPSTensor.cornerTransition}
     \leanok
     \uses{def:cyclic_sector_decomp}
-    For a cyclic projection family $(P_k)_{k \in \mathrm{Fin}\,m}$ on the
+    For a cyclic projection family $(P_k)_{k=0}^{m-1}$ on the
     ambient bond algebra of an MPS tensor $A$, the \emph{one-site corner
     transition} at sector $k$ is the family of per-site matrices
     \[
-        \tau_k(A)^i := P_k \cdot A^i \cdot P_{k+1}, \qquad i \in \mathrm{Fin}\,d,
+        \tau_k(A)^i := P_k \cdot A^i \cdot P_{k+1}, \qquad i = 0,\ldots,d-1,
     \]
-    where the index $k+1$ is taken cyclically in $\mathrm{Fin}\,m$.
+    where the index $k+1$ is taken cyclically modulo~$m$.
 \end{definition}
 
 \begin{definition}[Staircase evaluation]%
@@ -424,16 +424,14 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     \leanok
     \uses{def:corner_transition}
     For a word $w = (w_0,\dotsc,w_{L-1})$ on the physical index alphabet and
-    a starting sector $u$, the \emph{staircase evaluation} at $u$ is
+    a starting sector $u$, the \emph{staircase evaluation} at $u$ is the matrix
     \[
-        \mathrm{cornerEvalWord}(A, P, u, w)
-        := P_u \cdot A^{w_0} \cdot P_{u+1} \cdot A^{w_1} \cdot P_{u+2}
+        P_u \cdot A^{w_0} \cdot P_{u+1} \cdot A^{w_1} \cdot P_{u+2}
             \cdots A^{w_{L-1}} \cdot P_{u+L},
     \]
-    defined recursively by
-    $\mathrm{cornerEvalWord}(A, P, u, \varepsilon) = P_u$ and
-    $\mathrm{cornerEvalWord}(A, P, u, i \cdot w) =
-     P_u \cdot A^i \cdot \mathrm{cornerEvalWord}(A, P, u+1, w)$.
+    characterized recursively by the empty-word value $P_u$ and the rule that
+    prepending a letter $i$ inserts the factor $P_u \cdot A^i$ and advances the
+    starting sector from $u$ to $u+1$.
 \end{definition}
 
 \begin{definition}[Cyclic staircase product on blocked indices (Eq. A.8)]%
@@ -443,8 +441,8 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     \uses{def:corner_eval_word}
     The \emph{blocked corner transition tensor} at sector $u$ is the
     MPS tensor on blocked physical indices defined by
-    $i \mapsto \mathrm{cornerEvalWord}(A, P, u, w_i)$, where $w_i$ is the
-    length-$m$ physical word associated to the blocked index $i$. For a
+    sending a blocked index $i$ to the staircase evaluation along the
+    associated length-$m$ physical word $w_i$. For a
     blocked index $i$ with word $(i_0,\dotsc,i_{m-1})$ this returns the
     ambient-algebra matrix
     \[
@@ -652,8 +650,9 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     \lean{MPSTensor.PeriodicProjectiveRigidity}
     \leanok
     \uses{def:twisted_tensor, def:on_site_symmetric}
-    Let $A : \mathrm{MPSTensor}\ d\ D$ be on-site symmetric under a group
-    action $U : G \to \GL_d(\C)$.  The tensor $A$ satisfies the
+    Let $A$ be an MPS tensor with physical dimension $d$ and bond dimension $D$,
+    and assume it is on-site symmetric under a group action
+    $U : G \to \GL_d(\C)$.  The tensor $A$ satisfies the
     \emph{periodic projective-rigidity hypothesis} if one may choose a
     family of virtual gauges $Y : G \to \GL_D(\C)$ and a scalar
     $2$-cochain $u : G \times G \to \C^{\times}$ such that
@@ -781,21 +780,21 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.IsPRefinable}
     \leanok
     \uses{def:mps_tensor, def:blocked_tensor}
-    An MPS tensor $B : \mathrm{MPSTensor}\ d\ D$ is \emph{$p$-refinable}
-    if there exist another tensor $A : \mathrm{MPSTensor}\ d\ D$ and an
+    An MPS tensor $B$ with physical dimension $d$ and bond dimension $D$ is
+    \emph{$p$-refinable} if there exist another such tensor $A$ and an
     isometry $W : \C^d \to (\C^d)^{\otimes p}$ (encoded as a matrix
     $W \in M_{d^p \times d}(\C)$ with $W^{\dagger} W = \Id$) such that the
     $p$-blocked tensor $A^{[p]}$ matches the $W$-image of $B$ at the level
     of MPV coefficients:
     \[
-        \mathrm{coeff}\big(A^{[p]}\big)\big(\mathrm{ofFn}\,\tau\big)
+        V^{(N)}(A^{[p]})_\tau
         \;=\;
-        \sum_{\sigma : \mathrm{Fin}\, N \to \mathrm{Fin}\, d}
+        \sum_{\sigma \in \{0,\ldots,d-1\}^N}
             \Big(\prod_{k} W_{\tau(k),\,\sigma(k)}\Big)\,
-            \mathrm{coeff}\,B\,\big(\mathrm{ofFn}\,\sigma\big)
+            V^{(N)}(B)_\sigma
     \]
     for every $N \in \N$ and every
-    $\tau : \mathrm{Fin}\, N \to \mathrm{Fin}\, d^{p}$.
+    $\tau \in \{0,\ldots,d^p-1\}^N$.
 
     In paper notation, this encodes
     $\ket{V_{pN}(A)} = W^{\otimes N}\, \ket{V_N(B)}$ for all~$N$.
@@ -881,7 +880,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel}
     Let $B$ be an MPS tensor in irreducible form~II and let $p \ge 1$.
     Assume an \emph{inverse canonicalization} hypothesis providing a
-    witness $A : \mathrm{MPSTensor}\ d\ D$ with
+    witness tensor $A$ with the same physical and bond dimensions as $B$ and
     $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$ whenever $\mathcal{E}_B$ is
     $p$-divisible.  Then $p$-divisibility of $\mathcal{E}_B$ implies
     $p$-refinability of $B$.
@@ -897,7 +896,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     Kraus representations (\lean{kraus_isometry_freedom_iff}) supplies an
     isometry $V \in M_{d^p \times d}(\C)$ with $V^{\dagger} V = \Id$ and
     $(A^{[p]})^{\alpha} = \sum_{j} V_{\alpha,j}\, B^{j}$.  Expanding
-    $\mathrm{coeff}\,(A^{[p]})\,(\mathrm{ofFn}\,\tau)$ by linearity of
+    the blocked MPV coefficient $V^{(N)}(A^{[p]})_\tau$ by linearity of
     matrix multiplication and of the trace, the contributions
     reorganise into the $V$-weighted sum over length-$N$ words of $B$
     required by Definition~\ref{def:p_refinable}, exhibiting $V$ as the

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -198,7 +198,7 @@ and proves the GKSL theorem.
     Theorem~\ref{thm:expSemigroup_zero_ch12}.
 \end{proof}
 
-\begin{theorem}[Prop.~7.1: Every continuous semigroup is exponential]
+\begin{theorem}[Every continuous semigroup is exponential]
     \label{thm:continuousDynSemigroup_eq_exp_ch12}
     \lean{continuousDynSemigroup_eq_exp}\leanok
     \uses{def:continuous_dyn_semigroup_ch12, def:exp_semigroup_ch12}
@@ -227,7 +227,7 @@ and proves the GKSL theorem.
 \label{sec:perturbation}
 %% ---------------------------------------------------------
 
-\begin{theorem}[Lem.~7.1: Duhamel formula]\label{thm:duhamel_formula_ch12}
+\begin{theorem}[Duhamel formula]\label{thm:duhamel_formula_ch12}
     \lean{duhamel_formula}\leanok
     \uses{def:exp_semigroup_ch12, thm:hasDerivAt_expSemigroupCLM_ch12}
     Let $\Delta = L' - L$. For $t \ge 0$,
@@ -246,7 +246,7 @@ and proves the GKSL theorem.
     and $e^{tL'} - e^{tL} = f(t) - f(0) = \int_0^t f'(s)\,ds$.
 \end{proof}
 
-\begin{theorem}[Cor.~7.1: Perturbation bound]\label{thm:perturbation_bound_ch12}
+\begin{theorem}[Perturbation bound]\label{thm:perturbation_bound_ch12}
     \lean{perturbation_bound}\leanok
     \uses{thm:duhamel_formula_ch12}
     For $t \ge 0$,
@@ -611,7 +611,7 @@ which shows that such generators have the standard Lindblad form.
 
 \subsection{Characterization of conditional complete positivity}
 
-\begin{theorem}[Prop.~7.2, direction 1$\to$2]
+\begin{theorem}[Conditional complete positivity implies projected Choi positivity]
     \label{thm:ccp_implies_choi_projected}
     \lean{ccp_implies_choi_projected_posSemidef}\leanok
     \uses{def:is_ccp}
@@ -630,7 +630,7 @@ which shows that such generators have the standard Lindblad form.
     is positive.
 \end{proof}
 
-\begin{theorem}[Prop.~7.2, direction 2$\to$1]
+\begin{theorem}[Projected Choi positivity implies conditional complete positivity]
     \label{thm:choi_projected_implies_ccp}
     \lean{choi_projected_posSemidef_implies_ccp}\leanok
     \uses{def:is_ccp}
@@ -651,9 +651,9 @@ which shows that such generators have the standard Lindblad form.
     $(\kappa \otimes \Id)\ket{\Omega} = \ket{\psi}$ defines $\kappa$.
 \end{proof}
 
-\subsection{CP semigroups and CCP generators}
+\subsection{Completely positive semigroups and conditionally completely positive generators}
 
-\begin{theorem}[Prop.~7.3: CP semigroup implies CCP generator]
+\begin{theorem}[A completely positive semigroup has a conditionally completely positive generator]
     \label{thm:cp_semigroup_implies_ccp}
     \lean{cp_semigroup_implies_ccp_generator}\leanok
     \uses{def:cp_map, def:is_ccp, def:exp_semigroup_ch12}
@@ -670,7 +670,7 @@ which shows that such generators have the standard Lindblad form.
     Then Theorem~\ref{thm:choi_projected_implies_ccp} gives CCP.
 \end{proof}
 
-\begin{theorem}[Prop.~7.3: CCP generator implies CP semigroup]
+\begin{theorem}[A conditionally completely positive generator yields a completely positive semigroup]
     \label{thm:ccp_implies_cp_semigroup}
     \lean{ccp_generator_implies_cp_semigroup}\leanok
     \uses{def:cp_map, def:is_ccp, def:exp_semigroup_ch12}
@@ -689,7 +689,7 @@ which shows that such generators have the standard Lindblad form.
     norm to $e^{tL}$, and the cone of CP maps is closed.
 \end{proof}
 
-\begin{theorem}[Prop.~7.3: CP semigroup iff CCP generator]
+\begin{theorem}[A semigroup is completely positive iff its generator is conditionally completely positive]
     \label{thm:cp_semigroup_iff_ccp}
     \lean{cp_semigroup_iff_ccp_generator}\leanok
     \uses{def:cp_map, def:is_ccp, def:exp_semigroup_ch12}
@@ -740,7 +740,7 @@ which shows that such generators have the standard Lindblad form.
     $\tr(L_j) = 0$ for every $j$.
 \end{definition}
 
-\begin{theorem}[Prop.~7.4, item 2: CP-part uniqueness]
+\begin{theorem}[Uniqueness of the completely positive part]
     \label{thm:generatorDecomp_traceless_unique_phi}
     \lean{generatorDecomp_traceless_unique_phi}\leanok
     \uses{def:lindblad_form, def:has_traceless_kraus, def:generator_decomp}
@@ -754,7 +754,7 @@ which shows that such generators have the standard Lindblad form.
     Compare projected Choi matrices and use Choi injectivity.
 \end{proof}
 
-\begin{theorem}[Prop.~7.4, item 2: drift uniqueness modulo phase]
+\begin{theorem}[Uniqueness of the drift term modulo phase]
     \label{thm:generatorDecomp_traceless_unique_kappa}
     \lean{generatorDecomp_traceless_unique_kappa_modPhase}\leanok
     \uses{def:lindblad_form, def:has_traceless_kraus, def:generator_decomp,
@@ -779,7 +779,7 @@ which shows that such generators have the standard Lindblad form.
     and skew-Hermiticity forces $c = i\lambda$ for some $\lambda \in \R$.
 \end{proof}
 
-\begin{theorem}[Prop.~7.4, item 2: combined uniqueness]
+\begin{theorem}[Combined uniqueness of the traceless Lindblad form]
     \label{thm:generatorDecomp_traceless_unique}
     \lean{generatorDecomp_traceless_unique}\leanok
     \uses{thm:generatorDecomp_traceless_unique_phi,
@@ -827,7 +827,7 @@ which shows that such generators have the standard Lindblad form.
     from the right.
 \end{proof}
 
-\subsection{GKSL/Lindblad theorem}
+\subsection{The GKSL/Lindblad theorem}
 
 \begin{definition}[GKSL generator]\label{def:is_gksl_generator}
     \lean{IsGKSLGenerator}\leanok
@@ -836,7 +836,7 @@ which shows that such generators have the standard Lindblad form.
     if $e^{tL}$ is a quantum channel (CPTP) for all $t \ge 0$.
 \end{definition}
 
-\begin{theorem}[Thm.~7.1, Form~(i)]
+\begin{theorem}[A trace-constrained generator decomposition gives a GKSL generator]
     \label{thm:gksl_of_generatorDecomp}
     \lean{gksl_of_generatorDecomp_with_traceConstraint}\leanok
     \uses{def:cp_map, def:is_gksl_generator, def:generator_decomp,
@@ -857,7 +857,7 @@ which shows that such generators have the standard Lindblad form.
     Theorem~\ref{thm:ta_implies_tp_semigroup} gives trace preservation.
 \end{proof}
 
-\begin{theorem}[Thm.~7.1, Form~(i) conversely]
+\begin{theorem}[GKSL generators admit a trace-constrained generator decomposition]
     \label{thm:generatorDecomp_of_gksl}
     \lean{generatorDecomp_of_gksl}\leanok
     \uses{def:cp_map, def:is_gksl_generator, def:generator_decomp, def:is_trace_constraint}
@@ -877,7 +877,7 @@ which shows that such generators have the standard Lindblad form.
     trace-annihilation condition as $\phi^*(\Id) = \kappa + \kappa^\dagger$.
 \end{proof}
 
-\begin{theorem}[Thm.~7.1: GKSL iff CCP + trace-annihilating]
+\begin{theorem}[GKSL iff conditional complete positivity and trace annihilation]
     \label{thm:gksl_iff_ccp_ta}
     \lean{gksl_iff_ccp_and_traceAnnihilating}\leanok
     \uses{def:is_gksl_generator, def:is_ccp, def:is_trace_annihilating}
@@ -894,7 +894,7 @@ which shows that such generators have the standard Lindblad form.
     Theorem~\ref{thm:ta_implies_tp_semigroup}.
 \end{proof}
 
-\begin{theorem}[Thm.~7.1: GKSL iff Lindblad form]
+\begin{theorem}[GKSL iff Lindblad form]
     \label{thm:gksl_iff_lindblad}
     \lean{gksl_iff_lindbladForm}\leanok
     \uses{def:is_gksl_generator, def:lindblad_form}
@@ -1339,7 +1339,7 @@ which shows that such generators have the standard Lindblad form.
     gives the uniqueness criterion for irreducibility at every positive time.
 \end{proof}
 
-\begin{theorem}[Prop.~7.5: Irreducible semigroup implies primitive]
+\begin{theorem}[An irreducible semigroup is primitive]
     \label{thm:irreducible_semigroup_implies_primitive}
     \lean{irreducible_semigroup_implies_primitive}\leanok
     \uses{def:is_quantum_dyn_semigroup_ch12,
@@ -1358,7 +1358,7 @@ which shows that such generators have the standard Lindblad form.
     positive-time slice.
 \end{proof}
 
-\begin{theorem}[Prop.~7.5: Irreducibility iff primitivity for QDS]
+\begin{theorem}[Irreducibility iff primitivity for a quantum dynamical semigroup]
     \label{thm:qds_irreducible_iff_primitive}
     \lean{qds_irreducible_iff_primitive}\leanok
     \uses{thm:irreducible_semigroup_implies_primitive}
@@ -1460,7 +1460,7 @@ which shows that such generators have the standard Lindblad form.
     $\mathcal{D}_{L_j}^*(A)$ is zero under the commutation hypotheses.
 \end{proof}
 
-\begin{theorem}[Thm.~7.2: Adjoint kernel equals commutant (faithful state)]
+\begin{theorem}[The adjoint kernel is contained in the commutant under a faithful stationary state]
     \label{thm:adjointKernel_eq_commutant}
     \lean{LindbladForm.mem_commutant_of_mem_adjointKernel_of_hasFaithfulStationaryState}\leanok
     \uses{def:lindblad_form, def:has_faithful_stationary_state_ch12,
@@ -1490,7 +1490,7 @@ which shows that such generators have the standard Lindblad form.
     $[A, H] = 0$.
 \end{proof}
 
-\begin{theorem}[Thm.~7.2: Adjoint kernel equals commutant (full equivalence)]
+\begin{theorem}[The adjoint kernel equals the commutant under a faithful stationary state]
     \label{thm:adjointKernel_eq_commutant_full}
     \lean{LindbladForm.adjointKernel_eq_commutant_of_hasFaithfulStationaryState}\leanok
     \uses{thm:adjointKernel_eq_commutant, def:commutant_ch12, def:adjoint_kernel_ch12}
@@ -1620,7 +1620,7 @@ The four equivalent reducibility conditions of
     and~\ref{thm:semigroup_preserves_compression_from_generator_ch12}.
 \end{proof}
 
-\begin{theorem}[Prop.~7.6, (1)$\leftrightarrow$(2)]
+\begin{theorem}[Rank-deficient fixed densities are equivalent to rank-deficient kernel elements]
     \label{thm:wolf_prop_7_6_one_iff_two}
     \lean{wolf_prop_7_6_one_iff_two}\leanok
     \uses{def:has_rank_deficient_fixed_density,
@@ -1636,7 +1636,7 @@ The four equivalent reducibility conditions of
     at $t=0$ for the forward direction, and exponentiate for the reverse.
 \end{proof}
 
-\begin{theorem}[Prop.~7.6, (1)$\to$(3)]
+\begin{theorem}[A rank-deficient fixed density yields an invariant compression]
     \label{thm:wolf_prop_7_6_one_implies_three}
     \lean{wolf_prop_7_6_one_implies_three}\leanok
     \uses{def:has_rank_deficient_fixed_density,
@@ -1689,7 +1689,7 @@ The four equivalent reducibility conditions of
     Theorem~\ref{thm:semigroup_preserves_compression_from_generator_ch12}.
 \end{proof}
 
-\begin{theorem}[Prop.~7.6, (3)$\leftrightarrow$(4)]
+\begin{theorem}[Invariant compression is equivalent to block-upper-triangular Lindblad data]
     \label{thm:wolf_prop_7_6_three_iff_four}
     \lean{wolf_prop_7_6_three_implies_four, wolf_prop_7_6_four_implies_three}\leanok
     \uses{def:has_invariant_compression,
@@ -1707,7 +1707,7 @@ The four equivalent reducibility conditions of
     and~\ref{thm:hasBlockUpperTriangularLindblad_of_hasInvariantCompression_ch12}.
 \end{proof}
 
-\begin{theorem}[Prop.~7.6, (4)$\to$(2)]
+\begin{theorem}[Block-upper-triangular Lindblad data yield a rank-deficient kernel element]
     \label{thm:blockUpperTriangular_implies_rankDeficient}
     \lean{hasRankDeficientKernelElement_of_hasBlockUpperTriangularLindblad}\leanok
     \uses{def:has_block_upper_triangular_lindblad,
@@ -1732,7 +1732,7 @@ The four equivalent reducibility conditions of
     Since $P \neq \Id$, the matrix $\rho_0$ has nontrivial kernel.
 \end{proof}
 
-\begin{theorem}[Prop.~7.6: Full equivalence]
+\begin{theorem}[Equivalent formulations of reducibility]
     \label{thm:wolf_prop_7_6_full}
     \lean{wolf_prop_7_6_full_equivalence}\leanok
     \uses{def:is_gksl_generator, def:has_rank_deficient_fixed_density,
@@ -1884,7 +1884,7 @@ The four equivalent reducibility conditions of
     would then produce a block-upper-triangular Lindblad form.
 \end{proof}
 
-\begin{theorem}[Cor.~7.2(1): full algebra generation implies non-reducibility]
+\begin{theorem}[Full algebra generation implies non-reducibility]
     \label{thm:not_isReducible_of_generates_full_algebra}
     \lean{not_isReducible_of_generates_full_algebra}\leanok
     \uses{def:is_gksl_generator, def:lindblad_form,
@@ -1902,7 +1902,7 @@ The four equivalent reducibility conditions of
     Theorem~\ref{thm:not_isReducibleQDS_of_no_blockUpperTriangular_ch12}.
 \end{proof}
 
-\begin{theorem}[Cor.~7.2(2): Hermitian span + trivial commutant implies non-reducibility]
+\begin{theorem}[Hermitian span and trivial commutant imply non-reducibility]
     \label{thm:not_isReducible_of_hermitian_span_trivial_commutant}
     \lean{not_isReducible_of_hermitian_span_trivial_commutant}\leanok
     \uses{def:is_gksl_generator, def:is_lindblad_span_hermitian_closed,
@@ -1921,7 +1921,7 @@ The four equivalent reducibility conditions of
     Theorem~\ref{thm:not_isReducibleQDS_of_no_blockUpperTriangular_ch12}.
 \end{proof}
 
-\begin{theorem}[Cor.~7.2(3): large Kossakowski rank implies non-reducibility]
+\begin{theorem}[Large Kossakowski rank implies non-reducibility]
     \label{thm:not_isReducible_of_kossakowski_rank_ge}
     \lean{not_isReducible_of_kossakowski_rank_ge}\leanok
     \uses{def:is_gksl_generator, def:kossakowski_rank,

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -22,8 +22,8 @@ and blocked chains.
 Throughout, $D$ is the bond dimension and $d$ is the physical dimension
 with $d \ge D^2$.
 The extensions to injective and normal PEPS on arbitrary graphs and the
-improved system-size bound ($2L+1$ in place of $3L$) are left for
-future work.
+improved system-size bound ($2L+1$ in place of $3L$) are not pursued in
+this chapter.
 The chain data (Definition~\ref{def:non_ti_chain}),
 including same chain state, injectivity, and cyclic gauge equivalence,
 was introduced in Chapter~\ref{ch:single}.
@@ -247,7 +247,7 @@ conjugacy of the middle-bond insertion data.
     arbitrary chain length $n \ge 3$ and any bond position, with
     uniqueness of $Z$ up to scalar.
     The chain-level generalization to arbitrary $n \ge 3$
-    and any bond position is future work.
+    and any bond position is not pursued here.
 \end{lemma}
 
 \begin{proof}
@@ -384,18 +384,18 @@ reduction hypothesis.
     \leanok
     \uses{lem:blocking_preserves_injectivity, thm:ft_single}
     Choose one site of $\mathbf{A}$; its injectivity implies injectivity of
-    the bundled tensor by Lemma~\ref{lem:blocking_preserves_injectivity}.
+    the combined tensor by Lemma~\ref{lem:blocking_preserves_injectivity}.
     Apply the single-block Fundamental Theorem
-    (Theorem~\ref{thm:ft_single}) to the two bundled tensors.
-    This yields one invertible matrix $X$ such that every bundled matrix of
-    $\mathbf{B}$ equals the corresponding bundled matrix of
+    (Theorem~\ref{thm:ft_single}) to the two combined tensors.
+    This yields one invertible matrix $X$ such that every combined matrix of
+    $\mathbf{B}$ equals the corresponding combined matrix of
     $\mathbf{A}$ conjugated by $X$.
     Reading this identity back at each site gives
     $B_k^i = X A_k^i X^{-1}$ for all $k$ and $i$, so the constant choice
     $Z_k = X$ is a cyclic gauge.
 \end{proof}
 
-\subsection{From fixed-length chain states to bundled-tensor MPV agreement}
+\subsection{From fixed-length chain states to combined-tensor MPV agreement}
 
 \begin{definition}[Same-state reduction hypothesis]
     \label{def:same_state_reduction_hyp}
@@ -405,11 +405,11 @@ reduction hypothesis.
     A \emph{same-state reduction hypothesis} for dimensions $(d,D)$ is the
     assertion that whenever $\mathbf{A}$ is an injective $n$-site chain with
     $n \ge 3$ and $\mathbf{A},\mathbf{B}$ generate the same chain state,
-    then the bundled tensors of $\mathbf{A}$ and $\mathbf{B}$ generate the
+    then the combined tensors of $\mathbf{A}$ and $\mathbf{B}$ generate the
     same MPV family.
 \end{definition}
 
-\begin{lemma}[Same state gives bundled-tensor MPV agreement]
+\begin{lemma}[Same state gives combined-tensor MPV agreement]
     \label{lem:sameMPV_chainCombined_of_sameState}
     \lean{MPSChainTensor.sameMPV_chainCombined_of_sameState}
     \leanok
@@ -419,7 +419,7 @@ reduction hypothesis.
     dimension $D$, with $n \ge 3$, and assume that $\mathbf{A}$ is
     injective.
     If $\mathbf{A}$ and $\mathbf{B}$ generate the same chain state, then the
-    bundled tensors of $\mathbf{A}$ and $\mathbf{B}$ generate the same MPV
+    combined tensors of $\mathbf{A}$ and $\mathbf{B}$ generate the same MPV
     family.
 \end{lemma}
 
@@ -448,7 +448,7 @@ reduction hypothesis.
     \uses{lem:sameMPV_chainCombined_of_sameState,
         thm:fundamentalTheorem_injective_chain}
     Apply Lemma~\ref{lem:sameMPV_chainCombined_of_sameState} to convert the
-    fixed-length chain-state hypothesis into equality of the bundled-tensor
+    fixed-length chain-state hypothesis into equality of the combined-tensor
     MPV families, then invoke
     Theorem~\ref{thm:fundamentalTheorem_injective_chain}.
 \end{proof}
@@ -457,14 +457,14 @@ reduction hypothesis.
     \label{rem:ft_vs_singleBlock}
     \uses{thm:fundamentalTheorem_injective_chain, def:injective}
     Theorem~\ref{thm:fundamentalTheorem_injective_chain} treats a fixed chain
-    length and assumes equality of the bundled-tensor MPV families.
+    length and assumes equality of the combined-tensor MPV families.
     The single-block Fundamental Theorem
     (Theorem~\ref{thm:ft_single}) instead studies one tensor at all system
     sizes and concludes exact gauge equivalence
     $B^i = X A^i X^{-1}$.
-    The chain theorem is recovered by converting the chain into one bundled
+    The chain theorem is recovered by converting the chain into one combined
     tensor; the price is that the hypothesis is all-length MPV equality for
-    that bundled tensor rather than equality of the chain state at one fixed
+    that combined tensor rather than equality of the chain state at one fixed
     length.
 \end{remark}
 
@@ -547,7 +547,7 @@ reduction hypothesis.
     \uses{def:injective, def:same_mpv}
     Let $A$ and $B$ be MPS tensors of bond dimension $D$, and fix a chain
     length $n \ge 1$.
-    Assume that $A$ is injective and that the bundled tensors of the two
+    Assume that $A$ is injective and that the combined tensors of the two
     constant chains $(A, \ldots, A)$ and $(B, \ldots, B)$ generate the same
     MPV family.
     Then there exists an invertible matrix $X \in \GL_D(\C)$ such that
@@ -561,8 +561,8 @@ reduction hypothesis.
     \leanok
     \uses{lem:blocking_preserves_injectivity, thm:ft_single}
     Bundle the constant chains into one tensor.
-    Injectivity of $A$ implies injectivity of the bundled tensor by
-    Lemma~\ref{lem:blocking_preserves_injectivity}, and the bundled MPV
+    Injectivity of $A$ implies injectivity of the combined tensor by
+    Lemma~\ref{lem:blocking_preserves_injectivity}, and the combined-tensor MPV
     equality is exactly the hypothesis needed for the single-block
     Fundamental Theorem.
     The resulting gauge matrix is independent of the site because every site
@@ -575,7 +575,7 @@ reduction hypothesis.
     \uses{def:injective, def:same_mpv}
     Let $A$ and $B$ be MPS tensors of bond dimension $D$, and fix a chain
     length $n \ge 1$.
-    Assume that $A$ is injective and that the bundled tensors of the two
+    Assume that $A$ is injective and that the combined tensors of the two
     constant chains $(A, \ldots, A)$ and $(B, \ldots, B)$ generate the same
     MPV family.
     Then there exist an invertible matrix $Z \in \GL_D(\C)$ and a scalar
@@ -686,7 +686,7 @@ Chapter~\ref{ch:symmetry}.
     \uses{def:blocked_chain, def:same_mpv}
     Let $A$ and $B$ be MPS tensors of bond dimension $D$, let $L$ be a
     blocking length, and let $n$ be a chain length.
-    Assume that $A$ is $L$-block injective and that the bundled tensors of the
+    Assume that $A$ is $L$-block injective and that the combined tensors of the
     two constant blocked chains built from $A^{[L]}$ and $B^{[L]}$ generate the
     same MPV family.
     Then the two blocked chains are gauge equivalent.
@@ -703,10 +703,9 @@ Chapter~\ref{ch:symmetry}.
 \end{proof}
 
 \begin{remark}
-    The theorem above is the exact blocked-chain endpoint presently formalized
-    in Lean.
+    The theorem above is the exact blocked-chain endpoint established here.
     Recovering sitewise gauges for the original unblocked tensors, and hence
-    the paper's normal-MPS corollary, remains future work.
+    the paper's normal-MPS corollary, is not established here.
 \end{remark}
 
 %% ---------------------------------------------------------
@@ -1231,7 +1230,7 @@ which is then combined with overlap estimates and the leading-block peel.
     injective.
     Consider the two constant translation-invariant chains
     $(A, \ldots, A)$ and $(B, \ldots, B)$ of length $n \ge 1$.
-    If the bundled tensors of the two chains generate the same MPV
+    If the combined tensors of the two chains generate the same MPV
     family, then:
     \begin{enumerate}
         \item $B$ is gauge equivalent to $A$: there exists
@@ -1264,7 +1263,7 @@ which is then combined with overlap estimates and the leading-block peel.
     \uses{lem:sameMPV_chainCombined_of_sameState,
         thm:ti_reduction_corollary}
     The same-state reduction hypothesis upgrades equality of the two constant
-    chain states to equality of their bundled-tensor MPV families.
+    chain states to equality of their combined-tensor MPV families.
     Then Theorem~\ref{thm:ti_reduction_corollary} applies.
 \end{proof}
 
@@ -1647,10 +1646,9 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     (Theorem~2 of~\cite{Molnar2018NormalPEPS}).
 \end{theorem}
 
-\begin{remark}[Current scalar-uniqueness placeholder]
+\begin{remark}[Scalar-uniqueness caveat]
     \lean{TNLean.PEPS.gauge_unique_up_to_scalar}
-    The present Lean declaration records a global-scalar uniqueness claim, but
-    this conclusion is known to be too strong.
+    The stated global-scalar uniqueness claim is too strong.
     On a triangle with all bond dimensions equal to $1$, edge scalars
     $(a,a^{-1},a)$ preserve every local tensor yet are not all multiples of
     $(1,1,1)$ when $a \neq \pm 1$.

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -222,7 +222,7 @@ operation on the physical indices.
 %% ---------------------------------------------------------
 
 This section records the 3-site virtual-bond statement used later in the
-paper proof. In the current Lean development the hypothesis is already the
+paper proof. Here the hypothesis is already the
 all-length MPV equality of the combined tensors, and the conclusion is the
 conjugacy of the middle-bond insertion data.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -319,7 +319,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     Fix the last physical index $j$:
     \[
-        (\mathrm{restrictLast} \psi j)(\sigma) := \psi(\sigma_1,\ldots,\sigma_L,j).
+        \sigma \longmapsto \psi(\sigma_1,\ldots,\sigma_L,j).
     \]
 \end{definition}
 
@@ -328,7 +328,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     Fix the first physical index $i$:
     \[
-        (\mathrm{restrictFirst} \psi i)(\sigma) := \psi(i,\sigma_1,\ldots,\sigma_L).
+        \sigma \longmapsto \psi(i,\sigma_1,\ldots,\sigma_L).
     \]
 \end{definition}
 
@@ -337,7 +337,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{def:restrict_last, def:ground_space_parent}
     A state $\psi$ on $L+1$ sites satisfies the left ground condition if
-    $\mathrm{restrictLast} \psi j \in G_L(A)$ for every $j$.
+    for every $j$, the state obtained by fixing the last index to $j$ lies in
+    $G_L(A)$.
 \end{definition}
 
 \begin{definition}[Right ground membership]\label{def:in_right_ground}
@@ -345,7 +346,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{def:restrict_first, def:ground_space_parent}
     A state $\psi$ on $L+1$ sites satisfies the right ground condition if
-    $\mathrm{restrictFirst} \psi i \in G_L(A)$ for every $i$.
+    for every $i$, the state obtained by fixing the first index to $i$ lies in
+    $G_L(A)$.
 \end{definition}
 
 \subsection{Forward direction: ground space restricts}
@@ -355,7 +357,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{def:ground_space_parent, def:in_left_ground}
     If $\psi \in G_{L+1}(A)$, i.e.\ $\psi(\sigma) = \tr(A^\sigma X)$ for some~$X$,
-    then $\mathrm{restrictLast} \psi j \in G_L(A)$ with witness $A^j X$.
+    then for each $j$, the state obtained by fixing the last index to $j$
+    lies in $G_L(A)$ with witness $A^j X$.
 \end{lemma}
 
 \begin{proof}
@@ -374,7 +377,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{def:ground_space_parent, def:in_right_ground}
     If $\psi \in G_{L+1}(A)$ with $\psi(\sigma) = \tr(A^\sigma X)$, then
-    $\mathrm{restrictFirst} \psi i \in G_L(A)$ with witness $X A^i$.
+    for each $i$, the state obtained by fixing the first index to $i$
+    lies in $G_L(A)$ with witness $X A^i$.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1024,12 +1024,12 @@ interaction projectors commute with each other.
     \uses{def:is_rfp, def:is_nncph, def:normal}
     If $A$ is a normal renormalization fixed point, then for every chain length
     $N \ge 2$ the parent Hamiltonian with $L = 2$ has commuting local terms.
-    Here this implication is supplied by the external input
-    recording the product-of-entangled-pairs description from Appendix~B of
+    This implication is cited here from the product-of-entangled-pairs
+    description in Appendix~B of
     Theorem~3.10 in~\cite{Cirac2021Matrix}.
 \end{theorem}
 
-\begin{remark}[Product-pair data for future NNCPH proofs]%
+\begin{remark}[Product-pair data for NNCPH]%
     \label{rem:product_pair_bridge}
     \lean{MPSTensor.productPairWindow}
     \lean{MPSTensor.productPairState}
@@ -1058,8 +1058,8 @@ interaction projectors commute with each other.
     \uses{def:is_rfp, def:is_nncph, def:normal}
     If $A$ is normal, in left-canonical form, and its parent Hamiltonian with
     $L = 2$ has commuting local terms for every chain length $N \ge 2$, then $A$
-    is a renormalization fixed point. Here this
-    implication is supplied by the external input recording Beigi's ground-space
+    is a renormalization fixed point. This implication is cited here from Beigi's
+    ground-space
     characterization of one-dimensional commuting nearest-neighbor Hamiltonians; the
     left-canonical hypothesis fixes the normalization of the transfer map.
 \end{theorem}
@@ -1617,8 +1617,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \notready
     \uses{def:parent_ground_space_es, def:parent_hamiltonian_es,
         thm:parent_ground_space_es_kernel}
-    For an injective tensor $A$ and a range $L > 1$, the current Lean statement gives
-    the missing analytic estimate with the explicit constant
+    For an injective tensor $A$ and a range $L > 1$, the theorem asserts
+    the analytic estimate with the explicit constant
     \[
         \gamma_{L} := \frac{1}{4L} > 0.
     \]
@@ -1631,8 +1631,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \notready
-    This is exactly the missing MPS-specific Friedrichs-angle estimate together with the
-    row-sum bound. Once those analytic inputs are formalized, the result feeds directly into
+    This is exactly the MPS-specific Friedrichs-angle estimate together with the
+    row-sum bound. These two analytic inputs feed directly into
     the abstract martingale criterion.
 \end{proof}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1024,8 +1024,8 @@ interaction projectors commute with each other.
     \uses{def:is_rfp, def:is_nncph, def:normal}
     If $A$ is a normal renormalization fixed point, then for every chain length
     $N \ge 2$ the parent Hamiltonian with $L = 2$ has commuting local terms.
-    In the current formal development, this implication is supplied by the sanctioned
-    axiom recording the product-of-entangled-pairs description from Appendix~B of
+    Here this implication is supplied by the external input
+    recording the product-of-entangled-pairs description from Appendix~B of
     Theorem~3.10 in~\cite{Cirac2021Matrix}.
 \end{theorem}
 
@@ -1058,8 +1058,8 @@ interaction projectors commute with each other.
     \uses{def:is_rfp, def:is_nncph, def:normal}
     If $A$ is normal, in left-canonical form, and its parent Hamiltonian with
     $L = 2$ has commuting local terms for every chain length $N \ge 2$, then $A$
-    is a renormalization fixed point. In the current formal development, this
-    implication is supplied by the sanctioned axiom recording Beigi's ground-space
+    is a renormalization fixed point. Here this
+    implication is supplied by the external input recording Beigi's ground-space
     characterization of one-dimensional commuting nearest-neighbor Hamiltonians; the
     left-canonical hypothesis fixes the normalization of the transfer map.
 \end{theorem}


### PR DESCRIPTION
### Motivation
Refs LionSR/TNLean#732.
Closes LionSR/TNLean#758, LionSR/TNLean#759, and LionSR/QICLean#147.

This PR started from the three open style-instance tickets under the tracking issue, then expanded into a broader blueprint chapter audit once the same reader-facing patterns showed up elsewhere.

### Description
- rewrote the Chapter 8 `Remaining steps toward normal canonical form` remark so it stays chapter-local and treats the periodic material only as a short forward reference
- rewrote the MPDO finite-length-span discussion in mathematical prose and removed the remaining Lean-name `\texttt{...}` references from chapter prose
- removed source-indexed reader-facing section and subsection headings across Chapters 2b, 4, 6, 7, and 11b, including `Wolf ...`, `\S4.5`, `Lemma~2(b)`, and `(Proposition 3.3)` styles
- renamed source-indexed theorem, remark, example, and subsection titles across Chapters 4, 5, 6, 7, 11b, and 12 so they read as mathematical statements rather than bibliography labels
- replaced remaining project-status or implementation-facing prose in Chapters 2b, 4b, 5, 11b, 13, and 14 with reader-facing mathematical wording, including the Chapter 13 `combined tensor` terminology sweep

### Audit result
After this sweep:
- `rg -n \\begin\{(theorem|lemma|definition|remark|example|corollary)\}\[[^]]*(Wolf|Prop\.|Thm\.|Cor\.|Lemma~|Definition~) blueprint/src/chapter` returns no matches
- `rg -n bundled\ tensor|bundled\ tensors|bundled-tensor|provisional|current\ predicate|current\ statement|declaration\ above|external\ input|formalization\ project|future\ work|still\ wait|currently\ taken\ as\ assumptions blueprint/src/chapter` returns no matches
- `rg -n \\(sub\)*section\{[^}]*((\\S[0-9]|Lemma~|Theorem~|Proposition~|Corollary~|\\(Proposition|\\(Theorem|de\ las\ Cuevas|Pérez-García|Wolf|Appendix|Chapter~)) blueprint/src/chapter` returns no matches
- the earlier `\texttt{...}` and `Wolf` section-heading sweeps remain clean

### Validation
- `git diff --check`
- `leanblueprint web` (passes in this checkout; existing blueprint warnings about missing `web.bbl` / bibliography entries remain)
- `rg -n \\texttt\{[^}]+\} blueprint/src/chapter`
- `rg -n \\begin\{(theorem|lemma|definition|remark|example|corollary)\}\[[^]]*(Wolf|Prop\.|Thm\.|Cor\.|Lemma~|Definition~) blueprint/src/chapter`
- `rg -n bundled\ tensor|bundled\ tensors|bundled-tensor|provisional|current\ predicate|current\ statement|declaration\ above|external\ input|formalization\ project|future\ work|still\ wait|currently\ taken\ as\ assumptions blueprint/src/chapter`
- `rg -n \\(sub\)*section\{[^}]*((\\S[0-9]|Lemma~|Theorem~|Proposition~|Corollary~|\\(Proposition|\\(Theorem|de\ las\ Cuevas|Pérez-García|Wolf|Appendix|Chapter~)) blueprint/src/chapter`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure LaTeX documentation and naming/prose changes with no algorithmic, proof, or API behavior changes; primary risk is broken references/labels or wording regressions.
> 
> **Overview**
> Completes a cross-chapter blueprint style audit by rewriting reader-facing prose to remove implementation/status phrasing (e.g., “current/provisional”, “formalized in Lean”, “future work”), replacing it with mathematical statements and forward references.
> 
> Standardizes headings and titles across multiple chapters by removing source-indexed labels (e.g., “Wolf Thm./Prop.”, “Lemma 2(b)”, “\S…”) and renaming sections/theorems/examples to descriptive, content-based names; also tightens several definitions/explanations (e.g., MPDO canonical-form span/selector remark, entropy formulations, Choi/Kraus/Stinespring/Naimark statements) and completes a terminology sweep from “bundled tensor” to “combined tensor”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24f4b30be7f48680aac259383d87f39745ef9a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->