### PR TITLE
feat(MPS/CanonicalForm): expose BNT period-window separation

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -364,6 +364,28 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding
   exact exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding μ A hCF
     (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hPad
 
+/-- Canonical-form/BNT data plus period-window identity-padding certificates give one
+homogeneous pair trace-separating length for every ordered pair of distinct blocks.
+
+The BNT data supply all-words pair trace separation.  The period-window hypotheses are the
+remaining Burnside-Jacobson input needed to convert the cumulative separation data to one
+homogeneous length. -/
+theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_period_windows
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hWindow : ∀ k j : Fin r, j ≠ k → ∃ start period : ℕ, 0 < period ∧
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) period)) ∧
+      ∀ s : ℕ, s < period →
+        ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+            (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+          Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (start + s)))) :
+    ∃ T : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) T :=
+  exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows
+    A (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hWindow
+
 /-- Positive-length product-word span from canonical-form/BNT data plus a
 finite period-window identity-padding certificate for every ordered pair of
 distinct blocks.
@@ -389,8 +411,8 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_wind
       (⊤ : Submodule ℂ
         ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
   obtain ⟨T, hT⟩ :=
-    exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows
-      A (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hWindow
+    exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_period_windows
+      μ A hCF hWindow
   exact exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hT
 
 /-- Positive-length product-word span from cumulative pair trace separation plus

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -364,8 +364,8 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding
   exact exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding μ A hCF
     (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hPad
 
-/-- Canonical-form/BNT data plus period-window identity-padding certificates give one
-homogeneous pair trace-separating length for every ordered pair of distinct blocks.
+/-- Canonical-form/BNT data plus period-window identity-padding certificates give a common
+homogeneous trace-separating length for all ordered pairs of distinct blocks.
 
 The BNT data supply all-words pair trace separation.  The period-window hypotheses are the
 remaining Burnside-Jacobson input needed to convert the cumulative separation data to one


### PR DESCRIPTION
## Summary

- add `exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_period_windows`
- refactor the period-window product-span wrapper to consume that intermediate theorem
- keep the Burnside-Jacobson period/window certificate input explicit

## Stack

- Base: #1226 (`codex/bnt-period-window-product-span`)

## Related issues

- Narrows #1178 by exposing the BNT-level homogeneous pair-trace separation endpoint under finite period/window hypotheses.
- Narrows umbrella #1170.
- Still blocked on #1133 for producing the same-dimension Burnside-Jacobson period/window certificates.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

The only local warning in the target file is the pre-existing admitted unconditional theorem `exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new intermediate lemma and minor refactor in a Lean proof wrapper without changing runtime behavior or core APIs beyond an additional theorem.
> 
> **Overview**
> Adds a new theorem, `exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_period_windows`, which packages canonical-form/BNT data plus per-pair *period-window* identity-padding certificates into a single common homogeneous length `T` satisfying `PairTraceSeparatingAt` for all ordered distinct block pairs.
> 
> Refactors `exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows` to consume this new intermediate result (instead of re-deriving it inline), and expands the surrounding docstrings to clarify the Burnside–Jacobson period/window assumptions that remain explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 350348e4270318fb81936b014bba56e4d8520962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->