### PR TITLE
fix(blueprint): compact status badges for print

### DIFF
--- a/blueprint/src/macros/print.tex
+++ b/blueprint/src/macros/print.tex
@@ -27,14 +27,14 @@
 
 \newcommand{\tnleanStatusBadge}[3]{%
   \leavevmode\unskip
-  \nobreak\hspace{0.35em}%
+  \penalty0\hspace{0.3em plus 0.15em minus 0.05em}%
   \begingroup
   \setlength{\fboxsep}{1.4pt}%
   \fcolorbox{#1}{#2!8}{%
     \textcolor{#1}{\sffamily\scriptsize\bfseries #3}%
   }%
   \endgroup
-  \nobreak\hspace{0.25em}%
+  \penalty0\hspace{0.2em plus 0.1em minus 0.05em}%
   \ignorespaces
 }
 
@@ -59,7 +59,7 @@
     \href{\tnleanDocHome/find/\#doc/\tl_use:N \l_tmpa_tl}
       {
         \tnleanStatusBadge{tnleanStatusBlue}{tnleanStatusBlue}
-          {\texttt{\tl_to_str:N \l_tmpb_tl}}
+          {Lean}
       }
   }
 \NewDocumentCommand{\lean}{m}
@@ -74,19 +74,19 @@
 \newcommand{\leanok}{%
   \iftnleanInProof
     \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
-      {\ensuremath{\checkmark}\ Proof OK}%
+      {\ensuremath{\checkmark}\ Proof}%
   \else
     \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
-      {\ensuremath{\checkmark}\ Stmt OK}%
+      {\ensuremath{\checkmark}\ Stmt}%
   \fi
 }
 \newcommand{\mathlibok}{%
   \iftnleanInProof
     \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
-      {\ensuremath{\checkmark}\ Mathlib proof}%
+      {\ensuremath{\checkmark}\ ML proof}%
   \else
     \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
-      {\ensuremath{\checkmark}\ Mathlib stmt}%
+      {\ensuremath{\checkmark}\ ML stmt}%
   \fi
 }
 \newcommand{\notready}{%


### PR DESCRIPTION
### Motivation

- The blueprint PDF produces overflow errors (`Overfull \hbox`) caused by non-breakable spacing around every status badge and by over-long Lean declaration badge text (see #1148).

### Description

- Modified `blueprint/src/macros/print.tex` to replace `\nobreak` spacing around `\tnleanStatusBadge` with flexible, breakable `\hspace` (via `\penalty0`), allowing line breaks to fall between badges.
- Shortened proof/statement/mathlib status labels to `Proof`/`Stmt` and `ML proof`/`ML stmt`.
- Changed `\lean{...}` declaration badges to render as a compact linked `Lean` label instead of the full final declaration component.
- After these changes, `grep -c "Overfull \hbox" blueprint/print/print.log` reports 54 remaining overfulls; the remaining instances are not in the declaration-name/status-badge category addressed here.
- The MPDO chapter relocation mentioned in #1148 remains a separate structural follow-up.

### Testing

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint pdf`
- `cd blueprint && leanblueprint web`
- `git diff --check`

---
Addresses #1148

> [!NOTE]
> **Low Risk**
> Low risk: LaTeX-only macro tweaks affecting PDF layout/line breaking, with no changes to build logic or content generation.
>
> **Overview**
> Print-side LeanBlueprint status badges are tightened to reduce PDF overflow by replacing `\nobreak` spacing with flexible, breakable `\hspace` (via `\penalty0`) around `\tnleanStatusBadge`.
>
> Badge text is shortened (`Proof`/`Stmt`, `ML proof`/`ML stmt`), and `\lean{...}` declaration badges now render as a compact linked `Lean` label instead of the full final declaration component.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 089c2afc8204549fae51016ba29f1044e0658cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk LaTeX-only macro changes that affect PDF line breaking and badge text/spacing, with no impact on Lean sources or build logic.
> 
> **Overview**
> Reduces PDF `Overfull \hbox` issues by making `\tnleanStatusBadge` spacing *breakable and flexible* (replacing `\nobreak` gaps with `\penalty0` + stretch/shrink `\hspace`).
> 
> Compacts badge content by shortening `\leanok`/`\mathlibok` labels and rendering `\lean{...}` declaration badges as a single linked `Lean` tag instead of the declaration’s final component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9311b130572279199258bd8484806c2d05c6dcaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->