### PR TITLE
fix(ci): guard tracking workflow by event type

### DIFF
--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -24,10 +24,14 @@ jobs:
   track:
     # Skip: forks (no secrets), closed-but-not-completed issues, closed-but-not-merged PRs
     if: |
-      !github.event.pull_request.head.repo.fork &&
       (
-        (github.event_name == 'issues' && (github.event.issue.state_reason == 'completed' || github.event.action == 'reopened')) ||
-        (github.event_name == 'pull_request' && (github.event.action != 'closed' || github.event.pull_request.merged == true))
+        github.event_name == 'issues' &&
+        (github.event.issue.state_reason == 'completed' || github.event.action == 'reopened')
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        !github.event.pull_request.head.repo.fork &&
+        (github.event.action != 'closed' || github.event.pull_request.merged == true)
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
<!--
PR title format: type(scope): short mathematical description
Types: feat, fix, refactor, doc, style, ci, chore.
Examples:
- feat(MPS/CanonicalForm): assemble cyclic sectors at a common blocking length
- doc(Wolf Ch6): add Lean tags for spectral theorems
- style(MPS/CanonicalForm): rewrite equal-case prose in MPS language
-->

### Motivation
<!-- Why this change is needed (1--3 bullets). -->
<!-- For mathematical work, cite the source theorem, blueprint label, or issue. -->

-

### Description
<!-- What was changed: files added/modified, definitions introduced, lemmas proved. -->
<!-- State the mathematical content precisely enough for a reader who has not read
     the issue thread. -->

-

### Testing
<!-- What was verified and how. -->
<!-- Examples: `lake env lean TNLean/Foo/Bar.lean`, `lake build TNLean`,
     `rg -n "sorry|axiom" TNLean/Foo/Bar.lean || true`. -->

-

---
Addresses #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML logic change that only affects when the Issue Tracker workflow runs; main risk is accidentally skipping/triggering the job for certain issue/PR events.
> 
> **Overview**
> Tightens the `Issue Tracker` GitHub Actions workflow job gate so fork checks are only evaluated for `pull_request` events, while `issues` events are filtered solely by `state_reason`/`reopened`.
> 
> This prevents referencing `pull_request` context when the workflow is triggered by an issue event, reducing unintended skips or evaluation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029a2231605efc17d6896168952444310aba2a9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->