### PR TITLE
style(MPS/CanonicalForm): clean emitted warnings

### DIFF
--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -75,8 +75,8 @@ basis-of-normal-tensors construction from
 
 ## References
 
-- [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6,
-  Proposition 2.7]: BNT minimality condition and grouping.
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6, Proposition 2.7]:
+  BNT minimality condition and grouping.
 - [Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.A]: Existence of canonical form.
 -/
 

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -32,7 +32,8 @@ period `P` the weights become `(μ₀ k)^P`, and two distinct original weights `
 This file implements strategy **(b)** only in the restricted case where equal-modulus
 blocks on one side are already known to collapse to a single basis tensor. It is
 therefore a useful **special-case norm-class collapse** module, not the full
-basis-of-normal-tensors construction from [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Proposition A.6 /
+basis-of-normal-tensors construction from
+[Cirac--Perez-Garcia--Schuch--Verstraete 2017, Proposition A.6 /
 `prop:char-BNT`]. The general one-sided BNT construction remains open.
 
 ## Main results
@@ -74,7 +75,8 @@ basis-of-normal-tensors construction from [Cirac--Perez-Garcia--Schuch--Verstrae
 
 ## References
 
-- [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6, Proposition 2.7]: BNT minimality condition and grouping.
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6,
+  Proposition 2.7]: BNT minimality condition and grouping.
 - [Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.A]: Existence of canonical form.
 -/
 
@@ -406,11 +408,12 @@ occur at the same modulus, they should survive as different basis elements rathe
 than being forced into one norm class.
 
 **Why `hMPVEq` arises in the full theory**:
-In the BNT theory (Cirac--Perez-Garcia--Schuch--Verstraete 2017, Section 2.3), two blocks with the same weight norm are
-gauge-phase equivalent, hence have the same MPV.  In the existence reduction, this
-property would be derived after applying the BNT uniqueness theorem.  The derivation
-of `hMPVEq` from blocked `SameMPV₂` data is the subject of `EqualNormBridge.lean`
-and downstream theorems (see `exists_sectorDecomp_of_tp_primitive_irr_blocks`).
+In the BNT theory (Cirac--Perez-Garcia--Schuch--Verstraete 2017, Section 2.3),
+two blocks with the same weight norm are gauge-phase equivalent, hence have the
+same MPV. In the existence reduction, this property would be derived after
+applying the BNT uniqueness theorem. The derivation of `hMPVEq` from blocked
+`SameMPV₂` data is the subject of `EqualNormBridge.lean` and downstream
+theorems (see `exists_sectorDecomp_of_tp_primitive_irr_blocks`).
 
 **Proof:**
 1. Let `S = Finset.univ.image (‖μ ·‖)`, `g = S.card`.

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -115,8 +115,8 @@ Theorem matching, etc.).
 
 - [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Lemma A.2]: Overlap dichotomy for Normal Tensors.
 - [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Proposition A.6]: BNT construction and minimality.
-- [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6,
-  Proposition 2.7]: BNT minimality and grouping.
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6, Proposition 2.7]:
+  BNT minimality and grouping.
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -46,8 +46,9 @@ For block k gauge-phase equivalent to representative block j via `(X, ζ)`:
 
 ## Important: equal-norm blocks are NOT automatically gauge-phase equivalent
 
-The BNT of a tensor (Cirac--Perez-Garcia--Schuch--Verstraete 2017, Proposition A.6) is constructed so that all pairs of
-BNT elements have *decaying* cross-overlaps.  In particular, two BNT elements can
+The BNT of a tensor (Cirac--Perez-Garcia--Schuch--Verstraete 2017,
+Proposition A.6) is constructed so that all pairs of BNT elements have
+*decaying* cross-overlaps. In particular, two BNT elements can
 share the same weight norm while being completely independent (non-GPE).  The BNT
 already groups gauge-equivalent blocks together; remaining blocks are pairwise
 non-gauge-equivalent.  A counter-example shows that the
@@ -114,7 +115,8 @@ Theorem matching, etc.).
 
 - [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Lemma A.2]: Overlap dichotomy for Normal Tensors.
 - [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Proposition A.6]: BNT construction and minimality.
-- [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6, Proposition 2.7]: BNT minimality and grouping.
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6,
+  Proposition 2.7]: BNT minimality and grouping.
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -274,7 +274,8 @@ This is the furthest unconditional arbitrary-input step available before periodi
 the cyclic-sector and equal-weight arguments.
 -/
 
-/-- **Arbitrary-input TP-gauge reduction (1606.00608 Section 2.3 + App. A, with zero-block separation).**
+/-- **Arbitrary-input TP-gauge reduction
+(1606.00608 Section 2.3 + App. A, with zero-block separation).**
 
 From any `A : MPSTensor d D`, produce:
 * a zero-tail of dimension `zeroTailDim` accumulating all-zero irreducible blocks;

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -274,8 +274,9 @@ This is the furthest unconditional arbitrary-input step available before periodi
 the cyclic-sector and equal-weight arguments.
 -/
 
-/-- **Arbitrary-input TP-gauge reduction
-(1606.00608 Section 2.3 + App. A, with zero-block separation).**
+/-- **Arbitrary-input TP-gauge reduction.**
+
+1606.00608 Section 2.3 and Appendix A, with zero-block separation.
 
 From any `A : MPSTensor d D`, produce:
 * a zero-tail of dimension `zeroTailDim` accumulating all-zero irreducible blocks;

--- a/TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean
+++ b/TNLean/MPS/CanonicalForm/SectorIrreducibility/HLift.lean
@@ -1014,7 +1014,7 @@ theorem sectorFixedPointAlgebraRigidity_of_irreducible_tp
     (hPproj : ∀ k, IsOrthogonalProjection (P k))
     (hPsum : ∑ k : Fin m, P k = 1)
     (hcyclic : ∀ k,
-      transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k+1)) = P k) :
+      transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) :
     SectorFixedPointAlgebraRigidity
       (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) P := by
   let T : MatrixEnd D := transferMap (d := d) (D := D) (fun i => (A i)ᴴ)


### PR DESCRIPTION
## Summary

- Wrap canonical-form doc/comment lines that were emitted as style warnings in targeted builds.
- Fix the whitespace warning in `SectorIrreducibility/HLift.lean` at `(k + 1)`.
- Keep changes to formatting/prose only; no theorem statements or proof terms are changed.

This is a small cleanup slice for #1170/#334.

## Validation

- `lake build TNLean.MPS.CanonicalForm.SectorIrreducibility.HLift TNLean.MPS.CanonicalForm.NormalReduction.TPGauge TNLean.MPS.CanonicalForm.BNTGrouping TNLean.MPS.CanonicalForm.EqualNormBridge --log-level=info`
- `git diff --check`

The targeted build succeeds. Remaining warnings in the build output are from imported modules outside this PR's scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to comment/docstring wrapping and a minor whitespace tweak, with no changes to theorem statements or proofs.
> 
> **Overview**
> Cleans up style/lint warnings in CanonicalForm modules by reflowing long doc/comments (notably in `BNTGrouping.lean`, `EqualNormBridge.lean`, and `NormalReduction/TPGauge.lean`) and fixing a spacing warning in `SectorIrreducibility/HLift.lean` (e.g., `(k + 1)`).
> 
> No Lean definitions, theorem statements, or proof terms are modified; this PR is formatting/prose-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3949d79010cde1441e7fb516eaeab3f88953ade9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->