### PR TITLE
feat(MPS/CanonicalForm): add BNT period-window product span

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -364,6 +364,35 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding
   exact exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding μ A hCF
     (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hPad
 
+/-- Positive-length product-word span from canonical-form/BNT data plus a
+finite period-window identity-padding certificate for every ordered pair of
+distinct blocks.
+
+This is the BNT-facing consumer for the period-window version of the
+Burnside-Jacobson input.  The all-words pair-separation part is derived from
+BNT data here, while the finite period-window certificates remain explicit. -/
+theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hWindow : ∀ k j : Fin r, j ≠ k → ∃ start period : ℕ, 0 < period ∧
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) period)) ∧
+      ∀ s : ℕ, s < period →
+        ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+            (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+          Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (start + s)))) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  obtain ⟨T, hT⟩ :=
+    exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows
+      A (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hWindow
+  exact exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hT
+
 /-- Positive-length product-word span from cumulative pair trace separation plus
 exact identity padding. -/
 theorem

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -368,9 +368,9 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding
 finite period-window identity-padding certificate for every ordered pair of
 distinct blocks.
 
-This is the BNT-facing consumer for the period-window version of the
-Burnside-Jacobson input.  The all-words pair-separation part is derived from
-BNT data here, while the finite period-window certificates remain explicit. -/
+For a block family in canonical BNT form, it suffices to provide the finite
+period-window identity-padding certificates for the ordered pairs of distinct
+blocks.  The all-words pair separation follows from the BNT hypotheses. -/
 theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.CanonicalForm.BlockDiagonalCommutant.ProjectionSpan
 import TNLean.MPS.BNT.Construction
 import TNLean.MPS.MPDO.BiCFDerivation
+import TNLean.MPS.MPDO.BiCFDerivation.PairHomogenization
 import TNLean.MPS.SharedInfra.BlockAssembly
 
 /-!


### PR DESCRIPTION
## Summary

- adds `exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows`
- derives the all-words pair-separation input from BNT data
- keeps the per-pair finite period/window identity-padding certificates explicit

## Scope

Stacked on #1225. This is a BNT-facing consumer for the period-window Burnside-Jacobson interface; it does not prove the period/window certificates and does not close #1178.

## Validation

- `lake build TNLean.MPS.MPDO.BiCFDerivation.PairHomogenization`
- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
  - reports the pre-existing warning for `exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT` using `sorry`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows|\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new Lean theorem and import wiring in the canonical-form/BNT proof pipeline; risk is low but may affect downstream proofs due to additional dependency on `PairHomogenization` and new hypotheses shape.
> 
> **Overview**
> Adds `exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows`, which derives a positive-length product-word span from canonical-form/BNT data plus *per ordered pair* finite period-window identity-padding certificates, reusing the new homogenization bridge `exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows`.
> 
> Updates `BlockDiagonalCommutant.lean` to import `TNLean.MPS.MPDO.BiCFDerivation.PairHomogenization` and routes the proof through existing `pairTraceSeparatingAll_of_isCanonicalFormBNT` + `exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d7405fd26be891dfd39f5cbb65a5cd908e6a94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->