### PR TITLE
feat(MPS/CanonicalForm): prove normal canonical form for common-flat cyclic sectors

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -1368,6 +1368,27 @@ theorem commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
   let y := F.flatKey x
   simpa [commonFlatDim, y] using F.commonSectorBlock_dim_pos y.1 y.2
 
+/-- A common blocked cyclic-sector family is a normal canonical form once its
+transported flat weights are sorted by strictly decreasing modulus. -/
+theorem isNormalCanonicalForm_commonFlatBlocks
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ)
+    (hμ : ∀ k, μ k ≠ 0)
+    (hAnti : StrictAnti
+      (fun x : Fin (∑ k : Fin r, F.period k) => ‖F.commonFlatWeight μ x‖)) :
+    IsNormalCanonicalForm (d := blockPhysDim d F.p)
+      (F.commonFlatWeight μ) F.commonFlatBlocks :=
+  isNormalCanonicalForm_of_tp_primitive_irr_sorted
+    (d' := blockPhysDim d F.p)
+    (μ := F.commonFlatWeight μ)
+    F.commonFlatBlocks
+    F.commonFlatBlocks_tp
+    F.commonFlatBlocks_primitive
+    F.commonFlatDim_pos
+    (F.commonFlatWeight_ne_zero μ hμ)
+    F.commonFlatBlocks_irreducible
+    hAnti
+
 /-- Iterated blocking of a nonzero-weight block is the relabeled common block. -/
 theorem nestedBlock_sameMPV₂_commonReindexedBlock
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1741,25 +1741,31 @@ The following results separate the zero blocks from the nonzero blocks.
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks_irreducible,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim_pos,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonBlockWeight_ne_zero,
-		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero}
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero,
+		MPSTensor.CommonBlockedCyclicSectorFamily.isNormalCanonicalForm_commonFlatBlocks}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:tp_primitive_irreducible_extra_blocking,
 		thm:left_canonical_cast_phys_dim, thm:primitive_transfer_cast_phys_dim,
-		thm:irreducible_tensor_cast_phys_dim}
+		thm:irreducible_tensor_cast_phys_dim, thm:ncf_sorted_tp_primitive_irred}
 	The common-alphabet sectors are trace-preserving, have primitive transfer
 	maps, are tensor-irreducible, and have positive bond dimensions.  Original
 	nonzero weights remain nonzero after being transported to the common
-	blocking length and replicated over the flattened sector family.
+	blocking length and replicated over the flattened sector family.  If the
+	original weights are nonzero and the transported weights are sorted by
+	strictly decreasing norm, the flattened common-sector family is a normal
+	canonical form.
 \end{theorem}
 
 \begin{proof}\leanok
 	\uses{thm:tp_primitive_irreducible_extra_blocking,
 		thm:left_canonical_cast_phys_dim, thm:primitive_transfer_cast_phys_dim,
-		thm:irreducible_tensor_cast_phys_dim}
+		thm:irreducible_tensor_cast_phys_dim, thm:ncf_sorted_tp_primitive_irred}
 	Apply the extra-blocking theorem to each period-removal sector, substitute the
 	equality between the iterated and common physical alphabets, and use that a
-	positive power of a nonzero complex number is nonzero.
+	positive power of a nonzero complex number is nonzero.  The normal canonical
+	form statement is Theorem~\ref{thm:ncf_sorted_tp_primitive_irred} applied to
+	these derived sector data.
 \end{proof}
 
 \begin{theorem}[Weights of common-alphabet sectors]%


### PR DESCRIPTION
### Motivation

- Completing the structural theorem for multi-block MPS requires showing that the common-flat cyclic sector family satisfies the `IsNormalCanonicalForm` predicate; this combines previously established constituent properties into a single unified statement.
- Addresses part of #1068, which tasks the construction of common phase-cover data from the common-length cyclic-sector comparison.

### Description

- In `TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`: adds `CommonBlockedCyclicSectorFamily.isNormalCanonicalForm_commonFlatBlocks`, which combines the existing common-flat trace-preserving, primitive, irreducible, positive-dimension, and nonzero-weight properties into a single `IsNormalCanonicalForm` statement under the existing strict weight-order assumption.
- In `blueprint/src/chapter/ch08_canonical.tex`: records the new declaration in the canonical-form structural-properties block.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition` — completed successfully; only pre-existing style warnings in unrelated modules were replayed.
- `python3 scripts/blueprint_lean_sync.py --root . --ci --report /tmp/blueprint-lean-sync-1170.json`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Addresses #1068

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new derived lemma that composes existing TP/primitive/irreducible/positivity facts under an ordering hypothesis, plus a documentation update.
> 
> **Overview**
> Adds `CommonBlockedCyclicSectorFamily.isNormalCanonicalForm_commonFlatBlocks`, showing the flattened common-sector blocks satisfy `IsNormalCanonicalForm` once the transported weights are nonzero and **strictly decreasing by norm** (via `isNormalCanonicalForm_of_tp_primitive_irr_sorted`).
> 
> Updates the blueprint theorem on common-alphabet cyclic-sector properties to include this new normal-canonical-form statement and its dependency (`thm:ncf_sorted_tp_primitive_irred`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f40373a98514328d9183a9505947b698dd8a59b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->