### PR TITLE
ci(badges): add Shields.io status badges to README

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -11,6 +11,7 @@ on:
       - 'lake-manifest.json'
       - 'blueprint/src/**'
       - 'home_page/**'
+      - 'scripts/write_badges.py'
   workflow_dispatch:
 
 # Cancel previous runs if a new commit is pushed
@@ -39,6 +40,9 @@ jobs:
 
       - name: Install leanblueprint
         run: pip install leanblueprint
+
+      - name: Write status badges
+        run: python3 scripts/write_badges.py
 
       - name: Build blueprint
         run: |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Lean Action CI](https://github.com/LionSR/TNLean/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/LionSR/TNLean/actions/workflows/lean_action_ci.yml)
 [![Compile blueprint](https://github.com/LionSR/TNLean/actions/workflows/blueprint.yml/badge.svg)](https://github.com/LionSR/TNLean/actions/workflows/blueprint.yml)
+![sorries](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/sorries.json)
+![axioms](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/axioms.json)
+![Lean](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/lean.json)
+![Mathlib](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/mathlib.json)
 
 A Lean 4 formalization of major components of the **Fundamental Theorem of Matrix Product States**, the repository's **cumulative Quantum Wielandt theory**, and a growing body of finite-dimensional **quantum-channel theory** inspired by M. M. Wolf's *Quantum Channels & Operations*, using [Mathlib](https://github.com/leanprover-community/mathlib4) v4.29.0.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,6 +69,7 @@ gh workflow run "Full documentation" --repo LionSR/TNLean --ref main
 /blueprint/          ← leanblueprint web output
 /blueprint.pdf       ← leanblueprint PDF
 /docs/               ← doc-gen4 API documentation
+/badges/             ← Shields.io endpoint JSON for README status badges
 ```
 
 ## Setup

--- a/home_page/badges/axioms.json
+++ b/home_page/badges/axioms.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "axioms",
+  "message": "8",
+  "color": "orange"
+}

--- a/home_page/badges/lean.json
+++ b/home_page/badges/lean.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "Lean",
+  "message": "v4.29.0",
+  "color": "blue"
+}

--- a/home_page/badges/mathlib.json
+++ b/home_page/badges/mathlib.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "Mathlib",
+  "message": "v4.29.0",
+  "color": "blue"
+}

--- a/home_page/badges/sorries.json
+++ b/home_page/badges/sorries.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "sorries",
+  "message": "20",
+  "color": "orange"
+}

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -38,7 +38,8 @@ cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf" 2>/dev/
 echo "==> Updating homepage..."
 rm -rf "$WORK_DIR/site/_layouts" "$WORK_DIR/site/assets" \
        "$WORK_DIR/site/_config.yml" "$WORK_DIR/site/index.md" \
-       "$WORK_DIR/site/404.html" "$WORK_DIR/site/Gemfile"
+       "$WORK_DIR/site/404.html" "$WORK_DIR/site/Gemfile" \
+       "$WORK_DIR/site/badges"
 cp -r "$REPO_ROOT/home_page/"* "$WORK_DIR/site/"
 
 # Update API docs (only with --with-docs)

--- a/scripts/write_badges.py
+++ b/scripts/write_badges.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Write Shields.io endpoint JSON files for the project homepage."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BADGE_DIR = ROOT / "home_page" / "badges"
+LEAN_ROOT = ROOT / "TNLean"
+
+
+def strip_lean_comments_and_strings(text: str) -> str:
+    """Remove Lean comments and strings while preserving token separation."""
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    block_depth = 0
+    in_string = False
+
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+
+        if block_depth:
+            if ch == "/" and nxt == "-":
+                block_depth += 1
+                out.append("  ")
+                i += 2
+            elif ch == "-" and nxt == "/":
+                block_depth -= 1
+                out.append("  ")
+                i += 2
+            else:
+                out.append("\n" if ch == "\n" else " ")
+                i += 1
+            continue
+
+        if in_string:
+            if ch == "\\" and nxt:
+                out.append("  ")
+                i += 2
+            else:
+                if ch == '"':
+                    in_string = False
+                out.append("\n" if ch == "\n" else " ")
+                i += 1
+            continue
+
+        if ch == "-" and nxt == "-":
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if ch == "/" and nxt == "-":
+            block_depth = 1
+            out.append("  ")
+            i += 2
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(" ")
+            i += 1
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
+def lean_files() -> list[Path]:
+    return [
+        path
+        for path in LEAN_ROOT.rglob("*.lean")
+        if "Archive" not in path.relative_to(LEAN_ROOT).parts
+    ]
+
+
+def count_token(token: str) -> int:
+    pattern = re.compile(rf"(?<![A-Za-z0-9_']){re.escape(token)}(?![A-Za-z0-9_'])")
+    total = 0
+    for path in lean_files():
+        total += len(pattern.findall(strip_lean_comments_and_strings(path.read_text())))
+    return total
+
+
+def lean_version() -> str:
+    raw = (ROOT / "lean-toolchain").read_text().strip()
+    return raw.rsplit(":", 1)[-1] if ":" in raw else raw
+
+
+def mathlib_version() -> str:
+    manifest = json.loads((ROOT / "lake-manifest.json").read_text())
+    for package in manifest.get("packages", []):
+        if package.get("name") == "mathlib":
+            return package.get("inputRev") or package.get("rev", "")[:7]
+    return "unknown"
+
+
+def write_badge(name: str, label: str, message: str, color: str) -> None:
+    BADGE_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {"schemaVersion": 1, "label": label, "message": message, "color": color}
+    (BADGE_DIR / f"{name}.json").write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def count_color(count: int, *, warning_at: int = 1) -> str:
+    if count == 0:
+        return "brightgreen"
+    if count <= warning_at:
+        return "yellow"
+    return "orange"
+
+
+def main() -> None:
+    sorries = count_token("sorry")
+    axioms = count_token("axiom")
+    write_badge("sorries", "sorries", str(sorries), count_color(sorries, warning_at=10))
+    write_badge("axioms", "axioms", str(axioms), count_color(axioms, warning_at=0))
+    write_badge("lean", "Lean", lean_version(), "blue")
+    write_badge("mathlib", "Mathlib", mathlib_version(), "blue")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- The README has no visual status indicators for the formalization's current health (open sorrys, axioms, Lean version, Mathlib version).
- Adding Shields.io badges provides at-a-glance status information for contributors and readers visiting the repository.

### Description
- `scripts/write_badges.py` (new): generates Shields.io endpoint JSON files for sorry count, axiom count, Lean version, and Mathlib version.
- `home_page/badges/{sorries,axioms,lean,mathlib}.json` (new): initial badge endpoint JSON files served via GitHub Pages.
- `.github/workflows/blueprint.yml`: refresh badge endpoint directory during Pages deploys.
- `scripts/deploy-to-gh-pages.sh`: updated to include badge files in the deploy payload.
- `README.md`: four status badge images added (sorries, axioms, Lean, Mathlib).
- `docs/deploy.md`: documented the badge endpoint site path.

### Testing
- `python3 scripts/write_badges.py`
- `python3 -m py_compile scripts/write_badges.py`
- `bash -n scripts/deploy-to-gh-pages.sh`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
No linked issue found — please link a relevant issue manually if one exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `blueprint.yml` CI workflow and the `gh-pages` deploy script, which could affect documentation deployments if the badge generation or cleanup steps misbehave.
> 
> **Overview**
> Adds automated status badge generation: a new `scripts/write_badges.py` scans Lean sources (excluding `Archive`) to count `sorry`/`axiom`, reads Lean/Mathlib versions, and writes Shields.io endpoint JSON under `home_page/badges/`.
> 
> Updates the Pages pipeline to publish these endpoints: `blueprint.yml` now runs the badge script before building/deploying, `deploy-to-gh-pages.sh` clears and recopies the `badges/` directory, and docs/README are updated to reference and document the new `/badges/` path on `gh-pages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104584f4dd3a3220af09f7be2201f2db3e5e7714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->