### PR TITLE
feat(Channel): add Kraus-rank / Choi-rank toolkit (#670)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -51,6 +51,7 @@ import TNLean.Channel.PartialTrace
 import TNLean.Channel.MaximallyEntangled
 import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.Stinespring

--- a/TNLean/Channel/ChoiJamiolkowski.lean
+++ b/TNLean/Channel/ChoiJamiolkowski.lean
@@ -162,8 +162,10 @@ theorem omegaSlice_eq_single (i₂ j₂ : Fin D) :
   · subst hb; simp [ha, show ¬(i₂ = a) from Ne.symm ha]
   · simp [ha, hb, show ¬(i₂ = a) from Ne.symm ha, show ¬(j₂ = b) from Ne.symm hb]
 
+namespace Internal
+
 /-- `K * (c * c̄ · E_{i,j}) * K† = c · K_col(i) ⊗ c̄ · K_col(j)†` as an outer product. -/
-private theorem mul_single_mul_conjTranspose_eq_vecMulVec
+theorem mul_single_mul_conjTranspose_eq_vecMulVec
     (K : Matrix (Fin D) (Fin D) ℂ)
     (c : ℂ)
     (i₂ j₂ : Fin D) :
@@ -178,6 +180,8 @@ private theorem mul_single_mul_conjTranspose_eq_vecMulVec
   ext i₁ j₁
   simp [Matrix.vecMulVec_apply, Matrix.conjTranspose_apply, Matrix.col, Matrix.row]
   ring_nf
+
+end Internal
 
 /-- The omega coefficient `(1/√D)·(1/√D) = 1/D`. -/
 private theorem omegaCoeff_eq_inv (hd : 0 < D) :
@@ -272,7 +276,7 @@ theorem choiMatrix_of_kraus_posSemidef
     refine Finset.sum_congr rfl ?_
     intro x _
     simpa [Matrix.vecMulVec_apply] using congrArg (fun M => M i₁ j₁)
-      (mul_single_mul_conjTranspose_eq_vecMulVec (K := K x) (c := c) i₂ j₂)
+      (Internal.mul_single_mul_conjTranspose_eq_vecMulVec (K := K x) (c := c) i₂ j₂)
   rw [hchoi]
   refine Matrix.posSemidef_sum (s := Finset.univ)
     (x := fun i =>
@@ -384,7 +388,7 @@ theorem cp_iff_choi_posSemidef [NeZero D] :
                       (v m (a, i) / c) * star (v m (b, j) / c) := by
                     simpa [K, Matrix.vecMulVec_apply] using
                       congrArg (fun M => M a b)
-                        (mul_single_mul_conjTranspose_eq_vecMulVec
+                        (Internal.mul_single_mul_conjTranspose_eq_vecMulVec
                           (K := K m) (c := (1 : ℂ)) i j)
                   rw [hterm]
                   simp [div_eq_mul_inv, hstarc, hc, mul_assoc, mul_left_comm, mul_comm]
@@ -615,7 +619,7 @@ theorem exists_cpMap_of_choi_posSemidef [NeZero D]
       refine Finset.sum_congr rfl ?_
       intro x _
       simpa [Matrix.vecMulVec_apply] using congrArg (fun M => M i₁ j₁)
-        (mul_single_mul_conjTranspose_eq_vecMulVec (K := K x) (c := c) i₂ j₂)
+        (Internal.mul_single_mul_conjTranspose_eq_vecMulVec (K := K x) (c := c) i₂ j₂)
     simpa [T, K, div_eq_mul_inv, hstarc, hc, mul_assoc, mul_left_comm, mul_comm] using hchoi'
   refine ⟨T, ⟨r, K, fun X => rfl⟩, ?_⟩
   exact hchoi.trans hτeq.symm

--- a/TNLean/Channel/KrausRank.lean
+++ b/TNLean/Channel/KrausRank.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Data.Fintype.Card
+import TNLean.Channel.ChoiJamiolkowski
+
+/-!
+# Kraus-cardinality and Choi-rank bounds
+
+This file packages the basic channel-side infrastructure needed for future
+minimal-Kraus arguments.
+
+## Main definitions
+
+* `Channel.HasKrausCard E r` — `E` has an exact `r`-operator Kraus representation.
+* `Channel.HasKrausRankLE E r` — `E` has some Kraus representation with at most
+  `r` operators.
+* `Channel.choiRank E` — the rank of the Choi matrix of `E`.
+
+## Main results
+
+* `Channel.hasKrausCard_mono` — zero-padding enlarges a Kraus family.
+* `Channel.choiMatrix_eq_sum_vecMulVec_of_kraus` — the Choi matrix of a Kraus
+  map is a sum of rank-one outer products.
+* `Channel.choiRank_le_of_hasKrausCard` — any `r`-operator Kraus family gives
+  the upper bound `choiRank E ≤ r`.
+* `Channel.choiRank_le_of_hasKrausRankLE` — the same upper bound for bounded
+  Kraus-rank witnesses.
+
+## Design note
+
+This file does **not** yet prove the converse direction
+`HasKrausRankLE E (choiRank E)`. That is the genuine minimal-Kraus / Choi-rank
+identity still needed for Theorem 4.1 reverse.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset BigOperators
+
+namespace Channel
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- A linear map `E : M_D(ℂ) → M_D(ℂ)` has an exact `r`-operator Kraus
+representation. -/
+def HasKrausCard (E : Mat →ₗ[ℂ] Mat) (r : ℕ) : Prop :=
+  ∃ K : Fin r → Mat, ∀ X, E X = ∑ i : Fin r, K i * X * (K i)ᴴ
+
+/-- A linear map `E : M_D(ℂ) → M_D(ℂ)` admits a Kraus representation with at
+most `r` operators. -/
+def HasKrausRankLE (E : Mat →ₗ[ℂ] Mat) (r : ℕ) : Prop :=
+  ∃ s : ℕ, s ≤ r ∧ HasKrausCard E s
+
+/-- The Choi rank of a linear map is the rank of its Choi matrix. -/
+noncomputable def choiRank (E : Mat →ₗ[ℂ] Mat) : ℕ :=
+  (ChoiJamiolkowski.choiMatrix E).rank
+
+/-- A sum indexed by `Fin r` can be padded by zeros to a larger `Fin s`. -/
+private lemma sum_pad_zeros {r s : ℕ} {β : Type*} [AddCommMonoid β]
+    (f : Fin r → β) (hCard : r ≤ s) :
+    ∑ j : Fin r, f j =
+      ∑ α : Fin s, if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
+  symm
+  have hsub :
+      ∑ α ∈ Finset.univ.filter (fun α : Fin s => α.val < r),
+          (if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0) =
+        ∑ α : Fin s, if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
+    apply Finset.sum_subset (Finset.filter_subset _ _)
+    intro α _ hα
+    have : ¬ α.val < r := by
+      simpa using hα
+    simp [dif_neg this]
+  rw [← hsub]
+  symm
+  apply Finset.sum_nbij (fun j : Fin r => (⟨j.val, Nat.lt_of_lt_of_le j.isLt hCard⟩ : Fin s))
+  · intro j _
+    exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, j.isLt⟩
+  · intro j₁ _ j₂ _ hj
+    exact Fin.ext (Fin.mk.inj hj)
+  · intro α hα
+    have hα' := (Finset.mem_filter.mp (Finset.mem_coe.mp hα)).2
+    exact ⟨⟨α.val, hα'⟩, Finset.mem_coe.mpr (Finset.mem_univ _), Fin.ext rfl⟩
+  · intro j _
+    simp [Fin.eta]
+
+/-- If `E` has `r` Kraus operators and `r ≤ s`, then it also has `s` Kraus
+operators obtained by zero-padding. -/
+theorem hasKrausCard_mono {E : Mat →ₗ[ℂ] Mat} {r s : ℕ}
+    (hE : HasKrausCard E r) (hCard : r ≤ s) :
+    HasKrausCard E s := by
+  classical
+  rcases hE with ⟨K, hK⟩
+  refine ⟨fun α => if hlt : α.val < r then K ⟨α.val, hlt⟩ else 0, ?_⟩
+  intro X
+  rw [hK X, sum_pad_zeros (f := fun j => K j * X * (K j)ᴴ) hCard]
+  refine Finset.sum_congr rfl ?_
+  intro α _
+  simp only
+  split_ifs with hlt
+  · rfl
+  · simp
+
+/-- Any exact Kraus-cardinality witness yields a bounded one. -/
+theorem hasKrausRankLE_of_hasKrausCard {E : Mat →ₗ[ℂ] Mat} {r : ℕ}
+    (hE : HasKrausCard E r) : HasKrausRankLE E r :=
+  ⟨r, le_rfl, hE⟩
+
+section RankBounds
+
+variable {n : Type*} [Fintype n]
+
+/-- A sum of `r` rank-one outer products has rank at most `r`. -/
+theorem rank_le_card_of_eq_sum_vecMulVec {r : ℕ}
+    (M : Matrix n n ℂ) (v : Fin r → n → ℂ)
+    (hM : M = ∑ i, Matrix.vecMulVec (v i) (star (v i))) :
+    M.rank ≤ r := by
+  classical
+  rw [hM, Matrix.rank_eq_finrank_span_cols]
+  have hcols :
+      Submodule.span ℂ
+          (Set.range (fun j : n => (∑ i, Matrix.vecMulVec (v i) (star (v i))).col j)) ≤
+        Submodule.span ℂ (Set.range v) := by
+    refine Submodule.span_le.mpr ?_
+    rintro _ ⟨j, rfl⟩
+    have hcol :
+        (∑ i, Matrix.vecMulVec (v i) (star (v i))).col j =
+          ∑ i, star (v i j) • v i := by
+      ext x
+      simp [Matrix.col_apply, Matrix.sum_apply, Matrix.vecMulVec_apply, mul_comm]
+    simpa [hcol] using
+      (Submodule.sum_mem (Submodule.span ℂ (Set.range v)) fun i _ =>
+        Submodule.smul_mem _ _ <| Submodule.subset_span ⟨i, rfl⟩)
+  have hfinrank := Submodule.finrank_mono hcols
+  have hspan_card :
+      Module.finrank ℂ ↥(Submodule.span ℂ (Set.range v)) ≤ (Set.range v).toFinset.card := by
+    simpa using (finrank_span_le_card (R := ℂ) (s := Set.range v))
+  have hrange_finset : (Set.range v).toFinset = Finset.univ.image v := by
+    ext x
+    simp
+  have hcard_range : (Set.range v).toFinset.card ≤ r := by
+    rw [hrange_finset]
+    exact (Finset.card_image_le).trans_eq (by simp)
+  exact hfinrank.trans (hspan_card.trans hcard_range)
+
+end RankBounds
+
+/-- `K * (c * c̄ · E_{i,j}) * K†` is the rank-one matrix formed from the
+`i`-th and `j`-th columns of `K`, scaled by `c`. This duplicates the tiny
+file-local helper used inside `ChoiJamiolkowski.lean` so the Choi-rank bounds
+here can stay self-contained. -/
+private theorem mul_single_mul_conjTranspose_eq_vecMulVec
+    (K : Mat) (c : ℂ) (i₂ j₂ : Fin D) :
+    K * Matrix.single i₂ j₂ (c * star c) * Kᴴ =
+      Matrix.vecMulVec (fun i₁ : Fin D => c * K i₁ i₂)
+        (fun j₁ : Fin D => star (c * K j₁ j₂)) := by
+  rw [show Matrix.single i₂ j₂ (c * star c) =
+      (c * star c) • Matrix.vecMulVec (Pi.single i₂ (1 : ℂ)) (Pi.single j₂ 1) by
+    rw [← Matrix.single_eq_single_vecMulVec_single i₂ j₂]
+    simp]
+  rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_vecMulVec, Matrix.vecMulVec_mul]
+  ext i₁ j₁
+  simp [Matrix.vecMulVec_apply, Matrix.conjTranspose_apply, Matrix.col, Matrix.row]
+  ring_nf
+
+/-- The Choi matrix of a Kraus map is a sum of rank-one outer products. -/
+theorem choiMatrix_eq_sum_vecMulVec_of_kraus {r : ℕ}
+    (K : Fin r → Mat) (E : Mat →ₗ[ℂ] Mat)
+    (hE : ∀ X, E X = ∑ i : Fin r, K i * X * (K i)ᴴ) :
+    ChoiJamiolkowski.choiMatrix E =
+      ∑ j : Fin r,
+        Matrix.vecMulVec (fun p : Fin D × Fin D => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * K j p.1 p.2)
+          (star (fun p : Fin D × Fin D => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * K j p.1 p.2)) := by
+  classical
+  let c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  rw [ChoiJamiolkowski.choiMatrix_apply, hE,
+    ChoiJamiolkowski.omegaSlice_eq_single (D := D) i₂ j₂,
+    Matrix.sum_apply i₁ j₁, Matrix.sum_apply (i₁, i₂) (j₁, j₂)]
+  change ∑ x : Fin r,
+      (K x * Matrix.single i₂ j₂ (c * star c) * (K x)ᴴ) i₁ j₁ =
+    ∑ x : Fin r,
+      Matrix.vecMulVec (fun p : Fin D × Fin D => c * K x p.1 p.2)
+        (star (fun p : Fin D × Fin D => c * K x p.1 p.2)) (i₁, i₂) (j₁, j₂)
+  refine Finset.sum_congr rfl ?_
+  intro x _
+  simpa [Matrix.vecMulVec_apply] using
+    congrArg (fun M => M i₁ j₁)
+      (mul_single_mul_conjTranspose_eq_vecMulVec (K := K x) (c := c) i₂ j₂)
+
+/-- Any `r`-operator Kraus representation bounds the Choi rank by `r`. -/
+theorem choiRank_le_of_hasKrausCard {E : Mat →ₗ[ℂ] Mat} {r : ℕ}
+    (hE : HasKrausCard E r) :
+    choiRank E ≤ r := by
+  rcases hE with ⟨K, hK⟩
+  unfold choiRank
+  exact rank_le_card_of_eq_sum_vecMulVec _ _
+    (choiMatrix_eq_sum_vecMulVec_of_kraus K E hK)
+
+/-- A bounded Kraus-rank witness also bounds the Choi rank. -/
+theorem choiRank_le_of_hasKrausRankLE {E : Mat →ₗ[ℂ] Mat} {r : ℕ}
+    (hE : HasKrausRankLE E r) :
+    choiRank E ≤ r := by
+  rcases hE with ⟨s, hs, hE⟩
+  exact (choiRank_le_of_hasKrausCard hE).trans hs
+
+end Channel

--- a/TNLean/Channel/KrausRank.lean
+++ b/TNLean/Channel/KrausRank.lean
@@ -147,24 +147,6 @@ theorem rank_le_card_of_eq_sum_vecMulVec {r : ℕ}
 
 end RankBounds
 
-/-- `K * (c * c̄ · E_{i,j}) * K†` is the rank-one matrix formed from the
-`i`-th and `j`-th columns of `K`, scaled by `c`. This duplicates the tiny
-file-local helper used inside `ChoiJamiolkowski.lean` so the Choi-rank bounds
-here can stay self-contained. -/
-private theorem mul_single_mul_conjTranspose_eq_vecMulVec
-    (K : Mat) (c : ℂ) (i₂ j₂ : Fin D) :
-    K * Matrix.single i₂ j₂ (c * star c) * Kᴴ =
-      Matrix.vecMulVec (fun i₁ : Fin D => c * K i₁ i₂)
-        (fun j₁ : Fin D => star (c * K j₁ j₂)) := by
-  rw [show Matrix.single i₂ j₂ (c * star c) =
-      (c * star c) • Matrix.vecMulVec (Pi.single i₂ (1 : ℂ)) (Pi.single j₂ 1) by
-    rw [← Matrix.single_eq_single_vecMulVec_single i₂ j₂]
-    simp]
-  rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_vecMulVec, Matrix.vecMulVec_mul]
-  ext i₁ j₁
-  simp [Matrix.vecMulVec_apply, Matrix.conjTranspose_apply, Matrix.col, Matrix.row]
-  ring_nf
-
 /-- The Choi matrix of a Kraus map is a sum of rank-one outer products. -/
 theorem choiMatrix_eq_sum_vecMulVec_of_kraus {r : ℕ}
     (K : Fin r → Mat) (E : Mat →ₗ[ℂ] Mat)
@@ -188,7 +170,8 @@ theorem choiMatrix_eq_sum_vecMulVec_of_kraus {r : ℕ}
   intro x _
   simpa [Matrix.vecMulVec_apply] using
     congrArg (fun M => M i₁ j₁)
-      (mul_single_mul_conjTranspose_eq_vecMulVec (K := K x) (c := c) i₂ j₂)
+      (ChoiJamiolkowski.Internal.mul_single_mul_conjTranspose_eq_vecMulVec
+        (K := K x) (c := c) i₂ j₂)
 
 /-- Any `r`-operator Kraus representation bounds the Choi rank by `r`. -/
 theorem choiRank_le_of_hasKrausCard {E : Mat →ₗ[ℂ] Mat} {r : ℕ}

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -6,6 +6,7 @@ import TNLean.Channel.PartialTrace
 import TNLean.Channel.MaximallyEntangled
 import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.Stinespring
@@ -32,6 +33,9 @@ representations of quantum channels.
     Hermiticity-preserving ↔ `τ` is Hermitian ✅
   - `ChoiJamiolkowski.trace_choiMatrix_of_tp` — `tr(τ) = 1` for TP ✅
   - `ChoiJamiolkowski.choiMatrix_id` — `τ` of identity = `|Ω⟩⟨Ω|` ✅
+  - `Channel.choiRank` — rank of the Choi matrix ✅
+  - `Channel.choiRank_le_of_hasKrausCard` / `Channel.choiRank_le_of_hasKrausRankLE`
+    — Choi-rank upper bounds from exact / bounded Kraus families ✅
 
 * **Thm 2.1** (Kraus representation):
   - `kraus_tp_of_sum_conjTranspose_mul` — `∑Kᵢ†Kᵢ = 𝟙` ⟹ TP ✅

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.Channel.KrausRank
 import TNLean.MPS.Periodic.Symmetry.Theorem41Forward
 
 /-!
@@ -32,12 +33,46 @@ Morally, if `transferMap B = (E')^p` for a CPTP map `E'`, one would like to choo
 representation `A` of `E'` with exactly `d` Kraus operators. In general the minimum Kraus
 rank of `E'` may exceed `d`, so formalising this step requires a Kraus-rank reduction /
 canonical-form argument (the analogue of left-canonical reduction used for the forward
-direction). We expose the end-result as a hypothesis in the same style as
-`PRefinementCanonicalization`. -/
+direction). The theorem `pRefinementInverseCanonicalization_of_rootKrausRankBound` below
+shows that it is enough to prove a bounded-Kraus-rank statement for the root channel. -/
 def PRefinementInverseCanonicalization (d D p : ℕ) : Prop :=
   ∀ {B : MPSTensor d D}, IsIrreducibleForm B →
     IsPDivisibleChannel (transferMap B) p →
     ∃ A : MPSTensor d D, transferMap B = transferMap (blockTensor A p)
+
+/-- A bounded Kraus-rank witness for a channel root can be re-packaged as an
+`MPSTensor` with the ambient physical dimension by zero-padding the Kraus family. -/
+theorem exists_tensor_of_hasKrausRankLE
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hE : Channel.HasKrausRankLE (D := D) E d) :
+    ∃ A : MPSTensor d D, transferMap A = E := by
+  rcases hE with ⟨s, hs, hE⟩
+  obtain ⟨K, hK⟩ := Channel.hasKrausCard_mono (D := D) hE hs
+  refine ⟨K, ?_⟩
+  ext X i j
+  simpa [transferMap_apply] using congrArg (fun M => M i j) (hK X).symm
+
+/-- A clean root-cardinality hypothesis that isolates the remaining Kraus-rank
+step in the reverse direction of Theorem 4.1. -/
+def PRefinementInverseRootKrausRankBound (d D p : ℕ) : Prop :=
+  ∀ {B : MPSTensor d D}, IsIrreducibleForm B →
+    ∀ {E' : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ},
+      IsChannel E' → transferMap B = E' ^ p → Channel.HasKrausRankLE (D := D) E' d
+
+/-- A bounded-Kraus-rank root hypothesis is enough to recover the existing
+inverse canonicalization hypothesis. -/
+theorem pRefinementInverseCanonicalization_of_rootKrausRankBound
+    (hRoot : PRefinementInverseRootKrausRankBound d D p) :
+    PRefinementInverseCanonicalization d D p := by
+  intro B hB hDivisible
+  rcases hDivisible with ⟨E', hE'chan, hpow⟩
+  have hRank : Channel.HasKrausRankLE (D := D) E' d := hRoot hB hE'chan hpow
+  obtain ⟨A, hA⟩ := exists_tensor_of_hasKrausRankLE (d := d) (D := D) hRank
+  refine ⟨A, ?_⟩
+  calc
+    transferMap B = E' ^ p := hpow
+    _ = (transferMap A) ^ p := by rw [← hA]
+    _ = transferMap (blockTensor A p) := by rw [transferMap_blockTensor]
 
 /-- **Reverse direction of Theorem 4.1 (conditional form).**
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1223,6 +1223,31 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     immediate.
 \end{proof}
 
+\begin{remark}[Choi rank is bounded by Kraus rank]
+    \label{rem:choi_rank_le_kraus_rank}
+    \lean{Channel.HasKrausCard, Channel.HasKrausRankLE, Channel.choiRank,
+           Channel.choiRank_le_of_hasKrausCard,
+           Channel.choiRank_le_of_hasKrausRankLE}
+    \leanok
+    \uses{def:choi_matrix, def:cp_map}
+    If a completely positive map admits a Kraus representation with exactly $r$
+    operators, then its Choi matrix is a sum of $r$ rank-one outer products.
+    Consequently,
+    \[
+        \operatorname{rank}(\tau_E) \le r.
+    \]
+    More generally, any witness with at most $r$ Kraus operators yields the same
+    upper bound.
+\end{remark}
+
+\begin{proof}
+    \leanok
+    Expand the Choi matrix using the Kraus formula and
+    $\tau_E = \sum_j v_j v_j^\dagger$ with one vector $v_j$ for each Kraus
+    operator. The column space of this sum lies in the span of the $r$ vectors
+    $\{v_j\}$, so the rank is at most $r$.
+\end{proof}
+
 %% =========================================================
 \section{Stinespring dilation}
 \label{sec:stinespring}


### PR DESCRIPTION
## Summary
- add new quantum-channel toolkit `TNLean/Channel/KrausRank.lean` with exact/bounded Kraus-cardinality witnesses and the Choi-rank upper bounds they imply
- prove `Channel.choiMatrix_eq_sum_vecMulVec_of_kraus`, `Channel.choiRank_le_of_hasKrausCard`, and `Channel.choiRank_le_of_hasKrausRankLE`
- factor the reverse-side Theorem 4.1 blocker through a clean bounded-root-cardinality hypothesis in `Theorem41Reverse.lean`
- sync the Wolf Chapter 2 index, root import surface, and blueprint chapter-4 channel notes

## Lean declarations added
- `Channel.HasKrausCard`
- `Channel.HasKrausRankLE`
- `Channel.choiRank`
- `Channel.hasKrausCard_mono`
- `Channel.rank_le_card_of_eq_sum_vecMulVec`
- `Channel.choiMatrix_eq_sum_vecMulVec_of_kraus`
- `Channel.choiRank_le_of_hasKrausCard`
- `Channel.choiRank_le_of_hasKrausRankLE`
- `MPSTensor.exists_tensor_of_hasKrausRankLE`
- `MPSTensor.PRefinementInverseRootKrausRankBound`
- `MPSTensor.pRefinementInverseCanonicalization_of_rootKrausRankBound`

## Scope / residual gap
This PR makes the LionSR/TNLean#670 scout real, but it does **not** yet prove the full minimal-Kraus / Choi-rank identity `HasKrausRankLE E (Channel.choiRank E)`.
That remaining converse is now isolated cleanly as the missing step between a root-channel Choi-rank bound and `PRefinementInverseCanonicalization` in Theorem 4.1 reverse.

## Verification
- `cd .worktrees/issue-670-kraus-rank-real && lake env lean TNLean/Channel/KrausRank.lean`
- `cd .worktrees/issue-670-kraus-rank-real && lake build TNLean.MPS.Periodic.Symmetry.Theorem41Forward TNLean.MPS.Periodic.Symmetry.Theorem41Reverse`
- `cd .worktrees/issue-670-kraus-rank-real && lake env lean TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean`
- `cd .worktrees/issue-670-kraus-rank-real && lake build`
- `cd .worktrees/issue-670-kraus-rank-real && lake env lean TNLean/Channel/WolfChapter2Index.lean && lake env lean TNLean.lean`
- `cd .worktrees/issue-670-kraus-rank-real && rg -n "^\s*axiom |:= by\s*sorry|by\s*sorry|\bsorry\b" TNLean/Channel/KrausRank.lean TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean TNLean/Channel/WolfChapter2Index.lean TNLean.lean`
- `cd .worktrees/issue-670-kraus-rank-real/blueprint && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new formal infrastructure around Kraus-cardinality/Choi-rank and rewires the reverse direction of Theorem 4.1 to depend on a new bounded-root Kraus-rank hypothesis; proof-level changes may affect downstream lemmas and imports but don’t touch runtime code.
> 
> **Overview**
> Adds a new `Channel.KrausRank` module defining *exact* and *bounded* Kraus-cardinality witnesses (`HasKrausCard`, `HasKrausRankLE`), `choiRank`, and proving that any Kraus representation yields a **Choi-rank upper bound** (`choiRank_le_of_hasKrausCard` / `choiRank_le_of_hasKrausRankLE`) via an explicit “Choi matrix = sum of rank-one outer products” lemma.
> 
> Refactors `ChoiJamiolkowski` by exposing an internal helper lemma under `ChoiJamiolkowski.Internal` for reuse, and threads the new module into the public import surface (`TNLean.lean`) and `WolfChapter2Index`/blueprint documentation.
> 
> Updates `Theorem41Reverse` to factor the existing inverse-canonicalization assumption through a cleaner root-channel bounded-Kraus-rank hypothesis (`PRefinementInverseRootKrausRankBound`) and a packing lemma that zero-pads Kraus families into an `MPSTensor` witness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f83705fa5dd51befabec724b18f86daacd35de0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->