### PR TITLE
doc(paper-gaps): compare BNT inputs to source papers

### DIFF
--- a/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
@@ -7,186 +7,246 @@
 
 \input{docs/paper-gaps/command}
 
-\title{Homogeneous Pair Separation and Common BNT Comparison\\
-in the Non-periodic MPS Fundamental Theorem}
+\title{BNT Comparison Inputs in the Non-periodic MPS Fundamental Theorem}
 \author{}
 \date{2026-05-05}
 
 \begin{document}
 \maketitle
 
-\section{Scope}
+\section{The source theorem}
 
-This note records two comparison inputs in the non-periodic matrix product
-state fundamental theorem: homogeneous pair-word separation for BNT blocks, and
-common BNT comparison data for the after-blocking sector reduction.  It concerns
-the proof chain used for the non-periodic theorem in the
-matrix-product-density-operator setting of
-\cite[Section~II and Appendix~A]{Cirac2016MPDO_arXiv} and the survey account in
-\cite[Section~IV.C]{Cirac2021Matrix}.  It does not concern the periodic
-irreducible theorem of \cite{DeLasCuevas2017Irreducible}, except insofar as
-similar finite-length span questions reappear in the non-periodic reduction.
+The non-periodic matrix product vector Fundamental Theorem in
+\cite{Cirac2016MPDO_arXiv,Cirac2017MPDO_AnnPhys,Cirac2021Matrix} is a theorem
+about tensors already put in canonical form. The comparison is not stated as a
+theorem about arbitrary block-diagonal data plus unrelated finite-length
+hypotheses. The finite-length hypotheses appearing in the formal development
+are markers for source arguments which still have to be connected to the current
+formal canonical-form construction.
 
-The point at issue is not the shape of the final theorem, but the finite-length
-inputs used on the way to it.  The current formal development has made several
-consumer theorems conditional on explicit finite-length or phase-cover data.
-This is the right state while the corresponding producer theorems are still
-being proved.  The remaining issues should be closed only when the producer
-theorem, the consumer theorem, and the documented mathematical source all state
-the same assertion.
+The source matrix product vectors are indexed by positive lengths.  The 2016
+paper defines \( |V^{(N)}(A)\rangle \) for \(N=1,2,\ldots\) and compares
+families at those lengths \cite[lines~130--151]{Cirac2016MPDO_arXiv}.  Thus a
+formal comparison relation that also includes the empty word is slightly
+stronger than the relation appearing in the paper.  The length-zero term is a
+formal convention that must be handled separately when zero blocks or cumulative
+spans are present.
 
-The live proof issues covered here are \ghissue{1133}, \ghissue{1178},
-\ghissue{1068}, and \ghissue{944}, with \ghissue{1170} as the main tracker.
-The draft pull requests \ghpr{1233} and \ghpr{1237} isolate two of these
-boundaries; they do not close the corresponding mathematical issues.
+The first source step removes invariant subspaces. Starting from a tensor
+\(B\), the 2016 paper replaces it by block-diagonal matrices
+\[
+  A^i=\bigoplus_{k=1}^r \mu_k A_k^i
+\]
+which generate the same positive-length matrix product vectors
+\cite[lines~214--225]{Cirac2016MPDO_arXiv}. Each block is then treated through
+its completely positive map. Periodic peripheral eigenvalues are removed by
+blocking a common multiple of their periods
+\cite[lines~227--231]{Cirac2016MPDO_arXiv}. After that blocking, the blocks are
+normal in the sense used in the paper, and the tensor is in canonical form
+\cite[lines~233--255]{Cirac2016MPDO_arXiv}. The review gives the same
+description: block diagonalization, period-removing blocking, primitive
+transfer maps, and the resulting canonical form
+\cite[lines~1793--1839]{Cirac2021Matrix}.
 
-\section{Homogeneous Pair Identity Padding}
+The next source step chooses a basis of normal tensors. In the 2016 paper, a
+basis of normal tensors \(A_1,\ldots,A_g\) is a family of normal tensors whose
+matrix product vectors span the matrix product vectors of \(A\) at each length
+and are eventually linearly independent
+\cite[lines~271--274]{Cirac2016MPDO_arXiv}. Proposition
+\texttt{prop:char-BNT} characterizes such bases by phase-gauge equivalence and
+minimality: every normal block in the canonical form is a phase times an
+invertible conjugate of one selected basis tensor, and no two selected basis
+tensors are related in that way
+\cite[lines~278--280]{Cirac2016MPDO_arXiv}. The review repeats the same
+definition and characterization
+\cite[lines~1846--1859]{Cirac2021Matrix}.
 
-Issue \ghissue{1133} is the finite-length homogenization problem for the pair
-word algebra.  In mathematical terms, one starts from a cumulative full-span
-statement for the pair representation associated to two tensor families \(A\)
-and \(B\).  The consumer theorem needs more than the assertion that the identity
-pair belongs to a cumulative span.  It needs homogeneous identity-padding
-witnesses in all sufficiently large lengths, or equivalently a positive period
-and a complete residue window.
+For a tensor in canonical form, the source then writes the matrix product vector
+family through the basis of normal tensors as
+\[
+  |V^{(N)}(A)\rangle
+    = \sum_{j=1}^g
+        \left(\sum_{q=1}^{r_j}\mu_{j,q}^N\right)
+        |V^{(N)}(A_j)\rangle.
+\]
+This is the data that have to be compared between two tensors in the equal or
+proportional case
+\cite[lines~283--302]{Cirac2016MPDO_arXiv};
+\cite[lines~1864--1885]{Cirac2021Matrix}.
 
-The formal consumer is the trace-separation theorem for non-gauge-phase
-equivalent tensors.\footnote{The main consumer is
-\path{pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv}
-in \doclink{TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization}.  The explicit
-period-window boundary currently appears as
-\path{exists_pairIdentity_mem_pairWordTupleSpan_padding_window_of_%
-pairCumulativeWordTupleSpanTop}.}
-The corrected boundary asks for a positive integer period and a full residue
-window of homogeneous witnesses for the identity pair.  This is the
-Burnside--Jacobson input that turns cumulative full span into the finite-length
-identity padding used by the trace-separation argument.
+The Fundamental Theorem itself says that, for two tensors \(A\) and \(B\) in
+canonical form, proportionality of all matrix product vector families matches
+their bases of normal tensors up to a permutation, phases, and invertible gauge
+matrices
+\cite[lines~347--352]{Cirac2016MPDO_arXiv};
+\cite[lines~1890--1900]{Cirac2021Matrix}. In the equal case, the source then
+compares the coefficients in the BNT decompositions by the power-sum identity
+\[
+  \sum_{q=1}^{r_{a,j}}\mu_{j,q}^N
+  =
+  \sum_{q=1}^{r_{b,j}}(\nu_{j,q}e^{i\phi_j})^N
+\]
+for each matched basis tensor and all lengths \(N\). The elementary power-sum
+lemma recovers the multiplicities and weights, and the blockwise gauges assemble
+into the global conjugating matrix
+\cite[lines~1155--1192]{Cirac2016MPDO_arXiv}.
 
-The following stronger implication is false and must not be used:
-membership of \((1,1)\) in a cumulative pair-word span does not imply membership
-of \((1,1)\) in every later homogeneous pair-word span.  The cumulative span
-includes the empty word.  Thus \((1,1)\) already lies in the cumulative span in
-length \(0\) for every pair of tensor families.  If this alone implied
-homogeneous membership in length \(1\), then the one-letter pair span would
-always contain \((1,1)\).  This fails for the one-dimensional example with one
-physical letter and \(A_0=B_0=0\), where the length-one pair span is generated by
-\((0,0)\).
+\section{What Wielandt supplies}
 
-Consequently the correct proof issue is not to extract padding from the
-empty-word occurrence of the identity.  It is to prove, from the full pair-word
-algebra hypothesis, a genuine eventual or periodic homogeneous padding theorem.
+There are two different blocking operations in the source account. The
+period-removing blocking makes the transfer maps primitive. The Wielandt
+blocking supplies finite-length injectivity after normality is available. These
+steps should not be merged.
 
-\section{BNT Trace Separation}
+For one normal tensor, the quantum Wielandt theorem is cited as saying that
+after at most \(D^4\) blockings the tensor becomes injective
+\cite[line~332]{Cirac2016MPDO_arXiv}. The older canonical-form paper defines
+injectivity by the map
+\[
+  \Gamma_L(X)
+    =
+    \sum_{i_1,\ldots,i_L}
+      \operatorname{tr}(X A_{i_1}\cdots A_{i_L})
+      |i_1,\ldots,i_L\rangle,
+\]
+and observes that injectivity of \(\Gamma_L\) is equivalent to the length-\(L\)
+word products spanning the whole matrix algebra
+\cite[lines~888--908]{PerezGarcia2007MPSReps}. Thus the relevant conclusion is
+a homogeneous fixed-length span statement after a positive blocking length, not
+mere membership in a cumulative span. The 2021 review records a sharper
+MPS-specific Wielandt bound for normal tensors
+\cite[lines~1942--1945]{Cirac2021Matrix}; the formal issue here is the nature
+of the conclusion, not which numerical bound is ultimately used.
 
-Issue \ghissue{1178} concerns trace separation for basis-normal-triangular
-families.  The unconditional theorem sought there says that distinct BNT blocks
-admit a finite-length trace-separating word family.  The current conditional
-route is mathematically appropriate: if the pair families have the homogeneous
-identity-padding windows described above, then the pair trace-separation theorem
-can be applied uniformly to the BNT blocks.\footnote{The unconditional theorem
-is \path{exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT} in
-\doclink{TNLean/MPS/CanonicalForm/BlockDiagonalCommutant}.  The conditional
-period-window variant is
-\path{exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_%
-identity_period_windows}.}
+For several basis blocks, the paper needs block-injective canonical form. It
+defines this as the statement that one common physical tensor spans every block
+matrix simultaneously:
+\[
+  \bigl(A_1^i,\ldots,A_g^i\bigr)_i
+  \quad\text{spans}\quad
+  \bigoplus_{j=1}^g M_{D_j}(\mathbb C)
+\]
+after the appropriate blocking
+\cite[lines~317--332]{Cirac2016MPDO_arXiv}. The source then cites the
+P\'erez-Garc\'ia--Verstraete--Wolf--Cirac bound: if \(L\) is a length at which
+each normal tensor is injective, then after \(3(L+1)(D-1)\) blockings the
+canonical-form tensor is block-injective; together with \(L\le D^4\), this gives
+the \(3D^5\) bound
+\cite[lines~340--345]{Cirac2016MPDO_arXiv}. The review states the same
+block-injective conclusion and bound
+\cite[lines~2114--2124]{Cirac2021Matrix}.
 
-The issue remains downstream of \ghissue{1133}.  It should not be closed by
-restating the BNT theorem with an implicit padding assumption; that would only
-move the same mathematical input under another name.  It can be closed when the
-BNT hypotheses themselves, together with the relevant finite-dimensional span
-theory, produce the required homogeneous windows or an equivalent
-trace-separation statement.
+This block-injective conclusion is stronger than separate injectivity of the
+individual blocks. It includes the cross-block separation needed to prescribe
+different matrices in different BNT components at one common length. In dual
+form, it says that if
+\[
+  \sum_{j=1}^g \operatorname{tr}(\Delta_j A_j^w)=0
+\]
+for every word \(w\) of that common length, then every \(\Delta_j\) is zero.
+That is the trace-separation form currently used in the formal non-periodic
+proof. In the later MPDO argument the same source explicitly writes
+\(C_L(V)=\operatorname{span}(V^L)\) and invokes the block-injective proposition
+to obtain \(C_L(V)=\mathcal A_1\) for some fixed \(L\)
+\cite[lines~1984--1988]{Cirac2016MPDO_arXiv}. This is again an exact-length
+span statement.
 
-\section{Common Phase Covers and Overlap Spans}
+\section{The homogeneous padding point}
 
-Issues \ghissue{1068} and \ghissue{944} concern the producer side of the
-after-blocking theorem.  The consumer side now accepts common phase-cover data,
-proportional-decomposition data, or BNT-cover data and turns these into the
-sector overlap-span hypotheses needed for the non-periodic fundamental theorem.
-Those consumer theorems are not the remaining obstruction.
+The paper-level injectivity and block-injectivity conclusions are homogeneous:
+they concern words of a specified positive length after blocking. They are not
+consequences of the empty word lying in a cumulative word span.
 
-The first remaining producer theorem is the construction of a common MPV phase
-cover from common-length cyclic-sector data.\footnote{The main data structures
-and conversions are in
-\doclink{TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData},
-\doclink{TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison},
-\doclink{TNLean/MPS/CanonicalForm/Assembly/BasicSectorComparison}, and
-\doclink{TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison}.}
-The current obstruction is that flattening all cyclic sectors does not preserve
-the strict ordering of weights: sectors from the same original block have the
-same transported weight.  A faithful producer theorem should therefore choose
-or construct representative data, prove the strict comparison for those
-representatives, and transport the resulting phase-cover or proportional data
-back to the common-block formulation.
+This distinction matters for the pair representation used in the formal
+comparison proof. A cumulative span includes the empty word. Therefore the
+identity pair belongs to a cumulative span at length zero for every pair of
+tensors. That fact gives no positive-length padding. For example, over a
+one-letter alphabet with \(A_0=B_0=0\) in bond dimension one, the length-one
+pair span is generated by the zero pair, while the identity pair appears at
+length zero. Hence the implication from cumulative identity membership to
+identity membership in all later homogeneous spans is false.
 
-The second remaining producer theorem is the derivation of the
-sector-basis overlap-span hypotheses for the representatives produced by the
-BNT construction.\footnote{The target structure is
-\leanid{SectorBasisOverlapSpanHypotheses} in
-\doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition}.}
-This includes nonzero dimensions, injectivity, normalization, asymptotic
-self-overlap, asymptotic off-overlap, and finite-length span equality.  A proof
-of only one or two of these fields should update the issue, but it should not
-close it unless the full structure is derived or the remaining fields are
-replaced by documented hypotheses in the theorem statement.
+The correct missing theorem is instead a genuine homogenization theorem. Under
+the full pair-algebra hypotheses relevant to distinct BNT blocks, one must
+produce a positive period and a complete residue window, or an equivalent
+eventual homogeneous identity-padding statement. Such a theorem would match
+the role played by block-injective fixed-length span in the source proof. It
+would not be a formal restatement of the empty-word observation.
 
-\section{Criteria for Closing the Proof Issues}
+\section{Comparison data after common blocking}
 
-Every remaining proof boundary in this part of the theorem should have a
-separate mathematical issue.  The issue should state the theorem that consumes
-the missing input, the exact mathematical assertion still unavailable, the cited
-source passage, and the current formal declaration that marks the boundary.  If
-the tempting stronger statement is false, the issue should record the
-counterexample before any subsequent reformulation is attempted.
+The equal-case source proof compares BNT decompositions after the canonical form
+has been chosen. The formal after-blocking theorem reaches this situation
+through a longer route: remove the zero tail, choose one common physical
+blocking length for both tensors, reindex nested blocked words against flat
+words, separate period removal from later injectivity blocking, and then compare
+the resulting nonzero sector families.
 
-The formal statement at the boundary should be a true mathematical assertion,
-even if it is still unproved.  A statement that merely makes later declarations
-compile is not acceptable when it asserts an implication not justified by the
-paper.  In particular, finite-length homogeneous span membership should not be
-derived from cumulative membership without an explicit homogenization argument.
-The empty word is often already present in the cumulative span, and therefore
-does not by itself carry any positive-length padding information.
+The common-blocking issue is mathematical rather than clerical. If a block has
+period-removal length \(m_k\) and the final common length is \(p=m_ke_k\), the
+tensor obtained by blocking first by \(m_k\) and then by \(e_k\) has nested
+physical labels, whereas the tensor obtained by blocking once by \(p\) has flat
+word labels. Paper notation treats these identifications silently; the formal
+theorem must prove the reindexing statements.
 
-The closing test for a proof issue has four parts.  First, the boundary
-declaration has no placeholder proof.  Second, every downstream theorem that
-claimed the result conditionally has either been specialized by the new producer
-or has remained explicitly conditional for a mathematical reason.  Third, the
-blueprint statement and the corresponding paper-gap note describe the same
-mathematical assertion.  Fourth, the issue comment closing the matter identifies
-the theorem, the commit, and the verification command used at the new boundary.
+The BNT comparison data should therefore be produced for the final nonzero
+sector families after all chosen blockings and reindexings. In source terms,
+this means the proof must construct the matched basis tensors, the phase-gauge
+equivalences, and the power-sum comparison for exactly those families. In
+formal terms, common phase covers, proportional-decomposition data, and
+sector-basis overlap-span hypotheses are acceptable intermediate statements
+only when they are tied to that final mathematical object.
 
-Tracking issues should not be closed merely because a conditional theorem was
-isolated.  The tracker is closed only when all of its named proof leaves have
-either been proved or deliberately reclassified as separate mathematical
-hypotheses with documented source comparison.
+\section{Current formal boundary}
 
-\section{Relation to Existing Notes}
+The current Lean development has conditional theorems at the following
+mathematical boundaries.
 
-This note is not meant to replace the more specific paper-gap notes already in
-this directory.  The note on the conditional after-blocking theorem compares the
-formal after-blocking statement with the CPSV argument and records the remaining
-injectivity, BNT-cover, and transport inputs.\footnote{%
-\path{docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex}.}
-The common-blocking note records the common blocking and finite-length span
-equality questions.\footnote{%
-\path{docs/paper-gaps/mps_common_blocking_span_equality.tex}.}
-The block-separation note records the finite-length separation input related to
-Proposition~IV.3 of \cite{Cirac2021Matrix}.\footnote{%
-\path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.}
+\begin{itemize}
+  \item Homogeneous pair identity padding is still a producer theorem. The
+  consumer theorem may assume a period and residue window, but the proof must
+  ultimately derive it from the pair-algebra hypotheses, not from cumulative
+  length-zero membership.
 
-The role of the present note is to connect those local notes to the live proof
-issues and to state which theorem boundaries are allowed while the missing
-producer theorems remain open.
+  \item BNT trace separation is still a producer theorem in the unconditional
+  form. A conditional theorem using homogeneous identity-padding windows is a
+  faithful boundary, but it is not the source theorem by itself.
 
-\section{Conclusion}
+  \item Common phase-cover and proportional-decomposition data are still
+  producer data for the final common nonzero sector families. The source proof
+  obtains these from BNT matching and power-sum comparison; the formal proof
+  should not replace that step by unrelated assumptions without saying so.
 
-The non-periodic theorem should proceed through exact mathematical boundaries:
-homogeneous pair identity padding from full pair-word span, trace separation for
-BNT blocks from that padding input, and common phase-cover or overlap-span data
-from the after-blocking sector construction.  The current conditional theorems
-are acceptable only because they expose these inputs explicitly.  They are not
-substitutes for the producer theorems needed to close \ghissue{1133},
-\ghissue{1178}, \ghissue{1068}, or \ghissue{944}.
+  \item Sector-basis overlap-span hypotheses still have to be derived for the
+  representatives on which the final comparison theorem is applied. Single
+  fields such as nonzero dimensions or injectivity do not close the whole
+  comparison unless the remaining fields are proved or explicitly retained as
+  hypotheses.
+\end{itemize}
+
+For traceability, these are the mathematical contents behind
+\ghissue{1133}, \ghissue{1178}, \ghissue{1068}, and \ghissue{944}, with
+\ghissue{1170} tracking the larger non-periodic proof. The issue numbers are
+not part of the mathematical statement; they record where the remaining producer
+theorems are being followed.
+
+\section{Closing criterion}
+
+A proof issue in this part of the theorem should be closed only when the
+following three assertions agree.
+
+First, the source assertion has been identified at the level of the mathematical
+objects above: canonical form, basis of normal tensors, block-injective
+fixed-length span, phase-gauge BNT matching, or power-sum comparison. Second,
+the formal theorem proved in Lean states the same assertion for the same blocked
+and reindexed families, or explicitly records the extra hypothesis that remains.
+Third, the downstream comparison theorem uses the newly proved producer rather
+than an unrelated assumption with a similar shape.
+
+Conditional theorems are useful because they expose the missing mathematical
+inputs precisely. They should not be described as closing the source theorem
+until the corresponding producer theorem has been proved or the final theorem is
+deliberately restated with that hypothesis.
 
 \bibliographystyle{alpha}
 \bibliography{docs/paper-gaps/references}


### PR DESCRIPTION
## Summary

Rewrites `docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex` so the note is organized around the source-paper mathematics rather than around issue numbers.

The note now compares the formal boundaries against:

- the positive-length MPV convention in the 2016 MPDO paper,
- canonical form and BNT characterization after period-removing blocking,
- BNT expansion and the equal-case power-sum comparison,
- Wielandt/block-injective fixed-length span statements and the `3D^5` block-injective bound,
- the exact-length nature of the needed homogeneous padding and trace-separation inputs.

It keeps the GitHub issue references only as traceability for the remaining producer theorems.

## Validation

- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex`
- `git diff --check`

Fixes the readability/source-comparison problem in the proof-gap note added by #1248. Tracks #1133, #1178, #1068, #944, and #1170.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only rewrite; risk is limited to potential confusion if citations/wording misrepresent the source-paper arguments, but no code paths change.
> 
> **Overview**
> Rewrites `docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex` to organize the note around the *source-paper proof structure* (canonical form, BNT basis/expansion, power-sum comparison, Wielandt/block-injective fixed-length spans) rather than around GitHub issue-specific sections.
> 
> Clarifies that key missing inputs in the formalization are **positive-length / fixed-length homogeneous span** statements (not cumulative/empty-word membership), and reframes the remaining Lean “boundary” assumptions (identity-padding windows, BNT trace separation, post-blocking comparison data) as producer theorems that must be tied to the final blocked/reindexed sector families; issue references are retained only for traceability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec536bf3e4bc844f37255a33e7d0522ac821b8f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->