### PR TITLE
doc(canonical-form): use mathematical names

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1238,11 +1238,6 @@ noncomputable def commonReindexedBlock (F : CommonBlockedCyclicSectorFamily bloc
     (reindexPhysical (iteratedBlockIndex d (F.period k) (F.extra k))
       (blockTensor (d := d) (D := dim k) (blocks k) (F.period k * F.extra k)))
 
-@[deprecated commonReindexedBlock (since := "2026-04-29")]
-noncomputable abbrev oneShotReindexedBlock (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) : MPSTensor (blockPhysDim d F.p) (dim k) :=
-  F.commonReindexedBlock k
-
 /-- The derived flattened sector weights obtained from the original nonzero weights after
 blocking by the common length. -/
 noncomputable def commonFlatWeight (F : CommonBlockedCyclicSectorFamily blocks)
@@ -1362,11 +1357,6 @@ theorem nestedBlock_sameMPV₂_commonReindexedBlock
     (B := reindexPhysical (iteratedBlockIndex d (F.period k) (F.extra k))
       (blockTensor (d := d) (D := dim k) (blocks k) (F.period k * F.extra k)))).2 h
 
-@[deprecated nestedBlock_sameMPV₂_commonReindexedBlock (since := "2026-04-29")]
-abbrev nestedBlock_sameMPV₂_oneShotReindexedBlock
-    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :=
-  F.nestedBlock_sameMPV₂_commonReindexedBlock k
-
 /-- A relabeled nonzero-weight block is represented by its common-alphabet cyclic sectors. -/
 theorem commonReindexedBlock_sameMPV₂_commonSectorTensor
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
@@ -1380,11 +1370,6 @@ theorem commonReindexedBlock_sameMPV₂_commonSectorTensor
       ((F.nestedBlock_sameMPV₂_commonReindexedBlock k) N σ).symm
     _ = mpv (F.commonSectorTensor k) σ := by
       simpa [commonSectorTensor, commonSectorBlock] using F.nested_same k N σ
-
-@[deprecated commonReindexedBlock_sameMPV₂_commonSectorTensor (since := "2026-04-29")]
-abbrev oneShotReindexedBlock_sameMPV₂_commonSectorTensor
-    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :=
-  F.commonReindexedBlock_sameMPV₂_commonSectorTensor k
 
 /-- Weighted nonzero blocks with explicit relabelings flatten to the common-sector family. -/
 theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
@@ -1434,11 +1419,6 @@ theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ := by
           exact (mpv_toTensorFromBlocks_eq_sum (F.commonFlatWeight μ) (F.commonFlatBlocks) σ).symm
 
-@[deprecated sameMPV₂_weightedCommonReindexedBlock_commonFlat (since := "2026-04-29")]
-abbrev sameMPV₂_weightedOneShotReindexedBlock_commonFlat
-    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :=
-  F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ
-
 /-- If the canonical blocked nonzero part agrees with the explicitly reindexed
 blocks, then the weighted nonzero part agrees with the derived common-sector family.
 
@@ -1462,17 +1442,6 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
   intro N σ
   exact (hLabel N σ).trans
     (F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ)
-
-@[deprecated sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed (since := "2026-04-29")]
-abbrev sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot
-    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
-    (hLabel : SameMPV₂
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p)
-        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :=
-  F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μ hLabel
 
 end CommonBlockedCyclicSectorFamily
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1106,10 +1106,10 @@ flattened family `flatBlocks` is indexed by the finite type
 `Fin (∑ k, period k)`, using `finSigmaFinEquiv` to identify an index with an
 original nonzero-weight block and one of its cyclic sectors.
 
-The field `nested_same` records the checked MPV compatibility condition available
+The field `nested_same` gives the checked MPV compatibility condition available
 at this stage: the iterated blocked nonzero-weight block is MPV-equivalent to the corresponding
 unit-weight reblocked cyclic sectors, all at the common physical dimension.  The
-remaining work for issue #969 is the one-shot iterated-blocking identification
+remaining work for issue #969 is the single-step iterated-blocking identification
 and the weighted direct-sum flattening across the original nonzero weights. -/
 structure CommonBlockedCyclicSectorFamily {d r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k)) where
@@ -1232,11 +1232,16 @@ noncomputable def commonSectorTensor (F : CommonBlockedCyclicSectorFamily blocks
 
 /-- The common blocked tensor obtained by reindexing blocked physical words from
 iterated blocking to the ambient blocked alphabet. -/
-noncomputable def oneShotReindexedBlock (F : CommonBlockedCyclicSectorFamily blocks)
+noncomputable def commonReindexedBlock (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) : MPSTensor (blockPhysDim d F.p) (dim k) :=
   cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
     (reindexPhysical (iteratedBlockIndex d (F.period k) (F.extra k))
       (blockTensor (d := d) (D := dim k) (blocks k) (F.period k * F.extra k)))
+
+@[deprecated commonReindexedBlock (since := "2026-04-29")]
+noncomputable abbrev oneShotReindexedBlock (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : MPSTensor (blockPhysDim d F.p) (dim k) :=
+  F.commonReindexedBlock k
 
 /-- The derived flattened sector weights obtained from the original nonzero weights after
 blocking by the common length. -/
@@ -1246,7 +1251,7 @@ noncomputable def commonFlatWeight (F : CommonBlockedCyclicSectorFamily blocks)
 
 /-- Transported nonzero weights remain nonzero after common blocking.
 
-This named form records the per-block weight transport used before flattening;
+This named form gives the per-block weight transport used before flattening;
 `commonFlatWeight_ne_zero` is the corresponding statement after passing to flattened
 sector indices. -/
 theorem commonBlockWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
@@ -1342,13 +1347,13 @@ theorem commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
   simpa [commonFlatDim, y] using F.commonSectorBlock_dim_pos y.1 y.2
 
 /-- Iterated blocking of a nonzero-weight block is the relabeled common block. -/
-theorem nestedBlock_sameMPV₂_oneShotReindexedBlock
+theorem nestedBlock_sameMPV₂_commonReindexedBlock
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     SameMPV₂
       (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
         (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
           (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k)))
-      (F.oneShotReindexedBlock k) := by
+      (F.commonReindexedBlock k) := by
   have h := sameMPV₂_blockTensor_blockTensor_mul_reindex
     (d := d) (D := dim k) (A := blocks k) (m := F.period k) (n := F.extra k)
   exact (sameMPV₂_cast_physDim (F.blockPhysDim_nested_eq k)
@@ -1357,26 +1362,36 @@ theorem nestedBlock_sameMPV₂_oneShotReindexedBlock
     (B := reindexPhysical (iteratedBlockIndex d (F.period k) (F.extra k))
       (blockTensor (d := d) (D := dim k) (blocks k) (F.period k * F.extra k)))).2 h
 
+@[deprecated nestedBlock_sameMPV₂_commonReindexedBlock (since := "2026-04-29")]
+abbrev nestedBlock_sameMPV₂_oneShotReindexedBlock
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :=
+  F.nestedBlock_sameMPV₂_commonReindexedBlock k
+
 /-- A relabeled nonzero-weight block is represented by its common-alphabet cyclic sectors. -/
-theorem oneShotReindexedBlock_sameMPV₂_commonSectorTensor
+theorem commonReindexedBlock_sameMPV₂_commonSectorTensor
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
-    SameMPV₂ (F.oneShotReindexedBlock k) (F.commonSectorTensor k) := by
+    SameMPV₂ (F.commonReindexedBlock k) (F.commonSectorTensor k) := by
   intro N σ
   calc
-    mpv (F.oneShotReindexedBlock k) σ =
+    mpv (F.commonReindexedBlock k) σ =
         mpv (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
           (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
             (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k))) σ :=
-      ((F.nestedBlock_sameMPV₂_oneShotReindexedBlock k) N σ).symm
+      ((F.nestedBlock_sameMPV₂_commonReindexedBlock k) N σ).symm
     _ = mpv (F.commonSectorTensor k) σ := by
       simpa [commonSectorTensor, commonSectorBlock] using F.nested_same k N σ
 
+@[deprecated commonReindexedBlock_sameMPV₂_commonSectorTensor (since := "2026-04-29")]
+abbrev oneShotReindexedBlock_sameMPV₂_commonSectorTensor
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :=
+  F.commonReindexedBlock_sameMPV₂_commonSectorTensor k
+
 /-- Weighted nonzero blocks with explicit relabelings flatten to the common-sector family. -/
-theorem sameMPV₂_weightedOneShotReindexedBlock_commonFlat
+theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
     SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) (F.oneShotReindexedBlock))
+        (μ := fun k : Fin r => (μ k) ^ F.p) (F.commonReindexedBlock))
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) := by
   intro N σ
@@ -1384,14 +1399,14 @@ theorem sameMPV₂_weightedOneShotReindexedBlock_commonFlat
     ((μ y.1) ^ F.p) ^ N * mpv (F.commonSectorBlock y.1 y.2) σ
   calc
     mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) (F.oneShotReindexedBlock)) σ
+        (μ := fun k : Fin r => (μ k) ^ F.p) (F.commonReindexedBlock)) σ
         = ∑ k : Fin r, ((μ k) ^ F.p) ^ N •
-            mpv (F.oneShotReindexedBlock k) σ :=
+            mpv (F.commonReindexedBlock k) σ :=
           mpv_toTensorFromBlocks_eq_sum (fun k : Fin r => (μ k) ^ F.p)
-            (F.oneShotReindexedBlock) σ
+            (F.commonReindexedBlock) σ
     _ = ∑ k : Fin r, ((μ k) ^ F.p) ^ N • mpv (F.commonSectorTensor k) σ := by
           refine Finset.sum_congr rfl fun k _ => ?_
-          rw [F.oneShotReindexedBlock_sameMPV₂_commonSectorTensor k N σ]
+          rw [F.commonReindexedBlock_sameMPV₂_commonSectorTensor k N σ]
     _ = ∑ k : Fin r, ∑ s : Fin (F.period k),
           ((μ k) ^ F.p) ^ N • mpv (F.commonSectorBlock k s) σ := by
           refine Finset.sum_congr rfl fun k _ => ?_
@@ -1419,20 +1434,25 @@ theorem sameMPV₂_weightedOneShotReindexedBlock_commonFlat
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ := by
           exact (mpv_toTensorFromBlocks_eq_sum (F.commonFlatWeight μ) (F.commonFlatBlocks) σ).symm
 
+@[deprecated sameMPV₂_weightedCommonReindexedBlock_commonFlat (since := "2026-04-29")]
+abbrev sameMPV₂_weightedOneShotReindexedBlock_commonFlat
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :=
+  F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ
+
 /-- If the canonical blocked nonzero part agrees with the explicitly reindexed
 blocks, then the weighted nonzero part agrees with the derived common-sector family.
 
 The hypothesis isolates the remaining equality under the word reindexing from
 `iteratedBlockIndex`; the canonical blocked tensor uses the ambient blocked alphabet
 directly. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot
+theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hLabel : SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := fun k : Fin r => (μ k) ^ F.p)
         (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
       (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) F.oneShotReindexedBlock)) :
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
     SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := fun k : Fin r => (μ k) ^ F.p)
@@ -1441,7 +1461,18 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot
         (μ := F.commonFlatWeight μ) F.commonFlatBlocks) := by
   intro N σ
   exact (hLabel N σ).trans
-    (F.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μ N σ)
+    (F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ)
+
+@[deprecated sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed (since := "2026-04-29")]
+abbrev sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
+    (hLabel : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :=
+  F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μ hLabel
 
 end CommonBlockedCyclicSectorFamily
 

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -595,7 +595,7 @@ theorem fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_ze
 
 This companion to
 `fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail`
-uses the common cyclic-sector family to express the one-step reindexed data available
+uses the common cyclic-sector family to express the reindexed block data available
 after the iterated-blocking comparison theorem.  For each side, the cyclic
 sectors are expressed as derived common-alphabet blocks `family.commonFlatBlocks`,
 with weights `μ^family.p` and
@@ -841,10 +841,10 @@ theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector
   · intro x
     exact familyB.commonFlatDim_pos x
 
-/-- If the canonical blocked nonzero part agrees with the relabeled one-step
-blocks, the zero-tail equation can be rewritten using the derived common-sector
-family.  This is the one-sided theorem that puts the relabeled data above in the
-form used by the span and BNT comparison theorems. -/
+/-- If the canonical blocked nonzero part agrees with the common reindexed blocks,
+the zero-tail equation can be rewritten using the derived common-sector family.
+This is the one-sided theorem that puts the reindexed data above in the form used
+by the span and BNT comparison theorems. -/
 theorem zeroTail_commonFlat_of_reindexed_labelCompat
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -51,7 +51,7 @@ of TP sectors, where each sector is left-canonical and the direct sum is
 `SameMPV₂`-equivalent to the blocked tensor.
 
 The full proof chain is:
-1. Zero-block separation (`exists_irreducible_blockDecomp_liveBlocks`)
+1. Zero-block separation (`exists_irreducible_blockDecomp_nonzeroBlocks`)
 2. TP gauge (`exists_tp_gauge_from_arbitrary_with_zeroTail`)
 3. Common blocking to primitive (`exists_common_blocking_all_primitive_of_TP_irr`)
 4. Cyclic sector decomposition per block (`exists_cyclic_sector_decomp_after_blocking`)
@@ -82,13 +82,13 @@ uses a two-basis span comparison for the constructed sector bases, while
 transports a finite-length span equality for the original nonzero-weight block families to
 those bases. The zero-tail-aware theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail`
-separately records the `N = 0` bookkeeping when full overlap-span hypotheses are
+separately gives the length-zero identity when full overlap-span hypotheses are
 available.
 
 The remaining Gap §1 content is to flatten the per-block cyclic-sector data to a
 single common physical blocking level, derive one-site injectivity (or a blocked
 replacement) and the finite-length span comparison for the flattened family, and
-finish the zero-tail bookkeeping from the structural after-blocking reduction
+finish the zero-tail length-zero identity from the structural after-blocking reduction
 itself.
 -/
 
@@ -182,7 +182,7 @@ theorem bilateral_commonPeriod_blocking_tp_primitive_normal
 
 /-- **Fundamental Theorem of MPS (1606.00608, after blocking): current structural shell.**
 
-For any two MPS tensors `A, B` with `SameMPV₂ A B`, this theorem records the
+For any two MPS tensors `A, B` with `SameMPV₂ A B`, this theorem gives the
 currently formalized one-sided reduction data on both sides: after blocking,
 each tensor admits a decomposition into TP blocks with primitive transfer maps,
 nonzero weights, and positive bond dimensions.
@@ -192,7 +192,7 @@ families. The remaining missing content is the sector-level comparison described
 in the file documentation below: a general BNT sector construction for each side,
 followed by a two-basis equal-case comparison theorem for those sector decompositions.
 
-This theorem therefore records the structural shell currently available on the
+This theorem therefore gives the structural statement currently available on the
 way to arXiv:1606.00608, Theorem 1. -/
 theorem fundamentalTheorem_after_blocking_1606_structural
     {d D₁ D₂ : ℕ}
@@ -257,17 +257,17 @@ theorem fundamentalTheorem_after_blocking_1606_structural_with_blockedSameMPV₂
   · exact sameMPV₂_blockTensor A B hSame pA
   · exact sameMPV₂_blockTensor A B hSame pB
 
-/-- **Zero-tail bookkeeping for nonzero block tensors.**
+/-- **Zero-tail identity for nonzero block tensors.**
 
 Suppose two tensors with the same MPV family are each written as a zero-tail
 contribution plus a weighted nonzero block tensor. Then the nonzero parts agree at every
-positive length, while the length-zero equation records exactly the difference
+positive length, while the length-zero equation gives exactly the difference
 between the zero-tail dimensions and the nonzero block bond dimensions.
 
-This is the local bookkeeping needed before a full `SameMPV₂` comparison of the
+This is the local length-zero identity needed before a full `SameMPV₂` comparison of the
 nonzero block tensors can be recovered: the only missing datum is equality of the
 two zero-tail dimensions (or an equivalent replacement for the `N = 0` case). -/
-theorem liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+theorem nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
     {d D₁ D₂ rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -309,13 +309,32 @@ theorem liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
       _ = mpv B σ := hSame 0 σ
       _ = (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ := hBσ
 
-/-- **Reblocked nonzero-block equality with zero-tail bookkeeping.**
+@[deprecated nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
+  (since := "2026-04-29")]
+abbrev liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+    {d D₁ D₂ rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (zeroTailA zeroTailB : ℕ)
+    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
+    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
+    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) :=
+  nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
+    A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hA hB
+
+/-- **Reblocked nonzero-block equality with a zero-tail identity.**
 
 If two tensors have the same MPVs and each is expressed as a zero tail plus a
 weighted nonzero block tensor, then every positive common reblocking transports the
 nonzero weights to powers, preserves positive-length equality of the nonzero parts,
-and leaves the zero-tail contribution as the sole length-zero bookkeeping term. -/
-theorem liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+and leaves the zero-tail contribution as the sole length-zero term. -/
+theorem nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
     {d D₁ D₂ rA rB p : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -358,7 +377,7 @@ theorem liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sam
       (blockTensor (d := d) (D := D₂) B p) :=
     sameMPV₂_blockTensor A B hSame p
   have hBook :=
-    liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+    nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
       (d := blockPhysDim d p)
       (blockTensor (d := d) (D := D₁) A p)
       (blockTensor (d := d) (D := D₂) B p)
@@ -370,13 +389,33 @@ theorem liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sam
       hAblock hBblock
   exact ⟨fun N hN σ => hBook.1 hN σ, hBook.2⟩
 
+@[deprecated nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
+  (since := "2026-04-29")]
+abbrev liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+    {d D₁ D₂ rA rB p : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (zeroTailA zeroTailB : ℕ)
+    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
+    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hp : 0 < p)
+    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
+    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) :=
+  nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
+    A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hp hA hB
+
 /-- **Recover full nonzero-block `SameMPV₂` once zero tails agree.**
 
-This combines the positive-length bookkeeping theorem with the single additional
+This combines the positive-length theorem with the single additional
 length-zero datum needed to remove the zero tails. It does not assert that the
 zero-tail dimensions agree automatically; that remains a separate paper-level
-bookkeeping step for the unconditional after-blocking sector comparison. -/
-theorem liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
+length-zero condition for the unconditional after-blocking sector comparison. -/
+theorem nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
     {d D₁ D₂ rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -394,7 +433,7 @@ theorem liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
     SameMPV₂ (toTensorFromBlocks (d := d) (μ := μA) blocksA)
       (toTensorFromBlocks (d := d) (μ := μB) blocksB) := by
   have hBook :=
-    liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+    nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
       A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hA hB
   intro N σ
   by_cases hN : N = 0
@@ -408,14 +447,33 @@ theorem liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
     exact add_left_cancel h0'
   · exact hBook.1 (Nat.pos_of_ne_zero hN) σ
 
+@[deprecated nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq (since := "2026-04-29")]
+abbrev liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
+    {d D₁ D₂ rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (zeroTailA zeroTailB : ℕ)
+    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
+    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
+    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ)
+    (hZeroTail : zeroTailA = zeroTailB) :=
+  nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
+    A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hA hB hZeroTail
+
 /-- **Structural after-blocking theorem retaining zero-tail MPV equations.**
 
 This strengthens the structural shell by exposing the exact zero-tail identities
 returned by `exists_tp_primitive_blockDecomp_after_blocking`, in addition to the
 blocked `SameMPV₂` relations. The nonzero-weight blocks are trace-preserving, have
 primitive transfer maps, positive bond dimensions, and nonzero weights; the
-zero-tail equations record precisely why these nonzero parts are only immediately
-identified at positive lengths unless the `N = 0` zero-tail bookkeeping is also
+zero-tail equations explain precisely why these nonzero parts are only immediately
+identified at positive lengths unless the `N = 0` zero-tail identity is also
 resolved. -/
 theorem fundamentalTheorem_after_blocking_1606_structural_with_zeroTail
     {d D₁ D₂ : ℕ}
@@ -457,14 +515,14 @@ theorem fundamentalTheorem_after_blocking_1606_structural_with_zeroTail
   · exact sameMPV₂_blockTensor A B hSame pA
   · exact sameMPV₂_blockTensor A B hSame pB
 
-/-- **Per-block cyclic-sector decomposition with zero-tail bookkeeping.**
+/-- **Per-block cyclic-sector decomposition with a zero-tail identity.**
 
 This is the faithful predecessor to the common nonzero-sector statement. From
 `SameMPV₂ A B`, it first uses the invariant-subspace/zero-tail split and TP gauge
 to obtain irreducible nonzero-weight blocks on both sides. It then removes the period of
 each block separately, producing primitive irreducible cyclic sectors for
 every nonzero-weight block. The nonzero parts agree at positive lengths, and the length-zero
-case is recorded as the explicit zero-tail bookkeeping identity.
+case is given as the explicit zero-tail identity.
 
 The theorem intentionally keeps the per-block period-removal lengths inside
 `HasPrimitiveIrreducibleCyclicSectors`. It does not conflate those lengths with a
@@ -508,7 +566,7 @@ theorem fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTai
       hIrrB, hTPB, hμB, hDimB, hMPVB⟩ :=
     exists_tp_gauge_from_arbitrary_with_zeroTail (d := d) (D := D₂) B
   have hBook :=
-    liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+    nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
       A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hMPVA hMPVB
   refine ⟨zeroTailA, rA, dimA, μA, blocksA,
     zeroTailB, rB, dimB, μB, blocksB,
@@ -525,7 +583,7 @@ theorem fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTai
     exact hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor
       (blocksB k) (hTPB k) (hIrrB k)
 
-/-- **Common-blocking predecessor for nonzero cyclic sectors with zero-tail bookkeeping.**
+/-- **Common-blocking predecessor for nonzero cyclic sectors with a zero-tail identity.**
 
 This theorem combines the zero-tail/TP-gauge reduction for nonzero-weight blocks with the common
 reblocking constructor for per-block cyclic sectors.  The theorem asserts the
@@ -534,10 +592,10 @@ finite flattened sector family at the corresponding common blocked physical
 dimension.  The flattened sectors are trace-preserving, have primitive transfer
 maps, are tensor-irreducible, have positive bond dimensions, and carry nonzero
 unit weights.  The statement keeps the checked zero-tail equations,
-positive-length equality of the nonzero parts, and length-zero bookkeeping at the unblocked
+positive-length equality of the nonzero parts, and the length-zero identity at the unblocked
 nonzero-block level.  The companion theorem
 `fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_zeroTail`
-adds the one-shot, explicitly relabeled cyclic-sector flattening available after
+adds the explicitly relabeled cyclic-sector flattening available after
 the iterated-blocking comparison theorem. -/
 theorem fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail
     {d D₁ D₂ : ℕ}
@@ -591,7 +649,7 @@ theorem fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_ze
   · intro x
     exact familyB.flatWeight_ne_zero x
 
-/-- **Relabeled one-shot common-sector data with zero-tail reblocking.**
+/-- **Relabeled common-sector data with zero-tail reblocking.**
 
 This companion to
 `fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail`
@@ -599,7 +657,7 @@ uses the common cyclic-sector family to express the one-step reindexed data avai
 after the iterated-blocking comparison theorem.  For each side, the cyclic
 sectors are expressed as derived common-alphabet blocks `family.commonFlatBlocks`,
 with weights `μ^family.p` and
-nonzero transported sector weights.  The theorem also records the zero-tail
+nonzero transported sector weights.  The theorem also gives the zero-tail
 identities after the corresponding common reblocking.
 
 The statement is deliberately explicit about the reindexing of blocked physical
@@ -630,12 +688,12 @@ theorem fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_
               (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) familyB.p)) σ) ∧
       SameMPV₂
         (toTensorFromBlocks (d := blockPhysDim d familyA.p)
-          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.oneShotReindexedBlock)
+          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.commonReindexedBlock)
         (toTensorFromBlocks (d := blockPhysDim d familyA.p)
           (μ := familyA.commonFlatWeight μA) familyA.commonFlatBlocks) ∧
       SameMPV₂
         (toTensorFromBlocks (d := blockPhysDim d familyB.p)
-          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.oneShotReindexedBlock)
+          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.commonReindexedBlock)
         (toTensorFromBlocks (d := blockPhysDim d familyB.p)
           (μ := familyB.commonFlatWeight μB) familyB.commonFlatBlocks) ∧
       (∀ x, familyA.commonFlatWeight μA x ≠ 0) ∧
@@ -668,8 +726,8 @@ theorem fundamentalTheorem_after_blocking_1606_reindexed_commonSector_live_with_
   · exact zeroTail_toTensorFromBlocks_blockPower
       (d := d) (D := D₂) (r := rB) (z := zeroTailB) (p := familyB.p) (dim := dimB)
       B μB blocksB familyB.p_pos hMPVB
-  · exact familyA.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μA
-  · exact familyB.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μB
+  · exact familyA.sameMPV₂_weightedCommonReindexedBlock_commonFlat μA
+  · exact familyB.sameMPV₂_weightedCommonReindexedBlock_commonFlat μB
   · intro x
     exact familyA.commonFlatWeight_ne_zero μA hμA x
   · intro x
@@ -698,8 +756,8 @@ set_option maxHeartbeats 800000 in
 /-- **Two-sided common-length relabeled cyclic-sector theorem.**
 
 Starting from `SameMPV₂ A B`, this theorem chooses one positive physical blocking
-length for both sides.  At that common length it records the exact zero-tail
-bookkeeping for the canonically blocked nonzero parts, the positive-length equality
+length for both sides.  At that common length it gives the exact zero-tail
+identity for the canonically blocked nonzero parts, the positive-length equality
 of those nonzero parts, and the relabeled cyclic-sector families produced by
 `CommonBlockedCyclicSectorFamily` on both sides.
 
@@ -707,7 +765,7 @@ The last two `SameMPV₂` conclusions are deliberately stated for the relabeled
 blocked sector blocks.  They isolate the remaining equality under the chosen word
 reindexing needed to replace the canonical blocked nonzero blocks in the zero-tail
 equations by the derived primitive irreducible common-sector blocks. -/
-theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint
+theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B) :
@@ -748,12 +806,12 @@ theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoin
           (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ) ∧
       SameMPV₂
         (toTensorFromBlocks (d := blockPhysDim d familyA.p)
-          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.oneShotReindexedBlock)
+          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.commonReindexedBlock)
         (toTensorFromBlocks (d := blockPhysDim d familyA.p)
           (μ := familyA.commonFlatWeight μA) familyA.commonFlatBlocks) ∧
       SameMPV₂
         (toTensorFromBlocks (d := blockPhysDim d familyB.p)
-          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.oneShotReindexedBlock)
+          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.commonReindexedBlock)
         (toTensorFromBlocks (d := blockPhysDim d familyB.p)
           (μ := familyB.commonFlatWeight μB) familyB.commonFlatBlocks) ∧
       (∀ x, familyA.commonFlatWeight μA x ≠ 0) ∧
@@ -812,14 +870,14 @@ theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoin
     (d := d) (D := D₂) (r := rB) (z := zeroTailB) (p := p) (dim := dimB)
     B μB blocksB hp hMPVB
   have hBook :=
-    liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
+    nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
       A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hp hMPVA hMPVB
   refine ⟨p, hp, zeroTailA, rA, dimA, μA, blocksA,
     zeroTailB, rB, dimB, μB, blocksB, familyA, familyB,
     hFamilyA, hFamilyB, hZA, hZB, hBook.1, hBook.2, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
     ?_, ?_, ?_, ?_⟩
-  · exact familyA.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μA
-  · exact familyB.sameMPV₂_weightedOneShotReindexedBlock_commonFlat μB
+  · exact familyA.sameMPV₂_weightedCommonReindexedBlock_commonFlat μA
+  · exact familyB.sameMPV₂_weightedCommonReindexedBlock_commonFlat μB
   · intro x
     exact familyA.commonFlatWeight_ne_zero μA hμA x
   · intro x
@@ -841,11 +899,19 @@ theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoin
   · intro x
     exact familyB.commonFlatDim_pos x
 
+@[deprecated fundamentalTheorem_after_blocking_1606_commonLength_commonSector
+  (since := "2026-04-29")]
+abbrev fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :=
+  fundamentalTheorem_after_blocking_1606_commonLength_commonSector A B hSame
+
 /-- If the canonical blocked nonzero part agrees with the relabeled one-step
 blocks, the zero-tail equation can be rewritten using the derived common-sector
 family.  This is the one-sided theorem that puts the relabeled data above in the
 form used by the span and BNT comparison theorems. -/
-theorem zeroTail_commonFlat_of_oneShot_labelCompat
+theorem zeroTail_commonFlat_of_reindexed_labelCompat
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -858,7 +924,7 @@ theorem zeroTail_commonFlat_of_oneShot_labelCompat
         (μ := fun k : Fin r => (μ k) ^ F.p)
         (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
       (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) F.oneShotReindexedBlock)) :
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
     ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
       mpv (blockTensor (d := d) (D := D) A F.p) σ =
         mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
@@ -868,7 +934,7 @@ theorem zeroTail_commonFlat_of_oneShot_labelCompat
   have hCanon := zeroTail_toTensorFromBlocks_blockPower
     (d := d) (D := D) (r := r) (z := z) (p := F.p) (dim := dim)
     A μ blocks F.p_pos hMPV
-  have hFlat := F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot μ hLabel
+  have hFlat := F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μ hLabel
   calc
     mpv (blockTensor (d := d) (D := D) A F.p) σ =
         mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
@@ -879,6 +945,23 @@ theorem zeroTail_commonFlat_of_oneShot_labelCompat
           mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
             (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
           rw [hFlat N σ]
+
+@[deprecated zeroTail_commonFlat_of_reindexed_labelCompat (since := "2026-04-29")]
+abbrev zeroTail_commonFlat_of_oneShot_labelCompat
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hLabel : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :=
+  zeroTail_commonFlat_of_reindexed_labelCompat A μ blocks F hMPV hLabel
 
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 
@@ -1416,7 +1499,7 @@ theorem fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_commonPha
 If `A` and `B` have the same MPVs, and each is expressed as a zero tail plus a nonzero part,
 then equality of the zero-tail dimensions gives full `SameMPV₂` equality of the nonzero parts.
 For positive lengths the zero tails vanish; at length zero this is exactly the missing
-bookkeeping condition. -/
+zero-tail condition. -/
 theorem sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
     {d D₁ D₂ L₁ L₂ z₁ z₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -1461,7 +1544,7 @@ theorem sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
       exact hsum
     simpa [zero_add] using hsum'
 
-/-- **Common nonzero-block sector comparison with explicit zero-tail bookkeeping.**
+/-- **Common nonzero-block sector comparison with an explicit zero-tail identity.**
 
 This is the zero-tail-aware variant of
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan`.
@@ -1588,7 +1671,7 @@ hypotheses through `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching`
 
 The theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_injectiveSpan`
-records a nonzero-part overlap-span reduction from span equality for the
+gives a nonzero-part overlap-span reduction from span equality for the
 constructed sector bases. The theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_blockSpan`
 strengthens this in the phase-class representative setting: equality of the
@@ -1596,7 +1679,7 @@ finite-length spans of the original nonzero-weight block families is transported
 chosen sector bases and the sector-weight conclusion follows from the original
 `SameMPV₂ A B`. The theorem
 `fundamentalTheorem_after_blocking_1606_sector_of_common_blocks_overlapSpan_zeroTail`
-records the corresponding zero-tail bookkeeping route when full overlap-span data
+gives the corresponding zero-tail route when full overlap-span data
 are supplied.
 
 The remaining formal work for the completely unconditional
@@ -1605,7 +1688,7 @@ structural reduction itself:
 
 1. a common nonzero-block decomposition with primitive **and irreducible** blocks at
    the same physical blocking level;
-2. the `N = 0` bookkeeping for the zero-tail contribution;
+2. the `N = 0` identity for the zero-tail contribution;
 3. one-site injectivity of the nonzero-weight blocks, or a blocked replacement of the
    rigidity hypothesis; and
 4. equality of the finite-length MPV spans for the original nonzero-weight block families

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -309,25 +309,6 @@ theorem nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
       _ = mpv B σ := hSame 0 σ
       _ = (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ := hBσ
 
-@[deprecated nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
-  (since := "2026-04-29")]
-abbrev liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
-    {d D₁ D₂ rA rB : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B)
-    (zeroTailA zeroTailB : ℕ)
-    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
-    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
-    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
-    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) :=
-  nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
-    A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hA hB
-
 /-- **Reblocked nonzero-block equality with a zero-tail identity.**
 
 If two tensors have the same MPVs and each is expressed as a zero tail plus a
@@ -389,26 +370,6 @@ theorem nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sam
       hAblock hBblock
   exact ⟨fun N hN σ => hBook.1 hN σ, hBook.2⟩
 
-@[deprecated nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
-  (since := "2026-04-29")]
-abbrev liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂
-    {d D₁ D₂ rA rB p : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B)
-    (zeroTailA zeroTailB : ℕ)
-    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
-    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
-    (hp : 0 < p)
-    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
-    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) :=
-  nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
-    A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hp hA hB
-
 /-- **Recover full nonzero-block `SameMPV₂` once zero tails agree.**
 
 This combines the positive-length theorem with the single additional
@@ -446,25 +407,6 @@ theorem nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
       simpa [hZeroTail] using h0
     exact add_left_cancel h0'
   · exact hBook.1 (Nat.pos_of_ne_zero hN) σ
-
-@[deprecated nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq (since := "2026-04-29")]
-abbrev liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
-    {d D₁ D₂ rA rB : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B)
-    (zeroTailA zeroTailB : ℕ)
-    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
-    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
-    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
-    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ)
-    (hZeroTail : zeroTailA = zeroTailB) :=
-  nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
-    A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hA hB hZeroTail
 
 /-- **Structural after-blocking theorem retaining zero-tail MPV equations.**
 
@@ -899,14 +841,6 @@ theorem fundamentalTheorem_after_blocking_1606_commonLength_commonSector
   · intro x
     exact familyB.commonFlatDim_pos x
 
-@[deprecated fundamentalTheorem_after_blocking_1606_commonLength_commonSector
-  (since := "2026-04-29")]
-abbrev fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint
-    {d D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :=
-  fundamentalTheorem_after_blocking_1606_commonLength_commonSector A B hSame
-
 /-- If the canonical blocked nonzero part agrees with the relabeled one-step
 blocks, the zero-tail equation can be rewritten using the derived common-sector
 family.  This is the one-sided theorem that puts the relabeled data above in the
@@ -945,23 +879,6 @@ theorem zeroTail_commonFlat_of_reindexed_labelCompat
           mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
             (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
           rw [hFlat N σ]
-
-@[deprecated zeroTail_commonFlat_of_reindexed_labelCompat (since := "2026-04-29")]
-abbrev zeroTail_commonFlat_of_oneShot_labelCompat
-    {d D r z : ℕ} {dim : Fin r → ℕ}
-    (A : MPSTensor d D) (μ : Fin r → ℂ)
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (F : CommonBlockedCyclicSectorFamily blocks)
-    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
-    (hLabel : SameMPV₂
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p)
-        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :=
-  zeroTail_commonFlat_of_reindexed_labelCompat A μ blocks F hMPV hLabel
 
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -545,8 +545,4 @@ theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
     -- Chain everything together.
     rw [hA, hSplit, hLiveSum, hZeroSum, hZeroTail, hLive, add_comm]
 
-@[deprecated exists_irreducible_blockDecomp_nonzeroBlocks (since := "2026-04-29")]
-abbrev exists_irreducible_blockDecomp_liveBlocks (A : MPSTensor d D) :=
-  exists_irreducible_blockDecomp_nonzeroBlocks A
-
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -421,8 +421,8 @@ private theorem mpv_eq_dim_at_zero (A : MPSTensor d' D') (σ : Fin 0 → Fin d')
 
 /-- **Zero-block separation (1606.00608 §2.3).**
 
-Every MPS tensor `A : MPSTensor d D` admits an irreducible block decomposition that faithfully
-partitioned into:
+Every MPS tensor `A : MPSTensor d D` admits an irreducible block decomposition that is
+faithfully partitioned into:
 
 * a **zero tail** of dimension `zeroTailDim` (accumulating all-zero irreducible blocks), and
 * a family of **nonzero blocks** `blocks k : MPSTensor d (dim k)` for `k : Fin r`, each with at
@@ -450,38 +450,41 @@ theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
   -- Step 1: Obtain the irreducible block decomposition.
   obtain ⟨r₀, dim₀, blocks₀, hIrr₀, hSame₀⟩ :=
     exists_irreducible_blockDecomp (d := d) (D := D) A
-  -- Step 2: Classify blocks as "live" or "zero".
+  -- Step 2: Classify blocks as nonzero or zero.
   -- Use `set` to avoid `let ... in` scoping issues with big-operator notation.
-  set isLive : Fin r₀ → Prop := fun k => ∃ i, blocks₀ k i ≠ 0 with isLive_def
-  set liveSet : Finset (Fin r₀) := Finset.univ.filter (fun k => isLive k) with liveSet_def
-  set zeroSet : Finset (Fin r₀) := Finset.univ.filter (fun k => ¬ isLive k) with zeroSet_def
+  set isNonzero : Fin r₀ → Prop := fun k => ∃ i, blocks₀ k i ≠ 0 with isNonzero_def
+  set nonzeroSet : Finset (Fin r₀) := Finset.univ.filter (fun k => isNonzero k)
+    with nonzeroSet_def
+  set zeroSet : Finset (Fin r₀) := Finset.univ.filter (fun k => ¬ isNonzero k)
+    with zeroSet_def
   -- The zero tail dimension is the sum of bond dimensions of zero blocks.
   set zeroTailDim : ℕ := zeroSet.sum dim₀ with zeroTailDim_def
-  -- Reindex nonzero blocks via a bijection with `Fin liveSet.card`.
-  set liveEquiv : liveSet ≃ Fin liveSet.card := liveSet.equivFin with liveEquiv_def
-  -- Define the new live block family.
-  set r := liveSet.card with r_def
-  set dim : Fin r → ℕ := fun j => dim₀ (liveEquiv.symm j).1 with dim_def
+  -- Reindex nonzero blocks via a bijection with `Fin nonzeroSet.card`.
+  set nonzeroEquiv : nonzeroSet ≃ Fin nonzeroSet.card := nonzeroSet.equivFin
+    with nonzeroEquiv_def
+  -- Define the new nonzero block family.
+  set r := nonzeroSet.card with r_def
+  set dim : Fin r → ℕ := fun j => dim₀ (nonzeroEquiv.symm j).1 with dim_def
   set newBlocks : (k : Fin r) → MPSTensor d (dim k) :=
-    fun j => blocks₀ (liveEquiv.symm j).1 with newBlocks_def
+    fun j => blocks₀ (nonzeroEquiv.symm j).1 with newBlocks_def
   -- Step 3: Prove all properties.
   refine ⟨zeroTailDim, r, dim, newBlocks, ?_, ?_, ?_, ?_⟩
   -- (a) Irreducibility of nonzero blocks.
   · intro k
-    exact hIrr₀ (liveEquiv.symm k).1
-  -- (b) Each live block has a nonzero Kraus operator.
+    exact hIrr₀ (nonzeroEquiv.symm k).1
+  -- (b) Each nonzero block has a nonzero Kraus operator.
   · intro k
-    have hMem := (liveEquiv.symm k).2
-    -- `(liveEquiv.symm k).1 ∈ liveSet` means `isLive (liveEquiv.symm k).1`.
-    have hLive : isLive (liveEquiv.symm k).1 :=
+    have hMem := (nonzeroEquiv.symm k).2
+    -- Membership in `nonzeroSet` means `isNonzero`.
+    have hNonzero : isNonzero (nonzeroEquiv.symm k).1 :=
       (Finset.mem_filter.mp hMem).2
-    exact hLive
-  -- (c) Each live block has positive bond dimension.
+    exact hNonzero
+  -- (c) Each nonzero block has positive bond dimension.
   · intro k
-    have hMem := (liveEquiv.symm k).2
-    have hLive : isLive (liveEquiv.symm k).1 :=
+    have hMem := (nonzeroEquiv.symm k).2
+    have hNonzero : isNonzero (nonzeroEquiv.symm k).1 :=
       (Finset.mem_filter.mp hMem).2
-    rcases hLive with ⟨i, hi⟩
+    rcases hNonzero with ⟨i, hi⟩
     by_contra h
     push Not at h
     have hd0 : dim k = 0 := Nat.le_zero.mp h
@@ -495,28 +498,29 @@ theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
       have h := hSame₀ N σ
       rw [h, mpv_toTensorFromBlocks_eq_sum]
       simp only [one_pow, one_smul]
-    -- Expand the live-block toTensorFromBlocks.
-    have hLive : mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ =
+    -- Expand the nonzero-block toTensorFromBlocks.
+    have hNonzero : mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ =
         ∑ j : Fin r, mpv (newBlocks j) σ := by
       rw [mpv_toTensorFromBlocks_eq_sum]
       simp only [one_pow, one_smul]
-    -- Split the original sum into live and zero parts.
-    have hDisj : Disjoint liveSet zeroSet := by
-      simp only [liveSet_def, zeroSet_def]
+    -- Split the original sum into nonzero and zero parts.
+    have hDisj : Disjoint nonzeroSet zeroSet := by
+      simp only [nonzeroSet_def, zeroSet_def]
       exact Finset.disjoint_filter_filter_not _ _ _
-    have hUnion : liveSet ∪ zeroSet = Finset.univ := by
-      simp only [liveSet_def, zeroSet_def]
+    have hUnion : nonzeroSet ∪ zeroSet = Finset.univ := by
+      simp only [nonzeroSet_def, zeroSet_def]
       ext k
       simp [Finset.mem_filter, Finset.mem_union, em]
     have hSplit : ∑ k : Fin r₀, mpv (blocks₀ k) σ =
-        liveSet.sum (fun k => mpv (blocks₀ k) σ) +
+        nonzeroSet.sum (fun k => mpv (blocks₀ k) σ) +
           zeroSet.sum (fun k => mpv (blocks₀ k) σ) := by
       rw [← Finset.sum_union hDisj, hUnion]
     -- The nonzero-block sum equals ∑ over the reindexed blocks.
-    have hLiveSum : liveSet.sum (fun k => mpv (blocks₀ k) σ) =
+    have hNonzeroSum : nonzeroSet.sum (fun k => mpv (blocks₀ k) σ) =
         ∑ j : Fin r, mpv (newBlocks j) σ := by
-      rw [← liveSet.sum_coe_sort (fun k => mpv (blocks₀ k) σ)]
-      exact (liveEquiv.symm.sum_comp (fun x : liveSet => mpv (blocks₀ x.1) σ)).symm
+      rw [← nonzeroSet.sum_coe_sort (fun k => mpv (blocks₀ k) σ)]
+      exact (nonzeroEquiv.symm.sum_comp
+        (fun x : nonzeroSet => mpv (blocks₀ x.1) σ)).symm
     -- The zero sum: at N > 0, each zero block contributes 0; at N = 0, it contributes dim.
     have hZeroSum : zeroSet.sum (fun k => mpv (blocks₀ k) σ) =
         if N = 0 then (zeroTailDim : ℂ) else 0 := by
@@ -534,15 +538,15 @@ theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
         have hkz : ∀ i, blocks₀ k i = 0 := by
           by_contra hne
           push Not at hne
-          have hkLive : k ∈ liveSet :=
+          have hkNonzero : k ∈ nonzeroSet :=
             Finset.mem_filter.mpr ⟨Finset.mem_univ k, hne⟩
-          exact absurd hkLive (Finset.disjoint_right.mp hDisj hk)
+          exact absurd hkNonzero (Finset.disjoint_right.mp hDisj hk)
         exact mpv_eq_zero_of_all_zero (blocks₀ k) hkz σ (Nat.pos_of_ne_zero hN)
     -- Expand the zero-tail MPV.
     have hZeroTail : mpv (zeroMPSTensor d zeroTailDim) σ =
         if N = 0 then (zeroTailDim : ℂ) else 0 :=
       mpv_zeroMPSTensor σ zeroTailDim
     -- Chain everything together.
-    rw [hA, hSplit, hLiveSum, hZeroSum, hZeroTail, hLive, add_comm]
+    rw [hA, hSplit, hNonzeroSum, hZeroSum, hZeroTail, hNonzero, add_comm]
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -28,7 +28,7 @@ We currently have the following components:
 * Appendix A (CFII part): inside that TP gauge, unitary conjugation → diagonal PD fixed point.
 * Appendix A (periodicity): TP + irreducible → primitive after blocking.
 
-We also keep a couple of downstream compatibility wrappers for already-normalized primitive /
+We also keep a couple of downstream compatibility formulations for already-normalized primitive /
 injective block families, but those are **not** assembled from arbitrary input in this file.
 
 Note: the Appendix-A CFII story is genuinely two-step:
@@ -46,7 +46,7 @@ What is **not** yet assembled end-to-end here:
 
 Accordingly, this file should be read as a collection of early-stage
 reduction lemmas plus explicit continuation statements, **not** as a
-near-endpoint canonical-form existence theorem for arbitrary input tensors.
+near-final canonical-form existence theorem for arbitrary input tensors.
 -/
 
 namespace MPSTensor
@@ -147,7 +147,7 @@ theorem exists_blockTensor_isPrimitive
   simpa using
     (exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor (A := A) hTP hIrr hDpos)
 
-/-- **Reduction step (1606.00608 Appendix A, TP bookkeeping after blocking).**
+/-- **Reduction step (1606.00608 Appendix A, TP normalization after blocking).**
 
 If `A` is trace-preserving and irreducible, then some physical blocking makes the
 blocked transfer map primitive, and the blocked tensor remains left-canonical. -/
@@ -166,7 +166,7 @@ theorem exists_blockTensor_leftCanonical_isPrimitive
     exists_blockTensor_isPrimitive (A := A) hTP hIrr
   refine ⟨p, hp, leftCanonical_blockTensor (d := d) (D := D) (A := A) (L := p) hTP, hPrim⟩
 
-/-- **Reduction compatibility wrapper:** spectral-gap primitivity with a positive-definite
+/-- **Reduction compatibility theorem:** spectral-gap primitivity with a positive-definite
 fixed point implies normality. -/
 theorem isNormal_of_isPrimitiveMPS
     [NeZero D]
@@ -271,7 +271,7 @@ theorem isIrreducibleTensor_allZero_dim_le_one
 
 
 /-!
-## Unconditional arbitrary-input continuations (still far from the endpoint)
+## Unconditional arbitrary-input continuations
 
 The last unconditional arbitrary-input step currently available here is the blockwise PF / TP-gauge
 continuation below: after decomposing `A` into irreducible blocks, one may continue on each block
@@ -285,10 +285,10 @@ file does **not** currently construct that input from an arbitrary tensor.
 
 Remaining gap for a full end-to-end canonical-form existence theorem:
 
-* Thread the irreducible-to-TP-gauge wrapper blockwise through the irreducible block decomposition
+* Apply the irreducible-to-TP-gauge theorem blockwise through the irreducible block decomposition
   while handling possible zero blocks exactly.
 * Apply the TP-irreducible-to-primitive blocking theorem and then perform the post-blocking cyclic
-  sector / equal-weight bookkeeping needed for strict nonzero weight ordering.
+  sector and equal-weight arguments needed for strict nonzero weight ordering.
 * Use the resulting data to reach the stronger normal / injective-by-blocking hypotheses needed by
   the later normal-canonical-form packaging lemmas and the downstream `IsCanonicalForm` builders.
 -/
@@ -345,7 +345,7 @@ From an arbitrary tensor `A` we produce an irreducible block decomposition. More
 block, assuming one has already supplied (i) a TP representative and (ii) positive bond dimension,
 we can produce CFII fixed-point data (unitary conjugation + diagonal PD fixed point).
 
-This is an optional Appendix-A side branch, not a near-endpoint theorem: it does not thread the PF
+This is an optional Appendix-A side branch, not a near-final theorem: it does not thread the PF
 / TP-gauge or periodicity-removal steps through the block decomposition. Later packaging into
 normal canonical form, once primitive weighted blocks are already in hand, lives in the later
 normal-canonical-form packaging file. -/
@@ -379,12 +379,12 @@ theorem exists_irreducible_blockDecomp_with_CFII
       (A := blocks k) (hTP := hTPk) (hIrr := hIrr k) (hD := hDk))
 
 /-!
-## Zero-block separation (1606.00608 §2.3: partition into zero tail + live blocks)
+## Zero-block separation (1606.00608 §2.3: partition into zero tail + nonzero blocks)
 
 The irreducible block decomposition may produce all-zero blocks. Because `SameMPV₂` at `N = 0`
-records `trace(I_D) = D`, we cannot silently drop these. Instead we accumulate them into a
+includes the identity `trace(I_D) = D`, we cannot silently drop these. Instead we accumulate them into a
 **zero tail** of dimension `zeroTailDim` (the sum of their bond dimensions) and retain a family
-of **live blocks** (each having at least one nonzero Kraus operator).
+of **nonzero blocks** (each having at least one nonzero Kraus operator).
 
 Key facts:
 - All-zero irreducible blocks have `dim ≤ 1` (`isIrreducibleTensor_allZero_dim_le_one`).
@@ -424,8 +424,8 @@ Every MPS tensor `A : MPSTensor d D` admits an irreducible block decomposition t
 partitioned into:
 
 * a **zero tail** of dimension `zeroTailDim` (accumulating all-zero irreducible blocks), and
-* a family of **live blocks** `blocks k : MPSTensor d (dim k)` for `k : Fin r`, each with at least
-  one nonzero Kraus operator, positive bond dimension, and irreducibility.
+* a family of **nonzero blocks** `blocks k : MPSTensor d (dim k)` for `k : Fin r`, each with at
+  least one nonzero Kraus operator, positive bond dimension, and irreducibility.
 
 The MPV relationship is:
 
@@ -434,9 +434,9 @@ The MPV relationship is:
 which at `N = 0` reduces to `D = zeroTailDim + ∑ k, dim k` and at `N > 0` reduces to
 `mpv A σ = mpv (toTensorFromBlocks μ≡1 blocks) σ` (zero tail vanishes).
 
-This separation is **exact**: the zero tail is not silently discarded, and the `N = 0`
-bookkeeping is preserved. -/
-theorem exists_irreducible_blockDecomp_liveBlocks (A : MPSTensor d D) :
+This separation is **exact**: the zero tail is not silently discarded, and the length-zero
+identity is preserved. -/
+theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
       (blocks : (k : Fin r) → MPSTensor d (dim k)),
       (∀ k, IsIrreducibleTensor (blocks k)) ∧
@@ -456,7 +456,7 @@ theorem exists_irreducible_blockDecomp_liveBlocks (A : MPSTensor d D) :
   set zeroSet : Finset (Fin r₀) := Finset.univ.filter (fun k => ¬ isLive k) with zeroSet_def
   -- The zero tail dimension is the sum of bond dimensions of zero blocks.
   set zeroTailDim : ℕ := zeroSet.sum dim₀ with zeroTailDim_def
-  -- Reindex live blocks via a bijection with `Fin liveSet.card`.
+  -- Reindex nonzero blocks via a bijection with `Fin liveSet.card`.
   set liveEquiv : liveSet ≃ Fin liveSet.card := liveSet.equivFin with liveEquiv_def
   -- Define the new live block family.
   set r := liveSet.card with r_def
@@ -465,7 +465,7 @@ theorem exists_irreducible_blockDecomp_liveBlocks (A : MPSTensor d D) :
     fun j => blocks₀ (liveEquiv.symm j).1 with newBlocks_def
   -- Step 3: Prove all properties.
   refine ⟨zeroTailDim, r, dim, newBlocks, ?_, ?_, ?_, ?_⟩
-  -- (a) Irreducibility of live blocks.
+  -- (a) Irreducibility of nonzero blocks.
   · intro k
     exact hIrr₀ (liveEquiv.symm k).1
   -- (b) Each live block has a nonzero Kraus operator.
@@ -511,7 +511,7 @@ theorem exists_irreducible_blockDecomp_liveBlocks (A : MPSTensor d D) :
         liveSet.sum (fun k => mpv (blocks₀ k) σ) +
           zeroSet.sum (fun k => mpv (blocks₀ k) σ) := by
       rw [← Finset.sum_union hDisj, hUnion]
-    -- The live sum equals ∑ over reindexed live blocks.
+    -- The nonzero-block sum equals ∑ over the reindexed blocks.
     have hLiveSum : liveSet.sum (fun k => mpv (blocks₀ k) σ) =
         ∑ j : Fin r, mpv (newBlocks j) σ := by
       rw [← liveSet.sum_coe_sort (fun k => mpv (blocks₀ k) σ)]
@@ -543,5 +543,9 @@ theorem exists_irreducible_blockDecomp_liveBlocks (A : MPSTensor d D) :
       mpv_zeroMPSTensor σ zeroTailDim
     -- Chain everything together.
     rw [hA, hSplit, hLiveSum, hZeroSum, hZeroTail, hLive, add_comm]
+
+@[deprecated exists_irreducible_blockDecomp_nonzeroBlocks (since := "2026-04-29")]
+abbrev exists_irreducible_blockDecomp_liveBlocks (A : MPSTensor d D) :=
+  exists_irreducible_blockDecomp_nonzeroBlocks A
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -381,10 +381,11 @@ theorem exists_irreducible_blockDecomp_with_CFII
 /-!
 ## Zero-block separation (1606.00608 §2.3: partition into zero tail + nonzero blocks)
 
-The irreducible block decomposition may produce all-zero blocks. Because `SameMPV₂` at `N = 0`
-includes the identity `trace(I_D) = D`, we cannot silently drop these. Instead we accumulate them into a
-**zero tail** of dimension `zeroTailDim` (the sum of their bond dimensions) and retain a family
-of **nonzero blocks** (each having at least one nonzero Kraus operator).
+The irreducible block decomposition may produce all-zero blocks. Because `SameMPV₂`
+at `N = 0` includes the identity `trace(I_D) = D`, we cannot silently drop these.
+Instead we accumulate them into a **zero tail** of dimension `zeroTailDim` (the sum
+of their bond dimensions) and retain a family of **nonzero blocks** (each having at
+least one nonzero Kraus operator).
 
 Key facts:
 - All-zero irreducible blocks have `dim ≤ 1` (`isIrreducibleTensor_allZero_dim_le_one`).

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -14,8 +14,8 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder TNMatrixCFC
 /-!
 # TP-gauge reduction for normal canonical-form construction
 
-This module records the TP-gauge normalization part of the normal-reduction
-pipeline.
+This module gives the TP-gauge normalization part of the normal-canonical-form
+reduction.
 
 Its public outputs are:
 
@@ -24,8 +24,8 @@ Its public outputs are:
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
   arbitrary-input result obtained after zero-block separation.
 
-The auxiliary declarations stay file-local because they are bookkeeping lemmas
-for rescaling, gauge transport, and the final zero-tail threading step.
+The auxiliary declarations stay file-local because they are elementary lemmas for
+rescaling, gauge transport, and the final zero-tail identity.
 -/
 
 namespace MPSTensor
@@ -117,15 +117,15 @@ private theorem isIrreducibleTensor_tpGauge_of_isIrreducibleTensor
 /-- Blockwise Perron--Frobenius / TP-gauge stage for an irreducible block decomposition.
 
 This theorem is the blockwise TP-normalization step used by
-`exists_tp_gauge_from_arbitrary_with_zeroTail`, and it also records the earlier
+`exists_tp_gauge_from_arbitrary_with_zeroTail`, and it also gives the earlier
 TP-normalization route on a fixed irreducible decomposition. Its extra
 nonzero-block hypothesis lives on a chosen decomposition, so it still does not
-by itself give an unconditional arbitrary-input endpoint under the current
+by itself give an unconditional arbitrary-input theorem under the current
 `SameMPV₂` interface. Concretely, every input block is assumed to have some
 nonzero Kraus operator, excluding the all-zero scalar counterexample and
-matching the hypotheses of the corresponding irreducible-to-TP wrapper from
-`Existence.lean`. It remains separate from the later normal-canonical-form
-endpoint in `NormalReduction/Main.lean`. -/
+matching the hypotheses of the corresponding irreducible-to-TP result from
+`Existence.lean`. It remains separate from the later normal-canonical-form theorem
+in `NormalReduction/Main.lean`. -/
 theorem exists_tp_gauge_blockwise
     (A : MPSTensor d D)
     {r0 : ℕ} {dim0 : Fin r0 → ℕ}
@@ -271,7 +271,7 @@ The MPV relationship accounts exactly for both contributions:
   `mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ + mpv (toTensorFromBlocks μ blocks) σ`
 
 This is the furthest unconditional arbitrary-input step available before periodicity removal and
-cyclic-sector / equal-weight bookkeeping.
+the cyclic-sector and equal-weight arguments.
 -/
 
 /-- **Arbitrary-input TP-gauge reduction (1606.00608 §2.3 + App. A, with zero-block separation).**
@@ -301,8 +301,8 @@ theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
   classical
   -- Step 1: Obtain the zero-block-separated irreducible decomposition.
   obtain ⟨zeroTailDim, r₀, dim₀, blocks₀, hIrr₀, hNonzero₀, hDim₀, hMPV₀⟩ :=
-    exists_irreducible_blockDecomp_liveBlocks (d := d) (D := D) A
-  -- Step 2: Apply blockwise TP gauge to the live blocks.
+    exists_irreducible_blockDecomp_nonzeroBlocks (d := d) (D := D) A
+  -- Step 2: Apply blockwise TP gauge to the nonzero blocks.
   -- We feed `A_live := toTensorFromBlocks μ=1 blocks₀` as the input tensor.
   -- The SameMPV₂ hypothesis for `exists_tp_gauge_blockwise` holds by reflexivity.
   let A_live := toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -280,13 +280,13 @@ From any `A : MPSTensor d D`, produce:
 * a zero-tail of dimension `zeroTailDim` accumulating all-zero irreducible blocks;
 * TP-gauged irreducible blocks `blocks k` with nonzero weights `μ k`.
 
-Every live block satisfies:
+Every nonzero block satisfies:
 * `IsIrreducibleTensor`;
 * left-canonical normalization `∑ᵢ (Bᵢ)ᴴ Bᵢ = I`;
 * positive bond dimension;
 * nonzero weight.
 
-The MPV of `A` equals the zero-tail contribution plus the weighted live-block sum. -/
+The MPV of `A` equals the zero-tail contribution plus the weighted nonzero-block sum. -/
 theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
       (μ : Fin r → ℂ)
@@ -303,20 +303,20 @@ theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
   obtain ⟨zeroTailDim, r₀, dim₀, blocks₀, hIrr₀, hNonzero₀, hDim₀, hMPV₀⟩ :=
     exists_irreducible_blockDecomp_nonzeroBlocks (d := d) (D := D) A
   -- Step 2: Apply blockwise TP gauge to the nonzero blocks.
-  -- We feed `A_live := toTensorFromBlocks μ=1 blocks₀` as the input tensor.
+  -- We feed `A_nonzero := toTensorFromBlocks μ=1 blocks₀` as the input tensor.
   -- The SameMPV₂ hypothesis for `exists_tp_gauge_blockwise` holds by reflexivity.
-  let A_live := toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀
-  have hSame_refl : SameMPV₂ A_live
+  let A_nonzero := toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀
+  have hSame_refl : SameMPV₂ A_nonzero
       (toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀) :=
     fun _ _ => rfl
   obtain ⟨r₁, dim₁, μ₁, blocks₁, hSame₁, hIrr₁, hLeft₁, hμNe₁, hDim₁⟩ :=
-    exists_tp_gauge_blockwise A_live blocks₀ hIrr₀ hSame_refl hNonzero₀
+    exists_tp_gauge_blockwise A_nonzero blocks₀ hIrr₀ hSame_refl hNonzero₀
   -- Step 3: Assemble the result.
   refine ⟨zeroTailDim, r₁, dim₁, μ₁, blocks₁, hIrr₁, hLeft₁, hμNe₁, hDim₁, ?_⟩
   -- The MPV relationship chains through the zero-block separation and TP gauge.
   intro N σ
   calc mpv A σ
-      = mpv (zeroMPSTensor d zeroTailDim) σ + mpv A_live σ := hMPV₀ N σ
+      = mpv (zeroMPSTensor d zeroTailDim) σ + mpv A_nonzero σ := hMPV₀ N σ
     _ = mpv (zeroMPSTensor d zeroTailDim) σ +
           mpv (toTensorFromBlocks (d := d) (μ := μ₁) blocks₁) σ := by
         congr 1

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.MPDO.RFP
 /-!
 # Fusion-isometry formulations of the MPDO renormalization fixed point
 
-This file records the **fusion-isometry** side of the equivalence stated in
+This file gives the **fusion-isometry** side of the equivalence stated in
 arXiv:1606.00608 §4.5 (Cirac–Pérez-García–Schuch–Verstraete). In the notation
 of the paper, a fusion isometry at blocked size `n` is a pair of linear maps
 `T`, `S` between the physical space of `n` blocked sites and the corresponding
@@ -23,12 +23,12 @@ dynamics underlying the provisional `MPOTensor.IsRFP` predicate in
 Two layers coexist in this file.
 
 1. **Provisional shell layer** (`FusionIsometry`, `FusionIsometry.CompatibleWith`,
-   `IsRFP_MPDO_via_fusion_scaffold`): kept for downstream compatibility. The
+   `IsRFP_MPDO_via_fusionIsometries_provisional`): kept for downstream compatibility. The
    physical space at blocked size `n` and the support algebra at blocked size
    `n` are both represented by `Matrix (Fin D) (Fin D) ℂ`, a stand-in for the
    genuine objects; the compatibility predicate is currently the trivial
-   proposition `True`, so `IsRFP_MPDO_via_fusion_scaffold` as a whole is
-   satisfied by every `M`. The `_scaffold` suffix marks the predicate to
+   proposition `True`, so `IsRFP_MPDO_via_fusionIsometries_provisional` as a whole is
+   satisfied by every `M`. The name marks the predicate as provisional, to
    prevent its use in nontrivial reasoning until the relation is tightened.
 2. **Transfer-map-level layer** (`blockedTransferMap`, `FusionIsometryData`,
    `IsRFP_MPDO_via_fusion`): formalizes the transfer-map content already
@@ -46,7 +46,7 @@ Two layers coexist in this file.
 ## Main declarations
 
 * Provisional shell declarations: `FusionIsometry`, `FusionIsometry.CompatibleWith`,
-  `IsRFP_MPDO_via_fusion_scaffold`.
+  `IsRFP_MPDO_via_fusionIsometries_provisional`.
 * `blockedTransferMap`: the transfer map of the `n`-site blocked doubled-index
   MPS tensor.
 * `FusionIsometryData`: retract data whose characteristic identity is the
@@ -164,18 +164,21 @@ size close under multiplication via a system of fusion isometries
 compatible with `M`. The definition below asserts the existence of such a
 family using the relation `FusionIsometry.CompatibleWith`.
 
-The `_scaffold` suffix marks that `FusionIsometry.CompatibleWith` is
-currently `True`: the predicate is consequently satisfied by every `M`, and
-must not be used as a hypothesis or conclusion of any nontrivial result
-until the relation is tightened.
+The adjective `provisional` marks that `FusionIsometry.CompatibleWith` is currently
+`True`: the predicate is consequently satisfied by every `M`, and must not be used
+as a hypothesis or conclusion of any nontrivial result until the relation is tightened.
 
 TODO (#611): replace `FusionIsometry.CompatibleWith` with the
 compatibility condition between `M` and its fusion isometries, add the
 inter-level compatibility asking the size-`n+1` isometry to factor through
-the size-`n` one, and drop the `_scaffold` suffix once the relation is no
-longer trivial. -/
-def IsRFP_MPDO_via_fusion_scaffold (M : MPOTensor d D) : Prop :=
+the size-`n` one, and remove the provisional formulation once the relation is
+no longer trivial. -/
+def IsRFP_MPDO_via_fusionIsometries_provisional (M : MPOTensor d D) : Prop :=
   ∀ n : ℕ, ∃ F : FusionIsometry d D n, F.CompatibleWith M
+
+@[deprecated IsRFP_MPDO_via_fusionIsometries_provisional (since := "2026-04-29")]
+abbrev IsRFP_MPDO_via_fusion_scaffold (M : MPOTensor d D) : Prop :=
+  IsRFP_MPDO_via_fusionIsometries_provisional M
 
 /-! ## Transfer-map-level fusion data -/
 

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -176,10 +176,6 @@ no longer trivial. -/
 def IsRFP_MPDO_via_fusionIsometries_provisional (M : MPOTensor d D) : Prop :=
   ∀ n : ℕ, ∃ F : FusionIsometry d D n, F.CompatibleWith M
 
-@[deprecated IsRFP_MPDO_via_fusionIsometries_provisional (since := "2026-04-29")]
-abbrev IsRFP_MPDO_via_fusion_scaffold (M : MPOTensor d D) : Prop :=
-  IsRFP_MPDO_via_fusionIsometries_provisional M
-
 /-! ## Transfer-map-level fusion data -/
 
 /-- The blocked transfer map of an MPO tensor, obtained by viewing `M` as a

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -859,14 +859,6 @@ theorem equalCase_zgauge_of_power_sums
   let ⟨Z, hZm, hZmul⟩ := zgauge_construction m μ ν hPow hν
   ⟨Z, hZm, hZmul, weight_multisets_eq_of_power_sums_eq μ ν hPS⟩
 
-@[deprecated equalCase_zgauge_of_power_sums (since := "2026-04-29")]
-abbrev equalCase_zgauge_pipeline
-    {r : ℕ} (m : ℕ) (μ ν : Fin r → ℂ)
-    (hν : ∀ i, ν i ≠ 0)
-    (hPow : ∀ i, μ i ^ m = ν i ^ m)
-    (hPS : ∀ k : ℕ, 0 < k → ∑ i : Fin r, μ i ^ k = ∑ i : Fin r, ν i ^ k) :=
-  equalCase_zgauge_of_power_sums m μ ν hν hPow hPS
-
 end ZGaugeAssembly
 
 /-! ## Theorem 3.8 — Equal case assembly (arXiv:1708.00029)

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -107,7 +107,7 @@ abbrev PeriodicBlockMatchingWitness
 
 /-! ## Periodic overlap dichotomy hypothesis -/
 
-/-- Hypothesis recording the periodic overlap dichotomy (Proposition 3.3 of 1708.00029).
+/-- Hypothesis giving the periodic overlap dichotomy (Proposition 3.3 of 1708.00029).
 
 The `hetRepeatedBlocks_of_nondecaying` field can be filled via `periodicOverlapDichotomy`
 (see `PeriodicOverlapHypothesis.ofIsPeriodic`), though that dichotomy's proof in
@@ -847,7 +847,7 @@ produces: weight multiset equality, a diagonal Z with `Z^m = 1`, and `Z · diag(
 In the full Theorem 3.8 proof, hypothesis (3) follows from BNT linear independence + equal
 MPVs (via `power_sums_eq_of_eventually_eq`), and hypothesis (1) is the Newton-Girard
 consequence of (3) restricted to multiples of `m`. -/
-theorem equalCase_zgauge_pipeline
+theorem equalCase_zgauge_of_power_sums
     {r : ℕ} (m : ℕ) (μ ν : Fin r → ℂ)
     (hν : ∀ i, ν i ≠ 0)
     (hPow : ∀ i, μ i ^ m = ν i ^ m)
@@ -859,6 +859,14 @@ theorem equalCase_zgauge_pipeline
   let ⟨Z, hZm, hZmul⟩ := zgauge_construction m μ ν hPow hν
   ⟨Z, hZm, hZmul, weight_multisets_eq_of_power_sums_eq μ ν hPS⟩
 
+@[deprecated equalCase_zgauge_of_power_sums (since := "2026-04-29")]
+abbrev equalCase_zgauge_pipeline
+    {r : ℕ} (m : ℕ) (μ ν : Fin r → ℂ)
+    (hν : ∀ i, ν i ≠ 0)
+    (hPow : ∀ i, μ i ^ m = ν i ^ m)
+    (hPS : ∀ k : ℕ, 0 < k → ∑ i : Fin r, μ i ^ k = ∑ i : Fin r, ν i ^ k) :=
+  equalCase_zgauge_of_power_sums m μ ν hν hPow hPS
+
 end ZGaugeAssembly
 
 /-! ## Theorem 3.8 — Equal case assembly (arXiv:1708.00029)
@@ -866,7 +874,7 @@ end ZGaugeAssembly
 The equal-case Fundamental Theorem of MPS in irreducible form composes:
 
 1. **Theorem 3.4** (`fundamentalTheorem_periodic_proportional`): block matching.
-2. **Z-gauge construction** (`equalCase_zgauge_pipeline`): Newton–Girard + Z-gauge diagonal.
+2. **Z-gauge construction** (`equalCase_zgauge_of_power_sums`): Newton–Girard + Z-gauge diagonal.
 
 **Conditional on #81**: The `PeriodicOverlapHypothesis` and per-block weight power
 equality hypotheses will be discharged once the periodic overlap dichotomy (Proposition
@@ -915,7 +923,7 @@ This composes Theorem 3.4 with the Z-gauge construction from PR #94.
 
 **Conditional on #81**: The `PeriodicOverlapHypothesis` and `hPowEq` hypotheses will be
 discharged once the periodic overlap dichotomy and coefficient extraction infrastructure
-are formalized. The Z-gauge construction itself (`equalCase_zgauge_pipeline`) is fully
+are formalized. The Z-gauge construction itself (`equalCase_zgauge_of_power_sums`) is fully
 proved. -/
 theorem fundamentalTheorem_periodic_equalCase
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -950,7 +958,7 @@ theorem fundamentalTheorem_periodic_equalCase
   have hPow_period : (hA.μ j) ^ (hA.period j) = (hB.μ (perm j)) ^ (hA.period j) :=
     hPowEqJ (hA.period j) (hA.periodic j).period_pos
   obtain ⟨Z, hZpow, hZmul, hMultiset⟩ :=
-    equalCase_zgauge_pipeline (hA.period j)
+    equalCase_zgauge_of_power_sums (hA.period j)
       (fun _ : Fin 1 => hA.μ j) (fun _ : Fin 1 => hB.μ (perm j))
       (fun _ => hμB_ne (perm j))
       (fun _ => hPow_period)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -970,8 +970,7 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
 In the irreducible block decomposition, some blocks may have all-zero
 Kraus operators. Such blocks contribute to the MPV only at word length
 $N = 0$ (where their contribution equals their bond dimension).
-The following results separate the zero blocks from the
-``live'' (nonzero) blocks.
+The following results separate the zero blocks from the nonzero blocks.
 
 \begin{definition}[Zero MPS tensor]\label{def:zero_mps_tensor}
 	\lean{MPSTensor.zeroMPSTensor}
@@ -1000,7 +999,7 @@ The following results separate the zero blocks from the
 
 \begin{theorem}[Zero-block separation]%
 	\label{thm:zero_block_separation}
-	\lean{MPSTensor.exists_irreducible_blockDecomp_liveBlocks}
+	\lean{MPSTensor.exists_irreducible_blockDecomp_nonzeroBlocks}
 	\leanok
 	\uses{def:irreducible_tensor, def:zero_mps_tensor}
 	Every MPS tensor $A$ admits a block decomposition into:
@@ -1220,7 +1219,7 @@ The following results separate the zero blocks from the
 	right-hand side is $d^{mn}$.
 \end{proof}
 
-\begin{theorem}[Iterated blocking and one-shot blocking yield the same MPV family after relabeling]
+\begin{theorem}[Iterated blocking and direct blocking yield the same MPV family after relabeling]
 	\label{thm:iterated_blocking_samempv_reindex}
 	\lean{MPSTensor.sameMPV₂_blockTensor_blockTensor_mul_reindex}
 	\leanok
@@ -1234,7 +1233,7 @@ The following results separate the zero blocks from the
 \begin{proof}\leanok
 	For each iterated blocked index, decode the outer block, decode each inner
 	block, and concatenate the resulting words. This is exactly the word
-	decoded from the corresponding one-shot blocked index, so the word
+	decoded from the corresponding directly blocked index, so the word
 	evaluations, and hence all MPV coefficients, agree.
 \end{proof}
 
@@ -1649,7 +1648,7 @@ The following results separate the zero blocks from the
 	\leanok
 	\uses{def:primitive_irreducible_cyclic_sectors, def:blocked_tensor,
 		def:tensor_from_blocks, def:same_mpv2}
-	For a finite family of nonzero-weight blocks $(B_k)$, these data record a single
+	For a finite family of nonzero-weight blocks $(B_k)$, these data specify a single
 	positive physical blocking length $p$, the per-block period-removal lengths
 	$m_k$, the later positive reblocking lengths $e_k$ with $p=m_k e_k$, and the
 	resulting flattened finite sector family at physical dimension $d^p$.  They
@@ -1686,7 +1685,7 @@ The following results separate the zero blocks from the
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorTensor,
-		MPSTensor.CommonBlockedCyclicSectorFamily.oneShotReindexedBlock,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonReindexedBlock,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_family, def:blocked_tensor,
@@ -1730,11 +1729,11 @@ The following results separate the zero blocks from the
 	positive power of a nonzero complex number is nonzero.
 \end{proof}
 
-\begin{theorem}[Relabeled one-shot blocks decompose into common cyclic sectors]%
+\begin{theorem}[Reindexed blocks decompose into common cyclic sectors]%
 \label{thm:common_blocked_cyclic_sector_reindexed_samempv}
-	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.nestedBlock_sameMPV₂_oneShotReindexedBlock,
-		MPSTensor.CommonBlockedCyclicSectorFamily.oneShotReindexedBlock_sameMPV₂_commonSectorTensor,
-		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedOneShotReindexedBlock_commonFlat}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.nestedBlock_sameMPV₂_commonReindexedBlock,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonReindexedBlock_sameMPV₂_commonSectorTensor,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCommonReindexedBlock_commonFlat}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:iterated_blocking_samempv_reindex,
@@ -1742,7 +1741,7 @@ The following results separate the zero blocks from the
 		thm:common_blocked_cyclic_sector_derived_properties}
 	For each block, the iterated block $(B_k^{[m_k]})^{[e_k]}$ agrees, after the
 	explicit reindexing of blocked physical words, with the block of length
-	$m_k e_k$.  Combining this with the stored cyclic-sector decomposition gives an
+	$m_k e_k$.  Combining this with the given cyclic-sector decomposition gives an
 	MPV equality between the reindexed block and its derived common-sector tensor.
 	Summing over the original blocks transports the weights to $\mu_k^p$ and
 	flattens the two-level block/sector sum into one sector family.
@@ -1754,13 +1753,13 @@ The following results separate the zero blocks from the
 		thm:common_blocked_cyclic_sector_derived_properties}
 	First use the iterated-blocking comparison theorem and substitute the common
 	physical alphabet.  Then compose with the per-block cyclic-sector MPV
-	equivalence stored in the family.  Finally expand both block-diagonal tensors as
+	equivalence supplied by the family.  Finally expand both block-diagonal tensors as
 	sums and reindex the double sum over pairs $(k,s)$ by the flattened sector index.
 \end{proof}
 
 \begin{theorem}[Canonical blocked nonzero part under blocked-word relabeling]%
 \label{thm:common_blocked_cyclic_sector_canonical_label_compat}
-	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_oneShot}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed}
 	\leanok
 	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
 		def:common_blocked_cyclic_sector_derived_blocks}
@@ -1772,7 +1771,7 @@ The following results separate the zero blocks from the
 
 \begin{proof}\leanok
 	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv}
-	Compose the assumed MPV equality with the relabeled one-shot decomposition of
+	Compose the assumed MPV equality with the reindexed sector decomposition of
 	Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_samempv}.
 \end{proof}
 
@@ -2435,7 +2434,7 @@ The following results separate the zero blocks from the
 	blocking period $p$ making all transfer maps primitive. Lemma~\ref{lem:block_weights_ne_zero}
 	keeps the blocked weights nonzero, and
 	Theorem~\ref{thm:zero_tail_to_tensor_from_blocks_block_power} transports the
-	zero-tail/live MPV identity through the blocking step.
+	zero-tail/nonzero MPV identity through the blocking step.
 \end{proof}
 
 \begin{theorem}[TP-primitive irreducible tensor is normal]%
@@ -2671,7 +2670,7 @@ The following results separate the zero blocks from the
 	scalar factor $\zeta$ such that
 	$\ket{V^{(N)}(B_k)}=\zeta^N\ket{V^{(N)}(B_j)}$ for every length~$N$.
 	The class data enumerate the finite quotient, choose one representative per class,
-	record the scalar relating the representative to each member, and prove that
+	give the scalar relating the representative to each member, and prove that
 	distinct representatives are not gauge-phase equivalent.
 \end{definition}
 
@@ -2768,7 +2767,7 @@ The following results separate the zero blocks from the
 	Each representative is one of the original blocks. Conversely, every original
 	block appears in a phase class and differs from that class representative by a
 	nonzero scalar power at each length, so its MPV state lies in the
-	representative span. The one-sided sector theorem then records this identity
+	representative span. The one-sided sector theorem then gives this identity
 	for the chosen sector basis.
 \end{proof}
 
@@ -3069,15 +3068,15 @@ The following results separate the zero blocks from the
 	Theorem~\ref{thm:block_tensor_to_tensor_from_blocks}.
 \end{proof}
 
-\begin{theorem}[Zero-tail bookkeeping for nonzero block tensors]%
-\label{thm:live_block_zero_tail_bookkeeping}
-	\lean{MPSTensor.liveBlock_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂}
+\begin{theorem}[Zero-tail identity for nonzero block tensors]%
+\label{thm:nonzero_block_zero_tail_identity}
+	\lean{MPSTensor.nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂}
 	\leanok
 	\uses{def:same_mpv2, def:zero_mps_tensor, def:tensor_from_blocks}
 	Suppose two tensors have the same MPV family and each is expressed as a
 	zero-tail tensor plus a weighted nonzero-block tensor. Then the two nonzero-block
 	tensors agree on every positive system size, and at size $0$ the equality is
-	exactly the equality of the two zero-tail contributions plus the two live
+	exactly the equality of the two zero-tail contributions plus the two nonzero
 	bond-dimension traces.
 \end{theorem}
 
@@ -3085,44 +3084,44 @@ The following results separate the zero blocks from the
 	\uses{def:zero_mps_tensor}
 	For $N>0$, the MPV of a zero-tail tensor is zero, so the two decompositions
 	can be compared directly through the common MPV family. For $N=0$, the
-	zero-tail MPV is its bond dimension, giving the stated bookkeeping identity.
+	zero-tail MPV is its bond dimension, giving the stated length-zero identity.
 \end{proof}
 
-\begin{theorem}[Reblocked nonzero-part equality with zero-tail bookkeeping]%
-	\label{thm:live_block_block_power_zero_tail_bookkeeping}
-	\lean{MPSTensor.liveBlock_blockPower_positive_sameMPV₂_and_zeroTail_bookkeeping_of_sameMPV₂}
+\begin{theorem}[Reblocked nonzero-part equality with zero-tail identity]%
+	\label{thm:nonzero_block_block_power_zero_tail_identity}
+	\lean{MPSTensor.nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂}
 	\leanok
-	\uses{thm:live_block_zero_tail_bookkeeping,
+	\uses{thm:nonzero_block_zero_tail_identity,
 	      thm:zero_tail_to_tensor_from_blocks_block_power, def:same_mpv2_pos}
-	In the setting of Theorem~\ref{thm:live_block_zero_tail_bookkeeping}, after
+	In the setting of Theorem~\ref{thm:nonzero_block_zero_tail_identity}, after
 	any positive common blocking length $p$, the powered weighted nonzero-block tensors
 	agree on all positive blocked system sizes. At blocked length $0$, the same
-	zero-tail bookkeeping identity holds with weights transported from $\mu_k$ to
+	zero-tail identity holds with weights transported from $\mu_k$ to
 	$\mu_k^p$.
 \end{theorem}
 
 \begin{proof}\leanok
 	Use Theorem~\ref{thm:zero_tail_to_tensor_from_blocks_block_power} on both
 	zero-tail decompositions, block the original MPV equality, and apply
-	Theorem~\ref{thm:live_block_zero_tail_bookkeeping} at the blocked physical
+	Theorem~\ref{thm:nonzero_block_zero_tail_identity} at the blocked physical
 	dimension.
 \end{proof}
 
 \begin{theorem}[Equal zero tails give full nonzero-part MPV equality]%
-\label{thm:live_block_same_mpv_zero_tail_eq}
-	\lean{MPSTensor.liveBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq}
+\label{thm:nonzero_block_same_mpv_zero_tail_eq}
+	\lean{MPSTensor.nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq}
 	\leanok
-	\uses{thm:live_block_zero_tail_bookkeeping}
-	In the setting of Theorem~\ref{thm:live_block_zero_tail_bookkeeping}, if
+	\uses{thm:nonzero_block_zero_tail_identity}
+	In the setting of Theorem~\ref{thm:nonzero_block_zero_tail_identity}, if
 	the two zero-tail dimensions are equal, then the two nonzero-block tensors have
 	the same MPV family, including the length-zero case.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:live_block_zero_tail_bookkeeping}
+	\uses{thm:nonzero_block_zero_tail_identity}
 	The positive-length cases are exactly the first conclusion of
-	Theorem~\ref{thm:live_block_zero_tail_bookkeeping}. At $N=0$, substitute
-	the equality of zero-tail dimensions into the bookkeeping identity and cancel
+	Theorem~\ref{thm:nonzero_block_zero_tail_identity}. At $N=0$, substitute
+	the equality of zero-tail dimensions into the length-zero identity and cancel
 	the common scalar term.
 \end{proof}
 
@@ -3146,33 +3145,33 @@ The following results separate the zero blocks from the
 	blocking the original equality.
 \end{proof}
 
-\begin{theorem}[Per-block cyclic-sector decomposition with zero-tail bookkeeping]%
+\begin{theorem}[Per-block cyclic-sector decomposition with zero-tail identity]%
 \label{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
 	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_perBlock_cyclic_live_with_zeroTail}
 	\leanok
-	\uses{thm:tp_gauge_arbitrary, thm:live_block_zero_tail_bookkeeping,
+	\uses{thm:tp_gauge_arbitrary, thm:nonzero_block_zero_tail_identity,
 		def:primitive_irreducible_cyclic_sectors,
 		thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
 	If two tensors generate the same MPV family, then after the zero-tail split and
 	trace-preserving gauge each side has irreducible nonzero-weight blocks.
 	The nonzero-block tensors agree at all positive system sizes, while the
-	length-zero case is recorded as the exact zero-tail bookkeeping identity.
+	length-zero case is included as the exact zero-tail identity.
 	Moreover each nonzero-weight block has primitive irreducible cyclic sectors. The
 	period-removal length for those sectors is kept separate from any later common
 	blocking or injectivity length.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:tp_gauge_arbitrary, thm:live_block_zero_tail_bookkeeping,
+	\uses{thm:tp_gauge_arbitrary, thm:nonzero_block_zero_tail_identity,
 		thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
 	Apply the arbitrary-tensor TP-gauge theorem separately to $A$ and $B$. The
-	zero-tail bookkeeping theorem compares the two resulting nonzero parts at
-	positive lengths and records the $N=0$ identity. Finally apply
+	zero-tail identity theorem compares the two resulting nonzero parts at
+	positive lengths and gives the $N=0$ identity. Finally apply
 	Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr} to every
 	trace-preserving irreducible nonzero-weight block.
 \end{proof}
 
-\begin{theorem}[Common reblocked nonzero cyclic sectors with zero-tail bookkeeping]%
+\begin{theorem}[Common reblocked nonzero cyclic sectors with zero-tail identity]%
 \label{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail}
 	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_commonBlocked_cyclic_live_with_zeroTail}
 	\leanok
@@ -3185,7 +3184,7 @@ The following results separate the zero blocks from the
 	at one physical blocking length, with trace preservation, primitive transfer
 	maps, tensor irreducibility, positive bond dimensions, and nonzero unit
 	weights.  The theorem keeps the positive-length equality of the nonzero parts and the exact
-	$N=0$ zero-tail bookkeeping for the original nonzero-block tensors.
+	$N=0$ zero-tail identity for the original nonzero-block tensors.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3214,7 +3213,7 @@ The following results separate the zero blocks from the
 	derived common-sector tensors.  The sector weights are the transported powers
 	$\mu_k^p$ and remain nonzero, the derived sectors are trace-preserving,
 	primitive, tensor-irreducible, and positive-dimensional, and the zero-tail/nonzero
-	equations are also recorded after the corresponding common reblocking.
+	equations are also included after the corresponding common reblocking.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3224,25 +3223,25 @@ The following results separate the zero blocks from the
 		thm:common_blocked_cyclic_sector_derived_properties}
 	Start from the common reblocked cyclic-sector families on the two sides.  Apply
 	the zero-tail reblocking theorem to the original nonzero-block decomposition, then
-	use the relabeled one-shot sector decomposition and the derived structural
+	use the reindexed sector decomposition and the derived structural
 	properties of the common-sector family.
 \end{proof}
 
 \begin{theorem}[Two-sided common-length relabeled cyclic-sector theorem]%
 \label{thm:ft_after_blocking_common_length_common_sector_theorem}
-	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_commonLength_commonSector_endpoint}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_1606_commonLength_commonSector}
 	\leanok
 	\uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
 		thm:exists_common_blocked_cyclic_sector_family_common_multiple,
 		thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:live_block_block_power_zero_tail_bookkeeping,
+		thm:nonzero_block_block_power_zero_tail_identity,
 		thm:common_blocked_cyclic_sector_reindexed_samempv,
 		thm:common_blocked_cyclic_sector_derived_properties}
 	If two tensors generate the same MPV family, then one can choose a single
 	positive physical blocking length for the cyclic-sector data on both sides.
-	At that length the theorem records the exact zero-tail equations for the
+	At that length the theorem gives the exact zero-tail equations for the
 	canonically blocked nonzero tensors, the positive-length equality and length-zero
-	bookkeeping for those nonzero parts, and the relabeled primitive irreducible
+	identity for those nonzero parts, and the relabeled primitive irreducible
 	common-sector families on both sides with nonzero transported weights.
 \end{theorem}
 
@@ -3250,7 +3249,7 @@ The following results separate the zero blocks from the
 	\uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
 		thm:exists_common_blocked_cyclic_sector_family_common_multiple,
 		thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:live_block_block_power_zero_tail_bookkeeping,
+		thm:nonzero_block_block_power_zero_tail_identity,
 		thm:common_blocked_cyclic_sector_reindexed_samempv,
 		thm:common_blocked_cyclic_sector_derived_properties}
 	Start from the per-block cyclic-sector theorem.  Let $p_A$ and $p_B$ be the
@@ -3258,12 +3257,12 @@ The following results separate the zero blocks from the
 	use $p=\mathrm{lcm}(p_A,p_B)$.  The prescribed-common-multiple theorem constructs both
 	one-sided sector families at this same length.  The zero-tail and positive-
 	length equalities are the existing reblocking statements, and the relabeled
-	sector conclusions are the one-shot common-sector MPV equalities.
+	sector conclusions are the reindexed common-sector MPV equalities.
 \end{proof}
 
-\begin{theorem}[Zero-tail equation after resolving the one-shot relabeling]%
-\label{thm:zero_tail_common_flat_of_one_shot_label_compat}
-	\lean{MPSTensor.zeroTail_commonFlat_of_oneShot_labelCompat}
+\begin{theorem}[Zero-tail equation after resolving the blocked-word relabeling]%
+\label{thm:zero_tail_common_flat_of_reindexed_label_compat}
+	\lean{MPSTensor.zeroTail_commonFlat_of_reindexed_labelCompat}
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:common_blocked_cyclic_sector_canonical_label_compat}
@@ -3271,7 +3270,7 @@ The following results separate the zero blocks from the
 	family, into a zero-tail contribution plus a weighted block-sum nonzero part at
 	the original physical alphabet.  Suppose also that, after blocking by the
 	common length, the canonical blocked nonzero tensor agrees with the explicitly
-	relabeled reindexed one-step nonzero tensor as an MPV family.  Then the zero-tail equation
+	reindexed nonzero tensor as an MPV family.  Then the zero-tail equation
 	after blocking may be written directly with the weighted derived common-sector
 	family.
 \end{theorem}
@@ -3308,7 +3307,7 @@ The following results separate the zero blocks from the
 	gives the zero-tail block together with trace-preserving irreducible nonzero-weight
 	blocks, and Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
 	applies the cyclic-sector construction to each nonzero-weight block while keeping the
-	positive-length MPV equality and the $N=0$ bookkeeping.
+	positive-length MPV equality and the $N=0$ identity.
 	Theorem~\ref{thm:exists_common_blocked_cyclic_sector_family_common_multiple}
 	constructs the common reblocked sector family at any prescribed common multiple
 	of the period-removal lengths.  Consequently
@@ -3323,11 +3322,11 @@ The following results separate the zero blocks from the
 	What remains on the canonical-form side is the exact equality, after the
 	relabeling of blocked physical words, between the canonical blocked nonzero part
 	and the cyclic-sector tensor for the whole weighted family.  The conditional statement
-	Theorem~\ref{thm:zero_tail_common_flat_of_one_shot_label_compat} already shows
+	Theorem~\ref{thm:zero_tail_common_flat_of_reindexed_label_compat} already shows
 	that, once this blocked-word relabeling agreement is proved, the zero-tail equations
 	can be written directly with the weighted common-length cyclic sectors.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
-	records the next comparison step: if those common-length sector blocks are
+	gives the next comparison step: if those common-length sector blocks are
 	injective and the BNT proportional-decomposition comparison supplies the
 	blockwise permutation, bond-dimension equalities, and gauge phases, then the
 	finite-length span equality follows through the common phase-cover theorem.

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -9,7 +9,7 @@
 
 This chapter develops the periodic equal-case Fundamental Theorem of MPS
 (Theorem~\ref{thm:periodic_ft}) following
-\cite{DeLasCuevas2017Irreducible}, and records its two applications:
+\cite{DeLasCuevas2017Irreducible}, and gives its two applications:
 the symmetry corollary lifting a physical on-site symmetry of a tensor
 in irreducible form to a virtual $Z$-gauge, and the equivalence between
 $p$-refinability of the matrix-product-vector family and
@@ -369,7 +369,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
 
 \begin{theorem}[Periodic Fundamental Theorem]\notready
     \label{thm:periodic_ft}
-    \lean{MPSTensor.zgauge_construction, MPSTensor.equalCase_zgauge_pipeline,
+    \lean{MPSTensor.zgauge_construction, MPSTensor.equalCase_zgauge_of_power_sums,
           MPSTensor.fundamentalTheorem_periodic_equalCase_matching,
           MPSTensor.fundamentalTheorem_periodic_equalCase}
     \uses{def:irreducible_form, def:z_gauge_equiv}


### PR DESCRIPTION
## Summary

- Rename process-flavoured public declarations to mathematical names in the canonical-form, cyclic-sector, MPDO fusion-isometry, and periodic Z-gauge developments.
- Update the blueprint references and prose so the mathematical text points to the new declarations directly.
- Remove reader-facing language such as “pipeline”, “endpoint”, “scaffold”, “bookkeeping”, “record”, and “live block” from the touched Lean and blueprint files.

This PR intentionally makes the rename in one step, without deprecated compatibility abbreviations for the old names.

Closes #1001.

## Validation

- `lake build TNLean.MPS.CanonicalForm.Existence`
- `lake build TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- `lake build TNLean.MPS.MPDO.FusionIsometries`
- `lake build TNLean.MPS.Periodic.FundamentalTheorem`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

The full build still reports pre-existing warnings from unrelated files: existing `sorry` declarations in several periodic-overlap, parent-Hamiltonian, fixed-point, and PEPS modules, and existing line-length warnings in `CyclicSectorDecomposition.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily mechanical renames and doc/prose updates; main risk is broken downstream references/imports rather than behavioral changes.
> 
> **Overview**
> Renames a set of reader-facing Lean declarations across the canonical-form reduction to use mathematical terminology (e.g. **“live blocks” → “nonzero blocks”**, **“oneShotReindexedBlock” → `commonReindexedBlock`**, and **“bookkeeping” → “identity”**), and updates downstream theorems/lemmas to reference the new names.
> 
> Similarly renames a provisional MPDO fusion-isometry predicate to `IsRFP_MPDO_via_fusionIsometries_provisional`, renames the periodic Z-gauge assembly lemma to `equalCase_zgauge_of_power_sums`, and updates the blueprint LaTeX to point at the new declarations and match the revised prose (removing pipeline/scaffold/endpoint-style wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3522c9384b8d3694939576b610d55ad89e90b11e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->