### PR TITLE
feat(MPS/ParentHamiltonian): prove ES positivity via cyclic averaging (#835)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -103,16 +103,17 @@ private lemma offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
 
 private lemma add_offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
     (a + ((b + N - a) % N)) % N = b := by
-  rcases le_or_lt a b with hab | hab
-  · have hmod : (b + N - a) % N = b - a := by
-      have : b + N - a = N + (b - a) := by omega
-      rw [this, Nat.add_mod_left_left, Nat.mod_eq_of_lt (by omega)]
-    rw [hmod, Nat.mod_eq_of_lt (by omega)]
-    omega
+  rcases lt_or_ge b a with hab | hab
   · have hmod : (b + N - a) % N = b + N - a := by
       rw [Nat.mod_eq_of_lt (by omega)]
     rw [hmod, show a + (b + N - a) = b + N from by omega,
       Nat.add_mod_right, Nat.mod_eq_of_lt hb]
+  · have hsub : b - a < N := lt_of_le_of_lt (Nat.sub_le _ _) hb
+    have hmod : (b + N - a) % N = b - a := by
+      have : b + N - a = N + (b - a) := by omega
+      rw [this, Nat.add_mod, Nat.mod_self]
+      simpa using Nat.mod_eq_of_lt hsub
+    rw [hmod, Nat.add_sub_of_le hab, Nat.mod_eq_of_lt hb]
 
 /-- Extracting a window after replacing it recovers the replacement values. -/
 @[simp] lemma extractWindow_replaceWindow (L : ℕ) (hLN : L ≤ N) {α : Type*}

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -101,6 +101,19 @@ private lemma offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
   · rw [Nat.mod_eq_sub_mod hab, Nat.mod_eq_of_lt (by omega : a + b - N < N),
       show a + b - N + N - a = b from by omega, Nat.mod_eq_of_lt hb]
 
+private lemma add_offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
+    (a + ((b + N - a) % N)) % N = b := by
+  rcases le_or_lt a b with hab | hab
+  · have hmod : (b + N - a) % N = b - a := by
+      have : b + N - a = N + (b - a) := by omega
+      rw [this, Nat.add_mod_left_left, Nat.mod_eq_of_lt (by omega)]
+    rw [hmod, Nat.mod_eq_of_lt (by omega)]
+    omega
+  · have hmod : (b + N - a) % N = b + N - a := by
+      rw [Nat.mod_eq_of_lt (by omega)]
+    rw [hmod, show a + (b + N - a) = b + N from by omega,
+      Nat.add_mod_right, Nat.mod_eq_of_lt hb]
+
 /-- Extracting a window after replacing it recovers the replacement values. -/
 @[simp] lemma extractWindow_replaceWindow (L : ℕ) (hLN : L ≤ N) {α : Type*}
     (i : Fin N) (σ : Fin N → α) (τ : Fin L → α) :
@@ -111,6 +124,24 @@ private lemma offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
     offset_mod_eq i.isLt (Nat.lt_of_lt_of_le hj hLN)
   rw [dif_pos (show ((i.val + j) % N + N - i.val) % N < L by rw [key]; exact hj)]
   exact congr_arg τ (Fin.ext key)
+
+/-- Replacing a window by the values extracted from the same configuration leaves
+that configuration unchanged. -/
+@[simp] lemma replaceWindow_extractWindow (L : ℕ) (hLN : L ≤ N) {α : Type*}
+    (i : Fin N) (σ : Fin N → α) :
+    replaceWindow L hLN i σ (extractWindow L i σ) = σ := by
+  funext ⟨k, hk⟩
+  unfold replaceWindow extractWindow
+  set offset := (k + N - i.val) % N with hoff
+  have hN : 0 < N := Fin.pos i
+  have hoffN : offset < N := by
+    rw [hoff]
+    exact Nat.mod_lt _ hN
+  by_cases hoffset : offset < L
+  · rw [dif_pos hoffset]
+    have key : (i.val + offset) % N = k := add_offset_mod_eq i.isLt hk
+    exact congr_arg σ (Fin.ext key)
+  · rw [dif_neg hoffset]
 
 /-! ### Local term (site embedding) -/
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -274,9 +274,262 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
 terms. -/
 theorem parentHamiltonianES_eq_sum_localTermES (A : MPSTensor d D) (L N : ℕ) :
     parentHamiltonianES A L N = ∑ i : Fin N, localTermES A L i := by
-  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
   ext v σ
-  simp [parentHamiltonianES, parentHamiltonian, localTermES, e]
+  simp [parentHamiltonianES, parentHamiltonian, localTermES]
+
+attribute [local instance] Classical.propDecidable
+
+private theorem cyclicCfg_eq_replaceWindow {N : ℕ} (hN : 0 < N) (L : ℕ)
+    (hLN : L ≤ N) (i : Fin N) (σ : Cfg d L) (τ : Cfg d N) :
+    cyclicCfg hN L i σ τ = replaceWindow L hLN i τ σ := by
+  rfl
+
+@[simp] private theorem cyclicRestrictES_apply {N : ℕ} (hN : 0 < N) (L : ℕ)
+    (i : Fin N) (τ : Cfg d N) (v : EuclideanSpace ℂ (Cfg d N)) (ω : Cfg d L) :
+    cyclicRestrictES (d := d) hN L i τ v ω = v (cyclicCfg hN L i ω τ) := rfl
+
+private def SameOutsideWindow {N : ℕ} (L : ℕ) (i : Fin N) (σ τ : Cfg d N) : Prop :=
+  ∀ k : Fin N, ¬ ((k.val + N - i.val) % N < L) → τ k = σ k
+
+private theorem cyclicRestrictES_eq_of_sameOutsideWindow {N : ℕ} (hN : 0 < N)
+    {L : ℕ} (i : Fin N) {σ τ : Cfg d N}
+    (hστ : SameOutsideWindow (L := L) i σ τ) :
+    cyclicRestrictES (d := d) hN L i τ = cyclicRestrictES hN L i σ := by
+  ext v ω
+  change v.ofLp (cyclicCfg hN L i ω τ) = v.ofLp (cyclicCfg hN L i ω σ)
+  exact congrArg v.ofLp <| by
+    ext k
+    by_cases hk : ((k.val + N - i.val) % N) < L
+    · simp [cyclicCfg, hk]
+    · simp [cyclicCfg, hk, hστ k hk]
+
+private theorem sameOutsideWindow_of_cyclicCfg_eq {N : ℕ} (hN : 0 < N) {L : ℕ}
+    (i : Fin N) {σ τ : Cfg d N} {ω : Cfg d L}
+    (hEq : cyclicCfg hN L i ω τ = σ) :
+    SameOutsideWindow (L := L) i σ τ := by
+  intro k hk
+  have hEqk := congrFun hEq k
+  simpa [cyclicCfg, hk] using hEqk
+
+private theorem cyclicRestrictES_single_of_sameOutsideWindow {N : ℕ} (hN : 0 < N) {L : ℕ}
+    (hLN : L ≤ N) (i : Fin N) (σ τ : Cfg d N)
+    (hστ : SameOutsideWindow (L := L) i σ τ) :
+    cyclicRestrictES (d := d) hN L i τ (EuclideanSpace.single σ (1 : ℂ)) =
+      EuclideanSpace.single (extractWindow L i σ) (1 : ℂ) := by
+  ext ω
+  by_cases hω : ω = extractWindow L i σ
+  · subst hω
+    have hreplace : replaceWindow L hLN i τ (extractWindow L i σ) =
+        replaceWindow L hLN i σ (extractWindow L i σ) := by
+      ext k
+      by_cases hk : ((k.val + N - i.val) % N) < L
+      · simp [replaceWindow, hk]
+      · simp [replaceWindow, hk, hστ k hk]
+    have hEq : cyclicCfg hN L i (extractWindow L i σ) τ = σ := by
+      rw [cyclicCfg_eq_replaceWindow hN L hLN]
+      simpa using hreplace.trans (replaceWindow_extractWindow L hLN i σ)
+    rw [PiLp.single_apply]
+    simp [hEq]
+  · have hneq : cyclicCfg hN L i ω τ ≠ σ := by
+      intro hEq
+      apply hω
+      have hextract := congrArg (extractWindow L i) hEq
+      simpa [cyclicCfg_eq_replaceWindow, hLN] using hextract
+    simp [cyclicRestrictES, hneq, hω]
+
+private theorem cyclicRestrictES_single_of_not_sameOutsideWindow {N : ℕ} (hN : 0 < N) {L : ℕ}
+    (i : Fin N) (σ τ : Cfg d N)
+    (hστ : ¬ SameOutsideWindow (L := L) i σ τ) :
+    cyclicRestrictES (d := d) hN L i τ (EuclideanSpace.single σ (1 : ℂ)) = 0 := by
+  ext ω
+  have hneq : cyclicCfg hN L i ω τ ≠ σ := by
+    intro hEq
+    exact hστ (sameOutsideWindow_of_cyclicCfg_eq hN i hEq)
+  simp [cyclicRestrictES, hneq]
+
+private theorem cyclicRestrictES_adjoint_apply {N : ℕ} (hN : 0 < N) {L : ℕ}
+    (hLN : L ≤ N) (i : Fin N) (σ τ : Cfg d N)
+    (v : EuclideanSpace ℂ (Cfg d L)) :
+    ((cyclicRestrictES (d := d) hN L i τ).adjoint v) σ =
+      if SameOutsideWindow (L := L) i σ τ then v (extractWindow L i σ) else 0 := by
+  classical
+  by_cases hστ : SameOutsideWindow (L := L) i σ τ
+  · calc
+      ((cyclicRestrictES (d := d) hN L i τ).adjoint v) σ
+          = ⟪EuclideanSpace.single σ (1 : ℂ),
+              (cyclicRestrictES (d := d) hN L i τ).adjoint v⟫_ℂ := by
+              simpa using (EuclideanSpace.inner_single_left σ (1 : ℂ)
+                ((cyclicRestrictES (d := d) hN L i τ).adjoint v)).symm
+      _ = ⟪cyclicRestrictES (d := d) hN L i τ (EuclideanSpace.single σ (1 : ℂ)), v⟫_ℂ := by
+            rw [LinearMap.adjoint_inner_right]
+      _ = ⟪EuclideanSpace.single (extractWindow L i σ) (1 : ℂ), v⟫_ℂ := by
+            rw [cyclicRestrictES_single_of_sameOutsideWindow hN hLN i σ τ hστ]
+      _ = if SameOutsideWindow (L := L) i σ τ then v (extractWindow L i σ) else 0 := by
+            simpa [hστ] using (EuclideanSpace.inner_single_left (extractWindow L i σ) (1 : ℂ) v)
+  · calc
+      ((cyclicRestrictES (d := d) hN L i τ).adjoint v) σ
+          = ⟪EuclideanSpace.single σ (1 : ℂ),
+              (cyclicRestrictES (d := d) hN L i τ).adjoint v⟫_ℂ := by
+              simpa using (EuclideanSpace.inner_single_left σ (1 : ℂ)
+                ((cyclicRestrictES (d := d) hN L i τ).adjoint v)).symm
+      _ = ⟪cyclicRestrictES (d := d) hN L i τ (EuclideanSpace.single σ (1 : ℂ)), v⟫_ℂ := by
+            rw [LinearMap.adjoint_inner_right]
+      _ = ⟪0, v⟫_ℂ := by
+            rw [cyclicRestrictES_single_of_not_sameOutsideWindow hN i σ τ hστ]
+      _ = if SameOutsideWindow (L := L) i σ τ then v (extractWindow L i σ) else 0 := by
+            simp [hστ]
+
+@[simp] private theorem localTermES_apply {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N)
+    (hLN : L ≤ N) (v : EuclideanSpace ℂ (Cfg d N)) (σ : Cfg d N) :
+    localTermES A L i v σ =
+      parentInteractionES A L ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v)
+        (extractWindow L i σ) := by
+  have hcfg :
+      WithLp.toLp 2 ((LinearMap.pi fun τ =>
+        (LinearMap.proj (replaceWindow L hLN i σ τ) : NSiteSpace d N →ₗ[ℂ] ℂ)) v.ofLp) =
+      (cyclicRestrictES (d := d) (Fin.pos i) L i σ) v := by
+    ext τ
+    simp [cyclicRestrictES, cyclicCfg_eq_replaceWindow, hLN]
+  have hself : cyclicCfg (d := d) (Fin.pos i) L i (extractWindow L i σ) σ = σ := by
+    rw [cyclicCfg_eq_replaceWindow (d := d) (Fin.pos i) L hLN]
+    exact replaceWindow_extractWindow L hLN i σ
+  simp [localTermES, localTerm, hLN, parentInteraction, parentInteractionES]
+  simp [hcfg, hself]
+
+@[simp] private theorem localTermESSummand_apply {N : ℕ} (A : MPSTensor d D) (hN : 0 < N)
+    {L : ℕ} (hLN : L ≤ N) (i : Fin N) (τ v σ) :
+    localTermESSummand A hN L i τ v σ =
+      if SameOutsideWindow (L := L) i σ τ then localTermES A L i v σ else 0 := by
+  classical
+  rw [localTermESSummand]
+  simp only [LinearMap.comp_apply]
+  by_cases hστ : SameOutsideWindow (L := L) i σ τ
+  · rw [cyclicRestrictES_adjoint_apply hN hLN i σ τ]
+    rw [if_pos hστ, localTermES_apply A L i hLN v σ]
+    simp [hστ, cyclicRestrictES_eq_of_sameOutsideWindow hN i hστ]
+  · rw [cyclicRestrictES_adjoint_apply hN hLN i σ τ, if_neg hστ]
+    simp [hστ]
+
+private theorem sameOutsideWindow_card {N : ℕ} {L : ℕ} (hLN : L ≤ N)
+    (i : Fin N) (σ : Cfg d N) :
+    Fintype.card {τ : Cfg d N // SameOutsideWindow (L := L) i σ τ} = d ^ L := by
+  let f : Cfg d L → {τ : Cfg d N // SameOutsideWindow (L := L) i σ τ} :=
+    fun ω => ⟨replaceWindow L hLN i σ ω, by
+      intro k hk
+      simp [replaceWindow, hk]⟩
+  have hf : Function.Bijective f := by
+    constructor
+    · intro ω₁ ω₂ h
+      have h' := congrArg (fun τ : {τ : Cfg d N // SameOutsideWindow (L := L) i σ τ} =>
+        extractWindow L i τ.1) h
+      simpa [f] using h'
+    · intro τ
+      refine ⟨extractWindow L i τ.1, ?_⟩
+      apply Subtype.ext
+      have hreplace : replaceWindow L hLN i σ (extractWindow L i τ.1) =
+          replaceWindow L hLN i τ.1 (extractWindow L i τ.1) := by
+        ext k
+        by_cases hk : ((k.val + N - i.val) % N) < L
+        · simp [replaceWindow, hk]
+        · simp [replaceWindow, hk, τ.2 k hk]
+      simpa [f] using hreplace.trans (replaceWindow_extractWindow L hLN i τ.1)
+  calc
+    Fintype.card {τ : Cfg d N // SameOutsideWindow (L := L) i σ τ}
+        = Fintype.card (Cfg d L) := (Fintype.card_of_bijective (f := f) hf).symm
+    _ = d ^ L := by simp [Cfg]
+
+/-- The transported local term is the cyclic average of the positive Euclidean
+summands `Rᵢ,τ† P_L Rᵢ,τ`. -/
+theorem localTermES_eq_average_localTermESSummand {N : ℕ} (A : MPSTensor d D)
+    {L : ℕ} (hLN : L ≤ N) (i : Fin N) :
+    localTermES A L i =
+      ((((d ^ L : ℕ) : ℂ)⁻¹) • (∑ τ : Cfg d N, localTermESSummand A (Fin.pos i) L i τ)) := by
+  classical
+  ext v σ
+  let q : Cfg d N → Prop := SameOutsideWindow (L := L) i σ
+  let sq : Finset (Cfg d N) := Finset.univ.filter q
+  have hfilter :
+      (∑ τ : Cfg d N, if q τ then localTermES A L i v σ else 0) =
+        sq.sum (fun _ => localTermES A L i v σ) := by
+    dsimp [sq]
+    symm
+    simpa using (Finset.sum_filter (s := Finset.univ) (p := q)
+      (f := fun _ => localTermES A L i v σ))
+  have hsconst :
+      sq.sum (fun _ => localTermES A L i v σ) =
+        sq.card • localTermES A L i v σ := by
+    exact Finset.sum_const (s := sq) (b := localTermES A L i v σ)
+  have hcard_filter : sq.card = Fintype.card {τ : Cfg d N // q τ} := by
+    dsimp [sq]
+    symm
+    simpa using (Fintype.card_subtype q)
+  have hne_nat : (d ^ L : ℕ) ≠ 0 := by
+    have hcard : Fintype.card (Cfg d L) = d ^ L := by
+      simp [Cfg]
+    have : Fintype.card (Cfg d L) ≠ 0 := by
+      let _ : Nonempty (Cfg d L) := ⟨extractWindow L i σ⟩
+      exact Fintype.card_ne_zero
+    rwa [hcard] at this
+  have hne : (((d ^ L : ℕ) : ℂ)) ≠ 0 := by
+    exact_mod_cast hne_nat
+  calc
+    localTermES A L i v σ
+        = (((d ^ L : ℕ) : ℂ)⁻¹) * ((d ^ L) • localTermES A L i v σ) := by
+            symm
+            rw [nsmul_eq_mul, ← mul_assoc, inv_mul_cancel₀ hne, one_mul]
+    _ = (((d ^ L : ℕ) : ℂ)⁻¹) *
+          (Fintype.card {τ : Cfg d N // q τ} • localTermES A L i v σ) := by
+            rw [sameOutsideWindow_card hLN i σ]
+    _ = (((d ^ L : ℕ) : ℂ)⁻¹) *
+          (sq.card • localTermES A L i v σ) := by rw [hcard_filter]
+    _ = (((d ^ L : ℕ) : ℂ)⁻¹) *
+          (sq.sum (fun _ => localTermES A L i v σ)) := by rw [hsconst]
+    _ = (((d ^ L : ℕ) : ℂ)⁻¹) *
+          (∑ τ : Cfg d N, if q τ then localTermES A L i v σ else 0) := by rw [hfilter]
+    _ = (((d ^ L : ℕ) : ℂ)⁻¹) *
+          (∑ τ : Cfg d N, localTermESSummand A (Fin.pos i) L i τ v σ) := by
+            simp [q, localTermESSummand_apply, hLN]
+    _ = ((((d ^ L : ℕ) : ℂ)⁻¹) • (∑ τ : Cfg d N,
+          localTermESSummand A (Fin.pos i) L i τ)) v σ := by
+            simp
+
+private theorem isPositive_smul_of_real_re_nonneg {ι : Type*} [Fintype ι]
+    {T : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι} (hT : T.IsPositive) {c : ℂ}
+    (hc_star : star c = c) (hc_re : 0 ≤ c.re) :
+    (c • T).IsPositive := by
+  refine ⟨hT.left.smul hc_star, fun x => ?_⟩
+  have him : c.im = 0 := by
+    have him' := congrArg Complex.im hc_star
+    simp at him'
+    linarith
+  have himstar : RCLike.im ((starRingEnd ℂ) c) = 0 := by
+    simp [him]
+  have hre : RCLike.re ((starRingEnd ℂ) c) = c.re := by
+    simp
+  change 0 ≤ RCLike.re ⟪c • T x, x⟫_ℂ
+  rw [inner_smul_left, RCLike.mul_re, himstar, zero_mul, sub_zero, hre]
+  exact mul_nonneg hc_re (hT.re_inner_nonneg_left x)
+
+/-- The transported local term is positive because it is a finite cyclic average
+of the positive summands `Rᵢ,τ† P_L Rᵢ,τ`. -/
+theorem localTermES_isPositive {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N) :
+    (localTermES A L i).IsPositive := by
+  by_cases hLN : L ≤ N
+  · rw [localTermES_eq_average_localTermESSummand A hLN i]
+    refine isPositive_smul_of_real_re_nonneg
+      (localTermESSummand_sum_isPositive A (Fin.pos i) L i) ?_ ?_
+    · simp
+    · rw [Complex.inv_re, Complex.normSq_natCast]
+      have hnonneg : 0 ≤ ((d ^ L : ℕ) : ℝ) := by exact_mod_cast Nat.zero_le (d ^ L)
+      exact div_nonneg hnonneg (mul_nonneg hnonneg hnonneg)
+  · simp [localTermES, localTerm, hLN]
+
+/-- The full transported parent Hamiltonian is positive because it is a finite
+sum of positive transported local terms. -/
+theorem parentHamiltonianES_isPositive (A : MPSTensor d D) (L N : ℕ) :
+    (parentHamiltonianES A L N).IsPositive := by
+  rw [parentHamiltonianES_eq_sum_localTermES]
+  exact LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A L i
 
 /-- The transported parent-Hamiltonian ground space is exactly the kernel of the
 transported parent Hamiltonian. -/

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -249,6 +249,13 @@ theorem localTermESSummand_sum_isPositive {N : ℕ} (A : MPSTensor d D) (hN : 0 
 
 /-! ### Ground-space and Hamiltonian transport to `EuclideanSpace` -/
 
+/-- The translated local parent-Hamiltonian term transported to the
+`EuclideanSpace` model. -/
+noncomputable def localTermES {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N) :
+    EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
+  let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
+  e.symm.toLinearMap.comp ((localTerm A L N i).comp e.toLinearMap)
+
 /-- Ground-space submodule for the finite-size parent Hamiltonian,
 transported to the `EuclideanSpace` (inner-product) setting so that
 orthogonal complements are available. -/
@@ -262,6 +269,14 @@ noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
     EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
   let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
   e.symm.toLinearMap.comp ((parentHamiltonian A L N).comp e.toLinearMap)
+
+/-- The transported parent Hamiltonian is the sum of the transported local
+terms. -/
+theorem parentHamiltonianES_eq_sum_localTermES (A : MPSTensor d D) (L N : ℕ) :
+    parentHamiltonianES A L N = ∑ i : Fin N, localTermES A L i := by
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  ext v σ
+  simp [parentHamiltonianES, parentHamiltonian, localTermES, e]
 
 /-- The transported parent-Hamiltonian ground space is exactly the kernel of the
 transported parent Hamiltonian. -/

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1429,6 +1429,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \label{rem:euclidean_local_projector_ingredients}
     \lean{MPSTensor.parentInteractionES}
     \lean{MPSTensor.cyclicRestrictES}
+    \lean{MPSTensor.localTermES}
     \lean{MPSTensor.localTermESSummand}
     \leanok
     \uses{def:ground_space_es, rem:cyclic_window_operators}
@@ -1436,8 +1437,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $(G_L^{\mathrm{ES}}(A))^\perp$ on the Euclidean $L$-site space. For a cyclic
     window starting at $i$ and an outside configuration $\tau$, the transported
     restriction map $R_{i,\tau}$ evaluates an $N$-site Euclidean vector on that
-    window. The operator $R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}$ is the
-    basic local summand in the expected averaging formula for the transported local term.
+    window. The transported local term $h_{i,\mathrm{ES}}$ is the corresponding
+    $N$-site local projector, and $R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}$ is
+    the basic positive summand in its cyclic-averaging formula.
 \end{remark}
 
 \begin{lemma}[Positivity of the Euclidean local summands]
@@ -1456,6 +1458,45 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     Orthogonal projectors are positive. Conjugation by $R_{i,\tau}$ preserves
     positivity, and finite sums of positive operators remain positive.
+\end{proof}
+
+\begin{lemma}[Cyclic averaging for the transported ES local terms]
+    \label{lem:local_term_es_average}
+    \lean{MPSTensor.parentHamiltonianES_eq_sum_localTermES}
+    \lean{MPSTensor.localTermES_eq_average_localTermESSummand}
+    \leanok
+    \uses{rem:euclidean_local_projector_ingredients, lem:euclidean_local_projector_positive}
+    The transported parent Hamiltonian is the sum of the transported local terms
+    $H_{N,\mathrm{ES}} = \sum_i h_{i,\mathrm{ES}}$, and each transported local term admits
+    the exact cyclic-averaging formula
+    \[
+        h_{i,\mathrm{ES}}
+        = d^{-L} \sum_{\tau} R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Unfold the transported local term and compare it configuration-by-configuration
+    with the cyclic restrictions. The $d^{-L}$ factor compensates for the $d^L$
+    choices of the window coordinates in the ambient configuration parameter $\tau$.
+\end{proof}
+
+\begin{lemma}[Positivity of the transported ES Hamiltonian]
+    \label{lem:transported_es_positive}
+    \lean{MPSTensor.localTermES_isPositive}
+    \lean{MPSTensor.parentHamiltonianES_isPositive}
+    \leanok
+    \uses{lem:local_term_es_average}
+    Each transported local term $h_{i,\mathrm{ES}}$ is positive, hence the full
+    transported parent Hamiltonian $H_{N,\mathrm{ES}}$ is positive.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply the averaging formula above: $h_{i,\mathrm{ES}}$ is a nonnegative scalar
+    multiple of a finite sum of positive conjugates of $P_L^{\mathrm{ES}}(A)$, hence is
+    itself positive. Summing over $i$ yields positivity of $H_{N,\mathrm{ES}}$.
 \end{proof}
 
 \begin{lemma}[Quadratic form to norm bound]\label{lem:quadratic_form_to_norm_bound}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -199,6 +199,22 @@ onto $G_L(A)^\perp$ in the $L$-site Euclidean space.
     \]
 \end{lemma}
 
+\begin{lemma}[Replacing an extracted window]\label{lem:replace_window_extract_window}
+    \lean{MPSTensor.replaceWindow_extractWindow}
+    \leanok
+    \uses{def:extract_window, def:replace_window}
+    If $L \le N$, then replacing the cyclic window at $i$ in $\sigma$ by the values
+    extracted from that same $\sigma$ leaves $\sigma$ unchanged:
+    \[
+        \operatorname{replaceWindow}_{L,i}(\sigma,\operatorname{extractWindow}_{L,i}(\sigma)) = \sigma.
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    Case-split on whether the offset $(k - i + N) \bmod N$ lies in $[0,L)$: inside the
+    window the value comes from $\operatorname{extractWindow}$, which returns
+    $\sigma$ at the same position; outside the window both sides already agree with $\sigma$.
+\end{proof}
+
 For a periodic chain of length $N$, the parent Hamiltonian is the sum of
 translated copies of the local interaction.
 


### PR DESCRIPTION
## Summary
- prove the cyclic-averaging formula for the transported ES local term
- derive  and 
- sync the parent-Hamiltonian blueprint with the new ES local-term declarations

## Main Lean additions
- 
- 
- 
- 
- 
- helper infrastructure in  /  for cyclic-window compatibility counting

## Notes
- This closes the non-quantitative ES positivity slice of #460 tracked by #835.
- The separate quantitative blocker  remains the only  in .

## Testing
- Current branch: HEAD
Using cache (Azure) from origin: leanprover-community/mathlib4
No files to download
Already decompressed 8232 file(s)
- Build completed successfully (2321 jobs).
- ⚠ [2955/2955] Replayed TNLean.MPS.ParentHamiltonian.Martingale
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:595:8: declaration uses `sorry`
Build completed successfully (2955 jobs).
- ⚠ [8288/8616] Replayed TNLean.Channel.KrausFreedom
warning: TNLean/Channel/KrausFreedom.lean:126:0: Please, add a comment explaining the need for modifying the maxHeartbeat limit, as in
set_option synthInstance.maxHeartbeats 16000000 in
-- reason for change
...

Note: This linter can be disabled with `set_option linter.style.maxHeartbeats false`
⚠ [8292/8616] Replayed TNLean.Algebra.MatrixOperatorSpace
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [DecidableEq n] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/Algebra/MatrixOperatorSpace.lean:77:0: `instContinuousSMulRealMatrixComplex_tNLean` does not use the following hypothesis in its type:
  • [Fintype n] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8359/8616] Replayed TNLean.Channel.FixedPoint.WedderburnDecomp
warning: TNLean/Channel/FixedPoint/WedderburnDecomp.lean:86:7: declaration uses `sorry`
⚠ [8372/8616] Replayed TNLean.Channel.Peripheral.CyclicDecomposition.Basic
warning: TNLean/Channel/Peripheral/CyclicDecomposition/Basic.lean:232:6: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/Channel/Peripheral/CyclicDecomposition/Basic.lean:252:6: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
⚠ [8431/8616] Replayed TNLean.MPS.ParentHamiltonian.UniqueGroundState
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:356:8: declaration uses `sorry`
⚠ [8468/8616] Replayed TNLean.MPS.ParentHamiltonian.Martingale
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:595:8: declaration uses `sorry`
⚠ [8521/8616] Replayed TNLean.PEPS.FundamentalTheorem
warning: TNLean/PEPS/FundamentalTheorem.lean:521:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:554:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:640:8: declaration uses `sorry`
⚠ [8554/8616] Replayed TNLean.MPS.FundamentalTheorem.EqualProportional
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:438:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:449:12: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:459:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/MPS/FundamentalTheorem/EqualProportional.lean:464:4: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
⚠ [8594/8616] Replayed TNLean.MPS.ParentHamiltonian.DegenerateGS
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:132:8: declaration uses `sorry`
⚠ [8598/8616] Replayed TNLean.MPS.Periodic.Overlap.SelfOverlap
warning: TNLean/MPS/Periodic/Overlap/SelfOverlap.lean:195:16: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/SelfOverlap.lean:656:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/SelfOverlap.lean:902:8: declaration uses `sorry`
⚠ [8600/8616] Replayed TNLean.MPS.Periodic.Overlap.Case2
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:132:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:251:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:294:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:358:8: declaration uses `sorry`
⚠ [8601/8616] Replayed TNLean.MPS.Periodic.Overlap.Case3
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:87:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:222:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:284:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:348:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:404:8: declaration uses `sorry`
⚠ [8604/8616] Replayed TNLean.MPS.Periodic.Overlap.Dichotomy
warning: TNLean/MPS/Periodic/Overlap/Dichotomy.lean:43:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Dichotomy.lean:69:8: declaration uses `sorry`
Build completed successfully (8616 jobs).
- plasTeX version 3.1
- 
- TNLean/MPS/ParentHamiltonian/Martingale.lean:611:  sorry

Closes #835

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new core lemmas about window replacement arithmetic and proves positivity/averaging identities for transported parent-Hamiltonian operators, which could affect downstream spectral-gap arguments if incorrect.
> 
> **Overview**
> Adds a new `replaceWindow_extractWindow` simp lemma (plus supporting modular-arithmetic lemma) showing that replacing a cyclic window with its own extracted values leaves a configuration unchanged.
> 
> Introduces `localTermES` as the `EuclideanSpace`-transport of `localTerm`, proves `parentHamiltonianES` decomposes as a sum of these transported local terms, and establishes an exact cyclic-averaging formula expressing `localTermES` as `d^{-L}` times a finite sum of positive conjugated summands `localTermESSummand`.
> 
> Uses the averaging identity to prove positivity of each transported local term and of the full transported parent Hamiltonian, and updates the blueprint to document the new lemmas/definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3f4facea0815f6dde0e7450092c1ae7c46270d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->