### PR TITLE
feat(MPS/CanonicalForm): construct cyclic sectors for individual nonzero blocks (#942)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1067,6 +1067,36 @@ theorem exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducible
   · intro k
     exact Nat.pos_of_ne_zero (hNondeg k)
 
+/-- A one-block period-removal package with primitive irreducible sectors.
+
+`HasPrimitiveIrreducibleCyclicSectors A` means that some positive period `m`
+removes the cyclic peripheral structure of `A`: the blocked tensor `A^[m]` is
+represented by unit-weight sector blocks, each of which is trace-preserving, has
+primitive transfer map, is tensor-irreducible, and has positive bond dimension.
+The later common-refinement or Wielandt/injectivity blocking length is deliberately
+not part of this predicate. -/
+def HasPrimitiveIrreducibleCyclicSectors {d D : ℕ} (A : MPSTensor d D) : Prop :=
+  ∃ (m : ℕ), 0 < m ∧
+  ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
+    (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
+    SameMPV₂ (blockTensor (d := d) (D := D) A m)
+      (toTensorFromBlocks (d := blockPhysDim d m) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
+    (∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d m) (D := dim k) (blocks k))) ∧
+    (∀ k, IsIrreducibleTensor (blocks k)) ∧
+    (∀ k, 0 < dim k)
+
+/-- Trace-preserving irreducible tensors admit primitive irreducible cyclic sectors. -/
+theorem hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor
+    {d D : ℕ} [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A) :
+    HasPrimitiveIrreducibleCyclicSectors A := by
+  simpa [HasPrimitiveIrreducibleCyclicSectors] using
+    exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
+      (d := d) (D := D) A hTP hIrr
+
 end SectorOrbitLift
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/PrimitiveBlocks.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/PrimitiveBlocks.lean
@@ -197,6 +197,33 @@ theorem isIrreducibleTensor_blockTensor_of_tp_primitive_irr [NeZero D]
   -- Step 7: IsIrreducibleMap → IsIrreducibleTensor.
   exact isIrreducibleTensor_of_isIrreducibleMap (blockTensor A P) hIrrMap
 
+/-- **Extra blocking after period removal.**
+
+If a live sector block is already trace-preserving, primitive, and tensor-irreducible,
+then any later positive blocking length `k` preserves all three properties. In the
+canonical-form reduction, the period-removal length that produces such sector blocks
+is a different datum from this later finite blocking length, which is used only for
+common refinement or injectivity/Wielandt-span arguments. -/
+theorem tp_primitive_irreducible_extra_blocking [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
+    (hIrr : IsIrreducibleTensor A)
+    {k : ℕ} (hk : 0 < k) :
+    (∑ i : Fin (blockPhysDim d k),
+      (blockTensor (d := d) (D := D) A k i)ᴴ * blockTensor (d := d) (D := D) A k i = 1) ∧
+    _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d k) (D := D)
+        (blockTensor (d := d) (D := D) A k)) ∧
+    IsIrreducibleTensor (blockTensor (d := d) (D := D) A k) := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact leftCanonical_blockTensor (d := d) (D := D) (A := A) (L := k) hTP
+  · rw [transferMap_blockTensor]
+    exact isPrimitive_pow_of_isPrimitive (D := D)
+      (transferMap (d := d) (D := D) A) k hk hPrim
+  · exact isIrreducibleTensor_blockTensor_of_tp_primitive_irr
+      (d := d) (D := D) A hTP hPrim hIrr hk
+
 /-!
 ## Conditional Fundamental Theorem: proportional MPVs → block matching
 

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -68,19 +68,27 @@ The theorem `exists_tp_sector_decomp_after_blocking` below provides:
 The current library already settles the common-period blocking arithmetic and
 now has both a one-sided phase-class BNT construction for TP primitive
 irreducible live blocks and a witness-producing sector comparison from primitive
-overlap-span hypotheses. The exact-live theorem
+overlap-span hypotheses. The theorem
+`fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail`
+keeps the faithful paper order: first split off the zero tail and TP-gauge the
+irreducible live blocks, then remove each live block's period by cyclic sectors.
+It deliberately does not identify that period-removal length with the later
+finite blocking length used for common refinement or injectivity.
+
+The exact-live theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`
-combines `SameMPV₂ A B` with those ingredients once exact common live block
-decompositions, live-block injectivity, and the finite-length span comparison
-are supplied. The zero-tail-aware theorem
+combines `SameMPV₂ A B` with the BNT and matching ingredients once exact common
+live block decompositions, live-block injectivity, and the finite-length span
+comparison are supplied. The zero-tail-aware theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail`
 separately records the `N = 0` bookkeeping when full overlap-span hypotheses are
 available.
 
-The remaining Gap §1 content is to derive the exact live decompositions,
-one-site injectivity (or a blocked replacement), the finite-length span
-comparison, and the zero-tail bookkeeping from the structural after-blocking
-reduction itself.
+The remaining Gap §1 content is to flatten the per-block cyclic-sector data to a
+single common physical blocking level, derive one-site injectivity (or a blocked
+replacement) and the finite-length span comparison for the flattened family, and
+finish the zero-tail bookkeeping from the structural after-blocking reduction
+itself.
 -/
 
 section FundamentalTheorem1606
@@ -387,6 +395,74 @@ theorem fundamentalTheorem_after_blocking_1606_structural_with_zeroTail
     ?_, ?_, hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, hMPVA, hMPVB⟩
   · exact sameMPV₂_blockTensor A B hSame pA
   · exact sameMPV₂_blockTensor A B hSame pB
+
+/-- **Per-block cyclic live decomposition with zero-tail bookkeeping.**
+
+This is the faithful predecessor to the common-live-block statement. From
+`SameMPV₂ A B`, it first uses the invariant-subspace/zero-tail split and TP gauge
+to obtain irreducible live blocks on both sides. It then removes the period of
+each live block separately, producing primitive irreducible cyclic sectors for
+every live block. The positive-length live tensors agree, and the length-zero
+case is recorded as the explicit zero-tail bookkeeping identity.
+
+The theorem intentionally keeps the per-block period-removal lengths inside
+`HasPrimitiveIrreducibleCyclicSectors`. It does not conflate those lengths with a
+later common-refinement or Wielandt/injectivity blocking length; assembling the
+per-block cyclic sectors at one physical blocking level is the next formal
+interface still missing for #942/#652. -/
+theorem fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ (zeroTailA : ℕ) (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
+    ∃ (zeroTailB : ℕ) (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (k : Fin rB) → MPSTensor d (dimB k)),
+      (∀ k, IsIrreducibleTensor (blocksA k)) ∧
+      (∀ k, IsIrreducibleTensor (blocksB k)) ∧
+      (∀ k, ∑ i : Fin d, (blocksA k i)ᴴ * blocksA k i = 1) ∧
+      (∀ k, ∑ i : Fin d, (blocksB k i)ᴴ * blocksB k i = 1) ∧
+      (∀ k, μA k ≠ 0) ∧
+      (∀ k, μB k ≠ 0) ∧
+      (∀ k, 0 < dimA k) ∧
+      (∀ k, 0 < dimB k) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
+          mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
+          mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) ∧
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := d) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := d) (μ := μB) blocksB) ∧
+      (∀ σ : Fin 0 → Fin d,
+        (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) ∧
+      (∀ k, HasPrimitiveIrreducibleCyclicSectors (blocksA k)) ∧
+      (∀ k, HasPrimitiveIrreducibleCyclicSectors (blocksB k)) := by
+  obtain ⟨zeroTailA, rA, dimA, μA, blocksA,
+      hIrrA, hTPA, hμA, hDimA, hMPVA⟩ :=
+    exists_tp_gauge_from_arbitrary_with_zeroTail (d := d) (D := D₁) A
+  obtain ⟨zeroTailB, rB, dimB, μB, blocksB,
+      hIrrB, hTPB, hμB, hDimB, hMPVB⟩ :=
+    exists_tp_gauge_from_arbitrary_with_zeroTail (d := d) (D := D₂) B
+  have hBook :=
+    liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+      A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hMPVA hMPVB
+  refine ⟨zeroTailA, rA, dimA, μA, blocksA,
+    zeroTailB, rB, dimB, μB, blocksB,
+    hIrrA, hIrrB, hTPA, hTPB, hμA, hμB, hDimA, hDimB, hMPVA, hMPVB,
+    ?_, hBook.2, ?_, ?_⟩
+  · intro N hN σ
+    exact hBook.1 hN σ
+  · intro k
+    letI : NeZero (dimA k) := ⟨Nat.ne_of_gt (hDimA k)⟩
+    exact hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor
+      (blocksA k) (hTPA k) (hIrrA k)
+  · intro k
+    letI : NeZero (dimB k) := ⟨Nat.ne_of_gt (hDimB k)⟩
+    exact hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor
+      (blocksB k) (hTPB k) (hIrrB k)
 
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 

--- a/audits/2026-04-27_issue942_common_live.md
+++ b/audits/2026-04-27_issue942_common_live.md
@@ -1,0 +1,90 @@
+# Issue #942/#652 Wave 18 Slot A — per-block cyclic live data audit
+
+Date: 2026-04-27
+Branch/worktree: `wave18-A-942-common-live`
+
+## Checked Lean progress
+
+This branch advances the common-live-block predecessor without pretending that the
+common physical flattening is already formalized.
+
+1. `MPSTensor.HasPrimitiveIrreducibleCyclicSectors` in
+   `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean` packages the
+   one-block period-removal output: for a tensor `A`, there is a positive
+   period-removal length `m` such that `blockTensor A m` is represented by
+   unit-weight sector blocks which are trace-preserving, have primitive transfer
+   maps, are tensor-irreducible, and have positive bond dimensions.
+
+2. `MPSTensor.hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor`
+   repackages the existing checked cyclic-sector theorem
+   `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
+   through that predicate.
+
+3. `MPSTensor.tp_primitive_irreducible_extra_blocking` in
+   `TNLean/MPS/CanonicalForm/Assembly/PrimitiveBlocks.lean` records the separate
+   later-blocking step: if a sector block is already TP, primitive, and
+   tensor-irreducible, then any positive extra blocking length `k` preserves TP,
+   primitive transfer, and tensor irreducibility.  This is intentionally separate
+   from the period-removal length `m`.
+
+4. `MPSTensor.fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail`
+   in `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean` is the main
+   predecessor theorem.  From `SameMPV₂ A B`, it:
+   - applies the arbitrary-input zero-tail / TP-gauge reduction to both sides;
+   - keeps the irreducible TP live blocks, nonzero weights, positive dimensions,
+     and exact zero-tail MPV equations;
+   - proves the two live tensors agree at all positive lengths, with the exact
+     `N = 0` zero-tail bookkeeping identity retained; and
+   - proves every live block on both sides has primitive irreducible cyclic
+     sectors via the new predicate.
+
+Blueprint entries were added for the checked declarations in
+`blueprint/src/chapter/ch08_canonical.tex`:
+
+- `def:primitive_irreducible_cyclic_sectors`, source quote:
+  “some positive period-removal length $m$ represents $A^{[m]}$ as a unit-weight
+  block tensor whose sector blocks are trace-preserving, have primitive transfer
+  maps, are tensor-irreducible, and have positive bond dimensions.”
+- `thm:has_primitive_irreducible_cyclic_sectors_tp_irr`, source quote:
+  “Every trace-preserving irreducible tensor satisfies
+  Definition~\ref{def:primitive_irreducible_cyclic_sectors}.”
+- `thm:tp_primitive_irreducible_extra_blocking`, source quote:
+  “This $k$ is the subsequent common-refinement or injectivity length, distinct
+  from the period-removal length that produced the sector block.”
+- `thm:ft_after_blocking_per_block_cyclic_live_zero_tail`, source quote:
+  “The period-removal length for those sectors is kept separate from any later
+  common blocking or injectivity length.”
+
+## Paper-faithful route now represented
+
+The checked theorem follows the intended canonical-form sequence:
+
+1. invariant-subspace / zero-tail split;
+2. TP gauge on the irreducible live blocks;
+3. period removal by cyclic sectors for each live block; and only then
+4. a later finite blocking length for common refinement or injectivity, when such
+   a length is actually needed.
+
+In particular, it does not reuse the earlier `exists_tp_primitive_blockDecomp_after_blocking`
+output as if its blocked live blocks were automatically tensor-irreducible.  That
+would conflate the period-removal blocking with the live sector blocks: an
+irreducible periodic block can become reducible when blocked by its period, and
+its primitive irreducible pieces are the cyclic sectors.
+
+## Remaining blocker for the exact common-live theorem
+
+The exact #942 target still needs a dependent-index flattening theorem:
+starting from the per-live-block cyclic sector data, choose a common physical
+blocking level `p`, express each sector at that level by an additional positive
+blocking length `k`, transport through the nested-block physical-index equivalence
+between `blockPhysDim (blockPhysDim d m) k` and `blockPhysDim d (m * k)`, flatten
+`(live block, cyclic sector)` into one finite index family, and prove the exact
+MPV identity for `blockTensor A p` and `blockTensor B p`.
+
+That missing step is a real formal interface issue: it is about nested blocking
+associativity, physical-index transport, and dependent finite-index regrouping.
+It is not an overlap-span hypothesis and should not be hidden by assuming an
+already-common primitive-irreducible live family.  Once this flattening is
+available, the new extra-blocking lemma supplies the TP/primitive/irreducible
+transport for the later common-refinement or injectivity length without confusing
+that length with the period-removal period.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1423,6 +1423,35 @@ The following results separate the zero blocks from the
 	sector blocks.
 \end{proof}
 
+\begin{definition}[Primitive irreducible cyclic-sector package]%
+\label{def:primitive_irreducible_cyclic_sectors}
+	\lean{MPSTensor.HasPrimitiveIrreducibleCyclicSectors}
+	\leanok
+	\uses{def:blocked_tensor, def:tensor_from_blocks, def:same_mpv2}
+	A tensor has primitive irreducible cyclic sectors if some positive
+	period-removal length $m$ represents $A^{[m]}$ as a unit-weight block tensor
+	whose sector blocks are trace-preserving, have primitive transfer maps, are
+	tensor-irreducible, and have positive bond dimensions. This length $m$ is the
+	period-removal length, not the later finite blocking length used for common
+	refinement or injectivity.
+\end{definition}
+
+\begin{theorem}[Trace-preserving irreducible tensors have primitive irreducible cyclic sectors]%
+\label{thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
+	\lean{MPSTensor.hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor}
+	\leanok
+	\uses{def:primitive_irreducible_cyclic_sectors,
+		thm:cyclic_sector_decomp_irr_tp_prim_irr}
+	Every trace-preserving irreducible tensor satisfies
+	Definition~\ref{def:primitive_irreducible_cyclic_sectors}.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:cyclic_sector_decomp_irr_tp_prim_irr}
+	This is Theorem~\ref{thm:cyclic_sector_decomp_irr_tp_prim_irr}, repackaged as
+	the predicate of Definition~\ref{def:primitive_irreducible_cyclic_sectors}.
+\end{proof}
+
 \subsection{Sector irreducibility helpers}%
 \label{sec:sector_irreducibility_helpers}
 
@@ -2498,6 +2527,25 @@ The following results separate the zero blocks from the
 	the irreducibility criterion for the blocked tensor.
 \end{proof}
 
+\begin{theorem}[Extra blocking of primitive irreducible sector blocks]%
+\label{thm:tp_primitive_irreducible_extra_blocking}
+	\lean{MPSTensor.tp_primitive_irreducible_extra_blocking}
+	\leanok
+	\uses{def:blocked_tensor, thm:blocked_irreducible_tp_primitive}
+	If a sector block is already trace-preserving, has primitive transfer map, and
+	is tensor-irreducible, then every later positive blocking length $k$ preserves
+	all three properties. This $k$ is the subsequent common-refinement or
+	injectivity length, distinct from the period-removal length that produced the
+	sector block.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:blocked_irreducible_tp_primitive}
+	Trace preservation follows from blocking a trace-preserving tensor, primitivity
+	from taking a positive power of a primitive transfer map, and irreducibility
+	from Theorem~\ref{thm:blocked_irreducible_tp_primitive}.
+\end{proof}
+
 \begin{theorem}[Sorted TP-primitive irreducible data already forms a normal canonical form]%
 	\label{thm:ncf_sorted_tp_primitive_irred}
 	\lean{MPSTensor.isNormalCanonicalForm_of_tp_primitive_irr_sorted}
@@ -2641,6 +2689,31 @@ The following results separate the zero blocks from the
 	tensors and keep the zero-tail MPV equations returned by that theorem. The
 	property that the blocked tensors generate the same MPV family follows by
 	blocking the original equality.
+\end{proof}
+
+\begin{theorem}[Per-block cyclic live decomposition with zero-tail bookkeeping]%
+\label{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail}
+	\leanok
+	\uses{thm:tp_gauge_arbitrary, thm:live_block_zero_tail_bookkeeping,
+		def:primitive_irreducible_cyclic_sectors,
+		thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
+	If two tensors generate the same MPV family, then after the zero-tail split and
+	trace-preserving gauge each side has irreducible live blocks with nonzero
+	weights. The live block tensors agree at all positive system sizes, while the
+	length-zero case is recorded as the exact zero-tail bookkeeping identity.
+	Moreover each live block has primitive irreducible cyclic sectors. The
+	period-removal length for those sectors is kept separate from any later common
+	blocking or injectivity length.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:tp_gauge_arbitrary, thm:live_block_zero_tail_bookkeeping,
+		thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
+	Apply the arbitrary-input TP-gauge theorem separately to $A$ and $B$. The
+	zero-tail bookkeeping theorem compares the two resulting live tensors at
+	positive lengths and records the $N=0$ identity. Finally apply the cyclic-sector
+	package theorem to every trace-preserving irreducible live block.
 \end{proof}
 
 


### PR DESCRIPTION
## Summary

- Package the one-block cyclic period-removal output as `HasPrimitiveIrreducibleCyclicSectors`, with a helper deriving it from TP + tensor irreducibility.
- Add `tp_primitive_irreducible_extra_blocking`, keeping the later common-refinement/injectivity blocking length separate from the cyclic period-removal length.
- Prove `fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail`: from `SameMPV₂ A B`, obtain TP-gauged irreducible nonzero blocks on both sides, positive-length equality of the nonzero parts, exact `N = 0` zero-tail accounting, and per-nonzero-block primitive irreducible cyclic sectors.
- Document the exact remaining #942/#652 blocker: dependent-index flattening/nested-blocking associativity to put all per-block cyclic sectors at one common physical blocking level, plus downstream injectivity/span/zero-tail work.

## Paper-faithfulness note

This follows the canonical-form route the issue asks for: invariant-subspace / zero-tail split → TP gauge → period removal by cyclic sectors → only then a later finite blocking length for common refinement or injectivity. The new statements explicitly do **not** conflate the period-removal period `m` with the later Wielandt/injectivity length `k`.

## Validation

- `lake build --old TNLean.MPS.CanonicalForm.Assembly.PrimitiveBlocks TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` passed (only pre-existing long-line warnings at `CyclicSectorDecomposition.lean:683,913`).
- `lake build --old TNLean` passed with existing unrelated `sorry` warnings and the same pre-existing long-line warnings.
- `lake build --old TNLean.MPS.ParentHamiltonian.WrappingWindow TNLean.MPS.ParentHamiltonian.UniqueGroundState` passed to satisfy new main blueprint declarations from #959 (`UniqueGroundState` replays an existing unrelated `sorry` warning).
- Lean diagnostics: clean for `PrimitiveBlocks.lean` and `StructuralTheorem.lean`; `CyclicSectorDecomposition.lean` has only the two pre-existing long-line warnings.
- `cd blueprint && leanblueprint web` passed.
- `cd blueprint && leanblueprint checkdecls` passed.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passed.
- `git diff --check` passed.
- Added-line forbidden-token scan for `sorry|admit|axiom|native_decide|unsafe` passed.

Closes part of #942. Parent: #652, #877.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive Lean definitions/theorems and blueprint docs; risk is mainly proof/statement integration and downstream breakage from new interfaces.
> 
> **Overview**
> Introduces `HasPrimitiveIrreducibleCyclicSectors`, a predicate that packages one-block period removal into unit-weight sector blocks that are TP, primitive, tensor-irreducible, and positive-dimensional, plus a helper theorem deriving it from TP + irreducibility.
> 
> Adds `tp_primitive_irreducible_extra_blocking`, recording that *later* positive blocking preserves TP/primitivity/irreducibility once a block already has them (kept explicitly separate from the period-removal length).
> 
> Adds `fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail`, which from `SameMPV₂ A B` produces TP-gauged irreducible nonzero blocks on both sides, proves positive-length equality of the nonzero parts with explicit `N=0` zero-tail accounting, and attaches per-nonzero-block cyclic-sector packages. Blueprint and audit docs are updated to reference these new declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85c37df1532d10cce7745273d539bd0a99c3e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->