### PR TITLE
doc(Wielandt): refresh rank-one span reference

### DIFF
--- a/TNLean/Wielandt/RankOne/SpanGrowth.lean
+++ b/TNLean/Wielandt/RankOne/SpanGrowth.lean
@@ -19,8 +19,8 @@ The paper's Lemma 2(b) uses a Jordan/Fitting argument:
 * multiplication by `M` is injective on that invertible block,
 * hence certain "rectangular spans" grow in dimension until they stabilize.
 
-Here we start formalizing the linear-algebraic core, using the new range lemma from
-`TNLean/Wielandt/RankOneExtraction.lean`:
+Here we start formalizing the linear-algebraic core, using the range lemma from
+`TNLean.Wielandt.RankOne.Extraction`:
 
 `LinearMap.range (f^D) = ⨆ (μ ≠ 0), maxGenEigenspace f μ`.
 
@@ -87,7 +87,7 @@ theorem disjoint_ker_iSup_maxGenEigenspace_ne_zero (f : End ℂ (Fin D → ℂ))
 
 /-- `ker f` is disjoint from `range (f^D)`.
 
-This is where we use the new range description from `RankOneExtraction.lean`. -/
+This is where we use the range description from `TNLean.Wielandt.RankOne.Extraction`. -/
 theorem disjoint_ker_range_pow (f : End ℂ (Fin D → ℂ)) :
     Disjoint (LinearMap.ker f) (LinearMap.range (f ^ D)) := by
   -- Start from disjointness with the iSup of nonzero generalized eigenspaces,


### PR DESCRIPTION
### Motivation

- `TNLean/Wielandt/RankOne/SpanGrowth.lean` still referred to an obsolete rank-one extraction file path.
- The rank-one span-growth comments should point readers to the current module that provides the range decomposition lemma.

### Description

- Replaced the stale `TNLean/Wielandt/RankOneExtraction.lean` reference with `TNLean.Wielandt.RankOne.Extraction`.
- Did not change theorem statements or proofs.

### Testing

- `lake env lean TNLean/Wielandt/RankOne/SpanGrowth.lean`
- `lake env lean TNLean/Wielandt/RectangularSpan/Growth.lean`
- `git diff --check`

---
Partially addresses #1170

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates an import path and documentation/comments only, with no changes to theorem statements or proofs.
> 
> **Overview**
> Updates `TNLean/Wielandt/RankOne/SpanGrowth.lean` to reference the new module name `TNLean.Wielandt.RankOne.Extraction` (import and in-file comments), replacing the stale `RankOneExtraction.lean` path. No proof logic or lemma statements change; this is purely a documentation/module-path refresh to keep the range-decomposition lemma pointer accurate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0c363747a129d08d14b56936871528f3c1177a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->