### PR TITLE
ci(github): skip Claude steps when disabled

### DIFF
--- a/.github/workflows/blueprint-prose-review.yml
+++ b/.github/workflows/blueprint-prose-review.yml
@@ -27,7 +27,20 @@ jobs:
       id-token: write
 
     steps:
+      - name: Check Claude review switch
+        id: claude-switch
+        env:
+          CLAUDE_REVIEW_ENABLED: ${{ vars.CLAUDE_REVIEW_ENABLED }}
+        run: |
+          if [ "$CLAUDE_REVIEW_ENABLED" = "false" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude blueprint/prose review: CLAUDE_REVIEW_ENABLED=false"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check if head commit is a bot auto-fix
+        if: steps.claude-switch.outputs.skip != 'true'
         id: bot-check
         uses: actions/github-script@v8
         with:
@@ -45,13 +58,13 @@ jobs:
             if (isBot) core.notice(`Skipping prose review for bot-fix commit: ${msg.split('\n')[0]}`);
 
       - name: Checkout repository
-        if: steps.bot-check.outputs.skip != 'true'
+        if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Run Blueprint Sync & Prose Review
-        if: steps.bot-check.outputs.skip != 'true'
+        if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true'
         id: blueprint-prose-review
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,7 +31,20 @@ jobs:
       id-token: write
 
     steps:
+      - name: Check Claude review switch
+        id: claude-switch
+        env:
+          CLAUDE_REVIEW_ENABLED: ${{ vars.CLAUDE_REVIEW_ENABLED }}
+        run: |
+          if [ "$CLAUDE_REVIEW_ENABLED" = "false" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude code review: CLAUDE_REVIEW_ENABLED=false"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check if head commit is a bot auto-fix
+        if: steps.claude-switch.outputs.skip != 'true'
         id: bot-check
         uses: actions/github-script@v8
         with:
@@ -52,17 +65,17 @@ jobs:
             if (isBot) core.notice(`Skipping review for bot-fix commit: ${msg.split('\n')[0]}`);
 
       - name: Checkout repository
-        if: steps.bot-check.outputs.skip != 'true'
+        if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Set up Lean toolchain and cache
-        if: steps.bot-check.outputs.skip != 'true'
+        if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true'
         uses: ./.github/actions/setup-lean
 
       - name: Run Claude Code Review
-        if: steps.bot-check.outputs.skip != 'true'
+        if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -25,12 +25,26 @@ jobs:
       id-token: write
 
     steps:
+      - name: Check Claude review switch
+        id: claude-switch
+        env:
+          CLAUDE_REVIEW_ENABLED: ${{ vars.CLAUDE_REVIEW_ENABLED }}
+        run: |
+          if [ "$CLAUDE_REVIEW_ENABLED" = "false" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping PR cleanup: CLAUDE_REVIEW_ENABLED=false"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
+        if: steps.claude-switch.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Sanitize PR body
+        if: steps.claude-switch.outputs.skip != 'true'
         id: sanitize
         uses: actions/github-script@v8
         with:
@@ -43,6 +57,7 @@ jobs:
             core.setOutput('body', sanitized);
 
       - name: Clean up bot-generated PR
+        if: steps.claude-switch.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -43,12 +43,26 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Check Claude review switch
+        id: claude-switch
+        env:
+          CLAUDE_REVIEW_ENABLED: ${{ vars.CLAUDE_REVIEW_ENABLED }}
+        run: |
+          if [ "$CLAUDE_REVIEW_ENABLED" = "false" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping issue tracker: CLAUDE_REVIEW_ENABLED=false"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
+        if: steps.claude-switch.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Run Claude Code
+        if: steps.claude-switch.outputs.skip != 'true'
         id: claude
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
### Motivation
`CLAUDE_REVIEW_ENABLED=false` was added as a job-level gate, but at least one PR event still entered Claude-backed steps and failed on quota exhaustion. The switch needs to guard the Claude action steps directly as well.

### Description
- Add an explicit first-step `CLAUDE_REVIEW_ENABLED` check to Claude code review, blueprint/prose review, PR cleanup, and issue tracker workflows.
- Guard checkout/setup and Claude action steps with that output, so the job exits successfully without invoking Claude when the variable is `false`.

### Testing
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f) }; puts "ok"' .github/workflows/claude-code-review.yml .github/workflows/blueprint-prose-review.yml .github/workflows/pr-cleanup.yml .github/workflows/tracking-issue-sync.yml`
- `git diff --check`

Repository variable is already set: `CLAUDE_REVIEW_ENABLED=false`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds extra step-level gating; main risk is inadvertently skipping intended reviews/automation if the `skip` output logic or `if` conditions are mis-specified.
> 
> **Overview**
> Ensures Claude-backed workflows don’t invoke checkout/setup or the `anthropics/claude-code-action` when the repo variable `CLAUDE_REVIEW_ENABLED` is set to `false`.
> 
> Adds an explicit early `claude-switch` step to `claude-code-review.yml`, `blueprint-prose-review.yml`, `pr-cleanup.yml`, and `tracking-issue-sync.yml`, and updates subsequent steps (including the existing bot-commit skip check) to short-circuit based on `steps.claude-switch.outputs.skip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ff35966bc8c4bd5624c708520a0451beb9b8f83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->