### PR TITLE
feat(MPS/CanonicalForm): transport zero tails to common sectors (#971)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -845,7 +845,7 @@ theorem fundamentalTheorem_after_blocking_commonLength_commonSector
 the zero-tail equation can be rewritten using the derived common-sector family.
 This is the one-sided theorem that puts the reindexed data above in the form used
 by the span and BNT comparison theorems. -/
-theorem zeroTail_commonFlat_of_reindexed_labelCompat
+theorem zeroTail_commonFlat_of_reindexed
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -879,6 +879,69 @@ theorem zeroTail_commonFlat_of_reindexed_labelCompat
           mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
             (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
           rw [hFlat N σ]
+
+/-- Replacing nonzero parts by MPV-equivalent tensors preserves the positive-length
+MPV equality and the length-zero zero-tail identity. -/
+theorem sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂
+    {d LA LB LA' LB' zeroTailA zeroTailB : ℕ}
+    (liveA : MPSTensor d LA) (liveB : MPSTensor d LB)
+    (flatA : MPSTensor d LA') (flatB : MPSTensor d LB')
+    (hA : SameMPV₂ liveA flatA) (hB : SameMPV₂ liveB flatB)
+    (hPos : SameMPV₂Pos liveA liveB)
+    (hZero : ∀ σ : Fin 0 → Fin d,
+      (zeroTailA : ℂ) + mpv liveA σ = (zeroTailB : ℂ) + mpv liveB σ) :
+    SameMPV₂Pos flatA flatB ∧
+      ∀ σ : Fin 0 → Fin d,
+        (zeroTailA : ℂ) + mpv flatA σ = (zeroTailB : ℂ) + mpv flatB σ := by
+  refine ⟨?_, ?_⟩
+  · intro N hN σ
+    calc
+      mpv flatA σ = mpv liveA σ := (hA N σ).symm
+      _ = mpv liveB σ := hPos N hN σ
+      _ = mpv flatB σ := hB N σ
+  · intro σ
+    calc
+      (zeroTailA : ℂ) + mpv flatA σ = (zeroTailA : ℂ) + mpv liveA σ := by
+        rw [(hA 0 σ).symm]
+      _ = (zeroTailB : ℂ) + mpv liveB σ := hZero σ
+      _ = (zeroTailB : ℂ) + mpv flatB σ := by
+        rw [hB 0 σ]
+
+/-- Once the canonical blocked nonzero part agrees with the reindexed common-sector
+nonzero part, the zero-tail equation, the transported-weight equality, and the
+nonvanishing of the common-sector weights are available together. -/
+theorem zeroTail_commonFlat_transport_of_reindexed
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (hμ : ∀ k, μ k ≠ 0)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hRelabel : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
+    (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
+      mpv (blockTensor (d := d) (D := D) A F.p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ) ∧
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) F.commonFlatBlocks) ∧
+    (∀ x, F.commonFlatWeight μ x ≠ 0) := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact zeroTail_commonFlat_of_reindexed A μ blocks F hMPV hRelabel
+  · exact F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μ hRelabel
+  · intro x
+    exact F.commonFlatWeight_ne_zero μ hμ x
 
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3288,7 +3288,7 @@ The following results separate the zero blocks from the nonzero blocks.
 \label{thm:samempv_pos_zero_tail_identity_transport}
 	\lean{MPSTensor.sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂}
 	\leanok
-	\uses{def:same_mpv2}
+	\uses{def:same_mpv2, def:same_mpv2_pos}
 	Let $L_A,L_B$ be two nonzero parts whose MPV families agree at positive
 	lengths and whose zero-tail dimensions satisfy the length-zero identity.  If
 	$L_A'$ and $L_B'$ generate the same MPV families as $L_A$ and $L_B$, respectively,
@@ -3297,7 +3297,7 @@ The following results separate the zero blocks from the nonzero blocks.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{def:same_mpv2}
+	\uses{def:same_mpv2, def:same_mpv2_pos}
 	Use the two MPV equalities to replace $L_A'$ by $L_A$ and $L_B$ by $L_B'$ in
 	the positive-length statement and in the $N=0$ identity.
 \end{proof}
@@ -3309,12 +3309,14 @@ The following results separate the zero blocks from the nonzero blocks.
 	\uses{thm:zero_tail_common_flat_of_reindexed,
 		thm:common_blocked_cyclic_sector_canonical_label_compat,
 		thm:common_blocked_cyclic_sector_derived_properties}
-	Assume that the canonical blocked nonzero tensor agrees, after the prescribed
-	blocked-word relabeling, with the reindexed common-sector tensor.  Then the
-	zero-tail equation after blocking can be written with the weighted common-sector
-	family, the canonical blocked nonzero tensor generates the same MPV family as
-	that weighted common-sector family, and all transported common-sector weights
-	are nonzero.
+	Assume that the original tensor decomposes, as an MPV family, into a
+	zero-tail contribution plus a weighted nonzero block tensor, that all original
+	nonzero-block weights are nonzero, and that the canonical blocked nonzero
+	tensor agrees, after the prescribed blocked-word relabeling, with the
+	reindexed common-sector tensor.  Then the zero-tail equation after blocking
+	can be written with the weighted common-sector family, the canonical blocked
+	nonzero tensor generates the same MPV family as that weighted common-sector
+	family, and all transported common-sector weights are nonzero.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3261,8 +3261,8 @@ The following results separate the zero blocks from the nonzero blocks.
 \end{proof}
 
 \begin{theorem}[Zero-tail equation after resolving the blocked-word relabeling]%
-\label{thm:zero_tail_common_flat_of_reindexed_label_compat}
-	\lean{MPSTensor.zeroTail_commonFlat_of_reindexed_labelCompat}
+\label{thm:zero_tail_common_flat_of_reindexed}
+	\lean{MPSTensor.zeroTail_commonFlat_of_reindexed}
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:common_blocked_cyclic_sector_canonical_label_compat}
@@ -3281,6 +3281,49 @@ The following results separate the zero blocks from the nonzero blocks.
 	First transport the original zero-tail/nonzero decomposition through the common
 	blocking length.  Then replace the canonical blocked nonzero tensor by the
 	derived common-sector tensor using the blocked-word relabeling agreement.
+\end{proof}
+
+
+\begin{theorem}[Positive-length and length-zero identities under MPV equality]%
+\label{thm:samempv_pos_zero_tail_identity_transport}
+	\lean{MPSTensor.sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂}
+	\leanok
+	\uses{def:same_mpv2}
+	Let $L_A,L_B$ be two nonzero parts whose MPV families agree at positive
+	lengths and whose zero-tail dimensions satisfy the length-zero identity.  If
+	$L_A'$ and $L_B'$ generate the same MPV families as $L_A$ and $L_B$, respectively,
+	then $L_A'$ and $L_B'$ satisfy the same positive-length equality and the same
+	length-zero zero-tail identity.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{def:same_mpv2}
+	Use the two MPV equalities to replace $L_A'$ by $L_A$ and $L_B$ by $L_B'$ in
+	the positive-length statement and in the $N=0$ identity.
+\end{proof}
+
+\begin{theorem}[Common-sector zero-tail data after blocked-word relabeling]%
+\label{thm:zero_tail_common_flat_transport_of_reindexed}
+	\lean{MPSTensor.zeroTail_commonFlat_transport_of_reindexed}
+	\leanok
+	\uses{thm:zero_tail_common_flat_of_reindexed,
+		thm:common_blocked_cyclic_sector_canonical_label_compat,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	Assume that the canonical blocked nonzero tensor agrees, after the prescribed
+	blocked-word relabeling, with the reindexed common-sector tensor.  Then the
+	zero-tail equation after blocking can be written with the weighted common-sector
+	family, the canonical blocked nonzero tensor generates the same MPV family as
+	that weighted common-sector family, and all transported common-sector weights
+	are nonzero.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:zero_tail_common_flat_of_reindexed,
+		thm:common_blocked_cyclic_sector_canonical_label_compat,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	Combine Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} with
+	the weighted common-sector MPV equality and the nonzero-weight statement for
+	derived common sectors.
 \end{proof}
 
 
@@ -3321,9 +3364,11 @@ The following results separate the zero blocks from the nonzero blocks.
 
 	The next mathematical assertion is the equality, after relabeling blocked
 	physical words, between the canonical blocked nonzero part and the cyclic-sector
-	tensor for the whole weighted family.  The conditional statement
-	Theorem~\ref{thm:zero_tail_common_flat_of_reindexed_label_compat} shows that this
-	equality rewrites the zero-tail identity directly with the weighted
+	tensor for the whole weighted family.  The conditional statements
+	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed} and
+	\ref{thm:samempv_pos_zero_tail_identity_transport} show that this equality
+	rewrites the zero-tail identities, the positive-length equality, the length-zero
+	identity, and the nonzero transported weights directly with the weighted
 	common-length cyclic sectors.  Once the common-length sectors have also been
 	blocked far enough to be injective, a BNT proportional-decomposition comparison
 	gives the block permutation, the bond-dimension equalities, and the gauge


### PR DESCRIPTION
Refs #971.

## Summary
- Renames the one-sided zero-tail common-sector theorem to `zeroTail_commonFlat_of_reindexed`, avoiding the earlier abbreviated name.
- Adds `sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂`, a small transport lemma: MPV-equivalent replacements preserve positive-length equality and the $N=0$ zero-tail identity.
- Adds `zeroTail_commonFlat_transport_of_reindexed`, which takes the #990-shaped MPV equality between the directly blocked weighted nonzero tensor and the reindexed common-sector tensor, and returns the zero-tail equation with `commonFlatBlocks`, the corresponding MPV equality, and nonvanishing transported weights.
- Updates Chapter 8 to document how these results convert the remaining blocked-word relabeling statement into the common-length cyclic-sector zero-tail form used downstream.

## Validation
- `lake -Kjobs=1 build --old TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` then `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake -Kjobs=1 build --old TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web` with TikZ SVG tools hidden locally, while keeping `kpsewhich` and Graphviz on `PATH`
- `git diff --check`
- Added-line scans for `sorry`, `admit`, `axiom`, `native_decide`, `unsafe`, and the requested prose terms

The remaining mathematical input is still the #990 equality under the chosen relabeling of blocked physical words.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to Lean theorem statements/proofs and blueprint documentation, with the main risk being broken downstream references due to the theorem rename.
> 
> **Overview**
> **Canonical-form after-blocking pipeline now exposes transportable zero-tail/common-sector facts.** The one-sided theorem for rewriting the blocked zero-tail equation is renamed to `zeroTail_commonFlat_of_reindexed` and referenced accordingly in the blueprint.
> 
> Adds two new Lean theorems: `sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂` (MPV-equivalent replacements preserve positive-length equality and the `N=0` zero-tail identity) and `zeroTail_commonFlat_transport_of_reindexed`, which bundles (1) the rewritten blocked zero-tail equation over `commonFlatBlocks`, (2) the corresponding `SameMPV₂` between the canonical blocked nonzero tensor and the common-sector tensor, and (3) nonvanishing of transported `commonFlatWeight` under nonzero original weights. Documentation in Chapter 8 is updated to describe these new transport steps and theorem names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce3ac07dcee5772d3216ee8b9d8a3e349fde147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->