### PR TITLE
docs: replace process wording (records) with direct mathematical language in PEPS prose (#1023)

### DIFF
--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -5,7 +5,7 @@ import Mathlib.Logic.Equiv.Prod
 /-!
 # Edge-centered decompositions for PEPS local data
 
-This file records two elementary decompositions that recur in the PEPS
+This file provides two elementary decompositions that recur in the PEPS
 Fundamental-Theorem argument.
 
 First, if one incident edge at a vertex is singled out, then local virtual

--- a/TNLean/PEPS/Defs.lean
+++ b/TNLean/PEPS/Defs.lean
@@ -3,11 +3,11 @@ import Mathlib.Data.Complex.BigOperators
 import Mathlib.LinearAlgebra.LinearIndependent.Defs
 
 /-!
-# Exploratory PEPS definitions on finite simple graphs
+# PEPS definitions on finite simple graphs
 
-This file introduces a lightweight PEPS scaffold on a finite graph.
-The index types (`Edge`, `IncidentEdge`, `VirtualConfig`) are lightweight
-wrappers used for PEPS indexing.
+This file introduces the finite-graph PEPS tensor objects.
+The index types (`Edge`, `IncidentEdge`, `VirtualConfig`) are the combinatorial
+index sets for PEPS tensors on a finite simple graph.
 
 ## Design note on decidability
 

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -3,24 +3,24 @@ import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
--- This is a **scaffold** file: the forward direction and contraction algebra
--- are formalized, while the converse PEPS fundamental theorem remains as
--- `sorry` placeholders marking proof obligations for future PRs (see #128).
+-- The forward direction and contraction algebra are formalized, while the
+-- converse PEPS fundamental theorem remains as `sorry` placeholders marking
+-- proof obligations for future PRs (see #128).
 --
 -- Provability note: `IsVertexInjective` in `PEPS.Defs` is the
 -- linear-independence formulation `∀ v, LinearIndependent ℂ (A.component v)`
 -- (see issue #633 for the switch away from function-level injectivity, which
 -- is strictly weaker). Linear independence gives each vertex tensor a left
 -- inverse on its image, removes the old definitional blocker, and is the
--- correct hypothesis for the repaired uniqueness endpoint
+-- correct hypothesis for the repaired uniqueness statement
 -- `gauge_unique_mod_edge_scalars`.
 --
 -- The remaining `sorry`s split into three independently tracked groups:
 -- * `gaugeConsistency` (issue #820) still requires the full edge-centred
 --   reduction from arXiv:1804.04964 §3. The local left inverse and the
---   elementary blocking data now live in `PEPS/VirtualInsertion` and
+--   elementary blocking data are developed in `PEPS/VirtualInsertion` and
 --   `PEPS/Blocking`, and `localGauge_exists` has been reduced to the sharper
---   local hypothesis `HasLocalGaugeLift`. The wrapper `BlockedMiddleGaugeHyp`
+--   local hypothesis `HasLocalGaugeLift`. The abbreviation `BlockedMiddleGaugeHyp`
 --   isolates the exact remaining step: build the blocked middle tensor,
 --   compare it with the 3-site MPS theorem, and derive that explicit local
 --   gauge formula from `SameState`.
@@ -30,14 +30,14 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 --   Its derivation from `SameState` plus vertex injectivity still needs a
 --   boundary-insertion / blocking lemma.
 -- * `gauge_unique_mod_edge_scalars` (issue #842) is the repaired uniqueness
---   endpoint, but its proof still needs the same blocking infrastructure
+--   statement, but its proof still needs the same blocking infrastructure
 --   together with a local tensor-factor uniqueness lemma for the balanced
 --   edge-scalar quotient.
 
 /-!
-# Fundamental Theorem for injective PEPS (scaffold)
+# Fundamental Theorem for injective PEPS
 
-This file scaffolds the Fundamental Theorem for injective PEPS on simple graphs
+This file develops the Fundamental Theorem for injective PEPS on simple graphs
 (arXiv:1804.04964, Theorem 2, Section 3):
 
 > Two injective PEPS defined on a graph (no double edges/self-loops) generate
@@ -500,7 +500,7 @@ noncomputable def localTensorEval (A : Tensor G d) (v : V)
 /-- Under the sharper local hypothesis `HasLocalGaugeLift`, one obtains a
 factorized local gauge relation at `v`.
 
-The local left inverse and the canonical candidate operator now live in
+The local left inverse and the canonical candidate operator are defined in
 `PEPS/LocalGauge`. The remaining PEPS-Fundamental-Theorem gap is to prove
 `BlockedMiddleGaugeHyp` from `SameState` via the blocked-middle / three-site-MPS
 reduction, then convert it to `HasLocalGaugeLift` by

--- a/TNLean/PEPS/LocalGauge.lean
+++ b/TNLean/PEPS/LocalGauge.lean
@@ -17,10 +17,10 @@ be shown to
    `B` lies in the image of `localTensorMap A v`, and
 2. factor into independent edge gauges.
 
-We record those two requirements as `HasLocalGaugeLift`. This isolates the exact
+We capture those two requirements as `HasLocalGaugeLift`. This isolates the exact
 output still needed from the blocked-middle / three-site-MPS reduction in
-arXiv:1804.04964 §3, and `hasLocalGaugeLift_of_localGaugeFormula` records the
-final bookkeeping step that turns an explicit local gauge formula into that
+arXiv:1804.04964 §3, and `hasLocalGaugeLift_of_localGaugeFormula` is the final
+conversion that turns an explicit local gauge formula into that
 sharper datum.
 -/
 
@@ -122,7 +122,7 @@ theorem localGaugeCandidate_apply_single (A B : Tensor G d)
 
 /-- Sharper local hypothesis for PEPS gauge extraction.
 
-This records exactly the two local outputs still needed from the blocked-middle
+This states exactly the two local conclusions still needed from the blocked-middle
 reduction in arXiv:1804.04964 §3:
 
 1. the local components of `B` lie in the image of `localTensorMap A v`, and

--- a/TNLean/PEPS/LocalGauge.lean
+++ b/TNLean/PEPS/LocalGauge.lean
@@ -145,7 +145,7 @@ structure HasLocalGaugeLift (A B : Tensor G d) (hA : IsVertexInjective A)
 /-- Any explicit edgewise local gauge formula at `v` yields the sharper datum
 `HasLocalGaugeLift`.
 
-This is the final bookkeeping step after the blocked-middle / three-site-MPS
+This is the final algebraic conversion after the blocked-middle / three-site-MPS
 reduction: once that reduction produces invertible incident-edge gauges
 realizing the local tensors of `B`, the canonical candidate pulled back through
 `localLeftInverse` is forced to be the same factorized operator. -/

--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -11,7 +11,7 @@ For a PEPS tensor `A` and a vertex `v`, the family
 virtual configurations into the physical space `Fin d → ℂ`. Under
 `IsVertexInjective A`, this map is injective, hence admits a left inverse.
 
-This file records that left inverse and the induced realization of virtual
+This file constructs that left inverse and the induced realization of virtual
 endomorphisms as physical linear maps on the local physical space.
 
 ## Main results

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -281,7 +281,7 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \leanok
     \uses{def:peps_localTensorMap, def:peps_localLeftInverse}
     For fixed $A$, $B$, a bond-dimension equality, and a vertex $v$, this
-    records the two local conclusions still needed from the blocked-middle
+    states the two local conclusions still needed from the blocked-middle
     reduction in~\cite{Molnar2018NormalPEPS}, §3:
     (i) each local component of $B$ lies in the image of the local tensor map
     of $A$, and (ii) the canonical pullback through the chosen left inverse of


### PR DESCRIPTION
## Summary

Continues and completes the #1023 PEPS mathematical-language cleanup.

### Changes

**New prose-only replacements (4 occurrences):**
- `TNLean/PEPS/Blocking.lean`: `records` → `provides`
- `TNLean/PEPS/VirtualInsertion.lean`: `records` → `constructs`
- `blueprint/src/chapter/ch13a_peps_ft.tex`: `records` → `states`
- `TNLean/PEPS/LocalGauge.lean`: `bookkeeping` → `algebraic conversion` (review fix)

**Existing edits from this branch (carried forward):**
- `TNLean/PEPS/Defs.lean`: replaced `scaffold` → `tensor objects`, `wrappers` → `index sets`, removed "Exploratory"
- `TNLean/PEPS/FundamentalTheorem.lean`: replaced `scaffold`/`scaffolds`, `live`/`endpoint`, `now live` phrasing
- `TNLean/PEPS/LocalGauge.lean`: replaced `record` → `capture`, `records` → `states`

### Validation
- `git diff --check` passes
- All `endpoint` references remaining in edited files are genuine graph/edge endpoint terminology
- `grep` confirms zero remaining `scaffold`/`wrapper`/`bookkeeping`/`records` in all touched `.lean` files and the blueprint chapter
- Lean diagnostics report zero errors in all touched `.lean` files

### CI Note
All 5 CI failures are due to GitHub Actions billing limit (`spending limit needs to be increased`) — a pre-existing repository infrastructure issue, not related to code changes.

### Related
- Closes #1023