### PR TITLE
feat(MPS/CanonicalForm): split zero-tail span adapters

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -9,15 +9,17 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 /-!
 # Sector comparisons from common MPV phase covers
 
-The results here give after-blocking sector-comparison consequences from common MPV phase covers,
-and record the special case where the cover comes from a BNT proportional-decomposition
-comparison of the nonzero-weight block families.
+The results here give after-blocking sector-comparison consequences from finite-length span
+comparisons and common MPV phase covers, and record the special case where the cover comes from a
+BNT proportional-decomposition comparison of the nonzero-weight block families.
 
 ## Main statements
 
 * `afterBlocking_sectorComparison_of_proportionalDecompositionConclusion` — exact
   nonzero part decompositions plus BNT proportional-decomposition data imply the sector-weight
   comparison.
+* `afterBlocking_sectorComparison_zeroTail_of_blockSpan` — zero-tail identities plus
+  finite-length MPV span equality for the nonzero part imply the sector-weight comparison.
 * `afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover` — zero-tail decompositions
   plus common MPV phase-cover data imply the same sector-weight comparison.
 * `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion` —
@@ -88,12 +90,121 @@ theorem afterBlocking_sectorComparison_of_proportionalDecompositionConclusion
     A B hSame hp μA blocksA μB blocksB cover hAblocks hBblocks hTPA hTPB hIrrA hIrrB
     hPrimA hPrimB hInjA hInjB hμA hμB
 
+/-- **Zero-tail sector comparison from finite-length nonzero-block span equality.**
+
+This zero-tail-aware variant combines exact zero-tail identities with equality of the
+finite-length MPV spans of the two nonzero-weight block families. The span equality supplies the
+last two-family hypothesis needed by the phase-class BNT representative construction; the
+zero-tail equality gives full equality of the two nonzero parts, including length zero. -/
+theorem afterBlocking_sectorComparison_zeroTail_of_blockSpan
+    {d D₁ D₂ p rA rB zeroTailA zeroTailB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k : Fin rA, NeZero (dimA k)]
+    [∀ k : Fin rB, NeZero (dimB k)]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hp : 0 < p)
+    (μA : Fin rA → ℂ)
+    (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d p) (dimA k))
+    (μB : Fin rB → ℂ)
+    (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d p) (dimB k))
+    (hAblocks :
+      ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ)
+    (hBblocks :
+      ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ)
+    (hZeroTail : zeroTailA = zeroTailB)
+    (hTPA : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksA k i)ᴴ * blocksA k i = 1)
+    (hTPB : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksB k i)ᴴ * blocksB k i = 1)
+    (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))
+    (hIrrB : ∀ k, IsIrreducibleTensor (blocksB k))
+    (hPrimA : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimA k) (blocksA k)))
+    (hPrimB : ∀ k, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimB k) (blocksB k)))
+    (hInjA : ∀ k, IsInjective (blocksA k))
+    (hInjB : ∀ k, IsInjective (blocksB k))
+    (hμA : ∀ k, μA k ≠ 0)
+    (hμB : ∀ k, μB k ≠ 0)
+    (hBlockSpan : ∀ N,
+      Submodule.span ℂ (Set.range (fun k : Fin rA =>
+        mpvState (d := blockPhysDim d p) (blocksA k) N)) =
+      Submodule.span ℂ (Set.range (fun k : Fin rB =>
+        mpvState (d := blockPhysDim d p) (blocksB k) N))) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
+    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
+      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
+      hPrimA hPrimB hInjA hInjB hμA hμB hBlockSpan
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
+    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      nonzeroA nonzeroB hAB hAblocks hBblocks hZeroTail
+  have hPeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p) P.toTensor := by
+    intro N hN σ
+    have hZero :
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ
+          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ + mpv nonzeroA σ :=
+            hAblocks N σ
+      _ = mpv nonzeroA σ := by rw [hZero]; simp
+      _ = mpv P.toTensor σ := (hPblocks N σ).symm
+  have hQeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p) Q.toTensor := by
+    intro N hN σ
+    have hZero :
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ
+          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ + mpv nonzeroB σ :=
+            hBblocks N σ
+      _ = mpv nonzeroB σ := by rw [hZero]; simp
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
+      _ = mpv nonzeroB σ := hNonzero N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  obtain ⟨M⟩ := hOverlapSpan.exists_sectorBasisMatching hPQeq
+  obtain ⟨ζ, hζne, hMultiset⟩ :=
+    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching M hPbnt hPQeq
+  exact ⟨p, hp, P, Q, hPeqPos, hQeqPos, hPQeq, hPbnt, hQbnt,
+          M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
+
 /-- **Zero-tail sector comparison from common MPV phase-cover data.**
 
 This zero-tail-aware variant combines exact zero-tail decompositions with a common MPV phase
 cover of the nonzero-weight block families. The cover gives the finite-length span equality for
-those families, while the one-sided phase-class BNT construction supplies the remaining overlap
-data for the representatives of the MPV phase-equivalence classes. -/
+those families, and the block-span theorem then gives the sector-weight comparison. -/
 theorem afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover
     {d D₁ D₂ p rA rB zeroTailA zeroTailB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -143,56 +254,10 @@ theorem afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover
         ∀ j : Fin P.basisCount,
           Finset.univ.val.map (P.weight j) =
             Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
-  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
-  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
-    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_commonPhaseCover
-      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
-      hPrimA hPrimB hInjA hInjB hμA hμB cover
-  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
-                      (blockTensor (d := d) (D := D₂) B p) :=
-    sameMPV₂_blockTensor A B hSame p
-  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
-    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
-      (blockTensor (d := d) (D := D₁) A p)
-      (blockTensor (d := d) (D := D₂) B p)
-      nonzeroA nonzeroB hAB hAblocks hBblocks hZeroTail
-  have hPeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p) P.toTensor := by
-    intro N hN σ
-    have hZero :
-        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ = 0 := by
-      rw [mpv_zeroMPSTensor]
-      simp [Nat.ne_of_gt hN]
-    calc
-      mpv (blockTensor (d := d) (D := D₁) A p) σ
-          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ + mpv nonzeroA σ :=
-            hAblocks N σ
-      _ = mpv nonzeroA σ := by rw [hZero]; simp
-      _ = mpv P.toTensor σ := (hPblocks N σ).symm
-  have hQeqPos : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p) Q.toTensor := by
-    intro N hN σ
-    have hZero :
-        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ = 0 := by
-      rw [mpv_zeroMPSTensor]
-      simp [Nat.ne_of_gt hN]
-    calc
-      mpv (blockTensor (d := d) (D := D₂) B p) σ
-          = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ + mpv nonzeroB σ :=
-            hBblocks N σ
-      _ = mpv nonzeroB σ := by rw [hZero]; simp
-      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
-  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
-    intro N σ
-    calc
-      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
-      _ = mpv nonzeroB σ := hNonzero N σ
-      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
-  obtain ⟨M⟩ := hOverlapSpan.exists_sectorBasisMatching hPQeq
-  obtain ⟨ζ, hζne, hMultiset⟩ :=
-    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching M hPbnt hPQeq
-  exact ⟨p, hp, P, Q, hPeqPos, hQeqPos, hPQeq, hPbnt, hQbnt,
-          M.perm, M.copies_eq, ζ, hζne, hMultiset⟩
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) :=
+  afterBlocking_sectorComparison_zeroTail_of_blockSpan
+    A B hSame hp μA blocksA μB blocksB hAblocks hBblocks hZeroTail hTPA hTPB
+    hIrrA hIrrB hPrimA hPrimB hInjA hInjB hμA hμB (fun N => cover.span_eq N)
 
 /-- **Zero-tail sector comparison from BNT proportional-decomposition data.**
 

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -731,6 +731,22 @@ theorem nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
   · intro j
     exact ⟨perm j, by simp⟩
 
+/-- A BNT proportional-decomposition conclusion gives finite-length MPV span equality.
+
+The conclusion is obtained by taking the left family as the common MPV phase-cover family and
+then applying the common-cover span theorem. -/
+theorem mpv_span_eq_of_proportionalDecompositionConclusion
+    {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (h : ProportionalDecompositionConclusion (d := d) blocksA blocksB)
+    (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun j : Fin rA => mpvState (d := d) (blocksA j) N)) =
+    Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) := by
+  obtain ⟨cover⟩ := nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
+    (d := d) blocksA blocksB h
+  exact cover.span_eq N
+
 /-- Separated normal canonical-form data and a proportional decomposition produce a common MPV
 phase cover.
 
@@ -753,6 +769,28 @@ theorem nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
     (d := d) blocksA blocksB
     (fundamentalTheorem_of_separated_normalCFBNT_data
       blocksA blocksB hA_ncf hA_blocks hB_ncf hB_blocks hDecomp)
+
+/-- Separated normal canonical-form data give finite-length MPV span equality.
+
+The BNT comparison theorem gives a proportional-decomposition conclusion, hence a common
+MPV phase cover, and the common-cover theorem gives equality of the two block-family spans. -/
+theorem mpv_span_eq_of_separated_normalCFBNT_data
+    {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {DtotA DtotB : ℕ} {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA_ncf : IsNormalCanonicalForm μA blocksA)
+    (hA_blocks : BlocksNotGaugePhaseEquiv (d := d) blocksA)
+    (hB_ncf : IsNormalCanonicalForm μB blocksB)
+    (hB_blocks : BlocksNotGaugePhaseEquiv (d := d) blocksB)
+    (hDecomp : ProportionalDecompositionData (d := d) blocksA blocksB DtotA DtotB)
+    (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun j : Fin rA => mpvState (d := d) (blocksA j) N)) =
+    Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) := by
+  obtain ⟨cover⟩ := nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
+    (d := d) blocksA blocksB hA_ncf hA_blocks hB_ncf hB_blocks hDecomp
+  exact cover.span_eq N
 
 /-- Equivalence relation on block indices given by MPV phase equivalence. -/
 def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}

--- a/audits/2026-04-29_issue944_overlap_span_from_common_live.md
+++ b/audits/2026-04-29_issue944_overlap_span_from_common_live.md
@@ -52,9 +52,16 @@ New declarations:
 - `exists_bnt_sectorDecomp_pair_with_overlapSpan_of_proportionalDecompositionConclusion`
   (in namespace `MPSTensor`): first turns BNT proportional-decomposition data into a
   common MPV phase cover, then applies the previous theorem.
+- `mpv_span_eq_of_proportionalDecompositionConclusion` (in namespace `MPSTensor`):
+  exposes the finite-length MPV span equality obtained from the same proportional
+  comparison.
+- `mpv_span_eq_of_separated_normalCFBNT_data` (in namespace `MPSTensor`): combines
+  separated normal canonical-form data with the BNT comparison theorem to obtain the
+  same finite-length span equality.
 
 These theorems discharge the `span_eq` field through `MPVCommonPhaseCover.span_eq`; no
-finite-length span equality is assumed as a hypothesis.
+finite-length span equality is assumed as a hypothesis in the common-cover and
+proportional-decomposition routes.
 
 ### BNT proportional comparison assembly file
 
@@ -63,21 +70,29 @@ New declarations:
 - `MPSTensor.afterBlocking_sectorComparison_of_proportionalDecompositionConclusion`:
   exact nonzero-part decompositions at a common blocking period plus BNT
   proportional-decomposition data imply the sector-weight comparison theorem.
+- `afterBlocking_sectorComparison_zeroTail_of_blockSpan` (in namespace `MPSTensor`):
+  zero-tail equations at a common blocking period, equality of zero-tail dimensions,
+  injectivity, and finite-length nonzero-block span equality imply the zero-tail-aware
+  sector comparison theorem.
+- `afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover` (in namespace
+  `MPSTensor`): obtains the previous span hypothesis from common MPV phase-cover data.
 - `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion`
-  (in namespace `MPSTensor`): zero-tail equations at a common blocking period, equality
-  of zero-tail dimensions, injectivity, and BNT proportional-decomposition data imply the
-  zero-tail-aware sector comparison theorem.
+  (in namespace `MPSTensor`): obtains the common MPV phase-cover data from BNT
+  proportional-decomposition data and applies the common-cover zero-tail theorem.
 
-The zero-tail theorem is the direct mathematical consequence for the #989 data once a
+These zero-tail theorems are the direct mathematical consequence for the #989 data once a
 theorem identifies the canonical blocked nonzero part with the relabeled cyclic-sector
 description in the common blocked alphabet and any needed injectivity refinement has been
 supplied.
 
 ### Blueprint updates
 
-`blueprint/src/chapter/ch11_assembly.tex` now records the two overlap-span consequences
-and the two sector-comparison theorems. `blueprint/src/chapter/ch08_canonical.tex` now
-points from the common-length cyclic-sector discussion to the zero-tail
+`blueprint/src/chapter/ch11_assembly.tex` now records the overlap-span consequences,
+the direct span-equality corollaries, and the sector-comparison theorems. The zero-tail
+entries are split into block-span, common-cover, and proportional-decomposition forms so
+downstream arguments can cite exactly the hypothesis they have.
+`blueprint/src/chapter/ch08_canonical.tex` continues to point from the common-length
+cyclic-sector discussion to the zero-tail
 proportional-decomposition theorem as the next checked comparison step.
 
 ## Remaining paper hypotheses

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -878,6 +878,24 @@ single weighted block.
 	the required MPV-phase equivalence.
 \end{proof}
 
+\begin{theorem}[Proportional-decomposition conclusion gives nonzero-block span equality]%
+\label{thm:nonzero_block_span_eq_of_proportional_decomposition}
+	\lean{MPSTensor.mpv_span_eq_of_proportionalDecompositionConclusion}
+	\leanok
+	\uses{thm:common_phase_cover_of_proportional_decomposition,
+		lem:mpv_common_phase_cover_span_eq}
+	A BNT proportional-decomposition comparison gives equality, for every system
+	size, of the finite-length MPV spans of the two nonzero-weight block families.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_phase_cover_of_proportional_decomposition,
+		lem:mpv_common_phase_cover_span_eq}
+	First form the common MPV phase cover from the proportional-decomposition
+	comparison. The common-cover span lemma then gives the stated span equality.
+\end{proof}
+
 \begin{theorem}[Common phase cover gives phase-class representative overlap-span data]%
 \label{thm:bnt_sectorDecomp_pair_overlapSpan_of_commonPhaseCover}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_pair_with_overlapSpan_of_commonPhaseCover}
@@ -943,6 +961,26 @@ single weighted block.
 	matching the basis blocks, bond-dimension equalities, and gauge-phase
 	equivalences. Applying the previous theorem to that conclusion yields the
 	common phase cover data.
+\end{proof}
+
+\begin{theorem}[Separated normal canonical-form data give nonzero-block span equality]%
+\label{thm:separated_normal_bnt_span_eq}
+	\lean{MPSTensor.mpv_span_eq_of_separated_normalCFBNT_data}
+	\leanok
+	\uses{thm:common_phase_cover_of_separated_normal_bnt,
+		lem:mpv_common_phase_cover_span_eq}
+	For two separated normal canonical-form block families as in
+	Theorem~\ref{thm:common_phase_cover_of_separated_normal_bnt}, the BNT
+	comparison data imply equality, at every system size, of the finite-length
+	MPV spans of the two basis families.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_phase_cover_of_separated_normal_bnt,
+		lem:mpv_common_phase_cover_span_eq}
+	The separated normal-form comparison first gives a common MPV phase cover.
+	Applying the common-cover span lemma to that cover gives the span equality.
 \end{proof}
 
 \begin{theorem}[Sector comparison via a sector-basis matching]%
@@ -1213,41 +1251,70 @@ single weighted block.
 two-basis sector comparison theorem.
 \end{proof}
 
-\begin{theorem}[Zero-tail nonzero block decompositions with a common MPV phase cover]%
-\label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
-	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
+\begin{theorem}[Zero-tail nonzero block decompositions with nonzero-block span equality]%
+\label{thm:afterBlocking_sectorComparison_zeroTail_of_blockSpan}
+	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_blockSpan}
 	\leanok
-	\uses{def:same_mpv2_pos, def:mpv_common_phase_cover}
+	\uses{lem:sameMPV2_live_of_zeroTail_eq,
+		thm:bnt_sector_decomp_pair_overlap_span_of_block_span,
+		thm:sector_basis_overlap_span_to_matching,
+		thm:route_b_hetero_sector_matching}
 	Let $A$ and $B$ have the same MPV family. Fix $p>0$ and suppose $A^{[p]}$
 	and $B^{[p]}$ each decompose as a zero-tail tensor plus a weighted nonzero
 	part, with all blocks in the nonzero part trace-preserving, primitive,
 	irreducible, injective, and with nonzero weights. If the two zero-tail
-	dimensions agree and the two nonzero-weight block families have a common MPV
-	phase cover, then there exist a period $p' > 0$ and sector decompositions
-	$P,Q$ such that $A^{[p']}$ and $B^{[p']}$ agree with the corresponding sector
-	tensors at every positive length, $P$ and $Q$ have the same full MPV family,
-	both have BNT data, and their sector weights satisfy the matched sector-weight
-	conclusion.
+	dimensions agree and the two nonzero-weight block families have equal
+	finite-length MPV spans at every system size, then there exist a period
+	$p' > 0$ and sector decompositions $P,Q$ such that $A^{[p']}$ and
+	$B^{[p']}$ agree with the corresponding sector tensors at every positive
+	length, $P$ and $Q$ have the same full MPV family, both have BNT data, and
+	their sector weights satisfy the matched sector-weight conclusion.
 \end{theorem}
 
 \begin{proof}
 	\leanok
 	\uses{lem:sameMPV2_live_of_zeroTail_eq,
-		thm:bnt_sectorDecomp_pair_overlapSpan_of_commonPhaseCover,
+		thm:bnt_sector_decomp_pair_overlap_span_of_block_span,
 		thm:sector_basis_overlap_span_to_matching,
 		thm:route_b_hetero_sector_matching}
-	Zero-tail cancellation gives full equality of the two nonzero parts. The
-	common phase cover gives the primitive overlap-span hypotheses for the
-	phase-class representative sector bases. The sector basis matching and
-	two-basis sector comparison theorems then give the sector-weight conclusion.
+	The finite-length span equality gives the primitive overlap-span hypotheses
+	for the BNT sector bases of the two nonzero parts. Zero-tail cancellation
+	identifies the two nonzero parts as full MPV families, while the zero-tail
+	summands vanish at positive lengths, giving the positive-length comparison of
+	$A^{[p]}$ and $B^{[p]}$ with the two sector decompositions. The sector-basis
+	matching and two-basis comparison theorems then give the sector-weight
+	conclusion.
+\end{proof}
+
+\begin{theorem}[Zero-tail nonzero block decompositions with a common MPV phase cover]%
+\label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
+	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
+	\leanok
+	\uses{def:mpv_common_phase_cover, lem:mpv_common_phase_cover_span_eq,
+		thm:afterBlocking_sectorComparison_zeroTail_of_blockSpan}
+	Under the hypotheses of
+	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_blockSpan}, a
+	common MPV phase cover for the two nonzero-weight block families supplies the
+	finite-length span equality. Hence there exist a period $p' > 0$ and sector
+	decompositions $P,Q$ such that $A^{[p']}$ and $B^{[p']}$ agree with the
+	corresponding sector tensors at every positive length, $P$ and $Q$ have the
+	same full MPV family, both have BNT data, and their sector weights satisfy the
+	matched sector-weight conclusion.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{lem:mpv_common_phase_cover_span_eq,
+		thm:afterBlocking_sectorComparison_zeroTail_of_blockSpan}
+	Apply the common-cover span lemma to obtain the nonzero-block span equality at
+	each system size, then invoke the zero-tail block-span theorem.
 \end{proof}
 
 \begin{theorem}[Zero-tail nonzero block decompositions with BNT proportional-decomposition data]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	\leanok
-	\uses{def:same_mpv2_pos,
-		thm:common_phase_cover_of_proportional_decomposition,
+	\uses{thm:common_phase_cover_of_proportional_decomposition,
 		thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	Let $A$ and $B$ have the same MPV family. Fix $p>0$ and suppose $A^{[p]}$
 	and $B^{[p]}$ each decompose as a zero-tail tensor plus a weighted nonzero


### PR DESCRIPTION
## Summary

- adds span-equality corollaries from BNT proportional-decomposition data and from separated normal canonical-form data
- splits the zero-tail sector comparison into block-span and common MPV phase-cover forms, then makes the proportional-decomposition theorem compose through the common-cover form
- updates the Chapter 11 blueprint entries and the #944/#970 audit note with the new theorem names and remaining hypotheses

## Remaining work

This PR does not close #970. The remaining mathematical input is still to obtain the common MPV phase-cover data, or an equivalent finite-length span equality, from the common-length cyclic-sector data and the equality of the original MPS families. That is coordinated with #990, #969, #971, and #942, and is now tracked explicitly in #1068.

Refs #970.
Refs #944.
Refs #652.

## Validation

- `ulimit -n 8192 || true; lake build --old TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- added-line scans for proof-integrity tokens and banned prose terms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors core canonical-form comparison theorems and rewires proof dependencies (phase-cover vs span-equality), which may break downstream Lean proofs or change required hypotheses even though the mathematical conclusions are unchanged.
> 
> **Overview**
> Refactors the zero-tail after-blocking sector comparison by introducing `afterBlocking_sectorComparison_zeroTail_of_blockSpan`, which takes *finite-length nonzero-block span equality* as the key hypothesis, and re-deriving `afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover` as a thin wrapper that obtains that span equality from `MPVCommonPhaseCover.span_eq`.
> 
> Adds span-equality corollaries in `EqualNormBridge.lean` (`mpv_span_eq_of_proportionalDecompositionConclusion` and `mpv_span_eq_of_separated_normalCFBNT_data`) so proportional-decomposition and separated normal-CF BNT data can be used directly as span-equality inputs. Updates the proportional-decomposition zero-tail theorem to compose through the new common-cover wrapper, and syncs the audit note and Chapter 11 blueprint to the new theorem split and names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 331d01f2e2ca9f54ba6b4b3052a11124e666d3d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->