### PR TITLE
feat(PEPS): package the blocked-middle local-gauge bridge (#820)

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -20,7 +20,7 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 --   local left inverse and the elementary blocking data now live in
 --   `PEPS/VirtualInsertion` and `PEPS/Blocking`, and `localGauge_exists` has
 --   been reduced to the sharper local hypothesis `HasLocalGaugeLift`. The new
---   wrapper `BlockedMiddleGaugeHyp` isolates the exact remaining bridge: build
+--   wrapper `BlockedMiddleGaugeHyp` isolates the exact remaining step: build
 --   the blocked middle tensor, compare it with the 3-site MPS theorem, and
 --   derive that explicit local gauge formula from `SameState`.
 -- * `gauge_unique_mod_edge_scalars` is the repaired endpoint, but its proof
@@ -497,7 +497,7 @@ The local left inverse and the canonical candidate operator now live in
 `PEPS/LocalGauge`. The remaining PEPS-Fundamental-Theorem gap is to prove
 `BlockedMiddleGaugeHyp` from `SameState` via the blocked-middle / three-site-MPS
 reduction, then convert it to `HasLocalGaugeLift` by
-`HasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
+`hasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
 theorem localGauge_exists (A B : Tensor G d)
     (hA : IsVertexInjective A)
     (hDim : A.bondDim = B.bondDim) (v : V)
@@ -530,7 +530,7 @@ theorem gaugeConsistency (A B : Tensor G d)
           gaugeVertex A X v η σ := by
   -- TODO: first derive `BlockedMiddleGaugeHyp A B hA hDim v` from `SameState`
   -- at each vertex via the blocked-middle / three-site-MPS reduction, then use
-  -- `HasLocalGaugeLift_of_blockedMiddleGaugeHyp` to obtain the local gauges.
+  -- `hasLocalGaugeLift_of_blockedMiddleGaugeHyp` to obtain the local gauges.
   -- The key remaining consistency step is: for each edge e = (u,v), the gauges
   -- extracted from u and v must agree as inverse-transposes, with the
   -- orientation convention in `edgeGaugeAt`.

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -19,9 +19,10 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 --   require the full edge-centred reduction from arXiv:1804.04964 §3. The
 --   local left inverse and the elementary blocking data now live in
 --   `PEPS/VirtualInsertion` and `PEPS/Blocking`, and `localGauge_exists` has
---   been reduced to the sharper local hypothesis `HasLocalGaugeLift`, but the
---   blocked middle tensor and the comparison with the 3-site MPS theorem are
---   still missing.
+--   been reduced to the sharper local hypothesis `HasLocalGaugeLift`. The new
+--   wrapper `BlockedMiddleGaugeHyp` isolates the exact remaining bridge: build
+--   the blocked middle tensor, compare it with the 3-site MPS theorem, and
+--   derive that explicit local gauge formula from `SameState`.
 -- * `gauge_unique_mod_edge_scalars` is the repaired endpoint, but its proof
 --   still needs the same blocking infrastructure together with a local
 --   tensor-factor uniqueness lemma for the balanced edge-scalar quotient.
@@ -493,9 +494,10 @@ noncomputable def localTensorEval (A : Tensor G d) (v : V)
 factorized local gauge relation at `v`.
 
 The local left inverse and the canonical candidate operator now live in
-`PEPS/LocalGauge`. The remaining PEPS-Fundamental-Theorem gap is to derive
-`HasLocalGaugeLift` from `SameState` via the blocked-middle / three-site-MPS
-reduction from arXiv:1804.04964 §3. -/
+`PEPS/LocalGauge`. The remaining PEPS-Fundamental-Theorem gap is to prove
+`BlockedMiddleGaugeHyp` from `SameState` via the blocked-middle / three-site-MPS
+reduction, then convert it to `HasLocalGaugeLift` by
+`HasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
 theorem localGauge_exists (A B : Tensor G d)
     (hA : IsVertexInjective A)
     (hDim : A.bondDim = B.bondDim) (v : V)
@@ -526,12 +528,12 @@ theorem gaugeConsistency (A B : Tensor G d)
       ∀ (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
         B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
           gaugeVertex A X v η σ := by
-  -- TODO: first derive `HasLocalGaugeLift A B hA hDim v` from `SameState`
-  -- at each vertex via the blocked-middle / three-site-MPS reduction, then
-  -- combine the resulting local gauges across shared edges. The key remaining
-  -- consistency step is: for each edge e = (u,v), the gauges extracted from u
-  -- and v must agree as inverse-transposes, with the orientation convention in
-  -- `edgeGaugeAt`.
+  -- TODO: first derive `BlockedMiddleGaugeHyp A B hA hDim v` from `SameState`
+  -- at each vertex via the blocked-middle / three-site-MPS reduction, then use
+  -- `HasLocalGaugeLift_of_blockedMiddleGaugeHyp` to obtain the local gauges.
+  -- The key remaining consistency step is: for each edge e = (u,v), the gauges
+  -- extracted from u and v must agree as inverse-transposes, with the
+  -- orientation convention in `edgeGaugeAt`.
   sorry
 
 /-! ### Main theorem -/

--- a/TNLean/PEPS/LocalGauge.lean
+++ b/TNLean/PEPS/LocalGauge.lean
@@ -19,7 +19,9 @@ be shown to
 
 We package those two requirements as `HasLocalGaugeLift`. This isolates the exact
 output still needed from the blocked-middle / three-site-MPS reduction in
-arXiv:1804.04964 §3.
+arXiv:1804.04964 §3, and `HasLocalGaugeLift_of_localGaugeFormula` records the
+final bookkeeping step that turns an explicit local gauge formula into that
+sharper datum.
 -/
 
 open scoped BigOperators Matrix
@@ -140,12 +142,99 @@ structure HasLocalGaugeLift (A B : Tensor G d) (hA : IsVertexInjective A)
             (↑(Xv ie.1) : Matrix (Fin (A.bondDim ie.1)) (Fin (A.bondDim ie.1)) ℂ)
               (η ie) (η' ie)
 
+/-- Any explicit edgewise local gauge formula at `v` yields the sharper datum
+`HasLocalGaugeLift`.
+
+This is the final bookkeeping step after the blocked-middle / three-site-MPS
+reduction: once that reduction produces invertible incident-edge gauges
+realizing the local tensors of `B`, the canonical candidate pulled back through
+`localLeftInverse` is forced to be the same factorized operator. -/
+theorem HasLocalGaugeLift_of_localGaugeFormula (A B : Tensor G d)
+    (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
+    (hLocal :
+      ∃ Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
+        ∀ (η : LocalVirtualConfig A v) (σ : Fin d),
+          B.component v (castLocalVirtualConfig A B hDim v η) σ =
+            ∑ η' : LocalVirtualConfig A v,
+              (∏ ie : IncidentEdge G v,
+                (↑(Xv ie.1) : Matrix (Fin (A.bondDim ie.1))
+                    (Fin (A.bondDim ie.1)) ℂ) (η ie) (η' ie)) *
+                A.component v η' σ) :
+    HasLocalGaugeLift A B hA hDim v := by
+  rcases hLocal with ⟨Xv, hXv⟩
+  refine ⟨?_, ⟨Xv, ?_⟩⟩
+  · intro η
+    let c : LocalVirtualConfig A v → ℂ := fun η' =>
+      ∏ ie : IncidentEdge G v,
+        (↑(Xv ie.1) : Matrix (Fin (A.bondDim ie.1))
+            (Fin (A.bondDim ie.1)) ℂ) (η ie) (η' ie)
+    have hcomp :
+        B.component v (castLocalVirtualConfig A B hDim v η) =
+          localTensorMap A v c := by
+      ext σ
+      simpa [c, localTensorMap, Fintype.linearCombination_apply] using hXv η σ
+    calc
+      localProjector A hA v (B.component v (castLocalVirtualConfig A B hDim v η)) =
+          localProjector A hA v (localTensorMap A v c) := by rw [hcomp]
+      _ = localTensorMap A v c := by simp
+      _ = B.component v (castLocalVirtualConfig A B hDim v η) := by rw [hcomp]
+  · intro η η'
+    let c : LocalVirtualConfig A v → ℂ := fun ξ =>
+      ∏ ie : IncidentEdge G v,
+        (↑(Xv ie.1) : Matrix (Fin (A.bondDim ie.1))
+            (Fin (A.bondDim ie.1)) ℂ) (η ie) (ξ ie)
+    have hcomp :
+        B.component v (castLocalVirtualConfig A B hDim v η) =
+          localTensorMap A v c := by
+      ext σ
+      simpa [c, localTensorMap, Fintype.linearCombination_apply] using hXv η σ
+    have hcand :
+        localGaugeCandidate A B hA hDim v (Pi.single η (1 : ℂ)) = c := by
+      ext ξ
+      calc
+        localGaugeCandidate A B hA hDim v (Pi.single η (1 : ℂ)) ξ =
+            localLeftInverse A hA v
+              (B.component v (castLocalVirtualConfig A B hDim v η)) ξ := by
+              rw [localGaugeCandidate, LinearMap.comp_apply, LinearMap.comp_apply,
+                localTensorMap_castLocalCoeffMap_single]
+        _ = localLeftInverse A hA v (localTensorMap A v c) ξ := by rw [hcomp]
+        _ = c ξ := by simp
+    simpa [c] using congrArg (fun f : LocalVirtualConfig A v → ℂ => f η') hcand
+
+/-- Abstract output expected from the edge-centered blocked-middle / three-site-
+MPS reduction at a vertex.
+
+The remaining open PEPS bridge step should construct this object from
+`SameState`: an incident-edge family of invertible matrices whose local gauge
+formula already reconstructs the local tensors of `B` from those of `A`. The
+next theorem then turns this explicit local formula into `HasLocalGaugeLift`. -/
+structure BlockedMiddleGaugeHyp (A B : Tensor G d) (hA : IsVertexInjective A)
+    (hDim : A.bondDim = B.bondDim) (v : V) : Prop where
+  localGauge_formula :
+    ∃ Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
+      ∀ (η : LocalVirtualConfig A v) (σ : Fin d),
+        B.component v (castLocalVirtualConfig A B hDim v η) σ =
+          ∑ η' : LocalVirtualConfig A v,
+            (∏ ie : IncidentEdge G v,
+              (↑(Xv ie.1) : Matrix (Fin (A.bondDim ie.1))
+                  (Fin (A.bondDim ie.1)) ℂ) (η ie) (η' ie)) *
+              A.component v η' σ
+
+/-- The blocked-middle / three-site-MPS output immediately yields
+`HasLocalGaugeLift`. -/
+theorem HasLocalGaugeLift_of_blockedMiddleGaugeHyp (A B : Tensor G d)
+    (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
+    (hBlocked : BlockedMiddleGaugeHyp A B hA hDim v) :
+    HasLocalGaugeLift A B hA hDim v :=
+  HasLocalGaugeLift_of_localGaugeFormula A B hA hDim v hBlocked.localGauge_formula
+
 /-- Under `HasLocalGaugeLift`, one obtains the factorized local-gauge formula at
 vertex `v`.
 
 This is the honest local endpoint currently available in Lean: the remaining PEPS
-Fundamental-Theorem gap is to derive `HasLocalGaugeLift` from `SameState` via the
-blocked-middle / three-site-MPS reduction. -/
+Fundamental-Theorem gap is to prove `BlockedMiddleGaugeHyp` from `SameState` via
+the blocked-middle / three-site-MPS reduction and then apply
+`HasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
 theorem localGauge_exists_of_liftData (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
     (hLift : HasLocalGaugeLift A B hA hDim v) :

--- a/TNLean/PEPS/LocalGauge.lean
+++ b/TNLean/PEPS/LocalGauge.lean
@@ -17,9 +17,9 @@ be shown to
    `B` lies in the image of `localTensorMap A v`, and
 2. factor into independent edge gauges.
 
-We package those two requirements as `HasLocalGaugeLift`. This isolates the exact
+We record those two requirements as `HasLocalGaugeLift`. This isolates the exact
 output still needed from the blocked-middle / three-site-MPS reduction in
-arXiv:1804.04964 §3, and `HasLocalGaugeLift_of_localGaugeFormula` records the
+arXiv:1804.04964 §3, and `hasLocalGaugeLift_of_localGaugeFormula` records the
 final bookkeeping step that turns an explicit local gauge formula into that
 sharper datum.
 -/
@@ -122,7 +122,7 @@ theorem localGaugeCandidate_apply_single (A B : Tensor G d)
 
 /-- Sharper local hypothesis for PEPS gauge extraction.
 
-This packages exactly the two local outputs still needed from the blocked-middle
+This records exactly the two local outputs still needed from the blocked-middle
 reduction in arXiv:1804.04964 §3:
 
 1. the local components of `B` lie in the image of `localTensorMap A v`, and
@@ -149,7 +149,7 @@ This is the final bookkeeping step after the blocked-middle / three-site-MPS
 reduction: once that reduction produces invertible incident-edge gauges
 realizing the local tensors of `B`, the canonical candidate pulled back through
 `localLeftInverse` is forced to be the same factorized operator. -/
-theorem HasLocalGaugeLift_of_localGaugeFormula (A B : Tensor G d)
+theorem hasLocalGaugeLift_of_localGaugeFormula (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
     (hLocal :
       ∃ Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
@@ -201,40 +201,39 @@ theorem HasLocalGaugeLift_of_localGaugeFormula (A B : Tensor G d)
         _ = c ξ := by simp
     simpa [c] using congrArg (fun f : LocalVirtualConfig A v → ℂ => f η') hcand
 
-/-- Abstract output expected from the edge-centered blocked-middle / three-site-
-MPS reduction at a vertex.
+/-- Abbreviated proposition for the output expected from the edge-centered
+blocked-middle / three-site-MPS reduction at a vertex.
 
-The remaining open PEPS bridge step should construct this object from
-`SameState`: an incident-edge family of invertible matrices whose local gauge
-formula already reconstructs the local tensors of `B` from those of `A`. The
-next theorem then turns this explicit local formula into `HasLocalGaugeLift`. -/
-structure BlockedMiddleGaugeHyp (A B : Tensor G d) (hA : IsVertexInjective A)
-    (hDim : A.bondDim = B.bondDim) (v : V) : Prop where
-  localGauge_formula :
-    ∃ Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
-      ∀ (η : LocalVirtualConfig A v) (σ : Fin d),
-        B.component v (castLocalVirtualConfig A B hDim v η) σ =
-          ∑ η' : LocalVirtualConfig A v,
-            (∏ ie : IncidentEdge G v,
-              (↑(Xv ie.1) : Matrix (Fin (A.bondDim ie.1))
-                  (Fin (A.bondDim ie.1)) ℂ) (η ie) (η' ie)) *
-              A.component v η' σ
+The remaining open PEPS step should prove this proposition from `SameState`:
+an incident-edge family of invertible matrices whose local gauge formula
+already reconstructs the local tensors of `B` from those of `A`. The next
+theorem then turns this explicit local formula into `HasLocalGaugeLift`. -/
+abbrev BlockedMiddleGaugeHyp (A B : Tensor G d) (_hA : IsVertexInjective A)
+    (hDim : A.bondDim = B.bondDim) (v : V) : Prop :=
+  ∃ Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
+    ∀ (η : LocalVirtualConfig A v) (σ : Fin d),
+      B.component v (castLocalVirtualConfig A B hDim v η) σ =
+        ∑ η' : LocalVirtualConfig A v,
+          (∏ ie : IncidentEdge G v,
+            (↑(Xv ie.1) : Matrix (Fin (A.bondDim ie.1))
+                (Fin (A.bondDim ie.1)) ℂ) (η ie) (η' ie)) *
+            A.component v η' σ
 
 /-- The blocked-middle / three-site-MPS output immediately yields
 `HasLocalGaugeLift`. -/
-theorem HasLocalGaugeLift_of_blockedMiddleGaugeHyp (A B : Tensor G d)
+theorem hasLocalGaugeLift_of_blockedMiddleGaugeHyp (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
     (hBlocked : BlockedMiddleGaugeHyp A B hA hDim v) :
     HasLocalGaugeLift A B hA hDim v :=
-  HasLocalGaugeLift_of_localGaugeFormula A B hA hDim v hBlocked.localGauge_formula
+  hasLocalGaugeLift_of_localGaugeFormula A B hA hDim v hBlocked
 
 /-- Under `HasLocalGaugeLift`, one obtains the factorized local-gauge formula at
 vertex `v`.
 
-This is the honest local endpoint currently available in Lean: the remaining PEPS
+This is the current local endpoint available in Lean: the remaining PEPS
 Fundamental-Theorem gap is to prove `BlockedMiddleGaugeHyp` from `SameState` via
 the blocked-middle / three-site-MPS reduction and then apply
-`HasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
+`hasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
 theorem localGauge_exists_of_liftData (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
     (hLift : HasLocalGaugeLift A B hA hDim v) :

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1599,7 +1599,7 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \leanok
     \uses{def:peps_localTensorMap, def:peps_localLeftInverse}
     For fixed $A$, $B$, a bond-dimension equality, and a vertex $v$, this
-    packages the two local conclusions still needed from the blocked-middle
+    records the two local conclusions still needed from the blocked-middle
     reduction in~\cite{Molnar2018NormalPEPS}, §3:
     (i) each local component of $B$ lies in the image of the local tensor map
     of $A$, and (ii) the canonical pullback through the chosen left inverse of
@@ -1611,15 +1611,15 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \lean{TNLean.PEPS.BlockedMiddleGaugeHyp}
     \leanok
     \uses{def:peps_hasLocalGaugeLift}
-    This packages the explicit local gauge formula that the edge-centered
+    This states the explicit local gauge formula that the edge-centered
     blocked-middle reduction is expected to produce: a family of invertible
     matrices on the incident edges of $v$ whose product kernel reconstructs each
     local component of $B$ from those of $A$.
 \end{definition}
 
 \begin{theorem}[Blocked-middle output implies sharpened lift]%
-    \label{thm:peps_HasLocalGaugeLift_of_blockedMiddleGaugeHyp}
-    \lean{TNLean.PEPS.HasLocalGaugeLift_of_blockedMiddleGaugeHyp}
+    \label{thm:peps_hasLocalGaugeLift_of_blockedMiddleGaugeHyp}
+    \lean{TNLean.PEPS.hasLocalGaugeLift_of_blockedMiddleGaugeHyp}
     \leanok
     \uses{def:peps_blockedMiddleGaugeHyp, def:peps_hasLocalGaugeLift}
     Any explicit local gauge formula from the blocked-middle reduction yields
@@ -1646,7 +1646,7 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \lean{TNLean.PEPS.BlockedMiddleGaugeHyp} from the global same-state
     hypothesis via the blocked middle tensor and the corresponding three-site
     injective-chain argument, then invoke
-    \lean{TNLean.PEPS.HasLocalGaugeLift_of_blockedMiddleGaugeHyp}.
+    \lean{TNLean.PEPS.hasLocalGaugeLift_of_blockedMiddleGaugeHyp}.
     Under that hypothesis, injectivity on the star neighbourhood provides a
     left inverse that isolates the local edge gauges:
     \[

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1606,15 +1606,47 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     $A$ factorizes as one invertible matrix on each incident edge.
 \end{definition}
 
+\begin{definition}[Blocked-middle local gauge output]%
+    \label{def:peps_blockedMiddleGaugeHyp}
+    \lean{TNLean.PEPS.BlockedMiddleGaugeHyp}
+    \leanok
+    \uses{def:peps_hasLocalGaugeLift}
+    This packages the explicit local gauge formula that the edge-centered
+    blocked-middle reduction is expected to produce: a family of invertible
+    matrices on the incident edges of $v$ whose product kernel reconstructs each
+    local component of $B$ from those of $A$.
+\end{definition}
+
+\begin{theorem}[Blocked-middle output implies sharpened lift]%
+    \label{thm:peps_HasLocalGaugeLift_of_blockedMiddleGaugeHyp}
+    \lean{TNLean.PEPS.HasLocalGaugeLift_of_blockedMiddleGaugeHyp}
+    \leanok
+    \uses{def:peps_blockedMiddleGaugeHyp, def:peps_hasLocalGaugeLift}
+    Any explicit local gauge formula from the blocked-middle reduction yields
+    \lean{TNLean.PEPS.HasLocalGaugeLift}. The remaining open step is therefore
+    to build \lean{TNLean.PEPS.BlockedMiddleGaugeHyp} from
+    \lean{TNLean.PEPS.SameState}.
+\end{theorem}
+\begin{proof}\leanok
+    The explicit local gauge formula already places each local component of
+    $B$ in the image of the local tensor map of $A$. Applying the chosen left
+    inverse of $A$ identifies the canonical candidate with the same factorized
+    coefficient kernel, so both fields of
+    \lean{TNLean.PEPS.HasLocalGaugeLift} follow.
+\end{proof}
+
 \begin{theorem}[Local gauge extraction]%
     \label{thm:localGauge_exists}
     \lean{TNLean.PEPS.localGauge_exists}
     \notready
-    \uses{def:peps_hasLocalGaugeLift, def:localTensorEval}
+    \uses{def:peps_hasLocalGaugeLift, def:peps_blockedMiddleGaugeHyp,
+        def:localTensorEval}
     Lean now proves the local gauge formula from the sharper hypothesis
-    \lean{TNLean.PEPS.HasLocalGaugeLift}. What remains open is to derive this
-    local lift datum from the global same-state hypothesis via the blocked
-    middle tensor and the corresponding three-site injective-chain argument.
+    \lean{TNLean.PEPS.HasLocalGaugeLift}. What remains open is to derive
+    \lean{TNLean.PEPS.BlockedMiddleGaugeHyp} from the global same-state
+    hypothesis via the blocked middle tensor and the corresponding three-site
+    injective-chain argument, then invoke
+    \lean{TNLean.PEPS.HasLocalGaugeLift_of_blockedMiddleGaugeHyp}.
     Under that hypothesis, injectivity on the star neighbourhood provides a
     left inverse that isolates the local edge gauges:
     \[


### PR DESCRIPTION
## Summary
- prove `TNLean.PEPS.HasLocalGaugeLift_of_localGaugeFormula`, showing that any explicit incident-edge local gauge formula already yields `HasLocalGaugeLift`
- add `TNLean.PEPS.BlockedMiddleGaugeHyp` and `TNLean.PEPS.HasLocalGaugeLift_of_blockedMiddleGaugeHyp` as the honest wrapper for the blocked-middle / three-site-MPS reduction
- update the PEPS FT comments and blueprint so the remaining gap is stated sharply as deriving `BlockedMiddleGaugeHyp` from `SameState`

## Why this is the right forward step
PR #816 isolated `HasLocalGaugeLift` as the missing local PEPS datum. This PR does **not** yet construct the blocked-middle tensor or prove the `SameState -> BlockedMiddleGaugeHyp` bridge. Instead, it formalizes the last identification step after the three-site MPS reduction: once that reduction produces the explicit local edge gauges, Lean can now convert them into the PEPS-side lift datum with no further `sorry`.

## Verification
- `lake env lean TNLean/PEPS/LocalGauge.lean`
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`
- `lake env lean TNLean.lean`
- `lake build TNLean.PEPS.LocalGauge TNLean.PEPS.FundamentalTheorem TNLean`
- `lake build`
- `rg -n "sorry|axiom" TNLean/PEPS/`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`

## Links
- progress on #820
- follow-up to #780
- downstream of #809 and #816

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR mostly adds a new lemma/abstraction layer and updates documentation/comments; it doesn’t change core PEPS state/gauge definitions or remove any existing proof obligations.
> 
> **Overview**
> Introduces `hasLocalGaugeLift_of_localGaugeFormula`, showing that an explicit factorized incident-edge gauge reconstruction of `B.component` at a vertex is sufficient to produce the sharper hypothesis `HasLocalGaugeLift`.
> 
> Adds `BlockedMiddleGaugeHyp` (the expected blocked-middle / three-site-MPS output) plus `hasLocalGaugeLift_of_blockedMiddleGaugeHyp` as the one-step conversion, and updates PEPS Fundamental Theorem scaffolding comments and the blueprint to state the remaining gap as proving `SameState → BlockedMiddleGaugeHyp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8cb2a000384ddc3caa3fc261c98488213e8a9aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->