### PR TITLE
style(Algebra+PiAlgebra+Axioms): clean foundational prose wording

### DIFF
--- a/TNLean/Algebra/BlockTriangularTrace.lean
+++ b/TNLean/Algebra/BlockTriangularTrace.lean
@@ -7,9 +7,9 @@ import Mathlib.Logic.Equiv.Fin.Basic
 /-!
 # Block-triangular trace invariance for MPS tensors
 
-This file records the observation that strict upper-right blocks do not affect
-word traces of block upper-triangular tensors. It defines block-sum and
-reindexing helpers and proves `sameMPV_upperFin_diagFin`, reducing an
+This file proves that strict upper-right blocks do not affect word traces of
+block upper-triangular tensors. It defines block-sum and reindexing maps and
+proves `sameMPV_upperFin_diagFin`, reducing an
 upper-triangular tensor to its block-diagonal part.
 -/
 
@@ -69,7 +69,7 @@ lemma trace_fromBlocks_upper (X : Matrix (Fin n) (Fin n) ℂ)
 
 /-- For any word `w`, evaluating `upperSum` gives an upper-triangular block matrix.
 
-We record the (inessential) upper-right block in an auxiliary recursion `UR`. -/
+The (inessential) upper-right block is carried by an auxiliary recursion `UR`. -/
 lemma evalWord_upperSum_is_fromBlocks
     (A11 : Fin d → Matrix (Fin n) (Fin n) ℂ)
     (A12 : Fin d → Matrix (Fin n) (Fin m) ℂ)

--- a/TNLean/Algebra/MatrixFunctionalCalculus.lean
+++ b/TNLean/Algebra/MatrixFunctionalCalculus.lean
@@ -4,8 +4,8 @@ import Mathlib.Analysis.Matrix.Order
 /-!
 # Matrix Functional Calculus Scopes
 
-This helper module centralizes the real matrix functional-calculus instances
-used throughout the Lean 4.29 upgrade work, so downstream files can opt into
+This module provides the real matrix functional-calculus instances
+used throughout the Lean 4.29 upgrade, so downstream files can opt into
 them via `open scoped TNMatrixCFC`.
 -/
 

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -14,7 +14,7 @@ import Mathlib.Tactic.Ring
 This module isolates the finite-dimensional matrix step used in Appendix C.2,
 Lemma C.4 of arXiv:1606.00608.  The bare Perron--Frobenius statement
 "primitive plus constant trace powers implies rank one" is false, so the
-usable theorem here records the extra diagonalizability supplied by positive
+usable theorem here includes the extra diagonalizability supplied by positive
 semidefiniteness.
 
 The main corrected theorem is

--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -33,8 +33,8 @@ Lieb concavity (Lieb–Ruskai 1973). This requires:
 
 Replace `hayashi_ssa_equality_characterization` with a proof of the equality
 case of strong subadditivity. A faithful formalization is expected to require:
-1. Conditional mutual information / recovery-map infrastructure
-2. A finite-dimensional direct-sum / tensor-factorization API compatible with
+1. Conditional mutual information and recovery maps
+2. A finite-dimensional direct-sum / tensor-factorization theory compatible with
    basis changes on the middle subsystem
 3. The equivalence between equality in SSA and the quantum Markov-chain
    structure of the tripartite state
@@ -121,7 +121,7 @@ end HayashiMarkov
 /-- Data witnessing the Hayashi / Ruskai / Hayden--Jozsa--Petz--Winter
 quantum-Markov-chain structure for a tripartite density matrix.
 
-The record encodes an explicit finite direct-sum decomposition of the middle
+This structure specifies an explicit finite direct-sum decomposition of the middle
 system `B`, an explicit unitary basis change on `B`, probabilities `p_j`, and
 left/right density matrices `ρ_{A B_jᴸ}` and `ρ_{B_jᴿ C}` such that after
 conjugating `ρ_ABC` by `1_A ⊗ U_B ⊗ 1_C` and reindexing `B` along the chosen
@@ -212,7 +212,7 @@ unitary basis change on `B`, the probabilities `p_j`, the component density
 matrices, and the block-diagonal equality.
 
 This result is introduced here as a **sanctioned axiom**: the full proof needs
-operator-algebra / recovery-map infrastructure that is not yet formalized in
+operator-algebra and recovery-map theory that is not yet formalized in
 Mathlib or in this repository. Downstream consumers should import the theorem
 statement from `TNLean/Entropy/MarkovChain.lean`, not this axiom module.
 

--- a/TNLean/PiAlgebra/BlockSeparation.lean
+++ b/TNLean/PiAlgebra/BlockSeparation.lean
@@ -15,7 +15,7 @@ individual block equalities `mpv(A_k, σ) = mpv(B_k, σ)` for each `k`.
 requires *fixed* coefficients at each power, but here the "coefficients"
 `mpv(A_k, σ) - mpv(B_k, σ)` depend on `σ : Fin N → Fin d` whose type varies with `N`.
 
-**Alternative route recorded here (repeated-word / Newton's identities)**:
+**Alternative route via repeated words and Newton's identities**:
 
 1. For any fixed word `w` of length `M`, consider the `L`-fold concatenation `w^L` of
    length `M · L`. The evalWord identity gives
@@ -38,7 +38,7 @@ separating the combined eigenvalue multiset into per-block multisets. This is a
 polynomial/algebraic-geometry argument (Zariski density of the non-collision locus)
 that is not yet available in Mathlib.
 
-This file records that alternative Vandermonde / Newton route and the elementary
+This file develops that alternative Vandermonde / Newton route and the elementary
 repeated-word lemmas supporting it. It is **not** part of the current checked
 end-to-end proof chain: the canonical-form reduction uses the mixed-transfer
 peeling argument in `CanonicalFormSep.lean`, and the later weight-multiset
@@ -72,7 +72,7 @@ section BlockSeparation
 
 variable {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
 
-/-! #### Helper: evalWord of a replicated list -/
+/-! #### Evaluation on replicated lists -/
 
 /-- `evalWord A` on a replicated single letter gives a matrix power. -/
 lemma evalWord_replicate (A : MPSTensor d D) (i : Fin d) (L : ℕ) :
@@ -149,7 +149,7 @@ per-block `mpv(A_k,σ) = mpv(B_k,σ)` uses the multiplicative structure of `eval
 The formal gap is step (3): the genericity argument (Zariski density of the non-collision
 locus) requires algebraic geometry tools not currently in Mathlib.
 
-This comment records the same alternative route as the module docstring. The
+This comment gives the same alternative route as the module docstring. The
 current checked reduction instead proceeds through `CanonicalFormSep.lean` and
 later BNT linear-independence arguments.
 
@@ -168,7 +168,7 @@ The per-block separation statement one might hope for,
 is **false** without additional hypotheses (e.g. canonical-form normalization
 preventing rescalings between the block tensors and the phases `μ k`).
 
-Accordingly, this file currently only provides the trustworthy helper lemmas
+Accordingly, this file currently only provides the trustworthy lemmas
 `evalWord_replicate`, `evalWord_flatten_replicate`, `mpv_const_eq_trace_pow`,
 and `sameMPV₂_repeated_word`.
 

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -18,15 +18,15 @@ import TNLean.Channel.Peripheral.Spectrum
 import Mathlib.Analysis.Complex.Basic
 
 /-!
-# Separated canonical-form hypotheses — Auxiliary definitions and helpers
+# Separated canonical-form hypotheses — auxiliary definitions and lemmas
 
 This file contains the structure definitions, algebraic lemmas, overlap bounds, peeling lemma,
-and block-separation core helper lemmas that underpin the main block-separation results in
+and block-separation core lemmas that underpin the main block-separation results in
 `CanonicalFormSep.lean`.
 
 ## Contents
 
-- Additive split API: `HasInjectiveBlocks`, `HasIrreducibleBlocks`, `HasPrimitiveBlocks`,
+- Additive split conditions: `HasInjectiveBlocks`, `HasIrreducibleBlocks`, `HasPrimitiveBlocks`,
   `IsLeftCanonicalBlockFamily`, `HasOrderedNonzeroWeights`, `HasStrictOrderedNonzeroWeights`,
   `HasNormalizedSelfOverlap`.
 - Bundled conditions: `IsCanonicalForm`, `IsNormalCanonicalForm` with projections and
@@ -35,7 +35,7 @@ and block-separation core helper lemmas that underpin the main block-separation 
 - Section `OverlapBounds`: MPV overlap bounds from left-canonical normalization.
 - Left-canonical trace bounds: `leftCanonical_evalWord_trace_bound`.
 - Section `PeelingLemma`: `peeling_exponential_bound` for the block-separation induction.
-- Section `BlockSeparationCoreHelpers`: local helper lemmas used by the induction in
+- Section `BlockSeparationCoreHelpers`: local lemmas used by the induction in
   `CanonicalFormSep.lean`.
 -/
 
@@ -58,9 +58,9 @@ Equivalently, the associated transfer map is trace-preserving. We do **not** ass
 unital identity `∑ᵢ Aᵢ Aᵢ† = I`.
 -/
 
-/-! ### Additive split API for canonical-form hypotheses
+/-! ### Additive split conditions for canonical-form hypotheses
 
-The existing `IsCanonicalForm` bundle is kept unchanged for backwards compatibility.  The
+The existing `IsCanonicalForm` predicate is kept unchanged for backwards compatibility.  The
 structures below expose weaker pieces of data so theorem signatures can migrate gradually without
 forcing an immediate project-wide refactor.
 -/
@@ -241,7 +241,7 @@ structure IsCanonicalForm {r : ℕ} {dim : Fin r → ℕ}
   /-- **Aperiodicity / overlap normalization**: the MPV self-overlap converges to `1`.
 
   This field is kept for backward compatibility with the original separated FT interface. In the
-  normal-canonical-form API the same conclusion is derived from irreducibility, left-canonical
+  normal-canonical-form formulation the same conclusion is derived from irreducibility, left-canonical
   normalization, and peripheral-spectrum primitivity via
   `MPSTensor.overlap_tendsto_one_of_peripheralPrimitive_of_irreducible`. -/
   overlap_tendsto_one :
@@ -274,7 +274,7 @@ def toHasNormalizedSelfOverlap (hCF : IsCanonicalForm μ A) :
     HasNormalizedSelfOverlap (d := d) A :=
   HasNormalizedSelfOverlap.ofForall hCF.overlap_tendsto_one
 
-/-- Rebuild the `IsCanonicalForm` bundle from the additive split API (relaxed ordering). -/
+/-- Assemble `IsCanonicalForm` from the additive split conditions (relaxed ordering). -/
 def ofSeparatedData
     (hInj : HasInjectiveBlocks (d := d) A)
     (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
@@ -287,7 +287,7 @@ def ofSeparatedData
   mu_ne_zero := hμ.mu_ne_zero
   overlap_tendsto_one := hOverlap.overlap_tendsto_one
 
-/-- Rebuild the `IsCanonicalForm` bundle from the additive split API (strict ordering). -/
+/-- Assemble `IsCanonicalForm` from the additive split conditions (strict ordering). -/
 def ofStrictSeparatedData
     (hInj : HasInjectiveBlocks (d := d) A)
     (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
@@ -356,7 +356,7 @@ def toHasOrderedNonzeroWeights (hNCF : IsNormalCanonicalForm μ A) :
   mu_antitone := hNCF.mu_antitone
   mu_ne_zero := hNCF.mu_ne_zero
 
-/-- Rebuild the `IsNormalCanonicalForm` bundle from the additive split API (relaxed ordering). -/
+/-- Assemble `IsNormalCanonicalForm` from the additive split conditions (relaxed ordering). -/
 def ofSeparatedData
     (hIrr : HasIrreducibleBlocks (d := d) A)
     (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
@@ -371,7 +371,7 @@ def ofSeparatedData
   mu_ne_zero := hμ.mu_ne_zero
   dim_pos := hDim
 
-/-- Rebuild the `IsNormalCanonicalForm` bundle from the additive split API (strict ordering). -/
+/-- Assemble `IsNormalCanonicalForm` from the additive split conditions (strict ordering). -/
 def ofStrictSeparatedData
     (hIrr : HasIrreducibleBlocks (d := d) A)
     (hLeft : IsLeftCanonicalBlockFamily (d := d) A)


### PR DESCRIPTION
### Motivation

Issue #1017 tracks cleanup of process-oriented wording in foundational Lean-source prose. This PR takes a small, low-risk slice across algebra, entropy axioms, and Pi-algebra comments without changing any declarations.

### Description

- Replaces residual `record`, `helper`, `API`, and `infrastructure` phrasing in six foundational files.
- Rephrases module docstrings and local comments as mathematical descriptions of trace invariance, matrix functional calculus, rank-one criteria, entropy equality structure, repeated-word separation, and separated canonical-form hypotheses.
- Leaves public names and theorem statements unchanged.

### Testing

- `lake env lean TNLean/Algebra/BlockTriangularTrace.lean`
- `lake env lean TNLean/Algebra/MatrixFunctionalCalculus.lean`
- `lake env lean TNLean/Algebra/PerronFrobenius/RankOne.lean`
- `lake env lean TNLean/Axioms/Entropy.lean`
- `lake env lean TNLean/PiAlgebra/BlockSeparation.lean`
- `lake env lean TNLean/PiAlgebra/CanonicalFormSepAux.lean`
- `git diff --check`
- targeted vocabulary scan on the touched files

---
Addresses #1017

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docstrings and comments, with no modifications to definitions, theorem statements, or proof terms.
> 
> **Overview**
> Updates prose across several foundational Lean modules to use more mathematical/descriptive wording (e.g., replacing "record/helper/API/infrastructure" phrasing) and to clarify intent in docstrings/comments for block-triangular trace invariance, matrix functional calculus scopes, Perron–Frobenius rank-one criteria, entropy axioms, repeated-word block separation, and canonical-form separation assumptions.
> 
> No declarations, signatures, or proof code change; this is a documentation/style-only refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1953c25fb43edd4f420765273ba5e7064b28fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->