### PR TITLE
feat(MPS/CanonicalForm): record common-sector span consequences

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -31,6 +31,8 @@ BNT proportional-decomposition comparison of the nonzero-weight block families.
 * `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses` —
   the common primitive nonzero-sector theorem, followed by the remaining zero-tail,
   injectivity, and finite-length span hypotheses.
+* `afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts` —
+  common-length cyclic-sector output with conditional finite-length block-span consequences.
 
 ## References
 
@@ -491,6 +493,87 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHyp
     A B hSame hp μA blocksA μB blocksB hAblocks hBblocks hHyp.zeroTail_eq hTPA hTPB
     hIrrA hIrrB hPrimA hPrimB hHyp.left_injective hHyp.right_injective
     hμA hμB hHyp.span_eq
+
+
+/-- **Common-length primitive irreducible sectors with conditional block-span consequences.**
+
+The structural theorem gives the common blocking length and the two primitive irreducible
+common-sector nonzero parts, conditional on the equality after relabeling blocked physical words.
+This statement records, for exactly those families, that either common MPV phase-cover data or a
+BNT proportional-decomposition conclusion supplies the finite-length block-span hypothesis used by
+`afterBlocking_sectorComparison_zeroTail_of_blockSpan`.  Thus the remaining mathematical inputs are
+kept explicit: the blocked-word relabeling equality, and the later common-phase or BNT matching
+comparison. -/
+theorem afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ (zeroTailA zeroTailB : ℕ),
+    ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)),
+    ∃ (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)),
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
+      (∀ x, μA x ≠ 0) ∧
+      (∀ x, μB x ≠ 0) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) ∧
+      (∀ x, IsIrreducibleTensor (blocksA x)) ∧
+      (∀ x, IsIrreducibleTensor (blocksB x)) ∧
+      (∀ x, 0 < dimA x) ∧
+      (∀ x, 0 < dimB x) ∧
+      (MPVCommonPhaseCover blocksA blocksB →
+        ∀ N,
+          Submodule.span ℂ (Set.range (fun x : Fin rA =>
+            mpvState (d := blockPhysDim d p) (blocksA x) N)) =
+          Submodule.span ℂ (Set.range (fun y : Fin rB =>
+            mpvState (d := blockPhysDim d p) (blocksB y) N))) ∧
+      (ProportionalDecompositionConclusion (d := blockPhysDim d p) blocksA blocksB →
+        ∀ N,
+          Submodule.span ℂ (Set.range (fun x : Fin rA =>
+            mpvState (d := blockPhysDim d p) (blocksA x) N)) =
+          Submodule.span ℂ (Set.range (fun y : Fin rB =>
+            mpvState (d := blockPhysDim d p) (blocksB y) N))) := by
+  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
+      hZeroTailIdentity, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB,
+      hDimA, hDimB⟩ :=
+    afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
+      A B hSame hReindexed
+  refine ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+    rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
+    hZeroTailIdentity, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB,
+    hDimA, hDimB, ?_, ?_⟩
+  · intro cover N
+    exact cover.span_eq N
+  · intro hMatch N
+    exact mpv_span_eq_of_proportionalDecompositionConclusion
+      (d := blockPhysDim d p) blocksA blocksB hMatch N
 
 /-- **Sector comparison from relabeled common sectors and a common phase cover.**
 

--- a/audits/2026-05-01_issue1068_common_phase_cover_from_common_sectors.md
+++ b/audits/2026-05-01_issue1068_common_phase_cover_from_common_sectors.md
@@ -8,7 +8,7 @@ comparison theorem, or equivalently to common MPV phase-cover data for the two
 nonzero-sector families.
 
 The Lean theorem added in this round is
-`MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_blockSpanConsequences_of_reindexedNonzeroParts`
+`MPSTensor.afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts`
 in `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`.  It starts
 from `SameMPV₂ A B` and the one-sided equality after relabeling blocked physical
 words used by
@@ -73,4 +73,4 @@ common-sector output without an external span hypothesis, one still needs:
    further blocking;
 4. the zero-tail dimension equality required by the zero-tail block-span theorem.
 
-No Gemma-periodic fundamental theorem input is used here.
+No periodic-blocking fundamental theorem from the Gemma route (arXiv:1708.00029) is used here.

--- a/audits/2026-05-01_issue1068_common_phase_cover_from_common_sectors.md
+++ b/audits/2026-05-01_issue1068_common_phase_cover_from_common_sectors.md
@@ -1,0 +1,76 @@
+# Issue #1068 common-sector span consequence audit
+
+## Scope
+
+Issue #1068 asks for the step from the common-length cyclic-sector construction to
+the finite-length nonzero-block span hypothesis used by the zero-tail sector
+comparison theorem, or equivalently to common MPV phase-cover data for the two
+nonzero-sector families.
+
+The Lean theorem added in this round is
+`MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_blockSpanConsequences_of_reindexedNonzeroParts`
+in `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`.  It starts
+from `SameMPV₂ A B` and the one-sided equality after relabeling blocked physical
+words used by
+`MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`.
+It then returns the common blocking length, the two zero-tail decompositions, the
+weighted common-sector nonzero families, and their trace-preserving, primitive,
+tensor-irreducible, positive-dimension, nonzero-weight, positive-length, and
+length-zero conclusions.
+
+For these exact common-sector families it records two conditional span
+consequences:
+
+- a common MPV phase cover gives the finite-length nonzero-block span equality by
+  `MPSTensor.MPVCommonPhaseCover.span_eq`;
+- a BNT proportional-decomposition conclusion gives the same span equality by
+  `MPSTensor.mpv_span_eq_of_proportionalDecompositionConclusion`.
+
+This is intentionally not an unconditional construction of the common phase
+cover.  The theorem exposes the two remaining mathematical inputs: the
+blocked-word coordinate equality tracked by #1075, and the final cross-side BNT
+matching or common-phase comparison for the common-sector families.
+
+## Relation to the paper proof
+
+The paper-level comparison uses a basis of normal tensors and then pairs the
+basis blocks by phase and gauge.  In the 2016 MPDO text this is stated in
+`Papers/1606.00608/MPDO-22-12-17-2.tex:278--280` for the BNT characterization,
+`350--352` for the proportional MPV theorem, and `355--357` for the equal-MPV
+corollary.  The appendix proof gives the block pairing explicitly at
+`Papers/1606.00608/MPDO-22-12-17-2.tex:1182`, where nonzero overlap identifies a
+basis tensor and then Lemma `equalMPS` supplies the phase and gauge.  The review
+version states the same chain at
+`Papers/2011.12127/TN-Review-main.tex:1852--1854`, `1892--1894`, and
+`1897--1900`.
+
+The new theorem formalizes the bookkeeping immediately before that comparison:
+after the common-length cyclic-sector construction has supplied the primitive
+irreducible nonzero-sector families, a common phase cover or the BNT
+proportional-decomposition data is exactly what is needed to obtain equality of
+the finite-length MPV spans.
+
+## Blueprint updates
+
+The theorem is recorded in
+`blueprint/src/chapter/ch11_assembly.tex` as
+`thm:after_blocking_common_primitive_irreducible_blocks_block_span_consequences`.
+The Ch. 8 open-direction remark now points to this theorem as the intermediate
+span consequence between the common-sector decomposition and the zero-tail sector
+comparison theorem.  The Ch. 11 equal-case remark states that this step remains
+conditional on the common phase cover or proportional-decomposition comparison.
+
+## Remaining inputs
+
+To apply `MPSTensor.afterBlocking_sectorComparison_zeroTail_of_blockSpan` to the
+common-sector output without an external span hypothesis, one still needs:
+
+1. the blocked-word coordinate equality of #1075, or an equivalent theorem that
+   supplies the `hReindexed` hypothesis for the weighted nonzero families;
+2. a common MPV phase cover or a BNT proportional-decomposition conclusion for
+   the chosen common-sector families;
+3. the injectivity hypotheses for the common-sector blocks after any required
+   further blocking;
+4. the zero-tail dimension equality required by the zero-tail block-span theorem.
+
+No Gemma-periodic fundamental theorem input is used here.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3537,7 +3537,12 @@ The following results separate the zero blocks from the nonzero blocks.
 	collects the resulting primitive irreducible sector decompositions needed for
 	comparison.  The remaining blocked-word assertion is the equality of these
 	words for the chosen coordinates, or an equivalent final comparison with the
-	relabeling made explicit.  Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	relabeling made explicit.
+	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_block_span_consequences}
+	records the intermediate span consequence for these common-sector families: a
+	common MPV phase cover or proportional-decomposition conclusion supplies the
+	finite-length nonzero-block span equality.
+	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
 	states the exact remaining inputs after this point: equality of the zero-tail
 	dimensions, injectivity at the chosen common length, and a common MPV phase cover
 	(or the equivalent finite-length span equality) for the two nonzero-sector

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1445,6 +1445,42 @@ two-basis sector comparison theorem.
 	isolated by the remaining coordinate equality for direct and iterated blocking.
 \end{definition}
 
+\begin{theorem}[Common-length sectors with conditional block-span consequences]%
+\label{thm:after_blocking_common_primitive_irreducible_blocks_block_span_consequences}
+	\lean{MPSTensor.afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts}
+	\leanok
+	\uses{def:common_sector_relabeling_hypothesis, def:same_mpv2_pos,
+		def:mpv_common_phase_cover}
+	Assume two tensors generate the same MPV family and assume the blocked-word
+	relabeling hypothesis used in the common-sector construction.  Then there is a
+	common blocking length at which both tensors have zero-tail decompositions whose
+	nonzero parts are weighted families of trace-preserving, primitive,
+	tensor-irreducible blocks with positive bond dimension and nonzero weights.  The
+	theorem further records the three positive-length MPV agreements
+	\(\mc{V}^{+}(\cdot)=\mc{V}^{+}(\cdot)\): the two agreements comparing each
+	blocked tensor with its own nonzero-sector part and the agreement comparing the
+	two nonzero-sector parts, together with the length-zero zero-tail identity, as
+	in
+	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}.
+	For these particular common-sector families, any common MPV phase cover gives
+	the finite-length nonzero-block span equality needed by the zero-tail block-span
+	theorem.  A BNT proportional-decomposition conclusion for the same families
+	gives the same span equality.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed,
+		lem:mpv_common_phase_cover_span_eq,
+		thm:nonzero_block_span_eq_of_proportional_decomposition}
+	Apply
+	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+	to obtain the common-sector decompositions.  The implication from a common MPV
+	phase cover is Lemma~\ref{lem:mpv_common_phase_cover_span_eq}; the implication
+	from proportional-decomposition data is
+	Theorem~\ref{thm:nonzero_block_span_eq_of_proportional_decomposition}.
+\end{proof}
+
 \begin{theorem}[Relabeled common sectors with a common MPV phase cover]%
 \label{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover}
@@ -1559,12 +1595,18 @@ two-basis sector comparison theorem.
 	relabeled cyclic-sector tensor for the whole weighted family.  With that
 	equality, Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	gives the common weighted nonzero-sector decompositions needed for the
-	comparison theorems.  Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
+	comparison theorems.
+	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
 	then records the remaining hypotheses in their present form: equality of the
 	zero-tail dimensions, injectivity of the common nonzero-sector blocks, and
-	finite-length MPV span equality.  Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
-	shows that a common MPV phase cover supplies that span equality and therefore
-	gives the same sector-weight conclusion.  Establishing these hypotheses is the
-	mathematical passage from equality of total MPV vectors to the componentwise
-	power-sum identities used in the paper proof of Corollary~IV.5.
+	finite-length MPV span equality.
+	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_block_span_consequences}
+	records the corresponding conditional span consequence for the common-sector
+	families themselves: a common MPV phase cover or a proportional-decomposition
+	conclusion supplies the finite-length nonzero-block span equality.
+	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	adds the zero-tail and injectivity data to the common phase-cover route and
+	therefore gives the same sector-weight conclusion.  Establishing these
+	hypotheses is the mathematical passage from equality of total MPV vectors to the
+	componentwise power-sum identities used in the paper proof of Corollary~IV.5.
 \end{remark}


### PR DESCRIPTION
## Summary

- add `MPSTensor.afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts`
- package the common-length cyclic-sector output together with the conditional finite-length block-span consequence
- record both routes to the span input: a common MPV phase cover, or a BNT proportional-decomposition conclusion for the same common-sector families
- update the Ch. 8/11 blueprint remarks and add an audit note spelling out the remaining dependencies (#1075, injectivity, zero-tail dimension equality, and final BNT/common-phase matching)

## Mathematical status

The exact common MPV phase cover is not constructed unconditionally here. The new theorem keeps the dependencies explicit: it assumes the blocked-word relabeling equality in the same form as `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`, and then shows that the common-sector witnesses it produces have the downstream `hBlockSpan` consequence as soon as either common phase-cover data or BNT proportional-decomposition data is supplied for those witnesses.

Partially addresses #1068.
Refs #970.
Refs #944.
Refs #652.
Refs #1075.

## Validation

- `lake exe cache get`
- `lake -Kjobs=1 build --old TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `lake -Kjobs=1 build --old TNLean`
- Lean diagnostics for `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- added-line proof/prose scans for placeholder tokens and banned common-sector prose

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new Lean theorem plus documentation/audit updates) and do not modify existing comparison logic, though they introduce a new interface that downstream proofs may start depending on.
> 
> **Overview**
> Adds `afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts`, bundling the existing common-sector (reindexed) decomposition witnesses with *conditional* ways to obtain the finite-length nonzero-block span equality needed by `afterBlocking_sectorComparison_zeroTail_of_blockSpan` (either from `MPVCommonPhaseCover` or from a `ProportionalDecompositionConclusion`).
> 
> Updates the blueprint (Ch. 8/11) to reference this intermediate span-consequence step, and adds an audit note documenting the remaining dependencies (blocked-word relabeling equality, injectivity, and zero-tail dimension equality).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3333774b994ee05946cc6c4d132ac06fffd592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->