### PR TITLE
doc(blueprint): link Brouwer fixed-point infrastructure

### DIFF
--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -10,6 +10,25 @@ The conceptual source is Wolf's treatment of irreducible positive
 maps~\cite[Chapter~6, especially Theorems~6.2--6.5 and Corollary~6.3]{Wolf2012Quantum}
 and~\cite{Evans1978Spectral}.
 
+\begin{theorem}[Brouwer fixed point on density matrices]%
+	\label{thm:brouwer_density_matrices}
+	\lean{brouwer_fixedPoint_densityMatrices}
+	\lean{fixedPoint_of_compact_retract, fixedPoint_of_compact_retract_fin}
+	\lean{exists_fixedPoint_closedCube, exists_fixedPoint_unitCube}
+	\leanok
+	\uses{def:density_matrices, thm:density_compact}
+	Let $D > 0$. Every continuous map from the compact convex set of
+	density matrices in $\MN{D}$ to itself has a fixed point.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	The proof starts from Brouwer's theorem for products of simplices,
+	transfers it to closed cubes, and then to compact retracts of
+	finite-dimensional real normed spaces. The density-matrix set is
+	such a compact retract, using the explicit density retraction.
+\end{proof}
+
 \section{Positive definiteness}
 
 \begin{remark}\leanok


### PR DESCRIPTION
## Summary

- add a chapter 5 blueprint entry for the proved density-matrix Brouwer fixed-point theorem
- link the compact-retract and closed-cube fixed-point declarations used by that route
- keep the existing Cesaro channel fixed-point route unchanged

## Verification

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

Related: #335

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only LaTeX blueprint documentation is updated to reference an already-proved fixed-point theorem and its Lean infrastructure, with no code or logic changes.
> 
> **Overview**
> Adds a new Chapter 5 blueprint theorem, `thm:brouwer_density_matrices`, stating Brouwer’s fixed-point result for continuous self-maps on the compact convex set of density matrices.
> 
> The entry links the corresponding Lean declarations (`brouwer_fixedPoint_densityMatrices`) and the supporting fixed-point route via closed cubes and compact retracts, leaving the existing Cesàro-based fixed-point path unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044bae655e7c16f1ccbb5c812a7a9f2be50ca74f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->