### PR TITLE
feat(MPS/CanonicalForm): add conditional CPSV theorem form

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -41,7 +41,7 @@ original names, including
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
 `fundamentalTheorem_after_blocking_structural`.
 
-This public entry point also records a paper-facing wrapper for the present
+This public entry point also records the present closest paper-facing analogue of the
 non-Gemma route.  The structure `AfterBlockingFundamentalTheoremHypotheses`
 names the remaining comparison inputs, while
 `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` returns the current
@@ -170,8 +170,8 @@ structure AfterBlockingFundamentalTheoremConclusion
 Let `A` and `B` generate the same MPV family.  Under the currently explicit remaining comparison
 hypotheses, there is a positive blocking after which the two tensors admit BNT sector
 decompositions with the same sector MPV family, matched basis-sector multiplicities, and matched
-sector-weight multisets up to nonzero phases.  This is the strongest paper-facing wrapper currently
-available on the non-Gemma route: it is a direct repackaging of
+sector-weight multisets up to nonzero phases.  This is the strongest paper-facing conditional form
+currently available on the non-Gemma route: it is a direct consequence of
 `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional`, not a new hidden
 assumption or an appeal to the periodic fundamental theorem. -/
 theorem fundamentalTheorem_afterBlocking_of_comparisonHypotheses

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -41,14 +41,14 @@ original names, including
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
 `fundamentalTheorem_after_blocking_structural`.
 
-This public entry point also records the present closest paper-facing analogue of the
-non-Gemma route.  The structure `AfterBlockingFundamentalTheoremHypotheses`
-names the remaining comparison inputs, while
-`fundamentalTheorem_afterBlocking_of_comparisonHypotheses` returns the current
-closest analogue of the Cirac--Pérez-García--Schuch--Verstraete fundamental
-theorem: after blocking, the two tensors are represented by BNT sector
-decompositions whose basis sectors and weights match up to permutation and
-nonzero phases.
+This public entry point also records a conditional formulation of the
+Cirac--Pérez-García--Schuch--Verstraete after-blocking theorem that does not
+invoke the periodic Fundamental Theorem.  The structure
+`AfterBlockingFundamentalTheoremHypotheses` names the remaining comparison inputs,
+while `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` gives the
+corresponding sector-decomposition conclusion: after blocking, the two tensors
+are represented by BNT sector decompositions whose basis sectors and weights
+match up to permutation and nonzero phases.
 
 ## References
 
@@ -64,15 +64,15 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
 namespace MPSTensor
 
-/-- Remaining hypotheses for the paper-facing after-blocking fundamental theorem.
+/-- Remaining hypotheses for the after-blocking Fundamental Theorem formulation.
 
-The formalized non-Gemma route from `SameMPV₂ A B` already constructs common primitive
+Starting from `SameMPV₂ A B`, the present derivation constructs common primitive
 nonzero-sector families after a common blocking, once the blocked-word relabeling assertion is
-available.  To reach the sector-weight conclusion of the Cirac--Pérez-García--Schuch--Verstraete
-fundamental theorem for exactly those produced families, the current library still needs the
-comparison data for those produced families.  The field `comparison` is supplied with their
-trace-preserving, primitive, and irreducible structural evidence, so the remaining assumptions
-cannot be applied to a different, more convenient decomposition. -/
+established.  To reach the sector-weight conclusion of the Cirac--Pérez-García--Schuch--Verstraete
+Fundamental Theorem for exactly those produced families, one still needs comparison data for
+those produced families.  The field `comparison` is supplied with their trace-preserving,
+primitive, and irreducible structural evidence, so the remaining assumptions cannot be applied to
+a different decomposition. -/
 structure AfterBlockingFundamentalTheoremHypotheses
     {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop where
   /-- The one-sided blocked-word relabeling equality for common cyclic-sector families. -/
@@ -119,13 +119,13 @@ structure AfterBlockingFundamentalTheoremHypotheses
       (∀ x, 0 < dimB x) →
       CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB
 
-/-- Paper-facing conclusion of the current after-blocking fundamental theorem.
+/-- Conclusion of the conditional after-blocking Fundamental Theorem formulation.
 
-The conclusion follows the Cirac--Pérez-García--Schuch--Verstraete source language as closely
-as the present infrastructure permits.  After one positive blocking, there are sector
-decompositions `P` and `Q` with BNT data.  The blocked tensors agree with these sector
-tensors at all positive lengths, the two sector tensors generate the same full MPV family, and the
-basis sectors have matching multiplicities and weights up to a permutation and nonzero phases.
+The conclusion follows the Cirac--Pérez-García--Schuch--Verstraete statement at the level of
+BNT sector decompositions.  After one positive blocking, there are sector decompositions `P` and
+`Q` with BNT data.  The blocked tensors agree with these sector tensors at all positive lengths,
+the two sector tensors generate the same full MPV family, and the basis sectors have matching
+multiplicities and weights up to a permutation and nonzero phases.
 
 The positive-length comparison with the original blocked tensors is intentional: before the
 zero-tail dimensions are identified, the zero-tail contribution is the only obstruction at
@@ -164,15 +164,15 @@ structure AfterBlockingFundamentalTheoremConclusion
       Finset.univ.val.map
         (fun q => phase j * Q.weight (perm j) (Fin.cast (copies_eq j) q))
 
-/-- **Paper-facing non-Gemma fundamental theorem after blocking, conditional form.**
+/-- **Conditional after-blocking Fundamental Theorem formulation.**
 
-Let `A` and `B` generate the same MPV family.  Under the currently explicit remaining comparison
+Let `A` and `B` generate the same MPV family.  Under the explicit remaining comparison
 hypotheses, there is a positive blocking after which the two tensors admit BNT sector
 decompositions with the same sector MPV family, matched basis-sector multiplicities, and matched
-sector-weight multisets up to nonzero phases.  This is the strongest paper-facing conditional form
-currently available on the non-Gemma route: it is a direct consequence of
-`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional`, not a new hidden
-assumption or an appeal to the periodic fundamental theorem. -/
+sector-weight multisets up to nonzero phases.  This is the conditional formulation proved by the
+present periodic-theorem-free derivation: it is a direct consequence of
+`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional`, not a hidden
+assumption or an appeal to the periodic Fundamental Theorem. -/
 theorem fundamentalTheorem_afterBlocking_of_comparisonHypotheses
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -41,6 +41,15 @@ original names, including
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
 `fundamentalTheorem_after_blocking_structural`.
 
+This public entry point also records a paper-facing wrapper for the present
+non-Gemma route.  The structure `AfterBlockingFundamentalTheoremHypotheses`
+names the remaining comparison inputs, while
+`fundamentalTheorem_afterBlocking_of_comparisonHypotheses` returns the current
+closest analogue of the Cirac--Pérez-García--Schuch--Verstraete fundamental
+theorem: after blocking, the two tensors are represented by BNT sector
+decompositions whose basis sectors and weights match up to permutation and
+nonzero phases.
+
 ## References
 
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, §2.3 + Appendix A]
@@ -50,3 +59,145 @@ original names, including
 
 matrix product states, canonical form, blocking, primitive transfer maps
 -/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+
+namespace MPSTensor
+
+/-- Remaining hypotheses for the paper-facing after-blocking fundamental theorem.
+
+The formalized non-Gemma route from `SameMPV₂ A B` already constructs common primitive
+nonzero-sector families after a common blocking, once the blocked-word relabeling assertion is
+available.  To reach the sector-weight conclusion of the Cirac--Pérez-García--Schuch--Verstraete
+fundamental theorem for exactly those produced families, the current library still needs the
+comparison data listed here: equality of zero-tail dimensions, one-site injectivity, and a BNT
+proportional-decomposition comparison.  The field `comparison` is deliberately phrased for the
+families produced by the structural theorem, so the remaining assumptions cannot be applied to a
+different, more convenient decomposition. -/
+structure AfterBlockingFundamentalTheoremHypotheses
+    {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop where
+  /-- The one-sided blocked-word relabeling equality for common cyclic-sector families. -/
+  relabel : CommonSectorRelabelingHypothesis d
+  /-- The remaining zero-tail, injectivity, and BNT proportional-comparison data for the produced
+  common primitive nonzero-sector families. -/
+  comparison : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB
+
+/-- Paper-facing conclusion of the current after-blocking fundamental theorem.
+
+The conclusion follows the Cirac--Pérez-García--Schuch--Verstraete source language as closely
+as the present infrastructure permits.  After one positive blocking, there are sector
+decompositions `P` and `Q` with BNT data.  The blocked tensors agree with these sector
+tensors at all positive lengths, the two sector tensors generate the same full MPV family, and the
+basis sectors have matching multiplicities and weights up to a permutation and nonzero phases.
+
+The positive-length comparison with the original blocked tensors is intentional: before the
+zero-tail dimensions are identified, the zero-tail contribution is the only obstruction at
+length zero. -/
+structure AfterBlockingFundamentalTheoremConclusion
+    {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) where
+  /-- The common physical blocking length. -/
+  p : ℕ
+  /-- The blocking length is positive. -/
+  p_pos : 0 < p
+  /-- The sector decomposition representing the left blocked tensor. -/
+  P : SectorDecomposition (blockPhysDim d p)
+  /-- The sector decomposition representing the right blocked tensor. -/
+  Q : SectorDecomposition (blockPhysDim d p)
+  /-- The left blocked tensor agrees with its sector tensor at positive lengths. -/
+  left_mpv : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p) P.toTensor
+  /-- The right blocked tensor agrees with its sector tensor at positive lengths. -/
+  right_mpv : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p) Q.toTensor
+  /-- The two sector tensors generate the same full MPV family. -/
+  sector_mpv : SameMPV₂ P.toTensor Q.toTensor
+  /-- The left sector decomposition carries BNT data. -/
+  left_bnt : HasBNTSectorData P
+  /-- The right sector decomposition carries BNT data. -/
+  right_bnt : HasBNTSectorData Q
+  /-- The matching of BNT sectors. -/
+  perm : Fin P.basisCount ≃ Fin Q.basisCount
+  /-- Matched BNT sectors have the same multiplicity. -/
+  copies_eq : ∀ j, P.copies j = Q.copies (perm j)
+  /-- The nonzero phase relating each matched sector. -/
+  phase : Fin P.basisCount → ℂ
+  /-- The sector phases are nonzero. -/
+  phase_ne_zero : ∀ j, phase j ≠ 0
+  /-- Sector weights match as multisets after multiplying the right weights by the sector phase. -/
+  weight_multiset_eq : ∀ j : Fin P.basisCount,
+    Finset.univ.val.map (P.weight j) =
+      Finset.univ.val.map
+        (fun q => phase j * Q.weight (perm j) (Fin.cast (copies_eq j) q))
+
+/-- **Paper-facing non-Gemma fundamental theorem after blocking, conditional form.**
+
+Let `A` and `B` generate the same MPV family.  Under the currently explicit remaining comparison
+hypotheses, there is a positive blocking after which the two tensors admit BNT sector
+decompositions with the same sector MPV family, matched basis-sector multiplicities, and matched
+sector-weight multisets up to nonzero phases.  This is the strongest paper-facing wrapper currently
+available on the non-Gemma route: it is a direct repackaging of
+`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional`, not a new hidden
+assumption or an appeal to the periodic fundamental theorem. -/
+theorem fundamentalTheorem_afterBlocking_of_comparisonHypotheses
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (h : AfterBlockingFundamentalTheoremHypotheses A B) :
+    Nonempty (AfterBlockingFundamentalTheoremConclusion A B) := by
+  obtain ⟨p, hp, P, Q, hA, hB, hPQ, hPbnt, hQbnt,
+      perm, hCopies, phase, hPhase, hWeights⟩ :=
+    afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional
+      A B hSame h.relabel h.comparison
+  exact ⟨{
+    p := p
+    p_pos := hp
+    P := P
+    Q := Q
+    left_mpv := hA
+    right_mpv := hB
+    sector_mpv := hPQ
+    left_bnt := hPbnt
+    right_bnt := hQbnt
+    perm := perm
+    copies_eq := hCopies
+    phase := phase
+    phase_ne_zero := hPhase
+    weight_multiset_eq := hWeights }⟩
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -70,16 +70,15 @@ The formalized non-Gemma route from `SameMPV₂ A B` already constructs common p
 nonzero-sector families after a common blocking, once the blocked-word relabeling assertion is
 available.  To reach the sector-weight conclusion of the Cirac--Pérez-García--Schuch--Verstraete
 fundamental theorem for exactly those produced families, the current library still needs the
-comparison data listed here: equality of zero-tail dimensions, one-site injectivity, and a BNT
-proportional-decomposition comparison.  The field `comparison` is deliberately phrased for the
-families produced by the structural theorem, so the remaining assumptions cannot be applied to a
-different, more convenient decomposition. -/
+comparison data for those produced families.  The field `comparison` is supplied with their
+trace-preserving, primitive, and irreducible structural evidence, so the remaining assumptions
+cannot be applied to a different, more convenient decomposition. -/
 structure AfterBlockingFundamentalTheoremHypotheses
     {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop where
   /-- The one-sided blocked-word relabeling equality for common cyclic-sector families. -/
   relabel : CommonSectorRelabelingHypothesis d
-  /-- The remaining zero-tail, injectivity, and BNT proportional-comparison data for the produced
-  common primitive nonzero-sector families. -/
+  /-- The remaining comparison data for the produced common primitive nonzero-sector families,
+  with the structural evidence for trace preservation, primitivity, and irreducibility supplied. -/
   comparison : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
       {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
       {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}

--- a/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
+++ b/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
@@ -38,27 +38,28 @@ BNT sector comparison and matched sector weights
 
 A scan of `TNLean/MPS/CanonicalForm` and `TNLean/MPS/FundamentalTheorem` found no local `sorry` or `admit` occurrences.  The remaining issue is therefore not proof integrity; it is the shape of the public and intermediate API.
 
-## Paper-facing theorem form now available
+## Conditional CPSV theorem formulation
 
-The follow-up API in `TNLean/MPS/CanonicalForm/Assembly.lean` adds the current
-strongest statement in the language of the Cirac--Pérez-García--Schuch--Verstraete
+The declaration group in `TNLean/MPS/CanonicalForm/Assembly.lean` records a
+conditional statement in the language of the Cirac--Pérez-García--Schuch--Verstraete
 Fundamental Theorem:
 
 - `MPSTensor.AfterBlockingFundamentalTheoremHypotheses` names the remaining
-  comparison inputs: blocked-word relabeling, equality of the zero-tail
-  dimensions, one-site injectivity of the produced common primitive sectors, and
-  BNT proportional-comparison data for those same produced sectors.
-- `MPSTensor.AfterBlockingFundamentalTheoremConclusion` records the output: after
-  a positive blocking, there are BNT sector decompositions `P` and `Q`; the
+  comparison data.  It includes blocked-word relabeling, and its comparison field
+  is supplied with the produced sectors' trace-preserving, primitive, and
+  irreducible structure before returning the remaining zero-tail, injectivity, and
+  BNT proportional-comparison hypotheses for those same sectors.
+- `MPSTensor.AfterBlockingFundamentalTheoremConclusion` records the conclusion:
+  after a positive blocking, there are BNT sector decompositions `P` and `Q`; the
   original blocked tensors agree with them at positive lengths; `P` and `Q`
   generate the same full MPV family; and the basis sectors, multiplicities, and
   sector-weight multisets match up to a permutation and nonzero phases.
-- `MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses` proves the
-  conclusion from `SameMPV₂ A B` and those named hypotheses by repackaging the
+- `MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses` derives the
+  conclusion from `SameMPV₂ A B` and those named hypotheses by applying the
   existing relabeled-common-sector proportional theorem.
 
-This is intentionally conditional.  It mirrors the source assertions that bases
-of normal tensors match up to permutation, phases, and gauge transformations
+The statement is conditional.  It mirrors the source assertions that bases of
+normal tensors match up to permutation, phases, and gauge transformations
 (`Papers/1606.00608/MPDO-22-12-17-2.tex` lines 347--360 and
 `Papers/2011.12127/TN-Review-main.tex` lines 1887--1900), while keeping the real
 remaining inputs explicit rather than hiding them behind a vague convenience
@@ -66,7 +67,7 @@ hypothesis.
 
 ## What is still not clean
 
-The non-Gemma route is not yet a single unconditional paper-level theorem.  The remaining mathematical inputs are still visible, and this is the right kind of incompleteness:
+The derivation without the periodic theorem is not yet a single unconditional CPSV/CPGSV theorem.  The remaining mathematical inputs are still visible, and this is the right kind of incompleteness:
 
 1. **Blocked-word coordinate agreement.**  The current path isolates this as `CommonSectorRelabelingHypothesis d`.  PR #1096 narrowed the direct-versus-iterated blocking equivalence, but the exact common-sector coordinate agreement is still part of the #990 line of work.
 2. **Transport of weights and zero tails through the final common-sector choice.**  The #971 line remains relevant wherever the statement needs the produced common sectors to carry the exact weights and zero-tail comparison in the final form.
@@ -117,7 +118,7 @@ This is a documentation reorganization, but it prevents future theorem names fro
 
 ### 4. Keep `MPS/FundamentalTheorem` and `MPS/CanonicalForm/Assembly` distinct
 
-`TNLean/MPS/FundamentalTheorem` contains the equal-case and proportional BNT comparison layer.  `TNLean/MPS/CanonicalForm/Assembly` builds the after-blocking canonical-form reduction.  The non-Gemma route uses both, but they should not be collapsed into one file or one theorem family yet.  The clean final theorem should import the comparison layer, not duplicate it.
+`TNLean/MPS/FundamentalTheorem` contains the equal-case and proportional BNT comparison layer.  `TNLean/MPS/CanonicalForm/Assembly` builds the after-blocking canonical-form reduction.  The derivation without the periodic theorem uses both, but they should not be collapsed into one file or one theorem family yet.  The clean final theorem should import the comparison layer, not duplicate it.
 
 ## Suggested next PRs
 
@@ -128,4 +129,4 @@ This is a documentation reorganization, but it prevents future theorem names fro
 
 ## Answer to the issue question
 
-The route is much cleaner now, and it is clean in the most important sense: the non-Gemma assumptions are exposed rather than hidden.  It is not yet as clean as it can be.  The remaining cleanup is mostly API reorganization around theorem names and named hypothesis structures, while the remaining mathematical work is exactly the blocked-word, zero-tail/weight transport, common-cover/proportional, and injectivity data listed above.
+The derivation is much clearer now, in the most important sense: the non-Gemma assumptions are exposed rather than hidden.  It is not yet as clean as it can be.  The remaining cleanup is mostly API reorganization around theorem names and named hypothesis structures, while the remaining mathematical work is exactly the blocked-word, zero-tail/weight transport, common-cover/proportional, and injectivity data listed above.

--- a/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
+++ b/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
@@ -38,7 +38,7 @@ BNT sector comparison and matched sector weights
 
 A scan of `TNLean/MPS/CanonicalForm` and `TNLean/MPS/FundamentalTheorem` found no local `sorry` or `admit` occurrences.  The remaining issue is therefore not proof integrity; it is the shape of the public and intermediate API.
 
-## Paper-facing wrapper now available
+## Paper-facing theorem form now available
 
 The follow-up API in `TNLean/MPS/CanonicalForm/Assembly.lean` adds the current
 strongest statement in the language of the Cirac--Pérez-García--Schuch--Verstraete
@@ -48,7 +48,7 @@ Fundamental Theorem:
   comparison inputs: blocked-word relabeling, equality of the zero-tail
   dimensions, one-site injectivity of the produced common primitive sectors, and
   BNT proportional-comparison data for those same produced sectors.
-- `MPSTensor.AfterBlockingFundamentalTheoremConclusion` packages the output: after
+- `MPSTensor.AfterBlockingFundamentalTheoremConclusion` records the output: after
   a positive blocking, there are BNT sector decompositions `P` and `Q`; the
   original blocked tensors agree with them at positive lengths; `P` and `Q`
   generate the same full MPV family; and the basis sectors, multiplicities, and

--- a/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
+++ b/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
@@ -38,6 +38,32 @@ BNT sector comparison and matched sector weights
 
 A scan of `TNLean/MPS/CanonicalForm` and `TNLean/MPS/FundamentalTheorem` found no local `sorry` or `admit` occurrences.  The remaining issue is therefore not proof integrity; it is the shape of the public and intermediate API.
 
+## Paper-facing wrapper now available
+
+The follow-up API in `TNLean/MPS/CanonicalForm/Assembly.lean` adds the current
+strongest statement in the language of the Cirac--Pérez-García--Schuch--Verstraete
+Fundamental Theorem:
+
+- `MPSTensor.AfterBlockingFundamentalTheoremHypotheses` names the remaining
+  comparison inputs: blocked-word relabeling, equality of the zero-tail
+  dimensions, one-site injectivity of the produced common primitive sectors, and
+  BNT proportional-comparison data for those same produced sectors.
+- `MPSTensor.AfterBlockingFundamentalTheoremConclusion` packages the output: after
+  a positive blocking, there are BNT sector decompositions `P` and `Q`; the
+  original blocked tensors agree with them at positive lengths; `P` and `Q`
+  generate the same full MPV family; and the basis sectors, multiplicities, and
+  sector-weight multisets match up to a permutation and nonzero phases.
+- `MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses` proves the
+  conclusion from `SameMPV₂ A B` and those named hypotheses by repackaging the
+  existing relabeled-common-sector proportional theorem.
+
+This is intentionally conditional.  It mirrors the source assertions that bases
+of normal tensors match up to permutation, phases, and gauge transformations
+(`Papers/1606.00608/MPDO-22-12-17-2.tex` lines 347--360 and
+`Papers/2011.12127/TN-Review-main.tex` lines 1887--1900), while keeping the real
+remaining inputs explicit rather than hiding them behind a vague convenience
+hypothesis.
+
 ## What is still not clean
 
 The non-Gemma route is not yet a single unconditional paper-level theorem.  The remaining mathematical inputs are still visible, and this is the right kind of incompleteness:

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1624,9 +1624,9 @@ two-basis sector comparison theorem.
 	for the non-Gemma after-blocking route to reach the source-language
 	Fundamental Theorem. It contains the blocked-word relabeling hypothesis for
 	common cyclic sectors. For the common primitive nonzero-sector families
-	produced from two tensors with the same MPV family, it then requires equality
-	of the zero-tail dimensions, one-site injectivity of the produced blocks, and a
-	BNT proportional-decomposition comparison for those produced blocks.
+	produced from two tensors with the same MPV family, the comparison field is
+	supplied with their isometry, primitivity, and irreducibility evidence before
+	returning the remaining proportional-comparison hypotheses for those blocks.
 	The hypotheses are tied to the produced families rather than to an arbitrary
 	chosen decomposition.
 \end{definition}
@@ -1667,7 +1667,7 @@ two-basis sector comparison theorem.
 	\cite[Theorem~\texttt{thm1} and Corollary~\texttt{II\_cor2},
 	lines 1891--1900]{Cirac2021Matrix}. The remaining hypotheses are explicit:
 	the statement does not assume away the blocked-word relabeling, zero-tail,
-	injectivity, or proportional-comparison inputs.
+	isometry, primitivity, irreducibility, or proportional-comparison inputs.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1620,7 +1620,7 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:common_sector_relabeling_hypothesis,
 		def:common_primitive_proportional_hypotheses}
-	This named hypothesis package records exactly the comparison data still needed
+	These named hypotheses record exactly the comparison data still needed
 	for the non-Gemma after-blocking route to reach the source-language
 	Fundamental Theorem. It contains the blocked-word relabeling hypothesis for
 	common cyclic sectors. For the common primitive nonzero-sector families
@@ -1676,9 +1676,9 @@ two-basis sector comparison theorem.
 	Apply
 	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_proportional} with
 	the relabeling and proportional-comparison data from
-	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. The Lean
-	wrapper repackages the resulting blocking length, sector decompositions,
-	BNT data, permutation, multiplicity equalities, phases, and sector-weight
+	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. The proof
+	then records the resulting blocking length, sector decompositions, BNT data,
+	permutation, multiplicity equalities, phases, and sector-weight
 	multiset equalities as the conclusion structure.
 \end{proof}
 

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1614,6 +1614,74 @@ two-basis sector comparison theorem.
 	comparison theorem with common phase-cover data.
 \end{proof}
 
+\begin{definition}[After-blocking hypotheses for the paper-facing Fundamental Theorem]%
+\label{def:after_blocking_fundamental_theorem_hypotheses}
+	\lean{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}
+	\leanok
+	\uses{def:common_sector_relabeling_hypothesis,
+		def:common_primitive_proportional_hypotheses}
+	This named hypothesis package records exactly the comparison data still needed
+	for the non-Gemma after-blocking route to reach the source-language
+	Fundamental Theorem. It contains the blocked-word relabeling hypothesis for
+	common cyclic sectors. For the common primitive nonzero-sector families
+	produced from two tensors with the same MPV family, it then requires equality
+	of the zero-tail dimensions, one-site injectivity of the produced blocks, and a
+	BNT proportional-decomposition comparison for those produced blocks.
+	The hypotheses are tied to the produced families rather than to an arbitrary
+	chosen decomposition.
+\end{definition}
+
+\begin{definition}[Paper-facing after-blocking Fundamental Theorem conclusion]%
+\label{def:after_blocking_fundamental_theorem_conclusion}
+	\lean{MPSTensor.AfterBlockingFundamentalTheoremConclusion}
+	\leanok
+	\uses{def:paper_sector_data}
+	The conclusion consists of a positive blocking length and sector
+	decompositions $P,Q$ at that length. The blocked tensors agree with
+	$P$ and $Q$ at every positive length, while $P$ and $Q$ generate the same
+	full MPV family. Both sector decompositions carry BNT data. Their basis
+	sectors are matched by a permutation, the corresponding multiplicities agree,
+	and the sector-weight multisets agree after multiplying the weights on one
+	side by nonzero sector phases.
+\end{definition}
+
+\begin{theorem}[Paper-facing after-blocking Fundamental Theorem, conditional form]%
+\label{thm:fundamental_theorem_after_blocking_comparison_hypotheses}
+	\lean{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}
+	\leanok
+	\uses{def:after_blocking_fundamental_theorem_hypotheses,
+		def:after_blocking_fundamental_theorem_conclusion,
+		thm:afterBlocking_sectorComparison_reindexed_proportional}
+	Let $A$ and $B$ generate the same MPV family. Assume the after-blocking
+	comparison hypotheses of
+	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. Then the
+	paper-facing conclusion of
+	Definition~\ref{def:after_blocking_fundamental_theorem_conclusion} is
+	nonempty.
+
+	This is the current formal statement closest to the Cirac--P\'erez-Garc\'ia--
+	Schuch--Verstraete Fundamental Theorem: after blocking, the tensor families are
+	represented by BNT sector decompositions whose basis sectors and weights match
+	up to permutation and nonzero phases, as in
+	\cite[Theorem~\texttt{thm1}, lines 347--352]{Cirac2016MPDO_arXiv} and
+	\cite[Theorem~\texttt{thm1} and Corollary~\texttt{II\_cor2},
+	lines 1891--1900]{Cirac2021Matrix}. The remaining hypotheses are explicit:
+	the statement does not assume away the blocked-word relabeling, zero-tail,
+	injectivity, or proportional-comparison inputs.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:afterBlocking_sectorComparison_reindexed_proportional}
+	Apply
+	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_proportional} with
+	the relabeling and proportional-comparison data from
+	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. The Lean
+	wrapper repackages the resulting blocking length, sector decompositions,
+	BNT data, permutation, multiplicity equalities, phases, and sector-weight
+	multiset equalities as the conclusion structure.
+\end{proof}
+
 \begin{theorem}[Cast-compatible MPV scaling implies phase-matched sector comparison]%
 \label{thm:route_b_hetero_mpv_scaling}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1614,24 +1614,24 @@ two-basis sector comparison theorem.
 	comparison theorem with common phase-cover data.
 \end{proof}
 
-\begin{definition}[After-blocking hypotheses for the paper-facing Fundamental Theorem]%
+\begin{definition}[After-blocking hypotheses for the CPSV formulation]%
 \label{def:after_blocking_fundamental_theorem_hypotheses}
 	\lean{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}
 	\leanok
 	\uses{def:common_sector_relabeling_hypothesis,
 		def:common_primitive_proportional_hypotheses}
-	These named hypotheses record exactly the comparison data still needed
-	for the non-Gemma after-blocking route to reach the source-language
-	Fundamental Theorem. It contains the blocked-word relabeling hypothesis for
-	common cyclic sectors. For the common primitive nonzero-sector families
-	produced from two tensors with the same MPV family, the comparison field is
-	supplied with their isometry, primitivity, and irreducibility evidence before
-	returning the remaining proportional-comparison hypotheses for those blocks.
-	The hypotheses are tied to the produced families rather than to an arbitrary
-	chosen decomposition.
+	These named hypotheses record the comparison data still needed for the
+	periodic-theorem-free after-blocking formulation of the CPSV Fundamental
+	Theorem. They contain the blocked-word relabeling hypothesis for common cyclic
+	sectors. For the common primitive nonzero-sector families produced from two
+	tensors with the same MPV family, the comparison field is supplied with their
+	isometry, primitivity, and irreducibility evidence before returning the
+	remaining proportional-comparison hypotheses for those blocks. The hypotheses
+	are tied to the produced families rather than to an arbitrary chosen
+	decomposition.
 \end{definition}
 
-\begin{definition}[Paper-facing after-blocking Fundamental Theorem conclusion]%
+\begin{definition}[CPSV after-blocking Fundamental Theorem conclusion]%
 \label{def:after_blocking_fundamental_theorem_conclusion}
 	\lean{MPSTensor.AfterBlockingFundamentalTheoremConclusion}
 	\leanok
@@ -1645,7 +1645,7 @@ two-basis sector comparison theorem.
 	side by nonzero sector phases.
 \end{definition}
 
-\begin{theorem}[Paper-facing after-blocking Fundamental Theorem, conditional form]%
+\begin{theorem}[Conditional after-blocking CPSV formulation]%
 \label{thm:fundamental_theorem_after_blocking_comparison_hypotheses}
 	\lean{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}
 	\leanok
@@ -1655,15 +1655,15 @@ two-basis sector comparison theorem.
 	Let $A$ and $B$ generate the same MPV family. Assume the after-blocking
 	comparison hypotheses of
 	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. Then the
-	paper-facing conclusion of
+	the CPSV conclusion of
 	Definition~\ref{def:after_blocking_fundamental_theorem_conclusion} is
 	nonempty.
 
-	This is the current formal statement closest to the Cirac--P\'erez-Garc\'ia--
-	Schuch--Verstraete Fundamental Theorem: after blocking, the tensor families are
-	represented by BNT sector decompositions whose basis sectors and weights match
-	up to permutation and nonzero phases, as in
-	\cite[Theorem~\texttt{thm1}, lines 347--352]{Cirac2016MPDO_arXiv} and
+	The conclusion matches the sector-decomposition part of the
+	Cirac--P\'erez-Garc\'ia--Schuch--Verstraete Fundamental Theorem: after
+	blocking, the tensor families are represented by BNT sector decompositions
+	whose basis sectors and weights match up to permutation and nonzero phases, as
+	in \cite[Theorem~\texttt{thm1}, lines 347--352]{Cirac2016MPDO_arXiv} and
 	\cite[Theorem~\texttt{thm1} and Corollary~\texttt{II\_cor2},
 	lines 1891--1900]{Cirac2021Matrix}. The remaining hypotheses are explicit:
 	the statement does not assume away the blocked-word relabeling, zero-tail,

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -1,4 +1,4 @@
-\documentclass{article}
+\documentclass[11pt]{article}
 
 \usepackage{amsmath,amssymb}
 \usepackage{xurl}
@@ -18,11 +18,11 @@
 
 The non-periodic matrix product vector Fundamental Theorem in
 \cite{Cirac2016MPDO_arXiv,Cirac2017MPDO_AnnPhys,Cirac2021Matrix} is not stated
-with the auxiliary hypotheses used in the present formal theorem form.
-It is stated after the tensors have already been put in canonical form and after
-bases of normal tensors have been chosen. This note records the distinction for
-the conditional after-blocking theorem introduced in \ghpr{1104}, which is part
-of the discussion in \ghissue{1093}.
+with the auxiliary hypotheses used in the conditional Lean theorem.  It is stated
+after the tensors have already been put in canonical form and after bases of
+normal tensors have been chosen.  This note records that distinction for the
+after-blocking theorem in \ghpr{1104}, which is part of the discussion in
+\ghissue{1093}.
 
 In the 2016 source, the canonical-form discussion first removes invariant
 subspaces. After finitely many steps the matrices are replaced by block-diagonal
@@ -64,7 +64,7 @@ after blocking at most $3D^5$ sites a canonical-form tensor acquires
 block-injective canonical form
 \cite[lines~2114--2124]{Cirac2021Matrix}.
 
-The paper-facing theorem itself is then short. For tensors $A$ and $B$ in
+The CPSV statement itself is then short. For tensors $A$ and $B$ in
 canonical form, with bases of normal tensors $A_{k_a}$ and $B_{k_b}$,
 proportionality of all matrix product vector families implies equality of the
 number of basis tensors and a matching of basis tensors up to permutation,
@@ -76,31 +76,34 @@ review repeats these two statements
 \cite[Theorem~\texttt{thm1} and Corollary~\texttt{II\_cor2}, lines~1891--1900]{Cirac2021Matrix}.
 The review also points out that a later periodic Fundamental Theorem avoids the
 period-removing blocking step
-\cite[lines~1908--1909]{Cirac2021Matrix}; that route is intentionally not used in
-the non-Gemma formal development considered here.
+\cite[lines~1908--1909]{Cirac2021Matrix}; that theorem is intentionally not used
+in the derivation considered here.
 
-\section{The conditional formal theorem form}
+\section{The conditional Lean theorem}
 
-The theorem form added in \ghpr{1104} starts from two tensors $A$ and $B$
-with the same formal matrix product vector family. Its conclusion is close to
-the source theorem: after a positive blocking, there are sector decompositions
-$P$ and $Q$ with basis-of-normal-tensor data, the blocked tensors agree with
-these sector decompositions at positive lengths, the sector decompositions have
-the same full matrix product vector family, and the sector multiplicities and
-weights match up to a permutation and nonzero phases. Formally this is the
-structure \path{MPSTensor.AfterBlockingFundamentalTheoremConclusion} and the
-theorem \path{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}.
+The theorem added in \ghpr{1104} starts from two tensors $A$ and $B$ with the
+same formal matrix product vector family.  Its conclusion has the same shape as
+the sector-comparison part of the CPSV statement: after a positive blocking,
+there are sector decompositions $P$ and $Q$ with basis-of-normal-tensor data, the
+blocked tensors agree with these sector decompositions at positive lengths, the
+sector decompositions have the same full matrix product vector family, and the
+sector multiplicities and weights match up to a permutation and nonzero phases.
+Formally this is the structure
+\path{MPSTensor.AfterBlockingFundamentalTheoremConclusion} and the theorem
+\path{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}.
 
-The hypotheses of this theorem form are collected in
-\path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}. They consist of a
-blocked-word relabeling assertion for common cyclic sectors and, for the common
-primitive nonzero-sector families produced by the preceding structural theorem,
-equality of the zero-tail dimensions, one-site injectivity on both sides, and a
-BNT proportional-comparison conclusion for those produced families.
+The hypotheses of this theorem are collected in
+\path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}.  They consist of a
+blocked-word relabeling assertion for common cyclic sectors and a comparison
+field for the common primitive nonzero-sector families produced by the preceding
+structural theorem.  That field is supplied with trace-preserving, primitive, and
+irreducible structural data for the produced families; it then returns equality
+of the zero-tail dimensions, one-site injectivity on both sides, and a BNT
+proportional-comparison conclusion for those produced families.
 
 These hypotheses are not written as hypotheses of Theorem~\texttt{thm1} or of
 Corollary~\texttt{II\_cor2} in the cited papers. They are the formal boundary
-between the canonical-form construction already available in \Lean{} and the
+between the canonical-form construction already proved in \Lean{} and the
 compressed source argument which passes from equality of total matrix product
 vectors to the BNT comparison theorem.
 
@@ -108,14 +111,15 @@ vectors to the BNT comparison theorem.
 
 Two parts of the named hypotheses correspond to genuine paper-level mathematics
 which the sources treat as part of the theorem or as standard cited input, but
-which is not yet derived in the present non-Gemma Lean route for the specific
-common-sector families produced by the construction.
+which is not yet derived in the present Lean proof without using the periodic
+Fundamental Theorem, for the specific common-sector families produced by the
+construction.
 
 First, the injectivity assumptions on the produced nonzero-sector blocks
 correspond to the paper's use of quantum Wielandt and block injectivity. The
 sources do not assume injectivity in Theorem~\texttt{thm1}; rather, they explain
 that one obtains injective or block-injective tensors after further blocking.
-The formal proof must still show that this refinement is available for the final
+The formal proof must still show that this refinement holds for the final
 common primitive sector families to which the overlap-rigidity comparison is
 applied.
 
@@ -125,15 +129,16 @@ the tensors are in canonical form and the bases of normal tensors have been
 chosen, proportionality or equality of all matrix product vectors matches the
 basis tensors up to phases and gauges. The formal theorem in \ghpr{1104} still
 takes the corresponding proportional-decomposition conclusion as input for the
-specific common-sector families. A complete non-Gemma formal proof must derive
-that conclusion from the equality of the original tensors' matrix product vector
-families, after all blockings and reindexings have been accounted for.
+specific common-sector families. A complete proof without the periodic
+Fundamental Theorem must derive that conclusion from the equality of the original
+tensors' matrix product vector families, after all blockings and reindexings have
+been accounted for.
 
 These two inputs are therefore not extra assumptions proposed by the papers. They
 are parts of the paper argument that remain to be connected to the current
 formal construction.
 
-\section{Formal bookkeeping introduced by the representation}
+\section{Coordinate and transport conditions in the formal representation}
 
 The other hypotheses are best understood as coordinate and transport data exposed
 by the formal representation. They are mathematical assertions, but the papers do
@@ -157,7 +162,7 @@ identity separate. This is a consequence of the chosen formal convention, not a
 hypothesis appearing in the paper theorem.
 
 The transport of weights and zero-tail identities through the chosen common-sector
-representatives is likewise a bookkeeping step. The comparison theorem must be
+representatives is likewise a coordinate-transport condition. The comparison theorem must be
 applied to exactly the final family of blocks after common blocking and relabeling.
 The paper moves between these descriptions without naming each transport map; the
 formal proof must show that the weights, nonzero-sector tensors, and zero-tail
@@ -168,17 +173,17 @@ identities survive these changes of description.
 The papers do not state the hypotheses of
 \path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses} as explicit theorem
 hypotheses. The conditional theorem in \ghpr{1104} is therefore not yet the
-unconditional CPSV/CPGSV statement. It is the strongest current formal theorem
-form on the non-Gemma route, with the missing paper-level inputs and the formal
-coordinate transports made visible.
+unconditional CPSV/CPGSV statement. It records the theorem form proved by the
+present derivation without the periodic Fundamental Theorem, with the remaining
+paper-level inputs and formal coordinate transports made visible.
 
-This note records a formalization gap rather than a source error. The cited
-papers compress the canonical-form reduction, blocking, BNT matching, and
-injectivity refinements in the usual paper notation. The Lean development should
-keep the theorem conditional until the injectivity refinement, the BNT
-proportional comparison for the produced sectors, the blocked-word relabeling,
-and the zero-tail and weight transports have been proved for the same final
-common-sector data.
+This note records a proof gap in the present Lean development rather than a
+source error. The cited papers compress the canonical-form reduction, blocking,
+BNT matching, and injectivity refinements in the usual paper notation. The Lean
+development should keep the theorem conditional until the injectivity refinement,
+the BNT proportional comparison for the produced sectors, the blocked-word
+relabeling, and the zero-tail and weight transports have been proved for the same
+final common-sector data.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -1,0 +1,186 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Conditional After-Blocking Fundamental Theorem versus the CPSV Statement}
+\author{}
+\date{2026-05-01}
+
+\begin{document}
+\maketitle
+
+\section{The source statement}
+
+The non-periodic matrix product vector Fundamental Theorem in
+\cite{Cirac2016MPDO_arXiv,Cirac2017MPDO_AnnPhys,Cirac2021Matrix} is not stated
+with the auxiliary hypotheses used in the present formal theorem form.
+It is stated after the tensors have already been put in canonical form and after
+bases of normal tensors have been chosen. This note records the distinction for
+the conditional after-blocking theorem introduced in \ghpr{1104}, which is part
+of the discussion in \ghissue{1093}.
+
+In the 2016 source, the canonical-form discussion first removes invariant
+subspaces. After finitely many steps the matrices are replaced by block-diagonal
+matrices
+\[
+  A^i = \bigoplus_{k=1}^r \mu_k A_k^i,
+\]
+which generate the same family of matrix product vectors as the original tensor;
+zero blocks are allowed in the sense that $\sum_k D_k\le D$
+\cite[lines~214--219]{Cirac2016MPDO_arXiv}. Periodic peripheral components are
+then removed by blocking a common multiple of their periods
+\cite[lines~227--231]{Cirac2016MPDO_arXiv}, and the paper records the resulting
+canonical-form existence statement: after blocking, any tensor can be represented
+by a tensor in canonical form generating the same family
+\cite[lines~249--251]{Cirac2016MPDO_arXiv}. The review gives the same two-step
+account: first canonical form with the same family of matrix product vectors, and
+then the Fundamental Theorem for tensors already in canonical form
+\cite[lines~1752--1758]{Cirac2021Matrix}. It also describes the direct-sum
+canonical form and the period-removing blocking
+\cite[lines~1798--1820]{Cirac2021Matrix}.
+
+The comparison theorem is expressed through bases of normal tensors. In the
+2016 source a basis of normal tensors is a minimal family of normal tensors such
+that the matrix product vectors of the original tensor are linear combinations of
+those basis vectors and the latter are eventually linearly independent
+\cite[lines~271--280]{Cirac2016MPDO_arXiv}. For a tensor in canonical form, the
+paper then writes the matrix product vectors as sums of the basis-of-normal-tensor
+vectors with coefficients $\sum_q \mu_{j,q}^N$
+\cite[lines~283--302]{Cirac2016MPDO_arXiv}. The review states the same basis
+notion and the same expansion
+\cite[lines~1846--1885]{Cirac2021Matrix}.
+
+Injectivity is supplied separately. The 2016 source defines injectivity and
+block-injective canonical form, invokes the quantum Wielandt theorem to say that
+normal tensors become injective after blocking, and records the block-injective
+bound for canonical-form tensors
+\cite[lines~317--344]{Cirac2016MPDO_arXiv}. The review likewise states that
+after blocking at most $3D^5$ sites a canonical-form tensor acquires
+block-injective canonical form
+\cite[lines~2114--2124]{Cirac2021Matrix}.
+
+The paper-facing theorem itself is then short. For tensors $A$ and $B$ in
+canonical form, with bases of normal tensors $A_{k_a}$ and $B_{k_b}$,
+proportionality of all matrix product vector families implies equality of the
+number of basis tensors and a matching of basis tensors up to permutation,
+phases, and invertible gauge matrices
+\cite[Theorem~\texttt{thm1}, lines~347--352]{Cirac2016MPDO_arXiv}. In the equal
+case the paper states the corresponding global gauge conclusion
+\cite[Corollary~\texttt{II\_cor2}, lines~354--360]{Cirac2016MPDO_arXiv}. The
+review repeats these two statements
+\cite[Theorem~\texttt{thm1} and Corollary~\texttt{II\_cor2}, lines~1891--1900]{Cirac2021Matrix}.
+The review also points out that a later periodic Fundamental Theorem avoids the
+period-removing blocking step
+\cite[lines~1908--1909]{Cirac2021Matrix}; that route is intentionally not used in
+the non-Gemma formal development considered here.
+
+\section{The conditional formal theorem form}
+
+The theorem form added in \ghpr{1104} starts from two tensors $A$ and $B$
+with the same formal matrix product vector family. Its conclusion is close to
+the source theorem: after a positive blocking, there are sector decompositions
+$P$ and $Q$ with basis-of-normal-tensor data, the blocked tensors agree with
+these sector decompositions at positive lengths, the sector decompositions have
+the same full matrix product vector family, and the sector multiplicities and
+weights match up to a permutation and nonzero phases. Formally this is the
+structure \path{MPSTensor.AfterBlockingFundamentalTheoremConclusion} and the
+theorem \path{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}.
+
+The hypotheses of this theorem form are collected in
+\path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}. They consist of a
+blocked-word relabeling assertion for common cyclic sectors and, for the common
+primitive nonzero-sector families produced by the preceding structural theorem,
+equality of the zero-tail dimensions, one-site injectivity on both sides, and a
+BNT proportional-comparison conclusion for those produced families.
+
+These hypotheses are not written as hypotheses of Theorem~\texttt{thm1} or of
+Corollary~\texttt{II\_cor2} in the cited papers. They are the formal boundary
+between the canonical-form construction already available in \Lean{} and the
+compressed source argument which passes from equality of total matrix product
+vectors to the BNT comparison theorem.
+
+\section{Paper-level inputs still to be formalized}
+
+Two parts of the named hypotheses correspond to genuine paper-level mathematics
+which the sources treat as part of the theorem or as standard cited input, but
+which is not yet derived in the present non-Gemma Lean route for the specific
+common-sector families produced by the construction.
+
+First, the injectivity assumptions on the produced nonzero-sector blocks
+correspond to the paper's use of quantum Wielandt and block injectivity. The
+sources do not assume injectivity in Theorem~\texttt{thm1}; rather, they explain
+that one obtains injective or block-injective tensors after further blocking.
+The formal proof must still show that this refinement is available for the final
+common primitive sector families to which the overlap-rigidity comparison is
+applied.
+
+Second, the BNT proportional-comparison hypothesis is the paper-level comparison
+itself, specialized to the produced nonzero-sector families. In the source, once
+the tensors are in canonical form and the bases of normal tensors have been
+chosen, proportionality or equality of all matrix product vectors matches the
+basis tensors up to phases and gauges. The formal theorem in \ghpr{1104} still
+takes the corresponding proportional-decomposition conclusion as input for the
+specific common-sector families. A complete non-Gemma formal proof must derive
+that conclusion from the equality of the original tensors' matrix product vector
+families, after all blockings and reindexings have been accounted for.
+
+These two inputs are therefore not extra assumptions proposed by the papers. They
+are parts of the paper argument that remain to be connected to the current
+formal construction.
+
+\section{Formal bookkeeping introduced by the representation}
+
+The other hypotheses are best understood as coordinate and transport data exposed
+by the formal representation. They are mathematical assertions, but the papers do
+not state them because their notation identifies the relevant objects implicitly.
+
+The blocked-word relabeling hypothesis says that the nonzero part obtained by
+blocking once at the common length agrees with the same sector family obtained by
+first removing each period and then grouping the resulting blocks. In ordinary
+paper notation both tensors are simply regarded as tensors over words of the
+common blocked length. In the formal statement, the direct alphabet of words of
+length $p$ and the nested alphabet obtained from iterated blocking are different
+coordinate descriptions, so their equality must be recorded explicitly.
+
+The zero-tail condition has a similar origin. The source definition of matrix
+product vectors is for positive lengths, and zero blocks are invisible there.
+The formal relation $\mathrm{SameMPV}_2$ also includes the empty word. A zero
+block of bond dimension $D_0$ contributes nothing at positive length but
+contributes $D_0$ at length zero. Hence the formal proof records a zero-tail
+dimension and must either identify the two zero tails or keep the length-zero
+identity separate. This is a consequence of the chosen formal convention, not a
+hypothesis appearing in the paper theorem.
+
+The transport of weights and zero-tail identities through the chosen common-sector
+representatives is likewise a bookkeeping step. The comparison theorem must be
+applied to exactly the final family of blocks after common blocking and relabeling.
+The paper moves between these descriptions without naming each transport map; the
+formal proof must show that the weights, nonzero-sector tensors, and zero-tail
+identities survive these changes of description.
+
+\section{Conclusion}
+
+The papers do not state the hypotheses of
+\path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses} as explicit theorem
+hypotheses. The conditional theorem in \ghpr{1104} is therefore not yet the
+unconditional CPSV/CPGSV statement. It is the strongest current formal theorem
+form on the non-Gemma route, with the missing paper-level inputs and the formal
+coordinate transports made visible.
+
+This note records a formalization gap rather than a source error. The cited
+papers compress the canonical-form reduction, blocking, BNT matching, and
+injectivity refinements in the usual paper notation. The Lean development should
+keep the theorem conditional until the injectivity refinement, the BNT
+proportional comparison for the produced sectors, the blocked-word relabeling,
+and the zero-tail and weight transports have been proved for the same final
+common-sector data.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

Issue 1093 follow-up.

This PR adds a conditional CPSV/CPGSV after-blocking Fundamental Theorem formulation for the derivation that does not invoke the periodic Fundamental Theorem:

- `MPSTensor.AfterBlockingFundamentalTheoremHypotheses` names the remaining inputs instead of hiding them: blocked-word relabeling and a comparison field which receives trace-preserving/isometry, primitivity, and irreducibility evidence for the produced common primitive sectors before returning the remaining zero-tail, injectivity, and BNT proportional-comparison hypotheses for those same sectors.
- `MPSTensor.AfterBlockingFundamentalTheoremConclusion` records the CPSV-type sector-decomposition conclusion: after a positive blocking, BNT sector decompositions `P` and `Q` represent the two tensors at positive lengths, have the same full MPV family, and have matched sector multiplicities and weights up to permutation and nonzero phases.
- `MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses` proves the conclusion by applying the existing relabeled-common-sector proportional theorem and recording its output in the new conclusion structure.
- Updates Ch. 11 blueprint and the issue-1093 audit with the source comparison to `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 347--360 and `Papers/2011.12127/TN-Review-main.tex` lines 1887--1900.
- Adds `docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex`, explaining which hypotheses are paper-level inputs still to prove in Lean and which are coordinate/transport conditions introduced by the formal representation.

The theorem remains conditional and keeps the genuine remaining hypotheses explicit, so issue 1093 should stay open after this PR.

## Validation

- `lake build TNLean.MPS.CanonicalForm.Assembly` *(passed; existing long-line warnings replayed in unrelated modules)*
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/Assembly.lean`
- `leanblueprint checkdecls`
- `leanblueprint web` from `/tmp/mpslean-wave26-1093-blueprint` no-space copy, followed by `lake exe checkdecls blueprint/lean_decls`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error conditional_after_blocking_ft_cpsv_statement.tex` from `docs/paper-gaps`, followed by `latexmk -C` cleanup
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch11_assembly.tex`
- `chktex -q -l blueprint/.chktexrc docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new public-facing Lean API structures and a packaged theorem that may affect downstream imports and expectations, though it largely wraps existing results without changing proof logic.
> 
> **Overview**
> Adds a *paper-facing, conditional* after-blocking Fundamental Theorem entry point in `CanonicalForm/Assembly`: a new `AfterBlockingFundamentalTheoremHypotheses` structure to explicitly name the remaining comparison assumptions, a new `AfterBlockingFundamentalTheoremConclusion` structure to package the CPSV-style sector-decomposition output, and a theorem `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` that derives the packaged conclusion by applying the existing relabeled common-sector proportional comparison theorem.
> 
> Updates the supporting documentation to mirror this new API: extends the issue #1093 audit note, adds blueprint definitions/theorem statements for the new declarations, and introduces a new LaTeX note in `docs/paper-gaps` explaining how the conditional Lean statement relates to the source CPSV formulation and what inputs remain explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62a094333494ef06553d1f618f07bff4b59959e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->