### PR TITLE
ci(github): skip linter autofix build when Claude is disabled

### DIFF
--- a/.github/workflows/lean-linter-warning-autofix.yml
+++ b/.github/workflows/lean-linter-warning-autofix.yml
@@ -48,16 +48,32 @@ jobs:
             exit 1
           fi
 
+      - name: Check write-mode kill switch
+        id: write_mode
+        env:
+          CREATE_PR: ${{ inputs.create_pr }}
+          CLAUDE_AUTO_FIX_ENABLED: ${{ vars.CLAUDE_AUTO_FIX_ENABLED }}
+        run: |
+          set -euo pipefail
+          if [ "$CREATE_PR" = "true" ] && [ "$CLAUDE_AUTO_FIX_ENABLED" = "false" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "CLAUDE_AUTO_FIX_ENABLED=false; skipping before Lean setup/build." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Lean toolchain and cache
+        if: steps.write_mode.outputs.skip != 'true'
         uses: ./.github/actions/setup-lean
 
       - name: Set up Python for warning summary
-        if: always()
+        if: always() && steps.write_mode.outputs.skip != 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Run Lean build and capture warnings
+        if: steps.write_mode.outputs.skip != 'true'
         id: build
         continue-on-error: true
         run: |
@@ -70,7 +86,7 @@ jobs:
 
       - name: Summarize linter warnings
         id: warnings
-        if: always()
+        if: always() && steps.write_mode.outputs.skip != 'true'
         env:
           REPORT_PREFIX: ${{ runner.temp }}/lean-linter-warning-autofix
         run: |
@@ -82,6 +98,7 @@ jobs:
             --count-output "$GITHUB_OUTPUT"
 
       - name: Check Claude token availability
+        if: steps.write_mode.outputs.skip != 'true'
         id: claude_token
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -94,6 +111,7 @@ jobs:
           fi
 
       - name: Decide whether to run auto-fix
+        if: steps.write_mode.outputs.skip != 'true'
         id: decide
         env:
           BUILD_OUTCOME: ${{ steps.build.outcome }}
@@ -316,7 +334,7 @@ jobs:
           echo "Opened $pr_url" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload auto-fix warning report
-        if: always()
+        if: always() && steps.write_mode.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: lean-linter-warning-autofix-report
@@ -327,7 +345,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Fail if Lean build failed
-        if: steps.build.outcome != 'success'
+        if: steps.write_mode.outputs.skip != 'true' && steps.build.outcome != 'success'
         run: |
           echo "The initial Lean build failed; inspect the uploaded log before running linter auto-fix."
           exit 1

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -403,7 +403,7 @@ provider or mention handler.
 
 | Variable | Disabled workflows |
 |----------|--------------------|
-| `CLAUDE_AUTO_FIX_ENABLED=false` | `auto-fix.yml` and manual PR creation in `lean-linter-warning-autofix.yml` |
+| `CLAUDE_AUTO_FIX_ENABLED=false` | `auto-fix.yml`; write-mode linter auto-fix skips before Lean setup/build |
 | `CLAUDE_REVIEW_ENABLED=false` | `claude-code-review.yml`, `blueprint-prose-review.yml`, `pr-cleanup.yml`, and `tracking-issue-sync.yml` |
 | `CODEX_AUTO_FIX_ENABLED=false` | `auto-fix-codex.yml` |
 | `CODEX_MENTION_ENABLED=false` | `codex.yml` (`@chatgpt` mention handler) |


### PR DESCRIPTION
## Summary

- Add an early write-mode guard to `lean-linter-warning-autofix.yml`.
- When `create_pr=true` and `CLAUDE_AUTO_FIX_ENABLED=false`, the workflow now skips before Lean setup/build.
- Update the CI automation docs to describe this behavior.

## Notes

This addresses the current skip-before-build part of #1246 for the remaining manual linter auto-fix path. The broader automatic quota-detection and timed re-enable behavior would need separate stateful workflow work.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lean-linter-warning-autofix.yml"); puts "ok"'`
- `git diff --check`

Closes #1246

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions step conditions and documentation, changing when the workflow exits early without affecting runtime code or build outputs.
> 
> **Overview**
> Adds an early **write-mode kill switch** to `lean-linter-warning-autofix.yml`: when `create_pr=true` and `CLAUDE_AUTO_FIX_ENABLED=false`, the workflow now exits before Lean/Python setup, the build, warning parsing, artifact upload, and failure gating.
> 
> Updates `docs/ci-automation.md` to reflect that `CLAUDE_AUTO_FIX_ENABLED=false` also disables the write-mode linter auto-fix path (skipping before setup/build).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4978e92528dbc89355e316b7ea048051e2a63175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->