### PR TITLE
feat(MPS/CanonicalForm): construct common phase covers from BNT matching (#970)

### DIFF
--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -103,6 +103,13 @@ Theorem matching, etc.).
 * `MPVCommonPhaseCover` — bundled common-family, class-map, phase, and
   surjectivity data for the same span-equality theorem.
 
+* `SectorBasisPreMatching.commonPhaseCover` — turns BNT pre-matching data into
+  a common MPV phase cover, hence into finite-length basis-span equality.
+
+* `nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data` — reads the
+  span-equality-free BNT proportional-decomposition comparison as common-cover
+  existence.
+
 ## References
 
 - [CPGSV17, Lemma A.2]: Overlap dichotomy for Normal Tensors.
@@ -635,6 +642,127 @@ theorem span_eq (C : MPVCommonPhaseCover blocksA blocksB) (N : ℕ) :
     C.classA C.classB C.phaseA C.phaseB C.surjA C.surjB N
 
 end MPVCommonPhaseCover
+
+namespace SectorBasisPreMatching
+
+variable {P Q : SectorDecomposition d}
+
+/-- A sector-basis pre-matching supplies a common MPV phase cover of the two basis families.
+
+The common family is the left basis. The left class map is the identity, the right
+class map is the inverse of the matching permutation, and gauge-phase equivalence
+of matched basis blocks gives the required MPV-phase equivalences. -/
+def commonPhaseCover (M : SectorBasisPreMatching P Q) :
+    MPVCommonPhaseCover P.basis Q.basis := by
+  refine {
+    rC := P.basisCount
+    dimC := P.basisDim
+    common := P.basis
+    classA := id
+    classB := M.perm.symm
+    phaseA := ?_
+    phaseB := ?_
+    surjA := ?_
+    surjB := ?_
+  }
+  · intro j
+    exact MPVBlockPhaseEquiv.refl (P.basis j)
+  · intro k
+    rcases M.basis_equiv (M.perm.symm k) with ⟨X, ζ, hζ, hX⟩
+    refine ⟨ζ, hζ, ?_⟩
+    intro N σ
+    have hk : M.perm (M.perm.symm k) = k := M.perm.apply_symm_apply k
+    conv_lhs => rw [← hk]
+    rw [mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congr_arg (MPSTensor d) (M.dim_eq (M.perm.symm k)))
+        (P.basis (M.perm.symm k)))
+      (B := Q.basis (M.perm (M.perm.symm k))) X ζ hX N σ,
+      mpv_cast_dim (M.dim_eq (M.perm.symm k)) (P.basis (M.perm.symm k)) N σ]
+  · intro j
+    exact ⟨j, rfl⟩
+  · intro j
+    exact ⟨M.perm j, by simp⟩
+
+/-- A sector-basis pre-matching gives equality of finite-length MPV spans of the two basis
+families. -/
+theorem span_eq (M : SectorBasisPreMatching P Q) (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
+      mpvState (d := d) (P.basis j) N)) =
+    Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
+      mpvState (d := d) (Q.basis k) N)) :=
+  M.commonPhaseCover.span_eq N
+
+/-- A sector-basis pre-matching supplies the finite-length span field of the primitive
+overlap-span hypotheses. -/
+theorem to_overlapSpan (M : SectorBasisPreMatching P Q)
+    (HP : SectorBasisOverlapOrthoHypotheses P)
+    (HQ : SectorBasisOverlapOrthoHypotheses Q)
+    (hP_inj : ∀ j : Fin P.basisCount, IsInjective (P.basis j))
+    (hQ_inj : ∀ k : Fin Q.basisCount, IsInjective (Q.basis k)) :
+    SectorBasisOverlapSpanHypotheses P Q :=
+  HP.to_overlapSpan HQ hP_inj hQ_inj M.span_eq
+
+end SectorBasisPreMatching
+
+/-- A proportional-decomposition BNT comparison conclusion produces a common MPV phase cover. -/
+theorem nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
+    {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (h : ProportionalDecompositionConclusion (d := d) blocksA blocksB) :
+    Nonempty (MPVCommonPhaseCover blocksA blocksB) := by
+  rcases h with ⟨_hcount, perm, hmatch⟩
+  refine ⟨?_⟩
+  refine {
+    rC := rA
+    dimC := dimA
+    common := blocksA
+    classA := id
+    classB := perm.symm
+    phaseA := ?_
+    phaseB := ?_
+    surjA := ?_
+    surjB := ?_
+  }
+  · intro j
+    exact MPVBlockPhaseEquiv.refl (blocksA j)
+  · intro k
+    obtain ⟨hdim, hGPE⟩ := hmatch (perm.symm k)
+    rcases hGPE with ⟨X, ζ, hζ, hX⟩
+    refine ⟨ζ, hζ, ?_⟩
+    intro N σ
+    have hk : perm (perm.symm k) = k := perm.apply_symm_apply k
+    conv_lhs => rw [← hk]
+    rw [mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congr_arg (MPSTensor d) hdim) (blocksA (perm.symm k)))
+      (B := blocksB (perm (perm.symm k))) X ζ hX N σ,
+      mpv_cast_dim hdim (blocksA (perm.symm k)) N σ]
+  · intro j
+    exact ⟨j, rfl⟩
+  · intro j
+    exact ⟨perm j, by simp⟩
+
+/-- Separated normal BNT data and a proportional decomposition produce a common MPV phase cover.
+
+The proof uses the BNT comparison theorem to obtain a permutation and gauge phases between the
+basis blocks, then reads that matching as a common MPV phase cover. It does not use a
+finite-length span equality hypothesis. -/
+theorem nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
+    {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {DtotA DtotB : ℕ} {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA_ncf : IsNormalCanonicalForm μA blocksA)
+    (hA_blocks : BlocksNotGaugePhaseEquiv (d := d) blocksA)
+    (hB_ncf : IsNormalCanonicalForm μB blocksB)
+    (hB_blocks : BlocksNotGaugePhaseEquiv (d := d) blocksB)
+    (hDecomp : ProportionalDecompositionData (d := d) blocksA blocksB DtotA DtotB) :
+    Nonempty (MPVCommonPhaseCover blocksA blocksB) :=
+  nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
+    (d := d) blocksA blocksB
+    (fundamentalTheorem_of_separated_normalCFBNT_data
+      blocksA blocksB hA_ncf hA_blocks hB_ncf hB_blocks hDecomp)
 
 /-- Equivalence relation on block indices given by MPV phase equivalence. -/
 def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -668,10 +668,11 @@ def commonPhaseCover (M : SectorBasisPreMatching P Q) :
   · intro j
     exact MPVBlockPhaseEquiv.refl (P.basis j)
   · intro k
-    simpa [M.perm.apply_symm_apply k] using
-      MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast
-        (P.basis (M.perm.symm k)) (Q.basis (M.perm (M.perm.symm k)))
-        (M.dim_eq (M.perm.symm k)) (M.basis_equiv (M.perm.symm k))
+    have h := MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast
+      (P.basis (M.perm.symm k)) (Q.basis (M.perm (M.perm.symm k)))
+      (M.dim_eq (M.perm.symm k)) (M.basis_equiv (M.perm.symm k))
+    rw [M.perm.apply_symm_apply k] at h
+    exact h
   · intro j
     exact ⟨j, rfl⟩
   · intro j
@@ -722,10 +723,10 @@ theorem nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
     exact MPVBlockPhaseEquiv.refl (blocksA j)
   · intro k
     obtain ⟨hdim, hGPE⟩ := hmatch (perm.symm k)
-    have hk : perm (perm.symm k) = k := perm.apply_symm_apply k
-    rw [← hk]
-    exact MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast
+    have h := MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast
       (blocksA (perm.symm k)) (blocksB (perm (perm.symm k))) hdim hGPE
+    rw [perm.apply_symm_apply k] at h
+    exact h
   · intro j
     exact ⟨j, rfl⟩
   · intro j

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -692,8 +692,8 @@ theorem span_eq (M : SectorBasisPreMatching P Q) (N : ℕ) :
       mpvState (d := d) (Q.basis k) N)) :=
   M.commonPhaseCover.span_eq N
 
-/-- A sector-basis pre-matching supplies the finite-length span field of the primitive
-overlap-span hypotheses. -/
+/-- A sector-basis pre-matching establishes the finite-length span equality needed by the
+primitive overlap-span hypotheses. -/
 theorem to_overlapSpan (M : SectorBasisPreMatching P Q)
     (HP : SectorBasisOverlapOrthoHypotheses P)
     (HQ : SectorBasisOverlapOrthoHypotheses Q)

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -651,7 +651,7 @@ variable {P Q : SectorDecomposition d}
 
 The common family is the left basis. The left class map is the identity, the right
 class map is the inverse of the matching permutation, and gauge-phase equivalence
-of matched basis blocks gives the required MPV-phase equivalences. -/
+of paired basis blocks gives the required MPV-phase equivalences. -/
 def commonPhaseCover (M : SectorBasisPreMatching P Q) :
     MPVCommonPhaseCover P.basis Q.basis := by
   refine {

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -106,9 +106,9 @@ Theorem matching, etc.).
 * `SectorBasisPreMatching.commonPhaseCover` — turns BNT pre-matching data into
   a common MPV phase cover, hence into finite-length basis-span equality.
 
-* `nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data` — reads the
-  span-equality-free BNT proportional-decomposition comparison as common-cover
-  existence.
+* `nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data` — the
+  span-equality-free BNT proportional-decomposition comparison gives
+  common-cover existence.
 
 ## References
 
@@ -742,11 +742,12 @@ theorem nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
   · intro j
     exact ⟨perm j, by simp⟩
 
-/-- Separated normal BNT data and a proportional decomposition produce a common MPV phase cover.
+/-- Separated normal canonical-form data and a proportional decomposition produce a common MPV
+phase cover.
 
 The proof uses the BNT comparison theorem to obtain a permutation and gauge phases between the
-basis blocks, then reads that matching as a common MPV phase cover. It does not use a
-finite-length span equality hypothesis. -/
+basis blocks; applying the proportional-decomposition cover theorem to that matching yields the
+common MPV phase cover. It does not use a finite-length span equality hypothesis. -/
 theorem nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -668,16 +668,10 @@ def commonPhaseCover (M : SectorBasisPreMatching P Q) :
   · intro j
     exact MPVBlockPhaseEquiv.refl (P.basis j)
   · intro k
-    rcases M.basis_equiv (M.perm.symm k) with ⟨X, ζ, hζ, hX⟩
-    refine ⟨ζ, hζ, ?_⟩
-    intro N σ
-    have hk : M.perm (M.perm.symm k) = k := M.perm.apply_symm_apply k
-    conv_lhs => rw [← hk]
-    rw [mpv_eq_pow_mul_of_gaugePhase
-      (A := cast (congr_arg (MPSTensor d) (M.dim_eq (M.perm.symm k)))
-        (P.basis (M.perm.symm k)))
-      (B := Q.basis (M.perm (M.perm.symm k))) X ζ hX N σ,
-      mpv_cast_dim (M.dim_eq (M.perm.symm k)) (P.basis (M.perm.symm k)) N σ]
+    simpa [M.perm.apply_symm_apply k] using
+      MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast
+        (P.basis (M.perm.symm k)) (Q.basis (M.perm (M.perm.symm k)))
+        (M.dim_eq (M.perm.symm k)) (M.basis_equiv (M.perm.symm k))
   · intro j
     exact ⟨j, rfl⟩
   · intro j
@@ -728,15 +722,10 @@ theorem nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
     exact MPVBlockPhaseEquiv.refl (blocksA j)
   · intro k
     obtain ⟨hdim, hGPE⟩ := hmatch (perm.symm k)
-    rcases hGPE with ⟨X, ζ, hζ, hX⟩
-    refine ⟨ζ, hζ, ?_⟩
-    intro N σ
     have hk : perm (perm.symm k) = k := perm.apply_symm_apply k
-    conv_lhs => rw [← hk]
-    rw [mpv_eq_pow_mul_of_gaugePhase
-      (A := cast (congr_arg (MPSTensor d) hdim) (blocksA (perm.symm k)))
-      (B := blocksB (perm (perm.symm k))) X ζ hX N σ,
-      mpv_cast_dim hdim (blocksA (perm.symm k)) N σ]
+    rw [← hk]
+    exact MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast
+      (blocksA (perm.symm k)) (blocksB (perm (perm.symm k))) hdim hGPE
   · intro j
     exact ⟨j, rfl⟩
   · intro j

--- a/audits/2026-04-28_issue970_cover_construction.md
+++ b/audits/2026-04-28_issue970_cover_construction.md
@@ -37,7 +37,10 @@ New declarations:
 - `MPSTensor.nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion`:
   a BNT proportional-decomposition comparison conclusion already contains enough data (permutation, bond-dimension equalities, gauge phases) to produce a common MPV phase cover.
 - `MPSTensor.nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data`:
-  the existing span-equality-free irreducible trace-preserving BNT comparison theorem supplies the preceding conclusion, hence produces common-cover existence directly from separated normal BNT data and proportional-decomposition hypotheses.
+  the existing span-equality-free irreducible trace-preserving BNT comparison theorem gives the
+  preceding conclusion, hence produces common MPV phase-cover existence directly from separated
+  normal canonical-form data, the no-gauge-phase-equivalent-distinct-blocks hypothesis, and
+  proportional-decomposition hypotheses.
 
 The key point is non-circularity: these declarations do not use `SectorBasisOverlapSpanHypotheses`, the live-block span equality, or `mpv_span_eq_of_common_phase_cover` as an input to obtain the BNT pre-matching.  The direction is the paper direction: BNT matching data gives the common cover; the common cover then gives span equality.
 
@@ -49,7 +52,7 @@ New entries at lines 814--899 document:
 - sector-basis span equality from a pre-matching (`lem:sector_basis_pre_matching_span_eq`);
 - primitive overlap-span hypotheses from a pre-matching (`thm:sector_basis_pre_matching_to_overlap_span`);
 - common phase cover from a BNT proportional-decomposition conclusion (`thm:common_phase_cover_of_proportional_decomposition`);
-- common phase cover from separated normal BNT data (`thm:common_phase_cover_of_separated_normal_bnt`).
+- common phase cover from separated normal canonical-form data (`thm:common_phase_cover_of_separated_normal_bnt`).
 
 ## Remaining paper input
 

--- a/audits/2026-04-28_issue970_cover_construction.md
+++ b/audits/2026-04-28_issue970_cover_construction.md
@@ -1,0 +1,63 @@
+# 2026-04-28 — Issue #970 cover construction predecessor
+
+## Scope and issue-thread check
+
+This branch starts from PR #987 (`issue970-common-phase-cover`, head `5efa33ac`) and keeps the #970/#944 goal focused on the non-Gemma CPSV/CPGSV path.  Before writing Lean statements I re-read the bodies and comments for issues #970, #944, #969, #942, and #652.
+
+The current issue-thread conclusions are:
+
+- #970 asks for the finite-length live-block span equality from equal MPVs after the common live-sector reduction.
+- #944 now needs that span equality as the remaining input after one-sided BNT representative-span transport.
+- #969 has produced common blocking and explicitly relabeled common sectors, but it has not yet produced the final weighted exact-live tensor equality with a common cross-side phase family.
+- #652 remains open until the common-sector construction, injectivity/Wielandt refinement, and zero-tail bookkeeping all feed the sector comparison endpoint.
+
+This branch does not claim the final exact-live construction from arbitrary `SameMPV₂`.  It records the strongest non-circular predecessor available from the existing BNT comparison layer: a BNT pre-matching, or the existing proportional-decomposition BNT comparison theorem, now produces `MPVCommonPhaseCover` data and therefore supplies the span field used by #944.
+
+## Paper route checked
+
+The Lean statements follow the BNT comparison step in the papers.
+
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 271--280 define a basis of normal tensors and its minimality characterization.  In particular, line 279 says each canonical-form normal tensor is related to a basis tensor by a nonsingular matrix and a phase, and line 279 also states the minimality condition.
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 283--302 write a canonical-form tensor in terms of BNT blocks and give the MPV decomposition `|V^{N}(A)\rangle = \sum_j (\sum_q \mu_{j,q}^N)|V^{(N)}(A_j)\rangle` on lines 300--301.
+- `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 349--352 state the BNT matching conclusion of the Fundamental Theorem: equal/proportional MPV families have BNT blocks matched by a permutation, phases, and nonsingular matrices.
+- `Papers/2011.12127/TN-Review-main.tex` lines 1846--1859 give the same BNT definition and minimality characterization; lines 1864--1885 give the BNT block decomposition and MPV expansion; lines 1891--1894 state the matching conclusion for proportional MPVs.
+
+## Lean progress in this branch
+
+### `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`
+
+New declarations:
+
+- `MPSTensor.SectorBasisPreMatching.commonPhaseCover`:
+  a sector-basis pre-matching between sector decompositions `P` and `Q` gives a concrete `MPVCommonPhaseCover P.basis Q.basis`.  The common family is the left basis; the left class map is the identity; the right class map is the inverse permutation; the pre-matching gauge phases give the MPV-phase equivalences.
+- `MPSTensor.SectorBasisPreMatching.span_eq`:
+  applying `MPVCommonPhaseCover.span_eq` to the preceding construction gives equality of the finite-length MPV spans of the two sector bases.
+- `MPSTensor.SectorBasisPreMatching.to_overlapSpan`:
+  combines the pre-matching span equality with the one-family overlap-orthogonality and injectivity fields to produce `SectorBasisOverlapSpanHypotheses P Q`.
+- `MPSTensor.nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion`:
+  a BNT proportional-decomposition comparison conclusion already contains enough data (permutation, bond-dimension equalities, gauge phases) to produce a common MPV phase cover.
+- `MPSTensor.nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data`:
+  the existing span-equality-free irreducible trace-preserving BNT comparison theorem supplies the preceding conclusion, hence produces common-cover existence directly from separated normal BNT data and proportional-decomposition hypotheses.
+
+The key point is non-circularity: these declarations do not use `SectorBasisOverlapSpanHypotheses`, the live-block span equality, or `mpv_span_eq_of_common_phase_cover` as an input to obtain the BNT pre-matching.  The direction is the paper direction: BNT matching data gives the common cover; the common cover then gives span equality.
+
+### `blueprint/src/chapter/ch11_assembly.tex`
+
+New entries at lines 814--899 document:
+
+- common phase cover from a sector basis pre-matching (`def:sector_basis_pre_matching_common_phase_cover`);
+- sector-basis span equality from a pre-matching (`lem:sector_basis_pre_matching_span_eq`);
+- primitive overlap-span hypotheses from a pre-matching (`thm:sector_basis_pre_matching_to_overlap_span`);
+- common phase cover from a BNT proportional-decomposition conclusion (`thm:common_phase_cover_of_proportional_decomposition`);
+- common phase cover from separated normal BNT data (`thm:common_phase_cover_of_separated_normal_bnt`).
+
+## Remaining paper input
+
+The full #970/#944 theorem is still blocked upstream of these declarations.  The remaining mathematical input is:
+
+1. convert the common-length cyclic-sector output of #969 into final exact live block families, including the weighted direct sum and zero-tail equations at the final blocking length;
+2. add the common injectivity/Wielandt blocking stage required by the overlap-rigidity endpoint;
+3. obtain the proportional-decomposition data for the final BNT basis families from the exact live equality without reintroducing a finite-length span assumption;
+4. apply `nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data` (or the pre-matching construction directly) to produce the `MPVCommonPhaseCover` consumed by `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPhaseCover`.
+
+Thus the new Lean code moves the #970 bottleneck from an assumed span equality to the paper-level BNT matching/proportional-decomposition data, while keeping the missing #969 exact-live and Wielandt inputs explicit.

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -50,10 +50,20 @@ The main references are
 	large $N$ it is invertible, so the MPV states are linearly independent.
 \end{proof}
 
+\begin{definition}[No gauge-phase-equivalent distinct blocks]%
+\label{def:blocks_not_gauge_phase_equiv}
+	\lean{MPSTensor.BlocksNotGaugePhaseEquiv}
+	\leanok
+	\uses{def:gauge_phase_equiv}
+	A finite block family has no gauge-phase-equivalent distinct blocks when,
+	for any two distinct indices with the same bond dimension, the corresponding
+	blocks are not gauge-phase equivalent.
+\end{definition}
+
 \begin{definition}[Canonical form with BNT separation]\label{def:cf_bnt}
 	\lean{MPSTensor.IsCanonicalFormBNT}
 	\leanok
-	\uses{def:is_canonical_form, def:gauge_phase_equiv}
+	\uses{def:is_canonical_form, def:blocks_not_gauge_phase_equiv}
 	A family is in \emph{canonical form with BNT separation}
 	if it satisfies Definition~\ref{def:is_canonical_form} and,
 	in addition:
@@ -88,7 +98,7 @@ The main references are
 
 \begin{definition}[Normal canonical form with BNT separation]\label{def:normal_cf_bnt}
 	\lean{MPSTensor.IsNormalCanonicalFormBNT}\leanok
-	\uses{def:is_normal_canonical_form, def:gauge_phase_equiv}
+	\uses{def:is_normal_canonical_form, def:blocks_not_gauge_phase_equiv}
 	A family is in \emph{normal canonical form with BNT separation}
 	if it satisfies Definition~\ref{def:is_normal_canonical_form}
 	and, in addition:

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -811,6 +811,94 @@ single weighted block.
 	and the MPV-phase equivalences. The span lemma then applies directly.
 \end{proof}
 
+\begin{definition}[Common phase cover from a sector basis pre-matching]%
+\label{def:sector_basis_pre_matching_common_phase_cover}
+	\lean{MPSTensor.SectorBasisPreMatching.commonPhaseCover}
+	\leanok
+	\uses{def:sector_basis_pre_matching, def:mpv_common_phase_cover}
+	A sector basis pre-matching between sector decompositions $P$ and $Q$
+	canonically gives a common MPV phase cover of their basis block families.  The
+	common family is the basis of $P$, the class map from $P$ is the identity, and
+	the class map from $Q$ is the inverse of the pre-matching permutation.
+\end{definition}
+
+\begin{lemma}[Sector basis pre-matching gives basis-span equality]%
+\label{lem:sector_basis_pre_matching_span_eq}
+	\lean{MPSTensor.SectorBasisPreMatching.span_eq}
+	\leanok
+	\uses{def:sector_basis_pre_matching_common_phase_cover,
+		lem:mpv_common_phase_cover_span_eq}
+	A sector basis pre-matching between $P$ and $Q$ implies equality, for every
+	system size, of the finite-length MPV spans of the two sector bases.
+\end{lemma}
+
+\begin{proof}
+	\leanok
+	\uses{lem:mpv_common_phase_cover_span_eq}
+	Apply the common-cover span lemma to the common phase cover constructed from
+	the pre-matching.
+\end{proof}
+
+\begin{theorem}[Pre-matching supplies primitive overlap-span hypotheses]%
+\label{thm:sector_basis_pre_matching_to_overlap_span}
+	\lean{MPSTensor.SectorBasisPreMatching.to_overlapSpan}
+	\leanok
+	\uses{def:sector_basis_pre_matching, def:sector_basis_overlap_ortho_hyps,
+		def:sector_basis_overlap_span_hyps}
+	If two sector bases satisfy the one-family overlap-orthogonality data and their
+	basis blocks are one-site injective, then a sector basis pre-matching between
+	them supplies the finite-length span field and hence the full primitive
+	overlap-span hypotheses.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{lem:sector_basis_pre_matching_span_eq,
+		thm:sector_basis_overlap_ortho_to_span}
+	The pre-matching gives the basis-span equality. Combining that equality with
+	the one-family overlap data and injectivity is exactly the construction of
+	Theorem~\ref{thm:sector_basis_overlap_ortho_to_span}.
+\end{proof}
+
+\begin{theorem}[Common phase cover from a BNT proportional-decomposition conclusion]%
+\label{thm:common_phase_cover_of_proportional_decomposition}
+	\lean{MPSTensor.nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion}
+	\leanok
+	\uses{def:mpv_common_phase_cover}
+	If a BNT proportional-decomposition comparison has produced a permutation of
+	the two basis families together with matched bond dimensions and gauge-phase
+	equivalences, then the two basis families have a common MPV phase cover.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{def:mpv_block_phase_equiv}
+	Take the left basis family as the common family. The comparison permutation and
+	its inverse give the two class maps, while each gauge-phase equivalence gives
+	the required MPV-phase equivalence.
+\end{proof}
+
+\begin{theorem}[Separated normal BNT data produce a common phase cover]%
+\label{thm:common_phase_cover_of_separated_normal_bnt}
+	\lean{MPSTensor.nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data}
+	\leanok
+	\uses{def:mpv_common_phase_cover, thm:bnt_perm_prop_nt}
+	For two separated normal BNT families with proportional decompositions whose
+	coefficient limits are nonzero, the two basis families have a common MPV phase
+	cover. This is the BNT route to the cover data; it does not assume equality of
+	finite-length spans.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_phase_cover_of_proportional_decomposition,
+		thm:bnt_perm_prop_nt}
+	The irreducible trace-preserving BNT permutation theorem gives the matched
+	basis permutation, bond-dimension equalities, and gauge-phase equivalences.
+	The previous theorem reads that matched basis conclusion as a common phase
+	cover.
+\end{proof}
+
 \begin{theorem}[Heterogeneous sector comparison via a bundled matching witness]%
 \label{thm:route_b_hetero_sector_matching}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -847,7 +847,7 @@ single weighted block.
 		def:sector_basis_overlap_span_hyps}
 	If two sector bases satisfy the one-family overlap-orthogonality data and their
 	basis blocks are one-site injective, then a sector basis pre-matching between
-	them supplies the finite-length span field and hence the full primitive
+	them establishes the finite-length span equality and hence the full primitive
 	overlap-span hypotheses.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -895,10 +895,10 @@ single weighted block.
 	\leanok
 	\uses{thm:common_phase_cover_of_proportional_decomposition,
 		thm:bnt_perm_prop_nt}
-	The irreducible trace-preserving BNT permutation theorem gives the matched
-	basis permutation, bond-dimension equalities, and gauge-phase equivalences.
-	Applying the previous theorem to the matched basis conclusion yields the common
-	phase cover data.
+	The irreducible trace-preserving BNT permutation theorem gives the permutation
+	matching the basis blocks, bond-dimension equalities, and gauge-phase
+	equivalences. Applying the previous theorem to that conclusion yields the
+	common phase cover data.
 \end{proof}
 
 \begin{theorem}[Heterogeneous sector comparison via a bundled matching witness]%

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -878,14 +878,16 @@ single weighted block.
 	the required MPV-phase equivalence.
 \end{proof}
 
-\begin{theorem}[Separated normal BNT data produce a common phase cover]%
+\begin{theorem}[Separated normal canonical-form data produce a common phase cover]%
 \label{thm:common_phase_cover_of_separated_normal_bnt}
 	\lean{MPSTensor.nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data}
 	\leanok
-	\uses{def:mpv_common_phase_cover, thm:bnt_perm_prop_nt}
-	For two separated normal BNT families with proportional decompositions whose
-	coefficient limits are nonzero, the two basis families have a common MPV phase
-	cover. This is the BNT route to the cover data; it does not assume equality of
+	\uses{def:mpv_common_phase_cover, def:is_normal_canonical_form,
+		def:blocks_not_gauge_phase_equiv, thm:bnt_perm_prop_nt}
+	For two normal canonical-form block families with no gauge-phase-equivalent
+	distinct equal-dimension blocks, proportional decompositions whose coefficient
+	limits are nonzero give a common MPV phase cover of the two basis families.
+	This is the BNT route to the cover data; it does not assume equality of
 	finite-length spans.
 \end{theorem}
 
@@ -895,8 +897,8 @@ single weighted block.
 		thm:bnt_perm_prop_nt}
 	The irreducible trace-preserving BNT permutation theorem gives the matched
 	basis permutation, bond-dimension equalities, and gauge-phase equivalences.
-	The previous theorem reads that matched basis conclusion as a common phase
-	cover.
+	Applying the previous theorem to the matched basis conclusion yields the common
+	phase cover data.
 \end{proof}
 
 \begin{theorem}[Heterogeneous sector comparison via a bundled matching witness]%


### PR DESCRIPTION
## Summary

- Construct `MPVCommonPhaseCover` data from existing non-circular BNT matching inputs: sector-basis pre-matchings and proportional-decomposition BNT comparison conclusions.
- Add `SectorBasisPreMatching.span_eq` and `SectorBasisPreMatching.to_overlapSpan`, so a pre-matching supplies the span field needed by the #944 overlap-span endpoint without assuming the span equality first.
- Document the remaining paper input in Ch. 11 and a new audit: exact common nonzero-sector weighted assembly from #969, common injectivity/Wielandt blocking, and proportional-decomposition data for the final BNT bases.

## Paper / issue context

This is a follow-up to PR #987 for #970/#944.  It uses the CPSV/CPGSV BNT route rather than Gemma/1708: the papers' BNT comparison theorem gives a permutation, matched bond dimensions, and gauge phases; this PR reads that data as a common MPV phase cover, which then yields finite-length span equality via the already-merged common-cover span theorem.

Refs: #970, #944, #969, #942, #652.

## Validation

- `lake build --old TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` passed (only the two pre-existing long-line warnings in `CyclicSectorDecomposition.lean`).
- `lake build --old TNLean` passed with pre-existing unrelated `sorry` warnings and the same CSD long-line warnings.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passed.
- `cd blueprint && leanblueprint checkdecls` passed.
- `git diff --check origin/main...HEAD` passed.
- Added-line scans for proof-integrity tokens and banned prose terms passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new Lean constructions and theorems that are used to discharge nontrivial span/overlap hypotheses in the BNT/Fundamental Theorem pipeline; mistakes would invalidate downstream proofs rather than cause runtime issues.
> 
> **Overview**
> Adds new Lean glue that turns *existing BNT matching outputs* into bundled `MPVCommonPhaseCover` witnesses, so finite-length MPV span equality can be derived rather than assumed.
> 
> Concretely, a `SectorBasisPreMatching` now yields a canonical `commonPhaseCover`, a derived `span_eq`, and a `to_overlapSpan` adapter that fills `SectorBasisOverlapSpanHypotheses` given one-family overlap data and injectivity. Separately, proportional-decomposition comparison conclusions (and the existing separated normal-CF BNT comparison theorem) now produce `Nonempty (MPVCommonPhaseCover ...)` directly.
> 
> Updates the blueprint (Ch. 10/11) and adds an audit note documenting this non-circular predecessor step for issue #970/#944.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57718bb22a993a9cb63babeef9aa78a67386fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->