### PR TITLE
docs(Wielandt): state paper results mathematically

### DIFF
--- a/TNLean/Wielandt/PaperResults/EigenvectorSpreading.lean
+++ b/TNLean/Wielandt/PaperResults/EigenvectorSpreading.lean
@@ -7,7 +7,7 @@ import TNLean.Wielandt.Primitivity.Equivalence
 import TNLean.Wielandt.SpanGrowth.EigenvectorSpreading
 
 /-!
-# Lemma 2(a) — paper-facing eigenvector spreading wrapper (arXiv:0909.5347)
+# Lemma 2(a) — paper-level eigenvector-spreading statement (arXiv:0909.5347)
 
 This file states the current formal version of **Lemma 2(a)** from
 Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequality*
@@ -30,7 +30,7 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
    using `vectorSpreadSpan_eq_top_of_cumulativeVectorSpan_eq_top_of_eigenvector`.
 
 This keeps the public statement in the exact fixed-length `H_{D-1}` form of the
-paper/Wolf lemma, while reusing the existing backend infrastructure.
+paper/Wolf lemma, while reusing the existing underlying formalization.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -40,7 +40,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- **Lemma 2(a)** (paper-facing wrapper).
+/-- **Lemma 2(a)** (paper-level statement).
 
 If `A` is normalized and primitive in the paper sense, and `φ` is a
 nonzero eigenvector of some `A i₀` with nonzero corresponding eigenvalue `μ`,

--- a/TNLean/Wielandt/PaperResults/MatrixSpanExistence.lean
+++ b/TNLean/Wielandt/PaperResults/MatrixSpanExistence.lean
@@ -26,7 +26,7 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
 ## Quantitative status
 
 These statements are intentionally **coarse existential** statements. They use the
-backend theorem `wielandt_lemma2b`, which produces a witness `N` without
+underlying theorem `wielandt_lemma2b`, which produces a witness `N` without
 claiming the paper's exact bound.
 
 They state only the qualitative conclusion `∃ N, S_N(A) = M_D(ℂ)`. In

--- a/TNLean/Wielandt/PaperResults/MatrixSpanExistence.lean
+++ b/TNLean/Wielandt/PaperResults/MatrixSpanExistence.lean
@@ -7,11 +7,11 @@ import TNLean.Wielandt.Primitivity.Equivalence
 import TNLean.Wielandt.RankOne.ExtractionFull
 
 /-!
-# Lemma 2(b) — coarse existential wrapper (arXiv:0909.5347)
+# Lemma 2(b) — coarse existential statement (arXiv:0909.5347)
 
 This file states a **coarse existential** version of **Lemma 2(b)** from
 Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequality*
-(arXiv:0909.5347), in the paper-facing `IsPrimitivePaper` language.
+(arXiv:0909.5347), in the `IsPrimitivePaper` language of the paper.
 
 ## Main results
 
@@ -25,11 +25,11 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
 
 ## Quantitative status
 
-These wrappers are intentionally **coarse existential** statements. They use the
+These statements are intentionally **coarse existential** statements. They use the
 backend theorem `wielandt_lemma2b`, which produces a witness `N` without
 claiming the paper's exact bound.
 
-They record only the qualitative conclusion `∃ N, S_N(A) = M_D(ℂ)`. In
+They state only the qualitative conclusion `∃ N, S_N(A) = M_D(ℂ)`. In
 particular, they do **not** track the explicit `D²` blocked noninvertible bound
 or the sharp `D² − D + 1` fixed-length bound. Those quantitative statements are
 formalized separately in `PaperResults/MatrixSpanSharpBound.lean` and in the
@@ -50,7 +50,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- **Lemma 2(b)** (coarse existential wrapper).
+/-- **Lemma 2(b)** (coarse existential statement).
 
 If `A` is normalized and primitive in the paper sense, then there exists `N`
 such that `S_N(A) = M_D(ℂ)`.

--- a/TNLean/Wielandt/PaperResults/MatrixSpanSharpBound.lean
+++ b/TNLean/Wielandt/PaperResults/MatrixSpanSharpBound.lean
@@ -7,11 +7,11 @@ import TNLean.Wielandt.Primitivity.Equivalence
 import TNLean.Wielandt.RectangularSpan.Universality
 
 /-!
-# Lemma 2(b) — exact D²−D+1 paper-facing wrapper (arXiv:0909.5347)
+# Lemma 2(b) — exact D²−D+1 paper-level statement (arXiv:0909.5347)
 
 This file states the **exact paper-level** version of **Lemma 2(b)** from
 Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequality*
-(arXiv:0909.5347), in the paper-facing `IsPrimitivePaper` language.
+(arXiv:0909.5347), in the `IsPrimitivePaper` language of the paper.
 
 ## Main results
 

--- a/TNLean/Wielandt/PaperResults/NonzeroTraceWord.lean
+++ b/TNLean/Wielandt/PaperResults/NonzeroTraceWord.lean
@@ -7,12 +7,12 @@ import TNLean.Wielandt.Primitivity.Equivalence
 import TNLean.Wielandt.SpanGrowth.NonzeroTraceProduct
 
 /-!
-# Lemma 1 — paper-facing nonzero-trace wrapper (arXiv:0909.5347)
+# Lemma 1 — nonzero-trace word (arXiv:0909.5347)
 
 This file states the formal version of **Lemma 1** from
 Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequality*
-(arXiv:0909.5347), and the corresponding discussion in Wolf's Chapter 6, in the
-paper-facing `IsPrimitivePaper` language.
+(arXiv:0909.5347), and the corresponding discussion in Wolf's Chapter 6,
+in the `IsPrimitivePaper` language of the paper.
 
 ## Main results
 
@@ -49,7 +49,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- **Lemma 1** (paper-facing wrapper, coarse version).
+/-- **Lemma 1** (existential version).
 
 If `A` is normalized and primitive in the paper sense, then there exists a
 word `w` with `|w| ≤ D^2` such that `tr (evalWord A w) ≠ 0`.
@@ -65,7 +65,7 @@ theorem exists_nonzero_trace_word_of_isPrimitivePaper [NeZero D]
     ∃ w : List (Fin d), w.length ≤ D ^ 2 ∧ Matrix.trace (evalWord A w) ≠ 0 := by
   exact exists_nonzero_trace_word A (isNormal_of_isPrimitivePaper A hNorm hPrim)
 
-/-- **Lemma 1, sharp version** (paper-facing wrapper).
+/-- **Lemma 1, sharp version**.
 
 If `A` is normalized and primitive in the paper sense, then there exists a
 word `w` with `|w| ≤ D² − krausRank(A) + 1` such that `tr (evalWord A w) ≠ 0`.
@@ -74,7 +74,7 @@ This is the exact quantitative bound from Lemma 1 of arXiv:0909.5347:
 "If E_A is primitive, then there exists A^(n) ∈ S_n(A) with
 n ≤ D² − d + 1 such that tr(A^(n)) ≠ 0."
 
-The paper uses the raw parameter `d` (number of Kraus operators), but
+The paper uses the explicit parameter `d` (number of Kraus operators), but
 dim(S₁(A)) ≤ d in general, and `krausRank A = dim(S₁(A))` is the
 tight quantity. When `{A₁,…,Aₐ}` is a minimal Kraus family (linearly
 independent), `krausRank A = d` and the bounds coincide.
@@ -90,7 +90,7 @@ theorem exists_nonzero_trace_word_of_isPrimitivePaper_sharp [NeZero D]
       Matrix.trace (evalWord A w) ≠ 0 := by
   exact exists_nonzero_trace_word_sharp A (isNormal_of_isPrimitivePaper A hNorm hPrim)
 
-/-- **Lemma 1, sharp cumulative span** (paper-facing wrapper).
+/-- **Lemma 1, sharp cumulative span** (paper-level statement).
 
 If `A` is normalized and primitive in the paper sense, then the cumulative
 span reaches ⊤ by step D² − krausRank(A) + 1:
@@ -106,7 +106,7 @@ theorem cumulativeSpan_eq_top_of_isPrimitivePaper_sharp [NeZero D]
   exact cumulativeSpan_eq_top_of_isNormal_sharp A
     (isNormal_of_isPrimitivePaper A hNorm hPrim)
 
-/-- **Lemma 1, sharp positive-length version** (paper-facing wrapper).
+/-- **Lemma 1, sharp positive-length version** (paper-level statement).
 
 For `D ≥ 2`, if `A` is normalized and primitive in the paper sense, then there
 exists a **positive-length** word `w` with `|w| ≤ D² − krausRank(A) + 1`

--- a/TNLean/Wielandt/PaperResults/WielandtInequality.lean
+++ b/TNLean/Wielandt/PaperResults/WielandtInequality.lean
@@ -13,7 +13,7 @@ import TNLean.Wielandt.RankOne.Products
 /-!
 # Theorem 1 — Quantum Wielandt's inequality (arXiv:0909.5347 / Wolf §6.9)
 
-This file contains the public paper-facing wrappers for the currently
+This file contains the public paper-level statements for the currently
 formalized parts of **Theorem 1** from Sanz–Pérez-García–Wolf–Cirac,
 *A quantum version of Wielandt's inequality* (arXiv:0909.5347), equivalently
 Wolf's Theorem 6.9 in *Quantum Channels & Operations: Guided Tour*.
@@ -55,17 +55,17 @@ Theorem 1 also gives the case-(2) bound:
   the corresponding numeric bound
   `iIndex A ≤ D ^ 2 - krausRank A + 1`.
 
-These case-(2) wrappers pass from paper primitivity to `IsNormal A` and then
+These case-(2) statements pass from paper primitivity to `IsNormal A` and then
 invoke the backend theorem `wordSpan_eq_top_of_isNormal_of_isUnit` from
 `SpanGrowth/InvertibleWordSpan.lean`.
 
-Within TNLean these results are currently standalone paper-facing endpoints:
+Within TNLean these results are currently standalone paper-level theorem statements:
 the canonical / FT / BNT development does not import them directly.
 
 This file is the preferred public entry point for the currently formalized
-Theorem 1 wrappers. The auxiliary module `QuantumWielandt.lean` keeps a
+Theorem 1 statements. The auxiliary module `QuantumWielandt.lean` keeps a
 backward-compatible exact-word-span witness theorem with an explicit
-aperiodicity argument in its statement; it is not the default paper-facing API.
+aperiodicity argument in its statement; it is not the default paper-level formulation.
 
 ### Part 4 — Case (1): general bound
 

--- a/TNLean/Wielandt/PaperResults/WielandtInequality.lean
+++ b/TNLean/Wielandt/PaperResults/WielandtInequality.lean
@@ -56,7 +56,7 @@ Theorem 1 also gives the case-(2) bound:
   `iIndex A ≤ D ^ 2 - krausRank A + 1`.
 
 These case-(2) statements pass from paper primitivity to `IsNormal A` and then
-invoke the backend theorem `wordSpan_eq_top_of_isNormal_of_isUnit` from
+invoke the theorem `wordSpan_eq_top_of_isNormal_of_isUnit` from
 `SpanGrowth/InvertibleWordSpan.lean`.
 
 Within TNLean these results are currently standalone paper-level theorem statements:

--- a/TNLean/Wielandt/Primitivity/Equivalence.lean
+++ b/TNLean/Wielandt/Primitivity/Equivalence.lean
@@ -10,7 +10,7 @@ import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
 /-!
 # Proposition 3 — Full Equivalence (arXiv:0909.5347)
 
-This file contains the paper-facing development of **Proposition 3** from
+This file contains the paper-level development of **Proposition 3** from
 Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequality*
 (arXiv:0909.5347, Section II), and establishes the full circular equivalence.
 
@@ -44,7 +44,7 @@ import surface. The direction-specific files
 `Primitivity/ImpliesStronglyIrreducibleAux.lean`, and
 `Primitivity/StronglyIrreducibleToFullRank.lean` remain specialized
 implementation modules, while the canonical / FT / BNT assembly does not
-import these wrappers directly.
+import these statements directly.
 
 ## Full-equivalence corollaries
 
@@ -214,13 +214,13 @@ theorem hasEventuallyFullKrausRank_iff_stronglyIrreducible [NeZero D]
   ⟨fun hB => isStronglyIrreduciblePaper_of_hasEventuallyFullKrausRank A hNorm hB,
    fun hC => prop3_cb A hNorm hC⟩
 
-/-! ## Wolf Theorem 6.8 packaged forms -/
+/-! ## Wolf Theorem 6.8 statements -/
 
 /-- **Wolf Theorem 6.8 (Kraus-span form)**:
 paper primitivity is equivalent to eventual full Kraus-word span.
 
-This is a naming wrapper around `primitivePaper_iff_hasEventuallyFullKrausRank`,
-matching Wolf's Chapter 6 wording ("the Kraus operators eventually span all
+This theorem gives `primitivePaper_iff_hasEventuallyFullKrausRank` the
+numbered Wolf Chapter 6 name ("the Kraus operators eventually span all
 matrices"). -/
 theorem wolf_theorem_6_8_kraus_span [NeZero D]
     (A : MPSTensor d D)
@@ -228,7 +228,7 @@ theorem wolf_theorem_6_8_kraus_span [NeZero D]
     IsPrimitivePaper A ↔ HasEventuallyFullKrausRank A :=
   primitivePaper_iff_hasEventuallyFullKrausRank A hNorm
 
-/-- **Wolf Theorem 6.8 (packaged conjunction form)**:
+/-- **Wolf Theorem 6.8 (conjunction form)**:
 paper primitivity is equivalent to the conjunction of eventual full Kraus rank,
 normality, and strong irreducibility.
 
@@ -273,7 +273,7 @@ theorem prop3_a_implies_peripherallyPrimitive [NeZero D]
 /-- **Equation (2)**: the primitivity index is at most the full-Kraus-rank
 index.
 
-This records the quantitative bound following Proposition 3.
+This states the quantitative bound following Proposition 3.
 Paper: arXiv:0909.5347, equation (2); Wolf, Theorem 6.9.
 -/
 theorem prop3_qIndex_le_iIndex (A : MPSTensor d D)

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
@@ -12,16 +12,16 @@ import Mathlib.Analysis.InnerProductSpace.Positive
 import Mathlib.Analysis.Matrix.Spectrum
 
 /-!
-# Proposition 3, (a) → (c): Helper lemmas (Parts 1–8)
+# Proposition 3, (a) → (c): Auxiliary lemmas (Parts 1–8)
 
-This file develops the foundational helper lemmas (Parts 1–8) toward the (a)→(c)
+This file develops the foundational auxiliary lemmas (Parts 1–8) toward the (a)→(c)
 direction of Proposition 3 from arXiv:0909.5347:
 **IsPrimitivePaper A → IsStronglyIrreduciblePaper A**.
 
-The spectral-perturbation machinery and concluding theorems (Parts 9–14) are in
+The spectral-perturbation argument and concluding theorems (Parts 9–14) are in
 `TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducibleAux`.
 
-For the packaged public Proposition 3 API, prefer
+For the public Proposition 3 formulation, prefer
 `TNLean.Wielandt.Primitivity.Equivalence`; this file is retained for specialized
 access to the intermediate lemmas used in the (a)→(c) proof.
 
@@ -251,7 +251,7 @@ theorem posDef_fixedPoint_of_isPrimitivePaper
 
 /-! ## Part 6: Positivity-improving map and fixed-point contradiction lemmas
 
-These lemmas form the contradiction machinery for the paper's case analysis
+These lemmas form the contradiction argument for the paper's case analysis
 in the proof of `IsPrimitivePaper A → IsPeripherallyPrimitive A`.
 
 **Paper context** (arXiv:0909.5347 Proposition 3, (a)→(c)):

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -11,10 +11,10 @@ import TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducible
 This file continues the (a)→(c) direction of Proposition 3 from arXiv:0909.5347:
 **IsPrimitivePaper A → IsStronglyIrreduciblePaper A**.
 
-It builds on the helper lemmas in `ImpliesStronglyIrreducible` (Parts 1–8) and develops:
+It builds on the auxiliary lemmas in `ImpliesStronglyIrreducible` (Parts 1–8) and develops:
 
 - **Part 9: Spectral perturbation** — from peripheral eigenvectors to PSD non-PosDef
-  fixed points (the machinery for case (iii) of Wolf §6.4 Theorem 6.7).
+  fixed points (the argument for case (iii) of Wolf §6.4 Theorem 6.7).
 - **Part 10: Uniqueness** of PSD fixed points under paper-primitivity.
 - **Part 11: Channel structure** — the iterated transfer map `E^p` is a quantum channel.
 - **Part 12: Hermitian vanishing** — Hermitian trace-zero `E^p`-fixed points vanish
@@ -24,7 +24,7 @@ It builds on the helper lemmas in `ImpliesStronglyIrreducible` (Parts 1–8) and
 - **Part 14: Conclusion** — `IsPrimitivePaper A → IsPeripherallyPrimitive A` and
   `IsPrimitivePaper A → IsStronglyIrreduciblePaper A`.
 
-For the packaged public Proposition 3 API, prefer
+For the public Proposition 3 formulation, prefer
 `TNLean.Wielandt.Primitivity.Equivalence`; this file is retained for specialized
 access to the intermediate lemmas used in the (a)→(c) proof.
 
@@ -41,7 +41,7 @@ namespace MPSTensor
 
 /-! ## Part 9: Spectral perturbation — from peripheral eigenvectors to PSD non-PosDef fixed points
 
-This section develops the spectral-perturbation machinery needed for the paper's case (iii)
+This section develops the spectral-perturbation argument needed for the paper's case (iii)
 in Proposition 3 (a)→(c) of arXiv:0909.5347.
 
 **Setup**: Given `ρ.PosDef` with `E(ρ) = ρ`, and a nontrivial peripheral eigenvector
@@ -265,7 +265,7 @@ theorem exists_hermitian_ne_zero_trace_zero_pow_fixedPoint
       not_posSemidef_of_hermitian_ne_zero_trace_eq_zero
         (isHermitian_smul_I_sub_conjTranspose X) h (trace_antiHermitianPart_eq_zero htr)⟩
 
-/-! ### Step 7: Helper lemmas for the perturbation construction -/
+/-! ### Step 7: Auxiliary lemmas for the perturbation construction -/
 
 /-- **Negative eigenvalue of non-PSD Hermitian matrix.**
 
@@ -666,12 +666,12 @@ a positive-definite fixed point, peripheral spectrum `{1}`, and is irreducible
    `IsIrreducibleMap` on the transfer map
    (`isIrreducibleCP_transferMap_of_isIrreducibleTensor`).
 
-This packaged strong-irreducibility statement is exactly the input later fed
+This formulated strong-irreducibility statement is exactly the input later fed
 into Proposition 3(c)→(b), which yields eventual full Kraus rank (hence
 normality) directly, without passing through an aperiodicity argument.
 
 Paper: Proposition 3 (a)⟹(c) of arXiv:0909.5347.
-This is the full paper-facing (a)→(c) direction. -/
+This is the full paper-level (a)→(c) direction. -/
 theorem isStronglyIrreduciblePaper_of_isPrimitivePaper [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -10,7 +10,7 @@ import TNLean.Wielandt.WielandtBound
 /-!
 # Primitivity consequences and normality restatements
 
-This file records the low-level consequences of `HasPrimitiveFixedPoint` used in the
+This file states the low-level consequences of `HasPrimitiveFixedPoint` used in the
 Wielandt development and recalls the normality side of the chain from
 `WielandtBound.lean`.
 
@@ -26,7 +26,7 @@ with extra `ρ.PosDef` and aperiodicity hypotheses is assembled in
 * `transferMap_pow_apply_eq_sum`: `E^n(X) = Σ_σ (evalWord A σ) X (evalWord A σ)†`
 * `exists_nonzero_evalWord_of_isPrimitiveMPS`: for every `n`, some length-`n`
   word product is nonzero
-* `exists_nonzero_evalWord_of_hasPrimitiveFixedPoint`: existential wrapper
+* `exists_nonzero_evalWord_of_hasPrimitiveFixedPoint`: existential statement
 * `transferMap_pow_ne_zero_of_hasPrimitiveFixedPoint`: every transfer-map iterate is nonzero
 
 ### From normality
@@ -97,7 +97,7 @@ theorem exists_nonzero_evalWord_of_isPrimitiveMPS [NeZero D]
   rw [hsum] at hfix
   exact hP.fixedPoint_ne_zero hfix.symm
 
-/-- Existential wrapper: if `A` has a primitive fixed point, every word length has a
+/-- Existential statement: if `A` has a primitive fixed point, every word length has a
 nonzero word product. -/
 theorem exists_nonzero_evalWord_of_hasPrimitiveFixedPoint [NeZero D]
     {A : MPSTensor d D} (hP : HasPrimitiveFixedPoint A) (n : ℕ) :
@@ -119,7 +119,7 @@ theorem transferMap_pow_ne_zero_of_isPrimitiveMPS [NeZero D]
   rw [transferMap_pow_fixed hP.fixedPoint_is_fixed n] at this
   exact hP.fixedPoint_ne_zero this
 
-/-- Existential wrapper for `transferMap_pow_ne_zero`. -/
+/-- Existential statement for `transferMap_pow_ne_zero`. -/
 theorem transferMap_pow_ne_zero_of_hasPrimitiveFixedPoint [NeZero D]
     {A : MPSTensor d D} (hP : HasPrimitiveFixedPoint A) (n : ℕ) :
     (transferMap (d := d) (D := D) A) ^ n ≠ 0 := by
@@ -136,7 +136,7 @@ Given `IsNormal A`, the full Wielandt chain provides:
 3. A nonzero eigenvalue μ and eigenvector φ for evalWord A w₀
 4. Vector spanning: for any nonzero φ, word products applied to φ span ℂ^D
 
-This records `wielandt_chain` from `WielandtBound.lean` under a cleaner name. -/
+This states `wielandt_chain` from `WielandtBound.lean` under a cleaner name. -/
 theorem wielandt_full_analysis [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     cumulativeSpan A (D ^ 2) = ⊤ ∧
@@ -158,8 +158,8 @@ positive definite and `1 ∈ wordSpan A 1`.
 
 What remains here is the gap from bare spectral-gap primitivity to eventual
 full matrix spanning. Conceptually this should follow from irreducibility plus a
-Burnside- or peripheral-spectrum argument, but that infrastructure is kept out
-of this lightweight wrapper file.
+Burnside- or peripheral-spectrum argument, but that formalization is kept out
+of this lightweight statement file.
 -/
 
 

--- a/TNLean/Wielandt/Primitivity/PaperDefinitions.lean
+++ b/TNLean/Wielandt/Primitivity/PaperDefinitions.lean
@@ -7,15 +7,15 @@ import TNLean.MPS.Core.Transfer
 import TNLean.Channel.Peripheral.Spectrum
 
 /-!
-# Paper-facing definition layer for primitivity (arXiv:0909.5347)
+# Paper-level definition layer for primitivity (arXiv:0909.5347)
 
 This file provides **paper-faithful definitions** that mirror the notation and
 terminology of Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's
 inequality* (arXiv:0909.5347) and Wolf's lecture notes (Chapter 6).
 
-All definitions here are thin wrappers around existing codebase constructs.
-They are intended as the public API surface for stating Proposition 3 and the
-Wielandt bound in paper notation, without changing the internal proof machinery.
+All definitions here are concise restatements of existing codebase constructs.
+They provide the public paper-notation formulation of Proposition 3 and the
+Wielandt bound, without changing the internal proof argument.
 
 ## Main definitions
 
@@ -37,12 +37,12 @@ There are four distinct primitivity predicates in the codebase:
   peripheral-spectrum predicate for an arbitrary linear map `E`, defined by
   `peripheralEigenvalues E = {1}`.
 * `MPSTensor.HasPrimitiveFixedPoint A` in
-  `TNLean/MPS/Structure/PrimitivityBridge.lean`: the existential wrapper
+  `TNLean/MPS/Structure/PrimitivityBridge.lean`: the existential statement
   `∃ ρ, IsPrimitiveMPS A ρ`, encoding the spectral-gap formulation used in the MPS
-  proof chain.
+  proof route.
 * `IsPrimitivePaper A` in this file: the paper-faithful uniform spreading condition from
   Proposition 3(a).
-* `IsPeripherallyPrimitive A` in this file: the transfer-map wrapper around
+* `IsPeripherallyPrimitive A` in this file: the transfer-map formulation of
   `_root_.IsPrimitive (transferMap A)`.
 
 The intended relationships are:
@@ -59,13 +59,12 @@ The intended relationships are:
 
 ## Design notes
 
-These are **paper-facing wrappers only**. The internal proof chain flows through
+These are **paper-level statements only**. The internal proof route flows through
 `IsNormal`, `IsPrimitiveMPS`, `HasPrimitiveFixedPoint`, etc. The full equivalence of
 all three Proposition 3 conditions is assembled in `Primitivity/Equivalence.lean`.
 
 At present this layer is not imported by the canonical / FT / BNT assembly in
-`TNLean.MPS.*` or `TNLean.PiAlgebra.*`; it serves the standalone paper-facing
-endpoint modules below.
+`TNLean.MPS.*` or `TNLean.PiAlgebra.*`; it serves the standalone theorem modules below.
 
 ## References
 
@@ -152,23 +151,23 @@ if no such `q` exists. -/
 noncomputable def qIndex (A : MPSTensor d D) : ℕ :=
   sInf {q : ℕ | ∀ φ : Fin D → ℂ, φ ≠ 0 → vectorSpreadSpan A φ q = ⊤}
 
-/-! ## Peripheral primitivity (transfer-map wrapper) -/
+/-! ## Peripheral primitivity (transfer-map formulation) -/
 
 /-- **Peripheral primitivity** of an MPS tensor: the transfer map `E_A` has
 peripheral spectrum `{1}`, i.e. `1` is the only eigenvalue of `E_A` on the unit
 circle.
 
-This is the transfer-map wrapper around the canonical predicate
+This is the transfer-map formulation of the canonical predicate
 `_root_.IsPrimitive (transferMap A)` from
 `TNLean/Channel/Peripheral/Spectrum.lean`.
 
 For orientation, the codebase distinguishes four related notions:
 
 * `_root_.IsPrimitive E`: generic peripheral-spectrum primitivity for any linear map `E`;
-* `MPSTensor.HasPrimitiveFixedPoint A`: existential wrapper around the spectral-gap
+* `MPSTensor.HasPrimitiveFixedPoint A`: existential statement around the spectral-gap
   predicate `IsPrimitiveMPS`;
 * `IsPrimitivePaper A`: the paper-faithful uniform spreading condition;
-* `IsPeripherallyPrimitive A`: this thin transfer-map wrapper.
+* `IsPeripherallyPrimitive A`: this thin transfer-map formulation.
 
 Paper: "E_A is primitive" means `1` is the only eigenvalue with `|λ| = 1`.
 Wolf Ch6 Definition 6.2(2). -/
@@ -200,7 +199,7 @@ quantum Perron–Frobenius theorem) and aperiodicity giving uniqueness of the
 peripheral eigenvalue.
 
 **Relationship to `IsPrimitiveMPS` / `HasPrimitiveFixedPoint`**: this is
-strictly stronger than the spectral-gap wrapper because the fixed point is
+strictly stronger than the spectral-gap statement because the fixed point is
 required to be positive *definite* (not merely positive semidefinite). For
 irreducible channels, the PSD fixed point is automatically PosDef, so the two
 notions coincide in that case.

--- a/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
@@ -214,7 +214,7 @@ theorem isNormal_of_isIrreducibleAction_of_aperiodic [NeZero D]
 /-- If `IsIrreducibleTensor A`, `1 ∈ wordSpan A 1`, and `NeZero D`, then `IsNormal A`.
 
 Extends the chain with `IsIrreducibleTensor → IsIrreducibleAction`
-(proved in `IrreducibleTensorAction.lean`). This is the endpoint later combined
+(proved in `IrreducibleTensorAction.lean`). This is the conclusion later combined
 with strong irreducibility, which supplies the aperiodicity hypothesis. -/
 theorem isNormal_of_isIrreducibleTensor_of_aperiodic [NeZero D]
     (A : MPSTensor d D)


### PR DESCRIPTION
## Summary

- Replaces paper-facing/wrapper/endpoint/helper/machinery wording with direct mathematical descriptions in Wielandt paper-result and primitivity modules.
- Describes Proposition 3, Lemma 1, Lemma 2, and the Quantum Wielandt statements as paper-level statements and theorem formulations.

Closes #1024.

## Testing

- `lake build --old TNLean.Wielandt.PaperResults.EigenvectorSpreading TNLean.Wielandt.PaperResults.MatrixSpanExistence TNLean.Wielandt.PaperResults.MatrixSpanSharpBound TNLean.Wielandt.PaperResults.NonzeroTraceWord TNLean.Wielandt.PaperResults.WielandtInequality TNLean.Wielandt.Primitivity.PaperDefinitions TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducible TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducibleAux TNLean.Wielandt.Primitivity.Equivalence TNLean.Wielandt.Primitivity.Normal TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`
- `git diff --check`
- grep scan for `paper-facing|wrapper|endpoint|helper lemmas|machinery|standalone paper-facing|recorded|package|raw|API|infrastructure` in touched files (no process-prose matches; remaining `standalone paper-level` is deliberate mathematical wording)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring/comment-only changes with no impact on proof terms or exported theorem behavior.
> 
> **Overview**
> Updates documentation/comments across the Wielandt “paper results” and primitivity modules to present theorems as direct **paper-level mathematical statements**, replacing “paper-facing wrapper/endpoint/helper/machinery” language with terminology like “statement”, “formulation”, and “auxiliary lemmas”.
> 
> No proof code or theorem statements are materially changed; the PR is a wording/organization pass to align module headers and docstrings for Proposition 3, Lemma 1, Lemma 2, and Theorem 1 with the paper/Wolf phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 663e3706b47f96efaf617a2759bb40aff96771e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->