### PR TITLE
doc(audits): record issue #27 cor66 and thm614 blockers

### DIFF
--- a/audits/2026-04-23_issue27_thm614_concrete_blocker.md
+++ b/audits/2026-04-23_issue27_thm614_concrete_blocker.md
@@ -9,7 +9,6 @@ I worked in the isolated worktree `.worktrees/issue-27-cor66` on branch
 - `docs/PROOF_INTEGRITY.md`
 - `docs/style.md`
 - `docs/blueprint_style_guide.md`
-- `/memories/issue_27_fixedpoint_corollary_20260421.md`
 - issue #27
 - the current fixed-point / stationary-support / cyclic-decomposition files
 - the Chapter 6 index and blueprint section
@@ -69,7 +68,7 @@ Let `ρ ≥ 0` satisfy `map K ρ = ρ`, and let
 Then:
 
 1. `lowerZero_of_posSemidef_fixedPoint` gives
-   `∀ i, (1 - P) * K i * P = 0`.
+   `∀ i, (1 - P) * K_i * P = 0`.
 2. Hence the supported Kraus family
    `A_i := K_i * P`
    lands in the corner and satisfies
@@ -109,7 +108,7 @@ compression lemma plus the corner `ℂ`/`*`-algebra instances.
 ## Thm. 6.14 concrete-realization blocker
 
 The harder remaining part of Wolf Thm. 6.14 is still exactly the one already
-noted in issue #27 and in `/memories/issue_27_fixedpoint_corollary_20260421.md`:
+noted in issue #27 and in the earlier Chapter 6 fixed-point follow-up work:
 
 - the current file `TNLean/Channel/FixedPoint/WedderburnDecomp.lean` gives
   semisimplicity and an abstract product decomposition;

--- a/audits/2026-04-23_issue27_thm614_concrete_blocker.md
+++ b/audits/2026-04-23_issue27_thm614_concrete_blocker.md
@@ -1,0 +1,164 @@
+# 2026-04-23 — Issue #27 audit: Cor. 6.6 support-corner path and Thm. 6.14 concrete blocker
+
+## Scope
+
+I worked in the isolated worktree `.worktrees/issue-27-cor66` on branch
+`feat/27-cor66-corner-algebra`, after reading:
+
+- `CLAUDE.md`
+- `docs/PROOF_INTEGRITY.md`
+- `docs/style.md`
+- `docs/blueprint_style_guide.md`
+- `/memories/issue_27_fixedpoint_corollary_20260421.md`
+- issue #27
+- the current fixed-point / stationary-support / cyclic-decomposition files
+- the Chapter 6 index and blueprint section
+
+I targeted **Wolf Cor. 6.6** first, as requested.
+
+## Main finding for Cor. 6.6
+
+The earlier blocker description
+
+> "`cornerSubmodule Q` is only a `Submodule`; we still need to package the corner as a unital `*`-algebra with unit `Q`"
+
+is **partly outdated**.
+
+### What Mathlib already provides
+
+`Mathlib/RingTheory/Idempotents.lean` already defines the corner type
+
+- `IsIdempotentElem.Corner (e := P) hP`
+
+for an idempotent `P`, together with the ring structure whose unit is `P`.
+More precisely, for an idempotent `P` it gives:
+
+- the carrier `Set.range (P * · * P)`;
+- `Semiring` / `Ring` instances on the corner;
+- the correct unit `1 = P`.
+
+So the missing step is **not** to build the corner ring from nothing.
+
+### What is still actually missing
+
+For the matrix corner needed in Cor. 6.6, the missing pieces are:
+
+1. **Complex-linear packaging on the corner type**
+   - no out-of-the-box `SMul ℂ`, `Module ℂ`, or `Algebra ℂ` instance on
+     `IsIdempotentElem.Corner (e := P) hP.2`;
+2. **Star packaging on the corner type**
+   - no out-of-the-box `Star`, `StarRing`, or `StarModule ℂ` instance,
+     even when `P` is self-adjoint;
+3. **Bridge to the existing API**
+   - the repository-side corner object is still `cornerSubmodule P`, so one still
+     needs a clean equivalence between
+     `cornerSubmodule P = {X | P * X * P = X}`
+     and Mathlib's `IsIdempotentElem.Corner` carrier;
+4. **Faithfulness of the compressed fixed point**
+   - after compressing to the support, the resulting fixed point on the smaller
+     matrix algebra must be shown `PosDef`, not merely `PosSemidef`.
+
+That last point is the real proof bottleneck preventing a short derivation of
+Cor. 6.6 from the existing `fixedPointsStarSubalgebra` /
+`adjointFixedPointsStarSubalgebra` machinery.
+
+## Expected proof route for Cor. 6.6
+
+Let `ρ ≥ 0` satisfy `map K ρ = ρ`, and let
+`P := supportProj ρ`.
+Then:
+
+1. `lowerZero_of_posSemidef_fixedPoint` gives
+   `∀ i, (1 - P) * K i * P = 0`.
+2. Hence the supported Kraus family
+   `A_i := K_i * P`
+   lands in the corner and satisfies
+   `∑ A_i† A_i = P`.
+3. The existing compression infrastructure
+   (`cornerCompressionExpand`, `cornerCompressionInvFun`,
+   `cornerCompressionLinearEquiv`, or the stronger
+   `exists_compressedTensor_of_supported_projection`) should then produce a
+   smaller Kraus family `C` on `M_n(ℂ)` with
+   `∑ C_i† C_i = 1`.
+4. The compressed fixed point
+   `ρ_c`
+   should be the top-left block of `U† ρ U` on the support sector, hence
+   positive definite.
+5. Apply `adjointFixedPointsStarSubalgebra` to `C` and transport the result back
+   to the corner.
+
+### Remaining missing lemma for step 4
+
+The clean missing lemma is essentially:
+
+> if `ρ.PosSemidef` and `P = supportProj ρ`, then the compression of `ρ` to the
+> support sector is `PosDef`.
+
+A promising proof route is:
+
+- publicize the archived kernel lemma
+  `supportProj_mulVec_eq_zero_of_mulVec_eq_zero`
+  from `TNLean/Archive/BlockingPeriodicityCFII2.lean`;
+- combine it with
+  - `PosSemidef.submatrix`, and
+  - either `PosSemidef.posDef_iff_isUnit` or a direct kernel-vector contradiction.
+
+In other words, **Cor. 6.6 now looks close**, but it still needs one faithful-
+compression lemma plus the corner `ℂ`/`*`-algebra instances.
+
+## Thm. 6.14 concrete-realization blocker
+
+The harder remaining part of Wolf Thm. 6.14 is still exactly the one already
+noted in issue #27 and in `/memories/issue_27_fixedpoint_corollary_20260421.md`:
+
+- the current file `TNLean/Channel/FixedPoint/WedderburnDecomp.lean` gives
+  semisimplicity and an abstract product decomposition;
+- `IsWedderburnBlockDecomp` records only
+  - the number of simple blocks,
+  - block dimensions,
+  - multiplicities,
+  - an ambient-dimension bound, and
+  - an `AlgEquiv` to a product of matrix algebras.
+
+What is still missing for the full Wolf statement is the **concrete ambient
+realization**
+
+\[
+\operatorname{Fix}(T^*) = U \Bigl(0 \oplus \bigoplus_k M_{d_k}(\mathbb C) \otimes 1_{m_k}\Bigr) U^\dagger,
+\]
+
+and then the density-block refinement
+
+\[
+\operatorname{Fix}(T) = U \Bigl(0 \oplus \bigoplus_k M_{d_k}(\mathbb C) \otimes \rho_k\Bigr) U^\dagger.
+\]
+
+### Why the present infrastructure stops short
+
+Mathlib currently gives the **abstract** Wedderburn--Artin decomposition of a
+finite-dimensional semisimple algebra over `ℂ`, but not the additional data
+needed here:
+
+1. a `StarAlgEquiv` / C\*-compatible version of the decomposition;
+2. a proof that the algebra can be realized by **unitary conjugation** inside the
+   ambient matrix algebra;
+3. the multiplicity-space decomposition giving the `⊗ 1_{m_k}` factors;
+4. the final transport from the adjoint-fixed algebra to the Schrödinger fixed
+   space with density blocks `ρ_k`.
+
+So the honest next theorem for Thm. 6.14 is not another abstract algebra
+statement. It is a **representation-theoretic realization theorem** for finite-
+dimensional `*`-subalgebras of `M_D(ℂ)`.
+
+## Recommendation
+
+If issue #27 is continued immediately, the best next slice is still:
+
+1. expose a public kernel/support lemma for `supportProj`,
+2. add `ℂ`-module + `*`-ring instances on the corner type
+   `IsIdempotentElem.Corner`,
+3. prove the compressed support fixed point is `PosDef`,
+4. then finish Cor. 6.6.
+
+Only after that is it worth returning to the full concrete/unitary part of
+Thm. 6.14.


### PR DESCRIPTION
## Summary
- add an audit note for issue LionSR/QICLean#39 after scouting the remaining Cor. 6.6 / Thm. 6.14 work
- record that Mathlib already has the corner ring `IsIdempotentElem.Corner`, so the remaining Cor. 6.6 blocker is narrower than previously thought
- spell out the actual next lemmas needed for Cor. 6.6 (corner `ℂ`/`*`-algebra instances + faithful compressed fixed point) and the still-missing concrete/unitary layer for Thm. 6.14

## Context
This PR does **not** claim to formalize Cor. 6.6 or the remaining part of Thm. 6.14. It is an honest audit-only increment after trying the Cor. 6.6 route first.

## Verification
- `git diff --check HEAD^ HEAD`
- `lake env lean TNLean/Channel/FixedPoint/Corollaries.lean`
- `lake env lean TNLean/Channel/FixedPoint/WedderburnDecomp.lean` *(current `main` still emits an existing `declaration uses sorry` warning from this file, but there is no diff to it in this PR)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding an audit note; no code paths or proofs are modified.
> 
> **Overview**
> Adds a new audit note `audits/2026-04-23_issue27_thm614_concrete_blocker.md` documenting updated blockers for finishing Wolf Cor. 6.6 and the remaining “concrete/unitary realization” gap for Wolf Thm. 6.14.
> 
> The note narrows the Cor. 6.6 blocker by pointing to Mathlib’s existing `IsIdempotentElem.Corner` ring, and records the specific remaining work items (corner `ℂ`/`*`-algebra instances, equivalence with `cornerSubmodule`, and a lemma that the support-compressed fixed point is `PosDef`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffad06ac18dc7a27448ef76cfeebf25c5018f1a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->