### PR TITLE
feat(MPS/Core): isolate blocked-word grouping coordinates

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1429,7 +1429,7 @@ theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ := by
           exact (mpv_toTensorFromBlocks_eq_sum (F.commonFlatWeight μ) (F.commonFlatBlocks) σ).symm
 
-/-- The numeric cast from the common blocked alphabet to one iterated blocked alphabet
+/-- The canonical identification from the common blocked alphabet to one iterated blocked alphabet
 agrees with the map obtained by grouping a direct blocked word into consecutive blocks. -/
 def groupedBlockCastAgrees (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) : Prop :=
   ∀ i : Fin (blockPhysDim d F.p),
@@ -1437,9 +1437,9 @@ def groupedBlockCastAgrees (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin
       directToIteratedBlockIndex d (F.period k) (F.extra k)
         (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i)
 
-/-- The blocked-word comparison follows if the numeric cast from the common alphabet to
-an iterated alphabet agrees with the grouping map that reads a direct word in consecutive
-blocks of length $m_k$ (the period of block $k$). -/
+/-- The blocked-word comparison follows if the canonical identification from the common
+alphabet to an iterated alphabet agrees with the grouping map that reads a direct word in
+consecutive blocks of length $m_k$ (the period of block $k$). -/
 theorem wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hCast : F.groupedBlockCastAgrees k) :
@@ -1484,7 +1484,8 @@ theorem blockTensor_eq_commonReindexedBlock_of_word_eq
   simp [reindexPhysical, blockTensor, hWord i]
 
 /-- Direct blocking of one original block is the relabeled common block when the
-numeric cast to the iterated alphabet agrees with consecutive grouping of the direct word. -/
+canonical identification with the iterated alphabet agrees with consecutive grouping of the
+direct word. -/
 theorem blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hCast : F.groupedBlockCastAgrees k) :
@@ -1508,7 +1509,7 @@ theorem blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq
   exact fun _ _ => rfl
 
 /-- Direct and iterated common blocking of one original block have the same MPV family
-when the numeric cast to the iterated alphabet agrees with consecutive grouping. -/
+when the canonical identification with the iterated alphabet agrees with consecutive grouping. -/
 theorem blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hCast : F.groupedBlockCastAgrees k) :
@@ -1567,8 +1568,9 @@ theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq
   F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise μ
     (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
 
-/-- Agreement between the numeric casts and the consecutive grouping maps assembles the
-weighted direct sum obtained by direct blocking with the one obtained through iterated blocking. -/
+/-- Agreement between the canonical identifications and the consecutive grouping maps assembles
+the weighted direct sum obtained by direct blocking with the one obtained through iterated
+blocking. -/
 theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
@@ -1617,8 +1619,8 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq
   F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise μ
     (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
 
-/-- Agreement between the numeric casts and the consecutive grouping maps identifies the
-directly blocked weighted nonzero part with the derived common-sector family. -/
+/-- Agreement between the canonical identifications and the consecutive grouping maps identifies
+the directly blocked weighted nonzero part with the derived common-sector family. -/
 theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1429,6 +1429,43 @@ theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ := by
           exact (mpv_toTensorFromBlocks_eq_sum (F.commonFlatWeight μ) (F.commonFlatBlocks) σ).symm
 
+/-- The numeric cast from the common blocked alphabet to one iterated blocked alphabet
+agrees with the map obtained by grouping a direct blocked word into consecutive blocks. -/
+def groupedBlockCastAgrees (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) : Prop :=
+  ∀ i : Fin (blockPhysDim d F.p),
+    Fin.cast ((F.blockPhysDim_nested_eq k).symm) i =
+      directToIteratedBlockIndex d (F.period k) (F.extra k)
+        (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i)
+
+/-- The blocked-word comparison follows if the numeric cast from the common alphabet to
+an iterated alphabet agrees with the grouping map that reads a direct word in consecutive
+blocks of length $m_k$ (the period of block $k$). -/
+theorem wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
+    (hCast : F.groupedBlockCastAgrees k) :
+    ∀ i : Fin (blockPhysDim d F.p),
+      wordOfBlock d F.p i =
+        wordOfBlock d (F.period k * F.extra k)
+          (iteratedBlockIndex d (F.period k) (F.extra k)
+            (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i)) := by
+  intro i
+  calc
+    wordOfBlock d F.p i =
+        wordOfBlock d (F.period k * F.extra k)
+          (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i) :=
+      (wordOfBlock_cast_length d (F.p_eq_period_mul_extra k) i).symm
+    _ = wordOfBlock d (F.period k * F.extra k)
+        (iteratedBlockIndex d (F.period k) (F.extra k)
+          (directToIteratedBlockIndex d (F.period k) (F.extra k)
+            (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i))) :=
+      (wordOfBlock_iteratedBlockIndex_directToIteratedBlockIndex
+        d (F.period k) (F.extra k)
+        (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i)).symm
+    _ = wordOfBlock d (F.period k * F.extra k)
+        (iteratedBlockIndex d (F.period k) (F.extra k)
+          (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i)) := by
+          rw [← hCast i]
+
 /-- If the two decodings of each blocked physical word agree, then directly blocking
 one original block gives the corresponding block obtained through iterated blocking.
 
@@ -1446,6 +1483,15 @@ theorem blockTensor_eq_commonReindexedBlock_of_word_eq
   rw [commonReindexedBlock, cast_physDim_apply (F.blockPhysDim_nested_eq k)]
   simp [reindexPhysical, blockTensor, hWord i]
 
+/-- Direct blocking of one original block is the relabeled common block when the
+numeric cast to the iterated alphabet agrees with consecutive grouping of the direct word. -/
+theorem blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
+    (hCast : F.groupedBlockCastAgrees k) :
+    blockTensor (d := d) (D := dim k) (blocks k) F.p = F.commonReindexedBlock k :=
+  F.blockTensor_eq_commonReindexedBlock_of_word_eq k
+    (F.wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees k hCast)
+
 /-- Direct blocking of one original block has the same MPV family as the block obtained
 through iterated blocking, whenever the associated blocked-word decodings agree. -/
 theorem blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq
@@ -1460,6 +1506,18 @@ theorem blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq
       (F.commonReindexedBlock k) := by
   rw [F.blockTensor_eq_commonReindexedBlock_of_word_eq k hWord]
   exact fun _ _ => rfl
+
+/-- Direct and iterated common blocking of one original block have the same MPV family
+when the numeric cast to the iterated alphabet agrees with consecutive grouping. -/
+theorem blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
+    (hCast : F.groupedBlockCastAgrees k) :
+    SameMPV₂
+      (blockTensor (d := d) (D := dim k) (blocks k) F.p)
+      (F.commonReindexedBlock k) := by
+  rw [F.blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees k hCast]
+  intro N σ
+  rfl
 
 /-- Blockwise MPV comparisons assemble over the weighted direct sum after common blocking. -/
 theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise
@@ -1509,6 +1567,20 @@ theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq
   F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise μ
     (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
 
+/-- Agreement between the numeric casts and the consecutive grouping maps assembles the
+weighted direct sum obtained by direct blocking with the one obtained through iterated blocking. -/
+theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
+    (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock) :=
+  F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise μ
+    (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k (hCast k))
+
 /-- If every original block has the same MPV family after direct blocking as after
 iterated blocking, then the weighted nonzero part agrees with the derived common-sector family. -/
 theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise
@@ -1544,6 +1616,20 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq
         (μ := F.commonFlatWeight μ) F.commonFlatBlocks) :=
   F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise μ
     (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
+
+/-- Agreement between the numeric casts and the consecutive grouping maps identifies the
+directly blocked weighted nonzero part with the derived common-sector family. -/
+theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_groupedBlockCastAgrees
+    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
+    (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) F.commonFlatBlocks) :=
+  F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise μ
+    (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k (hCast k))
 
 /-- If the canonical blocked nonzero part agrees with the explicitly reindexed
 blocks, then the weighted nonzero part agrees with the derived common-sector family.

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -919,6 +919,25 @@ theorem zeroTail_commonFlat_of_word_eq
   exact zeroTail_commonFlat_of_blockwise A μ blocks F hMPV
     (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
 
+/-- If the numeric casts agree with consecutive grouping for every nonzero block, the
+zero-tail equation can be written using the derived common-sector family. -/
+theorem zeroTail_commonFlat_of_groupedBlockCastAgrees
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
+    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
+      mpv (blockTensor (d := d) (D := D) A F.p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
+  exact zeroTail_commonFlat_of_blockwise A μ blocks F hMPV
+    (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k (hCast k))
+
 /-- If the canonical blocked nonzero part agrees with the common reindexed blocks,
 the zero-tail equation can be rewritten using the derived common-sector family.
 This is the one-sided theorem that puts the reindexed data above in the form used

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -919,8 +919,8 @@ theorem zeroTail_commonFlat_of_word_eq
   exact zeroTail_commonFlat_of_blockwise A μ blocks F hMPV
     (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
 
-/-- If the numeric casts agree with consecutive grouping for every nonzero block, the
-zero-tail equation can be written using the derived common-sector family. -/
+/-- If the canonical identifications agree with consecutive grouping for every nonzero block,
+the zero-tail equation can be written using the derived common-sector family. -/
 theorem zeroTail_commonFlat_of_groupedBlockCastAgrees
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -320,6 +320,76 @@ theorem wordOfBlock_iteratedBlockIndex (d m n : ℕ)
   exact wordOfBlock_blockIndexOfList d (m * n)
     (flattenBlockedWord d m (wordOfBlock (blockPhysDim d m) n i)) _
 
+/-- The position of the `t`-th letter in the `j`-th block of a word split into
+`n` consecutive blocks of length `m`. -/
+private theorem blockWordChunkIndex_lt (m n : ℕ) (j : Fin n) (t : Fin m) :
+    m * (j : ℕ) + (t : ℕ) < m * n := by
+  calc
+    m * (j : ℕ) + (t : ℕ) < m * (j : ℕ) + m :=
+      Nat.add_lt_add_left t.is_lt _
+    _ = m * ((j : ℕ) + 1) := by rw [Nat.mul_add, Nat.mul_one]
+    _ ≤ m * n := Nat.mul_le_mul_left m (Nat.succ_le_of_lt j.is_lt)
+
+/-- The `j`-th length-`m` subword of a direct length-`m * n` blocked word. -/
+noncomputable def blockWordChunk (d m n : ℕ) (i : Fin (blockPhysDim d (m * n)))
+    (j : Fin n) : List (Fin d) :=
+  List.ofFn fun t : Fin m =>
+    decodeBlock d (m * n) i ⟨m * (j : ℕ) + (t : ℕ), blockWordChunkIndex_lt m n j t⟩
+
+@[simp] theorem length_blockWordChunk (d m n : ℕ) (i : Fin (blockPhysDim d (m * n)))
+    (j : Fin n) : (blockWordChunk d m n i j).length = m := by
+  simp [blockWordChunk]
+
+/-- Encode a direct length-`m * n` blocked index as an iterated blocked index by grouping
+its decoded word into `n` consecutive blocks of length `m`. -/
+noncomputable def directToIteratedBlockIndex (d m n : ℕ)
+    (i : Fin (blockPhysDim d (m * n))) :
+    Fin (blockPhysDim (blockPhysDim d m) n) :=
+  blockIndexOfList (blockPhysDim d m) n
+    (List.ofFn fun j : Fin n =>
+      blockIndexOfList d m (blockWordChunk d m n i j) (length_blockWordChunk d m n i j))
+    (by simp)
+
+/-- Encoding the decoded word of a block gives back the original blocked index. -/
+theorem blockIndexOfList_wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) :
+    blockIndexOfList d L (wordOfBlock d L i) (length_wordOfBlock d L i) = i := by
+  classical
+  unfold blockIndexOfList wordOfBlock decodeBlock
+  simp [blockPhysDim]
+
+/-- Flattening the grouped iterated index recovers the direct blocked word. -/
+theorem flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex (d m n : ℕ)
+    (i : Fin (blockPhysDim d (m * n))) :
+    flattenBlockedWord d m
+        (wordOfBlock (blockPhysDim d m) n (directToIteratedBlockIndex d m n i)) =
+      wordOfBlock d (m * n) i := by
+  classical
+  unfold directToIteratedBlockIndex
+  rw [wordOfBlock_blockIndexOfList]
+  simp only [flattenBlockedWord, List.map_ofFn]
+  change (List.ofFn (fun j : Fin n =>
+    wordOfBlock d m (blockIndexOfList d m (blockWordChunk d m n i j) _))).flatten =
+      wordOfBlock d (m * n) i
+  simp_rw [wordOfBlock_blockIndexOfList]
+  simpa [blockWordChunk, wordOfBlock] using
+    (List.ofFn_mul' (m := m) (n := n) (f := decodeBlock d (m * n) i)).symm
+
+/-- Direct blocking is recovered after grouping a direct blocked index and then flattening
+it through the iterated-blocking map. -/
+theorem wordOfBlock_iteratedBlockIndex_directToIteratedBlockIndex (d m n : ℕ)
+    (i : Fin (blockPhysDim d (m * n))) :
+    wordOfBlock d (m * n) (iteratedBlockIndex d m n (directToIteratedBlockIndex d m n i)) =
+      wordOfBlock d (m * n) i := by
+  rw [wordOfBlock_iteratedBlockIndex,
+    flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex]
+
+/-- Rewriting the blocking length does not change the decoded blocked word. -/
+theorem wordOfBlock_cast_length (d : ℕ) {L₁ L₂ : ℕ} (h : L₁ = L₂)
+    (i : Fin (blockPhysDim d L₁)) :
+    wordOfBlock d L₂ (Fin.cast (congr_arg (blockPhysDim d) h) i) = wordOfBlock d L₁ i := by
+  subst h
+  rfl
+
 /-- Reindex the physical alphabet of a tensor by a map of physical indices. -/
 noncomputable def reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
     (A : MPSTensor d₂ D) : MPSTensor d₁ D :=

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -326,9 +326,9 @@ private theorem blockWordChunkIndex_lt (m n : ℕ) (j : Fin n) (t : Fin m) :
     m * (j : ℕ) + (t : ℕ) < m * n := by
   calc
     m * (j : ℕ) + (t : ℕ) < m * (j : ℕ) + m :=
-      Nat.add_lt_add_left t.is_lt _
+      Nat.add_lt_add_left t.isLt _
     _ = m * ((j : ℕ) + 1) := by rw [Nat.mul_add, Nat.mul_one]
-    _ ≤ m * n := Nat.mul_le_mul_left m (Nat.succ_le_of_lt j.is_lt)
+    _ ≤ m * n := Nat.mul_le_mul_left m (Nat.succ_le_of_lt j.isLt)
 
 /-- The `j`-th length-`m` subword of a direct length-`m * n` blocked word. -/
 noncomputable def blockWordChunk (d m n : ℕ) (i : Fin (blockPhysDim d (m * n)))

--- a/audits/2026-04-30_issue990_blocked_word_comparison.md
+++ b/audits/2026-04-30_issue990_blocked_word_comparison.md
@@ -7,7 +7,7 @@ blocking each original nonzero block at the common length $p$ and the weighted
 direct sum obtained by the iterated-blocking relabelling used in
 `CommonBlockedCyclicSectorFamily.commonReindexedBlock`.
 
-The reusable finite-sum comparison theorem is recorded in
+The reusable finite-sum comparison theorems are recorded in
 `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`:
 
 - `CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_word_eq`
@@ -22,32 +22,66 @@ flattened iterated $(m_k,e_k)$ blocked word for each original nonzero block, the
 comparison automatically assembles over the weighted direct sum and composes with
 the common cyclic-sector family.
 
+The issue #1075 refinement adds a canonical grouping map in
+`TNLean/MPS/Core/BlockingInfrastructure.lean`:
+
+- `blockWordChunk`
+- `directToIteratedBlockIndex`
+- `flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex`
+- `wordOfBlock_iteratedBlockIndex_directToIteratedBlockIndex`
+
+For a direct blocked index of length $m n$, this map decodes its word, cuts it
+into $n$ consecutive words of length $m$, encodes those words as the letters of
+an iterated block, and proves that flattening the resulting iterated index
+recovers the original direct word.
+
+The assembly file also records the exact remaining coordinate assertion as
+`CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees` and provides the
+corresponding comparison theorems:
+
+- `CommonBlockedCyclicSectorFamily.wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees`
+- `CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees`
+- `CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees`
+- `CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees`
+- `CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_groupedBlockCastAgrees`
+
 The same comparison gives one-sided zero-tail statements in
 `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`:
 
 - `zeroTail_commonFlat_of_blockwise`
 - `zeroTail_commonFlat_of_word_eq`
+- `zeroTail_commonFlat_of_groupedBlockCastAgrees`
 
 These rewrite the zero-tail equation with the derived common-sector family from a
-blockwise comparison, or directly from equality of the blocked words.
+blockwise comparison, directly from equality of the blocked words, or from the
+sharpened coordinate assertion `groupedBlockCastAgrees`.
 
 ## Remaining point
 
-The remaining theorem is now the pure blocked-word coordinate statement: for each
-common cyclic-sector family `F`, block `k`, and physical index
-`i : Fin (blockPhysDim d F.p)`, prove that the length-$p$ word decoded directly
-from `i` is the same word as the length `F.period k * F.extra k` word obtained by
-viewing `i` as an iterated block through `F.blockPhysDim_nested_eq k` and applying
-`iteratedBlockIndex`.
+The remaining theorem is now sharpened to a precise coordinate assertion.  For
+each common cyclic-sector family `F`, block `k`, and physical index
+`i : Fin (blockPhysDim d F.p)`, the numeric cast
 
-Equivalently, the final comparison may be formulated with this relabelling of
-blocked words explicit. No new mathematical assumptions about MPS tensors are
-introduced here; the remaining question is the identification of the chosen
-coordinates for direct and iterated blocked words. Since the current blocked
-physical index is chosen through `Fintype.equivFin`, cardinal equality alone does
-not specify how a length-`p` direct word is grouped into an iterated
-`(m_k,e_k)` word; that coordinate choice has to be proved for the chosen
-encoding or carried as an explicit relabelling.
+```lean
+Fin.cast ((F.blockPhysDim_nested_eq k).symm) i
+```
+
+must agree with the index obtained by first rewriting the direct alphabet to the
+product length `F.period k * F.extra k` and then applying
+`directToIteratedBlockIndex`.  This is the proposition
+`F.groupedBlockCastAgrees k`.
+
+The new core theorem proves that `directToIteratedBlockIndex` is the mathematically
+expected grouping map: applying `iteratedBlockIndex` to it recovers the original
+direct blocked word.  Thus no MPS-theoretic assumption remains hidden in the
+comparison lemmas.  What remains is only the compatibility between this grouping
+map and the particular numeric `Fin.cast` used by `CommonBlockedCyclicSectorFamily`.
+
+Since the current blocked physical index is chosen through `Fintype.equivFin`,
+cardinal equality alone does not specify that the numeric order on the two `Fin`
+types is the consecutive grouping order.  That coordinate choice must either be
+proved for the chosen enumeration or kept as the explicit relabelling recorded by
+`groupedBlockCastAgrees`.
 
 ## Paper path
 

--- a/audits/2026-04-30_issue990_blocked_word_comparison.md
+++ b/audits/2026-04-30_issue990_blocked_word_comparison.md
@@ -27,6 +27,7 @@ The issue #1075 refinement adds a canonical grouping map in
 
 - `blockWordChunk`
 - `directToIteratedBlockIndex`
+- `blockIndexOfList_wordOfBlock`
 - `flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex`
 - `wordOfBlock_iteratedBlockIndex_directToIteratedBlockIndex`
 

--- a/audits/2026-04-30_issue990_blocked_word_comparison.md
+++ b/audits/2026-04-30_issue990_blocked_word_comparison.md
@@ -58,7 +58,7 @@ sharpened coordinate assertion `groupedBlockCastAgrees`.
 
 ## Remaining point
 
-The remaining theorem is now sharpened to a precise coordinate assertion.  For
+The remaining theorem is now sharpened to a precise coordinate assertion. For
 each common cyclic-sector family `F`, block `k`, and physical index
 `i : Fin (blockPhysDim d F.p)`, the numeric cast
 
@@ -68,18 +68,18 @@ Fin.cast ((F.blockPhysDim_nested_eq k).symm) i
 
 must agree with the index obtained by first rewriting the direct alphabet to the
 product length `F.period k * F.extra k` and then applying
-`directToIteratedBlockIndex`.  This is the proposition
+`directToIteratedBlockIndex`. This is the proposition
 `F.groupedBlockCastAgrees k`.
 
 The new core theorem proves that `directToIteratedBlockIndex` is the mathematically
 expected grouping map: applying `iteratedBlockIndex` to it recovers the original
-direct blocked word.  Thus no MPS-theoretic assumption remains hidden in the
-comparison lemmas.  What remains is only the compatibility between this grouping
+direct blocked word. Thus no MPS-theoretic assumption remains hidden in the
+comparison lemmas. What remains is only the compatibility between this grouping
 map and the particular numeric `Fin.cast` used by `CommonBlockedCyclicSectorFamily`.
 
 Since the current blocked physical index is chosen through `Fintype.equivFin`,
 cardinal equality alone does not specify that the numeric order on the two `Fin`
-types is the consecutive grouping order.  That coordinate choice must either be
+types is the consecutive grouping order. That coordinate choice must either be
 proved for the chosen enumeration or kept as the explicit relabelling recorded by
 `groupedBlockCastAgrees`.
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1767,7 +1767,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:iterated_blocking_phys_dim}
 	For one original block $k$ in a common blocked cyclic-sector family, this
-	predicate says that the numerical identification of the common blocked alphabet
+	predicate says that the canonical identification of the common blocked alphabet
 	with the iterated alphabet agrees with the following grouping of words: first
 	read the direct word of length $p=m_k e_k$, then group it into $e_k$
 	consecutive words of length $m_k$.
@@ -1807,7 +1807,7 @@ The following results separate the zero blocks from the nonzero blocks.
 		thm:common_blocked_cyclic_sector_reindexed_samempv}
 	The word equality gives equality of the corresponding block tensors, hence
 	blockwise MPV equality. The coordinate-grouping predicate supplies this word
-	equality by comparing the numerical cast with the explicit consecutive grouping
+	equality by comparing the canonical identification with the explicit consecutive grouping
 	of a direct blocked word. Expanding both weighted block-diagonal tensors as
 	finite sums over the original block index and applying the blockwise equality
 	term by term gives the weighted comparison.  Composing with

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1803,6 +1803,7 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{proof}\leanok
 	\uses{thm:mpv_decomposition,
+		def:common_blocked_cyclic_sector_grouped_block_cast,
 		thm:common_blocked_cyclic_sector_reindexed_samempv}
 	The word equality gives equality of the corresponding block tensors, hence
 	blockwise MPV equality. The coordinate-grouping predicate supplies this word

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1760,16 +1760,35 @@ The following results separate the zero blocks from the nonzero blocks.
 	sums and reindex the double sum over pairs $(k,s)$ by the flattened sector index.
 \end{proof}
 
-\begin{theorem}[Comparison of direct and iterated blocking for weighted nonzero blocks]%
-\label{thm:common_blocked_cyclic_sector_blocked_word_comparison}
-	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_word_eq,
-		MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq,
-		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise,
-		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq,
-		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise,
-		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq}
+\begin{definition}[Coordinate grouping for common blocked words]%
+\label{def:common_blocked_cyclic_sector_grouped_block_cast}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
+		thm:iterated_blocking_phys_dim}
+	For one original block $k$ in a common blocked cyclic-sector family, this
+	predicate says that the numerical identification of the common blocked alphabet
+	with the iterated alphabet agrees with the following grouping of words: first
+	read the direct word of length $p=m_k e_k$, then group it into $e_k$
+	consecutive words of length $m_k$.
+\end{definition}
+
+\begin{theorem}[Comparison of direct and iterated blocking for weighted nonzero blocks]%
+\label{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees,
+		MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_word_eq,
+		MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees,
+		MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq,
+		MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq,
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_groupedBlockCastAgrees}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_derived_blocks,
+		def:common_blocked_cyclic_sector_grouped_block_cast,
 		thm:common_blocked_cyclic_sector_reindexed_samempv}
 	The comparison has two forms.  First, assume that each directly blocked
 	nonzero block has the same MPV family as its corresponding iterated-blocking
@@ -1786,7 +1805,9 @@ The following results separate the zero blocks from the nonzero blocks.
 	\uses{thm:mpv_decomposition,
 		thm:common_blocked_cyclic_sector_reindexed_samempv}
 	The word equality gives equality of the corresponding block tensors, hence
-	blockwise MPV equality.  Expanding both weighted block-diagonal tensors as
+	blockwise MPV equality. The coordinate-grouping predicate supplies this word
+	equality by comparing the numerical cast with the explicit consecutive grouping
+	of a direct blocked word. Expanding both weighted block-diagonal tensors as
 	finite sums over the original block index and applying the blockwise equality
 	term by term gives the weighted comparison.  Composing with
 	Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_samempv} gives the
@@ -3301,7 +3322,8 @@ The following results separate the zero blocks from the nonzero blocks.
 \begin{theorem}[Zero-tail equation from blockwise comparison of direct and iterated blocking]%
 \label{thm:zero_tail_common_flat_of_blocked_word_comparison}
 	\lean{MPSTensor.zeroTail_commonFlat_of_blockwise,
-		MPSTensor.zeroTail_commonFlat_of_word_eq}
+		MPSTensor.zeroTail_commonFlat_of_word_eq,
+		MPSTensor.zeroTail_commonFlat_of_groupedBlockCastAgrees}
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:common_blocked_cyclic_sector_blocked_word_comparison}


### PR DESCRIPTION
## Summary

- add `directToIteratedBlockIndex`, which groups a directly decoded length-$m n$ blocked word into $n$ consecutive length-$m$ blocks
- prove that flattening this grouped iterated index with `iteratedBlockIndex` recovers the original direct blocked word
- isolate the remaining #1075 coordinate assertion as `CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees`, with blockwise, weighted common-flat, and zero-tail comparison adapters
- update the #990 audit to record the new exact remaining coordinate statement

## Validation

- `lake build TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- Lean diagnostics: `BlockingInfrastructure.lean`, `CyclicSectorDecomposition.lean`, `StructuralTheorem.lean`
- `git diff --check`

Closes #1075.
Follow-up to #990.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new core blocking/indexing definitions and lemmas that change how direct vs iterated blocked indices are related; while mostly additive, these are foundational proofs used by later canonical-form theorems and could ripple into downstream dependencies if the coordinate conventions mismatch.
> 
> **Overview**
> Introduces an explicit **direct-to-iterated blocked-index grouping map** `directToIteratedBlockIndex` (plus supporting lemmas) that decodes a direct length `m*n` blocked word, groups it into `n` consecutive length-`m` chunks, and proves that flattening back via `iteratedBlockIndex` recovers the original direct word.
> 
> Builds a new coordinate-compatibility predicate `CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees` and adds wrapper theorems that let existing direct-vs-iterated blocking comparisons (block equality, `SameMPV₂`, weighted common-flat, and zero-tail rewrites) be discharged from this single coordinate assertion.
> 
> Updates the #990/#1075 audit note and the blueprint to document the new grouping map, the remaining coordinate condition, and the new comparison/zero-tail theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3cd1f03905266031cbaedefce9b021c3e0c9b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->