### PR TITLE
feat(MPS/CanonicalForm): add normal BNT overlap adapter

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -1276,14 +1276,13 @@ theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdent
     hμA hμB hTPA hTPB hPrimA hPrimB hIrrA hIrrB hAntiA hAntiB hNotGpeA hNotGpeB
     hZero hInjA hInjB hPacked.1
 
-/-- **Sector basis overlap-span data from normal-CF-BNT common primitive data,
-deriving the zero-tail identity.**
+/-- **Sector-basis overlap-span hypotheses from normal-CF-BNT common primitive data,
+with the zero-tail identity derived from length-zero proportionality.**
 
-This variant accepts already-packaged normal-CF-BNT data for the common primitive
-families, instead of rebuilding the normal form and BNT separation fields from
-lower-level trace-preserving, primitive, irreducible, strict-ordering, and
-non-equivalence hypotheses.  The proportional-decomposition data and block
-injectivity hypotheses remain explicit. -/
+Normal canonical form together with BNT separation for the common primitive
+families, proportional-decomposition data, and injectivity of the nonzero blocks
+imply the overlap-span hypotheses.  The equality of the zero tails follows from
+the length-zero proportionality relation. -/
 theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveNormalBNTData_zeroTailIdentity
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -1276,6 +1276,84 @@ theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdent
     hμA hμB hTPA hTPB hPrimA hPrimB hIrrA hIrrB hAntiA hAntiB hNotGpeA hNotGpeB
     hZero hInjA hInjB hPacked.1
 
+/-- **Sector basis overlap-span data from normal-CF-BNT common primitive data,
+deriving the zero-tail identity.**
+
+This variant accepts already-packaged normal-CF-BNT data for the common primitive
+families, instead of rebuilding the normal form and BNT separation fields from
+lower-level trace-preserving, primitive, irreducible, strict-ordering, and
+non-equivalence hypotheses.  The proportional-decomposition data and block
+injectivity hypotheses remain explicit. -/
+theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveNormalBNTData_zeroTailIdentity
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      [∀ x : Fin rA, NeZero (dimA x)]
+      [∀ x : Fin rB, NeZero (dimB x)]
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      Σ DtotA : ℕ, Σ DtotB : ℕ,
+        { _hDecomp : ProportionalDecompositionData (d := blockPhysDim d p)
+            blocksA blocksB DtotA DtotB //
+          IsNormalCanonicalFormBNT (d := blockPhysDim d p) μA blocksA ∧
+          IsNormalCanonicalFormBNT (d := blockPhysDim d p) μB blocksB ∧
+          (∀ x, IsInjective (blocksA x)) ∧
+          (∀ x, IsInjective (blocksB x)) }) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      SectorBasisOverlapSpanHypotheses P Q := by
+  refine sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
+    A B hSame hReindexed ?_
+  intro p zeroTailA zeroTailB rA rB dimA dimB _ _ μA μB blocksA blocksB hp
+    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
+    hIrrA hIrrB hDimA hDimB
+  obtain ⟨DtotA, DtotB, hPacked⟩ :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  rcases hPacked.2 with ⟨hA, hB, hInjA, hInjB⟩
+  refine ⟨DtotA, DtotB, ⟨?_⟩⟩
+  exact CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT_zeroTailIdentity
+    hA hB hZero hInjA hInjB hPacked.1
+
 /-- **Sector basis overlap-span data via a BNT proportional-decomposition comparison.**
 
 This is the proportional-comparison variant of


### PR DESCRIPTION
## Summary

- add `sectorBasisOverlapSpanHypotheses_of_commonPrimitiveNormalBNTData_zeroTailIdentity`
- let the overlap-span endpoint consume already-packaged `IsNormalCanonicalFormBNT` data directly
- keep proportional-decomposition data and block injectivity explicit; derive zero-tail equality through the #1227 constructor

## Stack

- Base: #1227 (`codex/normal-cfbnt-cover-constructor`), itself based on #1221

## Related issues

- Narrows #944 and #1068 by reducing adapter friction once representative normal-CF-BNT data are available.
- Narrows umbrella #1170.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- targeted proof-integrity scan of `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new proof-level theorem/adapter without changing existing APIs or computational behavior, but it touches a central canonical-form comparison file so breakage would show up as proof failures.
> 
> **Overview**
> Adds `sectorBasisOverlapSpanHypotheses_of_commonPrimitiveNormalBNTData_zeroTailIdentity`, an adapter theorem that lets the overlap-span endpoint consume pre-packaged `IsNormalCanonicalFormBNT` hypotheses directly.
> 
> The new theorem keeps `ProportionalDecompositionData` and block injectivity as explicit inputs, and uses `CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT_zeroTailIdentity` to *derive* the zero-tail equality from the length-zero proportionality identity before forwarding to the existing BNT-cover overlap-span pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd45b1f1b63111f9bf2a3e1b6ac03f2ec65ed02d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->