### PR TITLE
feat(MPS/CanonicalForm): bundle BNT hypotheses for common phase-cover bridge (#1068)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -36,6 +36,12 @@ BNT proportional-decomposition comparison of the nonzero-weight block families.
 * `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional` — the
   same relabeled common-sector output, with the common cover obtained from a BNT
   proportional-decomposition comparison for the produced nonzero-sector families.
+* `CommonPrimitiveBNTCoverHypotheses` — bundles the BNT-level remaining hypotheses
+  (`IsNormalCanonicalForm`, `BlocksNotGaugePhaseEquiv`, `ProportionalDecompositionData`,
+  zero-tail equality, and one-site injectivity) for the common-length cyclic sector families.
+  The structure provides `.toMPVCommonPhaseCover` and `.toCommonPrimitivePhaseCoverHypotheses`
+  bridges to the common phase-cover layer.
+  See the structure docstring for the explicit mathematical gaps that remain.
 
 ## References
 
@@ -179,6 +185,86 @@ theorem toSpanHypotheses
   h.toPhaseCoverHypotheses.toSpanHypotheses
 
 end CommonPrimitiveProportionalHypotheses
+
+/-- Remaining BNT-level inputs for constructing a common MPV phase cover
+from the common-length cyclic sector families produced by the structural theorem.
+
+The structural theorem
+`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
+supplies trace-preserving, primitive, tensor-irreducible block families
+with nonzero weights and positive bond dimensions at a common blocking
+length.  The four fields below are the additional BNT hypotheses needed
+to compare the two families and obtain a common MPV phase cover.
+
+The remaining mathematical tasks are:
+1. Verify `IsNormalCanonicalForm` for the produced block families
+   (requires ordering the weights by decreasing modulus).
+2. Verify `BlocksNotGaugePhaseEquiv` for the cyclic-sector block families
+   (follows from the fact that distinct cyclic sectors carry
+   distinct peripheral eigenvalues and therefore cannot be
+   gauge-phase equivalent).
+3. Construct `ProportionalDecompositionData` from the `SameMPV₂`
+   equality of the two nonzero parts, which is available from the
+   structural theorem and the zero-tail identity. -/
+structure CommonPrimitiveBNTCoverHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    (μA : Fin rA → ℂ) (μB : Fin rB → ℂ)
+    (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x))
+    (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)) : Type where
+  /-- The left block family is in normal canonical form. -/
+  ncfA : IsNormalCanonicalForm (d := blockPhysDim d p) μA blocksA
+  /-- The right block family is in normal canonical form. -/
+  ncfB : IsNormalCanonicalForm (d := blockPhysDim d p) μB blocksB
+  /-- Distinct left blocks are not gauge-phase equivalent. -/
+  notGpeA : BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksA
+  /-- Distinct right blocks are not gauge-phase equivalent. -/
+  notGpeB : BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksB
+  /-- The two zero-tail dimensions agree. -/
+  zeroTail_eq : zeroTailA = zeroTailB
+  /-- The two nonzero-sector block families are one-site injective. -/
+  left_injective : ∀ x : Fin rA, IsInjective (blocksA x)
+  /-- The two nonzero-sector block families are one-site injective. -/
+  right_injective : ∀ x : Fin rB, IsInjective (blocksB x)
+  /-- Proportional decomposition data linking the two block families. -/
+  decompData : ProportionalDecompositionData (d := blockPhysDim d p)
+    blocksA blocksB DtotA DtotB
+
+namespace CommonPrimitiveBNTCoverHypotheses
+
+/-- A BNT cover hypothesis bundle produces a common MPV phase cover. -/
+theorem toMPVCommonPhaseCover
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (h : CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB) :
+    Nonempty (MPVCommonPhaseCover blocksA blocksB) :=
+  nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
+    (d := blockPhysDim d p) blocksA blocksB
+    h.ncfA h.notGpeA h.ncfB h.notGpeB h.decompData
+
+/-- A BNT cover hypothesis bundle produces the common primitive phase-cover hypotheses. -/
+theorem toCommonPrimitivePhaseCoverHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (h : CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB) :
+    CommonPrimitivePhaseCoverHypotheses zeroTailA zeroTailB blocksA blocksB where
+  zeroTail_eq := h.zeroTail_eq
+  left_injective := h.left_injective
+  right_injective := h.right_injective
+  cover := h.toMPVCommonPhaseCover
+
+end CommonPrimitiveBNTCoverHypotheses
 
 /-- **Sector comparison from BNT proportional-decomposition data.**
 


### PR DESCRIPTION
## Summary

Adds `CommonPrimitiveBNTCoverHypotheses` structure that bundles the remaining BNT-level inputs needed to construct a common MPV phase cover from the common-length cyclic sector families produced by the structural theorem.

### What's added

- **`CommonPrimitiveBNTCoverHypotheses`**: A new structure in `ProportionalComparison.lean` that bundles:
  - `IsNormalCanonicalForm` (both sides)
  - `BlocksNotGaugePhaseEquiv` (both sides)
  - `ProportionalDecompositionData`
  - Zero-tail dimension equality and one-site injectivity

- **`.toMPVCommonPhaseCover`**: Lemma proving that the bundle produces `Nonempty (MPVCommonPhaseCover blocksA blocksB)` via `nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data`.

- **`.toCommonPrimitivePhaseCoverHypotheses`**: Lemma lifting to the `CommonPrimitivePhaseCoverHypotheses` layer.

### Remaining gaps (documented in the structure docstring)

The structural theorem `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` supplies TP, primitive, irreducible block families. The three additional tasks are:

1. **Weight ordering** — verify `IsNormalCanonicalForm` (requires ordering the common-flat weights by decreasing modulus).
2. **Cyclic-sector separation** — prove `BlocksNotGaugePhaseEquiv` for the cyclic-sector block families (blocks with distinct peripheral eigenvalues cannot be gauge-phase equivalent).
3. **Proportional decomposition** — construct `ProportionalDecompositionData` from the `SameMPV₂` equality of the two nonzero parts.

These dependencies are tracked by issues #1113 (Fintype coordinate gap) and #1114 (`SectorBasisOverlapSpanHypotheses`).

### Dependencies

- Uses existing lemma `nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data` from `EqualNormBridge.lean`.
- No new imports needed (already imported via `StructuralTheorem`).

Refs #1068

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new hypothesis bundle and two bridging theorems without changing existing sector-comparison proofs; risk is low and mainly around typeclass/lemma wiring in Lean.
> 
> **Overview**
> Adds `CommonPrimitiveBNTCoverHypotheses`, a new structure bundling `IsNormalCanonicalForm`, `BlocksNotGaugePhaseEquiv`, zero-tail equality, one-site injectivity, and `ProportionalDecompositionData` for the common-length cyclic-sector block families.
> 
> Provides two bridge theorems: `toMPVCommonPhaseCover` (deriving `Nonempty (MPVCommonPhaseCover ...)` via `nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data`) and `toCommonPrimitivePhaseCoverHypotheses` (lifting that cover plus the remaining fields into the existing phase-cover hypothesis layer), and documents the remaining math gaps in the docstring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46117741d31a8e17303da5db5ca25c9f6218fec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->