### PR TITLE
feat(MPS/MPDO): Lemmas C.3–C.4 simple MPDO local structure (#781)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -249,6 +249,7 @@ import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.RFP
+import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.AlgebraStructure
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.Defs
+import TNLean.Entropy.MarkovChain
+import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
+
+/-!
+# Simple MPDO local structure
+
+This file records the local entropy-theoretic part of the simple MPDO
+renormalization fixed-point argument from Appendix C.2 of
+arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
+
+## Main declarations
+
+- `MPOTensor.EtaStructure`: the quantum-Markov decomposition on the middle
+  subsystem supplied by equality in strong subadditivity.
+- `MPOTensor.sal_implies_eta_structure`: the Lean form of the entropy step in
+  Lemma C.3.  We formalize the strong-area-law input locally as equality in
+  strong subadditivity for a normalized three-site reduced state.
+- `Matrix.HasRankOneFactorization`: a finite matrix factors as `vecMulVec a b`.
+- `Matrix.TracePowersConstant`: all positive powers of a matrix have the same
+  trace as the matrix itself.
+- `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the single missing
+  Perron–Frobenius input isolated by Lemma C.4.
+- `MPOTensor.sal_zcl_implies_rank_one_T`: the scoped Lemma C.4 consequence,
+  proved relative to that Perron–Frobenius input.
+
+## Implementation note
+
+In the paper, Lemma C.3 continues from equality in strong subadditivity to the
+explicit operators `η_{k,h}` by applying local inverse maps coming from the
+injectivity of the simple tensor. The current repository does not yet contain
+that inverse-map layer for simple MPDOs, so we formalize the entropic core
+exactly as the Hayashi / Ruskai / Hayden–Jozsa–Petz–Winter decomposition already
+available through `Entropy.QuantumMarkovDecomposition`.
+
+Lemma C.4 is further isolated to the finite-dimensional Perron–Frobenius step:
+for a primitive nonnegative matrix `T`, constant traces of positive powers force
+`T` to have rank one. We expose that step as the single hypothesis
+`Matrix.PrimitiveTracePowersConstantImpliesRankOne`, so the remaining gap is
+honestly localized and matches the paper one-to-one.
+
+## References
+
+- [CPGSV17] arXiv:1606.00608, Appendix C.2, Lemmas C.3–C.4
+- Hayashi, J. Phys. A: Math. Gen. 37 (2004) L205–L208
+- Ruskai, JMP 43, 4358 (2002)
+- Hayden, Jozsa, Petz, Winter, Commun. Math. Phys. 246, 359–374 (2004)
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace Matrix
+
+variable {n : ℕ}
+
+/-- A square real matrix has the rank-one factorization of Appendix C.2,
+Lemma C.4 if it is an outer product `a bᵀ`, represented in Lean as
+`Matrix.vecMulVec a b`. -/
+def HasRankOneFactorization (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
+  ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b
+
+/-- The traces of all positive powers of `T` agree with the trace of `T`
+itself.  This is the matrix-theoretic consequence of the ZCL step used in
+Appendix C.2, Lemma C.4. -/
+def TracePowersConstant (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
+  ∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T
+
+/-- The missing Perron–Frobenius input for Appendix C.2, Lemma C.4:
+for a primitive nonnegative matrix, constant traces of positive powers imply a
+rank-one factorization.
+
+This is intentionally packaged as a local hypothesis rather than a new global
+assumption. Once a genuine proof is formalized, downstream callers can simply
+supply that theorem here and the scoped result `MPOTensor.sal_zcl_implies_rank_one_T`
+will become unconditional. -/
+def PrimitiveTracePowersConstantImpliesRankOne
+    (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
+  Matrix.IsPrimitive T → TracePowersConstant T → HasRankOneFactorization T
+
+end Matrix
+
+namespace MPOTensor
+
+section LocalSAL
+
+variable {dA dB dC : ℕ}
+
+/-- The local `η`-structure used in the simple MPDO argument, formalized as the
+quantum-Markov decomposition on the middle subsystem produced by equality in
+strong subadditivity.
+
+For the current repository state, this is the exact entropy-theoretic content of
+Lemma C.3 that is already available through the sanctioned Hayashi equality
+characterization. The further conversion from this decomposition to explicit
+operators `η_{k,h}` requires the injective inverse-map layer for simple MPDOs
+and is deferred to future work. -/
+abbrev EtaStructure
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) : Type :=
+  Entropy.QuantumMarkovDecomposition ρ_ABC
+
+/-- **Lemma C.3, scoped entropy form**: strong area law implies the local
+`η`-structure.
+
+We formalize the SAL input at the exact local point where the paper invokes it:
+for the normalized three-site reduced state `ρ_ABC`, SAL gives equality in
+strong subadditivity. The Hayashi equality characterization then yields the
+quantum-Markov decomposition on the middle subsystem. -/
+theorem sal_implies_eta_structure
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSAL : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    Nonempty (EtaStructure ρ_ABC) :=
+  Entropy.exists_quantumMarkovDecomposition_of_ssaEquality ρ_ABC hρ_dm hSAL
+
+end LocalSAL
+
+section RankOneT
+
+variable {n : ℕ}
+
+/-- **Lemma C.4, scoped matrix form**: once the matrix `T` attached to the
+local `η`-structure is known to be primitive and to have constant trace on all
+positive powers, the remaining Perron–Frobenius input forces `T` to be rank one.
+
+The normalization `a ⬝ᵥ b = 1` is then immediate from `trace T = 1` and the
+identity `trace (vecMulVec a b) = a ⬝ᵥ b`. -/
+theorem sal_zcl_implies_rank_one_T
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hTrace : Matrix.trace T = 1)
+    (hZCL : Matrix.TracePowersConstant T)
+    (hPF : Matrix.PrimitiveTracePowersConstantImpliesRankOne T) :
+    ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
+  rcases hPF hPrimitive hZCL with ⟨a, b, hT⟩
+  refine ⟨a, b, hT, ?_⟩
+  calc
+    a ⬝ᵥ b = Matrix.trace (Matrix.vecMulVec a b) := by
+      symm
+      exact Matrix.trace_vecMulVec a b
+    _ = Matrix.trace T := by rw [← hT]
+    _ = 1 := hTrace
+
+end RankOneT
+
+end MPOTensor

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -384,6 +384,89 @@ legs cyclically and taking the resulting trace.
     (Theorem~\ref{thm:zcl_iff_idempotent_transfer}).
 \end{proof}
 
+\section{Simple local structure from SAL and ZCL}
+
+For the simple MPDO case in Appendix~C.2 of \cite{Cirac2017MPDO_AnnPhys},
+the strong-area-law hypothesis is used locally through the equality case of
+strong subadditivity for a normalized three-site reduced state.
+
+\begin{definition}[Local $\eta$-structure for a three-site reduced state]
+    \label{def:mpdo_eta_structure}
+    \lean{MPOTensor.EtaStructure}
+    \leanok
+    \uses{def:entropy_quantum_markov_decomposition}
+    For a three-site density operator $\rho_{ABC}$, the local $\eta$-structure
+    is the quantum Markov decomposition on the middle subsystem $B$ produced by
+    equality in strong subadditivity. Concretely, after a unitary change of
+    basis on $B$, one has a finite direct-sum decomposition
+    \[
+        B = \bigoplus_k \bigl(b_1^{(k)} \otimes b_2^{(k)}\bigr)
+    \]
+    such that
+    \[
+        \rho_{ABC} = \bigoplus_k \rho_{A b_1}^{(k)} \otimes \rho_{b_2 C}^{(k)}.
+    \]
+\end{definition}
+
+\begin{theorem}[SAL implies local $\eta$-structure]
+    \label{thm:sal_implies_eta_structure}
+    \lean{MPOTensor.sal_implies_eta_structure}
+    \leanok
+    \uses{def:ssa_equality, def:mpdo_eta_structure}
+    If a normalized three-site reduced state satisfies the equality case of
+    strong subadditivity --- the local entropy form of the simple-MPDO strong
+    area law --- then it admits the local $\eta$-structure of
+    Definition~\ref{def:mpdo_eta_structure}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:entropy_ssa_equality_quantum_markov}
+    This is exactly the forward implication of the Hayashi equality
+    characterization: equality in strong subadditivity yields a quantum Markov
+    decomposition on the middle subsystem.
+\end{proof}
+
+\begin{definition}[Auxiliary matrix predicates for the rank-one step]
+    \label{def:matrix_trace_rankone_predicates}
+    \lean{Matrix.TracePowersConstant}
+    \lean{Matrix.HasRankOneFactorization}
+    \lean{Matrix.PrimitiveTracePowersConstantImpliesRankOne}
+    \leanok
+    The auxiliary predicates record three matrix-theoretic ingredients used in
+    the rank-one step of Appendix~C.2, Lemma~C.4: constant traces of all
+    positive powers, existence of a rank-one factorization $T = a b^\top$, and
+    the Perron--Frobenius implication from primitivity together with constant
+    trace powers to such a factorization.
+\end{definition}
+
+\begin{theorem}[SAL and ZCL imply rank-one $T$ (scoped form)]
+    \label{thm:sal_zcl_implies_rank_one_t}
+    \lean{MPOTensor.sal_zcl_implies_rank_one_T}
+    \leanok
+    \uses{def:matrix_trace_rankone_predicates}
+    Let $T$ be the nonnegative matrix extracted from the local $\eta$-data.
+    Assume that $T$ is primitive, that $\tr(T) = 1$, and that every positive
+    power of $T$ has the same trace as $T$. If one further supplies the single
+    Perron--Frobenius input asserting that every primitive nonnegative matrix
+    with constant trace powers is rank one, then
+    \[
+        T = a b^\top
+    \]
+    for some vectors $a$ and $b$, with normalization
+    \[
+        a \cdot b = 1.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:matrix_trace_rankone_predicates}
+    The Perron--Frobenius input gives the factorization $T = a b^\top$.
+    Taking traces and using $\tr(a b^\top) = a \cdot b$ converts the
+    normalization $\tr(T) = 1$ into $a \cdot b = 1$.
+\end{proof}
+
 \section{Horizontal and Vertical Canonical Forms}
 
 \begin{definition}[Horizontal canonical form for an MPO]\label{def:horizontal_cf_mpdo}


### PR DESCRIPTION
## Summary
- add `TNLean/MPS/MPDO/SimpleLocalStructure.lean` for the Appendix C.2 local-structure slice of the simple MPDO argument
- prove `MPOTensor.sal_implies_eta_structure` by packaging the SAL input as SSA equality and applying the sanctioned Hayashi decomposition already available in `TNLean.Entropy.MarkovChain`
- isolate the remaining Perron–Frobenius step for Lemma C.4 via `Matrix.PrimitiveTracePowersConstantImpliesRankOne`, then prove the scoped theorem `MPOTensor.sal_zcl_implies_rank_one_T`
- sync the MPDO blueprint chapter with the new local-structure section and declarations

## Scope note
This lands the honest scoped partial requested in #781:
- C.3 is formalized as the entropy-theoretic local structure currently available in the repo (`EtaStructure = QuantumMarkovDecomposition`)
- C.4 is formalized relative to one explicit missing matrix lemma, rather than by introducing any new global assumption

The still-missing stronger paper-faithful pieces are:
1. the simple-MPDO injective inverse-map layer turning the Hayashi decomposition into explicit neighboring `η_{k,h}` operators;
2. a proved Perron–Frobenius theorem that primitive nonnegative matrices with constant trace powers are rank one.

## Validation
- `lake env lean TNLean/MPS/MPDO/SimpleLocalStructure.lean`
- `lake build TNLean.MPS.MPDO.SimpleLocalStructure TNLean`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `git diff -- TNLean/MPS/MPDO/SimpleLocalStructure.lean TNLean.lean blueprint/src/chapter/ch02b_mpdo.tex | rg -n "sorry|axiom"`

Refs #781 #236 #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new module + documentation) and reuse existing SSA-equality/Markov decomposition results; no existing proofs or core definitions are modified.
> 
> **Overview**
> Adds a new `SimpleLocalStructure` module formalizing the *local* entropy/matrix steps of Appendix C.2 (simple MPDO case): SAL is packaged as SSA equality to obtain an `EtaStructure` via `Entropy.QuantumMarkovDecomposition`, and the Lemma C.4 “rank-one `T`” conclusion is proved in a scoped form from primitivity + constant trace powers, parameterized by a single missing Perron–Frobenius implication (`Matrix.PrimitiveTracePowersConstantImpliesRankOne`).
> 
> Exposes the new module from `TNLean.lean` and updates the MPDO blueprint chapter with a corresponding “Simple local structure from SAL and ZCL” section and the new declarations/theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bef906c8afe347f042707ad49f30ac8fa1b8e93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->