### PR TITLE
feat(MPS/CanonicalForm): expose proportional common-sector cover bridge

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -33,6 +33,9 @@ BNT proportional-decomposition comparison of the nonzero-weight block families.
   injectivity, and finite-length span hypotheses.
 * `afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts` —
   common-length cyclic-sector output with conditional finite-length block-span consequences.
+* `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional` — the
+  same relabeled common-sector output, with the common cover obtained from a BNT
+  proportional-decomposition comparison for the produced nonzero-sector families.
 
 ## References
 
@@ -127,6 +130,55 @@ theorem toSpanHypotheses
     h.zeroTail_eq h.left_injective h.right_injective cover
 
 end CommonPrimitivePhaseCoverHypotheses
+
+/-- Remaining two-sided hypotheses for common primitive nonzero-sector families,
+formulated with a BNT proportional-decomposition comparison.
+
+This is the proportional-comparison version of `CommonPrimitivePhaseCoverHypotheses`: the
+structural theorem supplies the same primitive nonzero-sector data, while the remaining inputs
+are equality of the zero-tail dimensions, one-site injectivity on both sides, and a
+BNT comparison conclusion for the two block families. -/
+structure CommonPrimitiveProportionalHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (zeroTailA zeroTailB : ℕ)
+    (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x))
+    (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)) : Prop where
+  /-- The two zero-tail dimensions agree. -/
+  zeroTail_eq : zeroTailA = zeroTailB
+  /-- The left nonzero-sector blocks are one-site injective. -/
+  left_injective : ∀ x : Fin rA, IsInjective (blocksA x)
+  /-- The right nonzero-sector blocks are one-site injective. -/
+  right_injective : ∀ x : Fin rB, IsInjective (blocksB x)
+  /-- The two nonzero-sector block families satisfy the BNT proportional comparison conclusion. -/
+  proportional : ProportionalDecompositionConclusion (d := blockPhysDim d p) blocksA blocksB
+
+namespace CommonPrimitiveProportionalHypotheses
+
+/-- A proportional-decomposition comparison gives the corresponding phase-cover hypotheses. -/
+theorem toPhaseCoverHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {zeroTailA zeroTailB : ℕ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (h : CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB) :
+    CommonPrimitivePhaseCoverHypotheses zeroTailA zeroTailB blocksA blocksB where
+  zeroTail_eq := h.zeroTail_eq
+  left_injective := h.left_injective
+  right_injective := h.right_injective
+  cover := nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
+    (d := blockPhysDim d p) blocksA blocksB h.proportional
+
+/-- A proportional-decomposition comparison gives the corresponding span hypotheses. -/
+theorem toSpanHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {zeroTailA zeroTailB : ℕ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (h : CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB) :
+    CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB :=
+  h.toPhaseCoverHypotheses.toSpanHypotheses
+
+end CommonPrimitiveProportionalHypotheses
 
 /-- **Sector comparison from BNT proportional-decomposition data.**
 
@@ -655,5 +707,86 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonP
     hIrrA hIrrB hDimA hDimB
   exact (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
     hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toSpanHypotheses
+
+/-- **Sector comparison from relabeled common sectors and proportional-decomposition data.**
+
+Assume the blocked-word relabeling statement for common cyclic sectors.  Then the
+structural theorem
+`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` supplies one
+common positive blocking length and trace-preserving, primitive, irreducible
+nonzero-sector families on both sides.  If the remaining comparison assertions
+for exactly those families are available -- equality of the two zero-tail
+dimensions, injectivity at that blocking level, and a BNT proportional-decomposition
+comparison -- then `CommonPrimitiveProportionalHypotheses.toPhaseCoverHypotheses` gives
+the common MPV phase-cover hypotheses needed by
+`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover`.
+
+Thus this theorem exposes the BNT comparison as a precise conditional input for the
+common-sector families, without assuming a finite-length span equality separately. -/
+theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  refine afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover
+    A B hSame hReindexed ?_
+  intro p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB hp
+    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
+    hIrrA hIrrB hDimA hDimB
+  exact (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+    hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toPhaseCoverHypotheses
 
 end MPSTensor

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1352,6 +1352,58 @@ two-basis sector comparison theorem.
 	common MPV phase cover for the two block families.
 \end{proof}
 
+\begin{definition}[Remaining proportional-comparison hypotheses for common primitive sectors]%
+\label{def:common_primitive_proportional_hypotheses}
+	\lean{MPSTensor.CommonPrimitiveProportionalHypotheses}
+	\leanok
+	\uses{def:injective}
+	For two common primitive nonzero-sector families at one blocking length, this
+	condition records equality of the two zero-tail dimensions, one-site
+	injectivity of all blocks on both sides, and a BNT proportional-decomposition
+	comparison for the two block families. It is the BNT-comparison version of
+	Definition~\ref{def:common_primitive_phase_cover_hypotheses}.
+\end{definition}
+
+\begin{theorem}[Proportional-comparison hypotheses imply phase-cover hypotheses]%
+\label{thm:common_primitive_proportional_hypotheses_to_phase_cover_hypotheses}
+	\lean{MPSTensor.CommonPrimitiveProportionalHypotheses.toPhaseCoverHypotheses}
+	\leanok
+	\uses{def:common_primitive_proportional_hypotheses,
+		def:common_primitive_phase_cover_hypotheses,
+		thm:common_phase_cover_of_proportional_decomposition}
+	If two common primitive nonzero-sector families satisfy the proportional-comparison
+	hypotheses, then they satisfy the phase-cover hypotheses of
+	Definition~\ref{def:common_primitive_phase_cover_hypotheses}.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_phase_cover_of_proportional_decomposition}
+	The zero-tail equality and injectivity assumptions are already present. The BNT
+	proportional-decomposition comparison gives a common MPV phase cover by
+	Theorem~\ref{thm:common_phase_cover_of_proportional_decomposition}.
+\end{proof}
+
+\begin{theorem}[Proportional-comparison hypotheses imply the remaining span hypotheses]%
+\label{thm:common_primitive_proportional_hypotheses_to_span_hypotheses}
+	\lean{MPSTensor.CommonPrimitiveProportionalHypotheses.toSpanHypotheses}
+	\leanok
+	\uses{def:common_primitive_proportional_hypotheses,
+		def:common_primitive_span_hypotheses}
+	If two common primitive nonzero-sector families satisfy the proportional-comparison
+	hypotheses, then they satisfy the remaining span hypotheses of
+	Definition~\ref{def:common_primitive_span_hypotheses}.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_primitive_proportional_hypotheses_to_phase_cover_hypotheses,
+		thm:common_primitive_phase_cover_hypotheses_to_span_hypotheses}
+	First convert the BNT proportional-decomposition comparison into common phase-cover
+	hypotheses. The phase-cover-to-span theorem then gives the finite-length span
+	equality together with the zero-tail and injectivity hypotheses.
+\end{proof}
+
 \begin{theorem}[Zero-tail nonzero block decompositions with a common MPV phase cover]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
@@ -1505,6 +1557,29 @@ two-basis sector comparison theorem.
 	to form the remaining span hypotheses of
 	Definition~\ref{def:common_primitive_span_hypotheses}.  Then apply the
 	relabeled common-sector theorem with those span hypotheses.
+\end{proof}
+
+\begin{theorem}[Relabeled common sectors with proportional-comparison data]%
+\label{thm:afterBlocking_sectorComparison_reindexed_proportional}
+	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
+	\leanok
+	\uses{def:common_primitive_proportional_hypotheses,
+		def:common_sector_relabeling_hypothesis}
+	Let $A$ and $B$ have the same MPV family, and assume the blocked-word relabeling
+	hypothesis for common cyclic sectors. The common-sector structural theorem
+	produces the common primitive nonzero-sector families. If those families satisfy
+	the proportional-comparison hypotheses of
+	Definition~\ref{def:common_primitive_proportional_hypotheses}, then the same
+	sector-weight comparison conclusion holds.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_primitive_proportional_hypotheses_to_phase_cover_hypotheses,
+		thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	Convert the BNT proportional-decomposition comparison for the produced families
+	to common phase-cover hypotheses, and then apply the relabeled common-sector
+	comparison theorem with common phase-cover data.
 \end{proof}
 
 \begin{theorem}[Cast-compatible MPV scaling implies phase-matched sector comparison]%


### PR DESCRIPTION
## Summary

Refs #1068.

This is a conditional bridge on the #1068 path, rebased after PR #1082 merged. It does not duplicate #1082's common-sector block-span consequence. Instead it packages the BNT/proportional route that turns the produced common primitive nonzero-sector families into the common MPV phase-cover hypotheses already consumed by the zero-tail sector-comparison theorem.

Lean additions:
- `MPSTensor.CommonPrimitiveProportionalHypotheses`, bundling zero-tail dimension equality, one-site injectivity on both sides, and a `ProportionalDecompositionConclusion` for the produced common-sector families.
- `MPSTensor.CommonPrimitiveProportionalHypotheses.toPhaseCoverHypotheses`, using the proportional conclusion to construct the cover required by `CommonPrimitivePhaseCoverHypotheses`.
- `MPSTensor.CommonPrimitiveProportionalHypotheses.toSpanHypotheses`, composing the phase-cover route with `CommonPrimitivePhaseCoverHypotheses.toSpanHypotheses`.
- `MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional`, applying the relabeled common-sector theorem when the remaining produced families satisfy the proportional-comparison hypotheses.

This leaves issue #1068 open: the actual BNT/proportional comparison for the produced common-length cyclic-sector families, together with #990 relabeling and zero-tail/injectivity refinements, remains the paper-level input.

## Validation

- `lake build TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `lake build TNLean.MPS.CanonicalForm.Assembly`
- Lean diagnostics for `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean` clean
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- Added-line proof-integrity and banned-prose scans clean

Only pre-existing long-line warnings replayed in `PeripheralUnitary`, `BNT/Construction`, and `CyclicSectorDecomposition`.
