### PR TITLE
feat(Wolf Ch2): formalize Lorentz normal form and SVD representation existence

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -322,6 +322,9 @@ import TNLean.Channel.Peripheral.CyclicDecomposition
 import TNLean.Channel.Peripheral.Cycles
 import TNLean.Channel.Peripheral.MultiCycleDecomposition
 
+-- Chapter 2 §2.3 normal-form existence (SVD + Lorentz)
+import TNLean.Channel.NormalForm
+
 -- Public documentation index modules
 import TNLean.Channel.WolfChapter2Index
 import TNLean.Channel.WolfChapter6Index

--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -17,6 +17,25 @@ open scoped Matrix
 
 variable {D : ℕ}
 
+namespace Matrix.IsHermitian
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Spectral decomposition of a Hermitian complex matrix** (polymorphic in the
+index type): `M = U * diagonal λ * Uᴴ` where `U = hM.eigenvectorUnitary` and
+`λ = hM.eigenvalues` are the eigenvector unitary and real eigenvalues provided
+by Mathlib's Hermitian spectral theorem. -/
+theorem spectral_decomp_eq_of_generalIndex
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
+    M = (↑hM.eigenvectorUnitary : Matrix n n ℂ) *
+      Matrix.diagonal (fun j => (↑(hM.eigenvalues j) : ℂ)) *
+      (↑hM.eigenvectorUnitary : Matrix n n ℂ)ᴴ := by
+  have h := hM.spectral_theorem
+  rw [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose] at h
+  convert h using 2
+
+end Matrix.IsHermitian
+
 /-- `Uᴴ * U = 1` for the eigenvector unitary of a Hermitian matrix. -/
 theorem eig_conj_mul [DecidableEq (Fin D)]
     {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) :
@@ -38,10 +57,8 @@ theorem spectral_decomp_eq [DecidableEq (Fin D)]
     {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) :
     M = (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) *
       Matrix.diagonal (fun j => (↑(hM.eigenvalues j) : ℂ)) *
-      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
-  have h := hM.spectral_theorem
-  rw [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose] at h
-  convert h using 2
+      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)ᴴ :=
+  hM.spectral_decomp_eq_of_generalIndex
 
 namespace HermitianHelpers
 

--- a/TNLean/Channel/NormalForm.lean
+++ b/TNLean/Channel/NormalForm.lean
@@ -2,52 +2,47 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Algebra.HermitianHelpers
-import TNLean.Channel.Basic
-import TNLean.Channel.PartialTrace
 import TNLean.Channel.TransferMatrix
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Order
-import Mathlib.Data.Matrix.Invertible
 
 /-!
-# Normal forms for transfer matrices (Wolf §2.3)
+# SVD normal form for (transfer) matrices (Wolf §2.3)
 
-This file formalizes two existence results from Wolf §2.3 on normal forms of
-(transfer) matrices:
+This file formalizes the singular value decomposition (SVD) existence result
+from Wolf §2.3, which serves as the key technical building block for the
+transfer-matrix normal forms discussed there.
 
-* **Singular value decomposition (SVD)**. Every invertible complex square
-  matrix admits a decomposition `M = U * diagonal σ * Vᴴ` with `U, V` unitary
-  and `σ : n → ℝ` strictly positive. This is the SVD representation that
-  Wolf uses as a building block for transfer-matrix normal forms.
+* **SVD for PSD matrices.** Every positive semi-definite complex square matrix
+  admits a decomposition `M = U * diagonal σ * Uᴴ` with `U` unitary and `σ`
+  non-negative; this is the spectral theorem packaged in SVD form.
+* **SVD for invertible matrices.** Every invertible complex square matrix
+  admits a decomposition `M = U * diagonal σ * Vᴴ` with `U, V` unitary and
+  `σ : n → ℝ` strictly positive.
 
-* **Lorentz normal form (trivial witness)**. A qubit channel whose Choi matrix
-  already has both partial traces proportional to the identity (i.e. is
-  doubly-stochastic) is in Lorentz normal form under the trivial `SL(2, ℂ)`
-  filtering `X₁ = X₂ = 𝟙`. This captures the base case of Wolf Prop 2.11.
+The full Wolf §2.3 Lorentz normal form (Prop 2.9 / Prop 2.11 for qubit
+channels) requires an optimization / compactness step to show the infimum of
+`tr τ'` over `SL(2, ℂ)` filterings is attained; that iterative argument is out
+of scope for this existence milestone and is tracked in the Chapter 2 index.
 
-The SVD result is the key technical building block; the full Wolf Prop 2.9 /
-Prop 2.11 argument further requires an optimization / compactness step to show
-the infimum of `tr τ'` over filterings is attained. That iterative argument is
-out of scope for this existence milestone.
+The singular values produced here are not sorted and not proven unique;
+downstream Wolf §2.3 applications that need the sorted / unique variant will
+require additional work.
 
 ## Main results
 
 * `Matrix.svd_of_posSemidef` — SVD existence for positive-semidefinite
-  matrices (this is the spectral theorem packaged in SVD form).
+  matrices.
 * `Matrix.svd_of_isUnit` — SVD existence for invertible complex matrices.
 * `transferMatrix_svd_of_isUnit` — SVD existence specialised to invertible
   transfer matrices of linear channel super-operators.
-* `lorentz_normal_form_trivial` — trivial-filtering witness of the Lorentz
-  normal form existence for qubit channels whose Choi matrix is already
-  doubly-stochastic.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2.3][Wolf2012QChannels]
 -/
 
-open scoped Matrix BigOperators Kronecker ComplexOrder
+open scoped Matrix BigOperators ComplexOrder
 open Matrix
 
 namespace Matrix
@@ -90,8 +85,8 @@ theorem svd_of_isUnit {M : Matrix n n ℂ} (hM : IsUnit M) :
   have hN_unit : IsUnit (Mᴴ * M) := hMh_unit.mul hM
   have hN_pd : (Mᴴ * M).PosDef := hN_psd.posDef_iff_isUnit.mpr hN_unit
   -- Extract spectral data.
-  set V : Matrix.unitaryGroup n ℂ := hN_psd.isHermitian.eigenvectorUnitary with hV_def
-  set lam : n → ℝ := hN_psd.isHermitian.eigenvalues with hlam_def
+  set V : Matrix.unitaryGroup n ℂ := hN_psd.isHermitian.eigenvectorUnitary
+  set lam : n → ℝ := hN_psd.isHermitian.eigenvalues
   have hlam_pos : ∀ i, 0 < lam i := fun i => hN_pd.eigenvalues_pos i
   -- Singular values `σ_i = sqrt λ_i`.
   let sig : n → ℝ := fun i => Real.sqrt (lam i)
@@ -220,41 +215,3 @@ theorem transferMatrix_svd_of_isUnit
   Matrix.svd_of_isUnit (n := Fin D × Fin D) hT
 
 end TransferMatrixSVD
-
-/-! ### Lorentz normal form — trivial-filtering witness -/
-
-section LorentzNormalForm
-
-/-- A Choi-like matrix `τ` on `ℂ² ⊗ ℂ²` is **doubly-stochastic** when both of
-its partial traces are proportional to the `2×2` identity. This is the Wolf
-definition of Prop 2.9 specialised to qubit dimension. -/
-def IsDoublyStochasticChoi
-    (τ : Matrix (Fin 2 × Fin 2) (Fin 2 × Fin 2) ℂ) : Prop :=
-  (∃ c₁ : ℂ, Matrix.traceRight τ = c₁ • (1 : Matrix (Fin 2) (Fin 2) ℂ)) ∧
-  (∃ c₂ : ℂ, Matrix.traceLeft  τ = c₂ • (1 : Matrix (Fin 2) (Fin 2) ℂ))
-
-/-- **Lorentz normal form — trivial witness (Wolf Prop 2.11, base case).**
-If the Choi matrix of a qubit channel is already doubly-stochastic, then the
-identity `SL(2, ℂ)` filtering pair `(X₁, X₂) = (𝟙, 𝟙)` witnesses the Lorentz
-normal form: conjugation by `X₂ ⊗ X₁ = 𝟙 ⊗ 𝟙 = 𝟙` returns `τ` unchanged and
-therefore preserves double-stochasticity.
-
-This is the base case of the iterative optimisation argument sketched in
-Wolf §2.3 (Prop 2.9 / Prop 2.11). The full existence result additionally
-requires a compactness / minimisation step that is out of scope for this
-existence milestone. -/
-theorem lorentz_normal_form_trivial
-    {τ : Matrix (Fin 2 × Fin 2) (Fin 2 × Fin 2) ℂ}
-    (hτ : IsDoublyStochasticChoi τ) :
-    ∃ (X₁ X₂ : Matrix (Fin 2) (Fin 2) ℂ),
-      X₁.det = 1 ∧ X₂.det = 1 ∧
-      IsDoublyStochasticChoi
-        ((X₂ ⊗ₖ X₁) * τ * (X₂ ⊗ₖ X₁)ᴴ) := by
-  refine ⟨(1 : Matrix (Fin 2) (Fin 2) ℂ), (1 : Matrix (Fin 2) (Fin 2) ℂ),
-    Matrix.det_one, Matrix.det_one, ?_⟩
-  have hKron : ((1 : Matrix (Fin 2) (Fin 2) ℂ) ⊗ₖ
-      (1 : Matrix (Fin 2) (Fin 2) ℂ)) = 1 := Matrix.one_kronecker_one
-  rw [hKron]
-  simp [hτ]
-
-end LorentzNormalForm

--- a/TNLean/Channel/NormalForm.lean
+++ b/TNLean/Channel/NormalForm.lean
@@ -1,0 +1,260 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.HermitianHelpers
+import TNLean.Channel.Basic
+import TNLean.Channel.PartialTrace
+import TNLean.Channel.TransferMatrix
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Data.Matrix.Invertible
+
+/-!
+# Normal forms for transfer matrices (Wolf §2.3)
+
+This file formalizes two existence results from Wolf §2.3 on normal forms of
+(transfer) matrices:
+
+* **Singular value decomposition (SVD)**. Every invertible complex square
+  matrix admits a decomposition `M = U * diagonal σ * Vᴴ` with `U, V` unitary
+  and `σ : n → ℝ` strictly positive. This is the SVD representation that
+  Wolf uses as a building block for transfer-matrix normal forms.
+
+* **Lorentz normal form (trivial witness)**. A qubit channel whose Choi matrix
+  already has both partial traces proportional to the identity (i.e. is
+  doubly-stochastic) is in Lorentz normal form under the trivial `SL(2, ℂ)`
+  filtering `X₁ = X₂ = 𝟙`. This captures the base case of Wolf Prop 2.11.
+
+The SVD result is the key technical building block; the full Wolf Prop 2.9 /
+Prop 2.11 argument further requires an optimization / compactness step to show
+the infimum of `tr τ'` over filterings is attained. That iterative argument is
+out of scope for this existence milestone.
+
+## Main results
+
+* `Matrix.svd_of_posSemidef` — SVD existence for positive-semidefinite
+  matrices (this is the spectral theorem packaged in SVD form).
+* `Matrix.svd_of_isUnit` — SVD existence for invertible complex matrices.
+* `transferMatrix_svd_of_isUnit` — SVD existence specialised to invertible
+  transfer matrices of linear channel super-operators.
+* `lorentz_normal_form_trivial` — trivial-filtering witness of the Lorentz
+  normal form existence for qubit channels whose Choi matrix is already
+  doubly-stochastic.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2.3][Wolf2012QChannels]
+-/
+
+open scoped Matrix BigOperators Kronecker ComplexOrder
+open Matrix
+
+namespace Matrix
+
+section SVD
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **SVD for positive semi-definite matrices** (spectral theorem, packaged).
+If `M` is positive semi-definite, then `M = U * diagonal σ * Uᴴ` for a unitary
+`U` and some non-negative real sequence `σ`. -/
+theorem svd_of_posSemidef {M : Matrix n n ℂ} (hM : M.PosSemidef) :
+    ∃ (U : Matrix.unitaryGroup n ℂ) (σ : n → ℝ),
+      (∀ i, 0 ≤ σ i) ∧
+      M = (U : Matrix n n ℂ) *
+        Matrix.diagonal (fun i => (σ i : ℂ)) *
+        (U : Matrix n n ℂ)ᴴ := by
+  classical
+  refine ⟨hM.isHermitian.eigenvectorUnitary, hM.isHermitian.eigenvalues,
+    hM.eigenvalues_nonneg, ?_⟩
+  have h := hM.isHermitian.spectral_theorem
+  rw [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose] at h
+  convert h using 2
+
+/-- **Singular Value Decomposition (invertible case).** Every invertible
+complex square matrix admits an SVD
+`M = U * diagonal σ * Vᴴ` with `U, V` unitary and `σ` strictly positive. -/
+theorem svd_of_isUnit {M : Matrix n n ℂ} (hM : IsUnit M) :
+    ∃ (U V : Matrix.unitaryGroup n ℂ) (σ : n → ℝ),
+      (∀ i, 0 < σ i) ∧
+      M = (U : Matrix n n ℂ) *
+        Matrix.diagonal (fun i => (σ i : ℂ)) *
+        (V : Matrix n n ℂ)ᴴ := by
+  classical
+  -- `N := Mᴴ * M` is positive semi-definite; since `M` is invertible, it is
+  -- positive definite.
+  have hN_psd : (Mᴴ * M).PosSemidef := Matrix.posSemidef_conjTranspose_mul_self M
+  have hMh_unit : IsUnit Mᴴ := by
+    rw [← Matrix.star_eq_conjTranspose]; exact hM.star
+  have hN_unit : IsUnit (Mᴴ * M) := hMh_unit.mul hM
+  have hN_pd : (Mᴴ * M).PosDef := hN_psd.posDef_iff_isUnit.mpr hN_unit
+  -- Extract spectral data.
+  set V : Matrix.unitaryGroup n ℂ := hN_psd.isHermitian.eigenvectorUnitary with hV_def
+  set lam : n → ℝ := hN_psd.isHermitian.eigenvalues with hlam_def
+  have hlam_pos : ∀ i, 0 < lam i := fun i => hN_pd.eigenvalues_pos i
+  -- Singular values `σ_i = sqrt λ_i`.
+  let sig : n → ℝ := fun i => Real.sqrt (lam i)
+  have hsig_pos : ∀ i, 0 < sig i := fun i => Real.sqrt_pos.mpr (hlam_pos i)
+  have hsig_ne : ∀ i, sig i ≠ 0 := fun i => (hsig_pos i).ne'
+  have hsig_sq : ∀ i, (sig i) * (sig i) = lam i := fun i =>
+    Real.mul_self_sqrt (hlam_pos i).le
+  have hsigC_ne : ∀ i, (sig i : ℂ) ≠ 0 := fun i => by
+    exact_mod_cast hsig_ne i
+  -- Diagonal factors.
+  let Sdiag : Matrix n n ℂ := Matrix.diagonal (fun i => (sig i : ℂ))
+  let Sinv : Matrix n n ℂ :=
+    Matrix.diagonal (fun i => ((sig i : ℂ))⁻¹)
+  have hS_mul_Sinv : Sdiag * Sinv = 1 := by
+    simp only [Sdiag, Sinv, Matrix.diagonal_mul_diagonal]
+    rw [show (fun i => (sig i : ℂ) * ((sig i : ℂ))⁻¹) = fun _ => (1 : ℂ) from ?_]
+    · exact Matrix.diagonal_one
+    · funext i; field_simp [hsigC_ne i]
+  have hSinv_mul_S : Sinv * Sdiag = 1 := by
+    simp only [Sdiag, Sinv, Matrix.diagonal_mul_diagonal]
+    rw [show (fun i => ((sig i : ℂ))⁻¹ * (sig i : ℂ)) = fun _ => (1 : ℂ) from ?_]
+    · exact Matrix.diagonal_one
+    · funext i; field_simp [hsigC_ne i]
+  have hSinv_herm : Sinvᴴ = Sinv := by
+    simp only [Sinv, Matrix.diagonal_conjTranspose]
+    congr 1; funext i; simp
+  -- Spectral decomposition of `Mᴴ * M`.
+  have hSpectral :
+      Mᴴ * M = (V : Matrix n n ℂ) *
+        Matrix.diagonal (fun i => (lam i : ℂ)) *
+        (V : Matrix n n ℂ)ᴴ := by
+    have h := hN_psd.isHermitian.spectral_theorem
+    rw [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose] at h
+    simpa [V, lam] using h
+  -- Unitarity of V.
+  have hVhV : (V : Matrix n n ℂ)ᴴ * (V : Matrix n n ℂ) = 1 := by
+    have := Matrix.mem_unitaryGroup_iff'.mp V.prop
+    simpa [Matrix.star_eq_conjTranspose] using this
+  have hVVh : (V : Matrix n n ℂ) * (V : Matrix n n ℂ)ᴴ = 1 := by
+    have := Matrix.mem_unitaryGroup_iff.mp V.prop
+    simpa [Matrix.star_eq_conjTranspose] using this
+  -- Σ² = diagonal lam as complex matrices.
+  have hSsq : Sdiag * Sdiag = Matrix.diagonal (fun i => (lam i : ℂ)) := by
+    simp only [Sdiag, Matrix.diagonal_mul_diagonal]
+    congr 1; funext i
+    have : (sig i : ℂ) * (sig i : ℂ) = ((sig i * sig i : ℝ) : ℂ) := by push_cast; ring
+    rw [this, hsig_sq]
+  -- Define U := M * V * Sinv.
+  let Um : Matrix n n ℂ := M * (V : Matrix n n ℂ) * Sinv
+  -- Key computation: Umᴴ * Um = 1.
+  have hUhU : Umᴴ * Um = 1 := by
+    have step_conj : Umᴴ = Sinv * (V : Matrix n n ℂ)ᴴ * Mᴴ := by
+      simp only [Um, Matrix.conjTranspose_mul, hSinv_herm]
+      noncomm_ring
+    rw [step_conj]
+    have key :
+        Sinv * (V : Matrix n n ℂ)ᴴ * Mᴴ *
+          (M * (V : Matrix n n ℂ) * Sinv) =
+        Sinv *
+          ((V : Matrix n n ℂ)ᴴ * (Mᴴ * M) * (V : Matrix n n ℂ)) *
+          Sinv := by noncomm_ring
+    rw [key, hSpectral]
+    have collapse :
+        (V : Matrix n n ℂ)ᴴ *
+          ((V : Matrix n n ℂ) *
+            Matrix.diagonal (fun i => (lam i : ℂ)) *
+            (V : Matrix n n ℂ)ᴴ) *
+          (V : Matrix n n ℂ) =
+        Matrix.diagonal (fun i => (lam i : ℂ)) := by
+      calc (V : Matrix n n ℂ)ᴴ *
+            ((V : Matrix n n ℂ) *
+              Matrix.diagonal (fun i => (lam i : ℂ)) *
+              (V : Matrix n n ℂ)ᴴ) *
+            (V : Matrix n n ℂ)
+          = ((V : Matrix n n ℂ)ᴴ * (V : Matrix n n ℂ)) *
+              Matrix.diagonal (fun i => (lam i : ℂ)) *
+              ((V : Matrix n n ℂ)ᴴ * (V : Matrix n n ℂ)) := by noncomm_ring
+        _ = 1 * Matrix.diagonal (fun i => (lam i : ℂ)) * 1 := by rw [hVhV]
+        _ = Matrix.diagonal (fun i => (lam i : ℂ)) := by simp
+    rw [collapse, ← hSsq]
+    calc Sinv * (Sdiag * Sdiag) * Sinv
+        = (Sinv * Sdiag) * (Sdiag * Sinv) := by noncomm_ring
+      _ = 1 * 1 := by rw [hSinv_mul_S, hS_mul_Sinv]
+      _ = 1 := by simp
+  -- Package U as a unitary group element.
+  refine ⟨⟨Um, Matrix.mem_unitaryGroup_iff'.mpr
+    (by simpa [Matrix.star_eq_conjTranspose] using hUhU)⟩, V, sig, hsig_pos, ?_⟩
+  -- Verify M = Um * Sdiag * Vᴴ.
+  change M = Um * Sdiag * (V : Matrix n n ℂ)ᴴ
+  have expand :
+      Um * Sdiag * (V : Matrix n n ℂ)ᴴ =
+        M * ((V : Matrix n n ℂ) * (Sinv * Sdiag) *
+          (V : Matrix n n ℂ)ᴴ) := by
+    simp only [Um]; noncomm_ring
+  rw [expand, hSinv_mul_S]
+  calc M = M * 1 := by rw [mul_one]
+    _ = M * ((V : Matrix n n ℂ) * (V : Matrix n n ℂ)ᴴ) := by rw [hVVh]
+    _ = M * ((V : Matrix n n ℂ) * 1 * (V : Matrix n n ℂ)ᴴ) := by rw [mul_one]
+
+end SVD
+
+end Matrix
+
+/-! ### Transfer-matrix specialisation -/
+
+section TransferMatrixSVD
+
+variable {D : ℕ}
+
+/-- **SVD representation of a transfer matrix** (existence, Wolf §2.3).
+Every invertible transfer matrix admits a singular value decomposition
+`T̂ = U * diagonal σ * Vᴴ` with `U, V` unitary and `σ` strictly positive.
+
+This is a direct specialisation of `Matrix.svd_of_isUnit` to the
+`(Fin D × Fin D)` index type used by `transferMatrix`. -/
+theorem transferMatrix_svd_of_isUnit
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsUnit (transferMatrix T)) :
+    ∃ (U V : Matrix.unitaryGroup (Fin D × Fin D) ℂ)
+      (σ : (Fin D × Fin D) → ℝ),
+      (∀ i, 0 < σ i) ∧
+      transferMatrix T =
+        (U : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) *
+          Matrix.diagonal (fun i => (σ i : ℂ)) *
+          (V : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ)ᴴ :=
+  Matrix.svd_of_isUnit (n := Fin D × Fin D) hT
+
+end TransferMatrixSVD
+
+/-! ### Lorentz normal form — trivial-filtering witness -/
+
+section LorentzNormalForm
+
+/-- A Choi-like matrix `τ` on `ℂ² ⊗ ℂ²` is **doubly-stochastic** when both of
+its partial traces are proportional to the `2×2` identity. This is the Wolf
+definition of Prop 2.9 specialised to qubit dimension. -/
+def IsDoublyStochasticChoi
+    (τ : Matrix (Fin 2 × Fin 2) (Fin 2 × Fin 2) ℂ) : Prop :=
+  (∃ c₁ : ℂ, Matrix.traceRight τ = c₁ • (1 : Matrix (Fin 2) (Fin 2) ℂ)) ∧
+  (∃ c₂ : ℂ, Matrix.traceLeft  τ = c₂ • (1 : Matrix (Fin 2) (Fin 2) ℂ))
+
+/-- **Lorentz normal form — trivial witness (Wolf Prop 2.11, base case).**
+If the Choi matrix of a qubit channel is already doubly-stochastic, then the
+identity `SL(2, ℂ)` filtering pair `(X₁, X₂) = (𝟙, 𝟙)` witnesses the Lorentz
+normal form: conjugation by `X₂ ⊗ X₁ = 𝟙 ⊗ 𝟙 = 𝟙` returns `τ` unchanged and
+therefore preserves double-stochasticity.
+
+This is the base case of the iterative optimisation argument sketched in
+Wolf §2.3 (Prop 2.9 / Prop 2.11). The full existence result additionally
+requires a compactness / minimisation step that is out of scope for this
+existence milestone. -/
+theorem lorentz_normal_form_trivial
+    {τ : Matrix (Fin 2 × Fin 2) (Fin 2 × Fin 2) ℂ}
+    (hτ : IsDoublyStochasticChoi τ) :
+    ∃ (X₁ X₂ : Matrix (Fin 2) (Fin 2) ℂ),
+      X₁.det = 1 ∧ X₂.det = 1 ∧
+      IsDoublyStochasticChoi
+        ((X₂ ⊗ₖ X₁) * τ * (X₂ ⊗ₖ X₁)ᴴ) := by
+  refine ⟨(1 : Matrix (Fin 2) (Fin 2) ℂ), (1 : Matrix (Fin 2) (Fin 2) ℂ),
+    Matrix.det_one, Matrix.det_one, ?_⟩
+  have hKron : ((1 : Matrix (Fin 2) (Fin 2) ℂ) ⊗ₖ
+      (1 : Matrix (Fin 2) (Fin 2) ℂ)) = 1 := Matrix.one_kronecker_one
+  rw [hKron]
+  simp [hτ]
+
+end LorentzNormalForm

--- a/TNLean/Channel/NormalForm.lean
+++ b/TNLean/Channel/NormalForm.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.TransferMatrix
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Order
@@ -59,13 +60,9 @@ theorem svd_of_posSemidef {M : Matrix n n ℂ} (hM : M.PosSemidef) :
       (∀ i, 0 ≤ σ i) ∧
       M = (U : Matrix n n ℂ) *
         Matrix.diagonal (fun i => (σ i : ℂ)) *
-        (U : Matrix n n ℂ)ᴴ := by
-  classical
-  refine ⟨hM.isHermitian.eigenvectorUnitary, hM.isHermitian.eigenvalues,
-    hM.eigenvalues_nonneg, ?_⟩
-  have h := hM.isHermitian.spectral_theorem
-  rw [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose] at h
-  convert h using 2
+        (U : Matrix n n ℂ)ᴴ :=
+  ⟨hM.isHermitian.eigenvectorUnitary, hM.isHermitian.eigenvalues,
+    hM.eigenvalues_nonneg, hM.isHermitian.spectral_decomp_eq_of_generalIndex⟩
 
 /-- **Singular Value Decomposition (invertible case).** Every invertible
 complex square matrix admits an SVD
@@ -117,10 +114,8 @@ theorem svd_of_isUnit {M : Matrix n n ℂ} (hM : IsUnit M) :
   have hSpectral :
       Mᴴ * M = (V : Matrix n n ℂ) *
         Matrix.diagonal (fun i => (lam i : ℂ)) *
-        (V : Matrix n n ℂ)ᴴ := by
-    have h := hN_psd.isHermitian.spectral_theorem
-    rw [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose] at h
-    simpa [V, lam] using h
+        (V : Matrix n n ℂ)ᴴ :=
+    hN_psd.isHermitian.spectral_decomp_eq_of_generalIndex
   -- Unitarity of V.
   have hVhV : (V : Matrix n n ℂ)ᴴ * (V : Matrix n n ℂ) = 1 := by
     have := Matrix.mem_unitaryGroup_iff'.mp V.prop

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -13,6 +13,7 @@ import TNLean.Channel.Stinespring
 import TNLean.Channel.POVM
 import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
+import TNLean.Channel.NormalForm
 
 /-!
 # Wolf Lecture Notes — Chapter 2: Representations
@@ -101,6 +102,20 @@ representations of quantum channels.
 * `transferMatrix_unitaryConj_sandwich` — **Props 2.7-2.8 key identity**:
   `(Ad_{U₁} ∘ T ∘ Ad_{U₂})^ = (Ū₁⊗U₁) T̂ (Ū₂⊗U₂)` ✅
 
+### §2.3 Normal forms — SVD and Lorentz (existence)
+
+* `Matrix.svd_of_posSemidef` — **SVD for PSD matrices** (spectral theorem
+  packaged): `M = U * diagonal σ * Uᴴ` with `σ ≥ 0` ✅
+* `Matrix.svd_of_isUnit` — **SVD existence for invertible complex matrices**:
+  `M = U * diagonal σ * Vᴴ` with `U, V` unitary and `σ > 0` ✅
+* `transferMatrix_svd_of_isUnit` — **SVD representation of a transfer
+  matrix** (Wolf §2.3): every invertible transfer matrix admits an SVD ✅
+* `IsDoublyStochasticChoi` — Choi-matrix doubly-stochastic predicate (both
+  partial traces proportional to identity) ✅
+* `lorentz_normal_form_trivial` — **Lorentz normal form, trivial witness**
+  (Wolf Prop 2.11 base case): identity `SL(2, ℂ)` filtering on a
+  doubly-stochastic qubit Choi matrix ✅
+
 ### Infrastructure
 
 | Definition | File | Lean name |
@@ -131,8 +146,7 @@ representations of quantum channels.
 | Thm 2.3 (ordered CP-maps) | Needs Stinespring + contraction |
 | Thm 2.4 (Radon-Nikodym) | Follows from Thm 2.3 |
 | Thm 2.5 (open-system representation) | Embedding into unitary |
-| §2.3 Lorentz normal form (existence) | Needs SVD of transfer matrix |
-| §2.3 SVD representation (existence) | Needs Mathlib SVD |
+| §2.3 Lorentz normal form (full iterative existence) | Needs compactness / minimisation; `lorentz_normal_form_trivial` gives the base case |
 
 ## References
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -102,7 +102,7 @@ representations of quantum channels.
 * `transferMatrix_unitaryConj_sandwich` — **Props 2.7-2.8 key identity**:
   `(Ad_{U₁} ∘ T ∘ Ad_{U₂})^ = (Ū₁⊗U₁) T̂ (Ū₂⊗U₂)` ✅
 
-### §2.3 Normal forms — SVD and Lorentz (existence)
+### §2.3 SVD normal form (existence)
 
 * `Matrix.svd_of_posSemidef` — **SVD for PSD matrices** (spectral theorem
   packaged): `M = U * diagonal σ * Uᴴ` with `σ ≥ 0` ✅
@@ -110,11 +110,6 @@ representations of quantum channels.
   `M = U * diagonal σ * Vᴴ` with `U, V` unitary and `σ > 0` ✅
 * `transferMatrix_svd_of_isUnit` — **SVD representation of a transfer
   matrix** (Wolf §2.3): every invertible transfer matrix admits an SVD ✅
-* `IsDoublyStochasticChoi` — Choi-matrix doubly-stochastic predicate (both
-  partial traces proportional to identity) ✅
-* `lorentz_normal_form_trivial` — **Lorentz normal form, trivial witness**
-  (Wolf Prop 2.11 base case): identity `SL(2, ℂ)` filtering on a
-  doubly-stochastic qubit Choi matrix ✅
 
 ### Infrastructure
 
@@ -146,7 +141,8 @@ representations of quantum channels.
 | Thm 2.3 (ordered CP-maps) | Needs Stinespring + contraction |
 | Thm 2.4 (Radon-Nikodym) | Follows from Thm 2.3 |
 | Thm 2.5 (open-system representation) | Embedding into unitary |
-| §2.3 Lorentz normal form (full iterative existence) | Needs compactness / minimisation; `lorentz_normal_form_trivial` gives the base case |
+| §2.3 Lorentz normal form (existence) | Needs compactness / minimisation over `SL(2, ℂ)` filterings (Wolf Prop 2.9 / Prop 2.11) |
+| §2.3 Sorted / unique singular values | `svd_of_isUnit` is unsorted; downstream normal-form uses will want the sorted variant |
 
 ## References
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1698,14 +1698,18 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
 \end{proof}
 
 %% =========================================================
-\subsection{Normal forms: SVD and Lorentz (existence)}
-\label{subsec:svd_lorentz_normal_form}
+\subsection{SVD normal form (existence)}
+\label{subsec:svd_normal_form}
 %% =========================================================
 
 Wolf \S2.3 discusses two families of normal forms for the transfer-matrix
 representation of a quantum channel: the \emph{singular value decomposition}
 (SVD) and, for qubit channels, the \emph{Lorentz normal form} obtained by
-$\mathrm{SL}(2,\mathbb{C})$ filtering operations.
+$\mathrm{SL}(2,\mathbb{C})$ filtering operations. In this blueprint, the full
+existence statement formalized below is the SVD normal form; the Lorentz
+normal form existence requires a compactness / minimisation argument over
+$\mathrm{SL}(2,\mathbb{C})$ filterings (Wolf Prop 2.9 / Prop 2.11) that
+remains open in this formalisation.
 
 \begin{theorem}[SVD for positive semi-definite matrices]
     \label{thm:svd_posSemidef}
@@ -1764,37 +1768,14 @@ $\mathrm{SL}(2,\mathbb{C})$ filtering operations.
     representation.
 \end{proof}
 
-\begin{definition}[Doubly-stochastic Choi matrix]
-    \label{def:doubly_stochastic_choi}
-    \lean{IsDoublyStochasticChoi}\leanok
-    A Choi-like matrix $\tau \in \mathcal{M}_{2} \otimes \mathcal{M}_{2}$ is
-    \emph{doubly-stochastic} if both of its partial traces are proportional to
-    the $2 \times 2$ identity matrix.
-\end{definition}
-
-\begin{theorem}[Lorentz normal form — trivial-filtering witness]
-    \label{thm:lorentz_normal_form_trivial}
-    \lean{lorentz_normal_form_trivial}\leanok
-    \uses{def:doubly_stochastic_choi}
-    If a qubit Choi matrix $\tau$ is already doubly-stochastic, then the
-    trivial $\mathrm{SL}(2,\mathbb{C})$ filtering pair
-    $(X_{1}, X_{2}) = (\mathbf{1}, \mathbf{1})$ witnesses the Lorentz normal
-    form: both determinants are $1$ and conjugation by $X_{2} \otimes X_{1}
-    = \mathbf{1}$ returns $\tau$ unchanged and therefore preserves
-    double-stochasticity.
-
-    This is the base case of the iterative optimisation argument sketched in
-    Wolf \S2.3 (Prop 2.9 / Prop 2.11). The full existence result additionally
-    requires a compactness / minimisation step that remains open in this
-    formalisation.
-\end{theorem}
-
-\begin{proof}\leanok
-    Take $X_{1} = X_{2} = \mathbf{1}$. Then $\det X_{i} = 1$ and
-    $X_{2} \otimes X_{1} = \mathbf{1}$, so $(X_{2} \otimes X_{1}) \tau
-    (X_{2} \otimes X_{1})^{\dagger} = \tau$, which is doubly-stochastic by
-    assumption.
-\end{proof}
+\begin{remark}[Sorted / unique singular values]
+    Theorem~\ref{thm:svd_of_isUnit} produces the singular values as an
+    unordered family, without the usual convention that $\sigma_{i}$ are sorted
+    in non-increasing order or the statement that they are uniquely determined
+    by $M$. Downstream applications in Wolf \S2.3 (trace-norm identities,
+    polar decomposition, Lorentz normal form) will typically require the
+    sorted / unique variant; that refinement is future work.
+\end{remark}
 
 %% The following sections will not be needed for the fundamental theorem of the matrix product states.
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1697,6 +1697,105 @@ of~\cite[Ch.~2]{Wolf2012Quantum}.
     stated double-sum formula.
 \end{proof}
 
+%% =========================================================
+\subsection{Normal forms: SVD and Lorentz (existence)}
+\label{subsec:svd_lorentz_normal_form}
+%% =========================================================
+
+Wolf \S2.3 discusses two families of normal forms for the transfer-matrix
+representation of a quantum channel: the \emph{singular value decomposition}
+(SVD) and, for qubit channels, the \emph{Lorentz normal form} obtained by
+$\mathrm{SL}(2,\mathbb{C})$ filtering operations.
+
+\begin{theorem}[SVD for positive semi-definite matrices]
+    \label{thm:svd_posSemidef}
+    \lean{Matrix.svd_of_posSemidef}\leanok
+    Every positive semi-definite matrix $M \in \MN{D}$ admits a decomposition
+    \[
+        M = U \operatorname{diag}(\sigma) U^{\dagger},
+    \]
+    where $U \in \mathrm{U}(D)$ is unitary and $\sigma : \{1, \dots, D\} \to
+    \mathbb{R}_{\ge 0}$ has non-negative entries.
+\end{theorem}
+
+\begin{proof}\leanok
+    The spectral theorem for Hermitian matrices provides an orthonormal
+    eigenbasis with real eigenvalues. Positive semi-definiteness forces those
+    eigenvalues to be non-negative, and the decomposition is packaged in SVD
+    form with $U$ the eigenvector unitary and $\sigma$ the eigenvalue sequence.
+\end{proof}
+
+\begin{theorem}[SVD existence for invertible matrices]
+    \label{thm:svd_of_isUnit}
+    \lean{Matrix.svd_of_isUnit}\leanok
+    Every invertible complex square matrix $M \in \MN{D}$ admits a singular
+    value decomposition
+    \[
+        M = U \operatorname{diag}(\sigma) V^{\dagger},
+    \]
+    with $U, V \in \mathrm{U}(D)$ unitary and $\sigma_i > 0$ for all $i$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the spectral theorem to the positive definite matrix
+    $M^{\dagger} M$ to obtain $M^{\dagger} M = V \operatorname{diag}(\lambda)
+    V^{\dagger}$ with $\lambda_i > 0$. Set $\sigma_i := \sqrt{\lambda_i}$ and
+    $\Sigma := \operatorname{diag}(\sigma)$; since $\Sigma$ is a real positive
+    diagonal, it is self-adjoint and invertible. Define $U := M V \Sigma^{-1}$.
+    Then $U^{\dagger} U = \Sigma^{-1} V^{\dagger} (M^{\dagger} M) V \Sigma^{-1}
+    = \Sigma^{-1} \operatorname{diag}(\lambda) \Sigma^{-1} = I$, so $U$ is
+    unitary, and $U \Sigma V^{\dagger} = M V (\Sigma^{-1} \Sigma) V^{\dagger} =
+    M V V^{\dagger} = M$.
+\end{proof}
+
+\begin{theorem}[SVD representation of a transfer matrix]
+    \label{thm:transferMatrix_svd_of_isUnit}
+    \lean{transferMatrix_svd_of_isUnit}\leanok
+    \uses{thm:svd_of_isUnit}
+    Every invertible transfer matrix $\widehat{T}$ of a linear super-operator
+    $T : \MN{D} \to \MN{D}$ admits a singular value decomposition
+    $\widehat{T} = U \operatorname{diag}(\sigma) V^{\dagger}$ with $U, V$
+    unitary on $\mathbb{C}^{D} \otimes \mathbb{C}^{D}$ and $\sigma_i > 0$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Direct specialisation of Theorem~\ref{thm:svd_of_isUnit} to the index type
+    $\{1,\dots,D\} \times \{1,\dots,D\}$ used by the transfer-matrix
+    representation.
+\end{proof}
+
+\begin{definition}[Doubly-stochastic Choi matrix]
+    \label{def:doubly_stochastic_choi}
+    \lean{IsDoublyStochasticChoi}\leanok
+    A Choi-like matrix $\tau \in \mathcal{M}_{2} \otimes \mathcal{M}_{2}$ is
+    \emph{doubly-stochastic} if both of its partial traces are proportional to
+    the $2 \times 2$ identity matrix.
+\end{definition}
+
+\begin{theorem}[Lorentz normal form — trivial-filtering witness]
+    \label{thm:lorentz_normal_form_trivial}
+    \lean{lorentz_normal_form_trivial}\leanok
+    \uses{def:doubly_stochastic_choi}
+    If a qubit Choi matrix $\tau$ is already doubly-stochastic, then the
+    trivial $\mathrm{SL}(2,\mathbb{C})$ filtering pair
+    $(X_{1}, X_{2}) = (\mathbf{1}, \mathbf{1})$ witnesses the Lorentz normal
+    form: both determinants are $1$ and conjugation by $X_{2} \otimes X_{1}
+    = \mathbf{1}$ returns $\tau$ unchanged and therefore preserves
+    double-stochasticity.
+
+    This is the base case of the iterative optimisation argument sketched in
+    Wolf \S2.3 (Prop 2.9 / Prop 2.11). The full existence result additionally
+    requires a compactness / minimisation step that remains open in this
+    formalisation.
+\end{theorem}
+
+\begin{proof}\leanok
+    Take $X_{1} = X_{2} = \mathbf{1}$. Then $\det X_{i} = 1$ and
+    $X_{2} \otimes X_{1} = \mathbf{1}$, so $(X_{2} \otimes X_{1}) \tau
+    (X_{2} \otimes X_{1})^{\dagger} = \tau$, which is doubly-stochastic by
+    assumption.
+\end{proof}
+
 %% The following sections will not be needed for the fundamental theorem of the matrix product states.
 
 %% =========================================================


### PR DESCRIPTION
Addresses LionSR/QICLean#12

Auto-created by Claude Code action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive formalization, but it introduces a nontrivial new proof chain and new root-level imports that could affect build times and expose new compilation failures across dependent modules.
> 
> **Overview**
> Implements Wolf §2.3 *SVD normal-form existence* by adding `TNLean.Channel.NormalForm` with `Matrix.svd_of_posSemidef`, `Matrix.svd_of_isUnit`, and `transferMatrix_svd_of_isUnit` (invertible transfer-matrix SVD).
> 
> Refactors `HermitianHelpers` to add a general-index Hermitian spectral decomposition lemma (`spectral_decomp_eq_of_generalIndex`) and reuses it for the existing `Fin D` lemma.
> 
> Wires the new results into the public import surface (`TNLean.lean`), the Chapter 2 index (`WolfChapter2Index.lean`), and the blueprint text (new SVD normal-form subsection and notes on Lorentz normal form still pending).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44078094b5a2cdfd7d37317c07de4d0a05801b67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->