### PR TITLE
feat(MPS/CanonicalForm): add mpv_toTensorFromBlocks_normalize and flip blueprint

### DIFF
--- a/TNLean/MPS/SharedInfra/Scaling.lean
+++ b/TNLean/MPS/SharedInfra/Scaling.lean
@@ -117,4 +117,22 @@ theorem leftCanonical_phase_smul {D' : ℕ} (μ : ℂ) (hμ : μ ≠ 0)
   have hn := phase_norm_one (μ := μ) hμ
   exact leftCanonical_smul_of_norm_one _ hn A hA
 
+/-- MPV under block normalization: every block weight may be split into its
+modulus and a unit-modulus phase by absorbing the modulus into the block tensor.
+With $\eta_k := \mu_k / \|\mu_k\|$ and $B_k := \|\mu_k\| \cdot A_k$, the
+block-diagonal tensors $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \eta_k B_k$
+generate the same MPV family.  See arXiv:2011.12127 §IV.A. -/
+theorem mpv_toTensorFromBlocks_normalize {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0)
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {N : ℕ} (σ : Fin N → Fin d) :
+    mpv (toTensorFromBlocks μ A) σ =
+      mpv (toTensorFromBlocks (fun k => μ k / ↑‖μ k‖)
+        (fun k i => (↑‖μ k‖ : ℂ) • A k i)) σ := by
+  rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  have hne : (↑‖μ k‖ : ℂ) ≠ 0 := by exact_mod_cast norm_ne_zero_iff.mpr (hμ k)
+  rw [mpv_smul, smul_eq_mul, smul_eq_mul, ← mul_assoc, ← mul_pow,
+    div_mul_cancel₀ (μ k) hne]
+
 end MPSTensor

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -224,6 +224,27 @@ boundary conditions (PBC).
     and each step picks up one factor of $\zeta$.
 \end{proof}
 
+\begin{lemma}[Scaling of MPV components]\label{lem:mpv_smul}
+    \lean{MPSTensor.mpv_smul}
+    \leanok
+    \uses{def:mpv, lem:eval_word_smul}
+    Let $\zeta A$ denote the tensor with matrices
+    $\{\zeta \, A^i\}_{i=0}^{d-1}$.
+    Then for every $N$ and every configuration
+    $\sigma = (i_1, \ldots, i_N)$,
+    \[
+        V^{(N)}(\zeta A)_\sigma
+            \;=\; \zeta^{N} \, V^{(N)}(A)_\sigma.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:eval_word_smul}
+    Apply Lemma~\ref{lem:eval_word_smul} to the word
+    $w = (i_1, \ldots, i_N)$ of length $N$, then take the trace; the scalar
+    $\zeta^{N}$ pulls out by linearity.
+\end{proof}
+
 \begin{definition}[Gauge-phase equivalence]\label{def:gauge_phase_equiv}
     \lean{MPSTensor.GaugePhaseEquiv}
     \leanok

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -139,12 +139,13 @@ and~\cite[Ch.~6]{Wolf2012Quantum}.
 	remaining factor $\eta_k$ is a unit-modulus phase.
 \end{theorem}
 
-\begin{proof}\leanok\uses{thm:mpv_decomposition, lem:eval_word_smul}
+\begin{proof}\leanok\uses{thm:mpv_decomposition, lem:mpv_smul}
 	By the MPV decomposition
 	(Theorem~\ref{thm:mpv_decomposition}),
 	the $k$-th contribution of $\bigoplus_k \mu_k A_k$ is
 	$\mu_k^N V^{(N)}(A_k)_\sigma$.
-	For $B_k = |\mu_k| A_k$, Lemma~\ref{lem:eval_word_smul} gives
+	For $B_k = |\mu_k| A_k$, the MPV-scaling lemma
+	(Lemma~\ref{lem:mpv_smul}) gives
 	$V^{(N)}(B_k)_\sigma = |\mu_k|^N V^{(N)}(A_k)_\sigma$.
 	Hence
 	$\eta_k^N V^{(N)}(B_k)_\sigma

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -123,7 +123,8 @@ and~\cite[Ch.~6]{Wolf2012Quantum}.
 \end{proof}
 
 \begin{theorem}[MPV under block normalization]\label{thm:mpv_normalize}
-	\notready
+	\lean{MPSTensor.mpv_toTensorFromBlocks_normalize}
+	\leanok
 	\uses{def:tensor_from_blocks, def:mpv}
 	For any nonzero scaling factors $\mu_k$, set
 	$\eta_k := \mu_k / |\mu_k|$ and $B_k := |\mu_k| A_k$.
@@ -138,7 +139,7 @@ and~\cite[Ch.~6]{Wolf2012Quantum}.
 	remaining factor $\eta_k$ is a unit-modulus phase.
 \end{theorem}
 
-\begin{proof}\uses{thm:mpv_decomposition, lem:eval_word_smul}
+\begin{proof}\leanok\uses{thm:mpv_decomposition, lem:eval_word_smul}
 	By the MPV decomposition
 	(Theorem~\ref{thm:mpv_decomposition}),
 	the $k$-th contribution of $\bigoplus_k \mu_k A_k$ is


### PR DESCRIPTION
### Motivation

- `thm:mpv_normalize` in `blueprint/src/chapter/ch08_canonical.tex` was marked `\notready` solely because the Lean wrapper theorem was missing; all ingredient lemmas (`eval_word_smul`, `mpv_toTensorFromBlocks`, `leftCanonical_smul_of_norm_one`) were already proved.
- Adding the wrapper closes this blueprint gap and contributes to the MPS canonical form formalization effort (see #906).

### Description

- Added `MPSTensor.mpv_toTensorFromBlocks_normalize` in `TNLean/MPS/SharedInfra/Scaling.lean`: for nonzero block weights `μ_k`, the MPV of `toTensorFromBlocks μ A` equals the MPV with each weight replaced by its unit phase `μ_k / ‖μ_k‖` and the block tensor rescaled by `‖μ_k‖`. Proof combines `mpv_toTensorFromBlocks_eq_sum`, `mpv_smul`, and the cancellation `(μ_k / ‖μ_k‖) * ‖μ_k‖ = μ_k`.
- Updated `blueprint/src/chapter/ch08_canonical.tex`: replaced `\notready` with `\leanok`, added `\lean{MPSTensor.mpv_toTensorFromBlocks_normalize}`, and marked the proof block `\leanok`.
- No new `sorry` or `axiom` introduced.

### Testing

- `lake build TNLean.MPS.SharedInfra.Scaling` verifies the new theorem compiles.
- `cd blueprint && leanblueprint checkdecls` validates the new `\lean{}` tag resolves.
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
Addresses #906

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone Lean lemma and flips a blueprint theorem from placeholder to `\leanok` without changing core definitions or algorithms; main risk is proof brittleness from new rewriting steps.
>
> **Overview**
> Proves a new Lean theorem `MPSTensor.mpv_toTensorFromBlocks_normalize` showing that, for nonzero block weights `μ_k`, the MPV of `toTensorFromBlocks μ A` is unchanged when each weight is replaced by its unit phase `μ_k/‖μ_k‖` and the modulus `‖μ_k‖` is absorbed into the corresponding block tensor.
>
> Updates the blueprint theorem `thm:mpv_normalize` from `\notready` to reference the Lean proof (`\lean{...}`) and marks the statement/proof as `\leanok`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9170f5f36876040fae92786b3743654e4a3e5e8.</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new standalone Lean theorem and updates blueprint references/ready status without changing any core definitions or algorithms; main risk is proof brittleness from additional rewriting/cancellation steps.
> 
> **Overview**
> Proves `MPSTensor.mpv_toTensorFromBlocks_normalize`, showing that for nonzero block weights `μ_k`, the MPV of `toTensorFromBlocks μ A` is unchanged when each weight is replaced by its unit phase `μ_k/‖μ_k‖` and the modulus `‖μ_k‖` is absorbed into the corresponding block tensor.
> 
> Updates the blueprint by adding a documented MPV scaling lemma (`lem:mpv_smul`) and flipping `thm:mpv_normalize` from `\notready` to `\leanok`, wiring it to the new Lean theorem and adjusting the proof to cite the new lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed36907fe89acd0d4e7bb0b27b00a85ee4a88dc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->