### PR TITLE
feat(MPS/CanonicalForm): derive product span from BNT selector words

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -- Provides `Matrix.blockProjection`, `Matrix.IsBlockDiagonal'`, and the
 -- projection-commutant criterion used below.
 import TNLean.Algebra.ScalarCommutant
+import TNLean.MPS.BNT.Construction
+import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.SharedInfra.BlockAssembly
 
 /-!
@@ -158,6 +160,30 @@ namespace MPSTensor
 
 variable {d r : ℕ} {dim : Fin r → ℕ}
 
+/-- One-site algebraic injectivity is the same as `1`-block injectivity.
+
+This records the fixed-length form needed when a canonical-form block is
+concatenated with a block-selector word: the one-letter prefix spans the chosen
+matrix algebra, while the selector word kills all other blocks. -/
+theorem isNBlkInjective_one_of_isInjective {D : ℕ} {A : MPSTensor d D}
+    (hA : IsInjective A) :
+    IsNBlkInjective A 1 := by
+  unfold IsNBlkInjective
+  have hrange : (Set.range fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ)) =
+      Set.range A := by
+    ext M
+    constructor
+    · rintro ⟨σ, hσ⟩
+      refine ⟨σ 0, ?_⟩
+      simpa only [List.ofFn_succ, List.ofFn_zero, evalWord_cons,
+        evalWord_nil, mul_one] using hσ
+    · rintro ⟨i, hi⟩
+      refine ⟨fun _ => i, ?_⟩
+      simpa only [List.ofFn_succ, List.ofFn_zero, evalWord_cons,
+        evalWord_nil, mul_one] using hi
+  rw [hrange]
+  exact hA
+
 /-- Finite product-word span gives the projection-span input for the assembled tensor.
 
 Assume that the simultaneous length-`m` word evaluations
@@ -209,6 +235,20 @@ theorem blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_
         (evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω)))
   rw [hgen]
   exact hproj
+
+/-- `WordTupleSpanTop` spelling of
+`blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top`. -/
+theorem blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTupleSpanTop
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) {m : ℕ}
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    (hSpan : WordTupleSpanTop A m) :
+    ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω))) := by
+  exact blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top
+    (d := d) (dim := dim) μ A hμ (by simpa [WordTupleSpanTop, wordTuple] using hSpan)
 
 /-- Reindexed word-span version of the block-diagonal commutant criterion.
 
@@ -268,6 +308,78 @@ theorem isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_s
     (B := toTensorFromBlocks (d := d) (μ := μ) A)
     (blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top
       (d := d) (dim := dim) μ A hμ hSpan)
+    hComm
+
+/-- Canonical-form/BNT data plus finite block-selector words give full product-word span.
+
+The remaining paper-level separation step is the construction of the selector words
+from the BNT non-equivalence hypothesis. Once those selectors are available,
+canonical-form injectivity supplies a one-letter prefix spanning the selected
+block algebra, and concatenating prefix and selector words spans the whole
+product algebra. -/
+theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+    (hSel : HasBlockSelectorWords A S) :
+    WordTupleSpanTop A (1 + S) := by
+  refine wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
+    (A := A) (L := 1) (S := S) ?_ hSel
+  intro k
+  exact isNBlkInjective_one_of_isInjective (hCF.toHasInjectiveBlocks.block_injective k)
+
+/-- Positive-length product-word span obtained from canonical-form/BNT data and
+finite block-selector words.
+
+This is the issue-#934 goal shape with the still-missing selector-word theorem
+kept explicit rather than replaced by the conclusion. -/
+theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+    (hSel : HasBlockSelectorWords A S) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  refine ⟨1 + S, ?_, ?_⟩
+  · simp [Nat.add_comm]
+  simpa [WordTupleSpanTop, wordTuple] using
+    wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords μ A hCF hSel
+
+/-- Canonical-form/BNT data and selector words give the projection-span input for
+the assembled tensor. -/
+theorem blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+    (hSel : HasBlockSelectorWords A S) :
+    ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin (1 + S) → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω))) := by
+  exact blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTupleSpanTop
+    (d := d) (dim := dim) μ A hCF.toHasStrictOrderedNonzeroWeights.mu_ne_zero
+    (wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords μ A hCF hSel)
+
+/-- Selector-word version of the assembled-tensor commutant criterion.
+
+Under canonical-form/BNT data, finite block selectors replace the product-word
+span hypothesis in the commutant reduction. The construction of those selectors
+from BNT separation is the remaining finite-dimensional separation theorem. -/
+theorem isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+    (hSel : HasBlockSelectorWords A S)
+    {X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ}
+    (hComm : ∀ ω : Fin (1 + S) → Fin d,
+      X * evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω) =
+        evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω) * X) :
+    Matrix.IsBlockDiagonal'
+      (Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm X) := by
+  exact isBlockDiagonal'_of_commutes_reindexed_wordSpan
+    (B := toTensorFromBlocks (d := d) (μ := μ) A)
+    (blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords
+      (d := d) (dim := dim) μ A hCF hSel)
     hComm
 
 /-- Entrywise off-block-zero corollary of

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -160,30 +160,6 @@ namespace MPSTensor
 
 variable {d r : ℕ} {dim : Fin r → ℕ}
 
-/-- One-site algebraic injectivity is the same as `1`-block injectivity.
-
-This records the fixed-length form needed when a canonical-form block is
-concatenated with a block-selector word: the one-letter prefix spans the chosen
-matrix algebra, while the selector word kills all other blocks. -/
-theorem isNBlkInjective_one_of_isInjective {D : ℕ} {A : MPSTensor d D}
-    (hA : IsInjective A) :
-    IsNBlkInjective A 1 := by
-  unfold IsNBlkInjective
-  have hrange : (Set.range fun σ : Fin 1 → Fin d => evalWord A (List.ofFn σ)) =
-      Set.range A := by
-    ext M
-    constructor
-    · rintro ⟨σ, hσ⟩
-      refine ⟨σ 0, ?_⟩
-      simpa only [List.ofFn_succ, List.ofFn_zero, evalWord_cons,
-        evalWord_nil, mul_one] using hσ
-    · rintro ⟨i, hi⟩
-      refine ⟨fun _ => i, ?_⟩
-      simpa only [List.ofFn_succ, List.ofFn_zero, evalWord_cons,
-        evalWord_nil, mul_one] using hi
-  rw [hrange]
-  exact hA
-
 /-- Finite product-word span gives the projection-span input for the assembled tensor.
 
 Assume that the simultaneous length-`m` word evaluations
@@ -341,8 +317,7 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords
         fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
       (⊤ : Submodule ℂ
         ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
-  refine ⟨1 + S, ?_, ?_⟩
-  · simp [Nat.add_comm]
+  refine ⟨1 + S, Nat.add_pos_left Nat.zero_lt_one S, ?_⟩
   simpa [WordTupleSpanTop, wordTuple] using
     wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords μ A hCF hSel
 

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -136,23 +136,30 @@ def IsNormal (A : MPSTensor d D) : Prop :=
 @[simp] lemma isNormal_iff (A : MPSTensor d D) :
     IsNormal A ↔ ∃ N, IsNBlkInjective A N := Iff.rfl
 
-/-- Algebraic injectivity (1-block) implies normality (eventual block injectivity).
-This is the trivial direction: injectivity is `IsNBlkInjective 1`. -/
-lemma IsInjective.isNormal {A : MPSTensor d D} (h : IsInjective A) : IsNormal A := by
-  refine ⟨1, ?_⟩
+/-- Algebraic injectivity gives `1`-block injectivity. -/
+theorem isNBlkInjective_one_of_isInjective {A : MPSTensor d D}
+    (h : IsInjective A) : IsNBlkInjective A 1 := by
   unfold IsNBlkInjective
   have hrange : (Set.range fun σ : Fin 1 → Fin d =>
       evalWord A (List.ofFn σ)) = Set.range A := by
-    ext M; simp only [Set.mem_range]; constructor
+    ext M
+    simp only [Set.mem_range]
+    constructor
     · rintro ⟨σ, hσ⟩
-      exact ⟨σ 0, by
-        simp only [List.ofFn_succ, List.ofFn_zero,
-          evalWord_cons, evalWord_nil, mul_one] at hσ; exact hσ⟩
+      refine ⟨σ 0, ?_⟩
+      simpa only [List.ofFn_succ, List.ofFn_zero,
+        evalWord_cons, evalWord_nil, mul_one] using hσ
     · rintro ⟨i, hi⟩
-      exact ⟨fun _ => i, by
-        simp only [List.ofFn_succ, List.ofFn_zero,
-          evalWord_cons, evalWord_nil, mul_one]; exact hi⟩
-  rw [hrange]; exact h
+      refine ⟨fun _ => i, ?_⟩
+      simpa only [List.ofFn_succ, List.ofFn_zero,
+        evalWord_cons, evalWord_nil, mul_one] using hi
+  rw [hrange]
+  exact h
+
+/-- Algebraic injectivity (1-block) implies normality (eventual block injectivity).
+This is the trivial direction: injectivity is `IsNBlkInjective 1`. -/
+lemma IsInjective.isNormal {A : MPSTensor d D} (h : IsInjective A) : IsNormal A :=
+  ⟨1, isNBlkInjective_one_of_isInjective h⟩
 
 /-! ### Gauge invariance -/
 

--- a/audits/2026-04-26_issue934_product_word_span.md
+++ b/audits/2026-04-26_issue934_product_word_span.md
@@ -1,0 +1,73 @@
+# Issue #934 — product-word span from BNT selector words (2026-04-26)
+
+## Scope
+
+Wave 16 Slot B targeted the Route B finite product-word span input for the parent-Hamiltonian
+block decomposition.  The full paper-level theorem
+
+```lean
+IsCanonicalFormBNT μ A → ∃ m > 0, WordTupleSpanTop A m
+```
+
+is not yet proved from BNT separation alone.  This pass instead lands the next checked step on the
+paper path: once the finite BNT selector-word theorem is available, canonical-form injectivity turns
+those selectors into the required positive-length product-word span and into the downstream
+projection/commutant input.
+
+## Lean declarations added
+
+File: `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
+
+- `MPSTensor.isNBlkInjective_one_of_isInjective`
+  - Records that one-site injectivity is `1`-block injectivity.
+  - This supplies the prefix length used when concatenating block-spanning words with selector
+    words.
+
+- `MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTupleSpanTop`
+  - `WordTupleSpanTop` spelling of the existing raw product-span projection theorem.
+
+- `MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords`
+  - If `A` is in canonical form with BNT separation and `HasBlockSelectorWords A S`, then
+    `WordTupleSpanTop A (1 + S)`.
+  - Proof: use one-site injectivity for each block, then apply the existing
+    `wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords` theorem from the MPDO finite
+    witness infrastructure.
+
+- `MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords`
+  - The issue-#934 goal shape with the selector-word theorem kept explicit:
+    `∃ m, 0 < m ∧` the simultaneous length-`m` word tuples span the full product algebra.
+
+- `MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords`
+  - Composes the preceding product-word span with the projection-span reduction for
+    `toTensorFromBlocks μ A`.
+
+- `MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords`
+  - Selector-word version of the assembled-tensor commutant criterion.
+
+Blueprint Chapter 14 now records these declarations in
+`lem:product_word_span_from_bnt_selectors` and updates the not-ready parent-ground-space theorem to
+cite this selector-word reduction.
+
+## Remaining blocker
+
+The remaining mathematical content is still the finite BNT selector-word theorem:
+from separated CF/BNT data (`blocks_not_equiv` together with injectivity and left-canonical
+normalization), construct `HasBlockSelectorWords A S` for some finite `S`, or equivalently prove
+finite matrix-entry word-family linear independence.  The likely route remains the one recorded in
+issue #587/#822 notes: matrix-inserted word states, cross-sector Gram decay from BNT separation,
+nondegenerate same-sector Gram limits, and then the Gram-matrix linear-independence criterion.
+
+## Validation
+
+Successful local checks in `wave16-B-934-product-word-span`:
+
+- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
+- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
+- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant TNLean.MPS.MPDO.BiCFDerivation`
+  `TNLean.MPS.BNT.Construction`
+- `ulimit -n 8192 && lake build TNLean`
+  - The first two full-build invocations reached the command timeout while continuing the local
+    build; the final invocation completed successfully, with only pre-existing warnings in unrelated
+    modules.
+- `cd blueprint && leanblueprint web`
+- `cd blueprint && leanblueprint checkdecls`

--- a/audits/2026-04-26_issue934_product_word_span.md
+++ b/audits/2026-04-26_issue934_product_word_span.md
@@ -16,12 +16,14 @@ projection/commutant input.
 
 ## Lean declarations added
 
-File: `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
+File: `TNLean/MPS/Defs.lean`
 
 - `MPSTensor.isNBlkInjective_one_of_isInjective`
   - Records that one-site injectivity is `1`-block injectivity.
   - This supplies the prefix length used when concatenating block-spanning words with selector
-    words.
+    words, and `MPSTensor.IsInjective.isNormal` now reuses the lemma.
+
+File: `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
 
 - `MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTupleSpanTop`
   - `WordTupleSpanTop` spelling of the existing raw product-span projection theorem.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -338,6 +338,22 @@ boundary conditions (PBC).
     An injective tensor is $1$-block injective.
 \end{definition}
 
+\begin{lemma}[One-site injectivity gives one-block injectivity]
+    \label{lem:one_block_injective_of_injective}
+    \lean{MPSTensor.isNBlkInjective_one_of_isInjective}
+    \leanok
+    \uses{def:injective, def:l_blk_injective}
+    If the one-site matrices $\{A^i\}_{i=0}^{d-1}$ span $\MN{D}$, then the
+    length-one word products span $\MN{D}$, so $A$ is $1$-block injective.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The length-one words are exactly the letters $i \in \{0,\ldots,d-1\}$, and
+    evaluating a length-one word gives the matrix $A^i$. Thus the length-one
+    word span is the same span as in one-site injectivity.
+\end{proof}
+
 \begin{definition}[Normal tensor]\label{def:normal}
     \lean{MPSTensor.IsNormal}
     \leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2271,7 +2271,6 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Product-word span from BNT selector words]
     \label{lem:product_word_span_from_bnt_selectors}
-    \lean{MPSTensor.isNBlkInjective_one_of_isInjective}
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}
     \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords}
@@ -2289,9 +2288,11 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{proof}
     \leanok
-    \uses{lem:block_projection_span_from_product_word_span}
+    \uses{lem:one_block_injective_of_injective,
+        lem:block_projection_span_from_product_word_span}
     Definition~\ref{def:cf_bnt} gives one-site injectivity of each block, hence
-    $1$-block injectivity.  For a target tuple $(M_j)_j$, write $M_k$ as a
+    $1$-block injectivity by Lemma~\ref{lem:one_block_injective_of_injective}.
+    For a target tuple $(M_j)_j$, write $M_k$ as a
     one-letter linear combination in block $k$, multiply by the selector for $k$,
     and sum over $k$.  The selector kills all off-target blocks, while it is the
     identity on block $k$, so the length-$(1+S)$ word tuples span the full

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2243,6 +2243,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{lemma}[Projection span from product-word span]
     \label{lem:block_projection_span_from_product_word_span}
     \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
+    \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTupleSpanTop}
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
     \lean{MPSTensor.offBlock_zero_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
     \leanok
@@ -2266,6 +2267,36 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     exactly $P_j$.  The word-evaluation formula for the assembled tensor identifies these scaled
     diagonal matrices with the pulled-back assembled word products, and the commutant conclusion
     follows from Lemma~\ref{lem:route_b_block_diagonal_commutant_reduction}.
+\end{proof}
+
+\begin{lemma}[Product-word span from BNT selector words]
+    \label{lem:product_word_span_from_bnt_selectors}
+    \lean{MPSTensor.isNBlkInjective_one_of_isInjective}
+    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}
+    \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords}
+    \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords}
+    \leanok
+    \uses{def:cf_bnt, lem:block_projection_span_from_product_word_span}
+    Let $((\mu_j),(A_j))$ be in canonical form with BNT separation.  Suppose there are
+    length-$S$ block-selector words: for each sector $k$, a linear combination of
+    length-$S$ words evaluates to $I$ on $A_k$ and to $0$ on every other block.
+    Then the simultaneous length-$(1+S)$ block-word evaluations span
+    $\prod_j \MN{D_j}$, with positive length.  Consequently, the pulled-back
+    length-$(1+S)$ words of $\operatorname{Assemble}(\mu,A)$ span every virtual
+    sector projection, and the corresponding commutant reduction is available.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_projection_span_from_product_word_span}
+    Definition~\ref{def:cf_bnt} gives one-site injectivity of each block, hence
+    $1$-block injectivity.  For a target tuple $(M_j)_j$, write $M_k$ as a
+    one-letter linear combination in block $k$, multiply by the selector for $k$,
+    and sum over $k$.  The selector kills all off-target blocks, while it is the
+    identity on block $k$, so the length-$(1+S)$ word tuples span the full
+    product algebra.  The projection-span and commutant consequences then follow
+    from Lemma~\ref{lem:block_projection_span_from_product_word_span}.
 \end{proof}
 
 \begin{lemma}[Conditional boundary-matrix block split from projection span]
@@ -2324,7 +2355,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \uses{def:parent_hamiltonian_ground_space_bnt, def:bnt_span,
         thm:chain_ground_space_eq_mpv_blk,
         lem:conditional_boundary_matrix_block_split_projection_span,
-        lem:block_projection_span_from_product_word_span}
+        lem:block_projection_span_from_product_word_span,
+        lem:product_word_span_from_bnt_selectors}
     If $A$ is in canonical-form/BNT and $1 < L$ and $N \ge L + 1$, every vector in the
     assembled parent ground space should decompose into blockwise chain ground states, and
     therefore lie in the BNT span.
@@ -2333,9 +2365,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \notready
     The remaining structural step is the periodic block decomposition of the
-    assembled chain ground space. Lemma~\ref{lem:block_projection_span_from_product_word_span}
-    supplies the sector projections once the separated CF/BNT data has been turned
-    into a finite full-span statement for simultaneous block words.
+    assembled chain ground space. Lemma~\ref{lem:product_word_span_from_bnt_selectors}
+    reduces the needed product-word span to the finite BNT selector-word theorem;
+    Lemma~\ref{lem:block_projection_span_from_product_word_span} then supplies the sector
+    projections from that product-word span.
     Lemma~\ref{lem:conditional_boundary_matrix_block_split_projection_span}
     then supplies the conditional boundary-matrix endgame once the wrapping-window
     comparison provides a commuting boundary matrix. With that decomposition available,


### PR DESCRIPTION
## Summary

- add the checked Route B reduction from canonical-form/BNT data plus finite block-selector words to positive-length product-word span
- compose that selector-word span with the existing projection-span and assembled commutant reductions
- record the status in Chapter 14 and `audits/2026-04-26_issue934_product_word_span.md`

## Mathematical status

This advances #934 but deliberately does not claim the full paper-level theorem from bare `IsCanonicalFormBNT μ A`. The remaining finite-dimensional separation theorem is still to construct `HasBlockSelectorWords A S` (equivalently matrix-entry word-family linear independence) from the BNT non-equivalence/separation data. Once that selector theorem is supplied, the new declarations give:

- `MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords`
- `MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords`
- `MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords`
- `MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords`

Refs #934. Feeds #905 and #190.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.BNT.Construction`
- `ulimit -n 8192 && lake build TNLean` (completed; only pre-existing warnings in unrelated modules)
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `git diff --check`
- touched-file forbidden-token scan clean
- Lean diagnostics for `BlockDiagonalCommutant.lean`: no errors/warnings/hints

Ready for the orchestrator simplification/cleanup pass before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive Lean theorems/lemmas and documentation wiring, with no runtime behavior or IO/security concerns; main risk is proof/lemma dependency and downstream breakage if names or hypotheses are incorrect.
> 
> **Overview**
> Connects canonical-form/BNT assumptions plus a finite `HasBlockSelectorWords` hypothesis to the previously-required product-word span and assembled commutant reductions.
> 
> Adds bridging theorems in `BlockDiagonalCommutant.lean` that: (1) re-express the existing projection-span lemma in `WordTupleSpanTop` form, (2) derive `WordTupleSpanTop A (1+S)` and an explicit `∃ m>0` product-word-span statement from `IsCanonicalFormBNT` + selector words, and (3) compose these to obtain selector-word versions of the assembled projection-span and block-diagonal commutant criteria.
> 
> Refactors `Defs.lean` by extracting `isNBlkInjective_one_of_isInjective` and reusing it in `IsInjective.isNormal`, and updates the blueprint (Ch.02/Ch.14) plus a new audit note to reflect the new checked reduction and the remaining missing selector-word theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d20819f904517dabba72c1e4c6b355032a37824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->