### PR TITLE
feat(MPS/FundamentalTheorem): add SectorBasisMatching bundled witness

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -76,8 +76,8 @@ Gap §1 content is now more specific:
 
 The downstream algebraic reduction after a matched basis is now formalized by
 `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`, and
-the matching data itself is packaged by the `SectorBasisMatching` witness type
-consumed by
+the matching data itself is recorded by the `SectorBasisMatching` witness type
+used in
 `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching`. The
 remaining step is to construct such a `SectorBasisMatching` from arbitrary
 `SameMPV₂` sector decompositions (fed by the general BNT sector construction
@@ -174,16 +174,16 @@ theorem bilateral_commonPeriod_blocking_tp_primitive_normal
 
 /-- **Fundamental Theorem of MPS (1606.00608, after blocking): current structural shell.**
 
-For any two MPS tensors `A, B` with `SameMPV₂ A B`, this theorem packages the
+For any two MPS tensors `A, B` with `SameMPV₂ A B`, this theorem records the
 currently formalized one-sided reduction output on both sides: after blocking,
 each tensor admits a decomposition into TP blocks with primitive transfer maps,
 nonzero weights, and positive bond dimensions.
 
 The theorem does **not yet** use `SameMPV₂ A B` to compare the two blocked
-outputs. The remaining missing content is the sector-level endpoint described in
-the file documentation below: a general BNT sector construction for each side,
-followed by a heterogeneous equal-case comparison theorem for those sector
-decompositions.
+outputs. The remaining missing content is the sector-level comparison
+described in the file documentation below: a general BNT sector construction
+for each side, followed by a heterogeneous equal-case comparison theorem for
+those sector decompositions.
 
 This theorem therefore records the structural shell currently available on the
 way to arXiv:1606.00608, Theorem 1. -/
@@ -219,7 +219,7 @@ theorem fundamentalTheorem_after_blocking_1606_structural
 
 /-- A strengthened after-blocking structural interface that keeps the blocked `SameMPV₂`
 relations at the reduction periods. This is a small but genuine step toward Gap §1 because the
-common-equality input is no longer discarded by the public structural wrapper. -/
+common-equality input is no longer discarded by the public structural theorem. -/
 theorem fundamentalTheorem_after_blocking_1606_structural_with_blockedSameMPV₂
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -255,7 +255,7 @@ theorem fundamentalTheorem_after_blocking_1606_structural_with_blockedSameMPV₂
 
 The complete end-to-end FT should take two tensors `A, B` with `SameMPV₂ A B`
 and pass from the blocked reduction output to the paper's basis-of-normal-tensors
-endpoint. The remaining formalizations are now:
+sector comparison. The remaining formalizations are now:
 
 1. **General one-sided BNT construction**: starting from the blocked TP-primitive
    decomposition, construct a sector decomposition in the paper's general BNT
@@ -283,7 +283,7 @@ endpoint. The remaining formalizations are now:
    the equal-case FT.
 
 So the common-period blocking step is no longer the blocker; the missing content
-is specifically the paper-level sector endpoint.
+is specifically the paper-level sector comparison theorem.
 -/
 
 end FundamentalTheorem1606

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -75,8 +75,13 @@ Gap §1 content is now more specific:
   sector decompositions from arbitrary `SameMPV₂`.
 
 The downstream algebraic reduction after a matched basis is now formalized by
-`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`, but
-the full witness-producing sector endpoint is still missing.
+`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`, and
+the matching data itself is packaged by the `SectorBasisMatching` witness type
+consumed by
+`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching`. The
+remaining step is to construct such a `SectorBasisMatching` from arbitrary
+`SameMPV₂` sector decompositions (fed by the general BNT sector construction
+tracked separately).
 -/
 
 section FundamentalTheorem1606
@@ -259,14 +264,18 @@ endpoint. The remaining formalizations are now:
    represent one MPV family.
 
 2. **Witness-producing heterogeneous sector comparison**: the algebraic
-   reduction from a matched basis to per-sector weight multiset equality is now
+   reduction from a matched basis to per-sector weight multiset equality is
    formalized by
    `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`
    (with phase-match core
-   `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch`).
-   What is still missing is the theorem that derives the needed basis
-   permutation, gauge-phase data, and copy alignment from arbitrary equal total
-   MPVs of two sector decompositions.
+   `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch`), and
+   the matching data is bundled by the `SectorBasisMatching` witness type
+   exposed through
+   `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching`.
+   What is still missing is the theorem that constructs such a
+   `SectorBasisMatching` — deriving the basis permutation, gauge-phase data,
+   and copy alignment — from arbitrary equal total MPVs of two sector
+   decompositions.
 
 3. **Final global construction**: once steps 1–2 are available, combine them with the
    already-formalized common-period blocking, blocked irreducibility,

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -114,9 +114,9 @@ theorem weight_multiset_eq_of_copies_eq_of_coeff_eq
 
 /-! ### Extrapolation of power sum sequences
 
-The bridge between "eventually equal coefficients" (for `N > N₀`) and "all positive `k` equal
-coefficients" rests on a **telescoping induction** on linear combinations of geometric
-sequences.
+The connection between "eventually equal coefficients" (for `N > N₀`) and
+"equal coefficients for every positive `k`" rests on a **telescoping induction**
+on linear combinations of geometric sequences.
 
 **Key lemma** (`geom_sum_eventually_zero`): a finite linear combination
 `N ↦ ∑ᵢ cᵢ · wᵢᴺ` with all bases `wᵢ ≠ 0` that vanishes for all `N ≥ M` vanishes
@@ -340,9 +340,9 @@ matching copy counts, and per-basis MPV relations
 `SameMPV₂`, then after absorbing the phases `ζ_j` into the sector weights on the `Q` side,
 the per-basis sector weight multisets agree.
 
-This is the algebraic core of the heterogeneous BNT-sector endpoint: once a future theorem
-supplies the basis matching and the phase factors, the remaining comparison is exactly the
-shared-basis theorem above. -/
+This is the algebraic core of the heterogeneous BNT-sector comparison: once a
+future theorem supplies the basis matching and the phase factors, the remaining
+comparison is exactly the shared-basis theorem above. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
     (P Q : SectorDecomposition d)
     (perm : Fin P.basisCount ≃ Fin Q.basisCount)
@@ -432,9 +432,9 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
 
 /-- **Cast-compatible MPV scaling implies the phase-matched heterogeneous sector comparison.**
 
-This intermediate wrapper isolates the weaker data actually consumed by the
-phase-absorption argument: after matching basis dimensions, each block pair only needs a nonzero
-phase `ζ` relating the MPVs of the matched basis tensors. -/
+This intermediate theorem isolates the weaker data actually consumed by the
+phase-absorption argument: after matching basis dimensions, each block pair
+only needs a nonzero phase `ζ` relating the MPVs of the matched basis tensors. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis
     (P Q : SectorDecomposition d)
     (perm : Fin P.basisCount ≃ Fin Q.basisCount)
@@ -468,11 +468,13 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_mat
 
 /-- **Gauge-phase matched sector bases imply the phase-matched heterogeneous sector comparison.**
 
-This packages the MPV scaling relation obtained from blockwise `GaugePhaseEquiv` and feeds it
-into `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis`.
-Thus the remaining missing ingredients for the full heterogeneous BNT-sector endpoint are not
-the algebraic phase-absorption step below, but the derivation of the basis/copy matching data
-from arbitrary `SameMPV₂` sector decompositions. -/
+This theorem records the MPV scaling relation obtained from blockwise
+`GaugePhaseEquiv` and applies
+`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis`.
+Thus the remaining missing ingredients for the full heterogeneous BNT-sector
+comparison are not the algebraic phase-absorption step below, but the
+derivation of the basis/copy matching data from arbitrary `SameMPV₂` sector
+decompositions. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
     (P Q : SectorDecomposition d)
     (perm : Fin P.basisCount ≃ Fin Q.basisCount)

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -506,4 +506,106 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
   exact fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis
     P Q perm hCopies hScaling hLI hEqual
 
+/-! ## Witness bundle for the heterogeneous sector comparison
+
+The matched-basis endpoints above consume the matching data as a loose bag of
+hypotheses (permutation, copy alignment, per-block dimension equality, and
+per-block gauge-phase equivalence). The `SectorBasisMatching` structure
+bundles these into a single witness so that any future theorem producing the
+matching from `SameMPV₂` — the remaining step for the unconditional equal-case
+Fundamental Theorem, fed by the general basis-of-normal-tensors construction —
+can be slotted in as a single argument, and so that downstream consumers
+(e.g. the final global Corollary IV.5 construction) depend only on this type.
+-/
+
+/-- Bundled witness data matching two sector decompositions block-by-block.
+
+This packages the four pieces of data consumed by
+`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`:
+
+* a basis permutation,
+* per-block multiplicity agreement,
+* per-block bond-dimension equality, and
+* per-block gauge-phase equivalence of the (dimension-transported) basis blocks.
+
+Producing a `SectorBasisMatching P Q` from an arbitrary `SameMPV₂ P.toTensor
+Q.toTensor` is the remaining combinatorial step in the Gap §1 closure
+(see the remark in `blueprint/src/chapter/ch11_assembly.tex` and
+arXiv:2011.12127 §IV.B–IV.C). Once that extraction is available, the
+algebraic endpoint runs purely through
+`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching`. -/
+structure SectorBasisMatching (P Q : SectorDecomposition d) where
+  /-- Permutation matching basis indices of `P` and `Q`. -/
+  perm : Fin P.basisCount ≃ Fin Q.basisCount
+  /-- Matched basis blocks carry the same multiplicity. -/
+  copies_eq : ∀ j : Fin P.basisCount, P.copies j = Q.copies (perm j)
+  /-- Matched basis blocks share the same bond dimension. -/
+  dim_eq : ∀ j : Fin P.basisCount, P.basisDim j = Q.basisDim (perm j)
+  /-- Matched basis blocks are gauge-phase equivalent after dimension transport. -/
+  basis_equiv : ∀ j : Fin P.basisCount,
+    GaugePhaseEquiv (d := d)
+      (cast (congr_arg (MPSTensor d) (dim_eq j)) (P.basis j))
+      (Q.basis (perm j))
+
+namespace SectorBasisMatching
+
+variable {P Q : SectorDecomposition d}
+
+/-- Repackage the per-block data in the existential form consumed by
+`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`. -/
+lemma basis_match_exists (M : SectorBasisMatching P Q) :
+    ∀ j : Fin P.basisCount,
+      ∃ hdim : P.basisDim j = Q.basisDim (M.perm j),
+        GaugePhaseEquiv (d := d)
+          (cast (congr_arg (MPSTensor d) hdim) (P.basis j))
+          (Q.basis (M.perm j)) :=
+  fun j => ⟨M.dim_eq j, M.basis_equiv j⟩
+
+/-- Build a `SectorBasisMatching` from a bijective index correspondence together with the
+per-block copy / dimension / gauge-phase data.
+
+This is the natural output shape of a general basis-of-normal-tensors matching extractor
+(pending from #876): such an extractor delivers a function `f` on basis indices, a bijectivity
+certificate, and per-index compatibility data. -/
+noncomputable def ofBijective
+    (f : Fin P.basisCount → Fin Q.basisCount)
+    (hf : Function.Bijective f)
+    (hCopies : ∀ j, P.copies j = Q.copies (f j))
+    (hDim : ∀ j, P.basisDim j = Q.basisDim (f j))
+    (hEquiv : ∀ j, GaugePhaseEquiv (d := d)
+      (cast (congr_arg (MPSTensor d) (hDim j)) (P.basis j)) (Q.basis (f j))) :
+    SectorBasisMatching P Q where
+  perm := Equiv.ofBijective f hf
+  copies_eq := fun j => by
+    simpa [Equiv.ofBijective_apply] using hCopies j
+  dim_eq := fun j => by
+    simpa [Equiv.ofBijective_apply] using hDim j
+  basis_equiv := fun j => by
+    simpa [Equiv.ofBijective_apply] using hEquiv j
+
+end SectorBasisMatching
+
+/-- **Heterogeneous sector comparison via a bundled basis matching witness.**
+
+API wrapper that routes a `SectorBasisMatching` directly into the algebraic endpoint
+`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`. Once a future
+theorem extracts a `SectorBasisMatching P Q` from arbitrary `SameMPV₂ P.toTensor Q.toTensor`
+(the remaining combinatorial step fed by the general basis-of-normal-tensors construction
+in #876), this endpoint closes the Gap §1 heterogeneous sector comparison without taking
+the matching data as loose hypotheses. -/
+theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching
+    {P Q : SectorDecomposition d}
+    (M : SectorBasisMatching P Q)
+    (hLI : ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N))
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ ζ : Fin P.basisCount → ℂ,
+      (∀ j, ζ j ≠ 0) ∧
+      ∀ j : Fin P.basisCount,
+        Finset.univ.val.map (P.weight j) =
+          Finset.univ.val.map
+            (fun q => ζ j * Q.weight (M.perm j) (Fin.cast (M.copies_eq j) q)) :=
+  fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
+    P Q M.perm M.copies_eq M.basis_match_exists hLI hEqual
+
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -578,11 +578,15 @@ noncomputable def ofBijective
     SectorBasisMatching P Q where
   perm := Equiv.ofBijective f hf
   copies_eq := fun j => by
-    simpa [Equiv.ofBijective_apply] using hCopies j
+    change P.copies j = Q.copies (f j)
+    exact hCopies j
   dim_eq := fun j => by
-    simpa [Equiv.ofBijective_apply] using hDim j
+    change P.basisDim j = Q.basisDim (f j)
+    exact hDim j
   basis_equiv := fun j => by
-    simpa [Equiv.ofBijective_apply] using hEquiv j
+    change GaugePhaseEquiv (d := d)
+      (cast (congr_arg (MPSTensor d) (hDim j)) (P.basis j)) (Q.basis (f j))
+    exact hEquiv j
 
 end SectorBasisMatching
 

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -508,19 +508,20 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
 
 /-! ## Witness bundle for the heterogeneous sector comparison
 
-The matched-basis endpoints above consume the matching data as a loose bag of
+The matched-basis theorems above consume the matching data as four separate
 hypotheses (permutation, copy alignment, per-block dimension equality, and
 per-block gauge-phase equivalence). The `SectorBasisMatching` structure
-bundles these into a single witness so that any future theorem producing the
+records these as a single witness, so that any future theorem producing the
 matching from `SameMPV₂` — the remaining step for the unconditional equal-case
-Fundamental Theorem, fed by the general basis-of-normal-tensors construction —
-can be slotted in as a single argument, and so that downstream consumers
-(e.g. the final global Corollary IV.5 construction) depend only on this type.
+Fundamental Theorem, following from the general basis-of-normal-tensors
+construction — can be supplied as a single argument, and downstream results
+(such as the final global Corollary IV.5 construction) depend only on this
+structure.
 -/
 
 /-- Bundled witness data matching two sector decompositions block-by-block.
 
-This packages the four pieces of data consumed by
+This structure records the four pieces of data consumed by
 `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`:
 
 * a basis permutation,
@@ -532,7 +533,7 @@ Producing a `SectorBasisMatching P Q` from an arbitrary `SameMPV₂ P.toTensor
 Q.toTensor` is the remaining combinatorial step in the Gap §1 closure
 (see the remark in `blueprint/src/chapter/ch11_assembly.tex` and
 arXiv:2011.12127 §IV.B–IV.C). Once that extraction is available, the
-algebraic endpoint runs purely through
+algebraic reduction runs purely through
 `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching`. -/
 structure SectorBasisMatching (P Q : SectorDecomposition d) where
   /-- Permutation matching basis indices of `P` and `Q`. -/
@@ -587,12 +588,12 @@ end SectorBasisMatching
 
 /-- **Heterogeneous sector comparison via a bundled basis matching witness.**
 
-API wrapper that routes a `SectorBasisMatching` directly into the algebraic endpoint
-`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`. Once a future
-theorem extracts a `SectorBasisMatching P Q` from arbitrary `SameMPV₂ P.toTensor Q.toTensor`
-(the remaining combinatorial step fed by the general basis-of-normal-tensors construction
-in #876), this endpoint closes the Gap §1 heterogeneous sector comparison without taking
-the matching data as loose hypotheses. -/
+Corollary of `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`
+obtained by supplying the matching data in bundled form as a `SectorBasisMatching`. Once a
+future theorem constructs a `SectorBasisMatching P Q` from arbitrary `SameMPV₂ P.toTensor
+Q.toTensor` (the remaining combinatorial step, following from the general
+basis-of-normal-tensors construction in #876), this result completes the Gap §1
+heterogeneous sector comparison with the matching data gathered into a single argument. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching
     {P Q : SectorDecomposition d}
     (M : SectorBasisMatching P Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -552,7 +552,7 @@ namespace SectorBasisMatching
 
 variable {P Q : SectorDecomposition d}
 
-/-- Repackage the per-block data in the existential form consumed by
+/-- Reformulate the per-block data in the existential form consumed by
 `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`. -/
 lemma basis_match_exists (M : SectorBasisMatching P Q) :
     ∀ j : Fin P.basisCount,

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -474,6 +474,46 @@ single weighted block.
 	Theorem~\ref{thm:route_b_hetero_phase_match}.
 \end{proof}
 
+\begin{definition}[Sector basis matching witness]%
+\label{def:sector_basis_matching}
+	\lean{MPSTensor.SectorBasisMatching}
+	\leanok
+	\uses{def:paper_sector_data, def:gauge_phase_equiv}
+	A \emph{sector basis matching} between two sector decompositions $P$ and $Q$
+	is a bundle of
+	\begin{enumerate}
+		\item a basis permutation $\pi : \{1,\dots,g_P\} \to \{1,\dots,g_Q\}$,
+		\item per-block multiplicity equalities $r_j^P = r_{\pi(j)}^Q$,
+		\item per-block bond-dimension equalities $D_j^P = D_{\pi(j)}^Q$, and
+		\item per-block gauge-phase equivalences $P_j \simeq_{\mathrm{gp}} Q_{\pi(j)}$
+		      after transporting $P_j$ across the bond-dimension equality.
+	\end{enumerate}
+	The hypotheses consumed by
+	Theorem~\ref{thm:route_b_hetero_matched_basis} are exactly the fields of
+	this bundle.
+\end{definition}
+
+\begin{theorem}[Heterogeneous sector comparison via a bundled matching witness]%
+\label{thm:route_b_hetero_sector_matching}
+	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching}
+	\leanok
+	\uses{def:sector_basis_matching, thm:route_b_hetero_matched_basis}
+	Given two sector decompositions $P$ and $Q$, a sector basis matching
+	(Definition~\ref{def:sector_basis_matching}) between them, eventual
+	linear independence of the basis MPV states of $P$, and equality of the
+	total MPV families of $P$ and $Q$, one obtains nonzero phases $(\zeta_j)_j$
+	such that for each $j$ the sector weight multiset of $P_j$ equals the
+	multiset obtained from that of $Q_{\pi(j)}$ by multiplication by~$\zeta_j$.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:route_b_hetero_matched_basis}
+	The bundled matching witness repackages exactly the permutation, copy, and
+	gauge-phase hypotheses of Theorem~\ref{thm:route_b_hetero_matched_basis},
+	so the conclusion follows directly from that theorem.
+\end{proof}
+
 \begin{theorem}[Cast-compatible MPV scaling implies phase-matched sector comparison]%
 \label{thm:route_b_hetero_mpv_scaling}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis}
@@ -529,11 +569,12 @@ single weighted block.
 		      to a single basis tensor; and
 		\item a witness-producing matched-basis theorem for heterogeneous
 		      sector decompositions: the algebraic reduction after a basis
-		      matching is now formalized in
-		      Theorems~\ref{thm:route_b_hetero_phase_match}
-		      and~\ref{thm:route_b_hetero_matched_basis}, but one still needs
-		      a theorem that derives the permutation, multiplicity matching,
-		      and gauge-phase data directly from equality of the total MPV
+		      matching is formalized in
+		      Theorems~\ref{thm:route_b_hetero_phase_match},~\ref{thm:route_b_hetero_matched_basis},
+		      and~\ref{thm:route_b_hetero_sector_matching} (the bundled-witness
+		      API endpoint consuming Definition~\ref{def:sector_basis_matching}),
+		      but one still needs a theorem that constructs a sector basis
+		      matching witness directly from equality of the total MPV
 		      families.
 	\end{enumerate}
 	Once these two ingredients are in place, the final global gauge matrix

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -482,7 +482,8 @@ single weighted block.
 	A \emph{sector basis matching} between two sector decompositions $P$ and $Q$
 	is a bundle of
 	\begin{enumerate}
-		\item a basis permutation $\pi : \{1,\dots,g_P\} \to \{1,\dots,g_Q\}$,
+		\item a basis permutation (bijection)
+		      $\pi : \{1,\dots,g_P\} \simeq \{1,\dots,g_Q\}$,
 		\item per-block multiplicity equalities $r_j^P = r_{\pi(j)}^Q$,
 		\item per-block bond-dimension equalities $D_j^P = D_{\pi(j)}^Q$, and
 		\item per-block gauge-phase equivalences $P_j \simeq_{\mathrm{gp}} Q_{\pi(j)}$
@@ -571,8 +572,9 @@ single weighted block.
 		      sector decompositions: the algebraic reduction after a basis
 		      matching is formalized in
 		      Theorems~\ref{thm:route_b_hetero_phase_match},~\ref{thm:route_b_hetero_matched_basis},
-		      and~\ref{thm:route_b_hetero_sector_matching} (the bundled-witness
-		      API endpoint consuming Definition~\ref{def:sector_basis_matching}),
+		      and~\ref{thm:route_b_hetero_sector_matching} (the latter
+		      consuming a bundled matching witness,
+		      Definition~\ref{def:sector_basis_matching}),
 		      but one still needs a theorem that constructs a sector basis
 		      matching witness directly from equality of the total MPV
 		      families.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -510,7 +510,7 @@ single weighted block.
 \begin{proof}
 	\leanok
 	\uses{thm:route_b_hetero_matched_basis}
-	The bundled matching witness repackages exactly the permutation, copy, and
+	The bundled matching witness contains exactly the permutation, copy, and
 	gauge-phase hypotheses of Theorem~\ref{thm:route_b_hetero_matched_basis},
 	so the conclusion follows directly from that theorem.
 \end{proof}


### PR DESCRIPTION
### Motivation

- Follow-up from #844, which landed the algebraic endpoint for heterogeneous BNT-sector comparison; the missing piece is a bundled witness type that lets downstream consumers depend on a single matching object rather than separate hypotheses.
- Exposes the remaining Gap §1 combinatorial step (extraction of matching data from arbitrary `SameMPV₂`) as a clean, self-contained interface, coordinating with the BNT matching extractor in #876.

### Description

- `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`: adds `SectorBasisMatching` structure packaging the permutation, copy-count equality, bond-dimension equality, and gauge-phase equivalence; adds `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching` wrapper theorem; adds `SectorBasisMatching.ofBijective` smart constructor.
- `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`: updated documentation to reference the new bundled-witness API.
- `blueprint/src/chapter/ch11_assembly.tex`: added `def:sector_basis_matching` and `thm:route_b_hetero_sector_matching` with `\leanok` tags; updated `\notready` remark to reference the new endpoint.
- Note: combinatorial extraction of a `SectorBasisMatching` from arbitrary `SameMPV₂` (the Gap §1 step) is not attempted here — it depends on #876.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #860

> [!NOTE]
> **Low Risk**
> Adds a new witness structure and thin wrapper theorem without changing existing proof logic; primary risk is minor breakage for downstream code expecting the previous "loose hypotheses" API.
>
> **Overview**
> Introduces `SectorBasisMatching`, a bundled witness type packaging the permutation, copy-count equality, bond-dimension equality, and gauge-phase equivalence needed to compare two heterogeneous `SectorDecomposition`s.
>
> Adds `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching`, a convenience wrapper that feeds a `SectorBasisMatching` into the existing matched-basis endpoint, plus helper constructors/lemmas (`basis_match_exists`, `ofBijective`). Documentation/blueprint text is updated to reflect the new bundled-witness API and clarify that extracting this witness from arbitrary `SameMPV₂` remains the missing Gap §1 step.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217445e676f7fde2c074c83a3e9716229f141e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new witness structure and wrapper theorem without changing existing proof logic; main risk is minor downstream breakage if callers expect the unbundled hypothesis style.
> 
> **Overview**
> Introduces `SectorBasisMatching`, a bundled witness that packages the permutation, copy-count equality, bond-dimension equality, and per-block `GaugePhaseEquiv` needed to compare two heterogeneous `SectorDecomposition`s.
> 
> Adds `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching`, a thin corollary that feeds a `SectorBasisMatching` into the existing matched-basis heterogeneous comparison endpoint, plus helper API (`basis_match_exists`, `ofBijective`) to construct/consume the bundle.
> 
> Updates the after-blocking structural theorem docs and the blueprint to reference the new bundled-witness interface and clarify that extracting this witness from arbitrary `SameMPV₂` remains the remaining Gap §1 step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aca412c92390404a6bf18e2469adb1dbfdb1311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->