### PR TITLE
feat(MPS/ParentHamiltonian): prove local ES terms are projections

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -65,6 +65,9 @@ concrete Friedrichs-angle/row-sum lower bound that
 * `MPSTensor.localTermESSummand_isPositive` — positivity of the conjugated
   cyclic-window summands expected to appear in the averaged
   `EuclideanSpace` formula for local terms.
+* `MPSTensor.localTermES_isSymmetricProjection` — each transported local term is
+  a symmetric projection, with idempotence inherited from the local orthogonal
+  projector on every cyclic window.
 * `MPSTensor.parentHamiltonianES_gap_bound_of_quadratic_form` — the explicit
   reduction from the parent-Hamiltonian gap statement to the uniform
   Friedrichs/martingale quadratic-form estimate.
@@ -215,11 +218,17 @@ noncomputable def parentInteractionES (A : MPSTensor d D) (L : ℕ) :
     EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L) :=
   ((groundSpaceES A L)ᗮ.starProjection.toLinearMap)
 
+/-- The `EuclideanSpace` parent interaction is the symmetric projection onto
+`(groundSpaceES A L)ᗮ`. -/
+theorem parentInteractionES_isSymmetricProjection (A : MPSTensor d D) (L : ℕ) :
+    (parentInteractionES A L).IsSymmetricProjection := by
+  exact Submodule.isSymmetricProjection_starProjection ((groundSpaceES A L)ᗮ)
+
 /-- The `EuclideanSpace` parent interaction is positive because it is an
 orthogonal projection. -/
 theorem parentInteractionES_isPositive (A : MPSTensor d D) (L : ℕ) :
     (parentInteractionES A L).IsPositive := by
-  exact (Submodule.isSymmetricProjection_starProjection ((groundSpaceES A L)ᗮ)).isPositive
+  exact (parentInteractionES_isSymmetricProjection A L).isPositive
 
 /-- The cyclic window restriction map transported from `NSiteSpace` to the
 Hilbert-space model `EuclideanSpace`. -/
@@ -409,6 +418,24 @@ private theorem cyclicRestrictES_adjoint_apply {N : ℕ} (hN : 0 < N) {L : ℕ}
   simp [localTermES, localTerm, hLN, parentInteraction, parentInteractionES]
   simp [hcfg, hself]
 
+private theorem cyclicRestrictES_localTermES {N : ℕ} (A : MPSTensor d D) {L : ℕ}
+    (hLN : L ≤ N) (i : Fin N) (τ : Cfg d N) (v : EuclideanSpace ℂ (Cfg d N)) :
+    cyclicRestrictES (d := d) (Fin.pos i) L i τ (localTermES A L i v) =
+      parentInteractionES A L (cyclicRestrictES (d := d) (Fin.pos i) L i τ v) := by
+  ext ω
+  rw [cyclicRestrictES_apply]
+  rw [localTermES_apply A L i hLN v (cyclicCfg (d := d) (Fin.pos i) L i ω τ)]
+  have hsame : SameOutsideWindow (L := L) i (cyclicCfg (d := d) (Fin.pos i) L i ω τ) τ :=
+    sameOutsideWindow_of_cyclicCfg_eq (d := d) (Fin.pos i) i rfl
+  have hrestrict :
+      cyclicRestrictES (d := d) (Fin.pos i) L i τ =
+        cyclicRestrictES (d := d) (Fin.pos i) L i (cyclicCfg (d := d) (Fin.pos i) L i ω τ) :=
+    cyclicRestrictES_eq_of_sameOutsideWindow (d := d) (Fin.pos i) i hsame
+  have hextract : extractWindow L i (cyclicCfg (d := d) (Fin.pos i) L i ω τ) = ω := by
+    rw [cyclicCfg_eq_replaceWindow (d := d) (Fin.pos i) L hLN]
+    exact extractWindow_replaceWindow L hLN i τ ω
+  rw [← hrestrict, hextract]
+
 @[simp] private theorem localTermESSummand_apply {N : ℕ} (A : MPSTensor d D) (hN : 0 < N)
     {L : ℕ} (hLN : L ≤ N) (i : Fin N) (τ v σ) :
     localTermESSummand A hN L i τ v σ =
@@ -538,6 +565,43 @@ theorem localTermES_isPositive {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin 
       exact div_nonneg hnonneg (mul_nonneg hnonneg hnonneg)
   · simp [localTermES, localTerm, hLN]
 
+private theorem localTermES_isIdempotentElem {N : ℕ} (A : MPSTensor d D) (L : ℕ)
+    (i : Fin N) : IsIdempotentElem (localTermES A L i) := by
+  by_cases hLN : L ≤ N
+  · rw [isIdempotentElem_iff]
+    ext v σ
+    change localTermES A L i (localTermES A L i v) σ = localTermES A L i v σ
+    rw [localTermES_apply A L i hLN (localTermES A L i v) σ]
+    rw [cyclicRestrictES_localTermES A hLN i σ v]
+    rw [localTermES_apply A L i hLN v σ]
+    have hPidem : IsIdempotentElem (parentInteractionES A L) :=
+      (parentInteractionES_isSymmetricProjection A L).isIdempotentElem
+    have hPapply :
+        parentInteractionES A L
+            (parentInteractionES A L ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v)) =
+          parentInteractionES A L ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v) := by
+      simpa [Module.End.mul_apply] using
+        congrArg
+          (fun T : EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L) =>
+            T ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v)) hPidem.eq
+    rw [hPapply]
+  · simpa [localTermES, localTerm, hLN] using
+      (IsIdempotentElem.zero :
+        IsIdempotentElem (0 : EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N)))
+
+/-- Each transported local parent-Hamiltonian term is a symmetric projection.
+
+This is the Euclidean-space version of the fact that the local term is the
+orthogonal projector onto the complement of the translated local ground space.
+For `L ≤ N`, idempotence follows by restricting to the cyclic window, applying
+the local projector `parentInteractionES`, and using `P_L^2 = P_L`; for `L > N`
+the definition gives the zero projection. -/
+theorem localTermES_isSymmetricProjection {N : ℕ} (A : MPSTensor d D) (L : ℕ)
+    (i : Fin N) : (localTermES A L i).IsSymmetricProjection := by
+  exact LinearMap.IsSymmetricProjection.mk
+    (localTermES_isIdempotentElem A L i)
+    (localTermES_isPositive A L i).isSymmetric
+
 /-- The full transported parent Hamiltonian is positive because it is a finite
 sum of positive transported local terms. -/
 theorem parentHamiltonianES_isPositive (A : MPSTensor d D) (L N : ℕ) :
@@ -638,8 +702,8 @@ cross-term row bounds.
 
 This theorem is the parent-Hamiltonian instantiation of the abstract projection
 geometry in `ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum`.
-It assumes explicitly that the transported local terms are symmetric projections
-and that their ordered cross terms satisfy the row-summable bound
+The local projection input is supplied by `localTermES_isSymmetricProjection`, so
+its hypotheses are only the ordered row-summable cross-term bounds
 
 `Re ⟪hᵢ v, hⱼ v⟫ ≥ -(1 - γ) cᵢⱼ Re ⟪hᵢ v, v⟫`.
 
@@ -649,7 +713,6 @@ quadratic form, exactly in the shape consumed by
 theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
     (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
     (c : Fin N → Fin N → ℝ)
-    (hProj : ∀ i : Fin N, (localTermES A L i).IsSymmetricProjection)
     (hRow : ∀ i : Fin N, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1)
     (hCross : ∀ i j : Fin N, j ∈ Finset.univ.erase i →
       ∀ v : EuclideanSpace ℂ (Cfg d N),
@@ -663,22 +726,21 @@ theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
   simpa [parentHamiltonianES_eq_sum_localTermES A L N] using
     (ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum
       (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
-      (fun i : Fin N => localTermES A L i) hProj c hRow hCross v)
+      (fun i : Fin N => localTermES A L i)
+      (fun i : Fin N => localTermES_isSymmetricProjection A L i) c hRow hCross v)
 
 /-- Uniform explicit gap-bound reduction from ordered local cross-term row
 bounds.
 
-For every chain length `N ≥ 2L`, assume the transported local terms are symmetric
-projections and satisfy the ordered row-summable cross-term estimate with
-constant `γ = 1 / (4L)`. Then the existing quadratic-form-to-gap theorem applies
-and yields the explicit norm lower bound. This exact reduction leaves proving
-these projection and Friedrichs/row-sum hypotheses for the concrete MPS local
-terms as the model-specific analytic task. -/
+For every chain length `N ≥ 2L`, assume the transported local terms satisfy the
+ordered row-summable cross-term estimate with constant `γ = 1 / (4L)`. The local
+symmetric-projection input is already supplied by `localTermES_isSymmetricProjection`.
+Then the existing quadratic-form-to-gap theorem applies and yields the explicit
+norm lower bound. This exact reduction leaves proving the Friedrichs/row-sum
+hypotheses for the concrete MPS local terms as the model-specific analytic task. -/
 theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (c : ∀ N : ℕ, Fin N → Fin N → ℝ)
-    (hProj : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i : Fin N),
-      (localTermES A L i).IsSymmetricProjection)
     (hRow : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i : Fin N),
       (∑ j ∈ Finset.univ.erase i, c N i j) ≤ 1)
     (hCross : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
@@ -703,7 +765,7 @@ theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
     rw [div_le_iff₀ hden]
     nlinarith [hLge_one]
   exact parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
-    A L N hγle (c N) (hProj N hLN) (hRow N hLN) (hCross N hLN) v
+    A L N hγle (c N) (hRow N hLN) (hCross N hLN) v
 
 /-- Fixed-chain martingale quadratic-form estimate from finite-overlap
 Friedrichs data.
@@ -800,10 +862,11 @@ orthogonal-projection infrastructure (for example
 `Submodule.starProjection` and `orthogonalProjection`) but not a ready-made
 Kastoryano–Lucia-style angle-to-anticommutator bound. This is a real blocker
 for quantitative overlap constants.
-2. **Positivity formulation:** the local `EuclideanSpace` projector
-`parentInteractionES A L`, each conjugated cyclic-restriction summand
-`localTermESSummand A hN L i τ = Rᵢ,τ† P_L Rᵢ,τ`, each transported local term,
-and the full transported Hamiltonian are now available as positive operators.
+2. **Projection/positivity formulation:** the local `EuclideanSpace` projector
+`parentInteractionES A L` and each transported local term are now available as
+symmetric projections, and the conjugated cyclic-restriction summands
+`localTermESSummand A hN L i τ = Rᵢ,τ† P_L Rᵢ,τ` plus the full transported
+Hamiltonian are available as positive operators.
 3. **Quadratic-form reduction:**
 `parentHamiltonianES_norm_bound_of_quadratic_form` and
 `parentHamiltonianES_gap_bound_of_quadratic_form` reduce the gap statement to a
@@ -816,9 +879,10 @@ finite-sum algebra turning explicit ordered cross-term row bounds for local
 symmetric projections into the quadratic-form hypothesis above.
 5. **Remaining local analytic obligations:** the combinatorial overlap count comes
 from locality (`localTerm`, `parentHamiltonian`) and finite range: each window
-overlaps at most `2 * (L - 1)` neighbors. Still missing are the concrete local
-symmetric-projection theorem for `localTermES` and the Friedrichs-angle estimate
-that supplies the ordered cross-term constants with the required row sums.
+overlaps at most `2 * (L - 1)` neighbors. The local symmetric-projection theorem
+for `localTermES` is now proved above; the remaining input is the
+Friedrichs-angle estimate that supplies the ordered cross-term constants with
+the required row sums.
 6. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
 existential theorem, now proved by applying the Friedrichs-angle theorem
 below. The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -227,8 +227,8 @@ theorem parentInteractionES_isSymmetricProjection (A : MPSTensor d D) (L : ℕ) 
 /-- The `EuclideanSpace` parent interaction is positive because it is an
 orthogonal projection. -/
 theorem parentInteractionES_isPositive (A : MPSTensor d D) (L : ℕ) :
-    (parentInteractionES A L).IsPositive := by
-  exact (parentInteractionES_isSymmetricProjection A L).isPositive
+    (parentInteractionES A L).IsPositive :=
+  (parentInteractionES_isSymmetricProjection A L).isPositive
 
 /-- The cyclic window restriction map transported from `NSiteSpace` to the
 Hilbert-space model `EuclideanSpace`. -/
@@ -597,9 +597,7 @@ the local projector `parentInteractionES`, and using `P_L^2 = P_L`; for `L > N`
 the definition gives the zero projection. -/
 theorem localTermES_isSymmetricProjection {N : ℕ} (A : MPSTensor d D) (L : ℕ)
     (i : Fin N) : (localTermES A L i).IsSymmetricProjection :=
-  LinearMap.IsSymmetricProjection.mk
-    (localTermES_isIdempotentElem A L i)
-    (localTermES_isPositive A L i).isSymmetric
+  ⟨localTermES_isIdempotentElem A L i, (localTermES_isPositive A L i).isSymmetric⟩
 
 /-- The full transported parent Hamiltonian is positive because it is a finite
 sum of positive transported local terms. -/

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -221,8 +221,8 @@ noncomputable def parentInteractionES (A : MPSTensor d D) (L : ℕ) :
 /-- The `EuclideanSpace` parent interaction is the symmetric projection onto
 `(groundSpaceES A L)ᗮ`. -/
 theorem parentInteractionES_isSymmetricProjection (A : MPSTensor d D) (L : ℕ) :
-    (parentInteractionES A L).IsSymmetricProjection := by
-  exact Submodule.isSymmetricProjection_starProjection ((groundSpaceES A L)ᗮ)
+    (parentInteractionES A L).IsSymmetricProjection :=
+  Submodule.isSymmetricProjection_starProjection ((groundSpaceES A L)ᗮ)
 
 /-- The `EuclideanSpace` parent interaction is positive because it is an
 orthogonal projection. -/
@@ -574,20 +574,19 @@ private theorem localTermES_isIdempotentElem {N : ℕ} (A : MPSTensor d D) (L : 
     rw [localTermES_apply A L i hLN (localTermES A L i v) σ]
     rw [cyclicRestrictES_localTermES A hLN i σ v]
     rw [localTermES_apply A L i hLN v σ]
-    have hPidem : IsIdempotentElem (parentInteractionES A L) :=
-      (parentInteractionES_isSymmetricProjection A L).isIdempotentElem
     have hPapply :
         parentInteractionES A L
             (parentInteractionES A L ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v)) =
           parentInteractionES A L ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v) := by
       simpa [Module.End.mul_apply] using
-        congrArg
-          (fun T : EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L) =>
-            T ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v)) hPidem.eq
+        LinearMap.congr_fun
+          (parentInteractionES_isSymmetricProjection A L).isIdempotentElem.eq
+          ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v)
     rw [hPapply]
   · simpa [localTermES, localTerm, hLN] using
       (IsIdempotentElem.zero :
-        IsIdempotentElem (0 : EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N)))
+        IsIdempotentElem
+          (0 : EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N)))
 
 /-- Each transported local parent-Hamiltonian term is a symmetric projection.
 
@@ -597,8 +596,8 @@ For `L ≤ N`, idempotence follows by restricting to the cyclic window, applying
 the local projector `parentInteractionES`, and using `P_L^2 = P_L`; for `L > N`
 the definition gives the zero projection. -/
 theorem localTermES_isSymmetricProjection {N : ℕ} (A : MPSTensor d D) (L : ℕ)
-    (i : Fin N) : (localTermES A L i).IsSymmetricProjection := by
-  exact LinearMap.IsSymmetricProjection.mk
+    (i : Fin N) : (localTermES A L i).IsSymmetricProjection :=
+  LinearMap.IsSymmetricProjection.mk
     (localTermES_isIdempotentElem A L i)
     (localTermES_isPositive A L i).isSymmetric
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1594,7 +1594,6 @@ Lucia~\cite{Kastoryano2018Martingale}.
     itself positive. Summing over $i$ yields positivity of $H_{N,\mathrm{ES}}$.
 \end{proof}
 
-
 \begin{lemma}[Symmetric-projection structure of transported ES local terms]
     \label{lem:transported_es_local_projections}
     \lean{MPSTensor.parentInteractionES_isSymmetricProjection}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1594,6 +1594,30 @@ Lucia~\cite{Kastoryano2018Martingale}.
     itself positive. Summing over $i$ yields positivity of $H_{N,\mathrm{ES}}$.
 \end{proof}
 
+
+\begin{lemma}[Symmetric-projection structure of transported ES local terms]
+    \label{lem:transported_es_local_projections}
+    \lean{MPSTensor.parentInteractionES_isSymmetricProjection}
+    \lean{MPSTensor.localTermES_isSymmetricProjection}
+    \leanok
+    \uses{rem:euclidean_local_projector_ingredients, lem:transported_es_positive}
+    The Euclidean local projector $P_L^{\mathrm{ES}}(A)$ is a symmetric projection, and
+    every transported local term $h_{i,\mathrm{ES}}$ on the $N$-site chain is a
+    symmetric projection.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The local operator $P_L^{\mathrm{ES}}(A)$ is an orthogonal projection onto
+    $(G_L^{\mathrm{ES}}(A))^\perp$. For $L\le N$, restricting
+    $h_{i,\mathrm{ES}}v$ to a cyclic window gives
+    $P_L^{\mathrm{ES}}(A)$ applied to the corresponding restriction of $v$; applying
+    $h_{i,\mathrm{ES}}$ a second time therefore applies
+    $(P_L^{\mathrm{ES}}(A))^2=P_L^{\mathrm{ES}}(A)$ on that window. The positivity
+    result above supplies symmetry, and the case $L>N$ is the zero projection by
+    definition.
+\end{proof}
+
 \begin{lemma}[Quadratic form to norm bound]\label{lem:quadratic_form_to_norm_bound}
     \lean{FrustrationFree.spectralGap_of_martingale}
     \leanok
@@ -1736,10 +1760,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds}
     \leanok
     \uses{lem:ordered_projection_rowsum_reduction, def:parent_hamiltonian_es,
-        rem:euclidean_local_projector_ingredients}
+        rem:euclidean_local_projector_ingredients, lem:transported_es_local_projections}
     For a fixed chain length $N$, suppose the transported local terms
-    $h_{i,\mathrm{ES}}$ are symmetric projections and satisfy the ordered row-sum
-    estimate
+    $h_{i,\mathrm{ES}}$ satisfy the ordered row-sum estimate
     \[
         \operatorname{Re}\langle h_{i,\mathrm{ES}} v,h_{j,\mathrm{ES}}v\rangle
         \ge -(1-\gamma)c_{ij}\operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle
@@ -1758,8 +1781,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
-    Apply Lemma~\ref{lem:ordered_projection_rowsum_reduction} to the family
-    $P_i=h_{i,\mathrm{ES}}$ and use
+    Lemma~\ref{lem:transported_es_local_projections} supplies the symmetric-projection
+    hypothesis for the family $P_i=h_{i,\mathrm{ES}}$. Apply
+    Lemma~\ref{lem:ordered_projection_rowsum_reduction} to this family and use
     $H_{N,L}^{\mathrm{ES}}=\sum_i h_{i,\mathrm{ES}}$.
 \end{proof}
 
@@ -1768,10 +1792,10 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_ordered_local_term_bounds}
     \leanok
     \uses{lem:parent_hamiltonian_ordered_rowsum_quadratic,
-        lem:parent_hamiltonian_es_quadratic_reduction}
-    Assume uniformly for every $N\ge2L$ that the transported local terms are
-    symmetric projections and satisfy the ordered row-sum estimate above with
-    $\gamma=1/(4L)$. If $L>1$, then $1/(4L)>0$ and, for every
+        lem:parent_hamiltonian_es_quadratic_reduction, lem:transported_es_local_projections}
+    Assume uniformly for every $N\ge2L$ that the transported local terms satisfy
+    the ordered row-sum estimate above with $\gamma=1/(4L)$. If $L>1$, then
+    $1/(4L)>0$ and, for every
     $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
     \[
         \frac{1}{4L}\|v\|\le
@@ -1999,6 +2023,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         rem:euclidean_local_projector_ingredients,
         lem:euclidean_local_projector_positive,
         lem:local_term_es_average,
+        lem:transported_es_local_projections,
         lem:parent_hamiltonian_es_quadratic_reduction,
         lem:parent_hamiltonian_ordered_rowsum_gap,
         lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic,
@@ -2017,8 +2042,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \notready
-    The local averaging identity and positivity statements are now formalized in
-    Lemmas~\ref{lem:local_term_es_average} and~\ref{lem:transported_es_positive}.
+    The local averaging, positivity, and symmetric-projection statements are now
+    recorded in Lemmas~\ref{lem:local_term_es_average},
+    \ref{lem:transported_es_positive}, and~\ref{lem:transported_es_local_projections}.
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} reduces the present
     theorem to the remaining MPS-specific task: deriving the uniform
     quadratic-form estimate.  Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1806,6 +1806,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
+    \uses{lem:parent_hamiltonian_ordered_rowsum_quadratic,
+        lem:parent_hamiltonian_es_quadratic_reduction}
     The fixed-chain row-sum reduction supplies the quadratic-form estimate with
     $\gamma=1/(4L)$ for every admissible $N$.  The positivity and kernel
     identification of the transported Hamiltonian then allow

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1781,7 +1781,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
-    \uses{lem:transported_es_local_projections}
+    \uses{lem:transported_es_local_projections, lem:ordered_projection_rowsum_reduction}
     Lemma~\ref{lem:transported_es_local_projections} supplies the symmetric-projection
     hypothesis for the family $P_i=h_{i,\mathrm{ES}}$. Apply
     Lemma~\ref{lem:ordered_projection_rowsum_reduction} to this family and use

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1607,6 +1607,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
+    \uses{lem:transported_es_positive}
     The local operator $P_L^{\mathrm{ES}}(A)$ is an orthogonal projection onto
     $(G_L^{\mathrm{ES}}(A))^\perp$. For $L\le N$, restricting
     $h_{i,\mathrm{ES}}v$ to a cyclic window gives

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1781,6 +1781,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
+    \uses{lem:transported_es_local_projections}
     Lemma~\ref{lem:transported_es_local_projections} supplies the symmetric-projection
     hypothesis for the family $P_i=h_{i,\mathrm{ES}}$. Apply
     Lemma~\ref{lem:ordered_projection_rowsum_reduction} to this family and use


### PR DESCRIPTION
## Summary

Refs #460, #190.

This PR proves the local projection input needed after the row-sum martingale reduction from PR #919:

- adds `MPSTensor.parentInteractionES_isSymmetricProjection`;
- proves `MPSTensor.localTermES_isSymmetricProjection`, showing each transported local parent-Hamiltonian term is a symmetric projection;
- wires the ordered row-sum reductions so callers no longer need to pass a separate `hProj` hypothesis;
- syncs blueprint Chapter 14 with the new local projection lemma.

Mathematically, the idempotence proof uses the cyclic-window restriction identity: restricting `localTermES A L i v` to a window is the same as applying the local orthogonal projector `parentInteractionES A L` to the restricted vector. Applying the local term twice therefore applies `P_L^2 = P_L` on each cyclic window. Symmetry comes from the existing positivity theorem.

This intentionally leaves the remaining Friedrichs-angle / finite-overlap row-bound constants to the parallel row-bound work; no claim is made that `parentHamiltonianES_gap_bound_of_friedrichs` is fully closed here.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale TNLean.Analysis.ProjectionGeometry`
- `lake build TNLean` (first attempt hit a transient macOS/iCloud `Too many open files in system` near the end; immediate retry passed)
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- touched-file proof-integrity scan found only the pre-existing `parentHamiltonianES_gap_bound_of_friedrichs` `sorry` in `Martingale.lean`

Ready for an orchestrator simplification/cleanup pass before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to changes in theorem statements/assumptions (removing explicit `hProj` arguments) that may require downstream proof updates, but the changes are confined to formalization/proof infrastructure with no runtime or security impact.
> 
> **Overview**
> Adds `parentInteractionES_isSymmetricProjection` and proves `localTermES_isSymmetricProjection` by establishing idempotence via a new cyclic-window restriction lemma.
> 
> Updates the ordered row-sum quadratic-form and gap reductions to **no longer take an explicit local-projection hypothesis**, instead using `localTermES_isSymmetricProjection` internally.
> 
> Syncs Blueprint Ch.14 by introducing a new lemma for the symmetric-projection structure and updating subsequent spectral-gap reduction statements to depend on it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccce419a0cb4b8f07149a0fbda75c756257948d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->