### PR TITLE
refactor(MPS/FT): extract power-limit helper

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
@@ -19,9 +19,10 @@ that together prove the self-contained equal-case fundamental theorem
 
 * `tendsto_norm_selfOverlap_one`: normed form of a self-overlap tending to `1`.
 * `tendsto_inner_zero_swap`: swapping a decaying overlap conjugates the inner product.
+* `eq_one_of_pow_tendsto_nhds_one`: powers converging to `1` force the base to be `1`.
 
-This file currently consists of these two public auxiliary lemmas used by the full
-heterogeneous equal-case theorem.
+This file collects public auxiliary lemmas used by the full heterogeneous equal-case
+theorem.
 
 ## References
 
@@ -64,5 +65,19 @@ lemma tendsto_inner_zero_swap
     simp [mpvInner, inner_conj_symm]
   rw [hSwap]
   simpa using hAB.star
+
+/-- If the powers of a complex number converge to `1`, then the number itself is `1`. -/
+lemma eq_one_of_pow_tendsto_nhds_one {c : ℂ}
+    (hc : Tendsto (fun N : ℕ => c ^ N) atTop (nhds 1)) :
+    c = 1 := by
+  have h_shift : Tendsto (fun N : ℕ => c ^ (N + 1)) atTop (nhds 1) :=
+    hc.comp (tendsto_add_atTop_nat 1)
+  have h_mul : Tendsto (fun N : ℕ => c * c ^ N) atTop (nhds (c * 1)) :=
+    tendsto_const_nhds.mul hc
+  have h_eq_fun : (fun N : ℕ => c ^ (N + 1)) = fun N : ℕ => c * c ^ N := by
+    ext N
+    rw [pow_succ, mul_comm]
+  have hlim := tendsto_nhds_unique (h_eq_fun ▸ h_shift) h_mul
+  simpa using hlim.symm
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -630,18 +630,7 @@ lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
       have h_sub := h_prod.sub h_err
       rw [sub_zero] at h_sub
       exact h_sub.congr h_decomp
-    -- NOTE (extract): The "c^N → 1 and ‖c‖ = 1 implies c = 1" argument below
-    -- (shift + unique-limit) is a general-purpose lemma.  A future refactor
-    -- could extract it as `eq_one_of_pow_tendsto_nhds_one` in a utility file.
-    -- ratio^N → 1 implies ratio = 1 (shift argument).
-    have h_shift : Tendsto (fun N => ratio ^ (N + 1)) atTop (nhds 1) :=
-      h_ratio_tendsto.comp (tendsto_add_atTop_nat 1)
-    have h_mul : Tendsto (fun N => ratio * ratio ^ N) atTop (nhds (ratio * 1)) :=
-      tendsto_const_nhds.mul h_ratio_tendsto
-    have h_eq_fun : (fun N => ratio ^ (N + 1)) = (fun N => ratio * ratio ^ N) := by
-      ext N; rw [pow_succ, mul_comm]
-    have := tendsto_nhds_unique (h_eq_fun ▸ h_shift) h_mul
-    simpa using this.symm
+    exact eq_one_of_pow_tendsto_nhds_one h_ratio_tendsto
   have hTailState : ∀ N,
       ∑ j ∈ Finset.univ.erase a0, μA j ^ N • (A j).mpvState N =
       ∑ k ∈ Finset.univ.erase b0, μB k ^ N • (B k).mpvState N := by


### PR DESCRIPTION
## Summary

- add `eq_one_of_pow_tendsto_nhds_one` to the full heterogeneous FT helper module
- replace the local shift/unique-limit proof in `NondecayingOverlap` with the shared helper
- refresh the helper module docstring so it no longer counts a stale fixed number of helpers

## Validation

- `lake build TNLean.MPS.FundamentalTheorem.Full.Helpers -q --log-level=info`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/Helpers.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
- `lake env lean TNLean.lean`
- `git diff --check`
- `rg -n "NOTE \\(extract\\)|these two public auxiliary lemmas" TNLean/MPS/FundamentalTheorem/Full || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: extracts a repeated convergence argument into a shared lemma and updates one proof to call it, without changing theorem statements or core logic.
> 
> **Overview**
> Extracts a reusable helper lemma `eq_one_of_pow_tendsto_nhds_one` (if `c^N → 1` in `ℂ`, then `c = 1`) into `Full/Helpers.lean` and updates the module docs to reflect the expanded helper set.
> 
> Replaces the previously inlined “shift + unique-limit” argument in `Full/NondecayingOverlap.lean` with a call to the new helper, reducing duplicated proof code while keeping the surrounding proof structure unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6031b2fabe6da8d30a6117f332a5c66713e0f536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->