### PR TITLE
docs(Entropy): state axiom formulations directly

### DIFF
--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -47,7 +47,7 @@ proved theorems). They are the two axioms introduced by
 
 Replace `Axioms.rfp_to_nncph_commute` with a Lean proof that uses the
 product-of-entangled-pairs structural form (Appendix B of
-arXiv:1606.00608). The structural bridge in
+arXiv:1606.00608). The structural construction in
 `TNLean/MPS/RFP/CommutingBridge.lean` (`ProductPairBridge`) already
 encodes the key combinatorial content; the missing piece is the
 extraction of a `ProductPairBridge A` witness from `IsRFP A` and
@@ -101,7 +101,7 @@ the file that consumes it.
 (source line 1307) as *"trivial from Theorem [charact-MPS]"*, i.e.,
 from Theorem 3.10 itself. It does **not** depend on S. Beigi (2012);
 it depends only on the product-of-entangled-pairs structural form
-(Appendix B of arXiv:1606.00608). A structural bridge for that decomposition
+(Appendix B of arXiv:1606.00608). A structural construction for that decomposition
 lives in `TNLean/MPS/RFP/CommutingBridge.lean` as
 `ProductPairBridge`.
 

--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -9,11 +9,11 @@ import TNLean.MPS.Periodic.Defs
 /-!
 # Beigi's ground-space theorem (axiomatized) and the RFP ⟺ NNCPH split
 
-This module records two axioms that together realize the equivalence
+This module states two axioms that together realize the equivalence
 `IsRFP A ⇔ IsNNCPH A N` used in the proof of Theorem 3.10 of
 arXiv:1606.00608. Following the proof in §3.3 of that paper, the two
 directions have very different external provenance and so are
-recorded here as **separate** axioms with **separate** citations:
+stated here as **separate** axioms with **separate** citations:
 
 * `Axioms.rfp_to_nncph_commute` — RFP ⟹ NNCPH. Per
   arXiv:1606.00608 §3.3 (line 1307 of the source): *"The implication
@@ -47,7 +47,7 @@ proved theorems). They are the two axioms introduced by
 
 Replace `Axioms.rfp_to_nncph_commute` with a Lean proof that uses the
 product-of-entangled-pairs structural form (Appendix B of
-arXiv:1606.00608). The scaffolding in
+arXiv:1606.00608). The structural bridge in
 `TNLean/MPS/RFP/CommutingBridge.lean` (`ProductPairBridge`) already
 encodes the key combinatorial content; the missing piece is the
 extraction of a `ProductPairBridge A` witness from `IsRFP A` and
@@ -101,7 +101,7 @@ the file that consumes it.
 (source line 1307) as *"trivial from Theorem [charact-MPS]"*, i.e.,
 from Theorem 3.10 itself. It does **not** depend on S. Beigi (2012);
 it depends only on the product-of-entangled-pairs structural form
-(Appendix B of arXiv:1606.00608). A scaffold for that structural form
+(Appendix B of arXiv:1606.00608). A structural bridge for that decomposition
 lives in `TNLean/MPS/RFP/CommutingBridge.lean` as
 `ProductPairBridge`.
 

--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -16,7 +16,7 @@ clear to downstream files and to CI.
 ## Status
 
 * `strong_subadditivity` is an **axiom** (proof deferred; see TODO below).
-* `hayashi_ssa_equality_characterization` is an **axiom** recording the
+* `hayashi_ssa_equality_characterization` is an **axiom** stating the
   standard equality case of strong subadditivity as a quantum-Markov-chain
   decomposition on the middle subsystem.
 * A `subadditivity` result can be derived from `strong_subadditivity` by
@@ -214,7 +214,7 @@ matrices, and the block-diagonal equality.
 This result is introduced here as a **sanctioned axiom**: the full proof needs
 operator-algebra / recovery-map infrastructure that is not yet formalized in
 Mathlib or in this repository. Downstream consumers should import the theorem
-wrapper from `TNLean/Entropy/MarkovChain.lean`, not this axiom module.
+statement from `TNLean/Entropy/MarkovChain.lean`, not this axiom module.
 
 References:
 * Hayashi, J. Phys. A: Math. Gen. 37 (2004) L205--L208

--- a/TNLean/Entropy/MarkovChain.lean
+++ b/TNLean/Entropy/MarkovChain.lean
@@ -7,7 +7,7 @@ import TNLean.Entropy.StrongSubadditivity
 /-!
 # SSA equality and quantum Markov-chain structure
 
-This module records the sanctioned axiom
+This module states the sanctioned axiom
 `_root_.hayashi_ssa_equality_characterization` from
 `TNLean/Axioms/Entropy.lean` in the `Entropy` namespace.
 
@@ -21,15 +21,15 @@ subsystem `B`: after a unitary change of basis on `B`, the Hilbert space of
 block-diagonal direct sum `⊕_j p_j (ρ_{A B_jᴸ} ⊗ ρ_{B_jᴿ C})`.
 
 The actual proof is intentionally deferred to the sanctioned axiom in
-`TNLean.Axioms.Entropy`; this file provides only theorem wrappers and the
-abbreviation used for the decomposition record in the `Entropy` namespace.
+`TNLean.Axioms.Entropy`; this file provides only the named formulations and the
+namespace abbreviation for the quantum-Markov-chain decomposition.
 
 ## Main declarations
 
 * `Entropy.QuantumMarkovDecomposition` — abbreviation for
   `_root_.HayashiMarkovDecomposition`.
-* `Entropy.ssaEquality_iff_exists_quantumMarkovDecomposition` — theorem wrapper
-  around `_root_.hayashi_ssa_equality_characterization`.
+* `Entropy.ssaEquality_iff_exists_quantumMarkovDecomposition` — theorem statement of
+  the sanctioned equivalence `_root_.hayashi_ssa_equality_characterization`.
 * `Entropy.exists_quantumMarkovDecomposition_of_ssaEquality` — forward
   direction.
 * `Entropy.isSSAEquality_of_quantumMarkovDecomposition` — reverse direction.
@@ -52,7 +52,7 @@ section MarkovChain
 
 variable {dA dB dC : ℕ}
 
-/-- Namespaced abbreviation for the quantum-Markov-chain decomposition witness
+/-- Namespace abbreviation for the quantum-Markov-chain decomposition witness
 associated to equality in strong subadditivity. -/
 abbrev QuantumMarkovDecomposition
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
@@ -62,7 +62,7 @@ abbrev QuantumMarkovDecomposition
 /-- Equality in strong subadditivity is equivalent to the existence of a
 quantum-Markov-chain decomposition on the middle subsystem.
 
-This is a theorem wrapper around the sanctioned axiom
+This is a statement of the sanctioned axiom
 `_root_.hayashi_ssa_equality_characterization`; no new axiom is introduced by
 this file. -/
 theorem ssaEquality_iff_exists_quantumMarkovDecomposition

--- a/TNLean/Entropy/StrongSubadditivity.lean
+++ b/TNLean/Entropy/StrongSubadditivity.lean
@@ -7,23 +7,22 @@ import TNLean.Entropy.TripartiteTrace
 import TNLean.Entropy.VonNeumann
 
 /-!
-# Strong subadditivity (namespaced wrapper + basic corollaries)
+# Strong subadditivity (theorem formulation and basic corollaries)
 
-This module exposes **strong subadditivity** (SSA) of the von Neumann
-entropy inside the `Entropy` namespace, following the roadmap of
-issue #613 for the Simple MPDO RFP track (issue #236, umbrella
-#239).
+This module states **strong subadditivity** (SSA) of the von Neumann
+entropy as a theorem inside the `Entropy` namespace, following the
+roadmap of issue #613 for the Simple MPDO RFP track (issue #236,
+umbrella #239).
 
 SSA is the statement that for any tripartite density matrix
 `ρ_ABC` on `A ⊗ B ⊗ C`,
 `S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)`.
-This is a deep theorem of Lieb–Ruskai (1973). Its full Lean proof is
+This is a deep theorem of Lieb–Ruskai (1973). The full Lean proof is
 deferred to the sanctioned axiom `_root_.strong_subadditivity` in
 `TNLean.Axioms.Entropy`; the theorem `Entropy.strongSubadditivity`
-provided here is a thin *theorem* wrapper around that single
-axiom, so that the sanctioned axiom inventory under
-`TNLean/Axioms/` remains authoritative and no duplicate
-axiomatization of SSA is introduced.
+stated here forwards that single axiom, so that the sanctioned
+axiom inventory under `TNLean/Axioms/` remains authoritative and
+no duplicate axiomatization of SSA is introduced.
 
 ## Main declarations
 
@@ -69,13 +68,14 @@ open Matrix Finset Real
 
 namespace Entropy
 
-/-! ## The strong subadditivity wrapper -/
+/-! ## The strong subadditivity theorem -/
 
 section StrongSubadditivity
 
 variable {dA dB dC : ℕ}
 
-/-- **Strong subadditivity** (Lieb–Ruskai 1973), namespaced wrapper.
+/-- **Strong subadditivity** (Lieb–Ruskai 1973), stated in the
+`Entropy` namespace.
 
 For a tripartite density matrix `ρ_ABC` on `A ⊗ B ⊗ C`:
   `S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)`
@@ -84,7 +84,7 @@ where the reduced states are obtained via the tripartite partial
 traces `traceAC_ABC`, `traceC_ABC`, `traceA_ABC` (see
 `TNLean.Analysis.Entropy`).
 
-This is a thin theorem wrapper around the sanctioned axiom
+This theorem forwards the sanctioned axiom
 `_root_.strong_subadditivity` (in `TNLean/Axioms/Entropy.lean`); no
 new axiom is introduced by this module. See the module-level TODO for
 the roadmap replacing the underlying axiom with a proof.

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -216,7 +216,7 @@ finite-dimensional quantum systems.
 
 \section{Entropy formulations}
 
-This section records the entropy formulations used later in the
+This section states the entropy formulations used later in the
 development: von Neumann entropy, strong subadditivity, quantum Markov
 decomposition, and mutual information. These statements are cited from the
 standard entropy literature and supply the entropy-theoretic input for the
@@ -240,9 +240,9 @@ later MPDO arguments.
     \[
         S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC}).
     \]
-    This formulation introduces no new axiom: it records the same
-    strong-subadditivity input already used above. The underlying
-    axiom's
+    This formulation introduces no new axiom: it is the same
+    strong-subadditivity statement as
+    Theorem~\ref{thm:strong_subadditivity}. The underlying axiom's
     proof (Lieb--Ruskai 1973) is deferred to the umbrella entropy
     issue.
 \end{theorem}
@@ -266,9 +266,8 @@ later MPDO arguments.
     subadditivity holds if and only if $\rho_{ABC}$ admits a quantum
     Markov decomposition on the middle subsystem $B$.
 
-    This formulation introduces no new axiom: it records the same
-    equality criterion as
-    Theorem~\ref{thm:hayashi_ssa_equality_characterization}.
+    This formulation introduces no new axiom: it is the same equality
+    criterion as Theorem~\ref{thm:hayashi_ssa_equality_characterization}.
 \end{theorem}
 
 \begin{definition}[Entropy formulation of mutual information]\label{def:entropy_mutual_information}


### PR DESCRIPTION
## Summary

- Replaces wrapper/record/scaffold phrasing with direct mathematical descriptions in entropy and axiom modules.
- States SSA, Markov decomposition, and Beigi/RFP axioms as named formulations rather than implementation wrappers.
- Updates the entropy blueprint prose to avoid note-taking language.

Closes #1027.

## Testing

- `lake build --old TNLean.Entropy.StrongSubadditivity TNLean.Entropy.MarkovChain TNLean.Axioms.Entropy TNLean.Axioms.Beigi`
- `git diff --check`
- grep scan for `records the same|records|recorded|wrapper|scaffold|scaffolding|namespaced wrapper|thin theorem wrapper|theorem wrappers|decomposition record|axiom recording|recorded here` in touched files (no matches)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` was attempted before opening; it reported pre-existing missing generated declaration-list data in this worktree, while the touched prose does not change Lean declarations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure doc/prose changes (Lean module docstrings and blueprint text) with no changes to definitions, theorem statements, or proofs.
> 
> **Overview**
> Updates documentation prose across `TNLean/Axioms/Entropy.lean`, `TNLean/Entropy/StrongSubadditivity.lean`, `TNLean/Entropy/MarkovChain.lean`, and `TNLean/Axioms/Beigi.lean` to describe the existing axioms/theorems as *directly stated formulations* (and clarifies citations/TODO wording), replacing “wrapper/record/scaffold” phrasing.
> 
> Aligns the blueprint chapter text (`ch04b_entropy.tex`) with the same wording, emphasizing that the “entropy formulations” do not introduce additional axioms beyond the sanctioned ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835f098f057279a010230a662370669039a97025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->