### PR TITLE
feat(MPS/MPDO): algebra-structure blocked-coefficient follow-up (#612)

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Algebra.Algebra.Bilinear
+import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import TNLean.Algebra.MatrixFrobenius
 import TNLean.Channel.FixedPoint.Algebra
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
@@ -18,9 +20,10 @@ arXiv:1606.00608, §4.5.
 The paper's full statement uses coefficient systems
 $c_{\alpha,\beta,\gamma}^{(L)} =
   \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$
-and BNT data. That coefficient layer is not yet formalized here. What we do
+and BNT data. That full coefficient layer is not yet formalized here. What we do
 formalize is the stationary C$^*$-algebra package naturally attached to an MPO
-whose blocked transfer maps are idempotent.
+whose blocked transfer maps are idempotent, together with a first explicit
+coordinate layer obtained by choosing bases of the blocked support algebras.
 
 More precisely, `AlgebraStructureData` now records a genuine tower of support
 `StarSubalgebra`s together with multiplication and inclusion maps realized by the
@@ -85,6 +88,10 @@ namespace MPOTensor
 variable {d D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+local instance instFiniteDimensionalStarSubalgebra (S : StarSubalgebra ℂ Mat) :
+    FiniteDimensional ℂ S :=
+  FiniteDimensional.of_subalgebra_toSubmodule (S := S.toSubalgebra) inferInstance
 
 /-- Algebra-structure data for the stationary support-algebra picture of an MPO.
 
@@ -245,6 +252,159 @@ theorem isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed
     IsRFP_MPDO_via_algebra M := by
   exact isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
     (M := M) (isRFP_of_isRFP_MPDO_via_fusion hFusion) h_tp hρ hρ_fix
+
+namespace AlgebraStructureData
+
+/-- A chosen finite index set for coordinates on the blocked support algebra `A n`. -/
+abbrev BlockedIndex (data : AlgebraStructureData d D) (n : ℕ) :=
+  Module.Basis.ofVectorSpaceIndex ℂ (data.A n)
+
+/-- The coordinate space attached to the blocked support algebra `A n`. -/
+abbrev BlockedCoefficients (data : AlgebraStructureData d D) (n : ℕ) :=
+  BlockedIndex data n → ℂ
+
+/-- A chosen basis for the blocked support algebra `A n`. -/
+noncomputable def blockedBasis (data : AlgebraStructureData d D) (n : ℕ) :
+    Module.Basis (BlockedIndex data n) ℂ (data.A n) :=
+  Module.Basis.ofVectorSpace ℂ (data.A n)
+
+/-- Coordinates of a blocked algebra element in the chosen basis of `A n`. -/
+noncomputable def toBlockedCoefficients (data : AlgebraStructureData d D) (n : ℕ) :
+    data.A n ≃ₗ[ℂ] BlockedCoefficients data n :=
+  (data.blockedBasis n).equivFun
+
+/-- Reconstruct a blocked algebra element from its coefficient family. -/
+noncomputable def reconstructFromBlockedCoefficients
+    (data : AlgebraStructureData d D) (n : ℕ) :
+    BlockedCoefficients data n →ₗ[ℂ] data.A n :=
+  (data.toBlockedCoefficients n).symm.toLinearMap
+
+@[simp] theorem toBlockedCoefficients_reconstructFromBlockedCoefficients
+    (data : AlgebraStructureData d D) (n : ℕ) (a : BlockedCoefficients data n) :
+    data.toBlockedCoefficients n (data.reconstructFromBlockedCoefficients n a) = a := by
+  exact (data.toBlockedCoefficients n).apply_symm_apply a
+
+@[simp] theorem reconstructFromBlockedCoefficients_toBlockedCoefficients
+    (data : AlgebraStructureData d D) (n : ℕ) (x : data.A n) :
+    data.reconstructFromBlockedCoefficients n (data.toBlockedCoefficients n x) = x := by
+  exact (data.toBlockedCoefficients n).symm_apply_apply x
+
+/-- The chosen basis reconstructs every blocked coefficient family by a finite sum. -/
+theorem reconstructFromBlockedCoefficients_apply
+    (data : AlgebraStructureData d D) (n : ℕ) (a : BlockedCoefficients data n) :
+    data.reconstructFromBlockedCoefficients n a =
+      ∑ i, a i • data.blockedBasis n i := by
+  rw [reconstructFromBlockedCoefficients, toBlockedCoefficients]
+  exact (data.blockedBasis n).equivFun_symm_apply a
+
+/-- Ambient-matrix version of `reconstructFromBlockedCoefficients_apply`. -/
+theorem coe_reconstructFromBlockedCoefficients_apply
+    (data : AlgebraStructureData d D) (n : ℕ) (a : BlockedCoefficients data n) :
+    ((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat) =
+      ∑ i, a i • ((data.blockedBasis n i : data.A n) : Mat) := by
+  rw [reconstructFromBlockedCoefficients_apply (data := data) (n := n) (a := a)]
+  simp
+
+/-- Coordinates of an ambient matrix already known to lie in `A n`. -/
+noncomputable def toBlockedCoefficientsOfMem
+    (data : AlgebraStructureData d D) (n : ℕ) (X : Mat) (hX : X ∈ data.A n) :
+    BlockedCoefficients data n :=
+  data.toBlockedCoefficients n ⟨X, hX⟩
+
+/-- Reconstructing the coefficients of a matrix in `A n` recovers that matrix. -/
+@[simp] theorem reconstructFromBlockedCoefficients_of_mem
+    (data : AlgebraStructureData d D) (n : ℕ) (X : Mat) (hX : X ∈ data.A n) :
+    ((data.reconstructFromBlockedCoefficients n
+      (data.toBlockedCoefficientsOfMem n X hX) : data.A n) : Mat) = X := by
+  exact congrArg (fun x : data.A n => (x : Mat))
+    (reconstructFromBlockedCoefficients_toBlockedCoefficients
+      (data := data) (n := n) (x := ⟨X, hX⟩))
+
+/-- Coordinates of an adjoint blocked fixed point, extracted through a compatible
+algebra tower. -/
+noncomputable def toBlockedCoefficientsOfFixedPoint
+    (data : AlgebraStructureData d D) {M : MPOTensor d D}
+    (hCompat : data.CompatibleWith M) {n : ℕ} (hn : 0 < n) (X : Mat)
+    (hX : (blockedTransferMap M n).adjoint X = X) :
+    BlockedCoefficients data n :=
+  data.toBlockedCoefficientsOfMem n X ((hCompat n hn X).2 hX)
+
+/-- Reconstructing the extracted coefficients of an adjoint blocked fixed point
+recovers the original matrix. -/
+@[simp] theorem reconstructFromBlockedCoefficients_of_fixedPoint
+    (data : AlgebraStructureData d D) {M : MPOTensor d D}
+    (hCompat : data.CompatibleWith M) {n : ℕ} (hn : 0 < n) (X : Mat)
+    (hX : (blockedTransferMap M n).adjoint X = X) :
+    ((data.reconstructFromBlockedCoefficients n
+      (data.toBlockedCoefficientsOfFixedPoint hCompat hn X hX) : data.A n) : Mat) = X := by
+  rw [toBlockedCoefficientsOfFixedPoint]
+  exact reconstructFromBlockedCoefficients_of_mem
+    (data := data) (n := n) (X := X) ((hCompat n hn X).2 hX)
+
+/-- Any coefficient family reconstructed inside a compatible algebra tower is fixed by the
+adjoint blocked transfer map. -/
+theorem adjoint_blockedTransferMap_reconstructFromBlockedCoefficients_eq
+    (data : AlgebraStructureData d D) {M : MPOTensor d D}
+    (hCompat : data.CompatibleWith M) {n : ℕ} (hn : 0 < n)
+    (a : BlockedCoefficients data n) :
+    (blockedTransferMap M n).adjoint
+        (((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat)) =
+      (((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat)) := by
+  exact (hCompat n hn _).1 (data.reconstructFromBlockedCoefficients n a).property
+
+/-- The coefficient family of the blocked product of two chosen basis elements. -/
+noncomputable def blockedStructureCoefficients
+    (data : AlgebraStructureData d D) (n : ℕ)
+    (i j : BlockedIndex data n) :
+    BlockedCoefficients data (2 * n) :=
+  data.toBlockedCoefficients (2 * n) (data.m n (data.blockedBasis n i) (data.blockedBasis n j))
+
+/-- The multiplication coefficients reconstruct the product of two basis elements
+in `A (2 * n)`. -/
+@[simp] theorem reconstructFromBlockedStructureCoefficients
+    (data : AlgebraStructureData d D) (n : ℕ)
+    (i j : BlockedIndex data n) :
+    data.reconstructFromBlockedCoefficients (2 * n)
+        (data.blockedStructureCoefficients n i j) =
+      data.m n (data.blockedBasis n i) (data.blockedBasis n j) := by
+  simp [blockedStructureCoefficients]
+
+/-- Ambient-matrix form of the blocked multiplication reconstruction formula. -/
+theorem coe_mul_eq_sum_blockedStructureCoefficients
+    (data : AlgebraStructureData d D) (n : ℕ)
+    (i j : BlockedIndex data n) :
+    ((data.m n (data.blockedBasis n i) (data.blockedBasis n j) : data.A (2 * n)) : Mat) =
+      ∑ k, data.blockedStructureCoefficients n i j k •
+        ((data.blockedBasis (2 * n) k : data.A (2 * n)) : Mat) := by
+  simpa [reconstructFromBlockedStructureCoefficients] using
+    coe_reconstructFromBlockedCoefficients_apply
+      (data := data) (n := 2 * n) (a := data.blockedStructureCoefficients n i j)
+
+/-- The coefficient family of the inclusion image of a chosen basis element. -/
+noncomputable def blockedInclusionCoefficients
+    (data : AlgebraStructureData d D) (n : ℕ) (i : BlockedIndex data n) :
+    BlockedCoefficients data (n + 1) :=
+  data.toBlockedCoefficients (n + 1) (data.iota n (data.blockedBasis n i))
+
+/-- The inclusion coefficients reconstruct the ambient inclusion of a basis element. -/
+@[simp] theorem reconstructFromBlockedInclusionCoefficients
+    (data : AlgebraStructureData d D) (n : ℕ) (i : BlockedIndex data n) :
+    data.reconstructFromBlockedCoefficients (n + 1)
+        (data.blockedInclusionCoefficients n i) =
+      data.iota n (data.blockedBasis n i) := by
+  simp [blockedInclusionCoefficients]
+
+/-- Ambient-matrix form of the blocked inclusion reconstruction formula. -/
+theorem coe_iota_eq_sum_blockedInclusionCoefficients
+    (data : AlgebraStructureData d D) (n : ℕ) (i : BlockedIndex data n) :
+    ((data.iota n (data.blockedBasis n i) : data.A (n + 1)) : Mat) =
+      ∑ k, data.blockedInclusionCoefficients n i k •
+        ((data.blockedBasis (n + 1) k : data.A (n + 1)) : Mat) := by
+  simpa [reconstructFromBlockedInclusionCoefficients] using
+    coe_reconstructFromBlockedCoefficients_apply
+      (data := data) (n := n + 1) (a := data.blockedInclusionCoefficients n i)
+
+end AlgebraStructureData
 
 end MPOTensor
 

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -130,15 +130,6 @@ def CompatibleWith (data : AlgebraStructureData d D) (M : MPOTensor d D) : Prop 
   ∀ n : ℕ, 0 < n → ∀ X : Matrix (Fin D) (Fin D) ℂ,
     X ∈ data.A n ↔ (blockedTransferMap M n).adjoint X = X
 
-/-- A constant algebra tower is compatible with `M` as soon as all positive
-blocked adjoint transfer maps have the same fixed-point algebra. -/
-theorem compatible_of_eq_adjointFixedPoints
-    (data : AlgebraStructureData d D) (M : MPOTensor d D)
-    (hCompat : ∀ n : ℕ, 0 < n → ∀ X : Matrix (Fin D) (Fin D) ℂ,
-      X ∈ data.A n ↔ (blockedTransferMap M n).adjoint X = X) :
-    data.CompatibleWith M :=
-  hCompat
-
 end AlgebraStructureData
 
 /-- The fixed-point support algebra attached to a trace-preserving MPO tensor and
@@ -225,13 +216,6 @@ An MPO tensor satisfies `IsRFP_MPDO_via_algebra` when it admits algebra-structur
 support data compatible with its blocked adjoint transfer maps. -/
 def IsRFP_MPDO_via_algebra (M : MPOTensor d D) : Prop :=
   ∃ data : AlgebraStructureData d D, data.CompatibleWith M
-
-/-- Backwards-compatible alias for the previous scaffold name.
-
-The old definition was vacuous. The new alias points to the non-vacuous algebra
-predicate above. -/
-abbrev IsRFP_MPDO_via_algebra_scaffold (M : MPOTensor d D) : Prop :=
-  IsRFP_MPDO_via_algebra M
 
 /-- A trace-preserving MPO with a positive-definite fixed point admits a
 stationary algebra tower as soon as it is an RFP. -/

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -1,142 +1,251 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
+import Mathlib.Algebra.Algebra.Bilinear
+import TNLean.Algebra.MatrixFrobenius
+import TNLean.Channel.FixedPoint.Algebra
+import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.MPS.MPDO.FusionIsometries
 
 /-!
-# Algebra-structure formulation of the MPDO renormalization fixed point
+# Algebra-structure witnesses for MPDO renormalization fixed points
 
-This file records the **algebra-structure** side of the general MPDO RFP
-equivalence of arXiv:1606.00608 §4.5, Theorem IV.13
-(Cirac–Pérez-García–Schuch–Verstraete).
+This file upgrades the old scaffold for the algebra-structure side of
+arXiv:1606.00608, §4.5.
 
-Theorem IV.13 of the paper characterises renormalization-fixed-point MPDOs by
-the existence of a tower of support algebras `𝒜_n` with structure coefficients
-`c_{αβγ}^{(L)}` and compatible multiplication/blocking maps. The support
-algebras are indexed C*-subalgebras of matrix algebras; the multiplication is
-the blocking map `𝒜_n × 𝒜_n → 𝒜_{2n}` arising from physically concatenating
-two blocks; and the inclusions `𝒜_n ↪ 𝒜_{n+1}` arise from appending a single
-site at the boundary.
+The paper's full statement uses coefficient systems
+$c_{\alpha,\beta,\gamma}^{(L)} =
+  \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$
+and BNT data. That coefficient layer is not yet formalized here. What we do
+formalize is the stationary C$^*$-algebra package naturally attached to an MPO
+whose blocked transfer maps are idempotent.
 
-The development of the C*-algebraic API required for the full statement is
-deferred. This file records the **shape** of the data as a plain Lean
-structure, uses `Prop`-valued provisional conditions, and names the
-relation to a given MPO tensor through `AlgebraStructureData.CompatibleWith`.
-Each provisional choice is flagged with a `TODO (#612)` comment citing
-the corresponding paper reference.
+More precisely, `AlgebraStructureData` now records a genuine tower of support
+`StarSubalgebra`s together with multiplication and inclusion maps realized by the
+ambient matrix product and the ambient inclusion. Compatibility with an MPO
+tensor `M` means that, for every positive blocked size `n`, the carrier `A n`
+coincides with the fixed-point algebra of the adjoint blocked transfer map
+`(blockedTransferMap M n).adjoint`.
 
-## Main declarations
+Under a trace-preserving normalization and a positive-definite fixed point of the
+MPO transfer map, an RFP tensor yields a **stationary** algebra tower. Combined
+with the transfer-map fusion criterion from `FusionIsometries.lean`, this gives a
+one-way bridge
 
-* `AlgebraStructureData`: the tower of support algebras with blocking and
-  inclusion maps.
-* `AlgebraStructureData.CompatibleWith`: relation linking algebra-structure
-  data to an MPO tensor, currently the trivial proposition `True`.
-* `IsRFP_MPDO_via_algebra_scaffold`: the provisional RFP predicate built from
-  the existence of algebra-structure data related to the tensor by
-  `CompatibleWith`. The `_scaffold` suffix marks that the relation
-  `CompatibleWith` is currently `True` and the predicate consequently vacuous.
+* `isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed`
+* `isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed`
+
+from the current fusion formulation to the algebra formulation, under the same
+side hypotheses.
+
+## Remaining gap to the paper
+
+The present `CompatibleWith` relation identifies the support algebras with the
+adjoint fixed-point algebras of the blocked transfer maps. It does **not** yet
+extract the coefficient family `c_{\alpha,\beta,\gamma}^{(L)}` of
+Theorem IV.13(ii), nor prove the converse algebra-to-fusion implication. Those
+steps still require the BNT / coefficient-comparison layer from Appendix C.3--C.4.
 
 ## References
 
-* [CPGSV17] arXiv:1606.00608, §4.5 and Appendix C.3
-  (Cirac–Pérez-García–Schuch–Verstraete, Ann. Phys. 378, 100–149), in
-  particular Theorem IV.13 and its proof in C.3.
+* [CPGSV17] arXiv:1606.00608, §4.5 and Appendix C.3--C.4
+* [Wolf12] Wolf, *Quantum Channels & Operations*, Theorem 6.12
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+
+noncomputable section
+
+local instance instMatrixNormedAddCommGroup (D : ℕ) :
+    NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+  Matrix.toMatrixNormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1
+    (Matrix.frobenius_posDef_one (D := D))
+
+local instance instMatrixInnerProductSpace (D : ℕ) :
+    InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+  Matrix.toMatrixInnerProductSpace (n := Fin D) (𝕜 := ℂ) 1
+    (Matrix.frobenius_posDef_one (D := D)).posSemidef
+
+namespace MPSTensor
+
+private theorem transferMap_adjoint_apply_eq_adjointMap {d D : ℕ}
+    (A : MPSTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
+    (transferMap A).adjoint X = Kraus.adjointMap A X := by
+  have h := congrArg (fun F => F X)
+    (transferMap_conjTranspose_eq_adjoint (A := A)).symm
+  simpa [transferMap_apply, Kraus.adjointMap, Matrix.conjTranspose_conjTranspose,
+    Matrix.mul_assoc] using h
+
+end MPSTensor
 
 namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- The *support algebra at size `n`*.
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-TODO (#612): replace with a `Subalgebra ℂ (Matrix (Fin D^n) (Fin D^n) ℂ)`
-cut out by the span of operator matrix elements at size `n`, matching `𝒜_n`
-from Theorem IV.13. The current definition uses `Matrix (Fin D) (Fin D) ℂ` as
-a stand-in for every `n`. -/
-abbrev SupportAlgebra (D : ℕ) (_n : ℕ) : Type :=
-  Matrix (Fin D) (Fin D) ℂ
+/-- Algebra-structure data for the stationary support-algebra picture of an MPO.
 
-/-- **Algebra-structure data** for a putative MPDO renormalization fixed
-point.
-
-In the paper (Theorem IV.13 of arXiv:1606.00608), such data consists of a
-family of support algebras `𝒜_n`, blocking maps
-`m_n : 𝒜_n × 𝒜_n → 𝒜_{2n}` realising the horizontal concatenation of
-blocks, and unital inclusion maps `ι_n : 𝒜_n → 𝒜_{n+1}` that add a single
-site. The coherence conditions (associativity of blocking, interplay with
-inclusions, existence of the positive structure coefficients
-`c_{αβγ}^{(L)} = tr(χ_{αβγ}^L)`, and the idempotence relation
-`m_γ = Σ c_{αβγ}^{(1)} m_α m_β`) are recorded as a single `Prop`-valued
-hypothesis, weaker than the conjunction of the conditions of the paper.
-
-In the present formulation the support algebra at every size is represented
-by `SupportAlgebra D n = Matrix (Fin D) (Fin D) ℂ`; the multiplication and
-inclusion fields are typed against this stand-in.
-
-TODO (#612): tighten fields to `Subalgebra`/`AlgHom` types and install
-the coherence hypotheses of Theorem IV.13. -/
+At blocked size `n`, the support object is a `StarSubalgebra` of bond-space
+matrices. The map `m n` is the blocking multiplication, landing in the
+size-`2n` support algebra, while `iota n` is the inclusion into the size-`n+1`
+support algebra. The fields `m_apply` and `iota_apply` require that these maps
+are realized by the ambient matrix product and ambient inclusion. -/
 structure AlgebraStructureData (d D : ℕ) where
-  /-- Multiplication / blocking map at each size `n`.
-
-  TODO (#612): upgrade to a linear map `A n ⊗ A n →ₗ[ℂ] A (2 * n)` once
-  the support algebras are genuine subalgebras. -/
-  m : ∀ n : ℕ,
-    SupportAlgebra D n →ₗ[ℂ] SupportAlgebra D n →ₗ[ℂ] SupportAlgebra D (2 * n)
-  /-- Unital inclusion at each size `n`.
-
-  TODO (#612): upgrade to an `AlgHom` once the support algebras are
-  genuine subalgebras. -/
-  iota : ∀ n : ℕ, SupportAlgebra D n →ₗ[ℂ] SupportAlgebra D (n + 1)
-  /-- Coherence relation between blocking at consecutive sizes.
-
-  TODO (#612): replace by the associativity/compatibility condition of
-  §4.5, in particular the condition that `m_n` and `iota_n` satisfy the
-  diagram implicit in equation (29) of the paper. -/
-  coherence : Prop
-  /-- The coherence relation holds. -/
-  coherence_holds : coherence
+  /-- Support algebra at blocked size `n`. -/
+  A : ℕ → StarSubalgebra ℂ (Matrix (Fin D) (Fin D) ℂ)
+  /-- Blocking multiplication at size `n`. -/
+  m : ∀ n : ℕ, A n →ₗ[ℂ] A n →ₗ[ℂ] A (2 * n)
+  /-- Inclusion map adding one physical site. -/
+  iota : ∀ n : ℕ, A n →ₗ[ℂ] A (n + 1)
+  /-- `m n` is realized by ambient matrix multiplication. -/
+  m_apply : ∀ n : ℕ, ∀ x y : A n,
+    ((m n x y : A (2 * n)) : Matrix (Fin D) (Fin D) ℂ) =
+      (x : Matrix (Fin D) (Fin D) ℂ) * y
+  /-- `iota n` is realized by the ambient inclusion. -/
+  iota_apply : ∀ n : ℕ, ∀ x : A n,
+    ((iota n x : A (n + 1)) : Matrix (Fin D) (Fin D) ℂ) =
+      (x : Matrix (Fin D) (Fin D) ℂ)
 
 namespace AlgebraStructureData
 
 variable {d D : ℕ}
 
-/-- Compatibility relation between algebra-structure data and an MPO tensor
-`M`. In the final formulation this asserts that the structure coefficients
-carried by `data` match the BNT decomposition of `M`, following
-Theorem IV.13 (ii) of arXiv:1606.00608. The present definition is the trivial
-proposition `True`, which is satisfied by every pair `(data, M)`.
-TODO (#612): replace by the compatibility condition relating
-`c_{αβγ}^{(L)}` to the BNT decomposition of `M`. -/
-def CompatibleWith (_data : AlgebraStructureData d D) (_M : MPOTensor d D) :
-    Prop :=
-  True
+/-- Compatibility between algebra-structure data and an MPO tensor `M`.
+
+The current compatibility condition says that, for every positive blocked size
+`n`, the support algebra `A n` is exactly the fixed-point algebra of the
+adjoint blocked transfer map. This is a non-vacuous algebra-side condition, but
+it is still weaker than the full coefficient statement of Theorem IV.13(ii). -/
+def CompatibleWith (data : AlgebraStructureData d D) (M : MPOTensor d D) : Prop :=
+  ∀ n : ℕ, 0 < n → ∀ X : Matrix (Fin D) (Fin D) ℂ,
+    X ∈ data.A n ↔ (blockedTransferMap M n).adjoint X = X
+
+/-- A constant algebra tower is compatible with `M` as soon as all positive
+blocked adjoint transfer maps have the same fixed-point algebra. -/
+theorem compatible_of_eq_adjointFixedPoints
+    (data : AlgebraStructureData d D) (M : MPOTensor d D)
+    (hCompat : ∀ n : ℕ, 0 < n → ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      X ∈ data.A n ↔ (blockedTransferMap M n).adjoint X = X) :
+    data.CompatibleWith M :=
+  hCompat
 
 end AlgebraStructureData
 
-/-- **Provisional algebra-structure formulation of the MPDO renormalization
-fixed point.**
+/-- The fixed-point support algebra attached to a trace-preserving MPO tensor and
+one of its positive-definite fixed points.
 
-In the paper, an MPDO `M` is a renormalization fixed point whenever its
-operators `O_L(M_α)` span an algebra with positive structure coefficients
-satisfying the idempotence relation (equations (29)–(30) of §4.5). The
-definition below asserts the existence of algebra-structure data related to
-`M` by the relation `AlgebraStructureData.CompatibleWith`.
+Concretely, this is the fixed-point `StarSubalgebra` of the adjoint transfer map
+`(transferMap M).adjoint`, packaged through Wolf Theorem 6.12 for the doubled
+MPS tensor `M.toMPSTensor`. -/
+noncomputable def faithfulFixedPointSupportAlgebra
+    (M : MPOTensor d D) (h_tp : Kraus.IsTP M.toMPSTensor)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ) :
+    StarSubalgebra ℂ Mat :=
+  Kraus.fixedPoints_starSubalgebra (K := M.toMPSTensor) h_tp hρ
+    (by simpa [transferMap_eq_toMPSTensor] using hρ_fix)
 
-The `_scaffold` suffix marks that `AlgebraStructureData.CompatibleWith` is
-currently `True` and that `AlgebraStructureData d D` is inhabited (e.g. by
-zero multiplication, zero inclusion, and `coherence := True`). The predicate
-is consequently satisfied by every `M`, and must not be used as a hypothesis
-or conclusion of any nontrivial result until the relation is tightened.
+/-- Membership in `faithfulFixedPointSupportAlgebra` is fixed-point membership
+for the adjoint MPO transfer map. -/
+theorem mem_faithfulFixedPointSupportAlgebra_iff
+    (M : MPOTensor d D) (h_tp : Kraus.IsTP M.toMPSTensor)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ)
+    (X : Mat) :
+    X ∈ faithfulFixedPointSupportAlgebra M h_tp hρ hρ_fix ↔
+      (transferMap M).adjoint X = X := by
+  unfold faithfulFixedPointSupportAlgebra
+  rw [Kraus.mem_fixedPoints_starSubalgebra, Kraus.mem_adjointFixedPoints]
+  have hAdj : Kraus.adjointMap M.toMPSTensor X = (transferMap M).adjoint X := by
+    simpa [transferMap_eq_toMPSTensor] using
+      (MPSTensor.transferMap_adjoint_apply_eq_adjointMap (A := M.toMPSTensor) X).symm
+  constructor
+  · intro h
+    rw [hAdj] at h
+    exact h
+  · intro h
+    rw [hAdj]
+    exact h
 
-TODO (#612): replace `AlgebraStructureData.CompatibleWith` with the
-compatibility condition between `M` and the data, following
-Theorem IV.13 (ii): the structure coefficients `c_{αβγ}^{(L)}` of the algebra
-associated to `data` must match the BNT decomposition of `M`. Drop the
-`_scaffold` suffix once the relation is no longer trivial. -/
-def IsRFP_MPDO_via_algebra_scaffold (M : MPOTensor d D) : Prop :=
+namespace AlgebraStructureData
+
+/-- The stationary algebra tower attached to a faithful fixed point of the MPO
+transfer map.
+
+All support algebras are the same `StarSubalgebra`, multiplication is ordinary
+matrix multiplication, and the inclusion maps are identities. -/
+noncomputable def stationaryOfFaithfulFixedPoint
+    (M : MPOTensor d D) (h_tp : Kraus.IsTP M.toMPSTensor)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ) :
+    AlgebraStructureData d D := by
+  let S : StarSubalgebra ℂ Mat := faithfulFixedPointSupportAlgebra M h_tp hρ hρ_fix
+  refine
+    { A := fun _ => S
+      m := fun _ => LinearMap.mul ℂ ↥S
+      iota := fun _ => LinearMap.id
+      m_apply := ?_
+      iota_apply := ?_ }
+  · intro n x y
+    rfl
+  · intro n x
+    rfl
+
+/-- The stationary tower from a faithful fixed point is compatible with any RFP
+MPO tensor, because all positive blocked transfer maps agree with `transferMap M`. -/
+theorem stationaryOfFaithfulFixedPoint_compatible
+    (M : MPOTensor d D) (h_tp : Kraus.IsTP M.toMPSTensor)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ)
+    (hRFP : IsRFP M) :
+    (stationaryOfFaithfulFixedPoint M h_tp hρ hρ_fix).CompatibleWith M := by
+  simp only [AlgebraStructureData.CompatibleWith]
+  intro n hn X
+  change X ∈ faithfulFixedPointSupportAlgebra M h_tp hρ hρ_fix ↔
+    (blockedTransferMap M n).adjoint X = X
+  rw [mem_faithfulFixedPointSupportAlgebra_iff (M := M) h_tp hρ hρ_fix X]
+  have hAdj : LinearMap.adjoint ((MPSTensor.transferMap M.toMPSTensor) ^ n) =
+      LinearMap.adjoint (MPSTensor.transferMap M.toMPSTensor) := by
+    simpa [blockedTransferMap_eq_pow, transferMap_eq_toMPSTensor] using
+      congrArg LinearMap.adjoint
+        (blockedTransferMap_eq_transferMap_of_isRFP (M := M) hRFP hn)
+  simp [blockedTransferMap_eq_pow, transferMap_eq_toMPSTensor, hAdj]
+
+end AlgebraStructureData
+
+/-- The algebra-structure formulation of MPDO RFP used in this file.
+
+An MPO tensor satisfies `IsRFP_MPDO_via_algebra` when it admits algebra-structure
+support data compatible with its blocked adjoint transfer maps. -/
+def IsRFP_MPDO_via_algebra (M : MPOTensor d D) : Prop :=
   ∃ data : AlgebraStructureData d D, data.CompatibleWith M
 
+/-- Backwards-compatible alias for the previous scaffold name.
+
+The old definition was vacuous. The new alias points to the non-vacuous algebra
+predicate above. -/
+abbrev IsRFP_MPDO_via_algebra_scaffold (M : MPOTensor d D) : Prop :=
+  IsRFP_MPDO_via_algebra M
+
+/-- A trace-preserving MPO with a positive-definite fixed point admits a
+stationary algebra tower as soon as it is an RFP. -/
+theorem isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
+    {M : MPOTensor d D} (hRFP : IsRFP M) (h_tp : Kraus.IsTP M.toMPSTensor)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ) :
+    IsRFP_MPDO_via_algebra M := by
+  refine ⟨AlgebraStructureData.stationaryOfFaithfulFixedPoint M h_tp hρ hρ_fix, ?_⟩
+  exact AlgebraStructureData.stationaryOfFaithfulFixedPoint_compatible
+    (M := M) (h_tp := h_tp) hρ hρ_fix hRFP
+
+/-- Under the same side hypotheses, the transfer-map fusion formulation implies
+this algebra formulation. -/
+theorem isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed
+    {M : MPOTensor d D} (hFusion : IsRFP_MPDO_via_fusion M)
+    (h_tp : Kraus.IsTP M.toMPSTensor) {ρ : Mat} (hρ : ρ.PosDef)
+    (hρ_fix : transferMap M ρ = ρ) :
+    IsRFP_MPDO_via_algebra M := by
+  exact isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
+    (M := M) (isRFP_of_isRFP_MPDO_via_fusion hFusion) h_tp hρ hρ_fix
+
 end MPOTensor
+
+end

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -503,7 +503,6 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPSTensor.PropBlockInjective}
     \lean{MPSTensor.wordTupleSpanTop_of_propBlockInjective}
     \lean{MPSTensor.hasBiCF_of_propBlockInjective}
-    \lean{MPSTensor.hasBiCF_of_propBlockInjective}
     \lean{MPOTensor.horizontalCFData_of_wordTupleSpanTop}
     \lean{MPOTensor.horizontalCFData_of_propBlockInjective}
     \leanok
@@ -526,28 +525,22 @@ strong subadditivity for a normalized three-site reduced state.
     separates the blocks by their word evaluations.
 
     Proposition~IV.3 gives a concrete sufficient criterion for this
-    finite-length separation. The predicate \texttt{PropBlockInjective}
-    isolates this finite-length content: after some common blocking length,
-    each block is block-injective, and after a second finite blocking length
-    one can form word combinations which equal the identity on one chosen
-    block and vanish on all others. Concatenating an injective prefix with
-    such a selector suffix yields the product-algebra span condition above.
-    This is formalized by
-    \texttt{wordTupleSpanTop\_of\_propBlockInjective}; the resulting biCF
-    conclusion is the theorem
-    \texttt{hasBiCF\_of\_propBlockInjective}, and the corresponding
-    horizontal canonical-form package is
-    \texttt{horizontalCFData\_of\_propBlockInjective}.
+    finite-length separation: after some common blocking length, each block is
+    block-injective, and after a second finite blocking length one can form
+    word combinations which equal the identity on one chosen block and vanish
+    on all others. Concatenating an injective prefix with such a selector
+    suffix yields the product-algebra span condition above, and therefore the
+    horizontal canonical-form conclusion.
 \end{remark}
 
-\begin{proposition}[Abstract Proposition~IV.3 package]
-    \label{prop:propblockinj_abstract}
+\begin{theorem}[Abstract Proposition~IV.3 package]
+    \label{thm:propblockinj_abstract}
     \lean{MPSTensor.hasBiCF_of_propBlockInjective}
     \leanok
     \uses{rem:word_tuple_span_top}
     If a block family admits the finite-length selector data of
     Proposition~IV.3, then it is in block-injective canonical form.
-\end{proposition}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -562,7 +555,7 @@ strong subadditivity for a normalized three-site reduced state.
     \label{lem:blockwise_insert_eq_of_mpv_agree}
     \lean{MPOTensor.blockwise_insert_eq_of_mpv_agree}
     \leanok
-    \uses{def:tensor_from_blocks, def:injective, prop:propblockinj_abstract}
+    \uses{def:tensor_from_blocks, def:injective, thm:propblockinj_abstract}
     Let $\bigoplus_k \mu_k A_k$ be a block-diagonal tensor whose blocks are
     injective, left-canonical, weighted by nonzero scalars, and jointly
     block-injective in the sense that for some blocking length~$L$ the tuple of
@@ -575,9 +568,9 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{def:tensor_from_blocks, def:injective, prop:propblockinj_abstract}
+    \uses{def:tensor_from_blocks, def:injective, thm:propblockinj_abstract}
     This is Lemma~L from \cite[Appendix~A]{Cirac2017MPDO_AnnPhys}, using the
-    abstract Proposition~IV.3 package from Proposition~\ref{prop:propblockinj_abstract}.
+    abstract Proposition~IV.3 package from Theorem~\ref{thm:propblockinj_abstract}.
     Expanding the hypothesis over a word of length~$L+1$ beginning with the
     fixed site and folding each block contribution into a trace pairing
     against the corresponding first-site insertion tensor yields, upon taking the
@@ -725,9 +718,8 @@ recovery theorem for the MPDO renormalization fixed-point condition.
     \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion}
     Assume the doubled tensor is trace-preserving and the transfer map admits a
     positive-definite fixed point. If the transfer-map fusion criterion holds,
-    then there exists a stationary family of support algebras, all equal to the
-    fixed-point algebra of the adjoint transfer map, with multiplication given
-    by matrix multiplication and inclusions given by the identity.
+    then the MPO satisfies the algebra-structure formulation of the
+    renormalization fixed-point condition.
 \end{theorem}
 \begin{proof}\leanok
 The fusion criterion implies idempotence of the transfer map. Under the

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -503,6 +503,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPSTensor.PropBlockInjective}
     \lean{MPSTensor.wordTupleSpanTop_of_propBlockInjective}
     \lean{MPSTensor.hasBiCF_of_propBlockInjective}
+    \lean{MPSTensor.hasBiCF_of_propBlockInjective}
     \lean{MPOTensor.horizontalCFData_of_wordTupleSpanTop}
     \lean{MPOTensor.horizontalCFData_of_propBlockInjective}
     \leanok
@@ -525,22 +526,43 @@ strong subadditivity for a normalized three-site reduced state.
     separates the blocks by their word evaluations.
 
     Proposition~IV.3 gives a concrete sufficient criterion for this
-    finite-length separation. After one common blocking length, each block is
-    block-injective; after a further finite blocking length, one can choose
-    linear combinations of words which act as the identity on one selected
-    block and vanish on all the others. Combining an injective prefix with
-    such a selector suffix yields the spanning condition above.
-
-    Once this finite-length separation is available, together with
-    injectivity, left-canonicality, and nonzero weights, one obtains the
-    horizontal canonical-form structure for the MPO.
+    finite-length separation. The predicate \texttt{PropBlockInjective}
+    isolates this finite-length content: after some common blocking length,
+    each block is block-injective, and after a second finite blocking length
+    one can form word combinations which equal the identity on one chosen
+    block and vanish on all others. Concatenating an injective prefix with
+    such a selector suffix yields the product-algebra span condition above.
+    This is formalized by
+    \texttt{wordTupleSpanTop\_of\_propBlockInjective}; the resulting biCF
+    conclusion is the theorem
+    \texttt{hasBiCF\_of\_propBlockInjective}, and the corresponding
+    horizontal canonical-form package is
+    \texttt{horizontalCFData\_of\_propBlockInjective}.
 \end{remark}
+
+\begin{proposition}[Abstract Proposition~IV.3 package]
+    \label{prop:propblockinj_abstract}
+    \lean{MPSTensor.hasBiCF_of_propBlockInjective}
+    \leanok
+    \uses{rem:word_tuple_span_top}
+    If a block family admits the finite-length selector data of
+    Proposition~IV.3, then it is in block-injective canonical form.
+\end{proposition}
+
+\begin{proof}
+    \leanok
+    \uses{rem:word_tuple_span_top}
+    This is the direct implication from the abstract selector package to the
+    finite-length trace-separation statement. What remains open in the full
+    Proposition~IV.3 is the derivation of the selector hypothesis from separated
+    canonical-form / BNT data.
+\end{proof}
 
 \begin{lemma}[Blockwise equality from agreement on the MPV family]
     \label{lem:blockwise_insert_eq_of_mpv_agree}
     \lean{MPOTensor.blockwise_insert_eq_of_mpv_agree}
     \leanok
-    \uses{def:tensor_from_blocks, def:injective}
+    \uses{def:tensor_from_blocks, def:injective, prop:propblockinj_abstract}
     Let $\bigoplus_k \mu_k A_k$ be a block-diagonal tensor whose blocks are
     injective, left-canonical, weighted by nonzero scalars, and jointly
     block-injective in the sense that for some blocking length~$L$ the tuple of
@@ -553,8 +575,9 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{def:tensor_from_blocks, def:injective}
-    This is Lemma~L from \cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
+    \uses{def:tensor_from_blocks, def:injective, prop:propblockinj_abstract}
+    This is Lemma~L from \cite[Appendix~A]{Cirac2017MPDO_AnnPhys}, using the
+    abstract Proposition~IV.3 package from Proposition~\ref{prop:propblockinj_abstract}.
     Expanding the hypothesis over a word of length~$L+1$ beginning with the
     fixed site and folding each block contribution into a trace pairing
     against the corresponding first-site insertion tensor yields, upon taking the
@@ -672,28 +695,47 @@ recovery theorem for the MPDO renormalization fixed-point condition.
     \lean{MPOTensor.AlgebraStructureData}
     \leanok
     \uses{def:mpo_tensor}
-    A family of support algebras $\{\mathcal{A}_n\}_{n \ge 0}$, one at every
-    blocking size, equipped with blocking maps
-    $m_n : \mathcal{A}_n \otimes \mathcal{A}_n \to \mathcal{A}_{2n}$ arising
-    from horizontal concatenation of blocks and unital inclusion maps
-    $\iota_n : \mathcal{A}_n \to \mathcal{A}_{n+1}$ arising from appending a
-    single site, together with a coherence condition relating $m_n$ and
-    $\iota_n$.
+    A family of support $*$-algebras $\{\mathcal{A}_n\}_{n \ge 0}$, one at
+    every blocking size, equipped with blocking maps
+    $m_n : \mathcal{A}_n \otimes \mathcal{A}_n \to \mathcal{A}_{2n}$ and
+    inclusion maps $\iota_n : \mathcal{A}_n \to \mathcal{A}_{n+1}$ such that,
+    after viewing all elements inside the ambient bond-space matrix algebra,
+    $m_n$ is ordinary matrix multiplication and $\iota_n$ is the ambient
+    inclusion.
 \end{definition}
 
-\begin{definition}[Algebra-structure formulation of MPDO RFP]%
+\begin{definition}[Algebra-structure RFP predicate]%
     \label{def:mpdo_rfp_via_algebra}
-    \lean{MPOTensor.IsRFP_MPDO_via_algebra_scaffold}
+    \lean{MPOTensor.IsRFP_MPDO_via_algebra}
+    \leanok
     \uses{def:mpdo_algebra_structure_data, def:mpo_tensor}
-    An MPO tensor $M$ satisfies the \emph{algebra-structure formulation} of
-    the renormalization fixed-point condition when there exist
-    algebra-structure data compatible with $M$, in the sense of
-    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}. Here compatibility is
-    taken to be the trivial relation that holds for every pair, so this
-    formulation is satisfied by every MPO tensor. The intended compatibility
-    condition is the one appearing in
-    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}.
+    An MPO tensor $M$ satisfies the \emph{algebra-structure formulation} used
+    here when there exist algebra-structure data whose support algebra at every
+    positive blocking size coincides with the fixed-point algebra of the adjoint
+    blocked transfer map. This is a genuine algebraic condition, but it is still
+    weaker than the full coefficient formulation of
+    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}, since the coefficient
+    family $c_{\alpha,\beta,\gamma}^{(L)}$ is not yet extracted.
 \end{definition}
+
+\begin{theorem}[Fusion yields a stationary algebra tower under a faithful fixed point]%
+    \label{thm:mpdo_rfp_via_algebra_from_fusion}
+    \lean{MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed}
+    \leanok
+    \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion}
+    Assume the doubled tensor is trace-preserving and the transfer map admits a
+    positive-definite fixed point. If the transfer-map fusion criterion holds,
+    then there exists a stationary family of support algebras, all equal to the
+    fixed-point algebra of the adjoint transfer map, with multiplication given
+    by matrix multiplication and inclusions given by the identity.
+\end{theorem}
+\begin{proof}\leanok
+The fusion criterion implies idempotence of the transfer map. Under the
+trace-preserving normalization and the faithful fixed point, Wolf's
+fixed-point-algebra theorem gives a $*$-subalgebra of adjoint fixed points.
+Idempotence identifies every positive blocked transfer map with the original
+one, so the same fixed-point algebra works at every blocking size.
+\end{proof}
 
 \section{Commuting form and GSNNCH}
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -737,6 +737,76 @@ Idempotence identifies every positive blocked transfer map with the original
 one, so the same fixed-point algebra works at every blocking size.
 \end{proof}
 
+The current Lean layer still does not recover the paper's special diagonal
+matrices $\chi_{\alpha,\beta,\gamma}$ from Theorem~IV.13(ii). What it does
+provide is the first explicit coefficient package attached to the algebra tower:
+a chosen basis of each support algebra, coordinate maps into a finite scalar
+family, and the corresponding multiplication / inclusion coefficient arrays.
+
+\begin{definition}[Blocked coefficients for the algebra tower]%
+    \label{def:mpdo_blocked_coefficients}
+    \lean{MPOTensor.AlgebraStructureData.toBlockedCoefficients}
+    \leanok
+    \uses{def:mpdo_algebra_structure_data}
+    For each blocked size $n$, once a basis of $\mathcal{A}_n$ is chosen,
+    every element of $\mathcal{A}_n$ is identified with a finite coefficient
+    family on that basis.
+\end{definition}
+
+\begin{theorem}[Reconstruction from blocked coefficients]%
+    \label{thm:mpdo_reconstruct_blocked_coefficients}
+    \lean{MPOTensor.AlgebraStructureData.reconstructFromBlockedCoefficients_apply}
+    \leanok
+    \uses{def:mpdo_blocked_coefficients}
+    Reconstructing a coefficient family gives the corresponding basis
+    expansion $\sum_i a_i b_i$ in $\mathcal{A}_n$.
+\end{theorem}
+\begin{proof}\leanok
+This is exactly the finite-basis reconstruction formula for the chosen basis of
+$\mathcal{A}_n$.
+\end{proof}
+
+\begin{definition}[Blocked multiplication coefficients]%
+    \label{def:mpdo_blocked_structure_coefficients}
+    \lean{MPOTensor.AlgebraStructureData.blockedStructureCoefficients}
+    \leanok
+    \uses{def:mpdo_blocked_coefficients}
+    The blocking multiplication map $m_n$ determines a coefficient family for
+    the product of any two chosen basis elements of $\mathcal{A}_n$, now viewed
+    in the basis of $\mathcal{A}_{2n}$.
+\end{definition}
+
+\begin{theorem}[Blocked multiplication reconstructs from its coefficients]%
+    \label{thm:mpdo_mul_coefficients_reconstruct}
+    \lean{MPOTensor.AlgebraStructureData.coe_mul_eq_sum_blockedStructureCoefficients}
+    \leanok
+    \uses{def:mpdo_blocked_structure_coefficients}
+    In the ambient bond-space matrix algebra, the product of two chosen basis
+    elements of $\mathcal{A}_n$ is the sum of the basis elements of
+    $\mathcal{A}_{2n}$ weighted by these extracted coefficients.
+\end{theorem}
+\begin{proof}\leanok
+Apply the reconstruction formula of
+Theorem~\ref{thm:mpdo_reconstruct_blocked_coefficients} to the element
+$m_n(b_i,b_j) \in \mathcal{A}_{2n}$.
+\end{proof}
+
+\begin{theorem}[Compatible adjoint fixed points reconstruct from blocked coefficients]%
+    \label{thm:mpdo_fixedpoint_coefficients_reconstruct}
+    \lean{MPOTensor.AlgebraStructureData.reconstructFromBlockedCoefficients_of_fixedPoint}
+    \leanok
+    \uses{def:mpdo_rfp_via_algebra, def:mpdo_blocked_coefficients}
+    If the algebra tower is compatible with an MPO tensor $M$, then every adjoint
+    blocked fixed point of $E_n = \operatorname{blockedTransferMap}(M,n)$ belongs
+    to $\mathcal{A}_n$ and is recovered exactly from its extracted coefficient
+    family.
+\end{theorem}
+\begin{proof}\leanok
+Compatibility identifies $\mathcal{A}_n$ with the adjoint fixed-point algebra of
+$E_n$, so the fixed point first becomes an element of $\mathcal{A}_n$ and then
+Theorem~\ref{thm:mpdo_reconstruct_blocked_coefficients} reconstructs it.
+\end{proof}
+
 \section{Commuting form and GSNNCH}
 
 \begin{definition}[Commuting-form data for an MPDO]


### PR DESCRIPTION
## Summary

This is an **Option A** follow-up for #612 on top of the non-vacuous algebra scaffold from #810.

**Dependency note:** this branch is based on `feat/612-algebra-structure-v2` (PR #810). If #810 merges first, this PR should reduce to the new blocked-coefficient layer added here.

What this PR lands:
- adds a first explicit **blocked-coefficient extraction** layer for `MPOTensor.AlgebraStructureData`
- keeps the current algebra-side package honest: these are basis-coordinate coefficients for the support algebras, **not yet** the paper's diagonal matrices `χ_{α,β,γ}` or the trace-power coefficients `c_{α,β,γ}^{(L)}` from Theorem IV.13(ii)
- syncs the §4.5 blueprint entry with the new coefficient API

## Lean additions

In `TNLean/MPS/MPDO/AlgebraStructure.lean`:
- `MPOTensor.AlgebraStructureData.BlockedIndex`
- `MPOTensor.AlgebraStructureData.BlockedCoefficients`
- `MPOTensor.AlgebraStructureData.blockedBasis`
- `MPOTensor.AlgebraStructureData.toBlockedCoefficients`
- `MPOTensor.AlgebraStructureData.reconstructFromBlockedCoefficients`
- `MPOTensor.AlgebraStructureData.toBlockedCoefficientsOfMem`
- `MPOTensor.AlgebraStructureData.toBlockedCoefficientsOfFixedPoint`
- `MPOTensor.AlgebraStructureData.blockedStructureCoefficients`
- `MPOTensor.AlgebraStructureData.blockedInclusionCoefficients`
- reconstruction theorems for ordinary elements, compatible adjoint fixed points, multiplication, and inclusion

Mathematically, the new layer does the following.
For each blocked size `n`, choose a basis of the support algebra `A n`.
Then:
- every element of `A n` is equivalent to a finite coefficient family;
- every compatible adjoint blocked fixed point is reconstructed from those coefficients;
- the structure maps `m n` and `iota n` yield explicit coefficient arrays in the chosen bases.

## What is still open for #612

This still does **not** finish the full paper endpoint.
Remaining gap:
1. identify / extract the paper's special positive diagonal matrices `χ_{α,β,γ}`;
2. prove that the paper's coefficients satisfy `c_{α,β,γ}^{(L)} = tr((χ_{α,β,γ})^L)`;
3. land the converse algebra ⇒ fusion direction (or a clean named intermediate hypothesis for it).

So this PR should be read as: **support-algebra tower → explicit basis-coordinate coefficient layer**, not yet the full Appendix C.3--C.4 coefficient-comparison theorem.

## Blueprint

Updated `blueprint/src/chapter/ch02b_mpdo.tex` at the end of the §4.5 algebra-structure block with:
- blocked-coefficient coordinates;
- reconstruction from coefficients;
- blocked multiplication coefficients;
- reconstruction of compatible adjoint fixed points from extracted coefficients.

## Verification

In the worktree:
- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake build TNLean.MPS.MPDO.AlgebraStructure`
- `lake build`
- `rg -n "\b(sorry|axiom)\b" TNLean/MPS/MPDO/AlgebraStructure.lean blueprint/src/chapter/ch02b_mpdo.tex`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors core `MPOTensor.AlgebraStructureData`/RFP predicates from a vacuous scaffold into `StarSubalgebra`-based definitions and adds new compatibility/coordinate machinery that may break downstream Lean proofs relying on the old interfaces.
> 
> **Overview**
> Strengthens the MPDO algebra-structure layer by replacing the prior placeholder support algebras with a tower of `StarSubalgebra`s whose multiplication/inclusion are required to coincide with ambient matrix multiplication/inclusion, and makes `CompatibleWith` non-vacuous by identifying `A n` with the adjoint fixed-point algebra of `(blockedTransferMap M n)`.
> 
> Adds a construction of a *stationary* algebra tower from a trace-preserving MPO with a positive-definite fixed point, and proves one-way implications from `IsRFP` (and from the fusion criterion under the same hypotheses) to the new `IsRFP_MPDO_via_algebra` predicate.
> 
> Introduces an explicit blocked-coordinate layer: chosen bases for each `A n`, linear equivalences to coefficient families, reconstruction lemmas, and extracted coefficient arrays for multiplication (`blockedStructureCoefficients`) and inclusion (`blockedInclusionCoefficients`), plus reconstruction results for compatible adjoint fixed points. Updates the blueprint text to match these definitions and new theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086be65c45a9644bea60632fdc4beda22a0d5b62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->