### PR TITLE
feat(MPS/ParentHamiltonian): isolate overlap Friedrichs norm bound

### DIFF
--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -12,7 +12,9 @@ parent-Hamiltonian martingale method.  The main theorem is a purely algebraic
 quadratic-form reduction for a finite sum of symmetric projections: if the
 ordered off-diagonal terms satisfy a row-summable cross-term bound, then
 `H = ∑ i, P i` satisfies `H² ≥ γ H` as a quadratic form.  The file also records
-that commuting symmetric projections have nonnegative ordered cross terms.
+that commuting symmetric projections have nonnegative ordered cross terms, and
+converts norm-compression estimates for products of projections into the ordered
+Friedrichs cross-term bounds used by the row-sum reduction.
 
 The statements deliberately keep the MPS/Friedrichs-angle estimates as explicit
 hypotheses.  They provide the reusable projection-geometry layer into which the
@@ -43,6 +45,45 @@ theorem re_inner_apply_apply_self {P : E →ₗ[𝕜] E} (hP : P.IsSymmetricProj
 theorem re_inner_nonneg {P : E →ₗ[𝕜] E} (hP : P.IsSymmetricProjection) (v : E) :
     0 ≤ RCLike.re (⟪P v, v⟫_𝕜) :=
   hP.isPositive.re_inner_nonneg_left v
+
+/-- A norm bound on the compressed product of two projections gives the ordered
+Friedrichs lower bound.
+
+For a symmetric projection `P`, the ordered cross term satisfies
+`Re ⟪P v, Q v⟫ = Re ⟪P v, P (Q v)⟫`. Hence Cauchy--Schwarz shows that a
+bound `‖P (Q v)‖ ≤ c ‖P v‖` implies
+`Re ⟪P v, Q v⟫ ≥ -c Re ⟪P v, v⟫`. This is the finite-dimensional
+projection-geometry conversion from a principal-angle norm estimate to the
+ordered quadratic-form estimate used by the martingale row-sum argument. -/
+theorem re_inner_apply_apply_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
+    (hP : P.IsSymmetricProjection) {c : ℝ}
+    (hNorm : ∀ v : E, ‖P (Q v)‖ ≤ c * ‖P v‖) (v : E) :
+    -c * RCLike.re (⟪P v, v⟫_𝕜) ≤ RCLike.re (⟪P v, Q v⟫_𝕜) := by
+  have hPidem : P (P v) = P v := by
+    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[𝕜] E => T v)
+      hP.isIdempotentElem.eq
+  have hcompress : ⟪P v, Q v⟫_𝕜 = ⟪P v, P (Q v)⟫_𝕜 := by
+    calc
+      ⟪P v, Q v⟫_𝕜 = ⟪P (P v), Q v⟫_𝕜 := by rw [hPidem]
+      _ = ⟪P v, P (Q v)⟫_𝕜 := hP.isSymmetric (P v) (Q v)
+  have hdiag : RCLike.re (⟪P v, v⟫_𝕜) = ‖P v‖ ^ 2 := by
+    rw [← hP.re_inner_apply_apply_self v, inner_self_eq_norm_sq]
+  have hre_lower : -‖⟪P v, P (Q v)⟫_𝕜‖ ≤ RCLike.re (⟪P v, P (Q v)⟫_𝕜) := by
+    have h := RCLike.re_le_norm (-(⟪P v, P (Q v)⟫_𝕜))
+    have h' : -RCLike.re (⟪P v, P (Q v)⟫_𝕜) ≤ ‖⟪P v, P (Q v)⟫_𝕜‖ := by
+      simpa using h
+    exact neg_le.mp h'
+  have hnorm_inner : ‖⟪P v, P (Q v)⟫_𝕜‖ ≤ c * ‖P v‖ ^ 2 := by
+    calc
+      ‖⟪P v, P (Q v)⟫_𝕜‖ ≤ ‖P v‖ * ‖P (Q v)‖ := norm_inner_le_norm (P v) (P (Q v))
+      _ ≤ ‖P v‖ * (c * ‖P v‖) :=
+          mul_le_mul_of_nonneg_left (hNorm v) (norm_nonneg (P v))
+      _ = c * ‖P v‖ ^ 2 := by ring
+  calc
+    -c * RCLike.re (⟪P v, v⟫_𝕜) = -(c * ‖P v‖ ^ 2) := by rw [hdiag]; ring
+    _ ≤ -‖⟪P v, P (Q v)⟫_𝕜‖ := neg_le_neg hnorm_inner
+    _ ≤ RCLike.re (⟪P v, P (Q v)⟫_𝕜) := hre_lower
+    _ = RCLike.re (⟪P v, Q v⟫_𝕜) := by rw [← hcompress]
 
 /-- Commuting symmetric projections have nonnegative ordered cross terms.
 
@@ -267,6 +308,37 @@ theorem quadraticForm_sum_projections_of_finite_overlap {γ : ℝ} (hγle : γ �
     · simpa [c, hoverlap] using hFriedrichs i j hij hoverlap v
     · simpa [c, hoverlap] using hDisjoint i j hij hoverlap v
   exact quadraticForm_sum_projections_of_ordered_rowSum hγle P hP c hRow hCross
+
+/-- Finite-overlap row-sum reduction from a norm-compression Friedrichs bound.
+
+For symmetric projections, a principal-angle style estimate
+`‖P_i (P_j v)‖ ≤ (1 - γ) m⁻¹ ‖P_i v‖` on every interacting pair implies the
+ordered cross-term estimate used by
+`quadraticForm_sum_projections_of_finite_overlap`.  Thus the same finite-overlap
+quadratic-form conclusion follows from this norm formulation, together with the
+usual row-cardinality and noninteraction nonnegativity hypotheses. -/
+theorem quadraticForm_sum_projections_of_finite_overlap_norm_bound {γ : ℝ} (hγle : γ ≤ 1)
+    (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)
+    (overlaps : ι → ι → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (hDisjoint : ∀ i j, j ∈ Finset.univ.erase i → ¬ overlaps i j →
+      ∀ v : E, 0 ≤ (⟪P i v, P j v⟫_ℂ).re)
+    (hOverlapNorm : ∀ i j, j ∈ Finset.univ.erase i → overlaps i j →
+      ∀ v : E,
+        ‖P i (P j v)‖ ≤ ((1 - γ) * ((m : ℝ)⁻¹)) * ‖P i v‖) :
+    ∀ v : E,
+      γ * (⟪(∑ i, P i) v, v⟫_ℂ).re ≤
+        (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := by
+  refine quadraticForm_sum_projections_of_finite_overlap hγle P hP overlaps hm hCard
+    hDisjoint ?_
+  intro i j hij hoverlap v
+  have hraw :
+      -((1 - γ) * ((m : ℝ)⁻¹)) * (⟪P i v, v⟫_ℂ).re ≤
+        (⟪P i v, P j v⟫_ℂ).re :=
+    (hP i).re_inner_apply_apply_ge_neg_of_norm_apply_le
+      (hOverlapNorm i j hij hoverlap) v
+  convert hraw using 1
+  ring
 
 end OffDiagonal
 

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -52,7 +52,7 @@ Friedrichs lower bound.
 For a symmetric projection `P`, the ordered cross term satisfies
 `Re ⟪P v, Q v⟫ = Re ⟪P v, P (Q v)⟫`. Hence Cauchy--Schwarz shows that a
 bound `‖P (Q v)‖ ≤ c ‖P v‖` implies
-`Re ⟪P v, Q v⟫ ≥ -c Re ⟪P v, v⟫`. This is the finite-dimensional
+`Re ⟪P v, Q v⟫ ≥ -c Re ⟪P v, v⟫`. This is the
 projection-geometry conversion from a principal-angle norm estimate to the
 ordered quadratic-form estimate used by the martingale row-sum argument. -/
 theorem re_inner_apply_apply_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -2,8 +2,8 @@
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.Defs
+import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 
 /-!
 # Cyclic window infrastructure for periodic MPS chains

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import TNLean.MPS.ParentHamiltonian.Defs
 
 /-!
 # Cyclic window infrastructure for periodic MPS chains
@@ -238,6 +239,29 @@ theorem eq_cyclic_site_of_offset_eq {N : ℕ} (hN : 0 < N) {i k : Fin N} {r : �
       rw [hsum, Nat.add_mod_right]
       exact Nat.mod_eq_of_lt k.isLt
     exact hmod.symm
+
+/-- Membership in a cyclic-window support is equivalently the cyclic offset from
+the starting site being smaller than the window length, in the non-repeating regime
+`L ≤ N`. -/
+theorem mem_cyclicWindowSupport_iff {N L : ℕ} (hLN : L ≤ N) (i k : Fin N) :
+    k ∈ cyclicWindowSupport N L i ↔ ((k.val + N - i.val) % N < L) := by
+  constructor
+  · intro hk
+    rw [cyclicWindowSupport, Finset.mem_image] at hk
+    rcases hk with ⟨r, hrange, hr⟩
+    have hrL : r < L := Finset.mem_range.mp hrange
+    have hrN : r < N := Nat.lt_of_lt_of_le hrL hLN
+    rw [← hr]
+    change (((i.val + r) % N + N - i.val) % N) < L
+    rw [offset_mod_eq i.isLt hrN]
+    exact hrL
+  · intro hk
+    rw [cyclicWindowSupport, Finset.mem_image]
+    let r := (k.val + N - i.val) % N
+    refine ⟨r, Finset.mem_range.mpr hk, ?_⟩
+    have hsite :=
+      (eq_cyclic_site_of_offset_eq (Fin.pos i) (i := i) (k := k) (r := r) rfl).symm
+    simpa [cyclicForwardSite, r] using hsite
 
 @[simp]
 theorem cyclicForwardSite_zero {N : ℕ} (i : Fin N) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -1178,25 +1178,17 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
-  refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
-  intro N hLN v
-  have hLpos : (0 : ℝ) < (L : ℝ) := by
-    exact_mod_cast (Nat.zero_lt_of_lt hL)
-  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
-    exact_mod_cast (Nat.le_of_lt hL)
-  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
-    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
-    rw [div_le_iff₀ hden]
-    nlinarith [hLge_one]
-  have hm : 0 < 2 * (L - 1) :=
-    Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
-  have hLN' : L ≤ N := by omega
-  exact parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound
-    A L N hγle (cyclicWindowsOverlap N L) hm
-    (fun i => cyclicWindowsOverlap_card_le hLN hL i)
-    (fun _i _j _hij hno v =>
-      localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A hLN' hno v)
-    (fun i j hij hoverlap v => hOverlapNorm N hLN i j hij hoverlap v) v
+  refine parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs A L hL ?_
+  intro N hLN i j hij hoverlap v
+  have hCross :
+      -((1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+          (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) *
+        (⟪localTermES A L i v, v⟫_ℂ).re ≤
+          (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re :=
+    (localTermES_isSymmetricProjection A L i).re_inner_apply_apply_ge_neg_of_norm_apply_le
+      (hOverlapNorm N hLN i j hij hoverlap) v
+  convert hCross using 1
+  ring
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -71,6 +71,9 @@ concrete Friedrichs-angle/row-sum lower bound that
 * `MPSTensor.localTermES_re_inner_nonneg_of_cyclic_windows_disjoint` — disjoint
   cyclic windows give commuting transported local projections and hence
   nonnegative ordered cross terms.
+* `MPSTensor.localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap` — failure
+  of the concrete cyclic-support overlap predicate gives the same nonnegative
+  ordered cross term.
 * `MPSTensor.parentHamiltonianES_gap_bound_of_quadratic_form` — the explicit
   reduction from the parent-Hamiltonian gap statement to the uniform
   Friedrichs/martingale quadratic-form estimate.
@@ -83,6 +86,9 @@ concrete Friedrichs-angle/row-sum lower bound that
 * `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs` — the
   same reduction specialized to the concrete cyclic-window overlap predicate and
   its `2 * (L - 1)` row-cardinality bound.
+* `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound` —
+  the final reduction from the overlapping-window norm-compression Friedrichs
+  estimate to the explicit gap bound.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
   Friedrichs-angle bound recorded in
@@ -788,6 +794,27 @@ theorem localTermES_re_inner_nonneg_of_cyclic_windows_disjoint {N : ℕ}
     (localTermES_isSymmetricProjection A L j)
     (localTermES_commute_of_cyclic_windows_disjoint A hLN hij) v
 
+/-- If the concrete cyclic supports do not overlap, then the offset-based
+site-disjointness predicate holds. -/
+theorem CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap {N L : ℕ} (hLN : L ≤ N)
+    {i j : Fin N} (hij : ¬ cyclicWindowsOverlap N L i j) :
+    CyclicWindowsDisjoint L i j := by
+  intro k hki hkj
+  exact hij ⟨k, (mem_cyclicWindowSupport_iff hLN i k).2 hki,
+    (mem_cyclicWindowSupport_iff hLN j k).2 hkj⟩
+
+/-- Non-overlap positivity for the concrete cyclic-window overlap predicate.
+
+When `cyclicWindowsOverlap N L i j` fails and `L ≤ N`, the two windows are
+site-disjoint, so the transported local terms commute and have nonnegative ordered
+cross term. -/
+theorem localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap {N : ℕ}
+    (A : MPSTensor d D) {L : ℕ} (hLN : L ≤ N) {i j : Fin N}
+    (hij : ¬ cyclicWindowsOverlap N L i j) (v : EuclideanSpace ℂ (Cfg d N)) :
+    0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re :=
+  localTermES_re_inner_nonneg_of_cyclic_windows_disjoint A hLN
+    (CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap hLN hij) v
+
 /-- The full transported parent Hamiltonian is positive because it is a finite
 sum of positive transported local terms. -/
 theorem parentHamiltonianES_isPositive (A : MPSTensor d D) (L N : ℕ) :
@@ -987,6 +1014,37 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
       (fun i : Fin N => localTermES A L i) hProj overlaps hm hCard hDisjoint
       hFriedrichs v)
 
+/-- Fixed-chain martingale quadratic-form estimate from finite-overlap
+norm-compression Friedrichs data.
+
+For each overlapping pair, it is enough to bound the compressed product
+`‖hᵢ (hⱼ v)‖` by `(1 - γ) / m` times `‖hᵢ v‖`.  The abstract projection-geometry
+lemma converts this principal-angle style norm estimate into the ordered
+cross-term bound consumed by the finite-overlap row-sum reduction. -/
+theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound
+    (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
+    (overlaps : Fin N → Fin N → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hCard : ∀ i : Fin N,
+      ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (hDisjoint : ∀ i j : Fin N, j ∈ Finset.univ.erase i → ¬ overlaps i j →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re)
+    (hOverlapNorm : ∀ i j : Fin N, j ∈ Finset.univ.erase i → overlaps i j →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        ‖localTermES A L i (localTermES A L j v)‖ ≤
+          ((1 - γ) * ((m : ℝ)⁻¹)) * ‖localTermES A L i v‖) :
+    ∀ v : EuclideanSpace ℂ (Cfg d N),
+      γ * (⟪parentHamiltonianES A L N v, v⟫_ℂ).re ≤
+        (⟪parentHamiltonianES A L N v,
+          parentHamiltonianES A L N v⟫_ℂ).re := by
+  intro v
+  simpa [parentHamiltonianES_eq_sum_localTermES A L N] using
+    (ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound
+      (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
+      (fun i : Fin N => localTermES A L i)
+      (fun i : Fin N => localTermES_isSymmetricProjection A L i) overlaps hm hCard
+      hDisjoint hOverlapNorm v)
+
 /-- Uniform explicit gap-bound reduction from finite-overlap Friedrichs data.
 
 For parent-Hamiltonian windows of length `L`, the expected finite-range bound is
@@ -1070,6 +1128,75 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
     (fun N _hLN i => localTermES_isSymmetricProjection A L i)
     (fun N hLN i => cyclicWindowsOverlap_card_le hLN hL i)
     hDisjoint hFriedrichs
+
+/-- Uniform explicit gap-bound reduction from the remaining overlapping-window
+Friedrichs estimate.
+
+The concrete cyclic-window row-cardinality bound, local symmetric-projection
+structure, and non-overlap positivity are already proved.  Consequently it is
+enough to assume the displayed ordered Friedrichs lower bound only for pairs whose
+cyclic supports overlap. -/
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (hFriedrichs : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹) *
+                (⟪localTermES A L i v, v⟫_ℂ).re ≤
+            (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  refine parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs A L hL ?_ hFriedrichs
+  intro N hLN _i _j _hij hno v
+  have hLN' : L ≤ N := by omega
+  exact localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A hLN' hno v
+
+/-- Uniform explicit gap-bound reduction from a norm-compression form of the
+overlapping-window Friedrichs estimate.
+
+It suffices to prove that for every overlapping off-diagonal pair the compressed
+product of transported local projections satisfies
+`‖hᵢ (hⱼ v)‖ ≤ (1 - 1/(4L)) / (2(L-1)) * ‖hᵢ v‖`.  The abstract projection
+geometry converts this principal-angle style condition into the ordered
+Friedrichs lower bound and then applies the finite-overlap martingale reduction. -/
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            ((1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) * ‖localTermES A L i v‖) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
+  intro N hLN v
+  have hLpos : (0 : ℝ) < (L : ℝ) := by
+    exact_mod_cast (Nat.zero_lt_of_lt hL)
+  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
+    exact_mod_cast (Nat.le_of_lt hL)
+  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
+    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
+    rw [div_le_iff₀ hden]
+    nlinarith [hLge_one]
+  have hm : 0 < 2 * (L - 1) :=
+    Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
+  have hLN' : L ≤ N := by omega
+  exact parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound
+    A L N hγle (cyclicWindowsOverlap N L) hm
+    (fun i => cyclicWindowsOverlap_card_le hLN hL i)
+    (fun _i _j _hij hno v =>
+      localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A hLN' hno v)
+    (fun i j hij hoverlap v => hOverlapNorm N hLN i j hij hoverlap v) v
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 

--- a/audits/2026-04-26_issue460_friedrichs_overlap_reduction.md
+++ b/audits/2026-04-26_issue460_friedrichs_overlap_reduction.md
@@ -1,9 +1,8 @@
 # Issue #460 — overlapping-window Friedrichs estimate reduction (2026-04-26)
 
 This note records the checked reduction added on the `wave17-C-460-friedrichs-overlap`
-branch.  It does not claim the full MPS Friedrichs-angle estimate; it isolates the
-last analytic statement in a norm-compression form that matches the martingale
-criterion.
+branch.  It does not claim the full MPS Friedrichs-angle estimate; it isolates a
+sufficient norm-compression input that feeds the martingale criterion.
 
 ## Paper anchor
 
@@ -19,7 +18,8 @@ The source paper discussion is `Papers/2011.12127/TN-Review-main.tex` §4.1
 
 The new Lean statements preserve this split: non-overlap positivity and row sums
 are discharged by existing local/cyclic-window theorems, while the remaining
-overlap condition is stated as a principal-angle-style norm bound.
+overlap condition is exposed both as an ordered Friedrichs lower bound and as a
+sufficient principal-angle-style norm bound.
 
 ## Checked declarations added
 
@@ -85,15 +85,16 @@ Blueprint sync:
 
 ## Remaining mathematical statement
 
-For injective MPS parent-Hamiltonian local terms, the remaining analytic theorem is:
-for all `N` with `2 * L ≤ N`, all off-diagonal `i,j` with
-`cyclicWindowsOverlap N L i j`, and all vectors `v`, prove
+For injective MPS parent-Hamiltonian local terms, the checked route still needs the
+paper's overlapping-window Friedrichs estimate.  One sufficient norm-compression
+form isolated by this branch is: for all `N` with `2 * L ≤ N`, all off-diagonal
+`i,j` with `cyclicWindowsOverlap N L i j`, and all vectors `v`, prove
 
 ```text
 ‖localTermES A L i (localTermES A L j v)‖
   ≤ (1 - 1/(4L)) * (2(L-1))⁻¹ * ‖localTermES A L i v‖.
 ```
 
-Equivalently, one may prove the ordered quadratic-form lower bound obtained from
-this norm estimate.  This is exactly the principal-angle/Friedrichs-angle content
-of the paper’s martingale condition; no new proof holes or axioms were introduced.
+Alternatively, one may prove the ordered quadratic-form lower bound directly.
+This is the principal-angle/Friedrichs-angle content of the paper's martingale
+condition; no new proof holes or axioms were introduced.

--- a/audits/2026-04-26_issue460_friedrichs_overlap_reduction.md
+++ b/audits/2026-04-26_issue460_friedrichs_overlap_reduction.md
@@ -1,0 +1,99 @@
+# Issue #460 — overlapping-window Friedrichs estimate reduction (2026-04-26)
+
+This note records the checked reduction added on the `wave17-C-460-friedrichs-overlap`
+branch.  It does not claim the full MPS Friedrichs-angle estimate; it isolates the
+last analytic statement in a norm-compression form that matches the martingale
+criterion.
+
+## Paper anchor
+
+The source paper discussion is `Papers/2011.12127/TN-Review-main.tex` §4.1
+`Gaps`, especially:
+
+- line 2175: “`$\sum''h_ih_j\ge0$`”, the non-overlap positivity contribution;
+- lines 2176--2179, equation `eq:4:martingale-2`:
+  “`h_ih_j+h_jh_i \ge -c_{ij} (1-\gamma)(h_i+h_j)`” for overlapping pairs;
+- line 2180: the coefficients `c_{ij}` “`has to be chosen to add up to 1`”;
+- line 2182: the condition depends on “`the principal angles between
+  $\ker h_i$ and $\ker h_j$`”.
+
+The new Lean statements preserve this split: non-overlap positivity and row sums
+are discharged by existing local/cyclic-window theorems, while the remaining
+overlap condition is stated as a principal-angle-style norm bound.
+
+## Checked declarations added
+
+### Projection geometry
+
+- `LinearMap.IsSymmetricProjection.re_inner_apply_apply_ge_neg_of_norm_apply_le`
+  proves the pointwise conversion
+  `‖P (Q v)‖ ≤ c ‖P v‖` ⇒
+  `Re ⟪P v, Q v⟫ ≥ -c Re ⟪P v, v⟫` for a symmetric projection `P`.
+  The proof uses symmetric idempotence to replace the cross term by
+  `Re ⟪P v, P(Q v)⟫`, Cauchy--Schwarz, and
+  `Re ⟪P v, v⟫ = ‖P v‖²`.
+- `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound`
+  feeds this conversion into the already-checked finite-overlap row-sum theorem.
+
+Blueprint sync: `blueprint/src/chapter/ch14_parent_hamiltonian.tex` line 1901,
+label `lem:finite_overlap_projection_norm_reduction`, quote:
+“`interacting pairs satisfy the norm-compression estimate`”.
+
+### Cyclic-window support/non-overlap bridge
+
+- `MPSTensor.mem_cyclicWindowSupport_iff` identifies support membership with the
+  cyclic-offset inequality `< L` under `L ≤ N`.
+- `MPSTensor.CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap` converts failure
+  of the concrete support-overlap predicate into the offset-based disjointness
+  predicate used by the transported-local-term commutation proof.
+- `MPSTensor.localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap` supplies
+  the non-overlap positivity condition for the concrete cyclic-window overlap
+  relation.
+
+Blueprint sync:
+
+- line 2053, label `lem:cyclic_window_support_offsets`, quote:
+  “`a site k belongs to the cyclic support S_i exactly when its cyclic offset from
+  i is below L`”;
+- line 2083, label `lem:cyclic_window_nonoverlap_positive`, quote:
+  “`If L≤N and the cyclic supports S_i and S_j do not meet, then the transported
+  local ES terms have nonnegative ordered cross term`”.
+
+### Parent-Hamiltonian reductions
+
+- `MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound`
+  is the fixed-chain MPS instantiation of the norm-compression projection
+  theorem.
+- `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs`
+  combines the already-checked cyclic row-cardinality, local-projection, and
+  non-overlap positivity facts, leaving only the ordered overlapping-window
+  Friedrichs lower bound.
+- `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound`
+  leaves the sharper norm-compression condition
+  `‖h_i (h_j v)‖ ≤ (1 - 1/(4L)) * (2(L-1))⁻¹ * ‖h_i v‖` for overlapping
+  off-diagonal cyclic windows, and derives the explicit gap bound.
+
+Blueprint sync:
+
+- line 2015, label `lem:parent_hamiltonian_finite_overlap_norm_quadratic`, quote:
+  “`overlapping local terms satisfy`” the displayed norm-compression estimate;
+- line 2179, label `lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap`, quote:
+  “`overlapping off-diagonal terms satisfy`” the ordered Friedrichs estimate;
+- line 2206, label `lem:parent_hamiltonian_cyclic_overlap_norm_gap`, quote:
+  “`overlapping off-diagonal pair`” satisfies the displayed norm-compression
+  estimate.
+
+## Remaining mathematical statement
+
+For injective MPS parent-Hamiltonian local terms, the remaining analytic theorem is:
+for all `N` with `2 * L ≤ N`, all off-diagonal `i,j` with
+`cyclicWindowsOverlap N L i j`, and all vectors `v`, prove
+
+```text
+‖localTermES A L i (localTermES A L j v)‖
+  ≤ (1 - 1/(4L)) * (2(L-1))⁻¹ * ‖localTermES A L i v‖.
+```
+
+Equivalently, one may prove the ordered quadratic-form lower bound obtained from
+this norm estimate.  This is exactly the principal-angle/Friedrichs-angle content
+of the paper’s martingale condition; no new proof holes or axioms were introduced.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1827,6 +1827,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_self}
     \lean{LinearMap.IsSymmetricProjection.re_inner_nonneg}
     \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_nonneg_of_commute}
+    \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_ge_neg_of_norm_apply_le}
     \lean{ProjectionGeometry.re_inner_sum_apply_left}
     \lean{ProjectionGeometry.re_inner_sum_apply_apply}
     \lean{ProjectionGeometry.sum_sum_eq_diag_add_offdiag}
@@ -1837,7 +1838,10 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $\operatorname{Re}\langle Pv,Pv\rangle=\operatorname{Re}\langle Pv,v\rangle$
     for symmetric projections; nonnegativity of this quadratic form; nonnegativity
     of $\operatorname{Re}\langle Pv,Qv\rangle$ for commuting symmetric projections
-    $P,Q$; finite-sum expansions of
+    $P,Q$; the Cauchy--Schwarz conversion from
+    $\|P Q v\|\le c\|Pv\|$ to
+    $\operatorname{Re}\langle Pv,Qv\rangle\ge -c\operatorname{Re}\langle Pv,v\rangle$;
+    finite-sum expansions of
     $\operatorname{Re}\langle (\sum_i P_i)v,v\rangle$ and
     $\operatorname{Re}\langle (\sum_i P_i)v,(\sum_i P_i)v\rangle$; the
     diagonal/off-diagonal split of the ordered double sum; and the aggregate
@@ -1891,6 +1895,33 @@ Lucia~\cite{Kastoryano2018Martingale}.
     cardinality bound gives $\sum_{j\ne i}c_{ij}\le1$; noninteracting
     nonnegativity supplies the zero-coefficient cross-term estimates. Apply
     Lemma~\ref{lem:ordered_projection_rowsum_reduction}.
+\end{proof}
+
+\begin{lemma}[Finite-overlap projection norm-compression reduction]
+    \label{lem:finite_overlap_projection_norm_reduction}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound}
+    \leanok
+    \uses{lem:finite_overlap_projection_rowsum_reduction,
+        rem:projection_geometry_rowsum_identities}
+    Let $P_i$ be a finite family of symmetric projections and let $\gamma\le1$.
+    Suppose an interaction predicate has at most $m>0$ off-diagonal neighbours
+    in each row, noninteracting ordered cross terms are nonnegative, and
+    interacting pairs satisfy the norm-compression estimate
+    \[
+        \|P_iP_jv\|\le (1-\gamma)\frac{1}{m}\|P_iv\|.
+    \]
+    Then $H=\sum_iP_i$ satisfies $H^2\ge\gamma H$ as a quadratic form.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:finite_overlap_projection_rowsum_reduction,
+        rem:projection_geometry_rowsum_identities}
+    Cauchy--Schwarz and symmetric idempotence turn the norm-compression estimate
+    into
+    $\operatorname{Re}\langle P_i v,P_jv\rangle
+    \ge -(1-\gamma)m^{-1}\operatorname{Re}\langle P_iv,v\rangle$.
+    The finite-overlap row-sum reduction then applies.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian ordered row-sum quadratic-form reduction]
@@ -1980,6 +2011,32 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $P_i=h_{i,\mathrm{ES}}$.
 \end{proof}
 
+\begin{lemma}[Parent-Hamiltonian finite-overlap norm-compression quadratic reduction]
+    \label{lem:parent_hamiltonian_finite_overlap_norm_quadratic}
+    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound}
+    \leanok
+    \uses{lem:finite_overlap_projection_norm_reduction, def:parent_hamiltonian_es,
+        lem:transported_es_local_projections}
+    For a fixed chain length $N$, let $m>0$ and $\gamma\le1$. Suppose an overlap
+    predicate on local windows has at most $m$ overlapping off-diagonal windows in
+    each row, non-overlapping local terms have nonnegative ordered cross terms,
+    and overlapping local terms satisfy
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le (1-\gamma)\frac{1}{m}\|h_{i,\mathrm{ES}}v\|.
+    \]
+    Then $H_{N,L}^{\mathrm{ES}}{}^2\ge \gamma H_{N,L}^{\mathrm{ES}}$ as a
+    quadratic form.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:finite_overlap_projection_norm_reduction,
+        lem:transported_es_local_projections}
+    Apply the finite-overlap norm-compression projection reduction to the family
+    $P_i=h_{i,\mathrm{ES}}$.
+\end{proof}
+
 \begin{definition}[Cyclic-window support]
     \label{def:cyclic_window_support}
     \lean{MPSTensor.cyclicWindowSupport}
@@ -1992,6 +2049,27 @@ Lucia~\cite{Kastoryano2018Martingale}.
     with repeated visits counted once.
 \end{definition}
 
+\begin{lemma}[Cyclic-window support offsets]
+    \label{lem:cyclic_window_support_offsets}
+    \lean{MPSTensor.mem_cyclicWindowSupport_iff}
+    \leanok
+    \uses{def:cyclic_window_support}
+    If $L\le N$, then a site $k$ belongs to the cyclic support $S_i$ exactly when
+    its cyclic offset from $i$ is below $L$:
+    \[
+        k\in S_i
+        \quad\Longleftrightarrow\quad
+        (k-i)\bmod N < L.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Write $k=i+r\pmod N$ for a representative offset $r$.  Membership in
+    $S_i$ gives an offset $r<L$, and conversely an offset below $L$ gives the
+    corresponding point of the support.
+\end{proof}
+
 \begin{definition}[Cyclic-window overlap]
     \label{def:cyclic_windows_overlap}
     \lean{MPSTensor.cyclicWindowsOverlap}
@@ -2000,6 +2078,29 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Two length-$L$ cyclic windows overlap, written $i\sim_L j$, when their
     supports meet: $S_i\cap S_j\ne\varnothing$.
 \end{definition}
+
+\begin{lemma}[Concrete non-overlap positivity for cyclic supports]
+    \label{lem:cyclic_window_nonoverlap_positive}
+    \lean{MPSTensor.CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap}
+    \lean{MPSTensor.localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap}
+    \leanok
+    \uses{lem:cyclic_window_support_offsets, def:cyclic_windows_overlap,
+        lem:transported_es_nonoverlap_positive}
+    If $L\le N$ and the cyclic supports $S_i$ and $S_j$ do not meet, then the
+    transported local ES terms have nonnegative ordered cross term:
+    \[
+        0\le\operatorname{Re}\langle h_{i,\mathrm{ES}}v,
+             h_{j,\mathrm{ES}}v\rangle .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:cyclic_window_support_offsets, lem:transported_es_nonoverlap_positive}
+    The support-offset characterization converts failure of $S_i\cap S_j\ne\varnothing$
+    into site-disjointness of the two cyclic windows.  The disjoint-window
+    positivity lemma then applies.
+\end{proof}
 
 \begin{lemma}[Cyclic-window overlap row cardinality]
     \label{lem:cyclic_window_overlap_cardinality}
@@ -2072,6 +2173,63 @@ Lucia~\cite{Kastoryano2018Martingale}.
     projection structure of each transported local term. Apply
     Lemma~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} with these
     facts and the stated cross-term hypotheses.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian gap from overlapping cyclic Friedrichs data]
+    \label{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs}
+    \leanok
+    \uses{lem:parent_hamiltonian_cyclic_window_friedrichs_gap,
+        lem:cyclic_window_nonoverlap_positive}
+    Fix $L>1$ and let $i\sim_L j$ mean that the cyclic supports of the
+    length-$L$ windows at $i$ and $j$ meet. Suppose uniformly for every
+    $N\ge2L$ that overlapping off-diagonal terms satisfy
+    \[
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
+        \ge -(1-\tfrac{1}{4L})\frac{1}{2(L-1)}
+              \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
+    \]
+    Then the explicit norm lower bound with constant $1/(4L)$ follows for
+    vectors in $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:parent_hamiltonian_cyclic_window_friedrichs_gap,
+        lem:cyclic_window_nonoverlap_positive}
+    The preceding concrete non-overlap positivity lemma supplies the non-overlap
+    condition required by the cyclic-window finite-overlap theorem.  The displayed
+    overlapping estimate supplies the remaining ordered cross-term condition.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian gap from overlapping cyclic norm-compression data]
+    \label{lem:parent_hamiltonian_cyclic_overlap_norm_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound}
+    \leanok
+    \uses{lem:parent_hamiltonian_finite_overlap_norm_quadratic,
+        lem:parent_hamiltonian_es_quadratic_reduction,
+        lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive}
+    Fix $L>1$.  Suppose uniformly for every $N\ge2L$ and every overlapping
+    off-diagonal pair that
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le (1-\tfrac{1}{4L})\frac{1}{2(L-1)}
+             \|h_{i,\mathrm{ES}}v\|.
+    \]
+    Then the explicit norm lower bound with constant $1/(4L)$ follows for
+    vectors in $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:parent_hamiltonian_finite_overlap_norm_quadratic,
+        lem:parent_hamiltonian_es_quadratic_reduction,
+        lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive}
+    The norm-compression condition is converted to the ordered Friedrichs lower
+    bound by the projection-geometry Cauchy--Schwarz lemma. The concrete cyclic
+    row-cardinality and non-overlap positivity results then give the finite-overlap
+    quadratic-form estimate, which the quadratic-form-to-gap reduction turns into
+    the norm lower bound.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
@@ -2243,7 +2401,11 @@ Lucia~\cite{Kastoryano2018Martingale}.
         lem:parent_hamiltonian_es_quadratic_reduction,
         lem:parent_hamiltonian_ordered_rowsum_gap,
         lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic,
-        lem:parent_hamiltonian_finite_overlap_friedrichs_gap}
+        lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
+        lem:cyclic_window_overlap_cardinality,
+        lem:cyclic_window_nonoverlap_positive,
+        lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
+        lem:parent_hamiltonian_cyclic_overlap_norm_gap}
     For an injective tensor $A$ and a range $L > 1$, the theorem asserts
     the analytic estimate with the explicit constant
     \[
@@ -2268,10 +2430,13 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Lemmas~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
     and~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} record the
     common finite-overlap specialization with $m=2(L-1)$.
-    Lemma~\ref{lem:transported_es_nonoverlap_positive} supplies the non-overlap
-    positivity input for site-disjoint windows.
-    The remaining analytic tasks are the cyclic-window row-cardinality bound and the
-    Friedrichs-angle estimate for overlapping windows.
+    Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the concrete cyclic
+    row-cardinality bound, while Lemma~\ref{lem:cyclic_window_nonoverlap_positive}
+    supplies the non-overlap positivity condition for support-disjoint windows.
+    Lemmas~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} and
+    \ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} isolate the remaining
+    analytic task: the overlapping-window Friedrichs estimate, equivalently its
+    norm-compression formulation.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2206,9 +2206,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \label{lem:parent_hamiltonian_cyclic_overlap_norm_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound}
     \leanok
-    \uses{lem:parent_hamiltonian_finite_overlap_norm_quadratic,
-        lem:parent_hamiltonian_es_quadratic_reduction,
-        lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive}
+    \uses{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
+        rem:projection_geometry_rowsum_identities}
     Fix $L>1$.  Suppose uniformly for every $N\ge2L$ and every overlapping
     off-diagonal pair that
     \[
@@ -2222,14 +2221,11 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
-    \uses{lem:parent_hamiltonian_finite_overlap_norm_quadratic,
-        lem:parent_hamiltonian_es_quadratic_reduction,
-        lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive}
+    \uses{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
+        rem:projection_geometry_rowsum_identities}
     The norm-compression condition is converted to the ordered Friedrichs lower
-    bound by the projection-geometry Cauchy--Schwarz lemma. The concrete cyclic
-    row-cardinality and non-overlap positivity results then give the finite-overlap
-    quadratic-form estimate, which the quadratic-form-to-gap reduction turns into
-    the norm lower bound.
+    bound by the projection-geometry Cauchy--Schwarz lemma.  The preceding
+    overlapping-cyclic Friedrichs reduction then gives the norm lower bound.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
@@ -2433,9 +2429,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the concrete cyclic
     row-cardinality bound, while Lemma~\ref{lem:cyclic_window_nonoverlap_positive}
     supplies the non-overlap positivity condition for support-disjoint windows.
-    Lemmas~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} and
-    \ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} isolate the remaining
-    analytic task: the overlapping-window Friedrichs estimate, equivalently its
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} isolates the
+    remaining overlapping-window Friedrichs estimate, and
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} records a sufficient
     norm-compression formulation.
 \end{proof}
 


### PR DESCRIPTION
Refs #460. Refs #190.\n\n## Summary\n- add a projection-geometry lemma converting the norm-compression estimate \|P_i P_j v\| ≤ c \|P_i v\| into the ordered Friedrichs cross-term lower bound\n- add the finite-overlap norm-compression quadratic-form reduction and MPS/cyclic-window gap wrappers\n- identify concrete cyclic support non-overlap with the offset-based disjointness predicate and use it to discharge non-overlap positivity automatically\n- sync blueprint Chapter 14 and add an audit documenting the exact remaining overlapping-window Friedrichs statement\n\n## Validation\n- lake build TNLean.Analysis.ProjectionGeometry TNLean.MPS.ParentHamiltonian.CyclicWindow TNLean.MPS.ParentHamiltonian.Martingale\n- lake build +TNLean:olean\n- lake build TNLean\n- cd blueprint && leanblueprint checkdecls\n- cd blueprint && leanblueprint web\n- git diff --check\n- touched-file and added-line forbidden-token scans (only the pre-existing Martingale Friedrichs sorry remains)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean lemmas and wrapper theorems without changing existing definitions or introducing new axioms; primary risk is proof/lemma API breakage for downstream users.
> 
> **Overview**
> Adds a projection-geometry lemma `re_inner_apply_apply_ge_neg_of_norm_apply_le` that converts a norm-compression bound on `P (Q v)` into the ordered Friedrichs real cross-term lower bound used by the row-sum martingale reduction.
> 
> Extends the finite-overlap quadratic-form reduction to accept overlap hypotheses in this norm-compression form (`quadraticForm_sum_projections_of_finite_overlap_norm_bound`) and threads it through new parent-Hamiltonian/martingale wrappers, including a cyclic-window specialization that only requires the norm bound on overlapping windows.
> 
> Bridges concrete cyclic-window support non-overlap to the existing offset-based disjointness predicate via `mem_cyclicWindowSupport_iff`, enabling automatic discharge of non-overlap positivity assumptions, and syncs the blueprint plus an audit note documenting the remaining unproved overlapping-window Friedrichs/norm estimate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4acc7337edfd1846cbce851c4062c6c1450d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->