### PR TITLE
refactor(MPS/CanonicalForm): remove stale BNT separation sorry

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -226,25 +226,6 @@ theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_ide
       pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
         (A k) (A j) hST (hSep k j hjk) (hPad k j hjk))
 
-/-- Homogeneous pair trace separation for all distinct BNT block pairs.
-
-For a finite BNT family, trace functionals separating distinct ordered block
-pairs at homogeneous lengths can be chosen with one common length. The
-conclusion asserts simultaneous homogeneous pair trace separation for every
-ordered pair of distinct blocks, which is the pair-separation input for the
-product-word span theorem. -/
-theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT
-    {r : ℕ} {dim : Fin r → ℕ}
-    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
-    (hCF : IsCanonicalFormBNT μ A) :
-    ∃ T : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) T := by
-  classical
-  have hInj := hCF.toHasInjectiveBlocks
-  have hLeft := hCF.toIsLeftCanonicalBlockFamily
-  have hNot := hCF.blocks_not_equiv
-  -- Pairwise homogeneous separation is combined over the finite ordered-pair set.
-  sorry
-
 /-- Positive-length product-word span from canonical-form/BNT data and
 pairwise block-separating word polynomials. -/
 theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords


### PR DESCRIPTION
## Summary
- remove the unsupported unconditional BNT homogeneous pair-trace separation theorem from `BlockDiagonalCommutant`
- keep the conditional identity-padding and period-window endpoints, where the paper-level hypotheses are explicit
- leave #1178/#1133 as open proof-production work rather than exposing a stale `sorry`-backed API

## Validation
- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only removes an unproven (`sorry`-backed) theorem and does not change any proven logic; impact is limited to downstream code that depended on the removed API.
> 
> **Overview**
> Removes the unconditional theorem `exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT` from `BlockDiagonalCommutant.lean`, which was left with a `sorry` and implicitly promised homogeneous pair trace separation without the remaining Burnside–Jacobson padding assumptions.
> 
> Keeps the supported, *hypothesis-explicit* endpoints (e.g. identity-padding / period-window packaging lemmas) as the intended route for obtaining common homogeneous separation lengths and subsequent product-word span results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96338cc7ac088c43d55a08c22b1de19e4fe438a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->