### PR TITLE
feat(MPS/ParentHamiltonian): package positive cyclic summands (#460)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -302,7 +302,7 @@ orthogonal-projection infrastructure (for example
 `Submodule.starProjection` and `orthogonalProjection`) but not a ready-made
 Kastoryano–Lucia-style angle-to-anticommutator bound. This is a real blocker
 for quantitative overlap constants.
-2. **Positivity packaging:** the local `EuclideanSpace` projector
+2. **Positivity formulation:** the local `EuclideanSpace` projector
 `parentInteractionES A L` is positive, and each conjugated cyclic-restriction
 summand `localTermESSummand A hN L i τ = Rᵢ,τ† P_L Rᵢ,τ` is positive by
 `LinearMap.IsPositive.conj_adjoint`. Missing is the exact averaging identity

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.Basic
+import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import Mathlib.Analysis.InnerProductSpace.Positive
 import Mathlib.Analysis.InnerProductSpace.Spectrum
 
@@ -60,6 +61,9 @@ concrete Friedrichs-angle/row-sum lower bound that
   criterion: the quadratic-form inequality `γ ⟨H v, v⟩ ≤ ⟨H v, H v⟩`
   for a `LinearMap.IsPositive` operator `H` implies the norm bound
   `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`.
+* `MPSTensor.localTermESSummand_isPositive` — positivity of the conjugated
+  cyclic-window summands expected to appear in the averaged
+  `EuclideanSpace` formula for local terms.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
   Friedrichs-angle bound recorded in
@@ -192,6 +196,57 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+/-! ### Euclidean local projector ingredients -/
+
+/-- The `L`-site parent interaction viewed directly on the Hilbert-space model
+`EuclideanSpace ℂ (Cfg d L)`. Equivalently, this is the orthogonal projector
+onto `(groundSpaceES A L)ᗮ`. -/
+noncomputable def parentInteractionES (A : MPSTensor d D) (L : ℕ) :
+    EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L) :=
+  ((groundSpaceES A L)ᗮ.starProjection.toLinearMap)
+
+/-- The `EuclideanSpace` parent interaction is positive because it is an
+orthogonal projection. -/
+theorem parentInteractionES_isPositive (A : MPSTensor d D) (L : ℕ) :
+    (parentInteractionES A L).IsPositive := by
+  exact (Submodule.isSymmetricProjection_starProjection ((groundSpaceES A L)ᗮ)).isPositive
+
+/-- The cyclic window restriction map transported from `NSiteSpace` to the
+Hilbert-space model `EuclideanSpace`. -/
+noncomputable def cyclicRestrictES {N : ℕ} (hN : 0 < N) (L : ℕ) (i : Fin N)
+    (τ : Fin N → Fin d) :
+    EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L) :=
+  LinearMap.withLpMap 2 (cyclicRestrictₗ (d := d) hN L i τ)
+
+/-- One positive summand in the future averaged `EuclideanSpace` formula for a
+local parent-Hamiltonian term.
+
+This is the conjugate `Rᵢ,τ† P_L Rᵢ,τ` of the local orthogonal projector
+`P_L = parentInteractionES A L` by the transported cyclic restriction map
+`Rᵢ,τ = cyclicRestrictES hN L i τ`. -/
+noncomputable def localTermESSummand {N : ℕ} (A : MPSTensor d D) (hN : 0 < N)
+    (L : ℕ) (i : Fin N) (τ : Fin N → Fin d) :
+    EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
+  (cyclicRestrictES (d := d) hN L i τ).adjoint ∘ₗ
+    parentInteractionES A L ∘ₗ
+    cyclicRestrictES (d := d) hN L i τ
+
+/-- Each conjugated cyclic-restriction summand `Rᵢ,τ† P_L Rᵢ,τ` is positive. -/
+theorem localTermESSummand_isPositive {N : ℕ} (A : MPSTensor d D) (hN : 0 < N)
+    (L : ℕ) (i : Fin N) (τ : Fin N → Fin d) :
+    (localTermESSummand A hN L i τ).IsPositive := by
+  simpa [localTermESSummand, LinearMap.adjoint_adjoint] using
+    (LinearMap.IsPositive.conj_adjoint
+      (hT := parentInteractionES_isPositive A L)
+      ((cyclicRestrictES (d := d) hN L i τ).adjoint))
+
+/-- The unnormalised finite sum of the future averaging summands is positive. -/
+theorem localTermESSummand_sum_isPositive {N : ℕ} (A : MPSTensor d D) (hN : 0 < N)
+    (L : ℕ) (i : Fin N) :
+    (∑ τ : Cfg d N, localTermESSummand A hN L i τ).IsPositive := by
+  exact LinearMap.isPositive_sum _ fun τ _ =>
+    localTermESSummand_isPositive A hN L i τ
+
 /-! ### Ground-space and Hamiltonian transport to `EuclideanSpace` -/
 
 /-- Ground-space submodule for the finite-size parent Hamiltonian,
@@ -247,11 +302,16 @@ orthogonal-projection infrastructure (for example
 `Submodule.starProjection` and `orthogonalProjection`) but not a ready-made
 Kastoryano–Lucia-style angle-to-anticommutator bound. This is a real blocker
 for quantitative overlap constants.
-2. **Row-sum bound mapping:** the combinatorial part is already available from
+2. **Positivity packaging:** the local `EuclideanSpace` projector
+`parentInteractionES A L` is positive, and each conjugated cyclic-restriction
+summand `localTermESSummand A hN L i τ = Rᵢ,τ† P_L Rᵢ,τ` is positive by
+`LinearMap.IsPositive.conj_adjoint`. Missing is the exact averaging identity
+relating these positive summands to the transported local terms.
+3. **Row-sum bound mapping:** the combinatorial part is already available from
 locality (`localTerm`, `parentHamiltonian`) and finite range: each window
 overlaps at most `2 * (L - 1)` neighbors. Missing is the analytic implication
 from overlap-angle constants to operator-inequality coefficients `cᵢⱼ`.
-3. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
+4. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
 existential wrapper, now proved by applying the Friedrichs-angle theorem
 below. The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends
 on missing Friedrichs-angle infrastructure; this is the blocker and should not
@@ -272,14 +332,14 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
-  -- Remaining obligations: the MPS-specific Friedrichs-angle estimate for
-  -- adjacent local ground spaces, the finite-overlap row-sum bound, and
-  -- positivity of the transported parent Hamiltonian. The kernel
-  -- identification needed for the final martingale application is now
-  -- available as `parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES`.
-  -- Once the remaining analytic inputs are formalized, this should feed the
-  -- resulting quadratic-form inequality into
-  -- `FrustrationFree.spectralGap_of_martingale`.
+  -- Remaining obligations: the averaging identity expressing transported local
+  -- terms as finite averages of `localTermESSummand`, the MPS-specific
+  -- Friedrichs-angle estimate for adjacent local ground spaces, and the
+  -- finite-overlap row-sum bound. The kernel identification needed for the
+  -- final martingale application is now available as
+  -- `parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES`. Once the
+  -- remaining analytic inputs are formalized, this should feed the resulting
+  -- quadratic-form inequality into `FrustrationFree.spectralGap_of_martingale`.
   sorry
 
 /--

--- a/audits/2026-04-23_issue460_friedrichs_blocker.md
+++ b/audits/2026-04-23_issue460_friedrichs_blocker.md
@@ -73,7 +73,7 @@ The current sorry surface relevant to this issue is:
 
 ## Result of the analytic attempt (A)
 
-### 1. Negative scouting result: no packaged Friedrichs-angle / principal-angle API
+### 1. Negative scouting result: no Friedrichs-angle / principal-angle API
 
 I explicitly searched Mathlib for a subspace-angle / Friedrichs-angle layer.
 The result is still negative.
@@ -99,7 +99,7 @@ projection-geometry layer.
 
 ### 2. Positive scouting result: the operator-theoretic base is present
 
-Mathlib *does* provide the operator API needed for a future positivity package:
+Mathlib *does* provide the operator API needed for a future positivity formulation:
 
 - `Submodule.starProjection`
 - `Submodule.isSymmetricProjection_starProjection`
@@ -113,7 +113,7 @@ So the obstruction is not the absence of positivity infrastructure *per se*.
 The missing part is the exact connection from the current `localTerm`
 definition to a positive operator on `EuclideanSpace`.
 
-### 3. New candidate route for positivity packaging
+### 3. New candidate route for positivity formulation
 
 While re-reading `Defs.lean` and `CyclicWindow.lean`, I found a concrete route
 that seems mathematically correct, but it is **not yet formalized** in current
@@ -202,7 +202,7 @@ This confirms two important facts:
 
 1. the lifted cyclic restriction maps `Rᵢ,τ` exist as linear maps between the
    relevant Euclidean spaces and have adjoints; and
-2. the local projector `P_L` is already packaged as a positive operator.
+2. the local projector `P_L` is already available as a positive operator.
 
 ### 5. Why I am not claiming a proof
 
@@ -211,7 +211,7 @@ configuration-wise definition of `localTerm` to the averaged positive-conjugate
 formula above. That equality is combinatorial and nontrivial; it is not a one-
 line theorem search exercise.
 
-Even if that positivity package were landed, the **quantitative** part of
+Even if that positivity formulation were landed, the **quantitative** part of
 `parentHamiltonianES_gap_bound_of_friedrichs` would still remain:
 
 - the Friedrichs-angle / anti-commutator estimate for overlapping local ground
@@ -219,7 +219,7 @@ Even if that positivity package were landed, the **quantitative** part of
 - the finite-overlap row-sum bound in the exact coefficient form expected by the
   martingale inequality.
 
-So sub-goal (A) is still honestly blocked on current `main`.
+So sub-goal (A) is still blocked on current `main`.
 
 ## Result of the fallback attempt (B)
 
@@ -257,11 +257,11 @@ Without such a theorem, there is still no sound route from
 `ψ ∈ chainGroundSpace (toTensorFromBlocks μ A) L N` to membership in the span of
 block MPVs.
 
-So sub-goal (B) is also still honestly blocked on current `main`.
+So sub-goal (B) is also still blocked on current `main`.
 
 ## Recommended next PR targets
 
-### A. Positivity-packaging infrastructure PR (local to `ParentHamiltonian`)
+### A. Positivity formulation infrastructure PR (local to `ParentHamiltonian`)
 
 The most actionable next step on the martingale side is:
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -530,7 +530,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     compatibility of this restriction with deleting the last or first site.
 \end{remark}
 
-\begin{remark}[Cyclic window operators]
+\begin{remark}[Cyclic window operators]\label{rem:cyclic_window_operators}
     \lean{MPSTensor.cyclicCfg}
     \lean{MPSTensor.cyclicRestrictₗ}
     \lean{MPSTensor.cyclicRestrictₗ_apply}
@@ -1425,6 +1425,39 @@ Lucia~\cite{Kastoryano2018Martingale}.
     parent Hamiltonian annihilates it.
 \end{lemma}
 
+\begin{remark}[Euclidean local projector ingredients]
+    \label{rem:euclidean_local_projector_ingredients}
+    \lean{MPSTensor.parentInteractionES}
+    \lean{MPSTensor.cyclicRestrictES}
+    \lean{MPSTensor.localTermESSummand}
+    \leanok
+    \uses{def:ground_space_es, rem:cyclic_window_operators}
+    Let $P_L^{\mathrm{ES}}(A)$ denote the orthogonal projector onto
+    $(G_L^{\mathrm{ES}}(A))^\perp$ on the Euclidean $L$-site space. For a cyclic
+    window starting at $i$ and an outside configuration $\tau$, the transported
+    restriction map $R_{i,\tau}$ evaluates an $N$-site Euclidean vector on that
+    window. The operator $R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}$ is the
+    basic local summand in the expected averaging formula for the transported local term.
+\end{remark}
+
+\begin{lemma}[Positivity of the Euclidean local summands]
+    \label{lem:euclidean_local_projector_positive}
+    \lean{MPSTensor.parentInteractionES_isPositive}
+    \lean{MPSTensor.localTermESSummand_isPositive}
+    \lean{MPSTensor.localTermESSummand_sum_isPositive}
+    \leanok
+    \uses{rem:euclidean_local_projector_ingredients}
+    The Euclidean local projector $P_L^{\mathrm{ES}}(A)$ is positive. Consequently,
+    every summand $R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}$ is positive, and so
+    is the finite sum over $\tau$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Orthogonal projectors are positive. Conjugation by $R_{i,\tau}$ preserves
+    positivity, and finite sums of positive operators remain positive.
+\end{proof}
+
 \begin{lemma}[Quadratic form to norm bound]\label{lem:quadratic_form_to_norm_bound}
     \lean{FrustrationFree.spectralGap_of_martingale}
     \leanok
@@ -1620,7 +1653,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs}
     \notready
     \uses{def:parent_ground_space_es, def:parent_hamiltonian_es,
-        thm:parent_ground_space_es_kernel}
+        thm:parent_ground_space_es_kernel,
+        rem:euclidean_local_projector_ingredients,
+        lem:euclidean_local_projector_positive}
     For an injective tensor $A$ and a range $L > 1$, the theorem asserts
     the analytic estimate with the explicit constant
     \[
@@ -1635,9 +1670,13 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \notready
-    This is exactly the MPS-specific Friedrichs-angle estimate together with the
-    row-sum bound. These two analytic inputs feed directly into
-    the abstract martingale criterion.
+    The missing argument has two parts. First, one identifies each transported
+    local term with a finite average of the conjugate summands from
+    Remark~\ref{rem:euclidean_local_projector_ingredients};
+    Lemma~\ref{lem:euclidean_local_projector_positive} then supplies positivity
+    of the local Euclidean operators. Second, the MPS-specific Friedrichs-angle
+    estimate together with the row-sum bound feeds into the abstract martingale
+    criterion.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}


### PR DESCRIPTION
## Summary
- continue the post-#798 Friedrichs-angle branch with one concrete analytic forward step
- add the Euclidean local projector / cyclic restriction packaging needed for the positivity route
- prove positivity of each conjugated summand `R† P R` and of their finite sum

## Details
This PR does **not** claim a proof of
`MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`.

Instead, it lands the next honest sub-step identified in the blocker audit:

- `parentInteractionES`
- `cyclicRestrictES`
- `localTermESSummand`
- `parentInteractionES_isPositive`
- `localTermESSummand_isPositive`
- `localTermESSummand_sum_isPositive`

These theorems package the positivity side of the future averaging identity
for transported local terms. The remaining blocker is now more sharply isolated:
one still needs the exact finite averaging identity expressing the transported
local term as an average of the `localTermESSummand`, and then the genuinely
quantitative Friedrichs-angle / row-sum estimate.

## Verification
- `lake build TNLean.MPS.ParentHamiltonian.Martingale`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale.lean`
  - note: `TNLean/MPS/ParentHamiltonian/SpectralGap.lean` is still absent on current `main`, so `Martingale.lean` remains the spectral-gap file
- `lake build`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean definitions/lemmas about positivity of Euclidean-space projector conjugates and updates documentation, without changing existing core algorithms or downstream theorem statements (the main gap theorem remains `sorry`).
> 
> **Overview**
> Adds a small *positivity packaging* layer for the martingale spectral-gap development by introducing `parentInteractionES` (the Euclidean-space local projector), a transported cyclic restriction map `cyclicRestrictES`, and the conjugated summands `localTermESSummand = R† P R`.
> 
> Proves these summands are `IsPositive` (and that their finite sum over configurations is positive), and updates the in-file “scout report” plus the blueprint/audit docs to reflect the new positivity-formulation route and its remaining missing step (the averaging identity connecting these summands to transported local terms).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de695762a51d7a48dd18af7c44ab5ee714ecd14d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->