### PR TITLE
feat(MPS/MPDO): assemble selectors from pairwise separators

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -303,6 +303,37 @@ theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords
   intro k
   exact isNBlkInjective_one_of_isInjective (hCF.toHasInjectiveBlocks.block_injective k)
 
+/-- Canonical-form/BNT data plus pairwise block-separating word polynomials give
+full product-word span.
+
+The pairwise hypotheses ask only for a word polynomial separating one ordered
+pair of distinct blocks at a time.  The finite selector assembly in
+`hasBlockSelectorWords_of_pairBlockSeparatingWords` turns these pairwise
+separators into full block selectors, and the selector-word reduction then gives
+product-word span. -/
+theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+    (hPair : HasPairBlockSeparatingWords A S) :
+    WordTupleSpanTop A (1 + (r - 1) * S) :=
+  wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords μ A hCF
+    (hasBlockSelectorWords_of_pairBlockSeparatingWords A hPair)
+
+/-- Positive-length product-word span obtained from canonical-form/BNT data and
+pairwise block-separating word polynomials. -/
+theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+    (hPair : HasPairBlockSeparatingWords A S) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  refine ⟨1 + (r - 1) * S, Nat.add_pos_left Nat.zero_lt_one _, ?_⟩
+  simpa [WordTupleSpanTop, wordTuple] using
+    wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords μ A hCF hPair
+
 /-- Positive-length product-word span obtained from canonical-form/BNT data and
 finite block-selector words.
 

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -10,7 +10,7 @@ import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 # Finite-length sufficient conditions and obstructions for MPDO biCF
 
 The `HorizontalCFData` structure in `VerticalCF.lean` records the block-injective
-canonical-form property `biCF` as a hypothesis. This file records four complementary
+canonical-form property `biCF` as a hypothesis. This file records five complementary
 facts about that field.
 
 1. A clean **abstract sufficient condition**: if, after blocking to some fixed
@@ -138,8 +138,8 @@ def HasBlockSelectorWords
 other blocks. The tuple `M` lies in the span of simultaneous length-`S` word
 evaluations, is the identity on `k`, and vanishes on every block in `targets`.
 
-Taking `targets = Finset.univ.erase k` is equivalent to the coefficient-based
-`HasBlockSelectorWords` predicate below. Smaller target sets are useful for
+Taking `targets = Finset.univ.erase k` is the tuple-span form used to recover
+coefficient-based `HasBlockSelectorWords`. Smaller target sets are useful for
 assembling global selectors from pairwise block-separating word polynomials. -/
 def HasBlockSelectorOn
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -287,17 +287,14 @@ theorem hasBlockSelectorOn_finset_of_pairBlockSeparatingWords
       htail.mul hsingle
     have hsets : targets ∪ {j} = insert j targets := by
       ext l
-      by_cases hlj : l = j
-      · subst hlj
-        simp
-      · simp [hlj]
+      simp
     have hlen : (insert j targets).card * S = targets.card * S + S := by
       rw [Finset.card_insert_of_notMem hj_not_mem]
       exact Nat.succ_mul targets.card S
     simpa [hsets, hlen] using hmul
 
-/-- The coefficient-based selector predicate is equivalent to selecting each
-block on the target set `Finset.univ.erase k` in the tuple span. -/
+/-- Tuple-span selectors on `Finset.univ.erase k` recover coefficient-based
+block-selector words. -/
 theorem hasBlockSelectorWords_of_forall_hasBlockSelectorOn_univ_erase
     (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
     (h : ∀ k : Fin r, HasBlockSelectorOn A k S (Finset.univ.erase k)) :

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -32,15 +32,20 @@ facts about that field.
    This captures the finite-length block-separation content of
    [CPGSV17], Proposition IV.3.
 
-4. A concrete **counterexample**: blockwise injectivity, left-canonical
+4. A **pairwise-to-global selector reduction**: if every ordered pair of
+   distinct blocks admits a finite word polynomial that is the identity on the
+   first block and zero on the second, then multiplying these pairwise
+   separators gives full block-selector words.
+
+5. A concrete **counterexample**: blockwise injectivity, left-canonical
    normalization, nonzero weights, and even pairwise distinct weights do **not**
    imply `biCF`. Thus the current `HorizontalCFData` fields other than `biCF`
    are insufficient for deriving that property.
 
 This isolates the missing ingredient more precisely: one still needs a proved
-finite-length block-separation theorem producing either the selector data of
-item (3), or equivalently the word-entry linear independence of item (2), from
-canonical-form/BNT data.
+finite-length block-separation theorem producing either the pairwise separators
+of item (4), the selector data of item (3), or equivalently the word-entry
+linear independence of item (2), from canonical-form/BNT data.
 -/
 
 open scoped Matrix BigOperators
@@ -128,6 +133,206 @@ def HasBlockSelectorWords
     (∑ w : Fin S → Fin d, c w • evalWord (A k) (List.ofFn w)) = 1 ∧
     ∀ j : Fin r, j ≠ k →
       (∑ w : Fin S → Fin d, c w • evalWord (A j) (List.ofFn w)) = 0
+
+/-- A length-`S` word polynomial which selects block `k` on a finite set of
+other blocks. The tuple `M` lies in the span of simultaneous length-`S` word
+evaluations, is the identity on `k`, and vanishes on every block in `targets`.
+
+Taking `targets = Finset.univ.erase k` is equivalent to the coefficient-based
+`HasBlockSelectorWords` predicate below. Smaller target sets are useful for
+assembling global selectors from pairwise block-separating word polynomials. -/
+def HasBlockSelectorOn
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (k : Fin r) (S : ℕ) (targets : Finset (Fin r)) : Prop :=
+  ∃ M : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+    M ∈ Submodule.span ℂ (Set.range (wordTuple A S)) ∧
+      M k = 1 ∧
+      ∀ j : Fin r, j ∈ targets → M j = 0
+
+/-- Pairwise finite block separation: for each ordered pair of distinct blocks,
+there is a length-`S` word polynomial that is the identity on the first block
+and zero on the second. -/
+def HasPairBlockSeparatingWords
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (S : ℕ) : Prop :=
+  ∀ k j : Fin r, j ≠ k → HasBlockSelectorOn A k S {j}
+
+/-- The tuple-valued span of word evaluations is closed under pointwise matrix
+multiplication, at the cost of adding word lengths. -/
+theorem pointwise_mul_mem_span_wordTuple_add
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L S : ℕ}
+    {M N : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ}
+    (hM : M ∈ Submodule.span ℂ (Set.range (wordTuple A L)))
+    (hN : N ∈ Submodule.span ℂ (Set.range (wordTuple A S))) :
+    (fun k : Fin r => M k * N k) ∈
+      Submodule.span ℂ (Set.range (wordTuple A (L + S))) := by
+  classical
+  let spanLS : Submodule ℂ ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) :=
+    Submodule.span ℂ (Set.range (wordTuple A (L + S)))
+  have hleft_gen : ∀ u : Fin L → Fin d,
+      (fun k : Fin r => wordTuple A L u k * N k) ∈ spanLS := by
+    intro u
+    induction hN using Submodule.span_induction with
+    | mem N hNmem =>
+        rcases hNmem with ⟨v, rfl⟩
+        have hEq : (fun k : Fin r => wordTuple A L u k * wordTuple A S v k) =
+            wordTuple A (L + S) (Fin.append u v) := by
+          funext k
+          simp [wordTuple, List.ofFn_fin_append, evalWord_append]
+        rw [hEq]
+        exact Submodule.subset_span ⟨Fin.append u v, rfl⟩
+    | zero =>
+        have hzero : (fun k : Fin r =>
+            wordTuple A L u k *
+              (0 : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) k) = 0 := by
+          funext k
+          simp
+        rw [hzero]
+        exact Submodule.zero_mem _
+    | add N₁ N₂ _ _ hN₁ hN₂ =>
+        have hEq : (fun k : Fin r => wordTuple A L u k * (N₁ + N₂) k) =
+            (fun k : Fin r => wordTuple A L u k * N₁ k) +
+              (fun k : Fin r => wordTuple A L u k * N₂ k) := by
+          funext k
+          simp [Matrix.mul_add]
+        rw [hEq]
+        exact Submodule.add_mem _ hN₁ hN₂
+    | smul a N _ hN =>
+        have hEq : (fun k : Fin r => wordTuple A L u k * (a • N) k) =
+            a • (fun k : Fin r => wordTuple A L u k * N k) := by
+          funext k
+          simp
+        rw [hEq]
+        exact Submodule.smul_mem _ a hN
+  induction hM using Submodule.span_induction with
+  | mem M hMmem =>
+      rcases hMmem with ⟨u, rfl⟩
+      exact hleft_gen u
+  | zero =>
+      have hzero : (fun k : Fin r =>
+          (0 : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) k * N k) = 0 := by
+        funext k
+        simp
+      rw [hzero]
+      exact Submodule.zero_mem _
+  | add M₁ M₂ _ _ hM₁ hM₂ =>
+      have hEq : (fun k : Fin r => (M₁ + M₂) k * N k) =
+          (fun k : Fin r => M₁ k * N k) +
+            (fun k : Fin r => M₂ k * N k) := by
+        funext k
+        simp [Matrix.add_mul]
+      rw [hEq]
+      exact Submodule.add_mem _ hM₁ hM₂
+  | smul a M _ hM =>
+      have hEq : (fun k : Fin r => (a • M) k * N k) =
+          a • (fun k : Fin r => M k * N k) := by
+        funext k
+        simp
+      rw [hEq]
+      exact Submodule.smul_mem _ a hM
+
+/-- The empty word is the identity on every block, so it selects a block on the
+empty target set. -/
+theorem hasBlockSelectorOn_empty
+    (A : (k : Fin r) → MPSTensor d (dim k)) (k : Fin r) :
+    HasBlockSelectorOn A k 0 ∅ := by
+  classical
+  refine ⟨wordTuple A 0 (fun i => Fin.elim0 i), ?_, ?_, ?_⟩
+  · exact Submodule.subset_span ⟨fun i => Fin.elim0 i, rfl⟩
+  · simp [wordTuple]
+  · intro j hj
+    simp at hj
+
+/-- Multiplying two partial selectors for the same block produces a selector
+that vanishes on the union of their target sets. -/
+theorem HasBlockSelectorOn.mul
+    {A : (k : Fin r) → MPSTensor d (dim k)} {k : Fin r}
+    {L S : ℕ} {targets₁ targets₂ : Finset (Fin r)}
+    (h₁ : HasBlockSelectorOn A k L targets₁)
+    (h₂ : HasBlockSelectorOn A k S targets₂) :
+    HasBlockSelectorOn A k (L + S) (targets₁ ∪ targets₂) := by
+  classical
+  rcases h₁ with ⟨M, hM, hMk, hMzero⟩
+  rcases h₂ with ⟨N, hN, hNk, hNzero⟩
+  refine ⟨fun j => M j * N j, ?_, ?_, ?_⟩
+  · exact pointwise_mul_mem_span_wordTuple_add A hM hN
+  · simp [hMk, hNk]
+  · intro j hj
+    rcases Finset.mem_union.mp hj with hj | hj
+    · simp [hMzero j hj]
+    · simp [hNzero j hj]
+
+/-- Pairwise block-separating word polynomials multiply to a selector on any
+finite target set. -/
+theorem hasBlockSelectorOn_finset_of_pairBlockSeparatingWords
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    (hPair : HasPairBlockSeparatingWords A S)
+    (k : Fin r) (targets : Finset (Fin r))
+    (htargets : ∀ j : Fin r, j ∈ targets → j ≠ k) :
+    HasBlockSelectorOn A k (targets.card * S) targets := by
+  classical
+  revert htargets
+  refine Finset.induction_on targets ?base ?step
+  · intro _
+    simpa using hasBlockSelectorOn_empty A k
+  · intro j targets hj_not_mem ih htargets_insert
+    have htargets_tail : ∀ l : Fin r, l ∈ targets → l ≠ k := by
+      intro l hl
+      exact htargets_insert l (Finset.mem_insert_of_mem hl)
+    have htail := ih htargets_tail
+    have hjk : j ≠ k := htargets_insert j (Finset.mem_insert_self j targets)
+    have hsingle : HasBlockSelectorOn A k S {j} := hPair k j hjk
+    have hmul : HasBlockSelectorOn A k (targets.card * S + S) (targets ∪ {j}) :=
+      htail.mul hsingle
+    have hsets : targets ∪ {j} = insert j targets := by
+      ext l
+      by_cases hlj : l = j
+      · subst hlj
+        simp
+      · simp [hlj]
+    have hlen : (insert j targets).card * S = targets.card * S + S := by
+      rw [Finset.card_insert_of_notMem hj_not_mem]
+      exact Nat.succ_mul targets.card S
+    simpa [hsets, hlen] using hmul
+
+/-- The coefficient-based selector predicate is equivalent to selecting each
+block on the target set `Finset.univ.erase k` in the tuple span. -/
+theorem hasBlockSelectorWords_of_forall_hasBlockSelectorOn_univ_erase
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    (h : ∀ k : Fin r, HasBlockSelectorOn A k S (Finset.univ.erase k)) :
+    HasBlockSelectorWords A S := by
+  classical
+  intro k
+  rcases h k with ⟨M, hM, hMk, hMzero⟩
+  rcases (Submodule.mem_span_range_iff_exists_fun ℂ).mp hM with ⟨c, hc⟩
+  refine ⟨c, ?_, ?_⟩
+  · have hk := congrArg (fun N => N k) hc
+    simpa [wordTuple, hMk] using hk
+  · intro j hjk
+    have hjmem : j ∈ Finset.univ.erase k := by
+      simp [hjk]
+    have hj := congrArg (fun N => N j) hc
+    simpa [wordTuple, hMzero j hjmem] using hj
+
+/-- Pairwise block-separating word polynomials assemble into full block-selector
+words by multiplying the pairwise selectors for the chosen block against all
+other blocks. -/
+theorem hasBlockSelectorWords_of_pairBlockSeparatingWords
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    (hPair : HasPairBlockSeparatingWords A S) :
+    HasBlockSelectorWords A ((r - 1) * S) := by
+  classical
+  refine hasBlockSelectorWords_of_forall_hasBlockSelectorOn_univ_erase A ?_
+  intro k
+  have htargets : ∀ j : Fin r, j ∈ Finset.univ.erase k → j ≠ k := by
+    intro j hj
+    exact (Finset.mem_erase.mp hj).1
+  have hsel := hasBlockSelectorOn_finset_of_pairBlockSeparatingWords A hPair k
+    (Finset.univ.erase k) htargets
+  have hcard : (Finset.univ.erase k).card = r - 1 := by
+    simp [Fintype.card_fin]
+  simpa [hcard] using hsel
 
 /-- Any finite-length product-algebra spanning witness already contains block
 selectors as a special case. -/
@@ -289,6 +494,16 @@ def PropBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k)) : Prop :=
   ∃ L S : ℕ, (∀ k, IsNBlkInjective (A k) L) ∧ HasBlockSelectorWords A S
 
+/-- Common block injectivity plus pairwise block-separating word polynomials
+produce the abstract Proposition-IV.3 selector data. -/
+theorem propBlockInjective_of_common_blockInjective_of_pairBlockSeparatingWords
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L S : ℕ}
+    (hInj : ∀ k, IsNBlkInjective (A k) L)
+    (hPair : HasPairBlockSeparatingWords A S) :
+    PropBlockInjective A :=
+  ⟨L, (r - 1) * S, hInj, hasBlockSelectorWords_of_pairBlockSeparatingWords A hPair⟩
+
 /-- Common block injectivity plus finite-length block selectors yield the full
 word-tuple span condition. -/
 theorem wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
@@ -391,6 +606,28 @@ theorem wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
       _ = M j := hprefix j
   rw [← hassembled]
   exact hassembled_mem
+
+/-- Common block injectivity plus pairwise block-separating word polynomials
+yield the full word-tuple span condition. -/
+theorem wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L S : ℕ}
+    (hInj : ∀ k, IsNBlkInjective (A k) L)
+    (hPair : HasPairBlockSeparatingWords A S) :
+    WordTupleSpanTop A (L + (r - 1) * S) :=
+  wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords A hInj
+    (hasBlockSelectorWords_of_pairBlockSeparatingWords A hPair)
+
+/-- Common block injectivity plus pairwise block-separating word polynomials
+imply `HasBiCF`. -/
+theorem hasBiCF_of_common_blockInjective_of_pairBlockSeparatingWords
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L S : ℕ}
+    (hInj : ∀ k, IsNBlkInjective (A k) L)
+    (hPair : HasPairBlockSeparatingWords A S) :
+    HasBiCF A :=
+  hasBiCF_of_wordTupleSpanTop A
+    (wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords A hInj hPair)
 
 /-- The abstract Proposition-IV.3 selector data imply the finite-length
 word-tuple span condition. -/

--- a/audits/2026-04-26_issue934_pairwise_selector_assembly.md
+++ b/audits/2026-04-26_issue934_pairwise_selector_assembly.md
@@ -1,0 +1,102 @@
+# Issue #934 — pairwise selector assembly (2026-04-26)
+
+## Scope
+
+Wave 17 Slot D targeted the missing finite selector-word input for the Route B parent-Hamiltonian
+reduction.  The full paper-level theorem
+
+```lean
+IsCanonicalFormBNT μ A → ∃ S, HasBlockSelectorWords A S
+```
+
+is still not proved from BNT separation alone.  This pass lands a checked finite-dimensional
+predecessor: it reduces full block-selector words to **pairwise** block-separating word
+polynomials.  Thus the remaining BNT separation task is sharpened from constructing one global
+selector for each block to constructing, for every ordered pair of distinct blocks, a common-length
+word polynomial that is identity on the first block and zero on the second.
+
+## Lean declarations added
+
+File: `TNLean/MPS/MPDO/BiCFDerivation.lean`
+
+- `MPSTensor.HasBlockSelectorOn`
+  - Tuple-span form of a partial selector: a length-`S` word polynomial is identity on a block `k`
+    and zero on a finite target set of other blocks.
+
+- `MPSTensor.HasPairBlockSeparatingWords`
+  - Pairwise predecessor to global selector words: for each ordered pair `k ≠ j`, there is a
+    length-`S` partial selector for `k` on `{j}`.
+
+- `MPSTensor.pointwise_mul_mem_span_wordTuple_add`
+  - The span of simultaneous word tuples is closed under pointwise matrix multiplication, with
+    word lengths adding by concatenation.
+
+- `MPSTensor.hasBlockSelectorOn_empty`
+  - The empty word gives the identity tuple, hence a selector on the empty target set.
+
+- `MPSTensor.HasBlockSelectorOn.mul`
+  - Multiplying partial selectors for the same block unions their target sets.
+
+- `MPSTensor.hasBlockSelectorOn_finset_of_pairBlockSeparatingWords`
+  - Inducts over a finite target set and multiplies the relevant pairwise separators.
+
+- `MPSTensor.hasBlockSelectorWords_of_forall_hasBlockSelectorOn_univ_erase`
+  - Converts tuple-span selectors on `Finset.univ.erase k` into the existing coefficient-based
+    `HasBlockSelectorWords` predicate.
+
+- `MPSTensor.hasBlockSelectorWords_of_pairBlockSeparatingWords`
+  - Pairwise separators of length `S` give full block-selector words of length `(r - 1) * S`.
+
+- `MPSTensor.propBlockInjective_of_common_blockInjective_of_pairBlockSeparatingWords`
+  - Common block injectivity plus pairwise separators gives the abstract Proposition-IV.3 data.
+
+- `MPSTensor.wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords`
+  - Common block injectivity plus pairwise separators gives full product-word span.
+
+- `MPSTensor.hasBiCF_of_common_blockInjective_of_pairBlockSeparatingWords`
+  - The same hypotheses give the biCF trace-separation predicate.
+
+File: `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
+
+- `MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords`
+  - Composes CF/BNT block injectivity with the pairwise-to-global selector assembly and the merged
+    selector-word product-span reduction.
+
+- `MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords`
+  - Issue-#934 product-span shape with pairwise block-separating words as the explicit remaining
+    finite separation input.
+
+Blueprint Chapter 14 records the new definition/lemma at
+`def:pairwise_block_separating_words` and `lem:block_selectors_from_pairwise_separators`, and cites
+that reduction from the existing product-span and parent-ground-space roadmap entries.
+
+## Remaining blocker
+
+The remaining paper-level argument is now:
+
+```lean
+IsCanonicalFormBNT μ A → ∃ S, HasPairBlockSeparatingWords A S
+```
+
+or any equivalent construction implying it.  Concretely, from injectivity, left-canonical
+normalization, and `blocks_not_equiv`, one must produce a finite word polynomial separating each
+ordered pair of distinct blocks.  The expected route is still the BNT separation/Gram argument:
+use cross-sector overlap decay from `cross_overlap_tendsto_zero_of_separated_CFBNT_data`, prove
+nondegenerate same-sector limits for matrix-inserted word states, then extract finite pairwise
+separators (or global matrix-entry word-family linear independence).
+
+## Validation
+
+Successful local checks in `wave17-D-934-selector-words`:
+
+- `lake build TNLean.MPS.MPDO.BiCFDerivation`
+- `lake build TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
+- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean && lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
+- `ulimit -n 8192 && lake build TNLean`
+  - The first full-build continuation reached the command timeout after substantial progress; the
+    immediate continuation completed successfully, with only pre-existing warnings in unrelated
+    modules.
+- `cd blueprint && leanblueprint web`
+- `cd blueprint && leanblueprint checkdecls`
+- `git diff --check`
+- touched-file forbidden-token scan clean

--- a/audits/2026-04-26_issue934_pairwise_selector_assembly.md
+++ b/audits/2026-04-26_issue934_pairwise_selector_assembly.md
@@ -91,7 +91,8 @@ Successful local checks in `wave17-D-934-selector-words`:
 
 - `lake build TNLean.MPS.MPDO.BiCFDerivation`
 - `lake build TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
-- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean && lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
+- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
+- `lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
 - `ulimit -n 8192 && lake build TNLean`
   - The first full-build continuation reached the command timeout after substantial progress; the
     immediate continuation completed successfully, with only pre-existing warnings in unrelated

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2500,26 +2500,78 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     follows from Lemma~\ref{lem:route_b_block_diagonal_commutant_reduction}.
 \end{proof}
 
+\begin{definition}[Pairwise block-separating word polynomials]
+    \label{def:pairwise_block_separating_words}
+    \lean{MPSTensor.HasBlockSelectorOn}
+    \lean{MPSTensor.HasPairBlockSeparatingWords}
+    \leanok
+    A length-$S$ partial selector for block $k$ on a finite target set $T$ is a
+    tuple in the span of simultaneous length-$S$ block-word evaluations which is
+    $I$ on block $k$ and $0$ on every block in $T$.  The pairwise version asks for
+    such a partial selector for each ordered pair of distinct blocks, with
+    $T=\{j\}$.
+\end{definition}
+
+\begin{lemma}[Block selectors from pairwise block separation]
+    \label{lem:block_selectors_from_pairwise_separators}
+    \lean{MPSTensor.pointwise_mul_mem_span_wordTuple_add}
+    \lean{MPSTensor.hasBlockSelectorOn_empty}
+    \lean{MPSTensor.HasBlockSelectorOn.mul}
+    \lean{MPSTensor.hasBlockSelectorOn_finset_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.hasBlockSelectorWords_of_forall_hasBlockSelectorOn_univ_erase}
+    \lean{MPSTensor.hasBlockSelectorWords_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.propBlockInjective_of_common_blockInjective_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.hasBiCF_of_common_blockInjective_of_pairBlockSeparatingWords}
+    \leanok
+    \uses{def:pairwise_block_separating_words}
+    If every ordered pair of distinct blocks admits a common-length pairwise
+    separator, then full block-selector words exist.  More precisely, multiplying
+    the pairwise separators for a fixed block $k$ against all other blocks gives a
+    selector of length $(r-1)S$ for $k$.  Hence common block injectivity plus
+    pairwise separators implies the Proposition-IV.3 finite product-word span and
+    the biCF trace-separation condition.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The empty word gives the identity tuple, selecting on the empty target set.
+    The span of word tuples is closed under pointwise multiplication because the
+    product of a length-$L$ word and a length-$S$ word is the concatenated
+    length-$(L+S)$ word.  Inducting over the finite set of blocks different from
+    $k$ and multiplying the corresponding pairwise separators keeps the value $I$
+    on $k$ and introduces one additional zero block at each step.  Extracting
+    coefficients from the final tuple-span membership gives the coefficient form
+    of block-selector words.
+\end{proof}
+
 \begin{lemma}[Product-word span from BNT selector words]
     \label{lem:product_word_span_from_bnt_selectors}
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords}
+    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}
     \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords}
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords}
     \leanok
-    \uses{def:cf_bnt, lem:block_projection_span_from_product_word_span}
+    \uses{def:cf_bnt, lem:block_selectors_from_pairwise_separators,
+        lem:block_projection_span_from_product_word_span}
     Let $((\mu_j),(A_j))$ be in canonical form with BNT separation.  Suppose there are
     length-$S$ block-selector words: for each sector $k$, a linear combination of
     length-$S$ words evaluates to $I$ on $A_k$ and to $0$ on every other block.
     Then the simultaneous length-$(1+S)$ block-word evaluations span
-    $\prod_j \MN{D_j}$, with positive length.  Consequently, the pulled-back
-    length-$(1+S)$ words of $\operatorname{Assemble}(\mu,A)$ span every virtual
-    sector projection, and the corresponding commutant reduction is available.
+    $\prod_j \MN{D_j}$, with positive length.  It is enough, by
+    Lemma~\ref{lem:block_selectors_from_pairwise_separators}, to construct
+    pairwise separators for every ordered pair of distinct blocks.  Consequently,
+    the pulled-back words at the resulting length for
+    $\operatorname{Assemble}(\mu,A)$ span every virtual sector projection, and the
+    corresponding commutant reduction is available.
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{lem:one_block_injective_of_injective,
+        lem:block_selectors_from_pairwise_separators,
         lem:block_projection_span_from_product_word_span}
     Definition~\ref{def:cf_bnt} gives one-site injectivity of each block, hence
     $1$-block injectivity by Lemma~\ref{lem:one_block_injective_of_injective}.
@@ -2527,7 +2579,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     one-letter linear combination in block $k$, multiply by the selector for $k$,
     and sum over $k$.  The selector kills all off-target blocks, while it is the
     identity on block $k$, so the length-$(1+S)$ word tuples span the full
-    product algebra.  The projection-span and commutant consequences then follow
+    product algebra.  If one starts with pairwise separators instead, first use
+    Lemma~\ref{lem:block_selectors_from_pairwise_separators} to multiply them into
+    full selectors.  The projection-span and commutant consequences then follow
     from Lemma~\ref{lem:block_projection_span_from_product_word_span}.
 \end{proof}
 
@@ -2623,6 +2677,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, def:bnt_span,
         thm:chain_ground_space_eq_mpv_blk,
+        lem:block_selectors_from_pairwise_separators,
         lem:product_word_span_from_bnt_selectors,
         lem:route_b_block_split_from_product_word_span}
     If $A$ is in canonical-form/BNT and $1 < L$ and $N \ge L + 1$, every vector in the
@@ -2633,9 +2688,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \notready
     The remaining structural step is the periodic block decomposition of the
-    assembled chain ground space.  Lemma~\ref{lem:product_word_span_from_bnt_selectors}
-    reduces the product-word span hypothesis to the finite BNT selector-word
-    theorem.  Lemma~\ref{lem:route_b_block_split_from_product_word_span} gives
+    assembled chain ground space.  Lemma~\ref{lem:block_selectors_from_pairwise_separators}
+    reduces global selectors to pairwise block-separating word polynomials, and
+    Lemma~\ref{lem:product_word_span_from_bnt_selectors} reduces product-word span
+    to those finite BNT selector words.  Lemma~\ref{lem:route_b_block_split_from_product_word_span} gives
     the conditional Route B composition once that product-word span is available
     and the wrapping-window comparison provides the commuting boundary matrix.
     With that decomposition available,

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2691,8 +2691,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     assembled chain ground space.  Lemma~\ref{lem:block_selectors_from_pairwise_separators}
     reduces global selectors to pairwise block-separating word polynomials, and
     Lemma~\ref{lem:product_word_span_from_bnt_selectors} reduces product-word span
-    to those finite BNT selector words.  Lemma~\ref{lem:route_b_block_split_from_product_word_span} gives
-    the conditional Route B composition once that product-word span is available
+    to those finite selector words.  Lemma~\ref{lem:route_b_block_split_from_product_word_span}
+    gives the conditional Route B composition once that product-word span is available
     and the wrapping-window comparison provides the commuting boundary matrix.
     With that decomposition available,
     one applies the blockwise injective uniqueness theorem to each block separately


### PR DESCRIPTION
## Summary

- add tuple-span partial selectors and pairwise block-separating word polynomials as the next finite #934 witness
- prove that common-length pairwise separators multiply into full `HasBlockSelectorWords A ((r - 1) * S)`
- compose the pairwise selector predecessor with the merged CF/BNT selector-to-product-span Route B reductions, and record the new roadmap step in blueprint/audit

## Mathematical status

This advances #934 but still does **not** claim the full paper-level theorem from bare `IsCanonicalFormBNT μ A`.  The remaining finite separation theorem is sharpened to:

```lean
IsCanonicalFormBNT μ A → ∃ S, MPSTensor.HasPairBlockSeparatingWords A S
```

where a pairwise separator is identity on one block and zero on one other block.  The new checked theorem
`MPSTensor.hasBlockSelectorWords_of_pairBlockSeparatingWords` then multiplies these pairwise separators over all other blocks to obtain full block-selector words, feeding the existing #937 product-word span reduction.

Refs #934. Feeds #905 and #190.

## Mathematical references and blueprint synchronization

- Lean source: `TNLean/MPS/MPDO/BiCFDerivation.lean:144`, quote: `def HasBlockSelectorOn`.
- Lean source: `TNLean/MPS/MPDO/BiCFDerivation.lean:155`, quote: `def HasPairBlockSeparatingWords`.
- Lean source: `TNLean/MPS/MPDO/BiCFDerivation.lean:321`, quote: `theorem hasBlockSelectorWords_of_pairBlockSeparatingWords`.
- Lean source: `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean:314`, quote: `theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords`.
- Blueprint source: `blueprint/src/chapter/ch14_parent_hamiltonian.tex:2503`, label `def:pairwise_block_separating_words`, quote: `\begin{definition}[Pairwise block-separating word polynomials]`.
- Blueprint source: `blueprint/src/chapter/ch14_parent_hamiltonian.tex:2515`, label `lem:block_selectors_from_pairwise_separators`, quote: `\begin{lemma}[Block selectors from pairwise block separation]`.
- Blueprint source: `blueprint/src/chapter/ch14_parent_hamiltonian.tex:2563`, label `lem:product_word_span_from_bnt_selectors`, quote: `It is enough, by Lemma~\ref{lem:block_selectors_from_pairwise_separators}, to construct pairwise separators for every ordered pair of distinct blocks.`
- Paper anchors: arXiv:1606.00608 / CPGSV17 Proposition IV.3 (`propblockinj`) for the selector-word criterion, and arXiv:2011.12127 §IV.C / Def. 4.2 for the BNT parent-Hamiltonian setting.  The remaining BNT input is expected to use the repository's `TNLean/MPS/BNT/Construction.lean:262` cross-overlap decay theorem, quote: `theorem cross_overlap_tendsto_zero_of_separated_CFBNT_data`.

## Validation

- `lake build TNLean.MPS.MPDO.BiCFDerivation`
- `lake build TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean && lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
- `ulimit -n 8192 && lake build TNLean` (completed after a timeout-limited continuation; only pre-existing warnings in unrelated modules)
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- Lean diagnostics clean for both touched Lean files
- `git diff --cached --check`
- added-line forbidden-token scan clean (full touched-file scan only reports the pre-existing prose phrase `cannot admit` in `BiCFDerivation.lean`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds nontrivial new Lean definitions/lemmas that extend the formal route from block separation hypotheses to `WordTupleSpanTop`/`HasBiCF`, so proof breakage or incorrect assumptions could affect downstream theory, though there is no runtime code impact.
> 
> **Overview**
> Adds a new *pairwise-to-global* block-separation layer in `BiCFDerivation.lean`: defines tuple-span partial selectors (`HasBlockSelectorOn`) and pairwise separators (`HasPairBlockSeparatingWords`), proves the word-tuple span is closed under pointwise multiplication, and uses this to multiply pairwise separators into full `HasBlockSelectorWords A ((r - 1) * S)`.
> 
> Builds new composition theorems showing **common block injectivity + pairwise separators** implies `PropBlockInjective`, `WordTupleSpanTop` at length `L + (r - 1) * S`, and `HasBiCF`; and in `BlockDiagonalCommutant.lean` threads the same pairwise-separator assumption through the existing canonical-form/BNT reductions to obtain product-word span and an explicit positive-length span witness.
> 
> Updates the blueprint and adds an audit note to document the new roadmap step and the sharpened remaining #934 goal (constructing pairwise separators).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9f938ccd49cc0f63dbe291bbed3bb1cc826513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->