### PR TITLE
feat(MPS/CanonicalForm): discharge grouped block word cast (#1137)

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -844,9 +844,10 @@ private theorem sector_supported_pow_fixed_eq_smul_projection_of_scalarFixedPoin
 /-- If each blocked sector channel has only scalar adjoint fixed points, then
 its cyclic projections satisfy `SectorFixedPointAlgebraRigidity`.
 
-This is the strongest currently available general route in the direction of
-the scalar blocked fixed-point algebra result (see Cirac--Perez-Garcia--Schuch--Verstraete 2021, Appendix A): once
-the blocked fixed-point algebra is known to be scalar on all compressed sectors,
+This is the strongest currently available general route in the direction of the scalar
+blocked fixed-point algebra result
+(see Cirac--Perez-Garcia--Schuch--Verstraete 2021, Appendix A): once the blocked
+fixed-point algebra is known to be scalar on all compressed sectors,
 every `((transferMap A†)^m)`-fixed corner element is a scalar multiple of the
 corresponding sector projection, so the one-step adjoint transition is
 automatically multiplicative on the sector fixed-point algebra. -/
@@ -1277,7 +1278,7 @@ nonzero-weight block `k` carries the transported power `μ k ^ F.p`. -/
 theorem commonFlatWeight_apply_of_block (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ) (k : Fin r) (s : Fin (F.period k)) :
     F.commonFlatWeight μ (finSigmaFinEquiv (Sigma.mk k s)) = μ k ^ F.p := by
-  simp [commonFlatWeight, flatKey, finSigmaFinEquiv]
+  simp [commonFlatWeight, flatKey]
 
 /-- All sectors from the same original block carry the same transported weight. -/
 theorem commonFlatWeight_apply_block_eq (F : CommonBlockedCyclicSectorFamily blocks)
@@ -1478,64 +1479,44 @@ theorem groupedBlockCastAgrees_iff_iteratedBlockIndex_cast
           (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i) := by
             rw [hIndex i]
 
-/-- **Core Fintype-level coordinate assertion (remaining blocker for #942/#1075).**
+private lemma finFunctionFinEquiv_block_digit (x d m j : ℕ) (t : Fin m) :
+    x / (d ^ m) ^ j % d ^ m / d ^ (t : ℕ) % d =
+      x / d ^ (m * j + (t : ℕ)) % d := by
+  have ht_le : (t : ℕ) ≤ m := Nat.le_of_lt t.isLt
+  have hpow : d ^ m = d ^ (t : ℕ) * d ^ (m - (t : ℕ)) := by
+    rw [← Nat.pow_add, Nat.add_sub_of_le ht_le]
+  nth_rewrite 2 [hpow]
+  rw [Nat.mod_mul_right_div_self]
+  rw [Nat.mod_mod_of_dvd]
+  · rw [Nat.div_div_eq_div_mul]
+    have hden : (d ^ m) ^ j * d ^ (t : ℕ) = d ^ (m * j + (t : ℕ)) := by
+      rw [← Nat.pow_mul, ← Nat.pow_add]
+    rw [hden]
+  · simpa using Nat.pow_dvd_pow d (by omega : 1 ≤ m - (t : ℕ))
 
-Given a common blocked physical alphabet index `i`, the flattened inner word obtained by
-decoding `i` through the cardinal equality `blockPhysDim (blockPhysDim d m) n = blockPhysDim d p`
-(with `p = m*n`) agrees with the direct decoding of `i` at the common period length.
-
-**Mathematical truth.**  Both sides are `List (Fin d)` of length `m*n`.  The RHS
-`wordOfBlock d p i` decodes `i` via `Fintype.equivFin (Fin p → Fin d)`, returning the
-`i`-th function in the lexicographic enumeration of `Fin p → Fin d`.  The LHS first
-decodes `i` via `Fintype.equivFin (Fin n → Fin (blockPhysDim d m))`, which gives the
-`i`-th function `g : Fin n → Fin (blockPhysDim d m)` in the lexicographic enumeration
-of `Fin n → Fin (blockPhysDim d m)`.  Then each `g j : Fin (blockPhysDim d m)` is decoded
-via `Fintype.equivFin (Fin m → Fin d)` and the `n` lists of length `m` are flattened.
-
-Since Mathlib's `Fintype.equivFin` for function types uses `Fintype.piFinset` with
-subset of `Finset.pi`, both enumerations are lexicographic.  The lexicographic ordering
-of `Fin (m*n) → Fin d` coincides with the nested lexicographic ordering
-`Fin n → (Fin m → Fin d)` under the natural currying and the product equivalence
-`Fin (m*n) ≃ Fin n × Fin m` given by `finProdFinEquiv`.  Therefore the two decoding
-paths produce the same list for every `i`.
-
-**Attempted proofs.**  Several approaches were tried but all hit CI failures
-(heartbeat timeouts or type-inference complexity):
-1. Building an explicit equivalence `F` from `finProdFinEquiv`, `Equiv.curry`,
-   `Equiv.prodComm`, `finCongr` and using `Subsingleton.elim` on `Fintype.truncEquivFin`.
-   This typechecks locally but hits heartbeat limits (200k → 400k) on CI or has
-   unresolved `simp` goals in the `hF_apply` computation.
-2. Direct `Equiv.trans` chains instead of `calc` — same issues with type inference.
-3. `Fin.cast` vs `finCongr` distinctions for the cardinality equality.
-
-**What is needed.**  A Mathlib lemma establishing that `Fintype.equivFin` for `Fin L → Fin d`
-is compatible with `Fin L ≃ Fin L₁ × Fin L₂` product decompositions (like `finProdFinEquiv`)
-and currying (`Equiv.curry`).  The natural route is to prove that `Fintype.truncEquivFin`
-respects `Finset.map` of equivalences, which would give the compatibility generically.
-Alternatively, a characterization of `Fintype.equivFin` in terms of `Nat.digits`
-(via `Nat.bijOn_ofDigits`) could provide a computational proof.
-
-**Impact.**  As long as this lemma is unproved, the common-block chain
-(#942 / #990 / #1075) requires the hypothesis `CommonGroupedBlockCastHypothesis d`.
-The theorems `unconditional_commonPrimitiveIrreducibleBlocks`,
-`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`, and
-their downstream consequences remain conditional on this hypothesis.
--/
+/-- Flattening the explicit length-`n` blocked decoding of a length-`m*n` index agrees with
+the direct length-`m*n` decoding. -/
 theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
     (hp_eq : p = m * n) (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
     (i : Fin (blockPhysDim d p)) :
     flattenBlockedWord d m
       (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) =
     wordOfBlock d p i := by
-  -- See docstring for detailed explanation of the mathematical truth and attempted
-  -- proof strategies.  The core missing lemma is compatibility of `Fintype.equivFin`
-  -- with currying and product decomposition of function types.
-  sorry
+  subst hp_eq
+  simp only [flattenBlockedWord, wordOfBlock, decodeBlock, List.map_ofFn, Function.comp_apply]
+  rw [List.ofFn_mul']
+  apply congrArg List.flatten
+  exact congrArg List.ofFn (funext fun j => by
+    simp only [wordOfBlock, decodeBlock, Fin.cast_cast, Function.comp_apply]
+    exact congrArg List.ofFn (funext fun t => by
+      apply Fin.ext
+      simpa [blockPhysDim_eq_pow] using
+        finFunctionFinEquiv_block_digit (x := (i : ℕ)) (d := d) (m := m) (j := (j : ℕ)) t))
 
 /-- The global grouping-cast hypothesis applied to a specific family reduces to the
 core Fintype-level assertion. -/
 theorem groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
-    {d : ℕ} (h_flatten : ∀ {m n p : ℕ} (hp_eq : p = m * n)
+    {d : ℕ} (h_flatten : ∀ {m n p : ℕ} (_ : p = m * n)
       (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
       (i : Fin (blockPhysDim d p)),
       flattenBlockedWord d m

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1479,20 +1479,22 @@ theorem groupedBlockCastAgrees_iff_iteratedBlockIndex_cast
           (Fin.cast (congr_arg (blockPhysDim d) (F.p_eq_period_mul_extra k)) i) := by
             rw [hIndex i]
 
-private lemma finFunctionFinEquiv_block_digit (x d m j : ℕ) (t : Fin m) :
-    x / (d ^ m) ^ j % d ^ m / d ^ (t : ℕ) % d =
-      x / d ^ (m * j + (t : ℕ)) % d := by
-  have ht_le : (t : ℕ) ≤ m := Nat.le_of_lt t.isLt
+/-- Reading the `t`th base-`d` digit inside the `j`th block of length `m`
+is the same as reading digit `m*j+t` directly. -/
+private lemma Nat.div_pow_mod_pow_block (x d m j t : ℕ) (ht : t < m) :
+    x / (d ^ m) ^ j % d ^ m / d ^ t % d =
+      x / d ^ (m * j + t) % d := by
+  have ht_le : t ≤ m := Nat.le_of_lt ht
   have hpow : d ^ m = d ^ (t : ℕ) * d ^ (m - (t : ℕ)) := by
     rw [← Nat.pow_add, Nat.add_sub_of_le ht_le]
   nth_rewrite 2 [hpow]
   rw [Nat.mod_mul_right_div_self]
   rw [Nat.mod_mod_of_dvd]
   · rw [Nat.div_div_eq_div_mul]
-    have hden : (d ^ m) ^ j * d ^ (t : ℕ) = d ^ (m * j + (t : ℕ)) := by
+    have hden : (d ^ m) ^ j * d ^ t = d ^ (m * j + t) := by
       rw [← Nat.pow_mul, ← Nat.pow_add]
     rw [hden]
-  · simpa using Nat.pow_dvd_pow d (by omega : 1 ≤ m - (t : ℕ))
+  · simpa using Nat.pow_dvd_pow d (by omega : 1 ≤ m - t)
 
 /-- Flattening the explicit length-`n` blocked decoding of a length-`m*n` index agrees with
 the direct length-`m*n` decoding. -/
@@ -1511,7 +1513,8 @@ theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
     exact congrArg List.ofFn (funext fun t => by
       apply Fin.ext
       simpa [blockPhysDim_eq_pow] using
-        finFunctionFinEquiv_block_digit (x := (i : ℕ)) (d := d) (m := m) (j := (j : ℕ)) t))
+        Nat.div_pow_mod_pow_block (x := (i : ℕ)) (d := d) (m := m)
+          (j := (j : ℕ)) (t := (t : ℕ)) t.isLt))
 
 /-- The global grouping-cast hypothesis applied to a specific family reduces to the
 core Fintype-level assertion. -/

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1405,9 +1405,9 @@ theorem afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
 
 /-- **Unconditional common primitive irreducible block decompositions.**
 
-If the Fintype-level coordinate assertion `flattenWordOfBlock_cast_eq` holds, then the
-`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` theorem
-applies without any blocking-coordinate hypothesis.
+The proved blocked-word flattening identity supplies the grouped-cast hypothesis needed to
+apply `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` without any
+blocking-coordinate hypothesis.
 
 The proof chains:
 1. `flattenWordOfBlock_cast_eq` → `CommonGroupedBlockCastHypothesis d`
@@ -1416,18 +1416,9 @@ The proof chains:
    (via `CommonGroupedBlockCastHypothesis.toRelabelingHypothesis`)
 3. `CommonSectorRelabelingHypothesis d` → the full common-block decomposition
    (via `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`)
-
-The remaining gap for the fully unconditional version is exactly `flattenWordOfBlock_cast_eq`
-in `CyclicSectorDecomposition.lean` (see docstring there for details on the mathematical
-truth and the missing Mathlib lemma). -/
+-/
 theorem unconditional_commonPrimitiveIrreducibleBlocks
     {d D₁ D₂ : ℕ}
-    (h_flatten : ∀ {m n p : ℕ} (hp_eq : p = m * n)
-      (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
-      (i : Fin (blockPhysDim d p)),
-      flattenBlockedWord d m
-        (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) =
-      wordOfBlock d p i)
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B) :
     ∃ p : ℕ, 0 < p ∧
@@ -1470,7 +1461,9 @@ theorem unconditional_commonPrimitiveIrreducibleBlocks
       (∀ x, 0 < dimB x) := by
   have h_group : CommonGroupedBlockCastHypothesis d := by
     intro r dim blocks F k
-    exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq h_flatten k
+    exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+      (fun hp_eq h_card i =>
+        CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq hp_eq h_card i) k
   have h_relabel : CommonSectorRelabelingHypothesis d :=
     h_group.toRelabelingHypothesis
   exact afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts

--- a/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
@@ -25,7 +25,8 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 private noncomputable def singleBlockEquiv (d : ℕ) : Fin (blockPhysDim d 1) ≃ Fin d :=
-  (Fintype.equivFin (Fin 1 → Fin d)).symm.trans (Equiv.funUnique (Fin 1) (Fin d))
+  ((finCongr (blockPhysDim_eq_pow d 1)).trans finFunctionFinEquiv.symm).trans
+    (Equiv.funUnique (Fin 1) (Fin d))
 
 @[simp] private lemma wordOfBlock_one (i : Fin (blockPhysDim d 1)) :
     wordOfBlock d 1 i = [singleBlockEquiv d i] := by

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -30,8 +30,8 @@ lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) 
     · rintro ⟨i, rfl⟩
       exact ⟨decodeBlock d N i, rfl⟩
     · rintro ⟨σ, rfl⟩
-      exact ⟨(Fintype.equivFin (Fin N → Fin d)) σ, by
-        simp [decodeBlock]⟩
+      exact ⟨Fin.cast (blockPhysDim_eq_pow d N).symm (finFunctionFinEquiv σ), by
+        simp [decodeBlock, Fin.cast_cast]⟩
   unfold IsNBlkInjective IsInjective blockTensor
   have hSpan :
       Submodule.span ℂ

--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -10,6 +10,7 @@ import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Fintype.EquivFin
 import Mathlib.Data.Fin.Tuple.Basic
+import Mathlib.Algebra.BigOperators.Fin
 
 /-!
 # Physical blocking of MPS tensors
@@ -40,7 +41,7 @@ lemma blockPhysDim_eq_pow (d L : ℕ) : blockPhysDim d L = d ^ L := by
 
 /-- Decode a blocked physical index into the corresponding length-`L` word. -/
 noncomputable def decodeBlock (d L : ℕ) : Fin (blockPhysDim d L) → (Fin L → Fin d) :=
-  (Fintype.equivFin (Fin L → Fin d)).symm
+  finFunctionFinEquiv.symm ∘ Fin.cast (blockPhysDim_eq_pow d L)
 
 /-- Turn a blocked physical index into a list (word) of length `L`. -/
 noncomputable def wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) : List (Fin d) :=
@@ -60,7 +61,8 @@ noncomputable def blockTensor (A : MPSTensor d D) (L : ℕ) :
 noncomputable def flattenBlockedWord (d L : ℕ) : List (Fin (blockPhysDim d L)) → List (Fin d)
   | w => (w.map (wordOfBlock d L)).flatten
 
-@[simp, mps_block_words] lemma flattenBlockedWord_nil (d L : ℕ) : flattenBlockedWord d L [] = [] := by
+@[simp, mps_block_words]
+lemma flattenBlockedWord_nil (d L : ℕ) : flattenBlockedWord d L [] = [] := by
   simp [flattenBlockedWord]
 
 @[mps_block_words]
@@ -188,7 +190,7 @@ theorem leftCanonical_blockTensor
       (blockTensor (d := d) (D := D) A L i)ᴴ *
         blockTensor (d := d) (D := D) A L i = 1 := by
   let e : Fin (blockPhysDim d L) ≃ (Fin L → Fin d) :=
-    (Fintype.equivFin (Fin L → Fin d)).symm
+    (finCongr (blockPhysDim_eq_pow d L)).trans finFunctionFinEquiv.symm
   calc
     ∑ i : Fin (blockPhysDim d L),
         (blockTensor (d := d) (D := D) A L i)ᴴ *

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -289,7 +289,8 @@ theorem blockPhysDim_blockPhysDim (d m n : ℕ) :
 /-- Encode a word of length `L` as a single blocked physical index. -/
 noncomputable def blockIndexOfList (d L : ℕ) (w : List (Fin d)) (h : w.length = L) :
     Fin (blockPhysDim d L) :=
-  (Fintype.equivFin (Fin L → Fin d)) (fun i => w.get (Fin.cast h.symm i))
+  Fin.cast (blockPhysDim_eq_pow d L).symm
+    (finFunctionFinEquiv (fun i => w.get (Fin.cast h.symm i)))
 
 /-- Decoding the blocked index associated to a list returns the original list. -/
 theorem wordOfBlock_blockIndexOfList (d L : ℕ) (w : List (Fin d))
@@ -365,7 +366,7 @@ theorem wordOfBlock_injective (d L : ℕ) : Function.Injective (wordOfBlock d L)
   have hdecode : decodeBlock d L i = decodeBlock d L j := by
     exact List.ofFn_injective hij
   unfold decodeBlock at hdecode
-  exact (Fintype.equivFin (Fin L → Fin d)).symm.injective hdecode
+  exact ((finCongr (blockPhysDim_eq_pow d L)).trans finFunctionFinEquiv.symm).injective hdecode
 
 /-- Flattening the grouped iterated index recovers the direct blocked word. -/
 theorem flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex (d m n : ℕ)
@@ -507,7 +508,8 @@ map returns the direct block tensor at length `m*n`.
 This lemma avoids the `Fin.cast` / `Fintype.equivFin` identification and instead uses the
 explicit bijection `directToIteratedBlockIndex` (PR #1096).  It gives a clean connection
 between iterated and direct blocking without needing `groupedBlockCastAgrees`. -/
-theorem reindexPhysical_directToIteratedBlockIndex_blockTensor {D : ℕ} (A : MPSTensor d D) (m n : ℕ) :
+theorem reindexPhysical_directToIteratedBlockIndex_blockTensor {D : ℕ}
+    (A : MPSTensor d D) (m n : ℕ) :
     reindexPhysical (directToIteratedBlockIndex d m n)
       (blockTensor (d := blockPhysDim d m) (D := D)
         (blockTensor (d := d) (D := D) A m) n) =
@@ -566,7 +568,7 @@ dependent conditional theorems in `CyclicSectorDecomposition.lean` and
 
 ### Relationship with `flattenWordOfBlock_cast_eq`
 
-The single `sorry` in `CyclicSectorDecomposition.lean` (line 1495) encodes the same
+The theorem `flattenWordOfBlock_cast_eq` in `CyclicSectorDecomposition.lean` encodes the same
 combinatorial identity as a list equality.  The lemma
 `groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq` shows that this list-level
 assertion implies the coordinate-level one required by `groupedBlockCastAgrees`.

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -540,13 +540,13 @@ theorem sameMPV₂_reindexPhysical_directToIteratedBlockIndex_blockTensor
   intro N σ; rfl
 
 /-!
-### Blocked-word identification gap
+### Blocked-word identification
 
 The lemma `reindexPhysical_directToIteratedBlockIndex_blockTensor` shows that applying the
 explicit block-grouping bijection to the iterated block tensor recovers the direct block
-tensor.  The remaining point for closing issues #990 and #971 is to prove that this bijection
-coincides with the `Fin.cast` identification used in `CommonBlockedCyclicSectorFamily`.
-Concretely, one needs
+tensor.  For common-block cyclic sectors, the corresponding coordinate assertion is that this
+bijection coincides with the `Fin.cast` identification used in
+`CommonBlockedCyclicSectorFamily`.  Concretely, one compares
 
 ```lean
 Fin.cast ((F.blockPhysDim_nested_eq k).symm) i =
@@ -556,22 +556,17 @@ Fin.cast ((F.blockPhysDim_nested_eq k).symm) i =
 
 for each block `k` and each physical index `i : Fin (blockPhysDim d F.p)`.
 
-The obstruction is purely combinatorial: the current blocked-index encoding uses
-`Fintype.equivFin`, which gives a noncanonical enumeration.  Proving the equality requires
-showing that the `Fintype.equivFin` enumeration of `Fin (m*n) → Fin d` agrees with the
-nested enumeration `Fin n → (Fin m → Fin d)` under the natural grouping isomorphism.
-This is tracked as issue #1113.
-
-Once proved, it unconditionally discharges `groupedBlockCastAgrees` and closes all
-dependent conditional theorems in `CyclicSectorDecomposition.lean` and
-`StructuralTheorem.lean`.
+The proof is purely combinatorial.  With the explicit `finFunctionFinEquiv` encoding, the
+coordinate comparison reduces to the base-`d` digit identity relating a length-`m*n`
+word to a length-`n` word over length-`m` blocks.
 
 ### Relationship with `flattenWordOfBlock_cast_eq`
 
 The theorem `flattenWordOfBlock_cast_eq` in `CyclicSectorDecomposition.lean` encodes the same
 combinatorial identity as a list equality.  The lemma
 `groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq` shows that this list-level
-assertion implies the coordinate-level one required by `groupedBlockCastAgrees`.
+assertion implies the coordinate-level one required by `groupedBlockCastAgrees`, and the
+assembly theorem uses it to remove the former blocking-coordinate hypothesis.
 -/
 
 /-- Casting the physical dimension of both tensors preserves heterogeneous MPV equality. -/

--- a/TNLean/MPS/Core/BlockingTransfer.lean
+++ b/TNLean/MPS/Core/BlockingTransfer.lean
@@ -38,7 +38,7 @@ theorem transferMap_blockTensor_apply
   simp only [transferMap_apply, blockTensor, wordOfBlock]
   -- Reindex the blocked sum by the equivalence `Fin (blockPhysDim d L) ≃ (Fin L → Fin d)`.
   let e : Fin (blockPhysDim d L) ≃ (Fin L → Fin d) :=
-    (Fintype.equivFin (Fin L → Fin d)).symm
+    (finCongr (blockPhysDim_eq_pow d L)).trans finFunctionFinEquiv.symm
   -- After rewriting `decodeBlock` in terms of `e`, `Fintype.sum_equiv` is exactly the desired
   -- reindexing statement.
   simpa [decodeBlock, e, blockPhysDim] using

--- a/TNLean/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/Basic.lean
@@ -114,11 +114,9 @@ theorem wordSpan_le_wordSpan_blockTensor (A : MPSTensor d D) (L n : ℕ) :
     rw [hfactor]
     -- First factor: evalWord A (List.ofFn σ₀) is a single blocked Kraus operator
     set B := blockTensor (d := d) (D := D) A L
-    set σ₀_enc := (Fintype.equivFin (Fin L → Fin d)) σ₀
+    set σ₀_enc := Fin.cast (blockPhysDim_eq_pow d L).symm (finFunctionFinEquiv σ₀)
     have hfirst_eq : evalWord A (List.ofFn σ₀) = B σ₀_enc := by
-      simp only [B, blockTensor, wordOfBlock, decodeBlock, σ₀_enc]
-      congr 1
-      simp [Equiv.symm_apply_apply]
+      simp [B, blockTensor, wordOfBlock, decodeBlock, σ₀_enc, Fin.cast_cast]
     have hfirst : evalWord A (List.ofFn σ₀) ∈ wordSpan B 1 := by
       rw [hfirst_eq]
       apply Submodule.subset_span
@@ -159,7 +157,7 @@ theorem isNormal_blockTensor (A : MPSTensor d D) (L : ℕ) (hL : 0 < L)
 /-- Encoding a function `σ₀ : Fin L → Fin d` as a blocked index. -/
 noncomputable def encodeBlock (d L : ℕ) (σ₀ : Fin L → Fin d) :
     Fin (blockPhysDim d L) :=
-  (Fintype.equivFin (Fin L → Fin d)) σ₀
+  Fin.cast (blockPhysDim_eq_pow d L).symm (finFunctionFinEquiv σ₀)
 
 /-- The Kraus operator of the blocked tensor at the encoded index
 equals the word evaluation. -/
@@ -168,9 +166,7 @@ theorem blockTensor_apply_encodeBlock (A : MPSTensor d D) (L : ℕ)
     (blockTensor (d := d) (D := D) A L) (encodeBlock d L σ₀) =
       evalWord A (List.ofFn σ₀) := by
   classical
-  simp only [blockTensor, wordOfBlock, decodeBlock, encodeBlock]
-  congr 1
-  simp [Equiv.symm_apply_apply]
+  simp [blockTensor, wordOfBlock, decodeBlock, encodeBlock, Fin.cast_cast]
 
 /-- **Word eigenvector → single-index eigenvector of the blocked tensor.** -/
 theorem blockTensor_single_eigenvector (A : MPSTensor d D)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1778,7 +1778,6 @@ The following results separate the zero blocks from the nonzero blocks.
 \label{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq}
 	\leanok
-	\uses{def:common_blocked_cyclic_sector_grouped_block_cast}
 	Let $p=m n$.  For every common blocked physical index of length $p$, the
 	word obtained by direct base-$d$ decoding is the same as the word obtained by
 	decoding the index as $n$ consecutive blocks of length $m$ and concatenating

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1774,6 +1774,25 @@ The following results separate the zero blocks from the nonzero blocks.
 	consecutive words of length $m_k$.
 \end{definition}
 
+\begin{theorem}[Flattening direct blocked words]%
+\label{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_grouped_block_cast}
+	Let $p=m n$.  For every common blocked physical index of length $p$, the
+	word obtained by direct base-$d$ decoding is the same as the word obtained by
+	decoding the index as $n$ consecutive blocks of length $m$ and concatenating
+	those $n$ words.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	Compare the $t$th letter in the $j$th block on both sides.  Both readings
+	extract the same base-$d$ digit of the original blocked index, since division
+	by the block powers and reduction modulo the alphabet size commute with this
+	block decomposition.
+\end{proof}
+
 \begin{theorem}[Direct and iterated blocking for weighted blocks]%
 \label{thm:common_blocked_cyclic_sector_blocked_word_comparison}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees,
@@ -3523,9 +3542,9 @@ transport the zero-tail identity through this comparison.
 	then rewrites the one-sided zero-tail identity with the weighted common-length
 	cyclic sectors under this blockwise word equality.
 
-	The mathematical assertion still needed is the corresponding equality, after identifying
-	blocked physical words, between the blocked nonzero part and the
-	cyclic-sector tensor for the whole weighted family.
+	The remaining blocked-word equality, after identifying blocked physical
+	words, is the equality between the blocked nonzero part and the cyclic-sector
+	tensor for the whole weighted family.
 	Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} gives the
 	one-sided form of this conversion, and
 	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_reindexed}
@@ -3538,9 +3557,8 @@ transport the zero-tail identity through this comparison.
 	identities, while
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	collects the resulting primitive irreducible sector decompositions needed for
-	comparison.  The blocked-word assertion is the equality of these
-	words for the chosen coordinates, or an equivalent final comparison with the
-	word identification made explicit.
+	comparison.  Theorem~\ref{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+	supplies the direct word equality for the chosen coordinates.
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_block_span_consequences}
 	records the intermediate span consequence for these common-sector families: a
 	common MPV phase cover or proportional-decomposition conclusion supplies the

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1778,7 +1778,7 @@ The following results separate the zero blocks from the nonzero blocks.
 \label{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq}
 	\leanok
-	Let $p=m n$.  For every common blocked physical index of length $p$, the
+	Let $p=m n$.  For every physical alphabet index $i \in \{0,\ldots,d^p-1\}$, the
 	word obtained by direct base-$d$ decoding is the same as the word obtained by
 	decoding the index as $n$ consecutive blocks of length $m$ and concatenating
 	those $n$ words.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1569,9 +1569,7 @@ two-basis sector comparison theorem.
 \label{thm:unconditional_common_primitive_irreducible_blocks}
 	\lean{MPSTensor.unconditional_commonPrimitiveIrreducibleBlocks}
 	\leanok
-	\uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast,
-		thm:common_grouped_block_cast_to_relabeling,
-		thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+	\uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	Let $A$ and $B$ have the same MPV family.  Then there is a positive blocking
 	length at which both blocked tensors decompose into a zero-tail part and a
 	weighted direct sum of trace-preserving, primitive, tensor-irreducible blocks

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1565,6 +1565,32 @@ two-basis sector comparison theorem.
 	Theorem~\ref{thm:nonzero_block_span_eq_of_proportional_decomposition}.
 \end{proof}
 
+\begin{theorem}[Unconditional common primitive block decompositions]%
+\label{thm:unconditional_common_primitive_irreducible_blocks}
+	\lean{MPSTensor.unconditional_commonPrimitiveIrreducibleBlocks}
+	\leanok
+	\uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast,
+		thm:common_grouped_block_cast_to_relabeling,
+		thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+	Let $A$ and $B$ have the same MPV family.  Then there is a positive blocking
+	length at which both blocked tensors decompose into a zero-tail part and a
+	weighted direct sum of trace-preserving, primitive, tensor-irreducible blocks
+	with positive bond dimensions and nonzero weights.  The two nonzero-sector
+	families have the same positive-length MPV family, and the zero-tail parts
+	satisfy the length-zero identity.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast,
+		thm:common_grouped_block_cast_to_relabeling,
+		thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+	The direct digit computation gives the global coordinate-grouping hypothesis.
+	This implies the blocked-word identification for common sectors.  Applying the
+	common primitive decomposition theorem with this identification gives the
+	unconditional decomposition.
+\end{proof}
+
 \begin{theorem}[Common sectors from phase-cover data]%
 \label{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover}


### PR DESCRIPTION
### Motivation

- `flattenWordOfBlock_cast_eq` was the remaining sorry blocking the common grouped-block assembly chain (see #1137). The mathematical content — that iterated blocking of physical words agrees with direct blocking (arXiv:1708.00029 §3) — requires that nested lexicographic decoding and direct base-`d` digit decoding coincide under the natural currying `Fin (m*n) ≃ Fin n × Fin m`.
- The previous encoding via `Fintype.equivFin` made the direct-vs-iterated blocked-word comparison difficult to complete within Lean's heartbeat limit.

### Description

- Proves `flattenWordOfBlock_cast_eq`: for `p = m * n`, with `h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p`, the identity
  ```
  flattenBlockedWord d m (wordOfBlock (blockPhysDim d m) n (Fin.cast h_card.symm i)) = wordOfBlock d p i
  ```
  holds for every `i : Fin (blockPhysDim d p)`.
- Routes blocked word decoding/encoding through Mathlib's explicit `finFunctionFinEquiv` and `blockPhysDim_eq_pow`, replacing the previously opaque `Fintype.equivFin` path.
- Updates consumers in `Blocking`, `BlockingInfrastructure`, `BlockingTransfer`, `BlockedChainFT`, `NormalReduction/Main`, `Wielandt/RectangularSpan/Basic`, and the common-block assembly theorem.
- Removes stale prose saying the grouped-block cast identity is still open, and makes `unconditional_commonPrimitiveIrreducibleBlocks` use the proved flattening theorem directly.

### Testing

- `lake env lean TNLean/MPS/Core/Blocking.lean`
- `lake env lean TNLean/MPS/Core/BlockingInfrastructure.lean`
- `lake env lean TNLean/MPS/Chain/BlockedChainFT.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition`
- `lake build`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/Chain/BlockedChainFT.lean TNLean/MPS/Core/BlockingInfrastructure.lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `git diff --check`

---
Addresses #1137

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core blocking/encoding utilities (`decodeBlock`, index casting) used broadly across canonical-form proofs; while behavior should be equivalent, mistakes could subtly invalidate downstream theorems or break proof automation.
> 
> **Overview**
> Discharges the previously missing combinatorial lemma `flattenWordOfBlock_cast_eq` by proving a base-`d` digit/block identity, removing a `sorry` and enabling the common-blocking assembly chain to proceed unconditionally.
> 
> Refactors blocked-word encoding/decoding throughout core blocking and downstream consumers to use explicit `finFunctionFinEquiv` plus `blockPhysDim_eq_pow` (instead of `Fintype.equivFin`), updating casts/simp lemmas accordingly, and updates the assembly theorem `unconditional_commonPrimitiveIrreducibleBlocks` to rely directly on the now-proved flattening theorem. Also updates blueprint text to document the new theorems and the now-unconditional result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d37958762f2cc2f845599ae7868f632b64dbb7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->