### PR TITLE
feat(MPS/CanonicalForm): derive span equality from phase covers

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -938,6 +938,71 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan
   exact ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt,
           M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
 
+/-- **Common live-block construction from a common MPV-phase cover.**
+
+This exact-live variant discharges the live-block span equality required by
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan` from a stronger
+common-structure hypothesis: both live-block families map onto one common family of MPV phase
+classes, and every live block is MPV-phase equivalent to its image.  The conclusion is the same
+sector-weight comparison as the block-span theorem.
+
+This theorem is a paper-faithful predecessor for #970 while the final common-blocking theorem
+(#969) is not yet available: once that theorem supplies the common family and the two surjective
+class maps, the remaining span input is filled by `mpv_span_eq_of_common_phase_cover`. -/
+theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover
+    {d D₁ D₂ p rA rB rC : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ} {dimC : Fin rC → ℕ}
+    [∀ k : Fin rA, NeZero (dimA k)]
+    [∀ k : Fin rB, NeZero (dimB k)]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hp : 0 < p)
+    (μA : Fin rA → ℂ)
+    (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d p) (dimA k))
+    (μB : Fin rB → ℂ)
+    (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d p) (dimB k))
+    (common : (c : Fin rC) → MPSTensor (blockPhysDim d p) (dimC c))
+    (classA : Fin rA → Fin rC) (classB : Fin rB → Fin rC)
+    (hAphase : ∀ k : Fin rA, MPVBlockPhaseEquiv (common (classA k)) (blocksA k))
+    (hBphase : ∀ k : Fin rB, MPVBlockPhaseEquiv (common (classB k)) (blocksB k))
+    (hAsurj : Function.Surjective classA)
+    (hBsurj : Function.Surjective classB)
+    (hAblocks : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA))
+    (hBblocks : SameMPV₂ (blockTensor (d := d) (D := D₂) B p)
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB))
+    (hTPA : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksA k i)ᴴ * blocksA k i = 1)
+    (hTPB : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksB k i)ᴴ * blocksB k i = 1)
+    (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))
+    (hIrrB : ∀ k, IsIrreducibleTensor (blocksB k))
+    (hPrimA : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimA k) (blocksA k)))
+    (hPrimB : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimB k) (blocksB k)))
+    (hInjA : ∀ k, IsInjective (blocksA k))
+    (hInjB : ∀ k, IsInjective (blocksB k))
+    (hμA : ∀ k, μA k ≠ 0)
+    (hμB : ∀ k, μB k ≠ 0) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂ (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂ (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  refine fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan
+    A B hSame hp μA blocksA μB blocksB hAblocks hBblocks hTPA hTPB hIrrA hIrrB
+    hPrimA hPrimB hInjA hInjB hμA hμB ?_
+  intro N
+  exact mpv_span_eq_of_common_phase_cover (d := blockPhysDim d p)
+    blocksA blocksB common classA classB hAphase hBphase hAsurj hBsurj N
+
 /-- Remove matching zero tails from two MPV identities.
 
 If `A` and `B` have the same MPVs, and each is expressed as a zero tail plus a live tensor,

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -97,6 +97,9 @@ Theorem matching, etc.).
   signature-compatible reformulation retaining the TP / primitive / irreducible
   inputs expected by the one-sided BNT construction chain.
 
+* `mpv_span_eq_of_common_phase_cover` — finite-length live-block span equality
+  from a common family covered surjectively up to MPV phase.
+
 ## References
 
 - [CPGSV17, Lemma A.2]: Overlap dichotomy for Normal Tensors.
@@ -396,45 +399,99 @@ theorem bnt_grouping_single_norm_class_of_tp_primitive_irr_blocks
 
 /-! ### §4. MPV phase-class representatives -/
 
-/-- MPV phase equivalence for a dependent block family.
+/-- Heterogeneous MPV phase equivalence between two individual blocks.
 
-`MPVPhaseEquiv blocks j k` means that block `k` has the same MPV family as
-block `j` after multiplying length-`N` vectors by a nonzero scalar power
-`ζ ^ N`.  Gauge-phase equivalence implies this relation, and quotienting a
-finite family by this relation is enough to absorb all repeated scalar-power
-copies into sector weights. -/
-def MPVPhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
-    (blocks : (k : Fin r) → MPSTensor d (dim k)) (j k : Fin r) : Prop :=
+`MPVBlockPhaseEquiv A B` means that the finite-chain MPV of `B` is a nonzero
+scalar power times the finite-chain MPV of `A`, uniformly in the chain length and
+physical word.  The bond dimensions of `A` and `B` may differ. -/
+def MPVBlockPhaseEquiv {d DA DB : ℕ} (A : MPSTensor d DA) (B : MPSTensor d DB) : Prop :=
   ∃ ζ : ℂ, ζ ≠ 0 ∧ ∀ (N : ℕ) (σ : Fin N → Fin d),
-    mpv (blocks k) σ = ζ ^ N * mpv (blocks j) σ
+    mpv B σ = ζ ^ N * mpv A σ
 
-/-- MPV phase equivalence is reflexive. -/
-lemma MPVPhaseEquiv.refl {r : ℕ} {dim : Fin r → ℕ}
-    (blocks : (k : Fin r) → MPSTensor d (dim k)) (j : Fin r) :
-    MPVPhaseEquiv blocks j j := by
+namespace MPVBlockPhaseEquiv
+
+/-- Reflexivity of heterogeneous MPV phase equivalence. -/
+lemma refl {D : ℕ} (A : MPSTensor d D) : MPVBlockPhaseEquiv A A := by
   exact ⟨1, one_ne_zero, fun N σ => by simp⟩
 
-/-- MPV phase equivalence is symmetric. -/
-lemma MPVPhaseEquiv.symm {r : ℕ} {dim : Fin r → ℕ}
-    (blocks : (k : Fin r) → MPSTensor d (dim k)) {j k : Fin r}
-    (h : MPVPhaseEquiv blocks j k) : MPVPhaseEquiv blocks k j := by
+/-- Symmetry of heterogeneous MPV phase equivalence. -/
+lemma symm {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
+    (h : MPVBlockPhaseEquiv A B) : MPVBlockPhaseEquiv B A := by
   rcases h with ⟨ζ, hζ, hmpv⟩
   refine ⟨ζ⁻¹, inv_ne_zero hζ, ?_⟩
   intro N σ
   rw [hmpv N σ]
   rw [inv_pow, ← mul_assoc, inv_mul_cancel₀ (pow_ne_zero N hζ), one_mul]
 
-/-- MPV phase equivalence is transitive. -/
-lemma MPVPhaseEquiv.trans {r : ℕ} {dim : Fin r → ℕ}
-    (blocks : (k : Fin r) → MPSTensor d (dim k)) {i j k : Fin r}
-    (hij : MPVPhaseEquiv blocks i j) (hjk : MPVPhaseEquiv blocks j k) :
-    MPVPhaseEquiv blocks i k := by
-  rcases hij with ⟨ζ, hζ, hζmpv⟩
-  rcases hjk with ⟨η, hη, hηmpv⟩
+/-- Transitivity of heterogeneous MPV phase equivalence. -/
+lemma trans {DA DB DC : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
+    {C : MPSTensor d DC} (hAB : MPVBlockPhaseEquiv A B)
+    (hBC : MPVBlockPhaseEquiv B C) : MPVBlockPhaseEquiv A C := by
+  rcases hAB with ⟨ζ, hζ, hζmpv⟩
+  rcases hBC with ⟨η, hη, hηmpv⟩
   refine ⟨η * ζ, mul_ne_zero hη hζ, ?_⟩
   intro N σ
   rw [hηmpv N σ, hζmpv N σ, mul_pow]
   ring
+
+/-- Gauge-phase equivalence after a dimension cast gives heterogeneous MPV phase equivalence. -/
+lemma of_gaugePhaseEquiv_cast {DA DB : ℕ} (A : MPSTensor d DA) (B : MPSTensor d DB)
+    (hdim : DA = DB)
+    (hGPE : GaugePhaseEquiv (d := d)
+      (cast (congr_arg (MPSTensor d) hdim) A) B) :
+    MPVBlockPhaseEquiv A B := by
+  rcases hGPE with ⟨X, ζ, hζ, hX⟩
+  refine ⟨ζ, hζ, ?_⟩
+  intro N σ
+  rw [mpv_eq_pow_mul_of_gaugePhase
+    (A := cast (congr_arg (MPSTensor d) hdim) A) (B := B) X ζ hX N σ,
+    mpv_cast_dim hdim A N σ]
+
+/-- Heterogeneous MPV phase equivalence gives a scalar-power equality of MPV state vectors. -/
+lemma exists_mpvState_eq_smul {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
+    (h : MPVBlockPhaseEquiv A B) (N : ℕ) :
+    ∃ ζ : ℂ, ζ ≠ 0 ∧ mpvState (d := d) B N = ζ ^ N • mpvState (d := d) A N := by
+  rcases h with ⟨ζ, hζ, hmpv⟩
+  refine ⟨ζ, hζ, ?_⟩
+  ext σ
+  simp only [PiLp.smul_apply, smul_eq_mul, mpvState_apply]
+  exact hmpv N σ
+
+end MPVBlockPhaseEquiv
+
+/-- MPV phase equivalence for a dependent block family.
+
+`MPVPhaseEquiv blocks j k` means that block `k` has the same MPV family as
+block `j` after multiplying length-`N` vectors by a nonzero scalar power
+`ζ ^ N`.  Gauge-phase equivalence implies this relation, and quotienting a
+finite family by this relation is enough to absorb all repeated scalar-power
+copies into sector weights.
+
+This is the family-indexed specialization of `MPVBlockPhaseEquiv`, so the
+homogeneous phase-class relation shares the heterogeneous block-level relation
+rather than duplicating it. -/
+def MPVPhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) (j k : Fin r) : Prop :=
+  MPVBlockPhaseEquiv (blocks j) (blocks k)
+
+/-- MPV phase equivalence is reflexive. -/
+lemma MPVPhaseEquiv.refl {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) (j : Fin r) :
+    MPVPhaseEquiv blocks j j :=
+  MPVBlockPhaseEquiv.refl (blocks j)
+
+/-- MPV phase equivalence is symmetric. -/
+lemma MPVPhaseEquiv.symm {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) {j k : Fin r}
+    (h : MPVPhaseEquiv blocks j k) : MPVPhaseEquiv blocks k j :=
+  MPVBlockPhaseEquiv.symm h
+
+/-- MPV phase equivalence is transitive. -/
+lemma MPVPhaseEquiv.trans {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k)) {i j k : Fin r}
+    (hij : MPVPhaseEquiv blocks i j) (hjk : MPVPhaseEquiv blocks j k) :
+    MPVPhaseEquiv blocks i k :=
+  MPVBlockPhaseEquiv.trans hij hjk
 
 /-- A gauge-phase equivalence between equal-dimension blocks gives MPV phase equivalence. -/
 lemma MPVPhaseEquiv.of_gaugePhaseEquiv_cast {r : ℕ} {dim : Fin r → ℕ}
@@ -442,26 +499,101 @@ lemma MPVPhaseEquiv.of_gaugePhaseEquiv_cast {r : ℕ} {dim : Fin r → ℕ}
     (hdim : dim j = dim k)
     (hGPE : GaugePhaseEquiv (d := d)
       (cast (congr_arg (MPSTensor d) hdim) (blocks j)) (blocks k)) :
-    MPVPhaseEquiv blocks j k := by
-  rcases hGPE with ⟨X, ζ, hζ, hX⟩
-  refine ⟨ζ, hζ, ?_⟩
-  intro N σ
-  rw [mpv_eq_pow_mul_of_gaugePhase
-    (A := cast (congr_arg (MPSTensor d) hdim) (blocks j))
-    (B := blocks k) X ζ hX N σ,
-    mpv_cast_dim hdim (blocks j) N σ]
+    MPVPhaseEquiv blocks j k :=
+  MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast (blocks j) (blocks k) hdim hGPE
 
 /-- MPV phase equivalence gives a scalar-power equality of finite-length MPV state vectors. -/
 lemma MPVPhaseEquiv.exists_mpvState_eq_smul {r : ℕ} {dim : Fin r → ℕ}
     {blocks : (k : Fin r) → MPSTensor d (dim k)} {j k : Fin r}
     (h : MPVPhaseEquiv blocks j k) (N : ℕ) :
     ∃ ζ : ℂ, ζ ≠ 0 ∧
-      mpvState (d := d) (blocks k) N = ζ ^ N • mpvState (d := d) (blocks j) N := by
-  rcases h with ⟨ζ, hζ, hmpv⟩
-  refine ⟨ζ, hζ, ?_⟩
-  ext σ
-  simp only [PiLp.smul_apply, smul_eq_mul, mpvState_apply]
-  exact hmpv N σ
+      mpvState (d := d) (blocks k) N = ζ ^ N • mpvState (d := d) (blocks j) N :=
+  MPVBlockPhaseEquiv.exists_mpvState_eq_smul h N
+
+/-- Span inclusion for live blocks covered by another family up to MPV phase.
+
+For each block in `blocksA`, choose a block in `blocksB` whose MPV state differs only by a
+nonzero scalar power. Then, at every finite length, the MPV span of `blocksA` is contained in
+the MPV span of `blocksB`. -/
+theorem mpv_span_le_of_phase_cover {rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hcover : ∀ j : Fin rA, ∃ k : Fin rB, MPVBlockPhaseEquiv (blocksB k) (blocksA j))
+    (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun j : Fin rA => mpvState (d := d) (blocksA j) N)) ≤
+    Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) := by
+  refine Submodule.span_le.2 ?_
+  intro v hv
+  rcases hv with ⟨j, rfl⟩
+  obtain ⟨k, hphase⟩ := hcover j
+  obtain ⟨ζ, _hζ, hstate⟩ := hphase.exists_mpvState_eq_smul N
+  have hmem : ζ ^ N • mpvState (d := d) (blocksB k) N ∈
+      Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) :=
+    Submodule.smul_mem _ _ (Submodule.subset_span ⟨k, rfl⟩)
+  simpa [hstate] using hmem
+
+/-- Mutual MPV-phase covers give equality of finite-length live-block MPV spans. -/
+theorem mpv_span_eq_of_mutual_phase_cover {rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA_le_B : ∀ j : Fin rA, ∃ k : Fin rB, MPVBlockPhaseEquiv (blocksB k) (blocksA j))
+    (hB_le_A : ∀ k : Fin rB, ∃ j : Fin rA, MPVBlockPhaseEquiv (blocksA j) (blocksB k))
+    (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun j : Fin rA => mpvState (d := d) (blocksA j) N)) =
+    Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) :=
+  le_antisymm
+    (mpv_span_le_of_phase_cover blocksA blocksB hA_le_B N)
+    (mpv_span_le_of_phase_cover blocksB blocksA hB_le_A N)
+
+/-- A surjective common MPV-phase quotient preserves finite-length live-block spans.
+
+This is the abstract span step needed after a common live-block theorem has identified a family
+of representative blocks and shown that every live block maps onto it up to MPV phase. -/
+theorem mpv_span_eq_of_surjective_phase_cover {r rC : ℕ}
+    {dim : Fin r → ℕ} {dimC : Fin rC → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (common : (c : Fin rC) → MPSTensor d (dimC c))
+    (classOf : Fin r → Fin rC)
+    (hphase : ∀ k : Fin r, MPVBlockPhaseEquiv (common (classOf k)) (blocks k))
+    (hsurj : Function.Surjective classOf)
+    (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun k : Fin r => mpvState (d := d) (blocks k) N)) =
+    Submodule.span ℂ (Set.range (fun c : Fin rC => mpvState (d := d) (common c) N)) := by
+  refine mpv_span_eq_of_mutual_phase_cover blocks common ?_ ?_ N
+  · intro k
+    exact ⟨classOf k, hphase k⟩
+  · intro c
+    obtain ⟨k, hk⟩ := hsurj c
+    refine ⟨k, ?_⟩
+    rw [← hk]
+    exact (hphase k).symm
+
+/-- Two live-block families with a common surjective MPV-phase quotient have equal finite-length
+MPV spans.
+
+This theorem is deliberately independent of the sector weights.  It records the precise
+linear-algebra input needed by the exact-live after-blocking theorem once a future common-blocking
+result supplies a common family of live representatives and shows that both sides cover it. -/
+theorem mpv_span_eq_of_common_phase_cover {rA rB rC : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ} {dimC : Fin rC → ℕ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (common : (c : Fin rC) → MPSTensor d (dimC c))
+    (classA : Fin rA → Fin rC) (classB : Fin rB → Fin rC)
+    (hAphase : ∀ j : Fin rA, MPVBlockPhaseEquiv (common (classA j)) (blocksA j))
+    (hBphase : ∀ k : Fin rB, MPVBlockPhaseEquiv (common (classB k)) (blocksB k))
+    (hAsurj : Function.Surjective classA) (hBsurj : Function.Surjective classB)
+    (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun j : Fin rA => mpvState (d := d) (blocksA j) N)) =
+    Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) := by
+  calc
+    Submodule.span ℂ (Set.range (fun j : Fin rA => mpvState (d := d) (blocksA j) N))
+        = Submodule.span ℂ (Set.range (fun c : Fin rC => mpvState (d := d) (common c) N)) :=
+          mpv_span_eq_of_surjective_phase_cover blocksA common classA hAphase hAsurj N
+    _ = Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) :=
+          (mpv_span_eq_of_surjective_phase_cover blocksB common classB hBphase hBsurj N).symm
 
 /-- Equivalence relation on block indices given by MPV phase equivalence. -/
 def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}

--- a/audits/2026-04-26_issue877_after_blocking_sector.md
+++ b/audits/2026-04-26_issue877_after_blocking_sector.md
@@ -114,3 +114,29 @@ paper-level reduction: exact common live decompositions, the `N = 0` zero-tail
 bookkeeping, live-block injectivity or a blocked replacement for the primitive
 rigidity theorem, and finite-length span equality for the original live block
 families from the global equal-MPV hypothesis.
+
+## Issue #970 predecessor update
+
+Issue #969 is not yet available on `origin/main`, so the final theorem deriving
+live-block finite-length span equality from the full structural `SameMPV₂` data
+cannot honestly be proved in this step.  The new predecessor isolates a reusable
+span mechanism for the common-block route:
+
+- `MPSTensor.MPVBlockPhaseEquiv` records heterogeneous MPV phase equivalence
+  between individual blocks, allowing different bond dimensions.
+- `MPSTensor.mpv_span_eq_of_common_phase_cover` proves that if both live-block
+  families map surjectively to one common family and each live block is
+  MPV-phase equivalent to its image, then their finite-length MPV spans agree at
+  every system size.
+- `MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover`
+  feeds this span equality directly into
+  `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan`, so
+  the exact-live sector comparison no longer needs a raw span-equality
+  hypothesis once a future common-blocking theorem supplies the common family and
+  the two surjective class maps.
+
+This keeps the remaining #970 obligation mathematically honest: the unproved
+paper-level input is now the construction of the common live family (with the
+phase-cover maps) from the after-blocking structural reduction, together with
+zero-tail and injectivity bookkeeping, rather than any further quotient/span
+transport for the BNT representatives.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -752,6 +752,37 @@ single weighted block.
 	live-block span equality through the two representative-span identities.
 \end{proof}
 
+\begin{definition}[MPV phase equivalence for live blocks]
+\label{def:mpv_block_phase_equiv}
+	\lean{MPSTensor.MPVBlockPhaseEquiv}
+	\leanok
+	\uses{def:mpv}
+	Two live blocks $A$ and $B$ are MPV-phase equivalent if there is a nonzero
+	scalar $\zeta$ such that, for every system size $N$ and every physical word,
+	the MPV coefficient of $B$ equals $\zeta^N$ times the MPV coefficient of $A$.
+	The two bond dimensions are allowed to differ.
+\end{definition}
+
+\begin{lemma}[Common MPV phase cover gives live-block span equality]%
+\label{lem:live_block_span_eq_of_common_phase_cover}
+	\lean{MPSTensor.mpv_span_eq_of_common_phase_cover}
+	\leanok
+	\uses{def:mpv_block_phase_equiv, def:mpv_state}
+	Let two finite live-block families map onto a third finite family of common
+	blocks. Suppose both maps are surjective, and each live block has finite-length
+	MPV vectors equal to a nonzero scalar power times the MPV vectors of its common
+	block. Then, for every system size, the two live-block families span the same
+	MPV subspace.
+\end{lemma}
+
+\begin{proof}
+	\leanok
+	Each live-block MPV vector lies in the span of the common family because it is a
+	scalar multiple of its common block's MPV vector. Surjectivity gives the reverse
+	inclusion, so each live-block span equals the common span; transitivity gives
+	the equality of the two live-block spans.
+\end{proof}
+
 \begin{theorem}[Heterogeneous sector comparison via a bundled matching witness]%
 \label{thm:route_b_hetero_sector_matching}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching}
@@ -894,6 +925,32 @@ single weighted block.
 	Theorem~\ref{thm:sector_basis_overlap_span_to_matching} produces the sector
 	basis matching and Theorem~\ref{thm:route_b_hetero_sector_matching} gives the
 	sector-weight conclusion.
+\end{proof}
+
+\begin{theorem}[Common live blocks with a common MPV phase cover give sector comparison]%
+\label{thm:after_blocking_sector_common_blocks_phase_cover}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover}
+	\leanok
+	\uses{lem:live_block_span_eq_of_common_phase_cover,
+		thm:after_blocking_sector_common_blocks_block_span}
+	Let $A$ and $B$ have the same MPV family, and fix exact live decompositions at a
+	common blocking period as in
+	Theorem~\ref{thm:after_blocking_sector_common_blocks_block_span}. Assume the live
+	blocks are trace-preserving, primitive, irreducible, injective, and have nonzero
+	weights. Suppose moreover that both live-block families map surjectively to one
+	common family of blocks, and that every live block is MPV-phase equivalent to its
+	image in the common family. Then the same sector comparison conclusion as in
+	Theorem~\ref{thm:after_blocking_sector_common_blocks_block_span} holds.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{lem:live_block_span_eq_of_common_phase_cover,
+		thm:after_blocking_sector_common_blocks_block_span}
+	Lemma~\ref{lem:live_block_span_eq_of_common_phase_cover} converts the common
+	MPV phase cover into equality of the live-block finite-length spans.
+	Theorem~\ref{thm:after_blocking_sector_common_blocks_block_span} then applies
+	without any additional sector-basis assumptions.
 \end{proof}
 
 \begin{lemma}[Zero-tail cancellation]\label{lem:sameMPV2_live_of_zeroTail_eq}


### PR DESCRIPTION
## Summary

- add `MPVBlockPhaseEquiv`, a heterogeneous block-level MPV phase relation, and span transport lemmas for phase covers
- prove `mpv_span_eq_of_common_phase_cover`: two nonzero-block families have equal finite-length MPV spans when both surject onto one common MPV-phase family
- add `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover`, which discharges the `hBlockSpan` input of the #960 common block-decomposition theorem from that common phase-cover data
- document the new predecessor in Chapter 11 and update the #877/#970 audit note

## Context

Issue #969 is not yet available on `origin/main`, so this does not claim the final theorem from structural `SameMPV₂` alone. Instead it formalizes the span adapter that the future common-blocking theorem should feed: once the structural reduction provides a common family plus two surjective MPV-phase cover maps, the remaining nonzero-block span equality is kernel-checked and the existing exact-nonzero sector comparison applies.

Advances #970 and #944; supports #969 and #652.

## Validation

- `lake build TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` passed
  - only pre-existing long-line warnings replayed from `CyclicSectorDecomposition.lean`
- `lake build TNLean` passed
  - only pre-existing `sorry`/long-line warnings in unrelated modules replayed
- `leanblueprint web` passed with TeX diagram rendering disabled via PATH workaround, because the local worktree path contains a space and the TikZ subprocess cannot quote it correctly
- `leanblueprint checkdecls` passed
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passed
- `git diff --check` passed
- added-line proof-integrity scan for `sorry|admit|axiom|native_decide|unsafe` passed
- added-line banned-prose scan passed for `collapsed representative`, `heterogeneous decomposition`, `matched basis`, `matched-basis`, `copy alignment`, and related packaging/helper terms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core canonical-form/Fundamental-Theorem plumbing by adding new equivalence notions and span-transport lemmas that other theorems can depend on. Risk is mainly proof/API coupling and subtle assumptions around surjectivity/phase scaling rather than runtime behavior.
> 
> **Overview**
> Introduces `MPVBlockPhaseEquiv`, a heterogeneous (dimension-agnostic) MPV phase-scaling relation for individual nonzero blocks, and refactors the existing family-level `MPVPhaseEquiv` to reuse it.
> 
> Adds linear-algebra lemmas (`mpv_span_le_of_phase_cover`, `mpv_span_eq_of_common_phase_cover`, etc.) showing that if two nonzero-block families surject onto a common family up to MPV phase, then their finite-length MPV state spans coincide.
> 
> Adds `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover`, which replaces the explicit nonzero-block span-equality hypothesis in `..._blockSpan` with the new common phase-cover span result; accompanying audit note and blueprint Chapter 11 are updated to document the new predecessor route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d2a6f50b2003eb2063de9be2f0b4e2dd143c124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->