### PR TITLE
doc(blueprint): address merged review residue

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -71,15 +71,15 @@ nonzero-sector families after a common blocking, once the blocked-word relabelin
 established.  To reach the sector-weight conclusion of the Cirac--Pérez-García--Schuch--Verstraete
 Fundamental Theorem for exactly those produced families, one still needs comparison data for
 those produced families.  The field `comparison` is supplied with their trace-preserving,
-primitive, and irreducible structural evidence, so the remaining assumptions cannot be applied to
-a different decomposition. -/
+primitive, irreducible, and positive bond-dimension evidence, so the remaining assumptions
+cannot be applied to a different decomposition. -/
 structure AfterBlockingFundamentalTheoremHypotheses
     {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop where
   /-- The one-sided blocked-word relabeling equality for common cyclic-sector families. -/
   relabel : CommonSectorRelabelingHypothesis d
   /-- The remaining BNT-cover comparison data for the produced common primitive
   nonzero-sector families, with the structural evidence for trace preservation,
-  primitivity, and irreducibility supplied. -/
+  primitivity, irreducibility, and positive bond dimensions supplied. -/
   comparison : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
       {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
       [∀ x : Fin rA, NeZero (dimA x)]

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1767,7 +1767,7 @@ two-basis sector comparison theorem.
 		Theorem. They contain the blocked-word identification for common cyclic
 	sectors. For the common primitive nonzero-sector families produced from two
 	tensors with the same MPV family, the comparison field is supplied with their
-	isometry, primitivity, irreducibility, and positive bond-dimension evidence
+	trace-preserving, primitivity, irreducibility, and positive bond-dimension evidence
 	before returning BNT-cover comparison hypotheses for those blocks. The hypotheses
 	are tied to the produced families rather than to an arbitrary chosen
 	decomposition.
@@ -1807,8 +1807,8 @@ two-basis sector comparison theorem.
 	whose basis sectors and weights match up to permutation and nonzero phases, as
 	in \cite{Cirac2016MPDO_arXiv} and \cite{Cirac2021Matrix}. The explicit hypotheses are:
 	the statement does not assume away the blocked-word identification, zero-tail,
-	isometry, primitivity, irreducibility, positive bond-dimension, or BNT-cover
-	comparison inputs.
+	trace-preserving normalization, primitivity, irreducibility, positive bond-dimension,
+	or BNT-cover comparison inputs.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1767,7 +1767,8 @@ two-basis sector comparison theorem.
 		Theorem. They contain the blocked-word identification for common cyclic
 	sectors. For the common primitive nonzero-sector families produced from two
 	tensors with the same MPV family, the comparison field is supplied with their
-	trace-preserving, primitivity, irreducibility, and positive bond-dimension evidence
+	trace-preserving normalization, primitivity, irreducibility, and
+	positive bond-dimension evidence
 	before returning BNT-cover comparison hypotheses for those blocks. The hypotheses
 	are tied to the produced families rather than to an arbitrary chosen
 	decomposition.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -431,29 +431,29 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
 \end{definition}
 
 \begin{definition}[Blocked-middle local gauge formula]%
-	\label{def:peps_blockedMiddleGaugeFormula}
-	\lean{TNLean.PEPS.BlockedMiddleGaugeFormula}
-	\leanok
-	This states the explicit local gauge formula that the edge-centered
-	blocked-middle reduction is expected to produce: a family of invertible
-	matrices on the incident edges of $v$ whose product kernel reconstructs each
+    \label{def:peps_blockedMiddleGaugeFormula}
+    \lean{TNLean.PEPS.BlockedMiddleGaugeFormula}
+    \leanok
+    This states the explicit local gauge formula that the edge-centered
+    blocked-middle reduction is expected to produce: a family of invertible
+    matrices on the incident edges of $v$ whose product kernel reconstructs each
     local component of $B$ from those of $A$.
 \end{definition}
 
 \begin{theorem}[Blocked-middle formula implies factorized local gauge]%
     \label{thm:peps_hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula}
     \lean{TNLean.PEPS.hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula}
-	\leanok
-	\uses{def:peps_blockedMiddleGaugeFormula, def:peps_hasFactorizedLocalGauge}
-	Any explicit local gauge formula from the blocked-middle reduction yields
-	the factorized local gauge datum. The remaining open step is to derive this
-	blocked-middle formula from equality of PEPS states.
+    \leanok
+    \uses{def:peps_blockedMiddleGaugeFormula, def:peps_hasFactorizedLocalGauge}
+    Any explicit local gauge formula from the blocked-middle reduction yields
+    the factorized local gauge datum. The remaining open step is to derive this
+    blocked-middle formula from equality of PEPS states.
 \end{theorem}
 \begin{proof}\leanok
-	The explicit local gauge formula already places each local component of
-	$B$ in the image of the local tensor map of $A$. Applying the chosen left
-	inverse of $A$ identifies the canonical candidate with the same factorized
-	coefficient kernel, so both parts of the factorized local gauge datum follow.
+    The explicit local gauge formula already places each local component of
+    $B$ in the image of the local tensor map of $A$. Applying the chosen left
+    inverse of $A$ identifies the canonical candidate with the same factorized
+    coefficient kernel, so both parts of the factorized local gauge datum follow.
 \end{proof}
 
 \begin{theorem}[Local gauge extraction]%
@@ -472,8 +472,8 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \end{center}
 \end{theorem}
 \begin{proof}\leanok
-	The factorized local gauge datum already supplies the incident-edge
-	invertible matrices and the factorized local coefficient identity.
+    The factorized local gauge datum already supplies the incident-edge
+    invertible matrices and the factorized local coefficient identity.
 \end{proof}
 
 \begin{theorem}[Gauge consistency]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -431,30 +431,29 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
 \end{definition}
 
 \begin{definition}[Blocked-middle local gauge formula]%
-    \label{def:peps_blockedMiddleGaugeFormula}
-    \lean{TNLean.PEPS.BlockedMiddleGaugeFormula}
-    \leanok
-    \uses{def:peps_hasFactorizedLocalGauge}
-    This states the explicit local gauge formula that the edge-centered
-    blocked-middle reduction is expected to produce: a family of invertible
-    matrices on the incident edges of $v$ whose product kernel reconstructs each
+	\label{def:peps_blockedMiddleGaugeFormula}
+	\lean{TNLean.PEPS.BlockedMiddleGaugeFormula}
+	\leanok
+	This states the explicit local gauge formula that the edge-centered
+	blocked-middle reduction is expected to produce: a family of invertible
+	matrices on the incident edges of $v$ whose product kernel reconstructs each
     local component of $B$ from those of $A$.
 \end{definition}
 
 \begin{theorem}[Blocked-middle formula implies factorized local gauge]%
     \label{thm:peps_hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula}
     \lean{TNLean.PEPS.hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula}
-    \leanok
-    \uses{def:peps_blockedMiddleGaugeFormula, def:peps_hasFactorizedLocalGauge}
-    Any explicit local gauge formula from the blocked-middle reduction yields
-    the sharpened local lift. The remaining open step is to derive this
-    blocked-middle formula from equality of PEPS states.
+	\leanok
+	\uses{def:peps_blockedMiddleGaugeFormula, def:peps_hasFactorizedLocalGauge}
+	Any explicit local gauge formula from the blocked-middle reduction yields
+	the factorized local gauge datum. The remaining open step is to derive this
+	blocked-middle formula from equality of PEPS states.
 \end{theorem}
 \begin{proof}\leanok
-    The explicit local gauge formula already places each local component of
-    $B$ in the image of the local tensor map of $A$. Applying the chosen left
-    inverse of $A$ identifies the canonical candidate with the same factorized
-    coefficient kernel, so both parts of the sharpened lift follow.
+	The explicit local gauge formula already places each local component of
+	$B$ in the image of the local tensor map of $A$. Applying the chosen left
+	inverse of $A$ identifies the canonical candidate with the same factorized
+	coefficient kernel, so both parts of the factorized local gauge datum follow.
 \end{proof}
 
 \begin{theorem}[Local gauge extraction]%
@@ -473,8 +472,8 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \end{center}
 \end{theorem}
 \begin{proof}\leanok
-    The sharpened local lift datum already supplies the incident-edge
-    invertible matrices and the factorized local coefficient identity.
+	The factorized local gauge datum already supplies the incident-edge
+	invertible matrices and the factorized local coefficient identity.
 \end{proof}
 
 \begin{theorem}[Gauge consistency]%

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -130,9 +130,9 @@ tensors are in canonical form and the bases of normal tensors have been chosen,
 proportionality or equality of all matrix product vectors matches the basis
 tensors up to phases and gauges. The formal theorem in \ghpr{1104} still takes
 the corresponding BNT-cover data as input for the specific common-sector
-families: normal canonical-form data on both sides, separation of distinct
-sectors by gauge-phase equivalence, zero-tail and injectivity data, and the
-proportional-decomposition comparison. A complete proof without the periodic
+families: normal canonical-form data on both sides, proof that distinct sectors
+are not gauge-phase equivalent, zero-tail and injectivity data, and
+proportional-decomposition data. A complete proof without the periodic
 Fundamental Theorem must derive all of this data from the equality of the
 original tensors' matrix product vector families, after all blockings and
 reindexings have been accounted for.

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -129,10 +129,12 @@ specialized to the produced nonzero-sector families. In the source, once the
 tensors are in canonical form and the bases of normal tensors have been chosen,
 proportionality or equality of all matrix product vectors matches the basis
 tensors up to phases and gauges. The formal theorem in \ghpr{1104} still takes
-the corresponding BNT-cover data, including the proportional-decomposition
-conclusion, as input for the specific common-sector families. A complete proof
-without the periodic Fundamental Theorem must derive that data from the equality
-of the original tensors' matrix product vector families, after all blockings and
+the corresponding BNT-cover data as input for the specific common-sector
+families: normal canonical-form data on both sides, separation of distinct
+sectors by gauge-phase equivalence, zero-tail and injectivity data, and the
+proportional-decomposition comparison. A complete proof without the periodic
+Fundamental Theorem must derive all of this data from the equality of the
+original tensors' matrix product vector families, after all blockings and
 reindexings have been accounted for.
 
 These two inputs are therefore not extra assumptions proposed by the papers. They


### PR DESCRIPTION
### Motivation
- Issue #1165 reported that review comments remained unresolved after recent merges.
- Live review-thread inspection found concrete residue from #1162 and #1164 in the PEPS local-gauge blueprint and the CPSV after-blocking wrapper prose.

### Description
- Update the PEPS blueprint to use the current factorized-local-gauge wording and remove the incorrect self-use edge from `def:peps_blockedMiddleGaugeFormula`.
- Clarify the CPSV after-blocking wrapper docstring and blueprint text around trace-preserving normalization, primitivity, irreducibility, and positive bond dimensions.
- Expand the after-blocking paper-gap note to state the stronger BNT-cover comparison witness currently taken as input.
- No Lean theorem statements, proofs, or public declarations are changed.

### Testing
- `lake env lean TNLean/MPS/CanonicalForm/Assembly.lean`
- `lake env lean TNLean/PEPS/LocalGauge.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --report /tmp/tnlean-review-cleanup-sync.json`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Addresses #1165.
Refs #1162.
Refs #1164.
Refs #1148.
Refs #944.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/docstrings and blueprint `\uses` annotations, with no theorem statements or proof logic modified.
> 
> **Overview**
> Clarifies the after-blocking CPSV wrapper documentation to consistently describe the comparison inputs as *trace-preserving normalization*, primitivity, irreducibility, and positive bond dimensions (Lean docstring and chapter 11 blueprint prose), and updates the surrounding theorem text accordingly.
> 
> Cleans up PEPS local-gauge blueprint wording to use the current “factorized local gauge datum” terminology and removes an incorrect self-reference in the `def:peps_blockedMiddleGaugeFormula` `\uses` metadata.
> 
> Expands the after-blocking “paper gaps” note to spell out the stronger set of BNT-cover comparison witnesses currently assumed as input (normal-form/separation, zero-tail + injectivity, and proportional-decomposition data) for the produced common-sector families.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3faadb6f4df783fbcb6d6c5b5b537fddee5818a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->