### PR TITLE
feat(MPS/ParentHamiltonian): add cyclic normal open-chain reduction (#588)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -170,6 +170,31 @@ def cyclicCfg {N : ℕ} (_hN : 0 < N) (L : ℕ)
     then σ ⟨(k.val + N - i.val) % N, h⟩
     else τ k
 
+/-- If a site has cyclic offset `r` from `i`, then it is the site `i + r` modulo
+`N`. -/
+theorem eq_cyclic_site_of_offset_eq {N : ℕ} (hN : 0 < N) {i k : Fin N} {r : ℕ}
+    (hr : r < N) (h : (k.val + N - i.val) % N = r) :
+    k = ⟨(i.val + r) % N, Nat.mod_lt _ hN⟩ := by
+  ext
+  by_cases hik : i.val ≤ k.val
+  · have hoff : (k.val + N - i.val) % N = k.val - i.val := by
+      have hsum : k.val + N - i.val = k.val - i.val + N := by omega
+      rw [hsum, Nat.add_mod_right]
+      exact Nat.mod_eq_of_lt (by omega)
+    have hr_eq : r = k.val - i.val := by omega
+    have hsum : i.val + r = k.val := by omega
+    have hmod : (i.val + r) % N = k.val := by
+      rw [hsum]
+      exact Nat.mod_eq_of_lt k.isLt
+    exact hmod.symm
+  · have hoff : (k.val + N - i.val) % N = k.val + N - i.val := by
+      exact Nat.mod_eq_of_lt (by omega)
+    have hsum : i.val + r = k.val + N := by omega
+    have hmod : (i.val + r) % N = k.val := by
+      rw [hsum, Nat.add_mod_right]
+      exact Nat.mod_eq_of_lt k.isLt
+    exact hmod.symm
+
 /-- Linear restriction to a cyclic window at position `i`. -/
 def cyclicRestrictₗ {N : ℕ} (hN : 0 < N) (L : ℕ)
     (i : Fin N) (τ : Fin N → Fin d) : NSiteSpace d N →ₗ[ℂ] NSiteSpace d L where
@@ -181,6 +206,28 @@ def cyclicRestrictₗ {N : ℕ} (hN : 0 < N) (L : ℕ)
 theorem cyclicRestrictₗ_apply {N : ℕ} (hN : 0 < N) (L : ℕ)
     (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N) (σ : Fin L → Fin d) :
     cyclicRestrictₗ hN L i τ ψ σ = ψ (cyclicCfg hN L i σ τ) := rfl
+
+/-- Restricting the final site of a cyclic `(L + 1)`-window peels off the site with
+cyclic offset `L` and records its value in the outside configuration. -/
+theorem cyclicRestrictₗ_restrictLast {N L : ℕ} (hN : 0 < N)
+    (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N) (j : Fin d) :
+    restrictLast (cyclicRestrictₗ hN (L + 1) i τ ψ) j =
+      cyclicRestrictₗ hN L i
+        (fun k => if (k.val + N - i.val) % N = L then j else τ k) ψ := by
+  ext σ
+  simp only [restrictLast_apply, cyclicRestrictₗ_apply]
+  congr 1
+  ext k
+  simp only [cyclicCfg]
+  by_cases hsmall : (k.val + N - i.val) % N < L
+  · rw [dif_pos (Nat.lt_trans hsmall (Nat.lt_succ_self L)), dif_pos hsmall]
+    simp [Fin.snoc, hsmall]
+  · rw [dif_neg hsmall]
+    by_cases hlast : (k.val + N - i.val) % N = L
+    · rw [dif_pos (by omega : (k.val + N - i.val) % N < L + 1)]
+      simp [Fin.snoc, hlast]
+    · rw [dif_neg (by omega : ¬((k.val + N - i.val) % N < L + 1))]
+      simp [hlast]
 
 /-- For a non-wrapping window (`i + L ≤ N`), the cyclic config agrees with
 the contiguous config. -/

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -173,7 +173,7 @@ def cyclicCfg {N : ℕ} (_hN : 0 < N) (L : ℕ)
 /-- If a site has cyclic offset `r` from `i`, then it is the site `i + r` modulo
 `N`. -/
 theorem eq_cyclic_site_of_offset_eq {N : ℕ} (hN : 0 < N) {i k : Fin N} {r : ℕ}
-    (hr : r < N) (h : (k.val + N - i.val) % N = r) :
+    (h : (k.val + N - i.val) % N = r) :
     k = ⟨(i.val + r) % N, Nat.mod_lt _ hN⟩ := by
   ext
   by_cases hik : i.val ≤ k.val

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -87,10 +87,9 @@ On a periodic chain of `N` sites, the ground space of the parent Hamiltonian
 is the set of states whose restriction to every cyclic window of `L` consecutive
 sites lies in `G_L(A)`.
 
-The definition below makes this intersection explicit using the cyclic restriction
-maps from `CyclicWindow.lean`. It uses `⊤` for degenerate lengths (`N = 0` or
-`L > N`) so that downstream theorems can state their nondegenerate hypotheses
-separately. -/
+The definition below makes this intersection explicit using cyclic restriction
+maps. It uses `⊤` for degenerate lengths (`N = 0` or `L > N`) so that downstream
+theorems can state their nondegenerate hypotheses separately. -/
 
 /-- The periodic chain ground space: the set of states `ψ` on `N` sites such
 that every cyclic window of `L` consecutive sites restricts into `G_L(A)`.

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -107,7 +107,7 @@ noncomputable def chainGroundSpace (A : MPSTensor d D) (L N : ℕ) :
 The proof uses trace cyclicity: for each cyclic window at position `i`, the
 restriction of the MPV to that window equals `groundSpaceMap A L X_τ` where
 `X_τ` is the product of `A`-matrices at outside positions. The cyclic list
-bookkeeping is provided by `mpv_window_mem_groundSpace`. -/
+bookkeeping follows from the window-level membership calculation. -/
 theorem mpv_mem_chainGroundSpace (A : MPSTensor d D) (L N : ℕ)
     (hN : 0 < N) (hLN : L ≤ N) :
     (mpv A : NSiteSpace d N) ∈ chainGroundSpace A L N := by

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -400,9 +400,9 @@ theorem contiguous_mem_groundSpace_of_isNBlkInjective
 block-injective tensors.
 
 This combines cyclic window monotonicity (peeling longer cyclic windows down to
-`L₀ + 1`), the non-wrapping cyclic/contiguous identification, and the open-chain
-range-reduction theorem `contiguous_mem_groundSpace_of_isNBlkInjective`. It stops
-at open-chain membership; the wrapped-boundary scalarity step remains separate. -/
+`L₀ + 1`), the non-wrapping cyclic/contiguous identification, and the
+open-chain range-reduction argument for block-injective tensors. It stops at
+open-chain membership; the wrapped-boundary scalarity step remains separate. -/
 theorem chainGroundSpace_le_groundSpace_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -39,6 +39,8 @@ with the periodic boundary condition:
 * `MPSTensor.mpv_mem_groundSpace` — the MPV lies in the ground space
 * `MPSTensor.chainGroundSpace` — the periodic-chain ground space as intersection
   of cyclic window ground submodules
+* `MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective` — cyclic
+  normal-range constraints imply open-chain ground-space membership
 * `MPSTensor.groundSpace_unique_periodic` — uniqueness on the periodic chain
 * `MPSTensor.parentHamiltonian_unique_gs_injective` — uniqueness for `2L₀` sites
 * `MPSTensor.parentHamiltonian_unique_gs_normal` — optimal uniqueness for `L₀+1` sites
@@ -85,13 +87,10 @@ On a periodic chain of `N` sites, the ground space of the parent Hamiltonian
 is the set of states whose restriction to every cyclic window of `L` consecutive
 sites lies in `G_L(A)`.
 
-The full periodic-chain window restriction is not yet expressed directly in
-terms of cyclic window maps. We therefore expose only the chain ground-space
-interface for now, and will define it from local window constraints once those
-maps are in place. -/
-
--- TODO(parent-hamiltonian): define `chainGroundSpace` as the intersection of
--- cyclic window ground submodules once the periodic window maps are in place.
+The definition below makes this intersection explicit using the cyclic restriction
+maps from `CyclicWindow.lean`. It uses `⊤` for degenerate lengths (`N = 0` or
+`L > N`) so that downstream theorems can state their nondegenerate hypotheses
+separately. -/
 
 /-- The periodic chain ground space: the set of states `ψ` on `N` sites such
 that every cyclic window of `L` consecutive sites restricts into `G_L(A)`.
@@ -108,9 +107,8 @@ noncomputable def chainGroundSpace (A : MPSTensor d D) (L N : ℕ) :
 
 The proof uses trace cyclicity: for each cyclic window at position `i`, the
 restriction of the MPV to that window equals `groundSpaceMap A L X_τ` where
-`X_τ` is the product of `A`-matrices at outside positions.
-
-**Status**: requires cyclic list decomposition and trace cyclicity argument. -/
+`X_τ` is the product of `A`-matrices at outside positions. The cyclic list
+bookkeeping is provided by `mpv_window_mem_groundSpace`. -/
 theorem mpv_mem_chainGroundSpace (A : MPSTensor d D) (L N : ℕ)
     (hN : 0 < N) (hLN : L ≤ N) :
     (mpv A : NSiteSpace d N) ∈ chainGroundSpace A L N := by
@@ -145,7 +143,7 @@ theorem chainGroundSpace_le_chainGroundSpace_succ (A : MPSTensor d D)
     · rw [dif_neg hsmall, dif_neg hsmall]
       by_cases hlast : (k.val + N - i.val) % N = L
       · have hk : k = peeled :=
-          eq_cyclic_site_of_offset_eq hN (by omega : L < N) hlast
+          eq_cyclic_site_of_offset_eq hN hlast
         simp [τ', hk]
       · simp [τ', hlast]
   have hbig := hψ i τ
@@ -403,7 +401,8 @@ block-injective tensors.
 
 This combines cyclic window monotonicity (peeling longer cyclic windows down to
 `L₀ + 1`), the non-wrapping cyclic/contiguous identification, and the open-chain
-range-reduction theorem `contiguous_mem_groundSpace_of_isNBlkInjective`. -/
+range-reduction theorem `contiguous_mem_groundSpace_of_isNBlkInjective`. It stops
+at open-chain membership; the wrapped-boundary scalarity step remains separate. -/
 theorem chainGroundSpace_le_groundSpace_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -87,9 +87,9 @@ On a periodic chain of `N` sites, the ground space of the parent Hamiltonian
 is the set of states whose restriction to every cyclic window of `L` consecutive
 sites lies in `G_L(A)`.
 
-The definition below makes this intersection explicit using cyclic restriction
-maps. It uses `⊤` for degenerate lengths (`N = 0` or `L > N`) so that downstream
-theorems can state their nondegenerate hypotheses separately. -/
+For the nondegenerate regime used below, this is the intersection of all cyclic
+window constraints. The subsequent theorems state their nondegeneracy assumptions
+explicitly. -/
 
 /-- The periodic chain ground space: the set of states `ψ` on `N` sites such
 that every cyclic window of `L` consecutive sites restricts into `G_L(A)`.

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -120,6 +120,62 @@ theorem mpv_mem_chainGroundSpace (A : MPSTensor d D) (L N : ℕ)
   simpa [cyclicRestrictₗ_apply, cyclicCfg, replaceWindow] using
     mpv_window_mem_groundSpace A L N hLN i τ
 
+/-- Peeling the last site of every cyclic window shows that a larger interaction
+range imposes at least the constraints of the preceding range. -/
+theorem chainGroundSpace_le_chainGroundSpace_succ (A : MPSTensor d D)
+    {L N : ℕ} (hN : 0 < N) (hLN : L + 1 ≤ N) :
+    chainGroundSpace A (L + 1) N ≤ chainGroundSpace A L N := by
+  intro ψ hψ
+  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
+  rw [chainGroundSpace, dif_pos ⟨hN, show L ≤ N from by omega⟩]
+  simp only [Submodule.mem_iInf, Submodule.mem_comap]
+  intro i τ
+  let peeled : Fin N := ⟨(i.val + L) % N, Nat.mod_lt _ hN⟩
+  let τ' : Fin N → Fin d :=
+    fun k => if (k.val + N - i.val) % N = L then τ peeled else τ k
+  have hτ' : cyclicRestrictₗ hN L i τ' ψ = cyclicRestrictₗ hN L i τ ψ := by
+    ext σ
+    simp only [cyclicRestrictₗ_apply]
+    congr 1
+    ext k
+    simp only [cyclicCfg]
+    by_cases hsmall : (k.val + N - i.val) % N < L
+    · rw [dif_pos hsmall, dif_pos hsmall]
+    · rw [dif_neg hsmall, dif_neg hsmall]
+      by_cases hlast : (k.val + N - i.val) % N = L
+      · have hk : k = peeled :=
+          eq_cyclic_site_of_offset_eq hN (by omega : L < N) hlast
+        simp [τ', hk]
+      · simp [τ', hlast]
+  have hbig := hψ i τ
+  have hleft := groundSpace_inLeftGround A L hbig (τ peeled)
+  rw [cyclicRestrictₗ_restrictLast hN i τ ψ (τ peeled)] at hleft
+  exact hτ' ▸ hleft
+
+/-- The periodic chain ground space is antitone in the interaction range: longer
+cyclic windows imply all shorter cyclic-window constraints. -/
+theorem chainGroundSpace_le_chainGroundSpace_of_le (A : MPSTensor d D)
+    {L' L N : ℕ} (hN : 0 < N) (hL'L : L' ≤ L) (hLN : L ≤ N) :
+    chainGroundSpace A L N ≤ chainGroundSpace A L' N := by
+  have claim : ∀ m : ℕ, L' + m ≤ N →
+      chainGroundSpace A (L' + m) N ≤ chainGroundSpace A L' N := by
+    intro m
+    induction m with
+    | zero =>
+        intro _ ψ hψ
+        simpa using hψ
+    | succ m ih =>
+        intro hmN
+        exact le_trans
+          (by
+            simpa [Nat.add_assoc] using
+              chainGroundSpace_le_chainGroundSpace_succ (A := A) hN
+                (L := L' + m) (by omega : L' + m + 1 ≤ N))
+          (ih (by omega))
+  have hEq : L' + (L - L') = L := Nat.add_sub_of_le hL'L
+  simpa [hEq] using claim (L - L') (by omega : L' + (L - L') ≤ N)
+
 /-! ### Unique ground state -/
 
 /-- A submodule has a unique ground state (up to scalar) if its dimension is exactly 1. -/
@@ -341,6 +397,29 @@ theorem contiguous_mem_groundSpace_of_isNBlkInjective
     rw [dif_pos (show 0 ≤ k.val ∧ k.val < 0 + (N - (L₀ + 1) + L₀ + 1) by omega)]
     congr 1
   rwa [hfull] at hmemN
+
+/-- Cyclic reduced-window constraints imply open-chain ground-space membership for
+block-injective tensors.
+
+This combines cyclic window monotonicity (peeling longer cyclic windows down to
+`L₀ + 1`), the non-wrapping cyclic/contiguous identification, and the open-chain
+range-reduction theorem `contiguous_mem_groundSpace_of_isNBlkInjective`. -/
+theorem chainGroundSpace_le_groundSpace_of_isNBlkInjective
+    {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    (hN : 0 < N) (hL : L₀ < L) (hLN : L ≤ N) :
+    chainGroundSpace A L N ≤ groundSpace A N := by
+  intro ψ hψ
+  have hL₀N : L₀ + 1 ≤ N := by omega
+  have hψred : ψ ∈ chainGroundSpace A (L₀ + 1) N :=
+    chainGroundSpace_le_chainGroundSpace_of_le (A := A) hN (by omega : L₀ + 1 ≤ L) hLN hψ
+  rw [chainGroundSpace, dif_pos ⟨hN, hL₀N⟩] at hψred
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψred
+  apply contiguous_mem_groundSpace_of_isNBlkInjective hInj hL₀ hL₀N
+  intro s hs τ
+  rw [← cyclicRestrictₗ_eq_contiguousRestrictₗ hN hL₀N
+    (show (⟨s, by omega⟩ : Fin N).val + (L₀ + 1) ≤ N from hs)]
+  exact hψred ⟨s, by omega⟩ τ
 
 /-! ### Helper: vanishing on all word products implies zero -/
 

--- a/audits/2026-04-22_issue588_normal_range_reduction_partial.md
+++ b/audits/2026-04-22_issue588_normal_range_reduction_partial.md
@@ -44,7 +44,30 @@ Wave 14 addresses exactly that reverted transport layer by adding
 `tailRestrictₗ_contiguousRestrictₗ` and then landing the chain-level theorem
 `contiguous_mem_groundSpace_of_isNBlkInjective`.
 
-## Remaining blocker after Wave 14
+## 2026-04-25 Wave 15D update
+
+Current branch `wave15-D-588-normal-range` lands the cyclic-to-open-chain part of
+periodic reintegration:
+
+- `MPSTensor.eq_cyclic_site_of_offset_eq` and
+  `MPSTensor.cyclicRestrictₗ_restrictLast` in
+  `TNLean/MPS/ParentHamiltonian/CyclicWindow.lean` record the modular-index
+  calculation and the one-site peeling identity for cyclic windows.
+- `MPSTensor.chainGroundSpace_le_chainGroundSpace_succ` and
+  `MPSTensor.chainGroundSpace_le_chainGroundSpace_of_le` in
+  `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean` show that periodic-chain
+  constraints are antitone in the interaction range.
+- `MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective` combines that
+  cyclic monotonicity with the Wave 14 open-chain theorem, proving that cyclic
+  range-$L$ constraints with $L_0 < L \le N$ imply the full open-chain membership
+  `ψ ∈ groundSpace A N` whenever `A` is `L₀`-block-injective and `0 < L₀`.
+
+This leaves the final scalar-boundary step untouched: after writing
+`ψ = groundSpaceMap A N X`, the proof still has to turn the reduced wrapped
+window constraints into a long-word commutation family for `X`, and then apply
+`MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`.
+
+## Remaining blocker after Wave 15D
 
 The final target
 
@@ -52,20 +75,19 @@ The final target
 chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 ```
 
-still needs the periodic reintegration step. The open-chain representation
-`ψ ∈ groundSpace A N` is now available from contiguous `(L₀ + 1)`-window
-constraints, but the periodic proof must still connect the full cyclic
-`chainGroundSpace A L N` hypothesis to that reduced open-chain hypothesis and
-then force the boundary matrix in `ψ = groundSpaceMap A N X` to be scalar.
+still needs the scalar-boundary closure step. The full cyclic
+`chainGroundSpace A L N` hypothesis is now connected to the open-chain
+representation `ψ ∈ groundSpace A N`, so one can write
+`ψ = groundSpaceMap A N X`. The remaining proof must turn the reduced wrapped
+window constraints into a long-word commutation family for `X`, then use the
+existing block-stripping theorem to force generator commutation and hence
+scalarity.
 
-The expected next formal pieces are:
-
-1. a cyclic-window range monotonicity / peeling theorem reducing cyclic
-   `L`-window constraints to cyclic `(L₀ + 1)`-window constraints;
-2. a periodic closure theorem using the existing wrapped-window compatibility
-   and mirror compatibility lemmas in `WrappingWindow.lean`, together with
-   `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`,
-   to obtain the same generator-commutation conclusion as in the injective proof.
+The expected next formal piece is a periodic closure theorem using the wrapped
+window compatibility and mirror compatibility lemmas in `WrappingWindow.lean`,
+together with
+`MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`,
+to obtain the same generator-commutation conclusion as in the injective proof.
 
 ## Tracking / linkage
 
@@ -74,15 +96,18 @@ The expected next formal pieces are:
 - Related transport work: #869 / #883
 - Paper reference: CPGSV21, §IV.C
 
-## Files changed by the Wave 14 branch
+## Files changed by the Wave 14 and Wave 15D branches
 
-- `TNLean/MPS/ParentHamiltonian/RestrictTransport.lean`
+- `TNLean/MPS/ParentHamiltonian/RestrictTransport.lean` (Wave 14)
+- `TNLean/MPS/ParentHamiltonian/CyclicWindow.lean` (Wave 15D)
 - `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
+- `blueprint/src/chapter/ch14_parent_hamiltonian.tex` (Wave 15D)
 - `audits/2026-04-22_issue588_normal_range_reduction_partial.md`
 
-## Status after Wave 14
+## Status after Wave 15D
 
-Wave 14 lands the open-chain theorem but does **not** discharge the remaining
-periodic `sorry` in
-`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`. The remaining work
-is the cyclic-window reduction and wrapped-boundary scalar-closure assembly.
+Wave 14 lands the contiguous open-chain theorem, and Wave 15D lands the
+cyclic-window reduction from periodic constraints to that open-chain theorem. The
+remaining proof obligation in
+`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` is now concentrated
+in the wrapped-boundary scalar-closure step.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -553,13 +553,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.cyclicCfg}
     \lean{MPSTensor.cyclicRestrictₗ}
     \lean{MPSTensor.cyclicRestrictₗ_apply}
+    \lean{MPSTensor.eq_cyclic_site_of_offset_eq}
+    \lean{MPSTensor.cyclicRestrictₗ_restrictLast}
     \lean{MPSTensor.cyclicCfg_eq_contiguousCfg}
     \lean{MPSTensor.cyclicRestrictₗ_eq_contiguousRestrictₗ}
     \leanok
     On the periodic chain, a cyclic window starting at $i$ reads the sites
-    $i,i+1,\ldots,i+L-1$ modulo $N$. When this window does not wrap around the ring,
-    the cyclic construction agrees with the contiguous one, and so do the two
-    restriction maps.
+    $i,i+1,\ldots,i+L-1$ modulo $N$.  Deleting the final site of a cyclic
+    $(L+1)$-window records the value at cyclic offset $L$ in the outside
+    configuration and gives the $L$-window starting at the same site.  When this
+    window does not wrap around the ring, the cyclic construction agrees with the
+    contiguous one, and so do the two restriction maps.
 \end{remark}
 
 \begin{lemma}[Iterated contiguous-window intersection]\label{lem:contiguous_mem_ground_space}
@@ -721,6 +725,28 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     identify every fixed-prefix suffix with one of the assumed length-$L_0+1$
     windows. Theorem~\ref{thm:ground_space_extend_right_block_injective} then
     regrows the rightmost site.
+\end{proof}
+
+\begin{theorem}[Cyclic-window normal open-chain reduction]%
+    \label{thm:cyclic_normal_open_chain_range_reduction}
+    \lean{MPSTensor.chainGroundSpace_le_chainGroundSpace_succ,
+          MPSTensor.chainGroundSpace_le_chainGroundSpace_of_le,
+          MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}
+    \leanok
+    \uses{rem:cyclic_window_operators, thm:normal_open_chain_range_reduction}
+    Let $A$ be $L_0$-block injective with $L_0>0$. If an $N$-site periodic-chain
+    state satisfies all cyclic ground-space constraints at some range
+    $L \ge L_0+1$, then it lies in the open-chain ground space $G_N(A)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{rem:cyclic_window_operators, thm:normal_open_chain_range_reduction}
+    First peel cyclic windows one site at a time: a state satisfying the range
+    $L+1$ constraints also satisfies the range $L$ constraints. Iterating this
+    antitonicity reduces the cyclic hypotheses to range $L_0+1$. On every
+    non-wrapping interval, the cyclic and contiguous restriction maps agree, so
+    Theorem~\ref{thm:normal_open_chain_range_reduction} applies.
 \end{proof}
 
 \begin{theorem}[Boundary matrix commutation from the wrapping window]\label{thm:boundary_matrix_commutes}
@@ -960,7 +986,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction}
     \notready
     \uses{def:chain_ground_space, def:mpv_submodule, def:normal,
-        def:l_blk_injective, thm:normal_open_chain_range_reduction}
+        def:l_blk_injective, thm:cyclic_normal_open_chain_range_reduction}
     If $A$ is normal, $D \ge 1$, $L_0$-block-injective, with $N \ge 2$ and $L_0 < L \le N$, then
     \[
         \mathcal G_{N,L}(A) \subseteq \spn\bigl\{V^{(N)}(A)\bigr\}.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -742,7 +742,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    \uses{rem:cyclic_window_operators, thm:normal_open_chain_range_reduction}
+    \uses{rem:cyclic_window_operators, thm:normal_open_chain_range_reduction,
+        lem:ground_space_in_left_ground}
     First peel cyclic windows one site at a time: a state satisfying the range
     $L+1$ constraints also satisfies the range $L$ constraints. Iterating this
     antitonicity reduces the cyclic hypotheses to range $L_0+1$. On every

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -734,9 +734,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
           MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}
     \leanok
     \uses{rem:cyclic_window_operators, thm:normal_open_chain_range_reduction}
-    Let $A$ be $L_0$-block injective with $L_0>0$. If an $N$-site periodic-chain
-    state satisfies all cyclic ground-space constraints at some range
-    $L \ge L_0+1$, then it lies in the open-chain ground space $G_N(A)$.
+    Let $A$ be $L_0$-block injective with $L_0>0$ and $D \ge 1$.
+    If an $N$-site periodic-chain state satisfies all cyclic ground-space
+    constraints at some range $L_0+1 \le L \le N$, then it lies in the
+    open-chain ground space $G_N(A)$.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

This PR advances the remaining normal-range-reduction blocker for #588 by landing the cyclic-to-open-chain part of the periodic reintegration.

* Adds cyclic-window peeling infrastructure in `CyclicWindow.lean`:
  * `MPSTensor.eq_cyclic_site_of_offset_eq`
  * `MPSTensor.cyclicRestrictₗ_restrictLast`
* Adds periodic chain-window antitonicity in `UniqueGroundState.lean`:
  * `MPSTensor.chainGroundSpace_le_chainGroundSpace_succ`
  * `MPSTensor.chainGroundSpace_le_chainGroundSpace_of_le`
* Adds the new proof-path theorem
  * `MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective`

Together with the Wave 14 open-chain theorem, this proves that cyclic range-`L` constraints with `L₀ < L ≤ N` imply `ψ ∈ groundSpace A N` for an `L₀`-block-injective tensor with `0 < L₀`.

The original target `MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` is not overclaimed here. The remaining step is the wrapped-boundary scalar closure: from `ψ = groundSpaceMap A N X`, turn the reduced wrapped-window constraints into a long-word commutation family for `X`, then apply `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`.

## Paper / original LaTeX anchors

The local source for the cited CPGSV21 normal-range argument is:

* `Papers/2011.12127/TN-Review-main.tex` lines 2049--2078: blocked normal-MPS intersection / grow-back argument and the iteration from `L₀ + 1` windows to longer ranges.
* `Papers/2011.12127/TN-Review-main.tex` lines 2087--2094: theorem `thm:4:unique-gs-L0_plus_1`, stating the normal-MPS `L₀ + 1` parent-Hamiltonian uniqueness result.

This PR formalizes the cyclic-window-to-open-chain reduction component of that iteration; the wrapped-boundary scalar closure remains the explicit next step toward the full theorem.

## Validation

* `lake env lean TNLean/MPS/ParentHamiltonian/CyclicWindow.lean`
* `lake env lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean` (same pre-existing target warning)
* `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState`
* `lake build TNLean` (succeeds; pre-existing warnings only)
* `cd blueprint && leanblueprint web && leanblueprint checkdecls`
* `git diff --check`
* `rg -n "\\b(sorry|axiom|admit|native_decide|unsafe)\\b" ...` shows only the pre-existing target `sorry` in `UniqueGroundState.lean`

Refs #588 #190 #460 #195.

Please treat this as ready for an orchestrator simplification/cleanup pass before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds nontrivial new Lean theorems about cyclic-window restriction/monotonicity and uses them to derive open-chain ground-space membership from periodic constraints; risk is mainly proof/arithmetical correctness and potential downstream lemma breakage.
> 
> **Overview**
> Extends cyclic-window infrastructure with modular index arithmetic (`eq_cyclic_site_of_offset_eq`) and a new “peel last site” identity for cyclic restrictions (`cyclicRestrictₗ_restrictLast`).
> 
> Builds on this to prove that `chainGroundSpace` is **antitone in interaction range** (`chainGroundSpace_le_chainGroundSpace_succ` and iterated `..._of_le`), and combines the reduction to range `L₀+1` with the existing block-injective open-chain theorem to show `chainGroundSpace A L N ≤ groundSpace A N` under `IsNBlkInjective` and `L₀ < L ≤ N`.
> 
> Updates the audit note and blueprint to document the new cyclic-to-open-chain reduction theorem and references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e4227ab0e6f68dbf34ca2fa6cfa0790344d58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

