### PR TITLE
feat(MPS/ParentHamiltonian): add quadratic-form gap reduction (#460)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -64,6 +64,9 @@ concrete Friedrichs-angle/row-sum lower bound that
 * `MPSTensor.localTermESSummand_isPositive` — positivity of the conjugated
   cyclic-window summands expected to appear in the averaged
   `EuclideanSpace` formula for local terms.
+* `MPSTensor.parentHamiltonianES_gap_bound_of_quadratic_form` — the explicit
+  reduction from the parent-Hamiltonian gap statement to the uniform
+  Friedrichs/martingale quadratic-form estimate.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
   Friedrichs-angle bound recorded in
@@ -76,7 +79,7 @@ open scoped BigOperators InnerProductSpace
 
 The quadratic-form ⟹ norm-bound step is purely operator-theoretic and has no
 MPS content in its signature, so it lives in its own `FrustrationFree`
-namespace. The MPS-specific wrapper `MPSTensor.parentHamiltonian_gapped` below
+namespace. The MPS-specific theorem `MPSTensor.parentHamiltonian_gapped` below
 instantiates it for the parent Hamiltonian. -/
 
 namespace FrustrationFree
@@ -558,12 +561,73 @@ theorem parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES
     v ∈ parentHamiltonianGroundSpaceES A L N ↔ parentHamiltonianES A L N v = 0 := by
   rw [parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES, LinearMap.mem_ker]
 
+/-! ### Martingale quadratic-form reduction -/
+
+/-- A uniform quadratic-form estimate for the transported parent Hamiltonians
+implies the corresponding norm lower bound on the orthogonal complement of the
+transported ground space.
+
+This theorem isolates the operator-theoretic part of the remaining
+Friedrichs-angle route. The hypotheses already include the quantitative
+martingale/Friedrichs estimate
+
+`γ * re ⟪H_N v, v⟫ ≤ re ⟪H_N v, H_N v⟫`,
+
+to be supplied later from the finite-overlap projection geometry. The proof
+uses the established positivity of `parentHamiltonianES`, the kernel
+identification `parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES`, and
+the abstract spectral-theorem step `FrustrationFree.spectralGap_of_martingale`. -/
+theorem parentHamiltonianES_norm_bound_of_quadratic_form
+    (A : MPSTensor d D) (L : ℕ) {γ : ℝ} (hγ : 0 < γ)
+    (hQuad : ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+        γ * (⟪parentHamiltonianES A L N v, v⟫_ℂ).re ≤
+          (⟪parentHamiltonianES A L N v,
+              parentHamiltonianES A L N v⟫_ℂ).re) :
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
+  intro N hLN v hv
+  have hvKer : v ∈ (LinearMap.ker (parentHamiltonianES A L N))ᗮ := by
+    simpa [parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES A L N] using hv
+  exact FrustrationFree.spectralGap_of_martingale (ι := Cfg d N) hγ
+    (parentHamiltonianES_isPositive A L N) (hQuad N hLN) v hvKer
+
+/-- The exact explicit gap-bound reduction needed by
+`parentHamiltonianES_gap_bound_of_friedrichs` follows from the corresponding
+uniform quadratic-form estimate with constant `1 / (4 * L)`.
+
+Thus the remaining MPS-specific content is precisely to prove the hypothesis
+`hQuad` from the Friedrichs-angle / anti-commutator estimate and the finite
+row-sum bound; the positivity, kernel transport, and spectral-theorem conversion
+are already available here. -/
+theorem parentHamiltonianES_gap_bound_of_quadratic_form
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (hQuad : ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+        ((1 : ℝ) / (4 * (L : ℝ))) *
+          (⟪parentHamiltonianES A L N v, v⟫_ℂ).re ≤
+            (⟪parentHamiltonianES A L N v,
+                parentHamiltonianES A L N v⟫_ℂ).re) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  have hγ : 0 < (1 : ℝ) / (4 * (L : ℝ)) := by
+    have hLpos : (0 : ℝ) < (L : ℝ) := by
+      exact_mod_cast (Nat.zero_lt_of_lt hL)
+    exact div_pos (by norm_num) (mul_pos (by norm_num) hLpos)
+  exact ⟨hγ, parentHamiltonianES_norm_bound_of_quadratic_form A L hγ hQuad⟩
+
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
 /- Scout report (2026-04-19, Layer 4 KL martingale).
 
 1. **Friedrichs-angle surface:** TNLean currently has no dedicated
-`FriedrichsAngle`/principal-angle API in `TNLean/Analysis`. Mathlib provides
+`FriedrichsAngle`/principal-angle development in `TNLean/Analysis`. Mathlib provides
 orthogonal-projection infrastructure (for example
 `Mathlib.Analysis.InnerProductSpace.Projection.Basic` and
 `Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional`, exposing
@@ -571,16 +635,19 @@ orthogonal-projection infrastructure (for example
 Kastoryano–Lucia-style angle-to-anticommutator bound. This is a real blocker
 for quantitative overlap constants.
 2. **Positivity formulation:** the local `EuclideanSpace` projector
-`parentInteractionES A L` is positive, and each conjugated cyclic-restriction
-summand `localTermESSummand A hN L i τ = Rᵢ,τ† P_L Rᵢ,τ` is positive by
-`LinearMap.IsPositive.conj_adjoint`. Missing is the exact averaging identity
-relating these positive summands to the transported local terms.
-3. **Row-sum bound mapping:** the combinatorial part is already available from
+`parentInteractionES A L`, each conjugated cyclic-restriction summand
+`localTermESSummand A hN L i τ = Rᵢ,τ† P_L Rᵢ,τ`, each transported local term,
+and the full transported Hamiltonian are now available as positive operators.
+3. **Quadratic-form reduction:**
+`parentHamiltonianES_norm_bound_of_quadratic_form` and
+`parentHamiltonianES_gap_bound_of_quadratic_form` reduce the gap statement to a
+uniform estimate `γ * re ⟪H_N v, v⟫ ≤ re ⟪H_N v, H_N v⟫`.
+4. **Row-sum bound mapping:** the combinatorial part is already available from
 locality (`localTerm`, `parentHamiltonian`) and finite range: each window
 overlaps at most `2 * (L - 1)` neighbors. Missing is the analytic implication
-from overlap-angle constants to operator-inequality coefficients `cᵢⱼ`.
-4. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
-existential wrapper, now proved by applying the Friedrichs-angle theorem
+from overlap-angle constants to the quadratic-form inequality above.
+5. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
+existential theorem, now proved by applying the Friedrichs-angle theorem
 below. The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends
 on missing Friedrichs-angle infrastructure; this is the blocker and should not
 be replaced with axioms or unrelated sorrys. -/
@@ -600,14 +667,11 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
-  -- Remaining obligations: the averaging identity expressing transported local
-  -- terms as finite averages of `localTermESSummand`, the MPS-specific
-  -- Friedrichs-angle estimate for adjacent local ground spaces, and the
-  -- finite-overlap row-sum bound. The kernel identification needed for the
-  -- final martingale application is now available as
-  -- `parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES`. Once the
-  -- remaining analytic inputs are formalized, this should feed the resulting
-  -- quadratic-form inequality into `FrustrationFree.spectralGap_of_martingale`.
+  -- Remaining obligation: derive the uniform quadratic-form estimate required by
+  -- `parentHamiltonianES_gap_bound_of_quadratic_form` from the MPS-specific
+  -- Friedrichs-angle estimate for adjacent local ground spaces and the
+  -- finite-overlap row-sum bound. Positivity, kernel identification, and the
+  -- spectral-theorem conversion are already formalized above.
   sorry
 
 /--

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1550,6 +1550,40 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \ge \gamma^2 \sum_k |c_k|^2 = \gamma^2 \|v\|^2$.
 \end{proof}
 
+\begin{lemma}[Parent-Hamiltonian quadratic-form reduction]
+    \label{lem:parent_hamiltonian_es_quadratic_reduction}
+    \lean{MPSTensor.parentHamiltonianES_norm_bound_of_quadratic_form}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_quadratic_form}
+    \leanok
+    \uses{lem:transported_es_positive, thm:parent_ground_space_es_kernel,
+        lem:quadratic_form_to_norm_bound}
+    Let $H_{N,L}^{\mathrm{ES}}(A)$ be the transported parent Hamiltonian. If a
+    constant $\gamma > 0$ satisfies the uniform quadratic-form estimate
+    \[
+        \gamma\,\operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}(A)v, v\rangle
+        \le
+        \operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}(A)v,
+            H_{N,L}^{\mathrm{ES}}(A)v\rangle
+    \]
+    for every $N \ge 2L$ and every vector $v$, then
+    \[
+        \gamma\,\|v\| \le \|H_{N,L}^{\mathrm{ES}}(A)v\|
+    \]
+    for every $v \in (\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$. In particular,
+    with $L>1$ and $\gamma = 1/(4L)$, the explicit gap-bound conclusion follows
+    once this same quadratic-form estimate is supplied.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The transported Hamiltonian is positive by
+    Lemma~\ref{lem:transported_es_positive}, and its transported ground space is
+    its kernel by Theorem~\ref{thm:parent_ground_space_es_kernel}. Therefore the
+    abstract spectral-theorem conversion of
+    Lemma~\ref{lem:quadratic_form_to_norm_bound} applies directly. The
+    explicit constant is positive because $L>1$ implies $4L>0$.
+\end{proof}
+
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
     \notready
     \uses{def:is_frustration_free, lem:quadratic_form_to_norm_bound}
@@ -1712,7 +1746,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{def:parent_ground_space_es, def:parent_hamiltonian_es,
         thm:parent_ground_space_es_kernel,
         rem:euclidean_local_projector_ingredients,
-        lem:euclidean_local_projector_positive}
+        lem:euclidean_local_projector_positive,
+        lem:local_term_es_average,
+        lem:parent_hamiltonian_es_quadratic_reduction}
     For an injective tensor $A$ and a range $L > 1$, the theorem asserts
     the analytic estimate with the explicit constant
     \[
@@ -1727,13 +1763,12 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \notready
-    The missing argument has two parts. First, one identifies each transported
-    local term with a finite average of the conjugate summands from
-    Remark~\ref{rem:euclidean_local_projector_ingredients};
-    Lemma~\ref{lem:euclidean_local_projector_positive} then supplies positivity
-    of the local Euclidean operators. Second, the MPS-specific Friedrichs-angle
-    estimate together with the row-sum bound feeds into the abstract martingale
-    criterion.
+    The local averaging identity and positivity statements are now formalized in
+    Lemmas~\ref{lem:local_term_es_average} and~\ref{lem:transported_es_positive}.
+    Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} reduces the present
+    theorem to the remaining MPS-specific task: deriving the uniform
+    quadratic-form estimate from the Friedrichs-angle anti-commutator bound and
+    the finite-overlap row-sum estimate.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}


### PR DESCRIPTION
## Summary

- add `MPSTensor.parentHamiltonianES_norm_bound_of_quadratic_form`, reducing any uniform quadratic-form estimate for `parentHamiltonianES` to the desired norm lower bound on the transported ground-space orthogonal complement;
- add `MPSTensor.parentHamiltonianES_gap_bound_of_quadratic_form`, the exact explicit `1/(4L)` gap-bound shape needed by `parentHamiltonianES_gap_bound_of_friedrichs` once the Friedrichs/row-sum quadratic-form estimate is available;
- update the Martingale scout comment and blueprint Chapter 14 to record that positivity/kernel/spectral-theorem conversion are now formalized, leaving the genuine projection-geometry/Friedrichs estimate.

This is a faithful incremental step toward #460 / #190; it does not claim the remaining Friedrichs-angle analytic estimate.

## Verification

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale`
- `lake build TNLean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `rg -n "\\bsorry\\b|\\baxiom\\b|\\badmit\\b|native_decide" TNLean/MPS/ParentHamiltonian/Martingale.lean blueprint/src/chapter/ch14_parent_hamiltonian.tex`
  - only the pre-existing `parentHamiltonianES_gap_bound_of_friedrichs` `sorry` remains in `Martingale.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean theorems/documentation and refactors proof structure without changing existing definitions or computational behavior; the remaining gap proof is still `sorry`-blocked at the Friedrichs-angle estimate.
> 
> **Overview**
> Introduces `MPSTensor.parentHamiltonianES_norm_bound_of_quadratic_form`, which turns any uniform quadratic-form inequality for `parentHamiltonianES` into the desired norm lower bound on `(parentHamiltonianGroundSpaceES)ᗮ` by reusing positivity, the `ker` identification, and `FrustrationFree.spectralGap_of_martingale`.
> 
> Adds `MPSTensor.parentHamiltonianES_gap_bound_of_quadratic_form`, specializing the reduction to the explicit constant `1 / (4 * L)` and returning the exact statement shape expected by `parentHamiltonianES_gap_bound_of_friedrichs`; accompanying comments and Chapter 14 blueprint text are updated to reflect that the remaining work is now solely the Friedrichs-angle/row-sum quadratic-form estimate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa465ddd9332f6a087d670536387ffd39478dc6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->