### PR TITLE
feat(MPS/Periodic): split blocked equal-case continuation via Z-gauge extraction (#787)

### DIFF
--- a/TNLean/MPS/Periodic/Symmetry.lean
+++ b/TNLean/MPS/Periodic/Symmetry.lean
@@ -34,6 +34,8 @@ The imported modules provide the original public declarations at the same
 names, including `PeriodicEqualCaseFT`,
 `cor_4_1_physical_symmetry_zgauge`,
 `pRefinementCanonicalization_pullback_of_irreducibleForm`,
+`PeripheralEqualCaseZGaugeOfSameMPV`, `PeripheralEqualCaseRootFromZGauge`,
+`peripheralEqualCase_periodicFT_of_sameMPV`,
 `PeripheralEqualCasePeriodicFTOfSameMPV`,
 `pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`,
 `thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV`,

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -345,6 +345,40 @@ theorem thm_4_1_p_refinement_forward_witness
   ⟨transferMap A, transferMap_isChannel A hA_norm, by
     rw [hTransferEq, transferMap_blockTensor]⟩
 
+/-- **Blocked Z-gauge extraction for the periodic equal-case stage.**
+
+This Prop isolates the existence half of the blocked equal-case argument needed
+for Theorem 4.1: whenever an irreducible-form blocked tensor `C` has the same
+MPV family as a blocked root `blockTensor A p`, one can extract a periodic
+`Z`-gauge witness between `C` and `blockTensor A p`.
+
+Compared with `PeripheralEqualCasePeriodicFTOfSameMPV`, this does **not** yet
+recover a left-canonical root. It only packages the blocked equal-case
+Fundamental Theorem / Z-phase existence step. -/
+def PeripheralEqualCaseZGaugeOfSameMPV (d D p : ℕ) : Prop :=
+  ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D},
+    IsIrreducibleForm C →
+    SameMPV C (blockTensor A p) →
+      ∃ m : ℕ, 0 < m ∧ ZGaugeEquiv m C (blockTensor A p)
+
+/-- **Blocked-to-root reconstruction from a periodic `Z`-gauge witness.**
+
+This Prop isolates the second half of the blocked equal-case argument: once a
+blocked tensor `C` is related to `blockTensor A p` by a periodic `Z`-gauge,
+one can distribute that blocked phase data across a root tensor `A'` so that
+`A'` is left-canonical and `E_C = E_{A'^{[p]}}`.
+
+In the paper this is the blocked-to-root phase-distribution step after the
+periodic equal-case Fundamental Theorem. -/
+def PeripheralEqualCaseRootFromZGauge (d D p : ℕ) : Prop :=
+  ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D} {m : ℕ},
+    IsIrreducibleForm C →
+    0 < m →
+    ZGaugeEquiv m C (blockTensor A p) →
+      ∃ A' : MPSTensor d D,
+        (∑ i : Fin d, (A' i)ᴴ * A' i = 1) ∧
+        transferMap C = transferMap (blockTensor A' p)
+
 /-- **Blocked equal-case/root-reconstruction hypothesis for Theorem 4.1.**
 
 This Prop isolates exactly the remaining forward input after
@@ -357,7 +391,10 @@ In the paper this is the point where the blocked equal-case Fundamental Theorem
 (Theorem 3.8 of arXiv:1708.00029) is combined with the blocked-to-root
 reconstruction that distributes the resulting `Z`-gauge across the cyclic
 sectors of `A`. Formalizing that existence step is the remaining forward
-obstruction, so we package its endpoint as a separate hypothesis. -/
+obstruction, so we package its endpoint as a separate hypothesis. The theorem
+`peripheralEqualCase_periodicFT_of_sameMPV` below shows that this endpoint
+follows from the sharper split into blocked `Z`-gauge extraction and
+blocked-to-root reconstruction. -/
 def PeripheralEqualCasePeriodicFTOfSameMPV (d D p : ℕ) : Prop :=
   ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D},
     IsIrreducibleForm C →
@@ -365,6 +402,24 @@ def PeripheralEqualCasePeriodicFTOfSameMPV (d D p : ℕ) : Prop :=
       ∃ A' : MPSTensor d D,
         (∑ i : Fin d, (A' i)ᴴ * A' i = 1) ∧
         transferMap C = transferMap (blockTensor A' p)
+
+/-- **Blocked equal-case continuation from Z-gauge extraction and reconstruction.**
+
+If we can first extract a blocked periodic `Z`-gauge from
+`SameMPV C (blockTensor A p)` and then distribute that blocked `Z`-phase back
+to a left-canonical root, then the continuation hypothesis
+`PeripheralEqualCasePeriodicFTOfSameMPV` holds.
+
+This splits the blocked equal-case continuation into two explicit obligations:
+the blocked equal-case `Z`-gauge existence step and the subsequent
+blocked-to-root reconstruction. -/
+theorem peripheralEqualCase_periodicFT_of_sameMPV
+    (hZGauge : PeripheralEqualCaseZGaugeOfSameMPV d D p)
+    (hRoot : PeripheralEqualCaseRootFromZGauge d D p) :
+    PeripheralEqualCasePeriodicFTOfSameMPV d D p := by
+  intro A C hC hSame
+  obtain ⟨m, hm, hZ⟩ := hZGauge (A := A) (C := C) hC hSame
+  exact hRoot (A := A) (C := C) (m := m) hC hm hZ
 
 /-- **Canonicalization hypothesis for the forward direction of Theorem 4.1.**
 

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -835,11 +835,11 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \uses{def:irreducible_form, def:blocked_tensor, def:z_gauge_equiv}
     Assume the following two statements.
     First, whenever a blocked tensor $C$ in irreducible form~II has the same
-    MPV family as a blocked tensor $A^{[p]}$, there exist an integer $m \ge 1$
+    MPV family as a blocked tensor $A^{[p]}$, there exists an integer $m \ge 1$
     and a $\mathbb Z_m$-gauge equivalence between $C$ and $A^{[p]}$.
-    Second, whenever a blocked tensor $C$ in irreducible form~II is
-    $\mathbb Z_m$-gauge equivalent to $A^{[p]}$, there exists a tensor $A'$
-    with $\sum_i (A'^i)^\dagger A'^i = \Id$ and
+    Second, for every integer $m \ge 1$, whenever a blocked tensor $C$ in
+    irreducible form~II is $\mathbb Z_m$-gauge equivalent to $A^{[p]}$, there
+    exists a tensor $A'$ with $\sum_i (A'^i)^\dagger A'^i = \Id$ and
     $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
     Then whenever $C$ in irreducible form~II has the same MPV family as
     $A^{[p]}$, there exists such a tensor $A'$.

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -828,6 +828,29 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     irreducible-form decomposition of $C$.
 \end{proof}
 
+\begin{theorem}[Blocked equal-case continuation from Z-gauge extraction]
+    \label{thm:peripheral_equalcase_sameMPV_zgauge_reduction}
+    \lean{MPSTensor.peripheralEqualCase_periodicFT_of_sameMPV}
+    \leanok
+    \uses{def:irreducible_form, def:blocked_tensor, def:z_gauge_equiv}
+    Assume the following two statements.
+    First, whenever a blocked tensor $C$ in irreducible form~II has the same
+    MPV family as a blocked tensor $A^{[p]}$, there exist an integer $m \ge 1$
+    and a $\mathbb Z_m$-gauge equivalence between $C$ and $A^{[p]}$.
+    Second, whenever a blocked tensor $C$ in irreducible form~II is
+    $\mathbb Z_m$-gauge equivalent to $A^{[p]}$, there exists a tensor $A'$
+    with $\sum_i (A'^i)^\dagger A'^i = \Id$ and
+    $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
+    Then whenever $C$ in irreducible form~II has the same MPV family as
+    $A^{[p]}$, there exists such a tensor $A'$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the first assumed statement to obtain a blocked $\mathbb Z_m$-gauge
+    witness between $C$ and $A^{[p]}$. Then apply the second assumed statement
+    to that witness.
+\end{proof}
+
 \begin{theorem}[Reduction of forward canonicalization to the blocked equal-case stage]
     \label{thm:p_refinement_forward_equalcase_reduction}
     \lean{MPSTensor.pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV}


### PR DESCRIPTION
## Summary
- split the blocked equal-case continuation used in Theorem 4.1 into two named obligations:
  a blocked Z-gauge extraction step and a blocked-to-root reconstruction step
- prove `MPSTensor.peripheralEqualCase_periodicFT_of_sameMPV`, which packages those two obligations into the existing continuation hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`
- sync the periodic FT blueprint chapter with the new reduction theorem

## Scope
This is the smallest honest progress for #787 available on top of #797:
it does **not** prove Theorem 3.8 outright, and it does **not** discharge the existence of the blocked Z-gauge or the blocked-to-root phase distribution. Instead it states that split precisely and connects it to the already-landed forward Theorem 4.1 reduction.

This PR is stacked on top of #797 (`feat/622-thm41-forward-v3`).

## Verification
- `cd .worktrees/issue-787-equal-case && lake env lean TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean`
- `cd .worktrees/issue-787-equal-case && lake env lean TNLean/MPS/Periodic/Symmetry.lean`
- `cd .worktrees/issue-787-equal-case && lake build`
- `cd .worktrees/issue-787-equal-case && rg -n "sorry|axiom" TNLean/MPS/Periodic/`
- `cd .worktrees/issue-787-equal-case && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new intermediate Prop obligations and a small glue theorem in the Theorem 4.1 forward development, plus documentation/blueprint sync, without changing existing proof endpoints.
> 
> **Overview**
> **Splits the blocked equal-case continuation used in Theorem 4.1 (forward direction)** into two explicit hypotheses: `PeripheralEqualCaseZGaugeOfSameMPV` (extract a periodic `ZGaugeEquiv` from `SameMPV`) and `PeripheralEqualCaseRootFromZGauge` (reconstruct a left-canonical root and transfer-map equality from a `ZGaugeEquiv`).
> 
> Adds `peripheralEqualCase_periodicFT_of_sameMPV`, a glue theorem showing these two obligations imply the existing continuation predicate `PeripheralEqualCasePeriodicFTOfSameMPV`, and exposes the new declarations via `TNLean.MPS.Periodic.Symmetry`. The blueprint chapter is updated with a corresponding reduction theorem statement and proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36d88a92ff4b87542f46b08b3270dc5bf2dcc04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->