### PR TITLE
feat(MPS/CanonicalForm): package representative BNT data

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.Assembly.StructuralData
+import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 open Filter
@@ -37,6 +38,30 @@ produced common cyclic-sector data.
 
 matrix product states, canonical form, common sectors, zero-tail decomposition
 -/
+
+/-- The representative common-sector family is normal-CF-BNT once the
+representative weights are strictly ordered and the representatives are
+BNT-separated.
+
+This packages the representative normal-canonical-form theorem with the
+explicit BNT separation hypothesis; it does not assert that the representative
+family already gives the full common phase-cover data. -/
+theorem isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
+    {d r : ℕ} {dim : Fin r → ℕ}
+    {blocks : (k : Fin r) → MPSTensor d (dim k)}
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p : ℕ} (hp : F.p = p)
+    (μ : Fin r → ℂ)
+    (hμ : ∀ k, μ k ≠ 0)
+    (hAnti : StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖))
+    (hNotGpe : BlocksNotGaugePhaseEquiv
+      (d := blockPhysDim d p) (F.commonRepresentativeBlocksAt hp)) :
+    IsNormalCanonicalFormBNT (d := blockPhysDim d p)
+      (F.commonRepresentativeWeight μ) (F.commonRepresentativeBlocksAt hp) where
+  toIsNormalCanonicalForm :=
+    F.isNormalCanonicalForm_commonRepresentativeBlocksAt hp μ hμ hAnti
+  mu_strict_anti := hAnti
+  blocks_not_equiv := hNotGpe
 
 /-- If each directly blocked nonzero block agrees with its iterated-blocking version,
 the zero-tail equation can be written using the derived common-sector family. -/

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -43,9 +43,8 @@ matrix product states, canonical form, common sectors, zero-tail decomposition
 representative weights are strictly ordered and the representatives are
 BNT-separated.
 
-This packages the representative normal-canonical-form theorem with the
-explicit BNT separation hypothesis; it does not assert that the representative
-family already gives the full common phase-cover data. -/
+It combines the representative normal-canonical-form statement with the
+explicit hypothesis that distinct representatives are not gauge-phase equivalent. -/
 theorem isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
     {d r : ℕ} {dim : Fin r → ℕ}
     {blocks : (k : Fin r) → MPSTensor d (dim k)}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1742,8 +1742,7 @@ The following results separate the zero blocks from the nonzero blocks.
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim_pos,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonBlockWeight_ne_zero,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero,
-		MPSTensor.CommonBlockedCyclicSectorFamily.isNormalCanonicalForm_commonFlatBlocks,
-		MPSTensor.isNormalCanonicalFormBNT_commonRepresentativeBlocksAt}
+		MPSTensor.CommonBlockedCyclicSectorFamily.isNormalCanonicalForm_commonFlatBlocks}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:tp_primitive_irreducible_extra_blocking,
@@ -1767,6 +1766,28 @@ The following results separate the zero blocks from the nonzero blocks.
 	positive power of a nonzero complex number is nonzero.  The normal canonical
 	form statement is Theorem~\ref{thm:ncf_sorted_tp_primitive_irred} applied to
 	these derived sector data.
+\end{proof}
+
+\begin{theorem}[Common-sector representatives form a BNT-separated normal canonical form]%
+\label{thm:common_representative_normal_bnt}
+	\lean{MPSTensor.isNormalCanonicalFormBNT_commonRepresentativeBlocksAt}
+	\leanok
+	\uses{def:common_blocked_cyclic_sector_derived_blocks,
+		thm:common_blocked_cyclic_sector_derived_properties,
+		def:normal_cf_bnt}
+	For a prescribed common blocking length, choose one representative for
+	each original block among the common-alphabet cyclic sectors.  If the
+	transported representative weights are strictly ordered by decreasing
+	norm, and distinct representatives are not gauge-phase equivalent, then
+	the representative family is in normal canonical form with BNT
+	separation.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:common_blocked_cyclic_sector_derived_properties,
+		def:normal_cf_bnt}
+	Apply the normal-canonical-form statement for the representative family
+	and include the assumed separation of distinct representatives.
 \end{proof}
 
 \begin{theorem}[Weights of common-alphabet sectors]%

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1742,7 +1742,8 @@ The following results separate the zero blocks from the nonzero blocks.
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim_pos,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonBlockWeight_ne_zero,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero,
-		MPSTensor.CommonBlockedCyclicSectorFamily.isNormalCanonicalForm_commonFlatBlocks}
+		MPSTensor.CommonBlockedCyclicSectorFamily.isNormalCanonicalForm_commonFlatBlocks,
+		MPSTensor.isNormalCanonicalFormBNT_commonRepresentativeBlocksAt}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:tp_primitive_irreducible_extra_blocking,


### PR DESCRIPTION
## Summary

- add a representative-family `IsNormalCanonicalFormBNT` producer after common cyclic-sector blocking
- keep representative BNT separation explicit rather than deriving the common phase-cover/proportional data prematurely
- link the new declaration from the canonical-form blueprint chapter

## Validation

- `lake build TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean || true`

Relates to #1068, #944, and #1170.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small wrapper theorem and documentation linkage without changing existing proofs or core transport logic.
> 
> **Overview**
> Adds `MPSTensor.isNormalCanonicalFormBNT_commonRepresentativeBlocksAt`, a constructor-style theorem that bundles the existing representative normal-canonical-form result with explicit `BlocksNotGaugePhaseEquiv` (BNT separation) to produce `IsNormalCanonicalFormBNT` after common cyclic-sector blocking.
> 
> Updates the blueprint (`ch08_canonical.tex`) with a corresponding theorem/proof stub referencing the new Lean declaration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6eb19bd0e2816f364fdc96d51fa437d55c8bad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->