### PR TITLE
feat(MPS/Core): relate iterated blocking to direct blocking via reindexPhysical (#990)

### DIFF
--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -495,6 +495,73 @@ theorem sameMPV₂_blockTensor_blockTensor_mul_reindex {D : ℕ}
   intro N σ
   rfl
 
+
+/-- Reindexing the physical alphabet of the iterated block tensor by the consecutive-grouping
+map returns the direct block tensor at length `m*n`.
+
+This lemma avoids the `Fin.cast` / `Fintype.equivFin` identification and instead uses the
+explicit bijection `directToIteratedBlockIndex` (PR #1096).  It gives a clean connection
+between iterated and direct blocking without needing `groupedBlockCastAgrees`. -/
+theorem reindexPhysical_directToIteratedBlockIndex_blockTensor (A : MPSTensor d D) (m n : ℕ) :
+    reindexPhysical (directToIteratedBlockIndex d m n)
+      (blockTensor (d := blockPhysDim d m) (D := D)
+        (blockTensor (d := d) (D := D) A m) n) =
+    blockTensor (d := d) (D := D) A (m * n) := by
+  calc
+    reindexPhysical (directToIteratedBlockIndex d m n)
+        (blockTensor (d := blockPhysDim d m) (D := D)
+          (blockTensor (d := d) (D := D) A m) n) =
+      reindexPhysical (directToIteratedBlockIndex d m n)
+        (reindexPhysical (iteratedBlockIndex d m n)
+          (blockTensor (d := d) (D := D) A (m * n))) := by
+      rw [blockTensor_blockTensor_eq_reindex A m n]
+    _ = blockTensor (d := d) (D := D) A (m * n) := by
+      ext i
+      simp [reindexPhysical, iteratedBlockIndex_directToIteratedBlockIndex d m n]
+
+/-- Iterated blocking expressed with the block-grouping bijection equals direct blocking.
+This is the tensor-level version of the blocked-word identity that underlies
+`groupedBlockCastAgrees`. -/
+theorem sameMPV₂_reindexPhysical_directToIteratedBlockIndex_blockTensor
+    (A : MPSTensor d D) (m n : ℕ) :
+    SameMPV₂
+      (reindexPhysical (directToIteratedBlockIndex d m n)
+        (blockTensor (d := blockPhysDim d m) (D := D)
+          (blockTensor (d := d) (D := D) A m) n))
+      (blockTensor (d := d) (D := D) A (m * n)) := by
+  rw [reindexPhysical_directToIteratedBlockIndex_blockTensor A m n]
+  intro N σ; rfl
+
+
+/-!
+### Blocked-word identification gap
+
+The lemma `reindexPhysical_directToIteratedBlockIndex_blockTensor` shows that applying the
+explicit block-grouping bijection to the iterated block tensor recovers the direct block
+tensor.  The remaining point for closing issue #990 is to prove that this bijection coincides
+with the `Fin.cast` identification used in `CommonBlockedCyclicSectorFamily`.  Concretely,
+one needs
+
+```lean
+Fin.cast ((F.blockPhysDim_nested_eq k).symm) i =
+  directToIteratedBlockIndex d (F.period k) (F.extra k)
+    (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i)
+```
+
+for each block `k` and each physical index `i : Fin (blockPhysDim d F.p)`.
+
+The obstruction is purely combinatorial: the current blocked-index encoding uses
+`Fintype.equivFin`, which gives a noncanonical enumeration.  Proving the equality requires
+showing that the `Fintype.equivFin` enumeration of `Fin (m*n) → Fin d` agrees with the
+nested enumeration `Fin n → (Fin m → Fin d)` under the natural grouping isomorphism.
+This is likely a lemma about `Multiset.pi` or `Finset.univ` for function types, and
+the entry points suggested by earlier reviews (`Fin.prod_univ_succ`, `Fin.consEquiv`,
+`Fintype.piFinset` in `Mathlib/Data/Fin/Tuple/Finset.lean`) remain the natural path.
+Once proved in `TNLean/MPS/Core/BlockingInfrastructure.lean`, it unconditionally discharges
+`groupedBlockCastAgrees` and closes this issue together with all dependent conditional
+theorems in `CyclicSectorDecomposition.lean` and `StructuralTheorem.lean`.
+-/
+
 /-- Casting the physical dimension of both tensors preserves heterogeneous MPV equality. -/
 theorem sameMPV₂_cast_physDim {d₁ d₂ D₁ D₂ : ℕ} (h : d₁ = d₂)
     (A : MPSTensor d₁ D₁) (B : MPSTensor d₁ D₂) :

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -495,14 +495,13 @@ theorem sameMPV₂_blockTensor_blockTensor_mul_reindex {D : ℕ}
   intro N σ
   rfl
 
-
 /-- Reindexing the physical alphabet of the iterated block tensor by the consecutive-grouping
 map returns the direct block tensor at length `m*n`.
 
 This lemma avoids the `Fin.cast` / `Fintype.equivFin` identification and instead uses the
 explicit bijection `directToIteratedBlockIndex` (PR #1096).  It gives a clean connection
 between iterated and direct blocking without needing `groupedBlockCastAgrees`. -/
-theorem reindexPhysical_directToIteratedBlockIndex_blockTensor (A : MPSTensor d D) (m n : ℕ) :
+theorem reindexPhysical_directToIteratedBlockIndex_blockTensor {D : ℕ} (A : MPSTensor d D) (m n : ℕ) :
     reindexPhysical (directToIteratedBlockIndex d m n)
       (blockTensor (d := blockPhysDim d m) (D := D)
         (blockTensor (d := d) (D := D) A m) n) =
@@ -523,7 +522,7 @@ theorem reindexPhysical_directToIteratedBlockIndex_blockTensor (A : MPSTensor d 
 This is the tensor-level version of the blocked-word identity that underlies
 `groupedBlockCastAgrees`. -/
 theorem sameMPV₂_reindexPhysical_directToIteratedBlockIndex_blockTensor
-    (A : MPSTensor d D) (m n : ℕ) :
+    {D : ℕ} (A : MPSTensor d D) (m n : ℕ) :
     SameMPV₂
       (reindexPhysical (directToIteratedBlockIndex d m n)
         (blockTensor (d := blockPhysDim d m) (D := D)
@@ -531,7 +530,6 @@ theorem sameMPV₂_reindexPhysical_directToIteratedBlockIndex_blockTensor
       (blockTensor (d := d) (D := D) A (m * n)) := by
   rw [reindexPhysical_directToIteratedBlockIndex_blockTensor A m n]
   intro N σ; rfl
-
 
 /-!
 ### Blocked-word identification gap

--- a/audits/2026-04-30_issue990_blocked_word_comparison.md
+++ b/audits/2026-04-30_issue990_blocked_word_comparison.md
@@ -106,3 +106,23 @@ This is exactly the bookkeeping step between the common-length cyclic-sector dat
 used after the period-removal construction and the common-sector block family used
 by the later sector comparison theorems. It is independent of the Gemma/arXiv:1708
 periodic fundamental theorem route and of parent-Hamiltonian arguments.
+
+## 2026-05-01: reindexPhysical lemma (wave 27)
+
+Added `reindexPhysical_directToIteratedBlockIndex_blockTensor` in
+`TNLean/MPS/Core/BlockingInfrastructure.lean`.  This lemma bypasses the
+`Fin.cast` / `Fintype.equivFin` identification entirely and proves that the
+explicit block-grouping bijection `directToIteratedBlockIndex`, applied to
+the iterated block tensor via `reindexPhysical`, recovers the direct block
+tensor at length $m \cdot n$.
+
+The proof uses `blockTensor_blockTensor_eq_reindex` (already proved) and
+`iteratedBlockIndex_directToIteratedBlockIndex` to cancel the forward and
+inverse maps of the `directIteratedBlockEquiv`.
+
+The remaining obstruction for #990 is now documented explicitly in the
+source as a module doc comment (`### Blocked-word identification gap`):
+one must prove that the `Fin.cast` identification used in
+`CommonBlockedCyclicSectorFamily` coincides with `directToIteratedBlockIndex`.
+This is a pure statement about `Fintype.equivFin` for function types,
+independent of the MPS theory.


### PR DESCRIPTION
## Summary

Adds `reindexPhysical_directToIteratedBlockIndex_blockTensor` to `TNLean/MPS/Core/BlockingInfrastructure.lean`: applying the explicit block-grouping bijection `directToIteratedBlockIndex` (PR #1096) to the iterated block tensor via `reindexPhysical` recovers the direct block tensor at length `m*n`.  The proof uses the existing `blockTensor_blockTensor_eq_reindex` and `iteratedBlockIndex_directToIteratedBlockIndex`.

Also adds `sameMPV₂_reindexPhysical_directToIteratedBlockIndex_blockTensor` as a convenience `SameMPV₂` wrapper.

## Remaining gap

The remaining obstruction for issue #990 is documented in the source as a module doc comment: the `Fin.cast` identification used in `CommonBlockedCyclicSectorFamily` must be proved to coincide with `directToIteratedBlockIndex`.  This is a pure combinatorial statement about `Fintype.equivFin` for function types — specifically, that the `Fintype.equivFin` enumeration of `Fin (m*n) → Fin d` agrees with the nested enumeration `Fin n → (Fin m → Fin d)` under the natural grouping isomorphism.

Suggested entry points: `Fin.consEquiv`, `Fintype.piFinset` lemmas in `Mathlib/Data/Fin/Tuple/Finset.lean`.  Once proved, it unconditionally discharges `groupedBlockCastAgrees` and resolves issue #990 together with all dependent conditional theorems in `CyclicSectorDecomposition.lean` and `StructuralTheorem.lean`.

## References

- PR #1096: `directToIteratedBlockIndex` / `directIteratedBlockEquiv`
- PR #1079: `groupedBlockCastAgrees` predicate and conditional comparison theorems
- PR #1065: finite-sum comparison reduction
- Issue #990 (kept open)

## Validation

- `lake build TNLean.MPS.Core.BlockingInfrastructure` — OK (2964 jobs)
- `lake build TNLean.MPS.CanonicalForm.Assembly` — OK (8429 jobs)
- Lean diagnostics clean for `BlockingInfrastructure.lean`
- `git diff --check` clean
- Audit updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean lemmas/proofs connecting iterated and direct blocking via `reindexPhysical`; changes are additive and proof-only with minimal risk beyond potential downstream lemma dependency shifts.
> 
> **Overview**
> Proves a new tensor identity `reindexPhysical_directToIteratedBlockIndex_blockTensor`: reindexing an *iterated* block tensor by the explicit grouping bijection `directToIteratedBlockIndex` yields the *direct* block tensor at length `m*n`, avoiding the prior `Fin.cast`/`Fintype.equivFin` identification.
> 
> Adds a `SameMPV₂` wrapper lemma for the same result and documents (in-code and in the issue #990 audit) the remaining gap: showing this explicit bijection coincides with the `Fin.cast` identification used elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172fa24c670cb367dafa93417c3c6bf4c82cf126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->