### PR TITLE
doc(blueprint): tag representative BNT cover adapter

### DIFF
--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1454,6 +1454,7 @@ two-basis sector comparison theorem.
 	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData_zeroTailIdentity,
+		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentatives_zeroTailIdentity,
 		MPSTensor.zeroTail_eq_of_proportionalDecompositionConclusion}
 	\leanok
 	\uses{def:is_normal_canonical_form, def:blocks_not_gauge_phase_equiv,


### PR DESCRIPTION
## Summary

- adds the existing representative-sector zero-tail adapter to the Ch11 BNT-cover hypothesis `\lean{}` tag list
- keeps the note conditional: this only records the already-proved adapter and does not claim the missing producer theorem

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that only updates a `\lean{}` tag list; no proofs or logic are modified.
> 
> **Overview**
> Adds `MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentatives_zeroTailIdentity` to the `\lean{}` tag list for the Chapter 11 definition `CommonPrimitiveBNTCoverHypotheses`, making the blueprint explicitly reference the already-proved representative-sector zero-tail adapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a50c1ded5ff18d15bfe8b50b7ff17782cefef6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->