### PR TITLE
doc(canonical): add sector rigidity blueprint entry

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2199,6 +2199,29 @@ The following results separate the zero blocks from the nonzero blocks.
 	using the cyclic relation $\E_A^\dagger(P_k)=P_{k-1}$.
 \end{proof}
 
+\begin{theorem}[Sector fixed-point-algebra rigidity for trace-preserving tensors]%
+	\label{thm:sector_fixed_algebra_irred_tp}
+	\lean{MPSTensor.sectorFixedPointAlgebraRigidity_of_irreducible_tp}
+	\leanok
+	\uses{def:sector_fixed_point_algebra_rigidity, thm:sector_fixed_algebra_irred_cyclic}
+	Let $A$ be an irreducible trace-preserving MPS tensor, and let
+	$(P_k)_{k=1}^m$ be cyclic orthogonal sector projections for
+	$\E_A^\dagger$ with $\sum_k P_k = \Id$. Then the sector
+	fixed-point-algebra rigidity property holds for $\E_A^\dagger$.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{def:sector_fixed_point_algebra_rigidity, thm:md_characterization,
+		thm:sector_fixed_algebra_irred_cyclic}
+	The trace-preserving hypothesis makes $\E_A^\dagger$ unital. The cyclic
+	shift relation and Kadison--Schwarz equality place each sector projection in
+	the multiplicative domain of the adjoint Kraus family, by
+	Theorem~\ref{thm:md_characterization}. Hence multiplication by a sector
+	projection is preserved by $\E_A^\dagger$.
+	Theorem~\ref{thm:sector_fixed_algebra_irred_cyclic} then gives the sector
+	fixed-point-algebra rigidity property.
+\end{proof}
+
 \begin{theorem}[Sector fixed-point-algebra rigidity from scalar blocked fixed points]%
 	\label{thm:sector_fixed_algebra_scalar_blocked}
 	\lean{MPSTensor.sectorFixedPointAlgebraRigidity_of_cyclic_decomp_after_blocking_of_scalarBlockedFixedPoints}


### PR DESCRIPTION
### Motivation
- `MPSTensor.sectorFixedPointAlgebraRigidity_of_irreducible_tp` was proved in PR #1107 but the corresponding blueprint entry was not added at that time, leaving the blueprint out of sync with the Lean code (see #1115).

### Description
- Adds theorem block `thm:sector_fixed_algebra_irred_tp` to `blueprint/src/chapter/ch08_canonical.tex`, inserted directly after the adjacent entry `thm:sector_fixed_algebra_irred_cyclic`.
- The block carries `\lean{MPSTensor.sectorFixedPointAlgebraRigidity_of_irreducible_tp}`, `\leanok` on the statement, and `\begin{proof}\leanok` (proof is complete; no sorrys remain).
- `\uses{thm:sector_fixed_algebra_irred_cyclic, def:sector_fixed_point_algebra_rigidity}` appears in both the statement and proof environments.
- The theorem states: given an irreducible trace-preserving MPS tensor with a cyclic family of orthogonal sector projections, trace preservation implies unitality of the Kraus family, and a Kadison–Schwarz multiplicative-domain argument yields sector fixed-point-algebra rigidity for the adjoint transfer map.

### Testing
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Closes #1115

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a missing theorem/proof block; no executable code or formal statements are modified, but it should be checked for correct references/labels and Lean declaration linkage.
>
> **Overview**
> Adds a missing Chapter 8 blueprint theorem/proof block, `Sector fixed-point-algebra rigidity for trace-preserving tensors` (`thm:sector_fixed_algebra_irred_tp`), including its `\lean{MPSTensor.sectorFixedPointAlgebraRigidity_of_irreducible_tp}` tag.
>
> The new proof explains how trace preservation implies unitality and, combined with the cyclic shift/Kadison–Schwarz multiplicative-domain argument, reduces the result to the existing cyclic irreducibility theorem.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb1d9ddc7785db7100617874c068af434692086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a missing blueprint theorem/proof block; main risk is incorrect LaTeX label/Lean declaration linkage or `\uses` references.
> 
> **Overview**
> Adds a new Chapter 8 blueprint theorem/proof block, **"Sector fixed-point-algebra rigidity for trace-preserving tensors"** (`thm:sector_fixed_algebra_irred_tp`), including `\lean{MPSTensor.sectorFixedPointAlgebraRigidity_of_irreducible_tp}` and `\leanok` markers.
> 
> The inserted proof sketches the trace-preserving ⇒ unital step and a multiplicative-domain/Kadison–Schwarz argument to reduce the result to the existing cyclic irreducibility rigidity theorem, keeping blueprint references in sync with the Lean development.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66976e43bde965278fbe3a8e21778aec4a706b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->