### PR TITLE
feat(MPS/CanonicalForm): expose sector basis overlap-span data from reindexed common sectors (#1114)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -790,12 +790,38 @@ theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCov
       SameMPV₂ P.toTensor Q.toTensor ∧
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
       SectorBasisOverlapSpanHypotheses P Q :=
-  sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts A B hSame hReindexed
-    (fun p' ztA ztB rA' rB' dimA' dimB' μA' μB' blkA blkB
-      hp' hblkA hblkB hPosA hPosB hNzPos hZ hμA' hμB' hTPA' hTPB'
-      hPrimA' hPrimB' hIrrA' hIrrB' hDimA' hDimB' => by
-      apply (hRemaining hp' hblkA hblkB hPosA hPosB hNzPos hZ hμA' hμB'
-        hTPA' hTPB' hPrimA' hPrimB' hIrrA' hIrrB' hDimA' hDimB').toSpanHypotheses)
+  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
+      hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts A B hSame hReindexed
+  have hHyp : CommonPrimitivePhaseCoverHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  have hSpanHyp : CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hHyp.toSpanHypotheses
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
+    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      nonzeroA nonzeroB hAB hAblocks hBblocks hSpanHyp.zeroTail_eq
+  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
+    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
+      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
+      hPrimA hPrimB hSpanHyp.left_injective hSpanHyp.right_injective hμA hμB hSpanHyp.span_eq
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
+      _ = mpv nonzeroB σ := hNonzero N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  exact ⟨p, hp, P, Q, hPQeq, hPbnt, hQbnt, hOverlapSpan⟩
 
 /-- **Sector basis overlap-span data via a BNT proportional-decomposition comparison.**
 
@@ -851,13 +877,39 @@ theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_proportional
     ∃ P Q : SectorDecomposition (blockPhysDim d p),
       SameMPV₂ P.toTensor Q.toTensor ∧
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      SectorBasisOverlapSpanHypotheses P Q :=
-  sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts A B hSame hReindexed
-    (fun p' ztA ztB rA' rB' dimA' dimB' μA' μB' blkA blkB
-      hp' hblkA hblkB hPosA hPosB hNzPos hZ hμA' hμB' hTPA' hTPB'
-      hPrimA' hPrimB' hIrrA' hIrrB' hDimA' hDimB' => by
-      apply (hRemaining hp' hblkA hblkB hPosA hPosB hNzPos hZ hμA' hμB'
-        hTPA' hTPB' hPrimA' hPrimB' hIrrA' hIrrB' hDimA' hDimB').toSpanHypotheses)
+      SectorBasisOverlapSpanHypotheses P Q := by
+  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
+      hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts A B hSame hReindexed
+  have hHyp : CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  have hSpanHyp : CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hHyp.toSpanHypotheses
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
+    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      nonzeroA nonzeroB hAB hAblocks hBblocks hSpanHyp.zeroTail_eq
+  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
+    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
+      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
+      hPrimA hPrimB hSpanHyp.left_injective hSpanHyp.right_injective hμA hμB hSpanHyp.span_eq
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
+      _ = mpv nonzeroB σ := hNonzero N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  exact ⟨p, hp, P, Q, hPQeq, hPbnt, hQbnt, hOverlapSpan⟩
 
 
 /-- **Common-length primitive irreducible sectors with conditional block-span consequences.**

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -632,6 +632,233 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHyp
     hIrrA hIrrB hPrimA hPrimB hHyp.left_injective hHyp.right_injective
     hμA hμB hHyp.span_eq
 
+/-- **Sector basis overlap-span data from common primitive nonzero-sector families.**
+
+The common primitive irreducible block theorem supplies the two nonzero-sector decompositions
+obtained after blocked-word reindexing. If the remaining zero-tail equality, one-site
+injectivity, and finite-length span equality are supplied for those same families, the
+collapsed BNT representative construction produces a pair of sector decompositions satisfying
+`SectorBasisOverlapSpanHypotheses`.
+
+This theorem isolates the `SectorBasisOverlapSpanHypotheses` construction used internally by
+`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`. The
+conclusion records the nonzero-block MPV agreements, the BNT linear-independence data, and
+the eleven overlap-span fields: nonzero bond dimensions, injectivity, left-canonical
+normalization, asymptotic self- and off-diagonal overlaps, and equality of the finite-length
+MPV spans of the two sector bases.
+
+The `hRemaining` function must supply `CommonPrimitiveSpanHypotheses` for the block families
+produced by `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`.
+Concretely it needs to prove equality of the two zero-tail dimensions, one-site injectivity
+of the nonzero-weight blocks, and equality of their finite-length MPV spans. The last of
+these can be supplied by a common MPV phase cover (via
+`CommonPrimitiveSpanHypotheses.of_commonPhaseCover`) or by a BNT proportional-decomposition
+comparison (via `CommonPrimitiveProportionalHypotheses.toSpanHypotheses`). -/
+theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      SectorBasisOverlapSpanHypotheses P Q := by
+  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
+      hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts A B hSame hReindexed
+  have hHyp : CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
+    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      nonzeroA nonzeroB hAB hAblocks hBblocks hHyp.zeroTail_eq
+  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
+    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
+      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
+      hPrimA hPrimB hHyp.left_injective hHyp.right_injective hμA hμB hHyp.span_eq
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
+      _ = mpv nonzeroB σ := hNonzero N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  exact ⟨p, hp, P, Q, hPQeq, hPbnt, hQbnt, hOverlapSpan⟩
+
+/-- **Sector basis overlap-span data via a common MPV phase cover.**
+
+This is the common-phase-cover variant of
+`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts`. Instead of requiring the
+finite-length span equality directly, it asks for a common MPV phase cover of the two
+nonzero-weight block families. The cover supplies the span equality through
+`MPVCommonPhaseCover.span_eq`. -/
+theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      CommonPrimitivePhaseCoverHypotheses zeroTailA zeroTailB blocksA blocksB) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      SectorBasisOverlapSpanHypotheses P Q :=
+  sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts A B hSame hReindexed
+    (fun p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB
+      hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB => by
+      apply (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB
+        hTPA hTPB hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toSpanHypotheses)
+
+/-- **Sector basis overlap-span data via a BNT proportional-decomposition comparison.**
+
+This is the proportional-comparison variant of
+`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts`. A BNT proportional-decomposition
+conclusion for the two nonzero-weight block families gives a common MPV phase cover, hence the
+finite-length span equality needed by the collapsed BNT representative construction. -/
+theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_proportional
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      SectorBasisOverlapSpanHypotheses P Q :=
+  sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts A B hSame hReindexed
+    (fun p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB
+      hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB => by
+      apply (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB
+        hTPA hTPB hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toSpanHypotheses)
+
 
 /-- **Common-length primitive irreducible sectors with conditional block-span consequences.**
 

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -789,7 +789,7 @@ theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCov
     ∃ P Q : SectorDecomposition (blockPhysDim d p),
       SameMPV₂ P.toTensor Q.toTensor ∧
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      SectorBasisOverlapSpanHypotheses P Q :=
+      SectorBasisOverlapSpanHypotheses P Q := by
   obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
       rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
       hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -791,11 +791,11 @@ theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCov
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
       SectorBasisOverlapSpanHypotheses P Q :=
   sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts A B hSame hReindexed
-    (fun p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB
-      hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
-      hPrimA hPrimB hIrrA hIrrB hDimA hDimB => by
-      apply (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB
-        hTPA hTPB hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toSpanHypotheses)
+    (fun p' ztA ztB rA' rB' dimA' dimB' μA' μB' blkA blkB
+      hp' hblkA hblkB hPosA hPosB hNzPos hZ hμA' hμB' hTPA' hTPB'
+      hPrimA' hPrimB' hIrrA' hIrrB' hDimA' hDimB' => by
+      apply (hRemaining hp' hblkA hblkB hPosA hPosB hNzPos hZ hμA' hμB'
+        hTPA' hTPB' hPrimA' hPrimB' hIrrA' hIrrB' hDimA' hDimB').toSpanHypotheses)
 
 /-- **Sector basis overlap-span data via a BNT proportional-decomposition comparison.**
 
@@ -853,11 +853,11 @@ theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_proportional
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
       SectorBasisOverlapSpanHypotheses P Q :=
   sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts A B hSame hReindexed
-    (fun p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB
-      hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
-      hPrimA hPrimB hIrrA hIrrB hDimA hDimB => by
-      apply (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB
-        hTPA hTPB hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toSpanHypotheses)
+    (fun p' ztA ztB rA' rB' dimA' dimB' μA' μB' blkA blkB
+      hp' hblkA hblkB hPosA hPosB hNzPos hZ hμA' hμB' hTPA' hTPB'
+      hPrimA' hPrimB' hIrrA' hIrrB' hDimA' hDimB' => by
+      apply (hRemaining hp' hblkA hblkB hPosA hPosB hNzPos hZ hμA' hμB'
+        hTPA' hTPB' hPrimA' hPrimB' hIrrA' hIrrB' hDimA' hDimB').toSpanHypotheses)
 
 
 /-- **Common-length primitive irreducible sectors with conditional block-span consequences.**


### PR DESCRIPTION
## Summary

Adds three new theorems that extract `SectorBasisOverlapSpanHypotheses` from the common-block decomposition output produced by `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`.

## New theorems

1. **`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts`** — given `CommonPrimitiveSpanHypotheses` for the block families, produces collapsed BNT sector decompositions with the full overlap-span hypotheses (nonzero bond dimensions, injectivity, left-canonical normalization, asymptotic self- and off-diagonal overlaps, and equality of the finite-length MPV spans).

2. **`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover`** — variant where the span equality is supplied by a common MPV phase cover via `MPVCommonPhaseCover.span_eq`.

3. **`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_proportional`** — variant where a BNT proportional-decomposition conclusion supplies the common phase cover, hence the span equality.

## Dependencies

These theorems isolate the `SectorBasisOverlapSpanHypotheses` construction used internally by `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`. They remain conditional on `CommonSectorRelabelingHypothesis` (blocked-word coordinate agreement), whose unconditional proof depends on the Fintype-level coordinate equality `flattenWordOfBlock_cast_eq` being proved in #1113.

## What is proved vs. what remains

- **Proved**: For collapsed BNT representatives, given the structural data from `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`, all eleven fields of `SectorBasisOverlapSpanHypotheses` follow from the remaining span, injectivity, and zero-tail hypotheses.
- **Remaining**: The span equality hypothesis is not yet derived from `SameMPV₂` alone. It must be supplied by a common MPV phase cover, a BNT proportional-decomposition comparison, or eventually by the injectivity-plus-overlap argument that remains a paper-level gap (#944/#1068).

## Validation

- Targeted Lean compilation: `lake env lean --stdin ProportionalComparison.lean` passes.
- No banned prose terms in new docstrings.
- Follows plain Conventional Commit conventions.

Refs: #1114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean theorems/docstrings without changing existing definitions or proofs used by the core sector-comparison pipeline, aside from introducing additional reusable lemma entry points.
> 
> **Overview**
> Adds `sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts`, which packages the output of `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` plus remaining `CommonPrimitiveSpanHypotheses` into collapsed BNT sector decompositions `P/Q` and returns `SectorBasisOverlapSpanHypotheses` alongside `SameMPV₂` and `HasBNTSectorData`.
> 
> Also adds two convenience variants—`..._commonPhaseCover` and `..._proportional`—that derive the needed span hypotheses from `CommonPrimitivePhaseCoverHypotheses` or `CommonPrimitiveProportionalHypotheses`, respectively, while keeping the same existence/overlap-span conclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71742c5b03766f8fab3e1ec89bd9b0b5c929a1e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->