### PR TITLE
docs(style): document mathematical rename policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Detailed conventions live in `docs/`. Read the relevant file before working in t
 
 | File | Covers |
 |------|--------|
-| [`docs/style.md`](docs/style.md) | Code formatting, line length (100 chars), declarations, tactic style, whitespace, transparency |
+| [`docs/style.md`](docs/style.md) | Code formatting, line length (100 chars), declarations, tactic style, whitespace, transparency, deprecation, mathematical-language renames |
 | [`docs/naming.md`](docs/naming.md) | Capitalization rules, symbol-to-name dictionary, variable conventions |
 | [`docs/doc.md`](docs/doc.md) | Module docstrings, definition docstrings, sectioning comments, BibTeX citations |
 | [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) | PR title format (`type(scope): description`), issue conventions, label taxonomy, review checklist |
@@ -96,6 +96,7 @@ Detailed conventions live in `docs/`. Read the relevant file before working in t
 - **Proof integrity blockers**: `sorry`, `admit`, `native_decide`, `unsafeCast`, `axiom`, circular reasoning
 - **Blueprint prose**: Pure mathematics only — no Lean identifiers in text, no software jargon (see banned terms list in blueprint style guide)
 - **Paper references**: Cite theorem numbers in docstrings (e.g., "Wolf Thm 6.3", "arXiv:1606.00608 Appendix A")
+- **Mathematical renames**: When renaming a declaration whose old name encodes misleading terminology (banned vocabulary in `docs/prose_style.md` §2), skip the `@[deprecated] alias` and state the reason in the PR body (see `docs/style.md` §Mathematical-language renames).
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,10 @@ Detailed conventions live in `docs/`. Read the relevant file before working in t
 
 | File | Covers |
 |------|--------|
-| [`docs/style.md`](docs/style.md) | Code formatting, line length (100 chars), declarations, tactic style, whitespace, transparency, deprecation, mathematical-language renames |
+| [`docs/style.md`](docs/style.md) | Code formatting, line length (100 chars), declarations, tactic style, whitespace, transparency, deprecation |
 | [`docs/naming.md`](docs/naming.md) | Capitalization rules, symbol-to-name dictionary, variable conventions |
 | [`docs/doc.md`](docs/doc.md) | Module docstrings, definition docstrings, sectioning comments, BibTeX citations |
-| [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) | PR title format (`type(scope): description`), issue conventions, label taxonomy, review checklist |
+| [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) | PR title format (`type(scope): description`), issue conventions, label taxonomy, review checklist, mathematical-language renames |
 | [`docs/pr-review.md`](docs/pr-review.md) | Review criteria: style, documentation, location, improvements, library integration |
 | [`docs/pr_review_management.md`](docs/pr_review_management.md) | PR triage process, comment API mapping, merge decisions |
 | [`docs/PROOF_INTEGRITY.md`](docs/PROOF_INTEGRITY.md) | Blockers (`sorry`, `axiom`, kernel bypasses, circular reasoning) and warnings (`maxHeartbeats`, debug artifacts) |
@@ -96,7 +96,7 @@ Detailed conventions live in `docs/`. Read the relevant file before working in t
 - **Proof integrity blockers**: `sorry`, `admit`, `native_decide`, `unsafeCast`, `axiom`, circular reasoning
 - **Blueprint prose**: Pure mathematics only — no Lean identifiers in text, no software jargon (see banned terms list in blueprint style guide)
 - **Paper references**: Cite theorem numbers in docstrings (e.g., "Wolf Thm 6.3", "arXiv:1606.00608 Appendix A")
-- **Mathematical renames**: When renaming a declaration whose old name encodes misleading terminology (banned vocabulary in `docs/prose_style.md` §2), skip the `@[deprecated] alias` and state the reason in the PR body (see `docs/style.md` §Mathematical-language renames).
+- **Mathematical renames**: When renaming a declaration whose old name encodes misleading terminology (banned vocabulary in `docs/prose_style.md` §2), skip the `@[deprecated] alias` and state the reason in the PR body (see `docs/CONTRIBUTING.md` §Mathematical-language renames).
 
 ## Workflow
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -47,6 +47,10 @@ Every PR body must contain three sections:
 - Use bullet points.
 - State the mathematical content precisely enough for a reader who has not read
   the issue thread.
+- When renaming a public declaration and intentionally omitting a `@[deprecated]
+  alias` because the old name encodes misleading terminology, explicitly note:
+  `No compatibility alias is provided — the old name encodes [term] (see
+  docs/style.md §Mathematical-language renames).`
 
 ### Testing
 - What was verified and how.
@@ -241,7 +245,9 @@ Every PR touching Lean code should be reviewed against these criteria:
 
 2. **Mathlib style** -- Follow the naming conventions in [naming.md](naming.md)
    and documentation standards in [doc.md](doc.md). See [pr-review.md](pr-review.md)
-   for the full Mathlib review guide.
+   for the full Mathlib review guide. For renames that intentionally omit
+   deprecated aliases under the mathematical-language exception, confirm the
+   PR body states the reason (see [style.md §Mathematical-language renames](style.md#mathematical-language-renames)).
 
 3. **Type safety** -- No universe mismatches, coercion problems, or unresolved
    metavariables.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -47,10 +47,10 @@ Every PR body must contain three sections:
 - Use bullet points.
 - State the mathematical content precisely enough for a reader who has not read
   the issue thread.
-- When renaming a public declaration and intentionally omitting a `@[deprecated]
-  alias` because the old name encodes misleading terminology, explicitly note:
-  `No compatibility alias is provided — the old name encodes [term] (see
-  docs/style.md §Mathematical-language renames).`
+- When renaming a public declaration and intentionally omitting a
+  `@[deprecated] alias` because the old name encodes misleading terminology,
+  explicitly note: `No compatibility alias is provided — the old name encodes
+  [term] (see docs/style.md §Mathematical-language renames).`
 
 ### Testing
 - What was verified and how.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Every PR body must contain three sections:
 - When renaming a public declaration and intentionally omitting a
   `@[deprecated] alias` because the old name encodes misleading terminology,
   explicitly note: `No compatibility alias is provided — the old name encodes
-  [term] (see docs/style.md §Mathematical-language renames).`
+  [term] (see docs/CONTRIBUTING.md §Mathematical-language renames).`
 
 ### Testing
 - What was verified and how.
@@ -247,7 +247,7 @@ Every PR touching Lean code should be reviewed against these criteria:
    and documentation standards in [doc.md](doc.md). See [pr-review.md](pr-review.md)
    for the full Mathlib review guide. For renames that intentionally omit
    deprecated aliases under the mathematical-language exception, confirm the
-   PR body states the reason (see [style.md §Mathematical-language renames](style.md#mathematical-language-renames)).
+   PR body states the reason (see [CONTRIBUTING.md §Mathematical-language renames](#mathematical-language-renames)).
 
 3. **Type safety** -- No universe mismatches, coercion problems, or unresolved
    metavariables.
@@ -316,6 +316,60 @@ this project specifically:
 - `E` for transfer matrices / quantum channels
 - `d` for physical dimension, `D` for bond dimension
 - `N`, `L` for chain length
+
+### Mathematical-language renames
+
+The standard Mathlib deprecation convention says renamed declarations should keep
+a `@[deprecated] alias`.  When the **old name encodes misleading terminology** —
+process jargon, project-internal shorthand, or non-mathematical phrasing — a clean
+one-step rename without a deprecated alias is preferred.
+
+#### When to skip a deprecated alias
+
+Skip the alias when the old name contains a term that appears in, or is a
+contextual variant of, the banned-vocabulary list in
+[`docs/prose_style.md` §2](prose_style.md#2-banned-software-engineering-terms--replacements).
+Apply context-qualified bans only in the stated context: for example, "Assembly"
+is banned as a section or chapter title, but not when it is part of a standard
+mathematical phrase.
+
+Examples of terms that make an alias inappropriate in declaration names:
+
+- exact entries or variants of process/software metaphors from the prose guide:
+  `pipeline`, `package`, `scaffolding`/`scaffold`, `workflow`, `plumbing`,
+  `boilerplate`, `glueLayer`, `reexport`
+- additional project-internal cleanup terms with the same non-mathematical force:
+  `raw`, `helper`, `wrapper`, `endpoint` when it means a proof milestone rather
+  than a boundary point
+- project-internal shorthand: `liveBlock`, `oneShot`, `deadProof`, `sourceAnchor`
+- AI/LLM vocabulary in declaration names
+
+Keep the `@[deprecated] alias` when the old name uses genuine mathematical language that
+is merely imprecise or outdated (e.g., `transferMap` → `transferMatrix` when the object is
+a matrix) — the old name is not misleading, just suboptimal.
+
+#### What PRs must state
+
+When a rename skips a deprecated alias under this exception, the PR body must explicitly say:
+
+> **No compatibility alias is provided.** The old name encodes [misleading term]
+> (see [`docs/CONTRIBUTING.md` §Mathematical-language renames](CONTRIBUTING.md#mathematical-language-renames)).
+
+This makes the exception visible to reviewers and prevents downstream users from
+wondering whether the omission was an oversight.
+
+#### Blueprint references
+
+In the same PR, update every `\lean{OldName}` tag in `blueprint/src/` to
+`\lean{NewName}`.  Run `leanblueprint checkdecls` to confirm no stale references
+remain.
+
+#### Migration within the project
+
+Before deleting or renaming, search the project for call sites of the old name
+(`rg -n "oldName" TNLean/`) and update them in the same PR.  If the old name
+appears in a module docstring or comment, rewrite the surrounding prose to use
+the new mathematical name.
 
 ---
 

--- a/docs/style.md
+++ b/docs/style.md
@@ -752,60 +752,6 @@ In this case, no deprecation attribute is required for X, but it is for W.
 
 Named instances do not require deprecations. Deprecated declarations can be deleted after 6 months.
 
-### Mathematical-language renames
-
-The standard deprecation convention ([Deprecation](#deprecation)) says renamed declarations should keep
-a `@[deprecated] alias`.  When the **old name encodes misleading terminology** —
-process jargon, project-internal shorthand, or non-mathematical phrasing — a clean
-one-step rename without a deprecated alias is preferred.
-
-#### When to skip a deprecated alias
-
-Skip the alias when the old name contains a term that appears in, or is a
-contextual variant of, the banned-vocabulary list in
-[`docs/prose_style.md` §2](prose_style.md#2-banned-software-engineering-terms--replacements).
-Apply context-qualified bans only in the stated context: for example, "Assembly"
-is banned as a section or chapter title, but not when it is part of a standard
-mathematical phrase.
-
-Examples of terms that make an alias inappropriate in declaration names:
-
-- exact entries or variants of process/software metaphors from the prose guide:
-  `pipeline`, `package`, `scaffolding`/`scaffold`, `workflow`, `plumbing`,
-  `boilerplate`, `glueLayer`, `reexport`
-- additional project-internal cleanup terms with the same non-mathematical force:
-  `raw`, `helper`, `wrapper`, `endpoint` when it means a proof milestone rather
-  than a boundary point
-- project-internal shorthand: `liveBlock`, `oneShot`, `deadProof`, `sourceAnchor`
-- AI/LLM vocabulary in declaration names
-
-Keep the `@[deprecated] alias` when the old name uses genuine mathematical language that
-is merely imprecise or outdated (e.g., `transferMap` → `transferMatrix` when the object is
-a matrix) — the old name is not misleading, just suboptimal.
-
-#### What PRs must state
-
-When a rename skips a deprecated alias under this exception, the PR body must explicitly say:
-
-> **No compatibility alias is provided.** The old name encodes [misleading term]
-> (see [`docs/style.md` §Mathematical-language renames](style.md#mathematical-language-renames)).
-
-This makes the exception visible to reviewers and prevents downstream users from
-wondering whether the omission was an oversight.
-
-#### Blueprint references
-
-In the same PR, update every `\lean{OldName}` tag in `blueprint/src/` to
-`\lean{NewName}`.  Run `leanblueprint checkdecls` to confirm no stale references
-remain.
-
-#### Migration within the project
-
-Before deleting or renaming, search the project for call sites of the old name
-(`rg -n "oldName" TNLean/`) and update them in the same PR.  If the old name
-appears in a module docstring or comment, rewrite the surrounding prose to use
-the new mathematical name.
-
 ### Avoid `nonrec`
 
 The `nonrec` keyword tells Lean to assume that apparently recursive calls in the declaration body

--- a/docs/style.md
+++ b/docs/style.md
@@ -752,6 +752,50 @@ In this case, no deprecation attribute is required for X, but it is for W.
 
 Named instances do not require deprecations. Deprecated declarations can be deleted after 6 months.
 
+### Mathematical-language renames
+
+The standard deprecation convention (§Deprecation) says renamed declarations should keep
+a `@[deprecated] alias`.  When the **old name encodes misleading terminology** —
+process jargon, project-internal shorthand, or non-mathematical phrasing — a clean
+one-step rename without a deprecated alias is preferred.
+
+#### When to skip a deprecated alias
+
+Skip the alias when the old name contains a term that appears in the banned-vocabulary
+list in [`docs/prose_style.md` §2](prose_style.md#2-banned-software-engineering-terms--replacements).
+Examples of terms that make an alias inappropriate:
+
+- process/software metaphors: `pipeline`, `wrapper`, `package`, `raw`, `scaffold`, `bookkeeping`, `helper`, `endpoint`
+- project-internal shorthand: `liveBlock`, `oneShot`, `deadProof`, `sourceAnchor`
+- AI/LLM vocabulary in declaration names
+
+Keep the `@[deprecated] alias` when the old name uses genuine mathematical language that
+is merely imprecise or outdated (e.g., `transferMap` → `transferMatrix` when the object is
+a matrix) — the old name is not misleading, just suboptimal.
+
+#### What PRs must state
+
+When a rename skips a deprecated alias under this exception, the PR body must explicitly say:
+
+> **No compatibility alias is provided.** The old name encodes [misleading term]
+> (see [`docs/style.md` §Mathematical-language renames](style.md#mathematical-language-renames)).
+
+This makes the exception visible to reviewers and prevents downstream users from
+wondering whether the omission was an oversight.
+
+#### Blueprint references
+
+In the same PR, update every `\lean{OldName}` tag in `blueprint/src/` to
+`\lean{NewName}`.  Run `leanblueprint checkdecls` to confirm no stale references
+remain.
+
+#### Migration within the project
+
+Before deleting or renaming, search the project for call sites of the old name
+(`rg -n "oldName" TNLean/`) and update them in the same PR.  If the old name
+appears in a module docstring or comment, rewrite the surrounding prose to use
+the new mathematical name.
+
 ### Avoid `nonrec`
 
 The `nonrec` keyword tells Lean to assume that apparently recursive calls in the declaration body

--- a/docs/style.md
+++ b/docs/style.md
@@ -754,18 +754,28 @@ Named instances do not require deprecations. Deprecated declarations can be dele
 
 ### Mathematical-language renames
 
-The standard deprecation convention (§Deprecation) says renamed declarations should keep
+The standard deprecation convention ([Deprecation](#deprecation)) says renamed declarations should keep
 a `@[deprecated] alias`.  When the **old name encodes misleading terminology** —
 process jargon, project-internal shorthand, or non-mathematical phrasing — a clean
 one-step rename without a deprecated alias is preferred.
 
 #### When to skip a deprecated alias
 
-Skip the alias when the old name contains a term that appears in the banned-vocabulary
-list in [`docs/prose_style.md` §2](prose_style.md#2-banned-software-engineering-terms--replacements).
-Examples of terms that make an alias inappropriate:
+Skip the alias when the old name contains a term that appears in, or is a
+contextual variant of, the banned-vocabulary list in
+[`docs/prose_style.md` §2](prose_style.md#2-banned-software-engineering-terms--replacements).
+Apply context-qualified bans only in the stated context: for example, "Assembly"
+is banned as a section or chapter title, but not when it is part of a standard
+mathematical phrase.
 
-- process/software metaphors: `pipeline`, `wrapper`, `package`, `raw`, `scaffold`, `bookkeeping`, `helper`, `endpoint`
+Examples of terms that make an alias inappropriate in declaration names:
+
+- exact entries or variants of process/software metaphors from the prose guide:
+  `pipeline`, `package`, `scaffolding`/`scaffold`, `workflow`, `plumbing`,
+  `boilerplate`, `glueLayer`, `reexport`
+- additional project-internal cleanup terms with the same non-mathematical force:
+  `raw`, `helper`, `wrapper`, `endpoint` when it means a proof milestone rather
+  than a boundary point
 - project-internal shorthand: `liveBlock`, `oneShot`, `deadProof`, `sourceAnchor`
 - AI/LLM vocabulary in declaration names
 


### PR DESCRIPTION
## Summary

- Documents when mathematical-language renames may omit a deprecated alias because the old public name encodes misleading terminology.
- Adds the matching PR-body convention for such one-step renames.
- Points the repository guidance index at the new policy.

Closes #1025.

## Testing

- `git diff --check`
- Documentation-only change; no Lean build required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that clarify when renames may omit `@[deprecated]` aliases and require explicit PR-body justification, with no impact on Lean code or runtime behavior.
> 
> **Overview**
> Documents a new **mathematical-language rename** exception to Mathlib’s usual `@[deprecated] alias` practice: if an old public name uses misleading, non-mathematical or banned-vocabulary terminology, renames should be done as a clean break without a compatibility alias.
> 
> Updates `docs/CONTRIBUTING.md` to require PR bodies (and reviewer checklist) to explicitly state when an alias is intentionally omitted, and updates `CLAUDE.md` to index this policy in the repo’s guidance quick reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30d0a45f06e8400db92b5fd4c941c6ec2df4c54e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->