### PR TITLE
feat(MPS/CanonicalForm): prove common block-decomposition theorem (#942)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1419,22 +1419,54 @@ theorem sameMPV₂_weightedOneShotReindexedBlock_commonFlat
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ := by
           exact (mpv_toTensorFromBlocks_eq_sum (F.commonFlatWeight μ) (F.commonFlatBlocks) σ).symm
 
+/-- If the canonical one-shot blocked live blocks agree with the explicitly relabeled
+blocks, then the weighted live tensor agrees with the derived common-sector family.
+
+The hypothesis isolates the remaining physical-label compatibility step: `oneShotReindexedBlock`
+uses the iterated-blocking relabeling supplied by `iteratedBlockIndex`, while the canonical
+blocked live tensor uses the ambient blocked alphabet directly. -/
+theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
+    (hLabel : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.oneShotReindexedBlock)) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) F.commonFlatBlocks) := by
+  intro N σ
+  calc
+    mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p)) σ
+        = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+          (μ := fun k : Fin r => (μ k) ^ F.p) F.oneShotReindexedBlock) σ :=
+            hLabel N σ
+    _ = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ :=
+          F.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μ N σ
+
 end CommonBlockedCyclicSectorFamily
 
 /-- A finite family of live blocks with per-block primitive irreducible cyclic sectors
-admits one common physical blocking length for all those sectors.
+admits a prescribed common physical blocking length, provided that the prescribed
+length is a positive multiple of every period-removal length.
 
-This theorem chooses the least common multiple of the per-live-block period-removal
-lengths.  Each cyclic sector is then blocked by the corresponding quotient,
-identified with the common physical alphabet, and collected into one finite
-flattened family.  Trace preservation, primitive transfer maps, tensor
-irreducibility, positive bond dimensions, nonzero unit weights, and the per-block
-iterated-blocking MPV compatibility conditions are all retained. -/
-theorem exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors
+This variant is used for two-sided endpoints: one first chooses a common multiple
+of the period-removal lengths on both sides, then builds each one-sided cyclic
+sector family at that same physical length. -/
+theorem exists_commonBlockedCyclicSectorFamily_of_commonMultiple
     {d r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (hcyc : ∀ k, HasPrimitiveIrreducibleCyclicSectors (blocks k)) :
-    Nonempty (CommonBlockedCyclicSectorFamily blocks) := by
+    (hcyc : ∀ k, HasPrimitiveIrreducibleCyclicSectors (blocks k))
+    (p : ℕ) (hp : 0 < p)
+    (hperiod_dvd : ∀ k, (hcyc k).choose ∣ p) :
+    Nonempty { F : CommonBlockedCyclicSectorFamily blocks // F.p = p } := by
   classical
   let period : Fin r → ℕ := fun k => (hcyc k).choose
   have period_pos : ∀ k, 0 < period k := fun k => (hcyc k).choose_spec.1
@@ -1472,11 +1504,10 @@ theorem exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicS
     fun k => (hSector k).2.2.2.1
   have sector_dim_pos : ∀ k s, 0 < sectorDim k s :=
     fun k => (hSector k).2.2.2.2
-  let p := lcmPeriod period
-  have p_pos : 0 < p := lcmPeriod_pos period_pos
-  let extra : Fin r → ℕ := fun k => (dvd_lcmPeriod period k).choose
+  have p_pos : 0 < p := hp
+  let extra : Fin r → ℕ := fun k => (hperiod_dvd k).choose
   have p_eq_period_mul_extra : ∀ k, p = period k * extra k :=
-    fun k => (dvd_lcmPeriod period k).choose_spec
+    fun k => (hperiod_dvd k).choose_spec
   have extra_pos : ∀ k, 0 < extra k := by
     intro k
     have hmul_pos : 0 < period k * extra k := by
@@ -1580,7 +1611,7 @@ theorem exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicS
           (sectorBlocks k s) (extra k)))).2 hNested
     rw [toTensorFromBlocks_cast_physDim (h := hPhys k)] at hCast
     simpa using hCast
-  exact ⟨{
+  exact ⟨⟨{
     p := p
     p_pos := p_pos
     period := period
@@ -1602,7 +1633,31 @@ theorem exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicS
     flat_primitive := flat_primitive
     flat_irreducible := flat_irreducible
     flat_dim_pos := flat_dim_pos
-    nested_same := nested_same }⟩
+    nested_same := nested_same }, rfl⟩⟩
+
+/-- A finite family of live blocks with per-block primitive irreducible cyclic sectors
+admits one common physical blocking length for all those sectors.
+
+This theorem chooses the least common multiple of the per-live-block period-removal
+lengths.  Each cyclic sector is then blocked by the corresponding quotient,
+identified with the common physical alphabet, and collected into one finite
+flattened family.  Trace preservation, primitive transfer maps, tensor
+irreducibility, positive bond dimensions, nonzero unit weights, and the per-block
+iterated-blocking MPV compatibility conditions are all retained. -/
+theorem exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors
+    {d r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hcyc : ∀ k, HasPrimitiveIrreducibleCyclicSectors (blocks k)) :
+    Nonempty (CommonBlockedCyclicSectorFamily blocks) := by
+  classical
+  let period : Fin r → ℕ := fun k => (hcyc k).choose
+  have period_pos : ∀ k, 0 < period k := fun k => (hcyc k).choose_spec.1
+  obtain ⟨F, _hFp⟩ :=
+    exists_commonBlockedCyclicSectorFamily_of_commonMultiple
+      blocks hcyc (lcmPeriod period) (lcmPeriod_pos period_pos) (by
+        intro k
+        simpa [period] using (dvd_lcmPeriod period k))
+  exact ⟨F⟩
 
 end SectorOrbitLift
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1440,16 +1440,8 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := F.commonFlatWeight μ) F.commonFlatBlocks) := by
   intro N σ
-  calc
-    mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p)
-        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p)) σ
-        = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-          (μ := fun k : Fin r => (μ k) ^ F.p) F.oneShotReindexedBlock) σ :=
-            hLabel N σ
-    _ = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ :=
-          F.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μ N σ
+  exact (hLabel N σ).trans
+    (F.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μ N σ)
 
 end CommonBlockedCyclicSectorFamily
 
@@ -1504,14 +1496,13 @@ theorem exists_commonBlockedCyclicSectorFamily_of_commonMultiple
     fun k => (hSector k).2.2.2.1
   have sector_dim_pos : ∀ k s, 0 < sectorDim k s :=
     fun k => (hSector k).2.2.2.2
-  have p_pos : 0 < p := hp
   let extra : Fin r → ℕ := fun k => (hperiod_dvd k).choose
   have p_eq_period_mul_extra : ∀ k, p = period k * extra k :=
     fun k => (hperiod_dvd k).choose_spec
   have extra_pos : ∀ k, 0 < extra k := by
     intro k
     have hmul_pos : 0 < period k * extra k := by
-      simpa [p_eq_period_mul_extra k] using p_pos
+      simpa [p_eq_period_mul_extra k] using hp
     exact Nat.pos_of_mul_pos_left hmul_pos
   have hPhys : ∀ k,
       blockPhysDim (blockPhysDim d (period k)) (extra k) = blockPhysDim d p := by
@@ -1613,7 +1604,7 @@ theorem exists_commonBlockedCyclicSectorFamily_of_commonMultiple
     simpa using hCast
   exact ⟨⟨{
     p := p
-    p_pos := p_pos
+    p_pos := hp
     period := period
     period_pos := period_pos
     extra := extra

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1457,9 +1457,9 @@ end CommonBlockedCyclicSectorFamily
 admits a prescribed common physical blocking length, provided that the prescribed
 length is a positive multiple of every period-removal length.
 
-This variant is used for two-sided endpoints: one first chooses a common multiple
-of the period-removal lengths on both sides, then builds each one-sided cyclic
-sector family at that same physical length. -/
+This variant is used for two-sided constructions: one first chooses a common
+multiple of the period-removal lengths on both sides, then builds each one-sided
+cyclic sector family at that same physical length. -/
 theorem exists_commonBlockedCyclicSectorFamily_of_commonMultiple
     {d r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -784,21 +784,21 @@ theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoin
   have periodB_pos : ∀ k, 0 < periodB k := fun k => (hCycB k).choose_spec.1
   let pA : ℕ := lcmPeriod periodA
   let pB : ℕ := lcmPeriod periodB
-  let p : ℕ := pA * pB
+  let p : ℕ := Nat.lcm pA pB
   have hpA : 0 < pA := lcmPeriod_pos periodA_pos
   have hpB : 0 < pB := lcmPeriod_pos periodB_pos
-  have hp : 0 < p := Nat.mul_pos hpA hpB
+  have hp : 0 < p := Nat.lcm_pos hpA hpB
   have hDvdA : ∀ k, (hCycA k).choose ∣ p := by
     intro k
     have h₁ : periodA k ∣ pA := dvd_lcmPeriod periodA k
     have h₂ : periodA k ∣ p := by
-      simpa [p] using (Nat.dvd_mul_right_of_dvd h₁ pB)
+      exact Nat.dvd_trans h₁ (Nat.dvd_lcm_left pA pB)
     simpa [periodA] using h₂
   have hDvdB : ∀ k, (hCycB k).choose ∣ p := by
     intro k
     have h₁ : periodB k ∣ pB := dvd_lcmPeriod periodB k
     have h₂ : periodB k ∣ p := by
-      simpa [p] using (Nat.dvd_mul_left_of_dvd h₁ pA)
+      exact Nat.dvd_trans h₁ (Nat.dvd_lcm_right pA pB)
     simpa [periodB] using h₂
   obtain ⟨⟨familyA, hFamilyA⟩⟩ :=
     exists_commonBlockedCyclicSectorFamily_of_commonMultiple

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -693,10 +693,10 @@ theorem fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_
     exact familyB.commonFlatDim_pos x
 
 set_option maxHeartbeats 800000 in
--- The next endpoint has a large dependent existential conclusion, matching the
+-- The next theorem has a large dependent existential conclusion, matching the
 -- paper data needed downstream.
 
-/-- **Two-sided common-length relabeled cyclic-sector endpoint.**
+/-- **Two-sided common-length relabeled cyclic-sector theorem.**
 
 Starting from `SameMPV₂ A B`, this theorem chooses one positive physical blocking
 length for both sides.  At that common length it records the exact zero-tail

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -775,8 +775,8 @@ theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoin
       (∀ x, 0 < familyB.commonFlatDim x) := by
   obtain ⟨zeroTailA, rA, dimA, μA, blocksA,
       zeroTailB, rB, dimB, μB, blocksB,
-      hIrrA, hIrrB, hTPA, hTPB, hμA, hμB, hDimA, hDimB,
-      hMPVA, hMPVB, hPos, hZero, hCycA, hCycB⟩ :=
+      _hIrrA, _hIrrB, _hTPA, _hTPB, hμA, hμB, _hDimA, _hDimB,
+      hMPVA, hMPVB, _hPos, _hZero, hCycA, hCycB⟩ :=
     fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail A B hSame
   let periodA : Fin rA → ℕ := fun k => (hCycA k).choose
   let periodB : Fin rB → ℕ := fun k => (hCycB k).choose

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -692,6 +692,195 @@ theorem fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_
   · intro x
     exact familyB.commonFlatDim_pos x
 
+set_option maxHeartbeats 800000 in
+-- The next endpoint has a large dependent existential conclusion, matching the
+-- paper data needed downstream.
+
+/-- **Two-sided common-length relabeled cyclic-sector endpoint.**
+
+Starting from `SameMPV₂ A B`, this theorem chooses one positive physical blocking
+length for both sides.  At that common length it records the exact zero-tail
+bookkeeping for the canonically blocked live tensors, the positive-length equality
+of those live tensors, and the relabeled cyclic-sector families produced by
+`CommonBlockedCyclicSectorFamily` on both sides.
+
+The last two `SameMPV₂` conclusions are deliberately stated for the relabeled
+one-shot live blocks.  They isolate the remaining physical-label compatibility
+step needed to replace the canonical blocked live blocks in the zero-tail equations
+by the derived primitive irreducible common-sector blocks. -/
+theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ (p : ℕ), 0 < p ∧
+    ∃ (zeroTailA : ℕ) (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
+    ∃ (zeroTailB : ℕ) (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (k : Fin rB) → MPSTensor d (dimB k)),
+    ∃ (familyA : CommonBlockedCyclicSectorFamily blocksA),
+    ∃ (familyB : CommonBlockedCyclicSectorFamily blocksB),
+      familyA.p = p ∧
+      familyB.p = p ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (fun k => (μA k) ^ p)
+              (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (fun k => (μB k) ^ p)
+              (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ) ∧
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p)
+          (fun k => (μA k) ^ p)
+          (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p))
+        (toTensorFromBlocks (d := blockPhysDim d p)
+          (fun k => (μB k) ^ p)
+          (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) ∧
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (fun k => (μA k) ^ p)
+          (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ =
+        (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (fun k => (μB k) ^ p)
+          (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ) ∧
+      SameMPV₂
+        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
+          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.oneShotReindexedBlock)
+        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
+          (μ := familyA.commonFlatWeight μA) familyA.commonFlatBlocks) ∧
+      SameMPV₂
+        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
+          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.oneShotReindexedBlock)
+        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
+          (μ := familyB.commonFlatWeight μB) familyB.commonFlatBlocks) ∧
+      (∀ x, familyA.commonFlatWeight μA x ≠ 0) ∧
+      (∀ x, familyB.commonFlatWeight μB x ≠ 0) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d familyA.p),
+        (familyA.commonFlatBlocks x i)ᴴ * familyA.commonFlatBlocks x i = 1) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d familyB.p),
+        (familyB.commonFlatBlocks x i)ᴴ * familyB.commonFlatBlocks x i = 1) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d familyA.p) (D := familyA.commonFlatDim x)
+          (familyA.commonFlatBlocks x))) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d familyB.p) (D := familyB.commonFlatDim x)
+          (familyB.commonFlatBlocks x))) ∧
+      (∀ x, IsIrreducibleTensor (familyA.commonFlatBlocks x)) ∧
+      (∀ x, IsIrreducibleTensor (familyB.commonFlatBlocks x)) ∧
+      (∀ x, 0 < familyA.commonFlatDim x) ∧
+      (∀ x, 0 < familyB.commonFlatDim x) := by
+  obtain ⟨zeroTailA, rA, dimA, μA, blocksA,
+      zeroTailB, rB, dimB, μB, blocksB,
+      hIrrA, hIrrB, hTPA, hTPB, hμA, hμB, hDimA, hDimB,
+      hMPVA, hMPVB, hPos, hZero, hCycA, hCycB⟩ :=
+    fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail A B hSame
+  let periodA : Fin rA → ℕ := fun k => (hCycA k).choose
+  let periodB : Fin rB → ℕ := fun k => (hCycB k).choose
+  have periodA_pos : ∀ k, 0 < periodA k := fun k => (hCycA k).choose_spec.1
+  have periodB_pos : ∀ k, 0 < periodB k := fun k => (hCycB k).choose_spec.1
+  let pA : ℕ := lcmPeriod periodA
+  let pB : ℕ := lcmPeriod periodB
+  let p : ℕ := pA * pB
+  have hpA : 0 < pA := lcmPeriod_pos periodA_pos
+  have hpB : 0 < pB := lcmPeriod_pos periodB_pos
+  have hp : 0 < p := Nat.mul_pos hpA hpB
+  have hDvdA : ∀ k, (hCycA k).choose ∣ p := by
+    intro k
+    have h₁ : periodA k ∣ pA := dvd_lcmPeriod periodA k
+    have h₂ : periodA k ∣ p := by
+      simpa [p] using (Nat.dvd_mul_right_of_dvd h₁ pB)
+    simpa [periodA] using h₂
+  have hDvdB : ∀ k, (hCycB k).choose ∣ p := by
+    intro k
+    have h₁ : periodB k ∣ pB := dvd_lcmPeriod periodB k
+    have h₂ : periodB k ∣ p := by
+      simpa [p] using (Nat.dvd_mul_left_of_dvd h₁ pA)
+    simpa [periodB] using h₂
+  obtain ⟨⟨familyA, hFamilyA⟩⟩ :=
+    exists_commonBlockedCyclicSectorFamily_of_commonMultiple
+      blocksA hCycA p hp hDvdA
+  obtain ⟨⟨familyB, hFamilyB⟩⟩ :=
+    exists_commonBlockedCyclicSectorFamily_of_commonMultiple
+      blocksB hCycB p hp hDvdB
+  have hZA := zeroTail_toTensorFromBlocks_blockPower
+    (d := d) (D := D₁) (r := rA) (z := zeroTailA) (p := p) (dim := dimA)
+    A μA blocksA hp hMPVA
+  have hZB := zeroTail_toTensorFromBlocks_blockPower
+    (d := d) (D := D₂) (r := rB) (z := zeroTailB) (p := p) (dim := dimB)
+    B μB blocksB hp hMPVB
+  have hBook :=
+    liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+      A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hp hMPVA hMPVB
+  refine ⟨p, hp, zeroTailA, rA, dimA, μA, blocksA,
+    zeroTailB, rB, dimB, μB, blocksB, familyA, familyB,
+    hFamilyA, hFamilyB, hZA, hZB, hBook.1, hBook.2, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_⟩
+  · exact familyA.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μA
+  · exact familyB.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μB
+  · intro x
+    exact familyA.commonFlatWeight_ne_zero μA hμA x
+  · intro x
+    exact familyB.commonFlatWeight_ne_zero μB hμB x
+  · intro x
+    exact familyA.commonFlatBlocks_tp x
+  · intro x
+    exact familyB.commonFlatBlocks_tp x
+  · intro x
+    exact familyA.commonFlatBlocks_primitive x
+  · intro x
+    exact familyB.commonFlatBlocks_primitive x
+  · intro x
+    exact familyA.commonFlatBlocks_irreducible x
+  · intro x
+    exact familyB.commonFlatBlocks_irreducible x
+  · intro x
+    exact familyA.commonFlatDim_pos x
+  · intro x
+    exact familyB.commonFlatDim_pos x
+
+/-- If the canonical blocked live tensor is compatible with the relabeled one-shot
+blocks, the zero-tail equation can be rewritten using the derived common-sector
+family.  This is the one-sided theorem turning the relabeled data above into the exact
+live-sector shape consumed by the downstream span and BNT comparison theorems. -/
+theorem zeroTail_commonFlat_of_oneShot_labelCompat
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hLabel : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.oneShotReindexedBlock)) :
+    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
+      mpv (blockTensor (d := d) (D := D) A F.p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
+  intro N σ
+  have hCanon := zeroTail_toTensorFromBlocks_blockPower
+    (d := d) (D := D) (r := r) (z := z) (p := F.p) (dim := dim)
+    A μ blocks F.p_pos hMPV
+  have hFlat := F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot μ hLabel
+  calc
+    mpv (blockTensor (d := d) (D := D) A F.p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (fun k => (μ k) ^ F.p)
+            (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p)) σ := hCanon N σ
+    _ = mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
+          rw [hFlat N σ]
+
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 
 Given two tensors with `SameMPV₂`, a common-period BNT sector pair, and a

--- a/audits/2026-04-29_issue942_common_exact_live_endpoint.md
+++ b/audits/2026-04-29_issue942_common_exact_live_endpoint.md
@@ -49,7 +49,7 @@ The remaining paper inputs are stated below.
    `fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint`
    starts from `SameMPV₂ A B`.  It takes the per-block cyclic live reduction,
    lets `p_A` and `p_B` be the one-sided least common multiples, and chooses the
-   single two-sided length `p = p_A p_B`.  At this common length it records:
+   single two-sided length `p = lcm(p_A,p_B)`.  At this common length it records:
 
    - exact zero-tail equations for `blockTensor A p` and `blockTensor B p`
      against the canonically blocked live tensors;

--- a/audits/2026-04-29_issue942_common_exact_live_endpoint.md
+++ b/audits/2026-04-29_issue942_common_exact_live_endpoint.md
@@ -1,0 +1,101 @@
+# 2026-04-29 — Common exact live-sector endpoint predecessor (#942/#969/#970/#944/#652)
+
+## Scope
+
+This audit records a non-Gemma predecessor toward the common exact live-sector
+endpoint needed before the common phase-cover and BNT span theorems can close
+#970/#944 and then the #652 Gap §1 umbrella.
+
+The new Lean declarations are:
+
+- `MPSTensor.exists_commonBlockedCyclicSectorFamily_of_commonMultiple`
+- `MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot`
+- `MPSTensor.fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint`
+- `MPSTensor.zeroTail_commonFlat_of_oneShot_labelCompat`
+
+They deliberately do not assert the full arbitrary `SameMPV₂` fundamental theorem.
+The remaining paper inputs are stated below.
+
+## Source anchors
+
+- `Papers/1606.00608/MPDO-22-12-17-2.tex:214--231` describes replacing an
+  arbitrary tensor by a block diagonal live tensor and then blocking by the
+  periods.  In particular line 217 gives
+  `A^i = ... = \oplus_{k=1}^r \mu_k A^i_k`, and lines 227--231 state that
+  blocking by the least common multiple of the periods removes the peripheral
+  periodicity.
+- `Papers/2011.12127/TN-Review-main.tex:1798--1808` gives the same block
+  diagonal live form and transfer-operator normalization.  Lines 1815--1820
+  explain that an irreducible block may have peripheral period `p` and that
+  blocking `p` sites yields a primitive transfer operator.
+- `Papers/2011.12127/TN-Review-main.tex:1841--1859` introduces bases of normal
+  tensors and their phase/gauge equivalence classes.  Lines 1864--1884 rewrite
+  a canonical form in a BNT basis with coefficients
+  `\sum_q \mu_{j,q}^N`; this is the downstream comparison consumed by the
+  phase-cover and BNT matching theorems.
+
+## What this branch proves
+
+1. **One-sided common sectors at a prescribed length.**
+   `exists_commonBlockedCyclicSectorFamily_of_commonMultiple` strengthens the
+   earlier least-common-multiple constructor.  If a positive integer `p` is a
+   common multiple of every period-removal length in a live family, then the
+   one-sided `CommonBlockedCyclicSectorFamily` may be constructed with exactly
+   that `p`.  The proof writes `p = m_k e_k` for each live block, blocks each
+   cyclic sector by `e_k`, and transports trace preservation, primitivity,
+   tensor irreducibility, positive dimension, and MPV equivalence.
+
+2. **Two-sided common-length endpoint from structural reduction.**
+   `fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint`
+   starts from `SameMPV₂ A B`.  It takes the per-block cyclic live reduction,
+   lets `p_A` and `p_B` be the one-sided least common multiples, and chooses the
+   single two-sided length `p = p_A p_B`.  At this common length it records:
+
+   - exact zero-tail equations for `blockTensor A p` and `blockTensor B p`
+     against the canonically blocked live tensors;
+   - positive-length equality of those canonically blocked live tensors;
+   - the exact length-zero zero-tail bookkeeping identity at the common length;
+   - relabeled one-shot cyclic-sector families on both sides at that same `p`;
+   - nonzero transported sector weights and TP / primitive / tensor-irreducible /
+     positive-dimension properties for those derived sectors.
+
+3. **One-sided theorem for the remaining physical-label step.**
+   `sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot` and
+   `zeroTail_commonFlat_of_oneShot_labelCompat` state the exact conversion needed
+   after the physical-label compatibility is proved: if the canonical blocked
+   live tensor agrees with the explicitly relabeled one-shot live tensor, then
+   the zero-tail equation can be rewritten directly with the weighted derived
+   common-sector family.
+
+## Remaining paper inputs
+
+The exact blockers are now narrower than before:
+
+1. **Physical-label compatibility for the flat live tensor.**
+   The current common sectors are expressed through `oneShotReindexedBlock`, which
+   uses the iterated-blocking relabeling `iteratedBlockIndex` for each original
+   live block.  The canonical zero-tail equations use the ambient blocked
+   alphabet of `blockTensor (blocks k) p`.  One still needs the global statement
+   identifying the weighted canonical blocked live tensor with the weighted
+   relabeled one-shot live tensor, or an equivalent downstream theorem formulated
+   directly for the relabeled families.
+
+2. **Injectivity/Wielandt endpoint.**
+   The new endpoint proves trace preservation, primitive transfer maps, tensor
+   irreducibility, and positive bond dimension.  The #944/#652 overlap-rigidity
+   route also needs one-site injectivity of the final live blocks, or a theorem
+   replacing the one-site injectivity input by a later blocked variant.  This is
+   the later Wielandt stage mentioned in #969 and is not conflated with the
+   period-removal length.
+
+3. **Common phase-cover or BNT comparison data.**
+   PRs #987/#988 provide `MPVCommonPhaseCover`, `SectorBasisPreMatching`, and the
+   BNT cover construction once proportional-decomposition matching data is
+   available.  This branch supplies the common-length sector endpoint needed
+   before those theorems can be applied, but it does not construct the
+   cross-side class maps or phase equivalences from arbitrary `SameMPV₂`.
+
+4. **Final exact-live span input.**
+   After items 1--3, `MPVCommonPhaseCover.span_eq` or the BNT pre-matching
+   theorem should provide the finite-length live-sector span equality needed by
+   `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPhaseCover`.

--- a/audits/2026-04-29_issue942_common_exact_live_endpoint.md
+++ b/audits/2026-04-29_issue942_common_exact_live_endpoint.md
@@ -1,9 +1,9 @@
-# 2026-04-29 — Common exact live-sector endpoint predecessor (#942/#969/#970/#944/#652)
+# 2026-04-29 — Common exact live-sector construction predecessor (#942/#969/#970/#944/#652)
 
 ## Scope
 
 This audit records a non-Gemma predecessor toward the common exact live-sector
-endpoint needed before the common phase-cover and BNT span theorems can close
+statement needed before the common phase-cover and BNT span theorems can close
 #970/#944 and then the #652 Gap §1 umbrella.
 
 The new Lean declarations are:
@@ -45,7 +45,7 @@ The remaining paper inputs are stated below.
    cyclic sector by `e_k`, and transports trace preservation, primitivity,
    tensor irreducibility, positive dimension, and MPV equivalence.
 
-2. **Two-sided common-length endpoint from structural reduction.**
+2. **Two-sided common-length theorem from structural reduction.**
    `fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint`
    starts from `SameMPV₂ A B`.  It takes the per-block cyclic live reduction,
    lets `p_A` and `p_B` be the one-sided least common multiples, and chooses the
@@ -80,8 +80,8 @@ The exact blockers are now narrower than before:
    relabeled one-shot live tensor, or an equivalent downstream theorem formulated
    directly for the relabeled families.
 
-2. **Injectivity/Wielandt endpoint.**
-   The new endpoint proves trace preservation, primitive transfer maps, tensor
+2. **Injectivity/Wielandt stage.**
+   The new theorem proves trace preservation, primitive transfer maps, tensor
    irreducibility, and positive bond dimension.  The #944/#652 overlap-rigidity
    route also needs one-site injectivity of the final live blocks, or a theorem
    replacing the one-site injectivity input by a later blocked variant.  This is
@@ -91,7 +91,7 @@ The exact blockers are now narrower than before:
 3. **Common phase-cover or BNT comparison data.**
    PRs #987/#988 provide `MPVCommonPhaseCover`, `SectorBasisPreMatching`, and the
    BNT cover construction once proportional-decomposition matching data is
-   available.  This branch supplies the common-length sector endpoint needed
+   available.  This branch supplies the common-length sector data needed
    before those theorems can be applied, but it does not construct the
    cross-side class maps or phase equivalences from arbitrary `SameMPV₂`.
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1758,20 +1758,36 @@ The following results separate the zero blocks from the
 	sums and reindex the double sum over pairs $(k,s)$ by the flattened sector index.
 \end{proof}
 
-\begin{theorem}[Common reblocking of per-block cyclic sectors]%
-\label{thm:exists_common_blocked_cyclic_sector_family}
-	\lean{MPSTensor.exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors}
+\begin{theorem}[Canonical blocked live tensor under physical-label compatibility]%
+\label{thm:common_blocked_cyclic_sector_canonical_label_compat}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot}
+	\leanok
+	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
+		def:common_blocked_cyclic_sector_derived_blocks}
+	Assume that the canonical one-shot blocked live-block tensor agrees, as an
+	MPV family, with the explicitly relabeled one-shot live-block tensor coming
+	from iterated blocking.  Then the canonical weighted live-block tensor agrees
+	with the weighted derived common-sector tensor.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv}
+	Compose the assumed MPV equality with the relabeled one-shot decomposition of
+	Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_samempv}.
+\end{proof}
+
+\begin{theorem}[Common reblocking at a prescribed common multiple]%
+\label{thm:exists_common_blocked_cyclic_sector_family_common_multiple}
+	\lean{MPSTensor.exists_commonBlockedCyclicSectorFamily_of_commonMultiple}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_family,
 		def:primitive_irreducible_cyclic_sectors,
 		thm:tp_primitive_irreducible_extra_blocking,
 		thm:samempv_blocking_distributes}
-	If every live block in a finite family has primitive irreducible cyclic
-	sectors, then the family admits a common reblocked cyclic-sector family.
-	The proof chooses the least common multiple of the per-block periods, blocks
-	each sector by the corresponding quotient, transports all sectors to the common
-	physical alphabet, and preserves TP, primitivity, tensor irreducibility,
-	positive bond dimensions, and the unit-weight MPV equivalences.
+	If every live block has primitive irreducible cyclic sectors and a positive
+	integer $p$ is a common multiple of all period-removal lengths, then the live
+	family admits a common reblocked cyclic-sector family whose common length is
+	that prescribed $p$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1783,11 +1799,29 @@ The following results separate the zero blocks from the
 		thm:left_canonical_cast_phys_dim,
 		thm:primitive_transfer_cast_phys_dim,
 		thm:irreducible_tensor_cast_phys_dim}
-	Choose the least common multiple $p$ of the per-block periods $m_k$ and write
-	$p=m_k e_k$.  Apply the extra-blocking theorem to each cyclic sector for the
-	positive length $e_k$.  The MPV equivalence is obtained by blocking the
-	unit-weight cyclic-sector equivalence and transporting the physical alphabet
-	to $d^p$.
+	For each block with period $m_k$, write the prescribed common multiple as
+	$p=m_k e_k$.  Then block every cyclic sector by $e_k$, substitute the equality
+	between the iterated and common physical alphabets, and transport the MPV and
+	structural properties exactly as in the least-common-multiple construction.
+\end{proof}
+
+\begin{theorem}[Common reblocking of per-block cyclic sectors]%
+\label{thm:exists_common_blocked_cyclic_sector_family}
+	\lean{MPSTensor.exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors}
+	\leanok
+	\uses{thm:exists_common_blocked_cyclic_sector_family_common_multiple}
+	If every live block in a finite family has primitive irreducible cyclic
+	sectors, then the family admits a common reblocked cyclic-sector family.
+	The proof chooses the least common multiple of the per-block periods, blocks
+	each sector by the corresponding quotient, transports all sectors to the common
+	physical alphabet, and preserves TP, primitivity, tensor irreducibility,
+	positive bond dimensions, and the unit-weight MPV equivalences.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:exists_common_blocked_cyclic_sector_family_common_multiple}
+	Choose the least common multiple $p$ of the per-block periods and apply
+	Theorem~\ref{thm:exists_common_blocked_cyclic_sector_family_common_multiple}.
 \end{proof}
 
 \subsection{Sector irreducibility helpers}%
@@ -3193,6 +3227,59 @@ The following results separate the zero blocks from the
 	the zero-tail reblocking theorem to the original live-block decomposition, then
 	use the relabeled one-shot sector decomposition and the derived structural
 	properties of the common-sector family.
+\end{proof}
+
+\begin{theorem}[Two-sided common-length relabeled cyclic-sector endpoint]%
+\label{thm:ft_after_blocking_common_length_common_sector_endpoint}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint}
+	\leanok
+	\uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
+		thm:exists_common_blocked_cyclic_sector_family_common_multiple,
+		thm:zero_tail_to_tensor_from_blocks_block_power,
+		thm:live_block_block_power_zero_tail_bookkeeping,
+		thm:common_blocked_cyclic_sector_reindexed_samempv,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	If two tensors generate the same MPV family, then one can choose a single
+	positive physical blocking length for the cyclic-sector data on both sides.
+	At that length the theorem records the exact zero-tail equations for the
+	canonically blocked live tensors, the positive-length equality and length-zero
+	bookkeeping for those live tensors, and the relabeled primitive irreducible
+	common-sector families on both sides with nonzero transported weights.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
+		thm:exists_common_blocked_cyclic_sector_family_common_multiple,
+		thm:zero_tail_to_tensor_from_blocks_block_power,
+		thm:live_block_block_power_zero_tail_bookkeeping,
+		thm:common_blocked_cyclic_sector_reindexed_samempv,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	Start from the per-block cyclic live theorem.  Let $p_A$ and $p_B$ be the
+	least common multiples of the period-removal lengths on the two sides, and
+	use $p=p_Ap_B$.  The prescribed-common-multiple theorem constructs both
+	one-sided sector families at this same length.  The zero-tail and positive-
+	length equalities are the existing reblocking statements, and the relabeled
+	sector conclusions are the one-shot common-sector MPV equalities.
+\end{proof}
+
+\begin{theorem}[Zero-tail equation after resolving the one-shot relabeling]%
+\label{thm:zero_tail_common_flat_of_one_shot_label_compat}
+	\lean{MPSTensor.zeroTail_commonFlat_of_oneShot_labelCompat}
+	\leanok
+	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
+		thm:common_blocked_cyclic_sector_canonical_label_compat}
+	For one side, suppose the canonical blocked live tensor agrees with the
+	explicitly relabeled one-shot live tensor.  Then the zero-tail equation after
+	blocking may be written directly with the weighted derived common-sector
+	family.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
+		thm:common_blocked_cyclic_sector_canonical_label_compat}
+	First transport the original zero-tail/live decomposition through the common
+	blocking length.  Then replace the canonical blocked live tensor by the
+	derived common-sector tensor using the physical-label compatibility hypothesis.
 \end{proof}
 
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3310,23 +3310,29 @@ The following results separate the zero blocks from the
 	blocks, and Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
 	applies the cyclic-sector construction to each live block while keeping the
 	positive-length MPV equality and the $N=0$ bookkeeping.
-	Theorem~\ref{thm:exists_common_blocked_cyclic_sector_family} then replaces the
-	different sector periods in a finite live family by one common blocking length.
-	The supporting blocking and transport results, including
-	Theorem~\ref{thm:iterated_blocking_samempv_reindex}, identify
-	iterated blocking with one blocking by the product length, up to the evident
-	relabeling of physical words.
+	Theorem~\ref{thm:exists_common_blocked_cyclic_sector_family_common_multiple}
+	constructs the common reblocked sector family at any prescribed common multiple
+	of the period-removal lengths.  Consequently
+	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} now
+	chooses one physical blocking length for both tensors, carries the zero-tail
+	identities to that length, and supplies the relabeled cyclic-sector families on
+	both sides.  The supporting blocking and transport results, including
+	Theorem~\ref{thm:iterated_blocking_samempv_reindex}, identify iterated blocking
+	with one blocking by the product length, up to the evident relabeling of
+	physical words.
 
-	What remains is a single normal-canonical-form statement for the whole blocked
-	live tensor.  One must prove that, after the common blocking length is chosen,
-	the weighted direct sum of the original live blocks is MPV-equivalent to the
-	weighted direct sum of all common-length cyclic sectors, with the original
-	weights attached to the corresponding sectors and with the zero-tail equations
-	unchanged.  The current common-sector theorem records this information one
-	live block at a time; it does not yet assemble the weighted direct sum needed
-	by the equal-case theorem.  A later comparison of two equal MPV families also
-	needs a finite-length span statement for these common-length live sectors,
-	obtained after any additional blocking needed for injectivity.
+	What remains on the canonical-form side is the exact compatibility between the
+	canonical blocked live tensor and the explicitly relabeled one-shot live tensor
+	for the whole weighted live family.  The conditional statement
+	Theorem~\ref{thm:zero_tail_common_flat_of_one_shot_label_compat} already shows
+	that, once this physical-label compatibility is proved, the zero-tail equations
+	can be written directly with the weighted common-length cyclic sectors.  After
+	that conversion one still needs the final live-sector family used by the
+	equal-case comparison, any additional blocking required for injectivity, and a
+	finite-length span statement for the resulting live sectors.
+	Chapter~\ref{ch:assembly} contains the common phase-cover and BNT comparison
+	theorems that use such span
+	data once the canonical-form construction has supplied it.
 
 	The sorted normal-canonical-form theorem,
 	Theorem~\ref{thm:bnt_sorted_ncf}, assumes pairwise distinct nonzero weight

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3256,7 +3256,7 @@ The following results separate the zero blocks from the
 		thm:common_blocked_cyclic_sector_derived_properties}
 	Start from the per-block cyclic live theorem.  Let $p_A$ and $p_B$ be the
 	least common multiples of the period-removal lengths on the two sides, and
-	use $p=p_Ap_B$.  The prescribed-common-multiple theorem constructs both
+	use $p=\mathrm{lcm}(p_A,p_B)$.  The prescribed-common-multiple theorem constructs both
 	one-sided sector families at this same length.  The zero-tail and positive-
 	length equalities are the existing reblocking statements, and the relabeled
 	sector conclusions are the one-shot common-sector MPV equalities.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3229,8 +3229,8 @@ The following results separate the zero blocks from the
 	properties of the common-sector family.
 \end{proof}
 
-\begin{theorem}[Two-sided common-length relabeled cyclic-sector endpoint]%
-\label{thm:ft_after_blocking_common_length_common_sector_endpoint}
+\begin{theorem}[Two-sided common-length relabeled cyclic-sector theorem]%
+\label{thm:ft_after_blocking_common_length_common_sector_theorem}
 	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint}
 	\leanok
 	\uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
@@ -3268,9 +3268,12 @@ The following results separate the zero blocks from the
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:common_blocked_cyclic_sector_canonical_label_compat}
-	For one side, suppose the canonical blocked live tensor agrees with the
-	explicitly relabeled one-shot live tensor.  Then the zero-tail equation after
-	blocking may be written directly with the weighted derived common-sector
+	For one side, suppose first that the original tensor decomposes, as an MPV
+	family, into a zero-tail contribution plus a weighted block-sum live part at
+	the original physical alphabet.  Suppose also that, after blocking by the
+	common length, the canonical blocked live tensor agrees with the explicitly
+	relabeled one-shot live tensor as an MPV family.  Then the zero-tail equation
+	after blocking may be written directly with the weighted derived common-sector
 	family.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1215,19 +1215,28 @@ single weighted block.
 	then turns equality of live-sector spans into the hypotheses used by the
 	sector comparison theorem.
 
+	The common-family comparison input is also formalized in reusable forms.  A
+	common MPV phase cover gives equality of finite-length live-block spans by
+	Lemma~\ref{lem:mpv_common_phase_cover_span_eq}.  A sector basis pre-matching
+	gives such span equality and the primitive overlap-span hypotheses by
+	Lemma~\ref{lem:sector_basis_pre_matching_span_eq} and
+	Theorem~\ref{thm:sector_basis_pre_matching_to_overlap_span}.  The BNT comparison
+	results produce common phase-cover data from proportional-decomposition
+	conclusions in Theorems~\ref{thm:common_phase_cover_of_proportional_decomposition}
+	and~\ref{thm:common_phase_cover_of_separated_normal_bnt}.
+
 	The remaining input for the unconditional equal-case theorem is the connection
-	from arbitrary equal MPV families to those hypotheses.  After applying the
-	canonical-form reduction of Chapter~\ref{ch:canonical}, one must put the live
-	sectors of both tensors at one common blocking length, carry the original
-	weights and the zero-tail identities through that blocking, and prove that the
-	two resulting live-sector families span the same finite-length MPV spaces.  A
-	convenient sufficient form is already formalized in
-	Theorem~\ref{thm:after_blocking_sector_common_blocks_phase_cover}: both live
-	families may be compared with one common family of phase-gauge classes,
-	surjectively on both sides.  What is not yet formalized is the construction of
-	that common family, or an equivalent direct proof of the span equality, from
-	the equal-MPV hypothesis and the common-length cyclic-sector data of
-	Chapter~\ref{ch:canonical}.  Without this construction, equality of the total
-	MPV vectors has not yet been converted into the componentwise power-sum identities
-	used in the paper proof, so Corollary~IV.5 cannot be invoked unconditionally.
+	from arbitrary equal MPV families to those hypotheses.  Chapter~\ref{ch:canonical}
+	now supplies a common physical blocking length and relabeled cyclic-sector
+	families on both sides, while preserving the zero-tail identities.  What remains
+	is the exact physical-label compatibility that identifies the canonical blocked
+	live tensor with the relabeled one-shot live tensor for the whole weighted live
+	family, followed by the final live-sector extraction used by the equal-case
+	comparison.  After any additional blocking required for injectivity, one must
+	then prove the finite-length live-sector span equality, or produce the common
+	phase-cover or BNT proportional-decomposition data from which the theorems above
+	derive that equality.  Until this connection is formalized, equality of the
+	total MPV vectors has not yet been converted into the componentwise power-sum
+	identities used in the paper proof, so Corollary~IV.5 cannot be invoked
+	unconditionally.
 \end{remark}


### PR DESCRIPTION
## Summary

- Add a prescribed-common-multiple constructor for `CommonBlockedCyclicSectorFamily`, so both sides of the structural reduction can be built at one shared physical blocking length.
- Add a two-sided common-length relabeled cyclic-sector endpoint from arbitrary `SameMPV₂`, retaining zero-tail equations, positive-length equality of the nonzero parts, length-zero accounting, nonzero transported weights, and TP/primitive/irreducible/positive-dimension sector properties.
- Add a one-sided theorem converting the zero-tail equation to the derived common-sector family once the remaining compatibility under relabelling of physical indices is supplied.
- Document the exact remaining paper inputs: compatibility under relabelling of physical indices, later injectivity/Wielandt blocking, common phase-cover/BNT matching data, and final nonzero-sector span equality.

## Paper and blueprint references

- `Papers/1606.00608/MPDO-22-12-17-2.tex:214--231`: nonzero block diagonal form and LCM blocking to remove periods.
- `Papers/2011.12127/TN-Review-main.tex:1798--1820`: nonzero block form, transfer map normalization, and period-blocking to primitive blocks.
- `Papers/2011.12127/TN-Review-main.tex:1841--1884`: BNT basis and coefficient expansion consumed downstream by the #970/#944 machinery.

## Validation

- `lake build --old TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem TNLean.MPS.CanonicalForm.EqualNormBridge`
  - Passed; only the two pre-existing long-line warnings in `CyclicSectorDecomposition.lean` at lines 683 and 913 replayed.
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- Added-line scans for proof-integrity tokens and flagged prose terms passed.

Refs #942, #969, #971, #970, #944, #652.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds large new Lean theorems with deep dependent existential conclusions and heavy proof automation/heartbeats; risk is mainly build-time/proof fragility and subtle statement mismatches rather than runtime behavior.
> 
> **Overview**
> Adds a prescribed-length constructor `exists_commonBlockedCyclicSectorFamily_of_commonMultiple`, allowing `CommonBlockedCyclicSectorFamily` to be built at an explicitly chosen positive `p` when all per-block period-removal lengths divide `p`, and refactors the old LCM-based constructor to call this variant.
> 
> Introduces a conditional “label-compatibility” bridge `sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot` plus `zeroTail_commonFlat_of_oneShot_labelCompat`, letting reviewers rewrite canonical blocked zero-tail/live equations directly in terms of the derived flattened common-sector family once the remaining physical-index relabelling equality is provided.
> 
> Adds a new two-sided endpoint theorem `fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint` that, from `SameMPV₂ A B`, chooses a single common blocking length `p = lcm(pA,pB)` and packages both sides’ zero-tail equations at that length, positive-length equality of the nonzero parts and `N=0` accounting, and the relabeled common-sector families (with nonzero weights and TP/primitive/irreducible/positive-dimension properties). Documentation/audit and blueprint text are updated to reflect this new common-length endpoint and the remaining gap (compatibility under relabelling of physical indices/injectivity/span).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23b03fa1ed21293b185659c2e4e5db784514b6b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->