### PR TITLE
docs(audits): scout FT organization and proof tactics

### DIFF
--- a/audits/2026-05-01_issue1077_tn_proof_tactics_scout.md
+++ b/audits/2026-05-01_issue1077_tn_proof_tactics_scout.md
@@ -1,0 +1,159 @@
+# Issue #1077: scout for tensor-network proof tactics
+
+Issue #1077 asks whether the project should develop proof tactics for tensor-network arguments.  This note scopes the recurring proof patterns before adding any tactic code.  The main conclusion is that the first useful step is not a large tactic, but a small family of normalization lemmas and thin tactic wrappers around them.
+
+## Recurrent proof shapes
+
+A scan of the current MPS and channel files shows five proof shapes that recur often enough to deserve support.
+
+### 1. MPV extensionality and positive-length extensionality
+
+Many proofs start from one of the predicates
+
+```text
+SameMPV₂ A B
+SameMPV₂Pos A B
+```
+
+and immediately introduce a length and a physical word.  The informal argument is always the same: reduce a family equality to the scalar equality of the corresponding MPV coefficient.
+
+```text
+SameMPV₂ A B
+    │ intro N σ
+    ▼
+mpv A σ = mpv B σ
+```
+
+A small tactic `mpv_ext` could do only this introduction and leave the coefficient goal visible.  It should not try to solve transfer-matrix algebra.
+
+### 2. Zero-tail cancellation
+
+The canonical-form assembly layer repeatedly compares expressions of the form
+
+```text
+mpv (blockTensor A p) σ = mpv (zeroMPSTensor _ zA) σ + mpv NA σ
+mpv (blockTensor B p) σ = mpv (zeroMPSTensor _ zB) σ + mpv NB σ
+```
+
+At positive length, the zero-tail terms vanish; at length zero, the zero-tail dimensions remain.  The useful automation is a normal form that knows the two cases separately.
+
+```text
+positive length N > 0:       zero tail disappears
+length zero N = 0:           zero-tail dimension remains as a scalar
+```
+
+A tactic here should probably be called only after the proof has chosen the length case.  A good first target is a lemma collection, not a tactic that performs case splits automatically.
+
+### 3. Blocking-word normalization
+
+The blocked-word work in `TNLean/MPS/Core/BlockingInfrastructure.lean` now has a clean vocabulary:
+
+```text
+direct blocked index i
+        │ group into length-m chunks
+        ▼
+iterated blocked index j
+        │ flatten
+        ▼
+direct blocked index i
+```
+
+The key diagram is:
+
+```text
+Fin (blockPhysDim d (m * n))
+        directToIteratedBlockIndex d m n
+                 ─────────────────────────▶
+Fin (blockPhysDim (blockPhysDim d m) n)
+                 ◀─────────────────────────
+        iteratedBlockIndex d m n
+```
+
+PR #1096 added the equivalence
+`eq_directToIteratedBlockIndex_iff_iteratedBlockIndex_eq`.  The next useful tactic support is a `simp` normal form for this diagram:
+
+- rewrite `directIteratedBlockEquiv` to its two maps;
+- reduce a grouped index equality to a flattened-index equality;
+- normalize `wordOfBlock` after grouping and flattening.
+
+A tactic name such as `block_words` would be reasonable, but the tactic should initially be only a wrapper around a carefully curated simp set.
+
+### 4. Transfer-map and trace normalization
+
+The channel and overlap files repeatedly use identities such as `transferMap_apply`, `trace_smul`, and adjoint simplifications.  The pattern is less MPS-specific than the block-word pattern, but it is common in this repository.
+
+```text
+transferMap A X
+    │ unfold once
+    ▼
+∑ i, A i * X * (A i)ᴴ
+    │ trace and scalar rules
+    ▼
+standard trace expression
+```
+
+A useful helper would be a tactic `transfer_simp` that unfolds only the intended transfer-map definitions and applies a small trace-scalar simp set.  It should avoid broad `simp` over matrix multiplication, since that tends to make goals harder to read.
+
+### 5. Span consequences from common phase or proportional data
+
+The common-sector comparison layer now uses two direct implications:
+
+```text
+MPVCommonPhaseCover blocksA blocksB
+        ───────────────▶ finite-length span equality
+
+ProportionalDecompositionConclusion blocksA blocksB
+        ───────────────▶ finite-length span equality
+```
+
+These are already lemma-shaped.  A tactic is not the first need here.  The useful reorganization is to keep theorem statements consuming named structures such as `CommonPrimitiveSpanHypotheses`, `CommonPrimitivePhaseCoverHypotheses`, and the proportional bridge data, so that downstream proofs do not destruct raw conjunctions.
+
+## Proposed tactic layers
+
+The tactics should be staged from least to most ambitious.
+
+### Layer 0: named simp sets
+
+Add local theorem attributes only after the relevant lemmas are stable.  Candidate groups:
+
+```text
+[mps_block_words]
+[mps_transfer]
+[mps_zero_tail]
+```
+
+This layer is often enough.  It also gives reliable benchmarks for any later tactic.
+
+### Layer 1: thin wrappers
+
+Introduce very small tactics whose behavior can be described in one sentence:
+
+| tactic | intended behavior |
+|---|---|
+| `mpv_ext` | introduce MPV length and word variables for `SameMPV₂` or `SameMPV₂Pos` goals |
+| `block_words` | normalize direct/iterated blocking maps and `wordOfBlock` expressions |
+| `transfer_simp` | unfold transfer maps and simplify trace/scalar side conditions using the curated set |
+| `zero_tail_simp` | simplify zero-tail MPV terms after the length case is already fixed |
+
+The wrappers should be intentionally simple.  When the normal form does not apply, they should leave clear unsolved goals rather than search.
+
+### Layer 2: proof-pattern tactics
+
+Only after Layer 1 is tested should the project consider higher-level tactics, for example a tactic that turns a common MPV phase cover into the corresponding span hypothesis.  That layer should be restricted to the canonical-form assembly files, where the target structures are known.
+
+## Suggested first implementation target
+
+The safest first PR for actual tactic code would be a small `block_words` wrapper, because #1096 has just supplied a clean equivalence between grouped and flattened blocked indices.  A minimal first implementation would:
+
+1. create a small module under `TNLean/MPS/SharedInfra` or `TNLean/MPS/Core` for block-word simp support;
+2. tag only the direct/iterated block equivalence lemmas that have stable statements;
+3. add two or three example lemmas showing that the wrapper rewrites grouped-index equalities to flattened-index equalities;
+4. avoid changing mathematical theorem statements.
+
+## What not to build yet
+
+A broad tactic that tries to prove tensor-network equalities from diagrams would be premature.  The diagrams are useful for choosing normal forms, but Lean should first see explicit lemmas for the normal forms.  Once the block-word, zero-tail, and transfer-map normal forms are stable, a diagrammatic interface can be considered as notation for those lemmas.
+
+## Answer to the issue question
+
+Yes, the project can develop tensor-network proof tactics, but the first step should be a small infrastructure layer: named simp sets and thin wrappers for MPV extensionality, block-word normalization, transfer-map simplification, and zero-tail simplification.  The block-word normalizer is the best first candidate because it now has a precise direct-versus-iterated blocking equivalence to build on.

--- a/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
+++ b/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
@@ -1,0 +1,105 @@
+# Issue #1093: non-Gemma fundamental-theorem and canonical-form reorganization scout
+
+Issue #1093 asks whether the current fundamental-theorem and canonical-form reduction is as clean as it can be without using the Gemma-route periodic fundamental theorem.  Here “non-Gemma” means the route through the CPSV/CPGSV normal form and basis-of-normal-tensors comparison, rather than an appeal to the periodic fundamental theorem of arXiv:1708.00029.
+
+## Current state
+
+The direct canonical-form files are now in a much better state than they were before the common-sector waves.  In the present `main`, the assembly layer contains named hypotheses and bridge theorems for the previously implicit comparison data:
+
+- `MPSTensor.CommonSectorRelabelingHypothesis` names the remaining blocked-word relabeling assertion.
+- `MPSTensor.CommonPrimitiveSpanHypotheses` and `MPSTensor.CommonPrimitivePhaseCoverHypotheses` name the two common primitive comparison inputs.
+- `MPSTensor.afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts` records the finite-length span consequences available from a common phase cover or from proportional-decomposition data.
+- `MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover` composes the common primitive sector output with the common-cover comparison theorem.
+
+A useful high-level picture is:
+
+```text
+SameMPV₂ A B
+    │
+    ▼
+zero-tail split and TP primitive nonzero blocks
+    │
+    ▼
+common cyclic-sector blocking
+    │
+    ▼
+reindexed common primitive nonzero-sector families
+    │
+    ├── blocked-word relabeling hypothesis
+    ├── zero-tail and injectivity hypotheses
+    └── common phase cover or proportional-decomposition data
+            │
+            ▼
+finite-length nonzero-sector span equality
+            │
+            ▼
+BNT sector comparison and matched sector weights
+```
+
+A scan of `TNLean/MPS/CanonicalForm` and `TNLean/MPS/FundamentalTheorem` found no local `sorry` or `admit` occurrences.  The remaining issue is therefore not proof integrity; it is the shape of the public and intermediate API.
+
+## What is still not clean
+
+The non-Gemma route is not yet a single unconditional paper-level theorem.  The remaining mathematical inputs are still visible, and this is the right kind of incompleteness:
+
+1. **Blocked-word coordinate agreement.**  The current path isolates this as `CommonSectorRelabelingHypothesis d`.  PR #1096 narrowed the direct-versus-iterated blocking equivalence, but the exact common-sector coordinate agreement is still part of the #990 line of work.
+2. **Transport of weights and zero tails through the final common-sector choice.**  The #971 line remains relevant wherever the statement needs the produced common sectors to carry the exact weights and zero-tail comparison in the final form.
+3. **Common phase cover or proportional decomposition for the produced sectors.**  PR #1082 records the span consequences, and PR #1097 adds a proportional bridge, but the unconditional common-cover construction is still not closed.
+4. **Injectivity after any further blocking that the comparison theorem requires.**  The current theorems keep injectivity explicit, which is mathematically faithful.  It should remain explicit until the Wielandt/injectivity refinement is proved in the same language as the produced common sectors.
+
+These are real hypotheses, not mere naming artifacts.
+
+## Reorganization targets
+
+The next cleanup should avoid proving new mathematical content by hiding it inside broad theorem statements.  The useful reorganizations are local and structural.
+
+### 1. Keep intermediate theorem names in the `afterBlocking` family
+
+The old names beginning with `fundamentalTheorem_after_blocking_*` mix two roles: some are final theorem shapes, while others are intermediate structural facts.  The rename merged in PR #1099 is a good example of the desired direction.  Intermediate results should read like the mathematical operation they perform, for example:
+
+```text
+afterBlocking_*_of_sameMPV₂
+afterBlocking_*_of_reindexedNonzeroParts
+afterBlocking_*_of_commonPhaseCover
+```
+
+This makes the final fundamental theorem easier to state later, because the intermediate statements no longer claim to be the theorem itself.
+
+### 2. Continue replacing long anonymous hypotheses by named structures
+
+The structures added around #1080--#1083 are the right pattern.  When a theorem takes a long function returning many residual assumptions, the codomain should usually be a named structure.  The useful structures now are:
+
+```text
+CommonSectorRelabelingHypothesis
+CommonPrimitiveSpanHypotheses
+CommonPrimitivePhaseCoverHypotheses
+```
+
+The next proportional bridge should follow the same style.  A proportional-decomposition structure is better than another raw conjunction, provided its fields are the exact mathematical data needed downstream.
+
+### 3. Separate public entry points from construction lemmas
+
+`TNLean/MPS/CanonicalForm/Assembly.lean` should remain a public import file, but the module docstring can eventually contain a short table with three levels:
+
+| level | role |
+|---|---|
+| structural output | zero-tail split, TP primitive blocks, common cyclic sectors |
+| comparison hypotheses | blocked-word relabeling, zero-tail equality, injectivity, common phase/proportional data |
+| sector comparison | BNT sector data and matched sector weights |
+
+This is a documentation reorganization, but it prevents future theorem names from carrying the whole proof outline.
+
+### 4. Keep `MPS/FundamentalTheorem` and `MPS/CanonicalForm/Assembly` distinct
+
+`TNLean/MPS/FundamentalTheorem` contains the equal-case and proportional BNT comparison layer.  `TNLean/MPS/CanonicalForm/Assembly` builds the after-blocking canonical-form reduction.  The non-Gemma route uses both, but they should not be collapsed into one file or one theorem family yet.  The clean final theorem should import the comparison layer, not duplicate it.
+
+## Suggested next PRs
+
+1. Audit the remaining `fundamentalTheorem_after_blocking_*` intermediate names after the #1099 rename, and rename only those whose role is clearly structural rather than final.
+2. Continue the #1097 proportional-bridge style: any remaining proportional hypotheses should be named structures rather than anonymous conjunctions.
+3. Add a compact public-roadmap docstring to `TNLean/MPS/CanonicalForm/Assembly.lean`, once the active canonical branches have settled.
+4. Only after #990, #971, #1068, and the injectivity/Wielandt refinement are discharged should the project add a final theorem whose statement no longer exposes these hypotheses.
+
+## Answer to the issue question
+
+The route is much cleaner now, and it is clean in the most important sense: the non-Gemma assumptions are exposed rather than hidden.  It is not yet as clean as it can be.  The remaining cleanup is mostly API reorganization around theorem names and named hypothesis structures, while the remaining mathematical work is exactly the blocked-word, zero-tail/weight transport, common-cover/proportional, and injectivity data listed above.


### PR DESCRIPTION
## Summary

Refs #1093 and #1077.

This PR adds two audit notes:

- `audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md` assesses the current non-Gemma fundamental-theorem/canonical-form reduction and identifies concrete reorganization targets without duplicating the merged #1097/#1099 content.
- `audits/2026-05-01_issue1077_tn_proof_tactics_scout.md` scopes a staged approach to tensor-network proof tactics, with diagrams for MPV extensionality, zero-tail cancellation, blocked-word normalization, transfer-map normalization, and common-sector span consequences.

The notes do not close either issue; they provide the scouting requested there and identify safe follow-up work.

## Validation

- `git diff --check`
- local prose scan of the two new audit files against the main banned software/process vocabulary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds audit-only markdown notes with no changes to Lean code or behavior.
> 
> **Overview**
> Adds two new audit notes under `audits/`.
> 
> One note scopes recurring tensor-network/MPS proof patterns and proposes a staged plan for lightweight automation (curated simp sets plus thin wrappers like `mpv_ext`, `block_words`, `transfer_simp`, `zero_tail_simp`) rather than a monolithic tactic.
> 
> The other reviews the current non-Gemma fundamental-theorem/canonical-form route and identifies follow-up cleanup focused on API/theorem naming and using named hypothesis structures, without introducing new mathematical claims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729244a38a7d32dc6e2d9e3f05b46115be811893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->