### PR TITLE
feat(PEPS): add edge-blocked middle coefficient

### DIFF
--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -255,5 +255,276 @@ theorem stateCoeff_splitAtEdge (A : Tensor G d) (e : Edge G) (σ : V → Fin d) 
   intro η _
   exact prod_univ_splitAtEdge e (fun v : V => A.component v (fun ie => η ie.1) (σ v))
 
+/-- Boundary virtual data for the edge-centered three-block decomposition.
+
+For an edge `e = (u, w)`, this records the index on `e`, the residual indices on
+edges incident to `u` other than `e`, and the residual indices on edges incident
+to `w` other than `e`. The middle-region contraction below is fibred over this
+data. -/
+structure EdgeBoundaryConfig (A : Tensor G d) (e : Edge G) where
+  edgeIndex : Fin (A.bondDim e)
+  leftResidual : ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e)
+  rightResidual : ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e)
+
+/-- Product model for edge-centered boundary configurations. -/
+def edgeBoundaryConfigEquivProd (A : Tensor G d) (e : Edge G) :
+    EdgeBoundaryConfig (G := G) A e ≃
+      Fin (A.bondDim e) ×
+        ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e) ×
+        ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e) where
+  toFun β := (β.edgeIndex, β.leftResidual, β.rightResidual)
+  invFun x :=
+    { edgeIndex := x.1
+      leftResidual := x.2.1
+      rightResidual := x.2.2 }
+  left_inv β := by
+    cases β
+    rfl
+  right_inv x := by
+    rcases x with ⟨edgeIndex, leftResidual, rightResidual⟩
+    rfl
+
+noncomputable instance instFintypeEdgeBoundaryConfig (A : Tensor G d) (e : Edge G) :
+    Fintype (EdgeBoundaryConfig (G := G) A e) :=
+  Fintype.ofEquiv
+    (Fin (A.bondDim e) ×
+      ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e) ×
+      ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e))
+    (edgeBoundaryConfigEquivProd (G := G) A e).symm
+
+/-- The local virtual configuration at the left endpoint determined by an
+edge-centered boundary configuration. -/
+noncomputable def edgeLeftLocalConfig (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e) : LocalVirtualConfig A e.1.1 :=
+  (localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e)).symm
+    (β.edgeIndex, β.leftResidual)
+
+/-- The local virtual configuration at the right endpoint determined by an
+edge-centered boundary configuration. -/
+noncomputable def edgeRightLocalConfig (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e) : LocalVirtualConfig A e.1.2 :=
+  (localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e)).symm
+    (β.edgeIndex, β.rightResidual)
+
+omit [Fintype V] in
+@[simp] theorem edgeLeftLocalConfig_edgeIndex (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e) :
+    edgeLeftLocalConfig (G := G) A e β (edgeLeftIncident (G := G) e) =
+      β.edgeIndex := by
+  simpa [edgeLeftLocalConfig] using
+    localVirtualConfigSplitAt_symm_apply_fst (G := G) A (edgeLeftIncident (G := G) e)
+      (β.edgeIndex, β.leftResidual)
+
+omit [Fintype V] in
+@[simp] theorem edgeRightLocalConfig_edgeIndex (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e) :
+    edgeRightLocalConfig (G := G) A e β (edgeRightIncident (G := G) e) =
+      β.edgeIndex := by
+  simpa [edgeRightLocalConfig] using
+    localVirtualConfigSplitAt_symm_apply_fst (G := G) A (edgeRightIncident (G := G) e)
+      (β.edgeIndex, β.rightResidual)
+
+omit [Fintype V] in
+@[simp] theorem edgeLeftLocalConfig_residual (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e)
+    (ie : OtherIncidentEdge (G := G) e.1.1 (edgeLeftIncident (G := G) e)) :
+    edgeLeftLocalConfig (G := G) A e β ie.1 = β.leftResidual ie := by
+  simpa [edgeLeftLocalConfig] using
+    localVirtualConfigSplitAt_symm_apply_snd (G := G) A (edgeLeftIncident (G := G) e)
+      (β.edgeIndex, β.leftResidual) ie
+
+omit [Fintype V] in
+@[simp] theorem edgeRightLocalConfig_residual (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e)
+    (ie : OtherIncidentEdge (G := G) e.1.2 (edgeRightIncident (G := G) e)) :
+    edgeRightLocalConfig (G := G) A e β ie.1 = β.rightResidual ie := by
+  simpa [edgeRightLocalConfig] using
+    localVirtualConfigSplitAt_symm_apply_snd (G := G) A (edgeRightIncident (G := G) e)
+      (β.edgeIndex, β.rightResidual) ie
+
+/-- A global virtual configuration has prescribed edge-centered boundary data if
+it agrees with the distinguished edge index and both residual endpoint families. -/
+def edgeBoundaryMatches (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e) (η : VirtualConfig A) : Prop :=
+  η e = β.edgeIndex ∧
+    (∀ ie : OtherIncidentEdge (G := G) e.1.1 (edgeLeftIncident (G := G) e),
+      η ie.1.1 = β.leftResidual ie) ∧
+    (∀ ie : OtherIncidentEdge (G := G) e.1.2 (edgeRightIncident (G := G) e),
+      η ie.1.1 = β.rightResidual ie)
+
+/-- Global virtual configurations whose endpoint boundary data are fixed. These
+are the internal summation variables of the blocked middle tensor. -/
+abbrev EdgeMiddleConfig (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e) : Type _ :=
+  {η : VirtualConfig A // edgeBoundaryMatches (G := G) A e β η}
+
+noncomputable instance instFintypeEdgeMiddleConfig (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e) : Fintype (EdgeMiddleConfig (G := G) A e β) := by
+  classical
+  infer_instance
+
+/-- Read the edge-centered boundary data from a global virtual configuration. -/
+def edgeBoundaryOfVirtualConfig (A : Tensor G d) (e : Edge G)
+    (η : VirtualConfig A) : EdgeBoundaryConfig (G := G) A e where
+  edgeIndex := η e
+  leftResidual ie := η ie.1.1
+  rightResidual ie := η ie.1.1
+
+omit [Fintype V] in
+@[simp] theorem edgeBoundaryOfVirtualConfig_matches (A : Tensor G d) (e : Edge G)
+    (η : VirtualConfig A) :
+    edgeBoundaryMatches (G := G) A e (edgeBoundaryOfVirtualConfig (G := G) A e η) η := by
+  simp [edgeBoundaryMatches, edgeBoundaryOfVirtualConfig]
+
+/-- Global virtual configurations are equivalent to choosing their edge-centered
+boundary data together with a middle configuration in the corresponding fibre. -/
+noncomputable def virtualConfigEquivEdgeBoundary (A : Tensor G d) (e : Edge G) :
+    VirtualConfig A ≃
+      (Σ β : EdgeBoundaryConfig (G := G) A e, EdgeMiddleConfig (G := G) A e β) where
+  toFun η :=
+    ⟨edgeBoundaryOfVirtualConfig (G := G) A e η,
+      ⟨η, edgeBoundaryOfVirtualConfig_matches (G := G) A e η⟩⟩
+  invFun x := x.2.1
+  left_inv _ := rfl
+  right_inv x := by
+    rcases x with ⟨β, η, hη⟩
+    have hβ : edgeBoundaryOfVirtualConfig (G := G) A e η = β := by
+      rcases β with ⟨edgeIndex, leftResidual, rightResidual⟩
+      have hleft :
+          (fun ie : OtherIncidentEdge (G := G) e.1.1 (edgeLeftIncident (G := G) e) =>
+            η ie.1.1) = leftResidual := funext hη.2.1
+      have hright :
+          (fun ie : OtherIncidentEdge (G := G) e.1.2 (edgeRightIncident (G := G) e) =>
+            η ie.1.1) = rightResidual := funext hη.2.2
+      cases hη.1
+      cases hleft
+      cases hright
+      rfl
+    subst β
+    simp
+
+omit [Fintype V] in
+/-- The left endpoint local configuration obtained from a matching global virtual
+configuration is the one reconstructed from its boundary data. -/
+theorem edgeLeftLocalConfig_eq_of_boundaryMatches (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e) (η : VirtualConfig A)
+    (hη : edgeBoundaryMatches (G := G) A e β η) :
+    (fun ie : IncidentEdge G e.1.1 => η ie.1) = edgeLeftLocalConfig (G := G) A e β := by
+  funext ie
+  by_cases hie : ie = edgeLeftIncident (G := G) e
+  · subst ie
+    rw [edgeLeftLocalConfig_edgeIndex]
+    exact hη.1
+  · calc
+      η ie.1 = β.leftResidual ⟨ie, hie⟩ := hη.2.1 ⟨ie, hie⟩
+      _ = edgeLeftLocalConfig (G := G) A e β ie := by
+        simpa using (edgeLeftLocalConfig_residual (G := G) A e β ⟨ie, hie⟩).symm
+
+omit [Fintype V] in
+/-- The right endpoint local configuration obtained from a matching global
+virtual configuration is the one reconstructed from its boundary data. -/
+theorem edgeRightLocalConfig_eq_of_boundaryMatches (A : Tensor G d) (e : Edge G)
+    (β : EdgeBoundaryConfig (G := G) A e) (η : VirtualConfig A)
+    (hη : edgeBoundaryMatches (G := G) A e β η) :
+    (fun ie : IncidentEdge G e.1.2 => η ie.1) = edgeRightLocalConfig (G := G) A e β := by
+  funext ie
+  by_cases hie : ie = edgeRightIncident (G := G) e
+  · subst ie
+    rw [edgeRightLocalConfig_edgeIndex]
+    exact hη.1
+  · calc
+      η ie.1 = β.rightResidual ⟨ie, hie⟩ := hη.2.2 ⟨ie, hie⟩
+      _ = edgeRightLocalConfig (G := G) A e β ie := by
+        simpa using (edgeRightLocalConfig_residual (G := G) A e β ⟨ie, hie⟩).symm
+
+/-- The blocked middle tensor for an edge-centered decomposition, evaluated on a
+physical configuration and fixed endpoint boundary data. -/
+noncomputable def edgeMiddleWeight (A : Tensor G d) (e : Edge G) (σ : V → Fin d)
+    (β : EdgeBoundaryConfig (G := G) A e) : ℂ :=
+  ∑ η : EdgeMiddleConfig (G := G) A e β,
+    ∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η.1 ie.1) (σ v)
+
+/-- The PEPS coefficient written as a three-block contraction at the edge `e`: the
+left endpoint tensor, the blocked middle tensor, and the right endpoint tensor. -/
+noncomputable def edgeBlockedCoeff (A : Tensor G d) (e : Edge G) (σ : V → Fin d) : ℂ :=
+  ∑ β : EdgeBoundaryConfig (G := G) A e,
+    A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+      edgeMiddleWeight (G := G) A e σ β *
+      A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)
+
+/-- The edge-blocked coefficient is exactly the original PEPS coefficient. This is
+the algebraic form of the edge-centered blocking step before applying the
+three-site MPS fundamental theorem. -/
+theorem edgeBlockedCoeff_eq_stateCoeff (A : Tensor G d) (e : Edge G) (σ : V → Fin d) :
+    edgeBlockedCoeff (G := G) A e σ = stateCoeff A σ := by
+  classical
+  rw [stateCoeff_splitAtEdge]
+  change
+    (∑ β : EdgeBoundaryConfig (G := G) A e,
+        A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+          (∑ η : EdgeMiddleConfig (G := G) A e β,
+            ∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η.1 ie.1) (σ v)) *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)) =
+      ∑ η : VirtualConfig A,
+        A.component e.1.1 (fun ie => η ie.1) (σ e.1.1) *
+          (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η ie.1) (σ v)) *
+          A.component e.1.2 (fun ie => η ie.1) (σ e.1.2)
+  calc
+    (∑ β : EdgeBoundaryConfig (G := G) A e,
+        A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+          (∑ η : EdgeMiddleConfig (G := G) A e β,
+            ∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η.1 ie.1) (σ v)) *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2))
+      = ∑ β : EdgeBoundaryConfig (G := G) A e,
+          ∑ η : EdgeMiddleConfig (G := G) A e β,
+            A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+              (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η.1 ie.1) (σ v)) *
+              A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2) := by
+        refine Finset.sum_congr rfl ?_
+        intro β _
+        rw [Finset.mul_sum, Finset.sum_mul]
+    _ = ∑ x : (Σ β : EdgeBoundaryConfig (G := G) A e, EdgeMiddleConfig (G := G) A e β),
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e x.1) (σ e.1.1) *
+            (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => x.2.1 ie.1) (σ v)) *
+            A.component e.1.2 (edgeRightLocalConfig (G := G) A e x.1) (σ e.1.2) := by
+        rw [← Fintype.sum_sigma']
+    _ = ∑ η : VirtualConfig A,
+          A.component e.1.1 (fun ie => η ie.1) (σ e.1.1) *
+            (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η ie.1) (σ v)) *
+            A.component e.1.2 (fun ie => η ie.1) (σ e.1.2) := by
+        let φ := virtualConfigEquivEdgeBoundary (G := G) A e
+        let F : (Σ β : EdgeBoundaryConfig (G := G) A e,
+            EdgeMiddleConfig (G := G) A e β) → ℂ := fun x =>
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e x.1) (σ e.1.1) *
+            (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => x.2.1 ie.1) (σ v)) *
+            A.component e.1.2 (edgeRightLocalConfig (G := G) A e x.1) (σ e.1.2)
+        calc
+          (∑ x : (Σ β : EdgeBoundaryConfig (G := G) A e,
+              EdgeMiddleConfig (G := G) A e β), F x)
+            = ∑ η : VirtualConfig A, F (φ η) := by
+              exact (φ.sum_comp F).symm
+          _ = ∑ η : VirtualConfig A,
+              A.component e.1.1 (fun ie => η ie.1) (σ e.1.1) *
+                (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η ie.1) (σ v)) *
+                A.component e.1.2 (fun ie => η ie.1) (σ e.1.2) := by
+              refine Finset.sum_congr rfl ?_
+              intro η _
+              have hmatch : edgeBoundaryMatches (G := G) A e
+                  (edgeBoundaryOfVirtualConfig (G := G) A e η) η := by
+                simp
+              have hleft := edgeLeftLocalConfig_eq_of_boundaryMatches
+                (G := G) A e (edgeBoundaryOfVirtualConfig (G := G) A e η) η hmatch
+              have hright := edgeRightLocalConfig_eq_of_boundaryMatches
+                (G := G) A e (edgeBoundaryOfVirtualConfig (G := G) A e η) η hmatch
+              simp [F, φ, virtualConfigEquivEdgeBoundary, hleft.symm, hright.symm]
+
+/-- Equality of PEPS states gives equality of the corresponding edge-blocked
+three-block coefficients at every edge. -/
+theorem SameState.edgeBlockedCoeff_eq {A B : Tensor G d} (hAB : SameState A B)
+    (e : Edge G) (σ : V → Fin d) :
+    edgeBlockedCoeff (G := G) A e σ = edgeBlockedCoeff (G := G) B e σ := by
+  rw [edgeBlockedCoeff_eq_stateCoeff, edgeBlockedCoeff_eq_stateCoeff]
+  exact hAB σ
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -284,7 +284,7 @@ def edgeBoundaryConfigEquivProd (A : Tensor G d) (e : Edge G) :
     rcases x with ⟨edgeIndex, leftResidual, rightResidual⟩
     rfl
 
-noncomputable instance instFintypeEdgeBoundaryConfig (A : Tensor G d) (e : Edge G) :
+instance instFintypeEdgeBoundaryConfig (A : Tensor G d) (e : Edge G) :
     Fintype (EdgeBoundaryConfig (G := G) A e) :=
   Fintype.ofEquiv
     (Fin (A.bondDim e) ×
@@ -459,23 +459,15 @@ theorem edgeBlockedCoeff_eq_stateCoeff (A : Tensor G d) (e : Edge G) (σ : V →
     edgeBlockedCoeff (G := G) A e σ = stateCoeff A σ := by
   classical
   rw [stateCoeff_splitAtEdge]
-  change
-    (∑ β : EdgeBoundaryConfig (G := G) A e,
-        A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
-          (∑ η : EdgeMiddleConfig (G := G) A e β,
-            ∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η.1 ie.1) (σ v)) *
-          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)) =
-      ∑ η : VirtualConfig A,
-        A.component e.1.1 (fun ie => η ie.1) (σ e.1.1) *
-          (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η ie.1) (σ v)) *
-          A.component e.1.2 (fun ie => η ie.1) (σ e.1.2)
   calc
-    (∑ β : EdgeBoundaryConfig (G := G) A e,
-        A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
-          (∑ η : EdgeMiddleConfig (G := G) A e β,
-            ∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η.1 ie.1) (σ v)) *
-          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2))
+    edgeBlockedCoeff (G := G) A e σ
       = ∑ β : EdgeBoundaryConfig (G := G) A e,
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+            (∑ η : EdgeMiddleConfig (G := G) A e β,
+              ∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η.1 ie.1) (σ v)) *
+            A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2) := by
+          rfl
+    _ = ∑ β : EdgeBoundaryConfig (G := G) A e,
           ∑ η : EdgeMiddleConfig (G := G) A e β,
             A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
               (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => η.1 ie.1) (σ v)) *

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -20,10 +20,11 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 --   reduction from arXiv:1804.04964 §3. The local left inverse and the
 --   elementary blocking data are developed in `PEPS/VirtualInsertion` and
 --   `PEPS/Blocking`, and `localGauge_exists` has been reduced to the sharper
---   local hypothesis `HasLocalGaugeLift`. The abbreviation `BlockedMiddleGaugeHyp`
---   isolates the exact remaining step: build the blocked middle tensor,
---   compare it with the 3-site MPS theorem, and derive that explicit local
---   gauge formula from `SameState`.
+--   local hypothesis `HasLocalGaugeLift`. The edge-blocked coefficient and
+--   middle tensor are developed in `PEPS/Blocking`; the abbreviation
+--   `BlockedMiddleGaugeHyp` isolates the remaining step: compare that
+--   three-block contraction with the 3-site MPS theorem and derive the explicit
+--   local gauge formula from `SameState`.
 -- * The `hDim` step inside `fundamentalTheorem_PEPS` (issue #874) is now
 --   factored out as the conditional theorem `fundamentalTheorem_PEPS_of_bondDim`
 --   so that the bond-dimension obligation is orthogonal to `gaugeConsistency`.
@@ -502,8 +503,9 @@ factorized local gauge relation at `v`.
 
 The local left inverse and the canonical candidate operator are defined in
 `PEPS/LocalGauge`. The remaining PEPS-Fundamental-Theorem gap is to prove
-`BlockedMiddleGaugeHyp` from `SameState` via the blocked-middle / three-site-MPS
-reduction, then convert it to `HasLocalGaugeLift` by
+`BlockedMiddleGaugeHyp` from `SameState` by comparing the edge-blocked
+coefficient from `PEPS/Blocking` with the three-site MPS reduction, then convert
+it to `HasLocalGaugeLift` by
 `hasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
 theorem localGauge_exists (A B : Tensor G d)
     (hA : IsVertexInjective A)
@@ -536,7 +538,8 @@ theorem gaugeConsistency (A B : Tensor G d)
         B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
           gaugeVertex A X v η σ := by
   -- TODO: first derive `BlockedMiddleGaugeHyp A B hA hDim v` from `SameState`
-  -- at each vertex via the blocked-middle / three-site-MPS reduction, then use
+  -- at each vertex by comparing the edge-blocked coefficient from `PEPS/Blocking`
+  -- with the three-site MPS reduction, then use
   -- `hasLocalGaugeLift_of_blockedMiddleGaugeHyp` to obtain the local gauges.
   -- The key remaining consistency step is: for each edge e = (u,v), the gauges
   -- extracted from u and v must agree as inverse-transposes, with the

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -286,11 +286,90 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     endpoint tensors couple to the blocked middle region.
 \end{definition}
 
+\begin{definition}[Boundary data read from a virtual configuration]%
+    \label{def:peps_edgeBoundaryOfVirtualConfig}
+    \lean{TNLean.PEPS.edgeBoundaryOfVirtualConfig}
+    \leanok
+    \uses{def:peps_edgeBoundaryConfig, def:peps_virtual_config}
+    A global virtual configuration determines edge-centered boundary data by
+    reading the index on the distinguished edge and the residual endpoint
+    indices.
+\end{definition}
+
+\begin{definition}[Boundary compatibility at an edge]%
+    \label{def:peps_edgeBoundaryMatches}
+    \lean{TNLean.PEPS.edgeBoundaryMatches}
+    \leanok
+    \uses{def:peps_edgeBoundaryConfig, def:peps_virtual_config}
+    A global virtual configuration is compatible with fixed edge-centered
+    boundary data if it has the prescribed index on the distinguished edge and
+    the prescribed residual indices at both endpoint stars.
+\end{definition}
+
+\begin{definition}[Middle configurations over fixed boundary data]%
+    \label{def:peps_edgeMiddleConfig}
+    \lean{TNLean.PEPS.EdgeMiddleConfig}
+    \leanok
+    \uses{def:peps_edgeBoundaryMatches}
+    For fixed boundary data $\beta$, the middle configurations are the subtype
+    of global virtual configurations satisfying the compatibility condition with
+    $\beta$.
+\end{definition}
+
+\begin{definition}[Virtual configurations fibred by edge boundary data]%
+    \label{def:peps_virtualConfigEquivEdgeBoundary}
+    \lean{TNLean.PEPS.virtualConfigEquivEdgeBoundary}
+    \leanok
+    \uses{def:peps_edgeBoundaryOfVirtualConfig, def:peps_edgeMiddleConfig}
+    A global virtual configuration is equivalently a choice of edge-centered
+    boundary data together with a middle configuration in the corresponding
+    fibre.
+\end{definition}
+
+\begin{definition}[Left endpoint local configuration from boundary data]%
+    \label{def:peps_edgeLeftLocalConfig}
+    \lean{TNLean.PEPS.edgeLeftLocalConfig}
+    \leanok
+    \uses{def:peps_edgeBoundaryConfig, def:peps_localVirtualConfigSplitAt}
+    The left endpoint local virtual configuration is reconstructed from the
+    edge index and the residual data on the left endpoint star.
+\end{definition}
+
+\begin{definition}[Right endpoint local configuration from boundary data]%
+    \label{def:peps_edgeRightLocalConfig}
+    \lean{TNLean.PEPS.edgeRightLocalConfig}
+    \leanok
+    \uses{def:peps_edgeBoundaryConfig, def:peps_localVirtualConfigSplitAt}
+    The right endpoint local virtual configuration is reconstructed from the
+    edge index and the residual data on the right endpoint star.
+\end{definition}
+
+\begin{theorem}[Left endpoint reconstruction for compatible boundary data]%
+    \label{thm:peps_edgeLeftLocalConfig_eq_of_boundaryMatches}
+    \lean{TNLean.PEPS.edgeLeftLocalConfig_eq_of_boundaryMatches}
+    \leanok
+    \uses{def:peps_edgeBoundaryMatches, def:peps_edgeLeftLocalConfig}
+    If a global virtual configuration is compatible with boundary data, then its
+    restriction to the left endpoint star is the local configuration reconstructed
+    from those data.
+\end{theorem}
+
+\begin{theorem}[Right endpoint reconstruction for compatible boundary data]%
+    \label{thm:peps_edgeRightLocalConfig_eq_of_boundaryMatches}
+    \lean{TNLean.PEPS.edgeRightLocalConfig_eq_of_boundaryMatches}
+    \leanok
+    \uses{def:peps_edgeBoundaryMatches, def:peps_edgeRightLocalConfig}
+    If a global virtual configuration is compatible with boundary data, then its
+    restriction to the right endpoint star is the local configuration
+    reconstructed from those data.
+\end{theorem}
+
 \begin{definition}[Blocked middle tensor at an edge]%
     \label{def:peps_edgeMiddleWeight}
     \lean{TNLean.PEPS.edgeMiddleWeight}
     \leanok
-    \uses{def:peps_edgeBoundaryConfig, def:peps_edgeMiddleVertices}
+    \uses{def:peps_edgeBoundaryMatches, def:peps_edgeMiddleConfig,
+        def:peps_edgeMiddleVertices}
     Fixing the edge-centered boundary data, the blocked middle tensor is the sum
     over global virtual configurations compatible with those data of the product
     of local tensor entries over the middle region $V\setminus\{u,v\}$.
@@ -300,7 +379,8 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \label{def:peps_edgeBlockedCoeff}
     \lean{TNLean.PEPS.edgeBlockedCoeff}
     \leanok
-    \uses{def:peps_edgeBoundaryConfig, def:peps_edgeMiddleWeight}
+    \uses{def:peps_edgeLeftLocalConfig, def:peps_edgeMiddleWeight,
+        def:peps_edgeRightLocalConfig}
     The edge-blocked coefficient is the three-block contraction obtained from
     the left endpoint tensor, the blocked middle tensor, and the right endpoint
     tensor at the chosen edge.
@@ -310,12 +390,16 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \label{thm:peps_edgeBlockedCoeff_eq_stateCoeff}
     \lean{TNLean.PEPS.edgeBlockedCoeff_eq_stateCoeff}
     \leanok
-    \uses{def:peps_edgeBlockedCoeff, thm:peps_stateCoeff_splitAtEdge}
+    \uses{def:peps_edgeBlockedCoeff, thm:peps_stateCoeff_splitAtEdge,
+        def:peps_virtualConfigEquivEdgeBoundary}
     For every edge $e$, the edge-blocked three-block coefficient is exactly the
     original PEPS state coefficient.
 \end{theorem}
 \begin{proof}\leanok
-    Fibre the global virtual sum by the edge-centered boundary data.  The
+    \uses{def:peps_virtualConfigEquivEdgeBoundary,
+        thm:peps_edgeLeftLocalConfig_eq_of_boundaryMatches,
+        thm:peps_edgeRightLocalConfig_eq_of_boundaryMatches}
+    Fibre the global virtual sum by the edge-centered boundary data. The
     remaining fibre sum is the blocked middle tensor, and the two endpoint
     factors are reconstructed from the same boundary data.
 \end{proof}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -275,6 +275,64 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     edge to the per-vertex product inside each summand.
 \end{proof}
 
+\begin{definition}[Edge-centered boundary data]%
+    \label{def:peps_edgeBoundaryConfig}
+    \lean{TNLean.PEPS.EdgeBoundaryConfig}
+    \leanok
+    \uses{def:peps_tensor, def:peps_localVirtualConfigSplitAt}
+    For an edge $e=(u,v)$, the boundary data consist of the virtual index on
+    $e$, the remaining virtual indices incident to $u$, and the remaining
+    virtual indices incident to $v$. These are the indices over which the
+    endpoint tensors couple to the blocked middle region.
+\end{definition}
+
+\begin{definition}[Blocked middle tensor at an edge]%
+    \label{def:peps_edgeMiddleWeight}
+    \lean{TNLean.PEPS.edgeMiddleWeight}
+    \leanok
+    \uses{def:peps_edgeBoundaryConfig, def:peps_edgeMiddleVertices}
+    Fixing the edge-centered boundary data, the blocked middle tensor is the sum
+    over global virtual configurations compatible with those data of the product
+    of local tensor entries over the middle region $V\setminus\{u,v\}$.
+\end{definition}
+
+\begin{definition}[Edge-blocked PEPS coefficient]%
+    \label{def:peps_edgeBlockedCoeff}
+    \lean{TNLean.PEPS.edgeBlockedCoeff}
+    \leanok
+    \uses{def:peps_edgeBoundaryConfig, def:peps_edgeMiddleWeight}
+    The edge-blocked coefficient is the three-block contraction obtained from
+    the left endpoint tensor, the blocked middle tensor, and the right endpoint
+    tensor at the chosen edge.
+\end{definition}
+
+\begin{theorem}[Edge-blocked coefficient equals the PEPS coefficient]%
+    \label{thm:peps_edgeBlockedCoeff_eq_stateCoeff}
+    \lean{TNLean.PEPS.edgeBlockedCoeff_eq_stateCoeff}
+    \leanok
+    \uses{def:peps_edgeBlockedCoeff, thm:peps_stateCoeff_splitAtEdge}
+    For every edge $e$, the edge-blocked three-block coefficient is exactly the
+    original PEPS state coefficient.
+\end{theorem}
+\begin{proof}\leanok
+    Fibre the global virtual sum by the edge-centered boundary data.  The
+    remaining fibre sum is the blocked middle tensor, and the two endpoint
+    factors are reconstructed from the same boundary data.
+\end{proof}
+
+\begin{theorem}[Same state gives the same edge-blocked coefficients]%
+    \label{thm:peps_sameState_edgeBlockedCoeff_eq}
+    \lean{TNLean.PEPS.SameState.edgeBlockedCoeff_eq}
+    \leanok
+    \uses{def:peps_same_state, thm:peps_edgeBlockedCoeff_eq_stateCoeff}
+    If two PEPS tensors have the same state, then their edge-blocked
+    coefficients agree at every edge and every physical configuration.
+\end{theorem}
+\begin{proof}\leanok
+    Rewrite both edge-blocked coefficients as the corresponding PEPS state
+    coefficients and apply the same-state hypothesis.
+\end{proof}
+
 \begin{definition}[Sharpened local gauge lift datum]%
     \label{def:peps_hasLocalGaugeLift}
     \lean{TNLean.PEPS.HasLocalGaugeLift}
@@ -321,9 +379,9 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \leanok
     \uses{def:peps_hasLocalGaugeLift}
     Under the sharpened local lift hypothesis, the local gauge formula follows.
-    What remains open is to derive the blocked-middle formula from the global
-    same-state hypothesis via the blocked middle tensor and the corresponding
-    three-site injective-chain argument.
+    What remains open is to upgrade equality of the edge-blocked coefficients to
+    the blocked-middle formula using the corresponding three-site
+    injective-chain argument.
     Under that hypothesis, injectivity on the star neighbourhood provides a
     left inverse that isolates the local edge gauges:
     \begin{center}
@@ -415,8 +473,8 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     the split at one incident edge, and the partition
     $V = \{u\} \sqcup (V \setminus \{u,v\}) \sqcup \{v\}$ isolate the local
     data needed for the edge-centered reduction of
-    ~\cite{Molnar2018NormalPEPS}, §3. The remaining three PEPS theorems still
-    require the blocked tensor on the middle region and the comparison with the
+    ~\cite{Molnar2018NormalPEPS}, §3. The middle-region blocked coefficient is
+    now formalized; the remaining local-gauge step is the comparison with the
     corresponding three-site injective chain. The uniqueness statement has now
     been repaired to a quotient by balanced edge scalars, but its proof still
     requires the same blocking construction together with the corresponding


### PR DESCRIPTION
## Summary

Refs #820.

This PR lands the next reusable blocked-middle bridge for the PEPS local-gauge roadblock:

- adds edge-centered boundary data `TNLean.PEPS.EdgeBoundaryConfig`;
- defines the blocked middle contraction `TNLean.PEPS.edgeMiddleWeight` and the associated three-block coefficient `TNLean.PEPS.edgeBlockedCoeff`;
- proves `TNLean.PEPS.edgeBlockedCoeff_eq_stateCoeff`, so the three-block contraction is exactly the original PEPS coefficient;
- proves `TNLean.PEPS.SameState.edgeBlockedCoeff_eq`, turning `SameState` into equality of these edge-blocked coefficients at every edge;
- records the new declarations in the PEPS blueprint and updates the blocker comments.

## Remaining Lean-level blocker

This leaves issue #820 open.  The missing theorem is now sharper:

1. from `SameState.edgeBlockedCoeff_eq` and the bond-dimension equality, package the two edge-blocked contractions as the appropriate three-site injective chain around each edge;
2. prove the PEPS-to-chain comparison hypotheses needed by the 1D theorem;
3. apply the three-site injective-chain fundamental theorem to extract the incident-edge matrices giving `BlockedMiddleGaugeHyp A B hA hDim v`;
4. feed that into `hasLocalGaugeLift_of_blockedMiddleGaugeHyp`.

The current MPS theorem in Lean still works through the stronger `SameMPV`/bridge interface and does not yet provide this variable-boundary, PEPS-blocked three-site comparison directly.

## Validation

- `lake env lean TNLean/PEPS/Blocking.lean`
- `lake env lean TNLean/PEPS/LocalGauge.lean`
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`
- `lake env lean TNLean.lean`
- `lake build TNLean.PEPS.Blocking TNLean.PEPS.LocalGauge TNLean.PEPS.FundamentalTheorem TNLean`
- `cd blueprint && leanblueprint checkdecls`
- touched-file line-length scan: 0 lines over 100 columns
- proof-integrity scan on touched PEPS files: no new `sorry`, `admit`, `axiom`, or `native_decide`
- `git diff --check`

I also attempted `cd blueprint && leanblueprint web`; locally it fails before rendering the PEPS changes while compiling a cached TikZ diagram (`\\TNMPSLocal{A}{i}`) because the workspace path contains spaces (`Mobile Documents/...`).  `leanblueprint checkdecls` succeeds, and CI should run in a path without that local TeX quoting issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new PEPS blocking definitions/lemmas and documentation without changing existing theorem statements or behavior, aside from exposing new API that downstream proofs may start to depend on.
> 
> **Overview**
> Adds an edge-centered three-block decomposition for PEPS coefficients by introducing `EdgeBoundaryConfig` boundary data, fibred middle configurations (`EdgeMiddleConfig`), and the associated middle contraction `edgeMiddleWeight`.
> 
> Defines `edgeBlockedCoeff` as the endpoint–middle–endpoint contraction at a chosen edge and proves `edgeBlockedCoeff_eq_stateCoeff`, plus `SameState.edgeBlockedCoeff_eq` to lift `SameState` to equality of these edge-blocked coefficients. Updates the PEPS Fundamental Theorem comments/TODOs and extends the blueprint with the new definitions and theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee87a5cf2d6c127d879c6f8c1c5b41c3128a82f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

