### PR TITLE
fix(blueprint): install TikZ SVG render dependencies

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -16,10 +16,18 @@ runs:
         use-mathlib-cache: true
         build: false
 
-    - name: Install graphviz headers (needed by pygraphviz)
+    - name: Install blueprint system dependencies
       if: inputs.install-blueprint == 'true'
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y graphviz libgraphviz-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          dvisvgm \
+          graphviz \
+          libgraphviz-dev \
+          texlive-fonts-recommended \
+          texlive-latex-extra \
+          texlive-pictures
 
     - name: Set up Python for blueprint tooling
       if: inputs.install-blueprint == 'true'

--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Also install graphviz and leanblueprint (for blueprint workflows)'
     required: false
     default: 'false'
+  use-github-cache:
+    description: 'Enable lean-action GitHub caching for the .lake directory'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -14,6 +18,7 @@ runs:
       uses: leanprover/lean-action@v1
       with:
         use-mathlib-cache: true
+        use-github-cache: ${{ inputs.use-github-cache }}
         build: false
 
     - name: Install blueprint system dependencies

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -39,7 +39,15 @@ jobs:
           python-version: '3.12'
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y graphviz libgraphviz-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            dvisvgm \
+            graphviz \
+            libgraphviz-dev \
+            texlive-fonts-recommended \
+            texlive-latex-extra \
+            texlive-pictures
 
       - name: Install leanblueprint
         run: pip install leanblueprint -r .github/requirements/blueprint-python.txt
@@ -59,6 +67,10 @@ jobs:
           fi
           if grep -q "WARNING: File not found:" /tmp/blueprint-output.txt; then
             echo "::error::Blueprint has missing files (see WARNING lines above)"
+            exit 1
+          fi
+          if grep -R "TikZ SVG unavailable" blueprint/web --include='*.html'; then
+            echo "::error::Blueprint contains unrendered TikZ SVG placeholders"
             exit 1
           fi
 

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -60,8 +60,13 @@ jobs:
 
       - name: Build blueprint
         run: |
-          set -o pipefail
+          set +o pipefail
           leanblueprint web 2>&1 | tee /tmp/blueprint-output.txt
+          cmd_status=${PIPESTATUS[0]}
+          set -o pipefail
+          if [ "$cmd_status" -ne 0 ]; then
+            exit "$cmd_status"
+          fi
           if grep -q "^ERROR:" /tmp/blueprint-output.txt; then
             echo "::warning::Blueprint has unresolved labels (see ERROR lines above)"
           fi

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -60,19 +60,23 @@ jobs:
 
       - name: Build blueprint
         run: |
+          set -o pipefail
+          tmp_output_file="$(mktemp)"
+
           set +o pipefail
-          leanblueprint web 2>&1 | tee /tmp/blueprint-output.txt
+          leanblueprint web 2>&1 | tee "$tmp_output_file"
           cmd_status=${PIPESTATUS[0]}
           set -o pipefail
-          if [ "$cmd_status" -ne 0 ]; then
-            exit "$cmd_status"
-          fi
-          if grep -q "^ERROR:" /tmp/blueprint-output.txt; then
+
+          if grep -q "^ERROR:" "$tmp_output_file"; then
             echo "::warning::Blueprint has unresolved labels (see ERROR lines above)"
           fi
-          if grep -q "WARNING: File not found:" /tmp/blueprint-output.txt; then
+          if grep -q "WARNING: File not found:" "$tmp_output_file"; then
             echo "::error::Blueprint has missing files (see WARNING lines above)"
             exit 1
+          fi
+          if [ "$cmd_status" -ne 0 ]; then
+            exit "$cmd_status"
           fi
           if grep -R "TikZ SVG unavailable" blueprint/web --include='*.html'; then
             echo "::error::Blueprint contains unrendered TikZ SVG placeholders"

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -77,16 +77,20 @@ jobs:
         working-directory: blueprint
         run: |
           leanblueprint pdf
+          set -o pipefail
+          tmp_output_file="$(mktemp)"
+
           set +o pipefail
-          leanblueprint web 2>&1 | tee /tmp/blueprint-output.txt
+          leanblueprint web 2>&1 | tee "$tmp_output_file"
           cmd_status=${PIPESTATUS[0]}
           set -o pipefail
-          if [ "$cmd_status" -ne 0 ]; then
-            exit "$cmd_status"
-          fi
-          if grep -q "^ERROR:" /tmp/blueprint-output.txt; then
+
+          if grep -q "^ERROR:" "$tmp_output_file"; then
             echo "::error::Blueprint has unresolved labels (see ERROR lines above)"
             exit 1
+          fi
+          if [ "$cmd_status" -ne 0 ]; then
+            exit "$cmd_status"
           fi
           if grep -R "TikZ SVG unavailable" web --include='*.html'; then
             echo "::error::Blueprint contains unrendered TikZ SVG placeholders"

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -52,7 +52,17 @@ jobs:
           python-version: '3.12'
 
       - name: Install TeX and graphviz
-        run: sudo apt-get update && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended texlive-science latexmk graphviz libgraphviz-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            dvisvgm \
+            graphviz \
+            latexmk \
+            libgraphviz-dev \
+            texlive-fonts-recommended \
+            texlive-latex-extra \
+            texlive-pictures \
+            texlive-science
 
       - name: Install leanblueprint
         run: |
@@ -71,6 +81,10 @@ jobs:
           leanblueprint web 2>&1 | tee /tmp/blueprint-output.txt
           if grep -q "^ERROR:" /tmp/blueprint-output.txt; then
             echo "::error::Blueprint has unresolved labels (see ERROR lines above)"
+            exit 1
+          fi
+          if grep -R "TikZ SVG unavailable" web --include='*.html'; then
+            echo "::error::Blueprint contains unrendered TikZ SVG placeholders"
             exit 1
           fi
 

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -77,8 +77,13 @@ jobs:
         working-directory: blueprint
         run: |
           leanblueprint pdf
-          set -o pipefail
+          set +o pipefail
           leanblueprint web 2>&1 | tee /tmp/blueprint-output.txt
+          cmd_status=${PIPESTATUS[0]}
+          set -o pipefail
+          if [ "$cmd_status" -ne 0 ]; then
+            exit "$cmd_status"
+          fi
           if grep -q "^ERROR:" /tmp/blueprint-output.txt; then
             echo "::error::Blueprint has unresolved labels (see ERROR lines above)"
             exit 1

--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -42,10 +42,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Restore Lake build cache
+        id: lake-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+          restore-keys: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+
       - name: Set up Lean and blueprint tooling
         uses: ./.github/actions/setup-lean
         with:
           install-blueprint: 'true'
+          use-github-cache: 'false'
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py
@@ -75,6 +84,13 @@ jobs:
 
       - name: Build project (needed for checkdecls)
         run: lake build
+
+      - name: Save Lake build cache
+        if: steps.lake-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: .lake
+          key: ${{ steps.lake-cache.outputs.cache-primary-key }}
 
       - name: Generate lean_decls from blueprint .tex files
         run: python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -324,7 +324,9 @@ class _TNTikZDiagram(Command):
                 log.warning("TikZ SVG rendering needs LaTeX and dvisvgm on PATH.")
                 self.ownerDocument.userdata["_tn_svg_missing_tools"] = True
             if os.environ.get("CI") == "true":
-                raise RuntimeError("TikZ SVG rendering needs LaTeX and dvisvgm on PATH.")
+                raise RuntimeError(
+                    f"TikZ SVG rendering needs LaTeX and dvisvgm on PATH for {tex_call}."
+                )
             return _missing_tools_html(tex_call)
 
         return (

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -323,6 +323,8 @@ class _TNTikZDiagram(Command):
             if not logged:
                 log.warning("TikZ SVG rendering needs LaTeX and dvisvgm on PATH.")
                 self.ownerDocument.userdata["_tn_svg_missing_tools"] = True
+            if os.environ.get("CI") == "true":
+                raise RuntimeError("TikZ SVG rendering needs LaTeX and dvisvgm on PATH.")
             return _missing_tools_html(tex_call)
 
         return (


### PR DESCRIPTION
### Motivation

- Blueprint web builds were missing LaTeX/TikZ and `dvisvgm` dependencies, causing tensor-network diagram SVGs to silently produce placeholder HTML instead of rendered images.
- CI had no enforcement step to catch silent rendering failures, so broken blueprint deploys could go undetected.

### Description

- `.github/actions/setup-lean/action.yml`: added `dvisvgm` and broader TeX Live packages to the composite setup action.
- `.github/workflows/blueprint.yml`: updated the blueprint CI workflow to install the TikZ→SVG toolchain; added a grep step that fails CI if generated HTML contains the `TikZ SVG unavailable` placeholder.
- `.github/workflows/docgen.yml`: same dependency installation and validation additions for the docgen workflow.
- `blueprint/src/Packages/tn_diagrams.py`: `tn_diagrams.py` now raises a `RuntimeError` under `CI=true` when SVG render tools are missing, rather than silently emitting placeholder HTML.

### Testing

- `PATH="$HOME/.local/pipx/venvs/leanblueprint/bin:$PATH" ~/.local/bin/leanblueprint web`
- `grep -R "TikZ SVG unavailable" blueprint/web --include="*.html" || true` produced no matches
- `blueprint/web/ch-mps.html` contains `img.tn-svg` entries for `\TNMPSLocal` and `\TNMPSWord`
- `find blueprint/web/tn_svg -type f -name "*.svg" | wc -l` → 36
- `python3 -m py_compile blueprint/src/Packages/tn_diagrams.py`
- `git diff --check`

---
No linked issue found — please add `Addresses #N` manually once one is filed or identified.

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI workflows and makes blueprint generation fail hard when rendering dependencies or outputs are missing, which may break gh-pages deploys until environments/content are corrected.
>
> **Overview**
> **Blueprint CI now installs the full TikZ→SVG toolchain** by adding `dvisvgm` and broader TeX Live packages to the composite setup action and to the `blueprint.yml`/`docgen.yml` workflows.
>
> **Blueprint builds now enforce rendered output**: workflows grep generated HTML for the `TikZ SVG unavailable` placeholder and fail the job if any are found, and `tn_diagrams.py` raises a `RuntimeError` under `CI=true` when SVG render tools are missing instead of silently emitting placeholder HTML.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c942fb59cf3d44d06fb45ecffcbc52e58ba1b5b.</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily changes CI/workflow behavior and tightens blueprint build validation, which may newly fail existing pipelines if environments/content are missing required TeX/dvisvgm tooling or if placeholders were previously tolerated.
> 
> **Overview**
> Blueprint CI and reusable setup now install additional TikZ→SVG rendering dependencies (notably `dvisvgm` plus TeX Live packages) and expose a `use-github-cache` toggle for `lean-action` caching.
> 
> Blueprint and docgen workflows now capture `leanblueprint web` output more robustly, propagate its exit status, and **fail the job** if generated HTML still contains the `TikZ SVG unavailable` placeholder; `lint-blueprint` also adds explicit `.lake` cache restore/save around the run. In `tn_diagrams.py`, missing SVG tools now raise a `RuntimeError` when `CI=true` instead of silently emitting placeholder HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edd15827dd3104b067eafe33ea486ab72e9e8e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->