### PR TITLE
feat(MPS/MPDO): expose pair homogenization interface

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -165,6 +165,32 @@ theorem pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
     (pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding
       A B hST (pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo A B hSep) hPad)
 
+/-! ### Conditional all-words homogenization -/
+
+/-- All-words pair separation plus eventual homogeneous identity padding gives
+one homogeneous pair-trace separating length.
+
+This is the proved interface between the pair-product algebra density theorem
+(`PairAllWordsSpanTop`) and the Burnside-Jacobson identity-padding theorem.
+It records that once the two independent inputs are available, no additional
+BNT-specific argument is needed to obtain `PairTraceSeparatingAt`. -/
+theorem exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding
+    {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSpan : PairAllWordsSpanTop A B)
+    (hPad : ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
+      ((1 : Matrix (Fin D₁) (Fin D₁) ℂ), (1 : Matrix (Fin D₂) (Fin D₂) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B n))) :
+    ∃ T : ℕ, PairTraceSeparatingAt A B T := by
+  have hSepAll : PairTraceSeparatingAll A B :=
+    pairTraceSeparatingAll_of_pairAllWordsSpanTop A B hSpan
+  obtain ⟨S, hSepUpTo⟩ :=
+    exists_pairTraceSeparatingUpTo_of_pairTraceSeparatingAll A B hSepAll
+  obtain ⟨L, hPadAll⟩ := hPad
+  refine ⟨L + S, ?_⟩
+  exact pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
+    A B (S := S) (T := L + S) (by omega) hSepUpTo
+    (fun l hl => hPadAll (L + S - l) (by omega))
+
 /-! ### Burnside–Jacobson homogenization: from non-equivalence to homogeneous separation
 
 The theorems in this section bridge the gap between BNT block non-equivalence
@@ -266,19 +292,12 @@ theorem exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv
     (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
     (hNot : ¬ GaugePhaseEquiv A B) :
     ∃ T : ℕ, PairTraceSeparatingAt A B T := by
-  -- Step 1: non-gauge-equivalence ⇒ all-length separation
-  have hSepAll : PairTraceSeparatingAll A B :=
-    pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv
-      A B hA_inj hB_inj hA_norm hB_norm hNot
-  -- Step 2: finite cumulative cutoff (Noetherian chain stabilization)
-  obtain ⟨S, hSepUpTo⟩ := exists_pairTraceSeparatingUpTo_of_pairTraceSeparatingAll A B hSepAll
-  -- Step 3: homogenize via identity padding.
-  obtain ⟨L, hPadAll⟩ :=
-    pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv
+  apply exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding
+  · have hSepAll : PairTraceSeparatingAll A B :=
+      pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv
+        A B hA_inj hB_inj hA_norm hB_norm hNot
+    exact (pairAllWordsSpanTop_iff_pairTraceSeparatingAll A B).2 hSepAll
+  · exact pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv
       A B hA_inj hB_inj hNot
-  refine ⟨L + S, ?_⟩
-  exact pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
-    A B (S := S) (T := L + S) (by omega) hSepUpTo
-    (fun l hl => hPadAll (L + S - l) (by omega))
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3103,6 +3103,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.pair_mul_mem_span_pairWordTuple_add}
     \lean{MPSTensor.pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding}
     \lean{MPSTensor.pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding}
+    \lean{MPSTensor.exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding}
     \leanok
     \uses{def:pair_trace_separation_words, lem:all_length_pair_trace_separation_finite_cutoff}
     Suppose $S\le T$ and pair words of length at most $S$ span the product
@@ -3110,7 +3111,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     to the span of pair words of length $T-\ell$, then pair words of the single
     length $T$ already span the product algebra.  Equivalently, cumulative
     trace separation up to $S$ becomes homogeneous trace separation at length
-    $T$ under the same identity-padding hypothesis.
+    $T$ under the same identity-padding hypothesis.  Consequently, an all-word
+    product-span theorem together with eventual homogeneous identity padding
+    yields a homogeneous pair trace-separation length.
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

- add a proved conditional theorem turning `PairAllWordsSpanTop` plus eventual homogeneous identity padding into a homogeneous `PairTraceSeparatingAt` length
- refactor the non-gauge-equivalence endpoint to use this interface, keeping the two remaining Burnside-Jacobson leaves explicit
- update the Chapter 14 blueprint declaration list and prose for the homogenization bridge

## Validation

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean` (existing admitted Burnside-Jacobson leaves still warn)
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

## Issue context

This narrows #1132 and #1133 by making their exact proved handoff explicit: pair-product density supplies `PairAllWordsSpanTop`, identity padding supplies the eventual homogeneous identity, and this theorem produces the homogeneous pair trace-separation length needed upstream by #1178.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this factors existing proof steps into a new lemma and updates one call site and blueprint references, without changing any admitted Burnside–Jacobson placeholders or core definitions.
> 
> **Overview**
> Adds a new proved bridge theorem `exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding` that turns **(1)** `PairAllWordsSpanTop` plus **(2)** eventual homogeneous identity padding into the existence of a homogeneous length `T` with `PairTraceSeparatingAt`.
> 
> Refactors `exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv` to use this interface, keeping the two remaining Burnside–Jacobson inputs explicit (`pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv` and `pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv`). Updates the Chapter 14 blueprint lemma to list the new Lean theorem and extends the prose to mention the all-words+padding consequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c712077fa4fb1dc641fa5f136efe84b307c3d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->