### PR TITLE
feat(MPS/MPDO): add pair trace separation criterion

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -319,6 +319,21 @@ theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords
   wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords μ A hCF
     (hasBlockSelectorWords_of_pairBlockSeparatingWords A hPair)
 
+/-- Canonical-form/BNT data plus a finite pair trace-separation criterion give
+full product-word span.
+
+This is the Route-B-facing formulation of the remaining finite-dimensional BNT
+step: once every ordered distinct pair has a common homogeneous trace-separating
+length, the duality lemma in `BiCFDerivation` produces pairwise separators, and
+the existing selector assembly gives product-word span. -/
+theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S) :
+    WordTupleSpanTop A (1 + (r - 1) * S) :=
+  wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords μ A hCF
+    (hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt A hSep)
+
 /-- Positive-length product-word span obtained from canonical-form/BNT data and
 pairwise block-separating word polynomials. -/
 theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords
@@ -333,6 +348,21 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingW
   refine ⟨1 + (r - 1) * S, Nat.add_pos_left Nat.zero_lt_one _, ?_⟩
   simpa [WordTupleSpanTop, wordTuple] using
     wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords μ A hCF hPair
+
+/-- Positive-length product-word span obtained from canonical-form/BNT data and
+the finite pair trace-separation criterion. -/
+theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  refine ⟨1 + (r - 1) * S, Nat.add_pos_left Nat.zero_lt_one _, ?_⟩
+  simpa [WordTupleSpanTop, wordTuple] using
+    wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hSep
 
 /-- Positive-length product-word span obtained from canonical-form/BNT data and
 finite block-selector words.

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -322,10 +322,10 @@ theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords
 /-- Canonical-form/BNT data plus a finite pair trace-separation criterion give
 full product-word span.
 
-This is the Route-B-facing formulation of the remaining finite-dimensional BNT
-step: once every ordered distinct pair has a common homogeneous trace-separating
-length, the duality lemma in `BiCFDerivation` produces pairwise separators, and
-the existing selector assembly gives product-word span. -/
+This is the form of the result used in Route B for the remaining finite-dimensional
+BNT step: once every ordered distinct pair has a common homogeneous trace-separating
+length, the pair trace-separation duality theorem produces pairwise separators,
+and the existing selector assembly gives product-word span. -/
 theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) {S : ℕ}

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.VerticalCF
 import TNLean.PiAlgebra.Construction
-import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 import Mathlib.LinearAlgebra.Prod
 

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.VerticalCF
 import TNLean.PiAlgebra.Construction
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.LinearAlgebra.Finsupp.LinearCombination
+import Mathlib.LinearAlgebra.Prod
 
 /-!
 # Finite-length sufficient conditions and obstructions for MPDO biCF
@@ -156,6 +158,181 @@ def HasPairBlockSeparatingWords
     (A : (k : Fin r) → MPSTensor d (dim k))
     (S : ℕ) : Prop :=
   ∀ k j : Fin r, j ≠ k → HasBlockSelectorOn A k S {j}
+
+/-- The simultaneous length-`S` word evaluation of two blocks. -/
+def pairWordTuple {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (S : ℕ) (w : Fin S → Fin d) :
+    Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ :=
+  (evalWord A (List.ofFn w), evalWord B (List.ofFn w))
+
+/-- Finite-length product-algebra span for a single ordered pair of blocks. -/
+def PairWordTupleSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) (S : ℕ) : Prop :=
+  Submodule.span ℂ (Set.range (pairWordTuple A B S)) = ⊤
+
+/-- Dual trace-separation criterion for a single ordered pair of blocks at a fixed
+length.
+
+This is the homogeneous finite-dimensional dual of pair product-span: no nonzero
+pair of trace test matrices may annihilate all simultaneous length-`S` word
+pairs.  The remaining BNT step is to prove such a finite `S` from block
+non-equivalence. -/
+def PairTraceSeparatingAt {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) (S : ℕ) : Prop :=
+  ∀ ΔA : Matrix (Fin D₁) (Fin D₁) ℂ,
+    ∀ ΔB : Matrix (Fin D₂) (Fin D₂) ℂ,
+      (∀ w : Fin S → Fin d,
+        Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+          Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) →
+      ΔA = 0 ∧ ΔB = 0
+
+private theorem exists_trace_repr {n : Type*} [Fintype n]
+    (f : Matrix n n ℂ →ₗ[ℂ] ℂ) :
+    ∃ Δ : Matrix n n ℂ, ∀ M : Matrix n n ℂ, f M = Matrix.trace (Δ * M) := by
+  classical
+  let Δ : Matrix n n ℂ := fun p q => f (Matrix.single q p (1 : ℂ))
+  refine ⟨Δ, ?_⟩
+  have hfg : f = (Matrix.traceLinearMap n ℂ ℂ).comp (LinearMap.mulLeft ℂ Δ) := by
+    apply Matrix.ext_linearMap ℂ
+    intro i j
+    apply LinearMap.ext
+    intro a
+    simp only [LinearMap.comp_apply, Matrix.singleLinearMap_apply,
+      Matrix.traceLinearMap_apply, LinearMap.mulLeft_apply]
+    have hsingle : Matrix.single i j a = a • Matrix.single i j (1 : ℂ) := by
+      ext p q
+      by_cases hp : p = i <;> by_cases hq : q = j <;> simp [Matrix.single, hp, hq]
+    calc
+      f (Matrix.single i j a) = a * f (Matrix.single i j (1 : ℂ)) := by
+        rw [hsingle, map_smul]
+        rfl
+      _ = Matrix.trace (Δ * Matrix.single i j a) := by
+        rw [Matrix.trace_mul_single]
+        simp [Δ, mul_comm]
+  intro M
+  simp [hfg]
+
+private theorem exists_pair_trace_repr {m n : Type*} [Fintype m] [Fintype n]
+    (f : (Matrix m m ℂ × Matrix n n ℂ) →ₗ[ℂ] ℂ) :
+    ∃ ΔA : Matrix m m ℂ, ∃ ΔB : Matrix n n ℂ,
+      ∀ M : Matrix m m ℂ × Matrix n n ℂ,
+        f M = Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) := by
+  classical
+  obtain ⟨ΔA, hA⟩ := exists_trace_repr
+    (f.comp (LinearMap.inl ℂ (Matrix m m ℂ) (Matrix n n ℂ)))
+  obtain ⟨ΔB, hB⟩ := exists_trace_repr
+    (f.comp (LinearMap.inr ℂ (Matrix m m ℂ) (Matrix n n ℂ)))
+  refine ⟨ΔA, ΔB, ?_⟩
+  intro M
+  calc
+    f M = ((f.comp (LinearMap.inl ℂ (Matrix m m ℂ) (Matrix n n ℂ))).coprod
+        (f.comp (LinearMap.inr ℂ (Matrix m m ℂ) (Matrix n n ℂ)))) M := by
+      exact (congrArg
+        (fun g : (Matrix m m ℂ × Matrix n n ℂ) →ₗ[ℂ] ℂ => g M)
+        (LinearMap.coprod_comp_inl_inr f)).symm
+    _ = Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) := by
+      rw [LinearMap.coprod_apply]
+      change (f.comp (LinearMap.inl ℂ (Matrix m m ℂ) (Matrix n n ℂ))) M.1 +
+          (f.comp (LinearMap.inr ℂ (Matrix m m ℂ) (Matrix n n ℂ))) M.2 = _
+      rw [hA M.1, hB M.2]
+
+/-- The pair trace-separation criterion is the dual form of pair product-span. -/
+theorem pairWordTupleSpanTop_of_pairTraceSeparatingAt {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hSep : PairTraceSeparatingAt A B S) :
+    PairWordTupleSpanTop A B S := by
+  classical
+  unfold PairWordTupleSpanTop
+  by_contra hnot
+  let W : Submodule ℂ
+      (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ) :=
+    Submodule.span ℂ (Set.range (pairWordTuple A B S))
+  have hlt : W < ⊤ := lt_of_le_of_ne le_top (by simpa [W] using hnot)
+  obtain ⟨f, hfne, hfker⟩ := Submodule.exists_le_ker_of_lt_top W hlt
+  obtain ⟨ΔA, ΔB, hf_repr⟩ := exists_pair_trace_repr f
+  have hΔ : ΔA = 0 ∧ ΔB = 0 := by
+    refine hSep ΔA ΔB ?_
+    intro w
+    have hwmem : pairWordTuple A B S w ∈ W :=
+      Submodule.subset_span ⟨w, rfl⟩
+    have hf0 : f (pairWordTuple A B S w) = 0 := hfker hwmem
+    simpa [pairWordTuple, hf_repr] using hf0
+  have hfzero : f = 0 := by
+    apply LinearMap.ext
+    intro M
+    have hM := hf_repr M
+    rw [hΔ.1, hΔ.2] at hM
+    simpa using hM
+  exact hfne hfzero
+
+/-- Pair product-span at length `S` gives a length-`S` selector for the first
+block of the pair. -/
+theorem hasBlockSelectorOn_of_pairWordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    {k j : Fin r} (hSpan : PairWordTupleSpanTop (A k) (A j) S) :
+    HasBlockSelectorOn A k S {j} := by
+  classical
+  have htarget : ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+      (0 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+      Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) S)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  rcases (Submodule.mem_span_range_iff_exists_fun ℂ).mp htarget with ⟨c, hc⟩
+  let M : (l : Fin r) → Matrix (Fin (dim l)) (Fin (dim l)) ℂ :=
+    fun l => ∑ w : Fin S → Fin d, c w • evalWord (A l) (List.ofFn w)
+  refine ⟨M, ?_, ?_, ?_⟩
+  · refine (Submodule.mem_span_range_iff_exists_fun ℂ).mpr ⟨c, ?_⟩
+    ext l
+    simp [M, wordTuple]
+  · have hk := congrArg
+      (LinearMap.fst ℂ (Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+        (Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) hc
+    simpa [M, pairWordTuple, Fintype.linearCombination_apply] using hk
+  · intro l hl
+    have hlj : l = j := by simpa using hl
+    subst l
+    have hj := congrArg
+      (LinearMap.snd ℂ (Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+        (Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) hc
+    simpa [M, pairWordTuple, Fintype.linearCombination_apply] using hj
+
+/-- Pair trace-separation at length `S` gives a length-`S` selector for the
+first block of the pair. -/
+theorem hasBlockSelectorOn_of_pairTraceSeparatingAt
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    {k j : Fin r} (hSep : PairTraceSeparatingAt (A k) (A j) S) :
+    HasBlockSelectorOn A k S {j} :=
+  hasBlockSelectorOn_of_pairWordTupleSpanTop A
+    (pairWordTupleSpanTop_of_pairTraceSeparatingAt (A k) (A j) hSep)
+
+/-- A common pair product-span length for all ordered distinct pairs gives
+pairwise block separators. -/
+theorem hasPairBlockSeparatingWords_of_forall_pairWordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    (hSpan : ∀ k j : Fin r, j ≠ k → PairWordTupleSpanTop (A k) (A j) S) :
+    HasPairBlockSeparatingWords A S := by
+  intro k j hjk
+  exact hasBlockSelectorOn_of_pairWordTupleSpanTop A (hSpan k j hjk)
+
+/-- A common pair trace-separation length for all ordered distinct pairs gives
+pairwise block separators. -/
+theorem hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S) :
+    HasPairBlockSeparatingWords A S := by
+  intro k j hjk
+  exact hasBlockSelectorOn_of_pairTraceSeparatingAt A (hSep k j hjk)
+
+/-- Existential form of the pair trace-separation criterion for pairwise block
+separators. -/
+theorem exists_hasPairBlockSeparatingWords_of_exists_forall_pairTraceSeparatingAt
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hSep : ∃ S : ℕ,
+      ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S) :
+    ∃ S : ℕ, HasPairBlockSeparatingWords A S := by
+  rcases hSep with ⟨S, hS⟩
+  exact ⟨S, hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt A hS⟩
 
 /-- The tuple-valued span of word evaluations is closed under pointwise matrix
 multiplication, at the cost of adding word lengths. -/

--- a/audits/2026-04-27_issue934_pair_trace_separation.md
+++ b/audits/2026-04-27_issue934_pair_trace_separation.md
@@ -1,0 +1,130 @@
+# Issue #934 — pair trace-separation predecessor (2026-04-27)
+
+## Scope
+
+Wave 18 Slot C targeted the remaining Route B parent-Hamiltonian step
+
+```lean
+IsCanonicalFormBNT μ A → ∃ S, HasPairBlockSeparatingWords A S
+```
+
+or equivalently a direct construction of finite block-selector words from separated
+CF/BNT data.  The full implication from `blocks_not_equiv` is still not proved in
+this pass.  What is now checked is the finite-dimensional **dual trace criterion**
+immediately preceding the pairwise selector theorem.
+
+## Checked Lean progress
+
+File: `TNLean/MPS/MPDO/BiCFDerivation.lean`
+
+New public declarations:
+
+- `MPSTensor.pairWordTuple`
+  - The two-block homogeneous word tuple `w ↦ (evalWord A w, evalWord B w)` at a fixed length.
+
+- `MPSTensor.PairWordTupleSpanTop`
+  - Pair-level product-algebra span: the length-`S` pair word tuples span
+    `M_{D₁}(ℂ) × M_{D₂}(ℂ)`.
+
+- `MPSTensor.PairTraceSeparatingAt`
+  - The dual trace-separation criterion: the only pair of matrices `(ΔA, ΔB)` whose trace pairing
+    with every length-`S` pair tuple vanishes is `(0,0)`.
+
+- `MPSTensor.pairWordTupleSpanTop_of_pairTraceSeparatingAt`
+  - Proves the trace criterion is strong enough to give pair product-span.  The proof uses
+    `Submodule.exists_le_ker_of_lt_top` and represents a nonzero annihilating functional by the
+    matrix trace pairing.
+
+- `MPSTensor.hasBlockSelectorOn_of_pairWordTupleSpanTop`
+  - Extracts the tuple `(I,0)` from pair product-span and reuses its coefficients on the ambient
+    block family to get `HasBlockSelectorOn A k S {j}`.
+
+- `MPSTensor.hasBlockSelectorOn_of_pairTraceSeparatingAt`
+  - Combines the two previous facts.
+
+- `MPSTensor.hasPairBlockSeparatingWords_of_forall_pairWordTupleSpanTop`
+- `MPSTensor.hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt`
+- `MPSTensor.exists_hasPairBlockSeparatingWords_of_exists_forall_pairTraceSeparatingAt`
+  - Common-length pair criteria for all ordered distinct pairs imply `HasPairBlockSeparatingWords`.
+
+File: `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
+
+New Route-B-facing compositions:
+
+- `MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt`
+- `MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt`
+
+These say that once the pair trace-separation criterion is proved at a common finite length under
+CF/BNT hypotheses, the already-merged pairwise selector assembly gives the issue-#934 product-word
+span needed by Route B.
+
+Blueprint Chapter 14 now records:
+
+- `def:pair_trace_separation_words`
+- `lem:pair_trace_separation_to_pairwise_selectors`
+
+and adds the trace-separation route to `lem:product_word_span_from_bnt_selectors`.
+
+## Remaining mathematical blocker
+
+The real paper step is now isolated as the homogeneous finite-dimensional
+Burnside/Jacobson-density statement:
+
+```lean
+IsCanonicalFormBNT μ A →
+  ∃ S, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S
+```
+
+A pairwise version under split hypotheses would be:
+
+```lean
+IsInjective A → IsInjective B →
+left-canonical A → left-canonical B →
+¬ GaugePhaseEquiv A B →
+∃ S, PairTraceSeparatingAt A B S
+```
+
+with casts/equal-dimension bookkeeping, plus the dimension-mismatch branch.  This is not a
+convenience assumption: it is exactly the assertion that no nonzero trace functional survives on all
+homogeneous pair words.  In algebraic terms, the simultaneous homogeneous word representation of two
+non-gauge-equivalent simple matrix blocks must contain enough words of one common length to separate
+`(I,0)`.
+
+The expected proof route is:
+
+1. Use BNT separation (`blocks_not_equiv`) and the existing mixed-transfer/spectral-gap
+   infrastructure to rule out a nonzero asymptotically nondecaying mixed trace functional.
+2. Convert the absence of such functionals into a finite length `S`; finite-dimensionality should
+   turn the infinite homogeneous annihilator intersection into a finite cutoff.
+3. Apply `pairWordTupleSpanTop_of_pairTraceSeparatingAt` and
+   `hasBlockSelectorOn_of_pairTraceSeparatingAt`.
+4. Use the already-checked pairwise selector assembly from PR #950.
+
+## Source anchors
+
+- `Papers/2011.12127/TN-Review-main.tex` lines 2115--2116 define block-injective canonical form
+  by access to every element of the direct-sum block algebra:
+
+  > `A tensor A is in block injective canonical form ... for each element X\in \bigoplus_{j=1}^g ...`
+
+- `Papers/2011.12127/TN-Review-main.tex` lines 2123--2128 state the parent-Hamiltonian BNT
+  ground-space result and the strengthened `N ≥ L_0+1` version after restricting to block-diagonal
+  boundary conditions.
+
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 320--326 give the MPDO/biCF analogue, including
+  the inverse tensor identity with the extra `δ_{j,j'}` block selector factor.  Lines 340--344 cite
+  the finite blocking theorem producing biCF.
+
+## Validation
+
+Checks run on branch `wave18-C-934-bnt-separators`:
+
+- `lake exe cache get`
+- `lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
+- `lake build TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
+  - The first two build attempts reached the command timeout after building dependencies; the
+    immediate continuation completed successfully.
+- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean && lake env lean \
+  TNLean/MPS/MPDO/BiCFDerivation.lean`
+
+Further blueprint and repository hygiene checks are recorded in the PR validation summary.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2804,6 +2804,46 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     $T=\{j\}$.
 \end{definition}
 
+\begin{definition}[Pair trace-separation criterion]
+    \label{def:pair_trace_separation_words}
+    \lean{MPSTensor.pairWordTuple}
+    \lean{MPSTensor.PairWordTupleSpanTop}
+    \lean{MPSTensor.PairTraceSeparatingAt}
+    \leanok
+    For two blocks $A$ and $B$, the length-$S$ pair word tuple is
+    $w \mapsto (A^w,B^w)$.  The pair product-span condition says that these
+    tuples span $\MN{D_A}\times\MN{D_B}$.  Equivalently, in the trace-dual
+    formulation, the only pair of test matrices $(\Delta_A,\Delta_B)$ whose
+    trace pairing with every length-$S$ tuple vanishes is $(0,0)$.
+\end{definition}
+
+\begin{lemma}[Pair trace separation gives pairwise selectors]
+    \label{lem:pair_trace_separation_to_pairwise_selectors}
+    \lean{MPSTensor.pairWordTupleSpanTop_of_pairTraceSeparatingAt}
+    \lean{MPSTensor.hasBlockSelectorOn_of_pairWordTupleSpanTop}
+    \lean{MPSTensor.hasBlockSelectorOn_of_pairTraceSeparatingAt}
+    \lean{MPSTensor.hasPairBlockSeparatingWords_of_forall_pairWordTupleSpanTop}
+    \lean{MPSTensor.hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt}
+    \lean{MPSTensor.exists_hasPairBlockSeparatingWords_of_exists_forall_pairTraceSeparatingAt}
+    \leanok
+    \uses{def:pairwise_block_separating_words, def:pair_trace_separation_words}
+    At a fixed length $S$, the pair trace-separation criterion is dual to full
+    pair product-span.  Therefore a pair trace-separation witness supplies a
+    word polynomial that is identity on the first block and zero on the second.
+    A common witness for all ordered distinct pairs gives pairwise
+    block-separating words at the same length.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    If the pair span were proper, a nonzero linear functional would vanish on
+    it.  Nondegeneracy of the matrix trace pairing represents that functional
+    as $(\Delta_A,\Delta_B)$, contradicting pair trace separation.  Once the
+    pair span is the whole product algebra, the tuple $(I,0)$ is in the span;
+    using the same coefficients on the ambient block family gives the required
+    partial selector.
+\end{proof}
+
 \begin{lemma}[Block selectors from pairwise block separation]
     \label{lem:block_selectors_from_pairwise_separators}
     \lean{MPSTensor.pointwise_mul_mem_span_wordTuple_add}
@@ -2841,12 +2881,15 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \label{lem:product_word_span_from_bnt_selectors}
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords}
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}
     \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords}
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords}
     \leanok
-    \uses{def:cf_bnt, lem:block_selectors_from_pairwise_separators,
+    \uses{def:cf_bnt, lem:pair_trace_separation_to_pairwise_selectors,
+        lem:block_selectors_from_pairwise_separators,
         lem:block_projection_span_from_product_word_span}
     Let $((\mu_j),(A_j))$ be in canonical form with BNT separation.  Suppose there are
     length-$S$ block-selector words: for each sector $k$, a linear combination of
@@ -2854,8 +2897,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     Then the simultaneous length-$(1+S)$ block-word evaluations span
     $\prod_j \MN{D_j}$, with positive length.  It is enough, by
     Lemma~\ref{lem:block_selectors_from_pairwise_separators}, to construct
-    pairwise separators for every ordered pair of distinct blocks.  Consequently,
-    the pulled-back words at the resulting length for
+    pairwise separators for every ordered pair of distinct blocks; by
+    Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}, a common
+    pair trace-separation length is one sufficient finite-dimensional witness.
+    Consequently, the pulled-back words at the resulting length for
     $\operatorname{Assemble}(\mu,A)$ span every virtual sector projection, and the
     corresponding commutant reduction is available.
 \end{lemma}
@@ -2863,6 +2908,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \leanok
     \uses{lem:one_block_injective_of_injective,
+        lem:pair_trace_separation_to_pairwise_selectors,
         lem:block_selectors_from_pairwise_separators,
         lem:block_projection_span_from_product_word_span}
     Definition~\ref{def:cf_bnt} gives one-site injectivity of each block, hence
@@ -2873,7 +2919,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     identity on block $k$, so the length-$(1+S)$ word tuples span the full
     product algebra.  If one starts with pairwise separators instead, first use
     Lemma~\ref{lem:block_selectors_from_pairwise_separators} to multiply them into
-    full selectors.  The projection-span and commutant consequences then follow
+    full selectors; if one starts from the pair trace-separation criterion, first
+    use Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}.  The
+    projection-span and commutant consequences then follow
     from Lemma~\ref{lem:block_projection_span_from_product_word_span}.
 \end{proof}
 


### PR DESCRIPTION
## Summary

- Adds the pair-level homogeneous word tuple, pair product-span, and dual `PairTraceSeparatingAt` criterion.
- Proves the finite-dimensional duality step: pair trace separation gives pair product-span, hence pairwise block selectors at the same length.
- Composes the new criterion with the existing pairwise selector assembly to get Route-B-facing product-word span from `IsCanonicalFormBNT μ A` plus a common pair trace-separation witness.
- Documents the remaining paper step: derive the common finite `PairTraceSeparatingAt` length from BNT non-equivalence / Burnside-Jacobson density rather than assuming selectors or product-word span.

This advances #934 / #905 / #190 but does not close #934. The remaining theorem is now isolated as

```lean
IsCanonicalFormBNT μ A →
  ∃ S, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S
```

or the corresponding split pair theorem from injective normalized non-gauge-equivalent blocks.

## Validation

- `lake exe cache get`
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
- `lake build TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean && lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
- `lake build TNLean` (after rebasing onto current `origin/main`; only pre-existing warnings in unrelated modules)
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lean diagnostics clean for `TNLean/MPS/MPDO/BiCFDerivation.lean` and `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
- `git diff --check origin/main...HEAD`
- Added-line forbidden proof-integrity token scan clean for `origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new core predicates (`PairTraceSeparatingAt`) and several bridging theorems that will be reused in later Route B proofs; while purely formal, proof-level changes can have broad downstream impact on compilation and lemma selection.
> 
> **Overview**
> Adds a new *pair-level* separation framework in `BiCFDerivation.lean`: `pairWordTuple`, the pair product-span predicate `PairWordTupleSpanTop`, and the dual trace criterion `PairTraceSeparatingAt`, plus proofs that trace-separation implies pair span and yields pairwise block selectors (and lifts to common-length hypotheses over all ordered block pairs).
> 
> Extends `BlockDiagonalCommutant.lean` with Route-B-facing compositions showing that `IsCanonicalFormBNT` + a common finite `PairTraceSeparatingAt` witness implies full product-word span (and the corresponding `∃ m > 0` span statement).
> 
> Updates documentation/blueprint by adding an audit note for issue #934 progress and recording the new definition/lemma chain in Chapter 14.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8971705a53c559819b484216ecffdead35f0d170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->