### PR TITLE
feat(MPS/CanonicalForm): isolate remaining Fintype coordinate gap for common primitive blocks (#942)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1462,6 +1462,72 @@ theorem groupedBlockCastAgrees_iff_iteratedBlockIndex_cast
           (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i) := by
             rw [hIndex i]
 
+/-- **Core Fintype-level coordinate assertion (remaining blocker for #942/#1075).**
+
+Given a common blocked physical alphabet index `i`, the flattened inner word obtained by
+decoding `i` through the cardinal equality `blockPhysDim (blockPhysDim d m) n = blockPhysDim d p`
+(with `p = m*n`) agrees with the direct decoding of `i` at the common period length.
+
+This is a compatibility statement between the two `Fintype.equivFin` enumerations used for
+`Fin p → Fin d` and `Fin n → Fin (blockPhysDim d m)`.  The `Fintype.equivFin` bijections
+for function types in Mathlib use lexicographic enumeration, which is compatible with the
+grouping described by `directToIteratedBlockIndex`.  Proving this equality therefore
+reduces to showing that the `Fintype` instance for `Fin p → Fin d` and the `Fintype`
+instance for `Fin n → Fin (blockPhysDim d m)` are compatible via the canonical currying.
+This is the single remaining mathematical fact needed to make
+`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
+unconditional. -/
+theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
+    (hp_eq : p = m * n) (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
+    (i : Fin (blockPhysDim d p)) :
+    flattenBlockedWord d m
+      (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) =
+    wordOfBlock d p i := by
+  -- The two sides are lists of `Fin d` of the same length `p`.
+  -- Equality follows from compatibility of the Fintype.equivFin enumerations
+  -- for `Fin p → Fin d` (used on the RHS) and `Fin n → Fin (blockPhysDim d m)`
+  -- (used on the LHS), together with the fact that grouping m-sized chunks of
+  -- a function `Fin p → Fin d` corresponds to the currying `Fin n → (Fin m → Fin d)`
+  -- under the product identification `Fin (m*n) ≃ Fin m × Fin n` encoded by
+  -- the standard Fintype instances.
+  sorry
+
+/-- The global grouping-cast hypothesis applied to a specific family reduces to the
+core Fintype-level assertion. -/
+theorem groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+    {d : ℕ} (h_flatten : ∀ {m n p : ℕ} (hp_eq : p = m * n)
+      (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
+      (i : Fin (blockPhysDim d p)),
+      flattenBlockedWord d m
+        (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) =
+      wordOfBlock d p i)
+    {r : ℕ} {dim : Fin r → ℕ}
+    {blocks : (k : Fin r) → MPSTensor d (dim k)}
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
+    F.groupedBlockCastAgrees k := by
+  rw [F.groupedBlockCastAgrees_iff_iteratedBlockIndex_cast k]
+  intro i
+  let m := F.period k
+  let n := F.extra k
+  have hp_eq : F.p = m * n := F.p_eq_period_mul_extra k
+  have hcard_symm : blockPhysDim d F.p = blockPhysDim (blockPhysDim d m) n :=
+    (F.blockPhysDim_nested_eq k).symm
+  have hcast_eq : iteratedBlockIndex d m n (Fin.cast hcard_symm i) =
+      Fin.cast (congr_arg (blockPhysDim d) hp_eq) i := by
+    apply wordOfBlock_injective d (m * n)
+    calc
+      wordOfBlock d (m * n)
+        (iteratedBlockIndex d m n (Fin.cast hcard_symm i)) =
+        flattenBlockedWord d m
+          (wordOfBlock (blockPhysDim d m) n (Fin.cast hcard_symm i)) := by
+        rw [wordOfBlock_iteratedBlockIndex]
+      _ = wordOfBlock d F.p i := by
+        simpa [hcard_symm, hp_eq] using h_flatten hp_eq (F.blockPhysDim_nested_eq k) i
+      _ = wordOfBlock d (m * n)
+          (Fin.cast (congr_arg (blockPhysDim d) hp_eq) i) :=
+        wordOfBlock_cast_length d hp_eq i
+  simpa using hcast_eq
+
 /-- The blocked-word comparison follows if the canonical identification from the common
 alphabet to an iterated alphabet agrees with the grouping map that reads a direct word in
 consecutive blocks of length $m_k$ (the period of block $k$). -/

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -680,7 +680,8 @@ hypothesis, uses
 `isIrreducibleOnCorner_of_cyclic_decomp_mps_of_sectorFixedPointAlgebraRigidity`
 to obtain corner irreducibility of `((transferMap A†)^m)|_{P_k}`, and then
 applies the compression transport theorem above. -/
-theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity
+theorem
+  primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -910,7 +911,8 @@ concentrated in proving that the blocked sector adjoint fixed-point algebra is
 scalar. Once that hypothesis is available, the present theorem derives
 `SectorFixedPointAlgebraRigidity` and applies the orbit-sum / corner-compression
 reduction from the fixed-algebra-rigidity sector-block theorem. -/
-theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_scalarBlockedFixedPoints
+theorem
+  primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_scalarBlockedFixedPoints
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -1525,7 +1527,7 @@ theorem groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
         simpa [hcard_symm, hp_eq] using h_flatten hp_eq (F.blockPhysDim_nested_eq k) i
       _ = wordOfBlock d (m * n)
           (Fin.cast (congr_arg (blockPhysDim d) hp_eq) i) :=
-        wordOfBlock_cast_length d hp_eq i
+        (wordOfBlock_cast_length d hp_eq i).symm
   simpa using hcast_eq
 
 /-- The blocked-word comparison follows if the canonical identification from the common

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1194,6 +1194,79 @@ theorem toRelabelingHypothesis {d : ℕ}
 
 end CommonGroupedBlockCastHypothesis
 
+/-- **Unconditional common primitive irreducible block decompositions.**
+
+If the Fintype-level coordinate assertion `flattenWordOfBlock_cast_eq` holds (the
+single remaining mathematical fact from #1075/#990), then the
+`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` theorem
+applies without any blocking-coordinate hypothesis.
+
+The proof chains:
+1. `flattenWordOfBlock_cast_eq` → `CommonGroupedBlockCastHypothesis d`
+   (via `groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq`)
+2. `CommonGroupedBlockCastHypothesis d` → `CommonSectorRelabelingHypothesis d`
+   (via `CommonGroupedBlockCastHypothesis.toRelabelingHypothesis`)
+3. `CommonSectorRelabelingHypothesis d` → the full common-block decomposition
+   (via `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`)
+
+The remaining gap is therefore exactly the single `sorry` in
+`flattenWordOfBlock_cast_eq` in `CyclicSectorDecomposition.lean`. -/
+theorem unconditional_commonPrimitiveIrreducibleBlocks
+    {d D₁ D₂ : ℕ}
+    (h_flatten : ∀ {m n p : ℕ} (hp_eq : p = m * n)
+      (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
+      (i : Fin (blockPhysDim d p)),
+      flattenBlockedWord d m
+        (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) =
+      wordOfBlock d p i)
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ (zeroTailA zeroTailB : ℕ),
+    ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)),
+    ∃ (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)),
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
+      (∀ x, μA x ≠ 0) ∧
+      (∀ x, μB x ≠ 0) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) ∧
+      (∀ x, IsIrreducibleTensor (blocksA x)) ∧
+      (∀ x, IsIrreducibleTensor (blocksB x)) ∧
+      (∀ x, 0 < dimA x) ∧
+      (∀ x, 0 < dimB x) := by
+  have h_group : CommonGroupedBlockCastHypothesis d := by
+    intro r dim blocks F k
+    exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq h_flatten k
+  have h_relabel : CommonSectorRelabelingHypothesis d :=
+    h_group.toRelabelingHypothesis
+  exact afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
+    A B hSame h_relabel
+
 set_option maxHeartbeats 800000 in
 -- The conclusion records both decompositions and all their structural hypotheses together.
 /-- **Common primitive irreducible block decompositions after blocked-word reindexing.**

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1194,79 +1194,6 @@ theorem toRelabelingHypothesis {d : ℕ}
 
 end CommonGroupedBlockCastHypothesis
 
-/-- **Unconditional common primitive irreducible block decompositions.**
-
-If the Fintype-level coordinate assertion `flattenWordOfBlock_cast_eq` holds (the
-single remaining mathematical fact from #1075/#990), then the
-`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` theorem
-applies without any blocking-coordinate hypothesis.
-
-The proof chains:
-1. `flattenWordOfBlock_cast_eq` → `CommonGroupedBlockCastHypothesis d`
-   (via `groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq`)
-2. `CommonGroupedBlockCastHypothesis d` → `CommonSectorRelabelingHypothesis d`
-   (via `CommonGroupedBlockCastHypothesis.toRelabelingHypothesis`)
-3. `CommonSectorRelabelingHypothesis d` → the full common-block decomposition
-   (via `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`)
-
-The remaining gap is therefore exactly the single `sorry` in
-`flattenWordOfBlock_cast_eq` in `CyclicSectorDecomposition.lean`. -/
-theorem unconditional_commonPrimitiveIrreducibleBlocks
-    {d D₁ D₂ : ℕ}
-    (h_flatten : ∀ {m n p : ℕ} (hp_eq : p = m * n)
-      (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
-      (i : Fin (blockPhysDim d p)),
-      flattenBlockedWord d m
-        (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) =
-      wordOfBlock d p i)
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :
-    ∃ p : ℕ, 0 < p ∧
-    ∃ (zeroTailA zeroTailB : ℕ),
-    ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
-      (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)),
-    ∃ (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
-      (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)),
-      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-        mpv (blockTensor (d := d) (D := D₁) A p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) ∧
-      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-        mpv (blockTensor (d := d) (D := D₂) B p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
-      SameMPV₂Pos
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
-      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
-        (zeroTailA : ℂ) +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
-          (zeroTailB : ℂ) +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
-      (∀ x, μA x ≠ 0) ∧
-      (∀ x, μB x ≠ 0) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) ∧
-      (∀ x, IsIrreducibleTensor (blocksA x)) ∧
-      (∀ x, IsIrreducibleTensor (blocksB x)) ∧
-      (∀ x, 0 < dimA x) ∧
-      (∀ x, 0 < dimB x) := by
-  have h_group : CommonGroupedBlockCastHypothesis d := by
-    intro r dim blocks F k
-    exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq h_flatten k
-  have h_relabel : CommonSectorRelabelingHypothesis d :=
-    h_group.toRelabelingHypothesis
-  exact afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
-    A B hSame h_relabel
-
 set_option maxHeartbeats 800000 in
 -- The conclusion records both decompositions and all their structural hypotheses together.
 /-- **Common primitive irreducible block decompositions after blocked-word reindexing.**
@@ -1475,6 +1402,79 @@ theorem afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
     flatBlocksB,
     hZAflat, hZBflat, hAPos, hBPos, hNonzeroPos, hZeroFlat,
     hμA, hμB, hTPA', hTPB', hPrimA', hPrimB', hIrrA', hIrrB', hDimA, hDimB⟩
+
+/-- **Unconditional common primitive irreducible block decompositions.**
+
+If the Fintype-level coordinate assertion `flattenWordOfBlock_cast_eq` holds (the
+single remaining mathematical fact from #1075/#990), then the
+`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` theorem
+applies without any blocking-coordinate hypothesis.
+
+The proof chains:
+1. `flattenWordOfBlock_cast_eq` → `CommonGroupedBlockCastHypothesis d`
+   (via `groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq`)
+2. `CommonGroupedBlockCastHypothesis d` → `CommonSectorRelabelingHypothesis d`
+   (via `CommonGroupedBlockCastHypothesis.toRelabelingHypothesis`)
+3. `CommonSectorRelabelingHypothesis d` → the full common-block decomposition
+   (via `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`)
+
+The remaining gap is therefore exactly the single `sorry` in
+`flattenWordOfBlock_cast_eq` in `CyclicSectorDecomposition.lean`. -/
+theorem unconditional_commonPrimitiveIrreducibleBlocks
+    {d D₁ D₂ : ℕ}
+    (h_flatten : ∀ {m n p : ℕ} (hp_eq : p = m * n)
+      (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
+      (i : Fin (blockPhysDim d p)),
+      flattenBlockedWord d m
+        (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) =
+      wordOfBlock d p i)
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ (zeroTailA zeroTailB : ℕ),
+    ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)),
+    ∃ (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)),
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
+      (∀ x, μA x ≠ 0) ∧
+      (∀ x, μB x ≠ 0) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) ∧
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) ∧
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) ∧
+      (∀ x, IsIrreducibleTensor (blocksA x)) ∧
+      (∀ x, IsIrreducibleTensor (blocksB x)) ∧
+      (∀ x, 0 < dimA x) ∧
+      (∀ x, 0 < dimB x) := by
+  have h_group : CommonGroupedBlockCastHypothesis d := by
+    intro r dim blocks F k
+    exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq h_flatten k
+  have h_relabel : CommonSectorRelabelingHypothesis d :=
+    h_group.toRelabelingHypothesis
+  exact afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
+    A B hSame h_relabel
 
 set_option maxHeartbeats 900000 in
 -- The nested existential conclusion records both sides and the conditional

--- a/audits/2026-05-01_issue1075_fintype_coordinate_obstacle.md
+++ b/audits/2026-05-01_issue1075_fintype_coordinate_obstacle.md
@@ -1,0 +1,83 @@
+# 2026-05-01 — Fintype-level coordinate obstacle (#1075/#990)
+
+## Scope
+
+This note records the precise remaining mathematical gap that blocks the
+unconditional common primitive irreducible block decomposition from issue #942.
+
+The gap is a single Fintype-level compatibility assertion: the two independent
+instances of `Fintype.equivFin` used in the blocked-word infrastructure (one for
+`Fin p → Fin d` and one for `Fin n → Fin (blockPhysDim d m)`) are compatible
+under the natural currying and product-identification maps that send a function
+`Fin p → Fin d` (where `p = m*n`) to the corresponding `n`-tuple of `m`-tuples.
+
+## Lean statement
+
+In `CyclicSectorDecomposition.lean`, the lemma
+`flattenWordOfBlock_cast_eq` states:
+
+```lean
+theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
+    (hp_eq : p = m * n) (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
+    (i : Fin (blockPhysDim d p)) :
+    flattenBlockedWord d m
+      (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) =
+    wordOfBlock d p i := by
+  sorry
+```
+
+This lemma is the single remaining `sorry` that blocks:
+- `CommonGroupedBlockCastHypothesis d`
+- `CommonSectorRelabelingHypothesis d`
+- `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` (making it unconditional)
+- The closure of issues #1075, #990, and #942.
+
+## Dependencies
+
+The lemma `groupedBlockCastAgrees_iff_flatten_eq` reduces the coordinate
+assertion `groupedBlockCastAgrees` to exactly the equation above.
+The lemma `unconditional_commonPrimitiveIrreducibleBlocks` in
+`StructuralTheorem.lean` shows that proving `flattenWordOfBlock_cast_eq`
+immediately yields the unconditional common-block theorem.
+
+The reduction chain is:
+1. `flattenWordOfBlock_cast_eq` → `CommonGroupedBlockCastHypothesis d`
+2. → `CommonSectorRelabelingHypothesis d`
+3. → `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
+   (unconditional)
+
+## Mathematical content
+
+The equality concerns two ways to decode a blocked physical index
+`i : Fin (blockPhysDim d p)` (`= Fin (d^p)`) into a list of `p` physical letters:
+
+1. **Direct decoding** (RHS): `wordOfBlock d p i` uses `Fintype.equivFin (Fin p → Fin d)`
+   to interpret `i.val` as a function `Fin p → Fin d`, then lists its values.
+
+2. **Grouped decoding** (LHS): First interpret `i` through
+   `Fintype.equivFin (Fin n → Fin (blockPhysDim d m))` (where `blockPhysDim d m = d^m`),
+   obtaining an `n`-tuple of `Fin d^m` values; then decode each of those through
+   `Fintype.equivFin (Fin m → Fin d)`; then flatten the `n` lists of length `m` into
+   one list of length `p = m*n`.
+
+The equality asserts that these two decoding paths produce the same length-`p` word
+over `Fin d`.  This is true for the standard Mathlib `Fintype` instances for
+function types, which use lexicographic enumeration, because the lexicographic
+ordering of `Fin p → Fin d` coincides with the lexicographic ordering of
+`Fin n → (Fin m → Fin d)` under the natural currying isomorphism.
+
+Proving this in Lean requires chasing the specific `Fintype` instances for
+`Pi` types through `Fintype.equivFin`, `Fintype.truncEquivFin`, and the
+underlying `Finset` enumerations of `Fin n → Fin (blockPhysDim d m)`.
+The key lemma is likely `Fintype.truncEquivFin` applied to both function types,
+together with a lemma relating the `Finset` of all functions `Fin p → Fin d`
+to the product of `Finset`s of functions `Fin m → Fin d`.
+
+## References
+
+- `Mathlib/Data/Fintype/EquivFin.lean` — definition of `Fintype.equivFin`
+- `Mathlib/Data/Fintype/Basic.lean` — `Pi.fintype` instances
+- `Mathlib/Data/Fin/Fin.mp` — binary product decomposition of `Fin (m*n)`
+- `TNLean/MPS/Core/BlockingInfrastructure.lean` — `directToIteratedBlockIndex`, `iteratedBlockIndex`, etc.
+- `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean` — `flattenWordOfBlock_cast_eq`, `groupedBlockCastAgrees_iff_flatten_eq`
+- `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean` — `unconditional_commonPrimitiveIrreducibleBlocks`


### PR DESCRIPTION
## Summary

Reduces the common primitive irreducible block decomposition gap (issue #942) to a single Fintype-level assertion.

## What this PR does

1. **`flattenWordOfBlock_cast_eq`** (with `sorry`) — the core Fintype-level compatibility statement. This is the single remaining mathematical fact that blocks the unconditional common primitive irreducible block theorem. The assertion says: the two `Fintype.equivFin` enumerations for `Fin p → Fin d` and `Fin n → Fin (blockPhysDim d m)` are compatible under currying when `p = m*n`.

2. **`groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq`** — proves that the coordinate-grouping hypothesis follows directly from the Fintype assertion.

3. **`unconditional_commonPrimitiveIrreducibleBlocks`** — shows that `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` (from PR #1069) becomes unconditional once the Fintype assertion is proved. The reduction chain is:   `flattenWordOfBlock_cast_eq` → `CommonGroupedBlockCastHypothesis d` → `CommonSectorRelabelingHypothesis d` → unconditional theorem.

4. **Audit** `audits/2026-05-01_issue1075_fintype_coordinate_obstacle.md` — documents the precise mathematical content of the remaining gap, the reduction chain, and the Mathlib dependencies involved.

## What remains

The single `sorry` in `flattenWordOfBlock_cast_eq` needs to be proved. This is a compatibility statement between `Fintype.equivFin` instances for function types — the lexicographic enumeration of `Fin p → Fin d` coincides with the lexicographic enumeration of `Fin n → (Fin m → Fin d)` under currying. This is true for the standard Mathlib `Pi.fintype` instances but requires chasing `Fintype` internals.

## Related issues

- Closes a sub-goal of #942  
- Reduces #1075 and #990 to a single `sorry`  
- Unblocks the unconditional common-block theorem path to #944 and #652

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new central lemma stub (`flattenWordOfBlock_cast_eq`) with a remaining `sorry` and wires downstream results to depend on it, so proof completeness/regressions hinge on this unproven statement.
> 
> **Overview**
> Isolates the remaining blocked-word coordinate problem for unconditional common primitive/irreducible block decompositions to a single new lemma, `flattenWordOfBlock_cast_eq`, asserting compatibility of the two `Fintype.equivFin` encodings used when flattening nested blocking (left as a `sorry`).
> 
> Builds a bridge lemma (`groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq`) showing this Fintype assertion implies the per-family coordinate-grouping condition, and adds `unconditional_commonPrimitiveIrreducibleBlocks` to make the common-block theorem unconditional once the lemma is proved. An audit note is added documenting the exact gap, dependency chain, and relevant Mathlib files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d9a25cb302cf403dbd5307a5dd3a9437643572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->