### PR TITLE
feat(MPS/ParentHamiltonian): add Route B commutant reduction (#911)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -201,6 +201,7 @@ import TNLean.MPS.Symmetry.StringOrder
 
 -- Layer 5: Multi-block
 import TNLean.MPS.Core.MultiBlock
+import TNLean.MPS.CanonicalForm.BlockDiagonalCommutant
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.BasisNormal

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -10,9 +10,10 @@ import TNLean.MPS.SharedInfra.BlockAssembly
 /-!
 # Block-diagonal commutants from sector projections
 
-This file isolates the algebraic part of the Route B parent-Hamiltonian block
-argument.  If the sector projections of a dependent direct sum lie in the span
-of a family of matrices and a boundary matrix commutes with that family, then it
+This file isolates the algebraic part of the block-diagonal commutant argument
+for the parent-Hamiltonian block decomposition. If the sector projections of a
+dependent direct sum lie in the span of a family of matrices and a boundary
+matrix commutes with that family, then it
 commutes with the projections and hence has no off-block entries.
 
 The remaining CF/BNT-specific step is to prove that the sector projections lie

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -2,6 +2,8 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+-- Provides `Matrix.blockProjection`, `Matrix.IsBlockDiagonal'`, and the
+-- projection-commutant criterion used below.
 import TNLean.Algebra.ScalarCommutant
 import TNLean.MPS.SharedInfra.BlockAssembly
 

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.ScalarCommutant
+import TNLean.MPS.SharedInfra.BlockAssembly
+
+/-!
+# Block-diagonal commutants from sector projections
+
+This file isolates the algebraic part of the Route B parent-Hamiltonian block
+argument.  If the sector projections of a dependent direct sum lie in the span
+of a family of matrices and a boundary matrix commutes with that family, then it
+commutes with the projections and hence has no off-block entries.
+
+The remaining CF/BNT-specific step is to prove that the sector projections lie
+in the finite word span of the assembled tensor.  Once that finite-span input is
+available, `MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan` turns
+long-word commutation of the assembled boundary matrix into block diagonality.
+-/
+
+open scoped Matrix BigOperators
+
+namespace Matrix
+
+variable {ι α : Type*} {n : ι → Type*}
+variable [Fintype ι] [DecidableEq ι]
+variable [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+
+/-- If every block projection lies in the span of a matrix family `S`, then any
+matrix commuting with all members of `S` is block diagonal.
+
+This records the common linearity step used in commutant arguments: commutation
+extends from generators to their span, giving commutation with each projection;
+`Matrix.isBlockDiagonal'_of_commutes_blockProjection` then kills all off-block
+entries. -/
+theorem isBlockDiagonal'_of_commutes_span_blockProjection
+    {S : α → Matrix ((i : ι) × n i) ((i : ι) × n i) ℂ}
+    {X : Matrix ((i : ι) × n i) ((i : ι) × n i) ℂ}
+    (hProj : ∀ k : ι,
+      blockProjection (n := n) (R := ℂ) k ∈ Submodule.span ℂ (Set.range S))
+    (hComm : ∀ a : α, X * S a = S a * X) :
+    IsBlockDiagonal' X := by
+  classical
+  apply isBlockDiagonal'_of_commutes_blockProjection (n := n) (R := ℂ)
+  intro k
+  have hcomm_span : ∀ M ∈ Submodule.span ℂ (Set.range S), X * M = M * X := by
+    intro M hM
+    induction hM using Submodule.span_induction with
+    | mem M hM =>
+        rcases hM with ⟨a, rfl⟩
+        exact hComm a
+    | zero => simp
+    | add M N _ _ hM hN => rw [mul_add, add_mul, hM, hN]
+    | smul c M _ hM =>
+        simp only [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, hM]
+  exact hcomm_span (blockProjection (n := n) (R := ℂ) k) (hProj k)
+
+end Matrix
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+
+/-- Reindexed word-span version of the block-diagonal commutant criterion.
+
+Let `B` be a tensor whose bond space is the reindexed direct sum
+`Fin (∑ k, dim k)`.  Pull all length-`m` word products and the boundary matrix
+back to the dependent `Σ`-indexed direct sum via `finSigmaFinEquiv.symm`.  If the
+block projections lie in the span of these pulled-back word products, then any
+matrix on the assembled bond space commuting with all length-`m` word products
+pulls back to a block-diagonal matrix.
+
+For `B = toTensorFromBlocks μ A`, the pulled-back word products are the matrices
+`Matrix.blockDiagonal' (fun k => (μ k)^m • evalWord (A k) (List.ofFn ω))` by
+`evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal`. -/
+theorem isBlockDiagonal'_of_commutes_reindexed_wordSpan
+    (B : MPSTensor d (∑ k : Fin r, dim k)) {m : ℕ}
+    {X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ}
+    (hProj : ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord B (List.ofFn ω))))
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord B (List.ofFn ω) = evalWord B (List.ofFn ω) * X) :
+    Matrix.IsBlockDiagonal'
+      (Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm X) := by
+  classical
+  let e : ((k : Fin r) × Fin (dim k)) ≃ Fin (∑ k : Fin r, dim k) := finSigmaFinEquiv
+  apply Matrix.isBlockDiagonal'_of_commutes_span_blockProjection
+    (n := fun k : Fin r => Fin (dim k))
+    (S := fun ω : Fin m → Fin d => Matrix.reindex e.symm e.symm (evalWord B (List.ofFn ω)))
+    hProj
+  intro ω
+  have h := congrArg (Matrix.reindex e.symm e.symm) (hComm ω)
+  simpa [e, Matrix.reindex_apply, Matrix.submatrix_mul_equiv] using h
+
+/-- Entrywise off-block-zero corollary of
+`isBlockDiagonal'_of_commutes_reindexed_wordSpan`.
+
+This is often the most convenient form when using the result inside a boundary
+matrix decomposition proof: after pulling the boundary matrix back to dependent
+block coordinates, every entry from block `i` to a distinct block `j` vanishes. -/
+theorem offBlock_zero_of_commutes_reindexed_wordSpan
+    (B : MPSTensor d (∑ k : Fin r, dim k)) {m : ℕ}
+    {X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ}
+    (hProj : ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord B (List.ofFn ω))))
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord B (List.ofFn ω) = evalWord B (List.ofFn ω) * X)
+    {i j : Fin r} (hij : i ≠ j) (a : Fin (dim i)) (b : Fin (dim j)) :
+    (Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm X) ⟨i, a⟩ ⟨j, b⟩ = 0 := by
+  have hBD := isBlockDiagonal'_of_commutes_reindexed_wordSpan (B := B) hProj hComm
+  exact (Matrix.isBlockDiagonal'_iff_offBlock_zero _).mp hBD hij a b
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
+++ b/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
@@ -129,7 +129,7 @@ This is the `≥` half of the structural decomposition
 referenced at the parent-Hamiltonian docstring (see `parentHamiltonian_gs_eq_bnt_span`).
 
 The reverse inclusion — that every periodic-chain ground state of the assembled
-tensor decomposes blockwise — is now reduced algebraically to the Route B
+tensor decomposes blockwise — is now reduced algebraically to the block-diagonal
 boundary-matrix commutant step. The lemma
 `isBlockDiagonal'_of_commutes_reindexed_wordSpan` shows that, once the virtual
 sector projections are known to lie in the finite span of assembled long-word
@@ -242,7 +242,7 @@ splitting theorem** of the form
 `parentHamiltonianGroundSpace (μ := μ) A L N ≤ ⨆ j, chainGroundSpace (A j) L N`,
 saying that a state whose cyclic windows all lie in the block-diagonal local
 ground space decomposes into a sum of block chain-ground-state components.
-The Route B commutant reduction in `BlockDiagonalCommutant` now supplies the
+The block-diagonal commutant reduction in `BlockDiagonalCommutant` now supplies the
 algebraic off-block-zero step once the virtual sector projections are known to
 lie in the finite word span of the assembled tensor. The repository still lacks
 that CF/BNT finite-span block-separation theorem and the resulting periodic-chain

--- a/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
+++ b/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 import TNLean.MPS.BNT.Construction
+import TNLean.MPS.CanonicalForm.BlockDiagonalCommutant
 import TNLean.MPS.CanonicalForm.Assembly
 import TNLean.MPS.FundamentalTheorem.Multi
 
@@ -129,13 +130,14 @@ This is the `≥` half of the structural decomposition
 referenced at the parent-Hamiltonian docstring (see `parentHamiltonian_gs_eq_bnt_span`).
 
 The reverse inclusion — that every periodic-chain ground state of the assembled
-tensor decomposes blockwise — is the structural projector argument from
-[CPGSV21] arXiv:2011.12127 §IV.C: the abelian-symmetry projectors
-`P_α = ∑ χ̄_k(g) U_g` onto the virtual-space irrep sectors commute with the
-assembled tensor and split a chain ground state into block components. That
-inclusion is not yet formalized; together with the blockwise normal-form
-uniqueness `chainGroundSpace_eq_mpvSubmodule_normal` (issue #588) it would
-discharge `parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition`. -/
+tensor decomposes blockwise — is now reduced algebraically to the Route B
+boundary-matrix commutant step. The lemma
+`isBlockDiagonal'_of_commutes_reindexed_wordSpan` shows that, once the virtual
+sector projections are known to lie in the finite span of assembled long-word
+matrices, any boundary matrix commuting with those long words has no off-block
+entries. The remaining structural input is the CF/BNT finite-span statement for
+those sector projections; after that, the blockwise injective endgame isolated
+below applies `chainGroundSpace_eq_mpvSubmodule` to reach the BNT span. -/
 theorem iSup_chainGroundSpace_block_le_toTensorFromBlocks
     (μ' : Fin r → ℂ) (hμ : ∀ j, μ' j ≠ 0)
     (A : (k : Fin r) → MPSTensor d (dim k)) (L N : ℕ) :
@@ -241,10 +243,11 @@ splitting theorem** of the form
 `parentHamiltonianGroundSpace (μ := μ) A L N ≤ ⨆ j, chainGroundSpace (A j) L N`,
 saying that a state whose cyclic windows all lie in the block-diagonal local
 ground space decomposes into a sum of block chain-ground-state components.
-This is the "projectors commute through the tensor" step from the proof sketch.
-No such periodic-chain block-splitting infrastructure is currently available in
-`MPS/ParentHamiltonian`, and the repository does not yet expose the analogous
-finite-length block-separation theorem used elsewhere in biCF-style arguments.
+The Route B commutant reduction in `BlockDiagonalCommutant` now supplies the
+algebraic off-block-zero step once the virtual sector projections are known to
+lie in the finite word span of the assembled tensor. The repository still lacks
+that CF/BNT finite-span block-separation theorem and the resulting periodic-chain
+block-splitting infrastructure.
 
 Given that block-splitting theorem, the ⊆ direction becomes:
 ```

--- a/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
+++ b/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 import TNLean.MPS.BNT.Construction
-import TNLean.MPS.CanonicalForm.BlockDiagonalCommutant
 import TNLean.MPS.CanonicalForm.Assembly
 import TNLean.MPS.FundamentalTheorem.Multi
 

--- a/audits/2026-04-25_issue911_routeB_commutant_reduction.md
+++ b/audits/2026-04-25_issue911_routeB_commutant_reduction.md
@@ -1,0 +1,96 @@
+# Issue #911 Route B commutant reduction audit (2026-04-25)
+
+Branch: `wave14-B-911-blockdiag-reverse`.
+
+## Scope
+
+This note records the status after adding the first Route B algebraic reduction for the
+reverse inclusion from issue #911 / parent issue #905. The branch was rebased onto
+`origin/main` after PR #899 landed the blockwise-injective endgame in
+`DegenerateGS.lean`.
+
+```lean
+chainGroundSpace (toTensorFromBlocks μ A) L N ≤ ⨆ j, chainGroundSpace (A j) L N
+```
+
+## New formal layer
+
+The new module `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean` proves:
+
+- `Matrix.isBlockDiagonal'_of_commutes_span_blockProjection`: if every dependent
+  block projection lies in the span of a family of matrices, then any matrix
+  commuting with that family is block diagonal.
+- `MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan`: for a tensor on
+  the reindexed direct-sum bond space, if the pulled-back length-`m` word span
+  contains all block projections, then any boundary matrix commuting with every
+  length-`m` word has block-diagonal pullback.
+- `MPSTensor.offBlock_zero_of_commutes_reindexed_wordSpan`: the entrywise
+  off-block-zero form of the previous theorem.
+
+This uses the project-native #913 API:
+
+- `Matrix.blockProjection`
+- `Matrix.IsBlockDiagonal'`
+- `Matrix.isBlockDiagonal'_of_commutes_blockProjection`
+
+and keeps the finite-span hypothesis explicit.
+
+## Remaining mathematical input
+
+The full CF/BNT commutant theorem still requires the finite-span/separation step:
+for canonical BNT data, prove that the virtual sector projections of the assembled
+tensor lie in the span of sufficiently long assembled word products after pulling
+back along `finSigmaFinEquiv`.
+
+Concretely, for `B = toTensorFromBlocks μ A`, the remaining target has the shape
+
+```lean
+∀ k,
+  Matrix.blockProjection (n := fun j : Fin r => Fin (dim j)) (R := ℂ) k ∈
+    Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+      Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+        (MPSTensor.evalWord B (List.ofFn ω)))
+```
+
+or, equivalently using `evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal`, the
+span of block-diagonal matrices
+
+```lean
+Matrix.blockDiagonal' fun j => (μ j)^m • MPSTensor.evalWord (A j) (List.ofFn ω)
+```
+
+contains each sector projection.
+
+This is the finite-length Schur/BNT-separation step described in the issue thread:
+projecting long-word commutation onto off-diagonal blocks gives intertwiners
+between distinct CF/BNT blocks, and block separation should force those
+intertwiners to vanish. The available asymptotic separation theorem is
+`cross_overlap_tendsto_zero_of_separated_CFBNT_data`; it still has to be converted
+into the finite word-span/projection statement above.
+
+## Downstream use once the finite-span step lands
+
+1. A periodic-chain ground vector of the assembled tensor gives a boundary matrix
+   `X` by `contiguous_mem_groundSpace`.
+2. The wrapping-window argument gives commutation of `X` with sufficiently long
+   assembled words.
+3. The new `MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan` theorem
+   turns that commutation plus the finite-span projection statement into block
+   diagonality of `X`.
+4. The block-diagonal boundary matrix can then be decomposed blockwise, and the
+   existing forward inclusion / blockwise uniqueness results finish the planned
+   reverse inclusion.
+
+No reverse-inclusion theorem is claimed in this branch; the finite-span CF/BNT
+projection statement is still the load-bearing missing input.
+
+## Validation
+
+Local validation on this branch:
+
+- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
+- `lake build TNLean.MPS.ParentHamiltonian.DegenerateGS`
+- `lake build TNLean.MPS.ParentHamiltonian.DegenerateGS TNLean.MPS.SharedInfra.BlockAssembly TNLean.Algebra.ScalarCommutant TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
+- `lake build TNLean`
+- `cd blueprint && leanblueprint web && leanblueprint checkdecls` initially needed the root `TNLean.olean`; after `lake build TNLean`, `cd blueprint && leanblueprint checkdecls` succeeded.
+- Proof-integrity grep over the touched Lean/blueprint files found only the pre-existing deferred proof in `TNLean/MPS/ParentHamiltonian/DegenerateGS.lean` (`parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition`).

--- a/audits/2026-04-25_issue911_routeB_commutant_reduction.md
+++ b/audits/2026-04-25_issue911_routeB_commutant_reduction.md
@@ -1,10 +1,10 @@
-# Issue #911 Route B commutant reduction audit (2026-04-25)
+# Issue #911 block-diagonal commutant reduction audit (2026-04-25)
 
 Branch: `wave14-B-911-blockdiag-reverse`.
 
 ## Scope
 
-This note records the status after adding the first Route B algebraic reduction for the
+This note records the status after adding the first block-diagonal commutant reduction for the
 reverse inclusion from issue #911 / parent issue #905. The branch was rebased onto
 `origin/main` after PR #899 landed the blockwise-injective endgame in
 `DegenerateGS.lean`.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1913,7 +1913,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     definition.
 \end{proof}
 
-\begin{lemma}[Route B block-diagonal commutant reduction]
+\begin{lemma}[Block-diagonal commutant reduction from span extension]
     \label{lem:route_b_block_diagonal_commutant_reduction}
     \lean{Matrix.isBlockDiagonal'_of_commutes_span_blockProjection}
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan}
@@ -1954,8 +1954,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \notready
     The remaining structural step is the periodic block decomposition of the assembled chain
-    ground space. The Route B reduction above supplies the algebraic off-block-zero step once
-    the virtual sector projections are obtained from the finite word span of the assembled
+    ground space. The block-diagonal commutant reduction above supplies the algebraic
+    off-block-zero step once the virtual sector projections are obtained from the finite word
+    span of the assembled
     tensor. With that decomposition available, one applies the blockwise injective uniqueness
     theorem to each block separately and recovers the BNT span.
 \end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1913,12 +1913,38 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     definition.
 \end{proof}
 
+\begin{lemma}[Route B block-diagonal commutant reduction]
+    \label{lem:route_b_block_diagonal_commutant_reduction}
+    \lean{Matrix.isBlockDiagonal'_of_commutes_span_blockProjection}
+    \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan}
+    \lean{MPSTensor.offBlock_zero_of_commutes_reindexed_wordSpan}
+    \leanok
+    \uses{def:block_projection, def:block_diagonal_matrix,
+        lem:block_diagonal_of_commutes_block_projection}
+    Suppose the virtual sector projections $P_j$ of a dependent direct-sum bond space
+    lie in the span of a family of matrices. Any boundary matrix commuting with that
+    family commutes with each $P_j$, hence is block diagonal. Applied after pulling an
+    assembled tensor back along the direct-sum reindexing, length-$m$ word commutation
+    plus the corresponding projection-span hypothesis forces all off-block entries of
+    the boundary matrix to vanish.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Commutation is linear in the matrix from the spanning family, so it extends from
+    the generators to their span. Since each $P_j$ lies in that span, the boundary
+    matrix commutes with every sector projection. Lemma~\ref{lem:block_diagonal_of_commutes_block_projection}
+    then gives block diagonality, and Lemma~\ref{lem:block_diagonal_iff_off_block_zero}
+    gives the entrywise off-block-zero formulation.
+\end{proof}
+
 \begin{theorem}[Containment in the BNT span by block decomposition]
     \label{thm:parent_ground_space_le_bnt_span}
     \lean{MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition}
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, def:bnt_span,
-        thm:chain_ground_space_eq_mpv_blk}
+        thm:chain_ground_space_eq_mpv_blk,
+        lem:route_b_block_diagonal_commutant_reduction}
     If $A$ is in canonical-form/BNT and $1 < L$ and $N \ge L + 1$, every vector in the
     assembled parent ground space should decompose into blockwise chain ground states, and
     therefore lie in the BNT span.
@@ -1926,9 +1952,11 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{proof}
     \notready
-    The missing step is the periodic block decomposition of the assembled chain ground space.
-    Once such a decomposition is available, one applies the blockwise injective uniqueness theorem to each
-    block separately and recovers the BNT span.
+    The remaining structural step is the periodic block decomposition of the assembled chain
+    ground space. The Route B reduction above supplies the algebraic off-block-zero step once
+    the virtual sector projections are obtained from the finite word span of the assembled
+    tensor. With that decomposition available, one applies the blockwise injective uniqueness
+    theorem to each block separately and recovers the BNT span.
 \end{proof}
 
 \begin{theorem}[Ground space equals span of BNT]\label{thm:gs_eq_bnt_span}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1919,18 +1919,19 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan}
     \lean{MPSTensor.offBlock_zero_of_commutes_reindexed_wordSpan}
     \leanok
-    \uses{def:block_projection, def:block_diagonal_matrix,
-        lem:block_diagonal_of_commutes_block_projection}
+    \uses{def:block_projection, def:block_diagonal_matrix}
     Suppose the virtual sector projections $P_j$ of a dependent direct-sum bond space
     lie in the span of a family of matrices. Any boundary matrix commuting with that
     family commutes with each $P_j$, hence is block diagonal. Applied after pulling an
     assembled tensor back along the direct-sum reindexing, length-$m$ word commutation
     plus the corresponding projection-span hypothesis forces all off-block entries of
-    the boundary matrix to vanish.
+    the pulled-back boundary matrix to vanish.
 \end{lemma}
 
 \begin{proof}
     \leanok
+    \uses{lem:block_diagonal_of_commutes_block_projection,
+        lem:block_diagonal_iff_off_block_zero}
     Commutation is linear in the matrix from the spanning family, so it extends from
     the generators to their span. Since each $P_j$ lies in that span, the boundary
     matrix commutes with every sector projection. Lemma~\ref{lem:block_diagonal_of_commutes_block_projection}


### PR DESCRIPTION
## Summary
- Add `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean` with a block-projection span criterion for block diagonality and an entrywise off-block-zero corollary for reindexed assembled word spans.
- Update `DegenerateGS.lean` comments to point the reverse-inclusion route at this finite-span commutant reduction after the #899 blockwise-injective endgame.
- Sync Chapter 14 blueprint entries and add an audit note describing the remaining CF/BNT finite-span separation step.

Refs #911, #905.

## Validation
- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `lake build TNLean.MPS.ParentHamiltonian.DegenerateGS`
- `lake build TNLean.MPS.ParentHamiltonian.DegenerateGS TNLean.MPS.SharedInfra.BlockAssembly TNLean.Algebra.ScalarCommutant TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `lake build TNLean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `rg -n '\b(sorry|axiom|admit|native_decide|unsafe)\b' TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean TNLean/MPS/ParentHamiltonian/DegenerateGS.lean blueprint/src/chapter/ch14_parent_hamiltonian.tex audits/2026-04-25_issue911_routeB_commutant_reduction.md || true` (only the pre-existing deferred proof in `DegenerateGS.lean`)

## Remaining blocker
This PR does not claim the full reverse inclusion. The remaining load-bearing step is to prove the CF/BNT finite-span separation theorem showing that the virtual sector projections of `toTensorFromBlocks μ A` lie in the finite span of sufficiently long assembled word products.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new algebraic lemmas that will be used to justify block-diagonal/boundary-matrix commutant arguments; while self-contained, mistakes could invalidate downstream formalizations that rely on them. Other changes are documentation/import wiring only.
> 
> **Overview**
> Adds `MPS/CanonicalForm/BlockDiagonalCommutant.lean`, formalizing a reusable commutant-to-block-diagonal criterion (`Matrix.isBlockDiagonal'_of_commutes_span_blockProjection`) plus reindexed assembled-word variants for MPS boundary matrices (`MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan` and an off-block entry corollary).
> 
> Updates the root `TNLean.lean` import surface, refocuses the reverse-inclusion commentary in `ParentHamiltonian/DegenerateGS.lean` around this finite-span commutant reduction (without proving the full reverse inclusion), and syncs blueprint/audit documentation to reference the new lemmas and remaining finite-span CF/BNT separation blocker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75626ef05566bc635652bb1c64a4b06fbd8e9df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->