### PR TITLE
feat(MPS/ParentHamiltonian): add conditional block-split endgame (#905)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
+++ b/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
@@ -179,7 +179,7 @@ If the boundary matrix for `toTensorFromBlocks μ A` is itself the reindexed
 block diagonal with diagonal blocks `Xb k`, then the corresponding `N`-site
 open-chain vector is the sum of the blockwise open-chain vectors, with the
 expected weight factor `(μ k) ^ N`. -/
-private theorem groundSpaceMap_toTensorFromBlocks_blockDiagonal
+private lemma groundSpaceMap_toTensorFromBlocks_blockDiagonal
     (μ' : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (Xb : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) (N : ℕ) :
     groundSpaceMap (toTensorFromBlocks μ' A) N
@@ -204,27 +204,24 @@ private theorem groundSpaceMap_toTensorFromBlocks_blockDiagonal
 
 /-- Applying `groundSpaceMap` to a scalar boundary matrix gives a scalar multiple
 of the periodic MPV coefficient vector. -/
-private theorem groundSpaceMap_matrix_scalar
+private lemma groundSpaceMap_matrix_scalar
     (A : MPSTensor d D) (N : ℕ) (c : ℂ) :
     groundSpaceMap A N (Matrix.scalar (Fin D) c) = c • (mpv A : NSiteSpace d N) := by
   ext σ
   simp only [groundSpaceMap_apply, Pi.smul_apply, smul_eq_mul, mpv, coeff]
   have hscalar : Matrix.scalar (Fin D) c = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
     ext i j
-    by_cases hij : i = j
-    · subst j
-      simp
-    · simp [Matrix.scalar, hij]
+    by_cases hij : i = j <;> simp [Matrix.scalar, hij]
   rw [hscalar, Matrix.mul_smul, mul_one, Matrix.trace_smul]
   simp [smul_eq_mul]
 
 /-- Boundary-matrix block split from the projection-span input.
 
 This is the algebraic endgame for the block-decomposition argument. Assume the
-finite-span input that every virtual sector projection lies in the pulled-back
-span of length-`m` assembled word products. If a boundary matrix `X` for the
-assembled tensor commutes with those length-`m` words (the output expected from
-the wrapping-window comparison), then the open-chain vector
+#911 finite-span input that every virtual sector projection lies in the
+pulled-back span of length-`m` assembled word products. If a boundary matrix `X`
+for the assembled tensor commutes with those length-`m` words (the output
+expected from the wrapping-window comparison), then the open-chain vector
 `groundSpaceMap (toTensorFromBlocks μ A) N X` lies in the supremum of the
 blockwise periodic chain ground spaces.
 
@@ -252,10 +249,9 @@ theorem groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed
       ⨆ j : Fin r, chainGroundSpace (A j) L N := by
   classical
   let e : ((k : Fin r) × Fin (dim k)) ≃ Fin (∑ k : Fin r, dim k) := finSigmaFinEquiv
-  have hBD :=
-    isBlockDiagonal'_of_commutes_reindexed_wordSpan
-      (B := toTensorFromBlocks μ A) (m := m) hProj hComm
-  rcases hBD with ⟨Xb, hXb⟩
+  rcases isBlockDiagonal'_of_commutes_reindexed_wordSpan
+      (B := toTensorFromBlocks μ A) (m := m) hProj hComm with
+    ⟨Xb, hXb⟩
   have hCommRe : ∀ ω : Fin m → Fin d,
       Matrix.blockDiagonal' Xb *
           Matrix.blockDiagonal' (fun k : Fin r =>
@@ -325,12 +321,9 @@ theorem groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed
       exact hCommBlock k ω
   choose c hc using hScalar
   have hX : X = Matrix.reindex e e (Matrix.blockDiagonal' Xb) := by
-    calc
-      X = Matrix.reindex e e (Matrix.reindex e.symm e.symm X) := by
-        ext a b
-        simp [e]
-      _ = Matrix.reindex e e (Matrix.blockDiagonal' Xb) := by
-        rw [hXb]
+    rw [← hXb]
+    ext a b
+    simp [e]
   rw [hX, groundSpaceMap_toTensorFromBlocks_blockDiagonal]
   refine Submodule.sum_mem _ ?_
   intro k _
@@ -341,12 +334,12 @@ theorem groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed
 
 /-- Conditional reverse block split from the finite projection-span input.
 
-Besides the projection-span hypothesis, this theorem assumes the boundary-matrix
-output of the wrapping/open-chain layer: every vector in the assembled periodic
-ground space can be represented as `groundSpaceMap` applied to a boundary matrix
-that commutes with all length-`m` assembled word products. Under these inputs,
-the assembled periodic ground space is contained in the supremum of the blockwise
-periodic ground spaces. -/
+Besides the #911 projection-span hypothesis, this theorem assumes the
+boundary-matrix output of the wrapping/open-chain layer: every vector in the
+assembled periodic ground space can be represented as `groundSpaceMap` applied to
+a boundary matrix that commutes with all length-`m` assembled word products. Under
+these inputs, the assembled periodic ground space is contained in the supremum of
+the blockwise periodic ground spaces. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan
     (A : (j : Fin r) → MPSTensor d (dim j))
     (hCF : IsCanonicalFormBNT μ A) {L N m : ℕ}
@@ -375,10 +368,10 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan
 
 This combines the already-proved forward inclusion with
 `chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan`. The
-only CF/BNT-specific finite-span assumption here is the projection-span input;
-the remaining boundary-matrix representation/commutation hypothesis is the
-wrapping-window output that supplies the boundary matrix to which the commutant
-reduction applies. -/
+only CF/BNT-specific finite-span assumption here is the #911 projection-span
+input; the remaining boundary-matrix representation/commutation hypothesis is
+the wrapping-window output that supplies the boundary matrix to which the
+commutant reduction applies. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_reindexed_projectionSpan
     (A : (j : Fin r) → MPSTensor d (dim j))
     (hCF : IsCanonicalFormBNT μ A) {L N m : ℕ}
@@ -440,10 +433,10 @@ private theorem parentHamiltonianGroundSpace_le_bntSpan_of_block_chain_split
 /-- Conditional containment in the BNT span from projection-span and boundary data.
 
 This is the parent-Hamiltonian endgame after a block split has been produced by
-`chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan`.  The
-projection-span hypothesis is the finite CF/BNT input still tracked separately;
-the boundary hypothesis is the wrapping/open-chain output that supplies the
-commuting boundary matrix.  The proof then delegates to
+`chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan`. The
+projection-span hypothesis is the #911 finite CF/BNT input still tracked
+separately; the boundary hypothesis is the wrapping/open-chain output that
+supplies the commuting boundary matrix. The proof then delegates to
 `parentHamiltonianGroundSpace_le_bntSpan_of_block_chain_split`, so the final step
 uses the existing blockwise injective uniqueness theorem. -/
 theorem parentHamiltonianGroundSpace_le_bntSpan_of_reindexed_projectionSpan
@@ -513,12 +506,11 @@ The remaining missing ingredient is therefore a **periodic-chain block
 splitting theorem** of the form
 `parentHamiltonianGroundSpace (μ := μ) A L N ≤ ⨆ j, chainGroundSpace (A j) L N`,
 saying that a state whose cyclic windows all lie in the block-diagonal local
-ground space decomposes into a sum of block chain-ground-state components.
-The block-diagonal commutant reduction in `BlockDiagonalCommutant` now supplies the
-algebraic off-block-zero step once the virtual sector projections are known to
-lie in the finite word span of the assembled tensor. The repository still lacks
-that CF/BNT finite-span block-separation theorem and the resulting periodic-chain
-block-splitting infrastructure.
+ground space decomposes into a sum of block chain-ground-state components. The
+conditional Route B endgame in this file supplies the algebraic off-block-zero
+step once the #911 virtual-sector projection-span input is available and the
+wrapping/open-chain comparison has produced a commuting boundary matrix; it does
+not replace either of those remaining structural inputs.
 
 Given that block-splitting theorem, the ⊆ direction becomes:
 ```

--- a/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
+++ b/TNLean/MPS/ParentHamiltonian/DegenerateGS.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 import TNLean.MPS.BNT.Construction
 import TNLean.MPS.CanonicalForm.Assembly
+import TNLean.MPS.CanonicalForm.BlockDiagonalCommutant
 import TNLean.MPS.FundamentalTheorem.Multi
 
 /-!
@@ -24,7 +25,7 @@ The detailed proof is split conceptually into two inclusions:
 
 namespace MPSTensor
 
-open scoped Matrix
+open scoped Matrix BigOperators
 
 variable {d r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
 
@@ -172,6 +173,236 @@ theorem bnt_mem_groundSpace
   exact chainGroundSpace_block_le_toTensorFromBlocks μ A j hμj L N
     (mpv_mem_chainGroundSpace (A j) L N hN' hLN)
 
+/-- Boundary-map expansion for block-diagonal assembled boundaries.
+
+If the boundary matrix for `toTensorFromBlocks μ A` is itself the reindexed
+block diagonal with diagonal blocks `Xb k`, then the corresponding `N`-site
+open-chain vector is the sum of the blockwise open-chain vectors, with the
+expected weight factor `(μ k) ^ N`. -/
+private theorem groundSpaceMap_toTensorFromBlocks_blockDiagonal
+    (μ' : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (Xb : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) (N : ℕ) :
+    groundSpaceMap (toTensorFromBlocks μ' A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' Xb)) =
+      ∑ k : Fin r, (μ' k) ^ N • groundSpaceMap (A k) N (Xb k) := by
+  classical
+  ext σ
+  simp only [groundSpaceMap_apply]
+  have hwlen : (List.ofFn σ).length = N := by simp
+  rw [evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal μ' A (List.ofFn σ)]
+  rw [show Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+          (Matrix.blockDiagonal' fun k =>
+            (μ' k) ^ (List.ofFn σ).length • evalWord (A k) (List.ofFn σ)) *
+        Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv (Matrix.blockDiagonal' Xb) =
+      Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        ((Matrix.blockDiagonal' fun k =>
+            (μ' k) ^ (List.ofFn σ).length • evalWord (A k) (List.ofFn σ)) *
+          Matrix.blockDiagonal' Xb) from by
+        simp [Matrix.reindex_apply, Matrix.submatrix_mul_equiv]]
+  rw [Matrix.trace_reindex, ← Matrix.blockDiagonal'_mul, Matrix.trace_blockDiagonal']
+  simp [groundSpaceMap_apply, hwlen, Matrix.trace_smul, Algebra.smul_mul_assoc]
+
+/-- Applying `groundSpaceMap` to a scalar boundary matrix gives a scalar multiple
+of the periodic MPV coefficient vector. -/
+private theorem groundSpaceMap_matrix_scalar
+    (A : MPSTensor d D) (N : ℕ) (c : ℂ) :
+    groundSpaceMap A N (Matrix.scalar (Fin D) c) = c • (mpv A : NSiteSpace d N) := by
+  ext σ
+  simp only [groundSpaceMap_apply, Pi.smul_apply, smul_eq_mul, mpv, coeff]
+  have hscalar : Matrix.scalar (Fin D) c = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    ext i j
+    by_cases hij : i = j
+    · subst j
+      simp
+    · simp [Matrix.scalar, hij]
+  rw [hscalar, Matrix.mul_smul, mul_one, Matrix.trace_smul]
+  simp [smul_eq_mul]
+
+/-- Boundary-matrix block split from the projection-span input.
+
+This is the algebraic endgame for the block-decomposition argument. Assume the
+finite-span input that every virtual sector projection lies in the pulled-back
+span of length-`m` assembled word products. If a boundary matrix `X` for the
+assembled tensor commutes with those length-`m` words (the output expected from
+the wrapping-window comparison), then the open-chain vector
+`groundSpaceMap (toTensorFromBlocks μ A) N X` lies in the supremum of the
+blockwise periodic chain ground spaces.
+
+The proof first applies
+`MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan` to make the pulled-back
+boundary matrix block diagonal. Then the same length-`m` commutation, restricted
+to each diagonal block, and blockwise injectivity from `IsCanonicalFormBNT` force
+each diagonal block to be scalar. The boundary-map expansion above rewrites the
+state as a finite sum of scalar multiples of the block MPV states; each block MPV
+is in its own `chainGroundSpace`. -/
+theorem groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed_projectionSpan
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    (hCF : IsCanonicalFormBNT μ A) {L N m : ℕ}
+    (hL : 1 < L) (hN : N ≥ L + 1) (hm : 0 < m)
+    (hProj : ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord (toTensorFromBlocks μ A) (List.ofFn ω))))
+    {X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ}
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord (toTensorFromBlocks μ A) (List.ofFn ω) =
+        evalWord (toTensorFromBlocks μ A) (List.ofFn ω) * X) :
+    groundSpaceMap (toTensorFromBlocks μ A) N X ∈
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  classical
+  let e : ((k : Fin r) × Fin (dim k)) ≃ Fin (∑ k : Fin r, dim k) := finSigmaFinEquiv
+  have hBD :=
+    isBlockDiagonal'_of_commutes_reindexed_wordSpan
+      (B := toTensorFromBlocks μ A) (m := m) hProj hComm
+  rcases hBD with ⟨Xb, hXb⟩
+  have hCommRe : ∀ ω : Fin m → Fin d,
+      Matrix.blockDiagonal' Xb *
+          Matrix.blockDiagonal' (fun k : Fin r =>
+            (μ k) ^ m • evalWord (A k) (List.ofFn ω)) =
+        Matrix.blockDiagonal' (fun k : Fin r =>
+            (μ k) ^ m • evalWord (A k) (List.ofFn ω)) *
+          Matrix.blockDiagonal' Xb := by
+    intro ω
+    have h := congrArg (Matrix.reindex e.symm e.symm) (hComm ω)
+    have hEval :
+        Matrix.reindex e.symm e.symm
+            (evalWord (toTensorFromBlocks μ A) (List.ofFn ω)) =
+          Matrix.blockDiagonal' (fun k : Fin r =>
+            (μ k) ^ m • evalWord (A k) (List.ofFn ω)) := by
+      rw [evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal μ A (List.ofFn ω)]
+      ext a b
+      simp [e]
+    have hLeft :
+        Matrix.reindex e.symm e.symm
+            (X * evalWord (toTensorFromBlocks μ A) (List.ofFn ω)) =
+          Matrix.reindex e.symm e.symm X *
+            Matrix.reindex e.symm e.symm
+              (evalWord (toTensorFromBlocks μ A) (List.ofFn ω)) := by
+      rw [Matrix.reindex_apply, Matrix.reindex_apply, Matrix.reindex_apply]
+      exact (Matrix.submatrix_mul_equiv X
+        (evalWord (toTensorFromBlocks μ A) (List.ofFn ω)) e e e).symm
+    have hRight :
+        Matrix.reindex e.symm e.symm
+            (evalWord (toTensorFromBlocks μ A) (List.ofFn ω) * X) =
+          Matrix.reindex e.symm e.symm
+              (evalWord (toTensorFromBlocks μ A) (List.ofFn ω)) *
+            Matrix.reindex e.symm e.symm X := by
+      rw [Matrix.reindex_apply, Matrix.reindex_apply, Matrix.reindex_apply]
+      exact (Matrix.submatrix_mul_equiv
+        (evalWord (toTensorFromBlocks μ A) (List.ofFn ω)) X e e e).symm
+    rw [hLeft, hRight, hXb, hEval] at h
+    exact h
+  have hCommBlock : ∀ (k : Fin r) (ω : Fin m → Fin d),
+      Xb k * evalWord (A k) (List.ofFn ω) = evalWord (A k) (List.ofFn ω) * Xb k := by
+    intro k ω
+    have hblock_smul :
+        (μ k) ^ m • (Xb k * evalWord (A k) (List.ofFn ω)) =
+          (μ k) ^ m • (evalWord (A k) (List.ofFn ω) * Xb k) := by
+      have hblockEq :
+          Matrix.blockDiagonal' (fun k : Fin r =>
+              Xb k * ((μ k) ^ m • evalWord (A k) (List.ofFn ω))) =
+            Matrix.blockDiagonal' (fun k : Fin r =>
+              ((μ k) ^ m • evalWord (A k) (List.ofFn ω)) * Xb k) := by
+        rw [Matrix.blockDiagonal'_mul, Matrix.blockDiagonal'_mul]
+        exact hCommRe ω
+      ext a b
+      have hentry := congrFun (congrFun hblockEq ⟨k, a⟩) ⟨k, b⟩
+      simpa [Algebra.mul_smul_comm, Algebra.smul_mul_assoc] using hentry
+    have hμpow : (μ k) ^ m ≠ 0 :=
+      pow_ne_zero m (hCF.toHasStrictOrderedNonzeroWeights.mu_ne_zero k)
+    have hcancel := congrArg (fun M => ((μ k) ^ m)⁻¹ • M) hblock_smul
+    simpa [smul_smul, hμpow] using hcancel
+  have hScalar : ∀ k : Fin r, ∃ c : ℂ, Xb k = Matrix.scalar (Fin (dim k)) c := by
+    intro k
+    refine Matrix.isScalar_of_commute_span_eq_top
+      (S := Set.range fun ω : Fin m → Fin d => evalWord (A k) (List.ofFn ω))
+      (Xb k) ?_ ?_
+    · simpa [wordSpan] using
+        wordSpan_eq_top_of_isInjective (hCF.toHasInjectiveBlocks.block_injective k) hm
+    · intro M hM
+      rcases hM with ⟨ω, rfl⟩
+      exact hCommBlock k ω
+  choose c hc using hScalar
+  have hX : X = Matrix.reindex e e (Matrix.blockDiagonal' Xb) := by
+    calc
+      X = Matrix.reindex e e (Matrix.reindex e.symm e.symm X) := by
+        ext a b
+        simp [e]
+      _ = Matrix.reindex e e (Matrix.blockDiagonal' Xb) := by
+        rw [hXb]
+  rw [hX, groundSpaceMap_toTensorFromBlocks_blockDiagonal]
+  refine Submodule.sum_mem _ ?_
+  intro k _
+  rw [hc k, groundSpaceMap_matrix_scalar, smul_smul]
+  exact Submodule.smul_mem _ _
+    ((le_iSup (fun j : Fin r => chainGroundSpace (A j) L N) k)
+      (mpv_mem_chainGroundSpace (A k) L N (by omega) (by omega)))
+
+/-- Conditional reverse block split from the finite projection-span input.
+
+Besides the projection-span hypothesis, this theorem assumes the boundary-matrix
+output of the wrapping/open-chain layer: every vector in the assembled periodic
+ground space can be represented as `groundSpaceMap` applied to a boundary matrix
+that commutes with all length-`m` assembled word products. Under these inputs,
+the assembled periodic ground space is contained in the supremum of the blockwise
+periodic ground spaces. -/
+theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    (hCF : IsCanonicalFormBNT μ A) {L N m : ℕ}
+    (hL : 1 < L) (hN : N ≥ L + 1) (hm : 0 < m)
+    (hProj : ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord (toTensorFromBlocks μ A) (List.ofFn ω))))
+    (hBoundary : ∀ ⦃ψ : NSiteSpace d N⦄,
+      ψ ∈ chainGroundSpace (toTensorFromBlocks μ A) L N →
+        ∃ X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks μ A) N X ∧
+          ∀ ω : Fin m → Fin d,
+            X * evalWord (toTensorFromBlocks μ A) (List.ofFn ω) =
+              evalWord (toTensorFromBlocks μ A) (List.ofFn ω) * X) :
+    chainGroundSpace (toTensorFromBlocks μ A) L N ≤
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  intro ψ hψ
+  rcases hBoundary hψ with ⟨X, hψX, hComm⟩
+  rw [hψX]
+  exact groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed_projectionSpan
+    (μ := μ) A hCF hL hN hm hProj hComm
+
+/-- Conditional periodic block-decomposition equality for the assembled tensor.
+
+This combines the already-proved forward inclusion with
+`chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan`. The
+only CF/BNT-specific finite-span assumption here is the projection-span input;
+the remaining boundary-matrix representation/commutation hypothesis is the
+wrapping-window output that supplies the boundary matrix to which the commutant
+reduction applies. -/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_reindexed_projectionSpan
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    (hCF : IsCanonicalFormBNT μ A) {L N m : ℕ}
+    (hL : 1 < L) (hN : N ≥ L + 1) (hm : 0 < m)
+    (hProj : ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord (toTensorFromBlocks μ A) (List.ofFn ω))))
+    (hBoundary : ∀ ⦃ψ : NSiteSpace d N⦄,
+      ψ ∈ chainGroundSpace (toTensorFromBlocks μ A) L N →
+        ∃ X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks μ A) N X ∧
+          ∀ ω : Fin m → Fin d,
+            X * evalWord (toTensorFromBlocks μ A) (List.ofFn ω) =
+              evalWord (toTensorFromBlocks μ A) (List.ofFn ω) * X) :
+    chainGroundSpace (toTensorFromBlocks μ A) L N =
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  apply le_antisymm
+  · exact chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan
+      (μ := μ) A hCF hL hN hm hProj hBoundary
+  · exact iSup_chainGroundSpace_block_le_toTensorFromBlocks μ
+      (fun j => hCF.toHasStrictOrderedNonzeroWeights.mu_ne_zero j) A L N
+
 /-- If the assembled periodic ground space splits blockwise into the block chain
 ground spaces, then blockwise injective uniqueness already yields membership in
 `bntSpan`. This isolates the endgame so the only missing ingredient is the
@@ -205,6 +436,47 @@ private theorem parentHamiltonianGroundSpace_le_bntSpan_of_block_chain_split
   rw [mpvSubmodule, Submodule.mem_span_singleton] at hψ
   rcases hψ with ⟨c, rfl⟩
   exact Submodule.smul_mem _ c (Submodule.subset_span ⟨j, rfl⟩)
+
+/-- Conditional containment in the BNT span from projection-span and boundary data.
+
+This is the parent-Hamiltonian endgame after a block split has been produced by
+`chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan`.  The
+projection-span hypothesis is the finite CF/BNT input still tracked separately;
+the boundary hypothesis is the wrapping/open-chain output that supplies the
+commuting boundary matrix.  The proof then delegates to
+`parentHamiltonianGroundSpace_le_bntSpan_of_block_chain_split`, so the final step
+uses the existing blockwise injective uniqueness theorem. -/
+theorem parentHamiltonianGroundSpace_le_bntSpan_of_reindexed_projectionSpan
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    (hCF : IsCanonicalFormBNT μ A) {L N m : ℕ}
+    (hL : 1 < L) (hN : N ≥ L + 1) (hm : 0 < m)
+    (hProj : ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord (toTensorFromBlocks μ A) (List.ofFn ω))))
+    (hBoundary : ∀ ⦃ψ : NSiteSpace d N⦄,
+      ψ ∈ parentHamiltonianGroundSpace (μ := μ) A L N →
+        ∃ X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks μ A) N X ∧
+          ∀ ω : Fin m → Fin d,
+            X * evalWord (toTensorFromBlocks μ A) (List.ofFn ω) =
+              evalWord (toTensorFromBlocks μ A) (List.ofFn ω) * X) :
+    parentHamiltonianGroundSpace (μ := μ) A L N ≤ bntSpan A N := by
+  refine parentHamiltonianGroundSpace_le_bntSpan_of_block_chain_split
+    (μ := μ) A hCF hL hN ?_
+  have hBoundary' : ∀ ⦃ψ : NSiteSpace d N⦄,
+      ψ ∈ chainGroundSpace (toTensorFromBlocks μ A) L N →
+        ∃ X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks μ A) N X ∧
+          ∀ ω : Fin m → Fin d,
+            X * evalWord (toTensorFromBlocks μ A) (List.ofFn ω) =
+              evalWord (toTensorFromBlocks μ A) (List.ofFn ω) * X := by
+    intro ψ hψ
+    exact hBoundary (by simpa [parentHamiltonianGroundSpace_eq] using hψ)
+  simpa [parentHamiltonianGroundSpace_eq] using
+    chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan
+      (μ := μ) A hCF hL hN hm hProj hBoundary'
 
 /-- Reverse-inclusion step for the BNT ground-space theorem.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2086,13 +2086,58 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     gives the entrywise off-block-zero formulation.
 \end{proof}
 
+\begin{lemma}[Conditional boundary-matrix block split from projection span]
+    \label{lem:conditional_boundary_matrix_block_split_projection_span}
+    \lean{MPSTensor.groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed_projectionSpan}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_reindexed_projectionSpan}
+    \lean{MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_reindexed_projectionSpan}
+    \leanok
+    \uses{lem:route_b_block_diagonal_commutant_reduction,
+        lem:eval_word_block_diagonal_tensor, lem:mpv_mem_chain_ground_space,
+        lem:isup_chain_ground_space_block_le_assembled,
+        thm:chain_ground_space_eq_mpv_blk, lem:center_scalar}
+    Assume that every virtual sector projection lies in the pulled-back span of
+    the length-$m$ word products of the assembled tensor.  If a boundary matrix
+    for the assembled tensor commutes with all those length-$m$ words, then the
+    vector obtained by applying the assembled ground-space map to that boundary
+    matrix lies in $\bigvee_j \mathcal G_{N,L}(A_j)$.  Consequently, if every
+    assembled periodic-chain ground vector admits such a commuting boundary
+    matrix representation (the output of the wrapping-window comparison), then
+    \[
+        \mathcal G_{N,L}\bigl(\operatorname{assemble}_\mu(A)\bigr)
+        \subseteq \bigvee_j \mathcal G_{N,L}(A_j),
+    \]
+    and together with the already-proved forward inclusion this gives the
+    corresponding conditional equality.  Composing the reverse inclusion with
+    blockwise injective uniqueness gives the conditional containment of the
+    assembled parent ground space in the BNT span.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:route_b_block_diagonal_commutant_reduction,
+        lem:eval_word_block_diagonal_tensor, lem:mpv_mem_chain_ground_space,
+        lem:isup_chain_ground_space_block_le_assembled,
+        thm:chain_ground_space_eq_mpv_blk, lem:center_scalar}
+    The commutant reduction makes the pulled-back boundary matrix block diagonal.
+    Restricting the same word-commutation identities to a diagonal block and
+    using the injectivity of that block shows, by the scalar-commutant lemma, that
+    each diagonal block is scalar.  Expanding the assembled ground-space map on a
+    block-diagonal boundary matrix gives a finite sum of scalar multiples of the
+    block MPV states, and each block MPV lies in its own periodic chain ground
+    space.  The reverse-inclusion, equality, and BNT-span forms are then formal
+    wrappers around this boundary-matrix calculation, the forward inclusion, and
+    the blockwise uniqueness theorem.
+\end{proof}
+
 \begin{theorem}[Containment in the BNT span by block decomposition]
     \label{thm:parent_ground_space_le_bnt_span}
     \lean{MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition}
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, def:bnt_span,
         thm:chain_ground_space_eq_mpv_blk,
-        lem:route_b_block_diagonal_commutant_reduction}
+        lem:conditional_boundary_matrix_block_split_projection_span}
     If $A$ is in canonical-form/BNT and $1 < L$ and $N \ge L + 1$, every vector in the
     assembled parent ground space should decompose into blockwise chain ground states, and
     therefore lie in the BNT span.
@@ -2101,11 +2146,12 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \notready
     The remaining structural step is the periodic block decomposition of the assembled chain
-    ground space. The block-diagonal commutant reduction above supplies the algebraic
-    off-block-zero step once the virtual sector projections are obtained from the finite word
-    span of the assembled
-    tensor. With that decomposition available, one applies the blockwise injective uniqueness
-    theorem to each block separately and recovers the BNT span.
+    ground space. Lemma~\ref{lem:conditional_boundary_matrix_block_split_projection_span}
+    supplies the conditional boundary-matrix endgame once the virtual sector
+    projections are obtained from the finite word span of the assembled tensor and
+    the wrapping-window comparison provides a commuting boundary matrix. With that
+    decomposition available, one applies the blockwise injective uniqueness theorem
+    to each block separately and recovers the BNT span.
 \end{proof}
 
 \begin{theorem}[Ground space equals span of BNT]\label{thm:gs_eq_bnt_span}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2097,21 +2097,25 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         lem:eval_word_block_diagonal_tensor, lem:mpv_mem_chain_ground_space,
         lem:isup_chain_ground_space_block_le_assembled,
         thm:chain_ground_space_eq_mpv_blk, lem:center_scalar}
-    Assume that every virtual sector projection lies in the pulled-back span of
-    the length-$m$ word products of the assembled tensor.  If a boundary matrix
-    for the assembled tensor commutes with all those length-$m$ words, then the
-    vector obtained by applying the assembled ground-space map to that boundary
-    matrix lies in $\bigvee_j \mathcal G_{N,L}(A_j)$.  Consequently, if every
-    assembled periodic-chain ground vector admits such a commuting boundary
-    matrix representation (the output of the wrapping-window comparison), then
+    Let $A$ be in canonical-form/BNT, and assume $1<L$, $N \ge L+1$, and
+    $0<m$.  Assume the remaining \#911 input: every virtual sector projection
+    lies in the pulled-back span of the length-$m$ word products of the assembled
+    tensor.  If a boundary matrix for the assembled tensor commutes with all
+    those length-$m$ words, then the vector obtained by applying the assembled
+    ground-space map to that boundary matrix lies in
+    $\bigsqcup_j \mathcal G_{N,L}(A_j)$.  Consequently, if every assembled
+    periodic-chain ground vector admits such a commuting boundary matrix
+    representation (the output of the wrapping-window comparison), then
     \[
-        \mathcal G_{N,L}\bigl(\operatorname{assemble}_\mu(A)\bigr)
-        \subseteq \bigvee_j \mathcal G_{N,L}(A_j),
+        \mathcal G_{N,L}\bigl(\operatorname{Assemble}(\mu, A)\bigr)
+        \subseteq \bigsqcup_j \mathcal G_{N,L}(A_j),
     \]
     and together with the already-proved forward inclusion this gives the
     corresponding conditional equality.  Composing the reverse inclusion with
     blockwise injective uniqueness gives the conditional containment of the
-    assembled parent ground space in the BNT span.
+    assembled parent ground space in the BNT span; this lemma is not a restatement
+    of the final theorem, because it keeps the \#911 projection-span and boundary
+    representation inputs explicit.
 \end{lemma}
 
 \begin{proof}
@@ -2126,9 +2130,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     each diagonal block is scalar.  Expanding the assembled ground-space map on a
     block-diagonal boundary matrix gives a finite sum of scalar multiples of the
     block MPV states, and each block MPV lies in its own periodic chain ground
-    space.  The reverse-inclusion, equality, and BNT-span forms are then formal
-    wrappers around this boundary-matrix calculation, the forward inclusion, and
-    the blockwise uniqueness theorem.
+    space.  The reverse-inclusion, equality, and BNT-span forms are then
+    reformulations of this boundary-matrix calculation, combined with the forward
+    inclusion and the blockwise uniqueness theorem.
 \end{proof}
 
 \begin{theorem}[Containment in the BNT span by block decomposition]
@@ -2145,9 +2149,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{proof}
     \notready
-    The remaining structural step is the periodic block decomposition of the assembled chain
-    ground space. Lemma~\ref{lem:conditional_boundary_matrix_block_split_projection_span}
-    supplies the conditional boundary-matrix endgame once the virtual sector
+    The remaining structural step is the periodic block decomposition of the
+    assembled chain ground space.
+    Lemma~\ref{lem:conditional_boundary_matrix_block_split_projection_span}
+    supplies the conditional boundary-matrix endgame once the \#911 virtual-sector
     projections are obtained from the finite word span of the assembled tensor and
     the wrapping-window comparison provides a commuting boundary matrix. With that
     decomposition available, one applies the blockwise injective uniqueness theorem


### PR DESCRIPTION
## Summary

Adds the conditional boundary-matrix block-split endgame in `DegenerateGS.lean`.

New proved declarations:
- `MPSTensor.groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed_projectionSpan`: if the sector projections lie in the pulled-back span of length-`m` assembled words and a boundary matrix commutes with those words, then the assembled `groundSpaceMap` vector lies in `⨆ j, chainGroundSpace (A j) L N`.
- `MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan`: conditional reverse inclusion assuming the wrapping/open-chain layer supplies a commuting boundary matrix representation for every assembled chain-ground vector.
- `MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_reindexed_projectionSpan`: conditional equality by combining the reverse inclusion with the existing forward inclusion.
- `MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_reindexed_projectionSpan`: conditional BNT-span containment by feeding the split into the existing blockwise-uniqueness endgame.

Blueprint Chapter 14 now records these as `lem:conditional_boundary_matrix_block_split_projection_span` and routes the not-yet-unconditional BNT-span theorem through that conditional endgame.

## Scope / remaining inputs

This PR does **not** prove the CF/BNT finite-span separation theorem from #911, and it does **not** prove the boundary extraction theorem from cyclic ground-space membership. It isolates the honest algebraic endgame once those inputs are available.

Please treat this as ready for a simplification/cleanup pass before merge, especially around the long conditional hypothesis names.

Refs #905, #911, #870, #190.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.DegenerateGS`
- `lake build TNLean`
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- Proof-integrity scan on touched files: only the pre-existing `DegenerateGS.lean` deferred proof at `parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial new Lean proofs and conditional theorems around block-diagonal commutant reduction and ground-space decomposition; risk is mainly proof fragility/maintenance due to long hypotheses and algebraic rewrites, not runtime behavior.
> 
> **Overview**
> Adds a **conditional “Route B” block-splitting endgame** in `DegenerateGS.lean`: from the #911 *virtual-sector projection-in-word-span* assumption plus a commuting boundary-matrix hypothesis, it proves `groundSpaceMap (toTensorFromBlocks μ A) N X ∈ ⨆ j, chainGroundSpace (A j) L N`, then lifts this to a conditional reverse inclusion and resulting equality for `chainGroundSpace (toTensorFromBlocks μ A) L N`.
> 
> Builds a corresponding conditional theorem `parentHamiltonianGroundSpace_le_bntSpan_of_reindexed_projectionSpan` by feeding the block split into the existing blockwise injective-uniqueness endgame, and updates the Chapter 14 blueprint to record and reference this new conditional lemma in the not-yet-finished BNT-span theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a71ab0fca870ee27f9d7398cf67ebdf05803b9f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->