### PR TITLE
style(blueprint): remove residual process wording

### DIFF
--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -40,7 +40,7 @@ boundary conditions (PBC).
         \TNMPSWord{A}{i_1}{i_L}{L}
     \end{center}
     in which each black node denotes the same local tensor $A$, the virtual
-    legs remain open, and the physical legs record the word
+    legs remain open, and the physical legs are labelled by the word
     $(i_1,\ldots,i_L)$.
 \end{definition}
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1326,7 +1326,7 @@ simple-MPDO equivalence.
     For an MPO tensor $K$, this consists of the local Appendix~C.2 data together
     with a compatibility relation attaching those local data to $K$, the
     commuting-form property, and zero correlation length. The local component
-    records the hypotheses used in the entropy-side route to commuting form,
+    consists of the hypotheses used in the entropy-side route to commuting form,
     while the blocked-RFP consequences below use only commuting form and zero
     correlation length.
 \end{definition}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -2155,7 +2155,7 @@ Subsection~\ref{subsec:lorentz_normal_form}.
 \label{subsec:lorentz_normal_form}
 %% =========================================================
 
-This subsection records the existence statements from
+This subsection states the existence theorems from
 \cite[Section~2.3]{Wolf2012Quantum}.
 
 \begin{definition}[SL-filtering operation]\label{def:sl_filtering}
@@ -2407,7 +2407,7 @@ This subsection records the existence statements from
 \end{proof}
 
 \begin{remark}\leanok
-    Theorem~\ref{thm:fixedPoints_in_multiplicativeDomain} records the
+    Theorem~\ref{thm:fixedPoints_in_multiplicativeDomain} is the
     trace-preserving / Heisenberg-picture counterpart of the same
     multiplicative-domain argument.
 \end{remark}
@@ -2593,7 +2593,7 @@ This subsection records the existence statements from
 %% =========================================================
 
 The one-parameter semigroup theory of Wolf Chapter~7 is treated in
-Chapter~\ref{ch:semigroup}. That later chapter records the exponential
+Chapter~\ref{ch:semigroup}. That later chapter develops the exponential
 representation of norm-continuous semigroups, perturbation bounds, and
 the GKSL/Lindblad description of generators. We do not duplicate that
 material here.

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -203,7 +203,7 @@ The spectral-gap proofs use the Frobenius (Hilbert--Schmidt) norm
 as the natural norm for the finite-dimensional matrix algebra.
 We write $\|{\cdot}\|_F$ for this norm; it coincides with, and we use it
 interchangeably with, the Hilbert--Schmidt norm $\|{\cdot}\|_{\mathrm{HS}}$ on finite-dimensional spaces.
-We record the squared version and an isometric embedding into
+We use the squared version and an isometric embedding into
 Euclidean space.
 
 \begin{definition}[Frobenius norm squared]\label{def:frob_sq}
@@ -874,7 +874,7 @@ the Perron--Frobenius fixed point.
 
 \section{Stationary support}
 
-This section records the support-projection theory
+This section develops the support-projection theory
 behind stationary states, following~\cite[Section~6.4]{Wolf2012Quantum}.
 
 \begin{lemma}[Lower-triangular Kraus condition implies corner invariance]%
@@ -1129,7 +1129,7 @@ sector is positive definite.
         0 \oplus \bigoplus_k M_{d_k}(\C) \otimes \Id_{m_k}
     \]
     together with the density-block form $M_{d_k}(\C) \otimes \rho_k$.
-    The theorem above records the product decomposition, multiplicities, and
+    The theorem above gives the product decomposition, multiplicities, and
     dimension bound needed from this block form.
 \end{remark}
 
@@ -1164,7 +1164,7 @@ sector is positive definite.
 
 \section{Further irreducibility and primitivity equivalences}
 
-This section records several criteria and equivalences from Wolf's Chapter~6 that are
+This section collects several criteria and equivalences from Wolf's Chapter~6 that are
 used later.
 
 \begin{theorem}[Exponential positivity condition]%
@@ -1241,7 +1241,7 @@ used later.
     \label{def:multi_cycle_decomposition}
     \lean{MultiCycleDecomposition}
     \leanok
-    A \emph{multi-cycle decomposition} of $T : \MN{D} \to \MN{D}$ records a
+    A \emph{multi-cycle decomposition} of $T : \MN{D} \to \MN{D}$ consists of a
     finite cycle index $\iota$, a per-cycle period
     $m : \iota \to \mathbb{N}_{>0}$, a projection family
     $P_{c,k} \in \MN{D}$ for $c \in \iota$ and $k \in \Fin{m(c)}$

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1708,7 +1708,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	The weight is the constant value $1$, so it is nonzero.
 \end{proof}
 
-\begin{definition}[Derived common-alphabet cyclic sectors]%
+\begin{definition}[Common-alphabet cyclic sectors]%
 \label{def:common_blocked_cyclic_sector_derived_blocks}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.flatKey,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock,
@@ -1721,16 +1721,16 @@ The following results separate the zero blocks from the nonzero blocks.
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_family, def:blocked_tensor,
 		def:tensor_from_blocks, thm:iterated_blocking_samempv_reindex}
-	From a common reblocked cyclic-sector family, one may derive sector tensors at
-	the common alphabet directly from the original per-block sector tensors.  The
-	same flattened common-sector family is also provided at a prescribed length
-	$p'$ assuming the family length equals $p'$.  The block data
-	keep the identification of blocked physical words explicit: for the block $B_k$, it
+	For a common reblocked cyclic-sector family, the sector tensors over the
+	common alphabet are obtained directly from the original per-block sector
+	tensors.  The same flattened common-sector family is available at a
+	prescribed length $p'$ assuming the family length equals $p'$.  The block data
+	specify the identification of blocked physical words: for the block $B_k$, it
 	uses $B_k^{[m_k e_k]}$ with the labels obtained by flattening an iterated
 	$(m_k,e_k)$ block.
 \end{definition}
 
-\begin{theorem}[Derived common-alphabet cyclic sectors retain structural properties]%
+\begin{theorem}[Common-alphabet cyclic sectors retain structural properties]%
 \label{thm:common_blocked_cyclic_sector_derived_properties}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock_tp,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock_primitive,
@@ -1747,10 +1747,10 @@ The following results separate the zero blocks from the nonzero blocks.
 		thm:tp_primitive_irreducible_extra_blocking,
 		thm:left_canonical_cast_phys_dim, thm:primitive_transfer_cast_phys_dim,
 		thm:irreducible_tensor_cast_phys_dim}
-	The derived common-alphabet sectors are trace-preserving, have primitive transfer
+	The common-alphabet sectors are trace-preserving, have primitive transfer
 	maps, are tensor-irreducible, and have positive bond dimensions.  Original
 	nonzero weights remain nonzero after being transported to the common
-	blocking length and replicated over the derived flattened sector family.
+	blocking length and replicated over the flattened sector family.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3627,11 +3627,11 @@ transport the zero-tail identity through this comparison.
 	Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} gives the
 	one-sided form of this conversion, and
 	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_reindexed}
-	records it simultaneously for the two common-length sector families.  The
+	states it simultaneously for the two common-length sector families.  The
 	auxiliary transport statements,
 	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed},
 	\ref{thm:zero_tail_common_flat_transport_of_grouped_block_cast}, and
-	\ref{thm:samempv_pos_zero_tail_identity_transport}, record the nonzero
+	\ref{thm:samempv_pos_zero_tail_identity_transport}, give the nonzero
 	transported weights and the preservation of the positive-length and length-zero
 	identities, while
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
@@ -3639,7 +3639,7 @@ transport the zero-tail identity through this comparison.
 	comparison.  Theorem~\ref{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 	supplies the direct word equality for the chosen coordinates.
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_block_span_consequences}
-	records the intermediate span consequence for these common-sector families: a
+	gives the intermediate span consequence for these common-sector families: a
 	common MPV phase cover or proportional-decomposition conclusion supplies the
 	finite-length nonzero-block span equality.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -1,6 +1,6 @@
 \chapter{Block Permutation and Separation}\label{ch:block_perm}
 
-This chapter records the algebra of block permutations, the product-algebra maps
+This chapter develops the algebra of block permutations, the product-algebra maps
 built from per-block same-MPV data, the invariant-projection splitting step that
 reduces a tensor to smaller blocks, and the block-separation argument that
 recovers the individual blocks from a block-diagonal same-MPV hypothesis.
@@ -439,7 +439,7 @@ We use this notation throughout the block-separation argument.
 \begin{remark}
     Theorems~\ref{thm:vandermonde_sep}
     and~\ref{thm:repeated_word_trace_identity}
-    record an alternative Newton/Vandermonde route.
+    give an alternative Newton/Vandermonde route.
     The proof here instead continues with the
     mixed-transfer peeling argument of Lemma~\ref{lem:block_sep_core},
     and the later BNT weight-matching step uses the linear-independence results

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1292,7 +1292,7 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:mpv_state, def:injective}
 	For two common primitive nonzero-sector families at one blocking length, this
-	condition records the hypotheses needed before applying the
+	condition consists of the hypotheses needed before applying the
 	zero-tail sector comparison: equality of the two zero-tail dimensions,
 	one-site injectivity of all blocks on both sides, and equality of the
 	finite-length MPV spans of the two block families for every system size.
@@ -1324,7 +1324,7 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:mpv_common_phase_cover, def:injective}
 	For two common primitive nonzero-sector families at one blocking length, this
-	condition records the phase-cover version of
+	condition is the phase-cover version of
 	Definition~\ref{def:common_primitive_span_hypotheses}: equality of the two
 	zero-tail dimensions, one-site injectivity of all blocks on both sides, and a
 	common MPV phase cover for the two block families.
@@ -1358,7 +1358,7 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:injective}
 	For two common primitive nonzero-sector families at one blocking length, this
-	condition records equality of the two zero-tail dimensions, one-site
+	condition asserts equality of the two zero-tail dimensions, one-site
 	injectivity of all blocks on both sides, and a BNT proportional-decomposition
 	comparison for the two block families. It is the BNT-comparison version of
 	Definition~\ref{def:common_primitive_phase_cover_hypotheses}.
@@ -1411,7 +1411,7 @@ two-basis sector comparison theorem.
 	\uses{def:is_normal_canonical_form, def:blocks_not_gauge_phase_equiv,
 		def:injective}
 	For two common primitive nonzero-sector families at one blocking length, this
-	condition records the BNT data needed to construct a common MPV phase cover:
+	condition contains the BNT data needed to construct a common MPV phase cover:
 	normal canonical-form data on both sides, separation of distinct sectors by
 	gauge-phase equivalence, equality of the zero-tail dimensions, one-site
 	injectivity, and a proportional-decomposition comparison.
@@ -1635,7 +1635,7 @@ two-basis sector comparison theorem.
 	common blocking length at which both tensors have zero-tail decompositions whose
 	nonzero parts are weighted families of trace-preserving, primitive,
 	tensor-irreducible blocks with positive bond dimension and nonzero weights.  The
-	theorem further records the three positive-length MPV agreements
+	theorem further includes the three positive-length MPV agreements
 	\(\mc{V}^{+}(\cdot)=\mc{V}^{+}(\cdot)\): the two agreements comparing each
 	blocked tensor with its own nonzero-sector part and the agreement comparing the
 	two nonzero-sector parts, together with the length-zero zero-tail identity, as
@@ -1762,7 +1762,7 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:common_sector_relabeling_hypothesis,
 		def:common_primitive_proportional_hypotheses}
-		These hypotheses record the comparison data for the
+		These hypotheses consist of the comparison data for the
 	periodic-theorem-free after-blocking formulation of the CPSV Fundamental
 		Theorem. They contain the blocked-word identification for common cyclic
 	sectors. For the common primitive nonzero-sector families produced from two
@@ -1817,7 +1817,7 @@ two-basis sector comparison theorem.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_proportional} with
 		the word-identification and proportional-comparison data from
 	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. The proof
-	then records the resulting blocking length, sector decompositions, BNT data,
+	then packages the resulting blocking length, sector decompositions, BNT data,
 	permutation, multiplicity equalities, phases, and sector-weight
 	multiset equalities as the conclusion structure.
 \end{proof}
@@ -1907,11 +1907,11 @@ two-basis sector comparison theorem.
 	gives the common weighted nonzero-sector decompositions needed for the
 	comparison theorems.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
-		then records the hypotheses: equality of the
+		then states the hypotheses: equality of the
 	zero-tail dimensions, injectivity of the common nonzero-sector blocks, and
 	finite-length MPV span equality.
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_block_span_consequences}
-	records the corresponding conditional span consequence for the common-sector
+	gives the corresponding conditional span consequence for the common-sector
 	families themselves: a common MPV phase cover or a proportional-decomposition
 	conclusion supplies the finite-length nonzero-block span equality.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -411,7 +411,7 @@ reduction hypothesis.
 \begin{proof}
     \leanok
     \uses{def:non_ti_chain}
-    Bundling the site and physical indices does not change which local matrix
+    Combining the site and physical indices does not change which local matrix
     is read at the component $(k,i)$, so both sides evaluate to
     $\zeta A_k^i$ there.
 \end{proof}

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -226,7 +226,7 @@ on the bond space.
     \leanok
     \uses{lem:gauge_unique_up_to_scalar}
     This is exactly Lemma~\ref{lem:gauge_unique_up_to_scalar}; the extra MPV
-    hypothesis records the setting in which the two gauges are usually
+    hypothesis specifies the setting in which the two gauges are usually
     produced.
 \end{proof}
 

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -1,6 +1,6 @@
 \chapter{Exponential Decay of Correlations}\label{ch:correlations}
 
-This chapter records the transfer-matrix expression for thermodynamic-limit
+This chapter derives the transfer-matrix expression for thermodynamic-limit
 correlators of a normal MPS and the resulting exponential decay estimate.
 The key mechanism is spectral: after removing the leading eigenvalue
 contribution, the connected part is governed by subleading eigenvalues of the
@@ -138,7 +138,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
 
 The spectral gap theorems in Chapter~\ref{ch:channels} establish
 $\rho(\E_A - P) < 1$ for primitive channels qualitatively.  This section
-records the \emph{quantitative} refinements that give explicit constants
+gives the \emph{quantitative} refinements with explicit constants
 and rates for the single-tensor transfer map $\E_A$.
 
 \begin{theorem}[Exponential convergence of injective primitive channels]%


### PR DESCRIPTION
### Motivation

Issue #1021 tracks remaining blueprint prose that still reads like notes or implementation process rather than mathematical statements.

### Description

This PR removes the remaining prose occurrences of the flagged language across the blueprint chapters:

- replaces residual `record` / `records` phrasing with mathematical verbs such as `states`, `gives`, `consists of`, `contains`, and `develops`;
- shortens the `ch08_canonical` common-alphabet cyclic-sector headings and removes `derived common` wording;
- replaces the remaining `Bundling` prose in the algebraic Fundamental Theorem chapter;
- leaves PEPS graph-endpoint terminology and `\lean{...Canonicalization...}` declaration names untouched, since those are mathematical/Lean identifiers rather than prose residue.

### Testing

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `cd blueprint && leanblueprint web` (completed with existing bibliography/render warnings)
- `rg -n -i 'derived common|derived flattened|\brecords\b|\brecord\b|bookkeeping|bundling|provisional|relabeled|canonicalization|recorded below|zero-tail bookkeeping' blueprint/src/chapter` (only `\lean{...Canonicalization...}` identifier hits remain)

---
Closes #1021

> [!NOTE]
> **Low Risk**
> Purely editorial LaTeX prose tweaks (wording/section headings) with no changes to mathematical statements, Lean declarations, or referenced labels, so risk is low aside from potential minor wording/clarity regressions.
>
> **Overview**
> Updates blueprint prose to remove process-style wording, replacing phrases like *"records"*/*"derived"*/*"bundling"* with more statement-oriented language (e.g., *"states"*, *"gives"*, *"consists of"*, *"develops"*) across several chapters.
>
> Also renames the `ch08_canonical` common-alphabet cyclic-sector definition/theorem headings to drop *"derived common"* wording while keeping the underlying labels/Lean references intact.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9d441fe5c5e529c6d0a9434006281f85befad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>