### PR TITLE
feat(MPS/CanonicalForm): add phase-cover equivalence theorem

### DIFF
--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -731,6 +731,41 @@ theorem nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
   · intro j
     exact ⟨perm j, by simp⟩
 
+/-- A bijective MPV-phase matching gives a common MPV phase cover.
+
+This is the direct implication used when a comparison theorem has already identified
+the phase classes by a bijection, without restating the data as a proportional
+decomposition conclusion. -/
+theorem nonempty_mpvCommonPhaseCover_of_equiv_phase
+    {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (e : Fin rA ≃ Fin rB)
+    (hPhase : ∀ j : Fin rA, MPVBlockPhaseEquiv (blocksA j) (blocksB (e j))) :
+    Nonempty (MPVCommonPhaseCover blocksA blocksB) := by
+  refine ⟨?_⟩
+  refine {
+    rC := rA
+    dimC := dimA
+    common := blocksA
+    classA := id
+    classB := e.symm
+    phaseA := ?_
+    phaseB := ?_
+    surjA := ?_
+    surjB := ?_
+  }
+  · intro j
+    exact MPVBlockPhaseEquiv.refl (blocksA j)
+  · intro k
+    have h := hPhase (e.symm k)
+    rw [e.apply_symm_apply k] at h
+    exact h
+  · intro j
+    exact ⟨j, rfl⟩
+  · intro j
+    exact ⟨e j, by simp⟩
+
 /-- A BNT proportional-decomposition conclusion gives finite-length MPV span equality.
 
 The conclusion is obtained by taking the left family as the common MPV phase-cover family and
@@ -745,6 +780,20 @@ theorem mpv_span_eq_of_proportionalDecompositionConclusion
     Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) := by
   obtain ⟨cover⟩ := nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
     (d := d) blocksA blocksB h
+  exact cover.span_eq N
+
+/-- A bijective MPV-phase matching gives finite-length MPV span equality. -/
+theorem mpv_span_eq_of_equiv_phase
+    {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (e : Fin rA ≃ Fin rB)
+    (hPhase : ∀ j : Fin rA, MPVBlockPhaseEquiv (blocksA j) (blocksB (e j)))
+    (N : ℕ) :
+    Submodule.span ℂ (Set.range (fun j : Fin rA => mpvState (d := d) (blocksA j) N)) =
+    Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) := by
+  obtain ⟨cover⟩ := nonempty_mpvCommonPhaseCover_of_equiv_phase
+    (d := d) blocksA blocksB e hPhase
   exact cover.span_eq N
 
 /-- Separated normal canonical-form data and a proportional decomposition produce a common MPV

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -888,6 +888,23 @@ single weighted block.
 	the required MPV-phase equivalence.
 \end{proof}
 
+\begin{theorem}[Common phase cover from a bijective phase matching]%
+\label{thm:common_phase_cover_of_equiv_phase}
+	\lean{MPSTensor.nonempty_mpvCommonPhaseCover_of_equiv_phase}
+	\leanok
+	\uses{def:mpv_common_phase_cover, def:mpv_block_phase_equiv}
+	If two block families are matched by a bijection and corresponding blocks have
+	the same matrix product vectors up to a nonzero scalar power depending on the
+	length, then the two families have a common MPV phase cover.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	Take the first block family as the common family. The bijection and its inverse
+	give the two class maps, and the assumed phase match gives the second
+	family's phase data.
+\end{proof}
+
 \begin{theorem}[Span equality from proportional-decomposition data]%
 \label{thm:nonzero_block_span_eq_of_proportional_decomposition}
 	\lean{MPSTensor.mpv_span_eq_of_proportionalDecompositionConclusion}
@@ -904,6 +921,22 @@ single weighted block.
 		lem:mpv_common_phase_cover_span_eq}
 	First form the common MPV phase cover from the proportional-decomposition
 	comparison. The common-cover span lemma then gives the stated span equality.
+\end{proof}
+
+\begin{theorem}[Span equality from a bijective phase matching]%
+\label{thm:nonzero_block_span_eq_of_equiv_phase}
+	\lean{MPSTensor.mpv_span_eq_of_equiv_phase}
+	\leanok
+	\uses{thm:common_phase_cover_of_equiv_phase,
+		lem:mpv_common_phase_cover_span_eq}
+	A bijective phase matching gives equality, for every system size, of the
+	finite-length MPV spans of the two block families.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	First form the common MPV phase cover from the bijective phase matching. The
+	common-cover span lemma then gives the stated span equality.
 \end{proof}
 
 \begin{theorem}[Overlap-span data from a common phase cover]%


### PR DESCRIPTION
## Summary

- add a direct common-phase-cover theorem from a bijection of block families plus per-block MPV phase equivalences
- add the corresponding finite-length MPV span equality theorem
- document the two declarations in the Ch. 11 assembly blueprint

## Issue context

This narrows the #1068/#944 interface by letting future common-blocking or proportional-comparison results hand over a bijective phase matching directly, without first restating it as a proportional-decomposition conclusion. It does not close #1068 or #944; the producer-side common primitive BNT data is still outstanding.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/EqualNormBridge.lean`
- `lake build TNLean.MPS.CanonicalForm.EqualNormBridge -q --log-level=info`
- `lake build TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison -q --log-level=info`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/CanonicalForm/EqualNormBridge.lean || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems and blueprint documentation without changing existing definitions or proof behavior. Main risk is downstream breakage from new API surface or lemma naming expectations.
> 
> **Overview**
> Adds a direct route from a *bijective* per-block `MPVBlockPhaseEquiv` matching (`Fin rA ≃ Fin rB`) to `Nonempty (MPVCommonPhaseCover blocksA blocksB)` via the new theorem `nonempty_mpvCommonPhaseCover_of_equiv_phase`.
> 
> Builds on that by adding `mpv_span_eq_of_equiv_phase`, proving finite-length MPV span equality from the same bijective phase-matching hypothesis.
> 
> Updates the Chapter 11 blueprint to document and reference these two new results alongside the existing proportional-decomposition-based variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51654cde36da8860c14205401729acc77bdb17af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->