### PR TITLE
feat(MPS/Core): record direct-iterated block equivalence

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1437,6 +1437,31 @@ def groupedBlockCastAgrees (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin
       directToIteratedBlockIndex d (F.period k) (F.extra k)
         (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i)
 
+/-- The grouped-block cast predicate is equivalently the assertion that flattening the
+order-preserving cast from the common blocked alphabet gives the corresponding direct
+blocked index.  This isolates the remaining point as a comparison between the `Fin.cast`
+identification and the canonical direct/iterated blocking equivalence. -/
+theorem groupedBlockCastAgrees_iff_iteratedBlockIndex_cast
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
+    F.groupedBlockCastAgrees k ↔
+      ∀ i : Fin (blockPhysDim d F.p),
+        iteratedBlockIndex d (F.period k) (F.extra k)
+          (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i) =
+          Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i := by
+  constructor
+  · intro hCast i
+    rw [hCast i, iteratedBlockIndex_directToIteratedBlockIndex]
+  · intro hIndex i
+    calc
+      Fin.cast ((F.blockPhysDim_nested_eq k).symm) i =
+          directToIteratedBlockIndex d (F.period k) (F.extra k)
+            (iteratedBlockIndex d (F.period k) (F.extra k)
+              (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i)) := by
+            rw [directToIteratedBlockIndex_iteratedBlockIndex]
+      _ = directToIteratedBlockIndex d (F.period k) (F.extra k)
+          (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i) := by
+            rw [hIndex i]
+
 /-- The blocked-word comparison follows if the canonical identification from the common
 alphabet to an iterated alphabet agrees with the grouping map that reads a direct word in
 consecutive blocks of length $m_k$ (the period of block $k$). -/

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -436,8 +436,8 @@ noncomputable def directIteratedBlockEquiv (d m n : ℕ) :
     (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
     (directIteratedBlockEquiv d m n).symm i = iteratedBlockIndex d m n i := rfl
 
-/-- A direct index is the grouping of a direct blocked word exactly when flattening it
-recovers that direct blocked index. -/
+/-- An iterated blocked index `j` is the grouping of a direct blocked index `i`
+exactly when flattening `j` recovers `i`. -/
 theorem eq_directToIteratedBlockIndex_iff_iteratedBlockIndex_eq (d m n : ℕ)
     (i : Fin (blockPhysDim d (m * n)))
     (j : Fin (blockPhysDim (blockPhysDim d m) n)) :

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -357,6 +357,14 @@ theorem blockIndexOfList_wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) :
   unfold blockIndexOfList wordOfBlock decodeBlock
   simp [blockPhysDim]
 
+/-- Decoding blocked physical indices as words is injective. -/
+theorem wordOfBlock_injective (d L : ℕ) : Function.Injective (wordOfBlock d L) := by
+  intro i j hij
+  have hdecode : decodeBlock d L i = decodeBlock d L j := by
+    exact List.ofFn_injective hij
+  unfold decodeBlock at hdecode
+  exact (Fintype.equivFin (Fin L → Fin d)).symm.injective hdecode
+
 /-- Flattening the grouped iterated index recovers the direct blocked word. -/
 theorem flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex (d m n : ℕ)
     (i : Fin (blockPhysDim d (m * n))) :
@@ -382,6 +390,67 @@ theorem wordOfBlock_iteratedBlockIndex_directToIteratedBlockIndex (d m n : ℕ)
       wordOfBlock d (m * n) i := by
   rw [wordOfBlock_iteratedBlockIndex,
     flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex]
+
+/-- Grouping a direct blocked index and then flattening the iterated index recovers the
+original direct blocked index. -/
+theorem iteratedBlockIndex_directToIteratedBlockIndex (d m n : ℕ)
+    (i : Fin (blockPhysDim d (m * n))) :
+    iteratedBlockIndex d m n (directToIteratedBlockIndex d m n i) = i := by
+  exact wordOfBlock_injective d (m * n)
+    (wordOfBlock_iteratedBlockIndex_directToIteratedBlockIndex d m n i)
+
+/-- The map grouping a direct blocked word into iterated blocked words is surjective. -/
+theorem directToIteratedBlockIndex_surjective (d m n : ℕ) :
+    Function.Surjective (directToIteratedBlockIndex d m n) := by
+  have hLeft : Function.LeftInverse (iteratedBlockIndex d m n) (directToIteratedBlockIndex d m n) :=
+    iteratedBlockIndex_directToIteratedBlockIndex d m n
+  have hInjective : Function.Injective (directToIteratedBlockIndex d m n) := hLeft.injective
+  have hEquiv : Fin (blockPhysDim d (m * n)) ≃
+      Fin (blockPhysDim (blockPhysDim d m) n) :=
+    finCongr (blockPhysDim_blockPhysDim d m n).symm
+  exact (Finite.injective_iff_surjective_of_equiv hEquiv).mp hInjective
+
+/-- Flattening an iterated blocked index and then grouping it back recovers the iterated
+blocked index. -/
+theorem directToIteratedBlockIndex_iteratedBlockIndex (d m n : ℕ)
+    (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
+    directToIteratedBlockIndex d m n (iteratedBlockIndex d m n i) = i := by
+  have hLeft : Function.LeftInverse (iteratedBlockIndex d m n) (directToIteratedBlockIndex d m n) :=
+    iteratedBlockIndex_directToIteratedBlockIndex d m n
+  exact hLeft.rightInverse_of_surjective (directToIteratedBlockIndex_surjective d m n) i
+
+/-- The canonical bijection between direct length-`m * n` blocked indices and iterated
+length-`n` blocked indices obtained by grouping consecutive length-`m` words. -/
+noncomputable def directIteratedBlockEquiv (d m n : ℕ) :
+    Fin (blockPhysDim d (m * n)) ≃ Fin (blockPhysDim (blockPhysDim d m) n) where
+  toFun := directToIteratedBlockIndex d m n
+  invFun := iteratedBlockIndex d m n
+  left_inv := iteratedBlockIndex_directToIteratedBlockIndex d m n
+  right_inv := directToIteratedBlockIndex_iteratedBlockIndex d m n
+
+@[simp] theorem directIteratedBlockEquiv_apply (d m n : ℕ)
+    (i : Fin (blockPhysDim d (m * n))) :
+    directIteratedBlockEquiv d m n i = directToIteratedBlockIndex d m n i := rfl
+
+@[simp] theorem directIteratedBlockEquiv_symm_apply (d m n : ℕ)
+    (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
+    (directIteratedBlockEquiv d m n).symm i = iteratedBlockIndex d m n i := rfl
+
+/-- A direct index is the grouping of a direct blocked word exactly when flattening it
+recovers that direct blocked index. -/
+theorem eq_directToIteratedBlockIndex_iff_iteratedBlockIndex_eq (d m n : ℕ)
+    (i : Fin (blockPhysDim d (m * n)))
+    (j : Fin (blockPhysDim (blockPhysDim d m) n)) :
+    j = directToIteratedBlockIndex d m n i ↔ iteratedBlockIndex d m n j = i := by
+  constructor
+  · intro h
+    rw [h, iteratedBlockIndex_directToIteratedBlockIndex]
+  · intro h
+    calc
+      j = directToIteratedBlockIndex d m n (iteratedBlockIndex d m n j) :=
+        (directToIteratedBlockIndex_iteratedBlockIndex d m n j).symm
+      _ = directToIteratedBlockIndex d m n i := by
+        rw [h]
 
 /-- Rewriting the blocking length does not change the decoded blocked word. -/
 theorem wordOfBlock_cast_length (d : ℕ) {L₁ L₂ : ℕ} (h : L₁ = L₂)

--- a/audits/2026-04-30_issue990_blocked_word_comparison.md
+++ b/audits/2026-04-30_issue990_blocked_word_comparison.md
@@ -31,14 +31,25 @@ The issue #1075 refinement adds a canonical grouping map in
 - `flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex`
 - `wordOfBlock_iteratedBlockIndex_directToIteratedBlockIndex`
 
+The issue #990 follow-up records this grouping map as a genuine equivalence:
+
+- `wordOfBlock_injective`
+- `iteratedBlockIndex_directToIteratedBlockIndex`
+- `directToIteratedBlockIndex_surjective`
+- `directToIteratedBlockIndex_iteratedBlockIndex`
+- `directIteratedBlockEquiv`
+- `eq_directToIteratedBlockIndex_iff_iteratedBlockIndex_eq`
+
 For a direct blocked index of length $m n$, this map decodes its word, cuts it
 into $n$ consecutive words of length $m$, encodes those words as the letters of
-an iterated block, and proves that flattening the resulting iterated index
-recovers the original direct word.
+an iterated block, and proves that flattening and regrouping are inverse
+operations on blocked indices, not only on decoded words.
 
 The assembly file also records the exact remaining coordinate assertion as
-`CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees` and provides the
-corresponding comparison theorems:
+`CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees`, the equivalent
+post-flattening formulation
+`CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees_iff_iteratedBlockIndex_cast`,
+and the corresponding comparison theorems:
 
 - `CommonBlockedCyclicSectorFamily.wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees`
 - `CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees`
@@ -61,7 +72,7 @@ sharpened coordinate assertion `groupedBlockCastAgrees`.
 
 The remaining theorem is now sharpened to a precise coordinate assertion. For
 each common cyclic-sector family `F`, block `k`, and physical index
-`i : Fin (blockPhysDim d F.p)`, the numeric cast
+`i : Fin (blockPhysDim d F.p)`, the canonical `Fin.cast` identification
 
 ```lean
 Fin.cast ((F.blockPhysDim_nested_eq k).symm) i
@@ -72,16 +83,21 @@ product length `F.period k * F.extra k` and then applying
 `directToIteratedBlockIndex`. This is the proposition
 `F.groupedBlockCastAgrees k`.
 
-The new core theorem proves that `directToIteratedBlockIndex` is the mathematically
-expected grouping map: applying `iteratedBlockIndex` to it recovers the original
-direct blocked word. Thus no MPS-theoretic assumption remains hidden in the
-comparison lemmas. What remains is only the compatibility between this grouping
-map and the particular numeric `Fin.cast` used by `CommonBlockedCyclicSectorFamily`.
+The core theorem now proves that `directToIteratedBlockIndex` is the
+mathematically expected grouping map: together with `iteratedBlockIndex`, it is
+an equivalence between direct length-$m n$ blocked indices and iterated
+length-$n$ blocked indices whose letters are length-$m$ blocked words. The
+assembly theorem
+`CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees_iff_iteratedBlockIndex_cast`
+therefore narrows the remaining point to one assertion: after applying
+`iteratedBlockIndex`, the canonical `Fin.cast` identification must give the same
+direct blocked index as the length rewrite coming from
+`F.p_eq_period_mul_extra k`.
 
 Since the current blocked physical index is chosen through `Fintype.equivFin`,
-cardinal equality alone does not specify that the numeric order on the two `Fin`
-types is the consecutive grouping order. That coordinate choice must either be
-proved for the chosen enumeration or kept as the explicit relabelling recorded by
+cardinal equality alone does not specify that the order on the two `Fin` types
+is the consecutive grouping order. That coordinate choice must either be proved
+for the chosen enumeration or kept as the explicit relabelling recorded by
 `groupedBlockCastAgrees`.
 
 ## Paper path


### PR DESCRIPTION
## Summary

- prove that the direct-to-iterated blocked-word grouping map is a genuine equivalence, inverse to `iteratedBlockIndex`
- add a reusable iff formulation of `CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees` after applying `iteratedBlockIndex`
- update the blocked-word comparison audit to record the sharpened remaining coordinate-enumeration problem

## Issue status

Issue: https://github.com/LionSR/TNLean/issues/990 (kept open). This PR does **not** settle the issue: the exact equality between the existing `Fin.cast ((F.blockPhysDim_nested_eq k).symm)` and the consecutive grouping map is still not proved. The remaining point is now narrowed to showing that, after flattening by `iteratedBlockIndex`, that canonical identification agrees with the direct length rewrite from `F.p_eq_period_mul_extra k`.

## Coordination

PR #1082 is currently open/approved at `cc333377` and touches `ProportionalComparison.lean`, Ch. 8/Ch. 11 blueprint prose, and a separate audit. This branch was fetched against current `origin/main` after that check and does not touch those files, so there is no direct dependency or content duplication expected; I am prepared to rebase if #1082 merges first.

## Validation

- `lake build TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem`
- `lake build TNLean.MPS.CanonicalForm.Assembly`
- Lean diagnostics: `BlockingInfrastructure.lean` and `CyclicSectorDecomposition.lean` clean
- `git diff --check`

Only pre-existing long-line warnings replayed in `PeripheralUnitary`, `BNT/Construction`, and two old declarations in `CyclicSectorDecomposition`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new lemmas/defs and an audit update) and primarily strengthen existing blocking proofs without altering existing definitions or runtime behavior.
> 
> **Overview**
> Formalizes the direct-vs-iterated physical blocking regrouping as an actual equivalence in `BlockingInfrastructure.lean`, adding injectivity/surjectivity results, the inverse law `directToIteratedBlockIndex_iteratedBlockIndex`, and the packaged `directIteratedBlockEquiv` plus an `↔` characterization lemma.
> 
> In `CyclicSectorDecomposition.lean`, adds `groupedBlockCastAgrees_iff_iteratedBlockIndex_cast` to restate `groupedBlockCastAgrees` after applying `iteratedBlockIndex`, isolating the remaining coordinate-compatibility goal to a single cast equality.
> 
> Updates the issue #990 audit to document these new equivalence lemmas and the sharpened “remaining point” statement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c9c14ca2c70780705f8e645ed94685022b9d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->