### PR TITLE
feat(MPS/CanonicalForm): retain structural MPV decompositions

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -184,8 +184,8 @@ theorem bilateral_commonPeriod_blocking_tp_primitive_normal
 
 For any two MPS tensors `A, B` with `SameMPV₂ A B`, this theorem gives the
 currently formalized one-sided reduction data on both sides: after blocking,
-each tensor admits a decomposition into TP blocks with primitive transfer maps,
-nonzero weights, and positive bond dimensions.
+each tensor admits a decomposition into a zero-tail tensor and TP blocks with
+primitive transfer maps, nonzero weights, and positive bond dimensions.
 
 The theorem does not yet use `SameMPV₂ A B` to compare the two blocked
 families. The subsequent content is the sector-level comparison:
@@ -194,10 +194,57 @@ followed by a two-basis equal-case comparison theorem for those sector decomposi
 
 This theorem therefore gives the structural statement currently available on the
 way to arXiv:1606.00608, Theorem 1. -/
-theorem afterBlocking_structuralData_of_sameMPV₂
+theorem afterBlocking_structuralDecompositionData_of_sameMPV₂
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (_hSame : SameMPV₂ A B) :
+    -- Both tensors have blocked TP-primitive decompositions
+    ∃ (zeroTailA : ℕ) (pA : ℕ) (_ : 0 < pA)
+      (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+      (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d pA) (dimA k)),
+    ∃ (zeroTailB : ℕ) (pB : ℕ) (_ : 0 < pB)
+      (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+      (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d pB) (dimB k)),
+      -- Blocks are TP
+      (∀ k, ∑ i, (blocksA k i)ᴴ * blocksA k i = 1) ∧
+      (∀ k, ∑ i, (blocksB k i)ᴴ * blocksB k i = 1) ∧
+      -- Blocks have primitive transfer maps
+      (∀ k, _root_.IsPrimitive (transferMap (blocksA k))) ∧
+      (∀ k, _root_.IsPrimitive (transferMap (blocksB k))) ∧
+      -- Nonzero weights
+      (∀ k, μA k ≠ 0) ∧
+      (∀ k, μB k ≠ 0) ∧
+      -- Positive bond dimensions
+      (∀ k, 0 < dimA k) ∧
+      (∀ k, 0 < dimB k) ∧
+      -- MPV decomposition equations
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d pA)),
+        mpv (blockTensor (d := d) (D := D₁) A pA) σ =
+          mpv (zeroMPSTensor (blockPhysDim d pA) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d pA) (μ := μA) blocksA) σ) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d pB)),
+        mpv (blockTensor (d := d) (D := D₂) B pB) σ =
+          mpv (zeroMPSTensor (blockPhysDim d pB) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d pB) (μ := μB) blocksB) σ) := by
+  obtain ⟨zeroTailA, pA, hpA, rA, dimA, μA, blocksA,
+    hTPA, hPrimA, hDimA, hμA, hMPVA⟩ :=
+    exists_tp_primitive_blockDecomp_after_blocking A
+  obtain ⟨zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
+    hTPB, hPrimB, hDimB, hμB, hMPVB⟩ :=
+    exists_tp_primitive_blockDecomp_after_blocking B
+  exact ⟨zeroTailA, pA, hpA, rA, dimA, μA, blocksA,
+    zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
+    hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, hMPVA, hMPVB⟩
+
+/-- Compatibility wrapper for the older structural data shape.
+
+This keeps the historical witness order while the stronger decomposition version
+`afterBlocking_structuralDecompositionData_of_sameMPV₂` exposes the zero-tail MPV
+equations needed for the paper-facing statement. -/
+theorem afterBlocking_structuralData_of_sameMPV₂
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B) :
     -- Both tensors have blocked TP-primitive decompositions
     ∃ (pA : ℕ) (_ : 0 < pA)
       (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
@@ -217,10 +264,10 @@ theorem afterBlocking_structuralData_of_sameMPV₂
       -- Positive bond dimensions
       (∀ k, 0 < dimA k) ∧
       (∀ k, 0 < dimB k) := by
-  obtain ⟨_, pA, hpA, rA, dimA, μA, blocksA, hTPA, hPrimA, hDimA, hμA, _⟩ :=
-    exists_tp_primitive_blockDecomp_after_blocking A
-  obtain ⟨_, pB, hpB, rB, dimB, μB, blocksB, hTPB, hPrimB, hDimB, hμB, _⟩ :=
-    exists_tp_primitive_blockDecomp_after_blocking B
+  obtain ⟨_zeroTailA, pA, hpA, rA, dimA, μA, blocksA,
+    _zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
+    hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, _hMPVA, _hMPVB⟩ :=
+    afterBlocking_structuralDecompositionData_of_sameMPV₂ A B hSame
   exact ⟨pA, hpA, rA, dimA, μA, blocksA, pB, hpB, rB, dimB, μB, blocksB,
     hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB⟩
 
@@ -249,7 +296,8 @@ theorem afterBlocking_structuralDataWithBlockedSameMPV₂_of_sameMPV₂
       (∀ k, μB k ≠ 0) ∧
       (∀ k, 0 < dimA k) ∧
       (∀ k, 0 < dimB k) := by
-  obtain ⟨pA, hpA, rA, dimA, μA, blocksA, pB, hpB, rB, dimB, μB, blocksB,
+  obtain ⟨pA, hpA, rA, dimA, μA, blocksA,
+    pB, hpB, rB, dimB, μB, blocksB,
     hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB⟩ :=
     afterBlocking_structuralData_of_sameMPV₂ A B hSame
   refine ⟨pA, hpA, rA, dimA, μA, blocksA, pB, hpB, rB, dimB, μB, blocksB,

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3185,12 +3185,21 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{theorem}[Structural after-blocking form of the fundamental theorem]%
 	\label{thm:ft_after_blocking_structural}
-	\lean{MPSTensor.afterBlocking_structuralData_of_sameMPV₂}
+	\lean{MPSTensor.afterBlocking_structuralDecompositionData_of_sameMPV₂}
 	\leanok
-	\uses{def:blocked_tensor}
+	\uses{def:blocked_tensor, def:same_mpv2, def:zero_mps_tensor, def:tensor_from_blocks}
 	If two tensors generate the same MPV family, then each tensor admits some
-	blocking after which it decomposes into nonzero left-canonical blocks with
-	primitive transfer maps and positive bond dimensions.
+	blocking after which it decomposes into a zero-tail tensor plus nonzero
+	left-canonical blocks with primitive transfer maps and positive bond
+	dimensions. Moreover, at every blocked system size and every blocked word,
+	the MPV of the blocked tensor is the sum of the zero-tail MPV and the MPV of
+	the weighted nonzero-block tensor:
+	\[
+		V^{(N)}(A^{[p_A]})_\sigma
+		= V^{(N)}(Z_{p_A,z_A})_\sigma
+		  + V^{(N)}\!\left(\bigoplus_k \mu^A_k A_k\right)_\sigma,
+	\]
+	and likewise for $B$.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Summary
- add `afterBlocking_structuralDecompositionData_of_sameMPV₂`, which retains the zero-tail dimensions and MPV decomposition equations returned by `exists_tp_primitive_blockDecomp_after_blocking`
- keep `afterBlocking_structuralData_of_sameMPV₂` as a compatibility wrapper with its historical witness order and return shape
- refresh the Ch8 blueprint statement so the `\leanok` tag points at the stronger decomposition declaration and states the MPV decomposition equation explicitly

## Validation
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --report /tmp/blueprint-lean-sync-1173-review2.json`
- `git diff --check`

Fixes #1173.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new public theorem and changes which theorem the blueprint references, potentially impacting downstream proofs relying on the previous statement shape/order.
> 
> **Overview**
> Introduces `afterBlocking_structuralDecompositionData_of_sameMPV₂`, strengthening the after-blocking structural theorem to *retain the zero-tail witness* and the explicit MPV decomposition equations `blockTensor = zeroMPSTensor + toTensorFromBlocks` for both tensors.
> 
> Keeps `afterBlocking_structuralData_of_sameMPV₂` as a compatibility wrapper that preserves the historical witness order/return shape by projecting from the stronger theorem.
> 
> Updates the Chapter 8 blueprint theorem to point to the stronger Lean statement and to explicitly state the zero-tail MPV decomposition equation (and adds the needed `\uses` dependencies).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d6a7e74670e08c785260a9aad6d5442146ac945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->