### PR TITLE
feat(MPS/ParentHamiltonian): bound cyclic-window overlap rows

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -172,34 +172,26 @@ def cyclicBackwardSite {N : ℕ} (i : Fin N) (r : ℕ) : Fin N :=
   ⟨(i.val + N - r % N) % N, Nat.mod_lt _ (Fin.pos i)⟩
 
 /-- The support of the length-`L` cyclic window starting at `i`, represented as the
-finite set of sites `i, i+1, ..., i+L-1` modulo `N`.  If `L > N`, repeated visits
-are collapsed by the `Finset.image`; the parent-Hamiltonian applications use
-`L ≤ N`. -/
+finite set of sites reached from `i` by offsets below `L`, modulo the chain
+length.  If `L` is larger than the chain length, repeated visits to a site are
+counted only once; the parent-Hamiltonian applications use `L ≤ N`. -/
 def cyclicWindowSupport (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
   (Finset.range L).image fun r => cyclicForwardSite i r
 
 /-- Cyclic-window overlap predicate for length-`L` windows on `Fin N`.
 
 Two windows overlap when their cyclic supports share at least one site.  This is
-the locality relation used for pairs of translated local terms
-`localTermES A L i` and `localTermES A L j`.  In row-cardinality estimates, the
-diagonal term j = i is excluded. -/
+the locality relation for translated local terms at the two starting sites.  In
+row-cardinality estimates, the diagonal term j = i is excluded. -/
 def cyclicWindowsOverlap (N L : ℕ) (i j : Fin N) : Prop :=
   ∃ k : Fin N, k ∈ cyclicWindowSupport N L i ∧ k ∈ cyclicWindowSupport N L j
 
 /-- The cyclic-window overlap relation is decidable on a finite chain. -/
-noncomputable instance cyclicWindowsOverlap_decidableRel (N L : ℕ) :
+instance cyclicWindowsOverlap_decidableRel (N L : ℕ) :
     DecidableRel (cyclicWindowsOverlap N L) := by
-  classical
   intro i j
-  exact inferInstance
-
-/-- A nonempty cyclic window overlaps itself. -/
-theorem cyclicWindowsOverlap_self_of_pos (N : ℕ) {L : ℕ} (hL : 0 < L) (i : Fin N) :
-    cyclicWindowsOverlap N L i i := by
-  refine ⟨i, ?_, ?_⟩ <;>
-    refine Finset.mem_image.mpr ⟨0, Finset.mem_range.mpr hL, ?_⟩ <;>
-    ext <;> simp [cyclicForwardSite, Nat.mod_eq_of_lt i.isLt]
+  unfold cyclicWindowsOverlap
+  exact Fintype.decidableExistsFintype
 
 /-- Clockwise neighbours of the cyclic window starting at `i` that can overlap it
 properly. -/
@@ -316,7 +308,8 @@ theorem cyclicWindowsOverlap_card_le {N L : ℕ} (hLN : 2 * L ≤ N) (hL : 1 < L
       rw [Nat.mod_eq_of_lt haN] at hmod
       exact hmod.symm
     by_cases hxb_lt : x + b < N
-    · have hsum : x + b = a := by
+    · -- No wraparound: the clockwise offset `x` is a positive distance below `L`.
+      have hsum : x + b = a := by
         rw [Nat.mod_eq_of_lt hxb_lt] at hxb_mod
         exact hxb_mod
       have hxpos : 0 < x := by
@@ -335,7 +328,8 @@ theorem cyclicWindowsOverlap_card_le {N L : ℕ} (hLN : 2 * L ≤ N) (hL : 1 < L
         simp
         omega
       simpa [hstep] using hjx.symm
-    · have hxb_ge : N ≤ x + b := Nat.le_of_not_gt hxb_lt
+    · -- Wraparound: the equivalent counterclockwise distance is `b - a`, below `L`.
+      have hxb_ge : N ≤ x + b := Nat.le_of_not_gt hxb_lt
       have hxb_lt_two : x + b < 2 * N := by omega
       have hmod_sub : (x + b) % N = x + b - N := by
         rw [Nat.mod_eq_sub_mod hxb_ge]
@@ -377,13 +371,6 @@ theorem cyclicWindowsOverlap_card_le {N L : ℕ} (hLN : 2 * L ≤ N) (hL : 1 < L
     _ ≤ cw.card + ccw.card := Finset.card_union_le cw ccw
     _ ≤ (L - 1) + (L - 1) := Nat.add_le_add hcw_card hccw_card
     _ = 2 * (L - 1) := by omega
-
-/-- Alias for the row-cardinality estimate in the finite-overlap regime. -/
-theorem cyclicWindowsOverlap_card_le_of_two_mul_le {N L : ℕ}
-    (hLN : 2 * L ≤ N) (hL : 1 < L) (i : Fin N) :
-    ((Finset.univ.erase i).filter (fun j => cyclicWindowsOverlap N L i j)).card ≤
-      2 * (L - 1) :=
-  cyclicWindowsOverlap_card_le hLN hL i
 
 /-- Linear restriction to a cyclic window at position `i`. -/
 def cyclicRestrictₗ {N : ℕ} (hN : 0 < N) (L : ℕ)

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -13,7 +13,11 @@ cyclic windows of L consecutive sites on a periodic chain.
 ## Main results
 
 * `MPSTensor.contiguous_mem_groundSpace` — iterated intersection:
-  non-wrapping window conditions imply membership in the open-chain ground space
+  non-wrapping window conditions imply membership in the open-chain ground space.
+* `MPSTensor.cyclicWindowSupport` and `MPSTensor.cyclicWindowsOverlap` — the
+  support and overlap predicate for translated cyclic windows.
+* `MPSTensor.cyclicWindowsOverlap_card_le` — each cyclic window overlaps at most
+  `2 * (L - 1)` other cyclic windows when `2 * L ≤ N`.
 -/
 
 open scoped Matrix BigOperators
@@ -163,9 +167,11 @@ theorem contiguous_mem_groundSpace {A : MPSTensor d D} (hA : IsInjective A)
 def cyclicForwardSite {N : ℕ} (i : Fin N) (r : ℕ) : Fin N :=
   ⟨(i.val + r) % N, Nat.mod_lt _ (Fin.pos i)⟩
 
-/-- The site obtained by moving `r` steps counterclockwise from `i` on the cyclic chain. -/
+/-- The site represented by `(i + N - r) % N`.
+For offsets `r ≤ N`, this is the site obtained by moving `r` steps
+counterclockwise from `i` on the cyclic chain. -/
 def cyclicBackwardSite {N : ℕ} (i : Fin N) (r : ℕ) : Fin N :=
-  ⟨(i.val + N - r) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  ⟨(i.val + N - r % N) % N, Nat.mod_lt _ (Fin.pos i)⟩
 
 /-- The support of the length-`L` cyclic window starting at `i`, represented as the
 finite set of sites `i, i+1, ..., i+L-1` modulo `N`.  If `L > N`, repeated visits
@@ -183,11 +189,11 @@ self-overlap case is removed by `Finset.erase`. -/
 def cyclicWindowsOverlap (N L : ℕ) (i j : Fin N) : Prop :=
   ∃ k : Fin N, k ∈ cyclicWindowSupport N L i ∧ k ∈ cyclicWindowSupport N L j
 
-noncomputable instance cyclicWindowsOverlap_decidableRel (N L : ℕ) :
+/-- The cyclic-window overlap relation is decidable on a finite chain. -/
+instance cyclicWindowsOverlap_decidableRel (N L : ℕ) :
     DecidableRel (cyclicWindowsOverlap N L) := by
-  classical
   intro i j
-  exact inferInstance
+  infer_instance
 
 /-- A nonempty cyclic window overlaps itself. -/
 theorem cyclicWindowsOverlap_self_of_pos (N : ℕ) {L : ℕ} (hL : 0 < L) (i : Fin N) :
@@ -198,12 +204,12 @@ theorem cyclicWindowsOverlap_self_of_pos (N : ℕ) {L : ℕ} (hL : 0 < L) (i : F
 
 /-- Clockwise neighbours of the cyclic window starting at `i` that can overlap it
 properly. -/
-def cyclicWindowClockwiseNeighbours (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
+private def cyclicWindowClockwiseNeighbours (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
   (Finset.univ : Finset (Fin (L - 1))).image fun r => cyclicForwardSite i (r.val + 1)
 
 /-- Counterclockwise neighbours of the cyclic window starting at `i` that can
 overlap it properly. -/
-def cyclicWindowCounterclockwiseNeighbours (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
+private def cyclicWindowCounterclockwiseNeighbours (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
   (Finset.univ : Finset (Fin (L - 1))).image fun r => cyclicBackwardSite i (r.val + 1)
 
 /-- Assemble an N-site configuration from a cyclic window at position `i`
@@ -341,12 +347,13 @@ theorem cyclicWindowsOverlap_card_le {N L : ℕ} (hLN : 2 * L ≤ N) (hL : 1 < L
       have hab : a < b := by omega
       have hdist_pos : 0 < b - a := by omega
       have hdist_lt : b - a < L := by omega
+      have hdistN : b - a < N := lt_of_lt_of_le hdist_lt hLNle
       have hx_eq : x = N + a - b := by omega
       have hjback : j = cyclicBackwardSite i (b - a) := by
         rw [hjx]
         ext
         simp only [cyclicForwardSite, cyclicBackwardSite, Fin.val_mk]
-        rw [hx_eq]
+        rw [Nat.mod_eq_of_lt hdistN, hx_eq]
         congr 1
         omega
       have hrlt : b - a - 1 < L - 1 := by omega

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -167,9 +167,7 @@ theorem contiguous_mem_groundSpace {A : MPSTensor d D} (hA : IsInjective A)
 def cyclicForwardSite {N : ℕ} (i : Fin N) (r : ℕ) : Fin N :=
   ⟨(i.val + r) % N, Nat.mod_lt _ (Fin.pos i)⟩
 
-/-- The site represented by `(i + N - r) % N`.
-For offsets `r ≤ N`, this is the site obtained by moving `r` steps
-counterclockwise from `i` on the cyclic chain. -/
+/-- The site obtained by moving `r` steps counterclockwise from `i` on the cyclic chain. -/
 def cyclicBackwardSite {N : ℕ} (i : Fin N) (r : ℕ) : Fin N :=
   ⟨(i.val + N - r % N) % N, Nat.mod_lt _ (Fin.pos i)⟩
 
@@ -190,10 +188,11 @@ def cyclicWindowsOverlap (N L : ℕ) (i j : Fin N) : Prop :=
   ∃ k : Fin N, k ∈ cyclicWindowSupport N L i ∧ k ∈ cyclicWindowSupport N L j
 
 /-- The cyclic-window overlap relation is decidable on a finite chain. -/
-instance cyclicWindowsOverlap_decidableRel (N L : ℕ) :
+noncomputable instance cyclicWindowsOverlap_decidableRel (N L : ℕ) :
     DecidableRel (cyclicWindowsOverlap N L) := by
+  classical
   intro i j
-  infer_instance
+  exact inferInstance
 
 /-- A nonempty cyclic window overlaps itself. -/
 theorem cyclicWindowsOverlap_self_of_pos (N : ℕ) {L : ℕ} (hL : 0 < L) (i : Fin N) :

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -182,8 +182,8 @@ def cyclicWindowSupport (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
 
 Two windows overlap when their cyclic supports share at least one site.  This is
 the locality relation used for pairs of translated local terms
-`localTermES A L i` and `localTermES A L j`.  In row-cardinality estimates the
-self-overlap case is removed by `Finset.erase`. -/
+`localTermES A L i` and `localTermES A L j`.  In row-cardinality estimates, the
+diagonal term j = i is excluded. -/
 def cyclicWindowsOverlap (N L : ℕ) (i j : Fin N) : Prop :=
   ∃ k : Fin N, k ∈ cyclicWindowSupport N L i ∧ k ∈ cyclicWindowSupport N L j
 

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -159,6 +159,53 @@ theorem contiguous_mem_groundSpace {A : MPSTensor d D} (hA : IsInjective A)
 
 /-! ### Cyclic window extraction -/
 
+/-- The site obtained by moving `r` steps clockwise from `i` on the cyclic chain. -/
+def cyclicForwardSite {N : ℕ} (i : Fin N) (r : ℕ) : Fin N :=
+  ⟨(i.val + r) % N, Nat.mod_lt _ (Fin.pos i)⟩
+
+/-- The site obtained by moving `r` steps counterclockwise from `i` on the cyclic chain. -/
+def cyclicBackwardSite {N : ℕ} (i : Fin N) (r : ℕ) : Fin N :=
+  ⟨(i.val + N - r) % N, Nat.mod_lt _ (Fin.pos i)⟩
+
+/-- The support of the length-`L` cyclic window starting at `i`, represented as the
+finite set of sites `i, i+1, ..., i+L-1` modulo `N`.  If `L > N`, repeated visits
+are collapsed by the `Finset.image`; the parent-Hamiltonian applications use
+`L ≤ N`. -/
+def cyclicWindowSupport (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
+  (Finset.range L).image fun r => cyclicForwardSite i r
+
+/-- Cyclic-window overlap predicate for length-`L` windows on `Fin N`.
+
+Two windows overlap when their cyclic supports share at least one site.  This is
+the locality relation used for pairs of translated local terms
+`localTermES A L i` and `localTermES A L j`.  In row-cardinality estimates the
+self-overlap case is removed by `Finset.erase`. -/
+def cyclicWindowsOverlap (N L : ℕ) (i j : Fin N) : Prop :=
+  ∃ k : Fin N, k ∈ cyclicWindowSupport N L i ∧ k ∈ cyclicWindowSupport N L j
+
+noncomputable instance cyclicWindowsOverlap_decidableRel (N L : ℕ) :
+    DecidableRel (cyclicWindowsOverlap N L) := by
+  classical
+  intro i j
+  exact inferInstance
+
+/-- A nonempty cyclic window overlaps itself. -/
+theorem cyclicWindowsOverlap_self_of_pos (N : ℕ) {L : ℕ} (hL : 0 < L) (i : Fin N) :
+    cyclicWindowsOverlap N L i i := by
+  refine ⟨i, ?_, ?_⟩ <;>
+    refine Finset.mem_image.mpr ⟨0, Finset.mem_range.mpr hL, ?_⟩ <;>
+    ext <;> simp [cyclicForwardSite, Nat.mod_eq_of_lt i.isLt]
+
+/-- Clockwise neighbours of the cyclic window starting at `i` that can overlap it
+properly. -/
+def cyclicWindowClockwiseNeighbours (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
+  (Finset.univ : Finset (Fin (L - 1))).image fun r => cyclicForwardSite i (r.val + 1)
+
+/-- Counterclockwise neighbours of the cyclic window starting at `i` that can
+overlap it properly. -/
+def cyclicWindowCounterclockwiseNeighbours (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
+  (Finset.univ : Finset (Fin (L - 1))).image fun r => cyclicBackwardSite i (r.val + 1)
+
 /-- Assemble an N-site configuration from a cyclic window at position `i`
 (covering sites `i, i+1, ..., i+L-1 mod N`) and outside values `τ`.
 Site `k` gets the window value `σ(offset)` where `offset = (k - i + N) % N`
@@ -194,6 +241,143 @@ theorem eq_cyclic_site_of_offset_eq {N : ℕ} (hN : 0 < N) {i k : Fin N} {r : �
       rw [hsum, Nat.add_mod_right]
       exact Nat.mod_eq_of_lt k.isLt
     exact hmod.symm
+
+@[simp]
+theorem cyclicForwardSite_zero {N : ℕ} (i : Fin N) :
+    cyclicForwardSite i 0 = i := by
+  ext
+  simp [cyclicForwardSite, Nat.mod_eq_of_lt i.isLt]
+
+@[simp]
+theorem cyclicForwardSite_forwardSite {N : ℕ} (i : Fin N) (a b : ℕ) :
+    cyclicForwardSite (cyclicForwardSite i a) b = cyclicForwardSite i (a + b) := by
+  ext
+  simp only [cyclicForwardSite, Fin.val_mk]
+  rw [Nat.mod_add_mod]
+  congr 1
+  omega
+
+private theorem cyclicForwardSite_eq_mod_eq {N : ℕ} (i : Fin N) {a b : ℕ}
+    (h : cyclicForwardSite i a = cyclicForwardSite i b) : a % N = b % N := by
+  have hval := congrArg Fin.val h
+  change (i.val + a) % N = (i.val + b) % N at hval
+  have hmodEq : (i.val + a) ≡ (i.val + b) [MOD N] := by
+    simpa [Nat.ModEq] using hval
+  have hcancel : a ≡ b [MOD N] :=
+    Nat.ModEq.add_left_cancel (Nat.ModEq.refl i.val) hmodEq
+  simpa [Nat.ModEq] using hcancel
+
+/-- Row-cardinality estimate for cyclic support overlap in the finite-overlap
+regime used by the martingale proof.
+
+If `2 * L ≤ N`, then every length-`L` cyclic window can meet only the `L - 1`
+clockwise starts and the `L - 1` counterclockwise starts.  Thus, after erasing
+the window itself, at most `2 * (L - 1)` translated local terms overlap it. -/
+theorem cyclicWindowsOverlap_card_le {N L : ℕ} (hLN : 2 * L ≤ N) (hL : 1 < L)
+    (i : Fin N) :
+    ((Finset.univ.erase i).filter (fun j => cyclicWindowsOverlap N L i j)).card ≤
+      2 * (L - 1) := by
+  classical
+  let cw := cyclicWindowClockwiseNeighbours N L i
+  let ccw := cyclicWindowCounterclockwiseNeighbours N L i
+  have hLNle : L ≤ N := by omega
+  have hsubset :
+      (Finset.univ.erase i).filter (fun j => cyclicWindowsOverlap N L i j) ⊆
+        cw ∪ ccw := by
+    intro j hj
+    rw [Finset.mem_filter] at hj
+    rcases hj with ⟨hjerase, hoverlap⟩
+    have hji : j ≠ i := Finset.ne_of_mem_erase hjerase
+    rcases hoverlap with ⟨k, hki, hkj⟩
+    rw [cyclicWindowSupport, Finset.mem_image] at hki hkj
+    rcases hki with ⟨a, haRange, hka⟩
+    rcases hkj with ⟨b, hbRange, hkb⟩
+    have haL : a < L := Finset.mem_range.mp haRange
+    have hbL : b < L := Finset.mem_range.mp hbRange
+    have haN : a < N := lt_of_lt_of_le haL hLNle
+    have hbN : b < N := lt_of_lt_of_le hbL hLNle
+    have hEq : cyclicForwardSite i a = cyclicForwardSite j b := hka.trans hkb.symm
+    let x := (j.val + N - i.val) % N
+    have hxN : x < N := by
+      dsimp [x]
+      exact Nat.mod_lt _ (Fin.pos i)
+    have hjx : j = cyclicForwardSite i x := by
+      simpa [x, cyclicForwardSite] using
+        (eq_cyclic_site_of_offset_eq (Fin.pos i) (i := i) (k := j) (r := x) rfl)
+    have hEq' : cyclicForwardSite i a = cyclicForwardSite i (x + b) := by
+      simpa [hjx, cyclicForwardSite_forwardSite] using hEq
+    have hmod := cyclicForwardSite_eq_mod_eq i hEq'
+    have hxb_mod : (x + b) % N = a := by
+      rw [Nat.mod_eq_of_lt haN] at hmod
+      exact hmod.symm
+    by_cases hxb_lt : x + b < N
+    · have hsum : x + b = a := by
+        rw [Nat.mod_eq_of_lt hxb_lt] at hxb_mod
+        exact hxb_mod
+      have hxpos : 0 < x := by
+        by_contra hxzero
+        push Not at hxzero
+        have hx0 : x = 0 := by omega
+        apply hji
+        rw [hjx, hx0]
+        simp
+      have hxL : x < L := by omega
+      have hrlt : x - 1 < L - 1 := by omega
+      apply Finset.mem_union_left
+      dsimp [cw, cyclicWindowClockwiseNeighbours]
+      refine Finset.mem_image.mpr ⟨⟨x - 1, hrlt⟩, Finset.mem_univ _, ?_⟩
+      have hstep : (⟨x - 1, hrlt⟩ : Fin (L - 1)).val + 1 = x := by
+        simp
+        omega
+      simpa [hstep] using hjx.symm
+    · have hxb_ge : N ≤ x + b := Nat.le_of_not_gt hxb_lt
+      have hxb_lt_two : x + b < 2 * N := by omega
+      have hmod_sub : (x + b) % N = x + b - N := by
+        rw [Nat.mod_eq_sub_mod hxb_ge]
+        exact Nat.mod_eq_of_lt (by omega)
+      have hsum : x + b - N = a := by
+        rw [hmod_sub] at hxb_mod
+        exact hxb_mod
+      have hab : a < b := by omega
+      have hdist_pos : 0 < b - a := by omega
+      have hdist_lt : b - a < L := by omega
+      have hx_eq : x = N + a - b := by omega
+      have hjback : j = cyclicBackwardSite i (b - a) := by
+        rw [hjx]
+        ext
+        simp only [cyclicForwardSite, cyclicBackwardSite, Fin.val_mk]
+        rw [hx_eq]
+        congr 1
+        omega
+      have hrlt : b - a - 1 < L - 1 := by omega
+      apply Finset.mem_union_right
+      dsimp [ccw, cyclicWindowCounterclockwiseNeighbours]
+      refine Finset.mem_image.mpr ⟨⟨b - a - 1, hrlt⟩, Finset.mem_univ _, ?_⟩
+      have hstep : (⟨b - a - 1, hrlt⟩ : Fin (L - 1)).val + 1 = b - a := by
+        simp
+        omega
+      simpa [hstep] using hjback.symm
+  have hcw_card : cw.card ≤ L - 1 := by
+    dsimp [cw, cyclicWindowClockwiseNeighbours]
+    simpa using (Finset.card_image_le (s := (Finset.univ : Finset (Fin (L - 1))))
+      (f := fun r : Fin (L - 1) => cyclicForwardSite i (r.val + 1)))
+  have hccw_card : ccw.card ≤ L - 1 := by
+    dsimp [ccw, cyclicWindowCounterclockwiseNeighbours]
+    simpa using (Finset.card_image_le (s := (Finset.univ : Finset (Fin (L - 1))))
+      (f := fun r : Fin (L - 1) => cyclicBackwardSite i (r.val + 1)))
+  calc
+    ((Finset.univ.erase i).filter (fun j => cyclicWindowsOverlap N L i j)).card ≤
+        (cw ∪ ccw).card := Finset.card_le_card hsubset
+    _ ≤ cw.card + ccw.card := Finset.card_union_le cw ccw
+    _ ≤ (L - 1) + (L - 1) := Nat.add_le_add hcw_card hccw_card
+    _ = 2 * (L - 1) := by omega
+
+/-- Alias for the row-cardinality estimate in the finite-overlap regime. -/
+theorem cyclicWindowsOverlap_card_le_of_two_mul_le {N L : ℕ}
+    (hLN : 2 * L ≤ N) (hL : 1 < L) (i : Fin N) :
+    ((Finset.univ.erase i).filter (fun j => cyclicWindowsOverlap N L i j)).card ≤
+      2 * (L - 1) :=
+  cyclicWindowsOverlap_card_le hLN hL i
 
 /-- Linear restriction to a cyclic window at position `i`. -/
 def cyclicRestrictₗ {N : ℕ} (hN : 0 < N) (L : ℕ)

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -856,8 +856,8 @@ predicate.
 For chains with `N ≥ 2L`, the predicate `cyclicWindowsOverlap N L i j` marks the
 cyclic translates whose length-`L` windows have the finite-range overlap relevant
 to the martingale method.  The row-cardinality estimate is supplied by
-`cyclicWindowsOverlap_card_le_of_two_mul_le`, and local projection structure is
-supplied by `localTermES_isSymmetricProjection`.  Consequently the only remaining
+`cyclicWindowsOverlap_card_le`, and local projection structure is supplied by
+`localTermES_isSymmetricProjection`.  Consequently the only remaining
 local hypotheses are non-overlap positivity and the Friedrichs-angle estimate for
 pairs marked by `cyclicWindowsOverlap`. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
@@ -882,7 +882,7 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
   exact parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs A L hL
     (fun N => cyclicWindowsOverlap N L)
     (fun N _hLN i => localTermES_isSymmetricProjection A L i)
-    (fun N hLN i => cyclicWindowsOverlap_card_le_of_two_mul_le hLN hL i)
+    (fun N hLN i => cyclicWindowsOverlap_card_le hLN hL i)
     hDisjoint hFriedrichs
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -77,6 +77,9 @@ concrete Friedrichs-angle/row-sum lower bound that
 * `MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs` — a
   finite-overlap reduction turning explicit local projection, overlap,
   non-overlap positivity, and Friedrichs estimates into the gap estimate.
+* `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs` — the
+  same reduction specialized to the concrete cyclic-window overlap predicate and
+  its `2 * (L - 1)` row-cardinality bound.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
   Friedrichs-angle bound recorded in
@@ -846,6 +849,41 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
   exact parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
     A L N hγle (overlaps N) hm (hProj N hLN) (hCard N hLN)
     (hDisjoint N hLN) (hFriedrichs N hLN) v
+
+/-- Uniform explicit gap-bound reduction using the concrete cyclic-window overlap
+predicate.
+
+For chains with `N ≥ 2L`, the predicate `cyclicWindowsOverlap N L i j` marks the
+cyclic translates whose length-`L` windows have the finite-range overlap relevant
+to the martingale method.  The row-cardinality estimate is supplied by
+`cyclicWindowsOverlap_card_le_of_two_mul_le`, and local projection structure is
+supplied by `localTermES_isSymmetricProjection`.  Consequently the only remaining
+local hypotheses are non-overlap positivity and the Friedrichs-angle estimate for
+pairs marked by `cyclicWindowsOverlap`. -/
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (hDisjoint : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → ¬ cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re)
+    (hFriedrichs : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹) *
+                (⟪localTermES A L i v, v⟫_ℂ).re ≤
+            (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  exact parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs A L hL
+    (fun N => cyclicWindowsOverlap N L)
+    (fun N _hLN i => localTermES_isSymmetricProjection A L i)
+    (fun N hLN i => cyclicWindowsOverlap_card_le_of_two_mul_le hLN hL i)
+    hDisjoint hFriedrichs
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1842,18 +1842,32 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $P_i=h_{i,\mathrm{ES}}$.
 \end{proof}
 
-\begin{lemma}[Cyclic-window overlap row cardinality]
-    \label{lem:cyclic_window_overlap_cardinality}
+\begin{definition}[Cyclic-window support]
+    \label{def:cyclic_window_support}
     \lean{MPSTensor.cyclicWindowSupport}
-    \lean{MPSTensor.cyclicWindowsOverlap}
-    \lean{MPSTensor.cyclicWindowsOverlap_card_le}
     \leanok
     \uses{rem:cyclic_window_operators}
-    For a length-$L$ cyclic window on $\Fin{N}$, let
+    For a length-$L$ cyclic window on $\Fin{N}$ starting at $i$, its support is
     \[
-        S_i=\{i,i+1,\ldots,i+L-1\}\pmod N
+        S_i=\{i,i+1,\ldots,i+L-1\}\pmod N,
     \]
-    be its cyclic support, and write $i\sim_L j$ when $S_i\cap S_j\ne\varnothing$.
+    with repeated visits counted once.
+\end{definition}
+
+\begin{definition}[Cyclic-window overlap]
+    \label{def:cyclic_windows_overlap}
+    \lean{MPSTensor.cyclicWindowsOverlap}
+    \leanok
+    \uses{def:cyclic_window_support}
+    Two length-$L$ cyclic windows overlap, written $i\sim_L j$, when their
+    supports meet: $S_i\cap S_j\ne\varnothing$.
+\end{definition}
+
+\begin{lemma}[Cyclic-window overlap row cardinality]
+    \label{lem:cyclic_window_overlap_cardinality}
+    \lean{MPSTensor.cyclicWindowsOverlap_card_le}
+    \leanok
+    \uses{def:cyclic_window_support, def:cyclic_windows_overlap}
     If $2L\le N$ and $L>1$, then for every $i\in\Fin{N}$,
     \[
         \#\{j\ne i: i\sim_L j\}\le 2(L-1).
@@ -1862,6 +1876,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
+    \uses{def:cyclic_window_support, def:cyclic_windows_overlap}
     If $S_i$ and $S_j$ meet, choose offsets $a,b<L$ with
     $i+a\equiv j+b\pmod N$.  Since $2L\le N$, the offset from $i$ to $j$ is
     either the clockwise distance $a-b\in\{1,\ldots,L-1\}$ or the

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1842,6 +1842,34 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $P_i=h_{i,\mathrm{ES}}$.
 \end{proof}
 
+\begin{lemma}[Cyclic-window overlap row cardinality]
+    \label{lem:cyclic_window_overlap_cardinality}
+    \lean{MPSTensor.cyclicWindowSupport}
+    \lean{MPSTensor.cyclicWindowsOverlap}
+    \lean{MPSTensor.cyclicWindowsOverlap_card_le}
+    \leanok
+    \uses{rem:cyclic_window_operators}
+    For a length-$L$ cyclic window on $\Fin{N}$, let
+    \[
+        S_i=\{i,i+1,\ldots,i+L-1\}\pmod N
+    \]
+    be its cyclic support, and write $i\sim_L j$ when $S_i\cap S_j\ne\varnothing$.
+    If $2L\le N$ and $L>1$, then for every $i\in\Fin{N}$,
+    \[
+        \#\{j\ne i: i\sim_L j\}\le 2(L-1).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    If $S_i$ and $S_j$ meet, choose offsets $a,b<L$ with
+    $i+a\equiv j+b\pmod N$.  Since $2L\le N$, the offset from $i$ to $j$ is
+    either the clockwise distance $a-b\in\{1,\ldots,L-1\}$ or the
+    counterclockwise distance $b-a\in\{1,\ldots,L-1\}$; the zero distance is
+    excluded by $j\ne i$. Thus every overlapping off-diagonal start lies among
+    the $L-1$ clockwise starts or the $L-1$ counterclockwise starts.
+\end{proof}
+
 \begin{lemma}[Parent-Hamiltonian gap from finite-overlap Friedrichs data]
     \label{lem:parent_hamiltonian_finite_overlap_friedrichs_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs}
@@ -1860,6 +1888,37 @@ Lucia~\cite{Kastoryano2018Martingale}.
     The fixed-chain finite-overlap reduction gives the required quadratic-form
     estimate for every admissible $N$. Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction}
     converts that estimate to the norm lower bound.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian gap from cyclic-window Friedrichs data]
+    \label{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs}
+    \leanok
+    \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
+        lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections}
+    Fix $L>1$ and let $i\sim_L j$ mean that the cyclic supports of the
+    length-$L$ windows at $i$ and $j$ meet. Suppose uniformly for every
+    $N\ge2L$ that non-overlapping transported local terms have nonnegative
+    ordered cross terms, while overlapping off-diagonal terms satisfy
+    \[
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
+        \ge -(1-\tfrac{1}{4L})\frac{1}{2(L-1)}
+              \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
+    \]
+    Then $1/(4L)>0$, and the explicit norm lower bound with constant $1/(4L)$
+    follows for vectors in $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
+        lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections}
+    Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the row-cardinality
+    bound $m=2(L-1)$ for the concrete cyclic-window overlap relation, and
+    Lemma~\ref{lem:transported_es_local_projections} supplies the symmetric
+    projection structure of each transported local term. Apply
+    Lemma~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} with these
+    facts and the stated cross-term hypotheses.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}


### PR DESCRIPTION
## Summary

Refs #460. Refs #190.

- define cyclic-window supports and the concrete support-intersection predicate 
- prove the finite-overlap row-cardinality bound  under  and 
- add a cyclic-window specialization of the finite-overlap Friedrichs gap reduction, discharging local projection structure and row-cardinality while leaving non-overlap positivity/Friedrichs estimates explicit
- sync Chapter 14 blueprint statements for the cyclic overlap cardinality and cyclic-window Friedrichs gap reduction

## Validation

- ⚠ [2956/2956] Replayed TNLean.MPS.ParentHamiltonian.Martingale
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:934:8: declaration uses `sorry`
Build completed successfully (2956 jobs). (passes; only the pre-existing  Friedrichs  warning)
- ⚠ [8371/8452] Replayed TNLean.Channel.FixedPoint.WedderburnDecomp
warning: TNLean/Channel/FixedPoint/WedderburnDecomp.lean:86:7: declaration uses `sorry`
⚠ [8455/8614] Replayed TNLean.MPS.ParentHamiltonian.UniqueGroundState
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:515:8: declaration uses `sorry`
⚠ [8508/8614] Replayed TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition
warning: TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean:42:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean:683:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean:912:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean:913:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
⚠ [8512/8614] Replayed TNLean.MPS.ParentHamiltonian.DegenerateGS
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:480:8: declaration uses `sorry`
⚠ [8520/8614] Replayed TNLean.MPS.ParentHamiltonian.Martingale
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:934:8: declaration uses `sorry`
⚠ [8540/8614] Replayed TNLean.MPS.Periodic.Overlap.SelfOverlap
warning: TNLean/MPS/Periodic/Overlap/SelfOverlap.lean:577:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/SelfOverlap.lean:823:8: declaration uses `sorry`
⚠ [8542/8614] Replayed TNLean.MPS.Periodic.Overlap.Case2
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:131:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:250:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:293:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:357:8: declaration uses `sorry`
⚠ [8543/8614] Replayed TNLean.MPS.Periodic.Overlap.Case3
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:87:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:222:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:284:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:348:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:404:8: declaration uses `sorry`
⚠ [8544/8614] Replayed TNLean.MPS.Periodic.Overlap.Dichotomy
warning: TNLean/MPS/Periodic/Overlap/Dichotomy.lean:43:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Dichotomy.lean:69:8: declaration uses `sorry`
⚠ [8629/8630] Replayed TNLean.PEPS.FundamentalTheorem
warning: TNLean/PEPS/FundamentalTheorem.lean:530:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:584:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:694:8: declaration uses `sorry`
Build completed successfully (8630 jobs). (passes after incremental reruns; pre-existing warnings/sorries only)
- plasTeX version 3.1
- 
- 
- added-line forbidden-token scan for //// (none; full touched Lean-file scan reports only the pre-existing  Friedrichs )

Ready for orchestrator simplification/cleanup before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core martingale-method infrastructure by adding new cyclic-window overlap definitions and a nontrivial counting proof that is used to specialize the spectral-gap reduction; mistakes would invalidate downstream gap arguments. Changes are proof-level (Lean) with no runtime impact but moderate logical risk due to combinatorial/mod-arithmetic reasoning.
> 
> **Overview**
> Defines `cyclicWindowSupport` and `cyclicWindowsOverlap` for length-`L` cyclic windows on `Fin N`, plus helper lemmas for cyclic site arithmetic and a decidable overlap relation.
> 
> Proves `cyclicWindowsOverlap_card_le`: under `2 * L ≤ N` and `1 < L`, each window overlaps at most `2 * (L - 1)` other translated windows (off-diagonal), providing the finite-overlap row-cardinality bound needed for martingale estimates.
> 
> Adds `parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs`, a wrapper around the existing finite-overlap Friedrichs reduction that fixes the overlap predicate to `cyclicWindowsOverlap` and discharges the projection/row-cardinality inputs automatically. Updates Chapter 14 blueprint statements to match these new definitions and lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88bfa4f92f1fc02304536c6f433406da2d91bc76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->