### PR TITLE
feat(Channel): add POVM resolvent inverse inequality lemmas (#863)

### DIFF
--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -249,12 +249,16 @@ all block weights and the defect scalar are nonzero. -/
 lemma povmDiagonal_inv (w : ι → ℝ) (t : ℝ) (hw : ∀ i, w i ≠ 0) (ht : t ≠ 0) :
     (povmDiagonal (D := D) w t)⁻¹ =
       povmDiagonal (D := D) (fun i => (w i)⁻¹) (t⁻¹) := by
+  refine Matrix.inv_eq_right_inv ?_
   unfold povmDiagonal
-  rw [Matrix.inv_diagonal]
-  -- Goal: diagonal (v⁻¹ʳ) = diagonal v' where v' has reciprocal entries
-  -- Both sides are diagonal matrices; compare entries via ext
-  ext a b
-  simp [Matrix.diagonal_apply, Pi.inv_apply, Ring.inverse_eq_inv]
+  rw [Matrix.diagonal_mul_diagonal, ← Matrix.diagonal_one]
+  congr 1
+  funext a
+  rcases a with ⟨i, _⟩ | _
+  · show ((w i : ℝ) : ℂ) * (((w i)⁻¹ : ℝ) : ℂ) = 1
+    rw [← Complex.ofReal_mul, mul_inv_cancel₀ (hw i), Complex.ofReal_one]
+  · show ((t : ℝ) : ℂ) * (((t)⁻¹ : ℝ) : ℂ) = 1
+    rw [← Complex.ofReal_mul, mul_inv_cancel₀ ht, Complex.ofReal_one]
 
 /-- Compressing the inverse of `povmDiagonal w t` by the POVM dilation. -/
 lemma povmIsometry_compress_diagonal_inv
@@ -307,23 +311,19 @@ lemma povm_resolvent_inv_le
   -- LHS simplification
   have hLHS : (Wᴴ * Y * W) = (∑ i, wgt i • (C i * (C i)ᴴ)) + t • (1 : MatD) := by
     rw [h_compress]
-    -- Goal: (∑ i, y i • B_i) + t • (S * Sᴴ) = (∑ i, wgt i • B_i) + t • 1
-    -- where y i = wgt i + t
-    have hy_sum : (∑ i : ι, y i • (C i * (C i)ᴴ)) = (∑ i : ι, wgt i • (C i * (C i)ᴴ)) + (∑ i : ι, t • (C i * (C i)ᴴ)) := by
-      simp [y, Finset.sum_add_distrib, add_smul]
-    rw [hy_sum]
-    -- Goal: ((∑ wgt_i•B_i) + (∑ t•B_i)) + t•(S*Sᴴ) = (∑ wgt_i•B_i) + t•1
-    rw [← add_assoc, add_comm (∑ i : ι, t • (C i * (C i)ᴴ)), add_assoc]
-    -- Goal: (∑ wgt_i•B_i) + ((∑ t•B_i) + t•(S*Sᴴ)) = (∑ wgt_i•B_i) + t•1
-    rw [add_left_cancel_iff]
-    -- Goal: (∑ t•B_i) + t•(S*Sᴴ) = t•1
-    rw [← Finset.smul_sum, ← smul_add, povm_sum_add_defect hdef, smul_eq_mul]
-    -- Goal: t • 1 = t • 1
-    rfl
-  -- RHS simplification: (y i)⁻¹ = (wgt i + t)⁻¹
-  have hRHS : Wᴴ * Y⁻¹ * W = (∑ i, (wgt i + t)⁻¹ • (C i * (C i)ᴴ)) + t⁻¹ • (S * Sᴴ) := by
-    rw [h_compress_inv]
-    simp [y]
+    have h1 : (∑ i : ι, y i • (C i * (C i)ᴴ)) =
+        (∑ i : ι, wgt i • (C i * (C i)ᴴ)) + (∑ i : ι, t • (C i * (C i)ᴴ)) := by
+      rw [← Finset.sum_add_distrib]
+      exact Finset.sum_congr rfl fun i _ => add_smul (wgt i) t (C i * (C i)ᴴ)
+    have h2 : (∑ i : ι, t • (C i * (C i)ᴴ)) = t • (∑ i : ι, C i * (C i)ᴴ) :=
+      (Finset.smul_sum).symm
+    have h3 : t • (∑ i : ι, C i * (C i)ᴴ) + t • (S * Sᴴ)
+        = t • ((∑ i : ι, C i * (C i)ᴴ) + S * Sᴴ) :=
+      (smul_add t _ _).symm
+    rw [h1, add_assoc, h2, h3, povm_sum_add_defect hdef]
+  -- RHS simplification: (y i)⁻¹ = (wgt i + t)⁻¹ (definitionally)
+  have hRHS : Wᴴ * Y⁻¹ * W = (∑ i, (wgt i + t)⁻¹ • (C i * (C i)ᴴ)) + t⁻¹ • (S * Sᴴ) :=
+    h_compress_inv
   rw [hLHS, hRHS] at h_inv_le
   exact h_inv_le
 

--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -17,7 +17,7 @@ Wolf Corollary 5.2, but the final Löwner-integral packaging is still absent.
 ## Main statements
 
 - `inverse_compression_le`: inverse of a compression is bounded by the
-  compression of the inverse.
+  compression of the inverse (Hansen--Pedersen for `x ↦ x⁻¹`).
 - `povmIsometry`: the isometric dilation attached to a finite PSD family and its
   defect block.
 - `povmIsometry_star_mul`: the dilation is an isometry.
@@ -26,13 +26,22 @@ Wolf Corollary 5.2, but the final Löwner-integral packaging is still absent.
 - `povm_sum_add_defect`: the POVM family plus defect block sums to the identity.
 - `povmDiagonal_posDef`: positivity of the scalar block-diagonal matrix used in
   the resolvent step.
+- `povmDiagonal_inv`: explicit inverse of the scalar block-diagonal matrix when
+  all block weights are nonzero.
+- `povmIsometry_compress_diagonal_inv`: compressing the inverse of the
+  block-diagonal matrix yields the weighted sum of reciprocals.
+- `povm_resolvent_inv_le`: the finite-POVM resolvent inequality, the key
+  algebraic step toward the concave real-power Jensen inequality.
 
 ## Status
 
 These lemmas formalize the compression / finite-POVM half of the direct proof
-route for the concave real-power Jensen inequality. The remaining unfinished
-step is the explicit diagonal-inverse rewrite together with the final algebraic
-rearrangement to the resolvent inequality.
+route for the concave real-power Jensen inequality. The diagonal-inverse formula
+(`povmDiagonal_inv`) and the finite-POVM resolvent inequality
+(`povm_resolvent_inv_le`) are now proved. The remaining unfinished step is the
+Löwner-integral packaging that carries the pointwise resolvent inequality
+through the integral representation of `rpow` to discharge
+`posMap_rpow_concave_jensen`.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -234,6 +243,89 @@ lemma povmDiagonal_posDef (w : ι → ℝ) {t : ℝ}
     | inr p =>
         simpa [d, Complex.lt_def] using ht
   simpa [povmDiagonal, d] using hdiag
+
+/-- The inverse of the scalar block-diagonal matrix `povmDiagonal w t`, assuming
+all block weights and the defect scalar are nonzero. -/
+lemma povmDiagonal_inv (w : ι → ℝ) (t : ℝ) (hw : ∀ i, w i ≠ 0) (ht : t ≠ 0) :
+    (povmDiagonal (D := D) w t)⁻¹ =
+      povmDiagonal (D := D) (fun i => (w i)⁻¹) (t⁻¹) := by
+  unfold povmDiagonal
+  rw [Matrix.inv_diagonal]
+  -- Goal: diagonal (v⁻¹ʳ) = diagonal v' where v' has reciprocal entries
+  -- Both sides are diagonal matrices; compare entries via ext
+  ext a b
+  simp [Matrix.diagonal_apply, Pi.inv_apply, Ring.inverse_eq_inv]
+
+/-- Compressing the inverse of `povmDiagonal w t` by the POVM dilation. -/
+lemma povmIsometry_compress_diagonal_inv
+    {C : ι → MatD} {S : MatD} (w : ι → ℝ) (t : ℝ)
+    (hw : ∀ i, w i ≠ 0) (ht : t ≠ 0) :
+    (povmIsometry C S)ᴴ * (povmDiagonal (D := D) w t)⁻¹ * povmIsometry C S =
+      (∑ i, (w i)⁻¹ • (C i * (C i)ᴴ)) + t⁻¹ • (S * Sᴴ) := by
+  rw [povmDiagonal_inv w t hw ht]
+  exact povmIsometry_compress_diagonal (fun i => (w i)⁻¹) t⁻¹
+
+/-- **Finite-POVM resolvent inequality.**
+
+Let `C_i` be a finite family of matrices defining POVM elements `B_i = C_i * (C_i)ᴴ`,
+let `S` be the defect satisfying `S * Sᴴ = 1 - ∑ B_i`, let `w_i ≥ 0` be spectral weights,
+and let `t > 0`. Then
+
+`(∑ w_i • B_i + t • 1)⁻¹ ≤ ∑ (w_i + t)⁻¹ • B_i + t⁻¹ • (S * Sᴴ)`.
+
+This is the key resolvent inequality that feeds into the Löwner-integral
+representation of `rpow` and is the foundational algebraic step for the
+direct finite-POVM proof of the concave real-power Jensen inequality
+(Wolf Corollary 5.2). -/
+lemma povm_resolvent_inv_le
+    {C : ι → MatD} {S : MatD} (wgt : ι → ℝ) (hwgt : ∀ i, 0 ≤ wgt i) (t : ℝ) (ht_pos : 0 < t)
+    (hdef : S * Sᴴ = 1 - ∑ i, C i * (C i)ᴴ) :
+    ((∑ i, wgt i • (C i * (C i)ᴴ)) + t • (1 : MatD))⁻¹ ≤
+      (∑ i, (wgt i + t)⁻¹ • (C i * (C i)ᴴ)) + t⁻¹ • (S * Sᴴ) := by
+  classical
+  -- Build the positive definite block-diagonal matrix with entries wgt_i + t and t
+  let y : ι → ℝ := fun i => wgt i + t
+  have hy_pos : ∀ i, 0 < y i := by
+    intro i
+    dsimp [y]
+    linarith [hwgt i, ht_pos]
+  have hy_ne : ∀ i, y i ≠ 0 := fun i => by linarith [hy_pos i]
+  have ht_ne : t ≠ 0 := by linarith
+  let Y : AuxMat := povmDiagonal (D := D) y t
+  have hY_posDef : Matrix.PosDef Y :=
+    povmDiagonal_posDef (w := y) ht_pos (fun i => hy_pos i)
+  let W : IsoMat := povmIsometry C S
+  have hW_isom : Wᴴ * W = (1 : MatD) :=
+    povmIsometry_star_mul hdef
+  have h_compress : Wᴴ * Y * W = (∑ i, y i • (C i * (C i)ᴴ)) + t • (S * Sᴴ) :=
+    povmIsometry_compress_diagonal y t
+  have h_compress_inv : Wᴴ * Y⁻¹ * W = (∑ i, (y i)⁻¹ • (C i * (C i)ᴴ)) + t⁻¹ • (S * Sᴴ) :=
+    povmIsometry_compress_diagonal_inv y t hy_ne ht_ne
+  -- The core inverse compression inequality
+  have h_inv_le : (Wᴴ * Y * W)⁻¹ ≤ Wᴴ * Y⁻¹ * W :=
+    Matrix.PosDef.inverse_compression_le hY_posDef hW_isom
+  -- LHS simplification
+  have hLHS : (Wᴴ * Y * W) = (∑ i, wgt i • (C i * (C i)ᴴ)) + t • (1 : MatD) := by
+    rw [h_compress]
+    -- Goal: (∑ i, y i • B_i) + t • (S * Sᴴ) = (∑ i, wgt i • B_i) + t • 1
+    -- where y i = wgt i + t
+    have hy_sum : (∑ i : ι, y i • (C i * (C i)ᴴ)) = (∑ i : ι, wgt i • (C i * (C i)ᴴ)) + (∑ i : ι, t • (C i * (C i)ᴴ)) := by
+      simp [y, Finset.sum_add_distrib, add_smul]
+    rw [hy_sum]
+    -- Goal: ((∑ wgt_i•B_i) + (∑ t•B_i)) + t•(S*Sᴴ) = (∑ wgt_i•B_i) + t•1
+    rw [← add_assoc, add_comm (∑ i : ι, t • (C i * (C i)ᴴ)), add_assoc]
+    -- Goal: (∑ wgt_i•B_i) + ((∑ t•B_i) + t•(S*Sᴴ)) = (∑ wgt_i•B_i) + t•1
+    rw [add_left_cancel_iff]
+    -- Goal: (∑ t•B_i) + t•(S*Sᴴ) = t•1
+    rw [← Finset.smul_sum, ← smul_add, povm_sum_add_defect hdef, smul_eq_mul]
+    -- Goal: t • 1 = t • 1
+    rfl
+  -- RHS simplification: (y i)⁻¹ = (wgt i + t)⁻¹
+  have hRHS : Wᴴ * Y⁻¹ * W = (∑ i, (wgt i + t)⁻¹ • (C i * (C i)ᴴ)) + t⁻¹ • (S * Sᴴ) := by
+    rw [h_compress_inv]
+    simp [y]
+  rw [hLHS, hRHS] at h_inv_le
+  exact h_inv_le
 
 end POVM
 


### PR DESCRIPTION
Rescued from uncommitted work in Wave 27.

## Summary

Adds the finite-POVM resolvent inequality lemmas needed for the concave real-power Jensen inequality (Wolf Corollary 5.2):

- **`povmDiagonal_inv`** — explicit inverse of the scalar block-diagonal matrix
- **`povmIsometry_compress_diagonal_inv`** — compression of the inverse  
- **`povm_resolvent_inv_le`** — the key resolvent inequality:
  ```lean
  ((∑ i, wgt i • (C i * (C i)ᴴ)) + t • 1)⁻¹ ≤ (∑ i, (wgt i + t)⁻¹ • (C i * (C i)ᴴ)) + t⁻¹ • (S * Sᴴ)
  ```

## Remaining for LionSR/QICLean#140

The Löwner-integral packaging that carries this pointwise resolvent inequality through the integral representation of `rpow` to discharge `posMap_rpow_concave_jensen`.

Refs: LionSR/QICLean#140

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean lemmas/proofs without changing runtime behavior, though the additional algebraic machinery could affect proof maintenance and compilation time.
> 
> **Overview**
> Adds missing finite-POVM algebra needed for the operator Jensen (concave `rpow`) route by proving an explicit inverse formula for the scalar block-diagonal matrix (`povmDiagonal_inv`) and a corresponding compression lemma for that inverse.
> 
> Builds on these to prove the key finite-POVM resolvent inequality (`povm_resolvent_inv_le`), and updates module documentation to reflect that the diagonal-inverse and resolvent steps are now completed (leaving only the Löwner-integral packaging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a804be399afa8492b0fbb8c6d00235ca89578558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->