### PR TITLE
feat(MPS/Core): relate iterated blocking to direct blocking

### DIFF
--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -284,6 +284,78 @@ theorem blockPhysDim_blockPhysDim (d m n : ℕ) :
     blockPhysDim (blockPhysDim d m) n = blockPhysDim d (m * n) := by
   simp [blockPhysDim_eq_pow, pow_mul]
 
+/-- Encode a word of length `L` as a single blocked physical index. -/
+noncomputable def blockIndexOfList (d L : ℕ) (w : List (Fin d)) (h : w.length = L) :
+    Fin (blockPhysDim d L) :=
+  (Fintype.equivFin (Fin L → Fin d)) (fun i => w.get (Fin.cast h.symm i))
+
+/-- Decoding the blocked index associated to a list returns the original list. -/
+theorem wordOfBlock_blockIndexOfList (d L : ℕ) (w : List (Fin d))
+    (h : w.length = L) :
+    wordOfBlock d L (blockIndexOfList d L w h) = w := by
+  classical
+  unfold blockIndexOfList wordOfBlock decodeBlock
+  conv_rhs => rw [← List.ofFn_get w]
+  have hcongr :=
+    (List.ofFn_congr (m := L) (n := w.length) h.symm
+      (fun i : Fin L => w.get (Fin.cast h.symm i)))
+  simpa [Function.comp, Fin.cast_cast, blockPhysDim] using hcongr
+
+/-- The physical index of the one-shot block obtained from an iterated blocked index. -/
+noncomputable def iteratedBlockIndex (d m n : ℕ)
+    (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
+    Fin (blockPhysDim d (m * n)) :=
+  let w := flattenBlockedWord d m (wordOfBlock (blockPhysDim d m) n i)
+  have hw : w.length = m * n := by
+    rw [length_flattenBlockedWord, length_wordOfBlock, Nat.mul_comm]
+  blockIndexOfList d (m * n) w hw
+
+/-- The one-shot word associated to an iterated blocked index is the flattened word. -/
+theorem wordOfBlock_iteratedBlockIndex (d m n : ℕ)
+    (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
+    wordOfBlock d (m * n) (iteratedBlockIndex d m n i) =
+      flattenBlockedWord d m (wordOfBlock (blockPhysDim d m) n i) := by
+  classical
+  unfold iteratedBlockIndex
+  exact wordOfBlock_blockIndexOfList d (m * n)
+    (flattenBlockedWord d m (wordOfBlock (blockPhysDim d m) n i)) _
+
+/-- Reindex the physical alphabet of a tensor by a map of physical indices. -/
+noncomputable def reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
+    (A : MPSTensor d₂ D) : MPSTensor d₁ D :=
+  fun i => A (f i)
+
+/-- Iterated physical blocking agrees with one-shot blocking after the canonical
+index relabeling from iterated blocks to flattened blocks. -/
+theorem blockTensor_blockTensor_apply {D : ℕ} (A : MPSTensor d D) (m n : ℕ)
+    (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
+    blockTensor (d := blockPhysDim d m) (D := D)
+        (blockTensor (d := d) (D := D) A m) n i =
+      blockTensor (d := d) (D := D) A (m * n) (iteratedBlockIndex d m n i) := by
+  simp [blockTensor, evalWord_blockTensor, wordOfBlock_iteratedBlockIndex]
+
+/-- Tensor form of iterated blocking versus one-shot blocking with physical relabeling. -/
+theorem blockTensor_blockTensor_eq_reindex {D : ℕ} (A : MPSTensor d D) (m n : ℕ) :
+    blockTensor (d := blockPhysDim d m) (D := D)
+        (blockTensor (d := d) (D := D) A m) n =
+      reindexPhysical (iteratedBlockIndex d m n)
+        (blockTensor (d := d) (D := D) A (m * n)) := by
+  funext i
+  exact blockTensor_blockTensor_apply (d := d) A m n i
+
+/-- Iterated physical blocking and one-shot blocking have the same MPV family after
+the natural relabeling of physical indices. -/
+theorem sameMPV₂_blockTensor_blockTensor_mul_reindex {D : ℕ}
+    (A : MPSTensor d D) (m n : ℕ) :
+    SameMPV₂
+      (blockTensor (d := blockPhysDim d m) (D := D)
+        (blockTensor (d := d) (D := D) A m) n)
+      (reindexPhysical (iteratedBlockIndex d m n)
+        (blockTensor (d := d) (D := D) A (m * n))) := by
+  rw [blockTensor_blockTensor_eq_reindex]
+  intro N σ
+  rfl
+
 /-- Casting the physical dimension of both tensors preserves heterogeneous MPV equality. -/
 theorem sameMPV₂_cast_physDim {d₁ d₂ D₁ D₂ : ℕ} (h : d₁ = d₂)
     (A : MPSTensor d₁ D₁) (B : MPSTensor d₁ D₂) :

--- a/audits/2026-04-28_issue969_common_blocking.md
+++ b/audits/2026-04-28_issue969_common_blocking.md
@@ -18,6 +18,7 @@ The new statements keep the period-removal lengths distinct from any later commo
 ## Lean declarations added
 
 - `MPSTensor.blockPhysDim_blockPhysDim`: physical dimension of iterated blocking agrees with one-shot blocking by the product length.
+- `MPSTensor.sameMPV₂_blockTensor_blockTensor_mul_reindex`: iterated blocking and one-shot blocking have the same MPV family after the physical labels are identified by flattening iterated blocks.
 - Physical-dimension transport lemmas in `TNLean/MPS/Core/BlockingInfrastructure.lean` for `SameMPV₂`, `toTensorFromBlocks`, trace preservation, transfer-map primitivity, and tensor irreducibility.
 - `MPSTensor.CommonBlockedCyclicSectorFamily`: one-sided data structure for a finite live-block family. It stores:
   - a single positive blocking length `p`;
@@ -33,9 +34,9 @@ The new statements keep the period-removal lengths distinct from any later commo
 
 ## What remains for full #969 closure
 
-The new API deliberately exposes the remaining formal obligations instead of hiding them:
+The new statements deliberately expose the remaining formal obligations:
 
-1. Prove a one-shot iterated-blocking MPV/tensor compatibility theorem identifying `(B_k^[period k])^[extra k]` with `B_k^[p]` at the MPV equivalence needed by `toTensorFromBlocks`.
+1. Use the iterated-blocking relabeling theorem inside the common cyclic-sector data so each `(B_k^[period k])^[extra k]` is replaced by the corresponding one-shot block `B_k^[p]` with the same flattened physical labels.
 2. Flatten the weighted direct sum over original live blocks and cyclic sectors, transporting the original nonzero weights through the common blocking length.
 3. Re-express the zero-tail equations after the common physical reblocking, including the exact length-zero bookkeeping.
 4. Use the flattened common-alphabet live block family as the exact-live input for the sector comparison theorem from PR #960 once the finite-length span equality is available.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1220,7 +1220,7 @@ The following results separate the zero blocks from the
 	right-hand side is $d^{mn}$.
 \end{proof}
 
-\begin{theorem}[Iterated blocking and one-shot blocking have the same tensors after relabeling]
+\begin{theorem}[Iterated blocking and one-shot blocking yield the same MPV family after relabeling]
 	\label{thm:iterated_blocking_samempv_reindex}
 	\lean{MPSTensor.sameMPV₂_blockTensor_blockTensor_mul_reindex}
 	\leanok

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1224,7 +1224,7 @@ The following results separate the zero blocks from the
 	\label{thm:iterated_blocking_samempv_reindex}
 	\lean{MPSTensor.sameMPV₂_blockTensor_blockTensor_mul_reindex}
 	\leanok
-	\uses{def:blocked_tensor, def:same_mpv2, thm:iterated_blocking_phys_dim}
+	\uses{def:blocked_tensor, def:same_mpv2}
 	If one first blocks $m$ sites and then blocks $n$ of the resulting sites,
 	the resulting tensor has the same MPV family as the tensor obtained by
 	blocking $mn$ original sites, after the physical labels are identified by

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1220,6 +1220,24 @@ The following results separate the zero blocks from the
 	right-hand side is $d^{mn}$.
 \end{proof}
 
+\begin{theorem}[Iterated blocking and one-shot blocking have the same tensors after relabeling]
+	\label{thm:iterated_blocking_samempv_reindex}
+	\lean{MPSTensor.sameMPV₂_blockTensor_blockTensor_mul_reindex}
+	\leanok
+	\uses{def:blocked_tensor, def:same_mpv2, thm:iterated_blocking_phys_dim}
+	If one first blocks $m$ sites and then blocks $n$ of the resulting sites,
+	the resulting tensor has the same MPV family as the tensor obtained by
+	blocking $mn$ original sites, after the physical labels are identified by
+	flattening each iterated block.
+\end{theorem}
+
+\begin{proof}\leanok
+	For each iterated blocked index, decode the outer block, decode each inner
+	block, and concatenate the resulting words. This is exactly the word
+	decoded from the corresponding one-shot blocked index, so the word
+	evaluations, and hence all MPV coefficients, agree.
+\end{proof}
+
 \begin{theorem}[Physical-dimension transport and MPV equality]
 	\label{thm:samempv_cast_phys_dim}
 	\lean{MPSTensor.sameMPV₂_cast_physDim}


### PR DESCRIPTION
### Motivation

- Issue #969 requires all per-block cyclic-sector decompositions to be expressed at one common physical blocking length; this PR lands the predecessor step: showing iterated blocking agrees with direct blocking after an explicit physical-index relabeling.
- Because `blockPhysDim` is represented by finite cardinalities, the identification is not definitional — the proof must carry an explicit relabeling of physical indices.

### Description

- `TNLean/MPS/Core/BlockingInfrastructure.lean`: add physical-index relabeling from iterated blocked indices to flattened direct blocked indices; prove iterated blocking agrees with direct blocking after this relabeling at both tensor and `SameMPV₂` level (+72 lines).
- `blueprint/src/chapter/ch08_canonical.tex`: document the new predecessor theorem with `\lean{}` and `\leanok` tags (+18 lines).
- `audits/2026-04-28_issue969_common_blocking.md`: update issue audit.
- Weighted sector-family flattening and zero-tail transport remain separate follow-up steps.

### Testing

- `lake -Kjobs=1 build TNLean.MPS.Core.BlockingInfrastructure`
- `git diff --check`
- `rg -n "sorry|axiom|admit" TNLean/MPS/Core/BlockingInfrastructure.lean || true` (no occurrences)

---
Addresses #969

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new helper definitions/lemmas and proofs without changing existing APIs’ behavior; main risk is proof fragility or mismatched reindexing assumptions affecting downstream formalization.
> 
> **Overview**
> Establishes an explicit *canonical reindexing* from iterated blocked physical indices to the flattened direct blocked index (`iteratedBlockIndex`/`reindexPhysical`), and proves `(blockTensor (blockTensor A m) n)` agrees with `blockTensor A (m*n)` after relabeling, both pointwise and as a `SameMPV₂` statement (`sameMPV₂_blockTensor_blockTensor_mul_reindex`).
> 
> Updates the audit note for issue #969 and extends the blueprint with the new relabeling theorem and proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa1a9d3c99381189e734568427a47253ee32fbe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->