### PR TITLE
feat(MPS/CanonicalForm): record common-length sector relabeling

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1224,6 +1224,16 @@ noncomputable def commonFlatBlocks (F : CommonBlockedCyclicSectorFamily blocks)
   show MPSTensor (blockPhysDim d F.p) (F.sectorDim y.1 y.2) from
     F.commonSectorBlock y.1 y.2
 
+/-- The same flattened common-sector family expressed at a prescribed common length.
+
+The equality hypothesis is usually supplied by the two-sided common-length theorem,
+which constructs both one-sided cyclic-sector families with the same blocking length. -/
+noncomputable def commonFlatBlocksAt (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p') (x : Fin (∑ k : Fin r, F.period k)) :
+    MPSTensor (blockPhysDim d p') (F.commonFlatDim x) :=
+  cast (congr_arg (fun q => MPSTensor (blockPhysDim d q) (F.commonFlatDim x)) hp)
+    (F.commonFlatBlocks x)
+
 /-- The common-alphabet sector tensor for one original nonzero-weight block. -/
 noncomputable def commonSectorTensor (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) : MPSTensor (blockPhysDim d F.p) (∑ s : Fin (F.period k), F.sectorDim k s) :=
@@ -1545,12 +1555,12 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq
 /-- If the canonical blocked nonzero part agrees with the explicitly reindexed
 blocks, then the weighted nonzero part agrees with the derived common-sector family.
 
-The hypothesis isolates the remaining equality after relabelling blocked physical
+The hypothesis isolates the remaining equality after relabeling blocked physical
 words by `iteratedBlockIndex`; the canonical blocked tensor uses the ambient blocked
 alphabet directly. -/
 theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
-    (hLabel : SameMPV₂
+    (hRelabel : SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := fun k : Fin r => (μ k) ^ F.p)
         (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
@@ -1563,8 +1573,28 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := F.commonFlatWeight μ) F.commonFlatBlocks) := by
   intro N σ
-  exact (hLabel N σ).trans
+  exact (hRelabel N σ).trans
     (F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ)
+
+/-- The preceding comparison expressed at a prescribed common length. -/
+theorem sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
+    {p' : ℕ} (hp : F.p = p')
+    (hRelabel : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d p')
+        (μ := fun k : Fin r => (μ k) ^ p')
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) p'))
+      (toTensorFromBlocks (d := blockPhysDim d p')
+        (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) := by
+  subst p'
+  simpa [commonFlatBlocksAt] using
+    F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μ hRelabel
 
 end CommonBlockedCyclicSectorFamily
 

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -938,6 +938,94 @@ theorem zeroTail_commonFlat_of_reindexed
             (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
           rw [hFlat N σ]
 
+/-- The same one-sided zero-tail rewriting, named by the blocked-word relabeling
+hypothesis it uses. -/
+theorem zeroTail_commonFlat_of_blockWordRelabeling
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hRelabel : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
+    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
+      mpv (blockTensor (d := d) (D := D) A F.p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
+  exact zeroTail_commonFlat_of_reindexed
+    (d := d) (D := D) (r := r) (z := z) (dim := dim)
+    A μ blocks F hMPV hRelabel
+
+/-- The preceding zero-tail rewriting expressed at a prescribed common length. -/
+theorem zeroTail_commonFlatAt_of_blockWordRelabeling
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p : ℕ} (hp : F.p = p)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hRelabel : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
+    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+      mpv (blockTensor (d := d) (D := D) A p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) σ := by
+  subst p
+  simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocksAt] using
+    zeroTail_commonFlat_of_blockWordRelabeling A μ blocks F hMPV hRelabel
+
+/-- At positive lengths, the blocked tensor has the same MPV coefficients as the
+weighted common-sector family once the blocked words have been reindexed. -/
+theorem sameMPV₂Pos_blockTensor_commonFlatAt_of_blockWordRelabeling
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p : ℕ} (hp : F.p = p)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hRelabel : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
+    SameMPV₂Pos
+      (blockTensor (d := d) (D := D) A p)
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) := by
+  intro N hN σ
+  have hZeroTail := zeroTail_commonFlatAt_of_blockWordRelabeling
+    (d := d) (D := D) (r := r) (z := z) (dim := dim)
+    A μ blocks F hp hMPV hRelabel
+  have hZero : mpv (zeroMPSTensor (blockPhysDim d p) z) σ = 0 := by
+    rw [mpv_zeroMPSTensor]
+    simp [Nat.ne_of_gt hN]
+  calc
+    mpv (blockTensor (d := d) (D := D) A p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) σ := hZeroTail N σ
+    _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) σ := by
+        rw [hZero]
+        simp
+
 /-- Replacing nonzero parts by MPV-equivalent tensors preserves the positive-length
 MPV equality and the length-zero zero-tail identity. -/
 theorem sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1218,6 +1218,218 @@ theorem afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
     hZAflat, hZBflat, hAPos, hBPos, hNonzeroPos, hZeroFlat,
     hμA, hμB, hTPA', hTPB', hPrimA', hPrimB', hIrrA', hIrrB', hDimA, hDimB⟩
 
+set_option maxHeartbeats 900000 in
+-- The nested existential conclusion records both sides and the conditional
+-- common-sector equalities.
+/-- **Common-length cyclic sectors after reindexing blocked words.**
+
+This theorem records the common-length data in the form used by the later
+sector comparison.  It first chooses one blocking length for both tensors and
+records the common cyclic-sector families.  If the canonical blocked nonzero
+families agree with the explicitly reindexed blocked-word families, then the
+nonzero parts are equal to the weighted common-sector families, and the zero-tail
+equations are rewritten with those common-sector families. -/
+theorem fundamentalTheorem_after_blocking_commonLength_commonSector_of_blockWordRelabeling
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ (p : ℕ), 0 < p ∧
+    ∃ (zeroTailA : ℕ) (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
+    ∃ (zeroTailB : ℕ) (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (k : Fin rB) → MPSTensor d (dimB k)),
+    ∃ (familyA : CommonBlockedCyclicSectorFamily blocksA),
+    ∃ (familyB : CommonBlockedCyclicSectorFamily blocksB),
+    ∃ (hFamilyA : familyA.p = p), ∃ (hFamilyB : familyB.p = p),
+      (∀ x, familyA.commonFlatWeight μA x ≠ 0) ∧
+      (∀ x, familyB.commonFlatWeight μB x ≠ 0) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d familyA.p),
+        (familyA.commonFlatBlocks x i)ᴴ * familyA.commonFlatBlocks x i = 1) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d familyB.p),
+        (familyB.commonFlatBlocks x i)ᴴ * familyB.commonFlatBlocks x i = 1) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d familyA.p) (D := familyA.commonFlatDim x)
+          (familyA.commonFlatBlocks x))) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d familyB.p) (D := familyB.commonFlatDim x)
+          (familyB.commonFlatBlocks x))) ∧
+      (∀ x, IsIrreducibleTensor (familyA.commonFlatBlocks x)) ∧
+      (∀ x, IsIrreducibleTensor (familyB.commonFlatBlocks x)) ∧
+      (∀ x, 0 < familyA.commonFlatDim x) ∧
+      (∀ x, 0 < familyB.commonFlatDim x) ∧
+      (SameMPV₂
+        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
+          (μ := fun k : Fin rA => (μA k) ^ familyA.p)
+          (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) familyA.p))
+        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
+          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.commonReindexedBlock) →
+      SameMPV₂
+        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
+          (μ := fun k : Fin rB => (μB k) ^ familyB.p)
+          (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) familyB.p))
+        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
+          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.commonReindexedBlock) →
+        SameMPV₂
+          (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := fun k : Fin rA => (μA k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p))
+          (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) ∧
+        SameMPV₂
+          (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := fun k : Fin rB => (μB k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p))
+          (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) ∧
+        (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+          mpv (blockTensor (d := d) (D := D₁) A p) σ =
+            mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+              mpv (toTensorFromBlocks (d := blockPhysDim d p)
+                (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ) ∧
+        (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+          mpv (blockTensor (d := d) (D := D₂) B p) σ =
+            mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+              mpv (toTensorFromBlocks (d := blockPhysDim d p)
+                (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ) ∧
+        SameMPV₂Pos
+          (blockTensor (d := d) (D := D₁) A p)
+          (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) ∧
+        SameMPV₂Pos
+          (blockTensor (d := d) (D := D₂) B p)
+          (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) ∧
+        SameMPV₂Pos
+          (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA))
+          (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) ∧
+        (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+          (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ =
+          (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ)) := by
+  obtain ⟨p, hp, zeroTailA, rA, dimA, μA, blocksA,
+      zeroTailB, rB, dimB, μB, blocksB, familyA, familyB,
+      hFamilyA, hFamilyB, hZA, hZB, hPos, hZero,
+      _hReindexA, _hReindexB, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB,
+      hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    fundamentalTheorem_after_blocking_commonLength_commonSector A B hSame
+  refine ⟨p, hp, zeroTailA, rA, dimA, μA, blocksA,
+    zeroTailB, rB, dimB, μB, blocksB, familyA, familyB, hFamilyA, hFamilyB,
+    hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB, ?_⟩
+  intro hRelabelA hRelabelB
+  have hFlatA := familyA.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling
+    μA hFamilyA hRelabelA
+  have hFlatB := familyB.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling
+    μB hFamilyB hRelabelB
+  have hZAflat : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+      mpv (blockTensor (d := d) (D := D₁) A p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (fun k => (μA k) ^ p)
+              (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ := hZA N σ
+      _ = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ := by
+          rw [hFlatA N σ]
+  have hZBflat : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+      mpv (blockTensor (d := d) (D := D₂) B p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (fun k => (μB k) ^ p)
+              (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ := hZB N σ
+      _ = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
+          rw [hFlatB N σ]
+  have hApos : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) := by
+    intro N hN σ
+    have hZeroTail : mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ :=
+            hZAflat N σ
+      _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ := by
+          rw [hZeroTail]
+          simp
+  have hBpos : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) := by
+    intro N hN σ
+    have hZeroTail : mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [Nat.ne_of_gt hN]
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p)
+              (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ :=
+            hZBflat N σ
+      _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
+          rw [hZeroTail]
+          simp
+  have hFlatPos : SameMPV₂Pos
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA))
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) := by
+    intro N hN σ
+    calc
+      mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ =
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k => (μA k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ :=
+            (hFlatA N σ).symm
+      _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k => (μB k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ :=
+            hPos N hN σ
+      _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ :=
+            hFlatB N σ
+  have hZeroFlat : ∀ σ : Fin 0 → Fin (blockPhysDim d p),
+      (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ =
+      (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
+    intro σ
+    calc
+      (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ =
+          (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k => (μA k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ := by
+            rw [(hFlatA 0 σ).symm]
+      _ = (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (fun k => (μB k) ^ p)
+            (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ := hZero σ
+      _ = (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
+            rw [hFlatB 0 σ]
+  exact ⟨hFlatA, hFlatB, hZAflat, hZBflat, hApos, hBpos, hFlatPos, hZeroFlat⟩
+
 /-- **Conditional after-blocking sector comparison (issue #877 target shape).**
 
 Given two tensors with `SameMPV₂`, a common-period BNT sector pair, and a

--- a/audits/2026-04-30_issue969_common_length_conditional_sectors.md
+++ b/audits/2026-04-30_issue969_common_length_conditional_sectors.md
@@ -1,0 +1,79 @@
+# 2026-04-30 — Common-length cyclic sectors with conditional exact nonzero parts (#969/#942)
+
+## Scope
+
+This note records the additional common-length statement added for issues #969 and
+#942 on the non-Gemma canonical-form route.  The Lean declarations keep the
+blocked-word relabeling hypothesis explicit, so they do not overlap with #990,
+which is the remaining theorem identifying the directly blocked nonzero family
+with the family obtained from iterated blocking.
+
+The new result strengthens the existing two-sided common-length theorem as a
+conditional exact statement: once the two blocked-word relabeling equalities are
+available, the canonical blocked nonzero parts are replaced by the weighted
+common cyclic-sector families on both sides, including the zero-tail equations,
+positive-length MPV equalities, and the length-zero identity.
+
+## Source anchors
+
+- `Papers/1606.00608/MPDO-22-12-17-2.tex:214--231` is the structural reduction
+  used here: the tensor is written as a nilpotent contribution plus a finite
+  nonzero block family, and the periods of the nonzero blocks are removed by
+  blocking a common multiple.
+- `Papers/2011.12127/TN-Review-main.tex:1798--1820` gives the same trace-preserving
+  irreducible block form and explains that blocking the period of an irreducible
+  block makes the transfer map primitive.
+- `Papers/2011.12127/TN-Review-main.tex:1841--1884` is the later BNT comparison
+  stage.  It consumes common normal blocks and compares their coefficients after
+  phase and gauge matching; the present theorem supplies the common-length cyclic
+  sectors in the exact MPV form needed before that comparison.
+
+## Lean declarations
+
+### `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`
+
+- `MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocksAt` expresses the
+  derived flattened common-sector family at a prescribed length `p'` when
+  `F.p = p'`.
+- `MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling`
+  is the prescribed-length form of the canonical-to-common-sector comparison.
+  Its hypothesis is the `SameMPV₂` equality between the directly blocked
+  nonzero family and the explicitly reindexed family.  This is exactly the
+  hypothesis expected from #990.
+
+### `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
+
+- `MPSTensor.zeroTail_commonFlat_of_blockWordRelabeling` is the renamed one-sided
+  zero-tail conversion; it avoids the earlier informal wording about labels.
+- `MPSTensor.zeroTail_commonFlatAt_of_blockWordRelabeling` gives the same
+  zero-tail conversion at a prescribed common length.
+- `MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_blockWordRelabeling` records
+  that the zero-tail term vanishes at positive system sizes, so the blocked tensor
+  and the weighted common-sector family have equal MPV coefficients there.
+- `MPSTensor.fundamentalTheorem_after_blocking_1606_commonLength_commonSector_of_blockWordRelabeling`
+  starts from `SameMPV₂ A B`, chooses one positive blocking length for both sides,
+  obtains common cyclic-sector families on both sides, and then conditionally
+  rewrites all nonzero-part and zero-tail conclusions with the weighted
+  common-sector families.
+
+## Relation to neighboring issues
+
+- #990 should supply the two blocked-word relabeling equalities assumed by the
+  new two-sided theorem.  This branch keeps those assumptions visible rather
+  than hiding them behind a new name.
+- #942 can use the conclusion as the exact common primitive irreducible block
+  data at one physical blocking length, after the #990 equalities are supplied.
+- #970 and #944 still need the later common phase-cover or BNT proportional
+  comparison data, as well as any additional injectivity blocking required for
+  the overlap-span theorem.
+
+## Remaining mathematical statements
+
+1. Prove the blocked-word relabeling equality for a `CommonBlockedCyclicSectorFamily`
+   on each side, reducing the direct blocked family to the explicitly reindexed
+   family.  This is issue #990.
+2. If one-site injectivity is required by the final overlap theorem, add the
+   separate Wielandt/injectivity blocking stage without identifying it with the
+   period-removal length.
+3. Derive the common phase-cover or BNT proportional-decomposition hypotheses
+   from the exact common-length nonzero-sector data.

--- a/audits/2026-04-30_issue969_common_length_conditional_sectors.md
+++ b/audits/2026-04-30_issue969_common_length_conditional_sectors.md
@@ -50,7 +50,7 @@ positive-length MPV equalities, and the length-zero identity.
 - `MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_blockWordRelabeling` records
   that the zero-tail term vanishes at positive system sizes, so the blocked tensor
   and the weighted common-sector family have equal MPV coefficients there.
-- `MPSTensor.fundamentalTheorem_after_blocking_1606_commonLength_commonSector_of_blockWordRelabeling`
+- `MPSTensor.fundamentalTheorem_after_blocking_commonLength_commonSector_of_blockWordRelabeling`
   starts from `SameMPV₂ A B`, chooses one positive blocking length for both sides,
   obtains common cyclic-sector families on both sides, and then conditionally
   rewrites all nonzero-part and zero-tail conclusions with the weighted

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1791,15 +1791,17 @@ The following results separate the zero blocks from the nonzero blocks.
 \end{proof}
 
 \begin{theorem}[Canonical blocked nonzero part under blocked-word relabeling]%
-\label{thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero}
-	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed}
+\label{thm:common_blocked_cyclic_sector_block_word_relabeling}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling}
 	\leanok
 	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
 		def:common_blocked_cyclic_sector_derived_blocks}
 	Assume that the canonical blocked nonzero part agrees, as an MPV family, with
 	the relabeled cyclic-sector tensor coming from iterated blocking.  Then the
-	canonical weighted nonzero part agrees
-	with the weighted derived common-sector tensor.
+	canonical weighted nonzero part agrees with the weighted derived common-sector
+	tensor.  The prescribed-length form gives the same conclusion after substituting
+	an equality between the family length and the chosen common length.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3319,26 +3321,34 @@ The following results separate the zero blocks from the nonzero blocks.
 \end{proof}
 
 \begin{theorem}[Zero-tail equation after resolving the blocked-word relabeling]%
-\label{thm:zero_tail_common_flat_of_reindexed}
-	\lean{MPSTensor.zeroTail_commonFlat_of_reindexed}
+\label{thm:zero_tail_common_flat_of_block_word_relabeling}
+	\lean{MPSTensor.zeroTail_commonFlat_of_reindexed,
+		MPSTensor.zeroTail_commonFlat_of_blockWordRelabeling,
+		MPSTensor.zeroTail_commonFlatAt_of_blockWordRelabeling,
+		MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_blockWordRelabeling}
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero}
+		thm:common_blocked_cyclic_sector_block_word_relabeling}
 	For one side, suppose first that the original tensor decomposes, as an MPV
 	family, into a zero-tail contribution plus a weighted block-sum nonzero part at
 	the original physical alphabet.  Suppose also that, after blocking by the
 	common length, the canonical blocked nonzero tensor agrees with the explicitly
-	reindexed nonzero tensor as an MPV family.  Then the zero-tail equation
-	after blocking may be written directly with the weighted derived common-sector
-	family.
+	reindexed nonzero tensor as an MPV family.  Then the zero-tail equation after
+	blocking may be written directly with the weighted derived common-sector
+	family, either at the family length or at an equal prescribed length.  At
+	positive system sizes the zero-tail term vanishes, so the blocked tensor and
+	the weighted common-sector tensor have the same MPV coefficients.
 \end{theorem}
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero}
+		thm:common_blocked_cyclic_sector_block_word_relabeling}
 	First transport the original zero-tail/nonzero decomposition through the common
 	blocking length.  Then replace the canonical blocked nonzero tensor by the
-	derived common-sector tensor using the blocked-word relabeling agreement.
+	derived common-sector tensor using the blocked-word relabeling agreement.  The
+	prescribed-length form follows by substituting the equality of blocking lengths,
+	and the positive-length statement follows because the zero-tail tensor has zero
+	MPV coefficients at all nonzero lengths.
 \end{proof}
 
 \begin{theorem}[Common primitive irreducible block decompositions after reindexing]%
@@ -3346,7 +3356,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	\lean{MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts}
 	\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero,
+		thm:common_blocked_cyclic_sector_block_word_relabeling,
 		def:same_mpv2_pos}
 	Assume the one-sided theorem identifying the canonically blocked weighted
 	nonzero part with the same family written through the reindexing of blocked
@@ -3361,7 +3371,7 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{proof}\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero}
+		thm:common_blocked_cyclic_sector_block_word_relabeling}
 	Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}
 	to choose the common blocking length and the two common cyclic-sector families.
 	The assumed blocked-word reindexing equality converts the canonically blocked
@@ -3393,8 +3403,8 @@ The following results separate the zero blocks from the nonzero blocks.
 \label{thm:zero_tail_common_flat_transport_of_reindexed}
 	\lean{MPSTensor.zeroTail_commonFlat_transport_of_reindexed}
 	\leanok
-	\uses{thm:zero_tail_common_flat_of_reindexed,
-		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero,
+	\uses{thm:zero_tail_common_flat_of_block_word_relabeling,
+		thm:common_blocked_cyclic_sector_block_word_relabeling,
 		thm:common_blocked_cyclic_sector_derived_properties}
 	Assume that the original tensor decomposes, as an MPV family, into a
 	zero-tail contribution plus a weighted nonzero block tensor, that all original
@@ -3407,14 +3417,40 @@ The following results separate the zero blocks from the nonzero blocks.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:zero_tail_common_flat_of_reindexed,
-		thm:common_blocked_cyclic_sector_canonical_reindexed_nonzero,
+	\uses{thm:zero_tail_common_flat_of_block_word_relabeling,
+		thm:common_blocked_cyclic_sector_block_word_relabeling,
 		thm:common_blocked_cyclic_sector_derived_properties}
-	Combine Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} with
+	Combine Theorem~\ref{thm:zero_tail_common_flat_of_block_word_relabeling} with
 	the weighted common-sector MPV equality and the nonzero-weight statement for
 	derived common sectors.
 \end{proof}
 
+\begin{theorem}[Two-sided common-length sectors after blocked-word relabeling]%
+\label{thm:ft_after_blocking_common_length_common_sector_block_word_relabeling}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_commonLength_commonSector_of_blockWordRelabeling}
+	\leanok
+	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
+		thm:common_blocked_cyclic_sector_block_word_relabeling}
+	If two tensors generate the same MPV family, then the common-length theorem can
+	be strengthened conditionally as follows.  The theorem chooses one positive
+	blocking length for both sides and gives common cyclic-sector families at that
+	length.  If, on each side, the canonically blocked nonzero family agrees with
+	the explicitly relabeled family coming from iterated blocking, then the
+	canonically blocked nonzero family agrees with the weighted common-sector
+	family.  The zero-tail equations, positive-length MPV equalities, and the
+	length-zero identity are then all rewritten with those common-sector families.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
+		thm:common_blocked_cyclic_sector_block_word_relabeling}
+	Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}.
+	The two assumed blocked-word relabeling equalities compose with
+	Theorem~\ref{thm:common_blocked_cyclic_sector_block_word_relabeling} to identify
+	the canonical nonzero parts with the weighted common-sector tensors.  Substituting
+	these two MPV equalities into the zero-tail equations gives the rewritten
+	zero-tail identities, the positive-length MPV equalities, and the $N=0$ identity.
+\end{proof}
 
 \section{Open directions}\label{sec:open_directions}
 
@@ -3452,29 +3488,38 @@ The following results separate the zero blocks from the nonzero blocks.
 	words.
 
 	The results above now separate the finite-sum comparison from the remaining
-	blocked-word assertion.  Theorem~\ref{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	blocked-word assertion.  Theorem~
+ef{thm:common_blocked_cyclic_sector_blocked_word_comparison}
 	shows that, once the length-$p$ word read directly from the common blocked
 	alphabet equals the word obtained by flattening an iterated $(m_k,e_k)$ block,
 	the weighted direct sum of directly blocked nonzero blocks agrees with the
-	derived common-sector family.  Theorem~\ref{thm:zero_tail_common_flat_of_blocked_word_comparison}
+	derived common-sector family.  Theorem~
+ef{thm:zero_tail_common_flat_of_blocked_word_comparison}
 	then rewrites the one-sided zero-tail identity with the weighted common-length
 	cyclic sectors under this blockwise word equality.
 
 	The next mathematical assertion is the corresponding equality, after relabeling
 	blocked physical words, between the canonical blocked nonzero part and the
-	cyclic-sector tensor for the whole weighted family.  Under this comparison,
-	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed},
-	\ref{thm:samempv_pos_zero_tail_identity_transport}, and
-	\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-	rewrite the zero-tail identities, the positive-length equality, the length-zero
-	identity, and the nonzero transported weights directly with the weighted
-	common-length cyclic sectors, while also collecting the two-sided primitive
-	irreducible sector decompositions needed for comparison.  The remaining
-	blocked-word assertion is the equality of these words for the chosen coordinates,
-	or an equivalent final comparison with the relabeling made explicit.  Once the
-	common-length sectors have also been blocked far enough to be injective, a BNT
-	proportional-decomposition comparison gives the block permutation, the
-	bond-dimension equalities, and the gauge phases.
+	cyclic-sector tensor for the whole weighted family.  Theorem~
+ef{thm:zero_tail_common_flat_of_block_word_relabeling}
+	gives the one-sided form of this conversion, and
+	Theorem~
+ef{thm:ft_after_blocking_common_length_common_sector_block_word_relabeling}
+	records it simultaneously for the two common-length sector families.  Under this
+	comparison, Theorems~
+ef{thm:zero_tail_common_flat_transport_of_reindexed} and
+	
+ef{thm:samempv_pos_zero_tail_identity_transport} rewrite the zero-tail
+	identities, the positive-length equality, the length-zero identity, and the
+	nonzero transported weights directly with the weighted common-length cyclic
+	sectors.  Theorem~
+ef{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+	collects the resulting primitive irreducible sector decompositions needed for
+	comparison.  The remaining blocked-word assertion is the equality of these words
+	for the chosen coordinates, or an equivalent final comparison with the relabeling
+	made explicit.  Once the common-length sectors have also been blocked far enough
+	to be injective, a BNT proportional-decomposition comparison gives the block
+	permutation, the bond-dimension equalities, and the gauge phases.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	then turns that comparison into the finite-length MPV span equality and the
 	sector-weight conclusion.  Thus the open canonical-form assertions are the

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1684,6 +1684,7 @@ The following results separate the zero blocks from the nonzero blocks.
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocksAt,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorTensor,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonReindexedBlock,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight}
@@ -1692,9 +1693,11 @@ The following results separate the zero blocks from the nonzero blocks.
 		def:tensor_from_blocks, thm:iterated_blocking_samempv_reindex}
 	From a common reblocked cyclic-sector family, one may derive sector tensors at
 	the common alphabet directly from the original per-block sector tensors.  The
-	reindexed block data keep the reindexing of blocked physical words explicit: for
-	the block $B_k$, it uses $B_k^{[m_k e_k]}$ with the labels obtained by flattening
-	an iterated $(m_k,e_k)$ block.
+	same flattened common-sector family is also provided at a prescribed length
+	$p'$ assuming the family length equals $p'$.  The reindexed block data
+	keep the reindexing of blocked physical words explicit: for the block $B_k$, it
+	uses $B_k^{[m_k e_k]}$ with the labels obtained by flattening an iterated
+	$(m_k,e_k)$ block.
 \end{definition}
 
 \begin{theorem}[Derived common-alphabet cyclic sectors retain structural properties]%

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3491,38 +3491,33 @@ The following results separate the zero blocks from the nonzero blocks.
 	words.
 
 	The results above now separate the finite-sum comparison from the remaining
-	blocked-word assertion.  Theorem~
-ef{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	blocked-word assertion.  Theorem~\ref{thm:common_blocked_cyclic_sector_blocked_word_comparison}
 	shows that, once the length-$p$ word read directly from the common blocked
 	alphabet equals the word obtained by flattening an iterated $(m_k,e_k)$ block,
 	the weighted direct sum of directly blocked nonzero blocks agrees with the
-	derived common-sector family.  Theorem~
-ef{thm:zero_tail_common_flat_of_blocked_word_comparison}
+	derived common-sector family.  Theorem~\ref{thm:zero_tail_common_flat_of_blocked_word_comparison}
 	then rewrites the one-sided zero-tail identity with the weighted common-length
 	cyclic sectors under this blockwise word equality.
 
 	The next mathematical assertion is the corresponding equality, after relabeling
 	blocked physical words, between the canonical blocked nonzero part and the
-	cyclic-sector tensor for the whole weighted family.  Theorem~
-ef{thm:zero_tail_common_flat_of_block_word_relabeling}
-	gives the one-sided form of this conversion, and
-	Theorem~
-ef{thm:ft_after_blocking_common_length_common_sector_block_word_relabeling}
-	records it simultaneously for the two common-length sector families.  Under this
-	comparison, Theorems~
-ef{thm:zero_tail_common_flat_transport_of_reindexed} and
-	
-ef{thm:samempv_pos_zero_tail_identity_transport} rewrite the zero-tail
-	identities, the positive-length equality, the length-zero identity, and the
-	nonzero transported weights directly with the weighted common-length cyclic
-	sectors.  Theorem~
-ef{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+	cyclic-sector tensor for the whole weighted family.
+	Theorem~\ref{thm:zero_tail_common_flat_of_block_word_relabeling} gives the
+	one-sided form of this conversion, and
+	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_block_word_relabeling}
+	records it simultaneously for the two common-length sector families.  The
+	auxiliary transport statements
+	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed} and
+	\ref{thm:samempv_pos_zero_tail_identity_transport} record the nonzero
+	transported weights and the preservation of the positive-length and length-zero
+	identities, while
+	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	collects the resulting primitive irreducible sector decompositions needed for
-	comparison.  The remaining blocked-word assertion is the equality of these words
-	for the chosen coordinates, or an equivalent final comparison with the relabeling
-	made explicit.  Once the common-length sectors have also been blocked far enough
-	to be injective, a BNT proportional-decomposition comparison gives the block
-	permutation, the bond-dimension equalities, and the gauge phases.
+	comparison.  The remaining blocked-word assertion is the equality of these
+	words for the chosen coordinates, or an equivalent final comparison with the
+	relabeling made explicit.  Once the common-length sectors have also been
+	blocked far enough to be injective, a BNT proportional-decomposition comparison
+	gives the block permutation, the bond-dimension equalities, and the gauge phases.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
 	then turns that comparison into the finite-length MPV span equality and the
 	sector-weight conclusion.  Thus the open canonical-form assertions are the


### PR DESCRIPTION
## Summary

- add a prescribed-length view of `CommonBlockedCyclicSectorFamily.commonFlatBlocks`
- prove conditional `SameMPV₂` and zero-tail statements that rewrite the common-length nonzero parts with the weighted common cyclic-sector families
- add a two-sided theorem from `SameMPV₂ A B` that records the common blocking length, structural sector properties, and the exact common-sector conclusions under the two blocked-word relabeling equalities expected from #990
- update Chapter 8 and add an audit note documenting the remaining #990/#970/#944 inputs

Partially addresses #969. Partially addresses #942. Refs #990.

## Validation

- `lake build --old TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition`
- `lake build --old TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- `lake build --old TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- added-line scan for proof-integrity tokens and banned relabeling prose

The full `TNLean` build replayed existing unrelated `sorry` warnings in parent-Hamiltonian, PEPS, and periodic-overlap files, plus existing long-line warnings outside the new declarations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Lean definitions/theorems that rewrite canonical blocked nonzero parts into common-sector families under an explicit relabeling hypothesis; the changes are proof-heavy and touch core canonical-form assembly statements, so regressions would surface as downstream proof breakages.
> 
> **Overview**
> Extends `CommonBlockedCyclicSectorFamily` with `commonFlatBlocksAt`, letting the flattened common-sector family be used at an externally chosen blocking length `p'` via a proof `F.p = p'`, and adds the corresponding prescribed-length `SameMPV₂` comparison theorem.
> 
> In `StructuralTheorem.lean`, introduces named/parameterized variants of the one-sided zero-tail rewrite under a blocked-word *relabeling* hypothesis (including a prescribed-length form and a `SameMPV₂Pos` corollary for positive lengths), and adds a new two-sided theorem that, starting from `SameMPV₂ A B`, records a single positive common blocking length and conditionally rewrites both sides’ nonzero parts/zero-tail identities with the weighted common-sector families once the two relabeling equalities are provided.
> 
> Updates Chapter 8 blueprint references/wording to match the new names and prescribed-length results, and adds an audit note documenting the new conditional common-length statement and remaining dependencies (#990/#970/#944).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c41559edabe732d2968b2dd6bad3fc3ef4d9549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

