### PR TITLE
feat(MPS/CanonicalForm): common representative injective blocking

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily
+import TNLean.MPS.CanonicalForm.Assembly.NormalityChain
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
@@ -133,6 +134,81 @@ theorem commonRepresentativeBlocksAt_exists_blockTensor_isInjective
     (F.commonRepresentativeBlocksAt_tp hp k)
     (F.commonRepresentativeBlocksAt_primitive hp k)
     (F.commonRepresentativeBlocksAt_irreducible hp k)
+
+/-- Each representative common-sector block becomes injective after a positive
+further blocking. -/
+theorem commonRepresentativeBlocksAt_exists_pos_blockTensor_isInjective
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p') (k : Fin r) :
+    ∃ L : ℕ, 0 < L ∧
+      IsInjective (blockTensor (F.commonRepresentativeBlocksAt hp k) L) := by
+  haveI : NeZero (F.commonRepresentativeDim k) :=
+    ⟨Nat.ne_of_gt (F.commonRepresentativeDim_pos k)⟩
+  exact exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible
+    (F.commonRepresentativeBlocksAt hp k)
+    (F.commonRepresentativeBlocksAt_tp hp k)
+    (F.commonRepresentativeBlocksAt_primitive hp k)
+    (F.commonRepresentativeBlocksAt_irreducible hp k)
+
+/-- A finite representative family can use one common further blocking length,
+provided positive local injective-blocking witnesses have already been chosen.
+
+This is the source-faithful finite-max/common-multiple step: it does not assert
+that the representatives are injective at the common cyclic period itself. -/
+theorem commonRepresentativeBlocksAt_blockTensor_isInjective_commonMultiple
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p')
+    (L : Fin r → ℕ)
+    (hL_pos : ∀ k, 0 < L k)
+    (hL : ∀ k, IsInjective (blockTensor (F.commonRepresentativeBlocksAt hp k) (L k)))
+    (k : Fin r) :
+    IsInjective
+      (blockTensor (F.commonRepresentativeBlocksAt hp k) (∏ j : Fin r, L j)) := by
+  classical
+  have hcommon :
+      (∏ j : Fin r, L j) = (∏ j ∈ Finset.univ.erase k, L j) * L k := by
+    simpa using (Finset.prod_erase_mul (s := Finset.univ) (a := k) (f := L)
+      (Finset.mem_univ k)).symm
+  have hmult_pos : 0 < ∏ j ∈ Finset.univ.erase k, L j :=
+    Finset.prod_pos fun j _ => hL_pos j
+  have hmul := blockTensor_isInjective_mul_of_blockTensor_isInjective
+    (F.commonRepresentativeBlocksAt hp k) hmult_pos (hL k)
+  rw [hcommon]
+  exact hmul
+
+/-- Existential form of
+`commonRepresentativeBlocksAt_blockTensor_isInjective_commonMultiple`. -/
+theorem exists_commonRepresentativeBlocksAt_blockTensor_isInjective_of_positive_witnesses
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p')
+    (h : ∃ L : Fin r → ℕ,
+      (∀ k, 0 < L k) ∧
+        ∀ k, IsInjective (blockTensor (F.commonRepresentativeBlocksAt hp k) (L k))) :
+    ∃ L₀ : ℕ, 0 < L₀ ∧
+      ∀ k : Fin r, IsInjective (blockTensor (F.commonRepresentativeBlocksAt hp k) L₀) := by
+  obtain ⟨L, hL_pos, hL⟩ := h
+  refine ⟨∏ k : Fin r, L k, Finset.prod_pos fun k _ => hL_pos k, ?_⟩
+  exact F.commonRepresentativeBlocksAt_blockTensor_isInjective_commonMultiple hp L hL_pos hL
+
+/-- Representative common-sector blocks have one positive common further
+blocking length at which every representative is one-site injective. -/
+theorem exists_commonRepresentativeBlocksAt_blockTensor_isInjective
+    (F : CommonBlockedCyclicSectorFamily blocks)
+    {p' : ℕ} (hp : F.p = p') :
+    ∃ L₀ : ℕ, 0 < L₀ ∧
+      ∀ k : Fin r, IsInjective (blockTensor (F.commonRepresentativeBlocksAt hp k) L₀) := by
+  classical
+  let L : Fin r → ℕ := fun k =>
+    Classical.choose (F.commonRepresentativeBlocksAt_exists_pos_blockTensor_isInjective hp k)
+  have hL_pos : ∀ k, 0 < L k := fun k =>
+    (Classical.choose_spec
+      (F.commonRepresentativeBlocksAt_exists_pos_blockTensor_isInjective hp k)).1
+  have hL : ∀ k, IsInjective (blockTensor (F.commonRepresentativeBlocksAt hp k) (L k)) :=
+    fun k =>
+      (Classical.choose_spec
+        (F.commonRepresentativeBlocksAt_exists_pos_blockTensor_isInjective hp k)).2
+  exact F.exists_commonRepresentativeBlocksAt_blockTensor_isInjective_of_positive_witnesses
+    hp ⟨L, hL_pos, hL⟩
 
 /-- A representative common-sector family is a normal canonical form once its transported
 representative weights are sorted by strictly decreasing modulus. -/

--- a/TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean
@@ -104,6 +104,102 @@ theorem exists_blockTensor_isInjective_of_tp_primitive_irreducible [NeZero D]
   obtain ⟨L, hL⟩ := isNormal_of_tp_primitive_irreducible A hTP hPrim hIrr
   exact ⟨L, (isNBlkInjective_iff_blockTensor_isInjective A L).1 hL⟩
 
+/-- A trace-preserving scalar tensor has a nonzero Kraus matrix. -/
+private theorem exists_nonzero_kraus_of_tp [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    ∃ i : Fin d, A i ≠ 0 := by
+  by_contra hnone
+  push Not at hnone
+  have hsum_zero :
+      ∑ i : Fin d, (A i)ᴴ * A i = (0 : Matrix (Fin D) (Fin D) ℂ) := by
+    apply Finset.sum_eq_zero
+    intro i _
+    simp [hnone i]
+  have hone_zero : (1 : Matrix (Fin D) (Fin D) ℂ) =
+      (0 : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [← hTP, hsum_zero]
+  let a : Fin D := ⟨0, NeZero.pos D⟩
+  have hentry : (1 : Matrix (Fin D) (Fin D) ℂ) a a = 0 := by
+    simpa using congr_fun (congr_fun hone_zero a) a
+  exact one_ne_zero hentry
+
+/-- A nonzero scalar matrix spans the scalar matrix algebra. -/
+private theorem isInjective_of_dim_one_of_exists_nonzero
+    (A : MPSTensor d 1) (hA : ∃ i : Fin d, A i ≠ 0) :
+    IsInjective A := by
+  obtain ⟨i₀, hi₀⟩ := hA
+  rw [IsInjective]
+  have hentry : A i₀ 0 0 ≠ 0 := by
+    intro h
+    apply hi₀
+    ext i j
+    have hi : i = 0 := Fin.eq_zero i
+    have hj : j = 0 := Fin.eq_zero j
+    subst hi
+    subst hj
+    simpa using h
+  have hsingle :
+      (ℂ ∙ A i₀ : Submodule ℂ (Matrix (Fin 1) (Fin 1) ℂ)) = ⊤ := by
+    refine (Submodule.span_singleton_eq_top_iff ℂ (A i₀)).2 ?_
+    intro M
+    refine ⟨M 0 0 / A i₀ 0 0, ?_⟩
+    ext i j
+    have hi : i = 0 := Fin.eq_zero i
+    have hj : j = 0 := Fin.eq_zero j
+    subst hi
+    subst hj
+    simp [div_eq_mul_inv, hentry]
+  exact eq_top_iff.mpr <| by
+    rw [← hsingle]
+    exact Submodule.span_mono (Set.singleton_subset_iff.mpr (Set.mem_range_self i₀))
+
+/-- Zero-length word products cannot span a matrix algebra of dimension at least two. -/
+private theorem wordSpan_zero_ne_top_of_two_le [NeZero D]
+    (A : MPSTensor d D) (hD : 2 ≤ D) :
+    wordSpan A 0 ≠ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) := by
+  intro h
+  have h1 : Module.finrank ℂ (wordSpan A 0) = 1 := by
+    rw [wordSpan_zero, finrank_span_singleton one_ne_zero]
+  rw [h, finrank_top] at h1
+  simp only [Module.finrank_matrix, Fintype.card_fin,
+    Module.finrank_self, mul_one] at h1
+  have hfour : 2 * 2 ≤ D * D := Nat.mul_le_mul hD hD
+  omega
+
+/-- **TP + primitive + irreducible → injective after positive blocking**.
+
+The normality witness may be zero in scalar bond dimension, so the positivity
+claim is proved separately: scalar trace-preserving tensors are already
+one-site injective, while dimensions at least two cannot have full
+zero-length word span. -/
+theorem exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
+    (hIrr : IsIrreducibleTensor A) :
+    ∃ L : ℕ, 0 < L ∧ IsInjective (blockTensor A L) := by
+  by_cases hD : D = 1
+  · subst D
+    have hInj : IsInjective A :=
+      isInjective_of_dim_one_of_exists_nonzero A (exists_nonzero_kraus_of_tp A hTP)
+    exact ⟨1, Nat.zero_lt_one,
+      (isNBlkInjective_iff_blockTensor_isInjective A 1).1
+        (isNBlkInjective_one_of_isInjective hInj)⟩
+  · have hD_pos : 0 < D := NeZero.pos D
+    have hD_ge : 2 ≤ D := by omega
+    obtain ⟨L, hL⟩ :=
+      exists_blockTensor_isInjective_of_tp_primitive_irreducible A hTP hPrim hIrr
+    refine ⟨L, ?_, hL⟩
+    by_contra hL_nonpos
+    have hL_zero : L = 0 := Nat.eq_zero_of_not_pos hL_nonpos
+    subst L
+    have hzero :
+        wordSpan A 0 = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) :=
+      (wordSpan_eq_top_iff_isNBlkInjective A 0).mpr
+        ((isNBlkInjective_iff_blockTensor_isInjective A 0).2 hL)
+    exact wordSpan_zero_ne_top_of_two_le A hD_ge hzero
+
 /-!
 ## Combined reduction: arbitrary → IsNormal (per block, for primitive blocks)
 
@@ -170,6 +266,25 @@ private theorem wordSpan_mul_eq_top_of_wordSpan_eq_top
               wordSpan_le_wordSpan_add_of_wordSpan_eq_top A hN (n * N)
           _ = wordSpan A ((n + 1) * N) := by ring_nf
       exact eq_top_iff.mpr (hprev ▸ hle)
+
+/-- Fixed-length injectivity persists at positive multiples of the length. -/
+theorem isNBlkInjective_mul_of_isNBlkInjective
+    (A : MPSTensor d D) {N m : ℕ} (hm : 0 < m) (hN : IsNBlkInjective A N) :
+    IsNBlkInjective A (m * N) := by
+  have hwordN : wordSpan A N = ⊤ :=
+    (wordSpan_eq_top_iff_isNBlkInjective A N).mpr hN
+  exact (wordSpan_eq_top_iff_isNBlkInjective A (m * N)).mp
+    (wordSpan_mul_eq_top_of_wordSpan_eq_top A hwordN m hm)
+
+/-- One-site injectivity of a blocked tensor persists after a positive further
+blocking, read back as direct blocking of the original tensor. -/
+theorem blockTensor_isInjective_mul_of_blockTensor_isInjective
+    (A : MPSTensor d D) {N m : ℕ} (hm : 0 < m)
+    (hN : IsInjective (blockTensor A N)) :
+    IsInjective (blockTensor A (m * N)) := by
+  exact (isNBlkInjective_iff_blockTensor_isInjective A (m * N)).1
+    (isNBlkInjective_mul_of_isNBlkInjective A hm
+      ((isNBlkInjective_iff_blockTensor_isInjective A N).2 hN))
 
 /-- **IsNormal is preserved by blocking.**
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1799,6 +1799,31 @@ The following results separate the zero blocks from the nonzero blocks.
 	the assumed separation of distinct representatives.
 \end{proof}
 
+\begin{theorem}[Common further blocking for representative sectors]%
+\label{thm:common_representative_common_further_blocking}
+	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_exists_pos_blockTensor_isInjective,
+		MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_blockTensor_isInjective_commonMultiple,
+		MPSTensor.CommonBlockedCyclicSectorFamily.exists_commonRepresentativeBlocksAt_blockTensor_isInjective,
+		MPSTensor.CommonBlockedCyclicSectorFamily.exists_commonRepresentativeBlocksAt_blockTensor_isInjective_of_positive_witnesses}
+	\leanok
+	Each representative common-sector block has a positive further blocking
+	at which it is one-site injective. Since there are finitely many
+	representatives, the product of these local blocking lengths is one
+	positive common further blocking length at which every representative
+	remains one-site injective.
+\end{theorem}
+
+\begin{proof}\leanok
+	\uses{thm:tp_primitive_irred_block_injective,
+		thm:normal_blocking_preserved}
+	First apply the positive-blocking consequence of trace preservation,
+	primitivity, and irreducibility to each representative.  For a fixed
+	representative, factor the common product as its local blocking length times
+	the product of all other local lengths.  Full fixed-length word span persists
+	under positive multiples, so the direct block at the common product remains
+	injective.
+\end{proof}
+
 \begin{theorem}[Weights of common-alphabet sectors]%
 \label{thm:common_flat_weight_apply_of_block}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_apply_of_block}
@@ -2653,13 +2678,14 @@ The following results separate the zero blocks from the nonzero blocks.
 
 \begin{theorem}[TP-primitive irreducible tensor is injective after blocking]%
 	\label{thm:tp_primitive_irred_block_injective}
-	\lean{MPSTensor.exists_blockTensor_isInjective_of_tp_primitive_irreducible}
+	\lean{MPSTensor.exists_blockTensor_isInjective_of_tp_primitive_irreducible,
+		MPSTensor.exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible}
 	\leanok
 	\uses{thm:normal_tp_primitive_irred,
 		lem:isNBlkInjective_iff_blockTensor_isInjective}
 	Let $A$ be a left-canonical MPS tensor with $D > 0$,
 	irreducible transfer map, and peripheral spectrum $\{1\}$.
-	Then some blocking $A^{[L]}$ is one-site injective.
+	Then some positive blocking $A^{[L]}$ is one-site injective.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2667,12 +2693,17 @@ The following results separate the zero blocks from the nonzero blocks.
 		lem:isNBlkInjective_iff_blockTensor_isInjective}
 	The previous theorem gives normality, which is eventual block injectivity.
 	The blocked-chain equivalence identifies this with one-site injectivity of
-	the corresponding blocked tensor.
+	the corresponding blocked tensor.  If the normality witness has length zero,
+	then either the bond dimension is scalar, where trace preservation gives a
+	nonzero one-site Kraus matrix, or the zero-length word span cannot be the
+	full matrix algebra.
 \end{proof}
 
 \begin{theorem}[Blocking preserves normality]%
 	\label{thm:normal_blocking_preserved}
-	\lean{MPSTensor.isNormal_blockTensor_of_isNormal}
+	\lean{MPSTensor.isNBlkInjective_mul_of_isNBlkInjective,
+		MPSTensor.blockTensor_isInjective_mul_of_blockTensor_isInjective,
+		MPSTensor.isNormal_blockTensor_of_isNormal}
 	\leanok
 	\uses{def:normal, def:blocked_tensor}
 	If $A$ is normal and $p \ge 1$, then $A^{[p]}$ is normal.


### PR DESCRIPTION
## Summary

- expose fixed-length injectivity persistence at positive multiples in the TP-primitive normality chain
- strengthen TP+primitive+irreducible to produce a positive injective-blocking witness, handling the scalar bond-dimension case separately
- add representative-sector packaging: each representative has a positive local injective-blocking witness, and the finite product gives one positive common further blocking length for all representatives
- document the new finite common-multiple step in Chapter 8 of the blueprint

## Mathematical scope

This keeps the comparison source-faithful: it does not claim that common-sector representatives are one-site injective at the original common cyclic period. The common length is obtained after the paper-style extra blocking step, by taking the finite product of positive local lengths and using fixed-length word-span persistence at positive multiples.

The positive-witness theorem does not reinterpret `IsNormal` as intrinsically positive. In scalar bond dimension, a zero normality witness can be real; that case is handled separately using trace preservation to get a nonzero one-site Kraus matrix.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` followed by `cd blueprint && leanblueprint checkdecls`
- `rg -n "sorry|admit|unsafeCast|\\baxiom\\b|native_decide" TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean || true`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends core canonical-form lemmas around injective blocking and relies on new case splits (notably scalar bond dimension), so downstream proofs that depend on blocking lengths may be sensitive to these strengthened statements.
> 
> **Overview**
> Adds a strengthened TP+primitive+irreducible consequence in `NormalityChain.lean`: `exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible` now produces an injective blocking length with `0 < L`, with separate handling for scalar bond dimension and a proof that `L = 0` cannot witness full spanning when `D ≥ 2`.
> 
> Exposes persistence lemmas showing injectivity is stable under positive multiples (`isNBlkInjective_mul_of_isNBlkInjective` and `blockTensor_isInjective_mul_of_blockTensor_isInjective`), then uses them in `CommonBlockedCyclicSectorRepresentatives.lean` to package **finite common-multiple** blocking: each representative gets a positive local injective-blocking witness, and the product yields one positive blocking length making all representatives’ blocked tensors injective.
> 
> Updates Chapter 8 of the blueprint to document the new positive-witness theorem and the representative-sector common further-blocking step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc933689ec3d8f57e002ec7bd6cd081d1264640a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->