### PR TITLE
feat(MPS/Periodic): factor blocked equal-case Z-gauge follow-up (#829)

### DIFF
--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -275,8 +275,8 @@ private lemma evalWord_leftMul_of_commute
   | i :: w => by
       have hCommZi : Commute Z (A i) := by
         simpa [Commute] using hcomm i
-      have hCommPow : A i * Z ^ w.length = Z ^ w.length * A i := by
-        exact (hCommZi.symm.pow_right w.length).eq
+      have hCommPow : A i * Z ^ w.length = Z ^ w.length * A i :=
+        (hCommZi.symm.pow_right w.length).eq
       calc
         evalWord (fun j => Z * A j) (i :: w)
             = (Z * A i) * evalWord (fun j => Z * A j) w := by

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -265,6 +265,68 @@ theorem ZGaugeEquiv.of_period_one {A B : MPSTensor d D}
       (Y : Matrix (Fin D) (Fin D) ℂ))) hAi
   simpa [Matrix.mul_assoc] using this.symm
 
+private lemma evalWord_leftMul_of_commute
+    {A : MPSTensor d D} {Z : Matrix (Fin D) (Fin D) ℂ}
+    (hcomm : ∀ i : Fin d, Z * A i = A i * Z) :
+    ∀ w : List (Fin d),
+      evalWord (fun i => Z * A i) w = Z ^ w.length * evalWord A w
+  | [] => by simp [evalWord]
+  | i :: w => by
+      have hCommZi : Commute Z (A i) := by
+        simpa [Commute] using hcomm i
+      have hCommPow : A i * Z ^ w.length = Z ^ w.length * A i := by
+        exact (hCommZi.symm.pow_right w.length).eq
+      calc
+        evalWord (fun j => Z * A j) (i :: w)
+            = (Z * A i) * evalWord (fun j => Z * A j) w := by
+                simp [evalWord]
+        _ = (Z * A i) * (Z ^ w.length * evalWord A w) := by
+              rw [evalWord_leftMul_of_commute hcomm w]
+        _ = Z * (A i * Z ^ w.length) * evalWord A w := by
+              simp [Matrix.mul_assoc]
+        _ = Z * (Z ^ w.length * A i) * evalWord A w := by
+              rw [hCommPow]
+        _ = (Z * Z ^ w.length) * (A i * evalWord A w) := by
+              simp [Matrix.mul_assoc]
+        _ = Z ^ (w.length + 1) * evalWord A (i :: w) := by
+              simp [evalWord, pow_succ', Matrix.mul_assoc]
+
+/-- Blocking a `ℤ_m`-gauge equivalence by a full period kills the `Z`-phase and
+produces an ordinary gauge equivalence. -/
+theorem ZGaugeEquiv.blockTensor_gaugeEquiv {m : ℕ} {A B : MPSTensor d D}
+    (h : ZGaugeEquiv m A B) :
+    GaugeEquiv (blockTensor A m) (blockTensor B m) := by
+  classical
+  rcases h with ⟨Y, Z, hpow, hcomm, hrel⟩
+  refine ⟨Y⁻¹, ?_⟩
+  intro i
+  have hWord :
+      evalWord A (wordOfBlock d m i) =
+        (Y : Matrix (Fin D) (Fin D) ℂ) * evalWord B (wordOfBlock d m i) *
+          (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
+    calc
+      evalWord A (wordOfBlock d m i)
+          = Z ^ (wordOfBlock d m i).length * evalWord A (wordOfBlock d m i) := by
+              simp [length_wordOfBlock, hpow]
+      _ = evalWord (fun j => Z * A j) (wordOfBlock d m i) := by
+            symm
+            exact evalWord_leftMul_of_commute hcomm (wordOfBlock d m i)
+      _ = (Y : Matrix (Fin D) (Fin D) ℂ) * evalWord B (wordOfBlock d m i) *
+            (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
+            simpa using
+              (evalWord_gauge (A := B) (B := fun j => Z * A j) Y
+                (by intro j; simpa using hrel j) (wordOfBlock d m i))
+  have := congrArg (fun M =>
+    (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * M *
+      (Y : Matrix (Fin D) (Fin D) ℂ))) hWord
+  simpa [blockTensor, Matrix.mul_assoc] using this
+
+/-- Full-period blocking turns a `ℤ_m`-gauge equivalence into MPV equality. -/
+theorem ZGaugeEquiv.blockTensor_sameMPV {m : ℕ} {A B : MPSTensor d D}
+    (h : ZGaugeEquiv m A B) :
+    SameMPV (blockTensor A m) (blockTensor B m) :=
+  GaugeEquiv.sameMPV (ZGaugeEquiv.blockTensor_gaugeEquiv h)
+
 /-- Repeated periodic blocks have equal periods, provided they share peripheral spectrum. -/
 theorem IsPeriodic.period_eq_of_repeatedBlocks
     {m n : ℕ} {A B : MPSTensor d D}

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -1,5 +1,6 @@
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Irreducible.PeriodicBlocking
+import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Chain.Defs
 import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Channel.Peripheral.CyclicDecomposition
@@ -308,9 +309,8 @@ theorem ZGaugeEquiv.blockTensor_gaugeEquiv {m : ℕ} {A B : MPSTensor d D}
       evalWord A (wordOfBlock d m i)
           = Z ^ (wordOfBlock d m i).length * evalWord A (wordOfBlock d m i) := by
               simp [length_wordOfBlock, hpow]
-      _ = evalWord (fun j => Z * A j) (wordOfBlock d m i) := by
-            symm
-            exact evalWord_leftMul_of_commute hcomm (wordOfBlock d m i)
+      _ = evalWord (fun j => Z * A j) (wordOfBlock d m i) :=
+            (evalWord_leftMul_of_commute hcomm (wordOfBlock d m i)).symm
       _ = (Y : Matrix (Fin D) (Fin D) ℂ) * evalWord B (wordOfBlock d m i) *
             (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
             simpa using
@@ -319,7 +319,7 @@ theorem ZGaugeEquiv.blockTensor_gaugeEquiv {m : ℕ} {A B : MPSTensor d D}
   have := congrArg (fun M =>
     (((Y⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * M *
       (Y : Matrix (Fin D) (Fin D) ℂ))) hWord
-  simpa [blockTensor, Matrix.mul_assoc] using this
+  simpa [blockTensor, Matrix.mul_assoc] using this.symm
 
 /-- Full-period blocking turns a `ℤ_m`-gauge equivalence into MPV equality. -/
 theorem ZGaugeEquiv.blockTensor_sameMPV {m : ℕ} {A B : MPSTensor d D}

--- a/TNLean/MPS/Periodic/Symmetry.lean
+++ b/TNLean/MPS/Periodic/Symmetry.lean
@@ -34,6 +34,11 @@ The imported modules provide the original public declarations at the same
 names, including `PeriodicEqualCaseFT`,
 `cor_4_1_physical_symmetry_zgauge`,
 `pRefinementCanonicalization_pullback_of_irreducibleForm`,
+`PeripheralEqualCaseZGaugeOfSameMPV`, `PeripheralEqualCaseRootFromZGauge`,
+`peripheralEqualCase_periodicFT_of_sameMPV`,
+`PeripheralEqualCasePeriodicFTOfSameMPV`,
+`pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`,
+`thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV`,
 `IsPDivisibleChannel`, `IsPRefinable`,
 `thm_4_1_p_refinement_forward`,
 `thm_4_1_p_refinement_reverse`, and `thm_4_1_p_refinement`.

--- a/TNLean/MPS/Periodic/Symmetry.lean
+++ b/TNLean/MPS/Periodic/Symmetry.lean
@@ -32,13 +32,19 @@ lives in six focused supporting modules:
 
 The imported modules provide the original public declarations at the same
 names, including `PeriodicEqualCaseFT`,
+`ZGaugeEquiv.blockTensor_gaugeEquiv`, `ZGaugeEquiv.blockTensor_sameMPV`,
 `cor_4_1_physical_symmetry_zgauge`,
 `pRefinementCanonicalization_pullback_of_irreducibleForm`,
 `PeripheralEqualCaseZGaugeOfSameMPV`, `PeripheralEqualCaseRootFromZGauge`,
 `peripheralEqualCase_periodicFT_of_sameMPV`,
-`PeripheralEqualCasePeriodicFTOfSameMPV`,
+`PeripheralEqualCasePeriodicFTOfSameMPV`, `PRefinementCanonicalization`,
 `pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`,
 `thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV`,
+`PeripheralEqualCaseRootChannelOfZGauge`,
+`peripheralEqualCaseRootFromZGauge_of_rootChannel`,
+`PRefinementInverseCanonicalization`,
+`PRefinementInverseRootKrausRankBound`,
+`pRefinementInverseCanonicalization_of_rootKrausRankBound`,
 `IsPDivisibleChannel`, `IsPRefinable`,
 `thm_4_1_p_refinement_forward`,
 `thm_4_1_p_refinement_reverse`, and `thm_4_1_p_refinement`.

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -345,6 +345,82 @@ theorem thm_4_1_p_refinement_forward_witness
   ⟨transferMap A, transferMap_isChannel A hA_norm, by
     rw [hTransferEq, transferMap_blockTensor]⟩
 
+/-- **Blocked Z-gauge extraction for the periodic equal-case stage.**
+
+This Prop isolates the existence half of the blocked equal-case argument needed
+for Theorem 4.1: whenever an irreducible-form blocked tensor `C` has the same
+MPV family as a blocked root `blockTensor A p`, one can extract a periodic
+`Z`-gauge witness between `C` and `blockTensor A p`.
+
+Compared with `PeripheralEqualCasePeriodicFTOfSameMPV`, this does **not** yet
+recover a left-canonical root. It only packages the blocked equal-case
+Fundamental Theorem / Z-phase existence step. -/
+def PeripheralEqualCaseZGaugeOfSameMPV (d D p : ℕ) : Prop :=
+  ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D},
+    IsIrreducibleForm C →
+    SameMPV C (blockTensor A p) →
+      ∃ m : ℕ, 0 < m ∧ ZGaugeEquiv m C (blockTensor A p)
+
+/-- **Blocked-to-root reconstruction from a periodic `Z`-gauge witness.**
+
+This Prop isolates the second half of the blocked equal-case argument: once a
+blocked tensor `C` is related to `blockTensor A p` by a periodic `Z`-gauge,
+one can distribute that blocked phase data across a root tensor `A'` so that
+`A'` is left-canonical and `E_C = E_{A'^{[p]}}`.
+
+In the paper this is the blocked-to-root phase-distribution step after the
+periodic equal-case Fundamental Theorem. -/
+def PeripheralEqualCaseRootFromZGauge (d D p : ℕ) : Prop :=
+  ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D} {m : ℕ},
+    IsIrreducibleForm C →
+    0 < m →
+    ZGaugeEquiv m C (blockTensor A p) →
+      ∃ A' : MPSTensor d D,
+        (∑ i : Fin d, (A' i)ᴴ * A' i = 1) ∧
+        transferMap C = transferMap (blockTensor A' p)
+
+/-- **Blocked equal-case/root-reconstruction hypothesis for Theorem 4.1.**
+
+This Prop isolates exactly the remaining forward input after
+`pRefinementCanonicalization_pullback_of_irreducibleForm`: whenever an
+irreducible-form blocked tensor `C` has the same MPV family as a blocked root
+`blockTensor A p`, one can replace `A` by a left-canonical root `A'` with the
+same blocked transfer map, `E_C = E_{A'^{[p]}}`.
+
+In the paper this is the point where the blocked equal-case Fundamental Theorem
+(Theorem 3.8 of arXiv:1708.00029) is combined with the blocked-to-root
+reconstruction that distributes the resulting `Z`-gauge across the cyclic
+sectors of `A`. Formalizing that existence step is the remaining forward
+obstruction, so we package its endpoint as a separate hypothesis. The theorem
+`peripheralEqualCase_periodicFT_of_sameMPV` below shows that this endpoint
+follows from the sharper split into blocked `Z`-gauge extraction and
+blocked-to-root reconstruction. -/
+def PeripheralEqualCasePeriodicFTOfSameMPV (d D p : ℕ) : Prop :=
+  ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D},
+    IsIrreducibleForm C →
+    SameMPV C (blockTensor A p) →
+      ∃ A' : MPSTensor d D,
+        (∑ i : Fin d, (A' i)ᴴ * A' i = 1) ∧
+        transferMap C = transferMap (blockTensor A' p)
+
+/-- **Blocked equal-case continuation from Z-gauge extraction and reconstruction.**
+
+If we can first extract a blocked periodic `Z`-gauge from
+`SameMPV C (blockTensor A p)` and then distribute that blocked `Z`-phase back
+to a left-canonical root, then the continuation hypothesis
+`PeripheralEqualCasePeriodicFTOfSameMPV` holds.
+
+This splits the blocked equal-case continuation into two explicit obligations:
+the blocked equal-case `Z`-gauge existence step and the subsequent
+blocked-to-root reconstruction. -/
+theorem peripheralEqualCase_periodicFT_of_sameMPV
+    (hZGauge : PeripheralEqualCaseZGaugeOfSameMPV d D p)
+    (hRoot : PeripheralEqualCaseRootFromZGauge d D p) :
+    PeripheralEqualCasePeriodicFTOfSameMPV d D p := by
+  intro A C hC hSame
+  obtain ⟨m, hm, hZ⟩ := hZGauge (A := A) (C := C) hC hSame
+  exact hRoot (A := A) (C := C) (m := m) hC hm hZ
+
 /-- **Canonicalization hypothesis for the forward direction of Theorem 4.1.**
 
 This Prop states the analytic content that remains between the
@@ -366,12 +442,59 @@ between `C` and `blockTensor A p`, which — combined with a unitary
 canonical-form reduction for irreducible form II and Wolf Theorem 2.18 —
 produces the sought left-canonical witness. Formalizing this remaining second
 stage in Lean still requires infrastructure (canonical unitary gauge, Kraus
-uniqueness), so we expose the end-result predicate as a hypothesis. -/
+uniqueness), so we expose the end-result predicate as a hypothesis. The theorem
+`pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`
+below shows that this coarse hypothesis follows from the sharper blocked-stage
+hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
 def PRefinementCanonicalization (d D p : ℕ) : Prop :=
   ∀ {B : MPSTensor d D}, IsIrreducibleForm B → IsPRefinable B p →
     ∃ A : MPSTensor d D,
       (∑ i : Fin d, (A i)ᴴ * A i = 1) ∧
       transferMap B = transferMap (blockTensor A p)
+
+/-- **Reduction of forward canonicalization to the blocked equal-case stage.**
+
+Assuming `PeripheralEqualCasePeriodicFTOfSameMPV`, the pullback theorem
+`pRefinementCanonicalization_pullback_of_irreducibleForm` already yields the
+full forward-side canonicalization hypothesis `PRefinementCanonicalization`.
+Thus the remaining forward gap in Theorem 4.1 is exactly the blocked
+equal-case/root-reconstruction step packaged by
+`PeripheralEqualCasePeriodicFTOfSameMPV`. -/
+theorem pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV
+    (hPeripheralEq : PeripheralEqualCasePeriodicFTOfSameMPV d D p) :
+    PRefinementCanonicalization d D p := by
+  intro B hB hRefine
+  obtain ⟨A, W, hC, _hW, hTransfer, hSame⟩ :=
+    pRefinementCanonicalization_pullback_of_irreducibleForm B hB p hRefine
+  let C : MPSTensor (blockPhysDim d p) D :=
+    fun τ : Fin (blockPhysDim d p) => ∑ σ : Fin d, W τ σ • B σ
+  have hC' : IsIrreducibleForm C := by
+    simpa [C] using hC
+  have hTransfer' : transferMap C = transferMap B := by
+    simpa [C] using hTransfer
+  have hSame' : SameMPV C (blockTensor A p) := by
+    simpa [C] using hSame
+  obtain ⟨A', hA'_norm, hTransferA'⟩ := hPeripheralEq (A := A) (C := C) hC' hSame'
+  refine ⟨A', hA'_norm, ?_⟩
+  calc
+    transferMap B = transferMap C := hTransfer'.symm
+    _ = transferMap (blockTensor A' p) := hTransferA'
+
+/-- **Forward direction of Theorem 4.1 from the blocked equal-case stage.**
+
+This repackages `thm_4_1_p_refinement_forward` after replacing the coarse
+hypothesis `PRefinementCanonicalization` by the sharper blocked-stage
+hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
+theorem thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV
+    (B : MPSTensor d D) (hB : IsIrreducibleForm B)
+    (p : ℕ)
+    (hPeripheralEq : PeripheralEqualCasePeriodicFTOfSameMPV d D p)
+    (hRefine : IsPRefinable B p) :
+    IsPDivisibleChannel (transferMap B) p := by
+  obtain ⟨A, hA_norm, hTransferEq⟩ :=
+    (pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV
+      hPeripheralEq) hB hRefine
+  exact thm_4_1_p_refinement_forward_witness B p A hA_norm hTransferEq
 
 /-- **Forward direction of Theorem 4.1 (conditional form).**
 

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -353,7 +353,7 @@ MPV family as a blocked root `blockTensor A p`, one can extract a periodic
 `Z`-gauge witness between `C` and `blockTensor A p`.
 
 Compared with `PeripheralEqualCasePeriodicFTOfSameMPV`, this does **not** yet
-recover a left-canonical root. It only packages the blocked equal-case
+recover a left-canonical root. It only records the blocked equal-case
 Fundamental Theorem / Z-phase existence step. -/
 def PeripheralEqualCaseZGaugeOfSameMPV (d D p : ℕ) : Prop :=
   ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D},
@@ -391,7 +391,7 @@ In the paper this is the point where the blocked equal-case Fundamental Theorem
 (Theorem 3.8 of arXiv:1708.00029) is combined with the blocked-to-root
 reconstruction that distributes the resulting `Z`-gauge across the cyclic
 sectors of `A`. Formalizing that existence step is the remaining forward
-obstruction, so we package its endpoint as a separate hypothesis. The theorem
+obstruction, so we record its endpoint as a separate hypothesis. The theorem
 `peripheralEqualCase_periodicFT_of_sameMPV` below shows that this endpoint
 follows from the sharper split into blocked `Z`-gauge extraction and
 blocked-to-root reconstruction. -/
@@ -458,7 +458,7 @@ Assuming `PeripheralEqualCasePeriodicFTOfSameMPV`, the pullback theorem
 `pRefinementCanonicalization_pullback_of_irreducibleForm` already yields the
 full forward-side canonicalization hypothesis `PRefinementCanonicalization`.
 Thus the remaining forward gap in Theorem 4.1 is exactly the blocked
-equal-case/root-reconstruction step packaged by
+equal-case/root-reconstruction step captured by
 `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
 theorem pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV
     (hPeripheralEq : PeripheralEqualCasePeriodicFTOfSameMPV d D p) :
@@ -482,7 +482,7 @@ theorem pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV
 
 /-- **Forward direction of Theorem 4.1 from the blocked equal-case stage.**
 
-This repackages `thm_4_1_p_refinement_forward` after replacing the coarse
+This restates `thm_4_1_p_refinement_forward` after replacing the coarse
 hypothesis `PRefinementCanonicalization` by the sharper blocked-stage
 hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
 theorem thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
@@ -40,7 +40,7 @@ def PRefinementInverseCanonicalization (d D p : ℕ) : Prop :=
     IsPDivisibleChannel (transferMap B) p →
     ∃ A : MPSTensor d D, transferMap B = transferMap (blockTensor A p)
 
-/-- A bounded Kraus-rank witness for a channel root can be re-packaged as an
+/-- A bounded Kraus-rank witness for a channel root can be expressed as an
 `MPSTensor` with the ambient physical dimension by zero-padding the Kraus family. -/
 theorem exists_tensor_of_hasKrausRankLE
     {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean
@@ -52,6 +52,49 @@ theorem exists_tensor_of_hasKrausRankLE
   ext X i j
   simpa [transferMap_apply] using congrArg (fun M => M i j) (hK X).symm
 
+/-- **Channel-root formulation of blocked-to-root reconstruction.**
+
+This Prop isolates the channel-theoretic core of
+`PeripheralEqualCaseRootFromZGauge`: from a blocked `Z`-gauge witness between
+`C` and `blockTensor A p`, extract a CPTP root `E'` of `transferMap C` whose
+Kraus rank is at most the ambient physical dimension `d`. Once such a root is
+available, the tensor-level reconstruction follows by choosing a Kraus family
+with `d` operators. -/
+def PeripheralEqualCaseRootChannelOfZGauge (d D p : ℕ) : Prop :=
+  ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D} {m : ℕ},
+    IsIrreducibleForm C →
+    0 < m →
+    ZGaugeEquiv m C (blockTensor A p) →
+      ∃ E' : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
+        IsChannel E' ∧
+        transferMap C = E' ^ p ∧
+        Channel.HasKrausRankLE (D := D) E' d
+
+/-- **Tensor-level blocked-to-root reconstruction from a bounded channel root.**
+
+If a blocked `Z`-gauge witness yields a CPTP root channel of `transferMap C`
+with Kraus rank at most `d`, then one can choose a tensor `A' : MPSTensor d D`
+realizing that root. The channel property forces `A'` to be left-canonical,
+and blocking recovers the transfer map of `C`. -/
+theorem peripheralEqualCaseRootFromZGauge_of_rootChannel
+    (hRoot : PeripheralEqualCaseRootChannelOfZGauge d D p) :
+    PeripheralEqualCaseRootFromZGauge d D p := by
+  intro A C m hC hm hZ
+  obtain ⟨E', hE'chan, hpow, hRank⟩ :=
+    hRoot (A := A) (C := C) (m := m) hC hm hZ
+  obtain ⟨A', hA'⟩ := exists_tensor_of_hasKrausRankLE (d := d) (D := D) hRank
+  refine ⟨A', ?_, ?_⟩
+  · have hK :
+        ∀ X : Matrix (Fin D) (Fin D) ℂ,
+          E' X = ∑ i : Fin d, A' i * X * (A' i)ᴴ := by
+        intro X
+        simpa [transferMap_apply] using (congrArg (fun T => T X) hA').symm
+    simpa using kraus_sum_conjTranspose_mul_of_tp A' E' hK hE'chan.tp
+  · calc
+      transferMap C = E' ^ p := hpow
+      _ = (transferMap A') ^ p := by rw [← hA']
+      _ = transferMap (blockTensor A' p) := by rw [transferMap_blockTensor]
+
 /-- A clean root-cardinality hypothesis that isolates the remaining Kraus-rank
 step in the reverse direction of Theorem 4.1. -/
 def PRefinementInverseRootKrausRankBound (d D p : ℕ) : Prop :=

--- a/audits/2026-04-23_issue829_zgauge_v2.md
+++ b/audits/2026-04-23_issue829_zgauge_v2.md
@@ -1,0 +1,54 @@
+# Issue #829 audit — blocked equal-case Z-gauge follow-up
+
+## Scope
+
+Target issue: `formalization(MPS/Periodic): supply PeripheralEqualCaseZGaugeOfSameMPV and PeripheralEqualCaseRootFromZGauge for Thm. 3.8 (#787 follow-up)`.
+
+Main file family:
+- `TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean`
+- `TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean`
+- `TNLean/MPS/Periodic/Defs.lean`
+
+## Baseline on `origin/main`
+
+`origin/main` did **not** yet contain the split blocked equal-case predicates from PR #799:
+- `PeripheralEqualCaseZGaugeOfSameMPV`
+- `PeripheralEqualCaseRootFromZGauge`
+- `PeripheralEqualCasePeriodicFTOfSameMPV`
+- `peripheralEqualCase_periodicFT_of_sameMPV`
+
+So the first necessary step was to port that decomposition onto a clean branch from `origin/main`.
+
+## What this branch adds so far
+
+1. Ported the #799 blocked equal-case split into `Theorem41Forward.lean` and the public synopsis file `Symmetry.lean`.
+2. Added a reusable periodic lemma in `Periodic/Defs.lean`:
+   - `ZGaugeEquiv.blockTensor_gaugeEquiv`
+   - consequence: `ZGaugeEquiv.blockTensor_sameMPV`
+
+   This formalizes the simple but useful fact that after blocking by a full `m`, the `Z`-phase disappears because `Z^m = 1`, so a `ℤ_m`-gauge becomes an ordinary gauge equivalence.
+3. Added a sharper reverse-side reduction in `Theorem41Reverse.lean`:
+   - `PeripheralEqualCaseRootChannelOfZGauge`
+   - `peripheralEqualCaseRootFromZGauge_of_rootChannel`
+
+   This isolates the remaining tensor-level root reconstruction to a cleaner channel statement:
+   from a blocked `Z`-gauge witness, it suffices to produce a CPTP root of `transferMap C` with Kraus rank at most `d`.
+
+## Current honest blocker
+
+The full issue is still blocked at the same conceptual point identified in the earlier #787 work:
+
+- extracting the blocked equal-case `Z`-gauge from `SameMPV C (blockTensor A p)` in full generality, and
+- distributing the resulting blocked `Z`-phase back to a root tensor of physical dimension `d`.
+
+The new channel-root reduction shows that the second obstruction can be stated independently of the tensor bookkeeping: the remaining missing input is a bounded-Kraus-rank channel root theorem tailored to the blocked `Z`-gauge situation.
+
+## Verification status
+
+Lean diagnostics report no errors on:
+- `TNLean/MPS/Periodic/Defs.lean`
+- `TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean`
+- `TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean`
+- `TNLean/MPS/Periodic/Symmetry.lean`
+
+A full `lake build` from the fresh worktree still needs to finish once dependency compilation settles.

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -285,6 +285,37 @@ $p$-divisibility of the transfer map.
     that appears only for $m > 1$.
 \end{remark}
 
+\begin{theorem}[Blocking a $\mathbb Z_m$-gauge gives an ordinary gauge]
+    \label{thm:z_gauge_blockTensor_gauge_equiv}
+    \lean{MPSTensor.ZGaugeEquiv.blockTensor_gaugeEquiv}
+    \leanok
+    \uses{def:z_gauge_equiv, def:blocked_tensor, def:gauge_equiv}
+    If $A$ and $B$ are $\mathbb Z_m$-gauge equivalent, then their $m$-blocked
+    tensors $A^{[m]}$ and $B^{[m]}$ are gauge equivalent in the ordinary sense.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write the $\mathbb Z_m$-gauge relation as
+    $Z A^i = Y B^i Y^{-1}$ with $Z^m = \Id$ and $[A^i, Z] = 0$.
+    For a blocked letter, commute one factor of $Z$ past each physical letter in
+    the associated length-$m$ word. The total prefactor becomes $Z^m = \Id$,
+    so the entire blocked word is related by the same ordinary gauge $Y$.
+\end{proof}
+
+\begin{corollary}[Blocking a $\mathbb Z_m$-gauge preserves the MPV family]
+    \label{cor:z_gauge_blockTensor_same_mpv}
+    \lean{MPSTensor.ZGaugeEquiv.blockTensor_sameMPV}
+    \leanok
+    \uses{thm:z_gauge_blockTensor_gauge_equiv, thm:gauge_invariance}
+    If $A$ and $B$ are $\mathbb Z_m$-gauge equivalent, then the blocked tensors
+    $A^{[m]}$ and $B^{[m]}$ have the same MPV family.
+\end{corollary}
+
+\begin{proof}\leanok
+    Apply Theorem~\ref{thm:z_gauge_blockTensor_gauge_equiv} and then the gauge
+    invariance of MPV families.
+\end{proof}
+
 \section{Periodic Fundamental Theorem}%
 \label{sec:periodic_ft}
 
@@ -849,7 +880,100 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     irreducible-form decomposition of $C$.
 \end{proof}
 
-\begin{theorem}[$p$-refinability iff $p$-divisibility]%
+\begin{definition}[Blocked equal-case Z-gauge extraction hypothesis]
+    \label{def:peripheral_equalcase_zgauge_sameMPV}
+    \lean{MPSTensor.PeripheralEqualCaseZGaugeOfSameMPV}
+    \leanok
+    \uses{def:irreducible_form, def:blocked_tensor, def:same_mpv, def:z_gauge_equiv}
+    Fix $(d,D,p)$. This hypothesis says that whenever a blocked tensor $C$ in
+    irreducible form~II has the same MPV family as a blocked root $A^{[p]}$,
+    there exists an integer $m \ge 1$ and a $\mathbb Z_m$-gauge equivalence
+    between $C$ and $A^{[p]}$.
+\end{definition}
+
+\begin{definition}[Blocked-to-root reconstruction hypothesis from Z-gauge]
+    \label{def:peripheral_equalcase_root_from_zgauge}
+    \lean{MPSTensor.PeripheralEqualCaseRootFromZGauge}
+    \leanok
+    \uses{def:irreducible_form, def:blocked_tensor, def:z_gauge_equiv}
+    Fix $(d,D,p)$. This hypothesis says that if $m \ge 1$ and a blocked tensor
+    $C$ in irreducible form~II is $\mathbb Z_m$-gauge equivalent to $A^{[p]}$,
+    then there exists a tensor $A'$ with
+    $\sum_i (A'^i)^\dagger A'^i = \Id$ and
+    $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
+\end{definition}
+
+\begin{definition}[Blocked equal-case continuation hypothesis]
+    \label{def:peripheral_equalcase_periodicFT_sameMPV}
+    \lean{MPSTensor.PeripheralEqualCasePeriodicFTOfSameMPV}
+    \leanok
+    \uses{def:irreducible_form, def:blocked_tensor, def:same_mpv}
+    Fix $(d,D,p)$. This packages the combined continuation statement: whenever a
+    blocked tensor $C$ in irreducible form~II has the same MPV family as a
+    blocked root $A^{[p]}$, one can replace $A$ by a left-canonical tensor $A'$
+    with $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
+\end{definition}
+
+\begin{theorem}[Blocked equal-case continuation from Z-gauge extraction]
+    \label{thm:peripheral_equalcase_sameMPV_zgauge_reduction}
+    \lean{MPSTensor.peripheralEqualCase_periodicFT_of_sameMPV}
+    \leanok
+    \uses{def:peripheral_equalcase_zgauge_sameMPV,
+          def:peripheral_equalcase_root_from_zgauge,
+          def:peripheral_equalcase_periodicFT_sameMPV}
+    If the blocked equal-case Z-gauge extraction hypothesis and the
+    blocked-to-root reconstruction hypothesis both hold, then the combined
+    blocked equal-case continuation hypothesis holds.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the Z-gauge extraction hypothesis to obtain a blocked
+    $\mathbb Z_m$-gauge witness between $C$ and $A^{[p]}$, and then apply the
+    reconstruction hypothesis to that witness.
+\end{proof}
+
+\begin{theorem}[Reduction of forward canonicalization to the blocked equal-case stage]
+    \label{thm:p_refinement_forward_equalcase_reduction}
+    \lean{MPSTensor.pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV}
+    \leanok
+    \uses{def:peripheral_equalcase_periodicFT_sameMPV,
+          def:irreducible_form, def:p_refinable,
+          thm:p_refinement_pullback_irreducible_form}
+    Assume the blocked equal-case continuation hypothesis. Then every
+    $p$-refinable tensor $B$ in irreducible form~II admits a left-canonical root
+    $A'$ with $\mathcal E_B = \mathcal E_{A'^{[p]}}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply Theorem~\ref{thm:p_refinement_pullback_irreducible_form} to the
+    refinement witness of $B$. This produces a blocked tensor $C$ in
+    irreducible form~II with $\mathcal E_C = \mathcal E_B$ and the same MPV
+    family as $A^{[p]}$. The blocked equal-case continuation hypothesis then
+    gives a left-canonical tensor $A'$ with
+    $\mathcal E_C = \mathcal E_{A'^{[p]}}$. Combining the two transfer-map
+    identities yields $\mathcal E_B = \mathcal E_{A'^{[p]}}$.
+\end{proof}
+
+\begin{theorem}[Forward direction from the blocked equal-case continuation]
+    \label{thm:thm_4_1_p_refinement_forward_blocked_equalcase}
+    \lean{MPSTensor.thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV}
+    \leanok
+    \uses{def:peripheral_equalcase_periodicFT_sameMPV,
+          def:irreducible_form, def:p_refinable, def:p_divisible_channel,
+          thm:p_refinement_forward_equalcase_reduction}
+    Assume the blocked equal-case continuation hypothesis. Then for every tensor
+    $B$ in irreducible form~II, $p$-refinability of $B$ implies
+    $p$-divisibility of $\mathcal E_B$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Combine Theorem~\ref{thm:p_refinement_forward_equalcase_reduction} with the
+    witness-level forward implication: once $\mathcal E_B$ is identified with
+    $\mathcal E_{A'^{[p]}}$ for a left-canonical $A'$, the blocking identity
+    gives $\mathcal E_B = (\mathcal E_{A'})^p$.
+\end{proof}
+
+\begin{theorem}[Thm.~4.1 — $p$-refinability $\iff$ $p$-divisibility]%
     \label{thm:thm_4_1_p_refinement}
     \lean{MPSTensor.thm_4_1_p_refinement}
     \leanok
@@ -865,15 +989,15 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
 
 \begin{proof}\leanok
     \uses{thm:thm_4_1_p_refinement_forward, thm:thm_4_1_p_refinement_reverse}
-    Combine the forward implication
+    Bundle the forward implication
     (Theorem~\ref{thm:thm_4_1_p_refinement_forward}) with the reverse
     implication (Theorem~\ref{thm:thm_4_1_p_refinement_reverse}) into a
-    single biconditional.  Both directions are stated conditionally
-    on their respective canonicalization hypotheses, whose combination
-    yields the full equivalence.
+    single biconditional. Both directions are formalised conditionally on their
+    respective canonicalization hypotheses, whose combination yields the full
+    equivalence.
 \end{proof}
 
-\begin{theorem}[$p$-refinability implies $p$-divisibility under the canonicalization hypothesis]%
+\begin{theorem}[Thm.~4.1 forward direction, conditional form]%
     \label{thm:thm_4_1_p_refinement_forward}
     \lean{MPSTensor.thm_4_1_p_refinement_forward}
     \leanok
@@ -887,41 +1011,72 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
 \begin{proof}\leanok
     The canonicalization hypothesis supplies a witness $A$ with
     $\sum_i (A^i)^\dagger A^i = \Id$ (left-canonical) and
-    $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$. The left-canonical property
-    makes $\mathcal{E}_A$ a CPTP channel, and the blocking identity
-    $\mathcal{E}_{A^{[p]}} = (\mathcal{E}_A)^p$ given by
+    $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$. The left-canonical property makes
+    $\mathcal{E}_A$ a CPTP channel, and the blocking identity
+    $\mathcal{E}_{A^{[p]}} = (\mathcal{E}_A)^p$ (formalised as
     \lean{MPSTensor.transferMap_blockTensor}) then identifies
     $\mathcal{E}_B$ with the $p$-th power of the channel $\mathcal{E}_A$.
 \end{proof}
 
-\begin{theorem}[$p$-divisibility implies $p$-refinability under the inverse canonicalization hypothesis]%
+\begin{definition}[Blocked-to-root channel-root hypothesis from Z-gauge]
+    \label{def:peripheral_equalcase_root_channel_from_zgauge}
+    \lean{MPSTensor.PeripheralEqualCaseRootChannelOfZGauge}
+    \leanok
+    \uses{def:peripheral_equalcase_root_from_zgauge, def:z_gauge_equiv,
+          def:p_divisible_channel}
+    Fix $(d,D,p)$. This sharpened reconstruction hypothesis asks for a CPTP map
+    $\mathcal E'$ such that
+    $\mathcal E_C = (\mathcal E')^p$ and the Choi/Kraus rank of
+    $\mathcal E'$ is at most $d$, whenever $C$ is related to $A^{[p]}$ by a
+    blocked $\mathbb Z_m$-gauge witness.
+\end{definition}
+
+\begin{theorem}[Channel-root criterion for blocked-to-root reconstruction]
+    \label{thm:peripheral_equalcase_root_from_root_channel}
+    \lean{MPSTensor.peripheralEqualCaseRootFromZGauge_of_rootChannel}
+    \leanok
+    \uses{def:peripheral_equalcase_root_channel_from_zgauge,
+          def:peripheral_equalcase_root_from_zgauge}
+    If the blocked-to-root channel-root hypothesis holds, then the tensor-level
+    blocked-to-root reconstruction hypothesis holds as well.
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose a tensor $A'$ realizing the bounded Kraus family of the root channel.
+    Because the channel is trace-preserving, the Kraus operators of $A'$ satisfy
+    $\sum_i (A'^i)^\dagger A'^i = \Id$. The identity
+    $\mathcal E_C = (\mathcal E_{A'})^p$ is then equivalent to
+    $\mathcal E_C = \mathcal E_{A'^{[p]}}$ by the blocking formula.
+\end{proof}
+
+\begin{theorem}[Thm.~4.1 reverse direction, conditional form]%
     \label{thm:thm_4_1_p_refinement_reverse}
     \lean{MPSTensor.thm_4_1_p_refinement_reverse}
     \leanok
     \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel}
     Let $B$ be an MPS tensor in irreducible form~II and let $p \ge 1$.
-    Assume an \emph{inverse canonicalization} hypothesis providing a
-    witness tensor $A$ with the same physical and bond dimensions as $B$ and
+    Assume an \emph{inverse canonicalization} hypothesis providing a witness
+    $A : \mathrm{MPSTensor}\ d\ D$ with
     $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$ whenever $\mathcal{E}_B$ is
-    $p$-divisible.  Then $p$-divisibility of $\mathcal{E}_B$ implies
+    $p$-divisible. Then $p$-divisibility of $\mathcal{E}_B$ implies
     $p$-refinability of $B$.
 \end{theorem}
 
 \begin{proof}\leanok
-    From the inverse canonicalization hypothesis, extract
-    $A$ with $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$.  This matches two
-    finite Kraus families of the same completely positive map: the
-    blocked family $A^{[p]}$ with $d^{p}$ operators and the original
-    family $B$ with $d$ operators.  The cardinality comparison
-    $d \le d^{p}$ holds whenever $p \ge 1$, so the isometric freedom of
-    Kraus representations (\lean{kraus_isometry_freedom_iff}) supplies an
-    isometry $V \in M_{d^p \times d}(\C)$ with $V^{\dagger} V = \Id$ and
-    $(A^{[p]})^{\alpha} = \sum_{j} V_{\alpha,j}\, B^{j}$.  Expanding
-    the blocked MPV coefficient $V^{(N)}(A^{[p]})_\tau$ by linearity of
-    matrix multiplication and of the trace, the contributions
-    reorganise into the $V$-weighted sum over length-$N$ words of $B$
-    required by Definition~\ref{def:p_refinable}, exhibiting $V$ as the
-    isometry $W$ in the statement of $p$-refinability.
+    From the inverse canonicalization hypothesis, extract $A$ with
+    $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$. This matches two finite Kraus
+    families of the same completely positive map: the blocked family $A^{[p]}$
+    with $d^{p}$ operators and the original family $B$ with $d$ operators.
+    The cardinality comparison $d \le d^{p}$ holds whenever $p \ge 1$, so Wolf
+    Theorem~2.18 (isometric freedom of Kraus representations, formalised as
+    \lean{kraus_isometry_freedom_iff}) supplies an isometry
+    $V \in M_{d^p \times d}(\C)$ with $V^{\dagger} V = \Id$ and
+    $(A^{[p]})^{\alpha} = \sum_{j} V_{\alpha,j}\, B^{j}$. Expanding
+    $\mathrm{coeff}\,(A^{[p]})\,(\mathrm{ofFn}\,\tau)$ by linearity of matrix
+    multiplication and of the trace, the contributions reorganise into the
+    $V$-weighted sum over length-$N$ words of $B$ required by
+    Definition~\ref{def:p_refinable}, exhibiting $V$ as the isometry $W$ in the
+    statement of $p$-refinability.
 \end{proof}
 
 \begin{remark}[Continuum-limit application]\notready

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -908,7 +908,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.PeripheralEqualCasePeriodicFTOfSameMPV}
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:same_mpv}
-    Fix $(d,D,p)$. This packages the combined continuation statement: whenever a
+    Fix $(d,D,p)$. This states the combined continuation statement: whenever a
     blocked tensor $C$ in irreducible form~II has the same MPV family as a
     blocked root $A^{[p]}$, one can replace $A$ by a left-canonical tensor $A'$
     with $\mathcal E_C = \mathcal E_{A'^{[p]}}$.


### PR DESCRIPTION
## Summary
- port the blocked equal-case split from #799 onto a clean branch from `origin/main`
- add `ZGaugeEquiv.blockTensor_gaugeEquiv` and `ZGaugeEquiv.blockTensor_sameMPV`
- reduce `PeripheralEqualCaseRootFromZGauge` to a bounded channel-root statement via `PeripheralEqualCaseRootChannelOfZGauge`

## Status
This is an honest forward step on #829, not a full discharge yet. The remaining gap is still the actual extraction of the blocked `Z`-gauge from `SameMPV` and the channel-root theorem needed to recover a physical-dimension-`d` root.

## Verification
- Lean diagnostics clean on touched files
- audit note: `audits/2026-04-23_issue829_zgauge_v2.md`
- `lake build` is running in the fresh worktree while dependency compilation settles

Refs #829

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new foundational lemmas/hypothesis interfaces (`ZGaugeEquiv.blockTensor_gaugeEquiv` and new blocked equal-case predicates) that may affect downstream theorem statements and proof dependencies, even though changes are purely formal/proof-level with no runtime behavior.
> 
> **Overview**
> Adds `ZGaugeEquiv.blockTensor_gaugeEquiv` (and derived `blockTensor_sameMPV`) showing that blocking by the full `m` turns a `ℤ_m`-gauge equivalence into an ordinary `GaugeEquiv`/`SameMPV`, via a new commuting `evalWord` lemma.
> 
> Refactors the forward direction of Theorem 4.1 by introducing explicit blocked equal-case predicates (`PeripheralEqualCaseZGaugeOfSameMPV`, `PeripheralEqualCaseRootFromZGauge`, `PeripheralEqualCasePeriodicFTOfSameMPV`) and proving reductions that let `thm_4_1_p_refinement_forward` depend on this sharper blocked-stage hypothesis.
> 
> On the reverse side, introduces `PeripheralEqualCaseRootChannelOfZGauge` and proves `peripheralEqualCaseRootFromZGauge_of_rootChannel`, reducing tensor-level reconstruction to existence of a CPTP root channel with Kraus rank `≤ d`, and updates public docs/blueprint and adds an audit note describing the partial progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76bdc44509ec5b4edf1f4f1cc7b3e0d3ce7d1035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->