### PR TITLE
feat(MPS/CanonicalForm): compare blocked-word sums (#990)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1419,12 +1419,135 @@ theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ := by
           exact (mpv_toTensorFromBlocks_eq_sum (F.commonFlatWeight μ) (F.commonFlatBlocks) σ).symm
 
+private theorem cast_physDim_apply {d₁ d₂ D : ℕ} (h : d₁ = d₂)
+    (A : MPSTensor d₁ D) (i : Fin d₂) :
+    cast (congr_arg (fun d' => MPSTensor d' D) h) A i = A (Fin.cast h.symm i) := by
+  subst h
+  rfl
+
+/-- If the two decodings of each blocked physical word agree, then directly blocking
+one original block gives the corresponding block obtained through iterated blocking.
+
+The hypothesis compares the word read from the common block alphabet with the word
+read after first viewing the same index as an iterated block and then flattening it. -/
+theorem blockTensor_eq_commonReindexedBlock_of_word_eq
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
+    (hWord : ∀ i : Fin (blockPhysDim d F.p),
+      wordOfBlock d F.p i =
+        wordOfBlock d (F.period k * F.extra k)
+          (iteratedBlockIndex d (F.period k) (F.extra k)
+            (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i))) :
+    blockTensor (d := d) (D := dim k) (blocks k) F.p = F.commonReindexedBlock k := by
+  funext i
+  rw [commonReindexedBlock, cast_physDim_apply (F.blockPhysDim_nested_eq k)]
+  simp [reindexPhysical, blockTensor, hWord i]
+
+/-- Direct blocking of one original block has the same MPV family as the block obtained
+through iterated blocking, whenever the associated blocked-word decodings agree. -/
+theorem blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
+    (hWord : ∀ i : Fin (blockPhysDim d F.p),
+      wordOfBlock d F.p i =
+        wordOfBlock d (F.period k * F.extra k)
+          (iteratedBlockIndex d (F.period k) (F.extra k)
+            (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i))) :
+    SameMPV₂
+      (blockTensor (d := d) (D := dim k) (blocks k) F.p)
+      (F.commonReindexedBlock k) := by
+  rw [F.blockTensor_eq_commonReindexedBlock_of_word_eq k hWord]
+  intro N σ
+  rfl
+
+/-- Blockwise MPV comparisons assemble over the weighted direct sum after common blocking. -/
+theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
+    (hBlock : ∀ k : Fin r,
+      SameMPV₂
+        (blockTensor (d := d) (D := dim k) (blocks k) F.p)
+        (F.commonReindexedBlock k)) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock) := by
+  intro N σ
+  calc
+    mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p)) σ
+        = ∑ k : Fin r, ((μ k) ^ F.p) ^ N •
+            mpv (blockTensor (d := d) (D := dim k) (blocks k) F.p) σ :=
+          mpv_toTensorFromBlocks_eq_sum (fun k : Fin r => (μ k) ^ F.p)
+            (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p) σ
+    _ = ∑ k : Fin r, ((μ k) ^ F.p) ^ N • mpv (F.commonReindexedBlock k) σ := by
+          refine Finset.sum_congr rfl fun k _ => ?_
+          rw [hBlock k N σ]
+    _ = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock) σ := by
+          exact (mpv_toTensorFromBlocks_eq_sum (fun k : Fin r => (μ k) ^ F.p)
+            F.commonReindexedBlock σ).symm
+
+/-- Agreement of blocked-word decodings assembles the weighted direct sum obtained by
+blocking the original nonzero blocks with the one obtained through iterated blocking. -/
+theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
+    (hWord : ∀ (k : Fin r) (i : Fin (blockPhysDim d F.p)),
+      wordOfBlock d F.p i =
+        wordOfBlock d (F.period k * F.extra k)
+          (iteratedBlockIndex d (F.period k) (F.extra k)
+            (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i))) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock) :=
+  F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise μ
+    (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
+
+/-- If every original block has the same MPV family after direct blocking as after
+iterated blocking, then the weighted nonzero part agrees with the derived common-sector family. -/
+theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
+    (hBlock : ∀ k : Fin r,
+      SameMPV₂
+        (blockTensor (d := d) (D := dim k) (blocks k) F.p)
+        (F.commonReindexedBlock k)) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) F.commonFlatBlocks) := by
+  intro N σ
+  exact (F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise μ hBlock N σ).trans
+    (F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ)
+
+/-- Agreement of blocked-word decodings identifies the directly blocked weighted
+nonzero part with the derived common-sector family. -/
+theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
+    (hWord : ∀ (k : Fin r) (i : Fin (blockPhysDim d F.p)),
+      wordOfBlock d F.p i =
+        wordOfBlock d (F.period k * F.extra k)
+          (iteratedBlockIndex d (F.period k) (F.extra k)
+            (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i))) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) F.commonFlatBlocks) :=
+  F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise μ
+    (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
+
 /-- If the canonical blocked nonzero part agrees with the explicitly reindexed
 blocks, then the weighted nonzero part agrees with the derived common-sector family.
 
-The hypothesis isolates the remaining equality under the word reindexing from
-`iteratedBlockIndex`; the canonical blocked tensor uses the ambient blocked alphabet
-directly. -/
+The hypothesis isolates the remaining equality after relabelling blocked physical
+words by `iteratedBlockIndex`; the canonical blocked tensor uses the ambient blocked
+alphabet directly. -/
 theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hLabel : SameMPV₂

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -841,6 +841,64 @@ theorem fundamentalTheorem_after_blocking_commonLength_commonSector
   · intro x
     exact familyB.commonFlatDim_pos x
 
+/-- If each directly blocked nonzero block agrees with its iterated-blocking version,
+the zero-tail equation can be written using the derived common-sector family. -/
+theorem zeroTail_commonFlat_of_blockwise
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hBlock : ∀ k : Fin r,
+      SameMPV₂
+        (blockTensor (d := d) (D := dim k) (blocks k) F.p)
+        (F.commonReindexedBlock k)) :
+    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
+      mpv (blockTensor (d := d) (D := D) A F.p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
+  intro N σ
+  have hCanon := zeroTail_toTensorFromBlocks_blockPower
+    (d := d) (D := D) (r := r) (z := z) (p := F.p) (dim := dim)
+    A μ blocks F.p_pos hMPV
+  have hFlat := F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise μ hBlock
+  calc
+    mpv (blockTensor (d := d) (D := D) A F.p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (fun k => (μ k) ^ F.p)
+            (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p)) σ := hCanon N σ
+    _ = mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
+          rw [hFlat N σ]
+
+/-- If the blocked-word decodings agree for every nonzero block, the zero-tail equation
+can be written using the derived common-sector family. -/
+theorem zeroTail_commonFlat_of_word_eq
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hWord : ∀ (k : Fin r) (i : Fin (blockPhysDim d F.p)),
+      wordOfBlock d F.p i =
+        wordOfBlock d (F.period k * F.extra k)
+          (iteratedBlockIndex d (F.period k) (F.extra k)
+            (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i))) :
+    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
+      mpv (blockTensor (d := d) (D := D) A F.p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
+  exact zeroTail_commonFlat_of_blockwise A μ blocks F hMPV
+    (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
+
 /-- If the canonical blocked nonzero part agrees with the common reindexed blocks,
 the zero-tail equation can be rewritten using the derived common-sector family.
 This is the one-sided theorem that puts the reindexed data above in the form used

--- a/audits/2026-04-30_issue990_blocked_word_comparison.md
+++ b/audits/2026-04-30_issue990_blocked_word_comparison.md
@@ -1,0 +1,57 @@
+# Issue #990 blocked-word comparison audit
+
+## Scope
+
+Issue #990 asks for the comparison between the weighted direct sum obtained by
+blocking each original nonzero block at the common length $p$ and the weighted
+direct sum obtained by the iterated-blocking relabelling used in
+`CommonBlockedCyclicSectorFamily.commonReindexedBlock`.
+
+The reusable finite-sum comparison theorem is recorded in
+`TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`:
+
+- `CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_word_eq`
+- `CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq`
+- `CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise`
+- `CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq`
+- `CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise`
+- `CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq`
+
+These show that once the direct length-$p$ blocked word is identified with the
+flattened iterated $(m_k,e_k)$ blocked word for each original nonzero block, the
+comparison automatically assembles over the weighted direct sum and composes with
+the common cyclic-sector family.
+
+The same comparison gives one-sided zero-tail statements in
+`TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`:
+
+- `zeroTail_commonFlat_of_blockwise`
+- `zeroTail_commonFlat_of_word_eq`
+
+These rewrite the zero-tail equation with the derived common-sector family from a
+blockwise comparison, or directly from equality of the blocked words.
+
+## Remaining point
+
+The remaining theorem is now the pure blocked-word coordinate statement: for each
+common cyclic-sector family `F`, block `k`, and physical index
+`i : Fin (blockPhysDim d F.p)`, prove that the length-$p$ word decoded directly
+from `i` is the same word as the length `F.period k * F.extra k` word obtained by
+viewing `i` as an iterated block through `F.blockPhysDim_nested_eq k` and applying
+`iteratedBlockIndex`.
+
+Equivalently, the final comparison may be formulated with this relabelling of
+blocked words explicit. No new mathematical assumptions about MPS tensors are
+introduced here; the remaining question is the identification of the chosen
+coordinates for direct and iterated blocked words. Since the current blocked
+physical index is chosen through `Fintype.equivFin`, cardinal equality alone does
+not specify how a length-`p` direct word is grouped into an iterated
+`(m_k,e_k)` word; that coordinate choice has to be proved for the chosen
+encoding or carried as an explicit relabelling.
+
+## Paper path
+
+This is exactly the bookkeeping step between the common-length cyclic-sector data
+used after the period-removal construction and the common-sector block family used
+by the later sector comparison theorems. It is independent of the Gemma/arXiv:1708
+periodic fundamental theorem route and of parent-Hamiltonian arguments.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1757,6 +1757,36 @@ The following results separate the zero blocks from the nonzero blocks.
 	sums and reindex the double sum over pairs $(k,s)$ by the flattened sector index.
 \end{proof}
 
+\begin{theorem}[Comparison of direct and iterated blocking for weighted nonzero blocks]%
+\label{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_word_eq,
+		MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_derived_blocks,
+		thm:common_blocked_cyclic_sector_reindexed_samempv}
+	Suppose that, for each original nonzero block, the length-$p$ word read from
+	the common blocked alphabet is the same word as the one obtained by viewing the
+	index as an iterated $(m_k,e_k)$ block and flattening it.  Then direct blocking
+	of each original block agrees with the corresponding iterated-blocking tensor.
+	Consequently the weighted direct sum of the directly blocked nonzero blocks
+	agrees with the weighted direct sum built from the iterated-blocking tensors,
+	and hence with the derived common-sector family.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv}
+	The word equality gives equality of the corresponding block tensors, hence
+	blockwise MPV equality.  Expanding both weighted block-diagonal tensors as
+	finite sums over the original block index and applying the blockwise equality
+	term by term gives the weighted comparison.  Composing with
+	Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_samempv} gives the
+	common-sector statement.
+\end{proof}
+
 \begin{theorem}[Canonical blocked nonzero part under blocked-word relabeling]%
 \label{thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed}
@@ -3260,6 +3290,31 @@ The following results separate the zero blocks from the nonzero blocks.
 	sector conclusions are the reindexed common-sector MPV equalities.
 \end{proof}
 
+\begin{theorem}[Zero-tail equation from blockwise comparison of direct and iterated blocking]%
+\label{thm:zero_tail_common_flat_of_blocked_word_comparison}
+	\lean{MPSTensor.zeroTail_commonFlat_of_blockwise,
+		MPSTensor.zeroTail_commonFlat_of_word_eq}
+	\leanok
+	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
+		thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	For one side, suppose that the original tensor decomposes, as an MPV family,
+	into a zero-tail contribution plus a weighted block-sum nonzero part over the
+	original physical alphabet.  If each directly blocked nonzero block agrees with
+	the corresponding iterated-blocking tensor, then after the common blocking length
+	the zero-tail equation may be written directly with the weighted derived
+	common-sector family.  It is enough to prove the corresponding equality of
+	blocked words for every nonzero block.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
+		thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	First transport the original zero-tail/nonzero decomposition through the common
+	blocking length.  Then use the blockwise comparison of direct and iterated
+	blocking, assembled over the weighted direct sum, to replace the directly
+	blocked nonzero part by the weighted derived common-sector tensor.
+\end{proof}
+
 \begin{theorem}[Zero-tail equation after resolving the blocked-word relabeling]%
 \label{thm:zero_tail_common_flat_of_reindexed}
 	\lean{MPSTensor.zeroTail_commonFlat_of_reindexed}
@@ -3393,19 +3448,31 @@ The following results separate the zero blocks from the nonzero blocks.
 	with one blocking by the product length, after relabeling the blocked physical
 	words.
 
-	The next mathematical assertion is the equality, after relabeling blocked
-	physical words, between the canonical blocked nonzero part and the cyclic-sector
-	tensor for the whole weighted family.  The conditional statements
+	The results above now separate the finite-sum comparison from the remaining
+	blocked-word assertion.  Theorem~\ref{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	shows that, once the length-$p$ word read directly from the common blocked
+	alphabet equals the word obtained by flattening an iterated $(m_k,e_k)$ block,
+	the weighted direct sum of directly blocked nonzero blocks agrees with the
+	derived common-sector family.  Theorem~\ref{thm:zero_tail_common_flat_of_blocked_word_comparison}
+	then rewrites the one-sided zero-tail identity with the weighted common-length
+	cyclic sectors under this blockwise word equality.
+
+	The next mathematical assertion is the corresponding equality, after relabeling
+	blocked physical words, between the canonical blocked nonzero part and the
+	cyclic-sector tensor for the whole weighted family.  Under this comparison,
 	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed},
 	\ref{thm:samempv_pos_zero_tail_identity_transport}, and
 	\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-	show that this equality rewrites the zero-tail identities, the positive-length
-	equality, the length-zero identity, and the nonzero transported weights directly
-	with the weighted common-length cyclic sectors, while also collecting the
-	two-sided primitive irreducible sector decompositions needed for comparison.
-	Once these sectors have also been blocked far enough to be injective, a BNT
-	proportional-decomposition comparison gives the block permutation, the
-	bond-dimension equalities, and the gauge phases.
+	rewrite the zero-tail identities, the positive-length equality, the length-zero
+	identity, and the nonzero transported weights directly with the weighted
+	common-length cyclic sectors, while also collecting the two-sided primitive
+	irreducible sector decompositions needed for comparison.  Thus the remaining
+	assertions are this equality of blocked words for the chosen coordinates, or an
+	equivalent final comparison with the relabeling made explicit, and the
+	injectivity of a suitable further blocking.  Once the common-length sectors have
+	also been blocked far enough to be injective, a BNT proportional-decomposition
+	comparison gives the block permutation, the bond-dimension equalities, and the
+	gauge phases.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	then turns that comparison into the finite-length MPV span equality and the
 	sector-weight conclusion.  Thus the open canonical-form assertions are the

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1778,7 +1778,8 @@ The following results separate the zero blocks from the nonzero blocks.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv}
+	\uses{thm:mpv_decomposition,
+		thm:common_blocked_cyclic_sector_reindexed_samempv}
 	The word equality gives equality of the corresponding block tensors, hence
 	blockwise MPV equality.  Expanding both weighted block-diagonal tensors as
 	finite sums over the original block index and applying the blockwise equality

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1768,13 +1768,15 @@ The following results separate the zero blocks from the nonzero blocks.
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:common_blocked_cyclic_sector_reindexed_samempv}
-	Suppose that, for each original nonzero block, the length-$p$ word read from
-	the common blocked alphabet is the same word as the one obtained by viewing the
-	index as an iterated $(m_k,e_k)$ block and flattening it.  Then direct blocking
-	of each original block agrees with the corresponding iterated-blocking tensor.
-	Consequently the weighted direct sum of the directly blocked nonzero blocks
+	The comparison has two forms.  First, assume that each directly blocked
+	nonzero block has the same MPV family as its corresponding iterated-blocking
+	tensor.  Then the weighted direct sum of the directly blocked nonzero blocks
 	agrees with the weighted direct sum built from the iterated-blocking tensors,
-	and hence with the derived common-sector family.
+	and hence with the derived common-sector family.  Second, this blockwise MPV
+	equality follows from the stronger pointwise condition that the length-$p$ word
+	read from the common blocked alphabet is the same word as the one obtained by
+	viewing the index as an iterated $(m_k,e_k)$ block and flattening it; under this
+	condition the two individual block tensors are equal.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3467,13 +3469,12 @@ The following results separate the zero blocks from the nonzero blocks.
 	rewrite the zero-tail identities, the positive-length equality, the length-zero
 	identity, and the nonzero transported weights directly with the weighted
 	common-length cyclic sectors, while also collecting the two-sided primitive
-	irreducible sector decompositions needed for comparison.  Thus the remaining
-	assertions are this equality of blocked words for the chosen coordinates, or an
-	equivalent final comparison with the relabeling made explicit, and the
-	injectivity of a suitable further blocking.  Once the common-length sectors have
-	also been blocked far enough to be injective, a BNT proportional-decomposition
-	comparison gives the block permutation, the bond-dimension equalities, and the
-	gauge phases.
+	irreducible sector decompositions needed for comparison.  The remaining
+	blocked-word assertion is the equality of these words for the chosen coordinates,
+	or an equivalent final comparison with the relabeling made explicit.  Once the
+	common-length sectors have also been blocked far enough to be injective, a BNT
+	proportional-decomposition comparison gives the block permutation, the
+	bond-dimension equalities, and the gauge phases.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	then turns that comparison into the finite-length MPV span equality and the
 	sector-weight conclusion.  Thus the open canonical-form assertions are the


### PR DESCRIPTION
## Summary

- Add blockwise comparison lemmas for a `CommonBlockedCyclicSectorFamily`: direct blocking of each original nonzero block agrees with the iterated-blocking tensor once the two blocked-word decodings are identified.
- Assemble the blockwise comparison over the weighted direct sum and compose it with the derived common-sector family.
- Add one-sided zero-tail statements that rewrite the blocked zero-tail equation with the derived common-sector tensor under the same blocked-word comparison.
- Record the remaining coordinate statement in an audit note: the current blocked index is chosen through `Fintype.equivFin`, so cardinal equality alone does not determine how the direct length-`p` word is grouped into an iterated `(m_k,e_k)` word.

Refs #990.

## Validation

- `lake build --old TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` passed using the already-built shared cache; only pre-existing long-line warnings in `PeripheralUnitary`, `BNT/Construction`, and `CyclicSectorDecomposition` replayed.
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- Added-line scan for proof-integrity tokens and flagged prose terms.

## Remaining point

The theorem now needed for the direct canonical nonzero block is the pure blocked-word coordinate equality:
for each block `k` and index `i : Fin (blockPhysDim d F.p)`, the length-`F.p` word decoded directly from `i` should match the word obtained by viewing `i` as an iterated block through `F.blockPhysDim_nested_eq k`, applying `iteratedBlockIndex`, and decoding at length `F.period k * F.extra k`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems and documentation around blocked-word reindexing without changing core definitions or algorithms, though proof refactors may affect downstream lemma dependencies.
> 
> **Overview**
> Adds a reusable set of lemmas showing that **direct length-`p` blocking** of each nonzero block matches the **iterated-blocking + `iteratedBlockIndex` relabeling** version when the two blocked-word decodings agree, and that these per-block equalities/`SameMPV₂` results assemble over the weighted direct sum to compare against the derived `CommonBlockedCyclicSectorFamily.commonFlatBlocks`.
> 
> Extends the structural after-blocking development with one-sided `zeroTail_commonFlat_of_blockwise` / `zeroTail_commonFlat_of_word_eq` theorems that rewrite the blocked zero-tail equation using the derived common-sector family under the same blockwise or blocked-word hypotheses, and updates the blueprint plus an audit note documenting the remaining coordinate-level blocked-word equality obligation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d73819629f5ade9036d5014e68c8e371d52f366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->