### PR TITLE
doc(PEPS): clean mathematical prose

### DIFF
--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -257,7 +257,7 @@ theorem stateCoeff_splitAtEdge (A : Tensor G d) (e : Edge G) (σ : V → Fin d) 
 
 /-- Boundary virtual data for the edge-centered three-block decomposition.
 
-For an edge `e = (u, w)`, this records the index on `e`, the residual indices on
+For an edge `e = (u, w)`, this consists of the index on `e`, the residual indices on
 edges incident to `u` other than `e`, and the residual indices on edges incident
 to `w` other than `e`. The middle-region contraction below is fibred over this
 data. -/

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -3,36 +3,33 @@ import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
--- The forward direction and contraction algebra are formalized, while the
--- converse PEPS fundamental theorem remains as `sorry` placeholders marking
--- proof obligations for future PRs (see #128).
+-- The forward direction and contraction algebra are formalized. The converse
+-- PEPS fundamental theorem still depends on the mathematical hypotheses listed
+-- below.
 --
 -- Provability note: `IsVertexInjective` in `PEPS.Defs` is the
 -- linear-independence formulation `∀ v, LinearIndependent ℂ (A.component v)`
 -- (see issue #633 for the switch away from function-level injectivity, which
 -- is strictly weaker). Linear independence gives each vertex tensor a left
--- inverse on its image, removes the old definitional blocker, and is the
--- correct hypothesis for the repaired uniqueness statement
+-- inverse on its image and is the correct hypothesis for the repaired uniqueness statement
 -- `gauge_unique_mod_edge_scalars`.
 --
--- The remaining `sorry`s split into three independently tracked groups:
--- * `gaugeConsistency` (issue #820) still requires the full edge-centred
---   reduction from arXiv:1804.04964 Section 3. The local left inverse and the
---   elementary blocking data are developed in `PEPS/VirtualInsertion` and
---   `PEPS/Blocking`, and `localGauge_exists` has been reduced to the sharper
---   local hypothesis `HasLocalGaugeLift`. The edge-blocked coefficient and
---   middle tensor are developed in `PEPS/Blocking`; the abbreviation
---   `BlockedMiddleGaugeHyp` isolates the remaining step: compare that
---   three-block contraction with the 3-site MPS theorem and derive the explicit
---   local gauge formula from `SameState`.
--- * The `hDim` step inside `fundamentalTheorem_PEPS` (issue #874) is now
---   factored out as the conditional theorem `fundamentalTheorem_PEPS_of_bondDim`
---   so that the bond-dimension obligation is orthogonal to `gaugeConsistency`.
---   Its derivation from `SameState` plus vertex injectivity still needs a
---   boundary-insertion / blocking lemma.
--- * `gauge_unique_mod_edge_scalars` (issue #842) is the repaired uniqueness
---   statement, but its proof still needs the same blocking infrastructure
---   together with a local tensor-factor uniqueness lemma for the balanced
+-- The unproved converse ingredients split into three groups:
+-- * `gaugeConsistency` requires the full edge-centred reduction from
+--   arXiv:1804.04964 Section 3. The local left inverse and the elementary
+--   blocking data are developed in `PEPS/VirtualInsertion` and `PEPS/Blocking`,
+--   and `localGauge_exists` has been reduced to the sharper local hypothesis
+--   `HasLocalGaugeLift`. The edge-blocked coefficient and middle tensor are
+--   developed in `PEPS/Blocking`; the abbreviation `BlockedMiddleGaugeHyp`
+--   isolates the remaining implication from `SameState` to the explicit local
+--   gauge formula.
+-- * The `hDim` step inside `fundamentalTheorem_PEPS` is factored out as the
+--   conditional theorem `fundamentalTheorem_PEPS_of_bondDim`, so that the
+--   bond-dimension equality is orthogonal to `gaugeConsistency`. Its derivation
+--   from `SameState` plus vertex injectivity still requires a boundary-insertion
+--   / blocking lemma.
+-- * `gauge_unique_mod_edge_scalars` is the repaired uniqueness statement. Its
+--   proof still requires local tensor-factor uniqueness for the balanced
 --   edge-scalar quotient.
 
 /-!
@@ -502,10 +499,9 @@ noncomputable def localTensorEval (A : Tensor G d) (v : V)
 factorized local gauge relation at `v`.
 
 The local left inverse and the canonical candidate operator are defined in
-`PEPS/LocalGauge`. The remaining PEPS-Fundamental-Theorem gap is to prove
-`BlockedMiddleGaugeHyp` from `SameState` by comparing the edge-blocked
-coefficient from `PEPS/Blocking` with the three-site MPS reduction, then convert
-it to `HasLocalGaugeLift` by
+`PEPS/LocalGauge`. It remains to derive `BlockedMiddleGaugeHyp` from `SameState`
+by comparing the edge-blocked coefficient from `PEPS/Blocking` with the
+three-site MPS reduction, then convert it to `HasLocalGaugeLift` by
 `hasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
 theorem localGauge_exists (A B : Tensor G d)
     (hA : IsVertexInjective A)
@@ -552,12 +548,11 @@ theorem gaugeConsistency (A B : Tensor G d)
 equality** (arXiv:1804.04964, Theorem 2).
 
 Given matching bond dimensions, two vertex-injective PEPS that generate the
-same state are gauge-equivalent. This isolates the two remaining blockers of
+same state are gauge-equivalent. This isolates the two unproved ingredients of
 `fundamentalTheorem_PEPS` into orthogonal hypotheses:
 
-* the bond-dimension equality `hDim` (tracked in issue #874), and
-* the globally consistent edge gauges produced by `gaugeConsistency`
-  (tracked in issue #820).
+* the bond-dimension equality `hDim`, and
+* the globally consistent edge gauges produced by `gaugeConsistency`.
 
 Downstream consumers that already have a specific bond-dimension witness can
 call this conditional form directly, without waiting for the boundary-insertion
@@ -588,17 +583,13 @@ theorem fundamentalTheorem_PEPS (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B)
     (hAB : SameState A B) :
     GaugeEquiv A B := by
-  -- Step 1: Show bond dimensions must agree.  Tracked in issue #874.
-  -- `SameState` captures only the fully-contracted scalar, whereas the PEPS FT
-  -- derivation of bond-dimension equality uses the full family of boundary
+  -- Bond-dimension equality should follow from the full family of boundary
   -- insertions. Linear independence at each vertex (`IsVertexInjective`) gives
-  -- the right local data, but the global argument that different bond
-  -- dimensions cannot yield the same state family still requires a
+  -- the right local data, while the global comparison still requires a
   -- boundary-insertion / blocking lemma.
   have hDim : A.bondDim = B.bondDim := by
     sorry
-  -- Step 2: Extract globally consistent gauges via `gaugeConsistency`
-  -- (tracked in issue #820).
+  -- With matching bond dimensions, `gaugeConsistency` supplies the global gauges.
   exact fundamentalTheorem_PEPS_of_bondDim A B hA hB hAB hDim
 
 /-! ### Balanced edge scalars -/
@@ -721,15 +712,14 @@ theorem gauge_unique_mod_edge_scalars (A B : Tensor G d)
         ∏ ie : IncidentEdge G v, edgeGaugeAt A Y v ie (η ie) (η' ie) :=
     fun v η η' =>
       edgeGaugeProduct_eq_of_gaugeVertex_eq (G := G) A hA v X Y (hGauge v) η η'
-  -- Remaining step (issue #842): the tensor-factor uniqueness lemma.
   -- From `hProd v` at each vertex `v`, extract a nonzero scalar `c_v(ie)` on
   -- each incident edge such that `edgeGaugeAt A X v ie = c_v(ie) • edgeGaugeAt A Y v ie`
   -- with the oriented product of `c_v(ie)` over incident `ie` at `v` equal to
   -- `1`, then reconcile `c_u` and `c_w` on every shared edge `e = (u,w)` into a
   -- single global family `c : (e : Edge G) → Units ℂ` satisfying
   -- `IsVertexBalanced c`. This is the local scalar-ratio argument of
-  -- arXiv:1804.04964 Section 3; it is independent of the virtual-insertion / blocking
-  -- machinery tracked in #763.
+  -- arXiv:1804.04964 Section 3; it is independent of the virtual-insertion and
+  -- blocking lemmas used for local gauge existence.
   sorry
 
 end PEPS

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -11,16 +11,16 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 -- linear-independence formulation `∀ v, LinearIndependent ℂ (A.component v)`
 -- (see issue #633 for the switch away from function-level injectivity, which
 -- is strictly weaker). Linear independence gives each vertex tensor a left
--- inverse on its image and is the correct hypothesis for the repaired uniqueness statement
--- `gauge_unique_mod_edge_scalars`.
+-- inverse on its image and is the correct hypothesis for the repaired
+-- uniqueness statement `gauge_unique_mod_edge_scalars`.
 --
 -- The unproved converse ingredients split into three groups:
 -- * `gaugeConsistency` requires the full edge-centred reduction from
 --   arXiv:1804.04964 Section 3. The local left inverse and the elementary
 --   blocking data are developed in `PEPS/VirtualInsertion` and `PEPS/Blocking`,
 --   and `localGauge_exists` has been reduced to the sharper local hypothesis
---   `HasLocalGaugeLift`. The edge-blocked coefficient and middle tensor are
---   developed in `PEPS/Blocking`; the abbreviation `BlockedMiddleGaugeHyp`
+--   `HasFactorizedLocalGauge`. The edge-blocked coefficient and middle tensor are
+--   developed in `PEPS/Blocking`; the abbreviation `BlockedMiddleGaugeFormula`
 --   isolates the remaining implication from `SameState` to the explicit local
 --   gauge formula.
 -- * The `hDim` step inside `fundamentalTheorem_PEPS` is factored out as the
@@ -495,18 +495,18 @@ noncomputable def localTensorEval (A : Tensor G d) (v : V)
   ∑ η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1),
     (∏ ie : IncidentEdge G v, f ie (η ie)) * A.component v η σ
 
-/-- Under the sharper local hypothesis `HasLocalGaugeLift`, one obtains a
+/-- Under the sharper local hypothesis `HasFactorizedLocalGauge`, one obtains a
 factorized local gauge relation at `v`.
 
-The local left inverse and the canonical candidate operator are defined in
-`PEPS/LocalGauge`. It remains to derive `BlockedMiddleGaugeHyp` from `SameState`
-by comparing the edge-blocked coefficient from `PEPS/Blocking` with the
-three-site MPS reduction, then convert it to `HasLocalGaugeLift` by
-`hasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
+The local left inverse and the canonical local gauge map are defined in
+`PEPS/LocalGauge`. It remains to derive `BlockedMiddleGaugeFormula` from
+`SameState` by comparing the edge-blocked coefficient from `PEPS/Blocking` with
+the three-site MPS reduction, then convert it to `HasFactorizedLocalGauge` by
+`hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula`. -/
 theorem localGauge_exists (A B : Tensor G d)
     (hA : IsVertexInjective A)
     (hDim : A.bondDim = B.bondDim) (v : V)
-    (hLift : HasLocalGaugeLift A B hA hDim v) :
+    (hFactorized : HasFactorizedLocalGauge A B hA hDim v) :
     ∃ (Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ),
       ∀ (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
         B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
@@ -514,7 +514,7 @@ theorem localGauge_exists (A B : Tensor G d)
             (∏ ie : IncidentEdge G v,
               (↑(Xv ie.1) : Matrix _ _ ℂ) (η ie) (η' ie)) *
               A.component v η' σ :=
-  localGauge_exists_of_liftData A B hA hDim v hLift
+  localGauge_exists_of_factorizedLocalGauge A B hA hDim v hFactorized
 
 /-! ### Gauge consistency across edges -/
 
@@ -533,10 +533,11 @@ theorem gaugeConsistency (A B : Tensor G d)
       ∀ (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
         B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
           gaugeVertex A X v η σ := by
-  -- TODO: first derive `BlockedMiddleGaugeHyp A B hA hDim v` from `SameState`
-  -- at each vertex by comparing the edge-blocked coefficient from `PEPS/Blocking`
-  -- with the three-site MPS reduction, then use
-  -- `hasLocalGaugeLift_of_blockedMiddleGaugeHyp` to obtain the local gauges.
+  -- Derive `BlockedMiddleGaugeFormula A B hA hDim v` from `SameState` at each
+  -- vertex by comparing the edge-blocked coefficient from `PEPS/Blocking` with
+  -- the three-site MPS reduction, then use
+  -- `hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula` to obtain the local
+  -- gauges.
   -- The key remaining consistency step is: for each edge e = (u,v), the gauges
   -- extracted from u and v must agree as inverse-transposes, with the
   -- orientation convention in `edgeGaugeAt`.
@@ -572,7 +573,7 @@ the same state, then they are gauge-equivalent: there exist invertible matrices
 
 The proof proceeds in two stages:
 1. **Local extraction** (`localGauge_exists`): after proving the sharper local
-   hypothesis `HasLocalGaugeLift`, injectivity and the chosen left inverse
+   hypothesis `HasFactorizedLocalGauge`, injectivity and the chosen left inverse
    produce a factorized local gauge relation.
 2. **Global consistency** (`gaugeConsistency`): local gauges along shared
    edges are shown to be compatible, yielding a single coherent family of

--- a/TNLean/PEPS/LocalGauge.lean
+++ b/TNLean/PEPS/LocalGauge.lean
@@ -3,25 +3,25 @@ import TNLean.PEPS.VirtualInsertion
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 /-!
-# Local gauge candidates for injective PEPS
+# Local gauge maps for injective PEPS
 
 For a vertex-injective PEPS tensor `A`, the chosen local left inverse lets us pull
 any local physical vector back to a coefficient function on the virtual star at a
 vertex `v`. When `A` and `B` have the same bond dimensions, this yields a
-canonical candidate endomorphism on the local virtual coefficient space of `A`.
+canonical endomorphism on the local virtual coefficient space of `A`.
 
-To complete the PEPS Fundamental-Theorem argument, this candidate must still be
-shown to
+To complete the PEPS Fundamental-Theorem argument, this endomorphism must still
+be shown to
 
 1. reconstruct the local tensors of `B`, equivalently that the local image of
    `B` lies in the image of `localTensorMap A v`, and
 2. factor into independent edge gauges.
 
-We capture those two requirements as `HasLocalGaugeLift`. This isolates the
-exact output of the blocked-middle / three-site-MPS reduction in
-arXiv:1804.04964 Section 3, and `hasLocalGaugeLift_of_localGaugeFormula` is the
-final conversion that turns an explicit local gauge formula into that sharper
-datum.
+We capture those two requirements as `HasFactorizedLocalGauge`. This isolates
+the exact output of the blocked-middle / three-site-MPS reduction in
+arXiv:1804.04964 Section 3, and `hasFactorizedLocalGauge_of_localGaugeFormula`
+is the final conversion that turns an explicit local gauge formula into that
+sharper datum.
 -/
 
 open scoped BigOperators Matrix
@@ -92,9 +92,9 @@ omit [Fintype V] in
       simpa using congrArg (castLocalVirtualConfig A B hDim v) hs
     simp [castLocalCoeffMap_apply, hξ, hs]
 
-/-- The canonical local coefficient-space candidate obtained by pulling the local
+/-- The canonical local coefficient-space map obtained by pulling the local
 `B`-tensor back through the chosen left inverse of `A`. -/
-noncomputable def localGaugeCandidate (A B : Tensor G d)
+noncomputable def localGaugeMap (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V) :
     LocalVirtualOp A v :=
   (localLeftInverse A hA v).comp <|
@@ -109,14 +109,14 @@ theorem localTensorMap_castLocalCoeffMap_single (A B : Tensor G d)
       B.component v (castLocalVirtualConfig A B hDim v η) := by
   rw [castLocalCoeffMap_single, localTensorMap_apply_single]
 
-/-- The canonical local gauge candidate reconstructs the projection of `B`'s
+/-- The canonical local gauge map reconstructs the projection of `B`'s
 local tensor into the image of `localTensorMap A v`. -/
-theorem localGaugeCandidate_apply_single (A B : Tensor G d)
+theorem localGaugeMap_apply_single (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
     (η : LocalVirtualConfig A v) :
-    localTensorMap A v (localGaugeCandidate A B hA hDim v (Pi.single η (1 : ℂ))) =
+    localTensorMap A v (localGaugeMap A B hA hDim v (Pi.single η (1 : ℂ))) =
       localProjector A hA v (B.component v (castLocalVirtualConfig A B hDim v η)) := by
-  rw [localGaugeCandidate, LinearMap.comp_apply, LinearMap.comp_apply,
+  rw [localGaugeMap, LinearMap.comp_apply, LinearMap.comp_apply,
     localTensorMap_castLocalCoeffMap_single]
   simp [localProjector, physRealizeLocalOp]
 
@@ -126,30 +126,30 @@ This states exactly the two local conclusions still needed from the blocked-midd
 reduction in arXiv:1804.04964 Section 3:
 
 1. the local components of `B` lie in the image of `localTensorMap A v`, and
-2. the canonical candidate `localGaugeCandidate` factorizes into one invertible
+2. the canonical map `localGaugeMap` factorizes into one invertible
    matrix on each incident edge. -/
-structure HasLocalGaugeLift (A B : Tensor G d) (hA : IsVertexInjective A)
+structure HasFactorizedLocalGauge (A B : Tensor G d) (hA : IsVertexInjective A)
     (hDim : A.bondDim = B.bondDim) (v : V) : Prop where
   projector_fixes :
     ∀ η : LocalVirtualConfig A v,
       localProjector A hA v (B.component v (castLocalVirtualConfig A B hDim v η)) =
         B.component v (castLocalVirtualConfig A B hDim v η)
-  factorized_candidate :
+  factorized_localGaugeMap :
     ∃ Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
       ∀ η η' : LocalVirtualConfig A v,
-        localGaugeCandidate A B hA hDim v (Pi.single η (1 : ℂ)) η' =
+        localGaugeMap A B hA hDim v (Pi.single η (1 : ℂ)) η' =
           ∏ ie : IncidentEdge G v,
             (↑(Xv ie.1) : Matrix (Fin (A.bondDim ie.1)) (Fin (A.bondDim ie.1)) ℂ)
               (η ie) (η' ie)
 
 /-- Any explicit edgewise local gauge formula at `v` yields the sharper datum
-`HasLocalGaugeLift`.
+`HasFactorizedLocalGauge`.
 
 This is the final algebraic conversion after the blocked-middle / three-site-MPS
 reduction: once that reduction produces invertible incident-edge gauges
-realizing the local tensors of `B`, the canonical candidate pulled back through
+realizing the local tensors of `B`, the canonical map pulled back through
 `localLeftInverse` is forced to be the same factorized operator. -/
-theorem hasLocalGaugeLift_of_localGaugeFormula (A B : Tensor G d)
+theorem hasFactorizedLocalGauge_of_localGaugeFormula (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
     (hLocal :
       ∃ Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
@@ -160,7 +160,7 @@ theorem hasLocalGaugeLift_of_localGaugeFormula (A B : Tensor G d)
                 (↑(Xv ie.1) : Matrix (Fin (A.bondDim ie.1))
                     (Fin (A.bondDim ie.1)) ℂ) (η ie) (η' ie)) *
                 A.component v η' σ) :
-    HasLocalGaugeLift A B hA hDim v := by
+    HasFactorizedLocalGauge A B hA hDim v := by
   rcases hLocal with ⟨Xv, hXv⟩
   refine ⟨?_, ⟨Xv, ?_⟩⟩
   · intro η
@@ -189,13 +189,13 @@ theorem hasLocalGaugeLift_of_localGaugeFormula (A B : Tensor G d)
       ext σ
       simpa [c, localTensorMap, Fintype.linearCombination_apply] using hXv η σ
     have hcand :
-        localGaugeCandidate A B hA hDim v (Pi.single η (1 : ℂ)) = c := by
+        localGaugeMap A B hA hDim v (Pi.single η (1 : ℂ)) = c := by
       ext ξ
       calc
-        localGaugeCandidate A B hA hDim v (Pi.single η (1 : ℂ)) ξ =
+        localGaugeMap A B hA hDim v (Pi.single η (1 : ℂ)) ξ =
             localLeftInverse A hA v
               (B.component v (castLocalVirtualConfig A B hDim v η)) ξ := by
-              rw [localGaugeCandidate, LinearMap.comp_apply, LinearMap.comp_apply,
+              rw [localGaugeMap, LinearMap.comp_apply, LinearMap.comp_apply,
                 localTensorMap_castLocalCoeffMap_single]
         _ = localLeftInverse A hA v (localTensorMap A v c) ξ := by rw [hcomp]
         _ = c ξ := by simp
@@ -207,8 +207,8 @@ blocked-middle / three-site-MPS reduction at a vertex.
 The PEPS fundamental theorem requires deriving this proposition from `SameState`:
 an incident-edge family of invertible matrices whose local gauge formula already
 reconstructs the local tensors of `B` from those of `A`. The next theorem then
-turns this explicit local formula into `HasLocalGaugeLift`. -/
-abbrev BlockedMiddleGaugeHyp (A B : Tensor G d) (_hA : IsVertexInjective A)
+turns this explicit local formula into `HasFactorizedLocalGauge`. -/
+abbrev BlockedMiddleGaugeFormula (A B : Tensor G d) (_hA : IsVertexInjective A)
     (hDim : A.bondDim = B.bondDim) (v : V) : Prop :=
   ∃ Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
     ∀ (η : LocalVirtualConfig A v) (σ : Fin d),
@@ -220,23 +220,23 @@ abbrev BlockedMiddleGaugeHyp (A B : Tensor G d) (_hA : IsVertexInjective A)
             A.component v η' σ
 
 /-- The blocked-middle / three-site-MPS output immediately yields
-`HasLocalGaugeLift`. -/
-theorem hasLocalGaugeLift_of_blockedMiddleGaugeHyp (A B : Tensor G d)
+`HasFactorizedLocalGauge`. -/
+theorem hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
-    (hBlocked : BlockedMiddleGaugeHyp A B hA hDim v) :
-    HasLocalGaugeLift A B hA hDim v :=
-  hasLocalGaugeLift_of_localGaugeFormula A B hA hDim v hBlocked
+    (hBlocked : BlockedMiddleGaugeFormula A B hA hDim v) :
+    HasFactorizedLocalGauge A B hA hDim v :=
+  hasFactorizedLocalGauge_of_localGaugeFormula A B hA hDim v hBlocked
 
-/-- Under `HasLocalGaugeLift`, one obtains the factorized local-gauge formula at
+/-- Under `HasFactorizedLocalGauge`, one obtains the factorized local-gauge formula at
 vertex `v`.
 
-This theorem gives the local factorized gauge relation under `HasLocalGaugeLift`.
+This theorem gives the local factorized gauge relation under `HasFactorizedLocalGauge`.
 Deriving that hypothesis from `SameState` remains the blocked-middle /
 three-site-MPS reduction, followed by
-`hasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
-theorem localGauge_exists_of_liftData (A B : Tensor G d)
+`hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula`. -/
+theorem localGauge_exists_of_factorizedLocalGauge (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
-    (hLift : HasLocalGaugeLift A B hA hDim v) :
+    (hFactorized : HasFactorizedLocalGauge A B hA hDim v) :
     ∃ (Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ),
       ∀ (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
         B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
@@ -244,22 +244,22 @@ theorem localGauge_exists_of_liftData (A B : Tensor G d)
             (∏ ie : IncidentEdge G v,
               (↑(Xv ie.1) : Matrix _ _ ℂ) (η ie) (η' ie)) *
               A.component v η' σ := by
-  rcases hLift.factorized_candidate with ⟨Xv, hXv⟩
+  rcases hFactorized.factorized_localGaugeMap with ⟨Xv, hXv⟩
   refine ⟨Xv, ?_⟩
   intro η σ
-  have hproj := congrArg (fun f : Fin d → ℂ => f σ) (hLift.projector_fixes η)
+  have hproj := congrArg (fun f : Fin d → ℂ => f σ) (hFactorized.projector_fixes η)
   have hspec := congrArg (fun f : Fin d → ℂ => f σ)
-    (localGaugeCandidate_apply_single A B hA hDim v η)
+    (localGaugeMap_apply_single A B hA hDim v η)
   calc
     B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
         (localProjector A hA v
           (B.component v (castLocalVirtualConfig A B hDim v η))) σ := by
           simpa [castLocalVirtualConfig_apply] using hproj.symm
     _ = (localTensorMap A v
-          (localGaugeCandidate A B hA hDim v (Pi.single η (1 : ℂ)))) σ := by
+          (localGaugeMap A B hA hDim v (Pi.single η (1 : ℂ)))) σ := by
           simpa using hspec.symm
     _ = ∑ η' : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1),
-          localGaugeCandidate A B hA hDim v (Pi.single η (1 : ℂ)) η' *
+          localGaugeMap A B hA hDim v (Pi.single η (1 : ℂ)) η' *
             A.component v η' σ := by
           simp [localTensorMap, Fintype.linearCombination_apply]
     _ = ∑ η' : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1),

--- a/TNLean/PEPS/LocalGauge.lean
+++ b/TNLean/PEPS/LocalGauge.lean
@@ -10,18 +10,18 @@ any local physical vector back to a coefficient function on the virtual star at 
 vertex `v`. When `A` and `B` have the same bond dimensions, this yields a
 canonical candidate endomorphism on the local virtual coefficient space of `A`.
 
-The remaining PEPS Fundamental-Theorem blocker is that this candidate must still
-be shown to
+To complete the PEPS Fundamental-Theorem argument, this candidate must still be
+shown to
 
 1. reconstruct the local tensors of `B`, equivalently that the local image of
    `B` lies in the image of `localTensorMap A v`, and
 2. factor into independent edge gauges.
 
-We capture those two requirements as `HasLocalGaugeLift`. This isolates the exact
-output still needed from the blocked-middle / three-site-MPS reduction in
-arXiv:1804.04964 Section 3, and `hasLocalGaugeLift_of_localGaugeFormula` is the final
-conversion that turns an explicit local gauge formula into that
-sharper datum.
+We capture those two requirements as `HasLocalGaugeLift`. This isolates the
+exact output of the blocked-middle / three-site-MPS reduction in
+arXiv:1804.04964 Section 3, and `hasLocalGaugeLift_of_localGaugeFormula` is the
+final conversion that turns an explicit local gauge formula into that sharper
+datum.
 -/
 
 open scoped BigOperators Matrix
@@ -204,10 +204,10 @@ theorem hasLocalGaugeLift_of_localGaugeFormula (A B : Tensor G d)
 /-- Abbreviated proposition for the output expected from the edge-centered
 blocked-middle / three-site-MPS reduction at a vertex.
 
-The remaining open PEPS step should prove this proposition from `SameState`:
-an incident-edge family of invertible matrices whose local gauge formula
-already reconstructs the local tensors of `B` from those of `A`. The next
-theorem then turns this explicit local formula into `HasLocalGaugeLift`. -/
+The PEPS fundamental theorem requires deriving this proposition from `SameState`:
+an incident-edge family of invertible matrices whose local gauge formula already
+reconstructs the local tensors of `B` from those of `A`. The next theorem then
+turns this explicit local formula into `HasLocalGaugeLift`. -/
 abbrev BlockedMiddleGaugeHyp (A B : Tensor G d) (_hA : IsVertexInjective A)
     (hDim : A.bondDim = B.bondDim) (v : V) : Prop :=
   ∃ Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
@@ -230,9 +230,9 @@ theorem hasLocalGaugeLift_of_blockedMiddleGaugeHyp (A B : Tensor G d)
 /-- Under `HasLocalGaugeLift`, one obtains the factorized local-gauge formula at
 vertex `v`.
 
-This is the current local endpoint available in Lean: the remaining PEPS
-Fundamental-Theorem gap is to prove `BlockedMiddleGaugeHyp` from `SameState` via
-the blocked-middle / three-site-MPS reduction and then apply
+This theorem gives the local factorized gauge relation under `HasLocalGaugeLift`.
+Deriving that hypothesis from `SameState` remains the blocked-middle /
+three-site-MPS reduction, followed by
 `hasLocalGaugeLift_of_blockedMiddleGaugeHyp`. -/
 theorem localGauge_exists_of_liftData (A B : Tensor G d)
     (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)


### PR DESCRIPTION
### Motivation

- The PEPS modules contained software-process language and status notes that described implementation state rather than mathematical content; #1016 records the full scan of affected terms (`scaffold`, `infrastructure`, `machinery`, `bookkeeping`, `blocker`, and similar).
- Review feedback asked for the cleanup to include Lean identifier names, not only comments.

### Description

- `TNLean/PEPS/FundamentalTheorem.lean`: rewrote docstrings and block comments to name the remaining hypotheses in mathematical terms.
- `TNLean/PEPS/LocalGauge.lean`: renamed the local-gauge declarations so the public names describe the mathematical objects directly: `localGaugeMap`, `HasFactorizedLocalGauge`, and `BlockedMiddleGaugeFormula`.
- `TNLean/PEPS/Blocking.lean`: removed the last non-mathematical prose-scan hit while preserving edge-endpoint language that refers to graph vertices.
- The old names were mathematical-language cleanup targets, so this PR intentionally does not add deprecated aliases.

### Testing

- `rg -n -i "scaffold|wrapper|infrastructure|machinery|bookkeeping|\brecords?\b|blocker|available in Lean|placeholder|candidate|TODO" TNLean/PEPS`
- `rg -n "HasLocalGaugeLift|BlockedMiddleGaugeHyp|hasLocalGaugeLift|localGaugeCandidate|localGauge_exists_of_liftData|factorized_candidate" TNLean`
- `git diff --check`
- `lake env lean TNLean/PEPS/Blocking.lean`
- `lake env lean TNLean/PEPS/LocalGauge.lean`
- `lake build TNLean.PEPS.LocalGauge`
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean` (existing sorry warnings only)

---
Closes #1016