### PR TITLE
doc(blueprint): refresh FT and Wielandt frontier notes

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -2356,23 +2356,23 @@ chosen sector bases and the sector-weight conclusion follows from the original
 gives the corresponding zero-tail route when full overlap-span data
 are supplied.
 
-The remaining formal work for the completely unconditional
-`fundamentalTheorem_after_blocking_sector` is therefore to derive, from the
-structural reduction itself:
+The blocked-word relabelling and common primitive irreducible nonzero-block
+decompositions are now part of this file's structural reduction. The remaining
+formal work for the completely unconditional
+`fundamentalTheorem_after_blocking_sector` is therefore narrower:
 
-1. a common nonzero-block decomposition with primitive **and irreducible** blocks at
-   the same physical blocking level;
-2. the `N = 0` identity for the zero-tail contribution;
-3. one-site injectivity of the nonzero-weight blocks, or a blocked replacement of the
+1. the `N = 0` identity for the zero-tail contribution;
+2. one-site injectivity of the nonzero-weight blocks, or a blocked replacement of the
    rigidity hypothesis; and
-4. equality of the finite-length MPV spans for the original nonzero-weight block families
-   (or directly for the two BNT bases), followed by the final global gauge
-   construction of the equal-case FT.
+3. equality of the finite-length MPV spans for the original nonzero-weight block families
+   (or directly for the two BNT bases), equivalently a common phase/BNT-cover comparison,
+   followed by the final global gauge construction of the equal-case FT.
 
-Thus the common-period arithmetic and the abstract sector-matching witness are no
-longer the main blockers; the remaining gap is the paper-level derivation of the
-listed nonzero-block, zero-tail, injectivity, and span facts for the actual sector
-tensors produced by the after-blocking reduction.
+Thus the common-period arithmetic, the blocked-word relabelling, the common
+primitive irreducible nonzero-sector families, and the abstract sector-matching
+witness are no longer the main blockers. The remaining gap is the paper-level
+derivation of the listed zero-tail, injectivity, and span/comparison facts for
+the actual sector tensors produced by the after-blocking reduction.
 -/
 
 end FundamentalTheoremAfterBlocking

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -375,11 +375,12 @@ available equal-case result for sector decompositions sharing a common BNT basis
 multiplicities produce equal total MPVs, then the sector weight multisets are equal for each
 basis block.
 
-**What remains open**: global gauge equivalence of the assembled tensors. This would follow
-from `fundamentalTheorem_proportionalMPV_CFBNT` (the proportional-case FT in `Full.lean`)
-if one could additionally supply convergent decomposition coefficients with nonzero limits.
-The sector decomposition coefficients `∑_q μ_{j,q}^N` are sums of geometric sequences that
-may oscillate (unit-modulus terms), so coefficient convergence is not automatic and requires
+**What remains open**: global gauge equivalence of the assembled tensors. The
+coefficient-explicit route goes through `fundamentalTheorem_proportionalMPV_CFBNT`
+in `EqualProportional.lean`, but it still needs convergent decomposition
+coefficients with nonzero limits. The sector decomposition coefficients
+`∑_q μ_{j,q}^N` are sums of geometric sequences that may oscillate
+(unit-modulus terms), so coefficient convergence is not automatic and requires
 either a dominant-weight hypothesis or an explicit normalization strategy.
 -/
 
@@ -677,11 +678,11 @@ This structure collects the four pieces of data consumed by
 * per-block bond-dimension equality, and
 * per-block gauge-phase equivalence of the (dimension-transported) basis blocks.
 
-Producing a `SectorBasisMatching P Q` from an arbitrary `SameMPV₂ P.toTensor
-Q.toTensor` is the remaining combinatorial step in the Gap Section 1 closure
-(see the remark in `blueprint/src/chapter/ch11_assembly.tex` and
-arXiv:2011.12127 Section IV.B–IV.C). Once that extraction is available, the
-algebraic reduction runs purely through
+Producing a `SectorBasisMatching P Q` is now handled by the overlap/span route
+when `SectorBasisOverlapSpanHypotheses` are available. The remaining work is to
+derive those hypotheses, or an equivalent common phase/BNT-cover comparison, for
+the sector decompositions produced by the after-blocking reduction. Once that
+extraction is available, the algebraic reduction runs purely through
 `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching`. -/
 structure SectorBasisMatching (P Q : SectorDecomposition d) where
   /-- Permutation matching basis indices of `P` and `Q`. -/
@@ -997,11 +998,10 @@ end SectorBasisOverlapSpanHypotheses
 /-- **Heterogeneous sector comparison via a bundled basis matching witness.**
 
 Corollary of `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`
-obtained by supplying the matching data in bundled form as a `SectorBasisMatching`. Once a
-theorem constructs a `SectorBasisMatching P Q` from arbitrary `SameMPV₂ P.toTensor
-Q.toTensor` (the remaining combinatorial step, following from the general
-basis-of-normal-tensors construction in #876), this result completes the Gap Section 1
-heterogeneous sector comparison with the matching data gathered into a single argument. -/
+obtained by supplying the matching data in bundled form as a `SectorBasisMatching`.
+The matching can be extracted from `SectorBasisOverlapSpanHypotheses`; the current
+blocker is producing those hypotheses, or equivalent common phase/BNT-cover data,
+for the actual after-blocking sector decompositions. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching
     {P Q : SectorDecomposition d}
     (M : SectorBasisMatching P Q)

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -15,8 +15,9 @@ Wielandt development and recalls the normality side of the chain from
 `WielandtBound.lean`.
 
 It does **not** prove `HasPrimitiveFixedPoint → IsNormal`. The currently formalized route
-with extra `ρ.PosDef` and aperiodicity hypotheses is assembled in
-`QuantumWielandt.lean`; the unconditional implication remains future work.
+from paper-style primitivity to normality with an additional positive-definite
+fixed point hypothesis is assembled in `QuantumWielandt.lean`; exact-length
+positivity witnesses still require the separate aperiodicity input.
 
 ## Main results
 

--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -298,8 +298,8 @@ Then `wordSpan A (n+m) = ⊤`.
 This is the part of Lemma 2(b) that turns rank-one operators + vector spanning
 into full matrix spanning.
 
-The remaining hard part (TODO) is to construct these rank-one operators from the
-Jordan/Fitting analysis of an eigenvalue word.
+The rank-one operators are constructed later by the Fitting-based extraction
+theorems in `TNLean.Wielandt.RankOne.ExtractionFull`.
 -/
 theorem wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis
     (A : MPSTensor d D) (φ : Fin D → ℂ) {n m : ℕ}

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -8,7 +8,7 @@ import TNLean.Wielandt.RankOne.Products
 import TNLean.Wielandt.SpanGrowth.EigenvectorSpreading
 
 /-!
-# Quantum Wielandt Bound — proof roadmap
+# Quantum Wielandt Bound - proof roadmap
 
 This file collects the main results of the quantum Wielandt bound
 from arXiv:0909.5347 (Sanz, Pérez-García, Wolf, Cirac).
@@ -40,11 +40,10 @@ We formalize the proof chain up to the following:
 
 5. **Proof synthesis**: connecting these pieces into the Wielandt bound.
 
-The gap between vector spanning (step 4) and matrix spanning (the full bound)
-corresponds to Lemma 2(b) of the paper, which requires converting
-"word products applied to φ span ℂ^D" into "word products span M_D(ℂ)".
-This step uses the Jordan/Fitting decomposition and needs additional lemmas for
-the full formalization.
+The paper-level fixed-length matrix-spanning step, Lemma 2(b), is now carried by
+the `TNLean.Wielandt.PaperResults` and rank-one extraction modules. This file
+keeps the original cumulative-span and eigenvector-spreading chain as a compact
+roadmap and compatibility layer for the later fixed-length results.
 
 ## References
 
@@ -139,21 +138,21 @@ theorem vector_spanning_from_normality [NeZero D]
   cumulativeVectorSpan_eq_top_of_cumulativeSpan_eq_top A φ hφ
     (cumulativeSpan_eq_top A hN)
 
-/-! ## Part 3: Wielandt bound — main statements
+/-! ## Part 3: Wielandt bound - main statements
 
-The full Wielandt bound `i(A) ≤ (D²-d+1)·D²` requires Lemma 2(b),
-which converts vector spanning into matrix spanning. We state the
-key intermediate results and the final bound.
+The exact fixed-length paper bound is proved in
+`TNLean.Wielandt.PaperResults.WielandtInequality` using the matrix-span and
+rank-one extraction modules. The results below record the older cumulative
+normality route used by that proof chain.
 
 ### What we prove:
 - `cumulative_wielandt_bound`: T_{D²}(A) = ⊤ for normal tensors
 - `isNormal_iff_cumulativeSpan_eq_top`: characterization of normality
   via cumulative span
 
-### What needs Lemma 2(b) for the full proof:
-- Converting `cumulativeVectorSpan A φ N = ⊤` (all vectors reachable)
-  into `wordSpan A N' = ⊤` (all matrices reachable with fixed-length words)
-- This is the step from "S_n(A)|φ⟩ = ℂ^D" to "S_{N'}(A) = M_D(ℂ)"
+### Fixed-length passage:
+The conversion from vector spanning to fixed-length matrix spanning is formalized
+by the Lemma 2(b) results in `TNLean.Wielandt.PaperResults.MatrixSpanSharpBound`.
 -/
 
 /-- **Cumulative Wielandt bound**: Under `IsNormal`, the cumulative word
@@ -245,21 +244,10 @@ theorem wielandt_chain [NeZero D]
 8. `evalWord_append_eigenvector`: Pumping lemma for eigenvectors
 9. `evalWord_replicate_eigenvector`: Iterated pumping
 
-### Remaining for full D⁴ bound (Lemma 2(b)):
-- Converting "word products applied to φ span ℂ^D" (vector spanning)
-  into "word products of fixed length span M_D(ℂ)" (matrix spanning)
-- This requires showing that rank-1 matrices |φ⟩⟨ψ| can be realized
-  as linear combinations of word products, using the Fitting decomposition
-  to control the nilpotent and invertible parts separately
-- The paper achieves this via Jordan NF (we have Fitting instead)
-
-### Architecture for completing the bound:
-To prove `IsNormal A → IsNBlkInjective A (D^4)`:
-1. Use `exists_word_eigenvector` to get w₀ with |w₀| ≤ D²
-2. Consider the |w₀|-th power channel
-3. Apply `eigenvector_spreading` to the power channel
-4. Use Fitting decomposition on `evalWord A w₀` to convert vector → matrix
-5. Conclude `wordSpan A (|w₀| · D²) = ⊤`, giving the bound
+### Fixed-length bound route:
+The later paper-results modules combine the word-eigenvector extraction, the
+blocked rank-one construction, and fixed-length assembly to prove the paper-level
+index bound. This theorem remains as a named roadmap anchor for older references.
 -/
 theorem wielandt_roadmap : True := trivial
 

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -859,7 +859,7 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
 (i.e.\ word products of \emph{exactly} one length span all matrices).
 
 \begin{definition}[Fixed-length vector span]\label{def:vector_spread_span}
-    \lean{MPSTensor.vectorSpreadSpan_eq_top_of_isPrimitivePaper_of_eigenvector}
+    \lean{MPSTensor.vectorSpreadSpan}
     \leanok
     \uses{def:mps_tensor, def:eval_word}
     The \emph{fixed-length vector span} at length~$n$ is
@@ -1044,7 +1044,7 @@ used to produce rank-one elements.
 \end{proof}
 
 \begin{theorem}[Blocked fixed-length matrix spanning]\label{thm:wielandt_blocked_assembly}
-    \lean{MPSTensor.wielandt_blocked_assembly_complete}
+    \lean{MPSTensor.wielandt_blocked_assembly}
     \leanok
     \uses{def:word_span, def:normal, def:blocked_tensor}
     Suppose $A$ is normal and $L > 0$, and we have:
@@ -1080,6 +1080,23 @@ used to produce rank-one elements.
     Theorem~\ref{thm:blockTensor_single_eigenvector}.
     Transfer back to the original tensor via
     Lemma~\ref{lem:blocking_transfer}.
+\end{proof}
+
+\begin{theorem}[Blocked fixed-length matrix spanning from word eigenvectors]
+    \label{thm:wielandt_blocked_assembly_complete}
+    \lean{MPSTensor.wielandt_blocked_assembly_complete}
+    \leanok
+    \uses{thm:wielandt_blocked_assembly}
+    Suppose $A$ is normal and $L > 0$. If a length-$L$ word has a nonzero
+    eigenvector and a length-$L$ word has a nonzero transpose eigenvector, then
+    there exists $N$ such that $S_N(A)=\MN{D}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:rankone_extraction_blockTensor, thm:wielandt_blocked_assembly}
+    The rank-one extraction theorem supplies the blocked rank-one element
+    required by Theorem~\ref{thm:wielandt_blocked_assembly}; apply the blocked
+    assembly theorem.
 \end{proof}
 
 \begin{theorem}[Rank-one extraction for blocked tensor]%

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -66,10 +66,9 @@ used in this chapter.
     The normal canonical form data provide the BNT separation
     and overlap convergence hypotheses;
     the non-degeneracy condition (no two distinct blocks in the same
-    family are gauge-phase equivalent) ensures that the permutation
-    $\pi$ produced by Theorem~\ref{thm:ft_proportional_nt} is uniquely
-    determined, so that the per-block gauge equivalences can be
-    assembled consistently.
+    family are gauge-phase equivalent) is one of the hypotheses used to
+    obtain an existential block-count equality, a matching permutation,
+    and per-block gauge-phase equivalences.
 \end{proof}
 
 \section{Proportional Fundamental Theorem}%
@@ -1920,12 +1919,10 @@ two-basis sector comparison theorem.
 	Chapter~\ref{ch:canonical} supplies the canonical-form reduction needed before
 	these comparison theorems can be applied: a common physical blocking length,
 	the zero-tail identities at that length, and cyclic-sector families for both
-	tensors on a common blocked alphabet.  The unproved assertion is the exact
-	equality, after identifying blocked physical words, between the blocked nonzero part and the
-	common cyclic-sector tensor for the whole weighted family.  With that
-	equality, Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-	gives the common weighted nonzero-sector decompositions needed for the
-	comparison theorems.
+	tensors on a common blocked alphabet.  The blocked-word relabelling and the
+	common primitive irreducible nonzero-sector decompositions are now part of the
+	formalized reduction, culminating in
+	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
 		then states the hypotheses: equality of the
 	zero-tail dimensions, injectivity of the common nonzero-sector blocks, and

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -367,6 +367,9 @@ directly to periodic tensors.
 \subsection{Statement of the periodic Fundamental Theorem}
 
 The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducible}.
+The Lean entries listed here are conditional components of that route: the final
+entry still assumes periodic-overlap and power-equality hypotheses, so the
+literature theorem is not yet a single unconditional Lean statement.
 
 \begin{theorem}[Periodic Fundamental Theorem]\notready
     \label{thm:periodic_ft}
@@ -465,7 +468,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     starting sector from $u$ to $u+1$.
 \end{definition}
 
-\begin{definition}[Cyclic staircase product on blocked indices (Equation A.8)]%
+\begin{definition}[Cyclic staircase product on blocked indices]%
     \label{def:blocked_corner_transition_tensor}
     \lean{MPSTensor.blockedCornerTransitionTensor}
     \leanok
@@ -590,7 +593,7 @@ The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducibl
     $N \ge N_0$ the vectors $\{\ket{V^{(pN)}(A_j)}\}_j$ are linearly independent.
 \end{theorem}
 
-\begin{remark}[Comparison with the 1606.00608 approach]\notready
+\begin{remark}[Comparison with the blocking approach]\notready
     \label{rem:periodic_vs_blocking_ft}
     Theorem~\ref{thm:periodic_ft} and the equal-MPV Fundamental Theorem
     (Theorem~\ref{thm:ft_equal}) both characterize the gauge freedom

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1250,7 +1250,7 @@ which is then combined with overlap estimates and the leading-block peel.
     \label{thm:fundamentalTheorem_equalMPV_CFBNT_hetero}
     \lean{MPSTensor.fundamentalTheorem_equalMPV_CFBNT_hetero}
     \leanok
-    \uses{def:same_mpv}
+    \uses{def:same_mpv, def:cf_bnt, def:gauge_phase_equiv}
     Let $\{\mu_j A_j\}_{j=0}^{r_A-1}$ and $\{\nu_k B_k\}_{k=0}^{r_B-1}$ be
     two canonical-form BNT families, possibly with different block counts and
     different bond dimensions in corresponding blocks.
@@ -1258,6 +1258,8 @@ which is then combined with overlap estimates and the leading-block peel.
     the two families have the same number of blocks, the blocks can be matched
     by a permutation preserving the bond dimensions, and each matched pair is
     gauge-phase equivalent.
+    This is the block-matching conclusion, not yet the final global weighted
+    gauge-equivalence statement for the assembled tensors.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
### Motivation

- The Ch11 blueprint frontier for the after-blocking Fundamental Theorem still listed blocked-word relabelling and common primitive irreducible nonzero-block decompositions as open items, though both are now resolved.
- The Ch7 Wielandt blueprint entry conflated a conditional theorem with its unconditional word-eigenvector wrapper, and the fixed-length vector span definition pointed to the wrong location.
- Adjacent FT, periodic, and Wielandt prose did not distinguish the proved block-matching and conditional components from the remaining global comparison and gauge statements, obscuring what is actually open.

Continues blueprint documentation work for the Fundamental Theorem and Wielandt bound; see #1170.

### Description

Documentation-only changes (blueprint TeX and Lean docstrings; no proof terms are modified):

- `blueprint/src/chapter/ch11_assembly.tex`: removes blocked-word relabelling and the common primitive irreducible nonzero-block decomposition from the open frontier; narrows remaining items to the zero-tail case (`N = 0`), injectivity and rigidity, and span/phase-cover comparisons.
- `blueprint/src/chapter/ch07_wielandt.tex`: splits the blocked-assembly entry into the conditional theorem `wielandt_blocked_assembly` and the unconditional word-eigenvector wrapper `wielandt_blocked_assembly_complete`; updates the reference for the fixed-length vector span definition to point to the correct declaration.
- `blueprint/src/chapter/ch11b_periodic_ft.tex`, `ch13_algebraic_ft.tex`: updates the extraction-route reference from `SectorBasisOverlapSpanHypotheses` to `SectorBasisMatching` and refreshes adjacent prose to reflect the current proof structure.
- `TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`, `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`, `TNLean/Wielandt/WielandtBound.lean`, `TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean`, `TNLean/Wielandt/Primitivity/Normal.lean`: refreshes inline comments to match the updated blueprint frontier.

Also updates status context for #324, #1093, and #1173.

### Testing

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls --report /tmp/blueprint-lean-sync-frontier-update.json`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --report /tmp/blueprint-lean-sync-frontier-ci.json`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`
- `lake env lean TNLean/Wielandt/WielandtBound.lean`
- `lake env lean TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean`
- `lake env lean TNLean/Wielandt/Primitivity/Normal.lean`
- `git diff --check`

---
Addresses #1170

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update (Lean docstrings and blueprint TeX) that should not affect compiled proofs beyond comment/label references.
> 
> **Overview**
> Updates FT and Wielandt roadmap documentation to reflect recent progress: after-blocking structural reduction now includes blocked-word relabeling and common primitive irreducible nonzero-block decompositions, narrowing the remaining open items to *zero-tail `N=0`*, injectivity/rigidity, and span/phase-cover comparisons.
> 
> Refreshes sector-decomposition and Wielandt notes to point to the current extraction route (`SectorBasisOverlapSpanHypotheses` → `SectorBasisMatching`) and to split the blueprint's blocked assembly into the conditional theorem `wielandt_blocked_assembly` plus the word-eigenvector wrapper `wielandt_blocked_assembly_complete`, while updating references to the fixed-length vector span definition and the newer paper-results/rank-one extraction modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3f68128cf336871b7681cc221ca02fa66e5f30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates to Lean docstrings and blueprint TeX; no proof terms or definitions change, but incorrect/obsolete references could confuse reviewers if they drift from code.
> 
> **Overview**
> Updates the Fundamental Theorem and Wielandt-bound *frontier/roadmap documentation* to reflect recently formalized steps and to clarify what remains open.
> 
> On the FT side, comments and blueprint text now treat blocked-word relabelling and common primitive irreducible nonzero-block decompositions as completed, narrowing remaining gaps to the `N = 0` zero-tail identity, injectivity/rigidity inputs, and finite-length span or common phase/BNT-cover comparisons.
> 
> On the Wielandt side, the blueprint and Lean module headers are adjusted to point fixed-length vector spanning at `vectorSpreadSpan`, split the blocked assembly theorem reference (`wielandt_blocked_assembly` vs `wielandt_blocked_assembly_complete`), and reframe Lemma 2(b) status as handled by newer paper-results/rank-one extraction modules, with `WielandtBound.lean` kept as a compatibility roadmap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41b39df20996bb48188dd213cd01efc22f9d3bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->