### PR TITLE
feat(MPS/MPDO): expose span-top padding window

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -742,6 +742,23 @@ theorem pairIdentity_mem_pairWordTupleSpan_eventually_of_period_window {D₁ D�
   rw [← hlen]
   exact hpad
 
+/-- A finite residue window of full homogeneous pair spans gives eventual
+identity padding. -/
+theorem pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window
+    {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    {start period : ℕ} (hperiod_pos : 0 < period)
+    (hperiod : PairWordTupleSpanTop A B period)
+    (hwindow : ∀ r : ℕ, r < period → PairWordTupleSpanTop A B (start + r)) :
+    ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
+      ((1 : Matrix (Fin D₁) (Fin D₁) ℂ), (1 : Matrix (Fin D₂) (Fin D₂) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B n)) :=
+  pairIdentity_mem_pairWordTupleSpan_eventually_of_period_window
+    (A := A) (B := B) hperiod_pos
+    (pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop A B hperiod)
+    (fun r hr =>
+      pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop A B (hwindow r hr))
+
 /-- A cumulative pair span can be homogenized once the simultaneous pair identity
 is available at every padding length needed to reach the target length.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3140,6 +3140,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.pairEvalWordTuple_mem_span_pairWordTuple_length}
     \lean{MPSTensor.pair_mul_mem_span_pairWordTuple_add}
     \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_add}
+    \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window}
     \lean{MPSTensor.pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding}
     \lean{MPSTensor.pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding}


### PR DESCRIPTION
## Summary

- add `pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window`
- connect period-window `PairWordTupleSpanTop` certificates directly to eventual homogeneous identity padding
- record the new declaration in the Chapter 14 blueprint entry

This is a narrow #1133 interface slice. It does not prove the remaining Burnside-Jacobson period/window witness; it makes the future span-top witness usable by the existing identity-padding theorem.

## Validation

- `lake build TNLean.MPS.Defs -q --log-level=info`
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean` (pre-existing #1133 `sorry` warning remains)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "\b(admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean || true`

Refs #1133
Refs #1178

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small additive Lean interface theorem that composes existing lemmas and a documentation reference update, with no changes to existing proofs or definitions.
> 
> **Overview**
> Exposes a new Lean theorem, `pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window`, which **bridges period/window `PairWordTupleSpanTop` span-top certificates to the existing “eventual identity padding” interface** by wrapping `pairIdentity_mem_pairWordTupleSpan_eventually_of_period_window`.
> 
> Updates the Chapter 14 blueprint lemma `pair_trace_separation_homogenization_with_padding` to reference the new declaration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b7b36477adb10a9d7fd00959aee710d0be9b168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->