### PR TITLE
refactor(MPS/CanonicalForm): normalize reindexed common-sector names

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1577,7 +1577,7 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
     (F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ)
 
 /-- The preceding comparison expressed at a prescribed common length. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling
+theorem sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     {p' : ℕ} (hp : F.p = p')
     (hRelabel : SameMPV₂

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -841,6 +841,7 @@ theorem fundamentalTheorem_after_blocking_commonLength_commonSector
   · intro x
     exact familyB.commonFlatDim_pos x
 
+/-- Transport a zero-tail decomposition along an MPV equivalence of its nonzero part. -/
 private theorem zeroTail_eq_of_sameMPV₂
     {d D L L' z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
     (flat : MPSTensor d L')
@@ -855,6 +856,7 @@ private theorem zeroTail_eq_of_sameMPV₂
     _ = mpv (zeroMPSTensor d z) σ + mpv flat σ := by
       rw [hFlat N σ]
 
+/-- At positive lengths, a zero-tail decomposition reduces to the nonzero part. -/
 private theorem sameMPV₂Pos_of_zeroTail_eq
     {d D L z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
     (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -841,6 +841,34 @@ theorem fundamentalTheorem_after_blocking_commonLength_commonSector
   · intro x
     exact familyB.commonFlatDim_pos x
 
+private theorem zeroTail_eq_of_sameMPV₂
+    {d D L L' z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
+    (flat : MPSTensor d L')
+    (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ)
+    (hFlat : SameMPV₂ live flat) :
+    ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv flat σ := by
+  intro N σ
+  calc
+    mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ := hZeroTail N σ
+    _ = mpv (zeroMPSTensor d z) σ + mpv flat σ := by
+      rw [hFlat N σ]
+
+private theorem sameMPV₂Pos_of_zeroTail_eq
+    {d D L z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
+    (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ) :
+    SameMPV₂Pos A live := by
+  intro N hN σ
+  have hZero : mpv (zeroMPSTensor d z) σ = 0 := by
+    rw [mpv_zeroMPSTensor]
+    simp [Nat.ne_of_gt hN]
+  calc
+    mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ := hZeroTail N σ
+    _ = mpv live σ := by
+      rw [hZero, zero_add]
+
 /-- If each directly blocked nonzero block agrees with its iterated-blocking version,
 the zero-tail equation can be written using the derived common-sector family. -/
 theorem zeroTail_commonFlat_of_blockwise
@@ -860,21 +888,11 @@ theorem zeroTail_commonFlat_of_blockwise
         mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
           mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
             (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
-  intro N σ
   have hCanon := zeroTail_toTensorFromBlocks_blockPower
     (d := d) (D := D) (r := r) (z := z) (p := F.p) (dim := dim)
     A μ blocks F.p_pos hMPV
   have hFlat := F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise μ hBlock
-  calc
-    mpv (blockTensor (d := d) (D := D) A F.p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-            (fun k => (μ k) ^ F.p)
-            (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p)) σ := hCanon N σ
-    _ = mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
-          rw [hFlat N σ]
+  exact zeroTail_eq_of_sameMPV₂ _ _ _ hCanon hFlat
 
 /-- If the blocked-word decodings agree for every nonzero block, the zero-tail equation
 can be written using the derived common-sector family. -/
@@ -922,49 +940,14 @@ theorem zeroTail_commonFlat_of_reindexed
         mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
           mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
             (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
-  intro N σ
   have hCanon := zeroTail_toTensorFromBlocks_blockPower
     (d := d) (D := D) (r := r) (z := z) (p := F.p) (dim := dim)
     A μ blocks F.p_pos hMPV
   have hFlat := F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μ hLabel
-  calc
-    mpv (blockTensor (d := d) (D := D) A F.p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-            (fun k => (μ k) ^ F.p)
-            (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p)) σ := hCanon N σ
-    _ = mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
-          rw [hFlat N σ]
-
-/-- The same one-sided zero-tail rewriting, named by the blocked-word relabeling
-hypothesis it uses. -/
-theorem zeroTail_commonFlat_of_blockWordRelabeling
-    {d D r z : ℕ} {dim : Fin r → ℕ}
-    (A : MPSTensor d D) (μ : Fin r → ℂ)
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (F : CommonBlockedCyclicSectorFamily blocks)
-    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
-    (hRelabel : SameMPV₂
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p)
-        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
-    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
-      mpv (blockTensor (d := d) (D := D) A F.p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ := by
-  exact zeroTail_commonFlat_of_reindexed
-    (d := d) (D := D) (r := r) (z := z) (dim := dim)
-    A μ blocks F hMPV hRelabel
+  exact zeroTail_eq_of_sameMPV₂ _ _ _ hCanon hFlat
 
 /-- The preceding zero-tail rewriting expressed at a prescribed common length. -/
-theorem zeroTail_commonFlatAt_of_blockWordRelabeling
+theorem zeroTail_commonFlatAt_of_reindexed
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -986,11 +969,11 @@ theorem zeroTail_commonFlatAt_of_blockWordRelabeling
             (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) σ := by
   subst p
   simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocksAt] using
-    zeroTail_commonFlat_of_blockWordRelabeling A μ blocks F hMPV hRelabel
+    zeroTail_commonFlat_of_reindexed A μ blocks F hMPV hRelabel
 
 /-- At positive lengths, the blocked tensor has the same MPV coefficients as the
 weighted common-sector family once the blocked words have been reindexed. -/
-theorem sameMPV₂Pos_blockTensor_commonFlatAt_of_blockWordRelabeling
+theorem sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -1009,22 +992,10 @@ theorem sameMPV₂Pos_blockTensor_commonFlatAt_of_blockWordRelabeling
       (blockTensor (d := d) (D := D) A p)
       (toTensorFromBlocks (d := blockPhysDim d p)
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) := by
-  intro N hN σ
-  have hZeroTail := zeroTail_commonFlatAt_of_blockWordRelabeling
+  have hZeroTail := zeroTail_commonFlatAt_of_reindexed
     (d := d) (D := D) (r := r) (z := z) (dim := dim)
     A μ blocks F hp hMPV hRelabel
-  have hZero : mpv (zeroMPSTensor (blockPhysDim d p) z) σ = 0 := by
-    rw [mpv_zeroMPSTensor]
-    simp [Nat.ne_of_gt hN]
-  calc
-    mpv (blockTensor (d := d) (D := D) A p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) σ := hZeroTail N σ
-    _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) σ := by
-        rw [hZero]
-        simp
+  exact sameMPV₂Pos_of_zeroTail_eq _ _ hZeroTail
 
 /-- Replacing nonzero parts by MPV-equivalent tensors preserves the positive-length
 MPV equality and the length-zero zero-tail identity. -/
@@ -1317,7 +1288,7 @@ records the common cyclic-sector families.  If the canonical blocked nonzero
 families agree with the explicitly reindexed blocked-word families, then the
 nonzero parts are equal to the weighted common-sector families, and the zero-tail
 equations are rewritten with those common-sector families. -/
-theorem fundamentalTheorem_after_blocking_commonLength_commonSector_of_blockWordRelabeling
+theorem fundamentalTheorem_after_blocking_commonLength_commonSector_of_reindexed
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B) :
@@ -1407,76 +1378,30 @@ theorem fundamentalTheorem_after_blocking_commonLength_commonSector_of_blockWord
     zeroTailB, rB, dimB, μB, blocksB, familyA, familyB, hFamilyA, hFamilyB,
     hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB, ?_⟩
   intro hRelabelA hRelabelB
-  have hFlatA := familyA.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling
+  have hFlatA := familyA.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed
     μA hFamilyA hRelabelA
-  have hFlatB := familyB.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling
+  have hFlatB := familyB.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed
     μB hFamilyB hRelabelB
   have hZAflat : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
       mpv (blockTensor (d := d) (D := D₁) A p) σ =
         mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
           mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ := by
-    intro N σ
-    calc
-      mpv (blockTensor (d := d) (D := D₁) A p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p)
-              (fun k => (μA k) ^ p)
-              (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ := hZA N σ
-      _ = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p)
-              (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ := by
-          rw [hFlatA N σ]
+            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ :=
+    zeroTail_eq_of_sameMPV₂ _ _ _ hZA hFlatA
   have hZBflat : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
       mpv (blockTensor (d := d) (D := D₂) B p) σ =
         mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
           mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
-    intro N σ
-    calc
-      mpv (blockTensor (d := d) (D := D₂) B p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p)
-              (fun k => (μB k) ^ p)
-              (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ := hZB N σ
-      _ = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p)
-              (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
-          rw [hFlatB N σ]
+            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ :=
+    zeroTail_eq_of_sameMPV₂ _ _ _ hZB hFlatB
   have hApos : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
       (toTensorFromBlocks (d := blockPhysDim d p)
-        (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) := by
-    intro N hN σ
-    have hZeroTail : mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ = 0 := by
-      rw [mpv_zeroMPSTensor]
-      simp [Nat.ne_of_gt hN]
-    calc
-      mpv (blockTensor (d := d) (D := D₁) A p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p)
-              (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ :=
-            hZAflat N σ
-      _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ := by
-          rw [hZeroTail]
-          simp
+        (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) :=
+    sameMPV₂Pos_of_zeroTail_eq _ _ hZAflat
   have hBpos : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
       (toTensorFromBlocks (d := blockPhysDim d p)
-        (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) := by
-    intro N hN σ
-    have hZeroTail : mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ = 0 := by
-      rw [mpv_zeroMPSTensor]
-      simp [Nat.ne_of_gt hN]
-    calc
-      mpv (blockTensor (d := d) (D := D₂) B p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p)
-              (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ :=
-            hZBflat N σ
-      _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
-          rw [hZeroTail]
-          simp
+        (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) :=
+    sameMPV₂Pos_of_zeroTail_eq _ _ hZBflat
   have hFlatPos : SameMPV₂Pos
       (toTensorFromBlocks (d := blockPhysDim d p)
         (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA))

--- a/audits/2026-04-30_issue969_common_length_conditional_sectors.md
+++ b/audits/2026-04-30_issue969_common_length_conditional_sectors.md
@@ -35,12 +35,11 @@ positive-length MPV equalities, and the length-zero identity.
 - `MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocksAt` expresses the
   derived flattened common-sector family at a prescribed length `p'` when
   `F.p = p'`.
-- `MPSTensor.CommonBlockedCyclicSectorFamily.`
-  `sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed` is the prescribed-length
-  form of the canonical-to-common-sector comparison.  Its hypothesis is the `SameMPV₂`
-  equality between the directly blocked
-  nonzero family and the explicitly reindexed family.  This is exactly the
-  hypothesis expected from #990.
+- The prescribed-length comparison is
+  `MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed`.
+  Its hypothesis is the `SameMPV₂` equality between the directly blocked nonzero
+  family and the explicitly reindexed family.  This is exactly the hypothesis expected
+  from #990.
 
 ### `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
 

--- a/audits/2026-04-30_issue969_common_length_conditional_sectors.md
+++ b/audits/2026-04-30_issue969_common_length_conditional_sectors.md
@@ -35,22 +35,23 @@ positive-length MPV equalities, and the length-zero identity.
 - `MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocksAt` expresses the
   derived flattened common-sector family at a prescribed length `p'` when
   `F.p = p'`.
-- `MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling`
-  is the prescribed-length form of the canonical-to-common-sector comparison.
-  Its hypothesis is the `SameMPV₂` equality between the directly blocked
+- `MPSTensor.CommonBlockedCyclicSectorFamily.`
+  `sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed` is the prescribed-length
+  form of the canonical-to-common-sector comparison.  Its hypothesis is the `SameMPV₂`
+  equality between the directly blocked
   nonzero family and the explicitly reindexed family.  This is exactly the
   hypothesis expected from #990.
 
 ### `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
 
-- `MPSTensor.zeroTail_commonFlat_of_blockWordRelabeling` is the renamed one-sided
-  zero-tail conversion; it avoids the earlier informal wording about labels.
-- `MPSTensor.zeroTail_commonFlatAt_of_blockWordRelabeling` gives the same
-  zero-tail conversion at a prescribed common length.
-- `MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_blockWordRelabeling` records
+- `MPSTensor.zeroTail_commonFlat_of_reindexed` is the one-sided zero-tail
+  conversion for the reindexed nonzero-part hypothesis.
+- `MPSTensor.zeroTail_commonFlatAt_of_reindexed` gives the same zero-tail
+  conversion at a prescribed common length.
+- `MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed` records
   that the zero-tail term vanishes at positive system sizes, so the blocked tensor
   and the weighted common-sector family have equal MPV coefficients there.
-- `MPSTensor.fundamentalTheorem_after_blocking_commonLength_commonSector_of_blockWordRelabeling`
+- `MPSTensor.fundamentalTheorem_after_blocking_commonLength_commonSector_of_reindexed`
   starts from `SameMPV₂ A B`, chooses one positive blocking length for both sides,
   obtains common cyclic-sector families on both sides, and then conditionally
   rewrites all nonzero-part and zero-tail conclusions with the weighted
@@ -77,3 +78,14 @@ positive-length MPV equalities, and the length-zero identity.
    period-removal length.
 3. Derive the common phase-cover or BNT proportional-decomposition hypotheses
    from the exact common-length nonzero-sector data.
+
+## Cleanup note (#1073)
+
+The follow-up cleanup normalized the public suffix for the remaining conditional
+common-sector comparisons to `_of_reindexed`, matching the tensor
+`commonReindexedBlock` that appears in the hypothesis.  The pure alias
+`zeroTail_commonFlat_of_blockWordRelabeling` was removed rather than retained as
+a compatibility theorem; the blueprint now points directly to
+`zeroTail_commonFlat_of_reindexed`.  A private zero-tail transport helper factors
+the repeated one-sided calculations used to pass from the canonical blocked
+nonzero part to the weighted common-sector family.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1793,15 +1793,15 @@ The following results separate the zero blocks from the nonzero blocks.
 	common-sector statement.
 \end{proof}
 
-\begin{theorem}[Canonical blocked nonzero part under blocked-word relabeling]%
-\label{thm:common_blocked_cyclic_sector_block_word_relabeling}
+\begin{theorem}[Canonical blocked nonzero part after reindexing blocked words]%
+\label{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed,
-		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_relabeling}
+		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed}
 	\leanok
 	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
 		def:common_blocked_cyclic_sector_derived_blocks}
 	Assume that the canonical blocked nonzero part agrees, as an MPV family, with
-	the relabeled cyclic-sector tensor coming from iterated blocking.  Then the
+	the reindexed cyclic-sector tensor coming from iterated blocking.  Then the
 	canonical weighted nonzero part agrees with the weighted derived common-sector
 	tensor.  The prescribed-length form gives the same conclusion after substituting
 	an equality between the family length and the chosen common length.
@@ -3323,15 +3323,14 @@ The following results separate the zero blocks from the nonzero blocks.
 	blocked nonzero part by the weighted derived common-sector tensor.
 \end{proof}
 
-\begin{theorem}[Zero-tail equation after resolving the blocked-word relabeling]%
-\label{thm:zero_tail_common_flat_of_block_word_relabeling}
+\begin{theorem}[Zero-tail equation after reindexing blocked words]%
+\label{thm:zero_tail_common_flat_of_reindexed}
 	\lean{MPSTensor.zeroTail_commonFlat_of_reindexed,
-		MPSTensor.zeroTail_commonFlat_of_blockWordRelabeling,
-		MPSTensor.zeroTail_commonFlatAt_of_blockWordRelabeling,
-		MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_blockWordRelabeling}
+		MPSTensor.zeroTail_commonFlatAt_of_reindexed,
+		MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed}
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_block_word_relabeling}
+		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	For one side, suppose first that the original tensor decomposes, as an MPV
 	family, into a zero-tail contribution plus a weighted block-sum nonzero part at
 	the original physical alphabet.  Suppose also that, after blocking by the
@@ -3345,10 +3344,10 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_block_word_relabeling}
+		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	First transport the original zero-tail/nonzero decomposition through the common
 	blocking length.  Then replace the canonical blocked nonzero tensor by the
-	derived common-sector tensor using the blocked-word relabeling agreement.  The
+	derived common-sector tensor using the reindexed nonzero-part agreement.  The
 	prescribed-length form follows by substituting the equality of blocking lengths,
 	and the positive-length statement follows because the zero-tail tensor has zero
 	MPV coefficients at all nonzero lengths.
@@ -3359,7 +3358,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	\lean{MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts}
 	\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_block_word_relabeling,
+		thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
 		def:same_mpv2_pos}
 	Assume the one-sided theorem identifying the canonically blocked weighted
 	nonzero part with the same family written through the reindexing of blocked
@@ -3374,7 +3373,7 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{proof}\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_block_word_relabeling}
+		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}
 	to choose the common blocking length and the two common cyclic-sector families.
 	The assumed blocked-word reindexing equality converts the canonically blocked
@@ -3402,17 +3401,17 @@ The following results separate the zero blocks from the nonzero blocks.
 	the positive-length statement and in the $N=0$ identity.
 \end{proof}
 
-\begin{theorem}[Common-sector zero-tail data after blocked-word relabeling]%
+\begin{theorem}[Common-sector zero-tail data after reindexing blocked words]%
 \label{thm:zero_tail_common_flat_transport_of_reindexed}
 	\lean{MPSTensor.zeroTail_commonFlat_transport_of_reindexed}
 	\leanok
-	\uses{thm:zero_tail_common_flat_of_block_word_relabeling,
-		thm:common_blocked_cyclic_sector_block_word_relabeling,
+	\uses{thm:zero_tail_common_flat_of_reindexed,
+		thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
 		thm:common_blocked_cyclic_sector_derived_properties}
 	Assume that the original tensor decomposes, as an MPV family, into a
 	zero-tail contribution plus a weighted nonzero block tensor, that all original
 	nonzero-block weights are nonzero, and that the canonical blocked nonzero
-	tensor agrees, after the prescribed blocked-word relabeling, with the
+	tensor agrees, after reindexing blocked words, with the
 	reindexed common-sector tensor.  Then the zero-tail equation after blocking
 	can be written with the weighted common-sector family, the canonical blocked
 	nonzero tensor generates the same MPV family as that weighted common-sector
@@ -3420,25 +3419,25 @@ The following results separate the zero blocks from the nonzero blocks.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:zero_tail_common_flat_of_block_word_relabeling,
-		thm:common_blocked_cyclic_sector_block_word_relabeling,
+	\uses{thm:zero_tail_common_flat_of_reindexed,
+		thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
 		thm:common_blocked_cyclic_sector_derived_properties}
-	Combine Theorem~\ref{thm:zero_tail_common_flat_of_block_word_relabeling} with
+	Combine Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} with
 	the weighted common-sector MPV equality and the nonzero-weight statement for
 	derived common sectors.
 \end{proof}
 
-\begin{theorem}[Two-sided common-length sectors after blocked-word relabeling]%
-\label{thm:ft_after_blocking_common_length_common_sector_block_word_relabeling}
-	\lean{MPSTensor.fundamentalTheorem_after_blocking_commonLength_commonSector_of_blockWordRelabeling}
+\begin{theorem}[Two-sided common-length sectors after reindexing blocked words]%
+\label{thm:ft_after_blocking_common_length_common_sector_reindexed}
+	\lean{MPSTensor.fundamentalTheorem_after_blocking_commonLength_commonSector_of_reindexed}
 	\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_block_word_relabeling}
+		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	If two tensors generate the same MPV family, then the common-length theorem can
 	be strengthened conditionally as follows.  The theorem chooses one positive
 	blocking length for both sides and gives common cyclic-sector families at that
 	length.  If, on each side, the canonically blocked nonzero family agrees with
-	the explicitly relabeled family coming from iterated blocking, then the
+	the explicitly reindexed family coming from iterated blocking, then the
 	canonically blocked nonzero family agrees with the weighted common-sector
 	family.  The zero-tail equations, positive-length MPV equalities, and the
 	length-zero identity are then all rewritten with those common-sector families.
@@ -3446,10 +3445,10 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{proof}\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_block_word_relabeling}
+		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}.
-	The two assumed blocked-word relabeling equalities compose with
-	Theorem~\ref{thm:common_blocked_cyclic_sector_block_word_relabeling} to identify
+	The two assumed reindexed nonzero-part equalities compose with
+	Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part} to identify
 	the canonical nonzero parts with the weighted common-sector tensors.  Substituting
 	these two MPV equalities into the zero-tail equations gives the rewritten
 	zero-tail identities, the positive-length MPV equalities, and the $N=0$ identity.
@@ -3502,9 +3501,9 @@ The following results separate the zero blocks from the nonzero blocks.
 	The next mathematical assertion is the corresponding equality, after relabeling
 	blocked physical words, between the canonical blocked nonzero part and the
 	cyclic-sector tensor for the whole weighted family.
-	Theorem~\ref{thm:zero_tail_common_flat_of_block_word_relabeling} gives the
+	Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} gives the
 	one-sided form of this conversion, and
-	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_block_word_relabeling}
+	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_reindexed}
 	records it simultaneously for the two common-length sector families.  The
 	auxiliary transport statements
 	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed} and
@@ -3515,7 +3514,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	collects the resulting primitive irreducible sector decompositions needed for
 	comparison.  The remaining blocked-word assertion is the equality of these
 	words for the chosen coordinates, or an equivalent final comparison with the
-	relabeling made explicit.  Once the common-length sectors have also been
+	reindexing made explicit.  Once the common-length sectors have also been
 	blocked far enough to be injective, a BNT proportional-decomposition comparison
 	gives the block permutation, the bond-dimension equalities, and the gauge phases.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}


### PR DESCRIPTION
## Summary

- normalize the remaining common-sector conditional names to the `_of_reindexed` suffix
- remove the pure `zeroTail_commonFlat_of_blockWordRelabeling` alias in favor of the existing reindexed theorem
- factor the repeated zero-tail and positive-length transport calculations through private helpers
- update Chapter 8 blueprint labels/prose and the #969 audit note

Closes #1073.
Refs #969.
Refs #990.

## Validation

- `lean_diagnostics` on `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`
- `lean_diagnostics` on `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `lake exe cache get`
- `lake build --old TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- `lake build --old TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- added-line hygiene scans for `sorry|admit|axiom|native_decide|unsafe` and banned wording

The full `TNLean` build replayed existing unrelated warnings about sorries and long lines outside this cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it renames public Lean theorems and removes an alias, which can break downstream references even though the mathematical content is largely refactoring and proof factoring.
> 
> **Overview**
> Normalizes the remaining conditional common-sector theorems to the `_of_reindexed` suffix (e.g. `sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed` and `fundamentalTheorem_after_blocking_commonLength_commonSector_of_reindexed`) and updates call sites accordingly.
> 
> Refactors repeated proof steps in `StructuralTheorem.lean` by introducing private helpers (`zeroTail_eq_of_sameMPV₂`, `sameMPV₂Pos_of_zeroTail_eq`) and uses them to simplify the one-sided zero-tail rewrites/positive-length results; removes the redundant alias `zeroTail_commonFlat_of_blockWordRelabeling`.
> 
> Updates the audit note and Chapter 8 blueprint labels/prose to match the renamed declarations and terminology (“reindexed” vs “relabeling”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e45649ca938c34147e00d40e687d1f4697ccef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->