### PR TITLE
refactor(MPS): retire unused BNT proof surface

### DIFF
--- a/TNLean/MPS/BNT/BasisNormal.lean
+++ b/TNLean/MPS/BNT/BasisNormal.lean
@@ -4,31 +4,19 @@ import Mathlib.Algebra.Module.Submodule.Range
 import Mathlib.LinearAlgebra.Vandermonde
 
 /-!
-# Basis / normality tools for the multi-block Fundamental Theorem
+# Vandermonde separation for canonical-form weights
 
-This file contains the (purely algebraic) Vandermonde-based separation lemmas that underpin the
-"eventual linear independence" arguments for multi-block MPS canonical forms.
-
-The key point is that, if the block scaling factors `μ k` are pairwise distinct, then the vectors
-`(μ k) ^ N` form an invertible Vandermonde system for `N = 0, …, r-1`.  This lets us separate block
-contributions once we can reduce to an equation of the form
-
-`∑ k, v k * (μ k) ^ N = 0` for `N = 0, …, r-1`.
+This file contains the purely algebraic Vandermonde separation lemma for distinct
+canonical-form weights. The main BNT comparison route uses eventual linear independence from
+overlap orthogonality; this file only records the scalar finite-dimensional separation step used
+elsewhere in the block-permutation discussion.
 -/
 
 open scoped Matrix BigOperators
 
 namespace MPSTensor
 
-variable {d D : ℕ}
-
-/-- The MPV at system size `N` viewed as a vector in the function space
-`(Fin N → Fin d) → ℂ`. -/
-def mpvFun (A : MPSTensor d D) (N : ℕ) : (Fin N → Fin d) → ℂ :=
-  fun σ => mpv A σ
-
-@[simp] lemma mpvFun_apply (A : MPSTensor d D) (N : ℕ) (σ : Fin N → Fin d) :
-    mpvFun A N σ = mpv A σ := rfl
+variable {d : ℕ}
 
 /-- The Vandermonde separation lemma: if the scaling factors `μ k` are distinct,
 then any linear relation `∑ k, c k * (μ k) ^ N = 0` holding for `N = 0, …, r-1`
@@ -40,57 +28,5 @@ lemma vandermonde_separation (C : CanonicalForm d)
       (∑ k : Fin C.numBlocks, c k * (C.μ k) ^ (N : ℕ)) = 0) :
     c = 0 := by
   simpa using Matrix.eq_zero_of_forall_pow_sum_mul_pow_eq_zero hμ hc
-
-/-- A function-valued variant of `vandermonde_separation`.
-
-If `μ` is injective and we have Vandermonde-type relations pointwise in `a : α`, then the whole
-family of functions must vanish. -/
-lemma vandermonde_separation_fun {n : ℕ} {α : Type*}
-    (μ : Fin n → ℂ) (hμ : Function.Injective μ)
-    (v : Fin n → α → ℂ)
-    (hv : ∀ i : Fin n, ∀ a : α, (∑ j : Fin n, v j a * μ j ^ (i : ℕ)) = 0) :
-    v = 0 := by
-  classical
-  funext j a
-  exact congr_fun
-    (Matrix.eq_zero_of_forall_pow_sum_mul_pow_eq_zero hμ (fun i => by simpa using hv i a)) j
-
-/-- Vandermonde separation for MPVs of blocks at a *fixed* system size.
-
-This is the basic linear-algebraic fact we use later: once the coefficient vectors are fixed (here,
-functions `σ ↦ mpv (blockTensor k) σ` for a fixed `N₀`), distinct scaling factors `μ k` allow one to
-separate the contributions by looking at finitely many powers. -/
-lemma block_mpvs_separation_at_fixed_size (C : CanonicalForm d)
-    (hμ : Function.Injective C.μ) (N₀ : ℕ)
-    (c : Fin C.numBlocks → ℂ)
-    (hc : ∀ i : Fin C.numBlocks, ∀ σ : Fin N₀ → Fin d,
-      (∑ k : Fin C.numBlocks,
-        (c k * mpv (C.blockTensor k) σ) * (C.μ k) ^ (i : ℕ)) = 0) :
-    ∀ k : Fin C.numBlocks, c k • mpvFun (C.blockTensor k) N₀ = 0 := by
-  classical
-  intro k
-  have hv := vandermonde_separation_fun C.μ hμ
-    (v := fun j σ => (c j • mpvFun (C.blockTensor j) N₀) σ) (fun i σ => by
-      simpa [mpvFun, smul_eq_mul, mul_assoc, mul_left_comm, mul_comm] using hc i σ)
-  exact congr_fun hv k
-
-/-- A convenient corollary of `block_mpvs_separation_at_fixed_size`:
-
-if each block MPV is nonzero at size `N₀`, then the Vandermonde relations force the coefficients
-themselves to vanish. -/
-lemma block_mpvs_lin_indep_at_fixed_size (C : CanonicalForm d)
-    (hμ : Function.Injective C.μ) (N₀ : ℕ)
-    (hnonzero : ∀ k : Fin C.numBlocks, mpvFun (C.blockTensor k) N₀ ≠ 0)
-    (c : Fin C.numBlocks → ℂ)
-    (hc : ∀ i : Fin C.numBlocks, ∀ σ : Fin N₀ → Fin d,
-      (∑ k : Fin C.numBlocks,
-        (c k * mpv (C.blockTensor k) σ) * (C.μ k) ^ (i : ℕ)) = 0) :
-    c = 0 := by
-  classical
-  have hsep := block_mpvs_separation_at_fixed_size C hμ N₀ c hc
-  funext k
-  obtain ⟨σ, hσ⟩ := Function.ne_iff.mp (hnonzero k)
-  exact (mul_eq_zero.mp (by simpa [Pi.smul_apply, smul_eq_mul] using congr_fun (hsep k) σ)
-    ).resolve_right hσ
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/BasicSectorComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/BasicSectorComparison.lean
@@ -10,9 +10,8 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 # Basic sector comparisons from phase covers
 
 This module contains the first sector-comparison consequences used after the
-canonical-form reduction: proportional-decomposition comparisons, zero-tail
-block-span comparisons, common MPV phase covers, and the corresponding
-zero-tail proportional-decomposition specialization.
+canonical-form reduction: zero-tail block-span comparisons and common MPV
+phase-cover routes for the leftover all-zero block bookkeeping.
 
 ## References
 
@@ -25,59 +24,6 @@ matrix product states, canonical form, BNT, proportional decomposition
 -/
 
 namespace MPSTensor
-
-/-- **Sector comparison from BNT proportional-decomposition data.**
-
-A proportional-decomposition comparison supplies a common MPV phase cover of the two
-nonzero-weight block families. Therefore the common-cover sector theorem applies without an
-extra finite-length span hypothesis. -/
-theorem afterBlocking_sectorComparison_of_proportionalDecompositionConclusion
-    {d D₁ D₂ p rA rB : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    [∀ k : Fin rA, NeZero (dimA k)]
-    [∀ k : Fin rB, NeZero (dimB k)]
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B)
-    (hp : 0 < p)
-    (μA : Fin rA → ℂ)
-    (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d p) (dimA k))
-    (μB : Fin rB → ℂ)
-    (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d p) (dimB k))
-    (hMatch : ProportionalDecompositionConclusion (d := blockPhysDim d p) blocksA blocksB)
-    (hAblocks : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
-      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA))
-    (hBblocks : SameMPV₂ (blockTensor (d := d) (D := D₂) B p)
-      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB))
-    (hTPA : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksA k i)ᴴ * blocksA k i = 1)
-    (hTPB : ∀ k, ∑ i : Fin (blockPhysDim d p), (blocksB k i)ᴴ * blocksB k i = 1)
-    (hIrrA : ∀ k, IsIrreducibleTensor (blocksA k))
-    (hIrrB : ∀ k, IsIrreducibleTensor (blocksB k))
-    (hPrimA : ∀ k, _root_.IsPrimitive
-      (transferMap (d := blockPhysDim d p) (D := dimA k) (blocksA k)))
-    (hPrimB : ∀ k, _root_.IsPrimitive
-      (transferMap (d := blockPhysDim d p) (D := dimB k) (blocksB k)))
-    (hInjA : ∀ k, IsInjective (blocksA k))
-    (hInjB : ∀ k, IsInjective (blocksB k))
-    (hμA : ∀ k, μA k ≠ 0)
-    (hμB : ∀ k, μB k ≠ 0) :
-    ∃ p' : ℕ, 0 < p' ∧
-    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
-      SameMPV₂ (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
-      SameMPV₂ (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
-      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
-      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
-      ∃ ζ : Fin P.basisCount → ℂ,
-        (∀ j, ζ j ≠ 0) ∧
-        ∀ j : Fin P.basisCount,
-          Finset.univ.val.map (P.weight j) =
-            Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  obtain ⟨cover⟩ := nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
-    (d := blockPhysDim d p) blocksA blocksB hMatch
-  exact fundamentalTheorem_after_blocking_sector_of_common_blocks_commonPhaseCover
-    A B hSame hp μA blocksA μB blocksB cover hAblocks hBblocks hTPA hTPB hIrrA hIrrB
-    hPrimA hPrimB hInjA hInjB hμA hμB
 
 /-- **Zero-tail sector comparison from finite-length nonzero-block span equality.**
 

--- a/TNLean/PiAlgebra/BlockSeparation.lean
+++ b/TNLean/PiAlgebra/BlockSeparation.lean
@@ -11,8 +11,8 @@ The step from global `SameMPV₂` on block-diagonal tensors to per-block `SameMP
 separating the weighted sum `∑_k μ_k^N · mpv(A_k, σ) = ∑_k μ_k^N · mpv(B_k, σ)` into
 individual block equalities `mpv(A_k, σ) = mpv(B_k, σ)` for each `k`.
 
-**The difficulty**: the standard Vandermonde argument (as in `vandermonde_separation_fun`)
-requires *fixed* coefficients at each power, but here the "coefficients"
+**The difficulty**: a direct Vandermonde argument requires *fixed* coefficients
+at each power, but here the "coefficients"
 `mpv(A_k, σ) - mpv(B_k, σ)` depend on `σ : Fin N → Fin d` whose type varies with `N`.
 
 **Alternative route via repeated words and Newton's identities**:

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -977,6 +977,22 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     fixed-length word-span saturation result.
 \end{remark}
 
+\begin{remark}[Use of the quantum Wielandt theorem in the MPS route]
+    The source papers use the quantum Wielandt theorem as an input converting
+    normality into injectivity after blocking. In the notation of this chapter,
+    the input has two distinct conclusions. First,
+    Theorem~\ref{thm:wielandt_bound} gives cumulative saturation
+    $T_{D^2}(A)=\MN{D}$. This alone is not the injectivity statement used in
+    canonical form, because injectivity requires products of one fixed length.
+    Second, Lemma~2(b) of~\cite{Sanz2010Quantum}, formalized here through
+    Theorem~\ref{thm:wielandt_lemma2b}, supplies a length $N$ for which
+    $S_N(A)=\MN{D}$. This is the statement that matches the injectivity of
+    $\Gamma_N$ and can be transported through blocking by
+    Lemma~\ref{lem:blocking_transfer}. Thus any later use of Wielandt in the
+    Fundamental Theorem must specify whether it is using cumulative span,
+    exact-length span, or the blocked version of the exact-length conclusion.
+\end{remark}
+
 \section{Blocked tensor and rectangular span}\label{sec:rectangular_span}
 
 This section extends the Lemma~2(b) argument to the

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -459,56 +459,6 @@ The main references are
 	(Theorem~\ref{thm:bnt_perm_prop}) suffices for the Fundamental Theorem.
 \end{remark}
 
-\subsection{Fixed-size separation by Vandermonde inversion}
-
-\begin{lemma}[Vandermonde separation]
-	\label{lem:bnt_vandermonde_separation}
-	\lean{MPSTensor.vandermonde_separation}
-	\leanok
-	\uses{def:is_canonical_form}
-	Let $C$ be a canonical form with $r$ blocks and pairwise distinct
-	weights $\mu_k$.
-	If coefficients $c_k$ satisfy
-	\[
-		\sum_k c_k \mu_k^N = 0
-	\]
-	for $N = 0, \ldots, r-1$, then every $c_k$ vanishes.
-\end{lemma}
-
-\begin{proof}\leanok
-	The Vandermonde matrix with entries $V_{Nk} = \mu_k^N$ is invertible when
-	the weights are pairwise distinct. Therefore the displayed linear system
-	has only the zero solution.
-\end{proof}
-
-\begin{lemma}[Fixed-size linear independence of block MPVs]
-	\label{lem:block_mpvs_fixed_size_li}
-	\lean{MPSTensor.block_mpvs_lin_indep_at_fixed_size}
-	\leanok
-	\uses{lem:bnt_vandermonde_separation}
-	Let $C$ be a canonical form with $r$ blocks and pairwise distinct
-	weights $\mu_k$, and fix a system size $N_0$. Assume that each block MPV
-	$\ket{V^{(N_0)}(A_k)}$ is nonzero. If
-	\[
-		\sum_k c_k\,V^{(N_0)}(A_k)_\sigma\,\mu_k^i = 0
-	\]
-	for every word $\sigma$ of length $N_0$ and every $i = 0, \ldots, r-1$,
-	then $c_k = 0$ for all $k$.
-\end{lemma}
-
-\begin{proof}\leanok\uses{lem:bnt_vandermonde_separation}
-	Apply Lemma~\ref{lem:bnt_vandermonde_separation} pointwise in the word
-	$\sigma$. This shows that every component of
-	$c_k\ket{V^{(N_0)}(A_k)}$ vanishes. Since the MPV of each block is
-	nonzero at size $N_0$, some component survives, so $c_k = 0$.
-\end{proof}
-
-\begin{remark}
-	These fixed-size Vandermonde theorems remain available for alternative
-	finite-length arguments.  The BNT comparison below uses eventual linear
-	independence from Theorem~\ref{thm:bnt_overlap_orthonormal_li}.
-\end{remark}
-
 \section{Coefficient convergence}
 
 \begin{theorem}[Coefficient ratio decay]\label{thm:coeff_ratio_decay}
@@ -564,6 +514,21 @@ The main references are
 	Equal power sums for $A$ and $B$ therefore give equal coefficients,
 	hence equal characteristic polynomials.
 \end{proof}
+
+\begin{remark}[How the power-sum input is used]
+	The equal-MPV corollary in the source compares, for each matched basis
+	tensor, the sums
+	\[
+		\sum_q \mu_{j,q}^N
+	\]
+	on the two sides. The Newton--Girard input says that equality of all these
+	power sums determines the multiset of weights with multiplicity. It is not
+	a replacement for the BNT matching argument: the block permutation and the
+	phase gauges must already have identified which basis tensor is being
+	compared. Once that matching is available, the power-sum lemma supplies the
+	multiplicity and weight equality needed to assemble the weighted
+	block-diagonal gauge.
+\end{remark}
 
 \begin{theorem}[Equal power sums imply equal multisets]\label{thm:power_sum_multiset}
 	\lean{Matrix.sum_pow_eq_implies_multiset_eq}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1222,48 +1222,29 @@ single weighted block.
 	hypotheses.
 \end{proof}
 
-\begin{theorem}[Sector comparison from proportional-decomposition data]%
-\label{thm:afterBlocking_sectorComparison_of_proportionalDecompositionConclusion}
-	\lean{MPSTensor.afterBlocking_sectorComparison_of_proportionalDecompositionConclusion}
-	\leanok
-	\uses{thm:after_blocking_sector_common_blocks_common_phase_cover}
-	Let $A$ and $B$ have the same MPV family, and fix exact decompositions of the
-	nonzero parts at a common blocking period as in
-	Theorem~\ref{thm:after_blocking_sector_common_blocks_common_phase_cover}. Assume
-	the blocks in the nonzero parts are trace-preserving, primitive, irreducible,
-	injective, and have nonzero weights. If a BNT proportional-decomposition
-	comparison supplies a permutation, equal bond dimensions, and gauge-phase
-	equivalences between the two block families, then the same sector comparison
-	conclusion holds.
-\end{theorem}
-
-\begin{proof}
-	\leanok
-	\uses{thm:common_phase_cover_of_proportional_decomposition,
-		thm:after_blocking_sector_common_blocks_common_phase_cover}
-	The BNT proportional-decomposition data give common MPV phase-cover data.
-	Apply Theorem~\ref{thm:after_blocking_sector_common_blocks_common_phase_cover}
-	to those data.
-\end{proof}
-
-\begin{lemma}[Zero-tail cancellation]\label{lem:sameMPV2_live_of_zeroTail_eq}
+\begin{lemma}[Zero-tail cancellation for leftover zero blocks]\label{lem:sameMPV2_live_of_zeroTail_eq}
 	\lean{MPSTensor.sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq}
 	\leanok
 	\uses{def:same_mpv2, def:mpv}
-	Let $A$ and $B$ have the same MPV family, each decomposed as a zero-tail
-	tensor plus a nonzero part. If the zero-tail dimensions agree, then the
-	nonzero parts themselves have the same MPV family, including at length zero.
+	Let $A$ and $B$ have the same MPV family, each decomposed as an all-zero
+	leftover block, called the zero-tail part in this formal convention, plus a
+	nonzero part. If the leftover zero-block dimensions agree, then the nonzero
+	parts themselves have the same MPV family, including at length zero.
 \end{lemma}
 
 \begin{proof}
 	\leanok
-	\uses{def:mpv}
-	At positive lengths the zero-tail term vanishes, so the nonzero parts
-	agree. At length zero the zero-tail values are equal by hypothesis, and
-	cancellation gives equality of the nonzero parts there too.
+	\uses{thm:mpv_zero_tensor}
+	At positive lengths the all-zero leftover block vanishes, so the nonzero
+	parts agree. Theorem~\ref{thm:mpv_zero_tensor} gives the exact value
+	\[
+		V^{(0)}(\mathbf{0}_{d,D_0})_\varnothing=D_0,
+	\]
+	so equality of the two leftover zero-block dimensions gives cancellation
+	at length zero as well.
 \end{proof}
 
-\begin{theorem}[Sector comparison with zero-tail agreement]%
+\begin{theorem}[Sector comparison with zero-tail zero-block agreement]%
 \label{thm:after_blocking_sector_common_blocks_overlap_span_zero_tail}
 	\lean{MPSTensor.fundamentalTheorem_after_blocking_sector_of_common_blocks_overlapSpan_zeroTail}
 	\leanok
@@ -1271,10 +1252,11 @@ single weighted block.
 		thm:bnt_sector_decomp_tp_prim_irr_collapsed,
 		def:sector_basis_overlap_span_hyps}
 	Let $A$ and $B$ have the same MPV family. Fix $p > 0$ and suppose
-	$A^{[p]}$ and $B^{[p]}$ each decompose as a zero-tail tensor plus a
-	weighted nonzero-block tensor, with all blocks trace-preserving, primitive,
-	irreducible, and with nonzero weights. If the two zero-tail dimensions
-	agree and any pair of BNT sector decompositions equivalent to the two
+	$A^{[p]}$ and $B^{[p]}$ each decompose as an all-zero leftover block plus
+	a weighted nonzero-block tensor, with all nonzero blocks trace-preserving,
+	primitive, irreducible, and with nonzero weights. If the two leftover
+	zero-block dimensions agree and any pair of BNT sector decompositions
+	equivalent to the two
 	nonzero-block tensors satisfies the primitive overlap-span hypotheses, then there
 	exist positive $p'$ and sector decompositions $P$, $Q$ such that
 	$A^{[p']}$ equals $P$'s tensor at all positive lengths, $B^{[p']}$ equals
@@ -1289,8 +1271,8 @@ single weighted block.
 		thm:bnt_sector_decomp_tp_prim_irr_collapsed,
 		thm:sector_basis_overlap_span_to_matching,
 		thm:route_b_hetero_sector_matching}
-	Apply the zero-tail cancellation lemma to recover full equality of the
-	nonzero-block tensors. Then proceed as in
+	Apply the leftover-zero-block cancellation lemma to recover full equality
+	of the nonzero-block tensors. Then proceed as in
 	Theorem~\ref{thm:after_blocking_sector_common_blocks_overlap_span}: apply
 	the BNT construction to each block family, compose the sector
 	equivalences to obtain equality of the total MPV families of $P$ and $Q$,
@@ -1307,10 +1289,11 @@ two-basis sector comparison theorem.
 		thm:sector_basis_overlap_span_to_matching,
 		thm:route_b_hetero_sector_matching}
 	Let $A$ and $B$ have the same MPV family. Fix $p>0$ and suppose $A^{[p]}$
-	and $B^{[p]}$ each decompose as a zero-tail tensor plus a weighted nonzero
-	part, with all blocks in the nonzero part trace-preserving, primitive,
-	irreducible, injective, and with nonzero weights. If the two zero-tail
-	dimensions agree and the two nonzero-weight block families have equal
+	and $B^{[p]}$ each decompose as an all-zero leftover block plus a weighted
+	nonzero part, with all blocks in the nonzero part trace-preserving,
+	primitive, irreducible, injective, and with nonzero weights. If the two
+	leftover zero-block dimensions agree and the two nonzero-weight block
+	families have equal
 	finite-length MPV spans at every system size, then there exist a period
 	$p' > 0$ and sector decompositions $P,Q$ such that $A^{[p']}$ and
 	$B^{[p']}$ agree with the corresponding sector tensors at every positive
@@ -1325,12 +1308,12 @@ two-basis sector comparison theorem.
 		thm:sector_basis_overlap_span_to_matching,
 		thm:route_b_hetero_sector_matching}
 	The finite-length span equality gives the primitive overlap-span hypotheses
-	for the BNT sector bases of the two nonzero parts. Zero-tail cancellation
-	identifies the two nonzero parts as full MPV families, while the zero-tail
-	summands vanish at positive lengths, giving the positive-length comparison of
-	$A^{[p]}$ and $B^{[p]}$ with the two sector decompositions. The sector-basis
-	matching and two-basis comparison theorems then give the sector-weight
-	conclusion.
+	for the BNT sector bases of the two nonzero parts. Cancellation of leftover
+	zero blocks identifies the two nonzero parts as full MPV families, while the
+	leftover zero-block summands vanish at positive lengths, giving the
+	positive-length comparison of $A^{[p]}$ and $B^{[p]}$ with the two sector
+	decompositions. The sector-basis matching and two-basis comparison theorems
+	then give the sector-weight conclusion.
 \end{proof}
 
 \begin{definition}[Span hypotheses for common primitive sectors]%
@@ -1340,9 +1323,10 @@ two-basis sector comparison theorem.
 	\uses{def:mpv_state, def:injective}
 	For two common primitive nonzero-sector families at one blocking length, this
 	condition consists of the hypotheses needed before applying the
-	zero-tail sector comparison: equality of the two zero-tail dimensions,
-	one-site injectivity of all blocks on both sides, and equality of the
-	finite-length MPV spans of the two block families for every system size.
+	zero-block sector comparison: equality of the two leftover zero-block
+	dimensions, one-site injectivity of all blocks on both sides, and equality
+	of the finite-length MPV spans of the two block families for every system
+	size.
 \end{definition}
 
 \begin{theorem}[Phase covers supply span hypotheses]%
@@ -1782,19 +1766,20 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:common_sector_relabeling_hypothesis, def:same_mpv2_pos,
 		def:mpv_common_phase_cover}
-		Assume two tensors generate the same MPV family and assume the blocked-word
-		identification used in the common-sector construction.  Then there is a
-	common blocking length at which both tensors have zero-tail decompositions whose
-	nonzero parts are weighted families of trace-preserving, primitive,
-	tensor-irreducible blocks with positive bond dimension and nonzero weights.  The
-	theorem further includes the three positive-length MPV agreements
+	Assume two tensors generate the same MPV family and assume the blocked-word
+	identification used in the common-sector construction.  Then there is a
+	common blocking length at which both tensors decompose into a leftover
+	all-zero block and a weighted nonzero part whose summands are
+	trace-preserving, primitive, tensor-irreducible blocks with positive bond
+	dimension and nonzero weights.  The theorem further includes the three
+	positive-length MPV agreements
 	\(\mc{V}^{+}(\cdot)=\mc{V}^{+}(\cdot)\): the two agreements comparing each
 	blocked tensor with its own nonzero-sector part and the agreement comparing the
-	two nonzero-sector parts, together with the length-zero zero-tail identity, as
-	in
+	two nonzero-sector parts, together with the length-zero leftover-block
+	identity, as in
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}.
 	For these particular common-sector families, any common MPV phase cover gives
-	the finite-length nonzero-block span equality needed by the zero-tail block-span
+	the finite-length nonzero-block span equality needed by the zero-block block-span
 	theorem.  A BNT proportional-decomposition conclusion for the same families
 	gives the same span equality.
 \end{theorem}
@@ -1818,11 +1803,11 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	Let $A$ and $B$ have the same MPV family.  Then there is a positive blocking
-	length at which both blocked tensors decompose into a zero-tail part and a
-	weighted direct sum of trace-preserving, primitive, tensor-irreducible blocks
-	with positive bond dimensions and nonzero weights.  The two nonzero-sector
-	families have the same positive-length MPV family, and the zero-tail parts
-	satisfy the length-zero identity.
+	length at which both blocked tensors decompose into a leftover all-zero
+	block and a weighted direct sum of trace-preserving, primitive,
+	tensor-irreducible blocks with positive bond dimensions and nonzero weights.
+	The two nonzero-sector families have the same positive-length MPV family,
+	and the leftover zero blocks satisfy the length-zero identity.
 \end{theorem}
 
 \begin{proof}

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -79,12 +79,6 @@ heterogeneous block-matching theorem is a genuine formal endpoint for the
 block-matching part, while the final global weighted gauge equivalence remains
 the paper-level equal-MPV target.
 
-\paragraph{Parent-Hamiltonian statements.}
-The parent-Hamiltonian chapter uses additional intersection-property,
-periodic-chain, and ground-space-span results.  These are cited mathematical
-ingredients for the parent-Hamiltonian consequences, not extra theorems in the
-non-periodic Fundamental Theorem proof.
-
 \section{External lemmas need explanations}
 
 When a result is needed but the MPS source only cites it, the formal
@@ -117,12 +111,6 @@ This applies in particular to the following families of external input.
     they are not proved in the MPS source.  When they are used to recover
     coefficients, multiplicities, or weight multisets, the blueprint should
     explain the finite linear system or the power-sum recursion.
-  \item Parent-Hamiltonian gap statements use the FNW intersection-property and
-    martingale estimates from \cite{Fannes1992Finitely,Nachtergaele1996Spectral}
-    and later refinements such as \cite{Kastoryano2018Martingale}.  If the
-    source only invokes these estimates, the blueprint should state the
-    finite-size criterion and the constants being used before applying it to
-    MPS parent Hamiltonians.
   \item Perron--Frobenius and peripheral-spectrum facts for quantum channels are
     standard inputs from finite-dimensional channel theory, but they are not
     interchangeable.  A formal theorem should specify whether it uses
@@ -145,13 +133,21 @@ paper-level theorems.
     \]
     It is not the full equal-MPV corollary from the papers.  It assumes the
     coefficient arrays and their nonzero limits.
-  \item The Vandermonde fixed-size separation declarations are lemmas.  They
-    remain available for finite-length arguments, but the main BNT comparison
-    route uses eventual linear independence and overlap orthogonality.
+  \item The unused fixed-size BNT Vandermonde MPV declarations have been
+    removed.  The scalar Vandermonde separation lemma remains because it is a
+    small algebraic input elsewhere, but it is not presented as part of the
+    main BNT comparison route.
   \item The equal-span permutation rigidity statement with asymptotically
     orthonormal overlaps is a lemma.  It is a useful span route, but the
     proportional BNT permutation theorem is the theorem used by the main
     proportional Fundamental Theorem in Chapter~11.
+  \item The older wrapper from proportional-decomposition data to sector
+    comparison without leftover-zero-block bookkeeping has been removed.  The
+    active after-blocking route keeps this bookkeeping visible because the
+    formal equality relation includes the empty word.  This is not terminology
+    from \cite{Cirac2016MPDO_arXiv}; the source only says that canonical forms
+    may have zero blocks through the inequality
+    \(\sum_k D_k \le D\) \cite[lines~217--219]{Cirac2016MPDO_arXiv}.
 \end{itemize}
 
 \section{Statements to keep visibly conditional}
@@ -164,11 +160,6 @@ should remain visibly conditional until the missing paper input is produced.
     canonical-form theorem.
   \item The explicit-coefficient equal case assumes coefficient arrays rather
     than deriving the BNT power-sum data from bare equality of MPVs.
-  \item The parent-Hamiltonian unique-ground-state endpoints depend on the
-    normal chain ground-space identification, and the BNT ground-space span
-    endpoint depends on the periodic block-decomposition inclusion.  They are
-    paper-level targets, but the proof surface should keep those dependencies
-    explicit until the corresponding lemmas are completed.
 \end{itemize}
 
 \section{Retirement criterion}

--- a/slides/preamble.tex
+++ b/slides/preamble.tex
@@ -73,7 +73,7 @@
                HopfieldNet, CPTPMap, IsCompletelyPositive,
                choi_PSD_iff_CP_map, pft_irreducible, spectral_dominance_of_primitive,
                IsIrreducible, IsPrimitive,
-               piAlgEquiv, perBlockLinearExtension, mpvFun},
+               piAlgEquiv, perBlockLinearExtension},
   keywordstyle=[2]\color{leangreen},
   comment=[l]{--},
   commentstyle=\color{gray}\itshape,

--- a/slides/presentation_gap_analysis.tex
+++ b/slides/presentation_gap_analysis.tex
@@ -786,14 +786,6 @@ theorem vandermonde_separation (C : CanonicalForm d)
     (hc : (*@$\forall$@*) N : Fin C.numBlocks,
       ((*@$\sum$@*) k, c k * (C.(*@$\mu$@*) k) ^ (N : (*@$\mathbb{N}$@*))) = 0) :
     c = 0
-
--- Function-valued Vandermonde (BasisNormal.lean)
-theorem vandermonde_separation_fun {n : (*@$\mathbb{N}$@*)} {(*@$\alpha$@*) : Type*}
-    ((*@$\mu$@*) : Fin n (*@$\to$@*) (*@$\mathbb{C}$@*)) (h(*@$\mu$@*) : Function.Injective (*@$\mu$@*))
-    (v : Fin n (*@$\to$@*) (*@$\alpha$@*) (*@$\to$@*) (*@$\mathbb{C}$@*))
-    (hv : (*@$\forall$@*) i : Fin n, (*@$\forall$@*) a : (*@$\alpha$@*),
-      ((*@$\sum$@*) j, v j a * (*@$\mu$@*) j ^ (i : (*@$\mathbb{N}$@*))) = 0) :
-    v = 0
 \end{lstlisting}
 
 \vspace{0.05em}


### PR DESCRIPTION
### Motivation

- Continue #1170 by reducing the active theorem surface before adding more formal proof routes.
- Keep the non-periodic Fundamental Theorem route faithful to arXiv:1606.00608 and arXiv:2011.12127 by separating paper statements from auxiliary formal bookkeeping.
- Clarify that the formal `zeroTail` convention records leftover all-zero blocks allowed by the source condition `sum_k D_k <= D`; it is not source terminology or a paper theorem hypothesis.

### Description

- Removes the unused fixed-size BNT Vandermonde MPV route: `mpvFun`, the function-valued Vandermonde separator, and the fixed-size block-MPV separation and linear-independence lemmas.
- Removes the older proportional-decomposition sector wrapper that did not expose leftover-zero-block bookkeeping; the active after-blocking route keeps that bookkeeping explicit.
- Updates the blueprint language in Chapters 7, 10, and 11 to distinguish cumulative Wielandt span from exact-length injectivity, explain the Newton-Girard power-sum input after BNT matching, and describe leftover all-zero blocks in source-faithful terms.
- Updates `docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex` to stay scoped to the non-periodic FT/BNT/canonical-form route and to remove parent-Hamiltonian examples from this audit.

### Testing

- `lake build TNLean.MPS.BNT.BasisNormal TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison TNLean.PiAlgebra.BlockSeparation`
- `PATH=/Users/siruilu/.local/pipx/venvs/leanblueprint/bin:$PATH leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `PATH=/Users/siruilu/.local/pipx/venvs/leanblueprint/bin:$PATH leanblueprint checkdecls`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`
- `git diff --check`
- Proof-integrity grep on the touched Lean files

---
Addresses #1170
Addresses #1278
Related: #944, #1178, #1133

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes unused lemmas/theorems and updates documentation/blueprint text; main risk is breaking downstream imports or references to the retired declarations.
> 
> **Overview**
> Reduces the active BNT/Fundamental-Theorem proof surface by deleting the unused fixed-size Vandermonde MPV separation route (removing `mpvFun` and related function-valued / fixed-size block MPV separation lemmas) while keeping only the scalar `vandermonde_separation` lemma.
> 
> Removes the older proportional-decomposition→sector-comparison wrapper and shifts the sector-comparison API and exposition to explicitly track the leftover all-zero “zeroTail” block bookkeeping (including length-zero behavior).
> 
> Updates blueprint/docs/slides text to reflect the retired lemmas, clarify how Wielandt’s cumulative vs exact-length conclusions are used, and explain the Newton–Girard power-sum step as an input after BNT matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63a9ef16c6e251a44cb919e7f38991a80fba0fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->