### PR TITLE
feat(MPS/CanonicalForm): construct common phase covers (#970)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1171,7 +1171,7 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCove
 
 /-- **Common live-block sector comparison from a bundled common MPV-phase cover.**
 
-This is the packaged form of
+This is the bundled form of
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover`: the
 common family, the two class maps, the MPV-phase identifications, and the
 surjectivity proofs are supplied as a single `MPVCommonPhaseCover`.  It does not

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1218,8 +1218,8 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPha
         ∀ j : Fin P.basisCount,
           Finset.univ.val.map (P.weight j) =
             Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  exact fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) :=
+  fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover
     A B hSame hp μA blocksA μB blocksB cover.common cover.classA cover.classB
     cover.phaseA cover.phaseB cover.surjA cover.surjB hAblocks hBblocks
     hTPA hTPB hIrrA hIrrB hPrimA hPrimB hInjA hInjB hμA hμB

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1169,6 +1169,61 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCove
   exact mpv_span_eq_of_common_phase_cover (d := blockPhysDim d p)
     blocksA blocksB common classA classB hAphase hBphase hAsurj hBsurj N
 
+/-- **Common live-block sector comparison from a bundled common MPV-phase cover.**
+
+This is the packaged form of
+`fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover`: the
+common family, the two class maps, the MPV-phase identifications, and the
+surjectivity proofs are supplied as a single `MPVCommonPhaseCover`.  It does not
+construct that cover from the structural `SameMPV₂` hypothesis; that cross-side
+BNT comparison is the remaining paper-level input. -/
+theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPhaseCover
+    {d D₁ D₂ p rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k : Fin rA, NeZero (dimA k)]
+    [∀ k : Fin rB, NeZero (dimB k)]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hp : 0 < p)
+    (μA : Fin rA → ℂ)
+    (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d p) (dimA k))
+    (μB : Fin rB → ℂ)
+    (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d p) (dimB k))
+    (cover : MPVCommonPhaseCover blocksA blocksB)
+    (hAblocks : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA))
+    (hBblocks : SameMPV₂ (blockTensor (d := d) (D := D₂) B p)
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB))
+    (hTPA : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksA k i)ᴴ * blocksA k i = 1)
+    (hTPB : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksB k i)ᴴ * blocksB k i = 1)
+    (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))
+    (hIrrB : ∀ k, IsIrreducibleTensor (blocksB k))
+    (hPrimA : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimA k) (blocksA k)))
+    (hPrimB : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimB k) (blocksB k)))
+    (hInjA : ∀ k, IsInjective (blocksA k))
+    (hInjB : ∀ k, IsInjective (blocksB k))
+    (hμA : ∀ k, μA k ≠ 0)
+    (hμB : ∀ k, μB k ≠ 0) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂ (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂ (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  exact fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover
+    A B hSame hp μA blocksA μB blocksB cover.common cover.classA cover.classB
+    cover.phaseA cover.phaseB cover.surjA cover.surjB hAblocks hBblocks
+    hTPA hTPB hIrrA hIrrB hPrimA hPrimB hInjA hInjB hμA hμB
+
 /-- Remove matching zero tails from two MPV identities.
 
 If `A` and `B` have the same MPVs, and each is expressed as a zero tail plus a live tensor,

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -467,8 +467,8 @@ end MPVBlockPhaseEquiv
 The data record the finite common family, the class maps from the two
 live-block families to it, the MPV-phase equivalences to the chosen common
 blocks, and surjectivity of both class maps.  They are the exact paper-level
-input needed by the current span adapter; constructing this package from the
-full structural `SameMPV₂` data is a separate comparison theorem. -/
+input needed by the current span adapter; constructing this bundled data from
+the full structural `SameMPV₂` data is a separate comparison theorem. -/
 structure MPVCommonPhaseCover {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -100,6 +100,9 @@ Theorem matching, etc.).
 * `mpv_span_eq_of_common_phase_cover` — finite-length live-block span equality
   from a common family covered surjectively up to MPV phase.
 
+* `MPVCommonPhaseCover` — bundled common-family, class-map, phase, and
+  surjectivity data for the same span-equality theorem.
+
 ## References
 
 - [CPGSV17, Lemma A.2]: Overlap dichotomy for Normal Tensors.
@@ -459,6 +462,27 @@ lemma exists_mpvState_eq_smul {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor 
 
 end MPVBlockPhaseEquiv
 
+/-- Bundled common MPV-phase cover for two live-block families.
+
+The data record the finite common family, the class maps from the two
+live-block families to it, the MPV-phase equivalences to the chosen common
+blocks, and surjectivity of both class maps.  They are the exact paper-level
+input needed by the current span adapter; constructing this package from the
+full structural `SameMPV₂` data is a separate comparison theorem. -/
+structure MPVCommonPhaseCover {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k)) where
+  rC : ℕ
+  dimC : Fin rC → ℕ
+  common : (c : Fin rC) → MPSTensor d (dimC c)
+  classA : Fin rA → Fin rC
+  classB : Fin rB → Fin rC
+  phaseA : ∀ j : Fin rA, MPVBlockPhaseEquiv (common (classA j)) (blocksA j)
+  phaseB : ∀ k : Fin rB, MPVBlockPhaseEquiv (common (classB k)) (blocksB k)
+  surjA : Function.Surjective classA
+  surjB : Function.Surjective classB
+
 /-- MPV phase equivalence for a dependent block family.
 
 `MPVPhaseEquiv blocks j k` means that block `k` has the same MPV family as
@@ -594,6 +618,22 @@ theorem mpv_span_eq_of_common_phase_cover {rA rB rC : ℕ}
           mpv_span_eq_of_surjective_phase_cover blocksA common classA hAphase hAsurj N
     _ = Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) :=
           (mpv_span_eq_of_surjective_phase_cover blocksB common classB hBphase hBsurj N).symm
+
+namespace MPVCommonPhaseCover
+
+variable {rA rB : ℕ}
+variable {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+variable {blocksA : (j : Fin rA) → MPSTensor d (dimA j)}
+variable {blocksB : (k : Fin rB) → MPSTensor d (dimB k)}
+
+/-- The bundled common cover gives equality of the finite-length live-block MPV spans. -/
+theorem span_eq (C : MPVCommonPhaseCover blocksA blocksB) (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun j : Fin rA => mpvState (d := d) (blocksA j) N)) =
+    Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) :=
+  mpv_span_eq_of_common_phase_cover (d := d) blocksA blocksB C.common
+    C.classA C.classB C.phaseA C.phaseB C.surjA C.surjB N
+
+end MPVCommonPhaseCover
 
 /-- Equivalence relation on block indices given by MPV phase equivalence. -/
 def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -465,10 +465,11 @@ end MPVBlockPhaseEquiv
 /-- Bundled common MPV-phase cover for two live-block families.
 
 The data record the finite common family, the class maps from the two
-live-block families to it, the MPV-phase equivalences to the chosen common
-blocks, and surjectivity of both class maps.  They are the exact paper-level
-input needed by the current span adapter; constructing this bundled data from
-the full structural `SameMPV₂` data is a separate comparison theorem. -/
+live-block families to it, the MPV-phase equivalences between each live block
+and its chosen common block, and surjectivity of both class maps.  They are the
+exact paper-level input needed by the current span adapter; constructing this
+bundled data from the full structural `SameMPV₂` data is a separate comparison
+theorem. -/
 structure MPVCommonPhaseCover {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))

--- a/audits/2026-04-28_issue970_common_phase_cover.md
+++ b/audits/2026-04-28_issue970_common_phase_cover.md
@@ -1,0 +1,95 @@
+# 2026-04-28 — Issue #970 common phase-cover adapter
+
+## Scope and issue-thread check
+
+This branch starts the next non-Gemma bridge after merged PR #984.  Before
+writing statements I read the bodies and comments for issues #970, #944, #969,
+#942, and #652, and inspected the merged PR #984 diff.
+
+The issue-thread conclusions used here are:
+
+- #976 already proved the live-block span adapter
+  `MPSTensor.mpv_span_eq_of_common_phase_cover` and the exact-live sector theorem
+  `MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover`.
+- #984 exposes explicitly relabeled one-sided common-sector families, but it does
+  not yet construct cross-side maps from both live-sector families onto a single
+  common MPV phase family.
+- #944 is now reduced to the finite-length span comparison for the original live
+  block families, after the one-sided BNT representative-span transport.
+- #970 asks for the bridge from the common live-sector construction to that span
+  comparison.  The mathematically precise input is a common family together with
+  surjective class maps from both sides and MPV-phase equivalences for every live
+  block.
+- #969 and #652 still require a later common injectivity/Wielandt blocking stage
+  before the fully unconditional non-periodic canonical-form theorem can be
+  closed.
+
+## Paper route checked
+
+This branch follows the CPSV/CPGSV non-Gemma route.
+
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 217--225 state the block-diagonal
+  weighted live decomposition and normalize the corresponding completely positive
+  maps by their spectral radii.
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 227--231 state the blocking by the
+  least common multiple of periods to remove peripheral cyclic components.
+- `Papers/2011.12127/TN-Review-main.tex` lines 1815--1820 give the same
+  period-removal step and identify the primitive output after blocking.
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 317--332 define injectivity and
+  state the Wielandt blocking step.  This branch does not assert that final
+  injectivity refinement.
+
+## Lean progress in this branch
+
+### `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`
+
+New declarations:
+
+- `MPSTensor.MPVCommonPhaseCover`: a data record for two live-block families.
+  It stores a finite common block family, class maps from both live families to
+  the common family, MPV-phase equivalences from each live block to its common
+  representative, and surjectivity of both maps.
+- `MPSTensor.MPVCommonPhaseCover.span_eq`: applies the already-merged span
+  theorem to prove equality of the two finite-length live-block MPV spans from
+  this common-cover data.
+
+The data record deliberately contains only the actual mathematical comparison
+data needed by the span adapter.  It does not claim that this data follows from
+`SameMPV₂` alone.
+
+### `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
+
+New theorem:
+
+- `MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPhaseCover`.
+
+This is the packaged form of
+`MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover`:
+callers supply one `MPVCommonPhaseCover` instead of separately passing the common
+family, two class maps, phase equivalences, and surjectivity proofs.  The proof is
+a direct application of the existing theorem and introduces no new analytic
+assumption.
+
+### `blueprint/src/chapter/ch11_assembly.tex`
+
+Added entries for:
+
+- the common MPV phase-cover data;
+- the span equality theorem obtained from that data;
+- the exact-live sector theorem that consumes the data.
+
+## Remaining paper input
+
+The full #970/#944 bridge is not closed by this branch.  The remaining
+mathematical input is the construction, from the structural `SameMPV₂` reduction
+and the common-blocking output, of:
+
+1. one common live-sector family after any needed relabeling and further
+   injectivity blocking;
+2. surjective class maps from each side's live sectors to that common family;
+3. MPV-phase equivalences between every live sector and its common representative;
+4. exact zero-tail bookkeeping at the final common blocking length.
+
+Once those data are available, `MPVCommonPhaseCover.span_eq` discharges the
+finite-length span equality required by #944, and the new assembly wrapper feeds
+that span equality into the existing after-blocking sector comparison theorem.

--- a/audits/2026-04-28_issue970_common_phase_cover.md
+++ b/audits/2026-04-28_issue970_common_phase_cover.md
@@ -63,7 +63,7 @@ New theorem:
 
 - `MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPhaseCover`.
 
-This is the packaged form of
+This is the bundled form of
 `MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_phaseCover`:
 callers supply one `MPVCommonPhaseCover` instead of separately passing the common
 family, two class maps, phase equivalences, and surjectivity proofs.  The proof is

--- a/audits/2026-04-28_issue970_common_phase_cover.md
+++ b/audits/2026-04-28_issue970_common_phase_cover.md
@@ -2,7 +2,7 @@
 
 ## Scope and issue-thread check
 
-This branch starts the next non-Gemma bridge after merged PR #984.  Before
+This branch starts the next non-Gemma connection after merged PR #984.  Before
 writing statements I read the bodies and comments for issues #970, #944, #969,
 #942, and #652, and inspected the merged PR #984 diff.
 
@@ -16,8 +16,8 @@ The issue-thread conclusions used here are:
   common MPV phase family.
 - #944 is now reduced to the finite-length span comparison for the original live
   block families, after the one-sided BNT representative-span transport.
-- #970 asks for the bridge from the common live-sector construction to that span
-  comparison.  The mathematically precise input is a common family together with
+- #970 asks for the comparison step from the common live-sector construction to
+  that span comparison.  The mathematically precise input is a common family together with
   surjective class maps from both sides and MPV-phase equivalences for every live
   block.
 - #969 and #652 still require a later common injectivity/Wielandt blocking stage
@@ -47,8 +47,8 @@ New declarations:
 
 - `MPSTensor.MPVCommonPhaseCover`: a data record for two live-block families.
   It stores a finite common block family, class maps from both live families to
-  the common family, MPV-phase equivalences from each live block to its common
-  representative, and surjectivity of both maps.
+  the common family, MPV-phase equivalences between each live block and its
+  common representative, and surjectivity of both maps.
 - `MPSTensor.MPVCommonPhaseCover.span_eq`: applies the already-merged span
   theorem to prove equality of the two finite-length live-block MPV spans from
   this common-cover data.
@@ -80,7 +80,7 @@ Added entries for:
 
 ## Remaining paper input
 
-The full #970/#944 bridge is not closed by this branch.  The remaining
+The full #970/#944 comparison is not closed by this branch.  The remaining
 mathematical input is the construction, from the structural `SameMPV₂` reduction
 and the common-blocking output, of:
 
@@ -91,5 +91,5 @@ and the common-blocking output, of:
 4. exact zero-tail bookkeeping at the final common blocking length.
 
 Once those data are available, `MPVCommonPhaseCover.span_eq` discharges the
-finite-length span equality required by #944, and the new assembly wrapper feeds
-that span equality into the existing after-blocking sector comparison theorem.
+finite-length span equality required by #944, and the new assembly reformulation
+feeds that span equality into the existing after-blocking sector comparison theorem.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -770,7 +770,7 @@ single weighted block.
 	\uses{def:mpv_block_phase_equiv}
 	For two finite live-block families, a common MPV phase cover consists of a third
 	finite family of blocks, a map from each live-block family onto that common
-	family, and MPV-phase equivalences from each live block to its common
+	family, and MPV-phase equivalences between each live block and its common
 	representative. Both maps are required to be surjective, so the common family
 	contains no unused representative.
 \end{definition}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -763,6 +763,18 @@ single weighted block.
 	The two bond dimensions are allowed to differ.
 \end{definition}
 
+\begin{definition}[Common MPV phase-cover data]
+\label{def:mpv_common_phase_cover}
+	\lean{MPSTensor.MPVCommonPhaseCover}
+	\leanok
+	\uses{def:mpv_block_phase_equiv}
+	For two finite live-block families, a common MPV phase cover consists of a third
+	finite family of blocks, a map from each live-block family onto that common
+	family, and MPV-phase equivalences from each live block to its common
+	representative. Both maps are required to be surjective, so the common family
+	contains no unused representative.
+\end{definition}
+
 \begin{lemma}[Common MPV phase cover gives live-block span equality]%
 \label{lem:live_block_span_eq_of_common_phase_cover}
 	\lean{MPSTensor.mpv_span_eq_of_common_phase_cover}
@@ -781,6 +793,22 @@ single weighted block.
 	scalar multiple of its common block's MPV vector. Surjectivity gives the reverse
 	inclusion, so each live-block span equals the common span; transitivity gives
 	the equality of the two live-block spans.
+\end{proof}
+
+\begin{lemma}[Bundled common phase cover gives live-block span equality]%
+\label{lem:mpv_common_phase_cover_span_eq}
+	\lean{MPSTensor.MPVCommonPhaseCover.span_eq}
+	\leanok
+	\uses{def:mpv_common_phase_cover, lem:live_block_span_eq_of_common_phase_cover}
+	A common MPV phase cover for two live-block families gives equality of their
+	finite-length MPV spans at every system size.
+\end{lemma}
+
+\begin{proof}
+	\leanok
+	\uses{lem:live_block_span_eq_of_common_phase_cover}
+	The common cover data specify the common family, the two surjective class maps,
+	and the MPV-phase equivalences. The span lemma then applies directly.
 \end{proof}
 
 \begin{theorem}[Heterogeneous sector comparison via a bundled matching witness]%
@@ -951,6 +979,29 @@ single weighted block.
 	MPV phase cover into equality of the live-block finite-length spans.
 	Theorem~\ref{thm:after_blocking_sector_common_blocks_block_span} then applies
 	without any additional sector-basis assumptions.
+\end{proof}
+
+\begin{theorem}[Common live blocks with bundled MPV phase cover give sector comparison]%
+\label{thm:after_blocking_sector_common_blocks_common_phase_cover}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPhaseCover}
+	\leanok
+	\uses{def:mpv_common_phase_cover,
+		thm:after_blocking_sector_common_blocks_phase_cover}
+	Let $A$ and $B$ have the same MPV family, and fix exact live decompositions at a
+	common blocking period as in
+	Theorem~\ref{thm:after_blocking_sector_common_blocks_phase_cover}. Assume the
+	live blocks are trace-preserving, primitive, irreducible, injective, and have
+	nonzero weights. If the two live-block families are equipped with common MPV
+	phase-cover data, then the same sector comparison conclusion holds.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:after_blocking_sector_common_blocks_phase_cover}
+	The common cover data specify the common representative family, the two
+	surjective maps, and the MPV-phase equivalences. The common-cover sector
+	theorem then applies with the same live decompositions and structural
+	hypotheses.
 \end{proof}
 
 \begin{lemma}[Zero-tail cancellation]\label{lem:sameMPV2_live_of_zeroTail_eq}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -799,7 +799,7 @@ single weighted block.
 \label{lem:mpv_common_phase_cover_span_eq}
 	\lean{MPSTensor.MPVCommonPhaseCover.span_eq}
 	\leanok
-	\uses{def:mpv_common_phase_cover, lem:live_block_span_eq_of_common_phase_cover}
+	\uses{def:mpv_common_phase_cover}
 	A common MPV phase cover for two live-block families gives equality of their
 	finite-length MPV spans at every system size.
 \end{lemma}


### PR DESCRIPTION
## Summary

- Add `MPSTensor.MPVCommonPhaseCover`, bundling the common nonzero-block family, class maps, MPV-phase equivalences, and surjectivity hypotheses needed by the #976 span adapter.
- Prove `MPVCommonPhaseCover.span_eq` by applying `mpv_span_eq_of_common_phase_cover`.
- Add `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPhaseCover`, a low-risk assembly wrapper that consumes the bundled cover package and calls the existing common block-decomposition phase-cover theorem.
- Update Chapter 11 blueprint entries and add an audit note documenting the remaining paper-level input from `SameMPV₂`.

## Paper-faithful scope

This PR does **not** claim that the common phase-cover data follows from `SameMPV₂` alone. The remaining #970/#944 input is still the actual cross-side construction of a common nonzero-sector family and surjective MPV-phase cover maps, after the final common blocking/relabeling and injectivity/Wielandt stage.

Paper lines checked in the audit:

- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 217--225: weighted block-diagonal live decomposition.
- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 227--231: common blocking by the least common multiple of periods.
- `Papers/2011.12127/TN-Review-main.tex` lines 1815--1820: period removal and primitive output.
- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 317--332: injectivity and the Wielandt blocking step.

## Validation

- [x] `lake exe cache get`
- [x] `lake build --old TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
  - only the two pre-existing long-line warnings in `CyclicSectorDecomposition.lean` replayed
- [x] `lake build --old TNLean`
  - only pre-existing unrelated `sorry` warnings and the same pre-existing long-line warnings replayed
- [x] Lean diagnostics clean for `EqualNormBridge.lean` and `StructuralTheorem.lean`
- [x] `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (to generate the ignored local `blueprint/lean_decls` required by checkdecls)
- [x] `leanblueprint checkdecls`
- [x] `python3 scripts/blueprint_lean_sync.py --root . --ci`
- [x] `git diff --check`
- [x] Added-line scans for `sorry|admit|axiom|native_decide|unsafe|unsafeCast|maxHeartbeats` and banned shorthand prose

Refs #970, #944, #969, #942, #652. Follows PR #984.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR mainly adds new bundled wrapper definitions/theorems that repackage existing hypotheses and proofs, without changing core algorithms or adding new axioms.
> 
> **Overview**
> Introduces `MPSTensor.MPVCommonPhaseCover`, bundling a finite common representative family, surjective class maps from two nonzero-block families, and per-block `MPVBlockPhaseEquiv` witnesses.
> 
> Adds `MPVCommonPhaseCover.span_eq`, a convenience lemma that derives finite-length MPV span equality by directly applying `mpv_span_eq_of_common_phase_cover`.
> 
> Adds an assembly-level wrapper theorem `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPhaseCover` that consumes the bundled cover and forwards to the existing phase-cover sector-comparison theorem, and updates blueprint/audit documentation accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efa33ac919877aee78462ea74cfd5a291fb1ec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->