### PR TITLE
feat(MPS/CanonicalForm): derive after-blocking relabeling internally

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -68,7 +68,7 @@ namespace MPSTensor
 
 Starting from `SameMPV₂ A B`, the present derivation constructs common primitive
 nonzero-sector families after a common blocking.  The blocked-word relabeling assertion is now
-derived inside the wrapper from the grouped-block cast theorem.  To reach the sector-weight
+derived in this formulation from the grouped-block cast theorem.  To reach the sector-weight
 conclusion of the Cirac--Pérez-García--Schuch--Verstraete Fundamental Theorem for exactly those
 produced families, one still needs comparison data for those produced families.  The field
 `comparison` is supplied with their trace-preserving, primitive, irreducible, and positive
@@ -184,11 +184,8 @@ theorem fundamentalTheorem_afterBlocking_of_comparisonHypotheses
     (hSame : SameMPV₂ A B)
     (h : AfterBlockingFundamentalTheoremHypotheses A B) :
     Nonempty (AfterBlockingFundamentalTheoremConclusion A B) := by
-  have h_group : CommonGroupedBlockCastHypothesis d := by
-    intro r dim blocks F k
-    exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
-      (fun hp_eq h_card i =>
-        CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq hp_eq h_card i) k
+  have h_group : CommonGroupedBlockCastHypothesis d :=
+    CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq d
   have h_relabel : CommonSectorRelabelingHypothesis d :=
     h_group.toRelabelingHypothesis
   obtain ⟨p, hp, P, Q, hA, hB, hPQ, hPbnt, hQbnt,

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -67,16 +67,15 @@ namespace MPSTensor
 /-- Remaining hypotheses for the after-blocking Fundamental Theorem formulation.
 
 Starting from `SameMPV₂ A B`, the present derivation constructs common primitive
-nonzero-sector families after a common blocking, once the blocked-word relabeling assertion is
-established.  To reach the sector-weight conclusion of the Cirac--Pérez-García--Schuch--Verstraete
-Fundamental Theorem for exactly those produced families, one still needs comparison data for
-those produced families.  The field `comparison` is supplied with their trace-preserving,
-primitive, irreducible, and positive bond-dimension evidence, so the remaining assumptions
-cannot be applied to a different decomposition. -/
+nonzero-sector families after a common blocking.  The blocked-word relabeling assertion is now
+derived inside the wrapper from the grouped-block cast theorem.  To reach the sector-weight
+conclusion of the Cirac--Pérez-García--Schuch--Verstraete Fundamental Theorem for exactly those
+produced families, one still needs comparison data for those produced families.  The field
+`comparison` is supplied with their trace-preserving, primitive, irreducible, and positive
+bond-dimension evidence, so the remaining assumptions cannot be applied to a different
+decomposition. -/
 structure AfterBlockingFundamentalTheoremHypotheses
     {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop where
-  /-- The one-sided blocked-word relabeling equality for common cyclic-sector families. -/
-  relabel : CommonSectorRelabelingHypothesis d
   /-- The remaining BNT-cover comparison data for the produced common primitive
   nonzero-sector families, with the structural evidence for trace preservation,
   primitivity, irreducibility, and positive bond dimensions supplied. -/
@@ -185,10 +184,17 @@ theorem fundamentalTheorem_afterBlocking_of_comparisonHypotheses
     (hSame : SameMPV₂ A B)
     (h : AfterBlockingFundamentalTheoremHypotheses A B) :
     Nonempty (AfterBlockingFundamentalTheoremConclusion A B) := by
+  have h_group : CommonGroupedBlockCastHypothesis d := by
+    intro r dim blocks F k
+    exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+      (fun hp_eq h_card i =>
+        CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq hp_eq h_card i) k
+  have h_relabel : CommonSectorRelabelingHypothesis d :=
+    h_group.toRelabelingHypothesis
   obtain ⟨p, hp, P, Q, hA, hB, hPQ, hPbnt, hQbnt,
       perm, hCopies, phase, hPhase, hWeights⟩ :=
     afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
-      A B hSame h.relabel h.comparison
+      A B hSame h_relabel h.comparison
   exact ⟨{
     p := p
     p_pos := hp

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -1183,6 +1183,13 @@ abbrev CommonGroupedBlockCastHypothesis (d : ℕ) : Prop :=
 
 namespace CommonGroupedBlockCastHypothesis
 
+/-- The canonical coordinate grouping for common blocked cyclic-sector families. -/
+theorem of_flattenWordOfBlock_cast_eq (d : ℕ) : CommonGroupedBlockCastHypothesis d := by
+  intro r dim blocks F k
+  exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+    (fun hp_eq h_card i =>
+      CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq hp_eq h_card i) k
+
 /-- The coordinate-grouping assertion implies the one-sided reindexing hypothesis
 used by the common-sector structural theorem. -/
 theorem toRelabelingHypothesis {d : ℕ}
@@ -1459,11 +1466,8 @@ theorem unconditional_commonPrimitiveIrreducibleBlocks
       (∀ x, IsIrreducibleTensor (blocksB x)) ∧
       (∀ x, 0 < dimA x) ∧
       (∀ x, 0 < dimB x) := by
-  have h_group : CommonGroupedBlockCastHypothesis d := by
-    intro r dim blocks F k
-    exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
-      (fun hp_eq h_card i =>
-        CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq hp_eq h_card i) k
+  have h_group : CommonGroupedBlockCastHypothesis d :=
+    CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq d
   have h_relabel : CommonSectorRelabelingHypothesis d :=
     h_group.toRelabelingHypothesis
   exact afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1757,18 +1757,17 @@ two-basis sector comparison theorem.
 \end{proof}
 
 \begin{definition}[After-blocking hypotheses for the CPSV formulation]%
-\label{def:after_blocking_fundamental_theorem_hypotheses}
-	\lean{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}
-	\leanok
-	\uses{def:common_sector_relabeling_hypothesis,
-		def:common_primitive_bnt_cover_hypotheses}
-		These hypotheses consist of the comparison data for the
-	periodic-theorem-free after-blocking formulation of the CPSV Fundamental
-		Theorem. They contain the blocked-word identification for common cyclic
-	sectors. For the common primitive nonzero-sector families produced from two
-	tensors with the same MPV family, the comparison field is supplied with their
-	trace-preserving normalization, primitivity, irreducibility, and
-	positive bond-dimension evidence
+	\label{def:after_blocking_fundamental_theorem_hypotheses}
+		\lean{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}
+		\leanok
+		\uses{def:common_primitive_bnt_cover_hypotheses}
+			These hypotheses consist of the comparison data for the
+		periodic-theorem-free after-blocking formulation of the CPSV Fundamental
+			Theorem. The blocked-word identification for common cyclic sectors is
+		now derived by the wrapper. For the common primitive nonzero-sector families produced from two
+		tensors with the same MPV family, the comparison field is supplied with their
+		trace-preserving normalization, primitivity, irreducibility, and
+		positive bond-dimension evidence
 	before returning BNT-cover comparison hypotheses for those blocks. The hypotheses
 	are tied to the produced families rather than to an arbitrary chosen
 	decomposition.
@@ -1793,8 +1792,9 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}
 	\leanok
 	\uses{def:after_blocking_fundamental_theorem_hypotheses,
-		def:after_blocking_fundamental_theorem_conclusion,
-		thm:afterBlocking_sectorComparison_reindexed_bntCover}
+			def:after_blocking_fundamental_theorem_conclusion,
+			thm:common_grouped_block_cast_to_relabeling,
+			thm:afterBlocking_sectorComparison_reindexed_bntCover}
 	Let $A$ and $B$ generate the same MPV family. Assume the after-blocking
 	comparison hypotheses of
 	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. Then the
@@ -1804,12 +1804,12 @@ two-basis sector comparison theorem.
 
 	The conclusion matches the sector-decomposition part of the
 	Cirac--P\'erez-Garc\'ia--Schuch--Verstraete Fundamental Theorem: after
-	blocking, the tensor families are represented by BNT sector decompositions
-	whose basis sectors and weights match up to permutation and nonzero phases, as
-	in \cite{Cirac2016MPDO_arXiv} and \cite{Cirac2021Matrix}. The explicit hypotheses are:
-	the statement does not assume away the blocked-word identification, zero-tail,
-	trace-preserving normalization, primitivity, irreducibility, positive bond-dimension,
-	or BNT-cover comparison inputs.
+		blocking, the tensor families are represented by BNT sector decompositions
+		whose basis sectors and weights match up to permutation and nonzero phases, as
+		in \cite{Cirac2016MPDO_arXiv} and \cite{Cirac2021Matrix}. The explicit hypotheses are:
+		the statement does not assume away zero-tail, trace-preserving normalization,
+		primitivity, irreducibility, positive bond-dimension, or BNT-cover comparison
+		inputs.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1605,18 +1605,18 @@ two-basis sector comparison theorem.
 \end{definition}
 
 	\begin{theorem}[Canonical coordinate grouping]%
-\label{thm:common_grouped_block_cast_of_flatten_word}
+	\label{thm:common_grouped_block_cast_of_flatten_word}
 		\lean{MPSTensor.CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq}
 		\leanok
 		\uses{def:common_grouped_block_cast_hypothesis,
-			thm:common_blocked_cyclic_sector_grouped_block_cast}
+			thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 		The canonical coordinate grouping holds for every common blocked
 		cyclic-sector family.  The proof identifies each grouped block with the
 		corresponding direct blocked word.
 	\end{theorem}
 
 	\begin{proof}\leanok
-		\uses{thm:common_blocked_cyclic_sector_grouped_block_cast}
+		\uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 		Apply the grouped-block cast comparison to each original nonzero block.
 	\end{proof}
 

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1604,9 +1604,25 @@ two-basis sector comparison theorem.
 	consecutive words of the period-removal length.
 \end{definition}
 
-\begin{theorem}[Coordinate grouping gives the word identification]%
+	\begin{theorem}[Canonical coordinate grouping]%
+\label{thm:common_grouped_block_cast_of_flatten_word}
+		\lean{MPSTensor.CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq}
+		\leanok
+		\uses{def:common_grouped_block_cast_hypothesis,
+			thm:common_blocked_cyclic_sector_grouped_block_cast}
+		The canonical coordinate grouping holds for every common blocked
+		cyclic-sector family.  The proof identifies each grouped block with the
+		corresponding direct blocked word.
+	\end{theorem}
+
+	\begin{proof}\leanok
+		\uses{thm:common_blocked_cyclic_sector_grouped_block_cast}
+		Apply the grouped-block cast comparison to each original nonzero block.
+	\end{proof}
+
+	\begin{theorem}[Coordinate grouping gives the word identification]%
 \label{thm:common_grouped_block_cast_to_relabeling}
-	\lean{MPSTensor.CommonGroupedBlockCastHypothesis.toRelabelingHypothesis}
+		\lean{MPSTensor.CommonGroupedBlockCastHypothesis.toRelabelingHypothesis}
 	\leanok
 	\uses{def:common_grouped_block_cast_hypothesis,
 		def:common_sector_relabeling_hypothesis,
@@ -1764,7 +1780,7 @@ two-basis sector comparison theorem.
 			These hypotheses consist of the comparison data for the
 		periodic-theorem-free after-blocking formulation of the CPSV Fundamental
 			Theorem. The blocked-word identification for common cyclic sectors is
-		now derived by the wrapper. For the common primitive nonzero-sector families produced from two
+		now derived from the grouped-block cast theorem. For the common primitive nonzero-sector families produced from two
 		tensors with the same MPV family, the comparison field is supplied with their
 		trace-preserving normalization, primitivity, irreducibility, and
 		positive bond-dimension evidence
@@ -1792,9 +1808,7 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}
 	\leanok
 	\uses{def:after_blocking_fundamental_theorem_hypotheses,
-			def:after_blocking_fundamental_theorem_conclusion,
-			thm:common_grouped_block_cast_to_relabeling,
-			thm:afterBlocking_sectorComparison_reindexed_bntCover}
+			def:after_blocking_fundamental_theorem_conclusion}
 	Let $A$ and $B$ generate the same MPV family. Assume the after-blocking
 	comparison hypotheses of
 	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. Then the
@@ -1812,13 +1826,17 @@ two-basis sector comparison theorem.
 		inputs.
 \end{theorem}
 
-\begin{proof}
-	\leanok
-	\uses{thm:afterBlocking_sectorComparison_reindexed_bntCover}
-	Apply
-	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover} with
-		the word-identification and BNT-cover comparison data from
-	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. The proof
+	\begin{proof}
+		\leanok
+		\uses{thm:common_grouped_block_cast_of_flatten_word,
+			thm:common_grouped_block_cast_to_relabeling,
+			thm:afterBlocking_sectorComparison_reindexed_bntCover}
+		Apply
+		Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover} with
+			the word-identification derived from
+		Theorem~\ref{thm:common_grouped_block_cast_to_relabeling} and the BNT-cover
+		comparison data from
+		Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. The proof
 	then packages the resulting blocking length, sector decompositions, BNT data,
 	permutation, multiplicity equalities, phases, and sector-weight
 	multiset equalities as the conclusion structure.

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -93,14 +93,14 @@ Formally this is the structure
 \path{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}.
 
 The hypotheses of this theorem are collected in
-\path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}.  They consist of a
-blocked-word relabeling assertion for cyclic-sector data and a comparison
-field for the common primitive nonzero-sector families produced by the preceding
-structural theorem.  That field is supplied with trace-preserving, primitive, and
-irreducible structural data and positive bond dimensions for the produced
-families; it then returns BNT-cover data containing the zero-tail, injectivity,
-normal-form separation, and proportional-decomposition comparison needed for
-those produced families.
+\path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}.  They now consist
+of the comparison field for the common primitive nonzero-sector families
+produced by the preceding structural theorem; the blocked-word relabeling
+assertion for cyclic-sector data is derived inside the wrapper.  The comparison
+field is supplied with trace-preserving, primitive, and irreducible structural
+data and positive bond dimensions for the produced families; it then returns
+BNT-cover data containing the zero-tail, injectivity, normal-form separation,
+and proportional-decomposition comparison needed for those produced families.
 
 These hypotheses are not written as hypotheses of Theorem~\texttt{thm1} or of
 Corollary~\texttt{II\_cor2} in the cited papers. They are the formal boundary
@@ -147,13 +147,12 @@ The other hypotheses are best understood as coordinate and transport data expose
 by the formal representation. They are mathematical assertions, but the papers do
 not state them because their notation identifies the relevant objects implicitly.
 
-The blocked-word relabeling hypothesis says that the nonzero part obtained by
+The blocked-word relabeling theorem says that the nonzero part obtained by
 blocking once at the common length agrees with the same sector family obtained by
 first removing each period and then grouping the resulting blocks. In ordinary
 paper notation both tensors are simply regarded as tensors over words of the
-common blocked length. In the formal statement, the direct alphabet of words of
-length $p$ and the nested alphabet obtained from iterated blocking are different
-coordinate descriptions, so their equality must be recorded explicitly.
+common blocked length. In the formal theorem, this coordinate identification is
+now derived inside the wrapper from the grouped-block cast construction.
 
 The zero-tail condition has a similar origin. The source definition of matrix
 product vectors is for positive lengths, and zero blocks are invisible there.
@@ -166,7 +165,8 @@ hypothesis appearing in the paper theorem.
 
 The transport of weights and zero-tail identities through the chosen common-sector
 representatives is likewise a coordinate-transport condition. The comparison theorem must be
-applied to exactly the final family of blocks after common blocking and relabeling.
+applied to exactly the final family of blocks after common blocking and the
+canonical relabeling supplied by the structural route.
 The paper moves between these descriptions without naming each transport map; the
 formal proof must show that the weights, nonzero-sector tensors, and zero-tail
 identities survive these changes of description.
@@ -183,10 +183,9 @@ paper-level inputs and formal coordinate transports made visible.
 This note records a proof gap in the present Lean development rather than a
 source error. The cited papers compress the canonical-form reduction, blocking,
 BNT matching, and injectivity refinements in the usual paper notation. The Lean
-development should keep the theorem conditional until the injectivity refinement,
-the BNT-cover comparison for the produced sectors, the blocked-word
-relabeling, and the zero-tail and weight transports have been proved for the same
-final common-sector data.
+development should keep the theorem conditional until the injectivity
+refinement, the BNT-cover comparison for the produced sectors, and the zero-tail
+and weight transports have been proved for the same final common-sector data.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -96,7 +96,7 @@ The hypotheses of this theorem are collected in
 \path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}.  They now consist
 of the comparison field for the common primitive nonzero-sector families
 produced by the preceding structural theorem; the blocked-word relabeling
-assertion for cyclic-sector data is derived inside the wrapper.  The comparison
+assertion for cyclic-sector data is derived in the formal theorem.  The comparison
 field is supplied with trace-preserving, primitive, and irreducible structural
 data and positive bond dimensions for the produced families; it then returns
 BNT-cover data containing the zero-tail, injectivity, normal-form separation,
@@ -152,7 +152,7 @@ blocking once at the common length agrees with the same sector family obtained b
 first removing each period and then grouping the resulting blocks. In ordinary
 paper notation both tensors are simply regarded as tensors over words of the
 common blocked length. In the formal theorem, this coordinate identification is
-now derived inside the wrapper from the grouped-block cast construction.
+now derived from the grouped-block cast construction.
 
 The zero-tail condition has a similar origin. The source definition of matrix
 product vectors is for positive lengths, and zero blocks are invisible there.


### PR DESCRIPTION
### Motivation
- The common blocked-word relabeling proof has landed on `main`, so the public conditional CPSV theorem no longer needs to expose `CommonSectorRelabelingHypothesis` as a remaining input.
- This keeps `AfterBlockingFundamentalTheoremHypotheses` focused on the BNT-cover comparison data that is still genuinely external to the theorem.

### Description
- Remove the `relabel` field from `MPSTensor.AfterBlockingFundamentalTheoremHypotheses`.
- Add `MPSTensor.CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq` for the canonical grouped-block cast derivation.
- Reuse that lemma in both `unconditional_commonPrimitiveIrreducibleBlocks` and `fundamentalTheorem_afterBlocking_of_comparisonHypotheses`.
- Update the chapter 11 blueprint and the CPSV paper-gap note to reflect that blocked-word relabeling is derived by the formal theorem.

### Testing
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --report /tmp/tnlean-remove-relabel-sync-3.json`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`
- `git diff --check`

---
Refs #1093.
Refs #840.
Refs #944.
Refs #1068.