### PR TITLE
feat(MPS/CanonicalForm): transport BNT representative spans

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -791,8 +791,9 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injective
 
 This exact-live variant removes the opaque two-sector `overlapSpanData` input from
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan`. The
-one-sided MPV phase-equivalence class representative construction supplies positive dimensions, injectivity,
-normalization, and the asymptotic overlap data for the representative bases. The only
+one-sided MPV phase-equivalence class representative construction supplies positive
+dimensions, injectivity, normalization, and the asymptotic overlap data for the
+representative bases. The only
 remaining two-family analytic input is the finite-length span equality for the original live
 block families; `exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq` transports it
 to the chosen sector bases. -/

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -66,9 +66,9 @@ The theorem `exists_tp_sector_decomp_after_blocking` below provides:
   `zeroMPSTensor + toTensorFromBlocks μ sectors` for some weights `μ`
 
 The current library already settles the common-period blocking arithmetic and
-now has both a one-sided phase-class BNT construction for TP primitive
-irreducible live blocks and a witness-producing sector comparison from primitive
-overlap-span hypotheses. The theorem
+now has a one-sided phase-class BNT construction for TP primitive irreducible
+live blocks, one-sided overlap data, and witness-producing sector comparison
+from primitive overlap-span hypotheses. The theorem
 `fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail`
 keeps the faithful paper order: first split off the zero tail and TP-gauge the
 irreducible live blocks, then remove each live block's period by cyclic sectors.
@@ -77,9 +77,10 @@ finite blocking length used for common refinement or injectivity.
 
 The exact-live theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`
-combines `SameMPV₂ A B` with the BNT and matching ingredients once exact common
-live block decompositions, live-block injectivity, and the finite-length span
-comparison are supplied. The zero-tail-aware theorem
+uses a two-basis span comparison for the constructed sector bases, while
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan`
+transports a finite-length span equality for the original live block families to
+those bases. The zero-tail-aware theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail`
 separately records the `N = 0` bookkeeping when full overlap-span hypotheses are
 available.
@@ -311,7 +312,7 @@ theorem liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
 
 /-- **Recover full live-block `SameMPV₂` once zero tails agree.**
 
-This packages the positive-length bookkeeping theorem with the single additional
+This combines the positive-length bookkeeping theorem with the single additional
 length-zero datum needed to remove the zero tails. It does not assert that the
 zero-tail dimensions agree automatically; that remains a separate paper-level
 bookkeeping step for the unconditional after-blocking sector comparison. -/
@@ -547,7 +548,7 @@ constructed by `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching` and
 then fed to the bundled heterogeneous sector comparison theorem.
 
 Thus the theorem connects the post-#860 comparison machinery without assuming a
-`SectorBasisMatching` or a permutation/copy alignment as input. -/
+`SectorBasisMatching` or a permutation with copy-count equalities as input. -/
 theorem fundamentalTheorem_after_blocking_1606_sector_of_bntPair_overlapSpan
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -786,6 +787,95 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injective
   exact ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt,
           M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
 
+/-- **Common live-block construction from live-block span equality.**
+
+This exact-live variant removes the opaque two-sector `overlapSpanData` input from
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan`. The
+one-sided MPV phase-equivalence class representative construction supplies positive dimensions, injectivity,
+normalization, and the asymptotic overlap data for the representative bases. The only
+remaining two-family analytic input is the finite-length span equality for the original live
+block families; `exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq` transports it
+to the chosen sector bases. -/
+theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan
+    {d D₁ D₂ p rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k : Fin rA, NeZero (dimA k)]
+    [∀ k : Fin rB, NeZero (dimB k)]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hp : 0 < p)
+    (μA : Fin rA → ℂ)
+    (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d p) (dimA k))
+    (μB : Fin rB → ℂ)
+    (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d p) (dimB k))
+    (hAblocks : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA))
+    (hBblocks : SameMPV₂ (blockTensor (d := d) (D := D₂) B p)
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB))
+    (hTPA : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksA k i)ᴴ * blocksA k i = 1)
+    (hTPB : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksB k i)ᴴ * blocksB k i = 1)
+    (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))
+    (hIrrB : ∀ k, IsIrreducibleTensor (blocksB k))
+    (hPrimA : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimA k) (blocksA k)))
+    (hPrimB : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimB k) (blocksB k)))
+    (hInjA : ∀ k, IsInjective (blocksA k))
+    (hInjB : ∀ k, IsInjective (blocksB k))
+    (hμA : ∀ k, μA k ≠ 0)
+    (hμB : ∀ k, μB k ≠ 0)
+    (hBlockSpan : ∀ N,
+      Submodule.span ℂ (Set.range (fun k : Fin rA =>
+        mpvState (d := blockPhysDim d p) (blocksA k) N)) =
+      Submodule.span ℂ (Set.range (fun k : Fin rB =>
+        mpvState (d := blockPhysDim d p) (blocksB k) N))) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂ (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂ (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
+    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
+      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
+      hPrimA hPrimB hInjA hInjB hμA hμB hBlockSpan
+  have hPeq : SameMPV₂ (blockTensor (d := d) (D := D₁) A p) P.toTensor := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ
+          = mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ :=
+            hAblocks N σ
+      _ = mpv P.toTensor σ := (hPblocks N σ).symm
+  have hQeq : SameMPV₂ (blockTensor (d := d) (D := D₂) B p) Q.toTensor := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ
+          = mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ :=
+            hBblocks N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ
+          = mpv (blockTensor (d := d) (D := D₁) A p) σ := (hPeq N σ).symm
+      _ = mpv (blockTensor (d := d) (D := D₂) B p) σ := hAB N σ
+      _ = mpv Q.toTensor σ := hQeq N σ
+  obtain ⟨M⟩ := hOverlapSpan.exists_sectorBasisMatching hPQeq
+  obtain ⟨ζ, hζne, hMultiset⟩ :=
+    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching M hPbnt hPQeq
+  exact ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt,
+          M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
+
 /-- Remove matching zero tails from two MPV identities.
 
 If `A` and `B` have the same MPVs, and each is expressed as a zero tail plus a live tensor,
@@ -963,11 +1053,13 @@ hypotheses through `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching`
 
 The theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`
-records the strongest exact-live overlap-input reduction currently available:
-once a common blocking period gives exact live TP primitive irreducible block
-decompositions on both sides, live-block injectivity and finite-length span
-equality are enough to derive the overlap-span hypotheses for the constructed
-sector bases and produce the matched sector-weight conclusion. The theorem
+records an exact-live overlap-input reduction from span equality for the
+constructed sector bases. The theorem
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan`
+strengthens this in the phase-class representative setting: equality of the
+finite-length spans of the original live block families is transported to the
+chosen sector bases and the sector-weight conclusion follows from the original
+`SameMPV₂ A B`. The theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail`
 records the corresponding zero-tail bookkeeping route when full overlap-span data
 are supplied.
@@ -981,8 +1073,9 @@ structural reduction itself:
 2. the `N = 0` bookkeeping for the zero-tail contribution;
 3. one-site injectivity of the live blocks, or a blocked replacement of the
    rigidity input; and
-4. equality of the finite-length MPV spans for the two BNT bases, followed by the
-   final global gauge construction of the equal-case FT.
+4. equality of the finite-length MPV spans for the original live block families
+   (or directly for the two BNT bases), followed by the final global gauge
+   construction of the equal-case FT.
 
 Thus the common-period arithmetic and the abstract sector-matching witness are no
 longer the main blockers; the remaining gap is the paper-level derivation of the

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -877,8 +877,8 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
 classes, including the finite-length representative-span identity.
 
 
-This private helper keeps the proof of the common fields shared by the public one-sided overlap
-data theorems in one place. -/
+This private auxiliary lemma consolidates the proof of the common fields shared by the
+public one-sided overlap data theorems. -/
 private theorem bntSectorDecomp_overlapData_basisSpan_aux
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -451,6 +451,15 @@ lemma MPVPhaseEquiv.of_gaugePhaseEquiv_cast {r : ℕ} {dim : Fin r → ℕ}
     (B := blocks k) X ζ hX N σ,
     mpv_cast_dim hdim (blocks j) N σ]
 
+/-- MPV phase equivalence gives scalar-power equality of the finite-length MPV state vectors. -/
+lemma MPVPhaseEquiv.mpvState_eq_smul {r : ℕ} {dim : Fin r → ℕ}
+    {blocks : (k : Fin r) → MPSTensor d (dim k)} {j k : Fin r}
+    (h : MPVPhaseEquiv blocks j k) (N : ℕ) :
+    mpvState (d := d) (blocks k) N = h.choose ^ N • mpvState (d := d) (blocks j) N := by
+  ext σ
+  simp only [PiLp.smul_apply, smul_eq_mul, mpvState_apply]
+  exact h.choose_spec.2 N σ
+
 /-- Equivalence relation on block indices given by MPV phase equivalence. -/
 def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k)) : Setoid (Fin r) where
@@ -489,6 +498,62 @@ structure MPVPhaseClassData {r : ℕ} {dim : Fin r → ℕ}
   blocks_not_equiv : BlocksNotGaugePhaseEquiv (d := d) (fun j => blocks (repr j))
   regroup : ∀ f : Fin r → ℂ,
     ∑ j : Fin g, ∑ q : Fin (copies j), f (enum j q) = ∑ k : Fin r, f k
+
+namespace MPVPhaseClassData
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+variable {blocks : (k : Fin r) → MPSTensor d (dim k)}
+
+/-- Every original block index occurs in the finite enumeration of MPV phase classes. -/
+lemma exists_enum_eq (classes : MPVPhaseClassData blocks) (k : Fin r) :
+    ∃ j : Fin classes.g, ∃ q : Fin (classes.copies j), classes.enum j q = k := by
+  classical
+  by_contra h
+  push Not at h
+  have hzero :
+      (∑ j : Fin classes.g, ∑ q : Fin (classes.copies j),
+        (if classes.enum j q = k then (1 : ℂ) else 0)) = 0 := by
+    apply Finset.sum_eq_zero
+    intro j _
+    apply Finset.sum_eq_zero
+    intro q _
+    simp [h j q]
+  have hone : (∑ x : Fin r, (if x = k then (1 : ℂ) else 0)) = 1 := by
+    simp
+  have hregroup := classes.regroup (fun x : Fin r => if x = k then (1 : ℂ) else 0)
+  rw [hzero, hone] at hregroup
+  exact zero_ne_one hregroup
+
+/-- The chosen MPV phase-class representatives span exactly the same finite-length MPV
+subspace as the original block family.
+
+Each representative is one of the original blocks, giving one inclusion. Conversely, every
+original block occurs in a phase class and is a nonzero scalar-power multiple of that class's
+representative at each length, hence lies in the representative span. -/
+theorem representative_mpv_span_eq (classes : MPVPhaseClassData blocks) (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun j : Fin classes.g =>
+      mpvState (d := d) (blocks (classes.repr j)) N)) =
+    Submodule.span ℂ (Set.range (fun k : Fin r =>
+      mpvState (d := d) (blocks k) N)) := by
+  classical
+  apply le_antisymm
+  · refine Submodule.span_le.2 ?_
+    intro v hv
+    rcases hv with ⟨j, rfl⟩
+    exact Submodule.subset_span ⟨classes.repr j, rfl⟩
+  · refine Submodule.span_le.2 ?_
+    intro v hv
+    rcases hv with ⟨k, rfl⟩
+    obtain ⟨j, q, hq⟩ := classes.exists_enum_eq k
+    have hphase : MPVPhaseEquiv blocks (classes.repr j) k := by
+      simpa [hq] using classes.enum_phase j q
+    change mpvState (d := d) (blocks k) N ∈
+      Submodule.span ℂ (Set.range (fun j : Fin classes.g =>
+        mpvState (d := d) (blocks (classes.repr j)) N))
+    rw [hphase.mpvState_eq_smul N]
+    exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨j, rfl⟩)
+
+end MPVPhaseClassData
 
 /-- Construct the finite MPV phase classes of a block family.
 
@@ -840,6 +905,142 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData
       (d := d) μ blocks hTP hIrr hPrim hμne
   exact ⟨P, hSame, hBNT, hOrtho.dim_pos, hInj_of hInj, hOrtho.normalized,
     hOrtho.self_overlap, hOrtho.off_overlap⟩
+
+/-- **Collapsed BNT sector construction with overlap data and the quotient span identity.**
+
+This strengthens `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData` by
+also exposing the finite-length span invariant of the collapsed construction: at every length,
+the chosen MPV phase-class representatives span the same MPV subspace as the original block
+family.  This removes the quotient/enumeration bookkeeping from later two-sided span
+comparisons; the remaining comparison is the genuine equality of the two original live-block
+spans. -/
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData_and_basisSpan
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hInj : ∀ k, IsInjective (blocks k))
+    (hμne : ∀ k, μ k ≠ 0) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P ∧
+      (∀ j : Fin P.basisCount, 0 < P.basisDim j) ∧
+      (∀ j : Fin P.basisCount, IsInjective (P.basis j)) ∧
+      (∀ j : Fin P.basisCount, (∑ i : Fin d, (P.basis j i)ᴴ * (P.basis j i)) = 1) ∧
+      (∀ j : Fin P.basisCount,
+        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
+          Filter.atTop (nhds (1 : ℂ))) ∧
+      (∀ i j : Fin P.basisCount, i ≠ j →
+        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
+          Filter.atTop (nhds 0)) ∧
+      (∀ N,
+        Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
+          mpvState (d := d) (P.basis j) N)) =
+        Submodule.span ℂ (Set.range (fun k : Fin r =>
+          mpvState (d := d) (blocks k) N))) := by
+  classical
+  let classes := mpvPhaseClassData blocks
+  let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
+  have hSame : SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) :=
+    collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
+  have hBNT : HasBNTSectorData (d := d) P :=
+    collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
+  refine ⟨P, hSame, hBNT, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro j
+    simpa [P, collapsedBntSectorDecomp] using NeZero.pos (dim (classes.repr j))
+  · intro j
+    simpa [P, collapsedBntSectorDecomp] using hInj (classes.repr j)
+  · intro j
+    simpa [P, collapsedBntSectorDecomp] using hTP (classes.repr j)
+  · intro j
+    simpa [P, collapsedBntSectorDecomp] using
+      overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      (blocks (classes.repr j)) (hIrr (classes.repr j)) (hTP (classes.repr j))
+      (hPrim (classes.repr j))
+  · intro i j hij
+    simpa [P, collapsedBntSectorDecomp] using
+      cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
+      (fun j : Fin classes.g => blocks (classes.repr j))
+      (HasIrreducibleBlocks.ofForall (fun j => hIrr (classes.repr j)))
+      (IsLeftCanonicalBlockFamily.ofForall (fun j => hTP (classes.repr j)))
+      classes.blocks_not_equiv i j hij
+  · intro N
+    simpa [P, collapsedBntSectorDecomp] using classes.representative_mpv_span_eq (d := d) N
+
+/-- **Two-sided collapsed BNT overlap-span data from live-block span equality.**
+
+Apply the collapsed representative construction on both live block families.  The one-sided
+quotient span identity above transports a finite-length span equality for the original live
+blocks to the two independently chosen collapsed sector bases.  Thus the theorem packages all
+fields of `SectorBasisOverlapSpanHypotheses` without assuming that structure directly.
+
+The remaining paper-level task, not proved here, is to derive the displayed live-block span
+equality from the global `SameMPV₂` and structural reduction data. -/
+theorem exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
+    {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    (μA : Fin rA → ℂ)
+    (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
+    (μB : Fin rB → ℂ)
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hTPA : ∀ k, ∑ i : Fin d, (blocksA k i)ᴴ * blocksA k i = 1)
+    (hTPB : ∀ k, ∑ i : Fin d, (blocksB k i)ᴴ * blocksB k i = 1)
+    (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))
+    (hIrrB : ∀ k, IsIrreducibleTensor (blocksB k))
+    (hPrimA : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dimA k) (blocksA k)))
+    (hPrimB : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dimB k) (blocksB k)))
+    (hInjA : ∀ k, IsInjective (blocksA k))
+    (hInjB : ∀ k, IsInjective (blocksB k))
+    (hμA : ∀ k, μA k ≠ 0)
+    (hμB : ∀ k, μB k ≠ 0)
+    (hBlockSpan : ∀ N,
+      Submodule.span ℂ (Set.range (fun k : Fin rA =>
+        mpvState (d := d) (blocksA k) N)) =
+      Submodule.span ℂ (Set.range (fun k : Fin rB =>
+        mpvState (d := d) (blocksB k) N))) :
+    ∃ P Q : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μA) blocksA) ∧
+      SameMPV₂ Q.toTensor (toTensorFromBlocks (d := d) (μ := μB) blocksB) ∧
+      HasBNTSectorData (d := d) P ∧
+      HasBNTSectorData (d := d) Q ∧
+      SectorBasisOverlapSpanHypotheses P Q := by
+  obtain ⟨P, hPblocks, hPbnt, hPdim, hPinj, hPnorm, hPself, hPoff, hPspan⟩ :=
+    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData_and_basisSpan
+      (d := d) μA blocksA hTPA hIrrA hPrimA hInjA hμA
+  obtain ⟨Q, hQblocks, hQbnt, hQdim, hQinj, hQnorm, hQself, hQoff, hQspan⟩ :=
+    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData_and_basisSpan
+      (d := d) μB blocksB hTPB hIrrB hPrimB hInjB hμB
+  have hSpan : ∀ N,
+      Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
+        mpvState (d := d) (P.basis j) N)) =
+      Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
+        mpvState (d := d) (Q.basis k) N)) := by
+    intro N
+    calc
+      Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
+          mpvState (d := d) (P.basis j) N))
+          = Submodule.span ℂ (Set.range (fun k : Fin rA =>
+              mpvState (d := d) (blocksA k) N)) := hPspan N
+      _ = Submodule.span ℂ (Set.range (fun k : Fin rB =>
+              mpvState (d := d) (blocksB k) N)) := hBlockSpan N
+      _ = Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
+              mpvState (d := d) (Q.basis k) N)) := (hQspan N).symm
+  refine ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, ?_⟩
+  exact {
+    left_dim_pos := hPdim
+    right_dim_pos := hQdim
+    left_injective := hPinj
+    right_injective := hQinj
+    left_normalized := hPnorm
+    right_normalized := hQnorm
+    left_self_overlap := hPself
+    left_off_overlap := hPoff
+    right_self_overlap := hQself
+    right_off_overlap := hQoff
+    span_eq := hSpan
+  }
 
 /-! ### §6. Conditional sector construction under BNT linear independence -/
 

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -813,7 +813,6 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
   · exact collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
   · exact collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
 
-
 /-- **Phase-class BNT sector construction with one-sided overlap data.**
 
 Starting from trace-preserving primitive irreducible blocks with nonzero weights,
@@ -875,7 +874,6 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
 
 /-- Concrete one-sided data for the construction using representatives of MPV phase-equivalence
 classes, including the finite-length representative-span identity.
-
 
 This private auxiliary lemma consolidates the proof of the common fields shared by the
 public one-sided overlap data theorems. -/

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -88,7 +88,7 @@ Theorem matching, etc.).
   including equal-modulus ones, and proves `HasBNTSectorData` from overlap
   asymptotics rather than from an explicit linear-independence hypothesis.
 
-* `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` — the collapsed-representative
+* `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` — the representative
   construction: it quotients arbitrary TP / primitive / irreducible blocks by MPV phase
   equivalence, absorbs the scalar factors into sector weights, proves representative
   separation, and then obtains `HasBNTSectorData` from the separated-family theorem.
@@ -394,7 +394,7 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
       exact ⟨ζ, hζne, hζ_norm, hmpv⟩
   exact bnt_grouping_single_norm_class μ blocks k0 hμne hNorm hPhase
 
-/-! ### §4. Collapsed representatives from MPV phase classes -/
+/-! ### §4. MPV phase-class representatives -/
 
 /-- MPV phase equivalence for a dependent block family.
 
@@ -451,14 +451,17 @@ lemma MPVPhaseEquiv.of_gaugePhaseEquiv_cast {r : ℕ} {dim : Fin r → ℕ}
     (B := blocks k) X ζ hX N σ,
     mpv_cast_dim hdim (blocks j) N σ]
 
-/-- MPV phase equivalence gives scalar-power equality of the finite-length MPV state vectors. -/
-lemma MPVPhaseEquiv.mpvState_eq_smul {r : ℕ} {dim : Fin r → ℕ}
+/-- MPV phase equivalence gives a scalar-power equality of finite-length MPV state vectors. -/
+lemma MPVPhaseEquiv.exists_mpvState_eq_smul {r : ℕ} {dim : Fin r → ℕ}
     {blocks : (k : Fin r) → MPSTensor d (dim k)} {j k : Fin r}
     (h : MPVPhaseEquiv blocks j k) (N : ℕ) :
-    mpvState (d := d) (blocks k) N = h.choose ^ N • mpvState (d := d) (blocks j) N := by
+    ∃ ζ : ℂ, ζ ≠ 0 ∧
+      mpvState (d := d) (blocks k) N = ζ ^ N • mpvState (d := d) (blocks j) N := by
+  rcases h with ⟨ζ, hζ, hmpv⟩
+  refine ⟨ζ, hζ, ?_⟩
   ext σ
   simp only [PiLp.smul_apply, smul_eq_mul, mpvState_apply]
-  exact h.choose_spec.2 N σ
+  exact hmpv N σ
 
 /-- Equivalence relation on block indices given by MPV phase equivalence. -/
 def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}
@@ -550,7 +553,8 @@ theorem representative_mpv_span_eq (classes : MPVPhaseClassData blocks) (N : ℕ
     change mpvState (d := d) (blocks k) N ∈
       Submodule.span ℂ (Set.range (fun j : Fin classes.g =>
         mpvState (d := d) (blocks (classes.repr j)) N))
-    rw [hphase.mpvState_eq_smul N]
+    obtain ⟨ζ, _hζ, hstate⟩ := hphase.exists_mpvState_eq_smul N
+    rw [hstate]
     exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨j, rfl⟩)
 
 end MPVPhaseClassData
@@ -700,7 +704,7 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_blocksNotGaugePhas
     exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv
       blocks hTP hIrr hPrim hBlocks
 
-/-- The concrete collapsed-representative sector decomposition obtained from MPV phase classes. -/
+/-- The concrete sector decomposition obtained from representatives of MPV phase classes. -/
 private noncomputable def collapsedBntSectorDecomp
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
@@ -793,7 +797,7 @@ representative is chosen for each class; for every original block in the class,
 the associated phase is multiplied into its sector weight.  Gauge-phase-equivalent
 blocks land in the same MPV phase class, so the chosen representatives satisfy
 `BlocksNotGaugePhaseEquiv`.  The separated-family BNT independence theorem then
-proves `HasBNTSectorData` for the collapsed sector decomposition. -/
+proves `HasBNTSectorData` for the constructed sector decomposition. -/
 theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
@@ -809,6 +813,7 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks
   · exact collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
   · exact collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
 
+
 /-- **Phase-class BNT sector construction with one-sided overlap data.**
 
 Starting from trace-preserving primitive irreducible blocks with nonzero weights,
@@ -820,9 +825,8 @@ overlap-rigidity route.
 
 The theorem also records that if the original blocks are one-site injective,
 then the chosen basis blocks are injective. It does not claim the remaining
-two-family input of `SectorBasisOverlapSpanHypotheses`: equality of the
-finite-length MPV spans between two independently constructed bases is a
-separate Gap §1 task. -/
+two-family input: equality of the finite-length MPV spans between two
+independently constructed bases is a separate Gap §1 task. -/
 theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
@@ -869,52 +873,13 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
   · intro hInj j
     simpa [P, collapsedBntSectorDecomp] using hInj (classes.repr j)
 
-/-- **Collapsed BNT sector construction with primitive overlap data.**
+/-- Concrete one-sided data for the construction using representatives of MPV phase-equivalence
+classes, including the finite-length representative-span identity.
 
-This strengthens `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` by exposing the
-properties of the chosen representative basis blocks that are needed by the overlap-rigidity
-layer. The extra `hInj` hypothesis is intentional: the one-sided BNT constructor assumes
-irreducibility, primitivity, and trace preservation, while
-`SectorBasisOverlapSpanHypotheses` consumes length-1 MPS-injectivity.
 
-The finite-span comparison between two independently constructed sector bases is not part of
-this one-sided theorem; it depends on comparing the two sides. -/
-theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData
-    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
-    (μ : Fin r → ℂ)
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
-    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
-    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
-    (hInj : ∀ k, IsInjective (blocks k))
-    (hμne : ∀ k, μ k ≠ 0) :
-    ∃ P : SectorDecomposition d,
-      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
-      HasBNTSectorData (d := d) P ∧
-      (∀ j : Fin P.basisCount, 0 < P.basisDim j) ∧
-      (∀ j : Fin P.basisCount, IsInjective (P.basis j)) ∧
-      (∀ j : Fin P.basisCount, (∑ i : Fin d, (P.basis j i)ᴴ * (P.basis j i)) = 1) ∧
-      (∀ j : Fin P.basisCount,
-        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
-          Filter.atTop (nhds (1 : ℂ))) ∧
-      (∀ i j : Fin P.basisCount, i ≠ j →
-        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
-          Filter.atTop (nhds 0)) := by
-  obtain ⟨P, hSame, hBNT, hOrtho, hInj_of⟩ :=
-    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
-      (d := d) μ blocks hTP hIrr hPrim hμne
-  exact ⟨P, hSame, hBNT, hOrtho.dim_pos, hInj_of hInj, hOrtho.normalized,
-    hOrtho.self_overlap, hOrtho.off_overlap⟩
-
-/-- **Collapsed BNT sector construction with overlap data and the quotient span identity.**
-
-This strengthens `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData` by
-also exposing the finite-length span invariant of the collapsed construction: at every length,
-the chosen MPV phase-class representatives span the same MPV subspace as the original block
-family.  This removes the quotient/enumeration bookkeeping from later two-sided span
-comparisons; the remaining comparison is the genuine equality of the two original live-block
-spans. -/
-theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData_and_basisSpan
+This private helper keeps the proof of the common fields shared by the public one-sided overlap
+data theorems in one place. -/
+private theorem bntSectorDecomp_overlapData_basisSpan_aux
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -969,12 +934,87 @@ theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData_and_
   · intro N
     simpa [P, collapsedBntSectorDecomp] using classes.representative_mpv_span_eq (d := d) N
 
-/-- **Two-sided collapsed BNT overlap-span data from live-block span equality.**
+/-- **Phase-class BNT sector construction with primitive overlap data.**
 
-Apply the collapsed representative construction on both live block families.  The one-sided
-quotient span identity above transports a finite-length span equality for the original live
-blocks to the two independently chosen collapsed sector bases.  Thus the theorem packages all
-fields of `SectorBasisOverlapSpanHypotheses` without assuming that structure directly.
+This strengthens `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` by exposing the
+properties of the chosen representative basis blocks that are needed by the overlap-rigidity
+layer. The extra `hInj` hypothesis is intentional: the one-sided BNT constructor assumes
+irreducibility, primitivity, and trace preservation, while
+`SectorBasisOverlapSpanHypotheses` consumes length-1 MPS-injectivity.
+
+The finite-span comparison between two independently constructed sector bases is not part of
+this one-sided theorem; it depends on comparing the two sides. -/
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hInj : ∀ k, IsInjective (blocks k))
+    (hμne : ∀ k, μ k ≠ 0) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P ∧
+      (∀ j : Fin P.basisCount, 0 < P.basisDim j) ∧
+      (∀ j : Fin P.basisCount, IsInjective (P.basis j)) ∧
+      (∀ j : Fin P.basisCount, (∑ i : Fin d, (P.basis j i)ᴴ * (P.basis j i)) = 1) ∧
+      (∀ j : Fin P.basisCount,
+        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
+          Filter.atTop (nhds (1 : ℂ))) ∧
+      (∀ i j : Fin P.basisCount, i ≠ j →
+        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
+          Filter.atTop (nhds 0)) := by
+  obtain ⟨P, hSame, hBNT, hPos, hBasisInj, hBasisTP, hSelfOverlap, hCrossOverlap, _hSpan⟩ :=
+    bntSectorDecomp_overlapData_basisSpan_aux
+      (d := d) μ blocks hTP hIrr hPrim hInj hμne
+  exact ⟨P, hSame, hBNT, hPos, hBasisInj, hBasisTP, hSelfOverlap, hCrossOverlap⟩
+
+/-- **Phase-class BNT sector construction with overlap data and the quotient span identity.**
+
+This strengthens `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData` by
+also exposing the finite-length span invariant of the phase-class representative
+construction: at every length, the chosen MPV phase-class representatives span the same
+MPV subspace as the original block
+family.  This removes the quotient/enumeration bookkeeping from later two-sided span
+comparisons; the remaining comparison is the genuine equality of the two original live-block
+spans. -/
+theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData_and_basisSpan
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hInj : ∀ k, IsInjective (blocks k))
+    (hμne : ∀ k, μ k ≠ 0) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      HasBNTSectorData (d := d) P ∧
+      (∀ j : Fin P.basisCount, 0 < P.basisDim j) ∧
+      (∀ j : Fin P.basisCount, IsInjective (P.basis j)) ∧
+      (∀ j : Fin P.basisCount, (∑ i : Fin d, (P.basis j i)ᴴ * (P.basis j i)) = 1) ∧
+      (∀ j : Fin P.basisCount,
+        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
+          Filter.atTop (nhds (1 : ℂ))) ∧
+      (∀ i j : Fin P.basisCount, i ≠ j →
+        Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
+          Filter.atTop (nhds 0)) ∧
+      (∀ N,
+        Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
+          mpvState (d := d) (P.basis j) N)) =
+        Submodule.span ℂ (Set.range (fun k : Fin r =>
+          mpvState (d := d) (blocks k) N))) := by
+  exact bntSectorDecomp_overlapData_basisSpan_aux
+    (d := d) μ blocks hTP hIrr hPrim hInj hμne
+
+/-- **Two-sided overlap-span data from live-block span equality.**
+
+Apply the construction using representatives of MPV phase-equivalence classes on both live
+block families. The one-sided quotient span identity above transports a finite-length span
+equality for the original live blocks to the two independently chosen sector bases. Thus the
+theorem provides all fields of `SectorBasisOverlapSpanHypotheses` without assuming that
+structure directly.
 
 The remaining paper-level task, not proved here, is to derive the displayed live-block span
 equality from the global `SameMPV₂` and structural reduction data. -/

--- a/audits/2026-04-26_issue877_after_blocking_sector.md
+++ b/audits/2026-04-26_issue877_after_blocking_sector.md
@@ -75,33 +75,42 @@ reduction:
    live sector tensors requires either equal zero-tail dimensions or a
    positive-length variant of the sector comparison/extrapolation layer.
 
-3. **Overlap/span hypotheses for the phase-class BNT bases.**
-   The one-sided #923 constructor proves `HasBNTSectorData` but does not expose
-   all fields of `SectorBasisOverlapSpanHypotheses`; deriving them for the
-   phase-class BNT bases is the next paper-level task.
+3. **Live-block span comparison for the chosen sector bases.**
+   PR #955 exposed the one-sided representative data needed by
+   `SectorBasisOverlapSpanHypotheses`: positive dimensions, injectivity (from an
+   explicit live-block injectivity input), normalization, and self/off-overlap
+   limits. Wave 18B adds the missing quotient-span bookkeeping:
+   `MPSTensor.MPVPhaseClassData.representative_mpv_span_eq` proves that the
+   chosen MPV phase-class representatives span exactly the same finite-length MPV
+   subspace as the original live blocks, and
+   `MPSTensor.exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq`
+   transports an equality of the two original live-block spans to the two chosen
+   sector bases. Thus the remaining span input is now precisely the live-block
+   span equality itself, not an opaque `SectorBasisOverlapSpanHypotheses` field.
 
 ## Wave 17 Slot G update
 
 `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho`
-now strengthens the #923 constructor for the fields that are one-sided in nature:
+strengthened the #923 constructor for the fields that are one-sided in nature:
 positive basis dimensions, left-canonical normalization, self-overlap limits,
 off-overlap limits, and representative injectivity when the original live blocks
-are one-site injective.  The helper
+are one-site injective. The helper
 `MPSTensor.SectorBasisOverlapOrthoHypotheses.to_overlapSpan` then combines those
-one-sided fields with the two genuinely two-family inputs still needed by the
-#860 overlap-rigidity theorem: injectivity of the chosen bases and equality of
-the finite-length MPV spans.
+one-sided fields with the two genuinely two-family inputs needed by the #860
+overlap-rigidity theorem: injectivity of the chosen bases and equality of the
+finite-length MPV spans.
 
-Accordingly,
-`MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`
-replaces the earlier opaque overlap-span-data input by explicit live-block
-injectivity plus a finite-span comparison for the phase-class BNT bases.  The
-remaining unproved Gap §1 content is now narrower: obtain the exact common
-live-block input above, arrange one-site injectivity (or a blocked variant of the
-rigidity theorem), and prove the finite-length span comparison for the two BNT
-bases.
+## Wave 18B update
 
-Therefore this branch combines the available #923 and #860 ingredients without
-hiding the missing work behind `SectorBasisMatching`. The remaining work is to
-prove the listed live-block and span facts for the actual sector decompositions
-produced by the after-blocking reduction.
+`MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan`
+now replaces the two-sector span input by equality of the finite-length MPV spans
+of the original live block families. The one-sided representative-span identity
+transports those live-block spans to the chosen BNT sector bases, and the #860
+matching theorem then gives the sector-weight conclusion.
+
+Therefore the available #923/#944/#955 and #860 ingredients now reduce the
+unconditional theorem to the genuine structural inputs still missing from the
+paper-level reduction: exact common live decompositions, the `N = 0` zero-tail
+bookkeeping, live-block injectivity or a blocked replacement for the primitive
+rigidity theorem, and finite-length span equality for the original live block
+families from the global equal-MPV hypothesis.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2372,6 +2372,32 @@ The following results separate the zero blocks from the
 	injectivity field required by this theorem's unbundled conclusion.
 \end{proof}
 
+\begin{theorem}[Chosen phase representatives preserve finite-length spans]
+	\label{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data_span}
+	\lean{MPSTensor.MPVPhaseClassData.representative_mpv_span_eq}
+	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData_and_basisSpan}
+	\leanok
+	\uses{def:mpv_phase_class_data,
+		thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}
+	For any finite block family, the chosen MPV phase-class representatives span
+	the same finite-length MPV subspace as the original blocks at every system
+	size. Consequently, for trace-preserving primitive irreducible injective
+	blocks with nonzero weights, the one-sided BNT sector construction can be
+	chosen with all overlap data from
+	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data} and
+	with this representative-span identity.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{def:mpv_phase_class_data,
+		thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}
+	Each representative is one of the original blocks. Conversely, every original
+	block appears in a phase class and differs from that class representative by a
+	nonzero scalar power at each length, so its MPV state lies in the
+	representative span. The one-sided sector theorem then records this identity
+	for the chosen sector basis.
+\end{proof}
+
 \begin{theorem}[TP primitive irreducible version with eventual BNT independence]
 	\label{thm:bnt_sector_decomp_tp_prim_irr_linear_independent}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -658,7 +658,7 @@ single weighted block.
 	\leanok
 	\uses{thm:route_b_hetero_phase_match_copies}
 	Gauge-phase equivalence gives the required phase-scaling identities for
-	the matched basis MPVs. Theorem~\ref{thm:route_b_hetero_phase_match_copies}
+	the corresponding basis MPVs. Theorem~\ref{thm:route_b_hetero_phase_match_copies}
 	recovers the missing copy-count equalities, which are precisely the extra
 	fields needed for Definition~\ref{def:sector_basis_matching}.
 \end{proof}
@@ -679,7 +679,7 @@ single weighted block.
 	\leanok
 	\uses{thm:route_b_hetero_phase_match_copies}
 	The gauge-phase equivalences in the pre-matching give the phase-scaling
-	identities for the matched basis MPVs.
+	identities for the corresponding basis MPVs.
 	Theorem~\ref{thm:route_b_hetero_phase_match_copies} then gives the
 	copy-count equalities and the phase-adjusted multiset equalities.
 \end{proof}
@@ -724,6 +724,32 @@ single weighted block.
 	normalization, overlap, and span assumptions of
 	Theorem~\ref{thm:sector_basis_matching_from_overlap_ortho_span}. Applying
 	that theorem gives the matching witness.
+\end{proof}
+
+
+\begin{theorem}[Live-block span equality gives phase-class representative overlap-span data]%
+\label{thm:bnt_sector_decomp_pair_overlap_span_of_block_span}
+	\lean{MPSTensor.exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq}
+	\leanok
+	\uses{def:sector_basis_overlap_span_hyps,
+		thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data_span}
+	Let two live block families be trace-preserving, primitive, irreducible,
+	injective, and carry nonzero weights. If their finite-length MPV spans agree
+	for every system size, then there exist sector decompositions $P$ and $Q$
+	whose total tensors have the same MPVs as the two weighted live block tensors,
+	whose bases satisfy BNT linear independence, and whose sector bases satisfy
+	the primitive overlap-span hypotheses.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data_span}
+	Apply the one-sided construction with the representative-span identity on both
+	sides. The one-sided positive-dimension, injectivity, normalization, and
+	overlap fields fill all fields of
+	Definition~\ref{def:sector_basis_overlap_span_hyps} except the two-family
+	span equality. That span equality follows by transporting the assumed
+	live-block span equality through the two representative-span identities.
 \end{proof}
 
 \begin{theorem}[Heterogeneous sector comparison via a bundled matching witness]%
@@ -797,7 +823,7 @@ single weighted block.
 	\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed,
 		thm:sector_basis_overlap_span_to_matching,
 		thm:route_b_hetero_sector_matching}
-	Apply the one-sided collapsed BNT construction
+	Apply the one-sided phase-class BNT construction
 	(Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}) to the two live
 	block families. The resulting sector decompositions satisfy the overlap-span
 	hypotheses; Theorem~\ref{thm:sector_basis_overlap_span_to_matching} then
@@ -834,6 +860,40 @@ single weighted block.
 	comparison combines with those one-family data by
 	Theorem~\ref{thm:sector_basis_overlap_ortho_to_span}; the matching and
 	sector-weight comparison then proceed as before.
+\end{proof}
+
+
+\begin{theorem}[Common live blocks with live-block span equality give sector comparison]%
+\label{thm:after_blocking_sector_common_blocks_block_span}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan}
+	\leanok
+	\uses{thm:bnt_sector_decomp_pair_overlap_span_of_block_span,
+		thm:sector_basis_overlap_span_to_matching,
+		thm:route_b_hetero_sector_matching}
+	Let $A$ and $B$ have the same MPV family, and fix a common blocking period
+	$p>0$ with exact live decompositions by trace-preserving, primitive,
+	irreducible, injective blocks with nonzero weights. If the two live block
+	families have equal finite-length MPV spans at every system size, then there
+	exist a positive blocking period $p'$ and sector decompositions $P,Q$ over the
+	blocked physical dimension such that $A^{[p']}$ and $B^{[p']}$ have the same
+	MPV families as $P$ and $Q$, both sector bases satisfy BNT linear
+	independence, and there are a basis permutation, matched copy-count equalities,
+	and nonzero scalars $\zeta_j$ making the corresponding sector-weight multisets
+	equal after multiplication by $\zeta_j$.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:bnt_sector_decomp_pair_overlap_span_of_block_span,
+		thm:sector_basis_overlap_span_to_matching,
+		thm:route_b_hetero_sector_matching}
+	Theorem~\ref{thm:bnt_sector_decomp_pair_overlap_span_of_block_span} converts
+	the live-block span equality into the primitive overlap-span hypotheses for the
+	chosen sector bases. Equality of the blocked total MPVs gives equality of the
+	sector tensors, so
+	Theorem~\ref{thm:sector_basis_overlap_span_to_matching} produces the sector
+	basis matching and Theorem~\ref{thm:route_b_hetero_sector_matching} gives the
+	sector-weight conclusion.
 \end{proof}
 
 \begin{lemma}[Zero-tail cancellation]\label{lem:sameMPV2_live_of_zeroTail_eq}
@@ -895,7 +955,7 @@ single weighted block.
 	\uses{def:paper_sector_data}
 	Let $P$ and $Q$ be sector decompositions. Assume there is a permutation
 	$\pi$ matching the basis blocks, the multiplicities satisfy
-	$r_j^P = r_{\pi(j)}^Q$, and for each $j$ the matched basis blocks have the
+	$r_j^P = r_{\pi(j)}^Q$, and for each $j$ the corresponding basis blocks have the
 	same auxiliary dimension and satisfy
 	\[
 		V^{(N)}(Q_{\pi(j)})_\sigma = \zeta_j^N V^{(N)}(P_j)_\sigma
@@ -911,7 +971,7 @@ single weighted block.
 \begin{proof}
 	\leanok
 	\uses{thm:route_b_hetero_phase_match}
-	After transporting the matched basis tensor of $P_j$ across the dimension
+	After transporting the corresponding basis tensor of $P_j$ across the dimension
 	identity, this is exactly the hypothesis of
 	Theorem~\ref{thm:route_b_hetero_phase_match}. The conclusion is therefore
 	the same multiset equality.


### PR DESCRIPTION
## Summary

- prove that MPV phase-class representatives span the same finite-length MPV subspace as the original nonzero block family (`MPVPhaseClassData.representative_mpv_span_eq`)
- strengthen the PR #955 one-sided overlap-data constructor with this basis-span identity
- package two-sided `SectorBasisOverlapSpanHypotheses` from equality of the original nonzero-block spans, and add an common block-decomposition after-blocking theorem using that input instead of opaque two-sector overlap-span data
- update blueprint/audit notes to make the remaining #944/#652 input precise: derive nonzero-block finite-length span equality from the global equal-MPV structural reduction

## Validation

- `lake build TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem TNLean.MPS.CanonicalForm.EqualNormBridge`
  - passed; only pre-existing long-line warnings replayed from `CyclicSectorDecomposition.lean`
- Lean diagnostics clean for:
  - `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`
  - `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- added-line whole-word scan for `sorry|admit|axiom|native_decide|unsafe`
- added-line scan for banned prose phrases `copy alignment` and `matched-basis`

## Notes

This does not hide the final paper-level span argument behind `SectorBasisOverlapSpanHypotheses`.  It removes the quotient/representative accounting: the remaining field is now exactly finite-length span equality for the original nonzero block families.

Advances #944 and #652.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are new/strengthened Lean theorems and documentation around canonical-form sector comparison, with no runtime behavior or external interfaces beyond theorem APIs.
> 
> **Overview**
> Adds formal accounting showing MPV phase-class representatives preserve finite-length MPV spans (`MPVPhaseClassData.representative_mpv_span_eq`) and threads this span-transport through the one-sided phase-class BNT constructor (`exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapData_and_basisSpan`).
> 
> Builds a new two-sided helper (`exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq`) that derives `SectorBasisOverlapSpanHypotheses` from equality of the *original* nonzero-block spans, and uses it to introduce `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan`, replacing the prior opaque overlap-span input with a direct nonzero-block span-equality assumption.
> 
> Updates blueprint/audit prose to reflect the new “remaining gap”: proving nonzero-block finite-span equality from global `SameMPV₂` and structural reduction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54bdd67b6101554fdbb54c9382499f103b5ba9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->