### PR TITLE
feat(MPS/CanonicalForm): derive BNT LI for separated sectors

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -114,7 +114,7 @@ def toHasNormalizedSelfOverlap (hCF : IsCanonicalFormBNT μ A) :
     HasNormalizedSelfOverlap (d := d) A :=
   hCF.toIsCanonicalForm.toHasNormalizedSelfOverlap
 
-/-- Rebuild `IsCanonicalFormBNT` from the additive split API plus the BNT separation axiom. -/
+/-- Rebuild `IsCanonicalFormBNT` from the additive split API plus the BNT separation assumption. -/
 def ofSeparatedData
     (hInj : HasInjectiveBlocks (d := d) A)
     (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
@@ -129,7 +129,7 @@ def ofSeparatedData
 end IsCanonicalFormBNT
 
 /-- An `IsCanonicalForm` family with pairwise distinct block dimensions and strictly
-decreasing moduli automatically satisfies `IsCanonicalFormBNT`, since the separation axiom
+decreasing moduli automatically satisfies `IsCanonicalFormBNT`, since the separation assumption
 is vacuous. -/
 theorem IsCanonicalForm.toIsCanonicalFormBNT_of_distinct_dims
     {r : ℕ} {dim : Fin r → ℕ}
@@ -153,7 +153,7 @@ and that the block weight moduli are **strictly decreasing**.
 
 Here `IsNormalCanonicalForm` encodes the spectral / primitive-transfer-map version of
 normality with non-increasing moduli. The BNT level adds strict ordering (justified by the
-grouping step) and the BNT separation axiom.
+grouping step) and the BNT separation assumption.
 
 The later `IsBNT` predicate instead asks for blockwise `IsNormal`, i.e. the
 equivalent algebraic eventual-block-injectivity notion, so the primitive-to-normal bridge must be
@@ -201,7 +201,7 @@ def toHasNormalizedSelfOverlap [∀ k, NeZero (dim k)]
   hNCF.toIsNormalCanonicalForm.toHasNormalizedSelfOverlap
 
 /-- Rebuild `IsNormalCanonicalFormBNT` from the additive split API plus the BNT separation
-axiom. -/
+assumption. -/
 def ofSeparatedData
     (hIrr : HasIrreducibleBlocks (d := d) A)
     (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
@@ -229,8 +229,13 @@ private theorem spans_mpv_toTensorFromBlocks
   intro σ
   simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ A σ
 
-/-- Overlaps converging to the Kronecker delta give eventual linear independence of block MPVs. -/
-private theorem eventually_li_of_overlap_limits
+/-- **Existential BNT linear independence from asymptotic orthonormal overlaps.**
+
+If the self-overlaps of a finite block family tend to `1` and the cross-overlaps
+of distinct blocks tend to `0`, then the MPV states are linearly independent for
+every sufficiently large system size.  This is the threshold form of
+`bntFamilies_eventually_linearIndependent`. -/
+theorem exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hSelf : ∀ j,
@@ -253,7 +258,7 @@ variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
 /-- Split-data version of CF-BNT cross-overlap decay.
 
-Only injectivity, left-canonical normalization, and the BNT non-equivalence axiom are used. -/
+Only injectivity, left-canonical normalization, and the BNT non-equivalence assumption are used. -/
 theorem cross_overlap_tendsto_zero_of_separated_CFBNT_data
     [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -292,7 +297,7 @@ theorem isBNT_of_separated_CFBNT_data [∀ k, NeZero (dim k)]
   normal := fun j => (hInj.block_injective j).isNormal
   spans_mpv := spans_mpv_toTensorFromBlocks μ A
   eventually_li :=
-    eventually_li_of_overlap_limits A
+    exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal A
       hOverlap.overlap_tendsto_one
       (fun i j hij =>
         cross_overlap_tendsto_zero_of_separated_CFBNT_data A hInj hLeft hBlocks i j hij)
@@ -346,7 +351,8 @@ variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
 /-- Split-data version of normal-CF-BNT cross-overlap decay.
 
-Only irreducibility, left-canonical normalization, and the BNT non-equivalence axiom are used. -/
+Only irreducibility, left-canonical normalization, and the BNT non-equivalence
+assumption are used. -/
 theorem cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
     [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -385,7 +391,7 @@ theorem spans_mpv_and_eventually_li_of_separated_normalCFBNT_data [∀ k, NeZero
   constructor
   · exact spans_mpv_toTensorFromBlocks μ A
   · exact
-      eventually_li_of_overlap_limits A
+      exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal A
         (fun j => hNCF.overlap_tendsto_one j)
         (fun i j hij =>
           cross_overlap_tendsto_zero_of_separated_normalCFBNT_data A

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -37,7 +37,7 @@ Def. 4.2 / Prop. char-BNT in arXiv:2011.12127 and arXiv:1606.00608, lines 1145�
 4. **`fundamentalTheorem_of_separated_CFBNT_data`** and the legacy wrapper
    **`fundamentalTheorem_of_IsCanonicalFormBNT`**: if two CF-BNT decompositions generate
    proportional MPVs with convergent nonzero coefficients, then the blocks match up to
-   permutation, dimension equality, and gauge-phase equivalence. This is a bridge from
+   permutation, dimension equality, and gauge-phase equivalence. This connects
    canonical/BNT split data to the hypotheses of `BNT/PermutationRigidity`.
 
 ## Design note on coefficients
@@ -156,8 +156,8 @@ normality with non-increasing moduli. The BNT level adds strict ordering (justif
 grouping step) and the BNT separation assumption.
 
 The later `IsBNT` predicate instead asks for blockwise `IsNormal`, i.e. the
-equivalent algebraic eventual-block-injectivity notion, so the primitive-to-normal bridge must be
-supplied explicitly when passing from this predicate to `IsBNT`. -/
+equivalent algebraic eventual-block-injectivity notion, so the primitive-to-normal
+implication must be supplied explicitly when passing from this predicate to `IsBNT`. -/
 structure IsNormalCanonicalFormBNT {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) : Prop extends
     IsNormalCanonicalForm μ A where
@@ -404,7 +404,7 @@ theorem spans_mpv_and_eventually_li_of_separated_normalCFBNT_data [∀ k, NeZero
 Here `hNCF` supplies normality via the primitive-transfer-map characterization packaged by
 `IsNormalCanonicalForm`, while `hNormal` supplies the equivalent algebraic `IsNormal` predicate
 (eventual block injectivity) required by `IsBNT`. In applications `hNormal` comes from the
-Wielandt / primitive-to-normal bridge. -/
+Wielandt / primitive-to-normal implication. -/
 theorem isBNT_of_separated_normalCFBNT_data [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -448,9 +448,9 @@ theorem isBNT [∀ k, NeZero (dim k)]
 
 end IsNormalCanonicalFormBNT
 
-/-! ### Bridge to BNT/PermutationRigidity -/
+/-! ### Connection with BNT/PermutationRigidity -/
 
-/-- Common proportional-decomposition hypotheses used by the BNT bridge theorems. -/
+/-- Common proportional-decomposition hypotheses used by the BNT comparison theorems. -/
 structure ProportionalDecompositionData
     {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -478,7 +478,7 @@ structure ProportionalDecompositionData
   hc : Tendsto c atTop (nhds cLim)
   hcLim_ne : cLim ≠ 0
 
-/-- Conclusion shared by the BNT proportional-MPV bridge theorems. -/
+/-- Conclusion shared by the BNT proportional-MPV comparison theorems. -/
 abbrev ProportionalDecompositionConclusion
     {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -492,7 +492,7 @@ abbrev ProportionalDecompositionConclusion
             (cast (congr_arg (MPSTensor d) hdim) (A j))
             (B (perm j))
 
-/-- Split-data bridge theorem for CF-BNT-style decompositions (Thm 4.4).
+/-- Split-data comparison theorem for CF-BNT-style decompositions (Thm 4.4).
 
 The theorem only needs the separated pieces of data used by the proportional-MPV argument:
 blockwise injectivity, left-canonical normalization, self-overlap normalization, and the BNT
@@ -535,7 +535,7 @@ theorem fundamentalTheorem_of_separated_CFBNT_data
     (_haLim_ne := hDecomp.haLim_ne) (_hbLim_ne := hDecomp.hbLim_ne)
     (hProp := hDecomp.hProp) (hc := hDecomp.hc) (_hcLim_ne := hDecomp.hcLim_ne)
 
-/-- **Fundamental theorem bridge for CF-BNT decompositions (Thm 4.4).**
+/-- **Fundamental theorem comparison for CF-BNT decompositions (Thm 4.4).**
 
 If two families of tensors in canonical-form BNT give rise to proportional MPVs
 (with convergent nonzero coefficients), then the families have the same number
@@ -582,7 +582,7 @@ theorem fundamentalTheorem_of_IsCanonicalFormBNT
     ⟨A_total, B_total, aCoeff, bCoeff, aLim, bLim, c, cLim,
       hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
-/-- Split-data bridge theorem for normal-CF-BNT-style decompositions (NT Thm 4.4). -/
+/-- Split-data comparison theorem for normal-CF-BNT-style decompositions (NT Thm 4.4). -/
 theorem fundamentalTheorem_of_separated_normalCFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -624,7 +624,7 @@ theorem fundamentalTheorem_of_separated_normalCFBNT_data
     (_haLim_ne := hDecomp.haLim_ne) (_hbLim_ne := hDecomp.hbLim_ne)
     (hProp := hDecomp.hProp) (hc := hDecomp.hc) (_hcLim_ne := hDecomp.hcLim_ne)
 
-/-- Fundamental theorem bridge for normal-CF-BNT decompositions (NT Thm 4.4). -/
+/-- Fundamental theorem comparison for normal-CF-BNT decompositions (NT Thm 4.4). -/
 theorem fundamentalTheorem_of_IsNormalCanonicalFormBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.BNTGrouping
+import TNLean.MPS.BNT.Construction
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.MPS.Overlap.CastLemmas
@@ -69,10 +70,23 @@ Theorem matching, etc.).
   the reduction output to a BNT-grouped `SectorDecomposition`.  **Fully proved.**
   Requires a `hNonDecay` hypothesis for equal-norm blocks.
 
+* `exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal` —
+  turns asymptotic orthonormality of MPV overlaps into the existential eventual
+  linear-independence form used by `HasBNTSectorData`.
+
+* `exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv` —
+  derives that eventual linear independence from TP / primitive / irreducible
+  blocks once the family is already separated by non-gauge-phase-equivalence.
+
 * `exists_bnt_sectorDecomp_of_linearIndependent` — conditional construction
   toward the post-#886 `HasBNTSectorData` predicate.  It forms the granular
   `trivialSectorDecomp` as a BNT sector decomposition when the actual BNT
   linear-independence condition is supplied explicitly.
+
+* `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv` —
+  the separated-family constructor: it retains all separated basis blocks,
+  including equal-modulus ones, and proves `HasBNTSectorData` from overlap
+  asymptotics rather than from an explicit linear-independence hypothesis.
 
 * `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent` —
   signature-compatible reformulation retaining the TP / primitive / irreducible
@@ -375,7 +389,86 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
       exact ⟨ζ, hζne, hζ_norm, hmpv⟩
   exact bnt_grouping_single_norm_class μ blocks k0 hμne hNorm hPhase
 
-/-! ### §4. Conditional sector construction under BNT linear independence -/
+/-! ### §4. Eventual independence from separated overlap data -/
+
+/-- **Existential BNT linear independence from asymptotic orthonormal overlaps.**
+
+This is the existential form of `bntFamilies_eventually_linearIndependent` used by
+`HasBNTSectorData`: if the self-overlaps tend to `1` and all cross-overlaps tend
+to `0`, then the MPV states are linearly independent for every sufficiently large
+system size. -/
+theorem exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal
+    {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hSelf : ∀ k,
+      Tendsto (fun N => mpvOverlap (d := d) (blocks k) (blocks k) N) atTop
+        (nhds (1 : ℂ)))
+    (hCross : ∀ j k : Fin r, j ≠ k →
+      Tendsto (fun N => mpvOverlap (d := d) (blocks j) (blocks k) N) atTop
+        (nhds (0 : ℂ))) :
+    ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun k : Fin r => mpvState (d := d) (blocks k) N) := by
+  have hLI := bntFamilies_eventually_linearIndependent blocks hSelf hCross
+  rw [Filter.Eventually] at hLI
+  obtain ⟨N0, hN0⟩ := Filter.mem_atTop_sets.mp hLI
+  exact ⟨N0, fun N hN => hN0 N (le_of_lt hN)⟩
+
+/-- **Eventual BNT linear independence for an already separated normal family.**
+
+For TP primitive irreducible blocks that are pairwise not gauge-phase equivalent,
+self-overlaps tend to `1` and cross-overlaps tend to `0`.  Hence their MPV states
+are eventually linearly independent.  This is the linear-independence bridge that
+remains after a future one-sided BNT construction has chosen separated
+representatives and absorbed all repeated gauge phases into sector weights. -/
+theorem exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) blocks) :
+    ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun k : Fin r => mpvState (d := d) (blocks k) N) := by
+  apply exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal blocks
+  · intro k
+    exact overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      (blocks k) (hIrr k) (hTP k) (hPrim k)
+  · intro j k hjk
+    exact cross_overlap_tendsto_zero_of_separated_normalCFBNT_data blocks
+      (HasIrreducibleBlocks.ofForall hIrr)
+      (IsLeftCanonicalBlockFamily.ofForall hTP)
+      hBlocks j k hjk
+
+/-- **Separated-family BNT sector construction.**
+
+If the TP primitive irreducible input blocks are already pairwise separated by
+non-gauge-phase-equivalence, the granular sector decomposition is a genuine BNT
+sector decomposition: it represents the original weighted block sum and satisfies
+`HasBNTSectorData` by the overlap-derived eventual linear independence above.
+
+This theorem does not collapse gauge-phase-equivalent input blocks.  Instead it
+identifies the exact remaining task for the full one-sided construction: first
+choose separated representatives and absorb the corresponding phases into sector
+weights, then apply this constructor. -/
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) blocks) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P := by
+  refine ⟨trivialSectorDecomp μ blocks hμne,
+    sameMPV₂_trivialSectorDecomp μ blocks hμne, ?_⟩
+  simpa [trivialSectorDecomp] using
+    exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
+      blocks hTP hIrr hPrim hBlocks
+
+/-! ### §5. Conditional sector construction under BNT linear independence -/
 
 /-- **Minimal granular sector decomposition carrying current `HasBNTSectorData`.**
 

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -391,28 +391,6 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
 
 /-! ### §4. Eventual independence from separated overlap data -/
 
-/-- **Existential BNT linear independence from asymptotic orthonormal overlaps.**
-
-This is the existential form of `bntFamilies_eventually_linearIndependent` used by
-`HasBNTSectorData`: if the self-overlaps tend to `1` and all cross-overlaps tend
-to `0`, then the MPV states are linearly independent for every sufficiently large
-system size. -/
-theorem exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal
-    {r : ℕ} {dim : Fin r → ℕ}
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (hSelf : ∀ k,
-      Tendsto (fun N => mpvOverlap (d := d) (blocks k) (blocks k) N) atTop
-        (nhds (1 : ℂ)))
-    (hCross : ∀ j k : Fin r, j ≠ k →
-      Tendsto (fun N => mpvOverlap (d := d) (blocks j) (blocks k) N) atTop
-        (nhds (0 : ℂ))) :
-    ∃ N0 : ℕ, ∀ N > N0,
-      LinearIndependent ℂ (fun k : Fin r => mpvState (d := d) (blocks k) N) := by
-  have hLI := bntFamilies_eventually_linearIndependent blocks hSelf hCross
-  rw [Filter.Eventually] at hLI
-  obtain ⟨N0, hN0⟩ := Filter.mem_atTop_sets.mp hLI
-  exact ⟨N0, fun N hN => hN0 N (le_of_lt hN)⟩
-
 /-- **Eventual BNT linear independence for an already separated normal family.**
 
 For TP primitive irreducible blocks that are pairwise not gauge-phase equivalent,

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -417,9 +417,9 @@ theorem exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal
 
 For TP primitive irreducible blocks that are pairwise not gauge-phase equivalent,
 self-overlaps tend to `1` and cross-overlaps tend to `0`.  Hence their MPV states
-are eventually linearly independent.  This is the linear-independence bridge that
-remains after a future one-sided BNT construction has chosen separated
-representatives and absorbed all repeated gauge phases into sector weights. -/
+are eventually linearly independent.  This supplies the missing linear-independence
+step after a future one-sided BNT construction has chosen separated representatives
+and absorbed all repeated gauge phases into sector weights. -/
 theorem exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (blocks : (k : Fin r) → MPSTensor d (dim k))

--- a/audits/2026-04-25_issue876_bnt_sector_blocker.md
+++ b/audits/2026-04-25_issue876_bnt_sector_blocker.md
@@ -69,3 +69,24 @@ from the blocked TP-primitive output.  Informally, it must:
 Until that theorem exists, #860 and #877 should continue to treat the one-sided
 BNT sector pair as a hypothesis, as in
 `fundamentalTheorem_after_blocking_1606_sector_of_bntPair_matched`.
+
+## Wave 14 slot D update
+
+The branch `wave14-D-876-bnt-basis` removes one real sub-blocker without
+claiming the full construction.  It adds a separated-family bridge:
+
+- `MPSTensor.exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal`
+  rewrites the existing overlap-orthonormality criterion into the existential
+  threshold form used by `HasBNTSectorData`.
+- `MPSTensor.exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv`
+  derives that threshold from TP / primitive / irreducible blocks once the
+  chosen family is already pairwise non-gauge-phase-equivalent.
+- `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv`
+  applies the granular sector construction to such a separated family and proves
+  the current `HasBNTSectorData` predicate without an explicit LI hypothesis.
+
+This retains distinct basis tensors even at equal coefficient modulus.  The
+remaining #876 theorem is now more precise: construct the separated family from
+arbitrary TP-primitive-irreducible blocks by identifying gauge-phase-equivalent
+normal tensors, absorbing the associated phases into sector weights, and proving
+that the constructed representatives satisfy `BlocksNotGaugePhaseEquiv`.

--- a/audits/2026-04-25_issue876_bnt_sector_blocker.md
+++ b/audits/2026-04-25_issue876_bnt_sector_blocker.md
@@ -73,7 +73,7 @@ BNT sector pair as a hypothesis, as in
 ## Wave 14 slot D update
 
 The branch `wave14-D-876-bnt-basis` removes one real sub-blocker without
-claiming the full construction.  It adds a separated-family bridge:
+claiming the full construction.  It adds a separated-family result:
 
 - `MPSTensor.exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal`
   rewrites the existing overlap-orthonormality criterion into the existential

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2186,13 +2186,13 @@ The following results separate the zero blocks from the
 	\lean{MPSTensor.exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv}
 	\leanok
 	\uses{thm:bnt_li_from_overlap_limits_exists, def:gauge_phase_equiv}
-	For trace-preserving primitive irreducible blocks that are pairwise not
-	gauge-phase equivalent, the block MPV states are linearly independent for all
-	sufficiently large system sizes.
+	For trace-preserving primitive irreducible blocks of positive bond dimension
+	that are pairwise not gauge-phase equivalent, the block MPV states are
+	linearly independent for all sufficiently large system sizes.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:bnt_li_from_overlap_limits_exists, thm:gauge_equiv_nondecay}
+	\uses{thm:bnt_li_from_overlap_limits_exists}
 	Primitivity and trace preservation give self-overlap convergence to $1$.
 	BNT separation gives cross-overlap convergence to $0$ for distinct blocks.
 	The result follows from
@@ -2223,8 +2223,9 @@ The following results separate the zero blocks from the
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv}
 	\leanok
 	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv, thm:bnt_li_tp_prim_irr_separated}
-	For trace-preserving primitive irreducible blocks with nonzero weights, if
-	distinct blocks are pairwise not gauge-phase equivalent, then the granular
+	For trace-preserving primitive irreducible blocks of positive bond dimension
+	with nonzero weights, if distinct blocks are pairwise not gauge-phase
+	equivalent, then the granular
 	sector decomposition represents the same MPS family and satisfies the BNT
 	linear-independence condition.  Equal-modulus separated blocks remain as
 	distinct basis blocks.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2165,6 +2165,40 @@ The following results separate the zero blocks from the
 	sector decomposition with strict norm ordering.
 \end{theorem}
 
+\begin{theorem}[Existential BNT independence from overlap limits]
+	\label{thm:bnt_li_from_overlap_limits_exists}
+	\lean{MPSTensor.exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal}
+	\leanok
+	\uses{thm:bnt_overlap_orthonormal_li}
+	If the self-overlaps of a finite block family tend to $1$ and the
+	cross-overlaps of distinct blocks tend to $0$, then the MPV states are
+	linearly independent for all sufficiently large system sizes.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:bnt_overlap_orthonormal_li}
+	This is Theorem~\ref{thm:bnt_overlap_orthonormal_li}, rewritten from the
+	filter-eventual form into an explicit threshold $N_0$.
+\end{proof}
+
+\begin{theorem}[BNT independence for separated primitive normal blocks]
+	\label{thm:bnt_li_tp_prim_irr_separated}
+	\lean{MPSTensor.exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv}
+	\leanok
+	\uses{thm:bnt_li_from_overlap_limits_exists, def:gauge_phase_equiv}
+	For trace-preserving primitive irreducible blocks that are pairwise not
+	gauge-phase equivalent, the block MPV states are linearly independent for all
+	sufficiently large system sizes.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:bnt_li_from_overlap_limits_exists, thm:gauge_equiv_nondecay}
+	Primitivity and trace preservation give self-overlap convergence to $1$.
+	BNT separation gives cross-overlap convergence to $0$ for distinct blocks.
+	The result follows from
+	Theorem~\ref{thm:bnt_li_from_overlap_limits_exists}.
+\end{proof}
+
 \begin{theorem}[Granular sector decomposition from eventual BNT independence]
 	\label{thm:bnt_sector_decomp_linear_independent}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_linearIndependent}
@@ -2182,6 +2216,26 @@ The following results separate the zero blocks from the
 	Lemma~\ref{lem:trivial_sector_decomp_same_mpv}.  The assumed eventual linear
 	independence is exactly the BNT condition for the basis blocks of the granular
 	sector decomposition.
+\end{proof}
+
+\begin{theorem}[Separated primitive normal sector construction]
+	\label{thm:bnt_sector_decomp_tp_prim_irr_separated}
+	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv}
+	\leanok
+	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv, thm:bnt_li_tp_prim_irr_separated}
+	For trace-preserving primitive irreducible blocks with nonzero weights, if
+	distinct blocks are pairwise not gauge-phase equivalent, then the granular
+	sector decomposition represents the same MPS family and satisfies the BNT
+	linear-independence condition.  Equal-modulus separated blocks remain as
+	distinct basis blocks.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{lem:trivial_sector_decomp_same_mpv, thm:bnt_li_tp_prim_irr_separated}
+	The granular sector decomposition preserves the represented family by
+	Lemma~\ref{lem:trivial_sector_decomp_same_mpv}.  The separated primitive
+	normal hypotheses give the eventual linear independence by
+	Theorem~\ref{thm:bnt_li_tp_prim_irr_separated}.
 \end{proof}
 
 \begin{theorem}[TP primitive irreducible version with eventual BNT independence]

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2177,8 +2177,8 @@ The following results separate the zero blocks from the
 
 \begin{proof}\leanok
 	\uses{thm:bnt_overlap_orthonormal_li}
-	This is Theorem~\ref{thm:bnt_overlap_orthonormal_li}, rewritten from the
-	filter-eventual form into an explicit threshold $N_0$.
+	This is Theorem~\ref{thm:bnt_overlap_orthonormal_li}, restated with an
+	explicit threshold $N_0$.
 \end{proof}
 
 \begin{theorem}[BNT independence for separated primitive normal blocks]

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -564,10 +564,12 @@ single weighted block.
 	not merely a final gauge-construction step.  Two paper-level ingredients
 	remain to be formalized:
 	\begin{enumerate}
-		\item a general basis-of-normal-tensors construction for the
-		      after-blocking output, beyond the current special case where
-		      equal-modulus blocks on one side are already known to collapse
-		      to a single basis tensor; and
+		\item a one-sided basis-of-normal-tensors construction for the
+		      after-blocking output that chooses representatives of
+		      gauge-phase-equivalent normal tensors and proves the resulting
+		      separated family has the required sector weights; the separated
+		      primitive-normal case already gives BNT linear independence by
+		      Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_separated}; and
 		\item a witness-producing matched-basis theorem for heterogeneous
 		      sector decompositions: the algebraic reduction after a basis
 		      matching is formalized in


### PR DESCRIPTION
Refs #876. Parent: #652.

## Summary

- Add an existential BNT linear-independence bridge from asymptotically orthonormal MPV overlaps.
- Derive eventual linear independence for TP primitive irreducible block families that are already pairwise non-gauge-phase-equivalent.
- Add a separated-family sector construction producing `SectorDecomposition` plus current `HasBNTSectorData` without taking an explicit LI hypothesis.
- Update the #876 audit and blueprint to record the sharper remaining step: construct the separated representative family by identifying gauge-phase-equivalent normal tensors and absorbing phases into sector weights.

## Scope

This does **not** close #876.  It removes the LI sub-blocker once BNT-separated representatives are available, but the full one-sided BNT construction still needs the finite representative/collapse step from arbitrary TP primitive irreducible blocks.

## Validation

- `lake build TNLean.MPS.CanonicalForm.BNTGrouping TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem TNLean.MPS.FundamentalTheorem.SectorDecomposition`
- `cd blueprint && leanblueprint checkdecls`
- `rg -n "\\b(sorry|admit|axiom|native_decide|unsafe)\\b" TNLean/MPS/CanonicalForm/EqualNormBridge.lean audits/2026-04-25_issue876_bnt_sector_blocker.md blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch11_assembly.tex || true`
- `git diff --check`

Only pre-existing warnings replayed from `Assembly/CyclicSectorDecomposition.lean` during the target build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate proof/API impact: introduces new public theorems and rewires existing `IsBNT` construction lemmas to use an existential-threshold linear-independence form, which may affect downstream imports and proof scripts but does not change computational behavior.
> 
> **Overview**
> Adds a new bridge theorem `exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal` (in `MPS/BNT/Construction`) that converts asymptotic overlap orthonormality into the explicit-threshold form `∃ N0, ∀ N > N0, LinearIndependent ...`, and updates the CF-BNT/normal-CF-BNT `IsBNT` constructors to use it.
> 
> Builds on that to add results in `CanonicalForm/EqualNormBridge` that (1) derive eventual linear independence for TP/primitive/irreducible block families assuming *BNT separation* (`BlocksNotGaugePhaseEquiv`), and (2) construct a separated-family `SectorDecomposition` proving `HasBNTSectorData` from overlap asymptotics (without requiring an explicit LI hypothesis).
> 
> Updates the #876 audit note and blueprint text to document the new separated-family path and clarify the remaining missing step: producing separated representatives by collapsing gauge-phase-equivalent normal tensors and absorbing phases into sector weights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9485fb1d03c79a8b46a99f22e3252082f56d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->