### PR TITLE
feat(MPS/CanonicalForm): package representative injectivity blocking

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
@@ -119,6 +119,21 @@ theorem commonRepresentativeDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
   simpa [commonRepresentativeDim] using
     F.commonSectorBlock_dim_pos k ⟨0, F.period_pos k⟩
 
+/-- Each representative common-sector block becomes injective after a further
+blocking.  This deliberately does not assert one-site injectivity at the chosen
+common blocking length. -/
+theorem commonRepresentativeBlocksAt_exists_blockTensor_isInjective
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p') (k : Fin r) :
+    ∃ L : ℕ, IsInjective (blockTensor (F.commonRepresentativeBlocksAt hp k) L) := by
+  haveI : NeZero (F.commonRepresentativeDim k) :=
+    ⟨Nat.ne_of_gt (F.commonRepresentativeDim_pos k)⟩
+  exact exists_blockTensor_isInjective_of_tp_primitive_irreducible
+    (F.commonRepresentativeBlocksAt hp k)
+    (F.commonRepresentativeBlocksAt_tp hp k)
+    (F.commonRepresentativeBlocksAt_primitive hp k)
+    (F.commonRepresentativeBlocksAt_irreducible hp k)
+
 /-- A representative common-sector family is a normal canonical form once its transported
 representative weights are sorted by strictly decreasing modulus. -/
 theorem isNormalCanonicalForm_commonRepresentativeBlocks


### PR DESCRIPTION
## Summary

- add `CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_exists_blockTensor_isInjective`
- package the source-faithful statement that each representative common-sector block admits some further injective blocking from TP, primitive, and irreducible structure
- keep the stronger one-site injectivity-at-the-current-common-period claim out of the API

This is a small #1068/#944/#1170 support slice for the representative/grouped BNT route. It does not prove the proportional/phase-cover producer theorem.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "sorry|admit|unsafe|axiom" TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single derived lemma packaging an existing injectivity-after-blocking result; no changes to core definitions or proofs beyond reusing established TP/primitive/irreducible hypotheses.
> 
> **Overview**
> Adds `commonRepresentativeBlocksAt_exists_blockTensor_isInjective`, which packages that each representative common-sector block (at a specified common blocking length) admits *some further* blocking `L` such that `blockTensor` becomes `IsInjective`, derived from existing TP/primitive/irreducible facts.
> 
> The API intentionally avoids claiming one-site injectivity at the chosen common period, only eventual injectivity after additional blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897b19ec7f7d5043b7385a90a441de793ff68c1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->