### PR TITLE
ci(github): add Claude review kill switch

### DIFF
--- a/.github/workflows/blueprint-prose-review.yml
+++ b/.github/workflows/blueprint-prose-review.yml
@@ -14,6 +14,10 @@ concurrency:
 
 jobs:
   blueprint-and-prose:
+    # Repository variable kill switch:
+    #   CLAUDE_REVIEW_ENABLED=false disables Claude-powered blueprint/prose review.
+    #   unset or any other value preserves the default enabled behavior.
+    if: vars.CLAUDE_REVIEW_ENABLED != 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,10 @@ concurrency:
 
 jobs:
   claude-review:
+    # Repository variable kill switch:
+    #   CLAUDE_REVIEW_ENABLED=false disables Claude-powered PR review.
+    #   unset or any other value preserves the default enabled behavior.
+    if: vars.CLAUDE_REVIEW_ENABLED != 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   cleanup:
     if: |
+      vars.CLAUDE_REVIEW_ENABLED != 'false' &&
       !github.event.pull_request.head.repo.fork &&
       (
         startsWith(github.event.pull_request.head.ref, 'claude/') ||

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -24,14 +24,17 @@ jobs:
   track:
     # Skip: forks (no secrets), closed-but-not-completed issues, closed-but-not-merged PRs
     if: |
+      vars.CLAUDE_REVIEW_ENABLED != 'false' &&
       (
-        github.event_name == 'issues' &&
-        (github.event.issue.state_reason == 'completed' || github.event.action == 'reopened')
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        !github.event.pull_request.head.repo.fork &&
-        (github.event.action != 'closed' || github.event.pull_request.merged == true)
+        (
+          github.event_name == 'issues' &&
+          (github.event.issue.state_reason == 'completed' || github.event.action == 'reopened')
+        ) ||
+        (
+          github.event_name == 'pull_request' &&
+          !github.event.pull_request.head.repo.fork &&
+          (github.event.action != 'closed' || github.event.pull_request.merged == true)
+        )
       )
     runs-on: ubuntu-latest
     permissions:

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -404,6 +404,7 @@ provider or mention handler.
 | Variable | Disabled workflows |
 |----------|--------------------|
 | `CLAUDE_AUTO_FIX_ENABLED=false` | `auto-fix.yml` and manual PR creation in `lean-linter-warning-autofix.yml` |
+| `CLAUDE_REVIEW_ENABLED=false` | `claude-code-review.yml`, `blueprint-prose-review.yml`, and `pr-cleanup.yml` |
 | `CODEX_AUTO_FIX_ENABLED=false` | `auto-fix-codex.yml` |
 | `CODEX_MENTION_ENABLED=false` | `codex.yml` (`@chatgpt` mention handler) |
 
@@ -411,6 +412,7 @@ Set them with:
 
 ```bash
 gh variable set CLAUDE_AUTO_FIX_ENABLED --body false
+gh variable set CLAUDE_REVIEW_ENABLED --body false
 gh variable set CODEX_AUTO_FIX_ENABLED --body false
 gh variable set CODEX_MENTION_ENABLED --body false
 ```

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -404,7 +404,7 @@ provider or mention handler.
 | Variable | Disabled workflows |
 |----------|--------------------|
 | `CLAUDE_AUTO_FIX_ENABLED=false` | `auto-fix.yml` and manual PR creation in `lean-linter-warning-autofix.yml` |
-| `CLAUDE_REVIEW_ENABLED=false` | `claude-code-review.yml`, `blueprint-prose-review.yml`, and `pr-cleanup.yml` |
+| `CLAUDE_REVIEW_ENABLED=false` | `claude-code-review.yml`, `blueprint-prose-review.yml`, `pr-cleanup.yml`, and `tracking-issue-sync.yml` |
 | `CODEX_AUTO_FIX_ENABLED=false` | `auto-fix-codex.yml` |
 | `CODEX_MENTION_ENABLED=false` | `codex.yml` (`@chatgpt` mention handler) |
 


### PR DESCRIPTION
### Motivation
Claude quota exhaustion currently makes Claude-powered PR review, blueprint/prose review, PR cleanup, and tracker checks fail even when the underlying PR content is fine. The existing kill switches cover auto-fix and `@chatgpt`, but not those Claude-backed PR automation jobs.

### Description
- Add `CLAUDE_REVIEW_ENABLED=false` as a job-level gate for `claude-code-review.yml` and `blueprint-prose-review.yml`.
- Apply the same gate to `pr-cleanup.yml` and `tracking-issue-sync.yml`, which also consume Claude quota on PR events.
- Document the new repository variable with the existing CI kill switches.

### Testing
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f) }; puts "ok"' .github/workflows/claude-code-review.yml .github/workflows/blueprint-prose-review.yml .github/workflows/pr-cleanup.yml .github/workflows/tracking-issue-sync.yml`
- `git diff --check`

Repository variable set: `CLAUDE_REVIEW_ENABLED=false`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds job-level `if` guards and documentation, changing when workflows run but not their logic or permissions.
> 
> **Overview**
> Adds a repository-variable kill switch (`CLAUDE_REVIEW_ENABLED=false`) to **disable Claude-powered automation** without editing workflow files.
> 
> Applies the gate at the job level for `claude-code-review.yml` and `blueprint-prose-review.yml`, and also prevents Claude-consuming ancillary workflows (`pr-cleanup.yml`, `tracking-issue-sync.yml`) from running when the switch is off. Documentation in `docs/ci-automation.md` is updated to list and show how to set the new variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd3a45049f7d488b97aa33d1b919a8ada813f0cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->