### PR TITLE
feat(MPS/CanonicalForm): prove zero-tail comparison for nonzero sectors (#877)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -61,7 +61,7 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-!
-## Cyclic sector decomposition via the CyclicSectors API
+## Cyclic sector decomposition from cyclic-sector data
 
 ### Mathematical overview
 
@@ -963,7 +963,7 @@ theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_o
 /-- Unconditional cyclic-sector block primitivity and irreducibility after blocking.
 
 This uses `isIrreducibleOnCorner_of_cyclic_decomp_mps`, so the older
-`hProjStep` and `SectorFixedPointAlgebraRigidity` interfaces are no longer needed
+projection-step and fixed-point-algebra rigidity assumptions are no longer needed
 once the ambient tensor is irreducible and trace-preserving. -/
 theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking
     {d D m : ℕ} [NeZero D] [NeZero m]
@@ -1020,9 +1020,9 @@ theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking
 
 This strengthens `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` by
 exposing the primitive and irreducible conclusions already available from the
-unconditional sector-orbit lift. It is the public one-block interface needed by
-later assembly steps before flattening the sectors of all live blocks to a common
-period. -/
+unconditional sector-orbit lift. It is the one-block result used in the later
+multi-block construction before the sectors of all live blocks are flattened to
+a common period. -/
 theorem exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1016,6 +1016,57 @@ theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking
     A hTP hγprim hperiph blocks P φ hPproj hPsum hcyclic hIntertwine hMul hStar hNondeg
     hCornerIrr
 
+/-- Cyclic sector decomposition with primitive and tensor-irreducible sector blocks.
+
+This strengthens `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` by
+exposing the primitive and irreducible conclusions already available from the
+unconditional sector-orbit lift. It is the public one-block interface needed by
+later assembly steps before flattening the sectors of all live blocks to a common
+period. -/
+theorem exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
+    {d D : ℕ} [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A) :
+    ∃ (m : ℕ) (_ : 0 < m)
+      (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
+      (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
+      SameMPV₂ (blockTensor A m)
+        (toTensorFromBlocks (d := blockPhysDim d m) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
+      (∀ k, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d m) (D := dim k) (blocks k))) ∧
+      (∀ k, IsIrreducibleTensor (blocks k)) ∧
+      (∀ k, 0 < dim k) := by
+  -- Use shared setup to get conjugate Kraus data and the cyclic peripheral structure.
+  obtain ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
+    conjTranspose_kraus_setup A hTP hIrr
+  obtain ⟨m, γ, hm_pos, hγ_prim, hperiph_set⟩ :=
+    PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure _ h_unitalK ρ hρ_pd h_adjfix hIrrK
+  have hperiph_range :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+        Set.range (fun j : Fin m => γ ^ (j : ℕ)) := by
+    rw [hperiph_set]
+    ext x
+    simp [Set.mem_range, eq_comm]
+  haveI : NeZero m := ⟨by omega⟩
+  obtain ⟨dim, blocks, P, φ, hTP_blocks, hSame, hPproj, hPsum, hcyclic, _hComm,
+      _hTrace, hIntertwine, hMul, hStar, hNondeg⟩ :=
+    exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim
+      hperiph_range
+  have hPrimIrr : ∀ u : Fin m,
+      _root_.IsPrimitive (transferMap (d := blockPhysDim d m) (D := dim u) (blocks u)) ∧
+        IsIrreducibleTensor (blocks u) :=
+    primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking
+      A hTP hIrr hγ_prim hperiph_range blocks P φ hPproj hPsum hcyclic hIntertwine hMul hStar
+      hNondeg
+  refine ⟨m, hm_pos, dim, blocks, hTP_blocks, hSame, ?_, ?_, ?_⟩
+  · intro k
+    exact (hPrimIrr k).1
+  · intro k
+    exact (hPrimIrr k).2
+  · intro k
+    exact Nat.pos_of_ne_zero (hNondeg k)
+
 end SectorOrbitLift
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -39,9 +39,9 @@ its MPS-formulation for irreducible TP tensors.
 * `sectorFixedPointAlgebraRigidity_of_cyclic_decomp_after_blocking_of_scalarBlockedFixedPoints`
   — a scalar blocked fixed-point algebra hypothesis implies the sector
   rigidity needed by the orbit-sum argument.
-* `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_scalarBlockedFixedPoints`
-  — the same blocked fixed-point algebra hypothesis yields primitive,
-  tensor-irreducible compressed sectors.
+* The scalar blocked fixed-point variant of the sector-block theorem — the same
+  blocked fixed-point algebra hypothesis yields primitive, tensor-irreducible
+  compressed sectors.
 * `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking`
   — the unconditional conclusion using
   `isIrreducibleOnCorner_of_cyclic_decomp_mps`.
@@ -371,7 +371,7 @@ theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
         Set.range (fun j : Fin m => γ ^ (j : ℕ)) := by
     rw [hperiph_set]; ext x; simp [Set.mem_range, eq_comm]
   -- Apply exists_cyclic_sector_decomp_after_blocking.
-  haveI : NeZero m := ⟨by omega⟩
+  haveI : NeZero m := ⟨Nat.ne_of_gt hm_pos⟩
   obtain ⟨dim, blocks, _, _, hTP_blocks, hSame, _, _, _, _, _, _, _⟩ :=
     exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim
       hperiph_range
@@ -680,7 +680,8 @@ hypothesis, uses
 `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`
 to obtain corner irreducibility of `((transferMap A†)^m)|_{P_k}`, and then
 applies the compression transport theorem above. -/
-theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity
+theorem
+  primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -909,8 +910,9 @@ orbit-sum / corner-compression reduction: the paper-level remaining gap is now
 concentrated in proving that the blocked sector adjoint fixed-point algebra is
 scalar. Once that input is available, the present theorem derives
 `SectorFixedPointAlgebraRigidity` and applies the orbit-sum / corner-compression
-reduction from `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`. -/
-theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_scalarBlockedFixedPoints
+reduction from the fixed-algebra-rigidity sector-block theorem. -/
+theorem
+  primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_scalarBlockedFixedPoints
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -1048,7 +1050,7 @@ theorem exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducible
     rw [hperiph_set]
     ext x
     simp [Set.mem_range, eq_comm]
-  haveI : NeZero m := ⟨by omega⟩
+  haveI : NeZero m := ⟨Nat.ne_of_gt hm_pos⟩
   obtain ⟨dim, blocks, P, φ, hTP_blocks, hSame, hPproj, hPsum, hcyclic, _hComm,
       _hTrace, hIntertwine, hMul, hStar, hNondeg⟩ :=
     exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -680,8 +680,7 @@ hypothesis, uses
 `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`
 to obtain corner irreducibility of `((transferMap A†)^m)|_{P_k}`, and then
 applies the compression transport theorem above. -/
-theorem
-  primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity
+theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -911,8 +910,7 @@ concentrated in proving that the blocked sector adjoint fixed-point algebra is
 scalar. Once that input is available, the present theorem derives
 `SectorFixedPointAlgebraRigidity` and applies the orbit-sum / corner-compression
 reduction from the fixed-algebra-rigidity sector-block theorem. -/
-theorem
-  primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_scalarBlockedFixedPoints
+theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_scalarBlockedFixedPoints
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -244,6 +244,146 @@ theorem fundamentalTheorem_after_blocking_1606_structural_with_blockedSameMPV₂
   · exact sameMPV₂_blockTensor A B hSame pA
   · exact sameMPV₂_blockTensor A B hSame pB
 
+/-- **Zero-tail bookkeeping for live block tensors.**
+
+Suppose two tensors with the same MPV family are each written as a zero-tail
+contribution plus a live block tensor. Then the live block tensors agree at every
+positive length, while the length-zero equation records exactly the difference
+between the zero-tail dimensions and the live bond dimensions.
+
+This is the local bookkeeping needed before a full `SameMPV₂` comparison of the
+live sector tensors can be recovered: the only missing datum is equality of the
+two zero-tail dimensions (or an equivalent replacement for the `N = 0` case). -/
+theorem liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+    {d D₁ D₂ rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (zeroTailA zeroTailB : ℕ)
+    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
+    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
+    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) :
+    (∀ {N : ℕ}, 0 < N → ∀ σ : Fin N → Fin d,
+      mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ =
+        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) ∧
+    (∀ σ : Fin 0 → Fin d,
+      (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ =
+        (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) := by
+  constructor
+  · intro N hN σ
+    have hN_ne : N ≠ 0 := Nat.ne_of_gt hN
+    have hAσ := hA N σ
+    have hBσ := hB N σ
+    rw [mpv_zeroMPSTensor, if_neg hN_ne, zero_add] at hAσ
+    rw [mpv_zeroMPSTensor, if_neg hN_ne, zero_add] at hBσ
+    calc
+      mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ = mpv A σ := hAσ.symm
+      _ = mpv B σ := hSame N σ
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ := hBσ
+  · intro σ
+    have hAσ := hA 0 σ
+    have hBσ := hB 0 σ
+    rw [mpv_zeroMPSTensor] at hAσ
+    rw [mpv_zeroMPSTensor] at hBσ
+    simp only [↓reduceIte] at hAσ hBσ
+    calc
+      (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ
+          = mpv A σ := hAσ.symm
+      _ = mpv B σ := hSame 0 σ
+      _ = (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ := hBσ
+
+/-- **Recover full live-block `SameMPV₂` once zero tails agree.**
+
+This packages the positive-length bookkeeping theorem with the single additional
+length-zero datum needed to remove the zero tails. It does not assert that the
+zero-tail dimensions agree automatically; that remains a separate paper-level
+bookkeeping step for the unconditional after-blocking sector endpoint. -/
+theorem liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
+    {d D₁ D₂ rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (zeroTailA zeroTailB : ℕ)
+    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
+    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
+    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ)
+    (hZeroTail : zeroTailA = zeroTailB) :
+    SameMPV₂ (toTensorFromBlocks (d := d) (μ := μA) blocksA)
+      (toTensorFromBlocks (d := d) (μ := μB) blocksB) := by
+  have hBook :=
+    liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+      A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hA hB
+  intro N σ
+  by_cases hN : N = 0
+  · subst N
+    have h0 := hBook.2 σ
+    have h0' : (zeroTailB : ℂ) +
+        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ =
+        (zeroTailB : ℂ) +
+        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ := by
+      simpa [hZeroTail] using h0
+    exact add_left_cancel h0'
+  · exact hBook.1 (Nat.pos_of_ne_zero hN) σ
+
+/-- **Structural after-blocking theorem retaining zero-tail MPV equations.**
+
+This strengthens the structural shell by exposing the exact zero-tail identities
+returned by `exists_tp_primitive_blockDecomp_after_blocking`, in addition to the
+blocked `SameMPV₂` relations. The live blocks are trace-preserving, have
+primitive transfer maps, positive bond dimensions, and nonzero weights; the
+zero-tail equations record precisely why these live tensors are only immediately
+identified at positive lengths unless the `N = 0` zero-tail bookkeeping is also
+resolved. -/
+theorem fundamentalTheorem_after_blocking_1606_structural_with_zeroTail
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ (zeroTailA : ℕ) (pA : ℕ) (_ : 0 < pA)
+      (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d pA) (dimA k)),
+    ∃ (zeroTailB : ℕ) (pB : ℕ) (_ : 0 < pB)
+      (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d pB) (dimB k)),
+      SameMPV₂ (blockTensor (d := d) (D := D₁) A pA)
+        (blockTensor (d := d) (D := D₂) B pA) ∧
+      SameMPV₂ (blockTensor (d := d) (D := D₁) A pB)
+        (blockTensor (d := d) (D := D₂) B pB) ∧
+      (∀ k, ∑ i, (blocksA k i)ᴴ * blocksA k i = 1) ∧
+      (∀ k, ∑ i, (blocksB k i)ᴴ * blocksB k i = 1) ∧
+      (∀ k, _root_.IsPrimitive (transferMap (blocksA k))) ∧
+      (∀ k, _root_.IsPrimitive (transferMap (blocksB k))) ∧
+      (∀ k, μA k ≠ 0) ∧
+      (∀ k, μB k ≠ 0) ∧
+      (∀ k, 0 < dimA k) ∧
+      (∀ k, 0 < dimB k) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d pA)),
+        mpv (blockTensor (d := d) (D := D₁) A pA) σ =
+          mpv (zeroMPSTensor (blockPhysDim d pA) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d pA) (μ := μA) blocksA) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d pB)),
+        mpv (blockTensor (d := d) (D := D₂) B pB) σ =
+          mpv (zeroMPSTensor (blockPhysDim d pB) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d pB) (μ := μB) blocksB) σ) := by
+  obtain ⟨zeroTailA, pA, hpA, rA, dimA, μA, blocksA, hTPA, hPrimA, hDimA, hμA, hMPVA⟩ :=
+    exists_tp_primitive_blockDecomp_after_blocking A
+  obtain ⟨zeroTailB, pB, hpB, rB, dimB, μB, blocksB, hTPB, hPrimB, hDimB, hμB, hMPVB⟩ :=
+    exists_tp_primitive_blockDecomp_after_blocking B
+  refine ⟨zeroTailA, pA, hpA, rA, dimA, μA, blocksA,
+    zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
+    ?_, ?_, hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, hMPVA, hMPVB⟩
+  · exact sameMPV₂_blockTensor A B hSame pA
+  · exact sameMPV₂_blockTensor A B hSame pB
+
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 
 Given two tensors with `SameMPV₂`, a common-period BNT sector pair, and a

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -288,9 +288,8 @@ theorem liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
   · intro σ
     have hAσ := hA 0 σ
     have hBσ := hB 0 σ
-    rw [mpv_zeroMPSTensor] at hAσ
-    rw [mpv_zeroMPSTensor] at hBσ
-    simp only [↓reduceIte] at hAσ hBσ
+    rw [mpv_zeroMPSTensor, if_pos rfl] at hAσ
+    rw [mpv_zeroMPSTensor, if_pos rfl] at hBσ
     calc
       (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ
           = mpv A σ := hAσ.symm
@@ -302,7 +301,7 @@ theorem liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
 This packages the positive-length bookkeeping theorem with the single additional
 length-zero datum needed to remove the zero tails. It does not assert that the
 zero-tail dimensions agree automatically; that remains a separate paper-level
-bookkeeping step for the unconditional after-blocking sector endpoint. -/
+bookkeeping step for the unconditional after-blocking sector comparison. -/
 theorem liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
     {d D₁ D₂ rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/audits/2026-04-26_issue877_common_live_blocks.md
+++ b/audits/2026-04-26_issue877_common_live_blocks.md
@@ -1,0 +1,84 @@
+# Issue #877 Wave 17 Slot F — common live-block / zero-tail audit
+
+Date: 2026-04-26
+Branch/worktree: `wave17-F-877-common-live-blocks`
+
+## Checked Lean progress
+
+This branch advances the live-block side of #877/#652 without discharging the
+separate overlap/span hypotheses owned by Slot G.
+
+1. `MPSTensor.exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
+   in `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean` exposes a
+   public one-block cyclic-sector API.  From a trace-preserving irreducible tensor
+   `A`, it returns a period `m > 0` and a unit-weight decomposition of
+   `blockTensor A m` into sector blocks which are all trace-preserving, primitive,
+   tensor-irreducible, and nonzero-dimensional.  The proof reuses the existing
+   cyclic sector construction and the unconditional
+   `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking` theorem.
+
+2. `MPSTensor.liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂`
+   in `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean` records the exact
+   zero-tail bookkeeping: if two equal-MPV tensors are each written as
+   `zeroMPSTensor zeroTail + livePart`, then the live parts agree for every
+   positive length, and the length-zero equation is exactly
+   `(zeroTailA : ℂ) + liveA₀ = (zeroTailB : ℂ) + liveB₀`.
+
+3. `MPSTensor.liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq` packages the previous
+   result with the additional datum `zeroTailA = zeroTailB`, yielding full
+   `SameMPV₂` of the two live tensors.  The equality of zero tails is deliberately
+   not asserted automatically here.
+
+4. `MPSTensor.fundamentalTheorem_after_blocking_1606_structural_with_zeroTail`
+   strengthens the existing structural wrapper by retaining the zero-tail MPV
+   equations returned by `exists_tp_primitive_blockDecomp_after_blocking`, together
+   with the blocked `SameMPV₂` relations from the original equality.
+
+Blueprint entries were added for these checked declarations at:
+
+- `blueprint/src/chapter/ch08_canonical.tex:1405`, label
+  `thm:cyclic_sector_decomp_irr_tp_prim_irr`, source quote:
+  “there is a period $m \ge 1$ and a unit-weight decomposition of $A^{[m]}$ into
+  sector blocks … every $C_k$ is left-canonical, has primitive transfer map, is
+  tensor-irreducible, and has nonzero bond dimension.”
+- `blueprint/src/chapter/ch08_canonical.tex:2541`, label
+  `thm:live_block_zero_tail_bookkeeping`, source quote:
+  “the two live block tensors agree on every positive system size, and at size
+  $0$ the equality is exactly the equality of the two zero-tail contributions
+  plus the two live bond-dimension traces.”
+- `blueprint/src/chapter/ch08_canonical.tex:2560`, label
+  `thm:live_block_same_mpv_zero_tail_eq`, source quote:
+  “if the two zero-tail dimensions are equal, then the two live block tensors are
+  fully SameMPV$_2$-equivalent, including the length-zero case.”
+- `blueprint/src/chapter/ch08_canonical.tex:2578`, label
+  `thm:ft_after_blocking_structural_zero_tail`, source quote:
+  “each tensor admits a blocked decomposition into a zero-tail tensor plus
+  nonzero left-canonical live blocks with primitive transfer maps and positive
+  bond dimensions.”
+
+## Paper anchors
+
+- CPSV17, arXiv:1606.00608, §2.3 and Appendix A: split off vanishing blocks,
+  reduce irreducible trace-preserving tensors by cyclic blocking, and compare the
+  surviving live sectors.
+- CPGSV21, arXiv:2011.12127, §IV / Appendix A: the cyclic sector blocks after
+  the period blocking are the primitive irreducible components used in the BNT
+  sector construction.
+
+## Remaining blocker for #877/#652
+
+The new cyclic-sector theorem exposes the one-block primitive irreducible output,
+but the full common live-block theorem still needs the multi-block flattening
+step: starting from the zero-tail TP-gauge reduction, choose a common physical
+blocking level, transport all per-block cyclic sector decompositions to that
+level, flatten the nested `(live block, cyclic sector)` index into one `Fin r`
+family, and prove the exact MPV equation for the resulting live tensor.  This is
+a genuine dependent-index / blocking-associativity construction, not an overlap
+or span hypothesis.
+
+The zero-tail lemmas isolate the `N = 0` obstruction.  Positive lengths compare
+the live tensors immediately after the zero-tail terms vanish.  Full `SameMPV₂`
+of live tensors requires either equality of the zero-tail dimensions or a
+positive-length variant of the downstream sector comparison.  This branch records
+that boundary explicitly rather than hiding it inside the PR #935 overlap-span
+assumption.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1414,7 +1414,8 @@ The following results separate the zero blocks from the
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:cyclic_sector_decomp_after_blocking, thm:blocked_sector_unconditional}
+	\uses{thm:conjtranspose_kraus_setup, thm:peripheral_cyclic_structure,
+		thm:cyclic_sector_decomp_after_blocking, thm:blocked_sector_unconditional}
 	The proof repeats the cyclic-sector construction of
 	Theorem~\ref{thm:cyclic_sector_decomp_irr_tp}, keeps the projection and
 	compression data, and applies
@@ -2563,8 +2564,8 @@ The following results separate the zero blocks from the
 	\leanok
 	\uses{thm:live_block_zero_tail_bookkeeping}
 	In the setting of Theorem~\ref{thm:live_block_zero_tail_bookkeeping}, if
-	the two zero-tail dimensions are equal, then the two live block tensors are
-	fully SameMPV$_2$-equivalent, including the length-zero case.
+	the two zero-tail dimensions are equal, then the two live block tensors have
+	the same MPV family, including the length-zero case.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2583,14 +2584,16 @@ The following results separate the zero blocks from the
 	If two tensors generate the same MPV family, then each tensor admits a blocked
 	decomposition into a zero-tail tensor plus nonzero left-canonical live blocks
 	with primitive transfer maps and positive bond dimensions. The theorem also
-	retains the blocked SameMPV$_2$ relations supplied by the original equality.
+	retains, for each blocking period, the relation that the blocked tensors
+	generate the same MPV family.
 \end{theorem}
 
 \begin{proof}\leanok
 	\uses{thm:tp_primitive_blockdecomp}
 	Apply Theorem~\ref{thm:tp_primitive_blockdecomp} separately to the two
 	tensors and keep the zero-tail MPV equations returned by that theorem. The
-	blocked SameMPV$_2$ relations follow by blocking the original equality.
+	property that the blocked tensors generate the same MPV family follows by
+	blocking the original equality.
 \end{proof}
 
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1402,6 +1402,26 @@ The following results separate the zero blocks from the
 	Apply Theorem~\ref{thm:cyclic_sector_decomp_after_blocking}.
 \end{proof}
 
+\begin{theorem}[Cyclic sector decomposition with primitive irreducible sectors]%
+\label{thm:cyclic_sector_decomp_irr_tp_prim_irr}
+	\lean{MPSTensor.exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor}
+	\leanok
+	\uses{thm:cyclic_sector_decomp_after_blocking, thm:blocked_sector_unconditional}
+	Let $A$ be a left-canonical irreducible tensor. Then there is a period
+	$m \ge 1$ and a unit-weight decomposition of $A^{[m]}$ into sector blocks
+	$(C_k)_{k=1}^m$ such that every $C_k$ is left-canonical, has primitive
+	transfer map, is tensor-irreducible, and has nonzero bond dimension.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:cyclic_sector_decomp_after_blocking, thm:blocked_sector_unconditional}
+	The proof repeats the cyclic-sector construction of
+	Theorem~\ref{thm:cyclic_sector_decomp_irr_tp}, keeps the projection and
+	compression data, and applies
+	Theorem~\ref{thm:blocked_sector_unconditional} to the resulting
+	sector blocks.
+\end{proof}
+
 \subsection{Sector irreducibility helpers}%
 \label{sec:sector_irreducibility_helpers}
 
@@ -2517,6 +2537,62 @@ The following results separate the zero blocks from the
 	\uses{thm:tp_primitive_blockdecomp}
 	Apply Theorem~\ref{thm:tp_primitive_blockdecomp} separately to the two tensors.
 \end{proof}
+
+\begin{theorem}[Zero-tail bookkeeping for live block tensors]%
+\label{thm:live_block_zero_tail_bookkeeping}
+	\lean{MPSTensor.liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂}
+	\leanok
+	\uses{def:same_mpv2, def:zero_mps_tensor, def:tensor_from_blocks}
+	Suppose two tensors have the same MPV family and each is expressed as a
+	zero-tail tensor plus a weighted live block tensor. Then the two live block
+	tensors agree on every positive system size, and at size $0$ the equality is
+	exactly the equality of the two zero-tail contributions plus the two live
+	bond-dimension traces.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{def:zero_mps_tensor}
+	For $N>0$, the MPV of a zero-tail tensor is zero, so the two decompositions
+	can be compared directly through the common MPV family. For $N=0$, the
+	zero-tail MPV is its bond dimension, giving the stated bookkeeping identity.
+\end{proof}
+
+\begin{theorem}[Equal zero tails give full live MPV equality]%
+\label{thm:live_block_same_mpv_zero_tail_eq}
+	\lean{MPSTensor.liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq}
+	\leanok
+	\uses{thm:live_block_zero_tail_bookkeeping}
+	In the setting of Theorem~\ref{thm:live_block_zero_tail_bookkeeping}, if
+	the two zero-tail dimensions are equal, then the two live block tensors are
+	fully SameMPV$_2$-equivalent, including the length-zero case.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:live_block_zero_tail_bookkeeping}
+	The positive-length cases are exactly the first conclusion of
+	Theorem~\ref{thm:live_block_zero_tail_bookkeeping}. At $N=0$, substitute
+	the equality of zero-tail dimensions into the bookkeeping identity and cancel
+	the common scalar term.
+\end{proof}
+
+\begin{theorem}[Structural after-blocking form with zero-tail equations]%
+\label{thm:ft_after_blocking_structural_zero_tail}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_structural_with_zeroTail}
+	\leanok
+	\uses{thm:tp_primitive_blockdecomp, def:same_mpv2, def:zero_mps_tensor}
+	If two tensors generate the same MPV family, then each tensor admits a blocked
+	decomposition into a zero-tail tensor plus nonzero left-canonical live blocks
+	with primitive transfer maps and positive bond dimensions. The theorem also
+	retains the blocked SameMPV$_2$ relations supplied by the original equality.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:tp_primitive_blockdecomp}
+	Apply Theorem~\ref{thm:tp_primitive_blockdecomp} separately to the two
+	tensors and keep the zero-tail MPV equations returned by that theorem. The
+	blocked SameMPV$_2$ relations follow by blocking the original equality.
+\end{proof}
+
 
 \section{Open directions}\label{sec:open_directions}
 


### PR DESCRIPTION
## Summary

Advances #877 / #652 by exposing the nonzero-sector and zero-tail interfaces needed before the PR #935 overlap-span comparison can be applied, without hiding Slot G's overlap/span hypotheses.

Lean declarations added:

- `MPSTensor.exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
  - public one-block cyclic-sector API: TP irreducible input -> a positive period and sector blocks that are TP, primitive, tensor-irreducible, and nonzero-dimensional.
- `MPSTensor.liveBlock_positive_sameMPV₂_and_zeroTail_accounting_of_sameMPV₂`
  - if equal-MPV tensors are each `zeroTail + livePart`, the nonzero parts agree for all positive lengths and the `N = 0` equation is recorded explicitly.
- `MPSTensor.liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq`
  - equal zero-tail dimensions upgrade the previous positive-length equality to full live `SameMPV₂`.
- `MPSTensor.fundamentalTheorem_after_blocking_1606_structural_with_zeroTail`
  - structural wrapper retaining the zero-tail MPV equations from the one-sided after-blocking reduction plus the blocked `SameMPV₂` relations.

Blueprint entries were added in `blueprint/src/chapter/ch08_canonical.tex` for all four checked declarations, and `audits/2026-04-26_issue877_common_live_blocks.md` records the remaining multi-block common-period flattening blocker and the `N=0` zero-tail boundary.

## Scope / honesty

This does **not** close #877 or #652. It also does not assume or discharge `SectorBasisOverlapSpanHypotheses`; Slot G owns those. The remaining nonzero-block step is the dependent-index/common-period flattening of all per-nonzero-block cyclic sectors into one exact common physical blocking level, followed by the zero-tail `N=0` resolution or a positive-length sector-comparison variant.

Refs #877. Parent #652. Related follow-ups: #942, #943, #944.

## Validation

- `lake build TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` ✅
  - Replayed only pre-existing long-line warnings in `CyclicSectorDecomposition.lean`.
- `lake build TNLean` ✅
  - Existing unrelated `sorry` warnings replayed in pre-existing files; pre-existing long-line warnings in `CyclicSectorDecomposition.lean` replayed.
- `cd blueprint && leanblueprint web && leanblueprint checkdecls` ✅
- Lean diagnostics:
  - `StructuralTheorem.lean`: clean
  - `CyclicSectorDecomposition.lean`: only four pre-existing long-line warnings
- `git diff --check` ✅
- Touched-file forbidden-token scan for `sorry|admit|axiom|native_decide|unsafe` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive, kernel-checked Lean theorems plus documentation/audit updates, with minimal impact on existing APIs aside from exposing stronger interfaces for later proofs.
> 
> **Overview**
> Adds a new public one-block cyclic-sector theorem, `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`, which upgrades the existing cyclic sector decomposition API to also return *primitive* and tensor-*irreducible* sector blocks with positive bond dimension.
> 
> Introduces explicit “zero-tail vs nonzero-block” accounting lemmas: `liveBlock_positive_sameMPV₂_and_zeroTail_accounting_of_sameMPV₂` (nonzero parts match for all `N>0`, and records the exact `N=0` scalar equation) and `liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq` (zero-tail equality upgrades this to full `SameMPV₂` for the nonzero parts). It also adds `fundamentalTheorem_after_blocking_1606_structural_with_zeroTail`, a strengthened structural wrapper that retains the per-side zero-tail MPV equations alongside the blocked `SameMPV₂` relations.
> 
> Updates the blueprint with new theorem entries and adds an audit note documenting the remaining multi-block flattening/`N=0` zero-tail blocker for issue #877.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8df6b84a00a162f1b20fda8be76f33dc01f632ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->