### PR TITLE
feat(MPS/MPDO): add pair all-words period-window bridge

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -979,6 +979,21 @@ theorem pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_pe
     (fun r hr =>
       pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop A B (hwindow r hr))
 
+/-- The Burnside-Jacobson all-words span route reduces to producing one
+period and a full residue window of homogeneous span-top certificates. -/
+theorem pairIdentity_mem_pairWordTupleSpan_eventually_of_pairAllWordsSpanTop_period_window
+    {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (_hSpan : PairAllWordsSpanTop A B)
+    {start period : ℕ} (hperiod_pos : 0 < period)
+    (hperiod : PairWordTupleSpanTop A B period)
+    (hwindow : ∀ r : ℕ, r < period → PairWordTupleSpanTop A B (start + r)) :
+    ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
+      ((1 : Matrix (Fin D₁) (Fin D₁) ℂ), (1 : Matrix (Fin D₂) (Fin D₂) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B n)) :=
+  pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window
+    A B hperiod_pos hperiod hwindow
+
 /-- A cumulative pair span can be homogenized once the simultaneous pair identity
 is available at every padding length needed to reach the target length.
 


### PR DESCRIPTION
## Summary

- adds `pairIdentity_mem_pairWordTupleSpan_eventually_of_pairAllWordsSpanTop_period_window`
- keeps the Burnside-Jacobson all-words span route explicit while delegating to the existing homogeneous period/window padding lemma
- documents the exact remaining #1133 input: produce the period/window span-top certificate from the all-words span or from the injective non-gauge-equivalent pair data

## Scope

Stacked on #1222. This is a narrow conditional bridge for #1133; it does not close the `pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv` sorry and does not claim the period/window producer.

## Validation

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean`
  - reports the pre-existing warning for `pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv` using `sorry`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "pairIdentity_mem_pairWordTupleSpan_eventually_of_pairAllWordsSpanTop_period_window|\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a thin wrapper theorem and documentation in a Lean proof file, delegating entirely to an existing lemma without changing behavior elsewhere.
> 
> **Overview**
> Adds `pairIdentity_mem_pairWordTupleSpan_eventually_of_pairAllWordsSpanTop_period_window`, documenting the Burnside–Jacobson “all-words span → period + residue window” route and re-exposing it as an explicit theorem.
> 
> The new theorem takes a `PairAllWordsSpanTop` hypothesis (currently unused) and simply delegates to the existing `pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window` lemma, keeping the period/window certificate as the concrete remaining input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecd8bea5dae9e0f941e8482cdd36d872619c591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->