### PR TITLE
feat(MPS/CanonicalForm): compose common-sector comparison

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -89,6 +89,43 @@ theorem of_commonPhaseCover
 
 end CommonPrimitiveSpanHypotheses
 
+/-- Remaining two-sided hypotheses for common primitive nonzero-sector families,
+formulated with a common MPV phase cover.
+
+This is the common-cover variant of `CommonPrimitiveSpanHypotheses`: the structural
+theorem supplies the same primitive nonzero-sector data, while the remaining inputs
+are equality of the zero-tail dimensions, one-site injectivity on both sides, and a
+common phase cover for the two block families. -/
+structure CommonPrimitivePhaseCoverHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (zeroTailA zeroTailB : ℕ)
+    (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x))
+    (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)) : Prop where
+  /-- The two zero-tail dimensions agree. -/
+  zeroTail_eq : zeroTailA = zeroTailB
+  /-- The left nonzero-sector blocks are one-site injective. -/
+  left_injective : ∀ x : Fin rA, IsInjective (blocksA x)
+  /-- The right nonzero-sector blocks are one-site injective. -/
+  right_injective : ∀ x : Fin rB, IsInjective (blocksB x)
+  /-- The two nonzero-sector block families admit a common MPV phase cover. -/
+  cover : Nonempty (MPVCommonPhaseCover blocksA blocksB)
+
+namespace CommonPrimitivePhaseCoverHypotheses
+
+/-- A common-cover hypothesis package supplies the span-hypothesis package. -/
+theorem toSpanHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {zeroTailA zeroTailB : ℕ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (h : CommonPrimitivePhaseCoverHypotheses zeroTailA zeroTailB blocksA blocksB) :
+    CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB := by
+  obtain ⟨cover⟩ := h.cover
+  exact CommonPrimitiveSpanHypotheses.of_commonPhaseCover
+    h.zeroTail_eq h.left_injective h.right_injective cover
+
+end CommonPrimitivePhaseCoverHypotheses
+
 /-- **Sector comparison from BNT proportional-decomposition data.**
 
 A proportional-decomposition comparison supplies a common MPV phase cover of the two
@@ -311,23 +348,6 @@ theorem afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover
     A B hSame hp μA blocksA μB blocksB hAblocks hBblocks hZeroTail hTPA hTPB
     hIrrA hIrrB hPrimA hPrimB hInjA hInjB hμA hμB (fun N => cover.span_eq N)
 
-/-- The one-sided blocked-word relabeling hypothesis for common cyclic sectors.
-
-It says that, for every common cyclic-sector family, the canonically blocked
-weighted nonzero tensor agrees as an MPV family with the same blocks read through
-the explicit relabeling of blocked physical words. This is the hypothesis isolated
-by the current blocked-word coordinate problem. -/
-abbrev CommonSectorRelabelingHypothesis (d : ℕ) : Prop :=
-  ∀ {r : ℕ} {dim : Fin r → ℕ}
-    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (F : CommonBlockedCyclicSectorFamily blocks),
-    SameMPV₂
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p)
-        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)
-
 /-- **Zero-tail sector comparison from BNT proportional-decomposition data.**
 
 This zero-tail-aware variant combines the exact nonzero part cancellation step with the BNT
@@ -404,15 +424,7 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHyp
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
-    (hReindexed : ∀ {r : ℕ} {dim : Fin r → ℕ}
-      (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
-      (F : CommonBlockedCyclicSectorFamily blocks),
-      SameMPV₂
-        (toTensorFromBlocks (d := blockPhysDim d F.p)
-          (μ := fun k : Fin r => (μ k) ^ F.p)
-          (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-        (toTensorFromBlocks (d := blockPhysDim d F.p)
-          (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock))
+    (hReindexed : CommonSectorRelabelingHypothesis d)
     (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
       {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
       {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
@@ -489,7 +501,7 @@ common positive blocking length and trace-preserving, primitive, irreducible
 nonzero-sector families on both sides.  If the remaining comparison assertions
 for exactly those families are available -- equality of the two zero-tail
 dimensions, injectivity at that blocking level, and a common MPV phase cover --
-then `CommonPrimitiveSpanHypotheses.of_commonPhaseCover` gives the span hypotheses
+then `CommonPrimitivePhaseCoverHypotheses.toSpanHypotheses` gives the span hypotheses
 needed by `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`.
 
 Thus this theorem isolates the remaining open inputs: the blocked-word relabeling
@@ -538,10 +550,7 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonP
       (∀ x, IsIrreducibleTensor (blocksB x)) →
       (∀ x, 0 < dimA x) →
       (∀ x, 0 < dimB x) →
-      zeroTailA = zeroTailB ∧
-        (∀ x, IsInjective (blocksA x)) ∧
-        (∀ x, IsInjective (blocksB x)) ∧
-        Nonempty (MPVCommonPhaseCover blocksA blocksB)) :
+      CommonPrimitivePhaseCoverHypotheses zeroTailA zeroTailB blocksA blocksB) :
     ∃ p' : ℕ, 0 < p' ∧
     ∃ P Q : SectorDecomposition (blockPhysDim d p'),
       SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
@@ -561,11 +570,7 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonP
   intro p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB hp
     hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
     hIrrA hIrrB hDimA hDimB
-  obtain ⟨hZeroTail, hInjA, hInjB, hCover⟩ :=
-    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
-      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
-  obtain ⟨cover⟩ := hCover
-  exact CommonPrimitiveSpanHypotheses.of_commonPhaseCover hZeroTail hInjA hInjB cover
-
+  exact (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+    hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toSpanHypotheses
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -112,7 +112,7 @@ structure CommonPrimitivePhaseCoverHypotheses
 
 namespace CommonPrimitivePhaseCoverHypotheses
 
-/-- A common-cover hypothesis package supplies the span-hypothesis package. -/
+/-- A common MPV phase cover hypothesis implies the corresponding span hypothesis. -/
 theorem toSpanHypotheses
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     {zeroTailA zeroTailB : ℕ}

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -22,6 +22,10 @@ BNT proportional-decomposition comparison of the nonzero-weight block families.
   finite-length MPV span equality for the nonzero part imply the sector-weight comparison.
 * `afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover` — zero-tail decompositions
   plus common MPV phase-cover data imply the same sector-weight comparison.
+* `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover` — the
+  common-length cyclic-sector output, together with the blocked-word relabeling
+  equality and the remaining zero-tail, injectivity, and common-cover assertions,
+  implies the sector-weight comparison.
 * `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion` —
   the zero-tail common-cover theorem applied to BNT proportional-decomposition data.
 * `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses` —
@@ -307,6 +311,23 @@ theorem afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover
     A B hSame hp μA blocksA μB blocksB hAblocks hBblocks hZeroTail hTPA hTPB
     hIrrA hIrrB hPrimA hPrimB hInjA hInjB hμA hμB (fun N => cover.span_eq N)
 
+/-- The one-sided blocked-word relabeling hypothesis for common cyclic sectors.
+
+It says that, for every common cyclic-sector family, the canonically blocked
+weighted nonzero tensor agrees as an MPV family with the same blocks read through
+the explicit relabeling of blocked physical words. This is the hypothesis isolated
+by the current blocked-word coordinate problem. -/
+abbrev CommonSectorRelabelingHypothesis (d : ℕ) : Prop :=
+  ∀ {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks),
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)
+
 /-- **Zero-tail sector comparison from BNT proportional-decomposition data.**
 
 This zero-tail-aware variant combines the exact nonzero part cancellation step with the BNT
@@ -458,5 +479,93 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHyp
     A B hSame hp μA blocksA μB blocksB hAblocks hBblocks hHyp.zeroTail_eq hTPA hTPB
     hIrrA hIrrB hPrimA hPrimB hHyp.left_injective hHyp.right_injective
     hμA hμB hHyp.span_eq
+
+/-- **Sector comparison from relabeled common sectors and a common phase cover.**
+
+Assume the blocked-word relabeling statement for common cyclic sectors.  Then the
+structural theorem
+`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` supplies one
+common positive blocking length and trace-preserving, primitive, irreducible
+nonzero-sector families on both sides.  If the remaining comparison assertions
+for exactly those families are available -- equality of the two zero-tail
+dimensions, injectivity at that blocking level, and a common MPV phase cover --
+then `CommonPrimitiveSpanHypotheses.of_commonPhaseCover` gives the span hypotheses
+needed by `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`.
+
+Thus this theorem isolates the remaining open inputs: the blocked-word relabeling
+equality, the zero-tail/injectivity refinements, and the common phase cover (or
+equivalently the finite-length span equality supplied by that cover). -/
+theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      zeroTailA = zeroTailB ∧
+        (∀ x, IsInjective (blocksA x)) ∧
+        (∀ x, IsInjective (blocksB x)) ∧
+        Nonempty (MPVCommonPhaseCover blocksA blocksB)) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  refine afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses
+    A B hSame hReindexed ?_
+  intro p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB hp
+    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
+    hIrrA hIrrB hDimA hDimB
+  obtain ⟨hZeroTail, hInjA, hInjB, hCover⟩ :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  obtain ⟨cover⟩ := hCover
+  exact CommonPrimitiveSpanHypotheses.of_commonPhaseCover hZeroTail hInjA hInjB cover
+
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1062,6 +1062,23 @@ theorem zeroTail_commonFlat_transport_of_reindexed
   · intro x
     exact F.commonFlatWeight_ne_zero μ hμ x
 
+/-- The one-sided blocked-word relabeling hypothesis for common cyclic sectors.
+
+It says that, for every common cyclic-sector family, the canonically blocked
+weighted nonzero tensor agrees as an MPV family with the same blocks read through
+the explicit relabeling of blocked physical words. This is the hypothesis isolated
+by the current blocked-word coordinate problem. -/
+abbrev CommonSectorRelabelingHypothesis (d : ℕ) : Prop :=
+  ∀ {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks),
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)
+
 set_option maxHeartbeats 800000 in
 -- The conclusion records both decompositions and all their structural hypotheses together.
 /-- **Common primitive irreducible block decompositions after blocked-word reindexing.**
@@ -1082,15 +1099,7 @@ theorem afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
-    (hReindexed : ∀ {r : ℕ} {dim : Fin r → ℕ}
-      (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
-      (F : CommonBlockedCyclicSectorFamily blocks),
-      SameMPV₂
-        (toTensorFromBlocks (d := blockPhysDim d F.p)
-          (μ := fun k : Fin r => (μ k) ^ F.p)
-          (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-        (toTensorFromBlocks (d := blockPhysDim d F.p)
-          (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
+    (hReindexed : CommonSectorRelabelingHypothesis d) :
     ∃ p : ℕ, 0 < p ∧
     ∃ (zeroTailA zeroTailB : ℕ),
     ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3514,14 +3514,13 @@ The following results separate the zero blocks from the nonzero blocks.
 	collects the resulting primitive irreducible sector decompositions needed for
 	comparison.  The remaining blocked-word assertion is the equality of these
 	words for the chosen coordinates, or an equivalent final comparison with the
-	reindexing made explicit.  Once the common-length sectors have also been
-	blocked far enough to be injective, a BNT proportional-decomposition comparison
-	gives the block permutation, the bond-dimension equalities, and the gauge phases.
-	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion}
-	then turns that comparison into the finite-length MPV span equality and the
-	sector-weight conclusion.  Thus the open canonical-form assertions are the
-	blocked-word relabeling equality for the whole weighted nonzero family, the
-	injectivity of a suitable further blocking, and the proportional-decomposition
+	relabeling made explicit.  Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	states the exact remaining inputs after this point: equality of the zero-tail
+	dimensions, injectivity at the chosen common length, and a common MPV phase cover
+	(or the equivalent finite-length span equality) for the two nonzero-sector
+	families.  Thus the open canonical-form assertions are the blocked-word
+	relabeling equality for the whole weighted nonzero family, the zero-tail and
+	injectivity refinements, and the common-phase or proportional-decomposition
 	comparison for the common-length nonzero sectors.
 
 	The sorted normal-canonical-form theorem,

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1401,6 +1401,42 @@ two-basis sector comparison theorem.
 	zero-tail block-span comparison theorem.
 \end{proof}
 
+\begin{definition}[Blocked-word relabeling hypothesis for common sectors]%
+\label{def:common_sector_relabeling_hypothesis}
+	\lean{MPSTensor.CommonSectorRelabelingHypothesis}
+	\leanok
+	This is the one-sided assertion that the canonically blocked weighted nonzero
+	part agrees, as an MPV family, with the same common cyclic-sector family after
+	the explicit relabeling of blocked physical words. It is the formal hypothesis
+	isolated by the remaining coordinate equality for direct and iterated blocking.
+\end{definition}
+
+\begin{theorem}[Relabeled common sectors with a common MPV phase cover]%
+\label{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover}
+	\leanok
+	\uses{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses,
+		thm:common_primitive_span_hypotheses_of_common_phase_cover,
+		def:common_sector_relabeling_hypothesis}
+	Let $A$ and $B$ have the same MPV family.  Assume the blocked-word relabeling
+	hypothesis for common cyclic sectors.  The common-sector structural theorem then
+	produces a common blocking length, zero-tail identities, and trace-preserving,
+	primitive, irreducible nonzero-sector families on both sides.  If the two
+	zero-tail dimensions agree, the blocks are injective at that length, and the two
+	families have a common MPV phase cover, then the sector decompositions obtained
+	from the two sides have BNT data, agree as full MPV families, and their sector
+	weights satisfy the matched sector-weight conclusion.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses,
+		thm:common_primitive_span_hypotheses_of_common_phase_cover}
+	Use the common phase cover to form the remaining span hypotheses of
+	Definition~\ref{def:common_primitive_span_hypotheses}.  Then apply the
+	relabeled common-sector theorem with those span hypotheses.
+\end{proof}
+
 \begin{theorem}[Cast-compatible MPV scaling implies phase-matched sector comparison]%
 \label{thm:route_b_hetero_mpv_scaling}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis}
@@ -1492,8 +1528,9 @@ two-basis sector comparison theorem.
 	comparison theorems.  Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
 	then records the remaining hypotheses in their present form: equality of the
 	zero-tail dimensions, injectivity of the common nonzero-sector blocks, and
-	either finite-length MPV span equality or a common phase cover for those
-	blocks.  Establishing these hypotheses is the mathematical passage from
-	equality of total MPV vectors to the componentwise power-sum identities used in
-	the paper proof of Corollary~IV.5.
+	finite-length MPV span equality.  Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	shows that a common MPV phase cover supplies that span equality and therefore
+	gives the same sector-weight conclusion.  Establishing these hypotheses is the
+	mathematical passage from equality of total MPV vectors to the componentwise
+	power-sum identities used in the paper proof of Corollary~IV.5.
 \end{remark}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1318,6 +1318,41 @@ two-basis sector comparison theorem.
 	Lemma~\ref{lem:mpv_common_phase_cover_span_eq}.
 \end{proof}
 
+\begin{definition}[Remaining phase-cover hypotheses for common primitive sectors]%
+\label{def:common_primitive_phase_cover_hypotheses}
+	\lean{MPSTensor.CommonPrimitivePhaseCoverHypotheses}
+	\leanok
+	\uses{def:mpv_common_phase_cover, def:injective}
+	For two common primitive nonzero-sector families at one blocking length, this
+	condition records the phase-cover version of
+	Definition~\ref{def:common_primitive_span_hypotheses}: equality of the two
+	zero-tail dimensions, one-site injectivity of all blocks on both sides, and a
+	common MPV phase cover for the two block families.
+\end{definition}
+
+\begin{theorem}[Phase-cover hypotheses imply the remaining span hypotheses]%
+\label{thm:common_primitive_phase_cover_hypotheses_to_span_hypotheses}
+	\lean{MPSTensor.CommonPrimitivePhaseCoverHypotheses.toSpanHypotheses}
+	\leanok
+	\uses{def:common_primitive_phase_cover_hypotheses,
+		def:common_primitive_span_hypotheses,
+		thm:common_primitive_span_hypotheses_of_common_phase_cover}
+	If two common primitive nonzero-sector families satisfy the phase-cover
+	hypotheses of
+	Definition~\ref{def:common_primitive_phase_cover_hypotheses}, then they
+	satisfy the remaining span hypotheses of
+	Definition~\ref{def:common_primitive_span_hypotheses}.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_primitive_span_hypotheses_of_common_phase_cover}
+	The zero-tail equality and the two injectivity assertions are already part of
+	the phase-cover hypotheses.  Apply
+	Theorem~\ref{thm:common_primitive_span_hypotheses_of_common_phase_cover} to a
+	common MPV phase cover for the two block families.
+\end{proof}
+
 \begin{theorem}[Zero-tail nonzero block decompositions with a common MPV phase cover]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
@@ -1416,23 +1451,24 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover}
 	\leanok
 	\uses{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses,
-		thm:common_primitive_span_hypotheses_of_common_phase_cover,
+		def:common_primitive_phase_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis}
 	Let $A$ and $B$ have the same MPV family.  Assume the blocked-word relabeling
 	hypothesis for common cyclic sectors.  The common-sector structural theorem then
 	produces a common blocking length, zero-tail identities, and trace-preserving,
-	primitive, irreducible nonzero-sector families on both sides.  If the two
-	zero-tail dimensions agree, the blocks are injective at that length, and the two
-	families have a common MPV phase cover, then the sector decompositions obtained
-	from the two sides have BNT data, agree as full MPV families, and their sector
-	weights satisfy the matched sector-weight conclusion.
+	primitive, irreducible nonzero-sector families on both sides.  If those
+	families satisfy the phase-cover hypotheses of
+	Definition~\ref{def:common_primitive_phase_cover_hypotheses}, then the sector
+	decompositions obtained from the two sides have BNT data, agree as full MPV
+	families, and their sector weights satisfy the matched sector-weight conclusion.
 \end{theorem}
 
 \begin{proof}
 	\leanok
 	\uses{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses,
-		thm:common_primitive_span_hypotheses_of_common_phase_cover}
-	Use the common phase cover to form the remaining span hypotheses of
+		thm:common_primitive_phase_cover_hypotheses_to_span_hypotheses}
+	Use Theorem~\ref{thm:common_primitive_phase_cover_hypotheses_to_span_hypotheses}
+	to form the remaining span hypotheses of
 	Definition~\ref{def:common_primitive_span_hypotheses}.  Then apply the
 	relabeled common-sector theorem with those span hypotheses.
 \end{proof}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1335,8 +1335,7 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.CommonPrimitivePhaseCoverHypotheses.toSpanHypotheses}
 	\leanok
 	\uses{def:common_primitive_phase_cover_hypotheses,
-		def:common_primitive_span_hypotheses,
-		thm:common_primitive_span_hypotheses_of_common_phase_cover}
+		def:common_primitive_span_hypotheses}
 	If two common primitive nonzero-sector families satisfy the phase-cover
 	hypotheses of
 	Definition~\ref{def:common_primitive_phase_cover_hypotheses}, then they
@@ -1450,8 +1449,7 @@ two-basis sector comparison theorem.
 \label{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover}
 	\leanok
-	\uses{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses,
-		def:common_primitive_phase_cover_hypotheses,
+	\uses{def:common_primitive_phase_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis}
 	Let $A$ and $B$ have the same MPV family.  Assume the blocked-word relabeling
 	hypothesis for common cyclic sectors.  The common-sector structural theorem then


### PR DESCRIPTION
## Summary

- Adds `CommonSectorRelabelingHypothesis` for the one-sided blocked-word relabeling statement isolated by #1075.
- Adds `CommonPrimitiveIrreducibleSectorCompletion`, recording the exact remaining data after the common-sector structural theorem: zero-tail equality, injectivity, and a common MPV phase cover.
- Proves `afterBlocking_sectorComparison_of_reindexedNonzeroParts_commonPhaseCover`, composing the newly merged common primitive irreducible block theorem with the zero-tail common-cover sector comparison.
- Updates the Ch. 8/11 blueprint remarks to state the remaining non-Gemma inputs precisely.

Refs #652. Refs #924. Related: #1075, #1068, #944.

## Validation

- `lake build TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `lake build TNLean.MPS.CanonicalForm.Assembly`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- Lean diagnostics clean for `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`

Note: `cd blueprint && leanblueprint web` was attempted locally, but the TN diagram SVG helper fails under this workspace path because the absolute path contains a space; the failure occurs while compiling a pre-existing TikZ macro (`\\TNMPSLocal{A}{i}`), before reaching these edited statements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely additive/refactoring changes to formal Lean statements/proofs and blueprint docs, with no runtime or external-facing behavior; main risk is proof breakage due to changed hypothesis interfaces.
> 
> **Overview**
> Adds a named `CommonSectorRelabelingHypothesis` to package the one-sided blocked-word relabeling condition used by the common-sector structural theorem, and updates downstream theorems to take this single hypothesis instead of an inlined binder.
> 
> Introduces `CommonPrimitivePhaseCoverHypotheses` plus a conversion lemma to span-based hypotheses, and uses it to prove a new composition theorem `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover`, deriving the sector-weight comparison from the relabeled common-sector output together with zero-tail equality, injectivity, and a common MPV phase cover.
> 
> Updates the blueprint (Ch. 8/11) to document the new hypothesis names and the new composed comparison theorem as the precise remaining inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe4b6225d9d8c9b910eb5c6fc97a109d54dbee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->