### PR TITLE
doc(blueprint): add thm:blocked_sector_projStep entry

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1835,6 +1835,37 @@ The following results separate the zero blocks from the
 \section{Reduction to primitive blocks}%
 \label{sec:reduction_to_normal_form}
 
+\begin{theorem}[Projection-step hypothesis yields primitive blocked sectors]%
+	\label{thm:blocked_sector_projStep}
+	\lean{MPSTensor.primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_projStep}
+	\leanok
+	\uses{thm:cyclic_sector_decomp_after_blocking,
+	      thm:sector_irred_proj_step,
+	      thm:primitive_adjoint_equiv}
+	Let $A$ be a left-canonical irreducible tensor whose adjoint transfer map has
+	peripheral spectrum $\{\gamma^j : 0 \le j < m\}$ for a primitive $m$-th root
+	of unity $\gamma$. Let $(C_u)_{u=1}^m$, $(P_u)_{u=1}^m$, and
+	$\varphi_u : \MN{\dim C_u} \xrightarrow{\sim} P_u \MN{D} P_u$
+	be the blocked cyclic-sector data. If the one-step projection-preservation
+	hypothesis of Lemma~\ref{lem:orbit_sum_hLift_proj_step} holds, then every
+	blocked sector tensor $C_u$ has primitive transfer map and is irreducible.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:sector_irred_proj_step,
+	      thm:primitive_adjoint_equiv}
+	Theorem~\ref{thm:sector_irred_proj_step} gives irreducibility of
+	$(\E_A^\dagger)^m$ on each corner $P_u$.
+	The blocked cyclic-sector data provide compression equivalences
+	$\varphi_u$ intertwining the adjoint transfer map of $C_u$ with the
+	corresponding corner restriction of $(\E_A^\dagger)^m$.
+	The same cyclic peripheral-spectrum argument that produces the sector
+	decomposition shows that each corner restriction is primitive.
+	Transport primitivity and irreducibility across $\varphi_u$, then use
+	Theorem~\ref{thm:primitive_adjoint_equiv} to pass from the adjoint blocked
+	map to the primal transfer map of $C_u$.
+\end{proof}
+
 \begin{theorem}[Fixed-point-algebra rigidity yields primitive blocked sectors]%
 	\label{thm:blocked_sector_fixed_algebra}
 	\lean{MPSTensor.primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1836,12 +1836,13 @@ The following results separate the zero blocks from the
 \label{sec:reduction_to_normal_form}
 
 \begin{theorem}[Projection-step hypothesis yields primitive blocked sectors]%
-	\label{thm:blocked_sector_projStep}
+	\label{thm:blocked_sector_proj_step}
 	\lean{MPSTensor.primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_projStep}
 	\leanok
 	\uses{thm:cyclic_sector_decomp_after_blocking,
 	      thm:sector_irred_proj_step,
-	      thm:primitive_adjoint_equiv}
+	      thm:primitive_adjoint_equiv,
+	      lem:orbit_sum_hLift_proj_step}
 	Let $A$ be a left-canonical irreducible tensor whose adjoint transfer map has
 	peripheral spectrum $\{\gamma^j : 0 \le j < m\}$ for a primitive $m$-th root
 	of unity $\gamma$. Let $(C_u)_{u=1}^m$, $(P_u)_{u=1}^m$, and


### PR DESCRIPTION
### Motivation
- Follow-up from #830 (*feat(MPS/CanonicalForm): wire fixed-algebra orbit lift into assembly*): the sibling theorem `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_projStep` had no corresponding blueprint entry, making the gap more visible by contrast with `thm:blocked_sector_fixed_algebra` added in #830.

### Description
- Adds `thm:blocked_sector_projStep` to `blueprint/src/chapter/ch08_canonical.tex` under `\section{Reduction to primitive blocks}`, mirroring the structure of `thm:blocked_sector_fixed_algebra`.
- Includes `\lean{MPSTensor.primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_projStep}`, `\leanok`, and `\uses{thm:cyclic_sector_decomp_after_blocking, thm:sector_irred_proj_step, thm:primitive_adjoint_equiv}`.
- States the result under the one-step projection-preservation hypothesis `hProjStep`: each blocked cyclic sector is irreducible and has a primitive transfer map.

### Testing
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- Blueprint validation: `cd blueprint && leanblueprint checkdecls` and `cd blueprint && leanblueprint web`.

---
Addresses #864

> [!NOTE]
> **Low Risk**
> Low risk: adds a new LaTeX blueprint theorem/proof without changing any executable code or existing statements, aside from introducing a new reference point reviewers should validate for mathematical correctness.
> 
> **Overview**
> Adds a new blueprint theorem `thm:blocked_sector_projStep` in `ch08_canonical.tex` stating that, under the *one-step projection-preservation* hypothesis, each blocked cyclic sector `C_u` is **irreducible** and has **primitive** transfer map.
> 
> Includes a short proof that chains existing results (`thm:sector_irred_proj_step`, cyclic-sector compression equivalences `\varphi_u`, and `thm:primitive_adjoint_equiv`) to transport primitivity/irreducibility from corner restrictions of `((\E_A^\dagger)^m)` to the blocked sector transfer maps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faff465bf0fb11159c7d0ec1a68bbd8eddbbaeef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adds a new blueprint theorem/proof entry without affecting Lean code or any executable logic; review is mainly for correctness of the stated dependencies and math wording.
> 
> **Overview**
> Adds a missing blueprint theorem `thm:blocked_sector_proj_step` in `ch08_canonical.tex` under *Reduction to primitive blocks*, covering the projection-step (one-step projection-preservation) hypothesis variant.
> 
> The new statement/proof asserts that, given the blocked cyclic-sector data, each sector block `C_u` is **irreducible** and has **primitive** transfer map, by chaining `thm:sector_irred_proj_step`, transporting properties across the compression equivalences `\varphi_u`, and applying `thm:primitive_adjoint_equiv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14faf4513244b53ba5f21fc9c8a6da76b500f827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->