### PR TITLE
refactor(MPS/Core): promote physical-dimension cast helper

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1429,12 +1429,6 @@ theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ := by
           exact (mpv_toTensorFromBlocks_eq_sum (F.commonFlatWeight μ) (F.commonFlatBlocks) σ).symm
 
-private theorem cast_physDim_apply {d₁ d₂ D : ℕ} (h : d₁ = d₂)
-    (A : MPSTensor d₁ D) (i : Fin d₂) :
-    cast (congr_arg (fun d' => MPSTensor d' D) h) A i = A (Fin.cast h.symm i) := by
-  subst h
-  rfl
-
 /-- If the two decodings of each blocked physical word agree, then directly blocking
 one original block gives the corresponding block obtained through iterated blocking.
 
@@ -1465,8 +1459,7 @@ theorem blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq
       (blockTensor (d := d) (D := dim k) (blocks k) F.p)
       (F.commonReindexedBlock k) := by
   rw [F.blockTensor_eq_commonReindexedBlock_of_word_eq k hWord]
-  intro N σ
-  rfl
+  exact fun _ _ => rfl
 
 /-- Blockwise MPV comparisons assemble over the weighted direct sum after common blocking. -/
 theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -377,6 +377,13 @@ theorem toTensorFromBlocks_cast_physDim {d₁ d₂ r : ℕ} {dim : Fin r → ℕ
   subst h
   rfl
 
+/-- Evaluating a physical-dimension cast amounts to casting the physical index. -/
+theorem cast_physDim_apply {d₁ d₂ D : ℕ} (h : d₁ = d₂)
+    (A : MPSTensor d₁ D) (i : Fin d₂) :
+    cast (congr_arg (fun d' => MPSTensor d' D) h) A i = A (Fin.cast h.symm i) := by
+  subst h
+  rfl
+
 /-- Casting the physical dimension preserves trace-preserving normalization. -/
 theorem leftCanonical_cast_physDim {d₁ d₂ D : ℕ} (h : d₁ = d₂)
     (A : MPSTensor d₁ D) :


### PR DESCRIPTION
## Summary

- promote `cast_physDim_apply` from the cyclic-sector assembly file to `TNLean.MPS.Core.BlockingInfrastructure`
- replace the private local helper by the shared core lemma
- tighten the reflexive `SameMPV₂` proof in the blocked-word comparison wrapper

Closes #1074.
Refs #990.

## Validation

- `lean_diagnostics` clean for `TNLean/MPS/Core/BlockingInfrastructure.lean`
- `lean_diagnostics` clean for `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`
- `git diff --check`
- added-line hygiene scan for `sorry`, debug commands, and long added lines
- scan confirmed no remaining private `cast_physDim_apply` helper under `TNLean/MPS`
- `lake build --old TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition`
  - build succeeded; it replayed pre-existing long-line warnings in `PeripheralUnitary`, `BNT.Construction`, and two existing long theorem-name lines in `CyclicSectorDecomposition`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that relocates a helper lemma and slightly simplifies a `SameMPV₂` wrapper proof, without changing any computational behavior.
> 
> **Overview**
> Promotes the physical-dimension cast evaluation lemma `cast_physDim_apply` from a private helper in `CyclicSectorDecomposition.lean` into `MPS/Core/BlockingInfrastructure.lean` so it can be reused across the codebase.
> 
> Updates the cyclic-sector assembly proof to use the shared core lemma and tightens one `SameMPV₂` wrapper by replacing a trivial `intro`/`rfl` block with `fun _ _ => rfl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8aca464941648eaefaec765b85f337bb89cd361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->