### PR TITLE
feat(MPS/CanonicalForm): heterogeneous BNT-sector endpoint toward Gap §1 closure (#824)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -70,11 +70,13 @@ Gap §1 content is now more specific:
 - a **general BNT sector construction** for the blocked output, matching the
   paper's basis-of-normal-tensors decomposition rather than only the restricted
   norm-class-collapse theorem `exists_bnt_grouping`, and
-- a **heterogeneous sector comparison theorem** matching two such BNT sector
-  decompositions up to permutation, gauge phase, and sector-weight multisets.
+- a **witness-producing heterogeneous sector comparison theorem** deriving the
+  basis permutation, gauge-phase data, and copy alignment for two such BNT
+  sector decompositions from arbitrary `SameMPV₂`.
 
-Those sector-level endpoint theorems are documented below but are not yet
-formalized.
+The downstream algebraic reduction after a matched basis is now formalized by
+`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`, but
+the full witness-producing sector endpoint is still missing.
 -/
 
 section FundamentalTheorem1606
@@ -256,12 +258,15 @@ endpoint. The remaining formalizations are now:
    `exists_bnt_grouping`, which only collapses norm classes already known to
    represent one MPV family.
 
-2. **Heterogeneous sector comparison**: if two such BNT sector decompositions
-   have equal total MPVs, first match their basis tensors up to permutation and
-   gauge phase, and then compare the sector-weight multisets after absorbing the
-   phases. The current theorem
-   `fundamentalTheorem_equalMPV_sectorDecomposition` only handles the shared-basis
-   subcase after this matching has already been done.
+2. **Witness-producing heterogeneous sector comparison**: the algebraic
+   reduction from a matched basis to per-sector weight multiset equality is now
+   formalized by
+   `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`
+   (with phase-match core
+   `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch`).
+   What is still missing is the theorem that derives the needed basis
+   permutation, gauge-phase data, and copy alignment from arbitrary equal total
+   MPVs of two sector decompositions.
 
 3. **Final global assembly**: once steps 1–2 are available, combine them with the
    already-formalized common-period blocking, blocked irreducibility,

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -268,7 +268,7 @@ endpoint. The remaining formalizations are now:
    permutation, gauge-phase data, and copy alignment from arbitrary equal total
    MPVs of two sector decompositions.
 
-3. **Final global assembly**: once steps 1–2 are available, combine them with the
+3. **Final global construction**: once steps 1–2 are available, combine them with the
    already-formalized common-period blocking, blocked irreducibility,
    `isNormal_of_tp_primitive_irreducible`, and the global gauge construction of
    the equal-case FT.

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -430,13 +430,49 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
   intro j
   simpa [T] using hMultiset j
 
+/-- **Cast-compatible MPV scaling implies the phase-matched heterogeneous sector comparison.**
+
+This intermediate wrapper isolates the weaker data actually consumed by the
+phase-absorption argument: after matching basis dimensions, each block pair only needs a nonzero
+phase `ζ` relating the MPVs of the matched basis tensors. -/
+theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis
+    (P Q : SectorDecomposition d)
+    (perm : Fin P.basisCount ≃ Fin Q.basisCount)
+    (hCopies : ∀ j : Fin P.basisCount, P.copies j = Q.copies (perm j))
+    (hBasis : ∀ j : Fin P.basisCount,
+      ∃ hdim : P.basisDim j = Q.basisDim (perm j),
+        ∃ ζ : ℂ, ζ ≠ 0 ∧
+          ∀ (N : ℕ) (σ : Fin N → Fin d),
+            mpv (Q.basis (perm j)) σ =
+              ζ ^ N * mpv (cast (congr_arg (MPSTensor d) hdim) (P.basis j)) σ)
+    (hLI : ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N))
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ ζ : Fin P.basisCount → ℂ,
+      (∀ j, ζ j ≠ 0) ∧
+      ∀ j : Fin P.basisCount,
+        Finset.univ.val.map (P.weight j) =
+          Finset.univ.val.map
+            (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  have hPhase : ∀ j : Fin P.basisCount,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (Q.basis (perm j)) σ = ζ ^ N * mpv (P.basis j) σ := by
+    intro j
+    obtain ⟨hdim, ζ, hζne, hmpv⟩ := hBasis j
+    refine ⟨ζ, hζne, ?_⟩
+    intro N σ
+    rw [hmpv N σ, mpv_cast_dim hdim (P.basis j) N σ]
+  exact fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
+    P Q perm hCopies hPhase hLI hEqual
+
 /-- **Gauge-phase matched sector bases imply the phase-matched heterogeneous sector comparison.**
 
 This packages the MPV scaling relation obtained from blockwise `GaugePhaseEquiv` and feeds it
-into `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch`. Thus the remaining
-missing ingredients for the full heterogeneous BNT-sector endpoint are not the algebraic
-phase-absorption step below, but the derivation of the basis/copy matching data from arbitrary
-`SameMPV₂` sector decompositions. -/
+into `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis`.
+Thus the remaining missing ingredients for the full heterogeneous BNT-sector endpoint are not
+the algebraic phase-absorption step below, but the derivation of the basis/copy matching data
+from arbitrary `SameMPV₂` sector decompositions. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
     (P Q : SectorDecomposition d)
     (perm : Fin P.basisCount ≃ Fin Q.basisCount)
@@ -455,17 +491,19 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
         Finset.univ.val.map (P.weight j) =
           Finset.univ.val.map
             (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  have hPhase : ∀ j : Fin P.basisCount,
-      ∃ ζ : ℂ, ζ ≠ 0 ∧
+  have hScaling : ∀ j : Fin P.basisCount,
+      ∃ hdim : P.basisDim j = Q.basisDim (perm j),
+        ∃ ζ : ℂ, ζ ≠ 0 ∧
         ∀ (N : ℕ) (σ : Fin N → Fin d),
-          mpv (Q.basis (perm j)) σ = ζ ^ N * mpv (P.basis j) σ := by
+          mpv (Q.basis (perm j)) σ =
+            ζ ^ N * mpv (cast (congr_arg (MPSTensor d) hdim) (P.basis j)) σ := by
     intro j
     obtain ⟨hdim, hGPE⟩ := hBasis j
     obtain ⟨X, ζ, hζne, hX⟩ := hGPE
-    refine ⟨ζ, hζne, ?_⟩
+    refine ⟨hdim, ζ, hζne, ?_⟩
     intro N σ
-    rw [mpv_eq_pow_mul_of_gaugePhase _ _ X ζ hX N σ, mpv_cast_dim hdim (P.basis j) N σ]
-  exact fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
-    P Q perm hCopies hPhase hLI hEqual
+    exact mpv_eq_pow_mul_of_gaugePhase _ _ X ζ hX N σ
+  exact fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis
+    P Q perm hCopies hScaling hLI hEqual
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.SharedInfra.SectorDecomposition
 import TNLean.MPS.BNT.Basic
+import TNLean.MPS.Overlap.CastLemmas
+import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.Algebra.ScalarPowerSumIdentity
 
 import Mathlib.Data.Fintype.BigOperators
@@ -329,5 +331,142 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition
       = mpv (SectorDecomposition.mk g dim basis S).toTensor σ := hExpandS.symm
     _ = mpv (SectorDecomposition.mk g dim basis T).toTensor σ := hEqual N σ
     _ = ∑ j, T.coeff N j * mpv (basis j) σ := hExpandT
+
+/-- **Heterogeneous sector comparison reduces to the shared-basis case after phase matching.**
+
+Assume two sector decompositions `P` and `Q` have basis blocks matched by a permutation `perm`,
+matching copy counts, and per-basis MPV relations
+`mpv (Q.basis (perm j)) σ = ζ_j^N * mpv (P.basis j) σ`. If the total tensors are
+`SameMPV₂`, then after absorbing the phases `ζ_j` into the sector weights on the `Q` side,
+the per-basis sector weight multisets agree.
+
+This is the algebraic core of the heterogeneous BNT-sector endpoint: once a future theorem
+supplies the basis matching and the phase factors, the remaining comparison is exactly the
+shared-basis theorem above. -/
+theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
+    (P Q : SectorDecomposition d)
+    (perm : Fin P.basisCount ≃ Fin Q.basisCount)
+    (hCopies : ∀ j : Fin P.basisCount, P.copies j = Q.copies (perm j))
+    (hPhase : ∀ j : Fin P.basisCount,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (Q.basis (perm j)) σ = ζ ^ N * mpv (P.basis j) σ)
+    (hLI : ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N))
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ ζ : Fin P.basisCount → ℂ,
+      (∀ j, ζ j ≠ 0) ∧
+      ∀ j : Fin P.basisCount,
+        Finset.univ.val.map (P.weight j) =
+          Finset.univ.val.map
+            (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  classical
+  let ζFn : Fin P.basisCount → ℂ := fun j => (hPhase j).choose
+  have hζ_ne : ∀ j : Fin P.basisCount, ζFn j ≠ 0 :=
+    fun j => (hPhase j).choose_spec.1
+  have hζ_mpv : ∀ (j : Fin P.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (Q.basis (perm j)) σ = (ζFn j) ^ N * mpv (P.basis j) σ :=
+    fun j N σ => (hPhase j).choose_spec.2 N σ
+  let T : SectorWeightData P.basisCount := {
+    copies := fun j => Q.copies (perm j)
+    copies_pos := fun j => Q.copies_pos (perm j)
+    weight := fun j q => ζFn j * Q.weight (perm j) q
+    weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j) (Q.weight_ne_zero (perm j) q)
+  }
+  let Q' : SectorDecomposition d := {
+    basisCount := P.basisCount
+    basisDim := P.basisDim
+    basis := P.basis
+    sectors := T
+  }
+  have hTransport : SameMPV₂ Q'.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv Q'.toTensor σ
+          = ∑ j : Fin P.basisCount,
+              ∑ q : Fin (Q.copies (perm j)),
+                (ζFn j * Q.weight (perm j) q) ^ N * mpv (P.basis j) σ := by
+              simpa [Q', T] using Q'.mpv_toTensor_eq_sum_sectors (N := N) σ
+      _ = ∑ j : Fin P.basisCount,
+            ∑ q : Fin (Q.copies (perm j)),
+              (Q.weight (perm j) q) ^ N * mpv (Q.basis (perm j)) σ := by
+            refine Finset.sum_congr rfl fun j _ => ?_
+            refine Finset.sum_congr rfl fun q _ => ?_
+            calc
+              (ζFn j * Q.weight (perm j) q) ^ N * mpv (P.basis j) σ
+                  = (Q.weight (perm j) q) ^ N * ((ζFn j) ^ N * mpv (P.basis j) σ) := by
+                      rw [mul_pow]
+                      ring
+              _ = (Q.weight (perm j) q) ^ N * mpv (Q.basis (perm j)) σ := by
+                      rw [hζ_mpv j N σ]
+      _ = ∑ k : Fin Q.basisCount,
+            ∑ q : Fin (Q.copies k),
+              (Q.weight k q) ^ N * mpv (Q.basis k) σ := by
+            let f : Fin P.basisCount → ℂ := fun j =>
+              ∑ q : Fin (Q.copies (perm j)),
+                (Q.weight (perm j) q) ^ N * mpv (Q.basis (perm j)) σ
+            let g : Fin Q.basisCount → ℂ := fun k =>
+              ∑ q : Fin (Q.copies k),
+                (Q.weight k q) ^ N * mpv (Q.basis k) σ
+            have hfg : ∀ j, f j = g (perm j) := by
+              intro j
+              rfl
+            simpa [f, g] using (Fintype.sum_equiv perm f g hfg)
+      _ = mpv Q.toTensor σ := by
+            simpa using (Q.mpv_toTensor_eq_sum_sectors (N := N) σ).symm
+  have hEqual' : SameMPV₂ P.toTensor Q'.toTensor := by
+    intro N σ
+    rw [hEqual N σ, (hTransport N σ).symm]
+  have hCopies' : ∀ j : Fin P.basisCount, P.sectors.copies j = T.copies j := by
+    intro j
+    simpa [T] using hCopies j
+  have hMultiset :
+      ∀ j : Fin P.basisCount,
+        Finset.univ.val.map (P.weight j) =
+          Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies' j) q)) := by
+    apply fundamentalTheorem_equalMPV_sectorDecomposition (basis := P.basis)
+      P.sectors T hCopies' hLI
+    simpa [Q', T] using hEqual'
+  refine ⟨ζFn, hζ_ne, ?_⟩
+  intro j
+  simpa [T] using hMultiset j
+
+/-- **Gauge-phase matched sector bases imply the phase-matched heterogeneous sector comparison.**
+
+This packages the MPV scaling relation obtained from blockwise `GaugePhaseEquiv` and feeds it
+into `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch`. Thus the remaining
+missing ingredients for the full heterogeneous BNT-sector endpoint are not the algebraic
+phase-absorption step below, but the derivation of the basis/copy matching data from arbitrary
+`SameMPV₂` sector decompositions. -/
+theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
+    (P Q : SectorDecomposition d)
+    (perm : Fin P.basisCount ≃ Fin Q.basisCount)
+    (hCopies : ∀ j : Fin P.basisCount, P.copies j = Q.copies (perm j))
+    (hBasis : ∀ j : Fin P.basisCount,
+      ∃ hdim : P.basisDim j = Q.basisDim (perm j),
+        GaugePhaseEquiv (d := d)
+          (cast (congr_arg (MPSTensor d) hdim) (P.basis j))
+          (Q.basis (perm j)))
+    (hLI : ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N))
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ ζ : Fin P.basisCount → ℂ,
+      (∀ j, ζ j ≠ 0) ∧
+      ∀ j : Fin P.basisCount,
+        Finset.univ.val.map (P.weight j) =
+          Finset.univ.val.map
+            (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  have hPhase : ∀ j : Fin P.basisCount,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (Q.basis (perm j)) σ = ζ ^ N * mpv (P.basis j) σ := by
+    intro j
+    obtain ⟨hdim, hGPE⟩ := hBasis j
+    obtain ⟨X, ζ, hζne, hX⟩ := hGPE
+    refine ⟨ζ, hζne, ?_⟩
+    intro N σ
+    rw [mpv_eq_pow_mul_of_gaugePhase _ _ X ζ hX N σ, mpv_cast_dim hdim (P.basis j) N σ]
+  exact fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
+    P Q perm hCopies hPhase hLI hEqual
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -416,17 +416,16 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
             simpa using (Q.mpv_toTensor_eq_sum_sectors (N := N) σ).symm
   have hEqual' : SameMPV₂ P.toTensor Q'.toTensor := by
     intro N σ
-    rw [hEqual N σ, (hTransport N σ).symm]
+    exact (hEqual N σ).trans (hTransport N σ).symm
   have hCopies' : ∀ j : Fin P.basisCount, P.sectors.copies j = T.copies j := by
     intro j
     simpa [T] using hCopies j
   have hMultiset :
       ∀ j : Fin P.basisCount,
         Finset.univ.val.map (P.weight j) =
-          Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies' j) q)) := by
-    apply fundamentalTheorem_equalMPV_sectorDecomposition (basis := P.basis)
-      P.sectors T hCopies' hLI
-    simpa [Q', T] using hEqual'
+          Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies' j) q)) :=
+      fundamentalTheorem_equalMPV_sectorDecomposition
+        (basis := P.basis) (S := P.sectors) (T := T) hCopies' hLI hEqual'
   refine ⟨ζFn, hζ_ne, ?_⟩
   intro j
   simpa [T] using hMultiset j

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -474,6 +474,35 @@ single weighted block.
 	Theorem~\ref{thm:route_b_hetero_phase_match}.
 \end{proof}
 
+\begin{theorem}[Cast-compatible MPV scaling implies phase-matched sector comparison]%
+\label{thm:route_b_hetero_mpv_scaling}
+	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis}
+	\leanok
+	\uses{def:paper_sector_data}
+	Let $P$ and $Q$ be sector decompositions. Assume there is a permutation
+	$\pi$ matching the basis blocks, the multiplicities satisfy
+	$r_j^P = r_{\pi(j)}^Q$, and for each $j$ the matched basis blocks have the
+	same auxiliary dimension and satisfy
+	\[
+		V^{(N)}(Q_{\pi(j)})_\sigma = \zeta_j^N V^{(N)}(P_j)_\sigma
+	\]
+	for some nonzero complex number $\zeta_j$, after identifying the two basis
+	tensors along that dimension equality. If the total MPV families of $P$
+	and $Q$ agree and the basis blocks of $P$ are eventually linearly
+	independent, then for each $j$ the sector weight multiset of $P_j$ equals
+	the multiset obtained from that of $Q_{\pi(j)}$ by multiplication
+	by~$\zeta_j$.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:route_b_hetero_phase_match}
+	After transporting the matched basis tensor of $P_j$ across the dimension
+	identity, this is exactly the hypothesis of
+	Theorem~\ref{thm:route_b_hetero_phase_match}. The conclusion is therefore
+	the same multiset equality.
+\end{proof}
+
 \begin{remark}[Remaining step in the unconditional equal-case theorem]\notready
 	This chapter provides three complementary equal-case results:
 	\begin{enumerate}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -421,6 +421,59 @@ single weighted block.
 	now aggregated over the multiplicity layers.
 \end{theorem}
 
+\begin{theorem}[Heterogeneous sector comparison after phase matching]%
+\label{thm:route_b_hetero_phase_match}
+	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch}
+	\leanok
+	\uses{def:paper_sector_data}
+	Let $P$ and $Q$ be sector decompositions. Assume there is a permutation
+	$\pi$ matching the basis blocks, the multiplicities satisfy
+	$r_j^P = r_{\pi(j)}^Q$, and for each $j$ there is a nonzero complex number
+	$\zeta_j$ such that
+	\[
+		V^{(N)}(Q_{\pi(j)})_\sigma = \zeta_j^N V^{(N)}(P_j)_\sigma
+	\]
+	for every $N$ and $\sigma$. If the total MPV families of $P$ and $Q$
+	agree and the basis blocks of $P$ are eventually linearly independent,
+	then for each $j$ the sector weight multiset of $P_j$ equals the
+	multiset obtained from that of $Q_{\pi(j)}$ by multiplication by~$\zeta_j$.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:paper_decomp_formula, thm:route_b_equal}
+	Absorb the factors $\zeta_j$ into the sector weights of $Q$ and keep the
+	basis blocks of $P$. The phase-matching hypothesis and the sector
+	decomposition formula show that the resulting decomposition has the same
+	total MPV family as~$Q$, hence also as~$P$. One is then in the
+	shared-basis situation of Theorem~\ref{thm:route_b_equal}, which yields
+	the claimed equality of multisets.
+\end{proof}
+
+\begin{theorem}[Gauge-phase matched bases imply phase-matched sector comparison]%
+\label{thm:route_b_hetero_matched_basis}
+	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis}
+	\leanok
+	\uses{def:paper_sector_data, def:gauge_phase_equiv}
+	Let $P$ and $Q$ be sector decompositions. Assume there is a permutation
+	$\pi$ matching the basis blocks, the multiplicities satisfy
+	$r_j^P = r_{\pi(j)}^Q$, and each matched pair of basis blocks is
+	gauge-phase equivalent. If the total MPV families of $P$ and $Q$ agree
+	and the basis blocks of $P$ are eventually linearly independent, then
+	for each $j$ the sector weight multiset of $P_j$ equals the multiset
+	obtained from that of $Q_{\pi(j)}$ after multiplication by the
+	corresponding gauge phase.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:gauge_phase_mpv_scaling, thm:route_b_hetero_phase_match}
+	Gauge-phase equivalence gives the required phase-scaling identity for the
+	MPVs by Theorem~\ref{thm:gauge_phase_mpv_scaling}. The conclusion then
+	follows immediately from
+	Theorem~\ref{thm:route_b_hetero_phase_match}.
+\end{proof}
+
 \begin{remark}[Remaining step in the unconditional equal-case theorem]\notready
 	This chapter provides three complementary equal-case results:
 	\begin{enumerate}
@@ -445,15 +498,16 @@ single weighted block.
 		      after-blocking output, beyond the current special case where
 		      equal-modulus blocks on one side are already known to collapse
 		      to a single basis tensor; and
-		\item a heterogeneous sector-decomposition comparison theorem:
-		      given two such basis-of-normal-tensors decompositions with the
-		      same total MPV family, first match the basis tensors up to
-		      permutation and gauge phase, and only then compare the sector
-		      weight multisets after absorbing those phases.
+		\item a witness-producing matched-basis theorem for heterogeneous
+		      sector decompositions: the algebraic reduction after a basis
+		      matching is now formalized in
+		      Theorems~\ref{thm:route_b_hetero_phase_match}
+		      and~\ref{thm:route_b_hetero_matched_basis}, but one still needs
+		      a theorem that derives the permutation, multiplicity matching,
+		      and gauge-phase data directly from equality of the total MPV
+		      families.
 	\end{enumerate}
-	The theorem proved above supplies only the shared-basis part of the second
-	item.  Once these two ingredients are in place, the final global gauge matrix
+	Once these two ingredients are in place, the final global gauge matrix
 	of Corollary~IV.5 is obtained by the same phase-absorption and blockwise
-	assembly argument already formalized in the strict single-weight setting.
+	composition argument already formalized in the strict single-weight setting.
 \end{remark}
-


### PR DESCRIPTION
Extends the single-sector BNT endpoint (#818) to the general heterogeneous-sector case for CPSV17 Thm 1 Gap §1 closure. Adds sector-decomposition wrappers in FundamentalTheorem and threads them through the StructuralTheorem assembly, replacing the vacuous SameMPV₂ parameter with a concrete structural reduction.

Follow-up to PR #818 (#652). Resolves #824.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to introducing new nontrivial Lean theorems and dependencies (`GaugePhase`, cast lemmas) that may affect proof stability and downstream compilation, but no runtime/production behavior changes.
> 
> **Overview**
> Formalizes the *heterogeneous* sector-decomposition equal-MPV reduction: given a basis permutation, matched multiplicities, and per-block phase (or `GaugePhaseEquiv`) relations, it proves sector-weight multiset equality after absorbing phases via new theorems `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch`, `_of_mpvScaling_matched_basis`, and `_of_matched_basis`.
> 
> Updates `StructuralTheorem.lean` and the blueprint text to reframe the remaining Gap §1 work: the algebraic “after matched basis” step is now covered, and what remains is the witness-producing theorem that derives the permutation/copy/phase matching data from arbitrary `SameMPV₂` sector decompositions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc67e169838da06b1aa75ea49e727cfd7a48ecf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->