### PR TITLE
feat(MPS/MPDO): non-vacuous algebra-structure data for general MPDO RFP (#612)

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -212,9 +212,8 @@ def IsRFP_MPDO_via_algebra (M : MPOTensor d D) : Prop :=
 
 The old definition was vacuous. The new alias points to the non-vacuous algebra
 predicate above. -/
-@[deprecated IsRFP_MPDO_via_algebra (since := "2026-04-24")]
-abbrev IsRFP_MPDO_via_algebra_scaffold (M : MPOTensor d D) : Prop :=
-  IsRFP_MPDO_via_algebra M
+@[deprecated (since := "2026-04-24")] alias IsRFP_MPDO_via_algebra_scaffold :=
+  IsRFP_MPDO_via_algebra
 
 /-- A trace-preserving MPO with a positive-definite fixed point admits a
 stationary algebra tower as soon as it is an RFP. -/

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -41,7 +41,9 @@ one-way bridge
 * `isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed`
 
 from the current fusion formulation to the algebra formulation, under the same
-side hypotheses.
+side hypotheses. The `IsRFP` assumption is essential here: without idempotence,
+the adjoint fixed-point algebras of the blocked transfer maps need not stabilize
+with the blocking length.
 
 ## Remaining gap to the paper
 
@@ -138,7 +140,7 @@ one of its positive-definite fixed points.
 Concretely, this is the fixed-point `StarSubalgebra` of the adjoint transfer map
 `(transferMap M).adjoint`, packaged through Wolf Theorem 6.12 for the doubled
 MPS tensor `M.toMPSTensor`. -/
-noncomputable def faithfulFixedPointSupportAlgebra
+def faithfulFixedPointSupportAlgebra
     (M : MPOTensor d D) (h_tp : Kraus.IsTP M.toMPSTensor)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ) :
     StarSubalgebra ℂ Mat :=
@@ -158,13 +160,7 @@ theorem mem_faithfulFixedPointSupportAlgebra_iff
   have hAdj : Kraus.adjointMap M.toMPSTensor X = (transferMap M).adjoint X := by
     simpa [transferMap_eq_toMPSTensor] using
       (MPSTensor.transferMap_adjoint_apply_eq_adjointMap (A := M.toMPSTensor) X).symm
-  constructor
-  · intro h
-    rw [hAdj] at h
-    exact h
-  · intro h
-    rw [hAdj]
-    exact h
+  rw [hAdj]
 
 namespace AlgebraStructureData
 
@@ -173,21 +169,16 @@ transfer map.
 
 All support algebras are the same `StarSubalgebra`, multiplication is ordinary
 matrix multiplication, and the inclusion maps are identities. -/
-noncomputable def stationaryOfFaithfulFixedPoint
+def stationaryOfFaithfulFixedPoint
     (M : MPOTensor d D) (h_tp : Kraus.IsTP M.toMPSTensor)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ) :
-    AlgebraStructureData d D := by
+    AlgebraStructureData d D :=
   let S : StarSubalgebra ℂ Mat := faithfulFixedPointSupportAlgebra M h_tp hρ hρ_fix
-  refine
-    { A := fun _ => S
-      m := fun _ => LinearMap.mul ℂ ↥S
-      iota := fun _ => LinearMap.id
-      m_apply := ?_
-      iota_apply := ?_ }
-  · intro n x y
-    rfl
-  · intro n x
-    rfl
+  { A := fun _ => S
+    m := fun _ => LinearMap.mul ℂ ↥S
+    iota := fun _ => LinearMap.id
+    m_apply := fun _ _ _ => rfl
+    iota_apply := fun _ _ => rfl }
 
 /-- The stationary tower from a faithful fixed point is compatible with any RFP
 MPO tensor, because all positive blocked transfer maps agree with `transferMap M`. -/
@@ -216,6 +207,14 @@ An MPO tensor satisfies `IsRFP_MPDO_via_algebra` when it admits algebra-structur
 support data compatible with its blocked adjoint transfer maps. -/
 def IsRFP_MPDO_via_algebra (M : MPOTensor d D) : Prop :=
   ∃ data : AlgebraStructureData d D, data.CompatibleWith M
+
+/-- Backwards-compatible alias for the previous scaffold name.
+
+The old definition was vacuous. The new alias points to the non-vacuous algebra
+predicate above. -/
+@[deprecated IsRFP_MPDO_via_algebra (since := "2026-04-24")]
+abbrev IsRFP_MPDO_via_algebra_scaffold (M : MPOTensor d D) : Prop :=
+  IsRFP_MPDO_via_algebra M
 
 /-- A trace-preserving MPO with a positive-definite fixed point admits a
 stationary algebra tower as soon as it is an RFP. -/

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -774,22 +774,37 @@ recovery theorem for the MPDO renormalization fixed-point condition.
     family $c_{\alpha,\beta,\gamma}^{(L)}$ is not yet extracted.
 \end{definition}
 
+\begin{theorem}[RFP yields a stationary algebra tower under a faithful fixed point]%
+    \label{thm:mpdo_rfp_via_algebra_from_rfp}
+    \lean{MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed}
+    \leanok
+    \uses{def:is_rfp_mpdo, def:mpdo_rfp_via_algebra}
+    Assume the doubled tensor is trace-preserving and the transfer map admits a
+    positive-definite fixed point. If the transfer map is idempotent, then there
+    exists a stationary family of support algebras, all equal to the fixed-point
+    algebra of the adjoint transfer map, with multiplication given by matrix
+    multiplication and inclusions given by the identity.
+\end{theorem}
+\begin{proof}\leanok
+Under the trace-preserving normalization and the faithful fixed point, Wolf's
+fixed-point-algebra theorem gives a $*$-subalgebra of adjoint fixed points.
+Idempotence identifies every positive blocked transfer map with the original
+one, so the same fixed-point algebra works at every blocking size.
+\end{proof}
+
 \begin{theorem}[Fusion yields a stationary algebra tower under a faithful fixed point]%
     \label{thm:mpdo_rfp_via_algebra_from_fusion}
     \lean{MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed}
     \leanok
-    \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion}
+    \uses{thm:mpdo_rfp_of_fusion, thm:mpdo_rfp_via_algebra_from_rfp}
     Assume the doubled tensor is trace-preserving and the transfer map admits a
     positive-definite fixed point. If the transfer-map fusion criterion holds,
     then the MPO satisfies the algebra-structure formulation of the
     renormalization fixed-point condition.
 \end{theorem}
 \begin{proof}\leanok
-The fusion criterion implies idempotence of the transfer map. Under the
-trace-preserving normalization and the faithful fixed point, Wolf's
-fixed-point-algebra theorem gives a $*$-subalgebra of adjoint fixed points.
-Idempotence identifies every positive blocked transfer map with the original
-one, so the same fixed-point algebra works at every blocking size.
+Combine Theorem~\ref{thm:mpdo_rfp_of_fusion} with
+Theorem~\ref{thm:mpdo_rfp_via_algebra_from_rfp}.
 \end{proof}
 
 The current Lean layer still does not recover the paper's special diagonal


### PR DESCRIPTION
## Summary

This PR delivers genuine forward progress on #612 by replacing the old vacuous algebra-side scaffold with a non-vacuous support-algebra formulation for general MPDO RFP.

What lands:
- `MPOTensor.AlgebraStructureData` is now a tower of genuine `StarSubalgebra ℂ (Matrix ...)` objects `A n`, with
  - blocking maps `m n : A n →ₗ[ℂ] A n →ₗ[ℂ] A (2 * n)`;
  - inclusion maps `iota n : A n →ₗ[ℂ] A (n + 1)`;
  - fields asserting these are realized by ambient matrix multiplication / ambient inclusion.
- `AlgebraStructureData.CompatibleWith` is no longer `True`; it now says that for every positive blocked size `n`, membership in `A n` is equivalent to being fixed by the adjoint blocked transfer map `(blockedTransferMap M n).adjoint`.
- `MPOTensor.faithfulFixedPointSupportAlgebra` packages the adjoint fixed-point `StarSubalgebra` from Wolf Theorem 6.12 under TP + positive-definite fixed-point hypotheses.
- `MPOTensor.AlgebraStructureData.stationaryOfFaithfulFixedPoint` builds the constant/stationary algebra tower with ordinary matrix multiplication and identity inclusions.
- Honest forward bridge theorems:
  - `MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed`
  - `MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed`

So, under the trace-preserving normalization and a positive-definite fixed point of the transfer map, the transfer-map fusion formulation now implies a genuine algebra-side formulation.

## What is still left

This is **not yet** the full Theorem IV.13(ii) coefficient formalization.
Remaining follow-up work:
- extract the coefficient family `c_{α,β,γ}^{(L)}` / `χ_{α,β,γ}` from the BNT data;
- prove the converse algebra ⇒ fusion direction;
- finish the full equivalence with the paper's coefficient statement.

In that sense, this PR supersedes the old purely-blocker state from #692: the basic support-algebra layer is no longer vacuous, but the coefficient/BNT layer is still outstanding.

## Blueprint

Updated `blueprint/src/chapter/ch02b_mpdo.tex` to:
- reflect the new non-vacuous algebra-structure definition;
- add the forward fusion ⇒ algebra theorem under TP + faithful fixed-point hypotheses;
- fix a stale declaration tag (`MPSTensor.propblockinj_of_propBlockInjective` → `MPSTensor.hasBiCF_of_propBlockInjective`) so `leanblueprint checkdecls` succeeds.

## Validation

Run in `.worktrees/issue-612-v2`:
- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake build TNLean.MPS.MPDO.AlgebraStructure`
- `lake build`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `git diff --unified=0 origin/main -- TNLean/MPS/MPDO/AlgebraStructure.lean blueprint/src/chapter/ch02b_mpdo.tex | rg -n '\b(sorry|axiom|admit|native_decide)\b' || true`

Refs #612 #237

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core logical predicates (`IsRFP_MPDO_via_algebra*`) from vacuous to meaningful, which can invalidate downstream lemmas and require proof updates. No runtime/security impact; risk is confined to theorem statements and proof obligations.
> 
> **Overview**
> Upgrades the MPDO algebra-side RFP layer so `AlgebraStructureData.CompatibleWith` becomes a **real condition**: for every positive blocking length `n`, `A n` is exactly the adjoint fixed-point algebra of `(blockedTransferMap M n).adjoint`.
> 
> Adds `faithfulFixedPointSupportAlgebra` (Wolf fixed-point `StarSubalgebra` under TP + pos-def fixed point) and uses it to build a *stationary* algebra tower `stationaryOfFaithfulFixedPoint`, proving `isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed` (and hence the fusion ⇒ algebra bridge). A deprecated alias keeps the old name `IsRFP_MPDO_via_algebra_scaffold` pointing to the new predicate, and the blueprint text is updated to include the new theorem and simplify the fusion ⇒ algebra proof reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57ff27c8b37f66b3e1433ce1581da478943148b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->