### PR TITLE
style(MPS): correct prose in MPDO and ParentHamiltonian docstrings

### DIFF
--- a/TNLean/MPS/MPDO/PRFP.lean
+++ b/TNLean/MPS/MPDO/PRFP.lean
@@ -57,7 +57,7 @@ def purifyingMPSTensor {dK D' : ℕ}
     purifyingMPSTensor A ik = A ik.divNat ik.modNat :=
   rfl
 
-/-- Repackaging `IsLPDO` in terms of `IsLPDOWitness`. -/
+/-- The LPDO condition expressed in terms of `IsLPDOWitness`. -/
 theorem isLPDO_iff_exists_witness (M : MPOTensor d D) :
     IsLPDO M ↔
       ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -123,7 +123,7 @@ A normal renormalization fixed-point tensor has a nearest-neighbor
 commuting parent Hamiltonian.
 
 Per arXiv:1606.00608 §3.3 (source line 1307), this direction is
-*"trivial from Theorem [charact-MPS]"*; it is therefore **not** gated
+*"trivial from Theorem [charact-MPS]"*; it therefore does not depend
 on S. Beigi (2012). It is conditioned only on the product-of-entangled-pairs
 structural form (Appendix B), stated here as
 `Axioms.rfp_to_nncph_commute`. -/


### PR DESCRIPTION
### Motivation

- Docstrings in `TNLean/MPS/MPDO/PRFP.lean` and `TNLean/MPS/ParentHamiltonian/Commuting.lean` contained process-oriented vocabulary ("Repackaging", "gated") that the project prose guide bans in reader-facing Lean text.
- The corrections make both docstrings state their content as direct mathematical conditions, without borrowing implementation or software-process language (see issue #1015).

### Description

- `TNLean/MPS/MPDO/PRFP.lean`: the docstring of `isLPDO_iff_exists_witness` previously read "Repackaging `IsLPDO` in terms of `IsLPDOWitness`"; it now reads "The LPDO condition expressed in terms of `IsLPDOWitness`", removing the banned "repackaging" framing.
- `TNLean/MPS/ParentHamiltonian/Commuting.lean`: the docstring of `rfp_implies_nncph` described the RFP-to-NNCPH direction as "**not** gated on S. Beigi (2012)"; it now reads "it therefore does not depend on S. Beigi (2012)", which is the direct mathematical statement of independence.
- No theorem statements, proofs, or definitions are changed.

### Testing

- `lake env lean TNLean/MPS/MPDO/PRFP.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Commuting.lean`

Both files elaborate with the existing local Mathlib cache.

---
Addresses #1015

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only wording changes with no impact on elaboration, logic, or runtime behavior.
> 
> **Overview**
> Updates documentation strings in `TNLean/MPS/MPDO/PRFP.lean` and `TNLean/MPS/ParentHamiltonian/Commuting.lean` to replace process-oriented phrasing with direct mathematical statements (e.g., “repackaging” → “expressed in terms of”, “not gated” → “does not depend”).
> 
> No definitions, theorem statements, or proofs change; only reader-facing doc prose is adjusted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f5bb01d67023fd11ebf019468b1c23e0ecd8e05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->