### PR TITLE
feat(MPS/CanonicalForm): package reindexed overlap orthogonality

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean
@@ -28,6 +28,56 @@ matrix product states, canonical form, BNT, overlap spans
 
 namespace MPSTensor
 
+/-- **One-sided BNT overlap-orthogonality data from reindexed nonzero sectors.**
+
+The common primitive irreducible block theorem supplies the final nonzero-sector
+families after the chosen blocking and blocked-word reindexing. Applying the
+phase-class BNT construction separately to the two families gives sector bases
+with positive dimensions, left-canonical normalization, self-overlap limit `1`,
+and off-overlap limit `0` for distinct representatives.
+
+This theorem deliberately stops before the two-family finite-length span
+comparison and one-site injectivity inputs. Those are the remaining data needed
+to upgrade the one-sided overlap-orthogonality hypotheses to
+`SectorBasisOverlapSpanHypotheses`. -/
+theorem sectorBasisOverlapOrthoHypotheses_of_reindexedNonzeroParts
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hReindexed : CommonSectorRelabelingHypothesis d) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p) P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p) Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      SectorBasisOverlapOrthoHypotheses P ∧
+      SectorBasisOverlapOrthoHypotheses Q := by
+  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB, _hAblocks, _hBblocks, hAPos, hBPos, _hNonzeroPos,
+      _hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts A B hSame hReindexed
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  let nonzeroA := toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA
+  let nonzeroB := toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB
+  obtain ⟨P, hPblocks, hPbnt, hPOrtho, _hPInj_of⟩ :=
+    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
+      (d := blockPhysDim d p) μA blocksA hTPA hIrrA hPrimA hμA
+  obtain ⟨Q, hQblocks, hQbnt, hQOrtho, _hQInj_of⟩ :=
+    exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
+      (d := blockPhysDim d p) μB blocksB hTPB hIrrB hPrimB hμB
+  have hAP : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p) P.toTensor := by
+    intro N hN σ
+    calc
+      mpv (blockTensor (d := d) (D := D₁) A p) σ = mpv nonzeroA σ := hAPos N hN σ
+      _ = mpv P.toTensor σ := (hPblocks N σ).symm
+  have hBQ : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p) Q.toTensor := by
+    intro N hN σ
+    calc
+      mpv (blockTensor (d := d) (D := D₂) B p) σ = mpv nonzeroB σ := hBPos N hN σ
+      _ = mpv Q.toTensor σ := (hQblocks N σ).symm
+  exact ⟨p, hp, P, Q, hAP, hBQ, hPbnt, hQbnt, hPOrtho, hQOrtho⟩
+
 /-- **Sector basis overlap-span data from common primitive nonzero-sector families.**
 
 The common primitive irreducible block theorem supplies the two nonzero-sector decompositions

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1506,6 +1506,29 @@ two-basis sector comparison theorem.
 	hypotheses. The preceding theorem supplies the common MPV phase cover.
 \end{proof}
 
+\begin{theorem}[Reindexed sectors give single-family overlap data]%
+\label{thm:sector_basis_overlap_ortho_reindexed}
+	\lean{MPSTensor.sectorBasisOverlapOrthoHypotheses_of_reindexedNonzeroParts}
+	\leanok
+	\uses{def:common_sector_relabeling_hypothesis,
+		def:sector_basis_overlap_ortho_hyps}
+	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
+	identification hypothesis for the cyclic-sector data. After the common
+	blocking and reindexing, each nonzero-sector family admits a BNT sector
+	decomposition with positive-length MPV agreement, BNT data, and the
+	single-family overlap-orthogonality hypotheses.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed,
+		thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_ortho}
+	The common primitive reindexing theorem produces trace-preserving,
+	primitive, irreducible nonzero-sector families with positive dimensions.
+	Apply the one-sided phase-class BNT construction separately to the two
+	families.
+\end{proof}
+
 \begin{theorem}[Phase-cover data give overlap-span hypotheses]%
 \label{thm:sector_basis_overlap_span_reindexed_commonPhaseCover}
 	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover}


### PR DESCRIPTION
## Summary
- add `sectorBasisOverlapOrthoHypotheses_of_reindexedNonzeroParts`
- package the final reindexed nonzero-sector families into BNT sector decompositions with one-sided overlap-orthogonality data
- keep injectivity and finite-length span equality explicit for later `SectorBasisOverlapSpanHypotheses` upgrades
- add the matching blueprint entry in Chapter 11

## Validation
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison -q --log-level=info` (passed with existing long-line warnings replayed in other files)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

Refs #944, #1068, #1170

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean theorem and corresponding blueprint documentation without changing existing proof behavior or APIs beyond exposing an extra lemma.
> 
> **Overview**
> Adds `MPSTensor.sectorBasisOverlapOrthoHypotheses_of_reindexedNonzeroParts`, packaging the post-blocking/reindexed nonzero-sector families into BNT `SectorDecomposition`s that each satisfy one-sided `SectorBasisOverlapOrthoHypotheses`, while **intentionally** leaving injectivity and two-family span comparison as separate later inputs.
> 
> Updates Chapter 11 of the blueprint with a matching theorem statement and proof sketch referencing the new Lean result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5485eb72d6a27bb50fa5f90849cab2595b0b81cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->