### PR TITLE
feat(MPS/CanonicalForm): expose common flat blocks normal form at length

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
@@ -287,6 +287,21 @@ theorem isNormalCanonicalForm_commonFlatBlocks
     F.commonFlatBlocks_irreducible
     hAnti
 
+/-- The derived flattened common-sector family is a normal canonical form when
+expressed at a prescribed common blocking length. -/
+theorem isNormalCanonicalForm_commonFlatBlocksAt
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p')
+    (μ : Fin r → ℂ)
+    (hμ : ∀ k, μ k ≠ 0)
+    (hAnti : StrictAnti
+      (fun x : Fin (∑ k : Fin r, F.period k) => ‖F.commonFlatWeight μ x‖)) :
+    IsNormalCanonicalForm (d := blockPhysDim d p')
+      (F.commonFlatWeight μ) (F.commonFlatBlocksAt hp) := by
+  subst p'
+  simpa [commonFlatBlocksAt] using
+    F.isNormalCanonicalForm_commonFlatBlocks μ hμ hAnti
+
 /-- Iterated blocking of a nonzero-weight block is the relabeled common block. -/
 theorem nestedBlock_sameMPV₂_commonReindexedBlock
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :


### PR DESCRIPTION
## Summary

- add `CommonBlockedCyclicSectorFamily.isNormalCanonicalForm_commonFlatBlocksAt`
- reuse the existing uncasted normal-form theorem after substituting the prescribed common blocking length
- keep this as a small producer-side adapter for the #1068/#944 common primitive BNT path

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily -q --log-level=info`
- `lake env lean TNLean.lean`
- `git diff --check`
- `rg -n "\\b(sorry|admit|axiom|native_decide|unsafeCast)\\b" TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small wrapper theorem that reuses the existing normal-form proof after substituting an equal blocking length, without changing any underlying definitions or algorithms.
> 
> **Overview**
> Exposes `CommonBlockedCyclicSectorFamily.isNormalCanonicalForm_commonFlatBlocksAt`, proving the derived flattened common-sector family is an `IsNormalCanonicalForm` when expressed at a prescribed blocking length `p'` via an equality `F.p = p'`.
> 
> The proof is a thin adapter: it `subst`s the length and `simpa`s using the existing `isNormalCanonicalForm_commonFlatBlocks` result (bridging through `commonFlatBlocksAt`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21918b343c18baca1b2d2cfa4222dad844ca8469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->