### PR TITLE
feat(MPS/CanonicalForm): add after-blocking sector endpoint for Gap §1

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -245,6 +245,82 @@ theorem fundamentalTheorem_after_blocking_1606_structural_with_blockedSameMPV₂
   · exact sameMPV₂_blockTensor A B hSame pA
   · exact sameMPV₂_blockTensor A B hSame pB
 
+/-- **Conditional after-blocking sector endpoint (issue #877 target shape).**
+
+Given two tensors with `SameMPV₂` and the two missing Gap §1 inputs tracked by
+issues #876 and #860, this theorem produces the target assembly endpoint: a
+common blocking period, a `SectorDecomposition` on each side carrying BNT basis
+data, and matched sector-weight data closing the canonical-form reduction.
+
+The two hypotheses express the missing paper-level inputs:
+
+* `bntSectorPair` supplies a common-period BNT sector decomposition for both
+  sides, `SameMPV₂`-equivalent to the blocked tensors and carrying
+  `HasBNTSectorData`.  This is the endpoint tracked by issue #876 and replaces
+  the current single-norm-class result `bnt_grouping_single_norm_class`.
+* `matchedBasisData` supplies the matched-basis witness (permutation, copy
+  alignment, per-block gauge-phase equivalence) from `SameMPV₂` between two
+  sector decompositions whose first entry has BNT basis data.  This is the
+  endpoint tracked by issue #860.
+
+The body is a kernel-checked composition of the existing structural wrapper's
+blocking compatibility (`sameMPV₂_blockTensor`), the two hypotheses, and the
+matched-basis algebraic endpoint from PR #844
+(`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`).
+
+Once #876 and #860 land on `main`, the unconditional endpoint
+`fundamentalTheorem_after_blocking_1606_sector` of issue #877 is obtained by
+instantiating this theorem with the delivered constructors. -/
+theorem fundamentalTheorem_after_blocking_1606_sector_of_bntPair_matched
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (bntSectorPair :
+      ∃ p : ℕ, 0 < p ∧
+      ∃ P Q : SectorDecomposition (blockPhysDim d p),
+        SameMPV₂ (blockTensor (d := d) (D := D₁) A p) P.toTensor ∧
+        SameMPV₂ (blockTensor (d := d) (D := D₂) B p) Q.toTensor ∧
+        HasBNTSectorData P ∧ HasBNTSectorData Q)
+    (matchedBasisData : ∀ {d' : ℕ} (P Q : SectorDecomposition d'),
+      HasBNTSectorData P → SameMPV₂ P.toTensor Q.toTensor →
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+        (∀ j, P.copies j = Q.copies (perm j)) ∧
+        ∀ j : Fin P.basisCount,
+          ∃ hdim : P.basisDim j = Q.basisDim (perm j),
+            GaugePhaseEquiv (d := d')
+              (cast (congr_arg (MPSTensor d') hdim) (P.basis j))
+              (Q.basis (perm j))) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂ (blockTensor (d := d) (D := D₁) A p) P.toTensor ∧
+      SameMPV₂ (blockTensor (d := d) (D := D₂) B p) Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  obtain ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt⟩ := bntSectorPair
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ
+          = mpv (blockTensor (d := d) (D := D₁) A p) σ := (hPeq N σ).symm
+      _ = mpv (blockTensor (d := d) (D := D₂) B p) σ := hAB N σ
+      _ = mpv Q.toTensor σ := hQeq N σ
+  obtain ⟨perm, hCopies, hBasisGPE⟩ := matchedBasisData P Q hPbnt hPQeq
+  obtain ⟨ζ, hζne, hMultiset⟩ :=
+    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
+      P Q perm hCopies hBasisGPE hPbnt hPQeq
+  exact ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt,
+          perm, hCopies, ζ, hζne, hMultiset⟩
+
 /-!
 ### What remains for the full 1606.00608 Fundamental Theorem
 
@@ -275,6 +351,12 @@ endpoint. The remaining formalizations are now:
 
 So the common-period blocking step is no longer the blocker; the missing content
 is specifically the paper-level sector endpoint.
+
+The conditional theorem
+`fundamentalTheorem_after_blocking_1606_sector_of_bntPair_matched` above gives
+the target assembly shape from issue #877: once the two missing paper-level
+endpoints (issues #876 and #860) land on `main`, the unconditional
+after-blocking sector endpoint is a one-line instantiation of that theorem.
 -/
 
 end FundamentalTheorem1606

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -40,20 +40,21 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- **BNT basis data packaged with a sector decomposition.**
+/-- **Predicate asserting a sector decomposition's basis satisfies the BNT
+linear-independence condition.**
 
-`HasBNTSectorData P` says that the basis of the sector decomposition `P` is a
-basis of normal tensors in the sense of Def. 4.2 of arXiv:2011.12127: for all
+`HasBNTSectorData P` asserts that the basis of the sector decomposition `P` is
+a basis of normal tensors in the sense of Def. 4.2 of arXiv:2011.12127: for all
 sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
-are linearly independent.
+are linearly independent.  It is a `Prop`; no data is bundled.
 
 This is exactly the linear-independence hypothesis consumed by the equal-case
 sector comparison theorems in this file, i.e.
 `fundamentalTheorem_equalMPV_sectorDecomposition` and the heterogeneous variants
 introduced in PR #844.  It is the predicate tracked by issue #876 as the output
 of a general BNT sector construction for the after-blocking canonical-form
-reduction, and is the BNT payload expected by the after-blocking sector
-endpoint of issue #877. -/
+reduction, and is the linear-independence hypothesis expected by the
+after-blocking sector endpoint of issue #877. -/
 def HasBNTSectorData (P : SectorDecomposition d) : Prop :=
   ∃ N0 : ℕ, ∀ N > N0,
     LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N)

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -40,6 +40,24 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+/-- **BNT basis data packaged with a sector decomposition.**
+
+`HasBNTSectorData P` says that the basis of the sector decomposition `P` is a
+basis of normal tensors in the sense of Def. 4.2 of arXiv:2011.12127: for all
+sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
+are linearly independent.
+
+This is exactly the linear-independence hypothesis consumed by the equal-case
+sector comparison theorems in this file, i.e.
+`fundamentalTheorem_equalMPV_sectorDecomposition` and the heterogeneous variants
+introduced in PR #844.  It is the predicate tracked by issue #876 as the output
+of a general BNT sector construction for the after-blocking canonical-form
+reduction, and is the BNT payload expected by the after-blocking sector
+endpoint of issue #877. -/
+def HasBNTSectorData (P : SectorDecomposition d) : Prop :=
+  ∃ N0 : ℕ, ∀ N > N0,
+    LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N)
+
 /-! ## Coefficient comparison from BNT linear independence -/
 
 namespace SectorWeightData


### PR DESCRIPTION
### Motivation

- Closes the assembly gap in Gap §1 of the fundamental theorem reduction: the after-blocking structural theorem currently stops before producing the final sector-decomposition endpoint needed by the multi-block argument (see #877).
- Provides a conditional interface that composes common blocking (`sameMPV₂_blockTensor`) with the BNT sector construction (#876) and matched-basis witness (#860), so downstream work can land incrementally once those dependencies are merged.

### Description

- `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`: adds `HasBNTSectorData`, a reusable predicate capturing the BNT "eventual linear independence" assumption for sector bases.
- `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`: introduces `fundamentalTheorem_after_blocking_1606_sector_of_bntPair_matched`, which conditionally assembles the after-blocking sector endpoint by composing `sameMPV₂_blockTensor`, a hypothesized paired BNT sector decomposition (#876), a hypothesized matched-basis witness (#860), and the #844 heterogeneous comparison result to yield a permutation/copy alignment plus per-sector phase-scaled weight-multiset equality.
- No new `sorry`/`axiom`: the theorem is kernel-checked and reduces to a one-line instantiation once #876 and #860 are merged.
- Blueprint edits deferred until the unconditional Lean endpoint is available (when #876 and #860 land on `main`).

### Testing

- `lake build TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem TNLean.MPS.FundamentalTheorem.SectorDecomposition`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `rg -n "sorry|axiom" TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean || true` — no results

---
Addresses #877

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean propositions/theorems and documentation, without changing existing definitions or algorithms; main risk is proof breakage due to tighter interfaces around `SameMPV₂`/sector decomposition data.
>
> **Overview**
> Adds `HasBNTSectorData` to `SectorDecomposition.lean` as a reusable predicate capturing the BNT "eventual linear independence" assumption for sector bases.
>
> Introduces `fundamentalTheorem_after_blocking_1606_sector_of_bntPair_matched` in `StructuralTheorem.lean`, which *conditionally* assembles the issue #877 after-blocking sector endpoint by composing common blocking (`sameMPV₂_blockTensor`), a hypothesized paired BNT sector decomposition (issue #876), a hypothesized matched-basis witness (issue #860), and the existing heterogeneous comparison result to produce a permutation/copy alignment plus per-sector phase-scaled weight-multiset equality.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c77032b0924f1c1f7f996289f0f97f3c53f7cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean `Prop`/theorem plumbing without changing existing definitions or proof behavior; main risk is downstream breakage from the new `HasBNTSectorData` interface being used by future proofs.
> 
> **Overview**
> Adds `HasBNTSectorData` in `SectorDecomposition.lean` to capture the BNT “eventual linear independence” assumption for sector bases.
> 
> Introduces `fundamentalTheorem_after_blocking_1606_sector_of_bntPair_matched` in `StructuralTheorem.lean`, a **conditional** after-blocking endpoint that composes common blocking (`sameMPV₂_blockTensor`) with assumed BNT sector decompositions and assumed matched-basis data to produce a permutation/copy alignment plus phase-scaled sector-weight multiset equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff05503ef94b9e462046b12b32dd1cff1134497a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->