### PR TITLE
feat(MPS/MPDO): extract χ-matrices and trace-power formula

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -45,13 +45,23 @@ side hypotheses. The `IsRFP` assumption is essential here: without idempotence,
 the adjoint fixed-point algebras of the blocked transfer maps need not stabilize
 with the blocking length.
 
+## Diagonal $\chi$-matrices and the trace-power formula
+
+On top of the blocked-coefficient layer, this file now formalizes the target
+shape of Theorem IV.13(ii): the special diagonal matrices
+$\chi_{\alpha,\beta,\gamma}$ are packaged as a `DiagonalChiFamily`, and the
+identity $c_{\alpha,\beta,\gamma}^{(L)} = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$
+is encoded as the `HasChiTracePowerForm` predicate. The basic trace-power
+identity `tr(χ_{α,β,γ}^L) = \sum_k \chi_{\alpha,\beta,\gamma,k}^L` is proved
+directly from `Matrix.diagonal_pow` and `Matrix.trace_diagonal`.
+
 ## Remaining gap to the paper
 
 The present `CompatibleWith` relation identifies the support algebras with the
 adjoint fixed-point algebras of the blocked transfer maps. It does **not** yet
-extract the coefficient family `c_{\alpha,\beta,\gamma}^{(L)}` of
-Theorem IV.13(ii), nor prove the converse algebra-to-fusion implication. Those
-steps still require the BNT / coefficient-comparison layer from Appendix C.3--C.4.
+construct the specific `DiagonalChiFamily` attached to an RFP MPDO tensor, nor
+prove the converse algebra-to-fusion implication. Those steps still require the
+BNT / coefficient-comparison layer from Appendix C.3--C.4.
 
 ### Why the converse algebra-to-fusion implication is blocked
 
@@ -487,6 +497,88 @@ theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply
           blockedTransferMap M k ∘ₗ transferMap M := by
         simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
       rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, ih, hX]
+
+/-! ### Diagonal $\chi$-matrices and the trace-power formula
+
+The paper arXiv:1606.00608 (CPGSV17), Theorem IV.13(ii) asserts that the
+structure coefficients $c_{\alpha,\beta,\gamma}^{(L)}$ of the blocked MPDO
+support algebra have the form
+$c_{\alpha,\beta,\gamma}^{(L)} = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$
+for a family of diagonal matrices $\chi_{\alpha,\beta,\gamma}$ with positive
+entries. This subsection packages those diagonal matrices as explicit Lean data
+and states the trace-power identity. -/
+
+/-- A family of diagonal matrices `χ_{α,β,γ}` indexed by ordered triples drawn
+from a common index type `I`. The diagonal size `rank α β γ` is allowed to
+depend on the triple, and `entry α β γ` gives the diagonal entries as complex
+numbers.
+
+In the RFP characterization of [CPGSV17, Thm IV.13(ii)] the index type `I`
+collects the BNT labels `α, β, γ`, and every `χ_{α,β,γ}` is a diagonal matrix
+with positive real entries. Positivity is *not* part of this structure: it is
+supplied separately through `PosEntries` so that the bare data can be used in
+intermediate constructions. -/
+structure DiagonalChiFamily (I : Type*) where
+  /-- Size of the diagonal matrix `χ_{α,β,γ}`. -/
+  rank : I → I → I → ℕ
+  /-- Diagonal entries of `χ_{α,β,γ}`, in order. -/
+  entry : ∀ α β γ : I, Fin (rank α β γ) → ℂ
+
+namespace DiagonalChiFamily
+
+variable {I : Type*} (χ : DiagonalChiFamily I)
+
+/-- The underlying diagonal matrix `χ_{α,β,γ}` on the index set `Fin (rank α β γ)`. -/
+noncomputable def matrix (α β γ : I) :
+    Matrix (Fin (χ.rank α β γ)) (Fin (χ.rank α β γ)) ℂ :=
+  Matrix.diagonal (χ.entry α β γ)
+
+/-- The trace-power coefficient `∑_k (χ_{α,β,γ,k})^L`. -/
+noncomputable def tracePowerCoeff (α β γ : I) (L : ℕ) : ℂ :=
+  ∑ k, (χ.entry α β γ k) ^ L
+
+/-- The $L$-th power of `χ_{α,β,γ}` is again diagonal, with entries
+`(χ_{α,β,γ,k})^L`. -/
+theorem matrix_pow (α β γ : I) (L : ℕ) :
+    χ.matrix α β γ ^ L = Matrix.diagonal fun k => (χ.entry α β γ k) ^ L := by
+  simp [matrix, Matrix.diagonal_pow]
+
+/-- Trace-power identity: `tr(χ_{α,β,γ}^L) = ∑_k (χ_{α,β,γ,k})^L`, i.e. the
+trace of the $L$-th matrix power matches `tracePowerCoeff`. -/
+theorem trace_matrix_pow (α β γ : I) (L : ℕ) :
+    (χ.matrix α β γ ^ L).trace = χ.tracePowerCoeff α β γ L := by
+  simp [matrix_pow, Matrix.trace_diagonal, tracePowerCoeff]
+
+/-- Predicate asserting that every entry of `χ_{α,β,γ}` is a positive real
+number, matching the positivity hypothesis of [CPGSV17, Thm IV.13(ii)]. -/
+def PosEntries : Prop :=
+  ∀ α β γ : I, ∀ k : Fin (χ.rank α β γ), 0 < (χ.entry α β γ k).re ∧ (χ.entry α β γ k).im = 0
+
+end DiagonalChiFamily
+
+/-- *Trace-power compatibility* between an abstract structure-coefficient family
+`c L α β γ` and a diagonal `χ` family: for every blocking size `L` and every
+triple `(α, β, γ)`, the structure coefficient `c L α β γ` equals
+`tr(χ_{α,β,γ}^L)`.
+
+This is the Lean-level form of the target identity of
+[CPGSV17, Thm IV.13(ii)] for the blocked MPDO structure coefficients. It is a
+predicate on abstract coefficient data rather than on any specific
+`AlgebraStructureData`, so that it can be reused both for the blocked
+multiplication coefficients of the algebra-side formulation and for the length-`L`
+operator algebra appearing in the paper. -/
+def HasChiTracePowerForm {I : Type*}
+    (c : ℕ → I → I → I → ℂ) (χ : DiagonalChiFamily I) : Prop :=
+  ∀ L : ℕ, ∀ α β γ : I, c L α β γ = χ.tracePowerCoeff α β γ L
+
+/-- Convenience reformulation: under trace-power compatibility, the
+structure coefficient at size `L` equals the trace of the `L`-th matrix power of
+the corresponding `χ`. -/
+theorem HasChiTracePowerForm.eq_trace_matrix_pow {I : Type*}
+    {c : ℕ → I → I → I → ℂ} {χ : DiagonalChiFamily I}
+    (h : HasChiTracePowerForm c χ) (L : ℕ) (α β γ : I) :
+    c L α β γ = (χ.matrix α β γ ^ L).trace := by
+  rw [h L α β γ, χ.trace_matrix_pow]
 
 end MPOTensor
 

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -550,23 +550,31 @@ theorem trace_matrix_pow (α β γ : I) (L : ℕ) :
   simp [matrix_pow, Matrix.trace_diagonal, tracePowerCoeff]
 
 /-- Predicate asserting that every entry of `χ_{α,β,γ}` is a positive real
-number, matching the positivity hypothesis of [CPGSV17, Thm IV.13(ii)]. -/
+number, matching the positivity hypothesis of [CPGSV17, Thm IV.13(ii)].
+Under the scoped `ComplexOrder` instance (opened at the top of the file), a
+strict inequality `0 < z` on `ℂ` is equivalent to `0 < z.re ∧ z.im = 0`. -/
 def PosEntries : Prop :=
-  ∀ α β γ : I, ∀ k : Fin (χ.rank α β γ), 0 < (χ.entry α β γ k).re ∧ (χ.entry α β γ k).im = 0
+  ∀ α β γ : I, ∀ k : Fin (χ.rank α β γ), 0 < χ.entry α β γ k
 
 end DiagonalChiFamily
 
 /-- *Trace-power compatibility* between an abstract structure-coefficient family
 `c L α β γ` and a diagonal `χ` family: for every blocking size `L` and every
-triple `(α, β, γ)`, the structure coefficient `c L α β γ` equals
-`tr(χ_{α,β,γ}^L)`.
+triple `(α, β, γ)`, the structure coefficient `c L α β γ` equals the trace-power
+coefficient `χ.tracePowerCoeff α β γ L = ∑_k (χ_{α,β,γ,k})^L` of `χ`.
+
+The trace-power coefficient is equal to the trace of the `L`-th matrix power
+`tr(χ_{α,β,γ}^L)` via `DiagonalChiFamily.trace_matrix_pow`, but that identity is
+not definitional; the predicate is stated in terms of `tracePowerCoeff` to keep
+the right-hand side a plain finite sum. The trace formulation
+`c L α β γ = (χ.matrix α β γ ^ L).trace` is then available through
+`HasChiTracePowerForm.eq_trace_matrix_pow`.
 
 This is the Lean-level form of the target identity of
 [CPGSV17, Thm IV.13(ii)] for the blocked MPDO structure coefficients. It is a
-predicate on abstract coefficient data rather than on any specific
-`AlgebraStructureData`, so that it can be reused both for the blocked
-multiplication coefficients of the algebra-side formulation and for the length-`L`
-operator algebra appearing in the paper. -/
+*binary* predicate on the pair `(c, χ)` rather than an existential in `χ`, so
+that callers can carry a specific witness `χ` around explicitly; an
+existential version `∃ χ, HasChiTracePowerForm c χ` is available on demand. -/
 def HasChiTracePowerForm {I : Type*}
     (c : ℕ → I → I → I → ℂ) (χ : DiagonalChiFamily I) : Prop :=
   ∀ L : ℕ, ∀ α β γ : I, c L α β γ = χ.tracePowerCoeff α β γ L

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -509,7 +509,7 @@ entries. This subsection packages those diagonal matrices as explicit Lean data
 and states the trace-power identity. -/
 
 /-- A family of diagonal matrices `χ_{α,β,γ}` indexed by ordered triples drawn
-from a common index type `I`. The diagonal size `rank α β γ` is allowed to
+from a common index type `I`. The diagonal size `dim α β γ` is allowed to
 depend on the triple, and `entry α β γ` gives the diagonal entries as complex
 numbers.
 
@@ -519,18 +519,19 @@ with positive real entries. Positivity is *not* part of this structure: it is
 supplied separately through `PosEntries` so that the bare data can be used in
 intermediate constructions. -/
 structure DiagonalChiFamily (I : Type*) where
-  /-- Size of the diagonal matrix `χ_{α,β,γ}`. -/
-  rank : I → I → I → ℕ
+  /-- Size of the diagonal matrix `χ_{α,β,γ}` — the cardinality of its index
+  set `Fin _`, not the linear-algebraic rank. -/
+  dim : I → I → I → ℕ
   /-- Diagonal entries of `χ_{α,β,γ}`, in order. -/
-  entry : ∀ α β γ : I, Fin (rank α β γ) → ℂ
+  entry : ∀ α β γ : I, Fin (dim α β γ) → ℂ
 
 namespace DiagonalChiFamily
 
 variable {I : Type*} (χ : DiagonalChiFamily I)
 
-/-- The underlying diagonal matrix `χ_{α,β,γ}` on the index set `Fin (rank α β γ)`. -/
+/-- The underlying diagonal matrix `χ_{α,β,γ}` on the index set `Fin (dim α β γ)`. -/
 noncomputable def matrix (α β γ : I) :
-    Matrix (Fin (χ.rank α β γ)) (Fin (χ.rank α β γ)) ℂ :=
+    Matrix (Fin (χ.dim α β γ)) (Fin (χ.dim α β γ)) ℂ :=
   Matrix.diagonal (χ.entry α β γ)
 
 /-- The trace-power coefficient `∑_k (χ_{α,β,γ,k})^L`. -/
@@ -554,7 +555,7 @@ number, matching the positivity hypothesis of [CPGSV17, Thm IV.13(ii)].
 Under the scoped `ComplexOrder` instance (opened at the top of the file), a
 strict inequality `0 < z` on `ℂ` is equivalent to `0 < z.re ∧ z.im = 0`. -/
 def PosEntries : Prop :=
-  ∀ α β γ : I, ∀ k : Fin (χ.rank α β γ), 0 < χ.entry α β γ k
+  ∀ α β γ : I, ∀ k : Fin (χ.dim α β γ), 0 < χ.entry α β γ k
 
 end DiagonalChiFamily
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -976,10 +976,12 @@ diagonal matrices.
     \lean{MPOTensor.DiagonalChiFamily.trace_matrix_pow}
     \leanok
     \uses{def:mpdo_diagonal_chi_family}
-    For every triple $(\alpha, \beta, \gamma)$ and every $L \ge 0$,
+    For every triple $(\alpha, \beta, \gamma)$, if $\chi_{\alpha,\beta,\gamma}$
+    has size $r_{\alpha,\beta,\gamma}$, then for every $L \ge 0$,
     \[
         \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr)
-            = \sum_{k} \chi_{\alpha,\beta,\gamma,k}^{L},
+            = \sum_{k=1}^{r_{\alpha,\beta,\gamma}}
+                \chi_{\alpha,\beta,\gamma,k}^{L},
     \]
     where $\chi_{\alpha,\beta,\gamma,k}$ are the diagonal entries.
 \end{theorem}
@@ -993,12 +995,21 @@ is the sum of its entries.
     \lean{MPOTensor.HasChiTracePowerForm}
     \leanok
     \uses{def:mpdo_diagonal_chi_family}
-    An abstract structure-coefficient family $c^{(L)}_{\alpha,\beta,\gamma}$ has
-    \emph{trace-power form} when there is a diagonal $\chi$ family with
-    $c^{(L)}_{\alpha,\beta,\gamma} = \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr)$
-    for every $L$ and every triple $(\alpha, \beta, \gamma)$. This is the
-    Lean-level form of the target identity of
-    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}.
+    A binary compatibility predicate between an abstract structure-coefficient
+    family $c^{(L)}_{\alpha,\beta,\gamma}$ and a diagonal $\chi$ family: the
+    pair $(c, \chi)$ is said to be in \emph{trace-power form} when
+    \[
+        c^{(L)}_{\alpha,\beta,\gamma}
+            = \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr)
+            = \sum_{k=1}^{r_{\alpha,\beta,\gamma}}
+                \chi_{\alpha,\beta,\gamma,k}^{L}
+    \]
+    for every $L \ge 0$ and every triple $(\alpha, \beta, \gamma)$, where
+    $r_{\alpha,\beta,\gamma}$ is the size of $\chi_{\alpha,\beta,\gamma}$. This
+    is the Lean-level form of the target identity of
+    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}; the existential
+    version---``there exists $\chi$ for which $(c,\chi)$ has trace-power
+    form''---is obtained by quantifying over $\chi$.
 \end{definition}
 
 \section{Commuting form and GSNNCH}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -951,6 +951,56 @@ blocking size under the algebra-structure predicate.
     Theorem~\ref{thm:newton_girard}.
 \end{remark}
 
+\subsection{Diagonal $\chi$-matrices and the trace-power formula}
+
+The following layer formalizes the target shape of
+\cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys} in which the structure
+coefficients of the length-$L$ operator algebra are trace-powers of positive
+diagonal matrices $\chi_{\alpha,\beta,\gamma}$. The RFP MPDO itself is not yet
+constructed here; what is formalized is the language in which the paper's
+identity is stated, together with the elementary trace-power identity for
+diagonal matrices.
+
+\begin{definition}[Diagonal $\chi$ family]%
+    \label{def:mpdo_diagonal_chi_family}
+    \lean{MPOTensor.DiagonalChiFamily}
+    \leanok
+    A family of diagonal complex matrices $\chi_{\alpha,\beta,\gamma}$ indexed
+    by ordered triples drawn from a common index type, each of a specified
+    size. This is the paper's $\chi_{\alpha,\beta,\gamma}$ in
+    Theorem~IV.13(ii).
+\end{definition}
+
+\begin{theorem}[Trace of $\chi^L$ equals the sum of $L$-th powers of entries]%
+    \label{thm:mpdo_trace_matrix_pow}
+    \lean{MPOTensor.DiagonalChiFamily.trace_matrix_pow}
+    \leanok
+    \uses{def:mpdo_diagonal_chi_family}
+    For every triple $(\alpha, \beta, \gamma)$ and every $L \ge 0$,
+    \[
+        \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr)
+            = \sum_{k} \chi_{\alpha,\beta,\gamma,k}^{L},
+    \]
+    where $\chi_{\alpha,\beta,\gamma,k}$ are the diagonal entries.
+\end{theorem}
+\begin{proof}\leanok
+Diagonal matrices raise to powers entrywise and the trace of a diagonal matrix
+is the sum of its entries.
+\end{proof}
+
+\begin{definition}[Trace-power form of a structure-coefficient family]%
+    \label{def:mpdo_has_chi_trace_power_form}
+    \lean{MPOTensor.HasChiTracePowerForm}
+    \leanok
+    \uses{def:mpdo_diagonal_chi_family}
+    An abstract structure-coefficient family $c^{(L)}_{\alpha,\beta,\gamma}$ has
+    \emph{trace-power form} when there is a diagonal $\chi$ family with
+    $c^{(L)}_{\alpha,\beta,\gamma} = \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr)$
+    for every $L$ and every triple $(\alpha, \beta, \gamma)$. This is the
+    Lean-level form of the target identity of
+    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}.
+\end{definition}
+
 \section{Commuting form and GSNNCH}
 
 \begin{definition}[Commuting-form data for an MPDO]


### PR DESCRIPTION
### Motivation
- PR #814 added the blocked-coefficient layer in `TNLean/MPS/MPDO/AlgebraStructure.lean`; the next paper-faithful step is to identify the diagonal χ_{α,β,γ} matrices and prove the trace-power formula `c_{α,β,γ}^(L) = tr(χ^L)`.
- Provides the minimum preparatory layer needed to later state and prove the algebra-side formulation of the MPDO RFP theorem without committing to the full BNT / coefficient-comparison layer (Appendix C.3–C.4).

### Description
- `TNLean/MPS/MPDO/AlgebraStructure.lean` (+95/-3): introduces `MPOTensor.DiagonalChiFamily` structure packaging the χ_{α,β,γ} matrices with `matrix`, `tracePowerCoeff`, and `PosEntries` fields; proves the identity `tr(χ^L) = ∑_k χ_k^L` via `Matrix.diagonal_pow` and `Matrix.trace_diagonal`; defines the `HasChiTracePowerForm` predicate on structure-coefficient families.
- `blueprint/src/chapter/ch02b_mpdo.tex` (+50): adds subsection with definitions and theorem statement for the χ trace-power identity (arXiv:1606.00608 §4.5, Thm IV.13(ii)).

### Testing
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #825

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean definitions/lemmas and blueprint documentation for the χ trace-power statement, without changing existing MPDO algebra-tower logic or proofs used elsewhere.
>
> **Overview**
> Adds a new formal layer for the *diagonal* `χ_{α,β,γ}` matrices used in [CPGSV17, Thm IV.13(ii)]. This introduces `MPOTensor.DiagonalChiFamily` (with `matrix`, `tracePowerCoeff`, and `PosEntries`) and proves the basic identity `tr(χ^L) = ∑_k χ_k^L` via `Matrix.diagonal_pow` and `Matrix.trace_diagonal`.
>
> Defines `HasChiTracePowerForm` to express that an abstract coefficient family `c L α β γ` is given by these trace-power coefficients, plus a convenience lemma rewriting it as equality with `(χ.matrix α β γ ^ L).trace`. Updates the blueprint with the corresponding subsection, definitions, and theorem statement.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5cd92cdda1384583673f80d2f9752c5a4ceb85e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean definitions/lemmas and matching blueprint documentation, without altering existing MPDO algebra-tower or transfer-map logic.
> 
> **Overview**
> Adds a new formal layer for Theorem IV.13(ii) by introducing `MPOTensor.DiagonalChiFamily` to represent the diagonal matrices `χ_{α,β,γ}`, plus derived helpers (`matrix`, `tracePowerCoeff`) and a positivity predicate `PosEntries`.
> 
> Proves the elementary trace-power identity for these diagonal matrices (`tr(χ^L) = ∑ k χ_k^L`) and introduces `HasChiTracePowerForm` (with a convenience lemma rewriting it as a trace of `χ.matrix ^ L`) to express when an abstract coefficient family is given by these trace powers.
> 
> Updates the blueprint with a new subsection documenting the new definitions and the trace-power theorem statement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6eec4ae7a72bb032cd4f605e33c0805b7ec36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->