### PR TITLE
doc(MPS/BNT): refresh permutation rigidity references

### DIFF
--- a/TNLean/MPS/BNT/PermutationRigidity.lean
+++ b/TNLean/MPS/BNT/PermutationRigidity.lean
@@ -14,9 +14,9 @@ import Mathlib.Data.Fintype.EquivFin
 (paper hypotheses, no span-equality)
 
 This module replaces the extra span-equality hypothesis used in
-`BNTPermutationSimple.lean` with the **paper-style** hypotheses from Theorem 4.4
-(arXiv:2011.12127 / 1606.00608, primitive branch): proportionality of the *full*
-MPV families together with explicit decompositions into BNT families.
+`PermutationRigidityPrimitive.lean` with the **paper-style** hypotheses from Theorem 4.4
+(arXiv:2011.12127 / 1606.00608, primitive branch): proportionality of the full MPV
+families together with explicit decompositions into BNT families.
 
 It contains both directions of the key nonvanishing-overlap step and the resulting
 full permutation / gauge-phase matching theorems, in both the injective and
@@ -50,7 +50,7 @@ Then for each `k`, it is impossible that `mpvOverlap (A j) (B k)` tends to `0`
 for all `j`.
 
 This lemma is the replacement for the span-equality-based argument
-`exists_nonzero_overlap` in `BNTPermutationSimple.lean`.
+`exists_nonzero_overlap` in `PermutationRigidityPrimitive.lean`.
 -/
 theorem exists_nonzero_overlap_of_proportional_decomp
     {d : ℕ}

--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -14,9 +14,8 @@ import Mathlib.LinearAlgebra.Dimension.Constructions
 # Permutation rigidity for basis-of-normal-tensors (BNT) decompositions — simplified
 (primitive branch)
 
-This is a *simpler* alternative to `BNTPermutation.lean`, implementing the
-permutation/phase-rigidity step for families satisfying the basis-of-normal-tensors (BNT)
-condition in the
+This module proves the span-equality version of the permutation/phase-rigidity step for
+families satisfying the basis-of-normal-tensors (BNT) condition in the
 primitive (aperiodic) branch of the Fundamental Theorem of MPS (Theorem 4.4 of
 arXiv:2011.12127).
 


### PR DESCRIPTION
### Motivation

- The BNT permutation-rigidity docstrings still named obsolete source files that no longer exist in `TNLean/MPS/BNT/`.
- Current references should distinguish the span-equality rigidity theorem from the paper-hypothesis theorem without stale filenames.

### Description

- Replaced obsolete `BNTPermutation.lean` and `BNTPermutationSimple.lean` references with current mathematical descriptions and the current `PermutationRigidityPrimitive.lean` module name.
- Did not change theorem statements or proofs.

### Testing

- `lake env lean TNLean/MPS/BNT/PermutationRigidityPrimitive.lean`
- `lake env lean TNLean/MPS/BNT/PermutationRigidity.lean`
- `git diff --check`

---
Partially addresses #1170

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only updates that rename/clarify cross-references between the paper-hypothesis (`PermutationRigidity.lean`) and span-equality (`PermutationRigidityPrimitive.lean`) variants; no theorem statements or proofs are changed.
> 
> **Overview**
> Updates the top-level documentation in `PermutationRigidity.lean` and `PermutationRigidityPrimitive.lean` to remove stale references to old `BNTPermutation*` modules and to clearly distinguish the *paper-hypothesis, no span-equality* route from the *span-equality* route.
> 
> No functional Lean code changes (theorems/proofs unchanged); this is purely a documentation/reference refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcbb44714bc950f434b058e6d56d403d03982238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->