### PR TITLE
feat(MPS/ParentHamiltonian): expose adjacent overlap intersection

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -51,6 +51,26 @@ noncomputable def groundSpaceES (A : MPSTensor d D) (L : ℕ) :
     Submodule ℂ (EuclideanSpace ℂ (Cfg d L)) :=
   (groundSpace A L).map (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm.toLinearMap
 
+/-- Membership in the Euclidean version of the MPS ground space is the same as
+membership of the transported vector in the original function-space ground space. -/
+theorem mem_groundSpaceES_iff (A : MPSTensor d D) (L : ℕ)
+    (v : EuclideanSpace ℂ (Cfg d L)) :
+    v ∈ groundSpaceES A L ↔
+      (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)) v ∈ groundSpace A L := by
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d L)
+  constructor
+  · intro hv
+    rw [groundSpaceES, Submodule.mem_map] at hv
+    rcases hv with ⟨w, hw, hwv⟩
+    have hvw : e v = w := by
+      rw [← hwv]
+      simp [e]
+    change e v ∈ groundSpace A L
+    rwa [hvw]
+  · intro hv
+    rw [groundSpaceES, Submodule.mem_map]
+    exact ⟨e v, hv, by simp [e]⟩
+
 /-! ### Parent interaction -/
 
 /-- Parent interaction on `L` consecutive sites: the orthogonal projector onto

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -57,19 +57,9 @@ theorem mem_groundSpaceES_iff (A : MPSTensor d D) (L : ℕ)
     (v : EuclideanSpace ℂ (Cfg d L)) :
     v ∈ groundSpaceES A L ↔
       (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)) v ∈ groundSpace A L := by
-  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d L)
-  constructor
-  · intro hv
-    rw [groundSpaceES, Submodule.mem_map] at hv
-    rcases hv with ⟨w, hw, hwv⟩
-    have hvw : e v = w := by
-      rw [← hwv]
-      simp [e]
-    change e v ∈ groundSpace A L
-    rwa [hvw]
-  · intro hv
-    rw [groundSpaceES, Submodule.mem_map]
-    exact ⟨e v, hv, by simp [e]⟩
+  rw [groundSpaceES]
+  exact Submodule.mem_map_equiv (p := groundSpace A L)
+    (e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm) (x := v)
 
 /-! ### Parent interaction -/
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -252,17 +252,8 @@ theorem parentInteractionES_apply_eq_zero_iff (A : MPSTensor d D) (L : ℕ)
     parentInteractionES A L v = 0 ↔ v ∈ groundSpaceES A L := by
   change (groundSpaceES A L)ᗮ.starProjection v = 0 ↔ v ∈ groundSpaceES A L
   rw [Submodule.starProjection_orthogonal']
-  constructor
-  · intro hv
-    have hsub : v - (groundSpaceES A L).starProjection v = 0 := by
-      simpa [ContinuousLinearMap.sub_apply] using hv
-    have hproj : (groundSpaceES A L).starProjection v = v := by
-      exact (sub_eq_zero.mp hsub).symm
-    exact Submodule.starProjection_eq_self_iff.mp hproj
-  · intro hv
-    have hproj : (groundSpaceES A L).starProjection v = v :=
-      Submodule.starProjection_eq_self_iff.mpr hv
-    simp [ContinuousLinearMap.sub_apply, hproj]
+  simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.one_apply]
+  rw [sub_eq_zero, eq_comm, Submodule.starProjection_eq_self_iff]
 
 /-- The cyclic window restriction map transported from `NSiteSpace` to the
 Hilbert-space model `EuclideanSpace`. -/
@@ -726,7 +717,7 @@ theorem adjacent_localTermES_eq_zero_of_mem_groundSpaceES_succ
     exact groundSpace_inRightGround A L hψ (τ 0)
 
 /-- Adjacent local kernels on an `(L+1)`-site chain intersect in the MPS ground
-space.  This repackages the open-chain intersection property in the same
+space.  This restates the open-chain intersection property in the same
 Euclidean local-projector language used by the martingale proof. -/
 theorem adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ {A : MPSTensor d D}
     (hA : IsInjective A) {L : ℕ} (hL : 1 < L)

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -74,6 +74,9 @@ concrete Friedrichs-angle/row-sum lower bound that
 * `MPSTensor.localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap` — failure
   of the concrete cyclic-support overlap predicate gives the same nonnegative
   ordered cross term.
+* `MPSTensor.adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ` — the
+  open-chain intersection property restated as an equality between the kernels
+  of two adjacent transported local terms and the `(L+1)`-site MPS ground space.
 * `MPSTensor.parentHamiltonianES_gap_bound_of_quadratic_form` — the explicit
   reduction from the parent-Hamiltonian gap statement to the uniform
   Friedrichs/martingale quadratic-form estimate.
@@ -241,6 +244,25 @@ orthogonal projection. -/
 theorem parentInteractionES_isPositive (A : MPSTensor d D) (L : ℕ) :
     (parentInteractionES A L).IsPositive :=
   (parentInteractionES_isSymmetricProjection A L).isPositive
+
+/-- The kernel of the Euclidean parent interaction is exactly the Euclidean MPS
+local ground space. -/
+theorem parentInteractionES_apply_eq_zero_iff (A : MPSTensor d D) (L : ℕ)
+    (v : EuclideanSpace ℂ (Cfg d L)) :
+    parentInteractionES A L v = 0 ↔ v ∈ groundSpaceES A L := by
+  change (groundSpaceES A L)ᗮ.starProjection v = 0 ↔ v ∈ groundSpaceES A L
+  rw [Submodule.starProjection_orthogonal']
+  constructor
+  · intro hv
+    have hsub : v - (groundSpaceES A L).starProjection v = 0 := by
+      simpa [ContinuousLinearMap.sub_apply] using hv
+    have hproj : (groundSpaceES A L).starProjection v = v := by
+      exact (sub_eq_zero.mp hsub).symm
+    exact Submodule.starProjection_eq_self_iff.mp hproj
+  · intro hv
+    have hproj : (groundSpaceES A L).starProjection v = v :=
+      Submodule.starProjection_eq_self_iff.mpr hv
+    simp [ContinuousLinearMap.sub_apply, hproj]
 
 /-- The cyclic window restriction map transported from `NSiteSpace` to the
 Hilbert-space model `EuclideanSpace`. -/
@@ -577,6 +599,146 @@ private theorem cyclicRestrictES_localTermES {N : ℕ} (A : MPSTensor d D) {L : 
     rw [cyclicCfg_eq_replaceWindow (d := d) (Fin.pos i) L hLN]
     exact extractWindow_replaceWindow L hLN i τ ω
   rw [← hrestrict, hextract]
+
+/-- A transported local term vanishes exactly when every boundary-filled cyclic
+restriction to its window lies in the `L`-site MPS ground space. -/
+theorem localTermES_eq_zero_iff_forall_cyclicRestrictES_mem_groundSpaceES {N : ℕ}
+    (A : MPSTensor d D) {L : ℕ} (hLN : L ≤ N) (i : Fin N)
+    (v : EuclideanSpace ℂ (Cfg d N)) :
+    localTermES A L i v = 0 ↔
+      ∀ τ : Cfg d N,
+        cyclicRestrictES (d := d) (Fin.pos i) L i τ v ∈ groundSpaceES A L := by
+  constructor
+  · intro hv τ
+    rw [← parentInteractionES_apply_eq_zero_iff]
+    rw [← cyclicRestrictES_localTermES A hLN i τ v, hv, map_zero]
+  · intro hv
+    ext σ
+    rw [localTermES_apply A L i hLN v σ]
+    have hker := (parentInteractionES_apply_eq_zero_iff A L
+      (cyclicRestrictES (d := d) (Fin.pos i) L i σ v)).2 (hv σ)
+    rw [hker]
+    rfl
+
+/-- If a transported local term vanishes, every cyclic restriction to its window
+is an element of the corresponding MPS ground space. -/
+theorem cyclicRestrictES_mem_groundSpaceES_of_localTermES_eq_zero {N : ℕ}
+    (A : MPSTensor d D) {L : ℕ} (hLN : L ≤ N) (i : Fin N)
+    {v : EuclideanSpace ℂ (Cfg d N)} (hv : localTermES A L i v = 0)
+    (τ : Cfg d N) :
+    cyclicRestrictES (d := d) (Fin.pos i) L i τ v ∈ groundSpaceES A L :=
+  (localTermES_eq_zero_iff_forall_cyclicRestrictES_mem_groundSpaceES A hLN i v).1 hv τ
+
+private theorem restrictLast_eq_cyclicRestrictES_zero {L : ℕ}
+    (v : EuclideanSpace ℂ (Cfg d (L + 1))) (τ : Cfg d (L + 1)) :
+    restrictLast ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (L + 1))) v) (τ (Fin.last L)) =
+      (WithLp.linearEquiv 2 ℂ (NSiteSpace d L))
+        (cyclicRestrictES (d := d) (Fin.pos (0 : Fin (L + 1))) L (0 : Fin (L + 1))
+          τ v) := by
+  ext σ
+  change v.ofLp (Fin.snoc σ (τ (Fin.last L))) = v.ofLp
+    (cyclicCfg (d := d) (Fin.pos (0 : Fin (L + 1))) L (0 : Fin (L + 1)) σ τ)
+  apply congrArg v.ofLp
+  funext k
+  rcases Fin.eq_castSucc_or_eq_last k with ⟨r, rfl⟩ | rfl
+  · have hmod : r.val % (L + 1) = r.val := Nat.mod_eq_of_lt (by omega)
+    simp [cyclicCfg, hmod]
+  · simp [cyclicCfg]
+
+private theorem restrictFirst_eq_cyclicRestrictES_one {L : ℕ} (hL : 0 < L)
+    (v : EuclideanSpace ℂ (Cfg d (L + 1))) (τ : Cfg d (L + 1)) :
+    restrictFirst ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (L + 1))) v) (τ 0) =
+      (WithLp.linearEquiv 2 ℂ (NSiteSpace d L))
+        (cyclicRestrictES (d := d) (Fin.pos (1 : Fin (L + 1))) L (1 : Fin (L + 1))
+          τ v) := by
+  ext σ
+  change v.ofLp (Fin.cons (τ 0) σ) = v.ofLp
+    (cyclicCfg (d := d) (Fin.pos (1 : Fin (L + 1))) L (1 : Fin (L + 1)) σ τ)
+  apply congrArg v.ofLp
+  funext k
+  have hOneNat : 1 % (L + 1) = 1 := Nat.mod_eq_of_lt (by omega)
+  rcases Fin.eq_zero_or_eq_succ k with rfl | ⟨r, rfl⟩
+  · simp [cyclicCfg, hOneNat]
+  · have hmod : (r.val + 1 + L) % (L + 1) = r.val := by
+      rw [show r.val + 1 + L = r.val + (L + 1) by omega]
+      rw [Nat.add_mod_right]
+      exact Nat.mod_eq_of_lt (by omega)
+    simp [cyclicCfg, hOneNat, hmod]
+
+/-- Forward local intersection property for adjacent transported local terms.
+
+On an `(L+1)`-site chain, if the two overlapping `L`-site local terms based at
+`0` and `1` both annihilate a vector, then the vector lies in the `(L+1)`-site
+MPS ground space.  This is the Euclidean/local-projector form of the
+open-chain intersection property `groundSpace_intersection`; it is a structural
+predecessor to the quantitative Friedrichs-angle estimate for overlapping
+windows. -/
+theorem mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero {A : MPSTensor d D}
+    (hA : IsInjective A) {L : ℕ} (hL : 1 < L)
+    {v : EuclideanSpace ℂ (Cfg d (L + 1))}
+    (hleft : localTermES A L (0 : Fin (L + 1)) v = 0)
+    (hright : localTermES A L (1 : Fin (L + 1)) v = 0) :
+    v ∈ groundSpaceES A (L + 1) := by
+  let eN := WithLp.linearEquiv 2 ℂ (NSiteSpace d (L + 1))
+  have hLN : L ≤ L + 1 := by omega
+  have hLeft : InLeftGround A L (eN v) := by
+    intro j
+    have hmemES : cyclicRestrictES (d := d) (Fin.pos (0 : Fin (L + 1))) L
+        (0 : Fin (L + 1)) (fun _ => j) v ∈ groundSpaceES A L :=
+      cyclicRestrictES_mem_groundSpaceES_of_localTermES_eq_zero A hLN
+        (0 : Fin (L + 1)) hleft (fun _ => j)
+    have hmemNS := (mem_groundSpaceES_iff A L _).1 hmemES
+    rwa [restrictLast_eq_cyclicRestrictES_zero v (fun _ => j)]
+  have hRight : InRightGround A L (eN v) := by
+    intro i
+    have hmemES : cyclicRestrictES (d := d) (Fin.pos (1 : Fin (L + 1))) L
+        (1 : Fin (L + 1)) (fun _ => i) v ∈ groundSpaceES A L :=
+      cyclicRestrictES_mem_groundSpaceES_of_localTermES_eq_zero A hLN
+        (1 : Fin (L + 1)) hright (fun _ => i)
+    have hmemNS := (mem_groundSpaceES_iff A L _).1 hmemES
+    rwa [restrictFirst_eq_cyclicRestrictES_one (by omega : 0 < L) v (fun _ => i)]
+  have hψ : eN v ∈ groundSpace A (L + 1) :=
+    groundSpace_intersection hA hL hLeft hRight
+  exact (mem_groundSpaceES_iff A (L + 1) v).2 hψ
+
+/-- Vectors in the `(L+1)`-site MPS ground space are killed by the two adjacent
+`L`-site transported local terms. -/
+theorem adjacent_localTermES_eq_zero_of_mem_groundSpaceES_succ
+    (A : MPSTensor d D) {L : ℕ} (hL : 0 < L)
+    {v : EuclideanSpace ℂ (Cfg d (L + 1))} (hv : v ∈ groundSpaceES A (L + 1)) :
+    localTermES A L (0 : Fin (L + 1)) v = 0 ∧
+      localTermES A L (1 : Fin (L + 1)) v = 0 := by
+  let eN := WithLp.linearEquiv 2 ℂ (NSiteSpace d (L + 1))
+  have hψ : eN v ∈ groundSpace A (L + 1) := (mem_groundSpaceES_iff A (L + 1) v).1 hv
+  have hLN : L ≤ L + 1 := by omega
+  constructor
+  · rw [localTermES_eq_zero_iff_forall_cyclicRestrictES_mem_groundSpaceES A hLN
+      (0 : Fin (L + 1)) v]
+    intro τ
+    rw [mem_groundSpaceES_iff]
+    rw [← restrictLast_eq_cyclicRestrictES_zero v τ]
+    exact groundSpace_inLeftGround A L hψ (τ (Fin.last L))
+  · rw [localTermES_eq_zero_iff_forall_cyclicRestrictES_mem_groundSpaceES A hLN
+      (1 : Fin (L + 1)) v]
+    intro τ
+    rw [mem_groundSpaceES_iff]
+    rw [← restrictFirst_eq_cyclicRestrictES_one hL v τ]
+    exact groundSpace_inRightGround A L hψ (τ 0)
+
+/-- Adjacent local kernels on an `(L+1)`-site chain intersect in the MPS ground
+space.  This repackages the open-chain intersection property in the same
+Euclidean local-projector language used by the martingale proof. -/
+theorem adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ {A : MPSTensor d D}
+    (hA : IsInjective A) {L : ℕ} (hL : 1 < L)
+    {v : EuclideanSpace ℂ (Cfg d (L + 1))} :
+    localTermES A L (0 : Fin (L + 1)) v = 0 ∧
+      localTermES A L (1 : Fin (L + 1)) v = 0 ↔
+        v ∈ groundSpaceES A (L + 1) := by
+  constructor
+  · intro h
+    exact mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero hA hL h.1 h.2
+  · intro hv
+    exact adjacent_localTermES_eq_zero_of_mem_groundSpaceES_succ A (by omega : 0 < L) hv
 
 @[simp] private theorem localTermESSummand_apply {N : ℕ} (A : MPSTensor d D) (hN : 0 < N)
     {L : ℕ} (hLN : L ≤ N) (i : Fin N) (τ v σ) :

--- a/audits/2026-04-27_issue952_adjacent_intersection.md
+++ b/audits/2026-04-27_issue952_adjacent_intersection.md
@@ -1,0 +1,98 @@
+# Issue #952 / #460 — adjacent-window intersection predecessor for Friedrichs (2026-04-27)
+
+This note records checked progress on branch `wave18-D-952-friedrichs`.  The full
+overlapping-window Friedrichs / norm-compression estimate is still open; this branch
+formalizes the local intersection-property surface in the same Euclidean local-term
+language used by the martingale reduction.
+
+## Paper anchor
+
+The source paper discussion is `Papers/2011.12127/TN-Review-main.tex` §4.1 `Gaps`,
+especially:
+
+- line 2168: the martingale method relates the gap to the "`minimum non-zero angle
+  between the ground spaces of overlapping regions`";
+- lines 2176--2179, equation `eq:4:martingale-2`: the required overlapping-pair
+  estimate is
+  `h_ih_j+h_jh_i \ge -c_{ij} (1-\gamma)(h_i+h_j)`;
+- line 2180: the estimate is a "`lower bound on the smallest non-zero angle between
+  the ground spaces of h_i and h_j`";
+- line 2182: the quantities depend on "`the principal angles between \ker h_i and
+  \ker h_j`".
+
+The new Lean declarations do not claim this quantitative angle bound.  They identify,
+for adjacent overlapping windows, the exact local kernel intersection to which the
+principal-angle estimate must be applied.
+
+## Checked declarations added
+
+### Local ground-space transport
+
+- `MPSTensor.mem_groundSpaceES_iff` (`TNLean/MPS/ParentHamiltonian/Defs.lean`):
+  membership in `groundSpaceES A L` is equivalent to membership of the transported
+  vector in the original `groundSpace A L`.
+
+Blueprint sync:
+
+- `blueprint/src/chapter/ch14_parent_hamiltonian.tex` lines 142--148,
+  label `lem:mem_ground_space_es`, quote: "`A Euclidean vector lies in
+  G_L^{\mathrm{ES}}(A) exactly when transporting it back ... gives an element of
+  the original local ground space`".
+
+### Kernel characterizations for transported local terms
+
+- `MPSTensor.parentInteractionES_apply_eq_zero_iff`: the Euclidean parent
+  interaction `P_L^{ES}(A)` has kernel exactly `groundSpaceES A L`.
+- `MPSTensor.localTermES_eq_zero_iff_forall_cyclicRestrictES_mem_groundSpaceES`:
+  for `L ≤ N`, `localTermES A L i v = 0` iff every boundary-filled cyclic
+  restriction of `v` to the window starting at `i` lies in `groundSpaceES A L`.
+- `MPSTensor.cyclicRestrictES_mem_groundSpaceES_of_localTermES_eq_zero`: the forward
+  direction packaged for reuse.
+
+Blueprint sync:
+
+- lines 1777--1786, label `lem:parent_interaction_es_kernel`, quote:
+  "`P_L^{\mathrm{ES}}(A)v=0` iff `v\in G_L^{\mathrm{ES}}(A)`";
+- lines 1796--1803, label `lem:local_term_es_kernel_restrictions`, quote:
+  "`a transported local term ... annihilates a vector v iff every boundary-filled
+  restriction ... lies in G_L^{\mathrm{ES}}(A)`".
+
+### Adjacent-window local intersection property
+
+- `MPSTensor.mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero`: if `A` is
+  injective, `1 < L`, and the adjacent transported `L`-site terms at starts `0`
+  and `1` on an `(L+1)`-site chain both annihilate `v`, then
+  `v ∈ groundSpaceES A (L+1)`.
+- `MPSTensor.adjacent_localTermES_eq_zero_of_mem_groundSpaceES_succ`: the converse
+  direction, using the forward restriction lemmas.
+- `MPSTensor.adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ`: the combined
+  equivalence
+  ```text
+  localTermES A L 0 v = 0 ∧ localTermES A L 1 v = 0
+    ↔ v ∈ groundSpaceES A (L+1).
+  ```
+
+Blueprint sync:
+
+- lines 1814--1829, label `thm:adjacent_local_kernels_ground_space_es`, quote:
+  "`the kernels of the two adjacent transported L-site local terms are exactly the
+  transported (L+1)-site MPS ground space`".
+
+## What remains
+
+The checked adjacent-kernel theorem supplies the qualitative subspace intersection
+for the smallest overlapping union.  The remaining analytic task is still to prove a
+quantitative Friedrichs/principal-angle estimate for overlapping cyclic windows,
+strong enough for the already-isolated norm-compression input:
+
+```text
+‖localTermES A L i (localTermES A L j v)‖
+  ≤ (1 - 1/(4L)) * (2(L-1))⁻¹ * ‖localTermES A L i v‖
+```
+
+for all `N` with `2 * L ≤ N`, off-diagonal `i,j` satisfying
+`cyclicWindowsOverlap N L i j`, and all `v`.  Equivalently, one can prove the ordered
+anti-commutator/Friedrichs lower bound used by
+`parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs`.
+
+No proof holes or proof-integrity workarounds were introduced.

--- a/audits/2026-04-27_issue952_adjacent_intersection.md
+++ b/audits/2026-04-27_issue952_adjacent_intersection.md
@@ -7,18 +7,19 @@ language used by the martingale reduction.
 
 ## Paper anchor
 
-The source paper discussion is `Papers/2011.12127/TN-Review-main.tex` §4.1 `Gaps`,
-especially:
+The source paper discussion is `Papers/2011.12127/TN-Review-main.tex`,
+subsubsection label `sec:4:hams-gaps` ("Gaps"), especially equation
+`eq:4:martingale-2` and its surrounding principal-angle discussion:
 
 - line 2168: the martingale method relates the gap to the "`minimum non-zero angle
   between the ground spaces of overlapping regions`";
 - lines 2176--2179, equation `eq:4:martingale-2`: the required overlapping-pair
-  estimate is
-  `h_ih_j+h_jh_i \ge -c_{ij} (1-\gamma)(h_i+h_j)`;
-- line 2180: the estimate is a "`lower bound on the smallest non-zero angle between
-  the ground spaces of h_i and h_j`";
-- line 2182: the quantities depend on "`the principal angles between \ker h_i and
-  \ker h_j`".
+  estimate is `h_ih_j+h_jh_i \ge -c_{ij} (1-\gamma)(h_i+h_j)`;
+- line 2180: the text following `eq:4:martingale-2` describes this estimate as a
+  "`lower bound on the smallest non-zero angle between the ground spaces of
+  h_i and h_j`";
+- line 2182: the subsequent paragraph notes that the relevant quantities depend on
+  "`the principal angles between \ker h_i and \ker h_j`".
 
 The new Lean declarations do not claim this quantitative angle bound.  They identify,
 for adjacent overlapping windows, the exact local kernel intersection to which the
@@ -34,8 +35,8 @@ principal-angle estimate must be applied.
 
 Blueprint sync:
 
-- `blueprint/src/chapter/ch14_parent_hamiltonian.tex` lines 142--148,
-  label `lem:mem_ground_space_es`, quote: "`A Euclidean vector lies in
+- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`, label
+  `lem:mem_ground_space_es`, quote: "`A Euclidean vector lies in
   G_L^{\mathrm{ES}}(A) exactly when transporting it back ... gives an element of
   the original local ground space`".
 
@@ -51,9 +52,9 @@ Blueprint sync:
 
 Blueprint sync:
 
-- lines 1777--1786, label `lem:parent_interaction_es_kernel`, quote:
+- label `lem:parent_interaction_es_kernel`, quote:
   "`P_L^{\mathrm{ES}}(A)v=0` iff `v\in G_L^{\mathrm{ES}}(A)`";
-- lines 1796--1803, label `lem:local_term_es_kernel_restrictions`, quote:
+- label `lem:local_term_es_kernel_restrictions`, quote:
   "`a transported local term ... annihilates a vector v iff every boundary-filled
   restriction ... lies in G_L^{\mathrm{ES}}(A)`".
 
@@ -74,7 +75,7 @@ Blueprint sync:
 
 Blueprint sync:
 
-- lines 1814--1829, label `thm:adjacent_local_kernels_ground_space_es`, quote:
+- label `thm:adjacent_local_kernels_ground_space_es`, quote:
   "`the kernels of the two adjacent transported L-site local terms are exactly the
   transported (L+1)-site MPS ground space`".
 

--- a/audits/2026-04-27_issue952_adjacent_intersection.md
+++ b/audits/2026-04-27_issue952_adjacent_intersection.md
@@ -11,14 +11,14 @@ The source paper discussion is `Papers/2011.12127/TN-Review-main.tex`,
 subsubsection label `sec:4:hams-gaps` ("Gaps"), especially equation
 `eq:4:martingale-2` and its surrounding principal-angle discussion:
 
-- line 2168: the martingale method relates the gap to the "`minimum non-zero angle
+- the martingale method relates the gap to the "`minimum non-zero angle
   between the ground spaces of overlapping regions`";
-- lines 2176--2179, equation `eq:4:martingale-2`: the required overlapping-pair
-  estimate is `h_ih_j+h_jh_i \ge -c_{ij} (1-\gamma)(h_i+h_j)`;
-- line 2180: the text following `eq:4:martingale-2` describes this estimate as a
+- equation `eq:4:martingale-2` gives the required overlapping-pair estimate
+  `h_ih_j+h_jh_i \ge -c_{ij} (1-\gamma)(h_i+h_j)`;
+- the text following `eq:4:martingale-2` describes this estimate as a
   "`lower bound on the smallest non-zero angle between the ground spaces of
   h_i and h_j`";
-- line 2182: the subsequent paragraph notes that the relevant quantities depend on
+- the subsequent paragraph notes that the relevant quantities depend on
   "`the principal angles between \ker h_i and \ker h_j`".
 
 The new Lean declarations do not claim this quantitative angle bound.  They identify,

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -139,6 +139,21 @@ onto $G_L(A)^\perp$ in the $L$-site Euclidean space.
     \]
 \end{definition}
 
+\begin{lemma}[Membership in the transported local ground space]\label{lem:mem_ground_space_es}
+    \lean{MPSTensor.mem_groundSpaceES_iff}
+    \leanok
+    \uses{def:ground_space_es, def:ground_space_parent}
+    A Euclidean vector lies in $G_L^{\mathrm{ES}}(A)$ exactly when transporting it
+    back through the canonical coefficient-space equivalence gives an element of
+    the original local ground space $G_L(A)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is just the definition of $G_L^{\mathrm{ES}}(A)$ as the image of
+    $G_L(A)$ under the inverse of the canonical equivalence.
+\end{proof}
+
 \begin{definition}[Parent interaction]\label{def:parent_interaction}
     \lean{MPSTensor.parentInteraction}
     \leanok
@@ -1836,6 +1851,73 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $(P_L^{\mathrm{ES}}(A))^2=P_L^{\mathrm{ES}}(A)$ on that window. The positivity
     result above supplies symmetry, and the case $L>N$ is the zero projection by
     definition.
+\end{proof}
+
+\begin{lemma}[Kernel of the Euclidean parent interaction]\label{lem:parent_interaction_es_kernel}
+    \lean{MPSTensor.parentInteractionES_apply_eq_zero_iff}
+    \leanok
+    \uses{def:ground_space_es, rem:euclidean_local_projector_ingredients}
+    The Euclidean local interaction $P_L^{\mathrm{ES}}(A)$ annihilates exactly the
+    Euclidean local ground space:
+    \[
+        P_L^{\mathrm{ES}}(A)v=0 \quad\Longleftrightarrow\quad
+        v\in G_L^{\mathrm{ES}}(A).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Since $P_L^{\mathrm{ES}}(A)$ is the orthogonal projector onto
+    $(G_L^{\mathrm{ES}}(A))^\perp$, its kernel is the original subspace
+    $G_L^{\mathrm{ES}}(A)$.
+\end{proof}
+
+\begin{lemma}[Local-term kernel via cyclic restrictions]\label{lem:local_term_es_kernel_restrictions}
+    \lean{MPSTensor.localTermES_eq_zero_iff_forall_cyclicRestrictES_mem_groundSpaceES}
+    \lean{MPSTensor.cyclicRestrictES_mem_groundSpaceES_of_localTermES_eq_zero}
+    \leanok
+    \uses{lem:parent_interaction_es_kernel, rem:euclidean_local_projector_ingredients}
+    For $L\le N$, a transported local term $h_{i,\mathrm{ES}}$ annihilates a vector
+    $v$ iff every boundary-filled restriction of $v$ to the cyclic $L$-window
+    starting at $i$ lies in $G_L^{\mathrm{ES}}(A)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Restricting $h_{i,\mathrm{ES}}v$ to the same cyclic window gives
+    $P_L^{\mathrm{ES}}(A)$ applied to the corresponding restriction of $v$.
+    Lemma~\ref{lem:parent_interaction_es_kernel} identifies the vanishing of this
+    local projector with membership in $G_L^{\mathrm{ES}}(A)$.
+\end{proof}
+
+\begin{theorem}[Adjacent local kernels realize the intersection property]
+    \label{thm:adjacent_local_kernels_ground_space_es}
+    \lean{MPSTensor.mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero}
+    \lean{MPSTensor.adjacent_localTermES_eq_zero_of_mem_groundSpaceES_succ}
+    \lean{MPSTensor.adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}
+    \leanok
+    \uses{thm:ground_space_intersection, lem:local_term_es_kernel_restrictions,
+        lem:mem_ground_space_es}
+    If $A$ is injective and $L\ge2$, then on an $(L+1)$-site chain the kernels of
+    the two adjacent transported $L$-site local terms are exactly the transported
+    $(L+1)$-site MPS ground space:
+    \[
+        h_{0,\mathrm{ES}}v=0\ \text{ and }\ h_{1,\mathrm{ES}}v=0
+        \quad\Longleftrightarrow\quad
+        v\in G_{L+1}^{\mathrm{ES}}(A).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_intersection, lem:local_term_es_kernel_restrictions,
+        lem:mem_ground_space_es}
+    Lemma~\ref{lem:local_term_es_kernel_restrictions} translates the two local
+    kernel assumptions into the left and right $L$-site ground conditions.  The
+    open-chain intersection property, Theorem~\ref{thm:ground_space_intersection},
+    then regrows the shared $(L-1)$-site overlap to the $(L+1)$-site ground space.
+    The converse uses the forward restriction lemmas for ground-space vectors and
+    the same kernel--restriction characterization.
 \end{proof}
 
 \begin{lemma}[Non-overlap positivity for transported ES local terms]


### PR DESCRIPTION
## Summary

- add `mem_groundSpaceES_iff` to relate the Euclidean local ground space to the original MPS ground space
- characterize kernels of `parentInteractionES` and `localTermES` via boundary-filled cyclic restrictions
- prove that on an `(L+1)`-site chain the adjacent transported `L`-site local kernels at starts `0` and `1` intersect exactly in `groundSpaceES A (L+1)`, repackaging `groundSpace_intersection` in the local-projector language used by the martingale reduction
- document the progress in the parent-Hamiltonian blueprint and an audit, while leaving the quantitative overlapping-window Friedrichs/norm-compression estimate explicit as the remaining analytic task

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale TNLean.Analysis.ProjectionGeometry`
  - passed; only the pre-existing `parentHamiltonianES_gap_bound_of_friedrichs` warning remains
- `LAKE_JOBS=1 lake build +TNLean:olean`
  - passed after timeout-resume runs; pre-existing warnings/sorries only
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- added-line scan for proof-integrity tokens was clean; touched-file scan only finds the pre-existing Martingale Friedrichs proof hole

## Notes

This does **not** prove the full CPGSV21/Kastoryano--Lucia angle estimate.  It proves the qualitative adjacent-window kernel-intersection statement that the quantitative principal-angle/Friedrichs estimate must refine.

Refs #952. Refs #460. Refs #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean lemmas/theorems around ground-space transport and kernel characterizations; changes are proof-level and documentation-only with minimal risk aside from potential downstream proof breakage due to new dependencies.
> 
> **Overview**
> Adds a transport lemma `mem_groundSpaceES_iff` relating membership in `groundSpaceES` to membership in the original `groundSpace` after applying `WithLp.linearEquiv`.
> 
> In `Martingale.lean`, introduces kernel characterizations for the transported projector and local terms (e.g. `parentInteractionES_apply_eq_zero_iff` and `localTermES_eq_zero_iff_forall_cyclicRestrictES_mem_groundSpaceES`), and proves an **adjacent-window intersection** statement on `(L+1)` sites: `localTermES` at starts `0` and `1` both vanishing is equivalent to membership in `groundSpaceES A (L+1)`.
> 
> Updates the parent-Hamiltonian blueprint with the corresponding new lemmas/theorem and adds an audit note documenting the new “adjacent overlap intersection” surface and the remaining Friedrichs/principal-angle estimate work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0511bb431e96d30d08197b79803fb283eaa8ede1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->