### PR TITLE
refactor(MPS/CanonicalForm): rename structural zero-tail theorem

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -417,7 +417,7 @@ primitive transfer maps, positive bond dimensions, and nonzero weights; the
 zero-tail equations explain precisely why these nonzero parts are only immediately
 identified at positive lengths unless the `N = 0` zero-tail identity is also
 resolved. -/
-theorem fundamentalTheorem_after_blocking_structural_with_zeroTail
+theorem afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B) :

--- a/audits/2026-04-26_issue877_common_live_blocks.md
+++ b/audits/2026-04-26_issue877_common_live_blocks.md
@@ -29,7 +29,7 @@ separate overlap/span hypotheses owned by Slot G.
    `SameMPV₂` of the two nonzero-block tensors.  The equality of zero tails is deliberately
    not asserted automatically here.
 
-4. `MPSTensor.fundamentalTheorem_after_blocking_structural_with_zeroTail`
+4. `MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`
    strengthens the existing structural wrapper by retaining the zero-tail MPV
    equations returned by `exists_tp_primitive_blockDecomp_after_blocking`, together
    with the blocked `SameMPV₂` relations from the original equality.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3187,7 +3187,7 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{theorem}[Structural after-blocking form with zero-tail equations]%
 \label{thm:ft_after_blocking_structural_zero_tail}
-	\lean{MPSTensor.fundamentalTheorem_after_blocking_structural_with_zeroTail}
+	\lean{MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂}
 	\leanok
 	\uses{thm:tp_primitive_blockdecomp, def:same_mpv2, def:zero_mps_tensor}
 	If two tensors generate the same MPV family, then each tensor admits a blocked


### PR DESCRIPTION
## Summary
- rename `MPSTensor.fundamentalTheorem_after_blocking_structural_with_zeroTail` to `MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`
- update the Ch. 8 blueprint `\lean{}` entry and the existing issue #877 audit reference
- intentionally do not add a deprecated alias, since preserving the old process-inspired public API name would perpetuate the naming problem tracked by #1061

## Coordination
- rebased onto latest `origin/main` after PR #1082 merged at `819e6c3b`
- this PR does not duplicate #1082 content: it only renames an existing StructuralTheorem declaration and its references
- independent of still-open canonical branches/issues such as #1096/#1068/#971; if another branch edits the same Ch. 8 neighborhood, this PR should rebase cleanly as a one-line `\lean{}` update

## Validation
- `lake build TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem TNLean.MPS.CanonicalForm.Assembly`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (local ignored `blueprint/lean_decls` regeneration)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- Lean diagnostics: no errors/warnings/hints for `StructuralTheorem.lean` and `ProportionalComparison.lean`
- `git diff --check`

Closes #1061

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename-only change, but it is a breaking API change for any downstream Lean code that referenced the old theorem name.
> 
> **Overview**
> Renames the structural after-blocking zero-tail theorem from `MPSTensor.fundamentalTheorem_after_blocking_structural_with_zeroTail` to `MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`.
> 
> Updates documentation references to the new name in the issue #877 audit note and the Ch. 8 blueprint `\lean{}` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a205e487a22c39b0c2033946f97b06f34865ef16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->