### PR TITLE
feat(MPS/CanonicalForm): compare common primitive sectors

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -24,6 +24,9 @@ BNT proportional-decomposition comparison of the nonzero-weight block families.
   plus common MPV phase-cover data imply the same sector-weight comparison.
 * `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion` —
   the zero-tail common-cover theorem applied to BNT proportional-decomposition data.
+* `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses` —
+  the common primitive nonzero-sector theorem, followed by the remaining zero-tail,
+  injectivity, and finite-length span hypotheses.
 
 ## References
 
@@ -36,6 +39,51 @@ matrix product states, canonical form, BNT, proportional decomposition
 -/
 
 namespace MPSTensor
+
+/-- Remaining two-sided hypotheses for common primitive nonzero-sector families.
+
+The common-sector structural theorem supplies zero-tail decompositions, positive-length
+nonzero-part equality, nonzero weights, trace-preserving normalization, primitive transfer maps,
+irreducibility, and positive bond dimensions. To pass to the overlap-rigidity sector comparison
+one still needs equality of zero-tail dimensions, one-site injectivity for the two block families,
+and equality of their finite-length MPV spans. -/
+structure CommonPrimitiveSpanHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (zeroTailA zeroTailB : ℕ)
+    (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x))
+    (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)) : Prop where
+  /-- The two zero-tail dimensions agree. -/
+  zeroTail_eq : zeroTailA = zeroTailB
+  /-- The left nonzero-sector blocks are one-site injective. -/
+  left_injective : ∀ x : Fin rA, IsInjective (blocksA x)
+  /-- The right nonzero-sector blocks are one-site injective. -/
+  right_injective : ∀ x : Fin rB, IsInjective (blocksB x)
+  /-- The two nonzero-sector block families have the same finite-length MPV spans. -/
+  span_eq : ∀ N,
+    Submodule.span ℂ (Set.range (fun x : Fin rA =>
+      mpvState (d := blockPhysDim d p) (blocksA x) N)) =
+    Submodule.span ℂ (Set.range (fun x : Fin rB =>
+      mpvState (d := blockPhysDim d p) (blocksB x) N))
+
+namespace CommonPrimitiveSpanHypotheses
+
+/-- A common MPV phase cover supplies the span field in the common primitive hypotheses. -/
+theorem of_commonPhaseCover
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {zeroTailA zeroTailB : ℕ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (hZeroTail : zeroTailA = zeroTailB)
+    (hInjA : ∀ x : Fin rA, IsInjective (blocksA x))
+    (hInjB : ∀ x : Fin rB, IsInjective (blocksB x))
+    (cover : MPVCommonPhaseCover blocksA blocksB) :
+    CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB where
+  zeroTail_eq := hZeroTail
+  left_injective := hInjA
+  right_injective := hInjB
+  span_eq := fun N => cover.span_eq N
+
+end CommonPrimitiveSpanHypotheses
 
 /-- **Sector comparison from BNT proportional-decomposition data.**
 
@@ -320,5 +368,95 @@ theorem afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConc
   exact afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover
     A B hSame hp μA blocksA μB blocksB cover hAblocks hBblocks hZeroTail
     hTPA hTPB hIrrA hIrrB hPrimA hPrimB hInjA hInjB hμA hμB
+
+/-- **Zero-tail sector comparison from common primitive nonzero-sector data.**
+
+The common primitive irreducible block theorem supplies the two nonzero-sector decompositions
+obtained after blocked-word reindexing. If the remaining zero-tail equality, one-site
+injectivity, and finite-length span equality are supplied for those same families, then the
+zero-tail block-span comparison theorem gives the sector-weight conclusion.
+
+This theorem deliberately keeps the blocked-word reindexing equality and the final span or
+common-cover assertion as hypotheses, so it does not duplicate the separate coordinate and
+common-cover constructions. -/
+theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : ∀ {r : ℕ} {dim : Fin r → ℕ}
+      (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+      (F : CommonBlockedCyclicSectorFamily blocks),
+      SameMPV₂
+        (toTensorFromBlocks (d := blockPhysDim d F.p)
+          (μ := fun k : Fin r => (μ k) ^ F.p)
+          (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+        (toTensorFromBlocks (d := blockPhysDim d F.p)
+          (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock))
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
+      hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts A B hSame hReindexed
+  have hHyp : CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  exact afterBlocking_sectorComparison_zeroTail_of_blockSpan
+    A B hSame hp μA blocksA μB blocksB hAblocks hBblocks hHyp.zeroTail_eq hTPA hTPB
+    hIrrA hIrrB hPrimA hPrimB hHyp.left_injective hHyp.right_injective
+    hμA hμB hHyp.span_eq
 
 end MPSTensor

--- a/audits/2026-04-29_issue944_overlap_span_from_common_live.md
+++ b/audits/2026-04-29_issue944_overlap_span_from_common_live.md
@@ -107,3 +107,32 @@ The branch deliberately leaves the following hypotheses explicit:
 
 Once these are supplied, the new zero-tail theorem produces the overlap-span data and
 sector-weight conclusion through the common phase-cover route.
+
+## 2026-05-01 update: common primitive sector hypotheses
+
+After the common primitive and common-length sector theorems from Wave 23, the
+zero-tail sector comparison can be stated one step closer to the canonical-form
+reduction.  The new structure
+`MPSTensor.CommonPrimitiveSpanHypotheses` records precisely the remaining
+conditions on the common primitive nonzero-sector families: equality of the two
+zero-tail dimensions, one-site injectivity of the sector blocks, and equality of
+the finite-length MPV spans.  The helper
+`MPSTensor.CommonPrimitiveSpanHypotheses.of_commonPhaseCover` fills the span field
+from a common MPV phase cover.
+
+The theorem
+`MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`
+then composes the conditional common primitive theorem
+`MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
+with the zero-tail block-span comparison.  It does not construct the blocked-word
+coordinate equality or the common phase cover.  Instead, it consumes exactly the
+mathematical assertions expected from those neighboring steps: the reindexing of
+blocked physical words, equal zero tails, injectivity, and either span equality
+or common phase-cover data for the produced common primitive sector families.
+
+This remains aligned with the paper references listed above.  The BNT comparison
+and phase matching are the steps described in `Papers/1606.00608/MPDO-22-12-17-2.tex`
+lines 271--302 and 349--352, while the injectivity/Wielandt blocking requirement
+is the passage in lines 317--332.  In the review article, the corresponding BNT
+comparison is `Papers/2011.12127/TN-Review-main.tex` lines 1846--1859,
+1864--1885, and 1891--1894.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1286,6 +1286,38 @@ two-basis sector comparison theorem.
 	conclusion.
 \end{proof}
 
+\begin{definition}[Remaining span hypotheses for common primitive sectors]%
+\label{def:common_primitive_span_hypotheses}
+	\lean{MPSTensor.CommonPrimitiveSpanHypotheses}
+	\leanok
+	\uses{def:mpv_state, def:injective}
+	For two common primitive nonzero-sector families at one blocking length, this
+	condition records the remaining two-sided hypotheses needed before applying the
+	zero-tail sector comparison: equality of the two zero-tail dimensions,
+	one-site injectivity of all blocks on both sides, and equality of the
+	finite-length MPV spans of the two block families for every system size.
+\end{definition}
+
+\begin{theorem}[Common phase cover supplies the remaining span hypotheses]%
+\label{thm:common_primitive_span_hypotheses_of_common_phase_cover}
+	\lean{MPSTensor.CommonPrimitiveSpanHypotheses.of_commonPhaseCover}
+	\leanok
+	\uses{def:common_primitive_span_hypotheses, def:mpv_common_phase_cover,
+		lem:mpv_common_phase_cover_span_eq}
+	If the two common primitive nonzero-sector families have equal zero-tail
+	dimensions, are one-site injective, and are equipped with a common MPV phase cover, then
+	they satisfy the remaining span hypotheses of
+	Definition~\ref{def:common_primitive_span_hypotheses}.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{lem:mpv_common_phase_cover_span_eq}
+	The zero-tail and injectivity fields are exactly the supplied hypotheses.  The
+	common phase cover gives the finite-length span equality by
+	Lemma~\ref{lem:mpv_common_phase_cover_span_eq}.
+\end{proof}
+
 \begin{theorem}[Zero-tail nonzero block decompositions with a common MPV phase cover]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
@@ -1335,6 +1367,38 @@ two-basis sector comparison theorem.
 		thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	First convert the proportional-decomposition conclusion into common MPV
 	phase-cover data. The preceding zero-tail theorem then applies.
+\end{proof}
+
+\begin{theorem}[Common primitive sectors with the remaining span hypotheses]%
+\label{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
+	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
+	\leanok
+	\uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed,
+		def:common_primitive_span_hypotheses,
+		thm:afterBlocking_sectorComparison_zeroTail_of_blockSpan}
+	Assume $A$ and $B$ have the same MPV family and that the canonically blocked
+	nonzero parts agree with the same families written using the reindexing of
+	blocked physical words.  The common primitive theorem then produces one
+	positive blocking length, zero-tail equations, trace-preserving primitive
+	irreducible nonzero-sector families with positive bond dimensions and nonzero
+	weights, and the positive-length and length-zero identities for those
+	families.  If these produced families also satisfy
+	Definition~\ref{def:common_primitive_span_hypotheses}, then the zero-tail
+	sector comparison conclusion holds: after a positive blocking, there are
+	sector decompositions $P,Q$ agreeing with $A$ and $B$ at all positive lengths,
+	with $P$ and $Q$ generating the same full MPV family, carrying BNT data, and
+	with their sector weights matched up to a permutation and nonzero phases.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed,
+		thm:afterBlocking_sectorComparison_zeroTail_of_blockSpan}
+	Apply the common primitive theorem to obtain the nonzero-sector families and
+	their structural properties.  The remaining span hypotheses provide equal
+	zero-tail dimensions, one-site injectivity, and finite-length nonzero-sector
+	span equality.  These are exactly the additional hypotheses required by the
+	zero-tail block-span comparison theorem.
 \end{proof}
 
 \begin{theorem}[Cast-compatible MPV scaling implies phase-matched sector comparison]%
@@ -1425,10 +1489,11 @@ two-basis sector comparison theorem.
 	relabeled cyclic-sector tensor for the whole weighted family.  With that
 	equality, Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	gives the common weighted nonzero-sector decompositions needed for the
-	comparison theorems.  After a further injective blocking, one must establish
-	either the finite-length MPV span equality of the nonzero sectors or the
-	corresponding common phases, equivalently the BNT proportional-decomposition
-	conclusion, from which the theorems above derive the span equality.  This is
-	the mathematical passage from equality of total MPV vectors to the componentwise
-	power-sum identities used in the paper proof of Corollary~IV.5.
+	comparison theorems.  Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
+	then records the remaining hypotheses in their present form: equality of the
+	zero-tail dimensions, injectivity of the common nonzero-sector blocks, and
+	either finite-length MPV span equality or a common phase cover for those
+	blocks.  Establishing these hypotheses is the mathematical passage from
+	equality of total MPV vectors to the componentwise power-sum identities used in
+	the paper proof of Corollary~IV.5.
 \end{remark}


### PR DESCRIPTION
## Summary

- Add `CommonPrimitiveSpanHypotheses`, the remaining zero-tail, injectivity, and finite-length span hypotheses for common primitive nonzero-sector families.
- Add `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`, composing the Wave 23 common primitive theorem with the zero-tail block-span sector comparison.
- Record the theorem in Ch. 11 and update the #944 audit note with the remaining #1068/#1075-shaped hypotheses.

## Validation

- `lake -Kjobs=1 build --old TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- added-line proof/prose hygiene scan

Partially addresses #944.
Refs #652.
Refs #1068.
Refs #1075.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean statements/structuring and documentation without changing existing theorem behavior, but may affect downstream proof dependencies through new abstractions.
> 
> **Overview**
> Adds `MPSTensor.CommonPrimitiveSpanHypotheses` to bundle the remaining assumptions (zero-tail equality, one-site injectivity, and finite-length span equality) needed to move from *common primitive* nonzero-sector families to the zero-tail sector-weight comparison, plus a helper `of_commonPhaseCover` that derives the span equality from `MPVCommonPhaseCover`.
> 
> Introduces `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`, which composes `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` with `afterBlocking_sectorComparison_zeroTail_of_blockSpan` while leaving the blocked-word reindexing and “remaining hypotheses” explicit. Updates the audit note and Ch. 11 blueprint to document the new structure/theorem and the refined remaining hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58adf9c45f415b82b28c4e8d3951c7b75b3f754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->