### PR TITLE
docs(github): require mathematical generated prose

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,7 +15,7 @@ body:
     id: description
     attributes:
       label: Description
-      description: What is broken? Include error messages or sorry locations.
+      description: What is broken? Include error messages, sorry locations, or the affected mathematical statement.
       placeholder: |
         `lake build` fails with:
         ```
@@ -25,10 +25,21 @@ body:
       required: true
 
   - type: textarea
+    id: mathematical_context
+    attributes:
+      label: Mathematical context
+      description: Give the theorem, definition, blueprint entry, or paper reference affected, if applicable.
+      placeholder: |
+        The failure affects the formalization of Wolf Prop. 6.7 in
+        `blueprint/src/chapter/ch06_spectral.tex:88`.
+    validations:
+      required: false
+
+  - type: textarea
     id: expected
     attributes:
       label: Expected behavior
-      description: What should happen instead?
+      description: What should the statement, proof, or build do instead?
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/formalization-task.yml
+++ b/.github/ISSUE_TEMPLATE/formalization-task.yml
@@ -6,8 +6,8 @@ body:
     id: statement
     attributes:
       label: Mathematical statement
-      description: Name and source of the result to formalize
-      placeholder: "e.g., Wolf Thm 6.15: conditional expectation from faithful fixed point"
+      description: State the theorem, definition, or lemma in mathematical language.
+      placeholder: "e.g., Wolf Thm 6.15: faithful fixed points yield a conditional expectation"
     validations:
       required: true
 
@@ -15,8 +15,25 @@ body:
     id: reference
     attributes:
       label: Reference
-      description: Paper or textbook citation
+      description: >-
+        Paper, textbook, or blueprint citation, including theorem/lemma label
+        if available.
       placeholder: "e.g., arXiv:1804.04964 Theorem 3.2, Wolf Lecture Notes Prop 7.4"
+    validations:
+      required: true
+
+  - type: textarea
+    id: source_location
+    attributes:
+      label: Source location and quotation
+      description: >-
+        Give a file path and line number when the source is in this repository,
+        plus a short quotation or precise paraphrase of the mathematical claim.
+      placeholder: |
+        - Source: `blueprint/src/chapter/ch06_spectral.tex:142`
+        - Label: `thm:peripheral-fixed-point`
+        - Claim: The peripheral fixed points form a finite-dimensional
+          C*-algebra under the stated hypotheses.
     validations:
       required: true
 
@@ -33,9 +50,10 @@ body:
     id: dependencies
     attributes:
       label: Dependencies
-      description: Existing Lean declarations or issues this depends on
+      description: Existing formalized results, blueprint entries, or issues this depends on
       placeholder: |
         - `MPSTensor.transferMap` (exists)
+        - `blueprint/src/chapter/ch06_spectral.tex:118`
         - #191 (ground space definitions, in progress)
     validations:
       required: false
@@ -44,8 +62,12 @@ body:
     id: sketch
     attributes:
       label: Proof sketch / approach
-      description: Brief outline of the formalization strategy
-      placeholder: Optional
+      description: >-
+        Brief mathematical proof sketch, with the main lemmas or reductions
+        expected.
+      placeholder: |
+        Reduce to the finite-dimensional spectral decomposition, identify the
+        fixed-point projection, and apply the cited conditional-expectation theorem.
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/tracking-issue.yml
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.yml
@@ -59,9 +59,6 @@ body:
       value: |
         ```[tasklist]
         ### Tasks
-        - [ ] #
-        - [ ] #
-        - [ ] #
         ```
       placeholder: |
         ```[tasklist]

--- a/.github/ISSUE_TEMPLATE/tracking-issue.yml
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.yml
@@ -1,13 +1,15 @@
 name: Tracking Issue
-description: Create a tracking issue to monitor progress across multiple issues and PRs
+description: Create a tracking issue for a group of mathematical tasks
 labels: ["tracking"]
 body:
   - type: markdown
     attributes:
       value: |
         ## Tracking Issue
-        Use this template to create an issue that tracks progress across multiple related issues and PRs.
-        List each sub-task inside a native tasklist block so GitHub shows "Tracked by" on child issues.
+        Use this template for a family of related mathematical tasks.
+        Each task should be a separate GitHub issue with its own statement and source citation.
+        List sub-issues inside a native tasklist block so GitHub shows "Tracked by" on child issues.
+        Do not use ordinary Markdown checklists for tracked work.
 
   - type: input
     id: area
@@ -21,20 +23,39 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Description
-      description: Describe the goal this tracking issue covers
-      placeholder: What is the overall objective?
+      label: Mathematical goal
+      description: >-
+        Describe the theorem, chapter, construction, or proof family covered by
+        this tracking issue.
+      placeholder: |
+        Formalize the spectral decomposition results for finite-dimensional
+        quantum channels in Wolf Chapter 6, with each sub-issue tied to a
+        theorem label or blueprint entry.
+    validations:
+      required: true
+
+  - type: textarea
+    id: sources
+    attributes:
+      label: Sources
+      description: >-
+        List the papers, blueprint files, theorem labels, or repository notes
+        that define the scope.
+      placeholder: |
+        - Wolf Lecture Notes, Chapter 6, Theorems 6.14--6.18
+        - `blueprint/src/chapter/ch06_spectral.tex:120`
     validations:
       required: true
 
   - type: textarea
     id: tasks
     attributes:
-      label: Tracked Tasks
+      label: Sub-issues
       description: |
-        List issues/PRs to track using a native tasklist block.
+        List issue numbers to track using a native GitHub tasklist block.
         Each line must contain only the issue reference (no descriptions).
-        The workflow will automatically update checkboxes when issues are closed or PRs are merged.
+        Put mathematical descriptions in the sub-issue titles and bodies.
+        The tracking workflow updates checkboxes when issues are closed or reopened.
       value: |
         ```[tasklist]
         ### Tasks
@@ -54,8 +75,9 @@ body:
   - type: textarea
     id: notes
     attributes:
-      label: Additional Notes
-      description: Any extra context, dependencies, or milestones
-      placeholder: Optional notes
+      label: Dependencies and order
+      description: State mathematical dependencies, proposed order, or milestone information.
+      placeholder: |
+        Prove the fixed-point algebra statements before the peripheral-spectrum statements.
     validations:
       required: false

--- a/.github/actions/auto-create-issue-pr/action.yml
+++ b/.github/actions/auto-create-issue-pr/action.yml
@@ -78,11 +78,42 @@ runs:
           exit 0
         fi
 
-        ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title')
+        ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title,labels,url)
+        ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+        ISSUE_URL=$(echo "$ISSUE_JSON" | jq -r '.url')
+        ISSUE_LABELS=$(echo "$ISSUE_JSON" | jq -r '[.labels[].name] | join(", ")')
+
+        CHANGED_FILES=$(
+          git diff --name-only "origin/main...origin/$BRANCH" 2>/dev/null \
+            | sed 's/^/- `/' \
+            | sed 's/$/`/' \
+            || true
+        )
+        if [ -z "$CHANGED_FILES" ]; then
+          CHANGED_FILES="- See the commits on \`$BRANCH\`."
+        fi
 
         echo "Creating PR from $BRANCH → main for issue #${ISSUE_NUMBER}"
 
-        PR_BODY=$'Addresses #'"${ISSUE_NUMBER}"$'\n\nAuto-created by '"${CREATOR_NAME}"$'.'
+        PR_BODY=$(cat <<EOF
+        ### Motivation
+        - Addresses #${ISSUE_NUMBER}: ${ISSUE_TITLE}.
+        - Source issue: ${ISSUE_URL}
+
+        ### Description
+        - This PR was opened from \`${BRANCH}\` by ${CREATOR_NAME}.
+        - Changed files:
+        ${CHANGED_FILES}
+
+        ### Testing
+        - CI should run the Lean and blueprint checks for this branch.
+
+        ---
+        Addresses #${ISSUE_NUMBER}
+
+        Issue labels: ${ISSUE_LABELS}
+        EOF
+        )
 
         PR_URL=$(gh pr create \
           --repo "$REPO" \

--- a/.github/actions/auto-create-issue-pr/action.yml
+++ b/.github/actions/auto-create-issue-pr/action.yml
@@ -78,10 +78,8 @@ runs:
           exit 0
         fi
 
-        ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title,labels,url)
-        ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
-        ISSUE_URL=$(echo "$ISSUE_JSON" | jq -r '.url')
-        ISSUE_LABELS=$(echo "$ISSUE_JSON" | jq -r '[.labels[].name] | join(", ")')
+        ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title')
+        ISSUE_URL=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json url --jq '.url')
 
         CHANGED_FILES=$(
           git diff --name-only "origin/main...origin/$BRANCH" 2>/dev/null \
@@ -102,7 +100,6 @@ runs:
 
         ### Description
         - This PR was opened from \`${BRANCH}\` by ${CREATOR_NAME}.
-        - Linked issue labels: ${ISSUE_LABELS}
         - Changed files:
         ${CHANGED_FILES}
 

--- a/.github/actions/auto-create-issue-pr/action.yml
+++ b/.github/actions/auto-create-issue-pr/action.yml
@@ -102,6 +102,7 @@ runs:
 
         ### Description
         - This PR was opened from \`${BRANCH}\` by ${CREATOR_NAME}.
+        - Linked issue labels: ${ISSUE_LABELS}
         - Changed files:
         ${CHANGED_FILES}
 
@@ -110,8 +111,6 @@ runs:
 
         ---
         Addresses #${ISSUE_NUMBER}
-
-        Issue labels: ${ISSUE_LABELS}
         EOF
         )
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,13 @@
 ### Motivation
 <!-- Why this change is needed (1--3 bullets). -->
+<!-- For mathematical work, cite the source theorem, blueprint label, or issue. -->
 
 -
 
 ### Description
 <!-- What was changed: files added/modified, definitions introduced, lemmas proved. -->
+<!-- State the mathematical content precisely enough for a reader who has not read
+     the issue thread. -->
 
 -
 

--- a/.github/workflows/auto-fix-codex.yml
+++ b/.github/workflows/auto-fix-codex.yml
@@ -341,7 +341,7 @@ jobs:
             1. Use your judgment on whether Mathlib scouting is needed. For proof-level review comments, read PR/issue comments for existing **Mathlib Scouting Reports**. For cosmetic comments (naming, docstrings, style), skip scouting.
             2. Read each review thread conversation and understand the issue raised, including any follow-up replies.
             3. Fix each issue in the relevant file at the indicated line.
-            4. If the review state is "APPROVED" with no actionable comments, do nothing.
+            4. If the review state is "APPROVED" with no comments requiring changes, do nothing.
             5. Common fixes:
                - Remove `sorry` and fully close the lemma/theorem.
                - Fix naming to match Mathlib conventions.

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -357,7 +357,7 @@ jobs:
                your fix. For cosmetic comments (naming, docstrings, style), skip scouting and fix directly.
             2. Read each review thread conversation and understand the issue being raised, including any follow-up replies that may refine or clarify the original comment.
             3. Fix each issue in the relevant file at the indicated line.
-            4. If the review state is "APPROVED" with no actionable comments, do nothing.
+            4. If the review state is "APPROVED" with no comments requiring changes, do nothing.
             5. Common fixes:
                - Remove `sorry` and fully close the lemma/theorem with a complete proof. Do NOT leave `sorry` behind or replace it with another shortcut.
                - Fix naming to match Mathlib conventions.

--- a/.github/workflows/blueprint-lean-sync.md
+++ b/.github/workflows/blueprint-lean-sync.md
@@ -141,6 +141,8 @@ When you make updates, create a PR that includes:
 - Which `.tex` files were modified
 - Whether `lean_decls` was updated
 - The current formalization progress (from the sync checker output)
+- The theorem, lemma, or definition labels affected by the changes
+- Mathematical descriptions without AI vocabulary or software-process metaphors
 
 ## Safety and quality constraints
 

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -170,9 +170,9 @@ jobs:
             and attentive to the logical dependencies between results. When discussing
             proofs, note the key lemmas invoked, the mathematical content of what was
             shown, and any `sorry` eliminations (which represent open proof obligations
-            finally discharged). Distinguish between scaffolding (imports, refactors,
-            API lemmas) and substantive mathematical progress (new theorems, completed
-            proofs, resolved conjectures).
+            finally discharged). Distinguish between preliminary formal material
+            (imports, reorganized declarations, auxiliary lemmas) and substantive
+            mathematical progress (new theorems, completed proofs, resolved conjectures).
 
             Today's date: ${{ steps.date.outputs.today }}
             Activity window: last ${{ fromJSON(steps.activity.outputs.result).hoursBack }} hours (since ${{ fromJSON(steps.activity.outputs.result).since }})
@@ -227,7 +227,7 @@ jobs:
               of the blueprint")
 
             ## Proof Engineering & Refactors
-            - API lemmas, simp lemmas, or coercions added to smooth future work
+            - Auxiliary lemmas, simp lemmas, or coercions added for later proofs
             - Import restructuring, namespace changes, or Mathlib alignment
             - Performance improvements (proof term simplification, reducing heartbeats)
 
@@ -253,8 +253,13 @@ jobs:
             Guidelines:
             - Be precise and mathematically literate — this is for a team of
               mathematicians and formalization experts
+            - Write as mathematics first: cite theorem labels, blueprint entries,
+              paper references, and file paths when the activity concerns a specific
+              statement or proof
             - Use proper mathematical terminology (e.g., "completely positive map"
               not "channel function", "tensor product" not "combined space")
+            - Avoid AI vocabulary, software-process metaphors, and local shorthand
+              when describing mathematical work
             - Reference PR/issue numbers (e.g., #123) and file paths where relevant
             - If there was no activity, state so briefly
             - Prioritize mathematical substance over engineering details

--- a/.github/workflows/docs-blueprint-sync.md
+++ b/.github/workflows/docs-blueprint-sync.md
@@ -83,6 +83,9 @@ When you make updates, create a PR that includes:
 - A concise summary of what was out of sync
 - Which documentation/blueprint files were updated
 - Why those updates were needed based on recent code changes
+- For mathematical content, cite the relevant theorem label, blueprint entry,
+  paper reference, or Lean declaration rather than using local shorthand
+- Avoid AI vocabulary and software-process metaphors when describing mathematics
 
 If no updates are needed, call `noop` with a short explanation of what you checked.
 

--- a/.github/workflows/lean-audit.yml
+++ b/.github/workflows/lean-audit.yml
@@ -47,6 +47,12 @@ jobs:
 
             ${{ github.event.inputs.audit_type == 'mathlib-readiness' && 'Task: Review the TNLean/ directory for lemmas that could be upstreamed to Mathlib. Look for: (1) general-purpose lemmas not specific to the MPS/quantum channel domain, (2) lemmas that fill gaps in existing Mathlib files (check import paths), (3) well-documented, sorry-free results. For each candidate, note the file, lemma name, and which Mathlib module it could belong to. Output a markdown list.' || '' }}
 
+            Write the audit as mathematics first. For each formalization item, give
+            file path, line number, declaration name, mathematical statement, and
+            paper or blueprint source when available. Avoid AI vocabulary,
+            software-process metaphors, and local shorthand when describing
+            mathematics.
+
           claude_args: |
             --model claude-sonnet-4-6
             --allowedTools "Read,Glob,Grep,Bash(lake build),Bash(lake exe cache get),Bash(lake update),Bash(lake env),Bash(lean *),Bash(elan *),Bash(grep *),Bash(find *),Bash(wc *),Bash(leanblueprint *)"

--- a/.github/workflows/mathlib-scout.yml
+++ b/.github/workflows/mathlib-scout.yml
@@ -63,6 +63,10 @@ jobs:
 
             Instructions:
             1. Read the issue to understand what mathematical result needs to be formalized.
+               Check that the issue identifies a mathematical source: paper or book
+               citation, theorem/lemma label when available, and repository file path
+               plus line number when the source is in `blueprint/`, `Papers/`, or `Notes/`.
+               If this information is missing, say so in the report.
             2. Scout Mathlib thoroughly:
                a. Grep Mathlib source files (under .lake/packages/mathlib/) for related
                   definitions, theorems, and lemmas. Search by mathematical keywords,
@@ -77,6 +81,10 @@ jobs:
                this format:
 
                ## Mathlib Scouting Report
+
+               ### Mathematical source
+               - Citation, theorem/lemma label, and repository location if supplied.
+               - Short quotation or precise paraphrase of the statement to formalize.
 
                ### Relevant Mathlib definitions
                - `Namespace.Definition` — brief description (from `Mathlib/Path/File.lean`)

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,4 +1,4 @@
-name: PR Cleanup (AI-generated)
+name: PR Cleanup (bot-generated)
 
 on:
   pull_request:
@@ -41,13 +41,13 @@ jobs:
               .replace(/```/g, '\u200B`\u200B`\u200B`');
             core.setOutput('body', sanitized);
 
-      - name: Clean up AI-generated PR
+      - name: Clean up bot-generated PR
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'claude,chatgpt-codex-connector'
           prompt: |
-            You are a PR-cleanup bot. Your job is to bring AI-generated pull requests
+            You are a PR-cleanup bot. Your job is to bring bot-generated pull requests
             into compliance with this project's conventions. Do NOT touch code — only
             update PR metadata (title, body, labels) and comment on the linked issue.
 
@@ -69,6 +69,7 @@ jobs:
               - `docs/doc.md` — documentation standards
               - `docs/style.md` — code style (helps determine PR type)
               - `docs/pr-review.md` — review checklist (what reviewers expect)
+              - `docs/prose_style.md` — mathematical prose and banned AI/software language
 
             These files are checked out in the workspace. Read them before proceeding
             so your cleanup is fully aligned with project standards.
@@ -166,6 +167,14 @@ jobs:
             - If `### Motivation`, `### Description`, `### Testing` sections already
               exist and are filled in, keep their content — just ensure all three
               sections are present and the `Addresses` footer exists.
+            - For mathematical work, the body must name the paper theorem, blueprint
+              label, issue, or repository source location that fixes the scope. If
+              the source is missing from the original PR and linked issue, state
+              that the source is not yet identified rather than inventing one.
+            - State definitions, lemmas, and theorems in mathematical language
+              understandable without reading the issue thread.
+            - Avoid AI vocabulary, software-process metaphors, and local shorthand
+              when describing mathematics.
             - Use `Addresses #N` (keeps issue open but linked) by default. If the
               original body says "Closes" or "Fixes", preserve that verb instead.
             - If there's a Cursor Bugbot `> [!NOTE]` block at the end, preserve it
@@ -211,7 +220,7 @@ jobs:
             ─── STEP 7: TAG THE ISSUE ───
             If an issue was found, post a comment on it:
               ```
-              gh issue comment <N> --repo <REPO> --body "🤖 PR #<PR_NUMBER> has been opened to address this issue.
+              gh issue comment <N> --repo <REPO> --body "PR #<PR_NUMBER> has been opened to address this issue.
 
               **Branch:** \`<BRANCH>\`
               **Title:** <new title>
@@ -223,7 +232,7 @@ jobs:
             After completing all steps, post a PR comment summarizing what was changed:
               ```
               gh pr comment <NUMBER> --repo <REPO> --body "$(cat <<'CEOF'
-              🧹 **PR Cleanup Bot**
+              **PR cleanup**
 
               | Field | Before | After |
               |-------|--------|-------|

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -220,13 +220,13 @@ jobs:
             ─── STEP 7: TAG THE ISSUE ───
             If an issue was found, post a comment on it:
               ```
-              gh issue comment <N> --repo <REPO> --body "PR #<PR_NUMBER> has been opened to address this issue.
-
-              **Branch:** \`<BRANCH>\`
-              **Title:** <new title>
+              gh issue comment <N> --repo <REPO> --body "PR #<PR_NUMBER> has been opened for this mathematical task.
 
               **Mathematical statement:** <one-line statement, or "not identified in the linked issue">
               **Source:** <paper theorem, blueprint label, file:line, or "not identified">
+
+              **Branch:** \`<BRANCH>\`
+              **Title:** <new title>
 
               <one-line summary of what the PR proves or changes>"
               ```

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -225,7 +225,10 @@ jobs:
               **Branch:** \`<BRANCH>\`
               **Title:** <new title>
 
-              <one-line summary of what the PR does>"
+              **Mathematical statement:** <one-line statement, or "not identified in the linked issue">
+              **Source:** <paper theorem, blueprint label, file:line, or "not identified">
+
+              <one-line summary of what the PR proves or changes>"
               ```
 
             ─── OUTPUT ───

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -105,6 +105,12 @@ jobs:
             descriptions on the same line. When editing checkboxes, preserve
             this format exactly.
 
+            Generated tracking prose must be mathematical and self-contained.
+            When creating an issue, include a paper or blueprint source, theorem
+            label, file path and line number when available, and a short quotation
+            or precise paraphrase of the claim. Do not describe mathematical work
+            with AI vocabulary, software-process metaphors, or local shorthand.
+
             ### Label Taxonomy
 
             Use the project's established labels (see `docs/CONTRIBUTING.md` §4):
@@ -127,8 +133,8 @@ jobs:
 
             - **PR Cleanup** (`pr-cleanup.yml`): When a PR opens from a
               `claude/*` or `codex/*` branch, it already comments on the
-              linked issue ("🤖 PR #X has been opened…"). Do NOT duplicate
-              that comment for AI-generated PRs.
+              linked issue ("PR #X has been opened…"). Do NOT duplicate
+              that comment for bot-generated PRs.
             - **Claude Code Review** (`claude-code-review.yml`): Handles
               code quality. You handle tracking metadata only.
             - **Daily Standup / CI Auto-Fix**: Separate workflows. Treat
@@ -176,7 +182,7 @@ jobs:
             4. Suggest next steps (see §5 below).
             5. Comment on the tracking issue (check recent comments first
                to avoid duplicates — Key Rules §3):
-               "✅ #N (*title*) has been resolved. Updated checklist.
+               "#N (*title*) has been resolved. Updated tasklist.
                [X/Y tasks complete]
 
                **Suggested next:** <one-line recommendation from §5>"
@@ -197,7 +203,7 @@ jobs:
                to happen to re-resolve it (see §5, linked-issue variant).
             5. Comment on the tracking issue (check recent comments first
                to avoid duplicates — Key Rules §3):
-               "🔄 #N (*title*) has been reopened. Unchecked in tasklist.
+               "#N (*title*) has been reopened. Marked as open in the tasklist.
                [X/Y tasks complete]
 
                **Suggested next:** <why it was reopened + what to do>"
@@ -224,7 +230,7 @@ jobs:
                first to avoid duplicates — Key Rules §3) with a summary:
                the PR title, what it accomplished, current task progress,
                and a follow-up suggestion. Example:
-               "📦 PR #X (*title*) merged. <what was done>. [X/Y tasks
+               "PR #X (*title*) merged. <what was proved or changed>. [X/Y tasks
                complete]
 
                **Suggested next:** <one-line recommendation from §5>"
@@ -234,7 +240,7 @@ jobs:
                what the PR accomplished and what remains. Include a
                follow-up suggestion for what to tackle next on that issue.
                Example:
-               "📦 PR #X (*title*) has been merged. <what was done>.
+               "PR #X (*title*) has been merged. <what was proved or changed>.
                Remaining: <what's left>.
 
                **Suggested next step:** <concrete action for this issue>"
@@ -281,10 +287,18 @@ jobs:
               ```markdown
               ## Context
               Follow-up from #<PR> (<PR title>).
-              <Why this work is needed>
+              <Why this mathematical statement or proof obligation is needed>
 
-              ## Details
-              <What needs to be done — specific declarations, files, proofs>
+              ## Mathematical statement
+              <Precise theorem, lemma, definition, or proof obligation>
+
+              ## Source
+              - File: `<path>:<line>` when available
+              - Label or citation: <paper theorem, blueprint label, or review comment>
+              - Claim: <short quotation or precise paraphrase>
+
+              ## Formalization target
+              <Specific declarations, files, and proofs>
 
               ## References
               - PR: #<PR>
@@ -300,12 +314,12 @@ jobs:
             - If the tracking issue had the `all-resolved` label, remove
               it (new unchecked items mean it's no longer all-resolved).
             - Comment (check recent comments first — Key Rules §3):
-              "📋 Added follow-up issues from #<PR>: #<issue1>, …
+              "Added follow-up issues from #<PR>: #<issue1>, …
               [X/Y tasks complete]"
             - If multiple follow-ups were created, suggest which one to
               tackle first (see §5, tracking-issue variant).
 
-            **Be conservative.** Only create issues for genuine, actionable
+            **Be conservative.** Only create issues for genuine, concrete
             follow-ups. When in doubt, skip. False positives create noise.
 
             ---
@@ -323,7 +337,7 @@ jobs:
                workflow. All comments go on the **tracking issue**:
                - **PR opened** — only for branches that do NOT start with
                  `claude/` or `codex/` (PR Cleanup already handles those):
-                 "🔄 #<PR> opened to address #<issue>"
+                 "#<PR> opened to address #<issue>"
             4. Skip everything else silently.
 
             ---
@@ -331,7 +345,7 @@ jobs:
             ## §5 — Follow-up Suggestions
 
             When a playbook asks you to "suggest next steps", generate a
-            brief, actionable recommendation. Think beyond the immediate
+            brief, concrete recommendation. Think beyond the immediate
             next task — consider what this completion unblocks downstream,
             how it fits into the broader formalization roadmap, and whether
             preparatory work (scouting, blueprint review) would de-risk
@@ -379,7 +393,7 @@ jobs:
 
             For tasks that are mathematically complex or involve new
             Mathlib API surface, suggest preparatory scouting before
-            diving into the proof:
+            starting the proof:
 
             - **Mathlib scouting**: If the recommended issue involves
               heavy Mathlib dependencies and does not already have a

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,10 +39,14 @@ Every PR body must contain three sections:
 ```markdown
 ### Motivation
 - Why this change is needed (1--3 bullets).
+- For mathematical work, cite the paper theorem, blueprint entry, or issue
+  that fixes the scope.
 
 ### Description
 - What was changed: files added/modified, definitions introduced, lemmas proved.
 - Use bullet points.
+- State the mathematical content precisely enough for a reader who has not read
+  the issue thread.
 
 ### Testing
 - What was verified and how.
@@ -90,6 +94,13 @@ Symmetry/SPT 3/6 Definitions: twisted tensor and on-site symmetry
 
 Label with **area** + **arXiv paper** + **topic** as applicable.
 
+The body must identify the mathematical source precisely. Include the paper or
+book citation, the theorem/lemma/definition label when available, the repository
+file path and line number when the source is in `blueprint/`, `Papers/`, or
+`Notes/`, and either a short quotation or a precise paraphrase of the claim.
+Avoid AI vocabulary, software-process metaphors, and local shorthand when
+describing the mathematics.
+
 ### Multi-part work
 
 For work spanning multiple PRs, use the `Area K/N: title` pattern and create
@@ -119,6 +130,10 @@ in prose above the tasklist block. Items that are not issue references (plain te
 TODOs) cannot go inside the tasklist block; list them as ordinary checkboxes
 outside it.
 
+Generated tracking issues should create sub-issues for the mathematical tasks
+rather than using Markdown task lists as the only record of work. Each sub-issue
+should carry its own source citation and precise statement.
+
 ### Tracking issues
 
 Use the **Tracking Issue** template (`.github/ISSUE_TEMPLATE/tracking-issue.yml`).
@@ -144,7 +159,7 @@ target date; remove it when the date no longer applies.
 ### Discussions
 
 GitHub Discussions is enabled for design questions, proof strategy debates, and
-topics that don't map to a single actionable issue (e.g., "Should MPDO live
+topics that do not determine a single concrete issue (e.g., "Should MPDO live
 under MPS/?"). Use issues for concrete work items; use discussions for open-ended
 conversations.
 
@@ -310,7 +325,7 @@ The following workflows run automatically:
 | **Blueprint Lint** (`lint-blueprint.yml`) | PRs touching blueprint files | Validates LaTeX blueprint for broken labels and references |
 | **Docs & Blueprint Sync** (`docs-blueprint-sync.lock.yml`) | Daily (weekdays) + manual dispatch | Detects stale documentation and opens a sync PR if needed |
 | **Lean Audit** (`lean-audit.yml`) | On demand | Audits Lean code for style and correctness |
-| **PR Cleanup** (`pr-cleanup.yml`) | AI-generated PR opened (`claude/*` or `codex/*` branches) | Normalizes title to `type(scope): desc`, restructures body to PR template, copies labels from linked issue, adds `Addresses #N` reference, comments on the issue |
+| **PR Cleanup** (`pr-cleanup.yml`) | Bot-generated PR opened (`claude/*` or `codex/*` branches) | Normalizes title to `type(scope): desc`, restructures body to PR template, copies labels from linked issue, adds `Addresses #N` reference, comments on the issue |
 
 ### What CI checks before merge
 

--- a/docs/prose_style.md
+++ b/docs/prose_style.md
@@ -32,6 +32,12 @@ The dedicated `Blueprint Sync & Prose Review` CI workflow
 - `Papers/`, `Notes/` (LaTeX sources of the underlying papers, not project prose).
 - `Archive/` (legacy code, kept for reference).
 
+Generated GitHub issues, pull requests, audit reports, standup summaries, and
+tracking comments should also follow the spirit of this guide. They should ask
+for mathematical references, theorem labels, blueprint locations, and precise
+statements; they should not introduce AI vocabulary, software-process metaphors,
+or local shorthand when describing mathematics.
+
 ---
 
 ## 1. No Lean jargon in the leanblueprint


### PR DESCRIPTION
### Motivation
- Addresses #1002: generated TNLean issues, pull requests, tracking comments, and reports should begin in mathematical language.
- The generated text should request precise sources: paper or blueprint locations, theorem labels, file paths, line numbers, and short quotations or paraphrases.

### Description
- Strengthens the formalization, bug, tracking, and pull request templates so new GitHub text asks for mathematical statements and source citations.
- Updates contributor and prose guidance to cover generated issues, PRs, audits, standups, scouting reports, and tracking comments.
- Revises workflow prompts that create or clean up prose, including Mathlib scouting, daily standups, tracking follow-ups, PR cleanup, Lean audits, and documentation/blueprint sync.
- Expands the auto-created PR body from a placeholder into the project Motivation / Description / Testing form.

### Testing
- Parsed edited YAML files with Ruby's YAML parser.
- Checked the edited shell script body from `.github/actions/auto-create-issue-pr/action.yml` with `bash -n`.
- Ran `git diff --check`.

---
Addresses #1002

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub templates and workflow/action prose, with only a small behavior change in the PR auto-creation body formatting and metadata included.
> 
> **Overview**
> Aligns GitHub *input surfaces* (issue templates and PR template) with the repo’s math-first conventions by explicitly prompting for the affected mathematical statement, source citations (paper/theorem label/blueprint file:line), dependencies, and proof sketches.
> 
> Updates multiple automation/workflow prompts (auto-fix, Mathlib scout, Lean audit, standup, docs/blueprint sync, tracking-issue sync, PR cleanup) to require mathematically self-contained generated prose and to avoid AI/software-process jargon; also tweaks language to consistently refer to *bot-generated* output.
> 
> Enhances the `auto-create-issue-pr` composite action to generate a fuller PR body in the standard Motivation/Description/Testing format, include the source issue URL, and list changed files for the branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36a836a4ef68b11b1cf6efd2eff40acb8787d103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->