### PR TITLE
feat(MPS/CanonicalForm): transport weights through reblocking (#971)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -310,6 +310,67 @@ theorem liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
       _ = mpv B σ := hSame 0 σ
       _ = (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ := hBσ
 
+/-- **Reblocked live-block equality with zero-tail bookkeeping.**
+
+If two tensors have the same MPVs and each is expressed as a zero tail plus a
+weighted live block tensor, then every positive common reblocking transports the
+live weights to powers, preserves positive-length equality of the live tensors,
+and leaves the zero-tail contribution as the sole length-zero bookkeeping term. -/
+theorem liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+    {d D₁ D₂ rA rB p : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (zeroTailA zeroTailB : ℕ)
+    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
+    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hp : 0 < p)
+    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
+    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) :
+    SameMPV₂Pos
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k => (μA k) ^ p)
+        (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p))
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k => (μB k) ^ p)
+        (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) ∧
+    (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+      (zeroTailA : ℂ) +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k => (μA k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ =
+        (zeroTailB : ℂ) +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k => (μB k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ) := by
+  have hAblock :=
+    zeroTail_toTensorFromBlocks_blockPower
+      (d := d) (D := D₁) (r := rA) (z := zeroTailA) (p := p) (dim := dimA)
+      A μA blocksA hp hA
+  have hBblock :=
+    zeroTail_toTensorFromBlocks_blockPower
+      (d := d) (D := D₂) (r := rB) (z := zeroTailB) (p := p) (dim := dimB)
+      B μB blocksB hp hB
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hBook :=
+    liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+      (d := blockPhysDim d p)
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      hAB zeroTailA zeroTailB
+      (fun k => (μA k) ^ p)
+      (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)
+      (fun k => (μB k) ^ p)
+      (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)
+      hAblock hBblock
+  exact ⟨fun N hN σ => hBook.1 hN σ, hBook.2⟩
+
 /-- **Recover full live-block `SameMPV₂` once zero tails agree.**
 
 This combines the positive-length bookkeeping theorem with the single additional

--- a/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
@@ -59,6 +59,74 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+/-! ## Zero-tail and weight transport through blocking -/
+
+/-- Reblocking preserves a zero-tail/live MPV decomposition.
+
+The positive-period hypothesis is exactly what keeps the zero-tail contribution
+confined to length zero after blocking: a blocked chain of positive length expands
+to a positive number of original sites. -/
+theorem zeroTail_mpv_decomp_blockTensor
+    {d D L z p : ℕ}
+    (A : MPSTensor d D) (live : MPSTensor d L)
+    (hp : 0 < p)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ) :
+    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+      mpv (blockTensor (d := d) (D := D) A p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
+          mpv (blockTensor (d := d) (D := L) live p) σ := by
+  intro N σ
+  let σflat := blockedFlatConfig (d := d) p σ
+  rw [mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) A p σ]
+  rw [hMPV (N * p) σflat]
+  have hNP_iff : N * p = 0 ↔ N = 0 := by
+    rw [Nat.mul_eq_zero]
+    exact ⟨fun h => h.resolve_right hp.ne', fun h => Or.inl h⟩
+  have hZero :
+      mpv (zeroMPSTensor d z) σflat =
+        mpv (zeroMPSTensor (blockPhysDim d p) z) σ := by
+    rw [mpv_zeroMPSTensor, mpv_zeroMPSTensor]
+    simp [hNP_iff]
+  rw [hZero]
+  congr 1
+  exact (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) live p σ).symm
+
+/-- Reblocking a zero-tail plus weighted live-block decomposition transports every
+live-block weight to the corresponding blocking power. -/
+theorem zeroTail_toTensorFromBlocks_blockPower
+    {d D r z p : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D)
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hp : 0 < p)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ) :
+    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+      mpv (blockTensor (d := d) (D := D) A p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k => (μ k) ^ p)
+            (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) σ := by
+  intro N σ
+  have hBlock :=
+    zeroTail_mpv_decomp_blockTensor
+      (d := d) (D := D) (L := ∑ k : Fin r, dim k) (z := z) (p := p)
+      A (toTensorFromBlocks (d := d) (μ := μ) blocks) hp hMPV N σ
+  have hLive := sameMPV₂_blockTensor_toTensorFromBlocks
+    (d := d) (dim := dim) μ blocks p
+  calc
+    mpv (blockTensor (d := d) (D := D) A p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
+          mpv (blockTensor (d := d) (D := ∑ k : Fin r, dim k)
+            (toTensorFromBlocks (d := d) (μ := μ) blocks) p) σ := hBlock
+    _ = mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k => (μ k) ^ p)
+            (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) σ := by
+          rw [hLive N σ]
+
 /-!
 ## The main reduction theorem
 
@@ -130,54 +198,13 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
   · exact hPrim
   -- (c) Positive bond dimensions (unchanged by blocking).
   · exact hDim₀
-  -- (d) Nonzero weights: (μ₀ k)^P ≠ 0 since μ₀ k ≠ 0.
-  · intro k
-    exact pow_ne_zero P (hμNe₀ k)
+  -- (d) Nonzero weights: `(μ₀ k)^P` remains nonzero since `μ₀ k ≠ 0`.
+  · exact blockWeights_ne_zero μ₀ hμNe₀ P
   -- (e) MPV relationship.
-  · intro N σ
-    -- Build the flattened configuration σflat : Fin (N * P) → Fin d.
-    set flat : List (Fin d) := flattenBlockedWord d P (List.ofFn σ) with flat_def
-    have hlen : flat.length = N * P := by
-      simpa [flat_def] using (length_flattenBlockedWord (d := d) (L := P) (List.ofFn σ))
-    set σflat : Fin (N * P) → Fin d :=
-      fun i => flat.get (Fin.cast hlen.symm i) with σflat_def
-    have hofFn : List.ofFn σflat = flat := by
-      rw [σflat_def]
-      conv_rhs => rw [← List.ofFn_get flat]
-      have hcongr :=
-        (List.ofFn_congr (m := N * P) (n := flat.length) hlen.symm
-          (fun i : Fin (N * P) => flat.get (Fin.cast hlen.symm i)))
-      simpa [Function.comp, Fin.cast_cast] using hcongr
-    -- Key: for ANY tensor T, mpv (blockTensor T P) σ = mpv T σflat.
-    have hblock (D' : ℕ) (T : MPSTensor d D') :
-        mpv (blockTensor (d := d) (D := D') T P) σ = mpv T σflat := by
-      simp [mpv, coeff, hofFn, flat_def, evalWord_blockTensor]
-    -- LHS: mpv (blockTensor A P) σ = mpv A σflat.
-    rw [hblock D A]
-    -- Pre-blocking MPV identity: mpv A σflat = zero-tail + live-blocks.
-    rw [hMPV₀ (N * P) σflat]
-    -- Trivial block: both sides equal `if N = 0 then zeroTailDim else 0`.
-    have hNP_iff : N * P = 0 ↔ N = 0 := by
-      rw [Nat.mul_eq_zero]
-      exact ⟨fun h => h.resolve_right hP.ne', fun h => Or.inl h⟩
-    have hZero :
-        mpv (zeroMPSTensor d zeroTailDim) σflat =
-          mpv (zeroMPSTensor (blockPhysDim d P) zeroTailDim) σ := by
-      rw [mpv_zeroMPSTensor, mpv_zeroMPSTensor]
-      simp [hNP_iff]
-    rw [hZero]
-    -- Live blocks: expand both sides via toTensorFromBlocks.
-    congr 1
-    rw [mpv_toTensorFromBlocks_eq_sum (μ := μ₀) (A := blocks₀) (σ := σflat)]
-    rw [mpv_toTensorFromBlocks_eq_sum (μ := μ₁) (A := blocks₁) (σ := σ)]
-    refine Finset.sum_congr rfl fun k _ => ?_
-    -- Weights: (μ₀ k)^(N*P) = ((μ₀ k)^P)^N = (μ₁ k)^N.
-    have hpow : (μ₀ k) ^ (N * P) = (μ₁ k) ^ N := by
-      simp [μ₁_def, Nat.mul_comm, pow_mul]
-    rw [hpow]
-    -- Block MPV: mpv (blocks₀ k) σflat = mpv (blockTensor (blocks₀ k) P) σ.
-    congr 1
-    exact (hblock (dim₀ k) (blocks₀ k)).symm
+  · simpa [μ₁_def, blocks₁_def] using
+      zeroTail_toTensorFromBlocks_blockPower
+        (d := d) (D := D) (r := r₀) (z := zeroTailDim) (p := P) (dim := dim₀)
+        A μ₀ blocks₀ hP hMPV₀
 
 /-!
 ## Conditional normal canonical form

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -60,22 +60,26 @@ section SameMPV₂Blocking
 
 variable {D : ℕ} {r : ℕ} {dim : Fin r → ℕ}
 
+/-- Flatten a blocked configuration to the underlying word of original physical indices. -/
 private noncomputable def blockedFlatWord (p : ℕ) {N : ℕ}
     (σ : Fin N → Fin (blockPhysDim d p)) : List (Fin d) :=
   flattenBlockedWord d p (List.ofFn σ)
 
+/-- The flattened word of an `N`-site blocked configuration has length `N * p`. -/
 private theorem length_blockedFlatWord (p : ℕ) {N : ℕ}
     (σ : Fin N → Fin (blockPhysDim d p)) :
     (blockedFlatWord (d := d) p σ).length = N * p := by
   simpa [blockedFlatWord] using
     (length_flattenBlockedWord (d := d) (L := p) (List.ofFn σ))
 
-private noncomputable def blockedFlatConfig (p : ℕ) {N : ℕ}
+/-- The flattened configuration associated to a blocked physical configuration. -/
+noncomputable def blockedFlatConfig (p : ℕ) {N : ℕ}
     (σ : Fin N → Fin (blockPhysDim d p)) : Fin (N * p) → Fin d :=
   fun i =>
     (blockedFlatWord (d := d) p σ).get
       (Fin.cast (length_blockedFlatWord (d := d) p σ).symm i)
 
+/-- Reconstruct the flattened blocked word from `blockedFlatConfig`. -/
 private theorem ofFn_blockedFlatConfig (p : ℕ) {N : ℕ}
     (σ : Fin N → Fin (blockPhysDim d p)) :
     List.ofFn (blockedFlatConfig (d := d) p σ) = blockedFlatWord (d := d) p σ := by
@@ -89,7 +93,9 @@ private theorem ofFn_blockedFlatConfig (p : ℕ) {N : ℕ}
           (Fin.cast (length_blockedFlatWord (d := d) p σ).symm i)))
   simpa [Function.comp, Fin.cast_cast] using hcongr
 
-private theorem mpv_blockTensor_eq_mpv_blockedFlatConfig
+/-- Evaluating the blocked tensor on a blocked configuration agrees with evaluating
+    the original tensor on the flattened configuration. -/
+theorem mpv_blockTensor_eq_mpv_blockedFlatConfig
     {D' : ℕ} (T : MPSTensor d D') (p : ℕ) {N : ℕ}
     (σ : Fin N → Fin (blockPhysDim d p)) :
     mpv (blockTensor (d := d) (D := D') T p) σ =
@@ -151,7 +157,118 @@ theorem sameMPV₂_blockTensor
     _ = mpv (blockTensor (d := d) (D := D₂) B p) σ :=
           (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) B p σ).symm
 
+/-- Blocking the assembled weighted block tensor is MPV-equivalent to assembling the
+blocked blocks with powered weights. -/
+theorem sameMPV₂_blockTensor_toTensorFromBlocks
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (p : ℕ) :
+    SameMPV₂
+      (blockTensor (d := d) (D := ∑ k : Fin r, dim k)
+        (toTensorFromBlocks (d := d) (μ := μ) blocks) p)
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k => (μ k) ^ p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) := by
+  exact sameMPV₂_blockTensor_of_sameMPV₂_toTensorFromBlocks
+    (d := d) (D := ∑ k : Fin r, dim k) (dim := dim)
+    (A := toTensorFromBlocks (d := d) (μ := μ) blocks)
+    μ blocks (by intro N σ; rfl) p
+
+/-- Positive-length MPV equality is preserved by positive physical blocking. -/
+theorem sameMPV₂Pos_blockTensor
+    {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂Pos A B) (p : ℕ) (hp : 0 < p) :
+    SameMPV₂Pos
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p) := by
+  intro N hN σ
+  let σflat := blockedFlatConfig (d := d) p σ
+  calc
+    mpv (blockTensor (d := d) (D := D₁) A p) σ
+        = mpv A σflat := mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) A p σ
+    _ = mpv B σflat := hSame (N * p) (Nat.mul_pos hN hp) σflat
+    _ = mpv (blockTensor (d := d) (D := D₂) B p) σ :=
+          (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) B p σ).symm
+
+/-- Positive-length equality of weighted live block tensors is preserved after
+positive common blocking, with each weight transported to the corresponding power. -/
+theorem sameMPV₂Pos_toTensorFromBlocks_blockPower
+    {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
+    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hSame : SameMPV₂Pos
+      (toTensorFromBlocks (d := d) (μ := μA) blocksA)
+      (toTensorFromBlocks (d := d) (μ := μB) blocksB))
+    (p : ℕ) (hp : 0 < p) :
+    SameMPV₂Pos
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k => (μA k) ^ p)
+        (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p))
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k => (μB k) ^ p)
+        (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) := by
+  have hA := sameMPV₂_blockTensor_toTensorFromBlocks
+    (d := d) (dim := dimA) μA blocksA p
+  have hB := sameMPV₂_blockTensor_toTensorFromBlocks
+    (d := d) (dim := dimB) μB blocksB p
+  have hBlock : SameMPV₂Pos
+      (blockTensor (d := d) (D := ∑ k : Fin rA, dimA k)
+        (toTensorFromBlocks (d := d) (μ := μA) blocksA) p)
+      (blockTensor (d := d) (D := ∑ k : Fin rB, dimB k)
+        (toTensorFromBlocks (d := d) (μ := μB) blocksB) p) :=
+    sameMPV₂Pos_blockTensor
+      (d := d)
+      (toTensorFromBlocks (d := d) (μ := μA) blocksA)
+      (toTensorFromBlocks (d := d) (μ := μB) blocksB) hSame p hp
+  intro N hN σ
+  calc
+    mpv (toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k => (μA k) ^ p)
+        (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ
+        = mpv (blockTensor (d := d) (D := ∑ k : Fin rA, dimA k)
+            (toTensorFromBlocks (d := d) (μ := μA) blocksA) p) σ := (hA N σ).symm
+    _ = mpv (blockTensor (d := d) (D := ∑ k : Fin rB, dimB k)
+            (toTensorFromBlocks (d := d) (μ := μB) blocksB) p) σ := hBlock N hN σ
+    _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k => (μB k) ^ p)
+        (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ := hB N σ
+
 end SameMPV₂Blocking
+
+/-! ## Weight transport under blocking and sector replication -/
+
+section WeightTransport
+
+variable {r : ℕ}
+
+/-- Nonzero block weights remain nonzero after taking a blocking power. -/
+theorem blockWeights_ne_zero
+    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) (p : ℕ) :
+    ∀ k, (μ k) ^ p ≠ 0 := by
+  intro k
+  exact pow_ne_zero p (hμ k)
+
+/-- Replicating a block weight over cyclic sectors preserves nonvanishing after
+any family of blocking powers. -/
+theorem replicatedWeights_pow_ne_zero
+    {m : Fin r → ℕ}
+    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) (p : Fin r → ℕ) :
+    ∀ x : Σ k : Fin r, Fin (m k), (μ x.1) ^ (p x.1) ≠ 0 := by
+  intro x
+  exact pow_ne_zero (p x.1) (hμ x.1)
+
+/-- A nonzero sector phase can be multiplied into a transported block weight
+without making the sector weight vanish. -/
+theorem replicatedWeights_pow_mul_phase_ne_zero
+    {m : Fin r → ℕ}
+    (μ : Fin r → ℂ) (θ : (Σ k : Fin r, Fin (m k)) → ℂ)
+    (hμ : ∀ k, μ k ≠ 0) (hθ : ∀ x, θ x ≠ 0) (p : Fin r → ℕ) :
+    ∀ x : Σ k : Fin r, Fin (m k), (μ x.1) ^ (p x.1) * θ x ≠ 0 := by
+  intro x
+  exact mul_ne_zero (replicatedWeights_pow_ne_zero μ hμ p x) (hθ x)
+
+end WeightTransport
 
 /-!
 ## Part B: Primitivity under multiples

--- a/audits/2026-04-27_issue971_weight_zero_tail.md
+++ b/audits/2026-04-27_issue971_weight_zero_tail.md
@@ -1,0 +1,32 @@
+# 2026-04-27 — Issue #971 weight transport and zero-tail reblocking
+
+This branch adds checked bookkeeping lemmas for transporting live-block weights and zero-tail MPV identities through positive physical reblocking, as a modular input for the common cyclic-sector flattening work in #969.
+
+## Lean declarations added
+
+In `TNLean/MPS/Core/BlockingInfrastructure.lean`:
+
+- `MPSTensor.blockedFlatConfig` and `MPSTensor.mpv_blockTensor_eq_mpv_blockedFlatConfig`: shared flattened-configuration helpers for reusing the same original physical word across blocked tensors.
+- `MPSTensor.sameMPV₂_blockTensor_toTensorFromBlocks`: direct adapter saying that blocking an assembled weighted block tensor agrees, as an MPV family, with assembling the individually blocked blocks and powered weights.
+- `MPSTensor.sameMPV₂Pos_blockTensor`: positive-length MPV equality is preserved by positive blocking.
+- `MPSTensor.sameMPV₂Pos_toTensorFromBlocks_blockPower`: positive-length equality of two weighted live block tensors is preserved by positive common blocking, with weights transported to powers.
+- `MPSTensor.blockWeights_ne_zero`: nonzero block weights remain nonzero after blocking powers.
+- `MPSTensor.replicatedWeights_pow_ne_zero`: nonzero block weights remain nonzero when replicated over cyclic sectors with per-block powers.
+- `MPSTensor.replicatedWeights_pow_mul_phase_ne_zero`: the same nonvanishing persists after multiplying by nonzero sector phase factors.
+
+In `TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean`:
+
+- `MPSTensor.zeroTail_mpv_decomp_blockTensor`: a zero-tail/live MPV decomposition remains a zero-tail/live decomposition after positive blocking, with the zero-tail term still isolated at blocked length zero.
+- `MPSTensor.zeroTail_toTensorFromBlocks_blockPower`: the weighted-live version, transporting `μ_k` to `μ_k^p` and `B_k` to `B_k^[p]`.
+
+In `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`:
+
+- `MPSTensor.liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂`: combines the reblocked zero-tail identities for two globally equal MPV families to give positive-length equality of powered live block tensors plus the exact blocked length-zero zero-tail bookkeeping identity.
+
+## Refactor
+
+`MPSTensor.exists_tp_primitive_blockDecomp_after_blocking` now uses `blockWeights_ne_zero` and `zeroTail_toTensorFromBlocks_blockPower` instead of reproving the power and length-zero arithmetic inline.
+
+## Remaining #969/#971 interface gap
+
+These lemmas do not yet construct the final flattened cyclic-sector family at one common physical blocking level. They provide the reusable arithmetic and MPV bookkeeping that such a theorem should call once the dependent-index flattening and nested-blocking associativity data are fixed.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1087,6 +1087,92 @@ The following results separate the zero blocks from the
 	then gives the equivalence at length $N$ with weights $\mu_k^p$.
 \end{proof}
 
+\begin{theorem}[Blocking assembled weighted blocks]%
+	\label{thm:block_tensor_to_tensor_from_blocks}
+	\lean{MPSTensor.sameMPV₂_blockTensor_toTensorFromBlocks}
+	\leanok
+	\uses{thm:samempv_blocking_distributes, def:tensor_from_blocks, def:blocked_tensor}
+	For any weighted block tensor $\bigoplus_k \mu_k B_k$ and any blocking
+	length $p \ge 0$, its blocked MPV family agrees with the weighted block tensor
+	formed from the blocked blocks $B_k^{[p]}$ and the powered weights $\mu_k^p$.
+\end{theorem}
+
+\begin{proof}\leanok
+	Apply Theorem~\ref{thm:samempv_blocking_distributes} to the identity MPV
+	relation for the assembled weighted block tensor.
+\end{proof}
+
+\begin{theorem}[Positive-length MPV equality after blocking]%
+	\label{thm:samempv2pos_block_tensor}
+	\lean{MPSTensor.sameMPV₂Pos_blockTensor}
+	\leanok
+	\uses{def:same_mpv2_pos, def:blocked_tensor}
+	If two tensors agree on all positive system sizes, then their $p$-blocked
+	tensors agree on all positive blocked system sizes for every $p \ge 1$.
+\end{theorem}
+
+\begin{proof}\leanok
+	A positive blocked chain of length $N$ corresponds to an original chain of
+	length $Np$, which is positive when both $N$ and $p$ are positive.
+\end{proof}
+
+\begin{theorem}[Positive-length equality for powered weighted live blocks]%
+	\label{thm:samempv2pos_toTensorFromBlocks_block_power}
+	\lean{MPSTensor.sameMPV₂Pos_toTensorFromBlocks_blockPower}
+	\leanok
+	\uses{thm:block_tensor_to_tensor_from_blocks, thm:samempv2pos_block_tensor,
+	      def:tensor_from_blocks}
+	If two weighted live block tensors agree on all positive system sizes, then
+	after any positive common blocking their blocked live block tensors still agree
+	on all positive system sizes, with weights transported from $\mu_k$ to
+	$\mu_k^p$.
+\end{theorem}
+
+\begin{proof}\leanok
+	Use Theorem~\ref{thm:samempv2pos_block_tensor} for the assembled live tensors,
+	then rewrite each blocked assembled tensor by
+	Theorem~\ref{thm:block_tensor_to_tensor_from_blocks}.
+\end{proof}
+
+\begin{lemma}[Nonzero weights after blocking powers]%
+	\label{lem:block_weights_ne_zero}
+	\lean{MPSTensor.blockWeights_ne_zero}
+	\leanok
+	If every $\mu_k$ is nonzero, then every powered weight $\mu_k^p$ is nonzero.
+\end{lemma}
+
+\begin{proof}\leanok
+	This is the elementary fact that powers of a nonzero complex number are
+	nonzero.
+\end{proof}
+
+\begin{lemma}[Nonzero weights after sector replication]%
+	\label{lem:replicated_weights_pow_ne_zero}
+	\lean{MPSTensor.replicatedWeights_pow_ne_zero}
+	\leanok
+	Suppose a live block $k$ is replaced by a finite family of cyclic sectors. If
+	$\mu_k \ne 0$, then every replicated sector weight $\mu_k^{p_k}$ remains
+	nonzero.
+\end{lemma}
+
+\begin{proof}\leanok
+	Apply Lemma~\ref{lem:block_weights_ne_zero} to the parent block weight and the
+	blocking power assigned to that block.
+\end{proof}
+
+\begin{lemma}[Nonzero replicated weights with sector phases]%
+	\label{lem:replicated_weights_pow_mul_phase_ne_zero}
+	\lean{MPSTensor.replicatedWeights_pow_mul_phase_ne_zero}
+	\leanok
+	If the replicated sector weights are additionally multiplied by nonzero sector
+	phases, then the resulting sector weights are still nonzero.
+\end{lemma}
+
+\begin{proof}\leanok
+	Combine Lemma~\ref{lem:replicated_weights_pow_ne_zero} with nonvanishing of
+	the phase factor.
+\end{proof}
+
 \begin{theorem}[Primitive channels remain primitive under powers]%
 	\label{thm:primitive_pow}
 	\lean{MPSTensor.isPrimitive_pow_of_isPrimitive}
@@ -2056,12 +2142,14 @@ The following results separate the zero blocks from the
 
 \begin{proof}\leanok
 	\uses{thm:tp_gauge_arbitrary, thm:common_blocking_period,
-	      thm:samempv_blocking_distributes}
+	      lem:block_weights_ne_zero, thm:zero_tail_to_tensor_from_blocks_block_power}
 	Apply Theorem~\ref{thm:tp_gauge_arbitrary} to get the trivial block
 	and left-canonical nontrivial blocks.
 	Apply Theorem~\ref{thm:common_blocking_period} to find a common
-	blocking period $p$ making all transfer maps primitive.
-	Apply Theorem~\ref{thm:samempv_blocking_distributes}.
+	blocking period $p$ making all transfer maps primitive. Lemma~\ref{lem:block_weights_ne_zero}
+	keeps the blocked weights nonzero, and
+	Theorem~\ref{thm:zero_tail_to_tensor_from_blocks_block_power} transports the
+	zero-tail/live MPV identity through the blocking step.
 \end{proof}
 
 \begin{theorem}[TP-primitive irreducible tensor is normal]%
@@ -2660,6 +2748,41 @@ The following results separate the zero blocks from the
 	Apply Theorem~\ref{thm:tp_primitive_blockdecomp} separately to the two tensors.
 \end{proof}
 
+\begin{theorem}[Zero-tail decomposition after blocking]%
+	\label{thm:zero_tail_decomp_block_tensor}
+	\lean{MPSTensor.zeroTail_mpv_decomp_blockTensor}
+	\leanok
+	\uses{def:blocked_tensor, def:zero_mps_tensor}
+	Suppose $A$ is expressed as a zero-tail tensor plus a live tensor $L$ at all
+	system sizes. For every positive blocking length $p$, the blocked tensor
+	$A^{[p]}$ is expressed as the same zero-tail bond dimension plus $L^{[p]}$.
+	The zero-tail term still contributes only at blocked length $0$.
+\end{theorem}
+
+\begin{proof}\leanok
+	Flatten a blocked word of length $N$ to an original word of length $Np$. Since
+	$p>0$, this length is zero exactly when $N=0$, so the zero-tail MPV is
+	unchanged by the reblocking convention.
+\end{proof}
+
+\begin{theorem}[Zero-tail weighted block decomposition after blocking]%
+	\label{thm:zero_tail_to_tensor_from_blocks_block_power}
+	\lean{MPSTensor.zeroTail_toTensorFromBlocks_blockPower}
+	\leanok
+	\uses{thm:zero_tail_decomp_block_tensor, thm:block_tensor_to_tensor_from_blocks,
+	      def:tensor_from_blocks}
+	Suppose $A$ is expressed as a zero-tail tensor plus the weighted live block
+	tensor $\bigoplus_k \mu_k B_k$. For every positive blocking length $p$,
+	$A^{[p]}$ is expressed as the same zero-tail contribution plus the weighted
+	blocked live tensor $\bigoplus_k \mu_k^p B_k^{[p]}$.
+\end{theorem}
+
+\begin{proof}\leanok
+	Apply Theorem~\ref{thm:zero_tail_decomp_block_tensor} to the assembled
+	weighted live tensor and rewrite the blocked assembled tensor using
+	Theorem~\ref{thm:block_tensor_to_tensor_from_blocks}.
+\end{proof}
+
 \begin{theorem}[Zero-tail bookkeeping for live block tensors]%
 \label{thm:live_block_zero_tail_bookkeeping}
 	\lean{MPSTensor.liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂}
@@ -2677,6 +2800,26 @@ The following results separate the zero blocks from the
 	For $N>0$, the MPV of a zero-tail tensor is zero, so the two decompositions
 	can be compared directly through the common MPV family. For $N=0$, the
 	zero-tail MPV is its bond dimension, giving the stated bookkeeping identity.
+\end{proof}
+
+\begin{theorem}[Reblocked live equality with zero-tail bookkeeping]%
+	\label{thm:live_block_block_power_zero_tail_bookkeeping}
+	\lean{MPSTensor.liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂}
+	\leanok
+	\uses{thm:live_block_zero_tail_bookkeeping,
+	      thm:zero_tail_to_tensor_from_blocks_block_power, def:same_mpv2_pos}
+	In the setting of Theorem~\ref{thm:live_block_zero_tail_bookkeeping}, after
+	any positive common blocking length $p$, the powered weighted live block tensors
+	agree on all positive blocked system sizes. At blocked length $0$, the same
+	zero-tail bookkeeping identity holds with weights transported from $\mu_k$ to
+	$\mu_k^p$.
+\end{theorem}
+
+\begin{proof}\leanok
+	Use Theorem~\ref{thm:zero_tail_to_tensor_from_blocks_block_power} on both
+	zero-tail decompositions, block the original MPV equality, and apply
+	Theorem~\ref{thm:live_block_zero_tail_bookkeeping} at the blocked physical
+	dimension.
 \end{proof}
 
 \begin{theorem}[Equal zero tails give full live MPV equality]%


### PR DESCRIPTION
## Summary

Closes useful checked predecessors for #971 by factoring the arithmetic and MPV accounting needed when nonzero block families are reblocked and later flattened into cyclic sectors.

Lean additions:

- `sameMPV₂_blockTensor_toTensorFromBlocks`: blocking a weighted block tensor agrees with assembling blocked blocks and powered weights.
- `sameMPV₂Pos_blockTensor` and `sameMPV₂Pos_toTensorFromBlocks_blockPower`: positive-length live equality is preserved under positive common reblocking.
- `blockWeights_ne_zero`, `replicatedWeights_pow_ne_zero`, `replicatedWeights_pow_mul_phase_ne_zero`: nonzero weights survive blocking powers, sector replication, and nonzero phase factors.
- `zeroTail_mpv_decomp_blockTensor` and `zeroTail_toTensorFromBlocks_blockPower`: zero-tail/live MPV decompositions reblock with the same zero-tail contribution and powered live weights.
- `liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_accounting_of_sameMPV₂`: two global equal-MPV decompositions give positive-length equality of powered nonzero blocks plus exact length-zero accounting after reblocking.

Also refactors `exists_tp_primitive_blockDecomp_after_blocking` to call these adapters rather than reproving the arithmetic inline, and documents the public declarations in Chapter 8 plus an audit note.

## Validation

- Lean diagnostics clean for:
  - `TNLean/MPS/Core/BlockingInfrastructure.lean`
  - `TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean`
  - `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web` passed with TikZ SVG rendering disabled in `PATH` to avoid the local iCloud path quoting bug in `tn_diagrams.py`.
- `git diff --check`
- Added-line scans clean for forbidden proof tokens and banned prose phrases.
- Local targeted `lake build --old TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.Assembly.TPPrimitiveReduction TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` is still running after populating this fresh worktree cache; CI should provide the authoritative full build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new core blocking/MPV accounting lemmas and refactors the TP-primitive reduction proof to reuse them; risk is mainly proof breakage or subtle lemma assumptions (e.g., `p > 0`) affecting downstream theorems.
> 
> **Overview**
> Introduces reusable Lean lemmas to **transport MPV equalities through physical blocking**, including helpers to flatten blocked configurations, show `blockTensor` evaluation matches evaluation on the flattened configuration, and rewrite blocked `toTensorFromBlocks` into **blocked blocks with weights powered by the blocking length**.
> 
> Adds zero-tail-specific reblocking theorems that keep the zero-tail contribution isolated at length 0 and upgrades the structural accounting result to cover **common positive reblocking** (positive-length live equality plus an explicit length-0 identity). Refactors `exists_tp_primitive_blockDecomp_after_blocking` to call these new lemmas, and updates the blueprint/audit docs accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c0c35a3fd4a051293a71c43245bd06c1fdca5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->