### PR TITLE
doc(blueprint): add common phase-cover overlap entry

### DIFF
--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1453,6 +1453,29 @@ two-basis sector comparison theorem.
 	hypotheses. The preceding theorem supplies the common MPV phase cover.
 \end{proof}
 
+\begin{theorem}[Phase-cover data give overlap-span hypotheses]%
+\label{thm:sector_basis_overlap_span_reindexed_commonPhaseCover}
+	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover}
+	\leanok
+	\uses{def:common_primitive_phase_cover_hypotheses,
+		def:common_sector_relabeling_hypothesis}
+	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
+	identification hypothesis for the cyclic-sector data. The common-sector
+	structural theorem produces common primitive nonzero-sector families. If those
+	families satisfy the phase-cover hypotheses, then the associated sector
+	decompositions have BNT data, agree as full MPV families, and satisfy the
+	primitive overlap-span hypotheses.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:common_primitive_phase_cover_hypotheses_to_span_hypotheses,
+		thm:bnt_sector_decomp_pair_overlap_span_of_block_span}
+	Convert the phase-cover hypotheses for the produced families into span
+	hypotheses. The BNT sector-decomposition theorem with block-span equality then
+	gives the sector decompositions and their primitive overlap-span hypotheses.
+\end{proof}
+
 \begin{theorem}[BNT-cover data give overlap-span hypotheses]%
 \label{thm:sector_basis_overlap_span_reindexed_bnt_cover}
 	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover}
@@ -1469,7 +1492,8 @@ two-basis sector comparison theorem.
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses}
+	\uses{thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses,
+		thm:sector_basis_overlap_span_reindexed_commonPhaseCover}
 	Convert the BNT-cover hypotheses for the produced families into common
 	phase-cover hypotheses. The common phase-cover construction then gives the
 	sector decompositions and their primitive overlap-span hypotheses.


### PR DESCRIPTION
### Motivation

- The theorem `MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover` has no blueprint entry in `ch11_assembly.tex`, so the dependency graph omits the edge from `thm:sector_basis_overlap_span_reindexed_bnt_cover` to this common-phase-cover ancestor (see #1154).
- Without a `\lean{}` / `\leanok` tag the blueprint cannot reflect that the BNT-cover overlap-span result delegates to this theorem.

### Description

- Adds a theorem block in `blueprint/src/chapter/ch11_assembly.tex` for the Lean declaration `MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover`, marked `\leanok` with `\uses` edges for its hypotheses (`def:common_primitive_phase_cover_hypotheses`, `def:common_sector_relabeling_hypothesis`).
- Updates the proof `\uses` block of `thm:sector_basis_overlap_span_reindexed_bnt_cover` to cite the new common-phase-cover theorem as its ancestor.
- Only `blueprint/src/chapter/ch11_assembly.tex` is modified; no Lean source files are changed.

### Testing

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Closes #1154

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new theorem block and updates `\uses` dependency links; no runtime code or logic is affected.
>
> **Overview**
> Adds a new blueprint theorem `thm:sector_basis_overlap_span_reindexed_commonPhaseCover` documenting the Lean result `MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover`, including its `\leanok` status and dependency edges.
>
> Updates the existing `thm:sector_basis_overlap_span_reindexed_bnt_cover` proof to cite this new common-phase-cover theorem as its ancestor in the `\uses` graph.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1279a3ec4704c79eb36dd38996531d155098572e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>