### PR TITLE
feat(MPS/CanonicalForm): construct relabelled common sectors (#969)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1212,7 +1212,9 @@ noncomputable def commonSectorBlock (F : CommonBlockedCyclicSectorFamily blocks)
 /-- Bond dimensions of the derived flattened common-sector family. -/
 noncomputable def commonFlatDim (F : CommonBlockedCyclicSectorFamily blocks) :
     Fin (∑ k : Fin r, F.period k) → ℕ :=
-  fun x => F.sectorDim (F.flatKey x).1 (F.flatKey x).2
+  fun x =>
+    let y := F.flatKey x
+    F.sectorDim y.1 y.2
 
 /-- The derived flattened common-sector family, indexed by `Fin (∑ k, F.period k)`. -/
 noncomputable def commonFlatBlocks (F : CommonBlockedCyclicSectorFamily blocks)
@@ -1254,49 +1256,52 @@ theorem commonFlatWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
     (x : Fin (∑ k : Fin r, F.period k)) : F.commonFlatWeight μ x ≠ 0 :=
   pow_ne_zero F.p (hμ (F.flatKey x).1)
 
-/-- Derived common-alphabet sectors are trace-preserving. -/
-theorem commonSectorBlock_tp (F : CommonBlockedCyclicSectorFamily blocks)
+private theorem commonSectorBlock_structural (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :
-    ∑ i : Fin (blockPhysDim d F.p),
-      (F.commonSectorBlock k s i)ᴴ * F.commonSectorBlock k s i = 1 := by
+    (∑ i : Fin (blockPhysDim d F.p),
+      (F.commonSectorBlock k s i)ᴴ * F.commonSectorBlock k s i = 1) ∧
+    _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d F.p) (D := F.sectorDim k s)
+        (F.commonSectorBlock k s)) ∧
+    IsIrreducibleTensor (F.commonSectorBlock k s) := by
   haveI : NeZero (F.sectorDim k s) := ⟨Nat.ne_of_gt (F.sector_dim_pos k s)⟩
   have hExtra := tp_primitive_irreducible_extra_blocking
     (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
     (A := F.sectorBlocks k s) (F.sector_tp k s) (F.sector_primitive k s)
     (F.sector_irreducible k s) (hk := F.extra_pos k)
-  have hcast := (leftCanonical_cast_physDim (F.blockPhysDim_nested_eq k)
-    (A := blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
-      (F.sectorBlocks k s) (F.extra k))).2 hExtra.1
-  simpa [commonSectorBlock] using hcast
+  refine ⟨?_, ?_, ?_⟩
+  · have hcast := (leftCanonical_cast_physDim (F.blockPhysDim_nested_eq k)
+      (A := blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+        (F.sectorBlocks k s) (F.extra k))).2 hExtra.1
+    simpa [commonSectorBlock] using hcast
+  · have hcast := (isPrimitive_transferMap_cast_physDim (F.blockPhysDim_nested_eq k)
+      (A := blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+        (F.sectorBlocks k s) (F.extra k))).2 hExtra.2.1
+    simpa [commonSectorBlock] using hcast
+  · have hcast := (isIrreducibleTensor_cast_physDim (F.blockPhysDim_nested_eq k)
+      (A := blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+        (F.sectorBlocks k s) (F.extra k))).2 hExtra.2.2
+    simpa [commonSectorBlock] using hcast
+
+/-- Derived common-alphabet sectors are trace-preserving. -/
+theorem commonSectorBlock_tp (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) (s : Fin (F.period k)) :
+    ∑ i : Fin (blockPhysDim d F.p),
+      (F.commonSectorBlock k s i)ᴴ * F.commonSectorBlock k s i = 1 :=
+  (commonSectorBlock_structural F k s).1
 
 /-- Derived common-alphabet sectors have primitive transfer maps. -/
 theorem commonSectorBlock_primitive (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :
     _root_.IsPrimitive
       (transferMap (d := blockPhysDim d F.p) (D := F.sectorDim k s)
-        (F.commonSectorBlock k s)) := by
-  haveI : NeZero (F.sectorDim k s) := ⟨Nat.ne_of_gt (F.sector_dim_pos k s)⟩
-  have hExtra := tp_primitive_irreducible_extra_blocking
-    (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
-    (A := F.sectorBlocks k s) (F.sector_tp k s) (F.sector_primitive k s)
-    (F.sector_irreducible k s) (hk := F.extra_pos k)
-  have hcast := (isPrimitive_transferMap_cast_physDim (F.blockPhysDim_nested_eq k)
-    (A := blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
-      (F.sectorBlocks k s) (F.extra k))).2 hExtra.2.1
-  simpa [commonSectorBlock] using hcast
+        (F.commonSectorBlock k s)) :=
+  (commonSectorBlock_structural F k s).2.1
 
 /-- Derived common-alphabet sectors are tensor-irreducible. -/
 theorem commonSectorBlock_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) (s : Fin (F.period k)) : IsIrreducibleTensor (F.commonSectorBlock k s) := by
-  haveI : NeZero (F.sectorDim k s) := ⟨Nat.ne_of_gt (F.sector_dim_pos k s)⟩
-  have hExtra := tp_primitive_irreducible_extra_blocking
-    (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
-    (A := F.sectorBlocks k s) (F.sector_tp k s) (F.sector_primitive k s)
-    (F.sector_irreducible k s) (hk := F.extra_pos k)
-  have hcast := (isIrreducibleTensor_cast_physDim (F.blockPhysDim_nested_eq k)
-    (A := blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
-      (F.sectorBlocks k s) (F.extra k))).2 hExtra.2.2
-  simpa [commonSectorBlock] using hcast
+    (k : Fin r) (s : Fin (F.period k)) : IsIrreducibleTensor (F.commonSectorBlock k s) :=
+  (commonSectorBlock_structural F k s).2.2
 
 /-- Derived common-alphabet sectors have positive bond dimensions. -/
 theorem commonSectorBlock_dim_pos (F : CommonBlockedCyclicSectorFamily blocks)

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1182,19 +1182,233 @@ structure CommonBlockedCyclicSectorFamily {d r : ℕ} {dim : Fin r → ℕ}
 
 namespace CommonBlockedCyclicSectorFamily
 
+variable {d r : ℕ} {dim : Fin r → ℕ}
+variable {blocks : (k : Fin r) → MPSTensor d (dim k)}
+
+/-- Decode a flattened common-sector index as an original live block and a cyclic sector. -/
+noncomputable def flatKey (F : CommonBlockedCyclicSectorFamily blocks)
+    (x : Fin (∑ k : Fin r, F.period k)) : (k : Fin r) × Fin (F.period k) :=
+  finSigmaFinEquiv.symm x
+
 /-- The flattened sectors produced by `CommonBlockedCyclicSectorFamily` carry unit weights. -/
-def flatWeight {d r : ℕ} {dim : Fin r → ℕ}
-    {blocks : (k : Fin r) → MPSTensor d (dim k)}
-    (F : CommonBlockedCyclicSectorFamily blocks) :
+def flatWeight (F : CommonBlockedCyclicSectorFamily blocks) :
     Fin (∑ k : Fin r, F.period k) → ℂ :=
   fun _ => 1
 
 /-- The unit weights of the flattened common-alphabet sectors are nonzero. -/
-theorem flatWeight_ne_zero {d r : ℕ} {dim : Fin r → ℕ}
-    {blocks : (k : Fin r) → MPSTensor d (dim k)}
-    (F : CommonBlockedCyclicSectorFamily blocks) (x : Fin (∑ k : Fin r, F.period k)) :
-    F.flatWeight x ≠ 0 := by
+theorem flatWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
+    (x : Fin (∑ k : Fin r, F.period k)) : F.flatWeight x ≠ 0 := by
   simp [flatWeight]
+
+/-- The common-alphabet sector obtained by later reblocking one cyclic sector. -/
+noncomputable def commonSectorBlock (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) (s : Fin (F.period k)) :
+    MPSTensor (blockPhysDim d F.p) (F.sectorDim k s) :=
+  cast (congr_arg (fun d' => MPSTensor d' (F.sectorDim k s))
+      (F.blockPhysDim_nested_eq k))
+    (blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+      (F.sectorBlocks k s) (F.extra k))
+
+/-- Bond dimensions of the derived flattened common-sector family. -/
+noncomputable def commonFlatDim (F : CommonBlockedCyclicSectorFamily blocks) :
+    Fin (∑ k : Fin r, F.period k) → ℕ :=
+  fun x => F.sectorDim (F.flatKey x).1 (F.flatKey x).2
+
+/-- The derived flattened common-sector family, indexed by `Fin (∑ k, F.period k)`. -/
+noncomputable def commonFlatBlocks (F : CommonBlockedCyclicSectorFamily blocks)
+    (x : Fin (∑ k : Fin r, F.period k)) :
+    MPSTensor (blockPhysDim d F.p) (F.commonFlatDim x) :=
+  let y := F.flatKey x
+  show MPSTensor (blockPhysDim d F.p) (F.sectorDim y.1 y.2) from
+    F.commonSectorBlock y.1 y.2
+
+/-- The common-alphabet sector tensor for one original live block. -/
+noncomputable def commonSectorTensor (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : MPSTensor (blockPhysDim d F.p) (∑ s : Fin (F.period k), F.sectorDim k s) :=
+  toTensorFromBlocks (d := blockPhysDim d F.p)
+    (μ := fun _ : Fin (F.period k) => (1 : ℂ)) (F.commonSectorBlock k)
+
+/-- A one-shot common-blocked live block with the explicit physical-label relabeling
+from iterated blocking to the one-shot blocked alphabet. -/
+noncomputable def oneShotReindexedBlock (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : MPSTensor (blockPhysDim d F.p) (dim k) :=
+  cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
+    (reindexPhysical (iteratedBlockIndex d (F.period k) (F.extra k))
+      (blockTensor (d := d) (D := dim k) (blocks k) (F.period k * F.extra k)))
+
+/-- The derived flattened sector weights obtained from the original live weights after
+blocking by the common length. -/
+noncomputable def commonFlatWeight (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) : Fin (∑ k : Fin r, F.period k) → ℂ :=
+  fun x => (μ (F.flatKey x).1) ^ F.p
+
+/-- Transported live weights remain nonzero after common blocking. -/
+theorem commonBlockWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) (k : Fin r) :
+    (μ k) ^ F.p ≠ 0 :=
+  pow_ne_zero F.p (hμ k)
+
+/-- Flattened sector weights remain nonzero after common blocking. -/
+theorem commonFlatWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0)
+    (x : Fin (∑ k : Fin r, F.period k)) : F.commonFlatWeight μ x ≠ 0 :=
+  pow_ne_zero F.p (hμ (F.flatKey x).1)
+
+/-- Derived common-alphabet sectors are trace-preserving. -/
+theorem commonSectorBlock_tp (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) (s : Fin (F.period k)) :
+    ∑ i : Fin (blockPhysDim d F.p),
+      (F.commonSectorBlock k s i)ᴴ * F.commonSectorBlock k s i = 1 := by
+  haveI : NeZero (F.sectorDim k s) := ⟨Nat.ne_of_gt (F.sector_dim_pos k s)⟩
+  have hExtra := tp_primitive_irreducible_extra_blocking
+    (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+    (A := F.sectorBlocks k s) (F.sector_tp k s) (F.sector_primitive k s)
+    (F.sector_irreducible k s) (hk := F.extra_pos k)
+  have hcast := (leftCanonical_cast_physDim (F.blockPhysDim_nested_eq k)
+    (A := blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+      (F.sectorBlocks k s) (F.extra k))).2 hExtra.1
+  simpa [commonSectorBlock] using hcast
+
+/-- Derived common-alphabet sectors have primitive transfer maps. -/
+theorem commonSectorBlock_primitive (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) (s : Fin (F.period k)) :
+    _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d F.p) (D := F.sectorDim k s)
+        (F.commonSectorBlock k s)) := by
+  haveI : NeZero (F.sectorDim k s) := ⟨Nat.ne_of_gt (F.sector_dim_pos k s)⟩
+  have hExtra := tp_primitive_irreducible_extra_blocking
+    (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+    (A := F.sectorBlocks k s) (F.sector_tp k s) (F.sector_primitive k s)
+    (F.sector_irreducible k s) (hk := F.extra_pos k)
+  have hcast := (isPrimitive_transferMap_cast_physDim (F.blockPhysDim_nested_eq k)
+    (A := blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+      (F.sectorBlocks k s) (F.extra k))).2 hExtra.2.1
+  simpa [commonSectorBlock] using hcast
+
+/-- Derived common-alphabet sectors are tensor-irreducible. -/
+theorem commonSectorBlock_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) (s : Fin (F.period k)) : IsIrreducibleTensor (F.commonSectorBlock k s) := by
+  haveI : NeZero (F.sectorDim k s) := ⟨Nat.ne_of_gt (F.sector_dim_pos k s)⟩
+  have hExtra := tp_primitive_irreducible_extra_blocking
+    (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+    (A := F.sectorBlocks k s) (F.sector_tp k s) (F.sector_primitive k s)
+    (F.sector_irreducible k s) (hk := F.extra_pos k)
+  have hcast := (isIrreducibleTensor_cast_physDim (F.blockPhysDim_nested_eq k)
+    (A := blockTensor (d := blockPhysDim d (F.period k)) (D := F.sectorDim k s)
+      (F.sectorBlocks k s) (F.extra k))).2 hExtra.2.2
+  simpa [commonSectorBlock] using hcast
+
+/-- Derived common-alphabet sectors have positive bond dimensions. -/
+theorem commonSectorBlock_dim_pos (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) (s : Fin (F.period k)) : 0 < F.sectorDim k s :=
+  F.sector_dim_pos k s
+
+/-- The derived flattened common-sector family is trace-preserving. -/
+theorem commonFlatBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
+    (x : Fin (∑ k : Fin r, F.period k)) :
+    ∑ i : Fin (blockPhysDim d F.p),
+      (F.commonFlatBlocks x i)ᴴ * F.commonFlatBlocks x i = 1 := by
+  let y := F.flatKey x
+  simpa [commonFlatBlocks, commonFlatDim, y] using F.commonSectorBlock_tp y.1 y.2
+
+/-- The derived flattened common-sector family has primitive transfer maps. -/
+theorem commonFlatBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
+    (x : Fin (∑ k : Fin r, F.period k)) :
+    _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d F.p) (D := F.commonFlatDim x)
+        (F.commonFlatBlocks x)) := by
+  let y := F.flatKey x
+  simpa [commonFlatBlocks, commonFlatDim, y] using F.commonSectorBlock_primitive y.1 y.2
+
+/-- The derived flattened common-sector family is tensor-irreducible. -/
+theorem commonFlatBlocks_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
+    (x : Fin (∑ k : Fin r, F.period k)) : IsIrreducibleTensor (F.commonFlatBlocks x) := by
+  let y := F.flatKey x
+  simpa [commonFlatBlocks, commonFlatDim, y] using F.commonSectorBlock_irreducible y.1 y.2
+
+/-- The derived flattened common-sector family has positive bond dimensions. -/
+theorem commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
+    (x : Fin (∑ k : Fin r, F.period k)) : 0 < F.commonFlatDim x := by
+  let y := F.flatKey x
+  simpa [commonFlatDim, y] using F.commonSectorBlock_dim_pos y.1 y.2
+
+/-- Iterated blocking of a live block is the relabeled one-shot common block. -/
+theorem nestedBlock_sameMPV₂_oneShotReindexedBlock
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
+    SameMPV₂
+      (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
+        (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
+          (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k)))
+      (F.oneShotReindexedBlock k) := by
+  have h := sameMPV₂_blockTensor_blockTensor_mul_reindex
+    (d := d) (D := dim k) (A := blocks k) (m := F.period k) (n := F.extra k)
+  exact (sameMPV₂_cast_physDim (F.blockPhysDim_nested_eq k)
+    (A := blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
+      (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k))
+    (B := reindexPhysical (iteratedBlockIndex d (F.period k) (F.extra k))
+      (blockTensor (d := d) (D := dim k) (blocks k) (F.period k * F.extra k)))).2 h
+
+/-- A one-shot relabeled live block is represented by its common-alphabet cyclic sectors. -/
+theorem oneShotReindexedBlock_sameMPV₂_commonSectorTensor
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
+    SameMPV₂ (F.oneShotReindexedBlock k) (F.commonSectorTensor k) := by
+  intro N σ
+  calc
+    mpv (F.oneShotReindexedBlock k) σ =
+        mpv (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
+          (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
+            (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k))) σ :=
+      ((F.nestedBlock_sameMPV₂_oneShotReindexedBlock k) N σ).symm
+    _ = mpv (F.commonSectorTensor k) σ := by
+      simpa [commonSectorTensor, commonSectorBlock] using F.nested_same k N σ
+
+/-- Weighted live blocks with explicit one-shot relabelings flatten to the common-sector family. -/
+theorem sameMPV₂_weightedOneShotReindexedBlock_commonFlat
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) (F.oneShotReindexedBlock))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) := by
+  intro N σ
+  let gSigma : ((k : Fin r) × Fin (F.period k)) → ℂ := fun y =>
+    ((μ y.1) ^ F.p) ^ N * mpv (F.commonSectorBlock y.1 y.2) σ
+  calc
+    mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) (F.oneShotReindexedBlock)) σ
+        = ∑ k : Fin r, ((μ k) ^ F.p) ^ N •
+            mpv (F.oneShotReindexedBlock k) σ :=
+          mpv_toTensorFromBlocks_eq_sum (fun k : Fin r => (μ k) ^ F.p)
+            (F.oneShotReindexedBlock) σ
+    _ = ∑ k : Fin r, ((μ k) ^ F.p) ^ N • mpv (F.commonSectorTensor k) σ := by
+          refine Finset.sum_congr rfl fun k _ => ?_
+          rw [F.oneShotReindexedBlock_sameMPV₂_commonSectorTensor k N σ]
+    _ = ∑ k : Fin r, ∑ s : Fin (F.period k),
+          ((μ k) ^ F.p) ^ N • mpv (F.commonSectorBlock k s) σ := by
+          refine Finset.sum_congr rfl fun k _ => ?_
+          change ((μ k) ^ F.p) ^ N •
+              mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+                (fun _ : Fin (F.period k) => (1 : ℂ)) (F.commonSectorBlock k)) σ =
+            ∑ s : Fin (F.period k),
+              ((μ k) ^ F.p) ^ N • mpv (F.commonSectorBlock k s) σ
+          rw [mpv_toTensorFromBlocks_eq_sum
+            (fun _ : Fin (F.period k) => (1 : ℂ)) (F.commonSectorBlock k) σ]
+          simp [smul_eq_mul, Finset.mul_sum]
+    _ = ∑ y : ((k : Fin r) × Fin (F.period k)),
+          ((μ y.1) ^ F.p) ^ N • mpv (F.commonSectorBlock y.1 y.2) σ := by
+          exact (Fintype.sum_sigma'
+            (fun k s => ((μ k) ^ F.p) ^ N • mpv (F.commonSectorBlock k s) σ)).symm
+    _ = ∑ x : Fin (∑ k : Fin r, F.period k),
+          (F.commonFlatWeight μ x) ^ N • mpv (F.commonFlatBlocks x) σ := by
+          have h := (Equiv.sum_comp
+            (finSigmaFinEquiv.symm :
+              Fin (∑ k : Fin r, F.period k) ≃ ((k : Fin r) × Fin (F.period k)))
+            gSigma).symm
+          simpa [gSigma, commonFlatWeight, commonFlatBlocks, commonFlatDim, flatKey,
+            smul_eq_mul] using h
+    _ = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ := by
+          exact (mpv_toTensorFromBlocks_eq_sum (F.commonFlatWeight μ) (F.commonFlatBlocks) σ).symm
 
 end CommonBlockedCyclicSectorFamily
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1244,7 +1244,11 @@ noncomputable def commonFlatWeight (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ) : Fin (∑ k : Fin r, F.period k) → ℂ :=
   fun x => (μ (F.flatKey x).1) ^ F.p
 
-/-- Transported live weights remain nonzero after common blocking. -/
+/-- Transported live weights remain nonzero after common blocking.
+
+This named form records the per-live-block weight transport used before flattening;
+`commonFlatWeight_ne_zero` is the corresponding statement after passing to flattened
+sector indices. -/
 theorem commonBlockWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) (k : Fin r) :
     (μ k) ^ F.p ≠ 0 :=

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -534,12 +534,12 @@ existence of the original live block families on both sides and, for each side, 
 finite flattened sector family at the corresponding common blocked physical
 dimension.  The flattened sectors are trace-preserving, have primitive transfer
 maps, are tensor-irreducible, have positive bond dimensions, and carry nonzero
-unit weights.  The statement keeps the
-checked zero-tail equations, positive-length live equality, and length-zero
-bookkeeping at the unblocked live-block level; the remaining #969 work is the
-one-shot iterated-blocking identification and weighted direct-sum flattening that
-would turn these common-alphabet sector families into exact decompositions of a
-single `blockTensor A p` and `blockTensor B p`. -/
+unit weights.  The statement keeps the checked zero-tail equations,
+positive-length live equality, and length-zero bookkeeping at the unblocked
+live-block level.  The companion theorem
+`fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_zeroTail`
+adds the one-shot, explicitly relabeled cyclic-sector flattening available after
+the iterated-blocking comparison theorem. -/
 theorem fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -591,6 +591,106 @@ theorem fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_ze
     exact familyA.flatWeight_ne_zero x
   · intro x
     exact familyB.flatWeight_ne_zero x
+
+/-- **Relabeled one-shot common-sector data with zero-tail reblocking.**
+
+This companion to
+`fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail`
+uses the common cyclic-sector family to expose the actual one-shot output available
+after the iterated-blocking comparison theorem.  For each side, the cyclic
+sectors are expressed as derived common-alphabet blocks `family.commonFlatBlocks`,
+with weights `μ^family.p` and
+nonzero transported sector weights.  The theorem also records the zero-tail
+identities after the corresponding common reblocking.
+
+The statement is deliberately explicit about physical labels: `oneShotReindexedBlock`
+is the block `B_k^[family.p]` after the iterated-block-to-one-shot relabeling
+`iteratedBlockIndex`.  It does not assert that the canonical one-shot blocked live
+block family and the per-block relabeled family are label-identical. -/
+theorem fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_zeroTail
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ (zeroTailA : ℕ) (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
+    ∃ (zeroTailB : ℕ) (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (k : Fin rB) → MPSTensor d (dimB k)),
+    ∃ (familyA : CommonBlockedCyclicSectorFamily blocksA),
+    ∃ (familyB : CommonBlockedCyclicSectorFamily blocksB),
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d familyA.p)),
+        mpv (blockTensor (d := d) (D := D₁) A familyA.p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d familyA.p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d familyA.p)
+              (fun k => (μA k) ^ familyA.p)
+              (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) familyA.p)) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d familyB.p)),
+        mpv (blockTensor (d := d) (D := D₂) B familyB.p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d familyB.p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d familyB.p)
+              (fun k => (μB k) ^ familyB.p)
+              (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) familyB.p)) σ) ∧
+      SameMPV₂
+        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
+          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.oneShotReindexedBlock)
+        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
+          (μ := familyA.commonFlatWeight μA) familyA.commonFlatBlocks) ∧
+      SameMPV₂
+        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
+          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.oneShotReindexedBlock)
+        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
+          (μ := familyB.commonFlatWeight μB) familyB.commonFlatBlocks) ∧
+      (∀ x, familyA.commonFlatWeight μA x ≠ 0) ∧
+      (∀ x, familyB.commonFlatWeight μB x ≠ 0) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d familyA.p),
+        (familyA.commonFlatBlocks x i)ᴴ * familyA.commonFlatBlocks x i = 1) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d familyB.p),
+        (familyB.commonFlatBlocks x i)ᴴ * familyB.commonFlatBlocks x i = 1) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d familyA.p) (D := familyA.commonFlatDim x)
+          (familyA.commonFlatBlocks x))) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d familyB.p) (D := familyB.commonFlatDim x)
+          (familyB.commonFlatBlocks x))) ∧
+      (∀ x, IsIrreducibleTensor (familyA.commonFlatBlocks x)) ∧
+      (∀ x, IsIrreducibleTensor (familyB.commonFlatBlocks x)) ∧
+      (∀ x, 0 < familyA.commonFlatDim x) ∧
+      (∀ x, 0 < familyB.commonFlatDim x) := by
+  obtain ⟨zeroTailA, rA, dimA, μA, blocksA,
+      zeroTailB, rB, dimB, μB, blocksB,
+      familyA, familyB, _hIrrA, _hIrrB, _hTPA, _hTPB, hμA, hμB, _hDimA, _hDimB,
+      hMPVA, hMPVB, _hPos, _hZero, _hUnitA, _hUnitB⟩ :=
+    fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail A B hSame
+  refine ⟨zeroTailA, rA, dimA, μA, blocksA,
+    zeroTailB, rB, dimB, μB, blocksB, familyA, familyB, ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · exact zeroTail_toTensorFromBlocks_blockPower
+      (d := d) (D := D₁) (r := rA) (z := zeroTailA) (p := familyA.p) (dim := dimA)
+      A μA blocksA familyA.p_pos hMPVA
+  · exact zeroTail_toTensorFromBlocks_blockPower
+      (d := d) (D := D₂) (r := rB) (z := zeroTailB) (p := familyB.p) (dim := dimB)
+      B μB blocksB familyB.p_pos hMPVB
+  · exact familyA.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μA
+  · exact familyB.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μB
+  · intro x
+    exact familyA.commonFlatWeight_ne_zero μA hμA x
+  · intro x
+    exact familyB.commonFlatWeight_ne_zero μB hμB x
+  · intro x
+    exact familyA.commonFlatBlocks_tp x
+  · intro x
+    exact familyB.commonFlatBlocks_tp x
+  · intro x
+    exact familyA.commonFlatBlocks_primitive x
+  · intro x
+    exact familyB.commonFlatBlocks_primitive x
+  · intro x
+    exact familyA.commonFlatBlocks_irreducible x
+  · intro x
+    exact familyB.commonFlatBlocks_irreducible x
+  · intro x
+    exact familyA.commonFlatDim_pos x
+  · intro x
+    exact familyB.commonFlatDim_pos x
 
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 

--- a/audits/2026-04-28_issue969_direct_common_blocking.md
+++ b/audits/2026-04-28_issue969_direct_common_blocking.md
@@ -1,0 +1,153 @@
+# 2026-04-28 — Issue #969 direct common-blocking progress after PR #981
+
+## Scope and issue-thread check
+
+This branch continues issue #969 after merged predecessors #973, #975, #976, and #981.
+Before finalizing statements, I read the issue bodies and comments for #969, #971, #970,
+#944, #942, #652, #840, #924, #932, and #982.
+
+The important conclusions from those threads are:
+
+- #975 already introduced `MPSTensor.CommonBlockedCyclicSectorFamily` and the one-sided
+  common reblocking constructor.  This branch should not duplicate that construction.
+- #981 already supplied the iterated-blocking physical relabeling
+  `MPSTensor.iteratedBlockIndex` and the theorem
+  `MPSTensor.sameMPV₂_blockTensor_blockTensor_mul_reindex`.  This branch uses it inside
+  the common cyclic-sector data rather than reproving it.
+- #973 already supplied the weight and zero-tail reblocking lemmas.  This branch calls
+  `zeroTail_toTensorFromBlocks_blockPower` and reuses the powered-weight nonvanishing
+  pattern instead of reproving zero-tail arithmetic inline.
+- #976 reduced the later span-equality step to a common MPV phase-cover input.  This
+  branch does not attempt to close #970/#944; it only makes the #969 common-sector data
+  more usable by exposing the direct, explicitly relabeled one-shot sector family.
+- The issue #969 addendum remains binding: the full route to #944/#652 still needs a
+  later common injectivity/Wielandt blocking stage.  The present branch preserves the
+  distinction between period removal and later injectivity blocking.
+
+## Paper route checked
+
+The statements follow the non-Gemma CPSV/CPGSV route.
+
+- `Papers/2011.12127/TN-Review-main.tex` lines 1815--1820 explains the period-removal
+  step: irreducible CP maps can have peripheral eigenvalues `e^{i2\pi q/p}`, and
+  "In order to remove them, we block $p$ spins."  The branch models this as the
+  per-live-block `period k` datum.
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 227--231 states the common-period move:
+  "If there are $t$ $p$-periodic vectors ... by blocking lcm$(p_1,\ldots,p_t)$ systems,
+  one obtains a vector without $p$-periodic ones."  The branch keeps the LCM-produced
+  common length `F.p` and the quotients `F.extra k` explicit.
+- `Papers/quant-ph_0608197/MPSarchive.tex` lines 849--880 gives the older periodic-sector
+  picture: a one-block canonical TI-MPS with $p$ peripheral eigenvalues decomposes into
+  $p$ periodic states, nonzero only when the period divides the chain length.  This is the
+  origin of the cyclic-sector indexing by `Fin (F.period k)`.
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 317--332 defines injectivity and recalls
+  the Wielandt blocking step: "after blocking at most $D^4$ times, every NT becomes
+  injective."  That later injectivity stage is not asserted by this branch.
+
+## Lean progress in this branch
+
+### `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`
+
+New derived operations for an existing `F : MPSTensor.CommonBlockedCyclicSectorFamily blocks`:
+
+- `F.flatKey`: decodes a flattened sector index as `(k,s)`.
+- `F.commonSectorBlock`: the common-alphabet sector obtained by later reblocking
+  `F.sectorBlocks k s` and substituting the equality of physical alphabet sizes.
+- `F.commonFlatDim` and `F.commonFlatBlocks`: a derived flattened family tied directly to
+  `F.sectorBlocks`, avoiding any dependence on abstract `F.flatBlocks` coincidences.
+- `F.commonSectorTensor`: the unit-weight sector tensor for one original live block.
+- `F.oneShotReindexedBlock`: the one-shot live block with the explicit physical-label
+  relabeling supplied by `MPSTensor.iteratedBlockIndex`.
+- `F.commonFlatWeight μ`: the flattened sector weights `(μ k) ^ F.p`.
+
+New structural/nonvanishing facts:
+
+- `F.commonBlockWeight_ne_zero` and `F.commonFlatWeight_ne_zero`.
+- `F.commonSectorBlock_tp`, `F.commonSectorBlock_primitive`,
+  `F.commonSectorBlock_irreducible`, `F.commonSectorBlock_dim_pos`.
+- `F.commonFlatBlocks_tp`, `F.commonFlatBlocks_primitive`,
+  `F.commonFlatBlocks_irreducible`, `F.commonFlatDim_pos`.
+
+New MPV comparison facts:
+
+- `F.nestedBlock_sameMPV₂_oneShotReindexedBlock`: composes `F.nested_same` with
+  `sameMPV₂_blockTensor_blockTensor_mul_reindex`, keeping the per-block physical relabeling
+  explicit.
+- `F.oneShotReindexedBlock_sameMPV₂_commonSectorTensor`: the relabeled one-shot live block
+  is represented by the corresponding common-alphabet cyclic sectors.
+- `F.sameMPV₂_weightedOneShotReindexedBlock_commonFlat`: the weighted direct sum of
+  relabeled one-shot live blocks flattens to the derived common-sector family with weights
+  `F.commonFlatWeight μ`.
+
+### `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
+
+New theorem:
+
+- `MPSTensor.fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_zeroTail`.
+
+This theorem starts from `SameMPV₂ A B`, reuses the already-merged common cyclic-sector
+families on both sides, and exposes:
+
+1. zero-tail/live equations after the corresponding common reblocking on each side;
+2. a `SameMPV₂` comparison between the weighted relabeled one-shot live blocks and the
+   derived flattened common-sector family;
+3. nonzero transported sector weights;
+4. trace preservation, primitive transfer maps, tensor irreducibility, and positive bond
+   dimensions for the derived common-sector families.
+
+The statement is intentionally honest about labels.  It does **not** assert an unlabeled
+`SameMPV₂ (blockTensor (blocks k) F.p) ...`; instead it uses `F.oneShotReindexedBlock k`,
+which includes the explicit physical-label relabeling from iterated blocking to one-shot
+blocking.  Because the relabeling can depend on the live block through `F.period k` and
+`F.extra k`, a global label-independent equality for the original weighted live tensor is
+not claimed here.
+
+## Interface toward the #970/#944 span adapter
+
+Current `main` already contains the span adapter from #976:
+
+- `MPSTensor.MPVBlockPhaseEquiv`;
+- `MPSTensor.mpv_span_eq_of_common_phase_cover`;
+- `MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover`.
+
+This branch therefore aims only to make the #969 common-blocking output closer to the
+exact-live input those theorems will eventually need.  The new data provide:
+
+- **Sector families:** `family.commonFlatBlocks` at physical dimension
+  `blockPhysDim d family.p`.
+- **Weights:** `family.commonFlatWeight μ`, equal to `(μ k) ^ family.p` on every sector
+  coming from live block `k`; `family.commonFlatWeight_ne_zero` proves nonvanishing from
+  the original nonzero live weights.
+- **TP/primitive/irreducible/positive dimension:** the `commonFlatBlocks_*` theorems give
+  all four structural properties needed before a later injectivity refinement.
+- **Exact relabeled live decomposition:**
+  `family.sameMPV₂_weightedOneShotReindexedBlock_commonFlat` proves that the weighted
+  family of explicitly relabeled one-shot live blocks has the same MPV family as the
+  flattened common sectors.
+- **Zero-tail equations after common reblocking:**
+  `fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_zeroTail`
+  records the zero-tail/live equation for `blockTensor A familyA.p` and `blockTensor B familyB.p`
+  with canonical blocked live blocks, and separately records the relabeled common-sector
+  flattening.
+
+The theorem **does not yet** supply the final exact decomposition
+`SameMPV₂ (blockTensor A p) (toTensorFromBlocks ... commonFlatBlocks)` in canonical physical
+labels.  It supplies the exact decomposition for the explicitly relabeled live-block family.
+This is intentional: `iteratedBlockIndex` is a real physical-label relabeling, and the branch
+keeps it visible rather than asserting label-independent equality.
+
+## Remaining blockers after this branch
+
+1. **Global physical-label compatibility.**  The branch proves the strongest currently honest
+   statement with explicit per-live-block relabeling.  To feed exact-live theorems that expect
+   canonical `blockTensor A p` labels, one still needs either a global relabeling statement or a
+   downstream theorem formulated for this explicit relabeled family.
+2. **One common length for both sides plus injectivity.**  The current one-sided families have
+   their own common lengths.  The final #944/#652 route needs a combined refinement that also
+   performs the Wielandt/injectivity blocking stage flagged in #969.
+3. **Common phase-cover maps.**  #976 provides the span adapter, but the actual surjective maps
+   from the final live-sector families to a common MPV phase-cover family still have to be
+   constructed from the structural equal-MPV data.
+4. **Zero-tail closure at the final exact-live endpoint.**  This branch transports the zero-tail
+   equations through each side's common reblocking.  The final endpoint still has to align the
+   two sides at the same physical blocking length and settle the exact length-zero contribution.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1679,6 +1679,85 @@ The following results separate the zero blocks from the
 	The weight is the constant value $1$, so it is nonzero.
 \end{proof}
 
+\begin{definition}[Derived common-alphabet cyclic sectors]%
+\label{def:common_blocked_cyclic_sector_derived_blocks}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.flatKey,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorTensor,
+		MPSTensor.CommonBlockedCyclicSectorFamily.oneShotReindexedBlock,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_family, def:blocked_tensor,
+		def:tensor_from_blocks, thm:iterated_blocking_samempv_reindex}
+	From a common reblocked cyclic-sector family, one may derive sector tensors at
+	the common alphabet directly from the original per-block sector tensors.  The
+	definition `oneShotReindexedBlock` keeps the physical-label relabeling explicit:
+	for the live block $B_k$, it uses the one-shot block $B_k^{[m_k e_k]}$ with the
+	labels obtained by flattening an iterated $(m_k,e_k)$ block.
+\end{definition}
+
+\begin{theorem}[Derived common-alphabet cyclic sectors retain structural properties]%
+\label{thm:common_blocked_cyclic_sector_derived_properties}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock_tp,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock_primitive,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock_irreducible,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock_dim_pos,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks_tp,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks_primitive,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks_irreducible,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim_pos,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonBlockWeight_ne_zero,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_derived_blocks,
+		thm:tp_primitive_irreducible_extra_blocking,
+		thm:left_canonical_cast_phys_dim, thm:primitive_transfer_cast_phys_dim,
+		thm:irreducible_tensor_cast_phys_dim}
+	The derived common-alphabet sectors are trace-preserving, have primitive transfer
+	maps, are tensor-irreducible, and have positive bond dimensions.  Original
+	nonzero live-block weights remain nonzero after being transported to the common
+	blocking length and replicated over the derived flattened sector family.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:tp_primitive_irreducible_extra_blocking,
+		thm:left_canonical_cast_phys_dim, thm:primitive_transfer_cast_phys_dim,
+		thm:irreducible_tensor_cast_phys_dim}
+	Apply the extra-blocking theorem to each period-removal sector, substitute the
+	equality between the iterated and common physical alphabets, and use that a
+	positive power of a nonzero complex number is nonzero.
+\end{proof}
+
+\begin{theorem}[Relabeled one-shot blocks decompose into common cyclic sectors]%
+\label{thm:common_blocked_cyclic_sector_reindexed_samempv}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.nestedBlock_sameMPV₂_oneShotReindexedBlock,
+		MPSTensor.CommonBlockedCyclicSectorFamily.oneShotReindexedBlock_sameMPV₂_commonSectorTensor,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedOneShotReindexedBlock_commonFlat}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_derived_blocks,
+		thm:iterated_blocking_samempv_reindex,
+		thm:samempv_cast_phys_dim, thm:samempv_blocking_distributes,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	For each live block, the iterated block $(B_k^{[m_k]})^{[e_k]}$ agrees, after
+	the explicit physical-label relabeling, with a one-shot block of length
+	$m_k e_k$.  Combining this with the stored cyclic-sector decomposition gives an
+	MPV equality between the relabeled one-shot block and its derived common-sector
+	tensor.  Summing over live blocks transports the weights to $\mu_k^p$ and
+	flattens the two-level live-block/sector sum into one sector family.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:iterated_blocking_samempv_reindex,
+		thm:samempv_cast_phys_dim, thm:samempv_blocking_distributes,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	First use the iterated-blocking comparison theorem and substitute the common
+	physical alphabet.  Then compose with the per-live-block cyclic-sector MPV
+	equivalence stored in the family.  Finally expand both block-diagonal tensors as
+	sums and reindex the double sum over pairs $(k,s)$ by the flattened sector index.
+\end{proof}
+
 \begin{theorem}[Common reblocking of per-block cyclic sectors]%
 \label{thm:exists_common_blocked_cyclic_sector_family}
 	\lean{MPSTensor.exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors}
@@ -3083,6 +3162,35 @@ The following results separate the zero blocks from the
 	Then apply Theorem~\ref{thm:exists_common_blocked_cyclic_sector_family} to the
 	per-block cyclic-sector data on each side.  The nonzero unit-weight conclusion
 	is Theorem~\ref{thm:common_blocked_cyclic_sector_flat_weight_ne_zero}.
+\end{proof}
+
+\begin{theorem}[Relabeled common cyclic sectors with reblocked zero-tail equations]%
+\label{thm:ft_after_blocking_reindexed_common_sector_live_zero_tail}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_zeroTail}
+	\leanok
+	\uses{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail,
+		thm:zero_tail_to_tensor_from_blocks_block_power,
+		thm:common_blocked_cyclic_sector_reindexed_samempv,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	If two tensors generate the same MPV family, then the common cyclic-sector data
+	from Theorem~\ref{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail}
+	also yields, on each side, a derived common-alphabet sector family obtained from
+	one-shot blocked live blocks with explicit physical-label relabeling.  The
+	sector weights are the transported powers $\mu_k^p$ and remain nonzero, the
+	derived sectors are trace-preserving, primitive, tensor-irreducible, and
+	positive-dimensional, and the zero-tail/live equations are also recorded after
+	the corresponding common reblocking.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail,
+		thm:zero_tail_to_tensor_from_blocks_block_power,
+		thm:common_blocked_cyclic_sector_reindexed_samempv,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	Start from the common reblocked cyclic-sector families on the two sides.  Apply
+	the zero-tail reblocking theorem to the original live-block decomposition, then
+	use the relabeled one-shot sector decomposition and the derived structural
+	properties of the common-sector family.
 \end{proof}
 
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1693,9 +1693,9 @@ The following results separate the zero blocks from the
 		def:tensor_from_blocks, thm:iterated_blocking_samempv_reindex}
 	From a common reblocked cyclic-sector family, one may derive sector tensors at
 	the common alphabet directly from the original per-block sector tensors.  The
-	definition `oneShotReindexedBlock` keeps the physical-label relabeling explicit:
-	for the live block $B_k$, it uses the one-shot block $B_k^{[m_k e_k]}$ with the
-	labels obtained by flattening an iterated $(m_k,e_k)$ block.
+	one-shot live-block data keeps the physical-label relabeling explicit: for the
+	live block $B_k$, it uses the one-shot block $B_k^{[m_k e_k]}$ with the labels
+	obtained by flattening an iterated $(m_k,e_k)$ block.
 \end{definition}
 
 \begin{theorem}[Derived common-alphabet cyclic sectors retain structural properties]%
@@ -3176,10 +3176,12 @@ The following results separate the zero blocks from the
 	from Theorem~\ref{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail}
 	also yields, on each side, a derived common-alphabet sector family obtained from
 	one-shot blocked live blocks with explicit physical-label relabeling.  The
-	sector weights are the transported powers $\mu_k^p$ and remain nonzero, the
-	derived sectors are trace-preserving, primitive, tensor-irreducible, and
-	positive-dimensional, and the zero-tail/live equations are also recorded after
-	the corresponding common reblocking.
+	conclusion includes the two MPV-family equalities comparing the weighted
+	relabeled one-shot live-block tensors with the weighted derived common-sector
+	tensors.  The sector weights are the transported powers $\mu_k^p$ and remain
+	nonzero, the derived sectors are trace-preserving, primitive, tensor-irreducible,
+	and positive-dimensional, and the zero-tail/live equations are also recorded
+	after the corresponding common reblocking.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Summary

- Add derived `CommonBlockedCyclicSectorFamily` sector blocks and weights tied directly to the stored cyclic sector blocks, avoiding any reliance on abstract `flatBlocks` definitional coincidence.
- Use `sameMPV₂_blockTensor_blockTensor_mul_reindex` / `iteratedBlockIndex` to collapse the stored nested per-nonzero-block MPV equivalence into an explicit relabeled direct nonzero-block sector decomposition.
- Add `fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_zeroTail`, exposing common-sector families, nonzero transported weights, TP/primitive/irreducible/positive-dimension facts, and zero-tail equations after common reblocking.
- Update Chapter 8 blueprint entries and add an audit of the exact progress and remaining #969/#970/#944/#652 blockers.

## Paper/issue context

Refs #969. Related: #971, #970, #944, #942, #652.

Before finalizing the statement I read the issue bodies/comments for #969, #971, #970, #944, #942, #652, #840, #924, #932, and #982, and checked the paper passages:

- `Papers/2011.12127/TN-Review-main.tex` lines 1815--1820: period removal by blocking.
- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 227--231: LCM common blocking of periodicities.
- `Papers/quant-ph_0608197/MPSarchive.tex` lines 849--880: periodic-sector decomposition picture.
- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 317--332: later injectivity/Wielandt blocking, still not closed here.

This PR is intentionally honest about physical labels: the new exact decomposition is for the explicitly relabeled direct nonzero-block family (`oneShotReindexedBlock`), not for canonical `blockTensor A p` labels. The remaining global-label/injectivity/phase-cover blockers are recorded in the audit.

## Validation

- [x] `lake exe cache get`
- [x] `lake build --old TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
  - only the two pre-existing long-line warnings in `CyclicSectorDecomposition.lean` replayed at lines 683 and 913
- [x] `lake build --old TNLean`
  - only pre-existing unrelated `sorry` warnings replayed
- [x] `cd blueprint && leanblueprint checkdecls`
- [x] `cd blueprint && leanblueprint web` with a PATH shim hiding Homebrew `latex`/`dvisvgm` (known local iCloud-path/TikZ workaround)
- [x] `python3 scripts/blueprint_lean_sync.py --root . --ci`
- [x] `git diff --check`
- [x] added-line scan for `sorry|admit|axiom|native_decide|unsafe` and banned shorthand prose terms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial new Lean definitions/theorems around `CommonBlockedCyclicSectorFamily` reindexing/flattening, which can affect downstream proofs and typeclass/definitional equality expectations, but does not change core runtime logic.
> 
> **Overview**
> Extends `CommonBlockedCyclicSectorFamily` with *derived* common-alphabet sector blocks (`commonSectorBlock`, `commonFlatBlocks`) and transported weights (`commonFlatWeight`) that are defined directly from the stored per-block cyclic sectors, plus lemmas showing TP/primitive/irreducible/positive-dimension properties and nonvanishing of transported weights.
> 
> Adds MPV-equivalence results that make the physical-index relabelling explicit (`oneShotReindexedBlock` via `iteratedBlockIndex`) and prove the weighted direct-sum of these relabeled direct nonzero blocks flattens to the derived common sector family.
> 
> Introduces `fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_zeroTail`, a companion structural theorem that records the reblocked zero-tail equations and states the new relabeled/flattened common-sector data (including structural properties and nonzero weights). Documentation is updated via a new audit note and blueprint chapter additions reflecting the new derived constructions and theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfd92ed0d114777c6b666098bed0a80e50a1539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->