### PR TITLE
doc(PEPS): map blueprint diagrams to source proof

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -490,6 +490,23 @@ Theorem~2 of~\cite{Molnar2018NormalPEPS}.
     \end{center}
 \end{theorem}
 
+\begin{remark}
+    The five diagrams above record the gauge steps used in
+    \cite[Section~3]{Molnar2018NormalPEPS}. The edge-orientation and
+    vertex-action diagrams fix the endpoint convention for the edge gauges
+    obtained by blocking the PEPS to a three-site injective MPS. The
+    cancellation diagram is the converse contracted identity: inserting
+    opposite endpoint actions on an internal edge leaves the PEPS coefficient
+    unchanged. The local-extraction diagram summarizes the comparison of
+    one-site-enlarged injective regions with injective complements, after the
+    edge gauges have been absorbed into $\tilde{B}$. The global-consistency
+    diagram summarizes repeating the edge blocking over all edges, so the two
+    endpoint actions on a shared edge are one edge gauge. These pictures are
+    schematic orientation and absorption summaries of the proof of the
+    injective and normal PEPS fundamental theorems, not literal copies of the
+    paper's figures.
+\end{remark}
+
 \begin{theorem}[Fundamental Theorem for injective PEPS, conditional on
     bond-dimension equality]%
     \label{thm:fundamentalTheorem_PEPS_of_bondDim}


### PR DESCRIPTION
## Summary

- add a source-facing remark in Ch13a mapping the five PEPS gauge diagrams to the proof steps in Molnar normal PEPS Section 3
- clarify that the diagrams are schematic orientation/absorption summaries rather than literal copies of the paper figures

This addresses the source-map/documentation part of #1256 and supports the broader PEPS diagram audit in #335. It does not redraw the TikZ diagrams.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds explanatory text; no mathematical statements, Lean links, or code paths are modified.
> 
> **Overview**
> Adds a new `remark` in `ch13a_peps_ft.tex` that explicitly maps the five gauge-related diagrams (edge orientation, vertex action, cancellation, local extraction, global consistency) to the corresponding proof steps in \\cite[Section~3]{Molnar2018NormalPEPS}.
> 
> Clarifies that these diagrams are *schematic orientation/absorption summaries* of the argument rather than literal reproductions of the paper’s figures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5ac865a9befd9d6096378040c7c12570d5ac34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->