### PR TITLE
style(Wielandt): clean rank-one span prose

### DIFF
--- a/TNLean/Wielandt/PaperResults/EigenvectorSpreading.lean
+++ b/TNLean/Wielandt/PaperResults/EigenvectorSpreading.lean
@@ -25,7 +25,7 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
 1. Use Proposition 3 to pass from `IsPrimitivePaper A` to eventually full Kraus
    rank.
 2. Rewrite this as `IsNormal A`.
-3. Apply the backend cumulative spreading theorem `eigenvector_spreading`.
+3. Apply the cumulative spreading theorem `eigenvector_spreading`.
 4. Convert the cumulative conclusion to the exact fixed-length paper statement
    using `vectorSpreadSpan_eq_top_of_cumulativeVectorSpan_eq_top_of_eigenvector`.
 

--- a/TNLean/Wielandt/PaperResults/MatrixSpanExistence.lean
+++ b/TNLean/Wielandt/PaperResults/MatrixSpanExistence.lean
@@ -40,7 +40,7 @@ case analysis of `PaperResults/WielandtInequality.lean`.
 1. Use Proposition 3 to pass from `IsPrimitivePaper A` to eventually full Kraus
    rank (`HasEventuallyFullKrausRank A`).
 2. Rewrite as `IsNormal A`.
-3. Apply the backend existential theorem `wielandt_lemma2b`.
+3. Apply the existential theorem `wielandt_lemma2b`.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Wielandt/PaperResults/MatrixSpanSharpBound.lean
+++ b/TNLean/Wielandt/PaperResults/MatrixSpanSharpBound.lean
@@ -44,7 +44,7 @@ strictly stronger than the qualitative `∃ N` statement exported by
 1. Use Proposition 3 (`primitivePaper_iff_hasEventuallyFullKrausRank`) to pass
    from `IsPrimitivePaper A` to `HasEventuallyFullKrausRank A`.
 2. Rewrite as `IsNormal A` via `hasEventuallyFullKrausRank_iff_isNormal`.
-3. Apply the sharp backend theorem `vecMulVec_eigenvector_exact_wordSpan` from
+3. Apply the sharp theorem `vecMulVec_eigenvector_exact_wordSpan` from
    `TNLean.Wielandt.RectangularSpan.Universality`, which assembles:
    - one-sided `rectSpan` strict growth under normality,
    - the sharp bound `r + D·D̃ ≤ D² − D + 1`,
@@ -84,7 +84,7 @@ theorem vecMulVec_mem_wordSpan_of_isPrimitivePaper_of_noninvertible_eigenvector
     (heig : A i₀ *ᵥ φ = μ • φ) :
     ∀ ψ : Fin D → ℂ,
       Matrix.vecMulVec φ ψ ∈ wordSpan A (D ^ 2 - D + 1) := by
-  -- Proposition 3 supplies the normality needed by the sharp backend theorem.
+  -- Proposition 3 supplies the normality needed by the sharp theorem.
   exact vecMulVec_eigenvector_exact_wordSpan A i₀
     (isNormal_of_isPrimitivePaper A hNorm hPrim) hNotInv hμ heig
 

--- a/TNLean/Wielandt/PaperResults/NonzeroTraceWord.lean
+++ b/TNLean/Wielandt/PaperResults/NonzeroTraceWord.lean
@@ -38,7 +38,7 @@ in the `IsPrimitivePaper` language of the paper.
 ## Proof strategy
 
 Use Proposition 3 to pass from `IsPrimitivePaper A` to eventually full Kraus
-rank, rewrite this as `IsNormal A`, and then apply the backend nonzero-trace
+rank, rewrite this as `IsNormal A`, and then apply the nonzero-trace
 result from `NonzeroTraceProduct.lean`.
 -/
 

--- a/TNLean/Wielandt/Primitivity/ImpliesIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesIrreducible.lean
@@ -15,7 +15,7 @@ has no nontrivial invariant orthogonal projection, i.e., it is an irreducible te
 * `isIrreducibleTensor_of_isPrimitiveMPS_of_posDef`:
   `IsPrimitiveMPS A ρ → ρ.PosDef → IsIrreducibleTensor A`
 
-This is the irreducibility half of the later primitive-to-normal bridge: the
+This is the irreducibility half of the later primitive-to-normal implication: the
 complementary aperiodicity input is recovered from strong irreducibility
 (peripheral spectrum `{1}`) in `ImpliesStronglyIrreducible.lean` /
 `StronglyIrreducibleToFullRank.lean`.

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -571,7 +571,9 @@ theorem not_isPrimitivePaper_of_root_of_unity_eigenvector [NeZero D]
 
 end PeripheralContradiction
 
-/-! ## Part 14: Proposition 3(a) → (c) conclusion — IsPrimitivePaper implies IsPeripherallyPrimitive
+/-! ## Part 14: Proposition 3(a) → (c) conclusion
+
+Paper-primitivity implies peripheral primitivity.
 
 The culminating theorem of the (a)→(c) direction: paper-primitivity of an MPS
 tensor `A` implies peripheral primitivity of its transfer map.
@@ -693,7 +695,7 @@ theorem isStronglyIrreduciblePaper_of_isPrimitivePaper [NeZero D]
   have hIrr : IsIrreducibleMap E :=
     isIrreducibleCP_transferMap_of_isIrreducibleTensor A
       (isIrreducibleTensor_of_isPrimitivePaper A ⟨q, hq⟩)
-  -- Step 6: Package into IsStronglyIrreduciblePaper
+  -- Step 6: assemble `IsStronglyIrreduciblePaper`.
   exact isStronglyIrreduciblePaper_of ρ hρ_pd hρ_fix hCPrim hIrr
 
 end Construction

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -14,7 +14,7 @@ This file states the low-level consequences of `HasPrimitiveFixedPoint` used in 
 Wielandt development and recalls the normality side of the chain from
 `WielandtBound.lean`.
 
-It does **not** prove `HasPrimitiveFixedPoint → IsNormal`. The currently formalized bridge
+It does **not** prove `HasPrimitiveFixedPoint → IsNormal`. The currently formalized route
 with extra `ρ.PosDef` and aperiodicity hypotheses is assembled in
 `QuantumWielandt.lean`; the unconditional implication remains future work.
 
@@ -149,7 +149,7 @@ theorem wielandt_full_analysis [NeZero D]
       cumulativeVectorSpan A φ (D ^ 2) = ⊤) :=
   wielandt_chain A hN
 
-/-! ## Part 4: Status of the primitive → normal bridge
+/-! ## Part 4: Status of the primitive → normal implication
 
 The unconditional implication `HasPrimitiveFixedPoint → IsNormal` is still open
 in this file. The currently formalized route in `QuantumWielandt.lean` proves

--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -50,7 +50,7 @@ access to the (c)→(b) proof route and its quantitative intermediates.
    $$\sum_{|\sigma|=n} |\operatorname{tr}(B^\dagger A_\sigma)|^2 =
    \operatorname{Re}\Bigl(\sum_{i,k} [B^\dagger \mathcal E^n(e_{ik}) B]_{ik}\Bigr)$$
 
-2. **Primitivity bridge**: From strong irreducibility, derive `IsPrimitiveMPS A ρ`
+2. **Primitivity step**: From strong irreducibility, derive `IsPrimitiveMPS A ρ`
    with the *original* positive-definite fixed point `ρ`.
 
 3. **Convergence**: The complementary map `(E - P_ρ)^n → 0` in operator norm,
@@ -63,7 +63,7 @@ access to the (c)→(b) proof route and its quantitative intermediates.
 ## Main results
 
 * `sum_normSq_trace_conjTranspose_mul_evalWord` — the trace-pairing identity
-* `isPrimitiveMPS_of_isStronglyIrreduciblePaper` — primitivity bridge
+* `isPrimitiveMPS_of_isStronglyIrreduciblePaper` — primitivity implication
 * `IsPrimitiveMPS.transferMap_pow_apply_tendsto` — convergence `E^n → P_ρ`
 * `eq_zero_of_trace_conjTranspose_mul_posDef_mul_eq_zero` — PosDef nondegeneracy
 
@@ -190,7 +190,7 @@ theorem sum_normSq_trace_conjTranspose_mul_evalWord
     norm_cast
   rw [hlhs, sum_trace_mul_star_eq]
 
-/-! ### Part 2: Primitivity bridge
+/-! ### Part 2: Primitivity implication
 
 From `IsStronglyIrreduciblePaper A` + left-canonical normalization, we derive
 `IsPrimitiveMPS A ρ` with the *same* positive-definite fixed point `ρ` from the
@@ -203,7 +203,7 @@ definition. The proof chains:
 4. obtain `IsPrimitiveMPS A ρ`
 -/
 
-/-- **Primitivity bridge**: strong irreducibility implies the spectral-gap
+/-- **Primitivity implication**: strong irreducibility implies the spectral-gap
 predicate `IsPrimitiveMPS A ρ` for some positive-definite `ρ`.
 
 This is the key structural step in the (c) → (b) direction: it connects the
@@ -860,7 +860,7 @@ end UniformPositivity
 
 /-! ### Part 8: Final construction — (c) → (b)
 
-Combining the trace-pairing identity (Part 1), primitivity bridge (Part 2),
+Combining the trace-pairing identity (Part 1), primitivity implication (Part 2),
 convergence (Part 3), trace-pairing computation (Part 4), PosDef nondegeneracy
 (Part 5), word-span positivity criterion (Lemma A), operator-norm bound (Lemma B),
 and compactness lower bound (Step C), we prove the main theorem:

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -11,11 +11,11 @@ import TNLean.QPF.PosDef
 import TNLean.Spectral.MixedTransfer
 
 /-!
-# Preparatory lemmas for the current `IsPrimitiveMPS → IsNormal` bridge
+# Preparatory lemmas for the current `IsPrimitiveMPS → IsNormal` route
 
 This file collects spectral-gap consequences of `IsPrimitiveMPS` together with
 basic transfer-map compatibility lemmas. It stops short of proving any
-`IsNormal` theorem; the actual primitive-to-normal bridge now lives in
+`IsNormal` theorem; the actual primitive-to-normal implication now lives in
 `Primitivity/StronglyIrreducibleToFullRank.lean`, while `QuantumWielandt.lean`
 keeps a backward-compatible exact-word-span witness theorem whose public
 statement still carries an aperiodicity parameter.
@@ -47,7 +47,7 @@ fixed point. This is weaker than the paper's primitive condition in
 arXiv:0909.5347, Proposition 3, which additionally forces the fixed point to be
 positive definite.
 
-Accordingly, this file should be read as preparatory material for the bridge,
+Accordingly, this file should be read as preparatory material for the implication,
 not as the final primitive-to-normal theorem.
 
 ## References
@@ -185,7 +185,7 @@ theorem isIrreducibleMap_of_isIrreducibleTensor
 
 /-- **IsIrreducibleTensor ⟹ PosDef** for primitive tensors.
 
-Combines the bridge `IsIrreducibleTensor → IsIrreducibleMap` with
+Combines the implication `IsIrreducibleTensor → IsIrreducibleMap` with
 `posSemidef_fixedPoint_isPosDef_of_irreducible`. -/
 theorem posDef_of_isIrreducibleTensor_of_isPrimitiveMPS
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
@@ -199,7 +199,7 @@ theorem posDef_of_isIrreducibleTensor_of_isPrimitiveMPS
 
 This file intentionally stops before any `IsNormal` theorem.
 
-What it does provide is the preparatory material reused by the later bridge:
+What it does provide is the preparatory material reused by the later implication:
 
 1. `fixedPoint_unique`: the `1`-eigenspace of the transfer map is spanned by
    `ρ`
@@ -217,7 +217,7 @@ formalized here.
 
 For the legacy exact-word-span witness theorem with an explicit aperiodicity
 parameter, see `QuantumWielandt.lean`. For the actual
-`IsPrimitiveMPS + PosDef → IsNormal` bridge, see
+`IsPrimitiveMPS + PosDef → IsNormal` implication, see
 `Primitivity/StronglyIrreducibleToFullRank.lean`.
 -/
 

--- a/TNLean/Wielandt/QuantumWielandt.lean
+++ b/TNLean/Wielandt/QuantumWielandt.lean
@@ -40,7 +40,7 @@ additional `hAper : 1 ∈ wordSpan A 1` to upgrade `IsNormal A` to monotone
 exact-length word spans.
 
 This module is intentionally auxiliary. Downstream users who only need
-Proposition 3 / Theorem 1 wrappers should prefer
+Proposition 3 / Theorem 1 statements should prefer
 `Primitivity/Equivalence.lean` and `PaperResults/WielandtInequality.lean`.
 
 ## References

--- a/TNLean/Wielandt/RankOne/BoundedWord.lean
+++ b/TNLean/Wielandt/RankOne/BoundedWord.lean
@@ -16,7 +16,7 @@ This file introduces a two-sided ("bi-rectangular") span
 
 `biRectSpan P Q B n = span{ P * M * Q : M ∈ wordSpan B n }`
 
-and develops basic API (membership, finrank bounds, injectivity tools) for the
+and develops membership, finrank bounds, and injectivity lemmas for the
 missing rank-one extraction step in the Quantum Wielandt proof.
 
 The eventual goal is to show that for suitable choices of `P,Q` (coming from
@@ -286,7 +286,7 @@ theorem biRectSpan_finrank_le
 /-!
 ## Injectivity tools on invertible blocks
 
-The next lemmas package the `RankOneSpanGrowth` disjointness statement into
+The next lemmas turn the `RankOneSpanGrowth` disjointness statement into
 convenient pointwise injectivity statements for left and right multiplication.
 -/
 
@@ -386,7 +386,7 @@ end WielandtRankOne
 The intended use is with `P = (B i₀)^D` and `Q = (B i₁)^D` coming from the
 nilpotent-killing powers of word-eigenvalue products.
 
-At this stage we record a basic (coarse) monotonicity statement for `finrank`.
+At this stage we prove a basic (coarse) monotonicity statement for `finrank`.
 -/
 
 noncomputable section BiRectSpanDimGrowth

--- a/TNLean/Wielandt/RankOne/Element.lean
+++ b/TNLean/Wielandt/RankOne/Element.lean
@@ -38,7 +38,7 @@ variable {d D : ℕ}
 /-- If `M = evalWord A w`, then the matrix power `M ^ k` lies in the fixed-length
 word span at length `k * w.length`.
 
-This is a small helper for later bounded-length constructions. -/
+This lemma is used in later bounded-length constructions. -/
 theorem evalWord_pow_mem_wordSpan (A : MPSTensor d D) (w : List (Fin d)) (k : ℕ) :
     (evalWord A w) ^ k ∈ wordSpan A (k * w.length) := by
   classical
@@ -88,7 +88,7 @@ lemma pow_mulVec_eq_smul_of_mulVec_eq_smul
 
 namespace WielandtRankOne
 
-/-- Helper: if a linear map preserves a submodule, then all powers preserve it. -/
+/-- If a linear map preserves a submodule, then all powers preserve it. -/
 private lemma pow_apply_mem_of_mapsTo
     {V : Type*} [AddCommGroup V] [Module ℂ V]
     (f : End ℂ V) (U : Submodule ℂ V)
@@ -105,7 +105,7 @@ private lemma pow_apply_mem_of_mapsTo
       -- `f^(n+1) v = f^n (f v)`.
       simpa [pow_succ, Module.End.mul_apply] using ih (v := f v) hv'
 
-/-- Helper: on `V = Fin D → ℂ`, the zero generalized eigenspace is the kernel of `f ^ D`. -/
+/-- On `V = Fin D → ℂ`, the zero generalized eigenspace is the kernel of `f ^ D`. -/
 private lemma maxGenEigenspace_zero_eq_ker_pow
     (f : End ℂ (Fin D → ℂ)) :
     f.maxGenEigenspace (0 : ℂ) = LinearMap.ker (f ^ D) := by

--- a/TNLean/Wielandt/RankOne/Extraction.lean
+++ b/TNLean/Wielandt/RankOne/Extraction.lean
@@ -49,7 +49,7 @@ namespace WielandtRankOne
 
 /-- Coercing a restricted endomorphism back to the ambient space commutes with powers.
 
-This is a small helper for transporting computations from a generalized eigenspace
+This lemma transports computations from a generalized eigenspace
 (submodule) back to the full space. -/
 private lemma coe_pow_restrict
     {V : Type*} [AddCommGroup V] [Module ℂ V]

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -47,9 +47,9 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ## Helper lemmas -/
+/-! ## Linear-algebra lemmas -/
 
-section Helpers
+section LinearAlgebraLemmas
 
 /-- An eigenvector with nonzero eigenvalue lies in the range of the matrix. -/
 theorem mem_range_toLin'_of_eigenvector
@@ -192,7 +192,7 @@ private theorem BlockedTensorRangeData.rankOne_mem_wordSpan_of_cumulativeSpan_eq
     (d := blockPhysDim d L) (D := D)
     data.B data.P data.Q data.hP data.hQ hcs hone) data.rankOne_mem_range
 
-end Helpers
+end LinearAlgebraLemmas
 
 /-! ## Nonzero-trace word extraction from a full word span -/
 

--- a/TNLean/Wielandt/RankOne/Manufacture.lean
+++ b/TNLean/Wielandt/RankOne/Manufacture.lean
@@ -11,7 +11,7 @@ import Mathlib.LinearAlgebra.Matrix.ToLin
 /-!
 # Manufacturing a rank-one matrix in the range of two-sided multiplication
 
-This file provides a small helper lemma used in the rank-one step of the Wielandt proof:
+This file proves a lemma used in the rank-one step of the Wielandt proof:
 
 If a column vector `φ` lies in the range of left-multiplication by `P` (as a linear map on
 vectors), and a row vector `ψ` lies in the range of right-multiplication by `Q` (again as a

--- a/TNLean/Wielandt/RankOne/Products.lean
+++ b/TNLean/Wielandt/RankOne/Products.lean
@@ -13,7 +13,7 @@ import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.Analysis.Complex.Polynomial.Basic
 
 /-!
-# Eigenvalue Extraction and Rank-One Products (Lemma 2(b) Infrastructure)
+# Eigenvalue Extraction and Rank-One Products (Lemma 2(b) Ingredients)
 
 This file provides the eigenvalue/eigenvector extraction lemmas needed for
 the Quantum Wielandt bound assembly, corresponding to **Lemma 2(b)** of
@@ -28,12 +28,12 @@ The paper's proof of the main theorem proceeds by:
    word products applied to `φ` span all of `ℂ^D`
 4. Converting vector spanning to matrix spanning (Lemma 2(b))
 
-This file handles step 2 and provides the bridge between traces and eigenvalues.
+This file handles step 2 and relates nonzero traces to nonzero eigenvalues.
 
 ## Our approach
 
 We avoid the paper's Jordan Normal Form argument for Lemma 2(b) by using
-Mathlib's generalized eigenspace infrastructure via our `FittingDecomposition`.
+Mathlib's generalized eigenspace theory via our `FittingDecomposition`.
 The core insight is:
 - Nonzero trace implies nonzero eigenvalue (over algebraically closed fields)
 - Nonzero eigenvalue gives an eigenvector
@@ -109,8 +109,8 @@ theorem Matrix.exists_nonzero_spectrum_mem [NeZero D]
 
 /-- **Nonzero trace implies `HasEigenvalue` for the associated linear map.**
 
-This bridges between the matrix world and Mathlib's linear map eigenvalue theory.
-The eigenvalue is for `Matrix.toLin' M`, which is the linear map `v ↦ M *ᵥ v`.
+This relates a matrix eigenvalue to the corresponding eigenvalue of the linear
+map `Matrix.toLin' M`, namely `v ↦ M *ᵥ v`.
 
 Paper: used implicitly in Theorem 1 proof. -/
 theorem exists_hasEigenvalue_of_trace_ne_zero [NeZero D]

--- a/TNLean/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/Basic.lean
@@ -14,12 +14,12 @@ import Mathlib.Data.Fin.Tuple.Basic
 /-!
 # Rectangular Span Foundations and Lemma 2(b) Assembly
 
-This module contains the foundational rectangular-span API used in the Wielandt
+This module contains the foundational rectangular-span theory used in the Wielandt
 bound: blocking preserves normality, blocked eigenvector transfer, the basic
 one-sided and cumulative rectangular spans, and the conditional and blocked
 assembly steps for Lemma 2(b).
 
-The later growth, stabilization, universality, and sharp quantitative backends
+The later growth, stabilization, universality, and sharp quantitative theorems
 live in `TNLean.Wielandt.RectangularSpan.Growth` and
 `TNLean.Wielandt.RectangularSpan.Universality`.
 

--- a/TNLean/Wielandt/RectangularSpan/Growth.lean
+++ b/TNLean/Wielandt/RectangularSpan/Growth.lean
@@ -9,15 +9,14 @@ import TNLean.Wielandt.RectangularSpan.Basic
 /-!
 # Rectangular Span Growth and Stabilization
 
-This module develops the one-sided rectangular-span growth argument used in the
-Wielandt Lemma 2(b) backend. It proves that left-multiplication by `A i₀`
+This module develops the one-sided rectangular-span growth argument used in
+Wielandt Lemma 2(b). It proves that left-multiplication by `A i₀`
 induces an injective step map on `rectSpan ((A i₀)^D) A n`, deduces monotonicity
-of the associated finrank sequence, and records the stabilization criteria that
+of the associated finrank sequence, and proves the stabilization criteria that
 identify `rectSpan` and `cumulativeRectSpan` with `range (mulLeft P)`.
 
 `TNLean.Wielandt.RectangularSpan.Universality` builds on this file to turn stabilized
-rectangular spans into rank-one universality and the later sharp D²-D+1
-backends.
+rectangular spans into rank-one universality and the later sharp D²-D+1 theorems.
 -/
 
 open scoped Matrix

--- a/TNLean/Wielandt/RectangularSpan/Ranges.lean
+++ b/TNLean/Wielandt/RectangularSpan/Ranges.lean
@@ -108,7 +108,7 @@ noncomputable def colRangeSubmodule (P : Matrix (Fin D) (Fin D) ℂ) :
     simpa [hcol] using
       (Submodule.smul_mem (LinearMap.range (Matrix.toLin' P)) a (hM j))
 
-/-- Package the range of left-multiplication as the submodule of matrices whose columns lie in
+/-- Identify the range of left-multiplication as the submodule of matrices whose columns lie in
 `range (Matrix.toLin' P)`. -/
 theorem range_mulLeft_eq_pi (P : Matrix (Fin D) (Fin D) ℂ) :
     LinearMap.range (LinearMap.mulLeft ℂ P) = colRangeSubmodule (D := D) P := by
@@ -244,7 +244,7 @@ noncomputable def rowRangeSubmodule (Q : Matrix (Fin D) (Fin D) ℂ) :
     simpa [hrow] using
       (Submodule.smul_mem (LinearMap.range (Q.vecMulLinear)) a (hM i))
 
-/-- Package the range of right-multiplication as the submodule of matrices whose rows lie in
+/-- Identify the range of right-multiplication as the submodule of matrices whose rows lie in
 `range (Q.vecMulLinear)`. -/
 theorem range_mulRight_eq_pi (Q : Matrix (Fin D) (Fin D) ℂ) :
     LinearMap.range (LinearMap.mulRight ℂ Q) = rowRangeSubmodule (D := D) Q := by

--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -7,10 +7,10 @@ Authors: TNLean contributors
 import TNLean.Wielandt.RectangularSpan.UniversalityAux
 
 /-!
-# Rectangular Span Universality — Sharp Backends (Sections 8g–8h)
+# Rectangular Span Universality — Sharp Bounds (Sections 8g–8h)
 
-This module is the second half of the rectangular-span universality proof.  It imports
-all the auxiliary infrastructure from `UniversalityAux` and proves the key unconditional
+This module is the second half of the rectangular-span universality proof. It imports
+the auxiliary lemmas from `UniversalityAux` and proves the key unconditional
 theorems.
 
 ## Main results
@@ -163,7 +163,7 @@ theorem rectSpan_nilpIndex_eq_range_of_strict_growth
   set C := D * dTilde
   set a := fun n => finrank ℂ (rectSpan P A n)
   have hrank_eq : P.rank = dTilde := rank_pow_nilpIndex_eq A i₀
-  -- Monotonicity from nilpIndex growth infrastructure
+  -- Monotonicity from the nilpIndex growth lemmas.
   have hMono : ∀ n, a n ≤ a (n + 1) :=
     fun n => rectSpan_nilpIndex_finrank_mono A i₀ n
   -- Ceiling: finrank(R_n) ≤ D * D̃ for all n
@@ -303,7 +303,7 @@ theorem proj_gen_in_leftStep_of_finrank_eq
 /-! ### Part 5: NilpIndex structural consequences
 
 Analogues of Part 4 for `P = (A i₀)^r` where `r = nilpIndex(toLin'(A i₀))`.
-These use the nilpIndex growth infrastructure from Section 8f½. -/
+These use the nilpIndex growth lemmas from Section 8f½. -/
 
 /-- **NilpIndex version of structural invariance**: when finrank stabilizes
 at the nilpIndex power, `rectSpan P A (n+1) = (A i₀) · rectSpan P A n`. -/
@@ -399,11 +399,14 @@ Combined with the **commutativity** of `mulLeft` and `mulRight` on submodules
 1. **Right-expansion**: `rectSpan P A (n+1) = ⨆_j mulRight(A j)(rectSpan P A n)`
 2. **Structural permanence**: if `R_{n+1} = A i₀ · R_n` (from finrank stabilization),
    then `R_{n+2} = A i₀ · R_{n+1}` (by substituting and using commutativity)
-3. **Finrank permanence**: finrank(R_n) = finrank(R_{n+1}) ⟹ finrank(R_{n+1}) = finrank(R_{n+2})
-4. **Constant finrank**: stabilization at level n ⟹ finrank(R_m) = finrank(R_n) ∀ m ≥ n
+3. **Finrank permanence**:
+   finrank(R_n) = finrank(R_{n+1}) ⟹ finrank(R_{n+1}) = finrank(R_{n+2})
+4. **Constant finrank**:
+   stabilization at level n ⟹ finrank(R_m) = finrank(R_n) ∀ m ≥ n
 5. **Strict growth under IsNormal**: contrapositive of (4) using existence of N
    with rectSpan P A N = range(mulLeft P)
-6. **Unconditional sharp D²-D+1**: plugging (5) into `wielandt_unconditional_sharp_of_strict_growth`
+6. **Unconditional sharp D²-D+1**:
+   plug (5) into `wielandt_unconditional_sharp_of_strict_growth`
 -/
 
 section ExactPropagation
@@ -433,7 +436,7 @@ theorem wordSpan_succ_eq_mul_right (A : MPSTensor d D) (n : ℕ) :
       (Submodule.subset_span ⟨σ₂, rfl⟩)
   · exact wordSpan_mul_le A n 1
 
-/-! ### Helpers for length-1 word spans -/
+/-! ### Lemmas for length-1 word spans -/
 
 /-- `evalWord A (List.ofFn σ) = A (σ 0)` for `σ : Fin 1 → Fin d`. -/
 private lemma evalWord_ofFn_one (A : MPSTensor d D) (σ : Fin 1 → Fin d) :
@@ -784,7 +787,7 @@ The sharp direct route via `nilpIndex` provides:
 - `vecMulVec_eigenvector_sharp_of_rectSpan`: conditional sharp Lemma 2(b)
   — `∀ ψ, vecMulVec φ ψ ∈ cumulativeSpan A (D² - D + 1)`
 
-### NilpIndex growth infrastructure (Section 8f½)
+### NilpIndex growth lemmas (Section 8f½)
 Mirrors Section 8 growth for P = (A i₀)^r where r = nilpIndex:
 - `mulLeft_mem_rectSpan_nilpIndex_succ`: left-step membership
 - `rectSpanNilpIndexLeftStep`: the linear map
@@ -816,7 +819,8 @@ The permanence chain that closes the Appendix-A bottleneck:
 - `rectSpan_nilpIndex_strict_growth_of_isNormal`: **strict growth under IsNormal** ⭐
   — `finrank(R_n) < D·D̃ → finrank(R_n) < finrank(R_{n+1})`
 - `wielandt_sharp_unconditional`: **unconditional sharp D²-D+1 Lemma 2(b)** ⭐⭐
-  — `IsNormal → ¬IsUnit → eigenvector → ∀ψ, vecMulVec φ ψ ∈ cumulativeSpan A (D²-D+1)`
+  — `IsNormal → ¬IsUnit → eigenvector → ∀ψ,
+      vecMulVec φ ψ ∈ cumulativeSpan A (D²-D+1)`
 
 ### Eigenvector padding and exact wordSpan (Section 8h, Part 7)  ⭐⭐⭐ NEW
 Upgrades the cumulativeSpan result to exact wordSpan at the paper level D²-D+1:
@@ -826,7 +830,7 @@ Upgrades the cumulativeSpan result to exact wordSpan at the paper level D²-D+1:
 - `vecMulVec_eigenvector_exact_wordSpan`: **exact paper-level D²-D+1** ⭐⭐⭐
   — `IsNormal → ¬IsUnit → eigenvector → ∀ψ, vecMulVec φ ψ ∈ wordSpan A (D²-D+1)`
 
-This completes the exact-level backend at the paper level. The remaining work
+This completes the exact-level result at the paper level. The remaining work
 to get a fully unconditional `wordSpan A N = ⊤` for `N = D²-D+1` is purely
 in the top-level assembly: connecting eigenvector existence, blocking, and
 the sharp rank-one placement.

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
@@ -30,7 +30,7 @@ Combined with the stabilization results from Section 8b showing
 `rectSpan P A n = range(mulLeft P)`, this yields the key universality statement:
 for every `ψ`, `vecMulVec φ ψ ∈ rectSpan P A n`.
 
-This is the backend engine for the exact Lemma 2(b) of arXiv:0909.5347: once the
+This is the core implication behind the exact Lemma 2(b) of arXiv:0909.5347: once the
 one-sided rectangular span stabilizes to the full range, every rank-one matrix
 `|φ⟩⟨ψ|` with `φ` in the range of the D-th power projection lands in
 `rectSpan ⊆ wordSpan`.
@@ -250,8 +250,8 @@ Under `IsNormal A` and with an eigenvector `A i₀ *ᵥ φ = μ • φ` (`μ ≠
 there exists `n` such that for **every** `ψ`,
 `vecMulVec φ ψ ∈ wordSpan A (D + n)`.
 
-This is the backend theorem that directly feeds into the paper's Lemma 2(b)
-conditional assembly. -/
+This is the theorem that directly feeds into the paper's Lemma 2(b) conditional
+assembly. -/
 theorem exists_wordSpan_forall_vecMulVec_eigenvector
     (A : MPSTensor d D) (i₀ : Fin d) (hN : IsNormal A)
     {φ : Fin D → ℂ} {μ : ℂ} (hμ : μ ≠ 0)

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
@@ -19,10 +19,10 @@ open scoped Matrix
 
 namespace MPSTensor
 
-/-! ## Section 8f½: NilpIndex growth infrastructure
+/-! ## Section 8f½: NilpIndex growth lemmas
 
-The growth infrastructure in Section 8 (left-step membership, injectivity,
-finrank monotonicity, surjectivity) was proved for `P = (A i₀)^D`.
+The growth lemmas in Section 8 (left-step membership, injectivity,
+finrank monotonicity, surjectivity) were proved for `P = (A i₀)^D`.
 Here we prove the analogous results for `P = (A i₀)^r` where `r = nilpIndex`.
 
 The key observation: since `range((A i₀)^r) = range((A i₀)^D)` (by

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
@@ -20,7 +20,7 @@ namespace MPSTensor
 
 /-! ## Section 8e: Quantitative ceiling for one-sided rectangular span
 
-This section provides the quantitative dimension-counting infrastructure for the
+This section provides the quantitative dimension-counting lemmas for the
 exact Lemma 2(b) bound. The key results are:
 
 1. **Initial dimension**: `rectSpan P A 0` has finrank 1 when `P ≠ 0` (it equals `span{P}`).
@@ -257,7 +257,8 @@ such that `rectSpan ((A i₀)^D) A n₀ = range(mulLeft ((A i₀)^D))`, we get:
 i.e., the word span at length `D + n₀ + 2D - 2` is the full matrix algebra.
 
 ### Proof strategy
-1. Eigenvector `φ` lies in `range(toLin' ((A i₀)^D))` → for all `ψ`, `vecMulVec φ ψ ∈ rectSpan`
+1. Eigenvector `φ` lies in `range(toLin' ((A i₀)^D))`, so for all `ψ`,
+   `vecMulVec φ ψ ∈ rectSpan`.
 2. `rectSpan` stabilized at `n₀` → `vecMulVec φ ψ ∈ wordSpan A (D + n₀)`
 3. Apply conditional assembly (eigenvector spreading + row spreading)
 4. Output: `wordSpan A ((D-1) + ((D + n₀) + (D-1))) = ⊤`

--- a/TNLean/Wielandt/SpanGrowth/EigenvectorSpreading.lean
+++ b/TNLean/Wielandt/SpanGrowth/EigenvectorSpreading.lean
@@ -367,8 +367,8 @@ Deviation: we prove the cumulative conclusion `K_{D-1} = ⊤` instead of the pap
 single-level conclusion `H_{D-1} = ⊤`. This is enough for every downstream use in this
 formalization.
 
-The eigenvector data are kept in the statement for API compatibility with the paper and
-with downstream wrappers. The current cumulative proof uses only `hφ` together with
+The eigenvector data are kept in the statement to match the paper and downstream
+theorems. The current cumulative proof uses only `hφ` together with
 the normality witness. -/
 theorem eigenvector_spreading [NeZero D]
     (A : MPSTensor d D) (φ : Fin D → ℂ) (hφ : φ ≠ 0)

--- a/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
@@ -19,7 +19,7 @@ Wielandt inequality (arXiv:0909.5347, Theorem 1; Wolf Section 6.9).
 
 ## What is proved here
 
-### Sorry-free infrastructure
+### Established span-growth lemmas
 * `wordSpan_finrank_le`: `dim(S_n) ≤ D²`.
 * `mulLeft_image_wordSpan_le_succ`: `A i₀ · S_n ⊆ S_{n+1}`.
 * `wordSpan_finrank_mono_of_isUnit`: `dim(S_{n+1}) ≥ dim(S_n)` when `A i₀`

--- a/TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
+++ b/TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
@@ -30,7 +30,7 @@ We prove both the coarse and sharp versions:
 4. `exists_nonzero_trace_word_sharp`: There exists a word product of
    length ≤ D² − dim(S₁) + 1 with nonzero trace.
 
-The sharp bound uses `dim(S₁(A))` instead of the raw parameter `d`
+The sharp bound uses `dim(S₁(A))` instead of the ambient alphabet size `d`
 since `dim(S₁(A)) ≤ d` in general. When the Kraus operators are
 linearly independent, `dim(S₁(A)) = d` and the bounds coincide.
 
@@ -252,7 +252,7 @@ private theorem cumulativeSpan_dim_growth_from_one
             cumulativeSpan_finrank_strict_mono A hlt
         omega
 
-/-- The key step helper for the sharp bound: if `IsNormal` and
+/-- The key step for the sharp bound: if `IsNormal` and
 `dim(S₁) = r`, then `cumulativeSpan A (D² − r + 1) = ⊤`.
 
 This is the argument from arXiv:0909.5347, Lemma 1: the dimension of T_n
@@ -365,7 +365,7 @@ Paper: "If E_A is primitive, then there exists A^(n) ∈ S_n(A)
 with n ≤ D²−d+1 such that tr(A^(n)) ≠ 0."
 
 We use `dim(S₁(A))` (which equals `krausRank A` in the paper-facing
-layer) instead of the raw parameter `d`, since in general
+layer) instead of the ambient alphabet size `d`, since in general
 `dim(S₁(A)) ≤ d` and `dim(S₁(A))` is the tight quantity.
 (arXiv:0909.5347, Lemma 1) -/
 theorem exists_nonzero_trace_word_sharp [NeZero D]

--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -100,7 +100,7 @@ theorem wordSpan_mul_le (A : MPSTensor d D) (m n : ℕ) :
   -- Rewrite the product using `evalWord_append`.
   simpa [evalWord_append] using hmem
 
-/-- Helper: `⊤ * ⊤ = ⊤` for submodules of the matrix algebra. -/
+/-- The product of two full matrix-algebra submodules is full. -/
 private theorem top_mul_top_eq_top :
     (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) *
       (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) = ⊤ := by

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -43,8 +43,8 @@ We formalize the proof chain up to the following:
 The gap between vector spanning (step 4) and matrix spanning (the full bound)
 corresponds to Lemma 2(b) of the paper, which requires converting
 "word products applied to φ span ℂ^D" into "word products span M_D(ℂ)".
-This step uses the Jordan/Fitting decomposition but needs additional
-infrastructure for the full formalization.
+This step uses the Jordan/Fitting decomposition and needs additional lemmas for
+the full formalization.
 
 ## References
 


### PR DESCRIPTION
### Motivation

- Continues the prose-cleanup work of #1013 (after #1161) by removing process-oriented language from the rank-one extraction and rectangular-span Wielandt modules.
- The change is prose-only: no declarations, statements, imports, or proof terms are renamed or altered.

### Description

- Replaces software-process terms (`API`, `package`, `helper`, `record`, `infrastructure`, `backend`, `wrapper`, `raw`) with mathematical descriptions in the affected Wielandt files.
- Cleans rank-one extraction prose around nonzero traces, eigenvalues, finite-length word spans, and two-sided rectangular spans.
- Cleans rectangular-span prose around growth lemmas, nilpotent-index bounds, and the sharp D²−D+1 statements.

### Testing

- `rg -n -i "API|package|packaged|helper|helpers|infrastructure|bridge|bridges|backend|backends|wrapper|wrappers|raw|record|records|scaffold|bookkeeping|machinery" $(git diff --name-only -- TNLean/Wielandt)`
- `awk 'length($0)>100 {print FILENAME ":" FNR ":" length($0) ":" $0}' $(git diff --name-only -- TNLean/Wielandt)`
- `git diff --check`
- `lake env lean TNLean/Wielandt/RankOne/BoundedWord.lean`
- `lake env lean TNLean/Wielandt/RectangularSpan/Universality.lean`
- `lake env lean TNLean/Wielandt/QuantumWielandt.lean`
- `lake env lean TNLean/Wielandt/RankOne/ExtractionFull.lean`
- `lake env lean TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean`
- `lake env lean TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean`
- `lake env lean TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean`

---
Addresses #1013

> [!NOTE]
> **Low Risk**
> Comment-only edits across the Wielandt proof modules; no declarations, proofs, or imports are changed, so behavior and theorem statements are unaffected.
>
> **Overview**
> Updates documentation blocks and inline comments throughout the `Wielandt` rank-one extraction, rectangular-span, span-growth, and primitivity modules to use more mathematical phrasing (e.g., replacing process-oriented terms like *API/helper/infrastructure/backend*).
>
> No Lean definitions, theorem statements, or proof terms are modified—this PR is purely a prose/readability pass.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba9b92e8161fc726506b47494f5ee4d1c9b1d6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to comments and module docstrings, with no modifications to declarations, theorem statements, imports, or proof terms.
> 
> **Overview**
> Updates documentation and inline comments across the Wielandt `PaperResults`, `Primitivity`, `RankOne`, `RectangularSpan`, and `SpanGrowth` modules to use more mathematical phrasing and remove process-oriented terminology (e.g., “API”, “backend”, “package”, “helper”, “infrastructure”, “bridge”).
> 
> No Lean code behavior changes: all edits are prose-only, clarifying proof-strategy descriptions and section headings without altering definitions or proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ff4ceb812d862e90a707aad9e29ad482c00f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->