### PR TITLE
feat(Channel): formalize Lorentz/SVD normal form existence (#766)

### DIFF
--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -1,0 +1,293 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Basic
+import TNLean.Channel.TransferMatrix
+import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.NormalForm
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.Analysis.Matrix.Order
+
+/-!
+# Lorentz normal form for quantum channels (Wolf §2.3)
+
+This file formalises the existence results for normal forms of quantum channels
+under filtering operations, as described in Wolf §2.3.  The central idea is that
+every CP map with full Kraus rank can be brought to a doubly-stochastic normal
+form by pre- and post-composition with invertible Kraus-rank-1 CP maps (filtering
+operations).  For qubit channels (D = 2) the equivalence class under
+SL(2, ℂ)-filterings admits a particularly explicit classification — the *Lorentz
+normal form* — with three canonical representatives.
+
+## Structure
+
+1. **Filtering operations.**  An `SLFiltering` is a CP map Φ(X) = S X S† where
+   `det S = 1`.  Such maps are invertible and have Kraus rank 1.
+
+2. **Doubly-stochastic maps.**  A linear map T is *doubly-stochastic* if both
+   `T(1)` and the partial trace of its Choi matrix over the first subsystem
+   are proportional to the identity matrix.  This is the normal form target
+   for the generic construction (Wolf Prop 2.8).
+
+3. **Generic normal form (Wolf Prop 2.8).**  For a CP map with full Kraus rank
+   (equivalently, a positive-definite Choi matrix), there exist SL-filterings
+   Φ₁, Φ₂ such that Φ₂ ∘ T ∘ Φ₁ is doubly-stochastic.
+
+4. **Lorentz normal form for qubit channels (Wolf Prop 2.9 / Prop 2.11).**
+   For every qubit channel (D = 2), after suitable SL(2, ℂ)-filterings, the
+   transfer matrix takes one of three canonical forms: diagonal, non-diagonal,
+   or singular.
+
+## Dependencies on missing Mathlib infrastructure
+
+The compactness / minimisation argument used in the proof of Prop 2.8 and 2.9
+(over SL(n, ℂ) filterings) is not yet formalised in Mathlib or TNLean.  The
+relevant theorems are therefore stated with `sorry` for the minimisation core.
+See the documentation of `infimum_is_attained` for the precise missing fact.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2.3][Wolf2012QChannels]
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+open Matrix Finset
+open ChoiJamiolkowski
+
+namespace Wolf
+
+section FilteringOperations
+
+/-- An `SLFiltering` for `D × D` matrices bundles a matrix `S` with
+`det S = 1` (and `S` invertible) together with its associated CP map
+`Φ(X) = S X S†`.  Such maps are called *filtering operations* in Wolf §2.3.
+-/
+structure SLFiltering (D : ℕ) where
+  /-- The filtering matrix, with determinant 1. -/
+  S : Matrix (Fin D) (Fin D) ℂ
+  /-- `det S = 1`. -/
+  det_eq_one : S.det = 1
+  /-- `S` is invertible. -/
+  S_isUnit : IsUnit S
+  /-- The CP map: Φ(X) = S X S†. -/
+  map : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ
+  /-- `map` is exactly the unitary conjugation by `S`. -/
+  map_eq : map = unitaryConjLM (D := D) S
+  /-- SL-filterings are CP. -/
+  cp : IsCPMap map
+
+/-- The identity map is an SL-filtering (S = 1). -/
+noncomputable def SLFiltering.id (D : ℕ) : SLFiltering D where
+  S := 1
+  det_eq_one := by simp
+  S_isUnit := by simp
+  map := unitaryConjLM (D := D) 1
+  map_eq := rfl
+  cp := unitaryConjLM_isCPMap (D := D) 1
+
+/-- The canonical SL-filtering from a matrix S with det S = 1 (when S is invertible). -/
+noncomputable def SLFiltering.ofMatrix {D : ℕ} (S : Matrix (Fin D) (Fin D) ℂ)
+    (hdet : S.det = 1) (hunit : IsUnit S) : SLFiltering D where
+  S := S
+  det_eq_one := hdet
+  S_isUnit := hunit
+  map := unitaryConjLM (D := D) S
+  map_eq := rfl
+  cp := unitaryConjLM_isCPMap (D := D) S
+
+/-- Composition of two SL-filterings is an SL-filtering. -/
+noncomputable def SLFiltering.comp {D : ℕ} (Φ Ψ : SLFiltering D) : SLFiltering D where
+  S := Φ.S * Ψ.S
+  det_eq_one := by
+    rw [Matrix.det_mul, Φ.det_eq_one, Ψ.det_eq_one, one_mul]
+  S_isUnit := Φ.S_isUnit.mul Ψ.S_isUnit
+  map := unitaryConjLM (D := D) (Φ.S * Ψ.S)
+  map_eq := rfl
+  cp := by
+    have hcomp : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+        (unitaryConjLM Φ.S ∘ₗ unitaryConjLM Ψ.S) X =
+        unitaryConjLM (Φ.S * Ψ.S) X := by
+      intro X
+      simp [unitaryConjLM_apply, Matrix.mul_assoc, Matrix.conjTranspose_mul]
+    -- `unitaryConjLM (Φ.S * Ψ.S)` is CP (single Kraus operator).
+    exact unitaryConjLM_isCPMap (D := D) (Φ.S * Ψ.S)
+
+end FilteringOperations
+
+/-! ### Doubly-stochastic maps -/
+
+section DoublyStochastic
+
+variable {D : ℕ}
+
+/-- A CP map `T` is **doubly-stochastic** if `T(1) ∝ 1` and the reduced density
+matrix `tr₁[τ]` of its Choi matrix `τ = (T ⊗ id)(|Ω⟩⟨Ω|)` is proportional to
+the identity.  By Choi–Jamiołkowski, this is equivalent to both `T(1)` and
+`T*(1)` being proportional to identity, which is the target normal form in
+Wolf Prop 2.8.
+
+We use the partial-trace formulation to avoid depending on the Hilbert–Schmidt
+inner-product adjoint `LinearMap.adjoint`, which requires additional type-class
+instances. -/
+def DoublyStochastic (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) : Prop :=
+  (∃ c₁ : ℂ, T 1 = c₁ • (1 : Matrix (Fin D) (Fin D) ℂ)) ∧
+  (∃ c₂ : ℂ, Matrix.traceLeft (choiMatrix T) = c₂ • (1 : Matrix (Fin D) (Fin D) ℂ))
+
+/-- Doubly-stochastic implies T(1) ∝ 1. -/
+lemma DoublyStochastic.unital (hT : DoublyStochastic T) :
+    ∃ c : ℂ, T 1 = c • (1 : Matrix (Fin D) (Fin D) ℂ) := hT.1
+
+/-- Doubly-stochastic implies the partial trace of the Choi matrix is ∝ 1
+(equivalently, T*(1) ∝ 1). -/
+lemma DoublyStochastic.tracePreserving (hT : DoublyStochastic T) :
+    ∃ c : ℂ, Matrix.traceLeft (choiMatrix T) =
+      c • (1 : Matrix (Fin D) (Fin D) ℂ) := hT.2
+
+end DoublyStochastic
+
+/-! ### Generic normal form (Wolf Prop 2.8)
+
+The proof idea (see Wolf §2.3):
+1. Work at the level of the Choi matrix τ = (T ⊗ id)(|Ω⟩⟨Ω|).
+2. Under SL-filterings Φ(X) = S X S†, τ transforms as τ → (S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†
+   (up to transposition convention).
+3. Minimize tr[τ'] over S₁, S₂ with det = 1.
+4. The infimum is attained (compactness of the bounded subset of SL(n, ℂ)).
+5. At the optimum, both partial traces of τ' are proportional to identity,
+   giving doubly-stochastic T'.
+
+Step 4 is the compactness/minimisation argument that is **not yet formalised**
+in Mathlib or TNLean.  We state the lemma as `infimum_is_attained` with a
+`sorry` filler.  Step 5 follows from the optimality condition (AGM iteration),
+stated below. -/
+
+section GenericNormalForm
+
+variable {D : ℕ}
+
+/-- **Key lemma (not yet formalised).**  For a positive-definite Choi matrix τ,
+the infimum of `tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]` over `S₁, S₂` with `det = 1`
+is attained.  That is, the continuous function
+`(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
+achieves its minimum on the domain of SL(n, ℂ) × SL(n, ℂ).
+
+**Proof sketch** (Wolf §2.3).  There exist bounds
+  `0 < λ_min(τ) · ‖S₂ ⊗ₖ S₁‖² ≤ tr[τ'] ≤ tr[τ]`,
+so we may restrict to a bounded subset `{S_i | ‖S_i‖ ≤ C}` inside
+`{S | det S = 1}`.  In finite dimensions this set is compact, and the
+continuous trace functional attains its infimum by the extreme value theorem.
+
+**Missing Mathlib facts:**
+- Compactness of the set `{S : Matrix n n ℂ | det S = 1 ∧ ‖S‖ ≤ C}`.
+  This needs: (a) the determinant condition `det S = 1` defines a closed set
+  (it's a polynomial equation), and (b) the spectral-norm ball `‖S‖ ≤ C` is
+  compact (finite-dimensional Heine–Borel).
+- The extreme value theorem for the continuous map
+  `(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
+  on this compact product set.
+Both should be obtainable from `Mathlib.Topology.Instances.Matrix` and
+`Mathlib.Topology.Algebra.Module.FiniteDimension`, but the glue is missing.
+
+Once this lemma is proved, the rest of the normal-form argument (Thm 2.8) is
+purely algebraic and follows from the optimality conditions. -/
+lemma infimum_is_attained
+    {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
+    (_hτ_posDef : τ.PosDef) :
+    ∃ (S₁ S₂ : Matrix (Fin D) (Fin D) ℂ),
+      S₁.det = 1 ∧ S₂.det = 1 ∧
+      ∀ (T₁ T₂ : Matrix (Fin D) (Fin D) ℂ),
+        T₁.det = 1 → T₂.det = 1 →
+        Matrix.trace (((T₂ ⊗ₖ T₁) * τ * ((T₂ ⊗ₖ T₁)ᴴ))) ≥
+          Matrix.trace (((S₂ ⊗ₖ S₁) * τ * ((S₂ ⊗ₖ S₁)ᴴ))) := by
+  -- Not yet formalised: requires compactness of bounded SL(n, ℂ) sets and the
+  -- extreme value theorem.  See the docstring for the missing Mathlib facts.
+  sorry
+
+/-- **Wolf Prop 2.8: generic normal form for CP maps with full Kraus rank.**
+
+Let `T : M_D(ℂ) → M_D(ℂ)` be a completely positive map with full Kraus rank
+(equivalently, its Choi matrix is positive-definite).  Then there exist
+SL(D, ℂ)-filterings Φ₁, Φ₂ such that `Φ₂ ∘ T ∘ Φ₁` is doubly-stochastic.
+
+This is the main normal-form existence result for generic CP maps.  The Lorentz
+normal form for qubit channels (Prop 2.9) is the D = 2 specialisation with the
+complete classification of the possible doubly-stochastic normal forms. -/
+theorem exists_normal_form_generic
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (_hCP : IsCPMap T)
+    (_hFullRank : (choiMatrix T).PosDef) :
+    ∃ (Φ₁ Φ₂ : SLFiltering D),
+      DoublyStochastic (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) := by
+  -- Let τ be the Choi matrix of T.
+  let τ := choiMatrix T
+  -- Use the infimum-attainment lemma (sorry for now).
+  obtain ⟨_S₁, _S₂, _, _, _⟩ := infimum_is_attained (τ := τ) _hFullRank
+  -- The rest: use the optimality condition to conclude doubly-stochasticity.
+  -- This requires the AGM-inequality iteration from Wolf §2.3, which is
+  -- not yet formalised.
+  sorry
+
+end GenericNormalForm
+
+/-! ### Lorentz normal form for qubit channels (Wolf Prop 2.9 / Prop 2.11)
+
+For `D = 2` (qubit channels), the doubly-stochastic normal form from
+Prop 2.8 can be further simplified using the Lorentz group action on the
+transfer matrix.  The result is a complete classification into three
+canonical forms:
+
+1. **Diagonal** (generic case): unital with diagonal Δ.
+2. **Non-diagonal**: a one-parameter family with specific v and Δ.
+3. **Singular**: maps everything to a fixed output.
+
+The formal proof of this classification requires:
+- The Pauli basis representation of qubit channels (4 × 4 transfer matrix).
+- The spinor map SL(2, ℂ) → SO⁺(1, 3) (Lorentz group).
+- Singular value decomposition of the 3 × 3 real submatrix Δ.
+- The inequality λ₁ + λ₂ ≤ 1 + λ₃ for complete positivity.
+
+We state the theorem as a formal existence result with a `sorry` for the
+compactness / classification steps.  The statement is placed here as a
+formal target for future work. -/
+
+section LorentzNormalFormQubit
+
+/-- **Lorentz normal form for qubit channels (Wolf Prop 2.9 / Prop 2.11).**
+
+For every qubit channel `T : M₂(ℂ) → M₂(ℂ)`, there exist SL(2, ℂ)-filterings
+Φ₁, Φ₂ such that `T' = Φ₂ ∘ T ∘ Φ₁` is a qubit channel of one of three types:
+- `type_diagonal`: T' is unital with diagonal Δ (the generic case);
+- `type_nondiagonal`: T' has a specific one-parameter form;
+- `type_singular`: T' maps everything to a single pure state.
+
+The proof is not yet formalised; it depends on:
+- The compactness lemma `infimum_is_attained` (above);
+- The Lorentz group classification of SL(2, ℂ) orbits;
+- The complete-positivity condition λ₁ + λ₂ ≤ 1 + λ₃.
+
+See Wolf §2.3 for the complete proof. -/
+theorem exists_lorentz_normal_form_qubit
+    (T : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ)
+    (_hCh : IsChannel T) :
+    ∃ (Φ₁ Φ₂ : SLFiltering 2),
+      IsChannel (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) := by
+  -- Not yet formalised.  This is a target theorem; the proof depends on
+  -- `infimum_is_attained` and the Lorentz group classification, neither of
+  -- which is available in Mathlib or TNLean as of 2026-05.
+  sorry
+
+end LorentzNormalFormQubit
+
+/-
+## Connection to transfer-matrix normal forms (Wolf §2.3)
+
+The results above are stated at the level of CP maps.  The corresponding
+transfer-matrix formulation (Props 2.7-2.8 in the blueprint / TransferMatrix.lean)
+is obtained by applying `transferMatrix` to both sides.  The SVD normal form
+(`Matrix.svd_of_isUnit`, `transferMatrix_svd_of_isUnit`) provides the
+algebraic engine: after SL-filterings, the transfer matrix of the doubly-stochastic
+map admits an SVD, which for D = 2 yields the Lorentz normal form decomposition.
+-/
+
+end Wolf

--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -36,8 +36,8 @@ normal form* — with three canonical representatives.
 
 4. **Lorentz normal form for qubit channels (Wolf Prop 2.9 / Prop 2.11).**
    For every qubit channel (D = 2), after suitable SL(2, ℂ)-filterings, the
-   transfer matrix takes one of three canonical forms: diagonal, non-diagonal,
-   or singular.
+   Pauli-basis transfer matrix takes one of three canonical forms: diagonal,
+   non-diagonal, or singular.
 
 ## Dependencies on missing Mathlib infrastructure
 
@@ -61,15 +61,12 @@ section FilteringOperations
 
 /-- An `SLFiltering` for `D × D` matrices bundles a matrix `S` with
 `det S = 1` (and `S` invertible) together with its associated CP map
-`Φ(X) = S X S†`.  Such maps are called *filtering operations* in Wolf §2.3.
--/
+`Φ(X) = S X S†`.  Such maps are called *filtering operations* in Wolf §2.3. -/
 structure SLFiltering (D : ℕ) where
   /-- The filtering matrix, with determinant 1. -/
   S : Matrix (Fin D) (Fin D) ℂ
   /-- `det S = 1`. -/
   det_eq_one : S.det = 1
-  /-- `S` is invertible. -/
-  S_isUnit : IsUnit S
   /-- The CP map: Φ(X) = S X S†. -/
   map : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ
   /-- `map` is exactly the unitary conjugation by `S`. -/
@@ -77,41 +74,35 @@ structure SLFiltering (D : ℕ) where
   /-- SL-filterings are CP. -/
   cp : IsCPMap map
 
+/-- The matrix `S` of an SL-filtering is invertible (follows from `det_eq_one`). -/
+lemma SLFiltering.S_isUnit {D : ℕ} (Φ : SLFiltering D) : IsUnit Φ.S := by
+  have h : Φ.S.det = 1 := Φ.det_eq_one
+  have hdet : IsUnit (Φ.S.det) := by rw [h]; exact isUnit_one
+  -- In a CommRing, a matrix is invertible iff its determinant is a unit.
+  refine (Matrix.isUnit_iff_isUnit_det Φ.S).mpr hdet
+
 /-- The identity map is an SL-filtering (S = 1). -/
 noncomputable def SLFiltering.id (D : ℕ) : SLFiltering D where
   S := 1
   det_eq_one := by simp
-  S_isUnit := by simp
   map := unitaryConjLM (D := D) 1
   map_eq := rfl
   cp := unitaryConjLM_isCPMap (D := D) 1
-
-/-- The canonical SL-filtering from a matrix S with det S = 1 (when S is invertible). -/
-noncomputable def SLFiltering.ofMatrix {D : ℕ} (S : Matrix (Fin D) (Fin D) ℂ)
-    (hdet : S.det = 1) (hunit : IsUnit S) : SLFiltering D where
-  S := S
-  det_eq_one := hdet
-  S_isUnit := hunit
-  map := unitaryConjLM (D := D) S
-  map_eq := rfl
-  cp := unitaryConjLM_isCPMap (D := D) S
 
 /-- Composition of two SL-filterings is an SL-filtering. -/
 noncomputable def SLFiltering.comp {D : ℕ} (Φ Ψ : SLFiltering D) : SLFiltering D where
   S := Φ.S * Ψ.S
   det_eq_one := by
     rw [Matrix.det_mul, Φ.det_eq_one, Ψ.det_eq_one, one_mul]
-  S_isUnit := Φ.S_isUnit.mul Ψ.S_isUnit
   map := unitaryConjLM (D := D) (Φ.S * Ψ.S)
   map_eq := rfl
-  cp := by
-    have hcomp : ∀ X : Matrix (Fin D) (Fin D) ℂ,
-        (unitaryConjLM Φ.S ∘ₗ unitaryConjLM Ψ.S) X =
-        unitaryConjLM (Φ.S * Ψ.S) X := by
-      intro X
-      simp [unitaryConjLM_apply, Matrix.mul_assoc, Matrix.conjTranspose_mul]
-    -- `unitaryConjLM (Φ.S * Ψ.S)` is CP (single Kraus operator).
-    exact unitaryConjLM_isCPMap (D := D) (Φ.S * Ψ.S)
+  cp := unitaryConjLM_isCPMap (D := D) (Φ.S * Ψ.S)
+
+/-- `unitaryConjLM A ∘ₗ unitaryConjLM B = unitaryConjLM (A * B)`. -/
+lemma unitaryConjLM_comp {D : ℕ} (A B : Matrix (Fin D) (Fin D) ℂ) :
+    unitaryConjLM (D := D) A ∘ₗ unitaryConjLM (D := D) B =
+    unitaryConjLM (D := D) (A * B) := by
+  ext X; simp [unitaryConjLM_apply, Matrix.mul_assoc, Matrix.conjTranspose_mul]
 
 end FilteringOperations
 
@@ -119,7 +110,7 @@ end FilteringOperations
 
 section DoublyStochastic
 
-variable {D : ℕ}
+variable {D : ℕ} (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
 
 /-- A CP map `T` is **doubly-stochastic** if `T(1) ∝ 1` and the reduced density
 matrix `tr₁[τ]` of its Choi matrix `τ = (T ⊗ id)(|Ω⟩⟨Ω|)` is proportional to
@@ -127,10 +118,9 @@ the identity.  By Choi–Jamiołkowski, this is equivalent to both `T(1)` and
 `T*(1)` being proportional to identity, which is the target normal form in
 Wolf Prop 2.8.
 
-We use the partial-trace formulation to avoid depending on the Hilbert–Schmidt
-inner-product adjoint `LinearMap.adjoint`, which requires additional type-class
-instances. -/
-def DoublyStochastic (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) : Prop :=
+We use the partial-trace formulation to avoid depending on the adjoint of `T`
+as a Hilbert–Schmidt operator. -/
+def DoublyStochastic : Prop :=
   (∃ c₁ : ℂ, T 1 = c₁ • (1 : Matrix (Fin D) (Fin D) ℂ)) ∧
   (∃ c₂ : ℂ, Matrix.traceLeft (choiMatrix T) = c₂ • (1 : Matrix (Fin D) (Fin D) ℂ))
 
@@ -150,8 +140,7 @@ end DoublyStochastic
 
 The proof idea (see Wolf §2.3):
 1. Work at the level of the Choi matrix τ = (T ⊗ id)(|Ω⟩⟨Ω|).
-2. Under SL-filterings Φ(X) = S X S†, τ transforms as τ → (S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†
-   (up to transposition convention).
+2. Under SL-filterings Φ(X) = S X S†, τ transforms as τ → (S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†.
 3. Minimize tr[τ'] over S₁, S₂ with det = 1.
 4. The infimum is attained (compactness of the bounded subset of SL(n, ℂ)).
 5. At the optimum, both partial traces of τ' are proportional to identity,
@@ -181,16 +170,14 @@ continuous trace functional attains its infimum by the extreme value theorem.
 **Missing Mathlib facts:**
 - Compactness of the set `{S : Matrix n n ℂ | det S = 1 ∧ ‖S‖ ≤ C}`.
   This needs: (a) the determinant condition `det S = 1` defines a closed set
-  (it's a polynomial equation), and (b) the spectral-norm ball `‖S‖ ≤ C` is
+  (it is a polynomial equation), and (b) the spectral-norm ball `‖S‖ ≤ C` is
   compact (finite-dimensional Heine–Borel).
 - The extreme value theorem for the continuous map
   `(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
   on this compact product set.
 Both should be obtainable from `Mathlib.Topology.Instances.Matrix` and
-`Mathlib.Topology.Algebra.Module.FiniteDimension`, but the glue is missing.
-
-Once this lemma is proved, the rest of the normal-form argument (Thm 2.8) is
-purely algebraic and follows from the optimality conditions. -/
+`Mathlib.Topology.Algebra.Module.FiniteDimension`, but the connecting results
+are not yet in Mathlib. -/
 lemma infimum_is_attained
     {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
     (_hτ_posDef : τ.PosDef) :
@@ -198,34 +185,28 @@ lemma infimum_is_attained
       S₁.det = 1 ∧ S₂.det = 1 ∧
       ∀ (T₁ T₂ : Matrix (Fin D) (Fin D) ℂ),
         T₁.det = 1 → T₂.det = 1 →
-        Matrix.trace (((T₂ ⊗ₖ T₁) * τ * ((T₂ ⊗ₖ T₁)ᴴ))) ≥
-          Matrix.trace (((S₂ ⊗ₖ S₁) * τ * ((S₂ ⊗ₖ S₁)ᴴ))) := by
-  -- Not yet formalised: requires compactness of bounded SL(n, ℂ) sets and the
-  -- extreme value theorem.  See the docstring for the missing Mathlib facts.
+        (Matrix.trace (((T₂ ⊗ₖ T₁) * τ * ((T₂ ⊗ₖ T₁)ᴴ)))).re ≥
+          (Matrix.trace (((S₂ ⊗ₖ S₁) * τ * ((S₂ ⊗ₖ S₁)ᴴ)))).re := by
   sorry
 
-/-- **Wolf Prop 2.8: generic normal form for CP maps with full Kraus rank.**
+/-- **Wolf Prop 2.9: generic normal form for CP maps with full Kraus rank.**
 
 Let `T : M_D(ℂ) → M_D(ℂ)` be a completely positive map with full Kraus rank
 (equivalently, its Choi matrix is positive-definite).  Then there exist
 SL(D, ℂ)-filterings Φ₁, Φ₂ such that `Φ₂ ∘ T ∘ Φ₁` is doubly-stochastic.
 
-This is the main normal-form existence result for generic CP maps.  The Lorentz
-normal form for qubit channels (Prop 2.9) is the D = 2 specialisation with the
-complete classification of the possible doubly-stochastic normal forms. -/
+This is the CP-map version of Wolf Prop 2.8 (which is stated at the τ-level).
+The Lorentz normal form for qubit channels (Prop 2.9) is the D = 2
+specialisation with the complete classification of the possible
+doubly-stochastic normal forms. -/
 theorem exists_normal_form_generic
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (_hCP : IsCPMap T)
     (_hFullRank : (choiMatrix T).PosDef) :
     ∃ (Φ₁ Φ₂ : SLFiltering D),
       DoublyStochastic (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) := by
-  -- Let τ be the Choi matrix of T.
   let τ := choiMatrix T
-  -- Use the infimum-attainment lemma (sorry for now).
   obtain ⟨_S₁, _S₂, _, _, _⟩ := infimum_is_attained (τ := τ) _hFullRank
-  -- The rest: use the optimality condition to conclude doubly-stochasticity.
-  -- This requires the AGM-inequality iteration from Wolf §2.3, which is
-  -- not yet formalised.
   sorry
 
 end GenericNormalForm
@@ -233,48 +214,121 @@ end GenericNormalForm
 /-! ### Lorentz normal form for qubit channels (Wolf Prop 2.9 / Prop 2.11)
 
 For `D = 2` (qubit channels), the doubly-stochastic normal form from
-Prop 2.8 can be further simplified using the Lorentz group action on the
+Prop 2.8 is further simplified using the Lorentz group action on the
 transfer matrix.  The result is a complete classification into three
-canonical forms:
+canonical forms.
 
-1. **Diagonal** (generic case): unital with diagonal Δ.
-2. **Non-diagonal**: a one-parameter family with specific v and Δ.
-3. **Singular**: maps everything to a fixed output.
+We work in the Pauli basis representation: let σ₀, …, σ₃ be the Pauli
+matrices (σ₀ = 1, σ₁ = σₓ, σ₂ = σ_y, σ₃ = σ_z).  For a
+Hermiticity-preserving TP qubit channel `T`, the Pauli-basis transfer
+matrix
+  `T̂_{ij} = (1/2) tr[σ_i T(σ_j)]`   (i, j ∈ {0,1,2,3})
+has real entries and the block structure
+  `T̂ = [1 0; v Δ]`
+where `v ∈ ℝ³` and `Δ` is a 3×3 real matrix (the Bloch-ball affine map:
+`x ↦ v + Δ x`).
 
-The formal proof of this classification requires:
-- The Pauli basis representation of qubit channels (4 × 4 transfer matrix).
-- The spinor map SL(2, ℂ) → SO⁺(1, 3) (Lorentz group).
-- Singular value decomposition of the 3 × 3 real submatrix Δ.
-- The inequality λ₁ + λ₂ ≤ 1 + λ₃ for complete positivity.
+After SL(2, ℂ) filtering (which acts on `T̂` as a Lorentz transformation
+`L₂ T̂ L₁` with `L_i ∈ SO⁺(1,3)`), the transfer matrix can be brought to
+one of three canonical forms (Wolf Prop 2.9):
 
-We state the theorem as a formal existence result with a `sorry` for the
-compactness / classification steps.  The statement is placed here as a
-formal target for future work. -/
+1. **Diagonal** (generic, full Kraus rank): `T̂` is diagonal —
+   `v = 0` and `Δ = diag(λ₁, λ₂, λ₃)` with the CP condition
+   `λ₁ + λ₂ ≤ 1 + λ₃`.  This is the doubly-stochastic case.
+
+2. **Non-diagonal** (Kraus rank 3): `T̂` has
+   `Δ = diag(x/√3, x/√3, 1/3)`, `v = (0, 0, 2/3)`, with
+   `0 ≤ x ≤ 1`.
+
+3. **Singular** (Kraus rank 2): `T̂` has `Δ = 0` and `v = (0, 0, 1)`;
+   the channel maps every input to a single pure state. -/
 
 section LorentzNormalFormQubit
+
+/-- The four Pauli matrices as 2×2 complex matrices, indexed by `Fin 4`:
+`σ₀ = [[1,0],[0,1]]`, `σ₁ = [[0,1],[1,0]]`, `σ₂ = [[0,-I],[I,0]]`,
+`σ₃ = [[1,0],[0,-1]]`. -/
+def pauliMatrices : Fin 4 → Matrix (Fin 2) (Fin 2) ℂ
+  | 0 => !![1, 0; 0, 1]
+  | 1 => !![0, 1; 1, 0]
+  | 2 => !![0, -Complex.I; Complex.I, 0]
+  | 3 => !![1, 0; 0, -1]
+
+/-- The entry `(i,j)` of the **Pauli-basis transfer matrix** of a linear map
+`T : M₂(ℂ) → M₂(ℂ)`:
+  `T̂_{ij} = (1/2) tr[σ_i T(σ_j)]`.
+
+This is the `4×4` matrix representing `T` in the Pauli basis
+`{σ₀/√2, σ₁/√2, σ₂/√2, σ₃/√2}`, so that `T̂` has real entries for
+Hermiticity-preserving `T`. -/
+noncomputable def pauliTransferEntry
+    (T : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ)
+    (i j : Fin 4) : ℂ :=
+  ((1 : ℂ) / 2) * Matrix.trace (pauliMatrices i * T (pauliMatrices j))
+
+/-- A Hermiticity-preserving TP qubit channel `T'` is in **diagonal Lorentz normal
+form** (Wolf Prop 2.9, case 1) if its Pauli-basis transfer matrix is diagonal:
+`T'(1) = 1` (unital) and all off-diagonal entries of `T̂` vanish
+(i.e., `v = 0` and `Δ = diag(λ₁, λ₂, λ₃)`).
+
+Furthermore, the singular values satisfy the complete-positivity condition
+`λ₁ + λ₂ ≤ 1 + λ₃` (not checked here; future refinement). -/
+def IsLorentzDiagonal
+    (T' : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
+  IsChannel T' ∧ T' 1 = (1 : Matrix (Fin 2) (Fin 2) ℂ) ∧
+    ∀ (i j : Fin 4), i ≠ j → pauliTransferEntry T' i j = 0
+
+/-- A Hermiticity-preserving TP qubit channel `T'` is in **non-diagonal Lorentz
+normal form** (Wolf Prop 2.9, case 2) if its Pauli-basis transfer matrix has
+`Δ = diag(x/√3, x/√3, 1/3)` and `v = (0, 0, 2/3)` for some `x ∈ [0, 1]`.
+
+In Pauli-entry terms:
+- `T̂_{00} = 1` (TP)
+- `T̂_{0j} = 0` for `j > 0` (TP)
+- `T̂_{10} = T̂_{20} = 0`, `T̂_{30} = 2/3`
+- `T̂_{11} = T̂_{22} = x/√3`, `T̂_{33} = 1/3`
+- All other off-diagonals are zero. -/
+def IsLorentzNonDiagonal
+    (T' : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
+  IsChannel T' ∧
+    pauliTransferEntry T' 3 0 = (2/3 : ℂ) ∧
+    pauliTransferEntry T' 1 0 = 0 ∧ pauliTransferEntry T' 2 0 = 0 ∧
+    pauliTransferEntry T' 3 3 = (1/3 : ℂ) ∧
+    pauliTransferEntry T' 1 1 = pauliTransferEntry T' 2 2 ∧
+    (∀ (i j : Fin 4), i ≠ j → pauliTransferEntry T' i j = 0 ∨
+      (i = 3 ∧ j = 0) ∨ (i = 1 ∧ j = 1) ∨ (i = 2 ∧ j = 2) ∨ (i = 3 ∧ j = 3))
+
+/-- A Hermiticity-preserving TP qubit channel `T'` is in **singular Lorentz normal
+form** (Wolf Prop 2.9, case 3) if its Pauli-basis transfer matrix has
+`Δ = 0` and `v = (0, 0, 1)`.  That is, only `T̂_{00} = 1` and
+`T̂_{30} = 1` are nonzero; the channel maps every input to the pure state
+`(1 + σ_z)/2`. -/
+def IsLorentzSingular
+    (T' : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
+  IsChannel T' ∧
+    pauliTransferEntry T' 3 0 = 1 ∧
+    ∀ (i j : Fin 4), (i, j) ≠ (0, 0) ∧ (i, j) ≠ (3, 0) → pauliTransferEntry T' i j = 0
 
 /-- **Lorentz normal form for qubit channels (Wolf Prop 2.9 / Prop 2.11).**
 
 For every qubit channel `T : M₂(ℂ) → M₂(ℂ)`, there exist SL(2, ℂ)-filterings
-Φ₁, Φ₂ such that `T' = Φ₂ ∘ T ∘ Φ₁` is a qubit channel of one of three types:
-- `type_diagonal`: T' is unital with diagonal Δ (the generic case);
-- `type_nondiagonal`: T' has a specific one-parameter form;
-- `type_singular`: T' maps everything to a single pure state.
+Φ₁, Φ₂ such that the filtered channel `T' = Φ₂ ∘ T ∘ Φ₁` is in one of the
+three Lorentz normal forms: diagonal, non-diagonal, or singular.
 
 The proof is not yet formalised; it depends on:
 - The compactness lemma `infimum_is_attained` (above);
-- The Lorentz group classification of SL(2, ℂ) orbits;
-- The complete-positivity condition λ₁ + λ₂ ≤ 1 + λ₃.
+- The Lorentz group classification of SL(2, ℂ) orbits (spinor map
+  SL(2, ℂ) → SO⁺(1, 3));
+- The complete-positivity condition `λ₁ + λ₂ ≤ 1 + λ₃`.
 
 See Wolf §2.3 for the complete proof. -/
 theorem exists_lorentz_normal_form_qubit
     (T : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ)
     (_hCh : IsChannel T) :
     ∃ (Φ₁ Φ₂ : SLFiltering 2),
-      IsChannel (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) := by
-  -- Not yet formalised.  This is a target theorem; the proof depends on
-  -- `infimum_is_attained` and the Lorentz group classification, neither of
-  -- which is available in Mathlib or TNLean as of 2026-05.
+      IsLorentzDiagonal (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) ∨
+      IsLorentzNonDiagonal (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) ∨
+      IsLorentzSingular (Φ₂.map ∘ₗ T ∘ₗ Φ₁.map) := by
   sorry
 
 end LorentzNormalFormQubit

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -31,137 +31,137 @@ representations of quantum channels.
 ### §2.1 Choi–Jamiolkowski and Kraus
 
 * **Prop 2.1** (CJ isomorphism):
-  - `ChoiJamiolkowski.choiMatrix` — Choi matrix `τ = (T ⊗ id)(|Ω⟩⟨Ω|)` ✅
-  - `ChoiJamiolkowski.cp_iff_choi_posSemidef` — CP ↔ `τ ≥ 0` ✅
-  - `ChoiJamiolkowski.traceLeft_choiMatrix_of_tp` — TP ⟹ `tr_A(τ) = 𝟙/D` ✅
+  - `ChoiJamiolkowski.choiMatrix` — Choi matrix `τ = (T ⊗ id)(|Ω⟩⟨Ω|)` ✅️
+  - `ChoiJamiolkowski.cp_iff_choi_posSemidef` — CP ↔ `τ ≥ 0` ✅️
+  - `ChoiJamiolkowski.traceLeft_choiMatrix_of_tp` — TP ⟹ `tr_A(τ) = 𝟙/D` ✅️
   - `ChoiJamiolkowski.choiMatrix_isHermitian_iff_hermiticityPreserving` —
-    Hermiticity-preserving ↔ `τ` is Hermitian ✅
-  - `ChoiJamiolkowski.trace_choiMatrix_of_tp` — `tr(τ) = 1` for TP ✅
-  - `ChoiJamiolkowski.choiMatrix_id` — `τ` of identity = `|Ω⟩⟨Ω|` ✅
-  - `Channel.choiRank` — rank of the Choi matrix ✅
+    Hermiticity-preserving ↔ `τ` is Hermitian ✅️
+  - `ChoiJamiolkowski.trace_choiMatrix_of_tp` — `tr(τ) = 1` for TP ✅️
+  - `ChoiJamiolkowski.choiMatrix_id` — `τ` of identity = `|Ω⟩⟨Ω|` ✅️
+  - `Channel.choiRank` — rank of the Choi matrix ✅️
   - `Channel.choiRank_le_of_hasKrausCard` / `Channel.choiRank_le_of_hasKrausRankLE`
-    — Choi-rank upper bounds from exact / bounded Kraus families ✅
+    — Choi-rank upper bounds from exact / bounded Kraus families ✅️
   - `Channel.hasKrausCard_choiRank_of_cp` /
     `Channel.hasKrausRankLE_choiRank_of_cp` /
     `Channel.hasKrausRankLE_choiRank_of_cptp`
-    — minimal Kraus constructions from the Choi spectral decomposition ✅
+    — minimal Kraus constructions from the Choi spectral decomposition ✅️
 
 * **Thm 2.1** (Kraus representation):
-  - `kraus_tp_of_sum_conjTranspose_mul` — `∑Kᵢ†Kᵢ = 𝟙` ⟹ TP ✅
-  - `kraus_sum_conjTranspose_mul_of_tp` — TP ⟹ `∑Kᵢ†Kᵢ = 𝟙` ✅
-  - `kraus_sum_mul_conjTranspose_of_unital` — unital ⟹ `∑KᵢKᵢ† = 𝟙` ✅
-  - `kraus_same_map_of_unitary_combination` — unitary freedom (sufficient direction) ✅
+  - `kraus_tp_of_sum_conjTranspose_mul` — `∑Kᵢ†Kᵢ = 𝟙` ⟹ TP ✅️
+  - `kraus_sum_conjTranspose_mul_of_tp` — TP ⟹ `∑Kᵢ†Kᵢ = 𝟙` ✅️
+  - `kraus_sum_mul_conjTranspose_of_unital` — unital ⟹ `∑KᵢKᵢ† = 𝟙` ✅️
+  - `kraus_same_map_of_unitary_combination` — unitary freedom (sufficient direction) ✅️
   - `kraus_same_map_of_unitaryGroup_combination` / `kraus_same_map_of_exists_unitary_combination`
-    — bundled/existential unitary-witness formulations for reuse in the converse roadmap ✅
+    — bundled/existential unitary-witness formulations for reuse in the converse roadmap ✅️
   - `kraus_transition_unitary_of_hs_orthonormal`
-    — converse linear-algebra core: orthonormal Kraus frames force unitary transition ✅
-  - `kraus_dual_eq_of_map_eq` — dual map equality from primal map equality ✅
-  - `kraus_conjTranspose_mul_eq_of_map_eq` — equal Stinespring Gramians ✅
+    — converse linear-algebra core: orthonormal Kraus frames force unitary transition ✅️
+  - `kraus_dual_eq_of_map_eq` — dual map equality from primal map equality ✅️
+  - `kraus_conjTranspose_mul_eq_of_map_eq` — equal Stinespring Gramians ✅️
   - `kraus_rectangular_freedom` / `kraus_rectangular_freedom'`
-    — rectangular Kraus freedom (necessary direction) ✅
+    — rectangular Kraus freedom (necessary direction) ✅️
   - `kraus_isometry_freedom_iff`
-    — Wolf Thm 2.18 in isometric form, including zero-padding of the smaller family ✅
+    — Wolf Thm 2.18 in isometric form, including zero-padding of the smaller family ✅️
   - `kraus_unitary_freedom_iff`
-    — Wolf Thm 2.18 in same-size unitary form ✅
+    — Wolf Thm 2.18 in same-size unitary form ✅️
 
 * **Thm 2.2** (Stinespring dilation):
-  - `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` ✅
-  - `stinespringV_isometry_iff_kraus_normalized` — `V†V = 𝟙` ↔ TP ✅
-  - `stinespring_schrodinger_representation` — `T(ρ) = tr_r(VρV†)` ✅
+  - `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` ✅️
+  - `stinespringV_isometry_iff_kraus_normalized` — `V†V = 𝟙` ↔ TP ✅️
+  - `stinespring_schrodinger_representation` — `T(ρ) = tr_r(VρV†)` ✅️
 
 * **Thm 2.3** (ordered CP-maps):
-  - `CPDominates` — CP partial order: `S - T` is completely positive ✅
+  - `CPDominates` — CP partial order: `S - T` is completely positive ✅️
   - `Matrix.blockTopRows` / `Matrix.blockTopRows_mul_conjTranspose` /
     `Matrix.blockTopRows_conjTranspose_mul_le_one` — explicit block-top
-    contraction on the dilation space ✅
+    contraction on the dilation space ✅️
   - `stinespringV_eq_kronecker_blockTopRows_mul_append` — intertwining
-    `V_{K} = (𝟙_D ⊗ C) · V_{K ++ L}` for the block-top projector ✅
+    `V_{K} = (𝟙_D ⊗ C) · V_{K ++ L}` for the block-top projector ✅️
   - `CPDominates.exists_stinespring_contraction` — existential form of
-    Wolf Thm 2.3: `T₁ ≤ T₂` gives Stinespring realizations and a contraction ✅
+    Wolf Thm 2.3: `T₁ ≤ T₂` gives Stinespring realizations and a contraction ✅️
 
 * **Thm 2.4** (Radon–Nikodym for CP maps):
   - `Matrix.blockDiagTopProj` / `Matrix.blockDiagBotProj` — orthogonal
-    block projectors on the dilation space, PSD and summing to `𝟙` ✅
+    block projectors on the dilation space, PSD and summing to `𝟙` ✅️
   - `Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap` — Kronecker
-    identity `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙) (𝟙 ⊗ C)` ✅
+    identity `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙) (𝟙 ⊗ C)` ✅️
   - `IsCPMap.exists_radon_nikodym` — Wolf Thm 2.4 binary form:
     for CP `T₁, T₂`, a Stinespring matrix for `T₁ + T₂` yields
-    PSD `P₁ + P₂ = 𝟙` with `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✅
+    PSD `P₁ + P₂ = 𝟙` with `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✅️
 
 * **Thm 2.5** (open-system representation, reduced form):
   - `IsChannel.exists_stinespring_open_system` — every CPTP map is
-    `T(ρ)_{ij} = ∑ₖ (V ρ V†)_{(i,k),(j,k)}` for an isometric `V` ✅
+    `T(ρ)_{ij} = ∑ₖ (V ρ V†)_{(i,k),(j,k)}` for an isometric `V` ✅️
   - `IsChannel.exists_stinespring_open_system_traceRight` — equivalent
-    form via `Matrix.traceRight`: `T(ρ) = tr_E[V ρ V†]` ✅
+    form via `Matrix.traceRight`: `T(ρ) = tr_E[V ρ V†]` ✅️
 
 * **Thm 2.6** (Naimark / Neumark dilation for POVMs):
-  - `POVM` — positive operator-valued measure structure ✅
-  - `POVM.naimarkIsometry_isometry` — `V†V = 𝟙` ✅
+  - `POVM` — positive operator-valued measure structure ✅️
+  - `POVM.naimarkIsometry_isometry` — `V†V = 𝟙` ✅️
   - `POVM.naimarkProjection_mul_self` / `_hermitian` / `_orthogonal` /
-    `_sum_eq_one` — projective-measurement axioms on the dilation ✅
-  - `POVM.naimark_recovers_povm` — `V† P_i V = E_i` ✅
-  - `POVM.exists_naimark_dilation` — existential Naimark dilation ✅
+    `_sum_eq_one` — projective-measurement axioms on the dilation ✅️
+  - `POVM.naimark_recovers_povm` — `V† P_i V = E_i` ✅️
+  - `POVM.exists_naimark_dilation` — existential Naimark dilation ✅️
   - `POVM.IsNaimarkDilation` / `POVM.isNaimarkDilation_naimark`
-    — formulated Naimark-dilation predicate and canonical witness ✅
+    — formulated Naimark-dilation predicate and canonical witness ✅️
   - `POVM.exists_isometry_mul_naimarkIsometry_of_recovery`
     — concrete uniqueness: any dilation using the canonical projectors factors
-      through the canonical Naimark isometry via a dilation isometry ✅
+      through the canonical Naimark isometry via a dilation isometry ✅️
   - `POVM.ofPSDResolutionOfIdentity` — converse construction: PSD resolution
-    of identity on a dilation pulls back to a POVM ✅
+    of identity on a dilation pulls back to a POVM ✅️
   - `Instrument` — quantum-instrument structure + `total_isChannel`,
-    `sum_probability`, `posteriorState` interface ✅
+    `sum_probability`, `posteriorState` interface ✅️
 
 ### §2.1 Representation corollaries (Props 2.2–2.4)
 
 * **Prop 2.2** (CP decomposition):
   - `WolfProps.polarization_sandwich` — `4 • (A X Bᴴ) = (A+B) X (A+B)ᴴ
-    − (A−B) X (A−B)ᴴ + I•(A+I·B) X (A+I·B)ᴴ − I•(A−I·B) X (A−I·B)ᴴ` ✅
+    − (A−B) X (A−B)ᴴ + I•(A+I·B) X (A+I·B)ᴴ − I•(A−I·B) X (A−I·B)ᴴ` ✅️
   - `WolfProps.cp_decomposition_of_sandwich_sum` — every
-    `∑ᵢ Aᵢ X Bᵢᴴ` is a signed ℂ-linear combination of four CP maps ✅
+    `∑ᵢ Aᵢ X Bᵢᴴ` is a signed ℂ-linear combination of four CP maps ✅️
 
 * **Prop 2.3** (no information without disturbance):
   - `WolfProps.vecMulVec_star_eq_polarization` — rank-one outer products
-    polarize into rank-one self-outer-products ✅
+    polarize into rank-one self-outer-products ✅️
   - `WolfProps.linearMap_eq_id_of_fixes_rankOne` — a linear map fixing
-    every `vecMulVec v (star v)` is the identity ✅
+    every `vecMulVec v (star v)` is the identity ✅️
   - `WolfProps.channel_eq_id_of_fixes_pureStates` — a channel fixing
-    every pure-state projector is the identity channel ✅
+    every pure-state projector is the identity channel ✅️
 
 * **Prop 2.4** (equivalence of ensembles, Hughston–Jozsa–Wootters):
   - `WolfProps.pureEnsembleDensity` — density operator of a pure-state
-    ensemble `∑ᵢ |ψᵢ⟩⟨ψᵢ|` ✅
+    ensemble `∑ᵢ |ψᵢ⟩⟨ψᵢ|` ✅️
   - `WolfProps.pureEnsembleDensity_eq_of_isometric_mixing` — sufficient
     direction: ensembles related by an isometric mixing matrix share
-    the same density ✅
+    the same density ✅️
   - `WolfProps.exists_isometric_mixing_of_pureEnsembleDensity_eq` —
     necessary direction (HJW converse): equal densities force an
-    isometric mixing matrix between the two ensembles ✅
+    isometric mixing matrix between the two ensembles ✅️
   - `WolfProps.pureEnsembleDensity_eq_iff_exists_isometric_mixing` —
-    both directions stated as an iff ✅
+    both directions stated as an iff ✅️
 
 ### §2.2 Transfer matrix
 
 * `transferMatrix` — the `D² × D²` matrix representing `T` in the
-  standard-basis vectorization ✅
-* `transferMatrix_mulVec_eq` — `T̂ *ᵥ vec(ρ) = vec(T(ρ))` ✅
-* `transferMatrix_comp` — `(S ∘ T)^ = Ŝ * T̂` ✅
-* `transferMatrix_id` — transfer matrix of identity = identity ✅
-* `transferMatrix_injective` — the representation is faithful ✅
-* `transferMatrix_kraus` — Kraus form: `T̂ = ∑ᵢ K̄ᵢ ⊗ₖ Kᵢ` ✅
+  standard-basis vectorization ✅️
+* `transferMatrix_mulVec_eq` — `T̂ *ᵥ vec(ρ) = vec(T(ρ))` ✅️
+* `transferMatrix_comp` — `(S ∘ T)^ = Ŝ * T̂` ✅️
+* `transferMatrix_id` — transfer matrix of identity = identity ✅️
+* `transferMatrix_injective` — the representation is faithful ✅️
+* `transferMatrix_kraus` — Kraus form: `T̂ = ∑ᵢ K̄ᵢ ⊗ₖ Kᵢ` ✅️
 * `MPSTensor.transferMatrix_eq` — MPS bridge:
-  `E_A` has transfer matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ` ✅
+  `E_A` has transfer matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ` ✅️
 
 ### §2.2–2.3 Transfer matrix characterizations & normal forms (Props 2.5-2.8)
 
-* `transferMatrix_tp_iff` — **Prop 2.6**: TP ↔ column-diagonal sums = δ ✅
-* `transferMatrix_unital_iff` — **Prop 2.6**: unital ↔ row-diagonal sums = δ ✅
+* `transferMatrix_tp_iff` — **Prop 2.6**: TP ↔ column-diagonal sums = δ ✅️
+* `transferMatrix_unital_iff` — **Prop 2.6**: unital ↔ row-diagonal sums = δ ✅️
 * `transferMatrix_hermiticityPreserving_iff` — **Prop 2.5**: HP ↔ conjugation
-  symmetry of transfer matrix entries ✅
-* `unitaryConjLM` — unitary conjugation map `Ad_U(X) = U X U†` ✅
-* `transferMatrix_unitaryConj` — **Prop 2.7 ingredient**: `(Ad_U)^ = Ū ⊗ₖ U` ✅
-* `unitaryConjLM_isChannel_of_unitary` — `Ad_U` is a channel for unitary `U` ✅
+  symmetry of transfer matrix entries ✅️
+* `unitaryConjLM` — unitary conjugation map `Ad_U(X) = U X U†` ✅️
+* `transferMatrix_unitaryConj` — **Prop 2.7 ingredient**: `(Ad_U)^ = Ū ⊗ₖ U` ✅️
+* `unitaryConjLM_isChannel_of_unitary` — `Ad_U` is a channel for unitary `U` ✅️
 * `transferMatrix_unitaryConj_sandwich` — **Props 2.7-2.8 key identity**:
-  `(Ad_{U₁} ∘ T ∘ Ad_{U₂})^ = (Ū₁⊗U₁) T̂ (Ū₂⊗U₂)` ✅
+  `(Ad_{U₁} ∘ T ∘ Ad_{U₂})^ = (Ū₁⊗U₁) T̂ (Ū₂⊗U₂)` ✅️
 
 ### §2.3 SVD normal form (existence)
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -166,26 +166,26 @@ representations of quantum channels.
 ### §2.3 SVD normal form (existence)
 
 * `Matrix.svd_of_posSemidef` — **SVD for PSD matrices** (spectral theorem
-  formulated): `M = U * diagonal σ * Uᴴ` with `σ ≥ 0` ✅
+  formulated): `M = U * diagonal σ * Uᴴ` with `σ ≥ 0` ✅️
 * `Matrix.svd_of_isUnit` — **SVD existence for invertible complex matrices**:
-  `M = U * diagonal σ * Vᴴ` with `U, V` unitary and `σ > 0` ✅
+  `M = U * diagonal σ * Vᴴ` with `U, V` unitary and `σ > 0` ✅️
 * `transferMatrix_svd_of_isUnit` — **SVD representation of a transfer
-  matrix** (Wolf §2.3): every invertible transfer matrix admits an SVD ✅
+  matrix** (Wolf §2.3): every invertible transfer matrix admits an SVD ✅️
 
 ### §2.3 Lorentz normal form (existence)
 
 * `Wolf.SLFiltering` — **SL(d, ℂ)-filtering operation**: a CP map
-  Φ(X) = S X S† with det(S) = 1 ✅ (definitional)
+  Φ(X) = S X S† with det(S) = 1 ✅️ (definitional)
 * `Wolf.DoublyStochastic` — doubly-stochastic condition: T(1) ∝ 1 and
-  T*(1) ∝ 1 ✅ (definitional)
+  T*(1) ∝ 1 ✅️ (definitional)
 * `Wolf.infimum_is_attained` — **key compactness lemma**: the trace minimisation
-  over SL(d, ℂ) filterings attains its infimum ⚠️ (stated with `sorry`;
+  over SL(d, ℂ) filterings attains its infimum ⚠ (stated with `sorry`;
   requires compactness of bounded SL(n, ℂ) sets)
 * `Wolf.exists_normal_form_generic` — **Wolf Prop 2.8 (generic normal form)**:
   every CP map with full Kraus rank admits SL-filterings making it
-  doubly-stochastic ⚠️ (depends on `infimum_is_attained`)
+  doubly-stochastic ⚠ (depends on `infimum_is_attained`)
 * `Wolf.exists_lorentz_normal_form_qubit` — **Wolf Prop 2.9/2.11 (Lorentz
-  normal form for qubit channels)** ⚠️ (depends on `infimum_is_attained`
+  normal form for qubit channels)** ⚠ (depends on `infimum_is_attained`
   and Lorentz group classification)
 
 ### Formalization

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -17,6 +17,7 @@ import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.WolfProps
 import TNLean.Channel.NormalForm
+import TNLean.Channel.LorentzNormalForm
 
 /-!
 # Wolf Lecture Notes — Chapter 2: Representations
@@ -171,6 +172,22 @@ representations of quantum channels.
 * `transferMatrix_svd_of_isUnit` — **SVD representation of a transfer
   matrix** (Wolf §2.3): every invertible transfer matrix admits an SVD ✅
 
+### §2.3 Lorentz normal form (existence)
+
+* `Wolf.SLFiltering` — **SL(d, ℂ)-filtering operation**: a CP map
+  Φ(X) = S X S† with det(S) = 1 ✅ (definitional)
+* `Wolf.DoublyStochastic` — doubly-stochastic condition: T(1) ∝ 1 and
+  T*(1) ∝ 1 ✅ (definitional)
+* `Wolf.infimum_is_attained` — **key compactness lemma**: the trace minimisation
+  over SL(d, ℂ) filterings attains its infimum ⚠️ (stated with `sorry`;
+  requires compactness of bounded SL(n, ℂ) sets)
+* `Wolf.exists_normal_form_generic` — **Wolf Prop 2.8 (generic normal form)**:
+  every CP map with full Kraus rank admits SL-filterings making it
+  doubly-stochastic ⚠️ (depends on `infimum_is_attained`)
+* `Wolf.exists_lorentz_normal_form_qubit` — **Wolf Prop 2.9/2.11 (Lorentz
+  normal form for qubit channels)** ⚠️ (depends on `infimum_is_attained`
+  and Lorentz group classification)
+
 ### Formalization
 
 | Definition | File | Lean name |
@@ -190,13 +207,17 @@ representations of quantum channels.
 | Transfer matrix | `TransferMatrix.lean` | `transferMatrix` |
 | Unitary conjugation | `TransferMatrix.lean` | `unitaryConjLM` |
 | Vectorization | `Mathlib.LinearAlgebra.Matrix.Vec` | `Matrix.vec` |
+| SL-filtering | `LorentzNormalForm.lean` | `Wolf.SLFiltering` |
+| Doubly-stochastic | `LorentzNormalForm.lean` | `Wolf.DoublyStochastic` |
+| Lorentz normal form | `LorentzNormalForm.lean` | `Wolf.exists_lorentz_normal_form_qubit` |
 
 ### Not yet formalized
 
 | Result | Notes |
 |--------|-------|
 | Thm 2.5 (unitary form) | Reduced isometric form formalized; unitary form needs basis extension |
-| §2.3 Lorentz normal form (existence) | Needs compactness over `SL(2, ℂ)` filterings |
+| §2.3 Lorentz normal form (full proof) | Statement formalised (`exists_lorentz_normal_form_qubit`); proof blocked on compactness of bounded SL(n, ℂ) sets (`infimum_is_attained`) — see `LorentzNormalForm.lean` for details |
+| §2.3 Generic normal form (full proof) | Statement formalised (`exists_normal_form_generic`); proof blocked on same compactness lemma |
 | §2.3 Sorted singular values | Current SVD is unsorted; later uses want sorted values |
 
 ## References

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -176,17 +176,25 @@ representations of quantum channels.
 
 * `Wolf.SLFiltering` — **SL(d, ℂ)-filtering operation**: a CP map
   Φ(X) = S X S† with det(S) = 1 ✅️ (definitional)
+* `Wolf.SLFiltering.comp` — composition of SL-filterings ✅️
+* `Wolf.SLFiltering.S_isUnit` — `S` invertible follows from det=1 ✅️
 * `Wolf.DoublyStochastic` — doubly-stochastic condition: T(1) ∝ 1 and
-  T*(1) ∝ 1 ✅️ (definitional)
-* `Wolf.infimum_is_attained` — **key compactness lemma**: the trace minimisation
+  tr₁[τ] ∝ 1 ✅️ (definitional)
+* `pauliMatrices` — the four Pauli matrices (qubit basis) ✅️ (definitional)
+* `pauliTransferEntry` — Pauli-basis transfer matrix entry ✅️ (definitional)
+* `IsLorentzDiagonal` — diagonal Lorentz normal form (Wolf Prop 2.9 case 1) ✅️
+* `IsLorentzNonDiagonal` — non-diagonal Lorentz normal form (case 2) ✅️
+* `IsLorentzSingular` — singular Lorentz normal form (case 3) ✅️
+* `Wolf.infimum_is_attained` — **key compactness lemma**: trace minimisation
   over SL(d, ℂ) filterings attains its infimum ⚠ (stated with `sorry`;
   requires compactness of bounded SL(n, ℂ) sets)
-* `Wolf.exists_normal_form_generic` — **Wolf Prop 2.8 (generic normal form)**:
+* `Wolf.exists_normal_form_generic` — **Wolf Prop 2.9 (generic normal form)**:
   every CP map with full Kraus rank admits SL-filterings making it
   doubly-stochastic ⚠ (depends on `infimum_is_attained`)
 * `Wolf.exists_lorentz_normal_form_qubit` — **Wolf Prop 2.9/2.11 (Lorentz
-  normal form for qubit channels)** ⚠ (depends on `infimum_is_attained`
-  and Lorentz group classification)
+  normal form for qubit channels)**: conclusion is a three-way disjunction
+  `IsLorentzDiagonal ∨ IsLorentzNonDiagonal ∨ IsLorentzSingular` ⚠
+  (depends on `infimum_is_attained` and Lorentz group classification)
 
 ### Formalization
 
@@ -208,7 +216,13 @@ representations of quantum channels.
 | Unitary conjugation | `TransferMatrix.lean` | `unitaryConjLM` |
 | Vectorization | `Mathlib.LinearAlgebra.Matrix.Vec` | `Matrix.vec` |
 | SL-filtering | `LorentzNormalForm.lean` | `Wolf.SLFiltering` |
+| SL-filtering composition | `LorentzNormalForm.lean` | `Wolf.SLFiltering.comp` |
 | Doubly-stochastic | `LorentzNormalForm.lean` | `Wolf.DoublyStochastic` |
+| Pauli matrices | `LorentzNormalForm.lean` | `pauliMatrices` |
+| Pauli transfer entry | `LorentzNormalForm.lean` | `pauliTransferEntry` |
+| Diagonal Lorentz form | `LorentzNormalForm.lean` | `IsLorentzDiagonal` |
+| Non-diagonal Lorentz form | `LorentzNormalForm.lean` | `IsLorentzNonDiagonal` |
+| Singular Lorentz form | `LorentzNormalForm.lean` | `IsLorentzSingular` |
 | Lorentz normal form | `LorentzNormalForm.lean` | `Wolf.exists_lorentz_normal_form_qubit` |
 
 ### Not yet formalized

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -216,8 +216,11 @@ representations of quantum channels.
 | Result | Notes |
 |--------|-------|
 | Thm 2.5 (unitary form) | Reduced isometric form formalized; unitary form needs basis extension |
-| §2.3 Lorentz normal form (full proof) | Statement formalised (`exists_lorentz_normal_form_qubit`); proof blocked on compactness of bounded SL(n, ℂ) sets (`infimum_is_attained`) — see `LorentzNormalForm.lean` for details |
-| §2.3 Generic normal form (full proof) | Statement formalised (`exists_normal_form_generic`); proof blocked on same compactness lemma |
+| §2.3 Lorentz normal form (full proof) | Statement formalised (`exists_lorentz_normal_form_qubit`);
+  proof blocked on compactness of bounded SL(n, ℂ) sets (`infimum_is_attained`) —
+  see `LorentzNormalForm.lean` for details |
+| §2.3 Generic normal form (full proof) | Statement formalised (`exists_normal_form_generic`);
+  proof blocked on same compactness lemma |
 | §2.3 Sorted singular values | Current SVD is unsorted; later uses want sorted values |
 
 ## References

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -2077,11 +2077,12 @@ a common dilation space.
 Wolf \S2.3 discusses two families of normal forms for the transfer-matrix
 representation of a quantum channel: the \emph{singular value decomposition}
 (SVD) and, for qubit channels, the \emph{Lorentz normal form} obtained by
-$\mathrm{SL}(2,\mathbb{C})$ filtering operations. In this blueprint, the full
-existence statement formalized below is the SVD normal form; the Lorentz
-normal form existence requires a compactness / minimisation argument over
-$\mathrm{SL}(2,\mathbb{C})$ filterings (Wolf Prop 2.9 / Prop 2.11) that
-remains open in this formalisation.
+$\mathrm{SL}(2,\mathbb{C})$ filtering operations. In this blueprint, the SVD
+normal form is fully formalised.  The Lorentz normal form existence is stated
+as a theorem (Theorem~\ref{thm:lorentz_normal_form_qubit}) but the proof
+requires a compactness / minimisation argument over $\mathrm{SL}(2,\mathbb{C})$
+filterings (Wolf Prop 2.9 / Prop 2.11) that remains open in this
+formalisation---see \S\ref{subsec:lorentz_normal_form}.
 
 \begin{theorem}[SVD for positive semi-definite matrices]
     \label{thm:svd_posSemidef}
@@ -2148,6 +2149,63 @@ remains open in this formalisation.
     polar decomposition, Lorentz normal form) will typically require the
     sorted / unique variant; that refinement is future work.
 \end{remark}
+
+%% =========================================================
+\subsection{Lorentz normal form (Wolf \S2.3, existence statements)}
+\label{subsec:lorentz_normal_form}
+%% =========================================================
+
+\begin{definition}[SL-filtering operation]\label{def:sl_filtering}
+    \lean{Wolf.SLFiltering}\leanok
+    An \emph{SL-filtering} for $D \times D$ matrices is a completely
+    positive map of the form $\Phi(X) = S X S^{\dagger}$ where
+    $S \in M_{D}(\mathbb{C})$ satisfies $\det S = 1$.  Such maps are
+    invertible and have Kraus rank~1.
+\end{definition}
+
+\begin{definition}[Doubly-stochastic map]\label{def:doubly_stochastic}
+    \lean{Wolf.DoublyStochastic}\leanok
+    A linear map $T : \MN{D} \to \MN{D}$ is \emph{doubly-stochastic}
+    if $T(1) \propto 1$ and the reduced density matrix
+    $\tr_{1}[\tau]$ of its Choi matrix $\tau = (T \otimes \id)(\ketbra{\Omega}{\Omega})$
+    is proportional to the identity.  This is the target normal form
+    in Wolf Prop~2.8.
+\end{definition}
+
+\begin{lemma}[Infimum attainment for SL-filterings]\label{lem:infimum_is_attained}
+    \lean{Wolf.infimum_is_attained}
+    For a positive-definite Choi matrix $\tau$, the infimum of
+    $\tr\!\big[(S_{2} \otimes_{k} S_{1}) \tau (S_{2} \otimes_{k} S_{1})^{\dagger}\big]$
+    over $S_{1}, S_{2} \in M_{D}(\mathbb{C})$ with $\det S_{1} = \det S_{2} = 1$
+    is attained.  \textbf{Not yet proved}---requires compactness of bounded
+    subsets of $\SL(D, \mathbb{C})$ and the extreme-value theorem.
+\end{lemma}
+
+\begin{theorem}[Generic normal form for CP maps]\label{thm:exists_normal_form_generic}
+    \lean{Wolf.exists_normal_form_generic}
+    \uses{def:sl_filtering, def:doubly_stochastic, lem:infimum_is_attained}
+    Let $T : \MN{D} \to \MN{D}$ be a completely positive map whose Choi matrix
+    is positive-definite (equivalently, $T$ has full Kraus rank).  Then there
+    exist SL-filterings $\Phi_{1}, \Phi_{2}$ such that
+    $\Phi_{2} \circ T \circ \Phi_{1}$ is doubly-stochastic.
+    \textbf{Not yet proved}---proof blocked on Lemma~\ref{lem:infimum_is_attained}.
+\end{theorem}
+
+\begin{theorem}[Lorentz normal form for qubit channels]\label{thm:lorentz_normal_form_qubit}
+    \lean{Wolf.exists_lorentz_normal_form_qubit}
+    \uses{def:sl_filtering, lem:infimum_is_attained}
+    For every qubit channel $T : M_{2}(\mathbb{C}) \to M_{2}(\mathbb{C})$,
+    there exist $\SL(2, \mathbb{C})$-filterings $\Phi_{1}, \Phi_{2}$ such that
+    the filtered channel $T' = \Phi_{2} \circ T \circ \Phi_{1}$ is in one of
+    the three Lorentz normal forms: diagonal, non-diagonal, or singular.
+    The three canonical forms are defined as the Lean predicates
+    \texttt{Wolf.IsLorentzDiagonal}, \texttt{Wolf.IsLorentzNonDiagonal},
+    \texttt{Wolf.IsLorentzSingular} in
+    \texttt{LorentzNormalForm.lean}.
+    \textbf{Not yet proved}---proof blocked on
+    Lemma~\ref{lem:infimum_is_attained} and the Lorentz group classification
+    of $\SL(2, \mathbb{C})$ orbits.
+\end{theorem}
 
 %% The following sections will not be needed for the fundamental theorem of the matrix product states.
 


### PR DESCRIPTION
## Summary

Formalizes Wolf §2.3 Lorentz normal form and SVD representation existence results for quantum channels, addressing TNLean issue LionSR/QICLean#12.

### What's done

- **`Wolf.SLFiltering`**: Definition of SL(n, ℂ)-filtering operations Φ(X) = S X S† with det S = 1, including identity, canonical construction from a matrix, and composition.
- **`Wolf.DoublyStochastic`**: The doubly-stochastic property (target normal form in Wolf Prop 2.8): T(1) ∝ 1 and tr₁[τ] ∝ 1.
- **`Wolf.infimum_is_attained`**: Statement of the key compactness lemma — the trace minimisation over SL(n, ℂ) filterings attains its infimum. Formalised as a lemma with `sorry`; blocked on compactness of bounded SL(n, ℂ) sets and the extreme value theorem.
- **`Wolf.exists_normal_form_generic`**: Wolf Prop 2.8 — every CP map with full Kraus rank admits SL-filterings making it doubly-stochastic. Stated with `sorry` (depends on `infimum_is_attained`).
- **`Wolf.exists_lorentz_normal_form_qubit`**: Wolf Prop 2.9/2.11 — Lorentz normal form existence for qubit channels. Stated with `sorry` (depends on compactness + Lorentz group classification).
- Updated `WolfChapter2Index.lean` to reflect the new formalization status.

### Missing Mathlib infrastructure (documented in file)

1. Compactness of bounded SL(n, ℂ) sets: the set `{S : Matrix n n ℂ | det S = 1 ∧ ‖S‖ ≤ C}` is compact. Needs: determinant-as-polynomial closedness + finite-dimensional Heine–Borel.
2. Extreme value theorem for the continuous trace functional on this compact set.
3. (For the Lorentz normal form) Lorentz group classification of SL(2, ℂ) orbits and the CP inequality λ₁ + λ₂ ≤ 1 + λ₃.

### Note on SVD

The SVD part of the normal-form story (`Matrix.svd_of_isUnit`, `transferMatrix_svd_of_isUnit`) was already formalised in `NormalForm.lean` on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new core definitions and theorems around SL-filterings and Lorentz/generic normal forms, but key existence results are left as `sorry`, so any downstream use may inherit proof gaps or require additional assumptions.
> 
> **Overview**
> Introduces a new `LorentzNormalForm.lean` module formalizing Wolf §2.3 *filtering-based normal forms* for quantum channels: defines `Wolf.SLFiltering` (det=1 conjugation CP maps), the `Wolf.DoublyStochastic` target condition, and Pauli-basis utilities/predicates for the three qubit Lorentz canonical forms.
> 
> Adds existence statements for the generic doubly-stochastic normal form and the qubit Lorentz normal form (`Wolf.exists_normal_form_generic`, `Wolf.exists_lorentz_normal_form_qubit`), along with the key trace-minimization lemma `Wolf.infimum_is_attained`; these are currently stated with `sorry` where compactness/minimization and Lorentz-orbit classification infrastructure is missing.
> 
> Updates the Chapter 2 index and blueprint text to reference the new Lorentz normal form section and to flag the remaining unproved dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba5e4f5160769d5d113956947dd2d7325224418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->