### PR TITLE
feat(MPS/ParentHamiltonian): parameterize overlap compression gap

### DIFF
--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -346,8 +346,8 @@ coefficient.
 If interacting pairs satisfy `‖P_i (P_j v)‖ ≤ η ‖P_i v‖`, and the coefficient
 `η` is no larger than `(1 - γ) / m`, then the usual finite-overlap
 norm-compression theorem applies.  This form separates the analytic principal-angle
-constant from the gap parameter: any later bound `η < 1 / m` can be fed in by
-choosing a positive `γ` with `η ≤ (1 - γ) / m`. -/
+constant from the gap parameter: it suffices to choose a positive `γ` satisfying
+`η ≤ (1 - γ) / m` whenever a later bound gives `η < 1 / m`. -/
 theorem quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le
     {γ η : ℝ} (hγle : γ ≤ 1)
     (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -340,6 +340,35 @@ theorem quadraticForm_sum_projections_of_finite_overlap_norm_bound {γ : ℝ} (h
   convert hraw using 1
   ring
 
+/-- Finite-overlap row-sum reduction from an explicit overlap-compression
+coefficient.
+
+If interacting pairs satisfy `‖P_i (P_j v)‖ ≤ η ‖P_i v‖`, and the coefficient
+`η` is no larger than `(1 - γ) / m`, then the usual finite-overlap
+norm-compression theorem applies.  This form separates the analytic principal-angle
+constant from the gap parameter: any later bound `η < 1 / m` can be fed in by
+choosing a positive `γ` with `η ≤ (1 - γ) / m`. -/
+theorem quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le
+    {γ η : ℝ} (hγle : γ ≤ 1)
+    (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)
+    (overlaps : ι → ι → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (hDisjoint : ∀ i j, j ∈ Finset.univ.erase i → ¬ overlaps i j →
+      ∀ v : E, 0 ≤ (⟪P i v, P j v⟫_ℂ).re)
+    (hηle : η ≤ (1 - γ) * ((m : ℝ)⁻¹))
+    (hOverlapNorm : ∀ i j, j ∈ Finset.univ.erase i → overlaps i j →
+      ∀ v : E, ‖P i (P j v)‖ ≤ η * ‖P i v‖) :
+    ∀ v : E,
+      γ * (⟪(∑ i, P i) v, v⟫_ℂ).re ≤
+        (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := by
+  refine quadraticForm_sum_projections_of_finite_overlap_norm_bound hγle P hP
+    overlaps hm hCard hDisjoint ?_
+  intro i j hij hoverlap v
+  calc
+    ‖P i (P j v)‖ ≤ η * ‖P i v‖ := hOverlapNorm i j hij hoverlap v
+    _ ≤ ((1 - γ) * ((m : ℝ)⁻¹)) * ‖P i v‖ :=
+      mul_le_mul_of_nonneg_right hηle (norm_nonneg (P i v))
+
 end OffDiagonal
 
 end ProjectionGeometry

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -1415,9 +1415,9 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
 
 If every overlapping off-diagonal cyclic pair satisfies the compression estimate
 with coefficient `η`, and `η * (2 * (L - 1)) < 1`, then the transported parent
-Hamiltonians have gap constant `1 - η * (2 * (L - 1))`.  Thus the remaining MPS
-angle estimate can be supplied as any uniform compression constant strictly below
-the reciprocal of the cyclic overlap degree. -/
+Hamiltonians have gap constant `1 - η * (2 * (L - 1))`.  Thus any uniform
+compression constant strictly below the reciprocal of the cyclic overlap degree
+yields a positive gap. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -1205,6 +1205,38 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound
       (fun i : Fin N => localTermES_isSymmetricProjection A L i) overlaps hm hCard
       hDisjoint hOverlapNorm v)
 
+/-- Fixed-chain finite-overlap quadratic-form estimate from a separate
+norm-compression coefficient.
+
+If the compressed products on overlapping pairs are bounded by `η`, and
+`η ≤ (1 - γ) / m`, then the fixed-chain martingale quadratic form follows with
+constant `γ`.  This version keeps the analytic overlap constant separate from the
+gap parameter. -/
+theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le
+    (A : MPSTensor d D) (L N : ℕ) {γ η : ℝ} (hγle : γ ≤ 1)
+    (overlaps : Fin N → Fin N → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hCard : ∀ i : Fin N,
+      ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (hDisjoint : ∀ i j : Fin N, j ∈ Finset.univ.erase i → ¬ overlaps i j →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re)
+    (hηle : η ≤ (1 - γ) * ((m : ℝ)⁻¹))
+    (hOverlapNorm : ∀ i j : Fin N, j ∈ Finset.univ.erase i → overlaps i j →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        ‖localTermES A L i (localTermES A L j v)‖ ≤
+          η * ‖localTermES A L i v‖) :
+    ∀ v : EuclideanSpace ℂ (Cfg d N),
+      γ * (⟪parentHamiltonianES A L N v, v⟫_ℂ).re ≤
+        (⟪parentHamiltonianES A L N v,
+          parentHamiltonianES A L N v⟫_ℂ).re := by
+  intro v
+  simpa [parentHamiltonianES_eq_sum_localTermES A L N] using
+    (ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le
+      (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
+      (fun i : Fin N => localTermES A L i)
+      (fun i : Fin N => localTermES_isSymmetricProjection A L i) overlaps hm hCard
+      hDisjoint hηle hOverlapNorm v)
+
 /-- Uniform explicit gap-bound reduction from finite-overlap Friedrichs data.
 
 For parent-Hamiltonian windows of length `L`, the expected finite-range bound is
@@ -1345,6 +1377,88 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound
       (hOverlapNorm N hLN i j hij hoverlap) v
   convert hCross using 1
   ring
+
+/-- Uniform gap-bound reduction from an overlap norm-compression estimate with a
+separate coefficient.
+
+For cyclic windows with at most `2 * (L - 1)` overlapping off-diagonal neighbours,
+a compression estimate with coefficient `η` gives any positive gap parameter `γ`
+satisfying `η ≤ (1 - γ) / (2 * (L - 1))`.  This is the constant-flexible form of
+`parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound`. -/
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {γ η : ℝ}
+    (hγpos : 0 < γ) (hγle : γ ≤ 1)
+    (hηle : η ≤ (1 - γ) * (((2 * (L - 1) : ℕ) : ℝ)⁻¹))
+    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L i v‖) :
+    0 < γ ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
+  refine ⟨hγpos, ?_⟩
+  refine parentHamiltonianES_norm_bound_of_quadratic_form A L hγpos ?_
+  intro N hLN v
+  have hm : 0 < 2 * (L - 1) :=
+    Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
+  exact parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le
+    A L N hγle (cyclicWindowsOverlap N L) hm
+    (fun i => cyclicWindowsOverlap_card_le hLN hL i)
+    (fun _i _j _hij hnot w =>
+      localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A (by omega) hnot w)
+    hηle (fun i j hij hoverlap w => hOverlapNorm N hLN i j hij hoverlap w) v
+
+/-- Uniform gap-bound reduction from a strict overlap norm-compression constant.
+
+If every overlapping off-diagonal cyclic pair satisfies the compression estimate
+with coefficient `η`, and `η * (2 * (L - 1)) < 1`, then the transported parent
+Hamiltonians have gap constant `1 - η * (2 * (L - 1))`.  Thus the remaining MPS
+angle estimate can be supplied as any uniform compression constant strictly below
+the reciprocal of the cyclic overlap degree. -/
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
+    (hηnonneg : 0 ≤ η)
+    (hηlt : η * (((2 * (L - 1) : ℕ) : ℝ)) < 1)
+    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L i v‖) :
+    0 < 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        (1 - η * (((2 * (L - 1) : ℕ) : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  have hm : 0 < 2 * (L - 1) :=
+    Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
+  have hmRpos : 0 < (((2 * (L - 1) : ℕ) : ℝ)) := by
+    exact_mod_cast hm
+  have hγpos : 0 < 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) := by
+    linarith
+  have hγle : 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) ≤ 1 := by
+    have hmul_nonneg : 0 ≤ η * (((2 * (L - 1) : ℕ) : ℝ)) :=
+      mul_nonneg hηnonneg hmRpos.le
+    linarith
+  have hηle :
+      η ≤ (1 - (1 - η * (((2 * (L - 1) : ℕ) : ℝ)))) *
+        (((2 * (L - 1) : ℕ) : ℝ)⁻¹) := by
+    have hmne : (((2 * (L - 1) : ℕ) : ℝ)) ≠ 0 := ne_of_gt hmRpos
+    have hηeq :
+        η = (1 - (1 - η * (((2 * (L - 1) : ℕ) : ℝ)))) *
+          (((2 * (L - 1) : ℕ) : ℝ)⁻¹) := by
+      calc
+        η = η * (((2 * (L - 1) : ℕ) : ℝ) *
+            (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) := by
+              rw [mul_inv_cancel₀ hmne, mul_one]
+        _ = (1 - (1 - η * (((2 * (L - 1) : ℕ) : ℝ)))) *
+            (((2 * (L - 1) : ℕ) : ℝ)⁻¹) := by ring
+    exact le_of_eq hηeq
+  exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
+    A L hL hγpos hγle hηle hOverlapNorm
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 

--- a/audits/2026-05-01_issue952_overlap_constant_reduction.md
+++ b/audits/2026-05-01_issue952_overlap_constant_reduction.md
@@ -45,7 +45,7 @@ is the material around
   `γ ≤ 1`, and
 
   ```text
-  η ≤ (1 - γ) * (((2 * (L - 1) : ℕ) : ℝ)⁻¹),
+  η ≤ (1 - γ) * (((2 * (L - 1) : ℕ) : ℝ)⁻¹)
   ```
 
   then the uniform norm lower bound with constant `γ` follows from the cyclic
@@ -54,13 +54,13 @@ is the material around
   packages the preceding theorem in the strict form: if `0 ≤ η` and
 
   ```text
-  η * (((2 * (L - 1) : ℕ) : ℝ)) < 1,
+  η * (((2 * (L - 1) : ℕ) : ℝ)) < 1
   ```
 
   then the transported parent Hamiltonians have the checked lower-bound constant
 
   ```text
-  1 - η * (((2 * (L - 1) : ℕ) : ℝ)).
+  1 - η * (((2 * (L - 1) : ℕ) : ℝ))
   ```
 
 ## Remaining mathematical statement

--- a/audits/2026-05-01_issue952_overlap_constant_reduction.md
+++ b/audits/2026-05-01_issue952_overlap_constant_reduction.md
@@ -1,0 +1,84 @@
+# Issue #952 — overlap-compression constant reduction (2026-05-01)
+
+This note records the checked reduction added on the `wave25-952-friedrichs-overlap`
+branch. It does not prove the MPS principal-angle estimate requested in issue #952.
+Instead, it separates the analytic overlap-compression constant from the gap
+parameter in the finite-overlap martingale argument.
+
+## Paper and project anchors
+
+The remaining analytic estimate is the overlapping-window Friedrichs bound from
+arXiv:2011.12127 §4.1, equation `eq:4:martingale-2`, also recorded in
+`audits/2026-04-26_issue460_friedrichs_overlap_reduction.md`. In the blueprint this
+is the material around
+`lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap` and
+`lem:parent_hamiltonian_cyclic_overlap_norm_gap` in
+`blueprint/src/chapter/ch14_parent_hamiltonian.tex`.
+
+## New checked declarations
+
+### Projection geometry
+
+- `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le`
+  is a constant-flexible form of the finite-overlap norm-compression reduction.
+  For symmetric projections `P_i`, an overlap relation of row degree at most `m`,
+  and a separate compression coefficient `η`, it proves the quadratic-form estimate
+  with gap parameter `γ` whenever
+
+  ```text
+  η ≤ (1 - γ) * (m : ℝ)⁻¹
+  ```
+
+  and every interacting pair satisfies
+
+  ```text
+  ‖P_i (P_j v)‖ ≤ η * ‖P_i v‖.
+  ```
+
+### Parent-Hamiltonian reductions
+
+- `MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le`
+  instantiates the preceding projection-geometry theorem for fixed-chain
+  transported local terms.
+- `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le`
+  specializes to the concrete cyclic-window overlap relation. If `γ > 0`,
+  `γ ≤ 1`, and
+
+  ```text
+  η ≤ (1 - γ) * (((2 * (L - 1) : ℕ) : ℝ)⁻¹),
+  ```
+
+  then the uniform norm lower bound with constant `γ` follows from the cyclic
+  overlap-compression estimate with coefficient `η`.
+- `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt`
+  packages the preceding theorem in the strict form: if `0 ≤ η` and
+
+  ```text
+  η * (((2 * (L - 1) : ℕ) : ℝ)) < 1,
+  ```
+
+  then the transported parent Hamiltonians have the checked lower-bound constant
+
+  ```text
+  1 - η * (((2 * (L - 1) : ℕ) : ℝ)).
+  ```
+
+## Remaining mathematical statement
+
+The issue #952 endpoint with the explicit coefficient
+
+```text
+(1 - 1/(4L)) * (2(L-1))⁻¹
+```
+
+is still open. The new strict theorem shows that it is enough to prove any uniform
+cyclic-overlap compression constant `η` satisfying
+
+```text
+0 ≤ η,
+η < (2(L-1))⁻¹.
+```
+
+The previous explicit endpoint is recovered by taking
+`η = (1 - 1/(4L)) * (2(L-1))⁻¹`, which leaves the checked gap constant
+`1/(4L)`. No new proof holes were introduced.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2103,6 +2103,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \begin{lemma}[Finite-overlap projection norm-compression reduction]
     \label{lem:finite_overlap_projection_norm_reduction}
     \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le}
     \leanok
     \uses{lem:finite_overlap_projection_rowsum_reduction,
         rem:projection_geometry_rowsum_identities}
@@ -2113,7 +2114,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \[
         \|P_iP_jv\|\le (1-\gamma)\frac{1}{m}\|P_iv\|.
     \]
-    Then $H=\sum_iP_i$ satisfies $H^2\ge\gamma H$ as a quadratic form.
+    Then $H=\sum_iP_i$ satisfies $H^2\ge\gamma H$ as a quadratic form. The same
+    conclusion holds from a separate compression coefficient $\eta$ whenever
+    $\eta\le (1-\gamma)/m$.
 \end{lemma}
 
 \begin{proof}
@@ -2124,7 +2127,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     into
     $\operatorname{Re}\langle P_i v,P_jv\rangle
     \ge -(1-\gamma)m^{-1}\operatorname{Re}\langle P_iv,v\rangle$.
-    The finite-overlap row-sum reduction then applies.
+    If a separate coefficient $\eta$ is used, the assumption
+    $\eta\le(1-\gamma)/m$ first weakens that estimate to the displayed one. The
+    finite-overlap row-sum reduction then applies.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian ordered row-sum quadratic-form reduction]
@@ -2217,6 +2222,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \begin{lemma}[Parent-Hamiltonian finite-overlap norm-compression quadratic reduction]
     \label{lem:parent_hamiltonian_finite_overlap_norm_quadratic}
     \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound}
+    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le}
     \leanok
     \uses{lem:finite_overlap_projection_norm_reduction, def:parent_hamiltonian_es,
         lem:transported_es_local_projections}
@@ -2229,7 +2235,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
         \le (1-\gamma)\frac{1}{m}\|h_{i,\mathrm{ES}}v\|.
     \]
     Then $H_{N,L}^{\mathrm{ES}}{}^2\ge \gamma H_{N,L}^{\mathrm{ES}}$ as a
-    quadratic form.
+    quadratic form. The same conclusion holds from a separate coefficient $\eta$
+    satisfying $\eta\le(1-\gamma)/m$.
 \end{lemma}
 
 \begin{proof}
@@ -2237,7 +2244,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{lem:finite_overlap_projection_norm_reduction,
         lem:transported_es_local_projections}
     Apply the finite-overlap norm-compression projection reduction to the family
-    $P_i=h_{i,\mathrm{ES}}$.
+    $P_i=h_{i,\mathrm{ES}}$. If a separate coefficient $\eta$ is used, first weaken
+    the compression estimate using $\eta\le(1-\gamma)/m$.
 \end{proof}
 
 \begin{definition}[Cyclic-window support]
@@ -2432,6 +2440,42 @@ Lucia~\cite{Kastoryano2018Martingale}.
     The norm-compression condition is converted to the ordered Friedrichs lower
     bound by the projection-geometry Cauchy--Schwarz lemma.  The preceding
     overlapping-cyclic Friedrichs reduction then gives the norm lower bound.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian gap from a cyclic overlap compression constant]
+    \label{lem:parent_hamiltonian_cyclic_overlap_norm_constant_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt}
+    \leanok
+    \uses{lem:parent_hamiltonian_finite_overlap_norm_quadratic,
+        lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive,
+        lem:parent_hamiltonian_es_quadratic_reduction}
+    Fix $L>1$, and let $m=2(L-1)$. Suppose uniformly for every $N\ge2L$ and every
+    overlapping off-diagonal pair that
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le \eta\,\|h_{i,\mathrm{ES}}v\|.
+    \]
+    If $\gamma>0$, $\gamma\le1$, and $\eta\le(1-\gamma)/m$, then $\gamma$ is a
+    valid norm lower-bound constant for vectors in
+    $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$. In particular, if
+    $\eta\ge0$ and $\eta m<1$, then
+    \[
+        (1-\eta m)\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:parent_hamiltonian_finite_overlap_norm_quadratic,
+        lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive,
+        lem:parent_hamiltonian_es_quadratic_reduction}
+    The cyclic-window cardinality lemma gives at most $m=2(L-1)$ overlapping
+    off-diagonal neighbours in each row, while the non-overlap positivity lemma
+    handles disjoint supports. The finite-overlap norm-compression reduction gives
+    the quadratic-form estimate with the chosen $\gamma$, and the positive
+    quadratic-form criterion converts it to the norm lower bound. The strict form
+    is the same statement with $\gamma=1-\eta m$.
 \end{proof}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2456,9 +2456,14 @@ Lucia~\cite{Kastoryano2018Martingale}.
         \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
         \le \eta\,\|h_{i,\mathrm{ES}}v\|.
     \]
-    If $\gamma>0$, $\gamma\le1$, and $\eta\le(1-\gamma)/m$, then $\gamma$ is a
-    valid norm lower-bound constant for vectors in
-    $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$. In particular, if
+    If $\gamma>0$, $\gamma\le1$, and $\eta\le(1-\gamma)/m$, then $0<\gamma$
+    and, for every admissible $N$ and every
+    $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
+    \[
+        \gamma\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+    The assertion $0<\gamma$ repeats the hypothesis, in the same shape as the
+    strict statement below. In particular, if
     $\eta\ge0$ and $\eta m<1$, then for every admissible $N$ and every
     $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
     \[

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2464,8 +2464,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \]
     The assertion $0<\gamma$ repeats the hypothesis, in the same shape as the
     strict statement below. In particular, if
-    $\eta\ge0$ and $\eta m<1$, then for every admissible $N$ and every
-    $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
+    $\eta\ge0$ and $\eta m<1$, then $0<1-\eta m$ and, for every admissible $N$
+    and every $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
     \[
         (1-\eta m)\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2459,7 +2459,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
     If $\gamma>0$, $\gamma\le1$, and $\eta\le(1-\gamma)/m$, then $\gamma$ is a
     valid norm lower-bound constant for vectors in
     $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$. In particular, if
-    $\eta\ge0$ and $\eta m<1$, then
+    $\eta\ge0$ and $\eta m<1$, then for every admissible $N$ and every
+    $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
     \[
         (1-\eta m)\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
     \]


### PR DESCRIPTION
## Summary

Refs #952. Refs #460. Refs #190.

This PR leaves the Friedrichs-overlap issue open: the MPS overlapping-window principal-angle estimate is still the analytic blocker. It narrows the blocker by separating the cyclic overlap-compression constant from the gap parameter in the finite-overlap martingale reduction.

Lean additions:

- `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le`: finite-overlap norm-compression reduction with a separate coefficient `η`, assuming `η ≤ (1 - γ) / m`.
- `MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le`: fixed-chain parent-Hamiltonian instantiation.
- `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le`: cyclic-window gap wrapper for arbitrary positive `γ` satisfying the coefficient inequality.
- `MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt`: strict form showing that any uniform `η` with `0 ≤ η` and `η * (2(L-1)) < 1` gives gap `1 - η * 2(L-1)`.

Blueprint Chapter 14 and a new audit note record the remaining MPS-specific statement. The original explicit endpoint is recovered by taking
`η = (1 - 1/(4L)) * (2(L-1))⁻¹`, which gives the old `1/(4L)` gap constant.

## Validation

- `lake exe cache get` ✅
- `lake build TNLean.Analysis.ProjectionGeometry` ✅
- `lake build TNLean.MPS.ParentHamiltonian.Martingale` ✅ (only the pre-existing Martingale Friedrichs `sorry` warning)
- `lake build TNLean.Analysis.ProjectionGeometry TNLean.MPS.ParentHamiltonian.Martingale` ✅ (same pre-existing warning)
- `LAKE_JOBS=1 lake build +TNLean:olean` ✅ (pre-existing warnings/sorries only)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` ✅
- `lake exe checkdecls blueprint/lean_decls` ✅
- `cd blueprint && leanblueprint checkdecls` ✅
- `git diff --check` ✅
- Added/untracked proof-token scan for `sorry`/`admit`/`axiom`/`native_decide`/`unsafe` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new Lean theorems/docs) and only refactor constants in existing finite-overlap reductions without altering existing statements or introducing new proof gaps.
> 
> **Overview**
> Adds a *constant-flexible* finite-overlap norm-compression lemma `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le`, allowing a separate overlap-compression coefficient `η` with the side condition `η ≤ (1 - γ) / m`.
> 
> Instantiates this for parent Hamiltonians via `parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le`, and introduces new uniform cyclic-window gap wrappers `parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le` and a strict packaged form `..._of_lt` that yields a concrete gap `1 - η * (2*(L-1))` when `η*(2*(L-1)) < 1`.
> 
> Updates the blueprint chapter to reference the new lemmas, and adds an audit note documenting the reduction and the remaining analytic Friedrichs/principal-angle bound needed for issue #952.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c08d71e231b04593dbba8750c9ba802c5525ee64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


