### PR TITLE
feat(MPS/ParentHamiltonian): assemble cyclic-window gap reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -296,7 +296,8 @@ theorem CyclicWindowsDisjoint.symm {N : ℕ} {L : ℕ} {i j : Fin N}
     (hij : CyclicWindowsDisjoint L i j) : CyclicWindowsDisjoint L j i :=
   fun k hj hi => hij k hi hj
 
-private theorem cyclicWindowsDisjoint_of_not_cyclicWindowsOverlap {N L : ℕ}
+/-- If the cyclic supports of two windows do not overlap, then the windows are site-disjoint. -/
+theorem CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap {N L : ℕ}
     {i j : Fin N} (hij : ¬ cyclicWindowsOverlap N L i j) :
     CyclicWindowsDisjoint L i j := by
   intro k hki hkj
@@ -1083,7 +1084,7 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
     (fun N hLN i => cyclicWindowsOverlap_card_le hLN hL i)
     (fun N hLN i j _hij hnot v =>
       localTermES_re_inner_nonneg_of_cyclic_windows_disjoint A (by omega)
-        (cyclicWindowsDisjoint_of_not_cyclicWindowsOverlap hnot) v)
+        (CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap hnot) v)
     hFriedrichs
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -1109,9 +1109,9 @@ cyclic translates whose length-`L` windows have the finite-range overlap relevan
 to the martingale method.  The row-cardinality estimate is supplied by
 `cyclicWindowsOverlap_card_le`, local projection structure is supplied by
 `localTermES_isSymmetricProjection`, and non-overlap positivity is supplied by
-`localTermES_re_inner_nonneg_of_cyclic_windows_disjoint`.  Consequently the only
-remaining local hypothesis is the Friedrichs-angle estimate for pairs marked by
-`cyclicWindowsOverlap`. -/
+`localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap`.  Consequently the
+only remaining local hypothesis is the Friedrichs-angle estimate for pairs
+marked by `cyclicWindowsOverlap`. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (hFriedrichs : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -81,8 +81,8 @@ concrete Friedrichs-angle/row-sum lower bound that
   finite-overlap reduction turning explicit local projection, overlap,
   non-overlap positivity, and Friedrichs estimates into the gap estimate.
 * `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs` — the
-  same reduction specialized to the concrete cyclic-window overlap predicate and
-  its `2 * (L - 1)` row-cardinality bound.
+  same reduction specialized to the concrete cyclic-window overlap predicate,
+  its `2 * (L - 1)` row-cardinality bound, and the non-overlap positivity theorem.
 * `MPSTensor.parentHamiltonian_gapped` — uniform spectral gap for MPS
   parent Hamiltonians on injective tensors, obtained from the
   Friedrichs-angle bound recorded in
@@ -295,6 +295,21 @@ def CyclicWindowsDisjoint {N : ℕ} (L : ℕ) (i j : Fin N) : Prop :=
 theorem CyclicWindowsDisjoint.symm {N : ℕ} {L : ℕ} {i j : Fin N}
     (hij : CyclicWindowsDisjoint L i j) : CyclicWindowsDisjoint L j i :=
   fun k hj hi => hij k hi hj
+
+private theorem cyclicWindowsDisjoint_of_not_cyclicWindowsOverlap {N L : ℕ}
+    {i j : Fin N} (hij : ¬ cyclicWindowsOverlap N L i j) :
+    CyclicWindowsDisjoint L i j := by
+  intro k hki hkj
+  apply hij
+  refine ⟨k, ?_, ?_⟩
+  · rw [cyclicWindowSupport, Finset.mem_image]
+    refine ⟨(k.val + N - i.val) % N, Finset.mem_range.mpr hki, ?_⟩
+    exact (eq_cyclic_site_of_offset_eq (Fin.pos i) (i := i) (k := k)
+      (r := (k.val + N - i.val) % N) rfl).symm
+  · rw [cyclicWindowSupport, Finset.mem_image]
+    refine ⟨(k.val + N - j.val) % N, Finset.mem_range.mpr hkj, ?_⟩
+    exact (eq_cyclic_site_of_offset_eq (Fin.pos j) (i := j) (k := k)
+      (r := (k.val + N - j.val) % N) rfl).symm
 
 /-- Ground-space submodule for the finite-size parent Hamiltonian,
 transported to the `EuclideanSpace` (inner-product) setting so that
@@ -1042,16 +1057,13 @@ predicate.
 For chains with `N ≥ 2L`, the predicate `cyclicWindowsOverlap N L i j` marks the
 cyclic translates whose length-`L` windows have the finite-range overlap relevant
 to the martingale method.  The row-cardinality estimate is supplied by
-`cyclicWindowsOverlap_card_le`, and local projection structure is supplied by
-`localTermES_isSymmetricProjection`.  Consequently the only remaining
-local hypotheses are non-overlap positivity and the Friedrichs-angle estimate for
-pairs marked by `cyclicWindowsOverlap`. -/
+`cyclicWindowsOverlap_card_le`, local projection structure is supplied by
+`localTermES_isSymmetricProjection`, and non-overlap positivity is supplied by
+`localTermES_re_inner_nonneg_of_cyclic_windows_disjoint`.  Consequently the only
+remaining local hypothesis is the Friedrichs-angle estimate for pairs marked by
+`cyclicWindowsOverlap`. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
-    (hDisjoint : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
-      j ∈ Finset.univ.erase i → ¬ cyclicWindowsOverlap N L i j →
-        ∀ v : EuclideanSpace ℂ (Cfg d N),
-          0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re)
     (hFriedrichs : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
       j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
         ∀ v : EuclideanSpace ℂ (Cfg d N),
@@ -1069,7 +1081,10 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
     (fun N => cyclicWindowsOverlap N L)
     (fun N _hLN i => localTermES_isSymmetricProjection A L i)
     (fun N hLN i => cyclicWindowsOverlap_card_le hLN hL i)
-    hDisjoint hFriedrichs
+    (fun N hLN i j _hij hnot v =>
+      localTermES_re_inner_nonneg_of_cyclic_windows_disjoint A (by omega)
+        (cyclicWindowsDisjoint_of_not_cyclicWindowsOverlap hnot) v)
+    hFriedrichs
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
@@ -1098,12 +1113,10 @@ uniform estimate `γ * re ⟪H_N v, v⟫ ≤ re ⟪H_N v, H_N v⟫`.
 `parentHamiltonianES_gap_bound_of_ordered_local_term_bounds` now formalize the
 finite-sum algebra turning explicit ordered cross-term row bounds for local
 symmetric projections into the quadratic-form hypothesis above.
-5. **Remaining local analytic obligations:** the combinatorial overlap count comes
-from locality (`localTerm`, `parentHamiltonian`) and finite range: each window
-overlaps at most `2 * (L - 1)` neighbors. The local symmetric-projection theorem
-for `localTermES` is now proved above; the remaining input is the
-Friedrichs-angle estimate that supplies the ordered cross-term constants with
-the required row sums.
+5. **Remaining local analytic obligation:** local projection structure, cyclic-window
+row cardinality, and non-overlap positivity are now formalized above. The remaining
+hypothesis is the Friedrichs-angle estimate for overlapping cyclic windows with the
+coefficient required by the finite-overlap row reduction.
 6. **Sorry dependency split:** `parentHamiltonian_gapped` is the downstream
 existential theorem, now proved by applying the Friedrichs-angle theorem
 below. The theorem `parentHamiltonianES_gap_bound_of_friedrichs` still depends
@@ -1125,11 +1138,10 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
-  -- Remaining obligation: derive the uniform quadratic-form estimate required by
-  -- `parentHamiltonianES_gap_bound_of_quadratic_form` from the MPS-specific
-  -- Friedrichs-angle estimate for adjacent local ground spaces and the
-  -- finite-overlap row-sum bound. Positivity, kernel identification, and the
-  -- spectral-theorem conversion are already formalized above.
+  -- Remaining obligation: prove the overlapping cyclic-window Friedrichs-angle
+  -- estimate consumed by `parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs`.
+  -- Local projection structure, row cardinality, non-overlap positivity, kernel
+  -- identification, and the spectral-theorem conversion are already formalized above.
   sorry
 
 /--

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -809,6 +809,7 @@ theorem localTermES_re_inner_nonneg_of_cyclic_windows_disjoint {N : ℕ}
     (localTermES_isSymmetricProjection A L i)
     (localTermES_isSymmetricProjection A L j)
     (localTermES_commute_of_cyclic_windows_disjoint A hLN hij) v
+
 /-- Non-overlap positivity for the concrete cyclic-window overlap predicate.
 
 When `cyclicWindowsOverlap N L i j` fails and `L ≤ N`, the two windows are
@@ -1245,7 +1246,7 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
   -- Remaining obligation: prove the overlapping cyclic-window Friedrichs-angle
-  -- estimate consumed by `parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs`.
+  -- estimate required by `parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs`.
   -- Local projection structure, row cardinality, non-overlap positivity, kernel
   -- identification, and the spectral-theorem conversion are already formalized above.
   sorry

--- a/audits/2026-04-25_issue460_friedrichs_rowbounds.md
+++ b/audits/2026-04-25_issue460_friedrichs_rowbounds.md
@@ -48,8 +48,10 @@ finite-overlap hypotheses are now formalized.
      2 * (L - 1)` under `2 * L ≤ N` and `1 < L` (PR #940).
 4. Non-overlap positivity is supplied by
    `MPSTensor.localTermES_re_inner_nonneg_of_cyclic_windows_disjoint` (PR #941).
-   In the cyclic-window gap assembly, the negation of `cyclicWindowsOverlap`
-   provides the site-disjointness condition needed by this theorem.
+   In the cyclic-window gap assembly,
+   `MPSTensor.CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap` converts the
+   negation of `cyclicWindowsOverlap` into the site-disjointness condition needed
+   by this theorem.
 5. The sole remaining analytic hypothesis for the new cyclic-window gap wrapper is
    the Friedrichs-angle estimate for overlapping cyclic windows:
    `Re ⟪h_i v, h_j v⟫ ≥ -(1 - 1/(4L)) * (2(L-1))⁻¹ * Re ⟪h_i v, v⟫`.

--- a/audits/2026-04-25_issue460_friedrichs_rowbounds.md
+++ b/audits/2026-04-25_issue460_friedrichs_rowbounds.md
@@ -31,26 +31,34 @@ specialize the reduction to the transported local terms `localTermES A L i`,
 with the expected cyclic-window degree `m = 2 * (L - 1)` and the explicit gap
 constant `γ = 1 / (4 * L)`.
 
-## Remaining MPS-specific hypotheses
+## Current MPS-specific status after the cyclic-window assembly
 
 The final theorem `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs` still
-needs the following concrete hypotheses.
+needs the concrete overlapping-window Friedrichs estimate, but the other
+finite-overlap hypotheses are now formalized.
 
-1. Local projector structure: for all admissible `N` and `i`, prove
-   `(localTermES A L i).IsSymmetricProjection`. This row-bound branch keeps the
-   hypothesis explicit; PR #925 owns the separate projection-structure proof.
-2. Choose a cyclic-window overlap predicate, for example “the length-`L` cyclic
-   supports of `i` and `j` intersect”.
-3. Prove the row-cardinality estimate
-   `((Finset.univ.erase i).filter (fun j => overlaps N i j)).card ≤ 2 * (L - 1)`
-   under `2 * L ≤ N`.
-4. Prove non-overlap positivity of ordered cross terms, expected from disjoint
-   tensor factors / commuting local projectors:
-   `0 ≤ Re ⟪localTermES A L i v, localTermES A L j v⟫` whenever the windows are
-   disjoint.
-5. Prove the Friedrichs-angle estimate for overlapping cyclic windows:
+1. Local projector structure is supplied by
+   `MPSTensor.localTermES_isSymmetricProjection` (PR #925).
+2. The concrete overlap predicate is
+   `MPSTensor.cyclicWindowsOverlap`: two length-`L` cyclic supports intersect
+   (PR #940).
+3. The row-cardinality estimate is supplied by
+   `MPSTensor.cyclicWindowsOverlap_card_le`:
+   `((Finset.univ.erase i).filter (fun j => cyclicWindowsOverlap N L i j)).card ≤
+     2 * (L - 1)` under `2 * L ≤ N` and `1 < L` (PR #940).
+4. Non-overlap positivity is supplied by
+   `MPSTensor.localTermES_re_inner_nonneg_of_cyclic_windows_disjoint` (PR #941).
+   In the cyclic-window gap assembly, the negation of `cyclicWindowsOverlap`
+   provides the site-disjointness condition needed by this theorem.
+5. The sole remaining analytic hypothesis for the new cyclic-window gap wrapper is
+   the Friedrichs-angle estimate for overlapping cyclic windows:
    `Re ⟪h_i v, h_j v⟫ ≥ -(1 - 1/(4L)) * (2(L-1))⁻¹ * Re ⟪h_i v, v⟫`.
 
-Items 2–5 are the genuine CPGSV21 / Kastoryano–Lucia overlap analysis. The new
-Lean theorems only perform the finite-sum and row-sum algebra once those local
-estimates are available.
+Accordingly,
+`MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs` now composes
+local projection structure, cyclic-window row cardinality, and non-overlap
+positivity. Its only local hypothesis is the overlapping-window Friedrichs
+estimate above. This matches the martingale discussion in
+`Papers/2011.12127/TN-Review-main.tex:2166-2180`, especially equations
+`eq:4:martingale-1` and `eq:4:martingale-2`, where non-overlapping products are
+nonnegative and the only estimate imposed is on overlapping pairs.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2048,11 +2048,11 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs}
     \leanok
     \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
-        lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections}
+        lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections,
+        lem:transported_es_nonoverlap_positive}
     Fix $L>1$ and let $i\sim_L j$ mean that the cyclic supports of the
     length-$L$ windows at $i$ and $j$ meet. Suppose uniformly for every
-    $N\ge2L$ that non-overlapping transported local terms have nonnegative
-    ordered cross terms, while overlapping off-diagonal terms satisfy
+    $N\ge2L$ that overlapping off-diagonal terms satisfy
     \[
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
         \ge -(1-\tfrac{1}{4L})\frac{1}{2(L-1)}
@@ -2065,13 +2065,17 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \begin{proof}
     \leanok
     \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
-        lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections}
+        lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections,
+        lem:transported_es_nonoverlap_positive}
     Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the row-cardinality
     bound $m=2(L-1)$ for the concrete cyclic-window overlap relation, and
     Lemma~\ref{lem:transported_es_local_projections} supplies the symmetric
-    projection structure of each transported local term. Apply
+    projection structure of each transported local term. If two cyclic supports
+    do not meet, the corresponding windows are site-disjoint, so
+    Lemma~\ref{lem:transported_es_nonoverlap_positive} gives the required
+    nonnegative ordered cross term. Apply
     Lemma~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} with these
-    facts and the stated cross-term hypotheses.
+    facts and the displayed overlapping-window estimate.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}
@@ -2243,7 +2247,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
         lem:parent_hamiltonian_es_quadratic_reduction,
         lem:parent_hamiltonian_ordered_rowsum_gap,
         lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic,
-        lem:parent_hamiltonian_finite_overlap_friedrichs_gap}
+        lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
+        lem:cyclic_window_overlap_cardinality,
+        lem:parent_hamiltonian_cyclic_window_friedrichs_gap}
     For an injective tensor $A$ and a range $L > 1$, the theorem asserts
     the analytic estimate with the explicit constant
     \[
@@ -2269,9 +2275,12 @@ Lucia~\cite{Kastoryano2018Martingale}.
     and~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} record the
     common finite-overlap specialization with $m=2(L-1)$.
     Lemma~\ref{lem:transported_es_nonoverlap_positive} supplies the non-overlap
-    positivity input for site-disjoint windows.
-    The remaining analytic tasks are the cyclic-window row-cardinality bound and the
-    Friedrichs-angle estimate for overlapping windows.
+    positivity statement for site-disjoint windows, and
+    Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the finite-overlap
+    row-cardinality bound.
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap} combines
+    these ingredients with the finite-overlap reduction, so the remaining
+    analytic task is the Friedrichs-angle estimate for overlapping cyclic windows.
 \end{proof}
 
 \begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2225,8 +2225,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \label{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs}
     \leanok
-    \uses{lem:parent_hamiltonian_cyclic_window_friedrichs_gap,
-        lem:cyclic_window_nonoverlap_positive}
+    \uses{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}
     Fix $L>1$ and let $i\sim_L j$ mean that the cyclic supports of the
     length-$L$ windows at $i$ and $j$ meet. Suppose uniformly for every
     $N\ge2L$ that overlapping off-diagonal terms satisfy
@@ -2241,11 +2240,11 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
-    \uses{lem:parent_hamiltonian_cyclic_window_friedrichs_gap,
-        lem:cyclic_window_nonoverlap_positive}
-    The preceding concrete non-overlap positivity lemma supplies the non-overlap
-    condition required by the cyclic-window finite-overlap theorem.  The displayed
-    overlapping estimate supplies the remaining ordered cross-term condition.
+    \uses{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}
+    Apply Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}.
+    Its non-overlap positivity and finite-row hypotheses are already internal to
+    that cyclic-window reduction; the displayed overlapping estimate supplies its
+    remaining ordered cross-term condition.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian gap from overlapping cyclic norm-compression data]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1722,6 +1722,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \label{lem:transported_es_nonoverlap_positive}
     \lean{MPSTensor.CyclicWindowsDisjoint}
     \lean{MPSTensor.CyclicWindowsDisjoint.symm}
+    \lean{MPSTensor.CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap}
     \lean{MPSTensor.localTermES_commute_of_cyclic_windows_disjoint}
     \lean{MPSTensor.localTermES_re_inner_nonneg_of_cyclic_windows_disjoint}
     \leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2192,7 +2192,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
         lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections,
-        lem:transported_es_nonoverlap_positive}
+        lem:cyclic_window_nonoverlap_positive}
     Fix $L>1$ and let $i\sim_L j$ mean that the cyclic supports of the
     length-$L$ windows at $i$ and $j$ meet. Suppose uniformly for every
     $N\ge2L$ that overlapping off-diagonal terms satisfy
@@ -2209,13 +2209,13 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
         lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections,
-        lem:transported_es_nonoverlap_positive}
+        lem:cyclic_window_nonoverlap_positive}
     Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the row-cardinality
     bound $m=2(L-1)$ for the concrete cyclic-window overlap relation, and
     Lemma~\ref{lem:transported_es_local_projections} supplies the symmetric
     projection structure of each transported local term. If two cyclic supports
     do not meet, the corresponding windows are site-disjoint, so
-    Lemma~\ref{lem:transported_es_nonoverlap_positive} gives the required
+    Lemma~\ref{lem:cyclic_window_nonoverlap_positive} gives the required
     nonnegative ordered cross term. Apply
     Lemma~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} with these
     facts and the displayed overlapping-window estimate.

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -206,8 +206,22 @@ def collect_lean_decls(lean_root: Path) -> dict[str, LeanDecl]:
 # Parse blueprint .tex files
 # ---------------------------------------------------------------------------
 
+def collect_blueprint_lean_names(blueprint_src: Path) -> set[str]:
+    """Return all declaration names appearing in ``\\lean{...}`` tags."""
+    chapter_dir = blueprint_src / "chapter"
+    if not chapter_dir.exists():
+        return set()
+
+    names: set[str] = set()
+    for tex_file in sorted(chapter_dir.glob("*.tex")):
+        text = tex_file.read_text(errors="replace")
+        for lm in _TEX_LEAN_RE.finditer(text):
+            names.update(_split_lean_decls(lm.group(1)))
+    return names
+
+
 def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
-    """Parse all chapter .tex files for \\lean{} and \\leanok."""
+    """Parse theorem-like blueprint environments for ``\\lean{}`` and ``\\leanok``."""
     entries: list[BlueprintEntry] = []
     chapter_dir = blueprint_src / "chapter"
     if not chapter_dir.exists():
@@ -242,7 +256,8 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                     "has_leanok": bool(_TEX_LEANOK_RE.search(line)),
                 }
                 env_stack.append(env)
-                # Check rest of line for \lean{} and \leanok
+                # Check rest of line for \lean{} and \leanok.  Multi-line tags
+                # are attributed to the line where the tag starts.
                 env["lean_decls"].extend(lean_decls_by_line.get(i, []))
                 continue
 
@@ -275,29 +290,21 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                 in_proof = True
                 current_proof = {
                     "has_leanok": bool(_TEX_LEANOK_RE.search(line)),
-                    "_entry_start": len(entries),
                 }
-                if last_env:
-                    for decl in lean_decls_by_line.get(i, []):
-                        entries.append(BlueprintEntry(
-                            file=last_env["file"],
-                            line=i,
-                            env_type="proof",
-                            label=last_env["label"],
-                            lean_decl=decl,
-                            has_leanok=current_proof["has_leanok"],
-                            proof_has_leanok=current_proof["has_leanok"],
-                        ))
                 continue
 
             # Inside a proof block: detect \leanok on its own line
             if in_proof and current_proof and _TEX_LEANOK_RE.search(line):
                 current_proof["has_leanok"] = True
                 continue
+
             # Proof end
             m = _TEX_PROOF_END_RE.search(line)
             if m and in_proof:
-                # Attach proof leanok to all entries from the preceding environment
+                # Attach proof leanok to all entries from the preceding environment.
+                # Inline \lean{} citations inside proof prose are deliberately not
+                # turned into BlueprintEntry values; they are only used when checking
+                # blueprint/lean_decls synchronisation via collect_blueprint_lean_names.
                 if current_proof and current_proof["has_leanok"] and last_env:
                     for idx in range(last_env["_entry_start"], last_env["_entry_end"]):
                         e = entries[idx]
@@ -310,35 +317,13 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                             has_leanok=e.has_leanok,
                             proof_has_leanok=True,
                         )
-                    for idx in range(current_proof["_entry_start"], len(entries)):
-                        e = entries[idx]
-                        entries[idx] = BlueprintEntry(
-                            file=e.file,
-                            line=e.line,
-                            env_type=e.env_type,
-                            label=e.label,
-                            lean_decl=e.lean_decl,
-                            has_leanok=True,
-                            proof_has_leanok=True,
-                        )
                 in_proof = False
                 current_proof = None
                 continue
 
-            # Inside a proof block: collect \lean{} references attached to the
-            # preceding statement/proposition environment.
-            if in_proof and current_proof:
-                if last_env:
-                    for decl in lean_decls_by_line.get(i, []):
-                        entries.append(BlueprintEntry(
-                            file=last_env["file"],
-                            line=i,
-                            env_type="proof",
-                            label=last_env["label"],
-                            lean_decl=decl,
-                            has_leanok=current_proof["has_leanok"],
-                            proof_has_leanok=current_proof["has_leanok"],
-                        ))
+            # Ignore proof prose for formalization statistics.  Raw \lean{} tags
+            # there are collected separately by collect_blueprint_lean_names.
+            if in_proof:
                 continue
 
             # Inside an environment: collect \lean{} and \leanok
@@ -508,30 +493,33 @@ def run_sync(
     report.lean_decls = collect_lean_decls(lean_root)
     print(f"  Found {len(report.lean_decls)} declarations in Lean source")
 
-    # 2. Collect blueprint entries
+    # 2. Collect blueprint entries and raw tag names
     print("Scanning blueprint .tex files …")
+    all_blueprint_decl_names = collect_blueprint_lean_names(blueprint_src)
     report.blueprint_entries = collect_blueprint_entries(blueprint_src)
-    print(f"  Found {len(report.blueprint_entries)} \\lean{{}} references in blueprint")
+    print(f"  Found {len(all_blueprint_decl_names)} unique \\lean{{}} references in blueprint")
+    print(f"  Found {len(report.blueprint_entries)} theorem-like blueprint entries")
 
-    # 3. Cross-reference
-    blueprint_decl_names: set[str] = set()
+    # 3. Cross-reference theorem-like entries against Lean.  Inline proof-prose
+    # citations are intentionally excluded from the formalization statistics; they
+    # are still included in the lean_decls-file synchronisation below.
     for entry in report.blueprint_entries:
-        blueprint_decl_names.add(entry.lean_decl)
         if entry.lean_decl not in report.lean_decls:
             report.missing_in_lean.append(entry)
             if entry.has_leanok:
                 report.leanok_but_missing.append(entry)
 
-    # 4. Check lean_decls file
+    # 4. Check lean_decls file against every raw \lean{} tag, including inline
+    # proof-prose citations that leanblueprint records in blueprint/lean_decls.
     existing_lean_decls = read_lean_decls_file(lean_decls_path)
-    for name in sorted(existing_lean_decls - blueprint_decl_names):
+    for name in sorted(existing_lean_decls - all_blueprint_decl_names):
         report.stale_lean_decls.append(name)
-    for name in sorted(blueprint_decl_names - existing_lean_decls):
+    for name in sorted(all_blueprint_decl_names - existing_lean_decls):
         report.missing_from_lean_decls_file.append(name)
 
     # 5. Optionally update lean_decls
     if update_lean_decls:
-        sorted_decls = sorted(blueprint_decl_names)
+        sorted_decls = sorted(all_blueprint_decl_names)
         lean_decls_path.write_text("\n".join(sorted_decls) + "\n")
         print(f"  Updated {lean_decls_path} with {len(sorted_decls)} entries")
 

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -48,7 +48,7 @@ _SECTION_OPEN_RE = re.compile(
 )
 _NAMESPACE_CLOSE_RE = re.compile(r"^\s*end\s+([\w.]+)", re.MULTILINE)
 
-_TEX_LEAN_RE = re.compile(r"\\lean\{([^}]+)\}")
+_TEX_LEAN_RE = re.compile(r"\\lean\{([^}]*)\}", re.DOTALL)
 _TEX_LEANOK_RE = re.compile(r"\\leanok")
 _TEX_ENV_BEGIN_RE = re.compile(
     r"\\begin\{(definition|theorem|lemma|proposition|corollary|remark|example)\}"
@@ -60,6 +60,18 @@ _TEX_ENV_END_RE = re.compile(
 )
 _TEX_PROOF_BEGIN_RE = re.compile(r"\\begin\{proof\}")
 _TEX_PROOF_END_RE = re.compile(r"\\end\{proof\}")
+
+
+def _split_lean_decls(payload: str) -> list[str]:
+    """Split the contents of a ``\\lean{...}`` tag into declaration names.
+
+    Blueprint tags are often wrapped across several TeX source lines for
+    readability.  Normalising whitespace here keeps the sync checker aligned
+    with ``leanblueprint web``, whose generated ``lean_decls`` file includes
+    declarations from both one-line and multi-line tags.
+    """
+    normalised = re.sub(r"\s+", " ", payload)
+    return [decl.strip() for decl in normalised.split(",") if decl.strip()]
 
 
 # ---------------------------------------------------------------------------
@@ -204,6 +216,12 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
     for tex_file in sorted(chapter_dir.glob("*.tex")):
         text = tex_file.read_text(errors="replace")
         lines = text.splitlines()
+        lean_decls_by_line: dict[int, list[str]] = {}
+        for lm in _TEX_LEAN_RE.finditer(text):
+            start_line = text.count("\n", 0, lm.start()) + 1
+            lean_decls_by_line.setdefault(start_line, []).extend(
+                _split_lean_decls(lm.group(1))
+            )
 
         # State machine: track current environment
         env_stack: list[dict] = []
@@ -225,11 +243,7 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                 }
                 env_stack.append(env)
                 # Check rest of line for \lean{} and \leanok
-                for lm in _TEX_LEAN_RE.finditer(line):
-                    for decl in lm.group(1).split(","):
-                        decl = decl.strip()
-                        if decl:
-                            env["lean_decls"].append(decl)
+                env["lean_decls"].extend(lean_decls_by_line.get(i, []))
                 continue
 
             # Check for environment end
@@ -261,14 +275,25 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                 in_proof = True
                 current_proof = {
                     "has_leanok": bool(_TEX_LEANOK_RE.search(line)),
+                    "_entry_start": len(entries),
                 }
+                if last_env:
+                    for decl in lean_decls_by_line.get(i, []):
+                        entries.append(BlueprintEntry(
+                            file=last_env["file"],
+                            line=i,
+                            env_type="proof",
+                            label=last_env["label"],
+                            lean_decl=decl,
+                            has_leanok=current_proof["has_leanok"],
+                            proof_has_leanok=current_proof["has_leanok"],
+                        ))
                 continue
 
             # Inside a proof block: detect \leanok on its own line
             if in_proof and current_proof and _TEX_LEANOK_RE.search(line):
                 current_proof["has_leanok"] = True
                 continue
-
             # Proof end
             m = _TEX_PROOF_END_RE.search(line)
             if m and in_proof:
@@ -285,17 +310,40 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                             has_leanok=e.has_leanok,
                             proof_has_leanok=True,
                         )
+                    for idx in range(current_proof["_entry_start"], len(entries)):
+                        e = entries[idx]
+                        entries[idx] = BlueprintEntry(
+                            file=e.file,
+                            line=e.line,
+                            env_type=e.env_type,
+                            label=e.label,
+                            lean_decl=e.lean_decl,
+                            has_leanok=True,
+                            proof_has_leanok=True,
+                        )
                 in_proof = False
                 current_proof = None
                 continue
 
+            # Inside a proof block: collect \lean{} references attached to the
+            # preceding statement/proposition environment.
+            if in_proof and current_proof:
+                if last_env:
+                    for decl in lean_decls_by_line.get(i, []):
+                        entries.append(BlueprintEntry(
+                            file=last_env["file"],
+                            line=i,
+                            env_type="proof",
+                            label=last_env["label"],
+                            lean_decl=decl,
+                            has_leanok=current_proof["has_leanok"],
+                            proof_has_leanok=current_proof["has_leanok"],
+                        ))
+                continue
+
             # Inside an environment: collect \lean{} and \leanok
             if env_stack:
-                for lm in _TEX_LEAN_RE.finditer(line):
-                    for decl in lm.group(1).split(","):
-                        decl = decl.strip()
-                        if decl:
-                            env_stack[-1]["lean_decls"].append(decl)
+                env_stack[-1]["lean_decls"].extend(lean_decls_by_line.get(i, []))
                 if _TEX_LEANOK_RE.search(line):
                     env_stack[-1]["has_leanok"] = True
 

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -206,18 +206,34 @@ def collect_lean_decls(lean_root: Path) -> dict[str, LeanDecl]:
 # Parse blueprint .tex files
 # ---------------------------------------------------------------------------
 
-def collect_blueprint_lean_names(blueprint_src: Path) -> set[str]:
-    """Return all declaration names appearing in ``\\lean{...}`` tags."""
+def collect_blueprint_lean_refs(blueprint_src: Path) -> list[BlueprintEntry]:
+    """Return all raw declaration references appearing in ``\\lean{...}`` tags."""
     chapter_dir = blueprint_src / "chapter"
     if not chapter_dir.exists():
-        return set()
+        return []
 
-    names: set[str] = set()
+    refs: list[BlueprintEntry] = []
     for tex_file in sorted(chapter_dir.glob("*.tex")):
         text = tex_file.read_text(errors="replace")
+        rel = str(tex_file.relative_to(blueprint_src.parent))
         for lm in _TEX_LEAN_RE.finditer(text):
-            names.update(_split_lean_decls(lm.group(1)))
-    return names
+            line = text.count("\n", 0, lm.start()) + 1
+            for decl in _split_lean_decls(lm.group(1)):
+                refs.append(BlueprintEntry(
+                    file=rel,
+                    line=line,
+                    env_type="lean-tag",
+                    label=None,
+                    lean_decl=decl,
+                    has_leanok=False,
+                    proof_has_leanok=False,
+                ))
+    return refs
+
+
+def collect_blueprint_lean_names(blueprint_src: Path) -> set[str]:
+    """Return all declaration names appearing in ``\\lean{...}`` tags."""
+    return {ref.lean_decl for ref in collect_blueprint_lean_refs(blueprint_src)}
 
 
 def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
@@ -243,6 +259,24 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
         current_proof: dict | None = None
         last_env: dict | None = None  # last closed environment
 
+        def finish_proof() -> None:
+            """Attach proof ``\\leanok`` to the preceding theorem-like environment."""
+            nonlocal in_proof, current_proof
+            if current_proof and current_proof["has_leanok"] and last_env:
+                for idx in range(last_env["_entry_start"], last_env["_entry_end"]):
+                    e = entries[idx]
+                    entries[idx] = BlueprintEntry(
+                        file=e.file,
+                        line=e.line,
+                        env_type=e.env_type,
+                        label=e.label,
+                        lean_decl=e.lean_decl,
+                        has_leanok=e.has_leanok,
+                        proof_has_leanok=True,
+                    )
+            in_proof = False
+            current_proof = None
+
         for i, line in enumerate(lines, 1):
             # Check for environment begin
             m = _TEX_ENV_BEGIN_RE.search(line)
@@ -256,7 +290,7 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                     "has_leanok": bool(_TEX_LEANOK_RE.search(line)),
                 }
                 env_stack.append(env)
-                # Check rest of line for \lean{} and \leanok.  Multi-line tags
+                # Check rest of line for \\lean{} and \\leanok.  Multi-line tags
                 # are attributed to the line where the tag starts.
                 env["lean_decls"].extend(lean_decls_by_line.get(i, []))
                 continue
@@ -279,54 +313,36 @@ def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
                 env["_entry_start"] = env_entry_start
                 env["_entry_end"] = len(entries)
                 # Only track as last_env if it produced lean entries, so an
-                # intervening remark without \lean{} doesn't steal the proof.
+                # intervening remark without \\lean{} doesn't steal the proof.
                 if env_entry_start < len(entries):
                     last_env = env
                 continue
 
-            # Proof begin
-            m = _TEX_PROOF_BEGIN_RE.search(line)
-            if m:
+            # Proof begin.  Handle one-line proofs such as
+            # ``\\begin{proof}\\leanok ... \\end{proof}`` without leaving the parser
+            # stuck inside proof mode.
+            if _TEX_PROOF_BEGIN_RE.search(line):
                 in_proof = True
                 current_proof = {
                     "has_leanok": bool(_TEX_LEANOK_RE.search(line)),
                 }
+                if _TEX_PROOF_END_RE.search(line):
+                    finish_proof()
                 continue
 
-            # Inside a proof block: detect \leanok on its own line
-            if in_proof and current_proof and _TEX_LEANOK_RE.search(line):
-                current_proof["has_leanok"] = True
-                continue
-
-            # Proof end
-            m = _TEX_PROOF_END_RE.search(line)
-            if m and in_proof:
-                # Attach proof leanok to all entries from the preceding environment.
-                # Inline \lean{} citations inside proof prose are deliberately not
-                # turned into BlueprintEntry values; they are only used when checking
-                # blueprint/lean_decls synchronisation via collect_blueprint_lean_names.
-                if current_proof and current_proof["has_leanok"] and last_env:
-                    for idx in range(last_env["_entry_start"], last_env["_entry_end"]):
-                        e = entries[idx]
-                        entries[idx] = BlueprintEntry(
-                            file=e.file,
-                            line=e.line,
-                            env_type=e.env_type,
-                            label=e.label,
-                            lean_decl=e.lean_decl,
-                            has_leanok=e.has_leanok,
-                            proof_has_leanok=True,
-                        )
-                in_proof = False
-                current_proof = None
-                continue
-
-            # Ignore proof prose for formalization statistics.  Raw \lean{} tags
-            # there are collected separately by collect_blueprint_lean_names.
+            # Inside a proof block, update the proof-status flag before checking
+            # for the proof end, so ``\\leanok`` and ``\\end{proof}`` may share a line.
+            # Inline ``\\lean{}`` citations inside proof prose are deliberately not
+            # turned into BlueprintEntry values; they are only used when checking
+            # blueprint/lean_decls synchronisation via collect_blueprint_lean_refs.
             if in_proof:
+                if current_proof and _TEX_LEANOK_RE.search(line):
+                    current_proof["has_leanok"] = True
+                if _TEX_PROOF_END_RE.search(line):
+                    finish_proof()
                 continue
 
-            # Inside an environment: collect \lean{} and \leanok
+            # Inside an environment: collect \\lean{} and \\leanok
             if env_stack:
                 env_stack[-1]["lean_decls"].extend(lean_decls_by_line.get(i, []))
                 if _TEX_LEANOK_RE.search(line):
@@ -495,21 +511,29 @@ def run_sync(
 
     # 2. Collect blueprint entries and raw tag names
     print("Scanning blueprint .tex files …")
-    all_blueprint_decl_names = collect_blueprint_lean_names(blueprint_src)
+    all_blueprint_refs = collect_blueprint_lean_refs(blueprint_src)
+    all_blueprint_decl_names = {ref.lean_decl for ref in all_blueprint_refs}
     report.blueprint_entries = collect_blueprint_entries(blueprint_src)
     print(f"  Found {len(all_blueprint_decl_names)} unique \\lean{{}} references in blueprint")
     print(f"  Found {len(report.blueprint_entries)} theorem-like blueprint entries")
 
-    # 3. Cross-reference theorem-like entries against Lean.  Inline proof-prose
-    # citations are intentionally excluded from the formalization statistics; they
-    # are still included in the lean_decls-file synchronisation below.
+    # 3. Cross-reference all raw \\lean{} tags against Lean.  Only theorem-like
+    # entries contribute to formalization statistics and \\leanok accounting, but
+    # proof-prose citations should still fail CI if their declaration name is stale
+    # or misspelled.
+    missing_seen: set[str] = set()
     for entry in report.blueprint_entries:
         if entry.lean_decl not in report.lean_decls:
             report.missing_in_lean.append(entry)
+            missing_seen.add(entry.lean_decl)
             if entry.has_leanok:
                 report.leanok_but_missing.append(entry)
+    for ref in all_blueprint_refs:
+        if ref.lean_decl not in report.lean_decls and ref.lean_decl not in missing_seen:
+            report.missing_in_lean.append(ref)
+            missing_seen.add(ref.lean_decl)
 
-    # 4. Check lean_decls file against every raw \lean{} tag, including inline
+    # 4. Check lean_decls file against every raw \\lean{} tag, including inline
     # proof-prose citations that leanblueprint records in blueprint/lean_decls.
     existing_lean_decls = read_lean_decls_file(lean_decls_path)
     for name in sorted(existing_lean_decls - all_blueprint_decl_names):

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -231,11 +231,6 @@ def collect_blueprint_lean_refs(blueprint_src: Path) -> list[BlueprintEntry]:
     return refs
 
 
-def collect_blueprint_lean_names(blueprint_src: Path) -> set[str]:
-    """Return all declaration names appearing in ``\\lean{...}`` tags."""
-    return {ref.lean_decl for ref in collect_blueprint_lean_refs(blueprint_src)}
-
-
 def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
     """Parse theorem-like blueprint environments for ``\\lean{}`` and ``\\leanok``."""
     entries: list[BlueprintEntry] = []


### PR DESCRIPTION
Partially addresses #460. Partially addresses #190.

## Summary

- Strengthens `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs`: the cyclic-window wrapper now composes the merged local projection theorem, row-cardinality theorem, and non-overlap positivity theorem, so its only local hypothesis is the overlapping-window Friedrichs estimate.
- Adds a private support/complement bridge showing that `¬ cyclicWindowsOverlap N L i j` gives the site-disjointness predicate needed by `localTermES_re_inner_nonneg_of_cyclic_windows_disjoint`.
- Updates Chapter 14 and the issue #460 audit note so the remaining spectral-gap analytic task is exactly the overlapping cyclic-window Friedrichs estimate.

## Blueprint / paper anchors

- Blueprint source `blueprint/src/chapter/ch14_parent_hamiltonian.tex:2046`, label `lem:parent_hamiltonian_cyclic_window_friedrichs_gap`, now states: “Suppose uniformly for every $N\ge2L$ that overlapping off-diagonal terms satisfy ...”.
- Blueprint source `blueprint/src/chapter/ch14_parent_hamiltonian.tex:2236`, label `thm:friedrichs_gap_bound`, now says the remaining analytic task is the Friedrichs-angle estimate for overlapping cyclic windows.
- Paper source `Papers/2011.12127/TN-Review-main.tex:2166-2180`, §“The martingale method”: equations `eq:4:martingale-1` / `eq:4:martingale-2` explicitly discard the non-overlapping sum via `\sum''h_i h_j\ge0` and impose the anticommutator estimate only “for all overlapping pairs $(i,j)$”.

## Remaining after this PR

This does not prove the overlapping-window estimate itself (owned separately). The remaining hypothesis has the exact form

```lean
Re ⟪localTermES A L i v, localTermES A L j v⟫ ≥
  - (1 - 1 / (4 * L)) * (2 * (L - 1))⁻¹ *
    Re ⟪localTermES A L i v, v⟫
```

for off-diagonal pairs satisfying `cyclicWindowsOverlap N L i j`.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale` ✅ (only the pre-existing `parentHamiltonianES_gap_bound_of_friedrichs` `sorry` warning)
- `ulimit -n 8192 && lake build +TNLean:olean` ✅ (pre-existing warnings/sorries only)
- `cd blueprint && leanblueprint web` ✅
- `cd blueprint && leanblueprint checkdecls` ✅
- `git diff --check` ✅
- Added-line forbidden-token scan over `*.lean`, `*.tex`, `*.md` ✅ (`none`); full touched Lean-file scan reports only the pre-existing `Martingale.lean` `sorry`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes key theorem interfaces in the parent-Hamiltonian gap reduction and modifies the blueprint sync checker’s parsing/cross-referencing logic, which can affect downstream proofs and CI validation.
> 
> **Overview**
> **Parent-Hamiltonian martingale assembly:** `parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs` no longer takes a separate non-overlap-positivity hypothesis; it now supplies it internally via `localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap`, leaving only the *overlapping* Friedrichs-angle estimate as input.
> 
> Adds `CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap` (support-disjoint ⇒ site-disjoint) to bridge the concrete `cyclicWindowsOverlap` predicate to the disjoint-window commutation/positivity lemma, and updates the downstream overlap-only wrapper accordingly.
> 
> **Docs/tooling updates:** Refreshes the audit note and Chapter 14 blueprint text to reflect the new “overlap-only” remaining obligation, and enhances `scripts/blueprint_lean_sync.py` to correctly parse multi-line `\lean{...}` tags, attribute proof `\leanok` even when `\end{proof}` is on the same line, and validate *all* raw `\lean{}` citations (including inline proof prose) against Lean + `blueprint/lean_decls`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 307c84e77170bc5c898bc13eeae5cdbb3e2b996a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->