### PR TITLE
style(Spectral): clean prose wording

### DIFF
--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -8,7 +8,7 @@ import Mathlib.Analysis.Matrix.Order
 /-!
 # Frobenius norm squared and Euclidean-space embedding for matrices
 
-Shared infrastructure for the spectral-gap modules (`SpectralGap.lean`,
+Shared Frobenius-norm identities for the spectral-gap modules (`SpectralGap.lean`,
 `SpectralGapRect.lean`).  Everything here works for *rectangular*
 `Matrix (Fin m) (Fin n) ℂ`; the square case is obtained by setting `m = n`.
 
@@ -22,7 +22,7 @@ Shared infrastructure for the spectral-gap modules (`SpectralGap.lean`,
 * `MPSTensor.frobSq_trace`: `frobSq X = (trace(X† X)).re`.
 * `MPSTensor.frobSq_eq_zero_iff`, `frobSq_pos_of_ne_zero`, `frobSq_smul`.
 * `MPSTensor.norm_matToES_sq`: `‖matToES X‖² = frobSq X`.
-* `MPSTensor.norm_sq_sum_mul_le`: Cauchy–Schwarz helper for norm-squared of
+* `MPSTensor.norm_sq_sum_mul_le`: Cauchy–Schwarz estimate for norm-squared of
   an inner product.
 -/
 
@@ -102,7 +102,7 @@ lemma norm_matToES_sq (M : Matrix (Fin m) (Fin n) ℂ) :
       ← Complex.ofReal_pow]]
   exact Complex.ofReal_re _
 
-/-! ### Cauchy–Schwarz helper -/
+/-! ### Cauchy–Schwarz estimate -/
 
 /-- Cauchy–Schwarz for `‖∑ aₖ bₖ‖²`. -/
 lemma norm_sq_sum_mul_le {D : ℕ} (a b : Fin D → ℂ) :

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -11,7 +11,7 @@ import Mathlib.Data.Matrix.Block
 import Mathlib.Analysis.Matrix.Normed
 
 /-!
-# Shared gauge-construction infrastructure for spectral-gap rigidity
+# Shared gauge construction for spectral-gap rigidity
 
 This module factors out the common "modulus-one eigenvector gives intertwining"
 core used by the spectral-gap rigidity arguments.  The shared pattern is:
@@ -27,7 +27,7 @@ open scoped Matrix Matrix.Norms.Operator MatrixOrder ComplexOrder BigOperators
 
 attribute [local instance] Matrix.linftyOpNormedAddCommGroup Matrix.linftyOpNormedSpace
 
-/-! ### ContinuousLinearMap endomorphism infrastructure
+/-! ### ContinuousLinearMap endomorphism structure
 
 These definitions provide the analytic structure on `Matrix (Fin m) (Fin n) ℂ →L[ℂ] …`
 needed by the spectral-radius arguments. They are activated locally via

--- a/TNLean/Spectral/MixedTransfer.lean
+++ b/TNLean/Spectral/MixedTransfer.lean
@@ -62,7 +62,7 @@ lemma mixedTransferMap_apply (A B : MPSTensor d D) (X : Matrix (Fin D) (Fin D) â
   classical
   simp [mixedTransferMap, Matrix.mul_assoc]
 
-/-- Definitional helper: the mixed transfer operator with `A = B` is the standard transfer map. -/
+/-- The mixed transfer operator with `A = B` is the standard transfer map. -/
 theorem mixedTransferMap_self (A : MPSTensor d D) :
     mixedTransferMap A A = transferMap (d := d) (D := D) A := by
   ext X
@@ -86,8 +86,8 @@ end MixedTransfer
 
 /-! ## Iterated mixed transfer and MPV cross-correlations
 
-The key bridge: iterating the mixed transfer operator `N` times connects
-to sums over all words of length `N` of products of word evaluations.
+Iterating the mixed transfer operator `N` times gives the corresponding sum
+over all words of length `N` of products of word evaluations.
 -/
 
 section IteratedTransfer

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -76,7 +76,7 @@ theorem mixedTransferSpectralRadius_eq (A B : MPSTensor d D) :
 
 /-! ### Frobenius norm squared
 
-The definition and basic API (`frobSq`, `frobSq_nonneg`, `frobSq_eq_zero_iff`,
+The definition and basic lemmas (`frobSq`, `frobSq_nonneg`, `frobSq_eq_zero_iff`,
 `frobSq_pos_of_ne_zero`, `frobSq_smul`, `frobSq_trace`, `matToES`, …) are
 provided by `TNLean.Spectral.FrobeniusNorm` for general rectangular matrices.
 Below we add the square-matrix-specific lemma `frobSq_mul_le`. -/
@@ -98,7 +98,7 @@ lemma eigenvector_pow {V : Type*} [AddCommMonoid V] [Module ℂ V]
     change (F ^ n) (F v) = _
     rw [h, map_smul, ih, smul_smul, mul_comm]; ring_nf
 
-/-! ### Helper lemmas for the HS contraction bound -/
+/-! ### Hilbert–Schmidt contraction estimates -/
 
 /-- Iterated TP condition: `∑_σ evalWord(K,σ)† evalWord(K,σ) = I`. -/
 lemma word_conjTranspose_mul_sum (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
@@ -129,7 +129,7 @@ lemma trace_transferMap (A : MPSTensor d D) (Z : Matrix (Fin D) (Fin D) ℂ)
 
 /-! ### Hilbert–Schmidt contraction for the mixed transfer operator
 
-The Euclidean-space embedding `matToES` and its basic API are imported from
+The Euclidean-space embedding `matToES` and its basic lemmas are imported from
 `TNLean.Spectral.FrobeniusNorm`.  Below we add square-matrix submultiplicativity. -/
 
 private lemma frobSq_mul_le (A B : Matrix (Fin D) (Fin D) ℂ) :
@@ -251,7 +251,7 @@ theorem spectralRadius_mixedTransfer_le_one
     exact_mod_cast eigenvalue_norm_le_one A B hA_norm hB_norm k
       (Module.End.hasEigenvalue_iff_mem_spectrum.mpr (h_spec ▸ hk))
 
-/-! ### Helper lemmas for the eigenvalue rigidity theorem -/
+/-! ### Eigenvalue rigidity lemmas -/
 
 /-
 **Eigenvector implies gauge** (the algebraic core of eigenvalue rigidity).

--- a/TNLean/Spectral/SpectralGapRect.lean
+++ b/TNLean/Spectral/SpectralGapRect.lean
@@ -73,7 +73,7 @@ theorem mixedTransferSpectralRadius₂_eq
 
 /-! ## Rectangular Frobenius norm and Euclidean-space embedding
 
-The general definitions `frobSq`, `matToES`, and their basic API are imported from
+The general definitions `frobSq`, `matToES`, and their basic lemmas are imported from
 `TNLean.Spectral.FrobeniusNorm`.  We introduce `frobSq₂` as a deprecated alias kept
 for local readability, and add the mixed-shape submultiplicativity lemma. -/
 

--- a/TNLean/Spectral/TraceExpansion.lean
+++ b/TNLean/Spectral/TraceExpansion.lean
@@ -11,11 +11,11 @@ import Mathlib.LinearAlgebra.Matrix.Trace
 /-!
 # Trace expansion over matrix units
 
-Shared infrastructure for expanding `LinearMap.trace` as a sum over matrix-unit basis elements,
+Trace-expansion lemmas for `LinearMap.trace` as a sum over matrix-unit basis elements,
 and for evaluating entries of products involving `Matrix.single`.
 
-The lemmas are stated over a general `CommRing 𝕜` so that no import of complex-number
-infrastructure is required here. Downstream files instantiate `𝕜 := ℂ`.
+The lemmas are stated over a general `CommRing 𝕜`, so this file does not need
+complex-number imports. Downstream files instantiate `𝕜 := ℂ`.
 
 ## Main results
 


### PR DESCRIPTION
### Motivation
- Issue #1017 tracks remaining mathematical-language cleanup after the merged Algebra/PiAlgebra/Axioms slice in #1157.
- The latest issue direction calls out `TNLean/Spectral/` as the next targeted area.

### Description
- Replace process-oriented prose in Spectral module text and comments with mathematical descriptions.
- Clean wording around Frobenius-norm identities, trace-expansion lemmas, Hilbert-Schmidt contraction estimates, eigenvalue rigidity, gauge construction, and mixed transfer iteration.
- No declarations, theorem statements, proof terms, or imports are changed.

### Validation
- `lake env lean TNLean/Spectral/FrobeniusNorm.lean`
- `lake env lean TNLean/Spectral/TraceExpansion.lean`
- `lake env lean TNLean/Spectral/MixedTransfer.lean`
- `lake env lean TNLean/Spectral/SpectralGap.lean`
- `lake env lean TNLean/Spectral/SpectralGapRect.lean`
- `lake env lean TNLean/Spectral/GaugeConstruction.lean`
- `rg -n -i '\b(infrastructure|api|helper|bridge)\b' TNLean/Spectral/FrobeniusNorm.lean TNLean/Spectral/TraceExpansion.lean TNLean/Spectral/SpectralGap.lean TNLean/Spectral/SpectralGapRect.lean TNLean/Spectral/GaugeConstruction.lean TNLean/Spectral/MixedTransfer.lean`
- `git diff --check`

Refs #1017.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docstrings/section headers and comment wording with no changes to declarations, proofs, or imports.
> 
> **Overview**
> Tightens and clarifies prose across the `TNLean/Spectral` modules by rewording module headers, section titles, and lemma comments (e.g., Frobenius-norm identities, Cauchy–Schwarz estimate, mixed-transfer iteration, Hilbert–Schmidt contraction, gauge construction, and trace-expansion lemmas).
> 
> No definitions, theorem statements, proofs, or dependencies are modified; this is a documentation-only cleanup aimed at more mathematical phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00fb5bf90aef64f0d6464741ed93aac413c1204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->