### PR TITLE
docs(MPS): describe blocking constructions mathematically

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -12,7 +12,7 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 This file contains the after-blocking sector-comparison consequences that use a BNT
 proportional-decomposition comparison of the nonzero-weight block families.  They are separated
 from `StructuralTheorem` so the structural reduction file remains focused on common blocking and
-zero-tail bookkeeping.
+zero-tail equations.
 
 ## Main statements
 
@@ -20,7 +20,7 @@ zero-tail bookkeeping.
   nonzero part decompositions plus BNT proportional-decomposition data imply the sector-weight
   comparison.
 * `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion` —
-  the same comparison with explicit zero-tail bookkeeping.
+  the same comparison with an explicit length-zero zero-tail equation.
 
 ## References
 

--- a/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
@@ -61,7 +61,7 @@ variable {d D : ℕ}
 
 /-! ## Zero-tail and weight transport through blocking -/
 
-/-- Reblocking preserves a zero-tail/live MPV decomposition.
+/-- Reblocking preserves an explicit zero-tail equation for the nonzero tensor.
 
 The positive-period hypothesis is exactly what keeps the zero-tail contribution
 confined to length zero after blocking: a blocked chain of positive length expands

--- a/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
@@ -61,7 +61,7 @@ variable {d D : ℕ}
 
 /-! ## Zero-tail and weight transport through blocking -/
 
-/-- Reblocking preserves an explicit zero-tail equation for the nonzero tensor.
+/-- Reblocking preserves an explicit zero-tail equation for the live tensor.
 
 The positive-period hypothesis is exactly what keeps the zero-tail contribution
 confined to length zero after blocking: a blocked chain of positive length expands

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -191,7 +191,7 @@ theorem sameMPV₂Pos_blockTensor
     _ = mpv (blockTensor (d := d) (D := D₂) B p) σ :=
           (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) B p σ).symm
 
-/-- Positive-length equality of weighted live block tensors is preserved after
+/-- Positive-length equality of nonzero-weight block families is preserved after
 positive common blocking, with each weight transported to the corresponding power. -/
 theorem sameMPV₂Pos_toTensorFromBlocks_blockPower
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -279,7 +279,7 @@ dimensions leaves the tensors and their MPV/transfer-map properties unchanged.
 -/
 
 /-- The physical dimension of an iterated blocking is the physical dimension of
-one-shot blocking by the product length. -/
+direct blocking by the product length. -/
 theorem blockPhysDim_blockPhysDim (d m n : ℕ) :
     blockPhysDim (blockPhysDim d m) n = blockPhysDim d (m * n) := by
   simp [blockPhysDim_eq_pow, pow_mul]
@@ -301,7 +301,7 @@ theorem wordOfBlock_blockIndexOfList (d L : ℕ) (w : List (Fin d))
       (fun i : Fin L => w.get (Fin.cast h.symm i)))
   simpa [Function.comp, Fin.cast_cast, blockPhysDim] using hcongr
 
-/-- The physical index of the one-shot block obtained from an iterated blocked index. -/
+/-- The physical index of the direct block obtained from an iterated blocked index. -/
 noncomputable def iteratedBlockIndex (d m n : ℕ)
     (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
     Fin (blockPhysDim d (m * n)) :=
@@ -310,7 +310,7 @@ noncomputable def iteratedBlockIndex (d m n : ℕ)
     rw [length_flattenBlockedWord, length_wordOfBlock, Nat.mul_comm]
   blockIndexOfList d (m * n) w hw
 
-/-- The one-shot word associated to an iterated blocked index is the flattened word. -/
+/-- The flattened physical word associated to an iterated blocked index is the flattened word. -/
 theorem wordOfBlock_iteratedBlockIndex (d m n : ℕ)
     (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
     wordOfBlock d (m * n) (iteratedBlockIndex d m n i) =
@@ -325,7 +325,7 @@ noncomputable def reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂
     (A : MPSTensor d₂ D) : MPSTensor d₁ D :=
   fun i => A (f i)
 
-/-- Iterated physical blocking agrees with one-shot blocking after the canonical
+/-- Iterated physical blocking agrees with direct blocking after the canonical
 index relabeling from iterated blocks to flattened blocks. -/
 theorem blockTensor_blockTensor_apply {D : ℕ} (A : MPSTensor d D) (m n : ℕ)
     (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
@@ -334,7 +334,7 @@ theorem blockTensor_blockTensor_apply {D : ℕ} (A : MPSTensor d D) (m n : ℕ)
       blockTensor (d := d) (D := D) A (m * n) (iteratedBlockIndex d m n i) := by
   simp [blockTensor, evalWord_blockTensor, wordOfBlock_iteratedBlockIndex]
 
-/-- Tensor form of iterated blocking versus one-shot blocking with physical relabeling. -/
+/-- Tensor form of iterated blocking versus direct blocking with physical relabeling. -/
 theorem blockTensor_blockTensor_eq_reindex {D : ℕ} (A : MPSTensor d D) (m n : ℕ) :
     blockTensor (d := blockPhysDim d m) (D := D)
         (blockTensor (d := d) (D := D) A m) n =
@@ -343,7 +343,7 @@ theorem blockTensor_blockTensor_eq_reindex {D : ℕ} (A : MPSTensor d D) (m n : 
   funext i
   exact blockTensor_blockTensor_apply (d := d) A m n i
 
-/-- Iterated physical blocking and one-shot blocking have the same MPV family after
+/-- Iterated physical blocking and direct blocking have the same MPV family after
 the natural relabeling of physical indices. -/
 theorem sameMPV₂_blockTensor_blockTensor_mul_reindex {D : ℕ}
     (A : MPSTensor d D) (m n : ℕ) :

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -191,7 +191,7 @@ theorem sameMPV₂Pos_blockTensor
     _ = mpv (blockTensor (d := d) (D := D₂) B p) σ :=
           (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) B p σ).symm
 
-/-- Positive-length equality of nonzero-weight block families is preserved after
+/-- Positive-length equality of weighted block families is preserved after
 positive common blocking, with each weight transported to the corresponding power. -/
 theorem sameMPV₂Pos_toTensorFromBlocks_blockPower
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -310,7 +310,8 @@ noncomputable def iteratedBlockIndex (d m n : ℕ)
     rw [length_flattenBlockedWord, length_wordOfBlock, Nat.mul_comm]
   blockIndexOfList d (m * n) w hw
 
-/-- The flattened physical word associated to an iterated blocked index is the flattened word. -/
+/-- Decoding the direct-block index produced by `iteratedBlockIndex` yields the
+flattened word obtained from decoding the iterated blocked index. -/
 theorem wordOfBlock_iteratedBlockIndex (d m n : ℕ)
     (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
     wordOfBlock d (m * n) (iteratedBlockIndex d m n i) =

--- a/TNLean/MPS/Core/BlockingTransfer.lean
+++ b/TNLean/MPS/Core/BlockingTransfer.lean
@@ -87,7 +87,7 @@ theorem transferMap_blockTensor_fixedPoint
   -- Now rewrite the blocked transfer map as an iterate.
   simpa [transferMap_blockTensor_apply (A := A) (L := L) (X := X)] using hpow
 
-/-- Iterated physical blocking is compatible with one-shot blocking by the multiplied period,
+/-- Iterated physical blocking is compatible with direct blocking by the multiplied period,
 at the transfer-map level:
 `transferMap(block(block(A, m), n)) = transferMap(block(A, m * n))`. -/
 theorem transferMap_blockTensor_mul

--- a/TNLean/MPS/Irreducible/PeriodicBlocking.lean
+++ b/TNLean/MPS/Irreducible/PeriodicBlocking.lean
@@ -18,7 +18,7 @@ This module records lightweight definitions used by periodic-sector arguments:
 
 namespace MPSTensor
 
-/-! ## GCD blocking numerics (Lemma 2.5 bookkeeping) -/
+/-! ## GCD arithmetic for periodic-sector blocking (Lemma 2.5) -/
 
 /-- Number of periodic blocks after blocking period-`m` data by `p`: `gcd(m,p)`. -/
 def periodicBlockCount (m p : ℕ) : ℕ := Nat.gcd m p


### PR DESCRIPTION
## Summary

- Replaces blocking prose such as live-block, one-shot, and bookkeeping language with standard MPS terms.
- Describes iterated/direct blocking, zero-tail equations, and periodic-sector gcd arithmetic mathematically.

Closes #1022.

## Testing

- `lake build --old TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.Core.BlockingTransfer TNLean.MPS.Irreducible.PeriodicBlocking TNLean.MPS.CanonicalForm.Assembly.TPPrimitiveReduction TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `git diff --check`
- `rg -n "weighted live block|live MPV|zero-tail/live|one-shot|oneShot|GCD blocking numerics|bookkeeping|zero-tail bookkeeping" ...` (no matches in touched files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring/comment-only edits; no changes to definitions, theorems, or proofs, so behavior and soundness risk is minimal.
> 
> **Overview**
> Updates documentation/comments across the MPS blocking and canonical-form assembly modules to use more standard mathematical terminology.
> 
> In particular, rewrites prose around *iterated vs direct blocking*, *explicit length-zero zero-tail equations*, and *periodic-sector gcd arithmetic* (with no functional or proof changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a04baef18781a8d97faadb8b45a394e26c36ad21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->