### PR TITLE
style(Wielandt/Primitivity): clean primitivity prose

### DIFF
--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -24,8 +24,8 @@ import Mathlib.Analysis.Normed.Module.RCLike.Real
 This file proves the $(c) \to (b)$ direction of Proposition 3 from
 Sanz--Pérez-García--Wolf--Cirac (arXiv:0909.5347): strong irreducibility of the
 transfer map forces eventual full word span / Kraus rank. It collects the
-results connecting strong irreducibility, convergence of transfer powers, and the final full-rank
-conclusion used by the public equivalence API.
+results connecting strong irreducibility, convergence of transfer powers, and
+the full-rank conclusion used by the Proposition 3 equivalence.
 -/
 
 /-!
@@ -39,9 +39,9 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
 > point, irreducible, unique peripheral eigenvalue `{1}`), then `A` has
 > eventually full Kraus rank (i.e., word products eventually span `M_D(ℂ)`).
 
-It is a direction-specific implementation module. For the packaged public
-Proposition 3 API, prefer `TNLean.Wielandt.Primitivity.Equivalence`; this file is retained for
-specialized access to the (c)→(b) proof route and its quantitative
+This file gives the direction-specific proof. For the two-sided Proposition 3
+equivalence, prefer `TNLean.Wielandt.Primitivity.Equivalence`; this file is
+retained for specialized access to the (c)→(b) proof route and its quantitative
 intermediates.
 
 ## Proof strategy (following the paper / Wolf Chapter 6)
@@ -85,7 +85,7 @@ variable {d D : ℕ}
 /-- Complex-valued form of the trace-pairing identity:
 `∑_σ tr(B† A_σ) · star(tr(B† A_σ)) = ∑_{i,k} [B† · E^n(e_{ik}) · B]_{ik}`.
 
-This is the raw algebraic content before extracting the real part. -/
+This is the complex trace identity before extracting the real part. -/
 private theorem sum_trace_mul_star_eq [NeZero D]
     (A : MPSTensor d D) (n : ℕ)
     (B : Matrix (Fin D) (Fin D) ℂ) :
@@ -200,7 +200,7 @@ definition. The proof chains:
 2. `IsIrreducibleTensor` → unique trace-zero fixed point (`huniq_fp`)
 3. `huniq_fp` + `IsPeripherallyPrimitive` → spectral gap
    (complement spectral radius < 1)
-4. Package as `IsPrimitiveMPS A ρ`
+4. obtain `IsPrimitiveMPS A ρ`
 -/
 
 /-- **Primitivity bridge**: strong irreducibility implies the spectral-gap
@@ -511,7 +511,7 @@ This bounds the error term `Q_{(E − P_ρ)^n}(B)` uniformly. -/
 
 section UniformPositivity
 
-/-! #### Helper: representing dual functionals via the trace pairing
+/-! #### Trace representation of dual functionals
 
 Every linear functional `φ : M_D(ℂ) → ℂ` can be represented as
 `φ(N) = tr(M_φ · N)` for a unique matrix `M_φ`.  We prove this concretely
@@ -1011,8 +1011,8 @@ end FinalConstruction
 full Kraus rank.
 
 This is the Proposition ~3 route `(IsPrimitiveMPS + ρ.PosDef) → (c) → (b)`: first
-package the data as `IsStronglyIrreduciblePaper`, then apply the already
-formalized `StronglyIrreducible → HasEventuallyFullKrausRank` implication. -/
+view the hypotheses as `IsStronglyIrreduciblePaper`, then apply the formalized
+`StronglyIrreducible → HasEventuallyFullKrausRank` implication. -/
 theorem hasEventuallyFullKrausRank_of_isPrimitiveMPS_of_posDef [NeZero D]
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ)
@@ -1031,4 +1031,3 @@ theorem isNormal_of_isPrimitiveMPS_with_posDef [NeZero D]
     (hasEventuallyFullKrausRank_of_isPrimitiveMPS_of_posDef hP hρ_pd)
 
 end MPSTensor
-

--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -39,10 +39,10 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
 > point, irreducible, unique peripheral eigenvalue `{1}`), then `A` has
 > eventually full Kraus rank (i.e., word products eventually span `M_D(ℂ)`).
 
-This file gives the direction-specific proof. For the two-sided Proposition 3
-equivalence, prefer `TNLean.Wielandt.Primitivity.Equivalence`; this file is
-retained for specialized access to the (c)→(b) proof route and its quantitative
-intermediates.
+This file gives the direction-specific proof. For the full Proposition 3
+equivalence of (a), (b), and (c), prefer
+`TNLean.Wielandt.Primitivity.Equivalence`; this file is retained for specialized
+access to the (c)→(b) proof route and its quantitative intermediates.
 
 ## Proof strategy (following the paper / Wolf Chapter 6)
 
@@ -715,7 +715,7 @@ private theorem norm_tracePairBilin_le [NeZero D]
     _ ≤ ∑ p ∈ Finset.univ ×ˢ Finset.univ,
         ‖Bᴴ‖ * ‖Φ‖ * ‖B‖ := by
           apply Finset.sum_le_sum; intro p _
-          -- ‖F x‖ = ‖Φ x‖ since Φ wraps F with continuous structure
+          -- ‖F x‖ = ‖Φ x‖ because `Φ` is the continuous-linear-map form of `F`.
           have hFΦ : ‖F (Matrix.single p.1 p.2 1)‖ =
               ‖Φ (Matrix.single p.1 p.2 (1 : ℂ))‖ := by rfl
           calc ‖(Bᴴ * F (Matrix.single p.1 p.2 1) *

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -13,9 +13,9 @@ import TNLean.Spectral.MixedTransfer
 /-!
 # Preparatory lemmas for the current `IsPrimitiveMPS → IsNormal` bridge
 
-This file collects spectral-gap consequences of `IsPrimitiveMPS` together with a
-small transfer-map compatibility API. It stops short of proving any `IsNormal`
-theorem; the actual primitive-to-normal bridge now lives in
+This file collects spectral-gap consequences of `IsPrimitiveMPS` together with
+basic transfer-map compatibility lemmas. It stops short of proving any
+`IsNormal` theorem; the actual primitive-to-normal bridge now lives in
 `Primitivity/StronglyIrreducibleToFullRank.lean`, while `QuantumWielandt.lean`
 keeps a backward-compatible exact-word-span witness theorem whose public
 statement still carries an aperiodicity parameter.
@@ -29,7 +29,7 @@ statement still carries an aperiodicity parameter.
   `ρ`
 * `IsPrimitiveMPS.complement_pow_tendsto_zero`: `(E - P_ρ)^n → 0`
 
-### Transfer-map wrappers
+### Transfer-map compatibility
 
 * `IsPrimitiveMPS.transferMap_isChannel`
 * `IsPrimitiveMPS.transferMap_trace_preserving`
@@ -42,7 +42,7 @@ statement still carries an aperiodicity parameter.
 
 ## Important note on definitions
 
-Our `IsPrimitiveMPS` hypothesis records a spectral gap around a nonzero PSD
+Our `IsPrimitiveMPS` hypothesis consists of a spectral gap around a nonzero PSD
 fixed point. This is weaker than the paper's primitive condition in
 arXiv:0909.5347, Proposition 3, which additionally forces the fixed point to be
 positive definite.
@@ -163,7 +163,7 @@ theorem IsPrimitiveMPS.transferMap_trace_preserving
 
 /-- **Irreducible transfer map implies a positive-definite fixed point.**
 
-If `ρ` is the PSD fixed point packaged by `IsPrimitiveMPS A ρ` and the transfer
+If `ρ` is the PSD fixed point in `IsPrimitiveMPS A ρ` and the transfer
 map is irreducible, then `ρ` is positive definite.
 
 This is the Perron–Frobenius `PosDef` result from `TNLean.QPF.PosDef`
@@ -177,7 +177,7 @@ theorem posDef_of_isIrreducibleMap_of_isPrimitiveMPS
     hP.fixedPoint_psd hP.fixedPoint_ne_zero hP.fixedPoint_is_fixed
 
 omit [NeZero D] in
-/-- Bridge from irreducible tensor to irreducible map, recorded here for convenience. -/
+/-- Irreducibility of a tensor gives irreducibility of its transfer map. -/
 theorem isIrreducibleMap_of_isIrreducibleTensor
     (A : MPSTensor d D) (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
     IsIrreducibleMap (transferMap (d := d) (D := D) A) :=


### PR DESCRIPTION
### Motivation

- Process-oriented language in the Wielandt primitivity modules (words such as "API", "wrapper", "package", "helper", "record") obscures the mathematical content and conflicts with the project's prose standards (see #1013).
- `TNLean/Wielandt/Primitivity/ToNormal.lean` and `TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean` contain module notes and docstrings that describe the Proposition 3 (c)→(b) proof route in process language rather than finite-dimensional linear algebra.

### Description

- Replaced process-oriented prose in `TNLean/Wielandt/Primitivity/ToNormal.lean` with mathematical descriptions of the bridge from strong irreducibility to the normality conditions used in Proposition 3.
- Cleaned module notes in `TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean`, rephrasing the role of the `IsPrimitiveMPS` compatibility results in terms of the underlying rank and span conditions.
- No theorems, definitions, or proof terms are renamed or altered; all changes are limited to docstrings, section headings, and inline comments.
- Broader prose cleanup of rank-one extraction and rectangular-span modules is deferred to a separate PR.

### Testing

- `rg -n -i "API|wrapper|raw|package|packaged|helper|record|records|infrastructure" TNLean/Wielandt/Primitivity/ToNormal.lean TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean`
- `git diff --check`
- `lake env lean TNLean/Wielandt/Primitivity/ToNormal.lean`
- `lake env lean TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean`

---
Addresses #1013

> [!NOTE]
> **Low Risk**
> Documentation-only edits that rephrase module/theorem comments without changing any Lean declarations or proofs, so behavioral risk is minimal.
> 
> **Overview**
> Cleans up and clarifies prose in `Primitivity/StronglyIrreducibleToFullRank.lean` and `Primitivity/ToNormal.lean`, replacing process-oriented wording with more mathematical descriptions of the Proposition 3 (c)→(b) proof route and the role of the `IsPrimitiveMPS` compatibility lemmas.
> 
> No theorems, definitions, or proof terms are renamed or altered; changes are limited to docstrings/section headings and minor phrasing tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d675ffd31e338a8f7f6437b16adff2f75cf2824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docstrings/section headers/inline comments in Lean files, with no modifications to definitions, theorem statements, or proofs.
> 
> **Overview**
> Updates documentation in `Primitivity/StronglyIrreducibleToFullRank.lean` and `Primitivity/ToNormal.lean` to replace process-oriented wording with more mathematical descriptions of the Proposition 3 **(c) → (b)** proof route and the role of the `IsPrimitiveMPS` lemmas.
> 
> No Lean declarations or proof terms are changed; edits are purely prose/formatting (module notes, headings, and comment clarifications).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d06ceb2d89e30608733d36ebe2abb3a66ae1d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->