### PR TITLE
feat(MPS/CanonicalForm): construct collapsed BNT representatives

### DIFF
--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -90,8 +90,8 @@ Theorem matching, etc.).
 
 * `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` — the collapsed-representative
   construction: it quotients arbitrary TP / primitive / irreducible blocks by MPV phase
-  equivalence, absorbs the phases into sector weights, proves representative separation,
-  and then obtains `HasBNTSectorData` from the separated-family theorem.
+  equivalence, absorbs the scalar factors into sector weights, proves representative
+  separation, and then obtains `HasBNTSectorData` from the separated-family theorem.
 
 * `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent` —
   signature-compatible reformulation retaining the TP / primitive / irreducible
@@ -401,9 +401,9 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
 `MPVPhaseEquiv blocks j k` means that block `k` has the same MPV family as
 block `j` after multiplying length-`N` vectors by a nonzero scalar power
 `ζ ^ N`.  Gauge-phase equivalence implies this relation, and quotienting a
-finite family by this relation is enough to absorb all repeated phase copies
-into sector weights. -/
-abbrev MPVPhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
+finite family by this relation is enough to absorb all repeated scalar-power
+copies into sector weights. -/
+def MPVPhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k)) (j k : Fin r) : Prop :=
   ∃ ζ : ℂ, ζ ≠ 0 ∧ ∀ (N : ℕ) (σ : Fin N → Fin d),
     mpv (blocks k) σ = ζ ^ N * mpv (blocks j) σ
@@ -452,7 +452,7 @@ lemma MPVPhaseEquiv.of_gaugePhaseEquiv_cast {r : ℕ} {dim : Fin r → ℕ}
     mpv_cast_dim hdim (blocks j) N σ]
 
 /-- Equivalence relation on block indices given by MPV phase equivalence. -/
-noncomputable def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}
+def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k)) : Setoid (Fin r) where
   r := MPVPhaseEquiv blocks
   iseqv := {
@@ -462,7 +462,7 @@ noncomputable def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}
   }
 
 /-- Quotient set of MPV phase equivalence classes. -/
-noncomputable abbrev MPVPhaseClass {r : ℕ} {dim : Fin r → ℕ}
+abbrev MPVPhaseClass {r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k)) :=
   Quotient (mpvPhaseSetoid blocks)
 
@@ -495,7 +495,7 @@ structure MPVPhaseClassData {r : ℕ} {dim : Fin r → ℕ}
 The representative of each class is the first element in the finite enumeration
 of that class.  If two representatives were gauge-phase equivalent, then they
 would be MPV-phase equivalent and hence lie in the same quotient class; this
-proves the BNT separation field. -/
+proves that distinct representatives are pairwise not gauge-phase equivalent. -/
 noncomputable def mpvPhaseClassData {r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k)) : MPVPhaseClassData blocks := by
   classical
@@ -526,12 +526,7 @@ noncomputable def mpvPhaseClassData {r : ℕ} {dim : Fin r → ℕ}
     ext k
     simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, iff_true]
     refine ⟨e (Quotient.mk (mpvPhaseSetoid blocks) k), ?_⟩
-    change k ∈ Finset.univ.filter
-      (fun x => Quotient.mk (mpvPhaseSetoid blocks) x =
-        classOf (e (Quotient.mk (mpvPhaseSetoid blocks) k)))
-    rw [Finset.mem_filter]
-    refine ⟨Finset.mem_univ _, ?_⟩
-    simp [classOf, e]
+    simp [classFinset, classOf, e]
   let copiesFn : Fin g → ℕ := fun j => (classFinset j).card
   have hcopies_pos : ∀ j, 0 < copiesFn j :=
     fun j => Finset.card_pos.mpr (hClass_nonempty j)

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -2,12 +2,12 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.BNT.Construction
+import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
-import TNLean.MPS.SharedInfra.GaugePhase
-import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Overlap.CastDecay
+import TNLean.MPS.Overlap.CastLemmas
+import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.Spectral.SpectralGapNT
 
@@ -657,16 +657,16 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
       HasBNTSectorData (d := d) P := by
   classical
   let classes := mpvPhaseClassData blocks
-  let phaseζ : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
+  let ζFn : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
     fun j q => (classes.enum_phase j q).choose
-  have hζ_ne : ∀ j q, phaseζ j q ≠ 0 := fun j q => (classes.enum_phase j q).choose_spec.1
+  have hζ_ne : ∀ j q, ζFn j q ≠ 0 := fun j q => (classes.enum_phase j q).choose_spec.1
   have hζ_mpv : ∀ j q (N : ℕ) (σ : Fin N → Fin d),
-      mpv (blocks (classes.enum j q)) σ = (phaseζ j q) ^ N * mpv (blocks (classes.repr j)) σ :=
+      mpv (blocks (classes.enum j q)) σ = (ζFn j q) ^ N * mpv (blocks (classes.repr j)) σ :=
     fun j q N σ => (classes.enum_phase j q).choose_spec.2 N σ
   let sectors : SectorWeightData classes.g := {
     copies := classes.copies
     copies_pos := classes.copies_pos
-    weight := fun j q => phaseζ j q * μ (classes.enum j q)
+    weight := fun j q => ζFn j q * μ (classes.enum j q)
     weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j q) (hμne (classes.enum j q))
   }
   let P : SectorDecomposition d := {
@@ -683,7 +683,7 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
             P.mpv_toTensor_eq_sum_sectors σ
       _ = ∑ j : Fin classes.g,
             ∑ q : Fin (classes.copies j),
-              (phaseζ j q * μ (classes.enum j q)) ^ N *
+              (ζFn j q * μ (classes.enum j q)) ^ N *
                 mpv (blocks (classes.repr j)) σ := rfl
       _ = ∑ j : Fin classes.g,
             ∑ q : Fin (classes.copies j),

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -88,6 +88,11 @@ Theorem matching, etc.).
   including equal-modulus ones, and proves `HasBNTSectorData` from overlap
   asymptotics rather than from an explicit linear-independence hypothesis.
 
+* `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` — the collapsed-representative
+  construction: it quotients arbitrary TP / primitive / irreducible blocks by MPV phase
+  equivalence, absorbs the phases into sector weights, proves representative separation,
+  and then obtains `HasBNTSectorData` from the separated-family theorem.
+
 * `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent` —
   signature-compatible reformulation retaining the TP / primitive / irreducible
   inputs expected by the one-sided BNT construction chain.
@@ -389,7 +394,196 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
       exact ⟨ζ, hζne, hζ_norm, hmpv⟩
   exact bnt_grouping_single_norm_class μ blocks k0 hμne hNorm hPhase
 
-/-! ### §4. Eventual independence from separated overlap data -/
+/-! ### §4. Collapsed representatives from MPV phase classes -/
+
+/-- MPV phase equivalence for a dependent block family.
+
+`MPVPhaseEquiv blocks j k` means that block `k` has the same MPV family as
+block `j` after multiplying length-`N` vectors by a nonzero scalar power
+`ζ ^ N`.  Gauge-phase equivalence implies this relation, and quotienting a
+finite family by this relation is enough to absorb all repeated phase copies
+into sector weights. -/
+abbrev MPVPhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) (j k : Fin r) : Prop :=
+  ∃ ζ : ℂ, ζ ≠ 0 ∧ ∀ (N : ℕ) (σ : Fin N → Fin d),
+    mpv (blocks k) σ = ζ ^ N * mpv (blocks j) σ
+
+/-- MPV phase equivalence is reflexive. -/
+lemma MPVPhaseEquiv.refl {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) (j : Fin r) :
+    MPVPhaseEquiv blocks j j := by
+  exact ⟨1, one_ne_zero, fun N σ => by simp⟩
+
+/-- MPV phase equivalence is symmetric. -/
+lemma MPVPhaseEquiv.symm {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) {j k : Fin r}
+    (h : MPVPhaseEquiv blocks j k) : MPVPhaseEquiv blocks k j := by
+  rcases h with ⟨ζ, hζ, hmpv⟩
+  refine ⟨ζ⁻¹, inv_ne_zero hζ, ?_⟩
+  intro N σ
+  rw [hmpv N σ]
+  rw [inv_pow, ← mul_assoc, inv_mul_cancel₀ (pow_ne_zero N hζ), one_mul]
+
+/-- MPV phase equivalence is transitive. -/
+lemma MPVPhaseEquiv.trans {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) {i j k : Fin r}
+    (hij : MPVPhaseEquiv blocks i j) (hjk : MPVPhaseEquiv blocks j k) :
+    MPVPhaseEquiv blocks i k := by
+  rcases hij with ⟨ζ, hζ, hζmpv⟩
+  rcases hjk with ⟨η, hη, hηmpv⟩
+  refine ⟨η * ζ, mul_ne_zero hη hζ, ?_⟩
+  intro N σ
+  rw [hηmpv N σ, hζmpv N σ, mul_pow]
+  ring
+
+/-- A gauge-phase equivalence between equal-dimension blocks gives MPV phase equivalence. -/
+lemma MPVPhaseEquiv.of_gaugePhaseEquiv_cast {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) {j k : Fin r}
+    (hdim : dim j = dim k)
+    (hGPE : GaugePhaseEquiv (d := d)
+      (cast (congr_arg (MPSTensor d) hdim) (blocks j)) (blocks k)) :
+    MPVPhaseEquiv blocks j k := by
+  rcases hGPE with ⟨X, ζ, hζ, hX⟩
+  refine ⟨ζ, hζ, ?_⟩
+  intro N σ
+  rw [mpv_eq_pow_mul_of_gaugePhase
+    (A := cast (congr_arg (MPSTensor d) hdim) (blocks j))
+    (B := blocks k) X ζ hX N σ,
+    mpv_cast_dim hdim (blocks j) N σ]
+
+/-- Equivalence relation on block indices given by MPV phase equivalence. -/
+noncomputable def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) : Setoid (Fin r) where
+  r := MPVPhaseEquiv blocks
+  iseqv := {
+    refl := MPVPhaseEquiv.refl blocks
+    symm := fun {_ _} h => MPVPhaseEquiv.symm blocks h
+    trans := fun {_ _ _} h₁ h₂ => MPVPhaseEquiv.trans blocks h₁ h₂
+  }
+
+/-- Quotient set of MPV phase equivalence classes. -/
+noncomputable abbrev MPVPhaseClass {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) :=
+  Quotient (mpvPhaseSetoid blocks)
+
+/-- The finite quotient by MPV phase classes is finite. -/
+noncomputable instance instFintypeMPVPhaseClass {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) : Fintype (MPVPhaseClass blocks) := by
+  dsimp [MPVPhaseClass]
+  infer_instance
+
+/-- Finite class data for the MPV phase relation.
+
+The data consist of an enumeration of the quotient classes, a choice of
+representative per class, the scalar-power relation from each representative to
+each member, the separation property for the representatives, and the regrouping
+identity for finite sums over the original blocks. -/
+structure MPVPhaseClassData {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) where
+  g : ℕ
+  copies : Fin g → ℕ
+  copies_pos : ∀ j, 0 < copies j
+  enum : (j : Fin g) → Fin (copies j) → Fin r
+  repr : Fin g → Fin r
+  enum_phase : ∀ j q, MPVPhaseEquiv blocks (repr j) (enum j q)
+  blocks_not_equiv : BlocksNotGaugePhaseEquiv (d := d) (fun j => blocks (repr j))
+  regroup : ∀ f : Fin r → ℂ,
+    ∑ j : Fin g, ∑ q : Fin (copies j), f (enum j q) = ∑ k : Fin r, f k
+
+/-- Construct the finite MPV phase classes of a block family.
+
+The representative of each class is the first element in the finite enumeration
+of that class.  If two representatives were gauge-phase equivalent, then they
+would be MPV-phase equivalent and hence lie in the same quotient class; this
+proves the BNT separation field. -/
+noncomputable def mpvPhaseClassData {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) : MPVPhaseClassData blocks := by
+  classical
+  let cls := MPVPhaseClass blocks
+  let e : cls ≃ Fin (Fintype.card cls) := Fintype.equivFin cls
+  let g := Fintype.card cls
+  let classOf : Fin g → cls := e.symm
+  let classFinset : Fin g → Finset (Fin r) :=
+    fun j => Finset.univ.filter (fun k => Quotient.mk (mpvPhaseSetoid blocks) k = classOf j)
+  have hClass_nonempty : ∀ j, (classFinset j).Nonempty := by
+    intro j
+    obtain ⟨k, hk⟩ := Quotient.exists_rep (classOf j)
+    refine ⟨k, ?_⟩
+    simp [classFinset, hk]
+  have hClass_disj :
+      Set.PairwiseDisjoint (↑(Finset.univ : Finset (Fin g)) : Set (Fin g)) classFinset := by
+    intro j _ k _ hne
+    apply Finset.disjoint_left.mpr
+    intro x hxj hxk
+    have hxj' : Quotient.mk (mpvPhaseSetoid blocks) x = classOf j :=
+      (Finset.mem_filter.mp hxj).2
+    have hxk' : Quotient.mk (mpvPhaseSetoid blocks) x = classOf k :=
+      (Finset.mem_filter.mp hxk).2
+    have hclass : classOf j = classOf k := hxj'.symm.trans hxk'
+    apply hne
+    simpa [classOf, e] using congrArg e hclass
+  have hClass_cover : Finset.biUnion Finset.univ classFinset = Finset.univ := by
+    ext k
+    simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, iff_true]
+    refine ⟨e (Quotient.mk (mpvPhaseSetoid blocks) k), ?_⟩
+    change k ∈ Finset.univ.filter
+      (fun x => Quotient.mk (mpvPhaseSetoid blocks) x =
+        classOf (e (Quotient.mk (mpvPhaseSetoid blocks) k)))
+    rw [Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    simp [classOf, e]
+  let copiesFn : Fin g → ℕ := fun j => (classFinset j).card
+  have hcopies_pos : ∀ j, 0 < copiesFn j :=
+    fun j => Finset.card_pos.mpr (hClass_nonempty j)
+  let enumFn : (j : Fin g) → Fin (copiesFn j) → Fin r :=
+    fun j => (classFinset j).orderEmbOfFin rfl
+  let reprFn : Fin g → Fin r := fun j => enumFn j ⟨0, hcopies_pos j⟩
+  have hrepr_mem : ∀ j, Quotient.mk (mpvPhaseSetoid blocks) (reprFn j) = classOf j := by
+    intro j
+    exact (Finset.mem_filter.mp ((classFinset j).orderEmbOfFin_mem rfl ⟨0, hcopies_pos j⟩)).2
+  have hEnum_phase : ∀ j q, MPVPhaseEquiv blocks (reprFn j) (enumFn j q) := by
+    intro j q
+    have hrepr : Quotient.mk (mpvPhaseSetoid blocks) (reprFn j) = classOf j := hrepr_mem j
+    have henum : Quotient.mk (mpvPhaseSetoid blocks) (enumFn j q) = classOf j :=
+      (Finset.mem_filter.mp ((classFinset j).orderEmbOfFin_mem rfl q)).2
+    exact Quotient.exact (hrepr.trans henum.symm)
+  have hBlocks : BlocksNotGaugePhaseEquiv (d := d) (fun j => blocks (reprFn j)) := by
+    intro j k hjk hdim hGPE
+    have hphase : MPVPhaseEquiv blocks (reprFn j) (reprFn k) :=
+      MPVPhaseEquiv.of_gaugePhaseEquiv_cast blocks hdim hGPE
+    have hquot : Quotient.mk (mpvPhaseSetoid blocks) (reprFn j) =
+        Quotient.mk (mpvPhaseSetoid blocks) (reprFn k) :=
+      Quotient.sound hphase
+    have hclass : classOf j = classOf k := by
+      exact (hrepr_mem j).symm.trans (hquot.trans (hrepr_mem k))
+    apply hjk
+    simpa [classOf, e] using congrArg e hclass
+  have hRegroup : ∀ (f : Fin r → ℂ),
+      ∑ j : Fin g, ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k : Fin r, f k := by
+    intro f
+    have inner_eq : ∀ j : Fin g,
+        ∑ q : Fin (copiesFn j), f (enumFn j q) = ∑ k ∈ classFinset j, f k := by
+      intro j
+      rw [← Finset.map_orderEmbOfFin_univ (classFinset j) rfl, Finset.sum_map]
+      rfl
+    simp_rw [inner_eq]
+    calc ∑ j : Fin g, ∑ k ∈ classFinset j, f k
+        = ∑ k ∈ Finset.biUnion Finset.univ classFinset, f k :=
+            (Finset.sum_biUnion hClass_disj).symm
+      _ = ∑ k ∈ Finset.univ, f k := by rw [hClass_cover]
+      _ = ∑ k : Fin r, f k := rfl
+  exact {
+    g := g
+    copies := copiesFn
+    copies_pos := hcopies_pos
+    enum := enumFn
+    repr := reprFn
+    enum_phase := hEnum_phase
+    blocks_not_equiv := hBlocks
+    regroup := hRegroup
+  }
+
+/-! ### §5. Eventual independence from separated overlap data -/
 
 /-- **Eventual BNT linear independence for an already separated normal family.**
 
@@ -446,7 +640,80 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_blocksNotGaugePhas
     exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
       blocks hTP hIrr hPrim hBlocks
 
-/-! ### §5. Conditional sector construction under BNT linear independence -/
+/-- **Unconditional one-sided BNT sector construction for primitive irreducible blocks.**
+
+Starting from arbitrary trace-preserving primitive irreducible blocks with
+nonzero weights, quotient the block indices by MPV phase equivalence.  One
+representative is chosen for each class; for every original block in the class,
+the associated phase is multiplied into its sector weight.  Gauge-phase-equivalent
+blocks land in the same MPV phase class, so the chosen representatives satisfy
+`BlocksNotGaugePhaseEquiv`.  The separated-family BNT independence theorem then
+proves `HasBNTSectorData` for the collapsed sector decomposition. -/
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P := by
+  classical
+  let classes := mpvPhaseClassData blocks
+  let phaseζ : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
+    fun j q => (classes.enum_phase j q).choose
+  have hζ_ne : ∀ j q, phaseζ j q ≠ 0 := fun j q => (classes.enum_phase j q).choose_spec.1
+  have hζ_mpv : ∀ j q (N : ℕ) (σ : Fin N → Fin d),
+      mpv (blocks (classes.enum j q)) σ = (phaseζ j q) ^ N * mpv (blocks (classes.repr j)) σ :=
+    fun j q N σ => (classes.enum_phase j q).choose_spec.2 N σ
+  let sectors : SectorWeightData classes.g := {
+    copies := classes.copies
+    copies_pos := classes.copies_pos
+    weight := fun j q => phaseζ j q * μ (classes.enum j q)
+    weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j q) (hμne (classes.enum j q))
+  }
+  let P : SectorDecomposition d := {
+    basisCount := classes.g
+    basisDim := fun j => dim (classes.repr j)
+    basis := fun j => blocks (classes.repr j)
+    sectors := sectors
+  }
+  refine ⟨P, ?_, ?_⟩
+  · intro N σ
+    calc mpv P.toTensor σ
+        = ∑ j : Fin P.basisCount,
+            ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
+            P.mpv_toTensor_eq_sum_sectors σ
+      _ = ∑ j : Fin classes.g,
+            ∑ q : Fin (classes.copies j),
+              (phaseζ j q * μ (classes.enum j q)) ^ N *
+                mpv (blocks (classes.repr j)) σ := rfl
+      _ = ∑ j : Fin classes.g,
+            ∑ q : Fin (classes.copies j),
+              (μ (classes.enum j q)) ^ N * mpv (blocks (classes.enum j q)) σ := by
+              refine Finset.sum_congr rfl (fun j _ =>
+                Finset.sum_congr rfl (fun q _ => ?_))
+              rw [mul_pow, hζ_mpv j q N σ]
+              ring
+      _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ :=
+            classes.regroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+              symm
+              simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
+  · have hLI : ∃ N0 : ℕ, ∀ N > N0,
+        LinearIndependent ℂ
+          (fun j : Fin classes.g => mpvState (d := d) (blocks (classes.repr j)) N) :=
+      exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
+        (fun j : Fin classes.g => blocks (classes.repr j))
+        (fun j => hTP (classes.repr j))
+        (fun j => hIrr (classes.repr j))
+        (fun j => hPrim (classes.repr j))
+        classes.blocks_not_equiv
+    simpa [P] using hLI
+
+/-! ### §6. Conditional sector construction under BNT linear independence -/
 
 /-- **Minimal granular sector decomposition carrying current `HasBNTSectorData`.**
 

--- a/audits/2026-04-25_issue876_bnt_sector_blocker.md
+++ b/audits/2026-04-25_issue876_bnt_sector_blocker.md
@@ -66,7 +66,7 @@ from the blocked TP-primitive output.  Informally, it must:
 4. return a `SectorDecomposition` whose `HasBNTSectorData` is the current
    post-#886 linear-independence predicate.
 
-Until that theorem exists, #860 and #877 should continue to treat the one-sided
+Before the Wave 15 update below, #860 and #877 had to treat the one-sided
 BNT sector pair as a hypothesis, as in
 `fundamentalTheorem_after_blocking_1606_sector_of_bntPair_matched`.
 
@@ -90,3 +90,29 @@ remaining #876 theorem is now more precise: construct the separated family from
 arbitrary TP-primitive-irreducible blocks by identifying gauge-phase-equivalent
 normal tensors, absorbing the associated phases into sector weights, and proving
 that the constructed representatives satisfy `BlocksNotGaugePhaseEquiv`.
+
+## Wave 15 slot A update
+
+The branch `wave15-A-923-collapsed-reps` discharges the collapsed-representative
+step for the one-sided TP / primitive / irreducible input family.
+
+New declarations in `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`:
+
+- `MPSTensor.MPVPhaseEquiv`: the finite relation identifying blocks whose MPV
+  families differ by a nonzero length-power phase factor.
+- `MPSTensor.MPVPhaseClassData` and `MPSTensor.mpvPhaseClassData`: quotient the
+  finite block index set by that relation, choose one representative per class,
+  enumerate the original members of each class, and prove the representatives
+  satisfy `BlocksNotGaugePhaseEquiv`.  The separation proof uses the fact that a
+  gauge-phase equivalence produces an `MPVPhaseEquiv` relation, so two
+  gauge-phase-equivalent representatives would lie in the same quotient class.
+- `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`: constructs the
+  sector decomposition from arbitrary TP / primitive / irreducible blocks with
+  nonzero weights by absorbing each class member's phase into its sector weight,
+  then applies the separated-family linear-independence theorem from PR #920 to
+  prove the current `HasBNTSectorData` predicate.
+
+This closes the #923 one-sided collapsed-representative sub-blocker.  The broader
+Gap §1 / #652 assembly still needs the heterogeneous matched-basis theorem that
+constructs a sector-basis matching witness directly from equality of the total
+MPV families.

--- a/audits/2026-04-25_issue876_bnt_sector_blocker.md
+++ b/audits/2026-04-25_issue876_bnt_sector_blocker.md
@@ -99,7 +99,7 @@ step for the one-sided TP / primitive / irreducible input family.
 New declarations in `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`:
 
 - `MPSTensor.MPVPhaseEquiv`: the finite relation identifying blocks whose MPV
-  families differ by a nonzero length-power phase factor.
+  families differ by a nonzero length-power scalar factor.
 - `MPSTensor.MPVPhaseClassData` and `MPSTensor.mpvPhaseClassData`: quotient the
   finite block index set by that relation, choose one representative per class,
   enumerate the original members of each class, and prove the representatives
@@ -108,9 +108,9 @@ New declarations in `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`:
   gauge-phase-equivalent representatives would lie in the same quotient class.
 - `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`: constructs the
   sector decomposition from arbitrary TP / primitive / irreducible blocks with
-  nonzero weights by absorbing each class member's phase into its sector weight,
-  then applies the separated-family linear-independence theorem from PR #920 to
-  prove the current `HasBNTSectorData` predicate.
+  nonzero weights by absorbing each class member's scalar factor into its sector
+  weight, then applies the separated-family linear-independence theorem from PR #920
+  to prove the current `HasBNTSectorData` predicate.
 
 This closes the #923 one-sided collapsed-representative sub-blocker.  The broader
 Gap §1 / #652 assembly still needs the heterogeneous matched-basis theorem that

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2239,6 +2239,42 @@ The following results separate the zero blocks from the
 	Theorem~\ref{thm:bnt_li_tp_prim_irr_separated}.
 \end{proof}
 
+\begin{definition}[MPV phase class data]
+	\label{def:mpv_phase_class_data}
+	\lean{MPSTensor.MPVPhaseEquiv, MPSTensor.MPVPhaseClassData, MPSTensor.mpvPhaseClassData}
+	\leanok
+	For a finite family of blocks, put $j \sim k$ when there is a nonzero
+	phase factor $\zeta$ such that
+	$V^{(N)}(B_k)=\zeta^N V^{(N)}(B_j)$ for every length $N$.  The class
+	data enumerate the finite quotient, choose one representative per class,
+	record the phase relating the representative to each member, and prove that
+	distinct representatives are not gauge-phase equivalent.
+\end{definition}
+
+\begin{theorem}[Collapsed representative BNT sector construction]
+	\label{thm:bnt_sector_decomp_tp_prim_irr_collapsed}
+	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks}
+	\leanok
+	\uses{def:mpv_phase_class_data, thm:bnt_li_tp_prim_irr_separated}
+	For trace-preserving primitive irreducible blocks of positive bond dimension
+	with nonzero weights, there is a sector decomposition representing the same
+	weighted block sum and satisfying the BNT linear-independence condition.  The
+	construction chooses one representative per MPV phase class and absorbs the
+	phase factors into the sector weights.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{def:mpv_phase_class_data, thm:bnt_li_tp_prim_irr_separated}
+	Finite phase classes partition the original block indices.  Expanding the
+	sector decomposition gives the original finite sum after replacing each class
+	member by its representative and moving the factor $\zeta^N$ into
+	$(\zeta\mu_k)^N$.  If two chosen representatives were gauge-phase equivalent,
+	they would lie in the same MPV phase class, contradicting their being distinct
+	classes.  Therefore the representatives satisfy the separated primitive-normal
+	hypothesis, and Theorem~\ref{thm:bnt_li_tp_prim_irr_separated} gives the BNT
+	linear-independence condition.
+\end{proof}
+
 \begin{theorem}[TP primitive irreducible version with eventual BNT independence]
 	\label{thm:bnt_sector_decomp_tp_prim_irr_linear_independent}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2244,10 +2244,10 @@ The following results separate the zero blocks from the
 	\lean{MPSTensor.MPVPhaseEquiv, MPSTensor.MPVPhaseClassData, MPSTensor.mpvPhaseClassData}
 	\leanok
 	For a finite family of blocks, put $j \sim k$ when there is a nonzero
-	phase factor $\zeta$ such that
-	$V^{(N)}(B_k)=\zeta^N V^{(N)}(B_j)$ for every length $N$.  The class
-	data enumerate the finite quotient, choose one representative per class,
-	record the phase relating the representative to each member, and prove that
+	scalar factor $\zeta$ (a phase after normalization) such that
+	$\ket{V^{(N)}(B_k)}=\zeta^N\ket{V^{(N)}(B_j)}$ for every length~$N$.
+	The class data enumerate the finite quotient, choose one representative per class,
+	record the scalar relating the representative to each member, and prove that
 	distinct representatives are not gauge-phase equivalent.
 \end{definition}
 
@@ -2260,11 +2260,11 @@ The following results separate the zero blocks from the
 	with nonzero weights, there is a sector decomposition representing the same
 	weighted block sum and satisfying the BNT linear-independence condition.  The
 	construction chooses one representative per MPV phase class and absorbs the
-	phase factors into the sector weights.
+	nonzero scalar factors into the sector weights.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{def:mpv_phase_class_data, thm:bnt_li_tp_prim_irr_separated}
+	\uses{def:mpv_phase_class_data, thm:bnt_li_tp_prim_irr_separated, thm:mpv_decomposition}
 	Finite phase classes partition the original block indices.  Expanding the
 	sector decomposition gives the original finite sum after replacing each class
 	member by its representative and moving the factor $\zeta^N$ into

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2244,7 +2244,7 @@ The following results separate the zero blocks from the
 	\lean{MPSTensor.MPVPhaseEquiv, MPSTensor.MPVPhaseClassData, MPSTensor.mpvPhaseClassData}
 	\leanok
 	For a finite family of blocks, put $j \sim k$ when there is a nonzero
-	scalar factor $\zeta$ (a phase after normalization) such that
+	scalar factor $\zeta$ such that
 	$\ket{V^{(N)}(B_k)}=\zeta^N\ket{V^{(N)}(B_j)}$ for every length~$N$.
 	The class data enumerate the finite quotient, choose one representative per class,
 	record the scalar relating the representative to each member, and prove that

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -664,28 +664,20 @@ single weighted block.
 	\end{enumerate}
 	What is still missing for the unconditional equal-case theorem
 	(Theorem~\ref{thm:ft_equal}, \cite[Corollary~IV.5]{Cirac2021Matrix}) is
-	not merely a final gauge-construction step.  Two paper-level ingredients
-	remain to be formalized:
-	\begin{enumerate}
-		\item a one-sided basis-of-normal-tensors construction for the
-		      after-blocking output that chooses representatives of
-		      gauge-phase-equivalent normal tensors and proves the resulting
-		      separated family has the required sector weights; the separated
-		      primitive-normal case already gives BNT linear independence by
-		      Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_separated}; and
-		\item a matched-basis theorem for heterogeneous sector decompositions:
-		      the algebraic reduction after a basis matching is formalized in
-		      Theorems~\ref{thm:route_b_hetero_phase_match},~\ref{thm:route_b_hetero_matched_basis},
-		      and~\ref{thm:route_b_hetero_sector_matching}.  Copy alignment is now
-		      recovered from a basis pre-matching by
-		      Theorem~\ref{thm:sector_basis_pre_matching_to_matching}, and the
-		      primitive overlap-rigidity hypotheses produce such a matching by
-		      Theorem~\ref{thm:sector_basis_matching_from_overlap_ortho_span}.  The
-		      remaining task is to derive those span and overlap hypotheses from
-		      arbitrary equal-MPV sector decompositions produced by the one-sided
-		      BNT construction.
-	\end{enumerate}
-	Once these two ingredients are in place, the final global gauge matrix
+	not the one-sided sector construction: the collapsed-representative
+		construction for trace-preserving primitive irreducible blocks is now
+		Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}.  The remaining
+		paper-level ingredient is a matched-basis theorem for heterogeneous sector
+		decompositions.  The algebraic reduction after a basis matching is formalized in
+		Theorems~\ref{thm:route_b_hetero_phase_match},~\ref{thm:route_b_hetero_matched_basis},
+		and~\ref{thm:route_b_hetero_sector_matching}.  Copy alignment is now recovered
+		from a basis pre-matching by
+		Theorem~\ref{thm:sector_basis_pre_matching_to_matching}, and the primitive
+		overlap-rigidity hypotheses produce such a matching by
+		Theorem~\ref{thm:sector_basis_matching_from_overlap_ortho_span}.  The remaining
+		task is to derive those span and overlap hypotheses from arbitrary equal-MPV
+		sector decompositions produced by the one-sided BNT construction.
+		Once this ingredient is in place, the final global gauge matrix
 	of Corollary~IV.5 is obtained by the same phase-absorption and blockwise
 	composition argument already formalized in the strict single-weight setting.
 \end{remark}


### PR DESCRIPTION
Closes #923. Parent: #652.

## Summary

- Add `MPVPhaseEquiv` and finite `MPVPhaseClassData` for quotienting a dependent block family by MPV phase equivalence.
- Construct one representative per phase class, enumerate the original class members, and prove representatives satisfy `BlocksNotGaugePhaseEquiv` because gauge-phase equivalence implies MPV phase equivalence.
- Add `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`, which absorbs each class member's phase into its sector weight and proves `SameMPV₂` plus current `HasBNTSectorData` for arbitrary TP / primitive / irreducible input blocks with nonzero weights.
- Update the blueprint and the #876/#923 audit to record that the one-sided collapsed-representative step is now formalized; the remaining #652 blocker is heterogeneous matched-basis witness construction.

## Validation

- `lake build TNLean.MPS.CanonicalForm.EqualNormBridge`
- `lake build TNLean` (success; only pre-existing warnings in unrelated files replayed)
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `rg -n "\\b(sorry|admit|axiom|native_decide|unsafe)\\b" TNLean/MPS/CanonicalForm/EqualNormBridge.lean audits/2026-04-25_issue876_bnt_sector_blocker.md blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch11_assembly.tex || true`
- `git diff --check`

This PR is ready for an orchestrator simplification/cleanup pass; I will not merge it myself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds substantial new Lean proof machinery (a new equivalence relation, quotient/class enumeration, and a new sector-construction theorem) that can affect downstream proof stability and typeclass inference, though it is localized to canonical-form/BNT tooling.
> 
> **Overview**
> Adds an MPV-level phase equivalence (`MPVPhaseEquiv`) and supporting finite quotient infrastructure (`MPVPhaseClassData`/`mpvPhaseClassData`) to collapse a finite TP/primitive/irreducible block family into phase classes with chosen representatives and a regrouping identity.
> 
> Introduces `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`, which builds a `SectorDecomposition` by absorbing each class member’s scalar factor into its sector weight, proves `SameMPV₂` against the original weighted block sum, and derives `HasBNTSectorData` by reducing to the existing separated-family linear-independence theorem.
> 
> Updates the #876/#923 audit note and blueprint chapters to document the new collapsed-representative construction as the resolved one-sided sub-blocker and to narrow the remaining gap to heterogeneous matched-basis results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0c694797088b3975c8bf08df991d7cb604c3c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->