### PR TITLE
feat(MPS/CanonicalForm): add single-sector step toward Gap §1 (#652)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -203,6 +203,39 @@ theorem fundamentalTheorem_after_blocking_1606_structural
   exact ⟨pA, hpA, rA, dimA, μA, blocksA, pB, hpB, rB, dimB, μB, blocksB,
     hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB⟩
 
+/-- A strengthened after-blocking structural interface that keeps the blocked `SameMPV₂`
+relations at the reduction periods. This is a small but genuine step toward Gap §1 because the
+common-equality input is no longer discarded by the public structural wrapper. -/
+theorem fundamentalTheorem_after_blocking_1606_structural_with_blockedSameMPV₂
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ (pA : ℕ) (_ : 0 < pA)
+      (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d pA) (dimA k)),
+    ∃ (pB : ℕ) (_ : 0 < pB)
+      (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d pB) (dimB k)),
+      SameMPV₂ (blockTensor (d := d) (D := D₁) A pA)
+        (blockTensor (d := d) (D := D₂) B pA) ∧
+      SameMPV₂ (blockTensor (d := d) (D := D₁) A pB)
+        (blockTensor (d := d) (D := D₂) B pB) ∧
+      (∀ k, ∑ i, (blocksA k i)ᴴ * blocksA k i = 1) ∧
+      (∀ k, ∑ i, (blocksB k i)ᴴ * blocksB k i = 1) ∧
+      (∀ k, _root_.IsPrimitive (transferMap (blocksA k))) ∧
+      (∀ k, _root_.IsPrimitive (transferMap (blocksB k))) ∧
+      (∀ k, μA k ≠ 0) ∧
+      (∀ k, μB k ≠ 0) ∧
+      (∀ k, 0 < dimA k) ∧
+      (∀ k, 0 < dimB k) := by
+  obtain ⟨pA, hpA, rA, dimA, μA, blocksA, pB, hpB, rB, dimB, μB, blocksB,
+    hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB⟩ :=
+    fundamentalTheorem_after_blocking_1606_structural A B hSame
+  refine ⟨pA, hpA, rA, dimA, μA, blocksA, pB, hpB, rB, dimB, μB, blocksB,
+    ?_, ?_, hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB⟩
+  · exact sameMPV₂_blockTensor A B hSame pA
+  · exact sameMPV₂_blockTensor A B hSame pB
+
 /-!
 ### What remains for the full 1606.00608 Fundamental Theorem
 

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -483,4 +483,71 @@ theorem exists_bnt_grouping
       classes.enum_norm i ⟨0, classes.copies_pos i⟩]
     exact classes.vals_strictAnti hij
 
+/-- Collapse a single norm class onto one sector basis tensor, keeping the full sector-weight
+multiplicity data. This is the one-class special case of the sector-decomposition surface used
+by the broader BNT grouping story. -/
+theorem bnt_grouping_single_norm_class
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (k0 : Fin r)
+    (hμne : ∀ k, μ k ≠ 0)
+    (hNorm : ∀ k : Fin r, ‖μ k‖ = ‖μ k0‖)
+    (hPhase : ∀ k : Fin r,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (blocks k) σ = ζ ^ N * mpv (blocks k0) σ) :
+    ∃ P : SectorDecomposition d,
+      P.basisCount = 1 ∧
+      P.totalCopies = r ∧
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      (∀ s : Fin P.totalCopies, ‖P.flatWeight s‖ = ‖μ k0‖) := by
+  classical
+  let ζFn : Fin r → ℂ := fun k => (hPhase k).choose
+  have hζ_ne : ∀ k : Fin r, ζFn k ≠ 0 := fun k => (hPhase k).choose_spec.1
+  have hζ_norm : ∀ k : Fin r, ‖ζFn k‖ = 1 := fun k => (hPhase k).choose_spec.2.1
+  have hζ_mpv : ∀ (k : Fin r) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (blocks k) σ = (ζFn k) ^ N * mpv (blocks k0) σ :=
+    fun k N σ => (hPhase k).choose_spec.2.2 N σ
+  have hr : 0 < r := by
+    exact Nat.lt_of_lt_of_le (Nat.zero_lt_succ _) (Nat.succ_le_of_lt k0.isLt)
+  let sectors : SectorWeightData 1 := {
+    copies := fun _ => r
+    copies_pos := fun _ => hr
+    weight := fun _ q => ζFn q * μ q
+    weight_ne_zero := fun _ q => mul_ne_zero (hζ_ne q) (hμne q)
+  }
+  let P : SectorDecomposition d := {
+    basisCount := 1
+    basisDim := fun _ => dim k0
+    basis := fun _ => blocks k0
+    sectors := sectors
+  }
+  refine ⟨P, rfl, ?_, ?_, ?_⟩
+  · simp [P, sectors, SectorDecomposition.totalCopies]
+  · intro N σ
+    calc
+      mpv P.toTensor σ
+          = ∑ j : Fin P.basisCount,
+              ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
+              P.mpv_toTensor_eq_sum_sectors σ
+      _ = ∑ q : Fin r, (ζFn q * μ q) ^ N * mpv (blocks k0) σ := by
+            simp [P, sectors]
+      _ = ∑ q : Fin r, (μ q) ^ N * mpv (blocks q) σ := by
+            refine Finset.sum_congr rfl fun q _ => ?_
+            rw [mul_pow, hζ_mpv q N σ]
+            ring
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+            symm
+            simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
+  · intro s
+    set t : ((j : Fin P.basisCount) × Fin (P.copies j)) := P.flatIndexEquiv.symm s with ht
+    rcases t with ⟨j, q⟩
+    have hj : j = 0 := Subsingleton.elim _ _
+    subst hj
+    rw [SectorDecomposition.flatWeight, ht.symm]
+    change ‖P.weight 0 q‖ = ‖μ k0‖
+    change ‖ζFn q * μ q‖ = ‖μ k0‖
+    rw [norm_mul, hζ_norm q, one_mul, hNorm q]
+
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -308,4 +308,58 @@ theorem exists_sectorDecomp_of_tp_primitive_irr_blocks
   -- Step 3: Apply the gauge-phase-aware BNT grouping theorem.
   exact exists_bnt_grouping_of_gaugePhaseEquiv μ blocks hμne hGPEζ
 
+/-- One-sector specialization of the TP + primitive + irreducible grouping route.
+
+This is a genuine restricted endpoint toward Gap §1: if all weights lie in a single norm class
+and every block has non-decaying overlap with a chosen representative, then the whole family
+collapses to a one-basis `SectorDecomposition`. -/
+theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (k0 : Fin r)
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hNorm : ∀ k : Fin r, ‖μ k‖ = ‖μ k0‖)
+    (hNonDecay : ∀ k : Fin r, k ≠ k0 →
+      ¬ Tendsto (fun N => mpvOverlap (d := d) (blocks k0) (blocks k) N) atTop (nhds 0)) :
+    ∃ P : SectorDecomposition d,
+      P.basisCount = 1 ∧
+      P.totalCopies = r ∧
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      (∀ s : Fin P.totalCopies, ‖P.flatWeight s‖ = ‖μ k0‖) := by
+  have hPhase : ∀ k : Fin r,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (blocks k) σ = ζ ^ N * mpv (blocks k0) σ := by
+    intro k
+    by_cases hk : k = k0
+    · subst hk
+      exact ⟨1, one_ne_zero, norm_one, fun N σ => by simp⟩
+    · obtain ⟨hdim, X, ζ, hζne, hX⟩ := gaugePhaseEquiv_of_nonDecaying_overlap
+        (blocks k0) (blocks k) (hIrr k0) (hIrr k) (hTP k0) (hTP k)
+        (hNonDecay k hk)
+      have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (blocks k) σ = ζ ^ N * mpv (blocks k0) σ := by
+        intro N σ
+        rw [mpv_eq_pow_mul_of_gaugePhase
+          (A := cast (congr_arg (MPSTensor d) hdim) (blocks k0))
+          (B := blocks k) X ζ hX N σ,
+          mpv_cast_dim hdim (blocks k0) N σ]
+      have hζ_norm : ‖ζ‖ = 1 := by
+        exact norm_gaugePhase_eq_one_of_irr_TP_primitive
+          (cast (congr_arg (MPSTensor d) hdim) (blocks k0))
+          (blocks k)
+          ((isIrreducibleTensor_cast_dim hdim (blocks k0)).mpr (hIrr k0))
+          (hIrr k)
+          ((leftCanonical_cast_dim hdim (blocks k0)).mpr (hTP k0))
+          (hTP k)
+          ((isPrimitive_transferMap_cast_dim hdim (blocks k0)).mpr (hPrim k0))
+          (hPrim k)
+          X ζ hX
+      exact ⟨ζ, hζne, hζ_norm, hmpv⟩
+  exact bnt_grouping_single_norm_class μ blocks k0 hμne hNorm hPhase
+
 end MPSTensor

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -60,6 +60,43 @@ section SameMPV₂Blocking
 
 variable {D : ℕ} {r : ℕ} {dim : Fin r → ℕ}
 
+private noncomputable def blockedFlatWord (p : ℕ) {N : ℕ}
+    (σ : Fin N → Fin (blockPhysDim d p)) : List (Fin d) :=
+  flattenBlockedWord d p (List.ofFn σ)
+
+private theorem length_blockedFlatWord (p : ℕ) {N : ℕ}
+    (σ : Fin N → Fin (blockPhysDim d p)) :
+    (blockedFlatWord (d := d) p σ).length = N * p := by
+  simpa [blockedFlatWord] using
+    (length_flattenBlockedWord (d := d) (L := p) (List.ofFn σ))
+
+private noncomputable def blockedFlatConfig (p : ℕ) {N : ℕ}
+    (σ : Fin N → Fin (blockPhysDim d p)) : Fin (N * p) → Fin d :=
+  fun i =>
+    (blockedFlatWord (d := d) p σ).get
+      (Fin.cast (length_blockedFlatWord (d := d) p σ).symm i)
+
+private theorem ofFn_blockedFlatConfig (p : ℕ) {N : ℕ}
+    (σ : Fin N → Fin (blockPhysDim d p)) :
+    List.ofFn (blockedFlatConfig (d := d) p σ) = blockedFlatWord (d := d) p σ := by
+  unfold blockedFlatConfig
+  conv_rhs => rw [← List.ofFn_get (blockedFlatWord (d := d) p σ)]
+  have hcongr :=
+    (List.ofFn_congr (m := N * p) (n := (blockedFlatWord (d := d) p σ).length)
+      (length_blockedFlatWord (d := d) p σ).symm
+      (fun i : Fin (N * p) =>
+        (blockedFlatWord (d := d) p σ).get
+          (Fin.cast (length_blockedFlatWord (d := d) p σ).symm i)))
+  simpa [Function.comp, Fin.cast_cast] using hcongr
+
+private theorem mpv_blockTensor_eq_mpv_blockedFlatConfig
+    {D' : ℕ} (T : MPSTensor d D') (p : ℕ) {N : ℕ}
+    (σ : Fin N → Fin (blockPhysDim d p)) :
+    mpv (blockTensor (d := d) (D := D') T p) σ =
+      mpv T (blockedFlatConfig (d := d) p σ) := by
+  simp [mpv, coeff, ofFn_blockedFlatConfig (d := d) p σ,
+    blockedFlatWord, evalWord_blockTensor]
+
 /-- Blocking distributes over `toTensorFromBlocks`: if
 `SameMPV₂ A (toTensorFromBlocks μ blocks)`, then blocking by `p` on both sides gives
 `SameMPV₂ (blockTensor A p) (toTensorFromBlocks (μ^p) (blockTensor blocks p))`.
@@ -78,29 +115,10 @@ theorem sameMPV₂_blockTensor_of_sameMPV₂_toTensorFromBlocks
       (toTensorFromBlocks (d := blockPhysDim d p)
         (fun k => (μ k) ^ p) (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) := by
   intro N σ
-  classical
-  -- Build the flattened configuration σflat : Fin (N * p) → Fin d.
-  -- This depends only on σ and p, not on any particular tensor.
-  set flat : List (Fin d) := flattenBlockedWord d p (List.ofFn σ) with flat_def
-  have hlen : flat.length = N * p := by
-    simpa [flat_def] using (length_flattenBlockedWord (d := d) (L := p) (List.ofFn σ))
-  set σflat : Fin (N * p) → Fin d :=
-    fun i => flat.get (Fin.cast hlen.symm i) with σflat_def
-  have hofFn : List.ofFn σflat = flat := by
-    rw [σflat_def]
-    conv_rhs => rw [← List.ofFn_get flat]
-    have hcongr :=
-      (List.ofFn_congr (m := N * p) (n := flat.length) hlen.symm
-        (fun i : Fin (N * p) => flat.get (Fin.cast hlen.symm i)))
-    simpa [Function.comp, Fin.cast_cast] using hcongr
-  -- Key: for ANY tensor T with physical dimension d, mpv (blockTensor T p) σ = mpv T σflat.
-  -- This is because the flattening σ ↦ σflat is independent of the tensor.
-  have hblock (D' : ℕ) (T : MPSTensor d D') :
-      mpv (blockTensor (d := d) (D := D') T p) σ = mpv T σflat := by
-    simp [mpv, coeff, hofFn, flat_def, evalWord_blockTensor]
+  let σflat := blockedFlatConfig (d := d) p σ
   calc
     mpv (blockTensor (d := d) (D := D) A p) σ
-        = mpv A σflat := hblock D A
+        = mpv A σflat := mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) A p σ
     _ = mpv (toTensorFromBlocks μ blocks) σflat := hSame (N * p) σflat
     _ = ∑ k : Fin r, (μ k) ^ (N * p) • mpv (blocks k) σflat := by
           exact mpv_toTensorFromBlocks_eq_sum μ blocks σflat
@@ -109,7 +127,7 @@ theorem sameMPV₂_blockTensor_of_sameMPV₂_toTensorFromBlocks
           refine Finset.sum_congr rfl fun k _ => ?_
           have hpow : (μ k) ^ (N * p) = ((μ k) ^ p) ^ N := by
             rw [Nat.mul_comm, pow_mul]
-          rw [hpow, (hblock (dim k) (blocks k)).symm]
+          rw [hpow, (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) (blocks k) p σ).symm]
     _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
           (fun k => (μ k) ^ p) (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) σ := by
           exact (mpv_toTensorFromBlocks_eq_sum
@@ -125,27 +143,13 @@ theorem sameMPV₂_blockTensor
       (blockTensor (d := d) (D := D₁) A p)
       (blockTensor (d := d) (D := D₂) B p) := by
   intro N σ
-  classical
-  set flat : List (Fin d) := flattenBlockedWord d p (List.ofFn σ) with flat_def
-  have hlen : flat.length = N * p := by
-    simpa [flat_def] using (length_flattenBlockedWord (d := d) (L := p) (List.ofFn σ))
-  set σflat : Fin (N * p) → Fin d :=
-    fun i => flat.get (Fin.cast hlen.symm i) with σflat_def
-  have hofFn : List.ofFn σflat = flat := by
-    rw [σflat_def]
-    conv_rhs => rw [← List.ofFn_get flat]
-    have hcongr :=
-      (List.ofFn_congr (m := N * p) (n := flat.length) hlen.symm
-        (fun i : Fin (N * p) => flat.get (Fin.cast hlen.symm i)))
-    simpa [Function.comp, Fin.cast_cast] using hcongr
-  have hblock (D' : ℕ) (T : MPSTensor d D') :
-      mpv (blockTensor (d := d) (D := D') T p) σ = mpv T σflat := by
-    simp [mpv, coeff, hofFn, flat_def, evalWord_blockTensor]
+  let σflat := blockedFlatConfig (d := d) p σ
   calc
     mpv (blockTensor (d := d) (D := D₁) A p) σ
-        = mpv A σflat := hblock D₁ A
+        = mpv A σflat := mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) A p σ
     _ = mpv B σflat := hSame (N * p) σflat
-    _ = mpv (blockTensor (d := d) (D := D₂) B p) σ := (hblock D₂ B).symm
+    _ = mpv (blockTensor (d := d) (D := D₂) B p) σ :=
+          (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) B p σ).symm
 
 end SameMPV₂Blocking
 

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -116,6 +116,37 @@ theorem sameMPV₂_blockTensor_of_sameMPV₂_toTensorFromBlocks
             (fun k => (μ k) ^ p)
             (fun k => blockTensor (d := d) (D := dim k) (blocks k) p) σ).symm
 
+/-- Blocking preserves `SameMPV₂` directly. -/
+theorem sameMPV₂_blockTensor
+    {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) (p : ℕ) :
+    SameMPV₂
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p) := by
+  intro N σ
+  classical
+  set flat : List (Fin d) := flattenBlockedWord d p (List.ofFn σ) with flat_def
+  have hlen : flat.length = N * p := by
+    simpa [flat_def] using (length_flattenBlockedWord (d := d) (L := p) (List.ofFn σ))
+  set σflat : Fin (N * p) → Fin d :=
+    fun i => flat.get (Fin.cast hlen.symm i) with σflat_def
+  have hofFn : List.ofFn σflat = flat := by
+    rw [σflat_def]
+    conv_rhs => rw [← List.ofFn_get flat]
+    have hcongr :=
+      (List.ofFn_congr (m := N * p) (n := flat.length) hlen.symm
+        (fun i : Fin (N * p) => flat.get (Fin.cast hlen.symm i)))
+    simpa [Function.comp, Fin.cast_cast] using hcongr
+  have hblock (D' : ℕ) (T : MPSTensor d D') :
+      mpv (blockTensor (d := d) (D := D') T p) σ = mpv T σflat := by
+    simp [mpv, coeff, hofFn, flat_def, evalWord_blockTensor]
+  calc
+    mpv (blockTensor (d := d) (D := D₁) A p) σ
+        = mpv A σflat := hblock D₁ A
+    _ = mpv B σflat := hSame (N * p) σflat
+    _ = mpv (blockTensor (d := d) (D := D₂) B p) σ := (hblock D₂ B).symm
+
 end SameMPV₂Blocking
 
 /-!


### PR DESCRIPTION
## Summary
- add `sameMPV₂_blockTensor`, a direct blocking-compatibility theorem for equal MPVs
- add `bnt_grouping_single_norm_class`, an explicit one-sector decomposition theorem over a chosen representative block
- add `bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks`, a real restricted Gap §1 endpoint from TP + primitive + irreducible blocks with one norm class and representative non-decay
- add `fundamentalTheorem_after_blocking_1606_structural_with_blockedSameMPV₂`, so the structural after-blocking wrapper now keeps honest blocked `SameMPV₂` data instead of discarding the input equality entirely

## Why this helps #652
The open Gap §1 audits isolated the missing endpoint as a sector-level theorem family. This PR does not solve the full heterogeneous BNT-sector comparison problem, but it lands a genuine one-sided sub-endpoint:

- if a TP/primitive/irreducible block family lies in a **single norm class** and each block has non-decaying overlap with a chosen representative, then it collapses to a **one-basis `SectorDecomposition`** with the full sector-weight multiplicity data preserved.

That gives a real checked theorem on the non-Gemma canonical-form path, rather than another audit note.

## New declarations
- `MPSTensor.sameMPV₂_blockTensor`
- `MPSTensor.bnt_grouping_single_norm_class`
- `MPSTensor.bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks`
- `MPSTensor.fundamentalTheorem_after_blocking_1606_structural_with_blockedSameMPV₂`

## Verification
- `lake env lean TNLean/MPS/Core/BlockingInfrastructure.lean`
- `lake env lean TNLean/MPS/CanonicalForm/BNTGrouping.lean`
- `lake env lean TNLean/MPS/CanonicalForm/EqualNormBridge.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `lake build TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.BNTGrouping TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/Core/BlockingInfrastructure.lean TNLean/MPS/CanonicalForm/BNTGrouping.lean TNLean/MPS/CanonicalForm/EqualNormBridge.lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new core lemmas about how `SameMPV₂` behaves under `blockTensor` and threads that fact into higher-level structural theorems; mistakes could invalidate downstream canonical-form proofs. Changes are proof-centric but touch shared infrastructure used across the reduction chain.
> 
> **Overview**
> Extends the blocking infrastructure with reusable flattening helpers and a new theorem `sameMPV₂_blockTensor` showing `SameMPV₂` is preserved by blocking both tensors, and refactors the existing `toTensorFromBlocks` blocking proof to use this shared flattening.
> 
> Adds a one-norm-class BNT grouping result `bnt_grouping_single_norm_class` (collapsing many equal-norm blocks to a single-basis `SectorDecomposition` while preserving multiplicities), plus a TP/primitive/irreducible + non-decaying-overlap specialization `bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks`.
> 
> Strengthens `fundamentalTheorem_after_blocking_1606_structural` with `fundamentalTheorem_after_blocking_1606_structural_with_blockedSameMPV₂`, which now *retains* the blocked `SameMPV₂` relations at the produced reduction periods instead of discarding the input equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 295bcb0973e89c746aa2c4a8f8cdd664b0783471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->