### PR TITLE
fix(MPS/MPDO): require period window for pair homogenization

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -1277,43 +1277,31 @@ theorem exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop
   · exact pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window
       A B hperiod_pos hperiod hwindow
 
-/-- Burnside–Jacobson identity padding for injective, non-gauge-equivalent
-same-dimension blocks.
-
-For injective tensors whose simultaneous pair algebra is the full product
-algebra, the pair identity `(1, 1)` belongs to the homogeneous pair-word span at
-every sufficiently large length. -/
-theorem pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv
-    {d D : ℕ} [NeZero D]
-    (A B : MPSTensor d D)
-    (hA_inj : IsInjective A) (hB_inj : IsInjective B)
-    (hNot : ¬ GaugePhaseEquiv A B) :
-    ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
-      ((1 : Matrix (Fin D) (Fin D) ℂ), (1 : Matrix (Fin D) (Fin D) ℂ)) ∈
-        Submodule.span ℂ (Set.range (pairWordTuple A B n)) := by
-  sorry
-
-/-- Homogeneous pair trace separation from BNT non-equivalence.
+/-- Homogeneous pair trace separation from same-dimension BNT non-equivalence
+and a homogeneous identity-padding period window.
 
 For injective same-dimension tensors satisfying the left-canonical
-normalization hypotheses and not gauge-phase equivalent, the pair trace
-functionals separate at some fixed homogeneous length. Burnside-Jacobson
-identity padding converts cumulative separation into separation at one word
-length. -/
-theorem exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv
+normalization hypotheses and not gauge-phase equivalent, the simultaneous pair
+words are trace-separating over all finite lengths.  A period-window of full
+homogeneous pair spans supplies the identity padding needed to convert that
+all-length separation into one homogeneous trace-separating length. -/
+theorem exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv_of_pairWordTupleSpanTop_period_window
     {d D : ℕ} [NeZero D]
     (A B : MPSTensor d D)
     (hA_inj : IsInjective A) (hB_inj : IsInjective B)
     (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
-    (hNot : ¬ GaugePhaseEquiv A B) :
+    (hNot : ¬ GaugePhaseEquiv A B)
+    {start period : ℕ} (hperiod_pos : 0 < period)
+    (hperiod : PairWordTupleSpanTop A B period)
+    (hwindow : ∀ r : ℕ, r < period → PairWordTupleSpanTop A B (start + r)) :
     ∃ T : ℕ, PairTraceSeparatingAt A B T := by
   apply exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding
   · have hSepAll : PairTraceSeparatingAll A B :=
       pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv
         A B hA_inj hB_inj hA_norm hB_norm hNot
     exact (pairAllWordsSpanTop_iff_pairTraceSeparatingAll A B).2 hSepAll
-  · exact pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv
-      A B hA_inj hB_inj hNot
+  · exact pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window
+      A B hperiod_pos hperiod hwindow
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3153,6 +3153,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows}
     \lean{MPSTensor.pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv_cast_left}
+    \lean{MPSTensor.exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv_of_pairWordTupleSpanTop_period_window}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop_period_window}
     \leanok
     \uses{def:pair_trace_separation_words, lem:all_length_pair_trace_separation_finite_cutoff}


### PR DESCRIPTION
## Summary
- remove the unsupported same-dimension identity-padding theorem from injectivity plus non-gauge-equivalence alone
- replace the same-dimension homogeneous trace-separation endpoint with an explicit homogeneous period-window hypothesis
- add the replacement theorem to Ch. 14 blueprint tags

This follows the paper-source boundary for #1133/#1178: fixed-length/homogeneous padding must be supplied by a genuine period-window or block-injective-span producer, not inferred from cumulative/all-word fullness or the empty word.

## Validation
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv|exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv(\\b|[^_])|\\bsorry\\b|\\baxiom\\b" TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean` (no hits)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes theorem statements/assumptions in the pair homogenization proof pipeline, which may break downstream lemmas relying on the previous (stronger) non-equivalence→padding implication. Logical risk is moderate but scoped to the MPDO pair-trace separation/homogenization layer and blueprint references.
> 
> **Overview**
> Removes the (previously unproven/unsupported) lemma `pairIdentity_mem_pairWordTupleSpan_eventually_of_not_gaugePhaseEquiv` that attempted to derive eventual homogeneous identity padding from injectivity plus `¬ GaugePhaseEquiv` alone.
> 
> Updates the same-dimension homogenization endpoint by replacing `exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv` with `exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv_of_pairWordTupleSpanTop_period_window`, which now *requires* a `start/period` window of `PairWordTupleSpanTop` hypotheses to supply identity padding.
> 
> Updates Chapter 14 blueprint Lean tags to reference the new theorem name/signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97c3256215cc63433968ae5a0052fbb2862b0571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->