### PR TITLE
feat(PEPS): virtual-insertion and graph-blocking infrastructure (#763)

### DIFF
--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -11,7 +11,7 @@ For a PEPS tensor `A` and a vertex `v`, the family
 virtual configurations into the physical space `Fin d → ℂ`. Under
 `IsVertexInjective A`, this map is injective, hence admits a left inverse.
 
-This file packages that left inverse and the induced realization of virtual
+This file records that left inverse and the induced realization of virtual
 endomorphisms as physical linear maps on the local physical space.
 
 ## Main results


### PR DESCRIPTION
## Summary
- add `TNLean.PEPS.VirtualInsertion` with the local virtual configuration type, the local tensor map, a chosen left inverse under vertex injectivity, and the physical realization of local virtual endomorphisms
- add `TNLean.PEPS.Blocking` with endpoint-incidence helpers, the split of a star at one distinguished incident edge, and the edge-centered vertex partition data
- wire the new modules into `TNLean.lean`, reuse the endpoint-incidence helpers in `TNLean/PEPS/FundamentalTheorem.lean`, and extend the PEPS blueprint section to match the landed infrastructure

## What this gives to #780
- the per-vertex linear-algebra input from arXiv:1804.04964 §3 is now packaged explicitly: `localTensorMap`, `localLeftInverse`, and `physRealizeLocalOp`
- the elementary edge-centered decompositions needed for the later three-site reduction are now available: `localVirtualConfigSplitAt`, `edgeMiddleVertices`, and `edgeVertices_union`
- the remaining PEPS FT `sorry`s are now documented against the narrower missing piece: the blocked middle/environment tensor and its comparison with the 1D injective MPS theorem

## What still remains
- define the blocked tensor on the middle region for an edge-centered partition
- prove that the blocked neighbourhood around an edge gives the right injective three-site MPS input
- use that reduction to discharge `localGauge_exists`, `gaugeConsistency`, and the `hDim` step inside `fundamentalTheorem_PEPS`

## Validation
- `lake env lean TNLean/PEPS/VirtualInsertion.lean`
- `lake env lean TNLean/PEPS/Blocking.lean`
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`
- `lake build TNLean.PEPS.VirtualInsertion TNLean.PEPS.Blocking TNLean.PEPS.FundamentalTheorem TNLean`
- `lake build`
- `rg -n "sorry|axiom" TNLean/PEPS/`
- `leanblueprint web`
- `leanblueprint checkdecls`

Net new `sorry`s: 0. The PEPS directory still has the same four pre-existing `sorry`s in `TNLean/PEPS/FundamentalTheorem.lean`.

Refs #763 #780 #128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a docstring sentence in `TNLean/PEPS/VirtualInsertion.lean` with no functional or proof changes.
> 
> **Overview**
> Updates the module documentation in `TNLean/PEPS/VirtualInsertion.lean`, rephrasing the description of the file’s purpose ("packages" → "records") without changing any definitions or theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c04c0c7569fb6a56c7bc8ccc118a5e5c188a5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->