### PR TITLE
feat(MPS/CanonicalForm): tighten Gap §1 BNT grouping for #652

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -64,12 +64,17 @@ The theorem `exists_tp_sector_decomp_after_blocking` below provides:
 - The MPV relationship: `blockTensor A p` is `SameMPV₂`-equivalent to
   `zeroMPSTensor + toTensorFromBlocks μ sectors` for some weights `μ`
 
-The full FT also requires showing each sector is:
-- **Irreducible** (from `isIrreducible_restriction_of_cyclic_decomp` + orbit-sum lift)
-- **Normal** (from irreducibility + primitivity of sector transfer maps)
-- **Gauge-phase unique** (from the BNT permutation rigidity theorem)
+The current library already settles the common-period blocking step and the
+primitive / irreducible / normal bridges needed after blocking. The remaining
+Gap §1 content is now more specific:
+- a **general BNT sector construction** for the blocked output, matching the
+  paper's basis-of-normal-tensors decomposition rather than only the restricted
+  norm-class-collapse theorem `exists_bnt_grouping`, and
+- a **heterogeneous sector comparison theorem** matching two such BNT sector
+  decompositions up to permutation, gauge phase, and sector-weight multisets.
 
-These additional properties are documented but not yet fully formalized.
+Those sector-level endpoint theorems are documented below but are not yet
+formalized.
 -/
 
 section FundamentalTheorem1606
@@ -160,19 +165,21 @@ theorem bilateral_commonPeriod_blocking_tp_primitive_normal
   · exact isNormal_blockTensor_of_isNormal (d := d) (D := D₁) A hp hNormalA
   · exact isNormal_blockTensor_of_isNormal (d := d) (D := D₂) B hp hNormalB
 
-/-- **Fundamental Theorem of MPS (1606.00608, after blocking): structural version.**
+/-- **Fundamental Theorem of MPS (1606.00608, after blocking): current structural shell.**
 
-For any two MPS tensors `A, B` with `SameMPV₂ A B`, after a common blocking period,
-both blocked tensors admit TP-primitive decompositions. If the blocked decompositions
-additionally satisfy:
-- Tensor irreducibility of each block
-- Distinct weight norms (pairwise)
-- BNT separation (no gauge-phase equivalent pairs with same dimension)
+For any two MPS tensors `A, B` with `SameMPV₂ A B`, this theorem packages the
+currently formalized one-sided reduction output on both sides: after blocking,
+each tensor admits a decomposition into TP blocks with primitive transfer maps,
+nonzero weights, and positive bond dimensions.
 
-then the block structures match up to permutation and gauge-phase equivalence.
+The theorem does **not yet** use `SameMPV₂ A B` to compare the two blocked
+outputs. The remaining missing content is the sector-level endpoint described in
+the file documentation below: a general BNT sector construction for each side,
+followed by a heterogeneous equal-case comparison theorem for those sector
+decompositions.
 
-This theorem states the structural content of arXiv:1606.00608, Theorem 1,
-connecting the reduction output to the fundamental theorem conclusion. -/
+This theorem therefore records the structural shell currently available on the
+way to arXiv:1606.00608, Theorem 1. -/
 theorem fundamentalTheorem_after_blocking_1606_structural
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -206,27 +213,30 @@ theorem fundamentalTheorem_after_blocking_1606_structural
 /-!
 ### What remains for the full 1606.00608 Fundamental Theorem
 
-The complete end-to-end FT would take two tensors `A, B` with `SameMPV₂ A B` and
-produce a common blocking period `p` and matching block structures. The remaining
-formalizations are:
+The complete end-to-end FT should take two tensors `A, B` with `SameMPV₂ A B`
+and pass from the blocked reduction output to the paper's basis-of-normal-tensors
+endpoint. The remaining formalizations are now:
 
-1. **Common blocking period**: Re-block both decompositions to `p = lcm(pA, pB)`.
-   This requires the relation between `blockTensor (blockTensor A pA) q`
-   and `blockTensor A (pA * q)`.
+1. **General one-sided BNT construction**: starting from the blocked TP-primitive
+   decomposition, construct a sector decomposition in the paper's general BNT
+   sense. This is stronger than the current special-case theorem
+   `exists_bnt_grouping`, which only collapses norm classes already known to
+   represent one MPV family.
 
-2. **Sector irreducibility**: Each cyclic sector of a blocked periodic block should be
-   irreducible. The orbit-sum lift hypothesis from `isIrreducible_restriction_of_cyclic_decomp`
-   in `CyclicDecomposition.lean` provides this conditionally; the concrete orbit-sum
-   construction from MPS Kraus operators remains to be formalized.
+2. **Heterogeneous sector comparison**: if two such BNT sector decompositions
+   have equal total MPVs, first match their basis tensors up to permutation and
+   gauge phase, and then compare the sector-weight multisets after absorbing the
+   phases. The current theorem
+   `fundamentalTheorem_equalMPV_sectorDecomposition` only handles the shared-basis
+   subcase after this matching has already been done.
 
-3. **Normal canonical form per sector**: Each irreducible TP-primitive sector becomes
-   `IsNormal` via `isNormal_of_tp_primitive_irreducible` (already proved in this file).
+3. **Final global assembly**: once steps 1–2 are available, combine them with the
+   already-formalized common-period blocking, blocked irreducibility,
+   `isNormal_of_tp_primitive_irreducible`, and the global gauge construction of
+   the equal-case FT.
 
-4. **BNT separation + weight ordering + gauge-phase matching**: Apply
-   `weakFundamentalTheorem_conditional` to obtain permutation and gauge-phase matching.
-
-Steps 1–2 are the main remaining formalizations; steps 3–4 are already formalized
-and just need to be combined once steps 1–2 are complete.
+So the common-period blocking step is no longer the blocker; the missing content
+is specifically the paper-level sector endpoint.
 -/
 
 end FundamentalTheorem1606

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -34,7 +34,7 @@ blocks on one side are already known to collapse to a single basis tensor. It is
 therefore a useful **special-case norm-class collapse** module, not the full
 basis-of-normal-tensors construction from [CPGSV17, Proposition A.6 /
 `prop:char-BNT`]. The general one-sided BNT construction remains open and is part
-of the remaining Gap §1 work for issue #652.
+of the remaining Gap 2 work for issue #652 (labeled "Gap §1" in that issue).
 
 ## Main results
 

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -29,8 +29,12 @@ period `P` the weights become `(μ₀ k)^P`, and two distinct original weights `
 * **(a)** Relax the predicate to match the paper's canonical form definition.
 * **(b)** Add a BNT grouping/sorting step.
 
-This file implements strategy **(b)** for the common case and states the full result
-for the equal-norm case.
+This file implements strategy **(b)** only in the restricted case where equal-modulus
+blocks on one side are already known to collapse to a single basis tensor. It is
+therefore a useful **special-case norm-class collapse** module, not the full
+basis-of-normal-tensors construction from [CPGSV17, Proposition A.6 /
+`prop:char-BNT`]. The general one-sided BNT construction remains open and is part
+of the remaining Gap §1 work for issue #652.
 
 ## Main results
 
@@ -369,12 +373,11 @@ noncomputable def normClassGroupingData {r : ℕ} (μ : Fin r → ℂ) :
     regroup := hRegroup
   }
 
-/-- **BNT grouping step (equal-norm case, proved via norm-class enumeration).**
+/-- **Restricted BNT grouping step (equal-norm collapse via norm-class enumeration).**
 
 Given a weighted block family `(μ, blocks)` where some blocks may share the same norm
-`‖μ j‖ = ‖μ k‖`, and given that equal-norm blocks share the same MPV function
-(a hypothesis that follows from BNT uniqueness in the full formalization), there exists
-a `SectorDecomposition P` with:
+`‖μ j‖ = ‖μ k‖`, and given that equal-norm blocks already share the same MPV function,
+there exists a `SectorDecomposition P` with:
 
 1. `SameMPV₂ P.toTensor (toTensorFromBlocks μ blocks)`.
 2. `StrictAnti` on the BNT-level norms (one norm value per group).
@@ -389,6 +392,11 @@ Note that no equal-dimension hypothesis is needed: the sector's bond dimension i
 fixed by the chosen representative `reprFn j`, and other members of the same norm
 class may have different dimensions — their MPV values are matched via `hMPVEq`,
 which uses the heterogeneous `SameMPV₂` to accommodate different bond dimensions.
+
+This theorem is intentionally a **restricted collapse theorem**. It is not the
+paper's full basis-of-normal-tensors construction: if two distinct basis tensors
+occur at the same modulus, they should survive as different basis elements rather
+than being forced into one norm class.
 
 **Why `hMPVEq` arises in the full theory**:
 In the BNT theory (CPGSV17, §2.3), two blocks with the same weight norm are

--- a/audits/2026-04-21_issue652_gap1_blocker.md
+++ b/audits/2026-04-21_issue652_gap1_blocker.md
@@ -1,5 +1,10 @@
 # Issue #652 blocker audit — Gap §1 / unconditional structural FT after blocking
 
+> **Superseded on 2026-04-23.** See
+> `audits/2026-04-23_issue652_gap1_followup.md` for the sharper theorem-shape
+> audit. The April 21 file remains useful as the first counterexample-based
+> obstruction note, but the follow-up audit is now the authoritative roadmap.
+
 Date: 2026-04-21
 Branch: `feat/652-bnt-grouping-unconditional`
 Target files:

--- a/audits/2026-04-23_issue652_gap1_followup.md
+++ b/audits/2026-04-23_issue652_gap1_followup.md
@@ -1,0 +1,283 @@
+# Issue #652 follow-up audit — Gap §1 / general BNT sector endpoint
+
+Date: 2026-04-23
+Branch: `feat/652-bnt-grouping-v2`
+Supersedes: `audits/2026-04-21_issue652_gap1_blocker.md`
+
+## Executive summary
+
+The April 21 audit correctly showed that the original Step 1 request is false:
+whole-tensor `SameMPV₂` does **not** imply the same-side hypothesis
+`hMPVEq : ‖μ j‖ = ‖μ k‖ → SameMPV₂ (blocks j) (blocks k)`.
+
+After re-reading the current Lean endpoint and the paper proofs, the sharper
+conclusion is:
+
+1. `exists_bnt_grouping` is only a **norm-class collapse** theorem. It is not
+   the full basis-of-normal-tensors construction from
+   [CPSV17, Proposition `prop:char-BNT`] /
+   [CPSV21, Proposition `prop:char-BNT`].
+2. The after-blocking endpoint must be stated at the level of **general BNT
+   sector decompositions**, not strict `IsCanonicalFormBNT` families. The
+   paper-level decomposition has coefficients
+   `c_j(N) = ∑ q, μ_{j,q} ^ N`, not one geometric weight per basis block.
+3. The genuinely missing formal content is therefore a two-step sector
+   endpoint:
+   (a) a one-sided BNT-sector construction from arbitrary TP-primitive-
+   irreducible blocks, and
+   (b) a heterogeneous equal-case comparison theorem for two such sector
+   decompositions.
+
+This is sharper than the April 21 audit: the missing theorem family is not only
+"compare two sector decompositions once they exist". We also still lack the
+paper's **general** one-sided BNT construction that allows several distinct BNT
+basis tensors to occur at the same coefficient modulus.
+
+## Existing Lean theorems already on `main`
+
+The current library already provides all of the following.
+
+### Reduction / blocking infrastructure
+
+- `exists_tp_primitive_blockDecomp_after_blocking`
+  (`TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean`)
+- `bilateral_commonPeriod_blocking_tp_primitive_normal`
+  (`TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`)
+- `sameMPV₂_blockTensor_of_sameMPV₂_toTensorFromBlocks`
+  (`TNLean/MPS/Core/BlockingInfrastructure.lean`)
+- `isPrimitive_transferMap_blockTensor_of_dvd`
+- `isIrreducibleTensor_blockTensor_of_tp_primitive_irr`
+- `isNormal_of_tp_primitive_irreducible`
+
+So the common-period arithmetic is **not** the blocker anymore.
+
+### Special-case same-side grouping
+
+- `exists_bnt_grouping`
+  (`TNLean/MPS/CanonicalForm/BNTGrouping.lean`)
+- `exists_bnt_grouping_of_gaugePhaseEquiv`
+- `exists_sectorDecomp_of_tp_primitive_irr_blocks`
+  (`TNLean/MPS/CanonicalForm/EqualNormBridge.lean`)
+
+These theorems cover only the special case where same-side equal-norm blocks are
+already known to collapse onto one basis tensor.
+
+### Current equal-case endpoints
+
+- `fundamentalTheorem_equalMPV_CFBNT_hetero`
+  (`TNLean/MPS/FundamentalTheorem/Full.lean`)
+- `fundamentalTheorem_equalMPV_sectorDecomposition`
+  (`TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`)
+
+The first theorem is for **strict** CF-BNT families with one weight per block.
+The second theorem is for **sector decompositions over a shared basis**.
+Neither theorem covers the missing paper-level endpoint by itself.
+
+## New clarification beyond the April 21 audit
+
+### 1. `exists_bnt_grouping` is not the paper's full BNT construction
+
+The theorem `exists_bnt_grouping` groups by **weight norm classes** and outputs a
+sector decomposition with one basis tensor per norm class and strictly
+decreasing representative norms.
+
+That is a useful special case, but it is stronger than the paper's general BNT
+shape. In [CPSV17, Eq. `eq:II_ABasicTensors`] and [CPSV21, Eq. `eq:II_ABasicTensors`],
+a tensor in canonical form is written as
+
+$$
+  A^i = \bigoplus_{j=1}^g \bigoplus_{q=1}^{r_j}
+    \mu_{j,q} X_{j,q} A_j^i X_{j,q}^{-1},
+  \qquad
+  |V^{(N)}(A)\rangle = \sum_{j=1}^g
+    \left(\sum_{q=1}^{r_j} \mu_{j,q}^N\right)
+    |V^{(N)}(A_j)\rangle.
+$$
+
+Nothing in that formula forbids two **different** basis tensors `A_j`, `A_k`
+from having coefficient multisets with the same modulus. The current Lean
+special case forbids that by construction.
+
+The scalar counterexample from the April 21 audit shows exactly why this matters:
+
+- `A₀(0) = 1`, `A₀(1) = 0`
+- `A₁(0) = 0`, `A₁(1) = 1`
+- `μ₀ = μ₁ = 1`
+
+These are TP, primitive, irreducible, same norm, and not `SameMPV₂`. Any
+correct one-sided BNT construction must allow them to survive as **two distinct
+basis tensors at the same modulus**. Therefore the current theorem shape
+`equal norm class = one basis tensor` cannot be the general endpoint.
+
+### 2. The shared-basis sector theorem covers only the last paper step
+
+`fundamentalTheorem_equalMPV_sectorDecomposition` proves equality of sector
+weight multisets **once the two sides already share the same basis**.
+
+This matches only the last part of the paper proof of the equal case
+([CPSV17, proof of Corollary `II_cor2`, lines 1184–1192] /
+[CPSV21, Corollary `II_cor2`, lines 1896–1900]): after the BNT basis tensors are
+already matched, compare the power sums `∑_q μ_{j,q}^N` and recover the weight
+multisets.
+
+What is still missing is the earlier heterogeneous step:
+
+- from `SameMPV₂` of the **total** sector tensors,
+- recover the BNT basis matching across the two sides,
+- and only then compare the sector coefficients on the matched basis.
+
+## Paper-level theorem family that is actually missing
+
+The paper proof decomposes into three layers.
+
+### Layer A. One-sided BNT construction
+
+Paper source:
+
+- [CPSV17, Proposition `prop:char-BNT`, lines 1135–1148]
+- [CPSV21, Proposition `prop:char-BNT`, lines 1852–1861]
+
+This is the appendix construction of a basis of normal tensors by choosing a
+maximal subset with decaying mixed overlaps and then expressing every remaining
+block by gauge phase relative to one representative.
+
+A Lean theorem close to the paper shape should look like:
+
+```lean
+/-- Suggested helper predicate packaging the paper-level BNT sector data. -/
+structure HasBNTSectorData (P : SectorDecomposition d) : Prop where
+  basis_ncf :
+    IsNormalCanonicalForm
+      (fun j : Fin P.basisCount =>
+        P.weight j ⟨0, P.copies_pos j⟩)
+      P.basis
+  basis_blocks : BlocksNotGaugePhaseEquiv (d := d) P.basis
+  class_const_norm :
+    ∀ j (q : Fin (P.copies j)),
+      ‖P.weight j q‖ = ‖P.weight j ⟨0, P.copies_pos j⟩‖
+```
+
+```lean
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, IsPrimitive (transferMap (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P
+```
+
+This theorem would **replace** the current attempt to strengthen
+`exists_bnt_grouping`. The point is not to derive `hMPVEq`; the point is to
+formalize the paper's general BNT construction, which does not require that all
+same-modulus blocks on one side coincide.
+
+### Layer B. Heterogeneous equal-case comparison for BNT sector decompositions
+
+Paper source:
+
+- [CPSV17, Theorem `thm1`, lines 1167–1183]
+- [CPSV21, Theorem `thm1`, lines 1891–1893]
+- [CPSV17, Corollary `II_cor2`, proof lines 1184–1192]
+- [CPSV21, Corollary `II_cor2`, lines 1896–1900]
+
+A Lean theorem close to the needed endpoint should look like:
+
+```lean
+theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero
+    (P Q : SectorDecomposition d)
+    (hP : HasBNTSectorData (d := d) P)
+    (hQ : HasBNTSectorData (d := d) Q)
+    (hSame : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ _h : P.basisCount = Q.basisCount,
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+        ∃ hCopies : ∀ j : Fin P.basisCount,
+          P.copies j = Q.copies (perm j),
+          ∀ j : Fin P.basisCount,
+            ∃ hdim : P.basisDim j = Q.basisDim (perm j),
+              ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧
+                GaugePhaseEquiv (d := d)
+                  (cast (congr_arg (MPSTensor d) hdim) (P.basis j))
+                  (Q.basis (perm j)) ∧
+                Finset.univ.val.map (P.weight j) =
+                  Finset.univ.val.map
+                    (fun q =>
+                      ζ * Q.weight (perm j)
+                        (Fin.cast (hCopies j) q))
+```
+
+This is the actual missing bridge between the two current endpoints:
+
+- it starts from two **different** BNT sector decompositions,
+- first matches the basis tensors up to permutation and gauge phase,
+- then absorbs the phases into the sector weights,
+- and finally compares the sector-weight multisets.
+
+The existing theorem
+`fundamentalTheorem_equalMPV_sectorDecomposition` would then become the
+**shared-basis subroutine** for the final weight-multiset line after transporting
+`Q` along the matched permutation and absorbed phases.
+
+### Layer C. After-blocking assembly theorem
+
+Once Layers A and B exist, the structural after-blocking theorem can finally be
+retargeted honestly:
+
+```lean
+theorem fundamentalTheorem_after_blocking_1606_sector
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ p : ℕ, 0 < p ∧
+      ∃ P : SectorDecomposition (blockPhysDim d p),
+      ∃ Q : SectorDecomposition (blockPhysDim d p),
+        SameMPV₂ (blockTensor (d := d) (D := D₁) A p) P.toTensor ∧
+        SameMPV₂ (blockTensor (d := d) (D := D₂) B p) Q.toTensor ∧
+        HasBNTSectorData (d := blockPhysDim d p) P ∧
+        HasBNTSectorData (d := blockPhysDim d p) Q ∧
+        -- plus the permutation / phase / sector-weight conclusion of Layer B
+        True
+```
+
+The placeholder `True` above is exactly the Layer-B conclusion instantiated at
+physical dimension `blockPhysDim d p`. The common-period blocking itself is
+already formalized on `main`; the missing content is the sector endpoint.
+
+## Why the current code stops exactly before these theorems
+
+- `exists_bnt_grouping` and
+  `exists_sectorDecomp_of_tp_primitive_irr_blocks` are special-case tools for
+  already-collapsible norm classes.
+- `fundamentalTheorem_equalMPV_CFBNT_hetero` is a theorem for strict
+  `toTensorFromBlocks μ basis` data, not for sector coefficients
+  `c_j(N) = ∑_q μ_{j,q}^N`.
+- `fundamentalTheorem_equalMPV_sectorDecomposition` compares sector weights only
+  after a common basis is already fixed.
+- The coefficient-convergence route from
+  `fundamentalTheorem_proportionalMPV_CFBNT` still does not apply to general
+  sector coefficients, exactly as documented in
+  `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean:290-295`.
+
+## Recommended next split
+
+1. **General BNT construction issue**:
+   formalize Proposition `prop:char-BNT` for TP-primitive-irreducible block
+   families and land `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`.
+2. **Heterogeneous sector comparison issue**:
+   formalize the basis-matching + phase-absorption theorem
+   `fundamentalTheorem_equalMPV_sectorDecomposition_hetero`.
+3. **Assembly issue**:
+   retarget `fundamentalTheorem_after_blocking_1606_structural` at the sector
+   endpoint, then tighten the `\notready` blueprint remark in
+   `blueprint/src/chapter/ch11_assembly.tex`.
+
+## Bottom line
+
+Issue #652 still cannot be closed by trying to discharge `hMPVEq` inside the
+current `exists_bnt_grouping` statement. The correct endpoint is a **general BNT
+sector endpoint**, matching the paper's Appendix-A construction and the theorem /
+corollary pair in §IV of the review article.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -432,13 +432,25 @@ single weighted block.
 		      recovers the sector weight multisets without requiring
 		      explicit coefficient convergence hypotheses.
 	\end{enumerate}
-	The unconditional equal-case theorem
-	(Theorem~\ref{thm:ft_equal}, \cite[Corollary~IV.5]{Cirac2021Matrix})
-	still requires one final global gauge-construction step: combining the
-	weight-recovery result above with
-	(a)~the proportional FT for block matching and gauge-phase equivalences,
-	(b)~phase absorption into weights, and
-	(c)~global gauge construction via permutation and cast transport.
+	What is still missing for the unconditional equal-case theorem
+	(Theorem~\ref{thm:ft_equal}, \cite[Corollary~IV.5]{Cirac2021Matrix}) is
+	not merely a final gauge-construction step.  Two paper-level ingredients
+	remain to be formalized:
+	\begin{enumerate}
+		\item a general basis-of-normal-tensors construction for the
+		      after-blocking output, beyond the current special case where
+		      equal-modulus blocks on one side are already known to collapse
+		      to a single basis tensor; and
+		\item a heterogeneous sector-decomposition comparison theorem:
+		      given two such basis-of-normal-tensors decompositions with the
+		      same total MPV family, first match the basis tensors up to
+		      permutation and gauge phase, and only then compare the sector
+		      weight multisets after absorbing those phases.
+	\end{enumerate}
+	The theorem proved above supplies only the shared-basis part of the second
+	item.  Once these two ingredients are in place, the final global gauge matrix
+	of Corollary~IV.5 is obtained by the same phase-absorption and blockwise
+	assembly argument already formalized in the strict single-weight setting.
 \end{remark}
 
 


### PR DESCRIPTION
## Summary

- Outcome: **option 3 (sharper audit)** for #652; this is documentation-only,
  not a proof-closing PR.
- Add `audits/2026-04-23_issue652_gap1_followup.md`, which supersedes the
  April 21 audit and states the actual missing theorem family for Gap §1.
- Tighten `BNTGrouping.lean` and
  `Assembly/StructuralTheorem.lean` docstrings to record that
  `exists_bnt_grouping` is a restricted norm-class collapse theorem, not the
  full paper-level BNT construction.
- Tighten `blueprint/src/chapter/ch11_assembly.tex`'s `\notready` remark so it
  now states the remaining sector-level ingredients precisely.
- Leave `fundamentalTheorem_after_blocking_1606_structural` unchanged as code;
  the new audit explains why the missing endpoint is a general BNT sector
  theorem plus a heterogeneous sector-comparison theorem.

## Outcome

The follow-up audit identifies three precise target interfaces:

1. `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` — one-sided general
   BNT construction matching Proposition `prop:char-BNT`.
2. `fundamentalTheorem_equalMPV_sectorDecomposition_hetero` — heterogeneous
   equal-case comparison for two BNT sector decompositions, yielding basis
   matching up to permutation / gauge phase and phase-absorbed sector-weight
   multiset equality.
3. `fundamentalTheorem_after_blocking_1606_sector` — after-blocking assembly
   theorem consuming (1) and (2).

The audit also sharpens the April 21 diagnosis by recording that the current
`exists_bnt_grouping` theorem is only a **special-case norm-class collapse**
theorem. A correct one-sided BNT construction must allow distinct basis tensors
at the same coefficient modulus (paper Eq. `eq:II_ABasicTensors`; scalar
counterexample from the earlier audit / #587 context).

## Precise remaining blocker

No single residual hypothesis was strong enough to turn the existing
`fundamentalTheorem_after_blocking_1606_structural` into the desired endpoint.
The blocker is now explicitly the absence of the two sector-level theorems
above, not common-period blocking arithmetic.

## Blueprint sync

- Tightened the `\notready` remark in `blueprint/src/chapter/ch11_assembly.tex`.
- Did **not** flip any `\notready` tags to `\leanok`.

## Cross-references

Refs #652

Predecessor #243 • depends on #299 landing • addresses the remaining ambiguity
called out in #443 • sharpens the audit trail from #325 and #328 • uses the
counterexample obstruction discussed in #587.

## Validation

- [x] `cd .worktrees/issue-652-v2 && lake env lean TNLean/MPS/CanonicalForm/BNTGrouping.lean`
- [x] `cd .worktrees/issue-652-v2 && lake env lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- [x] `cd .worktrees/issue-652-v2 && leanblueprint checkdecls`
- [x] `cd .worktrees/issue-652-v2 && rg -n "sorry|axiom" TNLean/MPS/CanonicalForm/ || true`
  - only existing comment mention: `TNLean/MPS/CanonicalForm/EqualNormBridge.lean:109`
- [x] No overlong lines in edited Lean / audit files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/audit updates plus comment/docstring tightening; no proof terms or theorem statements/implementations were modified.
> 
> **Overview**
> Updates Gap §1 documentation to clarify that current Lean coverage stops at a **restricted norm-class collapse** (`exists_bnt_grouping`) and that the remaining after-blocking endpoint requires a **general BNT sector decomposition construction** plus a **heterogeneous sector-comparison theorem**.
> 
> Adds a new follow-up audit (`audits/2026-04-23_issue652_gap1_followup.md`) superseding the prior blocker note, and tightens the `\notready` blueprint remark and Lean docstrings in `BNTGrouping.lean` and `Assembly/StructuralTheorem.lean` to reflect this sharper roadmap (no code/proof changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c54db842d8d419367ae37ae916d6bf52a03506b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->