### PR TITLE
feat(MPS/CanonicalForm): expose collapsed BNT overlap data

### DIFF
--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -635,6 +635,91 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_blocksNotGaugePhas
     exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
       blocks hTP hIrr hPrim hBlocks
 
+/-- The concrete collapsed-representative sector decomposition obtained from MPV phase classes. -/
+private noncomputable def collapsedBntSectorDecomp
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hμne : ∀ k, μ k ≠ 0) : SectorDecomposition d :=
+  let classes := mpvPhaseClassData blocks
+  let ζFn : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
+    fun j q => (classes.enum_phase j q).choose
+  let hζ_ne : ∀ j q, ζFn j q ≠ 0 :=
+    fun j q => (classes.enum_phase j q).choose_spec.1
+  let sectors : SectorWeightData classes.g := {
+    copies := classes.copies
+    copies_pos := classes.copies_pos
+    weight := fun j q => ζFn j q * μ (classes.enum j q)
+    weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j q) (hμne (classes.enum j q))
+  }
+  {
+    basisCount := classes.g
+    basisDim := fun j => dim (classes.repr j)
+    basis := fun j => blocks (classes.repr j)
+    sectors := sectors
+  }
+
+private theorem collapsedBntSectorDecomp_sameMPV₂
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hμne : ∀ k, μ k ≠ 0) :
+    SameMPV₂ (collapsedBntSectorDecomp (d := d) μ blocks hμne).toTensor
+      (toTensorFromBlocks (d := d) (μ := μ) blocks) := by
+  classical
+  let classes := mpvPhaseClassData blocks
+  let ζFn : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
+    fun j q => (classes.enum_phase j q).choose
+  have hζ_mpv : ∀ j q (N : ℕ) (σ : Fin N → Fin d),
+      mpv (blocks (classes.enum j q)) σ = (ζFn j q) ^ N * mpv (blocks (classes.repr j)) σ :=
+    fun j q N σ => (classes.enum_phase j q).choose_spec.2 N σ
+  let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
+  intro N σ
+  calc mpv P.toTensor σ
+      = ∑ j : Fin P.basisCount,
+          ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
+          P.mpv_toTensor_eq_sum_sectors σ
+    _ = ∑ j : Fin classes.g,
+          ∑ q : Fin (classes.copies j),
+            (ζFn j q * μ (classes.enum j q)) ^ N *
+              mpv (blocks (classes.repr j)) σ := by
+            rfl
+    _ = ∑ j : Fin classes.g,
+          ∑ q : Fin (classes.copies j),
+            (μ (classes.enum j q)) ^ N * mpv (blocks (classes.enum j q)) σ := by
+            refine Finset.sum_congr rfl (fun j _ =>
+              Finset.sum_congr rfl (fun q _ => ?_))
+            rw [mul_pow, hζ_mpv j q N σ]
+            ring
+    _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ :=
+          classes.regroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
+    _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+            symm
+            simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
+
+private theorem collapsedBntSectorDecomp_hasBNT
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hμne : ∀ k, μ k ≠ 0) :
+    HasBNTSectorData (d := d) (collapsedBntSectorDecomp (d := d) μ blocks hμne) := by
+  classical
+  let classes := mpvPhaseClassData blocks
+  let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
+  have hLI : ∃ N0 : ℕ, ∀ N > N0,
+      LinearIndependent ℂ
+        (fun j : Fin classes.g => mpvState (d := d) (blocks (classes.repr j)) N) :=
+    exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
+      (fun j : Fin classes.g => blocks (classes.repr j))
+      (fun j => hTP (classes.repr j))
+      (fun j => hIrr (classes.repr j))
+      (fun j => hPrim (classes.repr j))
+      classes.blocks_not_equiv
+  simpa [P, collapsedBntSectorDecomp] using hLI
+
 /-- **Unconditional one-sided BNT sector construction for primitive irreducible blocks.**
 
 Starting from arbitrary trace-preserving primitive irreducible blocks with
@@ -655,58 +740,9 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
     ∃ P : SectorDecomposition d,
       SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
       HasBNTSectorData (d := d) P := by
-  classical
-  let classes := mpvPhaseClassData blocks
-  let ζFn : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
-    fun j q => (classes.enum_phase j q).choose
-  have hζ_ne : ∀ j q, ζFn j q ≠ 0 := fun j q => (classes.enum_phase j q).choose_spec.1
-  have hζ_mpv : ∀ j q (N : ℕ) (σ : Fin N → Fin d),
-      mpv (blocks (classes.enum j q)) σ = (ζFn j q) ^ N * mpv (blocks (classes.repr j)) σ :=
-    fun j q N σ => (classes.enum_phase j q).choose_spec.2 N σ
-  let sectors : SectorWeightData classes.g := {
-    copies := classes.copies
-    copies_pos := classes.copies_pos
-    weight := fun j q => ζFn j q * μ (classes.enum j q)
-    weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j q) (hμne (classes.enum j q))
-  }
-  let P : SectorDecomposition d := {
-    basisCount := classes.g
-    basisDim := fun j => dim (classes.repr j)
-    basis := fun j => blocks (classes.repr j)
-    sectors := sectors
-  }
-  refine ⟨P, ?_, ?_⟩
-  · intro N σ
-    calc mpv P.toTensor σ
-        = ∑ j : Fin P.basisCount,
-            ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
-            P.mpv_toTensor_eq_sum_sectors σ
-      _ = ∑ j : Fin classes.g,
-            ∑ q : Fin (classes.copies j),
-              (ζFn j q * μ (classes.enum j q)) ^ N *
-                mpv (blocks (classes.repr j)) σ := rfl
-      _ = ∑ j : Fin classes.g,
-            ∑ q : Fin (classes.copies j),
-              (μ (classes.enum j q)) ^ N * mpv (blocks (classes.enum j q)) σ := by
-              refine Finset.sum_congr rfl (fun j _ =>
-                Finset.sum_congr rfl (fun q _ => ?_))
-              rw [mul_pow, hζ_mpv j q N σ]
-              ring
-      _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ :=
-            classes.regroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
-      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
-              symm
-              simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
-  · have hLI : ∃ N0 : ℕ, ∀ N > N0,
-        LinearIndependent ℂ
-          (fun j : Fin classes.g => mpvState (d := d) (blocks (classes.repr j)) N) :=
-      exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
-        (fun j : Fin classes.g => blocks (classes.repr j))
-        (fun j => hTP (classes.repr j))
-        (fun j => hIrr (classes.repr j))
-        (fun j => hPrim (classes.repr j))
-        classes.blocks_not_equiv
-    simpa [P] using hLI
+  refine ⟨collapsedBntSectorDecomp (d := d) μ blocks hμne, ?_, ?_⟩
+  · exact collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
+  · exact collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
 
 /-- **Collapsed BNT sector construction with primitive overlap data.**
 
@@ -714,7 +750,7 @@ This strengthens `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` by exposin
 properties of the chosen representative basis blocks that are needed by the overlap-rigidity
 layer. The extra `hInj` hypothesis is intentional: the one-sided BNT constructor assumes
 irreducibility, primitivity, and trace preservation, while
-`SectorBasisOverlapSpanHypotheses` consumes one-letter injectivity.
+`SectorBasisOverlapSpanHypotheses` consumes length-1 MPS-injectivity.
 
 The finite-span comparison between two independently constructed sector bases is not part of
 this one-sided theorem; it depends on comparing the two sides. -/
@@ -741,70 +777,26 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData
           Filter.atTop (nhds 0)) := by
   classical
   let classes := mpvPhaseClassData blocks
-  let ζFn : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
-    fun j q => (classes.enum_phase j q).choose
-  have hζ_ne : ∀ j q, ζFn j q ≠ 0 := fun j q => (classes.enum_phase j q).choose_spec.1
-  have hζ_mpv : ∀ j q (N : ℕ) (σ : Fin N → Fin d),
-      mpv (blocks (classes.enum j q)) σ = (ζFn j q) ^ N * mpv (blocks (classes.repr j)) σ :=
-    fun j q N σ => (classes.enum_phase j q).choose_spec.2 N σ
-  let sectors : SectorWeightData classes.g := {
-    copies := classes.copies
-    copies_pos := classes.copies_pos
-    weight := fun j q => ζFn j q * μ (classes.enum j q)
-    weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j q) (hμne (classes.enum j q))
-  }
-  let P : SectorDecomposition d := {
-    basisCount := classes.g
-    basisDim := fun j => dim (classes.repr j)
-    basis := fun j => blocks (classes.repr j)
-    sectors := sectors
-  }
-  have hSame : SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) := by
-    intro N σ
-    calc mpv P.toTensor σ
-        = ∑ j : Fin P.basisCount,
-            ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
-            P.mpv_toTensor_eq_sum_sectors σ
-      _ = ∑ j : Fin classes.g,
-            ∑ q : Fin (classes.copies j),
-              (ζFn j q * μ (classes.enum j q)) ^ N *
-                mpv (blocks (classes.repr j)) σ := rfl
-      _ = ∑ j : Fin classes.g,
-            ∑ q : Fin (classes.copies j),
-              (μ (classes.enum j q)) ^ N * mpv (blocks (classes.enum j q)) σ := by
-              refine Finset.sum_congr rfl (fun j _ =>
-                Finset.sum_congr rfl (fun q _ => ?_))
-              rw [mul_pow, hζ_mpv j q N σ]
-              ring
-      _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ :=
-            classes.regroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
-      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
-              symm
-              simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
-  have hBNT : HasBNTSectorData (d := d) P := by
-    have hLI : ∃ N0 : ℕ, ∀ N > N0,
-        LinearIndependent ℂ
-          (fun j : Fin classes.g => mpvState (d := d) (blocks (classes.repr j)) N) :=
-      exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
-        (fun j : Fin classes.g => blocks (classes.repr j))
-        (fun j => hTP (classes.repr j))
-        (fun j => hIrr (classes.repr j))
-        (fun j => hPrim (classes.repr j))
-        classes.blocks_not_equiv
-    simpa [P] using hLI
+  let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
+  have hSame : SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) :=
+    collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
+  have hBNT : HasBNTSectorData (d := d) P :=
+    collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
   refine ⟨P, hSame, hBNT, ?_, ?_, ?_, ?_, ?_⟩
   · intro j
-    exact NeZero.pos (dim (classes.repr j))
+    simpa [P, collapsedBntSectorDecomp] using NeZero.pos (dim (classes.repr j))
   · intro j
-    exact hInj (classes.repr j)
+    simpa [P, collapsedBntSectorDecomp] using hInj (classes.repr j)
   · intro j
-    exact hTP (classes.repr j)
+    simpa [P, collapsedBntSectorDecomp] using hTP (classes.repr j)
   · intro j
-    exact overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+    simpa [P, collapsedBntSectorDecomp] using
+      overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
       (blocks (classes.repr j)) (hIrr (classes.repr j)) (hTP (classes.repr j))
       (hPrim (classes.repr j))
   · intro i j hij
-    exact cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
+    simpa [P, collapsedBntSectorDecomp] using
+      cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
       (fun j : Fin classes.g => blocks (classes.repr j))
       (HasIrreducibleBlocks.ofForall (fun j => hIrr (classes.repr j)))
       (IsLeftCanonicalBlockFamily.ofForall (fun j => hTP (classes.repr j)))

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -708,6 +708,108 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
         classes.blocks_not_equiv
     simpa [P] using hLI
 
+/-- **Collapsed BNT sector construction with primitive overlap data.**
+
+This strengthens `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` by exposing the
+properties of the chosen representative basis blocks that are needed by the overlap-rigidity
+layer. The extra `hInj` hypothesis is intentional: the one-sided BNT constructor assumes
+irreducibility, primitivity, and trace preservation, while
+`SectorBasisOverlapSpanHypotheses` consumes one-letter injectivity.
+
+The finite-span comparison between two independently constructed sector bases is not part of
+this one-sided theorem; it depends on comparing the two sides. -/
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hInj : ∀ k, IsInjective (blocks k))
+    (hμne : ∀ k, μ k ≠ 0) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P ∧
+      (∀ j : Fin P.basisCount, 0 < P.basisDim j) ∧
+      (∀ j : Fin P.basisCount, IsInjective (P.basis j)) ∧
+      (∀ j : Fin P.basisCount, (∑ i : Fin d, (P.basis j i)ᴴ * (P.basis j i)) = 1) ∧
+      (∀ j : Fin P.basisCount,
+        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
+          Filter.atTop (nhds (1 : ℂ))) ∧
+      (∀ i j : Fin P.basisCount, i ≠ j →
+        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
+          Filter.atTop (nhds 0)) := by
+  classical
+  let classes := mpvPhaseClassData blocks
+  let ζFn : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
+    fun j q => (classes.enum_phase j q).choose
+  have hζ_ne : ∀ j q, ζFn j q ≠ 0 := fun j q => (classes.enum_phase j q).choose_spec.1
+  have hζ_mpv : ∀ j q (N : ℕ) (σ : Fin N → Fin d),
+      mpv (blocks (classes.enum j q)) σ = (ζFn j q) ^ N * mpv (blocks (classes.repr j)) σ :=
+    fun j q N σ => (classes.enum_phase j q).choose_spec.2 N σ
+  let sectors : SectorWeightData classes.g := {
+    copies := classes.copies
+    copies_pos := classes.copies_pos
+    weight := fun j q => ζFn j q * μ (classes.enum j q)
+    weight_ne_zero := fun j q => mul_ne_zero (hζ_ne j q) (hμne (classes.enum j q))
+  }
+  let P : SectorDecomposition d := {
+    basisCount := classes.g
+    basisDim := fun j => dim (classes.repr j)
+    basis := fun j => blocks (classes.repr j)
+    sectors := sectors
+  }
+  have hSame : SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) := by
+    intro N σ
+    calc mpv P.toTensor σ
+        = ∑ j : Fin P.basisCount,
+            ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
+            P.mpv_toTensor_eq_sum_sectors σ
+      _ = ∑ j : Fin classes.g,
+            ∑ q : Fin (classes.copies j),
+              (ζFn j q * μ (classes.enum j q)) ^ N *
+                mpv (blocks (classes.repr j)) σ := rfl
+      _ = ∑ j : Fin classes.g,
+            ∑ q : Fin (classes.copies j),
+              (μ (classes.enum j q)) ^ N * mpv (blocks (classes.enum j q)) σ := by
+              refine Finset.sum_congr rfl (fun j _ =>
+                Finset.sum_congr rfl (fun q _ => ?_))
+              rw [mul_pow, hζ_mpv j q N σ]
+              ring
+      _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ :=
+            classes.regroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+              symm
+              simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
+  have hBNT : HasBNTSectorData (d := d) P := by
+    have hLI : ∃ N0 : ℕ, ∀ N > N0,
+        LinearIndependent ℂ
+          (fun j : Fin classes.g => mpvState (d := d) (blocks (classes.repr j)) N) :=
+      exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
+        (fun j : Fin classes.g => blocks (classes.repr j))
+        (fun j => hTP (classes.repr j))
+        (fun j => hIrr (classes.repr j))
+        (fun j => hPrim (classes.repr j))
+        classes.blocks_not_equiv
+    simpa [P] using hLI
+  refine ⟨P, hSame, hBNT, ?_, ?_, ?_, ?_, ?_⟩
+  · intro j
+    exact NeZero.pos (dim (classes.repr j))
+  · intro j
+    exact hInj (classes.repr j)
+  · intro j
+    exact hTP (classes.repr j)
+  · intro j
+    exact overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      (blocks (classes.repr j)) (hIrr (classes.repr j)) (hTP (classes.repr j))
+      (hPrim (classes.repr j))
+  · intro i j hij
+    exact cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
+      (fun j : Fin classes.g => blocks (classes.repr j))
+      (HasIrreducibleBlocks.ofForall (fun j => hIrr (classes.repr j)))
+      (IsLeftCanonicalBlockFamily.ofForall (fun j => hTP (classes.repr j)))
+      classes.blocks_not_equiv i j hij
+
 /-! ### §6. Conditional sector construction under BNT linear independence -/
 
 /-- **Minimal granular sector decomposition carrying current `HasBNTSectorData`.**

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2275,6 +2275,31 @@ The following results separate the zero blocks from the
 	linear-independence condition.
 \end{proof}
 
+\begin{theorem}[Collapsed representative BNT sector construction with overlap data]
+	\label{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}
+	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData}
+	\leanok
+	\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed, thm:bnt_li_tp_prim_irr_separated}
+	For trace-preserving primitive irreducible blocks of positive bond dimension,
+	with nonzero weights, suppose moreover that the blocks are injective. Then
+	there is a collapsed representative sector decomposition representing the
+	same weighted block sum, satisfying the BNT linear-independence condition,
+	and whose chosen basis blocks have positive bond dimension, are injective and
+	trace-preserving, have self-overlap tending to~$1$, and have mutual overlaps
+	tending to~$0$ for distinct basis blocks.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{def:mpv_phase_class_data, thm:bnt_li_tp_prim_irr_separated}
+	Choose one representative per MPV phase class and absorb the phase factors
+	into the sector weights as in
+	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}. The
+	representatives inherit positivity of the bond dimension, injectivity, and
+	trace preservation from the original blocks. Their self-overlap limits follow
+	from primitivity and irreducibility, while their mutual overlap limits follow
+	from the separation of distinct phase-class representatives.
+\end{proof}
+
 \begin{theorem}[TP primitive irreducible version with eventual BNT independence]
 	\label{thm:bnt_sector_decomp_tp_prim_irr_linear_independent}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2279,7 +2279,7 @@ The following results separate the zero blocks from the
 	\label{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData}
 	\leanok
-	\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed, thm:bnt_li_tp_prim_irr_separated}
+	\uses{thm:bnt_li_tp_prim_irr_separated}
 	For trace-preserving primitive irreducible blocks of positive bond dimension,
 	with nonzero weights, suppose moreover that the blocks are injective. Then
 	there is a collapsed representative sector decomposition representing the
@@ -2290,7 +2290,8 @@ The following results separate the zero blocks from the
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{def:mpv_phase_class_data, thm:bnt_li_tp_prim_irr_separated}
+	\uses{def:mpv_phase_class_data, thm:bnt_li_tp_prim_irr_separated,
+		thm:bnt_sector_decomp_tp_prim_irr_collapsed}
 	Choose one representative per MPV phase class and absorb the phase factors
 	into the sector weights as in
 	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}. The


### PR DESCRIPTION
### Motivation

- `SectorBasisOverlapSpanHypotheses` requires the collapsed BNT representatives to satisfy positive bond dimensions, injectivity, normalization, asymptotic self-overlap, and asymptotic off-overlap conditions, but the existing `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` theorem does not expose these fields.
- Packaging this data in one theorem lets `overlapSpanData` in `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan` be discharged from structural hypotheses alone, making the unconditional `fundamentalTheorem_after_blocking_1606_sector` a direct corollary.
- Continues formalization of arXiv:1606.00608 §2.3 / Appendix A (CPSV17 Theorem 1), see #944.

### Description

- Modified `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`: added `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData`, exposing the collapsed representative sector decomposition together with BNT linear independence, positive bond dimensions, injectivity (`hInj`), normalization, self-overlap limits, and off-overlap limits. Injectivity is made explicit because the existing TP + primitive + irreducible block hypotheses do not yet provide `IsInjective` directly in the Lean API.
- Modified `blueprint/src/chapter/ch08_canonical.tex`: added corresponding blueprint entry in Chapter 8.
- The two-sided finite span equality required by `SectorBasisOverlapSpanHypotheses` remains a separate step (not addressed here).

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.CanonicalForm.EqualNormBridge`
- `git diff --check`
- `leanblueprint checkdecls` was not run locally (not installed in this environment); relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
Addresses #944

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a proof-focused refactor/addition that factors out the collapsed sector decomposition and adds a new theorem exposing extra overlap/injectivity facts, without changing computational behavior.
> 
> **Overview**
> Adds a factored-out collapsed-sector construction (`collapsedBntSectorDecomp`) for the one-sided BNT pipeline and rewires `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` to use it via separate `SameMPV₂` and `HasBNTSectorData` lemmas.
> 
> Introduces `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData`, which additionally returns **overlap-rigidity inputs** about the chosen representatives (positive bond dimension, injectivity, TP normalization, and self-/cross-overlap limits), and documents the new result in the Chapter 8 blueprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d92b1a75286a6cc0725f30ffb59c220fb73fbb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->