### PR TITLE
feat(MPS/CanonicalForm): add conditional BNT sector LI adapter

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -336,7 +336,7 @@ sector comparison. The remaining formalizations are now:
 1. **General one-sided BNT construction**: starting from the blocked TP-primitive
    decomposition, construct a sector decomposition in the paper's general BNT
    sense. Since `HasBNTSectorData` is the eventual linear-independence predicate,
-   this cannot be obtained by merely packaging every TP-primitive block as its
+   this cannot be obtained by merely treating every TP-primitive block as its
    own basis tensor; gauge-phase-equivalent or otherwise dependent blocks must
    first be quotient/collapsed to a true basis of normal tensors. This is
    stronger than the current special-case theorem `exists_bnt_grouping`, which

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -335,9 +335,12 @@ sector comparison. The remaining formalizations are now:
 
 1. **General one-sided BNT construction**: starting from the blocked TP-primitive
    decomposition, construct a sector decomposition in the paper's general BNT
-   sense. This is stronger than the current special-case theorem
-   `exists_bnt_grouping`, which only collapses norm classes already known to
-   represent one MPV family.
+   sense. Since `HasBNTSectorData` is the eventual linear-independence predicate,
+   this cannot be obtained by merely packaging every TP-primitive block as its
+   own basis tensor; gauge-phase-equivalent or otherwise dependent blocks must
+   first be quotient/collapsed to a true basis of normal tensors. This is
+   stronger than the current special-case theorem `exists_bnt_grouping`, which
+   only collapses norm classes already known to represent one MPV family.
 
 2. **Witness-producing heterogeneous sector comparison**: the algebraic
    reduction from a matched basis to per-sector weight multiset equality is

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -338,7 +338,7 @@ sector comparison. The remaining formalizations are now:
    sense. Since `HasBNTSectorData` is the eventual linear-independence predicate,
    this cannot be obtained by merely treating every TP-primitive block as its
    own basis tensor; gauge-phase-equivalent or otherwise dependent blocks must
-   first be quotient/collapsed to a true basis of normal tensors. This is
+   first be identified and collapsed to a true basis of normal tensors. This is
    stronger than the current special-case theorem `exists_bnt_grouping`, which
    only collapses norm classes already known to represent one MPV family.
 

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -224,23 +224,62 @@ theorem exists_sortedNCF_of_distinct_norms
     dim_pos           := fun k => hDim (e k)
   }⟩
 
-/-! ### §4. Trivial sector decomposition for the sorted distinct-norm case -/
+/-! ### §4. Trivial sector decomposition -/
+
+/-- **Granular `SectorDecomposition` with one basis tensor per input block.**
+
+Packages a block family `(μ, blocks)` as a `SectorDecomposition` with `copies j = 1`
+for every `j`.  Each input block becomes its own sector basis tensor with sector
+weight `μ j`.  This construction is deliberately only a packaging device: by itself
+it does **not** assert the basis-of-normal-tensors linear-independence condition
+`HasBNTSectorData` from `TNLean.MPS.FundamentalTheorem.SectorDecomposition`. -/
+def trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hμne : ∀ k, μ k ≠ 0) : SectorDecomposition d where
+  basisCount := r
+  basisDim   := dim
+  basis      := blocks
+  sectors    := {
+    copies         := fun _ => 1
+    copies_pos     := fun _ => Nat.one_pos
+    weight         := fun j _ => μ j
+    weight_ne_zero := fun j _ => hμne j
+  }
+
+/-- **MPV identity for `trivialSectorDecomp`.**
+
+The assembled tensor of `trivialSectorDecomp μ blocks hμne` has the same MPV family
+as `toTensorFromBlocks μ blocks`.  The proof expands both sides via
+`mpv_toTensor_eq_sum_coeff` and `mpv_toTensorFromBlocks_eq_sum`, using that
+`coeff N j = (μ j)^N` because `copies j = 1`. -/
+lemma sameMPV₂_trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hμne : ∀ k, μ k ≠ 0) :
+    SameMPV₂ (trivialSectorDecomp μ blocks hμne).toTensor
+      (toTensorFromBlocks (d := d) (μ := μ) blocks) := by
+  intro N σ
+  set P := trivialSectorDecomp μ blocks hμne with hP
+  calc mpv P.toTensor σ
+      = ∑ j : Fin r, P.coeff N j * mpv (P.basis j) σ :=
+          P.mpv_toTensor_eq_sum_coeff σ
+    _ = ∑ j : Fin r, (μ j) ^ N * mpv (blocks j) σ := by
+          refine Finset.sum_congr rfl fun j _ => ?_
+          have hcoeff : P.coeff N j = (μ j) ^ N := by
+            simp [P, trivialSectorDecomp, SectorDecomposition.coeff,
+              SectorWeightData.coeff]
+          rw [hcoeff]
+          rfl
+    _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+          symm
+          simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
 
 /-- **Trivial `SectorDecomposition` from a sorted block family.**
 
-Given a block family `(μ, blocks)` with sorted (strictly decreasing) norms and
-nonzero weights, package it as a `SectorDecomposition` with `copies j = 1` for all
-`j`.  The BNT-level norm ordering condition (§ 4 in the docstring) holds trivially:
-each group has exactly one weight `μ j`, and those are already strictly decreasing.
-
-The assembled `P.toTensor` has `SameMPV₂` with `toTensorFromBlocks μ blocks`, proved
-by expanding both sides via the decomposition formulas:
-
-  `mpv P.toTensor σ = ∑ j, P.coeff N j * mpv (blocks j) σ`
-                    `= ∑ j, (μ j)^N * mpv (blocks j) σ`
-                    `= mpv (toTensorFromBlocks μ blocks) σ`.
-
-Here `P.coeff N j = ∑ q : Fin 1, (μ j)^N = (μ j)^N` because `copies j = 1`. -/
+Specialization of `trivialSectorDecomp` to the sorted distinct-norm case: every block
+becomes its own basis tensor with `copies j = 1`, the assembled tensor has
+`SameMPV₂` with `toTensorFromBlocks μ blocks`, and the BNT-level norm ordering is
+`StrictAnti` because each basis carries exactly one weight `μ j`, already strictly
+decreasing. -/
 theorem exists_trivialSectorDecomp_of_sorted_distinct_norms
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
@@ -252,40 +291,10 @@ theorem exists_trivialSectorDecomp_of_sorted_distinct_norms
       SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
       StrictAnti (fun j : Fin P.basisCount =>
         ‖P.sectors.weight j ⟨0, P.sectors.copies_pos j⟩‖) := by
-  -- Construct the trivial sector decomposition: one copy per block.
-  let sectors : SectorWeightData r := {
-    copies         := fun _ => 1
-    copies_pos     := fun _ => Nat.one_pos
-    weight         := fun j _ => μ j
-    weight_ne_zero := fun j _ => hμne j
-  }
-  let P : SectorDecomposition d := {
-    basisCount := r
-    basisDim   := dim
-    basis      := blocks
-    sectors    := sectors
-  }
-  refine ⟨P, rfl, ?_, ?_⟩
-  · -- SameMPV₂ P.toTensor (toTensorFromBlocks μ blocks).
-    -- Expand both sides using the sector decomposition and blocks formulas.
-    intro N σ
-    calc mpv P.toTensor σ
-        = ∑ j : Fin r, P.coeff N j * mpv (P.basis j) σ :=
-            P.mpv_toTensor_eq_sum_coeff σ
-      _ = ∑ j : Fin r, (μ j) ^ N * mpv (blocks j) σ := by
-            -- P.coeff N j = ∑ q : Fin (sectors.copies j), (sectors.weight j q)^N
-            --             = ∑ q : Fin 1, (μ j)^N = (μ j)^N.
-            refine Finset.sum_congr rfl fun j _ => congr_arg₂ _ ?_ rfl
-            simp [SectorDecomposition.coeff, SectorWeightData.coeff, P, sectors]
-      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
-            symm
-            simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
-  · -- StrictAnti on BNT-level norms.
-    -- sectors.weight j 0 = μ j by definition, so the condition is exactly hAnti.
-    intro i j hij
-    change ‖P.sectors.weight j ⟨0, P.sectors.copies_pos j⟩‖ <
-      ‖P.sectors.weight i ⟨0, P.sectors.copies_pos i⟩‖
-    simpa only [P, sectors] using hAnti hij
+  refine ⟨trivialSectorDecomp μ blocks hμne, rfl,
+    sameMPV₂_trivialSectorDecomp μ blocks hμne, ?_⟩
+  intro i j hij
+  simpa [trivialSectorDecomp] using hAnti hij
 
 /-! ### §5. BNT grouping for blocks with possibly equal norms -/
 

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -58,8 +58,8 @@ of the remaining Gap 2 work for issue #652 (labeled "Gap §1" in that issue).
 
 ### §3 Trivial sector decomposition for the sorted distinct-norm case
 
-* `exists_trivialSectorDecomp_of_sorted_distinct_norms` — Packages a sorted
-  distinct-norm block family as a `SectorDecomposition` with all multiplicities
+* `exists_trivialSectorDecomp_of_sorted_distinct_norms` — Forms from a sorted
+  distinct-norm block family a `SectorDecomposition` with all multiplicities
   `copies j = 1`.
 
 ### §4 BNT grouping for possibly-equal norms (proved via norm-class enumeration)
@@ -182,9 +182,9 @@ Starting from a weighted block family satisfying all `IsNormalCanonicalForm` con
 * a `SameMPV₂` equivalence between the original and the permuted assembled tensors,
 * an `IsNormalCanonicalForm` certificate for the permuted family `(μ ∘ e, blocks ∘ e)`.
 
-This is the key reduction bridging step: it takes output from the TP-gauge / blocking
-reduction (where distinct norms are known but ordering is not guaranteed) and packages
-it as a proper normal canonical form.
+This is the key reduction step: it takes output from the TP-gauge / blocking
+reduction (where distinct norms are known but ordering is not guaranteed) and turns
+it into a proper normal canonical form.
 
 **Note on types**: The permutation changes the bond-dimension type from
 `∑ k, dim k` to `∑ k, dim (e k)`; these are equal as natural numbers (via
@@ -212,7 +212,7 @@ theorem exists_sortedNCF_of_distinct_norms
   -- Step 1: Get the sorting permutation and SameMPV₂.
   obtain ⟨e, hSame, he_anti⟩ :=
     exists_sorted_blockDecomp_of_distinct_norms μ blocks hDistinct
-  -- Step 2: Package as IsNormalCanonicalForm.
+  -- Step 2: Build the IsNormalCanonicalForm certificate.
   -- All conditions for the permuted family at index k reduce to the original conditions
   -- at index (e k), because (fun k => blocks (e k)) k = blocks (e k).
   exact ⟨e, hSame, {
@@ -228,9 +228,9 @@ theorem exists_sortedNCF_of_distinct_norms
 
 /-- **Granular `SectorDecomposition` with one basis tensor per input block.**
 
-Packages a block family `(μ, blocks)` as a `SectorDecomposition` with `copies j = 1`
+Forms from a block family `(μ, blocks)` a `SectorDecomposition` with `copies j = 1`
 for every `j`.  Each input block becomes its own sector basis tensor with sector
-weight `μ j`.  This construction is deliberately only a packaging device: by itself
+weight `μ j`.  This construction is deliberately only a structural form: by itself
 it does **not** assert the basis-of-normal-tensors linear-independence condition
 `HasBNTSectorData` from `TNLean.MPS.FundamentalTheorem.SectorDecomposition`. -/
 def trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
@@ -249,8 +249,8 @@ def trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
 /-- **MPV identity for `trivialSectorDecomp`.**
 
 The assembled tensor of `trivialSectorDecomp μ blocks hμne` has the same MPV family
-as `toTensorFromBlocks μ blocks`.  The proof expands both sides via
-`mpv_toTensor_eq_sum_coeff` and `mpv_toTensorFromBlocks_eq_sum`, using that
+as `toTensorFromBlocks μ blocks`.  The proof expands both sides using the
+sector-decomposition formula and the block-sum formula, together with the identity
 `coeff N j = (μ j)^N` because `copies j = 1`. -/
 lemma sameMPV₂_trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -258,7 +258,7 @@ lemma sameMPV₂_trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
     SameMPV₂ (trivialSectorDecomp μ blocks hμne).toTensor
       (toTensorFromBlocks (d := d) (μ := μ) blocks) := by
   intro N σ
-  set P := trivialSectorDecomp μ blocks hμne with hP
+  set P := trivialSectorDecomp μ blocks hμne
   calc mpv P.toTensor σ
       = ∑ j : Fin r, P.coeff N j * mpv (P.basis j) σ :=
           P.mpv_toTensor_eq_sum_coeff σ

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -69,8 +69,8 @@ Theorem matching, etc.).
   the reduction output to a BNT-grouped `SectorDecomposition`.  **Fully proved.**
   Requires a `hNonDecay` hypothesis for equal-norm blocks.
 
-* `exists_bnt_sectorDecomp_of_linearIndependent` — minimal adapter to the
-  post-#886 `HasBNTSectorData` predicate.  It forms the granular
+* `exists_bnt_sectorDecomp_of_linearIndependent` — conditional construction
+  toward the post-#886 `HasBNTSectorData` predicate.  It forms the granular
   `trivialSectorDecomp` as a BNT sector decomposition when the actual BNT
   linear-independence condition is supplied explicitly.
 
@@ -375,7 +375,7 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
       exact ⟨ζ, hζne, hζ_norm, hmpv⟩
   exact bnt_grouping_single_norm_class μ blocks k0 hμne hNorm hPhase
 
-/-! ### §4. Adapter to the post-#886 BNT-sector predicate -/
+/-! ### §4. Conditional sector construction under BNT linear independence -/
 
 /-- **Minimal granular sector decomposition carrying current `HasBNTSectorData`.**
 
@@ -386,7 +386,7 @@ themselves provide that linear-independence statement for the granular basis; th
 genuine one-sided BNT construction must first choose / collapse to a basis of normal
 tensors.
 
-Accordingly this theorem exposes the minimal reusable adapter: if the granular input
+Accordingly this theorem gives the simplest construction: if the granular input
 basis is already known to satisfy the current BNT linear-independence hypothesis,
 then `trivialSectorDecomp` gives the requested `SectorDecomposition` and the
 `HasBNTSectorData` certificate is exactly the supplied `hLI`. -/
@@ -407,8 +407,8 @@ theorem exists_bnt_sectorDecomp_of_linearIndependent
 /-- Signature-compatible reformulation for TP / primitive / irreducible block data.
 
 The extra block-normality hypotheses are intentionally retained here to match the
-shape expected by the one-sided BNT-construction route, but the actual adapter only
-uses nonzero weights and the current BNT linear-independence hypothesis.  Use
+shape expected by the one-sided BNT-construction route, but only nonzero weights and the
+current BNT linear-independence hypothesis are used.  Use
 `exists_bnt_sectorDecomp_of_linearIndependent` when those extra hypotheses are not
 already present. -/
 theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.BNTGrouping
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Overlap.CastDecay
@@ -68,6 +69,11 @@ Theorem matching, etc.).
   the reduction output to a BNT-grouped `SectorDecomposition`.  **Fully proved.**
   Requires a `hNonDecay` hypothesis for equal-norm blocks.
 
+* `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent` —
+  Conditional adapter to the post-#886 `HasBNTSectorData` API.  It packages the
+  granular `trivialSectorDecomp` as a BNT sector decomposition when the actual
+  BNT linear-independence condition is supplied explicitly.
+
 ## References
 
 - [CPGSV17, Lemma A.2]: Overlap dichotomy for Normal Tensors.
@@ -106,7 +112,7 @@ The proof uses the **spectral dichotomy** (proved in `SpectralGap.lean` and
 If the overlap does NOT decay, we are in the second case. Dimension equality
 follows from `mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP` (contrapositive).
 
-This factored-out lemma replaces the previous monolithic sorry in
+This factored-out lemma replaces the previous monolithic placeholder proof in
 `gaugePhaseEquiv_of_equal_norm_blocks`. -/
 theorem gaugePhaseEquiv_of_nonDecaying_overlap
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
@@ -238,7 +244,10 @@ theorem exists_bnt_grouping_of_gaugePhaseEquiv
 
 This theorem relates the output of the existence reduction
 (`exists_tp_primitive_blockDecomp_after_blocking` in `Assembly.lean`) to a
-`SectorDecomposition` with strictly decreasing BNT-level norms.
+`SectorDecomposition` with strictly decreasing BNT-level norms.  It does not by
+itself prove `HasBNTSectorData`: after #886 that predicate means eventual linear
+independence of the basis MPV states, not merely TP / irreducible / primitive
+block data.
 
 The `hNonDecay` hypothesis states that equal-norm blocks have non-decaying
 cross-overlaps.  This is NOT automatic from the block properties alone (see
@@ -361,5 +370,36 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
           X ζ hX
       exact ⟨ζ, hζne, hζ_norm, hmpv⟩
   exact bnt_grouping_single_norm_class μ blocks k0 hμne hNorm hPhase
+
+/-! ### §4. Adapter to the post-#886 BNT-sector predicate -/
+
+/-- **Conditional granular sector decomposition carrying current `HasBNTSectorData`.**
+
+This is the coherent post-#886 version of the old PR #882 endpoint.  The predicate
+`HasBNTSectorData` now means eventual linear independence of the sector basis MPV
+states.  TP, irreducibility, primitivity, and nonzero weights do not by themselves
+provide that linear-independence statement for the granular basis; the genuine
+one-sided BNT construction must first choose / collapse to a basis of normal tensors.
+
+Accordingly this theorem exposes a small reusable adapter: if the granular input
+basis is already known to satisfy the current BNT linear-independence hypothesis,
+then `trivialSectorDecomp` gives the requested `SectorDecomposition` and the
+`HasBNTSectorData` certificate is exactly the supplied `hLI`. -/
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (_hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (_hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (_hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hLI : ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun k : Fin r => mpvState (blocks k) N)) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P := by
+  refine ⟨trivialSectorDecomp μ blocks hμne,
+    sameMPV₂_trivialSectorDecomp μ blocks hμne, ?_⟩
+  simpa [trivialSectorDecomp] using hLI
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -69,10 +69,14 @@ Theorem matching, etc.).
   the reduction output to a BNT-grouped `SectorDecomposition`.  **Fully proved.**
   Requires a `hNonDecay` hypothesis for equal-norm blocks.
 
+* `exists_bnt_sectorDecomp_of_linearIndependent` — minimal adapter to the
+  post-#886 `HasBNTSectorData` predicate.  It forms the granular
+  `trivialSectorDecomp` as a BNT sector decomposition when the actual BNT
+  linear-independence condition is supplied explicitly.
+
 * `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent` —
-  Conditional adapter to the post-#886 `HasBNTSectorData` API.  It packages the
-  granular `trivialSectorDecomp` as a BNT sector decomposition when the actual
-  BNT linear-independence condition is supplied explicitly.
+  signature-compatible reformulation retaining the TP / primitive / irreducible
+  inputs expected by the one-sided BNT construction chain.
 
 ## References
 
@@ -319,7 +323,7 @@ theorem exists_sectorDecomp_of_tp_primitive_irr_blocks
 
 /-- One-sector specialization of the TP + primitive + irreducible grouping route.
 
-This is a genuine restricted endpoint toward Gap §1: if all weights lie in a single norm class
+This is a genuine restricted result toward Gap §1: if all weights lie in a single norm class
 and every block has non-decaying overlap with a chosen representative, then the whole family
 collapses to a one-basis `SectorDecomposition`. -/
 theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
@@ -373,18 +377,40 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
 
 /-! ### §4. Adapter to the post-#886 BNT-sector predicate -/
 
-/-- **Conditional granular sector decomposition carrying current `HasBNTSectorData`.**
+/-- **Minimal granular sector decomposition carrying current `HasBNTSectorData`.**
 
-This is the coherent post-#886 version of the old PR #882 endpoint.  The predicate
-`HasBNTSectorData` now means eventual linear independence of the sector basis MPV
-states.  TP, irreducibility, primitivity, and nonzero weights do not by themselves
-provide that linear-independence statement for the granular basis; the genuine
-one-sided BNT construction must first choose / collapse to a basis of normal tensors.
+This is the post-#886 formulation of the conditional sector construction.  The
+predicate `HasBNTSectorData` now means eventual linear independence of the sector
+basis MPV states.  TP, irreducibility, primitivity, and nonzero weights do not by
+themselves provide that linear-independence statement for the granular basis; the
+genuine one-sided BNT construction must first choose / collapse to a basis of normal
+tensors.
 
-Accordingly this theorem exposes a small reusable adapter: if the granular input
+Accordingly this theorem exposes the minimal reusable adapter: if the granular input
 basis is already known to satisfy the current BNT linear-independence hypothesis,
 then `trivialSectorDecomp` gives the requested `SectorDecomposition` and the
 `HasBNTSectorData` certificate is exactly the supplied `hLI`. -/
+theorem exists_bnt_sectorDecomp_of_linearIndependent
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hLI : ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun k : Fin r => mpvState (blocks k) N)) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P := by
+  refine ⟨trivialSectorDecomp μ blocks hμne,
+    sameMPV₂_trivialSectorDecomp μ blocks hμne, ?_⟩
+  simpa [trivialSectorDecomp] using hLI
+
+/-- Signature-compatible reformulation for TP / primitive / irreducible block data.
+
+The extra block-normality hypotheses are intentionally retained here to match the
+shape expected by the one-sided BNT-construction route, but the actual adapter only
+uses nonzero weights and the current BNT linear-independence hypothesis.  Use
+`exists_bnt_sectorDecomp_of_linearIndependent` when those extra hypotheses are not
+already present. -/
 theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
@@ -397,9 +423,7 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent
       LinearIndependent ℂ (fun k : Fin r => mpvState (blocks k) N)) :
     ∃ P : SectorDecomposition d,
       SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
-      HasBNTSectorData (d := d) P := by
-  refine ⟨trivialSectorDecomp μ blocks hμne,
-    sameMPV₂_trivialSectorDecomp μ blocks hμne, ?_⟩
-  simpa [trivialSectorDecomp] using hLI
+      HasBNTSectorData (d := d) P :=
+  exists_bnt_sectorDecomp_of_linearIndependent μ blocks hμne hLI
 
 end MPSTensor

--- a/audits/2026-04-25_issue876_bnt_sector_blocker.md
+++ b/audits/2026-04-25_issue876_bnt_sector_blocker.md
@@ -1,0 +1,71 @@
+# Issue #876 / PR #882 current-main audit (2026-04-25)
+
+## What was checked
+
+- `gh issue view 876`
+- `gh pr view 882 --json mergeable,mergeStateStatus,reviewDecision,comments,headRefName`
+- `origin/main` after the merge of PR #886 and the later Gap §1 API PRs.
+- PR #882 head `f3df1df5` on branch
+  `claude/issue-876-formalizationmpscanonicalform-construct-general-bnt-sector`.
+
+## Decision
+
+PR #882 should not be force-rebased as-is.  Its main Lean contribution used the
+name `MPSTensor.HasBNTSectorData` for a basis-level package of positive bond
+dimension, TP/left-canonical normalization, irreducibility, and primitive
+transfer maps.  Current `main` already defines `MPSTensor.HasBNTSectorData` in
+`TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean` as the actual
+basis-of-normal-tensors hypothesis consumed by the sector comparison layer:
+
+eventual linear independence of the basis MPV states.
+
+Those are different mathematical predicates.  Replaying #882 would either
+reintroduce a conflicting name or silently weaken the post-#886 API.
+
+## Precise blocker
+
+The granular construction "one sector basis tensor per input block" is a useful
+packaging step, but it does not prove the current `HasBNTSectorData` predicate.
+TP + primitive + irreducible block data gives normal building blocks; it does
+not by itself prove that the MPV state family is eventually linearly independent.
+That is exactly the paper-level basis-of-normal-tensors construction: dependent
+or gauge-phase-equivalent normal tensors must be identified/collapsed, and the
+remaining basis must be proved linearly independent for all sufficiently large
+system sizes.
+
+So the old PR's target theorem is only coherent after adding an explicit BNT
+linear-independence hypothesis, or after proving the missing one-sided BNT
+construction theorem that produces such a basis from the blocked data.
+
+## Replacement branch contribution
+
+The replacement branch adds the small post-#886 adapter that is actually true:
+
+- `MPSTensor.trivialSectorDecomp`
+- `MPSTensor.sameMPV₂_trivialSectorDecomp`
+- `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent`
+
+The last theorem has the old TP/primitive/irreducible inputs but also requires
+
+a supplied eventual-linear-independence hypothesis
+`∃ N0, ∀ N > N0, LinearIndependent ℂ (fun k => mpvState (blocks k) N)`.
+It then packages the granular sector decomposition and discharges the current
+`HasBNTSectorData` by exactly that hypothesis.  This is not a closure of #876;
+it is the clean adapter that future real BNT construction can feed.
+
+## Remaining #876 theorem
+
+A full solution of #876 still needs a theorem constructing a genuine BNT basis
+from the blocked TP-primitive output.  Informally, it must:
+
+1. group/collapse gauge-phase-equivalent normal tensors, absorbing phases into
+   sector weights;
+2. retain multiple distinct basis tensors even when their coefficient moduli are
+   equal;
+3. prove eventual linear independence of the resulting basis MPV states;
+4. return a `SectorDecomposition` whose `HasBNTSectorData` is the current
+   post-#886 linear-independence predicate.
+
+Until that theorem exists, #860 and #877 should continue to treat the one-sided
+BNT sector pair as a hypothesis, as in
+`fundamentalTheorem_after_blocking_1606_sector_of_bntPair_matched`.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1981,11 +1981,40 @@ The following results separate the zero blocks from the
 	If each block is irreducible, trace-preserving, primitive, and has positive dimension, then sorting by strictly decreasing weight norms produces a normal canonical form.
 \end{theorem}
 
+\begin{definition}[Granular sector decomposition]
+	\label{def:trivial_sector_decomp}
+	\lean{MPSTensor.trivialSectorDecomp}
+	\leanok
+	\uses{def:paper_sector_data}
+	Given nonzero weights $(\mu_k)_{k=1}^r$ and blocks $(B_k)_{k=1}^r$,
+	form a sector decomposition with one basis block for each original block,
+	one copy in each sector, and sector weight $\mu_k$ on the $k$th sector.
+\end{definition}
+
+\begin{lemma}[Granular sector decomposition preserves the represented family]
+	\label{lem:trivial_sector_decomp_same_mpv}
+	\lean{MPSTensor.sameMPV₂_trivialSectorDecomp}
+	\leanok
+	\uses{def:trivial_sector_decomp}
+	The granular sector decomposition associated to $(\mu_k,B_k)_k$ represents
+	the same MPS family as the original weighted block sum
+	$\bigoplus_k \mu_k B_k$.
+\end{lemma}
+
+\begin{proof}\leanok
+	\uses{def:trivial_sector_decomp}
+	Expanding the sector decomposition gives the sum
+	$\sum_k \mu_k^N V^{(N)}(B_k)_\sigma$, which is exactly the finite
+	block-sum expression for $\bigoplus_k \mu_k B_k$.
+\end{proof}
+
 \begin{theorem}[Trivial sector decomposition for the sorted distinct-norm case]
 	\label{thm:bnt_trivial_sector}
 	\lean{MPSTensor.exists_trivialSectorDecomp_of_sorted_distinct_norms}\leanok
-	\uses{thm:bnt_sorted_reindexing}
-	If weights are already strictly decreasing in norm, one obtains a sector decomposition with one copy per sector that preserves the represented MPS family.
+	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv}
+	If weights are already strictly decreasing in norm, one obtains a sector
+	decomposition with one copy per sector that preserves the represented
+	MPS family.
 \end{theorem}
 
 \begin{definition}[Norm-class partition]
@@ -2042,8 +2071,48 @@ The following results separate the zero blocks from the
 	\label{thm:sector_decomp_tp_prim_irr}
 	\lean{MPSTensor.exists_sectorDecomp_of_tp_primitive_irr_blocks}\leanok
 	\uses{thm:gauge_equiv_nondecay, thm:bnt_grouping_gauge_equiv}
-	From a trace-preserving primitive irreducible block decomposition with nonzero weights and non-decaying cross-overlaps for equal-norm blocks, one obtains a sector decomposition with strict norm ordering.
+	From a trace-preserving primitive irreducible block decomposition with nonzero
+	weights and non-decaying cross-overlaps for equal-norm blocks, one obtains a
+	sector decomposition with strict norm ordering.
 \end{theorem}
+
+\begin{theorem}[Granular sector decomposition from eventual BNT independence]
+	\label{thm:bnt_sector_decomp_linear_independent}
+	\lean{MPSTensor.exists_bnt_sectorDecomp_of_linearIndependent}
+	\leanok
+	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv, def:bnt}
+	If the MPV states of the blocks are linearly independent for all sufficiently
+	large system sizes and all weights are nonzero, then the granular sector
+	decomposition represents the same MPS family and satisfies the BNT
+	linear-independence condition.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv, def:bnt}
+	The equality of represented families is
+	Lemma~\ref{lem:trivial_sector_decomp_same_mpv}.  The assumed eventual linear
+	independence is exactly the BNT condition for the basis blocks of the granular
+	sector decomposition.
+\end{proof}
+
+\begin{theorem}[TP primitive irreducible version with eventual BNT independence]
+	\label{thm:bnt_sector_decomp_tp_prim_irr_linear_independent}
+	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent}
+	\leanok
+	\uses{thm:bnt_sector_decomp_linear_independent}
+	For trace-preserving primitive irreducible blocks of positive bond dimension,
+	if the block MPV states are linearly independent for all sufficiently large
+	system sizes and the weights are nonzero, then there is a sector decomposition
+	representing the same MPS family and satisfying the BNT linear-independence
+	condition.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:bnt_sector_decomp_linear_independent}
+	Apply Theorem~\ref{thm:bnt_sector_decomp_linear_independent}; the additional
+	trace-preserving, primitive, irreducible, and positivity assumptions are carried
+	along for compatibility with the one-sided BNT construction.
+\end{proof}
 
 \subsection{Cyclic Sectors}
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2012,8 +2012,8 @@ The following results separate the zero blocks from the
 	\label{thm:bnt_trivial_sector}
 	\lean{MPSTensor.exists_trivialSectorDecomp_of_sorted_distinct_norms}\leanok
 	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv}
-	If weights are already strictly decreasing in norm, one obtains a sector
-	decomposition with one copy per sector that preserves the represented
+	If all weights are nonzero and strictly decreasing in norm, one obtains a
+	sector decomposition with one copy per sector that preserves the represented
 	MPS family.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2088,7 +2088,7 @@ The following results separate the zero blocks from the
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv, def:bnt}
+	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv}
 	The equality of represented families is
 	Lemma~\ref{lem:trivial_sector_decomp_same_mpv}.  The assumed eventual linear
 	independence is exactly the BNT condition for the basis blocks of the granular


### PR DESCRIPTION
Refs #876. Parent: #652. Supersedes the stale PR #882 rather than force-rebasing it.

## Summary

- Add `MPSTensor.trivialSectorDecomp` and `MPSTensor.sameMPV₂_trivialSectorDecomp`, factoring the granular one-sector-per-input-block packaging from `exists_trivialSectorDecomp_of_sorted_distinct_norms`.
- Add `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent`, the post-#886 coherent adapter: it produces a `SectorDecomposition` with the current `HasBNTSectorData` predicate when the actual eventual-linear-independence hypothesis is supplied explicitly.
- Record the #882/current-main blocker in `audits/2026-04-25_issue876_bnt_sector_blocker.md` and update roadmap comments to avoid confusing basis-level TP/irreducible/primitive data with the post-#886 BNT linear-independence predicate.

## Why this replaces #882

PR #882 defined `HasBNTSectorData` as basis-level positive dimension / TP / irreducible / primitive data. Current `main` already defines `HasBNTSectorData` in `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean` as eventual linear independence of the basis MPV states. Replaying #882 would reintroduce a conflicting meaning and would not feed #860/#877's current API.

This PR keeps the useful granular packaging but makes the missing theorem explicit: the full #876 endpoint still has to construct a genuine BNT basis and prove the current `HasBNTSectorData` condition for it.

## Validation

- `lake build TNLean.MPS.CanonicalForm.BNTGrouping TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem TNLean.MPS.FundamentalTheorem.SectorDecomposition` ✔
  - Note: the build replayed one pre-existing long-line warning in `Assembly/CyclicSectorDecomposition.lean:677`; this PR does not touch that file.
- `rg -n "sorry|axiom" TNLean/MPS/CanonicalForm/BNTGrouping.lean TNLean/MPS/CanonicalForm/EqualNormBridge.lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean || true` ✔ (no matches)
- `rg -n "(structure|def) HasBNTSectorData" TNLean/MPS` ✔ (only the post-#886 definition in `FundamentalTheorem/SectorDecomposition.lean`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes introduce new `SectorDecomposition` constructors/lemmas used in the canonical-form/Fundamental-Theorem pipeline, so downstream proofs may break if assumptions about `HasBNTSectorData` or MPV equivalences are misapplied, though the changes are mostly additive/refactoring.
> 
> **Overview**
> Adds a reusable “granular” sector-decomposition constructor `MPSTensor.trivialSectorDecomp` (one basis tensor per input block, `copies = 1`) plus `sameMPV₂_trivialSectorDecomp`, and refactors `exists_trivialSectorDecomp_of_sorted_distinct_norms` to use them.
> 
> Extends `EqualNormBridge.lean` with conditional adapters that produce a `SectorDecomposition` satisfying the *current* `HasBNTSectorData` (eventual linear independence) **only when** that linear-independence hypothesis is supplied explicitly (`exists_bnt_sectorDecomp_of_linearIndependent` and a TP/primitive/irreducible signature-compatible wrapper).
> 
> Clarifies roadmap/docs to avoid conflating TP/irreducible/primitive block data with `HasBNTSectorData`, and updates the blueprint plus a new audit note explaining why the older #882 approach is incompatible post-#886.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db126b93a97e9b470e770f5364efd684189315ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->