### PR TITLE
ci(auto-fix-codex): use chatgpt-codex-connector[bot] git identity

### DIFF
--- a/.github/workflows/_codex-auto-fix-shared.yml
+++ b/.github/workflows/_codex-auto-fix-shared.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Setup git identity
         if: steps.loop_guard.outputs.skip != 'true'
         run: |
-          git config --global user.email "codex[bot]@users.noreply.github.com"
-          git config --global user.name "codex[bot]"
+          git config --global user.email "chatgpt-codex-connector[bot]@users.noreply.github.com"
+          git config --global user.name "chatgpt-codex-connector[bot]"
 
       - name: Set up Lean toolchain and cache
         if: inputs.setup_lean && steps.loop_guard.outputs.skip != 'true'
@@ -90,7 +90,7 @@ jobs:
           # and `gh pr comment` the summary. workspace-write blocks network.
           sandbox: danger-full-access
           # Allow iterations triggered by prior bot-authored fix commits
-          # (head of branch is authored by codex[bot] / claude[bot]).
+          # (head of branch is authored by chatgpt-codex-connector[bot] / claude[bot]).
           allow-bots: true
           prompt: |
             ${{ inputs.codex_prompt }}

--- a/.github/workflows/auto-fix-codex.yml
+++ b/.github/workflows/auto-fix-codex.yml
@@ -289,8 +289,8 @@ jobs:
       - name: Setup git identity
         if: steps.guard.outputs.skip != 'true'
         run: |
-          git config --global user.email "codex[bot]@users.noreply.github.com"
-          git config --global user.name "codex[bot]"
+          git config --global user.email "chatgpt-codex-connector[bot]@users.noreply.github.com"
+          git config --global user.name "chatgpt-codex-connector[bot]"
 
       - name: Fetch review comments
         if: steps.guard.outputs.skip != 'true'
@@ -318,7 +318,7 @@ jobs:
           # and `gh pr comment` the summary. workspace-write blocks network.
           sandbox: danger-full-access
           # Allow iterations triggered by prior bot-authored fix commits
-          # (head of branch is authored by codex[bot] / claude[bot]).
+          # (head of branch is authored by chatgpt-codex-connector[bot] / claude[bot]).
           allow-bots: true
           prompt: |
             The automated code review found issues in this PR. Your task is to fix them.


### PR DESCRIPTION
### Motivation

- The `codex[bot]` login does not exist on GitHub, so automated commits showed as a ghost author and other workflows could not match them by login.
- Aligning the git identity with the rest of the repo, which recognizes the Codex bot as `chatgpt-codex-connector[bot]` (see `auto-fix.yml`'s `allowed_bots`, `claude-code-review.yml`'s login filter, and `pr-cleanup.yml`).

### Description

Updated two GitHub Actions workflow files to use the correct bot identity:
- `.github/workflows/_codex-auto-fix-shared.yml`: Changed git config user email and name from `codex[bot]` to `chatgpt-codex-connector[bot]`, and updated related comment.
- `.github/workflows/auto-fix-codex.yml`: Changed git config user email and name from `codex[bot]` to `chatgpt-codex-connector[bot]`, and updated related comment.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build. No Lean code was changed.
- Workflow correctness will be validated by GitHub Actions when the workflows next execute.

---
<!-- No linked issue found — please link one manually if applicable. -->

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that updates git commit attribution for automated fixes; main risk is misattributed commits or failed pushes if the new bot identity is incorrect.
>
> **Overview**
> Updates the Codex auto-fix GitHub Actions workflows to use the `chatgpt-codex-connector[bot]` git user (email/name) instead of `codex[bot]`, ensuring generated fix commits are attributed to the new bot account.
>
> Also updates the inline `allow-bots` comment to reflect the new bot author name.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 264b86d561c7743e511c0457533ac72bc7700f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>