### PR TITLE
refactor(Wielandt): extract trace-pairing identity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -323,6 +323,7 @@ import TNLean.Wielandt.SpanGrowth.InvertibleWordSpan
 import TNLean.Wielandt.Primitivity.Normal
 import TNLean.Wielandt.Primitivity.ToNormal
 import TNLean.Wielandt.Primitivity.ImpliesIrreducible
+import TNLean.Wielandt.Primitivity.TracePairing
 import TNLean.Wielandt.RankOne.Element
 import TNLean.Wielandt.RankOne.Extraction
 import TNLean.Wielandt.RankOne.SpanGrowth

--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -7,6 +7,7 @@ import TNLean.Spectral.MixedTransfer
 import TNLean.Spectral.TraceExpansion
 import TNLean.MPS.Core.Transfer
 import TNLean.Wielandt.Primitivity.PaperDefinitions
+import TNLean.Wielandt.Primitivity.TracePairing
 import TNLean.MPS.Overlap.PeripheralToSpectralGap
 import TNLean.MPS.Irreducible.FormII
 import TNLean.Wielandt.Primitivity.ToNormal
@@ -80,117 +81,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ### Part 1: Trace-pairing identity -/
-
-/-- Complex-valued form of the trace-pairing identity:
-`∑_σ tr(B† A_σ) · star(tr(B† A_σ)) = ∑_{i,k} [B† · E^n(e_{ik}) · B]_{ik}`.
-
-This is the complex trace identity before extracting the real part. -/
-private theorem sum_trace_mul_star_eq [NeZero D]
-    (A : MPSTensor d D) (n : ℕ)
-    (B : Matrix (Fin D) (Fin D) ℂ) :
-    (∑ σ : Fin n → Fin d,
-        Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)) *
-          star (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)))) =
-      ∑ i : Fin D, ∑ k : Fin D,
-        (Bᴴ * ((transferMap (d := d) (D := D) A) ^ n)
-          (Matrix.single i k 1) * B) i k := by
-  -- Expand E^n(e_{ik}) = ∑_σ A_σ * e_{ik} * A_σᴴ
-  simp only [transferMap_pow_apply' A n]
-  -- Step 1: Push B† and B through the σ-sum and extract entries.
-  have hpush : ∀ (i k : Fin D),
-      (Bᴴ * (∑ σ : Fin n → Fin d,
-        evalWord A (List.ofFn σ) * Matrix.single i k (1 : ℂ) *
-          (evalWord A (List.ofFn σ))ᴴ) * B) i k =
-      ∑ σ : Fin n → Fin d,
-        (Bᴴ * evalWord A (List.ofFn σ)) i i *
-          ((evalWord A (List.ofFn σ))ᴴ * B) k k := by
-    intro i k
-    -- Distribute B† and B over the sum
-    have hdist : Bᴴ * (∑ σ : Fin n → Fin d,
-        evalWord A (List.ofFn σ) * Matrix.single i k 1 *
-          (evalWord A (List.ofFn σ))ᴴ) * B =
-        ∑ σ : Fin n → Fin d,
-          Bᴴ * evalWord A (List.ofFn σ) * Matrix.single i k 1 *
-            ((evalWord A (List.ofFn σ))ᴴ * B) := by
-      rw [Matrix.mul_sum, Finset.sum_mul]
-      congr 1; ext σ
-      simp only [Matrix.mul_assoc]
-    rw [hdist, Matrix.sum_apply]
-    congr 1; ext σ
-    exact entry_mul_single_mul
-      (Bᴴ * evalWord A (List.ofFn σ))
-      ((evalWord A (List.ofFn σ))ᴴ * B) i k
-  simp_rw [hpush]
-  -- Step 2: Swap sums so σ is outermost.
-  rw [show (∑ i : Fin D, ∑ k : Fin D, ∑ σ : Fin n → Fin d,
-        (Bᴴ * evalWord A (List.ofFn σ)) i i *
-          ((evalWord A (List.ofFn σ))ᴴ * B) k k) =
-      ∑ σ : Fin n → Fin d, ∑ i : Fin D, ∑ k : Fin D,
-        (Bᴴ * evalWord A (List.ofFn σ)) i i *
-          ((evalWord A (List.ofFn σ))ᴴ * B) k k from by
-    simpa using Finset.sum_comm_cycle
-      (s := (Finset.univ : Finset (Fin D)))
-      (t := (Finset.univ : Finset (Fin D)))
-      (u := (Finset.univ : Finset (Fin n → Fin d)))
-      (f := fun i k σ =>
-        (Bᴴ * evalWord A (List.ofFn σ)) i i *
-          ((evalWord A (List.ofFn σ))ᴴ * B) k k)]
-  -- Step 3: Factor double sum into product of traces.
-  congr 1; ext σ
-  -- ∑_{ik} M_{ii} * N_{kk} = (∑_i M_{ii}) * (∑_k N_{kk})
-  have hfactor :
-      ∑ i : Fin D, ∑ k : Fin D,
-        (Bᴴ * evalWord A (List.ofFn σ)) i i *
-          ((evalWord A (List.ofFn σ))ᴴ * B) k k =
-      (∑ i, (Bᴴ * evalWord A (List.ofFn σ)) i i) *
-        (∑ k, ((evalWord A (List.ofFn σ))ᴴ * B) k k) := by
-    simpa using (Fintype.sum_mul_sum
-      (f := fun i : Fin D => (Bᴴ * evalWord A (List.ofFn σ)) i i)
-      (g := fun k : Fin D => ((evalWord A (List.ofFn σ))ᴴ * B) k k)).symm
-  rw [hfactor]
-  -- (∑_i M_{ii}) = Matrix.trace M
-  change Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)) *
-    star (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))) =
-    Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)) *
-      Matrix.trace ((evalWord A (List.ofFn σ))ᴴ * B)
-  -- tr(A_σ† B) = star(tr(B† A_σ)) by Matrix.trace_conjTranspose
-  congr 1
-  rw [← Matrix.trace_conjTranspose (Bᴴ * evalWord A (List.ofFn σ))]
-  simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
-
-/-- **Trace-pairing identity for transfer-map powers.**
-
-The sum of squared absolute traces `∑_σ |tr(B† A_σ)|²` equals the `.re` of a
-bilinear form in `B` built from the iterated transfer map and matrix units.
-
-This is the core algebraic identity used in the proof of
-**Proposition 3(c)→(b)** of arXiv:0909.5347 (the "quantum Wielandt" paper). -/
-theorem sum_normSq_trace_conjTranspose_mul_evalWord
-    [NeZero D]
-    (A : MPSTensor d D) (n : ℕ)
-    (B : Matrix (Fin D) (Fin D) ℂ) :
-    (∑ σ : Fin n → Fin d,
-        ‖Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))‖ ^ 2 : ℝ) =
-      (∑ i : Fin D, ∑ k : Fin D,
-        (Bᴴ * ((transferMap (d := d) (D := D) A) ^ n)
-          (Matrix.single i k 1) * B) i k).re := by
-  -- Rewrite LHS: ‖z‖² = (z * star z).re since z * star z = ↑(‖z‖²)
-  have hlhs : (∑ σ : Fin n → Fin d,
-      ‖Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))‖ ^ 2 : ℝ) =
-    (∑ σ : Fin n → Fin d,
-      Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)) *
-        star (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)))).re := by
-    rw [Complex.re_sum]
-    congr 1; ext σ
-    have : star (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))) =
-        (starRingEnd ℂ) (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))) :=
-      (starRingEnd_apply _).symm
-    rw [this, Complex.mul_conj']
-    norm_cast
-  rw [hlhs, sum_trace_mul_star_eq]
-
-/-! ### Part 2: Primitivity implication
+/-! ### Part 1: Primitivity implication
 
 From `IsStronglyIrreduciblePaper A` + left-canonical normalization, we derive
 `IsPrimitiveMPS A ρ` with the *same* positive-definite fixed point `ρ` from the
@@ -307,7 +198,7 @@ theorem isStronglyIrreduciblePaper_of_isPrimitiveMPS_of_posDef [NeZero D]
     hP.isPeripherallyPrimitive
     (isIrreducibleMap_of_isPrimitiveMPS_of_posDef hP hρ_pd)
 
-/-! ### Part 3: Convergence of the transfer map
+/-! ### Part 2: Convergence of the transfer map
 
 Pointwise convergence: `E^n(X) → (tr X / tr ρ) • ρ`.
 
@@ -363,7 +254,7 @@ theorem IsPrimitiveMPS.transferMap_pow_apply_tendsto [NeZero D]
   rw [(map_pow (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) N (n + 1)).symm]
   rfl
 
-/-! ### Part 4: RHS bilinear form computation
+/-! ### Part 3: RHS bilinear form computation
 
 We show that the trace-pairing RHS, when evaluated at the fixed-point projection
 `P_ρ`, equals `tr(B† ρ B) / tr(ρ)`.  This is the limiting value of the
@@ -417,7 +308,7 @@ private theorem tracePairBilin_fixedPointProj [NeZero D]
       Matrix.trace (Bᴴ * ρ * B) / Matrix.trace ρ
   ring
 
-/-! ### Part 5: Nondegeneracy of the PosDef inner product
+/-! ### Part 4: Nondegeneracy of the PosDef inner product
 
 `tr(B† ρ B) > 0` when `ρ` is positive definite and `B ≠ 0`. -/
 
@@ -446,7 +337,7 @@ private theorem sum_normSq_eq_zero_of_trace_ortho [NeZero D]
   intro σ _
   simp [hB σ]
 
-/-! ### Part 6: Main theorem — strong irreducibility → eventually full Kraus rank
+/-! ### Part 5: Main theorem — strong irreducibility → eventually full Kraus rank
 
 The proof follows the paper's contradiction argument:
 1. From strong irreducibility, derive `IsPrimitiveMPS A ρ` with `ρ.PosDef`.
@@ -494,7 +385,7 @@ private theorem eq_zero_of_trace_conjTranspose_mul_posDef_mul_eq_zero
   rw [this, hBρB] at hpos
   simp at hpos
 
-/-! ### Part 7: Uniform positivity lemmas
+/-! ### Part 6: Uniform positivity lemmas
 
 These two lemmas set up the final compactness/uniform-positivity argument for the
 main theorem `hasEventuallyFullKrausRank_of_isStronglyIrreduciblePaper`.
@@ -858,7 +749,7 @@ private theorem trace_conjTranspose_posDef_mul_lower [NeZero D]
 
 end UniformPositivity
 
-/-! ### Part 8: Final construction — (c) → (b)
+/-! ### Part 7: Final construction — (c) → (b)
 
 Combining the trace-pairing identity (Part 1), primitivity implication (Part 2),
 convergence (Part 3), trace-pairing computation (Part 4), PosDef nondegeneracy

--- a/TNLean/Wielandt/Primitivity/TracePairing.lean
+++ b/TNLean/Wielandt/Primitivity/TracePairing.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import TNLean.Spectral.MixedTransfer
+import TNLean.Spectral.TraceExpansion
+import TNLean.MPS.Core.Transfer
+import TNLean.Wielandt.Primitivity.PaperDefinitions
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Data.Complex.BigOperators
+import Mathlib.LinearAlgebra.Matrix.Trace
+
+open scoped Matrix BigOperators ComplexConjugate ComplexOrder NNReal
+open Matrix Filter
+
+/-!
+# Trace-pairing identity for the Wielandt primitivity route
+
+This file contains the trace identity used in the proof that strong
+irreducibility implies eventual full Kraus rank.
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Complex-valued form of the trace-pairing identity:
+`∑_σ tr(B† A_σ) · star(tr(B† A_σ)) = ∑_{i,k} [B† · E^n(e_{ik}) · B]_{ik}`.
+
+This is the complex trace identity before extracting the real part. -/
+private theorem sum_trace_mul_star_eq [NeZero D]
+    (A : MPSTensor d D) (n : ℕ)
+    (B : Matrix (Fin D) (Fin D) ℂ) :
+    (∑ σ : Fin n → Fin d,
+        Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)) *
+          star (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)))) =
+      ∑ i : Fin D, ∑ k : Fin D,
+        (Bᴴ * ((transferMap (d := d) (D := D) A) ^ n)
+          (Matrix.single i k 1) * B) i k := by
+  -- Expand E^n(e_{ik}) = ∑_σ A_σ * e_{ik} * A_σᴴ
+  simp only [transferMap_pow_apply' A n]
+  -- Step 1: Push B† and B through the σ-sum and extract entries.
+  have hpush : ∀ (i k : Fin D),
+      (Bᴴ * (∑ σ : Fin n → Fin d,
+        evalWord A (List.ofFn σ) * Matrix.single i k (1 : ℂ) *
+          (evalWord A (List.ofFn σ))ᴴ) * B) i k =
+      ∑ σ : Fin n → Fin d,
+        (Bᴴ * evalWord A (List.ofFn σ)) i i *
+          ((evalWord A (List.ofFn σ))ᴴ * B) k k := by
+    intro i k
+    -- Distribute B† and B over the sum
+    have hdist : Bᴴ * (∑ σ : Fin n → Fin d,
+        evalWord A (List.ofFn σ) * Matrix.single i k 1 *
+          (evalWord A (List.ofFn σ))ᴴ) * B =
+        ∑ σ : Fin n → Fin d,
+          Bᴴ * evalWord A (List.ofFn σ) * Matrix.single i k 1 *
+            ((evalWord A (List.ofFn σ))ᴴ * B) := by
+      rw [Matrix.mul_sum, Finset.sum_mul]
+      congr 1; ext σ
+      simp only [Matrix.mul_assoc]
+    rw [hdist, Matrix.sum_apply]
+    congr 1; ext σ
+    exact entry_mul_single_mul
+      (Bᴴ * evalWord A (List.ofFn σ))
+      ((evalWord A (List.ofFn σ))ᴴ * B) i k
+  simp_rw [hpush]
+  -- Step 2: Swap sums so σ is outermost.
+  rw [show (∑ i : Fin D, ∑ k : Fin D, ∑ σ : Fin n → Fin d,
+        (Bᴴ * evalWord A (List.ofFn σ)) i i *
+          ((evalWord A (List.ofFn σ))ᴴ * B) k k) =
+      ∑ σ : Fin n → Fin d, ∑ i : Fin D, ∑ k : Fin D,
+        (Bᴴ * evalWord A (List.ofFn σ)) i i *
+          ((evalWord A (List.ofFn σ))ᴴ * B) k k from by
+    simpa using Finset.sum_comm_cycle
+      (s := (Finset.univ : Finset (Fin D)))
+      (t := (Finset.univ : Finset (Fin D)))
+      (u := (Finset.univ : Finset (Fin n → Fin d)))
+      (f := fun i k σ =>
+        (Bᴴ * evalWord A (List.ofFn σ)) i i *
+          ((evalWord A (List.ofFn σ))ᴴ * B) k k)]
+  -- Step 3: Factor double sum into product of traces.
+  congr 1; ext σ
+  -- ∑_{ik} M_{ii} * N_{kk} = (∑_i M_{ii}) * (∑_k N_{kk})
+  have hfactor :
+      ∑ i : Fin D, ∑ k : Fin D,
+        (Bᴴ * evalWord A (List.ofFn σ)) i i *
+          ((evalWord A (List.ofFn σ))ᴴ * B) k k =
+      (∑ i, (Bᴴ * evalWord A (List.ofFn σ)) i i) *
+        (∑ k, ((evalWord A (List.ofFn σ))ᴴ * B) k k) := by
+    simpa using (Fintype.sum_mul_sum
+      (f := fun i : Fin D => (Bᴴ * evalWord A (List.ofFn σ)) i i)
+      (g := fun k : Fin D => ((evalWord A (List.ofFn σ))ᴴ * B) k k)).symm
+  rw [hfactor]
+  -- (∑_i M_{ii}) = Matrix.trace M
+  change Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)) *
+    star (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))) =
+    Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)) *
+      Matrix.trace ((evalWord A (List.ofFn σ))ᴴ * B)
+  -- tr(A_σ† B) = star(tr(B† A_σ)) by Matrix.trace_conjTranspose
+  congr 1
+  rw [← Matrix.trace_conjTranspose (Bᴴ * evalWord A (List.ofFn σ))]
+  simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+
+/-- **Trace-pairing identity for transfer-map powers.**
+
+The sum of squared absolute traces `∑_σ |tr(B† A_σ)|²` equals the `.re` of a
+bilinear form in `B` built from the iterated transfer map and matrix units.
+
+This is the core algebraic identity used in the proof of
+**Proposition 3(c)→(b)** of arXiv:0909.5347 (the "quantum Wielandt" paper). -/
+theorem sum_normSq_trace_conjTranspose_mul_evalWord
+    [NeZero D]
+    (A : MPSTensor d D) (n : ℕ)
+    (B : Matrix (Fin D) (Fin D) ℂ) :
+    (∑ σ : Fin n → Fin d,
+        ‖Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))‖ ^ 2 : ℝ) =
+      (∑ i : Fin D, ∑ k : Fin D,
+        (Bᴴ * ((transferMap (d := d) (D := D) A) ^ n)
+          (Matrix.single i k 1) * B) i k).re := by
+  -- Rewrite LHS: ‖z‖² = (z * star z).re since z * star z = ↑(‖z‖²)
+  have hlhs : (∑ σ : Fin n → Fin d,
+      ‖Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))‖ ^ 2 : ℝ) =
+    (∑ σ : Fin n → Fin d,
+      Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)) *
+        star (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ)))).re := by
+    rw [Complex.re_sum]
+    congr 1; ext σ
+    have : star (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))) =
+        (starRingEnd ℂ) (Matrix.trace (Bᴴ * evalWord A (List.ofFn σ))) :=
+      (starRingEnd_apply _).symm
+    rw [this, Complex.mul_conj']
+    norm_cast
+  rw [hlhs, sum_trace_mul_star_eq]
+
+end MPSTensor


### PR DESCRIPTION
## Summary

- move the trace-pairing identity used in the strong-irreducibility-to-full-rank route into `Wielandt/Primitivity/TracePairing`
- keep the public declaration names unchanged
- keep `StronglyIrreducibleToFullRank` focused on the primitivity, convergence, and final full-rank argument

## Issue context

This is a #334 cleanup for the large Wielandt primitivity proof file. It is a refactor only: no theorem statements or mathematical hypotheses are changed.

## Validation

- `lake env lean TNLean/Wielandt/Primitivity/TracePairing.lean`
- `lake build TNLean.Wielandt.Primitivity.TracePairing TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank -q --log-level=info`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/Wielandt/Primitivity/TracePairing.lean TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: moves an internal proof block into a dedicated module while keeping the exported theorem name/signature unchanged. Main risk is accidental import/namespace or lemma-visibility breakage in downstream builds.
> 
> **Overview**
> Moves the trace-pairing identity proof (`sum_normSq_trace_conjTranspose_mul_evalWord` and its supporting private lemma) out of `Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean` into a new `Wielandt/Primitivity/TracePairing.lean`, leaving the public theorem name/signature intact.
> 
> Updates imports so `StronglyIrreducibleToFullRank` depends on the new module, and adds `TNLean.Wielandt.Primitivity.TracePairing` to the root `TNLean.lean` import list for downstream visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5487a1603032c592aa1e391466afe4f1a7cb071c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->