### PR TITLE
fix(MPS/MPDO): expose counterexample to PF rank-one claim (#832)

### DIFF
--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.MPDO.Defs
 import TNLean.Entropy.MarkovChain
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
+import Mathlib.Tactic
 
 /-!
 # Simple MPDO local structure
@@ -23,10 +24,12 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 - `Matrix.HasRankOneFactorization`: a finite matrix factors as `vecMulVec a b`.
 - `Matrix.TracePowersConstant`: all positive powers of a matrix have the same
   trace as the matrix itself.
-- `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the single missing
-  Perron–Frobenius input isolated by Lemma C.4.
+- `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the provisional
+  rank-one placeholder abstracted from Lemma C.4.
+- `Matrix.primitiveTraceCounterexample`: an explicit primitive nonnegative
+  matrix with constant trace powers that is not rank one.
 - `MPOTensor.sal_zcl_implies_rank_one_T`: the scoped Lemma C.4 consequence,
-  proved relative to that Perron–Frobenius input.
+  proved relative to that stronger placeholder input.
 
 ## Implementation note
 
@@ -37,11 +40,13 @@ that inverse-map layer for simple MPDOs, so we formalize the entropic core
 exactly as the Hayashi / Ruskai / Hayden–Jozsa–Petz–Winter decomposition already
 available through `Entropy.QuantumMarkovDecomposition`.
 
-Lemma C.4 is further isolated to the finite-dimensional Perron–Frobenius step:
-for a primitive nonnegative matrix `T`, constant traces of positive powers force
-`T` to have rank one. We expose that step as the single hypothesis
-`Matrix.PrimitiveTracePowersConstantImpliesRankOne`, so the remaining gap is
-honestly localized and matches the paper one-to-one.
+Lemma C.4 was initially isolated to the matrix claim that a primitive
+nonnegative matrix with constant traces of all positive powers must be rank
+one. The explicit declaration `Matrix.primitiveTraceCounterexample` shows that
+this matrix statement is false in full generality. We therefore keep
+`Matrix.PrimitiveTracePowersConstantImpliesRankOne` only as a provisional local
+placeholder for the stronger input that must ultimately be extracted from the
+full ZCL / local-`η` structure.
 
 ## References
 
@@ -69,17 +74,151 @@ Appendix C.2, Lemma C.4. -/
 def TracePowersConstant (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   ∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T
 
-/-- The missing Perron–Frobenius input for Appendix C.2, Lemma C.4:
-for a primitive nonnegative matrix, constant traces of positive powers imply a
-rank-one factorization.
+/-- A provisional rank-one placeholder for Appendix C.2, Lemma C.4.
 
-This is intentionally packaged as a local hypothesis rather than a new global
-assumption. Once a genuine proof is formalized, downstream callers can simply
-supply that theorem here and the scoped result `MPOTensor.sal_zcl_implies_rank_one_T`
-will become unconditional. -/
+The naive matrix statement “primitive + constant trace powers implies rank one”
+is false in general; see `primitiveTraceCounterexample`. We nevertheless keep
+this implication as a local placeholder because `sal_zcl_implies_rank_one_T`
+only needs some stronger input at exactly this point. The eventual replacement
+must come from additional structure in the full ZCL / local-`η` argument, not
+from Perron–Frobenius theory alone. -/
 def PrimitiveTracePowersConstantImpliesRankOne
     (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   Matrix.IsPrimitive T → TracePowersConstant T → HasRankOneFactorization T
+
+/-- A concrete primitive nonnegative matrix with constant trace powers but not a
+rank-one factorization. This shows that
+`PrimitiveTracePowersConstantImpliesRankOne` is not a valid global theorem for
+arbitrary primitive real matrices. -/
+noncomputable def primitiveTraceCounterexample : Matrix (Fin 3) (Fin 3) ℝ :=
+  Matrix.of fun i j =>
+    match i.1, j.1 with
+    | 0, 0 => 0
+    | 0, 1 => 0
+    | 0, 2 => 1 / 2
+    | 1, 0 => 1 / 2
+    | 1, 1 => 1 / 2
+    | 1, 2 => 0
+    | 2, 0 => 1 / 2
+    | 2, 1 => 1 / 2
+    | 2, 2 => 1 / 2
+    | _, _ => 0
+
+@[simp] theorem primitiveTraceCounterexample_sq :
+    primitiveTraceCounterexample ^ 2 =
+      Matrix.of fun i _ : Fin 3 => if i = 2 then (1 / 2 : ℝ) else (1 / 4 : ℝ) := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [primitiveTraceCounterexample, Matrix.of_apply, Matrix.mul_apply,
+      Fin.sum_univ_three, pow_two] <;> norm_num
+
+@[simp] theorem primitiveTraceCounterexample_sq_mul :
+    primitiveTraceCounterexample ^ 2 * primitiveTraceCounterexample =
+      primitiveTraceCounterexample ^ 2 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [primitiveTraceCounterexample, Matrix.of_apply, Matrix.mul_apply,
+      Fin.sum_univ_three, pow_two] <;> norm_num
+
+@[simp] theorem primitiveTraceCounterexample_cube :
+    primitiveTraceCounterexample ^ 3 = primitiveTraceCounterexample ^ 2 := by
+  simpa [pow_succ] using primitiveTraceCounterexample_sq_mul
+
+@[simp] theorem primitiveTraceCounterexample_pow_add_two (m : ℕ) :
+    primitiveTraceCounterexample ^ (m + 2) = primitiveTraceCounterexample ^ 2 := by
+  induction m with
+  | zero =>
+      simp
+  | succ m hm =>
+      calc
+        primitiveTraceCounterexample ^ (Nat.succ m + 2) =
+            primitiveTraceCounterexample ^ (m + 2) * primitiveTraceCounterexample := by
+              simp [Nat.succ_eq_add_one, Nat.add_assoc, pow_succ]
+        _ = primitiveTraceCounterexample ^ 2 * primitiveTraceCounterexample := by rw [hm]
+        _ = primitiveTraceCounterexample ^ 2 := primitiveTraceCounterexample_sq_mul
+
+private theorem primitiveTraceCounterexample_pow_succ_succ (m : ℕ) :
+    primitiveTraceCounterexample ^ Nat.succ (Nat.succ m) = primitiveTraceCounterexample ^ 2 := by
+  induction m with
+  | zero =>
+      simp
+  | succ m hm =>
+      calc
+        primitiveTraceCounterexample ^ Nat.succ (Nat.succ (Nat.succ m)) =
+            primitiveTraceCounterexample ^ Nat.succ (Nat.succ m) *
+              primitiveTraceCounterexample := by
+              simp [pow_succ]
+        _ = primitiveTraceCounterexample ^ 2 * primitiveTraceCounterexample := by rw [hm]
+        _ = primitiveTraceCounterexample ^ 2 := primitiveTraceCounterexample_sq_mul
+
+@[simp] theorem trace_primitiveTraceCounterexample :
+    Matrix.trace primitiveTraceCounterexample = 1 := by
+  simp [primitiveTraceCounterexample, Matrix.of_apply, Matrix.trace, Fin.sum_univ_three]
+  norm_num
+
+@[simp] theorem trace_primitiveTraceCounterexample_sq :
+    Matrix.trace (primitiveTraceCounterexample ^ 2) = 1 := by
+  simp [primitiveTraceCounterexample_sq, Matrix.of_apply, Matrix.trace, Fin.sum_univ_three]
+  norm_num
+
+/-- The explicit matrix `primitiveTraceCounterexample` is primitive because its
+square is entrywise strictly positive. -/
+theorem primitiveTraceCounterexample_isPrimitive :
+    Matrix.IsPrimitive primitiveTraceCounterexample := by
+  refine ⟨?_, 2, by norm_num, ?_⟩
+  · intro i j
+    fin_cases i <;> fin_cases j <;>
+      simp [primitiveTraceCounterexample, Matrix.of_apply]
+  · intro i j
+    fin_cases i <;> fin_cases j <;>
+      simp [primitiveTraceCounterexample_sq, Matrix.of_apply]
+
+/-- The explicit counterexample has constant trace on all positive powers. -/
+theorem primitiveTraceCounterexample_tracePowersConstant :
+    TracePowersConstant primitiveTraceCounterexample := by
+  intro k hk
+  cases k with
+  | zero =>
+      cases (Nat.lt_asymm hk hk)
+  | succ k =>
+      cases k with
+      | zero =>
+          simp
+      | succ k =>
+          calc
+            Matrix.trace (primitiveTraceCounterexample ^ Nat.succ (Nat.succ k)) =
+                Matrix.trace (primitiveTraceCounterexample ^ 2) := by
+                  rw [primitiveTraceCounterexample_pow_succ_succ]
+            _ = 1 := trace_primitiveTraceCounterexample_sq
+            _ = Matrix.trace primitiveTraceCounterexample := by simp
+
+/-- The explicit counterexample is not rank one. -/
+theorem primitiveTraceCounterexample_not_hasRankOneFactorization :
+    ¬ HasRankOneFactorization primitiveTraceCounterexample := by
+  rintro ⟨a, b, hT⟩
+  have h02 : a 0 * b 2 = (1 / 2 : ℝ) := by
+    simpa [primitiveTraceCounterexample, Matrix.vecMulVec_apply] using
+      (congrArg (fun M => M 0 2) hT).symm
+  have ha0 : a 0 ≠ 0 := by
+    intro ha0
+    have : (1 / 2 : ℝ) = 0 := by simpa [ha0] using h02.symm
+    norm_num at this
+  have h00 : a 0 * b 0 = 0 := by
+    simpa [primitiveTraceCounterexample, Matrix.vecMulVec_apply] using
+      (congrArg (fun M => M 0 0) hT).symm
+  have hb0 : b 0 = 0 := Or.resolve_left (mul_eq_zero.mp h00) ha0
+  have h10 : a 1 * b 0 = (1 / 2 : ℝ) := by
+    simpa [primitiveTraceCounterexample, Matrix.vecMulVec_apply] using
+      (congrArg (fun M => M 1 0) hT).symm
+  simp [hb0] at h10
+
+/-- Hence the placeholder implication is false for the explicit counterexample. -/
+theorem primitiveTraceCounterexample_not_pf_input :
+    ¬ PrimitiveTracePowersConstantImpliesRankOne primitiveTraceCounterexample := by
+  intro h
+  exact primitiveTraceCounterexample_not_hasRankOneFactorization
+    (h primitiveTraceCounterexample_isPrimitive
+      primitiveTraceCounterexample_tracePowersConstant)
 
 end Matrix
 
@@ -126,7 +265,8 @@ variable {n : ℕ}
 
 /-- **Lemma C.4, scoped matrix form**: once the matrix `T` attached to the
 local `η`-structure is known to be primitive and to have constant trace on all
-positive powers, the remaining Perron–Frobenius input forces `T` to be rank one.
+positive powers, any additional rank-one input available for that particular
+`T` yields a rank-one factorization.
 
 The normalization `a ⬝ᵥ b = 1` is then immediate from `trace T = 1` and the
 identity `trace (vecMulVec a b) = a ⬝ᵥ b`. -/

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -5,7 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.MPDO.Defs
 import TNLean.Entropy.MarkovChain
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
-import Mathlib.Tactic
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.NormNum
 
 /-!
 # Simple MPDO local structure
@@ -104,7 +105,7 @@ noncomputable def primitiveTraceCounterexample : Matrix (Fin 3) (Fin 3) ℝ :=
     | 2, 2 => 1 / 2
     | _, _ => 0
 
-@[simp] theorem primitiveTraceCounterexample_sq :
+theorem primitiveTraceCounterexample_sq :
     primitiveTraceCounterexample ^ 2 =
       Matrix.of fun i _ : Fin 3 => if i = 2 then (1 / 2 : ℝ) else (1 / 4 : ℝ) := by
   ext i j
@@ -112,7 +113,7 @@ noncomputable def primitiveTraceCounterexample : Matrix (Fin 3) (Fin 3) ℝ :=
     simp [primitiveTraceCounterexample, Matrix.of_apply, Matrix.mul_apply,
       Fin.sum_univ_three, pow_two] <;> norm_num
 
-@[simp] theorem primitiveTraceCounterexample_sq_mul :
+theorem primitiveTraceCounterexample_sq_mul :
     primitiveTraceCounterexample ^ 2 * primitiveTraceCounterexample =
       primitiveTraceCounterexample ^ 2 := by
   ext i j
@@ -120,11 +121,7 @@ noncomputable def primitiveTraceCounterexample : Matrix (Fin 3) (Fin 3) ℝ :=
     simp [primitiveTraceCounterexample, Matrix.of_apply, Matrix.mul_apply,
       Fin.sum_univ_three, pow_two] <;> norm_num
 
-@[simp] theorem primitiveTraceCounterexample_cube :
-    primitiveTraceCounterexample ^ 3 = primitiveTraceCounterexample ^ 2 := by
-  simpa [pow_succ] using primitiveTraceCounterexample_sq_mul
-
-@[simp] theorem primitiveTraceCounterexample_pow_add_two (m : ℕ) :
+theorem primitiveTraceCounterexample_pow_add_two (m : ℕ) :
     primitiveTraceCounterexample ^ (m + 2) = primitiveTraceCounterexample ^ 2 := by
   induction m with
   | zero =>
@@ -137,16 +134,12 @@ noncomputable def primitiveTraceCounterexample : Matrix (Fin 3) (Fin 3) ℝ :=
         _ = primitiveTraceCounterexample ^ 2 * primitiveTraceCounterexample := by rw [hm]
         _ = primitiveTraceCounterexample ^ 2 := primitiveTraceCounterexample_sq_mul
 
-private theorem primitiveTraceCounterexample_pow_succ_succ (m : ℕ) :
-    primitiveTraceCounterexample ^ Nat.succ (Nat.succ m) = primitiveTraceCounterexample ^ 2 :=
-  primitiveTraceCounterexample_pow_add_two m
-
-@[simp] theorem trace_primitiveTraceCounterexample :
+theorem trace_primitiveTraceCounterexample :
     Matrix.trace primitiveTraceCounterexample = 1 := by
   simp [primitiveTraceCounterexample, Matrix.of_apply, Matrix.trace, Fin.sum_univ_three]
   norm_num
 
-@[simp] theorem trace_primitiveTraceCounterexample_sq :
+theorem trace_primitiveTraceCounterexample_sq :
     Matrix.trace (primitiveTraceCounterexample ^ 2) = 1 := by
   simp [primitiveTraceCounterexample_sq, Matrix.of_apply, Matrix.trace, Fin.sum_univ_three]
   norm_num
@@ -169,7 +162,7 @@ theorem primitiveTraceCounterexample_tracePowersConstant :
   intro k hk
   cases k with
   | zero =>
-      cases (Nat.lt_asymm hk hk)
+      exact absurd hk (lt_irrefl 0)
   | succ k =>
       cases k with
       | zero =>
@@ -177,10 +170,13 @@ theorem primitiveTraceCounterexample_tracePowersConstant :
       | succ k =>
           calc
             Matrix.trace (primitiveTraceCounterexample ^ Nat.succ (Nat.succ k)) =
-                Matrix.trace (primitiveTraceCounterexample ^ 2) := by
-                  rw [primitiveTraceCounterexample_pow_succ_succ]
+                Matrix.trace (primitiveTraceCounterexample ^ (k + 2)) := by
+                  rfl
+            _ = Matrix.trace (primitiveTraceCounterexample ^ 2) := by
+                  rw [primitiveTraceCounterexample_pow_add_two]
             _ = 1 := trace_primitiveTraceCounterexample_sq
-            _ = Matrix.trace primitiveTraceCounterexample := by simp
+            _ = Matrix.trace primitiveTraceCounterexample :=
+                  trace_primitiveTraceCounterexample.symm
 
 /-- The explicit counterexample is not rank one. -/
 theorem primitiveTraceCounterexample_not_hasRankOneFactorization :

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -138,18 +138,8 @@ noncomputable def primitiveTraceCounterexample : Matrix (Fin 3) (Fin 3) ℝ :=
         _ = primitiveTraceCounterexample ^ 2 := primitiveTraceCounterexample_sq_mul
 
 private theorem primitiveTraceCounterexample_pow_succ_succ (m : ℕ) :
-    primitiveTraceCounterexample ^ Nat.succ (Nat.succ m) = primitiveTraceCounterexample ^ 2 := by
-  induction m with
-  | zero =>
-      simp
-  | succ m hm =>
-      calc
-        primitiveTraceCounterexample ^ Nat.succ (Nat.succ (Nat.succ m)) =
-            primitiveTraceCounterexample ^ Nat.succ (Nat.succ m) *
-              primitiveTraceCounterexample := by
-              simp [pow_succ]
-        _ = primitiveTraceCounterexample ^ 2 * primitiveTraceCounterexample := by rw [hm]
-        _ = primitiveTraceCounterexample ^ 2 := primitiveTraceCounterexample_sq_mul
+    primitiveTraceCounterexample ^ Nat.succ (Nat.succ m) = primitiveTraceCounterexample ^ 2 :=
+  primitiveTraceCounterexample_pow_add_two m
 
 @[simp] theorem trace_primitiveTraceCounterexample :
     Matrix.trace primitiveTraceCounterexample = 1 := by

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.MPDO.Defs
 import TNLean.Entropy.MarkovChain
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
+import Mathlib.LinearAlgebra.Matrix.Notation
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.NormNum
 
@@ -92,18 +93,9 @@ rank-one factorization. This shows that
 `PrimitiveTracePowersConstantImpliesRankOne` is not a valid global theorem for
 arbitrary primitive real matrices. -/
 noncomputable def primitiveTraceCounterexample : Matrix (Fin 3) (Fin 3) ℝ :=
-  Matrix.of fun i j =>
-    match i.1, j.1 with
-    | 0, 0 => 0
-    | 0, 1 => 0
-    | 0, 2 => 1 / 2
-    | 1, 0 => 1 / 2
-    | 1, 1 => 1 / 2
-    | 1, 2 => 0
-    | 2, 0 => 1 / 2
-    | 2, 1 => 1 / 2
-    | 2, 2 => 1 / 2
-    | _, _ => 0
+  !![(0 : ℝ), 0, 1 / 2;
+    1 / 2, 1 / 2, 0;
+    1 / 2, 1 / 2, 1 / 2]
 
 theorem primitiveTraceCounterexample_sq :
     primitiveTraceCounterexample ^ 2 =

--- a/audits/2026-04-23_issue832_pf_rank_one_counterexample.md
+++ b/audits/2026-04-23_issue832_pf_rank_one_counterexample.md
@@ -1,0 +1,66 @@
+# Issue #832 blocker note — primitive trace-power constancy does not force rank one
+
+## Summary
+
+The target implication from issue #832,
+
+```lean
+Matrix.IsPrimitive T → Matrix.TracePowersConstant T → Matrix.HasRankOneFactorization T
+```
+
+is **false in general** for nonnegative primitive real matrices.
+
+A concrete counterexample is
+
+\[
+T =
+\begin{pmatrix}
+0 & 0 & 1/2 \\
+1/2 & 1/2 & 0 \\
+1/2 & 1/2 & 1/2
+\end{pmatrix}.
+\]
+
+## Why this is a counterexample
+
+1. `T` is primitive, because
+   \[
+   T^2 =
+   \begin{pmatrix}
+   1/4 & 1/4 & 1/4 \\
+   1/4 & 1/4 & 1/4 \\
+   1/2 & 1/2 & 1/2
+   \end{pmatrix}
+   \]
+   has all entries strictly positive.
+2. `T` has constant trace powers:
+   - `tr(T) = 1`,
+   - `tr(T^2) = 1`, and
+   - `T^3 = T^2`, hence `T^n = T^2` for every `n ≥ 2`, so `tr(T^n) = 1` for all positive `n`.
+3. `T` is not rank one. For example, the first row `(0, 0, 1/2)` and the second row
+   `(1/2, 1/2, 0)` are not proportional.
+
+Equivalently, the spectrum is `{1, 0, 0}`, so the trace-power identities only force the
+non-Perron eigenvalues to vanish; they do **not** force the matrix itself to be the Perron
+rank-one projector.
+
+## Consequence for the MPDO development
+
+The current placeholder
+
+```lean
+Matrix.PrimitiveTracePowersConstantImpliesRankOne
+```
+
+cannot be discharged as a standalone Perron--Frobenius theorem with only the present
+hypotheses.
+
+So the real remaining gap after PR #807 is slightly different:
+
+- either extract a **stronger matrix hypothesis** from the full ZCL relation than mere trace-power
+  constancy,
+- or formalize the local `η_{k,h}` / `r_k,l_h` layer first (issue #833) and prove rank one from
+  that richer structure.
+
+In particular, the paper sentence “primitive + constant trace powers implies `T_{k,h} = a_k b_h`”
+appears to use additional structure that is not captured by the abstract matrix statement alone.

--- a/audits/2026-04-23_issue832_pf_rank_one_counterexample.md
+++ b/audits/2026-04-23_issue832_pf_rank_one_counterexample.md
@@ -40,9 +40,10 @@ T =
 3. `T` is not rank one. For example, the first row `(0, 0, 1/2)` and the second row
    `(1/2, 1/2, 0)` are not proportional.
 
-Equivalently, the spectrum is `{1, 0, 0}`, so the trace-power identities only force the
-non-Perron eigenvalues to vanish; they do **not** force the matrix itself to be the Perron
-rank-one projector.
+The spectrum is `{1, 0, 0}`, so the trace-power identities only force the
+non-Perron eigenvalues to vanish. What fails is that `T` is not the rank-one
+Perron projector: indeed `T^2 ≠ T`, while `T^2` is the idempotent rank-one
+limit picked out by the Perron–Frobenius dynamics.
 
 ## Consequence for the MPDO development
 
@@ -59,7 +60,7 @@ So the real remaining gap after PR #807 is slightly different:
 
 - either extract a **stronger matrix hypothesis** from the full ZCL relation than mere trace-power
   constancy,
-- or formalize the local `η_{k,h}` / `r_k,l_h` layer first (issue #833) and prove rank one from
+- or formalize the local `η_{k,h}` / `r_k` / `l_h` layer first (issue #833) and prove rank one from
   that richer structure.
 
 In particular, the paper sentence “primitive + constant trace powers implies `T_{k,h} = a_k b_h`”

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -437,9 +437,37 @@ strong subadditivity for a normalized three-site reduced state.
     The auxiliary predicates record three matrix-theoretic ingredients used in
     the rank-one step of Appendix~C.2, Lemma~C.4: constant traces of all
     positive powers, existence of a rank-one factorization $T = a b^\top$, and
-    the Perron--Frobenius implication from primitivity together with constant
-    trace powers to such a factorization.
+    an additional rank-one hypothesis imposed at this stage of the argument.
+    The formal development shows that primitivity together with constant trace
+    powers does not by itself force rank one for arbitrary nonnegative
+    matrices, so the final input must come from stronger local structure.
 \end{definition}
+
+\begin{proposition}[Primitive matrices with constant trace powers need not be rank one]
+    \label{prop:primitive_trace_powers_not_rank_one}
+    \lean{Matrix.primitiveTraceCounterexample}
+    \lean{Matrix.primitiveTraceCounterexample_isPrimitive}
+    \lean{Matrix.primitiveTraceCounterexample_tracePowersConstant}
+    \lean{Matrix.primitiveTraceCounterexample_not_hasRankOneFactorization}
+    \leanok
+    There exists a primitive nonnegative $3 \times 3$ matrix whose positive
+    powers all have the same trace, but which is not of the form $a b^\top$.
+\end{proposition}
+
+\begin{proof}
+    \leanok
+    The formal counterexample is
+    \[
+        \begin{pmatrix}
+            0 & 0 & 1/2 \\
+            1/2 & 1/2 & 0 \\
+            1/2 & 1/2 & 1/2
+        \end{pmatrix}.
+    \]
+    Its square is strictly positive, so it is primitive; its cube equals its
+    square, so all positive powers have trace $1$; and its first two rows are
+    not proportional, so it is not rank one.
+\end{proof}
 
 \begin{theorem}[SAL and ZCL imply rank-one $T$ (scoped form)]
     \label{thm:sal_zcl_implies_rank_one_t}
@@ -448,9 +476,9 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{def:matrix_trace_rankone_predicates}
     Let $T$ be the nonnegative matrix extracted from the local $\eta$-data.
     Assume that $T$ is primitive, that $\tr(T) = 1$, and that every positive
-    power of $T$ has the same trace as $T$. If one further supplies the single
-    Perron--Frobenius input asserting that every primitive nonnegative matrix
-    with constant trace powers is rank one, then
+    power of $T$ has the same trace as $T$. If one further supplies the
+    additional rank-one input packaged in
+    Definition~\ref{def:matrix_trace_rankone_predicates}, then
     \[
         T = a b^\top
     \]
@@ -463,7 +491,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{proof}
     \leanok
     \uses{def:matrix_trace_rankone_predicates}
-    The Perron--Frobenius input gives the factorization $T = a b^\top$.
+    The auxiliary rank-one input gives the factorization $T = a b^\top$.
     Taking traces and using $\tr(a b^\top) = a \cdot b$ converts the
     normalization $\tr(T) = 1$ into $a \cdot b = 1$.
 \end{proof}


### PR DESCRIPTION
## Summary
- formalize an explicit primitive nonnegative $3\times 3$ matrix with constant trace powers that is not rank one
- update `SimpleLocalStructure` to state honestly that the extracted issue #832 matrix claim is false in general and remains only a local placeholder
- document the counterexample and the corrected remaining gap in the blueprint and audit note

## Testing
- `lake build TNLean.MPS.MPDO.SimpleLocalStructure`
- `ulimit -n 8192 && lake build`
- `rg -n 'sorry|axiom' TNLean/MPS/MPDO/SimpleLocalStructure.lean blueprint/src/chapter/ch02b_mpdo.tex audits/2026-04-23_issue832_pf_rank_one_counterexample.md || true`
- `leanblueprint web`
- `leanblueprint checkdecls`
