### PR TITLE
fix(channel): align Lorentz normal-form predicate

### DIFF
--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -291,12 +291,16 @@ In Pauli-entry terms:
 def IsLorentzNonDiagonal
     (T' : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
   IsChannel T' ∧
-    pauliTransferEntry T' 3 0 = (2/3 : ℂ) ∧
-    pauliTransferEntry T' 1 0 = 0 ∧ pauliTransferEntry T' 2 0 = 0 ∧
-    pauliTransferEntry T' 3 3 = (1/3 : ℂ) ∧
-    pauliTransferEntry T' 1 1 = pauliTransferEntry T' 2 2 ∧
-    (∀ (i j : Fin 4), i ≠ j → pauliTransferEntry T' i j = 0 ∨
-      (i = 3 ∧ j = 0) ∨ (i = 1 ∧ j = 1) ∨ (i = 2 ∧ j = 2) ∨ (i = 3 ∧ j = 3))
+    ∃ x : ℝ, 0 ≤ x ∧ x ≤ 1 ∧
+      pauliTransferEntry T' 0 0 = 1 ∧
+      (∀ j : Fin 4, j ≠ 0 → pauliTransferEntry T' 0 j = 0) ∧
+      pauliTransferEntry T' 3 0 = (2/3 : ℂ) ∧
+      pauliTransferEntry T' 1 0 = 0 ∧ pauliTransferEntry T' 2 0 = 0 ∧
+      pauliTransferEntry T' 1 1 = ((x / Real.sqrt 3 : ℝ) : ℂ) ∧
+      pauliTransferEntry T' 2 2 = ((x / Real.sqrt 3 : ℝ) : ℂ) ∧
+      pauliTransferEntry T' 3 3 = (1/3 : ℂ) ∧
+      ∀ (i j : Fin 4), i ≠ j → (i, j) ≠ ((3 : Fin 4), (0 : Fin 4)) →
+        pauliTransferEntry T' i j = 0
 
 /-- A Hermiticity-preserving TP qubit channel `T'` is in **singular Lorentz normal
 form** (Wolf Proposition 2.9, case 3) if its Pauli-basis transfer matrix has

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -2196,8 +2196,9 @@ This subsection records the existence statements from
 
 \begin{definition}[Diagonal Lorentz normal form]\label{def:lorentz_diagonal}
     \lean{Wolf.IsLorentzDiagonal}\leanok
-    For a qubit channel $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$
-    for its matrix in the normalized Pauli basis
+    For a completely positive, trace-preserving qubit channel
+    $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$ for its matrix
+    in the normalized Pauli basis
     $\{\sigma_{0}/\sqrt{2},\sigma_{1}/\sqrt{2},
     \sigma_{2}/\sqrt{2},\sigma_{3}/\sqrt{2}\}$.  The channel is in
     \emph{diagonal Lorentz normal form} when it is unital and every
@@ -2206,9 +2207,10 @@ This subsection records the existence statements from
 
 \begin{definition}[Non-diagonal Lorentz normal form]\label{def:lorentz_non_diagonal}
     \lean{Wolf.IsLorentzNonDiagonal}\leanok
-    For a qubit channel $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$
-    in the normalized Pauli basis.  The channel is in \emph{non-diagonal
-    Lorentz normal form} when, for some $x \in [0,1]$,
+    For a completely positive, trace-preserving qubit channel
+    $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$ in the normalized
+    Pauli basis.  The channel is in \emph{non-diagonal Lorentz normal form}
+    when, for some $x \in [0,1]$,
     \[
         \widehat{T'} =
         \begin{pmatrix}
@@ -2222,9 +2224,9 @@ This subsection records the existence statements from
 
 \begin{definition}[Singular Lorentz normal form]\label{def:lorentz_singular}
     \lean{Wolf.IsLorentzSingular}\leanok
-    For a qubit channel $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$
-    in the normalized Pauli basis.  The channel is in \emph{singular Lorentz
-    normal form} when
+    For a completely positive, trace-preserving qubit channel
+    $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$ in the normalized
+    Pauli basis.  The channel is in \emph{singular Lorentz normal form} when
     \[
         \widehat{T'} =
         \begin{pmatrix}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -2208,11 +2208,16 @@ This subsection records the existence statements from
     \lean{Wolf.IsLorentzNonDiagonal}\leanok
     For a qubit channel $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$
     in the normalized Pauli basis.  The channel is in \emph{non-diagonal
-    Lorentz normal form} when
-    $\widehat{T'}_{30}=2/3$, $\widehat{T'}_{10}=\widehat{T'}_{20}=0$,
-    $\widehat{T'}_{33}=1/3$, the entries $\widehat{T'}_{11}$ and
-    $\widehat{T'}_{22}$ are equal, and every off-diagonal entry of
-    $\widehat{T'}$ vanishes except possibly $\widehat{T'}_{30}$.
+    Lorentz normal form} when, for some $x \in [0,1]$,
+    \[
+        \widehat{T'} =
+        \begin{pmatrix}
+            1 & 0 & 0 & 0 \\
+            0 & x/\sqrt{3} & 0 & 0 \\
+            0 & 0 & x/\sqrt{3} & 0 \\
+            2/3 & 0 & 0 & 1/3
+        \end{pmatrix}.
+    \]
 \end{definition}
 
 \begin{definition}[Singular Lorentz normal form]\label{def:lorentz_singular}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -2194,9 +2194,53 @@ This subsection records the existence statements from
     \textbf{Not yet proved}---proof blocked on Lemma~\ref{lem:infimum_is_attained}.
 \end{theorem}
 
+\begin{definition}[Diagonal Lorentz normal form]\label{def:lorentz_diagonal}
+    \lean{Wolf.IsLorentzDiagonal}\leanok
+    For a qubit channel $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$
+    for its matrix in the normalized Pauli basis
+    $\{\sigma_{0}/\sqrt{2},\sigma_{1}/\sqrt{2},
+    \sigma_{2}/\sqrt{2},\sigma_{3}/\sqrt{2}\}$.  The channel is in
+    \emph{diagonal Lorentz normal form} when it is unital and every
+    off-diagonal entry of $\widehat{T'}$ is zero.
+\end{definition}
+
+\begin{definition}[Non-diagonal Lorentz normal form]\label{def:lorentz_non_diagonal}
+    \lean{Wolf.IsLorentzNonDiagonal}
+    For a qubit channel $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$
+    in the normalized Pauli basis.  The channel is in \emph{non-diagonal
+    Lorentz normal form} when, for some $x \in [0,1]$,
+    \[
+        \widehat{T'} =
+        \begin{pmatrix}
+            1 & 0 & 0 & 0 \\
+            0 & x/\sqrt{3} & 0 & 0 \\
+            0 & 0 & x/\sqrt{3} & 0 \\
+            2/3 & 0 & 0 & 1/3
+        \end{pmatrix}.
+    \]
+\end{definition}
+
+\begin{definition}[Singular Lorentz normal form]\label{def:lorentz_singular}
+    \lean{Wolf.IsLorentzSingular}\leanok
+    For a qubit channel $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$
+    in the normalized Pauli basis.  The channel is in \emph{singular Lorentz
+    normal form} when
+    \[
+        \widehat{T'} =
+        \begin{pmatrix}
+            1 & 0 & 0 & 0 \\
+            0 & 0 & 0 & 0 \\
+            0 & 0 & 0 & 0 \\
+            1 & 0 & 0 & 0
+        \end{pmatrix},
+    \]
+    equivalently, every input state is mapped to $(1+\sigma_{3})/2$.
+\end{definition}
+
 \begin{theorem}[Lorentz normal form for qubit channels]\label{thm:lorentz_normal_form_qubit}
     \lean{Wolf.exists_lorentz_normal_form_qubit}
-    \uses{def:sl_filtering, lem:infimum_is_attained}
+    \uses{def:sl_filtering, lem:infimum_is_attained, def:lorentz_diagonal,
+    def:lorentz_non_diagonal, def:lorentz_singular}
     For every qubit channel $T : M_{2}(\mathbb{C}) \to M_{2}(\mathbb{C})$,
     there exist $\SL(2, \mathbb{C})$-filterings $\Phi_{1}, \Phi_{2}$ such that
     the filtered channel $T' = \Phi_{2} \circ T \circ \Phi_{1}$ is in one of

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -2205,19 +2205,14 @@ This subsection records the existence statements from
 \end{definition}
 
 \begin{definition}[Non-diagonal Lorentz normal form]\label{def:lorentz_non_diagonal}
-    \lean{Wolf.IsLorentzNonDiagonal}
+    \lean{Wolf.IsLorentzNonDiagonal}\leanok
     For a qubit channel $T' : M_{2}(\C) \to M_{2}(\C)$, write $\widehat{T'}$
     in the normalized Pauli basis.  The channel is in \emph{non-diagonal
-    Lorentz normal form} when, for some $x \in [0,1]$,
-    \[
-        \widehat{T'} =
-        \begin{pmatrix}
-            1 & 0 & 0 & 0 \\
-            0 & x/\sqrt{3} & 0 & 0 \\
-            0 & 0 & x/\sqrt{3} & 0 \\
-            2/3 & 0 & 0 & 1/3
-        \end{pmatrix}.
-    \]
+    Lorentz normal form} when
+    $\widehat{T'}_{30}=2/3$, $\widehat{T'}_{10}=\widehat{T'}_{20}=0$,
+    $\widehat{T'}_{33}=1/3$, the entries $\widehat{T'}_{11}$ and
+    $\widehat{T'}_{22}$ are equal, and every off-diagonal entry of
+    $\widehat{T'}$ vanishes except possibly $\widehat{T'}_{30}$.
 \end{definition}
 
 \begin{definition}[Singular Lorentz normal form]\label{def:lorentz_singular}


### PR DESCRIPTION
### Motivation

- The Lorentz normal-form blueprint needs definition blocks for the three Wolf Prop. 2.11 cases (#1120).
- The existing `Wolf.IsLorentzNonDiagonal` predicate was weaker than the Wolf non-diagonal case: it did not encode the `x \in [0,1]` witness or the `x/\sqrt{3}` diagonal entries (#1118).

### Description

- Adds blueprint definition environments for `Wolf.IsLorentzDiagonal`, `Wolf.IsLorentzNonDiagonal`, and `Wolf.IsLorentzSingular`.
- Updates `thm:lorentz_normal_form_qubit` to use the three new definition labels.
- Strengthens `Wolf.IsLorentzNonDiagonal` to encode the Wolf case-2 transfer matrix with an explicit real `x`, `0 <= x <= 1`, diagonal entries `x / sqrt 3`, fixed translation `2/3`, and off-diagonal zeros except the translation entry.
- Marks the non-diagonal blueprint definition `\leanok` after aligning the Lean predicate with the displayed matrix.

### Testing

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake env lean TNLean/Channel/LorentzNormalForm.lean`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

Fixes LionSR/QICLean#145.
Closes LionSR/QICLean#144.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because `Wolf.IsLorentzNonDiagonal` is strengthened (adds an `x ∈ [0,1]` witness and tighter transfer-matrix equalities), which may break or require updates to any downstream lemmas relying on the previous weaker predicate.
> 
> **Overview**
> Aligns the formal Lorentz normal-form predicates with the intended Wolf case split.
> 
> `Wolf.IsLorentzNonDiagonal` is strengthened to explicitly encode the case-2 Pauli transfer matrix: introduces a real parameter `x` with `0 ≤ x ≤ 1`, pins the diagonal entries to `x/√3` and `1/3`, enforces TP/unital-related first-row constraints, and requires all off-diagonal entries to be zero except `(3,0)=2/3`.
> 
> The blueprint now includes definition blocks for the three Lorentz normal forms (`diagonal`, `non-diagonal`, `singular`) and updates the qubit Lorentz normal form theorem’s `\uses` list to reference these new definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ddaace0a20018b25468ae2d3bd14dcb20afb36b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->