### PR TITLE
feat(MPS/CanonicalForm): transport representative sector data

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
@@ -50,6 +50,18 @@ theorem commonRepresentativeWeight_ne_zero (F : CommonBlockedCyclicSectorFamily 
     F.commonRepresentativeWeight μ k ≠ 0 :=
   F.commonBlockWeight_ne_zero μ hμ k
 
+/-- Strict ordering by weight norm is preserved when passing to representative
+common-sector weights. -/
+theorem commonRepresentativeWeight_strictAnti_of_weight_strictAnti
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    (μ : Fin r → ℂ)
+    (hAnti : StrictAnti (fun k : Fin r => ‖μ k‖)) :
+    StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖) := by
+  intro k l hkl
+  have hpow : ‖μ l‖ ^ F.p < ‖μ k‖ ^ F.p :=
+    pow_lt_pow_left₀ (hAnti hkl) (norm_nonneg (μ l)) (Nat.ne_of_gt F.p_pos)
+  simpa [commonRepresentativeWeight, norm_pow] using hpow
+
 /-- The representative common-sector family is trace-preserving. -/
 theorem commonRepresentativeBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) :
@@ -72,6 +84,34 @@ theorem commonRepresentativeBlocks_irreducible (F : CommonBlockedCyclicSectorFam
     (k : Fin r) : IsIrreducibleTensor (F.commonRepresentativeBlocks k) := by
   simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
     F.commonSectorBlock_irreducible k ⟨0, F.period_pos k⟩
+
+/-- The representative common-sector family is trace-preserving at a prescribed
+common blocking length. -/
+theorem commonRepresentativeBlocksAt_tp (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p') (k : Fin r) :
+    ∑ i : Fin (blockPhysDim d p'),
+      (F.commonRepresentativeBlocksAt hp k i)ᴴ *
+        F.commonRepresentativeBlocksAt hp k i = 1 := by
+  subst p'
+  simpa [commonRepresentativeBlocksAt] using F.commonRepresentativeBlocks_tp k
+
+/-- The representative common-sector family has primitive transfer maps at a
+prescribed common blocking length. -/
+theorem commonRepresentativeBlocksAt_primitive (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p') (k : Fin r) :
+    _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d p') (D := F.commonRepresentativeDim k)
+        (F.commonRepresentativeBlocksAt hp k)) := by
+  subst p'
+  simpa [commonRepresentativeBlocksAt] using F.commonRepresentativeBlocks_primitive k
+
+/-- The representative common-sector family is tensor-irreducible at a prescribed
+common blocking length. -/
+theorem commonRepresentativeBlocksAt_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p') (k : Fin r) :
+    IsIrreducibleTensor (F.commonRepresentativeBlocksAt hp k) := by
+  subst p'
+  simpa [commonRepresentativeBlocksAt] using F.commonRepresentativeBlocks_irreducible k
 
 /-- The representative common-sector family has positive bond dimensions. -/
 theorem commonRepresentativeDim_pos (F : CommonBlockedCyclicSectorFamily blocks)

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
@@ -223,19 +223,14 @@ The structural theorem
 `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
 supplies trace-preserving, primitive, tensor-irreducible block families
 with nonzero weights and positive bond dimensions at a common blocking
-length.  The four fields below are the additional BNT hypotheses needed
+length.  The fields below record the additional BNT hypotheses needed
 to compare the two families and obtain a common MPV phase cover.
 
-The remaining mathematical tasks are:
-1. Verify `IsNormalCanonicalForm` for the produced block families
-   (requires ordering the weights by decreasing modulus).
-2. Verify `BlocksNotGaugePhaseEquiv` for the cyclic-sector block families
-   (follows from the fact that distinct cyclic sectors carry
-   distinct peripheral eigenvalues and therefore cannot be
-   gauge-phase equivalent).
-3. Construct `ProportionalDecompositionData` from the `SameMPV₂`
-   equality of the two nonzero parts, which is available from the
-   structural theorem and the zero-tail identity. -/
+For non-periodic tensors, the comparison is applied after choosing one
+representative for each group of common cyclic sectors with the same transported
+weight. On that representative family one can impose strict ordering, BNT
+separation, and proportional block matching without confusing sectors that
+belong to the same original block. -/
 structure CommonPrimitiveBNTCoverHypotheses
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]


### PR DESCRIPTION
## Summary

- add representative-weight strict-order transport under common blocking
- add prescribed-length TP, primitive, and irreducible transport lemmas for representative common sectors
- refresh the BNT-cover hypothesis docstring to point at the representative/grouped boundary instead of the raw flattened cyclic-sector list

This is a narrow #1068/#944 support slice. It does not claim the missing representative BNT separation, injectivity, or proportional-decomposition producer.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean`
- `git diff --check`
- `rg -n "sorry|admit|unsafeCast|axiom" TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a handful of new Lean lemmas and a documentation tweak; changes are localized to canonical-form proofs with low likelihood of affecting runtime behavior.
> 
> **Overview**
> Extends `CommonBlockedCyclicSectorRepresentatives.lean` with transport lemmas showing **strict anti-ordering of weight norms** is preserved under representative common blocking, and adds `*_At` theorems to reuse trace-preserving/primitive/irreducible properties when the common blocking length is provided via an equality.
> 
> Updates `CommonPrimitiveProportionalData.lean` documentation for `CommonPrimitiveBNTCoverHypotheses` to clarify that BNT comparison is intended to be performed on **representative/grouped cyclic sectors** (not the raw flattened sector list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4425ecf03ce962054bd12ee80525ac8dbc4d1a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->