### PR TITLE
docs(blueprint): replace note-taking language with mathematical descriptions (#1021)

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1,6 +1,6 @@
 %% ==================================================
 %% Chapter: Matrix Product Operators and Density Operators
-%% Introduces MPO and LPDO notation for the blueprint and records the
+%% Introduces MPO and LPDO notation for the blueprint and describes the
 %% correspondence between local MPO data and the associated MPS view.
 %% ==================================================
 
@@ -236,7 +236,7 @@ legs cyclically and taking the resulting trace.
     $A^{(i,k)} \in \MN{D'}$ for $i \in \{0,\ldots,d{-}1\}$ and
     $k \in \{0,\ldots,d_K{-}1\}$, the \emph{purifying MPS tensor} is the
     MPS tensor with physical dimension $d \cdot d_K$ and bond dimension $D'$
-    obtained by bundling the pair $(i,k)$ into a single index.
+    obtained by combining the pair $(i,k)$ into a single index.
 \end{definition}
 
 \begin{definition}[Purification RFP]\label{def:is_prfp}
@@ -288,7 +288,7 @@ legs cyclically and taking the resulting trace.
     \lean{MPOTensor.isRFP_iff_isZCL}
     \leanok
     \uses{def:is_rfp_mpdo, def:mpo_is_zcl}
-    The provisional MPDO renormalization fixed-point condition is equivalent to
+    The current MPDO renormalization fixed-point condition is equivalent to
     the zero-correlation-length condition for MPO tensors.
 \end{theorem}
 
@@ -303,7 +303,7 @@ legs cyclically and taking the resulting trace.
     \leanok
     \uses{def:is_rfp_mpdo, def:mpo_to_mps, def:is_rfp, def:mpo_is_zcl,
         thm:mpo_is_zcl_iff_to_mps_rfp}
-    The provisional MPDO RFP condition is equivalent to the pure-state RFP
+    The current MPDO RFP condition is equivalent to the pure-state RFP
     condition for the doubled-index MPS tensor.
 \end{theorem}
 
@@ -478,8 +478,8 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{def:mpdo_explicit_eta_operators}
     Every explicit neighboring $\eta$-family determines a sector-by-sector trace
-    matrix. We record both its complex-valued form and the real-part version,
-    which is the direct input for the real Perron--Frobenius matrix $T$ used
+    matrix. We give both its complex-valued form and the real-part version,
+    which is the direct data for the real Perron--Frobenius matrix $T$ used
     in the rank-one step.
 \end{definition}
 
@@ -571,7 +571,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{Matrix.HasRankOneFactorization}
     \lean{Matrix.PrimitiveTracePowersConstantImpliesRankOne}
     \leanok
-    The auxiliary predicates record three matrix-theoretic ingredients used in
+    The auxiliary predicates state three matrix-theoretic ingredients used in
     the rank-one step of Appendix~C.2, Lemma~C.4: constant traces of all
     positive powers, existence of a rank-one factorization $T = a b^\top$, and
     the conditional Perron--Frobenius implication from primitivity together with
@@ -579,7 +579,7 @@ strong subadditivity for a normalized three-site reduced state.
 
     This conditional implication is not a globally provable theorem. As a
     universal statement over primitive nonnegative matrices it is false; a
-    concrete $3 \times 3$ counterexample is recorded in the archive. The
+    concrete $3 \times 3$ counterexample appears in the archive. The
     corrected criterion proved here adds positive semidefiniteness and trace
     normalization, which provide the diagonalizability needed to turn the
     trace-power condition into a rank-one factorization.
@@ -635,7 +635,7 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{def:matrix_trace_rankone_predicates}
     Let $T$ be a finite real square matrix. Assume that $T$ is primitive,
     that $\tr(T) = 1$, and that every positive power of $T$ has the same trace
-    as $T$. If one further supplies the Perron--Frobenius input asserting that
+    as $T$. If one further supplies the Perron--Frobenius hypothesis that
     this particular primitive nonnegative matrix with constant trace powers is
     rank one, then
     \[
@@ -650,7 +650,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{proof}
     \leanok
     \uses{def:matrix_trace_rankone_predicates}
-    The Perron--Frobenius input gives the factorization $T = a b^\top$.
+    The Perron--Frobenius hypothesis gives the factorization $T = a b^\top$.
     Taking traces and using $\tr(a b^\top) = a \cdot b$ converts the
     normalization $\tr(T) = 1$ into $a \cdot b = 1$.
 \end{proof}
@@ -873,7 +873,7 @@ retract.
     map $E_n$.
 \end{definition}
 
-\begin{theorem}[Fusion-isometry data imply the provisional MPDO RFP condition]%
+\begin{theorem}[Fusion-isometry data imply the MPDO RFP condition]%
     \label{thm:mpdo_rfp_of_fusion}
     \lean{MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
     \leanok
@@ -914,7 +914,7 @@ This range-factorization gives the required fusion-isometry data.
 \end{corollary}
 \begin{proof}\leanok
 Combine Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} with the diagonal pure-state
-recovery theorem for the provisional MPO predicate.
+recovery theorem for the MPO predicate.
 \end{proof}
 
 \section{Algebra structure}
@@ -1284,7 +1284,7 @@ Theorem~\ref{thm:mpdo_is_gsnnch_iff_has_commuting_form}.
     \lean{MPOTensor.EtaLocalStructureData}
     \leanok
     \uses{def:mpdo_has_commuting_form}
-    This records the post-extraction output of Appendix~C.2: a single
+    This defines the post-extraction form of Appendix~C.2: a single
     translation-invariant positive two-site bond whose translated copies commute
     on every periodic chain and realize the MPO at every finite length.
 \end{definition}
@@ -1320,7 +1320,7 @@ recovers the GSNNCH target of source label \texttt{propsimple}.
     \lean{MPOTensor.SimpleMPDOLocalStructureData}
     \leanok
     \uses{thm:sal_implies_eta_structure, thm:sal_zcl_implies_rank_one_t}
-    This data record collects the current local Appendix~C.2 input: a normalized
+    This structure collects the current local Appendix~C.2 data: a normalized
     three-site reduced state with equality in strong subadditivity, the
     resulting local $\eta$-structure, and the rank-one conclusion for the
     auxiliary primitive matrix $T$.
@@ -1333,7 +1333,7 @@ recovers the GSNNCH target of source label \texttt{propsimple}.
     \uses{def:simple_mpdo_local_structure_data, def:mpdo_has_commuting_form,
         def:mpo_is_zcl}
     For an MPO tensor $K$, this consists of the local Appendix~C.2 data together
-    with a provisional compatibility relation attaching those local data to
+    with a compatibility relation attaching those local data to
     $K$, the commuting-form property, and zero correlation length. The local
     component is retained so that the still-missing implication from the
     entropy-side hypotheses to commuting form has an explicit target, even
@@ -1353,7 +1353,7 @@ recovers the GSNNCH target of source label \texttt{propsimple}.
 \end{theorem}
 
 \begin{proof}\leanok
-Zero correlation length is the current provisional MPDO RFP predicate.
+Zero correlation length is the current MPDO RFP predicate.
 Applying the converse direction of
 Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to that RFP witness yields
 fusion-isometry data at every positive blocked size; evaluating it at size $2$
@@ -1391,6 +1391,6 @@ is the current RFP predicate.
     Theorem~\ref{thm:simple_mpdo_rfp_chain} is fully formalized, but to recover
     the original Appendix~C.2 implication from SAL and ZCL alone one still
     needs a theorem deriving the commuting-form property from the local
-    simple-MPDO structure of Lemmas~C.3--C.4. The record above is included so
+    simple-MPDO structure of Lemmas~C.3--C.4. The definition above is included so
     that this future implication has an explicit target.
 \end{remark}

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -468,7 +468,7 @@ The results follow~\cite{Sanz2010Quantum}.
     at most $D^2$.
     This is the cumulative-span part of \cite[Theorem~1]{Sanz2010Quantum}.
     The paper's theorem is stronger: via Lemma~2(b) it upgrades this to a
-    fixed-length conclusion $S_N(A) = \MN{D}$, recorded below as a
+    fixed-length conclusion $S_N(A) = \MN{D}$, stated below as a
     separate statement.
 \end{theorem}
 
@@ -541,7 +541,7 @@ The results follow~\cite{Sanz2010Quantum}.
         In the non-invertible case, the bound $S_{D^2}(B) = \MN{D}$ follows
         from tracking indices through the rank-one extraction argument of
         \cite[Lemma~2(b)]{Sanz2010Quantum}; the separate qualitative
-        fixed-length conclusion recorded below does not supply this
+        fixed-length conclusion stated below does not supply this
         explicit bound.
         In both cases $\iota(A) \le D^2 \cdot n \le D^2 \cdot (D^2 - d' + 1)$.
     \end{enumerate}
@@ -681,7 +681,7 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     matrix spanning.
     Theorem~\ref{thm:lemma2b_assembly} is the second step.
     Theorem~\ref{thm:rankone_extraction_blockTensor} supplies the
-    rank-one input in blocked form, and
+    rank-one hypothesis in blocked form, and
     Theorem~\ref{thm:wielandt_lemma2b} then gives a blocked,
     fixed-length word-span saturation result.
 \end{remark}
@@ -773,7 +773,7 @@ used to produce rank-one elements.
 
     \noindent\emph{Remark.}
     The proof gives the explicit bound $N = ((D{-}1) + m + (D{-}1)) \cdot L$;
-    the statement above records only the existential conclusion.
+    the statement above gives only the existential conclusion.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -336,7 +336,7 @@ used in this chapter.
 \subsection{Multiplicity structure for repeated blocks}%
 \label{sec:route_b}
 
-This subsection records the multiplicity data in which repeated copies
+This subsection presents the multiplicity data in which repeated copies
 of the same basis block are kept separate rather than merged into a
 single weighted block.
 
@@ -582,7 +582,7 @@ single weighted block.
 	\lean{MPSTensor.SectorBasisOverlapOrthoHypotheses}
 	\leanok
 	\uses{def:paper_sector_data, def:mpv_overlap}
-	For one sector decomposition $P$, this condition records positive basis
+	For one sector decomposition $P$, this condition states positive basis
 	dimensions, trace-preserving normalization of all basis blocks,
 	self-overlap limits equal to~$1$, and off-overlap limits equal to~$0$.
 \end{definition}
@@ -593,7 +593,7 @@ single weighted block.
 	\leanok
 	\uses{def:paper_sector_data, def:mpv_overlap, def:mpv_state,
 		def:sector_basis_overlap_ortho_hyps}
-	For sector decompositions $P$ and $Q$, this condition records the
+	For sector decompositions $P$ and $Q$, this condition states the
 	primitive overlap-rigidity hypotheses for their basis blocks: nonzero
 	bond dimensions, injectivity, trace-preserving normalization,
 	self-overlap limits equal to~$1$, off-overlap limits equal to~$0$, and
@@ -1228,7 +1228,7 @@ two-basis sector comparison theorem.
 	permutation, equal bond dimensions, and gauge-phase equivalences between the two
 	nonzero-weight block families, then the sector bases yield the comparison data
 	of Theorem~\ref{thm:after_blocking_sector_common_blocks_common_phase_cover},
-	with the positive-length zero-tail bookkeeping of
+	with the positive-length zero-tail identities of
 	Theorem~\ref{thm:after_blocking_sector_common_blocks_overlap_span_zero_tail}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -221,7 +221,7 @@ operation on the physical indices.
 \label{sec:virtual_bond_gauge}
 %% ---------------------------------------------------------
 
-This section records the 3-site virtual-bond statement used later in the
+This section presents the 3-site virtual-bond statement used later in the
 paper proof. Here the hypothesis is already the
 all-length MPV equality of the combined tensors, and the conclusion is the
 conjugacy of the middle-bond insertion data.
@@ -360,7 +360,7 @@ forces the local tensors to be proportional.
 \label{sec:ft_chain}
 %% ---------------------------------------------------------
 
-The current Lean endpoint for chains is obtained by bundling the site
+The current formalized result for chains is obtained by combining the site
 index into the physical index and applying the single-block Fundamental
 Theorem to the resulting tensor. The paper-style fixed-length
 same-state statement is recovered only after adding a separate same-state
@@ -374,7 +374,7 @@ reduction hypothesis.
     Let $\mathbf{A} = (A_0, \ldots, A_{n-1})$ and
     $\mathbf{B} = (B_0, \ldots, B_{n-1})$ be two $n$-site chains with
     common bond dimension $D$, and assume that $\mathbf{A}$ is injective.
-    Suppose that, after bundling the site index and physical index into a
+    Suppose that, after combining the site index and physical index into a
     single MPS tensor, the resulting two tensors generate the same MPV
     family. Then $\mathbf{A}$ and $\mathbf{B}$ are cyclically gauge
     equivalent.
@@ -760,7 +760,7 @@ Chapter~\ref{ch:symmetry}.
 \end{proof}
 
 \begin{remark}
-    The theorem above is the exact blocked-chain endpoint established here.
+    The theorem above is the exact blocked-chain result established here.
     Recovering sitewise gauges for the original unblocked tensors, and hence
     the paper's normal-MPS corollary, is not established here.
 \end{remark}
@@ -1245,7 +1245,7 @@ which is then combined with overlap estimates and the leading-block peel.
 \end{proof}
 
 %% ---------------------------------------------------------
-\section{Heterogeneous equal-case endpoint}%
+\section{Heterogeneous equal-case result}%
 \label{sec:hetero_equal_case_ft}
 %% ---------------------------------------------------------
 

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -360,9 +360,9 @@ forces the local tensors to be proportional.
 \label{sec:ft_chain}
 %% ---------------------------------------------------------
 
-The current formalized result for chains is obtained by combining the site
-index into the physical index and applying the single-block Fundamental
-Theorem to the resulting tensor. The paper-style fixed-length
+The current formalized result for chains is obtained by combining the site and
+physical indices into a single physical index and applying the single-block
+Fundamental Theorem to the resulting tensor. The paper-style fixed-length
 same-state statement is recovered only after adding a separate same-state
 reduction hypothesis.
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -281,14 +281,14 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \leanok
     \uses{def:peps_localTensorMap, def:peps_localLeftInverse}
     For fixed $A$, $B$, a bond-dimension equality, and a vertex $v$, this
-    records the two local conclusions still needed from the blocked-middle
+    states the two local conclusions still needed from the blocked-middle
     reduction in~\cite{Molnar2018NormalPEPS}, §3:
     (i) each local component of $B$ lies in the image of the local tensor map
     of $A$, and (ii) the canonical pullback through the chosen left inverse of
     $A$ factorizes as one invertible matrix on each incident edge.
 \end{definition}
 
-\begin{definition}[Blocked-middle local gauge output]%
+\begin{definition}[Blocked-middle local gauge data]%
     \label{def:peps_blockedMiddleGaugeHyp}
     \lean{TNLean.PEPS.BlockedMiddleGaugeHyp}
     \leanok
@@ -299,7 +299,7 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     local component of $B$ from those of $A$.
 \end{definition}
 
-\begin{theorem}[Blocked-middle output implies sharpened lift]%
+\begin{theorem}[Blocked-middle local gauge data implies sharpened lift]%
     \label{thm:peps_hasLocalGaugeLift_of_blockedMiddleGaugeHyp}
     \lean{TNLean.PEPS.hasLocalGaugeLift_of_blockedMiddleGaugeHyp}
     \leanok
@@ -419,6 +419,6 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     require the blocked tensor on the middle region and the comparison with the
     corresponding three-site injective chain. The uniqueness statement has now
     been repaired to a quotient by balanced edge scalars, but its proof still
-    requires the same blocking machinery together with the corresponding
+    requires the same blocking construction together with the corresponding
     tensor-factor uniqueness statement at a single vertex.
 \end{remark}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -188,7 +188,7 @@ onto $G_L(A)^\perp$ in the $L$-site Euclidean space.
     \[
         \operatorname{extractWindow}_{L,i}(\sigma) \in \{0,\ldots,d{-}1\}^{L}
     \]
-    records the entries of $\sigma$ on the cyclic interval $i,i+1,\ldots,i+L-1$ modulo $N$.
+    reads the entries of $\sigma$ on the cyclic interval $i,i+1,\ldots,i+L-1$ modulo $N$.
 \end{definition}
 
 \begin{definition}[Periodic window replacement]\label{def:replace_window}
@@ -330,7 +330,7 @@ chain.
 
 Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
-\begin{remark}[Word and restriction helper formulas]
+\begin{remark}[Word and restriction auxiliary formulas]
     \lean{List.ofFn_snoc}
     \lean{MPSTensor.evalWord_ofFn_snoc}
     \lean{MPSTensor.evalWord_ofFn_cons}
@@ -558,7 +558,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     For a non-wrapping interval $[s,s+M-1] \subseteq \{0,\ldots,N-1\}$, one can insert a
     length-$M$ word into that interval and keep the complementary sites fixed. The
     associated restriction map evaluates an $N$-site state on those configurations.
-    The auxiliary lemmas record the full-window case $s=0$, $M=N$, the
+    The auxiliary lemmas state the full-window case $s=0$, $M=N$, the
     compatibility of this restriction with deleting the last or first site, and
     the fact that fixing the first $K$ entries of a contiguous $(K+L)$-window
     leaves the contiguous $L$-window beginning at $s+K$.
@@ -575,7 +575,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     On the periodic chain, a cyclic window starting at $i$ reads the sites
     $i,i+1,\ldots,i+L-1$ modulo $N$.  Deleting the final site of a cyclic
-    $(L+1)$-window records the value at cyclic offset $L$ in the outside
+    $(L+1)$-window reads the value at cyclic offset $L$ in the outside
     configuration and gives the $L$-window starting at the same site.  When this
     window does not wrap around the ring, the cyclic construction agrees with the
     contiguous one, and so do the two restriction maps.
@@ -1231,7 +1231,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     The remaining step is the closure property from
     \cite[\S~IV.C]{Cirac2021Matrix}: Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
     supplies the two one-sided wrapped-boundary identities for the open-chain
-    boundary matrix $X$. The padded-annihilation lemma records that exact
+    boundary matrix $X$. The padded-annihilation lemma states that exact
     complement-span length mismatches are no longer the obstruction, and
     Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} formalizes the
     algebraic endgame once those one-sided identities have been compared to a
@@ -2513,7 +2513,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Only the $L = 2$ case is used in the spectral-gap theorem below.
     (When $L = 1$ the interaction terms have disjoint supports, so there are no
     overlapping pairs and the spectral gap follows directly without the
-    martingale machinery.)
+    martingale argument.)
 \end{lemma}
 
 \begin{proof}
@@ -2624,14 +2624,14 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \begin{proof}
     \notready
     The local averaging, positivity, and symmetric-projection statements are now
-    recorded in Lemmas~\ref{lem:local_term_es_average},
+    established in Lemmas~\ref{lem:local_term_es_average},
     \ref{lem:transported_es_positive}, and~\ref{lem:transported_es_local_projections}.
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} reduces the present
     theorem to the remaining MPS-specific task: deriving the uniform
     quadratic-form estimate.  Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}
     establishes the finite-sum algebra from ordered cross-term row bounds, and
     Lemmas~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
-    and~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} record the
+    and~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} state the
     common finite-overlap specialization with $m=2(L-1)$.
     Lemma~\ref{lem:transported_es_nonoverlap_positive} supplies the non-overlap
     positivity statement for site-disjoint windows, and
@@ -2642,9 +2642,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap} combines
     these ingredients with the finite-overlap reduction, so the remaining
     analytic task is the Friedrichs-angle estimate for overlapping cyclic windows.
-    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} records the
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} states the
     same overlap-only formulation, and
-    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} records a sufficient
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} states a sufficient
     norm-compression formulation.
 \end{proof}
 
@@ -2708,7 +2708,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \leanok
     \uses{rem:word_tuple_span_top}
     For a fixed length $m$, the Route B product-word span condition is the
-    finite-length spanning condition already recorded in
+    finite-length spanning condition already stated in
     Remark~\ref{rem:word_tuple_span_top}: the simultaneous block-word evaluations
     \[
         \omega \longmapsto \bigl(A_j^{\omega}\bigr)_j
@@ -3099,14 +3099,14 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         lem:isup_chain_ground_space_block_le_assembled,
         thm:chain_ground_space_eq_mpv_blk, lem:center_scalar}
     Let $A$ be in canonical-form/BNT, and assume $1<L$, $N \ge L+1$, and
-    $0<m$.  Assume the remaining \#911 input: every virtual sector projection
+    $0<m$.  Assume the remaining \#911 hypothesis: every virtual sector projection
     lies in the pulled-back span of the length-$m$ word products of the assembled
     tensor.  If a boundary matrix for the assembled tensor commutes with all
     those length-$m$ words, then the vector obtained by applying the assembled
     ground-space map to that boundary matrix lies in
     $\bigsqcup_j \mathcal G_{N,L}(A_j)$.  Consequently, if every assembled
     periodic-chain ground vector admits such a commuting boundary matrix
-    representation (the output of the wrapping-window comparison), then
+    representation (the result of the wrapping-window comparison), then
     \[
         \mathcal G_{N,L}\bigl(\operatorname{Assemble}(\mu, A)\bigr)
         \subseteq \bigsqcup_j \mathcal G_{N,L}(A_j),
@@ -3271,5 +3271,5 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{proof}
 
 \noindent\emph{Remark.} A separate kernel-identification statement for these assembled
-block families is still to be recorded; at present, the formal results are stated in the
+block families is still to be established; at present, the formal results are stated in the
 chain-ground-space model rather than directly as $\ker(H_{N})$.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3116,7 +3116,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     blockwise injective uniqueness gives the conditional containment of the
     assembled parent ground space in the BNT span; this lemma is not a restatement
     of the final theorem, because it keeps the \#911 projection-span and boundary
-    representation inputs explicit.
+    representation hypotheses explicit.
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

Continues the #1021 blueprint prose mathematical-language cleanup.

Replaces process/narrative terms (record, records, recorded, provisional, bundling, bookkeeping, endpoint (non-graph uses), output, input, helper, machinery) with mathematical descriptions: defines, states, presents, gives, reads, data, result, hypothesis, construction, argument, auxiliary.

## Files touched
- `blueprint/src/chapter/ch02b_mpdo.tex`: record/provisional/input/output → define/state/data
- `blueprint/src/chapter/ch07_wielandt.tex`: recorded/input → stated/hypothesis
- `blueprint/src/chapter/ch11_assembly.tex`: records/bookkeeping → presents/states/identities
- `blueprint/src/chapter/ch13_algebraic_ft.tex`: records/endpoint/bundling → presents/result/combining
- `blueprint/src/chapter/ch13a_peps_ft.tex`: records/output/machinery → states/data/construction
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: records/helper/machinery/input/output → states/auxiliary/argument/hypothesis/result

## Validation
- `git diff --check` passes ✓
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passes ✓ (after generating lean_decls)
- Grep of all touched files for flagged terms returns zero matches ✓
- Theorem labels and Lean declaration tags preserved ✓

Related: #1018, #999
Labels: documentation, cleanup, blueprint-sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Textual documentation edits only; no changes to Lean identifiers, theorem statements, or executable code paths.
> 
> **Overview**
> This PR is a **prose-only cleanup** across several blueprint chapters, replacing note-taking/narrative wording (e.g. *record/recorded*, *provisional*, *input/output*, *bookkeeping*, *bundling*, *endpoint*, *machinery*) with more mathematical phrasing (e.g. *define/state/present/give*, *current*, *hypothesis/data/result*, *combine*).
> 
> It also updates a handful of theorem/remark titles and surrounding sentences to match the new terminology while preserving existing labels and Lean declaration references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 806af10c9d479a4e77d799a259d7ad60c15e92a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->