### PR TITLE
doc(MPS/Symmetry): clarify FT route for virtual symmetry (#982)

### DIFF
--- a/TNLean/MPS/Symmetry/Defs.lean
+++ b/TNLean/MPS/Symmetry/Defs.lean
@@ -76,10 +76,10 @@ lemma twistedTensor_mul (A : MPSTensor d D)
 
 /-- Injective on-site symmetry implies each twisted tensor is gauge equivalent to `A`.
 
-This is the single-block Fundamental Theorem route: `hSymm g` supplies
+This is the single-block Fundamental Theorem route: on-site symmetry supplies
 `SameMPV A (twistedTensor A U g)`, and
-`sameMPV_iff_gaugeEquiv_of_injective hA` converts equal MPV families into gauge
-equivalence. -/
+`sameMPV_iff_gaugeEquiv_of_injective` converts equal MPV families into gauge
+equivalence for injective tensors. -/
 theorem gaugeEquiv_twistedTensor_of_injective
     (A : MPSTensor d D) (hA : IsInjective A)
     (U : G →* Matrix (Fin d) (Fin d) ℂ)

--- a/TNLean/MPS/Symmetry/Defs.lean
+++ b/TNLean/MPS/Symmetry/Defs.lean
@@ -6,6 +6,12 @@ import TNLean.MPS.FundamentalTheorem.Basic
 This module defines the symmetry-twisted tensor construction and proves its
 functoriality, establishing the algebraic foundations for on-site symmetric MPS.
 
+The injective virtual-gauge statement is deliberately routed through the
+single-block Fundamental Theorem: `IsOnSiteSymmetric` gives
+`SameMPV A (twistedTensor A U g)`, and
+`sameMPV_iff_gaugeEquiv_of_injective` turns that equality of MPV families into a
+virtual gauge. No string-order or periodic-FT input is used in this step.
+
 ## Main definitions
 
 * `MPSTensor.twistedTensor` : twist an MPS tensor by a group representation on the physical index
@@ -68,7 +74,12 @@ lemma twistedTensor_mul (A : MPSTensor d D)
     _ = twistedTensor (twistedTensor A U h) U g i := by
           simp [twistedTensor, Finset.smul_sum, smul_smul]
 
-/-- Injective on-site symmetry implies each twisted tensor is gauge equivalent to `A`. -/
+/-- Injective on-site symmetry implies each twisted tensor is gauge equivalent to `A`.
+
+This is the single-block Fundamental Theorem route: `hSymm g` supplies
+`SameMPV A (twistedTensor A U g)`, and
+`sameMPV_iff_gaugeEquiv_of_injective hA` converts equal MPV families into gauge
+equivalence. -/
 theorem gaugeEquiv_twistedTensor_of_injective
     (A : MPSTensor d D) (hA : IsInjective A)
     (U : G →* Matrix (Fin d) (Fin d) ℂ)

--- a/TNLean/MPS/Symmetry/VirtualRepresentation.lean
+++ b/TNLean/MPS/Symmetry/VirtualRepresentation.lean
@@ -14,6 +14,12 @@ then the virtual gauge matrices extracted from the single-block Fundamental Theo
 can be reindexed by inversion to produce a genuine projective representation on the
 bond space.
 
+The proof uses `gaugeEquiv_twistedTensor_of_injective` as its only source of the
+pointwise gauges. That theorem is the single-block Fundamental Theorem applied to
+each twisted tensor. The rest of this file uses gauge uniqueness and the twist
+composition law; the string-order development later consumes this theorem rather
+than proving it.
+
 ## Main results
 
 * `MPSTensor.virtual_rep_of_symmetric_injective`: the main theorem — the virtual gauges
@@ -88,7 +94,8 @@ private lemma gauge_product_intertwines
 /-- **Virtual representation theorem for injective MPS with on-site symmetry.**
 
 If an injective MPS tensor `A` is symmetric under on-site action of a group `G`,
-then there exist:
+then the single-block Fundamental Theorem supplies gauges for all twists, and
+there exist:
 - a unit-valued scalar cocycle `ω : ScalarCocycle G`,
 - a projective representation `ρ` of `G` on the bond space,
 

--- a/audits/2026-04-28_issue982_ft_symmetry_triage.md
+++ b/audits/2026-04-28_issue982_ft_symmetry_triage.md
@@ -1,0 +1,108 @@
+# 2026-04-28 — Issue #982 FT-based symmetry triage
+
+Issue #982 asks that symmetry be proved by the Fundamental Theorem rather than
+by the string-order development or the periodic-FT track.  I checked the current
+Lean files, blueprint, issue threads, and the relevant paper passages.
+
+## Existing injective theorem path
+
+The injective case is already on the Fundamental-Theorem route.
+
+* `MPSTensor.gaugeEquiv_twistedTensor_of_injective` in
+  `TNLean/MPS/Symmetry/Defs.lean` proves, for every group element `g`,
+  `GaugeEquiv A (twistedTensor A U g)` from injectivity and on-site symmetry.
+  Its proof is exactly
+  `(sameMPV_iff_gaugeEquiv_of_injective hA).1 (hSymm g)`.
+* `MPSTensor.sameMPV_iff_gaugeEquiv_of_injective` in
+  `TNLean/MPS/FundamentalTheorem/Basic.lean` is the wrapper around
+  `MPSTensor.fundamentalTheorem_singleBlock`.
+* `MPSTensor.virtual_rep_of_symmetric_injective` in
+  `TNLean/MPS/Symmetry/VirtualRepresentation.lean` chooses those gauges and uses
+  gauge uniqueness plus `MPSTensor.twistedTensor_mul` to package them as a
+  bond-space projective representation.
+* `MPSTensor.hasStringOrder_of_symmetric_injective` in
+  `TNLean/MPS/Symmetry/StringOrder.lean` consumes
+  `virtual_rep_of_symmetric_injective` later.  It is downstream of the FT-based
+  virtual representation theorem, not the proof of that theorem.
+
+The blueprint now says this explicitly in
+`blueprint/src/chapter/ch13b_symmetry.tex`, in the proof of
+`lem:gauge_equiv_twisted` and the new remark
+`rem:injective_symmetry_ft_route`.
+
+## Paper passages checked
+
+* `Papers/2011.12127/TN-Review-main.tex` lines 1084--1090 state the injective
+  symmetry route: equality of normal MPS implies a gauge, and applying a global
+  on-site symmetry gives
+  `\sum_j U_{ij}(g) A^j = e^{i\phi(g)} X^\dagger(g) A^i X(g)`.
+* The same file at lines 1103--1105 records the projective law
+  `X_g X_h = e^{i\omega(g,h)} X_{gh}` for virtual symmetries.
+* Lines 1743--1744 say the Fundamental Theorem is the basic tool for phase
+  classification under symmetries, with `B^i = \sum u_{ij} A^j`.
+* Lines 1896--1900 give the equal-MPV Fundamental Theorem corollary: in
+  canonical form, equal MPV families imply a global gauge.
+* `Papers/0802.0447/StringOrder-v10.tex` lines 306--311 prove the separate
+  string-order/local-symmetry criterion for pure FCS.  That is a detection and
+  rigidity result, not the shortest route to the virtual gauge in the injective
+  case.
+* `Papers/quant-ph_0608197/MPSarchive.tex` lines 742--763 give the TI canonical
+  form, lines 849--879 give the periodic sector decomposition, and lines
+  1002--1014 state canonical-form uniqueness.
+* `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 187--190 recall gauge
+  equivalence as the basic same-MPV mechanism, lines 227--231 explain blocking
+  by common periods, and lines 271--301 give the BNT expansion used by the
+  non-injective canonical-form route.
+
+## Issue-thread context
+
+* #982 itself has only the title/body request and no comments.
+* #652 is the non-periodic canonical-form umbrella.  The current thread no
+  longer asks for a direct same-norm shortcut; it has been refined to the
+  sector-level route through common live blocks, BNT sector comparison, zero-tail
+  bookkeeping, and finite-length span equality.
+* #942 remains open as the broad common-live-block tracker, but its thread now
+  points to the more precise common blocking work in #969.
+* #944 is the BNT representative overlap/span tracker.  PR #955 supplied the
+  one-sided overlap data; PR #960 transported representative spans; PR #976
+  added the common-phase-cover span adapter.  The remaining input is deriving
+  the common live family and phase-cover maps from the structural reduction.
+* #969 is the live common-blocking issue.  PR #975 introduced the common
+  cyclic-sector family; PR #981 supplied the iterated-blocking relabeling.  The
+  thread still records the remaining flattening, zero-tail transport, and later
+  injectivity/Wielandt blocking obligations.
+* #970 is the live-block span-equality issue.  PR #976 supplied
+  `MPSTensor.mpv_span_eq_of_common_phase_cover`, so the remaining span step is
+  to construct the common live family and surjective phase-cover maps.
+* #840 states the current global priority: parent Hamiltonians and
+  canonical-form reduction.  Its canonical-form ranking is #942/#944, now
+  refined by #969/#970.
+* #924 says to clean up the full canonical-form reduction without using the
+  periodic track; #932 asks issue/PR reports to cite LaTeX line numbers and
+  quote the relevant source.  This audit follows that convention.
+* Open symmetry-labelled issues #619, #622, #664, and #829 belong to the
+  periodic-FT track.  They are useful background for periodic symmetry results,
+  but they should not be the main route for #982.
+* #335 and #330 record that the injective symmetry/SPT blueprint chapter now
+  exists and includes string order.  This supports the conclusion above: string
+  order is present as a later consequence/detection theory, while the virtual
+  gauge for injective symmetric MPS comes from the Fundamental Theorem.
+
+## Remaining non-injective/multi-block route
+
+For a non-injective tensor `A`, the corresponding symmetry theorem should compare
+`A` with `twistedTensor A U g` using the non-periodic equal-case FT after the
+canonical-form reduction is completed.  The expected route is:
+
+1. use on-site symmetry to get `SameMPV₂ A (twistedTensor A U g)`;
+2. apply the after-blocking/canonical-sector equal-case theorem once #969,
+   #970, and #944 discharge the remaining common-live, zero-tail, injectivity,
+   and span inputs;
+3. package the resulting sector-level virtual data into a permutation/phase
+   action on canonical sectors, and then into projective data on each invariant
+   sector when the relevant stabilizer action is fixed.
+
+No new follow-up issue is needed yet: #969, #970, #944, and the umbrella #652
+already track the prerequisites.  A separate symmetry packaging issue would be
+appropriate only after those FT inputs expose the sector-level comparison as a
+public theorem.

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -153,7 +153,8 @@ on the bond space.
 
 \begin{remark}[Fundamental-Theorem route for injective symmetry]%
     \label{rem:injective_symmetry_ft_route}
-    \uses{thm:ft_single, lem:gauge_equiv_twisted, thm:virtual_rep_injective}
+    \uses{thm:ft_single, lem:gauge_equiv_twisted, lem:gauge_unique_up_to_scalar,
+        lem:twisted_tensor_mul, thm:virtual_rep_injective}
     The injective virtual-representation theorem is not proved from string-order
     rigidity. The on-site symmetry condition first identifies $A$ and
     $\widetilde{A}_g$ as the same MPV family; the single-block Fundamental
@@ -275,7 +276,7 @@ on the bond space.
     \leanok
     \uses{def:injective, def:on_site_symmetric, def:projective_rep,
         def:scalar_cocycle, lem:gauge_unique_up_to_scalar,
-        lem:twisted_tensor_mul, thm:ft_single}
+        lem:twisted_tensor_mul}
     Let $A$ be an injective MPS tensor that is on-site symmetric
     under a group representation $U : G \to \GL_d(\C)$.
     Then there exist:
@@ -308,7 +309,7 @@ on the bond space.
 \begin{proof}
     \leanok
     \uses{def:on_site_symmetric, lem:gauge_equiv_twisted,
-        lem:gauge_unique_up_to_scalar, lem:twisted_tensor_mul, thm:ft_single}
+        lem:gauge_unique_up_to_scalar, lem:twisted_tensor_mul}
     Since $A$ is injective and on-site symmetric, each twisted tensor
     $\widetilde{A}_g$ is gauge equivalent to~$A$
     (Lemma~\ref{lem:gauge_equiv_twisted}).

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -138,7 +138,7 @@ on the bond space.
     \label{lem:gauge_equiv_twisted}
     \lean{MPSTensor.gaugeEquiv_twistedTensor_of_injective}
     \leanok
-    \uses{def:injective, def:on_site_symmetric, thm:ft_single}
+    \uses{def:injective, def:on_site_symmetric}
     If $A$ is injective and on-site symmetric under $U$, then
     for every $g \in G$ the twisted tensor $\widetilde{A}_g$ is
     gauge equivalent to~$A$.

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -138,17 +138,30 @@ on the bond space.
     \label{lem:gauge_equiv_twisted}
     \lean{MPSTensor.gaugeEquiv_twistedTensor_of_injective}
     \leanok
-    \uses{def:injective, def:on_site_symmetric}
+    \uses{def:injective, def:on_site_symmetric, thm:ft_single}
     If $A$ is injective and on-site symmetric under $U$, then
     for every $g \in G$ the twisted tensor $\widetilde{A}_g$ is
     gauge equivalent to~$A$.
 \end{lemma}
 
-\begin{proof}\leanok\uses{def:on_site_symmetric}
+\begin{proof}\leanok\uses{def:on_site_symmetric, thm:ft_single}
     On-site symmetry gives
-    $\mc{V}(A) = \mc{V}(\widetilde{A}_g)$, and equal MPV
-    for injective tensors implies gauge equivalence.
+    $\mc{V}(A) = \mc{V}(\widetilde{A}_g)$, and the single-block
+    Fundamental Theorem turns this equality of MPV families into gauge
+    equivalence.
 \end{proof}
+
+\begin{remark}[Fundamental-Theorem route for injective symmetry]%
+    \label{rem:injective_symmetry_ft_route}
+    \uses{thm:ft_single, lem:gauge_equiv_twisted, thm:virtual_rep_injective}
+    The injective virtual-representation theorem is not proved from string-order
+    rigidity. The on-site symmetry condition first identifies $A$ and
+    $\widetilde{A}_g$ as the same MPV family; the single-block Fundamental
+    Theorem gives the gauge in Lemma~\ref{lem:gauge_equiv_twisted}. Gauge
+    uniqueness and the twist composition law then assemble these gauges into
+    Theorem~\ref{thm:virtual_rep_injective}. The string-order results later in
+    this chapter use this virtual representation as an input.
+\end{remark}
 
 \begin{theorem}[Virtual symmetry equation]\label{thm:virtual_symmetry_eq}
     \lean{MPSTensor.virtual_symmetry_eq}
@@ -262,7 +275,7 @@ on the bond space.
     \leanok
     \uses{def:injective, def:on_site_symmetric, def:projective_rep,
         def:scalar_cocycle, lem:gauge_unique_up_to_scalar,
-        lem:twisted_tensor_mul}
+        lem:twisted_tensor_mul, thm:ft_single}
     Let $A$ be an injective MPS tensor that is on-site symmetric
     under a group representation $U : G \to \GL_d(\C)$.
     Then there exist:
@@ -295,7 +308,7 @@ on the bond space.
 \begin{proof}
     \leanok
     \uses{def:on_site_symmetric, lem:gauge_equiv_twisted,
-        lem:gauge_unique_up_to_scalar, lem:twisted_tensor_mul}
+        lem:gauge_unique_up_to_scalar, lem:twisted_tensor_mul, thm:ft_single}
     Since $A$ is injective and on-site symmetric, each twisted tensor
     $\widetilde{A}_g$ is gauge equivalent to~$A$
     (Lemma~\ref{lem:gauge_equiv_twisted}).


### PR DESCRIPTION
## Summary

- Make the existing injective symmetry route explicit in Lean docstrings and Chapter 13b: `MPSTensor.gaugeEquiv_twistedTensor_of_injective` is the single-block Fundamental-Theorem application to each twist.
- Add blueprint remark `rem:injective_symmetry_ft_route` explaining that `MPSTensor.virtual_rep_of_symmetric_injective` is assembled from those FT-produced gauges plus gauge uniqueness and `twistedTensor_mul`; string order is downstream.
- Add `audits/2026-04-28_issue982_ft_symmetry_triage.md`, recording the issue-thread context (#982, #652, #942, #944, #969, #970, #840, #924, #932, and open periodic/symmetry issues) and paper line citations.

## Key theorem names for #982

- `MPSTensor.fundamentalTheorem_singleBlock`
- `MPSTensor.sameMPV_iff_gaugeEquiv_of_injective`
- `MPSTensor.gaugeEquiv_twistedTensor_of_injective`
- `MPSTensor.virtual_rep_of_symmetric_injective`
- `MPSTensor.virtual_rep_of_symmetric_injective_cocycle`

## Non-injective / multi-block conclusion

No new follow-up issue is opened here: the required non-periodic FT prerequisites are already tracked by #652, #969, #970, and #944. Once those expose the after-blocking canonical-sector equal-case theorem, the symmetry packaging step should compare `A` with `twistedTensor A U g` via `SameMPV₂` and then extract sector permutation/phase/projective data from the FT output.

## Paper / issue context cited

The audit cites the relevant LaTeX lines requested in #932, including:

- `Papers/2011.12127/TN-Review-main.tex` lines 1084--1090, 1103--1105, 1743--1744, 1896--1900.
- `Papers/0802.0447/StringOrder-v10.tex` lines 306--311.
- `Papers/quant-ph_0608197/MPSarchive.tex` lines 742--763, 849--879, 1002--1014.
- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 187--190, 227--231, 271--301.

## Validation

- `lake build --old TNLean.MPS.Symmetry.Defs TNLean.MPS.Symmetry.VirtualRepresentation` passed.
- `lake build --old TNLean` passed after rebuilding local dependencies; only pre-existing warnings/sorries/long-line warnings replayed.
- `cd blueprint && leanblueprint web` passed with a local PATH shim hiding Homebrew `latex`/`dvisvgm` to avoid the known iCloud-path-with-spaces TikZ subprocess issue; the shim was removed before commit.
- `cd blueprint && leanblueprint checkdecls` passed.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passed.
- `git diff --check` passed.
- Added/touched scans for proof-integrity tokens and banned unclear terms passed.

Closes #982.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation-only (docstrings/LaTeX/audit note) and do not modify any definitions or proofs’ behavior.
> 
> **Overview**
> Makes the **injective symmetry route explicit**: updates docstrings in `MPS/Symmetry/Defs.lean` and `MPS/Symmetry/VirtualRepresentation.lean` to state that `gaugeEquiv_twistedTensor_of_injective` (and thus `virtual_rep_of_symmetric_injective`) is obtained by applying the *single-block Fundamental Theorem* to each twist via `sameMPV_iff_gaugeEquiv_of_injective`.
> 
> Updates the blueprint (`chapter/ch13b_symmetry.tex`) to cite the single-block FT in the proof of `lem:gauge_equiv_twisted` and adds a new remark `rem:injective_symmetry_ft_route` explaining that string-order results are downstream consumers.
> 
> Adds `audits/2026-04-28_issue982_ft_symmetry_triage.md` documenting issue-thread/paper citations and confirming the existing FT-based path for the injective case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e35e5b91cb739158446025b884b52d609a26cd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->