### PR TITLE
doc(MPS/BNT): clean API prose

### DIFF
--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -49,13 +49,13 @@ Theorem 4.4 of arXiv:2011.12127 (Cirac–Pérez-García–Schuch–Verstraete, R
   sufficiently large system sizes there is an invertible coefficient matrix `U_N` expressing one
   family in terms of the other.
 
-## Intended use (Theorem 4.4 roadmap)
+## Intended use in Theorem 4.4
 
 1. **Block separation** produces two BNT families `A_bnt` and `B_bnt` from tensors `A_total` and
    `B_total` that generate the same MPV family.
 2. This module supplies the invertible `U_N` relating the two BNT families at each large `N`.
-3. A **subsequent step** (not in this file) will show that `U_N` converges to a
-   permutation-times-phase matrix, using the overlap orthonormality conditions.
+3. The permutation-rigidity argument identifies the limiting coefficient matrix as a
+   permutation times diagonal phases, using the overlap orthonormality conditions.
 -/
 
 open scoped BigOperators InnerProductSpace Matrix

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -23,18 +23,18 @@ Definition 4.2 / Proposition char-BNT in arXiv:2011.12127 and arXiv:1606.00608, 
 1. **`IsCanonicalFormBNT`**: A strengthened canonical form where no two distinct blocks are
    gauge-phase equivalent (the BNT grouping step has been performed).
 
-2. **`cross_overlap_tendsto_zero_of_separated_CFBNT_data`** and the legacy formulation
+2. **`cross_overlap_tendsto_zero_of_separated_CFBNT_data`** and the bundled-data formulation
    **`IsCanonicalFormBNT.cross_overlap_tendsto_zero`**: distinct CF-BNT blocks have decaying
    cross-overlaps. The proof combines:
    - Dimension-mismatch case: `mpvOverlap_tendsto_zero_of_dim_ne`
    - Same-dimension case: `mpvOverlap_tendsto_zero` (using `blocks_not_equiv` to supply
      `¬GaugePhaseEquiv`)
 
-3. **`isBNT_of_separated_CFBNT_data`** and the legacy formulation **`IsCanonicalFormBNT.isBNT`**:
+3. **`isBNT_of_separated_CFBNT_data`** and the bundled-data formulation **`IsCanonicalFormBNT.isBNT`**:
    a canonical-form decomposition into a basis of normal tensors yields a valid `IsBNT`
    structure, assembling all overlap and independence properties.
 
-4. **`fundamentalTheorem_of_separated_CFBNT_data`** and the legacy formulation
+4. **`fundamentalTheorem_of_separated_CFBNT_data`** and the bundled-data formulation
    **`fundamentalTheorem_of_IsCanonicalFormBNT`**: if two CF-BNT decompositions generate
    proportional MPVs with convergent nonzero coefficients, then the blocks match up to
    permutation, dimension equality, and gauge-phase equivalence. This connects
@@ -314,7 +314,8 @@ variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 /-- **Cross-overlap decay for CF-BNT blocks**: distinct blocks have
 `mpvOverlap (A j) (A k) N → 0` as `N → ∞`.
 
-This legacy theorem now delegates to `cross_overlap_tendsto_zero_of_separated_CFBNT_data`. -/
+This bundled-data theorem is a direct consequence of
+`cross_overlap_tendsto_zero_of_separated_CFBNT_data`. -/
 theorem cross_overlap_tendsto_zero
     [∀ k, NeZero (dim k)]
     (hCF : IsCanonicalFormBNT μ A) (j k : Fin r) (hjk : j ≠ k) :
@@ -330,7 +331,7 @@ theorem cross_overlap_tendsto_zero
 /-- A canonical-form decomposition into a basis of normal tensors yields a valid `IsBNT`
 structure.
 
-This legacy theorem now delegates to `isBNT_of_separated_CFBNT_data`. -/
+This bundled-data theorem is a direct consequence of `isBNT_of_separated_CFBNT_data`. -/
 theorem isBNT [∀ k, NeZero (dim k)]
     (hCF : IsCanonicalFormBNT μ A) :
     IsBNT (toTensorFromBlocks μ A) r dim A :=
@@ -542,7 +543,8 @@ If two families of tensors in canonical-form BNT give rise to proportional MPVs
 of blocks, and blocks match up to permutation, dimension equality, and gauge-phase
 equivalence.
 
-This legacy theorem now delegates to `fundamentalTheorem_of_separated_CFBNT_data`. -/
+This bundled-data theorem is a direct consequence of
+`fundamentalTheorem_of_separated_CFBNT_data`. -/
 theorem fundamentalTheorem_of_IsCanonicalFormBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -116,9 +116,8 @@ The theorem takes convergent coefficient data as explicit hypotheses.
 
 /-- Split-data proportional-MPV Fundamental Theorem for CF-BNT-style data (Theorem 4.4).
 
-This is the Stage B low-risk interface: it uses only the hypotheses actually used by the
-proportional-MPV argument, and leaves the legacy `IsCanonicalFormBNT` version below
-unchanged. -/
+This formulation exposes exactly the hypotheses used by the proportional-MPV argument,
+separating the BNT matching data from the bundled `IsCanonicalFormBNT` interface. -/
 abbrev BlockPermutationGaugeWitness
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}


### PR DESCRIPTION
### Motivation
A few BNT and proportional-FT docstrings still used workflow/status language such as "legacy", "Stage B", and "subsequent step". Those terms do not describe the mathematical API and make the declarations read like project notes.

### Description
- Rephrase the BNT matching roadmap in `BNT.Basic` as a stable Theorem 4.4 dependency chain.
- Describe bundled `IsCanonicalFormBNT` declarations as bundled-data consequences rather than legacy variants.
- Reword the split-data proportional-FT witness docstring to explain the mathematical interface.

### Testing
- `lake env lean TNLean/MPS/BNT/Basic.lean`
- `lake env lean TNLean/MPS/BNT/Construction.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/EqualProportional.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only edits that rephrase theorem roadmaps and interfaces without changing any definitions or proofs; risk is limited to minor documentation misunderstandings.
> 
> **Overview**
> Rewords documentation in `MPS/BNT/Basic.lean`, `MPS/BNT/Construction.lean`, and `MPS/FundamentalTheorem/EqualProportional.lean` to remove workflow/"legacy" language and describe results as stable, bundled-vs-separated-data interfaces.
> 
> Clarifies the intended dependency chain for Theorem 4.4 (BNT families → invertible `U_N` → permutation/phase rigidity) and updates theorem docstrings to state they are direct consequences of the corresponding separated-data lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 992ead3768e22bc2193ed651a01aad96ccc78c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->