### PR TITLE
feat(MPS/CanonicalForm): expose common primitive BNT adapter

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -945,6 +945,87 @@ theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
       hPrimA hPrimB hIrrA hIrrB hDimA hDimB
   exact hBNTCover.toCommonPrimitivePhaseCoverHypotheses
 
+/-- **Sector basis overlap-span data from explicit common primitive BNT data.**
+
+This is the explicit-data variant of
+`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover`. It forms the
+BNT-cover hypotheses from the common primitive structural data together with the
+remaining BNT comparison inputs, then applies the BNT-cover overlap-span theorem. -/
+theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      [∀ x : Fin rA, NeZero (dimA x)]
+      [∀ x : Fin rB, NeZero (dimB x)]
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      Σ DtotA : ℕ, Σ DtotB : ℕ,
+        { _hDecomp : ProportionalDecompositionData (d := blockPhysDim d p)
+            blocksA blocksB DtotA DtotB //
+          StrictAnti (fun x : Fin rA => ‖μA x‖) ∧
+          StrictAnti (fun x : Fin rB => ‖μB x‖) ∧
+          BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksA ∧
+          BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksB ∧
+          zeroTailA = zeroTailB ∧
+          (∀ x, IsInjective (blocksA x)) ∧
+          (∀ x, IsInjective (blocksB x)) }) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      SectorBasisOverlapSpanHypotheses P Q := by
+  refine sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
+    A B hSame hReindexed ?_
+  intro p zeroTailA zeroTailB rA rB dimA dimB _ _ μA μB blocksA blocksB hp
+    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
+    hIrrA hIrrB hDimA hDimB
+  obtain ⟨DtotA, DtotB, hPacked⟩ :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  rcases hPacked.2 with
+    ⟨hAntiA, hAntiB, hNotGpeA, hNotGpeB, hZeroTail, hInjA, hInjB⟩
+  refine ⟨DtotA, DtotB, ⟨?_⟩⟩
+  exact CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData
+    hμA hμB hTPA hTPB hPrimA hPrimB hIrrA hIrrB hAntiA hAntiB hNotGpeA hNotGpeB
+    hZeroTail hInjA hInjB hPacked.1
+
 /-- **Sector basis overlap-span data via a BNT proportional-decomposition comparison.**
 
 This is the proportional-comparison variant of

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -1278,6 +1278,101 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCove
       hPrimA hPrimB hIrrA hIrrB hDimA hDimB
   exact hBNTCover.toCommonPrimitivePhaseCoverHypotheses
 
+/-- **Sector comparison from explicit common primitive BNT data.**
+
+Assume the blocked-word relabeling statement for cyclic-sector data. The structural
+theorem supplies common primitive nonzero-sector families on both sides. If those
+families also carry the remaining BNT comparison inputs, then
+`CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData` gives the BNT-cover
+hypotheses needed by the phase-cover comparison theorem.
+
+This statement exposes the exact remaining assertions for the common primitive
+families: strict weight ordering, gauge-phase separation inside each family,
+zero-tail equality, injectivity, and proportional-decomposition data. -/
+theorem afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveBNTData
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      [∀ x : Fin rA, NeZero (dimA x)]
+      [∀ x : Fin rB, NeZero (dimB x)]
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      Σ DtotA : ℕ, Σ DtotB : ℕ,
+        { _hDecomp : ProportionalDecompositionData (d := blockPhysDim d p)
+            blocksA blocksB DtotA DtotB //
+          StrictAnti (fun x : Fin rA => ‖μA x‖) ∧
+          StrictAnti (fun x : Fin rB => ‖μB x‖) ∧
+          BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksA ∧
+          BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksB ∧
+          zeroTailA = zeroTailB ∧
+          (∀ x, IsInjective (blocksA x)) ∧
+          (∀ x, IsInjective (blocksB x)) }) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  refine afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
+    A B hSame hReindexed ?_
+  intro p zeroTailA zeroTailB rA rB dimA dimB _ _ μA μB blocksA blocksB hp
+    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
+    hIrrA hIrrB hDimA hDimB
+  obtain ⟨DtotA, DtotB, hPacked⟩ :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  rcases hPacked.2 with
+    ⟨hAntiA, hAntiB, hNotGpeA, hNotGpeB, hZeroTail, hInjA, hInjB⟩
+  refine ⟨DtotA, DtotB, ⟨?_⟩⟩
+  exact CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData
+    hμA hμB hTPA hTPB hPrimA hPrimB hIrrA hIrrB hAntiA hAntiB hNotGpeA hNotGpeB
+    hZeroTail hInjA hInjB hPacked.1
+
 /-- **Sector comparison from relabeled common sectors and proportional-decomposition data.**
 
 Assume the blocked-word relabeling statement for cyclic-sector data.  Then the

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1752,6 +1752,28 @@ two-basis sector comparison theorem.
 	with common phase-cover data.
 \end{proof}
 
+\begin{theorem}[Common sectors from explicit common primitive BNT data]%
+\label{thm:afterBlocking_sectorComparison_commonPrimitiveBNTData}
+	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveBNTData}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		thm:afterBlocking_sectorComparison_reindexed_bntCover}
+	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
+	identification hypothesis for the cyclic-sector data. The common-sector
+	structural theorem produces the common primitive nonzero-sector families. If
+	these families have strict weight ordering, internal gauge-phase separation,
+	equal zero-tail dimension, one-site injectivity, and proportional-decomposition
+	data, then the same sector-weight comparison conclusion holds.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		thm:afterBlocking_sectorComparison_reindexed_bntCover}
+	First form the BNT-cover hypotheses for the produced families from the stated
+	common primitive data. Then apply the BNT-cover comparison theorem.
+\end{proof}
+
 \begin{theorem}[Common sectors from proportional-comparison data]%
 \label{thm:afterBlocking_sectorComparison_reindexed_proportional}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1502,6 +1502,29 @@ two-basis sector comparison theorem.
 	sector decompositions and their primitive overlap-span hypotheses.
 \end{proof}
 
+\begin{theorem}[Explicit BNT data give overlap-span hypotheses]%
+\label{thm:sector_basis_overlap_span_commonPrimitiveBNTData}
+	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		thm:sector_basis_overlap_span_reindexed_bnt_cover}
+	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
+	identification hypothesis for the cyclic-sector data. The common-sector
+	structural theorem produces common primitive nonzero-sector families. If
+	these families have strict weight ordering, internal gauge-phase separation,
+	equal zero-tail dimension, one-site injectivity, and proportional-decomposition
+	data, then the associated sector decompositions have BNT data, agree as full
+	MPV families, and satisfy the primitive overlap-span hypotheses.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		thm:sector_basis_overlap_span_reindexed_bnt_cover}
+	First form the BNT-cover hypotheses for the produced families from the stated
+	common primitive data. Then apply the BNT-cover overlap-span theorem.
+\end{proof}
+
 \begin{theorem}[Sector comparison from a common phase cover]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1507,6 +1507,7 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
+		def:common_sector_relabeling_hypothesis,
 		thm:sector_basis_overlap_span_reindexed_bnt_cover}
 	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
 	identification hypothesis for the cyclic-sector data. The common-sector
@@ -1520,6 +1521,7 @@ two-basis sector comparison theorem.
 \begin{proof}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
+		def:common_sector_relabeling_hypothesis,
 		thm:sector_basis_overlap_span_reindexed_bnt_cover}
 	First form the BNT-cover hypotheses for the produced families from the stated
 	common primitive data. Then apply the BNT-cover overlap-span theorem.
@@ -1780,6 +1782,7 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveBNTData}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
+		def:common_sector_relabeling_hypothesis,
 		thm:afterBlocking_sectorComparison_reindexed_bntCover}
 	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
 	identification hypothesis for the cyclic-sector data. The common-sector
@@ -1792,6 +1795,7 @@ two-basis sector comparison theorem.
 \begin{proof}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
+		def:common_sector_relabeling_hypothesis,
 		thm:afterBlocking_sectorComparison_reindexed_bntCover}
 	First form the BNT-cover hypotheses for the produced families from the stated
 	common primitive data. Then apply the BNT-cover comparison theorem.


### PR DESCRIPTION
## Summary

- Add `afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveBNTData` in `ProportionalComparison.lean`.
- Add `sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData` for the overlap-span endpoint.
- Both theorems take the structural theorem's produced common primitive families and ask for the exact remaining BNT inputs: strict weight ordering, gauge-phase separation, zero-tail equality, injectivity, and proportional-decomposition data.
- Internally, they form `CommonPrimitiveBNTCoverHypotheses` via `ofCommonPrimitiveData` and apply the existing BNT-cover consumer theorems.
- Add the matching Chapter 11 blueprint theorem entries and proof sketches.

This is a focused #1068/#944 adapter slice: it does not prove the remaining producer-side facts, but makes their shape explicit and reusable.

## Validation

- `lake build TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison TNLean.MPS.CanonicalForm.Assembly --log-level=info`
- `cd blueprint && leanblueprint web`
- `git diff --check`

The Lake build succeeds. `leanblueprint web` exits successfully with the same existing local plasTeX/package and bibliography warnings seen on the current blueprint build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems and blueprint documentation without changing existing definitions or proof behavior, though the new exposed interfaces may slightly increase maintenance surface if downstream code relies on them.
> 
> **Overview**
> Adds two new adapter theorems, `sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData` and `afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveBNTData`, that let callers supply *explicit* “remaining” common-primitive BNT inputs (strict weight ordering, gauge-phase separation, zero-tail equality, injectivity, and proportional-decomposition data) and then reuse the existing BNT-cover consumer theorems.
> 
> Updates the Chapter 11 blueprint to document these new endpoints with corresponding theorem statements and short proof sketches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9582276ab844b195ec0f801c7bd634f6823a87d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->