### PR TITLE
feat(MPS/CanonicalForm): expose common primitive decompositions (#942)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -943,6 +943,223 @@ theorem zeroTail_commonFlat_transport_of_reindexed
   · intro x
     exact F.commonFlatWeight_ne_zero μ hμ x
 
+set_option maxHeartbeats 800000 in
+-- The conclusion records both decompositions and all their structural hypotheses together.
+/-- **Common primitive irreducible block decompositions after blocked-word reindexing.**
+
+Assume the one-sided equality which identifies, for every common cyclic-sector
+family, the canonically blocked weighted nonzero part with the same family written
+using the reindexing of blocked physical words.  Then two tensors with the same
+MPV family have one common positive blocking length whose nonzero parts are
+weighted families of trace-preserving, primitive, tensor-irreducible blocks with
+positive bond dimensions and nonzero weights.  The zero-tail equations are stated
+at that same blocking length, and the two nonzero parts agree at all positive
+lengths, with the length-zero zero-tail identity recorded separately.
+
+The displayed reindexing equality is the remaining one-sided blocked-word
+theorem; this result isolates the mathematical hypotheses used before the later
+injectivity and BNT comparison. -/
+theorem afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : ∀ {r : ℕ} {dim : Fin r → ℕ}
+      (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+      (F : CommonBlockedCyclicSectorFamily blocks),
+      SameMPV₂
+        (toTensorFromBlocks (d := blockPhysDim d F.p)
+          (μ := fun k : Fin r => (μ k) ^ F.p)
+          (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+        (toTensorFromBlocks (d := blockPhysDim d F.p)
+          (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ (zeroTailA zeroTailB : ℕ),
+    ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)),
+    ∃ (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)),
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
+      (∀ x, μA x ≠ 0) ∧
+      (∀ x, μB x ≠ 0) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) ∧
+      (∀ x, IsIrreducibleTensor (blocksA x)) ∧
+      (∀ x, IsIrreducibleTensor (blocksB x)) ∧
+      (∀ x, 0 < dimA x) ∧
+      (∀ x, 0 < dimB x) := by
+  obtain ⟨p, hp, zeroTailA, rA₀, dimA₀, μA₀, blocksA₀,
+      zeroTailB, rB₀, dimB₀, μB₀, blocksB₀, familyA, familyB,
+      hFamilyA, hFamilyB, hZA, hZB, hPosCanon, hZeroCanon,
+      _hReindexedA, _hReindexedB, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB,
+      hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    fundamentalTheorem_after_blocking_commonLength_commonSector A B hSame
+  have hWordA := hReindexed μA₀ blocksA₀ familyA
+  have hWordB := hReindexed μB₀ blocksB₀ familyB
+  have hFlatA_raw := familyA.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μA₀ hWordA
+  have hFlatB_raw := familyB.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μB₀ hWordB
+  let flatBlocksA : (x : Fin (∑ k : Fin rA₀, familyA.period k)) →
+      MPSTensor (blockPhysDim d p) (familyA.commonFlatDim x) :=
+    fun x => cast (congr_arg (fun q => MPSTensor (blockPhysDim d q)
+      (familyA.commonFlatDim x)) hFamilyA) (familyA.commonFlatBlocks x)
+  let flatBlocksB : (x : Fin (∑ k : Fin rB₀, familyB.period k)) →
+      MPSTensor (blockPhysDim d p) (familyB.commonFlatDim x) :=
+    fun x => cast (congr_arg (fun q => MPSTensor (blockPhysDim d q)
+      (familyB.commonFlatDim x)) hFamilyB) (familyB.commonFlatBlocks x)
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p)
+    (μ := familyA.commonFlatWeight μA₀) flatBlocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p)
+    (μ := familyB.commonFlatWeight μB₀) flatBlocksB
+  have hFlatA : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := fun k : Fin rA₀ => (μA₀ k) ^ p)
+        (fun k => blockTensor (d := d) (D := dimA₀ k) (blocksA₀ k) p))
+      nonzeroA := by
+    cases hFamilyA
+    simpa [flatBlocksA, nonzeroA] using hFlatA_raw
+  have hFlatB : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := fun k : Fin rB₀ => (μB₀ k) ^ p)
+        (fun k => blockTensor (d := d) (D := dimB₀ k) (blocksB₀ k) p))
+      nonzeroB := by
+    cases hFamilyB
+    simpa [flatBlocksB, nonzeroB] using hFlatB_raw
+  have hZAflat : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+      mpv (blockTensor (d := d) (D := D₁) A p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+          mpv nonzeroA σ := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (fun k : Fin rA₀ => (μA₀ k) ^ p)
+              (fun k => blockTensor (d := d) (D := dimA₀ k) (blocksA₀ k) p)) σ :=
+        hZA N σ
+      _ = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ + mpv nonzeroA σ := by
+        rw [hFlatA N σ]
+  have hZBflat : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+      mpv (blockTensor (d := d) (D := D₂) B p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+          mpv nonzeroB σ := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (fun k : Fin rB₀ => (μB₀ k) ^ p)
+              (fun k => blockTensor (d := d) (D := dimB₀ k) (blocksB₀ k) p)) σ :=
+        hZB N σ
+      _ = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ + mpv nonzeroB σ := by
+        rw [hFlatB N σ]
+  have hAPos : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p) nonzeroA := by
+    intro N hN σ
+    have hZero : mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ + mpv nonzeroA σ :=
+        hZAflat N σ
+      _ = mpv nonzeroA σ := by rw [hZero]; simp
+  have hBPos : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p) nonzeroB := by
+    intro N hN σ
+    have hZero : mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ + mpv nonzeroB σ :=
+        hZBflat N σ
+      _ = mpv nonzeroB σ := by rw [hZero]; simp
+  have hNonzeroPos : SameMPV₂Pos nonzeroA nonzeroB := by
+    intro N hN σ
+    calc
+      mpv nonzeroA σ =
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k : Fin rA₀ => (μA₀ k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimA₀ k) (blocksA₀ k) p)) σ :=
+        (hFlatA N σ).symm
+      _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k : Fin rB₀ => (μB₀ k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimB₀ k) (blocksB₀ k) p)) σ :=
+        hPosCanon N hN σ
+      _ = mpv nonzeroB σ := hFlatB N σ
+  have hZeroFlat : ∀ σ : Fin 0 → Fin (blockPhysDim d p),
+      (zeroTailA : ℂ) + mpv nonzeroA σ = (zeroTailB : ℂ) + mpv nonzeroB σ := by
+    intro σ
+    calc
+      (zeroTailA : ℂ) + mpv nonzeroA σ =
+          (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (fun k : Fin rA₀ => (μA₀ k) ^ p)
+              (fun k => blockTensor (d := d) (D := dimA₀ k) (blocksA₀ k) p)) σ := by
+        rw [← hFlatA 0 σ]
+      _ = (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (fun k : Fin rB₀ => (μB₀ k) ^ p)
+              (fun k => blockTensor (d := d) (D := dimB₀ k) (blocksB₀ k) p)) σ :=
+        hZeroCanon σ
+      _ = (zeroTailB : ℂ) + mpv nonzeroB σ := by
+        rw [hFlatB 0 σ]
+  have hTPA' : ∀ x,
+      ∑ i : Fin (blockPhysDim d p), (flatBlocksA x i)ᴴ * flatBlocksA x i = 1 := by
+    intro x
+    cases hFamilyA
+    simpa [flatBlocksA] using hTPA x
+  have hTPB' : ∀ x,
+      ∑ i : Fin (blockPhysDim d p), (flatBlocksB x i)ᴴ * flatBlocksB x i = 1 := by
+    intro x
+    cases hFamilyB
+    simpa [flatBlocksB] using hTPB x
+  have hPrimA' : ∀ x, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := familyA.commonFlatDim x) (flatBlocksA x)) := by
+    intro x
+    cases hFamilyA
+    simpa [flatBlocksA] using hPrimA x
+  have hPrimB' : ∀ x, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := familyB.commonFlatDim x) (flatBlocksB x)) := by
+    intro x
+    cases hFamilyB
+    simpa [flatBlocksB] using hPrimB x
+  have hIrrA' : ∀ x, IsIrreducibleTensor (flatBlocksA x) := by
+    intro x
+    cases hFamilyA
+    simpa [flatBlocksA] using hIrrA x
+  have hIrrB' : ∀ x, IsIrreducibleTensor (flatBlocksB x) := by
+    intro x
+    cases hFamilyB
+    simpa [flatBlocksB] using hIrrB x
+  refine ⟨p, hp, zeroTailA, zeroTailB,
+    (∑ k : Fin rA₀, familyA.period k), familyA.commonFlatDim, familyA.commonFlatWeight μA₀,
+    flatBlocksA,
+    (∑ k : Fin rB₀, familyB.period k), familyB.commonFlatDim, familyB.commonFlatWeight μB₀,
+    flatBlocksB,
+    hZAflat, hZBflat, hAPos, hBPos, hNonzeroPos, hZeroFlat,
+    hμA, hμB, hTPA', hTPB', hPrimA', hPrimB', hIrrA', hIrrB', hDimA, hDimB⟩
+
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 
 Given two tensors with `SameMPV₂`, a common-period BNT sector pair, and a

--- a/audits/2026-04-30_issue942_common_primitive_blocks.md
+++ b/audits/2026-04-30_issue942_common_primitive_blocks.md
@@ -1,0 +1,79 @@
+# 2026-04-30 — Common primitive irreducible block decompositions (#942/#969/#990/#944/#652)
+
+## Scope
+
+This note records the Lean theorem added for issue #942.  It is a conditional
+two-sided theorem: once the one-sided equality after reindexing blocked physical
+words is available, the common cyclic-sector construction gives the two weighted
+nonzero-sector families required before the injectivity and BNT comparison
+arguments.
+
+The theorem is deliberately not a full fundamental theorem.  It does not prove the
+blocked-word reindexing equality tracked by #990, it does not add the later
+Wielandt/injectivity blocking, and it does not construct the cross-side BNT
+proportional-decomposition data.
+
+## Source anchors
+
+- `Papers/1606.00608/MPDO-22-12-17-2.tex:214--231` describes the reduction to
+  a block-diagonal nonzero part and the subsequent common blocking by the
+  periods; line 217 gives the weighted direct sum and lines 227--231 describe
+  period removal by a common multiple.
+- `Papers/2011.12127/TN-Review-main.tex:1798--1820` gives the corresponding
+  irreducible trace-preserving block form and explains that blocking by the
+  period makes the transfer operator primitive.
+- `Papers/2011.12127/TN-Review-main.tex:1841--1884` introduces the basis of
+  normal tensors and the coefficient expansions consumed by the BNT comparison
+  stage.
+
+## Lean statement
+
+The new theorem is
+
+```lean
+MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
+```
+
+It assumes `SameMPV₂ A B` and the one-sided theorem asserting, for every
+`CommonBlockedCyclicSectorFamily F`, that the canonically blocked weighted
+nonzero part agrees as an MPV family with the same weighted family written using
+`F.commonReindexedBlock`.  Under that assumption it produces:
+
+- one common physical blocking length `p` with `0 < p`;
+- zero-tail dimensions on the two sides;
+- two weighted nonzero-sector families over `blockPhysDim d p`;
+- zero-tail equations for `blockTensor A p` and `blockTensor B p` written with
+  these weighted sector families;
+- positive-length MPV equality between each blocked tensor and its nonzero
+  sector part;
+- positive-length MPV equality between the two nonzero sector parts;
+- the length-zero zero-tail identity;
+- nonzero weights;
+- trace preservation, primitive transfer maps, tensor irreducibility, and
+  positive bond dimensions for every sector block.
+
+The proof composes
+`fundamentalTheorem_after_blocking_commonLength_commonSector` with
+`CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed`.
+The zero-tail equations and the positive-length equality are obtained by
+substitution in the already formalized common-length zero-tail bookkeeping.
+
+## Remaining hypotheses
+
+The theorem leaves three mathematically distinct obligations.
+
+1. **Agreement after reindexing blocked physical words.**  The needed one-sided
+   statement is the #990 equality comparing the canonically blocked weighted
+   nonzero part with the weighted `commonReindexedBlock` family.  Once this is
+   proved, it can be passed directly as the `hReindexed` argument of the new
+   theorem.
+2. **Injectivity after a further blocking, or a replacement theorem.**  The new
+   theorem gives trace preservation, primitive transfer maps, tensor irreducibility,
+   nonzero weights, and positive bond dimensions.  The current overlap-span
+   route to #944/#652 also assumes one-site injectivity of the final sector
+   blocks.
+3. **Common phase-cover or BNT proportional-decomposition data.**  The comparison
+   theorems in Chapter 11 turn such data into finite-length nonzero-sector span
+   equality and then into sector-weight comparison.  This branch supplies the
+   common nonzero-sector decompositions to which those theorems apply after the
+   preceding two obligations are supplied.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3296,8 +3296,9 @@ The following results separate the zero blocks from the nonzero blocks.
 	blocking length at which both nonzero parts are weighted families of
 	trace-preserving, primitive, tensor-irreducible blocks with positive bond
 	dimensions and nonzero weights.  The theorem records the two zero-tail
-	equations at this common length, the positive-length equality of the nonzero
-	parts, and the length-zero zero-tail identity.
+	equations at this common length, the positive-length agreement of each
+	blocked tensor with its own nonzero-sector part, the positive-length equality
+	of the two nonzero-sector parts, and the length-zero zero-tail identity.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1758,7 +1758,7 @@ The following results separate the zero blocks from the nonzero blocks.
 \end{proof}
 
 \begin{theorem}[Canonical blocked nonzero part under blocked-word relabeling]%
-\label{thm:common_blocked_cyclic_sector_canonical_label_compat}
+\label{thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed}
 	\leanok
 	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
@@ -3265,7 +3265,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	\lean{MPSTensor.zeroTail_commonFlat_of_reindexed}
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_canonical_label_compat}
+		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero}
 	For one side, suppose first that the original tensor decomposes, as an MPV
 	family, into a zero-tail contribution plus a weighted block-sum nonzero part at
 	the original physical alphabet.  Suppose also that, after blocking by the
@@ -3277,12 +3277,40 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_canonical_label_compat}
+		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero}
 	First transport the original zero-tail/nonzero decomposition through the common
 	blocking length.  Then replace the canonical blocked nonzero tensor by the
 	derived common-sector tensor using the blocked-word relabeling agreement.
 \end{proof}
 
+\begin{theorem}[Common primitive irreducible block decompositions after reindexing]%
+\label{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+	\lean{MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts}
+	\leanok
+	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
+		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero,
+		def:same_mpv2_pos}
+	Assume the one-sided theorem identifying the canonically blocked weighted
+	nonzero part with the same family written through the reindexing of blocked
+	physical words.  Then two tensors with the same MPV family have one positive
+	blocking length at which both nonzero parts are weighted families of
+	trace-preserving, primitive, tensor-irreducible blocks with positive bond
+	dimensions and nonzero weights.  The theorem records the two zero-tail
+	equations at this common length, the positive-length equality of the nonzero
+	parts, and the length-zero zero-tail identity.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
+		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero}
+	Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}
+	to choose the common blocking length and the two common cyclic-sector families.
+	The assumed blocked-word reindexing equality converts the canonically blocked
+	nonzero part into the weighted common-sector family on each side.  Substituting
+	these two equalities into the existing zero-tail equations gives the displayed
+	decompositions; the structural properties and nonzero weights are those of the
+	derived common-sector families.
+\end{proof}
 
 \begin{theorem}[Positive-length and length-zero identities under MPV equality]%
 \label{thm:samempv_pos_zero_tail_identity_transport}
@@ -3307,7 +3335,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	\lean{MPSTensor.zeroTail_commonFlat_transport_of_reindexed}
 	\leanok
 	\uses{thm:zero_tail_common_flat_of_reindexed,
-		thm:common_blocked_cyclic_sector_canonical_label_compat,
+		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero,
 		thm:common_blocked_cyclic_sector_derived_properties}
 	Assume that the original tensor decomposes, as an MPV family, into a
 	zero-tail contribution plus a weighted nonzero block tensor, that all original
@@ -3321,7 +3349,7 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_common_flat_of_reindexed,
-		thm:common_blocked_cyclic_sector_canonical_label_compat,
+		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero,
 		thm:common_blocked_cyclic_sector_derived_properties}
 	Combine Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} with
 	the weighted common-sector MPV equality and the nonzero-weight statement for
@@ -3367,14 +3395,17 @@ The following results separate the zero blocks from the nonzero blocks.
 	The next mathematical assertion is the equality, after relabeling blocked
 	physical words, between the canonical blocked nonzero part and the cyclic-sector
 	tensor for the whole weighted family.  The conditional statements
-	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed} and
-	\ref{thm:samempv_pos_zero_tail_identity_transport} show that this equality
-	rewrites the zero-tail identities, the positive-length equality, the length-zero
-	identity, and the nonzero transported weights directly with the weighted
-	common-length cyclic sectors.  Once the common-length sectors have also been
-	blocked far enough to be injective, a BNT proportional-decomposition comparison
-	gives the block permutation, the bond-dimension equalities, and the gauge
-	phases.  Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
+	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed},
+	\ref{thm:samempv_pos_zero_tail_identity_transport}, and
+	\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+	show that this equality rewrites the zero-tail identities, the positive-length
+	equality, the length-zero identity, and the nonzero transported weights directly
+	with the weighted common-length cyclic sectors, while also collecting the
+	two-sided primitive irreducible sector decompositions needed for comparison.
+	Once these sectors have also been blocked far enough to be injective, a BNT
+	proportional-decomposition comparison gives the block permutation, the
+	bond-dimension equalities, and the gauge phases.
+	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	then turns that comparison into the finite-length MPV span equality and the
 	sector-weight conclusion.  Thus the open canonical-form assertions are the
 	blocked-word relabeling equality for the whole weighted nonzero family, the

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1423,11 +1423,12 @@ two-basis sector comparison theorem.
 	on both sides.  The unproved assertion is the exact equality, after relabeling
 	blocked physical words, between the canonical blocked nonzero part and the
 	relabeled cyclic-sector tensor for the whole weighted family.  With that
-	equality, the zero-tail identity can be written in the common-length sector
-	basis; after a further injective blocking, one must establish either the
-	finite-length MPV span equality of the nonzero sectors or the corresponding
-	common phases, equivalently the BNT proportional-decomposition conclusion, from
-	which the theorems above derive the span equality.  This is the mathematical
-	passage from equality of total MPV vectors to the componentwise power-sum
-	identities used in the paper proof of Corollary~IV.5.
+	equality, Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+	gives the common weighted nonzero-sector decompositions needed for the
+	comparison theorems.  After a further injective blocking, one must establish
+	either the finite-length MPV span equality of the nonzero sectors or the
+	corresponding common phases, equivalently the BNT proportional-decomposition
+	conclusion, from which the theorems above derive the span equality.  This is
+	the mathematical passage from equality of total MPV vectors to the componentwise
+	power-sum identities used in the paper proof of Corollary~IV.5.
 \end{remark}


### PR DESCRIPTION
## Summary

- add `MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`, a two-sided consequence of the common-length cyclic-sector construction
- under the one-sided blocked-word reindexing equality, produce one common positive blocking length with zero-tail equations, nonzero weights, positive-length MPV equality, and trace-preserving primitive tensor-irreducible sector families on both sides
- update the Ch. 8/Ch. 11 blueprint remarks and add an audit note recording the remaining #990, injectivity, and BNT/common-cover inputs

## Validation

- `ulimit -n 16384 || true; lake build --old TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- `ulimit -n 16384 || true; lake build --old TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --cached --check`
- added-line scans for proof placeholders and banned prose terms

Refs #942, #969, #990, #970, #971, #944, #652.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large new Lean theorem with an extensive dependent-existential conclusion and a high heartbeat limit; main risk is proof fragility/compile-time regressions rather than behavioral changes.
> 
> **Overview**
> Introduces a new conditional two-sided Lean theorem, `MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`, which packages a **single common blocking length** together with both sides’ zero-tail decompositions, positive-length MPV equalities (blocked tensor vs nonzero part, and nonzero part vs nonzero part), the `N=0` zero-tail identity, and per-block structural facts (TP, primitive transfer map, tensor irreducibility, positive bond dimension, nonzero weights), assuming the one-sided blocked-word reindexing equality.
> 
> Updates the blueprint (Ch. 8/11) to reference the new theorem and renames the blocked-word relabeling theorem label to the “reindexed nonzero” wording, and adds an audit note documenting the new theorem’s scope and the remaining prerequisites (#990 reindexing equality, injectivity blocking, and BNT/common-cover inputs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5002ad08c474bfcdbe8a2f83cc1f11d7e5da8a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->