### PR TITLE
feat(MPS/CanonicalForm): compare zero-tail sectors from common phase covers

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -9,18 +9,18 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 /-!
 # BNT proportional-decomposition sector comparisons
 
-This file contains the after-blocking sector-comparison consequences that use a BNT
-proportional-decomposition comparison of the nonzero-weight block families.  They are separated
-from `StructuralTheorem` so the structural reduction file remains focused on common blocking and
-zero-tail identities.
+This module gives after-blocking sector-comparison consequences from common MPV phase covers and
+from BNT proportional-decomposition comparisons of the nonzero-weight block families.
 
 ## Main statements
 
 * `afterBlocking_sectorComparison_of_proportionalDecompositionConclusion` — exact
   nonzero part decompositions plus BNT proportional-decomposition data imply the sector-weight
   comparison.
+* `afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover` — zero-tail decompositions
+  plus common MPV phase-cover data imply the same sector-weight comparison.
 * `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion` —
-  the same comparison with explicit zero-tail identities.
+  the zero-tail common-cover theorem applied to BNT proportional-decomposition data.
 
 ## References
 
@@ -87,6 +87,112 @@ theorem afterBlocking_sectorComparison_of_proportionalDecompositionConclusion
     A B hSame hp μA blocksA μB blocksB cover hAblocks hBblocks hTPA hTPB hIrrA hIrrB
     hPrimA hPrimB hInjA hInjB hμA hμB
 
+/-- **Zero-tail sector comparison from common MPV phase-cover data.**
+
+This zero-tail-aware variant combines exact zero-tail decompositions with a common MPV phase
+cover of the nonzero-weight block families. The cover gives the finite-length span equality for
+those families, while the one-sided phase-class BNT construction supplies the remaining overlap
+data for the collapsed representatives. -/
+theorem afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover
+    {d D₁ D₂ p rA rB zeroTailA zeroTailB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k : Fin rA, NeZero (dimA k)]
+    [∀ k : Fin rB, NeZero (dimB k)]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hp : 0 < p)
+    (μA : Fin rA → ℂ)
+    (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d p) (dimA k))
+    (μB : Fin rB → ℂ)
+    (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d p) (dimB k))
+    (cover : MPVCommonPhaseCover blocksA blocksB)
+    (hAblocks :
+      ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ)
+    (hBblocks :
+      ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ)
+    (hZeroTail : zeroTailA = zeroTailB)
+    (hTPA : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksA k i)ᴴ * blocksA k i = 1)
+    (hTPB : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksB k i)ᴴ * blocksB k i = 1)
+    (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))
+    (hIrrB : ∀ k, IsIrreducibleTensor (blocksB k))
+    (hPrimA : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimA k) (blocksA k)))
+    (hPrimB : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimB k) (blocksB k)))
+    (hInjA : ∀ k, IsInjective (blocksA k))
+    (hInjB : ∀ k, IsInjective (blocksB k))
+    (hμA : ∀ k, μA k ≠ 0)
+    (hμB : ∀ k, μB k ≠ 0) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
+    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_commonPhaseCover
+      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
+      hPrimA hPrimB hInjA hInjB hμA hμB cover
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
+    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      nonzeroA nonzeroB hAB hAblocks hBblocks hZeroTail
+  have hPeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p) P.toTensor := by
+    intro N hN σ
+    have hZero :
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ
+          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ + mpv nonzeroA σ :=
+            hAblocks N σ
+      _ = mpv nonzeroA σ := by rw [hZero]; simp
+      _ = mpv P.toTensor σ := (hPblocks N σ).symm
+  have hQeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p) Q.toTensor := by
+    intro N hN σ
+    have hZero :
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ
+          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ + mpv nonzeroB σ :=
+            hBblocks N σ
+      _ = mpv nonzeroB σ := by rw [hZero]; simp
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
+      _ = mpv nonzeroB σ := hNonzero N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  obtain ⟨M⟩ := hOverlapSpan.exists_sectorBasisMatching hPQeq
+  obtain ⟨ζ, hζne, hMultiset⟩ :=
+    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching M hPbnt hPQeq
+  exact ⟨p, hp, P, Q, hPeqPos, hQeqPos, hPQeq, hPbnt, hQbnt,
+          M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
+
 /-- **Zero-tail sector comparison from BNT proportional-decomposition data.**
 
 This zero-tail-aware variant combines the exact nonzero part cancellation step with the BNT
@@ -143,54 +249,10 @@ theorem afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConc
           Finset.univ.val.map (P.weight j) =
             Finset.univ.val.map
               (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
-  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
-  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
-    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_proportionalDecompositionConclusion
-      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
-      hPrimA hPrimB hInjA hInjB hμA hμB hMatch
-  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
-                      (blockTensor (d := d) (D := D₂) B p) :=
-    sameMPV₂_blockTensor A B hSame p
-  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
-    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
-      (blockTensor (d := d) (D := D₁) A p)
-      (blockTensor (d := d) (D := D₂) B p)
-      nonzeroA nonzeroB hAB hAblocks hBblocks hZeroTail
-  have hPeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p) P.toTensor := by
-    intro N hN σ
-    have hZero :
-        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ = 0 := by
-      rw [mpv_zeroMPSTensor]
-      simp [Nat.ne_of_gt hN]
-    calc
-      mpv (blockTensor (d := d) (D := D₁) A p) σ
-          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ + mpv nonzeroA σ :=
-            hAblocks N σ
-      _ = mpv nonzeroA σ := by rw [hZero]; simp
-      _ = mpv P.toTensor σ := (hPblocks N σ).symm
-  have hQeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p) Q.toTensor := by
-    intro N hN σ
-    have hZero :
-        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ = 0 := by
-      rw [mpv_zeroMPSTensor]
-      simp [Nat.ne_of_gt hN]
-    calc
-      mpv (blockTensor (d := d) (D := D₂) B p) σ
-          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ + mpv nonzeroB σ :=
-            hBblocks N σ
-      _ = mpv nonzeroB σ := by rw [hZero]; simp
-      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
-  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
-    intro N σ
-    calc
-      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
-      _ = mpv nonzeroB σ := hNonzero N σ
-      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
-  obtain ⟨M⟩ := hOverlapSpan.exists_sectorBasisMatching hPQeq
-  obtain ⟨ζ, hζne, hMultiset⟩ :=
-    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching M hPbnt hPQeq
-  exact ⟨p, hp, P, Q, hPeqPos, hQeqPos, hPQeq, hPbnt, hQbnt,
-          M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
+  obtain ⟨cover⟩ := nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
+    (d := blockPhysDim d p) blocksA blocksB hMatch
+  exact afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover
+    A B hSame hp μA blocksA μB blocksB cover hAblocks hBblocks hZeroTail
+    hTPA hTPB hIrrA hIrrB hPrimA hPrimB hInjA hInjB hμA hμB
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -7,10 +7,11 @@ import TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
 /-!
-# BNT proportional-decomposition sector comparisons
+# Sector comparisons from common MPV phase covers
 
-This module gives after-blocking sector-comparison consequences from common MPV phase covers and
-from BNT proportional-decomposition comparisons of the nonzero-weight block families.
+The results here give after-blocking sector-comparison consequences from common MPV phase covers,
+and record the special case where the cover comes from a BNT proportional-decomposition
+comparison of the nonzero-weight block families.
 
 ## Main statements
 
@@ -92,7 +93,7 @@ theorem afterBlocking_sectorComparison_of_proportionalDecompositionConclusion
 This zero-tail-aware variant combines exact zero-tail decompositions with a common MPV phase
 cover of the nonzero-weight block families. The cover gives the finite-length span equality for
 those families, while the one-sided phase-class BNT construction supplies the remaining overlap
-data for the collapsed representatives. -/
+data for the representatives of the MPV phase-equivalence classes. -/
 theorem afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover
     {d D₁ D₂ p rA rB zeroTailA zeroTailB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1223,9 +1223,11 @@ two-basis sector comparison theorem.
 	part, with all blocks in the nonzero part trace-preserving, primitive,
 	irreducible, injective, and with nonzero weights. If the two zero-tail
 	dimensions agree and the two nonzero-weight block families have a common MPV
-	phase cover, then there are sector decompositions satisfying the positive-length
-	zero-tail identities, full equality of their MPV families, BNT linear
-	independence, and the matched sector-weight conclusion.
+	phase cover, then there exist a period $p' > 0$ and sector decompositions
+	$P,Q$ such that $A^{[p']}$ and $B^{[p']}$ agree with the corresponding sector
+	tensors at every positive length, $P$ and $Q$ have the same full MPV family,
+	both have BNT data, and their sector weights satisfy the matched sector-weight
+	conclusion.
 \end{theorem}
 
 \begin{proof}
@@ -1253,7 +1255,11 @@ two-basis sector comparison theorem.
 	irreducible, injective, and with nonzero weights. If the two zero-tail
 	dimensions agree and a BNT proportional-decomposition comparison supplies a
 	permutation, equal bond dimensions, and gauge-phase equivalences between the two
-	nonzero-weight block families, then the matched sector-weight conclusion holds.
+	nonzero-weight block families, then there exist a period $p' > 0$ and sector
+	decompositions $P,Q$ such that $A^{[p']}$ and $B^{[p']}$ agree with the
+	corresponding sector tensors at every positive length, $P$ and $Q$ have the
+	same full MPV family, both have BNT data, and their sector weights satisfy the
+	matched sector-weight conclusion.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1213,36 +1213,55 @@ single weighted block.
 two-basis sector comparison theorem.
 \end{proof}
 
+\begin{theorem}[Zero-tail nonzero block decompositions with a common MPV phase cover]%
+\label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
+	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
+	\leanok
+	\uses{def:same_mpv2_pos, def:mpv_common_phase_cover}
+	Let $A$ and $B$ have the same MPV family. Fix $p>0$ and suppose $A^{[p]}$
+	and $B^{[p]}$ each decompose as a zero-tail tensor plus a weighted nonzero
+	part, with all blocks in the nonzero part trace-preserving, primitive,
+	irreducible, injective, and with nonzero weights. If the two zero-tail
+	dimensions agree and the two nonzero-weight block families have a common MPV
+	phase cover, then there are sector decompositions satisfying the positive-length
+	zero-tail identities, full equality of their MPV families, BNT linear
+	independence, and the matched sector-weight conclusion.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{lem:sameMPV2_live_of_zeroTail_eq,
+		thm:bnt_sectorDecomp_pair_overlapSpan_of_commonPhaseCover,
+		thm:sector_basis_overlap_span_to_matching,
+		thm:route_b_hetero_sector_matching}
+	Zero-tail cancellation gives full equality of the two nonzero parts. The
+	common phase cover gives the primitive overlap-span hypotheses for the
+	phase-class representative sector bases. The sector basis matching and
+	two-basis sector comparison theorems then give the sector-weight conclusion.
+\end{proof}
+
 \begin{theorem}[Zero-tail nonzero block decompositions with BNT proportional-decomposition data]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	\leanok
 	\uses{def:same_mpv2_pos,
-		thm:after_blocking_sector_common_blocks_common_phase_cover,
-		thm:after_blocking_sector_common_blocks_overlap_span_zero_tail}
+		thm:common_phase_cover_of_proportional_decomposition,
+		thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	Let $A$ and $B$ have the same MPV family. Fix $p>0$ and suppose $A^{[p]}$
 	and $B^{[p]}$ each decompose as a zero-tail tensor plus a weighted nonzero
 	part, with all blocks in the nonzero part trace-preserving, primitive,
 	irreducible, injective, and with nonzero weights. If the two zero-tail
 	dimensions agree and a BNT proportional-decomposition comparison supplies a
 	permutation, equal bond dimensions, and gauge-phase equivalences between the two
-	nonzero-weight block families, then the sector bases yield the comparison data
-	of Theorem~\ref{thm:after_blocking_sector_common_blocks_common_phase_cover},
-	with the positive-length zero-tail identities of
-	Theorem~\ref{thm:after_blocking_sector_common_blocks_overlap_span_zero_tail}.
+	nonzero-weight block families, then the matched sector-weight conclusion holds.
 \end{theorem}
 
 \begin{proof}
 	\leanok
-	\uses{lem:sameMPV2_live_of_zeroTail_eq,
-		thm:bnt_sectorDecomp_pair_overlapSpan_of_proportionalDecompositionConclusion,
-		thm:sector_basis_overlap_span_to_matching,
-		thm:route_b_hetero_sector_matching}
-	Zero-tail cancellation gives full equality of the two nonzero parts. The
-	proportional-decomposition comparison gives the primitive overlap-span
-	hypotheses through the common phase-cover construction. The sector basis
-	matching and two-basis sector comparison theorems then give the
-	sector-weight conclusion.
+	\uses{thm:common_phase_cover_of_proportional_decomposition,
+		thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
+	First convert the proportional-decomposition conclusion into common MPV
+	phase-cover data. The preceding zero-tail theorem then applies.
 \end{proof}
 
 \begin{theorem}[Cast-compatible MPV scaling implies phase-matched sector comparison]%


### PR DESCRIPTION
## Summary

- Add `MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover`, a zero-tail sector comparison theorem whose hypotheses are the common MPV phase-cover data for the two nonzero-weight block families.
- Refactor `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion` to first obtain a common MPV phase cover and then apply the new theorem.
- Add the corresponding Chapter 11 blueprint statement and proof outline.

This keeps the remaining mathematical assumptions explicit: zero-tail equality, trace-preserving primitive irreducible injective nonzero-weight block families, nonzero weights, and a common MPV phase cover. The theorem therefore matches the data expected from #942/#969/#970/#971/#990 without duplicating the pending proof of agreement after relabeling blocked physical words.

Partially addresses #944.
Related: #970, #990, #969, #971, #942.

## Validation

- `lake build --old TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- added-line scans for proof-integrity tokens and flagged prose terms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a Lean-proof refactor/addition that introduces a new theorem and rewires an existing one to reuse it, plus corresponding blueprint documentation updates.
> 
> **Overview**
> Adds `afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover`, a new zero-tail after-blocking sector comparison theorem whose main extra input is `MPVCommonPhaseCover` data for the nonzero-weight block families.
> 
> Refactors `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion` to first derive a common phase cover from the proportional-decomposition conclusion and then dispatch to the new theorem, reducing duplication.
> 
> Updates the Chapter 11 blueprint to include the new theorem statement/proof outline and to rewrite the proportional-decomposition zero-tail theorem as a corollary that goes through the common-phase-cover result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032e104c297911f50146ded04f98c3b9a4c693de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->