### PR TITLE
doc(canonical): add block-grouping blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1236,6 +1236,38 @@ The following results separate the zero blocks from the nonzero blocks.
 	evaluations, and hence all MPV coefficients, agree.
 \end{proof}
 
+\begin{theorem}[Block-grouping bijection recovers direct blocking]
+	\label{thm:reindex_direct_to_iterated_block_tensor}
+	\lean{MPSTensor.reindexPhysical_directToIteratedBlockIndex_blockTensor}
+	\leanok
+	\uses{def:blocked_tensor}
+	Reindexing the physical alphabet of the iterated block tensor by the
+	consecutive-grouping bijection returns the tensor obtained by blocking
+	$mn$ original sites directly.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:iterated_blocking_samempv_reindex}
+	Apply the iterated-to-direct blocking identity and cancel the forward and
+	inverse maps of the grouping bijection.
+\end{proof}
+
+\begin{corollary}[Block-grouping bijection preserves the MPV family]
+	\label{cor:samempv2_reindex_direct_to_iterated_block_tensor}
+	\lean{MPSTensor.sameMPV₂_reindexPhysical_directToIteratedBlockIndex_blockTensor}
+	\leanok
+	\uses{def:same_mpv2, def:blocked_tensor}
+	Under the block-grouping bijection, the iterated block tensor and the
+	directly blocked tensor have the same matrix-product-vector family.
+\end{corollary}
+
+\begin{proof}
+	\leanok
+	\uses{thm:reindex_direct_to_iterated_block_tensor}
+	This is the matrix-product-vector form of the preceding tensor identity.
+\end{proof}
+
 \begin{theorem}[Physical-dimension transport and MPV equality]
 	\label{thm:samempv_cast_phys_dim}
 	\lean{MPSTensor.sameMPV₂_cast_physDim}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1248,9 +1248,8 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{proof}
 	\leanok
-	\uses{thm:iterated_blocking_samempv_reindex}
-	Apply the iterated-to-direct blocking identity and cancel the forward and
-	inverse maps of the grouping bijection.
+	Apply the tensor-level direct-to-iterated blocking identity and cancel the
+	forward and inverse maps of the grouping bijection.
 \end{proof}
 
 \begin{corollary}[Block-grouping bijection preserves the MPV family]


### PR DESCRIPTION
### Motivation
- Blueprint chapter `ch08_canonical.tex` has no entries for two theorems introduced in #1110 (`feat(MPS/Core): relate iterated blocking to direct blocking via reindexPhysical`).
- The Lean declarations `MPSTensor.reindexPhysical_directToIteratedBlockIndex_blockTensor` and `MPSTensor.sameMPV₂_reindexPhysical_directToIteratedBlockIndex_blockTensor` appear in `TNLean/MPS/Core/BlockingInfrastructure.lean` (lines 503–530) without corresponding blueprint entries.

### Description
- Modified `blueprint/src/chapter/ch08_canonical.tex`, adding two entries immediately after `thm:iterated_blocking_samempv_reindex`:
  - `thm:reindex_direct_to_iterated_block_tensor`: for `A : MPSTensor d D` and natural numbers `m`, `n`, reindexing the physical alphabet of the iterated block tensor by the consecutive-grouping bijection `directToIteratedBlockIndex d m n` yields the directly blocked tensor at length `m * n`.
  - `cor:samempv2_reindex_direct_to_iterated_block_tensor`: immediate corollary that the reindexed iterated block tensor and the directly blocked tensor have the same matrix-product-vector family.
- Both entries carry `\lean{}`, `\leanok`, and `\uses{}` tags; proof-level `\uses{}` dependencies are placed inside the proof environment.

### Testing
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `lake build`

---
Closes #1119

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change adding blueprint statements/proofs that reference existing Lean theorems, with no runtime or library logic modifications.
> 
> **Overview**
> Adds two new blueprint entries in `ch08_canonical.tex` formalizing the *block-grouping bijection* connection between iterated blocking and direct blocking.
> 
> Introduces `thm:reindex_direct_to_iterated_block_tensor` (tensor equality via reindexing) and its corollary `cor:samempv2_reindex_direct_to_iterated_block_tensor` (preservation of the MPV family), each linked to the corresponding Lean declarations and `\uses{}` dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c918d173c4d32b0c0b7bbbdc0e3cadf779e37205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->