### PR TITLE
feat(MPS/CanonicalForm): add common sector representatives

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
@@ -91,6 +91,16 @@ noncomputable def flatKey (F : CommonBlockedCyclicSectorFamily blocks)
     (x : Fin (∑ k : Fin r, F.period k)) : (k : Fin r) × Fin (F.period k) :=
   finSigmaFinEquiv.symm x
 
+/-- Encode one original block and one of its cyclic sectors as a flattened sector index. -/
+noncomputable def flatIndexOf (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) (s : Fin (F.period k)) : Fin (∑ k : Fin r, F.period k) :=
+  finSigmaFinEquiv (Sigma.mk k s)
+
+/-- The flattened sector chosen as the representative for one original block. -/
+noncomputable def flatRepresentativeIndex (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : Fin (∑ k : Fin r, F.period k) :=
+  F.flatIndexOf k ⟨0, F.period_pos k⟩
+
 /-- The flattened sectors produced by `CommonBlockedCyclicSectorFamily` carry unit weights. -/
 def flatWeight (F : CommonBlockedCyclicSectorFamily blocks) :
     Fin (∑ k : Fin r, F.period k) → ℂ :=
@@ -185,6 +195,42 @@ theorem commonFlatWeight_apply_block_eq (F : CommonBlockedCyclicSectorFamily blo
     F.commonFlatWeight μ (finSigmaFinEquiv (Sigma.mk k t)) := by
   simp [commonFlatWeight_apply_of_block]
 
+/-- Bond dimensions of the representative common-sector family. -/
+noncomputable def commonRepresentativeDim (F : CommonBlockedCyclicSectorFamily blocks) :
+    Fin r → ℕ :=
+  fun k => F.sectorDim k ⟨0, F.period_pos k⟩
+
+/-- One representative common-sector block for each original nonzero-weight block. -/
+noncomputable def commonRepresentativeBlocks (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : MPSTensor (blockPhysDim d F.p) (F.commonRepresentativeDim k) :=
+  F.commonSectorBlock k ⟨0, F.period_pos k⟩
+
+/-- Representative common-sector blocks expressed at a prescribed common length. -/
+noncomputable def commonRepresentativeBlocksAt (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p') (k : Fin r) :
+    MPSTensor (blockPhysDim d p') (F.commonRepresentativeDim k) :=
+  cast (congr_arg (fun q => MPSTensor (blockPhysDim d q) (F.commonRepresentativeDim k)) hp)
+    (F.commonRepresentativeBlocks k)
+
+/-- Weights carried by the representative common-sector family. -/
+noncomputable def commonRepresentativeWeight (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) : Fin r → ℂ :=
+  fun k => (μ k) ^ F.p
+
+/-- Representative weights agree with flattened weights at the chosen representatives. -/
+theorem commonRepresentativeWeight_apply (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) (k : Fin r) :
+    F.commonRepresentativeWeight μ k =
+      F.commonFlatWeight μ (F.flatRepresentativeIndex k) := by
+  simp [commonRepresentativeWeight, flatRepresentativeIndex, flatIndexOf,
+    commonFlatWeight, flatKey]
+
+/-- Representative weights remain nonzero after common blocking. -/
+theorem commonRepresentativeWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) (k : Fin r) :
+    F.commonRepresentativeWeight μ k ≠ 0 :=
+  F.commonBlockWeight_ne_zero μ hμ k
+
 private theorem commonSectorBlock_structural (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :
     (∑ i : Fin (blockPhysDim d F.p),
@@ -266,6 +312,35 @@ theorem commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
   let y := F.flatKey x
   simpa [commonFlatDim, y] using F.commonSectorBlock_dim_pos y.1 y.2
 
+/-- The representative common-sector family is trace-preserving. -/
+theorem commonRepresentativeBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) :
+    ∑ i : Fin (blockPhysDim d F.p),
+      (F.commonRepresentativeBlocks k i)ᴴ * F.commonRepresentativeBlocks k i = 1 := by
+  simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
+    F.commonSectorBlock_tp k ⟨0, F.period_pos k⟩
+
+/-- The representative common-sector family has primitive transfer maps. -/
+theorem commonRepresentativeBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) :
+    _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d F.p) (D := F.commonRepresentativeDim k)
+        (F.commonRepresentativeBlocks k)) := by
+  simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
+    F.commonSectorBlock_primitive k ⟨0, F.period_pos k⟩
+
+/-- The representative common-sector family is tensor-irreducible. -/
+theorem commonRepresentativeBlocks_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : IsIrreducibleTensor (F.commonRepresentativeBlocks k) := by
+  simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
+    F.commonSectorBlock_irreducible k ⟨0, F.period_pos k⟩
+
+/-- The representative common-sector family has positive bond dimensions. -/
+theorem commonRepresentativeDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : 0 < F.commonRepresentativeDim k := by
+  simpa [commonRepresentativeDim] using
+    F.commonSectorBlock_dim_pos k ⟨0, F.period_pos k⟩
+
 /-- A common blocked cyclic-sector family is a normal canonical form once its
 transported flat weights are sorted by strictly decreasing modulus. -/
 theorem isNormalCanonicalForm_commonFlatBlocks
@@ -301,6 +376,40 @@ theorem isNormalCanonicalForm_commonFlatBlocksAt
   subst p'
   simpa [commonFlatBlocksAt] using
     F.isNormalCanonicalForm_commonFlatBlocks μ hμ hAnti
+
+/-- A representative common-sector family is a normal canonical form once its transported
+representative weights are sorted by strictly decreasing modulus. -/
+theorem isNormalCanonicalForm_commonRepresentativeBlocks
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ)
+    (hμ : ∀ k, μ k ≠ 0)
+    (hAnti : StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
+    IsNormalCanonicalForm (d := blockPhysDim d F.p)
+      (F.commonRepresentativeWeight μ) F.commonRepresentativeBlocks :=
+  isNormalCanonicalForm_of_tp_primitive_irr_sorted
+    (d' := blockPhysDim d F.p)
+    (μ := F.commonRepresentativeWeight μ)
+    F.commonRepresentativeBlocks
+    F.commonRepresentativeBlocks_tp
+    F.commonRepresentativeBlocks_primitive
+    F.commonRepresentativeDim_pos
+    (F.commonRepresentativeWeight_ne_zero μ hμ)
+    F.commonRepresentativeBlocks_irreducible
+    hAnti
+
+/-- The representative common-sector family is a normal canonical form when expressed at a
+prescribed common blocking length. -/
+theorem isNormalCanonicalForm_commonRepresentativeBlocksAt
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p')
+    (μ : Fin r → ℂ)
+    (hμ : ∀ k, μ k ≠ 0)
+    (hAnti : StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
+    IsNormalCanonicalForm (d := blockPhysDim d p')
+      (F.commonRepresentativeWeight μ) (F.commonRepresentativeBlocksAt hp) := by
+  subst p'
+  simpa [commonRepresentativeBlocksAt] using
+    F.isNormalCanonicalForm_commonRepresentativeBlocks μ hμ hAnti
 
 /-- Iterated blocking of a nonzero-weight block is the relabeled common block. -/
 theorem nestedBlock_sameMPV₂_commonReindexedBlock


### PR DESCRIPTION
## Summary

Adds a representative-index API for `CommonBlockedCyclicSectorFamily` without assuming strict ordering across all flattened cyclic sectors.

- encode/decode helpers for representative flat indices
- representative dimensions, blocks, blocks-at-length, and weights
- inherited TP, primitive, irreducible, positive-dimension facts for representatives
- representative-only normal-form bridge under `StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)`

Addresses part of #1068 by isolating the safe representative family from the flattened family whose same-block sector weights can coincide.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean || true`
- `git diff --check -- TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new representative-indexed API and canonical-form theorems alongside the existing flattened-sector view; risk is mainly proof/lemma integration and potential downstream expectation changes around indexing/ordering assumptions.
> 
> **Overview**
> Introduces a *representative common-sector* view for `CommonBlockedCyclicSectorFamily`, selecting one cyclic sector per original block (via new `flatIndexOf`/`flatRepresentativeIndex`) to avoid relying on strict ordering across all flattened sectors.
> 
> Adds representative-level dims/blocks/weights (`commonRepresentativeDim`, `commonRepresentativeBlocks`, `commonRepresentativeWeight`, plus `...At`) and lifts the key structural facts (TP/primitive/irreducible/positive-dim, nonzero weights). Also adds normal-canonical-form theorems for the representative family under `StrictAnti` on representative weight norms, parallel to the existing flattened-family results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31720b4611dbf3af5fdcf145d0a3b205e59af9d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->