### PR TITLE
feat(Wolf Ch2): formalize ordered CP maps, Radon-Nikodym theorem, and open-system representation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -55,6 +55,8 @@ import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.Stinespring
+import TNLean.Channel.OrderedCP
+import TNLean.Channel.RadonNikodym
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.POVM
 import TNLean.Channel.POVM.Uniqueness

--- a/TNLean/Channel/OrderedCP.lean
+++ b/TNLean/Channel/OrderedCP.lean
@@ -1,0 +1,358 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Basic
+import TNLean.Channel.Stinespring
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+
+/-!
+# Ordered completely positive maps (Wolf Ch. 2, Thm 2.3)
+
+This file relates two CP maps `T₁ ≤ T₂` through their Stinespring dilations.
+The central statement is Wolf's Theorem 2.3: if `T₂ - T₁` is CP, then any
+Stinespring isometry for `T₁` factors through a Stinespring isometry for `T₂`
+via a **contraction** on the dilation space.
+
+In the canonical realization provided here, the Stinespring isometry for `T₂`
+is obtained by concatenating Kraus operators of `T₁` with Kraus operators of
+`T₂ - T₁`, and the intertwining contraction is the explicit block-top
+projector `C : ℂ^{r₁+s} → ℂ^{r₁}` (taking the first `r₁` coordinates).
+
+## Main definitions
+
+* `CPDominates S T` — the CP partial order: `S - T` is completely positive.
+* `Matrix.blockTopRows r s` — the rectangular `r × (r+s)` matrix whose rows
+  are the first `r` rows of the identity; equivalently, the block `[𝟙_r | 0]`.
+
+## Main results (Wolf Thm 2.3)
+
+* `Matrix.blockTopRows_mul_conjTranspose` — `C * Cᴴ = 1_r` (co-isometry).
+* `Matrix.blockTopRows_conjTranspose_mul_le_one` — `Cᴴ * C ≤ 1` (contraction).
+* `stinespringV_eq_kronecker_blockTopRows_mul_append` — entrywise intertwining:
+  `V₁ = (𝟙_D ⊗ C) * V₂` where `V₂ = stinespringV (Fin.append K L)`.
+* `CPDominates.exists_stinespring_contraction` — existential form of Wolf
+  Thm 2.3: if `T₁ ≤ T₂` (in the CP order), there exist Stinespring isometries
+  for both and a contraction on the dilation space that intertwines them.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Thm 2.3][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix Finset BigOperators
+
+variable {D : ℕ}
+
+/-! ### The CP partial order -/
+
+/-- **CP partial order**: `S` dominates `T` iff `S - T` is completely positive.
+This is the partial order on CP maps used throughout Wolf Chapter 2. -/
+def CPDominates
+    (S T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) : Prop :=
+  IsCPMap (S - T)
+
+/-- Reflexivity of the CP order: `T - T = 0` has the empty Kraus family. -/
+theorem CPDominates.refl
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    CPDominates T T := by
+  refine ⟨0, (fun i : Fin 0 => i.elim0), ?_⟩
+  intro X
+  simp
+
+/-! ### Kraus concatenation via `Fin.append` -/
+
+/-- Concatenation of Kraus families is again a Kraus family for the sum map. -/
+theorem isCPMap_kraus_append
+    {r s : ℕ}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (L : Fin s → Matrix (Fin D) (Fin D) ℂ) :
+    ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ j : Fin (r + s),
+        (Fin.append K L) j * X * ((Fin.append K L) j)ᴴ =
+      (∑ i : Fin r, K i * X * (K i)ᴴ) +
+      (∑ k : Fin s, L k * X * (L k)ᴴ) := by
+  intro X
+  rw [Fin.sum_univ_add]
+  congr 1 <;>
+    · refine Finset.sum_congr rfl ?_
+      intro i _
+      simp [Fin.append_left, Fin.append_right]
+
+/-! ### The block-top rectangular projector -/
+
+/-- The block-top rectangular matrix `C : Fin r → Fin (r+s)` whose rows are
+the first `r` rows of `𝟙_{r+s}`. Concretely, `C i j = 1` if `j = castAdd s i`
+and `0` otherwise. This is the canonical co-isometry from `ℂ^{r+s}` onto
+`ℂ^r` that picks out the first `r` coordinates. -/
+noncomputable def Matrix.blockTopRows (r s : ℕ) :
+    Matrix (Fin r) (Fin (r + s)) ℂ :=
+  fun i j => if j = Fin.castAdd s i then 1 else 0
+
+theorem Matrix.blockTopRows_apply (r s : ℕ) (i : Fin r) (j : Fin (r + s)) :
+    blockTopRows r s i j = if j = Fin.castAdd s i then 1 else 0 := rfl
+
+@[simp] theorem Matrix.blockTopRows_apply_castAdd (r s : ℕ) (i : Fin r) :
+    blockTopRows r s i (Fin.castAdd s i) = 1 := by
+  simp [Matrix.blockTopRows]
+
+theorem Matrix.castAdd_injective (r s : ℕ) :
+    Function.Injective (Fin.castAdd s : Fin r → Fin (r + s)) := by
+  intro k i h
+  have hval := Fin.val_eq_of_eq h
+  simp only [Fin.val_castAdd] at hval
+  exact Fin.ext hval
+
+theorem Matrix.blockTopRows_apply_natAdd (r s : ℕ) (i : Fin r) (k : Fin s) :
+    blockTopRows r s i (Fin.natAdd r k) = 0 := by
+  simp only [Matrix.blockTopRows]
+  refine if_neg ?_
+  intro h
+  have := Fin.val_eq_of_eq h
+  simp [Fin.natAdd, Fin.castAdd] at this
+  omega
+
+/-- `C * Cᴴ = 𝟙_r` for the block-top projector. -/
+theorem Matrix.blockTopRows_mul_conjTranspose (r s : ℕ) :
+    (blockTopRows r s) * (blockTopRows r s)ᴴ = (1 : Matrix (Fin r) (Fin r) ℂ) := by
+  ext i i'
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    Matrix.blockTopRows_apply]
+  have hterm : ∀ j : Fin (r + s),
+      (if j = Fin.castAdd s i then (1 : ℂ) else 0) *
+        star (if j = Fin.castAdd s i' then (1 : ℂ) else 0) =
+      if j = Fin.castAdd s i ∧ j = Fin.castAdd s i' then 1 else 0 := by
+    intro j
+    by_cases h1 : j = Fin.castAdd s i <;> by_cases h2 : j = Fin.castAdd s i' <;>
+      simp [h1, h2]
+  simp_rw [hterm]
+  by_cases hii : i = i'
+  · subst hii
+    rw [Finset.sum_eq_single (Fin.castAdd s i)]
+    · simp [Matrix.one_apply_eq]
+    · intro b _ hb
+      simp [hb]
+    · intro hj; exact absurd (Finset.mem_univ (Fin.castAdd s i)) hj
+  · have hcast : Fin.castAdd s i ≠ Fin.castAdd s i' := by
+      intro h; exact hii (Matrix.castAdd_injective r s h)
+    have hsum : ∑ j : Fin (r + s),
+        (if j = Fin.castAdd s i ∧ j = Fin.castAdd s i' then (1 : ℂ) else 0) = 0 := by
+      apply Finset.sum_eq_zero
+      intro j _
+      split_ifs with hk
+      · exact absurd (hk.1.symm.trans hk.2) hcast
+      · rfl
+    rw [hsum, Matrix.one_apply_ne hii]
+
+/-- The "diagonal" block-top projector `Cᴴ * C` equals the diagonal matrix that
+is `1` on the first `r` coordinates and `0` on the last `s`. -/
+theorem Matrix.blockTopRows_conjTranspose_mul_apply (r s : ℕ)
+    (j j' : Fin (r + s)) :
+    ((blockTopRows r s)ᴴ * blockTopRows r s) j j' =
+      if j = j' ∧ (j : ℕ) < r then 1 else 0 := by
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.blockTopRows_apply]
+  have hterm : ∀ k : Fin r,
+      star (if j = Fin.castAdd s k then (1 : ℂ) else 0) *
+        (if j' = Fin.castAdd s k then 1 else 0) =
+      if j = Fin.castAdd s k ∧ j' = Fin.castAdd s k then 1 else 0 := by
+    intro k
+    by_cases h1 : j = Fin.castAdd s k <;> by_cases h2 : j' = Fin.castAdd s k <;>
+      simp [h1, h2]
+  simp_rw [hterm]
+  by_cases hjr : (j : ℕ) < r
+  · set jFin : Fin r := ⟨(j : ℕ), hjr⟩ with hjFin
+    have hj : j = Fin.castAdd s jFin := by
+      ext; simp [Fin.castAdd, hjFin]
+    by_cases hjeq : j = j'
+    · subst hjeq
+      have hconv : ∀ k : Fin r,
+          (if j = Fin.castAdd s k ∧ j = Fin.castAdd s k then (1 : ℂ) else 0) =
+          if k = jFin then 1 else 0 := by
+        intro k
+        by_cases hk : j = Fin.castAdd s k
+        · have hkF : k = jFin := by
+            have : Fin.castAdd s k = Fin.castAdd s jFin := hk.symm.trans hj
+            exact Matrix.castAdd_injective r s this
+          simp [hk, hkF]
+        · have hkF : k ≠ jFin := by
+            intro he; apply hk; rw [he]; exact hj
+          simp [hk, hkF]
+      simp_rw [hconv]
+      rw [Finset.sum_eq_single jFin]
+      · simp [hjr]
+      · intro b _ hb; simp [hb]
+      · intro hj'; exact absurd (Finset.mem_univ jFin) hj'
+    · have hrhs : ¬ (j = j' ∧ (j : ℕ) < r) := fun ⟨h, _⟩ => hjeq h
+      rw [if_neg hrhs]
+      apply Finset.sum_eq_zero
+      intro k _
+      split_ifs with h
+      · exact absurd (h.1.trans h.2.symm) hjeq
+      · rfl
+  · have hrhs : ¬ (j = j' ∧ (j : ℕ) < r) := fun ⟨_, h⟩ => hjr h
+    rw [if_neg hrhs]
+    apply Finset.sum_eq_zero
+    intro k _
+    have hk : j ≠ Fin.castAdd s k := by
+      intro he
+      have := Fin.val_eq_of_eq he
+      simp [Fin.castAdd] at this
+      omega
+    simp [hk]
+
+/-- **C is a contraction**: `Cᴴ * C ≤ 𝟙_{r+s}`. -/
+theorem Matrix.blockTopRows_conjTranspose_mul_le_one (r s : ℕ) :
+    (blockTopRows r s)ᴴ * blockTopRows r s ≤ (1 : Matrix (Fin (r+s)) (Fin (r+s)) ℂ) := by
+  rw [Matrix.le_iff]
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
+  · -- Hermitian.
+    ext j j'
+    simp only [Matrix.sub_apply, Matrix.one_apply, Matrix.conjTranspose_apply,
+      Matrix.blockTopRows_conjTranspose_mul_apply]
+    by_cases hjj : j = j'
+    · subst hjj
+      by_cases hjr : (j : ℕ) < r
+      all_goals simp [hjr]
+    · have hne : j' ≠ j := fun h => hjj h.symm
+      simp [hjj, hne]
+  · -- PSD condition.
+    intro x
+    -- Compute ((1 - CᴴC).mulVec x) j entrywise.
+    have hmul : ∀ j : Fin (r + s),
+        (((1 : Matrix (Fin (r+s)) (Fin (r+s)) ℂ) -
+            ((blockTopRows r s)ᴴ * blockTopRows r s)) *ᵥ x) j =
+        (if (j : ℕ) < r then 0 else x j) := by
+      intro j
+      rw [Matrix.sub_mulVec]
+      rw [Matrix.one_mulVec]
+      simp only [Pi.sub_apply, Matrix.mulVec, dotProduct]
+      simp_rw [Matrix.blockTopRows_conjTranspose_mul_apply]
+      by_cases hjr : (j : ℕ) < r
+      · rw [if_pos hjr]
+        have hsum : ∑ j' : Fin (r + s),
+            (if j = j' ∧ (j : ℕ) < r then (1 : ℂ) else 0) * x j' = x j := by
+          rw [Finset.sum_eq_single j]
+          · simp [hjr]
+          · intro b _ hb
+            have : ¬ (j = b ∧ (j : ℕ) < r) := fun ⟨hjb, _⟩ => hb hjb.symm
+            simp [this]
+          · intro hj; exact absurd (Finset.mem_univ j) hj
+        rw [hsum, sub_self]
+      · rw [if_neg hjr]
+        have hsum : ∑ j' : Fin (r + s),
+            (if j = j' ∧ (j : ℕ) < r then (1 : ℂ) else 0) * x j' = 0 := by
+          apply Finset.sum_eq_zero
+          intro j' _
+          split_ifs with h
+          · exact absurd h.2 hjr
+          · ring
+        rw [hsum, sub_zero]
+    simp only [dotProduct]
+    refine Finset.sum_nonneg fun j _ => ?_
+    rw [hmul]
+    by_cases hjr : (j : ℕ) < r
+    · simp [hjr]
+    · simp only [hjr, if_false]
+      change 0 ≤ star (x j) * x j
+      have hsq : star (x j) * x j = ((‖x j‖ : ℝ) ^ 2 : ℂ) := by
+        rw [show star (x j) = starRingEnd ℂ (x j) from rfl, RCLike.conj_mul]
+        norm_cast
+      rw [hsq]
+      exact_mod_cast sq_nonneg ‖x j‖
+
+/-! ### Intertwining identity for the Stinespring isometries -/
+
+/-- **Entrywise intertwining (Wolf Thm 2.3 canonical form)**: the block-top
+projector `C = blockTopRows r s` relates the Stinespring isometry of a Kraus
+family `K : Fin r → M` with that of its append with another family
+`L : Fin s → M`:
+  `stinespringV K = (𝟙_D ⊗ C) * stinespringV (Fin.append K L)`. -/
+theorem stinespringV_eq_kronecker_blockTopRows_mul_append
+    {r s : ℕ}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (L : Fin s → Matrix (Fin D) (Fin D) ℂ) :
+    stinespringV K =
+      (Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
+          (Matrix.blockTopRows r s)) *
+        stinespringV (Fin.append K L) := by
+  ext ⟨i, j₁⟩ k
+  simp only [stinespringV_apply, Matrix.mul_apply, Matrix.kroneckerMap_apply,
+    Fintype.sum_prod_type, Matrix.blockTopRows_apply]
+  -- Reduce double sum to a single value.
+  rw [Finset.sum_eq_single i]
+  · rw [Finset.sum_eq_single (Fin.castAdd s j₁)]
+    · simp [Fin.append_left, Matrix.one_apply_eq]
+    · intro b _ hb
+      simp [Matrix.one_apply_eq, hb]
+    · intro hj; exact absurd (Finset.mem_univ (Fin.castAdd s j₁)) hj
+  · intro b _ hb
+    refine Finset.sum_eq_zero ?_
+    intro j _
+    have : ((1 : Matrix (Fin D) (Fin D) ℂ) i b) = 0 := Matrix.one_apply_ne (Ne.symm hb)
+    simp [this]
+  · intro hi; exact absurd (Finset.mem_univ i) hi
+
+/-! ### Wolf Theorem 2.3: ordered CP-maps -/
+
+/-- **Wolf Theorem 2.3 (ordered CP-maps, canonical form)**.
+
+Let `T₁, T₂ : M_D(ℂ) →ₗ M_D(ℂ)` be CP maps with `T₁ ≤ T₂` in the CP partial
+order (i.e. `T₂ - T₁` is CP). Then there exist an ancilla dimension `m`,
+Stinespring isometries `V₁ : Matrix (Fin D × Fin r₁) (Fin D) ℂ` and
+`V₂ : Matrix (Fin D × Fin m) (Fin D) ℂ` — both realizing `Tᵢ` in Heisenberg
+form `Tᵢ(A) = Vᵢᴴ * (A ⊗ 𝟙) * Vᵢ` — together with a **contraction**
+`C : Matrix (Fin r₁) (Fin m) ℂ` satisfying `Cᴴ * C ≤ 𝟙` and the intertwining
+identity `V₁ = (𝟙_D ⊗ C) * V₂`.
+
+In the canonical realization returned below, `m = r₁ + s` where `s` is a Kraus
+length of `T₂ - T₁`, the two Stinespring isometries are the Heisenberg-form
+constructions from conjugated Kraus families, and `C = blockTopRows r₁ s`. -/
+theorem CPDominates.exists_stinespring_contraction
+    {T₁ T₂ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT₁ : IsCPMap T₁) (hdom : CPDominates T₂ T₁) :
+    ∃ (r₁ m : ℕ)
+      (K₁ : Fin r₁ → Matrix (Fin D) (Fin D) ℂ)
+      (K₂ : Fin m → Matrix (Fin D) (Fin D) ℂ)
+      (C : Matrix (Fin r₁) (Fin m) ℂ),
+      (∀ A, T₁ A =
+        (stinespringV K₁)ᴴ * stinespringPi (r := r₁) A * stinespringV K₁) ∧
+      (∀ A, T₂ A =
+        (stinespringV K₂)ᴴ * stinespringPi (r := m) A * stinespringV K₂) ∧
+      Cᴴ * C ≤ 1 ∧
+      stinespringV K₁ =
+        (Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C) *
+          stinespringV K₂ := by
+  obtain ⟨r₁, K₁h, hK₁⟩ := exists_stinespring_dilation T₁ hT₁
+  obtain ⟨s, L, hL⟩ := hdom
+  let Lh : Fin s → Matrix (Fin D) (Fin D) ℂ := fun j => (L j)ᴴ
+  let K₂ : Fin (r₁ + s) → Matrix (Fin D) (Fin D) ℂ := Fin.append K₁h Lh
+  refine ⟨r₁, r₁ + s, K₁h, K₂, Matrix.blockTopRows r₁ s, hK₁, ?_, ?_, ?_⟩
+  · -- T₂ Heisenberg identity.
+    intro A
+    have hsum : T₂ A = T₁ A + (T₂ - T₁) A := by
+      simp [LinearMap.sub_apply]
+    rw [hsum, hK₁, hL]
+    have hLsum : ∑ j : Fin s, L j * A * (L j)ᴴ =
+        ∑ j : Fin s, (Lh j)ᴴ * A * (Lh j) := by
+      refine Finset.sum_congr rfl ?_
+      intro j _; simp [Lh]
+    rw [hLsum]
+    have hStK₂ : ∑ j : Fin (r₁ + s), (K₂ j)ᴴ * A * (K₂ j) =
+        (stinespringV K₂)ᴴ * stinespringPi (r := r₁ + s) A * stinespringV K₂ :=
+      (stinespring_dual_representation (K := K₂) (A := A)).symm
+    have hStK₁ : ∑ i : Fin r₁, (K₁h i)ᴴ * A * (K₁h i) =
+        (stinespringV K₁h)ᴴ * stinespringPi (r := r₁) A * stinespringV K₁h :=
+      (stinespring_dual_representation (K := K₁h) (A := A)).symm
+    have hSplit : ∑ j : Fin (r₁ + s), (K₂ j)ᴴ * A * (K₂ j) =
+        (∑ i : Fin r₁, (K₁h i)ᴴ * A * (K₁h i)) +
+        (∑ j : Fin s, (Lh j)ᴴ * A * (Lh j)) := by
+      rw [Fin.sum_univ_add]
+      congr 1 <;>
+      · refine Finset.sum_congr rfl ?_
+        intro i _
+        simp [K₂, Fin.append_left, Fin.append_right]
+    rw [← hStK₁, ← hStK₂, hSplit]
+  · exact Matrix.blockTopRows_conjTranspose_mul_le_one r₁ s
+  · exact stinespringV_eq_kronecker_blockTopRows_mul_append K₁h Lh

--- a/TNLean/Channel/OrderedCP.lean
+++ b/TNLean/Channel/OrderedCP.lean
@@ -80,22 +80,6 @@ theorem Matrix.blockTopRows_apply (r s : ℕ) (i : Fin r) (j : Fin (r + s)) :
     blockTopRows r s i (Fin.castAdd s i) = 1 := by
   simp [Matrix.blockTopRows]
 
-theorem Matrix.castAdd_injective (r s : ℕ) :
-    Function.Injective (Fin.castAdd s : Fin r → Fin (r + s)) := by
-  intro k i h
-  have hval := Fin.val_eq_of_eq h
-  simp only [Fin.val_castAdd] at hval
-  exact Fin.ext hval
-
-theorem Matrix.blockTopRows_apply_natAdd (r s : ℕ) (i : Fin r) (k : Fin s) :
-    blockTopRows r s i (Fin.natAdd r k) = 0 := by
-  simp only [Matrix.blockTopRows]
-  refine if_neg ?_
-  intro h
-  have := Fin.val_eq_of_eq h
-  simp [Fin.natAdd, Fin.castAdd] at this
-  omega
-
 /-- `C * Cᴴ = 𝟙_r` for the block-top projector. -/
 theorem Matrix.blockTopRows_mul_conjTranspose (r s : ℕ) :
     (blockTopRows r s) * (blockTopRows r s)ᴴ = (1 : Matrix (Fin r) (Fin r) ℂ) := by
@@ -118,7 +102,7 @@ theorem Matrix.blockTopRows_mul_conjTranspose (r s : ℕ) :
       simp [hb]
     · intro hj; exact absurd (Finset.mem_univ (Fin.castAdd s i)) hj
   · have hcast : Fin.castAdd s i ≠ Fin.castAdd s i' := by
-      intro h; exact hii (Matrix.castAdd_injective r s h)
+      intro h; exact hii (Fin.castAdd_injective r s h)
     have hsum : ∑ j : Fin (r + s),
         (if j = Fin.castAdd s i ∧ j = Fin.castAdd s i' then (1 : ℂ) else 0) = 0 := by
       apply Finset.sum_eq_zero
@@ -156,7 +140,7 @@ theorem Matrix.blockTopRows_conjTranspose_mul_apply (r s : ℕ)
         by_cases hk : j = Fin.castAdd s k
         · have hkF : k = jFin := by
             have : Fin.castAdd s k = Fin.castAdd s jFin := hk.symm.trans hj
-            exact Matrix.castAdd_injective r s this
+            exact Fin.castAdd_injective r s this
           simp [hk, hkF]
         · have hkF : k ≠ jFin := by
             intro he; apply hk; rw [he]; exact hj

--- a/TNLean/Channel/OrderedCP.lean
+++ b/TNLean/Channel/OrderedCP.lean
@@ -10,15 +10,15 @@ import Mathlib.LinearAlgebra.Matrix.Kronecker
 /-!
 # Ordered completely positive maps (Wolf Ch. 2, Thm 2.3)
 
-This file relates two CP maps `T₁ ≤ T₂` through their Stinespring dilations.
-The central statement is Wolf's Theorem 2.3: if `T₂ - T₁` is CP, then any
-Stinespring isometry for `T₁` factors through a Stinespring isometry for `T₂`
-via a **contraction** on the dilation space.
+This file relates two CP maps `T₁ ≤ T₂` through canonical Stinespring
+realizations. The central statement is Wolf's Theorem 2.3: if `T₂ - T₁` is CP,
+then a Heisenberg-form Stinespring realization for `T₁` factors through one for
+`T₂` via a **contraction** on the dilation space.
 
-In the canonical realization provided here, the Stinespring isometry for `T₂`
-is obtained by concatenating Kraus operators of `T₁` with Kraus operators of
+In the canonical realization provided here, the Stinespring matrix for `T₂` is
+obtained by concatenating Kraus operators of `T₁` with Kraus operators of
 `T₂ - T₁`, and the intertwining contraction is the explicit block-top
-projector `C : ℂ^{r₁+s} → ℂ^{r₁}` (taking the first `r₁` coordinates).
+co-isometry `C : ℂ^{r₁+s} → ℂ^{r₁}` (taking the first `r₁` coordinates).
 
 ## Main definitions
 
@@ -33,8 +33,9 @@ projector `C : ℂ^{r₁+s} → ℂ^{r₁}` (taking the first `r₁` coordinates
 * `stinespringV_eq_kronecker_blockTopRows_mul_append` — entrywise intertwining:
   `V₁ = (𝟙_D ⊗ C) * V₂` where `V₂ = stinespringV (Fin.append K L)`.
 * `CPDominates.exists_stinespring_contraction` — existential form of Wolf
-  Thm 2.3: if `T₁ ≤ T₂` (in the CP order), there exist Stinespring isometries
-  for both and a contraction on the dilation space that intertwines them.
+  Thm 2.3: if `T₁ ≤ T₂` (in the CP order), there exist Stinespring
+  realizations for both and a contraction on the dilation space that
+  intertwines them.
 
 ## References
 
@@ -62,26 +63,7 @@ theorem CPDominates.refl
   intro X
   simp
 
-/-! ### Kraus concatenation via `Fin.append` -/
-
-/-- Concatenation of Kraus families is again a Kraus family for the sum map. -/
-theorem isCPMap_kraus_append
-    {r s : ℕ}
-    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
-    (L : Fin s → Matrix (Fin D) (Fin D) ℂ) :
-    ∀ X : Matrix (Fin D) (Fin D) ℂ,
-      ∑ j : Fin (r + s),
-        (Fin.append K L) j * X * ((Fin.append K L) j)ᴴ =
-      (∑ i : Fin r, K i * X * (K i)ᴴ) +
-      (∑ k : Fin s, L k * X * (L k)ᴴ) := by
-  intro X
-  rw [Fin.sum_univ_add]
-  congr 1 <;>
-    · refine Finset.sum_congr rfl ?_
-      intro i _
-      simp [Fin.append_left, Fin.append_right]
-
-/-! ### The block-top rectangular projector -/
+/-! ### The block-top rectangular co-isometry -/
 
 /-- The block-top rectangular matrix `C : Fin r → Fin (r+s)` whose rows are
 the first `r` rows of `𝟙_{r+s}`. Concretely, `C i j = 1` if `j = castAdd s i`
@@ -262,10 +244,10 @@ theorem Matrix.blockTopRows_conjTranspose_mul_le_one (r s : ℕ) :
       rw [hsq]
       exact_mod_cast sq_nonneg ‖x j‖
 
-/-! ### Intertwining identity for the Stinespring isometries -/
+/-! ### Intertwining identity for the canonical Stinespring matrices -/
 
 /-- **Entrywise intertwining (Wolf Thm 2.3 canonical form)**: the block-top
-projector `C = blockTopRows r s` relates the Stinespring isometry of a Kraus
+co-isometry `C = blockTopRows r s` relates the Stinespring matrix of a Kraus
 family `K : Fin r → M` with that of its append with another family
 `L : Fin s → M`:
   `stinespringV K = (𝟙_D ⊗ C) * stinespringV (Fin.append K L)`. -/
@@ -300,15 +282,15 @@ theorem stinespringV_eq_kronecker_blockTopRows_mul_append
 
 Let `T₁, T₂ : M_D(ℂ) →ₗ M_D(ℂ)` be CP maps with `T₁ ≤ T₂` in the CP partial
 order (i.e. `T₂ - T₁` is CP). Then there exist an ancilla dimension `m`,
-Stinespring isometries `V₁ : Matrix (Fin D × Fin r₁) (Fin D) ℂ` and
-`V₂ : Matrix (Fin D × Fin m) (Fin D) ℂ` — both realizing `Tᵢ` in Heisenberg
-form `Tᵢ(A) = Vᵢᴴ * (A ⊗ 𝟙) * Vᵢ` — together with a **contraction**
-`C : Matrix (Fin r₁) (Fin m) ℂ` satisfying `Cᴴ * C ≤ 𝟙` and the intertwining
-identity `V₁ = (𝟙_D ⊗ C) * V₂`.
+Heisenberg-form Stinespring matrices
+`V₁ : Matrix (Fin D × Fin r₁) (Fin D) ℂ` and
+`V₂ : Matrix (Fin D × Fin m) (Fin D) ℂ` realizing `Tᵢ(A) = Vᵢᴴ * (A ⊗ 𝟙) * Vᵢ`,
+together with a **contraction** `C : Matrix (Fin r₁) (Fin m) ℂ` satisfying
+`Cᴴ * C ≤ 𝟙` and the intertwining identity `V₁ = (𝟙_D ⊗ C) * V₂`.
 
 In the canonical realization returned below, `m = r₁ + s` where `s` is a Kraus
-length of `T₂ - T₁`, the two Stinespring isometries are the Heisenberg-form
-constructions from conjugated Kraus families, and `C = blockTopRows r₁ s`. -/
+length of `T₂ - T₁`, the two Stinespring matrices come from conjugated Kraus
+families, and `C = blockTopRows r₁ s`. -/
 theorem CPDominates.exists_stinespring_contraction
     {T₁ T₂ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT₁ : IsCPMap T₁) (hdom : CPDominates T₂ T₁) :

--- a/TNLean/Channel/RadonNikodym.lean
+++ b/TNLean/Channel/RadonNikodym.lean
@@ -1,0 +1,347 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.OrderedCP
+
+/-!
+# Radon–Nikodym theorem for CP maps and open-system representation
+(Wolf Ch. 2, Thm 2.4 and Thm 2.5)
+
+This file formalizes the canonical Radon–Nikodym theorem for completely
+positive maps (Wolf Thm 2.4) and the open-system representation theorem
+(Wolf Thm 2.5).
+
+The Radon–Nikodym theorem says: if `T = T₁ + T₂` with both CP and `V` is a
+Stinespring isometry of `T`, then there exist PSD operators `P₁, P₂` on the
+dilation space with `P₁ + P₂ = 𝟙` such that `Tᵢ(A) = V†(A ⊗ Pᵢ)V`. In our
+canonical realization, `V` is built from concatenated Kraus families of
+`T₁` and `T₂`, and `P₁, P₂` are the orthogonal block projectors.
+
+The open-system representation says: every CPTP map `T` can be written as
+`T(ρ) = tr_r(V ρ V†)` for an isometry `V`, i.e. as the reduced unitary
+evolution on a system-plus-environment.
+
+## Main definitions
+
+* `Matrix.blockDiagTopProj r s` — the projector `Cᴴ C` onto the first `r`
+  coordinates of `ℂ^{r+s}` (equals `(blockTopRows r s)ᴴ * blockTopRows r s`).
+* `Matrix.blockDiagBotProj r s` — the complementary projector onto the last
+  `s` coordinates (equals `𝟙 - blockDiagTopProj r s`).
+
+## Main results
+
+* `Matrix.blockDiagTopProj_add_blockDiagBotProj` — the two projectors sum to
+  the identity: resolution of identity on the dilation space.
+* `Matrix.blockDiagTopProj_posSemidef`,
+  `Matrix.blockDiagBotProj_posSemidef` — both are PSD.
+* `CPDominates.exists_radon_nikodym` (Wolf Thm 2.4 binary form):
+  if `T = T₁ + T₂` with both CP, there exist a Stinespring isometry `V` and
+  two PSD "density" operators `P₁, P₂` with `P₁ + P₂ = 𝟙` such that
+  `Tᵢ(A) = V†(A ⊗ Pᵢ)V`.
+* `IsChannel.exists_stinespring_open_system` (Wolf Thm 2.5 reduced form):
+  every CPTP map admits an isometric Stinespring dilation realizing it as
+  the reduced dynamics `T(ρ) = tr_r(V ρ V†)`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Thms 2.4, 2.5]
+  [Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix Finset BigOperators
+
+variable {D : ℕ}
+
+/-! ### Block-diagonal projectors on the dilation space -/
+
+/-- The **top-block projector** on `ℂ^{r+s}`: projects onto the first `r`
+coordinates. Equals `Cᴴ * C` where `C = blockTopRows r s`. -/
+noncomputable def Matrix.blockDiagTopProj (r s : ℕ) :
+    Matrix (Fin (r + s)) (Fin (r + s)) ℂ :=
+  (Matrix.blockTopRows r s)ᴴ * (Matrix.blockTopRows r s)
+
+/-- The **bottom-block projector** on `ℂ^{r+s}`: projects onto the last `s`
+coordinates. Equals `𝟙 - blockDiagTopProj r s`. -/
+noncomputable def Matrix.blockDiagBotProj (r s : ℕ) :
+    Matrix (Fin (r + s)) (Fin (r + s)) ℂ :=
+  1 - Matrix.blockDiagTopProj r s
+
+/-- Resolution of identity: `P_top + P_bot = 𝟙`. -/
+theorem Matrix.blockDiagTopProj_add_blockDiagBotProj (r s : ℕ) :
+    Matrix.blockDiagTopProj r s + Matrix.blockDiagBotProj r s = 1 := by
+  simp [Matrix.blockDiagBotProj]
+
+/-- The top-block projector is PSD (it is `CᴴC` for some `C`). -/
+theorem Matrix.blockDiagTopProj_posSemidef (r s : ℕ) :
+    (Matrix.blockDiagTopProj r s).PosSemidef :=
+  Matrix.posSemidef_conjTranspose_mul_self (Matrix.blockTopRows r s)
+
+/-- The bottom-block projector is PSD: `𝟙 - CᴴC ≥ 0` since `CᴴC ≤ 𝟙`. -/
+theorem Matrix.blockDiagBotProj_posSemidef (r s : ℕ) :
+    (Matrix.blockDiagBotProj r s).PosSemidef := by
+  have := Matrix.blockTopRows_conjTranspose_mul_le_one r s
+  rw [Matrix.le_iff] at this
+  exact this
+
+/-- `P_top` is Hermitian, needed when forming Kronecker products. -/
+theorem Matrix.blockDiagTopProj_isHermitian (r s : ℕ) :
+    (Matrix.blockDiagTopProj r s).IsHermitian :=
+  (Matrix.blockDiagTopProj_posSemidef r s).isHermitian
+
+/-- `P_bot` is Hermitian. -/
+theorem Matrix.blockDiagBotProj_isHermitian (r s : ℕ) :
+    (Matrix.blockDiagBotProj r s).IsHermitian :=
+  (Matrix.blockDiagBotProj_posSemidef r s).isHermitian
+
+/-! ### Entrywise formulas for the block projectors -/
+
+theorem Matrix.blockDiagTopProj_apply (r s : ℕ) (j j' : Fin (r + s)) :
+    Matrix.blockDiagTopProj r s j j' =
+      if j = j' ∧ (j : ℕ) < r then 1 else 0 :=
+  Matrix.blockTopRows_conjTranspose_mul_apply r s j j'
+
+theorem Matrix.blockDiagBotProj_apply (r s : ℕ) (j j' : Fin (r + s)) :
+    Matrix.blockDiagBotProj r s j j' =
+      if j = j' ∧ ¬ (j : ℕ) < r then 1 else 0 := by
+  simp only [Matrix.blockDiagBotProj, Matrix.sub_apply, Matrix.one_apply,
+    Matrix.blockDiagTopProj_apply]
+  by_cases hjj : j = j'
+  · subst hjj
+    by_cases hjr : (j : ℕ) < r
+    · simp [hjr]
+    · simp [hjr]
+  · have hne : j' ≠ j := fun h => hjj h.symm
+    simp [hjj]
+
+/-! ### The key Kronecker identity: `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙)(𝟙 ⊗ C)` -/
+
+/-- For any matrix `C : Fin r → Fin m` and `A : Fin D → Fin D`,
+  `A ⊗ (Cᴴ * C) = (𝟙 ⊗ C)ᴴ * (A ⊗ 𝟙) * (𝟙 ⊗ C)`.
+This is the Kronecker identity used in the Radon–Nikodym construction: it
+rewrites `V†(A ⊗ P)V` with `P = CᴴC` as `(C̃ V)† (A ⊗ 𝟙)(C̃ V)` with
+`C̃ = 𝟙 ⊗ C`. -/
+theorem Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap
+    {D r m : ℕ} (A : Matrix (Fin D) (Fin D) ℂ)
+    (C : Matrix (Fin r) (Fin m) ℂ) :
+    (Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C)ᴴ *
+        Matrix.kroneckerMap (· * ·) A (1 : Matrix (Fin r) (Fin r) ℂ) *
+        Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C =
+      Matrix.kroneckerMap (· * ·) A (Cᴴ * C) := by
+  rw [Matrix.conjTranspose_kronecker]
+  rw [show (1 : Matrix (Fin D) (Fin D) ℂ)ᴴ = 1 from Matrix.conjTranspose_one]
+  rw [← Matrix.mul_kronecker_mul (A := (1 : Matrix (Fin D) (Fin D) ℂ)) (B := A)
+      (A' := Cᴴ) (B' := (1 : Matrix (Fin r) (Fin r) ℂ))]
+  rw [← Matrix.mul_kronecker_mul (A := (1 * A : Matrix (Fin D) (Fin D) ℂ))
+      (B := (1 : Matrix (Fin D) (Fin D) ℂ)) (A' := Cᴴ * 1) (B' := C)]
+  simp
+
+/-! ### Wolf Theorem 2.4 (Radon–Nikodym, binary form) -/
+
+/-- **Wolf Theorem 2.4 (Radon–Nikodym for CP maps, binary form)**.
+
+If `T = T₁ + T₂` with both `T₁, T₂` completely positive, then there exist:
+
+* an ancilla dimension `m`,
+* a Stinespring-type isometric family `K : Fin m → M_D(ℂ)` with associated
+  Stinespring matrix `V = stinespringV K`,
+* two **positive operators** `P₁, P₂ : M_m(ℂ)` on the dilation space,
+* with `P₁ + P₂ = 𝟙_m`,
+
+such that each `Tᵢ` is recovered by the "weighted" Stinespring formula
+`Tᵢ(A) = V† (A ⊗ Pᵢ) V`.
+
+In the canonical realization returned below, the Kraus family of `T` is the
+append of the Kraus families of `T₁` and `T₂`, and `P₁, P₂` are the
+orthogonal block projectors onto the two halves of the dilation space. -/
+theorem IsCPMap.exists_radon_nikodym
+    {T₁ T₂ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT₁ : IsCPMap T₁) (hT₂ : IsCPMap T₂) :
+    ∃ (m : ℕ) (K : Fin m → Matrix (Fin D) (Fin D) ℂ)
+      (P₁ P₂ : Matrix (Fin m) (Fin m) ℂ),
+      P₁.PosSemidef ∧ P₂.PosSemidef ∧ P₁ + P₂ = 1 ∧
+      (∀ A, T₁ A =
+        (stinespringV K)ᴴ *
+          Matrix.kroneckerMap (· * ·) A P₁ *
+          stinespringV K) ∧
+      (∀ A, T₂ A =
+        (stinespringV K)ᴴ *
+          Matrix.kroneckerMap (· * ·) A P₂ *
+          stinespringV K) := by
+  -- Heisenberg-form Kraus families for T₁ and T₂.
+  obtain ⟨r₁, K₁, hK₁⟩ := exists_stinespring_dilation T₁ hT₁
+  obtain ⟨s, L, hL⟩ := hT₂
+  -- Convert L to Heisenberg orientation.
+  let Lh : Fin s → Matrix (Fin D) (Fin D) ℂ := fun j => (L j)ᴴ
+  let K : Fin (r₁ + s) → Matrix (Fin D) (Fin D) ℂ := Fin.append K₁ Lh
+  refine ⟨r₁ + s, K, Matrix.blockDiagTopProj r₁ s, Matrix.blockDiagBotProj r₁ s,
+    Matrix.blockDiagTopProj_posSemidef r₁ s,
+    Matrix.blockDiagBotProj_posSemidef r₁ s,
+    Matrix.blockDiagTopProj_add_blockDiagBotProj r₁ s, ?_, ?_⟩
+  · -- T₁(A) = V†(A ⊗ P_top)V.
+    intro A
+    -- Use the Kronecker identity: A ⊗ P_top = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙)(𝟙 ⊗ C).
+    rw [Matrix.blockDiagTopProj,
+        ← Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap A
+          (Matrix.blockTopRows r₁ s)]
+    -- Reassociate: Vᴴ * ((𝟙⊗C)ᴴ * (A⊗𝟙) * (𝟙⊗C)) * V = ((𝟙⊗C)V)ᴴ * (A⊗𝟙) * ((𝟙⊗C)V).
+    rw [show (stinespringV K)ᴴ *
+        ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
+            (Matrix.blockTopRows r₁ s))ᴴ *
+          Matrix.kroneckerMap (· * ·) A
+            (1 : Matrix (Fin r₁) (Fin r₁) ℂ) *
+          Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
+            (Matrix.blockTopRows r₁ s)) *
+        stinespringV K =
+      ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
+            (Matrix.blockTopRows r₁ s)) * stinespringV K)ᴴ *
+        Matrix.kroneckerMap (· * ·) A (1 : Matrix (Fin r₁) (Fin r₁) ℂ) *
+        ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
+            (Matrix.blockTopRows r₁ s)) * stinespringV K) from by
+      rw [Matrix.conjTranspose_mul]
+      simp only [Matrix.mul_assoc]]
+    rw [← stinespringV_eq_kronecker_blockTopRows_mul_append K₁ Lh]
+    -- Now the goal is T₁(A) = (stinespringV K₁)ᴴ * (A ⊗ 𝟙) * (stinespringV K₁).
+    have : (stinespringV K₁)ᴴ *
+        Matrix.kroneckerMap (· * ·) A (1 : Matrix (Fin r₁) (Fin r₁) ℂ) *
+        stinespringV K₁ =
+        (stinespringV K₁)ᴴ * stinespringPi (r := r₁) A * stinespringV K₁ := rfl
+    rw [this, ← hK₁]
+  · -- T₂(A) = V†(A ⊗ P_bot)V.
+    -- Strategy: decompose P_bot = CᴴC where C is the "bottom-block rows" matrix.
+    -- Easier: use the identity A ⊗ P_bot = A ⊗ 𝟙 - A ⊗ P_top, so
+    -- V†(A ⊗ P_bot)V = V†(A ⊗ 𝟙)V - V†(A ⊗ P_top)V = T(A) - T₁(A) = T₂(A).
+    intro A
+    have hT_decomp : ∀ A, T₁ A + T₂ A =
+        (stinespringV K)ᴴ * stinespringPi (r := r₁ + s) A * stinespringV K := by
+      intro A
+      have hK₁_kraus : T₁ A = ∑ i : Fin r₁, (K₁ i)ᴴ * A * (K₁ i) := by
+        rw [hK₁]
+        exact stinespring_dual_representation (K := K₁) (A := A)
+      rw [hK₁_kraus, hL]
+      have hLsum : ∑ j : Fin s, L j * A * (L j)ᴴ =
+          ∑ j : Fin s, (Lh j)ᴴ * A * (Lh j) := by
+        refine Finset.sum_congr rfl ?_
+        intro j _; simp [Lh]
+      rw [hLsum]
+      have hSplit : ∑ j : Fin (r₁ + s), (K j)ᴴ * A * (K j) =
+          (∑ i : Fin r₁, (K₁ i)ᴴ * A * (K₁ i)) +
+          (∑ j : Fin s, (Lh j)ᴴ * A * (Lh j)) := by
+        rw [Fin.sum_univ_add]
+        congr 1 <;>
+        · refine Finset.sum_congr rfl ?_
+          intro i _
+          simp [K, Fin.append_left, Fin.append_right]
+      rw [← hSplit, ← stinespring_dual_representation (K := K) (A := A)]
+      rfl
+    have hT₁_kron : T₁ A =
+        (stinespringV K)ᴴ *
+          Matrix.kroneckerMap (· * ·) A
+            (Matrix.blockDiagTopProj r₁ s) *
+          stinespringV K := by
+      rw [Matrix.blockDiagTopProj,
+          ← Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap A
+            (Matrix.blockTopRows r₁ s)]
+      rw [show (stinespringV K)ᴴ *
+          ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
+              (Matrix.blockTopRows r₁ s))ᴴ *
+            Matrix.kroneckerMap (· * ·) A
+              (1 : Matrix (Fin r₁) (Fin r₁) ℂ) *
+            Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
+              (Matrix.blockTopRows r₁ s)) *
+          stinespringV K =
+        ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
+              (Matrix.blockTopRows r₁ s)) * stinespringV K)ᴴ *
+          Matrix.kroneckerMap (· * ·) A (1 : Matrix (Fin r₁) (Fin r₁) ℂ) *
+          ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ)
+              (Matrix.blockTopRows r₁ s)) * stinespringV K) from by
+        rw [Matrix.conjTranspose_mul]
+        simp only [Matrix.mul_assoc]]
+      rw [← stinespringV_eq_kronecker_blockTopRows_mul_append K₁ Lh]
+      have : (stinespringV K₁)ᴴ *
+          Matrix.kroneckerMap (· * ·) A (1 : Matrix (Fin r₁) (Fin r₁) ℂ) *
+          stinespringV K₁ =
+          (stinespringV K₁)ᴴ * stinespringPi (r := r₁) A * stinespringV K₁ := rfl
+      rw [this, ← hK₁]
+    -- Now T₂(A) = (T₁+T₂)(A) - T₁(A), and decompose the Kronecker product.
+    have h_bot_decomp :
+        Matrix.kroneckerMap (· * ·) A
+          (Matrix.blockDiagBotProj r₁ s) =
+        Matrix.kroneckerMap (· * ·) A
+          (1 : Matrix (Fin (r₁ + s)) (Fin (r₁ + s)) ℂ) -
+        Matrix.kroneckerMap (· * ·) A
+          (Matrix.blockDiagTopProj r₁ s) := by
+      rw [Matrix.blockDiagBotProj]
+      ext ⟨i, j⟩ ⟨i', j'⟩
+      simp [Matrix.kroneckerMap, Matrix.sub_apply, mul_sub]
+    calc T₂ A
+        = (T₁ A + T₂ A) - T₁ A := by abel
+      _ = (stinespringV K)ᴴ *
+            stinespringPi (r := r₁ + s) A *
+            stinespringV K - T₁ A := by rw [hT_decomp]
+      _ = (stinespringV K)ᴴ *
+            Matrix.kroneckerMap (· * ·) A
+              (1 : Matrix (Fin (r₁ + s)) (Fin (r₁ + s)) ℂ) *
+            stinespringV K -
+          (stinespringV K)ᴴ *
+            Matrix.kroneckerMap (· * ·) A
+              (Matrix.blockDiagTopProj r₁ s) *
+            stinespringV K := by
+          rw [hT₁_kron]
+          rfl
+      _ = (stinespringV K)ᴴ *
+            (Matrix.kroneckerMap (· * ·) A
+              (1 : Matrix (Fin (r₁ + s)) (Fin (r₁ + s)) ℂ) -
+             Matrix.kroneckerMap (· * ·) A
+              (Matrix.blockDiagTopProj r₁ s)) *
+            stinespringV K := by
+          rw [Matrix.mul_sub, Matrix.sub_mul]
+      _ = (stinespringV K)ᴴ *
+            Matrix.kroneckerMap (· * ·) A
+              (Matrix.blockDiagBotProj r₁ s) *
+            stinespringV K := by rw [← h_bot_decomp]
+
+/-! ### Wolf Theorem 2.5 (open-system representation) -/
+
+/-- **Wolf Theorem 2.5 (open-system representation, reduced form)**.
+
+Every CPTP quantum channel `T` admits a Stinespring isometric dilation `V`
+realizing `T` as the reduced dynamics
+  `T(ρ)_{ij} = ∑ₖ (V ρ V†)_{(i,k),(j,k)}`
+on a system-plus-environment Hilbert space. Equivalently `T(ρ) = tr_r(VρV†)`.
+
+This is the "reduced" form of Wolf's Thm 2.5; the full system-plus-environment
+unitary form follows by extending `V` to a unitary `U` on `ℂ^D ⊗ ℂ^r` and
+writing `V = U(𝟙 ⊗ |0⟩)`, which requires an orthonormal basis extension.
+The isometric form here already carries the essential physical content:
+`T` arises from coupling the system to an environment and tracing it out. -/
+theorem IsChannel.exists_stinespring_open_system
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsChannel T) :
+    ∃ (r : ℕ) (V : Matrix (Fin D × Fin r) (Fin D) ℂ),
+      Vᴴ * V = 1 ∧
+      ∀ (ρ : Matrix (Fin D) (Fin D) ℂ) (i j : Fin D),
+        (T ρ) i j = ∑ k : Fin r, (V * ρ * Vᴴ) (i, k) (j, k) := by
+  obtain ⟨r, K, hkSchr, hVisom⟩ := exists_stinespring_isometry_of_cptp T hT.cp hT.tp
+  refine ⟨r, stinespringV K, hVisom, ?_⟩
+  intro ρ i j
+  exact hkSchr ρ i j
+
+/-- **Wolf Theorem 2.5, partial-trace form**.
+
+Equivalent reformulation of the open-system representation expressed via
+`Matrix.traceRight`, matching Wolf's statement
+`T(ρ) = tr_E[V ρ V†]`. -/
+theorem IsChannel.exists_stinespring_open_system_traceRight
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsChannel T) :
+    ∃ (r : ℕ) (V : Matrix (Fin D × Fin r) (Fin D) ℂ),
+      Vᴴ * V = 1 ∧
+      ∀ ρ : Matrix (Fin D) (Fin D) ℂ, T ρ = (V * ρ * Vᴴ).traceRight := by
+  obtain ⟨r, V, hiso, hschr⟩ := hT.exists_stinespring_open_system
+  refine ⟨r, V, hiso, ?_⟩
+  intro ρ
+  ext i j
+  rw [hschr ρ i j]
+  simp [Matrix.traceRight]

--- a/TNLean/Channel/RadonNikodym.lean
+++ b/TNLean/Channel/RadonNikodym.lean
@@ -12,8 +12,8 @@ This file formalizes the canonical Radon–Nikodym theorem for completely
 positive maps (Wolf Thm 2.4) and the open-system representation theorem
 (Wolf Thm 2.5).
 
-The Radon–Nikodym theorem says: if `T = T₁ + T₂` with both CP and `V` is a
-Stinespring isometry of `T`, then there exist PSD operators `P₁, P₂` on the
+The Radon–Nikodym theorem says: for CP maps `T₁, T₂`, there exist a
+Stinespring matrix `V` for `T₁ + T₂` and PSD operators `P₁, P₂` on the
 dilation space with `P₁ + P₂ = 𝟙` such that `Tᵢ(A) = V†(A ⊗ Pᵢ)V`. In our
 canonical realization, `V` is built from concatenated Kraus families of
 `T₁` and `T₂`, and `P₁, P₂` are the orthogonal block projectors.
@@ -35,10 +35,9 @@ evolution on a system-plus-environment.
   the identity: resolution of identity on the dilation space.
 * `Matrix.blockDiagTopProj_posSemidef`,
   `Matrix.blockDiagBotProj_posSemidef` — both are PSD.
-* `CPDominates.exists_radon_nikodym` (Wolf Thm 2.4 binary form):
-  if `T = T₁ + T₂` with both CP, there exist a Stinespring isometry `V` and
-  two PSD "density" operators `P₁, P₂` with `P₁ + P₂ = 𝟙` such that
-  `Tᵢ(A) = V†(A ⊗ Pᵢ)V`.
+* `IsCPMap.exists_radon_nikodym` (Wolf Thm 2.4 binary form):
+  for CP `T₁, T₂`, there exist a Stinespring matrix `V` and two PSD
+  operators `P₁, P₂` with `P₁ + P₂ = 𝟙` such that `Tᵢ(A) = V†(A ⊗ Pᵢ)V`.
 * `IsChannel.exists_stinespring_open_system` (Wolf Thm 2.5 reduced form):
   every CPTP map admits an isometric Stinespring dilation realizing it as
   the reduced dynamics `T(ρ) = tr_r(V ρ V†)`.
@@ -141,20 +140,20 @@ theorem Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap
 
 /-- **Wolf Theorem 2.4 (Radon–Nikodym for CP maps, binary form)**.
 
-If `T = T₁ + T₂` with both `T₁, T₂` completely positive, then there exist:
+For completely positive maps `T₁, T₂`, there exist:
 
 * an ancilla dimension `m`,
-* a Stinespring-type isometric family `K : Fin m → M_D(ℂ)` with associated
-  Stinespring matrix `V = stinespringV K`,
+* a Kraus family `K : Fin m → M_D(ℂ)` with associated Stinespring matrix
+  `V = stinespringV K`,
 * two **positive operators** `P₁, P₂ : M_m(ℂ)` on the dilation space,
 * with `P₁ + P₂ = 𝟙_m`,
 
-such that each `Tᵢ` is recovered by the "weighted" Stinespring formula
+such that each `Tᵢ` is recovered by the weighted Stinespring formula
 `Tᵢ(A) = V† (A ⊗ Pᵢ) V`.
 
-In the canonical realization returned below, the Kraus family of `T` is the
-append of the Kraus families of `T₁` and `T₂`, and `P₁, P₂` are the
-orthogonal block projectors onto the two halves of the dilation space. -/
+In the canonical realization returned below, `K` is the append of the Kraus
+families of `T₁` and `T₂`, and `P₁, P₂` are the orthogonal block projectors
+onto the two halves of the dilation space. -/
 theorem IsCPMap.exists_radon_nikodym
     {T₁ T₂ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT₁ : IsCPMap T₁) (hT₂ : IsCPMap T₂) :

--- a/TNLean/Channel/RadonNikodym.lean
+++ b/TNLean/Channel/RadonNikodym.lean
@@ -84,35 +84,12 @@ theorem Matrix.blockDiagBotProj_posSemidef (r s : ℕ) :
   rw [Matrix.le_iff] at this
   exact this
 
-/-- `P_top` is Hermitian, needed when forming Kronecker products. -/
-theorem Matrix.blockDiagTopProj_isHermitian (r s : ℕ) :
-    (Matrix.blockDiagTopProj r s).IsHermitian :=
-  (Matrix.blockDiagTopProj_posSemidef r s).isHermitian
-
-/-- `P_bot` is Hermitian. -/
-theorem Matrix.blockDiagBotProj_isHermitian (r s : ℕ) :
-    (Matrix.blockDiagBotProj r s).IsHermitian :=
-  (Matrix.blockDiagBotProj_posSemidef r s).isHermitian
-
-/-! ### Entrywise formulas for the block projectors -/
+/-! ### Entrywise formula for the top-block projector -/
 
 theorem Matrix.blockDiagTopProj_apply (r s : ℕ) (j j' : Fin (r + s)) :
     Matrix.blockDiagTopProj r s j j' =
       if j = j' ∧ (j : ℕ) < r then 1 else 0 :=
   Matrix.blockTopRows_conjTranspose_mul_apply r s j j'
-
-theorem Matrix.blockDiagBotProj_apply (r s : ℕ) (j j' : Fin (r + s)) :
-    Matrix.blockDiagBotProj r s j j' =
-      if j = j' ∧ ¬ (j : ℕ) < r then 1 else 0 := by
-  simp only [Matrix.blockDiagBotProj, Matrix.sub_apply, Matrix.one_apply,
-    Matrix.blockDiagTopProj_apply]
-  by_cases hjj : j = j'
-  · subst hjj
-    by_cases hjr : (j : ℕ) < r
-    · simp [hjr]
-    · simp [hjr]
-  · have hne : j' ≠ j := fun h => hjj h.symm
-    simp [hjj]
 
 /-! ### The key Kronecker identity: `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙)(𝟙 ⊗ C)` -/
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -72,7 +72,7 @@ representations of quantum channels.
   - `stinespringV_eq_kronecker_blockTopRows_mul_append` — intertwining
     `V_{K} = (𝟙_D ⊗ C) · V_{K ++ L}` for the block-top projector ✅
   - `CPDominates.exists_stinespring_contraction` — existential form of
-    Wolf Thm 2.3: `T₁ ≤ T₂` gives Stinespring isometries and a contraction ✅
+    Wolf Thm 2.3: `T₁ ≤ T₂` gives Stinespring realizations and a contraction ✅
 
 * **Thm 2.4** (Radon–Nikodym for CP maps):
   - `Matrix.blockDiagTopProj` / `Matrix.blockDiagBotProj` — orthogonal
@@ -80,7 +80,8 @@ representations of quantum channels.
   - `Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap` — Kronecker
     identity `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙) (𝟙 ⊗ C)` ✅
   - `IsCPMap.exists_radon_nikodym` — Wolf Thm 2.4 binary form:
-    `T = T₁ + T₂` CP gives PSD `P₁ + P₂ = 𝟙` with `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✅
+    for CP `T₁, T₂`, a Stinespring matrix for `T₁ + T₂` yields
+    PSD `P₁ + P₂ = 𝟙` with `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✅
 
 * **Thm 2.5** (open-system representation, reduced form):
   - `IsChannel.exists_stinespring_open_system` — every CPTP map is
@@ -185,9 +186,9 @@ representations of quantum channels.
 | Result | Notes |
 |--------|-------|
 | Prop 2.4 (equiv of ensembles, necessity) | Needs purification/Schmidt decomp |
-| Thm 2.5 (unitary form) | Isometric form is formalized; unitary form needs basis extension |
-| §2.3 Lorentz normal form (existence) | Needs compactness / minimisation over `SL(2, ℂ)` filterings (Wolf Prop 2.9 / Prop 2.11) |
-| §2.3 Sorted / unique singular values | `svd_of_isUnit` is unsorted; downstream normal-form uses will want the sorted variant |
+| Thm 2.5 (unitary form) | Isometric form formalized; unitary form needs basis extension |
+| §2.3 Lorentz normal form | Needs compactness over `SL(2, ℂ)` filterings |
+| §2.3 Sorted singular values | Current SVD is unsorted; later uses want sorted values |
 
 ## References
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -10,6 +10,8 @@ import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.Stinespring
+import TNLean.Channel.OrderedCP
+import TNLean.Channel.RadonNikodym
 import TNLean.Channel.POVM
 import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
@@ -61,6 +63,30 @@ representations of quantum channels.
   - `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` ✅
   - `stinespringV_isometry_iff_kraus_normalized` — `V†V = 𝟙` ↔ TP ✅
   - `stinespring_schrodinger_representation` — `T(ρ) = tr_r(VρV†)` ✅
+
+* **Thm 2.3** (ordered CP-maps):
+  - `CPDominates` — CP partial order: `S - T` is completely positive ✅
+  - `Matrix.blockTopRows` / `Matrix.blockTopRows_mul_conjTranspose` /
+    `Matrix.blockTopRows_conjTranspose_mul_le_one` — explicit block-top
+    contraction on the dilation space ✅
+  - `stinespringV_eq_kronecker_blockTopRows_mul_append` — intertwining
+    `V_{K} = (𝟙_D ⊗ C) · V_{K ++ L}` for the block-top projector ✅
+  - `CPDominates.exists_stinespring_contraction` — existential form of
+    Wolf Thm 2.3: `T₁ ≤ T₂` gives Stinespring isometries and a contraction ✅
+
+* **Thm 2.4** (Radon–Nikodym for CP maps):
+  - `Matrix.blockDiagTopProj` / `Matrix.blockDiagBotProj` — orthogonal
+    block projectors on the dilation space, PSD and summing to `𝟙` ✅
+  - `Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap` — Kronecker
+    identity `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙) (𝟙 ⊗ C)` ✅
+  - `IsCPMap.exists_radon_nikodym` — Wolf Thm 2.4 binary form:
+    `T = T₁ + T₂` CP gives PSD `P₁ + P₂ = 𝟙` with `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✅
+
+* **Thm 2.5** (open-system representation, reduced form):
+  - `IsChannel.exists_stinespring_open_system` — every CPTP map is
+    `T(ρ)_{ij} = ∑ₖ (V ρ V†)_{(i,k),(j,k)}` for an isometric `V` ✅
+  - `IsChannel.exists_stinespring_open_system_traceRight` — equivalent
+    form via `Matrix.traceRight`: `T(ρ) = tr_E[V ρ V†]` ✅
 
 * **Thm 2.6** (Naimark / Neumark dilation for POVMs):
   - `POVM` — positive operator-valued measure structure ✅
@@ -159,9 +185,7 @@ representations of quantum channels.
 | Result | Notes |
 |--------|-------|
 | Prop 2.4 (equiv of ensembles, necessity) | Needs purification/Schmidt decomp |
-| Thm 2.3 (ordered CP-maps) | Needs Stinespring + contraction |
-| Thm 2.4 (Radon-Nikodym) | Follows from Thm 2.3 |
-| Thm 2.5 (open-system representation) | Embedding into unitary |
+| Thm 2.5 (unitary form) | Isometric form is formalized; unitary form needs basis extension |
 | §2.3 Lorentz normal form (existence) | Needs compactness / minimisation over `SL(2, ℂ)` filterings (Wolf Prop 2.9 / Prop 2.11) |
 | §2.3 Sorted / unique singular values | `svd_of_isUnit` is unsorted; downstream normal-form uses will want the sorted variant |
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1497,6 +1497,205 @@ representations already developed above. They correspond to
 \end{proof}
 
 %% =========================================================
+\section{Ordered CP maps, Radon--Nikodym, and open-system representation}
+\label{sec:ordered_cp}
+%% =========================================================
+
+The next three results form the structural package of~\cite[Thms.~2.3--2.5]{Wolf2012Quantum}:
+the ordered CP-map theorem, the Radon--Nikodym theorem for completely positive
+maps, and the open-system representation. They refine the Stinespring dilation
+by tracking how two CP maps related by domination or decomposition sit inside
+a common dilation space.
+
+\begin{definition}[CP partial order]\label{def:cp_dominates}
+    \lean{CPDominates}
+    \leanok
+    \uses{def:cp_map}
+    For linear maps $S, T : \MN{D} \to \MN{D}$, write $T \le S$ (in the CP
+    order) when $S - T$ is completely positive.
+\end{definition}
+
+\begin{definition}[Block-top contraction]\label{def:block_top_rows}
+    \lean{Matrix.blockTopRows}
+    \leanok
+    For natural numbers $r, s$, let $C = C_{r,s} \in \MN{}(\C)$ be the
+    rectangular $r \times (r+s)$ matrix whose rows are the first $r$ rows
+    of the identity on $\C^{r+s}$: $C_{ij} = 1$ if $j = i < r$ and $0$
+    otherwise.
+\end{definition}
+
+\begin{lemma}[$C$ is a co-isometry]\label{lem:block_top_rows_co_isometry}
+    \lean{Matrix.blockTopRows_mul_conjTranspose}
+    \leanok
+    \uses{def:block_top_rows}
+    The block-top matrix satisfies $C C^\dagger = \Id_r$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Direct entrywise computation: $(C C^\dagger)_{ii'} = \sum_j C_{ij}\overline{C_{i'j}}$
+    collapses to $\delta_{ii'}$.
+\end{proof}
+
+\begin{lemma}[$C$ is a contraction]\label{lem:block_top_rows_contraction}
+    \lean{Matrix.blockTopRows_conjTranspose_mul_le_one}
+    \leanok
+    \uses{def:block_top_rows}
+    The block-top matrix satisfies $C^\dagger C \le \Id_{r+s}$.
+\end{lemma}
+
+\begin{proof}\leanok
+    The matrix $C^\dagger C$ is diagonal with a $1$ on the first $r$
+    coordinates and a $0$ on the last $s$, so $\Id - C^\dagger C$ is
+    positive semidefinite.
+\end{proof}
+
+\begin{lemma}[Intertwining of Stinespring isometries]\label{lem:stinespring_intertwine_append}
+    \lean{stinespringV_eq_kronecker_blockTopRows_mul_append}
+    \leanok
+    \uses{def:stinespring_v, def:block_top_rows}
+    Let $K : \{0,\ldots,r-1\} \to \MN{D}$ and $L : \{0,\ldots,s-1\} \to \MN{D}$
+    be two Kraus families. Write $K\mathbin{+\!+}L$ for their concatenation
+    as a family indexed by $\{0,\ldots,r+s-1\}$. Then
+    \[
+        V_K = (\Id_D \otimes C_{r,s}) V_{K + \! + L}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Entrywise expansion of both sides: the Kronecker product with $C_{r,s}$
+    picks out the first $r$ coordinates of the dilation space, matching the
+    action of $V_{K + \! + L}$ on those coordinates, which is precisely $V_K$.
+\end{proof}
+
+\begin{theorem}[Ordered CP maps, Wolf Thm.~2.3]\label{thm:cp_dominates_stinespring_contraction}
+    \lean{CPDominates.exists_stinespring_contraction}
+    \leanok
+    \uses{def:cp_dominates, def:stinespring_v, def:block_top_rows,
+          lem:block_top_rows_contraction, lem:stinespring_intertwine_append}
+    Let $T_1, T_2 : \MN{D} \to \MN{D}$ be CP maps with $T_1 \le T_2$.
+    Then there exist an ancilla dimension $m$, Stinespring isometries
+    $V_1, V_2$ realizing $T_1, T_2$ in the Heisenberg form
+    $T_i(A) = V_i^\dagger (A \otimes \Id) V_i$, and a contraction
+    $\widetilde C$ on the dilation space with $\widetilde C^\dagger
+    \widetilde C \le \Id$ such that
+    \[
+        V_1 = (\Id_D \otimes \widetilde C)\, V_2.
+    \]
+    This is~\cite[Thm.~2.3]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:exists_stinespring_dilation, lem:block_top_rows_contraction,
+          lem:stinespring_intertwine_append}
+    Choose a Heisenberg-form Kraus family $K_1$ of $T_1$ with Stinespring
+    isometry $V_1 = V_{K_1}$, and Kraus operators $L$ of the CP map
+    $T_2 - T_1$ in Schr\"odinger orientation. Let $L^\dagger$ denote the
+    conjugate-transposed family. Set $m = r_1 + s$ and let
+    $K_2 = K_1 \mathbin{+\!+} L^\dagger$. Then
+    $T_2(A) = T_1(A) + (T_2 - T_1)(A)
+           = \sum_i (K_1^i)^\dagger A K_1^i + \sum_j L_j A L_j^\dagger$,
+    and the latter equals
+    $\sum_i (K_1^i)^\dagger A K_1^i + \sum_j (L_j^\dagger)^\dagger A L_j^\dagger$
+    which is the Heisenberg form for $K_2$, yielding
+    $T_2(A) = V_{K_2}^\dagger (A \otimes \Id) V_{K_2}$. Taking
+    $\widetilde C = C_{r_1, s}$ the intertwining
+    $V_{K_1} = (\Id_D \otimes \widetilde C) V_{K_2}$ is
+    Lemma~\ref{lem:stinespring_intertwine_append}, and
+    $\widetilde C^\dagger \widetilde C \le \Id$ is
+    Lemma~\ref{lem:block_top_rows_contraction}.
+\end{proof}
+
+\begin{definition}[Block-diagonal projectors on the dilation space]
+    \label{def:block_diag_projectors}
+    \lean{Matrix.blockDiagTopProj, Matrix.blockDiagBotProj}
+    \leanok
+    \uses{def:block_top_rows}
+    For $r, s$, let $P_{\mathrm{top}} = C_{r,s}^\dagger C_{r,s}$ and
+    $P_{\mathrm{bot}} = \Id - P_{\mathrm{top}}$. Both are PSD and
+    $P_{\mathrm{top}} + P_{\mathrm{bot}} = \Id$.
+\end{definition}
+
+\begin{theorem}[Radon--Nikodym for CP maps, Wolf Thm.~2.4]
+    \label{thm:cp_exists_radon_nikodym}
+    \lean{IsCPMap.exists_radon_nikodym}
+    \leanok
+    \uses{def:cp_map, def:stinespring_v, def:block_diag_projectors}
+    Let $T_1, T_2 : \MN{D} \to \MN{D}$ be completely positive. There exist
+    an ancilla dimension $m$, a Kraus family $K$ with Stinespring isometry
+    $V = V_K$, and positive semidefinite operators
+    $P_1, P_2 : \C^m \to \C^m$ with $P_1 + P_2 = \Id_m$ such that, for
+    every $A \in \MN{D}$,
+    \[
+        T_i(A) = V^\dagger (A \otimes P_i) V, \qquad i = 1, 2.
+    \]
+    This is~\cite[Thm.~2.4]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cp_dominates_stinespring_contraction, thm:exists_stinespring_dilation,
+          def:block_diag_projectors}
+    Take Heisenberg-form Kraus families $K_1$ for $T_1$ and
+    Schr\"odinger-form $L$ for $T_2$, and form $K = K_1 \mathbin{+\!+} L^\dagger$
+    on $\C^{r_1 + s}$. Choose $P_1 = P_{\mathrm{top}}$, $P_2 = P_{\mathrm{bot}}$
+    as in Definition~\ref{def:block_diag_projectors}. The Kronecker
+    identity $A \otimes (C^\dagger C) = (\Id \otimes C)^\dagger (A \otimes \Id)
+    (\Id \otimes C)$ rewrites $V^\dagger (A \otimes P_{\mathrm{top}}) V$ as
+    $((\Id \otimes C) V)^\dagger (A \otimes \Id) ((\Id \otimes C) V)$,
+    which equals $V_{K_1}^\dagger (A \otimes \Id) V_{K_1} = T_1(A)$ by
+    the intertwining Lemma~\ref{lem:stinespring_intertwine_append}. For the
+    complementary block, $A \otimes P_{\mathrm{bot}} = A \otimes \Id -
+    A \otimes P_{\mathrm{top}}$ and sandwiching by $V$ yields
+    $(T_1 + T_2)(A) - T_1(A) = T_2(A)$.
+\end{proof}
+
+\begin{theorem}[Open-system representation, Wolf Thm.~2.5 (isometric form)]
+    \label{thm:channel_exists_stinespring_open_system}
+    \lean{IsChannel.exists_stinespring_open_system}
+    \leanok
+    \uses{def:channel, def:stinespring_v, def:partial_trace}
+    Every quantum channel $T : \MN{D} \to \MN{D}$ admits a Stinespring
+    isometry $V$ on an ancilla space $\C^r$ such that
+    \[
+        T(\rho)_{ij} = \sum_{k=0}^{r-1} (V \rho V^\dagger)_{(i,k),(j,k)}
+        = \operatorname{tr}_r(V \rho V^\dagger).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:exists_stinespring_isometry_of_cptp,
+          thm:stinespring_schrodinger_representation}
+    Apply the existence of an isometric Stinespring dilation
+    (Theorem~\ref{thm:exists_stinespring_isometry_of_cptp}) and the
+    Schr\"odinger-picture identity
+    (Theorem~\ref{thm:stinespring_schrodinger_representation}).
+\end{proof}
+
+\begin{theorem}[Open-system representation, partial-trace form]
+    \label{thm:channel_exists_stinespring_open_system_traceRight}
+    \lean{IsChannel.exists_stinespring_open_system_traceRight}
+    \leanok
+    \uses{def:channel, def:stinespring_v, def:partial_trace}
+    Every quantum channel $T$ admits an isometric Stinespring dilation
+    $V$ such that $T(\rho) = \operatorname{tr}_E(V \rho V^\dagger)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:channel_exists_stinespring_open_system}
+    Rewrite the componentwise identity of
+    Theorem~\ref{thm:channel_exists_stinespring_open_system} as a partial
+    trace over the ancilla factor.
+\end{proof}
+
+\begin{remark}[Unitary form]
+    The fully unitary open-system form
+    $T(\rho) = \operatorname{tr}_E(U (\rho \otimes \ketbra{\phi}{\phi})
+    U^\dagger)$ of~\cite[Thm.~2.5]{Wolf2012Quantum} follows from the
+    isometric form by extending the Stinespring isometry $V$ to a unitary
+    $U$ on $\C^D \otimes \C^r$; this uses orthonormal basis extension and
+    is recorded as an outstanding formalization item.
+\end{remark}
+
+%% =========================================================
 \section{POVMs and Naimark dilation}
 \label{sec:povm_naimark}
 %% =========================================================

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1573,8 +1573,8 @@ a common dilation space.
     \uses{def:cp_dominates, def:stinespring_v, def:block_top_rows,
           lem:block_top_rows_contraction, lem:stinespring_intertwine_append}
     Let $T_1, T_2 : \MN{D} \to \MN{D}$ be CP maps with $T_1 \le T_2$.
-    Then there exist an ancilla dimension $m$, Stinespring isometries
-    $V_1, V_2$ realizing $T_1, T_2$ in the Heisenberg form
+    Then there exist an ancilla dimension $m$, Heisenberg-form Stinespring
+    matrices $V_1, V_2$ realizing $T_1, T_2$ via
     $T_i(A) = V_i^\dagger (A \otimes \Id) V_i$, and a contraction
     $\widetilde C$ on the dilation space with $\widetilde C^\dagger
     \widetilde C \le \Id$ such that
@@ -1588,7 +1588,7 @@ a common dilation space.
     \uses{thm:exists_stinespring_dilation, lem:block_top_rows_contraction,
           lem:stinespring_intertwine_append}
     Choose a Heisenberg-form Kraus family $K_1$ of $T_1$ with Stinespring
-    isometry $V_1 = V_{K_1}$, and Kraus operators $L$ of the CP map
+    matrix $V_1 = V_{K_1}$, and Kraus operators $L$ of the CP map
     $T_2 - T_1$ in Schr\"odinger orientation. Let $L^\dagger$ denote the
     conjugate-transposed family. Set $m = r_1 + s$ and let
     $K_2 = K_1 \mathbin{+\!+} L^\dagger$. Then
@@ -1609,10 +1609,11 @@ a common dilation space.
     \label{def:block_diag_projectors}
     \lean{Matrix.blockDiagTopProj, Matrix.blockDiagBotProj}
     \leanok
-    \uses{def:block_top_rows}
+    \uses{def:block_top_rows, lem:block_top_rows_contraction}
     For $r, s$, let $P_{\mathrm{top}} = C_{r,s}^\dagger C_{r,s}$ and
-    $P_{\mathrm{bot}} = \Id - P_{\mathrm{top}}$. Both are PSD and
-    $P_{\mathrm{top}} + P_{\mathrm{bot}} = \Id$.
+    $P_{\mathrm{bot}} = \Id - P_{\mathrm{top}}$. Both are PSD
+    (for $P_{\mathrm{bot}}$, by Lemma~\ref{lem:block_top_rows_contraction})
+    and $P_{\mathrm{top}} + P_{\mathrm{bot}} = \Id$.
 \end{definition}
 
 \begin{theorem}[Radon--Nikodym for CP maps, Wolf Thm.~2.4]
@@ -1621,7 +1622,7 @@ a common dilation space.
     \leanok
     \uses{def:cp_map, def:stinespring_v, def:block_diag_projectors}
     Let $T_1, T_2 : \MN{D} \to \MN{D}$ be completely positive. There exist
-    an ancilla dimension $m$, a Kraus family $K$ with Stinespring isometry
+    an ancilla dimension $m$, a Kraus family $K$ with Stinespring matrix
     $V = V_K$, and positive semidefinite operators
     $P_1, P_2 : \C^m \to \C^m$ with $P_1 + P_2 = \Id_m$ such that, for
     every $A \in \MN{D}$,


### PR DESCRIPTION
Addresses LionSR/QICLean#13

Auto-created by Claude Code action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial new Lean formalization and exposes it via root imports, which may impact downstream compile time and introduce new notation/lemmas into the public surface, but does not change existing proofs or core definitions.
> 
> **Overview**
> Formalizes Wolf Chapter 2 theorems **2.3–2.5** by adding the CP-domination order (`CPDominates`), an explicit dilation-space contraction (`Matrix.blockTopRows`) and its key properties, and the resulting Stinespring intertwining/contraction existence theorem.
> 
> Builds on this to add a **Radon–Nikodym theorem for CP maps** (`IsCPMap.exists_radon_nikodym`) using canonical block projectors and a Kronecker identity, and an **open-system representation** for channels (`IsChannel.exists_stinespring_open_system` plus `traceRight` form).
> 
> Updates the public import surface (`TNLean.lean`), the Chapter 2 index, and the blueprint text to include and document these new results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e889e7f0f2376b0b6534b3982f44146b637fd035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->