### PR TITLE
feat(MPS/CanonicalForm): add general BNT sector decomposition endpoint

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -67,22 +67,27 @@ The theorem `exists_tp_sector_decomp_after_blocking` below provides:
 The current library already settles the common-period blocking step and the
 primitive / irreducible / normal bridges needed after blocking. The remaining
 Gap §1 content is now more specific:
-- the **general BNT sector construction** for the blocked output is now
-  provided by `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`
-  (`TNLean.MPS.CanonicalForm.EqualNormBridge`), which produces a
-  `SectorDecomposition` with `HasBNTSectorData` from arbitrary TP +
-  primitive + irreducible block families with nonzero weights, no longer
-  restricted to the single-norm-class collapse of `exists_bnt_grouping`;
-- what still remains is the **witness-producing heterogeneous sector
-  comparison theorem** deriving the basis permutation, gauge-phase data, and
-  copy alignment for two such BNT sector decompositions from arbitrary
-  `SameMPV₂`.
+- the **basis-level BNT sector construction** for the blocked output is
+  supplied by
+  `exists_trivialSectorDecomp_with_bntBasisData_of_tp_primitive_irr_blocks`
+  (`TNLean.MPS.CanonicalForm.EqualNormBridge`), which packages arbitrary TP +
+  primitive + irreducible block families with nonzero weights as the granular
+  sector decomposition carrying `HasBNTSectorData`. This supplies the
+  basis-level input consumed by the matched-basis theorem, but is not the
+  paper's full basis-of-normal-tensors construction: distinct basis tensors
+  may still be gauge-phase-equivalent, so the BNT separation axiom is not
+  enforced here. The collapsing step that identifies gauge-phase-equivalent
+  basis tensors is tracked separately; and
+- the **witness-producing heterogeneous sector comparison theorem** deriving
+  the basis permutation, gauge-phase data, and copy alignment for two such
+  sector decompositions from arbitrary `SameMPV₂` is still missing.
 
 The downstream algebraic reduction after a matched basis is formalized by
 `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`,
-and the general sector-level input it expects is now supplied by
-`exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`. The remaining missing
-ingredient is therefore only the witness-producing matched-basis step.
+and the basis-level sector input it expects is now supplied by
+`exists_trivialSectorDecomp_with_bntBasisData_of_tp_primitive_irr_blocks`.
+The remaining missing ingredients are therefore the gauge-phase-equivalent
+collapsing step and the witness-producing matched-basis step.
 -/
 
 section FundamentalTheorem1606
@@ -258,12 +263,15 @@ The complete end-to-end FT should take two tensors `A, B` with `SameMPV₂ A B`
 and pass from the blocked reduction output to the paper's basis-of-normal-tensors
 endpoint. The remaining formalizations are now:
 
-1. **General one-sided BNT construction**: now provided by
-   `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`
-   (`TNLean.MPS.CanonicalForm.EqualNormBridge`), which produces a
-   `SectorDecomposition` carrying `HasBNTSectorData` for arbitrary TP +
-   primitive + irreducible block families with nonzero weights. This is no
-   longer restricted to the single-norm-class case
+1. **Basis-level BNT sector construction**: now provided by
+   `exists_trivialSectorDecomp_with_bntBasisData_of_tp_primitive_irr_blocks`
+   (`TNLean.MPS.CanonicalForm.EqualNormBridge`), which packages arbitrary TP
+   + primitive + irreducible block families with nonzero weights as a
+   granular `SectorDecomposition` carrying `HasBNTSectorData`. This supplies
+   the basis-level input consumed by the matched-basis theorem but does not
+   collapse gauge-phase-equivalent blocks; the collapsing step needed for
+   the paper's basis-of-normal-tensors separation axiom remains, and is
+   currently available only in the single-norm-class special case
    `bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks`.
 
 2. **Witness-producing heterogeneous sector comparison**: the algebraic
@@ -276,14 +284,16 @@ endpoint. The remaining formalizations are now:
    permutation, gauge-phase data, and copy alignment from arbitrary equal total
    MPVs of two sector decompositions.
 
-3. **Final global construction**: once step 2 is available, combine it with the
-   already-formalized common-period blocking, blocked irreducibility,
+3. **Final global construction**: once step 2 and the gauge-phase-equivalent
+   collapsing step are available, combine them with the already-formalized
+   common-period blocking, blocked irreducibility,
    `isNormal_of_tp_primitive_irreducible`, and the global gauge construction of
    the equal-case FT.
 
-So both the common-period blocking step and the general one-sided BNT sector
-construction are in place; the remaining paper-level ingredient is the
-witness-producing matched-basis step.
+So the common-period blocking step and the basis-level BNT sector
+construction are in place; the remaining paper-level ingredients are the
+gauge-phase-equivalent collapsing step and the witness-producing
+matched-basis step.
 -/
 
 end FundamentalTheorem1606

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -67,16 +67,22 @@ The theorem `exists_tp_sector_decomp_after_blocking` below provides:
 The current library already settles the common-period blocking step and the
 primitive / irreducible / normal bridges needed after blocking. The remaining
 Gap §1 content is now more specific:
-- a **general BNT sector construction** for the blocked output, matching the
-  paper's basis-of-normal-tensors decomposition rather than only the restricted
-  norm-class-collapse theorem `exists_bnt_grouping`, and
-- a **witness-producing heterogeneous sector comparison theorem** deriving the
-  basis permutation, gauge-phase data, and copy alignment for two such BNT
-  sector decompositions from arbitrary `SameMPV₂`.
+- the **general BNT sector construction** for the blocked output is now
+  provided by `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`
+  (`TNLean.MPS.CanonicalForm.EqualNormBridge`), which produces a
+  `SectorDecomposition` with `HasBNTSectorData` from arbitrary TP +
+  primitive + irreducible block families with nonzero weights, no longer
+  restricted to the single-norm-class collapse of `exists_bnt_grouping`;
+- what still remains is the **witness-producing heterogeneous sector
+  comparison theorem** deriving the basis permutation, gauge-phase data, and
+  copy alignment for two such BNT sector decompositions from arbitrary
+  `SameMPV₂`.
 
-The downstream algebraic reduction after a matched basis is now formalized by
-`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`, but
-the full witness-producing sector endpoint is still missing.
+The downstream algebraic reduction after a matched basis is formalized by
+`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`,
+and the general sector-level input it expects is now supplied by
+`exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`. The remaining missing
+ingredient is therefore only the witness-producing matched-basis step.
 -/
 
 section FundamentalTheorem1606
@@ -252,14 +258,16 @@ The complete end-to-end FT should take two tensors `A, B` with `SameMPV₂ A B`
 and pass from the blocked reduction output to the paper's basis-of-normal-tensors
 endpoint. The remaining formalizations are now:
 
-1. **General one-sided BNT construction**: starting from the blocked TP-primitive
-   decomposition, construct a sector decomposition in the paper's general BNT
-   sense. This is stronger than the current special-case theorem
-   `exists_bnt_grouping`, which only collapses norm classes already known to
-   represent one MPV family.
+1. **General one-sided BNT construction**: now provided by
+   `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`
+   (`TNLean.MPS.CanonicalForm.EqualNormBridge`), which produces a
+   `SectorDecomposition` carrying `HasBNTSectorData` for arbitrary TP +
+   primitive + irreducible block families with nonzero weights. This is no
+   longer restricted to the single-norm-class case
+   `bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks`.
 
 2. **Witness-producing heterogeneous sector comparison**: the algebraic
-   reduction from a matched basis to per-sector weight multiset equality is now
+   reduction from a matched basis to per-sector weight multiset equality is
    formalized by
    `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`
    (with phase-match core
@@ -268,13 +276,14 @@ endpoint. The remaining formalizations are now:
    permutation, gauge-phase data, and copy alignment from arbitrary equal total
    MPVs of two sector decompositions.
 
-3. **Final global construction**: once steps 1–2 are available, combine them with the
+3. **Final global construction**: once step 2 is available, combine it with the
    already-formalized common-period blocking, blocked irreducibility,
    `isNormal_of_tp_primitive_irreducible`, and the global gauge construction of
    the equal-case FT.
 
-So the common-period blocking step is no longer the blocker; the missing content
-is specifically the paper-level sector endpoint.
+So both the common-period blocking step and the general one-sided BNT sector
+construction are in place; the remaining paper-level ingredient is the
+witness-producing matched-basis step.
 -/
 
 end FundamentalTheorem1606

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -224,23 +224,60 @@ theorem exists_sortedNCF_of_distinct_norms
     dim_pos           := fun k => hDim (e k)
   }⟩
 
-/-! ### §4. Trivial sector decomposition for the sorted distinct-norm case -/
+/-! ### §4. Trivial sector decomposition -/
+
+/-- **Granular `SectorDecomposition` with one basis tensor per block.**
+
+Packages a block family `(μ, blocks)` as a `SectorDecomposition` with `copies j = 1` for
+every `j`: each block becomes its own basis tensor with sector weight `μ j`.  The MPV
+identity between the assembled tensor and `toTensorFromBlocks μ blocks` is provided
+separately by `sameMPV₂_trivialSectorDecomp`. -/
+def trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hμne : ∀ k, μ k ≠ 0) : SectorDecomposition d where
+  basisCount := r
+  basisDim   := dim
+  basis      := blocks
+  sectors    := {
+    copies         := fun _ => 1
+    copies_pos     := fun _ => Nat.one_pos
+    weight         := fun j _ => μ j
+    weight_ne_zero := fun j _ => hμne j
+  }
+
+/-- **MPV identity for `trivialSectorDecomp`.**
+
+The assembled tensor of `trivialSectorDecomp μ blocks hμne` has the same MPV family as
+`toTensorFromBlocks μ blocks`.  The proof expands both sides via
+`mpv_toTensor_eq_sum_coeff` and `mpv_toTensorFromBlocks_eq_sum`, using that
+`coeff N j = (μ j)^N` because `copies j = 1`. -/
+lemma sameMPV₂_trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hμne : ∀ k, μ k ≠ 0) :
+    SameMPV₂ (trivialSectorDecomp μ blocks hμne).toTensor
+      (toTensorFromBlocks (d := d) (μ := μ) blocks) := by
+  intro N σ
+  set P := trivialSectorDecomp μ blocks hμne with hP
+  calc mpv P.toTensor σ
+      = ∑ j : Fin r, P.coeff N j * mpv (P.basis j) σ :=
+          P.mpv_toTensor_eq_sum_coeff σ
+    _ = ∑ j : Fin r, (μ j) ^ N * mpv (blocks j) σ := by
+          refine Finset.sum_congr rfl fun j _ => ?_
+          have hcoeff : P.coeff N j = (μ j) ^ N := by
+            simp [P, trivialSectorDecomp, SectorDecomposition.coeff,
+              SectorWeightData.coeff]
+          rw [hcoeff]
+          rfl
+    _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+          symm
+          simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
 
 /-- **Trivial `SectorDecomposition` from a sorted block family.**
 
-Given a block family `(μ, blocks)` with sorted (strictly decreasing) norms and
-nonzero weights, package it as a `SectorDecomposition` with `copies j = 1` for all
-`j`.  The BNT-level norm ordering condition (§ 4 in the docstring) holds trivially:
-each group has exactly one weight `μ j`, and those are already strictly decreasing.
-
-The assembled `P.toTensor` has `SameMPV₂` with `toTensorFromBlocks μ blocks`, proved
-by expanding both sides via the decomposition formulas:
-
-  `mpv P.toTensor σ = ∑ j, P.coeff N j * mpv (blocks j) σ`
-                    `= ∑ j, (μ j)^N * mpv (blocks j) σ`
-                    `= mpv (toTensorFromBlocks μ blocks) σ`.
-
-Here `P.coeff N j = ∑ q : Fin 1, (μ j)^N = (μ j)^N` because `copies j = 1`. -/
+Specialization of `trivialSectorDecomp` to the sorted distinct-norm case: every block
+becomes its own basis tensor with `copies j = 1`, the assembled tensor has `SameMPV₂`
+with `toTensorFromBlocks μ blocks`, and the BNT-level norm ordering is `StrictAnti`
+because each basis carries exactly one weight `μ j`, already strictly decreasing. -/
 theorem exists_trivialSectorDecomp_of_sorted_distinct_norms
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
@@ -252,40 +289,10 @@ theorem exists_trivialSectorDecomp_of_sorted_distinct_norms
       SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
       StrictAnti (fun j : Fin P.basisCount =>
         ‖P.sectors.weight j ⟨0, P.sectors.copies_pos j⟩‖) := by
-  -- Construct the trivial sector decomposition: one copy per block.
-  let sectors : SectorWeightData r := {
-    copies         := fun _ => 1
-    copies_pos     := fun _ => Nat.one_pos
-    weight         := fun j _ => μ j
-    weight_ne_zero := fun j _ => hμne j
-  }
-  let P : SectorDecomposition d := {
-    basisCount := r
-    basisDim   := dim
-    basis      := blocks
-    sectors    := sectors
-  }
-  refine ⟨P, rfl, ?_, ?_⟩
-  · -- SameMPV₂ P.toTensor (toTensorFromBlocks μ blocks).
-    -- Expand both sides using the sector decomposition and blocks formulas.
-    intro N σ
-    calc mpv P.toTensor σ
-        = ∑ j : Fin r, P.coeff N j * mpv (P.basis j) σ :=
-            P.mpv_toTensor_eq_sum_coeff σ
-      _ = ∑ j : Fin r, (μ j) ^ N * mpv (blocks j) σ := by
-            -- P.coeff N j = ∑ q : Fin (sectors.copies j), (sectors.weight j q)^N
-            --             = ∑ q : Fin 1, (μ j)^N = (μ j)^N.
-            refine Finset.sum_congr rfl fun j _ => congr_arg₂ _ ?_ rfl
-            simp [SectorDecomposition.coeff, SectorWeightData.coeff, P, sectors]
-      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
-            symm
-            simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
-  · -- StrictAnti on BNT-level norms.
-    -- sectors.weight j 0 = μ j by definition, so the condition is exactly hAnti.
-    intro i j hij
-    change ‖P.sectors.weight j ⟨0, P.sectors.copies_pos j⟩‖ <
-      ‖P.sectors.weight i ⟨0, P.sectors.copies_pos i⟩‖
-    simpa only [P, sectors] using hAnti hij
+  refine ⟨trivialSectorDecomp μ blocks hμne, rfl,
+    sameMPV₂_trivialSectorDecomp μ blocks hμne, ?_⟩
+  intro i j hij
+  simpa [trivialSectorDecomp] using hAnti hij
 
 /-! ### §5. BNT grouping for blocks with possibly equal norms -/
 
@@ -558,23 +565,27 @@ theorem bnt_grouping_single_norm_class
     change ‖ζFn q * μ q‖ = ‖μ k0‖
     rw [norm_mul, hζ_norm q, one_mul, hNorm q]
 
-/-! ### §6. BNT-quality sector data -/
+/-! ### §6. Basis-level BNT sector data -/
 
-/-- Structural BNT-quality properties of a sector decomposition: every basis tensor is
-left-canonical (TP), irreducible, and has a primitive transfer map with positive bond
-dimension.  These are the basis-level conditions shared with `IsNormalCanonicalForm`,
-lifted to the sector-decomposition interface.
+/-- Basis-level BNT data of a sector decomposition: every basis tensor is left-canonical,
+irreducible, and has a primitive transfer map with positive bond dimension.  These are
+the basis-level conditions shared with `IsNormalCanonicalForm`, lifted to the
+sector-decomposition interface.
 
-Sector decompositions carrying `HasBNTSectorData` expose a reusable BNT-level basis for
-downstream consumers such as the heterogeneous sector comparison theorems in
-`TNLean.MPS.FundamentalTheorem.SectorDecomposition` and the final assembly step. -/
+Sector decompositions carrying `HasBNTSectorData` supply the basis-level input needed by
+the heterogeneous sector comparison theorems in
+`TNLean.MPS.FundamentalTheorem.SectorDecomposition` and the final assembly step.  They
+do **not** by themselves enforce the paper-level BNT separation axiom, which further
+requires that distinct basis tensors are not gauge-phase-equivalent (see
+`IsNormalCanonicalFormBNT.blocks_not_equiv`); the collapsing step needed for that is
+tracked separately. -/
 structure HasBNTSectorData {d : ℕ} (P : SectorDecomposition d) : Prop where
   /-- All basis bond dimensions are positive. -/
   basisDim_pos : ∀ j, 0 < P.basisDim j
   /-- Every basis tensor is irreducible. -/
   basis_irreducible : ∀ j, IsIrreducibleTensor (P.basis j)
-  /-- Every basis tensor is left-canonical (TP). -/
-  basis_TP : ∀ j, ∑ i : Fin d, (P.basis j i)ᴴ * P.basis j i = 1
+  /-- Every basis tensor is left-canonical. -/
+  basis_leftCanonical : ∀ j, ∑ i : Fin d, (P.basis j i)ᴴ * P.basis j i = 1
   /-- Every basis tensor has a primitive transfer map. -/
   basis_primitive : ∀ j, _root_.IsPrimitive
     (transferMap (d := d) (D := P.basisDim j) (P.basis j))

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -558,4 +558,25 @@ theorem bnt_grouping_single_norm_class
     change ‖ζFn q * μ q‖ = ‖μ k0‖
     rw [norm_mul, hζ_norm q, one_mul, hNorm q]
 
+/-! ### §6. BNT-quality sector data -/
+
+/-- Structural BNT-quality properties of a sector decomposition: every basis tensor is
+left-canonical (TP), irreducible, and has a primitive transfer map with positive bond
+dimension.  These are the basis-level conditions shared with `IsNormalCanonicalForm`,
+lifted to the sector-decomposition interface.
+
+Sector decompositions carrying `HasBNTSectorData` expose a reusable BNT-level basis for
+downstream consumers such as the heterogeneous sector comparison theorems in
+`TNLean.MPS.FundamentalTheorem.SectorDecomposition` and the final assembly step. -/
+structure HasBNTSectorData {d : ℕ} (P : SectorDecomposition d) : Prop where
+  /-- All basis bond dimensions are positive. -/
+  basisDim_pos : ∀ j, 0 < P.basisDim j
+  /-- Every basis tensor is irreducible. -/
+  basis_irreducible : ∀ j, IsIrreducibleTensor (P.basis j)
+  /-- Every basis tensor is left-canonical (TP). -/
+  basis_TP : ∀ j, ∑ i : Fin d, (P.basis j i)ᴴ * P.basis j i = 1
+  /-- Every basis tensor has a primitive transfer map. -/
+  basis_primitive : ∀ j, _root_.IsPrimitive
+    (transferMap (d := d) (D := P.basisDim j) (P.basis j))
+
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -362,4 +362,71 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
       exact ⟨ζ, hζne, hζ_norm, hmpv⟩
   exact bnt_grouping_single_norm_class μ blocks k0 hμne hNorm hPhase
 
+/-! ### §4. General BNT sector decomposition -/
+
+/-- **General BNT sector decomposition from TP + primitive + irreducible blocks.**
+
+For an arbitrary block family `(μ, blocks)` whose blocks are left-canonical (TP),
+irreducible, and have primitive transfer maps with nonzero weights, this produces a
+`SectorDecomposition P` with:
+
+1. `SameMPV₂ P.toTensor (toTensorFromBlocks μ blocks)`;
+2. `HasBNTSectorData P`: every basis tensor is irreducible, TP, primitive, with positive
+   bond dimension.
+
+Unlike the restricted single-norm-class bridge
+`bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks`, this endpoint does not require
+equal-norm hypotheses or spectral non-decay input.  The construction is the most granular
+sector decomposition: every block is a distinct basis tensor with copy multiplicity 1, so
+`HasBNTSectorData` is inherited directly from the input block hypotheses.
+
+Downstream refinements that collapse gauge-phase-equivalent blocks into shared basis tensors
+(needed for e.g. `StrictAnti` weight-norm ordering) can be applied on top of this output
+via the single-norm-class bridge when the required spectral data is available, and are
+tracked separately in the Gap §1 roadmap.
+
+This is the Layer A endpoint from issue #876: it produces reusable BNT sector data for the
+after-blocking output of the canonical-form reduction, feeding the witness-producing
+heterogeneous sector comparison planned in #860. -/
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P := by
+  let sectors : SectorWeightData r := {
+    copies         := fun _ => 1
+    copies_pos     := fun _ => Nat.one_pos
+    weight         := fun j _ => μ j
+    weight_ne_zero := fun j _ => hμne j
+  }
+  let P : SectorDecomposition d := {
+    basisCount := r
+    basisDim   := dim
+    basis      := blocks
+    sectors    := sectors
+  }
+  refine ⟨P, ?_, ?_⟩
+  · intro N σ
+    calc mpv P.toTensor σ
+        = ∑ j : Fin r, P.coeff N j * mpv (P.basis j) σ :=
+            P.mpv_toTensor_eq_sum_coeff σ
+      _ = ∑ j : Fin r, (μ j) ^ N * mpv (blocks j) σ := by
+            refine Finset.sum_congr rfl fun j _ => congr_arg₂ _ ?_ rfl
+            simp [SectorDecomposition.coeff, SectorWeightData.coeff, P, sectors]
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+            symm
+            simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
+  · exact {
+      basisDim_pos      := fun k => NeZero.pos (dim k)
+      basis_irreducible := hIrr
+      basis_TP          := hTP
+      basis_primitive   := hPrim
+    }
+
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -362,17 +362,18 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
       exact ⟨ζ, hζne, hζ_norm, hmpv⟩
   exact bnt_grouping_single_norm_class μ blocks k0 hμne hNorm hPhase
 
-/-! ### §4. General BNT sector decomposition -/
+/-! ### §4. Trivial sector decomposition with basis-level BNT data -/
 
-/-- **General BNT sector decomposition from TP + primitive + irreducible blocks.**
+/-- **Trivial sector decomposition with basis-level BNT data from TP + primitive +
+irreducible blocks.**
 
-For an arbitrary block family `(μ, blocks)` whose blocks are left-canonical (TP),
-irreducible, and have primitive transfer maps with nonzero weights, this produces a
-`SectorDecomposition P` with:
+For a block family `(μ, blocks)` whose blocks are left-canonical (TP), irreducible, and
+have primitive transfer maps with nonzero weights, this packages them as the granular
+`trivialSectorDecomp μ blocks hμne` (one copy per block) and shows:
 
 1. `SameMPV₂ P.toTensor (toTensorFromBlocks μ blocks)`;
-2. `HasBNTSectorData P`: every basis tensor is irreducible, TP, primitive, with positive
-   bond dimension.
+2. `HasBNTSectorData P`: every basis tensor is irreducible, left-canonical, primitive,
+   with positive bond dimension.
 
 Unlike the restricted single-norm-class bridge
 `bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks`, this endpoint does not require
@@ -380,15 +381,16 @@ equal-norm hypotheses or spectral non-decay input.  The construction is the most
 sector decomposition: every block is a distinct basis tensor with copy multiplicity 1, so
 `HasBNTSectorData` is inherited directly from the input block hypotheses.
 
-Downstream refinements that collapse gauge-phase-equivalent blocks into shared basis tensors
-(needed for e.g. `StrictAnti` weight-norm ordering) can be applied on top of this output
-via the single-norm-class bridge when the required spectral data is available, and are
-tracked separately in the Gap §1 roadmap.
+**Scope note.** The produced decomposition is not the paper's basis-of-normal-tensors
+canonical form: distinct basis tensors may still be gauge-phase-equivalent, so the BNT
+separation axiom (`IsNormalCanonicalFormBNT.blocks_not_equiv`) is not enforced here.
+Collapsing gauge-phase-equivalent blocks into shared basis tensors is a separate step
+(see the Gap §1 roadmap), and can be applied on top of this output via the
+single-norm-class bridge when the required spectral data is available.
 
-This is the Layer A endpoint from issue #876: it produces reusable BNT sector data for the
-after-blocking output of the canonical-form reduction, feeding the witness-producing
-heterogeneous sector comparison planned in #860. -/
-theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
+This is the Layer A endpoint from issue #876: it supplies the basis-level BNT data
+consumed by the witness-producing heterogeneous sector comparison planned in #860. -/
+theorem exists_trivialSectorDecomp_with_bntBasisData_of_tp_primitive_irr_blocks
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -399,34 +401,13 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
     ∃ P : SectorDecomposition d,
       SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
       HasBNTSectorData (d := d) P := by
-  let sectors : SectorWeightData r := {
-    copies         := fun _ => 1
-    copies_pos     := fun _ => Nat.one_pos
-    weight         := fun j _ => μ j
-    weight_ne_zero := fun j _ => hμne j
+  refine ⟨trivialSectorDecomp μ blocks hμne,
+    sameMPV₂_trivialSectorDecomp μ blocks hμne, ?_⟩
+  exact {
+    basisDim_pos        := fun k => NeZero.pos (dim k)
+    basis_irreducible   := hIrr
+    basis_leftCanonical := hTP
+    basis_primitive     := hPrim
   }
-  let P : SectorDecomposition d := {
-    basisCount := r
-    basisDim   := dim
-    basis      := blocks
-    sectors    := sectors
-  }
-  refine ⟨P, ?_, ?_⟩
-  · intro N σ
-    calc mpv P.toTensor σ
-        = ∑ j : Fin r, P.coeff N j * mpv (P.basis j) σ :=
-            P.mpv_toTensor_eq_sum_coeff σ
-      _ = ∑ j : Fin r, (μ j) ^ N * mpv (blocks j) σ := by
-            refine Finset.sum_congr rfl fun j _ => congr_arg₂ _ ?_ rfl
-            simp [SectorDecomposition.coeff, SectorWeightData.coeff, P, sectors]
-      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
-            symm
-            simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
-  · exact {
-      basisDim_pos      := fun k => NeZero.pos (dim k)
-      basis_irreducible := hIrr
-      basis_TP          := hTP
-      basis_primitive   := hPrim
-    }
 
 end MPSTensor

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -503,6 +503,43 @@ single weighted block.
 	the same multiset equality.
 \end{proof}
 
+\begin{definition}[BNT-quality sector data]%
+\label{def:has_bnt_sector_data}
+	\lean{MPSTensor.HasBNTSectorData}
+	\leanok
+	\uses{def:paper_sector_data}
+	A sector decomposition $P$ has \emph{BNT-quality sector data} when each
+	basis tensor is left-canonical (TP), irreducible, has a primitive
+	transfer map, and positive auxiliary dimension.  These are the
+	basis-level conditions shared with the normal canonical form, lifted to
+	the sector-decomposition interface; they are sufficient for calling the
+	heterogeneous sector comparison theorems after supplying basis matching
+	and gauge-phase data.
+\end{definition}
+
+\begin{theorem}[General BNT sector decomposition from TP + primitive + irreducible blocks]%
+\label{thm:exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks}
+	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks}
+	\leanok
+	\uses{def:has_bnt_sector_data, def:paper_sector_data}
+	Let $(\mu_k, A_k)_{k=1}^{r}$ be a block family with positive auxiliary
+	dimensions, where each block is left-canonical (TP), irreducible, has a
+	primitive transfer map, and carries a nonzero weight.  Then there exists
+	a sector decomposition $P$ with total MPV family equal to
+	$\sum_k \mu_k^N V^{(N)}(A_k)$ at every system size and basis indexed so
+	that $P$ has BNT-quality sector data.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:paper_decomp_formula}
+	Take $P$ with basis tensors $(A_k)_{k=1}^{r}$, basis dimension $d_k$,
+	single copy per basis, and sector weight $\mu_k$.  The MPV expansion
+	formula from Theorem~\ref{thm:paper_decomp_formula} gives the claimed
+	total MPV identity, and the BNT-quality sector data is inherited
+	directly from the hypotheses on the input blocks.
+\end{proof}
+
 \begin{remark}[Remaining step in the unconditional equal-case theorem]\notready
 	This chapter provides three complementary equal-case results:
 	\begin{enumerate}
@@ -518,25 +555,20 @@ single weighted block.
 		      recovers the sector weight multisets without requiring
 		      explicit coefficient convergence hypotheses.
 	\end{enumerate}
-	What is still missing for the unconditional equal-case theorem
+	The general basis-of-normal-tensors sector construction for the
+	after-blocking output is now formalized by
+	Theorem~\ref{thm:exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks}
+	without the single-norm-class restriction; what is still missing for
+	the unconditional equal-case theorem
 	(Theorem~\ref{thm:ft_equal}, \cite[Corollary~IV.5]{Cirac2021Matrix}) is
-	not merely a final gauge-construction step.  Two paper-level ingredients
-	remain to be formalized:
-	\begin{enumerate}
-		\item a general basis-of-normal-tensors construction for the
-		      after-blocking output, beyond the current special case where
-		      equal-modulus blocks on one side are already known to collapse
-		      to a single basis tensor; and
-		\item a witness-producing matched-basis theorem for heterogeneous
-		      sector decompositions: the algebraic reduction after a basis
-		      matching is now formalized in
-		      Theorems~\ref{thm:route_b_hetero_phase_match}
-		      and~\ref{thm:route_b_hetero_matched_basis}, but one still needs
-		      a theorem that derives the permutation, multiplicity matching,
-		      and gauge-phase data directly from equality of the total MPV
-		      families.
-	\end{enumerate}
-	Once these two ingredients are in place, the final global gauge matrix
-	of Corollary~IV.5 is obtained by the same phase-absorption and blockwise
-	composition argument already formalized in the strict single-weight setting.
+	a witness-producing matched-basis theorem for heterogeneous sector
+	decompositions: the algebraic reduction after a basis matching is now
+	formalized in Theorems~\ref{thm:route_b_hetero_phase_match}
+	and~\ref{thm:route_b_hetero_matched_basis}, but one still needs a
+	theorem that derives the permutation, multiplicity matching, and
+	gauge-phase data directly from equality of the total MPV families.
+	Once this ingredient is in place, the final global gauge matrix of
+	Corollary~IV.5 is obtained by the same phase-absorption and blockwise
+	composition argument already formalized in the strict single-weight
+	setting.
 \end{remark}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -503,31 +503,34 @@ single weighted block.
 	the same multiset equality.
 \end{proof}
 
-\begin{definition}[BNT-quality sector data]%
+\begin{definition}[Basis-level BNT sector data]%
 \label{def:has_bnt_sector_data}
 	\lean{MPSTensor.HasBNTSectorData}
 	\leanok
 	\uses{def:paper_sector_data}
-	A sector decomposition $P$ has \emph{BNT-quality sector data} when each
-	basis tensor is left-canonical (TP), irreducible, has a primitive
-	transfer map, and positive auxiliary dimension.  These are the
-	basis-level conditions shared with the normal canonical form, lifted to
-	the sector-decomposition interface; they are sufficient for calling the
+	A sector decomposition $P$ has \emph{basis-level BNT data} when each
+	basis tensor is left-canonical, irreducible, has a primitive transfer
+	map, and positive auxiliary dimension.  These are the basis-level
+	conditions shared with the normal canonical form, lifted to the
+	sector-decomposition interface; they are sufficient for calling the
 	heterogeneous sector comparison theorems after supplying basis matching
-	and gauge-phase data.
+	and gauge-phase data, but do not by themselves enforce the BNT
+	separation axiom of the basis-of-normal-tensors canonical form.
 \end{definition}
 
-\begin{theorem}[General BNT sector decomposition from TP + primitive + irreducible blocks]%
-\label{thm:exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks}
-	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks}
+\begin{theorem}[Trivial sector decomposition with basis-level BNT data from TP + primitive + irreducible blocks]%
+\label{thm:exists_trivialSectorDecomp_with_bntBasisData_of_tp_primitive_irr_blocks}
+	\lean{MPSTensor.exists_trivialSectorDecomp_with_bntBasisData_of_tp_primitive_irr_blocks}
 	\leanok
 	\uses{def:has_bnt_sector_data, def:paper_sector_data}
 	Let $(\mu_k, A_k)_{k=1}^{r}$ be a block family with positive auxiliary
-	dimensions, where each block is left-canonical (TP), irreducible, has a
-	primitive transfer map, and carries a nonzero weight.  Then there exists
-	a sector decomposition $P$ with total MPV family equal to
-	$\sum_k \mu_k^N V^{(N)}(A_k)$ at every system size and basis indexed so
-	that $P$ has BNT-quality sector data.
+	dimensions, where each block is left-canonical, irreducible, has a
+	primitive transfer map, and carries a nonzero weight.  Then there
+	exists a sector decomposition $P$ with total MPV family equal to
+	$\sum_k \mu_k^N V^{(N)}(A_k)$ at every system size and basis indexed
+	so that $P$ has basis-level BNT data; concretely, $P$ is the granular
+	decomposition where each block is its own basis tensor with copy
+	multiplicity one.
 \end{theorem}
 
 \begin{proof}
@@ -536,7 +539,7 @@ single weighted block.
 	Take $P$ with basis tensors $(A_k)_{k=1}^{r}$, basis dimension $d_k$,
 	single copy per basis, and sector weight $\mu_k$.  The MPV expansion
 	formula from Theorem~\ref{thm:paper_decomp_formula} gives the claimed
-	total MPV identity, and the BNT-quality sector data is inherited
+	total MPV identity, and the basis-level BNT data are inherited
 	directly from the hypotheses on the input blocks.
 \end{proof}
 
@@ -555,19 +558,23 @@ single weighted block.
 		      recovers the sector weight multisets without requiring
 		      explicit coefficient convergence hypotheses.
 	\end{enumerate}
-	The general basis-of-normal-tensors sector construction for the
-	after-blocking output is now formalized by
-	Theorem~\ref{thm:exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks}
-	without the single-norm-class restriction; what is still missing for
-	the unconditional equal-case theorem
-	(Theorem~\ref{thm:ft_equal}, \cite[Corollary~IV.5]{Cirac2021Matrix}) is
-	a witness-producing matched-basis theorem for heterogeneous sector
-	decompositions: the algebraic reduction after a basis matching is now
-	formalized in Theorems~\ref{thm:route_b_hetero_phase_match}
+	The basis-level BNT sector construction for the after-blocking output
+	is now formalized by
+	Theorem~\ref{thm:exists_trivialSectorDecomp_with_bntBasisData_of_tp_primitive_irr_blocks}
+	without the single-norm-class restriction.  This supplies the
+	basis-level input needed by the matched-basis theorem; the remaining
+	paper-level ingredients for the unconditional equal-case theorem
+	(Theorem~\ref{thm:ft_equal}, \cite[Corollary~IV.5]{Cirac2021Matrix})
+	are (i) a collapse step identifying gauge-phase-equivalent basis
+	tensors (needed for the BNT separation axiom of the
+	basis-of-normal-tensors canonical form), and (ii) a witness-producing
+	matched-basis theorem for heterogeneous sector decompositions: the
+	algebraic reduction after a basis matching is now formalized in
+	Theorems~\ref{thm:route_b_hetero_phase_match}
 	and~\ref{thm:route_b_hetero_matched_basis}, but one still needs a
 	theorem that derives the permutation, multiplicity matching, and
 	gauge-phase data directly from equality of the total MPV families.
-	Once this ingredient is in place, the final global gauge matrix of
+	Once these ingredients are in place, the final global gauge matrix of
 	Corollary~IV.5 is obtained by the same phase-absorption and blockwise
 	composition argument already formalized in the strict single-weight
 	setting.


### PR DESCRIPTION
### Motivation

- Gap §1 of the BNT canonical form assembly is missing a general sector construction that feeds the witness-producing comparison step (tracked in #860).
- The previous endpoint `bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks` was restricted to the single-norm-class case; this PR lifts that restriction.
- Continues the multi-block BNT formalization (parent #652), making the general result available for arbitrary heterogeneous block families.

### Description

- Adds `HasBNTSectorData` predicate on `SectorDecomposition` in `BNTGrouping.lean`, capturing BNT-quality per-basis assumptions (positive bond dimension, TP, irreducible, primitive transfer map).
- Introduces `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` in `EqualNormBridge.lean`: bridges arbitrary TP + primitive + irreducible weighted block families (nonzero weights) to a `SectorDecomposition` that is `SameMPV₂`-equivalent to `toTensorFromBlocks` and carries `HasBNTSectorData`.
- Updates Gap §1 roadmap comments in `Assembly/StructuralTheorem.lean` and blueprint `ch11_assembly.tex` to reflect that the one-sided general BNT sector construction is complete; only the witness-producing matched-basis comparison step remains.

### Testing

- `lake build TNLean.MPS.CanonicalForm.BNTGrouping TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- `rg -n "sorry|axiom" TNLean/MPS/CanonicalForm || true`
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---
Addresses #876

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean definitions/theorems and documentation without changing existing algorithms or runtime behavior.
>
> **Overview**
> Adds a new `HasBNTSectorData` predicate on `SectorDecomposition` to capture the BNT-quality per-basis assumptions (positive bond dimension, TP, irreducible, primitive transfer map).
>
> Introduces `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`, a general bridge from arbitrary TP + primitive + irreducible weighted block families (with nonzero weights) to a `SectorDecomposition` that is `SameMPV₂`-equivalent to `toTensorFromBlocks` and carries `HasBNTSectorData`.
>
> Updates the Gap §1 roadmap comments in `StructuralTheorem.lean` and the blueprint (ch11) to reflect that the one-sided general BNT sector construction is now done, leaving only the witness-producing matched-basis comparison step.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dff83c89215726c2b331836df276ee355774e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean definitions/theorems and refactors one proof without changing existing algorithms; main risk is proof/typing regressions in downstream formalization dependencies.
> 
> **Overview**
> Adds a **basis-level BNT sector decomposition endpoint** for arbitrary TP + irreducible + primitive block families with nonzero weights via `exists_trivialSectorDecomp_with_bntBasisData_of_tp_primitive_irr_blocks`, producing a granular `SectorDecomposition` plus `SameMPV₂` equivalence and new `HasBNTSectorData` evidence.
> 
> Refactors `BNTGrouping.lean` by extracting `trivialSectorDecomp` and `sameMPV₂_trivialSectorDecomp`, then reuses them to simplify `exists_trivialSectorDecomp_of_sorted_distinct_norms`. Updates the Gap §1 roadmap comments and blueprint text to reflect that the remaining work is now the gauge-phase-equivalent collapsing step and the witness-producing matched-basis theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3df1df5200e914cc54fd17e02d85828ebdd7b5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->