### PR TITLE
doc(blueprint): add BNT cover hypothesis blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1404,6 +1404,56 @@ two-basis sector comparison theorem.
 	equality together with the zero-tail and injectivity hypotheses.
 \end{proof}
 
+\begin{definition}[BNT-cover hypotheses for common primitive sectors]%
+\label{def:common_primitive_bnt_cover_hypotheses}
+	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses}
+	\leanok
+	\uses{def:is_normal_canonical_form, def:blocks_not_gauge_phase_equiv,
+		def:injective}
+	For two common primitive nonzero-sector families at one blocking length, this
+	condition records the BNT data needed to construct a common MPV phase cover:
+	normal canonical-form data on both sides, separation of distinct sectors by
+	gauge phase, equality of the zero-tail dimensions, one-site injectivity, and a
+	proportional-decomposition comparison.
+\end{definition}
+
+\begin{theorem}[BNT-cover hypotheses produce a common phase cover]%
+\label{thm:common_primitive_bnt_cover_hypotheses_to_common_phase_cover}
+	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses.toMPVCommonPhaseCover}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		def:mpv_common_phase_cover,
+		thm:common_phase_cover_of_separated_normal_bnt}
+	If two common primitive nonzero-sector families satisfy the BNT-cover
+	hypotheses, then they have a common MPV phase cover.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_phase_cover_of_separated_normal_bnt}
+	The normal canonical-form data, gauge-phase separation, and proportional
+	decomposition are exactly the hypotheses of
+	Theorem~\ref{thm:common_phase_cover_of_separated_normal_bnt}.
+\end{proof}
+
+\begin{theorem}[BNT-cover hypotheses imply phase-cover hypotheses]%
+\label{thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses}
+	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses.toCommonPrimitivePhaseCoverHypotheses}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		def:common_primitive_phase_cover_hypotheses}
+	If two common primitive nonzero-sector families satisfy the BNT-cover
+	hypotheses, then they satisfy the phase-cover hypotheses of
+	Definition~\ref{def:common_primitive_phase_cover_hypotheses}.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_primitive_bnt_cover_hypotheses_to_common_phase_cover}
+	The zero-tail equality and injectivity assumptions are part of the BNT-cover
+	hypotheses. The preceding theorem supplies the common MPV phase cover.
+\end{proof}
+
 \begin{theorem}[Sector comparison from a common phase cover]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1413,8 +1413,8 @@ two-basis sector comparison theorem.
 	For two common primitive nonzero-sector families at one blocking length, this
 	condition records the BNT data needed to construct a common MPV phase cover:
 	normal canonical-form data on both sides, separation of distinct sectors by
-	gauge phase, equality of the zero-tail dimensions, one-site injectivity, and a
-	proportional-decomposition comparison.
+	gauge-phase equivalence, equality of the zero-tail dimensions, one-site
+	injectivity, and a proportional-decomposition comparison.
 \end{definition}
 
 \begin{theorem}[BNT-cover hypotheses produce a common phase cover]%
@@ -1422,8 +1422,7 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses.toMPVCommonPhaseCover}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
-		def:mpv_common_phase_cover,
-		thm:common_phase_cover_of_separated_normal_bnt}
+		def:mpv_common_phase_cover}
 	If two common primitive nonzero-sector families satisfy the BNT-cover
 	hypotheses, then they have a common MPV phase cover.
 \end{theorem}


### PR DESCRIPTION
### Motivation

- `CommonPrimitiveBNTCoverHypotheses` and its two bridge theorems were added in PR #1127, but Chapter 11 of the blueprint (`ch11_assembly.tex`) did not yet have matching entries. This closes the blueprint-sync follow-up in #1131.

### Description

- Adds a definition entry for `MPSTensor.CommonPrimitiveBNTCoverHypotheses`.
- Adds theorem entries for:
  - `MPSTensor.CommonPrimitiveBNTCoverHypotheses.toMPVCommonPhaseCover`
  - `MPSTensor.CommonPrimitiveBNTCoverHypotheses.toCommonPrimitivePhaseCoverHypotheses`
- Places the new entries next to the proportional-comparison hypothesis entries in `ch11_assembly.tex`, following the format of the parallel `CommonPrimitiveProportionalHypotheses` block at lines 1357–1389.

### Testing

- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (local generated file only; not committed)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Closes #1131

> [!NOTE]
> **Low Risk**
> Documentation-only change adding blueprint entries; no runtime/logic impact beyond potential cross-referencing/Lean declaration sync issues.
>
> **Overview**
> Adds missing Chapter 11 blueprint entries for `MPSTensor.CommonPrimitiveBNTCoverHypotheses` and two associated bridge theorems that (1) derive a common MPV phase cover and (2) turn BNT-cover hypotheses into the existing phase-cover hypotheses.
>
> Places these new definition/theorem blocks next to the existing proportional-comparison/phase-cover hypothesis material to keep the blueprint aligned with the corresponding Lean declarations.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b50b215c4e271370057574f7c43026d169528438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adds blueprint definition/theorem stubs and cross-references without altering any Lean code or runtime behavior; main risk is broken LaTeX/Lean-decl linkage if labels or `\lean{}` names are wrong.
> 
> **Overview**
> Adds a new blueprint **definition** for `MPSTensor.CommonPrimitiveBNTCoverHypotheses` (BNT data needed to build a common MPV phase cover for common primitive sectors).
> 
> Adds two new blueprint **bridge theorems** showing these hypotheses (1) produce a `MPVCommonPhaseCover` and (2) imply the existing `CommonPrimitivePhaseCoverHypotheses`, with accompanying `\uses{...}` dependencies and proof sketches placed next to the existing proportional/phase-cover hypothesis material.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d952519f84a92b57396c2dcd63013c8cd3c88c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->