### PR TITLE
feat(MPS/ParentHamiltonian): add reduced wrapped-boundary compatibilities

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -512,7 +512,7 @@ families for an open-chain boundary matrix.
 After the cyclic-to-open-chain step writes a periodic-chain vector as
 `ψ = groundSpaceMap A N X`, the two reduced wrapped windows expose the boundary
 matrix `X` on opposite sides of the same length-`N - (L₀ + 1)` complement word.
-This theorem packages exactly the local algebraic output needed for the final
+This theorem gives exactly the local algebraic output needed for the final
 common-middle/long-word commutation step of the normal parent-Hamiltonian
 argument. -/
 theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -506,6 +506,79 @@ theorem chainGroundSpace_eq_mpvSubmodule {A : MPSTensor d D} [NeZero D]
     obtain ⟨c, rfl⟩ := hψ
     exact Submodule.smul_mem _ c (mpv_mem_chainGroundSpace A L N hN0 hLN)
 
+/-- Reduced cyclic constraints give the two wrapped-boundary compatibility
+families for an open-chain boundary matrix.
+
+After the cyclic-to-open-chain step writes a periodic-chain vector as
+`ψ = groundSpaceMap A N X`, the two reduced wrapped windows expose the boundary
+matrix `X` on opposite sides of the same length-`N - (L₀ + 1)` complement word.
+This theorem packages exactly the local algebraic output needed for the final
+common-middle/long-word commutation step of the normal parent-Hamiltonian
+argument. -/
+theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
+    {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
+    {ψ : NSiteSpace d N} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψ : ψ ∈ chainGroundSpace A L N) (hψX : ψ = groundSpaceMap A N X) :
+    ∃ Ywrap Ymirror : (Fin N → Fin d) → Matrix (Fin D) (Fin D) ℂ,
+      (∀ (j : Fin d) (τ : Fin N → Fin d),
+        evalWord A (List.ofFn (fun k : Fin (N - (L₀ + 1)) =>
+          τ ⟨k.val + L₀, by omega⟩)) * A j * X = Ywrap τ * A j) ∧
+      (∀ (j : Fin d) (τ : Fin N → Fin d),
+        X * A j * evalWord A (List.ofFn (fun k : Fin (N - (L₀ + 1)) =>
+          τ ⟨k.val + 1, by omega⟩)) = A j * Ymirror τ) := by
+  obtain ⟨M, rfl⟩ : ∃ M, N = M + 1 := ⟨N - 1, by omega⟩
+  have hN0 : 0 < M + 1 := by omega
+  have hL₀N : L₀ + 1 ≤ M + 1 := by omega
+  have hM : L₀ ≤ M := by omega
+  have hψmap : groundSpaceMap A (M + 1) X ∈ chainGroundSpace A L (M + 1) := by
+    simpa [hψX] using hψ
+  have hψred : groundSpaceMap A (M + 1) X ∈ chainGroundSpace A (L₀ + 1) (M + 1) :=
+    chainGroundSpace_le_chainGroundSpace_of_le (A := A) hN0
+      (by omega : L₀ + 1 ≤ L) hLN hψmap
+  rw [chainGroundSpace, dif_pos ⟨hN0, hL₀N⟩] at hψred
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψred
+  have hGSwrap : ∀ τ : Fin (M + 1) → Fin d,
+      ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+        ∀ σ_w : Fin (L₀ + 1) → Fin d,
+          Matrix.trace (evalWord A (List.ofFn
+            (cyclicCfg hN0 (L₀ + 1) ⟨M, by omega⟩ σ_w τ)) * X) =
+          Matrix.trace (evalWord A (List.ofFn σ_w) * Y) := by
+    intro τ
+    have hmem := hψred ⟨M, by omega⟩ τ
+    rw [groundSpace, LinearMap.mem_range] at hmem
+    obtain ⟨Y, hY⟩ := hmem
+    refine ⟨Y, fun σ_w => ?_⟩
+    have : cyclicRestrictₗ hN0 (L₀ + 1) ⟨M, by omega⟩ τ
+        (groundSpaceMap A (M + 1) X) σ_w = groundSpaceMap A (L₀ + 1) Y σ_w := by
+      rw [← hY]
+    simp only [cyclicRestrictₗ_apply, groundSpaceMap_apply] at this
+    exact this
+  choose Ywrap hYwrap using hGSwrap
+  have hWrap := wrapping_window_compatibility_of_isNBlkInjective
+    (A := A) hInj hL₀ hM Ywrap (fun τ σ_w => hYwrap τ σ_w)
+  have hGSmirror : ∀ τ : Fin (M + 1) → Fin d,
+      ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+        ∀ σ_w : Fin (L₀ + 1) → Fin d,
+          Matrix.trace (evalWord A (List.ofFn
+            (cyclicCfg hN0 (L₀ + 1) ⟨M + 1 - L₀, by omega⟩ σ_w τ)) * X) =
+          Matrix.trace (evalWord A (List.ofFn σ_w) * Y) := by
+    intro τ
+    have hmem := hψred ⟨M + 1 - L₀, by omega⟩ τ
+    rw [groundSpace, LinearMap.mem_range] at hmem
+    obtain ⟨Y, hY⟩ := hmem
+    refine ⟨Y, fun σ_w => ?_⟩
+    have : cyclicRestrictₗ hN0 (L₀ + 1) ⟨M + 1 - L₀, by omega⟩ τ
+        (groundSpaceMap A (M + 1) X) σ_w = groundSpaceMap A (L₀ + 1) Y σ_w := by
+      rw [← hY]
+    simp only [cyclicRestrictₗ_apply, groundSpaceMap_apply] at this
+    exact this
+  choose Ymirror hYmirror using hGSmirror
+  have hMirror := wrapping_window_mirror_compatibility_of_isNBlkInjective
+    (A := A) hInj hL₀ hM Ymirror (fun τ σ_w => hYmirror τ σ_w)
+  exact ⟨Ywrap, Ymirror, hWrap, hMirror⟩
+
 /-- Range-reduction bridge for normal tensors.
 
 This is the missing hard direction of `chainGroundSpace_eq_mpvSubmodule_normal`:

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -539,45 +539,30 @@ theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
       (by omega : L₀ + 1 ≤ L) hLN hψmap
   rw [chainGroundSpace, dif_pos ⟨hN0, hL₀N⟩] at hψred
   simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψred
-  have hGSwrap : ∀ τ : Fin (M + 1) → Fin d,
+  have hGSAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
       ∃ Y : Matrix (Fin D) (Fin D) ℂ,
         ∀ σ_w : Fin (L₀ + 1) → Fin d,
           Matrix.trace (evalWord A (List.ofFn
-            (cyclicCfg hN0 (L₀ + 1) ⟨M, by omega⟩ σ_w τ)) * X) =
+            (cyclicCfg hN0 (L₀ + 1) i σ_w τ)) * X) =
           Matrix.trace (evalWord A (List.ofFn σ_w) * Y) := by
-    intro τ
-    have hmem := hψred ⟨M, by omega⟩ τ
+    intro i τ
+    have hmem := hψred i τ
     rw [groundSpace, LinearMap.mem_range] at hmem
     obtain ⟨Y, hY⟩ := hmem
     refine ⟨Y, fun σ_w => ?_⟩
-    have : cyclicRestrictₗ hN0 (L₀ + 1) ⟨M, by omega⟩ τ
+    have : cyclicRestrictₗ hN0 (L₀ + 1) i τ
         (groundSpaceMap A (M + 1) X) σ_w = groundSpaceMap A (L₀ + 1) Y σ_w := by
       rw [← hY]
     simp only [cyclicRestrictₗ_apply, groundSpaceMap_apply] at this
     exact this
-  choose Ywrap hYwrap using hGSwrap
+  choose YAt hYAt using hGSAt
+  let wrapPos : Fin (M + 1) := ⟨M, by omega⟩
+  let mirrorPos : Fin (M + 1) := ⟨M + 1 - L₀, by omega⟩
   have hWrap := wrapping_window_compatibility_of_isNBlkInjective
-    (A := A) hInj hL₀ hM Ywrap (fun τ σ_w => hYwrap τ σ_w)
-  have hGSmirror : ∀ τ : Fin (M + 1) → Fin d,
-      ∃ Y : Matrix (Fin D) (Fin D) ℂ,
-        ∀ σ_w : Fin (L₀ + 1) → Fin d,
-          Matrix.trace (evalWord A (List.ofFn
-            (cyclicCfg hN0 (L₀ + 1) ⟨M + 1 - L₀, by omega⟩ σ_w τ)) * X) =
-          Matrix.trace (evalWord A (List.ofFn σ_w) * Y) := by
-    intro τ
-    have hmem := hψred ⟨M + 1 - L₀, by omega⟩ τ
-    rw [groundSpace, LinearMap.mem_range] at hmem
-    obtain ⟨Y, hY⟩ := hmem
-    refine ⟨Y, fun σ_w => ?_⟩
-    have : cyclicRestrictₗ hN0 (L₀ + 1) ⟨M + 1 - L₀, by omega⟩ τ
-        (groundSpaceMap A (M + 1) X) σ_w = groundSpaceMap A (L₀ + 1) Y σ_w := by
-      rw [← hY]
-    simp only [cyclicRestrictₗ_apply, groundSpaceMap_apply] at this
-    exact this
-  choose Ymirror hYmirror using hGSmirror
+    (A := A) hInj hL₀ hM (YAt wrapPos) (fun τ σ_w => hYAt wrapPos τ σ_w)
   have hMirror := wrapping_window_mirror_compatibility_of_isNBlkInjective
-    (A := A) hInj hL₀ hM Ymirror (fun τ σ_w => hYmirror τ σ_w)
-  exact ⟨Ywrap, Ymirror, hWrap, hMirror⟩
+    (A := A) hInj hL₀ hM (YAt mirrorPos) (fun τ σ_w => hYAt mirrorPos τ σ_w)
+  exact ⟨YAt wrapPos, YAt mirrorPos, hWrap, hMirror⟩
 
 /-- Range-reduction bridge for normal tensors.
 

--- a/audits/2026-04-22_issue588_normal_range_reduction_partial.md
+++ b/audits/2026-04-22_issue588_normal_range_reduction_partial.md
@@ -111,3 +111,42 @@ cyclic-window reduction from periodic constraints to that open-chain theorem. Th
 remaining proof obligation in
 `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` is now concentrated
 in the wrapped-boundary scalar-closure step.
+
+## 2026-04-26 Wave 16A update
+
+Current branch `wave16-A-588-wrapped-boundary-scalar` does **not** close the final
+MPV-line containment theorem; the existing proof placeholder in
+`MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` remains.
+It lands the next reusable Lean statement on the closure-property path:
+
+- `MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`
+  in `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`.
+
+The theorem starts from exactly the post-open-chain situation: an $N$-site vector
+`ψ ∈ chainGroundSpace A L N` with `ψ = groundSpaceMap A N X`, an
+`L₀`-block-injective tensor with `L₀ > 0`, and `L₀ < L ≤ N`. It first reduces the
+cyclic constraints to range `L₀ + 1`, then applies the existing wrapped-window
+compatibility theorem at the last site and the mirror compatibility theorem at
+the opposite wrapped position. The output is the two one-sided boundary identities
+for some boundary families `Ywrap` and `Ymirror`:
+
+```text
+C⁺_τ · A_j · X = Ywrap_τ · A_j,
+X · A_j · C⁻_τ = A_j · Ymirror_τ,
+```
+
+where `C⁺_τ` and `C⁻_τ` are the complementary word products of length
+`N - (L₀ + 1)` exposed by the two reduced wrapped windows.
+
+This is paper-faithful to the CPGSV21 closure-property sentence at
+`Papers/2011.12127/TN-Review-main.tex:2078--2079`, especially the source text
+"Once we have reached $k=L_0$, we can resort to the above Theorem, or
+alternatively apply a similar argument when closing the boundaries". It also
+feeds the theorem statement at lines `2087--2090`, labelled
+`thm:4:unique-gs-L0_plus_1`.
+
+The remaining blocker is now sharper: prove the common-middle comparison turning
+the two one-sided identities above into a long-word commutation family
+`X A^ω = A^ω X` for some positive word length (then amplify to length at least
+`L₀` if necessary) and apply
+`MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -751,6 +751,34 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:normal_open_chain_range_reduction} applies.
 \end{proof}
 
+\begin{theorem}[Reduced wrapped-boundary compatibilities]%
+    \label{thm:reduced_wrapped_boundary_compatibilities}
+    \lean{MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective}
+    \leanok
+    \uses{def:chain_ground_space, def:l_blk_injective,
+        thm:cyclic_normal_open_chain_range_reduction}
+    Let $A$ be $L_0$-block injective with $L_0>0$ and $D \ge 1$.
+    Suppose $\psi \in \mathcal G_{N,L}(A)$, $N \ge 2$, $L_0 < L \le N$, and
+    $\psi = \Gamma_N(X)$ for a boundary matrix $X$. Then there are two families
+    of boundary matrices $Y^+_\tau$ and $Y^-_\tau$, indexed by outside
+    configurations $\tau$, such that for every physical letter $j$,
+    \[
+        C^+_\tau A^j X = Y^+_\tau A^j,
+        \qquad
+        X A^j C^-_\tau = A^j Y^-_\tau,
+    \]
+    where $C^+_\tau$ and $C^-_\tau$ are the complementary words exposed by the
+    two opposite wrapped windows of reduced length $L_0+1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    First reduce the cyclic constraints from range $L$ to range $L_0+1$ by
+    Theorem~\ref{thm:cyclic_normal_open_chain_range_reduction}. Applying the
+    wrapped window and mirror wrapped window compatibility extractions at the
+    two boundary-crossing positions gives the displayed one-sided identities.
+\end{proof}
+
 \begin{theorem}[Boundary matrix commutation from the wrapping window]\label{thm:boundary_matrix_commutes}
     \lean{MPSTensor.boundary_matrix_commutes}
     \leanok
@@ -988,7 +1016,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction}
     \notready
     \uses{def:chain_ground_space, def:mpv_submodule, def:normal,
-        def:l_blk_injective, thm:cyclic_normal_open_chain_range_reduction}
+        def:l_blk_injective, thm:cyclic_normal_open_chain_range_reduction,
+        thm:reduced_wrapped_boundary_compatibilities,
+        lem:boundary_matrix_commutes_long_words}
     If $A$ is normal, $D \ge 1$, $L_0$-block-injective, with $N \ge 2$ and $L_0 < L \le N$, then
     \[
         \mathcal G_{N,L}(A) \subseteq \spn\bigl\{V^{(N)}(A)\bigr\}.
@@ -997,11 +1027,15 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    \uses{thm:boundary_matrix_commutes}
-    The remaining step is the periodic range-reduction theorem from
-    \cite[\S~IV.C]{Cirac2021Matrix}: one must show that the reduced cyclic window constraints
-    still force the same boundary-matrix commutation relation as in
-    Theorem~\ref{thm:boundary_matrix_commutes}.
+    \uses{thm:reduced_wrapped_boundary_compatibilities,
+        lem:boundary_matrix_commutes_long_words}
+    The remaining step is the closure property from
+    \cite[\S~IV.C]{Cirac2021Matrix}: Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
+    supplies the two one-sided wrapped-boundary identities for the open-chain
+    boundary matrix $X$. What is still missing is the common-middle comparison
+    that turns these identities into commutation of $X$ with a sufficiently long
+    word product; Lemma~\ref{lem:boundary_matrix_commutes_long_words} would then
+    give the generator commutation used in the injective proof.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the normal case]%

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -727,13 +727,30 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     regrows the rightmost site.
 \end{proof}
 
+\begin{lemma}[Cyclic-window range antitonicity]%
+    \label{lem:cyclic_window_range_antitonicity}
+    \lean{MPSTensor.chainGroundSpace_le_chainGroundSpace_succ,
+          MPSTensor.chainGroundSpace_le_chainGroundSpace_of_le}
+    \leanok
+    \uses{rem:cyclic_window_operators, lem:ground_space_in_left_ground}
+    On a nonempty periodic chain, longer cyclic-window constraints imply all
+    shorter cyclic-window constraints: if $L' \le L \le N$, then
+    $\mathcal G_{N,L}(A) \subseteq \mathcal G_{N,L'}(A)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Fix a cyclic window of length $L+1$ and restrict its last site. The resulting
+    length-$L$ vector is again in the ground space, so one-site peeling gives the
+    inclusion for consecutive ranges. Iteration gives the general antitonicity.
+\end{proof}
+
 \begin{theorem}[Cyclic-window normal open-chain reduction]%
     \label{thm:cyclic_normal_open_chain_range_reduction}
-    \lean{MPSTensor.chainGroundSpace_le_chainGroundSpace_succ,
-          MPSTensor.chainGroundSpace_le_chainGroundSpace_of_le,
-          MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}
+    \lean{MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}
     \leanok
-    \uses{rem:cyclic_window_operators, thm:normal_open_chain_range_reduction}
+    \uses{lem:cyclic_window_range_antitonicity,
+        thm:normal_open_chain_range_reduction}
     Let $A$ be $L_0$-block injective with $L_0>0$ and $D \ge 1$.
     If an $N$-site periodic-chain state satisfies all cyclic ground-space
     constraints at some range $L_0+1 \le L \le N$, then it lies in the
@@ -742,13 +759,56 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    \uses{rem:cyclic_window_operators, thm:normal_open_chain_range_reduction,
-        lem:ground_space_in_left_ground}
-    First peel cyclic windows one site at a time: a state satisfying the range
-    $L+1$ constraints also satisfies the range $L$ constraints. Iterating this
-    antitonicity reduces the cyclic hypotheses to range $L_0+1$. On every
-    non-wrapping interval, the cyclic and contiguous restriction maps agree, so
+    \uses{lem:cyclic_window_range_antitonicity,
+        thm:normal_open_chain_range_reduction}
+    Lemma~\ref{lem:cyclic_window_range_antitonicity} reduces the cyclic
+    hypotheses to range $L_0+1$. On every non-wrapping interval, the cyclic and
+    contiguous restriction maps agree, so
     Theorem~\ref{thm:normal_open_chain_range_reduction} applies.
+\end{proof}
+
+\begin{lemma}[Wrapped-window one-sided compatibility]%
+    \label{lem:wrapped_window_one_sided_compatibility}
+    \lean{MPSTensor.wrapping_window_compatibility_of_isNBlkInjective}
+    \leanok
+    \uses{def:l_blk_injective, rem:cyclic_window_operators,
+        lem:ground_space_map_injective_blk}
+    Assume $A$ is $L_0$-block injective with $L_0>0$ and $M \ge L_0$.
+    If the reduced wrapped window at the last site has boundary matrices
+    $Y_\tau$, then for every physical letter $j$ one has
+    \[
+        C^+_\tau A^j X = Y_\tau A^j,
+    \]
+    where $C^+_\tau$ is the complementary word seen by that wrapped window.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The trace identity for the wrapped window is tested against all words of
+    length $L_0$. Injectivity of $\Gamma_{L_0}$, which follows from
+    $L_0$-block injectivity, strips the test word and gives the displayed matrix
+    identity.
+\end{proof}
+
+\begin{lemma}[Mirror wrapped-window one-sided compatibility]%
+    \label{lem:mirror_wrapped_window_one_sided_compatibility}
+    \lean{MPSTensor.wrapping_window_mirror_compatibility_of_isNBlkInjective}
+    \leanok
+    \uses{def:l_blk_injective, rem:cyclic_window_operators,
+        lem:ground_space_map_injective_blk}
+    Assume $A$ is $L_0$-block injective with $L_0>0$ and $M \ge L_0$.
+    If the opposite reduced wrapped window has boundary matrices $Y_\tau$, then
+    \[
+        X A^j C^-_\tau = A^j Y_\tau
+    \]
+    for every physical letter $j$, where $C^-_\tau$ is the complementary word
+    seen from the opposite boundary-crossing position.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Factor the cyclic word at the opposite wrapped position, rotate the trace,
+    and use injectivity of $\Gamma_{L_0}$ to remove the length-$L_0$ test word.
 \end{proof}
 
 \begin{theorem}[Reduced wrapped-boundary compatibilities]%
@@ -756,7 +816,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective}
     \leanok
     \uses{def:chain_ground_space, def:l_blk_injective,
-        thm:cyclic_normal_open_chain_range_reduction}
+        lem:cyclic_window_range_antitonicity,
+        lem:wrapped_window_one_sided_compatibility,
+        lem:mirror_wrapped_window_one_sided_compatibility}
     Let $A$ be $L_0$-block injective with $L_0>0$ and $D \ge 1$.
     Suppose $\psi \in \mathcal G_{N,L}(A)$, $N \ge 2$, $L_0 < L \le N$, and
     $\psi = \Gamma_N(X)$ for a boundary matrix $X$. Then there are two families
@@ -773,10 +835,13 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    First reduce the cyclic constraints from range $L$ to range $L_0+1$ by
-    Theorem~\ref{thm:cyclic_normal_open_chain_range_reduction}. Applying the
-    wrapped window and mirror wrapped window compatibility extractions at the
-    two boundary-crossing positions gives the displayed one-sided identities.
+    \uses{lem:cyclic_window_range_antitonicity,
+        lem:wrapped_window_one_sided_compatibility,
+        lem:mirror_wrapped_window_one_sided_compatibility}
+    First use Lemma~\ref{lem:cyclic_window_range_antitonicity} to reduce the
+    cyclic constraints from range $L$ to range $L_0+1$. Then apply the wrapped
+    window and mirror wrapped window compatibility lemmas at the two
+    boundary-crossing positions to obtain the displayed one-sided identities.
 \end{proof}
 
 \begin{theorem}[Boundary matrix commutation from the wrapping window]\label{thm:boundary_matrix_commutes}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -732,7 +732,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.chainGroundSpace_le_chainGroundSpace_succ,
           MPSTensor.chainGroundSpace_le_chainGroundSpace_of_le}
     \leanok
-    \uses{rem:cyclic_window_operators, lem:ground_space_in_left_ground}
+    \uses{rem:cyclic_window_operators}
     On a nonempty periodic chain, longer cyclic-window constraints imply all
     shorter cyclic-window constraints: if $L' \le L \le N$, then
     $\mathcal G_{N,L}(A) \subseteq \mathcal G_{N,L'}(A)$.
@@ -740,6 +740,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
+    \uses{lem:ground_space_in_left_ground}
     Fix a cyclic window of length $L+1$ and restrict its last site. The resulting
     length-$L$ vector is again in the ground space, so one-site peeling gives the
     inclusion for consecutive ranges. Iteration gives the general antitonicity.
@@ -771,8 +772,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \label{lem:wrapped_window_one_sided_compatibility}
     \lean{MPSTensor.wrapping_window_compatibility_of_isNBlkInjective}
     \leanok
-    \uses{def:l_blk_injective, rem:cyclic_window_operators,
-        lem:ground_space_map_injective_blk}
+    \uses{def:l_blk_injective, rem:cyclic_window_operators}
     Assume $A$ is $L_0$-block injective with $L_0>0$ and $M \ge L_0$.
     If the reduced wrapped window at the last site has boundary matrices
     $Y_\tau$, then for every physical letter $j$ one has
@@ -784,6 +784,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
+    \uses{lem:ground_space_map_injective_blk}
     The trace identity for the wrapped window is tested against all words of
     length $L_0$. Injectivity of $\Gamma_{L_0}$, which follows from
     $L_0$-block injectivity, strips the test word and gives the displayed matrix
@@ -794,8 +795,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \label{lem:mirror_wrapped_window_one_sided_compatibility}
     \lean{MPSTensor.wrapping_window_mirror_compatibility_of_isNBlkInjective}
     \leanok
-    \uses{def:l_blk_injective, rem:cyclic_window_operators,
-        lem:ground_space_map_injective_blk}
+    \uses{def:l_blk_injective, rem:cyclic_window_operators}
     Assume $A$ is $L_0$-block injective with $L_0>0$ and $M \ge L_0$.
     If the opposite reduced wrapped window has boundary matrices $Y_\tau$, then
     \[
@@ -807,6 +807,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
+    \uses{lem:ground_space_map_injective_blk}
     Factor the cyclic word at the opposite wrapped position, rotate the trace,
     and use injectivity of $\Gamma_{L_0}$ to remove the length-$L_0$ test word.
 \end{proof}


### PR DESCRIPTION
## Summary

- adds `MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`, deriving the two one-sided reduced wrapped-boundary compatibility families from `ψ ∈ chainGroundSpace A L N` and `ψ = groundSpaceMap A N X`
- updates Chapter 14 with the new Lean-backed reduced wrapped-boundary compatibility statement
- records the remaining #588 blocker: a common-middle comparison turning these two one-sided identities into long-word commutation for `boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`

## Paper / blueprint anchors

- CPGSV21 source: `Papers/2011.12127/TN-Review-main.tex:2078--2079`, quote: “Once we have reached $k=L_0$, we can resort to the above Theorem, or alternatively apply a similar argument when closing the boundaries.”
- CPGSV21 theorem: `Papers/2011.12127/TN-Review-main.tex:2087--2090`, label `thm:4:unique-gs-L0_plus_1`, quote: “Consider a normal MPS which becomes injective upon blocking $L_0$ sites. Then, the parent Hamiltonian defined on $L_0+1$ sites has a unique ground state.”
- Blueprint: `blueprint/src/chapter/ch14_parent_hamiltonian.tex`, new label `thm:reduced_wrapped_boundary_compatibilities`; remaining target label `thm:normal_range_reduction_containment`

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState` ✅ (reports only the pre-existing target `sorry`)
- `cd blueprint && leanblueprint web && leanblueprint checkdecls` ✅ after warming required oleans
- `git diff --check` ✅
- touched-file forbidden-token scan shows only the pre-existing `UniqueGroundState.lean` target `sorry`; added-line scan is clean ✅

Refs #588. Refs #190. Refs #460.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new auxiliary Lean theorem and documentation/blueprint text without changing existing definitions or behavior; main remaining theorem is still `sorry`/`notready`.
> 
> **Overview**
> Adds `MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`, which reduces `ψ ∈ chainGroundSpace A L N` (with `L₀ < L ≤ N` and `ψ = groundSpaceMap A N X`) down to range `L₀+1` and then applies the existing wrapped-window and mirror-wrapped-window lemmas to produce the two one-sided boundary identities relating `X` to complementary words.
> 
> Updates the audit log and Chapter 14 blueprint to include the new Lean-backed statement (`thm:reduced_wrapped_boundary_compatibilities`) and to clarify that the remaining blocker is the common-middle comparison needed to turn these one-sided identities into long-word commutation for `X`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc9521fa3607082494ebbe64aacafc1c2b9ae50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->