### PR TITLE
feat(MPS/ParentHamiltonian): add normal open-chain range reduction (Refs #588)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
@@ -176,4 +176,41 @@ theorem contiguousRestrictₗ_reindex_total
         (reindexSites hN ψ) := by
   subst hN; rfl
 
+/-- Fixing the first `K` sites of a contiguous `(K + L)`-window leaves the
+contiguous `L`-window that starts at `s + K`, with the fixed prefix inserted into
+the outside configuration. -/
+theorem tailRestrictₗ_contiguousRestrictₗ
+    {N s K L : ℕ} (hsKL : s + (K + L) ≤ N)
+    (u : Fin K → Fin d) (τ : Fin N → Fin d) (ψ : NSiteSpace d N) :
+    tailRestrictₗ u (contiguousRestrictₗ s (K + L) hsKL τ ψ) =
+      contiguousRestrictₗ (s + K) L (by omega)
+        (fun k => if h : s ≤ k.val ∧ k.val < s + K
+          then u ⟨k.val - s, by omega⟩ else τ k) ψ := by
+  ext σ
+  simp only [tailRestrictₗ_apply, contiguousRestrictₗ_apply]
+  congr 1
+  ext ⟨k, hk⟩
+  simp only [contiguousCfg]
+  by_cases hLeft : s ≤ k ∧ k < s + K
+  · rw [dif_pos (show s ≤ k ∧ k < s + (K + L) by omega)]
+    rw [dif_neg (show ¬(s + K ≤ k ∧ k < s + K + L) by omega)]
+    rw [dif_pos hLeft]
+    have hidx : (⟨k - s, by omega⟩ : Fin (K + L)) =
+        Fin.castAdd L (⟨k - s, by omega⟩ : Fin K) := by
+      ext
+      simp [Fin.castAdd]
+    rw [hidx, Fin.append_left]
+  · by_cases hRight : s + K ≤ k ∧ k < s + K + L
+    · rw [dif_pos (show s ≤ k ∧ k < s + (K + L) by omega)]
+      rw [dif_pos hRight]
+      have hidx : (⟨k - s, by omega⟩ : Fin (K + L)) =
+          Fin.natAdd K (⟨k - (s + K), by omega⟩ : Fin L) := by
+        ext
+        simp [Fin.natAdd]
+        omega
+      rw [hidx, Fin.append_right]
+    · rw [dif_neg (show ¬(s ≤ k ∧ k < s + (K + L)) by omega)]
+      rw [dif_neg hRight]
+      rw [dif_neg hLeft]
+
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -327,21 +327,18 @@ theorem contiguous_mem_groundSpace_of_isNBlkInjective
           rw [tailRestrictₗ_contiguousRestrictₗ (d := d) (s := s) (K := K + 1)
             (L := L₀ + 1) hsTail u τ ψ]
           exact hwindow (s + (K + 1)) (by omega) _
-  let K := N - (L₀ + 1)
-  have hEq : K + L₀ + 1 = N := by
-    dsimp [K]
-    omega
-  have hmemK := claim K 0 (by dsimp [K]; omega) τ₀
-  have hmemN := reindexSites_mem_groundSpace hEq hmemK
+  have hK : N - (L₀ + 1) + L₀ + 1 = N := by omega
+  have hmemK := claim (N - (L₀ + 1)) 0 (by omega) τ₀
+  have hmemN := reindexSites_mem_groundSpace hK hmemK
   have hfull :
-      reindexSites hEq
-        (contiguousRestrictₗ 0 (K + L₀ + 1) (by dsimp [K]; omega) τ₀ ψ) = ψ := by
+      reindexSites hK
+        (contiguousRestrictₗ 0 (N - (L₀ + 1) + L₀ + 1) (by omega) τ₀ ψ) = ψ := by
     ext σ
     simp only [reindexSites_apply, contiguousRestrictₗ_apply]
     congr 1
     ext k
     simp only [contiguousCfg]
-    rw [dif_pos (show 0 ≤ k.val ∧ k.val < 0 + (K + L₀ + 1) by omega)]
+    rw [dif_pos (show 0 ≤ k.val ∧ k.val < 0 + (N - (L₀ + 1) + L₀ + 1) by omega)]
     congr 1
   rwa [hfull] at hmemN
 

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
+import TNLean.MPS.ParentHamiltonian.ExtendRight
+import TNLean.MPS.ParentHamiltonian.RestrictTransport
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
 import TNLean.MPS.FundamentalTheorem.FiniteLength
 import TNLean.Algebra.TracePairing
@@ -259,6 +261,89 @@ theorem mpv_ne_zero_of_isNBlkInjective {A : MPSTensor d D} [NeZero D]
       _ = 0 := by
           simpa [Matrix.traceLinearMap_apply] using congrArg (· M) hφ
   exact allZero_contradiction hInj hL₀ (by omega : 0 < N - L₀) hprod_zero
+
+/-- A positive block-injectivity length over nonzero virtual dimension forces the
+physical alphabet to be nonempty. -/
+private theorem neZero_d_of_isNBlkInjective [NeZero D]
+    {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) :
+    NeZero d := by
+  by_contra h
+  simp only [not_neZero] at h
+  subst h
+  have hempty :
+      Set.range (fun σ : Fin L₀ → Fin 0 => evalWord A (List.ofFn σ)) = ∅ := by
+    ext M
+    constructor
+    · rintro ⟨σ, _⟩
+      exact (σ ⟨0, hL₀⟩).elim0
+    · intro hM
+      cases hM
+  rw [IsNBlkInjective, hempty, Submodule.span_empty] at hInj
+  exact bot_ne_top hInj
+
+/-- Open-chain range reduction for block-injective tensors.
+
+If all contiguous windows of size `L₀ + 1` lie in the corresponding MPS ground
+space, then the full open chain lies in `groundSpace A N`.  This is the
+chain-level iteration of `groundSpace_extend_right_of_isNBlkInjective`; it is the
+open-boundary half of the normal parent-Hamiltonian range reduction. -/
+theorem contiguous_mem_groundSpace_of_isNBlkInjective
+    {A : MPSTensor d D} [NeZero D] {L₀ N : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hLN : L₀ + 1 ≤ N)
+    {ψ : NSiteSpace d N}
+    (hwindow : ∀ (s : ℕ) (hs : s + (L₀ + 1) ≤ N) (τ : Fin N → Fin d),
+      contiguousRestrictₗ s (L₀ + 1) hs τ ψ ∈ groundSpace A (L₀ + 1)) :
+    ψ ∈ groundSpace A N := by
+  haveI : NeZero d := neZero_d_of_isNBlkInjective hInj hL₀
+  have hd : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  let τ₀ : Fin N → Fin d := fun _ => ⟨0, hd⟩
+  have claim : ∀ K : ℕ, ∀ (s : ℕ) (hs : s + (K + L₀ + 1) ≤ N)
+      (τ : Fin N → Fin d),
+      contiguousRestrictₗ s (K + L₀ + 1) hs τ ψ ∈ groundSpace A (K + L₀ + 1) := by
+    intro K
+    induction K with
+    | zero =>
+        intro s hs τ
+        have hEq0 : L₀ + 1 = 0 + L₀ + 1 := by omega
+        have hs₀ : s + (L₀ + 1) ≤ N := by omega
+        rw [← contiguousRestrictₗ_reindex_window (d := d) hEq0 hs₀ hs τ ψ]
+        exact reindexSites_mem_groundSpace hEq0 (hwindow s hs₀ τ)
+    | succ K ih =>
+        intro s hs τ
+        apply groundSpace_extend_right_of_isNBlkInjective (A := A) (K := K + 1) hInj hL₀
+        · intro j
+          rw [contiguousRestrictₗ_restrictLast]
+          have hEq : K + L₀ + 1 = (K + 1) + L₀ := by omega
+          let τj := Function.update τ ⟨s + ((K + 1) + L₀), by omega⟩ j
+          have hs₁ : s + (K + L₀ + 1) ≤ N := by omega
+          have hs₂ : s + ((K + 1) + L₀) ≤ N := by omega
+          rw [← contiguousRestrictₗ_reindex_window (d := d) hEq hs₁ hs₂ τj ψ]
+          exact reindexSites_mem_groundSpace hEq (ih s hs₁ τj)
+        · intro u
+          have hsTail : s + ((K + 1) + (L₀ + 1)) ≤ N := by omega
+          change tailRestrictₗ u
+              (contiguousRestrictₗ s ((K + 1) + (L₀ + 1)) hsTail τ ψ) ∈
+            groundSpace A (L₀ + 1)
+          rw [tailRestrictₗ_contiguousRestrictₗ (d := d) (s := s) (K := K + 1)
+            (L := L₀ + 1) hsTail u τ ψ]
+          exact hwindow (s + (K + 1)) (by omega) _
+  let K := N - (L₀ + 1)
+  have hEq : K + L₀ + 1 = N := by
+    dsimp [K]
+    omega
+  have hmemK := claim K 0 (by dsimp [K]; omega) τ₀
+  have hmemN := reindexSites_mem_groundSpace hEq hmemK
+  have hfull :
+      reindexSites hEq
+        (contiguousRestrictₗ 0 (K + L₀ + 1) (by dsimp [K]; omega) τ₀ ψ) = ψ := by
+    ext σ
+    simp only [reindexSites_apply, contiguousRestrictₗ_apply]
+    congr 1
+    ext k
+    simp only [contiguousCfg]
+    rw [dif_pos (show 0 ≤ k.val ∧ k.val < 0 + (K + L₀ + 1) by omega)]
+    congr 1
+  rwa [hfull] at hmemN
 
 /-! ### Helper: vanishing on all word products implies zero -/
 

--- a/audits/2026-04-22_issue588_normal_range_reduction_partial.md
+++ b/audits/2026-04-22_issue588_normal_range_reduction_partial.md
@@ -27,11 +27,10 @@ turn cyclic `L`-window membership into the reduced contiguous `(L₀ + 1)`-windo
 hypotheses, then use the existing wrapped-window compatibility results in
 `WrappingWindow.lean` to force scalar boundary matrices.
 
-## Outcome of this pass
+## Historical 2026-04-22 outcome
 
-I explored the **open-chain** half of the normal-range reduction and found a
-credible proof route through the recently landed suffix-window / regrowth API.
-In particular, the intended argument is:
+The original `feat/588-chainGroundSpace-normal` pass identified the correct
+open-chain route but did not land a Lean theorem. Its intended argument was:
 
 1. shrink cyclic windows from length $L$ down to $L_0 + 1$ by peeling the last
    site;
@@ -39,76 +38,51 @@ In particular, the intended argument is:
 3. iterate `MPSTensor.groundSpace_extend_right_of_isNBlkInjective` to regrow
    from contiguous `(L_0 + 1)`-window conditions to full open-chain membership.
 
-I attempted to formalize this directly in
-`TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`, but the resulting Lean
-partial did **not** survive honest `lake build` / CI: the dependent arithmetic
-reindexing around `contiguousRestrictₗ` produced nontrivial type mismatches and
-proof-argument transport failures. To keep the branch compiling, I reverted that
-non-compiling Lean partial instead of forcing it through with brittle casts or
-new `sorry`s.
+That 2026-04-22 branch reverted its non-compiling Lean partial because dependent
+arithmetic reindexing around `contiguousRestrictₗ` produced type mismatches.
+Wave 14 addresses exactly that reverted transport layer by adding
+`tailRestrictₗ_contiguousRestrictₗ` and then landing the chain-level theorem
+`contiguous_mem_groundSpace_of_isNBlkInjective`.
 
-So this pass leaves **no new Lean theorem landed** in `UniqueGroundState.lean`.
-The branch now contains only this updated audit note together with a tiny import
-cleanup in `TNLean.lean` (dropping `TNLean.MPS.ParentHamiltonian.OpenChainRangeReduction`
-from the top-level imports). The concrete duplicate-declaration failure was
-`MPSTensor.groundSpace_extend_right_of_isNBlkInjective`, defined in both
-`TNLean.MPS.ParentHamiltonian.ExtendRight` and
-`TNLean.MPS.ParentHamiltonian.OpenChainRangeReduction`.
+## Remaining blocker after Wave 14
 
-## Exact remaining blocker
-
-To finish
+The final target
 
 ```lean
 chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 ```
 
-one still needs the block-injective wrapped-window theorem from follow-up issue
-#730.
+still needs the periodic reintegration step. The open-chain representation
+`ψ ∈ groundSpace A N` is now available from contiguous `(L₀ + 1)`-window
+constraints, but the periodic proof must still connect the full cyclic
+`chainGroundSpace A L N` hypothesis to that reduced open-chain hypothesis and
+then force the boundary matrix in `ψ = groundSpaceMap A N X` to be scalar.
 
-The precise missing ingredient is a wrapped-window comparison theorem which, for
-`ψ = groundSpaceMap A N X` satisfying all cyclic `(L₀ + 1)`-window constraints,
-produces the missing second one-sided compatibility (or an equivalent common
-middle matrix) needed to force boundary commutation.
+The expected next formal pieces are:
 
-A representative missing statement is:
-
-```lean
--- schematic shape
-∀ τ, ∃ Yτ,
-  (∀ j, Cτ τ * A j * X = Yτ * A j) ∧
-  (∀ j, X * A j * Cτ τ = A j * Yτ)
-```
-
-with `Cτ τ` the complement word determined by `τ`.
-
-Current `WrappingWindow` methods give the **first** compatibility after replacing
-one-site injectivity by `groundSpaceMap_injective_of_isNBlkInjective`, but not
-the second from the same witness. Once that missing comparison theorem exists,
-chunking plus
-
-```lean
-MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes
-```
-
-should complete the periodic step.
+1. a cyclic-window range monotonicity / peeling theorem reducing cyclic
+   `L`-window constraints to cyclic `(L₀ + 1)`-window constraints;
+2. a periodic closure theorem using the existing wrapped-window compatibility
+   and mirror compatibility lemmas in `WrappingWindow.lean`, together with
+   `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`,
+   to obtain the same generator-commutation conclusion as in the injective proof.
 
 ## Tracking / linkage
 
-- Downstream blocker issue: #730
 - Parent issue: #588
+- Related wrapped-window work: #730 / #761
+- Related transport work: #869 / #883
 - Paper reference: CPGSV21, §IV.C
 
-## Files changed on the final compilable branch state
+## Files changed by the Wave 14 branch
 
+- `TNLean/MPS/ParentHamiltonian/RestrictTransport.lean`
+- `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
 - `audits/2026-04-22_issue588_normal_range_reduction_partial.md`
-- `TNLean.lean` (import cleanup)
 
-## Honest status
+## Status after Wave 14
 
-This pass does **not** discharge the final `sorry` in
-`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
-It sharpens the roadmap for the open-chain side, but the actual Lean
-formalization was reverted after CI showed it was not yet robust. The true
-remaining blocker is still the periodic wrapped-window comparison theorem from
-#730.
+Wave 14 lands the open-chain theorem but does **not** discharge the remaining
+periodic `sorry` in
+`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`. The remaining work
+is the cyclic-window reduction and wrapped-boundary scalar-closure assembly.

--- a/audits/2026-04-22_issue588_normal_range_reduction_partial.md
+++ b/audits/2026-04-22_issue588_normal_range_reduction_partial.md
@@ -1,8 +1,31 @@
-# Issue #588 audit update — open-chain route identified, but no Lean theorem landed yet
+# Issue #588 audit update — open-chain route and Wave 14 formal step
 
 Date: 2026-04-22
 Branch: `feat/588-chainGroundSpace-normal`
 Target theorem: `MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal`
+
+## 2026-04-25 Wave 14 update
+
+Current branch `wave14-A-588-range-reduction` lands the reusable open-chain step
+that this audit had identified as missing:
+
+- `MPSTensor.tailRestrictₗ_contiguousRestrictₗ` in
+  `TNLean/MPS/ParentHamiltonian/RestrictTransport.lean` identifies a suffix
+  restriction of a contiguous `(K + L)` window with the contiguous `L`-window
+  beginning at `s + K`, after inserting the fixed prefix into the outside
+  configuration.
+- `MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective` in
+  `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean` iterates
+  `groundSpace_extend_right_of_isNBlkInjective`: contiguous `(L₀ + 1)`-window
+  ground-space constraints now imply full open-chain membership
+  `ψ ∈ groundSpace A N`.
+
+The public theorem
+`MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` is still
+not closed by this update. The remaining work is now the periodic reintegration:
+turn cyclic `L`-window membership into the reduced contiguous `(L₀ + 1)`-window
+hypotheses, then use the existing wrapped-window compatibility results in
+`WrappingWindow.lean` to force scalar boundary matrices.
 
 ## Outcome of this pass
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -704,14 +704,16 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{thm:ground_space_extend_right_block_injective, def:l_blk_injective,
         rem:contiguous_window_operators}
-    Let $A$ be $L_0$-block injective with $L_0 > 0$. If an $N$-site state
-    satisfies the ground-space constraint on every non-wrapping contiguous window
-    of length $L_0+1$, with $N \ge L_0+1$, then it lies in $G_N(A)$.
+    Let $A$ be $L_0$-block injective with $D \ge 1$ and $L_0 > 0$.
+    If an $N$-site state satisfies the ground-space constraint on every
+    non-wrapping contiguous window of length $L_0+1$, for every complementary
+    outside configuration, with $N \ge L_0+1$, then it lies in $G_N(A)$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:ground_space_extend_right_block_injective}
+    \uses{thm:ground_space_extend_right_block_injective,
+        def:tail_restrict_parent, rem:contiguous_window_operators}
     Induct on the extra length beyond $L_0+1$. The induction hypothesis gives the
     long left-window ground condition after deleting the last site, while
     Definition~\ref{def:tail_restrict_parent} and the contiguous-window transport above

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -706,8 +706,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         rem:contiguous_window_operators}
     Let $A$ be $L_0$-block injective with $D \ge 1$ and $L_0 > 0$.
     If an $N$-site state satisfies the ground-space constraint on every
-    non-wrapping contiguous window of length $L_0+1$, for every complementary
-    outside configuration, with $N \ge L_0+1$, then it lies in $G_N(A)$.
+    non-wrapping contiguous window of length $L_0+1$, for every choice $\tau$
+    of the complementary outside configuration, with $N \ge L_0+1$, then it
+    lies in $G_N(A)$.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -531,19 +531,22 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \subsubsection{Contiguous and cyclic window operators}
 
-\begin{remark}[Contiguous window operators]
+\begin{remark}[Contiguous window operators]\label{rem:contiguous_window_operators}
     \lean{MPSTensor.contiguousCfg}
     \lean{MPSTensor.contiguousRestrictₗ}
     \lean{MPSTensor.contiguousRestrictₗ_apply}
     \lean{MPSTensor.contiguousCfg_zero_full}
     \lean{MPSTensor.contiguousRestrictₗ_restrictLast}
     \lean{MPSTensor.contiguousRestrictₗ_restrictFirst}
+    \lean{MPSTensor.tailRestrictₗ_contiguousRestrictₗ}
     \leanok
     For a non-wrapping interval $[s,s+M-1] \subseteq \{0,\ldots,N-1\}$, one can insert a
     length-$M$ word into that interval and keep the complementary sites fixed. The
     associated restriction map evaluates an $N$-site state on those configurations.
-    The auxiliary lemmas record the full-window case $s=0$, $M=N$, and the
-    compatibility of this restriction with deleting the last or first site.
+    The auxiliary lemmas record the full-window case $s=0$, $M=N$, the
+    compatibility of this restriction with deleting the last or first site, and
+    the fact that fixing the first $K$ entries of a contiguous $(K+L)$-window
+    leaves the contiguous $L$-window beginning at $s+K$.
 \end{remark}
 
 \begin{remark}[Cyclic window operators]\label{rem:cyclic_window_operators}
@@ -693,6 +696,28 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     space vector determined by $X$. Since every configuration is obtained by
     adjoining its final letter to its initial $(K + L_0)$-tuple, the two states
     coincide, so $\psi$ lies in $G_{K + L_0 + 1}(A)$.
+\end{proof}
+
+\begin{theorem}[Open-chain normal range reduction]%
+    \label{thm:normal_open_chain_range_reduction}
+    \lean{MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective}
+    \leanok
+    \uses{thm:ground_space_extend_right_block_injective, def:l_blk_injective,
+        rem:contiguous_window_operators}
+    Let $A$ be $L_0$-block injective with $L_0 > 0$. If an $N$-site state
+    satisfies the ground-space constraint on every non-wrapping contiguous window
+    of length $L_0+1$, with $N \ge L_0+1$, then it lies in $G_N(A)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_extend_right_block_injective}
+    Induct on the extra length beyond $L_0+1$. The induction hypothesis gives the
+    long left-window ground condition after deleting the last site, while
+    Definition~\ref{def:tail_restrict_parent} and the contiguous-window transport above
+    identify every fixed-prefix suffix with one of the assumed length-$L_0+1$
+    windows. Theorem~\ref{thm:ground_space_extend_right_block_injective} then
+    regrows the rightmost site.
 \end{proof}
 
 \begin{theorem}[Boundary matrix commutation from the wrapping window]\label{thm:boundary_matrix_commutes}
@@ -927,14 +952,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     the reverse inclusion is Lemma~\ref{lem:mpv_mem_chain_ground_space}.
 \end{proof}
 
-% TODO(#703,#704): current main still lacks the suffix-window / extend-right API
-% from the recent blocked-intersection audits, so the open-boundary regrowth layer
-% is not yet documented here as separate \lean{...} entries.
 \begin{theorem}[Normal-range reduction: containment in the MPV line]
     \label{thm:normal_range_reduction_containment}
     \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction}
     \notready
-    \uses{def:chain_ground_space, def:mpv_submodule, def:normal, def:l_blk_injective}
+    \uses{def:chain_ground_space, def:mpv_submodule, def:normal,
+        def:l_blk_injective, thm:normal_open_chain_range_reduction}
     If $A$ is normal, $D \ge 1$, $L_0$-block-injective, with $N \ge 2$ and $L_0 < L \le N$, then
     \[
         \mathcal G_{N,L}(A) \subseteq \spn\bigl\{V^{(N)}(A)\bigr\}.


### PR DESCRIPTION
## Summary

Refs #588, #190, #460.

This PR lands the next reusable formal step toward the normal-range reduction in `UniqueGroundState.lean`:

- adds `MPSTensor.tailRestrictₗ_contiguousRestrictₗ` to `RestrictTransport.lean`, identifying a suffix restriction of a contiguous `(K + L)` window with the contiguous `L`-window beginning at `s + K` after inserting the fixed prefix into the outside configuration;
- adds `MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective`, which iterates `groundSpace_extend_right_of_isNBlkInjective` to prove that contiguous `(L₀ + 1)`-window ground-space constraints imply full open-chain membership `ψ ∈ groundSpace A N`;
- adds blueprint coverage in `blueprint/src/chapter/ch14_parent_hamiltonian.tex` under the LaTeX labels `rem:contiguous_window_operators` and `thm:normal_open_chain_range_reduction`, and updates the #588 audit note.

Paper/blueprint anchors:

- CPGSV21 local source: `Papers/2011.12127/TN-Review-main.tex` lines 2049--2078 (`\label{eq:4:initiate-intersection-proof}` through the iterated intersection/closure paragraph) and lines 2087--2094 (`\label{thm:4:unique-gs-L0_plus_1}`).
- Blueprint source: `blueprint/src/chapter/ch14_parent_hamiltonian.tex` labels `rem:contiguous_window_operators`, `thm:ground_space_extend_right_block_injective`, `thm:normal_open_chain_range_reduction`, and `thm:normal_range_reduction_containment`.

The public theorem `MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` is not closed in this PR, so this does **not** use `Closes #588`.

## Validation

- `lake env lean TNLean/MPS/ParentHamiltonian/RestrictTransport.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `lake build TNLean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `rg -n "sorry|axiom|admit|native_decide|unsafe" TNLean/MPS/ParentHamiltonian/RestrictTransport.lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
  - reports only the pre-existing target `sorry` in `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds nontrivial new Lean theorems and proof automation around dependent-length reindexing and window restriction transport; risk is mainly proof brittleness/regression in downstream formalization rather than runtime behavior.
> 
> **Overview**
> Adds a new transport lemma `tailRestrictₗ_contiguousRestrictₗ` to relate suffix restriction of a contiguous `(K+L)` window to the shifted contiguous `L` window, with the fixed prefix injected into the outside configuration.
> 
> Builds on that transport layer in `UniqueGroundState.lean` by importing `ExtendRight`/`RestrictTransport` and proving `contiguous_mem_groundSpace_of_isNBlkInjective`, an open-chain range-reduction theorem showing that *all* contiguous `(L₀+1)` window ground-space constraints imply full-chain membership `ψ ∈ groundSpace A N` (plus a small helper lemma `neZero_d_of_isNBlkInjective`).
> 
> Updates the audit note and blueprint to document the new open-chain theorem and reference it from the still-`sorry` periodic normal-range reduction statement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed086818eb792f0cbb109d753f1476c7a572daa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->