### PR TITLE
doc(MPS/CanonicalForm): clarify pair-trace gap

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -235,10 +235,11 @@ non-gauge-phase-equivalent BNT blocks admit a homogeneous pair-trace separator.
 Pairs with different bond dimensions are handled by a separate dimension-mismatch
 argument.
 
-The remaining formal ingredient is the Burnside--Jacobson identity-padding step
-that upgrades the pair-separation witness to the uniform homogeneous length used
-below. Once this padding result is available, the same-dimensional separator and
-therefore this BNT pair-separation theorem become unconditional. -/
+Two formal ingredients remain. The same-dimensional branch needs the
+Burnside–Jacobson identity-padding step, which upgrades a pair-separation witness
+to the common homogeneous length appearing in the statement. The different
+bond-dimension branch still needs its dimension-mismatch separation proof. Once both
+branches are available, this BNT pair-separation theorem becomes unconditional. -/
 theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -230,14 +230,15 @@ theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_ide
 Given canonical-form/BNT data, every ordered pair of distinct blocks admits a
 homogeneous word length `T` at which `PairTraceSeparatingAt` holds.
 
-The proof uses `exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv` from
-`BiCFDerivation.lean` for same-dimensional blocks and a separate dimension-
-mismatch argument for blocks of different bond dimensions.
+Same-dimensional block pairs are reduced to the biCF derivation: two
+non-gauge-phase-equivalent BNT blocks admit a homogeneous pair-trace separator.
+Pairs with different bond dimensions are handled by a separate dimension-mismatch
+argument.
 
-The remaining formal gap is the Burnside–Jacobson identity-padding lemma
-documented in `BiCFDerivation.lean`; once that lemma is proved, the
-`sorry` at `exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv` closes
-and this theorem becomes unconditional. -/
+The remaining formal ingredient is the Burnside--Jacobson identity-padding step
+that upgrades the pair-separation witness to the uniform homogeneous length used
+below. Once this padding result is available, the same-dimensional separator and
+therefore this BNT pair-separation theorem become unconditional. -/
 theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))


### PR DESCRIPTION
## Summary
- replace source-file/proof-location prose in the BNT pair-trace separation theorem docstring
- state the same-dimension biCF separator, dimension-mismatch branch, and Burnside--Jacobson padding gap mathematically
- keep the existing theorem statement and proof unchanged

## Validation
- git diff --check
- lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean (passes with the existing sorry warning in this theorem)

Progress on #1178 and #1018.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change: updates a theorem docstring to describe remaining proof obligations; no code or theorem statements are modified.
> 
> **Overview**
> Clarifies the docstring for `exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT` to state, in mathematical terms, how same-dimension block pairs reduce to the biCF derivation and how different bond dimensions should be handled.
> 
> Replaces prior file/location-oriented prose with an explicit description of the two remaining missing ingredients (Burnside–Jacobson identity padding and the dimension-mismatch separation proof), without changing any Lean statements or proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b4cd2d409066a217c70849e417c3e4a0c1ad39f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->