### PR TITLE
refactor(Analysis+Channel/Schwarz): remove unused proof wrappers

### DIFF
--- a/TNLean/Analysis/OperatorConvexity.lean
+++ b/TNLean/Analysis/OperatorConvexity.lean
@@ -122,28 +122,6 @@ theorem IsHermitian.cfc_neg {A : Matrix n n 𝕜} (hA : A.IsHermitian) (f : ℝ 
     hA.cfc (fun x => -f x) = -(hA.cfc f) := by
   rw [← hA.cfc_eq, ← hA.cfc_eq, _root_.cfc_neg f A]
 
-/-- **Diagonal Jensen for a concave function.**
-
-The concave companion of `Matrix.diagonal_jensen_of_convexOn`:
-for a concave `f : ℝ → ℝ` on `[0, ∞)`, PSD `A`, and unit vector `v`,
-`(star v ⬝ᵥ hA.1.cfc f *ᵥ v).re ≤ f ((star v ⬝ᵥ A *ᵥ v).re)`. -/
-theorem diagonal_jensen_of_concaveOn
-    {f : ℝ → ℝ} (hf : ConcaveOn ℝ (Set.Ici (0 : ℝ)) f)
-    {A : Matrix n n ℂ} (hA : A.PosSemidef)
-    {v : n → ℂ} (hv : star v ⬝ᵥ v = (1 : ℂ)) :
-    (star v ⬝ᵥ (hA.1.cfc f *ᵥ v)).re ≤ f ((star v ⬝ᵥ (A *ᵥ v)).re) := by
-  -- Apply convex Jensen to `-f` and unpack via `IsHermitian.cfc_neg`.
-  have hnegf : ConvexOn ℝ (Set.Ici (0 : ℝ)) (fun x => -f x) := hf.neg
-  have hconv := diagonal_jensen_of_convexOn (f := fun x => -f x) hnegf hA hv
-  rw [IsHermitian.cfc_neg hA.1 f] at hconv
-  -- `(star v ⬝ᵥ (-X) *ᵥ v).re = -(star v ⬝ᵥ X *ᵥ v).re`
-  have hnegmul : ∀ X : Matrix n n ℂ,
-      (star v ⬝ᵥ ((-X) *ᵥ v)).re = -(star v ⬝ᵥ X *ᵥ v).re := by
-    intro X
-    rw [Matrix.neg_mulVec, dotProduct_neg, Complex.neg_re]
-  rw [hnegmul] at hconv
-  linarith
-
 end Matrix
 
 namespace TNLean

--- a/TNLean/Channel/Schwarz/AndoLieb.lean
+++ b/TNLean/Channel/Schwarz/AndoLieb.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Axioms.OperatorConvexity
 import TNLean.Analysis.OperatorConvexity
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
@@ -10,10 +9,10 @@ import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
 import Mathlib.LinearAlgebra.Matrix.Trace
 
 /-!
-# Ando--Lieb theorem and trace convexity/concavity
+# Trace convexity and concavity consequences
 
-This file states the Ando--Lieb (Lieb concavity) theorem and its trace
-convexity/concavity consequences for matrix power functions.
+This file restates trace convexity/concavity consequences for matrix power
+functions in the Schwarz chapter namespace.
 
 ## Main results
 
@@ -21,25 +20,16 @@ convexity/concavity consequences for matrix power functions.
   matrices for `p ∈ [0, 1]`.
 * `trace_rpow_convex` — `A ↦ Re Tr(A ^ p)` is convex on PSD
   matrices for `p ∈ [1, 2]`.
-* `lieb_concavity` — For `s ∈ [0, 1]` and fixed `K`, the map
-  `(A, B) ↦ Tr(K† A^s K B^{1−s})` is jointly concave on PD matrices.
-
 ### Status
 
 * `trace_rpow_concave`, `trace_rpow_convex` are proved in
   `TNLean.Analysis.OperatorConvexity` using the spectral theorem and the
   scalar Jensen inequality. This file restates them in the present file,
   for downstream use.
-* `lieb_concavity` is still derived from `lieb_concavity_axiom` in
-  `TNLean.Axioms.OperatorConvexity`, pending the integral-representation
-  infrastructure in Mathlib.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Ch. 5]
-* [T. Ando, *Concavity of certain maps on positive definite matrices*, 1979]
-* [E. H. Lieb, *Convex trace functions and the Wigner--Yanase--Dyson
-  conjecture*, 1973]
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -99,28 +89,5 @@ theorem trace_rpow_convex
     (trace ((t • A₁ + (1 - t) • A₂) ^ p)).re ≤
       t * (trace (A₁ ^ p)).re + (1 - t) * (trace (A₂ ^ p)).re :=
   TNLean.trace_rpow_convex hp hA₁ hA₂ ht
-
-/-! ## Lieb concavity theorem -/
-
-/-- **Lieb concavity theorem** (Ando--Lieb).
-
-For `s ∈ [0, 1]`, any matrix `K`, and PD matrices `A₁, A₂, B₁, B₂`:
-  `t · Re Tr(K† A₁^s K B₁^{1−s}) + (1 − t) · Re Tr(K† A₂^s K B₂^{1−s}) ≤
-     Re Tr(K† (t A₁ + (1−t) A₂)^s K (t B₁ + (1−t) B₂)^{1−s})`.
-
-This is equivalent to joint concavity of `(A, B) ↦ Tr(K† A^s K B^{1−s})`.
-
-Proved from `lieb_concavity_axiom` in `TNLean.Axioms.OperatorConvexity`. -/
-theorem lieb_concavity
-    {s : ℝ} (hs : s ∈ Set.Icc (0 : ℝ) 1)
-    {A₁ A₂ B₁ B₂ K : Mat}
-    (hA₁ : A₁.PosDef) (hA₂ : A₂.PosDef)
-    (hB₁ : B₁.PosDef) (hB₂ : B₂.PosDef)
-    {t : ℝ} (ht : t ∈ Set.Icc (0 : ℝ) 1) :
-    t * (trace (Kᴴ * A₁ ^ s * K * B₁ ^ (1 - s))).re +
-      (1 - t) * (trace (Kᴴ * A₂ ^ s * K * B₂ ^ (1 - s))).re ≤
-    (trace (Kᴴ * (t • A₁ + (1 - t) • A₂) ^ s * K *
-      (t • B₁ + (1 - t) • B₂) ^ (1 - s))).re :=
-  lieb_concavity_axiom hs hA₁ hA₂ hB₁ hB₂ ht
 
 end

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -15,7 +15,7 @@ For an `N`-site operator `ρ`, a commuting-form witness consists of a positive
 semidefinite two-site matrix `B`, together with proofs that its translated
 copies on the periodic chain pairwise commute and that their product
 reproduces `ρ` up to a positive scalar. This is the projector-limit version of
-Definition 4.8 (GSNNCH). The actual entropy-side derivation
+the GSNNCH definition, source label `defrhoNComm`. The actual entropy-side derivation
 `SAL ⟹ HasCommutingForm` is not yet formalized here; it is isolated as the
 upstream missing theorem recorded in the accompanying audit for issue #782.
 
@@ -33,7 +33,7 @@ upstream missing theorem recorded in the accompanying audit for issue #782.
 
 ## References
 
-* [CPGSV17] arXiv:1606.00608, Definition 4.8 and Appendix C.2 Proposition C.6
+* [CPGSV17] arXiv:1606.00608, source labels `defrhoNComm` and `propsimple`
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -77,7 +77,7 @@ noncomputable def embedLocalOperator (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
   classical
   rfl
 
-/-- Chain-level commuting-form data for Proposition C.6.
+/-- Chain-level commuting-form data for source label `propsimple`.
 
 The current record stores the translation-invariant two-site factor `B` together
 with chain-level commutativity of its translated copies. The intended
@@ -142,11 +142,11 @@ def HasCommutingForm (M : MPOTensor d D) : Prop :=
 /-- A GSNNCH witness at chain length `N`: a commuting-form datum together with
 its positive normalization constant.
 
-This records Definition 4.8 in the equivalent positive-operator form
+This records source label `defrhoNComm` in the equivalent positive-operator form
 `ρ⁽ᴺ⁾ = c ∏ᵢ B_{i,i+1}`, where `c > 0` and the translated bond operators
 commute pairwise. The paper's exponential form is recovered by taking
 `B_{i,i+1} = e^{-h_{i,i+1}}` or, more generally, by the projector-limit
-convention explained immediately after Definition 4.8. -/
+convention explained immediately after `defrhoNComm`. -/
 structure GSNNCHData (d N : ℕ) where
   /-- The underlying commuting-form data. -/
   form : CommutingFormData d N
@@ -176,7 +176,7 @@ def IsGSNNCHAt {d N : ℕ} (ρ : ChainOperator d N) : Prop :=
   ∃ data : GSNNCHData d N, ρ = data.state
 
 /-- Global GSNNCH predicate for an MPO tensor: every chain length `N ≥ 2`
-produces a GSNNCH operator in the sense of Definition 4.8. -/
+produces a GSNNCH operator in the sense of source label `defrhoNComm`. -/
 def IsGSNNCH (M : MPOTensor d D) : Prop :=
   ∀ N : ℕ, 2 ≤ N → IsGSNNCHAt (mpo M N)
 
@@ -231,8 +231,8 @@ theorem isGSNNCH_iff_hasCommutingForm (M : MPOTensor d D) :
   · exact hasCommutingForm_of_isGSNNCH
   · exact isGSNNCH_of_hasCommutingForm
 
-/-- The GSNNCH branch of Theorem 4.9, bundled together with MPO zero
-correlation length. -/
+/-- The GSNNCH-with-zero-correlation-length branch of the simple-MPDO
+equivalence, matching source label `thm:main-simple`. -/
 def IsGSNNCHWithZCL (M : MPOTensor d D) : Prop :=
   IsGSNNCH M ∧ IsZCL M
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -893,8 +893,8 @@ Theorem~\ref{thm:mpdo_reconstruct_blocked_coefficients} reconstructs it.
     if every finite-chain operator admits the equivalent positive-operator
     presentation $\rho^{(N)} = c \prod_i B_{i,i+1}$ with $c > 0$ and
     commuting nearest-neighbor factors. The projector-limit convention after
-    Definition~4.8 of \cite{Cirac2017MPDO_AnnPhys} identifies this with the
-    exponential Gibbs form.
+    source label \texttt{defrhoNComm} in \cite{Cirac2017MPDO_AnnPhys}
+    identifies this with the exponential Gibbs form.
 \end{definition}
 
 \begin{theorem}[GSNNCH iff commuting form]
@@ -917,7 +917,8 @@ witness, and every GSNNCH witness remembers its underlying commuting-form data.
     \leanok
     \uses{def:mpdo_is_gsnnch, def:mpo_is_zcl}
     This is the conjunction of the GSNNCH condition with MPO zero correlation
-    length, i.e. the content of item~(iii) in the simple-MPDO theorem.
+    length, matching item~(iii) of the simple-MPDO equivalence in
+    \cite{Cirac2017MPDO_AnnPhys} (source label \texttt{thm:main-simple}).
 \end{definition}
 
 \begin{theorem}[GSNNCH with zero correlation length iff commuting form with zero correlation length]
@@ -934,7 +935,7 @@ Unfold the definition of GSNNCH with zero correlation length and apply
 Theorem~\ref{thm:mpdo_is_gsnnch_iff_has_commuting_form}.
 \end{proof}
 
-\begin{remark}[Remaining step toward Proposition~C.6]
+\begin{remark}[Remaining step toward source label \texttt{propsimple}]
 The remaining entropy-side theorem is to derive the commuting-form property
 from the strong-area-law hypotheses of Appendix~C.2. The present file isolates
 its GSNNCH target once that step is available.

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -967,17 +967,3 @@ logarithm are not developed in this chapter.
     \]
     See Lieb (1973) and Ando (1979).
 \end{theorem}
-
-\begin{theorem}[Map form of Lieb concavity]\label{thm:lieb_concavity}
-    \lean{lieb_concavity}
-    \notready
-    \uses{thm:lieb_concavity_axiom}
-    This is the corresponding map-form statement of
-    Theorem~\ref{thm:lieb_concavity_axiom}.
-    Its proof is deferred until
-    Theorem~\ref{thm:lieb_concavity_axiom} is proved.
-\end{theorem}
-
-\begin{proof}
-    Direct application of the axiom.
-\end{proof}

--- a/docs/counterexamples.md
+++ b/docs/counterexamples.md
@@ -1,0 +1,145 @@
+# Counterexample Registry
+
+This file records checked or audited counterexamples that block tempting
+shortcut lemmas. Add new entries here when an issue or PR discovers a
+mathematical obstruction.
+
+## MPDO and RFP
+
+### PRFP does not imply MPO ZCL
+
+- Location: `TNLean/MPS/MPDO/PRFP.lean`
+- Main declarations: `MPOTensor.exists_isPRFP_not_isZCL`,
+  `MPOTensor.isPRFP_not_implies_isZCL`
+- Statement refuted: the current `MPOTensor.IsPRFP` definition implies
+  `MPOTensor.IsZCL`.
+- Witness: a bond-dimension-`1` LPDO witness with purifying coefficients
+  `3/5` and `4/5`.
+
+### Primitive constant trace powers need not be rank one
+
+- Location: `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`
+- Main declaration: `TNLean.Archive.PerronFrobeniusRankOneCounterexample.counterexample`
+- Statement refuted: a primitive nonnegative matrix whose positive powers have
+  constant trace must have rank one.
+- Relevance: this blocks the standalone rank-one step used in the
+  simple-MPDO Appendix C.2 track of arXiv:1606.00608 unless extra structure is
+  added, such as positivity or diagonalizability hypotheses.
+
+### BiCF does not follow from the other horizontal canonical-form fields
+
+- Location: `TNLean/MPS/MPDO/BiCFDerivation.lean`
+- Statement refuted: blockwise injectivity, left-canonicality, nonzero weights,
+  and pairwise distinct weights imply `MPSTensor.HasBiCF`.
+- Witness: two scalar blocks over one physical letter with weights `1` and `2`;
+  the trace-pairing cancellation cannot isolate the two blocks.
+
+## Block Separation and Canonical Form
+
+### Weighted MPV cancellation does not imply per-block SameMPV
+
+- Location: `TNLean/Archive/BlockSepCounterexample.lean`
+- Main declaration: `MPSTensor.counterexample_block_powsum_separation`
+- Statement refuted: weighted all-length MPV cancellation with distinct nonzero
+  weights and injective blocks implies per-block `SameMPV`.
+- Relevance: block separation needs canonical-form normalization or a stronger
+  selector theorem.
+
+### Whole-tensor SameMPV does not identify equal-norm blocks
+
+- Location: `audits/2026-04-21_issue652_gap1_blocker.md`
+- Statement refuted: total `SameMPV₂` data alone determines same-norm primitive
+  blocks on one side.
+- Witness: two scalar bond-dimension-`1` blocks over two physical letters, with
+  equal weights, whose assembled tensor agrees with itself but whose individual
+  blocks already disagree at length `1`.
+
+### Same assembled MPVs determine gauge phases, not exact block MPVs
+
+- Location: `TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean`
+- Statement refuted: assembled `SameMPV2` forces exact per-block `SameMPV2`.
+- Witness: replace one block by `zeta * (X * A * X^-1)` with `|zeta| = 1` and
+  `zeta != 1`, and compensate the assembly weight by `muB = muA / zeta`.
+- Replacement target: per-block `GaugePhaseEquiv`.
+
+### Equal-norm blocks need not be gauge-phase equivalent
+
+- Location: `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`
+- Statement refuted: equal BNT-level norms plus the full-tensor MPV hypothesis
+  force non-decaying cross-overlaps, hence gauge-phase equivalence.
+- Relevance: issue #299 records the counterexample; the theorem keeps the
+  required non-decay hypothesis explicit.
+
+### Supported compression preserves positive lengths, not length zero
+
+- Location: `TNLean/MPS/CanonicalForm/CyclicSectors/CompressionPositive.lean`
+- Statement refuted: supported-projection compression gives heterogeneous
+  `SameMPV2` at all lengths.
+- Witness: the length-zero coefficient changes from `trace 1 = D` to
+  `trace P`, so only positive-length MPVs are preserved.
+
+### All-zero scalar blocks must be excluded before TP gauging
+
+- Location: `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
+- Statement refuted: the blockwise Perron-Frobenius TP-gauge step has an
+  unconditional arbitrary-input endpoint under the current `SameMPV2`
+  interface.
+- Witness: the all-zero scalar block; the theorem therefore requires a
+  nonzero Kraus operator in each input block.
+
+## Multiplicative Domain
+
+### Corner support does not imply multiplicative-domain membership
+
+- Location: `audits/2026-04-21_issue599_corner_multiplicativeDomain_counterexample.md`
+- Statement refuted: `P * X = X`, `X * P = X`, `T(P) = P`, and
+  `P` in the multiplicative domain force `X` into the multiplicative domain.
+- Witness: the dephasing channel on `M_2(C)` with `P = 1` and `X = E01`.
+- Relevance: the fixed-point-algebra route is needed; corner support alone is
+  insufficient.
+
+## Wielandt and PEPS
+
+### Cumulative spanning does not imply normality without aperiodicity
+
+- Locations: `TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean`,
+  `TNLean/Algebra/BurnsideMatrix.lean`,
+  `blueprint/src/chapter/ch07_wielandt.tex`
+- Statement refuted: cumulative spanning, or algebra generation, implies that a
+  single word length spans the full matrix algebra.
+- Witness: the tensor generated by `e12` and `e21`, whose word spans alternate
+  between diagonal and off-diagonal subspaces.
+
+### Irreducible channels need not be primitive
+
+- Location: `TNLean/QPF/Primitive.lean`
+- Statement refuted: irreducibility of a channel implies primitivity.
+- Witness: an irreducible channel can have period greater than `1`; primitivity
+  is a stronger peripheral-spectrum condition.
+
+### The peripheral eigenvalue set alone does not imply irreducibility
+
+- Location: `TNLean/Channel/Semigroup/Primitivity/MainTheorem.lean`
+- Statement refuted: `peripheralEigenvalues E = {1}` implies irreducibility.
+- Witness: the identity map on `M_2(C)` has peripheral eigenvalue set `{1}` in
+  the current definition but is not irreducible.
+
+### PEPS gauge uniqueness is not global-scalar uniqueness
+
+- Locations: `TNLean/PEPS/FundamentalTheorem.lean`,
+  `blueprint/src/chapter/ch13_algebraic_ft.tex`
+- Statement refuted: two PEPS gauge families differ by one global scalar.
+- Witness: the connected triangle, bond-dimension-`1` counterexample from
+  issue #762.
+- Replacement target: uniqueness modulo balanced edge scalars,
+  `TNLean.PEPS.GaugeEquivModEdgeScalars`.
+
+## Parent Hamiltonian
+
+### Positivity is necessary in the martingale spectral step
+
+- Location: `TNLean/MPS/ParentHamiltonian/Martingale.lean`
+- Statement refuted: the quadratic-form inequality `H^2 >= gamma H` alone gives
+  the norm lower bound on the orthogonal complement of `ker H`.
+- Witness: `H = -Id` satisfies the inequality vacuously for positive `gamma`
+  but fails the desired lower-bound conclusion.


### PR DESCRIPTION
### Motivation

- Remove two zero-use proof wrappers identified in the unused-proof audit (#841): `Matrix.diagonal_jensen_of_concaveOn` and the `lieb_concavity` restatement.
- Switch MPDO simple-theorem prose from bare source theorem numbers to LaTeX/source labels, addressing the style issue raised in #857.
- Add `docs/counterexamples.md` as a registry for audited counterexamples and false shortcut lemmas, per #856.

### Description

- `TNLean/Analysis/OperatorConvexity.lean`: remove `Matrix.diagonal_jensen_of_concaveOn` (zero uses; concave sibling of an existing used lemma).
- `TNLean/Channel/Schwarz/AndoLieb.lean`: remove `lieb_concavity` wrapper around `lieb_concavity_axiom` (zero uses).
- `blueprint/src/chapter/ch05_schwarz.tex`: drop the corresponding stale not-ready blueprint theorem entry.
- `TNLean/MPS/MPDO/CommutingForm.lean`: update doc references from bare source theorem numbers to LaTeX/source labels (`defrhoNComm`, `propsimple`, `thm:main-simple`).
- `blueprint/src/chapter/ch02b_mpdo.tex`: align blueprint prose with updated label conventions.
- `docs/counterexamples.md`: new file registering checked/audited counterexamples and false shortcut lemmas (MPDO/RFP, canonical form, multiplicative domain, etc.).

### Testing

- `lake exe cache get`
- `lake build TNLean.Analysis.OperatorConvexity TNLean.Channel.Schwarz.AndoLieb TNLean.MPS.MPDO.CommutingForm`
- `lake build TNLean`
- `leanblueprint web`
- `leanblueprint checkdecls`

Full build completed with only pre-existing warnings (unrelated `sorry`s and one long line in other modules).

---
Fixes #841.
Fixes #856.
Fixes #857.

> [!NOTE]
> **Low Risk**
> Low risk: this PR mainly deletes unused lemma wrappers and updates prose/documentation, with no changes to core algorithms or data structures.
>
> **Overview**
> Removes two unused proof-wrapper lemmas: `Matrix.diagonal_jensen_of_concaveOn` (in `TNLean/Analysis/OperatorConvexity.lean`) and the `lieb_concavity` restatement (in `TNLean/Channel/Schwarz/AndoLieb.lean`), and drops the corresponding not-ready blueprint theorem in `ch05_schwarz.tex`.
>
> Updates MPDO commuting-form/GSNNCH documentation to reference paper *source labels* (e.g. `defrhoNComm`, `propsimple`, `thm:main-simple`) instead of theorem numbers, aligning Lean comments and `ch02b_mpdo.tex`.
>
> Adds `docs/counterexamples.md` to centralize audited counterexamples that block overly-strong shortcut lemmas (MPDO/RFP, canonical form, multiplicative domain, etc.).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14939490d966df38bc4e50156f3202aad6e7a610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>