### PR TITLE
feat(MPS/CanonicalForm): expose injective extra blocking

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.Assembly.TPPrimitiveReduction
+import TNLean.MPS.Chain.BlockedChainFT
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 open Filter
@@ -24,6 +25,8 @@ normality.
 
 * `isNormal_of_tp_primitive_irreducible` — TP, primitive transfer map, and
   tensor irreducibility imply normality.
+* `exists_blockTensor_isInjective_of_tp_primitive_irreducible` — the same
+  hypotheses give an extra blocking whose blocked tensor is one-site injective.
 * `isNormal_live_block_of_primitive` — the same conclusion for a single
   nonzero-weight block from the reduction data.
 * `isNormal_blockTensor_of_isNormal` — blocking preserves normality.
@@ -85,6 +88,21 @@ theorem isNormal_of_tp_primitive_irreducible [NeZero D]
     posDef_of_isIrreducibleTensor_of_isPrimitiveMPS hPrimMPS hIrr
   -- Step 4: IsNormal from spectral gap + PosDef.
   exact isNormal_of_isPrimitiveMPS_with_posDef hPrimMPS hPD
+
+/-- **TP + primitive + irreducible → injective after blocking**.
+
+Normality is eventual block injectivity.  Combining
+`isNormal_of_tp_primitive_irreducible` with the equivalence between `N`-block
+injectivity and one-site injectivity of `blockTensor A N` gives a blocking length
+whose blocked tensor is injective. -/
+theorem exists_blockTensor_isInjective_of_tp_primitive_irreducible [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
+    (hIrr : IsIrreducibleTensor A) :
+    ∃ L : ℕ, IsInjective (blockTensor A L) := by
+  obtain ⟨L, hL⟩ := isNormal_of_tp_primitive_irreducible A hTP hPrim hIrr
+  exact ⟨L, (isNBlkInjective_iff_blockTensor_isInjective A L).1 hL⟩
 
 /-!
 ## Combined reduction: arbitrary → IsNormal (per block, for primitive blocks)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2620,6 +2620,25 @@ The following results separate the zero blocks from the nonzero blocks.
 	Apply Theorem~\ref{thm:normal_from_primitive_posdef}.
 \end{proof}
 
+\begin{theorem}[TP-primitive irreducible tensor is injective after blocking]%
+	\label{thm:tp_primitive_irred_block_injective}
+	\lean{MPSTensor.exists_blockTensor_isInjective_of_tp_primitive_irreducible}
+	\leanok
+	\uses{thm:normal_tp_primitive_irred,
+		lem:isNBlkInjective_iff_blockTensor_isInjective}
+	Let $A$ be a left-canonical MPS tensor with $D > 0$,
+	irreducible transfer map, and peripheral spectrum $\{1\}$.
+	Then some blocking $A^{[L]}$ is one-site injective.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:normal_tp_primitive_irred,
+		lem:isNBlkInjective_iff_blockTensor_isInjective}
+	The previous theorem gives normality, which is eventual block injectivity.
+	The blocked-chain equivalence identifies this with one-site injectivity of
+	the corresponding blocked tensor.
+\end{proof}
+
 \begin{theorem}[Blocking preserves normality]%
 	\label{thm:normal_blocking_preserved}
 	\lean{MPSTensor.isNormal_blockTensor_of_isNormal}


### PR DESCRIPTION
## Summary

- add `exists_blockTensor_isInjective_of_tp_primitive_irreducible`, deriving one-site injectivity after a blocking from the TP + primitive + irreducible chain
- use the existing normality theorem together with `isNBlkInjective_iff_blockTensor_isInjective`
- record the theorem in the Chapter 8 canonical-form blueprint

## Impact

This supplies a small producer-side ingredient for the #1068/#944 path: once common primitive sector blocks are available, their TP/primitive/irreducible data imply an additional blocking where the block tensors are injective.

Refs #1068, #944.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new derived theorem and documentation, reusing existing normality and blocking/injectivity equivalences without changing core definitions or algorithms.
> 
> **Overview**
> Extends the canonical-form normality chain with `exists_blockTensor_isInjective_of_tp_primitive_irreducible`, showing that a TP + primitive-transfer + tensor-irreducible `MPSTensor` admits some blocking length `L` where `blockTensor A L` is one-site injective (via `isNormal_of_tp_primitive_irreducible` and `isNBlkInjective_iff_blockTensor_isInjective`).
> 
> Updates the Chapter 8 blueprint to state and prove the corresponding “injective after blocking” theorem alongside the existing normality result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d86ce74f8ab9e882874997a13981f395d7e4af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->