### PR TITLE
feat(MPS/CanonicalForm): add normal BNT cover constructors

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -394,6 +394,63 @@ def ofCommonPrimitiveData_zeroTailIdentity
     hAntiA hAntiB hNotGpeA hNotGpeB
     (zeroTail_eq_of_proportionalDecompositionConclusion hZero hMatch) hInjA hInjB hDecomp
 
+/-- Form `CommonPrimitiveBNTCoverHypotheses` from normal-CF-BNT data and the remaining
+zero-tail, injectivity, and proportional-decomposition inputs. -/
+def ofNormalCanonicalFormBNT
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (hA : IsNormalCanonicalFormBNT (d := blockPhysDim d p) μA blocksA)
+    (hB : IsNormalCanonicalFormBNT (d := blockPhysDim d p) μB blocksB)
+    (hZeroTail : zeroTailA = zeroTailB)
+    (hInjA : ∀ x, IsInjective (blocksA x))
+    (hInjB : ∀ x, IsInjective (blocksB x))
+    (hDecomp : ProportionalDecompositionData (d := blockPhysDim d p)
+      blocksA blocksB DtotA DtotB) :
+    CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB where
+  ncfA := hA.toIsNormalCanonicalForm
+  ncfB := hB.toIsNormalCanonicalForm
+  notGpeA := hA.blocks_not_equiv
+  notGpeB := hB.blocks_not_equiv
+  zeroTail_eq := hZeroTail
+  left_injective := hInjA
+  right_injective := hInjB
+  decompData := hDecomp
+
+/-- Form `CommonPrimitiveBNTCoverHypotheses` from normal-CF-BNT data, deriving zero-tail
+equality from the length-zero identity and the proportional BNT comparison. -/
+def ofNormalCanonicalFormBNT_zeroTailIdentity
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (hA : IsNormalCanonicalFormBNT (d := blockPhysDim d p) μA blocksA)
+    (hB : IsNormalCanonicalFormBNT (d := blockPhysDim d p) μB blocksB)
+    (hZero : ∀ σ : Fin 0 → Fin (blockPhysDim d p),
+      (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+        (zeroTailB : ℂ) +
+          mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ)
+    (hInjA : ∀ x, IsInjective (blocksA x))
+    (hInjB : ∀ x, IsInjective (blocksB x))
+    (hDecomp : ProportionalDecompositionData (d := blockPhysDim d p)
+      blocksA blocksB DtotA DtotB) :
+    CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB := by
+  have hMatch : ProportionalDecompositionConclusion (d := blockPhysDim d p) blocksA blocksB :=
+    fundamentalTheorem_of_separated_normalCFBNT_data
+      blocksA blocksB
+      hA.toIsNormalCanonicalForm hA.blocks_not_equiv
+      hB.toIsNormalCanonicalForm hB.blocks_not_equiv
+      hDecomp
+  exact ofNormalCanonicalFormBNT hA hB
+    (zeroTail_eq_of_proportionalDecompositionConclusion hZero hMatch) hInjA hInjB hDecomp
+
 /-- A BNT cover hypothesis bundle produces a common MPV phase cover. -/
 theorem toMPVCommonPhaseCover
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}


### PR DESCRIPTION
## Summary

- add `CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT`
- add the zero-tail identity wrapper for normal-CF-BNT inputs
- keep the common primitive cover package tied to the existing separated normal-BNT comparison theorem

## Stack

- Base: #1221 (`codex/common-representative-bnt`)

## Related issues

- Advances #1068 and #944 by exposing the direct constructor expected once representative normal-CF-BNT data is available.
- Narrows the assembly cleanup tracker #1170.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- targeted proof-integrity scan of `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely additive Lean definitions that repackage existing hypotheses/theorems without changing existing proofs or behavior, though they may affect downstream typeclass/proof search if used.
> 
> **Overview**
> Adds `CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT`, a direct constructor that bundles normal-CF-BNT assumptions with zero-tail equality, injectivity, and `ProportionalDecompositionData`.
> 
> Adds `CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT_zeroTailIdentity`, which first obtains a `ProportionalDecompositionConclusion` via `fundamentalTheorem_of_separated_normalCFBNT_data` and then derives `zeroTailA = zeroTailB` using `zeroTail_eq_of_proportionalDecompositionConclusion` before delegating to the direct constructor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e47f47ea61cf668909e21e5db4bfd92cb005ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->