### PR TITLE
fix(blueprint): quantify rank-one vector

### DIFF
--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -677,8 +677,9 @@ The results follow~\cite{Sanz2010Quantum}.
     \uses{def:word_span, def:normal, thm:fitting_decomp}
     Let $A$ be a normal MPS tensor with bond dimension $D \ge 1$.
     Suppose that a Kraus operator $A^{i_0}$ is non-invertible and that
-    $A^{i_0}\varphi=\mu\varphi$ for some nonzero scalar $\mu$.
-    Then, for every $\psi \in \C^D$,
+    there exist a vector $\varphi \in \C^D$ and a nonzero scalar $\mu$
+    such that $A^{i_0}\varphi=\mu\varphi$. Then, for every
+    $\psi \in \C^D$,
     \[
         \ketbra{\varphi}{\psi} \in S_{D^2-D+1}(A).
     \]

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -677,7 +677,7 @@ The results follow~\cite{Sanz2010Quantum}.
     \uses{def:word_span, def:normal, thm:fitting_decomp}
     Let $A$ be a normal MPS tensor with bond dimension $D \ge 1$.
     Suppose that a Kraus operator $A^{i_0}$ is non-invertible and that
-    there exist a vector $\varphi \in \C^D$ and a nonzero scalar $\mu$
+    there exists a vector $\varphi \in \C^D$ and a nonzero scalar $\mu$
     such that $A^{i_0}\varphi=\mu\varphi$. Then, for every
     $\psi \in \C^D$,
     \[


### PR DESCRIPTION
## Summary
- Explicitly quantify the vector in the Ch.7 rank-one extraction lemma statement.
- This addresses the remaining Copilot wording thread from merged PR #1102.

Follow-up to merged PR #1102.

## Validation
- python3 scripts/blueprint_lean_sync.py --root . --ci
- cd blueprint && leanblueprint checkdecls
- git diff --check
- lake build TNLean.Wielandt.PaperResults.WielandtInequality
- leanblueprint web from a no-space temporary copy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a wording/quantifier fix in a LaTeX lemma statement with no code or logic changes, but it may affect downstream references to the lemma’s assumptions.
> 
> **Overview**
> Clarifies the statement of Chapter 7’s rank-one extraction lemma (`lem:rank_one_noninvertible_eigenvector`) by explicitly quantifying the existence of the eigenvector `\varphi` and nonzero eigenvalue `\mu` before asserting the rank-one conclusion for all `\psi`.
> 
> This is a documentation/specification fix to remove an implicit/ambiguous quantifier in the lemma hypothesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4aa5cb097e79ec86d2288c9808bdd635772266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->