### PR TITLE
feat(MPS/CanonicalForm): package representative BNT cover data

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
@@ -261,6 +261,58 @@ structure CommonPrimitiveBNTCoverHypotheses
   decompData : ProportionalDecompositionData (d := blockPhysDim d p)
     blocksA blocksB DtotA DtotB
 
+/-- BNT-cover inputs for representative common-sector families.
+
+The common cyclic-sector family can contain several sectors from the same original block with
+the same transported weight.  This structure collects the representative-sector hypotheses:
+one representative per original nonzero block, strict ordering of the representative weights,
+BNT separation among representatives, the length-zero identity for the representative nonzero
+parts, one-site injectivity, and proportional decomposition data for the two representative
+families. -/
+structure CommonRepresentativeBNTCoverHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {blocksA : (k : Fin rA) → MPSTensor d (dimA k)}
+    {blocksB : (k : Fin rB) → MPSTensor d (dimB k)}
+    (FA : CommonBlockedCyclicSectorFamily blocksA)
+    (FB : CommonBlockedCyclicSectorFamily blocksB)
+    (hpA : FA.p = p) (hpB : FB.p = p)
+    [∀ k, NeZero (FA.commonRepresentativeDim k)]
+    [∀ k, NeZero (FB.commonRepresentativeDim k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    (μA : Fin rA → ℂ) (μB : Fin rB → ℂ) : Type where
+  /-- The original left nonzero-sector weights are nonzero. -/
+  left_weight_ne_zero : ∀ k, μA k ≠ 0
+  /-- The original right nonzero-sector weights are nonzero. -/
+  right_weight_ne_zero : ∀ k, μB k ≠ 0
+  /-- The transported left representative weights are strictly ordered by norm. -/
+  left_weight_strict_anti :
+    StrictAnti (fun k : Fin rA => ‖FA.commonRepresentativeWeight μA k‖)
+  /-- The transported right representative weights are strictly ordered by norm. -/
+  right_weight_strict_anti :
+    StrictAnti (fun k : Fin rB => ‖FB.commonRepresentativeWeight μB k‖)
+  /-- Distinct left representatives are not gauge-phase equivalent. -/
+  notGpeA :
+    BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) (FA.commonRepresentativeBlocksAt hpA)
+  /-- Distinct right representatives are not gauge-phase equivalent. -/
+  notGpeB :
+    BlocksNotGaugePhaseEquiv (d := blockPhysDim d p) (FB.commonRepresentativeBlocksAt hpB)
+  /-- The length-zero identity for the representative nonzero parts. -/
+  zero_length_identity : ∀ σ : Fin 0 → Fin (blockPhysDim d p),
+    (zeroTailA : ℂ) +
+        mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := FA.commonRepresentativeWeight μA) (FA.commonRepresentativeBlocksAt hpA)) σ =
+      (zeroTailB : ℂ) +
+        mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := FB.commonRepresentativeWeight μB) (FB.commonRepresentativeBlocksAt hpB)) σ
+  /-- The left representative common-sector blocks are one-site injective. -/
+  left_injective : ∀ k, IsInjective (FA.commonRepresentativeBlocksAt hpA k)
+  /-- The right representative common-sector blocks are one-site injective. -/
+  right_injective : ∀ k, IsInjective (FB.commonRepresentativeBlocksAt hpB k)
+  /-- Proportional decomposition data linking the two representative families. -/
+  decompData : ProportionalDecompositionData (d := blockPhysDim d p)
+    (FA.commonRepresentativeBlocksAt hpA)
+    (FB.commonRepresentativeBlocksAt hpB) DtotA DtotB
+
 namespace CommonPrimitiveBNTCoverHypotheses
 
 /-- Form `CommonPrimitiveBNTCoverHypotheses` from common primitive structural data
@@ -414,7 +466,7 @@ def ofNormalCanonicalFormBNT_zeroTailIdentity
   exact ofNormalCanonicalFormBNT hA hB
     (zeroTail_eq_of_proportionalDecompositionConclusion hZero hMatch) hInjA hInjB hDecomp
 
-/-- Representative common-sector families give the BNT-cover hypothesis bundle once the
+/-- Representative common-sector families give the BNT-cover hypotheses once the
 representative weights are strictly ordered, representatives are BNT-separated, and the
 remaining zero-tail, injectivity, and proportional-decomposition inputs are supplied. -/
 noncomputable def ofCommonRepresentatives_zeroTailIdentity
@@ -462,7 +514,35 @@ noncomputable def ofCommonRepresentatives_zeroTailIdentity
       FB hpB μB hμB hAntiB hNotGpeB)
     hZero hInjA hInjB hDecomp
 
-/-- A BNT cover hypothesis bundle produces a common MPV phase cover. -/
+/-- Representative BNT-cover data convert to the primitive BNT-cover hypotheses for the
+representative common-sector families. -/
+noncomputable def ofCommonRepresentativeBNTCoverHypotheses
+    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {blocksA : (k : Fin rA) → MPSTensor d (dimA k)}
+    {blocksB : (k : Fin rB) → MPSTensor d (dimB k)}
+    (FA : CommonBlockedCyclicSectorFamily blocksA)
+    (FB : CommonBlockedCyclicSectorFamily blocksB)
+    (hpA : FA.p = p) (hpB : FB.p = p)
+    [∀ k, NeZero (FA.commonRepresentativeDim k)]
+    [∀ k, NeZero (FB.commonRepresentativeDim k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    (μA : Fin rA → ℂ) (μB : Fin rB → ℂ)
+    (h : CommonRepresentativeBNTCoverHypotheses (zeroTailA := zeroTailA)
+      (zeroTailB := zeroTailB) (DtotA := DtotA) (DtotB := DtotB)
+      FA FB hpA hpB μA μB) :
+    CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB)
+      (FA.commonRepresentativeWeight μA) (FB.commonRepresentativeWeight μB)
+      (FA.commonRepresentativeBlocksAt hpA)
+      (FB.commonRepresentativeBlocksAt hpB) :=
+  ofCommonRepresentatives_zeroTailIdentity
+    FA FB hpA hpB μA μB
+    h.left_weight_ne_zero h.right_weight_ne_zero
+    h.left_weight_strict_anti h.right_weight_strict_anti
+    h.notGpeA h.notGpeB
+    h.zero_length_identity h.left_injective h.right_injective h.decompData
+
+/-- BNT-cover hypotheses produce a common MPV phase cover. -/
 theorem toMPVCommonPhaseCover
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -477,7 +557,7 @@ theorem toMPVCommonPhaseCover
     (d := blockPhysDim d p) blocksA blocksB
     h.ncfA h.notGpeA h.ncfB h.notGpeB h.decompData
 
-/-- A BNT cover hypothesis bundle produces the common primitive phase-cover hypotheses. -/
+/-- BNT-cover hypotheses produce the common primitive phase-cover hypotheses. -/
 theorem toCommonPrimitivePhaseCoverHypotheses
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1452,8 +1452,10 @@ two-basis sector comparison theorem.
 \begin{definition}[BNT-cover hypotheses for common primitive sectors]%
 \label{def:common_primitive_bnt_cover_hypotheses}
 	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses,
+		MPSTensor.CommonRepresentativeBNTCoverHypotheses,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData_zeroTailIdentity,
+		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentativeBNTCoverHypotheses,
 		MPSTensor.zeroTail_eq_of_proportionalDecompositionConclusion}
 	\leanok
 	\uses{def:is_normal_canonical_form, def:blocks_not_gauge_phase_equiv,
@@ -1467,7 +1469,9 @@ two-basis sector comparison theorem.
 	canonical-form data, together with the remaining conditions above, they yield the
 	BNT-cover hypotheses. The length-zero identity and the proportional matching
 	identify the zero-tail dimensions, so this equality need not be supplied
-	separately once the proportional data are present.
+	separately once the proportional data are present. For common cyclic sectors,
+	the same condition is stated on the representative or grouped sector family,
+	where the strict ordering and BNT-separation hypotheses are meaningful.
 \end{definition}
 
 \begin{theorem}[BNT-cover hypotheses produce a common phase cover]%


### PR DESCRIPTION
## Summary
- add `CommonRepresentativeBNTCoverHypotheses` for representative common-sector BNT-cover inputs
- add a conversion from the representative bundle to `CommonPrimitiveBNTCoverHypotheses`
- update Ch. 11 blueprint text so the BNT-cover boundary is stated on representative/grouped sectors, not raw flattened cyclic sectors

This is a source-facing packaging slice for #1068/#944. It does not claim the missing proportional producer; it names the representative data that producer must supply.

## Validation
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `rg -n "\bsorry\b|\baxiom\b" TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean || true`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new hypothesis bundle and a new conversion helper that will affect downstream Lean interfaces and typeclass expectations, though it doesn’t change core comparison theorems.
> 
> **Overview**
> Adds a new Lean structure `CommonRepresentativeBNTCoverHypotheses` to bundle the BNT-cover assumptions specifically for *representative/grouped* common-sector families (strict ordering on representative weights, representative-level non-GPE separation, length-zero identity, injectivity, and proportional-decomposition data).
> 
> Introduces `CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentativeBNTCoverHypotheses`, a conversion that turns the representative bundle into the existing `CommonPrimitiveBNTCoverHypotheses` over `commonRepresentativeBlocksAt/Weight`, and updates the Chapter 11 blueprint definition to reference this representative-level boundary (plus minor wording fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3206e2f61bcc274db7651b518a8ee97dedf8ef79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->