### PR TITLE
feat(Archive/MPDO): add Perron-Frobenius rank-one counterexample

### DIFF
--- a/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
+++ b/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
@@ -4,7 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
 import Mathlib.Data.Matrix.Mul
-import Mathlib.Tactic
+import Mathlib.Data.Real.Basic
+import Mathlib.LinearAlgebra.Matrix.Notation
+import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 
 /-!
 # Counterexample: primitivity plus constant trace powers does not imply rank one

--- a/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
+++ b/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
+import Mathlib.Data.Matrix.Mul
+import Mathlib.Tactic
+
+/-!
+# Counterexample: primitivity plus constant trace powers does not imply rank one
+
+The standalone matrix statement
+
+    `Matrix.IsPrimitive T → Matrix.TracePowersConstant T → HasRankOneFactorization T`
+
+corresponding to `Matrix.PrimitiveTracePowersConstantImpliesRankOne` in
+`TNLean/MPS/MPDO/SimpleLocalStructure.lean` is **false** for a general
+primitive nonnegative real matrix. This module exhibits an explicit `3 × 3`
+nonnegative primitive matrix `T` with
+
+* all entries of `T ^ 2` strictly positive, so `T` is primitive in the sense of
+  `Mathlib.Matrix.IsPrimitive`;
+* `trace (T ^ k) = trace T = 1` for every `k ≥ 1`;
+* `T` of rank two — no rank-one factorization `T = vecMulVec a b` exists.
+
+Concretely, `T = P + (1/6) · N` where `P = (1/3) · J` is the Perron projector
+(`J` the `3 × 3` all-ones matrix) and `N = x · yᵀ` with `x = (1, -1, 0)`,
+`y = (1, 1, -2)`. One checks `N² = 0`, `P N = N P = 0`, `P² = P`, so
+`T ^ k = P` for all `k ≥ 2`, while `T` itself has a non-trivial Jordan block
+for the zero eigenvalue and thus rank two.
+
+This module documents the gap in the Appendix C.2, Lemma C.4 argument of
+arXiv:1606.00608: primitivity and constant trace powers alone are not
+sufficient; additional structure on `T` (for example positive
+semidefiniteness, or diagonalizability over `ℂ`) is required to close the
+rank-one step.
+
+This file is deliberately excluded from the root `TNLean.lean` import list.
+
+## References
+
+- arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete), Appendix C.2,
+  Lemma C.4
+- Issue #832 on the TNLean repository
+
+## Main results
+
+* `counterexample`: the explicit witness to the failure of the stated
+  implication.
+-/
+
+namespace TNLeanArchive.PerronFrobeniusRankOne
+
+open Matrix
+
+/-- The counterexample matrix. -/
+noncomputable def T : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![1/2, 1/2, 0; 1/6, 1/6, 2/3; 1/3, 1/3, 1/3]
+
+/-- The rank-one Perron projector for `T`, equal to `T ^ k` for every `k ≥ 2`. -/
+noncomputable def P : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![1/3, 1/3, 1/3; 1/3, 1/3, 1/3; 1/3, 1/3, 1/3]
+
+lemma T_sq : T * T = P := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [T, P, Matrix.mul_apply, Fin.sum_univ_three] <;> ring
+
+lemma T_mul_P : T * P = P := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [T, P, Matrix.mul_apply, Fin.sum_univ_three] <;> ring
+
+lemma P_mul_T : P * T = P := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [T, P, Matrix.mul_apply, Fin.sum_univ_three] <;> ring
+
+lemma T_nonneg (i j : Fin 3) : 0 ≤ T i j := by
+  fin_cases i <;> fin_cases j <;>
+    first
+    | (simp [T]; norm_num)
+    | simp [T]
+
+lemma T_pow2_pos (i j : Fin 3) : 0 < (T ^ 2) i j := by
+  have h : T ^ 2 = P := by rw [sq]; exact T_sq
+  rw [h]
+  fin_cases i <;> fin_cases j <;> simp [P]
+
+/-- `T` is primitive in Mathlib's sense. -/
+theorem T_isPrimitive : Matrix.IsPrimitive T :=
+  ⟨T_nonneg, 2, by norm_num, T_pow2_pos⟩
+
+lemma T_pow_eq_P : ∀ k : ℕ, 2 ≤ k → T ^ k = P := by
+  intro k hk
+  induction k with
+  | zero => omega
+  | succ n ih =>
+    rcases eq_or_lt_of_le hk with h | h
+    · rw [← h, sq]; exact T_sq
+    · have h2 : 2 ≤ n := by omega
+      rw [pow_succ, ih h2]
+      exact P_mul_T
+
+lemma trace_T : Matrix.trace T = 1 := by
+  simp [Matrix.trace, T, Fin.sum_univ_three]; ring
+
+lemma trace_P : Matrix.trace P = 1 := by
+  simp [Matrix.trace, P, Fin.sum_univ_three]; ring
+
+/-- Every positive power of `T` has the same trace as `T`. -/
+theorem T_tracePowersConstant :
+    ∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T := by
+  intro k hk
+  rcases Nat.lt_or_ge k 2 with h | h
+  · interval_cases k; simp
+  · rw [T_pow_eq_P k h, trace_T, trace_P]
+
+/-- `T` has no rank-one factorization. -/
+theorem T_not_rankOne : ¬ ∃ a b : Fin 3 → ℝ, T = Matrix.vecMulVec a b := by
+  rintro ⟨a, b, hT⟩
+  have h00 : a 0 * b 0 = (1 : ℝ) / 2 := by
+    have hh : T 0 0 = Matrix.vecMulVec a b 0 0 := by rw [hT]
+    simp [T, Matrix.vecMulVec_apply] at hh
+    linarith
+  have h02 : a 0 = 0 ∨ b 2 = 0 := by
+    have hh : T 0 2 = Matrix.vecMulVec a b 0 2 := by rw [hT]
+    simpa [T, Matrix.vecMulVec_apply] using hh
+  have h12 : a 1 * b 2 = (2 : ℝ) / 3 := by
+    have hh : T 1 2 = Matrix.vecMulVec a b 1 2 := by rw [hT]
+    simp [T, Matrix.vecMulVec_apply] at hh
+    linarith
+  have ha0 : a 0 ≠ 0 := fun h => by
+    rw [h, zero_mul] at h00; norm_num at h00
+  have hb2 : b 2 = 0 := h02.resolve_left ha0
+  rw [hb2, mul_zero] at h12
+  norm_num at h12
+
+/-- The explicit counterexample to the standalone statement of
+`Matrix.PrimitiveTracePowersConstantImpliesRankOne`: `T` is primitive,
+satisfies the constant-trace-powers hypothesis, yet has no rank-one
+factorization. -/
+theorem counterexample :
+    Matrix.IsPrimitive T ∧
+      (∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T) ∧
+      ¬ ∃ a b : Fin 3 → ℝ, T = Matrix.vecMulVec a b :=
+  ⟨T_isPrimitive, T_tracePowersConstant, T_not_rankOne⟩
+
+end TNLeanArchive.PerronFrobeniusRankOne

--- a/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
+++ b/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
@@ -49,7 +49,7 @@ This file is deliberately excluded from the root `TNLean.lean` import list.
   implication.
 -/
 
-namespace TNLeanArchive.PerronFrobeniusRankOne
+namespace TNLean.Archive.PerronFrobeniusRankOneCounterexample
 
 open Matrix
 
@@ -146,4 +146,4 @@ theorem counterexample :
       ¬ ∃ a b : Fin 3 → ℝ, T = Matrix.vecMulVec a b :=
   ⟨T_isPrimitive, T_tracePowersConstant, T_not_rankOne⟩
 
-end TNLeanArchive.PerronFrobeniusRankOne
+end TNLean.Archive.PerronFrobeniusRankOneCounterexample

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -41,7 +41,7 @@ Lemma C.4 is further isolated to the finite-dimensional Perron–Frobenius step:
 for a primitive nonnegative matrix `T`, constant traces of positive powers are
 *claimed* (in the paper) to force `T` to have rank one. We expose that step as
 the single hypothesis `Matrix.PrimitiveTracePowersConstantImpliesRankOne`, so
-the remaining gap is honestly localized and matches the paper one-to-one.
+the remaining gap is exactly localized and matches the paper one-to-one.
 
 The universally quantified form of that claim is in fact false — see
 `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean` for an explicit

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -38,10 +38,17 @@ exactly as the Hayashi / Ruskai / Hayden–Jozsa–Petz–Winter decomposition a
 available through `Entropy.QuantumMarkovDecomposition`.
 
 Lemma C.4 is further isolated to the finite-dimensional Perron–Frobenius step:
-for a primitive nonnegative matrix `T`, constant traces of positive powers force
-`T` to have rank one. We expose that step as the single hypothesis
-`Matrix.PrimitiveTracePowersConstantImpliesRankOne`, so the remaining gap is
-honestly localized and matches the paper one-to-one.
+for a primitive nonnegative matrix `T`, constant traces of positive powers are
+*claimed* (in the paper) to force `T` to have rank one. We expose that step as
+the single hypothesis `Matrix.PrimitiveTracePowersConstantImpliesRankOne`, so
+the remaining gap is honestly localized and matches the paper one-to-one.
+
+The universally quantified form of that claim is in fact false — see
+`TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean` for an explicit
+3 × 3 witness. Callers of `MPOTensor.sal_zcl_implies_rank_one_T` must therefore
+discharge the hypothesis using additional structure on the specific `T` coming
+from the MPDO context (the η-operators are positive semidefinite in the paper's
+construction, which supplies the missing diagonalizability).
 
 ## References
 
@@ -76,7 +83,16 @@ rank-one factorization.
 This is intentionally packaged as a local hypothesis rather than a new global
 assumption. Once a genuine proof is formalized, downstream callers can simply
 supply that theorem here and the scoped result `MPOTensor.sal_zcl_implies_rank_one_T`
-will become unconditional. -/
+will become unconditional.
+
+**Note.** As a universally quantified statement over primitive nonnegative real
+matrices this implication is *false*: there exist primitive nonnegative
+matrices with `trace (T ^ k) = trace T` for all `k ≥ 1` but rank greater than
+one. An explicit machine-checked `3 × 3` witness is recorded in
+`TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`. Discharging the
+hypothesis in a specific MPDO context therefore requires additional structure
+on `T` (for instance positive semidefiniteness or diagonalizability over `ℂ`)
+that the caller must supply. -/
 def PrimitiveTracePowersConstantImpliesRankOne
     (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   Matrix.IsPrimitive T → TracePowersConstant T → HasRankOneFactorization T

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -442,11 +442,9 @@ strong subadditivity for a normalized three-site reduced state.
 
     The last predicate is used as a scoped hypothesis, not a globally provable
     theorem. As a universal statement over primitive nonnegative matrices it is
-    false; a concrete $3 \times 3$ counterexample is recorded in the Lean
-    archive module
-    \texttt{TNLean.Archive.PerronFrobeniusRankOneCounterexample}. Discharging
-    the hypothesis in the simple-MPDO setting therefore requires the extra
-    structure carried by the specific $T$ arising from the positive
+    false; a concrete $3 \times 3$ counterexample is recorded in the archive.
+    Discharging the hypothesis in the simple-MPDO setting therefore requires
+    the extra structure carried by the specific $T$ arising from the positive
     semidefinite $\eta$-operators.
 \end{definition}
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -439,6 +439,15 @@ strong subadditivity for a normalized three-site reduced state.
     positive powers, existence of a rank-one factorization $T = a b^\top$, and
     the Perron--Frobenius implication from primitivity together with constant
     trace powers to such a factorization.
+
+    The last predicate is used as a scoped hypothesis, not a globally provable
+    theorem. As a universal statement over primitive nonnegative matrices it is
+    false; a concrete $3 \times 3$ counterexample is recorded in the Lean
+    archive module
+    \texttt{TNLean.Archive.PerronFrobeniusRankOneCounterexample}. Discharging
+    the hypothesis in the simple-MPDO setting therefore requires the extra
+    structure carried by the specific $T$ arising from the positive
+    semidefinite $\eta$-operators.
 \end{definition}
 
 \begin{theorem}[SAL and ZCL imply rank-one $T$ (scoped form)]


### PR DESCRIPTION
### Motivation

- Issue #832 identified `Matrix.PrimitiveTracePowersConstantImpliesRankOne` as the sole residual blocker after PR #807: prove it or supply a counterexample.
- The standalone claim (primitivity + constant trace powers ⟹ rank one) is false in full generality; a machine-checked 3×3 counterexample resolves the gap and clarifies what additional structure callers must supply in the MPDO setting (arXiv:1606.00608 Appendix C.2, Lemma C.4).

### Description

- **Added** `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean` — machine-checked 3×3 nonneg primitive matrix `T` satisfying `IsPrimitive T` and `TracePowersConstant T` yet `rank T = 2`, refuting the rank-one claim.
- **Modified** `TNLean/MPS/MPDO/SimpleLocalStructure.lean` — module docstring updated to flag `Matrix.PrimitiveTracePowersConstantImpliesRankOne` as a scoped hypothesis (not a universal theorem) and directs callers to the counterexample.
- **Modified** `blueprint/src/chapter/ch02b_mpdo.tex` — blueprint updated to reflect that the rank-one step requires additional structure (PSD or diagonalizability) beyond primitivity and constant trace powers.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #832

> [!NOTE]
> **Low Risk**
> Mostly adds an archived Lean module and documentation clarifying that `PrimitiveTracePowersConstantImpliesRankOne` is not true in full generality; no existing proofs or APIs are changed, but reviewers should note the newly documented limitation for downstream uses.
>
> **Overview**
> Adds an archived, machine-checked `3×3` nonnegative primitive matrix `T` showing that **primitivity + constant trace of all positive powers does not imply rank one**, via `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`.
>
> Updates `SimpleLocalStructure.lean` and the blueprint to explicitly flag `Matrix.PrimitiveTracePowersConstantImpliesRankOne` as a *scoped hypothesis* (not a universal theorem) and points callers to the counterexample, noting they must use extra structure (e.g. PSD/diagonalizability) to discharge it in the MPDO setting.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77e9a0ed5accc383394fde087a8a9b0652b30916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds a new archived Lean proof artifact and documentation/blueprint clarifications, with no changes to existing APIs or proof statements beyond comments. The main impact is conceptual—reviewers should note the newly documented limitation when discharging `Matrix.PrimitiveTracePowersConstantImpliesRankOne` in downstream proofs.
> 
> **Overview**
> Adds `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`, defining an explicit `3×3` nonnegative real matrix `T` and proving `Matrix.IsPrimitive T`, `trace (T ^ k) = trace T` for all `k > 0`, and `¬ ∃ a b, T = Matrix.vecMulVec a b`, yielding a bundled `counterexample` theorem.
> 
> Updates `SimpleLocalStructure.lean` to explicitly flag `Matrix.PrimitiveTracePowersConstantImpliesRankOne` as a *scoped hypothesis* whose universally quantified form is false, and points callers to the archived counterexample (noting extra structure like PSD/diagonalizability is needed to discharge it in the MPDO setting). The blueprint text in `ch02b_mpdo.tex` is updated to mirror this clarification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4834a9df38fb233eb27c735d948c488d010245e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->