### PR TITLE
doc(MPS): demote auxiliary theorem surface

### DIFF
--- a/TNLean/MPS/BNT/BasisNormal.lean
+++ b/TNLean/MPS/BNT/BasisNormal.lean
@@ -33,7 +33,7 @@ def mpvFun (A : MPSTensor d D) (N : ℕ) : (Fin N → Fin d) → ℂ :=
 /-- The Vandermonde separation lemma: if the scaling factors `μ k` are distinct,
 then any linear relation `∑ k, c k * (μ k) ^ N = 0` holding for `N = 0, …, r-1`
 forces all coefficients `c k` to vanish. -/
-theorem vandermonde_separation (C : CanonicalForm d)
+lemma vandermonde_separation (C : CanonicalForm d)
     (hμ : Function.Injective C.μ)
     (c : Fin C.numBlocks → ℂ)
     (hc : ∀ N : Fin C.numBlocks,
@@ -45,7 +45,7 @@ theorem vandermonde_separation (C : CanonicalForm d)
 
 If `μ` is injective and we have Vandermonde-type relations pointwise in `a : α`, then the whole
 family of functions must vanish. -/
-theorem vandermonde_separation_fun {n : ℕ} {α : Type*}
+lemma vandermonde_separation_fun {n : ℕ} {α : Type*}
     (μ : Fin n → ℂ) (hμ : Function.Injective μ)
     (v : Fin n → α → ℂ)
     (hv : ∀ i : Fin n, ∀ a : α, (∑ j : Fin n, v j a * μ j ^ (i : ℕ)) = 0) :
@@ -60,7 +60,7 @@ theorem vandermonde_separation_fun {n : ℕ} {α : Type*}
 This is the basic linear-algebraic fact we use later: once the coefficient vectors are fixed (here,
 functions `σ ↦ mpv (blockTensor k) σ` for a fixed `N₀`), distinct scaling factors `μ k` allow one to
 separate the contributions by looking at finitely many powers. -/
-theorem block_mpvs_separation_at_fixed_size (C : CanonicalForm d)
+lemma block_mpvs_separation_at_fixed_size (C : CanonicalForm d)
     (hμ : Function.Injective C.μ) (N₀ : ℕ)
     (c : Fin C.numBlocks → ℂ)
     (hc : ∀ i : Fin C.numBlocks, ∀ σ : Fin N₀ → Fin d,
@@ -78,7 +78,7 @@ theorem block_mpvs_separation_at_fixed_size (C : CanonicalForm d)
 
 if each block MPV is nonzero at size `N₀`, then the Vandermonde relations force the coefficients
 themselves to vanish. -/
-theorem block_mpvs_lin_indep_at_fixed_size (C : CanonicalForm d)
+lemma block_mpvs_lin_indep_at_fixed_size (C : CanonicalForm d)
     (hμ : Function.Injective C.μ) (N₀ : ℕ)
     (hnonzero : ∀ k : Fin C.numBlocks, mpvFun (C.blockTensor k) N₀ ≠ 0)
     (c : Fin C.numBlocks → ℂ)

--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -365,11 +365,11 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
 end MPSTensor
 
 /-!
-## Fundamental Theorem — Theorem 4.4, span-equality formulation (variable block count)
+## Permutation rigidity from equal spans
 
 This section applies the permutation-rigidity lemma for BNT decompositions
 (`MPSTensor.exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho` above) into a more
-general **paper-style** statement where the two BNT families may have **different**
+general auxiliary statement where the two BNT families may have **different**
 numbers of blocks (`gA ≠ gB`).
 
 The key new ingredient is a proof that the equal-span hypothesis forces
@@ -396,14 +396,14 @@ entangled pair states*, Rev. Mod. Phys. **93** (2021) 045003; arXiv:2011.12127.
 namespace MPSTensor
 
 /--
-**Theorem 4.4 (primitive, basis-of-normal-tensors permutation step), span-equality formulation.**
+**Primitive basis-of-normal-tensors permutation step, span-equality formulation.**
 
 Two BNT-like families with possibly different numbers of blocks `gA`, `gB`
 that are injective, normalised, asymptotically orthonormal, and span the same
 MPV subspace at every system size must have `gA = gB` and agree blockwise up to
 a permutation, dimension equality, and gauge-phase equivalence.
 -/
-theorem exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho
+lemma exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho
     {d gA gB : ℕ}
     {dimA : Fin gA → ℕ} {dimB : Fin gB → ℕ}
     [∀ j, NeZero (dimA j)] [∀ j, NeZero (dimB j)]

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -312,7 +312,7 @@ This theorem states the equal-case conclusion that *is* derivable from those res
 same coefficient hypotheses as the proportional theorem, equal MPVs force the phase-corrected
 weights to match blockwise.  After reindexing the `B`-family by the permutation from the
 proportional FT, the assembled weighted block tensors are globally gauge equivalent. -/
-theorem fundamentalTheorem_equalMPV_full
+theorem fundamentalTheorem_equalMPV_of_explicit_coefficients
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -71,8 +71,9 @@ forces:
 3. Blockwise gauge-phase equivalence: for each `j`, `dimA j = dimB (perm j)` and
    `GaugePhaseEquiv (cast … (A j)) (B (perm j))`.
 
-Unlike `fundamentalTheorem_proportionalMPV_CFBNT` and `fundamentalTheorem_equalMPV_full`,
-this theorem requires **no** explicit `aCoeff`, `bCoeff`, `aLim`, `bLim` arguments. The
+Unlike `fundamentalTheorem_proportionalMPV_CFBNT` and
+`fundamentalTheorem_equalMPV_of_explicit_coefficients`, this theorem requires **no** explicit
+`aCoeff`, `bCoeff`, `aLim`, `bLim` arguments. The
 coefficient convergence question that plagues the general proportional-case theorem is
 bypassed entirely: the BNT decomposition identity
   `∑_j (μA j)^N * mpv(A j) σ = ∑_k (μB k)^N * mpv(B k) σ`

--- a/blueprint/comments20260315/full_ft_verification.md
+++ b/blueprint/comments20260315/full_ft_verification.md
@@ -1,8 +1,8 @@
 # Verification: literature equal-MPV FT versus the current Lean endpoint
 
 This note records the status after the March 17, 2026 refinement of
-`MPSTensor.fundamentalTheorem_equalMPV_full` in
-`TNLean/MPS/FundamentalTheorem/Full.lean`.
+`MPSTensor.fundamentalTheorem_equalMPV_of_explicit_coefficients` in
+`TNLean/MPS/FundamentalTheorem/EqualProportional.lean`.
 
 The key point is simple: the current Lean theorem is now an
 explicit-coefficient equal-case upgrade of the currently formalized
@@ -24,7 +24,8 @@ case. In the papers, however, the equal-case argument keeps additional
 multiplicity data, so this remains a target statement rather than a
 formalized theorem in the present Lean development.
 
-### Current Lean theorem (`fundamentalTheorem_equalMPV_full`)
+### Explicit-coefficient Lean theorem
+(`fundamentalTheorem_equalMPV_of_explicit_coefficients`)
 
 Under the CF-BNT hypotheses, together with explicit coefficient arrays
 `aCoeff`, `bCoeff`, convergence to nonzero limits, and equality of MPVs,
@@ -44,6 +45,15 @@ then equal MPVs imply per-block gauge equivalence and hence global gauge
 equivalence.
 
 This remains a different formalized special case.
+
+### Heterogeneous block-matching theorem
+(`fundamentalTheorem_equalMPV_CFBNT_hetero`)
+
+This theorem starts from equal MPVs for two CF-BNT families with different
+block counts and bond dimensions. It proves equality of the block counts,
+a permutation preserving bond dimensions, and blockwise gauge-phase
+equivalence. It does not yet assert the final global weighted gauge
+equivalence of the assembled block-diagonal tensors.
 
 ---
 
@@ -86,10 +96,10 @@ full equal-case theorem.
   Recovering the individual weights in that generality needs a
   power-sum / Newton--Girard step (`Lem:app_simple`), not just the
   multiplicity-one linear-independence shortcut.
-- There is still no current Lean theorem that starts from only the
-  literature CF data and equal MPVs and then upgrades all the way to the
-  final global gauge equivalence without the extra coefficient
-  hypotheses.
+- The heterogeneous block-matching theorem now starts from equal MPVs
+  without explicit coefficient limits, but it stops at blockwise
+  gauge-phase matching. It does not yet upgrade all the way to the final
+  global weighted gauge equivalence of the literature corollary.
 
 So the refined theorem is honest and useful, but it is still a special
 formalized endpoint.
@@ -102,8 +112,10 @@ The blueprint should reflect the following separation.
 
 - `thm:ft_equal` should remain the unformalized target / literature-level
   equal-MPV theorem.
-- `MPSTensor.fundamentalTheorem_equalMPV_full` should back a separate
-  theorem for the explicit-coefficient equal case.
+- `MPSTensor.fundamentalTheorem_equalMPV_of_explicit_coefficients`
+  should back a separate theorem for the explicit-coefficient equal case.
+- `MPSTensor.fundamentalTheorem_equalMPV_CFBNT_hetero` should back the
+  block-matching part of the heterogeneous equal case.
 - `fundamentalTheorem_equalMPV_CFBNT` should remain labeled as the
   common-block-structure special case, not as the full equal-MPV theorem.
 
@@ -114,7 +126,8 @@ The blueprint should reflect the following separation.
 | Item | Status |
 | --- | --- |
 | Literature equal-MPV FT / Cor. IV.5 | target only; not yet formalized |
-| `fundamentalTheorem_equalMPV_full` | formalized explicit-coefficient equal-case upgrade of the proportional FT |
+| `fundamentalTheorem_equalMPV_of_explicit_coefficients` | formalized explicit-coefficient equal-case upgrade of the proportional FT |
+| `fundamentalTheorem_equalMPV_CFBNT_hetero` | formalized heterogeneous block-matching theorem |
 | `fundamentalTheorem_equalMPV_CFBNT` | formalized common-block-structure special case |
 | Power-sum / Newton--Girard tools | still relevant for the full literature route |
 | BNT linear-independence argument | valid for the explicit-coefficient special theorem now in Lean |

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -372,7 +372,7 @@ The main references are
 	abstract permutation argument from this canonical-form setting.
 \end{remark}
 
-\begin{theorem}[Permutation rigidity with asymptotically orthonormal overlaps]\label{thm:bnt_perm_simple}
+\begin{lemma}[Permutation rigidity with asymptotically orthonormal overlaps]\label{lem:bnt_perm_simple}
 	\lean{MPSTensor.exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho}
 	\leanok
 	\uses{def:injective, def:mpv, def:mpv_overlap, def:gauge_phase_equiv}
@@ -391,7 +391,7 @@ The main references are
 	then $g_A = g_B$, and there is a permutation $\pi$ of the common
 	block index set such that $A_j$ and $B_{\pi(j)}$ have the same bond
 	dimension and are gauge-phase equivalent for each~$j$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok\uses{thm:bnt_overlap_orthonormal_li, thm:bnt_perm_same_card}
 	By Theorem~\ref{thm:bnt_overlap_orthonormal_li}, both families are
@@ -454,15 +454,15 @@ The main references are
 \end{proof}
 
 \begin{remark}
-	Theorem~\ref{thm:bnt_perm_simple} is retained for completeness but is
+	Lemma~\ref{lem:bnt_perm_simple} is retained for completeness but is
 	not used in the proofs given here; the proportional version
 	(Theorem~\ref{thm:bnt_perm_prop}) suffices for the Fundamental Theorem.
 \end{remark}
 
 \subsection{Fixed-size separation by Vandermonde inversion}
 
-\begin{theorem}[Vandermonde separation]
-	\label{thm:bnt_vandermonde_separation}
+\begin{lemma}[Vandermonde separation]
+	\label{lem:bnt_vandermonde_separation}
 	\lean{MPSTensor.vandermonde_separation}
 	\leanok
 	\uses{def:is_canonical_form}
@@ -473,7 +473,7 @@ The main references are
 		\sum_k c_k \mu_k^N = 0
 	\]
 	for $N = 0, \ldots, r-1$, then every $c_k$ vanishes.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	The Vandermonde matrix with entries $V_{Nk} = \mu_k^N$ is invertible when
@@ -481,11 +481,11 @@ The main references are
 	has only the zero solution.
 \end{proof}
 
-\begin{theorem}[Fixed-size linear independence of block MPVs]
-	\label{thm:block_mpvs_fixed_size_li}
+\begin{lemma}[Fixed-size linear independence of block MPVs]
+	\label{lem:block_mpvs_fixed_size_li}
 	\lean{MPSTensor.block_mpvs_lin_indep_at_fixed_size}
 	\leanok
-	\uses{thm:bnt_vandermonde_separation}
+	\uses{lem:bnt_vandermonde_separation}
 	Let $C$ be a canonical form with $r$ blocks and pairwise distinct
 	weights $\mu_k$, and fix a system size $N_0$. Assume that each block MPV
 	$\ket{V^{(N_0)}(A_k)}$ is nonzero. If
@@ -494,10 +494,10 @@ The main references are
 	\]
 	for every word $\sigma$ of length $N_0$ and every $i = 0, \ldots, r-1$,
 	then $c_k = 0$ for all $k$.
-\end{theorem}
+\end{lemma}
 
-\begin{proof}\leanok\uses{thm:bnt_vandermonde_separation}
-	Apply Theorem~\ref{thm:bnt_vandermonde_separation} pointwise in the word
+\begin{proof}\leanok\uses{lem:bnt_vandermonde_separation}
+	Apply Lemma~\ref{lem:bnt_vandermonde_separation} pointwise in the word
 	$\sigma$. This shows that every component of
 	$c_k\ket{V^{(N_0)}(A_k)}$ vanishes. Since the MPV of each block is
 	nonzero at size $N_0$, some component survives, so $c_k = 0$.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -206,7 +206,8 @@ used in this chapter.
 \end{theorem}
 
 \begin{proof}
-	\uses{thm:ft_equal_explicit, thm:mpv_decomposition,
+	\uses{thm:ft_equal_explicit, thm:fundamentalTheorem_equalMPV_CFBNT_hetero,
+	      thm:mpv_decomposition,
 	      rem:cf_coeff_arrays, thm:route_b_equal,
 	      thm:afterBlocking_sectorComparison_reindexed_bntCover,
 	      thm:common_phase_cover_of_proportional_decomposition}
@@ -220,21 +221,24 @@ used in this chapter.
 	the sector-weight multisets from these identities.
 
 	The remaining synchronization statement for the bare equal-MPV theorem must
-	derive the coefficient identities and common phase data directly from equality
-	of the full MPV families.  The after-blocking comparison theorem
+	assemble the block-matching data into equality of the weighted block-diagonal
+	tensors.  The heterogeneous equal-case theorem
+	(Theorem~\ref{thm:fundamentalTheorem_equalMPV_CFBNT_hetero}) now proves the
+	block-count, bond-dimension, and gauge-phase matching directly from equality
+	of the full MPV families, without explicit coefficient limits.  The
+	after-blocking comparison theorem
 	(Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover}) gives the
 	matched sector-weight conclusion once BNT-cover comparison data are supplied.
 	Theorem~\ref{thm:common_phase_cover_of_proportional_decomposition} explains
 	how proportional block comparisons supply common phases.  Completing this
-	theorem therefore amounts to deriving the BNT-cover, overlap-span, or
-	common-phase hypotheses for the canonical decompositions produced from the
-	bare equality assumption.  Once those data are available, the phases are
-	absorbed into the recovered weights and the blockwise conjugacies assemble
-	into a global gauge equivalence.
+	theorem therefore amounts to deriving the BNT-cover and sector-weight data for
+	the canonical decompositions produced from the bare equality assumption.  Once
+	those data are available, the phases are absorbed into the recovered weights
+	and the blockwise conjugacies assemble into a global gauge equivalence.
 \end{proof}
 
-\begin{theorem}[Fundamental Theorem --- equal MPV case with explicit coefficients]\label{thm:ft_equal_explicit}
-	\lean{MPSTensor.fundamentalTheorem_equalMPV_full}
+\begin{theorem}[Equal MPV comparison with explicit coefficients]\label{thm:ft_equal_explicit}
+	\lean{MPSTensor.fundamentalTheorem_equalMPV_of_explicit_coefficients}
 	\leanok
 	\uses{def:cf_bnt, def:gauge_equiv}
 	Let $A_{\mathrm{tot}}$ and $B_{\mathrm{tot}}$ be MPS tensors
@@ -708,8 +712,8 @@ single weighted block.
 
 \begin{proof}
 	\leanok
-	\uses{thm:bnt_perm_simple, thm:sector_basis_pre_matching_to_matching}
-	The permutation-rigidity theorem for bases of normal tensors gives a
+	\uses{lem:bnt_perm_simple, thm:sector_basis_pre_matching_to_matching}
+	The permutation-rigidity lemma for bases of normal tensors gives a
 	permutation, the matched bond dimensions, and the gauge-phase equivalences
 	of the basis blocks, hence a sector basis pre-matching. Asymptotic
 	orthonormality gives the BNT linear-independence condition, and

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -1,0 +1,192 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{docs/paper-gaps/command}
+
+\title{Theorem Surface Audit for Canonical Form, BNT, and the Non-periodic MPS Fundamental Theorem}
+\author{}
+\date{2026-05-05}
+
+\begin{document}
+\maketitle
+
+\section{Purpose}
+
+This note compares the theorem surface in the formal development with the
+statements in the source papers.  It is not an issue index.  The goal is to
+separate four kinds of results:
+\begin{enumerate}
+  \item named statements appearing directly in the papers;
+  \item cited mathematical results used by the papers;
+  \item auxiliary formal statements needed to make an implicit proof step exact;
+  \item stronger or alternative statements that should not be presented as part
+        of the paper-level proof unless they become necessary.
+\end{enumerate}
+
+\section{Named source statements}
+
+The 2016 source has a small number of named statements in the canonical-form
+and BNT part:
+\begin{itemize}
+  \item normal tensor and canonical form definitions
+    \cite[lines~233--255]{Cirac2016MPDO_arXiv};
+  \item basis of normal tensors definition and characterization
+    \cite[lines~271--280]{Cirac2016MPDO_arXiv};
+  \item injective and block-injective canonical form definitions, together with
+    the quantum-Wielandt and block-injective-after-blocking assertions
+    \cite[lines~317--345]{Cirac2016MPDO_arXiv};
+  \item the proportional Fundamental Theorem and the equal-MPV corollary
+    \cite[lines~347--356]{Cirac2016MPDO_arXiv}.
+\end{itemize}
+The 2021 review gives the same normal tensor, BNT, proportional theorem, and
+equal-MPV corollary in Section~IV
+\cite[lines~1828--1899]{Cirac2021Matrix}.
+
+These are the paper-level targets.  They should remain the prominent theorem
+statements in the blueprint.
+
+\section{Why the formalization has more declarations}
+
+The paper proof suppresses finite-dimensional and finite-index operations that
+must be named in a proof assistant.  In this part of the development the extra
+formal statements usually fall into one of the following categories.
+
+\paragraph{Reduction statements.}
+The canonical-form proof splits the paper's ``put the tensor in canonical
+form'' step into invariant-subspace extraction, block-diagonal decomposition,
+trace-preserving normalization, period-removing blocking, and primitive-block
+normality.  These are not new mathematical claims beyond the source reduction,
+but they need separate hypotheses and conclusions so later theorems can apply
+them.
+
+\paragraph{Common blocking statements.}
+The paper says that periodicity is removed by blocking a common multiple of the
+periods.  The formalization must record positivity of the chosen block length,
+persistence of injectivity under further blocking, and the simultaneous
+application to a finite family of representative sectors.  These statements are
+auxiliary, but they are mathematically faithful to the period-removal step.
+
+\paragraph{BNT comparison statements.}
+The source BNT characterization selects one representative from each
+phase-gauge equivalence class and compares the power sums of weights.  The
+formalization separates this into overlap decay, eventual linear independence,
+permutation rigidity, sector-weight comparison, and phase absorption.  The
+heterogeneous block-matching theorem is a genuine formal endpoint for the
+block-matching part, while the final global weighted gauge equivalence remains
+the paper-level equal-MPV target.
+
+\paragraph{Parent-Hamiltonian statements.}
+The parent-Hamiltonian chapter uses additional intersection-property,
+periodic-chain, and ground-space-span results.  These are cited mathematical
+ingredients for the parent-Hamiltonian consequences, not extra theorems in the
+non-periodic Fundamental Theorem proof.
+
+\section{External lemmas need explanations}
+
+When a result is needed but the MPS source only cites it, the formal
+development should give a pedagogical explanation at the point where the result
+enters the proof.  A citation alone is not enough in this situation.  The
+explanation should include:
+\begin{enumerate}
+  \item the exact mathematical statement used;
+  \item the hypotheses in the MPS notation, after blocking or reindexing if
+        necessary;
+  \item a short proof idea, or a precise indication that the proof is imported
+        from the cited source;
+  \item the formal declaration that supplies the result, if it has already been
+        formalized.
+\end{enumerate}
+
+This applies in particular to the following families of external input.
+\begin{itemize}
+  \item The quantum Wielandt theorem supplies finite-length matrix-algebra span
+    from normality or primitivity \cite{Sanz2010Quantum}.  The paper cites it in
+    the canonical-form reduction; the formal text should say whether it is using
+    cumulative span, exact-length span, injectivity of the map $\Gamma_L$, or
+    block-injectivity of a direct sum.
+  \item The block-injective canonical-form bound uses the older MPS
+    injectivity and block-injectivity argument of
+    \cite{PerezGarcia2007MPSReps}.  The formal statement should identify the
+    common blocked physical alphabet and the direct-sum matrix algebra that is
+    being spanned.
+  \item Vandermonde inversion and Newton--Girard identities are elementary, but
+    they are not proved in the MPS source.  When they are used to recover
+    coefficients, multiplicities, or weight multisets, the blueprint should
+    explain the finite linear system or the power-sum recursion.
+  \item Parent-Hamiltonian gap statements use the FNW intersection-property and
+    martingale estimates from \cite{Fannes1992Finitely,Nachtergaele1996Spectral}
+    and later refinements such as \cite{Kastoryano2018Martingale}.  If the
+    source only invokes these estimates, the blueprint should state the
+    finite-size criterion and the constants being used before applying it to
+    MPS parent Hamiltonians.
+  \item Perron--Frobenius and peripheral-spectrum facts for quantum channels are
+    standard inputs from finite-dimensional channel theory, but they are not
+    interchangeable.  A formal theorem should specify whether it uses
+    irreducibility, primitivity, trace preservation, a faithful fixed point, or
+    a rank-one peripheral projection.
+\end{itemize}
+
+This rule also gives a retirement test.  If an external-looking lemma has no
+source citation, no proof explanation, and no current proof path needing it, it
+should not remain as a headline theorem in the paper-level blueprint.
+
+\section{Current demotions}
+
+The following declarations are auxiliary and should not be read as independent
+paper-level theorems.
+\begin{itemize}
+  \item The explicit-coefficient equal-MPV result is named
+    \[
+      \texttt{fundamentalTheorem\_equalMPV\_of\_explicit\_coefficients}.
+    \]
+    It is not the full equal-MPV corollary from the papers.  It assumes the
+    coefficient arrays and their nonzero limits.
+  \item The Vandermonde fixed-size separation declarations are lemmas.  They
+    remain available for finite-length arguments, but the main BNT comparison
+    route uses eventual linear independence and overlap orthogonality.
+  \item The equal-span permutation rigidity statement with asymptotically
+    orthonormal overlaps is a lemma.  It is a useful span route, but the
+    proportional BNT permutation theorem is the theorem used by the main
+    proportional Fundamental Theorem in Chapter~11.
+\end{itemize}
+
+\section{Statements to keep visibly conditional}
+
+Several declarations should stay in the development, but their statements
+should remain visibly conditional until the missing paper input is produced.
+\begin{itemize}
+  \item The conditional after-blocking Fundamental Theorem assumes the
+    post-blocking sector hypotheses.  It should not be cited as the unconditional
+    canonical-form theorem.
+  \item The explicit-coefficient equal case assumes coefficient arrays rather
+    than deriving the BNT power-sum data from bare equality of MPVs.
+  \item The parent-Hamiltonian unique-ground-state endpoints depend on the
+    normal chain ground-space identification, and the BNT ground-space span
+    endpoint depends on the periodic block-decomposition inclusion.  They are
+    paper-level targets, but the proof surface should keep those dependencies
+    explicit until the corresponding lemmas are completed.
+\end{itemize}
+
+\section{Retirement criterion}
+
+An auxiliary declaration should be removed or moved out of the main blueprint
+route when all three conditions hold:
+\begin{enumerate}
+  \item it is not a statement in the cited paper and is not a cited outside
+        result;
+  \item no current proof of a paper-level target uses it;
+  \item it states a stronger finite-length, span, or synchronization hypothesis
+        than the source proof requires.
+\end{enumerate}
+If a declaration is still used but only as a formal intermediate result, it
+should be a lemma or a clearly conditional theorem, not a headline replacement
+for the paper theorem.
+
+\bibliographystyle{alpha}
+\bibliography{docs/paper-gaps/references}
+
+\end{document}


### PR DESCRIPTION
## Summary

- rename the explicit-coefficient equal-MPV theorem so it no longer claims to be the full equal-MPV theorem
- demote auxiliary Vandermonde and equal-span permutation-rigidity declarations from theorem-shaped surface to lemmas, and update blueprint labels/references accordingly
- add a source-based theorem-surface audit note for canonical form, BNT, the non-periodic Fundamental Theorem, and external-lemma explanation requirements

## Rationale

The 1606.00608 and 2011.12127 sources have a small paper-level theorem surface. The formalization needs additional intermediate statements, but auxiliary or conditional statements should not be presented as replacement paper theorems. External inputs that the paper only cites now have an explicit standard: state the exact result used, match hypotheses in MPS notation, give the proof idea or source, and point to the formal declaration when available.

This is intentionally the start of a larger batched cleanup rather than a collection of tiny follow-ups. #1278 tracks the remaining external-input explanations so later PRs can group related source-faithfulness work.

## Related

- #1170
- #1278
- #944
- #1178
- #1133

## Checks

- `lake env lean TNLean/MPS/BNT/BasisNormal.lean`
- `lake env lean TNLean/MPS/BNT/PermutationRigidityPrimitive.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/EqualProportional.lean`
- `lake build TNLean.MPS.FundamentalTheorem.EqualProportional TNLean.MPS.FundamentalTheorem.Full TNLean.MPS.BNT.BasisNormal TNLean.MPS.BNT.PermutationRigidityPrimitive`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`
- `git diff --check`