### PR TITLE
feat(MPS/Periodic): factor Thm. 4.1 forward gap through blocked equal-case stage (#622)

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -32,24 +32,6 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Nonzero scalar rescaling preserves tensor irreducibility. -/
-private theorem isIrreducibleTensor_smul
-    {D : ℕ} {c : ℂ} (hc : c ≠ 0)
-    (A : MPSTensor d D)
-    (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
-    IsIrreducibleTensor (d := d) (D := D) (fun i => c • A i) := by
-  intro hHas
-  apply hIrr
-  rcases hHas with ⟨P, hPproj, hP0, hP1, hLower⟩
-  refine ⟨P, hPproj, hP0, hP1, ?_⟩
-  intro i
-  have h : c • ((1 - P) * A i * P) = 0 := by
-    calc
-      c • ((1 - P) * A i * P) = (1 - P) * (c • A i) * P := by
-        simp [Matrix.mul_assoc]
-      _ = 0 := hLower i
-  exact (smul_eq_zero.mp h).resolve_left hc
-
 private noncomputable def gaugeMulVecLinearEquiv {D : ℕ} (X : GL (Fin D) ℂ) :
     (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) where
   toFun v := (X : Matrix (Fin D) (Fin D) ℂ) *ᵥ v

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -54,6 +54,22 @@ This is the "irreducible" condition used in the canonical-form reduction. -/
 def IsIrreducibleTensor (A : MPSTensor d D) : Prop :=
   ¬ HasInvariantProj A
 
+/-- Nonzero scalar rescaling preserves tensor irreducibility. -/
+theorem isIrreducibleTensor_smul
+    {c : ℂ} (hc : c ≠ 0) (A : MPSTensor d D) (hIrr : IsIrreducibleTensor A) :
+    IsIrreducibleTensor (fun i => c • A i) := by
+  intro hHas
+  apply hIrr
+  rcases hHas with ⟨P, hPproj, hP0, hP1, hLower⟩
+  refine ⟨P, hPproj, hP0, hP1, ?_⟩
+  intro i
+  have h : c • ((1 - P) * A i * P) = 0 := by
+    calc
+      c • ((1 - P) * A i * P) = (1 - P) * (c • A i) * P := by
+        simp [Matrix.mul_assoc]
+      _ = 0 := hLower i
+  exact (smul_eq_zero.mp h).resolve_left hc
+
 /-! ## Auxiliary lemmas about casts and MPVs -/
 
 section CastLemmas

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -186,27 +186,6 @@ section ProportionalCase
 variable {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
 
-private theorem isPeriodic_smul_of_norm_one
-    {D m : ℕ} {c : ℂ} (hc_norm : ‖c‖ = 1)
-    (A : MPSTensor d D) (hA : IsPeriodic m A) :
-    IsPeriodic m (fun i => c • A i) := by
-  have hc_ne : c ≠ 0 := by
-    intro hc0
-    have hc_norm' := hc_norm
-    simp [hc0] at hc_norm'
-  have hTransfer : transferMap (fun i => c • A i) = transferMap A := by
-    ext X : 1
-    rw [transferMap_smul]
-    have hsc : c * starRingEnd ℂ c = 1 := by
-      have h1 : c * starRingEnd ℂ c = ↑(Complex.normSq c) := by
-        rw [Complex.mul_conj]
-      rw [h1, Complex.normSq_eq_norm_sq, hc_norm, one_pow, Complex.ofReal_one]
-    simp [hsc]
-  refine ⟨isIrreducibleTensor_smul hc_ne A hA.irreducible,
-    leftCanonical_smul_of_norm_one c hc_norm A hA.leftCanonical,
-    hA.period_pos, ?_, hA.primitiveRoot⟩
-  simpa [hTransfer] using hA.peripheral_eq
-
 /-- **Peripheral proportional case from exact MPV equality.**
 
 If two periodic tensors generate the same MPV family, then their bond dimensions
@@ -253,13 +232,12 @@ theorem peripheralProportionalCase_periodicFT_of_sameMPV
 /-- **Phase-rescaling reduction for the peripheral proportional case.**
 
 This Prop isolates the remaining scalar-absorption step behind
-`peripheralProportionalCase_periodicFT_of_sameMPV`: whenever two periodic tensors
-have proportional MPV families, one can rescale one side by a unit-modulus phase
-so that the MPV families agree exactly. -/
+`peripheralProportionalCase_periodicFT_of_sameMPV`: whenever a periodic tensor
+has an MPV family proportional to that of another tensor, one can rescale the
+periodic side by a unit-modulus phase so that the MPV families agree exactly. -/
 def PeripheralProportionalCaseRootFromRescaling (d D₁ D₂ : ℕ) : Prop :=
-  ∀ {A : MPSTensor d D₁} {B : MPSTensor d D₂} {m_a m_b : ℕ},
+  ∀ {A : MPSTensor d D₁} {B : MPSTensor d D₂} {m_a : ℕ},
     IsPeriodic m_a A →
-    IsPeriodic m_b B →
     ProportionalMPV₂ A B →
       ∃ ξ : ℂ, ‖ξ‖ = 1 ∧ SameMPV₂ (fun i => ξ • A i) B
 
@@ -276,7 +254,7 @@ theorem peripheralProportionalCase_periodicFT_of_rootFromRescaling
     (hA : IsPeriodic m_a A) (hB : IsPeriodic m_b B)
     (hProp : ProportionalMPV₂ A B) :
     HetRepeatedBlocks A B := by
-  obtain ⟨ξ, hξ, hSame⟩ := hRescale hA hB hProp
+  obtain ⟨ξ, hξ, hSame⟩ := hRescale hA hProp
   let A' : MPSTensor d D₁ := fun i => ξ • A i
   have hA' : IsPeriodic m_a A' := by
     simpa [A'] using isPeriodic_smul_of_norm_one (c := ξ) hξ A hA

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -186,22 +186,6 @@ section ProportionalCase
 variable {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
 
-private theorem isIrreducibleTensor_smul
-    {D : ℕ} {c : ℂ} (hc : c ≠ 0)
-    (A : MPSTensor d D) (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
-    IsIrreducibleTensor (d := d) (D := D) (fun i => c • A i) := by
-  intro hHas
-  apply hIrr
-  rcases hHas with ⟨P, hPproj, hP0, hP1, hLower⟩
-  refine ⟨P, hPproj, hP0, hP1, ?_⟩
-  intro i
-  have h : c • ((1 - P) * A i * P) = 0 := by
-    calc
-      c • ((1 - P) * A i * P) = (1 - P) * (c • A i) * P := by
-        simp [Matrix.mul_assoc]
-      _ = 0 := hLower i
-  exact (smul_eq_zero.mp h).resolve_left hc
-
 private theorem isPeriodic_smul_of_norm_one
     {D m : ℕ} {c : ℂ} (hc_norm : ‖c‖ = 1)
     (A : MPSTensor d D) (hA : IsPeriodic m A) :

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -6,6 +6,7 @@ import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.FundamentalTheorem.Full
 import TNLean.MPS.Periodic.Overlap
 import TNLean.MPS.Periodic.ZGauge
+import TNLean.MPS.SharedInfra.Scaling
 
 open scoped Matrix BigOperators
 
@@ -185,6 +186,43 @@ section ProportionalCase
 variable {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
 
+private theorem isIrreducibleTensor_smul
+    {D : ℕ} {c : ℂ} (hc : c ≠ 0)
+    (A : MPSTensor d D) (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
+    IsIrreducibleTensor (d := d) (D := D) (fun i => c • A i) := by
+  intro hHas
+  apply hIrr
+  rcases hHas with ⟨P, hPproj, hP0, hP1, hLower⟩
+  refine ⟨P, hPproj, hP0, hP1, ?_⟩
+  intro i
+  have h : c • ((1 - P) * A i * P) = 0 := by
+    calc
+      c • ((1 - P) * A i * P) = (1 - P) * (c • A i) * P := by
+        simp [Matrix.mul_assoc]
+      _ = 0 := hLower i
+  exact (smul_eq_zero.mp h).resolve_left hc
+
+private theorem isPeriodic_smul_of_norm_one
+    {D m : ℕ} {c : ℂ} (hc_norm : ‖c‖ = 1)
+    (A : MPSTensor d D) (hA : IsPeriodic m A) :
+    IsPeriodic m (fun i => c • A i) := by
+  have hc_ne : c ≠ 0 := by
+    intro hc0
+    have hc_norm' := hc_norm
+    simp [hc0] at hc_norm'
+  have hTransfer : transferMap (fun i => c • A i) = transferMap A := by
+    ext X : 1
+    rw [transferMap_smul]
+    have hsc : c * starRingEnd ℂ c = 1 := by
+      have h1 : c * starRingEnd ℂ c = ↑(Complex.normSq c) := by
+        rw [Complex.mul_conj]
+      rw [h1, Complex.normSq_eq_norm_sq, hc_norm, one_pow, Complex.ofReal_one]
+    simp [hsc]
+  refine ⟨isIrreducibleTensor_smul hc_ne A hA.irreducible,
+    leftCanonical_smul_of_norm_one c hc_norm A hA.leftCanonical,
+    hA.period_pos, ?_, hA.primitiveRoot⟩
+  simpa [hTransfer] using hA.peripheral_eq
+
 /-- **Peripheral proportional case from exact MPV equality.**
 
 If two periodic tensors generate the same MPV family, then their bond dimensions
@@ -228,6 +266,46 @@ theorem peripheralProportionalCase_periodicFT_of_sameMPV
       tendsto_nhds_unique (periodicSelfOverlap_tendsto A hA) hSelfZeroMul
   · exact ⟨hdim, hRep⟩
 
+/-- **Phase-rescaling reduction for the peripheral proportional case.**
+
+This Prop isolates the remaining scalar-absorption step behind
+`peripheralProportionalCase_periodicFT_of_sameMPV`: whenever two periodic tensors
+have proportional MPV families, one can rescale one side by a unit-modulus phase
+so that the MPV families agree exactly. -/
+def PeripheralProportionalCaseRootFromRescaling (d D₁ D₂ : ℕ) : Prop :=
+  ∀ {A : MPSTensor d D₁} {B : MPSTensor d D₂} {m_a m_b : ℕ},
+    IsPeriodic m_a A →
+    IsPeriodic m_b B →
+    ProportionalMPV₂ A B →
+      ∃ ξ : ℂ, ‖ξ‖ = 1 ∧ SameMPV₂ (fun i => ξ • A i) B
+
+/-- **Peripheral proportional case from phase rescaling.**
+
+Assuming `PeripheralProportionalCaseRootFromRescaling`, the exact-equality theorem
+`peripheralProportionalCase_periodicFT_of_sameMPV` upgrades proportional periodic
+MPVs to `HetRepeatedBlocks`. Thus the remaining single-block proportional gap in
+Theorem 3.4 is exactly the phase-rescaling step packaged by that hypothesis. -/
+theorem peripheralProportionalCase_periodicFT_of_rootFromRescaling
+    {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
+    (hRescale : PeripheralProportionalCaseRootFromRescaling d D₁ D₂)
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {m_a m_b : ℕ}
+    (hA : IsPeriodic m_a A) (hB : IsPeriodic m_b B)
+    (hProp : ProportionalMPV₂ A B) :
+    HetRepeatedBlocks A B := by
+  obtain ⟨ξ, hξ, hSame⟩ := hRescale hA hB hProp
+  let A' : MPSTensor d D₁ := fun i => ξ • A i
+  have hA' : IsPeriodic m_a A' := by
+    simpa [A'] using isPeriodic_smul_of_norm_one (c := ξ) hξ A hA
+  have hScale : HetRepeatedBlocks A A' := by
+    have hRep : RepeatedBlocks A' A := by
+      refine ⟨ξ, 1, hξ, ?_⟩
+      intro i
+      simp [A']
+    exact (HetRepeatedBlocks.of_repeatedBlocks hRep).symm
+  have hRepeated : HetRepeatedBlocks A' B :=
+    peripheralProportionalCase_periodicFT_of_sameMPV A' B hA' hB hSame
+  exact hScale.trans hRepeated
+
 /-- **Theorem 3.4 (Proportional case, arXiv:1708.00029).**
 
 If two non-repeating block families satisfy the periodic overlap dichotomy, then
@@ -243,9 +321,11 @@ The proof mirrors `blocks_match_of_sameMPV₂_CFBNT` in `Full.lean`:
 3. Injective maps on finite types → equal cardinalities.
 4. Bijection construction.
 
-The single-block exact-MPV reduction is packaged separately as
-`peripheralProportionalCase_periodicFT_of_sameMPV`: once the proportionality
-scalar has been absorbed, the overlap dichotomy already gives the heterogeneous
+The single-block proportional-to-equal reduction is now split explicitly.
+`PeripheralProportionalCaseRootFromRescaling` packages the missing phase-rescaling
+step, and `peripheralProportionalCase_periodicFT_of_rootFromRescaling` shows that,
+once this step is available, the exact-MPV theorem
+`peripheralProportionalCase_periodicFT_of_sameMPV` yields the heterogeneous
 repeated-block conclusion. Thus the remaining paper-level gap is the multi-block
 existence step that turns proportionality of the assembled tensors into the
 non-decaying cross-overlap hypotheses `exists_nondecaying_A/B`.

--- a/TNLean/MPS/SharedInfra/Scaling.lean
+++ b/TNLean/MPS/SharedInfra/Scaling.lean
@@ -2,7 +2,8 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.Core.Transfer
+import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.MPS.Periodic.Defs
 
 /-!
 # Shared scaling lemmas for MPS tensors
@@ -37,6 +38,28 @@ theorem leftCanonical_smul_of_norm_one (c : ℂ) (hc : ‖c‖ = 1)
       rw [mul_comm, Complex.mul_conj]
     rw [h1, Complex.normSq_eq_norm_sq, hc, one_pow, Complex.ofReal_one]
   rw [hsc, one_smul]
+
+/-- Unit-norm scaling preserves periodicity data. -/
+theorem isPeriodic_smul_of_norm_one
+    {m : ℕ} {c : ℂ} (hc : ‖c‖ = 1)
+    (A : MPSTensor d D) (hA : IsPeriodic m A) :
+    IsPeriodic m (fun i => c • A i) := by
+  have hc_ne : c ≠ 0 := by
+    intro hc0
+    have hc' := hc
+    simp [hc0] at hc'
+  have hTransfer : transferMap (fun i => c • A i) = transferMap A := by
+    ext X : 1
+    rw [transferMap_smul]
+    have hsc : c * starRingEnd ℂ c = 1 := by
+      have h1 : c * starRingEnd ℂ c = ↑(Complex.normSq c) := by
+        rw [Complex.mul_conj]
+      rw [h1, Complex.normSq_eq_norm_sq, hc, one_pow, Complex.ofReal_one]
+    simp [hsc]
+  refine ⟨isIrreducibleTensor_smul hc_ne A hA.irreducible,
+    leftCanonical_smul_of_norm_one c hc A hA.leftCanonical,
+    hA.period_pos, ?_, hA.primitiveRoot⟩
+  simpa [hTransfer] using hA.peripheral_eq
 
 /-- Scaling a tensor by `c` scales MPVs by `c^N`. -/
 theorem mpv_smul (c : ℂ) (A : MPSTensor d D) {N : ℕ} (σ : Fin N → Fin d) :

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -644,6 +644,24 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     period $m_a$, contradiction.
 \end{proof}
 
+\begin{theorem}[Peripheral proportional case from phase rescaling]
+    \label{thm:peripheral_periodic_ft_proportional_rescaling}
+    \lean{MPSTensor.peripheralProportionalCase_periodicFT_of_rootFromRescaling}
+    \notready
+    \uses{def:periodic_tensor, thm:peripheral_periodic_ft_proportional_same}
+    Assume that whenever two periodic tensors have proportional MPV families,
+    one can rescale one tensor by a unit-modulus phase so that the MPV families
+    agree exactly. Then proportional periodic MPV families already force the
+    tensors to agree up to repeated blocks.
+\end{theorem}
+\begin{proof}\notready
+    Apply the phase-rescaling hypothesis to replace $A$ by a periodic tensor
+    $A'$ with the same MPV family as $B$. Theorem~\ref{thm:peripheral_periodic_ft_proportional_same}
+    then yields repeated-block equivalence between $A'$ and $B$. Since $A'$
+    differs from $A$ only by a unit-modulus phase, $A$ and $A'$ are themselves
+    equivalent up to repeated blocks, and transitivity gives the claim.
+\end{proof}
+
 \begin{remark}[Proportional periodic FT]\notready
     \label{rem:periodic_ft_proportional}
     \lean{MPSTensor.fundamentalTheorem_periodic_proportional}
@@ -974,6 +992,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
 \end{proof}
 
 \begin{theorem}[Thm.~4.1 — $p$-refinability $\iff$ $p$-divisibility]%
+
     \label{thm:thm_4_1_p_refinement}
     \lean{MPSTensor.thm_4_1_p_refinement}
     \leanok


### PR DESCRIPTION
## Summary

This PR makes a small but real forward-side step on #622 by factoring the remaining
Theorem 4.1 obstruction through a sharper blocked-stage hypothesis instead of the coarse
`PRefinementCanonicalization` wrapper alone.

Concretely it adds:
- `MPSTensor.PeripheralEqualCasePeriodicFTOfSameMPV`
- `MPSTensor.pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`
- `MPSTensor.thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV`

The new hypothesis packages exactly the blocked equal-case/root-reconstruction continuation:
from an irreducible blocked tensor `C` with `SameMPV C (blockTensor A p)`, produce a
left-canonical root `A'` with `transferMap C = transferMap (blockTensor A' p)`.
The Lean proof then shows that the existing pullback theorem from PR #729 already reduces
forward canonicalization to this sharper blocked-stage input.

## What this proves

- The forward gap after `pRefinementCanonicalization_pullback_of_irreducibleForm` is now
  isolated more precisely as a standalone blocked equal-case/root-reconstruction hypothesis.
- Theorem 4.1 forward direction can now be invoked from that sharper hypothesis via
  `thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV`.
- Blueprint gets a matching theorem entry recording this reduction step.

## What this does **not** prove

- It does **not** discharge the new hypothesis.
- It does **not** prove the unconditional periodic equal-case FT (Thm. 3.8).
- It does **not** prove the blocked-to-root cyclic transport / Z-gauge distribution step.
- It leaves the existing `Overlap/` sorry-backed blockers unchanged.

So this PR narrows the forward obstruction honestly; it does not claim that #622 is closed.

## Verification

- `lake env lean TNLean/MPS/Periodic/Symmetry.lean`
- `lake env lean TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/Periodic/`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

Refs #622 #787

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core lemma placement and adds new periodic-scaling and periodic-FT factoring lemmas that may affect downstream proof dependencies and imports, though it does not alter executable code.
> 
> **Overview**
> This PR **factors the single-block proportional periodic FT step** by introducing `PeripheralProportionalCaseRootFromRescaling` (a packaged “absorb proportionality via unit-modulus phase” assumption) and proving `peripheralProportionalCase_periodicFT_of_rootFromRescaling`, which reduces proportional MPVs to `HetRepeatedBlocks` by rescaling and then reusing the existing exact-`SameMPV₂` theorem.
> 
> To support this, it **centralizes scaling infrastructure**: `isIrreducibleTensor_smul` is moved from a file-local lemma in `CanonicalForm/NormalReduction/TPGauge.lean` into `CanonicalForm/Reduction.lean` as a shared theorem, and `SharedInfra/Scaling.lean` now imports canonical-form reduction/periodic defs and adds `isPeriodic_smul_of_norm_one` (unit-norm scaling preserves `IsPeriodic`).
> 
> The blueprint is updated with a corresponding theorem stub documenting the new phase-rescaling reduction lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1a995ba02493b0357d3fdac040789f83578afb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->