### PR TITLE
feat(MPS/FundamentalTheorem): advance BNT sector matching extraction

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -204,45 +204,11 @@ lemma geom_sum_eventually_zero
     intro k
     rw [hGeom, hS0, mul_zero]
 
-/-- If two families of nonzero complex scalars have equal power sums for all sufficiently
-large exponents, then their power sums agree for ALL exponents.
-
-Reduces to `geom_sum_eventually_zero` by concatenating the two families with
-coefficients `+1` and `−1`. -/
-lemma power_sums_eq_of_eventually_eq
-    {m : ℕ} (a b : Fin m → ℂ)
-    (ha : ∀ i, a i ≠ 0) (hb : ∀ i, b i ≠ 0)
-    {M : ℕ}
-    (hEv : ∀ N, M ≤ N → ∑ i, a i ^ N = ∑ i, b i ^ N) :
-    ∀ k, ∑ i, a i ^ k = ∑ i, b i ^ k := by
-  let w : Fin (m + m) → ℂ := Fin.append a b
-  let coeffs : Fin (m + m) → ℂ := Fin.append (fun _ => (1 : ℂ)) (fun _ => (-1 : ℂ))
-  have hw : ∀ i, w i ≠ 0 :=
-    fun i => Fin.addCases
-      (fun j => by show w (Fin.castAdd m j) ≠ 0
-                   rw [show w (Fin.castAdd m j) = a j from Fin.append_left a b j]; exact ha j)
-      (fun j => by show w (Fin.natAdd m j) ≠ 0
-                   rw [show w (Fin.natAdd m j) = b j from Fin.append_right a b j]; exact hb j)
-      i
-  have hDecomp : ∀ k, ∑ i, coeffs i * w i ^ k = (∑ i, a i ^ k) - (∑ i, b i ^ k) := by
-    intro k
-    simp only [coeffs, w, Fin.sum_univ_add, Fin.append_left, Fin.append_right,
-               one_mul, neg_one_mul, Finset.sum_neg_distrib, sub_eq_add_neg]
-  have hEvCombined : ∀ N, M ≤ N → ∑ i, coeffs i * w i ^ N = 0 := by
-    intro N hN
-    rw [hDecomp, sub_eq_zero]
-    exact hEv N hN
-  have hAll := geom_sum_eventually_zero w coeffs hw hEvCombined
-  intro k
-  have hk := hAll k
-  rw [hDecomp] at hk
-  exact sub_eq_zero.mp hk
-
 /-- If two nonzero finite weight families have equal power sums for all sufficiently
 large exponents, then their power sums agree for every exponent.
 
-This is the unequal-cardinality form of `power_sums_eq_of_eventually_eq`. The
-proof concatenates the two families with coefficients `+1` and `-1` and uses
+This is the unequal-cardinality form used to recover copy counts. The proof
+concatenates the two families with coefficients `+1` and `-1` and uses
 `geom_sum_eventually_zero`. -/
 lemma power_sums_eq_of_eventually_eq_hetero
     {m n : ℕ} (a : Fin m → ℂ) (b : Fin n → ℂ)
@@ -278,6 +244,20 @@ lemma power_sums_eq_of_eventually_eq_hetero
   have hk := hAll k
   rw [hDecomp] at hk
   exact sub_eq_zero.mp hk
+
+/-- If two equal-cardinality families of nonzero complex scalars have equal power sums for all
+sufficiently large exponents, then their power sums agree for every exponent.
+
+This is the equal-cardinality specialization of
+`power_sums_eq_of_eventually_eq_hetero`. -/
+lemma power_sums_eq_of_eventually_eq
+    {m : ℕ} (a b : Fin m → ℂ)
+    (ha : ∀ i, a i ≠ 0) (hb : ∀ i, b i ≠ 0)
+    {M : ℕ}
+    (hEv : ∀ N, M ≤ N → ∑ i, a i ^ N = ∑ i, b i ^ N) :
+    ∀ k, ∑ i, a i ^ k = ∑ i, b i ^ k := by
+  exact power_sums_eq_of_eventually_eq_hetero
+    (m := m) (n := m) a b ha hb (M := M) hEv
 
 /-- Eventual equality of coefficient power sums forces equality of multiplicities. -/
 theorem copies_eq_of_eventually_coeff_eq
@@ -353,7 +333,7 @@ theorem weight_multiset_eq_of_sameMPV_bnt
     ∀ j : Fin g,
       Finset.univ.val.map (S.weight j) =
         Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
-  obtain ⟨N0, hCoeffEventuallyEq⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
+  obtain ⟨_, hCoeffEventuallyEq⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
   have hCoeffAllPosEq := eventually_coeff_eq_implies_all_pos_eq S T hCopies hCoeffEventuallyEq
   exact weight_multiset_eq_of_copies_eq_of_coeff_eq S T hCopies hCoeffAllPosEq
 
@@ -375,7 +355,7 @@ theorem exists_copies_eq_and_weight_multiset_eq_of_sameMPV_bnt
       ∀ j : Fin g,
         Finset.univ.val.map (S.weight j) =
           Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
-  obtain ⟨N0, hCoeffEventuallyEq⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
+  obtain ⟨_, hCoeffEventuallyEq⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
   let hCopies : ∀ j, S.copies j = T.copies j :=
     copies_eq_of_eventually_coeff_eq S T hCoeffEventuallyEq
   refine ⟨hCopies, ?_⟩
@@ -716,6 +696,21 @@ structure SectorBasisMatching (P Q : SectorDecomposition d) where
       (cast (congr_arg (MPSTensor d) (dim_eq j)) (P.basis j))
       (Q.basis (perm j))
 
+private lemma sectorBasisMatchExists_of_fields
+    {P Q : SectorDecomposition d}
+    (perm : Fin P.basisCount ≃ Fin Q.basisCount)
+    (dim_eq : ∀ j : Fin P.basisCount, P.basisDim j = Q.basisDim (perm j))
+    (basis_equiv : ∀ j : Fin P.basisCount,
+      GaugePhaseEquiv (d := d)
+        (cast (congr_arg (MPSTensor d) (dim_eq j)) (P.basis j))
+        (Q.basis (perm j))) :
+    ∀ j : Fin P.basisCount,
+      ∃ hdim : P.basisDim j = Q.basisDim (perm j),
+        GaugePhaseEquiv (d := d)
+          (cast (congr_arg (MPSTensor d) hdim) (P.basis j))
+          (Q.basis (perm j)) :=
+  fun j => ⟨dim_eq j, basis_equiv j⟩
+
 namespace SectorBasisMatching
 
 variable {P Q : SectorDecomposition d}
@@ -728,7 +723,7 @@ lemma basis_match_exists (M : SectorBasisMatching P Q) :
         GaugePhaseEquiv (d := d)
           (cast (congr_arg (MPSTensor d) hdim) (P.basis j))
           (Q.basis (M.perm j)) :=
-  fun j => ⟨M.dim_eq j, M.basis_equiv j⟩
+  sectorBasisMatchExists_of_fields M.perm M.dim_eq M.basis_equiv
 
 /-- Build a `SectorBasisMatching` from a bijective index correspondence together with the
 per-block copy / dimension / gauge-phase data.
@@ -769,7 +764,7 @@ lemma basis_match_exists (M : SectorBasisPreMatching P Q) :
         GaugePhaseEquiv (d := d)
           (cast (congr_arg (MPSTensor d) hdim) (P.basis j))
           (Q.basis (M.perm j)) :=
-  fun j => ⟨M.dim_eq j, M.basis_equiv j⟩
+  sectorBasisMatchExists_of_fields M.perm M.dim_eq M.basis_equiv
 
 /-- Gauge-phase pre-matching gives the MPV phase-scaling relation for each basis block. -/
 lemma phase_match_exists (M : SectorBasisPreMatching P Q) :

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.SharedInfra.SectorDecomposition
 import TNLean.MPS.BNT.Basic
+import TNLean.MPS.BNT.PermutationRigidityPrimitive
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.Algebra.ScalarPowerSumIdentity
@@ -54,7 +55,7 @@ sector comparison theorems in this file, i.e.
 introduced in PR #844.  It is the predicate tracked by issue #876 as the output
 of a general BNT sector construction for the after-blocking canonical-form
 reduction, and is the linear-independence hypothesis expected by the
-after-blocking sector endpoint of issue #877. -/
+after-blocking sector comparison of issue #877. -/
 def HasBNTSectorData (P : SectorDecomposition d) : Prop :=
   ∃ N0 : ℕ, ∀ N > N0,
     LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N)
@@ -237,6 +238,67 @@ lemma power_sums_eq_of_eventually_eq
   rw [hDecomp] at hk
   exact sub_eq_zero.mp hk
 
+/-- If two nonzero finite weight families have equal power sums for all sufficiently
+large exponents, then their power sums agree for every exponent.
+
+This is the unequal-cardinality form of `power_sums_eq_of_eventually_eq`. The
+proof concatenates the two families with coefficients `+1` and `-1` and uses
+`geom_sum_eventually_zero`. -/
+lemma power_sums_eq_of_eventually_eq_hetero
+    {m n : ℕ} (a : Fin m → ℂ) (b : Fin n → ℂ)
+    (ha : ∀ i, a i ≠ 0) (hb : ∀ i, b i ≠ 0)
+    {M : ℕ}
+    (hEv : ∀ N, M ≤ N → ∑ i, a i ^ N = ∑ i, b i ^ N) :
+    ∀ k, ∑ i, a i ^ k = ∑ i, b i ^ k := by
+  let w : Fin (m + n) → ℂ := Fin.append a b
+  let coeffs : Fin (m + n) → ℂ := Fin.append (fun _ : Fin m => (1 : ℂ))
+    (fun _ : Fin n => (-1 : ℂ))
+  have hw : ∀ i, w i ≠ 0 :=
+    fun i => Fin.addCases
+      (fun j => by
+        show w (Fin.castAdd n j) ≠ 0
+        rw [show w (Fin.castAdd n j) = a j from Fin.append_left a b j]
+        exact ha j)
+      (fun j => by
+        show w (Fin.natAdd m j) ≠ 0
+        rw [show w (Fin.natAdd m j) = b j from Fin.append_right a b j]
+        exact hb j)
+      i
+  have hDecomp : ∀ k,
+      ∑ i, coeffs i * w i ^ k = (∑ i, a i ^ k) - (∑ i, b i ^ k) := by
+    intro k
+    simp only [coeffs, w, Fin.sum_univ_add, Fin.append_left, Fin.append_right,
+      one_mul, neg_one_mul, Finset.sum_neg_distrib, sub_eq_add_neg]
+  have hEvCombined : ∀ N, M ≤ N → ∑ i, coeffs i * w i ^ N = 0 := by
+    intro N hN
+    rw [hDecomp, sub_eq_zero]
+    exact hEv N hN
+  have hAll := geom_sum_eventually_zero w coeffs hw hEvCombined
+  intro k
+  have hk := hAll k
+  rw [hDecomp] at hk
+  exact sub_eq_zero.mp hk
+
+/-- Eventual equality of coefficient power sums forces equality of multiplicities. -/
+theorem copies_eq_of_eventually_coeff_eq
+    (S T : SectorWeightData g)
+    {N0 : ℕ}
+    (hEv : ∀ N > N0, ∀ j : Fin g, S.coeff N j = T.coeff N j) :
+    ∀ j : Fin g, S.copies j = T.copies j := by
+  intro j
+  have hEvj : ∀ N, N0 + 1 ≤ N →
+      ∑ q : Fin (S.copies j), (S.weight j q) ^ N =
+        ∑ q : Fin (T.copies j), (T.weight j q) ^ N := by
+    intro N hN
+    have h := hEv N (by omega) j
+    simpa only [SectorWeightData.coeff] using h
+  have h0 := power_sums_eq_of_eventually_eq_hetero
+    (S.weight j) (T.weight j)
+    (fun q => S.weight_ne_zero j q)
+    (fun q => T.weight_ne_zero j q)
+    (M := N0 + 1) hEvj 0
+  exact (Nat.cast_injective (R := ℂ)) (by simpa using h0)
+
 /-- Power-sum sequences from finite weight families that eventually agree also agree for all
 positive exponents.
 
@@ -292,6 +354,31 @@ theorem weight_multiset_eq_of_sameMPV_bnt
       Finset.univ.val.map (S.weight j) =
         Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
   obtain ⟨N0, hCoeffEventuallyEq⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
+  have hCoeffAllPosEq := eventually_coeff_eq_implies_all_pos_eq S T hCopies hCoeffEventuallyEq
+  exact weight_multiset_eq_of_copies_eq_of_coeff_eq S T hCopies hCoeffAllPosEq
+
+/-- **BNT coefficient comparison recovers multiplicities and weight multisets.**
+
+This variant does not assume matching copy counts. Eventual coefficient equality is
+first extrapolated to exponent `0`, which recovers the cardinalities of the two
+weight families, and then Newton--Girard recovers the multisets. -/
+theorem exists_copies_eq_and_weight_multiset_eq_of_sameMPV_bnt
+    {dim : Fin g → ℕ}
+    (basis : (j : Fin g) → MPSTensor d (dim j))
+    (S T : SectorWeightData g)
+    (hLI : ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun j : Fin g => mpvState (basis j) N))
+    (hSame : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      ∑ j : Fin g, S.coeff N j * mpv (basis j) σ =
+      ∑ j : Fin g, T.coeff N j * mpv (basis j) σ) :
+    ∃ hCopies : ∀ j, S.copies j = T.copies j,
+      ∀ j : Fin g,
+        Finset.univ.val.map (S.weight j) =
+          Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
+  obtain ⟨N0, hCoeffEventuallyEq⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
+  let hCopies : ∀ j, S.copies j = T.copies j :=
+    copies_eq_of_eventually_coeff_eq S T hCoeffEventuallyEq
+  refine ⟨hCopies, ?_⟩
   have hCoeffAllPosEq := eventually_coeff_eq_implies_all_pos_eq S T hCopies hCoeffEventuallyEq
   exact weight_multiset_eq_of_copies_eq_of_coeff_eq S T hCopies hCoeffAllPosEq
 
@@ -351,21 +438,21 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition
     _ = mpv (SectorDecomposition.mk g dim basis T).toTensor σ := hEqual N σ
     _ = ∑ j, T.coeff N j * mpv (basis j) σ := hExpandT
 
-/-- **Heterogeneous sector comparison reduces to the shared-basis case after phase matching.**
+/-- **Phase matching and total MPV equality recover copy counts and sector weights.**
 
-Assume two sector decompositions `P` and `Q` have basis blocks matched by a permutation `perm`,
-matching copy counts, and per-basis MPV relations
-`mpv (Q.basis (perm j)) σ = ζ_j^N * mpv (P.basis j) σ`. If the total tensors are
-`SameMPV₂`, then after absorbing the phases `ζ_j` into the sector weights on the `Q` side,
-the per-basis sector weight multisets agree.
+Assume two sector decompositions `P` and `Q` have basis blocks matched by a
+permutation `perm`, and the matched basis MPVs differ by nonzero phase powers.
+If the total tensors are `SameMPV₂` and the basis of `P` is eventually linearly
+independent, then the copy counts are forced to agree. After absorbing the same
+phases into the weights of `Q`, the per-basis sector weight multisets agree.
 
-This is the algebraic core of the heterogeneous BNT-sector comparison: once a
-future theorem supplies the basis matching and the phase factors, the remaining
-comparison is exactly the shared-basis theorem above. -/
-theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
+This is the coefficient-extraction part of the heterogeneous sector comparison:
+copy alignment is not an input, but is recovered from the exponent-zero case of
+the power-sum identity after eventual coefficient equality has been extrapolated
+to all exponents. -/
+theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies
     (P Q : SectorDecomposition d)
     (perm : Fin P.basisCount ≃ Fin Q.basisCount)
-    (hCopies : ∀ j : Fin P.basisCount, P.copies j = Q.copies (perm j))
     (hPhase : ∀ j : Fin P.basisCount,
       ∃ ζ : ℂ, ζ ≠ 0 ∧
         ∀ (N : ℕ) (σ : Fin N → Fin d),
@@ -373,12 +460,13 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
     (hLI : ∃ N0 : ℕ, ∀ N > N0,
       LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N))
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ ζ : Fin P.basisCount → ℂ,
-      (∀ j, ζ j ≠ 0) ∧
-      ∀ j : Fin P.basisCount,
-        Finset.univ.val.map (P.weight j) =
-          Finset.univ.val.map
-            (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+    ∃ hCopies : ∀ j : Fin P.basisCount, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
   classical
   let ζFn : Fin P.basisCount → ℂ := fun j => (hPhase j).choose
   have hζ_ne : ∀ j : Fin P.basisCount, ζFn j ≠ 0 :=
@@ -436,22 +524,64 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
   have hEqual' : SameMPV₂ P.toTensor Q'.toTensor := by
     intro N σ
     exact (hEqual N σ).trans (hTransport N σ).symm
-  have hCopies' : ∀ j : Fin P.basisCount, P.sectors.copies j = T.copies j := by
-    intro j
-    simpa [T] using hCopies j
-  have hMultiset :
+  have hRecovered :
+      ∃ hCopies' : ∀ j : Fin P.basisCount, P.sectors.copies j = T.copies j,
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies' j) q)) :=
+    SectorWeightData.exists_copies_eq_and_weight_multiset_eq_of_sameMPV_bnt
+      (basis := P.basis) (S := P.sectors) (T := T) hLI (by
+        intro N σ
+        have hExpandP := P.mpv_toTensor_eq_sum_coeff σ (N := N)
+        have hExpandQ' := Q'.mpv_toTensor_eq_sum_coeff σ (N := N)
+        calc ∑ j, P.sectors.coeff N j * mpv (P.basis j) σ
+            = mpv P.toTensor σ := hExpandP.symm
+          _ = mpv Q'.toTensor σ := hEqual' N σ
+          _ = ∑ j, T.coeff N j * mpv (P.basis j) σ := hExpandQ')
+  obtain ⟨hCopies', hMultiset⟩ := hRecovered
+  let hCopies : ∀ j : Fin P.basisCount, P.copies j = Q.copies (perm j) := fun j => by
+    change P.sectors.copies j = T.copies j
+    exact hCopies' j
+  refine ⟨hCopies, ζFn, hζ_ne, ?_⟩
+  intro j
+  have hproof : hCopies' j = hCopies j := Subsingleton.elim _ _
+  simpa [T, hproof] using hMultiset j
+
+/-- **Heterogeneous sector comparison reduces to the shared-basis case after phase matching.**
+
+Assume two sector decompositions `P` and `Q` have basis blocks matched by a permutation `perm`,
+matching copy counts, and per-basis MPV relations
+`mpv (Q.basis (perm j)) σ = ζ_j^N * mpv (P.basis j) σ`. If the total tensors are
+`SameMPV₂`, then after absorbing the phases `ζ_j` into the sector weights on the `Q` side,
+the per-basis sector weight multisets agree. -/
+theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
+    (P Q : SectorDecomposition d)
+    (perm : Fin P.basisCount ≃ Fin Q.basisCount)
+    (hCopies : ∀ j : Fin P.basisCount, P.copies j = Q.copies (perm j))
+    (hPhase : ∀ j : Fin P.basisCount,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (Q.basis (perm j)) σ = ζ ^ N * mpv (P.basis j) σ)
+    (hLI : ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N))
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ ζ : Fin P.basisCount → ℂ,
+      (∀ j, ζ j ≠ 0) ∧
       ∀ j : Fin P.basisCount,
         Finset.univ.val.map (P.weight j) =
-          Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies' j) q)) :=
-      fundamentalTheorem_equalMPV_sectorDecomposition
-        (basis := P.basis) (S := P.sectors) (T := T) hCopies' hLI hEqual'
-  refine ⟨ζFn, hζ_ne, ?_⟩
+          Finset.univ.val.map
+            (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  obtain ⟨hCopies', ζ, hζ_ne, hMultiset⟩ :=
+    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies
+      P Q perm hPhase hLI hEqual
+  refine ⟨ζ, hζ_ne, ?_⟩
   intro j
-  simpa [T] using hMultiset j
+  have hproof : hCopies' j = hCopies j := Subsingleton.elim _ _
+  simpa [hproof] using hMultiset j
 
 /-- **Cast-compatible MPV scaling implies the phase-matched heterogeneous sector comparison.**
 
-This intermediate theorem isolates the weaker data actually consumed by the
+This theorem isolates the weaker data actually consumed by the
 phase-absorption argument: after matching basis dimensions, each block pair
 only needs a nonzero phase `ζ` relating the MPVs of the matched basis tensors. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis
@@ -532,13 +662,30 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
 The matched-basis theorems above consume the matching data as four separate
 hypotheses (permutation, copy alignment, per-block dimension equality, and
 per-block gauge-phase equivalence). The `SectorBasisMatching` structure
-records these as a single witness, so that any future theorem producing the
-matching from `SameMPV₂` — the remaining step for the unconditional equal-case
+records these as a single witness. A theorem deriving this witness from
+`SameMPV₂` supplies the remaining step for the unconditional equal-case
 Fundamental Theorem, following from the general basis-of-normal-tensors
-construction — can be supplied as a single argument, and downstream results
-(such as the final global Corollary IV.5 construction) depend only on this
-structure.
+construction; the final global Corollary IV.5 construction can then depend only
+on this structure.
 -/
+
+/-- Basis matching before sector multiplicities have been recovered.
+
+This structure records the part of the heterogeneous BNT comparison supplied by
+the overlap-dichotomy argument: a permutation of basis blocks, equality of their
+bond dimensions, and gauge-phase equivalence of the matched blocks. It does not
+include copy-count alignment; that alignment is recovered from total MPV equality
+by `SectorBasisPreMatching.exists_sectorBasisMatching_of_sameMPV`. -/
+structure SectorBasisPreMatching (P Q : SectorDecomposition d) where
+  /-- Permutation matching basis indices of `P` and `Q`. -/
+  perm : Fin P.basisCount ≃ Fin Q.basisCount
+  /-- Matched basis blocks share the same bond dimension. -/
+  dim_eq : ∀ j : Fin P.basisCount, P.basisDim j = Q.basisDim (perm j)
+  /-- Matched basis blocks are gauge-phase equivalent after dimension transport. -/
+  basis_equiv : ∀ j : Fin P.basisCount,
+    GaugePhaseEquiv (d := d)
+      (cast (congr_arg (MPSTensor d) (dim_eq j)) (P.basis j))
+      (Q.basis (perm j))
 
 /-- Bundled witness data matching two sector decompositions block-by-block.
 
@@ -611,11 +758,129 @@ noncomputable def ofBijective
 
 end SectorBasisMatching
 
+namespace SectorBasisPreMatching
+
+variable {P Q : SectorDecomposition d}
+
+/-- Reformulate pre-matching data in the existential form used by the matched-basis theorem. -/
+lemma basis_match_exists (M : SectorBasisPreMatching P Q) :
+    ∀ j : Fin P.basisCount,
+      ∃ hdim : P.basisDim j = Q.basisDim (M.perm j),
+        GaugePhaseEquiv (d := d)
+          (cast (congr_arg (MPSTensor d) hdim) (P.basis j))
+          (Q.basis (M.perm j)) :=
+  fun j => ⟨M.dim_eq j, M.basis_equiv j⟩
+
+/-- Gauge-phase pre-matching gives the MPV phase-scaling relation for each basis block. -/
+lemma phase_match_exists (M : SectorBasisPreMatching P Q) :
+    ∀ j : Fin P.basisCount,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (Q.basis (M.perm j)) σ = ζ ^ N * mpv (P.basis j) σ := by
+  intro j
+  obtain ⟨X, ζ, hζne, hX⟩ := M.basis_equiv j
+  refine ⟨ζ, hζne, ?_⟩
+  intro N σ
+  rw [mpv_eq_pow_mul_of_gaugePhase _ _ X ζ hX N σ,
+    mpv_cast_dim (M.dim_eq j) (P.basis j) N σ]
+
+/-- Promote a basis pre-matching to a full sector basis matching.
+
+The new information is the copy-count equality. It follows from total MPV equality
+and BNT linear independence by recovering the exponent-zero power sums for the
+matched sector coefficients. -/
+theorem exists_sectorBasisMatching_of_sameMPV
+    (M : SectorBasisPreMatching P Q)
+    (hLI : HasBNTSectorData P)
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ M' : SectorBasisMatching P Q, M'.perm = M.perm := by
+  obtain ⟨hCopies, _ζ, _hζ_ne, _hMultiset⟩ :=
+    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies
+      P Q M.perm M.phase_match_exists hLI hEqual
+  refine ⟨{
+    perm := M.perm
+    copies_eq := hCopies
+    dim_eq := M.dim_eq
+    basis_equiv := M.basis_equiv
+  }, rfl⟩
+
+end SectorBasisPreMatching
+
+/-- **Heterogeneous sector comparison from a basis pre-matching.**
+
+A pre-matching supplies the permutation, bond-dimension equalities, and
+gauge-phase equivalences of the basis blocks. Total MPV equality and BNT linear
+independence then recover the missing copy-count equalities and the phase-adjusted
+sector weight multisets. -/
+theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_preMatching
+    {P Q : SectorDecomposition d}
+    (M : SectorBasisPreMatching P Q)
+    (hLI : HasBNTSectorData P)
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ hCopies : ∀ j : Fin P.basisCount, P.copies j = Q.copies (M.perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (M.perm j) (Fin.cast (hCopies j) q)) :=
+  fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies
+    P Q M.perm M.phase_match_exists hLI hEqual
+
+/-- Produce a sector basis matching from the primitive overlap-rigidity hypotheses.
+
+The overlap-rigidity theorem gives the basis permutation, dimension equalities,
+and gauge-phase equivalences. The preceding pre-matching result then recovers
+the sector copy-count alignment from total MPV equality. -/
+theorem exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV
+    (P Q : SectorDecomposition d)
+    [∀ j : Fin P.basisCount, NeZero (P.basisDim j)]
+    [∀ k : Fin Q.basisCount, NeZero (Q.basisDim k)]
+    (hP_inj : ∀ j, IsInjective (P.basis j))
+    (hQ_inj : ∀ k, IsInjective (Q.basis k))
+    (hP_norm : ∀ j, (∑ i : Fin d, (P.basis j i)ᴴ * (P.basis j i)) = 1)
+    (hQ_norm : ∀ k, (∑ i : Fin d, (Q.basis k i)ᴴ * (Q.basis k i)) = 1)
+    (hP_self : ∀ j,
+      Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
+        Filter.atTop (nhds (1 : ℂ)))
+    (hP_off : ∀ i j, i ≠ j →
+      Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
+        Filter.atTop (nhds 0))
+    (hQ_self : ∀ k,
+      Filter.Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis k) N)
+        Filter.atTop (nhds (1 : ℂ)))
+    (hQ_off : ∀ k l, k ≠ l →
+      Filter.Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis l) N)
+        Filter.atTop (nhds 0))
+    (hspan : ∀ N,
+      Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
+        mpvState (d := d) (P.basis j) N)) =
+      Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
+        mpvState (d := d) (Q.basis k) N)))
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    Nonempty (SectorBasisMatching P Q) := by
+  obtain ⟨_hCount, perm, hBasis⟩ :=
+    exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho
+      (A := P.basis) (B := Q.basis)
+      hP_inj hQ_inj hP_norm hQ_norm hP_self hP_off hQ_self hQ_off hspan
+  let M₀ : SectorBasisPreMatching P Q := {
+    perm := perm
+    dim_eq := fun j => (hBasis j).choose
+    basis_equiv := fun j => (hBasis j).choose_spec
+  }
+  have hLI : HasBNTSectorData P := by
+    have hEventually := eventually_linearIndependent_of_overlap_tendsto_orthonormal
+      P.basis hP_self hP_off
+    obtain ⟨N0, hN0⟩ := Filter.eventually_atTop.1 hEventually
+    exact ⟨N0, fun N hN => hN0 N (le_of_lt hN)⟩
+  obtain ⟨M, _hperm⟩ := M₀.exists_sectorBasisMatching_of_sameMPV hLI hEqual
+  exact ⟨M⟩
+
 /-- **Heterogeneous sector comparison via a bundled basis matching witness.**
 
 Corollary of `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`
 obtained by supplying the matching data in bundled form as a `SectorBasisMatching`. Once a
-future theorem constructs a `SectorBasisMatching P Q` from arbitrary `SameMPV₂ P.toTensor
+theorem constructs a `SectorBasisMatching P Q` from arbitrary `SameMPV₂ P.toTensor
 Q.toTensor` (the remaining combinatorial step, following from the general
 basis-of-normal-tensors construction in #876), this result completes the Gap §1
 heterogeneous sector comparison with the matching data gathered into a single argument. -/

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -494,6 +494,89 @@ single weighted block.
 	this bundle.
 \end{definition}
 
+\begin{definition}[Sector basis pre-matching]%
+\label{def:sector_basis_pre_matching}
+	\lean{MPSTensor.SectorBasisPreMatching}
+	\leanok
+	\uses{def:paper_sector_data, def:gauge_phase_equiv}
+	A \emph{sector basis pre-matching} between sector decompositions $P$
+	and $Q$ consists of a permutation of their basis blocks, equality of the
+	matched bond dimensions, and gauge-phase equivalence of each matched pair.
+	It does not include the copy-count equality; that equality is recovered
+	from total MPV equality and BNT linear independence in
+	Theorem~\ref{thm:sector_basis_pre_matching_to_matching}.
+\end{definition}
+
+\begin{theorem}[Phase-matched comparison recovers copy counts]%
+\label{thm:route_b_hetero_phase_match_copies}
+	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies}
+	\leanok
+	\uses{thm:route_b_equal}
+	Let $P$ and $Q$ be sector decompositions whose basis blocks are matched by
+	a permutation and whose matched MPVs differ by nonzero phase powers. If
+	the total MPV families agree and the basis MPVs of $P$ are eventually
+	linearly independent, then the matched copy counts agree. After absorbing
+	the phases into the weights of $Q$, the corresponding sector-weight
+	multisets agree.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:route_b_equal}
+	Absorb the phase powers into the sector weights of $Q$ and write both
+	decompositions over the basis of $P$. Linear independence gives eventual
+	equality of the coefficient power sums. The telescoping identity for
+	finite sums of nonzero geometric sequences extends this equality to
+	exponent $0$, which gives equality of the copy counts. The positive
+	exponents then give equality of the weight multisets by the same
+	Newton--Girard argument as Theorem~\ref{thm:route_b_equal}.
+\end{proof}
+
+\begin{theorem}[A pre-matching gives a sector basis matching]%
+\label{thm:sector_basis_pre_matching_to_matching}
+	\lean{MPSTensor.SectorBasisPreMatching.exists_sectorBasisMatching_of_sameMPV}
+	\leanok
+	\uses{def:sector_basis_pre_matching, def:sector_basis_matching,
+		thm:route_b_hetero_phase_match_copies}
+	Let $M$ be a sector basis pre-matching between $P$ and $Q$. If the total
+	MPV families agree and the basis MPVs of $P$ are eventually linearly
+	independent, then the copy-count equalities recovered by
+	Theorem~\ref{thm:route_b_hetero_phase_match_copies} turn $M$ into a full
+	sector basis matching.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:route_b_hetero_phase_match_copies}
+	Gauge-phase equivalence gives the required phase-scaling identities for
+	the matched basis MPVs. Theorem~\ref{thm:route_b_hetero_phase_match_copies}
+	recovers the missing copy-count equalities, which are precisely the extra
+	fields needed for Definition~\ref{def:sector_basis_matching}.
+\end{proof}
+
+\begin{theorem}[Overlap rigidity gives a sector basis matching]%
+\label{thm:sector_basis_matching_from_overlap_ortho_span}
+	\lean{MPSTensor.exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV}
+	\leanok
+	\uses{thm:bnt_perm_simple, thm:sector_basis_pre_matching_to_matching}
+	Assume the basis blocks of two sector decompositions are trace-preserving
+	and injective, have asymptotically orthonormal overlaps within each family,
+	and span the same MPV subspace at every system size. If the total MPV
+	families also agree, then there exists a sector basis matching between the
+	two decompositions.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:bnt_perm_simple, thm:sector_basis_pre_matching_to_matching}
+	The permutation-rigidity theorem for bases of normal tensors gives a
+	permutation, the matched bond dimensions, and the gauge-phase equivalences
+	of the basis blocks, hence a sector basis pre-matching. Asymptotic
+	orthonormality gives the BNT linear-independence condition, and
+	Theorem~\ref{thm:sector_basis_pre_matching_to_matching} recovers the
+	copy-count equalities from equality of the total MPV families.
+\end{proof}
+
 \begin{theorem}[Heterogeneous sector comparison via a bundled matching witness]%
 \label{thm:route_b_hetero_sector_matching}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching}
@@ -570,16 +653,17 @@ single weighted block.
 		      separated family has the required sector weights; the separated
 		      primitive-normal case already gives BNT linear independence by
 		      Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_separated}; and
-		\item a witness-producing matched-basis theorem for heterogeneous
-		      sector decompositions: the algebraic reduction after a basis
-		      matching is formalized in
+		\item a matched-basis theorem for heterogeneous sector decompositions:
+		      the algebraic reduction after a basis matching is formalized in
 		      Theorems~\ref{thm:route_b_hetero_phase_match},~\ref{thm:route_b_hetero_matched_basis},
-		      and~\ref{thm:route_b_hetero_sector_matching} (the latter
-		      consuming a bundled matching witness,
-		      Definition~\ref{def:sector_basis_matching}),
-		      but one still needs a theorem that constructs a sector basis
-		      matching witness directly from equality of the total MPV
-		      families.
+		      and~\ref{thm:route_b_hetero_sector_matching}.  Copy alignment is now
+		      recovered from a basis pre-matching by
+		      Theorem~\ref{thm:sector_basis_pre_matching_to_matching}, and the
+		      primitive overlap-rigidity hypotheses produce such a matching by
+		      Theorem~\ref{thm:sector_basis_matching_from_overlap_ortho_span}.  The
+		      remaining task is to derive those span and overlap hypotheses from
+		      arbitrary equal-MPV sector decompositions produced by the one-sided
+		      BNT construction.
 	\end{enumerate}
 	Once these two ingredients are in place, the final global gauge matrix
 	of Corollary~IV.5 is obtained by the same phase-absorption and blockwise

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -511,7 +511,7 @@ single weighted block.
 \label{thm:route_b_hetero_phase_match_copies}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies}
 	\leanok
-	\uses{thm:route_b_equal}
+	\uses{def:paper_sector_data}
 	Let $P$ and $Q$ be sector decompositions whose basis blocks are matched by
 	a permutation and whose matched MPVs differ by nonzero phase powers. If
 	the total MPV families agree and the basis MPVs of $P$ are eventually
@@ -536,8 +536,7 @@ single weighted block.
 \label{thm:sector_basis_pre_matching_to_matching}
 	\lean{MPSTensor.SectorBasisPreMatching.exists_sectorBasisMatching_of_sameMPV}
 	\leanok
-	\uses{def:sector_basis_pre_matching, def:sector_basis_matching,
-		thm:route_b_hetero_phase_match_copies}
+	\uses{def:sector_basis_pre_matching, def:sector_basis_matching}
 	Let $M$ be a sector basis pre-matching between $P$ and $Q$. If the total
 	MPV families agree and the basis MPVs of $P$ are eventually linearly
 	independent, then the copy-count equalities recovered by
@@ -554,16 +553,37 @@ single weighted block.
 	fields needed for Definition~\ref{def:sector_basis_matching}.
 \end{proof}
 
+\begin{theorem}[Heterogeneous sector comparison from a pre-matching]%
+\label{thm:route_b_hetero_pre_matching}
+	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_preMatching}
+	\leanok
+	\uses{def:sector_basis_pre_matching, def:paper_sector_data}
+	Let $M$ be a sector basis pre-matching between sector decompositions $P$
+	and $Q$. If the total MPV families agree and the basis MPVs of $P$ are
+	eventually linearly independent, then the matched copy counts agree, and
+	after absorbing the gauge phases into the weights of $Q$ the corresponding
+	sector-weight multisets agree.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:route_b_hetero_phase_match_copies}
+	The gauge-phase equivalences in the pre-matching give the phase-scaling
+	identities for the matched basis MPVs.
+	Theorem~\ref{thm:route_b_hetero_phase_match_copies} then gives the
+	copy-count equalities and the phase-adjusted multiset equalities.
+\end{proof}
+
 \begin{theorem}[Overlap rigidity gives a sector basis matching]%
 \label{thm:sector_basis_matching_from_overlap_ortho_span}
 	\lean{MPSTensor.exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV}
 	\leanok
-	\uses{thm:bnt_perm_simple, thm:sector_basis_pre_matching_to_matching}
-	Assume the basis blocks of two sector decompositions are trace-preserving
-	and injective, have asymptotically orthonormal overlaps within each family,
-	and span the same MPV subspace at every system size. If the total MPV
-	families also agree, then there exists a sector basis matching between the
-	two decompositions.
+	\uses{def:paper_sector_data, def:sector_basis_matching, def:mpv_overlap}
+	Assume the basis blocks of two sector decompositions have nonzero bond
+	dimensions, are trace-preserving and injective, have asymptotically
+	orthonormal overlaps within each family, and span the same MPV subspace at
+	every system size. If the total MPV families also agree, then there exists a
+	sector basis matching between the two decompositions.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

Advances #860 for parent #652 and the downstream #877 assembly step.

- Adds a heterogeneous power-sum comparison that recovers sector copy counts from eventual coefficient equality, rather than assuming copy alignment.
- Adds `SectorBasisPreMatching`, representing the basis permutation/dimension/gauge-phase data supplied by the BNT overlap-dichotomy route before sector multiplicities are known.
- Promotes a pre-matching plus `HasBNTSectorData` and `SameMPV₂ P.toTensor Q.toTensor` to a full `SectorBasisMatching`, so the PR #884 matched-basis theorem can apply.
- Adds an overlap-rigidity theorem that combines the existing BNT permutation-rigidity result with copy-count recovery to produce a sector basis matching under the primitive overlap/span hypotheses.
- Updates the blueprint Gap §1 discussion with the new pre-matching and copy-alignment layer.

## Scope

This does **not** close #860 outright. The remaining paper-level extraction step is to derive the required span/overlap hypotheses (or equivalent pre-matching data) from arbitrary equal-MPV sector decompositions produced by the one-sided BNT construction.

Ready for an orchestrator simplification/cleanup pass before merge.

## Validation

- `lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`
- `lake build TNLean.MPS.FundamentalTheorem.SectorDecomposition TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- `lake build TNLean` (passes; only pre-existing `sorry` and long-line warnings replayed)
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- forbidden-token scan on touched files for `sorry|admit|axiom|native_decide|unsafe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Lean theorems that recover sector multiplicities/copy alignment from eventual coefficient equality and wires this into heterogeneous sector-matching extraction; mistakes here could invalidate later Fundamental Theorem steps even though it’s proof-only code.
> 
> **Overview**
> Extends sector-decomposition comparison so heterogeneous phase-matched MPV equality no longer assumes copy-count alignment: it now *derives* `copies` equality by extrapolating eventual coefficient/power-sum equality down to exponent `0`, then recovers weight multisets.
> 
> Introduces `SectorBasisPreMatching` (perm + dimension equality + gauge-phase equivalence, but no multiplicities) and shows how `SameMPV₂` + `HasBNTSectorData` promotes a pre-matching to a full `SectorBasisMatching`; also adds an overlap-rigidity corollary that builds this matching from the primitive overlap/span hypotheses.
> 
> Updates the blueprint (ch11 assembly) to document the new pre-matching layer and the new copy-count-recovery theorems in the Gap §1 route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e62b1cda877f758afd69a7206be370dc13be01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->