### PR TITLE
feat(MPS/MPDO): begin explicit η-operator extraction (#833)

### DIFF
--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -158,14 +158,14 @@ noncomputable def physRealize (K : MPOTensor d D) (hK : K.IsInjective)
 theorem physRealize_spec (K : MPOTensor d D) (hK : K.IsInjective)
     (X : Matrix (Fin D) (Fin D) ℂ) (p : Fin (d * d)) :
     K.toMPSTensor p * X =
-      ∑ q, (physRealize K hK X) p q • K.toMPSTensor q := by
-  simpa [physRealize] using MPSTensor.physRealize_spec K.toMPSTensor hK X p
+      ∑ q, (physRealize K hK X) p q • K.toMPSTensor q :=
+  MPSTensor.physRealize_spec K.toMPSTensor hK X p
 
 /-- `MPOTensor.physRealize` is multiplicative. -/
 theorem physRealize_mul (K : MPOTensor d D) (hK : K.IsInjective)
     (X Y : Matrix (Fin D) (Fin D) ℂ) :
-    physRealize K hK (X * Y) = physRealize K hK X * physRealize K hK Y := by
-  simpa [physRealize] using MPSTensor.physRealize_mul K.toMPSTensor hK X Y
+    physRealize K hK (X * Y) = physRealize K hK X * physRealize K hK Y :=
+  MPSTensor.physRealize_mul K.toMPSTensor hK X Y
 
 /-- The physical realization map for a left virtual insertion on an injective
 simple MPO tensor. -/
@@ -178,9 +178,8 @@ noncomputable def physRealizeLeft (K : MPOTensor d D) (hK : K.IsInjective)
 theorem physRealizeLeft_spec (K : MPOTensor d D) (hK : K.IsInjective)
     (X : Matrix (Fin D) (Fin D) ℂ) (p : Fin (d * d)) :
     X * K.toMPSTensor p =
-      ∑ q, (physRealizeLeft K hK X) p q • K.toMPSTensor q := by
-  simpa [physRealizeLeft] using
-    MPSTensor.physRealizeLeft_spec K.toMPSTensor hK X p
+      ∑ q, (physRealizeLeft K hK X) p q • K.toMPSTensor q :=
+  MPSTensor.physRealizeLeft_spec K.toMPSTensor hK X p
 
 end InjectiveInverseMaps
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -51,7 +51,7 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 In the paper, Lemma C.3 continues from equality in strong subadditivity to the
 explicit operators `η_{k,h}` by applying local inverse maps coming from the
 injectivity of the simple tensor. The present file now contains that
-inverse-map layer for an injective simple MPO tensor, packaged by
+inverse-map layer for an injective simple MPO tensor, given by
 `MPOTensor.inverseTensor`, `MPOTensor.physRealize`, and
 `MPOTensor.physRealizeLeft`.
 
@@ -97,7 +97,7 @@ def TracePowersConstant (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
 for a primitive nonnegative matrix, constant traces of positive powers imply a
 rank-one factorization.
 
-This is intentionally packaged as a local hypothesis rather than a new global
+This is intentionally stated as a local hypothesis rather than a new global
 assumption. Once a genuine proof is formalized, downstream callers can simply
 supply that theorem here and the scoped result `MPOTensor.sal_zcl_implies_rank_one_T`
 will become unconditional. -/
@@ -227,8 +227,8 @@ abbrev etaOperators
 
 /-- Explicit neighboring operators `η_{k,h}` together with their positivity.
 
-This packages the operator family from `MPOTensor.etaOperators` with the
-positivity condition `η_{k,h} ≥ 0` from Appendix C.2. -/
+This structure consists of the operator family from `MPOTensor.etaOperators`
+together with the positivity condition `η_{k,h} ≥ 0` from Appendix C.2. -/
 structure ExplicitEtaOperators
     {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ}

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -18,24 +18,31 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 
 - `MPOTensor.IsInjective`: injectivity of a simple MPO tensor, expressed via the
   doubled-index MPS tensor.
-- `MPOTensor.inverseTensor`: a concrete right inverse `K⁻¹` for an injective
-  simple MPO tensor.
-- `MPOTensor.physRealize` / `MPOTensor.physRealizeLeft`: the physical
-  realization maps for virtual insertions on an injective simple MPO tensor.
+- `MPOTensor.inverseTensor` / `MPOTensor.inverseTensor_spec`: the concrete
+  inverse tensor `K⁻¹` and its matrix-unit contraction identity.
+- `MPOTensor.physRealize` / `MPOTensor.physRealize_spec` /
+  `MPOTensor.physRealize_mul`: the physical realization of right virtual
+  insertions and its multiplicativity.
+- `MPOTensor.physRealizeLeft` / `MPOTensor.physRealizeLeft_spec`: the left-bond
+  analogue of the physical realization map.
 - `MPOTensor.EtaStructure`: the quantum-Markov decomposition on the middle
   subsystem supplied by equality in strong subadditivity.
+- `MPOTensor.sal_implies_eta_structure`: the Lean form of the entropy step in
+  Lemma C.3. We formalize the strong-area-law input locally as equality in
+  strong subadditivity for a normalized three-site reduced state.
+- `MPOTensor.etaOperators`: the dependent type of explicit neighboring operator
+  families over a fixed Hayashi decomposition.
 - `MPOTensor.ExplicitEtaOperators`: the explicit neighboring operators
-  `η_{k,h}` over a fixed Hayashi decomposition.
-- `MPOTensor.etaOperators`: the underlying family of operators in an
-  `ExplicitEtaOperators` witness.
+  `η_{k,h}` together with positivity.
+- `MPOTensor.ExplicitEtaOperators.traceMatrix` /
+  `MPOTensor.ExplicitEtaOperators.traceMatrixRe`: the complex trace matrix of an
+  explicit `η`-family and its real-part interface to the downstream
+  Perron–Frobenius step.
 - `Matrix.HasRankOneFactorization`: a finite matrix factors as `vecMulVec a b`.
 - `Matrix.TracePowersConstant`: all positive powers of a matrix have the same
   trace as the matrix itself.
 - `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the single missing
   Perron–Frobenius input isolated by Lemma C.4.
-- `MPOTensor.sal_implies_eta_structure`: the Lean form of the entropy step in
-  Lemma C.3. We formalize the strong-area-law input locally as equality in
-  strong subadditivity for a normalized three-site reduced state.
 - `MPOTensor.sal_zcl_implies_rank_one_T`: the scoped Lemma C.4 consequence,
   proved relative to that Perron–Frobenius input.
 
@@ -131,9 +138,13 @@ theorem inverseTensor_spec (K : MPOTensor d D) (hK : K.IsInjective)
     (α β : Fin D) :
     ∑ p : Fin (d * d), inverseTensor K hK p α β • K.toMPSTensor p =
       Matrix.single α β (1 : ℂ) := by
-  simpa [inverseTensor] using
-    (MPSTensor.decompositionMap_sum (A := K.toMPSTensor) hK
-      (Matrix.single α β (1 : ℂ)))
+  change
+    ∑ p : Fin (d * d),
+      MPSTensor.decompositionMap (A := K.toMPSTensor) hK
+          (Matrix.single α β (1 : ℂ)) p • K.toMPSTensor p
+        = Matrix.single α β (1 : ℂ)
+  exact MPSTensor.decompositionMap_sum (A := K.toMPSTensor) hK
+    (Matrix.single α β (1 : ℂ))
 
 /-- The physical realization map for a right virtual insertion on an injective
 simple MPO tensor. This is the MPO wrapper around
@@ -200,29 +211,30 @@ theorem sal_implies_eta_structure
     Nonempty (EtaStructure ρ_ABC) :=
   Entropy.exists_quantumMarkovDecomposition_of_ssaEquality ρ_ABC hρ_dm hSAL
 
-/-- Explicit neighboring operators `η_{k,h}` over a fixed Hayashi decomposition.
+/-- The type of explicit neighboring operator families `η_{k,h}` over a fixed
+Hayashi decomposition.
 
-For each pair of sectors `(k, h)`, the operator `eta k h` acts on the
+For each pair of sectors `(k, h)`, the operator `η_{k,h}` acts on the
 neighboring bond space `B_kᴿ ⊗ B_hᴸ`, represented in Lean as the matrix algebra
-on `Fin (hη.dR k) × Fin (hη.dL h)`. Positivity matches the paper's
-`η_{k,h} ≥ 0`. -/
+on `Fin (hη.dR k) × Fin (hη.dL h)`. -/
+abbrev etaOperators
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    (hη : EtaStructure ρ_ABC) : Type :=
+  (k h : Fin hη.m) →
+    Matrix (Fin (hη.dR k) × Fin (hη.dL h))
+      (Fin (hη.dR k) × Fin (hη.dL h)) ℂ
+
+/-- Explicit neighboring operators `η_{k,h}` together with their positivity.
+
+This packages the operator family from `MPOTensor.etaOperators` with the
+positivity condition `η_{k,h} ≥ 0` from Appendix C.2. -/
 structure ExplicitEtaOperators
     {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ}
     (hη : EtaStructure ρ_ABC) where
-  eta : (k h : Fin hη.m) →
-    Matrix (Fin (hη.dR k) × Fin (hη.dL h))
-      (Fin (hη.dR k) × Fin (hη.dL h)) ℂ
+  eta : etaOperators hη
   eta_pos : ∀ k h, (eta k h).PosSemidef
-
-/-- The underlying family of explicit neighboring operators in an
-`ExplicitEtaOperators` witness. -/
-abbrev etaOperators
-    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
-      (Fin dA × Fin dB × Fin dC) ℂ}
-    {hη : EtaStructure ρ_ABC}
-    (data : ExplicitEtaOperators hη) :=
-  data.eta
 
 namespace ExplicitEtaOperators
 
@@ -239,6 +251,18 @@ noncomputable def traceMatrix (data : ExplicitEtaOperators hη) :
 @[simp] theorem traceMatrix_apply (data : ExplicitEtaOperators hη)
     (k h : Fin hη.m) :
     data.traceMatrix k h = Matrix.trace (data.eta k h) := rfl
+
+/-- The real-part trace matrix attached to an explicit `η_{k,h}` family.
+
+This is the direct real-valued interface to the Perron–Frobenius matrix `T`
+used later in Appendix C.2, Lemma C.4. -/
+noncomputable def traceMatrixRe (data : ExplicitEtaOperators hη) :
+    Matrix (Fin hη.m) (Fin hη.m) ℝ :=
+  fun k h => (Matrix.trace (data.eta k h)).re
+
+@[simp] theorem traceMatrixRe_apply (data : ExplicitEtaOperators hη)
+    (k h : Fin hη.m) :
+    data.traceMatrixRe k h = (Matrix.trace (data.eta k h)).re := rfl
 
 end ExplicitEtaOperators
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.Defs
 import TNLean.Entropy.MarkovChain
+import TNLean.MPS.Chain.VirtualInsertion
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
 
 /-!
@@ -15,16 +16,26 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 
 ## Main declarations
 
+- `MPOTensor.IsInjective`: injectivity of a simple MPO tensor, expressed via the
+  doubled-index MPS tensor.
+- `MPOTensor.inverseTensor`: a concrete right inverse `K⁻¹` for an injective
+  simple MPO tensor.
+- `MPOTensor.physRealize` / `MPOTensor.physRealizeLeft`: the physical
+  realization maps for virtual insertions on an injective simple MPO tensor.
 - `MPOTensor.EtaStructure`: the quantum-Markov decomposition on the middle
   subsystem supplied by equality in strong subadditivity.
-- `MPOTensor.sal_implies_eta_structure`: the Lean form of the entropy step in
-  Lemma C.3.  We formalize the strong-area-law input locally as equality in
-  strong subadditivity for a normalized three-site reduced state.
+- `MPOTensor.ExplicitEtaOperators`: the explicit neighboring operators
+  `η_{k,h}` over a fixed Hayashi decomposition.
+- `MPOTensor.etaOperators`: the underlying family of operators in an
+  `ExplicitEtaOperators` witness.
 - `Matrix.HasRankOneFactorization`: a finite matrix factors as `vecMulVec a b`.
 - `Matrix.TracePowersConstant`: all positive powers of a matrix have the same
   trace as the matrix itself.
 - `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the single missing
   Perron–Frobenius input isolated by Lemma C.4.
+- `MPOTensor.sal_implies_eta_structure`: the Lean form of the entropy step in
+  Lemma C.3. We formalize the strong-area-law input locally as equality in
+  strong subadditivity for a normalized three-site reduced state.
 - `MPOTensor.sal_zcl_implies_rank_one_T`: the scoped Lemma C.4 consequence,
   proved relative to that Perron–Frobenius input.
 
@@ -32,10 +43,16 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 
 In the paper, Lemma C.3 continues from equality in strong subadditivity to the
 explicit operators `η_{k,h}` by applying local inverse maps coming from the
-injectivity of the simple tensor. The current repository does not yet contain
-that inverse-map layer for simple MPDOs, so we formalize the entropic core
-exactly as the Hayashi / Ruskai / Hayden–Jozsa–Petz–Winter decomposition already
-available through `Entropy.QuantumMarkovDecomposition`.
+injectivity of the simple tensor. The present file now contains that
+inverse-map layer for an injective simple MPO tensor, packaged by
+`MPOTensor.inverseTensor`, `MPOTensor.physRealize`, and
+`MPOTensor.physRealizeLeft`.
+
+What remains to be formalized is the final bookkeeping theorem connecting those
+inverse maps to the Hayashi decomposition blocks and thereby producing a term of
+`MPOTensor.ExplicitEtaOperators`. We therefore record both the inverse-map
+infrastructure and the target `η_{k,h}` family separately, so the residual gap
+is isolated to a single local extraction statement.
 
 Lemma C.4 is further isolated to the finite-dimensional Perron–Frobenius step:
 for a primitive nonnegative matrix `T`, constant traces of positive powers force
@@ -64,7 +81,7 @@ def HasRankOneFactorization (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b
 
 /-- The traces of all positive powers of `T` agree with the trace of `T`
-itself.  This is the matrix-theoretic consequence of the ZCL step used in
+itself. This is the matrix-theoretic consequence of the ZCL step used in
 Appendix C.2, Lemma C.4. -/
 def TracePowersConstant (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   ∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T
@@ -85,19 +102,84 @@ end Matrix
 
 namespace MPOTensor
 
+section InjectiveInverseMaps
+
+variable {d D : ℕ}
+
+/-- A simple MPO tensor is injective when its doubled-index MPS tensor is
+injective. This is the exact hypothesis needed for the local inverse-map layer
+in Appendix C.2. -/
+abbrev IsInjective (K : MPOTensor d D) : Prop :=
+  MPSTensor.IsInjective K.toMPSTensor
+
+/-- A concrete inverse tensor `K⁻¹` obtained from a right inverse to the linear
+combination map of the doubled-index MPS tensor.
+
+For each physical index `p : Fin (d * d)`, the matrix `inverseTensor K hK p`
+collects the coefficients of the standard matrix basis under the chosen right
+inverse. Equivalently, its `(α, β)` entry is the coefficient of `K p` in the
+expansion of the matrix unit `|α⟩⟨β|`. -/
+noncomputable def inverseTensor (K : MPOTensor d D) (hK : K.IsInjective) :
+    Fin (d * d) → Matrix (Fin D) (Fin D) ℂ :=
+  fun p => Matrix.of fun α β =>
+    MPSTensor.decompositionMap (A := K.toMPSTensor) hK (Matrix.single α β (1 : ℂ)) p
+
+/-- Contracting the chosen inverse tensor with the local MPO tensor recovers the
+matrix units on the virtual bond space. This is the Lean form of the paper's
+inverse-map identity for an injective simple tensor. -/
+theorem inverseTensor_spec (K : MPOTensor d D) (hK : K.IsInjective)
+    (α β : Fin D) :
+    ∑ p : Fin (d * d), inverseTensor K hK p α β • K.toMPSTensor p =
+      Matrix.single α β (1 : ℂ) := by
+  simpa [inverseTensor] using
+    (MPSTensor.decompositionMap_sum (A := K.toMPSTensor) hK
+      (Matrix.single α β (1 : ℂ)))
+
+/-- The physical realization map for a right virtual insertion on an injective
+simple MPO tensor. This is the MPO wrapper around
+`MPSTensor.physRealize` for the doubled-index tensor. -/
+noncomputable def physRealize (K : MPOTensor d D) (hK : K.IsInjective)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
+  MPSTensor.physRealize K.toMPSTensor hK X
+
+/-- Defining property of `MPOTensor.physRealize`. -/
+theorem physRealize_spec (K : MPOTensor d D) (hK : K.IsInjective)
+    (X : Matrix (Fin D) (Fin D) ℂ) (p : Fin (d * d)) :
+    K.toMPSTensor p * X =
+      ∑ q, (physRealize K hK X) p q • K.toMPSTensor q := by
+  simpa [physRealize] using MPSTensor.physRealize_spec K.toMPSTensor hK X p
+
+/-- `MPOTensor.physRealize` is multiplicative. -/
+theorem physRealize_mul (K : MPOTensor d D) (hK : K.IsInjective)
+    (X Y : Matrix (Fin D) (Fin D) ℂ) :
+    physRealize K hK (X * Y) = physRealize K hK X * physRealize K hK Y := by
+  simpa [physRealize] using MPSTensor.physRealize_mul K.toMPSTensor hK X Y
+
+/-- The physical realization map for a left virtual insertion on an injective
+simple MPO tensor. -/
+noncomputable def physRealizeLeft (K : MPOTensor d D) (hK : K.IsInjective)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
+  MPSTensor.physRealizeLeft K.toMPSTensor hK X
+
+/-- Defining property of `MPOTensor.physRealizeLeft`. -/
+theorem physRealizeLeft_spec (K : MPOTensor d D) (hK : K.IsInjective)
+    (X : Matrix (Fin D) (Fin D) ℂ) (p : Fin (d * d)) :
+    X * K.toMPSTensor p =
+      ∑ q, (physRealizeLeft K hK X) p q • K.toMPSTensor q := by
+  simpa [physRealizeLeft] using
+    MPSTensor.physRealizeLeft_spec K.toMPSTensor hK X p
+
+end InjectiveInverseMaps
+
 section LocalSAL
 
 variable {dA dB dC : ℕ}
 
 /-- The local `η`-structure used in the simple MPDO argument, formalized as the
 quantum-Markov decomposition on the middle subsystem produced by equality in
-strong subadditivity.
-
-For the current repository state, this is the exact entropy-theoretic content of
-Lemma C.3 that is already available through the sanctioned Hayashi equality
-characterization. The further conversion from this decomposition to explicit
-operators `η_{k,h}` requires the injective inverse-map layer for simple MPDOs
-and is deferred to future work. -/
+strong subadditivity. -/
 abbrev EtaStructure
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ) : Type :=
@@ -117,6 +199,48 @@ theorem sal_implies_eta_structure
     (hSAL : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
     Nonempty (EtaStructure ρ_ABC) :=
   Entropy.exists_quantumMarkovDecomposition_of_ssaEquality ρ_ABC hρ_dm hSAL
+
+/-- Explicit neighboring operators `η_{k,h}` over a fixed Hayashi decomposition.
+
+For each pair of sectors `(k, h)`, the operator `eta k h` acts on the
+neighboring bond space `B_kᴿ ⊗ B_hᴸ`, represented in Lean as the matrix algebra
+on `Fin (hη.dR k) × Fin (hη.dL h)`. Positivity matches the paper's
+`η_{k,h} ≥ 0`. -/
+structure ExplicitEtaOperators
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    (hη : EtaStructure ρ_ABC) where
+  eta : (k h : Fin hη.m) →
+    Matrix (Fin (hη.dR k) × Fin (hη.dL h))
+      (Fin (hη.dR k) × Fin (hη.dL h)) ℂ
+  eta_pos : ∀ k h, (eta k h).PosSemidef
+
+/-- The underlying family of explicit neighboring operators in an
+`ExplicitEtaOperators` witness. -/
+abbrev etaOperators
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hη : EtaStructure ρ_ABC}
+    (data : ExplicitEtaOperators hη) :=
+  data.eta
+
+namespace ExplicitEtaOperators
+
+variable
+  {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+    (Fin dA × Fin dB × Fin dC) ℂ}
+  {hη : EtaStructure ρ_ABC}
+
+/-- The trace matrix attached to an explicit `η_{k,h}` family. -/
+noncomputable def traceMatrix (data : ExplicitEtaOperators hη) :
+    Matrix (Fin hη.m) (Fin hη.m) ℂ :=
+  fun k h => Matrix.trace (data.eta k h)
+
+@[simp] theorem traceMatrix_apply (data : ExplicitEtaOperators hη)
+    (k h : Fin hη.m) :
+    data.traceMatrix k h = Matrix.trace (data.eta k h) := rfl
+
+end ExplicitEtaOperators
 
 end LocalSAL
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -428,6 +428,62 @@ strong subadditivity for a normalized three-site reduced state.
     decomposition on the middle subsystem.
 \end{proof}
 
+\begin{definition}[Injective inverse-map layer for a simple MPO tensor]
+    \label{def:mpdo_injective_inverse_layer}
+    \lean{MPOTensor.IsInjective}
+    \lean{MPOTensor.inverseTensor}
+    \lean{MPOTensor.physRealize}
+    \lean{MPOTensor.physRealizeLeft}
+    \leanok
+    \uses{def:mpo_tensor, def:mpo_to_mps, def:injective, def:decomposition_map, def:phys_realize}
+    A simple MPO tensor $K$ is called injective if its doubled-index MPS tensor
+    is injective. For such a tensor, the chosen decomposition map of the
+    doubled-index MPS furnishes a concrete inverse tensor $K^{-1}$ together
+    with right- and left-physical realization maps that turn virtual bond
+    insertions back into local physical operators.
+\end{definition}
+
+\begin{theorem}[Inverse-map identities for an injective simple MPO tensor]
+    \label{thm:mpdo_injective_inverse_layer_spec}
+    \lean{MPOTensor.inverseTensor_spec}
+    \lean{MPOTensor.physRealize_spec}
+    \lean{MPOTensor.physRealize_mul}
+    \lean{MPOTensor.physRealizeLeft_spec}
+    \leanok
+    \uses{def:mpdo_injective_inverse_layer}
+    For an injective simple MPO tensor, contracting $K^{-1}$ with $K$ recovers
+    the matrix units on the virtual bond space. Likewise, every right virtual
+    insertion admits a physical realization, this realization is multiplicative,
+    and the analogous left-insertion statement also holds.
+\end{theorem}
+
+\begin{definition}[Explicit neighboring $\eta$-operator data]
+    \label{def:mpdo_explicit_eta_operators}
+    \lean{MPOTensor.etaOperators}
+    \lean{MPOTensor.ExplicitEtaOperators}
+    \leanok
+    \uses{def:mpdo_eta_structure}
+    Fix a Hayashi decomposition witness $h_\eta$. An explicit neighboring
+    $\eta$-family is a dependent family $(\eta_{k,h})$ indexed by sector pairs,
+    where $\eta_{k,h}$ acts on the neighboring bond space
+    $B_k^{R} \otimes B_h^{L}$. Bundling positivity for each pair gives the
+    structure \lean{MPOTensor.ExplicitEtaOperators}.
+\end{definition}
+
+\begin{definition}[Trace matrices of explicit $\eta$-data]
+    \label{def:mpdo_explicit_eta_trace_matrix}
+    \lean{MPOTensor.ExplicitEtaOperators.traceMatrix}
+    \lean{MPOTensor.ExplicitEtaOperators.traceMatrix_apply}
+    \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe}
+    \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe_apply}
+    \leanok
+    \uses{def:mpdo_explicit_eta_operators}
+    Every explicit neighboring $\eta$-family determines a sector-by-sector trace
+    matrix. We record both its complex-valued form and the real-part version,
+    which is the direct interface to the real Perron--Frobenius matrix $T$ used
+    in the rank-one step.
+\end{definition}
+
 \begin{definition}[Auxiliary matrix predicates for the rank-one step]
     \label{def:matrix_trace_rankone_predicates}
     \lean{Matrix.TracePowersConstant}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -466,8 +466,8 @@ strong subadditivity for a normalized three-site reduced state.
     Fix a Hayashi decomposition witness $h_\eta$. An explicit neighboring
     $\eta$-family is a dependent family $(\eta_{k,h})$ indexed by sector pairs,
     where $\eta_{k,h}$ acts on the neighboring bond space
-    $B_k^{R} \otimes B_h^{L}$. Bundling positivity for each pair gives the
-    structure \lean{MPOTensor.ExplicitEtaOperators}.
+    $B_k^{R} \otimes B_h^{L}$. Requiring positivity for each pair gives the
+    corresponding positive $\eta$-data.
 \end{definition}
 
 \begin{definition}[Trace matrices of explicit $\eta$-data]


### PR DESCRIPTION
## Summary

This draft starts issue #833 by adding the missing **injective inverse-map layer**
needed to pass from the Hayashi Markov decomposition to explicit neighboring
operators in Appendix C.2.

Current scaffold in `TNLean/MPS/MPDO/SimpleLocalStructure.lean`:
- adds `MPOTensor.IsInjective` as the doubled-index injectivity predicate for a simple MPO tensor
- adds `MPOTensor.inverseTensor`, `MPOTensor.physRealize`, and `MPOTensor.physRealizeLeft`
- adds the target explicit-operator interface `MPOTensor.ExplicitEtaOperators`, `MPOTensor.etaOperators`, and `ExplicitEtaOperators.traceMatrix`
- updates the module docstring to isolate the remaining index-identification theorem that connects the inverse maps to the Hayashi blocks

## Status

This is intentionally an early draft PR per the wave-11 workflow. The remaining work is to prove the actual local extraction statement producing `ExplicitEtaOperators` from the Hayashi decomposition plus the simple-MPDO inverse-map data.

## Validation so far

- Lean diagnostics clean for `TNLean/MPS/MPDO/SimpleLocalStructure.lean`
- `rg -n 'sorry|axiom' TNLean/MPS/MPDO/SimpleLocalStructure.lean` is clean
- full `lake build` / blueprint validation still pending while the fresh worktree warms its cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds new Lean definitions/theorems and blueprint documentation without changing existing logic; primary risk is downstream proof breakage from new APIs/notations around injectivity and `η`-data.
> 
> **Overview**
> Adds the missing **injective inverse-map layer** for simple MPO tensors: `MPOTensor.IsInjective`, a concrete inverse tensor `inverseTensor` with `inverseTensor_spec`, and right/left physical realization maps `physRealize`/`physRealizeLeft` (plus specs and multiplicativity).
> 
> Introduces a first-pass interface for **explicit neighboring `η_{k,h}` data** (`etaOperators`, `ExplicitEtaOperators`) and defines associated complex/real trace matrices (`traceMatrix`, `traceMatrixRe`) to feed the later Perron–Frobenius/rank-one step.
> 
> Updates the module documentation and the blueprint (`ch02b_mpdo.tex`) to reflect these new definitions/theorems and to explicitly isolate the remaining extraction lemma still to be formalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2fafd490bd593adc6b4fb260d803f7220bb20a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->