### PR TITLE
doc(schwarz): add POVM resolvent blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -847,7 +847,12 @@ are not developed in this chapter.
 \end{proof}
 
 \begin{lemma}[Finite-POVM compression identities]\label{lem:operator_jensen_povm_compression}
-    \lean{TNLean.OperatorJensen.povmIsometry_star_mul, TNLean.OperatorJensen.povmIsometry_compress_diagonal, TNLean.OperatorJensen.povm_sum_add_defect, TNLean.OperatorJensen.povmDiagonal_posDef}
+    \lean{TNLean.OperatorJensen.povmIsometry_star_mul,
+        TNLean.OperatorJensen.povmIsometry_compress_diagonal,
+        TNLean.OperatorJensen.povm_sum_add_defect,
+        TNLean.OperatorJensen.povmDiagonal_posDef,
+        TNLean.OperatorJensen.povmDiagonal_inv,
+        TNLean.OperatorJensen.povmIsometry_compress_diagonal_inv}
     \leanok
     If the defect block satisfies
     \[
@@ -863,7 +868,11 @@ are not developed in this chapter.
         \sum_{i \in \iota} C_i C_i^\ast + S S^\ast = \Id,
     \]
     and strict positivity of all weights implies positivity of the scalar
-    block-diagonal matrix.
+    block-diagonal matrix. If the weights and defect scalar are nonzero, the
+    inverse diagonal has reciprocal weights, and compressing this inverse gives
+    \[
+        \sum_{i \in \iota} w_i^{-1}\, C_i C_i^\ast + t^{-1}\, S S^\ast.
+    \]
 \end{lemma}
 
 \begin{proof}
@@ -871,14 +880,40 @@ are not developed in this chapter.
     Expand the block matrix multiplication entrywise. The defect identity gives
     the isometry relation after summing the $\iota$-blocks and the defect block,
     and the weighted compression identity follows from the same expansion with
-    the scalar diagonal inserted. Positivity of the scalar block-diagonal matrix
-    is immediate from positivity of its diagonal entries.
+    the scalar diagonal inserted. Positivity and inversion of the scalar
+    block-diagonal matrix are immediate from the corresponding diagonal entries.
+\end{proof}
+
+\begin{lemma}[Finite-POVM resolvent inequality]\label{lem:operator_jensen_povm_resolvent}
+    \lean{TNLean.OperatorJensen.povm_resolvent_inv_le}
+    \leanok
+    \uses{lem:operator_jensen_povm_compression, lem:operator_jensen_inverse_compression}
+    Let $w_i\ge 0$ and $t>0$. If the defect block satisfies
+    \[
+        S S^\ast = \Id - \sum_{i \in \iota} C_i C_i^\ast,
+    \]
+    then
+    \[
+        \left(\sum_{i \in \iota} w_i\, C_i C_i^\ast + t\,\Id\right)^{-1}
+        \le
+        \sum_{i \in \iota} (w_i+t)^{-1}\, C_i C_i^\ast + t^{-1}\, S S^\ast.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:operator_jensen_povm_compression, lem:operator_jensen_inverse_compression}
+    Apply the compression inequality to the positive scalar block-diagonal matrix
+    with entries $w_i+t$ and defect entry $t$.  The compression identities rewrite
+    the compressed matrix as
+    $\sum_i w_i C_i C_i^\ast + t\Id$ and its inverse compression as the displayed
+    upper bound.
 \end{proof}
 
 \begin{theorem}[Jensen for concave real powers]\label{thm:posMap_rpow_concave_jensen}
     \lean{posMap_rpow_concave_jensen}
     \notready
-    \uses{def:positive_map}
+    \uses{def:positive_map, lem:operator_jensen_povm_resolvent}
     For a positive subunital map $T$ and $p\in[0,1]$:
     \[
         T(A^p) \le (TA)^p.

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -867,9 +867,10 @@ are not developed in this chapter.
     \[
         \sum_{i \in \iota} C_i C_i^\ast + S S^\ast = \Id,
     \]
-    and strict positivity of all weights implies positivity of the scalar
-    block-diagonal matrix. If the weights and defect scalar are nonzero, the
-    inverse diagonal has reciprocal weights, and compressing this inverse gives
+    and strict positivity of all weights together with $t>0$ implies positive
+    definiteness of the scalar block-diagonal matrix. If all weights are nonzero
+    and the defect scalar is nonzero, the inverse diagonal has reciprocal
+    weights, and compressing this inverse gives
     \[
         \sum_{i \in \iota} w_i^{-1}\, C_i C_i^\ast + t^{-1}\, S S^\ast.
     \]
@@ -880,8 +881,9 @@ are not developed in this chapter.
     Expand the block matrix multiplication entrywise. The defect identity gives
     the isometry relation after summing the $\iota$-blocks and the defect block,
     and the weighted compression identity follows from the same expansion with
-    the scalar diagonal inserted. Positivity and inversion of the scalar
-    block-diagonal matrix are immediate from the corresponding diagonal entries.
+    the scalar diagonal inserted. Positive definiteness uses strict positivity
+    of every diagonal entry, while the inverse formula uses the nonvanishing of
+    every diagonal entry.
 \end{proof}
 
 \begin{lemma}[Finite-POVM resolvent inequality]\label{lem:operator_jensen_povm_resolvent}
@@ -903,9 +905,9 @@ are not developed in this chapter.
 \begin{proof}
     \leanok
     \uses{lem:operator_jensen_povm_compression, lem:operator_jensen_inverse_compression}
-    Apply the compression inequality to the positive scalar block-diagonal matrix
-    with entries $w_i+t$ and defect entry $t$.  The compression identities rewrite
-    the compressed matrix as
+    Apply the compression inequality to the positive definite scalar
+    block-diagonal matrix with entries $w_i+t$ and defect entry $t$.  The
+    compression identities rewrite the compressed matrix as
     $\sum_i w_i C_i C_i^\ast + t\Id$ and its inverse compression as the displayed
     upper bound.
 \end{proof}


### PR DESCRIPTION
### Motivation

- Issue LionSR/QICLean#148 identified three fully proved declarations in `TNLean/Channel/Schwarz/OperatorJensenAux.lean` (introduced in LionSR/TNLean#1112) that lacked blueprint entries in `blueprint/src/chapter/ch05_schwarz.tex`.
- The absent entries cover: the inverse of the finite-POVM diagonal block matrix, the corresponding POVM isometry compression identity, and the resolvent inequality that enters the Löwner-integral representation of the concave real-power Jensen inequality (Wolf Corollary 5.2).

### Description

- Appends `\lean{}` tags for `TNLean.OperatorJensen.povmDiagonal_inv` and `TNLean.OperatorJensen.povmIsometry_compress_diagonal_inv` to the existing `lem:operator_jensen_povm_compression` entry in `ch05_schwarz.tex`.
  - `povmDiagonal_inv`: when all block weights $w_i$ and the defect scalar $t$ are nonzero, $(D_{w,t})^{-1} = D_{w^{-1},\,t^{-1}}$.
  - `povmIsometry_compress_diagonal_inv`: compressing $(D_{w,t})^{-1}$ by the POVM isometry $W$ yields $\sum_i (w_i)^{-1} C_i C_i^* + t^{-1} S S^*$.
- Inserts a new lemma block for the finite-POVM resolvent inequality: for $w_i \ge 0$, $t > 0$, and $SS^* = I - \sum_i C_i C_i^*$,
$$\bigl(\textstyle\sum_i w_i C_i C_i^* + tI\bigr)^{-1} \le \sum_i (w_i+t)^{-1} C_i C_i^* + t^{-1} S S^*,$$
with `\lean{TNLean.OperatorJensen.povm_resolvent_inv_le}`, `\leanok` on both the statement and proof, and `\uses{lem:operator_jensen_povm_compression, lem:operator_jensen_inverse_compression}`.

### Testing

- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint checkdecls`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the build.

---
Closes LionSR/QICLean#148

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates LaTeX blueprint statements/Lean tags and adds a new lemma entry without affecting executable code.
> 
> **Overview**
> Adds missing blueprint coverage for finite-POVM diagonal inversion and inverse-compression by extending `lem:operator_jensen_povm_compression` with new `\lean{}` tags and corresponding statement/proof text (including positive definiteness and reciprocal-weight formulas).
> 
> Introduces a new `lem:operator_jensen_povm_resolvent` blueprint lemma (tagged to `TNLean.OperatorJensen.povm_resolvent_inv_le`) and wires it into the dependency chain by referencing it from `thm:posMap_rpow_concave_jensen` via `\uses{...}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b83dd31ca1f0469e0e47dd64f031bfadb0997eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->