### PR TITLE
feat(MPS/MPDO): add word-entry endpoint toward Prop. IV.3 biCF (#587)

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -9,7 +9,7 @@ import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 /-!
 # Finite-length sufficient conditions and obstructions for MPDO biCF
 
-The `HorizontalCFData` structure in `VerticalCF.lean` packages the block-injective
+The `HorizontalCFData` structure in `VerticalCF.lean` records the block-injective
 canonical-form property `biCF` as a hypothesis. This file records four complementary
 facts about that field.
 
@@ -20,12 +20,12 @@ facts about that field.
    then the `biCF` conclusion follows from nondegeneracy of the product trace
    pairing.
 
-2. A finite-dimensional **linear-independence endpoint**: if the scalar word-entry
+2. A finite-dimensional **linear-independence criterion**: if the scalar word-entry
    family obtained by reading off every block matrix entry is linearly
    independent, then those tuple-valued word evaluations already span the full
-   product algebra. This reduces biCF to a concrete linear-algebra target.
+   product algebra. This reduces biCF to a concrete linear-algebra condition.
 
-3. An abstract **Proposition IV.3-style selector package**: if each block is
+3. An abstract **Proposition IV.3-style selector data criterion**: if each block is
    block-injective at some common length and a second finite family of words
    isolates the individual blocks (identity on one block, zero on the others),
    then concatenating the two families yields the preceding span condition.
@@ -37,8 +37,8 @@ facts about that field.
    imply `biCF`. Thus the current `HorizontalCFData` fields other than `biCF`
    are insufficient for deriving that property.
 
-This isolates the missing ingredient more precisely: one still needs a genuine
-finite-length block-separation theorem producing either the selector package of
+This isolates the missing ingredient more precisely: one still needs a proved
+finite-length block-separation theorem producing either the selector data of
 item (3), or equivalently the word-entry linear independence of item (2), from
 canonical-form/BNT data.
 -/
@@ -260,8 +260,8 @@ theorem wordTupleSpanTop_of_wordEntryFamily_linearIndependent
             exact False.elim (hmem (Finset.mem_univ _))
     _ = M j a b := rfl
 
-/-- The linear-independence endpoint above gives the abstract Proposition-IV.3
-selector package as a corollary. -/
+/-- The linear-independence criterion above gives the abstract Proposition-IV.3
+selector data as a corollary. -/
 theorem hasBlockSelectorWords_of_wordEntryFamily_linearIndependent
     (A : (k : Fin r) → MPSTensor d (dim k))
     {L : ℕ} (hLI : LinearIndependent ℂ (wordEntryFamily A L)) :
@@ -269,7 +269,7 @@ theorem hasBlockSelectorWords_of_wordEntryFamily_linearIndependent
   hasBlockSelectorWords_of_wordTupleSpanTop A
     (wordTupleSpanTop_of_wordEntryFamily_linearIndependent A hLI)
 
-/-- The linear-independence endpoint above also yields the `HasBiCF` witness
+/-- The linear-independence criterion above also yields the `HasBiCF` witness
 used by `HorizontalCFData`. -/
 theorem hasBiCF_of_wordEntryFamily_linearIndependent
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -392,7 +392,7 @@ theorem wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
   rw [← hassembled]
   exact hassembled_mem
 
-/-- The abstract Proposition-IV.3 selector package implies the finite-length
+/-- The abstract Proposition-IV.3 selector data imply the finite-length
 word-tuple span condition. -/
 theorem wordTupleSpanTop_of_propBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -402,7 +402,7 @@ theorem wordTupleSpanTop_of_propBlockInjective
   exact ⟨L + S,
     wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords A hInj hSel⟩
 
-/-- The abstract Proposition-IV.3 selector package implies `HasBiCF`. -/
+/-- The abstract Proposition-IV.3 selector data imply `HasBiCF`. -/
 theorem hasBiCF_of_propBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hProp : PropBlockInjective A) :
@@ -499,7 +499,7 @@ theorem duplicateScalarBlocks_not_hasBiCF :
   have hentry := congrFun (congrFun hzero 0) 0
   simp [Δ] at hentry
 
-/-- Packaged counterexample to deriving finite-length block separation from the
+/-- Counterexample to deriving finite-length block separation from the
 other `HorizontalCFData` fields alone. -/
 theorem duplicateScalarBlocks_counterexample :
     (∀ k, IsInjective (duplicateScalarBlocks k)) ∧
@@ -528,8 +528,7 @@ theorem HorizontalCFData.toHasBiCF
     MPSTensor.HasBiCF A :=
   hCF.biCF
 
-/-- A finite-length block-separation hypothesis packages directly into
-`HorizontalCFData`. -/
+/-- A finite-length block-separation hypothesis yields `HorizontalCFData`. -/
 theorem horizontalCFData_of_wordTupleSpanTop
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hInj : ∀ k, MPSTensor.IsInjective (A k))
@@ -560,8 +559,8 @@ theorem horizontalCFData_of_wordEntryFamily_linearIndependent
   horizontalCFData_of_wordTupleSpanTop A hInj hLeft hμne
     ⟨L, MPSTensor.wordTupleSpanTop_of_wordEntryFamily_linearIndependent A hLI⟩
 
-/-- Proposition-IV.3-style selector data packages directly into
-`HorizontalCFData` through the finite-length span criterion. -/
+/-- Proposition-IV.3-style selector data yield `HorizontalCFData` through the
+finite-length span criterion. -/
 theorem horizontalCFData_of_propBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hInj : ∀ k, MPSTensor.IsInjective (A k))
@@ -580,7 +579,7 @@ theorem horizontalCFData_of_propBlockInjective
 /-!
 ## Why the remaining `HorizontalCFData` fields are still insufficient
 
-The strengthened hypotheses used above are genuinely extra data. A simple
+The strengthened hypotheses used above are strictly extra data. A simple
 obstruction shows that one cannot derive `biCF` from blockwise injectivity,
 left-canonicality, and nonzero (even pairwise distinct) weights alone.
 
@@ -595,8 +594,8 @@ any blocking length `L` there is only one word `w : Fin L → Fin 1`, and
 
 for that unique word, while `Δ ≠ 0`. Therefore `HasBiCF A` fails.
 
-The new predicate `PropBlockInjective` packages one abstract finite-length route,
-while `wordEntryFamily` packages a second, equivalent linear-algebra endpoint.
+The new predicate `PropBlockInjective` expresses one abstract finite-length route,
+while `wordEntryFamily` gives a second, equivalent linear-algebra criterion.
 What remains open is to derive either of those finite-length witnesses from the
 repository's current BNT / canonical-form hypotheses, i.e. to formalize the full
 content of Proposition IV.3 of arXiv:1606.00608.

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -79,10 +79,6 @@ def wordEntryFamily
     (L : ℕ) : BlockEntryIndex dim → (Fin L → Fin d) → ℂ :=
   fun x w => blockEntryValue (wordTuple A L w) x
 
-/-- The delta function at a chosen index in a finite function space. -/
-private def deltaFun {ι : Type*} [DecidableEq ι] (i : ι) : ι → ℂ :=
-  fun j => if j = i then 1 else 0
-
 /-- The block-injective canonical-form property used by `HorizontalCFData`. -/
 def HasBiCF
     (A : (k : Fin r) → MPSTensor d (dim k)) : Prop :=
@@ -167,30 +163,48 @@ private theorem exists_dualCoeffs_of_wordEntryFamily_linearIndependent
     exact funext (Fintype.linearIndependent_iff.mp hLI c (by simpa [lc] using hc))
   obtain ⟨Ψ, hΨ⟩ := lc.exists_leftInverse_of_injective hlcKer
   let coeff : BlockEntryIndex dim → (Fin L → Fin d) → ℂ :=
-    fun x w => Ψ (deltaFun w) x
+    fun x w => Ψ ((Pi.single w (1 : ℂ) : (Fin L → Fin d) → ℂ)) x
   have hΨ_apply :
       ∀ (f : (Fin L → Fin d) → ℂ) (x : BlockEntryIndex dim),
         Ψ f x = ∑ w : Fin L → Fin d, f w * coeff x w := by
     intro f x
-    have hdecomp : f = ∑ w : Fin L → Fin d, f w • deltaFun w := by
-      ext w
-      simp [deltaFun]
-    rw [hdecomp, map_sum]
-    simp [coeff, deltaFun]
+    calc
+      Ψ f x = Ψ (∑ w : Fin L → Fin d, (Pi.single w (f w) : (Fin L → Fin d) → ℂ)) x := by
+        simpa using
+          congrArg (fun g : ((Fin L → Fin d) → ℂ) => Ψ g x) (Finset.univ_sum_single f).symm
+      _ = ∑ w : Fin L → Fin d, Ψ ((Pi.single w (f w) : (Fin L → Fin d) → ℂ)) x := by
+        rw [map_sum]
+        simp
+      _ = ∑ w : Fin L → Fin d, f w * coeff x w := by
+        refine Finset.sum_congr rfl ?_
+        intro w _
+        have hsingle_smul :
+            ((Pi.single w (f w) : (Fin L → Fin d) → ℂ)) =
+              f w • ((Pi.single w (1 : ℂ) : (Fin L → Fin d) → ℂ)) := by
+          ext z
+          by_cases hzw : z = w
+          · subst hzw
+            simp
+          · simp [Pi.single_eq_of_ne hzw]
+        rw [hsingle_smul]
+        simp [coeff]
   refine ⟨coeff, ?_⟩
   intro x y
-  have hsingle : lc (deltaFun y) = wordEntryFamily A L y := by
+  have hsingle :
+      lc ((Pi.single y (1 : ℂ) : BlockEntryIndex dim → ℂ)) = wordEntryFamily A L y := by
     ext w
     rw [Fintype.linearCombination_apply, Finset.sum_eq_single y]
-    · simp [deltaFun]
+    · simp
     · intro z _ hzy
-      simp [deltaFun, hzy]
+      simp [Pi.single_eq_of_ne hzy]
     · intro hy
       exact False.elim (hy (Finset.mem_univ y))
   have hy : Ψ (wordEntryFamily A L y) x = if x = y then 1 else 0 := by
-    have hleft : Ψ (lc (deltaFun y)) = deltaFun y := by
-      simpa using congrArg (fun f => f (deltaFun y)) hΨ
-    simpa [hsingle, deltaFun] using congrFun hleft x
+    have hleft :
+        Ψ (lc ((Pi.single y (1 : ℂ) : BlockEntryIndex dim → ℂ))) =
+          ((Pi.single y (1 : ℂ) : BlockEntryIndex dim → ℂ)) := by
+      simpa using congrArg (fun f => f ((Pi.single y (1 : ℂ) : BlockEntryIndex dim → ℂ))) hΨ
+    simpa [hsingle, Pi.single_apply] using congrFun hleft x
   simpa [hΨ_apply (wordEntryFamily A L y) x, mul_comm] using hy
 
 /-- Linear independence of the scalar word-entry family forces the tuple-valued

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -413,7 +413,7 @@ theorem hasBiCF_of_propBlockInjective
 section DuplicateScalarBlocks
 
 /-- Nonzero weights for the duplicate-block counterexample. -/
-noncomputable def duplicateScalarWeights : Fin 2 → ℂ
+def duplicateScalarWeights : Fin 2 → ℂ
   | 0 => 1
   | 1 => 2
 
@@ -423,7 +423,7 @@ abbrev duplicateScalarDim : Fin 2 → ℕ := fun _ => 1
 /-- Two identical `1 × 1` blocks. This family is blockwise injective and
 left-canonical, but it cannot admit any finite-length `wordEntryFamily`
 linear-independence witness. -/
-noncomputable def duplicateScalarBlocks :
+def duplicateScalarBlocks :
     (k : Fin 2) → MPSTensor 1 (duplicateScalarDim k)
   | _ => fun _ => (1 : Matrix (Fin 1) (Fin 1) ℂ)
 
@@ -457,7 +457,7 @@ theorem duplicateScalarBlocks_leftCanonical :
 theorem duplicateScalarWeights_ne_zero :
     ∀ k, duplicateScalarWeights k ≠ 0 := by
   intro k
-  fin_cases k <;> simp [duplicateScalarWeights]
+  fin_cases k <;> norm_num [duplicateScalarWeights]
 
 /-- Duplicate blocks force repeated scalar word-entry functionals, so no blocking
 length can make `wordEntryFamily` linearly independent. -/
@@ -478,10 +478,26 @@ theorem duplicateScalarBlocks_not_linearIndependent_wordEntryFamily (L : ℕ) :
 /-- Concrete obstruction to the Issue-#822 target on the current hypotheses:
 blockwise injectivity, left-canonicality, and nonzero weights do not by
 themselves imply a finite-length `wordEntryFamily` witness. -/
-theorem duplicateScalarBlocks_no_wordEntryFamily_linearIndependent :
+theorem duplicateScalarBlocks_not_exists_linearIndependent_wordEntryFamily :
     ¬ ∃ L, LinearIndependent ℂ (wordEntryFamily duplicateScalarBlocks L) := by
   rintro ⟨L, hL⟩
   exact duplicateScalarBlocks_not_linearIndependent_wordEntryFamily L hL
+
+/-- The duplicate scalar blocks do not satisfy the biCF trace-separation property. -/
+theorem duplicateScalarBlocks_not_hasBiCF :
+    ¬ HasBiCF duplicateScalarBlocks := by
+  rintro ⟨L, hL⟩
+  let Δ : (k : Fin 2) → Matrix (Fin (duplicateScalarDim k)) (Fin (duplicateScalarDim k)) ℂ :=
+    fun k => if k = 0 then 1 else -1
+  have hTrace :
+      ∀ w : Fin L → Fin 1,
+        (∑ k : Fin 2,
+          Matrix.trace (Δ k * evalWord (duplicateScalarBlocks k) (List.ofFn w))) = 0 := by
+    intro w
+    simp [Δ, duplicateScalarBlocks, duplicateScalarDim, Matrix.trace_fin_one]
+  have hzero := hL Δ hTrace 0
+  have hentry := congrFun (congrFun hzero 0) 0
+  simp [Δ] at hentry
 
 /-- Packaged counterexample to deriving finite-length block separation from the
 other `HorizontalCFData` fields alone. -/
@@ -490,10 +506,11 @@ theorem duplicateScalarBlocks_counterexample :
       (∀ k, ∑ i : Fin 1,
         (duplicateScalarBlocks k i)ᴴ * duplicateScalarBlocks k i = 1) ∧
       (∀ k, duplicateScalarWeights k ≠ 0) ∧
+      ¬ HasBiCF duplicateScalarBlocks ∧
       ¬ ∃ L, LinearIndependent ℂ (wordEntryFamily duplicateScalarBlocks L) := by
   refine ⟨duplicateScalarBlocks_isInjective, duplicateScalarBlocks_leftCanonical,
-    duplicateScalarWeights_ne_zero,
-    duplicateScalarBlocks_no_wordEntryFamily_linearIndependent⟩
+    duplicateScalarWeights_ne_zero, duplicateScalarBlocks_not_hasBiCF,
+    duplicateScalarBlocks_not_exists_linearIndependent_wordEntryFamily⟩
 
 end DuplicateScalarBlocks
 

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -10,7 +10,7 @@ import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 # Finite-length sufficient conditions and obstructions for MPDO biCF
 
 The `HorizontalCFData` structure in `VerticalCF.lean` packages the block-injective
-canonical-form property `biCF` as a hypothesis. This file records three complementary
+canonical-form property `biCF` as a hypothesis. This file records four complementary
 facts about that field.
 
 1. A clean **abstract sufficient condition**: if, after blocking to some fixed
@@ -20,21 +20,27 @@ facts about that field.
    then the `biCF` conclusion follows from nondegeneracy of the product trace
    pairing.
 
-2. An abstract **Proposition IV.3-style selector package**: if each block is
+2. A finite-dimensional **linear-independence endpoint**: if the scalar word-entry
+   family obtained by reading off every block matrix entry is linearly
+   independent, then those tuple-valued word evaluations already span the full
+   product algebra. This reduces biCF to a concrete linear-algebra target.
+
+3. An abstract **Proposition IV.3-style selector package**: if each block is
    block-injective at some common length and a second finite family of words
    isolates the individual blocks (identity on one block, zero on the others),
    then concatenating the two families yields the preceding span condition.
    This captures the finite-length block-separation content of
    [CPGSV17], Proposition IV.3.
 
-3. A concrete **counterexample**: blockwise injectivity, left-canonical
+4. A concrete **counterexample**: blockwise injectivity, left-canonical
    normalization, nonzero weights, and even pairwise distinct weights do **not**
    imply `biCF`. Thus the current `HorizontalCFData` fields other than `biCF`
    are insufficient for deriving that property.
 
-This isolates the missing ingredient precisely: one still needs a genuine
-finite-length block-separation theorem, i.e. the content of Proposition IV.3
-(`propblockinj`) from arXiv:1606.00608.
+This isolates the missing ingredient more precisely: one still needs a genuine
+finite-length block-separation theorem producing either the selector package of
+item (3), or equivalently the word-entry linear independence of item (2), from
+canonical-form/BNT data.
 -/
 
 open scoped Matrix BigOperators
@@ -55,6 +61,27 @@ def WordTupleSpanTop
     (A : (k : Fin r) → MPSTensor d (dim k))
     (L : ℕ) : Prop :=
   Submodule.span ℂ (Set.range (wordTuple A L)) = ⊤
+
+/-- Index type for a matrix entry inside a block family. -/
+abbrev BlockEntryIndex (dim : Fin r → ℕ) :=
+  Σ k : Fin r, Fin (dim k) × Fin (dim k)
+
+/-- The value of a tuple of block matrices at a chosen block entry. -/
+def blockEntryValue
+    (M : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+    (x : BlockEntryIndex dim) : ℂ :=
+  M x.1 x.2.1 x.2.2
+
+/-- The scalar word family obtained by reading off one chosen matrix entry of the
+block-word tuple. -/
+def wordEntryFamily
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (L : ℕ) : BlockEntryIndex dim → (Fin L → Fin d) → ℂ :=
+  fun x w => blockEntryValue (wordTuple A L w) x
+
+/-- The delta function at a chosen index in a finite function space. -/
+private def deltaFun {ι : Type*} [DecidableEq ι] (i : ι) : ι → ℂ :=
+  fun j => if j = i then 1 else 0
 
 /-- The block-injective canonical-form property used by `HorizontalCFData`. -/
 def HasBiCF
@@ -105,6 +132,137 @@ def HasBlockSelectorWords
     (∑ w : Fin S → Fin d, c w • evalWord (A k) (List.ofFn w)) = 1 ∧
     ∀ j : Fin r, j ≠ k →
       (∑ w : Fin S → Fin d, c w • evalWord (A j) (List.ofFn w)) = 0
+
+/-- Any finite-length product-algebra spanning witness already contains block
+selectors as a special case. -/
+theorem hasBlockSelectorWords_of_wordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {S : ℕ} (hSpan : WordTupleSpanTop A S) :
+    HasBlockSelectorWords A S := by
+  classical
+  intro k
+  let target : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j => if h : j = k then 1 else 0
+  have htarget : target ∈ Submodule.span ℂ (Set.range (wordTuple A S)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  rcases (Submodule.mem_span_range_iff_exists_fun ℂ).mp htarget with ⟨c, hc⟩
+  refine ⟨c, ?_, ?_⟩
+  · simpa [target] using congrArg (fun M => M k) hc
+  · intro j hj
+    simpa [target, hj] using congrArg (fun M => M j) hc
+
+private theorem exists_dualCoeffs_of_wordEntryFamily_linearIndependent
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L : ℕ} (hLI : LinearIndependent ℂ (wordEntryFamily A L)) :
+    ∃ coeff : BlockEntryIndex dim → (Fin L → Fin d) → ℂ,
+      ∀ x y : BlockEntryIndex dim,
+        ∑ w : Fin L → Fin d, coeff x w * wordEntryFamily A L y w =
+          if x = y then 1 else 0 := by
+  classical
+  let lc := Fintype.linearCombination ℂ (wordEntryFamily A L)
+  have hlcKer : lc.ker = ⊥ := by
+    rw [LinearMap.ker_eq_bot']
+    intro c hc
+    exact funext (Fintype.linearIndependent_iff.mp hLI c (by simpa [lc] using hc))
+  obtain ⟨Ψ, hΨ⟩ := lc.exists_leftInverse_of_injective hlcKer
+  let coeff : BlockEntryIndex dim → (Fin L → Fin d) → ℂ :=
+    fun x w => Ψ (deltaFun w) x
+  have hΨ_apply :
+      ∀ (f : (Fin L → Fin d) → ℂ) (x : BlockEntryIndex dim),
+        Ψ f x = ∑ w : Fin L → Fin d, f w * coeff x w := by
+    intro f x
+    have hdecomp : f = ∑ w : Fin L → Fin d, f w • deltaFun w := by
+      ext w
+      simp [deltaFun]
+    rw [hdecomp, map_sum]
+    simp [coeff, deltaFun]
+  refine ⟨coeff, ?_⟩
+  intro x y
+  have hsingle : lc (deltaFun y) = wordEntryFamily A L y := by
+    ext w
+    rw [Fintype.linearCombination_apply, Finset.sum_eq_single y]
+    · simp [deltaFun]
+    · intro z _ hzy
+      simp [deltaFun, hzy]
+    · intro hy
+      exact False.elim (hy (Finset.mem_univ y))
+  have hy : Ψ (wordEntryFamily A L y) x = if x = y then 1 else 0 := by
+    have hleft : Ψ (lc (deltaFun y)) = deltaFun y := by
+      simpa using congrArg (fun f => f (deltaFun y)) hΨ
+    simpa [hsingle, deltaFun] using congrFun hleft x
+  simpa [hΨ_apply (wordEntryFamily A L y) x, mul_comm] using hy
+
+/-- Linear independence of the scalar word-entry family forces the tuple-valued
+length-`L` word evaluations to span the full product algebra. -/
+theorem wordTupleSpanTop_of_wordEntryFamily_linearIndependent
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L : ℕ} (hLI : LinearIndependent ℂ (wordEntryFamily A L)) :
+    WordTupleSpanTop A L := by
+  classical
+  rcases exists_dualCoeffs_of_wordEntryFamily_linearIndependent A hLI with
+    ⟨coeff, hcoeff⟩
+  rw [WordTupleSpanTop, span_range_eq_top_iff_surjective_fintypeLinearCombination]
+  intro M
+  let c : (Fin L → Fin d) → ℂ :=
+    fun w => ∑ x : BlockEntryIndex dim, blockEntryValue M x * coeff x w
+  refine ⟨c, ?_⟩
+  ext j a b
+  calc
+    (Fintype.linearCombination ℂ (wordTuple A L) c) j a b
+        = (∑ w : Fin L → Fin d, c w • evalWord (A j) (List.ofFn w)) a b := by
+            simp [Fintype.linearCombination_apply, wordTuple, Pi.smul_apply]
+    _ = ∑ w : Fin L → Fin d, c w * wordEntryFamily A L ⟨j, (a, b)⟩ w := by
+          simp_rw [Matrix.sum_apply, Matrix.smul_apply]
+          simp [wordEntryFamily, blockEntryValue, wordTuple]
+    _ = ∑ w : Fin L → Fin d,
+          ∑ x : BlockEntryIndex dim,
+            blockEntryValue M x * (coeff x w * wordEntryFamily A L ⟨j, (a, b)⟩ w) := by
+          unfold c
+          refine Finset.sum_congr rfl ?_
+          intro w _
+          rw [Finset.sum_mul]
+          refine Finset.sum_congr rfl ?_
+          intro x _
+          ring
+    _ = ∑ x : BlockEntryIndex dim,
+          blockEntryValue M x *
+            (∑ w : Fin L → Fin d, coeff x w * wordEntryFamily A L ⟨j, (a, b)⟩ w) := by
+          rw [Finset.sum_comm]
+          refine Finset.sum_congr rfl ?_
+          intro x _
+          rw [← Finset.mul_sum]
+    _ = ∑ x : BlockEntryIndex dim,
+          blockEntryValue M x * (if x = ⟨j, (a, b)⟩ then 1 else 0) := by
+          refine Finset.sum_congr rfl ?_
+          intro x _
+          rw [hcoeff x ⟨j, (a, b)⟩]
+    _ = blockEntryValue M ⟨j, (a, b)⟩ := by
+          rw [Finset.sum_eq_single ⟨j, (a, b)⟩]
+          · simp
+          · intro x _ hx
+            simp [hx]
+          · intro hmem
+            exact False.elim (hmem (Finset.mem_univ _))
+    _ = M j a b := rfl
+
+/-- The linear-independence endpoint above gives the abstract Proposition-IV.3
+selector package as a corollary. -/
+theorem hasBlockSelectorWords_of_wordEntryFamily_linearIndependent
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L : ℕ} (hLI : LinearIndependent ℂ (wordEntryFamily A L)) :
+    HasBlockSelectorWords A L :=
+  hasBlockSelectorWords_of_wordTupleSpanTop A
+    (wordTupleSpanTop_of_wordEntryFamily_linearIndependent A hLI)
+
+/-- The linear-independence endpoint above also yields the `HasBiCF` witness
+used by `HorizontalCFData`. -/
+theorem hasBiCF_of_wordEntryFamily_linearIndependent
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L : ℕ} (hLI : LinearIndependent ℂ (wordEntryFamily A L)) :
+    HasBiCF A :=
+  hasBiCF_of_wordTupleSpanTop A
+    (wordTupleSpanTop_of_wordEntryFamily_linearIndependent A hLI)
 
 /-- Abstract finite-length data isolating the content of Proposition IV.3
 (`propblockinj`) from arXiv:1606.00608.
@@ -270,6 +428,20 @@ theorem horizontalCFData_of_wordTupleSpanTop
   }
   exact MPSTensor.hasBiCF_of_wordTupleSpanTop A hL
 
+/-- Linear independence of the scalar word-entry family is another concrete
+route into `HorizontalCFData`: it already implies the finite-length product
+algebra span condition. -/
+theorem horizontalCFData_of_wordEntryFamily_linearIndependent
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hInj : ∀ k, MPSTensor.IsInjective (A k))
+    (hLeft : ∀ k, ∑ i : Fin d, (A k i)ᴴ * A k i = 1)
+    (hμne : ∀ k, μ k ≠ 0)
+    {L : ℕ}
+    (hLI : LinearIndependent ℂ (MPSTensor.wordEntryFamily A L)) :
+    HorizontalCFData (d := d) μ A :=
+  horizontalCFData_of_wordTupleSpanTop A hInj hLeft hμne
+    ⟨L, MPSTensor.wordTupleSpanTop_of_wordEntryFamily_linearIndependent A hLI⟩
+
 /-- Proposition-IV.3-style selector data packages directly into
 `HorizontalCFData` through the finite-length span criterion. -/
 theorem horizontalCFData_of_propBlockInjective
@@ -305,8 +477,9 @@ any blocking length `L` there is only one word `w : Fin L → Fin 1`, and
 
 for that unique word, while `Δ ≠ 0`. Therefore `HasBiCF A` fails.
 
-The new predicate `PropBlockInjective` packages the extra finite-length block
-selectors abstractly. What remains open is to derive those selectors from the
+The new predicate `PropBlockInjective` packages one abstract finite-length route,
+while `wordEntryFamily` packages a second, equivalent linear-algebra endpoint.
+What remains open is to derive either of those finite-length witnesses from the
 repository's current BNT / canonical-form hypotheses, i.e. to formalize the full
 content of Proposition IV.3 of arXiv:1606.00608.
 -/

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -410,6 +410,93 @@ theorem hasBiCF_of_propBlockInjective
   rcases wordTupleSpanTop_of_propBlockInjective A hProp with ⟨N, hN⟩
   exact hasBiCF_of_wordTupleSpanTop A hN
 
+section DuplicateScalarBlocks
+
+/-- Nonzero weights for the duplicate-block counterexample. -/
+noncomputable def duplicateScalarWeights : Fin 2 → ℂ
+  | 0 => 1
+  | 1 => 2
+
+/-- Common block dimension for the duplicate-block counterexample. -/
+abbrev duplicateScalarDim : Fin 2 → ℕ := fun _ => 1
+
+/-- Two identical `1 × 1` blocks. This family is blockwise injective and
+left-canonical, but it cannot admit any finite-length `wordEntryFamily`
+linear-independence witness. -/
+noncomputable def duplicateScalarBlocks :
+    (k : Fin 2) → MPSTensor 1 (duplicateScalarDim k)
+  | _ => fun _ => (1 : Matrix (Fin 1) (Fin 1) ℂ)
+
+private theorem span_singleton_one_finOne_eq_top :
+    (ℂ ∙ (1 : Matrix (Fin 1) (Fin 1) ℂ)) = ⊤ := by
+  refine (Submodule.span_singleton_eq_top_iff ℂ
+    (1 : Matrix (Fin 1) (Fin 1) ℂ)).2 ?_
+  intro M
+  refine ⟨M 0 0, ?_⟩
+  ext i j
+  have hi : i = 0 := Fin.eq_zero i
+  have hj : j = 0 := Fin.eq_zero j
+  subst hi
+  subst hj
+  simp
+
+/-- Each duplicate scalar block is injective. -/
+theorem duplicateScalarBlocks_isInjective :
+    ∀ k, IsInjective (duplicateScalarBlocks k) := by
+  intro k
+  simpa [duplicateScalarBlocks, duplicateScalarDim, IsInjective, Set.range_const] using
+    span_singleton_one_finOne_eq_top
+
+/-- The duplicate scalar blocks are left-canonical. -/
+theorem duplicateScalarBlocks_leftCanonical :
+    ∀ k, ∑ i : Fin 1, (duplicateScalarBlocks k i)ᴴ * duplicateScalarBlocks k i = 1 := by
+  intro k
+  simp [duplicateScalarBlocks]
+
+/-- The counterexample weights are nonzero. -/
+theorem duplicateScalarWeights_ne_zero :
+    ∀ k, duplicateScalarWeights k ≠ 0 := by
+  intro k
+  fin_cases k <;> simp [duplicateScalarWeights]
+
+/-- Duplicate blocks force repeated scalar word-entry functionals, so no blocking
+length can make `wordEntryFamily` linearly independent. -/
+theorem duplicateScalarBlocks_not_linearIndependent_wordEntryFamily (L : ℕ) :
+    ¬ LinearIndependent ℂ (wordEntryFamily duplicateScalarBlocks L) := by
+  intro hLI
+  let x0 : BlockEntryIndex duplicateScalarDim := ⟨0, (0, 0)⟩
+  let x1 : BlockEntryIndex duplicateScalarDim := ⟨1, (0, 0)⟩
+  have hEq : wordEntryFamily duplicateScalarBlocks L x0 =
+      wordEntryFamily duplicateScalarBlocks L x1 := by
+    funext w
+    simp [x0, x1, wordEntryFamily, blockEntryValue, wordTuple, duplicateScalarBlocks]
+  have hx : x0 = x1 := hLI.injective hEq
+  have h01 : (0 : Fin 2) = 1 := by
+    simpa [x0, x1] using congrArg Sigma.fst hx
+  exact Fin.zero_ne_one h01
+
+/-- Concrete obstruction to the Issue-#822 target on the current hypotheses:
+blockwise injectivity, left-canonicality, and nonzero weights do not by
+themselves imply a finite-length `wordEntryFamily` witness. -/
+theorem duplicateScalarBlocks_no_wordEntryFamily_linearIndependent :
+    ¬ ∃ L, LinearIndependent ℂ (wordEntryFamily duplicateScalarBlocks L) := by
+  rintro ⟨L, hL⟩
+  exact duplicateScalarBlocks_not_linearIndependent_wordEntryFamily L hL
+
+/-- Packaged counterexample to deriving finite-length block separation from the
+other `HorizontalCFData` fields alone. -/
+theorem duplicateScalarBlocks_counterexample :
+    (∀ k, IsInjective (duplicateScalarBlocks k)) ∧
+      (∀ k, ∑ i : Fin 1,
+        (duplicateScalarBlocks k i)ᴴ * duplicateScalarBlocks k i = 1) ∧
+      (∀ k, duplicateScalarWeights k ≠ 0) ∧
+      ¬ ∃ L, LinearIndependent ℂ (wordEntryFamily duplicateScalarBlocks L) := by
+  refine ⟨duplicateScalarBlocks_isInjective, duplicateScalarBlocks_leftCanonical,
+    duplicateScalarWeights_ne_zero,
+    duplicateScalarBlocks_no_wordEntryFamily_linearIndependent⟩
+
+end DuplicateScalarBlocks
+
 end MPSTensor
 
 namespace MPOTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -138,7 +138,7 @@ theorem hasBlockSelectorWords_of_wordTupleSpanTop
   classical
   intro k
   let target : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
-    fun j => if h : j = k then 1 else 0
+    fun j => if j = k then 1 else 0
   have htarget : target ∈ Submodule.span ℂ (Set.range (wordTuple A S)) := by
     rw [hSpan]
     exact Submodule.mem_top

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -42,7 +42,7 @@ The full Proposition IV.12 / Prop. 4.13 bridge from horizontal to vertical
 canonical form is deferred to a follow-up PR: its blueprint entry
 `thm:vertical_cf_of_horizontal_cf` is marked `\notready`, and the corresponding
 Lean statement will be introduced together with its proof rather than as an
-axiomless scaffold.
+empty placeholder.
 
 ## Module location
 
@@ -130,11 +130,13 @@ structure HorizontalCFData {r : ℕ} {dim : Fin r → ℕ}
   any tensor in CF is in biCF, which is what the paper's Lemma L invokes to
   separate blockwise contributions.
 
-  *Interim status.* This is currently taken as a hypothesis rather than derived
-  from `block_injective` + `left_canonical`. The forward plan is to supply a
-  Lean proof of `propblockinj` (CPGSV17 Prop. IV.3) and then construct
-  `HorizontalCFData` without requiring `biCF` as an input; this is tracked by
-  the RFP/MPDO 3/5 milestone (issue #235). -/
+  *Current repository status.* `TNLean/MPS/MPDO/BiCFDerivation.lean` now provides
+  several honest constructors for this field: from a full finite-length tuple-span
+  witness (`WordTupleSpanTop`), from the abstract selector package
+  (`PropBlockInjective`), and from the more concrete linear-independence endpoint
+  `wordEntryFamily`. What is still open is to derive one of those finite-length
+  witnesses from the remaining canonical-form/BNT data alone, i.e. the actual
+  Proposition-IV.3 theorem from [CPGSV17]. -/
   biCF : ∃ L : ℕ, ∀ (Δ : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
     (∀ w : Fin L → Fin d,
         (∑ k : Fin r, Matrix.trace (Δ k * MPSTensor.evalWord (A k) (List.ofFn w))) = 0) →

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -9,14 +9,14 @@ import TNLean.MPS.SharedInfra.BlockAssembly
 /-!
 # Vertical canonical form for MPO tensors
 
-This file introduces a Lean-facing version of the vertical canonical-form
+This file introduces a block-decomposed version of the vertical canonical-form
 structure used in the MPDO analysis of arXiv:1606.00608, §4.4.
 
 The paper's Proposition IV.12 writes the tensor, after a local isometry on the
 physical indices, as a direct sum
 `⊕_α μ_α ⊗ M_α`, where the `μ_α` are positive diagonal matrices and the
 `M_α` form a basis of normal tensors (BNT). The current repository infrastructure
-packages canonical-form and BNT data using scalar block weights. We therefore
+uses canonical-form and BNT data with scalar block weights. We therefore
 encode the paper's diagonal matrices by **flattening** each diagonal entry of
 `μ_α` into a repeated positive scalar weight attached to the same block `M_α`.
 
@@ -105,7 +105,7 @@ lemma verticalTransferMap_apply (M : MPOTensor d D)
 
 /-- Lightweight horizontal canonical-form data for a family of blocks.
 
-This is the fragment of the full canonical-form package needed for the MPDO
+This is the fragment of the full canonical-form data needed for the MPDO
 vertical-canonical-form interface in this file: injective blocks, the
 left-canonical normalization, nonzero block weights, and block-injective
 canonical form (biCF). -/
@@ -123,17 +123,17 @@ structure HorizontalCFData {r : ℕ} {dim : Fin r → ℕ}
   `Δ k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ` pairs to zero against every
   length-`L` block-diagonal product, then each `Δ k` vanishes individually.
 
-  This is the Lean-facing surrogate for [CPGSV17], Proposition IV.3
+  This is the block-decomposed surrogate for [CPGSV17], Proposition IV.3
   (arXiv:1606.00608, "`propblockinj`"): after blocking at most `3 D^5` spins,
   where `D` denotes the bond dimension in the paper (in this block-decomposed
-  Lean setting one may take `D` to be a global bound such as `⨆ k, dim k`),
+  setting one may take `D` to be a global bound such as `⨆ k, dim k`),
   any tensor in CF is in biCF, which is what the paper's Lemma L invokes to
   separate blockwise contributions.
 
   *Current repository status.* `TNLean/MPS/MPDO/BiCFDerivation.lean` now provides
-  several honest constructors for this field: from a full finite-length tuple-span
-  witness (`WordTupleSpanTop`), from the abstract selector package
-  (`PropBlockInjective`), and from the more concrete linear-independence endpoint
+  several exact routes to this field: from a full finite-length tuple-span
+  witness (`WordTupleSpanTop`), from the abstract selector data
+  (`PropBlockInjective`), and from the more concrete linear-independence criterion
   `wordEntryFamily`. What is still open is to derive one of those finite-length
   witnesses from the remaining canonical-form/BNT data alone, i.e. the actual
   Proposition-IV.3 theorem from [CPGSV17]. -/

--- a/audits/2026-04-23_issue587_propblockinj_v2.md
+++ b/audits/2026-04-23_issue587_propblockinj_v2.md
@@ -3,7 +3,7 @@
 ## Scope of this pass
 
 This pass does **not** delete the `biCF` field from `MPOTensor.HorizontalCFData`.
-Instead it adds a genuine finite-dimensional reduction step in
+Instead it adds a substantive finite-dimensional reduction step in
 `TNLean/MPS/MPDO/BiCFDerivation.lean` and sharpens the remaining blocker.
 
 ## What landed in Lean
@@ -30,11 +30,11 @@ Mathematical content:
    family, its linear independence exactly gives a dual coefficient family on the
    finite word space. Those dual coefficients reconstruct arbitrary tuples of block
    matrices, hence force `WordTupleSpanTop`.
-3. As corollaries, the same linear-independence endpoint yields block selectors,
-   a `HasBiCF` witness, and a direct constructor of `HorizontalCFData`.
+3. As corollaries, the same linear-independence criterion yields block selectors,
+   a `HasBiCF` witness, and a direct `HorizontalCFData`.
 
-So the issue is now reduced to a more precise endpoint than the earlier abstract
-selector package: it is enough to prove
+So the issue is now reduced to a more precise criterion than the earlier abstract
+selector data: it is enough to prove
 
 > `∃ L, LinearIndependent ℂ (MPSTensor.wordEntryFamily A L)`
 
@@ -42,7 +42,7 @@ from the canonical-form/BNT hypotheses of CPGSV17 Proposition IV.3.
 
 ## Why this still does not close #587
 
-The remaining gap is **not** a generic linear-algebra packaging issue anymore.
+The remaining gap is **not** a generic linear-algebra reduction issue anymore.
 It is the actual block-separation theorem from CPGSV17 / David2006.
 
 The current `HorizontalCFData` fields still do **not** imply `biCF` directly; the
@@ -84,15 +84,15 @@ Paper statement:
   Proposition `propblockinj`: after blocking at most `3 D^5` spins, any tensor in
   CF is in biCF.
 
-Current repo-side missing endpoint:
+Current repo-side missing criterion:
 
 - no theorem in `TNLean/MPS/BNT/` or `TNLean/MPS/CanonicalForm/` currently produces
   finite-length linear independence of the **block-entry** word family, or the
-  equivalent `WordTupleSpanTop`/selector package, from BNT minimality.
+  equivalent `WordTupleSpanTop`/selector data, from BNT minimality.
 
-## Honest status
+## Status
 
-This pass is genuine forward progress, not a vacuous alias: it proves that one
-concrete finite-dimensional endpoint (`wordEntryFamily` linear independence) is
+This pass is substantive forward progress, not a vacuous alias: it proves that one
+concrete finite-dimensional criterion (`wordEntryFamily` linear independence) is
 already sufficient to obtain the full abstract `biCF` witness. But the pass does
-**not** yet derive that endpoint from the paper's hypotheses, so issue #587 stays open.
+**not** yet derive that criterion from the paper's hypotheses, so issue #587 stays open.

--- a/audits/2026-04-23_issue587_propblockinj_v2.md
+++ b/audits/2026-04-23_issue587_propblockinj_v2.md
@@ -1,0 +1,98 @@
+# Issue #587 — Prop IV.3 / biCF derivation v2 audit (2026-04-23)
+
+## Scope of this pass
+
+This pass does **not** delete the `biCF` field from `MPOTensor.HorizontalCFData`.
+Instead it adds a genuine finite-dimensional reduction step in
+`TNLean/MPS/MPDO/BiCFDerivation.lean` and sharpens the remaining blocker.
+
+## What landed in Lean
+
+New declarations in `TNLean/MPS/MPDO/BiCFDerivation.lean`:
+
+- `MPSTensor.BlockEntryIndex`
+- `MPSTensor.blockEntryValue`
+- `MPSTensor.wordEntryFamily`
+- `MPSTensor.hasBlockSelectorWords_of_wordTupleSpanTop`
+- `MPSTensor.wordTupleSpanTop_of_wordEntryFamily_linearIndependent`
+- `MPSTensor.hasBlockSelectorWords_of_wordEntryFamily_linearIndependent`
+- `MPSTensor.hasBiCF_of_wordEntryFamily_linearIndependent`
+- `MPOTensor.horizontalCFData_of_wordEntryFamily_linearIndependent`
+
+Mathematical content:
+
+1. The old abstract route
+   $$\texttt{WordTupleSpanTop} \Rightarrow \texttt{HasBiCF}$$
+   is now complemented by the new concrete route
+   $$\texttt{LinearIndependent}\bigl(\texttt{wordEntryFamily } A\,L\bigr)
+     \Rightarrow \texttt{WordTupleSpanTop } A\,L.$$
+2. Since `wordEntryFamily A L` indexes **every block matrix entry** across the whole
+   family, its linear independence exactly gives a dual coefficient family on the
+   finite word space. Those dual coefficients reconstruct arbitrary tuples of block
+   matrices, hence force `WordTupleSpanTop`.
+3. As corollaries, the same linear-independence endpoint yields block selectors,
+   a `HasBiCF` witness, and a direct constructor of `HorizontalCFData`.
+
+So the issue is now reduced to a more precise endpoint than the earlier abstract
+selector package: it is enough to prove
+
+> `∃ L, LinearIndependent ℂ (MPSTensor.wordEntryFamily A L)`
+
+from the canonical-form/BNT hypotheses of CPGSV17 Proposition IV.3.
+
+## Why this still does not close #587
+
+The remaining gap is **not** a generic linear-algebra packaging issue anymore.
+It is the actual block-separation theorem from CPGSV17 / David2006.
+
+The current `HorizontalCFData` fields still do **not** imply `biCF` directly; the
+counterexample already documented in `BiCFDerivation.lean` remains valid.
+What is missing is a theorem that produces finite-length separation between the
+full families of inserted/block-entry word functionals for distinct BNT sectors.
+
+A clean target statement for the next PR is:
+
+```lean
+∃ L : ℕ, LinearIndependent ℂ (MPSTensor.wordEntryFamily A L)
+```
+
+for a block family `A` satisfying the relevant canonical-form/BNT minimality
+hypotheses (pairwise non-gauge-phase-equivalent sectors, normality/injectivity
+after blocking, etc.).
+
+## Best next proof route
+
+The most plausible in-repo route is the Gram-limit strategy already suggested by
+existing infrastructure:
+
+1. Define matrix-inserted trace/word states for each block-entry basis element.
+2. Prove off-diagonal overlap decay between different BNT sectors using the
+   canonical/BNT separation machinery.
+3. Prove that within one sector the Gram matrix tends to a nondegenerate limit
+   coming from the positive-definite fixed point.
+4. Apply
+   `TNLean.Algebra.GramMatrixLI.eventually_linearIndependent_of_gram_tendsto_nondegenerate`
+   to obtain eventual linear independence of the whole block-entry family.
+5. Convert that eventual linear independence at some finite length `L` into
+   `wordTupleSpanTop A L` by the new theorem added in this pass.
+
+## Exact paper / repo blocker reference
+
+Paper statement:
+
+- `Papers/1606.00608/MPDO-22-12-17-2.tex:342-345`
+  Proposition `propblockinj`: after blocking at most `3 D^5` spins, any tensor in
+  CF is in biCF.
+
+Current repo-side missing endpoint:
+
+- no theorem in `TNLean/MPS/BNT/` or `TNLean/MPS/CanonicalForm/` currently produces
+  finite-length linear independence of the **block-entry** word family, or the
+  equivalent `WordTupleSpanTop`/selector package, from BNT minimality.
+
+## Honest status
+
+This pass is genuine forward progress, not a vacuous alias: it proves that one
+concrete finite-dimensional endpoint (`wordEntryFamily` linear independence) is
+already sufficient to obtain the full abstract `biCF` witness. But the pass does
+**not** yet derive that endpoint from the paper's hypotheses, so issue #587 stays open.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -561,6 +561,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPSTensor.WordTupleSpanTop}
     \lean{MPSTensor.BlockEntryIndex}
     \lean{MPSTensor.wordEntryFamily}
+    \lean{MPSTensor.duplicateScalarBlocks_counterexample}
     \lean{MPSTensor.wordTupleSpanTop_of_wordEntryFamily_linearIndependent}
     \lean{MPSTensor.hasBlockSelectorWords_of_wordEntryFamily_linearIndependent}
     \lean{MPSTensor.HasBiCF}
@@ -600,6 +601,10 @@ strong subadditivity for a normalized three-site reduced state.
     the product-algebra spanning statement, hence to block selectors and a
     biCF witness. The corresponding constructor packages this endpoint
     directly into horizontal canonical-form data.
+    The duplicate-scalar counterexample shows that this finite-length witness
+    is genuinely stronger than blockwise injectivity, left-canonicality, and
+    nonzero weights alone: two identical scalar blocks satisfy those hypotheses
+    while no blocking length makes the entrywise family linearly independent.
 
     Proposition~IV.3 gives a concrete sufficient criterion for the spanning
     condition: after a common blocking length each block is block-injective,

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -559,13 +559,19 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{remark}[Finite-length span and selector criteria for the abstract biCF hypothesis]%
     \label{rem:word_tuple_span_top}
     \lean{MPSTensor.WordTupleSpanTop}
+    \lean{MPSTensor.BlockEntryIndex}
+    \lean{MPSTensor.wordEntryFamily}
+    \lean{MPSTensor.wordTupleSpanTop_of_wordEntryFamily_linearIndependent}
+    \lean{MPSTensor.hasBlockSelectorWords_of_wordEntryFamily_linearIndependent}
     \lean{MPSTensor.HasBiCF}
     \lean{MPSTensor.hasBiCF_of_wordTupleSpanTop}
+    \lean{MPSTensor.hasBiCF_of_wordEntryFamily_linearIndependent}
     \lean{MPSTensor.HasBlockSelectorWords}
     \lean{MPSTensor.PropBlockInjective}
     \lean{MPSTensor.wordTupleSpanTop_of_propBlockInjective}
     \lean{MPSTensor.hasBiCF_of_propBlockInjective}
     \lean{MPOTensor.horizontalCFData_of_wordTupleSpanTop}
+    \lean{MPOTensor.horizontalCFData_of_wordEntryFamily_linearIndependent}
     \lean{MPOTensor.horizontalCFData_of_propBlockInjective}
     \leanok
     Let $(A_k)$ be a family of block tensors, and fix a length $L$.
@@ -588,6 +594,12 @@ strong subadditivity for a normalized three-site reduced state.
     by their word evaluations. Combined with injectivity, left-canonicality, and
     nonzero block weights, this finite-length separation yields the horizontal
     canonical-form data of the block-diagonal tensor.
+
+    The entrywise scalar family formalized in Lean repackages the same
+    finite-length data. Linear independence of that scalar family upgrades to
+    the product-algebra spanning statement, hence to block selectors and a
+    biCF witness. The corresponding constructor packages this endpoint
+    directly into horizontal canonical-form data.
 
     Proposition~IV.3 gives a concrete sufficient criterion for the spanning
     condition: after a common blocking length each block is block-injective,

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -598,13 +598,13 @@ strong subadditivity for a normalized three-site reduced state.
     nonzero block weights, this finite-length separation yields the horizontal
     canonical-form data of the block-diagonal tensor.
 
-    The entrywise scalar family formalized in Lean repackages the same
-    finite-length data. Linear independence of that scalar family upgrades to
-    the product-algebra spanning statement, hence to block selectors and a
-    biCF witness. The corresponding constructor packages this endpoint
-    directly into horizontal canonical-form data.
+    The entrywise scalar family of block-matrix coefficients encodes the same
+    finite-length data. Linear independence of that scalar family implies the
+    product-algebra spanning statement, hence block selectors and a biCF
+    witness. The same criterion therefore gives horizontal canonical-form data
+    directly.
     The duplicate-scalar counterexample shows that this finite-length witness
-    is genuinely stronger than blockwise injectivity, left-canonicality, and
+    is strictly stronger than blockwise injectivity, left-canonicality, and
     nonzero weights alone: two identical scalar blocks satisfy those hypotheses,
     but the biCF separation condition fails and no blocking length makes the
     entrywise family linearly independent.
@@ -619,7 +619,7 @@ strong subadditivity for a normalized three-site reduced state.
     canonical-form data.
 \end{remark}
 
-\begin{theorem}[Abstract Proposition~IV.3 package]
+\begin{theorem}[Abstract Proposition~IV.3 selector criterion]
     \label{thm:propblockinj_abstract}
     \lean{MPSTensor.hasBiCF_of_propBlockInjective}
     \leanok
@@ -631,7 +631,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{proof}
     \leanok
     \uses{rem:word_tuple_span_top}
-    This is the direct implication from the abstract selector package to the
+    This is the direct implication from the abstract selector data to the
     finite-length trace-separation statement. What remains open in the full
     Proposition~IV.3 is the derivation of the selector hypothesis from separated
     canonical-form / BNT data.
@@ -656,7 +656,7 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{def:tensor_from_blocks, def:injective, thm:propblockinj_abstract}
     This is Lemma~L from \cite[Appendix~A]{Cirac2017MPDO_AnnPhys}, using the
-    abstract Proposition~IV.3 package from Theorem~\ref{thm:propblockinj_abstract}.
+    abstract Proposition~IV.3 selector criterion from Theorem~\ref{thm:propblockinj_abstract}.
     Expanding the hypothesis over a word of length~$L+1$ beginning with the
     fixed site and folding each block contribution into a trace pairing
     against the corresponding first-site insertion tensor yields, upon taking the
@@ -690,8 +690,8 @@ strong subadditivity for a normalized three-site reduced state.
 
 \section{Fusion isometries}
 
-Following \cite[\S4.5]{Cirac2017MPDO_AnnPhys}, the current Lean development
-formalizes the transfer-map content of the fusion-isometry picture.
+Following \cite[\S4.5]{Cirac2017MPDO_AnnPhys}, the current formal development
+describes the transfer-map content of the fusion-isometry picture.
 For each blocked size $n \ge 1$, the doubled-index blocked tensor of an MPO
 has a blocked transfer map $E_n$ acting on bond-space matrices, and the
 support algebra is modeled by a subspace through which $E_n$ factors as a
@@ -792,7 +792,7 @@ recovery theorem for the provisional MPO predicate.
     An MPO tensor $M$ satisfies the \emph{algebra-structure formulation} used
     here when there exist algebra-structure data whose support algebra at every
     positive blocking size coincides with the fixed-point algebra of the adjoint
-    blocked transfer map. This is a genuine algebraic condition, but it is still
+    blocked transfer map. This is a nontrivial algebraic condition, but it is still
     weaker than the full coefficient formulation of
     \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}, since the coefficient
     family $c_{\alpha,\beta,\gamma}^{(L)}$ is not yet extracted.
@@ -831,9 +831,9 @@ Combine Theorem~\ref{thm:mpdo_rfp_of_fusion} with
 Theorem~\ref{thm:mpdo_rfp_via_algebra_from_rfp}.
 \end{proof}
 
-The current Lean layer still does not recover the paper's special diagonal
+The current formal layer still does not recover the paper's special diagonal
 matrices $\chi_{\alpha,\beta,\gamma}$ from Theorem~IV.13(ii). What it does
-provide is the first explicit coefficient package attached to the algebra tower:
+provide is the first explicit coefficient data attached to the algebra tower:
 a chosen basis of each support algebra, coordinate maps into a finite scalar
 family, and the corresponding multiplication / inclusion coefficient arrays.
 
@@ -1029,7 +1029,7 @@ is the sum of its entries.
     \]
     for every $L \ge 0$ and every triple $(\alpha, \beta, \gamma)$, where
     $r_{\alpha,\beta,\gamma}$ is the size of $\chi_{\alpha,\beta,\gamma}$. This
-    is the Lean-level form of the target identity of
+    is the formal analogue of the target identity of
     \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}; the existential
     version---``there exists $\chi$ for which $(c,\chi)$ has trace-power
     form''---is obtained by quantifying over $\chi$.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -563,6 +563,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPSTensor.wordEntryFamily}
     \lean{MPSTensor.duplicateScalarBlocks_counterexample}
     \lean{MPSTensor.wordTupleSpanTop_of_wordEntryFamily_linearIndependent}
+    \lean{MPSTensor.hasBlockSelectorWords_of_wordTupleSpanTop}
     \lean{MPSTensor.hasBlockSelectorWords_of_wordEntryFamily_linearIndependent}
     \lean{MPSTensor.HasBiCF}
     \lean{MPSTensor.hasBiCF_of_wordTupleSpanTop}
@@ -571,6 +572,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPSTensor.PropBlockInjective}
     \lean{MPSTensor.wordTupleSpanTop_of_propBlockInjective}
     \lean{MPSTensor.hasBiCF_of_propBlockInjective}
+    \lean{MPSTensor.duplicateScalarBlocks_not_hasBiCF}
     \lean{MPOTensor.horizontalCFData_of_wordTupleSpanTop}
     \lean{MPOTensor.horizontalCFData_of_wordEntryFamily_linearIndependent}
     \lean{MPOTensor.horizontalCFData_of_propBlockInjective}
@@ -603,8 +605,9 @@ strong subadditivity for a normalized three-site reduced state.
     directly into horizontal canonical-form data.
     The duplicate-scalar counterexample shows that this finite-length witness
     is genuinely stronger than blockwise injectivity, left-canonicality, and
-    nonzero weights alone: two identical scalar blocks satisfy those hypotheses
-    while no blocking length makes the entrywise family linearly independent.
+    nonzero weights alone: two identical scalar blocks satisfy those hypotheses,
+    but the biCF separation condition fails and no blocking length makes the
+    entrywise family linearly independent.
 
     Proposition~IV.3 gives a concrete sufficient criterion for the spanning
     condition: after a common blocking length each block is block-injective,


### PR DESCRIPTION
## Summary

This PR makes **genuine forward progress** on #587 without claiming the full CPGSV17 Proposition IV.3 theorem.

### What lands

In `TNLean/MPS/MPDO/BiCFDerivation.lean` it adds a new concrete endpoint for the biCF derivation:

- `MPSTensor.BlockEntryIndex`
- `MPSTensor.blockEntryValue`
- `MPSTensor.wordEntryFamily`
- `MPSTensor.hasBlockSelectorWords_of_wordTupleSpanTop`
- `MPSTensor.wordTupleSpanTop_of_wordEntryFamily_linearIndependent`
- `MPSTensor.hasBlockSelectorWords_of_wordEntryFamily_linearIndependent`
- `MPSTensor.hasBiCF_of_wordEntryFamily_linearIndependent`
- `MPOTensor.horizontalCFData_of_wordEntryFamily_linearIndependent`

Mathematically, the key new theorem is

$$
\mathrm{LinearIndependent}(\texttt{wordEntryFamily } A\,L)
\;\Longrightarrow\;
\texttt{WordTupleSpanTop } A\,L,
$$

so finite-length linear independence of the scalar block-entry word family already implies:

- the full product-algebra span condition,
- block selectors,
- a `HasBiCF` witness,
- and a direct `HorizontalCFData` constructor.

This sharpens the old abstract selector-package route from merged #682 into a more concrete finite-dimensional target.

### Docs / blueprint / audit

- updates the `HorizontalCFData.biCF` docstring in `VerticalCF.lean` to reflect the current honest constructor surface;
- extends the MPDO blueprint remark in `blueprint/src/chapter/ch02b_mpdo.tex` with the new word-entry endpoint;
- adds the audit note `audits/2026-04-23_issue587_propblockinj_v2.md`.

## Honest status

This PR **does not** delete the `biCF` field from `HorizontalCFData`, and it does **not** prove full `propblockinj` yet.

The remaining blocker is now sharper:

> from the canonical-form / BNT hypotheses, prove
> `∃ L, LinearIndependent ℂ (MPSTensor.wordEntryFamily A L)`
> (equivalently one of the finite-length selector / tuple-span criteria).

That is the actual finite-length block-separation content still missing from Prop. IV.3 / David2006.

## Verification

Run in `.worktrees/issue-587-biCF-derivation`:

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake build TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.MPDO.VerticalCF`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/MPDO/BiCFDerivation.lean TNLean/MPS/MPDO/VerticalCF.lean audits/2026-04-23_issue587_propblockinj_v2.md`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

All passed locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial new Lean proof machinery around finite-length spanning/linear-independence criteria and a new concrete counterexample; risk is mainly proof fragility and downstream lemma breakage rather than behavioral changes.
> 
> **Overview**
> Introduces a new *finite-dimensional endpoint* for obtaining `HorizontalCFData.biCF`: defines `BlockEntryIndex`/`wordEntryFamily` (scalar functionals reading off block-matrix entries) and proves `LinearIndependent (wordEntryFamily A L) → WordTupleSpanTop A L → HasBiCF A`, with corollaries yielding block selectors and a direct `horizontalCFData_of_wordEntryFamily_linearIndependent` constructor.
> 
> Extends `BiCFDerivation.lean` with a concrete duplicate-block counterexample (`duplicateScalarBlocks_*`) showing injectivity + left-canonicality + nonzero/distinct weights still do not imply `HasBiCF` or any `wordEntryFamily` linear-independence witness, and updates `VerticalCF.lean`/blueprint/audit docs to reflect the new derivation routes and the remaining Prop. IV.3 gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf97dabce334b8c278d50f596e64c6efabafe2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->