### PR TITLE
feat(MPS/CanonicalForm): assemble common cyclic-sector blocking (#969)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1202,8 +1202,8 @@ end CommonBlockedCyclicSectorFamily
 admits one common physical blocking length for all those sectors.
 
 This theorem chooses the least common multiple of the per-live-block period-removal
-lengths.  Each cyclic sector is then blocked by the corresponding quotient, cast
-to the common physical alphabet `blockPhysDim d p`, and collected into one finite
+lengths.  Each cyclic sector is then blocked by the corresponding quotient,
+identified with the common physical alphabet, and collected into one finite
 flattened family.  Trace preservation, primitive transfer maps, tensor
 irreducibility, positive bond dimensions, nonzero unit weights, and the per-block
 iterated-blocking MPV compatibility conditions are all retained. -/

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1106,8 +1106,8 @@ flattened family `flatBlocks` is indexed by the finite type
 `Fin (∑ k, period k)`, using `finSigmaFinEquiv` to identify an index with an
 original live block and one of its cyclic sectors.
 
-The field `nested_same` records the checked MPV interface that is available at
-this stage: the iterated blocked live block is MPV-equivalent to the corresponding
+The field `nested_same` records the checked MPV compatibility condition available
+at this stage: the iterated blocked live block is MPV-equivalent to the corresponding
 unit-weight reblocked cyclic sectors, all at the common physical dimension.  The
 remaining work for issue #969 is the one-shot iterated-blocking identification
 and the weighted direct-sum flattening across the original live-block weights. -/
@@ -1166,7 +1166,8 @@ structure CommonBlockedCyclicSectorFamily {d r : ℕ} {dim : Fin r → ℕ}
   flat_irreducible : ∀ x, IsIrreducibleTensor (flatBlocks x)
   /-- Flattened common-alphabet sectors have positive bond dimensions. -/
   flat_dim_pos : ∀ x, 0 < flatDim x
-  /-- The checked MPV interface for each original live block after later reblocking. -/
+  /-- The checked MPV compatibility condition for each original live block
+  after later reblocking. -/
   nested_same : ∀ k,
     SameMPV₂
       (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (blockPhysDim_nested_eq k))
@@ -1182,7 +1183,7 @@ structure CommonBlockedCyclicSectorFamily {d r : ℕ} {dim : Fin r → ℕ}
 namespace CommonBlockedCyclicSectorFamily
 
 /-- The flattened sectors produced by `CommonBlockedCyclicSectorFamily` carry unit weights. -/
-noncomputable def flatWeight {d r : ℕ} {dim : Fin r → ℕ}
+def flatWeight {d r : ℕ} {dim : Fin r → ℕ}
     {blocks : (k : Fin r) → MPSTensor d (dim k)}
     (F : CommonBlockedCyclicSectorFamily blocks) :
     Fin (∑ k : Fin r, F.period k) → ℂ :=
@@ -1205,7 +1206,7 @@ lengths.  Each cyclic sector is then blocked by the corresponding quotient, cast
 to the common physical alphabet `blockPhysDim d p`, and collected into one finite
 flattened family.  Trace preservation, primitive transfer maps, tensor
 irreducibility, positive bond dimensions, nonzero unit weights, and the per-block
-iterated-blocking MPV interfaces are all retained. -/
+iterated-blocking MPV compatibility conditions are all retained. -/
 theorem exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors
     {d r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1097,6 +1097,289 @@ theorem hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor
     exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
       (d := d) (D := D) A hTP hIrr
 
+/-- Common reblocking data for the cyclic sectors of a finite live-block family.
+
+For each original live block, `period k` is the period-removal length produced by
+cyclic-sector decomposition, while `extra k` is the later positive blocking length
+that moves all sectors to the single physical alphabet `blockPhysDim d p`.  The
+flattened family `flatBlocks` is indexed by the finite type
+`Fin (∑ k, period k)`, using `finSigmaFinEquiv` to identify an index with an
+original live block and one of its cyclic sectors.
+
+The field `nested_same` records the checked MPV interface that is available at
+this stage: the iterated blocked live block is MPV-equivalent to the corresponding
+unit-weight reblocked cyclic sectors, all at the common physical dimension.  The
+remaining work for issue #969 is the one-shot iterated-blocking identification
+and the weighted direct-sum flattening across the original live-block weights. -/
+structure CommonBlockedCyclicSectorFamily {d r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) where
+  /-- The common physical blocking length. -/
+  p : ℕ
+  /-- The common physical blocking length is positive. -/
+  p_pos : 0 < p
+  /-- The period-removal length of each original live block. -/
+  period : Fin r → ℕ
+  /-- Every period-removal length is positive. -/
+  period_pos : ∀ k, 0 < period k
+  /-- The later reblocking length applied after period removal. -/
+  extra : Fin r → ℕ
+  /-- Every later reblocking length is positive. -/
+  extra_pos : ∀ k, 0 < extra k
+  /-- The common length factors as period removal followed by later reblocking. -/
+  p_eq_period_mul_extra : ∀ k, p = period k * extra k
+  /-- Bond dimensions of the cyclic sector blocks before later reblocking. -/
+  sectorDim : (k : Fin r) → Fin (period k) → ℕ
+  /-- Cyclic sector blocks before later reblocking. -/
+  sectorBlocks : (k : Fin r) → (s : Fin (period k)) →
+    MPSTensor (blockPhysDim d (period k)) (sectorDim k s)
+  /-- The sector blocks are trace-preserving before later reblocking. -/
+  sector_tp : ∀ k s,
+    ∑ i : Fin (blockPhysDim d (period k)), (sectorBlocks k s i)ᴴ * sectorBlocks k s i = 1
+  /-- Each period-blocked live block is represented by its unit-weight cyclic sectors. -/
+  sector_same : ∀ k,
+    SameMPV₂ (blockTensor (d := d) (D := dim k) (blocks k) (period k))
+      (toTensorFromBlocks (d := blockPhysDim d (period k))
+        (μ := fun _ : Fin (period k) => (1 : ℂ)) (sectorBlocks k))
+  /-- The sector transfer maps are primitive before later reblocking. -/
+  sector_primitive : ∀ k s,
+    _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d (period k)) (D := sectorDim k s)
+        (sectorBlocks k s))
+  /-- The sector blocks are tensor-irreducible before later reblocking. -/
+  sector_irreducible : ∀ k s, IsIrreducibleTensor (sectorBlocks k s)
+  /-- The sector bond dimensions are positive before later reblocking. -/
+  sector_dim_pos : ∀ k s, 0 < sectorDim k s
+  /-- The iterated blocked physical alphabet is propositionally the common alphabet. -/
+  blockPhysDim_nested_eq : ∀ k,
+    blockPhysDim (blockPhysDim d (period k)) (extra k) = blockPhysDim d p
+  /-- Bond dimensions of the flattened common-alphabet sector family. -/
+  flatDim : Fin (∑ k : Fin r, period k) → ℕ
+  /-- The flattened common-alphabet sector family. -/
+  flatBlocks : (x : Fin (∑ k : Fin r, period k)) → MPSTensor (blockPhysDim d p) (flatDim x)
+  /-- Flattened common-alphabet sectors are trace-preserving. -/
+  flat_tp : ∀ x,
+    ∑ i : Fin (blockPhysDim d p), (flatBlocks x i)ᴴ * flatBlocks x i = 1
+  /-- Flattened common-alphabet sectors have primitive transfer maps. -/
+  flat_primitive : ∀ x,
+    _root_.IsPrimitive (transferMap (d := blockPhysDim d p) (D := flatDim x) (flatBlocks x))
+  /-- Flattened common-alphabet sectors are tensor-irreducible. -/
+  flat_irreducible : ∀ x, IsIrreducibleTensor (flatBlocks x)
+  /-- Flattened common-alphabet sectors have positive bond dimensions. -/
+  flat_dim_pos : ∀ x, 0 < flatDim x
+  /-- The checked MPV interface for each original live block after later reblocking. -/
+  nested_same : ∀ k,
+    SameMPV₂
+      (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (blockPhysDim_nested_eq k))
+        (blockTensor (d := blockPhysDim d (period k)) (D := dim k)
+          (blockTensor (d := d) (D := dim k) (blocks k) (period k)) (extra k)))
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := fun _ : Fin (period k) => (1 : ℂ))
+        (fun s => cast
+          (congr_arg (fun d' => MPSTensor d' (sectorDim k s)) (blockPhysDim_nested_eq k))
+          (blockTensor (d := blockPhysDim d (period k)) (D := sectorDim k s)
+            (sectorBlocks k s) (extra k))))
+
+namespace CommonBlockedCyclicSectorFamily
+
+/-- The flattened sectors produced by `CommonBlockedCyclicSectorFamily` carry unit weights. -/
+noncomputable def flatWeight {d r : ℕ} {dim : Fin r → ℕ}
+    {blocks : (k : Fin r) → MPSTensor d (dim k)}
+    (F : CommonBlockedCyclicSectorFamily blocks) :
+    Fin (∑ k : Fin r, F.period k) → ℂ :=
+  fun _ => 1
+
+/-- The unit weights of the flattened common-alphabet sectors are nonzero. -/
+theorem flatWeight_ne_zero {d r : ℕ} {dim : Fin r → ℕ}
+    {blocks : (k : Fin r) → MPSTensor d (dim k)}
+    (F : CommonBlockedCyclicSectorFamily blocks) (x : Fin (∑ k : Fin r, F.period k)) :
+    F.flatWeight x ≠ 0 := by
+  simp [flatWeight]
+
+end CommonBlockedCyclicSectorFamily
+
+/-- A finite family of live blocks with per-block primitive irreducible cyclic sectors
+admits one common physical blocking length for all those sectors.
+
+This theorem chooses the least common multiple of the per-live-block period-removal
+lengths.  Each cyclic sector is then blocked by the corresponding quotient, cast
+to the common physical alphabet `blockPhysDim d p`, and collected into one finite
+flattened family.  Trace preservation, primitive transfer maps, tensor
+irreducibility, positive bond dimensions, nonzero unit weights, and the per-block
+iterated-blocking MPV interfaces are all retained. -/
+theorem exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors
+    {d r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hcyc : ∀ k, HasPrimitiveIrreducibleCyclicSectors (blocks k)) :
+    Nonempty (CommonBlockedCyclicSectorFamily blocks) := by
+  classical
+  let period : Fin r → ℕ := fun k => (hcyc k).choose
+  have period_pos : ∀ k, 0 < period k := fun k => (hcyc k).choose_spec.1
+  let sectorDim : (k : Fin r) → Fin (period k) → ℕ :=
+    fun k => (hcyc k).choose_spec.2.choose
+  let sectorBlocks : (k : Fin r) → (s : Fin (period k)) →
+      MPSTensor (blockPhysDim d (period k)) (sectorDim k s) :=
+    fun k => (hcyc k).choose_spec.2.choose_spec.choose
+  have hSector : ∀ k,
+      (∀ s, ∑ i : Fin (blockPhysDim d (period k)),
+        (sectorBlocks k s i)ᴴ * sectorBlocks k s i = 1) ∧
+      SameMPV₂ (blockTensor (d := d) (D := dim k) (blocks k) (period k))
+        (toTensorFromBlocks (d := blockPhysDim d (period k))
+          (μ := fun _ : Fin (period k) => (1 : ℂ)) (sectorBlocks k)) ∧
+      (∀ s, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d (period k)) (D := sectorDim k s)
+          (sectorBlocks k s))) ∧
+      (∀ s, IsIrreducibleTensor (sectorBlocks k s)) ∧
+      (∀ s, 0 < sectorDim k s) := by
+    intro k
+    exact (hcyc k).choose_spec.2.choose_spec.choose_spec
+  have sector_tp : ∀ k s,
+      ∑ i : Fin (blockPhysDim d (period k)),
+        (sectorBlocks k s i)ᴴ * sectorBlocks k s i = 1 := fun k => (hSector k).1
+  have sector_same : ∀ k,
+      SameMPV₂ (blockTensor (d := d) (D := dim k) (blocks k) (period k))
+        (toTensorFromBlocks (d := blockPhysDim d (period k))
+          (μ := fun _ : Fin (period k) => (1 : ℂ)) (sectorBlocks k)) :=
+    fun k => (hSector k).2.1
+  have sector_primitive : ∀ k s,
+      _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d (period k)) (D := sectorDim k s)
+          (sectorBlocks k s)) := fun k => (hSector k).2.2.1
+  have sector_irreducible : ∀ k s, IsIrreducibleTensor (sectorBlocks k s) :=
+    fun k => (hSector k).2.2.2.1
+  have sector_dim_pos : ∀ k s, 0 < sectorDim k s :=
+    fun k => (hSector k).2.2.2.2
+  let p := lcmPeriod period
+  have p_pos : 0 < p := lcmPeriod_pos period_pos
+  let extra : Fin r → ℕ := fun k => (dvd_lcmPeriod period k).choose
+  have p_eq_period_mul_extra : ∀ k, p = period k * extra k :=
+    fun k => (dvd_lcmPeriod period k).choose_spec
+  have extra_pos : ∀ k, 0 < extra k := by
+    intro k
+    have hmul_pos : 0 < period k * extra k := by
+      simpa [p_eq_period_mul_extra k] using p_pos
+    exact Nat.pos_of_mul_pos_left hmul_pos
+  have hPhys : ∀ k,
+      blockPhysDim (blockPhysDim d (period k)) (extra k) = blockPhysDim d p := by
+    intro k
+    simpa [p_eq_period_mul_extra k] using
+      (blockPhysDim_blockPhysDim d (period k) (extra k))
+  let flatKey : Fin (∑ k : Fin r, period k) → ((k : Fin r) × Fin (period k)) :=
+    fun x => finSigmaFinEquiv.symm x
+  let flatDim : Fin (∑ k : Fin r, period k) → ℕ :=
+    fun x => sectorDim (flatKey x).1 (flatKey x).2
+  let flatBlocks : (x : Fin (∑ k : Fin r, period k)) →
+      MPSTensor (blockPhysDim d p) (flatDim x) := fun x =>
+    let y := flatKey x
+    show MPSTensor (blockPhysDim d p) (sectorDim y.1 y.2) from
+      cast (congr_arg (fun d' => MPSTensor d' (sectorDim y.1 y.2)) (hPhys y.1))
+        (blockTensor (d := blockPhysDim d (period y.1)) (D := sectorDim y.1 y.2)
+          (sectorBlocks y.1 y.2) (extra y.1))
+  have hExtra : ∀ k s,
+      (∑ i : Fin (blockPhysDim (blockPhysDim d (period k)) (extra k)),
+        (blockTensor (d := blockPhysDim d (period k)) (D := sectorDim k s)
+          (sectorBlocks k s) (extra k) i)ᴴ *
+          blockTensor (d := blockPhysDim d (period k)) (D := sectorDim k s)
+            (sectorBlocks k s) (extra k) i = 1) ∧
+      _root_.IsPrimitive
+        (transferMap (d := blockPhysDim (blockPhysDim d (period k)) (extra k))
+          (D := sectorDim k s)
+          (blockTensor (d := blockPhysDim d (period k)) (D := sectorDim k s)
+            (sectorBlocks k s) (extra k))) ∧
+      IsIrreducibleTensor
+        (blockTensor (d := blockPhysDim d (period k)) (D := sectorDim k s)
+          (sectorBlocks k s) (extra k)) := by
+    intro k s
+    haveI : NeZero (sectorDim k s) := ⟨Nat.ne_of_gt (sector_dim_pos k s)⟩
+    exact tp_primitive_irreducible_extra_blocking
+      (d := blockPhysDim d (period k)) (D := sectorDim k s)
+      (A := sectorBlocks k s) (sector_tp k s) (sector_primitive k s)
+      (sector_irreducible k s) (hk := extra_pos k)
+  have flat_tp : ∀ x,
+      ∑ i : Fin (blockPhysDim d p), (flatBlocks x i)ᴴ * flatBlocks x i = 1 := by
+    intro x
+    let y := flatKey x
+    have hcast := (leftCanonical_cast_physDim (hPhys y.1)
+      (A := blockTensor (d := blockPhysDim d (period y.1)) (D := sectorDim y.1 y.2)
+        (sectorBlocks y.1 y.2) (extra y.1))).2 (hExtra y.1 y.2).1
+    simpa [flatBlocks, y] using hcast
+  have flat_primitive : ∀ x,
+      _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := flatDim x) (flatBlocks x)) := by
+    intro x
+    let y := flatKey x
+    have hcast := (isPrimitive_transferMap_cast_physDim (hPhys y.1)
+      (A := blockTensor (d := blockPhysDim d (period y.1)) (D := sectorDim y.1 y.2)
+        (sectorBlocks y.1 y.2) (extra y.1))).2 (hExtra y.1 y.2).2.1
+    simpa [flatBlocks, flatDim, y] using hcast
+  have flat_irreducible : ∀ x, IsIrreducibleTensor (flatBlocks x) := by
+    intro x
+    let y := flatKey x
+    have hcast := (isIrreducibleTensor_cast_physDim (hPhys y.1)
+      (A := blockTensor (d := blockPhysDim d (period y.1)) (D := sectorDim y.1 y.2)
+        (sectorBlocks y.1 y.2) (extra y.1))).2 (hExtra y.1 y.2).2.2
+    simpa [flatBlocks, y] using hcast
+  have flat_dim_pos : ∀ x, 0 < flatDim x := by
+    intro x
+    let y := flatKey x
+    simpa [flatDim, y] using sector_dim_pos y.1 y.2
+  have nested_same : ∀ k,
+      SameMPV₂
+        (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (hPhys k))
+          (blockTensor (d := blockPhysDim d (period k)) (D := dim k)
+            (blockTensor (d := d) (D := dim k) (blocks k) (period k)) (extra k)))
+        (toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := fun _ : Fin (period k) => (1 : ℂ))
+          (fun s => cast
+            (congr_arg (fun d' => MPSTensor d' (sectorDim k s)) (hPhys k))
+            (blockTensor (d := blockPhysDim d (period k)) (D := sectorDim k s)
+              (sectorBlocks k s) (extra k)))) := by
+    intro k
+    have hNested : SameMPV₂
+        (blockTensor (d := blockPhysDim d (period k)) (D := dim k)
+          (blockTensor (d := d) (D := dim k) (blocks k) (period k)) (extra k))
+        (toTensorFromBlocks (d := blockPhysDim (blockPhysDim d (period k)) (extra k))
+          (μ := fun _ : Fin (period k) => (1 : ℂ))
+          (fun s => blockTensor (d := blockPhysDim d (period k)) (D := sectorDim k s)
+            (sectorBlocks k s) (extra k))) := by
+      simpa using
+        (sameMPV₂_blockTensor_of_sameMPV₂_toTensorFromBlocks
+          (d := blockPhysDim d (period k)) (D := dim k)
+          (A := blockTensor (d := d) (D := dim k) (blocks k) (period k))
+          (μ := fun _ : Fin (period k) => (1 : ℂ))
+          (blocks := sectorBlocks k) (hSame := sector_same k) (p := extra k))
+    have hCast := (sameMPV₂_cast_physDim (hPhys k)
+      (A := blockTensor (d := blockPhysDim d (period k)) (D := dim k)
+        (blockTensor (d := d) (D := dim k) (blocks k) (period k)) (extra k))
+      (B := toTensorFromBlocks (d := blockPhysDim (blockPhysDim d (period k)) (extra k))
+        (μ := fun _ : Fin (period k) => (1 : ℂ))
+        (fun s => blockTensor (d := blockPhysDim d (period k)) (D := sectorDim k s)
+          (sectorBlocks k s) (extra k)))).2 hNested
+    rw [toTensorFromBlocks_cast_physDim (h := hPhys k)] at hCast
+    simpa using hCast
+  exact ⟨{
+    p := p
+    p_pos := p_pos
+    period := period
+    period_pos := period_pos
+    extra := extra
+    extra_pos := extra_pos
+    p_eq_period_mul_extra := p_eq_period_mul_extra
+    sectorDim := sectorDim
+    sectorBlocks := sectorBlocks
+    sector_tp := sector_tp
+    sector_same := sector_same
+    sector_primitive := sector_primitive
+    sector_irreducible := sector_irreducible
+    sector_dim_pos := sector_dim_pos
+    blockPhysDim_nested_eq := hPhys
+    flatDim := flatDim
+    flatBlocks := flatBlocks
+    flat_tp := flat_tp
+    flat_primitive := flat_primitive
+    flat_irreducible := flat_irreducible
+    flat_dim_pos := flat_dim_pos
+    nested_same := nested_same }⟩
+
 end SectorOrbitLift
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -468,11 +468,12 @@ theorem fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTai
 /-- **Common-blocking predecessor for live cyclic sectors with zero-tail bookkeeping.**
 
 This theorem combines the zero-tail/TP-gauge live-block reduction with the common
-reblocking constructor for per-block cyclic sectors.  It returns the original live
-block families on both sides and, for each side, a finite flattened sector family
-at one common physical dimension `blockPhysDim d F.p`.  The flattened sectors are
-trace-preserving, have primitive transfer maps, are tensor-irreducible, have
-positive bond dimensions, and carry nonzero unit weights.  The statement keeps the
+reblocking constructor for per-block cyclic sectors.  The theorem asserts the
+existence of the original live block families on both sides and, for each side, a
+finite flattened sector family at the corresponding common blocked physical
+dimension.  The flattened sectors are trace-preserving, have primitive transfer
+maps, are tensor-irreducible, have positive bond dimensions, and carry nonzero
+unit weights.  The statement keeps the
 checked zero-tail equations, positive-length live equality, and length-zero
 bookkeeping at the unblocked live-block level; the remaining #969 work is the
 one-shot iterated-blocking identification and weighted direct-sum flattening that

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -465,6 +465,71 @@ theorem fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTai
     exact hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor
       (blocksB k) (hTPB k) (hIrrB k)
 
+/-- **Common-blocking predecessor for live cyclic sectors with zero-tail bookkeeping.**
+
+This theorem combines the zero-tail/TP-gauge live-block reduction with the common
+reblocking constructor for per-block cyclic sectors.  It returns the original live
+block families on both sides and, for each side, a finite flattened sector family
+at one common physical dimension `blockPhysDim d F.p`.  The flattened sectors are
+trace-preserving, have primitive transfer maps, are tensor-irreducible, have
+positive bond dimensions, and carry nonzero unit weights.  The statement keeps the
+checked zero-tail equations, positive-length live equality, and length-zero
+bookkeeping at the unblocked live-block level; the remaining #969 work is the
+one-shot iterated-blocking identification and weighted direct-sum flattening that
+would turn these common-alphabet sector families into exact decompositions of a
+single `blockTensor A p` and `blockTensor B p`. -/
+theorem fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ (zeroTailA : ℕ) (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
+    ∃ (zeroTailB : ℕ) (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (k : Fin rB) → MPSTensor d (dimB k)),
+    ∃ (familyA : CommonBlockedCyclicSectorFamily blocksA),
+    ∃ (familyB : CommonBlockedCyclicSectorFamily blocksB),
+      (∀ k, IsIrreducibleTensor (blocksA k)) ∧
+      (∀ k, IsIrreducibleTensor (blocksB k)) ∧
+      (∀ k, ∑ i : Fin d, (blocksA k i)ᴴ * blocksA k i = 1) ∧
+      (∀ k, ∑ i : Fin d, (blocksB k i)ᴴ * blocksB k i = 1) ∧
+      (∀ k, μA k ≠ 0) ∧
+      (∀ k, μB k ≠ 0) ∧
+      (∀ k, 0 < dimA k) ∧
+      (∀ k, 0 < dimB k) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
+          mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
+          mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) ∧
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := d) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := d) (μ := μB) blocksB) ∧
+      (∀ σ : Fin 0 → Fin d,
+        (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) ∧
+      (∀ x, familyA.flatWeight x ≠ 0) ∧
+      (∀ x, familyB.flatWeight x ≠ 0) := by
+  obtain ⟨zeroTailA, rA, dimA, μA, blocksA,
+      zeroTailB, rB, dimB, μB, blocksB,
+      hIrrA, hIrrB, hTPA, hTPB, hμA, hμB, hDimA, hDimB,
+      hMPVA, hMPVB, hPos, hZero, hCycA, hCycB⟩ :=
+    fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail A B hSame
+  obtain ⟨familyA⟩ :=
+    exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors
+      blocksA hCycA
+  obtain ⟨familyB⟩ :=
+    exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors
+      blocksB hCycB
+  refine ⟨zeroTailA, rA, dimA, μA, blocksA,
+    zeroTailB, rB, dimB, μB, blocksB, familyA, familyB,
+    hIrrA, hIrrB, hTPA, hTPB, hμA, hμB, hDimA, hDimB,
+    hMPVA, hMPVB, hPos, hZero, ?_, ?_⟩
+  · intro x
+    exact familyA.flatWeight_ne_zero x
+  · intro x
+    exact familyB.flatWeight_ne_zero x
+
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 
 Given two tensors with `SameMPV₂`, a common-period BNT sector pair, and a

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -157,9 +157,8 @@ end SameMPV₂Blocking
 ## Physical-dimension casts and iterated blocking dimensions
 
 These auxiliary lemmas keep the later common-blocking statements at a single physical
-alphabet size.  They are all propositional transports: once the two physical
-dimensions are definitionally identified, the tensors and their MPV/transfer-map
-properties are unchanged.
+alphabet size.  Mathematically, they state that substituting equal physical
+dimensions leaves the tensors and their MPV/transfer-map properties unchanged.
 -/
 
 /-- The physical dimension of an iterated blocking is the physical dimension of

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -156,7 +156,7 @@ end SameMPV₂Blocking
 /-!
 ## Physical-dimension casts and iterated blocking dimensions
 
-These helpers keep the later common-blocking statements at a single physical
+These auxiliary lemmas keep the later common-blocking statements at a single physical
 alphabet size.  They are all propositional transports: once the two physical
 dimensions are definitionally identified, the tensors and their MPV/transfer-map
 properties are unchanged.

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -154,6 +154,70 @@ theorem sameMPV₂_blockTensor
 end SameMPV₂Blocking
 
 /-!
+## Physical-dimension casts and iterated blocking dimensions
+
+These helpers keep the later common-blocking statements at a single physical
+alphabet size.  They are all propositional transports: once the two physical
+dimensions are definitionally identified, the tensors and their MPV/transfer-map
+properties are unchanged.
+-/
+
+/-- The physical dimension of an iterated blocking is the physical dimension of
+one-shot blocking by the product length. -/
+theorem blockPhysDim_blockPhysDim (d m n : ℕ) :
+    blockPhysDim (blockPhysDim d m) n = blockPhysDim d (m * n) := by
+  simp [blockPhysDim_eq_pow, pow_mul]
+
+/-- Casting the physical dimension of both tensors preserves heterogeneous MPV equality. -/
+theorem sameMPV₂_cast_physDim {d₁ d₂ D₁ D₂ : ℕ} (h : d₁ = d₂)
+    (A : MPSTensor d₁ D₁) (B : MPSTensor d₁ D₂) :
+    SameMPV₂
+        (cast (congr_arg (fun d' => MPSTensor d' D₁) h) A)
+        (cast (congr_arg (fun d' => MPSTensor d' D₂) h) B) ↔
+      SameMPV₂ A B := by
+  subst h
+  rfl
+
+/-- Casting the physical dimension commutes with the block-diagonal tensor constructor. -/
+theorem toTensorFromBlocks_cast_physDim {d₁ d₂ r : ℕ} {dim : Fin r → ℕ}
+    (h : d₁ = d₂) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d₁ (dim k)) :
+    cast (congr_arg (fun d' => MPSTensor d' (∑ k : Fin r, dim k)) h)
+        (toTensorFromBlocks (d := d₁) (μ := μ) blocks) =
+      toTensorFromBlocks (d := d₂) (μ := μ)
+        (fun k => cast (congr_arg (fun d' => MPSTensor d' (dim k)) h) (blocks k)) := by
+  subst h
+  rfl
+
+/-- Casting the physical dimension preserves trace-preserving normalization. -/
+theorem leftCanonical_cast_physDim {d₁ d₂ D : ℕ} (h : d₁ = d₂)
+    (A : MPSTensor d₁ D) :
+    (∑ i : Fin d₂,
+        (cast (congr_arg (fun d' => MPSTensor d' D) h) A i)ᴴ *
+          cast (congr_arg (fun d' => MPSTensor d' D) h) A i = 1) ↔
+      (∑ i : Fin d₁, (A i)ᴴ * A i = 1) := by
+  subst h
+  simp
+
+/-- Casting the physical dimension preserves transfer-map primitivity. -/
+theorem isPrimitive_transferMap_cast_physDim {d₁ d₂ D : ℕ} (h : d₁ = d₂)
+    (A : MPSTensor d₁ D) :
+    _root_.IsPrimitive
+        (transferMap (d := d₂) (D := D)
+          (cast (congr_arg (fun d' => MPSTensor d' D) h) A)) ↔
+      _root_.IsPrimitive (transferMap (d := d₁) (D := D) A) := by
+  subst h
+  rfl
+
+/-- Casting the physical dimension preserves tensor irreducibility. -/
+theorem isIrreducibleTensor_cast_physDim {d₁ d₂ D : ℕ} (h : d₁ = d₂)
+    (A : MPSTensor d₁ D) :
+    IsIrreducibleTensor (cast (congr_arg (fun d' => MPSTensor d' D) h) A) ↔
+      IsIrreducibleTensor A := by
+  subst h
+  rfl
+
+/-!
 ## Part B: Primitivity under multiples
 
 If the transfer map of `blockTensor A p` is primitive and `p ∣ q`, then the

--- a/audits/2026-04-28_issue969_common_blocking.md
+++ b/audits/2026-04-28_issue969_common_blocking.md
@@ -1,0 +1,43 @@
+# 2026-04-28 — Issue #969 common reblocking predecessor
+
+## Scope
+
+Issue #969 asks for the global assembly step that takes the per-live-block cyclic-sector data from `MPSTensor.HasPrimitiveIrreducibleCyclicSectors` and expresses all resulting sectors at one common physical blocking length.
+
+This PR lands a checked predecessor for that step.
+
+## Paper route checked
+
+The implementation follows the period-removal route described in:
+
+- `Papers/2011.12127/TN-Review-main.tex` lines 1774--1836: remove invariant-subspace redundancy, then block by the periods to obtain normal blocks.
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 187--250: after irreducible block extraction, block by the least common multiple of the periodicities.
+
+The new statements keep the period-removal lengths distinct from any later common refinement or injectivity/Wielandt blocking length.
+
+## Lean declarations added
+
+- `MPSTensor.blockPhysDim_blockPhysDim`: physical dimension of iterated blocking agrees with one-shot blocking by the product length.
+- Physical-dimension cast helpers in `TNLean/MPS/Core/BlockingInfrastructure.lean` for `SameMPV₂`, `toTensorFromBlocks`, trace preservation, transfer-map primitivity, and tensor irreducibility.
+- `MPSTensor.CommonBlockedCyclicSectorFamily`: one-sided data structure for a finite live-block family. It stores:
+  - a single positive blocking length `p`;
+  - per-block period-removal lengths `period k`;
+  - later positive reblocking lengths `extra k` with `p = period k * extra k`;
+  - the original cyclic sector blocks;
+  - a flattened finite sector family at physical dimension `blockPhysDim d p`;
+  - TP, primitive transfer maps, tensor irreducibility, positive dimensions;
+  - the checked per-live-block iterated-blocking MPV interface.
+- `MPSTensor.CommonBlockedCyclicSectorFamily.flatWeight` and `.flatWeight_ne_zero`: the flattened common-reblocked sectors carry nonzero unit weights.
+- `MPSTensor.exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors`: constructs the one-sided common reblocked family by taking the LCM of the per-block periods and applying `tp_primitive_irreducible_extra_blocking` to each cyclic sector.
+- `MPSTensor.fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail`: combines the zero-tail/TP-gauge live-block reduction with the one-sided common reblocking constructor on both sides, preserving positive-length live equality and the exact `N = 0` zero-tail bookkeeping.
+
+## What remains for full #969 closure
+
+The new API deliberately exposes the remaining formal obligations instead of hiding them:
+
+1. Prove a one-shot iterated-blocking MPV/tensor compatibility theorem identifying `(B_k^[period k])^[extra k]` with `B_k^[p]` at the MPV interface needed by `toTensorFromBlocks`.
+2. Flatten the weighted direct sum over original live blocks and cyclic sectors, transporting the original nonzero weights through the common blocking length.
+3. Re-express the zero-tail equations after the common physical reblocking, including the exact length-zero bookkeeping.
+4. Use the flattened common-alphabet live block family as the exact-live input for the sector comparison theorem from PR #960 once the finite-length span equality is available.
+
+This is therefore strong progress on #969/#942/#652, but not the final exact-live common-block decomposition of `blockTensor A p` and `blockTensor B p`.

--- a/audits/2026-04-28_issue969_common_blocking.md
+++ b/audits/2026-04-28_issue969_common_blocking.md
@@ -18,7 +18,7 @@ The new statements keep the period-removal lengths distinct from any later commo
 ## Lean declarations added
 
 - `MPSTensor.blockPhysDim_blockPhysDim`: physical dimension of iterated blocking agrees with one-shot blocking by the product length.
-- Physical-dimension cast helpers in `TNLean/MPS/Core/BlockingInfrastructure.lean` for `SameMPV₂`, `toTensorFromBlocks`, trace preservation, transfer-map primitivity, and tensor irreducibility.
+- Physical-dimension transport lemmas in `TNLean/MPS/Core/BlockingInfrastructure.lean` for `SameMPV₂`, `toTensorFromBlocks`, trace preservation, transfer-map primitivity, and tensor irreducibility.
 - `MPSTensor.CommonBlockedCyclicSectorFamily`: one-sided data structure for a finite live-block family. It stores:
   - a single positive blocking length `p`;
   - per-block period-removal lengths `period k`;
@@ -26,7 +26,7 @@ The new statements keep the period-removal lengths distinct from any later commo
   - the original cyclic sector blocks;
   - a flattened finite sector family at physical dimension `blockPhysDim d p`;
   - TP, primitive transfer maps, tensor irreducibility, positive dimensions;
-  - the checked per-live-block iterated-blocking MPV interface.
+  - the checked per-live-block iterated-blocking MPV compatibility condition.
 - `MPSTensor.CommonBlockedCyclicSectorFamily.flatWeight` and `.flatWeight_ne_zero`: the flattened common-reblocked sectors carry nonzero unit weights.
 - `MPSTensor.exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors`: constructs the one-sided common reblocked family by taking the LCM of the per-block periods and applying `tp_primitive_irreducible_extra_blocking` to each cyclic sector.
 - `MPSTensor.fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail`: combines the zero-tail/TP-gauge live-block reduction with the one-sided common reblocking constructor on both sides, preserving positive-length live equality and the exact `N = 0` zero-tail bookkeeping.
@@ -35,7 +35,7 @@ The new statements keep the period-removal lengths distinct from any later commo
 
 The new API deliberately exposes the remaining formal obligations instead of hiding them:
 
-1. Prove a one-shot iterated-blocking MPV/tensor compatibility theorem identifying `(B_k^[period k])^[extra k]` with `B_k^[p]` at the MPV interface needed by `toTensorFromBlocks`.
+1. Prove a one-shot iterated-blocking MPV/tensor compatibility theorem identifying `(B_k^[period k])^[extra k]` with `B_k^[p]` at the MPV equivalence needed by `toTensorFromBlocks`.
 2. Flatten the weighted direct sum over original live blocks and cyclic sectors, transporting the original nonzero weights through the common blocking length.
 3. Re-express the zero-tail equations after the common physical reblocking, including the exact length-zero bookkeeping.
 4. Use the flattened common-alphabet live block family as the exact-live input for the sector comparison theorem from PR #960 once the finite-length span equality is available.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1587,7 +1587,13 @@ The following results separate the zero blocks from the
 
 \begin{proof}\leanok
 	\uses{thm:tp_primitive_irreducible_extra_blocking,
-		thm:samempv_blocking_distributes}
+		thm:samempv_blocking_distributes,
+		thm:iterated_blocking_phys_dim,
+		thm:samempv_cast_phys_dim,
+		thm:tensor_from_blocks_cast_phys_dim,
+		thm:left_canonical_cast_phys_dim,
+		thm:primitive_transfer_cast_phys_dim,
+		thm:irreducible_tensor_cast_phys_dim}
 	Choose the least common multiple $p$ of the per-block periods $m_k$ and write
 	$p=m_k e_k$.  Apply the extra-blocking theorem to each cyclic sector for the
 	positive length $e_k$.  The MPV equivalence is obtained by blocking the

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1134,6 +1134,73 @@ The following results separate the zero blocks from the
 	right-hand side is $d^{mn}$.
 \end{proof}
 
+\begin{theorem}[Physical-dimension transport preserves MPV equality]
+	\label{thm:samempv_cast_phys_dim}
+	\lean{MPSTensor.sameMPV₂_cast_physDim}
+	\leanok
+	\uses{def:same_mpv2}
+	If two physical alphabets have the same cardinality, identifying the tensor
+	families along that equality preserves heterogeneous MPV equality.
+\end{theorem}
+
+\begin{proof}\leanok
+	After substituting the equality of physical dimensions, the two MPV equality
+	statements are the same.
+\end{proof}
+
+\begin{theorem}[Physical-dimension transport preserves block-diagonal tensors]
+	\label{thm:tensor_from_blocks_cast_phys_dim}
+	\lean{MPSTensor.toTensorFromBlocks_cast_physDim}
+	\leanok
+	\uses{def:tensor_from_blocks}
+	Identifying equal physical alphabets commutes with forming a weighted
+	block-diagonal tensor from a finite block family.
+\end{theorem}
+
+\begin{proof}\leanok
+	Substitute the equality of physical dimensions; both sides are then the same
+	block-diagonal tensor.
+\end{proof}
+
+\begin{theorem}[Physical-dimension transport preserves trace preservation]
+	\label{thm:left_canonical_cast_phys_dim}
+	\lean{MPSTensor.leftCanonical_cast_physDim}
+	\leanok
+	\uses{def:tp_kraus}
+	Identifying equal physical alphabets preserves the trace-preserving condition
+	$\sum_i A_i^\dagger A_i=\Id$.
+\end{theorem}
+
+\begin{proof}\leanok
+	Substitute the equality of physical dimensions; the two normalization sums are
+	identical.
+\end{proof}
+
+\begin{theorem}[Physical-dimension transport preserves primitive transfer maps]
+	\label{thm:primitive_transfer_cast_phys_dim}
+	\lean{MPSTensor.isPrimitive_transferMap_cast_physDim}
+	\leanok
+	\uses{def:transfer_map, def:primitive_channel}
+	Identifying equal physical alphabets preserves primitivity of the transfer map.
+\end{theorem}
+
+\begin{proof}\leanok
+	Substitute the equality of physical dimensions; the transfer maps coincide.
+\end{proof}
+
+\begin{theorem}[Physical-dimension transport preserves tensor irreducibility]
+	\label{thm:irreducible_tensor_cast_phys_dim}
+	\lean{MPSTensor.isIrreducibleTensor_cast_physDim}
+	\leanok
+	\uses{def:irreducible_tensor}
+	Identifying equal physical alphabets preserves tensor irreducibility.
+\end{theorem}
+
+\begin{proof}\leanok
+	Substitute the equality of physical dimensions; the irreducibility predicates
+	are identical.
+\end{proof}
+
 \begin{theorem}[Iterated blocking multiplies periods at the transfer-map level]%
 	\label{thm:iterated_blocking_transfer}
 	\lean{MPSTensor.transferMap_blockTensor_mul}
@@ -1476,13 +1543,12 @@ The following results separate the zero blocks from the
 	\leanok
 	\uses{def:primitive_irreducible_cyclic_sectors, def:blocked_tensor,
 		def:tensor_from_blocks, def:same_mpv2}
-	For a finite family of live blocks $(B_k)$, this structure records a single
+	For a finite family of live blocks $(B_k)$, these data record a single
 	positive physical blocking length $p$, the per-block period-removal lengths
 	$m_k$, the later positive reblocking lengths $e_k$ with $p=m_k e_k$, and the
-	resulting flattened finite sector family at physical dimension
-	$\operatorname{blockPhysDim}(d,p)$.  It retains trace preservation,
-	primitive transfer maps, tensor irreducibility, positive bond dimensions, and
-	the per-block iterated-blocking MPV interfaces.
+	resulting flattened finite sector family at physical dimension $d^p$.  They
+	retain trace preservation, primitive transfer maps, tensor irreducibility,
+	positive bond dimensions, and the per-block iterated-blocking MPV equivalences.
 \end{definition}
 
 \begin{definition}[Unit weights for a common reblocked cyclic-sector family]%
@@ -1514,9 +1580,9 @@ The following results separate the zero blocks from the
 	If every live block in a finite family has primitive irreducible cyclic
 	sectors, then the family admits a common reblocked cyclic-sector family.
 	The proof chooses the least common multiple of the per-block periods, blocks
-	each sector by the corresponding quotient, casts all sectors to the common
+	each sector by the corresponding quotient, transports all sectors to the common
 	physical alphabet, and preserves TP, primitivity, tensor irreducibility,
-	positive bond dimensions, and the unit-weight MPV interfaces.
+	positive bond dimensions, and the unit-weight MPV equivalences.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1524,9 +1590,9 @@ The following results separate the zero blocks from the
 		thm:samempv_blocking_distributes}
 	Choose the least common multiple $p$ of the per-block periods $m_k$ and write
 	$p=m_k e_k$.  Apply the extra-blocking theorem to each cyclic sector for the
-	positive length $e_k$.  The MPV interface is obtained by blocking the
+	positive length $e_k$.  The MPV equivalence is obtained by blocking the
 	unit-weight cyclic-sector equivalence and transporting the physical alphabet
-	to $\operatorname{blockPhysDim}(d,p)$.
+	to $d^p$.
 \end{proof}
 
 \subsection{Sector irreducibility helpers}%
@@ -2838,7 +2904,8 @@ The following results separate the zero blocks from the
 
 \begin{proof}\leanok
 	\uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
-		thm:exists_common_blocked_cyclic_sector_family}
+		thm:exists_common_blocked_cyclic_sector_family,
+		thm:common_blocked_cyclic_sector_flat_weight_ne_zero}
 	Apply Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}.
 	Then apply Theorem~\ref{thm:exists_common_blocked_cyclic_sector_family} to the
 	per-block cyclic-sector data on each side.  The nonzero unit-weight conclusion

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1134,13 +1134,13 @@ The following results separate the zero blocks from the
 	right-hand side is $d^{mn}$.
 \end{proof}
 
-\begin{theorem}[Physical-dimension transport preserves MPV equality]
+\begin{theorem}[Physical-dimension transport and MPV equality]
 	\label{thm:samempv_cast_phys_dim}
 	\lean{MPSTensor.sameMPV₂_cast_physDim}
 	\leanok
 	\uses{def:same_mpv2}
-	If two physical alphabets have the same cardinality, identifying the tensor
-	families along that equality preserves heterogeneous MPV equality.
+	If two physical alphabets have the same cardinality, then the transported
+	tensors have the same MPV family if and only if the original tensors do.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1148,7 +1148,7 @@ The following results separate the zero blocks from the
 	statements are the same.
 \end{proof}
 
-\begin{theorem}[Physical-dimension transport preserves block-diagonal tensors]
+\begin{theorem}[Physical-dimension transport for block-diagonal tensors]
 	\label{thm:tensor_from_blocks_cast_phys_dim}
 	\lean{MPSTensor.toTensorFromBlocks_cast_physDim}
 	\leanok
@@ -1162,13 +1162,13 @@ The following results separate the zero blocks from the
 	block-diagonal tensor.
 \end{proof}
 
-\begin{theorem}[Physical-dimension transport preserves trace preservation]
+\begin{theorem}[Physical-dimension transport and trace preservation]
 	\label{thm:left_canonical_cast_phys_dim}
 	\lean{MPSTensor.leftCanonical_cast_physDim}
 	\leanok
 	\uses{def:tp_kraus}
-	Identifying equal physical alphabets preserves the trace-preserving condition
-	$\sum_i A_i^\dagger A_i=\Id$.
+	After identifying equal physical alphabets, the transported tensor is
+	trace-preserving if and only if the original tensor is trace-preserving.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1176,24 +1176,26 @@ The following results separate the zero blocks from the
 	identical.
 \end{proof}
 
-\begin{theorem}[Physical-dimension transport preserves primitive transfer maps]
+\begin{theorem}[Physical-dimension transport and primitive transfer maps]
 	\label{thm:primitive_transfer_cast_phys_dim}
 	\lean{MPSTensor.isPrimitive_transferMap_cast_physDim}
 	\leanok
 	\uses{def:transfer_map, def:primitive_channel}
-	Identifying equal physical alphabets preserves primitivity of the transfer map.
+	After identifying equal physical alphabets, the transported transfer map is
+	primitive if and only if the original transfer map is primitive.
 \end{theorem}
 
 \begin{proof}\leanok
 	Substitute the equality of physical dimensions; the transfer maps coincide.
 \end{proof}
 
-\begin{theorem}[Physical-dimension transport preserves tensor irreducibility]
+\begin{theorem}[Physical-dimension transport and tensor irreducibility]
 	\label{thm:irreducible_tensor_cast_phys_dim}
 	\lean{MPSTensor.isIrreducibleTensor_cast_physDim}
 	\leanok
 	\uses{def:irreducible_tensor}
-	Identifying equal physical alphabets preserves tensor irreducibility.
+	After identifying equal physical alphabets, the transported tensor is
+	irreducible if and only if the original tensor is irreducible.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1568,6 +1570,10 @@ The following results separate the zero blocks from the
 	Every unit weight in Definition~\ref{def:common_blocked_cyclic_sector_flat_weight}
 	is nonzero.
 \end{theorem}
+
+\begin{proof}\leanok
+	The weight is the constant value $1$, so it is nonzero.
+\end{proof}
 
 \begin{theorem}[Common reblocking of per-block cyclic sectors]%
 \label{thm:exists_common_blocked_cyclic_sector_family}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1116,6 +1116,24 @@ The following results separate the zero blocks from the
 	Apply Theorem~\ref{thm:primitive_pow} with $\E = \E_{A^{[p]}}$.
 \end{proof}
 
+\begin{theorem}[Iterated blocking multiplies physical dimensions]
+	\label{thm:iterated_blocking_phys_dim}
+	\lean{MPSTensor.blockPhysDim_blockPhysDim}
+	\leanok
+	\uses{def:blocked_tensor}
+	The physical alphabet obtained by first blocking $m$ sites and then blocking
+	$n$ of those sites has the same cardinality as blocking $mn$ original sites:
+	\[
+		\operatorname{blockPhysDim}(\operatorname{blockPhysDim}(d,m),n)
+		= \operatorname{blockPhysDim}(d,mn).
+	\]
+\end{theorem}
+
+\begin{proof}\leanok
+	Both sides are powers of $d$: the left-hand side is $(d^m)^n$, and the
+	right-hand side is $d^{mn}$.
+\end{proof}
+
 \begin{theorem}[Iterated blocking multiplies periods at the transfer-map level]%
 	\label{thm:iterated_blocking_transfer}
 	\lean{MPSTensor.transferMap_blockTensor_mul}
@@ -1450,6 +1468,65 @@ The following results separate the zero blocks from the
 	\uses{thm:cyclic_sector_decomp_irr_tp_prim_irr}
 	This is Theorem~\ref{thm:cyclic_sector_decomp_irr_tp_prim_irr}, restated as
 	the predicate of Definition~\ref{def:primitive_irreducible_cyclic_sectors}.
+\end{proof}
+
+\begin{definition}[Common reblocked cyclic-sector family]%
+\label{def:common_blocked_cyclic_sector_family}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily}
+	\leanok
+	\uses{def:primitive_irreducible_cyclic_sectors, def:blocked_tensor,
+		def:tensor_from_blocks, def:same_mpv2}
+	For a finite family of live blocks $(B_k)$, this structure records a single
+	positive physical blocking length $p$, the per-block period-removal lengths
+	$m_k$, the later positive reblocking lengths $e_k$ with $p=m_k e_k$, and the
+	resulting flattened finite sector family at physical dimension
+	$\operatorname{blockPhysDim}(d,p)$.  It retains trace preservation,
+	primitive transfer maps, tensor irreducibility, positive bond dimensions, and
+	the per-block iterated-blocking MPV interfaces.
+\end{definition}
+
+\begin{definition}[Unit weights for a common reblocked cyclic-sector family]%
+\label{def:common_blocked_cyclic_sector_flat_weight}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.flatWeight}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_family}
+	The flattened sectors of a common reblocked cyclic-sector family carry the
+	unit weights inherited from cyclic period removal.
+\end{definition}
+
+\begin{theorem}[Unit weights are nonzero for common reblocked cyclic sectors]%
+\label{thm:common_blocked_cyclic_sector_flat_weight_ne_zero}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.flatWeight_ne_zero}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_flat_weight}
+	Every unit weight in Definition~\ref{def:common_blocked_cyclic_sector_flat_weight}
+	is nonzero.
+\end{theorem}
+
+\begin{theorem}[Common reblocking of per-block cyclic sectors]%
+\label{thm:exists_common_blocked_cyclic_sector_family}
+	\lean{MPSTensor.exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_family,
+		def:primitive_irreducible_cyclic_sectors,
+		thm:tp_primitive_irreducible_extra_blocking,
+		thm:samempv_blocking_distributes}
+	If every live block in a finite family has primitive irreducible cyclic
+	sectors, then the family admits a common reblocked cyclic-sector family.
+	The proof chooses the least common multiple of the per-block periods, blocks
+	each sector by the corresponding quotient, casts all sectors to the common
+	physical alphabet, and preserves TP, primitivity, tensor irreducibility,
+	positive bond dimensions, and the unit-weight MPV interfaces.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:tp_primitive_irreducible_extra_blocking,
+		thm:samempv_blocking_distributes}
+	Choose the least common multiple $p$ of the per-block periods $m_k$ and write
+	$p=m_k e_k$.  Apply the extra-blocking theorem to each cyclic sector for the
+	positive length $e_k$.  The MPV interface is obtained by blocking the
+	unit-weight cyclic-sector equivalence and transporting the physical alphabet
+	to $\operatorname{blockPhysDim}(d,p)$.
 \end{proof}
 
 \subsection{Sector irreducibility helpers}%
@@ -2741,6 +2818,31 @@ The following results separate the zero blocks from the
 	positive lengths and records the $N=0$ identity. Finally apply
 	Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr} to every
 	trace-preserving irreducible live block.
+\end{proof}
+
+\begin{theorem}[Common reblocked live cyclic sectors with zero-tail bookkeeping]%
+\label{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail}
+	\leanok
+	\uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
+		thm:exists_common_blocked_cyclic_sector_family,
+		thm:common_blocked_cyclic_sector_flat_weight_ne_zero}
+	If two tensors generate the same MPV family, then the zero-tail/TP-gauge
+	live-block reduction can be combined with a common reblocking of all
+	per-block cyclic sectors.  Each side obtains a finite flattened sector family
+	at one physical blocking length, with trace preservation, primitive transfer
+	maps, tensor irreducibility, positive bond dimensions, and nonzero unit
+	weights.  The theorem keeps the positive-length live equality and the exact
+	$N=0$ zero-tail bookkeeping for the original live block tensors.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
+		thm:exists_common_blocked_cyclic_sector_family}
+	Apply Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}.
+	Then apply Theorem~\ref{thm:exists_common_blocked_cyclic_sector_family} to the
+	per-block cyclic-sector data on each side.  The nonzero unit-weight conclusion
+	is Theorem~\ref{thm:common_blocked_cyclic_sector_flat_weight_ne_zero}.
 \end{proof}
 
 


### PR DESCRIPTION
## Summary

- add physical-dimension compatibility/cast helpers for iterated blocking and MPV/TP/primitivity/irreducibility transports
- introduce `MPSTensor.CommonBlockedCyclicSectorFamily`, a one-sided common-reblocked cyclic-sector family with one physical blocking length, flattened sector blocks, TP/primitive/irreducible/positive-dimension data, nonzero unit weights, and per-block iterated-blocking MPV interfaces
- prove `exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors` by taking the LCM of per-nonzero-block periods and extra-blocking every cyclic sector
- add `fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail`, combining the common-reblocked sector families on both sides with the existing zero-tail and positive-length nonzero-block interfaces
- document the remaining exact-nonzero blockers in `audits/2026-04-28_issue969_common_blocking.md`

## Paper-faithfulness note

This follows the CPSV/CPGSV route from the issue: invariant-subspace/zero-tail split, TP-gauged irreducible nonzero blocks, period removal per nonzero block, then an LCM/common-reblocking step.  The period-removal lengths remain separate from later injectivity/Wielandt refinement lengths.

## Validation

- `lake build --old TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` passed (only the two pre-existing long-line warnings in `CyclicSectorDecomposition.lean`).
- `lake build --old TNLean` passed with existing unrelated `sorry` warnings and the same pre-existing long-line warnings.
- Lean diagnostics clean for `BlockingInfrastructure.lean`, `CyclicSectorDecomposition.lean`, and `StructuralTheorem.lean`.
- `cd blueprint && leanblueprint checkdecls` passed.
- `cd blueprint && PATH=/tmp/tnlean-no-latex-bin:/Users/siruilu/.local/bin:/Users/siruilu/miniforge3/bin:/usr/bin:/bin:/usr/sbin:/sbin leanblueprint web` passed.  The PATH shim hides local `latex`/`dvisvgm` because this iCloud checkout path contains spaces and Homebrew `latex` fails to open absolute paths with spaces; without the shim, `leanblueprint web` fails before touching this branch's changes while compiling the first existing TikZ diagram.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passed.
- `git diff --check` passed.
- Added/touched diff scans for `sorry|admit|axiom|native_decide|unsafe` and banned shorthand prose passed.

Advances #969. Related: #942, #652.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core canonical-form assembly proofs by adding new blocking/casting lemmas and a new construction used in later theorems; risk is mainly proof fragility/type-cast mismatches rather than runtime behavior.
> 
> **Overview**
> Introduces a **common-reblocking layer** for cyclic-sector data: `CommonBlockedCyclicSectorFamily` packages per-nonzero-block period removal plus an additional positive reblocking factor so all sectors live at one shared physical dimension, and states a flattened sector family with preserved TP/primitivity/irreducibility/positive-dimension facts and an MPV compatibility witness (`nested_same`).
> 
> Adds a constructive existence theorem `exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors` that chooses `p` as the LCM of per-block periods, blocks each sector by the corresponding quotient, casts to the common alphabet, and records unit sector weights (`flatWeight`) with nonzero proof.
> 
> Extends the after-blocking structural pipeline with `fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail`, combining the existing zero-tail/TP-gauge nonzero-block reduction with the new common-reblocking constructor on both sides; also adds supporting physical-dimension cast/transport lemmas in `BlockingInfrastructure.lean` and updates blueprint/audit documentation accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed1c8642879ee5efa5cbb8ef81d5dedd59a8e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->