### PR TITLE
feat(Tactic): add TN proof tactic simpsets and thin wrappers (#1077)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -150,6 +150,7 @@ import TNLean.Spectral.QuantitativeGap
 
 -- Layer 3: MPS core
 import TNLean.MPS.Defs
+import TNLean.MPS.Tactic.Basic
 import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.TensorEquality

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -9,6 +9,7 @@ import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.MPS.Overlap.PeripheralToSpectralGap
 import TNLean.MPS.CanonicalForm.FromPeripheralPrimitive
 import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
+import TNLean.MPS.Tactic.Basic
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 open Filter
@@ -402,6 +403,7 @@ Every Kraus operator is the zero matrix. At `N = 0`, its mpv equals the bond dim
 of the identity); at `N > 0`, its mpv is `0`. -/
 def zeroMPSTensor (d D : ℕ) : MPSTensor d D := fun _ => 0
 
+@[mps_zero_tail]
 theorem mpv_zeroMPSTensor {N : ℕ} (σ : Fin N → Fin d') (D' : ℕ) :
     mpv (zeroMPSTensor d' D') σ = if N = 0 then (D' : ℂ) else 0 := by
   split

--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
 import TNLean.MPS.Defs
+import TNLean.MPS.Tactic.Basic
 
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Fintype.Card
@@ -45,7 +46,7 @@ noncomputable def decodeBlock (d L : ℕ) : Fin (blockPhysDim d L) → (Fin L �
 noncomputable def wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) : List (Fin d) :=
   List.ofFn (decodeBlock d L i)
 
-@[simp] lemma length_wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) :
+@[simp, mps_block_words] lemma length_wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) :
     (wordOfBlock d L i).length = L := by
   classical
   simp [wordOfBlock]
@@ -59,14 +60,16 @@ noncomputable def blockTensor (A : MPSTensor d D) (L : ℕ) :
 noncomputable def flattenBlockedWord (d L : ℕ) : List (Fin (blockPhysDim d L)) → List (Fin d)
   | w => (w.map (wordOfBlock d L)).flatten
 
-@[simp] lemma flattenBlockedWord_nil (d L : ℕ) : flattenBlockedWord d L [] = [] := by
+@[simp, mps_block_words] lemma flattenBlockedWord_nil (d L : ℕ) : flattenBlockedWord d L [] = [] := by
   simp [flattenBlockedWord]
 
+@[mps_block_words]
 lemma flattenBlockedWord_cons (d L : ℕ) (i : Fin (blockPhysDim d L))
     (w : List (Fin (blockPhysDim d L))) :
     flattenBlockedWord d L (i :: w) = wordOfBlock d L i ++ flattenBlockedWord d L w := by
   simp [flattenBlockedWord]
 
+@[mps_block_words]
 lemma evalWord_blockTensor (A : MPSTensor d D) (L : ℕ) :
     ∀ w : List (Fin (blockPhysDim d L)),
       evalWord (blockTensor (d := d) (D := D) A L) w =
@@ -81,6 +84,7 @@ lemma evalWord_blockTensor (A : MPSTensor d D) (L : ℕ) :
       simp [evalWord, blockTensor, flattenBlockedWord_cons, ih, evalWord_append]
 
 /-- Length of a flattened blocked word. -/
+@[mps_block_words]
 lemma length_flattenBlockedWord (d L : ℕ) :
     ∀ w : List (Fin (blockPhysDim d L)), (flattenBlockedWord d L w).length = w.length * L := by
   intro w

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.Core.BlockingTransfer
 import TNLean.MPS.FundamentalTheorem.Multi
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
+import TNLean.MPS.Tactic.Basic
 
 import Mathlib.Algebra.GCDMonoid.Finset
 
@@ -120,7 +121,7 @@ theorem sameMPV₂_blockTensor_of_sameMPV₂_toTensorFromBlocks
       (blockTensor (d := d) (D := D) A p)
       (toTensorFromBlocks (d := blockPhysDim d p)
         (fun k => (μ k) ^ p) (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) := by
-  intro N σ
+  mpv_ext
   let σflat := blockedFlatConfig (d := d) p σ
   calc
     mpv (blockTensor (d := d) (D := D) A p) σ
@@ -148,7 +149,7 @@ theorem sameMPV₂_blockTensor
     SameMPV₂
       (blockTensor (d := d) (D := D₁) A p)
       (blockTensor (d := d) (D := D₂) B p) := by
-  intro N σ
+  mpv_ext
   let σflat := blockedFlatConfig (d := d) p σ
   calc
     mpv (blockTensor (d := d) (D := D₁) A p) σ
@@ -172,7 +173,7 @@ theorem sameMPV₂_blockTensor_toTensorFromBlocks
   exact sameMPV₂_blockTensor_of_sameMPV₂_toTensorFromBlocks
     (d := d) (D := ∑ k : Fin r, dim k) (dim := dim)
     (A := toTensorFromBlocks (d := d) (μ := μ) blocks)
-    μ blocks (by intro N σ; rfl) p
+    μ blocks (by mpv_ext; rfl) p
 
 /-- Positive-length MPV equality is preserved by positive physical blocking. -/
 theorem sameMPV₂Pos_blockTensor
@@ -182,7 +183,7 @@ theorem sameMPV₂Pos_blockTensor
     SameMPV₂Pos
       (blockTensor (d := d) (D := D₁) A p)
       (blockTensor (d := d) (D := D₂) B p) := by
-  intro N hN σ
+  mpv_ext
   let σflat := blockedFlatConfig (d := d) p σ
   calc
     mpv (blockTensor (d := d) (D := D₁) A p) σ
@@ -221,7 +222,7 @@ theorem sameMPV₂Pos_toTensorFromBlocks_blockPower
       (d := d)
       (toTensorFromBlocks (d := d) (μ := μA) blocksA)
       (toTensorFromBlocks (d := d) (μ := μB) blocksB) hSame p hp
-  intro N hN σ
+  mpv_ext
   calc
     mpv (toTensorFromBlocks (d := blockPhysDim d p)
         (fun k => (μA k) ^ p)
@@ -280,6 +281,7 @@ dimensions leaves the tensors and their MPV/transfer-map properties unchanged.
 
 /-- The physical dimension of an iterated blocking is the physical dimension of
 direct blocking by the product length. -/
+@[mps_block_words]
 theorem blockPhysDim_blockPhysDim (d m n : ℕ) :
     blockPhysDim (blockPhysDim d m) n = blockPhysDim d (m * n) := by
   simp [blockPhysDim_eq_pow, pow_mul]
@@ -393,6 +395,7 @@ theorem wordOfBlock_iteratedBlockIndex_directToIteratedBlockIndex (d m n : ℕ)
 
 /-- Grouping a direct blocked index and then flattening the iterated index recovers the
 original direct blocked index. -/
+@[mps_block_words]
 theorem iteratedBlockIndex_directToIteratedBlockIndex (d m n : ℕ)
     (i : Fin (blockPhysDim d (m * n))) :
     iteratedBlockIndex d m n (directToIteratedBlockIndex d m n i) = i := by
@@ -412,6 +415,7 @@ theorem directToIteratedBlockIndex_surjective (d m n : ℕ) :
 
 /-- Flattening an iterated blocked index and then grouping it back recovers the iterated
 blocked index. -/
+@[mps_block_words]
 theorem directToIteratedBlockIndex_iteratedBlockIndex (d m n : ℕ)
     (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
     directToIteratedBlockIndex d m n (iteratedBlockIndex d m n i) = i := by
@@ -428,16 +432,17 @@ noncomputable def directIteratedBlockEquiv (d m n : ℕ) :
   left_inv := iteratedBlockIndex_directToIteratedBlockIndex d m n
   right_inv := directToIteratedBlockIndex_iteratedBlockIndex d m n
 
-@[simp] theorem directIteratedBlockEquiv_apply (d m n : ℕ)
+@[simp, mps_block_words] theorem directIteratedBlockEquiv_apply (d m n : ℕ)
     (i : Fin (blockPhysDim d (m * n))) :
     directIteratedBlockEquiv d m n i = directToIteratedBlockIndex d m n i := rfl
 
-@[simp] theorem directIteratedBlockEquiv_symm_apply (d m n : ℕ)
+@[simp, mps_block_words] theorem directIteratedBlockEquiv_symm_apply (d m n : ℕ)
     (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
     (directIteratedBlockEquiv d m n).symm i = iteratedBlockIndex d m n i := rfl
 
 /-- An iterated blocked index `j` is the grouping of a direct blocked index `i`
 exactly when flattening `j` recovers `i`. -/
+@[mps_block_words]
 theorem eq_directToIteratedBlockIndex_iff_iteratedBlockIndex_eq (d m n : ℕ)
     (i : Fin (blockPhysDim d (m * n)))
     (j : Fin (blockPhysDim (blockPhysDim d m) n)) :
@@ -466,6 +471,7 @@ noncomputable def reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂
 
 /-- Iterated physical blocking agrees with direct blocking after the canonical
 index relabeling from iterated blocks to flattened blocks. -/
+@[mps_block_words]
 theorem blockTensor_blockTensor_apply {D : ℕ} (A : MPSTensor d D) (m n : ℕ)
     (i : Fin (blockPhysDim (blockPhysDim d m) n)) :
     blockTensor (d := blockPhysDim d m) (D := D)
@@ -492,7 +498,7 @@ theorem sameMPV₂_blockTensor_blockTensor_mul_reindex {D : ℕ}
       (reindexPhysical (iteratedBlockIndex d m n)
         (blockTensor (d := d) (D := D) A (m * n))) := by
   rw [blockTensor_blockTensor_eq_reindex]
-  intro N σ
+  mpv_ext
   rfl
 
 /-- Casting the physical dimension of both tensors preserves heterogeneous MPV equality. -/

--- a/TNLean/MPS/Core/Transfer.lean
+++ b/TNLean/MPS/Core/Transfer.lean
@@ -1,4 +1,5 @@
 import TNLean.MPS.Defs
+import TNLean.MPS.Tactic.Basic
 
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.PosDef
@@ -25,7 +26,7 @@ noncomputable def transferMap (A : MPSTensor d D) :
   ∑ i : Fin d,
     (LinearMap.mulLeft ℂ (A i)).comp (LinearMap.mulRight ℂ (A i)ᴴ)
 
-@[simp]
+@[simp, mps_transfer]
 lemma transferMap_apply (A : MPSTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
     transferMap (d := d) (D := D) A X = ∑ i : Fin d, A i * X * (A i)ᴴ := by
   classical

--- a/TNLean/MPS/Periodic/CornerTransition.lean
+++ b/TNLean/MPS/Periodic/CornerTransition.lean
@@ -79,7 +79,7 @@ The projections `P k` are typically the cyclic-sector projections of
 `IsCyclicSectorDecomp`; the definition itself does not require `(P k)` to be
 a projection, and the algebraic identities below isolate the hypotheses
 actually used. -/
-def cornerTransition {m : ℕ} [NeZero m] (A : MPSTensor d D)
+noncomputable def cornerTransition {m : ℕ} [NeZero m] (A : MPSTensor d D)
     (P : Fin m → Matrix (Fin D) (Fin D) ℂ) (k : Fin m) :
     MPSTensor d D :=
   fun i => P k * A i * P (k + 1)
@@ -147,7 +147,7 @@ For a word of length `L`, this expands to
 
 $$P_u \cdot A^{w_0} \cdot P_{u+1} \cdot A^{w_1} \cdot P_{u+2} \cdot
   \ldots \cdot A^{w_{L-1}} \cdot P_{u+L}.$$ -/
-def cornerEvalWord {m : ℕ} [NeZero m] (A : MPSTensor d D)
+noncomputable def cornerEvalWord {m : ℕ} [NeZero m] (A : MPSTensor d D)
     (P : Fin m → Matrix (Fin D) (Fin D) ℂ) :
     Fin m → List (Fin d) → Matrix (Fin D) (Fin D) ℂ
   | u, [] => P u

--- a/TNLean/MPS/Tactic/Basic.lean
+++ b/TNLean/MPS/Tactic/Basic.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Tactic
+
+/-!
+# Tactics for tensor-network proofs
+
+This file provides small custom `simp` attribute sets and thin tactic wrappers
+for recurring proof patterns in MPS / channel / overlap files.
+
+## Custom simp attributes
+
+* `mps_block_words` : direct/iterated blocking maps, `wordOfBlock` expressions
+* `mps_transfer` : transfer map unfoldings, basic trace/scalar identities
+* `mps_zero_tail` : zero-tail MPV terms
+
+## Tactic wrappers
+
+* `mpv_ext` : introduce `N`, `σ` for `SameMPV₂` or `N`, `hN`, `σ` for `SameMPV₂Pos`
+* `block_words` : normalize direct/iterated blocking maps and `wordOfBlock` expressions
+* `transfer_simp` : unfold transfer maps and simplify trace/scalar side conditions
+* `zero_tail_simp` : simplify zero-tail MPV terms after the length case is chosen
+
+## Design
+
+The tactics are intentionally simple. They do not search; when the normal form does
+not apply, they leave clear unsolved goals. The `simp` attribute sets are the primary
+mechanism; the tactic wrappers are thin sugar over the attributes.
+-/
+
+/-! ### Custom simp attribute sets -/
+
+/-- Simp set for direct/iterated blocking maps and `wordOfBlock` normal forms. -/
+register_simp_attr mps_block_words
+
+/-- Simp set for transfer map unfoldings and trace/scalar identities. -/
+register_simp_attr mps_transfer
+
+/-- Simp set for zero-tail MPV term simplification. -/
+register_simp_attr mps_zero_tail
+
+/-! ### Tactic wrappers -/
+
+/--
+Introduce MPV length and word variables for `SameMPV₂` or `SameMPV₂Pos` goals.
+
+For `SameMPV₂ A B` (i.e. `∀ N σ, mpv A σ = mpv B σ`), `mpv_ext` reduces the goal to
+`mpv A σ = mpv B σ` by introducing `N` and `σ` as fresh variables.
+
+For `SameMPV₂Pos A B` (i.e. `∀ N, 0 < N → ∀ σ, mpv A σ = mpv B σ`), `mpv_ext` also
+introduces a name for the positivity hypothesis.
+
+If the goal does not match either pattern, `mpv_ext` does nothing.
+-/
+macro "mpv_ext" : tactic => `(tactic|
+  first
+    | intro N hN σ
+    | intro N σ
+    | skip
+)
+
+/--
+Normalize direct/iterated blocking maps and `wordOfBlock` expressions.
+
+Uses the lemmas tagged with `@[mps_block_words]`.  After `block_words`:
+* `directIteratedBlockEquiv d m n i` is rewritten to `directToIteratedBlockIndex d m n i`
+* iterated-blocking dimension identities are unfolded
+* word-of-block normal forms are applied
+* grouped index equalities are reduced to flattened-index equalities
+
+The tactic does not rewrite general matrix multiplication or common MPS tensor identities;
+it only normalises the block-word presentation.
+-/
+macro "block_words" : tactic => `(tactic| simp [mps_block_words])
+
+/--
+Unfold transfer maps and simplify trace/scalar side conditions.
+
+Uses the lemmas tagged with `@[mps_transfer]`.  After `transfer_simp`:
+* `transferMap A X` is unfolded to `∑ i, A i * X * (A i)ᴴ`
+* basic `Multiplicative.ofAdd` conversions (if any) are resolved
+
+The tactic avoids broad `simp` over matrix multiplication, since that tends to
+make goals harder to read.
+-/
+macro "transfer_simp" : tactic => `(tactic| simp [mps_transfer])
+
+/--
+Simplify zero-tail MPV terms.
+
+Uses the lemmas tagged with `@[mps_zero_tail]`.  After `zero_tail_simp`:
+* at positive length `N > 0`, `mpv (zeroMPSTensor d D) σ` simplifies to `0`
+* at length zero `N = 0`, `mpv (zeroMPSTensor d D) σ` simplifies to `(D : ℂ)`
+
+Call `zero_tail_simp` only after fixing the length case.
+-/
+macro "zero_tail_simp" : tactic => `(tactic| simp [mps_zero_tail])

--- a/TNLean/MPS/Tactic/Basic.lean
+++ b/TNLean/MPS/Tactic/Basic.lean
@@ -7,41 +7,43 @@ import Mathlib.Tactic
 /-!
 # Tactics for tensor-network proofs
 
-This file provides small custom `simp` attribute sets and thin tactic wrappers
+This file provides small custom `simp` attribute sets and thin tactic macros
 for recurring proof patterns in MPS / channel / overlap files.
 
 ## Custom simp attributes
 
 * `mps_block_words` : direct/iterated blocking maps, `wordOfBlock` expressions
-* `mps_transfer` : transfer map unfoldings, basic trace/scalar identities
-* `mps_zero_tail` : zero-tail MPV terms
+* `mps_transfer` : transfer map unfoldings
+* `mps_zero_tail` : zero-tail MPV term simplification
 
-## Tactic wrappers
+## Tactic macros
 
 * `mpv_ext` : introduce `N`, `σ` for `SameMPV₂` or `N`, `hN`, `σ` for `SameMPV₂Pos`
 * `block_words` : normalize direct/iterated blocking maps and `wordOfBlock` expressions
-* `transfer_simp` : unfold transfer maps and simplify trace/scalar side conditions
-* `zero_tail_simp` : simplify zero-tail MPV terms after the length case is chosen
+* `transfer_simp` : unfold transfer maps using `@[mps_transfer]`
+* `zero_tail_simp` : simplify zero-tail MPV terms using `@[mps_zero_tail]`
 
 ## Design
 
 The tactics are intentionally simple. They do not search; when the normal form does
 not apply, they leave clear unsolved goals. The `simp` attribute sets are the primary
-mechanism; the tactic wrappers are thin sugar over the attributes.
+mechanism; the tactic macros are thin sugar over the attributes.
 -/
+
+open Lean Elab Tactic Meta
 
 /-! ### Custom simp attribute sets -/
 
 /-- Simp set for direct/iterated blocking maps and `wordOfBlock` normal forms. -/
 register_simp_attr mps_block_words
 
-/-- Simp set for transfer map unfoldings and trace/scalar identities. -/
+/-- Simp set for transfer map unfoldings. -/
 register_simp_attr mps_transfer
 
 /-- Simp set for zero-tail MPV term simplification. -/
 register_simp_attr mps_zero_tail
 
-/-! ### Tactic wrappers -/
+/-! ### Tactic macros -/
 
 /--
 Introduce MPV length and word variables for `SameMPV₂` or `SameMPV₂Pos` goals.
@@ -50,16 +52,37 @@ For `SameMPV₂ A B` (i.e. `∀ N σ, mpv A σ = mpv B σ`), `mpv_ext` reduces t
 `mpv A σ = mpv B σ` by introducing `N` and `σ` as fresh variables.
 
 For `SameMPV₂Pos A B` (i.e. `∀ N, 0 < N → ∀ σ, mpv A σ = mpv B σ`), `mpv_ext` also
-introduces a name for the positivity hypothesis.
+introduces `hN : 0 < N`.
 
-If the goal does not match either pattern, `mpv_ext` does nothing.
+If the goal does not match either pattern, `mpv_ext` leaves the goal unchanged.
 -/
-macro "mpv_ext" : tactic => `(tactic|
-  first
-    | intro N hN σ
-    | intro N σ
-    | skip
-)
+elab "mpv_ext" : tactic => do
+  -- Introduce N : ℕ
+  let fvNId ← liftMetaTacticAux fun mvarId => do
+    let (fvarId, mvarId) ← mvarId.intro `N
+    pure (fvarId, [mvarId])
+  Term.addLocalVarInfo (mkNullNode) (mkFVar fvNId)
+  -- Check next binder type to distinguish SameMPV₂ from SameMPV₂Pos
+  -- SameMPV₂:  ∀ (σ : Fin N → Fin d), ...   (non-Prop domain)
+  -- SameMPV₂Pos: 0 < N → ∀ σ, ...           (Prop domain)
+  let g ← getMainGoal
+  let targetType ← withTransparency .all <| whnf (← g.getType)
+  if targetType.isForall && !(← isProp targetType.bindingDomain!) then
+    -- SameMPV₂ path: immediate ∀ σ
+    let fvSId ← liftMetaTacticAux fun mvarId => do
+      let (fvarId, mvarId) ← mvarId.intro `σ
+      pure (fvarId, [mvarId])
+    Term.addLocalVarInfo (mkNullNode) (mkFVar fvSId)
+  else
+    -- SameMPV₂Pos path: 0 < N → then ∀ σ
+    let fvHNId ← liftMetaTacticAux fun mvarId => do
+      let (fvarId, mvarId) ← mvarId.intro `hN
+      pure (fvarId, [mvarId])
+    Term.addLocalVarInfo (mkNullNode) (mkFVar fvHNId)
+    let fvSId ← liftMetaTacticAux fun mvarId => do
+      let (fvarId, mvarId) ← mvarId.intro `σ
+      pure (fvarId, [mvarId])
+    Term.addLocalVarInfo (mkNullNode) (mkFVar fvSId)
 
 /--
 Normalize direct/iterated blocking maps and `wordOfBlock` expressions.
@@ -73,27 +96,22 @@ Uses the lemmas tagged with `@[mps_block_words]`.  After `block_words`:
 The tactic does not rewrite general matrix multiplication or common MPS tensor identities;
 it only normalises the block-word presentation.
 -/
-macro "block_words" : tactic => `(tactic| simp [mps_block_words])
+macro "block_words" : tactic => `(tactic| simp only [mps_block_words])
 
 /--
-Unfold transfer maps and simplify trace/scalar side conditions.
+Unfold transfer maps using `@[mps_transfer]`.
 
-Uses the lemmas tagged with `@[mps_transfer]`.  After `transfer_simp`:
-* `transferMap A X` is unfolded to `∑ i, A i * X * (A i)ᴴ`
-* basic `Multiplicative.ofAdd` conversions (if any) are resolved
-
-The tactic avoids broad `simp` over matrix multiplication, since that tends to
-make goals harder to read.
+Currently the `mps_transfer` set contains `transferMap_apply`, so `transfer_simp`
+unfolds `transferMap A X` to `∑ i, A i * X * (A i)ᴴ`.
 -/
-macro "transfer_simp" : tactic => `(tactic| simp [mps_transfer])
+macro "transfer_simp" : tactic => `(tactic| simp only [mps_transfer])
 
 /--
-Simplify zero-tail MPV terms.
+Simplify zero-tail MPV terms using `@[mps_zero_tail]`.
 
-Uses the lemmas tagged with `@[mps_zero_tail]`.  After `zero_tail_simp`:
-* at positive length `N > 0`, `mpv (zeroMPSTensor d D) σ` simplifies to `0`
-* at length zero `N = 0`, `mpv (zeroMPSTensor d D) σ` simplifies to `(D : ℂ)`
-
-Call `zero_tail_simp` only after fixing the length case.
+Currently the `mps_zero_tail` set contains `mpv_zeroMPSTensor`, so `zero_tail_simp`
+rewrites `mpv (zeroMPSTensor d D) σ` to `if N = 0 then (D : ℂ) else 0`.
+The user is responsible for resolving the `if` by providing the length case (e.g.
+`hN : 0 < N` or `hN : N ≠ 0`).
 -/
-macro "zero_tail_simp" : tactic => `(tactic| simp [mps_zero_tail])
+macro "zero_tail_simp" : tactic => `(tactic| simp only [mps_zero_tail])

--- a/TNLean/Wielandt/RankOne/Construction.lean
+++ b/TNLean/Wielandt/RankOne/Construction.lean
@@ -206,7 +206,7 @@ theorem cumulativeSpan_transposeTensor_eq_top_of_cumulativeSpan_eq_top
 /-! ## Row spreading: right action on row vectors -/
 
 /-- The linear map `M ↦ ψ ᵥ* M` for a fixed row vector `ψ`. -/
-def vecMulLinearMap (ψ : Fin D → ℂ) :
+noncomputable def vecMulLinearMap (ψ : Fin D → ℂ) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] (Fin D → ℂ) :=
   { toFun := fun M => Matrix.vecMul ψ M
     map_add' := fun M N => by
@@ -221,7 +221,7 @@ This is the row-analogue of `vectorSpreadSpan A φ n`.
 
 We keep it as a separate definition because `vectorSpreadSpan` uses `mulVec`
 (left action), while here we need `vecMul` (right action). -/
-def rowSpreadSpan (A : MPSTensor d D) (ψ : Fin D → ℂ) (n : ℕ) :
+noncomputable def rowSpreadSpan (A : MPSTensor d D) (ψ : Fin D → ℂ) (n : ℕ) :
     Submodule ℂ (Fin D → ℂ) :=
   Submodule.span ℂ (Set.range fun σ : Fin n → Fin d =>
     Matrix.vecMul ψ (evalWord A (List.ofFn σ)))

--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -45,7 +45,7 @@ variable {d D : ℕ}
 
 ## Basic linear map lemmas -/
 /-- The linear map `M ↦ M *ᵥ φ` for a fixed vector `φ`. -/
-def mulVecLinearMap (φ : Fin D → ℂ) :
+noncomputable def mulVecLinearMap (φ : Fin D → ℂ) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] (Fin D → ℂ) :=
   { toFun := fun M => M *ᵥ φ
     map_add' := fun M N => Matrix.add_mulVec M N φ


### PR DESCRIPTION
Closes #1077.

## Summary

This PR introduces a small tactics module `TNLean/MPS/Tactic/Basic.lean` for recurring tensor-network proof patterns, following the staged plan from the [scout audit](https://github.com/LionSR/TNLean/blob/main/audits/2026-05-01_issue1077_tn_proof_tactics_scout.md).

### Layer 0: Custom simp attributes
- `mps_block_words` — direct/iterated blocking maps, `wordOfBlock` expressions
- `mps_transfer` — transfer map unfoldings
- `mps_zero_tail` — zero-tail MPV terms

### Layer 1: Thin tactic wrappers
- `mpv_ext` — introduces `N`, `σ` for `SameMPV₂` goals (or `N`, `hN`, `σ` for `SameMPV₂Pos`)
- `block_words` — normalizes direct/iterated blocking maps via `simp [mps_block_words]`
- `transfer_simp` — unfolds transfer maps via `simp [mps_transfer]`
- `zero_tail_simp` — simplifies zero-tail terms via `simp [mps_zero_tail]`

### Tagged lemmas
Key lemmas in existing modules are tagged with the new attributes:
- `BlockingInfrastructure.lean`: 6 lemmas tagged `@[mps_block_words]`
- `Blocking.lean`: 4 lemmas tagged `@[mps_block_words]`
- `Transfer.lean`: `transferMap_apply` tagged `@[mps_transfer]`
- `Existence.lean`: `mpv_zeroMPSTensor` tagged `@[mps_zero_tail]`

### Demonstration
Five proofs in `BlockingInfrastructure.lean` now use `mpv_ext` instead of `intro N σ` / `intro N hN σ` patterns, giving a cleaner statement of the proof structure.

The tactics are intentionally simple — they do not search, and leave clear unsolved goals when the normal form does not apply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to proof automation (new `simp` attributes and tiny tactic macros) plus a few `noncomputable`/attribute annotations; no mathematical statements or core definitions are materially altered.
> 
> **Overview**
> Adds a new `TNLean.MPS.Tactic.Basic` module that defines three custom `simp` attribute sets (`mps_block_words`, `mps_transfer`, `mps_zero_tail`) and thin tactic macros (`mpv_ext`, `block_words`, `transfer_simp`, `zero_tail_simp`) to standardize recurring proof patterns.
> 
> Updates several MPS files to import this module, tag key lemmas with the new simp attributes (blocking/flattening lemmas, `transferMap_apply`, and `mpv_zeroMPSTensor`), and refactors multiple `SameMPV₂`/`SameMPV₂Pos` proofs to use `mpv_ext` instead of manual `intro` binders. Also marks `cornerTransition`/`cornerEvalWord` as `noncomputable` and makes a couple of linear-map helpers `noncomputable` for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adce7b9b67d5d3c772253e4f14c3e9887bdee927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->