### PR TITLE
feat(MPS/CanonicalForm): reduce projection span to product-word span (#911)

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -16,10 +16,13 @@ dependent direct sum lie in the span of a family of matrices and a boundary
 matrix commutes with that family, then it
 commutes with the projections and hence has no off-block entries.
 
-The remaining CF/BNT-specific step is to prove that the sector projections lie
-in the finite word span of the assembled tensor.  Once that finite-span input is
-available, `MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan` turns
-long-word commutation of the assembled boundary matrix into block diagonality.
+The file also records a finite-span bridge: if the simultaneous block word
+tuples span the full product algebra, then the sector projections lie in the
+finite word span of the assembled tensor.  The remaining paper-level CF/BNT input
+is to derive that product-word span from the separated canonical-form/BNT
+hypotheses.  Once the projection-span input is available,
+`MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan` turns long-word
+commutation of the assembled boundary matrix into block diagonality.
 -/
 
 open scoped Matrix BigOperators
@@ -27,6 +30,9 @@ open scoped Matrix BigOperators
 namespace Matrix
 
 variable {ι α : Type*} {n : ι → Type*}
+
+section CommutesSpan
+
 variable [Fintype ι] [DecidableEq ι]
 variable [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
 
@@ -59,11 +65,150 @@ theorem isBlockDiagonal'_of_commutes_span_blockProjection
         simp only [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, hM]
   exact hcomm_span (blockProjection (n := n) (R := ℂ) k) (hProj k)
 
+end CommutesSpan
+
+section ProjectionSpan
+
+variable [DecidableEq ι]
+variable [(i : ι) → DecidableEq (n i)]
+
+/-- If a family of block tuples spans the full product algebra, then the span of
+its nonzero componentwise scalar multiples, embedded as dependent block-diagonal
+matrices, contains each sector projection.
+
+This is the algebraic finite-span bridge used for assembled tensors: after a
+finite word-tuple span theorem supplies the full product algebra
+`(i : ι) → Matrix (n i) (n i) ℂ`, the diagonal embedding of those same word tuples
+contains the projections onto the individual direct-sum sectors. -/
+theorem blockProjection_mem_span_blockDiagonal'_of_pi_span_eq_top
+    {α : Type*} {T : α → (i : ι) → Matrix (n i) (n i) ℂ} {c : ι → ℂ}
+    (hc : ∀ i : ι, c i ≠ 0)
+    (hSpan : Submodule.span ℂ (Set.range T) =
+      (⊤ : Submodule ℂ ((i : ι) → Matrix (n i) (n i) ℂ)))
+    (k : ι) :
+    blockProjection (n := n) (R := ℂ) k ∈
+      Submodule.span ℂ (Set.range fun a : α =>
+        Matrix.blockDiagonal' fun i : ι => c i • T a i) := by
+  classical
+  let target : (i : ι) → Matrix (n i) (n i) ℂ :=
+    fun i => if i = k then (c i)⁻¹ • 1 else 0
+  let L : ((i : ι) → Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      Matrix ((i : ι) × n i) ((i : ι) × n i) ℂ := {
+    toFun := fun M => Matrix.blockDiagonal' fun i : ι => c i • M i
+    map_add' := by
+      intro M N
+      ext x y
+      rcases x with ⟨i, p⟩
+      rcases y with ⟨j, q⟩
+      by_cases hij : i = j
+      · subst j
+        simp [Pi.add_apply, smul_add]
+      · simp [Matrix.blockDiagonal'_apply_ne _ p q hij]
+    map_smul' := by
+      intro a M
+      ext x y
+      rcases x with ⟨i, p⟩
+      rcases y with ⟨j, q⟩
+      by_cases hij : i = j
+      · subst j
+        simp [smul_smul, mul_comm, mul_left_comm]
+      · simp [Matrix.blockDiagonal'_apply_ne _ p q hij] }
+  have htarget : target ∈ Submodule.span ℂ (Set.range T) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hmap_span : ∀ M ∈ Submodule.span ℂ (Set.range T),
+      L M ∈ Submodule.span ℂ (Set.range fun a : α =>
+        Matrix.blockDiagonal' fun i : ι => c i • T a i) := by
+    intro M hM
+    induction hM using Submodule.span_induction with
+    | mem M hM =>
+        rcases hM with ⟨a, rfl⟩
+        exact Submodule.subset_span ⟨a, rfl⟩
+    | zero =>
+        have hL0 : L 0 = 0 := by
+          ext x y
+          rcases x with ⟨i, p⟩
+          rcases y with ⟨j, q⟩
+          by_cases hij : i = j
+          · subst j
+            simp [L]
+          · simp [L, Matrix.blockDiagonal'_apply_ne _ p q hij]
+        rw [hL0]
+        exact Submodule.zero_mem _
+    | add M N _ _ hM hN => simpa [L.map_add] using Submodule.add_mem _ hM hN
+    | smul a M _ hM => simpa [L.map_smul] using Submodule.smul_mem _ a hM
+  have hL_target : L target = blockProjection (n := n) (R := ℂ) k := by
+    ext x y
+    rcases x with ⟨i, p⟩
+    rcases y with ⟨j, q⟩
+    by_cases hij : i = j
+    · subst j
+      by_cases hik : i = k
+      · subst k
+        simp [L, target, blockProjection, hc i]
+      · simp [L, target, blockProjection, hik]
+    · simp [L, blockProjection, Matrix.blockDiagonal'_apply_ne _ p q hij]
+  simpa [L, hL_target] using hmap_span target htarget
+
+end ProjectionSpan
+
 end Matrix
 
 namespace MPSTensor
 
 variable {d r : ℕ} {dim : Fin r → ℕ}
+
+/-- Finite product-word span gives the projection-span input for the assembled tensor.
+
+Assume that the simultaneous length-`m` word evaluations
+`ω ↦ (k ↦ evalWord (A k) (List.ofFn ω))` span the full product algebra of the
+blocks.  If all assembly weights are nonzero, then after pulling the length-`m`
+word products of `toTensorFromBlocks μ A` back to the dependent direct-sum basis,
+their span contains every sector projection.
+
+The remaining paper-level CF/BNT task is to prove the displayed product-word span
+hypothesis from the separated canonical-form/BNT assumptions. -/
+theorem blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) {m : ℕ}
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    (hSpan : Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ))) :
+    ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω))) := by
+  classical
+  intro k
+  let e : ((k : Fin r) × Fin (dim k)) ≃ Fin (∑ k : Fin r, dim k) := finSigmaFinEquiv
+  have hproj :
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+          Matrix.blockDiagonal' fun j : Fin r =>
+            (μ j) ^ m • evalWord (A j) (List.ofFn ω)) := by
+    exact Matrix.blockProjection_mem_span_blockDiagonal'_of_pi_span_eq_top
+      (n := fun k : Fin r => Fin (dim k))
+      (T := fun ω : Fin m → Fin d => fun j : Fin r => evalWord (A j) (List.ofFn ω))
+      (c := fun j : Fin r => (μ j) ^ m)
+      (fun j => pow_ne_zero m (hμ j)) hSpan k
+  have hgen : (fun ω : Fin m → Fin d =>
+        Matrix.reindex e.symm e.symm
+          (evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω))) =
+      (fun ω : Fin m → Fin d =>
+        Matrix.blockDiagonal' fun j : Fin r =>
+          (μ j) ^ m • evalWord (A j) (List.ofFn ω)) := by
+    funext ω
+    rw [evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal]
+    ext x y
+    simp [e, Matrix.reindex_apply]
+  change Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+    Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+      Matrix.reindex e.symm e.symm
+        (evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω)))
+  rw [hgen]
+  exact hproj
 
 /-- Reindexed word-span version of the block-diagonal commutant criterion.
 
@@ -99,6 +244,32 @@ theorem isBlockDiagonal'_of_commutes_reindexed_wordSpan
   have h := congrArg (Matrix.reindex e.symm e.symm) (hComm ω)
   simpa [e, Matrix.reindex_apply, Matrix.submatrix_mul_equiv] using h
 
+/-- Assembled-tensor commutant criterion using a finite product-word span
+hypothesis instead of an explicit projection-span hypothesis.
+
+The hypothesis says that the simultaneous block word evaluations of length `m`
+span the full product algebra.  The previous projection-span lemma turns this
+into the sector-projection input required by
+`isBlockDiagonal'_of_commutes_reindexed_wordSpan`. -/
+theorem isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) {m : ℕ}
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    (hSpan : Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)))
+    {X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ}
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω) =
+        evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω) * X) :
+    Matrix.IsBlockDiagonal'
+      (Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm X) := by
+  exact isBlockDiagonal'_of_commutes_reindexed_wordSpan
+    (B := toTensorFromBlocks (d := d) (μ := μ) A)
+    (blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top
+      (d := d) (dim := dim) μ A hμ hSpan)
+    hComm
+
 /-- Entrywise off-block-zero corollary of
 `isBlockDiagonal'_of_commutes_reindexed_wordSpan`.
 
@@ -118,6 +289,25 @@ theorem offBlock_zero_of_commutes_reindexed_wordSpan
     {i j : Fin r} (hij : i ≠ j) (a : Fin (dim i)) (b : Fin (dim j)) :
     (Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm X) ⟨i, a⟩ ⟨j, b⟩ = 0 := by
   have hBD := isBlockDiagonal'_of_commutes_reindexed_wordSpan (B := B) hProj hComm
+  exact (Matrix.isBlockDiagonal'_iff_offBlock_zero _).mp hBD hij a b
+
+/-- Entrywise off-block-zero form of the assembled-tensor criterion with a finite
+product-word span hypothesis. -/
+theorem offBlock_zero_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) {m : ℕ}
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    (hSpan : Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)))
+    {X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ}
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω) =
+        evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω) * X)
+    {i j : Fin r} (hij : i ≠ j) (a : Fin (dim i)) (b : Fin (dim j)) :
+    (Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm X) ⟨i, a⟩ ⟨j, b⟩ = 0 := by
+  have hBD := isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top
+    (d := d) (dim := dim) μ A hμ hSpan hComm
   exact (Matrix.isBlockDiagonal'_iff_offBlock_zero _).mp hBD hij a b
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -81,7 +81,7 @@ finite word-tuple span theorem supplies the full product algebra
 `(i : ι) → Matrix (n i) (n i) ℂ`, the diagonal embedding of those same word tuples
 contains the projections onto the individual direct-sum sectors. -/
 theorem blockProjection_mem_span_blockDiagonal'_of_pi_span_eq_top
-    {α : Type*} {T : α → (i : ι) → Matrix (n i) (n i) ℂ} {c : ι → ℂ}
+    {T : α → (i : ι) → Matrix (n i) (n i) ℂ} {c : ι → ℂ}
     (hc : ∀ i : ι, c i ≠ 0)
     (hSpan : Submodule.span ℂ (Set.range T) =
       (⊤ : Submodule ℂ ((i : ι) → Matrix (n i) (n i) ℂ)))

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -16,7 +16,7 @@ dependent direct sum lie in the span of a family of matrices and a boundary
 matrix commutes with that family, then it
 commutes with the projections and hence has no off-block entries.
 
-The file also records a finite-span bridge: if the simultaneous block word
+The file also records a finite-span reduction: if the simultaneous block word
 tuples span the full product algebra, then the sector projections lie in the
 finite word span of the assembled tensor.  The remaining paper-level CF/BNT input
 is to derive that product-word span from the separated canonical-form/BNT
@@ -76,7 +76,7 @@ variable [(i : ι) → DecidableEq (n i)]
 its nonzero componentwise scalar multiples, embedded as dependent block-diagonal
 matrices, contains each sector projection.
 
-This is the algebraic finite-span bridge used for assembled tensors: after a
+This is the algebraic finite-span reduction used for assembled tensors: after a
 finite word-tuple span theorem supplies the full product algebra
 `(i : ι) → Matrix (n i) (n i) ℂ`, the diagonal embedding of those same word tuples
 contains the projections onto the individual direct-sum sectors. -/

--- a/audits/2026-04-25_issue911_projection_span_reduction.md
+++ b/audits/2026-04-25_issue911_projection_span_reduction.md
@@ -38,10 +38,11 @@ File: `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
   - Entrywise off-block-zero corollary for the same hypotheses.
 
 Blueprint Chapter 14 now records these declarations as
-`lem:block_projection_span_from_product_word_span` and updates the downstream dependency list for
+`lem:block_projection_span_from_product_algebra_span` and
+`lem:block_projection_span_from_product_word_span`, and updates the downstream dependency list for
 `thm:parent_ground_space_le_bnt_span`.
 
-## Remaining paper-level bridge
+## Remaining paper-level finite-span theorem
 
 To close the original #911 target under bare `IsCanonicalFormBNT μ A`, one still needs a theorem of
 one of the following equivalent finite-length forms:

--- a/audits/2026-04-25_issue911_projection_span_reduction.md
+++ b/audits/2026-04-25_issue911_projection_span_reduction.md
@@ -1,0 +1,73 @@
+# Issue #911 — projection-span reduction from product-word span (2026-04-25)
+
+## Scope
+
+Wave 15 Slot B targeted the remaining finite-span input for the periodic block-decomposition
+commutant argument: the virtual sector projections should lie in the span of pulled-back
+length-`m` assembled word products.
+
+The fully paper-level CF/BNT theorem still requires a finite-length separation statement turning
+separated canonical-form/BNT data into a full product-word span for simultaneous block words. The
+current repository has the relevant asymptotic cross-overlap decay and eventual BNT state linear
+independence, but not yet the stronger boundary/matrix-entry product-word span needed here.
+
+## Lean declarations added
+
+File: `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
+
+- `Matrix.blockProjection_mem_span_blockDiagonal'_of_pi_span_eq_top`
+  - Pure algebra: if a family of tuples `T : α → (i : ι) → M_{n_i}(ℂ)` spans the
+    full product algebra and `c i ≠ 0`, then the span of the block-diagonal matrices
+    `blockDiagonal' (fun i => c i • T a i)` contains every dependent block projection.
+  - Proof uses the linear map sending a tuple to its scaled dependent block diagonal and applies it
+    to the tuple with `(c k)⁻¹ I` in the chosen component and zero elsewhere.
+
+- `MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top`
+  - MPS specialization: if the simultaneous length-`m` block-word tuples
+    `ω ↦ (k ↦ evalWord (A k) (List.ofFn ω))` span the full product algebra and all `μ k` are
+    nonzero, then every sector projection belongs to the span of the pulled-back length-`m` word
+    products of `toTensorFromBlocks μ A`.
+  - Uses `evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal` to identify the pulled-back
+    assembled word products with `blockDiagonal' (fun k => (μ k)^m • evalWord (A k) w)`.
+
+- `MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top`
+  - Composes the projection-span theorem with PR #921's commutant criterion: length-`m` word
+    commutation plus product-word span implies the pulled-back boundary matrix is block diagonal.
+
+- `MPSTensor.offBlock_zero_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top`
+  - Entrywise off-block-zero corollary for the same hypotheses.
+
+Blueprint Chapter 14 now records these declarations as
+`lem:block_projection_span_from_product_word_span` and updates the downstream dependency list for
+`thm:parent_ground_space_le_bnt_span`.
+
+## Remaining paper-level bridge
+
+To close the original #911 target under bare `IsCanonicalFormBNT μ A`, one still needs a theorem of
+one of the following equivalent finite-length forms:
+
+1. **Product-word span:** there exists a length `m` such that
+   `ω ↦ (k ↦ evalWord (A k) (List.ofFn ω))` spans `Π k, M_{dim k}(ℂ)`.
+2. **Block selector words:** for each sector `k`, a finite linear combination of length-`m` words is
+   the identity on block `k` and zero on all other blocks.
+3. **Matrix-entry independence:** the scalar word-entry family over all block matrix entries is
+   linearly independent for some finite length.
+
+`TNLean/MPS/MPDO/BiCFDerivation.lean` already contains abstract algebraic routes among these
+conditions (`WordTupleSpanTop`, `HasBlockSelectorWords`, `PropBlockInjective`, and
+`wordEntryFamily`). What is not yet formalized is the implication from separated CF/BNT data
+(`blocks_not_equiv` plus block injectivity/left canonicality, via the cross-overlap separation
+lemmas) to one of these finite-length witnesses. That implication is the remaining
+asymptotic-to-finite Schur / block-separation theorem.
+
+## Validation
+
+- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant` succeeded after the Lean cache was
+  fetched/decompressed in this fresh worktree.
+- `lake build TNLean` succeeded after rerunning with `ulimit -n 8192`; the first full-root attempt
+  failed only with macOS `Too many open files in system` while compiling independent modules.
+- `cd blueprint && leanblueprint web` succeeded; the first combined `checkdecls` invocation failed
+  only because `TNLean.olean` did not exist yet in the fresh worktree.
+- After `lake build TNLean`, `cd blueprint && leanblueprint checkdecls` succeeded.
+- `git diff --check` succeeded.
+- A proof-integrity grep over touched Lean/blueprint/audit files found no forbidden proof tokens.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2087,7 +2087,6 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{proof}
 
 \begin{lemma}[Block projections from product-algebra span]
-    
     \label{lem:block_projection_span_from_product_algebra_span}
     \lean{Matrix.blockProjection_mem_span_blockDiagonal'_of_pi_span_eq_top}
     \leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2086,6 +2086,55 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     gives the entrywise off-block-zero formulation.
 \end{proof}
 
+\begin{lemma}[Block projections from product-algebra span]
+    
+    \label{lem:block_projection_span_from_product_algebra_span}
+    \lean{Matrix.blockProjection_mem_span_blockDiagonal'_of_pi_span_eq_top}
+    \leanok
+    Let $T_a = (T_a(i))_i$ be a family of tuples spanning the full product algebra
+    $\prod_i \MN{n_i}$, and let $c_i\neq0$ be nonzero scalars. Then, for every
+    sector $k$, the sector projection $P_k$ lies in the span of the scaled
+    dependent block-diagonal matrices
+    \[
+        \bigoplus_i c_i T_a(i).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply the linear map $(M_i)_i \mapsto \bigoplus_i c_i M_i$ to the full-span
+    product-algebra element with $(c_k)^{-1} I$ in the $k$-th component and zero in
+    every other component. Its image is exactly $P_k$.
+\end{proof}
+
+\begin{lemma}[Projection span from product-word span]
+    \label{lem:block_projection_span_from_product_word_span}
+    \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
+    \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
+    \lean{MPSTensor.offBlock_zero_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
+    \leanok
+    \uses{lem:block_projection_span_from_product_algebra_span,
+        lem:route_b_block_diagonal_commutant_reduction}
+    If the simultaneous length-$m$ block-word tuples
+    \[
+        \omega \longmapsto \bigl(A_j^{\omega}\bigr)_j
+    \]
+    span the full product algebra $\prod_j \MN{D_j}$ and every $\mu_j$ is nonzero, then the
+    pulled-back length-$m$ word products of $\operatorname{Assemble}(\mu,A)$ span every
+    virtual sector projection $P_j$. Consequently, any boundary matrix commuting with all
+    those assembled words has block-diagonal pulled-back form, and its off-block entries vanish.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    First embed the product algebra linearly as dependent block-diagonal matrices, scaling the
+    $j$-th block by $\mu_j^m$.  Since $\mu_j^m\neq0$, the product-algebra span contains the
+    tuple with $(\mu_j^m)^{-1}I$ in one component and zero elsewhere; its scaled diagonal image is
+    exactly $P_j$.  The word-evaluation formula for the assembled tensor identifies these scaled
+    diagonal matrices with the pulled-back assembled word products, and the commutant conclusion
+    follows from Lemma~\ref{lem:route_b_block_diagonal_commutant_reduction}.
+\end{proof}
+
 \begin{lemma}[Conditional boundary-matrix block split from projection span]
     \label{lem:conditional_boundary_matrix_block_split_projection_span}
     \lean{MPSTensor.groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed_projectionSpan}
@@ -2141,7 +2190,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, def:bnt_span,
         thm:chain_ground_space_eq_mpv_blk,
-        lem:conditional_boundary_matrix_block_split_projection_span}
+        lem:conditional_boundary_matrix_block_split_projection_span,
+        lem:block_projection_span_from_product_word_span}
     If $A$ is in canonical-form/BNT and $1 < L$ and $N \ge L + 1$, every vector in the
     assembled parent ground space should decompose into blockwise chain ground states, and
     therefore lie in the BNT span.
@@ -2150,13 +2200,14 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \notready
     The remaining structural step is the periodic block decomposition of the
-    assembled chain ground space.
+    assembled chain ground space. Lemma~\ref{lem:block_projection_span_from_product_word_span}
+    supplies the sector projections once the separated CF/BNT data has been turned
+    into a finite full-span statement for simultaneous block words.
     Lemma~\ref{lem:conditional_boundary_matrix_block_split_projection_span}
-    supplies the conditional boundary-matrix endgame once the \#911 virtual-sector
-    projections are obtained from the finite word span of the assembled tensor and
-    the wrapping-window comparison provides a commuting boundary matrix. With that
-    decomposition available, one applies the blockwise injective uniqueness theorem
-    to each block separately and recovers the BNT span.
+    then supplies the conditional boundary-matrix endgame once the wrapping-window
+    comparison provides a commuting boundary matrix. With that decomposition available,
+    one applies the blockwise injective uniqueness theorem to each block separately
+    and recovers the BNT span.
 \end{proof}
 
 \begin{theorem}[Ground space equals span of BNT]\label{thm:gs_eq_bnt_span}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2112,8 +2112,6 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
     \lean{MPSTensor.offBlock_zero_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
     \leanok
-    \uses{lem:block_projection_span_from_product_algebra_span,
-        lem:route_b_block_diagonal_commutant_reduction}
     If the simultaneous length-$m$ block-word tuples
     \[
         \omega \longmapsto \bigl(A_j^{\omega}\bigr)_j
@@ -2126,6 +2124,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{proof}
     \leanok
+    \uses{lem:block_projection_span_from_product_algebra_span,
+        lem:route_b_block_diagonal_commutant_reduction}
     First embed the product algebra linearly as dependent block-diagonal matrices, scaling the
     $j$-th block by $\mu_j^m$.  Since $\mu_j^m\neq0$, the product-algebra span contains the
     tuple with $(\mu_j^m)^{-1}I$ in one component and zero elsewhere; its scaled diagonal image is


### PR DESCRIPTION
## Summary
- add a pure algebra lemma showing full product-algebra span of block tuples gives sector projections in the scaled block-diagonal span
- specialize it to pulled-back length-`m` word products of `toTensorFromBlocks μ A`
- add block-diagonal/off-block-zero commutant corollaries under the finite product-word span hypothesis
- document the remaining CF/BNT asymptotic-to-finite product-word span theorem in the blueprint and audit

## Remaining finite-span theorem
This PR does not close #911. It reduces the projection-span input to a finite product-word span statement for simultaneous block words. The remaining paper-level lemma is to derive that product-word span (or equivalent selector / matrix-entry independence data) from separated CF/BNT hypotheses.

## Validation
- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `ulimit -n 8192 && lake build TNLean`
- `cd blueprint && leanblueprint web` (succeeded before the fresh-worktree `TNLean.olean` checkdecls prerequisite existed)
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- proof-integrity grep over touched files found no forbidden proof tokens

Review-fix validation after `ee6b1007`:
- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- touched-file banned/proof-token greps

Refs #911, #905, #190.

Ready for an orchestrator simplification/cleanup pass before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive Lean lemmas and documentation updates, with no runtime/codegen impact; main risk is proof/lemma statement mismatch affecting downstream formalization dependencies.
> 
> **Overview**
> Adds a new algebraic reduction `Matrix.blockProjection_mem_span_blockDiagonal'_of_pi_span_eq_top` proving that *full product-algebra span* of block tuples implies each sector `blockProjection` lies in the span of corresponding scaled dependent block-diagonal embeddings.
> 
> Specializes this to assembled MPS tensors by deriving projection-span for pulled-back length-`m` words of `toTensorFromBlocks`, and adds derived commutant criteria (`isBlockDiagonal'`) plus entrywise off-block-zero corollaries under the new *finite product-word span* hypothesis.
> 
> Updates the blueprint (Chapter 14) to cite the new lemmas and adjust downstream dependencies for the parent-ground-space containment theorem, and adds an audit note documenting the remaining paper-level step (deriving the product-word span from separated CF/BNT hypotheses).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b3d7ba108f2b6efbe884b80d581f55afee3cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->