### PR TITLE
doc(MPS/CanonicalForm): clean after-blocking blueprint prose

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean
@@ -56,7 +56,7 @@ The full proof chain is:
 3. Common blocking to primitive (`exists_common_blocking_all_primitive_of_TP_irr`)
 4. Cyclic sector decomposition per block (`exists_cyclic_sector_decomp_after_blocking`)
 
-### Current status
+### Remaining mathematical inputs
 
 The theorem `exists_tp_sector_decomp_after_blocking` below provides:
 - A blocking period `p > 0`
@@ -236,7 +236,7 @@ theorem afterBlocking_structuralDecompositionData_of_sameMPV₂
     zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
     hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, hMPVA, hMPVB⟩
 
-/-- Compatibility wrapper for the older structural data shape.
+/-- Compatibility formulation for the older structural data shape.
 
 This keeps the historical witness order while the stronger decomposition version
 `afterBlocking_structuralDecompositionData_of_sameMPV₂` exposes the zero-tail MPV

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1777,19 +1777,20 @@ two-basis sector comparison theorem.
 
 \begin{definition}[After-blocking hypotheses for the CPSV formulation]%
 	\label{def:after_blocking_fundamental_theorem_hypotheses}
-		\lean{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}
-		\leanok
-		\uses{def:common_primitive_bnt_cover_hypotheses}
-			These hypotheses consist of the comparison data for the
-		periodic-theorem-free after-blocking formulation of the CPSV Fundamental
-			Theorem. The blocked-word identification for common cyclic sectors is
-		now derived from the grouped-block cast theorem. For the common primitive nonzero-sector families produced from two
-		tensors with the same MPV family, the comparison field is supplied with their
-		trace-preserving normalization, primitivity, irreducibility, and
-		positive bond-dimension evidence
-	before returning BNT-cover comparison hypotheses for those blocks. The hypotheses
-	are tied to the produced families rather than to an arbitrary chosen
-	decomposition.
+	\lean{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses}
+	These hypotheses consist of the comparison data for the after-blocking
+	formulation of the CPSV Fundamental Theorem that does not use the periodic
+	theorem. The blocked-word identification for common cyclic sectors is
+	derived from the grouped-block cast theorem.
+
+	For the common primitive nonzero-sector families produced from two tensors
+	with the same MPV family, the comparison data include their
+	trace-preserving normalization, primitivity, irreducibility, and positive
+	bond-dimension evidence before returning BNT-cover comparison hypotheses for
+	those blocks. The hypotheses are tied to the produced families rather than
+	to an arbitrary chosen decomposition.
 \end{definition}
 
 \begin{definition}[CPSV after-blocking Fundamental Theorem conclusion]%
@@ -1815,18 +1816,19 @@ two-basis sector comparison theorem.
 	Let $A$ and $B$ generate the same MPV family. Assume the after-blocking
 	comparison hypotheses of
 	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. Then the
-	the CPSV conclusion of
+	CPSV conclusion of
 	Definition~\ref{def:after_blocking_fundamental_theorem_conclusion} is
 	nonempty.
 
 	The conclusion matches the sector-decomposition part of the
 	Cirac--P\'erez-Garc\'ia--Schuch--Verstraete Fundamental Theorem: after
-		blocking, the tensor families are represented by BNT sector decompositions
-		whose basis sectors and weights match up to permutation and nonzero phases, as
-		in \cite{Cirac2016MPDO_arXiv} and \cite{Cirac2021Matrix}. The explicit hypotheses are:
-		the statement does not assume away zero-tail, trace-preserving normalization,
-		primitivity, irreducibility, positive bond-dimension, or BNT-cover comparison
-		inputs.
+	blocking, the tensor families are represented by BNT sector decompositions
+	whose basis sectors and weights match up to permutation and nonzero phases,
+	as in \cite{Cirac2016MPDO_arXiv} and \cite{Cirac2021Matrix}.
+
+	The explicit hypotheses include the zero-tail, trace-preserving
+	normalization, primitivity, irreducibility, positive bond-dimension, and
+	BNT-cover comparison inputs.
 \end{theorem}
 
 	\begin{proof}


### PR DESCRIPTION
## Summary

- Reflow the Chapter 11 after-blocking hypotheses prose around the CPSV formulation.
- Fix the duplicated `the` typo in the conditional after-blocking theorem statement.
- Replace two software-style phrases in `StructuralTheorem.lean` docstrings with mathematical wording.

This is a small cleanup slice for #1170 and #328. It does not close either tracker.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/StructuralTheorem.lean`
- `cd blueprint && leanblueprint web`
- `git diff --check`

`leanblueprint web` exits successfully. It still prints existing plasTeX warnings about the local package setup and missing bibliography entries, as on the current blueprint build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes: reworded Lean docstrings and refined blueprint LaTeX prose/typos, with no impact on compiled logic or APIs beyond comments.
> 
> **Overview**
> Clarifies after-blocking documentation by rephrasing two Lean docstrings in `StructuralTheorem.lean` (e.g., “Current status” → **“Remaining mathematical inputs”**, and “wrapper” → **“formulation”**).
> 
> Cleans up Chapter 11 blueprint prose around `AfterBlockingFundamentalTheoremHypotheses` and the conditional after-blocking theorem statement, including fixing a duplicated “the” typo and reflowing/clarifying the hypothesis and conclusion descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2afc7764221d64b4779ebe0a2eaa221bc5fec1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->