### PR TITLE
feat(MPS/CanonicalForm): add per-block weight transport lemmas and document #1113 Fintype gap (#971)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1272,6 +1272,20 @@ theorem commonFlatWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
     (x : Fin (∑ k : Fin r, F.period k)) : F.commonFlatWeight μ x ≠ 0 :=
   pow_ne_zero F.p (hμ (F.flatKey x).1)
 
+/-- Per-block weight transport under common blocking: every sector belonging to original
+nonzero-weight block `k` carries the transported power `μ k ^ F.p`. -/
+theorem commonFlatWeight_apply_of_block (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) (k : Fin r) (s : Fin (F.period k)) :
+    F.commonFlatWeight μ (finSigmaFinEquiv (Sigma.mk k s)) = μ k ^ F.p := by
+  simp [commonFlatWeight, flatKey, finSigmaFinEquiv]
+
+/-- All sectors from the same original block carry the same transported weight. -/
+theorem commonFlatWeight_apply_block_eq (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) (k : Fin r) (s t : Fin (F.period k)) :
+    F.commonFlatWeight μ (finSigmaFinEquiv (Sigma.mk k s)) =
+    F.commonFlatWeight μ (finSigmaFinEquiv (Sigma.mk k t)) := by
+  simp [commonFlatWeight_apply_of_block]
+
 private theorem commonSectorBlock_structural (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :
     (∑ i : Fin (blockPhysDim d F.p),

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -542,9 +542,9 @@ theorem sameMPV₂_reindexPhysical_directToIteratedBlockIndex_blockTensor
 
 The lemma `reindexPhysical_directToIteratedBlockIndex_blockTensor` shows that applying the
 explicit block-grouping bijection to the iterated block tensor recovers the direct block
-tensor.  The remaining point for closing issue #990 is to prove that this bijection coincides
-with the `Fin.cast` identification used in `CommonBlockedCyclicSectorFamily`.  Concretely,
-one needs
+tensor.  The remaining point for closing issues #990 and #971 is to prove that this bijection
+coincides with the `Fin.cast` identification used in `CommonBlockedCyclicSectorFamily`.
+Concretely, one needs
 
 ```lean
 Fin.cast ((F.blockPhysDim_nested_eq k).symm) i =
@@ -558,12 +558,18 @@ The obstruction is purely combinatorial: the current blocked-index encoding uses
 `Fintype.equivFin`, which gives a noncanonical enumeration.  Proving the equality requires
 showing that the `Fintype.equivFin` enumeration of `Fin (m*n) → Fin d` agrees with the
 nested enumeration `Fin n → (Fin m → Fin d)` under the natural grouping isomorphism.
-This is likely a lemma about `Multiset.pi` or `Finset.univ` for function types, and
-the entry points suggested by earlier reviews (`Fin.prod_univ_succ`, `Fin.consEquiv`,
-`Fintype.piFinset` in `Mathlib/Data/Fin/Tuple/Finset.lean`) remain the natural path.
-Once proved in `TNLean/MPS/Core/BlockingInfrastructure.lean`, it unconditionally discharges
-`groupedBlockCastAgrees` and closes this issue together with all dependent conditional
-theorems in `CyclicSectorDecomposition.lean` and `StructuralTheorem.lean`.
+This is tracked as issue #1113.
+
+Once proved, it unconditionally discharges `groupedBlockCastAgrees` and closes all
+dependent conditional theorems in `CyclicSectorDecomposition.lean` and
+`StructuralTheorem.lean`.
+
+### Relationship with `flattenWordOfBlock_cast_eq`
+
+The single `sorry` in `CyclicSectorDecomposition.lean` (line 1495) encodes the same
+combinatorial identity as a list equality.  The lemma
+`groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq` shows that this list-level
+assertion implies the coordinate-level one required by `groupedBlockCastAgrees`.
 -/
 
 /-- Casting the physical dimension of both tensors preserves heterogeneous MPV equality. -/

--- a/audits/2026-04-27_issue971_weight_zero_tail.md
+++ b/audits/2026-04-27_issue971_weight_zero_tail.md
@@ -63,3 +63,29 @@ as the comparison between this equivalence and the canonical identification used
 inside `CommonBlockedCyclicSectorFamily`.  The present transport theorem therefore
 uses the grouped-block coordinate assertion as the honest remaining input rather
 than replacing it by a stronger unproved coordinate choice.
+
+## 2026-05-02 update — per-block weight transport lemma and #1113 gap documentation
+
+New declarations in `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`:
+
+- `MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_apply_of_block`: for each
+  sector `s` of original nonzero-weight block `k`, the common-sector weight is `μ k ^ F.p`.
+- `MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_apply_block_eq`: all sectors
+  from the same original block carry the same transported weight.
+
+Updated documentation in `TNLean/MPS/Core/BlockingInfrastructure.lean`:
+
+- The blocked-word identification gap now explicitly references issue #1113
+  (Fintype coordinate equality for grouped-block relabeling).
+- Documents that `flattenWordOfBlock_cast_eq` (with its `sorry`) is the single
+  combinatorial assertion that blocks unconditional common-block decomposition.
+
+### Current status
+
+All MPS-level weight transport and zero-tail lemmas listed above are proved.
+The single remaining gap is the Fintype-level combinatorial identity
+`flattenWordOfBlock_cast_eq` (issue #1113), which says that the `Fintype.equivFin`
+enumeration for `Fin (m*n) → Fin d` is compatible with currying into
+`Fin n → (Fin m → Fin d)`.  Once this is proved, the conditional common-block
+theorem `unconditional_commonPrimitiveIrreducibleBlocks` becomes unconditional,
+closing issues #942, #944, #971, #990.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1711,7 +1711,9 @@ The following results separate the zero blocks from the nonzero blocks.
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks_irreducible,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim_pos,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonBlockWeight_ne_zero,
-		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero}
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_apply_of_block,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_apply_block_eq}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:tp_primitive_irreducible_extra_blocking,


### PR DESCRIPTION
## Summary

Adds reusable lemmas for weight transport through cyclic-sector decomposition and documents the remaining Fintype coordinate gap (issue #1113) that blocks full unconditional common-block decomposition.

## Changes

### `CyclicSectorDecomposition.lean`
- **`commonFlatWeight_apply_of_block`**: For each sector `s` of original nonzero-weight block `k`, the common-sector weight is `μ k ^ F.p`.
- **`commonFlatWeight_apply_block_eq`**: All sectors from the same original block carry the same transported weight.

### `BlockingInfrastructure.lean`
- Updated the blocked-word identification gap documentation to explicitly reference issue #1113.
- Clarified that `flattenWordOfBlock_cast_eq` (with its `sorry`) is the single combinatorial assertion blocking unconditional common-block decomposition.

### `ch08_canonical.tex`
- Registered the two new lemmas under the derived-properties theorem.

### `audits/2026-04-27_issue971_weight_zero_tail.md`
- Added 2026-05-02 update documenting the per-block weight transport lemma and the #1113 Fintype gap dependency.

## Context

Issue #971 asks for reusable lemmas that transport weights and zero-tail equations through cyclic-sector decomposition. All MPS-level lemmas (weight transport, nonzero weights, zero-tail MPV, positive-length equality) are already proved in prior PRs (#973, #1070, #1101). The single remaining gap is the Fintype-level combinatorial identity `flattenWordOfBlock_cast_eq` (issue #1113), which asserts that the `Fintype.equivFin` enumeration for `Fin (m*n) → Fin d` is compatible with currying into `Fin n → (Fin m → Fin d)`.

## Related

- Closes partial work toward #971
- Blocked by #1113
- See also #990, #942, #944

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds small, proof-only lemmas and documentation updates; no runtime behavior changes. Risk is limited to potential downstream proof breakage due to new lemma dependencies/names.
> 
> **Overview**
> Adds two new lemmas, `commonFlatWeight_apply_of_block` and `commonFlatWeight_apply_block_eq`, making the common-blocked cyclic-sector construction’s *weight transport* explicit per original block/sector.
> 
> Updates the blocking-gap documentation to point to the single remaining combinatorial blocker as issue `#1113` (the `Fintype.equivFin`/`Fin.cast` compatibility), and wires the new lemmas into the blueprint and audit notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e05029bff0d5fab4ac6ce075b31f40bdab09a6fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->