### PR TITLE
feat(MPS/MPDO): derive adjoint fixed-point descent from IsRFP_MPDO_via_algebra and document converse blocker

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -55,24 +55,33 @@ steps still require the BNT / coefficient-comparison layer from Appendix C.3--C.
 
 The lemma `adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra` below extracts
 the strongest direct consequence of `IsRFP_MPDO_via_algebra M`: the inclusion
-maps `iota n` force every adjoint fixed point of the blocked transfer map to
-be an adjoint fixed point of the unblocked transfer map, and hence
-`Fix((blockedTransferMap M n).adjoint)` coincides with
-`Fix((transferMap M).adjoint)` for every `n ≥ 1`. This rules out nontrivial
-peripheral eigenvalues of `(transferMap M).adjoint`, but stops short of
-forcing `transferMap M` itself to be idempotent. Ergodic channels with a
-strict spectral gap on the `1`-complement therefore satisfy
-`IsRFP_MPDO_via_algebra M` without being MPDO RFPs: for example,
-`E(X) = ε · X + (1 - ε) · avgDiag(X)` on `M_D(ℂ)` with `0 < ε < 1` has
-peripheral spectrum `{1}` and diagonal fixed-point algebra at every blocking
-size, yet `E ∘ E ≠ E`.
+maps `iota n` force every adjoint fixed point of the blocked transfer map at
+positive blocking size `n` to be an adjoint fixed point of the unblocked
+transfer map, i.e. `Fix((blockedTransferMap M n).adjoint)` is contained in
+`Fix((transferMap M).adjoint)` for every `n ≥ 1`. (The reverse inclusion is
+immediate from `blockedTransferMap_eq_pow` combined with the fact that an
+adjoint fixed point of `transferMap M` is fixed by every power of the
+adjoint.)
+
+This equality already excludes *finite-order* (root-of-unity) peripheral
+eigenvalues of `(transferMap M).adjoint`, because any such eigenvalue would
+produce a blocked adjoint fixed point at some positive `n` that is not fixed
+by the unblocked adjoint. It does *not* exclude unit-modulus eigenvalues of
+irrational phase, and a fortiori it is not enough to force `transferMap M`
+itself to be idempotent. Ergodic channels with a strict spectral gap on the
+`1`-complement therefore satisfy `IsRFP_MPDO_via_algebra M` without being
+MPDO RFPs: on `M_D(ℂ)`, with `0 < ε < 1`, consider
+`E(X) = ε · X + (1 - ε) · Π_diag(X)`, where `Π_diag` is the projection that
+zeroes the off-diagonal entries of `X`. Then `Π_diag ∘ Π_diag = Π_diag`,
+`E` has peripheral spectrum `{1}` and diagonal fixed-point algebra at every
+blocking size, yet `E ∘ E ≠ E`.
 
 Closing the converse algebra-to-fusion implication therefore requires
 strengthening the predicate to the paper's full coefficient formulation -- the
 positive diagonal matrices `χ_{α,β,γ}` from Appendix C.3 and the coefficient
 identity `c^{(L)}_{α,β,γ} = tr(χ_{α,β,γ}^L)` from Appendix C.4. The scalar
-Newton--Girard layer needed for the latter step is already available at
-`TNLean.Algebra.ScalarPowerSumIdentity`.
+Newton--Girard power-sum identity needed for the latter step is already
+available in this formalization.
 
 ## References
 
@@ -425,10 +434,13 @@ through `pow_succ` and applying `LinearMap.adjoint_comp` then extracts
 `(transferMap M).adjoint X = X`.
 
 This is the strongest consequence available from the current
-`IsRFP_MPDO_via_algebra` predicate: it rules out nontrivial peripheral
-eigenvalues of `(transferMap M).adjoint`, but is still not enough to force
-`transferMap M` to be idempotent. See the module docstring for the blocker
-on the converse algebra-to-fusion implication. -/
+`IsRFP_MPDO_via_algebra` predicate: it excludes *finite-order*
+(root-of-unity) peripheral eigenvalues of `(transferMap M).adjoint`, since
+any such eigenvalue would produce a blocked adjoint fixed point that is not
+fixed by the unblocked adjoint. It does not exclude unit-modulus eigenvalues
+of irrational phase, and is therefore not enough to force `transferMap M`
+to be idempotent. See the module docstring for the blocker on the converse
+algebra-to-fusion implication. -/
 theorem adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     {n : ℕ} (hn : 0 < n) {X : Mat}

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -58,10 +58,13 @@ the strongest direct consequence of `IsRFP_MPDO_via_algebra M`: the inclusion
 maps `iota n` force every adjoint fixed point of the blocked transfer map at
 positive blocking size `n` to be an adjoint fixed point of the unblocked
 transfer map, i.e. `Fix((blockedTransferMap M n).adjoint)` is contained in
-`Fix((transferMap M).adjoint)` for every `n ≥ 1`. (The reverse inclusion is
-immediate from `blockedTransferMap_eq_pow` combined with the fact that an
-adjoint fixed point of `transferMap M` is fixed by every power of the
-adjoint.)
+`Fix((transferMap M).adjoint)` for every `n ≥ 1`. The reverse inclusion, proved
+as `adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply`, is a simple
+induction using `blockedTransferMap_eq_pow` and `LinearMap.adjoint_comp`; it
+does not need the algebra-structure data. Together the two lemmas establish
+the fixed-point equality
+`Fix((blockedTransferMap M n).adjoint) = Fix((transferMap M).adjoint)` at every
+positive blocking size `n`.
 
 This equality already excludes *finite-order* (root-of-unity) peripheral
 eigenvalues of `(transferMap M).adjoint`, because any such eigenvalue would
@@ -463,6 +466,29 @@ theorem adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra
     rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, hX]
   rw [hAdj] at hXsucFix
   exact hXsucFix
+
+/-- Reverse inclusion for the adjoint fixed-point comparison: any adjoint fixed
+point of `transferMap M` is an adjoint fixed point of every blocked transfer
+map `blockedTransferMap M n`.
+
+Combined with `adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra`, this
+establishes the fixed-point equality
+`Fix((blockedTransferMap M n).adjoint) = Fix((transferMap M).adjoint)` at every
+positive blocking size `n` under `IsRFP_MPDO_via_algebra`. The proof is a
+simple induction using `blockedTransferMap_eq_pow` and `LinearMap.adjoint_comp`,
+and does not require the algebra-structure data. -/
+theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply
+    {M : MPOTensor d D} (n : ℕ) {X : Mat}
+    (hX : (transferMap M).adjoint X = X) :
+    (blockedTransferMap M n).adjoint X = X := by
+  induction n with
+  | zero =>
+      simp [blockedTransferMap_eq_pow, Module.End.one_eq_id]
+  | succ k ih =>
+      have hPow : blockedTransferMap M (k + 1) =
+          blockedTransferMap M k ∘ₗ transferMap M := by
+        simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
+      rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, ih, hX]
 
 end MPOTensor
 

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -51,6 +51,29 @@ extract the coefficient family `c_{\alpha,\beta,\gamma}^{(L)}` of
 Theorem IV.13(ii), nor prove the converse algebra-to-fusion implication. Those
 steps still require the BNT / coefficient-comparison layer from Appendix C.3--C.4.
 
+### Why the converse algebra-to-fusion implication is blocked
+
+The lemma `adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra` below extracts
+the strongest direct consequence of `IsRFP_MPDO_via_algebra M`: the inclusion
+maps `iota n` force every adjoint fixed point of the blocked transfer map to
+be an adjoint fixed point of the unblocked transfer map, and hence
+`Fix((blockedTransferMap M n).adjoint)` coincides with
+`Fix((transferMap M).adjoint)` for every `n ≥ 1`. This rules out nontrivial
+peripheral eigenvalues of `(transferMap M).adjoint`, but stops short of
+forcing `transferMap M` itself to be idempotent. Ergodic channels with a
+strict spectral gap on the `1`-complement therefore satisfy
+`IsRFP_MPDO_via_algebra M` without being MPDO RFPs: for example,
+`E(X) = ε · X + (1 - ε) · avgDiag(X)` on `M_D(ℂ)` with `0 < ε < 1` has
+peripheral spectrum `{1}` and diagonal fixed-point algebra at every blocking
+size, yet `E ∘ E ≠ E`.
+
+Closing the converse algebra-to-fusion implication therefore requires
+strengthening the predicate to the paper's full coefficient formulation -- the
+positive diagonal matrices `χ_{α,β,γ}` from Appendix C.3 and the coefficient
+identity `c^{(L)}_{α,β,γ} = tr(χ_{α,β,γ}^L)` from Appendix C.4. The scalar
+Newton--Girard layer needed for the latter step is already available at
+`TNLean.Algebra.ScalarPowerSumIdentity`.
+
 ## References
 
 * [CPGSV17] arXiv:1606.00608, §4.5 and Appendix C.3--C.4
@@ -389,6 +412,45 @@ theorem coe_iota_eq_sum_blockedInclusionCoefficients
       (data := data) (n := n + 1) (a := data.blockedInclusionCoefficients n i)
 
 end AlgebraStructureData
+
+/-- The algebra-structure RFP predicate forces every adjoint fixed point of the
+blocked transfer map to be an adjoint fixed point of the unblocked transfer
+map.
+
+Concretely, compatibility at size `n` places `X` in `data.A n`; the inclusion
+`data.iota n` lifts `X` into `data.A (n + 1)`, whence compatibility at size
+`n + 1` yields `(blockedTransferMap M (n + 1)).adjoint X = X`. Rewriting
+`blockedTransferMap M (n + 1) = blockedTransferMap M n ∘ₗ transferMap M`
+through `pow_succ` and applying `LinearMap.adjoint_comp` then extracts
+`(transferMap M).adjoint X = X`.
+
+This is the strongest consequence available from the current
+`IsRFP_MPDO_via_algebra` predicate: it rules out nontrivial peripheral
+eigenvalues of `(transferMap M).adjoint`, but is still not enough to force
+`transferMap M` to be idempotent. See the module docstring for the blocker
+on the converse algebra-to-fusion implication. -/
+theorem adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra
+    {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
+    {n : ℕ} (hn : 0 < n) {X : Mat}
+    (hX : (blockedTransferMap M n).adjoint X = X) :
+    (transferMap M).adjoint X = X := by
+  obtain ⟨data, hCompat⟩ := hAlg
+  have hXn : X ∈ data.A n := (hCompat n hn X).2 hX
+  have hXsuc : X ∈ data.A (n + 1) := by
+    have hι : ((data.iota n ⟨X, hXn⟩ : data.A (n + 1)) : Mat) = X := by
+      simpa using data.iota_apply n ⟨X, hXn⟩
+    rw [← hι]
+    exact (data.iota n ⟨X, hXn⟩).property
+  have hXsucFix : (blockedTransferMap M (n + 1)).adjoint X = X :=
+    (hCompat (n + 1) (Nat.succ_pos n) X).1 hXsuc
+  have hPow : blockedTransferMap M (n + 1) =
+      blockedTransferMap M n ∘ₗ transferMap M := by
+    simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
+  have hAdj : (blockedTransferMap M (n + 1)).adjoint X =
+      (transferMap M).adjoint X := by
+    rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, hX]
+  rw [hAdj] at hXsucFix
+  exact hXsucFix
 
 end MPOTensor
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -882,6 +882,23 @@ $(A \circ B)^{\dagger} = B^{\dagger} \circ A^{\dagger}$ together with the
 hypothesis $E_n^{\dagger} X = X$ extracts $E_1^{\dagger} X = X$.
 \end{proof}
 
+\begin{lemma}[Reverse inclusion of adjoint fixed points]%
+    \label{lem:mpdo_adjoint_fix_reverse}
+    \lean{MPOTensor.adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply}
+    \leanok
+    Every adjoint fixed point of the unblocked transfer map $E_1$ is an
+    adjoint fixed point of every blocked transfer map $E_n$.
+\end{lemma}
+\begin{proof}\leanok
+Induction on $n$ using $E_{n+1} = E_n \circ E_1$ and
+$(A \circ B)^{\dagger} = B^{\dagger} \circ A^{\dagger}$; the base case is
+$E_0 = \mathrm{id}$. This step does not require the algebra-structure data.
+Combined with Theorem~\ref{thm:mpdo_adjoint_fix_descent} this yields the
+fixed-point equality
+$\mathrm{Fix}(E_n^{\dagger}) = \mathrm{Fix}(E_1^{\dagger})$ at every positive
+blocking size under the algebra-structure predicate.
+\end{proof}
+
 \begin{remark}[Converse algebra-to-fusion gap]%
     \label{rem:mpdo_algebra_to_fusion_gap}
     \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion, thm:newton_girard}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -873,37 +873,49 @@ Theorem~\ref{thm:mpdo_reconstruct_blocked_coefficients} reconstructs it.
     transfer map $E_1$.
 \end{theorem}
 \begin{proof}\leanok
-Compatibility at size $n$ places $X$ in $\mathcal{A}_n$; the inclusion map
-$\iota_n$ lifts $X$ into $\mathcal{A}_{n+1}$, so compatibility at size $n + 1$
-yields $E_{n+1}^{\dagger} X = X$. Rewriting
-$E_{n+1} = E_n \circ E_1$ and applying
+Compatibility at size $n$ places $X$ in $\mathcal{A}_n$. The inclusion map
+$\iota_n$ lifts $X$ into $\mathcal{A}_{n+1}$, and since $\iota_n$ is just an
+inclusion it does not change the underlying operator, so we continue to
+denote the lifted element by $X$. Thus compatibility at size $n + 1$ yields
+$E_{n+1}^{\dagger} X = X$. Rewriting $E_{n+1} = E_n \circ E_1$ and applying
 $(A \circ B)^{\dagger} = B^{\dagger} \circ A^{\dagger}$ together with the
 hypothesis $E_n^{\dagger} X = X$ extracts $E_1^{\dagger} X = X$.
 \end{proof}
 
 \begin{remark}[Converse algebra-to-fusion gap]%
     \label{rem:mpdo_algebra_to_fusion_gap}
-    \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion}
+    \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion, thm:newton_girard}
     The converse implication
     $\ref{def:mpdo_rfp_via_algebra} \Rightarrow \ref{def:mpdo_rfp_via_fusion}$
     is not provable against the present predicate. Theorem
     \ref{thm:mpdo_adjoint_fix_descent} already gives the strongest available
-    consequence of the algebra-structure data -- aperiodicity of the adjoint
-    transfer map -- but ergodic quantum channels with a strict spectral gap
-    on the $1$-complement still satisfy the predicate without being RFPs;
-    for instance, on $M_D(\mathbb{C})$ with $0 < \varepsilon < 1$ the channel
-    $E(X) = \varepsilon X + (1 - \varepsilon) \cdot \mathrm{avgDiag}(X)$
-    has peripheral spectrum $\{1\}$ and diagonal fixed-point algebra at
-    every blocking size, yet $E \circ E \neq E$. Closing the converse
-    therefore requires strengthening the predicate to the coefficient
-    formulation of \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}: the
-    positive diagonal matrices $\chi_{\alpha,\beta,\gamma}$ of Appendix~C.3
-    and the coefficient identity
+    consequence of the algebra-structure data -- exclusion of \emph{finite
+    order} (root-of-unity) peripheral eigenvalues of the adjoint transfer
+    map, since any such eigenvalue would produce a new adjoint fixed point
+    at some positive blocking size. This does \emph{not}, however, exclude
+    unit-modulus eigenvalues of irrational phase, nor force idempotence of
+    the transfer map, so ergodic quantum channels with a strict spectral gap
+    on the $1$-complement still satisfy the predicate without being RFPs.
+    For instance, on $M_D(\mathbb{C})$ with $0 < \varepsilon < 1$ take
+    \[
+        E(X)
+            = \varepsilon\, X
+              + (1 - \varepsilon)\, \Pi_{\mathrm{diag}}(X),
+    \]
+    where $\Pi_{\mathrm{diag}}$ is the projection that zeroes the
+    off-diagonal entries of $X$; then $\Pi_{\mathrm{diag}} \circ
+    \Pi_{\mathrm{diag}} = \Pi_{\mathrm{diag}}$, the channel $E$ has
+    peripheral spectrum $\{1\}$ and diagonal fixed-point algebra at every
+    blocking size, yet $E \circ E \neq E$. Closing the converse therefore
+    requires strengthening the predicate to the coefficient formulation of
+    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}: the positive diagonal
+    matrices $\chi_{\alpha,\beta,\gamma}$ of Appendix~C.3 and the
+    coefficient identity
     $c^{(L)}_{\alpha,\beta,\gamma}
       = \mathrm{tr}(\chi_{\alpha,\beta,\gamma}^{L})$
-    of Appendix~C.4. The scalar Newton--Girard layer used in the latter
-    step is already formalised in
-    \texttt{TNLean.Algebra.ScalarPowerSumIdentity}.
+    of Appendix~C.4. The scalar Newton--Girard power-sum identity needed
+    for the latter step is already available as
+    Theorem~\ref{thm:newton_girard}.
 \end{remark}
 
 \section{Commuting form and GSNNCH}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -862,6 +862,50 @@ $E_n$, so the fixed point first becomes an element of $\mathcal{A}_n$ and then
 Theorem~\ref{thm:mpdo_reconstruct_blocked_coefficients} reconstructs it.
 \end{proof}
 
+\begin{theorem}[Adjoint fixed points descend through the algebra tower]%
+    \label{thm:mpdo_adjoint_fix_descent}
+    \lean{MPOTensor.adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra}
+    \leanok
+    \uses{def:mpdo_rfp_via_algebra}
+    If an MPO tensor satisfies the algebra-structure formulation, then every
+    adjoint fixed point of the blocked transfer map $E_n$ at a positive
+    blocking size $n$ is already an adjoint fixed point of the unblocked
+    transfer map $E_1$.
+\end{theorem}
+\begin{proof}\leanok
+Compatibility at size $n$ places $X$ in $\mathcal{A}_n$; the inclusion map
+$\iota_n$ lifts $X$ into $\mathcal{A}_{n+1}$, so compatibility at size $n + 1$
+yields $E_{n+1}^{\dagger} X = X$. Rewriting
+$E_{n+1} = E_n \circ E_1$ and applying
+$(A \circ B)^{\dagger} = B^{\dagger} \circ A^{\dagger}$ together with the
+hypothesis $E_n^{\dagger} X = X$ extracts $E_1^{\dagger} X = X$.
+\end{proof}
+
+\begin{remark}[Converse algebra-to-fusion gap]%
+    \label{rem:mpdo_algebra_to_fusion_gap}
+    \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion}
+    The converse implication
+    $\ref{def:mpdo_rfp_via_algebra} \Rightarrow \ref{def:mpdo_rfp_via_fusion}$
+    is not provable against the present predicate. Theorem
+    \ref{thm:mpdo_adjoint_fix_descent} already gives the strongest available
+    consequence of the algebra-structure data -- aperiodicity of the adjoint
+    transfer map -- but ergodic quantum channels with a strict spectral gap
+    on the $1$-complement still satisfy the predicate without being RFPs;
+    for instance, on $M_D(\mathbb{C})$ with $0 < \varepsilon < 1$ the channel
+    $E(X) = \varepsilon X + (1 - \varepsilon) \cdot \mathrm{avgDiag}(X)$
+    has peripheral spectrum $\{1\}$ and diagonal fixed-point algebra at
+    every blocking size, yet $E \circ E \neq E$. Closing the converse
+    therefore requires strengthening the predicate to the coefficient
+    formulation of \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}: the
+    positive diagonal matrices $\chi_{\alpha,\beta,\gamma}$ of Appendix~C.3
+    and the coefficient identity
+    $c^{(L)}_{\alpha,\beta,\gamma}
+      = \mathrm{tr}(\chi_{\alpha,\beta,\gamma}^{L})$
+    of Appendix~C.4. The scalar Newton--Girard layer used in the latter
+    step is already formalised in
+    \texttt{TNLean.Algebra.ScalarPowerSumIdentity}.
+\end{remark}
+
 \section{Commuting form and GSNNCH}
 
 \begin{definition}[Commuting-form data for an MPDO]


### PR DESCRIPTION
### Motivation
- Addresses the follow-up to PR #814, which proved the forward direction `IsRFP_MPDO_via_fusion → IsRFP_MPDO_via_algebra`.
- The converse direction is needed to close #612 with the full Theorem IV.13 biconditional (arXiv:1606.00608 §4.5).

### Description
- `TNLean/MPS/MPDO/AlgebraStructure.lean`: adds `MPOTensor.adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra`, proving that under `IsRFP_MPDO_via_algebra`, any adjoint fixed point of a blocked transfer map `E_n†` (`n > 0`) is already an adjoint fixed point of the unblocked `E_1†`.
- Documents the converse blocker: the inclusion map `ι_n` forces `Fix((blockedTransferMap M n).adjoint) = Fix((transferMap M).adjoint)`, but this is insufficient to force idempotence of `transferMap M` without the paper's coefficient/BNT layer.
- `blueprint/src/chapter/ch02b_mpdo.tex`: adds §4.5 documentation of this partial result, the blocker, and an ergodic-channel counterexample sketch.

### Testing
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #859

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the PR only adds new Lean theorems and blueprint exposition, without modifying existing definitions or computation-critical code paths.
> 
> **Overview**
> Proves a new descent result `MPOTensor.adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra`: under `IsRFP_MPDO_via_algebra`, any adjoint fixed point of a positive blocked transfer map `blockedTransferMap M n` is already fixed by the unblocked adjoint `(transferMap M).adjoint`.
> 
> Adds the reverse-direction lemma `MPOTensor.adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply` (by induction), so reviewers can derive the **fixed-point equality** `Fix((blockedTransferMap M n).adjoint) = Fix((transferMap M).adjoint)` for all `n ≥ 1`.
> 
> Updates the MPDO blueprint to include these results and explicitly documents the remaining blocker for the converse algebra-to-fusion implication (including an ergodic-channel counterexample sketch and pointer to the missing coefficient/BNT layer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c166814786965ebcfa54f230110e05230069b80d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->