### PR TITLE
feat(MPS/Periodic): add exact-MPV peripheral proportional reduction (#786)

### DIFF
--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -185,6 +185,48 @@ section ProportionalCase
 variable {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
 
+/-- **Peripheral proportional case from exact MPV equality.**
+
+If two periodic tensors generate the same MPV family, then they are repeated
+blocks. This is the single-block uniqueness direction behind Theorem 3.4 once the
+proportionality scalar has been absorbed into one side.
+
+The proof combines `periodicOverlapDichotomy` with `periodicSelfOverlap_tendsto`:
+the decay branch would force the self-overlap of `A` to tend to `0`, contradicting
+its periodic self-overlap limit `m_a` along the subsequence `m_a * ℕ`.
+
+As with `periodicOverlapDichotomy`, this theorem currently inherits the admitted
+sub-lemmas in `Periodic/Overlap`. -/
+theorem peripheralProportionalCase_periodicFT_of_sameMPV
+    {D : ℕ} [NeZero D]
+    (A B : MPSTensor d D) {m_a m_b : ℕ}
+    (hA : IsPeriodic m_a A) (hB : IsPeriodic m_b B)
+    (hSame : SameMPV A B) :
+    RepeatedBlocks A B := by
+  rcases periodicOverlapDichotomy A B hA hB with hDecay | ⟨hdim, hRep⟩
+  · have hSameOverlap : ∀ N : ℕ, mpvOverlap (d := d) A B N = mpvOverlap A A N := by
+      intro N
+      unfold mpvOverlap
+      refine Finset.sum_congr rfl ?_
+      intro σ _
+      rw [hSame N σ]
+    have hSelfZero : Filter.Tendsto (fun N => mpvOverlap A A N) Filter.atTop (nhds 0) :=
+      Filter.Tendsto.congr' (Filter.Eventually.of_forall hSameOverlap) hDecay
+    have hMulAtTop : Filter.Tendsto (fun k : ℕ => m_a * k) Filter.atTop Filter.atTop := by
+      rw [Filter.tendsto_atTop]
+      intro n
+      exact Filter.eventually_atTop.2 ⟨n, fun k hk => by
+        have hm_a : 1 ≤ m_a := Nat.succ_le_of_lt hA.period_pos
+        exact le_trans hk <| by simpa using Nat.mul_le_mul_right k hm_a⟩
+    have hSelfZeroMul :
+        Filter.Tendsto (fun k : ℕ => mpvOverlap A A (m_a * k)) Filter.atTop (nhds 0) :=
+      hSelfZero.comp hMulAtTop
+    have hm_ne : (m_a : ℂ) ≠ 0 := by
+      exact_mod_cast Nat.ne_of_gt hA.period_pos
+    exact False.elim <| hm_ne <| tendsto_nhds_unique (periodicSelfOverlap_tendsto A hA) hSelfZeroMul
+  · cases hdim
+    simpa using hRep
+
 /-- **Theorem 3.4 (Proportional case, arXiv:1708.00029).**
 
 If two non-repeating block families satisfy the periodic overlap dichotomy, then
@@ -199,6 +241,13 @@ The proof mirrors `blocks_match_of_sameMPV₂_CFBNT` in `Full.lean`:
 2. Injectivity from `HetRepeatedBlocks.trans` + non-repetition.
 3. Injective maps on finite types → equal cardinalities.
 4. Bijection construction.
+
+The single-block exact-MPV reduction is packaged separately as
+`peripheralProportionalCase_periodicFT_of_sameMPV`: once the proportionality
+scalar has been absorbed, the overlap dichotomy already gives the repeated-block
+conclusion. Thus the remaining paper-level gap is the multi-block existence step
+that turns proportionality of the assembled tensors into the non-decaying
+cross-overlap hypotheses `exists_nondecaying_A/B`.
 
 The `PeriodicOverlapHypothesis` parameter can be supplied via
 `PeriodicOverlapHypothesis.ofIsPeriodic`, which uses `periodicOverlapDichotomy`

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -187,8 +187,9 @@ variable {rA rB : ℕ}
 
 /-- **Peripheral proportional case from exact MPV equality.**
 
-If two periodic tensors generate the same MPV family, then they are repeated
-blocks. This is the single-block uniqueness direction behind Theorem 3.4 once the
+If two periodic tensors generate the same MPV family, then their bond dimensions
+agree and they are repeated blocks after identifying those bond spaces. This is
+the single-block uniqueness direction behind Theorem 3.4 once the
 proportionality scalar has been absorbed into one side.
 
 The proof combines `periodicOverlapDichotomy` with `periodicSelfOverlap_tendsto`:
@@ -198,11 +199,11 @@ its periodic self-overlap limit `m_a` along the subsequence `m_a * ℕ`.
 As with `periodicOverlapDichotomy`, this theorem currently inherits the admitted
 sub-lemmas in `Periodic/Overlap`. -/
 theorem peripheralProportionalCase_periodicFT_of_sameMPV
-    {D : ℕ} [NeZero D]
-    (A B : MPSTensor d D) {m_a m_b : ℕ}
+    {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {m_a m_b : ℕ}
     (hA : IsPeriodic m_a A) (hB : IsPeriodic m_b B)
-    (hSame : SameMPV A B) :
-    RepeatedBlocks A B := by
+    (hSame : SameMPV₂ A B) :
+    HetRepeatedBlocks A B := by
   rcases periodicOverlapDichotomy A B hA hB with hDecay | ⟨hdim, hRep⟩
   · have hSameOverlap : ∀ N : ℕ, mpvOverlap (d := d) A B N = mpvOverlap A A N := by
       intro N
@@ -223,9 +224,9 @@ theorem peripheralProportionalCase_periodicFT_of_sameMPV
       hSelfZero.comp hMulAtTop
     have hm_ne : (m_a : ℂ) ≠ 0 := by
       exact_mod_cast Nat.ne_of_gt hA.period_pos
-    exact False.elim <| hm_ne <| tendsto_nhds_unique (periodicSelfOverlap_tendsto A hA) hSelfZeroMul
-  · cases hdim
-    simpa using hRep
+    exact False.elim <| hm_ne <|
+      tendsto_nhds_unique (periodicSelfOverlap_tendsto A hA) hSelfZeroMul
+  · exact ⟨hdim, hRep⟩
 
 /-- **Theorem 3.4 (Proportional case, arXiv:1708.00029).**
 
@@ -244,10 +245,10 @@ The proof mirrors `blocks_match_of_sameMPV₂_CFBNT` in `Full.lean`:
 
 The single-block exact-MPV reduction is packaged separately as
 `peripheralProportionalCase_periodicFT_of_sameMPV`: once the proportionality
-scalar has been absorbed, the overlap dichotomy already gives the repeated-block
-conclusion. Thus the remaining paper-level gap is the multi-block existence step
-that turns proportionality of the assembled tensors into the non-decaying
-cross-overlap hypotheses `exists_nondecaying_A/B`.
+scalar has been absorbed, the overlap dichotomy already gives the heterogeneous
+repeated-block conclusion. Thus the remaining paper-level gap is the multi-block
+existence step that turns proportionality of the assembled tensors into the
+non-decaying cross-overlap hypotheses `exists_nondecaying_A/B`.
 
 The `PeriodicOverlapHypothesis` parameter can be supplied via
 `PeriodicOverlapHypothesis.ofIsPeriodic`, which uses `periodicOverlapDichotomy`

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -592,6 +592,25 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     periodic approach is the subject of the present chapter.
 \end{remark}
 
+\begin{theorem}[Peripheral proportional case from exact MPV equality]
+    \label{thm:peripheral_periodic_ft_proportional_same}
+    \lean{MPSTensor.peripheralProportionalCase_periodicFT_of_sameMPV}
+    \notready
+    \uses{def:periodic_tensor, thm:periodic_overlap_dichotomy,
+          thm:periodic_self_overlap_tendsto}
+    Let $A$ and $B$ be periodic tensors with the same matrix product vectors.
+    Then $A$ and $B$ are equivalent up to repeated blocks.
+\end{theorem}
+\begin{proof}\notready
+    By Theorem~\ref{thm:periodic_overlap_dichotomy}, either the overlap
+    $\braket{V^{(N)}(A)}{V^{(N)}(B)}$ tends to $0$ or $A$ and $B$ are
+    equivalent up to repeated blocks. In the decay case, equality of the MPV
+    families identifies the cross-overlap with the self-overlap of $A$ for every
+    $N$. But Theorem~\ref{thm:periodic_self_overlap_tendsto} gives
+    $\braket{V^{(m_a N)}(A)}{V^{(m_a N)}(A)} \to m_a$ along multiples of the
+    period $m_a$, contradiction.
+\end{proof}
+
 \begin{remark}[Proportional periodic FT]\notready
     \label{rem:periodic_ft_proportional}
     \lean{MPSTensor.fundamentalTheorem_periodic_proportional}

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -599,14 +599,16 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     \uses{def:periodic_tensor, thm:periodic_overlap_dichotomy,
           thm:periodic_self_overlap_tendsto}
     Let $A$ and $B$ be periodic tensors with the same matrix product vectors.
-    Then $A$ and $B$ are equivalent up to repeated blocks.
+    Then their bond dimensions agree, and after identifying the bond spaces,
+    $A$ and $B$ are equivalent up to repeated blocks.
 \end{theorem}
 \begin{proof}\notready
     By Theorem~\ref{thm:periodic_overlap_dichotomy}, either the overlap
-    $\braket{V^{(N)}(A)}{V^{(N)}(B)}$ tends to $0$ or $A$ and $B$ are
-    equivalent up to repeated blocks. In the decay case, equality of the MPV
-    families identifies the cross-overlap with the self-overlap of $A$ for every
-    $N$. But Theorem~\ref{thm:periodic_self_overlap_tendsto} gives
+    $\braket{V^{(N)}(A)}{V^{(N)}(B)}$ tends to $0$ or the bond dimensions agree
+    and $A$ and $B$ are equivalent up to repeated blocks. In the decay case,
+    equality of the MPV families identifies the cross-overlap with the
+    self-overlap of $A$ for every $N$. But
+    Theorem~\ref{thm:periodic_self_overlap_tendsto} gives
     $\braket{V^{(m_a N)}(A)}{V^{(m_a N)}(A)} \to m_a$ along multiples of the
     period $m_a$, contradiction.
 \end{proof}


### PR DESCRIPTION
## Summary

This PR lands a small but real proportional-side increment for #786.

Concretely it adds:
- `MPSTensor.peripheralProportionalCase_periodicFT_of_sameMPV`
- a matching blueprint entry in `ch11b_periodic_ft.tex`
- an updated docstring in `Periodic/FundamentalTheorem.lean` explaining that the
  remaining paper-level gap is the multi-block existence step turning proportional
  assembled MPVs into non-decaying cross-overlap witnesses

The new theorem isolates the **single-block / peripheral uniqueness step** of the
periodic proportional Fundamental Theorem: if two periodic tensors already have
exactly the same MPV family, then the periodic overlap dichotomy forces them to be
`RepeatedBlocks`.

## What this proves

- The proportional-case periodic FT now has a named exact-MPV peripheral reduction.
- The proof uses the current periodic infrastructure honestly:
  `periodicOverlapDichotomy` plus `periodicSelfOverlap_tendsto` rule out the decay branch.
- The remaining gap to the paper's full Theorem 3.4 is stated more sharply in the
  file documentation: the unresolved part is the **multi-block existence / rescaling**
  step that produces non-decaying cross-overlaps for the block families.

## What this does not prove

- It does **not** prove the full proportional periodic FT of Theorem 3.4.
- It does **not** construct the missing non-decaying overlap witnesses for the
  assembled irreducible-form block families.
- Since it depends on `periodicOverlapDichotomy` and `periodicSelfOverlap_tendsto`,
  it still inherits the existing admitted obligations in `Periodic/Overlap`.

## Verification

- `lake env lean TNLean/MPS/Periodic/FundamentalTheorem.lean`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/Periodic/FundamentalTheorem.lean blueprint/src/chapter/ch11b_periodic_ft.tex`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

Refs #786

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new theorem and documentation in the periodic FT development without changing existing APIs or computation, though the result depends on the already-admitted lemmas behind `periodicOverlapDichotomy`/`periodicSelfOverlap_tendsto`.
> 
> **Overview**
> Adds `peripheralProportionalCase_periodicFT_of_sameMPV`, isolating the **single-block** proportional/uniqueness step for periodic tensors: if `SameMPV₂ A B` and both are periodic, it rules out the decay branch of `periodicOverlapDichotomy` using `periodicSelfOverlap_tendsto`, yielding `HetRepeatedBlocks A B` (and hence matching bond dimensions).
> 
> Updates the Theorem 3.4 docstring to reference this reduction and clarify that the remaining gap to the paper is the **multi-block existence/rescaling** step that provides non-decaying cross-overlap witnesses, and adds a corresponding `
> theorem` entry in the blueprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c525ddf78ee32c47bc294a0d3303039cd11dcc94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->