### PR TITLE
refactor(MPS/CanonicalForm): split common representative sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -240,6 +240,7 @@ import TNLean.MPS.CanonicalForm.Assembly.TPPrimitiveReduction
 import TNLean.MPS.CanonicalForm.Assembly.NormalityChain
 import TNLean.MPS.CanonicalForm.Assembly.PrimitiveBlocks
 import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily
+import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorRepresentatives
 import TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition
 import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorConstruction
 import TNLean.MPS.CanonicalForm.Assembly.StructuralData

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -23,6 +23,8 @@ The supporting modules are:
   and the conditional weak block-matching theorem.
 * `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily` —
   common-period cyclic-sector family API.
+* `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorRepresentatives` —
+  representative common-sector family API.
 * `TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition` — cyclic sector
   decomposition after blocking.
 * `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorConstruction` —

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -22,9 +22,9 @@ The supporting modules are:
 * `TNLean.MPS.CanonicalForm.Assembly.PrimitiveBlocks` — blocked irreducibility
   and the conditional weak block-matching theorem.
 * `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily` —
-  common-period cyclic-sector family API.
+  definitions and lemmas for common-period cyclic-sector families.
 * `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorRepresentatives` —
-  representative common-sector family API.
+  definitions and lemmas for representative common-sector families.
 * `TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition` — cyclic sector
   decomposition after blocking.
 * `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorConstruction` —

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
@@ -195,42 +195,6 @@ theorem commonFlatWeight_apply_block_eq (F : CommonBlockedCyclicSectorFamily blo
     F.commonFlatWeight μ (finSigmaFinEquiv (Sigma.mk k t)) := by
   simp [commonFlatWeight_apply_of_block]
 
-/-- Bond dimensions of the representative common-sector family. -/
-noncomputable def commonRepresentativeDim (F : CommonBlockedCyclicSectorFamily blocks) :
-    Fin r → ℕ :=
-  fun k => F.sectorDim k ⟨0, F.period_pos k⟩
-
-/-- One representative common-sector block for each original nonzero-weight block. -/
-noncomputable def commonRepresentativeBlocks (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) : MPSTensor (blockPhysDim d F.p) (F.commonRepresentativeDim k) :=
-  F.commonSectorBlock k ⟨0, F.period_pos k⟩
-
-/-- Representative common-sector blocks expressed at a prescribed common length. -/
-noncomputable def commonRepresentativeBlocksAt (F : CommonBlockedCyclicSectorFamily blocks)
-    {p' : ℕ} (hp : F.p = p') (k : Fin r) :
-    MPSTensor (blockPhysDim d p') (F.commonRepresentativeDim k) :=
-  cast (congr_arg (fun q => MPSTensor (blockPhysDim d q) (F.commonRepresentativeDim k)) hp)
-    (F.commonRepresentativeBlocks k)
-
-/-- Weights carried by the representative common-sector family. -/
-noncomputable def commonRepresentativeWeight (F : CommonBlockedCyclicSectorFamily blocks)
-    (μ : Fin r → ℂ) : Fin r → ℂ :=
-  fun k => (μ k) ^ F.p
-
-/-- Representative weights agree with flattened weights at the chosen representatives. -/
-theorem commonRepresentativeWeight_apply (F : CommonBlockedCyclicSectorFamily blocks)
-    (μ : Fin r → ℂ) (k : Fin r) :
-    F.commonRepresentativeWeight μ k =
-      F.commonFlatWeight μ (F.flatRepresentativeIndex k) := by
-  simp [commonRepresentativeWeight, flatRepresentativeIndex, flatIndexOf,
-    commonFlatWeight, flatKey]
-
-/-- Representative weights remain nonzero after common blocking. -/
-theorem commonRepresentativeWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
-    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) (k : Fin r) :
-    F.commonRepresentativeWeight μ k ≠ 0 :=
-  F.commonBlockWeight_ne_zero μ hμ k
-
 private theorem commonSectorBlock_structural (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :
     (∑ i : Fin (blockPhysDim d F.p),
@@ -312,35 +276,6 @@ theorem commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
   let y := F.flatKey x
   simpa [commonFlatDim, y] using F.commonSectorBlock_dim_pos y.1 y.2
 
-/-- The representative common-sector family is trace-preserving. -/
-theorem commonRepresentativeBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) :
-    ∑ i : Fin (blockPhysDim d F.p),
-      (F.commonRepresentativeBlocks k i)ᴴ * F.commonRepresentativeBlocks k i = 1 := by
-  simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
-    F.commonSectorBlock_tp k ⟨0, F.period_pos k⟩
-
-/-- The representative common-sector family has primitive transfer maps. -/
-theorem commonRepresentativeBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) :
-    _root_.IsPrimitive
-      (transferMap (d := blockPhysDim d F.p) (D := F.commonRepresentativeDim k)
-        (F.commonRepresentativeBlocks k)) := by
-  simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
-    F.commonSectorBlock_primitive k ⟨0, F.period_pos k⟩
-
-/-- The representative common-sector family is tensor-irreducible. -/
-theorem commonRepresentativeBlocks_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) : IsIrreducibleTensor (F.commonRepresentativeBlocks k) := by
-  simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
-    F.commonSectorBlock_irreducible k ⟨0, F.period_pos k⟩
-
-/-- The representative common-sector family has positive bond dimensions. -/
-theorem commonRepresentativeDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) : 0 < F.commonRepresentativeDim k := by
-  simpa [commonRepresentativeDim] using
-    F.commonSectorBlock_dim_pos k ⟨0, F.period_pos k⟩
-
 /-- A common blocked cyclic-sector family is a normal canonical form once its
 transported flat weights are sorted by strictly decreasing modulus. -/
 theorem isNormalCanonicalForm_commonFlatBlocks
@@ -376,40 +311,6 @@ theorem isNormalCanonicalForm_commonFlatBlocksAt
   subst p'
   simpa [commonFlatBlocksAt] using
     F.isNormalCanonicalForm_commonFlatBlocks μ hμ hAnti
-
-/-- A representative common-sector family is a normal canonical form once its transported
-representative weights are sorted by strictly decreasing modulus. -/
-theorem isNormalCanonicalForm_commonRepresentativeBlocks
-    (F : CommonBlockedCyclicSectorFamily blocks)
-    (μ : Fin r → ℂ)
-    (hμ : ∀ k, μ k ≠ 0)
-    (hAnti : StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
-    IsNormalCanonicalForm (d := blockPhysDim d F.p)
-      (F.commonRepresentativeWeight μ) F.commonRepresentativeBlocks :=
-  isNormalCanonicalForm_of_tp_primitive_irr_sorted
-    (d' := blockPhysDim d F.p)
-    (μ := F.commonRepresentativeWeight μ)
-    F.commonRepresentativeBlocks
-    F.commonRepresentativeBlocks_tp
-    F.commonRepresentativeBlocks_primitive
-    F.commonRepresentativeDim_pos
-    (F.commonRepresentativeWeight_ne_zero μ hμ)
-    F.commonRepresentativeBlocks_irreducible
-    hAnti
-
-/-- The representative common-sector family is a normal canonical form when expressed at a
-prescribed common blocking length. -/
-theorem isNormalCanonicalForm_commonRepresentativeBlocksAt
-    (F : CommonBlockedCyclicSectorFamily blocks)
-    {p' : ℕ} (hp : F.p = p')
-    (μ : Fin r → ℂ)
-    (hμ : ∀ k, μ k ≠ 0)
-    (hAnti : StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
-    IsNormalCanonicalForm (d := blockPhysDim d p')
-      (F.commonRepresentativeWeight μ) (F.commonRepresentativeBlocksAt hp) := by
-  subst p'
-  simpa [commonRepresentativeBlocksAt] using
-    F.isNormalCanonicalForm_commonRepresentativeBlocks μ hμ hAnti
 
 /-- Iterated blocking of a nonzero-weight block is the relabeled common block. -/
 theorem nestedBlock_sameMPV₂_commonReindexedBlock

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+
+namespace MPSTensor
+namespace CommonBlockedCyclicSectorFamily
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+variable {blocks : (k : Fin r) → MPSTensor d (dim k)}
+
+/-! ### Representative common sectors -/
+
+/-- Bond dimensions of the representative common-sector family. -/
+noncomputable def commonRepresentativeDim (F : CommonBlockedCyclicSectorFamily blocks) :
+    Fin r → ℕ :=
+  fun k => F.sectorDim k ⟨0, F.period_pos k⟩
+
+/-- One representative common-sector block for each original nonzero-weight block. -/
+noncomputable def commonRepresentativeBlocks (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : MPSTensor (blockPhysDim d F.p) (F.commonRepresentativeDim k) :=
+  F.commonSectorBlock k ⟨0, F.period_pos k⟩
+
+/-- Representative common-sector blocks expressed at a prescribed common length. -/
+noncomputable def commonRepresentativeBlocksAt (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p') (k : Fin r) :
+    MPSTensor (blockPhysDim d p') (F.commonRepresentativeDim k) :=
+  cast (congr_arg (fun q => MPSTensor (blockPhysDim d q) (F.commonRepresentativeDim k)) hp)
+    (F.commonRepresentativeBlocks k)
+
+/-- Weights carried by the representative common-sector family. -/
+noncomputable def commonRepresentativeWeight (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) : Fin r → ℂ :=
+  fun k => (μ k) ^ F.p
+
+/-- Representative weights agree with flattened weights at the chosen representatives. -/
+theorem commonRepresentativeWeight_apply (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) (k : Fin r) :
+    F.commonRepresentativeWeight μ k =
+      F.commonFlatWeight μ (F.flatRepresentativeIndex k) := by
+  simp [commonRepresentativeWeight, flatRepresentativeIndex, flatIndexOf,
+    commonFlatWeight, flatKey]
+
+/-- Representative weights remain nonzero after common blocking. -/
+theorem commonRepresentativeWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) (k : Fin r) :
+    F.commonRepresentativeWeight μ k ≠ 0 :=
+  F.commonBlockWeight_ne_zero μ hμ k
+
+/-- The representative common-sector family is trace-preserving. -/
+theorem commonRepresentativeBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) :
+    ∑ i : Fin (blockPhysDim d F.p),
+      (F.commonRepresentativeBlocks k i)ᴴ * F.commonRepresentativeBlocks k i = 1 := by
+  simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
+    F.commonSectorBlock_tp k ⟨0, F.period_pos k⟩
+
+/-- The representative common-sector family has primitive transfer maps. -/
+theorem commonRepresentativeBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) :
+    _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d F.p) (D := F.commonRepresentativeDim k)
+        (F.commonRepresentativeBlocks k)) := by
+  simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
+    F.commonSectorBlock_primitive k ⟨0, F.period_pos k⟩
+
+/-- The representative common-sector family is tensor-irreducible. -/
+theorem commonRepresentativeBlocks_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : IsIrreducibleTensor (F.commonRepresentativeBlocks k) := by
+  simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
+    F.commonSectorBlock_irreducible k ⟨0, F.period_pos k⟩
+
+/-- The representative common-sector family has positive bond dimensions. -/
+theorem commonRepresentativeDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) : 0 < F.commonRepresentativeDim k := by
+  simpa [commonRepresentativeDim] using
+    F.commonSectorBlock_dim_pos k ⟨0, F.period_pos k⟩
+
+/-- A representative common-sector family is a normal canonical form once its transported
+representative weights are sorted by strictly decreasing modulus. -/
+theorem isNormalCanonicalForm_commonRepresentativeBlocks
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ)
+    (hμ : ∀ k, μ k ≠ 0)
+    (hAnti : StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
+    IsNormalCanonicalForm (d := blockPhysDim d F.p)
+      (F.commonRepresentativeWeight μ) F.commonRepresentativeBlocks :=
+  isNormalCanonicalForm_of_tp_primitive_irr_sorted
+    (d' := blockPhysDim d F.p)
+    (μ := F.commonRepresentativeWeight μ)
+    F.commonRepresentativeBlocks
+    F.commonRepresentativeBlocks_tp
+    F.commonRepresentativeBlocks_primitive
+    F.commonRepresentativeDim_pos
+    (F.commonRepresentativeWeight_ne_zero μ hμ)
+    F.commonRepresentativeBlocks_irreducible
+    hAnti
+
+/-- The representative common-sector family is a normal canonical form when expressed at a
+prescribed common blocking length. -/
+theorem isNormalCanonicalForm_commonRepresentativeBlocksAt
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p')
+    (μ : Fin r → ℂ)
+    (hμ : ∀ k, μ k ≠ 0)
+    (hAnti : StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
+    IsNormalCanonicalForm (d := blockPhysDim d p')
+      (F.commonRepresentativeWeight μ) (F.commonRepresentativeBlocksAt hp) := by
+  subst p'
+  simpa [commonRepresentativeBlocksAt] using
+    F.isNormalCanonicalForm_commonRepresentativeBlocks μ hμ hAnti
+
+end CommonBlockedCyclicSectorFamily
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.Assembly.StructuralData
-import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily
+import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorRepresentatives
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 open Filter


### PR DESCRIPTION
## Summary

- extracts the representative common-sector API from `CommonBlockedCyclicSectorFamily` into `CommonBlockedCyclicSectorRepresentatives`
- keeps `CommonBlockedCyclicSectorFamily` under the 800-line guard after #1221
- updates the assembly import list and `CommonSectorTransport` to depend on the narrower representative module

## Scope

Stacked on #1221. This is a cleanup slice for #334 and keeps the common-representative BNT work reviewable without changing theorem statements or mathematical content.

## Validation

- `lake build TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily`
- `lake build TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorRepresentatives`
- `lake build TNLean.MPS.CanonicalForm.Assembly.CommonSectorTransport`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves representative common-sector definitions/lemmas into a new module and updates imports; no theorem statements or core logic changes expected, but import/re-export wiring could break downstream builds if any missing dependencies remain.
> 
> **Overview**
> Extracts the *representative common-sector* API (e.g. `commonRepresentative*` defs and theorems like `isNormalCanonicalForm_commonRepresentativeBlocks*`) out of `CommonBlockedCyclicSectorFamily` into a new module `CommonBlockedCyclicSectorRepresentatives`.
> 
> Updates the public import surfaces (`TNLean.lean`, `Assembly.lean`) and switches `CommonSectorTransport` to depend on the narrower representative module instead of the full family file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71cbecebae7fd8c0105748481f935fa591c4010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->