### PR TITLE
fix(MPS/CanonicalForm): handle the length-zero term in sector comparison

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -481,7 +481,7 @@ theorem sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
       mpv A σ = mpv (zeroMPSTensor d z₁) σ + mpv liveA σ)
     (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
       mpv B σ = mpv (zeroMPSTensor d z₂) σ + mpv liveB σ)
-    (hz : (z₁ : ℂ) = (z₂ : ℂ)) :
+    (hz : z₁ = z₂) :
     SameMPV₂ liveA liveB := by
   intro N σ
   have hsum :
@@ -501,8 +501,8 @@ theorem sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
       simp
     have hsum' :
         (z₂ : ℂ) + mpv liveA σ = (z₂ : ℂ) + mpv liveB σ := by
-      rw [hz₁mpv, hz₂mpv, hz]
-        at hsum
+      rw [hz₁mpv, hz₂mpv] at hsum
+      rw [hz] at hsum
       exact hsum
     exact add_left_cancel hsum'
   · have hz₁mpv : mpv (zeroMPSTensor d z₁) σ = 0 := by
@@ -514,7 +514,7 @@ theorem sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
     have hsum' : (0 : ℂ) + mpv liveA σ = 0 + mpv liveB σ := by
       rw [hz₁mpv, hz₂mpv] at hsum
       exact hsum
-    simpa using hsum'
+    simpa [zero_add] using hsum'
 
 /-- **Common live-block sector comparison with explicit zero-tail bookkeeping.**
 
@@ -546,7 +546,7 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSp
         mpv (blockTensor (d := d) (D := D₂) B p) σ =
           mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
             mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ)
-    (hZeroTail : (zeroTailA : ℂ) = (zeroTailB : ℂ))
+    (hZeroTail : zeroTailA = zeroTailB)
     (hTPA : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksA k i)ᴴ * blocksA k i = 1)
     (hTPB : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksB k i)ᴴ * blocksB k i = 1)
     (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -466,6 +466,170 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSp
   exact ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt,
           M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
 
+/-- Remove matching zero tails from two MPV identities.
+
+If `A` and `B` have the same MPVs, and each is expressed as a zero tail plus a live tensor,
+then equality of the zero-tail dimensions gives full `SameMPV₂` equality of the live tensors.
+For positive lengths the zero tails vanish; at length zero this is exactly the missing
+bookkeeping condition. -/
+theorem sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+    {d D₁ D₂ L₁ L₂ z₁ z₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (liveA : MPSTensor d L₁) (liveB : MPSTensor d L₂)
+    (hSame : SameMPV₂ A B)
+    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z₁) σ + mpv liveA σ)
+    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv B σ = mpv (zeroMPSTensor d z₂) σ + mpv liveB σ)
+    (hz : (z₁ : ℂ) = (z₂ : ℂ)) :
+    SameMPV₂ liveA liveB := by
+  intro N σ
+  have hsum :
+      mpv (zeroMPSTensor d z₁) σ + mpv liveA σ =
+        mpv (zeroMPSTensor d z₂) σ + mpv liveB σ := by
+    calc
+      mpv (zeroMPSTensor d z₁) σ + mpv liveA σ = mpv A σ := (hA N σ).symm
+      _ = mpv B σ := hSame N σ
+      _ = mpv (zeroMPSTensor d z₂) σ + mpv liveB σ := hB N σ
+  by_cases hN : N = 0
+  · subst hN
+    have hz₁mpv : mpv (zeroMPSTensor d z₁) σ = (z₁ : ℂ) := by
+      rw [mpv_zeroMPSTensor]
+      simp
+    have hz₂mpv : mpv (zeroMPSTensor d z₂) σ = (z₂ : ℂ) := by
+      rw [mpv_zeroMPSTensor]
+      simp
+    have hsum' :
+        (z₂ : ℂ) + mpv liveA σ = (z₂ : ℂ) + mpv liveB σ := by
+      rw [hz₁mpv, hz₂mpv, hz]
+        at hsum
+      exact hsum
+    exact add_left_cancel hsum'
+  · have hz₁mpv : mpv (zeroMPSTensor d z₁) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [hN]
+    have hz₂mpv : mpv (zeroMPSTensor d z₂) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [hN]
+    have hsum' : (0 : ℂ) + mpv liveA σ = 0 + mpv liveB σ := by
+      rw [hz₁mpv, hz₂mpv] at hsum
+      exact hsum
+    simpa using hsum'
+
+/-- **Common live-block sector comparison with explicit zero-tail bookkeeping.**
+
+This is the zero-tail-aware variant of
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan`.
+The blocked tensors are related to their live parts only at positive lengths,
+which is the strongest statement available after removing a nonzero zero tail. If the two
+zero-tail dimensions agree, the live parts themselves are full `SameMPV₂`, including `N = 0`,
+so the existing sector-matching layer applies unchanged. -/
+theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail
+    {d D₁ D₂ p rA rB zeroTailA zeroTailB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k : Fin rA, NeZero (dimA k)]
+    [∀ k : Fin rB, NeZero (dimB k)]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hp : 0 < p)
+    (μA : Fin rA → ℂ)
+    (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d p) (dimA k))
+    (μB : Fin rB → ℂ)
+    (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d p) (dimB k))
+    (hAblocks :
+      ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ)
+    (hBblocks :
+      ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ)
+    (hZeroTail : (zeroTailA : ℂ) = (zeroTailB : ℂ))
+    (hTPA : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksA k i)ᴴ * blocksA k i = 1)
+    (hTPB : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksB k i)ᴴ * blocksB k i = 1)
+    (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))
+    (hIrrB : ∀ k, IsIrreducibleTensor (blocksB k))
+    (hPrimA : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimA k) (blocksA k)))
+    (hPrimB : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimB k) (blocksB k)))
+    (hμA : ∀ k, μA k ≠ 0)
+    (hμB : ∀ k, μB k ≠ 0)
+    (overlapSpanData :
+      ∀ P Q : SectorDecomposition (blockPhysDim d p),
+        SameMPV₂ P.toTensor (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+        SameMPV₂ Q.toTensor (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+        HasBNTSectorData P → HasBNTSectorData Q →
+        SectorBasisOverlapSpanHypotheses P Q) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  let liveA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let liveB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  obtain ⟨P, hPblocks, hPbnt⟩ :=
+    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
+      (d := blockPhysDim d p) μA blocksA hTPA hIrrA hPrimA hμA
+  obtain ⟨Q, hQblocks, hQbnt⟩ :=
+    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
+      (d := blockPhysDim d p) μB blocksB hTPB hIrrB hPrimB hμB
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hLive : SameMPV₂ liveA liveB :=
+    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      liveA liveB hAB hAblocks hBblocks hZeroTail
+  have hPeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p) P.toTensor := by
+    intro N hN σ
+    have hZero :
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ
+          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ + mpv liveA σ :=
+            hAblocks N σ
+      _ = mpv liveA σ := by rw [hZero]; simp
+      _ = mpv P.toTensor σ := (hPblocks N σ).symm
+  have hQeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p) Q.toTensor := by
+    intro N hN σ
+    have hZero :
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ
+          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ + mpv liveB σ :=
+            hBblocks N σ
+      _ = mpv liveB σ := by rw [hZero]; simp
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ = mpv liveA σ := hPblocks N σ
+      _ = mpv liveB σ := hLive N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  have hOverlapSpan := overlapSpanData P Q hPblocks hQblocks hPbnt hQbnt
+  obtain ⟨M⟩ := hOverlapSpan.exists_sectorBasisMatching hPQeq
+  obtain ⟨ζ, hζne, hMultiset⟩ :=
+    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching M hPbnt hPQeq
+  exact ⟨p, hp, P, Q, hPeqPos, hQeqPos, hPQeq, hPbnt, hQbnt,
+          M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
+
 /-!
 ### What remains for the full 1606.00608 Fundamental Theorem
 

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -89,6 +89,13 @@ block decompositions whose summands need not live in the same matrix algebra. -/
 def SameMPV₂ {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
   ∀ (N : ℕ) (σ : Fin N → Fin d), mpv A σ = mpv B σ
 
+/-- Positive-length MPV equality for possibly different bond dimensions.
+
+This is useful when compressions or zero-tail removals change the `N = 0`
+coefficient but preserve all nonempty-chain coefficients. -/
+def SameMPV₂Pos {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
+  ∀ {N : ℕ}, 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = mpv B σ
+
 /-- Proportionality of MPVs: for each N there exists c_N with V_N(A) = c_N · V_N(B). -/
 def ProportionalMPV₂ {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
   ∀ N : ℕ, ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -94,7 +94,7 @@ def SameMPV₂ {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
 This is useful when compressions or zero-tail removals change the `N = 0`
 coefficient but preserve all nonempty-chain coefficients. -/
 def SameMPV₂Pos {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
-  ∀ {N : ℕ}, 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = mpv B σ
+  ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = mpv B σ
 
 /-- Proportionality of MPVs: for each N there exists c_N with V_N(A) = c_N · V_N(B). -/
 def ProportionalMPV₂ {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -188,6 +188,16 @@ boundary conditions (PBC).
     $\ket{V^{(N)}(A)} = \ket{V^{(N)}(B)}$ for every $N$.
 \end{definition}
 
+\begin{definition}[Positive-length same MPV — different bond dimensions]%
+\label{def:same_mpv2_pos}
+    \lean{MPSTensor.SameMPV₂Pos}
+    \leanok
+    \uses{def:mpv}
+    For tensors $A$ and $B$ of possibly different bond dimensions,
+    we write $\mc{V}^+(A) = \mc{V}^+(B)$ if
+    $\ket{V^{(N)}(A)} = \ket{V^{(N)}(B)}$ for every $N > 0$.
+\end{definition}
+
 \begin{remark}\leanok
     Definition~\ref{def:same_mpv} is the same-bond-dimension
     specialization of Definition~\ref{def:same_mpv2}.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -777,6 +777,58 @@ single weighted block.
 	sector-weight conclusion.
 \end{proof}
 
+\begin{lemma}[Zero-tail cancellation]\label{lem:sameMPV2_live_of_zeroTail_eq}
+	\lean{MPSTensor.sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq}
+	\leanok
+	\uses{def:same_mpv2, def:mpv}
+	Let $A$ and $B$ have the same MPV family, each decomposed as a zero-tail
+	tensor plus a live tensor. If the zero-tail dimensions agree, then the
+	live tensors themselves have the same MPV family, including at length zero.
+\end{lemma}
+
+\begin{proof}
+	\leanok
+	\uses{def:mpv}
+	At positive lengths the zero-tail term vanishes, so the live tensors
+	agree. At length zero the zero-tail values are equal by hypothesis, and
+	cancellation gives equality of the live tensors there too.
+\end{proof}
+
+\begin{theorem}[Common live blocks with zero-tail agreement and overlap-span data]%
+\label{thm:after_blocking_sector_common_blocks_overlap_span_zero_tail}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail}
+	\leanok
+	\uses{def:same_mpv2_pos, lem:sameMPV2_live_of_zeroTail_eq,
+		thm:bnt_sector_decomp_tp_prim_irr_collapsed,
+		def:sector_basis_overlap_span_hyps}
+	Let $A$ and $B$ have the same MPV family. Fix $p > 0$ and suppose
+	$A^{[p]}$ and $B^{[p]}$ each decompose as a zero-tail tensor plus a
+	weighted live block tensor, with all blocks trace-preserving, primitive,
+	irreducible, and with nonzero weights. If the two zero-tail dimensions
+	agree and any pair of BNT sector decompositions equivalent to the two live
+	block tensors satisfies the primitive overlap-span hypotheses, then there
+	exist positive $p'$ and sector decompositions $P$, $Q$ such that
+	$A^{[p']}$ equals $P$'s tensor at all positive lengths, $B^{[p']}$ equals
+	$Q$'s tensor at all positive lengths, $P$ and $Q$ have the same full MPV
+	family, both have BNT data, and the matched sector-weight conclusion of
+	Theorem~\ref{thm:after_blocking_sector_bnt_pair_overlap_span} holds.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{lem:sameMPV2_live_of_zeroTail_eq,
+		thm:bnt_sector_decomp_tp_prim_irr_collapsed,
+		thm:sector_basis_overlap_span_to_matching,
+		thm:route_b_hetero_sector_matching}
+	Apply the zero-tail cancellation lemma to recover full equality of the
+	live block tensors. Then proceed as in
+	Theorem~\ref{thm:after_blocking_sector_common_blocks_overlap_span}: apply
+	the BNT construction to each live block family, compose the sector
+	equivalences to obtain equality of the total MPV families of $P$ and $Q$,
+	apply the overlap-span matching theorem, and conclude with the
+	heterogeneous sector comparison theorem.
+\end{proof}
+
 \begin{theorem}[Cast-compatible MPV scaling implies phase-matched sector comparison]%
 \label{thm:route_b_hetero_mpv_scaling}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis}


### PR DESCRIPTION
### Motivation

- Issue #943 identified that the after-blocking sector comparison cannot freely discard zero tails under full `SameMPV₂`, because the `N = 0` coefficient remembers bond dimension.
- Positive lengths can ignore the zero tail, but full `SameMPV₂` of the nonzero sector tensors requires the `N = 0` case to be recovered from equality of zero-tail dimensions.

### Description

- `TNLean/MPS/Defs.lean`: add `SameMPV₂Pos` for positive-length heterogeneous MPV equality
- `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`: add a zero-tail cancellation lemma proving nonzero block tensors satisfy full `SameMPV₂` when zero-tail dimensions agree; add a zero-tail-aware after-blocking sector comparison variant that states positive-length equivalence to the blocked tensors while preserving full `SameMPV₂` between nonzero sector tensors

### Testing

- `lake build TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` succeeds (existing long-line warnings in `CyclicSectorDecomposition.lean` are pre-existing and unrelated)

---
Closes #943

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive Lean changes (new predicate and theorems) with limited blast radius, but downstream proofs may need updates to choose between full vs positive-length MPV equality.
> 
> **Overview**
> Fixes the after-blocking sector-comparison pipeline to **account for nontrivial zero tails** at `N = 0`.
> 
> Adds `SameMPV₂Pos` (positive-length heterogeneous MPV equality) and a `sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq` cancellation lemma to recover full `SameMPV₂` for nonzero block tensors when the two zero-tail dimensions agree.
> 
> Introduces `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail`, a variant of the common-nonzero-block overlap-span theorem that only relates the blocked tensors to sector tensors for `N > 0` while still proving full `SameMPV₂` between the constructed sector tensors; the blueprint is updated with the corresponding definition/lemma/theorem statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13560ccd887543a23694e9ee6dcd7166bc9ce3f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->