### PR TITLE
ci(github): switch low-criticality workflows from Opus to Sonnet

### DIFF
--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -267,5 +267,5 @@ jobs:
               only polished conclusions.
 
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-sonnet-4-6
             --allowedTools "Read,Glob,Grep,Bash(git log *),Bash(git diff *),Bash(git show *),Bash(gh label create *),mcp__github__search_issues,mcp__github__issue_write,mcp__github__issue_read,mcp__github__add_issue_comment,mcp__github__get_label,mcp__github__list_issues,mcp__github__search_pull_requests,mcp__github__list_pull_requests,mcp__github__pull_request_read,mcp__github__list_commits"

--- a/.github/workflows/lean-audit.yml
+++ b/.github/workflows/lean-audit.yml
@@ -48,6 +48,6 @@ jobs:
             ${{ github.event.inputs.audit_type == 'mathlib-readiness' && 'Task: Review the TNLean/ directory for lemmas that could be upstreamed to Mathlib. Look for: (1) general-purpose lemmas not specific to the MPS/quantum channel domain, (2) lemmas that fill gaps in existing Mathlib files (check import paths), (3) well-documented, sorry-free results. For each candidate, note the file, lemma name, and which Mathlib module it could belong to. Output a markdown list.' || '' }}
 
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-sonnet-4-6
             --allowedTools "Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(find *),Bash(wc *),Bash(leanblueprint *)"
             --append-system-prompt "This is a Lean 4 / Mathlib formalization project for quantum information theory. Be thorough and precise. Report findings in clean markdown format."

--- a/.github/workflows/mathlib-scout.yml
+++ b/.github/workflows/mathlib-scout.yml
@@ -96,6 +96,6 @@ jobs:
             5. Do NOT create any files, branches, or PRs. Only post the scouting comment.
 
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-sonnet-4-6
             --allowedTools "Read,Glob,Grep,Bash(lean *),Bash(lake env),mcp__github__add_issue_comment,mcp__github__issue_read"
             --append-system-prompt "This is a Lean 4 / Mathlib repository for quantum information theory (MPS tensors, quantum channels, Wielandt theorem). Your ONLY task is to scout Mathlib and the existing codebase for relevant lemmas and post a scouting report. Do NOT write code or create files. Be thorough — search multiple keywords and naming conventions. Mathlib sources are under .lake/packages/mathlib/Mathlib/."

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -238,5 +238,5 @@ jobs:
               ```
 
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-sonnet-4-6
             --allowedTools "Read,Glob,Grep,Bash(gh pr:*),Bash(gh issue:*)"

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -48,7 +48,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-sonnet-4-6
             --allowedTools "mcp__github__*,Bash(git diff *),Bash(git log *),Bash(git show *)"
 
           prompt: |


### PR DESCRIPTION
daily-standup, tracking-issue-sync, pr-cleanup, lean-audit, and mathlib-scout use claude-sonnet-4-6 instead of claude-opus-4-7. These workflows do text summarization, label syncing, and search/report tasks that don't require Opus-level reasoning.

https://claude.ai/code/session_01NGXpkUgJTGpndkNPFt1557

### Motivation
<!-- Why this change is needed (1--3 bullets). -->

-

### Description
<!-- What was changed: files added/modified, definitions introduced, lemmas proved. -->

-

### Testing
<!-- What was verified and how. -->
<!-- Examples: `lake env lean TNLean/Foo/Bar.lean`, `lake build TNLean`,
     `rg -n "sorry|axiom" TNLean/Foo/Bar.lean || true`. -->

-

---
Addresses #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the Claude model used by a handful of non-critical GitHub Actions workflows, with no code or logic changes beyond potential output quality differences.
> 
> **Overview**
> Switches several automation workflows (`daily-standup`, `lean-audit`, `mathlib-scout`, `pr-cleanup`, `tracking-issue-sync`) to run `anthropics/claude-code-action` with `--model claude-sonnet-4-6` instead of `claude-opus-4-7`.
> 
> No workflow behavior, permissions, prompts, or tool allowlists are otherwise changed; impact is limited to cost/latency and the quality/consistency of generated summaries/comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72786d56f5a331a8a88a700ec7e56415e54467c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->