### PR TITLE
feat(MPS/Chain): gauge-phase contraction theorem for injective chains (#873)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -152,6 +152,7 @@ import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.FundamentalTheorem
+import TNLean.MPS.Chain.GaugePhase
 import TNLean.MPS.Chain.BlockedChainFT
 import TNLean.MPS.Chain.SameStateBridge
 import TNLean.MPS.Chain.TranslationInvariance

--- a/TNLean/MPS/Chain/GaugePhase.lean
+++ b/TNLean/MPS/Chain/GaugePhase.lean
@@ -1,0 +1,115 @@
+import TNLean.MPS.Chain.FundamentalTheorem
+
+/-!
+# Gauge-phase variant of the injective-chain Fundamental Theorem
+
+This file upgrades the exact injective-chain Fundamental Theorem to the case
+where the two **combined tensors** agree only up to a nonzero scalar.  The
+result is the chain-level contraction statement needed in periodic Case 3:
+from a gauge-phase equivalence of the full $m$-factor product tensor one
+recovers a cyclic gauge on the underlying chain together with a **common**
+nonzero phase on every site.
+
+## Main declarations
+
+* `MPSTensor.chainCombinedTensor_smul_chain`
+* `MPSChainTensor.fundamentalTheorem_injective_chain_gaugePhase`
+
+## Mathematical idea
+
+If
+$$
+\mathrm{chainCombinedTensor}(B)
+  = \zeta \cdot X \, \mathrm{chainCombinedTensor}(A) \, X^{-1},
+$$
+then rescaling every site tensor of `B` by `ζ⁻¹` removes the global scalar on
+its combined tensor.  The exact chain Fundamental Theorem then applies to the
+rescaled chain, and multiplying the site relations back by `ζ` gives the
+required cyclic gauge-phase relation.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Rescaling every site tensor in a chain rescales the combined tensor by the
+same scalar. -/
+@[simp] theorem chainCombinedTensor_smul_chain {n : ℕ}
+    (A : Fin n → MPSTensor d D) (ζ : ℂ) :
+    chainCombinedTensor (fun k i => ζ • A k i) = ζ • chainCombinedTensor A := by
+  funext j
+  simp [chainCombinedTensor]
+
+end MPSTensor
+
+namespace MPSChainTensor
+
+open MPSTensor
+
+variable {d D n : ℕ}
+
+/-- **Injective-chain contraction up to phase.**
+
+If the combined tensors of two chains are gauge-phase equivalent, then the
+chains themselves are cyclically gauge equivalent with one common nonzero phase
+`ζ` multiplying every site tensor of `A`.
+
+This is the finite-chain `$m$-factor cyclic contraction` used by the periodic
+Case-3 program: once a cyclic family of sector-transition tensors is packaged
+as an injective chain and its full product tensor is known to be
+`GaugePhaseEquiv`, the conclusion recovers sitewise proportionality with a
+cyclic gauge. -/
+theorem fundamentalTheorem_injective_chain_gaugePhase
+    (A B : MPSChainTensor d D n)
+    (hA : IsInjective A)
+    (hGauge : MPSTensor.GaugePhaseEquiv
+      (MPSTensor.chainCombinedTensor A)
+      (MPSTensor.chainCombinedTensor B)) :
+    ∃ Z : Fin n → GL (Fin D) ℂ,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧
+        ∀ k : Fin n, ∀ i : Fin d,
+          B k i =
+            ζ • ((Z k : Matrix (Fin D) (Fin D) ℂ) * A k i *
+              (((Z (cyclicSucc k))⁻¹ : GL (Fin D) ℂ) :
+                Matrix (Fin D) (Fin D) ℂ)) := by
+  rcases hGauge with ⟨X, ζ, hζ, hX⟩
+  let B' : MPSChainTensor d D n := fun k i => ζ⁻¹ • B k i
+  have hCombinedGauge :
+      MPSTensor.GaugeEquiv
+        (MPSTensor.chainCombinedTensor A)
+        (MPSTensor.chainCombinedTensor B') := by
+    refine ⟨X, ?_⟩
+    intro j
+    calc
+      MPSTensor.chainCombinedTensor B' j
+          = ζ⁻¹ • MPSTensor.chainCombinedTensor B j := by
+              simp [B', MPSTensor.chainCombinedTensor]
+      _ = ζ⁻¹ •
+            (ζ • ((X : Matrix (Fin D) (Fin D) ℂ) *
+              MPSTensor.chainCombinedTensor A j *
+              ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) := by
+            rw [hX j]
+      _ = ((X : Matrix (Fin D) (Fin D) ℂ) * MPSTensor.chainCombinedTensor A j *
+            ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
+            simp [smul_smul, hζ]
+  have hSame :
+      MPSTensor.SameMPV
+        (MPSTensor.chainCombinedTensor A)
+        (MPSTensor.chainCombinedTensor B') :=
+    MPSTensor.GaugeEquiv.sameMPV hCombinedGauge
+  obtain ⟨Z, hZ⟩ := fundamentalTheorem_injective_chain A B' hA hSame
+  refine ⟨Z, ζ, hζ, ?_⟩
+  intro k i
+  calc
+    B k i
+        = ζ • B' k i := by
+            simp [B', smul_smul, hζ]
+    _ = ζ •
+          ((Z k : Matrix (Fin D) (Fin D) ℂ) * A k i *
+            (((Z (cyclicSucc k))⁻¹ : GL (Fin D) ℂ) :
+              Matrix (Fin D) (Fin D) ℂ)) := by
+          rw [hZ k i]
+
+end MPSChainTensor

--- a/TNLean/MPS/Chain/GaugePhase.lean
+++ b/TNLean/MPS/Chain/GaugePhase.lean
@@ -6,9 +6,9 @@ import TNLean.MPS.Chain.FundamentalTheorem
 This file upgrades the exact injective-chain Fundamental Theorem to the case
 where the two **combined tensors** agree only up to a nonzero scalar.  The
 result is the chain-level contraction statement needed in periodic Case 3:
-from a gauge-phase equivalence of the full $m$-factor product tensor one
-recovers a cyclic gauge on the underlying chain together with a **common**
-nonzero phase on every site.
+from a gauge-phase equivalence between `chainCombinedTensor A` and
+`chainCombinedTensor B`, one recovers a cyclic gauge on the underlying chain
+together with a **common** nonzero phase on every site.
 
 ## Main declarations
 
@@ -36,7 +36,7 @@ variable {d D : ℕ}
 
 /-- Rescaling every site tensor in a chain rescales the combined tensor by the
 same scalar. -/
-@[simp] theorem chainCombinedTensor_smul_chain {n : ℕ}
+theorem chainCombinedTensor_smul_chain {n : ℕ}
     (A : Fin n → MPSTensor d D) (ζ : ℂ) :
     chainCombinedTensor (fun k i => ζ • A k i) = ζ • chainCombinedTensor A := by
   funext j
@@ -57,10 +57,10 @@ chains themselves are cyclically gauge equivalent with one common nonzero phase
 `ζ` multiplying every site tensor of `A`.
 
 This is the finite-chain `$m$-factor cyclic contraction` used by the periodic
-Case-3 program: once a cyclic family of sector-transition tensors is packaged
-as an injective chain and its full product tensor is known to be
-`GaugePhaseEquiv`, the conclusion recovers sitewise proportionality with a
-cyclic gauge. -/
+Case-3 program: once a cyclic family of sector-transition tensors is
+formulated as an injective chain and the corresponding combined tensors are
+known to satisfy `GaugePhaseEquiv`, the conclusion recovers sitewise
+proportionality with a cyclic gauge. -/
 theorem fundamentalTheorem_injective_chain_gaugePhase
     (A B : MPSChainTensor d D n)
     (hA : IsInjective A)
@@ -85,7 +85,8 @@ theorem fundamentalTheorem_injective_chain_gaugePhase
     calc
       MPSTensor.chainCombinedTensor B' j
           = ζ⁻¹ • MPSTensor.chainCombinedTensor B j := by
-              simp [B', MPSTensor.chainCombinedTensor]
+              simpa [B'] using
+                congrFun (MPSTensor.chainCombinedTensor_smul_chain (A := B) (ζ := ζ⁻¹)) j
       _ = ζ⁻¹ •
             (ζ • ((X : Matrix (Fin D) (Fin D) ℂ) *
               MPSTensor.chainCombinedTensor A j *

--- a/TNLean/MPS/Chain/GaugePhase.lean
+++ b/TNLean/MPS/Chain/GaugePhase.lean
@@ -17,10 +17,10 @@ together with a **common** nonzero phase on every site.
 
 ## Mathematical idea
 
-If
+If $\widetilde A$ and $\widetilde B$ denote the combined tensors of `A` and
+`B`, and if
 $$
-\mathrm{chainCombinedTensor}(B)
-  = \zeta \cdot X \, \mathrm{chainCombinedTensor}(A) \, X^{-1},
+\widetilde B = \zeta \cdot X \, \widetilde A \, X^{-1},
 $$
 then rescaling every site tensor of `B` by `ζ⁻¹` removes the global scalar on
 its combined tensor.  The exact chain Fundamental Theorem then applies to the

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -403,10 +403,11 @@ reduction hypothesis.
     \uses{def:non_ti_chain}
     Let $\mathbf{A} = (A_0, \ldots, A_{n-1})$ be an $n$-site chain and let
     $\zeta \in \C$. If $\zeta \mathbf{A}$ denotes the chain obtained by
-    replacing each site tensor $A_k$ with $\zeta A_k$, then
+    replacing each site tensor $A_k$ with $\zeta A_k$, and if
+    $\widetilde{\mathbf{A}}$ denotes the combined tensor of $\mathbf{A}$,
+    then
     \[
-        \operatorname{chainCombinedTensor}(\zeta \mathbf{A})
-        = \zeta\, \operatorname{chainCombinedTensor}(\mathbf{A}).
+        \widetilde{\zeta \mathbf{A}} = \zeta\, \widetilde{\mathbf{A}}.
     \]
 \end{lemma}
 
@@ -441,7 +442,7 @@ reduction hypothesis.
 \begin{proof}
     \leanok
     \uses{lem:chainCombinedTensor_smul_chain,
-        thm:fundamentalTheorem_injective_chain}
+        thm:gauge_invariance, thm:fundamentalTheorem_injective_chain}
     If the combined tensor of $\mathbf{B}$ differs from that of $\mathbf{A}$
     by a gauge and a nonzero scalar $\zeta$, rescale each site of
     $\mathbf{B}$ by $\zeta^{-1}$. Lemma~\ref{lem:chainCombinedTensor_smul_chain}

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -395,6 +395,62 @@ reduction hypothesis.
     $Z_k = X$ is a cyclic gauge.
 \end{proof}
 
+
+\begin{lemma}[Uniform site rescaling rescales the combined tensor]%
+    \label{lem:chainCombinedTensor_smul_chain}
+    \lean{MPSTensor.chainCombinedTensor_smul_chain}
+    \leanok
+    \uses{def:non_ti_chain}
+    Let $\mathbf{A} = (A_0, \ldots, A_{n-1})$ be an $n$-site chain and let
+    $\zeta \in \C$. If $\zeta \mathbf{A}$ denotes the chain obtained by
+    replacing each site tensor $A_k$ with $\zeta A_k$, then
+    \[
+        \operatorname{chainCombinedTensor}(\zeta \mathbf{A})
+        = \zeta\, \operatorname{chainCombinedTensor}(\mathbf{A}).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:non_ti_chain}
+    Bundling the site and physical indices does not change which local matrix
+    is read at the component $(k,i)$, so both sides evaluate to
+    $\zeta A_k^i$ there.
+\end{proof}
+
+\begin{theorem}[Injective-chain Fundamental Theorem up to a global phase]%
+    \label{thm:fundamentalTheorem_injective_chain_gaugePhase}
+    \lean{MPSChainTensor.fundamentalTheorem_injective_chain_gaugePhase}
+    \leanok
+    \uses{thm:fundamentalTheorem_injective_chain, def:gauge_phase_equiv,
+        def:non_ti_chain}
+    Let $\mathbf{A} = (A_0, \ldots, A_{n-1})$ and
+    $\mathbf{B} = (B_0, \ldots, B_{n-1})$ be two $n$-site chains with common
+    bond dimension $D$, and assume that $\mathbf{A}$ is injective.
+    Suppose that, after bundling the site index and physical index into a
+    single MPS tensor, the resulting tensors are gauge-phase equivalent.
+    Then there exist invertible matrices $Z_0, \ldots, Z_{n-1} \in \GL_D(\C)$
+    and a nonzero scalar $\zeta \in \C^{\times}$ such that
+    \[
+        B_k^i = \zeta\, Z_k A_k^i Z_{k+1}^{-1}
+    \]
+    for all sites $k$ and physical indices $i$, where $k+1$ is interpreted
+    cyclically modulo $n$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:chainCombinedTensor_smul_chain,
+        thm:fundamentalTheorem_injective_chain}
+    If the combined tensor of $\mathbf{B}$ differs from that of $\mathbf{A}$
+    by a gauge and a nonzero scalar $\zeta$, rescale each site of
+    $\mathbf{B}$ by $\zeta^{-1}$. Lemma~\ref{lem:chainCombinedTensor_smul_chain}
+    removes this common scalar from the combined tensor, so
+    Theorem~\ref{thm:fundamentalTheorem_injective_chain} applies to the
+    rescaled chain. Multiplying the resulting sitewise relations by $\zeta$
+    gives the displayed conclusion.
+\end{proof}
+
 \subsection{From fixed-length chain states to combined-tensor MPV agreement}
 
 \begin{definition}[Same-state reduction hypothesis]

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -428,8 +428,8 @@ reduction hypothesis.
     Let $\mathbf{A} = (A_0, \ldots, A_{n-1})$ and
     $\mathbf{B} = (B_0, \ldots, B_{n-1})$ be two $n$-site chains with common
     bond dimension $D$, and assume that $\mathbf{A}$ is injective.
-    Suppose that, after bundling the site index and physical index into a
-    single MPS tensor, the resulting tensors are gauge-phase equivalent.
+    Suppose that the combined tensors $\widetilde{\mathbf{A}}$ and
+    $\widetilde{\mathbf{B}}$ are gauge-phase equivalent.
     Then there exist invertible matrices $Z_0, \ldots, Z_{n-1} \in \GL_D(\C)$
     and a nonzero scalar $\zeta \in \C^{\times}$ such that
     \[


### PR DESCRIPTION
## Summary\n- add  for uniform chain rescaling\n- prove , the gauge-phase variant of the exact injective-chain FT\n- isolate the chain-side  needed by periodic Case 3 as a reusable theorem in \n\n## Relation to #873\nThis is a focused preparatory PR for #873. It lands the reusable chain contraction theorem that replaces the Appendix A  contraction once the periodic side can package the cyclic sector data as an injective chain.\n\nThe remaining blocker for the direct  sorry is now narrower: current  still does not expose the **rectangular compressed one-site corner-transition tensors** (or an equivalent bridge from cyclic-sector data to an injective chain of equal-dimension site tensors). Without that bridge, the new chain theorem cannot yet be applied directly inside .\n\n## Testing\n- \n- Build completed successfully (1799 jobs).\n- \n- \n\nRefs #873,timeout:120000,

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean module and blueprint statements extending the existing chain fundamental theorem to a scalar (phase) factor, without modifying existing proofs or core definitions.
> 
> **Overview**
> Adds a new `TNLean.MPS.Chain.GaugePhase` module that (1) proves `MPSTensor.chainCombinedTensor_smul_chain` (uniform sitewise rescaling scales the combined tensor) and (2) upgrades the injective-chain Fundamental Theorem to a *gauge + nonzero scalar* hypothesis via `MPSChainTensor.fundamentalTheorem_injective_chain_gaugePhase`, returning a cyclic gauge `Z` and a common nonzero `ζ` relating site tensors.
> 
> Exposes the new result from the root `TNLean.lean` import surface and documents the corresponding lemma/theorem in the blueprint chapter (ch13).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48adffbb06e20ff30e607866d7100785ae337bea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->