### PR TITLE
feat(MPS/MPDO): add finite-family pair homogenization

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -295,9 +295,9 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingA
 /-- Positive-length product-word span from all-words pair separation plus eventual
 identity padding for every ordered pair of distinct BNT blocks.
 
-This is the BNT-facing finite-maximum wrapper around
-`exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding`.
-It keeps the Burnside-Jacobson identity-padding input explicit. -/
+The proof takes a finite maximum over the separating and padding lengths for the
+ordered block pairs, obtaining a single homogeneous word length whose block-product
+word evaluations span the full direct product algebra. -/
 theorem exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A)
@@ -345,9 +345,10 @@ theorem pairTraceSeparatingAll_of_isCanonicalFormBNT
 /-- Positive-length product-word span from canonical-form/BNT data plus eventual
 identity padding for every ordered pair of distinct blocks.
 
-This is the BNT-facing consumer for the Burnside-Jacobson identity-padding
-input: the all-words pair-separation part is derived from BNT data here, while
-the homogeneous identity-padding theorem remains an explicit hypothesis. -/
+Canonical-form/BNT separation gives all-words trace separation for distinct blocks.
+Together with eventual homogeneous identity padding for each ordered block pair, this
+gives a positive word length at which the block-product word evaluations span the full
+direct product algebra. -/
 theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -292,9 +292,82 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingA
   simpa [WordTupleSpanTop, wordTuple] using
     wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hSep
 
+/-- Positive-length product-word span from all-words pair separation plus eventual
+identity padding for every ordered pair of distinct BNT blocks.
+
+This is the BNT-facing finite-maximum wrapper around
+`exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding`.
+It keeps the Burnside-Jacobson identity-padding input explicit. -/
+theorem exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAll (A k) (A j))
+    (hPad : ∀ k j : Fin r, j ≠ k → ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) n))) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  obtain ⟨T, hT⟩ :=
+    exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding
+      A hSep hPad
+  exact exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hT
+
+/-- Canonical-form/BNT data give all-words pair trace separation for every
+ordered pair of distinct blocks.
+
+Equal-dimensional pairs use the BNT non-gauge-phase-equivalence hypothesis and
+the pair-product algebra density theorem.  Unequal-dimensional pairs use the
+dimension-mismatch pair-product density theorem. -/
+theorem pairTraceSeparatingAll_of_isCanonicalFormBNT
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) :
+    ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAll (A k) (A j) := by
+  intro k j hjk
+  by_cases hdim : dim k = dim j
+  · exact pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv_cast_left hdim
+      (A k) (A j)
+      (hCF.toHasInjectiveBlocks.block_injective k)
+      (hCF.toHasInjectiveBlocks.block_injective j)
+      (hCF.toIsLeftCanonicalBlockFamily.leftCanonical k)
+      (hCF.toIsLeftCanonicalBlockFamily.leftCanonical j)
+      (hCF.blocks_not_equiv k j hjk.symm hdim)
+  · exact pairTraceSeparatingAll_of_injective_dim_ne
+      (A k) (A j)
+      (hCF.toHasInjectiveBlocks.block_injective k)
+      (hCF.toHasInjectiveBlocks.block_injective j)
+      hdim
+
+/-- Positive-length product-word span from canonical-form/BNT data plus eventual
+identity padding for every ordered pair of distinct blocks.
+
+This is the BNT-facing consumer for the Burnside-Jacobson identity-padding
+input: the all-words pair-separation part is derived from BNT data here, while
+the homogeneous identity-padding theorem remains an explicit hypothesis. -/
+theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hPad : ∀ k j : Fin r, j ≠ k → ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) n))) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  exact exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding μ A hCF
+    (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hPad
+
 /-- Positive-length product-word span from cumulative pair trace separation plus
 exact identity padding. -/
-theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding
+theorem
+    exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) {S T : ℕ}
     (hST : S ≤ T)

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -1065,10 +1065,9 @@ theorem exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding
 /-- A finite family of all-words pair-separation hypotheses and eventual identity
 padding hypotheses admits one common homogeneous trace-separating length.
 
-This packages the finite maximum needed by the BNT block-family argument.  It is
-conditional only on per-pair all-words separation and per-pair eventual homogeneous
-identity padding; the Burnside-Jacobson identity-padding theorem is the remaining
-mathematical input that supplies the second hypothesis in the equal-dimension branch. -/
+For finitely many ordered pairs of blocks, if each pair has trace separation over all
+word lengths and the pair identity belongs to every sufficiently long homogeneous
+pair-word span, then one word length separates all ordered pairs simultaneously. -/
 theorem exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAll (A k) (A j))
@@ -1183,11 +1182,9 @@ theorem pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv
       (pairAlgSpan_eq_top_of_injective_not_gaugePhaseEquiv A B hA_inj hB_inj hNot)
   exact pairTraceSeparatingAll_of_pairAllWordsSpanTop A B hPairSpanTop
 
-/-- Cast-left spelling of
-`pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv`.
-
-This is the form used by block families whose bond dimensions are only
-propositionally equal. -/
+/-- If two injective blocks have propositionally equal bond dimensions and are not
+gauge-phase equivalent after identifying those dimensions, then their simultaneous pair
+words are trace separating over all lengths. -/
 theorem pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv_cast_left
     {d D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂] (h : D₁ = D₂)
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -1062,6 +1062,40 @@ theorem exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding
     A B (S := S) (T := L + S) (by omega) hSepUpTo
     (fun l hl => hPadAll (L + S - l) (by omega))
 
+/-- A finite family of all-words pair-separation hypotheses and eventual identity
+padding hypotheses admits one common homogeneous trace-separating length.
+
+This packages the finite maximum needed by the BNT block-family argument.  It is
+conditional only on per-pair all-words separation and per-pair eventual homogeneous
+identity padding; the Burnside-Jacobson identity-padding theorem is the remaining
+mathematical input that supplies the second hypothesis in the equal-dimension branch. -/
+theorem exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAll (A k) (A j))
+    (hPad : ∀ k j : Fin r, j ≠ k → ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) n))) :
+    ∃ T : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) T := by
+  classical
+  obtain ⟨S, hSepUpTo⟩ :=
+    exists_forall_pairTraceSeparatingUpTo_of_forall_pairTraceSeparatingAll A hSep
+  let Lij : Fin r × Fin r → ℕ := fun p =>
+    if h : p.2 ≠ p.1 then Classical.choose (hPad p.1 p.2 h) else 0
+  let L : ℕ := Finset.univ.sup Lij
+  refine ⟨L + S, ?_⟩
+  intro k j hjk
+  have hPadBase : ∀ n : ℕ, n ≥ Lij (k, j) →
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) n)) := by
+    simpa [Lij, hjk] using Classical.choose_spec (hPad k j hjk)
+  have hLij_le : Lij (k, j) ≤ L := by
+    exact Finset.le_sup (s := Finset.univ) (f := Lij) (Finset.mem_univ (k, j))
+  exact pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
+    (A k) (A j) (S := S) (T := L + S) (by omega) (hSepUpTo k j hjk)
+    (fun l hl => hPadBase (L + S - l) (by omega))
+
 /-! ### Burnside–Jacobson homogenization: from non-equivalence to homogeneous separation
 
 The theorems in this section bridge the gap between BNT block non-equivalence
@@ -1148,6 +1182,23 @@ theorem pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv
     exact pairAllWordsSpanTop_of_pairAlgSpan_eq_top A B
       (pairAlgSpan_eq_top_of_injective_not_gaugePhaseEquiv A B hA_inj hB_inj hNot)
   exact pairTraceSeparatingAll_of_pairAllWordsSpanTop A B hPairSpanTop
+
+/-- Cast-left spelling of
+`pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv`.
+
+This is the form used by block families whose bond dimensions are only
+propositionally equal. -/
+theorem pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv_cast_left
+    {d D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂] (h : D₁ = D₂)
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hA_inj : IsInjective A) (hB_inj : IsInjective B)
+    (hA_norm : ∑ i : Fin d, (A i)ᴴ * (A i) = 1)
+    (hB_norm : ∑ i : Fin d, (B i)ᴴ * (B i) = 1)
+    (hNot : ¬ GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) A) B) :
+    PairTraceSeparatingAll A B := by
+  subst h
+  simpa using pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv
+    A B hA_inj hB_inj hA_norm hB_norm hNot
 
 /-- **Dimension mismatch ⇒ all-length pair trace separation.**
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3149,6 +3149,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding}
     \lean{MPSTensor.pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding}
+    \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding}
+    \lean{MPSTensor.pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv_cast_left}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop_period_window}
     \leanok
     \uses{def:pair_trace_separation_words, lem:all_length_pair_trace_separation_finite_cutoff}
@@ -3241,6 +3243,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding}
+    \lean{MPSTensor.pairTraceSeparatingAll_of_isCanonicalFormBNT}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding}
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}


### PR DESCRIPTION
## Summary

- add a cast-left all-words pair-separation helper for propositionally equal bond dimensions
- add a finite-family common homogeneous pair trace-separation lemma from per-pair all-words separation plus eventual identity padding
- derive per-pair all-words pair separation directly from BNT data, splitting equal-dimension non-gauge-equivalent pairs from unequal-dimension pairs
- add BNT-facing product-word span wrappers while keeping the Burnside-Jacobson identity-padding input explicit
- link the new formal declarations from the parent-Hamiltonian blueprint chapter

## Validation

- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean` (reports only existing sorries in these files)

Relates to #1178, #1133, and #1170.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Lean theorems that take finite maxima over per-pair separation/padding bounds; risk is mainly proof fragility and downstream lemma dependencies in the formalization, not runtime behavior.
> 
> **Overview**
> Connects *all-words* `PairTraceSeparatingAll` + eventual homogeneous identity padding to a **single common** `PairTraceSeparatingAt` length for an entire finite block family via `exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding`.
> 
> Extends BNT-facing results in `BlockDiagonalCommutant.lean` by deriving `PairTraceSeparatingAll` directly from `IsCanonicalFormBNT` (splitting equal- vs unequal-dimension block pairs, including a new `..._cast_left` helper), and adds wrappers that turn these hypotheses + identity padding into a positive-length full product-word span.
> 
> Updates the blueprint chapter to reference the new Lean declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a98872fea13d3e6c536ea531c883c2c0d20ee906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->