### PR TITLE
feat(MPS/CanonicalForm): route CPSV through BNT cover

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -77,10 +77,13 @@ structure AfterBlockingFundamentalTheoremHypotheses
     {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop where
   /-- The one-sided blocked-word relabeling equality for common cyclic-sector families. -/
   relabel : CommonSectorRelabelingHypothesis d
-  /-- The remaining comparison data for the produced common primitive nonzero-sector families,
-  with the structural evidence for trace preservation, primitivity, and irreducibility supplied. -/
+  /-- The remaining BNT-cover comparison data for the produced common primitive
+  nonzero-sector families, with the structural evidence for trace preservation,
+  primitivity, and irreducibility supplied. -/
   comparison : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
       {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      [∀ x : Fin rA, NeZero (dimA x)]
+      [∀ x : Fin rB, NeZero (dimB x)]
       {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
       {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
       {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
@@ -117,7 +120,10 @@ structure AfterBlockingFundamentalTheoremHypotheses
       (∀ x, IsIrreducibleTensor (blocksB x)) →
       (∀ x, 0 < dimA x) →
       (∀ x, 0 < dimB x) →
-      CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB
+      ∃ DtotA DtotB,
+        Nonempty
+          (CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+            (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB)
 
 /-- Conclusion of the conditional after-blocking Fundamental Theorem formulation.
 
@@ -171,7 +177,7 @@ hypotheses, there is a positive blocking after which the two tensors admit BNT s
 decompositions with the same sector MPV family, matched basis-sector multiplicities, and matched
 sector-weight multisets up to nonzero phases.  This is the conditional formulation proved by the
 present periodic-theorem-free derivation: it is a direct consequence of
-`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional`, not a hidden
+`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover`, not a hidden
 assumption or an appeal to the periodic Fundamental Theorem. -/
 theorem fundamentalTheorem_afterBlocking_of_comparisonHypotheses
     {d D₁ D₂ : ℕ}
@@ -181,7 +187,7 @@ theorem fundamentalTheorem_afterBlocking_of_comparisonHypotheses
     Nonempty (AfterBlockingFundamentalTheoremConclusion A B) := by
   obtain ⟨p, hp, P, Q, hA, hB, hPQ, hPbnt, hQbnt,
       perm, hCopies, phase, hPhase, hWeights⟩ :=
-    afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional
+    afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
       A B hSame h.relabel h.comparison
   exact ⟨{
     p := p

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1761,14 +1761,14 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}
 	\leanok
 	\uses{def:common_sector_relabeling_hypothesis,
-		def:common_primitive_proportional_hypotheses}
+		def:common_primitive_bnt_cover_hypotheses}
 		These hypotheses consist of the comparison data for the
 	periodic-theorem-free after-blocking formulation of the CPSV Fundamental
 		Theorem. They contain the blocked-word identification for common cyclic
 	sectors. For the common primitive nonzero-sector families produced from two
 	tensors with the same MPV family, the comparison field is supplied with their
-	isometry, primitivity, and irreducibility evidence before returning the
-		proportional-comparison hypotheses for those blocks. The hypotheses
+	isometry, primitivity, irreducibility, and positive bond-dimension evidence
+	before returning BNT-cover comparison hypotheses for those blocks. The hypotheses
 	are tied to the produced families rather than to an arbitrary chosen
 	decomposition.
 \end{definition}
@@ -1793,7 +1793,7 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:after_blocking_fundamental_theorem_hypotheses,
 		def:after_blocking_fundamental_theorem_conclusion,
-		thm:afterBlocking_sectorComparison_reindexed_proportional}
+		thm:afterBlocking_sectorComparison_reindexed_bntCover}
 	Let $A$ and $B$ generate the same MPV family. Assume the after-blocking
 	comparison hypotheses of
 	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. Then the
@@ -1807,15 +1807,16 @@ two-basis sector comparison theorem.
 	whose basis sectors and weights match up to permutation and nonzero phases, as
 	in \cite{Cirac2016MPDO_arXiv} and \cite{Cirac2021Matrix}. The explicit hypotheses are:
 	the statement does not assume away the blocked-word identification, zero-tail,
-	isometry, primitivity, irreducibility, or proportional-comparison inputs.
+	isometry, primitivity, irreducibility, positive bond-dimension, or BNT-cover
+	comparison inputs.
 \end{theorem}
 
 \begin{proof}
 	\leanok
-	\uses{thm:afterBlocking_sectorComparison_reindexed_proportional}
+	\uses{thm:afterBlocking_sectorComparison_reindexed_bntCover}
 	Apply
-	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_proportional} with
-		the word-identification and proportional-comparison data from
+	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover} with
+		the word-identification and BNT-cover comparison data from
 	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. The proof
 	then packages the resulting blocking length, sector decompositions, BNT data,
 	permutation, multiplicity equalities, phases, and sector-weight

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -97,9 +97,10 @@ The hypotheses of this theorem are collected in
 blocked-word relabeling assertion for cyclic-sector data and a comparison
 field for the common primitive nonzero-sector families produced by the preceding
 structural theorem.  That field is supplied with trace-preserving, primitive, and
-irreducible structural data for the produced families; it then returns equality
-of the zero-tail dimensions, one-site injectivity on both sides, and a BNT
-proportional-comparison conclusion for those produced families.
+irreducible structural data and positive bond dimensions for the produced
+families; it then returns BNT-cover data containing the zero-tail, injectivity,
+normal-form separation, and proportional-decomposition comparison needed for
+those produced families.
 
 These hypotheses are not written as hypotheses of Theorem~\texttt{thm1} or of
 Corollary~\texttt{II\_cor2} in the cited papers. They are the formal boundary
@@ -123,16 +124,16 @@ The formal proof must still show that this refinement holds for the final
 common primitive sector families to which the overlap-rigidity comparison is
 applied.
 
-Second, the BNT proportional-comparison hypothesis is the paper-level comparison
-itself, specialized to the produced nonzero-sector families. In the source, once
-the tensors are in canonical form and the bases of normal tensors have been
-chosen, proportionality or equality of all matrix product vectors matches the
-basis tensors up to phases and gauges. The formal theorem in \ghpr{1104} still
-takes the corresponding proportional-decomposition conclusion as input for the
-specific common-sector families. A complete proof without the periodic
-Fundamental Theorem must derive that conclusion from the equality of the original
-tensors' matrix product vector families, after all blockings and reindexings have
-been accounted for.
+Second, the BNT-cover hypothesis contains the paper-level comparison itself,
+specialized to the produced nonzero-sector families. In the source, once the
+tensors are in canonical form and the bases of normal tensors have been chosen,
+proportionality or equality of all matrix product vectors matches the basis
+tensors up to phases and gauges. The formal theorem in \ghpr{1104} still takes
+the corresponding BNT-cover data, including the proportional-decomposition
+conclusion, as input for the specific common-sector families. A complete proof
+without the periodic Fundamental Theorem must derive that data from the equality
+of the original tensors' matrix product vector families, after all blockings and
+reindexings have been accounted for.
 
 These two inputs are therefore not extra assumptions proposed by the papers. They
 are parts of the paper argument that remain to be connected to the current
@@ -181,7 +182,7 @@ This note records a proof gap in the present Lean development rather than a
 source error. The cited papers compress the canonical-form reduction, blocking,
 BNT matching, and injectivity refinements in the usual paper notation. The Lean
 development should keep the theorem conditional until the injectivity refinement,
-the BNT proportional comparison for the produced sectors, the blocked-word
+the BNT-cover comparison for the produced sectors, the blocked-word
 relabeling, and the zero-tail and weight transports have been proved for the same
 final common-sector data.
 


### PR DESCRIPTION
### Motivation
- Issue #944 asks for the remaining sector-comparison inputs needed to discharge the collapsed BNT representative route.
- The public conditional CPSV formulation should expose the BNT-cover data consumed by the current after-blocking sector comparison theorem.

### Description
- Change `AfterBlockingFundamentalTheoremHypotheses.comparison` to require BNT-cover data for the produced common primitive sectors.
- Route `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` through `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover`.
- Update `blueprint/src/chapter/ch11_assembly.tex` and `docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex` to describe the BNT-cover comparison input.

### Testing
- `lake env lean TNLean/MPS/CanonicalForm/Assembly.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --report /tmp/tnlean-blueprint-sync-cpsv.json`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Partially addresses #944

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the statement/signature of `AfterBlockingFundamentalTheoremHypotheses.comparison` and reroutes the main wrapper theorem to a different comparison lemma, which can break downstream proofs and require updated callers, though it does not change computational behavior.
> 
> **Overview**
> Updates the conditional CPSV after-blocking wrapper to require **BNT-cover** comparison data (including nonzero bond-dimension assumptions) instead of the prior proportional-comparison hypothesis, by changing `AfterBlockingFundamentalTheoremHypotheses.comparison` to return `CommonPrimitiveBNTCoverHypotheses`.
> 
> Reroutes `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` to use `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover`, and updates the blueprint chapter and the CPSV paper-gap note to describe the new proof boundary and inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cd0f838738223cc893619e6a9e48933264b07c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->