### PR TITLE
feat(Algebra/PF): add PSD trace-power rank-one criterion

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -31,6 +31,7 @@ import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.MatrixFrobenius
+import TNLean.Algebra.PerronFrobenius.RankOne
 import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.ScalarCommutant
 import TNLean.Algebra.CocycleCohomology

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -234,7 +234,7 @@ rank-one hypothesis from Lemma C.4.
 
 The PSD theorem is stronger than the primitive-matrix criterion once the trace
 normalization is available. -/
-theorem primitive_trace_powers_constant_implies_rank_one_of_pos_semidef
+theorem primitive_trace_powers_constant_implies_rank_one_of_posSemidef
     {T : Matrix (Fin n) (Fin n) ℝ}
     (hPSD : T.PosSemidef) (hTrace : Matrix.trace T = 1) :
     PrimitiveTracePowersConstantImpliesRankOne T := by

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -26,7 +26,6 @@ hypotheses because it is part of the paper's construction of the auxiliary
 matrix `T`.
 -/
 
-open BigOperators
 open scoped BigOperators Matrix ComplexOrder
 
 namespace Matrix
@@ -46,10 +45,10 @@ def TracePowersConstant (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
 
 /-- The conditional Perron--Frobenius hypothesis for Appendix C.2, Lemma C.4.
 
-This predicate is kept for callers that phrase the rank-one step as a local
-hypothesis. As a universally quantified statement over primitive nonnegative
-real matrices it is false: there exist primitive nonnegative matrices with
-constant trace powers and rank greater than one. See
+This predicate is retained for theorems that assume this implication directly
+as a hypothesis. As a universally quantified statement over primitive
+nonnegative real matrices it is false: there exist primitive nonnegative
+matrices with constant trace powers and rank greater than one. See
 `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`.
 
 The corrected theorem in this module is

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -150,11 +150,13 @@ private lemma hasRankOneFactorization_unitary_conj
   classical
   rcases hT with ⟨a, b, rfl⟩
   refine ⟨(U : Matrix (Fin n) (Fin n) ℝ) *ᵥ a,
-    fun j => ∑ k, b k * (star (U : Matrix (Fin n) (Fin n) ℝ)) k j, ?_⟩
+    (U : Matrix (Fin n) (Fin n) ℝ) *ᵥ b, ?_⟩
   ext i j
-  simp [Matrix.mul_apply, Matrix.vecMulVec, Matrix.mulVec, dotProduct,
-    Finset.mul_sum, Finset.sum_mul]
-  ring_nf
+  simp only [Matrix.mul_apply, Matrix.vecMulVec_apply, Matrix.mulVec, dotProduct,
+    Finset.mul_sum, Finset.sum_mul, Matrix.star_apply, star_trivial]
+  refine Finset.sum_congr rfl fun x _ => ?_
+  refine Finset.sum_congr rfl fun x_1 _ => ?_
+  ring
 
 /-- For a positive semidefinite matrix over the real or complex numbers, the
 trace of the square is the sum of the squares of its Hermitian eigenvalues. -/

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -34,8 +34,7 @@ namespace Matrix
 variable {n : ℕ}
 
 /-- A square real matrix has the rank-one factorization of Appendix C.2,
-Lemma C.4 if it is an outer product `a bᵀ`, represented in Lean as
-`Matrix.vecMulVec a b`. -/
+Lemma C.4 if it is an outer product of two vectors. -/
 def HasRankOneFactorization (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b
 

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -1,0 +1,237 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+
+/-!
+# Rank-one criteria for the MPDO Perron--Frobenius trace matrix
+
+This module isolates the finite-dimensional matrix step used in Appendix C.2,
+Lemma C.4 of arXiv:1606.00608.  The bare Perron--Frobenius statement
+"primitive plus constant trace powers implies rank one" is false, so the
+usable theorem here records the extra diagonalizability supplied by positive
+semidefiniteness.
+
+The main corrected theorem is
+`Matrix.PosSemidefTracePowersConstantImpliesRankOne`: if a real finite matrix is
+positive semidefinite, has trace one, and has constant traces on all positive
+powers, then it factors as an outer product.  Primitivity is not needed for this
+strengthened statement; it remains in the surrounding MPDO interface because it
+is part of the paper's construction of the auxiliary matrix `T`.
+-/
+
+open BigOperators
+open scoped BigOperators Matrix
+
+namespace Matrix
+
+variable {n : ℕ}
+
+/-- A square real matrix has the rank-one factorization of Appendix C.2,
+Lemma C.4 if it is an outer product `a bᵀ`, represented in Lean as
+`Matrix.vecMulVec a b`. -/
+def HasRankOneFactorization (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
+  ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b
+
+/-- The traces of all positive powers of `T` agree with the trace of `T`
+itself. This is the matrix-theoretic consequence of the ZCL step used in
+Appendix C.2, Lemma C.4. -/
+def TracePowersConstant (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
+  ∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T
+
+/-- The scoped Perron--Frobenius input for Appendix C.2, Lemma C.4.
+
+This predicate is retained as a compatibility interface for files that still
+phrase the rank-one step as a local hypothesis. As a universally quantified
+statement over primitive nonnegative real matrices it is false: there exist
+primitive nonnegative matrices with constant trace powers and rank greater than
+one. See `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`.
+
+The corrected theorem in this module is
+`Matrix.PosSemidefTracePowersConstantImpliesRankOne`, which discharges this
+predicate whenever the concrete matrix `T` is positive semidefinite and has
+trace one. -/
+def PrimitiveTracePowersConstantImpliesRankOne
+    (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
+  Matrix.IsPrimitive T → TracePowersConstant T → HasRankOneFactorization T
+
+/-- A finite family of nonnegative real numbers with sum and sum of squares both
+one has exactly one nonzero entry, and that entry is one. -/
+private lemma exists_eq_one_of_sum_eq_one_sum_sq_eq_one_nonneg
+    {ι : Type*} [Fintype ι] (lam : ι → ℝ)
+    (h_nonneg : ∀ i, 0 ≤ lam i)
+    (h_sum : ∑ i, lam i = 1)
+    (h_sq : ∑ i, (lam i) ^ 2 = 1) :
+    ∃ i, lam i = 1 ∧ ∀ j, j ≠ i → lam j = 0 := by
+  classical
+  have hle_one : ∀ i, lam i ≤ 1 := by
+    intro i
+    calc
+      lam i ≤ ∑ j, lam j :=
+        Finset.single_le_sum (fun j _ => h_nonneg j) (Finset.mem_univ i)
+      _ = 1 := h_sum
+  have hterm_nonneg : ∀ i, 0 ≤ lam i * (1 - lam i) := by
+    intro i
+    exact mul_nonneg (h_nonneg i) (sub_nonneg.mpr (hle_one i))
+  have hsum_term : ∑ i, lam i * (1 - lam i) = 0 := by
+    calc
+      ∑ i, lam i * (1 - lam i) = ∑ i, (lam i - (lam i) ^ 2) := by
+        simp [mul_sub, pow_two]
+      _ = (∑ i, lam i) - ∑ i, (lam i) ^ 2 := by
+        rw [Finset.sum_sub_distrib]
+      _ = 0 := by rw [h_sum, h_sq]; norm_num
+  have hterm_zero : ∀ i, lam i * (1 - lam i) = 0 := by
+    intro i
+    exact (Finset.sum_eq_zero_iff_of_nonneg
+      (fun j _ => hterm_nonneg j)).mp hsum_term i (Finset.mem_univ i)
+  have hex : ∃ i, lam i = 1 := by
+    by_contra hno
+    have hall_zero : ∀ i, lam i = 0 := by
+      intro i
+      have hz := hterm_zero i
+      have hcases : lam i = 0 ∨ 1 - lam i = 0 := by
+        exact mul_eq_zero.mp hz
+      rcases hcases with h0 | h1
+      · exact h0
+      · exfalso
+        apply hno
+        exact ⟨i, by linarith⟩
+    have hsum0 : ∑ i, lam i = 0 := by simp [hall_zero]
+    linarith
+  rcases hex with ⟨i, hi⟩
+  refine ⟨i, hi, ?_⟩
+  have hsum_erase : (Finset.univ.erase i).sum lam = 0 := by
+    have hdecomp :=
+      Finset.sum_erase_add (s := Finset.univ) (a := i) (f := lam) (Finset.mem_univ i)
+    rw [h_sum, hi] at hdecomp
+    linarith
+  intro j hji
+  have hj_mem : j ∈ Finset.univ.erase i := by simp [hji]
+  exact (Finset.sum_eq_zero_iff_of_nonneg
+    (fun k _ => h_nonneg k)).mp hsum_erase j hj_mem
+
+/-- Diagonal version of the trace-one/square-trace-one rank-one criterion. -/
+private lemma diagonal_hasRankOneFactorization
+    (d : Fin n → ℝ)
+    (h_nonneg : ∀ i, 0 ≤ d i)
+    (h_sum : ∑ i, d i = 1)
+    (h_sq : ∑ i, (d i) ^ 2 = 1) :
+    HasRankOneFactorization (Matrix.diagonal d) := by
+  classical
+  rcases exists_eq_one_of_sum_eq_one_sum_sq_eq_one_nonneg d h_nonneg h_sum h_sq with
+    ⟨i, hi, hzero⟩
+  refine ⟨Pi.single i 1, Pi.single i 1, ?_⟩
+  ext j k
+  by_cases hji : j = i
+  · subst j
+    by_cases hki : k = i
+    · subst k
+      simp [Matrix.diagonal, Matrix.vecMulVec, hi]
+    · have hik : i ≠ k := fun h => hki h.symm
+      simp [Matrix.diagonal, Matrix.vecMulVec, hki, hik]
+  · have hjzero : d j = 0 := hzero j hji
+    by_cases hki : k = i
+    · subst k
+      simp [Matrix.diagonal, Matrix.vecMulVec, hji]
+    · simp [Matrix.diagonal, Matrix.vecMulVec, hji, hki, hjzero]
+
+/-- Rank-one factorizations are preserved by unitary conjugation. -/
+private lemma hasRankOneFactorization_unitary_conj
+    (U : Matrix.unitaryGroup (Fin n) ℝ) {T : Matrix (Fin n) (Fin n) ℝ}
+    (hT : HasRankOneFactorization T) :
+    HasRankOneFactorization
+      ((U : Matrix (Fin n) (Fin n) ℝ) * T * star (U : Matrix (Fin n) (Fin n) ℝ)) := by
+  classical
+  rcases hT with ⟨a, b, rfl⟩
+  refine ⟨(U : Matrix (Fin n) (Fin n) ℝ) *ᵥ a,
+    fun j => ∑ k, b k * (star (U : Matrix (Fin n) (Fin n) ℝ)) k j, ?_⟩
+  ext i j
+  simp [Matrix.mul_apply, Matrix.vecMulVec, Matrix.mulVec, dotProduct,
+    Finset.mul_sum, Finset.sum_mul]
+  ring_nf
+
+/-- For a positive semidefinite real matrix, the trace of the square is the sum
+of the squares of its Hermitian eigenvalues. -/
+theorem PosSemidef.trace_sq_eq_sum_eigenvalues_sq
+    {T : Matrix (Fin n) (Fin n) ℝ} (hT : T.PosSemidef) :
+    Matrix.trace (T ^ 2) = ∑ i, (hT.isHermitian.eigenvalues i) ^ 2 := by
+  let hH : T.IsHermitian := hT.isHermitian
+  let U := hH.eigenvectorUnitary
+  let D : Matrix (Fin n) (Fin n) ℝ := diagonal hH.eigenvalues
+  have hspec : T = (Unitary.conjStarAlgAut ℝ (Matrix (Fin n) (Fin n) ℝ) U) D := by
+    simpa [D, U] using hH.spectral_theorem
+  calc
+    Matrix.trace (T ^ 2) =
+        Matrix.trace (((Unitary.conjStarAlgAut ℝ (Matrix (Fin n) (Fin n) ℝ) U) D) ^ 2) := by
+      rw [hspec]
+    _ = Matrix.trace ((Unitary.conjStarAlgAut ℝ (Matrix (Fin n) (Fin n) ℝ) U) (D ^ 2)) := by
+      rw [map_pow]
+    _ = Matrix.trace (D ^ 2) := by
+      simp [Unitary.conjStarAlgAut_apply, D, Matrix.trace_mul_cycle]
+    _ = ∑ i, (hH.eigenvalues i) ^ 2 := by
+      simp [D, diagonal_mul_diagonal, pow_two]
+
+/-- **Corrected rank-one criterion for Lemma C.4.**
+
+If a real finite matrix is positive semidefinite, has trace one, and has
+constant trace on all positive powers, then it has a rank-one factorization.
+This is the diagonalizable/PSD strengthening missing from the false bare
+primitive Perron--Frobenius statement. -/
+theorem PosSemidefTracePowersConstantImpliesRankOne
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPSD : T.PosSemidef)
+    (hTrace : Matrix.trace T = 1)
+    (hTPC : TracePowersConstant T) :
+    HasRankOneFactorization T := by
+  classical
+  let hH : T.IsHermitian := hPSD.isHermitian
+  let lam : Fin n → ℝ := hH.eigenvalues
+  have hsum : ∑ i, lam i = 1 := by
+    have htrace := hH.trace_eq_sum_eigenvalues
+    change Matrix.trace T = ∑ i, (lam i : ℝ) at htrace
+    rw [hTrace] at htrace
+    exact htrace.symm
+  have htrace2 : Matrix.trace (T ^ 2) = 1 := by
+    calc
+      Matrix.trace (T ^ 2) = Matrix.trace T := hTPC 2 (by norm_num)
+      _ = 1 := hTrace
+  have hsq : ∑ i, (lam i) ^ 2 = 1 := by
+    have htrace2eig := hPSD.trace_sq_eq_sum_eigenvalues_sq
+    change Matrix.trace (T ^ 2) = ∑ i, (lam i) ^ 2 at htrace2eig
+    rw [htrace2] at htrace2eig
+    exact htrace2eig.symm
+  have hnonneg : ∀ i, 0 ≤ lam i := by
+    intro i
+    exact hPSD.eigenvalues_nonneg i
+  have hD : HasRankOneFactorization (Matrix.diagonal lam) :=
+    diagonal_hasRankOneFactorization lam hnonneg hsum hsq
+  let U := hH.eigenvectorUnitary
+  have hconj : HasRankOneFactorization
+      ((U : Matrix (Fin n) (Fin n) ℝ) * Matrix.diagonal lam *
+        star (U : Matrix (Fin n) (Fin n) ℝ)) :=
+    hasRankOneFactorization_unitary_conj U hD
+  have hspec :
+      T = (U : Matrix (Fin n) (Fin n) ℝ) * Matrix.diagonal lam *
+        star (U : Matrix (Fin n) (Fin n) ℝ) := by
+    change T = (U : Matrix (Fin n) (Fin n) ℝ) * Matrix.diagonal hH.eigenvalues *
+      star (U : Matrix (Fin n) (Fin n) ℝ)
+    simpa [Unitary.conjStarAlgAut_apply] using hH.spectral_theorem
+  rcases hconj with ⟨a, b, hab⟩
+  exact ⟨a, b, by rw [hspec, hab]⟩
+
+/-- Positive semidefiniteness and trace normalization discharge the scoped
+primitive rank-one predicate. The primitive hypothesis is accepted and ignored:
+the PSD theorem is stronger once the trace normalization is available. -/
+theorem primitiveTracePowersConstantImpliesRankOne_of_posSemidef
+    {T : Matrix (Fin n) (Fin n) ℝ}
+    (hPSD : T.PosSemidef) (hTrace : Matrix.trace T = 1) :
+    PrimitiveTracePowersConstantImpliesRankOne T := by
+  intro _hPrimitive hTPC
+  exact PosSemidefTracePowersConstantImpliesRankOne T hPSD hTrace hTPC
+
+end Matrix

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -156,8 +156,8 @@ private lemma hasRankOneFactorization_unitary_conj
     Finset.mul_sum, Finset.sum_mul]
   ring_nf
 
-/-- For a positive semidefinite matrix over an `RCLike` field, the trace of
-the square is the sum of the squares of its Hermitian eigenvalues. -/
+/-- For a positive semidefinite matrix over the real or complex numbers, the
+trace of the square is the sum of the squares of its Hermitian eigenvalues. -/
 theorem PosSemidef.trace_sq_eq_sum_eigenvalues_sq
     {ι 𝕜 : Type*} [Fintype ι] [DecidableEq ι] [RCLike 𝕜]
     {T : Matrix ι ι 𝕜} (hT : T.PosSemidef) :
@@ -229,8 +229,10 @@ theorem PosSemidef.trace_powers_constant_implies_rank_one
   exact ⟨a, b, by rw [hspec, hab]⟩
 
 /-- Positive semidefiniteness and trace normalization establish the auxiliary
-primitive rank-one hypothesis. The primitive hypothesis is accepted and ignored:
-the PSD theorem is stronger once the trace normalization is available. -/
+rank-one hypothesis from Lemma C.4.
+
+The PSD theorem is stronger than the primitive-matrix criterion once the trace
+normalization is available. -/
 theorem primitive_trace_powers_constant_implies_rank_one_of_pos_semidef
     {T : Matrix (Fin n) (Fin n) ℝ}
     (hPSD : T.PosSemidef) (hTrace : Matrix.trace T = 1) :

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -18,15 +18,16 @@ usable theorem here records the extra diagonalizability supplied by positive
 semidefiniteness.
 
 The main corrected theorem is
-`Matrix.PosSemidefTracePowersConstantImpliesRankOne`: if a real finite matrix is
-positive semidefinite, has trace one, and has constant traces on all positive
-powers, then it factors as an outer product.  Primitivity is not needed for this
-strengthened statement; it remains in the surrounding MPDO interface because it
-is part of the paper's construction of the auxiliary matrix `T`.
+`Matrix.PosSemidef.trace_powers_constant_implies_rank_one`: if a real finite
+matrix is positive semidefinite, has trace one, and has constant traces on all
+positive powers, then it factors as an outer product.  Primitivity is not needed
+for this strengthened statement; it remains among the surrounding MPDO
+hypotheses because it is part of the paper's construction of the auxiliary
+matrix `T`.
 -/
 
 open BigOperators
-open scoped BigOperators Matrix
+open scoped BigOperators Matrix ComplexOrder
 
 namespace Matrix
 
@@ -44,18 +45,18 @@ Appendix C.2, Lemma C.4. -/
 def TracePowersConstant (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   ∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T
 
-/-- The scoped Perron--Frobenius input for Appendix C.2, Lemma C.4.
+/-- The conditional Perron--Frobenius hypothesis for Appendix C.2, Lemma C.4.
 
-This predicate is retained as a compatibility interface for files that still
-phrase the rank-one step as a local hypothesis. As a universally quantified
-statement over primitive nonnegative real matrices it is false: there exist
-primitive nonnegative matrices with constant trace powers and rank greater than
-one. See `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`.
+This predicate is kept for callers that phrase the rank-one step as a local
+hypothesis. As a universally quantified statement over primitive nonnegative
+real matrices it is false: there exist primitive nonnegative matrices with
+constant trace powers and rank greater than one. See
+`TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`.
 
 The corrected theorem in this module is
-`Matrix.PosSemidefTracePowersConstantImpliesRankOne`, which discharges this
-predicate whenever the concrete matrix `T` is positive semidefinite and has
-trace one. -/
+`Matrix.PosSemidef.trace_powers_constant_implies_rank_one`, which establishes
+this hypothesis whenever the concrete matrix `T` is positive semidefinite and
+has trace one. -/
 def PrimitiveTracePowersConstantImpliesRankOne
     (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   Matrix.IsPrimitive T → TracePowersConstant T → HasRankOneFactorization T
@@ -155,42 +156,45 @@ private lemma hasRankOneFactorization_unitary_conj
     Finset.mul_sum, Finset.sum_mul]
   ring_nf
 
-/-- For a positive semidefinite real matrix, the trace of the square is the sum
-of the squares of its Hermitian eigenvalues. -/
+/-- For a positive semidefinite matrix over an `RCLike` field, the trace of
+the square is the sum of the squares of its Hermitian eigenvalues. -/
 theorem PosSemidef.trace_sq_eq_sum_eigenvalues_sq
-    {T : Matrix (Fin n) (Fin n) ℝ} (hT : T.PosSemidef) :
-    Matrix.trace (T ^ 2) = ∑ i, (hT.isHermitian.eigenvalues i) ^ 2 := by
-  let hH : T.IsHermitian := hT.isHermitian
+    {ι 𝕜 : Type*} [Fintype ι] [DecidableEq ι] [RCLike 𝕜]
+    {T : Matrix ι ι 𝕜} (hT : T.PosSemidef) :
+    Matrix.trace (T ^ 2) =
+      ∑ i, (RCLike.ofReal (hT.isHermitian.eigenvalues i) : 𝕜) ^ 2 := by
+  have hH : T.IsHermitian := hT.isHermitian
   let U := hH.eigenvectorUnitary
-  let D : Matrix (Fin n) (Fin n) ℝ := diagonal hH.eigenvalues
-  have hspec : T = (Unitary.conjStarAlgAut ℝ (Matrix (Fin n) (Fin n) ℝ) U) D := by
+  let D : Matrix ι ι 𝕜 := diagonal (RCLike.ofReal ∘ hH.eigenvalues)
+  have hspec : T = (Unitary.conjStarAlgAut 𝕜 (Matrix ι ι 𝕜) U) D := by
     simpa [D, U] using hH.spectral_theorem
   calc
     Matrix.trace (T ^ 2) =
-        Matrix.trace (((Unitary.conjStarAlgAut ℝ (Matrix (Fin n) (Fin n) ℝ) U) D) ^ 2) := by
+        Matrix.trace (((Unitary.conjStarAlgAut 𝕜 (Matrix ι ι 𝕜) U) D) ^ 2) := by
       rw [hspec]
-    _ = Matrix.trace ((Unitary.conjStarAlgAut ℝ (Matrix (Fin n) (Fin n) ℝ) U) (D ^ 2)) := by
+    _ = Matrix.trace ((Unitary.conjStarAlgAut 𝕜 (Matrix ι ι 𝕜) U) (D ^ 2)) := by
       rw [map_pow]
     _ = Matrix.trace (D ^ 2) := by
       simp [Unitary.conjStarAlgAut_apply, D, Matrix.trace_mul_cycle]
-    _ = ∑ i, (hH.eigenvalues i) ^ 2 := by
+    _ = ∑ i, (RCLike.ofReal (hH.eigenvalues i) : 𝕜) ^ 2 := by
       simp [D, diagonal_mul_diagonal, pow_two]
 
 /-- **Corrected rank-one criterion for Lemma C.4.**
 
 If a real finite matrix is positive semidefinite, has trace one, and has
 constant trace on all positive powers, then it has a rank-one factorization.
-This is the diagonalizable/PSD strengthening missing from the false bare
-primitive Perron--Frobenius statement. -/
-theorem PosSemidefTracePowersConstantImpliesRankOne
-    (T : Matrix (Fin n) (Fin n) ℝ)
+Only the second moment is used in the proof; the stronger trace-power hypothesis
+matches the ZCL input in Appendix C.2. This is the diagonalizable/PSD
+strengthening missing from the false bare primitive Perron--Frobenius statement. -/
+theorem PosSemidef.trace_powers_constant_implies_rank_one
+    {T : Matrix (Fin n) (Fin n) ℝ}
     (hPSD : T.PosSemidef)
     (hTrace : Matrix.trace T = 1)
     (hTPC : TracePowersConstant T) :
     HasRankOneFactorization T := by
   classical
-  let hH : T.IsHermitian := hPSD.isHermitian
-  let lam : Fin n → ℝ := hH.eigenvalues
+  have hH : T.IsHermitian := hPSD.isHermitian
+  set lam : Fin n → ℝ := hH.eigenvalues with hlam
   have hsum : ∑ i, lam i = 1 := by
     have htrace := hH.trace_eq_sum_eigenvalues
     change Matrix.trace T = ∑ i, (lam i : ℝ) at htrace
@@ -207,10 +211,11 @@ theorem PosSemidefTracePowersConstantImpliesRankOne
     exact htrace2eig.symm
   have hnonneg : ∀ i, 0 ≤ lam i := by
     intro i
+    rw [hlam]
     exact hPSD.eigenvalues_nonneg i
   have hD : HasRankOneFactorization (Matrix.diagonal lam) :=
     diagonal_hasRankOneFactorization lam hnonneg hsum hsq
-  let U := hH.eigenvectorUnitary
+  set U := hH.eigenvectorUnitary with hU
   have hconj : HasRankOneFactorization
       ((U : Matrix (Fin n) (Fin n) ℝ) * Matrix.diagonal lam *
         star (U : Matrix (Fin n) (Fin n) ℝ)) :=
@@ -218,20 +223,19 @@ theorem PosSemidefTracePowersConstantImpliesRankOne
   have hspec :
       T = (U : Matrix (Fin n) (Fin n) ℝ) * Matrix.diagonal lam *
         star (U : Matrix (Fin n) (Fin n) ℝ) := by
-    change T = (U : Matrix (Fin n) (Fin n) ℝ) * Matrix.diagonal hH.eigenvalues *
-      star (U : Matrix (Fin n) (Fin n) ℝ)
+    rw [hlam, hU]
     simpa [Unitary.conjStarAlgAut_apply] using hH.spectral_theorem
   rcases hconj with ⟨a, b, hab⟩
   exact ⟨a, b, by rw [hspec, hab]⟩
 
-/-- Positive semidefiniteness and trace normalization discharge the scoped
-primitive rank-one predicate. The primitive hypothesis is accepted and ignored:
+/-- Positive semidefiniteness and trace normalization establish the auxiliary
+primitive rank-one hypothesis. The primitive hypothesis is accepted and ignored:
 the PSD theorem is stronger once the trace normalization is available. -/
-theorem primitiveTracePowersConstantImpliesRankOne_of_posSemidef
+theorem primitive_trace_powers_constant_implies_rank_one_of_pos_semidef
     {T : Matrix (Fin n) (Fin n) ℝ}
     (hPSD : T.PosSemidef) (hTrace : Matrix.trace T = 1) :
     PrimitiveTracePowersConstantImpliesRankOne T := by
   intro _hPrimitive hTPC
-  exact PosSemidefTracePowersConstantImpliesRankOne T hPSD hTrace hTPC
+  exact hPSD.trace_powers_constant_implies_rank_one hTrace hTPC
 
 end Matrix

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -158,18 +158,17 @@ private lemma hasRankOneFactorization_unitary_conj
   refine Finset.sum_congr rfl fun x_1 _ => ?_
   ring
 
-/-- For a positive semidefinite matrix over the real or complex numbers, the
-trace of the square is the sum of the squares of its Hermitian eigenvalues. -/
-theorem PosSemidef.trace_sq_eq_sum_eigenvalues_sq
+/-- For a Hermitian matrix over the real or complex numbers, the trace of the
+square is the sum of the squares of its Hermitian eigenvalues. -/
+theorem IsHermitian.trace_sq_eq_sum_eigenvalues_sq
     {ι 𝕜 : Type*} [Fintype ι] [DecidableEq ι] [RCLike 𝕜]
-    {T : Matrix ι ι 𝕜} (hT : T.PosSemidef) :
+    {T : Matrix ι ι 𝕜} (hT : T.IsHermitian) :
     Matrix.trace (T ^ 2) =
-      ∑ i, (RCLike.ofReal (hT.isHermitian.eigenvalues i) : 𝕜) ^ 2 := by
-  have hH : T.IsHermitian := hT.isHermitian
-  let U := hH.eigenvectorUnitary
-  let D : Matrix ι ι 𝕜 := diagonal (RCLike.ofReal ∘ hH.eigenvalues)
+      ∑ i, (RCLike.ofReal (hT.eigenvalues i) : 𝕜) ^ 2 := by
+  let U := hT.eigenvectorUnitary
+  let D : Matrix ι ι 𝕜 := diagonal (RCLike.ofReal ∘ hT.eigenvalues)
   have hspec : T = (Unitary.conjStarAlgAut 𝕜 (Matrix ι ι 𝕜) U) D := by
-    simpa [D, U] using hH.spectral_theorem
+    simpa [D, U] using hT.spectral_theorem
   calc
     Matrix.trace (T ^ 2) =
         Matrix.trace (((Unitary.conjStarAlgAut 𝕜 (Matrix ι ι 𝕜) U) D) ^ 2) := by
@@ -178,7 +177,7 @@ theorem PosSemidef.trace_sq_eq_sum_eigenvalues_sq
       rw [map_pow]
     _ = Matrix.trace (D ^ 2) := by
       simp [Unitary.conjStarAlgAut_apply, D, Matrix.trace_mul_cycle]
-    _ = ∑ i, (RCLike.ofReal (hH.eigenvalues i) : 𝕜) ^ 2 := by
+    _ = ∑ i, (RCLike.ofReal (hT.eigenvalues i) : 𝕜) ^ 2 := by
       simp [D, diagonal_mul_diagonal, pow_two]
 
 /-- **Corrected rank-one criterion for Lemma C.4.**
@@ -207,7 +206,7 @@ theorem PosSemidef.trace_powers_constant_implies_rank_one
       Matrix.trace (T ^ 2) = Matrix.trace T := hTPC 2 (by norm_num)
       _ = 1 := hTrace
   have hsq : ∑ i, (lam i) ^ 2 = 1 := by
-    have htrace2eig := hPSD.trace_sq_eq_sum_eigenvalues_sq
+    have htrace2eig := hH.trace_sq_eq_sum_eigenvalues_sq
     change Matrix.trace (T ^ 2) = ∑ i, (lam i) ^ 2 at htrace2eig
     rw [htrace2] at htrace2eig
     exact htrace2eig.symm

--- a/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
+++ b/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
@@ -21,7 +21,7 @@ The standalone matrix statement
     `Matrix.IsPrimitive T → Matrix.TracePowersConstant T → HasRankOneFactorization T`
 
 corresponding to `Matrix.PrimitiveTracePowersConstantImpliesRankOne` in
-`TNLean/MPS/MPDO/SimpleLocalStructure.lean` is **false** for a general
+`TNLean/Algebra/PerronFrobenius/RankOne.lean` is **false** for a general
 primitive nonnegative real matrix. This module exhibits an explicit `3 × 3`
 nonnegative primitive matrix `T` with
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -196,8 +196,8 @@ theorem sal_implies_eta_structure
 Hayashi decomposition.
 
 For each pair of sectors `(k, h)`, the operator `η_{k,h}` acts on the
-neighboring bond space `B_kᴿ ⊗ B_hᴸ`, represented in Lean as the matrix algebra
-on `Fin (hη.dR k) × Fin (hη.dL h)`. -/
+neighboring bond space `B_kᴿ ⊗ B_hᴸ`, the matrix algebra with row and column
+indices `Fin (hη.dR k) × Fin (hη.dL h)`. -/
 abbrev etaOperators
     {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ}

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -36,20 +36,19 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   `η_{k,h}` together with positivity.
 - `MPOTensor.ExplicitEtaOperators.traceMatrix` /
   `MPOTensor.ExplicitEtaOperators.traceMatrixRe`: the complex trace matrix of an
-  explicit `η`-family and its real-part interface to the downstream
+  explicit `η`-family and its real-part input to the downstream
   Perron–Frobenius step.
 - `Matrix.HasRankOneFactorization`: a finite matrix factors as `vecMulVec a b`.
 - `Matrix.TracePowersConstant`: all positive powers of a matrix have the same
   trace as the matrix itself.
-- `Matrix.PosSemidefTracePowersConstantImpliesRankOne`: the corrected PSD
-  rank-one criterion for the finite-dimensional Lemma C.4 step.
-- `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the legacy scoped
+- `Matrix.PosSemidef.trace_powers_constant_implies_rank_one`: the corrected
+  PSD rank-one criterion for the finite-dimensional Lemma C.4 step.
+- `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the conditional
   Perron–Frobenius input isolated by Lemma C.4.
-- `MPOTensor.sal_zcl_implies_rank_one_T`: the scoped Lemma C.4 consequence,
+- `MPOTensor.sal_zcl_implies_rank_one_T`: the conditional Lemma C.4 consequence,
   proved relative to that Perron–Frobenius input.
 - `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`: the same consequence
-  with the scoped Perron–Frobenius input discharged from positive
-  semidefiniteness of `T`.
+  with the Perron–Frobenius input derived from positive semidefiniteness of `T`.
 
 ## Implementation note
 
@@ -74,12 +73,13 @@ quantified form of that claim is false — see
 3 × 3 witness.
 
 The corrected matrix theorem now available is
-`Matrix.PosSemidefTracePowersConstantImpliesRankOne`: positive semidefiniteness
-of the concrete trace matrix, together with trace normalization and constant
-trace powers, supplies the missing diagonalizability and forces a rank-one
-factorization. The theorem `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`
-wires this corrected input into the Lemma C.4 interface. What remains on the
-MPDO side is to prove that the sector trace matrix `T` extracted from the
+`Matrix.PosSemidef.trace_powers_constant_implies_rank_one`: positive
+semidefiniteness of the concrete trace matrix, together with trace
+normalization and constant trace powers, supplies the missing diagonalizability
+and forces a rank-one factorization. The theorem
+`MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef` connects this corrected
+criterion to the Lemma C.4 structure. What remains on
+the MPDO side is to prove that the sector trace matrix `T` extracted from the
 η-operators is itself positive semidefinite or Hermitian; positivity of the
 individual η-operators alone only gives entrywise nonnegativity of the trace
 matrix.
@@ -182,7 +182,7 @@ abbrev EtaStructure
       (Fin dA × Fin dB × Fin dC) ℂ) : Type :=
   Entropy.QuantumMarkovDecomposition ρ_ABC
 
-/-- **Lemma C.3, scoped entropy form**: strong area law implies the local
+/-- **Lemma C.3, local entropy form**: strong area law implies the local
 `η`-structure.
 
 We formalize the SAL input at the exact local point where the paper invokes it:
@@ -240,8 +240,8 @@ noncomputable def traceMatrix (data : ExplicitEtaOperators hη) :
 
 /-- The real-part trace matrix attached to an explicit `η_{k,h}` family.
 
-This is the direct real-valued interface to the Perron–Frobenius matrix `T`
-used later in Appendix C.2, Lemma C.4. -/
+This is the direct real-valued input to the Perron–Frobenius matrix `T` used
+later in Appendix C.2, Lemma C.4. -/
 noncomputable def traceMatrixRe (data : ExplicitEtaOperators hη) :
     Matrix (Fin hη.m) (Fin hη.m) ℝ :=
   fun k h => (Matrix.trace (data.eta k h)).re
@@ -253,10 +253,11 @@ noncomputable def traceMatrixRe (data : ExplicitEtaOperators hη) :
 /-- Positivity of each neighboring operator makes the corresponding real trace
 entry nonnegative.
 
-This is the entrywise nonnegativity needed for the primitive-matrix interface.
+This is the entrywise nonnegativity needed for the primitive-matrix hypothesis.
 It is strictly weaker than the matrix-level positive semidefiniteness needed by
-`Matrix.PosSemidefTracePowersConstantImpliesRankOne`; proving that stronger
-property for the sector trace matrix is the remaining MPDO-specific evidence. -/
+`Matrix.PosSemidef.trace_powers_constant_implies_rank_one`; proving that
+stronger property for the sector trace matrix is the remaining MPDO-specific
+evidence. -/
 theorem traceMatrixRe_nonneg (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
     0 ≤ data.traceMatrixRe k h := by
   have htr : 0 ≤ Matrix.trace (data.eta k h) :=
@@ -271,7 +272,7 @@ section RankOneT
 
 variable {n : ℕ}
 
-/-- **Lemma C.4, scoped matrix form**: once the matrix `T` attached to the
+/-- **Lemma C.4, conditional matrix form**: once the matrix `T` attached to the
 local `η`-structure is known to be primitive and to have constant trace on all
 positive powers, the remaining Perron–Frobenius input forces `T` to be rank one.
 
@@ -295,8 +296,8 @@ theorem sal_zcl_implies_rank_one_T
 
 /-- **Lemma C.4, PSD-corrected matrix form**: if the auxiliary trace matrix `T`
 is positive semidefinite, then the corrected finite-dimensional theorem
-`Matrix.PosSemidefTracePowersConstantImpliesRankOne` supplies the scoped
-Perron--Frobenius input used by `MPOTensor.sal_zcl_implies_rank_one_T`.
+`Matrix.PosSemidef.trace_powers_constant_implies_rank_one` supplies the
+conditional Perron--Frobenius input used by `MPOTensor.sal_zcl_implies_rank_one_T`.
 
 The primitivity hypothesis is kept in the statement because it is part of the
 paper's construction of `T`, but the PSD rank-one criterion is stronger and does
@@ -309,7 +310,7 @@ theorem sal_zcl_implies_rank_one_T_of_posSemidef
     (hZCL : Matrix.TracePowersConstant T) :
     ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
   exact sal_zcl_implies_rank_one_T T hPrimitive hTrace hZCL
-    (Matrix.primitiveTracePowersConstantImpliesRankOne_of_posSemidef hPSD hTrace)
+    (Matrix.primitive_trace_powers_constant_implies_rank_one_of_pos_semidef hPSD hTrace)
 
 end RankOneT
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.MPDO.Defs
 import TNLean.Entropy.MarkovChain
 import TNLean.MPS.Chain.VirtualInsertion
-import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
+import TNLean.Algebra.PerronFrobenius.RankOne
 
 /-!
 # Simple MPDO local structure
@@ -41,10 +41,15 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 - `Matrix.HasRankOneFactorization`: a finite matrix factors as `vecMulVec a b`.
 - `Matrix.TracePowersConstant`: all positive powers of a matrix have the same
   trace as the matrix itself.
-- `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the single missing
+- `Matrix.PosSemidefTracePowersConstantImpliesRankOne`: the corrected PSD
+  rank-one criterion for the finite-dimensional Lemma C.4 step.
+- `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the legacy scoped
   Perron–Frobenius input isolated by Lemma C.4.
 - `MPOTensor.sal_zcl_implies_rank_one_T`: the scoped Lemma C.4 consequence,
   proved relative to that Perron–Frobenius input.
+- `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`: the same consequence
+  with the scoped Perron–Frobenius input discharged from positive
+  semidefiniteness of `T`.
 
 ## Implementation note
 
@@ -63,16 +68,21 @@ is isolated to a single local extraction statement.
 
 Lemma C.4 is further isolated to the finite-dimensional Perron–Frobenius step:
 for a primitive nonnegative matrix `T`, constant traces of positive powers are
-*claimed* (in the paper) to force `T` to have rank one. We expose that step as
-the single hypothesis `Matrix.PrimitiveTracePowersConstantImpliesRankOne`, so
-the remaining gap is exactly localized and matches the paper one-to-one.
-
-The universally quantified form of that claim is in fact false — see
+*claimed* (in the paper) to force `T` to have rank one. The universally
+quantified form of that claim is false — see
 `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean` for an explicit
-3 × 3 witness. Callers of `MPOTensor.sal_zcl_implies_rank_one_T` must therefore
-discharge the hypothesis using additional structure on the specific `T` coming
-from the MPDO context (the η-operators are positive semidefinite in the paper's
-construction, which supplies the missing diagonalizability).
+3 × 3 witness.
+
+The corrected matrix theorem now available is
+`Matrix.PosSemidefTracePowersConstantImpliesRankOne`: positive semidefiniteness
+of the concrete trace matrix, together with trace normalization and constant
+trace powers, supplies the missing diagonalizability and forces a rank-one
+factorization. The theorem `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`
+wires this corrected input into the Lemma C.4 interface. What remains on the
+MPDO side is to prove that the sector trace matrix `T` extracted from the
+η-operators is itself positive semidefinite or Hermitian; positivity of the
+individual η-operators alone only gives entrywise nonnegativity of the trace
+matrix.
 
 ## References
 
@@ -83,45 +93,6 @@ construction, which supplies the missing diagonalizability).
 -/
 
 open scoped Matrix ComplexOrder BigOperators
-
-namespace Matrix
-
-variable {n : ℕ}
-
-/-- A square real matrix has the rank-one factorization of Appendix C.2,
-Lemma C.4 if it is an outer product `a bᵀ`, represented in Lean as
-`Matrix.vecMulVec a b`. -/
-def HasRankOneFactorization (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
-  ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b
-
-/-- The traces of all positive powers of `T` agree with the trace of `T`
-itself. This is the matrix-theoretic consequence of the ZCL step used in
-Appendix C.2, Lemma C.4. -/
-def TracePowersConstant (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
-  ∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T
-
-/-- The missing Perron–Frobenius input for Appendix C.2, Lemma C.4:
-for a primitive nonnegative matrix, constant traces of positive powers imply a
-rank-one factorization.
-
-This is intentionally stated as a local hypothesis rather than a new global
-assumption. Once a genuine proof is formalized, downstream callers can simply
-supply that theorem here and the scoped result `MPOTensor.sal_zcl_implies_rank_one_T`
-will become unconditional.
-
-**Note.** As a universally quantified statement over primitive nonnegative real
-matrices this implication is *false*: there exist primitive nonnegative
-matrices with `trace (T ^ k) = trace T` for all `k ≥ 1` but rank greater than
-one. An explicit machine-checked `3 × 3` witness is recorded in
-`TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`. Discharging the
-hypothesis in a specific MPDO context therefore requires additional structure
-on `T` (for instance positive semidefiniteness or diagonalizability over `ℂ`)
-that the caller must supply. -/
-def PrimitiveTracePowersConstantImpliesRankOne
-    (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
-  Matrix.IsPrimitive T → TracePowersConstant T → HasRankOneFactorization T
-
-end Matrix
 
 namespace MPOTensor
 
@@ -279,6 +250,19 @@ noncomputable def traceMatrixRe (data : ExplicitEtaOperators hη) :
     (k h : Fin hη.m) :
     data.traceMatrixRe k h = (Matrix.trace (data.eta k h)).re := rfl
 
+/-- Positivity of each neighboring operator makes the corresponding real trace
+entry nonnegative.
+
+This is the entrywise nonnegativity needed for the primitive-matrix interface.
+It is strictly weaker than the matrix-level positive semidefiniteness needed by
+`Matrix.PosSemidefTracePowersConstantImpliesRankOne`; proving that stronger
+property for the sector trace matrix is the remaining MPDO-specific evidence. -/
+theorem traceMatrixRe_nonneg (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
+    0 ≤ data.traceMatrixRe k h := by
+  have htr : 0 ≤ Matrix.trace (data.eta k h) :=
+    (data.eta_pos k h).trace_nonneg
+  exact htr.1
+
 end ExplicitEtaOperators
 
 end LocalSAL
@@ -308,6 +292,24 @@ theorem sal_zcl_implies_rank_one_T
       exact Matrix.trace_vecMulVec a b
     _ = Matrix.trace T := by rw [← hT]
     _ = 1 := hTrace
+
+/-- **Lemma C.4, PSD-corrected matrix form**: if the auxiliary trace matrix `T`
+is positive semidefinite, then the corrected finite-dimensional theorem
+`Matrix.PosSemidefTracePowersConstantImpliesRankOne` supplies the scoped
+Perron--Frobenius input used by `MPOTensor.sal_zcl_implies_rank_one_T`.
+
+The primitivity hypothesis is kept in the statement because it is part of the
+paper's construction of `T`, but the PSD rank-one criterion is stronger and does
+not use primitivity once `trace T = 1` and constant trace powers are known. -/
+theorem sal_zcl_implies_rank_one_T_of_posSemidef
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hPSD : T.PosSemidef)
+    (hTrace : Matrix.trace T = 1)
+    (hZCL : Matrix.TracePowersConstant T) :
+    ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
+  exact sal_zcl_implies_rank_one_T T hPrimitive hTrace hZCL
+    (Matrix.primitiveTracePowersConstantImpliesRankOne_of_posSemidef hPSD hTrace)
 
 end RankOneT
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -38,15 +38,10 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   `MPOTensor.ExplicitEtaOperators.traceMatrixRe`: the complex trace matrix of an
   explicit `η`-family and its real-part input to the downstream
   Perron–Frobenius step.
-- `Matrix.HasRankOneFactorization`: a finite matrix factors as `vecMulVec a b`.
-- `Matrix.TracePowersConstant`: all positive powers of a matrix have the same
-  trace as the matrix itself.
-- `Matrix.PosSemidef.trace_powers_constant_implies_rank_one`: the corrected
-  PSD rank-one criterion for the finite-dimensional Lemma C.4 step.
-- `Matrix.PrimitiveTracePowersConstantImpliesRankOne`: the conditional
-  Perron–Frobenius input isolated by Lemma C.4.
+- `MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg`: positivity of each
+  neighboring operator gives entrywise nonnegativity of the real trace matrix.
 - `MPOTensor.sal_zcl_implies_rank_one_T`: the conditional Lemma C.4 consequence,
-  proved relative to that Perron–Frobenius input.
+  proved relative to the Perron–Frobenius rank-one input.
 - `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`: the same consequence
   with the Perron–Frobenius input derived from positive semidefiniteness of `T`.
 
@@ -310,7 +305,7 @@ theorem sal_zcl_implies_rank_one_T_of_posSemidef
     (hZCL : Matrix.TracePowersConstant T) :
     ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
   exact sal_zcl_implies_rank_one_T T hPrimitive hTrace hZCL
-    (Matrix.primitive_trace_powers_constant_implies_rank_one_of_pos_semidef hPSD hTrace)
+    (Matrix.primitive_trace_powers_constant_implies_rank_one_of_posSemidef hPSD hTrace)
 
 end RankOneT
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -262,7 +262,7 @@ theorem traceMatrixRe_nonneg (data : ExplicitEtaOperators hη) (k h : Fin hη.m)
     0 ≤ data.traceMatrixRe k h := by
   have htr : 0 ≤ Matrix.trace (data.eta k h) :=
     (data.eta_pos k h).trace_nonneg
-  exact htr.1
+  exact (Complex.le_def.mp htr).1
 
 end ExplicitEtaOperators
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -553,9 +553,9 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.sal_zcl_implies_rank_one_T}
     \leanok
     \uses{def:matrix_trace_rankone_predicates}
-    Let $T$ be the nonnegative matrix extracted from the local $\eta$-data.
-    Assume that $T$ is primitive, that $\tr(T) = 1$, and that every positive
-    power of $T$ has the same trace as $T$. If one further supplies the single
+    Let $T$ be a finite real square matrix. Assume that $T$ is primitive,
+    that $\tr(T) = 1$, and that every positive power of $T$ has the same trace
+    as $T$. If one further supplies the single
     Perron--Frobenius input asserting that every primitive nonnegative matrix
     with constant trace powers is rank one, then
     \[

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -483,15 +483,15 @@ strong subadditivity for a normalized three-site reduced state.
     in the rank-one step.
 \end{definition}
 
-\begin{lemma}[Entrywise nonnegativity of the real trace matrix]
-    \label{lem:mpdo_explicit_eta_trace_matrix_nonneg}
+\begin{theorem}[Entrywise nonnegativity of the real trace matrix]
+    \label{thm:mpdo_explicit_eta_trace_matrix_nonneg}
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg}
     \leanok
     \uses{def:mpdo_explicit_eta_trace_matrix}
     Positivity of the neighboring operators gives entrywise nonnegativity of
     the real trace matrix. Matrix-level positive semidefiniteness of $T$ is a
     separate structural condition.
-\end{lemma}
+\end{theorem}
 
 \begin{definition}[Auxiliary matrix predicates for the rank-one step]
     \label{def:matrix_trace_rankone_predicates}
@@ -513,23 +513,23 @@ strong subadditivity for a normalized three-site reduced state.
     trace-power condition into a rank-one factorization.
 \end{definition}
 
-\begin{lemma}[Trace square of a positive semidefinite matrix]
-    \label{lem:matrix_psd_trace_square_eigenvalues}
-    \lean{Matrix.PosSemidef.trace_sq_eq_sum_eigenvalues_sq}
+\begin{theorem}[Trace square of a Hermitian matrix]
+    \label{thm:matrix_hermitian_trace_square_eigenvalues}
+    \lean{Matrix.IsHermitian.trace_sq_eq_sum_eigenvalues_sq}
     \leanok
-    Let $T$ be a finite positive semidefinite matrix over a real or complex
-    scalar field, with Hermitian eigenvalues $\lambda_i$. Then
+    Let $T$ be a finite Hermitian matrix over a real or complex scalar field,
+    with Hermitian eigenvalues $\lambda_i$. Then
     \[
         \tr(T^2) = \sum_i \lambda_i^2.
     \]
-\end{lemma}
+\end{theorem}
 
 \begin{theorem}[PSD trace-power rank-one criterion]
     \label{thm:matrix_psd_trace_power_rank_one}
     \lean{Matrix.PosSemidef.trace_powers_constant_implies_rank_one}
     \lean{Matrix.primitive_trace_powers_constant_implies_rank_one_of_pos_semidef}
     \leanok
-    \uses{def:matrix_trace_rankone_predicates, lem:matrix_psd_trace_square_eigenvalues}
+    \uses{def:matrix_trace_rankone_predicates, thm:matrix_hermitian_trace_square_eigenvalues}
     Let $T$ be a finite real square matrix. If $T$ is positive semidefinite,
     normalized by $\tr(T)=1$, and has constant traces on all positive powers,
     then $T$ has a rank-one factorization. Consequently, under the same
@@ -539,7 +539,7 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{def:matrix_trace_rankone_predicates, lem:matrix_psd_trace_square_eigenvalues}
+    \uses{def:matrix_trace_rankone_predicates, thm:matrix_hermitian_trace_square_eigenvalues}
     The spectral theorem diagonalizes the positive semidefinite matrix with
     nonnegative real eigenvalues. The trace gives that their sum is $1$, while
     the second trace moment gives that the sum of their squares is also $1$.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -594,8 +594,7 @@ strong subadditivity for a normalized three-site reduced state.
     \label{thm:psd_trace_powers_rank_one_t}
     \lean{MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef}
     \leanok
-    \uses{def:matrix_trace_rankone_predicates, thm:sal_zcl_implies_rank_one_t,
-        thm:matrix_psd_trace_power_rank_one}
+    \uses{def:matrix_trace_rankone_predicates}
     Let $T$ be a finite real square matrix. Assume that $T$ is primitive,
     positive semidefinite, normalized by $\tr(T)=1$, and has constant traces on
     all positive powers. Then

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -475,41 +475,70 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrix_apply}
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe}
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe_apply}
-    \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg}
     \leanok
     \uses{def:mpdo_explicit_eta_operators}
     Every explicit neighboring $\eta$-family determines a sector-by-sector trace
     matrix. We record both its complex-valued form and the real-part version,
-    which is the direct interface to the real Perron--Frobenius matrix $T$ used
-    in the rank-one step. Positivity of the neighboring operators gives
-    entrywise nonnegativity of this real trace matrix; matrix-level positive
-    semidefiniteness of $T$ is a separate structural condition.
+    which is the direct input for the real Perron--Frobenius matrix $T$ used
+    in the rank-one step.
 \end{definition}
+
+\begin{lemma}[Entrywise nonnegativity of the real trace matrix]
+    \label{lem:mpdo_explicit_eta_trace_matrix_nonneg}
+    \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg}
+    \leanok
+    \uses{def:mpdo_explicit_eta_trace_matrix}
+    Positivity of the neighboring operators gives entrywise nonnegativity of
+    the real trace matrix. Matrix-level positive semidefiniteness of $T$ is a
+    separate structural condition.
+\end{lemma}
 
 \begin{definition}[Auxiliary matrix predicates for the rank-one step]
     \label{def:matrix_trace_rankone_predicates}
     \lean{Matrix.TracePowersConstant}
     \lean{Matrix.HasRankOneFactorization}
     \lean{Matrix.PrimitiveTracePowersConstantImpliesRankOne}
-    \lean{Matrix.PosSemidef.trace_sq_eq_sum_eigenvalues_sq}
-    \lean{Matrix.PosSemidefTracePowersConstantImpliesRankOne}
-    \lean{Matrix.primitiveTracePowersConstantImpliesRankOne_of_posSemidef}
     \leanok
     The auxiliary predicates record three matrix-theoretic ingredients used in
     the rank-one step of Appendix~C.2, Lemma~C.4: constant traces of all
     positive powers, existence of a rank-one factorization $T = a b^\top$, and
-    the scoped Perron--Frobenius implication from primitivity together with
+    the conditional Perron--Frobenius implication from primitivity together with
     constant trace powers to such a factorization.
 
-    The scoped implication is not a globally provable theorem. As a universal
-    statement over primitive nonnegative matrices it is false; a concrete
-    $3 \times 3$ counterexample is recorded in the archive. The corrected
-    criterion proved here adds positive semidefiniteness and trace normalization,
-    which provide the diagonalizability needed to turn the trace-power condition
-    into a rank-one factorization.
+    This conditional implication is not a globally provable theorem. As a
+    universal statement over primitive nonnegative matrices it is false; a
+    concrete $3 \times 3$ counterexample is recorded in the archive. The
+    corrected criterion proved here adds positive semidefiniteness and trace
+    normalization, which provide the diagonalizability needed to turn the
+    trace-power condition into a rank-one factorization.
 \end{definition}
 
-\begin{theorem}[SAL and ZCL imply rank-one $T$ (scoped form)]
+\begin{theorem}[PSD trace-power rank-one criterion]
+    \label{thm:matrix_psd_trace_power_rank_one}
+    \lean{Matrix.PosSemidef.trace_sq_eq_sum_eigenvalues_sq}
+    \lean{Matrix.PosSemidef.trace_powers_constant_implies_rank_one}
+    \lean{Matrix.primitive_trace_powers_constant_implies_rank_one_of_pos_semidef}
+    \leanok
+    \uses{def:matrix_trace_rankone_predicates}
+    Let $T$ be a finite real square matrix. If $T$ is positive semidefinite,
+    normalized by $\tr(T)=1$, and has constant traces on all positive powers,
+    then $T$ has a rank-one factorization. Consequently, under the same
+    positive-semidefinite and trace-normalization hypotheses, the conditional
+    rank-one criterion used in Lemma~C.4 follows.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:matrix_trace_rankone_predicates}
+    The spectral theorem diagonalizes the positive semidefinite matrix with
+    nonnegative real eigenvalues. The trace gives that their sum is $1$, while
+    the second trace moment gives that the sum of their squares is also $1$.
+    Hence exactly one eigenvalue is equal to $1$ and all others vanish, so the
+    diagonal form is rank one. Unitary conjugation preserves the existence of an
+    outer-product factorization.
+\end{proof}
+
+\begin{theorem}[SAL and ZCL imply rank-one $T$ (conditional form)]
     \label{thm:sal_zcl_implies_rank_one_t}
     \lean{MPOTensor.sal_zcl_implies_rank_one_T}
     \leanok
@@ -541,9 +570,9 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef}
     \leanok
     \uses{def:matrix_trace_rankone_predicates, thm:sal_zcl_implies_rank_one_t}
-    Let $T$ be the real matrix extracted from the local $\eta$-data. Assume that
-    $T$ is primitive, positive semidefinite, normalized by $\tr(T)=1$, and has
-    constant traces on all positive powers. Then
+    Let $T$ be a finite real square matrix. Assume that $T$ is primitive,
+    positive semidefinite, normalized by $\tr(T)=1$, and has constant traces on
+    all positive powers. Then
     \[
         T = a b^\top
     \]
@@ -555,8 +584,8 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{def:matrix_trace_rankone_predicates, thm:sal_zcl_implies_rank_one_t}
     The positive-semidefinite matrix criterion diagonalizes $T$, uses the first
     two trace moments to show that exactly one eigenvalue is nonzero, and hence
-    supplies the scoped rank-one input. The scoped Lemma~C.4 statement then
-    gives the factorization and trace normalization.
+    supplies the auxiliary rank-one criterion. The conditional Lemma~C.4
+    statement then gives the factorization and trace normalization.
 \end{proof}
 
 \section{Horizontal and Vertical Canonical Forms}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -542,7 +542,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{theorem}[PSD trace-power rank-one criterion]
     \label{thm:matrix_psd_trace_power_rank_one}
     \lean{Matrix.PosSemidef.trace_powers_constant_implies_rank_one}
-    \lean{Matrix.primitive_trace_powers_constant_implies_rank_one_of_pos_semidef}
+    \lean{Matrix.primitive_trace_powers_constant_implies_rank_one_of_posSemidef}
     \leanok
     \uses{def:matrix_trace_rankone_predicates}
     Let $T$ be a finite real square matrix. If $T$ is positive semidefinite,

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -475,12 +475,15 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrix_apply}
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe}
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe_apply}
+    \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg}
     \leanok
     \uses{def:mpdo_explicit_eta_operators}
     Every explicit neighboring $\eta$-family determines a sector-by-sector trace
     matrix. We record both its complex-valued form and the real-part version,
     which is the direct interface to the real Perron--Frobenius matrix $T$ used
-    in the rank-one step.
+    in the rank-one step. Positivity of the neighboring operators gives
+    entrywise nonnegativity of this real trace matrix; matrix-level positive
+    semidefiniteness of $T$ is a separate structural condition.
 \end{definition}
 
 \begin{definition}[Auxiliary matrix predicates for the rank-one step]
@@ -488,19 +491,22 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{Matrix.TracePowersConstant}
     \lean{Matrix.HasRankOneFactorization}
     \lean{Matrix.PrimitiveTracePowersConstantImpliesRankOne}
+    \lean{Matrix.PosSemidef.trace_sq_eq_sum_eigenvalues_sq}
+    \lean{Matrix.PosSemidefTracePowersConstantImpliesRankOne}
+    \lean{Matrix.primitiveTracePowersConstantImpliesRankOne_of_posSemidef}
     \leanok
     The auxiliary predicates record three matrix-theoretic ingredients used in
     the rank-one step of Appendix~C.2, Lemma~C.4: constant traces of all
     positive powers, existence of a rank-one factorization $T = a b^\top$, and
-    the Perron--Frobenius implication from primitivity together with constant
-    trace powers to such a factorization.
+    the scoped Perron--Frobenius implication from primitivity together with
+    constant trace powers to such a factorization.
 
-    The last predicate is used as a scoped hypothesis, not a globally provable
-    theorem. As a universal statement over primitive nonnegative matrices it is
-    false; a concrete $3 \times 3$ counterexample is recorded in the archive.
-    Discharging the hypothesis in the simple-MPDO setting therefore requires
-    the extra structure carried by the specific $T$ arising from the positive
-    semidefinite $\eta$-operators.
+    The scoped implication is not a globally provable theorem. As a universal
+    statement over primitive nonnegative matrices it is false; a concrete
+    $3 \times 3$ counterexample is recorded in the archive. The corrected
+    criterion proved here adds positive semidefiniteness and trace normalization,
+    which provide the diagonalizability needed to turn the trace-power condition
+    into a rank-one factorization.
 \end{definition}
 
 \begin{theorem}[SAL and ZCL imply rank-one $T$ (scoped form)]
@@ -528,6 +534,29 @@ strong subadditivity for a normalized three-site reduced state.
     The Perron--Frobenius input gives the factorization $T = a b^\top$.
     Taking traces and using $\tr(a b^\top) = a \cdot b$ converts the
     normalization $\tr(T) = 1$ into $a \cdot b = 1$.
+\end{proof}
+
+\begin{theorem}[PSD-corrected rank-one $T$ criterion]
+    \label{thm:psd_trace_powers_rank_one_t}
+    \lean{MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef}
+    \leanok
+    \uses{def:matrix_trace_rankone_predicates, thm:sal_zcl_implies_rank_one_t}
+    Let $T$ be the real matrix extracted from the local $\eta$-data. Assume that
+    $T$ is primitive, positive semidefinite, normalized by $\tr(T)=1$, and has
+    constant traces on all positive powers. Then
+    \[
+        T = a b^\top
+    \]
+    for some vectors $a$ and $b$, with $a \cdot b = 1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:matrix_trace_rankone_predicates, thm:sal_zcl_implies_rank_one_t}
+    The positive-semidefinite matrix criterion diagonalizes $T$, uses the first
+    two trace moments to show that exactly one eigenvalue is nonzero, and hence
+    supplies the scoped rank-one input. The scoped Lemma~C.4 statement then
+    gives the factorization and trace normalization.
 \end{proof}
 
 \section{Horizontal and Vertical Canonical Forms}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -493,6 +493,13 @@ strong subadditivity for a normalized three-site reduced state.
     separate structural condition.
 \end{theorem}
 
+\begin{proof}
+    \leanok
+    The trace of a positive semidefinite neighboring operator is nonnegative in
+    the complex order. Taking real parts gives the stated entrywise
+    nonnegativity.
+\end{proof}
+
 \begin{definition}[Auxiliary matrix predicates for the rank-one step]
     \label{def:matrix_trace_rankone_predicates}
     \lean{Matrix.TracePowersConstant}
@@ -524,12 +531,20 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{theorem}
 
+\begin{proof}
+    \leanok
+    The spectral theorem writes $T$ as a unitary conjugate of the diagonal
+    matrix of its Hermitian eigenvalues. Squaring commutes with this conjugation,
+    and cyclicity of trace reduces the identity to the trace of the squared
+    diagonal matrix.
+\end{proof}
+
 \begin{theorem}[PSD trace-power rank-one criterion]
     \label{thm:matrix_psd_trace_power_rank_one}
     \lean{Matrix.PosSemidef.trace_powers_constant_implies_rank_one}
     \lean{Matrix.primitive_trace_powers_constant_implies_rank_one_of_pos_semidef}
     \leanok
-    \uses{def:matrix_trace_rankone_predicates, thm:matrix_hermitian_trace_square_eigenvalues}
+    \uses{def:matrix_trace_rankone_predicates}
     Let $T$ be a finite real square matrix. If $T$ is positive semidefinite,
     normalized by $\tr(T)=1$, and has constant traces on all positive powers,
     then $T$ has a rank-one factorization. Consequently, under the same

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -570,9 +570,9 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{def:matrix_trace_rankone_predicates}
     Let $T$ be a finite real square matrix. Assume that $T$ is primitive,
     that $\tr(T) = 1$, and that every positive power of $T$ has the same trace
-    as $T$. If one further supplies the single
-    Perron--Frobenius input asserting that every primitive nonnegative matrix
-    with constant trace powers is rank one, then
+    as $T$. If one further supplies the Perron--Frobenius input asserting that
+    this particular primitive nonnegative matrix with constant trace powers is
+    rank one, then
     \[
         T = a b^\top
     \]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -513,13 +513,23 @@ strong subadditivity for a normalized three-site reduced state.
     trace-power condition into a rank-one factorization.
 \end{definition}
 
+\begin{lemma}[Trace square of a positive semidefinite matrix]
+    \label{lem:matrix_psd_trace_square_eigenvalues}
+    \lean{Matrix.PosSemidef.trace_sq_eq_sum_eigenvalues_sq}
+    \leanok
+    Let $T$ be a finite positive semidefinite matrix over a real or complex
+    scalar field, with Hermitian eigenvalues $\lambda_i$. Then
+    \[
+        \tr(T^2) = \sum_i \lambda_i^2.
+    \]
+\end{lemma}
+
 \begin{theorem}[PSD trace-power rank-one criterion]
     \label{thm:matrix_psd_trace_power_rank_one}
-    \lean{Matrix.PosSemidef.trace_sq_eq_sum_eigenvalues_sq}
     \lean{Matrix.PosSemidef.trace_powers_constant_implies_rank_one}
     \lean{Matrix.primitive_trace_powers_constant_implies_rank_one_of_pos_semidef}
     \leanok
-    \uses{def:matrix_trace_rankone_predicates}
+    \uses{def:matrix_trace_rankone_predicates, lem:matrix_psd_trace_square_eigenvalues}
     Let $T$ be a finite real square matrix. If $T$ is positive semidefinite,
     normalized by $\tr(T)=1$, and has constant traces on all positive powers,
     then $T$ has a rank-one factorization. Consequently, under the same
@@ -529,7 +539,7 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{def:matrix_trace_rankone_predicates}
+    \uses{def:matrix_trace_rankone_predicates, lem:matrix_psd_trace_square_eigenvalues}
     The spectral theorem diagonalizes the positive semidefinite matrix with
     nonnegative real eigenvalues. The trace gives that their sum is $1$, while
     the second trace moment gives that the sum of their squares is also $1$.
@@ -569,7 +579,8 @@ strong subadditivity for a normalized three-site reduced state.
     \label{thm:psd_trace_powers_rank_one_t}
     \lean{MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef}
     \leanok
-    \uses{def:matrix_trace_rankone_predicates, thm:sal_zcl_implies_rank_one_t}
+    \uses{def:matrix_trace_rankone_predicates, thm:sal_zcl_implies_rank_one_t,
+        thm:matrix_psd_trace_power_rank_one}
     Let $T$ be a finite real square matrix. Assume that $T$ is primitive,
     positive semidefinite, normalized by $\tr(T)=1$, and has constant traces on
     all positive powers. Then
@@ -581,7 +592,8 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{def:matrix_trace_rankone_predicates, thm:sal_zcl_implies_rank_one_t}
+    \uses{def:matrix_trace_rankone_predicates, thm:sal_zcl_implies_rank_one_t,
+        thm:matrix_psd_trace_power_rank_one}
     The positive-semidefinite matrix criterion diagonalizes $T$, uses the first
     two trace moments to show that exactly one eigenvalue is nonzero, and hence
     supplies the auxiliary rank-one criterion. The conditional Lemma~C.4


### PR DESCRIPTION
Refs #832.

## Summary

- Add `TNLean.Algebra.PerronFrobenius.RankOne` with the shared rank-one/trace-power predicates and a corrected PSD theorem:
  `Matrix.PosSemidef.trace_powers_constant_implies_rank_one`.
- Prove the spectral trace-square helper and the bridge
  `Matrix.primitive_trace_powers_constant_implies_rank_one_of_pos_semidef`, so the legacy scoped PF predicate can be discharged from `T.PosSemidef` plus `trace T = 1`.
- Wire `SimpleLocalStructure.lean` via `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef` and document the remaining MPDO-specific evidence: positivity of individual `η` operators gives entrywise nonnegativity of the trace matrix, but the corrected rank-one theorem needs matrix-level PSD/Hermitian structure for `T`.
- Sync the blueprint with the new PSD-corrected theorem and trace-matrix nonnegativity API.

## Test plan

- `ulimit -n 8192 && lake build TNLean.Algebra.PerronFrobenius.RankOne`
- `ulimit -n 8192 && lake build TNLean.MPS.MPDO.SimpleLocalStructure`
- `ulimit -n 8192 && lake build TNLean.Archive.PerronFrobeniusRankOneCounterexample`
- `ulimit -n 8192 && lake build TNLean.MPS.MPDO.BlockedRFPConstruction`
- `ulimit -n 8192 && lake build TNLean` (success on retry; only pre-existing warnings in unrelated modules)
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `rg -n "sorry|axiom|native_decide" TNLean/Algebra/PerronFrobenius/RankOne.lean TNLean/MPS/MPDO/SimpleLocalStructure.lean TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Perron–Frobenius-adjacent matrix lemmas and rewires the MPDO rank-one step to use a PSD-based theorem; risk is mainly proof soundness and downstream breakage in this core argument chain, not runtime behavior.
> 
> **Overview**
> Introduces a new `TNLean.Algebra.PerronFrobenius.RankOne` module that centralizes the rank-one/trace-power predicates and proves a **corrected** theorem `Matrix.PosSemidef.trace_powers_constant_implies_rank_one` (plus a Hermitian trace-square/eigenvalues helper) to replace the previously-assumed but false “primitive + constant trace powers ⇒ rank one” claim.
> 
> Updates the simple MPDO local-structure development to import these shared definitions, adds `MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg`, and provides `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef` which discharges the conditional Perron–Frobenius hypothesis from `T.PosSemidef` and `trace T = 1`.
> 
> Wires the new module into the root `TNLean.lean` import surface and syncs the blueprint text to document the counterexample, the PSD-corrected criterion, and the new nonnegativity lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6d925fb3adaca8d89487eb367e56a6f12622a22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

