### PR TITLE
feat(MPS/ParentHamiltonian): narrow wrapped-window witness comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -642,6 +642,81 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_c
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes
     (A := A) (L₀ := L₀) (m := m + 2) (N := N) hInj hL₀ (by omega) hComm
 
+/-- Reindexed wrapped-window witness comparison puts the boundary vector in the
+MPV line.
+
+This is the integrated form of the Wave 18E algebraic endgame for the actual
+wrapped and mirror windows.  The one-sided hypotheses are exactly the outputs of
+`chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`; the
+additional hypothesis says that, after both complements are filled by the same
+middle word `μ`, the two witnesses are equal. -/
+theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
+    {A : MPSTensor d D} {L₀ N : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (η : Fin d)
+    {X : Matrix (Fin D) (Fin D) ℂ}
+    (Ywrap Ymirror : (Fin N → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hWrap : ∀ (j : Fin d) (τ : Fin N → Fin d),
+      evalWord A (List.ofFn (fun k : Fin (N - (L₀ + 1)) =>
+        τ ⟨k.val + L₀, by omega⟩)) * A j * X = Ywrap τ * A j)
+    (hMirror : ∀ (j : Fin d) (τ : Fin N → Fin d),
+      X * A j * evalWord A (List.ofFn (fun k : Fin (N - (L₀ + 1)) =>
+        τ ⟨k.val + 1, by omega⟩)) = A j * Ymirror τ)
+    (hCompare : ∀ μ : Fin (N - (L₀ + 1)) → Fin d,
+      Ywrap (wrappedMiddleBackground L₀ N η μ) =
+        Ymirror (mirrorMiddleBackground L₀ N η μ)) :
+    groundSpaceMap A N X ∈ mpvSubmodule A N := by
+  obtain ⟨Y, hLeft, hRight⟩ :=
+    two_sided_middle_compatibility_of_wrapped_witness_comparison
+      (A := A) (L₀ := L₀) (N := N) η Ywrap Ymirror hWrap hMirror hCompare
+  exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility
+    (A := A) (L₀ := L₀) (m := N - (L₀ + 1)) (N := N) hInj hL₀ Y hLeft hRight
+
+/-- Conditional range-reduction theorem from the actual wrapped-window witness comparison.
+
+This theorem isolates the exact remaining proof obligation for the normal-case
+range reduction.  The already formalized cyclic-to-open-chain step produces a
+boundary matrix `X`, and
+`chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective` produces
+the two one-sided wrapped-window witness families.  If those actual witnesses
+agree after reindexing their complements to the same middle word, the chain
+state lies in the MPV line. -/
+theorem chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
+    {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
+    (hCompare :
+      ∀ {ψ : NSiteSpace d N} {X : Matrix (Fin D) (Fin D) ℂ} (η : Fin d),
+        (hψ : ψ ∈ chainGroundSpace A L N) →
+        (hψX : ψ = groundSpaceMap A N X) →
+        (Ywrap Ymirror : (Fin N → Fin d) → Matrix (Fin D) (Fin D) ℂ) →
+        (∀ (j : Fin d) (τ : Fin N → Fin d),
+          evalWord A (List.ofFn (fun k : Fin (N - (L₀ + 1)) =>
+            τ ⟨k.val + L₀, by omega⟩)) * A j * X = Ywrap τ * A j) →
+        (∀ (j : Fin d) (τ : Fin N → Fin d),
+          X * A j * evalWord A (List.ofFn (fun k : Fin (N - (L₀ + 1)) =>
+            τ ⟨k.val + 1, by omega⟩)) = A j * Ymirror τ) →
+        ∀ μ : Fin (N - (L₀ + 1)) → Fin d,
+          Ywrap (wrappedMiddleBackground L₀ N η μ) =
+            Ymirror (mirrorMiddleBackground L₀ N η μ)) :
+    chainGroundSpace A L N ≤ mpvSubmodule A N := by
+  intro ψ hψ
+  have hψGS : ψ ∈ groundSpace A N :=
+    chainGroundSpace_le_groundSpace_of_isNBlkInjective hInj hL₀ (by omega : 0 < N) hL hLN hψ
+  rw [groundSpace, LinearMap.mem_range] at hψGS
+  obtain ⟨X, hX⟩ := hψGS
+  haveI : NeZero d := neZero_d_of_isNBlkInjective hInj hL₀
+  let η : Fin d := ⟨0, Nat.pos_of_ne_zero (NeZero.ne d)⟩
+  obtain ⟨Ywrap, Ymirror, hWrap, hMirror⟩ :=
+    chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
+      (A := A) hInj hL₀ hN hL hLN hψ hX.symm
+  have hCompare' : ∀ μ : Fin (N - (L₀ + 1)) → Fin d,
+      Ywrap (wrappedMiddleBackground L₀ N η μ) =
+        Ymirror (mirrorMiddleBackground L₀ N η μ) :=
+    hCompare (ψ := ψ) (X := X) η hψ hX.symm Ywrap Ymirror hWrap hMirror
+  rw [← hX]
+  exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
+    (A := A) (L₀ := L₀) (N := N) hInj hL₀ η Ywrap Ymirror hWrap hMirror hCompare'
+
 /-- Range-reduction bridge for normal tensors.
 
 This is the missing hard direction of `chainGroundSpace_eq_mpvSubmodule_normal`:

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -645,8 +645,8 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_c
 /-- Reindexed wrapped-window witness comparison puts the boundary vector in the
 MPV line.
 
-This is the integrated form of the Wave 18E algebraic endgame for the actual
-wrapped and mirror windows.  The one-sided hypotheses are exactly the outputs of
+This combines the common-middle commutation argument with the actual wrapped and
+mirror windows.  The one-sided hypotheses are exactly the outputs of
 `chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`; the
 additional hypothesis says that, after both complements are filled by the same
 middle word `μ`, the two witnesses are equal. -/
@@ -673,13 +673,12 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_co
 
 /-- Conditional range-reduction theorem from the actual wrapped-window witness comparison.
 
-This theorem isolates the exact remaining proof obligation for the normal-case
-range reduction.  The already formalized cyclic-to-open-chain step produces a
-boundary matrix `X`, and
-`chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective` produces
-the two one-sided wrapped-window witness families.  If those actual witnesses
-agree after reindexing their complements to the same middle word, the chain
-state lies in the MPV line. -/
+This theorem isolates the remaining comparison needed for the normal-case range
+reduction.  The cyclic-to-open-chain reduction produces a boundary matrix `X`,
+and `chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`
+produces the two one-sided wrapped-window witness families.  If those actual
+witnesses agree after reindexing their complements to the same middle word, the
+chain state lies in the MPV line. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -519,8 +519,8 @@ are available with a common middle word and the same boundary witness. -/
 middle word.
 
 For the wrapped window at the last site, the complement occupies physical sites
-`L₀, ..., N - 2`.  This helper fills exactly those sites with `μ`; the remaining
-sites are dummy values and do not affect the complement word extracted by
+`L₀, ..., N - 2`.  This construction fills exactly those sites with `μ`; the
+remaining sites are dummy values and do not affect the complement word extracted by
 `wrapping_window_compatibility_of_isNBlkInjective`. -/
 def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
@@ -534,8 +534,8 @@ def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
 middle word.
 
 For the opposite wrapped window, the complement occupies physical sites
-`1, ..., N - L₀ - 1`.  This helper fills exactly those sites with `μ`; all window
-sites receive the dummy value `η`. -/
+`1, ..., N - L₀ - 1`.  This construction fills exactly those sites with `μ`; all
+window sites receive the dummy value `η`. -/
 def mirrorMiddleBackground (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
   fun i =>

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -515,6 +515,96 @@ theorem wrapping_window_mirror_compatibility_of_isNBlkInjective
 The two one-sided wrapped-boundary identities close the boundary matrix once they
 are available with a common middle word and the same boundary witness. -/
 
+/-- A background configuration whose wrapped-window complement is the prescribed
+middle word.
+
+For the wrapped window at the last site, the complement occupies physical sites
+`L₀, ..., N - 2`.  This helper fills exactly those sites with `μ`; the remaining
+sites are dummy values and do not affect the complement word extracted by
+`wrapping_window_compatibility_of_isNBlkInjective`. -/
+def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
+    (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
+  fun i =>
+    if h : L₀ ≤ i.val ∧ i.val < N - 1 then
+      μ ⟨i.val - L₀, by omega⟩
+    else
+      η
+
+/-- A background configuration whose mirror-window complement is the prescribed
+middle word.
+
+For the opposite wrapped window, the complement occupies physical sites
+`1, ..., N - L₀ - 1`.  This helper fills exactly those sites with `μ`; all window
+sites receive the dummy value `η`. -/
+def mirrorMiddleBackground (L₀ N : ℕ) (η : Fin d)
+    (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
+  fun i =>
+    if h : 1 ≤ i.val ∧ i.val < N - L₀ then
+      μ ⟨i.val - 1, by omega⟩
+    else
+      η
+
+/-- Extracting the wrapped complement from `wrappedMiddleBackground` returns the
+prescribed middle word. -/
+theorem wrappedMiddleBackground_complement (L₀ N : ℕ) (η : Fin d)
+    (μ : Fin (N - (L₀ + 1)) → Fin d) :
+    (fun k : Fin (N - (L₀ + 1)) =>
+      wrappedMiddleBackground L₀ N η μ ⟨k.val + L₀, by omega⟩) = μ := by
+  ext k
+  simp only [wrappedMiddleBackground]
+  rw [dif_pos]
+  · congr 1
+    ext
+    simp
+  · constructor <;> omega
+
+/-- Extracting the mirror complement from `mirrorMiddleBackground` returns the
+prescribed middle word. -/
+theorem mirrorMiddleBackground_complement (L₀ N : ℕ) (η : Fin d)
+    (μ : Fin (N - (L₀ + 1)) → Fin d) :
+    (fun k : Fin (N - (L₀ + 1)) =>
+      mirrorMiddleBackground L₀ N η μ ⟨k.val + 1, by omega⟩) = μ := by
+  ext k
+  simp only [mirrorMiddleBackground]
+  rw [dif_pos]
+  · congr 1
+  · constructor <;> omega
+
+/-- Reindexed wrapped and mirror witnesses give a same-witness common-middle pair.
+
+The hypotheses `hWrap` and `hMirror` are the two one-sided identities produced by
+`chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`.  The only
+extra input is the genuine witness comparison: after filling the two complements
+with the same middle word `μ`, the wrapped and mirror witnesses agree.  The
+conclusion packages the exact same-witness hypotheses needed by
+`commutes_words_of_two_sided_middle_compatibility`. -/
+theorem two_sided_middle_compatibility_of_wrapped_witness_comparison
+    {A : MPSTensor d D} {L₀ N : ℕ} (η : Fin d)
+    {X : Matrix (Fin D) (Fin D) ℂ}
+    (Ywrap Ymirror : (Fin N → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hWrap : ∀ (j : Fin d) (τ : Fin N → Fin d),
+      evalWord A (List.ofFn (fun k : Fin (N - (L₀ + 1)) =>
+        τ ⟨k.val + L₀, by omega⟩)) * A j * X = Ywrap τ * A j)
+    (hMirror : ∀ (j : Fin d) (τ : Fin N → Fin d),
+      X * A j * evalWord A (List.ofFn (fun k : Fin (N - (L₀ + 1)) =>
+        τ ⟨k.val + 1, by omega⟩)) = A j * Ymirror τ)
+    (hCompare : ∀ μ : Fin (N - (L₀ + 1)) → Fin d,
+      Ywrap (wrappedMiddleBackground L₀ N η μ) =
+        Ymirror (mirrorMiddleBackground L₀ N η μ)) :
+    ∃ Y : (Fin (N - (L₀ + 1)) → Fin d) → Matrix (Fin D) (Fin D) ℂ,
+      (∀ (j : Fin d) (μ : Fin (N - (L₀ + 1)) → Fin d),
+        evalWord A (List.ofFn μ) * A j * X = Y μ * A j) ∧
+      (∀ (j : Fin d) (μ : Fin (N - (L₀ + 1)) → Fin d),
+        X * A j * evalWord A (List.ofFn μ) = A j * Y μ) := by
+  refine ⟨fun μ => Ywrap (wrappedMiddleBackground L₀ N η μ), ?_, ?_⟩
+  · intro j μ
+    have h := hWrap j (wrappedMiddleBackground L₀ N η μ)
+    simpa [wrappedMiddleBackground_complement] using h
+  · intro j μ
+    have h := hMirror j (mirrorMiddleBackground L₀ N η μ)
+    have hCmp := hCompare μ
+    simpa [mirrorMiddleBackground_complement, hCmp.symm] using h
+
 /-- A same-witness pair of one-sided compatibilities around a common middle word
 forces `X` to commute with every word obtained by adjoining one physical letter on
 each side of that middle.

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -576,7 +576,7 @@ The hypotheses `hWrap` and `hMirror` are the two one-sided identities produced b
 `chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`.  The only
 extra input is the genuine witness comparison: after filling the two complements
 with the same middle word `μ`, the wrapped and mirror witnesses agree.  The
-conclusion packages the exact same-witness hypotheses needed by
+conclusion yields the exact same-witness hypotheses needed by
 `commutes_words_of_two_sided_middle_compatibility`. -/
 theorem two_sided_middle_compatibility_of_wrapped_witness_comparison
     {A : MPSTensor d D} {L₀ N : ℕ} (η : Fin d)

--- a/audits/2026-04-22_issue588_normal_range_reduction_partial.md
+++ b/audits/2026-04-22_issue588_normal_range_reduction_partial.md
@@ -228,3 +228,39 @@ family `Y_μ` satisfying the two same-witness identities above.  Once that
 comparison is available, the new Wave 18E theorem
 `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility`
 closes the MPV-line containment.
+
+## 2026-05-01 Wave 25 update
+
+Current branch `wave25-961-wrapped-window-witness` still does **not** close
+`MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`; the
+pre-existing proof placeholder remains.  It lands the reindexing and conditional
+endgame layer for the actual wrapped-window witness comparison:
+
+- `MPSTensor.wrappedMiddleBackground` and `MPSTensor.mirrorMiddleBackground` in
+  `TNLean/MPS/ParentHamiltonian/WrappingWindow.lean` build the two background
+  configurations whose exposed complements are the same middle word `μ`.
+- `MPSTensor.wrappedMiddleBackground_complement` and
+  `MPSTensor.mirrorMiddleBackground_complement` prove the corresponding
+  complement-extraction identities.
+- `MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison` turns
+  the concrete comparison
+  `Ywrap (wrappedMiddleBackground L₀ N η μ) =
+   Ymirror (mirrorMiddleBackground L₀ N η μ)`
+  into the same-witness common-middle hypotheses used by the Wave 18E algebraic
+  endgame.
+- `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison`
+  and
+  `MPSTensor.chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison`
+  integrate this comparison into the MPV-line containment argument.
+
+This narrows issue #961 to the remaining comparison theorem itself: for the
+witness families produced from the two reduced wrapped windows, prove equality
+after filling the complements by the same middle word through the two background
+maps above.  Once that theorem is available, the new conditional reduction theorem
+feeds directly into the existing normal-range containment target.
+
+Paper anchor retained: CPGSV21 §IV.C,
+`Papers/2011.12127/TN-Review-main.tex:2078--2079`, especially
+"Once we have reached $k=L_0$, we can resort to the above Theorem, or
+alternatively apply a similar argument when closing the boundaries", and theorem
+`thm:4:unique-gs-L0_plus_1` at lines 2087--2090.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -860,6 +860,57 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     boundary-crossing positions to obtain the displayed one-sided identities.
 \end{proof}
 
+\begin{lemma}[Middle-word backgrounds for the two wrapped complements]%
+    \label{lem:wrapped_middle_backgrounds}
+    \lean{MPSTensor.wrappedMiddleBackground,
+        MPSTensor.mirrorMiddleBackground,
+        MPSTensor.wrappedMiddleBackground_complement,
+        MPSTensor.mirrorMiddleBackground_complement}
+    \leanok
+    \uses{rem:cyclic_window_operators}
+    Fix a middle word $\mu$ of length $N-(L_0+1)$. There are two background
+    configurations, one for the last-site wrapped window and one for the opposite
+    wrapped window, whose exposed complements are both exactly $\mu$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Fill the physical sites $L_0,\ldots,N-2$ with $\mu$ for the last-site
+    wrapped window, and fill the sites $1,\ldots,N-L_0-1$ with $\mu$ for the
+    opposite wrapped window. The remaining sites are dummy window sites. The two
+    complement-extraction identities are then immediate from the index
+    arithmetic.
+\end{proof}
+
+\begin{lemma}[Same-witness identities from compared wrapped witnesses]%
+    \label{lem:two_sided_middle_of_wrapped_witness_comparison}
+    \lean{MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison}
+    \leanok
+    \uses{lem:wrapped_middle_backgrounds,
+        thm:reduced_wrapped_boundary_compatibilities}
+    Suppose the wrapped and mirror one-sided witnesses $Y^+$ and $Y^-$ have been
+    extracted. If, after the two complements are filled by the same middle word
+    $\mu$, the witnesses agree,
+    \[
+        Y^+_{\tau^+(\mu)} = Y^-_{\tau^-(\mu)},
+    \]
+    then there is a single family $Y_\mu$ satisfying
+    \[
+        A^\mu A^b X = Y_\mu A^b,
+        \qquad
+        X A^a A^\mu = A^a Y_\mu
+    \]
+    for all letters $a,b$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Define $Y_\mu$ to be the wrapped witness evaluated on the background
+    $\tau^+(\mu)$. Lemma~\ref{lem:wrapped_middle_backgrounds} rewrites the
+    wrapped complement as $\mu$, while the assumed comparison rewrites the mirror
+    witness to the same $Y_\mu$.
+\end{proof}
+
 \begin{lemma}[Same-witness common-middle commutation]%
     \label{lem:common_middle_same_witness_commutation}
     \lean{MPSTensor.commutes_words_of_two_sided_middle_compatibility}
@@ -1185,6 +1236,47 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     finishes.
 \end{proof}
 
+\begin{theorem}[MPV-line endgame from compared wrapped witnesses]
+    \label{thm:ground_space_map_mpv_of_wrapped_witness_comparison}
+    \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison}
+    \leanok
+    \uses{lem:two_sided_middle_of_wrapped_witness_comparison,
+        thm:ground_space_map_mpv_of_common_middle}
+    Let $A$ be $L_0$-block-injective with $L_0>0$. If the wrapped and mirror
+    one-sided witnesses agree after reindexing their complements to a common
+    middle word, then $\Gamma_N(X)$ lies in the MPV line.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:two_sided_middle_of_wrapped_witness_comparison} turns the
+    compared wrapped witnesses into a single same-witness common-middle family.
+    Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} then applies.
+\end{proof}
+
+\begin{theorem}[Conditional normal-range reduction from witness comparison]
+    \label{thm:conditional_normal_range_reduction_witness_comparison}
+    \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison}
+    \leanok
+    \uses{thm:cyclic_normal_open_chain_range_reduction,
+        thm:ground_space_map_mpv_of_wrapped_witness_comparison}
+    Suppose that, for every boundary matrix obtained from an $N$-site chain
+    ground state, the wrapped and mirror witnesses supplied by
+    Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities} agree after the
+    common-middle reindexing. Then the range-$L$ chain ground space is contained
+    in the MPV line.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The cyclic-to-open-chain reduction writes any chain ground state as
+    $\Gamma_N(X)$. The reduced wrapped-boundary compatibility theorem supplies
+    the two one-sided witness families for this $X$. The assumed comparison says
+    that these witnesses agree after the common-middle reindexing, and
+    Theorem~\ref{thm:ground_space_map_mpv_of_wrapped_witness_comparison}
+    finishes.
+\end{proof}
+
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%
     \label{thm:chain_ground_space_eq_mpv_blk}
     \lean{MPSTensor.chainGroundSpace_eq_mpvSubmodule}
@@ -1216,7 +1308,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{def:chain_ground_space, def:mpv_submodule, def:normal,
         def:l_blk_injective, thm:cyclic_normal_open_chain_range_reduction,
         thm:reduced_wrapped_boundary_compatibilities,
-        thm:ground_space_map_mpv_of_common_middle}
+        thm:conditional_normal_range_reduction_witness_comparison}
     If $A$ is normal, $D \ge 1$, $L_0$-block-injective, with $N \ge 2$ and $L_0 < L \le N$, then
     \[
         \mathcal G_{N,L}(A) \subseteq \spn\bigl\{V^{(N)}(A)\bigr\}.
@@ -1226,17 +1318,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \notready
     \uses{thm:reduced_wrapped_boundary_compatibilities,
-        thm:ground_space_map_mpv_of_common_middle,
+        thm:conditional_normal_range_reduction_witness_comparison,
         lem:padded_complement_annihilation}
     The remaining step is the closure property from
     \cite[\S~IV.C]{Cirac2021Matrix}: Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
     supplies the two one-sided wrapped-boundary identities for the open-chain
     boundary matrix $X$. The padded-annihilation lemma states that exact
-    complement-span length mismatches are no longer the obstruction, and
-    Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} formalizes the
-    algebraic endgame once those one-sided identities have been compared to a
-    single same-witness common-middle family. What is still missing is precisely
-    that witness comparison for the actual two wrapped windows.
+    complement-span length mismatches are no longer the obstruction. The new
+    conditional reduction theorem shows that the proof would finish as soon as
+    those actual wrapped-window witnesses are compared after reindexing their
+    complements to a common middle word. What is still missing is precisely that
+    comparison of the witnesses themselves.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the normal case]%

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -868,17 +868,18 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         MPSTensor.mirrorMiddleBackground_complement}
     \leanok
     \uses{rem:cyclic_window_operators}
-    Fix a middle word $\mu$ of length $N-(L_0+1)$. There are two background
-    configurations, one for the last-site wrapped window and one for the opposite
-    wrapped window, whose exposed complements are both exactly $\mu$.
+    Fix a dummy physical letter $\eta$ and a middle word $\mu$ of length
+    $N-(L_0+1)$.  Write $\tau^+_\eta(\mu)$ for the last-site wrapped background
+    and $\tau^-_\eta(\mu)$ for the opposite wrapped background. Their exposed
+    complements are both exactly $\mu$.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    Fill the physical sites $L_0,\ldots,N-2$ with $\mu$ for the last-site
-    wrapped window, and fill the sites $1,\ldots,N-L_0-1$ with $\mu$ for the
-    opposite wrapped window. The remaining sites are dummy window sites. The two
-    complement-extraction identities are then immediate from the index
+    With the same dummy letter $\eta$ on the remaining sites, fill the physical
+    sites $L_0,\ldots,N-2$ with $\mu$ for the last-site wrapped window, and fill
+    the sites $1,\ldots,N-L_0-1$ with $\mu$ for the opposite wrapped window.
+    The two complement-extraction identities are then immediate from the index
     arithmetic.
 \end{proof}
 
@@ -887,11 +888,11 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison}
     \leanok
     \uses{lem:wrapped_middle_backgrounds}
-    Suppose the wrapped and mirror one-sided witnesses $Y^+$ and $Y^-$ have been
-    extracted. If, after the two complements are filled by the same middle word
-    $\mu$, the witnesses agree,
+    Fix a dummy physical letter $\eta$. Suppose the wrapped and mirror one-sided
+    witnesses $Y^+$ and $Y^-$ have been extracted. If, for every middle word
+    $\mu$, the witnesses agree on the backgrounds built from $\eta$,
     \[
-        Y^+_{\tau^+(\mu)} = Y^-_{\tau^-(\mu)},
+        Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)},
     \]
     then there is a single family $Y_\mu$ satisfying
     \[
@@ -905,9 +906,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     Define $Y_\mu$ to be the wrapped witness evaluated on the background
-    $\tau^+(\mu)$. Lemma~\ref{lem:wrapped_middle_backgrounds} rewrites the
-    wrapped complement as $\mu$, while the assumed comparison rewrites the mirror
-    witness to the same $Y_\mu$.
+    $\tau^+_\eta(\mu)$. Lemma~\ref{lem:wrapped_middle_backgrounds} rewrites the
+    wrapped complement as $\mu$, while the assumed comparison at
+    $\tau^-_\eta(\mu)$ rewrites the mirror witness to the same $Y_\mu$.
 \end{proof}
 
 \begin{lemma}[Same-witness common-middle commutation]%
@@ -1241,16 +1242,20 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{lem:two_sided_middle_of_wrapped_witness_comparison,
         thm:ground_space_map_mpv_of_common_middle}
-    Let $A$ be $L_0$-block-injective with $L_0>0$. If the wrapped and mirror
-    one-sided witnesses agree after reindexing their complements to a common
-    middle word, then $\Gamma_N(X)$ lies in the MPV line.
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and fix a dummy physical
+    letter $\eta$. If the wrapped and mirror one-sided witnesses satisfy
+    \[
+        Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}
+    \]
+    for every middle word $\mu$, then $\Gamma_N(X)$ lies in the MPV line.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Lemma~\ref{lem:two_sided_middle_of_wrapped_witness_comparison} turns the
-    compared wrapped witnesses into a single same-witness common-middle family.
-    Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} then applies.
+    Lemma~\ref{lem:two_sided_middle_of_wrapped_witness_comparison} uses the
+    comparison at the two $\eta$-backgrounds to turn the wrapped witnesses into a
+    single same-witness common-middle family. Then
+    Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} applies.
 \end{proof}
 
 \begin{theorem}[Conditional normal-range reduction from witness comparison]
@@ -1261,11 +1266,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         thm:reduced_wrapped_boundary_compatibilities,
         thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D \ge 1$. Assume
-    $N \ge 2$ and $L_0 < L \le N$. Suppose that, for every boundary matrix
-    obtained from an $N$-site chain ground state, the wrapped and mirror witnesses
-    supplied by Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities} agree
-    after the common-middle reindexing. Then the range-$L$ chain ground space is
-    contained in the MPV line.
+    $N \ge 2$ and $L_0 < L \le N$. Suppose that, for every dummy letter $\eta$
+    and every boundary matrix obtained from an $N$-site chain ground state, the
+    wrapped and mirror witnesses supplied by
+    Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities} agree at
+    $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ for every middle word $\mu$. Then
+    the range-$L$ chain ground space is contained in the MPV line.
 \end{theorem}
 
 \begin{proof}
@@ -1275,8 +1281,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     The cyclic-to-open-chain reduction writes any chain ground state as
     $\Gamma_N(X)$. The reduced wrapped-boundary compatibility theorem supplies
-    the two one-sided witness families for this $X$. The assumed comparison says
-    that these witnesses agree after the common-middle reindexing, and
+    the two one-sided witness families for this $X$. The comparison hypothesis,
+    applied to a dummy letter $\eta$, says that these witnesses agree at
+    $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ for every middle word $\mu$.
     Theorem~\ref{thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     finishes.
 \end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -886,8 +886,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \label{lem:two_sided_middle_of_wrapped_witness_comparison}
     \lean{MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison}
     \leanok
-    \uses{lem:wrapped_middle_backgrounds,
-        thm:reduced_wrapped_boundary_compatibilities}
+    \uses{lem:wrapped_middle_backgrounds}
     Suppose the wrapped and mirror one-sided witnesses $Y^+$ and $Y^-$ have been
     extracted. If, after the two complements are filled by the same middle word
     $\mu$, the witnesses agree,
@@ -1259,16 +1258,21 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison}
     \leanok
     \uses{thm:cyclic_normal_open_chain_range_reduction,
+        thm:reduced_wrapped_boundary_compatibilities,
         thm:ground_space_map_mpv_of_wrapped_witness_comparison}
-    Suppose that, for every boundary matrix obtained from an $N$-site chain
-    ground state, the wrapped and mirror witnesses supplied by
-    Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities} agree after the
-    common-middle reindexing. Then the range-$L$ chain ground space is contained
-    in the MPV line.
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D \ge 1$. Assume
+    $N \ge 2$ and $L_0 < L \le N$. Suppose that, for every boundary matrix
+    obtained from an $N$-site chain ground state, the wrapped and mirror witnesses
+    supplied by Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities} agree
+    after the common-middle reindexing. Then the range-$L$ chain ground space is
+    contained in the MPV line.
 \end{theorem}
 
 \begin{proof}
     \leanok
+    \uses{thm:cyclic_normal_open_chain_range_reduction,
+        thm:reduced_wrapped_boundary_compatibilities,
+        thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     The cyclic-to-open-chain reduction writes any chain ground state as
     $\Gamma_N(X)$. The reduced wrapped-boundary compatibility theorem supplies
     the two one-sided witness families for this $X$. The assumed comparison says


### PR DESCRIPTION
## Summary

Refs #961.

This PR does not close the normal range-reduction sorry. It lands the strongest reusable layer I could make on the paper path: the common-middle reindexing and conditional MPV-line endgame for the actual wrapped-window witness comparison.

- add `wrappedMiddleBackground` / `mirrorMiddleBackground` and complement-extraction lemmas, which fill the two exposed complements with a common middle word `μ`
- add `two_sided_middle_compatibility_of_wrapped_witness_comparison`, converting equality of the reindexed wrapped/mirror witnesses into the Wave 18E same-witness hypotheses
- add `groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison` and a chain-level conditional reduction theorem that uses the actual witnesses produced by `chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`
- update the Chapter 14 blueprint and the #588 audit with the narrower remaining blocker

## Remaining blocker

The exact Lean-level blocker is now: for the witness families produced by the two reduced wrapped windows, prove

```lean
Ywrap (wrappedMiddleBackground L₀ N η μ) =
  Ymirror (mirrorMiddleBackground L₀ N η μ)
```

for every common middle word `μ`. Once this comparison theorem is available, the new conditional theorem feeds directly into the MPV-line containment target.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.WrappingWindow TNLean.MPS.ParentHamiltonian.UniqueGroundState` (passes; only the pre-existing normal range-reduction `sorry` warning in `UniqueGroundState.lean`)
- `lake build TNLean` (passes; pre-existing warnings only)
- `cd blueprint && leanblueprint checkdecls`
- `leanblueprint web` from a temporary no-space path copy (the direct iCloud path run hits the pre-existing TikZ/LaTeX path-with-spaces issue for `\TNMPSLocal{A}{i}`)
- `git diff --check`
- added-line forbidden-token scan for `sorry`, `admit`, `axiom`, `native_decide`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean definitions/lemmas and conditional theorems in the normal parent-Hamiltonian proof pipeline without altering existing interfaces or runtime behavior; risk is mainly proof/typing regressions in downstream lemmas.
> 
> **Overview**
> Introduces a *reindexing layer* for the two reduced wrapped windows by defining `wrappedMiddleBackground`/`mirrorMiddleBackground` plus lemmas showing their extracted complements equal a shared middle word `μ`.
> 
> Builds a new bridge theorem `two_sided_middle_compatibility_of_wrapped_witness_comparison` that turns an explicit equality of wrapped vs mirror witnesses (after reindexing) into the same-witness common-middle hypotheses, and wires this into the MPV-line endgame via new conditional theorems `groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison` and `chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison`.
> 
> Updates the audit note and Chapter 14 blueprint to reflect the narrowed remaining blocker: proving the actual wrapped/mirror witness equality on these reindexed backgrounds (the normal range-reduction proof remains `sorry`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4ca16bb585696b1f8a523bb79fb612a8e70f21e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->