### PR TITLE
docs(Algebra): describe auxiliary results mathematically

### DIFF
--- a/TNLean/Algebra/BurnsideMatrix.lean
+++ b/TNLean/Algebra/BurnsideMatrix.lean
@@ -196,7 +196,7 @@ theorem exists_cumulativeSpan_eq_top_of_algSpan_eq_top (A : MPSTensor d D)
 /-! ## Part 2: Invariant submodule characterization -/
 
 
-/-- Helper: if `(1 - P) * M * P = 0`, then `M * P = P * (M * P)`. -/
+/-- If `(1 - P) * M * P = 0`, then `M * P` lies in the range of `P`. -/
 private theorem mul_proj_eq {P M : Matrix (Fin D) (Fin D) ℂ}
     (hinv : (1 - P) * M * P = 0) :
     M * P = P * (M * P) := by

--- a/TNLean/Algebra/BurnsideMatrix.lean
+++ b/TNLean/Algebra/BurnsideMatrix.lean
@@ -196,7 +196,7 @@ theorem exists_cumulativeSpan_eq_top_of_algSpan_eq_top (A : MPSTensor d D)
 /-! ## Part 2: Invariant submodule characterization -/
 
 
-/-- If `(1 - P) * M * P = 0`, then `M * P` lies in the range of `P`. -/
+/-- If `(1 - P) * M * P = 0`, then `M * P = P * (M * P)`. -/
 private theorem mul_proj_eq {P M : Matrix (Fin D) (Fin D) ℂ}
     (hinv : (1 - P) * M * P = 0) :
     M * P = P * (M * P) := by

--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -5,10 +5,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.Analysis.Matrix.PosDef
 
 /-!
-# Hermitian matrix helpers
+# Hermitian matrix spectral decomposition and adjoint identities
 
-This file provides small reusable helpers for Hermitian complex matrices over
-`Fin D`: the unitary identities for the eigenvector matrix, the standard
+This file provides lemmas for Hermitian complex matrices over `Fin D`: the
+unitary identities for the eigenvector matrix, the standard
 `U * diagonal * Uᴴ` spectral decomposition, and the adjoint identity for the
 matrix-vector dot-product pairing.
 -/

--- a/TNLean/Algebra/MatrixSpectralDecomp.lean
+++ b/TNLean/Algebra/MatrixSpectralDecomp.lean
@@ -6,7 +6,7 @@ import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Spectrum
 
 /-!
-# Spectral decomposition helpers for complex matrices
+# Spectral decomposition lemmas for complex matrices
 
 This file collects channel-agnostic linear-algebra lemmas that relate a complex
 matrix to outer-product sums over its spectral data.

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -59,7 +59,7 @@ lemma SameMPV.trace_evalWord {A B : MPSTensor d D} (h : SameMPV A B) (w : List (
   -- Use the `SameMPV` equality on the configuration `σ := w.get`.
   simpa [mpv, coeff, List.ofFn_get] using h w.length w.get
 
-/-- Lemma 3 (helper): nondegeneracy of the trace pairing on `D×D` complex matrices. -/
+/-- Nondegeneracy of the trace pairing on `D×D` complex matrices. -/
 lemma trace_mul_right_eq_zero {M : Matrix (Fin D) (Fin D) ℂ}
     (h : ∀ N : Matrix (Fin D) (Fin D) ℂ, Matrix.trace (M * N) = 0) : M = 0 := by
   simpa using (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) M).1 h
@@ -76,9 +76,8 @@ lemma traceMulRightPi_apply (A : MPSTensor d D)
     traceMulRightPi A M i = Matrix.trace (M * A i) := by
   simp [traceMulRightPi, Matrix.traceLinearMap_apply]
 
-/-- Auxiliary length-2 specialisation of `SameMPV.trace_evalWord`.
-
-This is kept as a small helper for the linear-extension proofs. -/
+/-- Auxiliary length-2 specialisation of `SameMPV.trace_evalWord`, used in
+linear-extension proofs. -/
 lemma sameMPV_trace_word2 {A B : MPSTensor d D} (hAB : SameMPV A B) (i j : Fin d) :
     Matrix.trace (A i * A j) = Matrix.trace (B i * B j) := by
   have h := hAB.trace_evalWord [i, j]

--- a/TNLean/Analysis/ConvergenceHelpers.lean
+++ b/TNLean/Analysis/ConvergenceHelpers.lean
@@ -6,7 +6,7 @@ import Mathlib.Analysis.SpecificLimits.Normed
 import Mathlib.Analysis.Complex.Basic
 
 /-!
-# General-purpose convergence helpers
+# Convergence lemmas for complex sequences
 
 Convergence lemmas for complex sequences, geometric series, and weighted sums.
 These are used in the fundamental theorem proof chain but are fully general.

--- a/TNLean/Analysis/OperatorConvexity.lean
+++ b/TNLean/Analysis/OperatorConvexity.lean
@@ -21,23 +21,22 @@ This module proves the trace convexity and concavity of the map
 
 Both statements were previously axiomatized in `TNLean.Axioms.OperatorConvexity`
 (as `trace_rpow_concave_axiom` / `trace_rpow_convex_axiom`); this module
-discharges them using the matrix-analysis helpers
+discharges them using the matrix-analysis lemmas
 `Matrix.IsHermitian.trace_cfc_eq_sum_re` (from `TNLean/Channel/Schwarz/TraceCFC.lean`)
 and `Matrix.diagonal_jensen_of_convexOn`
 (from `TNLean/Channel/Schwarz/DiagonalJensen.lean`).
 
 ## Proof sketch
 
-The common scaffolding is factored into the private helper
-`trace_cfc_convex_bound`, which takes a convex `f : ℝ → ℝ` on `[0, ∞)` and
-proves the CFC-level trace inequality. The top-level theorems are then thin
-wrappers:
+The common reduction is the private lemma `trace_cfc_convex_bound`, which takes
+a convex `f : ℝ → ℝ` on `[0, ∞)` and proves the CFC-level trace inequality. The
+top-level theorems are then the two real-power specialisations:
 
-* `trace_rpow_convex` applies the helper directly to `f = fun x => x^p`.
-* `trace_rpow_concave` applies the helper to `-f` and uses
+* `trace_rpow_convex` applies the lemma directly to `f = fun x => x^p`.
+* `trace_rpow_concave` applies the lemma to `-f` and uses
   `IsHermitian.cfc_neg` plus `trace_neg` to flip signs.
 
-Internally the helper:
+Internally the convexity lemma:
 
 1. Rewrites `Re Tr(hH.cfc f) = ∑ⱼ f(μⱼ)` via `trace_cfc_eq_sum_re`, where
    `{ψⱼ}` is the eigenbasis of `A := t • A₁ + (1 − t) • A₂` and `μⱼ` its
@@ -179,15 +178,14 @@ private lemma psd_smul_real
       rw [Complex.le_def]; exact ⟨by simpa, by simp⟩
     exact mul_nonneg ht_ℂ hnn
 
-/-- Helper: `(t • A₁ + (1 − t) • A₂).PosSemidef` when `A₁, A₂` are PSD
-and `t, 1 − t ≥ 0`. -/
+/-- Positive semidefiniteness is preserved under convex combinations of PSD matrices. -/
 private lemma posSemidef_convex_combination
     {A₁ A₂ : Mat} (h₁ : A₁.PosSemidef) (h₂ : A₂.PosSemidef)
     {t : ℝ} (ht₀ : 0 ≤ t) (ht₁ : 0 ≤ 1 - t) :
     (t • A₁ + (1 - t) • A₂).PosSemidef :=
   (psd_smul_real h₁ ht₀).add (psd_smul_real h₂ ht₁)
 
-/-- **Shared scaffolding for trace convex/concave bounds on matrix CFC.**
+/-- **Trace convexity bound for the continuous functional calculus.**
 
 For a convex `f : ℝ → ℝ` on `[0, ∞)` and PSD matrices `A₁, A₂` with
 `t ∈ [0, 1]`, the real trace of `f` applied (via the Hermitian CFC) to the

--- a/TNLean/Topology/TendstoHelpers.lean
+++ b/TNLean/Topology/TendstoHelpers.lean
@@ -6,10 +6,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.Topology.Separation.Hausdorff
 
 /-!
-# Small helpers about `Filter.Tendsto`
+# Uniqueness of limits for `Filter.Tendsto`
 
-This file contains a uniqueness-of-limits helper for later compactness and
-convergence arguments. The theorem `Filter.Tendsto.ne_nhds` records the
+This file contains the uniqueness-of-limits theorem used in later compactness and
+convergence arguments. The theorem `Filter.Tendsto.ne_nhds` states the
 standard T2-space fact that a nontrivial filter cannot tend simultaneously to
 two distinct points.
 -/


### PR DESCRIPTION
## Summary

- Replaces helper/scaffolding-oriented prose with mathematical descriptions in algebra, analysis, and topology auxiliary modules.
- Describes trace pairing, Hermitian spectral decomposition, Burnside projections, operator convexity, and convergence lemmas directly.

Closes #1026.

## Testing

- `lake build --old TNLean.Algebra.TracePairing TNLean.Algebra.HermitianHelpers TNLean.Algebra.MatrixSpectralDecomp TNLean.Algebra.BurnsideMatrix TNLean.Analysis.OperatorConvexity TNLean.Analysis.ConvergenceHelpers TNLean.Topology.TendstoHelpers`
- `git diff --check`
- `rg -n "helper|Helper|helpers|Helpers|scaffold|scaffolding|wrapper|wrappers|record(s)?|machinery|API|package" ...` (remaining matches only in existing namespace/file names such as `HermitianHelpers`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes; no behavior, proof terms, or interfaces are modified.
> 
> **Overview**
> Updates module and lemma docstrings across algebra/analysis/topology helper files to describe results *mathematically* (e.g., spectral decompositions, trace pairing nondegeneracy, PSD convex combinations, uniqueness of limits) rather than as “helpers/scaffolding/wrappers”.
> 
> No definitions, proofs, or APIs are changed; this is a documentation-only clarification pass (mostly comment text and section headings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7135a3bc78009eb4e245fb4cccaeed6bfec719bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->