### PR TITLE
feat(MPS/MPDO): add pair trace homogenization bridge

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -334,6 +334,27 @@ theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt
   wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords μ A hCF
     (hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt A hSep)
 
+/-- Canonical-form/BNT data plus cumulative pair trace separation and exact
+identity padding give full product-word span.
+
+This is the Route B homogenization: the cumulative finite cutoff can be
+used once each ordered pair has simultaneous identity padding at the lengths
+needed to reach a common homogeneous target `T`. -/
+theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S T : ℕ}
+    (hST : S ≤ T)
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingUpTo (A k) (A j) S)
+    (hPad : ∀ k j : Fin r, j ≠ k → ∀ l : ℕ, l ≤ S →
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T - l)))) :
+    WordTupleSpanTop A (1 + (r - 1) * T) :=
+  wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF
+    (fun k j hjk =>
+      pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identityPadding
+        (A k) (A j) hST (hSep k j hjk) (hPad k j hjk))
+
 /-- Positive-length product-word span obtained from canonical-form/BNT data and
 pairwise block-separating word polynomials. -/
 theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords
@@ -363,6 +384,28 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingA
   refine ⟨1 + (r - 1) * S, Nat.add_pos_left Nat.zero_lt_one _, ?_⟩
   simpa [WordTupleSpanTop, wordTuple] using
     wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hSep
+
+/-- Positive-length product-word span from cumulative pair trace separation plus
+exact identity padding. -/
+theorem
+    exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S T : ℕ}
+    (hST : S ≤ T)
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingUpTo (A k) (A j) S)
+    (hPad : ∀ k j : Fin r, j ≠ k → ∀ l : ℕ, l ≤ S →
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T - l)))) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  refine ⟨1 + (r - 1) * T, Nat.add_pos_left Nat.zero_lt_one _, ?_⟩
+  simpa [WordTupleSpanTop, wordTuple] using
+    wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding
+      μ A hCF hST hSep hPad
 
 /-- Positive-length product-word span obtained from canonical-form/BNT data and
 finite block-selector words.

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -385,10 +385,10 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingA
   simpa [WordTupleSpanTop, wordTuple] using
     wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hSep
 
+set_option linter.style.longLine false in
 /-- Positive-length product-word span from cumulative pair trace separation plus
 exact identity padding. -/
-theorem
-    exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding
+theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) {S T : ℕ}
     (hST : S ≤ T)

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -385,6 +385,41 @@ theorem pairWordTupleSpanTop_of_pairTraceSeparatingAt {D₁ D₂ : ℕ}
     simpa using hM
   exact hfne hfzero
 
+/-- Homogeneous pair product-span gives homogeneous trace separation. -/
+theorem pairTraceSeparatingAt_of_pairWordTupleSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hSpan : PairWordTupleSpanTop A B S) :
+    PairTraceSeparatingAt A B S := by
+  classical
+  intro ΔA ΔB hΔ
+  have hZeroOnSpan :
+      ∀ M : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ,
+        M ∈ Submodule.span ℂ (Set.range (pairWordTuple A B S)) →
+          Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) = 0 := by
+    intro M hM
+    exact pair_trace_zero_on_span ΔA ΔB
+      (Ω := Set.range (pairWordTuple A B S))
+      (by
+        rintro M ⟨w, rfl⟩
+        exact hΔ w)
+      M hM
+  constructor
+  · apply trace_mul_right_eq_zero
+    intro M
+    have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
+    simpa using hpair
+  · apply trace_mul_right_eq_zero
+    intro N
+    have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
+    simpa using hpair
+
+/-- Homogeneous pair product-span is equivalent to homogeneous trace separation. -/
+theorem pairWordTupleSpanTop_iff_pairTraceSeparatingAt {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ} :
+    PairWordTupleSpanTop A B S ↔ PairTraceSeparatingAt A B S :=
+  ⟨pairTraceSeparatingAt_of_pairWordTupleSpanTop A B,
+    pairWordTupleSpanTop_of_pairTraceSeparatingAt A B⟩
+
 /-- Cumulative trace separation is the dual form of cumulative pair product-span. -/
 theorem pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo {D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
@@ -622,6 +657,154 @@ theorem exists_forall_pairTraceSeparatingUpTo_of_forall_pairTraceSeparatingAll
   have hle : Sij (k, j) ≤ S := by
     exact Finset.le_sup (s := Finset.univ) (f := Sij) (Finset.mem_univ (k, j))
   exact hbase.mono hle
+
+/-! ### Homogenizing cumulative pair spans -/
+
+/-- A finite word pair belongs to the homogeneous pair span at its own length. -/
+theorem pairEvalWordTuple_mem_span_pairWordTuple_length {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) (w : List (Fin d)) :
+    pairEvalWordTuple A B w ∈
+      Submodule.span ℂ (Set.range (pairWordTuple A B w.length)) := by
+  apply Submodule.subset_span
+  exact ⟨w.get, by simp [pairWordTuple, pairEvalWordTuple, List.ofFn_get]⟩
+
+/-- Homogeneous pair spans are closed under componentwise multiplication, with
+word lengths adding. -/
+theorem pair_mul_mem_span_pairWordTuple_add {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {L S : ℕ}
+    {M N : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hM : M ∈ Submodule.span ℂ (Set.range (pairWordTuple A B L)))
+    (hN : N ∈ Submodule.span ℂ (Set.range (pairWordTuple A B S))) :
+    (M.1 * N.1, M.2 * N.2) ∈
+      Submodule.span ℂ (Set.range (pairWordTuple A B (L + S))) := by
+  classical
+  let spanLS : Submodule ℂ
+      (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ) :=
+    Submodule.span ℂ (Set.range (pairWordTuple A B (L + S)))
+  have hleft_gen : ∀ u : Fin L → Fin d,
+      ((pairWordTuple A B L u).1 * N.1, (pairWordTuple A B L u).2 * N.2) ∈
+        spanLS := by
+    intro u
+    induction hN using Submodule.span_induction with
+    | mem N' hNmem =>
+        rcases hNmem with ⟨v, rfl⟩
+        have hEq :
+            ((pairWordTuple A B L u).1 * (pairWordTuple A B S v).1,
+                (pairWordTuple A B L u).2 * (pairWordTuple A B S v).2) =
+              pairWordTuple A B (L + S) (Fin.append u v) := by
+          ext <;> simp [pairWordTuple, List.ofFn_fin_append, evalWord_append]
+        rw [hEq]
+        exact Submodule.subset_span ⟨Fin.append u v, rfl⟩
+    | zero =>
+        have hzero :
+            ((pairWordTuple A B L u).1 *
+                (0 : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ).1,
+              (pairWordTuple A B L u).2 *
+                (0 : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ).2) = 0 := by
+          simp
+        rw [hzero]
+        exact Submodule.zero_mem _
+    | add N₁ N₂ _ _ hN₁ hN₂ =>
+        have hEq :
+            ((pairWordTuple A B L u).1 * (N₁ + N₂).1,
+              (pairWordTuple A B L u).2 * (N₁ + N₂).2) =
+              ((pairWordTuple A B L u).1 * N₁.1,
+                (pairWordTuple A B L u).2 * N₁.2) +
+              ((pairWordTuple A B L u).1 * N₂.1,
+                (pairWordTuple A B L u).2 * N₂.2) := by
+          ext <;> simp [Matrix.mul_add]
+        rw [hEq]
+        exact Submodule.add_mem _ hN₁ hN₂
+    | smul a N _ hN =>
+        have hEq :
+            ((pairWordTuple A B L u).1 * (a • N).1,
+              (pairWordTuple A B L u).2 * (a • N).2) =
+              a • ((pairWordTuple A B L u).1 * N.1,
+                (pairWordTuple A B L u).2 * N.2) := by
+          ext <;> simp
+        rw [hEq]
+        exact Submodule.smul_mem _ a hN
+  induction hM using Submodule.span_induction with
+  | mem M hMmem =>
+      rcases hMmem with ⟨u, rfl⟩
+      exact hleft_gen u
+  | zero =>
+      have hzero :
+          ((0 : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ).1 * N.1,
+            (0 : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ).2 * N.2)
+            = 0 := by
+        simp
+      rw [hzero]
+      exact Submodule.zero_mem _
+  | add M₁ M₂ _ _ hM₁ hM₂ =>
+      have hEq : ((M₁ + M₂).1 * N.1, (M₁ + M₂).2 * N.2) =
+          (M₁.1 * N.1, M₁.2 * N.2) + (M₂.1 * N.1, M₂.2 * N.2) := by
+        ext <;> simp [Matrix.add_mul]
+      rw [hEq]
+      exact Submodule.add_mem _ hM₁ hM₂
+  | smul a M _ hM =>
+      have hEq : ((a • M).1 * N.1, (a • M).2 * N.2) =
+          a • (M.1 * N.1, M.2 * N.2) := by
+        ext <;> simp
+      rw [hEq]
+      exact Submodule.smul_mem _ a hM
+
+/-- A cumulative pair span can be homogenized once the simultaneous pair identity
+is available at every padding length needed to reach the target length.
+
+The padding hypothesis is the Burnside-Jacobson input deferred to a later step. -/
+theorem pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identityPadding
+    {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S T : ℕ}
+    (hST : S ≤ T)
+    (hCum : PairCumulativeWordTupleSpanTop A B S)
+    (hPad : ∀ l : ℕ, l ≤ S →
+      ((1 : Matrix (Fin D₁) (Fin D₁) ℂ), (1 : Matrix (Fin D₂) (Fin D₂) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B (T - l)))) :
+    PairWordTupleSpanTop A B T := by
+  classical
+  unfold PairWordTupleSpanTop
+  apply eq_top_iff.mpr
+  intro M _
+  have hM : M ∈ pairCumulativeSpan A B S := by
+    rw [hCum]
+    exact Submodule.mem_top
+  suffices hle : pairCumulativeSpan A B S ≤
+      Submodule.span ℂ (Set.range (pairWordTuple A B T)) from hle hM
+  apply Submodule.span_le.mpr
+  rintro N ⟨w, hwS, rfl⟩
+  have hwT : w.length ≤ T := le_trans hwS hST
+  have hword :
+      pairEvalWordTuple A B w ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B w.length)) :=
+    pairEvalWordTuple_mem_span_pairWordTuple_length A B w
+  have hmul :=
+    pair_mul_mem_span_pairWordTuple_add (A := A) (B := B)
+      (L := w.length) (S := T - w.length)
+      (M := pairEvalWordTuple A B w)
+      (N := ((1 : Matrix (Fin D₁) (Fin D₁) ℂ), (1 : Matrix (Fin D₂) (Fin D₂) ℂ)))
+      hword (hPad w.length hwS)
+  have hlen : w.length + (T - w.length) = T := Nat.add_sub_of_le hwT
+  have hprod :
+      ((pairEvalWordTuple A B w).1 * (1 : Matrix (Fin D₁) (Fin D₁) ℂ),
+        (pairEvalWordTuple A B w).2 * (1 : Matrix (Fin D₂) (Fin D₂) ℂ)) =
+        pairEvalWordTuple A B w := by
+    ext <;> simp
+  rw [hlen] at hmul
+  simpa [hprod] using hmul
+
+/-- Trace-separation version of
+`pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identityPadding`. -/
+theorem pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identityPadding
+    {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S T : ℕ}
+    (hST : S ≤ T)
+    (hSep : PairTraceSeparatingUpTo A B S)
+    (hPad : ∀ l : ℕ, l ≤ S →
+      ((1 : Matrix (Fin D₁) (Fin D₁) ℂ), (1 : Matrix (Fin D₂) (Fin D₂) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B (T - l)))) :
+    PairTraceSeparatingAt A B T :=
+  pairTraceSeparatingAt_of_pairWordTupleSpanTop A B
+    (pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identityPadding
+      A B hST (pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo A B hSep) hPad)
 
 /-- Pair product-span at length `S` gives a length-`S` selector for the first
 block of the pair. -/

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -696,12 +696,11 @@ theorem pair_mul_mem_span_pairWordTuple_add {D₁ D₂ : ℕ}
         rw [hEq]
         exact Submodule.subset_span ⟨Fin.append u v, rfl⟩
     | zero =>
+        let PairMat := Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ
         have hzero :
-            ((pairWordTuple A B L u).1 *
-                (0 : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ).1,
-              (pairWordTuple A B L u).2 *
-                (0 : Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ).2) = 0 := by
-          simp
+            ((pairWordTuple A B L u).1 * (0 : PairMat).1,
+              (pairWordTuple A B L u).2 * (0 : PairMat).2) = 0 := by
+          simp [PairMat]
         rw [hzero]
         exact Submodule.zero_mem _
     | add N₁ N₂ _ _ hN₁ hN₂ =>

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2914,6 +2914,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.pairCumulativeSpan_mono}
     \lean{MPSTensor.PairTraceSeparatingUpTo.mono}
     \lean{MPSTensor.pairTraceSeparatingUpTo_of_pairTraceSeparatingAt}
+    \lean{MPSTensor.pairTraceSeparatingAt_of_pairWordTupleSpanTop}
+    \lean{MPSTensor.pairWordTupleSpanTop_iff_pairTraceSeparatingAt}
     \lean{MPSTensor.pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo}
     \lean{MPSTensor.pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop}
     \lean{MPSTensor.pairCumulativeWordTupleSpanTop_iff_pairTraceSeparatingUpTo}
@@ -2944,6 +2946,31 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     criterion gives the stated finite bound.  This proves the cumulative
     finite-dimensional step; the remaining BNT step is to convert it to a
     single homogeneous length.
+\end{proof}
+
+\begin{lemma}[Homogenizing cumulative pair separation]
+    \label{lem:pair_trace_separation_homogenization_with_padding}
+    \lean{MPSTensor.pairEvalWordTuple_mem_span_pairWordTuple_length}
+    \lean{MPSTensor.pair_mul_mem_span_pairWordTuple_add}
+    \lean{MPSTensor.pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identityPadding}
+    \lean{MPSTensor.pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identityPadding}
+    \leanok
+    \uses{def:pair_trace_separation_words, lem:all_length_pair_trace_separation_finite_cutoff}
+    Suppose $S\le T$ and pair words of length at most $S$ span the product
+    algebra.  If, for every $\ell\le S$, the simultaneous identity pair belongs
+    to the span of pair words of length $T-\ell$, then pair words of the single
+    length $T$ already span the product algebra.  Equivalently, cumulative
+    trace separation up to $S$ becomes homogeneous trace separation at length
+    $T$ under the same identity-padding hypothesis.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    A pair word of length $\ell$ is multiplied by a length-$T-\ell$ expression
+    for the simultaneous identity.  Componentwise multiplication concatenates
+    words, so each cumulative generator is rewritten as a linear combination of
+    length-$T$ pair words.  The trace-dual version follows from homogeneous
+    pair trace duality.
 \end{proof}
 
 \begin{lemma}[Pair trace separation gives pairwise selectors]
@@ -3013,11 +3040,14 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
+    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}
     \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords}
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords}
     \leanok
     \uses{def:cf_bnt, lem:pair_trace_separation_to_pairwise_selectors,
+        lem:pair_trace_separation_homogenization_with_padding,
         lem:block_selectors_from_pairwise_separators,
         lem:block_projection_span_from_product_word_span}
     Let $((\mu_j),(A_j))$ be in canonical form with BNT separation.  Suppose there are
@@ -3029,6 +3059,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     pairwise separators for every ordered pair of distinct blocks; by
     Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}, a common
     pair trace-separation length is one sufficient finite-dimensional witness.
+    A cumulative pair trace cutoff is also enough, once $S\le T$, when paired
+    with the simultaneous identity-padding hypothesis of
+    Lemma~\ref{lem:pair_trace_separation_homogenization_with_padding}.
     Consequently, the pulled-back words at the resulting length for
     $\operatorname{Assemble}(\mu,A)$ span every virtual sector projection, and the
     corresponding commutant reduction is available.


### PR DESCRIPTION
### Motivation

- Issue #977 asks for the remaining homogeneous `PairTraceSeparatingAt` step from BNT non-equivalence (Burnside-Jacobson homogenization).
- This PR formalizes the reusable algebraic bridge that converts the cumulative finite cutoff proved in #974 into a homogeneous word length, given exact identity padding; the Burnside-Jacobson padding input itself is deferred.

### Description

- `TNLean/MPS/MPDO/BiCFDerivation.lean`: add homogeneous pair product-span / trace-separation duality for a fixed word length, and a cumulative-to-homogeneous pair span bridge under an explicit simultaneous identity-padding hypothesis (+181 lines).
- `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`: add BNT Route B wrappers that consume cumulative pair trace separation plus identity padding (+42 lines).
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: record the new declarations in Chapter 14 (+33 lines).

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.MPDO.BiCFDerivation`
- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `git diff --check -- TNLean/MPS/MPDO/BiCFDerivation.lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- Full root `TNLean` build and `leanblueprint checkdecls` were not completed locally; relies on Lean CI (`lean_action_ci.yml`) for final validation.

---
Addresses #977

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean lemmas and wrapper theorems without changing existing definitions; risk is mainly proof fragility and potential downstream rewrite breakage due to new equivalences and span/trace bridging lemmas.
> 
> **Overview**
> Adds a new **cumulative-to-homogeneous “homogenization” bridge** for pair trace separation: proves `PairWordTupleSpanTop ↔ PairTraceSeparatingAt`, then derives homogeneous length-`T` span/trace separation from cumulative separation up to `S` assuming explicit *simultaneous identity padding* at lengths `T - l`.
> 
> Builds Route-B-facing wrappers in `BlockDiagonalCommutant.lean` that consume `PairTraceSeparatingUpTo` plus the padding hypothesis to produce full product-word span (and the corresponding positive-length existence statement).
> 
> Updates the Chapter 14 blueprint to reference the new Lean declarations and adds a lemma documenting the homogenization-with-padding step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70f9dae182bbd00505eeff440f0469d18bfe369d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->