### PR TITLE
doc(blueprint): clarify canonical-form remaining inputs

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2753,7 +2753,7 @@ The following results separate the zero blocks from the
 	irreducible live blocks, and then removes the periodic peripheral spectrum by
 	blocking. In the informal MPS literature, this second phrase often includes two
 	operations at once: block by a period and then restrict to the cyclic sectors
-	of the blocked tensor. Lean keeps these operations separate.
+	of the blocked tensor. Here we treat these operations as separate steps.
 
 	The arbitrary-input reduction of Theorem~\ref{thm:tp_gauge_arbitrary} gives the
 	zero-tail block and trace-preserving irreducible live blocks. The coarse

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1423,7 +1423,7 @@ The following results separate the zero blocks from the
 	sector blocks.
 \end{proof}
 
-\begin{definition}[Primitive irreducible cyclic-sector package]%
+\begin{definition}[Primitive irreducible cyclic-sector data]%
 \label{def:primitive_irreducible_cyclic_sectors}
 	\lean{MPSTensor.HasPrimitiveIrreducibleCyclicSectors}
 	\leanok
@@ -1448,7 +1448,7 @@ The following results separate the zero blocks from the
 
 \begin{proof}\leanok
 	\uses{thm:cyclic_sector_decomp_irr_tp_prim_irr}
-	This is Theorem~\ref{thm:cyclic_sector_decomp_irr_tp_prim_irr}, repackaged as
+	This is Theorem~\ref{thm:cyclic_sector_decomp_irr_tp_prim_irr}, restated as
 	the predicate of Definition~\ref{def:primitive_irreducible_cyclic_sectors}.
 \end{proof}
 
@@ -2738,8 +2738,9 @@ The following results separate the zero blocks from the
 		thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
 	Apply the arbitrary-input TP-gauge theorem separately to $A$ and $B$. The
 	zero-tail bookkeeping theorem compares the two resulting live tensors at
-	positive lengths and records the $N=0$ identity. Finally apply the cyclic-sector
-	package theorem to every trace-preserving irreducible live block.
+	positive lengths and records the $N=0$ identity. Finally apply
+	Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr} to every
+	trace-preserving irreducible live block.
 \end{proof}
 
 
@@ -2748,31 +2749,32 @@ The following results separate the zero blocks from the
 \begin{remark}[Remaining steps toward normal canonical form]%
 	\label{rem:canonical_pipeline_gaps}
 	\leanok
-	The arbitrary-input reduction
-	(Theorem~\ref{thm:tp_gauge_arbitrary}) produces a trivial block together
-	with left-canonical nontrivial blocks. After a common blocking step
-	(Theorem~\ref{thm:tp_primitive_blockdecomp}), the blocked blocks
-	have primitive transfer maps.
+	The paper proof first removes the upper-triangular redundancy by passing to
+	irreducible live blocks, and then removes the periodic peripheral spectrum by
+	blocking. In the informal MPS literature, this second phrase often includes two
+	operations at once: block by a period and then restrict to the cyclic sectors
+	of the blocked tensor. Lean keeps these operations separate.
 
-	To conclude the blocking-based normal-canonical-form reduction of this
-	chapter, two further inputs are still needed.
-	First, one must isolate irreducible TP-primitive sectors inside each
-	blocked block, because blocking does not in general preserve tensor
-	irreducibility. Theorems~\ref{thm:blockdecomp_commuting_projs}
-	and~\ref{thm:blockdecomp_adjoint_fixed} supply the relevant
-	sector-decomposition mechanism: commuting or adjoint-fixed projections
-	produce a direct-sum decomposition of the blocked tensor. What remains
-	is to show that the sectors arising in the canonical-form reduction are
-	themselves irreducible, so that the primitive-sector normality results
-	apply to them.
+	The arbitrary-input reduction of Theorem~\ref{thm:tp_gauge_arbitrary} gives the
+	zero-tail block and trace-preserving irreducible live blocks. The coarse
+	blocking theorem, Theorem~\ref{thm:tp_primitive_blockdecomp}, records a
+	blocked live-block form with primitive transfer maps, but it is not by itself
+	the final normal canonical form in the sense of the paper: after blocking, one
+	still has to identify the cyclic-sector summands that carry the normal blocks.
+	This sector step is now available one block at a time in
+	Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr}, which gives
+	trace-preserving primitive tensor-irreducible sectors for each
+	trace-preserving irreducible live block.
 
-	Second, one must control the weights attached to those sectors. In
-	particular, the present reduction does not yet produce the pairwise
-	distinct nonzero weight norms needed before the normal canonical form
-	after sorting of Theorem~\ref{thm:bnt_sorted_ncf} can be applied.
+	Thus the remaining reduction task in this chapter is not to prove irreducibility
+	of those cyclic sectors from scratch. It is to assemble all per-block cyclic
+	sector decompositions at one common physical blocking length, transport the
+	original block weights to the resulting sectors, and thread the existing
+	zero-tail bookkeeping through that common-length statement.
 
-	The periodic irreducible-form approach, which studies periodic blocks
-	directly rather than removing periodicity by blocking, belongs to
-	Chapter~\ref{ch:periodic_ft_apps}; it is not part of the reduction in
-	this chapter except as a forward reference.
+	The sorted normal-canonical-form theorem,
+	Theorem~\ref{thm:bnt_sorted_ncf}, assumes pairwise distinct nonzero weight
+	norms. This is a useful special form after sorting. Equal-norm families require
+	the basis-of-normal-tensors and multiplicity comparison developed later, rather
+	than an artificial separation of equal weight norms.
 \end{remark}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -977,7 +977,7 @@ single weighted block.
 	the same multiset equality.
 \end{proof}
 
-\begin{remark}[Remaining step in the unconditional equal-case theorem]\notready
+\begin{remark}[Remaining inputs for the unconditional equal-case theorem]\notready
 	This chapter provides three complementary equal-case results:
 	\begin{enumerate}
 		\item Theorem~\ref{thm:ft_equal_explicit}: the explicit-coefficient
@@ -994,22 +994,30 @@ single weighted block.
 	\end{enumerate}
 	What is still missing for the unconditional equal-case theorem
 	(Theorem~\ref{thm:ft_equal}, \cite[Corollary~IV.5]{Cirac2021Matrix}) is
-	not the one-sided construction of a basis of normal tensors: for
-	trace-preserving primitive irreducible blocks with positive bond dimensions
-	and nonzero weights, representatives of the MPV phase-equivalence classes are
-	constructed in Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}.
-	When the original blocks are also injective, the same construction exposes
-	positive dimension, injectivity, normalization, and asymptotic overlap
-	orthogonality in
-	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}.
-	The remaining paper-level inputs are to obtain, from the arbitrary
-	after-blocking reduction, exact live primitive irreducible block families at a
-	common blocking length, to settle the length-zero bookkeeping for discarded
-	zero blocks, and to prove equality of the finite-length MPV spans for the two
-	independently chosen bases of normal tensors.  Once those inputs are supplied,
+	now quite specific. The one-sided basis-of-normal-tensors construction is not
+	the obstruction: for trace-preserving primitive irreducible blocks with
+	positive bond dimensions and nonzero weights, representatives of the MPV
+	phase-equivalence classes are constructed in
+	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}. When the original
+	blocks are also injective, the same construction exposes positive dimension,
+	injectivity, normalization, and asymptotic overlap orthogonality in
+	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}. The
+	chosen representatives also preserve the finite-length MPV spans of the
+	original live blocks by
+	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data_span},
+	and Theorem~\ref{thm:bnt_sector_decomp_pair_overlap_span_of_block_span}
+	transports equality of the live-block spans to the overlap-span hypotheses for
+	the two chosen bases.
+
+	Thus the remaining paper-level inputs are upstream of the sector comparison:
+	starting from arbitrary equal MPVs, produce exact live primitive irreducible
+	block families for both tensors at one common physical blocking length,
+	transport the weights and the already-isolated zero-tail bookkeeping to that
+	common-length statement, and prove equality of the finite-length MPV spans of
+	those live block families. Once those inputs are supplied,
 	Theorems~\ref{thm:sector_basis_matching_from_overlap_ortho_span}
 	and~\ref{thm:route_b_hetero_sector_matching} recover the basis permutation,
-	multiplicities, and sector-weight multisets.  The final global gauge matrix of
+	multiplicities, and sector-weight multisets. The final global gauge matrix of
 	Corollary~IV.5 is then obtained by the same phase-absorption and blockwise
 	composition argument already formalized in the strict single-weight setting.
 \end{remark}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1010,11 +1010,11 @@ single weighted block.
 	the two chosen bases.
 
 	Thus the remaining paper-level inputs are upstream of the sector comparison:
-	starting from arbitrary equal MPVs, produce exact live primitive irreducible
-	block families for both tensors at one common physical blocking length,
-	transport the weights and the already-isolated zero-tail bookkeeping to that
-	common-length statement, and prove equality of the finite-length MPV spans of
-	those live block families. Once those inputs are supplied,
+	one must, starting from arbitrary equal MPVs, produce exact live primitive
+	irreducible block families for both tensors at one common physical blocking
+	length, transport the weights and the already-isolated zero-tail bookkeeping
+	to that common-length statement, and prove equality of the finite-length MPV
+	spans of those live block families. Once those inputs are supplied,
 	Theorems~\ref{thm:sector_basis_matching_from_overlap_ortho_span}
 	and~\ref{thm:route_b_hetero_sector_matching} recover the basis permutation,
 	multiplicities, and sector-weight multisets. The final global gauge matrix of


### PR DESCRIPTION
## Summary
- rewrite the Chapter 8 normal-canonical-form gap remark in standard MPS language: block by period plus cyclic-sector restriction are separate formal steps
- update the Chapter 11 equal-case gap remark after the recent BNT span-transport work (#960)
- remove stale/banned 'package'/'repackaged' wording in nearby Chapter 8 prose

## Paper references checked
-  lines 1774--1836
-  lines 187--250

## Validation
- 
- plasTeX version 3.1
- after building TNLean oleans: 
- Scanning Lean source tree …
- ✖ [0/0] Running job computation
error: time expired (error code: 60, operation timed out)
Some required targets logged failures:
- job computation completed successfully during validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits that rephrase and reorganize existing arguments; low risk aside from potential confusion if references/wording are inconsistent.
> 
> **Overview**
> Clarifies the canonical-form “remaining steps” narrative in Chapter 8 by explicitly separating *period blocking* from the subsequent *cyclic-sector restriction*, and by reframing the remaining work as assembling per-block sector decompositions at a common blocking length while threading weights and zero-tail accounting.
> 
> Updates nearby Chapter 8 prose to remove “package/repackaged” wording (e.g., renaming the cyclic-sector definition heading to “data” and tightening theorem/proof phrasing), and revises the Chapter 11 equal-case gap remark to reflect recent span-transport results, narrowing the stated missing inputs to the upstream task of producing common-length live primitive irreducible block families and proving their span equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc74b773b5e534dca30f510f6e03ff2d559044b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->