### PR TITLE
feat(MPS/CanonicalForm): transport grouped zero tails (#971)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1172,8 +1172,8 @@ abbrev CommonSectorRelabelingHypothesis (d : ℕ) : Prop :=
 
 /-- The global coordinate-grouping assertion for common cyclic-sector families.
 
-It requires every common blocked cyclic-sector family to satisfy
-`groupedBlockCastAgrees` for each original block, so the canonical identification
+It requires every common blocked cyclic-sector family to satisfy the
+coordinate-grouping condition for each original block, so the canonical identification
 with the iterated blocked alphabet is the explicit grouping of direct blocked words. -/
 abbrev CommonGroupedBlockCastHypothesis (d : ℕ) : Prop :=
   ∀ {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -938,6 +938,48 @@ theorem zeroTail_commonFlat_of_groupedBlockCastAgrees
   exact zeroTail_commonFlat_of_blockwise A μ blocks F hMPV
     (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k (hCast k))
 
+/-- The preceding zero-tail rewriting from the coordinate-grouping condition, expressed at a
+prescribed common length. -/
+theorem zeroTail_commonFlatAt_of_groupedBlockCastAgrees
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p : ℕ} (hp : F.p = p)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
+    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+      mpv (blockTensor (d := d) (D := D) A p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p)
+            (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) σ := by
+  subst p
+  simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocksAt] using
+    zeroTail_commonFlat_of_groupedBlockCastAgrees A μ blocks F hMPV hCast
+
+/-- At positive lengths, the blocked tensor has the same MPV coefficients as the
+weighted common-sector family whenever the coordinate-grouping condition holds. -/
+theorem sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p : ℕ} (hp : F.p = p)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
+    SameMPV₂Pos
+      (blockTensor (d := d) (D := D) A p)
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) := by
+  have hZeroTail := zeroTail_commonFlatAt_of_groupedBlockCastAgrees
+    (d := d) (D := D) (r := r) (z := z) (dim := dim)
+    A μ blocks F hp hMPV hCast
+  exact sameMPV₂Pos_of_zeroTail_eq _ _ hZeroTail
+
 /-- If the canonical blocked nonzero part agrees with the common reindexed blocks,
 the zero-tail equation can be rewritten using the derived common-sector family.
 This is the one-sided theorem that puts the reindexed data above in the form used
@@ -1081,6 +1123,36 @@ theorem zeroTail_commonFlat_transport_of_reindexed
   · intro x
     exact F.commonFlatWeight_ne_zero μ hμ x
 
+/-- The one-sided zero-tail equation, weighted nonzero-part equality, and nonvanishing
+of transported common-sector weights obtained from the coordinate-grouping condition. -/
+theorem zeroTail_commonFlat_transport_of_groupedBlockCastAgrees
+    {d D r z : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (hμ : ∀ k, μ k ≠ 0)
+    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
+    (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
+    (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
+      mpv (blockTensor (d := d) (D := D) A F.p) σ =
+        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
+          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ) ∧
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) F.commonFlatBlocks) ∧
+    (∀ x, F.commonFlatWeight μ x ≠ 0) := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact zeroTail_commonFlat_of_groupedBlockCastAgrees A μ blocks F hMPV hCast
+  · exact F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_groupedBlockCastAgrees μ hCast
+  · intro x
+    exact F.commonFlatWeight_ne_zero μ hμ x
+
 /-- The one-sided blocked-word relabeling hypothesis for common cyclic sectors.
 
 It says that, for every common cyclic-sector family, the canonically blocked
@@ -1097,6 +1169,30 @@ abbrev CommonSectorRelabelingHypothesis (d : ℕ) : Prop :=
         (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)
+
+/-- The global coordinate-grouping assertion for common cyclic-sector families.
+
+It requires every common blocked cyclic-sector family to satisfy
+`groupedBlockCastAgrees` for each original block, so the canonical identification
+with the iterated blocked alphabet is the explicit grouping of direct blocked words. -/
+abbrev CommonGroupedBlockCastHypothesis (d : ℕ) : Prop :=
+  ∀ {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (F : CommonBlockedCyclicSectorFamily blocks),
+    ∀ k : Fin r, F.groupedBlockCastAgrees k
+
+namespace CommonGroupedBlockCastHypothesis
+
+/-- The coordinate-grouping assertion implies the one-sided reindexing hypothesis
+used by the common-sector structural theorem. -/
+theorem toRelabelingHypothesis {d : ℕ}
+    (hCast : CommonGroupedBlockCastHypothesis d) :
+    CommonSectorRelabelingHypothesis d := by
+  intro r dim μ blocks F
+  exact F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees μ
+    (hCast blocks F)
+
+end CommonGroupedBlockCastHypothesis
 
 set_option maxHeartbeats 800000 in
 -- The conclusion records both decompositions and all their structural hypotheses together.

--- a/audits/2026-04-27_issue971_weight_zero_tail.md
+++ b/audits/2026-04-27_issue971_weight_zero_tail.md
@@ -30,3 +30,36 @@ In `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`:
 ## Remaining #969/#971 interface gap
 
 These lemmas do not yet construct the final flattened cyclic-sector family at one common physical blocking level. They provide the reusable arithmetic and MPV bookkeeping that such a theorem should call once the dependent-index flattening and nested-blocking associativity data are fixed.
+
+## 2026-05-01 update — coordinate-grouped common-sector transport
+
+After the common-sector comparison and blocked-word grouping infrastructure
+merged, the one-sided zero-tail transport can be stated directly from the precise
+coordinate assertion now isolated in
+`CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees`.
+
+New declarations in `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`:
+
+- `MPSTensor.zeroTail_commonFlatAt_of_groupedBlockCastAgrees`: the grouped-block
+  comparison rewrites the zero-tail equation with the weighted common-sector
+  family at any prescribed equal common length.
+- `MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees`: at
+  positive lengths the zero-tail term vanishes, so the blocked tensor agrees with
+  that weighted common-sector family.
+- `MPSTensor.zeroTail_commonFlat_transport_of_groupedBlockCastAgrees`: bundles the
+  zero-tail equation, the weighted nonzero-part MPV equality, and nonvanishing of
+  the transported common-sector weights under the grouped-block coordinate
+  assertion.
+- `MPSTensor.CommonGroupedBlockCastHypothesis` and
+  `MPSTensor.CommonGroupedBlockCastHypothesis.toRelabelingHypothesis`: record the
+  global coordinate-grouping assertion and show that it implies the reindexed
+  nonzero-part hypothesis used by the common-sector structural theorem.
+
+This does not prove the coordinate assertion itself.  After #1096, the direct
+and iterated blocked alphabets are related by the explicit equivalence
+`directIteratedBlockEquiv`, and
+`groupedBlockCastAgrees_iff_iteratedBlockIndex_cast` restates the remaining point
+as the comparison between this equivalence and the canonical identification used
+inside `CommonBlockedCyclicSectorFamily`.  The present transport theorem therefore
+uses the grouped-block coordinate assertion as the honest remaining input rather
+than replacing it by a stronger unproved coordinate choice.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3559,10 +3559,10 @@ The following results separate the zero blocks from the nonzero blocks.
 	one-sided form of this conversion, and
 	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_reindexed}
 	records it simultaneously for the two common-length sector families.  The
-	auxiliary transport statements
+	auxiliary transport statements,
 	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed},
 	\ref{thm:zero_tail_common_flat_transport_of_grouped_block_cast}, and
-	\ref{thm:samempv_pos_zero_tail_identity_transport} record the nonzero
+	\ref{thm:samempv_pos_zero_tail_identity_transport}, record the nonzero
 	transported weights and the preservation of the positive-length and length-zero
 	identities, while
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3324,22 +3324,29 @@ The following results separate the zero blocks from the nonzero blocks.
 \label{thm:zero_tail_common_flat_of_blocked_word_comparison}
 	\lean{MPSTensor.zeroTail_commonFlat_of_blockwise,
 		MPSTensor.zeroTail_commonFlat_of_word_eq,
-		MPSTensor.zeroTail_commonFlat_of_groupedBlockCastAgrees}
+		MPSTensor.zeroTail_commonFlat_of_groupedBlockCastAgrees,
+		MPSTensor.zeroTail_commonFlatAt_of_groupedBlockCastAgrees,
+		MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees}
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_blocked_word_comparison}
+		thm:common_blocked_cyclic_sector_blocked_word_comparison,
+		def:same_mpv2_pos}
 	For one side, suppose that the original tensor decomposes, as an MPV family,
 	into a zero-tail contribution plus a weighted block-sum nonzero part over the
 	original physical alphabet.  If each directly blocked nonzero block agrees with
 	the corresponding iterated-blocking tensor, then after the common blocking length
 	the zero-tail equation may be written directly with the weighted derived
 	common-sector family.  It is enough to prove the corresponding equality of
-	blocked words for every nonzero block.
+	blocked words for every nonzero block.  Under the coordinate-grouping condition,
+	the same statement is available at any prescribed equal common length, and at
+	positive lengths the zero-tail term vanishes so the blocked tensor agrees with
+	the weighted common-sector tensor.
 \end{theorem}
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_blocked_word_comparison}
+		thm:common_blocked_cyclic_sector_blocked_word_comparison,
+		def:same_mpv2_pos}
 	First transport the original zero-tail/nonzero decomposition through the common
 	blocking length.  Then use the blockwise comparison of direct and iterated
 	blocking, assembled over the weighted direct sum, to replace the directly
@@ -3450,6 +3457,30 @@ The following results separate the zero blocks from the nonzero blocks.
 	derived common sectors.
 \end{proof}
 
+\begin{theorem}[Common-sector zero-tail data from coordinate grouping]%
+\label{thm:zero_tail_common_flat_transport_of_grouped_block_cast}
+	\lean{MPSTensor.zeroTail_commonFlat_transport_of_groupedBlockCastAgrees}
+	\leanok
+	\uses{thm:zero_tail_common_flat_of_blocked_word_comparison,
+		thm:common_blocked_cyclic_sector_blocked_word_comparison,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	Assume the one-sided zero-tail/nonzero decomposition and nonzero original
+	weights.  If the canonical identification of the common blocked alphabet with
+	each iterated alphabet agrees with consecutive grouping of blocked words, then
+	the zero-tail equation is rewritten with the weighted common-sector family, the
+	canonically blocked nonzero part agrees with that weighted common-sector family,
+	and all transported common-sector weights are nonzero.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:zero_tail_common_flat_of_blocked_word_comparison,
+		thm:common_blocked_cyclic_sector_blocked_word_comparison,
+		thm:common_blocked_cyclic_sector_derived_properties}
+	Use the coordinate-grouping comparison to identify the directly blocked nonzero
+	part with the weighted common-sector family, and combine this with the zero-tail
+	rewriting and the nonzero-weight statement for derived common sectors.
+\end{proof}
+
 \begin{theorem}[Two-sided common-length sectors after reindexing blocked words]%
 \label{thm:ft_after_blocking_common_length_common_sector_reindexed}
 	\lean{MPSTensor.fundamentalTheorem_after_blocking_commonLength_commonSector_of_reindexed}
@@ -3529,7 +3560,8 @@ The following results separate the zero blocks from the nonzero blocks.
 	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_reindexed}
 	records it simultaneously for the two common-length sector families.  The
 	auxiliary transport statements
-	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed} and
+	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed},
+	\ref{thm:zero_tail_common_flat_transport_of_grouped_block_cast}, and
 	\ref{thm:samempv_pos_zero_tail_identity_transport} record the nonzero
 	transported weights and the preservation of the positive-length and length-zero
 	identities, while

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3463,7 +3463,8 @@ The following results separate the zero blocks from the nonzero blocks.
 	\leanok
 	\uses{thm:zero_tail_common_flat_of_blocked_word_comparison,
 		thm:common_blocked_cyclic_sector_blocked_word_comparison,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		thm:common_blocked_cyclic_sector_derived_properties,
+		def:same_mpv2}
 	Assume the one-sided zero-tail/nonzero decomposition and nonzero original
 	weights.  If the canonical identification of the common blocked alphabet with
 	each iterated alphabet agrees with consecutive grouping of blocked words, then
@@ -3475,7 +3476,8 @@ The following results separate the zero blocks from the nonzero blocks.
 \begin{proof}\leanok
 	\uses{thm:zero_tail_common_flat_of_blocked_word_comparison,
 		thm:common_blocked_cyclic_sector_blocked_word_comparison,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		thm:common_blocked_cyclic_sector_derived_properties,
+		def:same_mpv2}
 	Use the coordinate-grouping comparison to identify the directly blocked nonzero
 	part with the weighted common-sector family, and combine this with the zero-tail
 	rewriting and the nonzero-weight statement for derived common sectors.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1497,6 +1497,38 @@ two-basis sector comparison theorem.
 	isolated by the remaining coordinate equality for direct and iterated blocking.
 \end{definition}
 
+\begin{definition}[Global coordinate-grouping hypothesis for common sectors]%
+\label{def:common_grouped_block_cast_hypothesis}
+	\lean{MPSTensor.CommonGroupedBlockCastHypothesis}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_grouped_block_cast}
+	This is the corresponding global assertion at the level of blocked words: every
+	common blocked cyclic-sector family satisfies the coordinate-grouping condition
+	for each original nonzero block.  Equivalently, the canonical identification with
+	each iterated blocked alphabet agrees with grouping the direct blocked word into
+	consecutive words of the period-removal length.
+\end{definition}
+
+\begin{theorem}[Coordinate grouping implies common-sector relabeling]%
+\label{thm:common_grouped_block_cast_to_relabeling}
+	\lean{MPSTensor.CommonGroupedBlockCastHypothesis.toRelabelingHypothesis}
+	\leanok
+	\uses{def:common_grouped_block_cast_hypothesis,
+		def:common_sector_relabeling_hypothesis,
+		thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	If the global coordinate-grouping hypothesis holds, then the blocked-word
+	relabeling hypothesis used by the common-sector structural theorem holds.  The
+	proof is exactly the weighted finite-sum comparison for direct and iterated
+	blocking applied to each common cyclic-sector family.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	Apply the coordinate-grouping comparison to each one-sided family and sum over
+	the original nonzero blocks with the transported powers of the weights.
+\end{proof}
+
 \begin{theorem}[Common-length sectors with conditional block-span consequences]%
 \label{thm:after_blocking_common_primitive_irreducible_blocks_block_span_consequences}
 	\lean{MPSTensor.afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts}


### PR DESCRIPTION
## Summary

- add one-sided zero-tail and positive-length transport statements from the grouped blocked-word coordinate assertion:
  - `zeroTail_commonFlatAt_of_groupedBlockCastAgrees`
  - `sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees`
  - `zeroTail_commonFlat_transport_of_groupedBlockCastAgrees`
- add `CommonGroupedBlockCastHypothesis` and `.toRelabelingHypothesis`, making the implication from global coordinate grouping to the existing common-sector relabeling hypothesis explicit
- update Ch. 8/11 blueprint entries and the #971 audit note

## Mathematical status

This advances #971 but does **not** close it.  The result uses the merged #1096 grouped-block infrastructure: `directIteratedBlockEquiv` supplies the direct/iterated blocked-index equivalence, and `groupedBlockCastAgrees_iff_iteratedBlockIndex_cast` identifies the remaining coordinate assertion as comparison with the canonical identification used by `CommonBlockedCyclicSectorFamily`.

The PR does not duplicate #1097's proportional/common-cover bridge.  It is rebased on top of #1097/#1099 and is independent of any still-open branch.  The grouped-block coordinate assertion remains an explicit hypothesis; no theorem here assumes or hides that unproved coordinate choice.

Refs #971.
Refs #1096.
Refs #1097.

## Validation

- `lake -Kjobs=1 build --old TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check origin/main...HEAD`
- added-line scans for proof-integrity placeholders and banned common-sector prose
- Lean diagnostics for `StructuralTheorem.lean` were info-only (stale import hint after rebuild), with no errors or warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean lemmas and documentation wiring around the grouped-block coordinate hypothesis; changes are additive but touch core canonical-form theorem statements, so proof breakage is the main risk.
> 
> **Overview**
> Extends the common-sector structural theorem layer with new one-sided transport lemmas derived from `CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees`, including a prescribed-length zero-tail rewrite (`zeroTail_commonFlatAt_of_groupedBlockCastAgrees`) and a positive-length MPV equivalence where the zero tail vanishes (`sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees`).
> 
> Adds a bundled transport result (`zeroTail_commonFlat_transport_of_groupedBlockCastAgrees`) and introduces a global hypothesis `CommonGroupedBlockCastHypothesis` with a proof that it implies the existing `CommonSectorRelabelingHypothesis`. Updates the audit note and blueprint chapters to reference these new statements and the new coordinate-grouping hypothesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4828f6d014e89434a71aae256e6d1b9e21067a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->