### PR TITLE
feat(Channel/FixedPoint): formalize corner C-algebra instances and faithful-support compression

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -99,9 +99,11 @@ import TNLean.Channel.Schwarz.TraceCFC
 import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro
+import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp
 import TNLean.Channel.FixedPoint.Corollaries
+import TNLean.Channel.Spectral.Support
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Irreducible.Growth

--- a/TNLean/Channel/FixedPoint/CornerAlgebra.lean
+++ b/TNLean/Channel/FixedPoint/CornerAlgebra.lean
@@ -6,15 +6,16 @@ import TNLean.Channel.Peripheral.CyclicDecomposition.Basic
 import Mathlib.RingTheory.Idempotents
 
 /-!
-# Complex-algebra and star packaging on the idempotent corner
+# Complex-algebra and star structures on the idempotent corner
 
 Mathlib's `IsIdempotentElem.Corner` already provides the `Semiring` / `Ring` structure on the
 subsemigroup `Set.range (P * · * P)` for an idempotent `P`, with unit `P`. For the matrix
 corners appearing in the support-projection route for Wolf Cor. 6.6 we additionally need:
 
-* `ℂ`-linear packaging on the corner;
-* star packaging when `P` is self-adjoint;
-* a bridge with the repository's `cornerSubmodule P = {X | P * X * P = X}`.
+* a `ℂ`-module and `ℂ`-algebra structure on the corner;
+* star, `StarRing`, and `StarModule ℂ` structures when `P` is self-adjoint;
+* a `ℂ`-linear equivalence with the repository's
+  `cornerSubmodule P = {X | P * X * P = X}`.
 
 This file supplies those instances for `P : Matrix (Fin D) (Fin D) ℂ` and the linear
 equivalence `cornerSubmodule P ≃ₗ[ℂ] IsIdempotentElem.Corner hP`.
@@ -94,8 +95,9 @@ noncomputable instance instAlgebraComplexCorner (hP : IsIdempotentElem P) :
 /-! ### Star structure for a self-adjoint idempotent
 
 The `Star`, `InvolutiveStar`, `StarMul`, `StarAddMonoid`, `StarRing`, and `StarModule ℂ` instances
-on `hP.Corner` require the self-adjointness hypothesis `Pᴴ = P`. We package them as `def`s that
-produce the instance, rather than `instance`s, because the hypothesis is data-level.
+on `hP.Corner` require the self-adjointness hypothesis `Pᴴ = P`. Because this hypothesis is
+data-level, the structures below are given as `def`s rather than global `instance`s; callers
+should introduce them locally with `letI` at each use site.
 -/
 
 section Star
@@ -157,9 +159,9 @@ variable (hP : IsIdempotentElem P) (hPstar : Pᴴ = P)
 
 end Star
 
-/-! ### Bridge with the repository's `cornerSubmodule` -/
+/-! ### Identification with the repository's `cornerSubmodule` -/
 
-section Bridge
+section CornerSubmoduleIdentification
 
 /-- For an idempotent `P`, `cornerSubmodule P = {X | P * X * P = X}` has the same underlying set
 as `Subsemigroup.corner P = Set.range (P * · * P)`. -/
@@ -175,7 +177,8 @@ lemma cornerSubmodule_mem_iff_mem_corner
     change P * X * P = X
     rw [Matrix.mul_assoc, hR, hL]
 
-/-- The bridge `cornerSubmodule P ≃ₗ[ℂ] IsIdempotentElem.Corner hP`. -/
+/-- The `ℂ`-linear equivalence `cornerSubmodule P ≃ₗ[ℂ] IsIdempotentElem.Corner hP` for an
+idempotent matrix `P`, given by the identity on underlying matrices. -/
 def cornerSubmoduleCornerEquiv (hP : IsIdempotentElem P) :
     cornerSubmodule P ≃ₗ[ℂ] hP.Corner where
   toFun X := ⟨X.1, (cornerSubmodule_mem_iff_mem_corner hP X.1).mp X.2⟩
@@ -193,6 +196,6 @@ def cornerSubmoduleCornerEquiv (hP : IsIdempotentElem P) :
     (hP : IsIdempotentElem P) (X : hP.Corner) :
     ((cornerSubmoduleCornerEquiv hP).symm X).1 = X.1 := rfl
 
-end Bridge
+end CornerSubmoduleIdentification
 
 end MatrixCorner

--- a/TNLean/Channel/FixedPoint/CornerAlgebra.lean
+++ b/TNLean/Channel/FixedPoint/CornerAlgebra.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Peripheral.CyclicDecomposition.Basic
+import Mathlib.RingTheory.Idempotents
+
+/-!
+# Complex-algebra and star packaging on the idempotent corner
+
+Mathlib's `IsIdempotentElem.Corner` already provides the `Semiring` / `Ring` structure on the
+subsemigroup `Set.range (P * · * P)` for an idempotent `P`, with unit `P`. For the matrix
+corners appearing in the support-projection route for Wolf Cor. 6.6 we additionally need:
+
+* `ℂ`-linear packaging on the corner;
+* star packaging when `P` is self-adjoint;
+* a bridge with the repository's `cornerSubmodule P = {X | P * X * P = X}`.
+
+This file supplies those instances for `P : Matrix (Fin D) (Fin D) ℂ` and the linear
+equivalence `cornerSubmodule P ≃ₗ[ℂ] IsIdempotentElem.Corner hP`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Cor. 6.6].
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+open Matrix
+
+namespace MatrixCorner
+
+variable {D : ℕ} {P : Matrix (Fin D) (Fin D) ℂ}
+
+private lemma mem_corner_iff_matrix (hP : IsIdempotentElem P)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    X ∈ Subsemigroup.corner P ↔ P * X = X ∧ X * P = X :=
+  Subsemigroup.mem_corner_iff hP
+
+/-! ### `ℂ`-linear structure -/
+
+instance instSMulComplexCorner (hP : IsIdempotentElem P) : SMul ℂ hP.Corner where
+  smul c X := ⟨c • X.1, by
+    obtain ⟨hL, hR⟩ := (mem_corner_iff_matrix hP X.1).mp X.2
+    refine (mem_corner_iff_matrix hP _).mpr ⟨?_, ?_⟩
+    · rw [Matrix.mul_smul, hL]
+    · rw [smul_mul_assoc, hR]⟩
+
+@[simp] lemma smul_val (hP : IsIdempotentElem P) (c : ℂ) (X : hP.Corner) :
+    (c • X).1 = c • X.1 := rfl
+
+instance instMulActionComplexCorner (hP : IsIdempotentElem P) : MulAction ℂ hP.Corner where
+  one_smul X := Subtype.ext (one_smul ℂ X.1)
+  mul_smul c d X := Subtype.ext (mul_smul c d X.1)
+
+instance instDistribMulActionComplexCorner (hP : IsIdempotentElem P) :
+    DistribMulAction ℂ hP.Corner where
+  smul_zero c := Subtype.ext (smul_zero c)
+  smul_add c X Y := Subtype.ext (smul_add c X.1 Y.1)
+
+instance instModuleComplexCorner (hP : IsIdempotentElem P) : Module ℂ hP.Corner where
+  add_smul c d X := Subtype.ext (add_smul c d X.1)
+  zero_smul X := Subtype.ext (zero_smul ℂ X.1)
+
+/-- The algebra map `ℂ → hP.Corner` sending `c` to `c • P`. -/
+noncomputable def cornerAlgebraMap (hP : IsIdempotentElem P) : ℂ →+* hP.Corner where
+  toFun c := ⟨c • P, by
+    refine (mem_corner_iff_matrix hP _).mpr ⟨?_, ?_⟩
+    · rw [Matrix.mul_smul, hP.eq]
+    · rw [smul_mul_assoc, hP.eq]⟩
+  map_one' := Subtype.ext (one_smul ℂ P)
+  map_mul' c d := Subtype.ext <| by
+    change (c * d) • P = (c • P) * (d • P)
+    rw [smul_mul_smul_comm, hP.eq]
+  map_zero' := Subtype.ext (zero_smul ℂ P)
+  map_add' c d := Subtype.ext (add_smul c d P)
+
+@[simp] lemma cornerAlgebraMap_apply_val (hP : IsIdempotentElem P) (c : ℂ) :
+    (cornerAlgebraMap hP c).1 = c • P := rfl
+
+noncomputable instance instAlgebraComplexCorner (hP : IsIdempotentElem P) :
+    Algebra ℂ hP.Corner where
+  algebraMap := cornerAlgebraMap hP
+  commutes' c X := by
+    apply Subtype.ext
+    obtain ⟨hL, hR⟩ := (mem_corner_iff_matrix hP X.1).mp X.2
+    change (c • P) * X.1 = X.1 * (c • P)
+    rw [smul_mul_assoc, Matrix.mul_smul, hL, hR]
+  smul_def' c X := by
+    apply Subtype.ext
+    obtain ⟨hL, _⟩ := (mem_corner_iff_matrix hP X.1).mp X.2
+    change c • X.1 = (c • P) * X.1
+    rw [smul_mul_assoc, hL]
+
+/-! ### Star structure for a self-adjoint idempotent
+
+The `Star`, `InvolutiveStar`, `StarMul`, `StarAddMonoid`, `StarRing`, and `StarModule ℂ` instances
+on `hP.Corner` require the self-adjointness hypothesis `Pᴴ = P`. We package them as `def`s that
+produce the instance, rather than `instance`s, because the hypothesis is data-level.
+-/
+
+section Star
+
+variable (hP : IsIdempotentElem P) (hPstar : Pᴴ = P)
+
+/-- Star on `hP.Corner` given self-adjointness of `P`. -/
+@[reducible] noncomputable def cornerStar : Star hP.Corner where
+  star X := ⟨X.1ᴴ, by
+    obtain ⟨hL, hR⟩ := (mem_corner_iff_matrix hP X.1).mp X.2
+    refine (mem_corner_iff_matrix hP _).mpr ⟨?_, ?_⟩
+    · calc P * X.1ᴴ = Pᴴ * X.1ᴴ := by rw [hPstar]
+        _ = (X.1 * P)ᴴ := by rw [← Matrix.conjTranspose_mul]
+        _ = X.1ᴴ := by rw [hR]
+    · calc X.1ᴴ * P = X.1ᴴ * Pᴴ := by rw [hPstar]
+        _ = (P * X.1)ᴴ := by rw [← Matrix.conjTranspose_mul]
+        _ = X.1ᴴ := by rw [hL]⟩
+
+@[simp] lemma cornerStar_val
+    (X : hP.Corner) :
+    letI : Star hP.Corner := cornerStar hP hPstar
+    (Star.star X).1 = X.1ᴴ := rfl
+
+/-- `InvolutiveStar` structure on `hP.Corner` given self-adjointness of `P`. -/
+@[reducible] noncomputable def cornerInvolutiveStar : InvolutiveStar hP.Corner :=
+  letI : Star hP.Corner := cornerStar hP hPstar
+  { star := Star.star
+    star_involutive := fun X => Subtype.ext (Matrix.conjTranspose_conjTranspose X.1) }
+
+/-- `StarMul` structure on `hP.Corner` given self-adjointness of `P`. -/
+@[reducible] noncomputable def cornerStarMul : StarMul hP.Corner :=
+  letI : InvolutiveStar hP.Corner := cornerInvolutiveStar hP hPstar
+  { star_involutive := InvolutiveStar.star_involutive
+    star_mul := fun X Y => Subtype.ext (Matrix.conjTranspose_mul X.1 Y.1) }
+
+/-- `StarAddMonoid` structure on `hP.Corner` given self-adjointness of `P`. -/
+@[reducible] noncomputable def cornerStarAddMonoid : StarAddMonoid hP.Corner :=
+  letI : InvolutiveStar hP.Corner := cornerInvolutiveStar hP hPstar
+  { star_involutive := InvolutiveStar.star_involutive
+    star_add := fun X Y => Subtype.ext (Matrix.conjTranspose_add X.1 Y.1) }
+
+/-- `StarRing` structure on `hP.Corner` given self-adjointness of `P`. -/
+@[reducible] noncomputable def cornerStarRing : StarRing hP.Corner :=
+  letI : StarMul hP.Corner := cornerStarMul hP hPstar
+  letI : StarAddMonoid hP.Corner := cornerStarAddMonoid hP hPstar
+  { star := Star.star
+    star_involutive := InvolutiveStar.star_involutive
+    star_mul := StarMul.star_mul
+    star_add := StarAddMonoid.star_add }
+
+/-- `StarModule ℂ` on `hP.Corner` given self-adjointness of `P`. -/
+@[reducible] noncomputable def cornerStarModuleComplex :
+    letI : Star hP.Corner := cornerStar hP hPstar
+    StarModule ℂ hP.Corner :=
+  letI : Star hP.Corner := cornerStar hP hPstar
+  { star_smul := fun c X => Subtype.ext <| by
+      change (c • X.1)ᴴ = Star.star c • X.1ᴴ
+      exact Matrix.conjTranspose_smul c X.1 }
+
+end Star
+
+/-! ### Bridge with the repository's `cornerSubmodule` -/
+
+section Bridge
+
+/-- For an idempotent `P`, `cornerSubmodule P = {X | P * X * P = X}` has the same underlying set
+as `Subsemigroup.corner P = Set.range (P * · * P)`. -/
+lemma cornerSubmodule_mem_iff_mem_corner
+    (hP : IsIdempotentElem P) (X : Matrix (Fin D) (Fin D) ℂ) :
+    X ∈ cornerSubmodule P ↔ X ∈ Subsemigroup.corner P := by
+  constructor
+  · intro h
+    have h' : P * X * P = X := h
+    exact ⟨X, by simp [h']⟩
+  · intro h
+    obtain ⟨hL, hR⟩ := (mem_corner_iff_matrix hP X).mp h
+    change P * X * P = X
+    rw [Matrix.mul_assoc, hR, hL]
+
+/-- The bridge `cornerSubmodule P ≃ₗ[ℂ] IsIdempotentElem.Corner hP`. -/
+def cornerSubmoduleCornerEquiv (hP : IsIdempotentElem P) :
+    cornerSubmodule P ≃ₗ[ℂ] hP.Corner where
+  toFun X := ⟨X.1, (cornerSubmodule_mem_iff_mem_corner hP X.1).mp X.2⟩
+  invFun X := ⟨X.1, (cornerSubmodule_mem_iff_mem_corner hP X.1).mpr X.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+@[simp] lemma cornerSubmoduleCornerEquiv_apply_val
+    (hP : IsIdempotentElem P) (X : cornerSubmodule P) :
+    (cornerSubmoduleCornerEquiv hP X).1 = X.1 := rfl
+
+@[simp] lemma cornerSubmoduleCornerEquiv_symm_apply_val
+    (hP : IsIdempotentElem P) (X : hP.Corner) :
+    ((cornerSubmoduleCornerEquiv hP).symm X).1 = X.1 := rfl
+
+end Bridge
+
+end MatrixCorner

--- a/TNLean/Channel/Spectral/Support.lean
+++ b/TNLean/Channel/Spectral/Support.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Irreducible.FixedPointProjection
+
+/-!
+# Faithful compression of a PSD matrix onto its support sector
+
+For a positive semi-definite matrix `ρ` on `ℂ^D`, let `P := supportProj ρ` be its support
+projection. Although `ρ` is generally not positive definite on the whole space, it becomes
+positive definite when restricted to its support. This file packages that fact.
+
+## Main results
+
+* `Matrix.PosSemidef.dotProduct_mulVec_pos_of_supportProj_fixed` — if `v` is a nonzero vector
+  fixed by the support projection, then the quadratic form `x ↦ x⋆ ρ x` is strictly positive
+  on `v`.
+* `Matrix.PosSemidef.compression_on_support_posDef` — given a compression isometry
+  `V : Matrix (Fin k) (Fin D) ℂ` with `V * Vᴴ = 1` and `Vᴴ * V = supportProj ρ`, the
+  compression `V * ρ * Vᴴ` is positive definite.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Cor. 6.6]
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+open Matrix
+
+namespace Matrix
+
+namespace PosSemidef
+
+variable {D : ℕ} {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosSemidef)
+
+/-- If `v` is fixed by the support projection `P = supportProj ρ` and `v ≠ 0`, then
+`star v ⬝ᵥ (ρ *ᵥ v) > 0`. -/
+theorem dotProduct_mulVec_pos_of_supportProj_fixed
+    {v : Fin D → ℂ} (hv_ne : v ≠ 0)
+    (hv_fix : MPSTensor.supportProj (D := D) ρ hρ *ᵥ v = v) :
+    0 < star v ⬝ᵥ (ρ *ᵥ v) := by
+  classical
+  have h_nonneg : 0 ≤ star v ⬝ᵥ (ρ *ᵥ v) := hρ.dotProduct_mulVec_nonneg v
+  refine lt_of_le_of_ne h_nonneg ?_
+  intro habs
+  -- If the quadratic form vanishes, then `ρ *ᵥ v = 0`.
+  have hρv : ρ *ᵥ v = 0 := (hρ.dotProduct_mulVec_zero_iff v).mp habs.symm
+  -- Then the support projection also annihilates `v`.
+  have hPv : MPSTensor.supportProj (D := D) ρ hρ *ᵥ v = 0 :=
+    MPSTensor.supportProj_mulVec_eq_zero_of_mulVec_eq_zero (D := D) ρ hρ v hρv
+  -- Combined with the fixed-point hypothesis, this forces `v = 0`.
+  exact hv_ne (hv_fix.symm.trans hPv)
+
+/-- **Faithful compression onto the support sector.** Given a PSD matrix `ρ`, set
+`P := supportProj ρ`, and suppose `V : Matrix (Fin k) (Fin D) ℂ` is a compression isometry
+with `V * Vᴴ = 1` and `Vᴴ * V = P`. Then the compression `V * ρ * Vᴴ` is positive definite. -/
+theorem compression_on_support_posDef
+    {k : ℕ} {V : Matrix (Fin k) (Fin D) ℂ}
+    (hVVt : V * Vᴴ = 1)
+    (hVtV : Vᴴ * V = MPSTensor.supportProj (D := D) ρ hρ) :
+    (V * ρ * Vᴴ).PosDef := by
+  classical
+  set P : Matrix (Fin D) (Fin D) ℂ := MPSTensor.supportProj (D := D) ρ hρ with hP_def
+  -- Hermiticity of `V * ρ * Vᴴ`.
+  have h_herm : (V * ρ * Vᴴ).IsHermitian := by
+    unfold Matrix.IsHermitian
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_conjTranspose, hρ.isHermitian.eq, Matrix.mul_assoc]
+  -- Strict positivity of the quadratic form on nonzero vectors.
+  refine Matrix.PosDef.of_dotProduct_mulVec_pos h_herm ?_
+  intro w hw
+  set u : Fin D → ℂ := Vᴴ *ᵥ w with hu_def
+  -- `u ≠ 0`: otherwise `w = (V * Vᴴ) *ᵥ w = V *ᵥ u = 0`.
+  have hu_ne : u ≠ 0 := by
+    intro hu
+    apply hw
+    have : (V * Vᴴ) *ᵥ w = V *ᵥ u := by
+      simp [u, Matrix.mulVec_mulVec]
+    rw [hVVt, Matrix.one_mulVec] at this
+    rw [this, hu, Matrix.mulVec_zero]
+  -- `P *ᵥ u = u`: `P = Vᴴ * V`, so `P *ᵥ u = Vᴴ *ᵥ (V *ᵥ (Vᴴ *ᵥ w)) = Vᴴ *ᵥ w = u`.
+  have hPu : P *ᵥ u = u := by
+    simp only [hu_def, ← hVtV, Matrix.mulVec_mulVec, Matrix.mul_assoc]
+    rw [show Vᴴ * (V * Vᴴ) = Vᴴ from by rw [hVVt, Matrix.mul_one]]
+  -- Rewrite the quadratic form on `w` in terms of `u`.
+  have h_quadform : star w ⬝ᵥ ((V * ρ * Vᴴ) *ᵥ w) = star u ⬝ᵥ (ρ *ᵥ u) := by
+    have h1 : (V * ρ * Vᴴ) *ᵥ w = V *ᵥ (ρ *ᵥ u) := by
+      simp [u, Matrix.mulVec_mulVec, Matrix.mul_assoc]
+    rw [h1, Matrix.dotProduct_mulVec, Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
+  rw [h_quadform]
+  -- Apply the pointwise strict positivity lemma.
+  exact hρ.dotProduct_mulVec_pos_of_supportProj_fixed hu_ne hPu
+
+end PosSemidef
+
+end Matrix

--- a/TNLean/Channel/Spectral/Support.lean
+++ b/TNLean/Channel/Spectral/Support.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.Irreducible.FixedPointProjection
 
 For a positive semi-definite matrix `ρ` on `ℂ^D`, let `P := supportProj ρ` be its support
 projection. Although `ρ` is generally not positive definite on the whole space, it becomes
-positive definite when restricted to its support. This file packages that fact.
+positive definite when restricted to its support. This file records that fact.
 
 ## Main results
 

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -344,52 +344,8 @@ theorem lowerZero_of_posSemidef_fixedPoint
             rw [hv]
             simp only [Matrix.mulVec_zero]
   -- Kernel inclusion: `ker ρ ⊆ ker P` (spectral argument).
-  have ker_ρ_sub_ker_P : ∀ v, ρ *ᵥ v = 0 → P *ᵥ v = 0 := by
-    intro v hv
-    -- Expand the definition of the support projector.
-    let hH : ρ.IsHermitian := hρ_psd.isHermitian
-    set U : Matrix (Fin D) (Fin D) ℂ := ↑hH.eigenvectorUnitary
-    set s : Fin D → ℂ := fun i => if 0 < hH.eigenvalues i then 1 else 0
-    have hUU : Uᴴ * U = 1 := by
-      rw [← Matrix.star_eq_conjTranspose]
-      simp [U]
-    -- Work in the eigenbasis: `w := Uᴴ *ᵥ v`.
-    set w : Fin D → ℂ := Uᴴ *ᵥ v
-    have hΛw : Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) *ᵥ w = 0 := by
-      have hρv : (U * Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) * Uᴴ) *ᵥ v = 0 :=
-        spectral_decomp_eq (D := D) ρ hH ▸ hv
-      set Λ : Matrix (Fin D) (Fin D) ℂ := Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ))
-      have hUΛw : U *ᵥ (Λ *ᵥ w) = 0 := by
-        rw [Matrix.mulVec_mulVec, show w = Uᴴ *ᵥ v from rfl, Matrix.mulVec_mulVec]
-        exact hρv
-      have : Uᴴ *ᵥ (U *ᵥ (Λ *ᵥ w)) = 0 := by
-        rw [hUΛw]
-        simp only [Matrix.mulVec_zero]
-      rwa [Matrix.mulVec_mulVec, hUU, Matrix.one_mulVec] at this
-    have h_comp : ∀ j, (↑(hH.eigenvalues j) : ℂ) * w j = 0 := fun j => by
-      have := congrFun hΛw j
-      simp only [Matrix.mulVec, dotProduct, Matrix.diagonal_apply, Pi.zero_apply,
-        ite_mul, zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ite_true] at this
-      exact this
-    have hSw : Matrix.diagonal s *ᵥ w = 0 := by
-      ext j
-      -- Entrywise, multiplying by a diagonal matrix scales each coordinate.
-      rw [Matrix.mulVec_diagonal]
-      by_cases hjpos : 0 < hH.eigenvalues j
-      · have : w j = 0 := by
-          have hEig_ne : (↑(hH.eigenvalues j) : ℂ) ≠ 0 := by
-            exact_mod_cast (ne_of_gt hjpos)
-          exact (mul_eq_zero.mp (h_comp j)).resolve_left hEig_ne
-        simp [s, hjpos, this]
-      · simp [s, hjpos]
-    -- Finish: compute `P *ᵥ v` in the `U` eigenbasis.
-    have hP_def : P = U * Matrix.diagonal s * Uᴴ := by
-      simp [P, supportProj, U, s]
-    change (U * Matrix.diagonal s * Uᴴ) *ᵥ v = 0
-    have : (U * Matrix.diagonal s * Uᴴ) *ᵥ v = U *ᵥ (Matrix.diagonal s *ᵥ w) := by
-      rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec]
-    rw [this, hSw]
-    simp only [Matrix.mulVec_zero]
+  have ker_ρ_sub_ker_P : ∀ v, ρ *ᵥ v = 0 → P *ᵥ v = 0 := fun v hv =>
+    supportProj_mulVec_eq_zero_of_mulVec_eq_zero (D := D) ρ hρ_psd v hv
   -- Complement-zero (invariance) statement.
   have h_complement_zero : ∀ i : Fin d, (1 - P) * A i * P = 0 := by
     intro i

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -199,6 +199,49 @@ lemma mul_supportProj (hρ_psd : ρ.PosSemidef) :
   -- Rewrite.
   simpa [Matrix.conjTranspose_mul, hHermP.eq, hHermρ.eq] using this
 
+/-- Kernel inclusion `ker ρ ≤ ker (supportProj ρ)`: if `ρ *ᵥ v = 0`, then the support
+projection also annihilates `v`. -/
+theorem supportProj_mulVec_eq_zero_of_mulVec_eq_zero
+    (v : Fin D → ℂ) (hv : ρ *ᵥ v = 0) :
+    supportProj (D := D) ρ hρ *ᵥ v = 0 := by
+  classical
+  let hH : ρ.IsHermitian := hρ.isHermitian
+  set U : Matrix (Fin D) (Fin D) ℂ := ↑hH.eigenvectorUnitary
+  set s : Fin D → ℂ := fun i => if 0 < hH.eigenvalues i then 1 else 0
+  have hUU : Uᴴ * U = 1 := by
+    rw [← Matrix.star_eq_conjTranspose]
+    simp [U]
+  set w : Fin D → ℂ := Uᴴ *ᵥ v
+  have hρ_spec : ρ = U * Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) * Uᴴ := by
+    simpa [U] using (spectral_decomp_eq (D := D) ρ hH)
+  have hΛw : Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) *ᵥ w = 0 := by
+    have hρv : (U * Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) * Uᴴ) *ᵥ v = 0 := by
+      rw [← hρ_spec]; exact hv
+    have hUΛw : U *ᵥ (Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) *ᵥ w) = 0 := by
+      simpa [w, Matrix.mulVec_mulVec, Matrix.mul_assoc] using hρv
+    have hUΛw' : Uᴴ *ᵥ (U *ᵥ (Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) *ᵥ w)) = 0 := by
+      simp [hUΛw]
+    have : (Uᴴ * U) *ᵥ (Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) *ᵥ w) = 0 := by
+      simpa [Matrix.mulVec_mulVec, Matrix.mul_assoc] using hUΛw'
+    simpa [Matrix.mulVec_mulVec, hUU] using this
+  have h_comp : ∀ j, (↑(hH.eigenvalues j) : ℂ) * w j = 0 := fun j => by
+    have := congrFun hΛw j
+    simpa [Matrix.mulVec, dotProduct, Matrix.diagonal_apply] using this
+  have hSw : Matrix.diagonal s *ᵥ w = 0 := by
+    ext j
+    rw [Matrix.mulVec_diagonal]
+    by_cases hjpos : 0 < hH.eigenvalues j
+    · have hwj : w j = 0 := by
+        have hEig_ne : (↑(hH.eigenvalues j) : ℂ) ≠ 0 := by
+          exact_mod_cast (ne_of_gt hjpos)
+        exact (mul_eq_zero.mp (h_comp j)).resolve_left hEig_ne
+      simp [s, hjpos, hwj]
+    · simp [s, hjpos]
+  have hP_def : supportProj (D := D) ρ hρ = U * Matrix.diagonal s * Uᴴ := by rfl
+  have hPeval : (U * Matrix.diagonal s * Uᴴ) *ᵥ v = U *ᵥ (Matrix.diagonal s *ᵥ w) := by
+    simp [w, U, Matrix.mulVec_mulVec, Matrix.mul_assoc]
+  simp [hP_def, hPeval, hSw]
+
 end SupportProjLemmas
 
 

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -977,6 +977,83 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
     These statements are deferred in the present chapter.
 \end{remark}
 
+\subsection{Faithful compression onto the support sector}
+
+The statements in this subsection package the support-projection machinery
+needed for~\cite[Cor.~6.6]{Wolf2012Quantum}: the corner carries a
+$\C$-algebra and $*$-structure, the repository's corner submodule is
+identified with Mathlib's idempotent corner, and the compression of a PSD
+fixed point onto its support sector is positive definite.
+
+\begin{lemma}[Support projection annihilates the kernel]%
+    \label{lem:supportProj_mulVec_eq_zero_of_mulVec_eq_zero}
+    \lean{MPSTensor.supportProj_mulVec_eq_zero_of_mulVec_eq_zero}
+    \leanok
+    Let $\rho \succeq 0$ on $\C^D$ with support projection
+    $P = \mathrm{supp}(\rho)$. For every $v \in \C^D$, if $\rho\, v = 0$,
+    then $P\, v = 0$.
+\end{lemma}
+\begin{proof}\leanok
+    Diagonalize $\rho = U\,\mathrm{diag}(\lambda)\,U^\dagger$ with
+    $\lambda_j \ge 0$. Writing $w := U^\dagger v$, the hypothesis
+    $\rho v = 0$ gives $\lambda_j\, w_j = 0$ for every $j$; hence $w_j = 0$
+    whenever $\lambda_j > 0$. The support projection acts as
+    $\mathrm{diag}(\chi_{\lambda_j > 0})$ in the eigenbasis, so
+    $P\,v = U\,\mathrm{diag}(\chi_{\lambda_j > 0})\,w = 0$.
+\end{proof}
+
+\begin{definition}[Corner submodule / idempotent-corner bridge]%
+    \label{def:cornerSubmoduleCornerEquiv}
+    \lean{MatrixCorner.cornerSubmoduleCornerEquiv}
+    \leanok
+    For an idempotent $P \in \MN{D}$, the repository's corner submodule
+    $\{X \mid P X P = X\}$ and Mathlib's idempotent corner
+    $\{P\,X\,P \mid X \in \MN{D}\}$ are $\C$-linearly isomorphic via the
+    identity on underlying matrices.
+\end{definition}
+
+\begin{remark}[$\C$-algebra and $*$-structure on the corner]%
+    \label{rem:corner_algebra_star_instances}
+    \lean{MatrixCorner.instAlgebraComplexCorner}
+    \lean{MatrixCorner.cornerStar}
+    \lean{MatrixCorner.cornerStarRing}
+    \lean{MatrixCorner.cornerStarModuleComplex}
+    \leanok
+    Mathlib's \texttt{IsIdempotentElem.Corner} already carries a ring
+    structure with unit~$P$. For the matrix case we supply
+    $\C$-linear packaging (module and algebra structure) and, under the
+    additional assumption $P^\dagger = P$, star packaging (star, star ring,
+    and star module over~$\C$).
+\end{remark}
+
+\begin{theorem}[Faithful compression onto the support]%
+    \label{thm:compression_on_support_posDef}
+    \lean{Matrix.PosSemidef.compression_on_support_posDef}
+    \leanok
+    \uses{lem:supportProj_mulVec_eq_zero_of_mulVec_eq_zero}
+    Let $\rho \succeq 0$ on $\C^D$ with support projection
+    $P = \mathrm{supp}(\rho)$, and let
+    $V : \C^D \to \C^k$ be a compression isometry satisfying
+    $V\,V^\dagger = \Id_k$ and $V^\dagger\,V = P$. Then the compression
+    \[
+        V\,\rho\,V^\dagger \in \MN{k}
+    \]
+    is positive definite.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{lem:supportProj_mulVec_eq_zero_of_mulVec_eq_zero}
+    Hermiticity follows from Hermiticity of $\rho$ and the product-star
+    identity. For strict positivity, let $w \neq 0$, set
+    $u := V^\dagger w$, and note that $V V^\dagger = \Id_k$ forces
+    $u \neq 0$, while $V^\dagger V = P$ forces $P u = u$. The quadratic
+    form computes as
+    $w^\dagger (V\rho V^\dagger) w = u^\dagger \rho u$,
+    which is nonnegative by positive semidefiniteness. If it vanishes, then
+    $\rho u = 0$, and by
+    Lemma~\ref{lem:supportProj_mulVec_eq_zero_of_mulVec_eq_zero} also
+    $P u = 0$, contradicting $P u = u \neq 0$.
+\end{proof}
+
 \section{Wedderburn decomposition of the fixed-point algebra}
 
 \begin{theorem}[Fixed-point algebra is semisimple]%

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -979,7 +979,8 @@ behind stationary states, following~\cite[\S6.4]{Wolf2012Quantum}.
 
 \subsection{Faithful compression onto the support sector}
 
-The statements in this subsection package the support-projection machinery
+This subsection establishes the results on the corner algebra,
+$*$-structure, and compression of a PSD fixed point onto its support sector
 needed for~\cite[Cor.~6.6]{Wolf2012Quantum}: the corner carries a
 $\C$-algebra and $*$-structure, the repository's corner submodule is
 identified with Mathlib's idempotent corner, and the compression of a PSD
@@ -1002,14 +1003,14 @@ fixed point onto its support sector is positive definite.
     $P\,v = U\,\mathrm{diag}(\chi_{\lambda_j > 0})\,w = 0$.
 \end{proof}
 
-\begin{definition}[Corner submodule / idempotent-corner bridge]%
+\begin{definition}[Corner submodule / idempotent-corner identification]%
     \label{def:cornerSubmoduleCornerEquiv}
     \lean{MatrixCorner.cornerSubmoduleCornerEquiv}
     \leanok
     For an idempotent $P \in \MN{D}$, the repository's corner submodule
     $\{X \mid P X P = X\}$ and Mathlib's idempotent corner
-    $\{P\,X\,P \mid X \in \MN{D}\}$ are $\C$-linearly isomorphic via the
-    identity on underlying matrices.
+    $\{P\,X\,P \mid X \in \MN{D}\}$ are identified as $\C$-linear spaces
+    by the identity on underlying matrices.
 \end{definition}
 
 \begin{remark}[$\C$-algebra and $*$-structure on the corner]%
@@ -1020,10 +1021,10 @@ fixed point onto its support sector is positive definite.
     \lean{MatrixCorner.cornerStarModuleComplex}
     \leanok
     Mathlib's \texttt{IsIdempotentElem.Corner} already carries a ring
-    structure with unit~$P$. For the matrix case we supply
-    $\C$-linear packaging (module and algebra structure) and, under the
-    additional assumption $P^\dagger = P$, star packaging (star, star ring,
-    and star module over~$\C$).
+    structure with unit~$P$. For the matrix case we provide
+    $\C$-module and $\C$-algebra structures and, under the additional
+    assumption $P^\dagger = P$, star, star ring, and star module
+    structures over~$\C$.
 \end{remark}
 
 \begin{theorem}[Faithful compression onto the support]%


### PR DESCRIPTION
Addresses LionSR/QICLean#138

Auto-created by Claude Code action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new global `ℂ`-module/algebra instances for idempotent matrix corners and new spectral/support lemmas; these can impact typeclass inference and downstream proof stability despite being non-executable changes.
> 
> **Overview**
> Adds a new `CornerAlgebra` module that equips Mathlib’s idempotent matrix corner `hP.Corner` with **`ℂ`-scalar/module and `ℂ`-algebra structure**, plus *optional* `Star`/`StarRing`/`StarModule ℂ` constructions when `Pᴴ = P`, and a `ℂ`-linear equivalence `cornerSubmodule P ≃ₗ[ℂ] hP.Corner` to align the repo’s `cornerSubmodule` with Mathlib’s corner.
> 
> Introduces a new `Spectral.Support` module proving that compressing a PSD matrix onto its support via an isometry yields a **positive definite** matrix (`compression_on_support_posDef`), based on a new kernel-inclusion lemma `supportProj_mulVec_eq_zero_of_mulVec_eq_zero` extracted into `MPS/Irreducible/FixedPointProjection.lean` (and refactoring the prior inlined spectral proof to use it).
> 
> Updates the root `TNLean.lean` import surface and the blueprint chapter to expose/document these new results for the Wolf Cor. 6.6 development.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8041750378480cb6eac6aae5b8b63c67cc069cf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->