### PR TITLE
docs(Channel): clean semigroup proof-status prose

### DIFF
--- a/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
@@ -21,8 +21,10 @@ Euler step approximation.
 * `cp_semigroup_implies_ccp_generator` — **Prop 7.3** direction 1→2.
 * `cp_semigroup_iff_ccp_generator` — **Prop 7.3**: CP semigroup ↔ CCP generator.
 
-All Prop 7.3 statements in this file are proved constructively in Lean without
-`sorry`/`axiom` placeholders.
+The main theorem gives the two directions: a CP exponential semigroup has a CCP
+generator, and a CCP generator yields CP maps at all nonnegative times.  The
+proofs use projected Choi matrices, boundary derivatives of PSD curves, and the
+Euler product approximation.
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal MatrixOrder TNOperatorSpace
@@ -57,10 +59,10 @@ of completely positive maps, then `L` is conditionally completely positive.
 at `t = 0` to get `(L⊗id)(|Ω⟩⟨Ω|) + |Ω⟩⟨Ω|·(L⊗id)† ≥ 0` on the range of `P`,
 i.e. `P(L⊗id)(|Ω⟩⟨Ω|)P ≥ 0`. Then Prop 7.2 gives CCP.
 
-**Formalization needs**:
-1. Choi matrix of `exp(tL)` is PSD (from CP hypothesis)
-2. Derivative of a PSD-valued function at a boundary point has the PSD projection property
-3. Extract CCP decomposition from projected PSD Choi matrix (Prop 7.2 reverse) -/
+**Proof ingredients**:
+1. The CP hypothesis gives positivity of the Choi matrix of `exp(tL)`.
+2. Boundary differentiation of a PSD-valued curve yields positivity of the projected derivative.
+3. Wolf Prop. 7.2 identifies projected Choi positivity with conditional complete positivity. -/
 theorem cp_semigroup_implies_ccp_generator
     (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hCP : ∀ t : ℝ, 0 ≤ t → IsCPMap (expSemigroup L t)) :

--- a/TNLean/Channel/Semigroup/LiouvillianKernel.lean
+++ b/TNLean/Channel/Semigroup/LiouvillianKernel.lean
@@ -9,8 +9,8 @@ import TNLean.Channel.FixedPoint.Algebra
 /-!
 # Kernel of the Liouvillian — Wolf Theorem 7.2
 
-This file begins the formalization of Wolf Theorem 7.2 on the kernel of the
-Liouvillian. For a Lindblad form
+This file formalizes the faithful-stationary-state kernel/commutant statement
+from Wolf Theorem 7.2. For a Lindblad form
 
 $$
 L(\rho) = i(\rho H - H \rho) + \sum_j \left(L_j \rho L_j^\dagger -
@@ -470,8 +470,8 @@ theorem mem_commutant_of_mem_adjointKernel_of_hasFaithfulStationaryState
   rw [mem_commutant]
   exact ⟨hHA, fun j => ⟨hAL j, hALstar j⟩⟩
 
-/-- Wolf Theorem 7.2 with the current formalization status: under a faithful
-stationary state, the adjoint kernel equals the commutant. -/
+/-- Wolf Theorem 7.2: under a faithful stationary state, the adjoint kernel equals
+the commutant. -/
 theorem adjointKernel_eq_commutant_of_hasFaithfulStationaryState
     (F : LindbladForm D)
     (hstat : HasFaithfulStationaryState (D := D) F.toLinearMap) :

--- a/TNLean/Channel/Semigroup/Primitivity/Basic.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Basic.lean
@@ -39,7 +39,7 @@ norm-continuous semigroup.  The Lean proof realizes this propagation in
 density at the irreducible time with a primitive positive fractional slice.
 
 **Step B**: `T_t` irreducible + channel → peripheral eigenvalues of `T_t` are roots
-of unity (Wolf Thm 6.6). This channel-level bridge is now available as
+of unity (Wolf Thm 6.6). This channel-level result is available as
 `peripheral_isRootOfUnity_of_irreducible_channel`, proved by choosing a Kraus
 representation, converting to an irreducible tensor, and applying the existing
 blocking-periodicity theorem.

--- a/TNLean/Channel/Semigroup/Primitivity/Basic.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Basic.lean
@@ -33,11 +33,10 @@ import Mathlib.NumberTheory.Real.Irrational
 The proof requires the following chain:
 
 **Step A** (continuous-time key): `T_{t₀}` irreducible → `T_t` irreducible for all `t > 0`.
-This is the core continuous-time fact: irreducibility is a generator property.
-In a norm-continuous QDS `T_t = exp(tL)`, the generator `L` is irreducible
-(no non-trivial invariant faces of the PSD cone). An irreducible generator
-generates an irreducible semigroup: `T_t` is irreducible for ALL `t > 0`.
-*Missing formalization*: formalization of "generator irreducibility ↔ T_t irr ∀ t".
+This is the core continuous-time fact: irreducibility propagates through the
+norm-continuous semigroup.  The Lean proof realizes this propagation in
+`irreducible_all_of_irreducible_time` by combining the unique faithful fixed
+density at the irreducible time with a primitive positive fractional slice.
 
 **Step B**: `T_t` irreducible + channel → peripheral eigenvalues of `T_t` are roots
 of unity (Wolf Thm 6.6). This channel-level bridge is now available as
@@ -53,10 +52,10 @@ and `T_t σ' = μ σ'`.  Trace preservation forces `μ = 1`.
 
 The auxiliary lemmas `eigenvalue_exp_of_eigenvalue_generator`,
 `eq_zero_of_exp_mul_I_isRootOfUnity`, and `re_eq_zero_of_peripheral_generator`
-are fully proved. Step A (generator irreducibility ↔ semigroup irreducibility)
-is formalized via `irreducible_all_of_irreducible_time` in
-`IrreducibleAnalysis.lean`, but that theorem transitively depends on 13
-`sorry` placeholders (formerly `axiom` declarations).
+are fully proved.  The propagation theorem `irreducible_all_of_irreducible_time`
+in `IrreducibleAnalysis.lean` establishes Step A from the faithful fixed-density
+construction, the primitive fractional slice, and the one-dimensional fixed-point
+space obtained from that slice.
 
 ## References
 

--- a/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
@@ -224,12 +224,13 @@ theorem bounded_root_of_peripheral_closed_powers [NeZero D]
 
 /-- Power-closure auxiliary lemma at an irreducible time slice.
 
-This is the only new semigroup-specific ingredient still missing from the refactor below: we need
-that after a similarity transform by a positive-definite fixed point, the irreducible channel
-becomes unital with an adjoint fixed point, so Wolf's peripheral-power closure theorem applies.
+After conjugating by the square root of a positive-definite fixed point, the
+irreducible channel becomes unital with an adjoint fixed point, so Wolf's
+peripheral-power closure theorem applies to the gauged Kraus family.
 
-The statement is substantially simpler than the original circular `sorry`: it is a pure channel
-lemma, independent of continuous-time propagation or generator kernels. -/
+This is a purely channel-level lemma: its hypotheses mention one channel with a
+positive-definite fixed point and do not use continuous-time propagation or
+generator kernels. -/
 theorem peripheral_powers_closed_of_irreducible_channel_with_fixed [NeZero D]
     (E : Mat →ₗ[ℂ] Mat) (hE : IsChannel E) (hIrr : IsIrreducibleMap E)
     (σ : Mat) (hσ_pd : σ.PosDef) (hσ_fix : E σ = σ)

--- a/TNLean/Channel/Semigroup/Primitivity/MainTheorem.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/MainTheorem.lean
@@ -20,7 +20,7 @@ The proof has two parts:
 
 **Part 1 — Irreducibility propagation** (`hT_irr_all`):
 `T_{t₀}` irreducible → `T_s` irreducible for ALL `s > 0`.
-Uses the kernel bridge: `ker(L) = Span{σ}` where `σ` is the unique
+Uses the kernel characterization: `ker(L) = Span{σ}` where `σ` is the unique
 faithful density fixed point of `T_{t₀}`. Then `σ` is fixed by all `T_s`
 (semigroup commutativity + density uniqueness). For each `s > 0`, `T_s`
 is shown irreducible via `isIrreducibleMap_of_channel_posDef_fixedPoint_unique`.

--- a/TNLean/Channel/Semigroup/Primitivity/MainTheorem.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/MainTheorem.lean
@@ -32,10 +32,12 @@ the eigenvector `V` is a fixed point of `T_{pt}`. By irreducibility of
 `T_{pt}`, `V` must be proportional to the unique faithful density fixed
 point `σ'`, giving `T_t σ' = μ σ'`. Trace preservation then forces `μ = 1`.
 
-**Status**: The glue logic is complete, but this theorem transitively depends on
-13 `sorry` placeholders in `IrreducibleAnalysis.lean` (formerly `axiom`
-declarations), including `primitive_of_irreducible_all`,
-`exists_primitive_fraction_slice`, and `fixedPoint_eq_trace_smul_of_primitive_slice`. -/
+The Lean proof combines the propagation theorem
+`irreducible_all_of_irreducible_time` with the primitive-slice analysis in
+`IrreducibleAnalysis.lean`: `primitive_of_irreducible_all` reduces primitivity
+to irreducibility at all positive times, while `exists_primitive_fraction_slice`
+and `fixedPoint_eq_trace_smul_of_primitive_slice` supply the fixed-point input
+for the propagation theorem. -/
 theorem irreducible_semigroup_implies_primitive
     [NeZero D]
     (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)


### PR DESCRIPTION
## Summary

- remove stale comments claiming active `sorry`/`axiom` placeholders in the channel semigroup primitivity proof prose
- restate the Prop. 7.5 propagation comments in terms of the current Lean declarations (`irreducible_all_of_irreducible_time`, primitive fractional slices, and fixed-point uniqueness)
- clean adjacent proof-status wording in the Prop. 7.3 Euler-step and faithful Liouvillian-kernel comments

Closes #1086.

## Validation

- `lake exe cache get`
- `lake build TNLean.Channel.Semigroup.Primitivity.MainTheorem TNLean.Channel.Semigroup.LindbladForm.EulerStep TNLean.Channel.Semigroup.LiouvillianKernel`
- stale-claim grep (no matches):
  ```bash
  rg -n --glob '*.lean' '13 `sorry` placeholders|formerly `axiom`|sorry/axiom placeholders' TNLean/Channel/Semigroup
  ```
- broader proof-status grep (no matches):
  ```bash
  rg -n --glob '*.lean' '(sorry|axiom|placeholder|Missing formalization|Formalization needs|still missing|original circular|current formalization status)' TNLean/Channel/Semigroup
  ```
- executable semigroup sorry scan (no matches):
  ```bash
  rg -n --glob '!/.lake/**' --glob '!/.worktrees/**' --glob '*.lean' '^\s*sorry\b' TNLean/Channel/Semigroup
  ```
- Lean diagnostics: no errors/warnings/hints for touched modules
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits in Lean module docstrings/comments; no changes to theorem statements or proofs, so behavioral risk is minimal.
> 
> **Overview**
> Updates documentation and proof-outline prose across the semigroup formalization to reflect the current Lean developments.
> 
> In `LindbladForm/EulerStep.lean`, `LiouvillianKernel.lean`, and the primitivity modules, this removes stale mentions of missing formalization/`sorry`/`axiom` placeholders and rewrites the Prop. 7.3/7.5 and Thm. 7.2 commentary to reference the existing lemmas (e.g. `irreducible_all_of_irreducible_time`, primitive fractional slices, and fixed-point uniqueness) and the key proof ingredients being used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2281488fe64253df7dc20d5884ab2fd5fe9be043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->