### PR TITLE
feat(MPS): propagate unconditional sector irreducibility after #599

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -35,6 +35,7 @@ original names, including
 `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`,
 `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_projStep`,
 `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`,
+`primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking`,
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
 `fundamentalTheorem_after_blocking_1606_structural`.
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -36,6 +36,9 @@ its MPS-formulation for irreducible TP tensors.
 * `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`
   — the same conclusion under the structured fixed-point-algebra rigidity
   hypothesis from `SectorIrreducibility/HLift.lean`.
+* `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking`
+  — the unconditional wrapper using
+  `isIrreducibleOnCorner_of_cyclic_decomp_mps`.
 
 ## References
 
@@ -722,6 +725,62 @@ theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_o
     intro k
     exact isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity
       (A := A) (m := m) hIrrAdj hTP P hPproj hPsum hcyclic hMulLeft hMulRight hRigidity k
+  exact primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_cornerIrreducible
+    A hTP hγprim hperiph blocks P φ hPproj hPsum hcyclic hIntertwine hMul hStar hNondeg
+    hCornerIrr
+
+/-- Unconditional cyclic-sector block primitivity and irreducibility after blocking.
+
+This packages `isIrreducibleOnCorner_of_cyclic_decomp_mps`, so the older
+`hProjStep` and `SectorFixedPointAlgebraRigidity` interfaces are no longer needed
+once the ambient tensor is irreducible and trace-preserving. -/
+theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking
+    {d D m : ℕ} [NeZero D] [NeZero m]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A)
+    {γ : ℂ}
+    (hγprim : IsPrimitiveRoot γ m)
+    (hperiph :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+        Set.range (fun j : Fin m => γ ^ (j : ℕ)))
+    {dim : Fin m → ℕ}
+    (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+    (P : Fin m → MatrixAlg D)
+    (φ : (k : Fin m) →
+      Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k))
+    (hPproj : ∀ k, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hcyclic :
+      ∀ k : Fin m,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (hIntertwine :
+      ∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := blockPhysDim d m) (D := D)
+            (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1))
+    (hMul :
+      ∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1)
+    (hStar :
+      ∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ)
+    (hNondeg : ∀ k, dim k ≠ 0) :
+    ∀ u : Fin m,
+      _root_.IsPrimitive (transferMap (d := blockPhysDim d m) (D := dim u) (blocks u)) ∧
+        IsIrreducibleTensor (blocks u) := by
+  let T : MatrixEnd D := transferMap (d := d) (D := D) (fun i => (A i)ᴴ)
+  have hIrrAdj : IsIrreducibleMap T := by
+    simpa [T] using
+      isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor (A := A) hIrr
+  have hMulLeft := cyclic_projection_mul_left (A := A) (m := m) hTP P hPproj hcyclic
+  have hMulRight := cyclic_projection_mul_right (A := A) (m := m) hTP P hPproj hcyclic
+  have hCornerIrr :
+      ∀ k : Fin m, IsIrreducibleOnCorner (P k) (T ^ m) := by
+    intro k
+    exact isIrreducibleOnCorner_of_cyclic_decomp_mps
+      (A := A) (m := m) hIrrAdj hTP P hPproj hPsum hcyclic hMulLeft hMulRight k
   exact primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_cornerIrreducible
     A hTP hγprim hperiph blocks P φ hPproj hPsum hcyclic hIntertwine hMul hStar hNondeg
     hCornerIrr

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -731,7 +731,7 @@ theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_o
 
 /-- Unconditional cyclic-sector block primitivity and irreducibility after blocking.
 
-This packages `isIrreducibleOnCorner_of_cyclic_decomp_mps`, so the older
+This uses `isIrreducibleOnCorner_of_cyclic_decomp_mps`, so the older
 `hProjStep` and `SectorFixedPointAlgebraRigidity` interfaces are no longer needed
 once the ambient tensor is irreducible and trace-preserving. -/
 theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking

--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -50,11 +50,10 @@ the original blocked tensor, and `hCyclic` ensures the block indexing
 follows the cyclic orbit structure of the transfer map's peripheral
 spectrum (see `IsCyclicSectorDecomp`).
 
-The current proof-structure refactor isolates the remaining upstream gap in the
-private rigidity placeholder `sectorFixedPointAlgebraRigidity_cyclic_sector_supported`
-in `SelfOverlap.lean`; the public theorem
-`SelfOverlap.hProjStep_cyclic_sector_supported` packages the corresponding
-fixed-point projection step for follow-up use. -/
+The orbit-lift / corner-irreducibility input is now supplied unconditionally by
+`SelfOverlap.primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`. The
+remaining gaps in this file lie further downstream, in the sector-match and
+mixed-overlap arguments. -/
 lemma sectorBlocked_isNormal_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A)

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -185,34 +185,13 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     ⟨P, φ, hPproj, hPsum, hCyclic, hComm, hTrace, hIntertwine, hMul, hStar⟩, hNondeg⟩
 
 
-/-- Fixed-point-algebra rigidity on cyclic sectors.
-
-This is the structured remaining input behind the SelfOverlap / Case-2 normality
-pipeline: on each cyclic sector, the one-step adjoint transfer map should be
-multiplicative on the `((E_A^†)^m)`-fixed corner algebra. Once this is available,
-`hProjStep_cyclic_sector_supported` and the orbit-sum lift follow from the
-abstract infrastructure in `SectorIrreducibility.HLift`. -/
-private theorem sectorFixedPointAlgebraRigidity_cyclic_sector_supported
-    [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
-    {P : Fin m → MatrixAlg D}
-    (_hP : IsPeriodic m A)
-    (_hPproj : ∀ k, IsOrthogonalProjection (P k))
-    (_hCyclic :
-      ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) :
-    SectorFixedPointAlgebraRigidity
-      (D := D) (m := m)
-      (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) P := by
-  /- Remaining blocker: identify the fixed-point algebra of
-  `((E_A^†)^m)|_{P_k}` and show that one step of `E_A^†` acts multiplicatively
-  on that algebra. -/
-  sorry
-
 /-- One-step projection transport for `((E_A^†)^m)`-fixed cyclic-sector projections.
 
 This packages the exact `hProjStep`-style consequence needed by the overlap
 pipeline, assuming the fixed-point-algebra rigidity input on cyclic sectors.
-It is kept as a named wrapper for follow-up PRs even though the present file
-still routes more directly through `SectorFixedPointAlgebraRigidity`. -/
+It is kept as a named wrapper for arguments that still work through
+`SectorFixedPointAlgebraRigidity`, even though the main self-overlap route now
+uses the unconditional orbit-sum lift from `SectorIrreducibility.HLift`. -/
 theorem hProjStep_cyclic_sector_supported
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     {P : Fin m → MatrixAlg D}
@@ -238,61 +217,13 @@ theorem hProjStep_cyclic_sector_supported
       (D := D) (m := m) (T := T) (P := P) hStarT (by simpa [T] using hRigidity)
       (k := k) (X := X) hXproj hXP hPX hXfix
 
-private lemma hLift_cyclicDecomp_mps_of_fixUpgrade_missingBridge
-    [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
-    (hP : IsPeriodic m A)
-    {P : Fin m → MatrixAlg D}
-    (hPproj : ∀ k, IsOrthogonalProjection (P k))
-    (hPsum : ∑ k : Fin m, P k = 1)
-    (hCyclic :
-      ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) :
-    ∀ k : Fin m, ∀ Q : MatrixAlg D,
-      IsOrthogonalProjection Q →
-      Q * P k = Q →
-      P k * Q = Q →
-      PreservesCorner Q ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) →
-      ∃ R : MatrixAlg D,
-        IsOrthogonalProjection R ∧
-        PreservesCorner R (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ∧
-        (Q = 0 ↔ R = 0) ∧
-        (Q = P k ↔ R = 1) := by
-  have hIrrAdj :
-      IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) := by
-    simpa using
-      isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor
-        (A := A) hP.irreducible
-  have hMulLeft :
-      ∀ k : Fin m, ∀ X : MatrixAlg D,
-        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k * X) =
-          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) *
-            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X :=
-    cyclic_projection_mul_left (A := A) hP.leftCanonical P hPproj hCyclic
-  have hMulRight :
-      ∀ k : Fin m, ∀ X : MatrixAlg D,
-        transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (X * P k) =
-          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) X *
-            transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) :=
-    cyclic_projection_mul_right (A := A) hP.leftCanonical P hPproj hCyclic
-  have hRigidity :
-      SectorFixedPointAlgebraRigidity
-        (D := D) (m := m)
-        (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) P :=
-    sectorFixedPointAlgebraRigidity_cyclic_sector_supported
-      (A := A) (m := m) (P := P) hP hPproj hCyclic
-  exact
-    hLift_cyclicDecomp_mps_of_sectorFixedPointAlgebraRigidity
-      (A := A) (m := m) hIrrAdj hP.leftCanonical P hPproj hPsum hCyclic
-      hMulLeft hMulRight hRigidity
+/-- Corner primitivity and irreducibility for a cyclic sector.
 
-/-- Missing compressed-sector statement.
-
-This is the precise remaining interface needed by
-`primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`: the compressed sector
-tensor produced from a cyclic projection must have adjoint transfer map
-conjugate to the corner restriction of `(E_A†)^m`. Once that identification is
-available, corner primitivity and corner irreducibility give the two conclusions
-below, and the target lemma only has to convert from the adjoint map back to the
-ordinary transfer map/tensor statement. -/
+This isolates the channel-level input behind
+`primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`: on each cyclic corner,
+the `m`-step adjoint transfer map is primitive and irreducible. The later
+compression bridge transports these facts from the corner restriction to the
+compressed sector tensor. -/
 private lemma cornerRestriction_primitive_and_irreducible_of_cyclicDecomp
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A)
@@ -457,8 +388,8 @@ private lemma cornerRestriction_primitive_and_irreducible_of_cyclicDecomp
       isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor
         (A := A) hP.irreducible
   have hLift :=
-    hLift_cyclicDecomp_mps_of_fixUpgrade_missingBridge
-      A hP hPproj hPsum hCyclic
+    hLift_cyclicDecomp_mps
+      (A := A) (m := m) hIrr hP.leftCanonical P hPproj hPsum hCyclic hMulLeft hMulRight
   have hCornerIrr : IsIrreducibleOnCorner (P u) (T ^ m) :=
     isIrreducible_restriction_of_cyclic_decomp (T := T)
       hIrr P hPproj hPsum (by simpa [T] using hCyclic) (by simpa [T] using hLift) u
@@ -561,24 +492,13 @@ each nonzero compressed sector block `blocks u` arising from a cyclic sector
 decomposition of a periodic irreducible tensor has both a primitive transfer
 map and is tensor-irreducible.
 
-This is the still-missing identification
-
-  `transferMap (blocks u) ≃ cornerRestriction (P u) ((transferMap Aᴴ)^m)`
-
-threaded through the compression spectral isometry produced by
-`exists_compressedTensor_of_supported_projection` in
-`TNLean/MPS/CanonicalForm/CyclicSectors.lean`. Once that identification is in
-place, primitivity follows from `isPrimitive_restriction_of_cyclic_decomp` in
-`TNLean/Channel/Peripheral/CyclicDecomposition.lean` (which is unconditional),
-and corner irreducibility transports to `IsIrreducibleTensor (blocks u)` via
-the adjoint-side identification together with
-`MPS/Irreducible/Adjoint.lean`.
-
-See issue #450 for the recommended split: (i) close the MPS-level `hLift`
-in `SectorIrreducibility.lean` to expose corner irreducibility of `(E†)^m`,
-(ii) prove `compressedTensor_transferMap_conj` (the compressed ↔ cornerRestriction
-identification), (iii) combine with this helper to discharge
-`sectorBlocked_isNormal_of_isPeriodic`.
+The proof combines the unconditional corner result from
+`cornerRestriction_primitive_and_irreducible_of_cyclicDecomp` with the
+compression bridge `compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp`.
+The first supplies primitivity and irreducibility for the `m`-step adjoint
+transfer map on the corner `P u`; the second transports those properties to the
+compressed adjoint sector tensor, after which `MPS/Irreducible/Adjoint.lean`
+converts back to the ordinary transfer map.
 
 Kept as an explicit named sublemma so downstream consumers (`Case 2`,
 `Case 3`) and subsequent PRs can target its statement directly — the

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -187,8 +187,8 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
 
 /-- One-step projection transport for `((E_A^†)^m)`-fixed cyclic-sector projections.
 
-This packages the exact `hProjStep`-style consequence needed by the overlap
-pipeline, assuming the fixed-point-algebra rigidity input on cyclic sectors.
+This gives the exact `hProjStep`-style consequence needed in the overlap
+argument, assuming the fixed-point-algebra rigidity input on cyclic sectors.
 It is kept as a named wrapper for arguments that still work through
 `SectorFixedPointAlgebraRigidity`, even though the main self-overlap route now
 uses the unconditional orbit-sum lift from `SectorIrreducibility.HLift`. -/
@@ -222,8 +222,8 @@ theorem hProjStep_cyclic_sector_supported
 This isolates the channel-level input behind
 `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`: on each cyclic corner,
 the `m`-step adjoint transfer map is primitive and irreducible. The later
-compression bridge transports these facts from the corner restriction to the
-compressed sector tensor. -/
+compression identification converts these corner statements into the
+corresponding statements for the compressed sector tensor. -/
 private lemma cornerRestriction_primitive_and_irreducible_of_cyclicDecomp
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A)
@@ -494,11 +494,12 @@ map and is tensor-irreducible.
 
 The proof combines the unconditional corner result from
 `cornerRestriction_primitive_and_irreducible_of_cyclicDecomp` with the
-compression bridge `compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp`.
+compression identification provided by
+`compressedSector_adjointTransferMap_cornerBridge_of_cyclicDecomp`.
 The first supplies primitivity and irreducibility for the `m`-step adjoint
-transfer map on the corner `P u`; the second transports those properties to the
-compressed adjoint sector tensor, after which `MPS/Irreducible/Adjoint.lean`
-converts back to the ordinary transfer map.
+transfer map on the corner `P u`; the second identifies the compressed adjoint
+sector tensor with the corresponding corner restriction, after which
+`MPS/Irreducible/Adjoint.lean` converts back to the ordinary transfer map.
 
 Kept as an explicit named sublemma so downstream consumers (`Case 2`,
 `Case 3`) and subsequent PRs can target its statement directly — the

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1869,6 +1869,36 @@ The following results separate the zero blocks from the
 	map to the primal transfer map of $C_u$.
 \end{proof}
 
+\begin{theorem}[Unconditional primitive blocked sectors]%
+	\label{thm:blocked_sector_unconditional}
+	\lean{MPSTensor.primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking}
+	\leanok
+	\uses{thm:cyclic_sector_decomp_after_blocking,
+	      thm:sector_irred_unconditional,
+	      thm:primitive_adjoint_equiv}
+	Let $A$ be a left-canonical irreducible tensor whose adjoint transfer map has
+	peripheral spectrum $\{\gamma^j : 0 \le j < m\}$ for a primitive $m$-th root
+	of unity $\gamma$. Let $(C_u)_{u=1}^m$, $(P_u)_{u=1}^m$, and
+	$\varphi_u : \MN{\dim C_u} \xrightarrow{\sim} P_u \MN{D} P_u$
+	be the blocked cyclic-sector data. Then every blocked sector tensor $C_u$ has
+	primitive transfer map and is irreducible.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:sector_irred_unconditional,
+	      thm:primitive_adjoint_equiv}
+	Theorem~\ref{thm:sector_irred_unconditional} gives irreducibility of
+	$(\E_A^\dagger)^m$ on each corner $P_u$.
+	The blocked cyclic-sector data provide compression equivalences
+	$\varphi_u$ intertwining the adjoint transfer map of $C_u$ with the
+	corresponding corner restriction of $(\E_A^\dagger)^m$.
+	The same cyclic peripheral-spectrum argument that produces the sector
+	decomposition shows that each corner restriction is primitive.
+	Transport primitivity and irreducibility across $\varphi_u$, then use
+	Theorem~\ref{thm:primitive_adjoint_equiv} to pass from the adjoint blocked
+	map to the primal transfer map of $C_u$.
+\end{proof}
+
 \begin{theorem}[Arbitrary tensor to primitive block decomposition]%
 	\label{thm:tp_primitive_blockdecomp}
 	\lean{MPSTensor.exists_tp_primitive_blockDecomp_after_blocking}


### PR DESCRIPTION
## Summary
- remove the stale  placeholder that still routed through a private fixed-point-algebra bridge and instead use the unconditional 
- add  as the hypothesis-free blocked-sector wrapper in 
- refresh downstream docs in  and  to describe the unconditional sector-irreducibility route now available after #599

## Testing
- Lean diagnostics: 
- Lean diagnostics: 
- Lean diagnostics: 
- 

Ref #599

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core canonical-form/overlap theorems by changing how sector irreducibility is obtained (now unconditional), which could affect downstream lemma dependencies and proof obligations even though it’s mostly re-wiring rather than new mathematics.
> 
> **Overview**
> Adds `MPSTensor.primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking`, an **unconditional** wrapper that derives corner irreducibility via `isIrreducibleOnCorner_of_cyclic_decomp_mps` and then reuses the existing corner-transport pipeline to conclude per-sector primitivity and tensor irreducibility.
> 
> Cleans up downstream overlap code by removing a stale private “rigidity bridge” placeholder and switching the self-overlap/case-2 narrative to rely on the new unconditional orbit-lift route; updates the public `Assembly` entrypoint list and the blueprint with a corresponding new theorem statement and proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c73eb50388e7d340b6f5c5d3ac90d464e76c2bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->