### PR TITLE
refactor(MPS/CanonicalForm): extract zero-tail transport

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -242,6 +242,7 @@ import TNLean.MPS.CanonicalForm.Assembly.PrimitiveBlocks
 import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily
 import TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition
 import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorConstruction
+import TNLean.MPS.CanonicalForm.Assembly.ZeroTailTransport
 import TNLean.MPS.CanonicalForm.Assembly.StructuralData
 import TNLean.MPS.CanonicalForm.Assembly.SectorComparisonCore
 import TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -27,6 +27,8 @@ The supporting modules are:
   decomposition after blocking.
 * `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorConstruction` —
   construction of common-period cyclic-sector families.
+* `TNLean.MPS.CanonicalForm.Assembly.ZeroTailTransport` — generic zero-tail
+  MPV transport lemmas.
 * `TNLean.MPS.CanonicalForm.Assembly.StructuralData` — common-period blocking
   and structural after-blocking data.
 * `TNLean.MPS.CanonicalForm.Assembly.SectorComparisonCore` — conditional

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorConstruction
+import TNLean.MPS.CanonicalForm.Assembly.ZeroTailTransport
 import TNLean.MPS.CanonicalForm.EqualNormBridge
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
@@ -889,36 +890,6 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
   · intro x
     exact familyB.commonFlatDim_pos x
 
-/-- Transport a zero-tail decomposition along an MPV equivalence of its nonzero part. -/
-theorem zeroTail_eq_of_sameMPV₂
-    {d D L L' z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
-    (flat : MPSTensor d L')
-    (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ)
-    (hFlat : SameMPV₂ live flat) :
-    ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv flat σ := by
-  intro N σ
-  calc
-    mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ := hZeroTail N σ
-    _ = mpv (zeroMPSTensor d z) σ + mpv flat σ := by
-      rw [hFlat N σ]
-
-/-- At positive lengths, a zero-tail decomposition reduces to the nonzero part. -/
-theorem sameMPV₂Pos_of_zeroTail_eq
-    {d D L z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
-    (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ) :
-    SameMPV₂Pos A live := by
-  intro N hN σ
-  have hZero : mpv (zeroMPSTensor d z) σ = 0 := by
-    rw [mpv_zeroMPSTensor]
-    simp [Nat.ne_of_gt hN]
-  calc
-    mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ := hZeroTail N σ
-    _ = mpv live σ := by
-      rw [hZero, zero_add]
-
 set_option maxHeartbeats 900000 in
 -- The nested existential conclusion records both sides and the conditional
 -- common-sector equalities.
@@ -1084,56 +1055,6 @@ theorem afterBlocking_commonLengthCommonSectorData_of_reindexed
           (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
             rw [hFlatB 0 σ]
   exact ⟨hFlatA, hFlatB, hZAflat, hZBflat, hApos, hBpos, hFlatPos, hZeroFlat⟩
-
-/-- Remove matching zero tails from two MPV identities.
-
-If `A` and `B` have the same MPVs, and each is expressed as a zero tail plus a nonzero part,
-then equality of the zero-tail dimensions gives full `SameMPV₂` equality of the nonzero parts.
-For positive lengths the zero tails vanish; at length zero this is exactly the missing
-zero-tail condition. -/
-theorem sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
-    {d D₁ D₂ L₁ L₂ z₁ z₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (liveA : MPSTensor d L₁) (liveB : MPSTensor d L₂)
-    (hSame : SameMPV₂ A B)
-    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z₁) σ + mpv liveA σ)
-    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv B σ = mpv (zeroMPSTensor d z₂) σ + mpv liveB σ)
-    (hz : z₁ = z₂) :
-    SameMPV₂ liveA liveB := by
-  intro N σ
-  have hsum :
-      mpv (zeroMPSTensor d z₁) σ + mpv liveA σ =
-        mpv (zeroMPSTensor d z₂) σ + mpv liveB σ := by
-    calc
-      mpv (zeroMPSTensor d z₁) σ + mpv liveA σ = mpv A σ := (hA N σ).symm
-      _ = mpv B σ := hSame N σ
-      _ = mpv (zeroMPSTensor d z₂) σ + mpv liveB σ := hB N σ
-  by_cases hN : N = 0
-  · subst hN
-    have hz₁mpv : mpv (zeroMPSTensor d z₁) σ = (z₁ : ℂ) := by
-      rw [mpv_zeroMPSTensor]
-      simp
-    have hz₂mpv : mpv (zeroMPSTensor d z₂) σ = (z₂ : ℂ) := by
-      rw [mpv_zeroMPSTensor]
-      simp
-    have hsum' :
-        (z₂ : ℂ) + mpv liveA σ = (z₂ : ℂ) + mpv liveB σ := by
-      rw [hz₁mpv, hz₂mpv] at hsum
-      rw [hz] at hsum
-      exact hsum
-    exact add_left_cancel hsum'
-  · have hz₁mpv : mpv (zeroMPSTensor d z₁) σ = 0 := by
-      rw [mpv_zeroMPSTensor]
-      simp [hN]
-    have hz₂mpv : mpv (zeroMPSTensor d z₂) σ = 0 := by
-      rw [mpv_zeroMPSTensor]
-      simp [hN]
-    have hsum' : (0 : ℂ) + mpv liveA σ = 0 + mpv liveB σ := by
-      rw [hz₁mpv, hz₂mpv] at hsum
-      exact hsum
-    simpa [zero_add] using hsum'
 
 /-- **Common nonzero-block sector comparison with an explicit zero-tail identity.**
 

--- a/TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.Existence
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+
+/-!
+# Zero-tail MPV transport
+
+This module contains generic lemmas for transporting decompositions of an MPS
+tensor into a zero tail plus a nonzero part.
+-/
+
+namespace MPSTensor
+
+/-- Transport a zero-tail decomposition along an MPV equivalence of its nonzero part. -/
+theorem zeroTail_eq_of_sameMPV₂
+    {d D L L' z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
+    (flat : MPSTensor d L')
+    (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ)
+    (hFlat : SameMPV₂ live flat) :
+    ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv flat σ := by
+  intro N σ
+  calc
+    mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ := hZeroTail N σ
+    _ = mpv (zeroMPSTensor d z) σ + mpv flat σ := by
+      rw [hFlat N σ]
+
+/-- At positive lengths, a zero-tail decomposition reduces to the nonzero part. -/
+theorem sameMPV₂Pos_of_zeroTail_eq
+    {d D L z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
+    (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ) :
+    SameMPV₂Pos A live := by
+  intro N hN σ
+  have hZero : mpv (zeroMPSTensor d z) σ = 0 := by
+    rw [mpv_zeroMPSTensor]
+    simp [Nat.ne_of_gt hN]
+  calc
+    mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ := hZeroTail N σ
+    _ = mpv live σ := by
+      rw [hZero, zero_add]
+
+/-- Remove matching zero tails from two MPV identities.
+
+If `A` and `B` have the same MPVs, and each is expressed as a zero tail plus a nonzero part,
+then equality of the zero-tail dimensions gives full `SameMPV₂` equality of the nonzero parts.
+For positive lengths the zero tails vanish; at length zero this is exactly the missing
+zero-tail condition. -/
+theorem sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+    {d D₁ D₂ L₁ L₂ z₁ z₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (liveA : MPSTensor d L₁) (liveB : MPSTensor d L₂)
+    (hSame : SameMPV₂ A B)
+    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z₁) σ + mpv liveA σ)
+    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv B σ = mpv (zeroMPSTensor d z₂) σ + mpv liveB σ)
+    (hz : z₁ = z₂) :
+    SameMPV₂ liveA liveB := by
+  intro N σ
+  have hsum :
+      mpv (zeroMPSTensor d z₁) σ + mpv liveA σ =
+        mpv (zeroMPSTensor d z₂) σ + mpv liveB σ := by
+    calc
+      mpv (zeroMPSTensor d z₁) σ + mpv liveA σ = mpv A σ := (hA N σ).symm
+      _ = mpv B σ := hSame N σ
+      _ = mpv (zeroMPSTensor d z₂) σ + mpv liveB σ := hB N σ
+  by_cases hN : N = 0
+  · subst hN
+    have hz₁mpv : mpv (zeroMPSTensor d z₁) σ = (z₁ : ℂ) := by
+      rw [mpv_zeroMPSTensor]
+      simp
+    have hz₂mpv : mpv (zeroMPSTensor d z₂) σ = (z₂ : ℂ) := by
+      rw [mpv_zeroMPSTensor]
+      simp
+    have hsum' :
+        (z₂ : ℂ) + mpv liveA σ = (z₂ : ℂ) + mpv liveB σ := by
+      rw [hz₁mpv, hz₂mpv] at hsum
+      rw [hz] at hsum
+      exact hsum
+    exact add_left_cancel hsum'
+  · have hz₁mpv : mpv (zeroMPSTensor d z₁) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [hN]
+    have hz₂mpv : mpv (zeroMPSTensor d z₂) σ = 0 := by
+      rw [mpv_zeroMPSTensor]
+      simp [hN]
+    have hsum' : (0 : ℂ) + mpv liveA σ = 0 + mpv liveB σ := by
+      rw [hz₁mpv, hz₂mpv] at hsum
+      exact hsum
+    simpa [zero_add] using hsum'
+
+end MPSTensor


### PR DESCRIPTION
## Summary

- extracts the generic zero-tail MPV transport lemmas into `Assembly.ZeroTailTransport`
- keeps the existing declaration names unchanged and imports the new module from `StructuralData`
- updates the assembly module overview and root import list

## Scope

Refactor-only cleanup for #334. This does not change theorem statements, hypotheses, or proof content; it separates reusable zero-tail transport from the larger structural after-blocking data module.

Line-count impact:
- `StructuralData.lean`: 1297 -> 1218 lines
- new `ZeroTailTransport.lean`: 98 lines

## Validation

- `lake build TNLean.MPS.CanonicalForm.Assembly.ZeroTailTransport`
- `lake build TNLean.MPS.CanonicalForm.Assembly.StructuralData`
- `lake build TNLean.MPS.CanonicalForm.Assembly.CommonSectorTransport`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves existing zero-tail MPV transport lemmas into a new module and updates imports/docs; the main risk is broken imports or namespace resolution if downstream modules relied on the old location.
> 
> **Overview**
> Extracts the generic zero-tail MPV transport lemmas (`zeroTail_eq_of_sameMPV₂`, `sameMPV₂Pos_of_zeroTail_eq`, `sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq`) out of `Assembly/StructuralData.lean` into a new `Assembly/ZeroTailTransport.lean` module, keeping theorem names unchanged.
> 
> Updates module wiring and documentation by importing `ZeroTailTransport` from `StructuralData`, adding it to the `Assembly` overview, and exposing it through the root `TNLean.lean` import list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f499255e6a32ae26ac7648c57231360b3922a4a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->