### PR TITLE
doc(blueprint): sync PEPS local gauge names

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -417,9 +417,9 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     coefficients and apply the same-state hypothesis.
 \end{proof}
 
-\begin{definition}[Sharpened local gauge lift datum]%
-    \label{def:peps_hasLocalGaugeLift}
-    \lean{TNLean.PEPS.HasLocalGaugeLift}
+\begin{definition}[Factorized local gauge datum]%
+    \label{def:peps_hasFactorizedLocalGauge}
+    \lean{TNLean.PEPS.HasFactorizedLocalGauge}
     \leanok
     \uses{def:peps_localTensorMap, def:peps_localLeftInverse}
     For fixed $A$, $B$, a bond-dimension equality, and a vertex $v$, this
@@ -430,22 +430,22 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     $A$ factorizes as one invertible matrix on each incident edge.
 \end{definition}
 
-\begin{definition}[Blocked-middle local gauge data]%
-    \label{def:peps_blockedMiddleGaugeHyp}
-    \lean{TNLean.PEPS.BlockedMiddleGaugeHyp}
+\begin{definition}[Blocked-middle local gauge formula]%
+    \label{def:peps_blockedMiddleGaugeFormula}
+    \lean{TNLean.PEPS.BlockedMiddleGaugeFormula}
     \leanok
-    \uses{def:peps_hasLocalGaugeLift}
+    \uses{def:peps_hasFactorizedLocalGauge}
     This states the explicit local gauge formula that the edge-centered
     blocked-middle reduction is expected to produce: a family of invertible
     matrices on the incident edges of $v$ whose product kernel reconstructs each
     local component of $B$ from those of $A$.
 \end{definition}
 
-\begin{theorem}[Blocked-middle local gauge data implies sharpened lift]%
-    \label{thm:peps_hasLocalGaugeLift_of_blockedMiddleGaugeHyp}
-    \lean{TNLean.PEPS.hasLocalGaugeLift_of_blockedMiddleGaugeHyp}
+\begin{theorem}[Blocked-middle formula implies factorized local gauge]%
+    \label{thm:peps_hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula}
+    \lean{TNLean.PEPS.hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula}
     \leanok
-    \uses{def:peps_blockedMiddleGaugeHyp, def:peps_hasLocalGaugeLift}
+    \uses{def:peps_blockedMiddleGaugeFormula, def:peps_hasFactorizedLocalGauge}
     Any explicit local gauge formula from the blocked-middle reduction yields
     the sharpened local lift. The remaining open step is to derive this
     blocked-middle formula from equality of PEPS states.
@@ -461,8 +461,8 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \label{thm:localGauge_exists}
     \lean{TNLean.PEPS.localGauge_exists}
     \leanok
-    \uses{def:peps_hasLocalGaugeLift}
-    Under the sharpened local lift hypothesis, the local gauge formula follows.
+    \uses{def:peps_hasFactorizedLocalGauge}
+    Under the factorized local gauge hypothesis, the local gauge formula follows.
     What remains open is to upgrade equality of the edge-blocked coefficients to
     the blocked-middle formula using the corresponding three-site
     injective-chain argument.


### PR DESCRIPTION
### Motivation

- PR #1160 renamed the PEPS local-gauge declarations in Lean.
- The blueprint still referenced the old names, which made regenerated `blueprint/lean_decls` fail `checkdecls`.

### Description

- Update `ch13a_peps_ft.tex` to reference `HasFactorizedLocalGauge`, `BlockedMiddleGaugeFormula`, and `hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula`.
- Update the adjacent blueprint labels and `\uses{}` references to match the renamed declarations.

### Testing

- `rg -n "HasLocalGaugeLift|BlockedMiddleGaugeHyp|hasLocalGaugeLift_of_blockedMiddleGaugeHyp|peps_hasLocalGaugeLift|peps_blockedMiddleGaugeHyp" blueprint/src TNLean/PEPS`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --report /tmp/tnlean-blueprint-sync-peps.json`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- `lake env lean TNLean/PEPS/LocalGauge.lean`
- `git diff --check`
- `cd blueprint && leanblueprint web`

---
Addresses #1148

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that rename blueprint definitions/theorems and their `\lean{}`/`\uses{}` references to match existing Lean declaration renames; no behavior or proofs are changed.
>
> **Overview**
> Updates the PEPS Fundamental Theorem blueprint section to match renamed Lean local-gauge declarations by renaming the corresponding definition/theorem headings and labels, and by updating `\lean{}` and `\uses{}` references from `HasLocalGaugeLift`/`BlockedMiddleGaugeHyp` to `HasFactorizedLocalGauge`/`BlockedMiddleGaugeFormula` (and the associated implication theorem).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41cd737be34f325959c11b5e2f1950fbc2a652d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>