### PR TITLE
refactor(MPS/CanonicalForm): extract overlap-span comparison

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -252,6 +252,7 @@ import TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem
 import TNLean.MPS.CanonicalForm.Assembly.CommonSectorTransport
 import TNLean.MPS.CanonicalForm.Assembly.CommonPrimitiveProportionalData
 import TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison
+import TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison
 import TNLean.MPS.CanonicalForm.Assembly.CommonPrimitiveProportionalData
 import TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison
+import TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison
 import TNLean.MPS.CanonicalForm.Assembly.SectorComparisonCore
 
 /-!
@@ -45,6 +46,9 @@ The supporting modules are:
   common primitive span, phase-cover, proportional, and BNT-cover hypotheses.
 * `TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison` — basic sector
   comparisons from block-span, phase-cover, and proportional data.
+* `TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison` — overlap-span
+  hypothesis constructors from common primitive span, phase-cover, BNT-cover,
+  and proportional data.
 * `TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison` — sector comparison
   from BNT proportional-decomposition data.
 

--- a/TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean
@@ -2,67 +2,55 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison
+import TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
+
 /-!
-# Sector comparisons from common MPV phase covers
+# Sector-basis overlap-span hypotheses from common primitive data
 
-The results here give after-blocking sector-comparison consequences from finite-length span
-comparisons and common MPV phase covers, and record the special case where the cover comes from a
-BNT proportional-decomposition comparison of the nonzero-weight block families.
-
-## Main statements
-
-* `TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison` contains the basic
-  proportional-decomposition, block-span, and common-phase-cover sector comparisons.
-* `TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison` contains the
-  overlap-span hypothesis constructors from common primitive data.
-* `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover` — the
-  common-length cyclic-sector output, together with the blocked-word relabeling
-  equality and the remaining zero-tail, injectivity, and common-cover assertions,
-  implies the sector-weight comparison.
-* `afterBlocking_sectorComparison_zeroTail_of_proportionalDecompositionConclusion` —
-  the zero-tail common-cover theorem applied to BNT proportional-decomposition data.
-* `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses` —
-  the common primitive nonzero-sector theorem, followed by the remaining zero-tail,
-  injectivity, and finite-length span hypotheses.
-* `afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts` —
-  common-length cyclic-sector output with conditional finite-length block-span consequences.
-* `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional` — the
-  same relabeled common-sector output, with the common cover obtained from a BNT
-  proportional-decomposition comparison for the produced nonzero-sector families.
-* `CommonPrimitiveBNTCoverHypotheses` — bundles the BNT-level remaining hypotheses
-  (`IsNormalCanonicalForm`, `BlocksNotGaugePhaseEquiv`, `ProportionalDecompositionData`,
-  zero-tail equality, and one-site injectivity) for the common-length cyclic sector families.
-  The structure provides `.toMPVCommonPhaseCover` and `.toCommonPrimitivePhaseCoverHypotheses`
-  bridges to the common phase-cover layer.
-  See the structure docstring for the explicit mathematical gaps that remain.
+This module packages the overlap-span hypotheses produced from the common primitive
+nonzero-sector families obtained after blocked-word reindexing.  It keeps the span,
+common phase-cover, BNT-cover, explicit BNT-data, and proportional-comparison variants
+in one place, while leaving the final sector-comparison wrappers in
+`TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`.
 
 ## References
 
-* [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3 + Appendix A]
-* [Cirac–Pérez-García–Schuch–Verstraete, arXiv:2011.12127, Section IV]
+* [Cirac-Perez-Garcia-Schuch-Verstraete, arXiv:1606.00608, Section 2.3 + Appendix A]
+* [Cirac-Perez-Garcia-Schuch-Verstraete, arXiv:2011.12127, Section IV]
 
 ## Tags
 
-matrix product states, canonical form, BNT, proportional decomposition
+matrix product states, canonical form, BNT, overlap spans
 -/
 
 namespace MPSTensor
 
-/-- **Zero-tail sector comparison from common primitive nonzero-sector data.**
+/-- **Sector basis overlap-span data from common primitive nonzero-sector families.**
 
 The common primitive irreducible block theorem supplies the two nonzero-sector decompositions
 obtained after blocked-word reindexing. If the remaining zero-tail equality, one-site
-injectivity, and finite-length span equality are supplied for those same families, then the
-zero-tail block-span comparison theorem gives the sector-weight conclusion.
+injectivity, and finite-length span equality are supplied for those same families, the
+collapsed BNT representative construction produces a pair of sector decompositions satisfying
+`SectorBasisOverlapSpanHypotheses`.
 
-This theorem deliberately keeps the blocked-word reindexing equality and the final span or
-common-cover assertion as hypotheses, so it does not duplicate the separate coordinate and
-common-cover constructions. -/
-theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses
+This theorem isolates the `SectorBasisOverlapSpanHypotheses` construction used internally by
+`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`. The
+conclusion records the nonzero-block MPV agreements, the BNT linear-independence data, and
+the eleven overlap-span fields: nonzero bond dimensions, injectivity, left-canonical
+normalization, asymptotic self- and off-diagonal overlaps, and equality of the finite-length
+MPV spans of the two sector bases.
+
+The `hRemaining` function must supply `CommonPrimitiveSpanHypotheses` for the block families
+produced by `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`.
+Concretely it needs to prove equality of the two zero-tail dimensions, one-site injectivity
+of the nonzero-weight blocks, and equality of their finite-length MPV spans. The last of
+these can be supplied by a common MPV phase cover (via
+`CommonPrimitiveSpanHypotheses.of_commonPhaseCover`) or by a BNT proportional-decomposition
+comparison (via `CommonPrimitiveProportionalHypotheses.toSpanHypotheses`). -/
+theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -106,20 +94,11 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHyp
       (∀ x, 0 < dimA x) →
       (∀ x, 0 < dimB x) →
       CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB) :
-    ∃ p' : ℕ, 0 < p' ∧
-    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
-      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
       SameMPV₂ P.toTensor Q.toTensor ∧
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
-      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
-      ∃ ζ : Fin P.basisCount → ℂ,
-        (∀ j, ζ j ≠ 0) ∧
-        ∀ j : Fin P.basisCount,
-          Finset.univ.val.map (P.weight j) =
-            Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+      SectorBasisOverlapSpanHypotheses P Q := by
   obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
       rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
       hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
@@ -129,108 +108,36 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHyp
       hPrimA hPrimB hIrrA hIrrB hDimA hDimB
   letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
   letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
-  exact afterBlocking_sectorComparison_zeroTail_of_blockSpan
-    A B hSame hp μA blocksA μB blocksB hAblocks hBblocks hHyp.zeroTail_eq hTPA hTPB
-    hIrrA hIrrB hPrimA hPrimB hHyp.left_injective hHyp.right_injective
-    hμA hμB hHyp.span_eq
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
+    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      nonzeroA nonzeroB hAB hAblocks hBblocks hHyp.zeroTail_eq
+  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
+    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
+      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
+      hPrimA hPrimB hHyp.left_injective hHyp.right_injective hμA hμB hHyp.span_eq
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
+      _ = mpv nonzeroB σ := hNonzero N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  exact ⟨p, hp, P, Q, hPQeq, hPbnt, hQbnt, hOverlapSpan⟩
 
+/-- **Sector basis overlap-span data via a common MPV phase cover.**
 
-/-- **Common-length primitive irreducible sectors with conditional block-span consequences.**
-
-The structural theorem gives the common blocking length and the two primitive irreducible
-common-sector nonzero parts, conditional on the equality after relabeling blocked physical words.
-This statement records, for exactly those families, that either common MPV phase-cover data or a
-BNT proportional-decomposition conclusion supplies the finite-length block-span hypothesis used by
-`afterBlocking_sectorComparison_zeroTail_of_blockSpan`.  Thus the remaining mathematical inputs are
-kept explicit: the blocked-word relabeling equality, and the later common-phase or BNT matching
-comparison. -/
-theorem afterBlocking_commonSector_blockSpan_of_reindexedNonzeroParts
-    {d D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B)
-    (hReindexed : CommonSectorRelabelingHypothesis d) :
-    ∃ p : ℕ, 0 < p ∧
-    ∃ (zeroTailA zeroTailB : ℕ),
-    ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
-      (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)),
-    ∃ (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
-      (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)),
-      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-        mpv (blockTensor (d := d) (D := D₁) A p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) ∧
-      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-        mpv (blockTensor (d := d) (D := D₂) B p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
-      SameMPV₂Pos
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
-      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
-        (zeroTailA : ℂ) +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
-          (zeroTailB : ℂ) +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) ∧
-      (∀ x, μA x ≠ 0) ∧
-      (∀ x, μB x ≠ 0) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) ∧
-      (∀ x, IsIrreducibleTensor (blocksA x)) ∧
-      (∀ x, IsIrreducibleTensor (blocksB x)) ∧
-      (∀ x, 0 < dimA x) ∧
-      (∀ x, 0 < dimB x) ∧
-      (MPVCommonPhaseCover blocksA blocksB →
-        ∀ N,
-          Submodule.span ℂ (Set.range (fun x : Fin rA =>
-            mpvState (d := blockPhysDim d p) (blocksA x) N)) =
-          Submodule.span ℂ (Set.range (fun y : Fin rB =>
-            mpvState (d := blockPhysDim d p) (blocksB y) N))) ∧
-      (ProportionalDecompositionConclusion (d := blockPhysDim d p) blocksA blocksB →
-        ∀ N,
-          Submodule.span ℂ (Set.range (fun x : Fin rA =>
-            mpvState (d := blockPhysDim d p) (blocksA x) N)) =
-          Submodule.span ℂ (Set.range (fun y : Fin rB =>
-            mpvState (d := blockPhysDim d p) (blocksB y) N))) := by
-  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
-      rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
-      hZeroTailIdentity, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB,
-      hDimA, hDimB⟩ :=
-    afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
-      A B hSame hReindexed
-  refine ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
-    rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
-    hZeroTailIdentity, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB,
-    hDimA, hDimB, ?_, ?_⟩
-  · intro cover N
-    exact cover.span_eq N
-  · intro hMatch N
-    exact mpv_span_eq_of_proportionalDecompositionConclusion
-      (d := blockPhysDim d p) blocksA blocksB hMatch N
-
-/-- **Sector comparison from relabeled common sectors and a common phase cover.**
-
-Assume the blocked-word relabeling statement for cyclic-sector data.  Then the
-structural theorem
-`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` supplies one
-common positive blocking length and trace-preserving, primitive, irreducible
-nonzero-sector families on both sides.  If the remaining comparison assertions
-for exactly those families are available -- equality of the two zero-tail
-dimensions, injectivity at that blocking level, and a common MPV phase cover --
-then `CommonPrimitivePhaseCoverHypotheses.toSpanHypotheses` gives the span hypotheses
-needed by `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`.
-
-Thus this theorem isolates the remaining open inputs: the blocked-word relabeling
-equality, the zero-tail/injectivity refinements, and the common phase cover (or
-equivalently the finite-length span equality supplied by that cover). -/
-theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover
+This is the common-phase-cover variant of
+`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts`. Instead of requiring the
+finite-length span equality directly, it asks for a common MPV phase cover of the two
+nonzero-weight block families. The cover supplies the span equality through
+`MPVCommonPhaseCover.span_eq`. -/
+theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -274,37 +181,53 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonP
       (∀ x, 0 < dimA x) →
       (∀ x, 0 < dimB x) →
       CommonPrimitivePhaseCoverHypotheses zeroTailA zeroTailB blocksA blocksB) :
-    ∃ p' : ℕ, 0 < p' ∧
-    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
-      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
       SameMPV₂ P.toTensor Q.toTensor ∧
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
-      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
-      ∃ ζ : Fin P.basisCount → ℂ,
-        (∀ j, ζ j ≠ 0) ∧
-        ∀ j : Fin P.basisCount,
-          Finset.univ.val.map (P.weight j) =
-            Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  refine afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses
-    A B hSame hReindexed ?_
-  intro p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB hp
-    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
-    hIrrA hIrrB hDimA hDimB
-  exact (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
-    hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toSpanHypotheses
+      SectorBasisOverlapSpanHypotheses P Q := by
+  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
+      hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts A B hSame hReindexed
+  have hHyp : CommonPrimitivePhaseCoverHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  have hSpanHyp : CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hHyp.toSpanHypotheses
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
+    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      nonzeroA nonzeroB hAB hAblocks hBblocks hSpanHyp.zeroTail_eq
+  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
+    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
+      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
+      hPrimA hPrimB hSpanHyp.left_injective hSpanHyp.right_injective hμA hμB hSpanHyp.span_eq
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
+      _ = mpv nonzeroB σ := hNonzero N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  exact ⟨p, hp, P, Q, hPQeq, hPbnt, hQbnt, hOverlapSpan⟩
 
-/-- **Sector comparison from relabeled common sectors and BNT-cover data.**
+/-- **Sector basis overlap-span data via BNT-cover hypotheses.**
 
-Assume the blocked-word relabeling statement for cyclic-sector data. The structural
-theorem supplies common primitive nonzero-sector families; if those families carry
-BNT-cover data, then the conversion to phase-cover hypotheses gives the common
-phase-cover hypotheses. The common-phase-cover consumer theorem gives the same
-sector-weight comparison
-conclusion. -/
-theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
+This is the BNT-cover variant of
+`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover`.
+The remaining input provides the BNT-level data for the produced nonzero-sector
+families, with whatever total dimensions support the proportional-decomposition
+data. The conversion from BNT-cover hypotheses to common primitive phase-cover
+hypotheses then lets the common-phase-cover theorem supply the overlap-span data. -/
+theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -353,21 +276,12 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCove
         Nonempty
           (CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
             (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB)) :
-    ∃ p' : ℕ, 0 < p' ∧
-    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
-      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
       SameMPV₂ P.toTensor Q.toTensor ∧
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
-      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
-      ∃ ζ : Fin P.basisCount → ℂ,
-        (∀ j, ζ j ≠ 0) ∧
-        ∀ j : Fin P.basisCount,
-          Finset.univ.val.map (P.weight j) =
-            Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  refine afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover
+      SectorBasisOverlapSpanHypotheses P Q := by
+  refine sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover
     A B hSame hReindexed ?_
   intro p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB hp
     hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
@@ -379,18 +293,13 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCove
       hPrimA hPrimB hIrrA hIrrB hDimA hDimB
   exact hBNTCover.toCommonPrimitivePhaseCoverHypotheses
 
-/-- **Sector comparison from explicit common primitive BNT data.**
+/-- **Sector basis overlap-span data from explicit common primitive BNT data.**
 
-Assume the blocked-word relabeling statement for cyclic-sector data. The structural
-theorem supplies common primitive nonzero-sector families on both sides. If those
-families also carry the remaining BNT comparison inputs, then
-`CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData` gives the BNT-cover
-hypotheses needed by the phase-cover comparison theorem.
-
-This statement exposes the exact remaining assertions for the common primitive
-families: strict weight ordering, gauge-phase separation inside each family,
-zero-tail equality, injectivity, and proportional-decomposition data. -/
-theorem afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveBNTData
+This is the explicit-data variant of
+`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover`. It forms the
+BNT-cover hypotheses from the common primitive structural data together with the
+remaining BNT comparison inputs, then applies the BNT-cover overlap-span theorem. -/
+theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -445,21 +354,12 @@ theorem afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveBNTData
           zeroTailA = zeroTailB ∧
           (∀ x, IsInjective (blocksA x)) ∧
           (∀ x, IsInjective (blocksB x)) }) :
-    ∃ p' : ℕ, 0 < p' ∧
-    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
-      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
       SameMPV₂ P.toTensor Q.toTensor ∧
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
-      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
-      ∃ ζ : Fin P.basisCount → ℂ,
-        (∀ j, ζ j ≠ 0) ∧
-        ∀ j : Fin P.basisCount,
-          Finset.univ.val.map (P.weight j) =
-            Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  refine afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
+      SectorBasisOverlapSpanHypotheses P Q := by
+  refine sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
     A B hSame hReindexed ?_
   intro p zeroTailA zeroTailB rA rB dimA dimB _ _ μA μB blocksA blocksB hp
     hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
@@ -474,14 +374,94 @@ theorem afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveBNTData
     hμA hμB hTPA hTPB hPrimA hPrimB hIrrA hIrrB hAntiA hAntiB hNotGpeA hNotGpeB
     hZeroTail hInjA hInjB hPacked.1
 
-/-- **Sector comparison from normal-CF-BNT common primitive data.**
+/-- **Sector basis overlap-span data from explicit common primitive BNT data,
+deriving the zero-tail identity.**
 
-Assume the blocked-word relabeling statement for cyclic-sector data.  If the common primitive
-families supplied by the structural theorem are already in normal canonical form with BNT
-separation, and if they also carry proportional-decomposition data and one-site injectivity,
-then the zero-tail sector comparison follows.  The zero-tail equality is derived from the
-length-zero identity and the proportional comparison. -/
-theorem afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveNormalBNTData_zeroTailIdentity
+This variant of `sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData`
+removes the explicit zero-tail equality from the remaining data. The identity is
+derived from the length-zero MPV equality and proportional-decomposition data. -/
+theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdentity
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      [∀ x : Fin rA, NeZero (dimA x)]
+      [∀ x : Fin rB, NeZero (dimB x)]
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      Σ DtotA : ℕ, Σ DtotB : ℕ,
+        { _hDecomp : ProportionalDecompositionData (d := blockPhysDim d p)
+            blocksA blocksB DtotA DtotB //
+          StrictAnti (fun x : Fin rA => ‖μA x‖) ∧
+          StrictAnti (fun x : Fin rB => ‖μB x‖) ∧
+          BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksA ∧
+          BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) blocksB ∧
+          (∀ x, IsInjective (blocksA x)) ∧
+          (∀ x, IsInjective (blocksB x)) }) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      SectorBasisOverlapSpanHypotheses P Q := by
+  refine sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
+    A B hSame hReindexed ?_
+  intro p zeroTailA zeroTailB rA rB dimA dimB _ _ μA μB blocksA blocksB hp
+    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
+    hIrrA hIrrB hDimA hDimB
+  obtain ⟨DtotA, DtotB, hPacked⟩ :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  rcases hPacked.2 with
+    ⟨hAntiA, hAntiB, hNotGpeA, hNotGpeB, hInjA, hInjB⟩
+  refine ⟨DtotA, DtotB, ⟨?_⟩⟩
+  exact CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData_zeroTailIdentity
+    hμA hμB hTPA hTPB hPrimA hPrimB hIrrA hIrrB hAntiA hAntiB hNotGpeA hNotGpeB
+    hZero hInjA hInjB hPacked.1
+
+/-- **Sector-basis overlap-span hypotheses from normal-CF-BNT common primitive data,
+with the zero-tail identity derived from length-zero proportionality.**
+
+Normal canonical form together with BNT separation for the common primitive
+families, proportional-decomposition data, and injectivity of the nonzero blocks
+imply the overlap-span hypotheses.  The equality of the zero tails follows from
+the length-zero proportionality relation. -/
+theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveNormalBNTData_zeroTailIdentity
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -533,21 +513,12 @@ theorem afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveNormalBNTData_
           IsNormalCanonicalFormBNT (d := blockPhysDim d p) μB blocksB ∧
           (∀ x, IsInjective (blocksA x)) ∧
           (∀ x, IsInjective (blocksB x)) }) :
-    ∃ p' : ℕ, 0 < p' ∧
-    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
-      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
       SameMPV₂ P.toTensor Q.toTensor ∧
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
-      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
-      ∃ ζ : Fin P.basisCount → ℂ,
-        (∀ j, ζ j ≠ 0) ∧
-        ∀ j : Fin P.basisCount,
-          Finset.univ.val.map (P.weight j) =
-            Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  refine afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
+      SectorBasisOverlapSpanHypotheses P Q := by
+  refine sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
     A B hSame hReindexed ?_
   intro p zeroTailA zeroTailB rA rB dimA dimB _ _ μA μB blocksA blocksB hp
     hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
@@ -560,22 +531,13 @@ theorem afterBlocking_sectorComparison_zeroTail_of_commonPrimitiveNormalBNTData_
   exact CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT_zeroTailIdentity
     hA hB hZero hInjA hInjB hPacked.1
 
-/-- **Sector comparison from relabeled common sectors and proportional-decomposition data.**
+/-- **Sector basis overlap-span data via a BNT proportional-decomposition comparison.**
 
-Assume the blocked-word relabeling statement for cyclic-sector data.  Then the
-structural theorem
-`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` supplies one
-common positive blocking length and trace-preserving, primitive, irreducible
-nonzero-sector families on both sides.  If the remaining comparison assertions
-for exactly those families are available -- equality of the two zero-tail
-dimensions, injectivity at that blocking level, and a BNT proportional-decomposition
-comparison -- then `CommonPrimitiveProportionalHypotheses.toPhaseCoverHypotheses` gives
-the common MPV phase-cover hypotheses needed by
-`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover`.
-
-Thus this theorem exposes the BNT comparison as a precise conditional input for the
-common-sector families, without assuming a finite-length span equality separately. -/
-theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional
+This is the proportional-comparison variant of
+`sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts`. A BNT proportional-decomposition
+conclusion for the two nonzero-weight block families gives a common MPV phase cover, hence the
+finite-length span equality needed by the collapsed BNT representative construction. -/
+theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_proportional
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -619,26 +581,42 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proport
       (∀ x, 0 < dimA x) →
       (∀ x, 0 < dimB x) →
       CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB) :
-    ∃ p' : ℕ, 0 < p' ∧
-    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
-      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
       SameMPV₂ P.toTensor Q.toTensor ∧
       HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
-      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
-      ∃ ζ : Fin P.basisCount → ℂ,
-        (∀ j, ζ j ≠ 0) ∧
-        ∀ j : Fin P.basisCount,
-          Finset.univ.val.map (P.weight j) =
-            Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  refine afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover
-    A B hSame hReindexed ?_
-  intro p zeroTailA zeroTailB rA rB dimA dimB μA μB blocksA blocksB hp
-    hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB hPrimA hPrimB
-    hIrrA hIrrB hDimA hDimB
-  exact (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
-    hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toPhaseCoverHypotheses
+      SectorBasisOverlapSpanHypotheses P Q := by
+  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
+      hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts A B hSame hReindexed
+  have hHyp : CommonPrimitiveProportionalHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  have hSpanHyp : CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hHyp.toSpanHypotheses
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
+                      (blockTensor (d := d) (D := D₂) B p) :=
+    sameMPV₂_blockTensor A B hSame p
+  have hNonzero : SameMPV₂ nonzeroA nonzeroB :=
+    sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p)
+      nonzeroA nonzeroB hAB hAblocks hBblocks hSpanHyp.zeroTail_eq
+  obtain ⟨P, Q, hPblocks, hQblocks, hPbnt, hQbnt, hOverlapSpan⟩ :=
+    exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
+      (d := blockPhysDim d p) μA blocksA μB blocksB hTPA hTPB hIrrA hIrrB
+      hPrimA hPrimB hSpanHyp.left_injective hSpanHyp.right_injective hμA hμB hSpanHyp.span_eq
+  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
+    intro N σ
+    calc
+      mpv P.toTensor σ = mpv nonzeroA σ := hPblocks N σ
+      _ = mpv nonzeroB σ := hNonzero N σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  exact ⟨p, hp, P, Q, hPQeq, hPbnt, hQbnt, hOverlapSpan⟩
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean
@@ -10,10 +10,10 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 /-!
 # Sector-basis overlap-span hypotheses from common primitive data
 
-This module packages the overlap-span hypotheses produced from the common primitive
-nonzero-sector families obtained after blocked-word reindexing.  It keeps the span,
+This module collects the overlap-span hypotheses produced from the common primitive
+nonzero-sector families obtained after blocked-word reindexing. It keeps the span,
 common phase-cover, BNT-cover, explicit BNT-data, and proportional-comparison variants
-in one place, while leaving the final sector-comparison wrappers in
+in one place, while leaving the final sector-comparison reformulations in
 `TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison`.
 
 ## References


### PR DESCRIPTION
## Summary

- extract the `sectorBasisOverlapSpanHypotheses_*` common-primitive overlap-span constructors into `Assembly.OverlapSpanComparison`
- keep `Assembly.ProportionalComparison` as the importing compatibility surface for the final sector-comparison wrappers
- add the new module to the assembly entry point and root import

Line-count impact:
- `Assembly/ProportionalComparison.lean`: 1236 -> 645 lines
- new `Assembly/OverlapSpanComparison.lean`: 622 lines

This is a move-only refactor of existing declarations and proof bodies; no mathematical statements or hypotheses change.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison TNLean.MPS.CanonicalForm.Assembly -q --log-level=info`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- touched-file proof-placeholder scan: no proof placeholders in moved declarations; only existing prose/comment hits (`admit` in an English sentence, `axioms` in the root entropy comment)

Refs #334

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily moves existing Lean theorems into a new module and adjusts imports/re-exports; no changes to mathematical statements are intended. Main risk is import/path churn causing downstream breakage if any moved names or dependencies were missed.
> 
> **Overview**
> Extracts the `sectorBasisOverlapSpanHypotheses_*` overlap-span hypothesis constructors out of `Assembly/ProportionalComparison.lean` into a new `Assembly/OverlapSpanComparison.lean` module, leaving `ProportionalComparison` focused on the final sector-comparison wrappers.
> 
> Updates the public import surfaces (`TNLean.lean` and `CanonicalForm/Assembly.lean`) to include `OverlapSpanComparison` and switches `ProportionalComparison` to import it, significantly shrinking `ProportionalComparison` while preserving the same API via re-exported declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aed6f14776a7280538ebed42ca431e1fccdd508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->