### PR TITLE
style(repository): adopt issue and PR title conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,15 @@
 name: Bug Report
 description: Report a broken proof, type error, sorry regression, or CI failure
+title: "<area>: <broken theorem, proof, or workflow>"
 labels: ["bug"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use a plain title naming the affected mathematical or workflow area, for example
+        `Wolf Ch6: fixed-point decomposition no longer builds`.
+        Keep issue titles bracket-free and do not use PR prefixes such as `fix(...)`.
+
   - type: input
     id: file
     attributes:

--- a/.github/ISSUE_TEMPLATE/formalization-task.yml
+++ b/.github/ISSUE_TEMPLATE/formalization-task.yml
@@ -1,7 +1,16 @@
 name: Formalization Task
 description: A specific theorem, definition, or lemma to formalize in Lean
+title: "<area>: <mathematical result or construction>"
 labels: ["formalization"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use a plain mathematical title, for example
+        `Wolf Ch6: peripheral spectrum of irreducible Schwarz maps`.
+        Do not begin an issue title with `formalization(...)`, `feat(...)`,
+        `fix(...)`, or `doc(...)`.
+
   - type: input
     id: statement
     attributes:

--- a/.github/ISSUE_TEMPLATE/tracking-issue.yml
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.yml
@@ -1,5 +1,6 @@
 name: Tracking Issue
 description: Create a tracking issue for a group of mathematical tasks
+title: "Tracking: <area>"
 labels: ["tracking"]
 body:
   - type: markdown
@@ -10,6 +11,7 @@ body:
         Each task should be a separate GitHub issue with its own statement and source citation.
         List sub-issues inside a native tasklist block so GitHub shows "Tracked by" on child issues.
         Do not use ordinary Markdown checklists for tracked work.
+        The title should begin with `Tracking:` and should not contain brackets.
 
   - type: input
     id: area

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,12 @@
+<!--
+PR title format: type(scope): short mathematical description
+Types: feat, fix, refactor, doc, style, ci, chore.
+Examples:
+- feat(MPS/CanonicalForm): assemble cyclic sectors at a common blocking length
+- doc(Wolf Ch6): add Lean tags for spectral theorems
+- style(MPS/CanonicalForm): rewrite equal-case prose in MPS language
+-->
+
 ### Motivation
 <!-- Why this change is needed (1--3 bullets). -->
 <!-- For mathematical work, cite the source theorem, blueprint label, or issue. -->

--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -206,12 +206,12 @@ jobs:
 
             Before creating any issue, use the mcp__github__search_issues tool to check
             whether a standup issue for today's date already exists (search for
-            "Daily Standup — ${{ steps.date.outputs.today }}" with the "standup" label).
-            If such an issue exists, DO NOT create a new one — instead, use
+            "Daily Standup -- ${{ steps.date.outputs.today }}" with the "standup" label).
+            If such an issue exists, DO NOT create a new one -- instead, use
             mcp__github__add_issue_comment to update the existing issue.
 
             If no such issue exists, use mcp__github__issue_write to create a GitHub
-            issue with the title: "Daily Standup — ${{ steps.date.outputs.today }}" and
+            issue with the title: "Daily Standup -- ${{ steps.date.outputs.today }}" and
             label it "standup". Use mcp__github__get_label to check if the label exists
             first, and use Bash(gh label create *) to create it if needed.
 

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -119,7 +119,8 @@ jobs:
                         Channel/TransferMatrix, MPS/CanonicalForm
 
             Rules:
-            - If the current title already matches `type(scope): ...`, keep it as-is.
+            - If the current title already matches `type(scope): ...` with one
+              of the allowed types above, keep it as-is.
             - Otherwise, determine the correct type and scope:
               • Run `gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json files`
                 to see changed files. Derive the scope from the common path prefix.

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -102,15 +102,16 @@ jobs:
             Save the issue title, labels, and body for later steps.
 
             ─── STEP 3: FIX TITLE ───
-            The title MUST follow conventional-commit format (see docs/CONTRIBUTING.md §1):
+            The title MUST follow the PR title format (see docs/CONTRIBUTING.md §1):
               type(scope): short description
 
             Types (from CONTRIBUTING.md):
               feat     — New definition, lemma, theorem, or module
-              fix      — Bug fix (broken proof, wrong identifier, etc.)
-              refactor — Restructuring without changing API surface
-              docs     — Documentation or blueprint changes only
-              ci       — CI/CD workflow changes
+              fix      — Broken proof, wrong identifier, or wrong statement
+              refactor — Reorganization without changing mathematical content
+              doc      — Documentation or blueprint changes only
+              style    — Naming, formatting, prose, or title cleanup
+              ci       — CI workflow changes
               chore    — Dependency bumps, linting, toolchain updates
 
             Scope: shortened module path (omit TNLean/ prefix).
@@ -124,9 +125,10 @@ jobs:
                 to see changed files. Derive the scope from the common path prefix.
               • New definitions/lemmas/theorems → feat
               • Bug fixes, broken proofs, wrong identifiers → fix
-              • Blueprint-only `.tex` changes → docs(blueprint) or fix(blueprint)
+              • Blueprint-only `.tex` changes → doc(blueprint) or fix(blueprint)
                 depending on whether it's new content or fixing mismatches
               • Restructuring → refactor
+              • Naming, formatting, prose, or title cleanup → style
               • CI changes → ci
               • Dependency bumps → chore
             - Keep the description concise (under ~60 chars after prefix).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,11 @@ Detailed conventions live in `docs/`. Read the relevant file before working in t
 
 ### Quick Reference (from the docs above)
 
-- **PR titles**: `type(scope): description` — types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`; scope is shortened module path without `TNLean/` prefix
+- **PR titles**: `type(scope): description` -- types: `feat`, `fix`, `refactor`,
+  `doc`, `style`, `ci`, `chore`; scope is shortened module path without
+  `TNLean/` prefix
+- **Issue titles**: plain mathematical titles, not `type(scope): ...`; use
+  `Tracking: <area>` for trackers and keep titles bracket-free
 - **Naming**: Definitions `camelCase`, predicates `IsPrefix`, theorems `snake_case`, files `CamelCase.lean`
 - **Proof integrity blockers**: `sorry`, `admit`, `native_decide`, `unsafeCast`, `axiom`, circular reasoning
 - **Blueprint prose**: Pure mathematics only — no Lean identifiers in text, no software jargon (see banned terms list in blueprint style guide)

--- a/audits/2026-04-29_issue1003_title_scan.md
+++ b/audits/2026-04-29_issue1003_title_scan.md
@@ -1,0 +1,108 @@
+# Issue 1003 title scan
+
+This scan records repository titles that still visibly differ from the naming
+conventions in `docs/CONTRIBUTING.md`.
+
+Commands used on 2026-04-29:
+
+```bash
+gh issue list --repo LionSR/TNLean --state open --limit 1000 --json number,title,url
+gh pr list --repo LionSR/TNLean --state open --limit 1000 --json number,title,url
+gh issue list --repo LionSR/TNLean --state closed --limit 1000 --json number,title,url
+gh pr list --repo LionSR/TNLean --state merged --limit 1000 --json number,title,url
+```
+
+## Open pull requests
+
+No open pull request failed the `type(scope): description` check among 3 open
+pull requests.
+
+## Open issues
+
+The scan found 47 candidate open issues among 103 open issues. The most visible
+candidates are:
+
+Titles still using PR-style prefixes:
+
+- #905 `formalization(MPS/ParentHamiltonian): periodic block decomposition of chainGroundSpace for toTensorFromBlocks`
+- #874 `formalization(PEPS): prove bond-dimension equality from SameState and vertex injectivity`
+- #873 `formalization(MPS/Periodic): prove m-factor cyclic contraction for blocked sector gauges`
+- #872 `formalization(MPS/Periodic): extract nondecaying sector overlap from blocked gauge equivalence`
+- #871 `formalization(MPS/Periodic): prove orthogonal cyclic-sector trace rigidity for self-overlap`
+- #870 `formalization(MPS/ParentHamiltonian): split assembled BNT ground states into block components`
+- #869 `formalization(MPS/ParentHamiltonian): add contiguous/tail restriction transport API for normal range reduction`
+- #832 `formalization(Algebra/MPDO): corrected Perron-Frobenius rank-one step for Lemma C.4 (#781 follow-up)`
+- #829 `formalization(MPS/Periodic): supply PeripheralEqualCaseZGaugeOfSameMPV and PeripheralEqualCaseRootFromZGauge for Thm. 3.8 (#787 follow-up)`
+- #828 `formalization(MPS/Periodic): multi-block non-decaying overlap witnesses for proportional-case Thm. 3.4 (#786 follow-up)`
+- #826 `formalization(MPS/MPDO): converse algebra => fusion direction for section 4.5 RFP equivalence (#612 follow-up)`
+- #825 `formalization(MPS/MPDO): extract chi-matrices and trace-power formula for blocked coefficients (#612 follow-up)`
+- #823 `formalization(MPS/MPDO): HasCommutingForm local-to-global bridge (from SAL+ZCL) (#782/#783 follow-up)`
+- #822 `formalization(MPS/MPDO): finite-length block-separation step for biCF (LinearIndependent wordEntryFamily) (#587 follow-up)`
+- #821 `formalization(Channel): minimal-Kraus construction (Channel.HasKrausRankLE E (Channel.choiRank E)) (#670 follow-up)`
+- #820 `formalization(PEPS): derive HasLocalGaugeLift from SameState via blocked-middle 3-site MPS reduction (#780 follow-up)`
+- #785 `formalization(entropy): mutual-information monotonicity and area-law wrappers`
+- #784 `formalization(entropy): remaining von Neumann entropy and SSA core`
+- #783 `formalization(rfp-mpdo): simple MPDO RFP construction from blocked tensors`
+- #780 `formalization(PEPS): local gauge existence, consistency, and main theorem assembly`
+- #779 `formalization(Wolf Ch5): Ando-Lieb and trace convexity consequences`
+- #778 `formalization(Wolf Ch5): operator Jensen package for Corollary 5.2`
+- #766 `formalization(Wolf Ch2): Lorentz normal form and SVD representation existence`
+- #664 `formalization(MPS/Periodic): discharge canonicalization hypotheses to lift Thm. 4.1 from conditional to unconditional`
+- #652 `formalization(MPS/CanonicalForm): close BNT grouping Gap section 1 -- unconditional CPSV17 Thm 1 from arbitrary SameMPV2`
+- #622 `formalization(periodic): Thm 4.1 -- non-trivial proof of p-refinement iff p-divisibility`
+- #618 `infrastructure(periodic): compression-isometry + corner-transition refactor (unblocks Tier-A bridges)`
+
+Other open issue title forms to normalize:
+
+- #670 `scout -- Kraus-rank minimization feasibility for Thm 4.1 reverse discharge (report-only)`
+- #590 `MPS/CanonicalForm/SectorIrreducibility -- close the hLift orbit-sum lift hypothesis`
+- #588 `MPS/ParentHamiltonian/UniqueGroundState -- prove chainGroundSpace_eq_mpvSubmodule_normal`
+- #460 `ParentHamiltonian 3/3 -- prove spectral gap and degenerate ground space`
+- #448 `PeriodicOverlap -- prove self-overlap limit and non-matching decay (Cases 1-2)`
+- #82 `1708.00029 4/5 Periodic FT: proportional case, equal case, and Z-gauge construction (Thms 3.4, 3.8)`
+- #81 `1708.00029 3/5 Periodic overlap dichotomy (Proposition 3.3 / Appendix A)`
+
+Daily records still using the old date separator, written here as `[em dash]`:
+
+- #791 `Daily Standup [em dash] 2026-04-22`
+- #602 `Daily Standup [em dash] 2026-04-16`
+- #601 `Daily Standup [em dash] 2026-04-15`
+- #589 `Daily Standup [em dash] 2026-04-14`
+
+## Closed issues
+
+The scan found 116 candidate closed issues among 271 closed issues. The most
+recent closed issues with visible old forms are:
+
+- #911 `formalization(MPS/ParentHamiltonian): reverse inclusion of periodic block decomposition for chainGroundSpace (Route B)`
+- #906 `formalization(MPS/CanonicalForm): Lean theorem and blueprint flip for thm:mpv_normalize`
+- #877 `formalization(MPS/CanonicalForm): assemble after-blocking sector endpoint for Gap section 1`
+- #876 `formalization(MPS/CanonicalForm): construct general BNT sector decomposition for Gap section 1`
+- #835 `formalization(MPS/ParentHamiltonian): prove ES operator positivity via cyclic averaging (#460 follow-up)`
+- #834 `formalization(Channel/FixedPoint): corner C-algebra instances and faithful-support compression for Wolf Cor. 6.6 (#27 follow-up)`
+- #833 `formalization(MPS/MPDO): extract explicit eta operators from Hayashi Markov decomposition for Lemma C.3 (#781 follow-up)`
+- #824 `formalization(MPS/CanonicalForm): general heterogeneous BNT-sector endpoint (#652 follow-up)`
+- #819 `formalization(MPS/CanonicalForm): derive SectorFixedPointAlgebraRigidity from Wolf fixed-point algebra (#599 follow-up)`
+- #787 `formalization(periodic): equal-case periodic FT with Z-gauge (Thm. 3.8)`
+- #786 `formalization(periodic): proportional-case periodic FT (Thm. 3.4)`
+- #782 `formalization(rfp-mpdo): simple MPDO RFP commuting-form / GSNNCH branch`
+- #781 `formalization(rfp-mpdo): simple MPDO RFP local structure (Lemmas C.3-C.4)`
+- #205 `[cleanup] Fix in-proof comment in Stinespring.lean (PR #162 nit)`
+
+## Merged pull requests
+
+The scan found 116 candidate merged pull requests among 542 merged pull
+requests. The most recent merged pull requests with visible old forms are:
+
+- #890 `feat: formalization(Wolf Ch2): ordered CP maps, Radon-Nikodym, and open-system representation (Thms. 2.3-2.5)`
+- #855 `feat: formalization(Channel/FixedPoint): corner C-algebra instances and faithful-support compression for Wolf Cor. 6.6 (#27 follow-up)`
+- #854 `feat: formalization(Wolf Ch2): Lorentz normal form and SVD representation existence`
+- #853 `feat: formalization(Wolf Ch2): remaining foundational representation corollaries (Props. 2.2-2.4)`
+- #827 `ci: switch low-criticality workflows from Opus to Sonnet`
+- #790 `[codex] fix(PEPS): repair gauge uniqueness statement`
+- #754 `cleanup(ParentHamiltonian): remove duplicate OpenChainRangeReduction / ExtendRight (#747)`
+- #716 `cleanup(Channel/Determinant): namespace/import hygiene (#705)`
+- #691 `Unconditionalize Thm 4.1 canonicalization hypotheses (#664)`
+- #690 `Fix Docs & Blueprint Sync workflow failure`
+- #688 `cleanup(MPS/Periodic/ZGauge): trim unused imports (#686)`
+- #681 `cleanup(MPS/MPDO): close remaining section 4.5 scaffold integrity items (#625)`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Lean style, and CI automation used in the MPSLean project.
 
 ### Title format
 
-Use **conventional-commit** style:
+Use mathlib-style conventional titles:
 
 ```
 type(scope): short description
@@ -18,19 +18,20 @@ type(scope): short description
 | Type       | When to use                                      |
 |------------|--------------------------------------------------|
 | `feat`     | New definition, lemma, theorem, or module         |
-| `fix`      | Bug fix (broken proof, wrong identifier, etc.)    |
-| `refactor` | Restructuring without changing API surface        |
-| `docs`     | Documentation or blueprint changes only           |
-| `ci`       | CI/CD workflow changes                            |
+| `fix`      | Broken proof, wrong identifier, or wrong statement |
+| `refactor` | Reorganization without changing mathematical content |
+| `doc`      | Documentation or blueprint changes only           |
+| `style`    | Naming, formatting, prose, or title cleanup       |
+| `ci`       | CI workflow changes                               |
 | `chore`    | Dependency bumps, linting, toolchain updates      |
 
 **Scope** is a shortened module path: `MPS/Symmetry`, `Channel`, `blueprint+docgen`,
 `MPS/Core`, etc. Omit the `TNLean/` prefix.
 
 Examples:
-- `feat(MPS/Symmetry): add twistedTensor as MonoidHom`
-- `fix(blueprint+docgen): resolve broken labels and malformed docstring table`
-- `refactor(MPS): move Correlations.lean from ParentHamiltonian/ to Core/`
+- `feat(MPS/CanonicalForm): assemble cyclic sectors at a common blocking length`
+- `doc(Wolf Ch6): add Lean tags for spectral theorems`
+- `style(MPS/CanonicalForm): rewrite equal-case prose in MPS language`
 
 ### Body template
 
@@ -84,12 +85,34 @@ Three issue templates are available in `.github/ISSUE_TEMPLATE/`:
 | **Bug Report** | Broken proof, type error, sorry regression, CI failure |
 | **Tracking Issue** | Umbrella issue tracking a group of sub-issues |
 
+### Title format
+
+Issue titles are plain mathematical or repository-maintenance titles, not
+PR-title prefixes. Labels carry the type, topic, paper, chapter,
+priority, and status metadata.
+
+Use these forms:
+
+| Issue kind | Title form |
+|------------|------------|
+| Overall tracker | `Tracking: <area>` |
+| Formalization task | `<area>: <mathematical result or construction>` |
+| Blueprint or documentation task | `<document area>: <mathematical documentation change>` |
+| CI or repository maintenance | `<area>: <concrete maintenance task>` |
+| Daily record | `<record type> -- <date>` |
+
+Keep issue titles bracket-free. Use `Wolf Ch6: ...`, not `[Wolf Ch6] ...`.
+Do not put `feat(...)`, `fix(...)`, `doc(...)`, or `formalization(...)` at
+the start of an issue title. Put parent issue numbers, PR numbers, audit
+filenames, and implementation notes in the body unless they are needed to
+disambiguate the title.
+
 ### Formalization issues
 
 Use a descriptive title that names the mathematical content:
 
 ```
-Symmetry/SPT 3/6 Definitions: twisted tensor and on-site symmetry
+MPS/Symmetry: twisted tensor and on-site symmetry
 ```
 
 Label with **area** + **arXiv paper** + **topic** as applicable.
@@ -103,13 +126,13 @@ describing the mathematics.
 
 ### Multi-part work
 
-For work spanning multiple PRs, use the `Area K/N: title` pattern and create
-an umbrella **tracking issue**:
+For work spanning multiple PRs, create an umbrella **tracking issue** and put
+the part numbering in the body or in sub-issue relations when it is not needed
+to distinguish the mathematical statement:
 
 ```
-RFP/MPDO 1/5 Pure-state RFP: definitions, ZCL <=> E^2=E, structural form
-RFP/MPDO 2/5 Commuting parent Hamiltonians and decorrelation theorem
-...
+RFP/MPDO: algebra structure and fusion isometries
+RFP/MPDO: commuting parent Hamiltonians and decorrelation theorem
 ```
 
 The tracking issue lists each sub-issue using a **native GitHub tasklist** block

--- a/docs/pr_review_management.md
+++ b/docs/pr_review_management.md
@@ -33,14 +33,28 @@ PRs should follow the mathlib review checklist — review for: **style**, **docu
 - Sectioning comments `/-! ### Section title -/` for structure within files
 - References should use BibTeX entries
 
-### PR title and description convention
-@codex and @claude generate inconsistent PR titles. Unify before merging:
-- **Title format**: `type(scope): description` — e.g. `feat(Wolf Ch6): add conditional expectation (Thm 6.15)`
-- **Types**: `feat` (new formalization), `fix` (bug/correctness fix), `docs` (documentation only), `style` (formatting/naming), `refactor` (restructure without changing behavior), `ci` (CI/workflow changes)
-- **Scope**: paper tag or chapter — `Wolf Ch2`, `Wolf Ch6`, `1804.04964`, `1708.00029`, `MPS/Chain`, `PEPS`, etc. No brackets.
-- **Description**: lowercase, imperative mood, concise. Reference theorem/proposition numbers where applicable.
-- **Body**: should have `### Motivation` and `### Description` sections. Reference the issue number. List files changed.
-- **Clean up bot-generated titles** before merging — codex/claude often produce verbose or inconsistent titles like `[PR #165 follow-up] BlockedChainFT style cleanups and term-mode endpoint`. Rename to e.g. `style(MPS/Chain): BlockedChainFT term-mode endpoint and naming cleanup`.
+### PR and issue title conventions
+@codex and @claude generate inconsistent titles. Unify before merging:
+- **Title format**: `type(scope): description`, for example
+  `feat(Wolf Ch6): add conditional expectation (Thm 6.15)`.
+- **Types**: `feat` (new formalization), `fix` (mathematical or proof correction),
+  `doc` (documentation only), `style` (formatting, naming, prose, or title
+  cleanup), `refactor` (restructure without changing mathematical content),
+  `ci` (CI/workflow changes), `chore` (dependencies or linting).
+- **Scope**: paper tag or chapter, such as `Wolf Ch2`, `Wolf Ch6`,
+  `1804.04964`, `1708.00029`, `MPS/Chain`, or `PEPS`. No brackets.
+- **Description**: lowercase, imperative mood, concise. Reference
+  theorem/proposition numbers where applicable.
+- **Body**: should have `### Motivation` and `### Description` sections.
+  Reference the issue number. List files changed.
+- **Clean up bot-generated titles** before merging. Codex/Claude often produce
+  verbose or inconsistent titles like `[PR #165 follow-up] BlockedChainFT style
+  cleanups and term-mode endpoint`. Rename to, for example,
+  `style(MPS/Chain): BlockedChainFT term-mode endpoint and naming cleanup`.
+- **Issue titles**: do not use PR prefixes. Use plain mathematical titles such
+  as `Wolf Ch6: fixed-point decomposition for Schwarz maps`,
+  `MPS/CanonicalForm: assemble cyclic sectors at a common blocking length`, or
+  `Tracking: Wolf Ch6 spectral properties`.
 
 ### Review checklist (docs/pr-review.md)
 - **Style**: code formatting, naming conventions (`naming.html`), PR title/description informative
@@ -143,7 +157,10 @@ Putting `@codex` or `@claude` in the body text when creating an issue does nothi
 4. **@codex cannot fetch other branches.** Sandboxed environment blocks `git fetch` (HTTP 403). Asking it to "review branch X" or "push to branch Y" will always fail.
 
 ### Why @claude fails on codex branches — confirmed root cause
-Codex auto-generates branch names from the issue title: `codex/github-mention-{ISSUE_TITLE_SLUG}-{RANDOM}`. Our issue titles use `[brackets]` like `[Wolf Ch6]` or `[1804.04964]`, so `]` flows into the branch name.
+Codex auto-generates branch names from the issue title:
+`codex/github-mention-{ISSUE_TITLE_SLUG}-{RANDOM}`. Issue titles with brackets,
+such as `[Wolf Ch6]` or `[1804.04964]`, can therefore put `]` into the branch
+name.
 
 The `anthropics/claude-code-action` **explicitly validates branch names** and rejects any containing git special characters `~^:?*[\]`. The exact error:
 ```
@@ -151,12 +168,16 @@ Action failed with error: Invalid branch name: "codex/github-mention-wolf-ch5]-s
 Branch names cannot contain control characters, spaces, or special git characters (~^:?*[\]).
 ```
 
-This means **every PR created by @codex from a bracket-titled issue → @claude will always fail**. All 30 of our open issues have brackets in their titles.
+This means **every PR created by @codex from a bracket-titled issue → @claude will always fail**.
 
-**The root cause is our issue naming convention.** All 30 open issues use `[brackets]` in titles (e.g. `[Wolf Ch6]`, `[1804.04964]`). Codex strips the `[` but keeps the `]` in the branch slug.
+**The root cause was the old issue naming convention.** Codex strips the `[` but keeps the `]` in the branch slug.
 
 **Solutions:**
-- **ADOPTED: Bracket-free issue naming convention.** Use `Wolf Ch6 —` or `1804.04964 —` instead of `[Wolf Ch6]` or `[1804.04964]`. This prevents `]` from appearing in codex branch names, making them @claude-compatible. Apply to all new issues going forward; existing issues can be renamed as needed.
+- **ADOPTED: Bracket-free issue naming convention.** Use `Wolf Ch6: ...` or
+  `1804.04964: ...` instead of `[Wolf Ch6] ...` or `[1804.04964] ...`. This
+  prevents `]` from appearing in codex branch names, making them
+  @claude-compatible. Apply to all new issues going forward; existing issues
+  can be renamed as needed.
 - Fix locally (checkout branch, make changes, push) — still needed for existing `]` branches
 - Ask @codex on the issue to create a fresh replacement PR from main (new branch, new PR)
 - @codex on the PR can still run reviews (reads the diff, doesn't need to checkout the branch)

--- a/docs/pr_review_management.md
+++ b/docs/pr_review_management.md
@@ -45,8 +45,8 @@ PRs should follow the mathlib review checklist — review for: **style**, **docu
   `1804.04964`, `1708.00029`, `MPS/Chain`, or `PEPS`. No brackets.
 - **Description**: lowercase, imperative mood, concise. Reference
   theorem/proposition numbers where applicable.
-- **Body**: should have `### Motivation` and `### Description` sections.
-  Reference the issue number. List files changed.
+- **Body**: should have `### Motivation`, `### Description`, and
+  `### Testing` sections. Reference the issue number. List files changed.
 - **Clean up bot-generated titles** before merging. Codex/Claude often produce
   verbose or inconsistent titles like `[PR #165 follow-up] BlockedChainFT style
   cleanups and term-mode endpoint`. Rename to, for example,


### PR DESCRIPTION
### Motivation
- Issue #1003 asks for one consistent naming system for TNLean issues and pull requests.
- New issues should use plain mathematical titles while pull requests keep the `type(scope): ...` convention.

### Description
- Update contribution guidance, assistant quick references, issue templates, and the pull request template.
- Align PR cleanup and daily standup workflows with the title convention.
- Add an audit note recording current issue and pull request titles that still visibly differ from the convention.

### Testing
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/formalization-task.yml .github/ISSUE_TEMPLATE/bug-report.yml .github/ISSUE_TEMPLATE/tracking-issue.yml .github/workflows/pr-cleanup.yml .github/workflows/daily-standup.yml`
- `git diff --cached --check`

---
Addresses #1003

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/template/workflow text changes only; no Lean code or build logic is modified, with minimal risk beyond naming consistency in automation.
> 
> **Overview**
> Aligns repository conventions so **PRs use** `type(scope): description` while **issues use plain, bracket-free titles** (with `Tracking: <area>` and `Daily Standup -- <date>` forms), updating `docs/CONTRIBUTING.md`, `docs/pr_review_management.md`, and `CLAUDE.md` accordingly.
> 
> Updates GitHub templates and automation to enforce the new naming: issue templates now suggest canonical title formats, the PR template adds explicit title guidance, `pr-cleanup.yml` updates allowed types (including `doc`/`style`) and its heuristics, and `daily-standup.yml` switches the standup title separator to `--`.
> 
> Adds `audits/2026-04-29_issue1003_title_scan.md` documenting current issue/PR titles that still deviate from the conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 015fd189a696662efa555072a144a88717baa6cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->