### PR TITLE
doc(blueprint): clarify equal-case FT bridge

### DIFF
--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -206,20 +206,32 @@ used in this chapter.
 \end{theorem}
 
 \begin{proof}
-	\uses{thm:ft_proportional, thm:ft_equal_explicit, thm:mpv_decomposition,
-	      rem:cf_coeff_arrays, thm:route_b_equal}
-	Begin by applying Theorem~\ref{thm:ft_proportional} with $c_N = 1$,
-	which yields a
-	permutation of the matched blocks and blockwise gauge-phase equivalences.
-	One then compares the resulting MPV expansions from
-	Theorem~\ref{thm:mpv_decomposition}. The explicit-coefficient version
-		(Theorem~\ref{thm:ft_equal_explicit}) proves gauge equivalence after
-		permuting the weighted block-diagonal tensors, using BNT linear independence.
-	The proof then combines this with the coefficient-array construction
-	of Remark~\ref{rem:cf_coeff_arrays} and the weight-recovery theorem
-	(Theorem~\ref{thm:route_b_equal}). After the weights are identified, the phase
-	factors are absorbed into them and the blockwise conjugacies combine to
-	a global gauge equivalence.
+	\uses{thm:ft_equal_explicit, thm:mpv_decomposition,
+	      rem:cf_coeff_arrays, thm:route_b_equal,
+	      thm:afterBlocking_sectorComparison_reindexed_bntCover,
+	      thm:common_phase_cover_of_proportional_decomposition,
+	      def:common_primitive_bnt_cover_hypotheses}
+	The formalized comparison starts with explicit decomposition coefficients.
+	Theorem~\ref{thm:mpv_decomposition} expands the two canonical-form tensors in
+	their BNT bases, and Remark~\ref{rem:cf_coeff_arrays} describes the resulting
+	coefficient arrays.  When the required coefficient identities are supplied,
+	Theorem~\ref{thm:ft_equal_explicit} proves gauge equivalence after permuting
+	the weighted block-diagonal tensors.  The sector-weight comparison of
+	Theorem~\ref{thm:route_b_equal} recovers the multiplicities and weights from
+	these identities.
+
+	The missing bridge for the bare equal-MPV statement is the synchronization
+	step that derives the coefficient identities and common phase data directly
+	from equality of the full MPV families.  The after-blocking comparison theorem
+	(Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover}) gives
+	this conclusion conditionally from BNT-cover data, while
+	Theorem~\ref{thm:common_phase_cover_of_proportional_decomposition} explains
+	how proportional block comparisons supply common phases.  Completing this
+	theorem therefore amounts to deriving the BNT-cover, overlap-span, or
+	common-phase hypotheses for the canonical decompositions produced from the
+	bare equality assumption.  Once those data are available, the phases are
+	absorbed into the recovered weights and the blockwise conjugacies assemble
+	into a global gauge equivalence.
 \end{proof}
 
 \begin{theorem}[Fundamental Theorem --- equal MPV case with explicit coefficients]\label{thm:ft_equal_explicit}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -209,22 +209,21 @@ used in this chapter.
 	\uses{thm:ft_equal_explicit, thm:mpv_decomposition,
 	      rem:cf_coeff_arrays, thm:route_b_equal,
 	      thm:afterBlocking_sectorComparison_reindexed_bntCover,
-	      thm:common_phase_cover_of_proportional_decomposition,
-	      def:common_primitive_bnt_cover_hypotheses}
+	      thm:common_phase_cover_of_proportional_decomposition}
 	The formalized comparison starts with explicit decomposition coefficients.
 	Theorem~\ref{thm:mpv_decomposition} expands the two canonical-form tensors in
 	their BNT bases, and Remark~\ref{rem:cf_coeff_arrays} describes the resulting
 	coefficient arrays.  When the required coefficient identities are supplied,
 	Theorem~\ref{thm:ft_equal_explicit} proves gauge equivalence after permuting
 	the weighted block-diagonal tensors.  The sector-weight comparison of
-	Theorem~\ref{thm:route_b_equal} recovers the multiplicities and weights from
-	these identities.
+	Theorem~\ref{thm:route_b_equal} uses the supplied multiplicity data to recover
+	the sector-weight multisets from these identities.
 
-	The missing bridge for the bare equal-MPV statement is the synchronization
-	step that derives the coefficient identities and common phase data directly
-	from equality of the full MPV families.  The after-blocking comparison theorem
-	(Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover}) gives
-	this conclusion conditionally from BNT-cover data, while
+	The remaining synchronization statement for the bare equal-MPV theorem must
+	derive the coefficient identities and common phase data directly from equality
+	of the full MPV families.  The after-blocking comparison theorem
+	(Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover}) gives the
+	matched sector-weight conclusion once BNT-cover comparison data are supplied.
 	Theorem~\ref{thm:common_phase_cover_of_proportional_decomposition} explains
 	how proportional block comparisons supply common phases.  Completing this
 	theorem therefore amounts to deriving the BNT-cover, overlap-span, or


### PR DESCRIPTION
## Summary
- correct the Ch11 equal-MPV FT proof sketch so it no longer suggests the theorem follows directly from the proportional case with c_N = 1
- document the actual formalized pieces: explicit coefficients, BNT sector-weight recovery, conditional after-blocking comparison, and common-phase production
- keep the theorem `\notready` and identify the remaining mathematical bridge as deriving BNT-cover/overlap-span/common-phase data from bare equal MPVs

## Validation
- git diff --check
- leanblueprint web (completed with existing bibliography/renderer warnings)
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- python3 scripts/blueprint_lean_sync.py --root . --ci
- lake exe checkdecls blueprint/lean_decls

Progress on #328 and #1170.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates a LaTeX proof sketch to accurately reflect the formal dependency chain without altering any Lean code or theorem statements.
> 
> **Overview**
> Rewrites the proof sketch of `thm:ft_equal` (equal-MPV Fundamental Theorem) in `ch11_assembly.tex` to remove the misleading implication that it follows directly from the proportional case with `c_N = 1`.
> 
> The new text explicitly describes the intended bridge via `thm:ft_equal_explicit` + coefficient-array setup, sector-weight recovery (`thm:route_b_equal`), and the remaining gap: deriving the needed BNT-cover/overlap-span/common-phase comparison data from bare MPV equality (referencing `thm:afterBlocking_sectorComparison_reindexed_bntCover` and `thm:common_phase_cover_of_proportional_decomposition`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87400d8d60e9d2354d05149ad23ba9c3338ded4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->