### PR TITLE
doc(Wielandt): state cumulative bound data mathematically

### DIFF
--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -8,7 +8,7 @@ import TNLean.Wielandt.RankOne.Products
 import TNLean.Wielandt.SpanGrowth.EigenvectorSpreading
 
 /-!
-# Quantum Wielandt Bound - cumulative span chain
+# Quantum Wielandt bound: cumulative span consequences
 
 This file collects the main results of the quantum Wielandt bound
 from arXiv:0909.5347 (Sanz, Pérez-García, Wolf, Cirac).
@@ -20,9 +20,9 @@ For a primitive quantum channel `E_A` on `M_D(ℂ)` with `d` Kraus operators:
 
 where `i(A) = min{n : S_n(A) = M_D(ℂ)}` (the "full Kraus rank index").
 
-## Our results
+## Formalized statements
 
-We formalize the proof chain up to the following:
+This file records the cumulative-span part of the Wielandt argument:
 
 1. **Cumulative span reaches ⊤**: Under `IsNormal`, `T_{D²}(A) = M_D(ℂ)`
    (`cumulativeSpan_eq_top` from `NonzeroTraceProduct.lean`)
@@ -38,11 +38,11 @@ We formalize the proof chain up to the following:
 4. **Eigenvector spreading**: The cumulative vector span reaches ⊤ in D-1 steps
    (`eigenvector_spreading` from `EigenvectorSpreading.lean`)
 
-5. **Cumulative conclusion**: connecting these pieces into the cumulative span bound.
+5. **Cumulative conclusion**: these facts imply the cumulative span bound.
 
 The fixed-length matrix-spanning form of Lemma 2(b) is obtained by continuing
-this chain with rank-one extraction and exact word-length padding. The results
-below record the cumulative span and eigenvector-spreading part of the argument.
+with rank-one extraction and exact word-length padding. The results below record
+the cumulative span and eigenvector-spreading part of the argument.
 
 ## References
 
@@ -57,17 +57,18 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ## Part 1: The complete eigenvalue extraction chain
+/-! ## Part 1: Eigenvalue extraction data
 
-Given `IsNormal A`, the chain is:
+For a normal tensor, the following data are available:
 1. `cumulativeSpan A (D²) = ⊤` (from NonzeroTraceProduct)
 2. `∃ w₀, |w₀| ≤ D² ∧ tr(evalWord A w₀) ≠ 0` (from NonzeroTraceProduct)
 3. `∃ μ ≠ 0, ∃ φ ≠ 0, evalWord A w₀ *ᵥ φ = μ • φ` (from RankOneProducts)
 4. `cumulativeVectorSpan A φ (D-1) = ⊤` (from EigenvectorSpreading)
 
-These are combined into a single "analysis" structure. -/
+These facts are combined into a single analysis structure. -/
 
-/-- **Wielandt Analysis**: the complete chain of facts about a normal MPS tensor.
+/-- Wielandt analysis data for a normal MPS tensor.
+
 Given `IsNormal A`, we extract:
 - A word `w₀` of bounded length with nonzero trace
 - A nonzero eigenvalue `μ` and eigenvector `φ`
@@ -91,7 +92,7 @@ structure WielandtAnalysis [NeZero D] (A : MPSTensor d D) where
   /-- Eigenvector equation: `evalWord A w₀ *ᵥ φ = μ • φ`. -/
   heig : evalWord A w₀ *ᵥ φ = μ • φ
 
-/-- **Every normal MPS tensor admits a Wielandt analysis.**
+/-- Every normal MPS tensor admits Wielandt analysis data.
 
 This combines Lemma 1 (`exists_nonzero_trace_word`) with eigenvalue extraction
 (`exists_eigenvector_of_trace_ne_zero`) to produce the complete analysis
@@ -141,8 +142,8 @@ theorem vector_spanning_from_normality [NeZero D]
 
 The exact fixed-length paper bound is proved in
 `TNLean.Wielandt.PaperResults.WielandtInequality` using the matrix-span and
-rank-one extraction modules. The results below record the older cumulative
-normality route used by that proof chain.
+rank-one extraction modules. The results below record the cumulative normality
+consequences.
 
 ### What we prove:
 - `cumulative_wielandt_bound`: T_{D²}(A) = ⊤ for normal tensors

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -20,23 +20,19 @@ For a primitive quantum channel `E_A` on `M_D(ℂ)` with `d` Kraus operators:
 
 where `i(A) = min{n : S_n(A) = M_D(ℂ)}` (the "full Kraus rank index").
 
-## Formalized statements
+## Cumulative-span consequences
 
-This file records the cumulative-span part of the Wielandt argument:
+Normality gives the following cumulative-span data:
 
 1. **Cumulative span reaches ⊤**: Under `IsNormal`, `T_{D²}(A) = M_D(ℂ)`
-   (`cumulativeSpan_eq_top` from `NonzeroTraceProduct.lean`)
 
 2. **Nonzero trace product exists**: Under `IsNormal`, ∃ word `w₀` of length
    ≤ D² with `tr(evalWord A w₀) ≠ 0`
-   (`exists_nonzero_trace_word` from `NonzeroTraceProduct.lean`)
 
 3. **Eigenvalue/eigenvector extraction**: A matrix with nonzero trace has a
    nonzero eigenvalue and eigenvector
-   (`exists_eigenvector_of_trace_ne_zero` from `RankOneProducts.lean`)
 
 4. **Eigenvector spreading**: The cumulative vector span reaches ⊤ in D-1 steps
-   (`eigenvector_spreading` from `EigenvectorSpreading.lean`)
 
 5. **Cumulative conclusion**: these facts imply the cumulative span bound.
 
@@ -60,10 +56,10 @@ variable {d D : ℕ}
 /-! ## Part 1: Eigenvalue extraction data
 
 For a normal tensor, the following data are available:
-1. `cumulativeSpan A (D²) = ⊤` (from NonzeroTraceProduct)
-2. `∃ w₀, |w₀| ≤ D² ∧ tr(evalWord A w₀) ≠ 0` (from NonzeroTraceProduct)
-3. `∃ μ ≠ 0, ∃ φ ≠ 0, evalWord A w₀ *ᵥ φ = μ • φ` (from RankOneProducts)
-4. `cumulativeVectorSpan A φ (D-1) = ⊤` (from EigenvectorSpreading)
+1. `cumulativeSpan A (D²) = ⊤`
+2. `∃ w₀, |w₀| ≤ D² ∧ tr(evalWord A w₀) ≠ 0`
+3. `∃ μ ≠ 0, ∃ φ ≠ 0, evalWord A w₀ *ᵥ φ = μ • φ`
+4. `cumulativeVectorSpan A φ (D-1) = ⊤`
 
 These facts are combined into a single analysis structure. -/
 
@@ -140,10 +136,9 @@ theorem vector_spanning_from_normality [NeZero D]
 
 /-! ## Part 3: Wielandt bound - main statements
 
-The exact fixed-length paper bound is proved in
-`TNLean.Wielandt.PaperResults.WielandtInequality` using the matrix-span and
-rank-one extraction modules. The results below record the cumulative normality
-consequences.
+The fixed-length inequality additionally requires rank-one extraction and exact
+word-length padding. The cumulative statements below supply the
+normality-to-spanning input for that fixed-length passage.
 
 ### What we prove:
 - `cumulative_wielandt_bound`: T_{D²}(A) = ⊤ for normal tensors
@@ -151,8 +146,8 @@ consequences.
   via cumulative span
 
 ### Fixed-length passage:
-The conversion from vector spanning to fixed-length matrix spanning is formalized
-by the Lemma 2(b) results in `TNLean.Wielandt.PaperResults.MatrixSpanSharpBound`.
+The conversion from vector spanning to fixed-length matrix spanning is the
+Lemma 2(b) passage from the paper.
 -/
 
 /-- **Cumulative Wielandt bound**: Under `IsNormal`, the cumulative word


### PR DESCRIPTION
## Summary

- Rephrases `WielandtBound.lean` module prose around the cumulative-span part of the Wielandt argument.
- Removes proof-chain/status wording while keeping formal declarations unchanged.

Part of #1170.

## Validation

- `lake env lean TNLean/Wielandt/WielandtBound.lean`
- `lake build TNLean.Wielandt.WielandtBound -q --log-level=info`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits in `WielandtBound.lean`; no changes to theorem statements or proofs, so behavioral risk is minimal.
> 
> **Overview**
> Updates `TNLean/Wielandt/WielandtBound.lean` module/section docstrings to reframe the results as **cumulative-span consequences** of normality (tightening wording, headings, and references) without changing any definitions, theorem statements, or proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2371b6251cc87ed6c84d132aa3eff2eb13deab59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->