### PR TITLE
feat(MPS/CanonicalForm): expose BNT period-window word span

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -309,10 +309,10 @@ theorem pairTraceSeparatingAll_of_isCanonicalFormBNT
 /-- Canonical-form/BNT data plus eventual identity padding give a common
 homogeneous trace-separating length for all ordered pairs of distinct blocks.
 
-This is the finite-maximum packaging needed after the pairwise Burnside-Jacobson
-identity-padding input has been supplied. The BNT hypotheses provide all-words
-trace separation for each pair; the generic homogenization lemma chooses one
-length that works for the whole finite block family. -/
+This is the finite-maximum step after the pairwise Burnside-Jacobson
+identity-padding hypotheses have been supplied. The BNT hypotheses provide
+all-words trace separation for each pair; the generic homogenization lemma
+chooses one length that works for the whole finite block family. -/
 theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_padding
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -371,6 +371,50 @@ theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_pe
     ∃ T : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) T :=
   exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows
     A (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hWindow
+
+/-- Product-word span from canonical-form/BNT data plus period-window identity-padding
+certificates for every ordered pair of distinct blocks.
+
+This is the direct word-span form of
+`exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_period_windows`.
+It keeps the period-window hypothesis explicit and takes a finite maximum over block pairs
+to obtain a common length for later commutant and projection-span lemmas. -/
+theorem exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_identity_period_windows
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hWindow : ∀ k j : Fin r, j ≠ k → ∃ start period : ℕ, 0 < period ∧
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) period)) ∧
+      ∀ s : ℕ, s < period →
+        ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+            (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+          Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (start + s)))) :
+    ∃ T : ℕ, WordTupleSpanTop A (1 + (r - 1) * T) := by
+  obtain ⟨T, hT⟩ :=
+    exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_period_windows
+      μ A hCF hWindow
+  exact ⟨T, wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hT⟩
+
+/-- Product-word span from canonical-form/BNT data plus period windows of full
+homogeneous pair spans for every ordered pair of distinct blocks.
+
+This is the same BNT finite-family wrapper as
+`exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_identity_period_windows`, but
+with the period-window input stated as fixed-length full pair spans. -/
+theorem exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_pairSpanTop_period_windows
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hWindow : ∀ k j : Fin r, j ≠ k → ∃ start period : ℕ, 0 < period ∧
+      PairWordTupleSpanTop (A k) (A j) period ∧
+      ∀ s : ℕ, s < period → PairWordTupleSpanTop (A k) (A j) (start + s)) :
+    ∃ T : ℕ, WordTupleSpanTop A (1 + (r - 1) * T) := by
+  obtain ⟨T, hT⟩ :=
+    exists_forall_pairTraceSeparatingAt_of_pairSpanTop_period_windows
+      A (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hWindow
+  exact ⟨T, wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hT⟩
 
 /-- Positive-length product-word span from canonical-form/BNT data plus a
 finite period-window identity-padding certificate for every ordered pair of

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -1136,6 +1136,33 @@ theorem
   exact pairIdentity_mem_pairWordTupleSpan_eventually_of_period_window
     (A k) (A j) hperiod_pos hperiod hwindow
 
+/-- A finite family of all-words pair-separation hypotheses and per-pair
+period windows of full homogeneous pair spans admits one common homogeneous
+trace-separating length.
+
+This is the homogeneous-span version of
+`exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows`.
+It keeps the fixed-length period-window producer explicit and only converts full
+homogeneous pair span into the identity-padding certificates needed by the
+generic homogenization theorem. -/
+theorem
+    exists_forall_pairTraceSeparatingAt_of_pairSpanTop_period_windows
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAll (A k) (A j))
+    (hWindow : ∀ k j : Fin r, j ≠ k → ∃ start period : ℕ, 0 < period ∧
+      PairWordTupleSpanTop (A k) (A j) period ∧
+      ∀ s : ℕ, s < period → PairWordTupleSpanTop (A k) (A j) (start + s)) :
+    ∃ T : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) T := by
+  refine exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows
+    A hSep ?_
+  intro k j hj
+  rcases hWindow k j hj with ⟨start, period, hperiod_pos, hperiod, hwindow⟩
+  refine ⟨start, period, hperiod_pos, ?_, ?_⟩
+  · exact pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop (A k) (A j) hperiod
+  · intro s hs
+    exact pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop (A k) (A j)
+      (hwindow s hs)
+
 /-! ### Burnside–Jacobson homogenization: from non-equivalence to homogeneous separation
 
 The theorems in this section bridge the gap between BNT block non-equivalence

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3152,6 +3152,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows}
+    \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairSpanTop_period_windows}
     \lean{MPSTensor.pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv_cast_left}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv_of_pairWordTupleSpanTop_period_window}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop_period_window}
@@ -3249,6 +3250,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding}
     \lean{MPSTensor.pairTraceSeparatingAll_of_isCanonicalFormBNT}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding}
+    \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_identity_period_windows}
+    \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_pairSpanTop_period_windows}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows}
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}


### PR DESCRIPTION
## Summary

- add a generic finite-family adapter from per-pair homogeneous `PairWordTupleSpanTop` period windows to one common pair trace-separating length
- add a direct `WordTupleSpanTop` wrapper for canonical-form/BNT data with explicit pairwise period-window certificates
- tag the new wrappers and existing period-window product-span theorem in the Ch14 product-word span blueprint entry

This is a small #1178/#1133 interface slice. It keeps the period-window producer explicit and does not claim the missing Burnside-Jacobson/fixed-length span input.

## Validation

- `lake build TNLean.MPS.MPDO.BiCFDerivation.PairHomogenization`
- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "\\bsorry\\b|\\badmit\\b|unsafeCast|\\baxiom\\b" TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new wrapper theorems and documentation links without changing existing proof behavior or core definitions.
> 
> **Overview**
> Adds a new finite-family adapter `exists_forall_pairTraceSeparatingAt_of_pairSpanTop_period_windows` that turns *per-pair* period-window `PairWordTupleSpanTop` certificates into a single common homogeneous `PairTraceSeparatingAt` length.
> 
> Builds two new canonical-form/BNT wrappers, `exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_identity_period_windows` and `exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_pairSpanTop_period_windows`, exposing direct `WordTupleSpanTop` consequences from explicit period-window hypotheses.
> 
> Updates Ch14 blueprint lemma tags to reference the new adapter and the new BNT word-span wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31dc5b9077a4137b3ee58e63d7fc1dccc8f0282e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->