### PR TITLE
docs(blueprint): clarify canonical equal-case remarks

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3286,53 +3286,53 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \section{Open directions}\label{sec:open_directions}
 
-\begin{remark}[Remaining steps toward normal canonical form]%
+\begin{remark}[Canonical-form reduction before the equal-case comparison]%
 	\label{rem:canonical_pipeline_gaps}
 	\leanok
 	The canonical-form proof in the MPS literature first separates the nilpotent
 	part, which contributes only to the zero-length trace, from the nonzero part.
-	The nonzero part is decomposed into irreducible blocks and each block is put in
-	trace-preserving gauge.  If such a block has period $m$, one blocks $m$ sites
-	and restricts the blocked tensor to the cyclic spectral sectors.  The resulting
-	sector tensors are the normal blocks used later: they are trace-preserving,
-	primitive, irreducible, and have positive bond dimension.  For a finite family
-	of nonzero-weight blocks, the paper then chooses one common multiple of all periods
-	so that every sector is expressed over the same blocked physical alphabet.  This is the
+	The nonzero part is decomposed into irreducible blocks, and each block is put in
+	trace-preserving gauge.  A block of period $m$ is then blocked over $m$ sites and
+	restricted to its cyclic spectral sectors.  These sector tensors are the normal
+	blocks used in the comparison theorem: they are trace-preserving, primitive,
+	irreducible, and have positive bond dimension.  For a finite nonzero block
+	family, the paper chooses one common multiple of all periods so that every
+	sector is expressed over the same blocked physical alphabet.  This is the
 	construction of
 	\cite[\S2.3 and Appendix~A]{Cirac2017MPDO_AnnPhys}, and it is the
-	canonical-form data used before the basis-of-normal-tensors argument in
+	canonical-form information used before the basis-of-normal-tensors argument in
 	\cite[Proposition~IV.4 and Corollary~IV.5]{Cirac2021Matrix}.
 
-	The formalization has already separated these steps.  Theorem~\ref{thm:tp_gauge_arbitrary}
-	gives the zero-tail block together with trace-preserving irreducible nonzero-weight
-	blocks, and Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
-	applies the cyclic-sector construction to each nonzero-weight block while keeping the
-	positive-length MPV equality and the $N=0$ identity.
+	The statements in this chapter mirror this reduction.  Theorem~\ref{thm:tp_gauge_arbitrary}
+	gives the zero-tail block and the trace-preserving irreducible nonzero block
+	family.  Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
+	applies the cyclic-sector decomposition to each nonzero block, preserving the
+	positive-length MPV equality and the zero-tail identity at $N=0$.
 	Theorem~\ref{thm:exists_common_blocked_cyclic_sector_family_common_multiple}
-	constructs the common reblocked sector family at any prescribed common multiple
-	of the period-removal lengths.  Consequently
-	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} now
-	chooses one physical blocking length for both tensors, carries the zero-tail
-	identities to that length, and supplies the relabeled cyclic-sector families on
+	constructs the common reblocked sector family at any common multiple of the
+	period-removal lengths.  Consequently
+	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} chooses
+	one physical blocking length for both tensors, transports the zero-tail
+	identities to that length, and supplies relabelled cyclic-sector families on
 	both sides.  The supporting blocking and transport results, including
 	Theorem~\ref{thm:iterated_blocking_samempv_reindex}, identify iterated blocking
-	with one blocking by the product length, up to the evident relabeling of
-	physical words.
+	with one blocking by the product length, after relabelling the blocked physical
+	words.
 
-	What remains on the canonical-form side is the exact equality, after the
-	relabeling of blocked physical words, between the canonical blocked nonzero part
-	and the cyclic-sector tensor for the whole weighted family.  The conditional statement
-	Theorem~\ref{thm:zero_tail_common_flat_of_reindexed_label_compat} already shows
-	that, once this blocked-word relabeling agreement is proved, the zero-tail equations
-	can be written directly with the weighted common-length cyclic sectors.
-	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
-	gives the next comparison step: if those common-length sector blocks are
-	injective and the BNT proportional-decomposition comparison supplies the
-	blockwise permutation, bond-dimension equalities, and gauge phases, then the
-	finite-length span equality follows through the common phase-cover theorem.
-	Thus the remaining canonical-form hypotheses are precisely this blocked-word
-	relabeling agreement, any additional blocking needed for injectivity, and the final
-	BNT proportional-decomposition data for the common-length nonzero sector blocks.
+	The next mathematical assertion is the equality, after relabelling blocked
+	physical words, between the canonical blocked nonzero part and the cyclic-sector
+	tensor for the whole weighted family.  The conditional statement
+	Theorem~\ref{thm:zero_tail_common_flat_of_reindexed_label_compat} shows that this
+	equality rewrites the zero-tail identity directly with the weighted
+	common-length cyclic sectors.  Once the common-length sectors have also been
+	blocked far enough to be injective, a BNT proportional-decomposition comparison
+	gives the block permutation, the bond-dimension equalities, and the gauge
+	phases.  Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
+	then turns that comparison into the finite-length MPV span equality and the
+	sector-weight conclusion.  Thus the open canonical-form assertions are the
+	blocked-word relabelling equality for the whole weighted nonzero family, the
+	injectivity of a suitable further blocking, and the proportional-decomposition
+	comparison for the common-length nonzero sectors.
 
 	The sorted normal-canonical-form theorem,
 	Theorem~\ref{thm:bnt_sorted_ncf}, assumes pairwise distinct nonzero weight

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3290,7 +3290,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	\label{rem:canonical_pipeline_gaps}
 	\leanok
 	The canonical-form proof in the MPS literature first separates the nilpotent
-	part, which contributes only to the zero-length trace, from the nonzero part.
+	part, which contributes only to the length-zero trace, from the nonzero part.
 	The nonzero part is decomposed into irreducible blocks, and each block is put in
 	trace-preserving gauge.  A block of period $m$ is then blocked over $m$ sites and
 	restricted to its cyclic spectral sectors.  These sector tensors are the normal
@@ -3313,13 +3313,13 @@ The following results separate the zero blocks from the nonzero blocks.
 	period-removal lengths.  Consequently
 	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} chooses
 	one physical blocking length for both tensors, transports the zero-tail
-	identities to that length, and supplies relabelled cyclic-sector families on
+	identities to that length, and supplies relabeled cyclic-sector families on
 	both sides.  The supporting blocking and transport results, including
 	Theorem~\ref{thm:iterated_blocking_samempv_reindex}, identify iterated blocking
-	with one blocking by the product length, after relabelling the blocked physical
+	with one blocking by the product length, after relabeling the blocked physical
 	words.
 
-	The next mathematical assertion is the equality, after relabelling blocked
+	The next mathematical assertion is the equality, after relabeling blocked
 	physical words, between the canonical blocked nonzero part and the cyclic-sector
 	tensor for the whole weighted family.  The conditional statement
 	Theorem~\ref{thm:zero_tail_common_flat_of_reindexed_label_compat} shows that this
@@ -3330,7 +3330,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	phases.  Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	then turns that comparison into the finite-length MPV span equality and the
 	sector-weight conclusion.  Thus the open canonical-form assertions are the
-	blocked-word relabelling equality for the whole weighted nonzero family, the
+	blocked-word relabeling equality for the whole weighted nonzero family, the
 	injectivity of a suitable further blocking, and the proportional-decomposition
 	comparison for the common-length nonzero sectors.
 

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1274,69 +1274,68 @@ two-basis sector comparison theorem.
 	the same multiset equality.
 \end{proof}
 
-\begin{remark}[Remaining hypotheses for the unconditional equal-case theorem]\notready
-	The equal-case proof in the literature assumes first that both tensors are in
-	canonical form.  One chooses a basis of normal tensors for each tensor, so
-	that every canonical-form block is a phase times a gauge transform of exactly
-	one basis tensor; this is the content of the basis characterization in
+\begin{remark}[Equal-case comparison after canonical reduction]\notready
+	The equal-case proof in the literature begins with both tensors in canonical
+	form.  One chooses a basis of normal tensors for each tensor, so that every
+	canonical-form block is a phase times a gauge transform of exactly one basis
+	tensor; this is the basis characterization of
 	\cite[Proposition~\texttt{prop:char-BNT}, lines 1852--1861]{Cirac2021Matrix}
 	and
 	\cite[Proposition~\texttt{prop:char-BNT}, lines 1135--1148]{Cirac2016MPDO_arXiv}.
-	Equality, or proportionality, of the MPV families then forces the two bases to
-	pair by phase and gauge, as in
+	Equality, or proportionality, of the MPV families then pairs the two bases by
+	phase and gauge, as in
 	\cite[Theorem~\texttt{thm1}, lines 1167--1183]{Cirac2016MPDO_arXiv}.
 	In the equal case, one expands each tensor in its basis of normal tensors and
 	compares, for every basis tensor and every length $N$, the power sums
 	\[
 		\sum_q \mu_{j,q}^N = \sum_q (\nu_{j,q}e^{i\phi_j})^N.
 	\]
-	Newton identities, or equivalently the elementary power-sum lemma used in the
+	Newton identities, equivalently the elementary power-sum lemma used in the
 	paper, recover the multiplicities and the weights.  The blockwise gauge
-	matrices are then put on the diagonal to obtain the global conjugating matrix;
-	this is the proof of
+	matrices are then placed on the diagonal to obtain the global conjugating
+	matrix; this is the proof of
 	\cite[Corollary~\texttt{II\_cor2}, lines 1184--1192]{Cirac2016MPDO_arXiv},
 	restated as
 	\cite[Corollary~\texttt{II\_cor2}, lines 1896--1900]{Cirac2021Matrix}.
 
-	The formalized results cover the later comparison steps of this argument.
+	The comparison theorems in this chapter cover this latter part of the argument.
 	Theorem~\ref{thm:ft_equal_explicit} proves the equal case when the coefficient
 	identities are given explicitly,
 	Theorem~\ref{thm:ft_equal_same_structure} proves the common block-structure
 	special case, and Theorem~\ref{thm:route_b_equal} recovers the sector-weight
-	multisets from the multiplicity data.  The basis-of-normal-tensors
-	construction is also available for trace-preserving primitive irreducible
-	nonzero-weight blocks with positive bond dimensions and nonzero weights in
-	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}.  When these
-	blocks are injective, Theorems~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}
+	multisets from the multiplicity data.  The basis-of-normal-tensors construction
+	is available for trace-preserving primitive irreducible nonzero blocks with
+	positive bond dimensions and nonzero weights in
+	Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}.  When these blocks
+	are injective,
+	Theorems~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}
 	and~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data_span}
-	provide the asymptotic orthogonality and finite-length span preservation needed
-	to separate coefficients.  Theorem~\ref{thm:bnt_sector_decomp_pair_overlap_span_of_block_span}
+	give the asymptotic orthogonality and finite-length span preservation needed to
+	separate coefficients.  Theorem~\ref{thm:bnt_sector_decomp_pair_overlap_span_of_block_span}
 	then turns equality of nonzero-sector spans into the hypotheses used by the
 	sector comparison theorem.
 
-	The common-family comparison data are also formalized in reusable forms.  A
-	common MPV phase cover gives equality of finite-length nonzero-block spans by
+	The same comparison can also be expressed through common phases.  A common
+	MPV phase cover gives equality of finite-length nonzero-block spans by
 	Lemma~\ref{lem:mpv_common_phase_cover_span_eq}.  A sector basis pre-matching
-	gives such span equality and the primitive overlap-span hypotheses by
+	gives the same span equality and the primitive overlap-span hypotheses by
 	Lemma~\ref{lem:sector_basis_pre_matching_span_eq} and
 	Theorem~\ref{thm:sector_basis_pre_matching_to_overlap_span}.  The BNT comparison
-	results produce common phase-cover data from proportional-decomposition
-	conclusions in Theorems~\ref{thm:common_phase_cover_of_proportional_decomposition}
+	theorems produce such common phases from a proportional-decomposition conclusion in
+	Theorems~\ref{thm:common_phase_cover_of_proportional_decomposition}
 	and~\ref{thm:common_phase_cover_of_separated_normal_bnt}.
 
-	The remaining hypothesis for the unconditional equal-case theorem is the connection
-	from arbitrary equal MPV families to those hypotheses.  Chapter~\ref{ch:canonical}
-	now supplies a common physical blocking length and relabeled cyclic-sector
-	families on both sides, while preserving the zero-tail identities.  What remains
-	is the exact agreement, after reindexing blocked physical words, that identifies
-	the canonical blocked nonzero part with the relabeled cyclic-sector tensor for
-	the whole weighted family, followed by the final nonzero-sector extraction used
-	by the equal-case comparison.  After any additional blocking required for
-	injectivity, one must then prove the finite-length nonzero-sector span equality,
-	or produce the common phase-cover or BNT proportional-decomposition data from
-	which the theorems above derive that equality.  Until this connection is
-	formalized, equality of the total MPV vectors has not yet been converted into
-	the componentwise power-sum
-	identities used in the paper proof, so Corollary~IV.5 cannot be invoked
-	unconditionally.
+	Chapter~\ref{ch:canonical} supplies the canonical-form reduction needed before
+	these comparison theorems can be applied: a common physical blocking length,
+	the zero-tail identities at that length, and relabelled cyclic-sector families
+	on both sides.  The unproved assertion is the exact equality, after relabelling
+	blocked physical words, between the canonical blocked nonzero part and the
+	relabelled cyclic-sector tensor for the whole weighted family.  With that
+	equality, the zero-tail identity can be written in the common-length sector
+	basis; after a further injective blocking, one must establish either the
+	finite-length MPV span equality of the nonzero sectors or the corresponding
+	common phases, equivalently the BNT proportional-decomposition conclusion, from
+	which the theorems above derive the span equality.  This is the mathematical
+	passage from equality of total MPV vectors to the componentwise power-sum
+	identities used in the paper proof of Corollary~IV.5.
 \end{remark}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1327,10 +1327,10 @@ two-basis sector comparison theorem.
 
 	Chapter~\ref{ch:canonical} supplies the canonical-form reduction needed before
 	these comparison theorems can be applied: a common physical blocking length,
-	the zero-tail identities at that length, and relabelled cyclic-sector families
-	on both sides.  The unproved assertion is the exact equality, after relabelling
+	the zero-tail identities at that length, and relabeled cyclic-sector families
+	on both sides.  The unproved assertion is the exact equality, after relabeling
 	blocked physical words, between the canonical blocked nonzero part and the
-	relabelled cyclic-sector tensor for the whole weighted family.  With that
+	relabeled cyclic-sector tensor for the whole weighted family.  With that
 	equality, the zero-tail identity can be written in the common-length sector
 	basis; after a further injective blocking, one must establish either the
 	finite-length MPV span equality of the nonzero sectors or the corresponding


### PR DESCRIPTION
## Summary

- Rewrites the Ch. 8 open-direction remark around the non-Gemma canonical-form reduction in ordinary MPS language: nilpotent/nonzero split, trace-preserving irreducible nonzero blocks, common blocking length, cyclic-sector decomposition, zero-tail identity, and the remaining blocked-word relabelling equality.
- Rewrites the Ch. 11 equal-case remark to describe the post-canonical comparison through bases of normal tensors, common phases, finite-length nonzero-sector spans, and the BNT proportional-decomposition conclusion.
- Leaves style-policy PR #1029 and paper-gap note PRs #1051--#1058 untouched; this PR only edits `ch08_canonical.tex` and `ch11_assembly.tex`.

Refs #1021. Refs #924. Refs #652.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe cache get`
- `lake build --old TNLean` (after rebuilding two canonical modules individually to avoid a transient system open-file limit)
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits that rephrase two remarks; no changes to Lean code, theorems, or build logic.
> 
> **Overview**
> Clarifies the narrative around the *remaining gaps* in the canonical-form-to-comparison pipeline.
> 
> In `ch08_canonical.tex`, rewrites and retitles the open-directions remark to describe the canonical-form reduction steps (zero-tail vs nonzero, TP irreducible blocks, period blocking, cyclic-sector restriction, and common blocking length) and to more explicitly call out the next unformalized assertion: the blocked-word relabeling equality identifying the canonical blocked nonzero part with the common-length cyclic-sector tensor.
> 
> In `ch11_assembly.tex`, rewrites and retitles the equal-case remark to frame the post-canonical equal-case comparison via bases of normal tensors, power-sum/multiplicity recovery, and the role of common phases / phase covers / BNT proportional-decomposition data, explicitly stating what still needs to be proved to connect total MPV equality to the componentwise identities used in the literature proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 350f6491d223a2f1e4c22220e0264d19ffbec41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->