### PR TITLE
refactor(Channel/LorentzNormalForm): drop redundant Lorentz non-diagonal conjuncts

### DIFF
--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -282,20 +282,14 @@ def IsLorentzDiagonal
 normal form** (Wolf Proposition 2.9, case 2) if its Pauli-basis transfer matrix has
 `Δ = diag(x/√3, x/√3, 1/3)` and `v = (0, 0, 2/3)` for some `x ∈ [0, 1]`.
 
-In Pauli-entry terms:
-- `T̂_{00} = 1` (TP)
-- `T̂_{0j} = 0` for `j > 0` (TP)
-- `T̂_{10} = T̂_{20} = 0`, `T̂_{30} = 2/3`
-- `T̂_{11} = T̂_{22} = x/√3`, `T̂_{33} = 1/3`
-- All other off-diagonals are zero. -/
+The channel condition supplies the trace-preserving first row. The predicate
+records the non-trivial translation entry, the three diagonal entries, and the
+vanishing of all off-diagonal entries except the allowed translation. -/
 def IsLorentzNonDiagonal
     (T' : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
   IsChannel T' ∧
     ∃ x : ℝ, 0 ≤ x ∧ x ≤ 1 ∧
-      pauliTransferEntry T' 0 0 = 1 ∧
-      (∀ j : Fin 4, j ≠ 0 → pauliTransferEntry T' 0 j = 0) ∧
       pauliTransferEntry T' 3 0 = (2/3 : ℂ) ∧
-      pauliTransferEntry T' 1 0 = 0 ∧ pauliTransferEntry T' 2 0 = 0 ∧
       pauliTransferEntry T' 1 1 = ((x / Real.sqrt 3 : ℝ) : ℂ) ∧
       pauliTransferEntry T' 2 2 = ((x / Real.sqrt 3 : ℝ) : ℂ) ∧
       pauliTransferEntry T' 3 3 = (1/3 : ℂ) ∧

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -2220,6 +2220,7 @@ This subsection records the existence statements from
             2/3 & 0 & 0 & 1/3
         \end{pmatrix}.
     \]
+    Trace preservation supplies the first row of the displayed matrix.
 \end{definition}
 
 \begin{definition}[Singular Lorentz normal form]\label{def:lorentz_singular}
@@ -2237,6 +2238,7 @@ This subsection records the existence statements from
         \end{pmatrix},
     \]
     equivalently, every input state is mapped to $(1+\sigma_{3})/2$.
+    Trace preservation supplies the first row of the displayed matrix.
 \end{definition}
 
 \begin{theorem}[Lorentz normal form for qubit channels]\label{thm:lorentz_normal_form_qubit}


### PR DESCRIPTION
### Motivation

- `IsLorentzNonDiagonal` contains four conjuncts redundant given `IsChannel T'` (trace preservation): the entries `T̂_{00} = 1` and `T̂_{0j} = 0` for `j ≠ 0` follow directly from trace preservation (Wolf §2.3, Prop. 2.9/2.11), and the zero-translation entries at positions `(1,0)` and `(2,0)` are subsumed by the universal off-diagonal clause.
- The three Lorentz predicates express the trace-preserving first-row constraint inconsistently; this harmonizes them to rely uniformly on `IsChannel T'`.
- Follow-up from PR LionSR/TNLean#1146; see blueprint labels `def:lorentz_non_diagonal`, `def:lorentz_singular` in `blueprint/src/chapter/ch04_channels.tex:2197–2249`.

### Description

- `TNLean/Channel/LorentzNormalForm.lean`: removes four redundant conjuncts from `Wolf.IsLorentzNonDiagonal`, relying uniformly on `IsChannel T'` for the trace-preserving first row, matching the convention already used by `IsLorentzSingular`.
- `blueprint/src/chapter/ch04_channels.tex`: adds two sentences to `def:lorentz_non_diagonal` and `def:lorentz_singular` noting that trace preservation supplies the first row of the displayed Pauli-transfer matrices.
- Pre-existing `sorry` markers in `LorentzNormalForm.lean` are unchanged.

### Testing

- `lake env lean TNLean/Channel/LorentzNormalForm.lean` — only pre-existing `sorry` warnings present.
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Closes LionSR/QICLean#149

> [!NOTE]
> **Low Risk**
> Low risk: this only simplifies the logical shape of `Wolf.IsLorentzNonDiagonal` by dropping redundant Pauli-transfer equalities and updates accompanying documentation; no algorithms or proofs are changed.
> 
> **Overview**
> Simplifies `Wolf.IsLorentzNonDiagonal` in `LorentzNormalForm.lean` by relying on `IsChannel T'` for the trace-preserving first row and removing redundant conjuncts (explicit `T̂_{00}`/`T̂_{0j}` constraints and extra zero-translation entries), while still requiring the key diagonal/translation entries and forbidding other off-diagonals.
> 
> Updates the blueprint prose for the non-diagonal and singular Lorentz normal form definitions to explicitly note that trace preservation provides the first row of the displayed transfer matrices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed3c5e8af2ef321cc12256dd7051a0dfc77ff00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>