### PR TITLE
ci(badges): regenerate badge endpoints inside deploy-to-gh-pages.sh

### DIFF
--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -34,6 +34,11 @@ mkdir -p "$WORK_DIR/site/blueprint"
 cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
 cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf" 2>/dev/null || true
 
+# Regenerate badge endpoints so published JSON reflects current sorry/axiom
+# counts and toolchain versions, not the committed (possibly stale) values.
+echo "==> Regenerating badge endpoints..."
+python3 "$REPO_ROOT/scripts/write_badges.py"
+
 # Update homepage (remove all homepage files first, then copy fresh)
 echo "==> Updating homepage..."
 rm -rf "$WORK_DIR/site/_layouts" "$WORK_DIR/site/assets" \

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -34,11 +34,6 @@ mkdir -p "$WORK_DIR/site/blueprint"
 cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
 cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf" 2>/dev/null || true
 
-# Regenerate badge endpoints so published JSON reflects current sorry/axiom
-# counts and toolchain versions, not the committed (possibly stale) values.
-echo "==> Regenerating badge endpoints..."
-python3 "$REPO_ROOT/scripts/write_badges.py"
-
 # Update homepage (remove all homepage files first, then copy fresh)
 echo "==> Updating homepage..."
 rm -rf "$WORK_DIR/site/_layouts" "$WORK_DIR/site/assets" \
@@ -46,6 +41,11 @@ rm -rf "$WORK_DIR/site/_layouts" "$WORK_DIR/site/assets" \
        "$WORK_DIR/site/404.html" "$WORK_DIR/site/Gemfile" \
        "$WORK_DIR/site/badges"
 cp -r "$REPO_ROOT/home_page/"* "$WORK_DIR/site/"
+
+# Regenerate badge endpoints directly into the site so published JSON reflects
+# current sorry/axiom counts and toolchain versions, not committed (stale) values.
+echo "==> Regenerating badge endpoints..."
+python3 "$REPO_ROOT/scripts/write_badges.py" "$WORK_DIR/site/badges"
 
 # Update API docs (only with --with-docs)
 if [ "$WITH_DOCS" = true ]; then

--- a/scripts/write_badges.py
+++ b/scripts/write_badges.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python3
-"""Write Shields.io endpoint JSON files for the project homepage."""
+"""Write Shields.io endpoint JSON files for the project homepage.
+
+Usage:
+  write_badges.py [OUTPUT_DIR]
+
+  OUTPUT_DIR  Directory to write badge JSON files into.
+              Defaults to <repo-root>/home_page/badges.
+"""
 
 from __future__ import annotations
 
 import json
 import re
+import sys
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-BADGE_DIR = ROOT / "home_page" / "badges"
 LEAN_ROOT = ROOT / "TNLean"
 
 
@@ -101,10 +108,10 @@ def mathlib_version() -> str:
     return "unknown"
 
 
-def write_badge(name: str, label: str, message: str, color: str) -> None:
-    BADGE_DIR.mkdir(parents=True, exist_ok=True)
+def write_badge(name: str, label: str, message: str, color: str, badge_dir: Path) -> None:
+    badge_dir.mkdir(parents=True, exist_ok=True)
     payload = {"schemaVersion": 1, "label": label, "message": message, "color": color}
-    (BADGE_DIR / f"{name}.json").write_text(json.dumps(payload, indent=2) + "\n")
+    (badge_dir / f"{name}.json").write_text(json.dumps(payload, indent=2) + "\n")
 
 
 def count_color(count: int, *, warning_at: int = 1) -> str:
@@ -116,12 +123,13 @@ def count_color(count: int, *, warning_at: int = 1) -> str:
 
 
 def main() -> None:
+    badge_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT / "home_page" / "badges"
     sorries = count_token("sorry")
     axioms = count_token("axiom")
-    write_badge("sorries", "sorries", str(sorries), count_color(sorries, warning_at=10))
-    write_badge("axioms", "axioms", str(axioms), count_color(axioms, warning_at=0))
-    write_badge("lean", "Lean", lean_version(), "blue")
-    write_badge("mathlib", "Mathlib", mathlib_version(), "blue")
+    write_badge("sorries", "sorries", str(sorries), count_color(sorries, warning_at=10), badge_dir)
+    write_badge("axioms", "axioms", str(axioms), count_color(axioms, warning_at=0), badge_dir)
+    write_badge("lean", "Lean", lean_version(), "blue", badge_dir)
+    write_badge("mathlib", "Mathlib", mathlib_version(), "blue", badge_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- `scripts/deploy-to-gh-pages.sh` clears and recopies `/badges/` on every run, but `scripts/write_badges.py` was only invoked in the `blueprint.yml` workflow job.
- Any other workflow or manual invocation of `deploy-to-gh-pages.sh` would publish stale committed badge JSON (outdated sorry/axiom counts, version strings) instead of live-computed values.

### Description
- Modified `scripts/deploy-to-gh-pages.sh` to call `python3 scripts/write_badges.py` before the homepage copy step (5 lines added).
- Badge regeneration is now guaranteed regardless of which workflow invokes the deploy script.

### Testing
- Relies on the `gh-pages` deploy CI path to exercise the updated script.
- No Lean source changes; `lean_action_ci.yml` not triggered.

---
Addresses #866

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `gh-pages` deploy pipeline to run a Python badge-generation step, which could fail in CI if dependencies/paths differ. No production runtime code is affected beyond the published static badge JSON.
>
> **Overview**
> Ensures `gh-pages` deployments regenerate the homepage badge endpoint JSON by invoking `scripts/write_badges.py` during `scripts/deploy-to-gh-pages.sh`, so published badge counts/versions match the current repo state rather than potentially stale committed files.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0c3b46e4198f5090f92a055b7c4bf8fcf18a6ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because the gh-pages deploy path now depends on running `python3 scripts/write_badges.py`; CI/manual deploys could fail if Python is missing or paths/permissions differ. No production runtime code changes beyond the generated static `badges/*.json` content.
> 
> **Overview**
> Ensures `gh-pages` deployments publish **fresh badge endpoint JSON** by invoking `scripts/write_badges.py` from `scripts/deploy-to-gh-pages.sh` and writing directly into the checked-out site’s `badges/` directory.
> 
> Updates `scripts/write_badges.py` to accept an optional output directory argument and routes all badge writes through that provided path (defaulting to `home_page/badges`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28570b6f2d860e97488bdaf2f974315841dbe071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->