### PR TITLE
feat(MPS/RFP): reduce Appendix B product-pair extraction

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -25,8 +25,9 @@ not import `Commuting.lean`. Instead it does three things:
    projectors as an abstract witness on the full chain space, and proves from
    that witness the unfolded commutativity statement for the two-site local
    terms.
-3. It bundles the already-proved Appendix B structural data and names the
-   remaining chain-space extraction needed to turn that structural data into a
+3. It bundles the already-proved Appendix B structural data, removes the
+   harmless gauge matrices from coefficient calculations, and names the remaining
+   chain-space extraction needed to turn that structural data into a
    `ProductPairBridge`.
 
 The intended downstream use is:
@@ -62,6 +63,12 @@ def productPairWindow (N : ℕ) (σ : Cfg d (2 * N)) (p : Fin N) : Cfg d 2 :=
       have hj : j.val < 2 := j.isLt
       omega⟩ := rfl
 
+/-- On one pair, the product-pair window is the whole two-site configuration. -/
+@[simp] theorem productPairWindow_one (σ : Cfg d (2 * 1)) :
+    productPairWindow 1 σ 0 = σ := by
+  funext j
+  simp [productPairWindow]
+
 /-- The even-chain state obtained by repeating a fixed two-site amplitude on
 adjacent pairs.
 
@@ -76,6 +83,11 @@ def productPairState (ψ₂ : NSiteSpace d 2) (N : ℕ) : NSiteSpace d (2 * N) :
 @[simp] lemma productPairState_zero (ψ₂ : NSiteSpace d 2) :
     productPairState ψ₂ 0 = fun _ => (1 : ℂ) := by
   funext σ
+  simp [productPairState]
+
+/-- On a single pair, the product-pair state is the original two-site amplitude. -/
+@[simp] theorem productPairState_one (ψ₂ : NSiteSpace d 2) (σ : Cfg d (2 * 1)) :
+    productPairState ψ₂ 1 σ = ψ₂ σ := by
   simp [productPairState]
 
 /-- An MPS tensor has product-pair MPVs when every even-length coefficient
@@ -234,6 +246,56 @@ noncomputable def AppendixBStructuralData.twoSiteAmplitude {A : MPSTensor d D}
       ((hStruct.X * L * hStruct.U (σ 0) * hStruct.X⁻¹) *
         (hStruct.X * L * hStruct.U (σ 1) * hStruct.X⁻¹))
 
+/-- The gauge-removed tensor `Λ U_i` associated to a chosen Appendix B witness.
+
+The structural equality says that `A` is a similarity transform of this tensor.
+Separating it out lets the remaining even-chain coefficient calculation ignore the
+basis-change matrices `X` and `X⁻¹`. -/
+noncomputable def AppendixBStructuralData.coreTensor {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) : MPSTensor d D :=
+  fun i => Matrix.diagonal (fun k => (hStruct.Λ k : ℂ)) * hStruct.U i
+
+@[simp] theorem AppendixBStructuralData.coreTensor_apply {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) (i : Fin d) :
+    hStruct.coreTensor i = Matrix.diagonal (fun k => (hStruct.Λ k : ℂ)) * hStruct.U i :=
+  rfl
+
+/-- The original tensor is gauge equivalent to its gauge-removed Appendix B core. -/
+theorem AppendixBStructuralData.gaugeEquiv_coreTensor {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) :
+    GaugeEquiv hStruct.coreTensor A := by
+  let Xg : GL (Fin D) ℂ := Matrix.GeneralLinearGroup.mkOfDetNeZero hStruct.X hStruct.hX_det
+  refine ⟨Xg, ?_⟩
+  intro i
+  simp [Xg, AppendixBStructuralData.coreTensor, hStruct.hA_eq i, Matrix.mul_assoc]
+
+/-- The Appendix B basis change does not change any MPV coefficient. -/
+theorem AppendixBStructuralData.mpv_eq_coreTensor {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) {N : ℕ} (σ : Cfg d N) :
+    mpv A σ = mpv hStruct.coreTensor σ :=
+  (GaugeEquiv.sameMPV hStruct.gaugeEquiv_coreTensor N σ).symm
+
+/-- The structural two-site amplitude is exactly the two-site MPV coefficient. -/
+theorem AppendixBStructuralData.twoSiteAmplitude_eq_mpv {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) (σ : Cfg d 2) :
+    hStruct.twoSiteAmplitude σ = mpv A σ := by
+  simp [mpv, coeff, AppendixBStructuralData.twoSiteAmplitude, hStruct.hA_eq,
+    evalWord, List.ofFn_succ, List.ofFn_zero]
+
+/-- Equivalently, the structural two-site amplitude is the two-site coefficient of
+`Λ U_i`. -/
+theorem AppendixBStructuralData.twoSiteAmplitude_eq_coreTensor_mpv {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) (σ : Cfg d 2) :
+    hStruct.twoSiteAmplitude σ = mpv hStruct.coreTensor σ := by
+  rw [hStruct.twoSiteAmplitude_eq_mpv σ, hStruct.mpv_eq_coreTensor σ]
+
+/-- The length-two case of the requested even-chain factorization is automatic
+from the definition of the structural two-site amplitude. -/
+theorem AppendixBStructuralData.mpv_eq_productPairState_one {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) (σ : Cfg d (2 * 1)) :
+    mpv A σ = productPairState hStruct.twoSiteAmplitude 1 σ := by
+  rw [productPairState_one, hStruct.twoSiteAmplitude_eq_mpv]
+
 /-- The remaining chain-space extraction needed after Appendix B.
 
 For a fixed structural witness, this records the two facts that are still not
@@ -248,6 +310,22 @@ structure AppendixBProductPairExtraction {A : MPSTensor d D}
     mpv A σ = productPairState hStruct.twoSiteAmplitude N σ
   /-- Local product-pair projectors realizing the nearest-neighbor parent terms. -/
   localProjectors : ∀ N, HasProductPairLocalProjectors A N
+
+/-- Construct the MPV part of the extraction after removing the Appendix B gauge.
+
+This reduces the coefficient bookkeeping to the core tensor `Λ U_i`; the local
+projector data remains a separate chain-space input. -/
+noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
+    {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
+    (hCore : ∀ N (σ : Cfg d (2 * N)),
+      mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
+    (hProj : ∀ N, HasProductPairLocalProjectors A N) :
+    AppendixBProductPairExtraction hStruct where
+  hmpv := by
+    intro N σ
+    rw [hStruct.mpv_eq_coreTensor σ]
+    exact hCore N σ
+  localProjectors := hProj
 
 /-- Chain-space extraction data yields the established `ProductPairBridge` witness. -/
 noncomputable def AppendixBProductPairExtraction.toProductPairBridge

--- a/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
+++ b/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
@@ -48,11 +48,29 @@ route that does not call `Axioms.rfp_to_nncph_commute`:
 - `MPSTensor.rfp_implies_nncph_of_appendixBExtraction` proves NNCPH from RFP plus that extraction,
   without calling `Axioms.rfp_to_nncph_commute`.
 
+The 2026-04-25 wave-14 follow-up removes a real coefficient-bookkeeping nuisance:
+
+- `MPSTensor.productPairWindow_one` and `MPSTensor.productPairState_one` prove that the
+  one-pair product-pair state is just the chosen two-site amplitude;
+- `MPSTensor.AppendixBStructuralData.coreTensor` names the gauge-removed tensor
+  $\Lambda U_i$;
+- `MPSTensor.AppendixBStructuralData.gaugeEquiv_coreTensor` and
+  `MPSTensor.AppendixBStructuralData.mpv_eq_coreTensor` prove that the Appendix B gauge
+  matrices do not affect MPV coefficients;
+- `MPSTensor.AppendixBStructuralData.twoSiteAmplitude_eq_mpv` and
+  `MPSTensor.AppendixBStructuralData.mpv_eq_productPairState_one` prove the length-two
+  case of the requested product-pair coefficient identity;
+- `MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorization` reduces the MPV
+  field of `AppendixBProductPairExtraction` to the same factorization theorem for the
+  gauge-removed tensor, leaving the local-projector witness as a separate input.
+
 In other words, the internal part of the forward direction now factors as
 
 1. obtain Appendix B structural data from `rfp_nt_structural_full`;
-2. construct product-pair extraction data through that witness's two-site amplitude;
-3. apply the product-pair theorem to get NNCPH.
+2. remove the similarity matrices and prove the repeated-pair coefficient identity for the
+   core tensor $\Lambda U_i$;
+3. construct the product-pair local projector family;
+4. apply the product-pair theorem to get NNCPH.
 
 ## Gap 1 — replacing `Axioms.rfp_to_nncph_commute`
 
@@ -87,11 +105,16 @@ Concretely, the missing work is to turn the structural decomposition
 $$A_i = X \, \Lambda \, U_i \, X^{-1}$$
 into
 
-- an explicit repeated two-site amplitude on even chains, and
+- an explicit repeated two-site amplitude on even chains for the gauge-removed core tensor
+  $\Lambda U_i$ (the $X$ and $X^{-1}$ matrices are now formally removed from this step, and
+  the length-two case is proved), and
 - a family of chain-level projectors whose values are exactly the nearest-neighbor `localTerm`s.
 
 This is a genuine chain-space construction problem on `NSiteSpace d N`; it is **not** a remaining
-issue about the NNCPH definition itself.
+issue about the NNCPH definition itself. The present `AppendixBStructuralData` record still exposes
+only the left-canonical identity for `U`; a proof of the all-even-length factorization may need the
+stronger matrix-entry isometry produced inside `rfp_nt_structural_full` to be exported, or an
+alternative local-support description of the product-pair state.
 
 ## Gap 2 — the forward decorrelation theorem is blocked on tensor locality
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1052,7 +1052,9 @@ interaction projectors commute with each other.
 \begin{remark}[Product-pair data for NNCPH]%
     \label{rem:product_pair_bridge}
     \lean{MPSTensor.productPairWindow}
+    \lean{MPSTensor.productPairWindow_one}
     \lean{MPSTensor.productPairState}
+    \lean{MPSTensor.productPairState_one}
     \lean{MPSTensor.HasProductPairMPV}
     \lean{MPSTensor.HasProductPairLocalProjectors}
     \lean{MPSTensor.HasProductPairLocalProjectors.isNNCPH}
@@ -1064,7 +1066,15 @@ interaction projectors commute with each other.
     \lean{MPSTensor.AppendixBStructuralData.exists_ofRFP}
     \lean{MPSTensor.AppendixBStructuralData.ofRFP}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude}
+    \lean{MPSTensor.AppendixBStructuralData.coreTensor}
+    \lean{MPSTensor.AppendixBStructuralData.coreTensor_apply}
+    \lean{MPSTensor.AppendixBStructuralData.gaugeEquiv_coreTensor}
+    \lean{MPSTensor.AppendixBStructuralData.mpv_eq_coreTensor}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude_eq_mpv}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude_eq_coreTensor_mpv}
+    \lean{MPSTensor.AppendixBStructuralData.mpv_eq_productPairState_one}
     \lean{MPSTensor.AppendixBProductPairExtraction}
+    \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorization}
     \lean{MPSTensor.AppendixBProductPairExtraction.toProductPairBridge}
     \lean{MPSTensor.AppendixBProductPairExtraction.commuting_twoSite_localTerms}
     \lean{MPSTensor.commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction}
@@ -1072,14 +1082,19 @@ interaction projectors commute with each other.
     \leanok
     On an even chain, one can extract the $p$-th adjacent two-site word of a
     configuration and compare the MPS coefficients with a repeated two-site pair state.
-    The corresponding data record both that coefficient identity and a
-    family of idempotent chain-level projectors whose values are the nearest-neighbor
-    local terms. The final theorem in these data shows that these local terms commute.
-    Consequently the same data yields the nearest-neighbor commuting condition
-    on every finite chain. The Appendix~B construction extracts the already-proved
-    structural decomposition from normal left-canonical RFP data and identifies the
-    remaining internal step: construct product-pair extraction through the two-site
-    amplitude determined by that structural witness.
+    The one-pair case recovers the original two-site amplitude. For an Appendix~B
+    structural witness, the gauge-removed tensor $\Lambda U_i$ has the same MPV
+    coefficients as $A$, and the structural two-site amplitude is exactly the
+    two-site MPV coefficient. Hence the coefficient part of the extraction reduces
+    to proving the repeated-pair identity for this gauge-removed tensor. The
+    corresponding data also include a family of idempotent chain-level projectors
+    whose values are the nearest-neighbor local terms. The final theorem in these
+    data shows that these local terms commute. Consequently the same data yields
+    the nearest-neighbor commuting condition on every finite chain. The Appendix~B
+    construction extracts the already-proved structural decomposition from normal
+    left-canonical RFP data and identifies the remaining internal step: construct
+    product-pair extraction through the two-site amplitude determined by that
+    structural witness.
 \end{remark}
 
 \begin{theorem}[NNCPH implies RFP]\label{thm:nncph_implies_rfp}


### PR DESCRIPTION
## Summary

Refs #234.

- add the one-pair product-pair window/state identities
- introduce `AppendixBStructuralData.coreTensor = Λ U_i` and prove it has the same MPV coefficients as the original Appendix B tensor
- prove the structural two-site amplitude is exactly the two-site MPV coefficient, giving the length-two case of the requested product-pair factorization
- add `AppendixBProductPairExtraction.ofCoreTensorFactorization`, reducing the remaining coefficient extraction to the gauge-removed core tensor while keeping local projectors as a separate input
- update Chapter 14 and the #234 audit with the exact remaining blocker

## Validation

- `lake build TNLean.MPS.RFP.CommutingBridge TNLean.MPS.ParentHamiltonian.Commuting`
- `lake build TNLean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- touched-file proof-integrity grep for `sorry|admit|axiom|native_decide|unsafe`

## Remaining blocker

This does not close #234: the all-even-length coefficient factorization and the chain-level `HasProductPairLocalProjectors` construction are still missing. The audit now records that the present `AppendixBStructuralData` exposes only the left-canonical identity for `U`; finishing the coefficient factorization may require exporting the stronger matrix-entry isometry produced inside `rfp_nt_structural_full`, or replacing the current repeated-two-site-state target by an explicitly local-support formulation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive/organizational in proof code, introducing helper lemmas and a new construction path that should not affect downstream semantics beyond simplifying future coefficient proofs.
> 
> **Overview**
> Refines the Appendix B → product-pair bridge by introducing a gauge-removed `coreTensor = Λ U_i` and proving gauge invariance of MPV coefficients (`mpv_eq_coreTensor`), plus lemmas identifying the structural two-site amplitude with the length-2 MPV coefficient.
> 
> Adds one-pair simp theorems (`productPairWindow_one`, `productPairState_one`) and a new constructor `AppendixBProductPairExtraction.ofCoreTensorFactorization` so the remaining even-chain factorization proof can be stated for `coreTensor` while keeping local-projector data separate.
> 
> Updates the #234 audit and Chapter 14 blueprint references/text to reflect the new decomposition and the narrowed remaining blocker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0f8e9e3e3f645bfe535adbd387f2fd9c35ebd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->