### PR TITLE
refactor(CanonicalForm): package BNT identity-padding separation

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -343,6 +343,25 @@ theorem pairTraceSeparatingAll_of_isCanonicalFormBNT
       (hCF.toHasInjectiveBlocks.block_injective j)
       hdim
 
+/-- Canonical-form/BNT data plus eventual identity padding give a common
+homogeneous trace-separating length for all ordered pairs of distinct blocks.
+
+This is the finite-maximum packaging needed after the pairwise Burnside-Jacobson
+identity-padding input has been supplied. The BNT hypotheses provide all-words
+trace separation for each pair; the generic homogenization lemma chooses one
+length that works for the whole finite block family. -/
+theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_padding
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hPad : ∀ k j : Fin r, j ≠ k → ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) n))) :
+    ∃ T : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) T :=
+  exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding
+    A (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hPad
+
 /-- Positive-length product-word span from canonical-form/BNT data plus eventual
 identity padding for every ordered pair of distinct blocks.
 
@@ -363,8 +382,10 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding
         fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
       (⊤ : Submodule ℂ
         ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
-  exact exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding μ A hCF
-    (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hPad
+  obtain ⟨T, hT⟩ :=
+    exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_padding
+      μ A hCF hPad
+  exact exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hT
 
 /-- Canonical-form/BNT data plus period-window identity-padding certificates give a common
 homogeneous trace-separating length for all ordered pairs of distinct blocks.


### PR DESCRIPTION
## Summary

- Adds `exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_padding`, packaging canonical-form/BNT data plus pairwise eventual identity padding into one homogeneous trace-separating length for all ordered distinct block pairs.
- Rewires `exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding` through this homogeneous trace-separation theorem.
- Leaves the original unconditional theorem explicit: it still depends on the missing identity-padding input tracked by #1133/#1178.

Draft because this reduces the #1178 proof boundary but does not close #1178.

Part of #1178 and #1133.

## Validation

- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant -q --log-level=info`
- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- touched-file proof-integrity scan; the existing unconditional `sorry` remains at `exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in Lean proof code that adds a small packaging lemma and reroutes an existing theorem through it; no runtime logic or APIs are affected.
> 
> **Overview**
> Adds `exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_padding`, which packages **canonical-form/BNT all-words pair trace separation** plus **pairwise eventual identity padding** into a single homogeneous length `T` working for all ordered distinct block pairs.
> 
> Refactors `exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding` to first obtain this common `T` and then reuse the existing `..._of_pairTraceSeparatingAt` path, instead of directly invoking the more general `..._of_pairTraceSeparatingAll_of_identity_padding` lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f0db34df0a9e8a31fb104fc78ab7342af76da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->