### PR TITLE
feat(MPS/MPDO): add finite-family period-window wrapper

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -1096,6 +1096,32 @@ theorem exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identit
     (A k) (A j) (S := S) (T := L + S) (by omega) (hSepUpTo k j hjk)
     (fun l hl => hPadBase (L + S - l) (by omega))
 
+/-- A finite family of all-words pair-separation hypotheses and per-pair
+period-window identity-padding certificates admits one common homogeneous
+trace-separating length.
+
+This is only the finite-family arithmetic wrapper: the mathematical input is
+the period-window identity certificate for each ordered pair. -/
+theorem
+    exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAll (A k) (A j))
+    (hWindow : ∀ k j : Fin r, j ≠ k → ∃ start period : ℕ, 0 < period ∧
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) period)) ∧
+      ∀ s : ℕ, s < period →
+        ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+            (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+          Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (start + s)))) :
+    ∃ T : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) T := by
+  refine exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding
+    A hSep ?_
+  intro k j hj
+  rcases hWindow k j hj with ⟨start, period, hperiod_pos, hperiod, hwindow⟩
+  exact pairIdentity_mem_pairWordTupleSpan_eventually_of_period_window
+    (A k) (A j) hperiod_pos hperiod hwindow
+
 /-! ### Burnside–Jacobson homogenization: from non-equivalence to homogeneous separation
 
 The theorems in this section bridge the gap between BNT block non-equivalence

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -1100,8 +1100,8 @@ theorem exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identit
 period-window identity-padding certificates admits one common homogeneous
 trace-separating length.
 
-This is only the finite-family arithmetic wrapper: the mathematical input is
-the period-window identity certificate for each ordered pair. -/
+The proof is a finite-family arithmetic reduction: the mathematical hypothesis
+is the period-window identity certificate for each ordered pair. -/
 theorem
     exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3150,6 +3150,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding}
+    \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows}
     \lean{MPSTensor.pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv_cast_left}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop_period_window}
     \leanok


### PR DESCRIPTION
## Summary

- add a finite-family wrapper turning per-pair period-window identity-padding certificates into one common homogeneous pair trace-separation length
- keep the Burnside-Jacobson mathematical input explicit: this only packages the already-proved period-window arithmetic and finite-family maximum machinery
- link the new declaration from the parent-Hamiltonian blueprint chapter

## Validation

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean` (reports only the existing identity-padding `sorry` and surrounding doc text)

Stacked on #1220. Relates to #1133, #1178, and #1170.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small wrapper theorem that composes existing homogenization and period-window padding results, plus a documentation/blueprint cross-reference.
> 
> **Overview**
> Adds a new Lean theorem, `exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows`, which turns **per-pair period-window identity-padding certificates** into the existing **eventual padding** form and then reuses the finite-family homogenization machinery to produce one common homogeneous `T` for `PairTraceSeparatingAt` across all ordered block pairs.
> 
> Updates the parent-Hamiltonian blueprint (`ch14_parent_hamiltonian.tex`) to reference this new declaration in the “Homogenizing cumulative pair separation” lemma list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5b11be6e8e1b8c8321fa5281c56bcb29a0f467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->