### PR TITLE
docs(paper-gaps): note PEPS edge-scalar uniqueness

### DIFF
--- a/docs/paper-gaps/peps_gauge_edge_scalars.tex
+++ b/docs/paper-gaps/peps_gauge_edge_scalars.tex
@@ -35,7 +35,7 @@ if their tensors are related by local gauges. In short, the source says that the
 local gauges are ``unique up to a multiplicative constant.''\footnote{The
 quoted uniqueness phrase occurs in
 \path{Papers/1804.04964/paper_normal.tex:1207--1210}. For traceability, this
-note corresponds to \href{https://github.com/LionSR/TNLean/issues/1045}{issue \#1045}.}
+note corresponds to \ghissue{1045}.}
 Interpreted as uniqueness up to one common scalar multiplying all edge gauges,
 this statement is too small for a general graph.
 
@@ -105,7 +105,7 @@ global-scalar uniqueness interpretation is false even for a connected simple
 graph with one-dimensional bonds. The same example fits the balanced
 edge-scalar quotient exactly.\footnote{This is the counterexample recorded in
 \path{docs/counterexamples.md:127--135}. It originated in
-\href{https://github.com/LionSR/TNLean/issues/762}{issue \#762}; the formal
+\ghissue{762}; the formal
 statement was corrected in \ghpr{790}.}
 
 \section{Formal statement}
@@ -127,7 +127,7 @@ global vertex-balanced edge-scalar family.\footnote{For traceability, the
 declaration is \texttt{TNLean.PEPS.gauge\_unique\_mod\_edge\_scalars}, and the
 remaining proof obligation is at
 \path{TNLean/PEPS/FundamentalTheorem.lean:686--730}. This point is recorded in
-\href{https://github.com/LionSR/TNLean/issues/842}{issue \#842};
+\ghissue{842};
 \ghpr{879} reduced the formal
 statement to the scalar-ratio and global-reconciliation step.}
 

--- a/docs/paper-gaps/peps_gauge_edge_scalars.tex
+++ b/docs/paper-gaps/peps_gauge_edge_scalars.tex
@@ -73,8 +73,8 @@ $\prod_{e\ni v} c_{v,e}$. If the scalar family is vertex-balanced, this product
 is $1$ at every vertex, so all local gauged tensors are unchanged. Thus local
 gauge uniqueness can at best be uniqueness modulo these balanced edge scalars.
 The formal statement uses this quotient as the corrected uniqueness statement.\footnote{The formal definitions are
-\texttt{TNLean.PEPS.edgeScalarAt}, \texttt{TNLean.PEPS.IsVertexBalanced}, and
-\texttt{TNLean.PEPS.GaugeEquivModEdgeScalars} in
+\leanid{TNLean.PEPS.edgeScalarAt}, \leanid{TNLean.PEPS.IsVertexBalanced}, and
+\leanid{TNLean.PEPS.GaugeEquivModEdgeScalars} in
 \path{TNLean/PEPS/FundamentalTheorem.lean:603--625}. The corresponding
 blueprint entries are at \path{blueprint/src/chapter/ch13a_peps_ft.tex:375--423}.}
 
@@ -106,8 +106,7 @@ graph with one-dimensional bonds. The same example fits the balanced
 edge-scalar quotient exactly.\footnote{This is the counterexample recorded in
 \path{docs/counterexamples.md:127--135}. It originated in
 \href{https://github.com/LionSR/TNLean/issues/762}{issue \#762}; the formal
-statement was corrected in \href{https://github.com/LionSR/TNLean/pull/790}{PR
-\#790}.}
+statement was corrected in \ghpr{790}.}
 
 \section{Formal statement}
 
@@ -129,7 +128,7 @@ declaration is \texttt{TNLean.PEPS.gauge\_unique\_mod\_edge\_scalars}, and the
 remaining proof obligation is at
 \path{TNLean/PEPS/FundamentalTheorem.lean:686--730}. This point is recorded in
 \href{https://github.com/LionSR/TNLean/issues/842}{issue \#842};
-\href{https://github.com/LionSR/TNLean/pull/879}{PR \#879} reduced the formal
+\ghpr{879} reduced the formal
 statement to the scalar-ratio and global-reconciliation step.}
 
 Thus the corrected mathematical statement is uniqueness modulo balanced edge

--- a/docs/paper-gaps/peps_gauge_edge_scalars.tex
+++ b/docs/paper-gaps/peps_gauge_edge_scalars.tex
@@ -16,8 +16,8 @@
 
 \section{The assertion}
 
-This note concerns the uniqueness clause in the Fundamental Theorem for
-injective PEPS on a simple graph in \cite[Theorem~2 and Section~3]{Molnar2018NormalPEPS}.
+The uniqueness clause in the Fundamental Theorem for injective PEPS on a simple
+graph appears in \cite[Theorem~2 and Section~3]{Molnar2018NormalPEPS}.
 The argument first blocks the graph around a chosen edge to a three-site
 injective MPS. The one-dimensional fundamental theorem then assigns a gauge to
 that edge. Repeating this construction over all edges gives a family of edge
@@ -72,7 +72,7 @@ vertex $v$ by the factors $c_{v,e}$ multiplies the gauged local tensor at $v$ by
 $\prod_{e\ni v} c_{v,e}$. If the scalar family is vertex-balanced, this product
 is $1$ at every vertex, so all local gauged tensors are unchanged. Thus local
 gauge uniqueness can at best be uniqueness modulo these balanced edge scalars.
-The formal theorem uses this quotient as the corrected uniqueness target.\footnote{The formal definitions are
+The formal statement uses this quotient as the corrected uniqueness statement.\footnote{The formal definitions are
 \texttt{TNLean.PEPS.edgeScalarAt}, \texttt{TNLean.PEPS.IsVertexBalanced}, and
 \texttt{TNLean.PEPS.GaugeEquivModEdgeScalars} in
 \path{TNLean/PEPS/FundamentalTheorem.lean:603--625}. The corresponding
@@ -118,23 +118,23 @@ balanced edge-scalar family but not by one global scalar. Consequently the
 source phrase must either be read with this quotient understood, or corrected to
 say uniqueness modulo balanced edge scalars.
 
-The corrected quotient has not yet been fully proved.
-The theorem named \texttt{TNLean.PEPS.gauge\_unique\_mod\_edge\_scalars} states
-the repaired uniqueness result, but its proof still has a remaining tensor-factor
+The corrected quotient has not yet been fully proved. The repaired uniqueness
+result is stated formally, but its proof still has a remaining tensor-factor
 scalar-ratio and global-reconciliation step. The formal proof has reduced the
 problem to equality of products of incident edge-gauge entries at each vertex;
 what remains is to extract nonzero scalar ratios on the incident edges with
 product $1$ at the vertex, and then reconcile these local choices into a single
-global vertex-balanced edge-scalar family.\footnote{The declaration and
-remaining proof obligation are at
-\path{TNLean/PEPS/FundamentalTheorem.lean:686--730}. For traceability, the
-this point is recorded in \href{https://github.com/LionSR/TNLean/issues/842}{issue \#842};
-\href{https://github.com/LionSR/TNLean/pull/879}{PR \#879} reduced the formal statement
-to the scalar-ratio and global-reconciliation step.}
+global vertex-balanced edge-scalar family.\footnote{For traceability, the
+declaration is \texttt{TNLean.PEPS.gauge\_unique\_mod\_edge\_scalars}, and the
+remaining proof obligation is at
+\path{TNLean/PEPS/FundamentalTheorem.lean:686--730}. This point is recorded in
+\href{https://github.com/LionSR/TNLean/issues/842}{issue \#842};
+\href{https://github.com/LionSR/TNLean/pull/879}{PR \#879} reduced the formal
+statement to the scalar-ratio and global-reconciliation step.}
 
-Thus the present note records the corrected mathematical statement and the
-counterexample to the smaller quotient. It does not claim that the repaired
-uniqueness theorem has already been fully proved.
+Thus the corrected mathematical statement is uniqueness modulo balanced edge
+scalars, and the triangle example refutes the smaller quotient. The repaired
+uniqueness theorem remains a stated formal result rather than a completed proof.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/peps_gauge_edge_scalars.tex
+++ b/docs/paper-gaps/peps_gauge_edge_scalars.tex
@@ -105,8 +105,8 @@ global-scalar uniqueness interpretation is false even for a connected simple
 graph with one-dimensional bonds. The same example fits the balanced
 edge-scalar quotient exactly.\footnote{This is the counterexample recorded in
 \path{docs/counterexamples.md:127--135}. It originated in
-\href{https://github.com/LionSR/TNLean/issues/762}{issue \#762}; the endpoint
-statement was repaired in \href{https://github.com/LionSR/TNLean/pull/790}{PR
+\href{https://github.com/LionSR/TNLean/issues/762}{issue \#762}; the formal
+statement was corrected in \href{https://github.com/LionSR/TNLean/pull/790}{PR
 \#790}.}
 
 \section{Formal statement}
@@ -128,13 +128,13 @@ product $1$ at the vertex, and then reconcile these local choices into a single
 global vertex-balanced edge-scalar family.\footnote{The declaration and
 remaining proof obligation are at
 \path{TNLean/PEPS/FundamentalTheorem.lean:686--730}. For traceability, the
-remaining work is recorded in \href{https://github.com/LionSR/TNLean/issues/842}{issue \#842};
-\href{https://github.com/LionSR/TNLean/pull/879}{PR \#879} reduced the endpoint
+this point is recorded in \href{https://github.com/LionSR/TNLean/issues/842}{issue \#842};
+\href{https://github.com/LionSR/TNLean/pull/879}{PR \#879} reduced the formal statement
 to the scalar-ratio and global-reconciliation step.}
 
 Thus the present note records the corrected mathematical statement and the
 counterexample to the smaller quotient. It does not claim that the repaired
-uniqueness theorem has already been fully formalized.
+uniqueness theorem has already been fully proved.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/peps_gauge_edge_scalars.tex
+++ b/docs/paper-gaps/peps_gauge_edge_scalars.tex
@@ -1,0 +1,142 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{PEPS Gauge Uniqueness and Balanced Edge Scalars}
+\author{}
+\date{2026-04-30}
+
+\begin{document}
+\maketitle
+
+\section{The assertion}
+
+This note concerns the uniqueness clause in the Fundamental Theorem for
+injective PEPS on a simple graph in \cite[Theorem~2 and Section~3]{Molnar2018NormalPEPS}.
+The argument first blocks the graph around a chosen edge to a three-site
+injective MPS. The one-dimensional fundamental theorem then assigns a gauge to
+that edge. Repeating this construction over all edges gives a family of edge
+gauges, and a local two-tensor comparison gives scalar proportionalities at the
+vertices.\footnote{In the repository source, the edge-blocking step is at
+\path{Papers/1804.04964/paper_normal.tex:981--1009}; the assignment of edge
+gauges is at \path{Papers/1804.04964/paper_normal.tex:1037--1065}; the local
+scalar proportionality argument is at
+\path{Papers/1804.04964/paper_normal.tex:1066--1092} and
+\path{Papers/1804.04964/paper_normal.tex:1204--1207}.}
+
+The theorem is then stated for PEPS on graphs with no double edges and no
+self-loops. It says that two injective PEPS generate the same state if and only
+if their tensors are related by local gauges. In short, the source says that the
+local gauges are ``unique up to a multiplicative constant.''\footnote{The
+quoted uniqueness phrase occurs in
+\path{Papers/1804.04964/paper_normal.tex:1207--1210}. For traceability, this
+note corresponds to \href{https://github.com/LionSR/TNLean/issues/1045}{issue \#1045}.}
+Interpreted as uniqueness up to one common scalar multiplying all edge gauges,
+this statement is too small for a general graph.
+
+\section{The corrected quotient}
+
+Let $G=(V,E)$ be a finite simple graph with a fixed orientation of each edge.
+For an edge $e$, a local gauge family assigns an invertible matrix $X_e$ on the
+bond space of $e$. At the tail of $e$ the endpoint action is $X_e$, and at the
+head of $e$ it is $X_e^{-1}$.
+
+A family of nonzero edge scalars $c=(c_e)_{e\in E}$ determines endpoint scalars
+\[
+  c_{v,e}=\begin{cases}
+    c_e, & \text{if } v \text{ is the tail of } e,\\
+    c_e^{-1}, & \text{if } v \text{ is the head of } e.
+  \end{cases}
+\]
+The family is vertex-balanced if
+\[
+  \prod_{e\ni v} c_{v,e}=1
+  \qquad\text{for every } v\in V.
+\]
+Two gauge families $X$ and $Y$ are equivalent modulo balanced edge scalars if
+there is such a vertex-balanced family $c$ with
+\[
+  X_{v,e}=c_{v,e}Y_{v,e}
+  \qquad\text{for every incident pair } (v,e),
+\]
+where $X_{v,e}$ and $Y_{v,e}$ denote the oriented endpoint actions of the two
+families.
+
+This is the graph-correct quotient. Rescaling the incident endpoint gauges at a
+vertex $v$ by the factors $c_{v,e}$ multiplies the gauged local tensor at $v$ by
+$\prod_{e\ni v} c_{v,e}$. If the scalar family is vertex-balanced, this product
+is $1$ at every vertex, so all local gauged tensors are unchanged. Thus local
+gauge uniqueness can at best be uniqueness modulo these balanced edge scalars.
+The formal theorem uses this quotient as the corrected uniqueness target.\footnote{The formal definitions are
+\texttt{TNLean.PEPS.edgeScalarAt}, \texttt{TNLean.PEPS.IsVertexBalanced}, and
+\texttt{TNLean.PEPS.GaugeEquivModEdgeScalars} in
+\path{TNLean/PEPS/FundamentalTheorem.lean:603--625}. The corresponding
+blueprint entries are at \path{blueprint/src/chapter/ch13a_peps_ft.tex:375--423}.}
+
+\section{The triangle witness}
+
+The obstruction already appears on the connected triangle. Let the vertices be
+$1<2<3$, orient every edge from the smaller endpoint to the larger endpoint, and
+let every bond dimension be $1$. Then an edge gauge is just a nonzero complex
+number. Take any nonzero injective bond-dimension-one PEPS tensor $A$, and
+compare the identity gauge family with the scalar gauge family
+\[
+  c_{12}=t,\qquad c_{23}=t,\qquad c_{13}=t^{-1},
+  \qquad t\in\mathbb C^\times,\quad t^2\ne 1.
+\]
+At the three vertices the oriented products are
+\[
+  c_{12}c_{13}=1,\qquad
+  c_{12}^{-1}c_{23}=1,\qquad
+  c_{13}^{-1}c_{23}^{-1}=1.
+\]
+Hence the family is vertex-balanced. Applying this gauge family to $A$ gives
+back the same local tensor at every vertex, so it is a second gauge family
+relating $A$ to itself.
+
+There is no single global scalar $s$ with $c_{12}=c_{13}=c_{23}=s$. Indeed,
+$c_{12}=c_{13}$ would give $t=t^{-1}$, contradicting $t^2\ne 1$. Therefore the
+global-scalar uniqueness interpretation is false even for a connected simple
+graph with one-dimensional bonds. The same example fits the balanced
+edge-scalar quotient exactly.\footnote{This is the counterexample recorded in
+\path{docs/counterexamples.md:127--135}. It originated in
+\href{https://github.com/LionSR/TNLean/issues/762}{issue \#762}; the endpoint
+statement was repaired in \href{https://github.com/LionSR/TNLean/pull/790}{PR
+\#790}.}
+
+\section{Formal statement}
+
+The discrepancy is a statement-level divergence, not only an unfinished proof.
+The triangle example satisfies the graph-theoretic setting of the uniqueness
+clause and produces two genuine gauge families which differ by a
+balanced edge-scalar family but not by one global scalar. Consequently the
+source phrase must either be read with this quotient understood, or corrected to
+say uniqueness modulo balanced edge scalars.
+
+The corrected quotient has not yet been fully proved.
+The theorem named \texttt{TNLean.PEPS.gauge\_unique\_mod\_edge\_scalars} states
+the repaired uniqueness result, but its proof still has a remaining tensor-factor
+scalar-ratio and global-reconciliation step. The formal proof has reduced the
+problem to equality of products of incident edge-gauge entries at each vertex;
+what remains is to extract nonzero scalar ratios on the incident edges with
+product $1$ at the vertex, and then reconcile these local choices into a single
+global vertex-balanced edge-scalar family.\footnote{The declaration and
+remaining proof obligation are at
+\path{TNLean/PEPS/FundamentalTheorem.lean:686--730}. For traceability, the
+remaining work is recorded in \href{https://github.com/LionSR/TNLean/issues/842}{issue \#842};
+\href{https://github.com/LionSR/TNLean/pull/879}{PR \#879} reduced the endpoint
+to the scalar-ratio and global-reconciliation step.}
+
+Thus the present note records the corrected mathematical statement and the
+counterexample to the smaller quotient. It does not claim that the repaired
+uniqueness theorem has already been fully formalized.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

- Adds `docs/paper-gaps/peps_gauge_edge_scalars.tex` as the standalone note requested in #1045.
- The note is written as mathematical prose and uses relative paper-gap paths (`\input{command}`, `\bibliography{references}`).
- This PR is stacked on #1050, which adds `docs/paper-gaps/references.bib` and relative path fixes for the shared template/policy.

## Validation

- Before splitting the branches, all eight paper-gap notes compiled from `docs/paper-gaps` with:
  `latexmk -pdf -interaction=nonstopmode -halt-on-error`.
- A style pass rewrote the notes away from project-management/SWE phrasing toward mathematical prose.
- Generated PDFs and LaTeX build artifacts were removed; this PR contains no compiled PDFs.

Closes #1045.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone LaTeX note only; no code or formalization logic is changed.
> 
> **Overview**
> Adds a standalone paper-gap note `docs/paper-gaps/peps_gauge_edge_scalars.tex` clarifying that the PEPS gauge “uniqueness up to a multiplicative constant” statement on general simple graphs must be interpreted **modulo vertex-balanced edge scalars**, not a single global scalar.
> 
> The note defines the balanced edge-scalar quotient, gives a triangle counterexample to the global-scalar interpretation, and cross-references the corresponding Lean/blueprint statements and the remaining unproved reconciliation step in the formal proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d9139bf7c86b6e442f6a4d81c8330a693da9ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->