### PR TITLE
doc(Wielandt): refresh sharp-bound prose

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -71,9 +71,9 @@ under `IsNormal` (the "Appendix A" argument from arXiv:0909.5347 / Paz).
 The structural theorem `rectSpan_eq_mulLeft_image_of_finrank_eq` shows that
 finrank stabilization below the ceiling forces `rectSpan P A (n+1) = (A i₀) · rectSpan P A n`
 (all generators A i captured by the i₀-direction modulo `ker(mulLeft P)`), which
-combined with primitivity gives the contradiction. The theorem
-`rectSpan_nilpIndex_strict_growth_of_isNormal` proves this statement, and
-`wielandt_sharp_unconditional` applies it to Lemma 2(b).
+combined with primitivity gives the contradiction. This proves rank-one
+membership in the cumulative span at the sharp bound; an eigenvector-padding
+step later upgrades this to the exact fixed-length word-span form.
 -/
 
 section StrictGrowthReduction
@@ -233,8 +233,9 @@ level `n+1` only through the `A i₀` direction (modulo `ker(mulLeft P)`).
 Under `IsNormal` (primitivity), this invariance leads to a contradiction
 unless the finrank equals the ceiling `D · D̃`.
 
-This structural invariance is contradicted by primitivity in
-`rectSpan_nilpIndex_strict_growth_of_isNormal`. -/
+Primitivity contradicts this structural invariance: normality eventually forces
+the rectangular span to fill the whole range of left multiplication, while
+stabilization below the ceiling would keep it in a proper invariant subspace. -/
 theorem rectSpan_leftStep_image_eq_of_finrank_eq
     (A : MPSTensor d D) (i₀ : Fin d) (n : ℕ)
     (hfin : finrank ℂ (rectSpan ((A i₀) ^ D) A n) =
@@ -367,8 +368,9 @@ If `finrank(rectSpan P A n) < D * D̃` and `finrank(rectSpan P A n) =
 finrank(rectSpan P A (n+1))`, then `rectSpan P A n` is a proper subspace of
 `range(mulLeft P)` that absorbs all generator products via `A i₀`.
 
-This is the precise algebraic hypothesis contradicted by primitivity in the
-strict growth proof. -/
+Primitivity rules out this situation because normality eventually makes the
+rectangular span equal to the full range, whereas absorption after stabilization
+would keep it proper. -/
 theorem rectSpan_nilpIndex_proper_absorption
     (A : MPSTensor d D) (i₀ : Fin d) (n : ℕ)
     (hlt : finrank ℂ (rectSpan ((A i₀) ^ nilpIndex (toLin' (A i₀))) A n) <
@@ -769,15 +771,10 @@ theorem vecMulVec_eigenvector_exact_wordSpan
 end ExactPropagation
 
 /-!
-The rank-one extraction and top-level assembly are in `RankOne/ExtractionFull.lean`.
-The main declarations there are:
-
-* `exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors`, placing
-  `vecMulVec φ ψ` in a word span of the blocked tensor from external word eigenvectors
-  and `IsNormal A`;
-* `wielandt_blocked_assembly_complete`, combining rank-one extraction with the
-  conditional assembly to produce some `N` with `wordSpan A N = ⊤`;
-* `wielandt_lemma2b`, the fully unconditional Lemma 2(b) statement.
+The subsequent rank-one step applies the exact word-span result above to word
+eigenvectors of suitable blocked tensors. Combined with the conditional
+rank-one assembly theorem, this gives a single word length whose evaluations span
+the full matrix algebra, and hence the fully unconditional form of Lemma 2(b).
 -/
 
 end MPSTensor

--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -57,12 +57,12 @@ We prove:
    unconditional `D² − D + 1` Lemma 2(b) assuming only strict growth.
 4. **`rectSpan_eq_mulLeft_image_of_finrank_eq`** — structural consequence of
    finrank stabilization: `rectSpan P A (n+1) = (A i₀) · rectSpan P A n`.
-   This is the key algebraic invariance that must be contradicted by `IsNormal` to
-   discharge the strict growth hypothesis.
+   This is the key algebraic invariance contradicted by `IsNormal` in the strict
+   growth theorem proved below.
 
-### What remains for the fully unconditional sharp bound
+### Strict growth and the fully unconditional sharp bound
 
-The only remaining piece is proving:
+The decisive strict-growth statement is:
 
     ∀ n, finrank(rectSpan P A n) < D · D̃ →
          finrank(rectSpan P A n) < finrank(rectSpan P A (n+1))
@@ -71,7 +71,9 @@ under `IsNormal` (the "Appendix A" argument from arXiv:0909.5347 / Paz).
 The structural theorem `rectSpan_eq_mulLeft_image_of_finrank_eq` shows that
 finrank stabilization below the ceiling forces `rectSpan P A (n+1) = (A i₀) · rectSpan P A n`
 (all generators A i captured by the i₀-direction modulo `ker(mulLeft P)`), which
-combined with primitivity gives the contradiction.
+combined with primitivity gives the contradiction. The theorem
+`rectSpan_nilpIndex_strict_growth_of_isNormal` proves this statement, and
+`wielandt_sharp_unconditional` applies it to Lemma 2(b).
 -/
 
 section StrictGrowthReduction
@@ -231,8 +233,8 @@ level `n+1` only through the `A i₀` direction (modulo `ker(mulLeft P)`).
 Under `IsNormal` (primitivity), this invariance leads to a contradiction
 unless the finrank equals the ceiling `D · D̃`.
 
-To discharge the strict growth hypothesis in `wielandt_unconditional_sharp_of_strict_growth`,
-one needs to show this structural invariance contradicts primitivity. -/
+This structural invariance is contradicted by primitivity in
+`rectSpan_nilpIndex_strict_growth_of_isNormal`. -/
 theorem rectSpan_leftStep_image_eq_of_finrank_eq
     (A : MPSTensor d D) (i₀ : Fin d) (n : ℕ)
     (hfin : finrank ℂ (rectSpan ((A i₀) ^ D) A n) =
@@ -355,18 +357,18 @@ theorem proj_gen_in_leftStep_nilpIndex_of_finrank_eq
 /-! ### Part 6: Contrapositive — finrank stabilization ≠ range implies absorption
 
 The contrapositive of strict growth: if finrank stabilizes below the ceiling,
-then the rectSpan is a PROPER invariant subspace of range(mulLeft P) under
-the "quotient action" of generators via A_{i₀}. This is the KEY algebraic
-condition that must be contradicted under IsNormal. -/
+then the rectSpan is a proper invariant subspace of range(mulLeft P) under
+the quotient action of generators via A_{i₀}. This is the algebraic condition
+contradicted under `IsNormal`. -/
 
 /-- **Negation of strict growth implies absorption.**
 
 If `finrank(rectSpan P A n) < D * D̃` and `finrank(rectSpan P A n) =
-finrank(rectSpan P A (n+1))`, then `rectSpan P A n` is a PROPER subspace of
+finrank(rectSpan P A (n+1))`, then `rectSpan P A n` is a proper subspace of
 `range(mulLeft P)` that absorbs all generator products via `A i₀`.
 
-This is the precise algebraic hypothesis that must be contradicted by
-primitivity to prove the strict growth claim. -/
+This is the precise algebraic hypothesis contradicted by primitivity in the
+strict growth proof. -/
 theorem rectSpan_nilpIndex_proper_absorption
     (A : MPSTensor d D) (i₀ : Fin d) (n : ℕ)
     (hlt : finrank ℂ (rectSpan ((A i₀) ^ nilpIndex (toLin' (A i₀))) A n) <
@@ -768,7 +770,7 @@ end ExactPropagation
 
 /-!
 The rank-one extraction and top-level assembly are in `RankOne/ExtractionFull.lean`.
-The main downstream declarations are:
+The main declarations there are:
 
 * `exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors`, placing
   `vecMulVec φ ψ` in a word span of the blocked tensor from external word eigenvectors

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -40,10 +40,9 @@ We formalize the proof chain up to the following:
 
 5. **Cumulative conclusion**: connecting these pieces into the cumulative span bound.
 
-The paper-level fixed-length matrix-spanning step, Lemma 2(b), is now carried by
-the `TNLean.Wielandt.PaperResults` and rank-one extraction modules. This file keeps
-the original cumulative-span and eigenvector-spreading chain as named cumulative
-formulations used by the later fixed-length results.
+The fixed-length matrix-spanning form of Lemma 2(b) is obtained by continuing
+this chain with rank-one extraction and exact word-length padding. The results
+below record the cumulative span and eigenvector-spreading part of the argument.
 
 ## References
 
@@ -245,9 +244,9 @@ theorem wielandt_chain [NeZero D]
 9. `evalWord_replicate_eigenvector`: Iterated pumping
 
 ### Fixed-length bound route:
-The later paper-results modules combine the word-eigenvector extraction, the
-blocked rank-one construction, and fixed-length assembly to prove the paper-level
-index bound. This theorem remains as a named summary declaration for older references.
+The fixed-length argument continues from this cumulative chain by extracting
+rank-one matrices from eigenvectors, padding them to one exact word length, and
+assembling a full matrix span at the Wielandt index bound.
 -/
 theorem wielandt_roadmap : True := trivial
 

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -8,7 +8,7 @@ import TNLean.Wielandt.RankOne.Products
 import TNLean.Wielandt.SpanGrowth.EigenvectorSpreading
 
 /-!
-# Quantum Wielandt Bound - proof roadmap
+# Quantum Wielandt Bound - cumulative span chain
 
 This file collects the main results of the quantum Wielandt bound
 from arXiv:0909.5347 (Sanz, Pérez-García, Wolf, Cirac).
@@ -38,12 +38,12 @@ We formalize the proof chain up to the following:
 4. **Eigenvector spreading**: The cumulative vector span reaches ⊤ in D-1 steps
    (`eigenvector_spreading` from `EigenvectorSpreading.lean`)
 
-5. **Proof synthesis**: connecting these pieces into the Wielandt bound.
+5. **Cumulative conclusion**: connecting these pieces into the cumulative span bound.
 
 The paper-level fixed-length matrix-spanning step, Lemma 2(b), is now carried by
-the `TNLean.Wielandt.PaperResults` and rank-one extraction modules. This file
-keeps the original cumulative-span and eigenvector-spreading chain as a compact
-roadmap and compatibility layer for the later fixed-length results.
+the `TNLean.Wielandt.PaperResults` and rank-one extraction modules. This file keeps
+the original cumulative-span and eigenvector-spreading chain as named cumulative
+formulations used by the later fixed-length results.
 
 ## References
 
@@ -229,11 +229,11 @@ theorem wielandt_chain [NeZero D]
   · intro φ hφ
     exact vector_spanning_from_normality A hN φ hφ
 
-/-! ## Part 5: Remarks on the full bound -/
+/-! ## Part 5: Relation with the fixed-length bound -/
 
-/-- **Summary of what's proven and what remains.**
+/-- **Summary of the cumulative chain and fixed-length bound.**
 
-### Proven:
+### Cumulative chain:
 1. `cumulativeSpan_eq_top`: T_{D²}(A) = M_D(ℂ) for normal A
 2. `exists_nonzero_trace_word`: Lemma 1 — ∃ word with nonzero trace, length ≤ D²
 3. `exists_eigenvector_of_trace_ne_zero`: Nonzero trace → eigenvalue/eigenvector
@@ -247,7 +247,7 @@ theorem wielandt_chain [NeZero D]
 ### Fixed-length bound route:
 The later paper-results modules combine the word-eigenvector extraction, the
 blocked rank-one construction, and fixed-length assembly to prove the paper-level
-index bound. This theorem remains as a named roadmap anchor for older references.
+index bound. This theorem remains as a named summary declaration for older references.
 -/
 theorem wielandt_roadmap : True := trivial
 


### PR DESCRIPTION
## Summary

- Refreshes `WielandtBound.lean` so it describes the cumulative span chain rather than an unfinished proof roadmap.
- Updates `RectangularSpan/Universality.lean` to state that strict growth and the unconditional sharp bound are now proved in the current module stack.
- Removes stale "what remains" / "must be contradicted" wording from the Ch7 rectangular-span notes.

## Validation

- `git diff --check`
- `lake env lean TNLean/Wielandt/WielandtBound.lean`
- `lake env lean TNLean/Wielandt/RectangularSpan/Universality.lean`

Context: small follow-up from the live open-issue audit; no theorem statements or proof terms changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits that clarify proof status/roadmap; no theorem statements or proof terms are modified, so behavioral risk is minimal.
> 
> **Overview**
> Updates module-level prose to reflect the current state of the sharp-bound development: `RectangularSpan/Universality.lean` now states that strict growth and the unconditional sharp `D² − D + 1` bound are proved in the present stack, removing stale “what remains” wording.
> 
> Reframes `WielandtBound.lean` as a *cumulative span chain* document (not an unfinished roadmap) and clarifies how the later fixed-length Lemma 2(b) result is obtained by continuing with rank-one extraction and exact word-length padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e00c583aa0d104a184cfc9c8d52b471a4ae425b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->