### PR TITLE
doc(audits): add GitHub prose language scan

### DIFF
--- a/audits/2026-05-04_issue1000_github_language_scan.md
+++ b/audits/2026-05-04_issue1000_github_language_scan.md
@@ -1,0 +1,105 @@
+# GitHub prose scan for mathematical language
+
+Issue: #1000
+Date: 2026-05-04
+Repository state: `origin/main` at `e7ef01f1b`
+
+This audit records a live GitHub scan of issue and pull-request titles and
+public prose for the vocabulary listed in #1000 and #999.
+
+## Title conventions
+
+The current open-issue title scan is clean for PR-style prefixes and bracket /
+em-dash separator residue:
+
+```bash
+gh issue list --repo LionSR/TNLean --state open --limit 200 \
+  --json number,title,labels,url |
+  jq -r '.[] | select(.title|test("^(formalization|infrastructure|feat|fix|doc|style|ci|chore|refactor)\\("))'
+
+gh issue list --repo LionSR/TNLean --state open --limit 200 \
+  --json number,title,labels,url |
+  jq -r '.[] | select(.title|test("—|\\[|\\]"))'
+```
+
+Both commands returned no rows after the 2026-05-04 live rename pass. The
+renamed open issues include the former `formalization(...)` and
+`infrastructure(...)` titles, the four `Daily Standup — YYYY-MM-DD` issues, and
+the open audit/tracking titles with em-dash separators.
+
+The open pull-request title scan is also clean:
+
+```bash
+gh pr list --repo LionSR/TNLean --state open --limit 30 \
+  --json number,title,isDraft,reviewDecision,mergeStateStatus,headRefName,url
+```
+
+It returned no open pull requests.
+
+## Focused body searches
+
+Focused searches over GitHub issues and pull requests still find the #1000
+vocabulary, but many hits are deliberate style-guidance issues or issue bodies
+that now point to narrower follow-up issues.
+
+```bash
+for term in "live block" "live sector" "exact-live" "one-shot" \
+  "physical-label compatibility" "source anchors" "channel-side" \
+  "dead proof" "bookkeeping" "wrapper" "pipeline" "endpoint" \
+  "raw input" "handoff"; do
+  printf '%s\t' "$term"
+  gh api -X GET search/issues -f q="repo:LionSR/TNLean \"$term\"" --jq '.total_count'
+done
+```
+
+Counts on 2026-05-04:
+
+| Term | Hits |
+| --- | ---: |
+| `live block` | 60 |
+| `live sector` | 34 |
+| `exact-live` | 20 |
+| `one-shot` | 20 |
+| `physical-label compatibility` | 11 |
+| `source anchors` | 11 |
+| `channel-side` | 22 |
+| `dead proof` | 37 |
+| `bookkeeping` | 73 |
+| `wrapper` | 305 |
+| `pipeline` | 160 |
+| `endpoint` | 143 |
+| `raw input` | 3 |
+| `handoff` | 15 |
+
+Representative current hits:
+
+- `live block`: #1000 itself, #944, #999, and older cleanup PRs such as #1028
+  and #1031.
+- `bookkeeping`: #1016, #1000, #1018, and older blueprint cleanup PRs.
+- `wrapper`: #785, #190, #784, #239, and #1016.
+
+The high counts therefore should not be read as one remaining bulk edit. They
+mix style-guidance text, already-closed cleanup PRs, literal Lean identifiers,
+mathematical graph terminology such as PEPS endpoints, and real source-prose
+residue tracked by narrower issues.
+
+## Current disposition
+
+- Future-facing templates and workflow guidance are handled by #1002 and PR
+  #1158: tracking issues now use GitHub Sub-issues rather than Markdown
+  tasklists.
+- Current open issue titles are handled under #1003; the live open-title scans
+  above now return no rows.
+- Lean-source prose residue remains under #1013, #1016, #1017, and the parent
+  tracker #1018. Those issues should remain open until their scoped source
+  scans are clean.
+- Historical closed issue and merged PR prose still contains old wording, but
+  the scan shows no single safe bulk rewrite. Closed records should only be
+  edited when they are still visible from active trackers or when a narrower
+  audit identifies a title/body that misleads current work.
+
+## Recommendation
+
+Close #1000 as the repository-wide GitHub scan. Keep #999 open until the
+remaining child issues (#1003 and the Lean-source cleanup trackers) are closed
+or explicitly superseded.


### PR DESCRIPTION
### Motivation

- Issue #1000 asks for a repository-wide GitHub scan of issue and pull-request prose against the mathematical-language norm from #999.

### Description

- Adds `audits/2026-05-04_issue1000_github_language_scan.md` with the live open-title scans, focused GitHub body-search counts, representative hits, and disposition of the remaining residue.
- Records that open issue titles and open PR titles are currently clean after the live #1003 rename pass.
- Separates deliberate style-guidance / literal identifier hits from source-prose residue tracked by #1013, #1016, #1017, and #1018.

### Testing

- `gh issue list --repo LionSR/TNLean --state open --limit 200 --json number,title,labels,url | jq ...`
- `gh pr list --repo LionSR/TNLean --state open --limit 30 --json number,title,isDraft,reviewDecision,mergeStateStatus,headRefName,url`
- `gh api -X GET search/issues -f q='repo:LionSR/TNLean "<term>"' --jq '.total_count'`
- `git diff --check`

---
Closes #1000

> [!NOTE]
> **Low Risk**
> Low risk: adds an audit markdown document only, with no code or runtime behavior changes.
>
> **Overview**
> Adds a new audit document, `audits/2026-05-04_issue1000_github_language_scan.md`, capturing a 2026-05-04 GitHub scan of issue/PR titles and bodies for the #1000/#999 vocabulary.
>
> Documents the (now clean) open-title checks, provides term hit counts from GitHub search, and records recommended next steps/ownership for remaining prose residue tracked in follow-up issues.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8148ebe339c4be5b24e521711ff405be3c0ddfe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>