### PR TITLE
feat(MPS/CanonicalForm/Assembly): assemble BNT-cover hypothesis bundle from common primitive data

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -236,6 +236,49 @@ structure CommonPrimitiveBNTCoverHypotheses
 
 namespace CommonPrimitiveBNTCoverHypotheses
 
+/-- Form `CommonPrimitiveBNTCoverHypotheses` from common primitive structural data
+and explicit BNT comparison inputs. -/
+def ofCommonPrimitiveData
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (hμA : ∀ x, μA x ≠ 0)
+    (hμB : ∀ x, μB x ≠ 0)
+    (hTPA : ∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1)
+    (hTPB : ∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1)
+    (hPrimA : ∀ x, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x)))
+    (hPrimB : ∀ x, _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x)))
+    (hIrrA : ∀ x, IsIrreducibleTensor (blocksA x))
+    (hIrrB : ∀ x, IsIrreducibleTensor (blocksB x))
+    (hDimA : ∀ x, 0 < dimA x)
+    (hDimB : ∀ x, 0 < dimB x)
+    (hAntiA : StrictAnti (fun x : Fin rA => ‖μA x‖))
+    (hAntiB : StrictAnti (fun x : Fin rB => ‖μB x‖))
+    (hNotGpeA : BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksA)
+    (hNotGpeB : BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksB)
+    (hZeroTail : zeroTailA = zeroTailB)
+    (hInjA : ∀ x, IsInjective (blocksA x))
+    (hInjB : ∀ x, IsInjective (blocksB x))
+    (hDecomp : ProportionalDecompositionData (d := blockPhysDim d p)
+      blocksA blocksB DtotA DtotB) :
+    CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB where
+  ncfA := isNormalCanonicalForm_of_tp_primitive_irr_sorted
+    (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA hAntiA
+  ncfB := isNormalCanonicalForm_of_tp_primitive_irr_sorted
+    (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB hAntiB
+  notGpeA := hNotGpeA
+  notGpeB := hNotGpeB
+  zeroTail_eq := hZeroTail
+  left_injective := hInjA
+  right_injective := hInjB
+  decompData := hDecomp
+
 /-- A BNT cover hypothesis bundle produces a common MPV phase cover. -/
 theorem toMPVCommonPhaseCover
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -255,8 +255,6 @@ def ofCommonPrimitiveData
       (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x)))
     (hIrrA : ∀ x, IsIrreducibleTensor (blocksA x))
     (hIrrB : ∀ x, IsIrreducibleTensor (blocksB x))
-    (hDimA : ∀ x, 0 < dimA x)
-    (hDimB : ∀ x, 0 < dimB x)
     (hAntiA : StrictAnti (fun x : Fin rA => ‖μA x‖))
     (hAntiB : StrictAnti (fun x : Fin rB => ‖μB x‖))
     (hNotGpeA : BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksA)
@@ -268,10 +266,14 @@ def ofCommonPrimitiveData
       blocksA blocksB DtotA DtotB) :
     CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
       (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB where
-  ncfA := isNormalCanonicalForm_of_tp_primitive_irr_sorted
-    (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA hAntiA
-  ncfB := isNormalCanonicalForm_of_tp_primitive_irr_sorted
-    (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB hAntiB
+  ncfA := by
+    have hDimA : ∀ x, 0 < dimA x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimA x))
+    exact isNormalCanonicalForm_of_tp_primitive_irr_sorted
+      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA hAntiA
+  ncfB := by
+    have hDimB : ∀ x, 0 < dimB x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimB x))
+    exact isNormalCanonicalForm_of_tp_primitive_irr_sorted
+      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB hAntiB
   notGpeA := hNotGpeA
   notGpeB := hNotGpeB
   zeroTail_eq := hZeroTail

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1406,15 +1406,19 @@ two-basis sector comparison theorem.
 
 \begin{definition}[BNT-cover hypotheses for common primitive sectors]%
 \label{def:common_primitive_bnt_cover_hypotheses}
-	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses}
+	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses,
+		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData}
 	\leanok
 	\uses{def:is_normal_canonical_form, def:blocks_not_gauge_phase_equiv,
-		def:injective}
+		def:injective, thm:ncf_sorted_tp_primitive_irred}
 	For two common primitive nonzero-sector families at one blocking length, this
 	condition contains the BNT data needed to construct a common MPV phase cover:
 	normal canonical-form data on both sides, separation of distinct sectors by
 	gauge-phase equivalence, equality of the zero-tail dimensions, one-site
-	injectivity, and a proportional-decomposition comparison.
+	injectivity, and a proportional-decomposition comparison. When the primitive
+	structural data and strict weight ordering are supplied in place of normal
+	canonical-form data, together with the remaining fields above, they yield the
+	BNT-cover hypotheses.
 \end{definition}
 
 \begin{theorem}[BNT-cover hypotheses produce a common phase cover]%

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1417,7 +1417,7 @@ two-basis sector comparison theorem.
 	gauge-phase equivalence, equality of the zero-tail dimensions, one-site
 	injectivity, and a proportional-decomposition comparison. When the primitive
 	structural data and strict weight ordering are supplied in place of normal
-	canonical-form data, together with the remaining fields above, they yield the
+	canonical-form data, together with the remaining conditions above, they yield the
 	BNT-cover hypotheses.
 \end{definition}
 


### PR DESCRIPTION
### Motivation

- The BNT-cover hypothesis structure `CommonPrimitiveBNTCoverHypotheses` requires several fields: two normal-canonical-form properties that follow from the primitive trace-preserving irreducible block theorem, plus gauge-phase separation, zero-tail equality, injectivity, and proportional-decomposition data that depend on structural inputs not produced by that theorem alone.
- Providing a constructor that assembles the full hypothesis bundle from these separate sources is a required step toward the sector-comparison result in the multi-block Fundamental Theorem.
- Continues the formalization of multi-block assembly following arXiv:1606.00608 §2.3; see #944 and #1068.

### Description

- In `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`, adds `CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData`: a constructor for the BNT-cover hypothesis bundle that derives the two normal-canonical-form fields from the sorted trace-preserving primitive irreducible block theorem, and takes gauge-phase separation, zero-tail equality, injectivity, and proportional-decomposition as explicit hypotheses.
- In `blueprint/src/chapter/ch11_assembly.tex`, records this construction in the assembly blueprint entry for BNT-cover hypotheses.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --report /tmp/blueprint-lean-sync-1172-review2.json`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- Module build completed successfully; only pre-existing style warnings in unrelated modules were replayed.

---
Addresses part of #944 and #1068

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean constructor/proof wrapper and updates blueprint documentation, without changing existing theorem statements or core logic.
> 
> **Overview**
> Adds `CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData`, a constructor that assembles a full BNT-cover hypothesis bundle by *deriving* the `IsNormalCanonicalForm` fields from trace-preserving + primitive + irreducible + strictly ordered weight inputs, while taking gauge-phase separation, zero-tail equality, injectivity, and `ProportionalDecompositionData` as explicit hypotheses.
> 
> Updates the blueprint (`ch11_assembly.tex`) to reference this new constructor and its dependency on `thm:ncf_sorted_tp_primitive_irred`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360117c25623b37ce312461e06d9077ce6bf7c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->