### PR TITLE
doc(blueprint): clarify equal-case canonical-form gap

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2272,7 +2272,7 @@ The following results separate the zero blocks from the
 	distinct representatives are not gauge-phase equivalent.
 \end{definition}
 
-\begin{theorem}[Collapsed representative BNT sector construction]
+\begin{theorem}[Phase-class BNT sector construction]
 	\label{thm:bnt_sector_decomp_tp_prim_irr_collapsed}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks}
 	\leanok
@@ -2296,18 +2296,18 @@ The following results separate the zero blocks from the
 	linear-independence condition.
 \end{proof}
 
-\begin{theorem}[Collapsed representative BNT sector construction with overlap data]
+\begin{theorem}[Phase-class BNT sector construction with overlap data]
 	\label{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData}
 	\leanok
 	\uses{thm:bnt_li_tp_prim_irr_separated}
 	For trace-preserving primitive irreducible blocks of positive bond dimension,
 	with nonzero weights, suppose moreover that the blocks are injective. Then
-	there is a collapsed representative sector decomposition representing the
-	same weighted block sum, satisfying the BNT linear-independence condition,
-	and whose chosen basis blocks have positive bond dimension, are injective and
-	trace-preserving, have self-overlap tending to~$1$, and have mutual overlaps
-	tending to~$0$ for distinct basis blocks.
+	there is a sector decomposition, obtained by choosing one block per MPV phase
+	class, which represents the same weighted block sum, satisfies the BNT
+	linear-independence condition, and has chosen basis blocks of positive bond
+	dimension which are injective and trace-preserving, have self-overlap tending
+	to~$1$, and have mutual overlaps tending to~$0$ for distinct basis blocks.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -876,11 +876,12 @@ single weighted block.
 	What is still missing for the unconditional equal-case theorem
 	(Theorem~\ref{thm:ft_equal}, \cite[Corollary~IV.5]{Cirac2021Matrix}) is
 	not the one-sided construction of a basis of normal tensors: for
-	trace-preserving primitive irreducible blocks, representatives of the MPV
-	phase-equivalence classes are constructed in
-	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}, and their
+	trace-preserving primitive irreducible blocks with positive bond dimensions
+	and nonzero weights, representatives of the MPV phase-equivalence classes are
+	constructed in Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}.
+	When the original blocks are also injective, the same construction exposes
 	positive dimension, injectivity, normalization, and asymptotic overlap
-	orthogonality are exposed in
+	orthogonality in
 	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}.
 	The remaining paper-level inputs are to obtain, from the arbitrary
 	after-blocking reduction, exact live primitive irreducible block families at a

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -875,20 +875,21 @@ single weighted block.
 	\end{enumerate}
 	What is still missing for the unconditional equal-case theorem
 	(Theorem~\ref{thm:ft_equal}, \cite[Corollary~IV.5]{Cirac2021Matrix}) is
-	not the one-sided sector construction: the collapsed-representative
-		construction for trace-preserving primitive irreducible blocks is now
-		Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}.  The remaining
-		paper-level ingredient is a matched-basis theorem for heterogeneous sector
-		decompositions.  The algebraic reduction after a basis matching is formalized in
-		Theorems~\ref{thm:route_b_hetero_phase_match},~\ref{thm:route_b_hetero_matched_basis},
-		and~\ref{thm:route_b_hetero_sector_matching}.  Copy alignment is now recovered
-		from a basis pre-matching by
-		Theorem~\ref{thm:sector_basis_pre_matching_to_matching}, and the primitive
-		overlap-rigidity hypotheses produce such a matching by
-		Theorem~\ref{thm:sector_basis_matching_from_overlap_ortho_span}.  The remaining
-		task is to derive those span and overlap hypotheses from arbitrary equal-MPV
-		sector decompositions produced by the one-sided BNT construction.
-		Once this ingredient is in place, the final global gauge matrix
-	of Corollary~IV.5 is obtained by the same phase-absorption and blockwise
+	not the one-sided construction of a basis of normal tensors: for
+	trace-preserving primitive irreducible blocks, representatives of the MPV
+	phase-equivalence classes are constructed in
+	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}, and their
+	positive dimension, injectivity, normalization, and asymptotic overlap
+	orthogonality are exposed in
+	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}.
+	The remaining paper-level inputs are to obtain, from the arbitrary
+	after-blocking reduction, exact live primitive irreducible block families at a
+	common blocking length, to settle the length-zero bookkeeping for discarded
+	zero blocks, and to prove equality of the finite-length MPV spans for the two
+	independently chosen bases of normal tensors.  Once those inputs are supplied,
+	Theorems~\ref{thm:sector_basis_matching_from_overlap_ortho_span}
+	and~\ref{thm:route_b_hetero_sector_matching} recover the basis permutation,
+	multiplicities, and sector-weight multisets.  The final global gauge matrix of
+	Corollary~IV.5 is then obtained by the same phase-absorption and blockwise
 	composition argument already formalized in the strict single-weight setting.
 \end{remark}

--- a/docs/prose_style.md
+++ b/docs/prose_style.md
@@ -133,6 +133,10 @@ or section/namespace names.
 | "Dependency injection" | avoid; describe the mathematical dependency |
 | "Under the hood" | "internally", or drop |
 | "End-to-end" (as software metaphor) | describe the mathematical chain |
+| "Collapsed representative" / "collapsed-representative" | "representative of an MPV phase-equivalence class", or name the quotient construction |
+| "Heterogeneous decomposition" / "heterogeneous sector decomposition" | "two sector decompositions with different bases", or state the relevant dimensions/bases explicitly |
+| "Matched basis" / "matched-basis" (as unexplained shorthand) | "permutation matching the basis blocks", "paired basis blocks", or state the matching data |
+| "Copy alignment" | "multiplicity equality", "equality of copy numbers", or state the exact multiplicity condition |
 
 ---
 


### PR DESCRIPTION
### Motivation

Clarify the remaining gap in the unconditional equal-case MPS Fundamental Theorem in standard MPS terminology, following the paper route and avoiding internal shorthand.

### Description

- Rewrites the not-ready remark in Chapter 11 to say that the one-sided basis-of-normal-tensors construction and overlap data are now available.
- Names the actual remaining inputs: common live primitive irreducible block families at a common blocking length, zero-tail length-zero accounting, and finite-length MPV span equality for the two chosen BNT bases.
- Describes the final comparison in terms of basis permutation, multiplicities, sector-weight multisets, phase absorption, and blockwise gauge composition.

### Testing

- plasTeX version 3.1 passed (run by the audit agent before rebase).
- ⚠ [8372/8631] Replayed TNLean.Channel.FixedPoint.WedderburnDecomp
warning: TNLean/Channel/FixedPoint/WedderburnDecomp.lean:86:7: declaration uses `sorry`
⚠ [8441/8631] Replayed TNLean.MPS.ParentHamiltonian.UniqueGroundState
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:606:8: declaration uses `sorry`
⚠ [8479/8631] Replayed TNLean.MPS.ParentHamiltonian.Martingale
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:1239:8: declaration uses `sorry`
⚠ [8532/8631] Replayed TNLean.PEPS.FundamentalTheorem
warning: TNLean/PEPS/FundamentalTheorem.lean:530:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:584:8: declaration uses `sorry`
warning: TNLean/PEPS/FundamentalTheorem.lean:694:8: declaration uses `sorry`
⚠ [8569/8631] Replayed TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition
warning: TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean:683:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean:913:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
⚠ [8575/8631] Replayed TNLean.MPS.ParentHamiltonian.DegenerateGS
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:645:8: declaration uses `sorry`
⚠ [8588/8631] Replayed TNLean.MPS.Periodic.Overlap.SelfOverlap
warning: TNLean/MPS/Periodic/Overlap/SelfOverlap.lean:577:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/SelfOverlap.lean:823:8: declaration uses `sorry`
⚠ [8590/8631] Replayed TNLean.MPS.Periodic.Overlap.Case2
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:131:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:250:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:293:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case2.lean:357:8: declaration uses `sorry`
⚠ [8591/8631] Replayed TNLean.MPS.Periodic.Overlap.Case3
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:87:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:222:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:284:14: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:348:6: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:404:8: declaration uses `sorry`
⚠ [8592/8631] Replayed TNLean.MPS.Periodic.Overlap.Dichotomy
warning: TNLean/MPS/Periodic/Overlap/Dichotomy.lean:43:8: declaration uses `sorry`
warning: TNLean/MPS/Periodic/Overlap/Dichotomy.lean:69:8: declaration uses `sorry`
✔ [8630/8631] Built TNLean (16s)
Build completed successfully (8631 jobs). then  passed before rebase.
- After rebasing on current , I reran  and ; both passed. The first checkdecls attempt before rebuilding  reported missing newly merged selector Route B declarations, then ⚠ [2916/3000] Replayed TNLean.MPS.ParentHamiltonian.UniqueGroundState
warning: TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean:606:8: declaration uses `sorry`
⚠ [8445/8451] Replayed TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition
warning: TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean:683:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean:913:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
⚠ [8451/8451] Replayed TNLean.MPS.ParentHamiltonian.DegenerateGS
warning: TNLean/MPS/ParentHamiltonian/DegenerateGS.lean:645:8: declaration uses `sorry`
Build completed successfully (8451 jobs). passed.

Refs #652. Refs #942. Refs #944.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only wording updates: renames and reframes blueprint theorems/remarks without changing Lean code or mathematical statements; low risk aside from potential reference/terminology confusion for readers.
> 
> **Overview**
> **Clarifies blueprint terminology around the one-sided BNT construction and the remaining gap for the unconditional equal-MPV Fundamental Theorem.**
> 
> In Chapter 8, retitles the “collapsed representative” BNT sector-construction theorems to “phase-class” and rewrites the overlap-data statement to explicitly describe choosing representatives of MPV phase-equivalence classes and absorbing phases into weights.
> 
> In Chapter 11’s not-ready remark, rewrites the narrative to state that the one-sided basis-of-normal-tensors construction (and overlap/orthogonality data in the injective case) is available, and enumerates the remaining paper-level inputs (common blocking/nonzero blocks, zero-tail length-zero accounting, and finite-length MPV span equality) needed before the basis/sector matching theorems apply.
> 
> Also updates `docs/prose_style.md` to ban internal shorthand terms (e.g. “collapsed representative”, “heterogeneous decomposition”, “matched basis”, “copy alignment”) and suggest clearer mathematical replacements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5daa1f7ad824ddf516e80082c283720562b47ace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->