### PR TITLE
doc(canonical): split weight transport blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1710,9 +1710,7 @@ The following results separate the zero blocks from the nonzero blocks.
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks_irreducible,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim_pos,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonBlockWeight_ne_zero,
-		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero,
-		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_apply_of_block,
-		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_apply_block_eq}
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:tp_primitive_irreducible_extra_blocking,
@@ -1731,6 +1729,34 @@ The following results separate the zero blocks from the nonzero blocks.
 	Apply the extra-blocking theorem to each period-removal sector, substitute the
 	equality between the iterated and common physical alphabets, and use that a
 	positive power of a nonzero complex number is nonzero.
+\end{proof}
+
+\begin{theorem}[Weights of common-alphabet sectors]%
+\label{thm:common_flat_weight_apply_of_block}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_apply_of_block}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_derived_blocks}
+	For a sector $s$ of the original block $k$, the weight assigned to the
+	corresponding common-alphabet sector is $\mu_k^p$.
+\end{theorem}
+
+\begin{proof}\leanok
+	Unfold the flattened-sector indexing and the definition of the transported
+	weight.
+\end{proof}
+
+\begin{theorem}[Equal weights inside one original block]%
+\label{thm:common_flat_weight_apply_block_eq}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_apply_block_eq}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_derived_blocks}
+	All common-alphabet sectors coming from the same original block carry the same
+	transported weight.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:common_flat_weight_apply_of_block}
+	Apply the formula for each sector of the fixed original block.
 \end{proof}
 
 \begin{theorem}[Blocked sectors on a common alphabet]%


### PR DESCRIPTION
## Motivation

The two common-sector weight transport declarations were listed on the broader derived-structure theorem in `ch08_canonical.tex`, but that theorem only states structural preservation and nonzero weights. Issue #1134 asks for blueprint entries whose prose states the exact transported weight formula and the equal-weight property inside one original block.

## Description

- Move `commonFlatWeight_apply_of_block` and `commonFlatWeight_apply_block_eq` out of the derived-properties theorem's `\lean{}` list.
- Add separate theorem entries for the common-alphabet sector weight formula and equal weights inside one original block.
- Keep the proof sketches aligned with the Lean proofs: the first unfolds the flattened-sector indexing, and the second applies the formula for the fixed block.

Closes #1134

## Testing

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint checkdecls`
- `git diff --check`