### PR TITLE
feat(MPS/MPDO): blocked-RFP assembly toward simple MPDO FT (#783)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -51,6 +51,7 @@ import TNLean.Channel.PartialTrace
 import TNLean.Channel.MaximallyEntangled
 import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.Stinespring
@@ -71,6 +72,7 @@ import TNLean.Axioms.Entropy
 -- re-state the sanctioned entropy axioms under the Entropy namespace.
 import TNLean.Entropy.VonNeumann
 import TNLean.Entropy.StrongSubadditivity
+import TNLean.Entropy.TripartiteTrace
 import TNLean.Entropy.MarkovChain
 import TNLean.Entropy.MutualInformation
 -- Layer 2b: Axiomatized operator convexity/concavity results (pending upstream Mathlib)
@@ -338,4 +340,7 @@ import TNLean.Channel.Determinant
 
 -- PEPS (exploratory)
 import TNLean.PEPS.Defs
+import TNLean.PEPS.VirtualInsertion
+import TNLean.PEPS.Blocking
+import TNLean.PEPS.LocalGauge
 import TNLean.PEPS.FundamentalTheorem

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -253,7 +253,7 @@ import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.AlgebraStructure
 import TNLean.MPS.MPDO.CommutingForm
-import TNLean.MPS.MPDO.BlockedRFPAssembly
+import TNLean.MPS.MPDO.BlockedRFPConstruction
 
 -- MPS examples
 import TNLean.MPS.Examples.AKLT

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -51,7 +51,6 @@ import TNLean.Channel.PartialTrace
 import TNLean.Channel.MaximallyEntangled
 import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
-import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.Stinespring
@@ -71,7 +70,6 @@ import TNLean.Axioms.Entropy
 -- from `TNLean.Axioms.Entropy`; the `TNLean.Entropy.*` modules
 -- re-state the sanctioned entropy axioms under the Entropy namespace.
 import TNLean.Entropy.VonNeumann
-import TNLean.Entropy.TripartiteTrace
 import TNLean.Entropy.StrongSubadditivity
 import TNLean.Entropy.MarkovChain
 import TNLean.Entropy.MutualInformation
@@ -255,6 +253,7 @@ import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.AlgebraStructure
 import TNLean.MPS.MPDO.CommutingForm
+import TNLean.MPS.MPDO.BlockedRFPAssembly
 
 -- MPS examples
 import TNLean.MPS.Examples.AKLT
@@ -339,7 +338,4 @@ import TNLean.Channel.Determinant
 
 -- PEPS (exploratory)
 import TNLean.PEPS.Defs
-import TNLean.PEPS.VirtualInsertion
-import TNLean.PEPS.Blocking
-import TNLean.PEPS.LocalGauge
 import TNLean.PEPS.FundamentalTheorem

--- a/TNLean/MPS/MPDO/BlockedRFPAssembly.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPAssembly.lean
@@ -1,0 +1,233 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CommutingForm
+import TNLean.MPS.MPDO.FusionIsometries
+import TNLean.MPS.MPDO.SimpleLocalStructure
+
+/-!
+# Blocked-RFP construction for simple MPDOs
+
+This file records the current blocked-RFP theorem interface for the simple-MPDO
+branch of arXiv:1606.00608, Appendix C.2 / Theorem 4.9.
+
+At the present repository state, the local entropy side and the commuting-form
+side live in separate modules:
+
+* `SimpleLocalStructure.lean` isolates the local SAL/SSA and rank-one-`T`
+  consequences of Lemmas C.3--C.4.
+* `CommutingForm.lean` records the GSNNCH / commuting-form target side of
+  Proposition C.6 and Theorem 4.9(iii).
+
+What is still missing upstream is the theorem turning the local simple-MPDO data
+into the global commuting-form property. Because of that gap, the present file
+is formulated around the explicit record `SimpleMPDOBlockedRFPData`. The local
+Appendix C.2 data are retained there so that the eventual local-to-global
+implication has a canonical target.
+
+The current consequences recorded here are:
+
+* a **blocked fusion-isometry witness** at size `2`, formalized as
+  `Nonempty (FusionIsometryData K 2)`;
+* the GSNNCH-with-ZCL branch of Theorem 4.9;
+* the transfer-map fusion formulation of MPDO RFP.
+
+Thus this file supplies the paper-facing endpoint that downstream work can use
+once the remaining local-to-global implication has been formalized.
+
+## Main declarations
+
+* `MPOTensor.SimpleMPDOLocalStructureData`
+* `MPOTensor.SimpleMPDOBlockedRFPData`
+* `MPOTensor.structural_implies_rfp_blocked`
+* `MPOTensor.simple_mpdo_rfp_chain`
+
+## References
+
+* [CPGSV17] arXiv:1606.00608, Appendix C.2, Proposition C.5 and Theorem 4.9
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The local simple-MPDO structure isolated by Appendix C.2, Lemmas C.3--C.4.
+
+This records exactly the information exposed by `SimpleLocalStructure.lean`:
+
+a normalized three-site reduced state satisfying equality in strong
+subadditivity, the resulting local `η`-structure, and a primitive real matrix
+`T` together with the rank-one conclusion extracted from the constant-trace
+condition.
+
+The record is intentionally independent of a particular MPO tensor. The missing
+upstream theorem is the map from a concrete simple MPDO satisfying SAL/ZCL to
+such a record and then onward to `HasCommutingForm`. -/
+structure SimpleMPDOLocalStructureData where
+  /-- Dimensions of the three contiguous local regions. -/
+  dA : ℕ
+  dB : ℕ
+  dC : ℕ
+  /-- The normalized three-site reduced state entering Lemma C.3. -/
+  rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ
+  /-- Density-matrix normalization for the local state. -/
+  hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1
+  /-- Equality in strong subadditivity for `rhoABC`. -/
+  hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian
+  /-- The local `η`-structure extracted from SSA equality. -/
+  eta : Nonempty (EtaStructure rhoABC)
+  /-- The auxiliary real matrix `T` from Lemma C.4. -/
+  Tdim : ℕ
+  T : Matrix (Fin Tdim) (Fin Tdim) ℝ
+  /-- Primitivity of `T`. -/
+  hPrimitive : Matrix.IsPrimitive T
+  /-- Trace normalization of `T`. -/
+  hTrace : Matrix.trace T = 1
+  /-- Constancy of the traces of positive powers of `T`. -/
+  hTraceConst : Matrix.TracePowersConstant T
+  /-- Rank-one conclusion for `T`. -/
+  rankOne : ∃ a b : Fin Tdim → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1
+
+namespace SimpleMPDOLocalStructureData
+
+/-- Construct the local simple-MPDO data record from the scoped Lemma C.3/C.4
+inputs already available in `SimpleLocalStructure.lean`. -/
+def ofSALZCL
+    {dA dB dC n : ℕ}
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hTrace : Matrix.trace T = 1)
+    (hTraceConst : Matrix.TracePowersConstant T)
+    (hPF : Matrix.PrimitiveTracePowersConstantImpliesRankOne T) :
+    SimpleMPDOLocalStructureData where
+  dA := dA
+  dB := dB
+  dC := dC
+  rhoABC := rhoABC
+  hRhoDM := hRhoDM
+  hSSA := hSSA
+  eta := sal_implies_eta_structure rhoABC hRhoDM hSSA
+  Tdim := n
+  T := T
+  hPrimitive := hPrimitive
+  hTrace := hTrace
+  hTraceConst := hTraceConst
+  rankOne := sal_zcl_implies_rank_one_T T hPrimitive hTrace hTraceConst hPF
+
+end SimpleMPDOLocalStructureData
+
+/-- Auxiliary record for the simple-MPDO blocked-RFP argument.
+
+The field `localData` records the Appendix C.2 local structure from issue #781,
+while `commutingForm` and `zcl` record the issue-#782 target side and the MPO
+zero-correlation-length input. This is the current point where the two sibling
+branches meet: the missing theorem is the derivation of `commutingForm` from
+`localData` and the original simple-MPDO SAL hypotheses.
+
+The present blocked-RFP consequences only use `commutingForm` and `zcl`; the
+`localData` field is retained so that the eventual local-to-global implication
+has a canonical target. -/
+structure SimpleMPDOBlockedRFPData (K : MPOTensor d D) where
+  /-- Local SAL/SSA/rank-one data from Appendix C.2. -/
+  localData : SimpleMPDOLocalStructureData
+  /-- Global commuting-form / GSNNCH data. -/
+  commutingForm : HasCommutingForm K
+  /-- Zero correlation length, hence the current provisional RFP predicate. -/
+  zcl : IsZCL K
+
+namespace SimpleMPDOBlockedRFPData
+
+variable {K : MPOTensor d D}
+
+/-- Construct this record directly from the scoped local lemmas of
+`SimpleLocalStructure.lean`, the commuting-form hypothesis, and MPO ZCL. -/
+def ofSALZCLAndCommutingForm
+    {dA dB dC n : ℕ}
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hTrace : Matrix.trace T = 1)
+    (hTraceConst : Matrix.TracePowersConstant T)
+    (hPF : Matrix.PrimitiveTracePowersConstantImpliesRankOne T)
+    (hCommuting : HasCommutingForm K) (hZCL : IsZCL K) :
+    SimpleMPDOBlockedRFPData K where
+  localData := SimpleMPDOLocalStructureData.ofSALZCL
+    rhoABC hRhoDM hSSA T hPrimitive hTrace hTraceConst hPF
+  commutingForm := hCommuting
+  zcl := hZCL
+
+/-- The issue-#782 commuting-form data together with MPO ZCL yield the
+GSNNCH-with-ZCL branch of Theorem 4.9. -/
+theorem isGSNNCHWithZCL (data : SimpleMPDOBlockedRFPData K) :
+    IsGSNNCHWithZCL K := by
+  exact (isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL K).2
+    ⟨data.commutingForm, data.zcl⟩
+
+/-- The data record implies the current provisional MPDO RFP predicate. -/
+theorem isRFP (data : SimpleMPDOBlockedRFPData K) : IsRFP K :=
+  data.zcl
+
+/-- The data record implies the transfer-map fusion formulation of MPDO RFP. -/
+theorem isRFPViaFusion (data : SimpleMPDOBlockedRFPData K) :
+    IsRFP_MPDO_via_fusion K := by
+  exact isRFP_MPDO_via_fusion_of_isRFP (M := K) data.isRFP
+
+end SimpleMPDOBlockedRFPData
+
+/-- Zero correlation length yields a blocked fusion-isometry witness at size `2`. -/
+theorem structural_implies_rfp_blocked {K : MPOTensor d D}
+    (hZCL : IsZCL K) :
+    Nonempty (FusionIsometryData K 2) :=
+  (isRFP_MPDO_via_fusion_of_isRFP
+    (M := K)
+    (show IsRFP K from hZCL)) 2 (show 0 < 2 by decide)
+
+/-- **Proposition C.5, data-parameterized form**: if the simple-MPDO inputs are
+recorded in `SimpleMPDOBlockedRFPData`, then the blocked fusion-isometry
+witness follows from the zero-correlation-length field.
+
+The fields `localData` and `commutingForm` are retained for the larger
+simple-MPDO interface, even though the present blocked-fusion consequence only
+uses `data.zcl`. -/
+theorem structural_implies_rfp_blocked_of_data {K : MPOTensor d D}
+    (data : SimpleMPDOBlockedRFPData K) :
+    Nonempty (FusionIsometryData K 2) :=
+  structural_implies_rfp_blocked (K := K) data.zcl
+
+/-- **Theorem 4.9 endpoint, data-parameterized form**.
+
+From the explicit simple-MPDO inputs one simultaneously recovers:
+
+* the GSNNCH-with-ZCL branch of Theorem 4.9(iii),
+* the blocked fusion-isometry witness at size `2`, and
+* the transfer-map fusion formulation of MPDO RFP.
+
+Relative to the current repository state, this is the final construction layer
+on top of issues #781 and #782. -/
+theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
+    (data : SimpleMPDOBlockedRFPData K) :
+    IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
+      IsRFP_MPDO_via_fusion K := by
+  refine ⟨data.isGSNNCHWithZCL, structural_implies_rfp_blocked_of_data data,
+    data.isRFPViaFusion⟩
+
+/-- Direct-argument form of Theorem 4.9 using only the hypotheses that enter the
+current conclusion. -/
+theorem simple_mpdo_rfp_chain {K : MPOTensor d D}
+    (hCommuting : HasCommutingForm K) (hZCL : IsZCL K) :
+    IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
+      IsRFP_MPDO_via_fusion K := by
+  refine ⟨?_, structural_implies_rfp_blocked (K := K) hZCL, ?_⟩
+  · exact (isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL K).2 ⟨hCommuting, hZCL⟩
+  · exact isRFP_MPDO_via_fusion_of_isRFP (M := K) (show IsRFP K from hZCL)
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -163,7 +163,11 @@ namespace SimpleMPDOBlockedRFPData
 variable {K : MPOTensor d D}
 
 /-- Construct this record directly from the scoped local lemmas of
-`SimpleLocalStructure.lean`, the commuting-form hypothesis, and MPO ZCL. -/
+`SimpleLocalStructure.lean`, the commuting-form hypothesis, and MPO ZCL.
+
+At present, the downstream consequences in this file use only `hCommuting` and
+`hZCL`. The local-data inputs are retained so that the eventual local-to-global
+implication from Appendix C.2 already has a canonical type-level target. -/
 def ofSALZCLAndCommutingForm
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -24,7 +24,8 @@ side live in separate modules:
 What is still missing upstream is the theorem turning the local simple-MPDO data
 into the global commuting-form property. Because of that gap, the present file
 is formulated around the explicit record `SimpleMPDOBlockedRFPData`. The local
-Appendix C.2 data are retained there so that the eventual local-to-global
+Appendix C.2 data are retained there, together with a provisional compatibility
+relation to the ambient MPO tensor, so that the eventual local-to-global
 implication has a canonical target.
 
 The current consequences recorded here are:
@@ -123,20 +124,35 @@ def ofSALZCL
 
 end SimpleMPDOLocalStructureData
 
+/-- Provisional relation expressing that local simple-MPDO structure data are
+attached to a specific MPO tensor.
+
+The current development does not yet formalize the local-to-global map from the
+Appendix-C.2 entropy input to a commuting-form witness for `K`, so this
+compatibility relation is temporarily the trivial proposition. It is included
+already so that `SimpleMPDOBlockedRFPData` carries a type-level field linking
+its local data to the ambient tensor. -/
+def SimpleMPDOLocalStructureData.CompatibleWith
+    (_data : SimpleMPDOLocalStructureData) (_K : MPOTensor d D) : Prop :=
+  True
+
 /-- Auxiliary record for the simple-MPDO blocked-RFP argument.
 
 The field `localData` records the Appendix C.2 local structure from issue #781,
-while `commutingForm` and `zcl` record the issue-#782 target side and the MPO
+the field `compatible` records its provisional attachment to `K`, and the
+fields `commutingForm` and `zcl` record the issue-#782 target side and the MPO
 zero-correlation-length input. This is the current point where the two sibling
 branches meet: the missing theorem is the derivation of `commutingForm` from
-`localData` and the original simple-MPDO SAL hypotheses.
+the entropy-side hypotheses attached to `K`.
 
 The present blocked-RFP consequences only use `commutingForm` and `zcl`; the
-`localData` field is retained so that the eventual local-to-global implication
-has a canonical target. -/
+pair `localData` / `compatible` is retained so that the eventual local-to-global
+implication already has a type-level target. -/
 structure SimpleMPDOBlockedRFPData (K : MPOTensor d D) where
   /-- Local SAL/SSA/rank-one data from Appendix C.2. -/
   localData : SimpleMPDOLocalStructureData
+  /-- Provisional attachment of the local data to the ambient MPO tensor. -/
+  compatible : localData.CompatibleWith K
   /-- Global commuting-form / GSNNCH data. -/
   commutingForm : HasCommutingForm K
   /-- Zero correlation length, hence the current provisional RFP predicate. -/
@@ -162,6 +178,7 @@ def ofSALZCLAndCommutingForm
     SimpleMPDOBlockedRFPData K where
   localData := SimpleMPDOLocalStructureData.ofSALZCL
     rhoABC hRhoDM hSSA T hPrimitive hTrace hTraceConst hPF
+  compatible := trivial
   commutingForm := hCommuting
   zcl := hZCL
 
@@ -183,7 +200,8 @@ theorem isRFPViaFusion (data : SimpleMPDOBlockedRFPData K) :
 
 end SimpleMPDOBlockedRFPData
 
-/-- Zero correlation length yields a blocked fusion-isometry witness at size `2`. -/
+/-- Under the current convention `IsRFP = IsZCL`, zero correlation length yields
+a blocked fusion-isometry witness at size `2`. -/
 theorem structural_implies_rfp_blocked {K : MPOTensor d D}
     (hZCL : IsZCL K) :
     Nonempty (FusionIsometryData K 2) :=
@@ -191,13 +209,12 @@ theorem structural_implies_rfp_blocked {K : MPOTensor d D}
     (M := K)
     (show IsRFP K from hZCL)) 2 (show 0 < 2 by decide)
 
-/-- **Proposition C.5, data-parameterized form**: if the simple-MPDO inputs are
-recorded in `SimpleMPDOBlockedRFPData`, then the blocked fusion-isometry
-witness follows from the zero-correlation-length field.
+/-- Data-parameterized blocked fusion-isometry witness.
 
-The fields `localData` and `commutingForm` are retained for the larger
-simple-MPDO interface, even though the present blocked-fusion consequence only
-uses `data.zcl`. -/
+Relative to the current convention `IsRFP = IsZCL`, the present conclusion uses
+only `data.zcl`. The fields `localData`, `compatible`, and `commutingForm` are
+retained for the larger simple-MPDO interface and for the future local-to-global
+implication. -/
 theorem structural_implies_rfp_blocked_of_data {K : MPOTensor d D}
     (data : SimpleMPDOBlockedRFPData K) :
     Nonempty (FusionIsometryData K 2) :=

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -255,8 +255,8 @@ legs cyclically and taking the resulting trace.
     \uses{def:is_prfp, def:mpo_is_zcl}
     The current purification-RFP condition is strictly weaker than MPO zero
     correlation length: there exists an MPO tensor with purification RFP whose
-    transfer map is not idempotent. Equivalently, the implication from the Lean
-    predicate \texttt{IsPRFP} to the predicate \texttt{IsZCL} fails.
+    transfer map is not idempotent. Equivalently, purification RFP does not
+    imply MPO zero correlation length.
 \end{remark}
 
 \begin{theorem}[Purification RFP implies LPDO]\label{thm:prfp_is_lpdo}
@@ -568,34 +568,30 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     Let $(A_k)$ be a family of block tensors, and fix a length $L$.
     Write $A_k^w$ for the length-$L$ word evaluation of $A_k$ along a word $w$.
-    The predicate \texttt{WordTupleSpanTop} says that the tuple-valued evaluations
+    The finite-length spanning hypothesis says that the tuple-valued evaluations
     \[
         w \longmapsto (A_k^w)_k
     \]
     span the full product algebra of block matrices.
-    The predicate \texttt{HasBiCF} records the corresponding finite-length
-    separation property: there exists $L$ such that if
+    The corresponding finite-length separation property asserts that there
+    exists a length $L$ such that if
     \[
         \sum_k \tr(\Delta_k A_k^w) = 0
         \qquad \text{for every word } w \text{ of length } L,
     \]
     then every block coefficient $\Delta_k$ vanishes.
-    The theorem \texttt{hasBiCF\_of\_wordTupleSpanTop} proves that the
-    spanning condition implies this separation property, by nondegeneracy of the
-    product trace pairing. The theorem
-    \texttt{horizontalCFData\_of\_wordTupleSpanTop} then inserts the resulting
-    biCF witness into \texttt{HorizontalCFData} once injectivity,
-    left-canonicality, and nonzero weights are given.
+    One theorem proves that the spanning condition implies this separation
+    property by nondegeneracy of the product trace pairing. A second theorem
+    then inserts the resulting biCF witness into horizontal canonical-form data
+    once injectivity, left-canonicality, and nonzero weights are given.
 
-    The predicate \texttt{PropBlockInjective} isolates the finite-length content
-    of Proposition~IV.3: after some common blocking length, each block is
-    block-injective, and after a second finite blocking length one can form word
-    combinations which equal the identity on one chosen block and vanish on all
-    others. Concatenating an injective prefix with such a selector suffix yields
-    the product-algebra span condition above. This is formalized by
-    \texttt{wordTupleSpanTop\_of\_propBlockInjective}, and the resulting biCF
-    witness is inserted into horizontal canonical-form data by
-    \texttt{horizontalCFData\_of\_propBlockInjective}.
+    The Proposition~IV.3 block-injectivity hypothesis isolates the
+    finite-length content needed here: after some common blocking length, each
+    block is block-injective, and after a second finite blocking length one can
+    form word combinations which equal the identity on one chosen block and
+    vanish on all others. Concatenating an injective prefix with such a selector
+    suffix yields the product-algebra span condition above, and hence again a
+    biCF witness and horizontal canonical-form data.
 \end{remark}
 
 \begin{theorem}[Abstract Proposition~IV.3 package]
@@ -963,7 +959,8 @@ its GSNNCH target once that step is available.
     \uses{def:simple_mpdo_local_structure_data, def:mpdo_has_commuting_form,
         def:mpo_is_zcl}
     For an MPO tensor $K$, this consists of the local Appendix~C.2 data together
-    with the commuting-form property and zero correlation length. The local
+    with a provisional compatibility relation attaching those local data to
+    $K$, the commuting-form property, and zero correlation length. The local
     component is retained so that the still-missing implication from the
     entropy-side hypotheses to commuting form has an explicit target, even
     though the current blocked-RFP consequences below use only the
@@ -976,8 +973,8 @@ its GSNNCH target once that step is available.
     \leanok
     \uses{def:mpo_is_zcl, def:mpdo_rfp_via_fusion}
     If an MPO tensor $K$ has zero correlation length, then it has a blocked
-    fusion-isometry witness at size $2$, i.e. a term of type
-    \texttt{Nonempty (MPOTensor.FusionIsometryData K 2)}.
+    fusion-isometry witness at size $2$ in the sense of
+    Definition~\ref{def:mpdo_fusion_isometry}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1015,8 +1012,7 @@ which is the current RFP predicate.
         def:simple_mpdo_blocked_rfp_data, thm:simple_mpdo_rfp_chain}
     Theorem~\ref{thm:simple_mpdo_rfp_chain} is fully formalized, but to recover
     the original Appendix~C.2 implication from SAL and ZCL alone one still
-    needs a theorem deriving \lean{MPOTensor.HasCommutingForm} from the local
-    simple-MPDO structure of Lemmas~C.3--C.4. The record
-    \lean{MPOTensor.SimpleMPDOBlockedRFPData} is included so that this future
-    implication has an explicit target.
+    needs a theorem deriving the commuting-form property from the local
+    simple-MPDO structure of Lemmas~C.3--C.4. The record above is included so
+    that this future implication has an explicit target.
 \end{remark}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -723,7 +723,7 @@ Since $E_1$ is the original transfer map, this is exactly
     The fusion-isometry formulation is equivalent to
     \lean{MPOTensor.IsRFP}.
 \end{theorem}
-\begin{proof}\leanok
+\begin{proof}\leanok\uses{thm:mpdo_rfp_of_fusion}
 The forward implication is Theorem~\ref{thm:mpdo_rfp_of_fusion}.
 Conversely, if the transfer map $E$ is idempotent, then every positive blocked
 transfer map equals $E$ and therefore factors through its range.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -156,7 +156,7 @@ legs cyclically and taking the resulting trace.
     By Lemma~\ref{lem:mpo_transfer_eq_mps}, the transfer map of $M$ agrees with
     the transfer map of its doubled-index MPS view. Thus
     $\E_M \circ \E_M = \E_M$ holds exactly when the transfer map of
-    $M.\mathrm{toMPSTensor}$ is idempotent, which is the RFP condition.
+    that doubled-index MPS tensor is idempotent, which is the RFP condition.
 \end{proof}
 
 \section{MPDOs and LPDOs}
@@ -634,7 +634,7 @@ strong subadditivity for a normalized three-site reduced state.
     abstract Proposition~IV.3 package from Theorem~\ref{thm:propblockinj_abstract}.
     Expanding the hypothesis over a word of length~$L+1$ beginning with the
     fixed site and folding each block contribution into a trace pairing
-    against $\mathrm{insertedTensor}\,W\,A_k$ yields, upon taking the
+    against the corresponding first-site insertion tensor yields, upon taking the
     $Y$\!-$Z$ difference, a tuple of block matrices whose trace pairings
     against every length-$L$ block word vanish. The biCF hypothesis then
     forces each block difference to be zero, and dividing by the nonzero
@@ -971,7 +971,8 @@ its GSNNCH target once that step is available.
     \label{thm:structural_implies_rfp_blocked}
     \lean{MPOTensor.structural_implies_rfp_blocked}
     \leanok
-    \uses{def:mpo_is_zcl, def:mpdo_rfp_via_fusion}
+    \uses{def:mpo_is_zcl, def:mpdo_fusion_isometry, def:mpdo_rfp_via_fusion,
+        thm:mpdo_rfp_via_fusion_iff}
     If an MPO tensor $K$ has zero correlation length, then it has a blocked
     fusion-isometry witness at size $2$ in the sense of
     Definition~\ref{def:mpdo_fusion_isometry}.
@@ -979,9 +980,10 @@ its GSNNCH target once that step is available.
 
 \begin{proof}\leanok
 Zero correlation length is the current provisional MPDO RFP predicate.
-Applying the fusion criterion from Definition~\ref{def:mpdo_rfp_via_fusion} to
-that RFP witness yields fusion-isometry data at every positive blocked size;
-evaluating it at size $2$ produces the blocked witness.
+Applying the converse direction of
+Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to that RFP witness yields
+fusion-isometry data at every positive blocked size; evaluating it at size $2$
+produces the blocked witness.
 \end{proof}
 
 \begin{theorem}[Simple-MPDO RFP chain from commuting form and ZCL]
@@ -990,7 +992,8 @@ evaluating it at size $2$ produces the blocked witness.
     \leanok
     \uses{def:mpdo_has_commuting_form, def:mpo_is_zcl,
         thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl,
-        thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion}
+        thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion,
+        thm:mpdo_rfp_via_fusion_iff}
     From the commuting-form property and zero correlation length one
     simultaneously recovers the GSNNCH-with-ZCL branch of Theorem~4.9, the
     blocked fusion-isometry witness at size $2$, and the transfer-map fusion
@@ -1001,8 +1004,9 @@ evaluating it at size $2$ produces the blocked witness.
 The commuting-form and zero-correlation-length hypotheses give the GSNNCH--ZCL
 branch via Theorem~\ref{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}.
 The blocked witness is Theorem~\ref{thm:structural_implies_rfp_blocked}. The
-full transfer-map fusion formulation again follows from zero correlation length,
-which is the current RFP predicate.
+full transfer-map fusion formulation follows by applying the converse direction
+of Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to zero correlation length, which
+is the current RFP predicate.
 \end{proof}
 
 \begin{remark}[Remaining paper-level gap for Theorem~4.9]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -533,6 +533,7 @@ strong subadditivity for a normalized three-site reduced state.
 \section{Horizontal and Vertical Canonical Forms}
 
 \begin{definition}[Horizontal canonical form for an MPO]\label{def:horizontal_cf_mpdo}
+    \lean{MPOTensor.IsHorizontalCF}
     \notready
     \uses{def:mpo_tensor, def:tensor_from_blocks, def:injective, def:same_mpv2}
     An MPO tensor is in \emph{horizontal canonical form} if its doubled-index
@@ -542,6 +543,7 @@ strong subadditivity for a normalized three-site reduced state.
 \end{definition}
 
 \begin{definition}[Vertical canonical form for an MPO]\label{def:vertical_cf_mpdo}
+    \lean{MPOTensor.IsVerticalCF}
     \notready
     \uses{def:mpo_tensor, def:bnt, def:same_mpv2, def:tensor_from_blocks}
     An MPO tensor is in \emph{vertical canonical form} if its diagonal MPS

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -156,8 +156,7 @@ legs cyclically and taking the resulting trace.
     By Lemma~\ref{lem:mpo_transfer_eq_mps}, the transfer map of $M$ agrees with
     the transfer map of its doubled-index MPS view. Thus
     $\E_M \circ \E_M = \E_M$ holds exactly when the transfer map of
-    the doubled-index MPS view is idempotent, which is precisely the
-    renormalization fixed-point condition.
+    $M.\mathrm{toMPSTensor}$ is idempotent, which is the RFP condition.
 \end{proof}
 
 \section{MPDOs and LPDOs}
@@ -256,8 +255,8 @@ legs cyclically and taking the resulting trace.
     \uses{def:is_prfp, def:mpo_is_zcl}
     The current purification-RFP condition is strictly weaker than MPO zero
     correlation length: there exists an MPO tensor with purification RFP whose
-    transfer map is not idempotent. Equivalently, purification RFP does not
-    imply MPO zero correlation length.
+    transfer map is not idempotent. Equivalently, the implication from the Lean
+    predicate \texttt{IsPRFP} to the predicate \texttt{IsZCL} fails.
 \end{remark}
 
 \begin{theorem}[Purification RFP implies LPDO]\label{thm:prfp_is_lpdo}
@@ -289,7 +288,7 @@ legs cyclically and taking the resulting trace.
     \lean{MPOTensor.isRFP_iff_isZCL}
     \leanok
     \uses{def:is_rfp_mpdo, def:mpo_is_zcl}
-    The MPDO renormalization fixed-point condition is equivalent to
+    The provisional MPDO renormalization fixed-point condition is equivalent to
     the zero-correlation-length condition for MPO tensors.
 \end{theorem}
 
@@ -304,7 +303,7 @@ legs cyclically and taking the resulting trace.
     \leanok
     \uses{def:is_rfp_mpdo, def:mpo_to_mps, def:is_rfp, def:mpo_is_zcl,
         thm:mpo_is_zcl_iff_to_mps_rfp}
-    The MPDO renormalization fixed-point condition is equivalent to the pure-state RFP
+    The provisional MPDO RFP condition is equivalent to the pure-state RFP
     condition for the doubled-index MPS tensor.
 \end{theorem}
 
@@ -534,7 +533,6 @@ strong subadditivity for a normalized three-site reduced state.
 \section{Horizontal and Vertical Canonical Forms}
 
 \begin{definition}[Horizontal canonical form for an MPO]\label{def:horizontal_cf_mpdo}
-    \lean{MPOTensor.IsHorizontalCF}
     \notready
     \uses{def:mpo_tensor, def:tensor_from_blocks, def:injective, def:same_mpv2}
     An MPO tensor is in \emph{horizontal canonical form} if its doubled-index
@@ -544,7 +542,6 @@ strong subadditivity for a normalized three-site reduced state.
 \end{definition}
 
 \begin{definition}[Vertical canonical form for an MPO]\label{def:vertical_cf_mpdo}
-    \lean{MPOTensor.IsVerticalCF}
     \notready
     \uses{def:mpo_tensor, def:bnt, def:same_mpv2, def:tensor_from_blocks}
     An MPO tensor is in \emph{vertical canonical form} if its diagonal MPS
@@ -557,7 +554,7 @@ strong subadditivity for a normalized three-site reduced state.
     from \cite[\S4.4]{Cirac2017MPDO_AnnPhys}.
 \end{definition}
 
-\begin{remark}[Finite-length span and selector criteria for the horizontal canonical-form hypothesis]%
+\begin{remark}[Finite-length span and selector criteria for the abstract biCF hypothesis]%
     \label{rem:word_tuple_span_top}
     \lean{MPSTensor.WordTupleSpanTop}
     \lean{MPSTensor.HasBiCF}
@@ -571,29 +568,34 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     Let $(A_k)$ be a family of block tensors, and fix a length $L$.
     Write $A_k^w$ for the length-$L$ word evaluation of $A_k$ along a word $w$.
-    Consider the tuple-valued evaluations
+    The predicate \texttt{WordTupleSpanTop} says that the tuple-valued evaluations
     \[
         w \longmapsto (A_k^w)_k
     \]
-    in the direct product of the block matrix algebras.
-    The finite-length spanning hypothesis says that these tuples span the
-    whole product algebra.
-    Equivalently, if matrices $\Delta_k$ satisfy
+    span the full product algebra of block matrices.
+    The predicate \texttt{HasBiCF} records the corresponding finite-length
+    separation property: there exists $L$ such that if
     \[
         \sum_k \tr(\Delta_k A_k^w) = 0
         \qquad \text{for every word } w \text{ of length } L,
     \]
-    then every $\Delta_k$ vanishes. This is the nondegeneracy statement for
-    the product trace pairing, so a single finite blocking length already
-    separates the blocks by their word evaluations.
+    then every block coefficient $\Delta_k$ vanishes.
+    The theorem \texttt{hasBiCF\_of\_wordTupleSpanTop} proves that the
+    spanning condition implies this separation property, by nondegeneracy of the
+    product trace pairing. The theorem
+    \texttt{horizontalCFData\_of\_wordTupleSpanTop} then inserts the resulting
+    biCF witness into \texttt{HorizontalCFData} once injectivity,
+    left-canonicality, and nonzero weights are given.
 
-    Proposition~IV.3 gives a concrete sufficient criterion for this
-    finite-length separation: after some common blocking length, each block is
-    block-injective, and after a second finite blocking length one can form
-    word combinations which equal the identity on one chosen block and vanish
-    on all others. Concatenating an injective prefix with such a selector
-    suffix yields the product-algebra span condition above, and therefore the
-    horizontal canonical-form conclusion.
+    The predicate \texttt{PropBlockInjective} isolates the finite-length content
+    of Proposition~IV.3: after some common blocking length, each block is
+    block-injective, and after a second finite blocking length one can form word
+    combinations which equal the identity on one chosen block and vanish on all
+    others. Concatenating an injective prefix with such a selector suffix yields
+    the product-algebra span condition above. This is formalized by
+    \texttt{wordTupleSpanTop\_of\_propBlockInjective}, and the resulting biCF
+    witness is inserted into horizontal canonical-form data by
+    \texttt{horizontalCFData\_of\_propBlockInjective}.
 \end{remark}
 
 \begin{theorem}[Abstract Proposition~IV.3 package]
@@ -636,7 +638,7 @@ strong subadditivity for a normalized three-site reduced state.
     abstract Proposition~IV.3 package from Theorem~\ref{thm:propblockinj_abstract}.
     Expanding the hypothesis over a word of length~$L+1$ beginning with the
     fixed site and folding each block contribution into a trace pairing
-    against the corresponding first-site insertion tensor yields, upon taking the
+    against $\mathrm{insertedTensor}\,W\,A_k$ yields, upon taking the
     $Y$\!-$Z$ difference, a tuple of block matrices whose trace pairings
     against every length-$L$ block word vanish. The biCF hypothesis then
     forces each block difference to be zero, and dividing by the nonzero
@@ -667,8 +669,8 @@ strong subadditivity for a normalized three-site reduced state.
 
 \section{Fusion isometries}
 
-Following \cite[\S4.5]{Cirac2017MPDO_AnnPhys}, this section records the
-transfer-map content of the fusion-isometry picture.
+Following \cite[\S4.5]{Cirac2017MPDO_AnnPhys}, the current Lean development
+formalizes the transfer-map content of the fusion-isometry picture.
 For each blocked size $n \ge 1$, the doubled-index blocked tensor of an MPO
 has a blocked transfer map $E_n$ acting on bond-space matrices, and the
 support algebra is modeled by a subspace through which $E_n$ factors as a
@@ -701,12 +703,13 @@ retract.
     map $E_n$.
 \end{definition}
 
-\begin{theorem}[Fusion-isometry data imply MPDO RFP]%
+\begin{theorem}[Fusion-isometry data imply the provisional MPDO RFP condition]%
     \label{thm:mpdo_rfp_of_fusion}
     \lean{MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
-    The fusion-isometry formulation implies \lean{MPOTensor.IsRFP}.
+    The fusion-isometry formulation implies the current predicate
+    \lean{MPOTensor.IsRFP}.
 \end{theorem}
 \begin{proof}\leanok
 Apply the definition at blocked size $n = 1$.
@@ -724,7 +727,7 @@ Since $E_1$ is the original transfer map, this is exactly
     The fusion-isometry formulation is equivalent to
     \lean{MPOTensor.IsRFP}.
 \end{theorem}
-\begin{proof}\leanok\uses{thm:mpdo_rfp_of_fusion}
+\begin{proof}\leanok
 The forward implication is Theorem~\ref{thm:mpdo_rfp_of_fusion}.
 Conversely, if the transfer map $E$ is idempotent, then every positive blocked
 transfer map equals $E$ and therefore factors through its range.
@@ -741,10 +744,10 @@ This range-factorization gives the required fusion-isometry data.
 \end{corollary}
 \begin{proof}\leanok
 Combine Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} with the diagonal pure-state
-recovery theorem for the MPDO renormalization fixed-point condition.
+recovery theorem for the provisional MPO predicate.
 \end{proof}
 
-\section{Support-algebra structure}
+\section{Algebra structure}
 
 \begin{definition}[Algebra-structure data for an MPDO]%
     \label{def:mpdo_algebra_structure_data}
@@ -938,4 +941,82 @@ Theorem~\ref{thm:mpdo_is_gsnnch_iff_has_commuting_form}.
 The remaining entropy-side theorem is to derive the commuting-form property
 from the strong-area-law hypotheses of Appendix~C.2. The present file isolates
 its GSNNCH target once that step is available.
+\end{remark}
+
+\section{Blocked-RFP construction for simple MPDOs}
+
+\begin{definition}[Local simple-MPDO structure data]
+    \label{def:simple_mpdo_local_structure_data}
+    \lean{MPOTensor.SimpleMPDOLocalStructureData}
+    \leanok
+    \uses{thm:sal_implies_eta_structure, thm:sal_zcl_implies_rank_one_t}
+    This data record collects the current local Appendix~C.2 input: a normalized
+    three-site reduced state with equality in strong subadditivity, the
+    resulting local $\eta$-structure, and the rank-one conclusion for the
+    auxiliary primitive matrix $T$.
+\end{definition}
+
+\begin{definition}[Simple-MPDO blocked-RFP data]
+    \label{def:simple_mpdo_blocked_rfp_data}
+    \lean{MPOTensor.SimpleMPDOBlockedRFPData}
+    \leanok
+    \uses{def:simple_mpdo_local_structure_data, def:mpdo_has_commuting_form,
+        def:mpo_is_zcl}
+    For an MPO tensor $K$, this consists of the local Appendix~C.2 data together
+    with the commuting-form property and zero correlation length. The local
+    component is retained so that the still-missing implication from the
+    entropy-side hypotheses to commuting form has an explicit target, even
+    though the current blocked-RFP consequences below use only the
+    commuting-form and zero-correlation-length entries.
+\end{definition}
+
+\begin{theorem}[Zero correlation length gives a blocked fusion-isometry witness]
+    \label{thm:structural_implies_rfp_blocked}
+    \lean{MPOTensor.structural_implies_rfp_blocked}
+    \leanok
+    \uses{def:mpo_is_zcl, def:mpdo_rfp_via_fusion}
+    If an MPO tensor $K$ has zero correlation length, then it has a blocked
+    fusion-isometry witness at size $2$, i.e. a term of type
+    \texttt{Nonempty (MPOTensor.FusionIsometryData K 2)}.
+\end{theorem}
+
+\begin{proof}\leanok
+Zero correlation length is the current provisional MPDO RFP predicate.
+Applying the fusion criterion from Definition~\ref{def:mpdo_rfp_via_fusion} to
+that RFP witness yields fusion-isometry data at every positive blocked size;
+evaluating it at size $2$ produces the blocked witness.
+\end{proof}
+
+\begin{theorem}[Simple-MPDO RFP chain from commuting form and ZCL]
+    \label{thm:simple_mpdo_rfp_chain}
+    \lean{MPOTensor.simple_mpdo_rfp_chain}
+    \leanok
+    \uses{def:mpdo_has_commuting_form, def:mpo_is_zcl,
+        thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl,
+        thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion}
+    From the commuting-form property and zero correlation length one
+    simultaneously recovers the GSNNCH-with-ZCL branch of Theorem~4.9, the
+    blocked fusion-isometry witness at size $2$, and the transfer-map fusion
+    formulation of MPDO RFP.
+\end{theorem}
+
+\begin{proof}\leanok
+The commuting-form and zero-correlation-length hypotheses give the GSNNCH--ZCL
+branch via Theorem~\ref{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}.
+The blocked witness is Theorem~\ref{thm:structural_implies_rfp_blocked}. The
+full transfer-map fusion formulation again follows from zero correlation length,
+which is the current RFP predicate.
+\end{proof}
+
+\begin{remark}[Remaining paper-level gap for Theorem~4.9]
+    \label{rem:simple_mpdo_rfp_chain_gap}
+    \notready
+    \uses{def:simple_mpdo_local_structure_data,
+        def:simple_mpdo_blocked_rfp_data, thm:simple_mpdo_rfp_chain}
+    Theorem~\ref{thm:simple_mpdo_rfp_chain} is fully formalized, but to recover
+    the original Appendix~C.2 implication from SAL and ZCL alone one still
+    needs a theorem deriving \lean{MPOTensor.HasCommutingForm} from the local
+    simple-MPDO structure of Lemmas~C.3--C.4. The record
+    \lean{MPOTensor.SimpleMPDOBlockedRFPData} is included so that this future
+    implication has an explicit target.
 \end{remark}


### PR DESCRIPTION
## Summary

This PR adds a new assembly module
`TNLean/MPS/MPDO/BlockedRFPAssembly.lean` for the simple-MPDO Appendix C.2 /
Theorem 4.9 track.

It lands the following new declarations:

- `MPOTensor.SimpleMPDOLocalStructureData`
- `MPOTensor.SimpleMPDOBlockedRFPData`
- `MPOTensor.structural_implies_rfp_blocked`
- `MPOTensor.simple_mpdo_rfp_chain`

The current repo still lacks the local-to-global bridge turning the Appendix C.2
local `η` / rank-one data into `HasCommutingForm`. So this PR takes **Option B/C**:
I merged the sibling branches for #781 and #782 locally, then packaged the
assembly endpoint through an explicit data interface. Concretely, once one has

1. the local SAL/SSA / rank-one-`T` package from `SimpleLocalStructure.lean`,
2. the commuting-form target data from `CommutingForm.lean`, and
3. MPO ZCL,

one now gets both a blocked fusion-isometry witness at size `2` and the full
transfer-map fusion formulation of MPDO RFP.

## Dependency status

This branch locally merges:

- `origin/feat/781-simple-mpdo-local-structure` (PR #807)
- `origin/feat/782-simple-mpdo-commuting` (PR #808)

So this PR should stay **draft** until #807 and #808 merge, or else it will show
those sibling diffs against `main` as part of the combined branch.

I intentionally did **not** edit the sibling-owned files
`SimpleLocalStructure.lean`, `CommutingForm.lean`, or `AlgebraStructure.lean`.

## Blueprint

Added a disjoint end-of-§C section in `blueprint/src/chapter/ch02b_mpdo.tex` for:

- `MPOTensor.SimpleMPDOLocalStructureData`
- `MPOTensor.SimpleMPDOBlockedRFPData`
- `MPOTensor.structural_implies_rfp_blocked`
- `MPOTensor.simple_mpdo_rfp_chain`

plus a `\notready` remark recording the remaining paper-level gap.

## Verification

Ran in `.worktrees/issue-783-blocked-rfp`:

- `lake build TNLean.MPS.MPDO.BlockedRFPAssembly`
- `lake env lean TNLean/MPS/MPDO/BlockedRFPAssembly.lean`
- `lake env lean TNLean.lean`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/MPDO/BlockedRFPAssembly.lean blueprint/src/chapter/ch02b_mpdo.tex`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

## Notes

- No new `sorry` / `axiom` in the touched files.
- The endpoint is intentionally data-parameterized: the remaining honest gap is
  still the theorem constructing `MPOTensor.HasCommutingForm` from the local
  simple-MPDO structure of Lemmas C.3--C.4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean module and blueprint text that assemble existing lemmas into higher-level theorems, with minimal impact beyond a new root import and public API surface.
> 
> **Overview**
> Adds a new `BlockedRFPConstruction` module that packages the simple-MPDO Appendix C.2/Theorem 4.9 endpoint behind explicit data records (`SimpleMPDOLocalStructureData`, `SimpleMPDOBlockedRFPData`) and derives downstream consequences (`structural_implies_rfp_blocked`, `simple_mpdo_rfp_chain`) from commuting form + ZCL (with a provisional `CompatibleWith := True` placeholder).
> 
> Wires the new module into the public import surface (`TNLean.lean`) and extends the blueprint chapter with matching definitions/theorems plus minor wording/section-title edits that clarify the “provisional” MPDO RFP predicate and document the remaining local-to-global gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c15ac4a8c759d8518f669bf3e4e30c28df5ad0f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->