### PR TITLE
feat(Analysis): add projection row-sum martingale reduction (#460)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -38,6 +38,7 @@ import TNLean.Algebra.CocycleCohomology
 
 -- Layer 0b: General analysis
 import TNLean.Analysis.ConvergenceHelpers
+import TNLean.Analysis.ProjectionGeometry
 
 -- Layer 1: Generic convex/topological infrastructure
 import TNLean.Topology.ConvexProjection

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -1,0 +1,204 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.InnerProductSpace.Positive
+import Mathlib.Data.Complex.BigOperators
+
+/-!
+# Projection-geometry lemmas for martingale estimates
+
+This file collects small finite-dimensional Hilbert-space lemmas used by the
+parent-Hamiltonian martingale method.  The main theorem is a purely algebraic
+quadratic-form reduction for a finite sum of symmetric projections: if the
+ordered off-diagonal terms satisfy a row-summable anti-commutator bound, then
+`H = ∑ i, P i` satisfies `H² ≥ γ H` as a quadratic form.
+
+The statements deliberately keep the MPS/Friedrichs-angle estimates as explicit
+hypotheses.  They provide the reusable projection-geometry layer into which the
+model-specific overlap and row-sum bounds can later be plugged.
+-/
+
+open scoped BigOperators InnerProductSpace
+
+namespace ProjectionGeometry
+
+variable {ι E : Type*} [Fintype ι]
+variable [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+
+/-- The quadratic form of a positive-order comparison is monotone. -/
+theorem re_inner_le_of_le {S T : E →ₗ[ℂ] E} (h : S ≤ T) (v : E) :
+    (⟪S v, v⟫_ℂ).re ≤ (⟪T v, v⟫_ℂ).re := by
+  have hpos : (T - S).IsPositive := h
+  have hnonneg := hpos.re_inner_nonneg_left v
+  simpa [LinearMap.sub_apply, inner_sub_left, map_sub, sub_nonneg] using hnonneg
+
+/-- The real quadratic form of the anti-commutator of two symmetric operators is
+twice the ordered cross term. This is the algebraic form behind the usual
+martingale estimate `P Q + Q P ≥ -ε (P + Q)`. -/
+theorem IsSymmetric.re_inner_anticommutator
+    {P Q : E →ₗ[ℂ] E} (hP : P.IsSymmetric) (hQ : Q.IsSymmetric) (v : E) :
+    (⟪(P * Q + Q * P) v, v⟫_ℂ).re = 2 * (⟪P v, Q v⟫_ℂ).re := by
+  have hPQ : ⟪(P * Q) v, v⟫_ℂ = ⟪Q v, P v⟫_ℂ := by
+    change ⟪P (Q v), v⟫_ℂ = ⟪Q v, P v⟫_ℂ
+    exact hP (Q v) v
+  have hQP : ⟪(Q * P) v, v⟫_ℂ = ⟪P v, Q v⟫_ℂ := by
+    change ⟪Q (P v), v⟫_ℂ = ⟪P v, Q v⟫_ℂ
+    exact hQ (P v) v
+  have hRe : (⟪Q v, P v⟫_ℂ).re = (⟪P v, Q v⟫_ℂ).re := by
+    exact inner_re_symm (𝕜 := ℂ) (Q v) (P v)
+  calc
+    (⟪(P * Q + Q * P) v, v⟫_ℂ).re
+        = (⟪(P * Q) v, v⟫_ℂ + ⟪(Q * P) v, v⟫_ℂ).re := by
+            simp [LinearMap.add_apply, inner_add_left]
+    _ = (⟪Q v, P v⟫_ℂ + ⟪P v, Q v⟫_ℂ).re := by rw [hPQ, hQP]
+    _ = 2 * (⟪P v, Q v⟫_ℂ).re := by
+      rw [Complex.add_re, hRe]
+      ring
+
+/-- For a symmetric projection `P`, the diagonal term in `‖P v‖²` is its
+quadratic form. -/
+theorem IsSymmetricProjection.re_inner_apply_apply_self
+    {P : E →ₗ[ℂ] E} (hP : P.IsSymmetricProjection) (v : E) :
+    (⟪P v, P v⟫_ℂ).re = (⟪P v, v⟫_ℂ).re := by
+  have hidem : P (P v) = P v := by
+    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E => T v) hP.isIdempotentElem.eq
+  calc
+    (⟪P v, P v⟫_ℂ).re = (⟪P (P v), v⟫_ℂ).re := by
+      exact congrArg Complex.re ((hP.isSymmetric (P v) v).symm)
+    _ = (⟪P v, v⟫_ℂ).re := by
+      rw [hidem]
+
+/-- A symmetric projection has nonnegative quadratic form. -/
+theorem IsSymmetricProjection.re_inner_nonneg
+    {P : E →ₗ[ℂ] E} (hP : P.IsSymmetricProjection) (v : E) :
+    0 ≤ (⟪P v, v⟫_ℂ).re :=
+  hP.isPositive.re_inner_nonneg_left v
+
+/-- The quadratic form of a finite sum expands into the finite sum of quadratic
+forms. -/
+theorem re_inner_sum_apply_left (P : ι → E →ₗ[ℂ] E) (v : E) :
+    (⟪(∑ i, P i) v, v⟫_ℂ).re = ∑ i, (⟪P i v, v⟫_ℂ).re := by
+  simp only [LinearMap.sum_apply, sum_inner]
+  rw [Complex.re_sum]
+
+/-- The norm-square quadratic form of a finite sum expands into all ordered
+cross terms. -/
+theorem re_inner_sum_apply_apply (P : ι → E →ₗ[ℂ] E) (v : E) :
+    (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re =
+      ∑ i, ∑ j, (⟪P i v, P j v⟫_ℂ).re := by
+  simp only [LinearMap.sum_apply, sum_inner, inner_sum]
+  rw [Complex.re_sum]
+  simp_rw [Complex.re_sum]
+  rw [Finset.sum_comm]
+
+section OffDiagonal
+
+variable [DecidableEq ι]
+
+/-- Split an ordered double sum into diagonal and off-diagonal parts. -/
+theorem sum_sum_eq_diag_add_offdiag (f : ι → ι → ℝ) :
+    (∑ i, ∑ j, f i j) =
+      (∑ i, f i i) + (∑ i, ∑ j ∈ Finset.univ.erase i, f i j) := by
+  calc
+    (∑ i, ∑ j, f i j) =
+        ∑ i, (f i i + ∑ j ∈ Finset.univ.erase i, f i j) := by
+      refine Finset.sum_congr rfl ?_
+      intro i _
+      exact (Finset.add_sum_erase Finset.univ (fun j => f i j) (Finset.mem_univ i)).symm
+    _ = (∑ i, f i i) + (∑ i, ∑ j ∈ Finset.univ.erase i, f i j) := by
+      rw [Finset.sum_add_distrib]
+
+/-- Row-summable ordered off-diagonal bounds imply the aggregate cross-term
+bound used in the martingale method.
+
+Here `q i` is the nonnegative diagonal quadratic form of the `i`-th projection,
+`cross i j` is the ordered real cross term, and `c i j` is a row-summable
+coefficient matrix. -/
+theorem crossTerm_sum_bound_of_ordered_rowSum {γ : ℝ} (hγle : γ ≤ 1)
+    (q : ι → ℝ) (cross c : ι → ι → ℝ)
+    (hq_nonneg : ∀ i, 0 ≤ q i)
+    (hRow : ∀ i, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1)
+    (hCross : ∀ i j, j ∈ Finset.univ.erase i →
+      -(1 - γ) * c i j * q i ≤ cross i j) :
+    -(1 - γ) * (∑ i, q i) ≤
+      ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j := by
+  have hrowmul : ∀ i,
+      -(1 - γ) * q i ≤
+        ∑ j ∈ Finset.univ.erase i, -(1 - γ) * c i j * q i := by
+    intro i
+    have hnonneg : 0 ≤ 1 - γ := sub_nonneg.mpr hγle
+    have hq : 0 ≤ q i := hq_nonneg i
+    have hmul : (∑ j ∈ Finset.univ.erase i, c i j) * q i ≤ 1 * q i :=
+      mul_le_mul_of_nonneg_right (hRow i) hq
+    have hmul' : (1 - γ) * ((∑ j ∈ Finset.univ.erase i, c i j) * q i) ≤
+        (1 - γ) * q i := by
+      simpa [one_mul] using mul_le_mul_of_nonneg_left hmul hnonneg
+    have hneg := neg_le_neg hmul'
+    calc
+      -(1 - γ) * q i = - ((1 - γ) * q i) := by ring
+      _ ≤ - ((1 - γ) * ((∑ j ∈ Finset.univ.erase i, c i j) * q i)) := hneg
+      _ = ∑ j ∈ Finset.univ.erase i, -(1 - γ) * c i j * q i := by
+        rw [← Finset.sum_mul, ← Finset.mul_sum]
+        ring
+  calc
+    -(1 - γ) * (∑ i, q i)
+        = ∑ i, -(1 - γ) * q i := by
+            simp [Finset.mul_sum]
+    _ ≤ ∑ i, ∑ j ∈ Finset.univ.erase i, -(1 - γ) * c i j * q i := by
+            exact Finset.sum_le_sum (fun i _ => hrowmul i)
+    _ ≤ ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j := by
+            refine Finset.sum_le_sum ?_
+            intro i _
+            refine Finset.sum_le_sum ?_
+            intro j hj
+            exact hCross i j hj
+
+/-- If the ordered off-diagonal terms of a finite family of symmetric
+projections satisfy a row-summable anti-commutator bound, then the sum satisfies
+`H² ≥ γ H` as a quadratic form.
+
+The hypothesis `hCross` is the ordered form of the martingale anti-commutator
+estimate after taking real quadratic forms:
+`Re ⟪P_i v, P_j v⟫ ≥ -(1 - γ) c_{ij} Re ⟪P_i v, v⟫` for `i ≠ j`.
+The row bound `∑_{j ≠ i} c_{ij} ≤ 1` then gives the aggregate estimate. -/
+theorem quadraticForm_sum_projections_of_ordered_rowSum {γ : ℝ} (hγle : γ ≤ 1)
+    (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)
+    (c : ι → ι → ℝ)
+    (hRow : ∀ i, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1)
+    (hCross : ∀ i j, j ∈ Finset.univ.erase i → ∀ v : E,
+      -(1 - γ) * c i j * (⟪P i v, v⟫_ℂ).re ≤
+        (⟪P i v, P j v⟫_ℂ).re) :
+    ∀ v : E,
+      γ * (⟪(∑ i, P i) v, v⟫_ℂ).re ≤
+        (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := by
+  intro v
+  let q : ι → ℝ := fun i => (⟪P i v, v⟫_ℂ).re
+  let cross : ι → ι → ℝ := fun i j => (⟪P i v, P j v⟫_ℂ).re
+  have hq_nonneg : ∀ i, 0 ≤ q i := fun i =>
+    IsSymmetricProjection.re_inner_nonneg (hP i) v
+  have hCrossSum : -(1 - γ) * (∑ i, q i) ≤
+      ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j :=
+    crossTerm_sum_bound_of_ordered_rowSum hγle q cross c hq_nonneg hRow
+      (fun i j hj => hCross i j hj v)
+  have hDiag : (∑ i, cross i i) = ∑ i, q i := by
+    refine Finset.sum_congr rfl ?_
+    intro i _
+    exact IsSymmetricProjection.re_inner_apply_apply_self (hP i) v
+  have hSplit := sum_sum_eq_diag_add_offdiag (fun i j => cross i j)
+  have hHq : (⟪(∑ i, P i) v, v⟫_ℂ).re = ∑ i, q i := by
+    simpa [q] using re_inner_sum_apply_left P v
+  have hHH : (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re =
+      ∑ i, q i + ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j := by
+    rw [re_inner_sum_apply_apply P v, hSplit, hDiag]
+  calc
+    γ * (⟪(∑ i, P i) v, v⟫_ℂ).re
+        = γ * (∑ i, q i) := by rw [hHq]
+    _ = (∑ i, q i) + (-(1 - γ) * (∑ i, q i)) := by ring
+    _ ≤ (∑ i, q i) + ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j :=
+        add_le_add le_rfl hCrossSum
+    _ = (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := hHH.symm
+
+end OffDiagonal
+
+end ProjectionGeometry

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Analysis.InnerProductSpace.Positive
-import Mathlib.Data.Complex.BigOperators
 
 /-!
 # Projection-geometry lemmas for martingale estimates
@@ -11,7 +10,7 @@ import Mathlib.Data.Complex.BigOperators
 This file collects small finite-dimensional Hilbert-space lemmas used by the
 parent-Hamiltonian martingale method.  The main theorem is a purely algebraic
 quadratic-form reduction for a finite sum of symmetric projections: if the
-ordered off-diagonal terms satisfy a row-summable anti-commutator bound, then
+ordered off-diagonal terms satisfy a row-summable cross-term bound, then
 `H = ∑ i, P i` satisfies `H² ≥ γ H` as a quadratic form.
 
 The statements deliberately keep the MPS/Friedrichs-angle estimates as explicit
@@ -19,85 +18,66 @@ hypotheses.  They provide the reusable projection-geometry layer into which the
 model-specific overlap and row-sum bounds can later be plugged.
 -/
 
-open scoped BigOperators InnerProductSpace
+open scoped InnerProductSpace
 
-namespace ProjectionGeometry
+namespace LinearMap.IsSymmetricProjection
 
-variable {ι E : Type*} [Fintype ι]
-variable [NormedAddCommGroup E] [InnerProductSpace ℂ E]
-
-/-- The quadratic form of a positive-order comparison is monotone. -/
-theorem re_inner_le_of_le {S T : E →ₗ[ℂ] E} (h : S ≤ T) (v : E) :
-    (⟪S v, v⟫_ℂ).re ≤ (⟪T v, v⟫_ℂ).re := by
-  have hpos : (T - S).IsPositive := h
-  have hnonneg := hpos.re_inner_nonneg_left v
-  simpa [LinearMap.sub_apply, inner_sub_left, map_sub, sub_nonneg] using hnonneg
-
-/-- The real quadratic form of the anti-commutator of two symmetric operators is
-twice the ordered cross term. This is the algebraic form behind the usual
-martingale estimate `P Q + Q P ≥ -ε (P + Q)`. -/
-theorem IsSymmetric.re_inner_anticommutator
-    {P Q : E →ₗ[ℂ] E} (hP : P.IsSymmetric) (hQ : Q.IsSymmetric) (v : E) :
-    (⟪(P * Q + Q * P) v, v⟫_ℂ).re = 2 * (⟪P v, Q v⟫_ℂ).re := by
-  have hPQ : ⟪(P * Q) v, v⟫_ℂ = ⟪Q v, P v⟫_ℂ := by
-    change ⟪P (Q v), v⟫_ℂ = ⟪Q v, P v⟫_ℂ
-    exact hP (Q v) v
-  have hQP : ⟪(Q * P) v, v⟫_ℂ = ⟪P v, Q v⟫_ℂ := by
-    change ⟪Q (P v), v⟫_ℂ = ⟪P v, Q v⟫_ℂ
-    exact hQ (P v) v
-  have hRe : (⟪Q v, P v⟫_ℂ).re = (⟪P v, Q v⟫_ℂ).re := by
-    exact inner_re_symm (𝕜 := ℂ) (Q v) (P v)
-  calc
-    (⟪(P * Q + Q * P) v, v⟫_ℂ).re
-        = (⟪(P * Q) v, v⟫_ℂ + ⟪(Q * P) v, v⟫_ℂ).re := by
-            simp [LinearMap.add_apply, inner_add_left]
-    _ = (⟪Q v, P v⟫_ℂ + ⟪P v, Q v⟫_ℂ).re := by rw [hPQ, hQP]
-    _ = 2 * (⟪P v, Q v⟫_ℂ).re := by
-      rw [Complex.add_re, hRe]
-      ring
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
 /-- For a symmetric projection `P`, the diagonal term in `‖P v‖²` is its
 quadratic form. -/
-theorem IsSymmetricProjection.re_inner_apply_apply_self
-    {P : E →ₗ[ℂ] E} (hP : P.IsSymmetricProjection) (v : E) :
-    (⟪P v, P v⟫_ℂ).re = (⟪P v, v⟫_ℂ).re := by
+theorem re_inner_apply_apply_self {P : E →ₗ[𝕜] E} (hP : P.IsSymmetricProjection)
+    (v : E) :
+    RCLike.re (⟪P v, P v⟫_𝕜) = RCLike.re (⟪P v, v⟫_𝕜) := by
   have hidem : P (P v) = P v := by
-    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E => T v) hP.isIdempotentElem.eq
+    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[𝕜] E => T v)
+      hP.isIdempotentElem.eq
   calc
-    (⟪P v, P v⟫_ℂ).re = (⟪P (P v), v⟫_ℂ).re := by
-      exact congrArg Complex.re ((hP.isSymmetric (P v) v).symm)
-    _ = (⟪P v, v⟫_ℂ).re := by
+    RCLike.re (⟪P v, P v⟫_𝕜) = RCLike.re (⟪P (P v), v⟫_𝕜) := by
+      exact congrArg RCLike.re ((hP.isSymmetric (P v) v).symm)
+    _ = RCLike.re (⟪P v, v⟫_𝕜) := by
       rw [hidem]
 
 /-- A symmetric projection has nonnegative quadratic form. -/
-theorem IsSymmetricProjection.re_inner_nonneg
-    {P : E →ₗ[ℂ] E} (hP : P.IsSymmetricProjection) (v : E) :
-    0 ≤ (⟪P v, v⟫_ℂ).re :=
+theorem re_inner_nonneg {P : E →ₗ[𝕜] E} (hP : P.IsSymmetricProjection) (v : E) :
+    0 ≤ RCLike.re (⟪P v, v⟫_𝕜) :=
   hP.isPositive.re_inner_nonneg_left v
+
+end LinearMap.IsSymmetricProjection
+
+namespace ProjectionGeometry
+
+section InnerSums
+
+variable {ι 𝕜 E : Type*} [Fintype ι]
+variable [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
 /-- The quadratic form of a finite sum expands into the finite sum of quadratic
 forms. -/
-theorem re_inner_sum_apply_left (P : ι → E →ₗ[ℂ] E) (v : E) :
-    (⟪(∑ i, P i) v, v⟫_ℂ).re = ∑ i, (⟪P i v, v⟫_ℂ).re := by
+theorem re_inner_sum_apply_left (P : ι → E →ₗ[𝕜] E) (v : E) :
+    RCLike.re (⟪(∑ i, P i) v, v⟫_𝕜) =
+      ∑ i, RCLike.re (⟪P i v, v⟫_𝕜) := by
   simp only [LinearMap.sum_apply, sum_inner]
-  rw [Complex.re_sum]
+  exact map_sum (RCLike.re : 𝕜 →+ ℝ) (fun i => ⟪P i v, v⟫_𝕜) Finset.univ
 
 /-- The norm-square quadratic form of a finite sum expands into all ordered
 cross terms. -/
-theorem re_inner_sum_apply_apply (P : ι → E →ₗ[ℂ] E) (v : E) :
-    (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re =
-      ∑ i, ∑ j, (⟪P i v, P j v⟫_ℂ).re := by
+theorem re_inner_sum_apply_apply (P : ι → E →ₗ[𝕜] E) (v : E) :
+    RCLike.re (⟪(∑ i, P i) v, (∑ i, P i) v⟫_𝕜) =
+      ∑ i, ∑ j, RCLike.re (⟪P i v, P j v⟫_𝕜) := by
   simp only [LinearMap.sum_apply, sum_inner, inner_sum]
-  rw [Complex.re_sum]
-  simp_rw [Complex.re_sum]
+  rw [map_sum (RCLike.re : 𝕜 →+ ℝ)]
+  simp_rw [map_sum (RCLike.re : 𝕜 →+ ℝ)]
   rw [Finset.sum_comm]
+
+end InnerSums
 
 section OffDiagonal
 
-variable [DecidableEq ι]
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
 /-- Split an ordered double sum into diagonal and off-diagonal parts. -/
-theorem sum_sum_eq_diag_add_offdiag (f : ι → ι → ℝ) :
+theorem sum_sum_eq_diag_add_offdiag {M : Type*} [AddCommMonoid M] (f : ι → ι → M) :
     (∑ i, ∑ j, f i j) =
       (∑ i, f i i) + (∑ i, ∑ j ∈ Finset.univ.erase i, f i j) := by
   calc
@@ -108,6 +88,8 @@ theorem sum_sum_eq_diag_add_offdiag (f : ι → ι → ℝ) :
       exact (Finset.add_sum_erase Finset.univ (fun j => f i j) (Finset.mem_univ i)).symm
     _ = (∑ i, f i i) + (∑ i, ∑ j ∈ Finset.univ.erase i, f i j) := by
       rw [Finset.sum_add_distrib]
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 
 /-- Row-summable ordered off-diagonal bounds imply the aggregate cross-term
 bound used in the martingale method.
@@ -155,11 +137,11 @@ theorem crossTerm_sum_bound_of_ordered_rowSum {γ : ℝ} (hγle : γ ≤ 1)
             exact hCross i j hj
 
 /-- If the ordered off-diagonal terms of a finite family of symmetric
-projections satisfy a row-summable anti-commutator bound, then the sum satisfies
+projections satisfy a row-summable cross-term bound, then the sum satisfies
 `H² ≥ γ H` as a quadratic form.
 
-The hypothesis `hCross` is the ordered form of the martingale anti-commutator
-estimate after taking real quadratic forms:
+The hypothesis `hCross` is the ordered form of the martingale overlap estimate
+after taking real quadratic forms:
 `Re ⟪P_i v, P_j v⟫ ≥ -(1 - γ) c_{ij} Re ⟪P_i v, v⟫` for `i ≠ j`.
 The row bound `∑_{j ≠ i} c_{ij} ≤ 1` then gives the aggregate estimate. -/
 theorem quadraticForm_sum_projections_of_ordered_rowSum {γ : ℝ} (hγle : γ ≤ 1)
@@ -173,23 +155,25 @@ theorem quadraticForm_sum_projections_of_ordered_rowSum {γ : ℝ} (hγle : γ �
       γ * (⟪(∑ i, P i) v, v⟫_ℂ).re ≤
         (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := by
   intro v
-  let q : ι → ℝ := fun i => (⟪P i v, v⟫_ℂ).re
-  let cross : ι → ι → ℝ := fun i j => (⟪P i v, P j v⟫_ℂ).re
-  have hq_nonneg : ∀ i, 0 ≤ q i := fun i =>
-    IsSymmetricProjection.re_inner_nonneg (hP i) v
+  let q : ι → ℝ := fun i => RCLike.re (⟪P i v, v⟫_ℂ)
+  let cross : ι → ι → ℝ := fun i j => RCLike.re (⟪P i v, P j v⟫_ℂ)
+  have hq_nonneg : ∀ i, 0 ≤ q i := fun i => (hP i).re_inner_nonneg v
   have hCrossSum : -(1 - γ) * (∑ i, q i) ≤
       ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j :=
     crossTerm_sum_bound_of_ordered_rowSum hγle q cross c hq_nonneg hRow
-      (fun i j hj => hCross i j hj v)
+      (fun i j hj => by simpa [q, cross] using hCross i j hj v)
   have hDiag : (∑ i, cross i i) = ∑ i, q i := by
     refine Finset.sum_congr rfl ?_
     intro i _
-    exact IsSymmetricProjection.re_inner_apply_apply_self (hP i) v
+    exact (hP i).re_inner_apply_apply_self v
   have hSplit := sum_sum_eq_diag_add_offdiag (fun i j => cross i j)
   have hHq : (⟪(∑ i, P i) v, v⟫_ℂ).re = ∑ i, q i := by
+    change RCLike.re (⟪(∑ i, P i) v, v⟫_ℂ) = ∑ i, q i
     simpa [q] using re_inner_sum_apply_left P v
   have hHH : (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re =
       ∑ i, q i + ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j := by
+    change RCLike.re (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ) =
+      ∑ i, q i + ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j
     rw [re_inner_sum_apply_apply P v, hSplit, hDiag]
   calc
     γ * (⟪(∑ i, P i) v, v⟫_ℂ).re

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
+import TNLean.Analysis.ProjectionGeometry
 import Mathlib.Analysis.InnerProductSpace.Positive
 import Mathlib.Analysis.InnerProductSpace.Spectrum
 
@@ -67,6 +68,9 @@ concrete Friedrichs-angle/row-sum lower bound that
 * `MPSTensor.parentHamiltonianES_gap_bound_of_quadratic_form` — the explicit
   reduction from the parent-Hamiltonian gap statement to the uniform
   Friedrichs/martingale quadratic-form estimate.
+* `MPSTensor.parentHamiltonianES_gap_bound_of_ordered_local_term_bounds` — a
+  reusable reduction from explicit ordered anti-commutator row bounds for the
+  local symmetric projections to the quadratic-form hypothesis above.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
   Friedrichs-angle bound recorded in
@@ -622,6 +626,78 @@ theorem parentHamiltonianES_gap_bound_of_quadratic_form
     exact div_pos (by norm_num) (mul_pos (by norm_num) hLpos)
   exact ⟨hγ, parentHamiltonianES_norm_bound_of_quadratic_form A L hγ hQuad⟩
 
+/-- Fixed-chain martingale quadratic-form estimate from ordered local
+anti-commutator row bounds.
+
+This theorem is the parent-Hamiltonian instantiation of the abstract projection
+geometry in `ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum`.
+It assumes explicitly that the transported local terms are symmetric projections
+and that their ordered cross terms satisfy the row-summable bound
+
+`Re ⟪hᵢ v, hⱼ v⟫ ≥ -(1 - γ) cᵢⱼ Re ⟪hᵢ v, v⟫`.
+
+Under these hypotheses the transported Hamiltonian satisfies `H² ≥ γ H` as a
+quadratic form, exactly in the shape consumed by
+`parentHamiltonianES_norm_bound_of_quadratic_form`. -/
+theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
+    (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
+    (c : Fin N → Fin N → ℝ)
+    (hProj : ∀ i : Fin N, (localTermES A L i).IsSymmetricProjection)
+    (hRow : ∀ i : Fin N, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1)
+    (hCross : ∀ i j : Fin N, j ∈ Finset.univ.erase i →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        - (1 - γ) * c i j * (⟪localTermES A L i v, v⟫_ℂ).re ≤
+          (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re) :
+    ∀ v : EuclideanSpace ℂ (Cfg d N),
+      γ * (⟪parentHamiltonianES A L N v, v⟫_ℂ).re ≤
+        (⟪parentHamiltonianES A L N v,
+          parentHamiltonianES A L N v⟫_ℂ).re := by
+  intro v
+  simpa [parentHamiltonianES_eq_sum_localTermES A L N] using
+    (ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum
+      (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
+      (fun i : Fin N => localTermES A L i) hProj c hRow hCross v)
+
+/-- Uniform explicit gap-bound reduction from ordered local anti-commutator row
+bounds.
+
+For every chain length `N ≥ 2L`, assume the transported local terms are symmetric
+projections and satisfy the ordered row-summable anti-commutator estimate with
+constant `γ = 1 / (4L)`. Then the existing quadratic-form-to-gap theorem applies
+and yields the explicit norm lower bound. This exact reduction leaves proving
+these projection and Friedrichs/row-sum hypotheses for the concrete MPS local
+terms as the model-specific analytic task. -/
+theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (c : ∀ N : ℕ, Fin N → Fin N → ℝ)
+    (hProj : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i : Fin N),
+      (localTermES A L i).IsSymmetricProjection)
+    (hRow : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i : Fin N),
+      (∑ j ∈ Finset.univ.erase i, c N i j) ≤ 1)
+    (hCross : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → ∀ v : EuclideanSpace ℂ (Cfg d N),
+        - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) * c N i j *
+            (⟪localTermES A L i v, v⟫_ℂ).re ≤
+          (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
+  intro N hLN v
+  have hLpos : (0 : ℝ) < (L : ℝ) := by
+    exact_mod_cast (Nat.zero_lt_of_lt hL)
+  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
+    exact_mod_cast (Nat.le_of_lt hL)
+  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
+    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
+    rw [div_le_iff₀ hden]
+    nlinarith
+  exact parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
+    A L N hγle (c N) (hProj N hLN) (hRow N hLN) (hCross N hLN) v
+
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
 /- Scout report (2026-04-19, Layer 4 KL martingale).
@@ -642,11 +718,18 @@ and the full transported Hamiltonian are now available as positive operators.
 `parentHamiltonianES_norm_bound_of_quadratic_form` and
 `parentHamiltonianES_gap_bound_of_quadratic_form` reduce the gap statement to a
 uniform estimate `γ * re ⟪H_N v, v⟫ ≤ re ⟪H_N v, H_N v⟫`.
-4. **Row-sum bound mapping:** the combinatorial part is already available from
-locality (`localTerm`, `parentHamiltonian`) and finite range: each window
-overlaps at most `2 * (L - 1)` neighbors. Missing is the analytic implication
-from overlap-angle constants to the quadratic-form inequality above.
-5. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
+4. **Projection-geometry row reduction:**
+`ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum`,
+`parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds`, and
+`parentHamiltonianES_gap_bound_of_ordered_local_term_bounds` now formalize the
+finite-sum algebra turning explicit ordered anti-commutator row bounds for local
+symmetric projections into the quadratic-form hypothesis above.
+5. **Remaining local analytic obligations:** the combinatorial overlap count comes
+from locality (`localTerm`, `parentHamiltonian`) and finite range: each window
+overlaps at most `2 * (L - 1)` neighbors. Still missing are the concrete local
+symmetric-projection theorem for `localTermES` and the Friedrichs-angle estimate
+that supplies the ordered anti-commutator constants with the required row sums.
+6. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
 existential theorem, now proved by applying the Friedrichs-angle theorem
 below. The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends
 on missing Friedrichs-angle infrastructure; this is the blocker and should not

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -69,7 +69,7 @@ concrete Friedrichs-angle/row-sum lower bound that
   reduction from the parent-Hamiltonian gap statement to the uniform
   Friedrichs/martingale quadratic-form estimate.
 * `MPSTensor.parentHamiltonianES_gap_bound_of_ordered_local_term_bounds` — a
-  reusable reduction from explicit ordered anti-commutator row bounds for the
+  reusable reduction from explicit ordered cross-term row bounds for the
   local symmetric projections to the quadratic-form hypothesis above.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
@@ -627,7 +627,7 @@ theorem parentHamiltonianES_gap_bound_of_quadratic_form
   exact ⟨hγ, parentHamiltonianES_norm_bound_of_quadratic_form A L hγ hQuad⟩
 
 /-- Fixed-chain martingale quadratic-form estimate from ordered local
-anti-commutator row bounds.
+cross-term row bounds.
 
 This theorem is the parent-Hamiltonian instantiation of the abstract projection
 geometry in `ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum`.
@@ -658,11 +658,11 @@ theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
       (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
       (fun i : Fin N => localTermES A L i) hProj c hRow hCross v)
 
-/-- Uniform explicit gap-bound reduction from ordered local anti-commutator row
+/-- Uniform explicit gap-bound reduction from ordered local cross-term row
 bounds.
 
 For every chain length `N ≥ 2L`, assume the transported local terms are symmetric
-projections and satisfy the ordered row-summable anti-commutator estimate with
+projections and satisfy the ordered row-summable cross-term estimate with
 constant `γ = 1 / (4L)`. Then the existing quadratic-form-to-gap theorem applies
 and yields the explicit norm lower bound. This exact reduction leaves proving
 these projection and Friedrichs/row-sum hypotheses for the concrete MPS local
@@ -722,13 +722,13 @@ uniform estimate `γ * re ⟪H_N v, v⟫ ≤ re ⟪H_N v, H_N v⟫`.
 `ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum`,
 `parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds`, and
 `parentHamiltonianES_gap_bound_of_ordered_local_term_bounds` now formalize the
-finite-sum algebra turning explicit ordered anti-commutator row bounds for local
+finite-sum algebra turning explicit ordered cross-term row bounds for local
 symmetric projections into the quadratic-form hypothesis above.
 5. **Remaining local analytic obligations:** the combinatorial overlap count comes
 from locality (`localTerm`, `parentHamiltonian`) and finite range: each window
 overlaps at most `2 * (L - 1)` neighbors. Still missing are the concrete local
 symmetric-projection theorem for `localTermES` and the Friedrichs-angle estimate
-that supplies the ordered anti-commutator constants with the required row sums.
+that supplies the ordered cross-term constants with the required row sums.
 6. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
 existential theorem, now proved by applying the Friedrichs-angle theorem
 below. The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1594,6 +1594,45 @@ Lucia~\cite{Kastoryano2018Martingale}.
     explicit constant is positive because $L>1$ implies $4L>0$.
 \end{proof}
 
+\begin{lemma}[Ordered projection row-sum reduction]
+    \label{lem:ordered_projection_rowsum_reduction}
+    \lean{ProjectionGeometry.re_inner_le_of_le}
+    \lean{ProjectionGeometry.IsSymmetric.re_inner_anticommutator}
+    \lean{ProjectionGeometry.IsSymmetricProjection.re_inner_apply_apply_self}
+    \lean{ProjectionGeometry.IsSymmetricProjection.re_inner_nonneg}
+    \lean{ProjectionGeometry.re_inner_sum_apply_left}
+    \lean{ProjectionGeometry.re_inner_sum_apply_apply}
+    \lean{ProjectionGeometry.sum_sum_eq_diag_add_offdiag}
+    \lean{ProjectionGeometry.crossTerm_sum_bound_of_ordered_rowSum}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum}
+    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_ordered_local_term_bounds}
+    \leanok
+    \uses{lem:parent_hamiltonian_es_quadratic_reduction}
+    Let $P_i$ be a finite family of symmetric projections and let
+    $H=\sum_i P_i$. If the ordered off-diagonal forms obey
+    \[
+        \operatorname{Re}\langle P_i v, P_j v\rangle
+        \ge -(1-\gamma)c_{ij}\operatorname{Re}\langle P_i v,v\rangle
+        \qquad (i\ne j),
+    \]
+    with row sums $\sum_{j\ne i} c_{ij}\le 1$ and $\gamma\le 1$, then
+    $H^2\ge \gamma H$ as a quadratic form.  Applied to the transported parent
+    Hamiltonian local terms, this supplies the hypothesis of
+    Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction}; the remaining
+    model-specific work is to prove the local projection property and the
+    Friedrichs-angle constants for those local terms.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand $\operatorname{Re}\langle H v,Hv\rangle$ as an ordered double sum.
+    Symmetric idempotence identifies each diagonal term with
+    $\operatorname{Re}\langle P_i v,v\rangle$, while the row-summable ordered
+    anti-commutator bounds control the off-diagonal contribution by
+    $-(1-\gamma)\sum_i\operatorname{Re}\langle P_i v,v\rangle$.
+\end{proof}
+
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
     \notready
     \uses{def:is_frustration_free, lem:quadratic_form_to_norm_bound}
@@ -1758,7 +1797,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
         rem:euclidean_local_projector_ingredients,
         lem:euclidean_local_projector_positive,
         lem:local_term_es_average,
-        lem:parent_hamiltonian_es_quadratic_reduction}
+        lem:parent_hamiltonian_es_quadratic_reduction,
+        lem:ordered_projection_rowsum_reduction}
     For an injective tensor $A$ and a range $L > 1$, the theorem asserts
     the analytic estimate with the explicit constant
     \[
@@ -1777,8 +1817,11 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Lemmas~\ref{lem:local_term_es_average} and~\ref{lem:transported_es_positive}.
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} reduces the present
     theorem to the remaining MPS-specific task: deriving the uniform
-    quadratic-form estimate from the Friedrichs-angle anti-commutator bound and
-    the finite-overlap row-sum estimate.
+    quadratic-form estimate.  Lemma~\ref{lem:ordered_projection_rowsum_reduction}
+    formalizes the finite-sum algebra from ordered anti-commutator row bounds;
+    the remaining MPS-specific tasks are to prove the local symmetric-projection
+    statement for the transported local terms and to obtain the Friedrichs-angle
+    constants with the required finite-overlap row sums.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1594,21 +1594,30 @@ Lucia~\cite{Kastoryano2018Martingale}.
     explicit constant is positive because $L>1$ implies $4L>0$.
 \end{proof}
 
-\begin{lemma}[Ordered projection row-sum reduction]
-    \label{lem:ordered_projection_rowsum_reduction}
-    \lean{ProjectionGeometry.re_inner_le_of_le}
-    \lean{ProjectionGeometry.IsSymmetric.re_inner_anticommutator}
-    \lean{ProjectionGeometry.IsSymmetricProjection.re_inner_apply_apply_self}
-    \lean{ProjectionGeometry.IsSymmetricProjection.re_inner_nonneg}
+\begin{remark}[Projection-geometry identities for row-sum arguments]
+    \label{rem:projection_geometry_rowsum_identities}
+    \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_self}
+    \lean{LinearMap.IsSymmetricProjection.re_inner_nonneg}
     \lean{ProjectionGeometry.re_inner_sum_apply_left}
     \lean{ProjectionGeometry.re_inner_sum_apply_apply}
     \lean{ProjectionGeometry.sum_sum_eq_diag_add_offdiag}
     \lean{ProjectionGeometry.crossTerm_sum_bound_of_ordered_rowSum}
-    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum}
-    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds}
-    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_ordered_local_term_bounds}
     \leanok
-    \uses{lem:parent_hamiltonian_es_quadratic_reduction}
+    The projection-geometry reduction uses the following elementary Hilbert-space
+    identities: the diagonal identity
+    $\operatorname{Re}\langle Pv,Pv\rangle=\operatorname{Re}\langle Pv,v\rangle$
+    for symmetric projections; nonnegativity of this quadratic form; finite-sum
+    expansions of $\operatorname{Re}\langle (\sum_i P_i)v,v\rangle$ and
+    $\operatorname{Re}\langle (\sum_i P_i)v,(\sum_i P_i)v\rangle$; the
+    diagonal/off-diagonal split of the ordered double sum; and the aggregate
+    off-diagonal estimate obtained from row sums $\sum_{j\ne i}c_{ij}\le1$.
+\end{remark}
+
+\begin{lemma}[Ordered projection row-sum quadratic-form reduction]
+    \label{lem:ordered_projection_rowsum_reduction}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum}
+    \leanok
+    \uses{rem:projection_geometry_rowsum_identities}
     Let $P_i$ be a finite family of symmetric projections and let
     $H=\sum_i P_i$. If the ordered off-diagonal forms obey
     \[
@@ -1617,11 +1626,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         \qquad (i\ne j),
     \]
     with row sums $\sum_{j\ne i} c_{ij}\le 1$ and $\gamma\le 1$, then
-    $H^2\ge \gamma H$ as a quadratic form.  Applied to the transported parent
-    Hamiltonian local terms, this supplies the hypothesis of
-    Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction}; the remaining
-    model-specific work is to prove the local projection property and the
-    Friedrichs-angle constants for those local terms.
+    $H^2\ge \gamma H$ as a quadratic form.
 \end{lemma}
 
 \begin{proof}
@@ -1629,8 +1634,66 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Expand $\operatorname{Re}\langle H v,Hv\rangle$ as an ordered double sum.
     Symmetric idempotence identifies each diagonal term with
     $\operatorname{Re}\langle P_i v,v\rangle$, while the row-summable ordered
-    anti-commutator bounds control the off-diagonal contribution by
+    cross-term bounds control the off-diagonal contribution by
     $-(1-\gamma)\sum_i\operatorname{Re}\langle P_i v,v\rangle$.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian ordered row-sum quadratic-form reduction]
+    \label{lem:parent_hamiltonian_ordered_rowsum_quadratic}
+    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds}
+    \leanok
+    \uses{lem:ordered_projection_rowsum_reduction, def:parent_hamiltonian_es,
+        rem:euclidean_local_projector_ingredients}
+    For a fixed chain length $N$, suppose the transported local terms
+    $h_{i,\mathrm{ES}}$ are symmetric projections and satisfy the ordered row-sum
+    estimate
+    \[
+        \operatorname{Re}\langle h_{i,\mathrm{ES}} v,h_{j,\mathrm{ES}}v\rangle
+        \ge -(1-\gamma)c_{ij}\operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle
+        \qquad (i\ne j),
+    \]
+    with $\sum_{j\ne i}c_{ij}\le1$ and $\gamma\le1$. Then the transported
+    parent Hamiltonian satisfies
+    \[
+        \gamma\operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}v,v\rangle
+        \le
+        \operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}v,
+            H_{N,L}^{\mathrm{ES}}v\rangle
+    \]
+    for every vector $v$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply Lemma~\ref{lem:ordered_projection_rowsum_reduction} to the family
+    $P_i=h_{i,\mathrm{ES}}$ and use
+    $H_{N,L}^{\mathrm{ES}}=\sum_i h_{i,\mathrm{ES}}$.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian gap from ordered local row bounds]
+    \label{lem:parent_hamiltonian_ordered_rowsum_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_ordered_local_term_bounds}
+    \leanok
+    \uses{lem:parent_hamiltonian_ordered_rowsum_quadratic,
+        lem:parent_hamiltonian_es_quadratic_reduction}
+    Assume uniformly for every $N\ge2L$ that the transported local terms are
+    symmetric projections and satisfy the ordered row-sum estimate above with
+    $\gamma=1/(4L)$. If $L>1$, then $1/(4L)>0$ and, for every
+    $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
+    \[
+        \frac{1}{4L}\|v\|\le
+        \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The fixed-chain row-sum reduction supplies the quadratic-form estimate with
+    $\gamma=1/(4L)$ for every admissible $N$.  The positivity and kernel
+    identification of the transported Hamiltonian then allow
+    Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} to convert this
+    quadratic-form estimate into the norm lower bound on the orthogonal
+    complement of the ground space.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
@@ -1798,7 +1861,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         lem:euclidean_local_projector_positive,
         lem:local_term_es_average,
         lem:parent_hamiltonian_es_quadratic_reduction,
-        lem:ordered_projection_rowsum_reduction}
+        lem:parent_hamiltonian_ordered_rowsum_gap}
     For an injective tensor $A$ and a range $L > 1$, the theorem asserts
     the analytic estimate with the explicit constant
     \[
@@ -1817,8 +1880,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Lemmas~\ref{lem:local_term_es_average} and~\ref{lem:transported_es_positive}.
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} reduces the present
     theorem to the remaining MPS-specific task: deriving the uniform
-    quadratic-form estimate.  Lemma~\ref{lem:ordered_projection_rowsum_reduction}
-    formalizes the finite-sum algebra from ordered anti-commutator row bounds;
+    quadratic-form estimate.  Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}
+    establishes the finite-sum algebra from ordered cross-term row bounds;
     the remaining MPS-specific tasks are to prove the local symmetric-projection
     statement for the transported local terms and to obtain the Friedrichs-angle
     constants with the required finite-overlap row sums.


### PR DESCRIPTION
## Summary

Refs #460.

This PR adds a reusable projection-geometry layer for the remaining parent-Hamiltonian spectral-gap analytic step after PR #916.

Lean additions:
- `TNLean.Analysis.ProjectionGeometry`
  - quadratic-form monotonicity for the Loewner order;
  - real quadratic-form identity for symmetric-operator anti-commutators;
  - diagonal/off-diagonal finite-sum expansion lemmas;
  - `crossTerm_sum_bound_of_ordered_rowSum`;
  - `quadraticForm_sum_projections_of_ordered_rowSum`, turning ordered row-summable anti-commutator bounds for symmetric projections into `H² ≥ γ H`.
- Parent-Hamiltonian instantiations in `Martingale.lean`:
  - `MPSTensor.parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds`;
  - `MPSTensor.parentHamiltonianES_gap_bound_of_ordered_local_term_bounds`.

Blueprint Chapter 14 is synced with a new ordered projection row-sum reduction lemma.

## What remains

This does **not** claim the full Friedrichs-angle estimate. The surviving `parentHamiltonianES_gap_bound_of_friedrichs` sorry still needs the MPS-specific local symmetric-projection theorem for `localTermES` and the actual Friedrichs-angle / finite-overlap constants that satisfy the row-sum hypotheses.

## Validation

- `lake build TNLean.Analysis.ProjectionGeometry`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale`
- `lake build TNLean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- touched-file proof-integrity grep: only the pre-existing `parentHamiltonianES_gap_bound_of_friedrichs` sorry remains in `Martingale.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean lemmas and reuses them to factor existing martingale-gap reductions, without changing any existing computational behavior; main risk is proof/compatibility breakage in downstream formalization due to new dependencies/imports.
> 
> **Overview**
> Adds a new `TNLean.Analysis.ProjectionGeometry` module that packages finite-dimensional Hilbert-space identities for symmetric projections and a reusable lemma turning **ordered row-summable cross-term bounds** into the quadratic-form inequality `H² ≥ γ H` for `H = ∑ i, P i`.
> 
> Updates `ParentHamiltonian/Martingale.lean` to instantiate this abstraction for transported local terms, adding `parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds` and a uniform gap-bound reduction `parentHamiltonianES_gap_bound_of_ordered_local_term_bounds` (bridging ordered local bounds to the existing quadratic-form-to-gap pipeline).
> 
> Exposes the new analysis module via `TNLean.lean` and synchronizes Blueprint Ch.14 with the new projection row-sum reduction lemmas and updated dependency chain for the Friedrichs-angle gap bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 428519ef751d21d6620b538ff74d29fec0cc8d6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->