### PR TITLE
feat(MPS/MPDO): add dimension-mismatch period-window adapter

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -1167,6 +1167,27 @@ theorem pairTraceSeparatingAll_of_injective_dim_ne
       (pairAlgSpan_eq_top_of_injective_dim_ne A B hA_inj hB_inj hdim)
   exact pairTraceSeparatingAll_of_pairAllWordsSpanTop A B hPairSpanTop
 
+/-- Unequal bond dimensions plus a finite period-window of homogeneous pair spans
+give one homogeneous pair trace-separating length.
+
+The dimension mismatch supplies all-words pair trace separation.  The
+period-window span hypothesis supplies the identity padding needed to convert
+that cumulative separation into a single homogeneous length. -/
+theorem exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop_period_window
+    {d D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hA_inj : IsInjective A) (hB_inj : IsInjective B)
+    (hdim : D₁ ≠ D₂)
+    {start period : ℕ} (hperiod_pos : 0 < period)
+    (hperiod : PairWordTupleSpanTop A B period)
+    (hwindow : ∀ r : ℕ, r < period → PairWordTupleSpanTop A B (start + r)) :
+    ∃ T : ℕ, PairTraceSeparatingAt A B T := by
+  apply exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding
+  · exact (pairAllWordsSpanTop_iff_pairTraceSeparatingAll A B).2
+      (pairTraceSeparatingAll_of_injective_dim_ne A B hA_inj hB_inj hdim)
+  · exact pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window
+      A B hperiod_pos hperiod hwindow
+
 /-- Placeholder for the Burnside–Jacobson identity-padding lemma.
 Once proved, it supplies the missing input to
 `pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding` and

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3149,6 +3149,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding}
     \lean{MPSTensor.pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding}
+    \lean{MPSTensor.exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop_period_window}
     \leanok
     \uses{def:pair_trace_separation_words, lem:all_length_pair_trace_separation_finite_cutoff}
     Suppose $S\le T$ and pair words of length at most $S$ span the product


### PR DESCRIPTION
## Summary

- add `MPSTensor.exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop_period_window`
- compose the unequal-dimension all-words pair separation with the period-window identity-padding interface
- tag the new adapter in the parent-Hamiltonian blueprint homogenization lemma

## Context

This narrows #1178 after #1211 by turning the unequal-dimension all-words separation branch into a homogeneous `PairTraceSeparatingAt` witness whenever the finite period-window pair-span certificate is available. It does not close #1178 or #1133; the same-dimension identity-padding theorem remains the live blocker.

## Validation

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean`
- `lake build TNLean.MPS.MPDO.BiCFDerivation.PairHomogenization -q --log-level=info`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean || true` (reports the pre-existing #1133 `sorry`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single theorem that composes existing lemmas without changing core definitions or algorithms; main risk is proof/lemma wiring and assumptions being too strong/weak.
> 
> **Overview**
> Adds `exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop_period_window`, composing the existing dimension-mismatch `PairTraceSeparatingAll` result with the period-window identity-padding interface to produce `∃ T, PairTraceSeparatingAt A B T`.
> 
> Updates the parent-Hamiltonian blueprint (`ch14_parent_hamiltonian.tex`) to reference this new Lean theorem in the homogenization-with-padding lemma list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c32d73835c53cd9951ffb0822b1782dad260e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->