### PR TITLE
ci(codex): add @chatgpt mention-driven Codex workflow

### DIFF
--- a/.github/actions/auto-create-issue-pr/action.yml
+++ b/.github/actions/auto-create-issue-pr/action.yml
@@ -17,8 +17,19 @@ inputs:
   autofix-label:
     description: 'Label to add when the trigger text contains an auto-fix keyword'
     required: true
-  trigger-text:
-    description: 'The user-supplied text to scan for auto-fix keywords (comment body, or issue body+title)'
+  event-name:
+    description: 'github.event_name; selects which fields to scan for the auto-fix keyword'
+    required: true
+  comment-body:
+    description: 'Comment body (scanned when event-name == issue_comment)'
+    required: false
+    default: ''
+  issue-body:
+    description: 'Issue body (scanned when event-name == issues)'
+    required: false
+    default: ''
+  issue-title:
+    description: 'Issue title (scanned when event-name == issues)'
     required: false
     default: ''
   gh-token:
@@ -37,7 +48,10 @@ runs:
         BRANCH_PREFIX: ${{ inputs.branch-prefix }}
         CREATOR_NAME: ${{ inputs.creator-name }}
         AUTOFIX_LABEL: ${{ inputs.autofix-label }}
-        TRIGGER_TEXT: ${{ inputs.trigger-text }}
+        EVENT_NAME: ${{ inputs.event-name }}
+        COMMENT_BODY: ${{ inputs.comment-body }}
+        ISSUE_BODY: ${{ inputs.issue-body }}
+        ISSUE_TITLE_INPUT: ${{ inputs.issue-title }}
       run: |
         set -euo pipefail
 
@@ -81,6 +95,16 @@ runs:
         PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 
         # Label so subsequent CI failures kick the matching auto-fix workflow.
+        # Scan only the fields that originated the trigger: the comment body for
+        # issue_comment events, or the issue body+title for issues events. Mixing
+        # them would mislabel a PR when the parent issue contains "auto-fix" but
+        # the actual triggering comment does not.
+        if [ "$EVENT_NAME" = "issue_comment" ]; then
+          TRIGGER_TEXT="$COMMENT_BODY"
+        else
+          TRIGGER_TEXT="$ISSUE_BODY $ISSUE_TITLE_INPUT"
+        fi
+
         if echo "$TRIGGER_TEXT" | grep -qiE 'auto[_ -]?fix'; then
           echo "Autofix keyword detected — adding '${AUTOFIX_LABEL}' label to PR #${PR_NUM}"
           gh pr edit "$PR_NUM" --repo "$REPO" --add-label "$AUTOFIX_LABEL" || true

--- a/.github/actions/auto-create-issue-pr/action.yml
+++ b/.github/actions/auto-create-issue-pr/action.yml
@@ -1,0 +1,87 @@
+name: 'Auto-create PR for issue work'
+description: 'Find the bot-pushed branch for an issue and open a PR; optionally add an autofix label when the trigger text mentions auto-fix'
+
+inputs:
+  issue-number:
+    description: 'The GitHub issue number'
+    required: true
+  repo:
+    description: 'owner/repo slug'
+    required: true
+  branch-prefix:
+    description: 'Branch prefix the bot uses (e.g. "claude/issue-" or "codex/issue-")'
+    required: true
+  creator-name:
+    description: 'Human-readable creator name for the PR body (e.g. "Claude Code action")'
+    required: true
+  autofix-label:
+    description: 'Label to add when the trigger text contains an auto-fix keyword'
+    required: true
+  trigger-text:
+    description: 'The user-supplied text to scan for auto-fix keywords (comment body, or issue body+title)'
+    required: false
+    default: ''
+  gh-token:
+    description: 'Token with PR write access'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - id: open-pr
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        REPO: ${{ inputs.repo }}
+        BRANCH_PREFIX: ${{ inputs.branch-prefix }}
+        CREATOR_NAME: ${{ inputs.creator-name }}
+        AUTOFIX_LABEL: ${{ inputs.autofix-label }}
+        TRIGGER_TEXT: ${{ inputs.trigger-text }}
+      run: |
+        set -euo pipefail
+
+        echo "Looking for branches matching ${BRANCH_PREFIX}${ISSUE_NUMBER}-*"
+
+        # Targeted refspec; works on shallow clones without full history.
+        git fetch origin --no-tags \
+          "refs/heads/${BRANCH_PREFIX}${ISSUE_NUMBER}-*:refs/remotes/origin/${BRANCH_PREFIX}${ISSUE_NUMBER}-*" \
+          || true
+
+        BRANCH=$(git for-each-ref --sort=-committerdate --format='%(refname:lstrip=3)' \
+          "refs/remotes/origin/${BRANCH_PREFIX}${ISSUE_NUMBER}-*" | head -1)
+
+        if [ -z "$BRANCH" ]; then
+          echo "No branch found for issue #${ISSUE_NUMBER} — bot likely just replied without code changes."
+          exit 0
+        fi
+
+        echo "Found branch: $BRANCH"
+
+        EXISTING=$(gh pr list --repo "$REPO" --head "$BRANCH" --state all --json number --jq 'length')
+        if [ "$EXISTING" -gt 0 ]; then
+          echo "PR already exists for branch $BRANCH — skipping."
+          exit 0
+        fi
+
+        ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title')
+
+        echo "Creating PR from $BRANCH → main for issue #${ISSUE_NUMBER}"
+
+        PR_BODY=$'Addresses #'"${ISSUE_NUMBER}"$'\n\nAuto-created by '"${CREATOR_NAME}"$'.'
+
+        PR_URL=$(gh pr create \
+          --repo "$REPO" \
+          --head "$BRANCH" \
+          --base main \
+          --title "feat: ${ISSUE_TITLE}" \
+          --body "$PR_BODY")
+
+        echo "PR created successfully: $PR_URL"
+        PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
+        # Label so subsequent CI failures kick the matching auto-fix workflow.
+        if echo "$TRIGGER_TEXT" | grep -qiE 'auto[_ -]?fix'; then
+          echo "Autofix keyword detected — adding '${AUTOFIX_LABEL}' label to PR #${PR_NUM}"
+          gh pr edit "$PR_NUM" --repo "$REPO" --add-label "$AUTOFIX_LABEL" || true
+        fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -89,8 +89,8 @@ jobs:
           branch-prefix: 'claude/issue-'
           creator-name: 'Claude Code action'
           autofix-label: 'auto-fix-claude'
-          trigger-text: |
-            ${{ github.event.comment.body || '' }}
-            ${{ github.event.issue.body || '' }}
-            ${{ github.event.issue.title || '' }}
+          event-name: ${{ github.event_name }}
+          comment-body: ${{ github.event.comment.body || '' }}
+          issue-body: ${{ github.event.issue.body || '' }}
+          issue-title: ${{ github.event.issue.title || '' }}
           gh-token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,15 +19,19 @@ env:
 
 jobs:
   claude:
-    # Skip bot triggers (e.g. Copilot reposting a review that contains "@claude") —
-    # claude-code-action rejects non-collaborator actors, so the job would just
-    # burn minutes on Lean toolchain setup before failing.
+    # Skip when:
+    #   - sender is a bot (e.g. Copilot reposting a review that contains "@claude")
+    #     — claude-code-action rejects non-collaborator actors anyway.
+    #   - the triggering author lacks write access (author_association not in
+    #     OWNER/MEMBER/COLLABORATOR). Defense-in-depth: this workflow runs with
+    #     write permissions and repo secrets, so prompt-injection from untrusted
+    #     commenters must not start the runner.
     if: |
       github.event.sender.type != 'Bot' && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,11 +16,16 @@ concurrency:
 
 jobs:
   claude:
+    # Skip bot triggers (e.g. Copilot reposting a review that contains "@claude") —
+    # claude-code-action rejects non-collaborator actors, so the job would just
+    # burn minutes on Lean toolchain setup before failing.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,8 +11,11 @@ on:
     types: [submitted]
 
 concurrency:
-  group: claude-respond-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
+  group: bot-respond-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
   cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
 
 jobs:
   claude:
@@ -27,6 +30,7 @@ jobs:
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     permissions:
       contents: write
@@ -40,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ env.GH_TOKEN }}
 
       - name: Set up Lean toolchain and cache
         uses: ./.github/actions/setup-lean
@@ -69,76 +73,20 @@ jobs:
             --append-system-prompt "This is a Lean 4 / Mathlib repository. Prefer minimal diffs. Hold your changes to the same 8-category quality bar used by Claude Code Review (proof integrity, proof correctness, Mathlib style, type safety, performance, modularity, documentation, blueprint sync). See docs/PROOF_INTEGRITY.md for the full integrity ruleset — no sorry, admit, native_decide on non-trivial goals, unsafeCast, or new axioms. Use your judgment on when Mathlib scouting is warranted — it is essential when writing new proofs, closing sorrys, or choosing proof strategies, but unnecessary for cosmetic fixes, docstrings, imports, or renaming. When scouting IS warranted: first read all comments on the issue/PR for existing Mathlib Scouting Reports, then scout Mathlib yourself using exact?, apply?, rw?, simp?, and by grepping Mathlib source files (.lake/packages/mathlib/Mathlib/) for related definitions and theorems. Reuse Mathlib lemmas wherever possible rather than reproving from scratch. If someone explicitly asks you to scout, or if the task has shifted enough that an earlier scouting report may be stale, do a fresh scout and post a new Mathlib Scouting Report comment with sections: Relevant Mathlib definitions, Relevant Mathlib lemmas/theorems, Relevant TNLean definitions, Suggested approach, and Gaps to fill. Before changing theorem statements, first try to complete the proof using existing lemmas. If a mathematical result looks wrong, too strong, or suspiciously general, scout the LaTeX sources in Papers/ and Notes/ where the original theorems and proofs are stored — read the relevant sections, compare hypotheses and conclusions, and cite the specific paper/section when flagging a discrepancy. When you add or complete (remove sorry from) theorems, lemmas, or definitions, update the corresponding blueprint entry in blueprint/src/chapter/ in the same PR — add \\lean{DeclarationName} and \\leanok tags for new results, or add \\leanok to \\begin{proof} for newly proven results. Validate with: lake build. Do not leave unrelated new sorrys. After substantial proof work, include a Mathlib Audit section in your comment listing which Mathlib lemmas/definitions you used or discovered (name, module path, and how it was used). Skip the audit for trivial changes. Always read existing review threads on the PR for context before responding. Reply directly to the review thread that triggered you. Do NOT resolve review threads yourself — leave resolution to humans or the automated review workflow."
 
       - name: Auto-create PR for completed issue work
-        # Only run for issue events (not PR comments), and only if Claude succeeded
         if: |
           !cancelled() &&
           steps.claude.outcome == 'success' &&
           (github.event_name == 'issues' ||
            (github.event_name == 'issue_comment' && !github.event.issue.pull_request))
-        env:
-          GH_TOKEN: ${{ secrets.BOT_PAT || github.token }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
-          # Pass user-controlled text via env vars to avoid script injection
-          COMMENT_BODY: ${{ github.event.comment.body || '' }}
-          ISSUE_BODY: ${{ github.event.issue.body || '' }}
-          EVENT_ISSUE_TITLE: ${{ github.event.issue.title || '' }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-
-          echo "Looking for branches matching claude/issue-${ISSUE_NUMBER}-*"
-
-          # Fetch matching remote refs so we can sort by committer date
-          git fetch origin --no-tags "refs/heads/claude/issue-${ISSUE_NUMBER}-*:refs/remotes/origin/claude/issue-${ISSUE_NUMBER}-*" 2>/dev/null || true
-
-          # Pick the most recently committed branch
-          BRANCH=$(git for-each-ref --sort=-committerdate --format='%(refname:lstrip=3)' \
-            "refs/remotes/origin/claude/issue-${ISSUE_NUMBER}-*" | head -1)
-
-          if [ -z "$BRANCH" ]; then
-            echo "No branch found for issue #${ISSUE_NUMBER} — Claude likely just replied without code changes."
-            exit 0
-          fi
-
-          echo "Found branch: $BRANCH"
-
-          # Check if a PR already exists for this branch
-          EXISTING=$(gh pr list --repo "$REPO" --head "$BRANCH" --state all --json number --jq 'length')
-          if [ "$EXISTING" -gt 0 ]; then
-            echo "PR already exists for branch $BRANCH — skipping."
-            exit 0
-          fi
-
-          # Get issue title for the PR
-          ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title')
-
-          echo "Creating PR from $BRANCH → main for issue #${ISSUE_NUMBER}"
-
-          # Check if the triggering text contains autofix keywords
-          TRIGGER_TEXT=""
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
-            TRIGGER_TEXT="$COMMENT_BODY"
-          else
-            TRIGGER_TEXT="$ISSUE_BODY $EVENT_ISSUE_TITLE"
-          fi
-
-          # Create the PR — pr-cleanup.yml will reformat title/body/labels
-          PR_BODY=$'Addresses #'"${ISSUE_NUMBER}"$'\n\nAuto-created by Claude Code action.'
-
-          PR_URL=$(gh pr create \
-            --repo "$REPO" \
-            --head "$BRANCH" \
-            --base main \
-            --title "feat: ${ISSUE_TITLE}" \
-            --body "$PR_BODY")
-
-          echo "PR created successfully: $PR_URL"
-          PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-
-          # If the triggering text contains autofix keywords, add the label.
-          # Done as a separate step so a missing label doesn't break PR creation.
-          if echo "$TRIGGER_TEXT" | grep -qiE 'auto[_ -]?fix'; then
-            echo "Autofix keyword detected — adding 'auto-fix-claude' label to PR #${PR_NUM}"
-            gh pr edit "$PR_NUM" --repo "$REPO" --add-label "auto-fix-claude" || true
-          fi
+        uses: ./.github/actions/auto-create-issue-pr
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          repo: ${{ github.repository }}
+          branch-prefix: 'claude/issue-'
+          creator-name: 'Claude Code action'
+          autofix-label: 'auto-fix-claude'
+          trigger-text: |
+            ${{ github.event.comment.body || '' }}
+            ${{ github.event.issue.body || '' }}
+            ${{ github.event.issue.title || '' }}
+          gh-token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,169 @@
+name: Codex (Lean)
+
+# Mention-driven Codex counterpart to claude.yml. Triggers on `@chatgpt` in
+# issue/PR comments, reviews, and issue bodies. Distinct from auto-fix-codex.yml,
+# which is label-gated and runs after CI/blueprint/review workflows finish.
+#
+# `@chatgpt` is unregistered on GitHub (no user/org owns the handle), so the
+# mention does not collide with the OpenAI Codex GitHub Connector (`@codex`,
+# which posts as `chatgpt-codex-connector[bot]`).
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: codex-respond-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
+  cancel-in-progress: false
+
+jobs:
+  codex:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@chatgpt')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@chatgpt')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@chatgpt')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@chatgpt') || contains(github.event.issue.title, '@chatgpt')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Setup git identity
+        run: |
+          git config --global user.email "chatgpt-codex-connector[bot]@users.noreply.github.com"
+          git config --global user.name "chatgpt-codex-connector[bot]"
+
+      - name: Set up Lean toolchain and cache
+        uses: ./.github/actions/setup-lean
+        with:
+          install-blueprint: 'true'
+
+      - name: Run Codex
+        id: codex
+        uses: openai/codex-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          # workspace-write blocks network; need outbound for `git push` and `gh ... comment`.
+          sandbox: danger-full-access
+          # Allow iterations when head of branch was authored by another bot
+          # (e.g. claude[bot] or chatgpt-codex-connector[bot]).
+          allow-bots: true
+          prompt: |
+            A user mentioned @chatgpt on this repository.
+
+            Event: ${{ github.event_name }}
+            Repository: ${{ github.repository }}
+            Issue/PR number: ${{ github.event.issue.number || github.event.pull_request.number }}
+            Triggering author: ${{ github.event.comment.user.login || github.event.review.user.login || github.event.issue.user.login }}
+
+            Instructions:
+            1. Read the full context with `gh`: triggering comment/review/issue body, the surrounding thread, the PR diff if applicable, and any relevant source files.
+               - PR comment: `gh pr view <num> --json ...` and `gh api repos/${{ github.repository }}/pulls/<num>/comments`.
+               - Issue comment / issue: `gh issue view <num> --json ...`.
+               - Review: read all threads via `gh api repos/${{ github.repository }}/pulls/<num>/reviews`.
+            2. Decide whether the request is a question (reply only) or a code change (edit + commit + reply).
+            3. Use your judgment on whether Mathlib scouting is needed. Warranted for new proofs, closing sorrys, or choosing proof strategies; unnecessary for cosmetic fixes, docstrings, imports, or renaming. When scouting, first read existing **Mathlib Scouting Reports** in PR/issue comments, then scout yourself with `exact?`, `apply?`, `rw?`, `simp?`, and by grepping `.lake/packages/mathlib/Mathlib/`. If asked explicitly to scout, post a fresh **Mathlib Scouting Report** with sections: Relevant Mathlib definitions, Relevant Mathlib lemmas/theorems, Relevant TNLean definitions, Suggested approach, Gaps to fill.
+            4. For code changes:
+               - On a PR: check out the PR's head branch (`gh pr checkout <num>`), edit, run `lake build` to verify zero errors and zero new `sorry`s, commit with prefix `[codex]`, push.
+               - On an issue: create a new branch `codex/issue-<NUMBER>-<short-description>` from main, edit, build, commit with prefix `[codex]`, push.
+            5. Reply via `gh pr comment <num>` or `gh issue comment <num>` summarizing what you did or answering the question. For review-thread triggers, reply directly to the triggering thread.
+            6. Do NOT resolve review threads — leave resolution to humans or the automated review workflow.
+
+            Quality bar (your work MUST satisfy ALL of these before committing):
+            - Proof integrity (BLOCKER): no `sorry`, `admit`, `native_decide` on non-trivial goals, `unsafeCast`, or new axioms. See docs/PROOF_INTEGRITY.md.
+            - Proof correctness (BLOCKER): structured proofs, not brute-force `simp`/`omega`/`ring` chains. If a result looks wrong, too strong, or suspiciously general, scout Papers/ and Notes/ for the original theorems, compare hypotheses/conclusions, cite the specific paper/section.
+            - Mathlib style: camelCase defs, snake_case lemmas, minimal imports, no unnecessary opens, prefer `exact` over `apply` + `rfl`.
+            - Type safety (BLOCKER): no universe issues, missing `[DecidableEq]`/`[Fintype]` instances, or coercion-chain unification failures.
+            - Performance: avoid `decide` on large types, unbounded `simp` sets, deep `rw` chains, `norm_num` on symbolic expressions.
+            - Modularity: keep new lemmas general; do not duplicate existing Mathlib results.
+            - Documentation: new definitions and key theorems get docstrings that explain mathematical meaning, not Lean syntax.
+            - Blueprint sync: when adding or completing (removing `sorry` from) theorems/lemmas/defs, update the corresponding `blueprint/src/chapter/` entry — add `\lean{DeclarationName}` and `\leanok` tags for new results, or add `\leanok` to `\begin{proof}` for newly proven results.
+            If you cannot satisfy a BLOCKER category, STOP and post a comment explaining the obstacle instead of pushing a half-fix.
+
+            Before changing theorem statements, first try to complete the proof using existing lemmas. Do not leave unrelated new sorrys.
+
+      - name: Auto-create PR for completed issue work
+        if: |
+          !cancelled() &&
+          steps.codex.outcome == 'success' &&
+          (github.event_name == 'issues' ||
+           (github.event_name == 'issue_comment' && !github.event.issue.pull_request))
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT || github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          # Pass user-controlled text via env vars to avoid script injection
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          ISSUE_BODY: ${{ github.event.issue.body || '' }}
+          EVENT_ISSUE_TITLE: ${{ github.event.issue.title || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          echo "Looking for branches matching codex/issue-${ISSUE_NUMBER}-*"
+
+          git fetch origin --no-tags "refs/heads/codex/issue-${ISSUE_NUMBER}-*:refs/remotes/origin/codex/issue-${ISSUE_NUMBER}-*" 2>/dev/null || true
+
+          BRANCH=$(git for-each-ref --sort=-committerdate --format='%(refname:lstrip=3)' \
+            "refs/remotes/origin/codex/issue-${ISSUE_NUMBER}-*" | head -1)
+
+          if [ -z "$BRANCH" ]; then
+            echo "No branch found for issue #${ISSUE_NUMBER} — Codex likely just replied without code changes."
+            exit 0
+          fi
+
+          echo "Found branch: $BRANCH"
+
+          EXISTING=$(gh pr list --repo "$REPO" --head "$BRANCH" --state all --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "PR already exists for branch $BRANCH — skipping."
+            exit 0
+          fi
+
+          ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title')
+
+          echo "Creating PR from $BRANCH → main for issue #${ISSUE_NUMBER}"
+
+          TRIGGER_TEXT=""
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            TRIGGER_TEXT="$COMMENT_BODY"
+          else
+            TRIGGER_TEXT="$ISSUE_BODY $EVENT_ISSUE_TITLE"
+          fi
+
+          PR_BODY=$'Addresses #'"${ISSUE_NUMBER}"$'\n\nAuto-created by Codex action.'
+
+          PR_URL=$(gh pr create \
+            --repo "$REPO" \
+            --head "$BRANCH" \
+            --base main \
+            --title "feat: ${ISSUE_TITLE}" \
+            --body "$PR_BODY")
+
+          echo "PR created successfully: $PR_URL"
+          PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
+          if echo "$TRIGGER_TEXT" | grep -qiE 'auto[_ -]?fix'; then
+            echo "Autofix keyword detected — adding 'auto-fix-codex' label to PR #${PR_NUM}"
+            gh pr edit "$PR_NUM" --repo "$REPO" --add-label "auto-fix-codex" || true
+          fi

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -18,17 +18,28 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Share the responder concurrency lane with claude.yml (same group name),
+# so @claude and @chatgpt jobs on the same issue/PR queue rather than racing
+# to push to the same branch.
 concurrency:
-  group: codex-respond-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
+  group: claude-respond-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
   cancel-in-progress: false
 
 jobs:
   codex:
+    # Skip when:
+    #   - sender is a bot (e.g. Copilot reposting a review that contains "@chatgpt") —
+    #     openai/codex-action errors out on non-collaborator actors anyway, so the
+    #     job would just burn minutes setting up Lean before failing.
+    #   - the same trigger also mentions @claude — let claude.yml handle it to avoid
+    #     two bots editing the same branch in parallel.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@chatgpt')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@chatgpt')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@chatgpt')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@chatgpt') || contains(github.event.issue.title, '@chatgpt')))
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@chatgpt') && !contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@chatgpt') && !contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@chatgpt') && !contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@chatgpt') || contains(github.event.issue.title, '@chatgpt')) && !(contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -33,14 +33,18 @@ jobs:
     #   - sender is a bot (e.g. Copilot reposting a review that contains "@chatgpt") —
     #     openai/codex-action errors out on non-collaborator actors anyway, so the
     #     job would just burn minutes setting up Lean before failing.
+    #   - the triggering author lacks write access (author_association not in
+    #     OWNER/MEMBER/COLLABORATOR). Defense-in-depth: this workflow runs with
+    #     write permissions, repo secrets, and a danger-full-access sandbox, so
+    #     prompt-injection from untrusted commenters must not start the runner.
     #   - the same trigger also mentions @claude — let claude.yml handle it to avoid
     #     two bots editing the same branch in parallel.
     if: |
       github.event.sender.type != 'Bot' && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@chatgpt') && !contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@chatgpt') && !contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@chatgpt') && !contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@chatgpt') || contains(github.event.issue.title, '@chatgpt')) && !(contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@chatgpt') && !contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@chatgpt') && !contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@chatgpt') && !contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@chatgpt') || contains(github.event.issue.title, '@chatgpt')) && !(contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -130,9 +130,8 @@ jobs:
           branch-prefix: 'codex/issue-'
           creator-name: 'Codex action'
           autofix-label: 'auto-fix-codex'
-          # Issue-comment events scan the comment; issue events scan body+title.
-          trigger-text: |
-            ${{ github.event.comment.body || '' }}
-            ${{ github.event.issue.body || '' }}
-            ${{ github.event.issue.title || '' }}
+          event-name: ${{ github.event_name }}
+          comment-body: ${{ github.event.comment.body || '' }}
+          issue-body: ${{ github.event.issue.body || '' }}
+          issue-title: ${{ github.event.issue.title || '' }}
           gh-token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -18,12 +18,14 @@ on:
   pull_request_review:
     types: [submitted]
 
-# Share the responder concurrency lane with claude.yml (same group name),
-# so @claude and @chatgpt jobs on the same issue/PR queue rather than racing
-# to push to the same branch.
+# Shared responder lane with claude.yml so @claude and @chatgpt jobs on the
+# same issue/PR queue rather than racing to push to the same branch.
 concurrency:
-  group: claude-respond-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
+  group: bot-respond-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
   cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
 
 jobs:
   codex:
@@ -55,7 +57,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ env.GH_TOKEN }}
 
       - name: Setup git identity
         run: |
@@ -70,8 +72,6 @@ jobs:
       - name: Run Codex
         id: codex
         uses: openai/codex-action@v1
-        env:
-          GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           # workspace-write blocks network; need outbound for `git push` and `gh ... comment`.
@@ -119,62 +119,16 @@ jobs:
           steps.codex.outcome == 'success' &&
           (github.event_name == 'issues' ||
            (github.event_name == 'issue_comment' && !github.event.issue.pull_request))
-        env:
-          GH_TOKEN: ${{ secrets.BOT_PAT || github.token }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
-          # Pass user-controlled text via env vars to avoid script injection
-          COMMENT_BODY: ${{ github.event.comment.body || '' }}
-          ISSUE_BODY: ${{ github.event.issue.body || '' }}
-          EVENT_ISSUE_TITLE: ${{ github.event.issue.title || '' }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-
-          echo "Looking for branches matching codex/issue-${ISSUE_NUMBER}-*"
-
-          git fetch origin --no-tags "refs/heads/codex/issue-${ISSUE_NUMBER}-*:refs/remotes/origin/codex/issue-${ISSUE_NUMBER}-*" 2>/dev/null || true
-
-          BRANCH=$(git for-each-ref --sort=-committerdate --format='%(refname:lstrip=3)' \
-            "refs/remotes/origin/codex/issue-${ISSUE_NUMBER}-*" | head -1)
-
-          if [ -z "$BRANCH" ]; then
-            echo "No branch found for issue #${ISSUE_NUMBER} — Codex likely just replied without code changes."
-            exit 0
-          fi
-
-          echo "Found branch: $BRANCH"
-
-          EXISTING=$(gh pr list --repo "$REPO" --head "$BRANCH" --state all --json number --jq 'length')
-          if [ "$EXISTING" -gt 0 ]; then
-            echo "PR already exists for branch $BRANCH — skipping."
-            exit 0
-          fi
-
-          ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title')
-
-          echo "Creating PR from $BRANCH → main for issue #${ISSUE_NUMBER}"
-
-          TRIGGER_TEXT=""
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
-            TRIGGER_TEXT="$COMMENT_BODY"
-          else
-            TRIGGER_TEXT="$ISSUE_BODY $EVENT_ISSUE_TITLE"
-          fi
-
-          PR_BODY=$'Addresses #'"${ISSUE_NUMBER}"$'\n\nAuto-created by Codex action.'
-
-          PR_URL=$(gh pr create \
-            --repo "$REPO" \
-            --head "$BRANCH" \
-            --base main \
-            --title "feat: ${ISSUE_TITLE}" \
-            --body "$PR_BODY")
-
-          echo "PR created successfully: $PR_URL"
-          PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-
-          if echo "$TRIGGER_TEXT" | grep -qiE 'auto[_ -]?fix'; then
-            echo "Autofix keyword detected — adding 'auto-fix-codex' label to PR #${PR_NUM}"
-            gh pr edit "$PR_NUM" --repo "$REPO" --add-label "auto-fix-codex" || true
-          fi
+        uses: ./.github/actions/auto-create-issue-pr
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          repo: ${{ github.repository }}
+          branch-prefix: 'codex/issue-'
+          creator-name: 'Codex action'
+          autofix-label: 'auto-fix-codex'
+          # Issue-comment events scan the comment; issue events scan body+title.
+          trigger-text: |
+            ${{ github.event.comment.body || '' }}
+            ${{ github.event.issue.body || '' }}
+            ${{ github.event.issue.title || '' }}
+          gh-token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -80,9 +80,6 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           # workspace-write blocks network; need outbound for `git push` and `gh ... comment`.
           sandbox: danger-full-access
-          # Allow iterations when head of branch was authored by another bot
-          # (e.g. claude[bot] or chatgpt-codex-connector[bot]).
-          allow-bots: true
           prompt: |
             A user mentioned @chatgpt on this repository.
 


### PR DESCRIPTION
### Motivation

- Extends the project's mention-driven bot infrastructure to cover the OpenAI Codex agent, mirroring the existing `claude.yml` workflow.
- The `@chatgpt` GitHub handle is unregistered on GitHub, so it does not collide with the `@codex` GitHub Connector.

### Description

- Adds `.github/workflows/codex.yml` (169 lines): a new mention-driven workflow triggered by `@chatgpt` in issues, issue comments, PR comments, and review comments.
- Invokes `openai/codex-action@v1` after setting up the Lean toolchain; mirrors the structure of the existing `claude.yml`.
- Configures the job to comment back via `gh`, optionally commit and push changes with bot git identity, and auto-create a PR from a `codex/issue-<n>-*` branch for issue-triggered work.
- Optionally applies the `auto-fix-codex` label when the trigger text includes an autofix keyword.

### Testing

- No Lean source files changed; workflow syntax is validated by GitHub Actions on push.
- Relies on Lean CI (`lean_action_ci.yml`) to validate any downstream Lean builds triggered by the workflow.

---
Addresses #901

> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Actions workflow that runs with write permissions and a `danger-full-access` sandbox when `@chatgpt` is mentioned, so misconfiguration or prompt abuse could cause unintended repo writes or PR/issue activity.
> 
> **Overview**
> Introduces a new mention-driven workflow (`.github/workflows/codex.yml`) that triggers on `@chatgpt` in issues, issue comments, PR comments, and reviews, and runs `openai/codex-action@v1` after setting up the Lean toolchain.
> 
> The job is configured to comment back via `gh`, optionally commit/push changes (with bot git identity), and for issue-triggered work can auto-create a PR from a `codex/issue-<n>-*` branch and optionally apply the `auto-fix-codex` label when the trigger text includes an autofix keyword.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb63bb4399c475c1557191b176ab1911dfaa5eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Actions workflow that runs with write permissions and a `danger-full-access` sandbox, so any mis-triggering or prompt abuse could lead to unintended repo writes/PR activity. Also refactors the PR auto-creation logic into a reusable composite action, which could affect existing bot automation if misconfigured.
> 
> **Overview**
> Introduces a new mention-driven workflow, `codex.yml`, that runs `openai/codex-action@v1` when trusted collaborators mention `@chatgpt`, with a shared concurrency lane to avoid conflicts with `@claude` runs.
> 
> Refactors the existing issue→PR automation into a reusable composite action, `auto-create-issue-pr`, and updates `claude.yml` to use it (including centralized `GH_TOKEN`, stricter trigger gating by non-bot + collaborator association, and optional auto-fix labeling based on the triggering text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cff46143d1ca52c257db867f02256d02244118cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->