### PR TITLE
feat(MPS/ParentHamiltonian): add common-middle algebraic endgame

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -43,6 +43,8 @@ with the periodic boundary condition:
   normal-range constraints imply open-chain ground-space membership
 * `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes`
   — the algebraic MPV-line endgame once long-word commutation is known
+* `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility`
+  — same-witness common-middle compatibilities imply MPV-line membership
 * `MPSTensor.groundSpace_unique_periodic` — uniqueness on the periodic chain
 * `MPSTensor.parentHamiltonian_unique_gs_injective` — uniqueness for `2L₀` sites
 * `MPSTensor.parentHamiltonian_unique_gs_normal` — optimal uniqueness for `L₀+1` sites
@@ -596,6 +598,49 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes
   ext σ
   simp only [groundSpaceMap_apply, Pi.smul_apply, smul_eq_mul, mpv, coeff]
   rw [hX_eq, Algebra.mul_smul_comm, mul_one, Matrix.trace_smul, smul_eq_mul]
+
+/-- Positive-length word commutation is enough for the MPV-line endgame.
+
+If `X` commutes with all words of any positive length `m`, then chunking gives
+commutation at the multiple `L₀ * m`, which is at least `L₀`.  The long-word
+centrality theorem then applies exactly as in
+`groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes`. -/
+theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes
+    {A : MPSTensor d D} {L₀ m N : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hm : 0 < m)
+    {X : Matrix (Fin D) (Fin D) ℂ}
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X) :
+    groundSpaceMap A N X ∈ mpvSubmodule A N := by
+  have hCommMul : ∀ ω : Fin (L₀ * m) → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X :=
+    commutes_words_mul_of_commutes_words (A := A) (m := m) (q := L₀) hComm
+  exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes
+    (A := A) (L₀ := L₀) (m := L₀ * m) (N := N) hInj hL₀
+    (Nat.le_mul_of_pos_right L₀ hm) hCommMul
+
+/-- Same-witness two-sided middle compatibilities put the boundary vector in the
+MPV line.
+
+This combines the common-middle algebraic lemma in `WrappingWindow` with the
+positive-length amplification above.  Thus the only remaining paper-level gap is
+to compare the two wrapped-window witnesses so that the hypotheses below hold for
+the actual common middle word. -/
+theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility
+    {A : MPSTensor d D} {L₀ m N : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {X : Matrix (Fin D) (Fin D) ℂ}
+    (Y : (Fin m → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hLeft : ∀ (j : Fin d) (μ : Fin m → Fin d),
+      evalWord A (List.ofFn μ) * A j * X = Y μ * A j)
+    (hRight : ∀ (j : Fin d) (μ : Fin m → Fin d),
+      X * A j * evalWord A (List.ofFn μ) = A j * Y μ) :
+    groundSpaceMap A N X ∈ mpvSubmodule A N := by
+  have hComm : ∀ ω : Fin (m + 2) → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X :=
+    commutes_words_of_two_sided_middle_compatibility (A := A) (X := X) Y hLeft hRight
+  exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes
+    (A := A) (L₀ := L₀) (m := m + 2) (N := N) hInj hL₀ (by omega) hComm
 
 /-- Range-reduction bridge for normal tensors.
 

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -43,6 +43,10 @@ proceeds as follows:
 
 ## Main results
 
+* `MPSTensor.commutes_words_of_two_sided_middle_compatibility`
+  — same-witness two-sided common-middle identities imply word commutation
+* `MPSTensor.commutes_words_mul_of_commutes_words`
+  — fixed-length word commutation amplifies to all multiple lengths
 * `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`
   — block injectivity turns long-word commutation into generator commutation
 * `MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul`
@@ -505,6 +509,108 @@ theorem wrapping_window_mirror_compatibility_of_isNBlkInjective
                   τ ⟨k.val + 1, by omega⟩))))
     _ = Matrix.trace (evalWord A (List.ofFn σ_head) * (A j * Y τ)) := by
           simpa [Matrix.mul_assoc] using key'
+
+/-! ### Common-middle algebraic closure
+
+The two one-sided wrapped-boundary identities close the boundary matrix once they
+are available with a common middle word and the same boundary witness. -/
+
+/-- A same-witness pair of one-sided compatibilities around a common middle word
+forces `X` to commute with every word obtained by adjoining one physical letter on
+each side of that middle.
+
+This is the algebraic core of the remaining normal parent-Hamiltonian closure
+step: after the wrapped and mirror windows have been compared so that their
+boundary witnesses agree on a shared complement `μ`, the identities
+`A^μ A^b X = Y_μ A^b` and `X A^a A^μ = A^a Y_μ` imply
+`X A^a A^μ A^b = A^a A^μ A^b X`. -/
+theorem commutes_words_of_two_sided_middle_compatibility
+    {A : MPSTensor d D} {m : ℕ} {X : Matrix (Fin D) (Fin D) ℂ}
+    (Y : (Fin m → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hLeft : ∀ (j : Fin d) (μ : Fin m → Fin d),
+      evalWord A (List.ofFn μ) * A j * X = Y μ * A j)
+    (hRight : ∀ (j : Fin d) (μ : Fin m → Fin d),
+      X * A j * evalWord A (List.ofFn μ) = A j * Y μ) :
+    ∀ ω : Fin (m + 2) → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X := by
+  intro ω
+  let a : Fin d := ω ⟨0, by omega⟩
+  let tail : Fin (m + 1) → Fin d := Fin.tail ω
+  let μ : Fin m → Fin d := Fin.init tail
+  let b : Fin d := tail (Fin.last m)
+  have htail : Fin.tail ω = Fin.snoc μ b := by
+    dsimp only [tail, μ, b]
+    exact (Fin.snoc_init_self (Fin.tail ω)).symm
+  have hω : ω = Fin.cons a (Fin.snoc μ b) := by
+    rw [← Fin.cons_self_tail ω, htail]
+    simp [a]
+  rw [hω, evalWord_ofFn_cons, evalWord_ofFn_snoc]
+  calc
+    X * (A a * (evalWord A (List.ofFn μ) * A b))
+        = (X * A a * evalWord A (List.ofFn μ)) * A b := by
+            simp [Matrix.mul_assoc]
+    _ = (A a * Y μ) * A b := by rw [hRight a μ]
+    _ = A a * (Y μ * A b) := by simp [Matrix.mul_assoc]
+    _ = A a * (evalWord A (List.ofFn μ) * A b * X) := by rw [← hLeft b μ]
+    _ = (A a * (evalWord A (List.ofFn μ) * A b)) * X := by
+            simp [Matrix.mul_assoc]
+
+/-- If `X` commutes with all words of a fixed length `m`, then it commutes
+with all words whose length is any multiple of `m`.
+
+The proof chunks a list of length `q * m` into a length-`m` prefix and a shorter
+multiple-length suffix. This formalizes the amplification observation used to
+feed positive-length commutation into the block-injective long-word endgame. -/
+theorem commutes_words_mul_of_commutes_words {A : MPSTensor d D}
+    {m q : ℕ} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hComm : ∀ ω : Fin m → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X) :
+    ∀ ω : Fin (q * m) → Fin d,
+      X * evalWord A (List.ofFn ω) = evalWord A (List.ofFn ω) * X := by
+  suffices hList : ∀ q : ℕ, ∀ w : List (Fin d), w.length = q * m →
+      X * evalWord A w = evalWord A w * X by
+    intro ω
+    exact hList q (List.ofFn ω) (by simp)
+  intro q
+  induction q with
+  | zero =>
+      intro w hw
+      have hw0 : w = [] := List.eq_nil_of_length_eq_zero (by simpa using hw)
+      simp [hw0]
+  | succ q ih =>
+      intro w hw
+      have htake_len : (w.take m).length = m := by
+        have hm_le : m ≤ w.length := by
+          rw [hw, Nat.succ_mul]
+          omega
+        rw [List.length_take, Nat.min_eq_left hm_le]
+      let μ : Fin m → Fin d := fun i => (w.take m).get ⟨i.val, by simp [htake_len]⟩
+      have hμ : List.ofFn μ = w.take m := by
+        simpa [μ, htake_len] using (List.ofFn_get (w.take m))
+      have hdrop_len : (w.drop m).length = q * m := by
+        rw [List.length_drop, hw, Nat.succ_mul]
+        omega
+      have hdrop_comm := ih (w.drop m) hdrop_len
+      calc
+        X * evalWord A w
+            = X * evalWord A (w.take m ++ w.drop m) := by
+                rw [List.take_append_drop m w]
+        _ = X * (evalWord A (w.take m) * evalWord A (w.drop m)) := by
+                rw [evalWord_append]
+        _ = (X * evalWord A (w.take m)) * evalWord A (w.drop m) := by
+                rw [Matrix.mul_assoc]
+        _ = (evalWord A (w.take m) * X) * evalWord A (w.drop m) := by
+                rw [← hμ, hComm μ]
+        _ = evalWord A (w.take m) * (X * evalWord A (w.drop m)) := by
+                simp [Matrix.mul_assoc]
+        _ = evalWord A (w.take m) * (evalWord A (w.drop m) * X) := by
+                rw [hdrop_comm]
+        _ = (evalWord A (w.take m) * evalWord A (w.drop m)) * X := by
+                simp [Matrix.mul_assoc]
+        _ = evalWord A (w.take m ++ w.drop m) * X := by
+                rw [evalWord_append]
+        _ = evalWord A w * X := by
+                rw [List.take_append_drop m w]
 
 /-! ### Main commutation result
 

--- a/audits/2026-04-22_issue588_normal_range_reduction_partial.md
+++ b/audits/2026-04-22_issue588_normal_range_reduction_partial.md
@@ -186,3 +186,45 @@ one still has to turn the two one-sided identities
 commutation for the same boundary matrix `X`.  The new MPV-line endgame shows
 that no further scalar-center work remains once that commutation family is
 available.
+
+## 2026-04-27 Wave 18E update
+
+Current branch `wave18-E-588-common-middle` still does **not** close
+`MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`; the
+pre-existing proof placeholder remains.  It lands the exact algebraic
+common-middle endgame that was missing after Wave 17A, without assuming
+commutation directly:
+
+- `MPSTensor.commutes_words_of_two_sided_middle_compatibility` in
+  `TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`: if the two one-sided
+  identities have been compared to a single same-witness family indexed by a
+  common middle word,
+  ```text
+  A^μ A^b X = Y_μ A^b,
+  X A^a A^μ = A^a Y_μ,
+  ```
+  then `X` commutes with every product `A^a A^μ A^b`.
+- `MPSTensor.commutes_words_mul_of_commutes_words` in the same file: fixed-length
+  commutation amplifies to all multiple lengths by chunking words.
+- `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes`
+  and
+  `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility`
+  in `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`: same-witness
+  common-middle compatibilities now put `Γ_N(X)` directly in the MPV line via the
+  positive-length amplification and the Wave 17A centrality endgame.
+
+Paper anchor retained: CPGSV21 §IV.C,
+`Papers/2011.12127/TN-Review-main.tex:2078--2079`, especially
+"Once we have reached $k=L_0$, we can resort to the above Theorem, or
+alternatively apply a similar argument when closing the boundaries", and theorem
+`thm:4:unique-gs-L0_plus_1` at lines 2087--2090.
+
+Remaining blocker after Wave 18E: prove the actual witness comparison for the two
+wrapped windows produced by
+`MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`.
+Concretely, one must reindex their complements to a common middle `μ` and show
+that the wrapped witness `Y^+` and mirror witness `Y^-` reduce to a single
+family `Y_μ` satisfying the two same-witness identities above.  Once that
+comparison is available, the new Wave 18E theorem
+`MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility`
+closes the MPV-line containment.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1070,14 +1070,15 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.commutes_words_mul_of_commutes_words}
     \leanok
     If a boundary matrix $X$ commutes with every word product of length $m$, then
-    it commutes with every word product whose length is a multiple $qm$.
+    it commutes with every word product whose length is a multiple $q\,m$.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    Chunk a word of length $qm$ into a length-$m$ prefix and a length-$(q-1)m$
-    suffix. The prefix commutes with $X$ by hypothesis, and the suffix commutes by
-    induction on $q$.
+    Proceed by induction on $q$. For $q=0$, the claim is trivial. For the
+    inductive step, let a word of length $(q+1)m$ be given and write it as a
+    length-$m$ prefix followed by a length-$q\,m$ suffix. The prefix commutes with
+    $X$ by hypothesis, and the suffix commutes by the induction hypothesis.
 \end{proof}
 
 \begin{lemma}[Padded complement annihilation]
@@ -1146,7 +1147,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     Lemma~\ref{lem:word_commutation_multiple_lengths} amplifies the length-$m$
-    commutation hypothesis to length $L_0m \ge L_0$. Then
+    commutation hypothesis to length $L_0\,m \ge L_0$. Then
     Theorem~\ref{thm:ground_space_map_mpv_of_long_word_commutes} applies.
 \end{proof}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -845,6 +845,32 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     boundary-crossing positions to obtain the displayed one-sided identities.
 \end{proof}
 
+\begin{lemma}[Same-witness common-middle commutation]%
+    \label{lem:common_middle_same_witness_commutation}
+    \lean{MPSTensor.commutes_words_of_two_sided_middle_compatibility}
+    \leanok
+    Suppose a single family of boundary matrices $Y_\mu$, indexed by middle
+    words $\mu$, satisfies the two one-sided identities
+    \[
+        A^\mu A^b X = Y_\mu A^b,
+        \qquad
+        X A^a A^\mu = A^a Y_\mu
+    \]
+    for every pair of physical letters $a,b$. Then $X$ commutes with every word
+    product $A^a A^\mu A^b$ obtained by adjoining one letter on each side of the
+    common middle.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Multiply the second identity on the right by $A^b$ and the first identity on
+    the left by $A^a$:
+    \[
+        X A^a A^\mu A^b = A^a Y_\mu A^b
+        = A^a A^\mu A^b X.
+    \]
+\end{proof}
+
 \begin{theorem}[Boundary matrix commutation from the wrapping window]\label{thm:boundary_matrix_commutes}
     \lean{MPSTensor.boundary_matrix_commutes}
     \leanok
@@ -1039,6 +1065,21 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     injectivity, so linearity gives $XM = MX$ for every $M \in \MN{D}$.
 \end{proof}
 
+\begin{lemma}[Amplifying fixed-length word commutation]
+    \label{lem:word_commutation_multiple_lengths}
+    \lean{MPSTensor.commutes_words_mul_of_commutes_words}
+    \leanok
+    If a boundary matrix $X$ commutes with every word product of length $m$, then
+    it commutes with every word product whose length is a multiple $qm$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Chunk a word of length $qm$ into a length-$m$ prefix and a length-$(q-1)m$
+    suffix. The prefix commutes with $X$ by hypothesis, and the suffix commutes by
+    induction on $q$.
+\end{proof}
+
 \begin{lemma}[Padded complement annihilation]
     \label{lem:padded_complement_annihilation}
     \lean{MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul}
@@ -1091,6 +1132,43 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $X=c\Id$, and therefore $\Gamma_N(X)=cV^{(N)}(A)$.
 \end{proof}
 
+\begin{theorem}[MPV-line endgame from positive-length commutation]
+    \label{thm:ground_space_map_mpv_of_positive_word_commutes}
+    \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes}
+    \leanok
+    \uses{lem:word_commutation_multiple_lengths,
+        thm:ground_space_map_mpv_of_long_word_commutes}
+    Let $A$ be $L_0$-block-injective with $L_0>0$. If $X$ commutes with every
+    word product of some positive length $m$, then $\Gamma_N(X)$ lies in the MPV
+    line.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:word_commutation_multiple_lengths} amplifies the length-$m$
+    commutation hypothesis to length $L_0m \ge L_0$. Then
+    Theorem~\ref{thm:ground_space_map_mpv_of_long_word_commutes} applies.
+\end{proof}
+
+\begin{theorem}[MPV-line endgame from a same-witness common middle]
+    \label{thm:ground_space_map_mpv_of_common_middle}
+    \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}
+    \leanok
+    \uses{lem:common_middle_same_witness_commutation,
+        thm:ground_space_map_mpv_of_positive_word_commutes}
+    Let $A$ be $L_0$-block-injective with $L_0>0$. If the common-middle
+    same-witness identities of
+    Lemma~\ref{lem:common_middle_same_witness_commutation} hold for $X$, then
+    $\Gamma_N(X)$ lies in the MPV line.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The common-middle identities give commutation with all words of length
+    $|\mu|+2$, a positive length. The positive-length MPV-line endgame then
+    finishes.
+\end{proof}
+
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%
     \label{thm:chain_ground_space_eq_mpv_blk}
     \lean{MPSTensor.chainGroundSpace_eq_mpvSubmodule}
@@ -1122,7 +1200,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{def:chain_ground_space, def:mpv_submodule, def:normal,
         def:l_blk_injective, thm:cyclic_normal_open_chain_range_reduction,
         thm:reduced_wrapped_boundary_compatibilities,
-        thm:ground_space_map_mpv_of_long_word_commutes}
+        thm:ground_space_map_mpv_of_common_middle}
     If $A$ is normal, $D \ge 1$, $L_0$-block-injective, with $N \ge 2$ and $L_0 < L \le N$, then
     \[
         \mathcal G_{N,L}(A) \subseteq \spn\bigl\{V^{(N)}(A)\bigr\}.
@@ -1132,17 +1210,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \notready
     \uses{thm:reduced_wrapped_boundary_compatibilities,
-        thm:ground_space_map_mpv_of_long_word_commutes,
+        thm:ground_space_map_mpv_of_common_middle,
         lem:padded_complement_annihilation}
     The remaining step is the closure property from
     \cite[\S~IV.C]{Cirac2021Matrix}: Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
     supplies the two one-sided wrapped-boundary identities for the open-chain
     boundary matrix $X$. The padded-annihilation lemma records that exact
-    complement-span length mismatches are no longer the obstruction. What is
-    still missing is the common-middle comparison that turns the one-sided
-    identities into commutation of $X$ with a sufficiently long word product;
-    Theorem~\ref{thm:ground_space_map_mpv_of_long_word_commutes} would then put
-    $\Gamma_N(X)$ directly in the MPV line.
+    complement-span length mismatches are no longer the obstruction, and
+    Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} formalizes the
+    algebraic endgame once those one-sided identities have been compared to a
+    single same-witness common-middle family. What is still missing is precisely
+    that witness comparison for the actual two wrapped windows.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the normal case]%


### PR DESCRIPTION
## Summary

This PR advances issue #588/#190 by landing the algebraic common-middle endgame that sits between the wrapped-boundary compatibilities from PR #936 and the scalar/MPV-line endgame from PR #947.

New checked Lean pieces:

- `MPSTensor.commutes_words_of_two_sided_middle_compatibility`:
  a same-witness pair of one-sided identities
  `A^μ A^b X = Y_μ A^b` and `X A^a A^μ = A^a Y_μ`
  implies `X` commutes with every word `A^a A^μ A^b`.
- `MPSTensor.commutes_words_mul_of_commutes_words`:
  fixed-length commutation amplifies to all multiple lengths by chunking.
- `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes`:
  positive-length commutation is enough for the MPV-line endgame.
- `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility`:
  same-witness common-middle compatibilities now put `Γ_N(X)` directly in `mpvSubmodule A N`.

The full `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` theorem is still not closed; the existing placeholder remains. The remaining blocker is now precisely the actual witness comparison for the two wrapped windows produced by `chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`: reindex their complements to a common middle `μ` and prove the wrapped/mirror witnesses reduce to one family `Y_μ` satisfying the same-witness identities above.

Blueprint Chapter 14 and the issue #588 audit are updated to reflect this narrower blocker.

Paper anchor retained: CPGSV21 §IV.C, `Papers/2011.12127/TN-Review-main.tex:2078--2079` (“Once we have reached $k=L_0$, we can resort to the above Theorem, or alternatively apply a similar argument when closing the boundaries”) and theorem `thm:4:unique-gs-L0_plus_1` at lines 2087--2090.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.WrappingWindow TNLean.MPS.ParentHamiltonian.UniqueGroundState` ✅
  - only the pre-existing `UniqueGroundState.lean` target `sorry` warning
- `cd blueprint && leanblueprint web && leanblueprint checkdecls` ✅
- `git diff --check` ✅
- added-line proof-integrity scan for `sorry|admit|axiom|native_decide|unsafe` ✅
  - touched Lean files contain only the pre-existing placeholder `sorry` in `UniqueGroundState.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new standalone Lean theorems and documentation without altering existing APIs or completing the still-`sorry` normal range-reduction proof. Main risk is proof fragility/maintenance due to additional algebraic lemmas and rewriting/omega automation.
> 
> **Overview**
> Adds a new *common-middle closure* step: `commutes_words_of_two_sided_middle_compatibility` turns paired one-sided wrapped-boundary identities with a shared witness into commutation of `X` with all words of length `m+2`.
> 
> Adds an *amplification lemma* `commutes_words_mul_of_commutes_words`, then uses it in `UniqueGroundState.lean` to show **positive-length** commutation suffices to place `groundSpaceMap A N X` in the MPV line, and to derive MPV-line membership directly from the same-witness common-middle hypotheses.
> 
> Updates the blueprint (chapter 14) and the issue-588 audit note to document these new lemmas and narrow the remaining blocker to comparing the two wrapped-window witnesses; the `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` placeholder remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf08fd0da0310d0df0354de8d8e6b3ef8b2b59cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->