### PR TITLE
feat(MPS/CanonicalForm): derive collapsed BNT overlap data (#652)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -66,16 +66,21 @@ The theorem `exists_tp_sector_decomp_after_blocking` below provides:
   `zeroMPSTensor + toTensorFromBlocks μ sectors` for some weights `μ`
 
 The current library already settles the common-period blocking arithmetic and
-now has both a one-sided collapsed BNT construction for TP primitive irreducible
-live blocks and a witness-producing sector comparison from primitive
-overlap-span hypotheses. The strongest theorem in this file,
-`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan`,
+now has both a one-sided phase-class BNT construction for TP primitive
+irreducible live blocks and a witness-producing sector comparison from primitive
+overlap-span hypotheses. The exact-live theorem
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`
 combines `SameMPV₂ A B` with those ingredients once exact common live block
-decompositions and the overlap-span hypotheses are supplied.
+decompositions, live-block injectivity, and the finite-length span comparison
+are supplied. The zero-tail-aware theorem
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail`
+separately records the `N = 0` bookkeeping when full overlap-span hypotheses are
+available.
 
-The remaining Gap §1 content is to derive those exact live decompositions and the
-primitive overlap-span hypotheses from the structural after-blocking reduction
-itself, including the zero-tail bookkeeping at length `N = 0`.
+The remaining Gap §1 content is to derive the exact live decompositions,
+one-site injectivity (or a blocked replacement), the finite-length span
+comparison, and the zero-tail bookkeeping from the structural after-blocking
+reduction itself.
 -/
 
 section FundamentalTheorem1606
@@ -605,6 +610,106 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSp
   exact ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt,
           M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
 
+/-- **Common live-block construction with derived one-sided overlap data.**
+
+This exact-live variant of
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan`
+uses the phase-class BNT construction to derive the positive-dimension,
+normalization, self-overlap, and off-overlap inputs, and to transfer the supplied
+one-site injectivity of live blocks to the chosen basis blocks. The remaining
+two-basis analytic input is the finite-length span comparison between the two
+constructed bases. -/
+theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan
+    {d D₁ D₂ p rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k : Fin rA, NeZero (dimA k)]
+    [∀ k : Fin rB, NeZero (dimB k)]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hp : 0 < p)
+    (μA : Fin rA → ℂ)
+    (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d p) (dimA k))
+    (μB : Fin rB → ℂ)
+    (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d p) (dimB k))
+    (hAblocks : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA))
+    (hBblocks : SameMPV₂ (blockTensor (d := d) (D := D₂) B p)
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB))
+    (hTPA : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksA k i)ᴴ * blocksA k i = 1)
+    (hTPB : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksB k i)ᴴ * blocksB k i = 1)
+    (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))
+    (hIrrB : ∀ k, IsIrreducibleTensor (blocksB k))
+    (hPrimA : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimA k) (blocksA k)))
+    (hPrimB : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimB k) (blocksB k)))
+    (hInjA : ∀ k, IsInjective (blocksA k))
+    (hInjB : ∀ k, IsInjective (blocksB k))
+    (hμA : ∀ k, μA k ≠ 0)
+    (hμB : ∀ k, μB k ≠ 0)
+    (spanData :
+      ∀ P Q : SectorDecomposition (blockPhysDim d p),
+        SameMPV₂ P.toTensor (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+        SameMPV₂ Q.toTensor (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+        HasBNTSectorData P → HasBNTSectorData Q →
+        SectorBasisOverlapOrthoHypotheses P → SectorBasisOverlapOrthoHypotheses Q →
+        ∀ N,
+          Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
+            mpvState (d := blockPhysDim d p) (P.basis j) N)) =
+          Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
+            mpvState (d := blockPhysDim d p) (Q.basis k) N))) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂ (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂ (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  obtain ⟨P, hPblocks, hPbnt, hPOrtho, hPInj_of⟩ :=
+    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
+      (d := blockPhysDim d p) μA blocksA hTPA hIrrA hPrimA hμA
+  obtain ⟨Q, hQblocks, hQbnt, hQOrtho, hQInj_of⟩ :=
+    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
+      (d := blockPhysDim d p) μB blocksB hTPB hIrrB hPrimB hμB
+  have hPeq : SameMPV₂ (blockTensor (d := d) (D := D₁) A p) P.toTensor := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ
+          = mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ :=
+            hAblocks N σ
+      _ = mpv P.toTensor σ := (hPblocks N σ).symm
+  have hQeq : SameMPV₂ (blockTensor (d := d) (D := D₂) B p) Q.toTensor := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ
+          = mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ :=
+            hBblocks N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ
+          = mpv (blockTensor (d := d) (D := D₁) A p) σ := (hPeq N σ).symm
+      _ = mpv (blockTensor (d := d) (D := D₂) B p) σ := hAB N σ
+      _ = mpv Q.toTensor σ := hQeq N σ
+  have hSpan := spanData P Q hPblocks hQblocks hPbnt hQbnt hPOrtho hQOrtho
+  have hOverlapSpan : SectorBasisOverlapSpanHypotheses P Q :=
+    hPOrtho.to_overlapSpan hQOrtho (hPInj_of hInjA) (hQInj_of hInjB) hSpan
+  obtain ⟨M⟩ := hOverlapSpan.exists_sectorBasisMatching hPQeq
+  obtain ⟨ζ, hζne, hMultiset⟩ :=
+    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching M hPbnt hPQeq
+  exact ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt,
+          M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
+
 /-- Remove matching zero tails from two MPV identities.
 
 If `A` and `B` have the same MPVs, and each is expressed as a zero tail plus a live tensor,
@@ -774,37 +879,39 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSp
 
 The complete end-to-end FT should take two tensors `A, B` with `SameMPV₂ A B`
 and pass from the blocked reduction output to the paper's basis-of-normal-tensors
-sector comparison. The one-sided collapsed BNT construction is now available as
-`exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`, and the sector matching
-extraction is available from primitive overlap-rigidity hypotheses through
-`SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching`.
+sector comparison. The one-sided phase-class BNT construction is available as
+`exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`, with one-sided overlap data
+exposed by `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho`.
+The sector matching extraction is available from primitive overlap-rigidity
+hypotheses through `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching`.
 
 The theorem
-`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan`
-records the strongest Lean statement currently available: once a common
-blocking period gives exact live TP primitive irreducible block decompositions on
-both sides, the one-sided BNT construction and the overlap-span matching theorem
-produce the matched sector-weight conclusion from the original `SameMPV₂ A B`.
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`
+records the strongest exact-live overlap-input reduction currently available:
+once a common blocking period gives exact live TP primitive irreducible block
+decompositions on both sides, live-block injectivity and finite-length span
+equality are enough to derive the overlap-span hypotheses for the constructed
+sector bases and produce the matched sector-weight conclusion. The theorem
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail`
+records the corresponding zero-tail bookkeeping route when full overlap-span data
+are supplied.
 
 The remaining formal work for the completely unconditional
-`fundamentalTheorem_after_blocking_1606_sector` is therefore not another matched
-basis assumption. It is to derive, from the structural reduction itself:
+`fundamentalTheorem_after_blocking_1606_sector` is therefore to derive, from the
+structural reduction itself:
 
 1. a common live block decomposition with primitive **and irreducible** blocks at
-   the same physical blocking level, with the zero-tail contribution handled at
-   `N = 0`;
-2. the nonzero-bond-dimension, injectivity, normalization, asymptotic
-   self/orthogonal-overlap, and finite-length span hypotheses bundled in
-   `SectorBasisOverlapSpanHypotheses` for the collapsed BNT bases produced by
-   `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`; and
-3. the final global gauge construction of the equal-case FT after the matched
-   sector-weight data has been obtained.
+   the same physical blocking level;
+2. the `N = 0` bookkeeping for the zero-tail contribution;
+3. one-site injectivity of the live blocks, or a blocked replacement of the
+   rigidity input; and
+4. equality of the finite-length MPV spans for the two BNT bases, followed by the
+   final global gauge construction of the equal-case FT.
 
 Thus the common-period arithmetic and the abstract sector-matching witness are no
 longer the main blockers; the remaining gap is the paper-level derivation of the
-primitive overlap-span hypotheses for the actual collapsed BNT bases, together
-with the live/zero-tail bookkeeping needed to compare the sector tensors as full
-`SameMPV₂` families.
+listed live-block, zero-tail, injectivity, and span facts for the actual sector
+tensors produced by the after-blocking reduction.
 -/
 
 end FundamentalTheorem1606

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -744,6 +744,66 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
   · exact collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
   · exact collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
 
+/-- **Phase-class BNT sector construction with one-sided overlap data.**
+
+Starting from trace-preserving primitive irreducible blocks with nonzero weights,
+quotient the block indices by MPV phase equivalence. The constructed sector
+decomposition represents the original weighted block sum, satisfies the BNT
+linear-independence condition, and its chosen basis blocks carry the
+single-family overlap-orthogonality data needed for the primitive
+overlap-rigidity route.
+
+The theorem also records that if the original blocks are one-site injective,
+then the chosen basis blocks are injective. It does not claim the remaining
+two-family input of `SectorBasisOverlapSpanHypotheses`: equality of the
+finite-length MPV spans between two independently constructed bases is a
+separate Gap §1 task. -/
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P ∧
+      SectorBasisOverlapOrthoHypotheses P ∧
+      ((∀ k, IsInjective (blocks k)) → ∀ j, IsInjective (P.basis j)) := by
+  classical
+  let classes := mpvPhaseClassData blocks
+  let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
+  have hSame : SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) :=
+    collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
+  have hBNT : HasBNTSectorData (d := d) P :=
+    collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
+  refine ⟨P, hSame, hBNT, ?_, ?_⟩
+  · refine {
+      dim_pos := ?_
+      normalized := ?_
+      self_overlap := ?_
+      off_overlap := ?_
+    }
+    · intro j
+      simpa [P, collapsedBntSectorDecomp] using NeZero.pos (dim (classes.repr j))
+    · intro j
+      simpa [P, collapsedBntSectorDecomp] using hTP (classes.repr j)
+    · intro j
+      simpa [P, collapsedBntSectorDecomp] using
+        overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+        (blocks (classes.repr j)) (hIrr (classes.repr j))
+        (hTP (classes.repr j)) (hPrim (classes.repr j))
+    · intro i j hij
+      simpa [P, collapsedBntSectorDecomp] using
+        cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
+        (fun j : Fin classes.g => blocks (classes.repr j))
+        (HasIrreducibleBlocks.ofForall (fun j => hIrr (classes.repr j)))
+        (IsLeftCanonicalBlockFamily.ofForall (fun j => hTP (classes.repr j)))
+        classes.blocks_not_equiv i j hij
+  · intro hInj j
+    simpa [P, collapsedBntSectorDecomp] using hInj (classes.repr j)
+
 /-- **Collapsed BNT sector construction with primitive overlap data.**
 
 This strengthens `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` by exposing the
@@ -775,32 +835,11 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData
       (∀ i j : Fin P.basisCount, i ≠ j →
         Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
           Filter.atTop (nhds 0)) := by
-  classical
-  let classes := mpvPhaseClassData blocks
-  let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
-  have hSame : SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) :=
-    collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
-  have hBNT : HasBNTSectorData (d := d) P :=
-    collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
-  refine ⟨P, hSame, hBNT, ?_, ?_, ?_, ?_, ?_⟩
-  · intro j
-    simpa [P, collapsedBntSectorDecomp] using NeZero.pos (dim (classes.repr j))
-  · intro j
-    simpa [P, collapsedBntSectorDecomp] using hInj (classes.repr j)
-  · intro j
-    simpa [P, collapsedBntSectorDecomp] using hTP (classes.repr j)
-  · intro j
-    simpa [P, collapsedBntSectorDecomp] using
-      overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
-      (blocks (classes.repr j)) (hIrr (classes.repr j)) (hTP (classes.repr j))
-      (hPrim (classes.repr j))
-  · intro i j hij
-    simpa [P, collapsedBntSectorDecomp] using
-      cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
-      (fun j : Fin classes.g => blocks (classes.repr j))
-      (HasIrreducibleBlocks.ofForall (fun j => hIrr (classes.repr j)))
-      (IsLeftCanonicalBlockFamily.ofForall (fun j => hTP (classes.repr j)))
-      classes.blocks_not_equiv i j hij
+  obtain ⟨P, hSame, hBNT, hOrtho, hInj_of⟩ :=
+    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
+      (d := d) μ blocks hTP hIrr hPrim hμne
+  exact ⟨P, hSame, hBNT, hOrtho.dim_pos, hInj_of hInj, hOrtho.normalized,
+    hOrtho.self_overlap, hOrtho.off_overlap⟩
 
 /-! ### §6. Conditional sector construction under BNT linear independence -/
 

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -822,6 +822,29 @@ theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_preMatching
   fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies
     P Q M.perm M.phase_match_exists hLI hEqual
 
+/-- Single-family primitive overlap-orthogonality data for a sector basis.
+
+This is the part of `SectorBasisOverlapSpanHypotheses` that can be checked one
+sector decomposition at a time: positive basis dimensions, left-canonical
+normalization, self-overlap convergence to `1`, and off-diagonal overlap
+convergence to `0`. It intentionally omits one-site injectivity and the
+finite-length span comparison between two different bases, because those are
+separate inputs in the current Gap §1 route. -/
+structure SectorBasisOverlapOrthoHypotheses (P : SectorDecomposition d) : Prop where
+  /-- The basis blocks have nonzero bond dimension. -/
+  dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j
+  /-- The basis blocks are left-canonical. -/
+  normalized :
+    ∀ j : Fin P.basisCount, (∑ i : Fin d, (P.basis j i)ᴴ * (P.basis j i)) = 1
+  /-- Each basis block has self-overlap tending to one. -/
+  self_overlap : ∀ j : Fin P.basisCount,
+    Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
+      Filter.atTop (nhds (1 : ℂ))
+  /-- Distinct basis blocks have asymptotically zero overlap. -/
+  off_overlap : ∀ i j : Fin P.basisCount, i ≠ j →
+    Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
+      Filter.atTop (nhds 0)
+
 /-- Primitive overlap-rigidity hypotheses for two sector bases.
 
 This structure records the analytic inputs used by
@@ -867,6 +890,38 @@ structure SectorBasisOverlapSpanHypotheses (P Q : SectorDecomposition d) : Prop 
       mpvState (d := d) (P.basis j) N)) =
     Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
       mpvState (d := d) (Q.basis k) N))
+
+namespace SectorBasisOverlapOrthoHypotheses
+
+variable {P Q : SectorDecomposition d}
+
+/-- Combine the single-family overlap-orthogonality data for two sector bases
+with the remaining one-site injectivity and finite-length span comparison inputs
+needed by the primitive overlap-rigidity theorem. -/
+theorem to_overlapSpan
+    (HP : SectorBasisOverlapOrthoHypotheses P)
+    (HQ : SectorBasisOverlapOrthoHypotheses Q)
+    (hP_inj : ∀ j : Fin P.basisCount, IsInjective (P.basis j))
+    (hQ_inj : ∀ k : Fin Q.basisCount, IsInjective (Q.basis k))
+    (hspan : ∀ N,
+      Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
+        mpvState (d := d) (P.basis j) N)) =
+      Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
+        mpvState (d := d) (Q.basis k) N))) :
+    SectorBasisOverlapSpanHypotheses P Q where
+  left_dim_pos := HP.dim_pos
+  right_dim_pos := HQ.dim_pos
+  left_injective := hP_inj
+  right_injective := hQ_inj
+  left_normalized := HP.normalized
+  right_normalized := HQ.normalized
+  left_self_overlap := HP.self_overlap
+  left_off_overlap := HP.off_overlap
+  right_self_overlap := HQ.self_overlap
+  right_off_overlap := HQ.off_overlap
+  span_eq := hspan
+
+end SectorBasisOverlapOrthoHypotheses
 
 /-- Produce a sector basis matching from the primitive overlap-rigidity hypotheses.
 

--- a/audits/2026-04-26_issue877_after_blocking_sector.md
+++ b/audits/2026-04-26_issue877_after_blocking_sector.md
@@ -75,15 +75,33 @@ reduction:
    live sector tensors requires either equal zero-tail dimensions or a
    positive-length variant of the sector comparison/extrapolation layer.
 
-3. **Overlap/span hypotheses for the collapsed BNT bases.**
+3. **Overlap/span hypotheses for the phase-class BNT bases.**
    The one-sided #923 constructor proves `HasBNTSectorData` but does not expose
-   injectivity, left-canonical normalization of the chosen representatives,
-   asymptotic overlap orthogonality, or equality of the finite-length spans
-   between the two sides. These are exactly the fields of
-   `SectorBasisOverlapSpanHypotheses`; deriving them from the collapsed
-   representatives is the next paper-level task.
+   all fields of `SectorBasisOverlapSpanHypotheses`; deriving them for the
+   phase-class BNT bases is the next paper-level task.
+
+## Wave 17 Slot G update
+
+`MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho`
+now strengthens the #923 constructor for the fields that are one-sided in nature:
+positive basis dimensions, left-canonical normalization, self-overlap limits,
+off-overlap limits, and representative injectivity when the original live blocks
+are one-site injective.  The helper
+`MPSTensor.SectorBasisOverlapOrthoHypotheses.to_overlapSpan` then combines those
+one-sided fields with the two genuinely two-family inputs still needed by the
+#860 overlap-rigidity theorem: injectivity of the chosen bases and equality of
+the finite-length MPV spans.
+
+Accordingly,
+`MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`
+replaces the earlier opaque overlap-span-data input by explicit live-block
+injectivity plus a finite-span comparison for the phase-class BNT bases.  The
+remaining unproved Gap §1 content is now narrower: obtain the exact common
+live-block input above, arrange one-site injectivity (or a blocked variant of the
+rigidity theorem), and prove the finite-length span comparison for the two BNT
+bases.
 
 Therefore this branch combines the available #923 and #860 ingredients without
 hiding the missing work behind `SectorBasisMatching`. The remaining work is to
-prove the listed live-block and overlap/span facts for the actual sector
-decompositions produced by the after-blocking reduction.
+prove the listed live-block and span facts for the actual sector decompositions
+produced by the after-blocking reduction.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2296,11 +2296,37 @@ The following results separate the zero blocks from the
 	linear-independence condition.
 \end{proof}
 
+
+\begin{theorem}[Phase-class BNT sector construction with one-sided overlap data]
+	\label{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_ortho}
+	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho}
+	\leanok
+	\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed,
+		def:sector_basis_overlap_ortho_hyps}
+	For trace-preserving primitive irreducible blocks of positive bond dimension
+	with nonzero weights, there is a sector decomposition, obtained by choosing
+	one block per MPV phase class, which represents the same weighted block sum,
+	satisfies the BNT linear-independence condition, and has a basis satisfying
+	the single-family overlap-orthogonality data.  If the original blocks are
+	one-site injective, then the chosen basis blocks are one-site injective.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{def:mpv_phase_class_data, thm:bnt_li_tp_prim_irr_separated,
+		thm:cross_overlap_zero_split, thm:bnt_sector_decomp_tp_prim_irr_collapsed}
+	The proof is the phase-class construction of
+	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}.  The chosen basis
+	blocks keep positive bond dimension, normalization, and any supplied
+	one-site injectivity from the original trace-preserving primitive
+	irreducible blocks.  Primitivity gives the self-overlap limit, while the
+	separation of distinct chosen phase-class blocks gives off-overlap decay.
+\end{proof}
+
 \begin{theorem}[Phase-class BNT sector construction with overlap data]
 	\label{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData}
 	\leanok
-	\uses{thm:bnt_li_tp_prim_irr_separated}
+	\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_ortho}
 	For trace-preserving primitive irreducible blocks of positive bond dimension,
 	with nonzero weights, suppose moreover that the blocks are injective. Then
 	there is a sector decomposition, obtained by choosing one block per MPV phase
@@ -2311,15 +2337,10 @@ The following results separate the zero blocks from the
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{def:mpv_phase_class_data, thm:bnt_li_tp_prim_irr_separated,
-		thm:bnt_sector_decomp_tp_prim_irr_collapsed}
-	Choose one representative per MPV phase class and absorb the phase factors
-	into the sector weights as in
-	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}. The
-	representatives inherit positivity of the bond dimension, injectivity, and
-	trace preservation from the original blocks. Their self-overlap limits follow
-	from primitivity and irreducibility, while their mutual overlap limits follow
-	from the separation of distinct phase-class representatives.
+	\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_ortho}
+	Apply Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_ortho}
+	and use the supplied injectivity of the original blocks to fill the
+	injectivity field required by this theorem's unbundled conclusion.
 \end{proof}
 
 \begin{theorem}[TP primitive irreducible version with eventual BNT independence]

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -577,11 +577,22 @@ single weighted block.
 	Theorem~\ref{thm:sector_basis_pre_matching_to_matching}.
 \end{definition}
 
+\begin{definition}[Single-family overlap-orthogonality data for sector bases]%
+\label{def:sector_basis_overlap_ortho_hyps}
+	\lean{MPSTensor.SectorBasisOverlapOrthoHypotheses}
+	\leanok
+	\uses{def:paper_sector_data, def:mpv_overlap}
+	For one sector decomposition $P$, this condition records positive basis
+	dimensions, trace-preserving normalization of all basis blocks,
+	self-overlap limits equal to~$1$, and off-overlap limits equal to~$0$.
+\end{definition}
+
 \begin{definition}[Primitive overlap-span hypotheses for sector bases]%
 \label{def:sector_basis_overlap_span_hyps}
 	\lean{MPSTensor.SectorBasisOverlapSpanHypotheses}
 	\leanok
-	\uses{def:paper_sector_data, def:mpv_overlap, def:mpv_state}
+	\uses{def:paper_sector_data, def:mpv_overlap, def:mpv_state,
+		def:sector_basis_overlap_ortho_hyps}
 	For sector decompositions $P$ and $Q$, this condition records the
 	primitive overlap-rigidity hypotheses for their basis blocks: nonzero
 	bond dimensions, injectivity, trace-preserving normalization,
@@ -589,6 +600,24 @@ single weighted block.
 	equality of the finite-length spans of the basis MPV states for every
 	system size.
 \end{definition}
+
+\begin{theorem}[Single-family overlap data plus span give overlap-span hypotheses]%
+\label{thm:sector_basis_overlap_ortho_to_span}
+	\lean{MPSTensor.SectorBasisOverlapOrthoHypotheses.to_overlapSpan}
+	\leanok
+	\uses{def:sector_basis_overlap_ortho_hyps, def:sector_basis_overlap_span_hyps}
+	If two sector bases each satisfy the single-family overlap-orthogonality data,
+	and one also supplies one-site injectivity of all their basis blocks together
+	with equality of the finite-length MPV spans, then the two bases satisfy the
+	primitive overlap-span hypotheses.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{def:sector_basis_overlap_ortho_hyps, def:sector_basis_overlap_span_hyps}
+	This is just collecting the one-family fields on the left and right, and adding
+	the remaining injectivity and span-comparison inputs.
+\end{proof}
 
 \begin{theorem}[Phase-matched comparison recovers copy counts]%
 \label{thm:route_b_hetero_phase_match_copies}
@@ -775,6 +804,36 @@ single weighted block.
 	produces a sector basis matching, and
 	Theorem~\ref{thm:route_b_hetero_sector_matching} gives the matched
 	sector-weight conclusion.
+\end{proof}
+
+
+\begin{theorem}[Common live blocks with derived overlap data and span comparison]%
+\label{thm:after_blocking_sector_common_blocks_injective_span}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan}
+	\leanok
+	\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_ortho,
+		thm:sector_basis_overlap_ortho_to_span,
+		thm:route_b_hetero_sector_matching}
+	Let $A$ and $B$ have the same MPV family and fix exact live decompositions at a
+	common blocking period as in
+	Theorem~\ref{thm:after_blocking_sector_common_blocks_overlap_span}.  Assume in
+	addition that the live blocks are one-site injective, and that the two chosen
+	BNT sector bases have equal finite-length MPV spans. Then the same matched
+	sector-weight conclusion holds.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_ortho,
+		thm:sector_basis_overlap_ortho_to_span,
+		thm:sector_basis_overlap_span_to_matching,
+		thm:route_b_hetero_sector_matching}
+	The phase-class BNT construction gives BNT linear independence and the
+	single-family overlap-orthogonality data for both sides, and carries one-site
+	injectivity from the live blocks to the chosen basis blocks.  The assumed span
+	comparison combines with those one-family data by
+	Theorem~\ref{thm:sector_basis_overlap_ortho_to_span}; the matching and
+	sector-weight comparison then proceed as before.
 \end{proof}
 
 \begin{lemma}[Zero-tail cancellation]\label{lem:sameMPV2_live_of_zeroTail_eq}


### PR DESCRIPTION
## Summary

- add `SectorBasisOverlapOrthoHypotheses`, the one-sided part of the #935 overlap-span bundle: positive sector-basis dimensions, left-canonical normalization, self-overlap limit `1`, and off-overlap limit `0`
- add `SectorBasisOverlapOrthoHypotheses.to_overlapSpan`, which combines that one-sided data with the remaining explicit inputs (basis injectivity and finite-length span equality) to produce `SectorBasisOverlapSpanHypotheses`
- strengthen the #923 collapsed representative constructor with `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho`, deriving one-sided overlap-orthogonality for the chosen representatives and transporting one-site injectivity from the original nonzero blocks
- add `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`, replacing PR #935's opaque `overlapSpanData` input by explicit injectivity of the nonzero blocks plus the remaining finite-length span comparison
- update the #877 audit and blueprint entries for the checked declarations

Refs #652 and #877. This advances the overlap/span-hypothesis derivation needed by PR #935; it does not claim the fully unconditional `hSame`-only theorem.

## What is now derived vs. still remaining

Derived for collapsed BNT representative bases from TP primitive irreducible nonzero blocks:

1. positive basis dimensions;
2. left-canonical normalization;
3. self-overlap convergence to `1`;
4. off-overlap convergence to `0` for distinct representatives;
5. representative one-site injectivity when the source nonzero blocks are one-site injective.

Still explicit, because these are genuinely two-family / after-blocking assembly inputs not implied by the one-sided constructor alone:

1. exact common nonzero-block decompositions from the structural zero-tail reduction;
2. one-site injectivity for the nonzero blocks, or a blocked variant of the #860 rigidity theorem;
3. finite-length span equality between the independently collapsed BNT bases;
4. zero-tail accounting at length `N = 0`.

## Blueprint / paper anchors

Paper references: CPSV17 (arXiv:1606.00608) Theorem 1 and Appendix A basis-of-normal-tensors construction; CPSV21 (arXiv:2011.12127) Definition 4.2, Theorem 4.4, and Corollary IV.5.

New/updated blueprint labels and source quotes:

- `blueprint/src/chapter/ch11_assembly.tex:580`, `def:sector_basis_overlap_ortho_hyps`: “For one sector decomposition $P$, this condition records positive basis dimensions, trace-preserving normalization of all basis blocks, self-overlap limits equal to~$1$, and off-overlap limits equal to~$0$.”
- `blueprint/src/chapter/ch11_assembly.tex:604`, `thm:sector_basis_overlap_ortho_to_span`: “If two sector bases each satisfy the single-family overlap-orthogonality data … then the two bases satisfy the primitive overlap-span hypotheses.”
- `blueprint/src/chapter/ch08_canonical.tex:2278`, `thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_ortho`: “the collapsed representative sector decomposition can be chosen so that its basis satisfies the single-family overlap-orthogonality data.”
- `blueprint/src/chapter/ch11_assembly.tex:809`, `thm:after_blocking_sector_common_blocks_injective_span`: “Assume in addition that the nonzero blocks are one-site injective, and that the collapsed representative sector bases on the two sides have equal finite-length MPV spans.”

## Validation

A worktree-local `.lake` build directory was used for validation to avoid concurrent Wave 17 jobs mutating the shared cache artifacts.

- `lake build TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.FundamentalTheorem.SectorDecomposition` — passed; only pre-existing long-line warnings in `CyclicSectorDecomposition.lean` replayed
- Lean diagnostics for `SectorDecomposition.lean`, `EqualNormBridge.lean`, and `StructuralTheorem.lean` — no errors/warnings/hints
- `cd blueprint && leanblueprint web` — passed
- `cd blueprint && leanblueprint checkdecls` — passed after locally building unrelated recent blueprint declaration modules (`Martingale`, `BlockDiagonalCommutant`, `DegenerateGS`, `UniqueGroundState`)
- `git diff --check` — passed
- touched-file whole-word forbidden-token scan for `sorry|admit|axiom|native_decide|unsafe` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new theorem/structure APIs and refactoring of key canonical-form proof entrypoints, which could ripple through downstream Lean proofs even though it’s all specification/proof-layer code.
> 
> **Overview**
> Introduces `SectorBasisOverlapOrthoHypotheses`, splitting the previously bundled overlap/span requirements into a *single-family* overlap-orthogonality predicate plus a helper `to_overlapSpan` that rebuilds `SectorBasisOverlapSpanHypotheses` when injectivity and finite-length span equality are provided.
> 
> Extends the collapsed (phase-class) BNT sector constructor with `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho`, which now returns the constructed sector decomposition together with derived one-sided overlap data and a lemma transporting one-site injectivity from the original blocks to the chosen basis blocks; `..._with_overlapData` is refactored to reuse this.
> 
> Adds `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`, replacing the earlier opaque `overlapSpanData` requirement with explicit assumptions: injectivity of the nonzero blocks on both sides plus a supplied finite-length MPV span comparison for the two constructed BNT bases. Documentation/audit/blueprint text is updated to reflect the new “phase-class” framing and the narrowed remaining Gap §1 obligations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405dde30e92b3aa87910f37a3922e8ad94cdf16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->