### PR TITLE
fix(PEPS): repair gauge uniqueness statement

### DIFF
--- a/TNLean/PEPS/Defs.lean
+++ b/TNLean/PEPS/Defs.lean
@@ -79,8 +79,9 @@ space `ℂ^d`, that map has trivial kernel iff the family `A.component v` is
 linearly independent.
 
 Note: the earlier `Function.Injective (A.component v)` formulation is *strictly
-weaker* and admits counterexamples to `gauge_unique_up_to_scalar` (see issue
-#594). Linear independence is the correct notion here. -/
+weaker* and admits counterexamples to the former global-scalar uniqueness
+claim for PEPS gauges (see issues #594 and #762). Linear independence is the
+correct notion here. -/
 def IsVertexInjective (A : Tensor G d) : Prop :=
   ∀ v : V, LinearIndependent ℂ (A.component v)
 

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -1,7 +1,6 @@
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
-import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 
 -- This is a **scaffold** file: the forward direction and contraction algebra
 -- are formalized, while the converse PEPS fundamental theorem remains as
@@ -11,7 +10,9 @@ import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 -- linear-independence formulation `∀ v, LinearIndependent ℂ (A.component v)`
 -- (see issue #633 for the switch away from function-level injectivity, which
 -- is strictly weaker). Linear independence gives each vertex tensor a left
--- inverse on its image and removes the old definitional blocker.
+-- inverse on its image, removes the old definitional blocker, and is the
+-- correct hypothesis for the repaired uniqueness endpoint
+-- `gauge_unique_mod_edge_scalars`.
 --
 -- The remaining `sorry`s split into two groups:
 -- * `gaugeConsistency` and the `hDim` step in `fundamentalTheorem_PEPS` still
@@ -21,9 +22,9 @@ import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 --   been reduced to the sharper local hypothesis `HasLocalGaugeLift`, but the
 --   blocked middle tensor and the comparison with the 3-site MPS theorem are
 --   still missing.
--- * `gauge_unique_up_to_scalar` additionally needs statement repair: the
---   current global-scalar conclusion fails on a connected triangle with bond
---   dimension `1`.
+-- * `gauge_unique_mod_edge_scalars` is the repaired endpoint, but its proof
+--   still needs the same blocking infrastructure together with a local
+--   tensor-factor uniqueness lemma for the balanced edge-scalar quotient.
 
 /-!
 # Fundamental Theorem for injective PEPS (scaffold)
@@ -33,7 +34,7 @@ This file scaffolds the Fundamental Theorem for injective PEPS on simple graphs
 
 > Two injective PEPS defined on a graph (no double edges/self-loops) generate
 > the same state iff the generating tensors are related by local gauges on each
-> edge, unique up to a multiplicative constant.
+> edge, with uniqueness understood modulo balanced edge scalars on the graph.
 
 ## Strategy
 
@@ -568,17 +569,75 @@ theorem fundamentalTheorem_PEPS (A B : Tensor G d)
   rcases gaugeConsistency A B hA hB hAB hDim with ⟨X, hX⟩
   exact ⟨hDim, X, hX⟩
 
-/-! ### Uniqueness (up to scalar) -/
+/-! ### Balanced edge scalars -/
 
-/-- Placeholder uniqueness endpoint for the PEPS Fundamental Theorem.
+/-- The scalar contributed by an edge-scalar family at a chosen endpoint.
 
-The current statement asks for a single nonzero scalar `c : ℂ` with
-`X_e = c · Y_e` on every edge. The issue-#503 discussion records a connected
-triangle counterexample with bond dimension `1`, so this conclusion is too
-strong as stated. The eventual replacement will need an explicit normalization
-for the edge gauges before one can ask for uniqueness. -/
-theorem gauge_unique_up_to_scalar (A B : Tensor G d)
-    (hConn : G.Connected)
+For an edge `(u, w)` with `u < w` and scalar `c_e`, the lower endpoint carries
+`c_e` and the upper endpoint carries `c_e⁻¹`, mirroring `edgeGaugeAt`. -/
+def edgeScalarAt (c : (e : Edge G) → Units ℂ)
+    (v : V) (ie : IncidentEdge G v) : ℂ :=
+  if ie.1.1.1 = v then (c ie.1 : ℂ) else ↑((c ie.1)⁻¹)
+
+/-- A scalar edge family is vertex-balanced if the oriented product of its
+endpoint scalars is `1` at every vertex. -/
+def IsVertexBalanced (c : (e : Edge G) → Units ℂ) : Prop :=
+  ∀ v : V, ∏ ie : IncidentEdge G v, edgeScalarAt (G := G) c v ie = 1
+
+/-- Two PEPS gauge families are equivalent modulo balanced edge scalars if,
+after inserting the corresponding endpoint scalars, they induce the same
+oriented edge action on every incident half-edge. -/
+def GaugeEquivalentModEdgeScalars (A : Tensor G d)
+    (X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ) : Prop :=
+  ∃ c : (e : Edge G) → Units ℂ,
+    IsVertexBalanced (G := G) c ∧
+      ∀ (v : V) (ie : IncidentEdge G v),
+        edgeGaugeAt A X v ie =
+          edgeScalarAt (G := G) c v ie • edgeGaugeAt A Y v ie
+
+/-- Balanced edge-scalar reweightings do not change the gauged tensor at a
+vertex. -/
+theorem GaugeEquivalentModEdgeScalars.gaugeVertex_eq
+    {A : Tensor G d}
+    {X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ}
+    (hXY : GaugeEquivalentModEdgeScalars (G := G) A X Y)
+    (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1))
+    (σ : Fin d) :
+    gaugeVertex A X v η σ = gaugeVertex A Y v η σ := by
+  rcases hXY with ⟨c, hc, hedge⟩
+  unfold gaugeVertex
+  refine Finset.sum_congr rfl ?_
+  intro η' _
+  have hprod :
+      ∏ ie : IncidentEdge G v, edgeGaugeAt A X v ie (η ie) (η' ie) =
+        ∏ ie : IncidentEdge G v, edgeGaugeAt A Y v ie (η ie) (η' ie) := by
+    calc
+      ∏ ie : IncidentEdge G v, edgeGaugeAt A X v ie (η ie) (η' ie) =
+          ∏ ie : IncidentEdge G v,
+            edgeScalarAt (G := G) c v ie *
+              edgeGaugeAt A Y v ie (η ie) (η' ie) := by
+            refine Finset.prod_congr rfl ?_
+            intro ie _
+            have hEntry := congrArg (fun M => M (η ie) (η' ie)) (hedge v ie)
+            simpa [Matrix.smul_apply, smul_eq_mul] using hEntry
+      _ = (∏ ie : IncidentEdge G v, edgeScalarAt (G := G) c v ie) *
+            ∏ ie : IncidentEdge G v, edgeGaugeAt A Y v ie (η ie) (η' ie) := by
+            rw [Finset.prod_mul_distrib]
+      _ = ∏ ie : IncidentEdge G v, edgeGaugeAt A Y v ie (η ie) (η' ie) := by
+            rw [hc v, one_mul]
+  rw [hprod]
+
+/-! ### Uniqueness modulo balanced edge scalars -/
+
+/-- **Gauge uniqueness modulo balanced edge scalars** (arXiv:1804.04964,
+Theorem 2, uniqueness clause, repaired form).
+
+If `X` and `Y` are two gauge families relating the same pair of injective PEPS,
+then they should represent the same gauge class modulo edge-wise nonzero
+scalars whose oriented product is `1` at every vertex. This replaces the
+earlier global-scalar conclusion, which is refuted by the connected-triangle,
+bond-dimension-`1` counterexample discussed in issue #762. -/
+theorem gauge_unique_mod_edge_scalars (A B : Tensor G d)
     (hA : IsVertexInjective A)
     (hDim : A.bondDim = B.bondDim)
     (X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ)
@@ -590,18 +649,16 @@ theorem gauge_unique_up_to_scalar (A B : Tensor G d)
         (σ : Fin d),
       B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
         gaugeVertex A Y v η σ) :
-    ∃ (c : ℂ), c ≠ 0 ∧ ∀ (e : Edge G),
-      (X e).val = c • (Y e).val := by
-  -- TODO: the current statement is too strong. The issue-#503 discussion gives
-  -- a connected triangle counterexample with bond dimension `1`, where two
-  -- nontrivial gauge families act trivially on every vertex but are not related
-  -- by one global scalar.
-  --
-  -- The eventual replacement needs two ingredients:
-  -- 1. statement repair, adding the right normalization or cocycle data for the
-  --    edge gauges;
-  -- 2. a uniqueness proof for that corrected statement, downstream of the
-  --    virtual-insertion / blocking argument from arXiv:1804.04964 §3.
+    GaugeEquivalentModEdgeScalars (G := G) A X Y := by
+  -- TODO: compare `hX` and `hY` vertexwise and use linear independence of
+  -- `A.component v` to extract scalar ratios on each incident edge.
+  -- The remaining missing ingredient is the tensor-factor uniqueness lemma:
+  -- if two products of oriented edge gauges act identically on an injective
+  -- vertex tensor, then the factors differ by nonzero scalars whose product
+  -- is `1` at that vertex. Assembling these local scalar relations into a
+  -- single edge family gives the desired balanced quotient relation.
+  -- This is the repaired uniqueness endpoint for PEPS gauges; the former
+  -- global-scalar statement was false on the triangle counterexample.
   sorry
 
 end PEPS

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -587,7 +587,7 @@ def IsVertexBalanced (c : (e : Edge G) → Units ℂ) : Prop :=
 /-- Two PEPS gauge families are equivalent modulo balanced edge scalars if,
 after inserting the corresponding endpoint scalars, they induce the same
 oriented edge action on every incident half-edge. -/
-def GaugeEquivalentModEdgeScalars (A : Tensor G d)
+def GaugeEquivModEdgeScalars (A : Tensor G d)
     (X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ) : Prop :=
   ∃ c : (e : Edge G) → Units ℂ,
     IsVertexBalanced (G := G) c ∧
@@ -597,10 +597,10 @@ def GaugeEquivalentModEdgeScalars (A : Tensor G d)
 
 /-- Balanced edge-scalar reweightings do not change the gauged tensor at a
 vertex. -/
-theorem GaugeEquivalentModEdgeScalars.gaugeVertex_eq
+theorem GaugeEquivModEdgeScalars.gaugeVertex_eq
     {A : Tensor G d}
     {X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ}
-    (hXY : GaugeEquivalentModEdgeScalars (G := G) A X Y)
+    (hXY : GaugeEquivModEdgeScalars (G := G) A X Y)
     (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1))
     (σ : Fin d) :
     gaugeVertex A X v η σ = gaugeVertex A Y v η σ := by
@@ -633,7 +633,7 @@ theorem GaugeEquivalentModEdgeScalars.gaugeVertex_eq
 Theorem 2, uniqueness clause, repaired form).
 
 If `X` and `Y` are two gauge families relating the same pair of injective PEPS,
-then they should represent the same gauge class modulo edge-wise nonzero
+then they represent the same gauge class modulo edge-wise nonzero
 scalars whose oriented product is `1` at every vertex. This replaces the
 earlier global-scalar conclusion, which is refuted by the connected-triangle,
 bond-dimension-`1` counterexample discussed in issue #762. -/
@@ -649,7 +649,7 @@ theorem gauge_unique_mod_edge_scalars (A B : Tensor G d)
         (σ : Fin d),
       B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
         gaugeVertex A Y v η σ) :
-    GaugeEquivalentModEdgeScalars (G := G) A X Y := by
+    GaugeEquivModEdgeScalars (G := G) A X Y := by
   -- TODO: compare `hX` and `hY` vertexwise and use linear independence of
   -- `A.component v` to extract scalar ratios on each incident edge.
   -- The remaining missing ingredient is the tensor-factor uniqueness lemma:

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1646,15 +1646,43 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     (Theorem~2 of~\cite{Molnar2018NormalPEPS}).
 \end{theorem}
 
-\begin{remark}[Scalar-uniqueness caveat]
-    \lean{TNLean.PEPS.gauge_unique_up_to_scalar}
-    The stated global-scalar uniqueness claim is too strong.
-    On a triangle with all bond dimensions equal to $1$, edge scalars
-    $(a,a^{-1},a)$ preserve every local tensor yet are not all multiples of
-    $(1,1,1)$ when $a \neq \pm 1$.
-    The expected uniqueness statement must therefore quotient the residual
-    edge-gauge freedom by a cocycle-type normalization on the graph.
-\end{remark}
+\begin{definition}[Gauge equivalence modulo balanced edge scalars]%
+    \label{def:GaugeEquivalentModEdgeScalars}
+    \lean{TNLean.PEPS.GaugeEquivalentModEdgeScalars}
+    \leanok
+    \uses{def:edgeGaugeAt}
+    Two gauge families are equivalent modulo balanced edge scalars if there is
+    a nonzero scalar $c_e$ on each edge such that the corresponding endpoint
+    actions rescale the oriented edge gauges, and the oriented product of those
+    endpoint scalars is $1$ at every vertex.
+\end{definition}
+
+\begin{theorem}[Balanced edge scalars preserve the local gauge action]%
+    \label{thm:GaugeEquivalentModEdgeScalars_gaugeVertex_eq}
+    \lean{TNLean.PEPS.GaugeEquivalentModEdgeScalars.gaugeVertex_eq}
+    \leanok
+    \uses{def:GaugeEquivalentModEdgeScalars, def:gaugeVertex}
+    If two gauge families differ by a balanced edge-scalar reweighting, then
+    they produce the same gauged tensor at every vertex.
+\end{theorem}
+
+\begin{proof}\leanok\uses{def:GaugeEquivalentModEdgeScalars, def:gaugeVertex}
+    In the defining sum for the gauged tensor, each incident edge contributes
+    its endpoint scalar factor in addition to the original gauge entry.
+    The product of these endpoint scalars is $1$ by the balancing condition,
+    so every summand is unchanged.
+\end{proof}
+
+\begin{theorem}[Gauge uniqueness modulo balanced edge scalars]%
+    \label{thm:gauge_unique_mod_edge_scalars}
+    \lean{TNLean.PEPS.gauge_unique_mod_edge_scalars}
+    \notready
+    \uses{def:GaugeEquivalentModEdgeScalars, def:IsVertexInjective}
+    If two gauge families relate the same injective PEPS tensor to the same
+    target tensor, then they should define the same class modulo balanced edge
+    scalars. This replaces the earlier global-scalar claim, which is false on
+    a triangle with bond dimension $1$.
+\end{theorem}
 
 \begin{remark}
     The local left inverse $\Psi_v$, the realization map $T \mapsto O_T$,
@@ -1663,11 +1691,10 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     data needed for the edge-centered reduction of
     ~\cite{Molnar2018NormalPEPS}, §3. The remaining three PEPS theorems still
     require the blocked tensor on the middle region and the comparison with the
-    corresponding three-site injective chain. For the uniqueness endpoint, the
-    current global-scalar conclusion is too strong: a connected triangle with
-    bond dimension $1$ admits nontrivial edge rescalings whose vertex products
-    are all $1$. A corrected statement will need an explicit normalization of
-    the edge gauges.
+    corresponding three-site injective chain. The uniqueness endpoint has now
+    been repaired to a quotient by balanced edge scalars, but its proof still
+    requires the same blocking machinery together with the corresponding
+    tensor-factor uniqueness statement at a single vertex.
 \end{remark}
 
 %% ---------------------------------------------------------

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1647,8 +1647,8 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
 \end{theorem}
 
 \begin{definition}[Gauge equivalence modulo balanced edge scalars]%
-    \label{def:GaugeEquivalentModEdgeScalars}
-    \lean{TNLean.PEPS.GaugeEquivalentModEdgeScalars}
+    \label{def:GaugeEquivModEdgeScalars}
+    \lean{TNLean.PEPS.GaugeEquivModEdgeScalars}
     \leanok
     \uses{def:edgeGaugeAt}
     Two gauge families are equivalent modulo balanced edge scalars if there is
@@ -1658,15 +1658,15 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
 \end{definition}
 
 \begin{theorem}[Balanced edge scalars preserve the local gauge action]%
-    \label{thm:GaugeEquivalentModEdgeScalars_gaugeVertex_eq}
-    \lean{TNLean.PEPS.GaugeEquivalentModEdgeScalars.gaugeVertex_eq}
+    \label{thm:GaugeEquivModEdgeScalars_gaugeVertex_eq}
+    \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.gaugeVertex_eq}
     \leanok
-    \uses{def:GaugeEquivalentModEdgeScalars, def:gaugeVertex}
+    \uses{def:GaugeEquivModEdgeScalars, def:gaugeVertex}
     If two gauge families differ by a balanced edge-scalar reweighting, then
     they produce the same gauged tensor at every vertex.
 \end{theorem}
 
-\begin{proof}\leanok\uses{def:GaugeEquivalentModEdgeScalars, def:gaugeVertex}
+\begin{proof}\leanok\uses{def:GaugeEquivModEdgeScalars, def:gaugeVertex}
     In the defining sum for the gauged tensor, each incident edge contributes
     its endpoint scalar factor in addition to the original gauge entry.
     The product of these endpoint scalars is $1$ by the balancing condition,
@@ -1677,9 +1677,9 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \label{thm:gauge_unique_mod_edge_scalars}
     \lean{TNLean.PEPS.gauge_unique_mod_edge_scalars}
     \notready
-    \uses{def:GaugeEquivalentModEdgeScalars, def:IsVertexInjective}
+    \uses{def:GaugeEquivModEdgeScalars, def:IsVertexInjective}
     If two gauge families relate the same injective PEPS tensor to the same
-    target tensor, then they should define the same class modulo balanced edge
+    target tensor, then they define the same class modulo balanced edge
     scalars. This replaces the earlier global-scalar claim, which is false on
     a triangle with bond dimension $1$.
 \end{theorem}


### PR DESCRIPTION
## Summary
- replace the false PEPS global-scalar uniqueness endpoint with a balanced edge-scalar quotient
- add the supporting Lean definitions and the invariant `GaugeEquivalentModEdgeScalars.gaugeVertex_eq`
- sync the PEPS blueprint section and the injectivity note with the repaired statement

## Why
Issue #762 calls out that `gauge_unique_up_to_scalar` was too strong: on a connected triangle with bond dimension `1`, edge scalars can preserve every local tensor without coming from one shared global scalar. This PR removes that false claim from the environment and replaces it with a statement that matches the current gauge API and the known counterexample.

## Validation
- `lake build TNLean.PEPS.FundamentalTheorem`
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`

## Notes
- The module still has the four pre-existing scaffold `sorry`s, including the repaired uniqueness endpoint.
- `leanblueprint checkdecls` is currently blocked in this checkout because `blueprint/lean_decls` is absent.

Closes #762.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the stated PEPS gauge-uniqueness endpoint and introduces new equivalence/normalization definitions, which may affect downstream theorem dependencies even though the main proof remains `sorry`-scaffolded.
> 
> **Overview**
> Repairs the PEPS Fundamental Theorem scaffold by **removing the false global-scalar gauge uniqueness endpoint** and replacing it with **uniqueness modulo balanced edge scalars** (to match the known triangle bond-dim-1 counterexample).
> 
> Adds Lean definitions for endpoint edge scalars and the vertex-balancing condition, plus `GaugeEquivModEdgeScalars` and a proved lemma `GaugeEquivModEdgeScalars.gaugeVertex_eq` showing these scalar reweightings do not change `gaugeVertex`. Documentation/comments (including the blueprint text and injectivity note) are updated to reflect the repaired statement and renamed endpoint `gauge_unique_mod_edge_scalars`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e7115f69f861ddaf93287472a000bae760ca36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->