### PR TITLE
fix(blueprint): align Wielandt review statements

### DIFF
--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -676,8 +676,8 @@ The results follow~\cite{Sanz2010Quantum}.
     \leanok
     \uses{def:word_span, def:normal, thm:fitting_decomp}
     Let $A$ be a normal MPS tensor with bond dimension $D \ge 1$.
-    Suppose that a Kraus operator $A^{i_0}$ is non-invertible and has
-    an eigenvector $\varphi\ne0$ with nonzero eigenvalue $\mu$.
+    Suppose that a Kraus operator $A^{i_0}$ is non-invertible and that
+    $A^{i_0}\varphi=\mu\varphi$ for some nonzero scalar $\mu$.
     Then, for every $\psi \in \C^D$,
     \[
         \ketbra{\varphi}{\psi} \in S_{D^2-D+1}(A).
@@ -799,7 +799,7 @@ The results follow~\cite{Sanz2010Quantum}.
 \begin{proof}
     \leanok
     \uses{thm:nonzero_trace_word_sharp_pos, thm:eigenvector_from_trace,
-          thm:isNormal_blockTensor, cor:wielandt_case2_generator,
+          thm:isNormal_blockTensor, thm:wielandt_case2_normal_generator,
           cor:wielandt_case3_generator}
     \begin{enumerate}
     \item \emph{$D = 1$:} In this case $\iota(A) = 0$, so the bound


### PR DESCRIPTION
## Summary
- Remove the extra nonzero-vector hypothesis from the rank-one extraction blueprint statement so it matches the Lean theorem.
- Change the general Wielandt proof dependency from the case-(2) generator corollary to the normal invertible-generator theorem actually used by the Lean proof.

Follow-up to merged PR #1098 review comments.

## Validation
- python3 scripts/blueprint_lean_sync.py --root . --ci
- cd blueprint && leanblueprint checkdecls
- git diff --check
- lake build TNLean.Wielandt.PaperResults.WielandtInequality
- leanblueprint web from a no-space temporary copy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes in the LaTeX blueprint: adjusts a lemma hypothesis and updates a referenced dependency in one proof; no executable code or proof logic changes in Lean.
> 
> **Overview**
> Aligns the blueprint’s Wielandt chapter statements with the corresponding Lean theorems.
> 
> The `Rank-one extraction from a non-invertible eigenvector` lemma drops the redundant explicit “nonzero eigenvector” wording and instead states the eigenvector relation `A^{i_0}\varphi=\mu\varphi` with `\mu \neq 0`.
> 
> In the general Wielandt bound proof, updates the declared dependency from `cor:wielandt_case2_generator` to the more specific `thm:wielandt_case2_normal_generator` actually used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfffcbfb2b63831755c5fef0ba6c10be847952a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->