### PR TITLE
feat(MPS/CanonicalForm): derive sector overlap-span from BNT cover hypotheses

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -26,6 +26,9 @@ BNT proportional-decomposition comparison of the nonzero-weight block families.
   common-length cyclic-sector output, together with the blocked-word relabeling
   equality and the remaining zero-tail, injectivity, and common-cover assertions,
   implies the sector-weight comparison.
+* `sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover` — the same
+  common-length cyclic-sector output, with the overlap-span hypotheses obtained from
+  BNT-cover data.
 * `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion` —
   the zero-tail common-cover theorem applied to BNT proportional-decomposition data.
 * `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses` —
@@ -823,6 +826,80 @@ theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCov
       _ = mpv Q.toTensor σ := (hQblocks N σ).symm
   exact ⟨p, hp, P, Q, hPQeq, hPbnt, hQbnt, hOverlapSpan⟩
 
+/-- **Sector basis overlap-span data via BNT-cover hypotheses.**
+
+This is the BNT-cover variant of
+`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover`.
+The remaining input provides the BNT-level data for the produced nonzero-sector
+families, with whatever total dimensions support the proportional-decomposition
+data. The BNT-cover bridge converts that data to common primitive phase-cover
+hypotheses, and the common-phase-cover theorem supplies the overlap-span data. -/
+theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      [∀ x : Fin rA, NeZero (dimA x)]
+      [∀ x : Fin rB, NeZero (dimB x)]
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      ∃ DtotA DtotB,
+        Nonempty
+          (CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+            (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB)) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      SectorBasisOverlapSpanHypotheses P Q := by
+  refine sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover
+    A B hSame hReindexed ?_
+  intro p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB hp
+    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
+    hIrrA hIrrB hDimA hDimB
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  obtain ⟨DtotA, DtotB, ⟨hBNTCover⟩⟩ :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  exact hBNTCover.toCommonPrimitivePhaseCoverHypotheses
+
 /-- **Sector basis overlap-span data via a BNT proportional-decomposition comparison.**
 
 This is the proportional-comparison variant of
@@ -1072,6 +1149,88 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonP
     hIrrA hIrrB hDimA hDimB
   exact (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
     hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toSpanHypotheses
+
+/-- **Sector comparison from relabeled common sectors and BNT-cover data.**
+
+Assume the blocked-word relabeling statement for cyclic-sector data. The structural
+theorem supplies common primitive nonzero-sector families; if those families carry
+BNT-cover data, then the BNT-cover bridge gives the common phase-cover hypotheses.
+The common-phase-cover consumer theorem then gives the same sector-weight comparison
+conclusion. -/
+theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      [∀ x : Fin rA, NeZero (dimA x)]
+      [∀ x : Fin rB, NeZero (dimB x)]
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      ∃ DtotA DtotB,
+        Nonempty
+          (CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+            (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB)) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  refine afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover
+    A B hSame hReindexed ?_
+  intro p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB hp
+    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
+    hIrrA hIrrB hDimA hDimB
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  obtain ⟨DtotA, DtotB, ⟨hBNTCover⟩⟩ :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  exact hBNTCover.toCommonPrimitivePhaseCoverHypotheses
 
 /-- **Sector comparison from relabeled common sectors and proportional-decomposition data.**
 

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -832,8 +832,8 @@ This is the BNT-cover variant of
 `sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover`.
 The remaining input provides the BNT-level data for the produced nonzero-sector
 families, with whatever total dimensions support the proportional-decomposition
-data. The BNT-cover bridge converts that data to common primitive phase-cover
-hypotheses, and the common-phase-cover theorem supplies the overlap-span data. -/
+data. The conversion from BNT-cover hypotheses to common primitive phase-cover
+hypotheses then lets the common-phase-cover theorem supply the overlap-span data. -/
 theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -1154,8 +1154,9 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonP
 
 Assume the blocked-word relabeling statement for cyclic-sector data. The structural
 theorem supplies common primitive nonzero-sector families; if those families carry
-BNT-cover data, then the BNT-cover bridge gives the common phase-cover hypotheses.
-The common-phase-cover consumer theorem then gives the same sector-weight comparison
+BNT-cover data, then the conversion to phase-cover hypotheses gives the common
+phase-cover hypotheses. The common-phase-cover consumer theorem gives the same
+sector-weight comparison
 conclusion. -/
 theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
     {d D₁ D₂ : ℕ}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1453,6 +1453,29 @@ two-basis sector comparison theorem.
 	hypotheses. The preceding theorem supplies the common MPV phase cover.
 \end{proof}
 
+\begin{theorem}[BNT-cover data give overlap-span hypotheses]%
+\label{thm:sector_basis_overlap_span_reindexed_bnt_cover}
+	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses}
+	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
+	identification hypothesis for the cyclic-sector data. The common-sector
+	structural theorem produces common primitive nonzero-sector families. If those
+	families satisfy the BNT-cover hypotheses, then the associated sector
+	decompositions have BNT data, agree as full MPV families, and satisfy the
+	primitive overlap-span hypotheses.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses,
+		thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	Convert the BNT-cover hypotheses for the produced families into common
+	phase-cover hypotheses. The common phase-cover construction then gives the
+	sector decompositions and their primitive overlap-span hypotheses.
+\end{proof}
+
 \begin{theorem}[Sector comparison from a common phase cover]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
@@ -1663,6 +1686,28 @@ two-basis sector comparison theorem.
 		to form the span hypotheses of
 	Definition~\ref{def:common_primitive_span_hypotheses}.  Then apply the
 	common-sector comparison theorem with those span hypotheses.
+\end{proof}
+
+\begin{theorem}[Common sectors from BNT-cover data]%
+\label{thm:afterBlocking_sectorComparison_reindexed_bntCover}
+	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		def:common_sector_relabeling_hypothesis}
+	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
+	identification hypothesis for the cyclic-sector data. The common-sector
+	structural theorem produces the common primitive nonzero-sector families. If
+	those families satisfy the BNT-cover hypotheses, then the same sector-weight
+	comparison conclusion holds.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses,
+		thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	Convert the BNT-cover hypotheses for the produced families to common
+	phase-cover hypotheses, and then apply the common-sector comparison theorem
+	with common phase-cover data.
 \end{proof}
 
 \begin{theorem}[Common sectors from proportional-comparison data]%

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1458,7 +1458,7 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
-		thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses}
+		def:common_sector_relabeling_hypothesis}
 	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
 	identification hypothesis for the cyclic-sector data. The common-sector
 	structural theorem produces common primitive nonzero-sector families. If those
@@ -1469,8 +1469,7 @@ two-basis sector comparison theorem.
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses,
-		thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	\uses{thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses}
 	Convert the BNT-cover hypotheses for the produced families into common
 	phase-cover hypotheses. The common phase-cover construction then gives the
 	sector decompositions and their primitive overlap-span hypotheses.


### PR DESCRIPTION
### Motivation
- The proportional-case fundamental theorem requires `SectorBasisOverlapSpanHypotheses` and an after-blocking sector weight comparison for BNT sector decompositions; no direct path from `CommonPrimitiveBNTCoverHypotheses` to these results existed (see #1114, tracking #942, #944).
- The BNT decomposition from `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` produces cover data in a form distinct from what the existing common phase-cover results require, so intermediate theorems converting between the two forms are needed.

### Description
- `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`: adds two theorems taking `CommonPrimitiveBNTCoverHypotheses` as hypothesis:
  1. A theorem establishing `SectorBasisOverlapSpanHypotheses` by converting BNT cover data to common phase-cover form and applying the existing overlap-span result.
  2. A theorem establishing the after-blocking sector weight comparison by the same conversion.
- `blueprint/src/chapter/ch11_assembly.tex`: documents and references both theorems with `\lean{}` and `\leanok` tags.

### Testing
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Closes #1114

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems that reuse existing bridges from `CommonPrimitiveBNTCoverHypotheses` to common phase-cover/span results, plus corresponding blueprint documentation; no existing logic is modified.
>
> **Overview**
> Adds two new BNT-cover theorems that let downstream proofs derive (1) `SectorBasisOverlapSpanHypotheses` and (2) the after-blocking sector-weight comparison directly from `CommonPrimitiveBNTCoverHypotheses`, by first converting BNT-cover data into common phase-cover hypotheses and then applying the existing common-phase-cover results.
>
> Updates the assembly blueprint to document and reference these new BNT-cover routes.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9c9bfb3ade85d374e6c8c20bc850a4a826e4e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems and blueprint documentation without modifying existing logic; main risk is proof brittleness due to additional abstraction/instances around BNT-cover-to-phase-cover conversions.
> 
> **Overview**
> Adds two new bridge theorems in `ProportionalComparison.lean` that let downstream proofs obtain (1) `SectorBasisOverlapSpanHypotheses` and (2) the zero-tail after-blocking sector-weight comparison directly from `CommonPrimitiveBNTCoverHypotheses`, by converting BNT-cover data into `CommonPrimitivePhaseCoverHypotheses` and reusing existing common-phase-cover results.
> 
> Updates the blueprint (`ch11_assembly.tex`) to state and prove the corresponding “BNT-cover implies overlap-span” and “BNT-cover implies common sectors/sector comparison” results with new theorem entries and references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 590bc45e3b1a40b7b36075b631b70c66eac87e32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->