### PR TITLE
fix(ci): use correct Codex commit author identity

### DIFF
--- a/.github/workflows/_codex-auto-fix-shared.yml
+++ b/.github/workflows/_codex-auto-fix-shared.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Setup git identity
         if: steps.loop_guard.outputs.skip != 'true'
         run: |
-          git config --global user.email "codex[bot]@users.noreply.github.com"
-          git config --global user.name "codex[bot]"
+          git config --global user.email "267193182+codex@users.noreply.github.com"
+          git config --global user.name "codex"
 
       - name: Set up Lean toolchain and cache
         if: inputs.setup_lean && steps.loop_guard.outputs.skip != 'true'
@@ -90,7 +90,7 @@ jobs:
           # and `gh pr comment` the summary. workspace-write blocks network.
           sandbox: danger-full-access
           # Allow iterations triggered by prior bot-authored fix commits
-          # (head of branch is authored by codex[bot] / claude[bot]).
+          # (head of branch is authored by codex / claude[bot]).
           allow-bots: true
           prompt: |
             ${{ inputs.codex_prompt }}

--- a/.github/workflows/auto-fix-codex.yml
+++ b/.github/workflows/auto-fix-codex.yml
@@ -289,8 +289,8 @@ jobs:
       - name: Setup git identity
         if: steps.guard.outputs.skip != 'true'
         run: |
-          git config --global user.email "codex[bot]@users.noreply.github.com"
-          git config --global user.name "codex[bot]"
+          git config --global user.email "267193182+codex@users.noreply.github.com"
+          git config --global user.name "codex"
 
       - name: Fetch review comments
         if: steps.guard.outputs.skip != 'true'
@@ -318,7 +318,7 @@ jobs:
           # and `gh pr comment` the summary. workspace-write blocks network.
           sandbox: danger-full-access
           # Allow iterations triggered by prior bot-authored fix commits
-          # (head of branch is authored by codex[bot] / claude[bot]).
+          # (head of branch is authored by codex / claude[bot]).
           allow-bots: true
           prompt: |
             The automated code review found issues in this PR. Your task is to fix them.


### PR DESCRIPTION
### Motivation
- Codex auto-fix workflows committed using `codex[bot]` as the git author identity, which is not a valid GitHub account and causes commit attribution failures.
- The correct noreply identity for the Codex bot is `267193182+codex@users.noreply.github.com` (confirmed via `gh api users/codex`).

### Description
- Updated `.github/workflows/_codex-auto-fix-shared.yml`: replace `codex[bot]` git author email with `267193182+codex@users.noreply.github.com`.
- Updated `.github/workflows/auto-fix-codex.yml`: same identity fix; also update inline comments describing bot-authored heads (`codex` / `claude[bot]`).

### Testing
- `gh api users/codex` confirmed login `codex` with id `267193182`.
- `rg` found no remaining `codex[bot]` references under `.github/workflows`, `.github/actions`, or `docs`.
- `git diff --check` passed.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
No linked issue — please link one manually if this addresses an open issue.

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that adjust commit author metadata and comments, without altering build/test logic or permissions.
> 
> **Overview**
> Fixes Codex auto-fix workflows to commit as **`codex`** using the correct noreply email (`267193182+codex@users.noreply.github.com`) instead of `codex[bot]`, so bot-pushed fix commits have a valid author identity.
> 
> Also updates inline workflow comments to reflect the new bot-authored head naming (`codex` / `claude[bot]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c35923d146d9fa65b6661eece05f1978c782c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>