### PR TITLE
doc(blueprint): tag representative sector transport

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1770,24 +1770,33 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{theorem}[Common-sector representatives form a BNT-separated normal canonical form]%
 \label{thm:common_representative_normal_bnt}
-	\lean{MPSTensor.isNormalCanonicalFormBNT_commonRepresentativeBlocksAt}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeWeight_strictAnti_of_weight_strictAnti,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_tp,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_primitive,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_irreducible,
+		MPSTensor.isNormalCanonicalFormBNT_commonRepresentativeBlocksAt}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:common_blocked_cyclic_sector_derived_properties,
 		def:normal_cf_bnt}
 	For a prescribed common blocking length, choose one representative for
-	each original block among the common-alphabet cyclic sectors.  If the
-	transported representative weights are strictly ordered by decreasing
-	norm, and distinct representatives are not gauge-phase equivalent, then
-	the representative family is in normal canonical form with BNT
-	separation.
+	each original block among the common-alphabet cyclic sectors.  Strict
+	ordering of the original weights transports to strict ordering of the
+	representative weights by decreasing norm, and the representative blocks
+	retain the trace-preserving, primitive, and tensor-irreducible properties
+	at the prescribed length.  If distinct representatives are not
+	gauge-phase equivalent, then the representative family is in normal
+	canonical form with BNT separation.
 \end{theorem}
 
 \begin{proof}\leanok
 	\uses{thm:common_blocked_cyclic_sector_derived_properties,
 		def:normal_cf_bnt}
-	Apply the normal-canonical-form statement for the representative family
-	and include the assumed separation of distinct representatives.
+	First transport the strict ordering of weights and the structural
+	trace-preserving, primitive, and tensor-irreducible properties to the
+	representative blocks at the prescribed length.  Apply the
+	normal-canonical-form statement for the representative family and include
+	the assumed separation of distinct representatives.
 \end{proof}
 
 \begin{theorem}[Weights of common-alphabet sectors]%


### PR DESCRIPTION
## Summary

- tag the representative common-sector transport lemmas from #1269 in the Ch8 normal-CF-BNT blueprint entry

This is documentation/blueprint sync only. It does not close #1068 or #944; the producer-side BNT comparison data remain open.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check HEAD~1..HEAD`

#1269 has merged as `f704193f`, so this PR is now based directly on `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to blueprint LaTeX documentation, updating referenced Lean lemma tags and explanatory text with no impact on runtime code or proofs beyond documentation sync.
> 
> **Overview**
> Updates Chapter 8’s blueprint statement for `thm:common_representative_normal_bnt` to **explicitly reference the new representative-transport lemmas** (weight ordering and TP/primitive/irreducible preservation) in the `\lean{...}` tags.
> 
> Rewords the theorem and proof text to reflect that strict weight ordering and structural properties are first transported to the chosen representative blocks before applying the existing normal-canonical-form+BNT argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8742073e84d0599dfac44275b3bacd2e3704e497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->