### PR TITLE
feat(PEPS/Blocking): add three-region vertex-partition splitting lemmas

### DIFF
--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -25,6 +25,10 @@ of a PEPS to a three-partite chain.
   incident edge.
 - `edgeLeftVertices`, `edgeMiddleVertices`, `edgeRightVertices`: the canonical
   three-region partition attached to an edge.
+- `prod_univ_splitAtEdge`: products over the vertex set factor through the
+  three-region partition.
+- `stateCoeff_splitAtEdge`: the PEPS amplitude `stateCoeff` factors the
+  per-vertex tensor contributions through the three-region partition.
 
 ## References
 
@@ -177,6 +181,69 @@ theorem edgeVertices_union (e : Edge G) :
   · by_cases hvRight : v = e.1.2
     · simp [edgeLeftVertices, edgeMiddleVertices, edgeRightVertices, hvRight]
     · simp [edgeLeftVertices, edgeMiddleVertices, edgeRightVertices, hvLeft, hvRight]
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem notMem_edgeMiddleVertices_left (e : Edge G) :
+    e.1.1 ∉ edgeMiddleVertices e := by
+  simp [mem_edgeMiddleVertices_iff]
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem notMem_edgeMiddleVertices_right (e : Edge G) :
+    e.1.2 ∉ edgeMiddleVertices e := by
+  simp [mem_edgeMiddleVertices_iff]
+
+omit [Fintype V] [DecidableRel G.Adj] in
+@[simp] theorem edgeLeftVertices_card (e : Edge G) :
+    (edgeLeftVertices e).card = 1 :=
+  Finset.card_singleton _
+
+omit [Fintype V] [DecidableRel G.Adj] in
+@[simp] theorem edgeRightVertices_card (e : Edge G) :
+    (edgeRightVertices e).card = 1 :=
+  Finset.card_singleton _
+
+omit [DecidableRel G.Adj] in
+theorem edgeMiddleVertices_card (e : Edge G) :
+    (edgeMiddleVertices e).card = Fintype.card V - 2 := by
+  have h1 : e.1.1 ∈ (Finset.univ : Finset V) := Finset.mem_univ _
+  have h2 : e.1.2 ∈ ((Finset.univ : Finset V).erase e.1.1) :=
+    Finset.mem_erase.mpr ⟨(ne_of_lt e.2.1).symm, Finset.mem_univ _⟩
+  change (((Finset.univ : Finset V).erase e.1.1).erase e.1.2).card = Fintype.card V - 2
+  rw [Finset.card_erase_of_mem h2, Finset.card_erase_of_mem h1, Finset.card_univ]
+  omega
+
+omit [DecidableRel G.Adj] in
+/-- Products over the vertex set factor through the three-region partition at
+any edge: the distinguished endpoints appear separately from the middle-region
+product. -/
+theorem prod_univ_splitAtEdge {M : Type*} [CommMonoid M] (e : Edge G) (f : V → M) :
+    ∏ v : V, f v = f e.1.1 * (∏ v ∈ edgeMiddleVertices e, f v) * f e.1.2 := by
+  have h1 : e.1.1 ∈ (Finset.univ : Finset V) := Finset.mem_univ _
+  have h2 : e.1.2 ∈ ((Finset.univ : Finset V).erase e.1.1) :=
+    Finset.mem_erase.mpr ⟨(ne_of_lt e.2.1).symm, Finset.mem_univ _⟩
+  have hstep1 : ∏ v : V, f v =
+      f e.1.1 * ∏ v ∈ (Finset.univ : Finset V).erase e.1.1, f v :=
+    (Finset.mul_prod_erase _ f h1).symm
+  have hstep2 : ∏ v ∈ (Finset.univ : Finset V).erase e.1.1, f v =
+      f e.1.2 * ∏ v ∈ edgeMiddleVertices e, f v :=
+    (Finset.mul_prod_erase _ f h2).symm
+  rw [hstep1, hstep2, mul_comm (f e.1.2) _, ← mul_assoc]
+
+/-- `stateCoeff` evaluates the two endpoint tensors against an independent
+product over the middle region. This isolates the two endpoints of an edge in
+the PEPS amplitude, matching the edge-centred blocking of
+arXiv:1804.04964 §3. -/
+theorem stateCoeff_splitAtEdge (A : Tensor G d) (e : Edge G) (σ : V → Fin d) :
+    stateCoeff A σ =
+      ∑ η : VirtualConfig A,
+        A.component e.1.1 (fun ie => η ie.1) (σ e.1.1) *
+          (∏ v ∈ edgeMiddleVertices e,
+              A.component v (fun ie => η ie.1) (σ v)) *
+          A.component e.1.2 (fun ie => η ie.1) (σ e.1.2) := by
+  unfold stateCoeff
+  refine Finset.sum_congr rfl ?_
+  intro η _
+  exact prod_univ_splitAtEdge e (fun v : V => A.component v (fun ie => η ie.1) (σ v))
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -60,6 +60,10 @@ omit [Fintype V] [DecidableRel G.Adj] in
     (edgeRightIncident (G := G) e).1 = e :=
   rfl
 
+omit [Fintype V] [DecidableRel G.Adj] in
+theorem edgeLeft_ne_edgeRight (e : Edge G) : e.1.1 ≠ e.1.2 :=
+  ne_of_lt e.2.1
+
 /-- The incident edges at `v` other than a chosen distinguished edge. -/
 abbrev OtherIncidentEdge (v : V) (ie : IncidentEdge G v) : Type _ :=
   { je : IncidentEdge G v // je ≠ ie }
@@ -169,8 +173,7 @@ theorem edgeLeftVertices_disjoint_edgeRightVertices (e : Edge G) :
   intro v hvLeft hvRight
   have hv₁ : v = e.1.1 := (mem_edgeLeftVertices e v).mp hvLeft
   have hv₂ : v = e.1.2 := (mem_edgeRightVertices e v).mp hvRight
-  have hne : e.1.1 ≠ e.1.2 := ne_of_lt e.2.1
-  exact hne <| hv₁.symm.trans hv₂
+  exact edgeLeft_ne_edgeRight e <| hv₁.symm.trans hv₂
 
 omit [DecidableRel G.Adj] in
 theorem edgeVertices_union (e : Edge G) :
@@ -203,14 +206,29 @@ omit [Fintype V] [DecidableRel G.Adj] in
   Finset.card_singleton _
 
 omit [DecidableRel G.Adj] in
+private theorem card_erase_erase_univ (a b : V) (hab : a ≠ b) :
+    (((Finset.univ : Finset V).erase a).erase b).card = Fintype.card V - 2 := by
+  have ha : a ∈ (Finset.univ : Finset V) := Finset.mem_univ _
+  have hb : b ∈ ((Finset.univ : Finset V).erase a) :=
+    Finset.mem_erase.mpr ⟨hab.symm, Finset.mem_univ _⟩
+  rw [Finset.card_erase_of_mem hb, Finset.card_erase_of_mem ha, Finset.card_univ]
+  rw [Nat.sub_sub]
+
+omit [DecidableRel G.Adj] in
+private theorem prod_univ_erase_erase {M : Type*} [CommMonoid M]
+    (a b : V) (hab : a ≠ b) (f : V → M) :
+    ∏ v : V, f v = f a * (∏ v ∈ (((Finset.univ : Finset V).erase a).erase b), f v) * f b := by
+  have ha : a ∈ (Finset.univ : Finset V) := Finset.mem_univ _
+  have hb : b ∈ ((Finset.univ : Finset V).erase a) :=
+    Finset.mem_erase.mpr ⟨hab.symm, Finset.mem_univ _⟩
+  rw [(Finset.mul_prod_erase _ f ha).symm, (Finset.mul_prod_erase _ f hb).symm]
+  simp [mul_left_comm, mul_comm]
+
+omit [DecidableRel G.Adj] in
 theorem edgeMiddleVertices_card (e : Edge G) :
     (edgeMiddleVertices e).card = Fintype.card V - 2 := by
-  have h1 : e.1.1 ∈ (Finset.univ : Finset V) := Finset.mem_univ _
-  have h2 : e.1.2 ∈ ((Finset.univ : Finset V).erase e.1.1) :=
-    Finset.mem_erase.mpr ⟨(ne_of_lt e.2.1).symm, Finset.mem_univ _⟩
-  change (((Finset.univ : Finset V).erase e.1.1).erase e.1.2).card = Fintype.card V - 2
-  rw [Finset.card_erase_of_mem h2, Finset.card_erase_of_mem h1, Finset.card_univ]
-  omega
+  simpa [edgeMiddleVertices] using
+    card_erase_erase_univ (V := V) e.1.1 e.1.2 (edgeLeft_ne_edgeRight e)
 
 omit [DecidableRel G.Adj] in
 /-- Products over the vertex set factor through the three-region partition at
@@ -218,16 +236,8 @@ any edge: the distinguished endpoints appear separately from the middle-region
 product. -/
 theorem prod_univ_splitAtEdge {M : Type*} [CommMonoid M] (e : Edge G) (f : V → M) :
     ∏ v : V, f v = f e.1.1 * (∏ v ∈ edgeMiddleVertices e, f v) * f e.1.2 := by
-  have h1 : e.1.1 ∈ (Finset.univ : Finset V) := Finset.mem_univ _
-  have h2 : e.1.2 ∈ ((Finset.univ : Finset V).erase e.1.1) :=
-    Finset.mem_erase.mpr ⟨(ne_of_lt e.2.1).symm, Finset.mem_univ _⟩
-  have hstep1 : ∏ v : V, f v =
-      f e.1.1 * ∏ v ∈ (Finset.univ : Finset V).erase e.1.1, f v :=
-    (Finset.mul_prod_erase _ f h1).symm
-  have hstep2 : ∏ v ∈ (Finset.univ : Finset V).erase e.1.1, f v =
-      f e.1.2 * ∏ v ∈ edgeMiddleVertices e, f v :=
-    (Finset.mul_prod_erase _ f h2).symm
-  rw [hstep1, hstep2, mul_comm (f e.1.2) _, ← mul_assoc]
+  simpa [edgeMiddleVertices] using
+    prod_univ_erase_erase (V := V) e.1.1 e.1.2 (edgeLeft_ne_edgeRight e) f
 
 /-- `stateCoeff` evaluates the two endpoint tensors against an independent
 product over the middle region. This isolates the two endpoints of an edge in

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1593,6 +1593,38 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     Every vertex is either $u$, $v$, or different from both.
 \end{proof}
 
+\begin{theorem}[Product splitting at an edge]%
+    \label{thm:peps_prod_univ_splitAtEdge}
+    \lean{TNLean.PEPS.prod_univ_splitAtEdge}
+    \leanok
+    \uses{def:peps_edgeMiddleVertices, thm:peps_edgeVertices_union}
+    For any edge $e = (u,v)$ and any function $f$ on the vertex set with values
+    in a commutative monoid $M$,
+    \[
+        \prod_{x \in V} f(x) = f(u) \Bigl(\prod_{x \in V \setminus \{u,v\}} f(x)\Bigr) f(v).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Isolate the two distinguished endpoints in the product over $V$ and group
+    the remaining factors into the middle region.
+\end{proof}
+
+\begin{theorem}[PEPS coefficient splitting at an edge]%
+    \label{thm:peps_stateCoeff_splitAtEdge}
+    \lean{TNLean.PEPS.stateCoeff_splitAtEdge}
+    \leanok
+    \uses{def:peps_stateCoeff, def:peps_edgeMiddleVertices,
+        thm:peps_prod_univ_splitAtEdge}
+    For any edge $e = (u,v)$, each summand in the PEPS coefficient factors into
+    the tensor contribution at $u$, the product over the middle region
+    $V \setminus \{u,v\}$, and the tensor contribution at $v$.
+\end{theorem}
+\begin{proof}\leanok
+    Expand \lean{TNLean.PEPS.stateCoeff} and apply
+    \lean{TNLean.PEPS.prod_univ_splitAtEdge} to the per-vertex product inside
+    each summand.
+\end{proof}
+
 \begin{definition}[Sharpened local gauge lift datum]%
     \label{def:peps_hasLocalGaugeLift}
     \lean{TNLean.PEPS.HasLocalGaugeLift}


### PR DESCRIPTION
### Motivation

- The PEPS Fundamental Theorem (arXiv:1804.04964 §3) requires factoring a state amplitude at an edge into left-endpoint, middle-region, and right-endpoint contributions; this preparatory infrastructure enables that reduction.
- Supports the downstream theorems `localGauge_exists`, `gaugeConsistency`, and `stateCoeff`-based steps inside `fundamentalTheorem_PEPS` (see #763).

### Description

- `TNLean/PEPS/Blocking.lean` (67 additions): adds five new lemmas for the three-region vertex partition:
  - `notMem_edgeMiddleVertices_left` / `notMem_edgeMiddleVertices_right`: the two endpoints lie outside the middle region, establishing disjointness with each endpoint singleton.
  - `edgeLeftVertices_card`, `edgeRightVertices_card`, `edgeMiddleVertices_card`: cardinality of each of the three regions (1, 1, and `Fintype.card V - 2`).
  - `prod_univ_splitAtEdge`: products over the full vertex set factor through the three-region partition in any commutative monoid.
  - `stateCoeff_splitAtEdge`: the PEPS amplitude isolates the two endpoint tensors against an independent product over the middle region.
- No new `sorry`/`admit`/`axiom`; existing staged placeholders in `PEPS/FundamentalTheorem.lean` are untouched.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- No new axioms or sorrys introduced (verifiable via `rg -n "sorry|axiom" TNLean/PEPS/Blocking.lean`).

---
Addresses #763

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean theorems/`simp` lemmas without changing existing definitions or computational behavior.
> 
> **Overview**
> Adds supporting lemmas for the edge-based 3-region vertex partition, including new `simp` facts excluding endpoints from `edgeMiddleVertices` and cardinality results for the left/right/middle regions.
> 
> Introduces `prod_univ_splitAtEdge` to rewrite a product over all vertices into endpoint factors times the middle-region product, and `stateCoeff_splitAtEdge` to apply this factoring inside `stateCoeff` to isolate the two endpoint tensor contributions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1da915f1652046bb9689c7d7c9bf1b4d0bcbee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean lemmas and simp facts without changing existing definitions or computational behavior.
> 
> **Overview**
> Adds supporting lemmas in `TNLean/PEPS/Blocking.lean` for the edge-induced three-region vertex partition, including endpoint non-membership/singleton cardinalities and a reusable `prod_univ_splitAtEdge` factorization of `∏ v, f v` into left endpoint, middle region, and right endpoint factors.
> 
> Introduces `stateCoeff_splitAtEdge`, rewriting each `stateCoeff` summand so the two endpoint tensor components are isolated around an independent product over `edgeMiddleVertices`, and updates the blueprint (`ch13_algebraic_ft.tex`) with matching statements and proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9dd3c67b17299311dab62bc2d76bcd066e0a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->