### PR TITLE
doc(blueprint): tag representative zero-tail adapter

### DIFF
--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1455,6 +1455,7 @@ two-basis sector comparison theorem.
 		MPSTensor.CommonRepresentativeBNTCoverHypotheses,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonPrimitiveData_zeroTailIdentity,
+		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentatives_zeroTailIdentity,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentativeBNTCoverHypotheses,
 		MPSTensor.zeroTail_eq_of_proportionalDecompositionConclusion}
 	\leanok


### PR DESCRIPTION
## Summary

- tag `MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentatives_zeroTailIdentity` in the BNT-cover blueprint entry
- reapply the narrow follow-up from the closed #1267 after #1264 landed on `main`

This records the already-formalized representative-to-primitive zero-tail adapter. It does not claim to supply the still-missing fixed-length comparison producer for #1068/#944/#1133.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, documentation-only change that adds a missing `\lean{...}` reference; no Lean code or logic is modified.
> 
> **Overview**
> Updates the blueprint entry for `BNT-cover hypotheses for common primitive sectors` to include the missing `\lean{}` tag `MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentatives_zeroTailIdentity`, so the representative-to-primitive zero-tail adapter is tracked in the rendered documentation/sync tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2498cc3ddf918f33768b4e600edd99d545fb7699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->