### PR TITLE
feat(Analysis): add Friedrichs row-bound reduction (#460)

### DIFF
--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -206,7 +206,7 @@ theorem quadraticForm_sum_projections_of_ordered_rowSum {γ : ℝ} (hγle : γ �
         add_le_add le_rfl hCrossSum
     _ = (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := hHH.symm
 
-/-- Finite-overlap Friedrichs input for a family of symmetric projections.
+/-- Finite-overlap Friedrichs conditions for a family of symmetric projections.
 
 Assume that each row has at most `m` interacting off-diagonal entries.  On an
 interacting pair, a Friedrichs-angle estimate supplies the ordered bound with

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -136,6 +136,29 @@ theorem crossTerm_sum_bound_of_ordered_rowSum {γ : ℝ} (hγle : γ ≤ 1)
             intro j hj
             exact hCross i j hj
 
+private theorem indicatorRowSum_le_one_of_card_le (overlaps : ι → ι → Prop)
+    [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m) :
+    ∀ i, (∑ j ∈ Finset.univ.erase i,
+      if overlaps i j then ((m : ℝ)⁻¹) else 0) ≤ 1 := by
+  intro i
+  have hsum : (∑ j ∈ Finset.univ.erase i,
+      if overlaps i j then ((m : ℝ)⁻¹) else 0) =
+      (((Finset.univ.erase i).filter (fun j => overlaps i j)).card : ℝ) *
+        ((m : ℝ)⁻¹) := by
+    rw [← Finset.sum_filter]
+    simp [Finset.sum_const, nsmul_eq_mul]
+  rw [hsum]
+  have hmpos : (0 : ℝ) < (m : ℝ) := by exact_mod_cast hm
+  have hcard_le :
+      (((Finset.univ.erase i).filter (fun j => overlaps i j)).card : ℝ) ≤
+        (m : ℝ) := by
+    exact_mod_cast hCard i
+  have hinv_nonneg : 0 ≤ ((m : ℝ)⁻¹) := inv_nonneg.mpr hmpos.le
+  have hmul := mul_le_mul_of_nonneg_right hcard_le hinv_nonneg
+  have hmne : (m : ℝ) ≠ 0 := ne_of_gt hmpos
+  simpa [hmne] using hmul
+
 /-- If the ordered off-diagonal terms of a finite family of symmetric
 projections satisfy a row-summable cross-term bound, then the sum satisfies
 `H² ≥ γ H` as a quadratic form.
@@ -182,6 +205,45 @@ theorem quadraticForm_sum_projections_of_ordered_rowSum {γ : ℝ} (hγle : γ �
     _ ≤ (∑ i, q i) + ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j :=
         add_le_add le_rfl hCrossSum
     _ = (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := hHH.symm
+
+/-- Finite-overlap Friedrichs input for a family of symmetric projections.
+
+Assume that each row has at most `m` interacting off-diagonal entries.  On an
+interacting pair, a Friedrichs-angle estimate supplies the ordered bound with
+coefficient `1 / m`; on a noninteracting pair, the ordered cross term is
+nonnegative.  Then the coefficient matrix
+`c i j = if overlaps i j then (m : ℝ)⁻¹ else 0` has row sums at most one, so the
+abstract row-sum reduction gives `H² ≥ γ H` as a quadratic form.
+
+This is the paper-level finite-range step: locality provides the cardinal bound
+(for parent Hamiltonians, `m = 2 * (L - 1)`), while the analytic Friedrichs-angle
+argument provides the interacting-pair estimate. -/
+theorem quadraticForm_sum_projections_of_finiteOverlap {γ : ℝ} (hγle : γ ≤ 1)
+    (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)
+    (overlaps : ι → ι → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (hDisjoint : ∀ i j, j ∈ Finset.univ.erase i → ¬ overlaps i j →
+      ∀ v : E, 0 ≤ (⟪P i v, P j v⟫_ℂ).re)
+    (hFriedrichs : ∀ i j, j ∈ Finset.univ.erase i → overlaps i j →
+      ∀ v : E,
+        - (1 - γ) * ((m : ℝ)⁻¹) * (⟪P i v, v⟫_ℂ).re ≤
+          (⟪P i v, P j v⟫_ℂ).re) :
+    ∀ v : E,
+      γ * (⟪(∑ i, P i) v, v⟫_ℂ).re ≤
+        (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := by
+  classical
+  let c : ι → ι → ℝ := fun i j => if overlaps i j then ((m : ℝ)⁻¹) else 0
+  have hRow : ∀ i, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1 := by
+    intro i
+    simpa [c] using indicatorRowSum_le_one_of_card_le overlaps hm hCard i
+  have hCross : ∀ i j, j ∈ Finset.univ.erase i → ∀ v : E,
+      -(1 - γ) * c i j * (⟪P i v, v⟫_ℂ).re ≤
+        (⟪P i v, P j v⟫_ℂ).re := by
+    intro i j hij v
+    by_cases hoverlap : overlaps i j
+    · simpa [c, hoverlap] using hFriedrichs i j hij hoverlap v
+    · simpa [c, hoverlap] using hDisjoint i j hij hoverlap v
+  exact quadraticForm_sum_projections_of_ordered_rowSum hγle P hP c hRow hCross
 
 end OffDiagonal
 

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -136,12 +136,12 @@ theorem crossTerm_sum_bound_of_ordered_rowSum {γ : ℝ} (hγle : γ ≤ 1)
             intro j hj
             exact hCross i j hj
 
-private theorem indicatorRowSum_le_one_of_card_le (overlaps : ι → ι → Prop)
+private theorem indicator_row_sum_le_one_of_card_le (overlaps : ι → ι → Prop)
     [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
-    (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m) :
-    ∀ i, (∑ j ∈ Finset.univ.erase i,
+    (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (i : ι) :
+    (∑ j ∈ Finset.univ.erase i,
       if overlaps i j then ((m : ℝ)⁻¹) else 0) ≤ 1 := by
-  intro i
   have hsum : (∑ j ∈ Finset.univ.erase i,
       if overlaps i j then ((m : ℝ)⁻¹) else 0) =
       (((Finset.univ.erase i).filter (fun j => overlaps i j)).card : ℝ) *
@@ -215,10 +215,10 @@ nonnegative.  Then the coefficient matrix
 `c i j = if overlaps i j then (m : ℝ)⁻¹ else 0` has row sums at most one, so the
 abstract row-sum reduction gives `H² ≥ γ H` as a quadratic form.
 
-This is the paper-level finite-range step: locality provides the cardinal bound
+This is the abstract finite-range step: locality provides the cardinal bound
 (for parent Hamiltonians, `m = 2 * (L - 1)`), while the analytic Friedrichs-angle
 argument provides the interacting-pair estimate. -/
-theorem quadraticForm_sum_projections_of_finiteOverlap {γ : ℝ} (hγle : γ ≤ 1)
+theorem quadraticForm_sum_projections_of_finite_overlap {γ : ℝ} (hγle : γ ≤ 1)
     (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)
     (overlaps : ι → ι → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
     (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
@@ -235,7 +235,7 @@ theorem quadraticForm_sum_projections_of_finiteOverlap {γ : ℝ} (hγle : γ �
   let c : ι → ι → ℝ := fun i j => if overlaps i j then ((m : ℝ)⁻¹) else 0
   have hRow : ∀ i, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1 := by
     intro i
-    simpa [c] using indicatorRowSum_le_one_of_card_le overlaps hm hCard i
+    simpa [c] using indicator_row_sum_le_one_of_card_le overlaps hm hCard i
   have hCross : ∀ i j, j ∈ Finset.univ.erase i → ∀ v : E,
       -(1 - γ) * c i j * (⟪P i v, v⟫_ℂ).re ≤
         (⟪P i v, P j v⟫_ℂ).re := by

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -211,9 +211,9 @@ theorem quadraticForm_sum_projections_of_ordered_rowSum {γ : ℝ} (hγle : γ �
 Assume that each row has at most `m` interacting off-diagonal entries.  On an
 interacting pair, a Friedrichs-angle estimate supplies the ordered bound with
 coefficient `1 / m`; on a noninteracting pair, the ordered cross term is
-nonnegative.  Then the coefficient matrix
-`c i j = if overlaps i j then (m : ℝ)⁻¹ else 0` has row sums at most one, so the
-abstract row-sum reduction gives `H² ≥ γ H` as a quadratic form.
+nonnegative.  Then choosing coefficient `1 / m` on interacting pairs and `0`
+on noninteracting pairs gives row sums at most one, so the abstract row-sum
+reduction gives `H² ≥ γ H` as a quadratic form.
 
 This is the abstract finite-range step: locality provides the cardinal bound
 (for parent Hamiltonians, `m = 2 * (L - 1)`), while the analytic Friedrichs-angle

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -72,8 +72,8 @@ concrete Friedrichs-angle/row-sum lower bound that
   reusable reduction from explicit ordered cross-term row bounds for the
   local symmetric projections to the quadratic-form hypothesis above.
 * `MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs` — a
-  finite-overlap interface turning local Friedrichs estimates and row-cardinality
-  bounds into the ordered row-sum input.
+  finite-overlap interface turning explicit local projection, overlap,
+  non-overlap positivity, and Friedrichs estimates into the gap input.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
   Friedrichs-angle bound recorded in
@@ -370,19 +370,22 @@ private theorem cyclicRestrictES_adjoint_apply {N : ℕ} (hN : 0 < N) {L : ℕ}
               (cyclicRestrictES (d := d) hN L i τ).adjoint v⟫_ℂ := by
               simpa using (EuclideanSpace.inner_single_left σ (1 : ℂ)
                 ((cyclicRestrictES (d := d) hN L i τ).adjoint v)).symm
-      _ = ⟪cyclicRestrictES (d := d) hN L i τ (EuclideanSpace.single σ (1 : ℂ)), v⟫_ℂ := by
+      _ = ⟪cyclicRestrictES (d := d) hN L i τ
+              (EuclideanSpace.single σ (1 : ℂ)), v⟫_ℂ := by
             rw [LinearMap.adjoint_inner_right]
       _ = ⟪EuclideanSpace.single (extractWindow L i σ) (1 : ℂ), v⟫_ℂ := by
             rw [cyclicRestrictES_single_of_sameOutsideWindow hN hLN i σ τ hστ]
       _ = if SameOutsideWindow (L := L) i σ τ then v (extractWindow L i σ) else 0 := by
-            simpa [hστ] using (EuclideanSpace.inner_single_left (extractWindow L i σ) (1 : ℂ) v)
+            simpa [hστ] using
+              (EuclideanSpace.inner_single_left (extractWindow L i σ) (1 : ℂ) v)
   · calc
       ((cyclicRestrictES (d := d) hN L i τ).adjoint v) σ
           = ⟪EuclideanSpace.single σ (1 : ℂ),
               (cyclicRestrictES (d := d) hN L i τ).adjoint v⟫_ℂ := by
               simpa using (EuclideanSpace.inner_single_left σ (1 : ℂ)
                 ((cyclicRestrictES (d := d) hN L i τ).adjoint v)).symm
-      _ = ⟪cyclicRestrictES (d := d) hN L i τ (EuclideanSpace.single σ (1 : ℂ)), v⟫_ℂ := by
+      _ = ⟪cyclicRestrictES (d := d) hN L i τ
+              (EuclideanSpace.single σ (1 : ℂ)), v⟫_ℂ := by
             rw [LinearMap.adjoint_inner_right]
       _ = ⟪0, v⟫_ℂ := by
             rw [cyclicRestrictES_single_of_not_sameOutsideWindow hN i σ τ hστ]
@@ -453,7 +456,8 @@ summands `Rᵢ,τ† P_L Rᵢ,τ`. -/
 theorem localTermES_eq_average_localTermESSummand {N : ℕ} (A : MPSTensor d D)
     {L : ℕ} (hLN : L ≤ N) (i : Fin N) :
     localTermES A L i =
-      ((((d ^ L : ℕ) : ℂ)⁻¹) • (∑ τ : Cfg d N, localTermESSummand A (Fin.pos i) L i τ)) := by
+      ((((d ^ L : ℕ) : ℂ)⁻¹) •
+        (∑ τ : Cfg d N, localTermESSummand A (Fin.pos i) L i τ)) := by
   classical
   ext v σ
   let q : Cfg d N → Prop := SameOutsideWindow (L := L) i σ
@@ -697,7 +701,7 @@ theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
   have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
     have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
     rw [div_le_iff₀ hden]
-    nlinarith
+    nlinarith [hLge_one]
   exact parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
     A L N hγle (c N) (hProj N hLN) (hRow N hLN) (hCross N hLN) v
 
@@ -705,7 +709,7 @@ theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
 Friedrichs data.
 
 This is the local-window specialization of
-`ProjectionGeometry.quadraticForm_sum_projections_of_finiteOverlap`.  The
+`ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap`.  The
 predicate `overlaps i j` marks the off-diagonal pairs for which a Friedrichs-angle
 estimate is needed.  If each row has at most `m` such pairs, the non-overlap
 cross terms are nonnegative, and every overlap obeys the ordered estimate with
@@ -730,7 +734,7 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
           parentHamiltonianES A L N v⟫_ℂ).re := by
   intro v
   simpa [parentHamiltonianES_eq_sum_localTermES A L N] using
-    (ProjectionGeometry.quadraticForm_sum_projections_of_finiteOverlap
+    (ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap
       (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
       (fun i : Fin N => localTermES A L i) hProj overlaps hm hCard hDisjoint
       hFriedrichs v)
@@ -739,9 +743,10 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
 
 For parent-Hamiltonian windows of length `L`, the expected finite-range bound is
 `m = 2 * (L - 1)`: each local term overlaps at most that many other cyclic
-translates when `N ≥ 2L`.  This theorem does not prove the MPS-specific overlap
-or Friedrichs-angle estimates; rather, it records exactly the assumptions needed
-to turn those estimates into the existing ordered row-sum gap theorem. -/
+translates when `N ≥ 2L`.  This theorem leaves the transported local projection
+structure, the cyclic-window overlap predicate, non-overlap positivity, and the
+Friedrichs-angle estimate as explicit inputs. It only performs the finite-overlap
+row-sum reduction and the existing quadratic-form-to-gap conversion. -/
 theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (overlaps : ∀ N : ℕ, Fin N → Fin N → Prop)
@@ -776,7 +781,7 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
   have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
     have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
     rw [div_le_iff₀ hden]
-    nlinarith
+    nlinarith [hLge_one]
   have hm : 0 < 2 * (L - 1) :=
     Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
   exact parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -71,6 +71,9 @@ concrete Friedrichs-angle/row-sum lower bound that
 * `MPSTensor.parentHamiltonianES_gap_bound_of_ordered_local_term_bounds` — a
   reusable reduction from explicit ordered cross-term row bounds for the
   local symmetric projections to the quadratic-form hypothesis above.
+* `MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs` — a
+  finite-overlap interface turning local Friedrichs estimates and row-cardinality
+  bounds into the ordered row-sum input.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
   Friedrichs-angle bound recorded in
@@ -697,6 +700,88 @@ theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
     nlinarith
   exact parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
     A L N hγle (c N) (hProj N hLN) (hRow N hLN) (hCross N hLN) v
+
+/-- Fixed-chain martingale quadratic-form estimate from finite-overlap
+Friedrichs data.
+
+This is the local-window specialization of
+`ProjectionGeometry.quadraticForm_sum_projections_of_finiteOverlap`.  The
+predicate `overlaps i j` marks the off-diagonal pairs for which a Friedrichs-angle
+estimate is needed.  If each row has at most `m` such pairs, the non-overlap
+cross terms are nonnegative, and every overlap obeys the ordered estimate with
+coefficient `1 / m`, then the transported parent Hamiltonian satisfies
+`H² ≥ γ H` as a quadratic form. -/
+theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
+    (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
+    (overlaps : Fin N → Fin N → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hProj : ∀ i : Fin N, (localTermES A L i).IsSymmetricProjection)
+    (hCard : ∀ i : Fin N,
+      ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (hDisjoint : ∀ i j : Fin N, j ∈ Finset.univ.erase i → ¬ overlaps i j →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re)
+    (hFriedrichs : ∀ i j : Fin N, j ∈ Finset.univ.erase i → overlaps i j →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        - (1 - γ) * ((m : ℝ)⁻¹) * (⟪localTermES A L i v, v⟫_ℂ).re ≤
+          (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re) :
+    ∀ v : EuclideanSpace ℂ (Cfg d N),
+      γ * (⟪parentHamiltonianES A L N v, v⟫_ℂ).re ≤
+        (⟪parentHamiltonianES A L N v,
+          parentHamiltonianES A L N v⟫_ℂ).re := by
+  intro v
+  simpa [parentHamiltonianES_eq_sum_localTermES A L N] using
+    (ProjectionGeometry.quadraticForm_sum_projections_of_finiteOverlap
+      (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
+      (fun i : Fin N => localTermES A L i) hProj overlaps hm hCard hDisjoint
+      hFriedrichs v)
+
+/-- Uniform explicit gap-bound reduction from finite-overlap Friedrichs data.
+
+For parent-Hamiltonian windows of length `L`, the expected finite-range bound is
+`m = 2 * (L - 1)`: each local term overlaps at most that many other cyclic
+translates when `N ≥ 2L`.  This theorem does not prove the MPS-specific overlap
+or Friedrichs-angle estimates; rather, it records exactly the assumptions needed
+to turn those estimates into the existing ordered row-sum gap theorem. -/
+theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (overlaps : ∀ N : ℕ, Fin N → Fin N → Prop)
+    [∀ N : ℕ, DecidableRel (overlaps N)]
+    (hProj : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i : Fin N),
+      (localTermES A L i).IsSymmetricProjection)
+    (hCard : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i : Fin N),
+      ((Finset.univ.erase i).filter (fun j => overlaps N i j)).card ≤ 2 * (L - 1))
+    (hDisjoint : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → ¬ overlaps N i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re)
+    (hFriedrichs : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → overlaps N i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹) *
+                (⟪localTermES A L i v, v⟫_ℂ).re ≤
+            (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
+  intro N hLN v
+  have hLpos : (0 : ℝ) < (L : ℝ) := by
+    exact_mod_cast (Nat.zero_lt_of_lt hL)
+  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
+    exact_mod_cast (Nat.le_of_lt hL)
+  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
+    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
+    rw [div_le_iff₀ hden]
+    nlinarith
+  have hm : 0 < 2 * (L - 1) :=
+    Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
+  exact parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
+    A L N hγle (overlaps N) hm (hProj N hLN) (hCard N hLN)
+    (hDisjoint N hLN) (hFriedrichs N hLN) v
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -72,8 +72,8 @@ concrete Friedrichs-angle/row-sum lower bound that
   reusable reduction from explicit ordered cross-term row bounds for the
   local symmetric projections to the quadratic-form hypothesis above.
 * `MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs` — a
-  finite-overlap interface turning explicit local projection, overlap,
-  non-overlap positivity, and Friedrichs estimates into the gap input.
+  finite-overlap reduction turning explicit local projection, overlap,
+  non-overlap positivity, and Friedrichs estimates into the gap estimate.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
   Friedrichs-angle bound recorded in
@@ -118,7 +118,7 @@ the row-sum bound) produces the operator inequality `H² ≥ γ H` for the
 PSD operator `H`, the norm lower bound — and hence the spectral gap
 for eigenvectors of `H` — follows by the spectral theorem. This lemma
 provides the final spectral-theorem step; the remaining MPS-specific
-quadratic-form input is recorded separately in
+quadratic-form hypothesis is recorded separately in
 `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`. -/
 theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 < γ)
     {H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι} (hH : H.IsPositive)
@@ -745,7 +745,7 @@ For parent-Hamiltonian windows of length `L`, the expected finite-range bound is
 `m = 2 * (L - 1)`: each local term overlaps at most that many other cyclic
 translates when `N ≥ 2L`.  This theorem leaves the transported local projection
 structure, the cyclic-window overlap predicate, non-overlap positivity, and the
-Friedrichs-angle estimate as explicit inputs. It only performs the finite-overlap
+Friedrichs-angle estimate as explicit hypotheses. It only performs the finite-overlap
 row-sum reduction and the existing quadratic-form-to-gap conversion. -/
 theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)

--- a/audits/2026-04-25_issue460_friedrichs_rowbounds.md
+++ b/audits/2026-04-25_issue460_friedrichs_rowbounds.md
@@ -1,6 +1,6 @@
 # Issue #460 — Friedrichs finite-overlap row-bound handoff (2026-04-25)
 
-This note records the remaining analytic inputs after adding the finite-overlap
+This note records the remaining analytic hypotheses after adding the finite-overlap
 row-bound reductions for the parent-Hamiltonian martingale argument.
 
 ## New formal row-bound layer
@@ -27,18 +27,18 @@ The parent-Hamiltonian wrappers
 - `MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs`,
 - `MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs`
 
-specialize the interface to the transported local terms `localTermES A L i`,
+specialize the reduction to the transported local terms `localTermES A L i`,
 with the expected cyclic-window degree `m = 2 * (L - 1)` and the explicit gap
 constant `γ = 1 / (4 * L)`.
 
-## Remaining MPS-specific inputs
+## Remaining MPS-specific hypotheses
 
 The final theorem `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs` still
-needs the following concrete inputs.
+needs the following concrete hypotheses.
 
 1. Local projector structure: for all admissible `N` and `i`, prove
    `(localTermES A L i).IsSymmetricProjection`. This row-bound branch keeps the
-   input explicit; PR #925 owns the separate projection-structure proof.
+   hypothesis explicit; PR #925 owns the separate projection-structure proof.
 2. Choose a cyclic-window overlap predicate, for example “the length-`L` cyclic
    supports of `i` and `j` intersect”.
 3. Prove the row-cardinality estimate

--- a/audits/2026-04-25_issue460_friedrichs_rowbounds.md
+++ b/audits/2026-04-25_issue460_friedrichs_rowbounds.md
@@ -1,14 +1,16 @@
 # Issue #460 — Friedrichs finite-overlap row-bound handoff (2026-04-25)
 
-This note records the remaining analytic inputs after adding the finite-overlap row-bound reductions for the parent-Hamiltonian martingale argument.
+This note records the remaining analytic inputs after adding the finite-overlap
+row-bound reductions for the parent-Hamiltonian martingale argument.
 
 ## New formal row-bound layer
 
 The projection-geometry theorem
 
-- `ProjectionGeometry.quadraticForm_sum_projections_of_finiteOverlap`
+- `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap`
 
-turns a finite family of symmetric projections `P i` and an interaction predicate `overlaps i j` into the quadratic-form estimate `H² ≥ γ H`, assuming:
+turns a finite family of symmetric projections `P i` and an interaction predicate
+`overlaps i j` into the quadratic-form estimate `H² ≥ γ H`, assuming:
 
 1. each row has at most `m` interacting off-diagonal entries;
 2. noninteracting ordered cross terms satisfy
@@ -16,27 +18,39 @@ turns a finite family of symmetric projections `P i` and an interaction predicat
 3. interacting pairs satisfy the Friedrichs-type ordered estimate
    `Re ⟪P_i v, P_j v⟫ ≥ -(1 - γ) * (m : ℝ)⁻¹ * Re ⟪P_i v, v⟫`.
 
-The proof chooses `c_{ij} = 1/m` on interacting pairs and `0` otherwise, derives the row-sum bound from the cardinality hypothesis, and then invokes the existing ordered row-sum reduction.
+The proof chooses `c_{ij} = 1/m` on interacting pairs and `0` otherwise,
+derives the row-sum bound from the cardinality hypothesis, and then invokes the
+existing ordered row-sum reduction.
 
 The parent-Hamiltonian wrappers
 
 - `MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs`,
 - `MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs`
 
-specialize the interface to the transported local terms `localTermES A L i`, with the expected cyclic-window degree `m = 2 * (L - 1)` and the explicit gap constant `γ = 1 / (4 * L)`.
+specialize the interface to the transported local terms `localTermES A L i`,
+with the expected cyclic-window degree `m = 2 * (L - 1)` and the explicit gap
+constant `γ = 1 / (4 * L)`.
 
-## Remaining MPS-specific constants
+## Remaining MPS-specific inputs
 
-The final theorem `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs` still needs the following concrete inputs.
+The final theorem `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs` still
+needs the following concrete inputs.
 
-1. Local projector structure: for all admissible `N` and `i`, prove `(localTermES A L i).IsSymmetricProjection`. This is intentionally separate from the row-bound work.
-2. Choose a cyclic-window overlap predicate, for example “the length-`L` cyclic supports of `i` and `j` intersect”.
+1. Local projector structure: for all admissible `N` and `i`, prove
+   `(localTermES A L i).IsSymmetricProjection`. This row-bound branch keeps the
+   input explicit; PR #925 owns the separate projection-structure proof.
+2. Choose a cyclic-window overlap predicate, for example “the length-`L` cyclic
+   supports of `i` and `j` intersect”.
 3. Prove the row-cardinality estimate
    `((Finset.univ.erase i).filter (fun j => overlaps N i j)).card ≤ 2 * (L - 1)`
    under `2 * L ≤ N`.
-4. Prove non-overlap positivity of ordered cross terms, expected from disjoint tensor factors / commuting local projectors:
-   `0 ≤ Re ⟪localTermES A L i v, localTermES A L j v⟫` whenever the windows are disjoint.
+4. Prove non-overlap positivity of ordered cross terms, expected from disjoint
+   tensor factors / commuting local projectors:
+   `0 ≤ Re ⟪localTermES A L i v, localTermES A L j v⟫` whenever the windows are
+   disjoint.
 5. Prove the Friedrichs-angle estimate for overlapping cyclic windows:
    `Re ⟪h_i v, h_j v⟫ ≥ -(1 - 1/(4L)) * (2(L-1))⁻¹ * Re ⟪h_i v, v⟫`.
 
-Items 2–5 are the genuine CPGSV21 / Kastoryano–Lucia overlap analysis. The new Lean theorems only perform the finite-sum and row-sum algebra once those local estimates are available.
+Items 2–5 are the genuine CPGSV21 / Kastoryano–Lucia overlap analysis. The new
+Lean theorems only perform the finite-sum and row-sum algebra once those local
+estimates are available.

--- a/audits/2026-04-25_issue460_friedrichs_rowbounds.md
+++ b/audits/2026-04-25_issue460_friedrichs_rowbounds.md
@@ -1,0 +1,42 @@
+# Issue #460 — Friedrichs finite-overlap row-bound handoff (2026-04-25)
+
+This note records the remaining analytic inputs after adding the finite-overlap row-bound reductions for the parent-Hamiltonian martingale argument.
+
+## New formal row-bound layer
+
+The projection-geometry theorem
+
+- `ProjectionGeometry.quadraticForm_sum_projections_of_finiteOverlap`
+
+turns a finite family of symmetric projections `P i` and an interaction predicate `overlaps i j` into the quadratic-form estimate `H² ≥ γ H`, assuming:
+
+1. each row has at most `m` interacting off-diagonal entries;
+2. noninteracting ordered cross terms satisfy
+   `0 ≤ Re ⟪P_i v, P_j v⟫`;
+3. interacting pairs satisfy the Friedrichs-type ordered estimate
+   `Re ⟪P_i v, P_j v⟫ ≥ -(1 - γ) * (m : ℝ)⁻¹ * Re ⟪P_i v, v⟫`.
+
+The proof chooses `c_{ij} = 1/m` on interacting pairs and `0` otherwise, derives the row-sum bound from the cardinality hypothesis, and then invokes the existing ordered row-sum reduction.
+
+The parent-Hamiltonian wrappers
+
+- `MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs`,
+- `MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs`
+
+specialize the interface to the transported local terms `localTermES A L i`, with the expected cyclic-window degree `m = 2 * (L - 1)` and the explicit gap constant `γ = 1 / (4 * L)`.
+
+## Remaining MPS-specific constants
+
+The final theorem `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs` still needs the following concrete inputs.
+
+1. Local projector structure: for all admissible `N` and `i`, prove `(localTermES A L i).IsSymmetricProjection`. This is intentionally separate from the row-bound work.
+2. Choose a cyclic-window overlap predicate, for example “the length-`L` cyclic supports of `i` and `j` intersect”.
+3. Prove the row-cardinality estimate
+   `((Finset.univ.erase i).filter (fun j => overlaps N i j)).card ≤ 2 * (L - 1)`
+   under `2 * L ≤ N`.
+4. Prove non-overlap positivity of ordered cross terms, expected from disjoint tensor factors / commuting local projectors:
+   `0 ≤ Re ⟪localTermES A L i v, localTermES A L j v⟫` whenever the windows are disjoint.
+5. Prove the Friedrichs-angle estimate for overlapping cyclic windows:
+   `Re ⟪h_i v, h_j v⟫ ≥ -(1 - 1/(4L)) * (2(L-1))⁻¹ * Re ⟪h_i v, v⟫`.
+
+Items 2–5 are the genuine CPGSV21 / Kastoryano–Lucia overlap analysis. The new Lean theorems only perform the finite-sum and row-sum algebra once those local estimates are available.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1795,8 +1795,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
         lem:parent_hamiltonian_es_quadratic_reduction}
     Fix $L>1$ and set $m=2(L-1)$. Suppose uniformly for every $N\ge2L$ that
     the hypotheses of the fixed-chain finite-overlap Friedrichs reduction hold
-    with $\gamma=1/(4L)$ and this value of $m$. Then the explicit norm lower
-    bound with constant $1/(4L)$ follows for vectors in
+    with $\gamma=1/(4L)$ and this value of $m$. Then $1/(4L)>0$, and the
+    explicit norm lower bound with constant $1/(4L)$ follows for vectors in
     $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
 \end{lemma}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1679,6 +1679,30 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $-(1-\gamma)\sum_i\operatorname{Re}\langle P_i v,v\rangle$.
 \end{proof}
 
+\begin{lemma}[Finite-overlap projection row-sum reduction]
+    \label{lem:finite_overlap_projection_rowsum_reduction}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finiteOverlap}
+    \leanok
+    \uses{lem:ordered_projection_rowsum_reduction}
+    Let $P_i$ be a finite family of symmetric projections. Suppose an
+    interaction predicate $i\sim j$ has at most $m$ off-diagonal neighbours in
+    each row. If noninteracting ordered cross terms are nonnegative and, on each
+    interacting pair,
+    \[
+        \operatorname{Re}\langle P_i v,P_jv\rangle
+        \ge -(1-\gamma)\frac{1}{m}\operatorname{Re}\langle P_i v,v\rangle,
+    \]
+    then $H=\sum_i P_i$ satisfies $H^2\ge \gamma H$ as a quadratic form.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Choose $c_{ij}=1/m$ on interacting pairs and $c_{ij}=0$ otherwise. The row
+    cardinality bound gives $\sum_{j\ne i}c_{ij}\le1$; noninteracting
+    nonnegativity supplies the zero-coefficient cross-term estimates. Apply
+    Lemma~\ref{lem:ordered_projection_rowsum_reduction}.
+\end{proof}
+
 \begin{lemma}[Parent-Hamiltonian ordered row-sum quadratic-form reduction]
     \label{lem:parent_hamiltonian_ordered_rowsum_quadratic}
     \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds}
@@ -1735,6 +1759,36 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} to convert this
     quadratic-form estimate into the norm lower bound on the orthogonal
     complement of the ground space.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian finite-overlap Friedrichs reduction]
+    \label{lem:parent_hamiltonian_finite_overlap_friedrichs}
+    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs}
+    \leanok
+    \uses{lem:finite_overlap_projection_rowsum_reduction,
+        lem:parent_hamiltonian_es_quadratic_reduction, def:parent_hamiltonian_es}
+    Fix $L>1$ and set $m=2(L-1)$.  Suppose that for each $N\ge2L$ there is an
+    overlap predicate on local windows such that each row has at most $m$
+    overlapping off-diagonal windows. Assume also that non-overlapping local
+    terms have nonnegative ordered cross terms, while overlapping local terms
+    satisfy the Friedrichs-angle estimate
+    \[
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
+        \ge -\left(1-\frac{1}{4L}\right)
+              \frac{1}{2(L-1)}
+              \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
+    \]
+    If the transported local terms are symmetric projections, then the explicit
+    norm lower bound with constant $1/(4L)$ follows.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply the finite-overlap projection reduction with
+    $P_i=h_{i,\mathrm{ES}}$ and $m=2(L-1)$.  The resulting quadratic-form estimate
+    is then converted to the norm lower bound by
+    Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction}.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
@@ -1902,7 +1956,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
         lem:euclidean_local_projector_positive,
         lem:local_term_es_average,
         lem:parent_hamiltonian_es_quadratic_reduction,
-        lem:parent_hamiltonian_ordered_rowsum_gap}
+        lem:parent_hamiltonian_ordered_rowsum_gap,
+        lem:parent_hamiltonian_finite_overlap_friedrichs}
     For an injective tensor $A$ and a range $L > 1$, the theorem asserts
     the analytic estimate with the explicit constant
     \[
@@ -1922,10 +1977,12 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} reduces the present
     theorem to the remaining MPS-specific task: deriving the uniform
     quadratic-form estimate.  Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}
-    establishes the finite-sum algebra from ordered cross-term row bounds;
-    the remaining MPS-specific tasks are to prove the local symmetric-projection
-    statement for the transported local terms and to obtain the Friedrichs-angle
-    constants with the required finite-overlap row sums.
+    establishes the finite-sum algebra from ordered cross-term row bounds, and
+    Lemma~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs} records the
+    common finite-overlap specialization with $m=2(L-1)$.  The remaining
+    MPS-specific tasks are to prove the local symmetric-projection statement for
+    the transported local terms, the cyclic-window row-cardinality bound, and the
+    Friedrichs-angle estimate for overlapping windows.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1681,13 +1681,13 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{lemma}[Finite-overlap projection row-sum reduction]
     \label{lem:finite_overlap_projection_rowsum_reduction}
-    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finiteOverlap}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap}
     \leanok
     \uses{lem:ordered_projection_rowsum_reduction}
-    Let $P_i$ be a finite family of symmetric projections. Suppose an
-    interaction predicate $i\sim j$ has at most $m$ off-diagonal neighbours in
-    each row. If noninteracting ordered cross terms are nonnegative and, on each
-    interacting pair,
+    Let $P_i$ be a finite family of symmetric projections and let $\gamma\le1$.
+    Suppose an interaction predicate $i\sim j$ has at most $m$ off-diagonal
+    neighbours in each row for some positive integer $m$. If noninteracting
+    ordered cross terms are nonnegative and, on each interacting pair,
     \[
         \operatorname{Re}\langle P_i v,P_jv\rangle
         \ge -(1-\gamma)\frac{1}{m}\operatorname{Re}\langle P_i v,v\rangle,
@@ -1779,8 +1779,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
               \frac{1}{2(L-1)}
               \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
     \]
-    If the transported local terms are symmetric projections, then the explicit
-    norm lower bound with constant $1/(4L)$ follows.
+    The transported-local-projection statement is a separate input: if the
+    transported local terms are symmetric projections, then the explicit norm
+    lower bound with constant $1/(4L)$ follows.
 \end{lemma}
 
 \begin{proof}
@@ -1979,10 +1980,12 @@ Lucia~\cite{Kastoryano2018Martingale}.
     quadratic-form estimate.  Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}
     establishes the finite-sum algebra from ordered cross-term row bounds, and
     Lemma~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs} records the
-    common finite-overlap specialization with $m=2(L-1)$.  The remaining
-    MPS-specific tasks are to prove the local symmetric-projection statement for
-    the transported local terms, the cyclic-window row-cardinality bound, and the
-    Friedrichs-angle estimate for overlapping windows.
+    common finite-overlap specialization with $m=2(L-1)$.  The Lean reduction
+    here keeps the transported-local-projection statement as an explicit input,
+    matching the separate projection-structure work. After that input is
+    supplied, the remaining analytic tasks are the cyclic-window row-cardinality
+    bound, non-overlap positivity, and the Friedrichs-angle estimate for
+    overlapping windows.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1761,35 +1761,50 @@ Lucia~\cite{Kastoryano2018Martingale}.
     complement of the ground space.
 \end{proof}
 
-\begin{lemma}[Parent-Hamiltonian finite-overlap Friedrichs reduction]
-    \label{lem:parent_hamiltonian_finite_overlap_friedrichs}
+\begin{lemma}[Parent-Hamiltonian finite-overlap Friedrichs quadratic reduction]
+    \label{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
     \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs}
-    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs}
     \leanok
-    \uses{lem:finite_overlap_projection_rowsum_reduction,
-        lem:parent_hamiltonian_es_quadratic_reduction, def:parent_hamiltonian_es}
-    Fix $L>1$ and set $m=2(L-1)$.  Suppose that for each $N\ge2L$ there is an
-    overlap predicate on local windows such that each row has at most $m$
-    overlapping off-diagonal windows. Assume also that non-overlapping local
-    terms have nonnegative ordered cross terms, while overlapping local terms
-    satisfy the Friedrichs-angle estimate
+    \uses{lem:finite_overlap_projection_rowsum_reduction, def:parent_hamiltonian_es}
+    For a fixed chain length $N$, let $m$ be a positive integer and let
+    $\gamma\le1$. Suppose an overlap predicate on local windows has at most $m$
+    overlapping off-diagonal windows in each row. If non-overlapping local terms
+    have nonnegative ordered cross terms, overlapping local terms satisfy the
+    finite-overlap Friedrichs estimate
     \[
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
-        \ge -\left(1-\frac{1}{4L}\right)
-              \frac{1}{2(L-1)}
-              \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
+        \ge -(1-\gamma)\frac{1}{m}
+              \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle,
     \]
-    The transported-local-projection statement is a separate input: if the
-    transported local terms are symmetric projections, then the explicit norm
-    lower bound with constant $1/(4L)$ follows.
+    and the transported local terms are symmetric projections, then the
+    transported Hamiltonian satisfies $H_{N,L}^{\mathrm{ES}}{}^2\ge
+    \gamma H_{N,L}^{\mathrm{ES}}$ as a quadratic form.
 \end{lemma}
 
 \begin{proof}
     \leanok
     Apply the finite-overlap projection reduction with
-    $P_i=h_{i,\mathrm{ES}}$ and $m=2(L-1)$.  The resulting quadratic-form estimate
-    is then converted to the norm lower bound by
-    Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction}.
+    $P_i=h_{i,\mathrm{ES}}$.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian gap from finite-overlap Friedrichs data]
+    \label{lem:parent_hamiltonian_finite_overlap_friedrichs_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs}
+    \leanok
+    \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic,
+        lem:parent_hamiltonian_es_quadratic_reduction}
+    Fix $L>1$ and set $m=2(L-1)$. Suppose uniformly for every $N\ge2L$ that
+    the hypotheses of the fixed-chain finite-overlap Friedrichs reduction hold
+    with $\gamma=1/(4L)$ and this value of $m$. Then the explicit norm lower
+    bound with constant $1/(4L)$ follows for vectors in
+    $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The fixed-chain finite-overlap reduction gives the required quadratic-form
+    estimate for every admissible $N$. Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction}
+    converts that estimate to the norm lower bound.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
@@ -1958,7 +1973,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
         lem:local_term_es_average,
         lem:parent_hamiltonian_es_quadratic_reduction,
         lem:parent_hamiltonian_ordered_rowsum_gap,
-        lem:parent_hamiltonian_finite_overlap_friedrichs}
+        lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic,
+        lem:parent_hamiltonian_finite_overlap_friedrichs_gap}
     For an injective tensor $A$ and a range $L > 1$, the theorem asserts
     the analytic estimate with the explicit constant
     \[
@@ -1979,13 +1995,14 @@ Lucia~\cite{Kastoryano2018Martingale}.
     theorem to the remaining MPS-specific task: deriving the uniform
     quadratic-form estimate.  Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}
     establishes the finite-sum algebra from ordered cross-term row bounds, and
-    Lemma~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs} records the
-    common finite-overlap specialization with $m=2(L-1)$.  The Lean reduction
-    here keeps the transported-local-projection statement as an explicit input,
-    matching the separate projection-structure work. After that input is
-    supplied, the remaining analytic tasks are the cyclic-window row-cardinality
-    bound, non-overlap positivity, and the Friedrichs-angle estimate for
-    overlapping windows.
+    Lemmas~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
+    and~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} record the
+    common finite-overlap specialization with $m=2(L-1)$.  This reduction keeps
+    the transported-local-projection statement as an explicit assumption,
+    matching the separate projection-structure work. Once that assumption is
+    established, the remaining analytic tasks are the cyclic-window
+    row-cardinality bound, non-overlap positivity, and the Friedrichs-angle
+    estimate for overlapping windows.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}


### PR DESCRIPTION
Refs #460. Refs #190.

## Summary
- add `ProjectionGeometry.quadraticForm_sum_projections_of_finiteOverlap`, a finite-overlap row-bound reduction choosing `c_{ij}=1/m` on interacting pairs and `0` otherwise
- add parent-Hamiltonian wrappers `parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs` and `parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs` with `m = 2 * (L - 1)` and `γ = 1/(4L)`
- sync blueprint declarations and add an audit note listing the remaining MPS overlap/Friedrichs constants

## Validation
- `lake build TNLean.Analysis.ProjectionGeometry TNLean.MPS.ParentHamiltonian.Martingale` (only the pre-existing `parentHamiltonianES_gap_bound_of_friedrichs` sorry warning)
- `ulimit -n 8192 && lake build +TNLean:olean` (for blueprint checkdecls; pre-existing sorry/style warnings only)
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- forbidden-token scan on touched files found only the pre-existing `Martingale.lean` sorry in `parentHamiltonianES_gap_bound_of_friedrichs`

Ready for an orchestrator simplification/cleanup pass before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems/wrappers and documentation without changing existing computational behavior, but may affect downstream proof obligations/typeclass inference if assumptions are later instantiated incorrectly.
> 
> **Overview**
> Adds a new finite-overlap row-sum reduction `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap`, deriving the row-sum bound by choosing `c_{ij}=1/m` on `overlaps` pairs (and `0` otherwise) and discharging it via a new helper lemma about filtered-cardinality.
> 
> Extends the parent-Hamiltonian martingale layer with `parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs` and `parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs`, wiring the finite-overlap hypotheses (cardinality, non-overlap positivity, Friedrichs bound) into the existing quadratic-form-to-gap pipeline with the expected constants `m = 2 * (L - 1)` and `γ = 1/(4L)`.
> 
> Updates blueprint/audit docs to reference the new lemmas and to record the remaining MPS-specific overlap/Friedrichs hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da80097c02bf29def92bfe4f8c930b94528253e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->