### PR TITLE
feat(MPS/ParentHamiltonian): add scalar-closure algebraic endgame

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -41,6 +41,8 @@ with the periodic boundary condition:
   of cyclic window ground submodules
 * `MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective` — cyclic
   normal-range constraints imply open-chain ground-space membership
+* `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes`
+  — the algebraic MPV-line endgame once long-word commutation is known
 * `MPSTensor.groundSpace_unique_periodic` — uniqueness on the periodic chain
 * `MPSTensor.parentHamiltonian_unique_gs_injective` — uniqueness for `2L₀` sites
 * `MPSTensor.parentHamiltonian_unique_gs_normal` — optimal uniqueness for `L₀+1` sites
@@ -563,6 +565,37 @@ theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
   have hMirror := wrapping_window_mirror_compatibility_of_isNBlkInjective
     (A := A) hInj hL₀ hM (YAt mirrorPos) (fun τ σ_w => hYAt mirrorPos τ σ_w)
   exact ⟨YAt wrapPos, YAt mirrorPos, hWrap, hMirror⟩
+
+/-- Long-word commutation is enough to place an open-chain boundary vector in the
+periodic MPV line.
+
+After the reduced wrapped-boundary compatibilities have been converted into a
+family of identities `X A^ω = A^ω X` for one word length `m ≥ L₀`, the existing
+block-stripping theorem makes `X` commute with the full matrix algebra.  Hence
+`X` is scalar and `groundSpaceMap A N X` is a scalar multiple of the MPV. -/
+theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes
+    {A : MPSTensor d D} {L₀ m N : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hm : L₀ ≤ m)
+    {X : Matrix (Fin D) (Fin D) ℂ}
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X) :
+    groundSpaceMap A N X ∈ mpvSubmodule A N := by
+  have hAll : ∀ M : Matrix (Fin D) (Fin D) ℂ, X * M = M * X :=
+    commutes_all_of_commutes_long_words_of_isNBlkInjective
+      (A := A) hInj hL₀ hm hComm
+  have hCenter : X ∈ Set.center (Matrix (Fin D) (Fin D) ℂ) := by
+    rw [Semigroup.mem_center_iff]
+    intro M
+    exact (hAll M).symm
+  rw [Matrix.center_eq_range] at hCenter
+  obtain ⟨c, hc⟩ := hCenter
+  have hX_eq : X = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [← hc, Matrix.scalar_apply, ← Matrix.smul_one_eq_diagonal]
+  rw [mpvSubmodule, Submodule.mem_span_singleton]
+  refine ⟨c, ?_⟩
+  ext σ
+  simp only [groundSpaceMap_apply, Pi.smul_apply, smul_eq_mul, mpv, coeff]
+  rw [hX_eq, Algebra.mul_smul_comm, mul_one, Matrix.trace_smul, smul_eq_mul]
 
 /-- Range-reduction bridge for normal tensors.
 

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -6,6 +6,7 @@ import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.FundamentalTheorem.FiniteLength
+import TNLean.Wielandt.RectangularSpan.Basic
 
 /-!
 # Wrapping window argument for periodic MPS chains
@@ -44,6 +45,8 @@ proceeds as follows:
 
 * `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`
   — block injectivity turns long-word commutation into generator commutation
+* `MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul`
+  — padding short complement annihilation to a full block-injective word span
 * `MPSTensor.boundary_matrix_commutes` — if `groundSpaceMap A N X` lies in
   every cyclic window's ground space, then `X` commutes with all `A_j`.
 
@@ -518,6 +521,65 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes
   intro j
   exact commutes_all_of_commutes_long_words_of_isNBlkInjective
     (A := A) hInj hL₀ hm hComm (A j)
+
+/-- If left multiplication by `Z` annihilates every word product of length `k`,
+and words of some longer length `n` span the full matrix algebra, then `Z = 0`.
+
+This is the padding form needed in the normal wrapped-boundary closure: an
+annihilation relation obtained for a short complement word can be multiplied by
+all padding words up to any length whose exact word span is `⊤`. -/
+theorem eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top
+    {A : MPSTensor d D} {k n : ℕ} {Z : Matrix (Fin D) (Fin D) ℂ}
+    (htop : wordSpan A n = ⊤) (hkn : k ≤ n)
+    (hzero : ∀ σ : Fin k → Fin d, Z * evalWord A (List.ofFn σ) = 0) :
+    Z = 0 := by
+  have hzero_span : ∀ M ∈ wordSpan A n, Z * M = 0 := by
+    apply Submodule.span_induction
+    · intro M hM
+      rcases hM with ⟨σ, rfl⟩
+      let w := List.ofFn σ
+      have htake_len : (w.take k).length = k := by
+        rw [List.length_take]
+        have hwlen : w.length = n := by simp [w]
+        omega
+      let σk : Fin k → Fin d := fun i =>
+        (w.take k).get ⟨i.val, by simp [htake_len]⟩
+      have hσk : List.ofFn σk = w.take k := by
+        simpa [σk, htake_len] using (List.ofFn_get (w.take k))
+      have hprefix : Z * evalWord A (w.take k) = 0 := by
+        simpa [hσk] using hzero σk
+      calc
+        Z * evalWord A w = Z * evalWord A (w.take k ++ w.drop k) := by
+          rw [List.take_append_drop k w]
+        _ = Z * (evalWord A (w.take k) * evalWord A (w.drop k)) := by
+          rw [evalWord_append]
+        _ = (Z * evalWord A (w.take k)) * evalWord A (w.drop k) := by
+          rw [Matrix.mul_assoc]
+        _ = 0 := by rw [hprefix, zero_mul]
+    · simp
+    · intro M₁ M₂ _ _ h₁ h₂
+      simp [Matrix.mul_add, h₁, h₂]
+    · intro c M _ hM
+      simp [hM]
+  have h1 : Z * (1 : Matrix (Fin D) (Fin D) ℂ) = 0 :=
+    hzero_span 1 (htop ▸ Submodule.mem_top)
+  simpa using h1
+
+/-- Block-injective padding variant of
+`eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top`.
+
+If `A` is `L₀`-block-injective, then every positive multiple of `L₀` has full
+word span. Hence an annihilation relation at length `k` already forces `Z = 0`
+as soon as `k` is bounded by such a multiple. -/
+theorem eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
+    {A : MPSTensor d D} {L₀ k q : ℕ} (hInj : IsNBlkInjective A L₀)
+    (hq : 1 ≤ q) (hkq : k ≤ q * L₀) {Z : Matrix (Fin D) (Fin D) ℂ}
+    (hzero : ∀ σ : Fin k → Fin d, Z * evalWord A (List.ofFn σ) = 0) :
+    Z = 0 := by
+  exact eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top
+    (A := A) (k := k) (n := q * L₀)
+    (wordSpan_top_of_mul A ((wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj) q hq)
+    hkq hzero
 
 set_option maxHeartbeats 800000 in
 -- The double spanning argument over window tails and complements creates large

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -6,7 +6,7 @@ import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.FundamentalTheorem.FiniteLength
-import TNLean.Wielandt.RectangularSpan.Basic
+import TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
 
 /-!
 # Wrapping window argument for periodic MPS chains

--- a/TNLean/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/Basic.lean
@@ -25,7 +25,6 @@ live in `TNLean.Wielandt.RectangularSpan.Growth` and
 
 ## Main results
 
-- `wordSpan_top_of_mul`
 - `isNormal_blockTensor`
 - `blockTensor_single_eigenvector`
 - `encodeBlock`, `blockTensor_apply_encodeBlock`
@@ -40,40 +39,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ## Section 1: wordSpan at multiples -/
-
-/-- Helper: ⊤ * ⊤ = ⊤ for submodules of the matrix algebra. -/
-private theorem top_mul_top_eq_top :
-    (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) *
-    (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) = ⊤ := by
-  apply eq_top_iff.mpr
-  intro M _
-  rw [show M = M * 1 by simp]
-  exact Submodule.mul_mem_mul Submodule.mem_top Submodule.mem_top
-
-/-- If `wordSpan A N = ⊤`, then `wordSpan A (k * N) = ⊤` for any `k ≥ 1`. -/
-theorem wordSpan_top_of_mul (A : MPSTensor d D) {N : ℕ}
-    (htop : wordSpan A N = ⊤) :
-    ∀ k : ℕ, 1 ≤ k → wordSpan A (k * N) = ⊤ := by
-  intro k hk
-  induction k with
-  | zero => omega
-  | succ k ih =>
-    by_cases hk0 : k = 0
-    · simp [hk0, htop]
-    · have hkge : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk0
-      have hih : wordSpan A (k * N) = ⊤ := ih hkge
-      have hmul : wordSpan A (k * N) * wordSpan A N ≤ wordSpan A (k * N + N) :=
-        wordSpan_mul_le A (k * N) N
-      have htoptop : wordSpan A (k * N) * wordSpan A N = ⊤ := by
-        rw [hih, htop]; exact top_mul_top_eq_top
-      have hle : (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) ≤ wordSpan A (k * N + N) := by
-        rw [← htoptop]; exact hmul
-      have hlen : k * N + N = (k + 1) * N := by ring
-      rw [hlen] at hle
-      exact eq_top_iff.mpr hle
-
-/-! ## Section 2: Blocking preserves normality -/
+/-! ## Section 1: Blocking preserves normality -/
 
 /-- A word evaluation of length `(n+1)*L` factors as a product of a length-L evaluation
 and a length-`n*L` evaluation.
@@ -188,7 +154,7 @@ theorem isNormal_blockTensor (A : MPSTensor d D) (L : ℕ) (hL : 0 < L)
     eq_top_iff.mpr (htopNL ▸ hle)
   exact ⟨N₀, (wordSpan_eq_top_iff_isNBlkInjective _ N₀).mp hBtop⟩
 
-/-! ## Section 3: Eigenvector for blocked tensor -/
+/-! ## Section 2: Eigenvector for blocked tensor -/
 
 /-- Encoding a function `σ₀ : Fin L → Fin d` as a blocked index. -/
 noncomputable def encodeBlock (d L : ℕ) (σ₀ : Fin L → Fin d) :
@@ -220,7 +186,7 @@ theorem blockTensor_transpose_encodeBlock (A : MPSTensor d D) (L : ℕ)
       (evalWord A (List.ofFn σ₀))ᵀ := by
   rw [blockTensor_apply_encodeBlock]
 
-/-! ## Section 4: Rectangular span -/
+/-! ## Section 3: Rectangular span -/
 
 /-- The **rectangular span** is the image of `wordSpan A n` under
 left-multiplication by a fixed matrix `P`. -/
@@ -248,7 +214,7 @@ theorem rectSpan_finrank_le (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D)
     _ = D * D * 1 := by simp [Fintype.card_fin, Module.finrank_self]
     _ = D ^ 2 := by ring
 
-/-! ## Section 5: Cumulative rectangular span -/
+/-! ## Section 4: Cumulative rectangular span -/
 
 /-- The **cumulative rectangular span**: image of `cumulativeSpan` under left-mult by P. -/
 noncomputable def cumulativeRectSpan (P : Matrix (Fin D) (Fin D) ℂ)
@@ -294,7 +260,7 @@ theorem cumulativeRectSpan_eq_range_of_isNormal [NeZero D]
   cumulativeRectSpan_eq_range_of_cumulativeSpan_eq_top P A
     (cumulativeSpan_eq_top A hN)
 
-/-! ## Section 6: Conditional assembly (Lemma 2(b)) -/
+/-! ## Section 5: Conditional assembly (Lemma 2(b)) -/
 
 /-- **Lemma 2(b) conditional assembly.**
 
@@ -328,7 +294,7 @@ theorem wielandt_lemma2b_conditional [NeZero D]
   exact wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOne
     A φ ψ hVecSpread hRankOne hRowSpread
 
-/-! ## Section 7: Blocked assembly -/
+/-! ## Section 6: Blocked assembly -/
 
 /-- **Assembly at the blocked level.**
 

--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -35,8 +35,15 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ## Basic linear map lemmas -/
+/-! ## Main results
 
+* `MPSTensor.wordSpan_mul_le` — fixed-length word spans multiply into the span at
+  the summed length
+* `MPSTensor.wordSpan_top_of_mul` — full word span persists at positive multiples
+* `MPSTensor.wordSpan_eq_top_of_blockTensor_wordSpan_eq_top` — full blocked word
+  span gives a full unblocked word span
+
+## Basic linear map lemmas -/
 /-- The linear map `M ↦ M *ᵥ φ` for a fixed vector `φ`. -/
 def mulVecLinearMap (φ : Fin D → ℂ) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] (Fin D → ℂ) :=
@@ -92,6 +99,42 @@ theorem wordSpan_mul_le (A : MPSTensor d D) (m n : ℕ) :
       (evalWord_mem_wordSpan A (List.ofFn σ₁ ++ List.ofFn σ₂))
   -- Rewrite the product using `evalWord_append`.
   simpa [evalWord_append] using hmem
+
+/-- Helper: `⊤ * ⊤ = ⊤` for submodules of the matrix algebra. -/
+private theorem top_mul_top_eq_top :
+    (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) *
+      (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) = ⊤ := by
+  apply eq_top_iff.mpr
+  intro M _
+  simpa using
+    (Submodule.mul_mem_mul (show M ∈ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) from
+        Submodule.mem_top)
+      (show (1 : Matrix (Fin D) (Fin D) ℂ) ∈ ⊤ from Submodule.mem_top))
+
+/-- If `wordSpan A N = ⊤`, then `wordSpan A (k * N) = ⊤` for any `k ≥ 1`. -/
+theorem wordSpan_top_of_mul (A : MPSTensor d D) {N : ℕ}
+    (htop : wordSpan A N = ⊤) :
+    ∀ k : ℕ, 1 ≤ k → wordSpan A (k * N) = ⊤ := by
+  intro k hk
+  induction k with
+  | zero => omega
+  | succ k ih =>
+      by_cases hk0 : k = 0
+      · simpa [hk0] using htop
+      · have hkge : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk0
+        have hih : wordSpan A (k * N) = ⊤ := ih hkge
+        have hmul : wordSpan A (k * N) * wordSpan A N ≤ wordSpan A (k * N + N) :=
+          wordSpan_mul_le A (k * N) N
+        have htoptop : wordSpan A (k * N) * wordSpan A N = ⊤ := by
+          rw [hih, htop]
+          exact top_mul_top_eq_top
+        have hle : (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) ≤
+            wordSpan A (k * N + N) := by
+          rw [← htoptop]
+          exact hmul
+        have hlen : k * N + N = (k + 1) * N := by ring
+        rw [hlen] at hle
+        exact eq_top_iff.mpr hle
 
 /-! ## Blocking transfer: word spans for blocked tensors -/
 

--- a/audits/2026-04-22_issue588_normal_range_reduction_partial.md
+++ b/audits/2026-04-22_issue588_normal_range_reduction_partial.md
@@ -150,3 +150,39 @@ the two one-sided identities above into a long-word commutation family
 `X A^ω = A^ω X` for some positive word length (then amplify to length at least
 `L₀` if necessary) and apply
 `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`.
+
+## 2026-04-26 Wave 17A update
+
+This branch still does **not** close
+`MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`; the
+pre-existing proof placeholder remains.  It lands two small Lean pieces that
+remove algebraic endgame noise from the remaining closure-property blocker:
+
+- `MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top` and
+  `MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul` in
+  `TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`.  These formalize the
+  padding observation from the 2026-04-21 audit: if an operator annihilates all
+  complement words of length `k`, then padding to any full exact word span
+  length `n ≥ k` forces the operator to be zero; for an `L₀`-block-injective
+  tensor, any positive multiple of `L₀` is such a full span.
+- `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes`
+  in `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`.  Once the wrapped
+  boundary identities are upgraded to a long-word commutation family
+  `X A^ω = A^ω X` for some `|ω| = m ≥ L₀`, this theorem applies the existing
+  block-stripping centrality theorem and the matrix-center calculation to put
+  `Γ_N(X)` directly in `mpvSubmodule A N`.
+
+Paper anchor retained: CPGSV21 §IV.C,
+`Papers/2011.12127/TN-Review-main.tex:2078--2079`, especially
+"Once we have reached $k=L_0$, we can resort to the above Theorem, or
+alternatively apply a similar argument when closing the boundaries", and theorem
+`thm:4:unique-gs-L0_plus_1` at lines 2087--2090.
+
+Remaining blocker after Wave 17A: the genuine common-middle / closure-property
+comparison.  Starting from
+`MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`,
+one still has to turn the two one-sided identities
+`C^+_τ A_j X = Y^+_τ A_j` and `X A_j C^-_τ = A_j Y^-_τ` into long-word
+commutation for the same boundary matrix `X`.  The new MPV-line endgame shows
+that no further scalar-center work remains once that commutation family is
+available.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1039,6 +1039,27 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     injectivity, so linearity gives $XM = MX$ for every $M \in \MN{D}$.
 \end{proof}
 
+\begin{lemma}[Padded complement annihilation]
+    \label{lem:padded_complement_annihilation}
+    \lean{MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul}
+    \leanok
+    \uses{def:l_blk_injective}
+    If $A$ is $L_0$-block-injective and $q \ge 1$, then an operator $Z$ that
+    annihilates every length-$k$ word product on the left is zero whenever
+    $k \le qL_0$:
+    \[
+        Z A^w = 0 \quad (|w|=k) \qquad\Longrightarrow\qquad Z=0.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The hypothesis $\spn\{A^u: |u|=L_0\}=\MN{D}$ implies the same spanning
+    statement at every positive multiple $qL_0$.  Each length-$qL_0$ word factors
+    as a length-$k$ prefix followed by padding, so $Z$ annihilates all generators
+    of the full span and hence annihilates the identity.
+\end{proof}
+
 \begin{lemma}[Generator commutation from long-word commutation]
     \label{lem:boundary_matrix_commutes_long_words}
     \lean{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes}
@@ -1051,6 +1072,23 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     Apply Theorem~\ref{thm:block_word_strip_central} with $M = A^i$.
+\end{proof}
+
+\begin{theorem}[MPV-line endgame from long-word commutation]
+    \label{thm:ground_space_map_mpv_of_long_word_commutes}
+    \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes}
+    \leanok
+    \uses{def:mpv_submodule, thm:block_word_strip_central}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and let $m \ge L_0$.
+    If a boundary matrix $X$ commutes with every length-$m$ word product, then
+    $\Gamma_N(X)$ lies in the MPV line $\spn\{V^{(N)}(A)\}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:block_word_strip_central} makes $X$ commute with the whole
+    matrix algebra.  The center of $\MN{D}$ consists of scalar matrices, so
+    $X=c\Id$, and therefore $\Gamma_N(X)=cV^{(N)}(A)$.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%
@@ -1084,7 +1122,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{def:chain_ground_space, def:mpv_submodule, def:normal,
         def:l_blk_injective, thm:cyclic_normal_open_chain_range_reduction,
         thm:reduced_wrapped_boundary_compatibilities,
-        lem:boundary_matrix_commutes_long_words}
+        thm:ground_space_map_mpv_of_long_word_commutes}
     If $A$ is normal, $D \ge 1$, $L_0$-block-injective, with $N \ge 2$ and $L_0 < L \le N$, then
     \[
         \mathcal G_{N,L}(A) \subseteq \spn\bigl\{V^{(N)}(A)\bigr\}.
@@ -1094,14 +1132,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \notready
     \uses{thm:reduced_wrapped_boundary_compatibilities,
-        lem:boundary_matrix_commutes_long_words}
+        thm:ground_space_map_mpv_of_long_word_commutes,
+        lem:padded_complement_annihilation}
     The remaining step is the closure property from
     \cite[\S~IV.C]{Cirac2021Matrix}: Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
     supplies the two one-sided wrapped-boundary identities for the open-chain
-    boundary matrix $X$. What is still missing is the common-middle comparison
-    that turns these identities into commutation of $X$ with a sufficiently long
-    word product; Lemma~\ref{lem:boundary_matrix_commutes_long_words} would then
-    give the generator commutation used in the injective proof.
+    boundary matrix $X$. The padded-annihilation lemma records that exact
+    complement-span length mismatches are no longer the obstruction. What is
+    still missing is the common-middle comparison that turns the one-sided
+    identities into commutation of $X$ with a sufficiently long word product;
+    Theorem~\ref{thm:ground_space_map_mpv_of_long_word_commutes} would then put
+    $\Gamma_N(X)$ directly in the MPV line.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the normal case]%


### PR DESCRIPTION
## Summary

This PR advances #588 / #190 without claiming the full normal-range closure.  The existing `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` placeholder remains; no new `sorry`/`axiom`/proof-integrity workaround is introduced.

Lean additions:

- `MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top` and
  `MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul` in
  `WrappingWindow.lean`: formalize the padding argument that an operator
  annihilating all complement words of length `k` is zero once those words can be
  padded to a full exact word-span length (in particular a positive multiple of
  the block-injectivity length).
- `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes`
  in `UniqueGroundState.lean`: once the wrapped-boundary closure supplies
  long-word commutation `X A^ω = A^ω X` for some `|ω| = m ≥ L₀`, the existing
  block-stripping centrality theorem makes `X` scalar and places
  `Γ_N(X)` in `mpvSubmodule A N`.
- Blueprint Chapter 14 and the #588 audit now record these real declarations and
  sharpen the remaining blocker.

## Paper anchors

CPGSV21 §IV.C in `Papers/2011.12127/TN-Review-main.tex`:

- lines 2078--2079: “Once we have reached $k=L_0$, we can resort to the above Theorem, or alternatively apply a similar argument when closing the boundaries.”
- theorem `thm:4:unique-gs-L0_plus_1` at lines 2087--2090.

## Remaining blocker

After PR #936, `MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective` gives the two one-sided wrapped-boundary identities

```text
C⁺_τ A_j X = Y⁺_τ A_j,
X A_j C⁻_τ = A_j Y⁻_τ.
```

This PR proves the scalar/MPV-line endgame after a long-word commutation family is obtained.  What is still missing is the genuine common-middle / closure-property comparison turning the one-sided identities above into `X A^ω = A^ω X` for some word length `m ≥ L₀`.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.WrappingWindow TNLean.MPS.ParentHamiltonian.UniqueGroundState` ✅
  - only the pre-existing `UniqueGroundState.lean` target `sorry` warning
- `lake build TNLean` ✅
  - pre-existing warnings only (known sorries/long lines outside this change)
- `cd blueprint && leanblueprint web` ✅
- `cd blueprint && leanblueprint checkdecls` ✅
- `git diff --check` ✅
- touched-file proof-token scan: only the pre-existing `UniqueGroundState.lean` placeholder; added-line scan clean ✅

Refs #588, #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a few new Lean theorems and refactors lemma placement/imports, without changing any runtime code or introducing new axioms/sorries.
> 
> **Overview**
> Adds a new “long-word commutation ⇒ MPV line” endgame lemma, `groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes`, which turns the remaining periodic closure goal into proving long-word commutation for the boundary matrix.
> 
> Strengthens the wrapping-window toolbox with padding/annihilation lemmas (`eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top` and the block-injective specialization) and wires in a new import so `wordSpan_top_of_mul` is now sourced from `Wielandt/SpanGrowth/VectorToMatrixSpan` (and removed from `Wielandt/RectangularSpan/Basic`).
> 
> Updates the blueprint and issue #588 audit notes to reference these new formal statements and clarify that the normal-range reduction theorem remains unresolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be76075b68af4ab24a40fd54f2e6d0d05cf667a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->