### PR TITLE
fix(MPS/MPDO): align padding theorem names

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -340,7 +340,7 @@ identity padding give full product-word span.
 This is the Route B homogenization: the cumulative finite cutoff can be
 used once each ordered pair has simultaneous identity padding at the lengths
 needed to reach a common homogeneous target `T`. -/
-theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding
+theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) {S T : ℕ}
     (hST : S ≤ T)
@@ -352,7 +352,7 @@ theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_ide
     WordTupleSpanTop A (1 + (r - 1) * T) :=
   wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF
     (fun k j hjk =>
-      pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identityPadding
+      pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
         (A k) (A j) hST (hSep k j hjk) (hPad k j hjk))
 
 /-- Positive-length product-word span obtained from canonical-form/BNT data and
@@ -385,10 +385,10 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingA
   simpa [WordTupleSpanTop, wordTuple] using
     wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hSep
 
-set_option linter.style.longLine false in
 /-- Positive-length product-word span from cumulative pair trace separation plus
 exact identity padding. -/
-theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding
+theorem
+    exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) {S T : ℕ}
     (hST : S ≤ T)
@@ -404,7 +404,7 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingU
         ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
   refine ⟨1 + (r - 1) * T, Nat.add_pos_left Nat.zero_lt_one _, ?_⟩
   simpa [WordTupleSpanTop, wordTuple] using
-    wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding
+    wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding
       μ A hCF hST hSep hPad
 
 /-- Positive-length product-word span obtained from canonical-form/BNT data and

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -752,7 +752,7 @@ theorem pair_mul_mem_span_pairWordTuple_add {D₁ D₂ : ℕ}
 is available at every padding length needed to reach the target length.
 
 The padding hypothesis is the Burnside-Jacobson input deferred to a later step. -/
-theorem pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identityPadding
+theorem pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding
     {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S T : ℕ}
     (hST : S ≤ T)
     (hCum : PairCumulativeWordTupleSpanTop A B S)
@@ -792,8 +792,8 @@ theorem pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identityPaddin
   simpa [hprod] using hmul
 
 /-- Trace-separation version of
-`pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identityPadding`. -/
-theorem pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identityPadding
+`pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding`. -/
+theorem pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
     {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S T : ℕ}
     (hST : S ≤ T)
     (hSep : PairTraceSeparatingUpTo A B S)
@@ -802,7 +802,7 @@ theorem pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identityPadding
         Submodule.span ℂ (Set.range (pairWordTuple A B (T - l)))) :
     PairTraceSeparatingAt A B T :=
   pairTraceSeparatingAt_of_pairWordTupleSpanTop A B
-    (pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identityPadding
+    (pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding
       A B hST (pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo A B hSep) hPad)
 
 /-- Pair product-span at length `S` gives a length-`S` selector for the first

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2952,8 +2952,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \label{lem:pair_trace_separation_homogenization_with_padding}
     \lean{MPSTensor.pairEvalWordTuple_mem_span_pairWordTuple_length}
     \lean{MPSTensor.pair_mul_mem_span_pairWordTuple_add}
-    \lean{MPSTensor.pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identityPadding}
-    \lean{MPSTensor.pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identityPadding}
+    \lean{MPSTensor.pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding}
+    \lean{MPSTensor.pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding}
     \leanok
     \uses{def:pair_trace_separation_words, lem:all_length_pair_trace_separation_finite_cutoff}
     Suppose $S\le T$ and pair words of length at most $S$ span the product
@@ -3040,8 +3040,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
-    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identityPadding}
+    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}
     \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords}
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords}


### PR DESCRIPTION
### Motivation

PR #979 merged with theorem names using `identityPadding` as a non-declaration phrase. Per `docs/naming.md` / mathlib naming rules, theorem names should keep ordinary phrase components in snake case.

### Description

- Rename the fresh identity-padding theorem suffixes from `_identityPadding` to `_identity_padding`.
- Update downstream references in `BlockDiagonalCommutant.lean` and Chapter 14 blueprint `\lean{...}` tags.
- Remove the local long-line linter escape by splitting the long theorem header.

### Testing

- `/Users/siruilu/.elan/bin/lake build TNLean.MPS.MPDO.BiCFDerivation`
- `/Users/siruilu/.elan/bin/lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `git diff --check -- TNLean/MPS/MPDO/BiCFDerivation.lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean blueprint/src/chapter/ch14_parent_hamiltonian.tex`

---
Follow-up to #979

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely mechanical renaming and reference updates; behavior and proofs are unchanged aside from potential breakage if any external downstream code still depends on the old theorem names.
> 
> **Overview**
> Renames the homogenization/trace-separation theorems suffixed with `identityPadding` to `identity_padding` (notably in `MPDO/BiCFDerivation.lean`) to comply with naming conventions.
> 
> Updates all call sites in `CanonicalForm/BlockDiagonalCommutant.lean` and corresponding Chapter 14 blueprint `\\lean{...}` references, and removes a local long-line linter escape by splitting a long theorem header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1f6d4b365d8711f116e32d22e6bbb929fc6dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->