### PR TITLE
feat(MPS/MPDO): simple-RFP commuting-form branch (#782)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -251,6 +251,7 @@ import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.RFP
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.AlgebraStructure
+import TNLean.MPS.MPDO.CommutingForm
 
 -- MPS examples
 import TNLean.MPS.Examples.AKLT

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -6,9 +6,9 @@ import TNLean.MPS.MPDO.RFP
 import TNLean.MPS.ParentHamiltonian.Defs
 
 /-!
-# Commuting-form and GSNNCH packaging for simple MPDOs
+# Commuting-form and GSNNCH data for simple MPDOs
 
-This file packages the commuting-form side of the simple MPDO story from
+This file records the commuting-form side of the simple MPDO story from
 arXiv:1606.00608 §4.4 and Appendix C.2.
 
 For an `N`-site operator `ρ`, a commuting-form witness consists of a positive
@@ -142,7 +142,7 @@ def HasCommutingForm (M : MPOTensor d D) : Prop :=
 /-- A GSNNCH witness at chain length `N`: a commuting-form datum together with
 its positive normalization constant.
 
-This packages Definition 4.8 in the equivalent positive-operator form
+This records Definition 4.8 in the equivalent positive-operator form
 `ρ⁽ᴺ⁾ = c ∏ᵢ B_{i,i+1}`, where `c > 0` and the translated bond operators
 commute pairwise. The paper's exponential form is recovered by taking
 `B_{i,i+1} = e^{-h_{i,i+1}}` or, more generally, by the projector-limit
@@ -185,7 +185,7 @@ namespace CommutingFormData
 variable {N : ℕ}
 
 /-- A commuting-form witness together with a positive normalization constant
-packages into GSNNCH data. -/
+induces GSNNCH data. -/
 def toGSNNCHData (data : CommutingFormData d N) (c : ℝ) (hc : 0 < c) :
     GSNNCHData d N where
   form := data

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -1,0 +1,243 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.RFP
+import TNLean.MPS.ParentHamiltonian.Defs
+
+/-!
+# Commuting-form and GSNNCH packaging for simple MPDOs
+
+This file packages the commuting-form side of the simple MPDO story from
+arXiv:1606.00608 §4.4 and Appendix C.2.
+
+For an `N`-site operator `ρ`, a commuting-form witness consists of a positive
+semidefinite two-site matrix `B`, together with proofs that its translated
+copies on the periodic chain pairwise commute and that their product
+reproduces `ρ` up to a positive scalar. This is the projector-limit version of
+Definition 4.8 (GSNNCH). The actual entropy-side derivation
+`SAL ⟹ HasCommutingForm` is not yet formalized here; it is isolated as the
+upstream missing theorem recorded in the accompanying audit for issue #782.
+
+## Main declarations
+
+* `MPOTensor.ChainOperator`
+* `MPOTensor.AgreesOutsideWindow`
+* `MPOTensor.embedLocalOperator`
+* `MPOTensor.CommutingFormData`
+* `MPOTensor.HasCommutingForm`
+* `MPOTensor.GSNNCHData`
+* `MPOTensor.IsGSNNCH`
+* `MPOTensor.isGSNNCH_iff_hasCommutingForm`
+* `MPOTensor.IsGSNNCHWithZCL`
+
+## References
+
+* [CPGSV17] arXiv:1606.00608, Definition 4.8 and Appendix C.2 Proposition C.6
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix Finset
+
+namespace MPOTensor
+
+attribute [local instance] Classical.decEq Classical.propDecidable
+
+variable {d D N : ℕ}
+
+/-- The matrix algebra on an `N`-site chain with local dimension `d`. -/
+abbrev ChainOperator (d N : ℕ) :=
+  Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ
+
+/-- Two chain configurations agree outside the translated length-`L` window
+starting at `i` when replacing the window of `τ` by that of `σ` recovers `σ`.
+This is the matrix-entry side condition used to embed an `L`-site operator into
+an `N`-site periodic chain. -/
+def AgreesOutsideWindow (L : ℕ) {N : ℕ} (hLN : L ≤ N) (i : Fin N)
+    (σ τ : Fin N → Fin d) : Prop :=
+  MPSTensor.replaceWindow L hLN i τ (MPSTensor.extractWindow L i σ) = σ
+
+/-- Embed an `L`-site operator into the periodic `N`-site chain at position `i`,
+acting as the given local matrix on the window and as the identity on the
+complement. -/
+noncomputable def embedLocalOperator (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
+    (B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) : ChainOperator d N := by
+  classical
+  exact Matrix.of fun σ τ =>
+    if AgreesOutsideWindow (d := d) L hLN i σ τ then
+      B (MPSTensor.extractWindow L i σ) (MPSTensor.extractWindow L i τ)
+    else 0
+
+@[simp] theorem embedLocalOperator_apply (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
+    (B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) (σ τ : Fin N → Fin d) :
+    embedLocalOperator (d := d) L N hLN i B σ τ =
+      if AgreesOutsideWindow (d := d) L hLN i σ τ then
+        B (MPSTensor.extractWindow L i σ) (MPSTensor.extractWindow L i τ)
+      else 0 := by
+  classical
+  rfl
+
+/-- Chain-level commuting-form data for Proposition C.6.
+
+The current record stores the translation-invariant two-site factor `B` together
+with chain-level commutativity of its translated copies. The intended
+nearest-neighbor support is encoded by `embedLocalOperator`; no separate
+factorization API is required downstream. -/
+structure CommutingFormData (d N : ℕ) where
+  /-- The theorem only makes sense for genuine nearest-neighbor chains. -/
+  hN : 2 ≤ N
+  /-- The positive semidefinite two-site factor `B`. -/
+  bond : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ
+  /-- Positivity of the local factor. -/
+  bond_pos : Matrix.PosSemidef bond
+  /-- Pairwise commutativity of the translated factors on the `N`-site chain. -/
+  bond_comm :
+    ∀ i j : Fin N,
+      embedLocalOperator (d := d) 2 N hN i bond
+        * embedLocalOperator (d := d) 2 N hN j bond
+      = embedLocalOperator (d := d) 2 N hN j bond
+          * embedLocalOperator (d := d) 2 N hN i bond
+
+namespace CommutingFormData
+
+variable {N : ℕ}
+
+/-- The translated copy of the local bond operator at site `i`. -/
+noncomputable def bondAt (data : CommutingFormData d N) (i : Fin N) :
+    ChainOperator d N :=
+  embedLocalOperator (d := d) 2 N data.hN i data.bond
+
+@[simp] theorem bondAt_apply (data : CommutingFormData d N) (i : Fin N)
+    (σ τ : Fin N → Fin d) :
+    data.bondAt i σ τ =
+      if AgreesOutsideWindow (d := d) 2 data.hN i σ τ then
+        data.bond (MPSTensor.extractWindow 2 i σ) (MPSTensor.extractWindow 2 i τ)
+      else 0 := by
+  classical
+  rfl
+
+theorem bondAt_comm (data : CommutingFormData d N) (i j : Fin N) :
+    data.bondAt i * data.bondAt j = data.bondAt j * data.bondAt i :=
+  data.bond_comm i j
+
+/-- The commuting product `∏_i B_{i,i+1}` on the periodic chain, taken in the
+natural order of `Fin N`. -/
+noncomputable def product (data : CommutingFormData d N) : ChainOperator d N :=
+  (List.ofFn fun i : Fin N => data.bondAt i).prod
+
+/-- The commuting-form datum realizes `ρ` when `ρ` equals the commuting product
+up to a positive real normalization factor. -/
+def Realizes (data : CommutingFormData d N) (ρ : ChainOperator d N) : Prop :=
+  ∃ c : ℝ, 0 < c ∧ ρ = (c : ℂ) • data.product
+
+end CommutingFormData
+
+/-- Global commuting-form property for an MPO tensor: each finite chain of
+length at least `2` admits a commuting-form witness for the corresponding MPO
+operator. -/
+def HasCommutingForm (M : MPOTensor d D) : Prop :=
+  ∀ N : ℕ, 2 ≤ N →
+    ∃ data : CommutingFormData d N, data.Realizes (mpo M N)
+
+/-- A GSNNCH witness at chain length `N`: a commuting-form datum together with
+its positive normalization constant.
+
+This packages Definition 4.8 in the equivalent positive-operator form
+`ρ⁽ᴺ⁾ = c ∏ᵢ B_{i,i+1}`, where `c > 0` and the translated bond operators
+commute pairwise. The paper's exponential form is recovered by taking
+`B_{i,i+1} = e^{-h_{i,i+1}}` or, more generally, by the projector-limit
+convention explained immediately after Definition 4.8. -/
+structure GSNNCHData (d N : ℕ) where
+  /-- The underlying commuting-form data. -/
+  form : CommutingFormData d N
+  /-- Positive normalization constant. -/
+  normalization : ℝ
+  /-- The normalization constant is strictly positive. -/
+  normalization_pos : 0 < normalization
+
+namespace GSNNCHData
+
+variable {N : ℕ}
+
+/-- The chain operator represented by a GSNNCH witness. -/
+noncomputable def state (data : GSNNCHData d N) : ChainOperator d N :=
+  (data.normalization : ℂ) • data.form.product
+
+/-- Every GSNNCH witness gives back the underlying commuting-form realization. -/
+theorem realizes_form_state (data : GSNNCHData d N) :
+    data.form.Realizes data.state := by
+  refine ⟨data.normalization, data.normalization_pos, ?_⟩
+  rfl
+
+end GSNNCHData
+
+/-- Chain-level GSNNCH predicate. -/
+def IsGSNNCHAt {d N : ℕ} (ρ : ChainOperator d N) : Prop :=
+  ∃ data : GSNNCHData d N, ρ = data.state
+
+/-- Global GSNNCH predicate for an MPO tensor: every chain length `N ≥ 2`
+produces a GSNNCH operator in the sense of Definition 4.8. -/
+def IsGSNNCH (M : MPOTensor d D) : Prop :=
+  ∀ N : ℕ, 2 ≤ N → IsGSNNCHAt (mpo M N)
+
+namespace CommutingFormData
+
+variable {N : ℕ}
+
+/-- A commuting-form witness together with a positive normalization constant
+packages into GSNNCH data. -/
+def toGSNNCHData (data : CommutingFormData d N) (c : ℝ) (hc : 0 < c) :
+    GSNNCHData d N where
+  form := data
+  normalization := c
+  normalization_pos := hc
+
+/-- Any commuting-form realization yields a GSNNCH witness for the same chain
+operator. -/
+theorem isGSNNCHAt_of_realizes (data : CommutingFormData d N)
+    {ρ : ChainOperator d N} (hρ : data.Realizes ρ) : IsGSNNCHAt ρ := by
+  rcases hρ with ⟨c, hc, hρ⟩
+  refine ⟨data.toGSNNCHData c hc, ?_⟩
+  simpa [GSNNCHData.state] using hρ
+
+end CommutingFormData
+
+theorem isGSNNCHAt_iff_exists_commutingForm {d N : ℕ} (ρ : ChainOperator d N) :
+    IsGSNNCHAt ρ ↔ ∃ data : CommutingFormData d N, data.Realizes ρ := by
+  constructor
+  · rintro ⟨data, hρ⟩
+    refine ⟨data.form, ?_⟩
+    rw [hρ]
+    exact data.realizes_form_state
+  · rintro ⟨data, hρ⟩
+    exact data.isGSNNCHAt_of_realizes hρ
+
+theorem isGSNNCH_of_hasCommutingForm {M : MPOTensor d D}
+    (hM : HasCommutingForm M) : IsGSNNCH M := by
+  intro N hN
+  obtain ⟨data, hdata⟩ := hM N hN
+  exact data.isGSNNCHAt_of_realizes hdata
+
+theorem hasCommutingForm_of_isGSNNCH {M : MPOTensor d D}
+    (hM : IsGSNNCH M) : HasCommutingForm M := by
+  intro N hN
+  rcases (isGSNNCHAt_iff_exists_commutingForm (mpo M N)).mp (hM N hN) with
+    ⟨data, hdata⟩
+  exact ⟨data, hdata⟩
+
+theorem isGSNNCH_iff_hasCommutingForm (M : MPOTensor d D) :
+    IsGSNNCH M ↔ HasCommutingForm M := by
+  constructor
+  · exact hasCommutingForm_of_isGSNNCH
+  · exact isGSNNCH_of_hasCommutingForm
+
+/-- The GSNNCH branch of Theorem 4.9, bundled together with MPO zero
+correlation length. -/
+def IsGSNNCHWithZCL (M : MPOTensor d D) : Prop :=
+  IsGSNNCH M ∧ IsZCL M
+
+theorem isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL (M : MPOTensor d D) :
+    IsGSNNCHWithZCL M ↔ HasCommutingForm M ∧ IsZCL M := by
+  rw [IsGSNNCHWithZCL, isGSNNCH_iff_hasCommutingForm]
+
+end MPOTensor

--- a/audits/2026-04-23_issue782_commuting_form_blocker.md
+++ b/audits/2026-04-23_issue782_commuting_form_blocker.md
@@ -1,0 +1,68 @@
+# Issue #782 blocker note — commuting form / GSNNCH branch
+
+## What landed in this branch
+
+This branch adds `TNLean/MPS/MPDO/CommutingForm.lean`, which formalizes the
+**target side** of Appendix C.2 / Theorem 4.9(iii):
+
+- a chain-level notion `MPOTensor.CommutingFormData` for a positive two-site
+  factor whose translated copies commute on an `N`-site periodic chain,
+- the global MPO predicate `MPOTensor.HasCommutingForm`,
+- the GSNNCH packaging `MPOTensor.GSNNCHData` / `MPOTensor.IsGSNNCH`, and
+- the equivalences
+  - `MPOTensor.isGSNNCHAt_iff_exists_commutingForm`,
+  - `MPOTensor.isGSNNCH_iff_hasCommutingForm`,
+  - `MPOTensor.isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL`.
+
+So the **downstream API** needed for Theorem 4.9 is now present.
+
+## Honest remaining blocker
+
+The missing theorem is the **upstream entropy / local-structure bridge** that
+should produce `HasCommutingForm` from the strong-area-law hypotheses.
+
+The paper route is:
+
+1. SAL gives SSA equality on the relevant tripartite reduction.
+2. Hayashi's characterization yields the block decomposition of the middle site.
+3. One extracts the local `η_{k,h}` data of Appendix C.2.
+4. From that local `η`-structure one constructs the commuting two-site factor
+   and proves the global commuting-form identity.
+
+Steps 1–2 are partially available in the repo through the sanctioned entropy
+API (`TNLean.Entropy.StrongSubadditivity`, `TNLean.Entropy.MarkovChain`), but
+steps 3–4 are not yet formalized for MPDO tensors. In particular, the project
+still lacks the MPDO-side local-structure record that would bridge the Hayashi
+block decomposition to the explicit two-site commuting factor.
+
+## Precise theorem statement now isolated by the new API
+
+With the new file in place, the mathematically precise remaining theorem is:
+
+> For a simple MPDO tensor satisfying the Appendix C.2 strong-area-law
+> hypotheses, prove `MPOTensor.HasCommutingForm`.
+
+Equivalently, once the local `η`-structure is defined, the immediate next Lean
+statement should be a theorem of the form
+
+```lean
+-- schematic statement, not yet in the library
+ theorem hasCommutingForm_of_etaLocalStructure
+    {d D : ℕ} {M : MPOTensor d D}
+    (hEta : -- output of the local-structure / issue #781 branch --) :
+    HasCommutingForm M
+```
+
+and the final Appendix C.2 corollary would be
+
+```lean
+-- schematic statement, pending future `Simple` / `SAL` predicates
+ theorem hasCommutingForm_of_simple_of_sal
+    {d D : ℕ} {M : MPOTensor d D}
+    (hSimple : ...)
+    (hSAL : ...) :
+    HasCommutingForm M
+```
+
+At that point `MPOTensor.isGSNNCH_of_hasCommutingForm` immediately packages the
+result as the GSNNCH side of Theorem 4.9.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -613,3 +613,81 @@ recovery theorem for the provisional MPO predicate.
     \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys} is to be substituted
     in place of the trivial relation in subsequent work.
 \end{definition}
+
+\section{Commuting form and GSNNCH}
+
+\begin{definition}[Commuting-form data for an MPDO]
+    \label{def:mpdo_commuting_form_data}
+    \lean{MPOTensor.CommutingFormData}
+    \leanok
+    \uses{def:mpo_tensor}
+    For a fixed chain length $N \ge 2$, this consists of a positive
+    semidefinite two-site operator $B$ such that its translated copies on the
+    periodic chain commute pairwise.
+\end{definition}
+
+\begin{definition}[Commuting-form property]
+    \label{def:mpdo_has_commuting_form}
+    \lean{MPOTensor.HasCommutingForm}
+    \leanok
+    \uses{def:mpdo_commuting_form_data, def:mpo_tensor}
+    An MPO tensor has the commuting-form property if for every $N \ge 2$ its
+    $N$-site operator is a positive scalar multiple of the product of the
+    translated copies of some commuting two-site operator $B$.
+\end{definition}
+
+\begin{definition}[GSNNCH]
+    \label{def:mpdo_is_gsnnch}
+    \lean{MPOTensor.IsGSNNCH}
+    \leanok
+    \uses{def:mpdo_has_commuting_form}
+    An MPO tensor is a Gibbs state of a nearest-neighbor commuting Hamiltonian
+    if every finite-chain operator admits the equivalent positive-operator
+    presentation $\rho^{(N)} = c \prod_i B_{i,i+1}$ with $c > 0$ and
+    commuting nearest-neighbor factors. The projector-limit convention after
+    Definition~4.8 of \cite{Cirac2017MPDO_AnnPhys} identifies this with the
+    exponential Gibbs form.
+\end{definition}
+
+\begin{theorem}[GSNNCH iff commuting form]
+    \label{thm:mpdo_is_gsnnch_iff_has_commuting_form}
+    \lean{MPOTensor.isGSNNCH_iff_hasCommutingForm}
+    \leanok
+    \uses{def:mpdo_is_gsnnch, def:mpdo_has_commuting_form}
+    For an MPO tensor, the GSNNCH condition is equivalent to the existence of
+    commuting-form data on every finite chain.
+\end{theorem}
+
+\begin{proof}\leanok
+A positive normalization constant converts commuting-form data into a GSNNCH
+witness, and every GSNNCH witness remembers its underlying commuting-form data.
+\end{proof}
+
+\begin{definition}[GSNNCH with zero correlation length]
+    \label{def:mpdo_is_gsnnch_zcl}
+    \lean{MPOTensor.IsGSNNCHWithZCL}
+    \leanok
+    \uses{def:mpdo_is_gsnnch, def:mpo_is_zcl}
+    This is the conjunction of the GSNNCH condition with MPO zero correlation
+    length, i.e. the content of item~(iii) in the simple-MPDO theorem.
+\end{definition}
+
+\begin{theorem}[GSNNCH with zero correlation length iff commuting form with zero correlation length]
+    \label{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}
+    \lean{MPOTensor.isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL}
+    \leanok
+    \uses{def:mpdo_is_gsnnch_zcl, thm:mpdo_is_gsnnch_iff_has_commuting_form}
+    The GSNNCH--ZCL branch is equivalent to the conjunction of the
+    commuting-form property with MPO zero correlation length.
+\end{theorem}
+
+\begin{proof}\leanok
+Unfold the definition of GSNNCH with zero correlation length and apply
+Theorem~\ref{thm:mpdo_is_gsnnch_iff_has_commuting_form}.
+\end{proof}
+
+\begin{remark}[Remaining step toward Proposition~C.6]
+The remaining entropy-side theorem is to derive the commuting-form property
+from the strong-area-law hypotheses of Appendix~C.2. The present file isolates
+its GSNNCH target once that step is available.
+\end{remark}


### PR DESCRIPTION
## Summary
- add `TNLean/MPS/MPDO/CommutingForm.lean` with chain-level commuting-form data, GSNNCH data, and the equivalence `IsGSNNCH ↔ HasCommutingForm`
- package the Theorem 4.9(iii) branch with `IsGSNNCHWithZCL` and sync the MPDO blueprint chapter
- add an honest blocker audit isolating the remaining upstream theorem `SAL/simple local structure -> HasCommutingForm`

## Status
This PR lands the **downstream commuting-form / GSNNCH API** for issue #782, but it does **not** yet prove Appendix C.2 Prop. C.6 from the strong-area-law hypotheses themselves.

The remaining blocker is the MPDO-side local-structure bridge from the entropy/Hayashi decomposition to an explicit commuting two-site factor. The new API isolates that missing theorem precisely as the statement `HasCommutingForm`.

## Validation
- `cd .worktrees/issue-782 && lake env lean TNLean/MPS/MPDO/CommutingForm.lean`
- `cd .worktrees/issue-782 && lake build TNLean.MPS.MPDO.CommutingForm TNLean`
- `cd .worktrees/issue-782 && lake env lean TNLean.lean`
- `cd .worktrees/issue-782 && rg -n "sorry|axiom" TNLean/MPS/MPDO/ TNLean/MPS/RFP/ TNLean/MPS/ParentHamiltonian/ || true`
- `cd .worktrees/issue-782/blueprint && leanblueprint web && leanblueprint checkdecls`

The `rg` command still reports pre-existing hits in `ParentHamiltonian/{DegenerateGS,Martingale,UniqueGroundState}.lean`; this PR adds no new `sorry`/`axiom` entries.

Refs #782 #236 #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive: new definitions/lemmas and documentation with no changes to existing proofs or core semantics; main risk is minor API naming/import-surface impact for downstream users.
> 
> **Overview**
> Introduces `TNLean/MPS/MPDO/CommutingForm.lean`, defining chain-level embedding of local operators and new predicates/records for *commuting-form* witnesses (`CommutingFormData`, `HasCommutingForm`) and their GSNNCH packaging (`GSNNCHData`, `IsGSNNCH`), including equivalences `IsGSNNCHAt`/`IsGSNNCH` ↔ existence of commuting-form realizations.
> 
> Adds `IsGSNNCHWithZCL` and the lemma `isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL` to align with the Theorem 4.9(iii) branch, exposes the module from `TNLean.lean`, updates the MPDO blueprint chapter with the new definitions/theorems, and adds an audit note explicitly isolating the remaining upstream theorem needed to derive `HasCommutingForm` from entropy/SAL hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca49211742c72e2a171ca6ecfb328adf7f93a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->