### PR TITLE
feat(MPS/MPDO): add cumulative pair trace separation

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -329,6 +329,33 @@ private theorem exists_pair_trace_repr {m n : Type*} [Fintype m] [Fintype n]
           (f.comp (LinearMap.inr ℂ (Matrix m m ℂ) (Matrix n n ℂ))) M.2 = _
       rw [hA M.1, hB M.2]
 
+private theorem pair_trace_zero_on_span {D₁ D₂ : ℕ}
+    {Ω : Set (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ)}
+    (ΔA : Matrix (Fin D₁) (Fin D₁) ℂ)
+    (ΔB : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hΩ : ∀ M ∈ Ω, Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) = 0) :
+    ∀ M : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ,
+      M ∈ Submodule.span ℂ Ω →
+        Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) = 0 := by
+  intro M hM
+  induction hM using Submodule.span_induction with
+  | mem M hMmem =>
+      exact hΩ M hMmem
+  | zero => simp
+  | add M N _ _ hM hN =>
+      calc
+        Matrix.trace (ΔA * (M + N).1) + Matrix.trace (ΔB * (M + N).2)
+            = (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) +
+                (Matrix.trace (ΔA * N.1) + Matrix.trace (ΔB * N.2)) := by
+              simp [Matrix.mul_add, Matrix.trace_add, add_assoc, add_left_comm]
+        _ = 0 := by simp [hM, hN]
+  | smul a M _ hM =>
+      calc
+        Matrix.trace (ΔA * (a • M).1) + Matrix.trace (ΔB * (a • M).2)
+            = a * (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) := by
+              simp [Matrix.trace_smul, mul_add]
+        _ = 0 := by simp [hM]
+
 /-- The pair trace-separation criterion is the dual form of pair product-span. -/
 theorem pairWordTupleSpanTop_of_pairTraceSeparatingAt {D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
@@ -399,24 +426,12 @@ theorem pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop {D₁ D₂ : �
         M ∈ pairCumulativeSpan A B S →
           Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) = 0 := by
     intro M hM
-    induction hM using Submodule.span_induction with
-    | mem M hMmem =>
-        rcases hMmem with ⟨w, hw, rfl⟩
-        exact hΔ w hw
-    | zero => simp
-    | add M N _ _ hM hN =>
-        calc
-          Matrix.trace (ΔA * (M + N).1) + Matrix.trace (ΔB * (M + N).2)
-              = (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) +
-                  (Matrix.trace (ΔA * N.1) + Matrix.trace (ΔB * N.2)) := by
-                simp [Matrix.mul_add, Matrix.trace_add, add_assoc, add_left_comm]
-          _ = 0 := by simp [hM, hN]
-    | smul a M _ hM =>
-        calc
-          Matrix.trace (ΔA * (a • M).1) + Matrix.trace (ΔB * (a • M).2)
-              = a * (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) := by
-                simp [Matrix.trace_smul, mul_add]
-          _ = 0 := by simp [hM]
+    exact pair_trace_zero_on_span ΔA ΔB
+      (Ω := {M | ∃ w : List (Fin d), w.length ≤ S ∧ M = pairEvalWordTuple A B w})
+      (by
+        rintro M ⟨w, hw, rfl⟩
+        exact hΔ w hw)
+      M (by simpa [pairCumulativeSpan] using hM)
   constructor
   · apply trace_mul_right_eq_zero
     intro M
@@ -503,24 +518,12 @@ theorem pairTraceSeparatingAll_of_pairAllWordsSpanTop {D₁ D₂ : ℕ}
         M ∈ pairAllWordsSpan A B →
           Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) = 0 := by
     intro M hM
-    induction hM using Submodule.span_induction with
-    | mem M hMmem =>
-        rcases hMmem with ⟨w, rfl⟩
-        exact hΔ w
-    | zero => simp
-    | add M N _ _ hM hN =>
-        calc
-          Matrix.trace (ΔA * (M + N).1) + Matrix.trace (ΔB * (M + N).2)
-              = (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) +
-                  (Matrix.trace (ΔA * N.1) + Matrix.trace (ΔB * N.2)) := by
-                simp [Matrix.mul_add, Matrix.trace_add, add_assoc, add_left_comm]
-          _ = 0 := by simp [hM, hN]
-    | smul a M _ hM =>
-        calc
-          Matrix.trace (ΔA * (a • M).1) + Matrix.trace (ΔB * (a • M).2)
-              = a * (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) := by
-                simp [Matrix.trace_smul, mul_add]
-          _ = 0 := by simp [hM]
+    exact pair_trace_zero_on_span ΔA ΔB
+      (Ω := Set.range (pairEvalWordTuple A B))
+      (by
+        rintro M ⟨w, rfl⟩
+        exact hΔ w)
+      M (by simpa [pairAllWordsSpan] using hM)
   constructor
   · apply trace_mul_right_eq_zero
     intro M

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -6,12 +6,13 @@ import TNLean.MPS.MPDO.VerticalCF
 import TNLean.PiAlgebra.Construction
 import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 import Mathlib.LinearAlgebra.Prod
+import Mathlib.RingTheory.Noetherian.Defs
 
 /-!
 # Finite-length sufficient conditions and obstructions for MPDO biCF
 
 The `HorizontalCFData` structure in `VerticalCF.lean` records the block-injective
-canonical-form property `biCF` as a hypothesis. This file records five complementary
+canonical-form property `biCF` as a hypothesis. This file records six complementary
 facts about that field.
 
 1. A clean **abstract sufficient condition**: if, after blocking to some fixed
@@ -38,7 +39,11 @@ facts about that field.
    first block and zero on the second, then multiplying these pairwise
    separators gives full block-selector words.
 
-5. A concrete **counterexample**: blockwise injectivity, left-canonical
+5. A finite-dimensional **cumulative pair trace criterion**: if no nonzero pair
+   trace functional vanishes on all finite pair words, then a finite cumulative
+   word-length bound already detects every nonzero test pair.
+
+6. A concrete **counterexample**: blockwise injectivity, left-canonical
    normalization, nonzero weights, and even pairwise distinct weights do **not**
    imply `biCF`. Thus the current `HorizontalCFData` fields other than `biCF`
    are insufficient for deriving that property.
@@ -186,6 +191,94 @@ def PairTraceSeparatingAt {D₁ D₂ : ℕ}
           Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) →
       ΔA = 0 ∧ ΔB = 0
 
+/-- The simultaneous word evaluation of two blocks for an arbitrary finite word. -/
+def pairEvalWordTuple {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (w : List (Fin d)) :
+    Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ :=
+  (evalWord A w, evalWord B w)
+
+/-- The cumulative span of pair word tuples of length at most `S`. -/
+noncomputable def pairCumulativeSpan {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) (S : ℕ) :
+    Submodule ℂ (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ) :=
+  Submodule.span ℂ
+    {M | ∃ w : List (Fin d), w.length ≤ S ∧ M = pairEvalWordTuple A B w}
+
+/-- Finite cumulative pair product-span: pair word tuples of length at most `S`
+span the full product matrix algebra. -/
+def PairCumulativeWordTupleSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) (S : ℕ) : Prop :=
+  pairCumulativeSpan A B S = ⊤
+
+/-- Trace-separation by all pair word tuples of length at most `S`.
+
+This finite cutoff form is weaker than the homogeneous criterion
+`PairTraceSeparatingAt`, but it is the exact finite-dimensional consequence of
+ruling out trace functionals that vanish on all word lengths. -/
+def PairTraceSeparatingUpTo {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) (S : ℕ) : Prop :=
+  ∀ ΔA : Matrix (Fin D₁) (Fin D₁) ℂ,
+    ∀ ΔB : Matrix (Fin D₂) (Fin D₂) ℂ,
+      (∀ w : List (Fin d), w.length ≤ S →
+        Matrix.trace (ΔA * evalWord A w) +
+          Matrix.trace (ΔB * evalWord B w) = 0) →
+      ΔA = 0 ∧ ΔB = 0
+
+/-- Infinite trace-separation by pair word tuples of all finite lengths. -/
+def PairTraceSeparatingAll {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
+  ∀ ΔA : Matrix (Fin D₁) (Fin D₁) ℂ,
+    ∀ ΔB : Matrix (Fin D₂) (Fin D₂) ℂ,
+      (∀ w : List (Fin d),
+        Matrix.trace (ΔA * evalWord A w) +
+          Matrix.trace (ΔB * evalWord B w) = 0) →
+      ΔA = 0 ∧ ΔB = 0
+
+/-- The span of pair word tuples over all finite words. -/
+noncomputable def pairAllWordsSpan {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
+    Submodule ℂ (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ) :=
+  Submodule.span ℂ (Set.range (pairEvalWordTuple A B))
+
+/-- All finite pair word tuples span the full product matrix algebra. -/
+def PairAllWordsSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
+  pairAllWordsSpan A B = ⊤
+
+/-- Membership of a pair word tuple in the cumulative pair span. -/
+theorem pairEvalWordTuple_mem_pairCumulativeSpan {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    {w : List (Fin d)} {S : ℕ} (hw : w.length ≤ S) :
+    pairEvalWordTuple A B w ∈ pairCumulativeSpan A B S :=
+  Submodule.subset_span ⟨w, hw, rfl⟩
+
+/-- Cumulative pair spans are monotone in the cutoff. -/
+theorem pairCumulativeSpan_mono {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    {S T : ℕ} (hST : S ≤ T) :
+    pairCumulativeSpan A B S ≤ pairCumulativeSpan A B T := by
+  apply Submodule.span_mono
+  rintro M ⟨w, hw, rfl⟩
+  exact ⟨w, le_trans hw hST, rfl⟩
+
+/-- Cumulative trace separation is monotone in the cutoff. -/
+theorem PairTraceSeparatingUpTo.mono {D₁ D₂ : ℕ}
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {S T : ℕ} (hSep : PairTraceSeparatingUpTo A B S) (hST : S ≤ T) :
+    PairTraceSeparatingUpTo A B T := by
+  intro ΔA ΔB hΔ
+  exact hSep ΔA ΔB (fun w hw => hΔ w (le_trans hw hST))
+
+/-- Homogeneous trace separation implies cumulative trace separation at the same cutoff. -/
+theorem pairTraceSeparatingUpTo_of_pairTraceSeparatingAt {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hSep : PairTraceSeparatingAt A B S) :
+    PairTraceSeparatingUpTo A B S := by
+  intro ΔA ΔB hΔ
+  exact hSep ΔA ΔB (fun w => by
+    simpa using hΔ (List.ofFn w) (by simp))
+
 private theorem exists_trace_repr {n : Type*} [Fintype n]
     (f : Matrix n n ℂ →ₗ[ℂ] ℂ) :
     ∃ Δ : Matrix n n ℂ, ∀ M : Matrix n n ℂ, f M = Matrix.trace (Δ * M) := by
@@ -264,6 +357,268 @@ theorem pairWordTupleSpanTop_of_pairTraceSeparatingAt {D₁ D₂ : ℕ}
     rw [hΔ.1, hΔ.2] at hM
     simpa using hM
   exact hfne hfzero
+
+/-- Cumulative trace separation is the dual form of cumulative pair product-span. -/
+theorem pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hSep : PairTraceSeparatingUpTo A B S) :
+    PairCumulativeWordTupleSpanTop A B S := by
+  classical
+  unfold PairCumulativeWordTupleSpanTop
+  by_contra hnot
+  let W : Submodule ℂ
+      (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ) :=
+    pairCumulativeSpan A B S
+  have hlt : W < ⊤ := lt_of_le_of_ne le_top (by simpa [W] using hnot)
+  obtain ⟨f, hfne, hfker⟩ := Submodule.exists_le_ker_of_lt_top W hlt
+  obtain ⟨ΔA, ΔB, hf_repr⟩ := exists_pair_trace_repr f
+  have hΔ : ΔA = 0 ∧ ΔB = 0 := by
+    refine hSep ΔA ΔB ?_
+    intro w hw
+    have hwmem : pairEvalWordTuple A B w ∈ W :=
+      pairEvalWordTuple_mem_pairCumulativeSpan A B hw
+    have hf0 : f (pairEvalWordTuple A B w) = 0 := hfker hwmem
+    simpa [pairEvalWordTuple, hf_repr] using hf0
+  have hfzero : f = 0 := by
+    apply LinearMap.ext
+    intro M
+    have hM := hf_repr M
+    rw [hΔ.1, hΔ.2] at hM
+    simpa using hM
+  exact hfne hfzero
+
+/-- Cumulative pair product-span gives cumulative trace separation. -/
+theorem pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hSpan : PairCumulativeWordTupleSpanTop A B S) :
+    PairTraceSeparatingUpTo A B S := by
+  classical
+  intro ΔA ΔB hΔ
+  have hZeroOnSpan :
+      ∀ M : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ,
+        M ∈ pairCumulativeSpan A B S →
+          Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) = 0 := by
+    intro M hM
+    induction hM using Submodule.span_induction with
+    | mem M hMmem =>
+        rcases hMmem with ⟨w, hw, rfl⟩
+        exact hΔ w hw
+    | zero => simp
+    | add M N _ _ hM hN =>
+        calc
+          Matrix.trace (ΔA * (M + N).1) + Matrix.trace (ΔB * (M + N).2)
+              = (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) +
+                  (Matrix.trace (ΔA * N.1) + Matrix.trace (ΔB * N.2)) := by
+                simp [Matrix.mul_add, Matrix.trace_add, add_assoc, add_left_comm]
+          _ = 0 := by simp [hM, hN]
+    | smul a M _ hM =>
+        calc
+          Matrix.trace (ΔA * (a • M).1) + Matrix.trace (ΔB * (a • M).2)
+              = a * (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) := by
+                simp [Matrix.trace_smul, mul_add]
+          _ = 0 := by simp [hM]
+  constructor
+  · apply trace_mul_right_eq_zero
+    intro M
+    have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
+    simpa using hpair
+  · apply trace_mul_right_eq_zero
+    intro N
+    have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
+    simpa using hpair
+
+/-- Cumulative trace separation is equivalent to cumulative pair product-span. -/
+theorem pairCumulativeWordTupleSpanTop_iff_pairTraceSeparatingUpTo {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ} :
+    PairCumulativeWordTupleSpanTop A B S ↔ PairTraceSeparatingUpTo A B S :=
+  ⟨pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop A B,
+    pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo A B⟩
+
+/-- Homogeneous pair product-span implies cumulative pair product-span at the same cutoff. -/
+theorem pairCumulativeWordTupleSpanTop_of_pairWordTupleSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hSpan : PairWordTupleSpanTop A B S) :
+    PairCumulativeWordTupleSpanTop A B S := by
+  classical
+  unfold PairCumulativeWordTupleSpanTop
+  apply eq_top_iff.mpr
+  intro M _
+  have hM : M ∈ Submodule.span ℂ (Set.range (pairWordTuple A B S)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hle : Submodule.span ℂ (Set.range (pairWordTuple A B S)) ≤
+      pairCumulativeSpan A B S := by
+    apply Submodule.span_le.mpr
+    rintro N ⟨w, rfl⟩
+    simpa [pairWordTuple, pairEvalWordTuple] using
+      (pairEvalWordTuple_mem_pairCumulativeSpan A B (w := List.ofFn w) (S := S) (by simp))
+  exact hle hM
+
+/-- Homogeneous trace separation implies cumulative pair product-span at the same cutoff. -/
+theorem pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingAt {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hSep : PairTraceSeparatingAt A B S) :
+    PairCumulativeWordTupleSpanTop A B S :=
+  pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo A B
+    (pairTraceSeparatingUpTo_of_pairTraceSeparatingAt A B hSep)
+
+/-- Trace separation by all finite pair words is dual to the span of all pair word tuples. -/
+theorem pairAllWordsSpanTop_of_pairTraceSeparatingAll {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSep : PairTraceSeparatingAll A B) :
+    PairAllWordsSpanTop A B := by
+  classical
+  unfold PairAllWordsSpanTop
+  by_contra hnot
+  let W : Submodule ℂ
+      (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ) :=
+    pairAllWordsSpan A B
+  have hlt : W < ⊤ := lt_of_le_of_ne le_top (by simpa [W] using hnot)
+  obtain ⟨f, hfne, hfker⟩ := Submodule.exists_le_ker_of_lt_top W hlt
+  obtain ⟨ΔA, ΔB, hf_repr⟩ := exists_pair_trace_repr f
+  have hΔ : ΔA = 0 ∧ ΔB = 0 := by
+    refine hSep ΔA ΔB ?_
+    intro w
+    have hwmem : pairEvalWordTuple A B w ∈ W :=
+      Submodule.subset_span ⟨w, rfl⟩
+    have hf0 : f (pairEvalWordTuple A B w) = 0 := hfker hwmem
+    simpa [pairEvalWordTuple, hf_repr] using hf0
+  have hfzero : f = 0 := by
+    apply LinearMap.ext
+    intro M
+    have hM := hf_repr M
+    rw [hΔ.1, hΔ.2] at hM
+    simpa using hM
+  exact hfne hfzero
+
+/-- The span of all finite pair words gives trace separation by all finite pair words. -/
+theorem pairTraceSeparatingAll_of_pairAllWordsSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSpan : PairAllWordsSpanTop A B) :
+    PairTraceSeparatingAll A B := by
+  classical
+  intro ΔA ΔB hΔ
+  have hZeroOnSpan :
+      ∀ M : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ,
+        M ∈ pairAllWordsSpan A B →
+          Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) = 0 := by
+    intro M hM
+    induction hM using Submodule.span_induction with
+    | mem M hMmem =>
+        rcases hMmem with ⟨w, rfl⟩
+        exact hΔ w
+    | zero => simp
+    | add M N _ _ hM hN =>
+        calc
+          Matrix.trace (ΔA * (M + N).1) + Matrix.trace (ΔB * (M + N).2)
+              = (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) +
+                  (Matrix.trace (ΔA * N.1) + Matrix.trace (ΔB * N.2)) := by
+                simp [Matrix.mul_add, Matrix.trace_add, add_assoc, add_left_comm]
+          _ = 0 := by simp [hM, hN]
+    | smul a M _ hM =>
+        calc
+          Matrix.trace (ΔA * (a • M).1) + Matrix.trace (ΔB * (a • M).2)
+              = a * (Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2)) := by
+                simp [Matrix.trace_smul, mul_add]
+          _ = 0 := by simp [hM]
+  constructor
+  · apply trace_mul_right_eq_zero
+    intro M
+    have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
+    simpa using hpair
+  · apply trace_mul_right_eq_zero
+    intro N
+    have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
+    simpa using hpair
+
+/-- All-length trace separation is equivalent to all-word pair product-span. -/
+theorem pairAllWordsSpanTop_iff_pairTraceSeparatingAll {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
+    PairAllWordsSpanTop A B ↔ PairTraceSeparatingAll A B :=
+  ⟨pairTraceSeparatingAll_of_pairAllWordsSpanTop A B,
+    pairAllWordsSpanTop_of_pairTraceSeparatingAll A B⟩
+
+/-- If all pair words span the product algebra, then words up to some finite cutoff already span. -/
+theorem exists_pairCumulativeWordTupleSpanTop_of_pairAllWordsSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSpan : PairAllWordsSpanTop A B) :
+    ∃ S : ℕ, PairCumulativeWordTupleSpanTop A B S := by
+  classical
+  let V := Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ
+  have hx : ∀ x : V, ∃ S : ℕ, x ∈ pairCumulativeSpan A B S := by
+    intro x
+    have hxAll : x ∈ pairAllWordsSpan A B := by
+      rw [hSpan]
+      exact Submodule.mem_top
+    induction hxAll using Submodule.span_induction with
+    | mem y hy =>
+        rcases hy with ⟨w, rfl⟩
+        exact ⟨w.length, pairEvalWordTuple_mem_pairCumulativeSpan A B le_rfl⟩
+    | zero => exact ⟨0, Submodule.zero_mem _⟩
+    | add x y _ _ hx hy =>
+        rcases hx with ⟨Sx, hSx⟩
+        rcases hy with ⟨Sy, hSy⟩
+        refine ⟨max Sx Sy, Submodule.add_mem _ ?_ ?_⟩
+        · exact (pairCumulativeSpan_mono A B (le_max_left Sx Sy)) hSx
+        · exact (pairCumulativeSpan_mono A B (le_max_right Sx Sy)) hSy
+    | smul a x _ hx =>
+        rcases hx with ⟨Sx, hSx⟩
+        exact ⟨Sx, Submodule.smul_mem _ a hSx⟩
+  haveI : IsNoetherian ℂ V := isNoetherian_of_isNoetherianRing_of_finite ℂ V
+  let f : ℕ →o Submodule ℂ V :=
+    ⟨fun S => pairCumulativeSpan A B S, fun _ _ hST => pairCumulativeSpan_mono A B hST⟩
+  obtain ⟨S₀, hstab⟩ := (monotone_stabilizes_iff_noetherian.mpr ‹IsNoetherian ℂ V›) f
+  refine ⟨S₀, eq_top_iff.mpr ?_⟩
+  intro x _
+  rcases hx x with ⟨S, hS⟩
+  rcases le_total S S₀ with hSS₀ | hS₀S
+  · exact (pairCumulativeSpan_mono A B hSS₀) hS
+  · have heq : pairCumulativeSpan A B S = pairCumulativeSpan A B S₀ :=
+      (hstab S hS₀S).symm
+    simpa [heq] using hS
+
+/-- If no nonzero trace functional vanishes on all pair words, then a finite cumulative
+cutoff already trace-separates the pair. -/
+theorem exists_pairTraceSeparatingUpTo_of_pairTraceSeparatingAll {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSep : PairTraceSeparatingAll A B) :
+    ∃ S : ℕ, PairTraceSeparatingUpTo A B S := by
+  obtain ⟨S, hS⟩ := exists_pairCumulativeWordTupleSpanTop_of_pairAllWordsSpanTop A B
+    (pairAllWordsSpanTop_of_pairTraceSeparatingAll A B hSep)
+  exact ⟨S, pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop A B hS⟩
+
+/-- A finite cumulative cutoff exists exactly when no nonzero trace functional
+vanishes on all finite pair words. -/
+theorem exists_pairTraceSeparatingUpTo_iff_pairTraceSeparatingAll {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
+    (∃ S : ℕ, PairTraceSeparatingUpTo A B S) ↔ PairTraceSeparatingAll A B := by
+  constructor
+  · rintro ⟨S, hS⟩ ΔA ΔB hΔ
+    exact hS ΔA ΔB (fun w _hw => hΔ w)
+  · exact exists_pairTraceSeparatingUpTo_of_pairTraceSeparatingAll A B
+
+/-- A finite family of all-length pair trace-separation hypotheses admits one common
+cumulative cutoff. -/
+theorem exists_forall_pairTraceSeparatingUpTo_of_forall_pairTraceSeparatingAll
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAll (A k) (A j)) :
+    ∃ S : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingUpTo (A k) (A j) S := by
+  classical
+  let Sij : Fin r × Fin r → ℕ := fun p =>
+    if h : p.2 ≠ p.1 then
+      Classical.choose (exists_pairTraceSeparatingUpTo_of_pairTraceSeparatingAll
+        (A p.1) (A p.2) (hSep p.1 p.2 h))
+    else 0
+  let S : ℕ := Finset.univ.sup Sij
+  refine ⟨S, ?_⟩
+  intro k j hjk
+  have hbase : PairTraceSeparatingUpTo (A k) (A j) (Sij (k, j)) := by
+    simpa [Sij, hjk] using
+      (Classical.choose_spec (exists_pairTraceSeparatingUpTo_of_pairTraceSeparatingAll
+        (A k) (A j) (hSep k j hjk)))
+  have hle : Sij (k, j) ≤ S := by
+    exact Finset.le_sup (s := Finset.univ) (f := Sij) (Finset.mem_univ (k, j))
+  exact hbase.mono hle
 
 /-- Pair product-span at length `S` gives a length-`S` selector for the first
 block of the pair. -/

--- a/audits/2026-04-28_issue966_pair_trace_finite_cutoff.md
+++ b/audits/2026-04-28_issue966_pair_trace_finite_cutoff.md
@@ -1,0 +1,117 @@
+# Issue #966 — finite cumulative pair trace-separation step (2026-04-28)
+
+## Scope
+
+Issue #966 asks for the finite homogeneous pair trace-separation length
+
+```lean
+IsCanonicalFormBNT μ A →
+  ∃ S, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S
+```
+
+from the BNT non-equivalence data.  The full homogeneous statement is still open.
+This pass proves the finite-dimensional compactness part for the cumulative version:
+if no nonzero trace functional annihilates all finite pair words, then a finite
+cutoff already detects every nonzero test pair.
+
+## Checked Lean progress
+
+File: `TNLean/MPS/MPDO/BiCFDerivation.lean`
+
+New public declarations:
+
+- `MPSTensor.pairEvalWordTuple`
+  - The pair word tuple `(A^w, B^w)` for an arbitrary finite word `w`.
+
+- `MPSTensor.pairCumulativeSpan`
+- `MPSTensor.PairCumulativeWordTupleSpanTop`
+  - The span of pair word tuples of length at most `S`, and the assertion that this span is the
+    whole product matrix algebra.
+
+- `MPSTensor.PairTraceSeparatingUpTo`
+  - Cumulative trace separation up to length `S`.
+
+- `MPSTensor.PairTraceSeparatingAll`
+- `MPSTensor.pairAllWordsSpan`
+- `MPSTensor.PairAllWordsSpanTop`
+  - All-length trace separation and its span formulation.
+
+- `MPSTensor.pairEvalWordTuple_mem_pairCumulativeSpan`
+- `MPSTensor.pairCumulativeSpan_mono`
+- `MPSTensor.PairTraceSeparatingUpTo.mono`
+- `MPSTensor.pairTraceSeparatingUpTo_of_pairTraceSeparatingAt`
+  - Basic membership, monotonicity, and the implication from homogeneous to cumulative separation.
+
+- `MPSTensor.pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo`
+- `MPSTensor.pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop`
+- `MPSTensor.pairCumulativeWordTupleSpanTop_iff_pairTraceSeparatingUpTo`
+  - Finite cumulative trace duality, using the matrix trace pairing.
+
+- `MPSTensor.pairCumulativeWordTupleSpanTop_of_pairWordTupleSpanTop`
+- `MPSTensor.pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingAt`
+  - Homogeneous pair span or homogeneous trace separation implies the cumulative span statement at
+    the same bound.
+
+- `MPSTensor.pairAllWordsSpanTop_of_pairTraceSeparatingAll`
+- `MPSTensor.pairTraceSeparatingAll_of_pairAllWordsSpanTop`
+- `MPSTensor.pairAllWordsSpanTop_iff_pairTraceSeparatingAll`
+  - All-length trace duality.
+
+- `MPSTensor.exists_pairCumulativeWordTupleSpanTop_of_pairAllWordsSpanTop`
+  - Finite-dimensional stabilization: if all finite pair words span the product algebra, then words
+    up to some finite length already span.  The proof uses Noetherian stabilization of the increasing
+    sequence of cumulative spans.
+
+- `MPSTensor.exists_pairTraceSeparatingUpTo_of_pairTraceSeparatingAll`
+- `MPSTensor.exists_pairTraceSeparatingUpTo_iff_pairTraceSeparatingAll`
+- `MPSTensor.exists_forall_pairTraceSeparatingUpTo_of_forall_pairTraceSeparatingAll`
+  - If all finite words trace-separate a pair, then some finite cumulative cutoff trace-separates it;
+    for finitely many ordered block pairs, one may take a common cutoff.
+
+Blueprint Chapter 14 now records the cumulative/all-length variants in
+`def:pair_trace_separation_words` and adds
+`lem:all_length_pair_trace_separation_finite_cutoff`.
+
+## Remaining mathematical blocker
+
+The new theorem closes the finite-dimensional stabilization for cumulative spans,
+not the homogeneous word-length assertion used by the Route B selector construction.
+To finish issue #966 one still needs a BNT/Burnside-Jacobson argument proving either:
+
+1. the exact homogeneous statement `PairTraceSeparatingAt (A k) (A j) S` at one common length, or
+2. an additional homogenization theorem that converts the finite cumulative cutoff supplied here into
+   such a homogeneous length under the paper's normal-block hypotheses.
+
+The expected paper path remains the one identified in the issue: BNT non-equivalence rules out a
+nonzero trace functional surviving on all pair words; finite-dimensionality then supplies a finite
+bound.  This PR formalizes the second sentence for the cumulative version.
+
+## Source anchors
+
+- `Papers/2011.12127/TN-Review-main.tex` lines 2115--2116 define block-injective canonical form by
+  access to every element of the direct-sum block algebra.
+- `Papers/2011.12127/TN-Review-main.tex` lines 2123--2128 state the parent-Hamiltonian BNT
+  ground-space result after blocking and the block-diagonal boundary improvement.
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 320--326 give the MPDO/biCF pair-separation
+  analogue with the selector factor `δ_{j,j'}`; lines 340--344 cite the finite blocking theorem
+  producing biCF.
+
+## Validation
+
+Local checks on branch `issue966-bnt-density`:
+
+- `lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
+- `lake build TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
+  - The first combined build timed out after completing `BiCFDerivation`; the immediate continuation
+    built `BlockDiagonalCommutant` successfully.
+- `lake build TNLean`
+  - Before the final rebase, several continuations were needed because of the command timeout.  After
+    rebasing onto current `origin/main`, the command completed successfully in one run.  Warnings were
+    pre-existing `sorry` and line-length warnings in unrelated modules.
+- `cd blueprint && leanblueprint web`
+  - The normal run hit the existing local TikZ path-with-spaces problem in the SVG renderer.  Rerun
+    with LaTeX hidden from `PATH` so the renderer emitted placeholder SVG messages; the web build then
+    succeeded.
+- `cd blueprint && leanblueprint checkdecls`
+- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
+- `python3 scripts/blueprint_lean_sync.py --root . --ci`

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2891,13 +2891,60 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.pairWordTuple}
     \lean{MPSTensor.PairWordTupleSpanTop}
     \lean{MPSTensor.PairTraceSeparatingAt}
+    \lean{MPSTensor.pairEvalWordTuple}
+    \lean{MPSTensor.pairCumulativeSpan}
+    \lean{MPSTensor.PairCumulativeWordTupleSpanTop}
+    \lean{MPSTensor.PairTraceSeparatingUpTo}
+    \lean{MPSTensor.PairTraceSeparatingAll}
+    \lean{MPSTensor.pairAllWordsSpan}
+    \lean{MPSTensor.PairAllWordsSpanTop}
     \leanok
     For two blocks $A$ and $B$, the length-$S$ pair word tuple is
     $w \mapsto (A^w,B^w)$.  The pair product-span condition says that these
     tuples span $\MN{D_A}\times\MN{D_B}$.  Equivalently, in the trace-dual
     formulation, the only pair of test matrices $(\Delta_A,\Delta_B)$ whose
-    trace pairing with every length-$S$ tuple vanishes is $(0,0)$.
+    trace pairing with every length-$S$ tuple vanishes is $(0,0)$.  The
+    cumulative variant replaces one fixed length by all word lengths at most
+    $S$, and the all-length variant allows every finite word.
 \end{definition}
+
+\begin{lemma}[All-length pair trace separation has finite cumulative length]
+    \label{lem:all_length_pair_trace_separation_finite_cutoff}
+    \lean{MPSTensor.pairEvalWordTuple_mem_pairCumulativeSpan}
+    \lean{MPSTensor.pairCumulativeSpan_mono}
+    \lean{MPSTensor.PairTraceSeparatingUpTo.mono}
+    \lean{MPSTensor.pairTraceSeparatingUpTo_of_pairTraceSeparatingAt}
+    \lean{MPSTensor.pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo}
+    \lean{MPSTensor.pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop}
+    \lean{MPSTensor.pairCumulativeWordTupleSpanTop_iff_pairTraceSeparatingUpTo}
+    \lean{MPSTensor.pairCumulativeWordTupleSpanTop_of_pairWordTupleSpanTop}
+    \lean{MPSTensor.pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingAt}
+    \lean{MPSTensor.pairAllWordsSpanTop_of_pairTraceSeparatingAll}
+    \lean{MPSTensor.pairTraceSeparatingAll_of_pairAllWordsSpanTop}
+    \lean{MPSTensor.pairAllWordsSpanTop_iff_pairTraceSeparatingAll}
+    \lean{MPSTensor.exists_pairCumulativeWordTupleSpanTop_of_pairAllWordsSpanTop}
+    \lean{MPSTensor.exists_pairTraceSeparatingUpTo_of_pairTraceSeparatingAll}
+    \lean{MPSTensor.exists_pairTraceSeparatingUpTo_iff_pairTraceSeparatingAll}
+    \lean{MPSTensor.exists_forall_pairTraceSeparatingUpTo_of_forall_pairTraceSeparatingAll}
+    \leanok
+    \uses{def:pair_trace_separation_words}
+    If no nonzero trace functional vanishes on all finite pair words, then
+    there is a finite $S$ such that vanishing on every word of length at most
+    $S$ already forces the test pair to be zero.  For a finite family of ordered
+    block pairs, these bounds can be replaced by one common bound.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The trace condition is dual to the span of all finite pair words.  If that
+    span is the whole product algebra, every vector lies in some cumulative
+    span.  Since the product algebra is finite-dimensional, the increasing
+    sequence of cumulative spans stabilizes; at the stabilization index it is
+    already the whole product algebra.  Applying the finite trace-duality
+    criterion gives the stated finite bound.  This proves the cumulative
+    finite-dimensional step; the remaining BNT step is to convert it to a
+    single homogeneous length.
+\end{proof}
 
 \begin{lemma}[Pair trace separation gives pairwise selectors]
     \label{lem:pair_trace_separation_to_pairwise_selectors}


### PR DESCRIPTION
## Summary

- Adds cumulative and all-length pair word-span/trace-separation predicates for two blocks.
- Proves the finite-dimensional duality chain: cumulative trace separation iff cumulative pair product-span, all-length trace separation iff all-word pair product-span, and all-length trace separation admits a finite cumulative cutoff by Noetherian stabilization.
- Extends the common-pair finite cutoff to all ordered block pairs and records the remaining homogeneous BNT/Burnside-Jacobson step in the blueprint/audit.

This advances #966. It does not close #966: the exact homogeneous `PairTraceSeparatingAt` length from BNT non-equivalence remains open, as does a homogenization theorem from the cumulative cutoff under normal-block hypotheses.

## Validation

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`
- `lake build TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `lake build TNLean` (warnings are pre-existing `sorry`/line-length warnings in unrelated modules)
- `cd blueprint && leanblueprint web` (normal run hits the existing local TikZ path-with-spaces issue; rerun with LaTeX hidden from `PATH` succeeded with placeholder SVG messages)
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lean diagnostics clean for `TNLean/MPS/MPDO/BiCFDerivation.lean` and `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
- `git diff --check origin/main...HEAD`
- Added-line proof-integrity scan over Lean diff (`sorry`/`admit`/`axiom`/`unsafe`/`native_decide`) clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive Lean definitions/proofs and documentation updates; risk is limited to potential proof-maintenance/compile-time fallout from new Noetherian-based lemmas.
> 
> **Overview**
> Extends `BiCFDerivation.lean` with **cumulative** and **all-length** variants of pair word evaluation/span and trace-separation (e.g. `PairTraceSeparatingUpTo`, `PairTraceSeparatingAll`) and proves the expected dualities between these trace predicates and corresponding span-top statements.
> 
> Adds a finite-dimensional stabilization result (using Noetherianity) showing that if *all* pair words span/trace-separate, then some **finite cutoff** already suffices, and lifts this to a uniform cutoff across finitely many ordered block pairs. The blueprint and an audit note are updated to document the new definitions/lemma and the remaining open step (recovering the *homogeneous* fixed-length separation `PairTraceSeparatingAt`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e446d4df3d54876112aebecc52aee7d311fdb823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->