### PR TITLE
feat(MPS/CanonicalForm): add zero-tail overlap adapter

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -1138,6 +1138,86 @@ theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData
     hμA hμB hTPA hTPB hPrimA hPrimB hIrrA hIrrB hAntiA hAntiB hNotGpeA hNotGpeB
     hZeroTail hInjA hInjB hPacked.1
 
+/-- **Sector basis overlap-span data from explicit common primitive BNT data,
+deriving the zero-tail identity.**
+
+This variant of `sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData`
+removes the explicit zero-tail equality from the remaining data. The identity is
+derived from the length-zero MPV equality and proportional-decomposition data. -/
+theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdentity
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      [∀ x : Fin rA, NeZero (dimA x)]
+      [∀ x : Fin rB, NeZero (dimB x)]
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      Σ DtotA : ℕ, Σ DtotB : ℕ,
+        { _hDecomp : ProportionalDecompositionData (d := blockPhysDim d p)
+            blocksA blocksB DtotA DtotB //
+          StrictAnti (fun x : Fin rA => ‖μA x‖) ∧
+          StrictAnti (fun x : Fin rB => ‖μB x‖) ∧
+          BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksA ∧
+          BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksB ∧
+          (∀ x, IsInjective (blocksA x)) ∧
+          (∀ x, IsInjective (blocksB x)) }) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      SectorBasisOverlapSpanHypotheses P Q := by
+  refine sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
+    A B hSame hReindexed ?_
+  intro p zeroTailA zeroTailB rA rB dimA dimB _ _ μA μB blocksA blocksB hp
+    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
+    hIrrA hIrrB hDimA hDimB
+  obtain ⟨DtotA, DtotB, hPacked⟩ :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  rcases hPacked.2 with
+    ⟨hAntiA, hAntiB, hNotGpeA, hNotGpeB, hInjA, hInjB⟩
+  refine ⟨DtotA, DtotB, ⟨?_⟩⟩
+  exact CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData_zeroTailIdentity
+    hμA hμB hTPA hTPB hPrimA hPrimB hIrrA hIrrB hAntiA hAntiB hNotGpeA hNotGpeB
+    hZero hInjA hInjB hPacked.1
+
 /-- **Sector basis overlap-span data via a BNT proportional-decomposition comparison.**
 
 This is the proportional-comparison variant of

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1542,6 +1542,32 @@ two-basis sector comparison theorem.
 	common primitive data. Then apply the BNT-cover overlap-span theorem.
 \end{proof}
 
+\begin{theorem}[Explicit BNT data with derived zero-tail identity give overlap-span hypotheses]%
+\label{thm:sector_basis_overlap_span_commonPrimitiveBNTData_zeroTailIdentity}
+	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdentity}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		def:common_sector_relabeling_hypothesis,
+		thm:sector_basis_overlap_span_reindexed_bnt_cover}
+	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
+	identification hypothesis for the cyclic-sector data. The common-sector
+	structural theorem produces common primitive nonzero-sector families. If
+	these families have strict weight ordering, internal gauge-phase separation,
+	one-site injectivity, and proportional-decomposition data, then the length-zero
+	MPV identity determines the zero tail, and the associated sector decompositions
+	have BNT data, agree as full MPV families, and satisfy the primitive
+	overlap-span hypotheses.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		thm:sector_basis_overlap_span_reindexed_bnt_cover}
+	First form the BNT-cover hypotheses for the produced families, deriving the
+	zero-tail identity from the proportional-decomposition data. Then apply the
+	BNT-cover overlap-span theorem.
+\end{proof}
+
 \begin{theorem}[Sector comparison from a common phase cover]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_commonPhaseCover}


### PR DESCRIPTION
## Summary

- add `sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdentity`
- derive the BNT-cover zero-tail identity from proportional-decomposition data instead of requiring it in the packed residual data
- document the adapter in the Ch11 assembly blueprint

This is the post-#1201 adapter toward #944/#1068.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

Refs #944
Refs #1068

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean theorem/adapter and corresponding blueprint documentation without changing existing theorem behavior, though it introduces a new alternative hypothesis signature that downstream proofs may start depending on.
> 
> **Overview**
> Adds `sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdentity`, an adapter theorem that *drops the need to provide `zeroTailA = zeroTailB` explicitly* when building `SectorBasisOverlapSpanHypotheses` from common primitive BNT data; the zero-tail equality is instead derived from the length-zero MPV identity plus `ProportionalDecompositionData` via `CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData_zeroTailIdentity`.
> 
> Updates the Ch11 assembly blueprint to document and reference this new derived-zero-tail overlap-span route alongside the existing explicit-data theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d90cb2e7deb98ec686bc9f0e400383ec54c80c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->