### PR TITLE
feat(MPS/MPDO): probe algebra-to-fusion converse on support towers (#826)

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
@@ -274,6 +274,24 @@ lemma transferMap_conjTranspose_eq_adjoint (A : MPSTensor d D) :
       _ = Matrix.trace (transferMap (d := d) (D := D) A Y * Xᴴ) := by
             rw [hadj]
 
+/-- The Frobenius adjoint of `transferMap A` is the Kraus adjoint map of `A`,
+viewed as a linear map. This is the linear-map form of
+`transferMap_conjTranspose_eq_adjoint`. -/
+lemma transferMap_adjoint_eq_adjointMapLM (A : MPSTensor d D) :
+    (transferMap A).adjoint = Kraus.adjointMapLM A := by
+  refine LinearMap.ext fun X => ?_
+  have h := congrArg (fun F => F X)
+    (transferMap_conjTranspose_eq_adjoint (A := A)).symm
+  simpa [transferMap_apply, Kraus.adjointMapLM_apply, Kraus.adjointMap,
+    Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc] using h
+
+/-- Pointwise form of `transferMap_adjoint_eq_adjointMapLM`. -/
+@[simp] lemma transferMap_adjoint_apply_eq_adjointMap (A : MPSTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    (transferMap A).adjoint X = Kraus.adjointMap A X := by
+  rw [transferMap_adjoint_eq_adjointMapLM]
+  exact Kraus.adjointMapLM_apply A X
+
 end
 
 end TransferAdjoint

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -21,7 +21,7 @@ The paper's full statement uses coefficient systems
 $c_{\alpha,\beta,\gamma}^{(L)} =
   \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$
 and BNT data. That full coefficient layer is not yet formalized here. What we do
-formalize is the stationary C$^*$-algebra package naturally attached to an MPO
+formalize is the stationary C$^*$-algebra structure naturally attached to an MPO
 whose blocked transfer maps are idempotent, together with a first explicit
 coordinate layer obtained by choosing bases of the blocked support algebras.
 
@@ -35,7 +35,7 @@ coincides with the fixed-point algebra of the adjoint blocked transfer map
 Under a trace-preserving normalization and a positive-definite fixed point of the
 MPO transfer map, an RFP tensor yields a **stationary** algebra tower. Combined
 with the transfer-map fusion criterion from `FusionIsometries.lean`, this gives a
-one-way bridge
+one-way implication
 
 * `isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed`
 * `isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed`
@@ -136,7 +136,7 @@ size-`2n` support algebra, while `iota n` is the inclusion into the size-`n+1`
 support algebra. The fields `m_apply` and `iota_apply` require that these maps
 are realized by the ambient matrix product and ambient inclusion.
 
-This structure records only this realization data. It does **not** yet package
+This structure records only this realization data. It does **not** yet include
 the full §4.5 coherence / coefficient / BNT layer from the paper. -/
 structure AlgebraStructureData (d D : ℕ) where
   /-- Support algebra at blocked size `n`. -/
@@ -174,7 +174,7 @@ end AlgebraStructureData
 one of its positive-definite fixed points.
 
 Concretely, this is the fixed-point `StarSubalgebra` of the adjoint transfer map
-`(transferMap M).adjoint`, packaged through Wolf Theorem 6.12 for the doubled
+`(transferMap M).adjoint`, constructed using Wolf Theorem 6.12 for the doubled
 MPS tensor `M.toMPSTensor`. -/
 def faithfulFixedPointSupportAlgebra
     (M : MPOTensor d D) (h_tp : Kraus.IsTP M.toMPSTensor)
@@ -223,7 +223,6 @@ theorem stationaryOfFaithfulFixedPoint_compatible
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ)
     (hRFP : IsRFP M) :
     (stationaryOfFaithfulFixedPoint M h_tp hρ hρ_fix).CompatibleWith M := by
-  simp only [AlgebraStructureData.CompatibleWith]
   intro n hn X
   change X ∈ faithfulFixedPointSupportAlgebra M h_tp hρ hρ_fix ↔
     (blockedTransferMap M n).adjoint X = X
@@ -246,7 +245,6 @@ theorem stationaryOfFaithfulFixedPoint_compatible_of_adjointFixedPoints_eq
     (hEq : ∀ n : ℕ, 0 < n → ∀ X : Mat,
       (transferMap M).adjoint X = X ↔ (blockedTransferMap M n).adjoint X = X) :
     (stationaryOfFaithfulFixedPoint M h_tp hρ hρ_fix).CompatibleWith M := by
-  simp only [AlgebraStructureData.CompatibleWith]
   intro n hn X
   change X ∈ faithfulFixedPointSupportAlgebra M h_tp hρ hρ_fix ↔
     (blockedTransferMap M n).adjoint X = X
@@ -286,8 +284,8 @@ theorem isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed
     {M : MPOTensor d D} (hFusion : IsRFP_MPDO_via_fusion M)
     (h_tp : Kraus.IsTP M.toMPSTensor) {ρ : Mat} (hρ : ρ.PosDef)
     (hρ_fix : transferMap M ρ = ρ) :
-    IsRFP_MPDO_via_algebra M := by
-  exact isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
+    IsRFP_MPDO_via_algebra M :=
+  isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
     (M := M) (isRFP_of_isRFP_MPDO_via_fusion hFusion) h_tp hρ hρ_fix
 
 /-- The current algebra-side predicate also holds whenever the blocked adjoint
@@ -371,6 +369,7 @@ noncomputable def toBlockedCoefficientsOfMem
   congrArg (fun x : data.A n => (x : Mat))
     (reconstructFromBlockedCoefficients_toBlockedCoefficients
       (data := data) (n := n) (x := ⟨X, hX⟩))
+
 /-- Coordinates of an adjoint blocked fixed point, extracted through a compatible
 algebra tower. -/
 noncomputable def toBlockedCoefficientsOfFixedPoint
@@ -402,6 +401,7 @@ theorem adjoint_blockedTransferMap_reconstructFromBlockedCoefficients_eq
         (((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat)) =
       (((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat)) :=
   (hCompat n hn _).1 (data.reconstructFromBlockedCoefficients n a).property
+
 /-- The coefficient family of the blocked product of two chosen basis elements. -/
 noncomputable def blockedStructureCoefficients
     (data : AlgebraStructureData d D) (n : ℕ)

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -118,21 +118,6 @@ local instance instMatrixInnerProductSpace (D : ℕ) :
   Matrix.toMatrixInnerProductSpace (n := Fin D) (𝕜 := ℂ) 1
     (Matrix.frobenius_posDef_one (D := D)).posSemidef
 
-namespace MPSTensor
-
-/-- The Frobenius adjoint of `transferMap A` acts by the Kraus adjoint map of
-`A`. This is the pointwise form of
-`MPSTensor.transferMap_conjTranspose_eq_adjoint`. -/
-theorem transferMap_adjoint_apply_eq_adjointMap {d D : ℕ}
-    (A : MPSTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
-    (transferMap A).adjoint X = Kraus.adjointMap A X := by
-  have h := congrArg (fun F => F X)
-    (transferMap_conjTranspose_eq_adjoint (A := A)).symm
-  simpa [transferMap_apply, Kraus.adjointMap, Matrix.conjTranspose_conjTranspose,
-    Matrix.mul_assoc] using h
-
-end MPSTensor
-
 namespace MPOTensor
 
 variable {d D : ℕ}
@@ -209,8 +194,8 @@ theorem mem_faithfulFixedPointSupportAlgebra_iff
   unfold faithfulFixedPointSupportAlgebra
   rw [Kraus.mem_fixedPoints_starSubalgebra, Kraus.mem_adjointFixedPoints]
   have hAdj : Kraus.adjointMap M.toMPSTensor X = (transferMap M).adjoint X := by
-    simpa [transferMap_eq_toMPSTensor] using
-      (MPSTensor.transferMap_adjoint_apply_eq_adjointMap (A := M.toMPSTensor) X).symm
+    rw [transferMap_eq_toMPSTensor]
+    exact (MPSTensor.transferMap_adjoint_apply_eq_adjointMap (A := M.toMPSTensor) X).symm
   rw [hAdj]
 
 namespace AlgebraStructureData
@@ -348,13 +333,13 @@ noncomputable def reconstructFromBlockedCoefficients
 
 @[simp] theorem toBlockedCoefficients_reconstructFromBlockedCoefficients
     (data : AlgebraStructureData d D) (n : ℕ) (a : BlockedCoefficients data n) :
-    data.toBlockedCoefficients n (data.reconstructFromBlockedCoefficients n a) = a := by
-  exact (data.toBlockedCoefficients n).apply_symm_apply a
+    data.toBlockedCoefficients n (data.reconstructFromBlockedCoefficients n a) = a :=
+  (data.toBlockedCoefficients n).apply_symm_apply a
 
 @[simp] theorem reconstructFromBlockedCoefficients_toBlockedCoefficients
     (data : AlgebraStructureData d D) (n : ℕ) (x : data.A n) :
-    data.reconstructFromBlockedCoefficients n (data.toBlockedCoefficients n x) = x := by
-  exact (data.toBlockedCoefficients n).symm_apply_apply x
+    data.reconstructFromBlockedCoefficients n (data.toBlockedCoefficients n x) = x :=
+  (data.toBlockedCoefficients n).symm_apply_apply x
 
 /-- The chosen basis reconstructs every blocked coefficient family by a finite sum. -/
 theorem reconstructFromBlockedCoefficients_apply
@@ -382,11 +367,10 @@ noncomputable def toBlockedCoefficientsOfMem
 @[simp] theorem reconstructFromBlockedCoefficients_of_mem
     (data : AlgebraStructureData d D) (n : ℕ) (X : Mat) (hX : X ∈ data.A n) :
     ((data.reconstructFromBlockedCoefficients n
-      (data.toBlockedCoefficientsOfMem n X hX) : data.A n) : Mat) = X := by
-  exact congrArg (fun x : data.A n => (x : Mat))
+      (data.toBlockedCoefficientsOfMem n X hX) : data.A n) : Mat) = X :=
+  congrArg (fun x : data.A n => (x : Mat))
     (reconstructFromBlockedCoefficients_toBlockedCoefficients
       (data := data) (n := n) (x := ⟨X, hX⟩))
-
 /-- Coordinates of an adjoint blocked fixed point, extracted through a compatible
 algebra tower. -/
 noncomputable def toBlockedCoefficientsOfFixedPoint
@@ -416,9 +400,8 @@ theorem adjoint_blockedTransferMap_reconstructFromBlockedCoefficients_eq
     (a : BlockedCoefficients data n) :
     (blockedTransferMap M n).adjoint
         (((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat)) =
-      (((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat)) := by
-  exact (hCompat n hn _).1 (data.reconstructFromBlockedCoefficients n a).property
-
+      (((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat)) :=
+  (hCompat n hn _).1 (data.reconstructFromBlockedCoefficients n a).property
 /-- The coefficient family of the blocked product of two chosen basis elements. -/
 noncomputable def blockedStructureCoefficients
     (data : AlgebraStructureData d D) (n : ℕ)

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -120,7 +120,10 @@ local instance instMatrixInnerProductSpace (D : ℕ) :
 
 namespace MPSTensor
 
-private theorem transferMap_adjoint_apply_eq_adjointMap {d D : ℕ}
+/-- The Frobenius adjoint of `transferMap A` acts by the Kraus adjoint map of
+`A`. This is the pointwise form of
+`MPSTensor.transferMap_conjTranspose_eq_adjoint`. -/
+theorem transferMap_adjoint_apply_eq_adjointMap {d D : ℕ}
     (A : MPSTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
     (transferMap A).adjoint X = Kraus.adjointMap A X := by
   have h := congrArg (fun F => F X)
@@ -146,7 +149,10 @@ At blocked size `n`, the support object is a `StarSubalgebra` of bond-space
 matrices. The map `m n` is the blocking multiplication, landing in the
 size-`2n` support algebra, while `iota n` is the inclusion into the size-`n+1`
 support algebra. The fields `m_apply` and `iota_apply` require that these maps
-are realized by the ambient matrix product and ambient inclusion. -/
+are realized by the ambient matrix product and ambient inclusion.
+
+This structure records only this realization data. It does **not** yet package
+the full §4.5 coherence / coefficient / BNT layer from the paper. -/
 structure AlgebraStructureData (d D : ℕ) where
   /-- Support algebra at blocked size `n`. -/
   A : ℕ → StarSubalgebra ℂ (Matrix (Fin D) (Fin D) ℂ)
@@ -273,8 +279,9 @@ def IsRFP_MPDO_via_algebra (M : MPOTensor d D) : Prop :=
 
 /-- Backwards-compatible alias for the previous scaffold name.
 
-The old definition was vacuous. The new alias points to the non-vacuous algebra
-predicate above. -/
+The old definition was vacuous. The alias points to the non-vacuous algebra
+predicate above, but that predicate is still weaker than the full paper
+converse: it only records the current support-algebra layer. -/
 @[deprecated (since := "2026-04-24")] alias IsRFP_MPDO_via_algebra_scaffold :=
   IsRFP_MPDO_via_algebra
 

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -244,6 +244,24 @@ theorem stationaryOfFaithfulFixedPoint_compatible
         (blockedTransferMap_eq_transferMap_of_isRFP (M := M) hRFP hn)
   simp [blockedTransferMap_eq_pow, transferMap_eq_toMPSTensor, hAdj]
 
+/-- The same stationary tower is compatible whenever the adjoint fixed points of
+all positive blocked transfer maps agree with the adjoint fixed points of the
+original transfer map. This criterion does not assume `IsRFP M`; it isolates
+exactly the stabilization property needed by the current compatibility
+predicate. -/
+theorem stationaryOfFaithfulFixedPoint_compatible_of_adjointFixedPoints_eq
+    (M : MPOTensor d D) (h_tp : Kraus.IsTP M.toMPSTensor)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ)
+    (hEq : ∀ n : ℕ, 0 < n → ∀ X : Mat,
+      (transferMap M).adjoint X = X ↔ (blockedTransferMap M n).adjoint X = X) :
+    (stationaryOfFaithfulFixedPoint M h_tp hρ hρ_fix).CompatibleWith M := by
+  simp only [AlgebraStructureData.CompatibleWith]
+  intro n hn X
+  change X ∈ faithfulFixedPointSupportAlgebra M h_tp hρ hρ_fix ↔
+    (blockedTransferMap M n).adjoint X = X
+  rw [mem_faithfulFixedPointSupportAlgebra_iff (M := M) h_tp hρ hρ_fix X]
+  exact hEq n hn X
+
 end AlgebraStructureData
 
 /-- The algebra-structure formulation of MPDO RFP used in this file.
@@ -279,6 +297,21 @@ theorem isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed
     IsRFP_MPDO_via_algebra M := by
   exact isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
     (M := M) (isRFP_of_isRFP_MPDO_via_fusion hFusion) h_tp hρ hρ_fix
+
+/-- The current algebra-side predicate also holds whenever the blocked adjoint
+fixed-point spaces stabilize across all positive powers. This extracts exactly
+what the present compatibility relation can see, without asserting the fusion /
+idempotence conclusion. -/
+theorem isRFP_MPDO_via_algebra_of_adjointFixedPoints_eq_of_isTP_of_posDef_fixed
+    {M : MPOTensor d D} (h_tp : Kraus.IsTP M.toMPSTensor)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ)
+    (hEq : ∀ n : ℕ, 0 < n → ∀ X : Mat,
+      (transferMap M).adjoint X = X ↔ (blockedTransferMap M n).adjoint X = X) :
+    IsRFP_MPDO_via_algebra M := by
+  refine ⟨AlgebraStructureData.stationaryOfFaithfulFixedPoint M h_tp hρ hρ_fix, ?_⟩
+  exact
+    AlgebraStructureData.stationaryOfFaithfulFixedPoint_compatible_of_adjointFixedPoints_eq
+      (M := M) (h_tp := h_tp) hρ hρ_fix hEq
 
 namespace AlgebraStructureData
 

--- a/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
+++ b/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
@@ -74,9 +74,23 @@ for the current Lean predicate, and the honest next step is either:
    why the full converse still requires the coefficient/BNT layer from
    Appendix C.3–C.4.
 
-## Current assessment
+## Outcome of this pass
 
-The issue may still allow a **strong honest forward step**, but the likely
-outcome is not a proof of the requested converse theorem. The first thing to
-settle is whether the current algebra predicate is already too weak; the
-candidate dephasing example suggests that it is.
+The explicit dephasing counterexample was **not** formalized in Lean during this
+pass, so I am not claiming a machine-checked disproof of the converse.
+
+What did land is the strongest clean intermediate result I could verify on top
+of the imported non-vacuous algebra layer:
+
+- `MPOTensor.AlgebraStructureData.stationaryOfFaithfulFixedPoint_compatible_of_adjointFixedPoints_eq`
+- `MPOTensor.isRFP_MPDO_via_algebra_of_adjointFixedPoints_eq_of_isTP_of_posDef_fixed`
+
+These isolate the exact extra hypothesis that the current Lean compatibility
+predicate can genuinely see: stabilization of the adjoint fixed-point algebras
+of the blocked transfer maps.
+
+So the branch now gives an honest forward theorem and updated blueprint text,
+but it does **not** prove the requested converse
+`IsRFP_MPDO_via_algebra → IsRFP_MPDO_via_fusion`.
+The remaining gap is still the stronger coefficient/BNT layer from
+Appendix C.3–C.4.

--- a/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
+++ b/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
@@ -1,0 +1,82 @@
+# Issue #826 scouting report — algebra ⇒ fusion converse
+
+Date: 2026-04-23
+Branch: `feat/826-algebra-to-fusion-v2`
+Target issue: #826
+
+## Scope
+
+Issue #826 asks for the converse direction of the MPDO §4.5 equivalence:
+
+given the algebra-structure formulation, derive the transfer-map fusion
+formulation under the same trace-preserving and positive-definite fixed-point
+side hypotheses used by the forward bridge.
+
+## Baseline imported into this branch
+
+`origin/main` still carries the **old vacuous scaffold** in
+`TNLean/MPS/MPDO/AlgebraStructure.lean`, so the issue cannot even be stated
+honestly there. As an initial scaffold, this branch copies in the current
+algebra-side work from the open follow-up branch `origin/feat/612-coefficient-extraction`:
+
+- `TNLean/MPS/MPDO/AlgebraStructure.lean`
+- `blueprint/src/chapter/ch02b_mpdo.tex`
+
+This gives the non-vacuous support-algebra tower, the blocked-coordinate layer,
+and the forward bridge
+`MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed`.
+
+## Preliminary mathematical concern
+
+The current compatibility predicate in that branch is still weaker than the full
+paper statement. It only says that, for each positive blocked size `n`, the
+support algebra `A n` agrees with the fixed-point algebra of
+`(blockedTransferMap M n).adjoint`.
+
+That looks too weak to force idempotence of `blockedTransferMap M n`.
+A candidate counterexample is the two-Kraus dephasing channel with Kraus family
+
+- `K₀ = (3/5) I`
+- `K₁ = (4/5) Z`
+
+on `M₂(ℂ)`, viewed as an MPO with only two nonzero diagonal physical entries.
+Then:
+
+1. the channel is trace-preserving and unital;
+2. `ρ = I` is a positive-definite fixed point;
+3. the off-diagonal sector is scaled by `λ = -7/25`, so the channel is **not**
+   idempotent;
+4. for every `n > 0`, the `n`th power scales the off-diagonal sector by
+   `λ^n ≠ 1`, so the adjoint fixed-point algebra stays equal to the diagonal
+   algebra for all positive powers.
+
+If this formalizes cleanly, it shows that the present
+`IsRFP_MPDO_via_algebra` does **not** imply `IsRFP_MPDO_via_fusion`, even under
+TP + faithful fixed-point hypotheses. In that case the issue as stated is false
+for the current Lean predicate, and the honest next step is either:
+
+- strengthen the algebra-side hypothesis toward the paper’s coefficient/BNT
+  data, or
+- prove the converse only from an explicitly strengthened intermediate bridge
+  assumption.
+
+## Planned next steps in this branch
+
+1. Verify that the imported algebra-side branch compiles cleanly on top of
+   `origin/main`.
+2. Add a reusable theorem giving algebra witnesses from a stationary faithful
+   fixed-point support algebra whenever the blocked adjoint fixed-point algebras
+   stabilize across positive powers.
+3. Formalize the explicit dephasing MPO and prove:
+   - it satisfies the current algebra predicate;
+   - it does not satisfy the fusion predicate.
+4. If the counterexample lands, update the blueprint/audit language to explain
+   why the full converse still requires the coefficient/BNT layer from
+   Appendix C.3–C.4.
+
+## Current assessment
+
+The issue may still allow a **strong honest forward step**, but the likely
+outcome is not a proof of the requested converse theorem. The first thing to
+settle is whether the current algebra predicate is already too weak; the
+candidate dephasing example suggests that it is.

--- a/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
+++ b/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
@@ -1,6 +1,6 @@
 # Issue #826 scouting report — algebra ⇒ fusion converse
 
-Date: 2026-04-23
+Date: 2026-04-23; rebased on current `main` on 2026-04-25
 Branch: `feat/826-algebra-to-fusion-v2`
 Target issue: #826
 
@@ -10,31 +10,36 @@ Issue #826 asks for the converse direction of the MPDO §4.5 equivalence:
 
 given the algebra-structure formulation, derive the transfer-map fusion
 formulation under the same trace-preserving and positive-definite fixed-point
-side hypotheses used by the forward bridge.
+side hypotheses used by the forward implication.
 
-## Baseline imported into this branch
+## Baseline context
 
-`origin/main` still carries the **old vacuous scaffold** in
-`TNLean/MPS/MPDO/AlgebraStructure.lean`, so the issue cannot even be stated
-honestly there. As an initial scaffold, this branch copies in the current
-algebra-side work from the open follow-up branch `origin/feat/612-coefficient-extraction`:
+When this branch was first opened, `origin/main` did not yet contain the
+non-vacuous algebra-side layer from the issue #612 follow-ups. The branch
+therefore started by copying the support-algebra tower and blocked-coordinate
+layer that later landed on `main` through PRs #810, #814, #885, and #887.
 
-- `TNLean/MPS/MPDO/AlgebraStructure.lean`
-- `blueprint/src/chapter/ch02b_mpdo.tex`
+After the 2026-04-25 rebase, `main` already contains that baseline plus the
+adjoint fixed-point descent and the diagonal `χ` trace-power language. This PR
+now contributes only the still-useful extra pieces:
 
-This gives the non-vacuous support-algebra tower, the blocked-coordinate layer,
-and the forward bridge
-`MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed`.
+- a public upstream transfer-map adjoint lemma in
+  `TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean`;
+- the stabilized-adjoint-fixed-point sufficient condition
+  `MPOTensor.AlgebraStructureData.stationaryOfFaithfulFixedPoint_compatible_of_adjointFixedPoints_eq`;
+- the corresponding wrapper
+  `MPOTensor.isRFP_MPDO_via_algebra_of_adjointFixedPoints_eq_of_isTP_of_posDef_fixed`.
 
-## Preliminary mathematical concern
+## Mathematical concern
 
-The current compatibility predicate in that branch is still weaker than the full
-paper statement. It only says that, for each positive blocked size `n`, the
-support algebra `A n` agrees with the fixed-point algebra of
+The current compatibility predicate is still weaker than the full paper
+statement. It only says that, for each positive blocked size `n`, the support
+algebra `A n` agrees with the fixed-point algebra of
 `(blockedTransferMap M n).adjoint`.
 
-That looks too weak to force idempotence of `blockedTransferMap M n`.
-A candidate counterexample is the two-Kraus dephasing channel with Kraus family
+That condition is too weak by itself to force idempotence of
+`blockedTransferMap M n`. A candidate counterexample is the two-Kraus dephasing
+channel with Kraus family
 
 - `K₀ = (3/5) I`
 - `K₁ = (4/5) Z`
@@ -50,42 +55,24 @@ Then:
    `λ^n ≠ 1`, so the adjoint fixed-point algebra stays equal to the diagonal
    algebra for all positive powers.
 
-If this formalizes cleanly, it shows that the present
-`IsRFP_MPDO_via_algebra` does **not** imply `IsRFP_MPDO_via_fusion`, even under
-TP + faithful fixed-point hypotheses. In that case the issue as stated is false
-for the current Lean predicate, and the honest next step is either:
-
-- strengthen the algebra-side hypothesis toward the paper’s coefficient/BNT
-  data, or
-- prove the converse only from an explicitly strengthened intermediate bridge
-  assumption.
-
-## Planned next steps in this branch
-
-1. Verify that the imported algebra-side branch compiles cleanly on top of
-   `origin/main`.
-2. Add a reusable theorem giving algebra witnesses from a stationary faithful
-   fixed-point support algebra whenever the blocked adjoint fixed-point algebras
-   stabilize across positive powers.
-3. Formalize the explicit dephasing MPO and prove:
-   - it satisfies the current algebra predicate;
-   - it does not satisfy the fusion predicate.
-4. If the counterexample lands, update the blueprint/audit language to explain
-   why the full converse still requires the coefficient/BNT layer from
-   Appendix C.3–C.4.
+A machine-checked counterexample was not completed in this pass. Still, the
+main-branch descent theorem from `IsRFP_MPDO_via_algebra` already shows that the
+present predicate sees only equality of adjoint fixed-point spaces across
+positive block lengths; it does not by itself recover the coefficient/BNT data
+used in the paper's converse direction.
 
 ## Outcome of this pass
 
 The explicit dephasing counterexample was **not** formalized in Lean during this
-pass, so I am not claiming a machine-checked disproof of the converse.
+pass, so this audit does not claim a machine-checked disproof of the converse.
 
-What did land is the strongest clean intermediate result I could verify on top
-of the imported non-vacuous algebra layer:
+What did land is the strongest clean intermediate result verified on top of the
+non-vacuous algebra layer:
 
 - `MPOTensor.AlgebraStructureData.stationaryOfFaithfulFixedPoint_compatible_of_adjointFixedPoints_eq`
 - `MPOTensor.isRFP_MPDO_via_algebra_of_adjointFixedPoints_eq_of_isTP_of_posDef_fixed`
 
-These isolate the exact extra hypothesis that the current Lean compatibility
+These isolate the exact extra hypothesis that the current formal compatibility
 predicate can genuinely see: stabilization of the adjoint fixed-point algebras
 of the blocked transfer maps.
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -980,9 +980,31 @@ Combine Theorem~\ref{thm:mpdo_rfp_of_fusion} with
 Theorem~\ref{thm:mpdo_rfp_via_algebra_from_rfp}.
 \end{proof}
 
-The current formal layer still does not recover the paper's special diagonal
-matrices $\chi_{\alpha,\beta,\gamma}$ from Theorem~IV.13(ii). What it does
-provide is the first explicit coefficient data attached to the algebra tower:
+\begin{theorem}[Stabilized blocked adjoint fixed points yield algebra data]%
+    \label{thm:mpdo_algebra_from_stabilized_adjoint_fixedpoints}
+    \lean{MPOTensor.isRFP_MPDO_via_algebra_of_adjointFixedPoints_eq_of_isTP_of_posDef_fixed}
+    \leanok
+    \uses{def:mpdo_rfp_via_algebra}
+    Assume the doubled tensor is trace-preserving and the transfer map admits a
+    positive-definite fixed point. If, for every positive blocked size $n$, the
+    adjoint fixed-point space of the blocked transfer map agrees with the
+    adjoint fixed-point space of the original transfer map, then the current
+    algebra predicate holds.
+\end{theorem}
+\begin{proof}\leanok
+Use the adjoint fixed-point algebra of the original transfer map as a constant
+support-algebra tower. The stabilization hypothesis identifies that same
+algebra with the adjoint fixed-point space of every positive blocked transfer
+map, so the stationary family is compatible with the present definition.
+\end{proof}
+
+This still falls short of the full converse direction of
+\cite[Theorem~IV.13]{Cirac2017MPDO_AnnPhys}: the present compatibility
+predicate only sees stabilized adjoint fixed-point algebras, not yet the
+paper's coefficient/BNT data. The current formal layer still does not recover
+the special diagonal matrices $\chi_{\alpha,\beta,\gamma}$ from
+Theorem~IV.13(ii). What it does provide is the first explicit coefficient data
+attached to the algebra tower:
 a chosen basis of each support algebra, coordinate maps into a finite scalar
 family, and the corresponding multiplication / inclusion coefficient arrays.
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1062,8 +1062,8 @@ $m_n(b_i,b_j) \in \mathcal{A}_{2n}$.
     \leanok
     \uses{def:mpdo_rfp_via_algebra, def:mpdo_blocked_coefficients}
     If the algebra tower is compatible with an MPO tensor $M$, then every adjoint
-    blocked fixed point of $E_n = \operatorname{blockedTransferMap}(M,n)$ belongs
-    to $\mathcal{A}_n$ and is recovered exactly from its extracted coefficient
+    blocked fixed point of the blocked transfer map $E_n$ belongs to
+    $\mathcal{A}_n$ and is recovered exactly from its extracted coefficient
     family.
 \end{theorem}
 \begin{proof}\leanok


### PR DESCRIPTION
## Summary

This draft starts issue #826 from `origin/main`, which still carries the old
vacuous `AlgebraStructure` scaffold.

So the branch first imports the current non-vacuous algebra-side work from the
open #612 follow-up branch:

- `TNLean/MPS/MPDO/AlgebraStructure.lean`
- `blueprint/src/chapter/ch02b_mpdo.tex`

and then adds the strongest clean converse-adjacent theorem I could verify on
top of that layer.

## Landed Lean result

New declarations in `TNLean/MPS/MPDO/AlgebraStructure.lean`:

- `MPOTensor.AlgebraStructureData.stationaryOfFaithfulFixedPoint_compatible_of_adjointFixedPoints_eq`
- `MPOTensor.isRFP_MPDO_via_algebra_of_adjointFixedPoints_eq_of_isTP_of_posDef_fixed`

Mathematically, these say:

> under TP + a positive-definite fixed point, if the adjoint fixed-point spaces
> of all positive blocked transfer maps stabilize to the adjoint fixed-point
> space of the original transfer map, then the **current Lean algebra
> predicate** holds.

So this branch cleanly isolates what the present compatibility relation can
actually see.

## What this does **not** prove

This branch does **not** prove the requested converse

```lean
MPOTensor.IsRFP_MPDO_via_algebra M → MPOTensor.IsRFP_MPDO_via_fusion M
```

because the current Lean compatibility predicate is still weaker than the full
paper statement: it only packages stabilized adjoint fixed-point algebras, not
yet the coefficient / BNT data from Appendix C.3–C.4.

The scouting audit keeps a plausible dephasing-channel counterexample on record,
but I am **not** claiming a machine-checked disproof of the converse from this
branch.

## Blueprint / audit sync

- added a blueprint theorem block for the new stabilization-to-algebra bridge
- updated the surrounding prose to state honestly that the full converse remains
  out of reach with the current Lean predicate
- updated the audit note with the actual outcome of the pass

## Validation

- `lake build TNLean.MPS.MPDO.AlgebraStructure`
- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake env lean TNLean.lean`
- `lake build`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- diff-scoped grep for `sorry|axiom|admit|native_decide`

## Files touched

- `TNLean/MPS/MPDO/AlgebraStructure.lean`
- `blueprint/src/chapter/ch02b_mpdo.tex`
- `audits/2026-04-23_issue826_algebra_to_fusion_scout.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive Lean lemmas/theorems plus documentation updates, with no runtime behavior; main risk is proof fragility or downstream lemma name/behavior expectations.
> 
> **Overview**
> Adds public lemmas in `BlockingViaAdjoint.lean` identifying `(transferMap A).adjoint` with `Kraus.adjointMap` (both linear-map and pointwise `simp` forms), so other files no longer need ad-hoc private versions.
> 
> Extends the MPDO algebra-structure development with a new sufficient condition showing the stationary support-algebra tower is compatible when **adjoint fixed-point spaces stabilize across all positive block lengths**, and a wrapper theorem that yields `IsRFP_MPDO_via_algebra` from this stabilization hypothesis (under TP + positive-definite fixed point), explicitly *without* assuming `IsRFP`/fusion.
> 
> Updates blueprint text and adds an audit note to document the new stabilization-to-algebra bridge and to clarify that the full algebra-to-fusion converse remains unproved with the current (support-algebra–only) predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34116bd020a77c64306aadc812a97ebd77215d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->