### PR TITLE
feat(PEPS/FundamentalTheorem): add edgeGaugeProduct helper, narrow gauge_unique sorry

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -1,5 +1,6 @@
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.LocalGauge
+import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 -- This is a **scaffold** file: the forward direction and contraction algebra
@@ -631,6 +632,31 @@ theorem GaugeEquivModEdgeScalars.gaugeVertex_eq
 
 /-! ### Uniqueness modulo balanced edge scalars -/
 
+/-- If the gauged vertex tensors produced by two gauge families agree pointwise
+at a vertex `v`, then, by linear independence of `A.component v`, the products
+of incident edge-gauge matrix entries coincide for every pair of virtual
+configurations `η, η'`.
+
+This reduces the remaining step in `gauge_unique_mod_edge_scalars` from the
+functional equality of gauged vertex tensors to an equality of scalar products
+of incident edge-gauge entries, which is the proper input to the pending
+tensor-factor uniqueness argument. -/
+private lemma edgeGaugeProduct_eq_of_gaugeVertex_eq
+    (A : Tensor G d) (hA : IsVertexInjective A) (v : V)
+    (X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ)
+    (h : ∀ (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1))
+        (σ : Fin d),
+      gaugeVertex A X v η σ = gaugeVertex A Y v η σ)
+    (η η' : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) :
+    (∏ ie : IncidentEdge G v, edgeGaugeAt A X v ie (η ie) (η' ie)) =
+      ∏ ie : IncidentEdge G v, edgeGaugeAt A Y v ie (η ie) (η' ie) := by
+  refine (hA v).eq_coords_of_eq
+    (f := fun ξ => ∏ ie : IncidentEdge G v, edgeGaugeAt A X v ie (η ie) (ξ ie))
+    (g := fun ξ => ∏ ie : IncidentEdge G v, edgeGaugeAt A Y v ie (η ie) (ξ ie))
+    ?_ η'
+  funext σ
+  simpa [gaugeVertex, Finset.sum_apply, Pi.smul_apply, smul_eq_mul] using h η σ
+
 /-- **Gauge uniqueness modulo balanced edge scalars** (arXiv:1804.04964,
 Theorem 2, uniqueness clause, repaired form).
 
@@ -652,15 +678,29 @@ theorem gauge_unique_mod_edge_scalars (A B : Tensor G d)
       B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
         gaugeVertex A Y v η σ) :
     GaugeEquivModEdgeScalars (G := G) A X Y := by
-  -- TODO: compare `hX` and `hY` vertexwise and use linear independence of
-  -- `A.component v` to extract scalar ratios on each incident edge.
-  -- The remaining missing ingredient is the tensor-factor uniqueness lemma:
-  -- if two products of oriented edge gauges act identically on an injective
-  -- vertex tensor, then the factors differ by nonzero scalars whose product
-  -- is `1` at that vertex. Assembling these local scalar relations into a
-  -- single edge family gives the desired balanced quotient relation.
-  -- This is the repaired uniqueness endpoint for PEPS gauges; the former
-  -- global-scalar statement was false on the triangle counterexample.
+  -- Step 1: combine `hX` and `hY` to obtain vertex-wise equality of the
+  -- gauged tensors `gaugeVertex A X v η σ = gaugeVertex A Y v η σ`.
+  have hGauge : ∀ (v : V)
+      (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
+      gaugeVertex A X v η σ = gaugeVertex A Y v η σ := fun v η σ => by
+    rw [← hX v η σ, hY v η σ]
+  -- Step 2: linear independence of `A.component v` promotes this to equality
+  -- of incident edge-gauge products for every configuration pair `η, η'`.
+  have hProd : ∀ (v : V)
+      (η η' : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)),
+      (∏ ie : IncidentEdge G v, edgeGaugeAt A X v ie (η ie) (η' ie)) =
+        ∏ ie : IncidentEdge G v, edgeGaugeAt A Y v ie (η ie) (η' ie) :=
+    fun v η η' =>
+      edgeGaugeProduct_eq_of_gaugeVertex_eq (G := G) A hA v X Y (hGauge v) η η'
+  -- Remaining step (issue #842): the tensor-factor uniqueness lemma.
+  -- From `hProd v` at each vertex `v`, extract a nonzero scalar `c_v(ie)` on
+  -- each incident edge such that `edgeGaugeAt A X v ie = c_v(ie) • edgeGaugeAt A Y v ie`
+  -- with the oriented product of `c_v(ie)` over incident `ie` at `v` equal to
+  -- `1`, then reconcile `c_u` and `c_w` on every shared edge `e = (u,w)` into a
+  -- single global family `c : (e : Edge G) → Units ℂ` satisfying
+  -- `IsVertexBalanced c`. This is the local scalar-ratio argument of
+  -- arXiv:1804.04964 §3; it is independent of the virtual-insertion / blocking
+  -- machinery tracked in #763.
   sorry
 
 end PEPS

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -682,8 +682,8 @@ theorem gauge_unique_mod_edge_scalars (A B : Tensor G d)
   -- gauged tensors `gaugeVertex A X v η σ = gaugeVertex A Y v η σ`.
   have hGauge : ∀ (v : V)
       (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
-      gaugeVertex A X v η σ = gaugeVertex A Y v η σ := fun v η σ => by
-    rw [← hX v η σ, hY v η σ]
+      gaugeVertex A X v η σ = gaugeVertex A Y v η σ :=
+    fun v η σ => (hX v η σ).symm.trans (hY v η σ)
   -- Step 2: linear independence of `A.component v` promotes this to equality
   -- of incident edge-gauge products for every configuration pair `η, η'`.
   have hProd : ∀ (v : V)


### PR DESCRIPTION
### Motivation

- PR #790 introduced `gauge_unique_mod_edge_scalars` with the correct statement (arXiv:1804.04964 §3 Theorem 2, uniqueness clause) but left the proof as a scaffold `sorry`.
- This PR narrows the remaining `sorry` to the single local tensor-factor uniqueness / scalar-ratio step, making further progress towards closing #842.

### Description

- Modified `TNLean/PEPS/FundamentalTheorem.lean`.
- Added private lemma `edgeGaugeProduct_eq_of_gaugeVertex_eq`: uses `IsVertexInjective` (linear independence via `LinearIndependent.eq_coords_of_eq`) to promote pointwise `gaugeVertex` equality to equality of incident edge-gauge products for every configuration pair.
- Updated `gauge_unique_mod_edge_scalars` to combine `hX`/`hY` into a direct `gaugeVertex` equality and apply the new lemma, reducing the `sorry` to the purely local tensor-factor uniqueness / scalar-ratio argument from arXiv:1804.04964 §3 (also needed for the `D = 1` triangle case from #762).
- No new `sorry`, `admit`, `axiom`, or `native_decide` introduced; existing sorry scope narrowed.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- Commit message confirms: no new proof-integrity blockers introduced.

---
Addresses #842

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to Lean proof scaffolding and add an auxiliary lemma/import, without affecting executable behavior.
>
> **Overview**
> Strengthens the `gauge_unique_mod_edge_scalars` scaffold by adding a private lemma `edgeGaugeProduct_eq_of_gaugeVertex_eq` that uses `IsVertexInjective` (linear independence) to convert pointwise `gaugeVertex` equality into equality of the corresponding products of incident `edgeGaugeAt` entries.
>
> Updates `gauge_unique_mod_edge_scalars` to (1) combine `hX`/`hY` into a direct `gaugeVertex` equality and (2) apply the new lemma to obtain vertex-wise product equalities (`hProd`), leaving only the final tensor-factor uniqueness step as `sorry`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c314e9a35db89c21e4773dcec66dd910e0135c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Lean proof scaffolding (new lemma/import and proof refactor) with no runtime behavior impact; main risk is only potential proof brittleness due to added reliance on `LinearIndependent.eq_coords_of_eq`.
> 
> **Overview**
> Progresses the scaffold proof of `gauge_unique_mod_edge_scalars` by introducing a private lemma `edgeGaugeProduct_eq_of_gaugeVertex_eq` that uses vertex injectivity (linear independence) to turn pointwise equality of `gaugeVertex` into equality of the corresponding products of `edgeGaugeAt` matrix entries.
> 
> Refactors `gauge_unique_mod_edge_scalars` to first combine `hX`/`hY` into a direct `gaugeVertex` equality (`hGauge`), then apply the new lemma to obtain vertex-wise product equalities (`hProd`), leaving only the final local tensor-factor uniqueness / balanced scalar-ratio argument as the remaining `sorry`. Also adds the needed Mathlib import for linear independence basics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cb00989475ef9b53f4e5218ace715601d74161a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->