### PR TITLE
feat(MPS/CanonicalForm): wire fixed-algebra orbit lift into assembly (#590)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -34,6 +34,7 @@ original names, including
 `isIrreducibleTensor_blockTensor_of_tp_primitive_irr`,
 `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`,
 `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_projStep`,
+`primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`,
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
 `fundamentalTheorem_after_blocking_1606_structural`.
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -33,6 +33,9 @@ its MPS-formulation for irreducible TP tensors.
 * `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_projStep`
   — under the remaining one-step orbit-lift hypothesis `hProjStep`, each
   compressed cyclic sector has primitive transfer map and is tensor-irreducible.
+* `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`
+  — the same conclusion under the structured fixed-point-algebra rigidity
+  hypothesis from `SectorIrreducibility/HLift.lean`.
 
 ## References
 
@@ -649,6 +652,71 @@ theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_o
     intro k
     exact isIrreducibleOnCorner_of_cyclic_decomp_mps_of_projStep
       (A := A) (m := m) hIrrAdj hTP P hPproj hPsum hcyclic hMulLeft hMulRight hProjStep k
+  exact primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_cornerIrreducible
+    A hTP hγprim hperiph blocks P φ hPproj hPsum hcyclic hIntertwine hMul hStar hNondeg
+    hCornerIrr
+
+/-- Under the structured fixed-point-algebra rigidity hypothesis
+`SectorFixedPointAlgebraRigidity`, the cyclic sector blocks produced after
+blocking are primitive and tensor-irreducible.
+
+This packages the remaining orbit-sum obstruction as a single named hypothesis,
+uses
+`isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`
+to obtain corner irreducibility of `((transferMap A†)^m)|_{P_k}`, and then
+applies the compression transport theorem above. -/
+theorem
+    primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity
+    {d D m : ℕ} [NeZero D] [NeZero m]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A)
+    {γ : ℂ}
+    (hγprim : IsPrimitiveRoot γ m)
+    (hperiph :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+        Set.range (fun j : Fin m => γ ^ (j : ℕ)))
+    {dim : Fin m → ℕ}
+    (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+    (P : Fin m → MatrixAlg D)
+    (φ : (k : Fin m) →
+      Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k))
+    (hPproj : ∀ k, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hcyclic :
+      ∀ k : Fin m,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (hIntertwine :
+      ∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := blockPhysDim d m) (D := D)
+            (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1))
+    (hMul :
+      ∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1)
+    (hStar :
+      ∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ)
+    (hNondeg : ∀ k, dim k ≠ 0)
+    (hRigidity :
+      SectorFixedPointAlgebraRigidity
+        (D := D) (m := m)
+        (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) P) :
+    ∀ u : Fin m,
+      _root_.IsPrimitive (transferMap (d := blockPhysDim d m) (D := dim u) (blocks u)) ∧
+        IsIrreducibleTensor (blocks u) := by
+  let T : MatrixEnd D := transferMap (d := d) (D := D) (fun i => (A i)ᴴ)
+  have hIrrAdj : IsIrreducibleMap T := by
+    simpa [T] using
+      isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor (A := A) hIrr
+  have hMulLeft := cyclic_projection_mul_left (A := A) (m := m) hTP P hPproj hcyclic
+  have hMulRight := cyclic_projection_mul_right (A := A) (m := m) hTP P hPproj hcyclic
+  have hCornerIrr :
+      ∀ k : Fin m, IsIrreducibleOnCorner (P k) (T ^ m) := by
+    intro k
+    exact isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity
+      (A := A) (m := m) hIrrAdj hTP P hPproj hPsum hcyclic hMulLeft hMulRight hRigidity k
   exact primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_cornerIrreducible
     A hTP hγprim hperiph blocks P φ hPproj hPsum hcyclic hIntertwine hMul hStar hNondeg
     hCornerIrr

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -660,8 +660,8 @@ theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_o
 `SectorFixedPointAlgebraRigidity`, the cyclic sector blocks produced after
 blocking are primitive and tensor-irreducible.
 
-This packages the remaining orbit-sum obstruction as a single named hypothesis,
-uses
+This reformulates the remaining orbit-sum obstruction as a single named
+hypothesis, uses
 `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`
 to obtain corner irreducibility of `((transferMap A†)^m)|_{P_k}`, and then
 applies the compression transport theorem above. -/

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -665,8 +665,7 @@ hypothesis, uses
 `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`
 to obtain corner irreducibility of `((transferMap A†)^m)|_{P_k}`, and then
 applies the compression transport theorem above. -/
-theorem
-    primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity
+theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/audits/2026-04-23_issue590_hLift_blocker.md
+++ b/audits/2026-04-23_issue590_hLift_blocker.md
@@ -4,9 +4,9 @@
 > The detailed blocker analysis below is now partly historical: current `main`
 > already contains `SectorFixedPointAlgebraRigidity`,
 > `hProjStep_of_sectorFixedPointAlgebraRigidity`, and
-> `hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`, which package the
-> former `hProjStep`/`hFixUpgrade` obstruction as a single named hypothesis.
-> The forward step added on top of that packaging is the downstream consumer
+> `hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`, which combine the
+> former `hProjStep`/`hFixUpgrade` obstruction into a single named hypothesis.
+> The forward step built on top of that reformulation is the downstream consumer
 > theorem
 > `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`
 > in `Assembly/CyclicSectorDecomposition.lean`. The remaining mathematical gap is
@@ -15,7 +15,7 @@
 
 ## Outcome
 
-I could **not** honestly close issue #590 on current `origin/main`.
+I could **not yet** close issue #590 on current `origin/main`.
 
 The reason is subtle but important: the orbit-sum **combination theorem requested by the
 original issue is already present** on current `main`, after the recent
@@ -199,7 +199,7 @@ In Lean terms, the missing ingredient appears to be one of the following stronge
 3. A direct formalization of the `lem:bdcf` fixed-point / blocked-sector argument that implies the
    needed one-step projection-preservation statement.
 
-Without one of these stronger ingredients, I do not see an honest way to discharge `hProjStep`.
+Without one of these stronger ingredients, I do not currently see a way to discharge `hProjStep`.
 
 ## Practical downstream consequence
 

--- a/audits/2026-04-23_issue590_hLift_blocker.md
+++ b/audits/2026-04-23_issue590_hLift_blocker.md
@@ -19,7 +19,7 @@ I could **not yet** close issue #590 on current `origin/main`.
 
 The reason is subtle but important: the orbit-sum **combination theorem requested by the
 original issue is already present** on current `main`, after the recent
-`SectorIrreducibility` split. The remaining missing step is **not** the orbit-sum assembly
+`SectorIrreducibility` split. The remaining missing step is **not** the orbit-sum construction
 itself, but the still-abstract one-step projection-preservation hypothesis `hProjStep`.
 
 Concretely, current `main` already contains the theorem
@@ -116,7 +116,7 @@ So the new modular structure helps readability, but the mathematical gap is unch
 
 ## Search / audit evidence
 
-I checked the surrounding API in the current repository for a theorem that would bridge sector
+I checked the surrounding API in the current repository for a theorem that would connect sector
 support to one-step projection preservation.
 
 ### 1. Multiplicative-domain API

--- a/audits/2026-04-23_issue590_hLift_blocker.md
+++ b/audits/2026-04-23_issue590_hLift_blocker.md
@@ -1,5 +1,18 @@
 # Issue #590 blocker report — April 23, 2026
 
+> **Status after rebasing onto current `origin/main` (later on April 23).**
+> The detailed blocker analysis below is now partly historical: current `main`
+> already contains `SectorFixedPointAlgebraRigidity`,
+> `hProjStep_of_sectorFixedPointAlgebraRigidity`, and
+> `hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`, which package the
+> former `hProjStep`/`hFixUpgrade` obstruction as a single named hypothesis.
+> The forward step added on top of that packaging is the downstream consumer
+> theorem
+> `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`
+> in `Assembly/CyclicSectorDecomposition.lean`. The remaining mathematical gap is
+> now to derive `SectorFixedPointAlgebraRigidity` from the cyclic-sector fixed-point
+> algebra / projection-word machinery.
+
 ## Outcome
 
 I could **not** honestly close issue #590 on current `origin/main`.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1766,6 +1766,40 @@ The following results separate the zero blocks from the
 \section{Reduction to primitive blocks}%
 \label{sec:reduction_to_normal_form}
 
+\begin{theorem}[Fixed-point-algebra rigidity yields primitive blocked sectors]%
+	\label{thm:blocked_sector_fixed_algebra}
+	\lean{MPSTensor.primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity}
+	\leanok
+	\uses{def:sector_fixed_point_algebra_rigidity,
+	      thm:cyclic_sector_decomp_after_blocking,
+	      thm:sector_irred_fixed_algebra,
+	      thm:primitive_adjoint_equiv}
+	Let $A$ be a left-canonical irreducible tensor whose adjoint transfer map has
+	peripheral spectrum $\{\gamma^j : 0 \le j < m\}$ for a primitive $m$-th root
+	of unity $\gamma$. Let $(C_u)_{u=1}^m$, $(P_u)_{u=1}^m$, and
+	$\varphi_u : \MN{\dim C_u} \xrightarrow{\sim} P_u \MN{D} P_u$
+	be the blocked cyclic-sector data. If the fixed-point-algebra rigidity
+	hypothesis from Definition~\ref{def:sector_fixed_point_algebra_rigidity}
+	holds, then every blocked sector tensor $C_u$ has primitive transfer map and
+	is irreducible.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{def:sector_fixed_point_algebra_rigidity,
+	      thm:sector_irred_fixed_algebra,
+	      thm:primitive_adjoint_equiv}
+	Theorem~\ref{thm:sector_irred_fixed_algebra} gives irreducibility of
+	$(\E_A^\dagger)^m$ on each corner $P_u$.
+	The blocked cyclic-sector data provide compression equivalences
+	$\varphi_u$ intertwining the adjoint transfer map of $C_u$ with the
+	corresponding corner restriction of $(\E_A^\dagger)^m$.
+	The same cyclic peripheral-spectrum argument that produces the sector
+	decomposition shows that each corner restriction is primitive.
+	Transport primitivity and irreducibility across $\varphi_u$, then use
+	Theorem~\ref{thm:primitive_adjoint_equiv} to pass from the adjoint blocked
+	map to the primal transfer map of $C_u$.
+\end{proof}
+
 \begin{theorem}[Arbitrary tensor to primitive block decomposition]%
 	\label{thm:tp_primitive_blockdecomp}
 	\lean{MPSTensor.exists_tp_primitive_blockDecomp_after_blocking}


### PR DESCRIPTION
## Summary

Follow-up to merged PR #801. After rebasing onto current `main`, I found that the
`SectorIrreducibility/HLift.lean` split work has already advanced further than
the original audit captured: `main` now contains
`SectorFixedPointAlgebraRigidity`,
`hProjStep_of_sectorFixedPointAlgebraRigidity`, and
`hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity`.

This PR pushes that packaging one step downstream by wiring the fixed-point-
algebra hypothesis into the assembly pipeline.

### Changes

- add
  `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`
  in `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`
- update `TNLean/MPS/CanonicalForm/Assembly.lean` docstring to mention the new
  assembly theorem
- annotate the existing audit note so it is clearly marked as historical after
  the rebase onto current `main`

## Why this helps issue #590

This does **not** derive `SectorFixedPointAlgebraRigidity` from the cyclic-
sector fixed-point algebra yet. But it makes the remaining gap explicit and
reusable at the next consumer boundary: once that rigidity hypothesis is proved,
the blocked-sector primitivity / irreducibility step is already packaged.

## Verification

- `lake build TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition`
- `lake build TNLean.MPS.CanonicalForm.Assembly`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly.lean`
- `lake build`
- `rg -n "sorry|axiom" TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean TNLean/MPS/CanonicalForm/Assembly.lean audits/2026-04-23_issue590_hLift_blocker.md`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new downstream assembly theorem that swaps an abstract `hProjStep` assumption for `SectorFixedPointAlgebraRigidity`; logic is additive and proof-driven, with low risk beyond potential proof/lemma dependency breakage.
> 
> **Overview**
> Extends the canonical-form *assembly* pipeline with `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`, which derives primitivity and tensor-irreducibility of each blocked cyclic sector assuming the packaged `SectorFixedPointAlgebraRigidity` hypothesis (instead of the ad-hoc `hProjStep`).
> 
> Updates public-facing docs (`Assembly.lean`, `Assembly/CyclicSectorDecomposition.lean`) and the Issue #590 audit note to reference the new consumer theorem and clarify that the remaining gap is proving `SectorFixedPointAlgebraRigidity` from the fixed-point algebra/projection machinery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3ca83e8750d0392da66ab8d7991622e03b352da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->