### PR TITLE
feat(Channel/Schwarz): add operator Jensen compression auxiliaries (#138)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -83,6 +83,7 @@ import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import TNLean.Channel.Schwarz.Douglas
 import TNLean.Channel.Schwarz.DiagonalJensen
+import TNLean.Channel.Schwarz.OperatorJensenAux
 import TNLean.Channel.Schwarz.OperatorConvexity
 import TNLean.Channel.Schwarz.OperatorMonotone
 import TNLean.Channel.Schwarz.AndoLieb

--- a/TNLean/Channel/Schwarz/OperatorConvexity.lean
+++ b/TNLean/Channel/Schwarz/OperatorConvexity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Schwarz.PositiveMapProperties
+import TNLean.Channel.Schwarz.OperatorJensenAux
 import TNLean.Axioms.OperatorConvexity
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
@@ -42,6 +43,10 @@ The three Jensen instances below are proved from the axioms in
 `TNLean.Axioms.OperatorConvexity`, which axiomatize the operator
 concavity/convexity results and the Jensen inequality pending upstream
 Mathlib work in `CFC.Rpow.Order` and `CFC.ExpLog.Order`.
+
+A first batch of finite-POVM / compression auxiliaries for the direct concave
+real-power route now lives in `OperatorJensenAux.lean`, but those lemmas are
+not yet assembled into the full Jensen theorem.
 
 These are consumed by the Corollary 5.2 proofs in `OperatorMonotone.lean`.
 

--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -44,11 +44,16 @@ attribute [local instance] Matrix.instL2OpNormedAddCommGroup
 attribute [local instance] Matrix.instL2OpNormedRing
 attribute [local instance] Matrix.instL2OpNormedAlgebra
 
+namespace Matrix.PosDef
+
 section
 
 variable {m n : Type*} [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
 variable {Y : Matrix n n ℂ} {W : Matrix n m ℂ}
 
+/-- The Schur-complement compression bound used in the Hansen--Pedersen route to
+operator Jensen: compressing a positive-definite matrix by an isometry makes the
+inverse larger in the Loewner order than the compression of the inverse. -/
 lemma inverse_compression_le
     (hY : Y.PosDef) (hW : Wᴴ * W = (1 : Matrix m m ℂ)) :
     (Wᴴ * Y * W)⁻¹ ≤ Wᴴ * Y⁻¹ * W := by
@@ -61,9 +66,8 @@ lemma inverse_compression_le
   letI : Invertible Y := hY.isUnit.invertible
   letI : Invertible (Wᴴ * Y * W) := hD.isUnit.invertible
   have hBlock : (Matrix.fromBlocks Y⁻¹ W Wᴴ (Wᴴ * Y * W)).PosSemidef := by
-    have hZero : ((Wᴴ * Y * W) - Wᴴ * (Y⁻¹)⁻¹ * W).PosSemidef := by
+    exact (Matrix.PosDef.fromBlocks₁₁ (B := W) (D := Wᴴ * Y * W) hY.inv).2 <| by
       simpa using (Matrix.PosSemidef.zero : (0 : Matrix m m ℂ).PosSemidef)
-    exact (Matrix.PosDef.fromBlocks₁₁ (B := W) (D := Wᴴ * Y * W) hY.inv).2 hZero
   have hSchur : (Y⁻¹ - W * (Wᴴ * Y * W)⁻¹ * Wᴴ).PosSemidef := by
     exact (Matrix.PosDef.fromBlocks₂₂ (A := Y⁻¹) (B := W) hD).1 hBlock
   rw [Matrix.le_iff]
@@ -82,6 +86,10 @@ lemma inverse_compression_le
 
 end
 
+end Matrix.PosDef
+
+namespace TNLean.OperatorJensen
+
 section POVM
 
 variable {D : ℕ} {ι : Type*} [Fintype ι] [DecidableEq ι]
@@ -91,16 +99,24 @@ local notation "AuxIx" => ((ι × Fin D) ⊕ Fin D)
 local notation "IsoMat" => Matrix AuxIx (Fin D) ℂ
 local notation "AuxMat" => Matrix AuxIx AuxIx ℂ
 
-noncomputable def povmIsometry (C : ι → MatD) (S : MatD) : IsoMat
+/-- The block matrix whose rows are the adjoints of a finite family `C i`
+together with a defect block `S`; this is the standard isometric dilation used
+to encode a finite POVM. -/
+def povmIsometry (C : ι → MatD) (S : MatD) : IsoMat
   | Sum.inl ⟨i, p⟩, q => star (C i q p)
   | Sum.inr p, q => star (S q p)
 
-noncomputable def povmDiagonal (w : ι → ℝ) (t : ℝ) : AuxMat :=
+/-- The scalar block-diagonal matrix whose `ι`-blocks carry the weights `w i`
+and whose defect block carries the scalar `t`. -/
+def povmDiagonal (w : ι → ℝ) (t : ℝ) : AuxMat :=
   Matrix.diagonal fun
     | Sum.inl ⟨i, _⟩ => ((w i : ℝ) : ℂ)
     | Sum.inr _ => (t : ℂ)
 
 omit [DecidableEq ι] in
+/-- If the defect block closes the finite POVM relation
+`∑ i, C i * (C i)ᴴ + S * Sᴴ = 1`, then the dilation matrix `povmIsometry C S`
+is an isometry. -/
 lemma povmIsometry_star_mul
     {C : ι → MatD} {S : MatD}
     (hdef : S * Sᴴ = 1 - ∑ i, C i * (C i)ᴴ) :
@@ -125,43 +141,64 @@ lemma povmIsometry_star_mul
       rw [hsum]
       ring
 
+/-- Compressing the scalar block-diagonal matrix `povmDiagonal w t` by the POVM
+dilation produces the weighted sum of the POVM blocks and the defect block. -/
 lemma povmIsometry_compress_diagonal
     {C : ι → MatD} {S : MatD} (w : ι → ℝ) (t : ℝ) :
     (povmIsometry C S)ᴴ * povmDiagonal w t * povmIsometry C S =
       (∑ i, w i • (C i * (C i)ᴴ)) + t • (S * Sᴴ) := by
   ext r s
-  simp [povmIsometry, povmDiagonal, Matrix.mul_apply, Matrix.diagonal_apply,
-    Fintype.sum_sum_type, Fintype.sum_prod_type, Matrix.conjTranspose_apply,
-    mul_comm, mul_left_comm, mul_assoc]
-  rw [Matrix.sum_apply]
-  simp [Matrix.smul_apply, Matrix.mul_apply]
   have hMain :
-      ∑ x, ∑ x_1, C x r x_1 * (↑(w x) * (starRingEnd ℂ) (C x s x_1)) =
+      ∑ x, ∑ x_1, C x r x_1 * ↑(w x) * (starRingEnd ℂ) (C x s x_1) =
         ∑ x, ↑(w x) * ∑ x_1, C x r x_1 * (starRingEnd ℂ) (C x s x_1) := by
     refine Finset.sum_congr rfl ?_
-    intro x hx
-    have hterm :
-        ∀ x_1 : Fin D,
-          C x r x_1 * (↑(w x) * (starRingEnd ℂ) (C x s x_1)) =
-            ↑(w x) * (C x r x_1 * (starRingEnd ℂ) (C x s x_1)) := by
-      intro x_1
-      ring
-    simp_rw [hterm]
-    rw [Finset.mul_sum]
+    intro x _
+    calc
+      ∑ x_1, C x r x_1 * ↑(w x) * (starRingEnd ℂ) (C x s x_1)
+          = ∑ x_1, ↑(w x) * (C x r x_1 * (starRingEnd ℂ) (C x s x_1)) := by
+              refine Finset.sum_congr rfl ?_
+              intro x_1 _
+              ring
+      _ = ↑(w x) * ∑ x_1, C x r x_1 * (starRingEnd ℂ) (C x s x_1) := by
+            simpa using
+              (Finset.mul_sum
+                (s := Finset.univ)
+                (f := fun x_1 : Fin D => C x r x_1 * (starRingEnd ℂ) (C x s x_1))
+                (a := (↑(w x) : ℂ))).symm
   have hDefect :
-      ∑ x, S r x * (↑t * (starRingEnd ℂ) (S s x)) =
+      ∑ x, S r x * ↑t * (starRingEnd ℂ) (S s x) =
         ↑t * ∑ x, S r x * (starRingEnd ℂ) (S s x) := by
-    have hterm :
-        ∀ x : Fin D,
-          S r x * (↑t * (starRingEnd ℂ) (S s x)) =
-            ↑t * (S r x * (starRingEnd ℂ) (S s x)) := by
-      intro x
-      ring
-    simp_rw [hterm]
-    rw [Finset.mul_sum]
-  rw [hMain, hDefect]
+    calc
+      ∑ x, S r x * ↑t * (starRingEnd ℂ) (S s x)
+          = ∑ x, ↑t * (S r x * (starRingEnd ℂ) (S s x)) := by
+              refine Finset.sum_congr rfl ?_
+              intro x _
+              ring
+      _ = ↑t * ∑ x, S r x * (starRingEnd ℂ) (S s x) := by
+            simpa using
+              (Finset.mul_sum
+                (s := Finset.univ)
+                (f := fun x : Fin D => S r x * (starRingEnd ℂ) (S s x))
+                (a := (↑t : ℂ))).symm
+  suffices
+      ∑ x, ∑ x_1, C x r x_1 * ↑(w x) * (starRingEnd ℂ) (C x s x_1) +
+          ∑ x, S r x * ↑t * (starRingEnd ℂ) (S s x) =
+        ∑ x, w x • ∑ j, C x r j * (C x)ᴴ j s + ↑t * ∑ x, S r x * (starRingEnd ℂ) (S s x) by
+    simpa [povmIsometry, povmDiagonal, Matrix.mul_apply, Matrix.diagonal_apply,
+      Fintype.sum_sum_type, Fintype.sum_prod_type, Matrix.conjTranspose_apply,
+      Matrix.sum_apply, Matrix.smul_apply] using this
+  calc
+    ∑ x, ∑ x_1, C x r x_1 * ↑(w x) * (starRingEnd ℂ) (C x s x_1) +
+        ∑ x, S r x * ↑t * (starRingEnd ℂ) (S s x)
+      = (∑ x, ↑(w x) * ∑ x_1, C x r x_1 * (starRingEnd ℂ) (C x s x_1)) +
+          ↑t * ∑ x, S r x * (starRingEnd ℂ) (S s x) := by
+            rw [hMain, hDefect]
+    _ = ∑ x, w x • ∑ j, C x r j * (C x)ᴴ j s + ↑t * ∑ x, S r x * (starRingEnd ℂ) (S s x) := by
+          simp [Matrix.conjTranspose_apply]
 
 omit [DecidableEq ι] in
+/-- Rewriting the defect relation gives the more symmetric identity
+`∑ i, C i * (C i)ᴴ + S * Sᴴ = 1`. -/
 lemma povm_sum_add_defect
     {C : ι → MatD} {S : MatD}
     (hdef : S * Sᴴ = 1 - ∑ i, C i * (C i)ᴴ) :
@@ -178,6 +215,8 @@ lemma povm_sum_add_defect
     _ = (1 : MatD) r s := by ring
 
 omit [Fintype ι] in
+/-- If every weight on the diagonal blocks is strictly positive, then the scalar
+block-diagonal matrix `povmDiagonal w t` is positive definite. -/
 lemma povmDiagonal_posDef (w : ι → ℝ) {t : ℝ}
     (ht : 0 < t) (hw : ∀ i, 0 < w i) :
     Matrix.PosDef (povmDiagonal (D := D) w t) := by
@@ -197,3 +236,5 @@ lemma povmDiagonal_posDef (w : ι → ℝ) {t : ℝ}
   simpa [povmDiagonal, d] using hdiag
 
 end POVM
+
+end TNLean.OperatorJensen

--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.CStarAlgebra.Matrix
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.LinearAlgebra.Matrix.PosDef
+
+/-!
+# Finite-POVM compression lemmas for operator Jensen
+
+This file records algebraic lemmas for the finite-POVM / compression route to
+operator Jensen inequalities. The main target is the concave real-power case in
+Wolf Corollary 5.2, but the final Löwner-integral packaging is still absent.
+
+## Main statements
+
+- `inverse_compression_le`: inverse of a compression is bounded by the
+  compression of the inverse.
+- `povmIsometry`: the isometric dilation attached to a finite PSD family and its
+  defect block.
+- `povmIsometry_star_mul`: the dilation is an isometry.
+- `povmIsometry_compress_diagonal`: compressing a scalar block-diagonal matrix
+  yields the expected weighted POVM sum.
+- `povm_sum_add_defect`: the POVM family plus defect block sums to the identity.
+- `povmDiagonal_posDef`: positivity of the scalar block-diagonal matrix used in
+  the resolvent step.
+
+## Status
+
+These lemmas formalize the compression / finite-POVM half of the direct proof
+route for the concave real-power Jensen inequality. The remaining unfinished
+step is the explicit diagonal-inverse rewrite together with the final algebraic
+rearrangement to the resolvent inequality.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+noncomputable section
+
+attribute [local instance] Matrix.instL2OpNormedAddCommGroup
+attribute [local instance] Matrix.instL2OpNormedRing
+attribute [local instance] Matrix.instL2OpNormedAlgebra
+
+section
+
+variable {m n : Type*} [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
+variable {Y : Matrix n n ℂ} {W : Matrix n m ℂ}
+
+lemma inverse_compression_le
+    (hY : Y.PosDef) (hW : Wᴴ * W = (1 : Matrix m m ℂ)) :
+    (Wᴴ * Y * W)⁻¹ ≤ Wᴴ * Y⁻¹ * W := by
+  have hWinj : Function.Injective W.mulVec := by
+    intro x y hxy
+    have hxy' := congrArg (fun z : n → ℂ => Wᴴ *ᵥ z) hxy
+    simpa [Matrix.mulVec_mulVec, hW] using hxy'
+  have hD : (Wᴴ * Y * W).PosDef :=
+    hY.conjTranspose_mul_mul_same hWinj
+  letI : Invertible Y := hY.isUnit.invertible
+  letI : Invertible (Wᴴ * Y * W) := hD.isUnit.invertible
+  have hBlock : (Matrix.fromBlocks Y⁻¹ W Wᴴ (Wᴴ * Y * W)).PosSemidef := by
+    have hZero : ((Wᴴ * Y * W) - Wᴴ * (Y⁻¹)⁻¹ * W).PosSemidef := by
+      simpa using (Matrix.PosSemidef.zero : (0 : Matrix m m ℂ).PosSemidef)
+    exact (Matrix.PosDef.fromBlocks₁₁ (B := W) (D := Wᴴ * Y * W) hY.inv).2 hZero
+  have hSchur : (Y⁻¹ - W * (Wᴴ * Y * W)⁻¹ * Wᴴ).PosSemidef := by
+    exact (Matrix.PosDef.fromBlocks₂₂ (A := Y⁻¹) (B := W) hD).1 hBlock
+  rw [Matrix.le_iff]
+  have hConj : (Wᴴ * (Y⁻¹ - W * (Wᴴ * Y * W)⁻¹ * Wᴴ) * W).PosSemidef :=
+    Matrix.PosSemidef.conjTranspose_mul_mul_same hSchur W
+  have hEq :
+      Wᴴ * (Y⁻¹ - W * (Wᴴ * Y * W)⁻¹ * Wᴴ) * W =
+        Wᴴ * Y⁻¹ * W - (Wᴴ * Y * W)⁻¹ := by
+    calc
+      Wᴴ * (Y⁻¹ - W * (Wᴴ * Y * W)⁻¹ * Wᴴ) * W
+          = Wᴴ * Y⁻¹ * W - Wᴴ * W * (Wᴴ * Y * W)⁻¹ * (Wᴴ * W) := by
+              simp [sub_eq_add_neg, Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc]
+      _ = Wᴴ * Y⁻¹ * W - (Wᴴ * Y * W)⁻¹ := by
+            simp [Matrix.mul_assoc, hW]
+  simpa [hEq] using hConj
+
+end
+
+section POVM
+
+variable {D : ℕ} {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+local notation "MatD" => Matrix (Fin D) (Fin D) ℂ
+local notation "AuxIx" => ((ι × Fin D) ⊕ Fin D)
+local notation "IsoMat" => Matrix AuxIx (Fin D) ℂ
+local notation "AuxMat" => Matrix AuxIx AuxIx ℂ
+
+noncomputable def povmIsometry (C : ι → MatD) (S : MatD) : IsoMat
+  | Sum.inl ⟨i, p⟩, q => star (C i q p)
+  | Sum.inr p, q => star (S q p)
+
+noncomputable def povmDiagonal (w : ι → ℝ) (t : ℝ) : AuxMat :=
+  Matrix.diagonal fun
+    | Sum.inl ⟨i, _⟩ => ((w i : ℝ) : ℂ)
+    | Sum.inr _ => (t : ℂ)
+
+omit [DecidableEq ι] in
+lemma povmIsometry_star_mul
+    {C : ι → MatD} {S : MatD}
+    (hdef : S * Sᴴ = 1 - ∑ i, C i * (C i)ᴴ) :
+    (povmIsometry C S)ᴴ * povmIsometry C S = (1 : MatD) := by
+  ext r s
+  rw [Matrix.mul_apply, Fintype.sum_sum_type]
+  calc
+    (∑ x : ι × Fin D,
+        (povmIsometry C S)ᴴ r (Sum.inl x) * povmIsometry C S (Sum.inl x) s) +
+        ∑ x : Fin D, (povmIsometry C S)ᴴ r (Sum.inr x) * povmIsometry C S (Sum.inr x) s
+      = (∑ i, (C i * (C i)ᴴ) r s) + (S * Sᴴ) r s := by
+          simp [povmIsometry, Matrix.mul_apply, Matrix.conjTranspose_apply,
+            Fintype.sum_prod_type]
+    _ = (1 : MatD) r s := by
+      have hdef' : (S * Sᴴ) r s = (1 : MatD) r s - ∑ i, (C i * (C i)ᴴ) r s := by
+        simpa [Matrix.sub_apply, Matrix.sum_apply] using congrArg (fun M : MatD => M r s) hdef
+      have hsum :
+          (∑ i, (C i * (C i)ᴴ) r s) + (S * Sᴴ) r s =
+            (∑ i, (C i * (C i)ᴴ) r s) +
+              ((1 : MatD) r s - ∑ i, (C i * (C i)ᴴ) r s) :=
+        congrArg (fun z : ℂ => (∑ i, (C i * (C i)ᴴ) r s) + z) hdef'
+      rw [hsum]
+      ring
+
+lemma povmIsometry_compress_diagonal
+    {C : ι → MatD} {S : MatD} (w : ι → ℝ) (t : ℝ) :
+    (povmIsometry C S)ᴴ * povmDiagonal w t * povmIsometry C S =
+      (∑ i, w i • (C i * (C i)ᴴ)) + t • (S * Sᴴ) := by
+  ext r s
+  simp [povmIsometry, povmDiagonal, Matrix.mul_apply, Matrix.diagonal_apply,
+    Fintype.sum_sum_type, Fintype.sum_prod_type, Matrix.conjTranspose_apply,
+    mul_comm, mul_left_comm, mul_assoc]
+  rw [Matrix.sum_apply]
+  simp [Matrix.smul_apply, Matrix.mul_apply]
+  have hMain :
+      ∑ x, ∑ x_1, C x r x_1 * (↑(w x) * (starRingEnd ℂ) (C x s x_1)) =
+        ∑ x, ↑(w x) * ∑ x_1, C x r x_1 * (starRingEnd ℂ) (C x s x_1) := by
+    refine Finset.sum_congr rfl ?_
+    intro x hx
+    have hterm :
+        ∀ x_1 : Fin D,
+          C x r x_1 * (↑(w x) * (starRingEnd ℂ) (C x s x_1)) =
+            ↑(w x) * (C x r x_1 * (starRingEnd ℂ) (C x s x_1)) := by
+      intro x_1
+      ring
+    simp_rw [hterm]
+    rw [Finset.mul_sum]
+  have hDefect :
+      ∑ x, S r x * (↑t * (starRingEnd ℂ) (S s x)) =
+        ↑t * ∑ x, S r x * (starRingEnd ℂ) (S s x) := by
+    have hterm :
+        ∀ x : Fin D,
+          S r x * (↑t * (starRingEnd ℂ) (S s x)) =
+            ↑t * (S r x * (starRingEnd ℂ) (S s x)) := by
+      intro x
+      ring
+    simp_rw [hterm]
+    rw [Finset.mul_sum]
+  rw [hMain, hDefect]
+
+omit [DecidableEq ι] in
+lemma povm_sum_add_defect
+    {C : ι → MatD} {S : MatD}
+    (hdef : S * Sᴴ = 1 - ∑ i, C i * (C i)ᴴ) :
+    (∑ i, C i * (C i)ᴴ) + S * Sᴴ = (1 : MatD) := by
+  ext r s
+  have hdef' : (S * Sᴴ) r s = (1 : MatD) r s - ∑ i, (C i * (C i)ᴴ) r s := by
+    simpa [Matrix.sub_apply, Matrix.sum_apply] using congrArg (fun M : MatD => M r s) hdef
+  calc
+    ((∑ i, C i * (C i)ᴴ) + S * Sᴴ) r s
+        = (∑ i, (C i * (C i)ᴴ) r s) + (S * Sᴴ) r s := by
+            simp [Matrix.add_apply, Matrix.sum_apply]
+    _ = (∑ i, (C i * (C i)ᴴ) r s) + ((1 : MatD) r s - ∑ i, (C i * (C i)ᴴ) r s) := by
+          rw [hdef']
+    _ = (1 : MatD) r s := by ring
+
+omit [Fintype ι] in
+lemma povmDiagonal_posDef (w : ι → ℝ) {t : ℝ}
+    (ht : 0 < t) (hw : ∀ i, 0 < w i) :
+    Matrix.PosDef (povmDiagonal (D := D) w t) := by
+  let d : AuxIx → ℂ := fun a =>
+    match a with
+    | Sum.inl ip => ((w ip.1 : ℝ) : ℂ)
+    | Sum.inr _ => (t : ℂ)
+  have hdiag : (Matrix.diagonal d).PosDef := by
+    refine Matrix.PosDef.diagonal ?_
+    intro a
+    cases a with
+    | inl ip =>
+        rcases ip with ⟨i, p⟩
+        simpa [d, Complex.lt_def] using hw i
+    | inr p =>
+        simpa [d, Complex.lt_def] using ht
+  simpa [povmDiagonal, d] using hdiag
+
+end POVM

--- a/audits/2026-04-23_issue138_op_convexity_blocker_v2.md
+++ b/audits/2026-04-23_issue138_op_convexity_blocker_v2.md
@@ -1,0 +1,202 @@
+# Issue #138 blocker audit v2 — operator Jensen after the 2026-04-23 scratch pass
+
+## Scope
+
+This pass re-opened the remaining Wolf Chapter 5 operator-Jensen gap on top of
+current `origin/main`, after the earlier audit-only PR #711 had already merged.
+The target declarations remain
+
+- `IsPositiveMap.cor52_item1_rpow_of_subunital`
+- `IsPositiveMap.cor52_item2_rpow_of_subunital`
+- `IsPositiveMap.cor52_item3_log_of_subunital`
+
+from `TNLean/Channel/Schwarz/OperatorMonotone.lean`.
+
+I did **not** land a proof edit to those declarations in this pass. I did,
+however, push the direct finite-POVM route much further than the 2026-04-22
+audit: for the **concave** real-power case, the obstacle now looks less like an
+upstream impossibility and more like a still-unfinished but plausible local
+implementation.
+
+## Re-scout of current Mathlib / TNLean state
+
+### Mathlib still available
+
+The same upstream facts remain available and relevant:
+
+- `CFC.rpow_le_rpow`, `CFC.monotone_rpow`
+- `CFC.log_le_log`, `CFC.log_monotoneOn`
+- `Real.exists_measure_rpow_eq_integral`
+- `CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁`
+- Schur-complement APIs `Matrix.PosDef.fromBlocks₁₁` and
+  `Matrix.PosDef.fromBlocks₂₂`
+- positivity-preserving congruence lemmas such as
+  `Matrix.PosSemidef.mul_mul_conjTranspose_same`
+- positive-definite compression lemma
+  `Matrix.PosDef.conjTranspose_mul_mul_same`
+
+### Mathlib still explicitly missing
+
+The upstream TODOs are unchanged on this toolchain:
+
+- `Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean`
+  lines 24–28 still list
+  - operator concavity of `rpow` on `[0,1]`
+  - operator convexity of `rpow` on `[1,2]`
+- `Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean`
+  lines 26–29 still list operator concavity of `log`
+- I still found **no** bundled Hansen–Pedersen / Choi–Davis operator Jensen
+  theorem for positive (sub)unital maps.
+
+So the general operator-convexity route is still absent upstream.
+
+## What changed in this pass
+
+The 2026-04-22 audit treated the finite-POVM Jensen package purely as a blocker
+statement. In this pass I tried to prove the **concave** finite-POVM real-power
+inequality directly, without introducing a general operator-convexity API.
+
+The proof strategy is:
+
+1. Reduce the finite-POVM family `Bᵢ` with `∑ᵢ Bᵢ ≤ 1` to an isometric
+   compression by adjoining a defect block.
+2. Prove the compression inverse inequality
+   $$
+   (W^\dagger Y W)^{-1} \le W^\dagger Y^{-1} W
+   $$
+   for positive-definite `Y` and an isometry `W`, using the Schur-complement
+   lemmas `Matrix.PosDef.fromBlocks₁₁` and `Matrix.PosDef.fromBlocks₂₂`.
+3. Specialize `Y` to a block-diagonal matrix with diagonal entries
+   `λᵢ + t` and `t`, obtaining the finite-POVM resolvent inequality
+   $$
+   \left(\sum_i \lambda_i B_i + t I\right)^{-1}
+   \le
+   \sum_i (\lambda_i + t)^{-1} B_i + t^{-1}\!\left(I - \sum_i B_i\right).
+   $$
+4. Rearrange this into the Jensen inequality for the Löwner integrand
+   $$
+   x \mapsto t^p\bigl(t^{-1} - (t+x)^{-1}\bigr)
+   = \operatorname{rpowIntegrand}_{0,1}(p,t,x),
+   $$
+   then integrate against the measure supplied by
+   `Real.exists_measure_rpow_eq_integral` /
+   `CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁`.
+
+## Concrete scratch progress
+
+In a local scratch file (not committed), I successfully formalized the following
+core lemmas for the direct finite-POVM route:
+
+- `inverse_compression_le`
+- `povmIsometry_star_mul`
+- `povmIsometry_compress_diagonal`
+- `povmDiagonal_posDef`
+- `povmDiagonal_inv`
+- `povm_resolvent_inv_le`
+
+In other words: the **resolvent/compression** half of the concave real-power
+argument now appears formalizable in the current repository.
+
+## What is still unfinished
+
+I did **not** finish the full chain to a committed theorem. The remaining work
+for the concave real-power branch is now more specific:
+
+1. **Committed finite-POVM packaging**
+   - turn the scratch dilation / defect construction into clean reusable lemmas
+   - connect it to the spectral decomposition `A = ∑ᵢ λᵢ Pᵢ` in the actual
+     `IsPositiveMap.rpow_concave_jensen` proof
+
+2. **Integral-to-`rpow` closing step**
+   - either rewrite the matrix resolvent integrand directly as
+     `cfcₙ (rpowIntegrand₀₁ p t)`
+   - or set up the scalar/matrix integral comparison carefully enough to invoke
+     the existing `exists_measure_*_integral_*` results without introducing a
+     fake order-by-Bochner step
+
+3. **Endpoint hygiene / theorem packaging**
+   - split off `p = 0` and `p = 1`
+   - rewrite the current axiom-backed theorem surface in
+     `TNLean/Channel/Schwarz/OperatorConvexity.lean`
+
+I stopped before landing this because the remaining integral plumbing was still
+substantial, and I did not want to half-commit a large proof skeleton.
+
+## Consequence for the three Cor. 5.2 declarations
+
+### Updated status assessment
+
+- `cor52_item1_rpow_of_subunital`
+  - **not proved in this pass**
+  - but the direct finite-POVM / Löwner-integral route now looks genuinely
+    plausible with current Mathlib + TNLean
+- `cor52_item2_rpow_of_subunital`
+  - still honestly blocked in this pass
+  - the convex branch `r ∈ [1,2]` still lacks a comparable completed direct
+    argument, and the upstream operator-convexity/Jensen TODOs remain relevant
+- `cor52_item3_log_of_subunital`
+  - still not closed in this pass
+  - likely needs either
+    - a direct logarithmic resolvent integral route, or
+    - a completed concave-`rpow` theorem plus a careful `p → 0+` limit argument
+      and strict-positivity packaging for `T A`
+
+So the honest bottom line is still:
+
+- item 1: **not yet closed**
+- item 2: **not yet closed**
+- item 3: **not yet closed**
+
+but the reason is now more nuanced than in the previous audit: the **concave
+real-power** case may no longer be fundamentally blocked by upstream absence of
+a general operator Jensen theorem.
+
+## Revised blocker picture
+
+### Still-upstream blockers
+
+These remain real blockers for the broad, reusable API:
+
+- operator concavity of `rpow` in Mathlib
+- operator convexity of `rpow` in Mathlib
+- operator concavity of `log` in Mathlib
+- a general Hansen–Pedersen / Choi–Davis Jensen theorem for positive maps
+
+### Likely local-only bottleneck now
+
+For the specific theorem `posMap_rpow_concave_jensen` / Cor. 5.2(1), the direct
+finite-POVM proof now seems to require **local proof engineering**, not a new
+upstream theorem statement:
+
+- a clean finite-POVM dilation API
+- diagonal inverse bookkeeping
+- matrix/scalar integral comparison plumbing
+
+That is a materially sharper conclusion than the earlier audit.
+
+## Ando–Lieb
+
+Nothing changed on the Ando–Lieb side. The usual integral representation
+$$
+A^s B^{1-s} = \frac{\sin(\pi s)}{\pi} \int_0^\infty t^{s-1} A(A+tB)^{-1}B\,dt
+$$
+and the surrounding operator-mean API are still absent from Mathlib, so the
+Lieb/Ando theorem remains outside reach in this pass.
+
+## Recommended next step
+
+A focused follow-up should now target exactly one theorem:
+
+- `posMap_rpow_concave_jensen`
+
+using the direct finite-POVM route above. The scratch work suggests that the
+hardest algebraic compression step is already under control; the remaining work
+is to package the resolvent inequality and carry the Löwner integral through to
+`rpow` in committed code.
+
+If that lands, then:
+
+- `IsPositiveMap.rpow_concave_jensen` becomes genuine,
+- `cor52_item1_rpow_of_subunital` should collapse immediately,
+- and the repository will have a concrete template for deciding whether the log
+  case can be finished by a `p \to 0+` limit or needs a separate integral proof.

--- a/audits/2026-04-24_issue138_operator_jensen_aux_progress.md
+++ b/audits/2026-04-24_issue138_operator_jensen_aux_progress.md
@@ -1,0 +1,47 @@
+# Issue #138 follow-up — finite-POVM compression auxiliaries (2026-04-24)
+
+This pass did **not** close `posMap_rpow_concave_jensen` or
+`cor52_item1_rpow_of_subunital`.
+
+It did, however, promote a substantial part of the earlier scratch work into
+committed code:
+
+- new module `TNLean/Channel/Schwarz/OperatorJensenAux.lean`
+- `TNLean/Channel/Schwarz/OperatorConvexity.lean` imports the new auxiliary
+  module and records the partial-progress status in its docstring
+
+## New formalized lemmas
+
+The new auxiliary module now proves the compression / finite-POVM half of the
+planned direct route:
+
+- `inverse_compression_le`
+- `povmIsometry`
+- `povmDiagonal`
+- `povmIsometry_star_mul`
+- `povmIsometry_compress_diagonal`
+- `povm_sum_add_defect`
+- `povmDiagonal_posDef`
+
+These are exactly the ingredients needed to turn a finite PSD family with
+`∑ᵢ Bᵢ ≤ 1` into an isometric compression of a scalar block-diagonal matrix.
+
+## What is still missing
+
+The unresolved step is the explicit **diagonal-inverse / resolvent packaging**:
+
+1. rewrite the inverse of the scalar block-diagonal matrix in the exact form
+   needed for the resolvent inequality;
+2. derive the finished finite-POVM resolvent inequality;
+3. carry that pointwise inequality through the Löwner-integral representation
+   to `posMap_rpow_concave_jensen`.
+
+So the branch now contains genuine reusable code for the hard compression step,
+but the Jensen theorem itself remains axiom-backed.
+
+## Checks
+
+- `lake env lean TNLean/Channel/Schwarz/OperatorJensenAux.lean`
+- `lake env lean TNLean/Channel/Schwarz/OperatorMonotone.lean`
+- `lake build`
+- `cd blueprint && leanblueprint checkdecls`

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -817,6 +817,63 @@ logarithm are not developed in this chapter.
 
 \subsection{Operator Jensen inequality for positive maps}
 
+\begin{definition}[Finite-POVM dilation data]\label{def:operator_jensen_povm_aux}
+    \lean{TNLean.OperatorJensen.povmIsometry, TNLean.OperatorJensen.povmDiagonal}
+    \leanok
+    For a finite family of matrices $\{C_i\}_{i \in \iota}$ and a defect block
+    $S$, one forms an isometric dilation whose rows are the adjoints of the
+    matrices $C_i$ together with the adjoint of $S$. One also forms the scalar
+    block-diagonal matrix whose $\iota$-blocks carry prescribed weights and
+    whose defect block carries a single scalar.
+\end{definition}
+
+\begin{lemma}[Compression auxiliary for Jensen]\label{lem:operator_jensen_inverse_compression}
+    \lean{Matrix.PosDef.inverse_compression_le}
+    \leanok
+    Let $Y$ be positive definite and let $W$ be an isometry. Then
+    \[
+        (W^\ast Y W)^{-1} \le W^\ast Y^{-1} W.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply the Schur-complement criterion to the block matrix
+    $\begin{psmallmatrix} Y^{-1} & W \\ W^\ast & W^\ast Y W \end{psmallmatrix}$.
+    The lower-right Schur complement is zero, hence positive semidefinite, and
+    compressing the resulting upper-left Schur complement by $W$ gives the
+    stated inequality.
+\end{proof}
+
+\begin{lemma}[Finite-POVM compression identities]\label{lem:operator_jensen_povm_compression}
+    \lean{TNLean.OperatorJensen.povmIsometry_star_mul, TNLean.OperatorJensen.povmIsometry_compress_diagonal, TNLean.OperatorJensen.povm_sum_add_defect, TNLean.OperatorJensen.povmDiagonal_posDef}
+    \leanok
+    If the defect block satisfies
+    \[
+        S S^\ast = \Id - \sum_{i \in \iota} C_i C_i^\ast,
+    \]
+    then the dilation is an isometry, compressing the weighted scalar
+    block-diagonal matrix gives
+    \[
+        \sum_{i \in \iota} w_i\, C_i C_i^\ast + t\, S S^\ast,
+    \]
+    the defect relation rewrites as
+    \[
+        \sum_{i \in \iota} C_i C_i^\ast + S S^\ast = \Id,
+    \]
+    and strict positivity of all weights implies positivity of the scalar
+    block-diagonal matrix.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand the block matrix multiplication entrywise. The defect identity gives
+    the isometry relation after summing the $\iota$-blocks and the defect block,
+    and the weighted compression identity follows from the same expansion with
+    the scalar diagonal inserted. Positivity of the scalar block-diagonal matrix
+    is immediate from positivity of its diagonal entries.
+\end{proof}
+
 \begin{theorem}[Jensen for concave real powers]\label{thm:posMap_rpow_concave_jensen}
     \lean{posMap_rpow_concave_jensen}
     \notready


### PR DESCRIPTION
## Summary
- add `TNLean/Channel/Schwarz/OperatorJensenAux.lean` with finite-POVM / compression lemmas for the direct operator-Jensen route
- import the new auxiliary module from `OperatorConvexity.lean` and record the partial-progress status in its module docstring
- add an audit note documenting the exact scope and the remaining diagonal-inverse / resolvent step

## What this does **not** finish
This PR does **not** yet discharge
`posMap_rpow_concave_jensen` or `cor52_item1_rpow_of_subunital`.
It formalizes the compression half of the planned proof route, but the final
resolvent / Löwner-integral packaging is still missing.

## Checks
- `lake env lean TNLean/Channel/Schwarz/OperatorJensenAux.lean`
- `lake env lean TNLean/Channel/Schwarz/OperatorMonotone.lean`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new auxiliary math lemmas and documentation/import wiring without changing existing theorems’ statements or behavior (Jensen results remain axiom-backed).
> 
> **Overview**
> Adds a new module `TNLean/Channel/Schwarz/OperatorJensenAux.lean` that formalizes the finite-POVM/isometric-compression toolkit needed for a direct operator-Jensen proof, including `inverse_compression_le` (Schur-complement inverse/compression bound) and POVM dilation/diagonal/compression/positivity lemmas.
> 
> Wires this module into the public surface (`TNLean.lean`) and the Jensen statement file (`OperatorConvexity.lean`), and updates the blueprint/audits to document progress and explicitly note the remaining missing step (diagonal-inverse/resolvent + Löwner-integral packaging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d32a05f913adcf02fecaeaff17c150f3193c7d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->