### PR TITLE
feat(MPS/CanonicalForm): discharge hProjStep/hFixUpgrade via sector fixed-point algebra (#599)

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
@@ -34,11 +34,15 @@ including `pairwise_mul_zero_of_orthogonalProjection_sum_one`,
 `orbit_iterate_isOrthogonalProjection`,
 `orbitSumProjection_eq_one_of_full_sector`,
 `hFixUpgrade_of_peripheral`,
+`SectorFixedPointAlgebraRigidity`,
+`hProjStep_of_sectorFixedPointAlgebraRigidity`,
 `hLift_cyclicDecomp_mps_of_fixUpgrade`,
 `hLift_cyclicDecomp_mps_of_projStep`,
+`hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`,
 `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift`,
-`isIrreducibleOnCorner_of_cyclic_decomp_mps_of_projStep`, and
-`isIrreducibleOnCorner_of_cyclic_decomp_mps_of_fixUpgrade`.
+`isIrreducibleOnCorner_of_cyclic_decomp_mps_of_projStep`,
+`isIrreducibleOnCorner_of_cyclic_decomp_mps_of_fixUpgrade`, and
+`isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`.
 
 ## Tags
 

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean
@@ -18,7 +18,7 @@ resulting MPS irreducibility statements.
 * `hFixUpgrade_of_peripheral` — corner preservation under the `m`-th adjoint
   iterate implies fixedness in the irreducible trace-preserving case.
 * `SectorFixedPointAlgebraRigidity` — a single fixed-point-algebra hypothesis
-  packaging the remaining one-step sector rigidity.
+  expressing the remaining one-step sector rigidity.
 * `hProjStep_of_sectorFixedPointAlgebraRigidity` — fixed `T^m`-sector
   projections are sent to projections under the one-step dynamics.
 * `hLift_cyclicDecomp_mps_of_fixUpgrade` — the orbit-sum construction supplies

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean
@@ -17,12 +17,19 @@ resulting MPS irreducibility statements.
 
 * `hFixUpgrade_of_peripheral` — corner preservation under the `m`-th adjoint
   iterate implies fixedness in the irreducible trace-preserving case.
+* `SectorFixedPointAlgebraRigidity` — a single fixed-point-algebra hypothesis
+  packaging the remaining one-step sector rigidity.
+* `hProjStep_of_sectorFixedPointAlgebraRigidity` — fixed `T^m`-sector
+  projections are sent to projections under the one-step dynamics.
 * `hLift_cyclicDecomp_mps_of_fixUpgrade` — the orbit-sum construction supplies
   the `hLift` input.
 * `hLift_cyclicDecomp_mps_of_projStep` — the fixed-point hypothesis is supplied
   by `hFixUpgrade_of_peripheral`.
-* `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift` and its two corollaries
-  — the resulting MPS irreducibility theorems.
+* `hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity` — both former
+  abstract inputs are replaced by `SectorFixedPointAlgebraRigidity`.
+* `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift` and its corollaries —
+  the resulting MPS irreducibility theorems, including the fixed-point-algebra
+  variant.
 
 ## Tags
 
@@ -516,5 +523,278 @@ theorem isIrreducibleOnCorner_of_cyclic_decomp_mps_of_fixUpgrade
         (A := A) (m := m) hTP P hPproj hPsum hcyclic
         hMulLeft hMulRight hProjStep hFixUpgrade)
 
+
+/-- Wolf-style fixed-point-algebra rigidity on cyclic sectors.
+
+For each sector projection `P k`, the one-step dynamics `T` is multiplicative on the
+algebra of `T^m`-fixed elements supported on that sector. This is the single structured
+hypothesis suggested by `lem:bdcf`: once combined with `hFixUpgrade_of_peripheral`, it
+replaces the former pair of abstract inputs `hProjStep` and `hFixUpgrade` in the
+orbit-sum lift. -/
+def SectorFixedPointAlgebraRigidity
+    [NeZero m] (T : MatrixEnd D) (P : Fin m → MatrixAlg D) : Prop :=
+  ∀ k : Fin m, ∀ X Y : MatrixAlg D,
+    X * P k = X →
+    P k * X = X →
+    Y * P k = Y →
+    P k * Y = Y →
+    (T ^ m) X = X →
+    (T ^ m) Y = Y →
+    T (X * Y) = T X * T Y
+
+/-- Under `SectorFixedPointAlgebraRigidity`, the one-step dynamics sends a `T^m`-fixed
+sector-supported orthogonal projection to an orthogonal projection. -/
+theorem hProjStep_of_sectorFixedPointAlgebraRigidity
+    [NeZero m]
+    {T : MatrixEnd D}
+    (P : Fin m → MatrixAlg D)
+    (hStar : ∀ X : MatrixAlg D, T Xᴴ = (T X)ᴴ)
+    (hRigidity : SectorFixedPointAlgebraRigidity (D := D) (m := m) T P)
+    {k : Fin m} {X : MatrixAlg D}
+    (hXproj : IsOrthogonalProjection X)
+    (hXP : X * P k = X) (hPX : P k * X = X)
+    (hXfix : (T ^ m) X = X) :
+    IsOrthogonalProjection (T X) := by
+  refine ⟨?_, ?_⟩
+  · calc
+      (T X)ᴴ = T Xᴴ := by
+        symm
+        exact hStar X
+      _ = T X := by rw [hXproj.1.eq]
+  · have hmul :=
+      hRigidity k X X hXP hPX hXP hPX hXfix hXfix
+    calc
+      T X * T X = T (X * X) := hmul.symm
+      _ = T X := by rw [hXproj.2]
+
+private theorem orbit_iterate_fixed_of_pow_fix
+    [NeZero m]
+    {T : MatrixEnd D} {Q : MatrixAlg D}
+    (hQfix : (T ^ m) Q = Q) :
+    ∀ l : Fin m, (T ^ m) ((T ^ (l : ℕ)) Q) = ((T ^ (l : ℕ)) Q) := by
+  intro l
+  calc
+    (T ^ m) ((T ^ (l : ℕ)) Q) = (T ^ (m + (l : ℕ))) Q := by
+      rw [pow_add, Module.End.mul_apply]
+    _ = (T ^ ((l : ℕ) + m)) Q := by rw [Nat.add_comm]
+    _ = (T ^ (l : ℕ)) ((T ^ m) Q) := by
+      rw [pow_add, Module.End.mul_apply]
+    _ = (T ^ (l : ℕ)) Q := by rw [hQfix]
+
+/-- Orbit-sum lift with the old `hProjStep` and `hFixUpgrade` inputs replaced by the
+single fixed-point-algebra hypothesis `SectorFixedPointAlgebraRigidity`.
+
+The remaining mathematical task is to derive this rigidity hypothesis from a Wolf-style
+description of the sector fixed-point algebra of `((\E_A^\dagger)^m)|_{P_k}`. -/
+theorem hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity
+    [NeZero D] [NeZero m]
+    {A : MPSTensor d D}
+    (hIrrAdj :
+      IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)))
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (P : Fin m → MatrixAlg D)
+    (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hcyclic :
+      ∀ k : Fin m,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (hMulLeft :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k * X) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X)
+    (hMulRight :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (X * P k) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k))
+    (hRigidity :
+      SectorFixedPointAlgebraRigidity
+        (D := D) (m := m)
+        (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) P) :
+    ∀ k : Fin m, ∀ Q : MatrixAlg D,
+      IsOrthogonalProjection Q →
+      Q * P k = Q → P k * Q = Q →
+      PreservesCorner Q
+        ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) →
+      ∃ R : MatrixAlg D,
+        IsOrthogonalProjection R ∧
+        PreservesCorner R
+          (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ∧
+        (Q = 0 ↔ R = 0) ∧
+        (Q = P k ↔ R = 1) := by
+  classical
+  let T : MatrixEnd D := transferMap (d := d) (D := D) (fun i => (A i)ᴴ)
+  have hStarT : ∀ X : MatrixAlg D, T Xᴴ = (T X)ᴴ := by
+    intro X
+    simpa [T, MPSTensor.transferMap_apply, Kraus.map] using
+      (Kraus.map_conjTranspose (K := fun i => (A i)ᴴ) X).symm
+  have hIrrTensor : IsIrreducibleTensor (d := d) (D := D) A :=
+    isIrreducibleTensor_of_isIrreducibleMap_conjTranspose (A := A) hIrrAdj
+  have hIrr : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+    isIrreducibleCP_transferMap_of_isIrreducibleTensor A hIrrTensor
+  intro k Q hQproj hQP hPQ hQcorner
+  have hQfix : (T ^ m) Q = Q := by
+    simpa [T] using
+      hFixUpgrade_of_peripheral (A := A) (period := m) hTP hIrr hQproj hQcorner
+  have hsupp :=
+    orbit_iterate_supported_on_shifted_sector
+      (T := T) (P := P) hcyclic hMulLeft hMulRight (k := k) (Q := Q) hQP hPQ
+  have hprojL : ∀ l : Fin m, IsOrthogonalProjection ((T ^ (l : ℕ)) Q) := by
+    suffices hmain : ∀ n : ℕ, ∀ hn : n < m, IsOrthogonalProjection ((T ^ n) Q) by
+      intro l
+      simpa using hmain (l : ℕ) l.is_lt
+    intro n
+    induction n with
+    | zero =>
+        intro _hn
+        simpa using hQproj
+    | succ n ih =>
+        intro hn1
+        have hn : n < m := Nat.lt_of_succ_lt hn1
+        have hproj_n : IsOrthogonalProjection ((T ^ n) Q) := ih hn
+        have hsupp_n := hsupp ⟨n, hn⟩
+        have hfix_n : (T ^ m) ((T ^ n) Q) = ((T ^ n) Q) := by
+          simpa using
+            orbit_iterate_fixed_of_pow_fix (T := T) (m := m) (Q := Q) hQfix ⟨n, hn⟩
+        have hstep_proj : IsOrthogonalProjection (T ((T ^ n) Q)) :=
+          hProjStep_of_sectorFixedPointAlgebraRigidity
+            (D := D) (m := m) (T := T) (P := P) hStarT hRigidity
+            (k := k - ⟨n, hn⟩) (X := (T ^ n) Q) hproj_n hsupp_n.1 hsupp_n.2 hfix_n
+        simpa [pow_succ'] using hstep_proj
+  have hPPair := pairwise_mul_zero_of_orthogonalProjection_sum_one (P := P) hPproj hPsum
+  have horbPair : ∀ l l' : Fin m, l ≠ l' →
+      ((T ^ (l : ℕ)) Q) * ((T ^ (l' : ℕ)) Q) = 0 := by
+    intro l l' hll
+    have h1 : (T ^ (l : ℕ)) Q * P (k - l) = (T ^ (l : ℕ)) Q := (hsupp l).1
+    have h2 : P (k - l') * (T ^ (l' : ℕ)) Q = (T ^ (l' : ℕ)) Q := (hsupp l').2
+    have hPneq : (k - l : Fin m) ≠ (k - l' : Fin m) := by
+      intro heq
+      exact hll (sub_right_injective heq)
+    have hP0 : P (k - l) * P (k - l') = 0 := hPPair hPneq
+    calc
+      ((T ^ (l : ℕ)) Q) * ((T ^ (l' : ℕ)) Q)
+          = ((T ^ (l : ℕ)) Q * P (k - l)) *
+              (P (k - l') * (T ^ (l' : ℕ)) Q) := by rw [h1, h2]
+      _ = ((T ^ (l : ℕ)) Q) * (P (k - l) * P (k - l')) *
+            ((T ^ (l' : ℕ)) Q) := by simp only [mul_assoc]
+      _ = ((T ^ (l : ℕ)) Q) * 0 * ((T ^ (l' : ℕ)) Q) := by rw [hP0]
+      _ = 0 := by
+            simp only [Matrix.mul_zero, Matrix.zero_mul]
+  have hRproj : IsOrthogonalProjection (orbitSumProjection (D := D) (m := m) T Q) := by
+    refine ⟨?_, ?_⟩
+    · change (orbitSumProjection (D := D) (m := m) T Q)ᴴ =
+          orbitSumProjection (D := D) (m := m) T Q
+      simp only [orbitSumProjection, Matrix.conjTranspose_sum]
+      refine Finset.sum_congr rfl ?_
+      intro l _
+      exact (hprojL l).1.eq
+    · change (∑ l : Fin m, (T ^ (l : ℕ)) Q) * (∑ l : Fin m, (T ^ (l : ℕ)) Q) =
+          ∑ l : Fin m, (T ^ (l : ℕ)) Q
+      rw [Finset.sum_mul]
+      refine Finset.sum_congr rfl ?_
+      intro l _
+      rw [Finset.mul_sum]
+      rw [Finset.sum_eq_single l]
+      · exact (hprojL l).2
+      · intro l' _ hne
+        exact horbPair l l' (Ne.symm hne)
+      · intro hmem
+        exact absurd (Finset.mem_univ l) hmem
+  refine ⟨orbitSumProjection (D := D) (m := m) T Q, hRproj, ?_, ?_, ?_⟩
+  · have hRfix : T (orbitSumProjection (D := D) (m := m) T Q) =
+        orbitSumProjection (D := D) (m := m) T Q :=
+      orbitSumProjection_fixed_of_pow_fix (T := T) (Q := Q) (m := m) hQfix
+    exact preservesCorner_of_adjoint_fixed_projection (A := A) hTP
+      (P := orbitSumProjection (D := D) (m := m) T Q) hRproj (hFix := hRfix)
+  · have hRQ : (orbitSumProjection (D := D) (m := m) T Q) * Q = Q := by
+      simp only [orbitSumProjection, Finset.sum_mul]
+      rw [Finset.sum_eq_single (0 : Fin m)]
+      · simp only [Fin.val_zero, pow_zero, Module.End.one_apply]
+        exact hQproj.2
+      · intros l _ hne
+        have hzero := horbPair l 0 hne
+        simpa using hzero
+      · intro hmem
+        exact absurd (Finset.mem_univ (0 : Fin m)) hmem
+    refine ⟨?_, ?_⟩
+    · intro hQ0
+      simp only [orbitSumProjection, hQ0, map_zero, Finset.sum_const_zero]
+    · intro hR0
+      have := hRQ
+      rw [hR0] at this
+      simpa using this.symm
+  · have hPRP : P k * (orbitSumProjection (D := D) (m := m) T Q) * P k = Q := by
+      simp only [orbitSumProjection, Finset.mul_sum, Finset.sum_mul]
+      rw [Finset.sum_eq_single (0 : Fin m)]
+      · simp only [Fin.val_zero, pow_zero, Module.End.one_apply]
+        calc
+          P k * Q * P k = Q * P k := by rw [hPQ]
+          _ = Q := hQP
+      · intros l _ hne
+        have hsupp_l := hsupp l
+        have h_left : P (k - l) * (T ^ (l : ℕ)) Q = (T ^ (l : ℕ)) Q := hsupp_l.2
+        have hPneq : (k - l : Fin m) ≠ k := by
+          intro heq
+          apply hne
+          have hk0 : k - l = k - 0 := by simpa using heq
+          exact sub_right_injective hk0
+        have hP0 : P k * P (k - l) = 0 := hPPair (Ne.symm hPneq)
+        calc
+          P k * ((T ^ (l : ℕ)) Q) * P k = P k * (P (k - l) * (T ^ (l : ℕ)) Q) * P k := by
+            rw [h_left]
+          _ = (P k * P (k - l)) * ((T ^ (l : ℕ)) Q) * P k := by
+                rw [← mul_assoc (P k) (P (k - l)) ((T ^ (l : ℕ)) Q)]
+          _ = 0 * ((T ^ (l : ℕ)) Q) * P k := by rw [hP0]
+          _ = 0 := by
+                simp only [Matrix.zero_mul]
+      · intro hmem
+        exact absurd (Finset.mem_univ (0 : Fin m)) hmem
+    refine ⟨?_, ?_⟩
+    · intro hQ
+      rw [hQ]
+      exact orbitSumProjection_eq_one_of_full_sector (T := T) (P := P) hPsum hcyclic k
+    · intro hR1
+      have := hPRP
+      rw [hR1] at this
+      simpa [(hPproj k).2] using this.symm
+
+/-- Sector irreducibility with the old `hProjStep` and `hFixUpgrade` inputs replaced by
+`SectorFixedPointAlgebraRigidity`. -/
+theorem isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity
+    [NeZero D] {A : MPSTensor d D}
+    [NeZero m]
+    (hIrr :
+      IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)))
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (P : Fin m → MatrixAlg D)
+    (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hcyclic :
+      ∀ k : Fin m,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (hMulLeft :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k * X) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X)
+    (hMulRight :
+      ∀ k : Fin m, ∀ X : MatrixAlg D,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (X * P k) =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X *
+            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k))
+    (hRigidity :
+      SectorFixedPointAlgebraRigidity
+        (D := D) (m := m)
+        (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) P) :
+    ∀ k : Fin m,
+      IsIrreducibleOnCorner
+        (P k) ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) := by
+  exact
+    isIrreducibleOnCorner_of_cyclic_decomp_mps_of_hLift
+      (A := A) (m := m) hIrr P hPproj hPsum hcyclic
+      (hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity
+        (A := A) (m := m) hIrr hTP P hPproj hPsum hcyclic
+        hMulLeft hMulRight hRigidity)
 
 end MPSTensor

--- a/audits/2026-04-23_issue599_fixed_point_route.md
+++ b/audits/2026-04-23_issue599_fixed_point_route.md
@@ -2,7 +2,7 @@
 
 ## Outcome
 
-I did **not** fully discharge the remaining `hProjStep` hypothesis on current `main`, but I did land a sharper single replacement hypothesis that packages the fixed-point route suggested by the issue discussion.
+I did **not** fully discharge the remaining `hProjStep` hypothesis on current `main`, but I did land a sharper single replacement hypothesis that captures the fixed-point route suggested by the issue discussion.
 
 ### Option picked
 
@@ -39,7 +39,7 @@ X = X P_k = P_k X,\quad Y = Y P_k = P_k Y,\quad T^m(X)=X,\quad T^m(Y)=Y
 \implies T(XY)=T(X)T(Y).
 $$
 
-This is the exact fixed-point-algebra package that the old `hProjStep` proof sketch was trying to access through the false multiplicative-domain shortcut.
+This is the exact fixed-point-algebra hypothesis that the old `hProjStep` proof sketch was trying to access through the false multiplicative-domain shortcut.
 
 ### What is now proved from it
 
@@ -61,7 +61,7 @@ This is the exact fixed-point-algebra package that the old `hProjStep` proof ske
 
 ## Residual gap
 
-The remaining honest gap is now sharply localized:
+The remaining gap is now sharply localized:
 
 > derive `SectorFixedPointAlgebraRigidity` from the paper-level fixed-point description of a periodic block (arXiv:1708.00029, Lemma `lem:bdcf`).
 

--- a/audits/2026-04-23_issue599_fixed_point_route.md
+++ b/audits/2026-04-23_issue599_fixed_point_route.md
@@ -1,0 +1,98 @@
+# Issue #599 fixed-point route — April 23, 2026
+
+## Outcome
+
+I did **not** fully discharge the remaining `hProjStep` hypothesis on current `main`, but I did land a sharper single replacement hypothesis that packages the fixed-point route suggested by the issue discussion.
+
+### Option picked
+
+**Option C**: replace the old pair
+
+- `hProjStep`
+- `hFixUpgrade`
+
+by a single structured hypothesis
+
+- `MPSTensor.SectorFixedPointAlgebraRigidity`
+
+and prove the orbit-sum lift / sector-irreducibility wrappers directly from it.
+
+## Lean declarations landed
+
+In `TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean` I added:
+
+1. `MPSTensor.SectorFixedPointAlgebraRigidity`
+2. `MPSTensor.hProjStep_of_sectorFixedPointAlgebraRigidity`
+3. `MPSTensor.hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`
+4. `MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`
+
+## Mathematical content
+
+Let
+$$
+T := \operatorname{transferMap}(A^\dagger).
+$$
+
+The new hypothesis `SectorFixedPointAlgebraRigidity` says that on each cyclic sector $P_k$, the one-step map $T$ is multiplicative on the algebra of $T^m$-fixed operators supported on the corner $P_k \mathcal M_D P_k$:
+$$
+X = X P_k = P_k X,\quad Y = Y P_k = P_k Y,\quad T^m(X)=X,\quad T^m(Y)=Y
+\implies T(XY)=T(X)T(Y).
+$$
+
+This is the exact fixed-point-algebra package that the old `hProjStep` proof sketch was trying to access through the false multiplicative-domain shortcut.
+
+### What is now proved from it
+
+- `hProjStep_of_sectorFixedPointAlgebraRigidity`:
+  if $X$ is an orthogonal projection, supported on $P_k$, and fixed by $T^m$, then $T(X)$ is again an orthogonal projection.
+
+  Proof idea:
+  - Kraus maps automatically preserve `conjTranspose`, so $T(X)$ is Hermitian.
+  - Rigidity gives $T(X^2)=T(X)^2$.
+  - Since $X^2=X$, we get $T(X)^2=T(X)$.
+
+- `hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`:
+  the orbit-sum lift now follows from the **single** rigidity hypothesis together with the already-landed theorem `hFixUpgrade_of_peripheral`.
+
+  The proof re-runs the orbit induction, but only on iterates $T^l(Q)$ of a projection $Q$ satisfying `PreservesCorner Q (T^m)`. After `hFixUpgrade_of_peripheral`, we know $T^m(Q)=Q`, hence also $T^m(T^l(Q))=T^l(Q)$ for all $l$, so the rigidity hypothesis applies exactly where the old `hProjStep` was needed.
+
+- `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`:
+  sector irreducibility on each corner follows immediately from the new orbit-sum lift.
+
+## Residual gap
+
+The remaining honest gap is now sharply localized:
+
+> derive `SectorFixedPointAlgebraRigidity` from the paper-level fixed-point description of a periodic block (arXiv:1708.00029, Lemma `lem:bdcf`).
+
+Concretely, the missing theorem family is a Wolf-style statement that the one-step sector dynamics acts as a `*`-homomorphism on the $T^m$-fixed corner algebra (equivalently, on the primitive blocked sector algebra). Once that is formalized, the old abstract `hProjStep` hypothesis can be removed entirely in favor of the new rigidity theorem.
+
+## Why this is better than the old state
+
+Previously the file still exposed two abstract inputs:
+
+- a one-step projection-preservation hypothesis `hProjStep`, and
+- a fixed-point upgrade `hFixUpgrade`.
+
+Now:
+
+- `hFixUpgrade` is already discharged unconditionally by `hFixUpgrade_of_peripheral`, and
+- the remaining input is a **single** structured fixed-point-algebra hypothesis that matches the paper's real missing endpoint.
+
+So the issue is no longer blocked on a vague projection-preservation black box; it is blocked on a precise algebraic statement tied to `lem:bdcf`.
+
+## Verification
+
+Commands run in `.worktrees/issue-599-fixed-algebra`:
+
+```bash
+lake env lean TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean
+lake env lean TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+lake build
+rg -n "sorry|axiom" \
+  TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean \
+  TNLean/MPS/CanonicalForm/SectorIrreducibility.lean
+cd blueprint && leanblueprint web && leanblueprint checkdecls
+```
+
+No new `sorry` / `axiom` were introduced in the touched Lean files.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1585,7 +1585,7 @@ The following results separate the zero blocks from the
 \end{definition}
 
 \begin{proof}\leanok
-	This is the formal packaging of the missing Wolf-style fixed-point-algebra
+	This is the formal statement of the missing Wolf-style fixed-point-algebra
 	rigidity statement suggested by Lemma~\texttt{lem:bdcf}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1560,6 +1560,56 @@ The following results separate the zero blocks from the
 	the $\rho$-weighted trace therefore forces it to vanish, giving the claim.
 \end{proof}
 
+\begin{definition}[Sector fixed-point-algebra rigidity]%
+	\label{def:sector_fixed_point_algebra_rigidity}
+	\lean{MPSTensor.SectorFixedPointAlgebraRigidity}
+	\leanok
+	Let $T$ be the adjoint transfer map and $(P_k)_{k=1}^m$ a cyclic family of
+	orthogonal sector projections. We say that the sector dynamics satisfies
+	fixed-point-algebra rigidity if, for each $k$, the one-step map $T$ is
+	multiplicative on the $T^m$-fixed operators supported on the corner
+	$P_k \mathcal M_D P_k$: whenever
+	\[
+		X = X P_k = P_k X,
+		\qquad
+		Y = Y P_k = P_k Y,
+		\qquad
+		T^m(X) = X,
+		\qquad
+		T^m(Y) = Y,
+	\]
+	one has
+	\[
+		T(XY) = T(X) T(Y).
+	\]
+\end{definition}
+
+\begin{proof}\leanok
+	This is the formal packaging of the missing Wolf-style fixed-point-algebra
+	rigidity statement suggested by Lemma~\texttt{lem:bdcf}.
+\end{proof}
+
+\begin{lemma}[Projection step from sector fixed-point-algebra rigidity]%
+	\label{lem:sector_fixed_algebra_proj_step}
+	\lean{MPSTensor.hProjStep_of_sectorFixedPointAlgebraRigidity}
+	\leanok
+	\uses{def:sector_fixed_point_algebra_rigidity}
+	Assume sector fixed-point-algebra rigidity. If $X$ is an orthogonal
+	projection supported on $P_k$ and fixed by $T^m$, then $T(X)$ is again an
+	orthogonal projection.
+\end{lemma}
+
+\begin{proof}\leanok
+	\uses{def:sector_fixed_point_algebra_rigidity}
+	Kraus maps preserve conjugate transpose, so $T(X)$ is Hermitian. The
+	rigidity hypothesis gives
+	\[
+		T(X)^2 = T(X^2) = T(X),
+	\]
+	since $X^2 = X$ for an orthogonal projection. Therefore $T(X)$ is again an
+	orthogonal projection.
+\end{proof}
+
 \begin{lemma}[Orbit-sum construction of the sector lift]%
 	\label{lem:orbit_sum_hLift_construction}
 	\lean{MPSTensor.hLift_cyclicDecomp_mps_of_fixUpgrade}
@@ -1629,6 +1679,37 @@ The following results separate the zero blocks from the
 	adjoint transfer map to the tensor and then back to the primal transfer map.
 \end{proof}
 
+\begin{lemma}[Orbit-sum construction, fixed-point-algebra variant]%
+	\label{lem:orbit_sum_hLift_fixed_algebra}
+	\lean{MPSTensor.hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity}
+	\leanok
+	\uses{def:sector_fixed_point_algebra_rigidity,
+	      lem:fix_upgrade_peripheral,
+	      lem:sector_fixed_algebra_proj_step,
+	      lem:orbit_sum_hLift_construction}
+	Let $A$ be a left-canonical MPS tensor with irreducible adjoint transfer map,
+	and let $(P_k)_{k=1}^m$ be cyclic orthogonal sector projections. Assume the
+	single fixed-point-algebra rigidity hypothesis from
+	Definition~\ref{def:sector_fixed_point_algebra_rigidity}. Then the orbit-sum
+	lift holds: for every orthogonal subprojection $Q \le P_k$ whose corner is
+	preserved by $(\E_A^\dagger)^m$, there is a global projection $R$ invariant
+	under $\E_A^\dagger$ with the same zero/full-sector tests.
+\end{lemma}
+
+\begin{proof}\leanok
+	\uses{def:sector_fixed_point_algebra_rigidity,
+	      lem:fix_upgrade_peripheral,
+	      lem:sector_fixed_algebra_proj_step,
+	      lem:orbit_sum_hLift_construction}
+	First apply Lemma~\ref{lem:fix_upgrade_peripheral} to upgrade corner
+	preservation of $Q$ under $(\E_A^\dagger)^m$ to an actual fixed-point
+	relation. The rigidity hypothesis then yields the one-step projection
+	preservation needed along the orbit of $Q$, via
+	Lemma~\ref{lem:sector_fixed_algebra_proj_step}. With those two inputs in hand,
+	the original orbit-sum construction from
+	Lemma~\ref{lem:orbit_sum_hLift_construction} applies verbatim.
+\end{proof}
+
 \begin{theorem}[Sector irreducibility from the orbit-sum construction]%
 	\label{thm:sector_irred_fix_upgrade}
 	\lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_fixUpgrade}
@@ -1662,6 +1743,24 @@ The following results separate the zero blocks from the
 \begin{proof}\leanok
 	\uses{thm:sector_irred_orbit_lift, lem:orbit_sum_hLift_proj_step}
 	Apply Lemma~\ref{lem:orbit_sum_hLift_proj_step} and then
+	Theorem~\ref{thm:sector_irred_orbit_lift}.
+\end{proof}
+
+\begin{theorem}[Sector irreducibility from fixed-point-algebra rigidity]%
+	\label{thm:sector_irred_fixed_algebra}
+	\lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity}
+	\leanok
+	\uses{thm:sector_irred_orbit_lift, lem:orbit_sum_hLift_fixed_algebra}
+	Let $A$ be a left-canonical MPS tensor with irreducible adjoint transfer map,
+	and let $(P_k)_{k=1}^m$ be cyclic orthogonal sector projections. Assume only
+	the fixed-point-algebra rigidity hypothesis from
+	Definition~\ref{def:sector_fixed_point_algebra_rigidity}. Then
+	$(\E_A^\dagger)^m$ is irreducible on each corner $P_k$.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:sector_irred_orbit_lift, lem:orbit_sum_hLift_fixed_algebra}
+	Apply Lemma~\ref{lem:orbit_sum_hLift_fixed_algebra} and then
 	Theorem~\ref{thm:sector_irred_orbit_lift}.
 \end{proof}
 


### PR DESCRIPTION
## Summary
- add `MPSTensor.SectorFixedPointAlgebraRigidity` as a single fixed-point-algebra hypothesis replacing the old abstract `hProjStep` + `hFixUpgrade` pair
- prove `hProjStep_of_sectorFixedPointAlgebraRigidity`, `hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`, and `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`
- sync `ch08_canonical.tex` and add the focused audit `audits/2026-04-23_issue599_fixed_point_route.md`

## What this lands
This PR takes **Option C** from issue #599.

`hFixUpgrade` is already discharged unconditionally by `MPSTensor.hFixUpgrade_of_peripheral`.
The remaining structural input is now packaged as the single hypothesis
`MPSTensor.SectorFixedPointAlgebraRigidity`, saying that the one-step adjoint
dynamics is multiplicative on the `T^m`-fixed corner algebra of each sector.

From that I prove:
- `MPSTensor.hProjStep_of_sectorFixedPointAlgebraRigidity`
- `MPSTensor.hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`
- `MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`

So the old two-input orbit-sum interface now has a one-hypothesis fixed-point-algebra variant.

## Residual gap
This does **not** yet prove `SectorFixedPointAlgebraRigidity` from current main.
The remaining honest endpoint is the Wolf-style sector fixed-point algebra / `lem:bdcf`
statement: the one-step sector dynamics should act as a `*`-homomorphism on the
`T^m`-fixed corner algebra.

## Verification
- `lake env lean TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean`
- `lake env lean TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean TNLean/MPS/CanonicalForm/SectorIrreducibility.lean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new core hypotheses and proof wrappers in the sector-irreducibility pipeline; mistakes could break downstream lemma dependencies even though changes are purely formal/proof-level.
> 
> **Overview**
> Introduces a new single hypothesis `MPSTensor.SectorFixedPointAlgebraRigidity` (multiplicativity of the one-step map on the `T^m`-fixed corner algebra) to *replace the previous pair* of abstract assumptions `hProjStep` + `hFixUpgrade` in the cyclic-sector orbit-sum lift.
> 
> Adds theorems `hProjStep_of_sectorFixedPointAlgebraRigidity`, `hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`, and `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`, and updates the umbrella `SectorIrreducibility.lean` exports accordingly. Documentation is synced via a new audit note and blueprint updates describing the new definition/lemmas and the now-localized remaining gap (deriving rigidity from the paper-level fixed-point-algebra result).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec44e2b35a82bffde93e8bc88a5afbe73c0c2c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->