### PR TITLE
doc(MPS): clarify direct-sum proof input

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -15,10 +15,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 This module introduces `IsCanonicalFormBNT`, which extends `IsCanonicalForm` with the
 requirement that distinct blocks are not gauge-phase equivalent (i.e., equivalent blocks
-have already been merged). This is a Lean comparison package for a canonical form whose
-blocks are already chosen as basis-of-normal-tensors representatives. It should not be
-confused with the source term "block-injective canonical form" (`biCF`), which is the
-separate exact-length direct-sum span condition from arXiv:1606.00608, lines 317–345.
+have already been merged). The blocks are already chosen as basis-of-normal-tensors
+representatives. This should not be confused with the source term "block-injective canonical
+form" (`biCF`), which is the separate exact-length direct-sum span condition from
+arXiv:1606.00608, lines 317–345.
 
 ## Main results
 

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -17,7 +17,7 @@ This module introduces `IsCanonicalFormBNT`, which extends `IsCanonicalForm` wit
 requirement that distinct blocks are not gauge-phase equivalent (i.e., equivalent blocks
 have already been merged). The blocks are already chosen as basis-of-normal-tensors
 representatives. This should not be confused with the source term "block-injective canonical
-form" (`biCF`), which is the separate exact-length direct-sum span condition from
+form" (biCF), which is the separate exact-length direct-sum span condition from
 arXiv:1606.00608, lines 317–345.
 
 ## Main results
@@ -82,7 +82,7 @@ non-increasing (`Antitone`) moduli, matching the paper definitions.
 
 In the language of arXiv:2011.12127 Definition 4.2, this corresponds to a canonical form where
 each block in the basis of normal tensors is represented by a single CF block. It is not
-the paper's `biCF` condition; block-injectivity is a further fixed-length span input. -/
+the paper's biCF condition; block-injectivity is a further fixed-length span input. -/
 structure IsCanonicalFormBNT {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) : Prop extends
     IsCanonicalForm μ A where

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -15,8 +15,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 This module introduces `IsCanonicalFormBNT`, which extends `IsCanonicalForm` with the
 requirement that distinct blocks are not gauge-phase equivalent (i.e., equivalent blocks
-have already been merged). This captures the "basis of normal tensors" (BNT) property of
-Definition 4.2 / Proposition char-BNT in arXiv:2011.12127 and arXiv:1606.00608, lines 1145–1148.
+have already been merged). This is a Lean comparison package for a canonical form whose
+blocks are already chosen as basis-of-normal-tensors representatives. It should not be
+confused with the source term "block-injective canonical form" (`biCF`), which is the
+separate exact-length direct-sum span condition from arXiv:1606.00608, lines 317–345.
 
 ## Main results
 
@@ -30,7 +32,8 @@ Definition 4.2 / Proposition char-BNT in arXiv:2011.12127 and arXiv:1606.00608, 
    - Same-dimension case: `mpvOverlap_tendsto_zero` (using `blocks_not_equiv` to supply
      `¬GaugePhaseEquiv`)
 
-3. **`isBNT_of_separated_CFBNT_data`** and the bundled-data formulation **`IsCanonicalFormBNT.isBNT`**:
+3. **`isBNT_of_separated_CFBNT_data`** and the bundled-data formulation
+   **`IsCanonicalFormBNT.isBNT`**:
    a canonical-form decomposition into a basis of normal tensors yields a valid `IsBNT`
    structure, assembling all overlap and independence properties.
 
@@ -78,7 +81,8 @@ gauge-phase-equivalent blocks with equal moduli. The base `IsCanonicalForm` only
 non-increasing (`Antitone`) moduli, matching the paper definitions.
 
 In the language of arXiv:2011.12127 Definition 4.2, this corresponds to a canonical form where
-each block in the basis of normal tensors is represented by a single CF block. -/
+each block in the basis of normal tensors is represented by a single CF block. It is not
+the paper's `biCF` condition; block-injectivity is a further fixed-length span input. -/
 structure IsCanonicalFormBNT {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) : Prop extends
     IsCanonicalForm μ A where
@@ -114,7 +118,8 @@ def toHasNormalizedSelfOverlap (hCF : IsCanonicalFormBNT μ A) :
     HasNormalizedSelfOverlap (d := d) A :=
   hCF.toIsCanonicalForm.toHasNormalizedSelfOverlap
 
-/-- Rebuild `IsCanonicalFormBNT` from the additive split formulation plus the BNT separation assumption. -/
+/-- Rebuild `IsCanonicalFormBNT` from the additive split formulation plus the BNT
+separation assumption. -/
 def ofSeparatedData
     (hInj : HasInjectiveBlocks (d := d) A)
     (hLeft : IsLeftCanonicalBlockFamily (d := d) A)

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -367,12 +367,12 @@ theorem wielandt_lemma2b [NeZero D]
 
 end WielandtLemma2b
 
-/-! ## Rank-one extraction with external eigenvectors -/
+/-! ## Parametrized rank-one extraction lemmas -/
 
 section ExternalEigenvectors
 
-/-- **Rank-one element in a bounded cumulative span of the blocked tensor, given external
-word eigenvectors and a cumulative spanning witness.**
+/-- **Rank-one element in a bounded cumulative span of the blocked tensor, from supplied
+word-eigenvector data and a cumulative spanning witness.**
 
 This is the cumulative analogue of the later exact-word-span result: the manufactured rank-one
 matrix lies in `T_{D + N + D}` of the blocked tensor as soon as `T_N` is already full. -/
@@ -427,7 +427,8 @@ theorem exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors_of_cumulative
   simpa [data.hB] using
     data.rankOne_mem_wordSpan_of_cumulativeSpan_eq_top_of_aperiodic hcsB honeB
 
-/-- **Rank-one element in the word span of the blocked tensor, given external eigenvectors.**
+/-- **Rank-one element in the word span of the blocked tensor, from supplied word-eigenvector
+data.**
 
 Given:
 - A blocking length `L > 0` and eigenvector data (word functions `σ₀`, `τ₀`, eigenvectors
@@ -470,7 +471,7 @@ theorem exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors
   exact ⟨D + N₁ + D, by
     simpa [data.hB] using data.rankOne_mem_wordSpan_of_wordSpan_eq_top hBtop⟩
 
-/-- **Wielandt Lemma 2(b) blocked assembly — unconditional version with external eigenvectors.**
+/-- **Wielandt Lemma 2(b) blocked assembly from supplied word-eigenvector data.**
 
 Given word eigenvectors of length `L` with nonzero eigenvalues and `IsNormal A`,
 produces `wordSpan A N = ⊤` for an explicit `N`.

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -226,7 +226,8 @@ theorem wielandt_chain [NeZero D]
 
 /-! ## Part 5: Relation with the fixed-length bound -/
 
-/-- **Summary of the cumulative chain and fixed-length bound.**
+/-
+Summary of the cumulative chain and fixed-length bound.
 
 ### Cumulative chain:
 1. `cumulativeSpan_eq_top`: T_{D²}(A) = M_D(ℂ) for normal A
@@ -244,6 +245,5 @@ The fixed-length argument continues from this cumulative chain by extracting
 rank-one matrices from eigenvectors, padding them to one exact word length, and
 assembling a full matrix span at the Wielandt index bound.
 -/
-theorem wielandt_roadmap : True := trivial
 
 end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -77,10 +77,10 @@ The main references are
 	\end{enumerate}
 	The strictly decreasing condition is justified by the BNT grouping
 	step, which merges gauge-phase-equivalent blocks with equal moduli.
-	This is a comparison package for already selected BNT representatives. It is
-	not the source notion of block-injective canonical form, which is the
+	This records the comparison data for already selected BNT representatives. It
+	is not the source notion of block-injective canonical form, which is the
 	fixed-length direct-sum span condition discussed in
-	Chapter~\ref{ch:wielandt} and the assembly chapter.
+	Chapter~\ref{ch:wielandt} and Chapter~\ref{ch:assembly}.
 \end{definition}
 
 \begin{theorem}[Distinct bond dimensions force BNT separation]

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -77,6 +77,10 @@ The main references are
 	\end{enumerate}
 	The strictly decreasing condition is justified by the BNT grouping
 	step, which merges gauge-phase-equivalent blocks with equal moduli.
+	This is a comparison package for already selected BNT representatives. It is
+	not the source notion of block-injective canonical form, which is the
+	fixed-length direct-sum span condition discussed in
+	Chapter~\ref{ch:wielandt} and the assembly chapter.
 \end{definition}
 
 \begin{theorem}[Distinct bond dimensions force BNT separation]

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1710,8 +1710,8 @@ two-basis sector comparison theorem.
 	part agrees, as an MPV family, with the same common cyclic-sector family after
 	identifying blocked physical words. It is a formal interface for the
 	coordinate equality between direct and iterated blocking. The
-	coordinate-grouping theorem below supplies this interface in the wrappers that
-	invoke it, so it is not a new paper-level mathematical hypothesis.
+	coordinate-grouping theorem below supplies this condition in the theorems that
+	take it as a hypothesis, so it is not a new paper-level mathematical hypothesis.
 \end{definition}
 
 \begin{definition}[Global coordinate-grouping hypothesis for common sectors]%

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1708,8 +1708,8 @@ two-basis sector comparison theorem.
 	\leanok
 	This is the one-sided assertion that the canonically blocked weighted nonzero
 	part agrees, as an MPV family, with the same common cyclic-sector family after
-	identifying blocked physical words. It is a formal interface for the
-	coordinate equality between direct and iterated blocking. The
+	identifying blocked physical words. It isolates the coordinate equality between
+	direct and iterated blocking. The
 	coordinate-grouping theorem below supplies this condition in the theorems that
 	take it as a hypothesis, so it is not a new paper-level mathematical hypothesis.
 \end{definition}
@@ -1830,10 +1830,10 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:common_primitive_phase_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis}
-	Let $A$ and $B$ have the same MPV family.  Given the formal blocked-word
-	identification for the common-sector data, the common-sector structural theorem
-	produces a common blocking length, zero-tail identities, and trace-preserving,
-	primitive, irreducible nonzero-sector families on both sides. If those
+	Let $A$ and $B$ have the same MPV family.  Assume the formal blocked-word
+	identification for the common-sector data.  The common-sector structural
+	theorem then produces a common blocking length, zero-tail identities, and
+	trace-preserving, primitive, irreducible nonzero-sector families on both sides. If those
 	families satisfy the phase-cover hypotheses of
 	Definition~\ref{def:common_primitive_phase_cover_hypotheses}, then the sector
 	decompositions obtained from the two sides have BNT data, agree as full MPV
@@ -1856,9 +1856,9 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis}
-	Let $A$ and $B$ have the same MPV family.  Given the formal blocked-word
-	identification for the common-sector data, the common-sector structural theorem
-	produces the common primitive nonzero-sector families. If
+	Let $A$ and $B$ have the same MPV family.  Assume the formal blocked-word
+	identification for the common-sector data.  The common-sector structural
+	theorem then produces the common primitive nonzero-sector families. If
 	those families satisfy the BNT-cover hypotheses, then the same sector-weight
 	comparison conclusion holds.
 \end{theorem}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1706,10 +1706,12 @@ two-basis sector comparison theorem.
 \label{def:common_sector_relabeling_hypothesis}
 	\lean{MPSTensor.CommonSectorRelabelingHypothesis}
 	\leanok
-		This is the one-sided assertion that the canonically blocked weighted nonzero
-		part agrees, as an MPV family, with the same common cyclic-sector family after
-		identifying blocked physical words. It isolates the coordinate equality for
-		direct and iterated blocking.
+	This is the one-sided assertion that the canonically blocked weighted nonzero
+	part agrees, as an MPV family, with the same common cyclic-sector family after
+	identifying blocked physical words. It is a formal interface for the
+	coordinate equality between direct and iterated blocking. The
+	coordinate-grouping theorem below supplies this interface in the wrappers that
+	invoke it, so it is not a new paper-level mathematical hypothesis.
 \end{definition}
 
 \begin{definition}[Global coordinate-grouping hypothesis for common sectors]%
@@ -1721,7 +1723,8 @@ two-basis sector comparison theorem.
 	common blocked cyclic-sector family satisfies the coordinate-grouping condition
 	for each original nonzero block.  Equivalently, the canonical identification with
 	each iterated blocked alphabet agrees with grouping the direct blocked word into
-	consecutive words of the period-removal length.
+	consecutive words of the period-removal length.  The next theorem proves this
+	assertion from the concrete word-cast construction.
 \end{definition}
 
 	\begin{theorem}[Canonical coordinate grouping]%
@@ -1827,11 +1830,10 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:common_primitive_phase_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis}
-	Let $A$ and $B$ have the same MPV family. Assume the blocked-word
-	identification hypothesis for the cyclic-sector data. The common-sector
-	structural theorem then produces a common blocking length, zero-tail
-	identities, and trace-preserving, primitive, irreducible nonzero-sector
-	families on both sides. If those
+	Let $A$ and $B$ have the same MPV family.  Given the formal blocked-word
+	identification for the common-sector data, the common-sector structural theorem
+	produces a common blocking length, zero-tail identities, and trace-preserving,
+	primitive, irreducible nonzero-sector families on both sides. If those
 	families satisfy the phase-cover hypotheses of
 	Definition~\ref{def:common_primitive_phase_cover_hypotheses}, then the sector
 	decompositions obtained from the two sides have BNT data, agree as full MPV
@@ -1854,9 +1856,9 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis}
-	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
-	identification hypothesis for the cyclic-sector data. The common-sector
-	structural theorem produces the common primitive nonzero-sector families. If
+	Let $A$ and $B$ have the same MPV family.  Given the formal blocked-word
+	identification for the common-sector data, the common-sector structural theorem
+	produces the common primitive nonzero-sector families. If
 	those families satisfy the BNT-cover hypotheses, then the same sector-weight
 	comparison conclusion holds.
 \end{theorem}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -1,0 +1,21 @@
+# Paper-Gap Notes
+
+This directory records places where the formal development needs more detail
+than the cited source paper states locally. A note should identify the exact
+source passage, state the mathematical input in paper notation, and then name
+the current formal boundary.
+
+For the non-periodic MPS Fundamental Theorem route:
+
+- `canonical_bnt_ft_theorem_surface.tex` separates paper-level theorem
+  statements from auxiliary formal declarations.
+- `nonperiodic_mps_bnt_comparison_inputs.tex` compares the current
+  canonical-form/BNT/after-blocking proof boundary against the local paper
+  sources.
+- `david2006_direct_sum_input.tex` explains the older MPS representation
+  paper's direct-sum input behind block-injective canonical form.
+- `quantum_wielandt_deviation.tex` records the local proof boundary for the
+  quantum Wielandt inequality.
+
+Parent-Hamiltonian notes live here too, but they are not part of the current
+non-periodic FT cleanup loop unless explicitly brought back into scope.

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -106,7 +106,8 @@ This applies in particular to the following families of external input.
     injectivity and block-injectivity argument of
     \cite{PerezGarcia2007MPSReps}.  The formal statement should identify the
     common blocked physical alphabet and the direct-sum matrix algebra that is
-    being spanned.
+    being spanned.  The direct-sum proof input in the older source is recorded
+    in \path{docs/paper-gaps/david2006_direct_sum_input.tex}.
   \item Vandermonde inversion and Newton--Girard identities are elementary, but
     they are not proved in the MPS source.  When they are used to recover
     coefficients, multiplicities, or weight multisets, the blueprint should

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -86,7 +86,7 @@ identity as padding.
 
 \section{Formal boundary}
 
-The current formal development has safe consumers of this input.
+The current formal development includes downstream lemmas that depend on this input.
 \begin{itemize}
   \item \leanid{WordTupleSpanTop} expresses exact-length span of a direct-sum
         block family.
@@ -96,32 +96,24 @@ The current formal development has safe consumers of this input.
         \path{TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean} turn a
         positive homogeneous window of \leanid{PairWordTupleSpanTop} data into
         homogeneous trace separation.
-  \item The BNT wrappers in
+  \item The BNT-level reformulations in
         \path{TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean} turn
         pairwise period-window data into a common \leanid{WordTupleSpanTop}
         length for a canonical-form BNT family.
 \end{itemize}
 
-What remains is the producer theorem matching the source statement: from the
-canonical-form BNT representatives, their injectivity after the prescribed
-blocking, and their phase-gauge inequivalence, produce the exact-length
-direct-sum span or the equivalent homogeneous period-window certificates.  Until
-that theorem is formalized, the final BNT pair-separation theorem should remain
-conditional on the explicit period-window or fixed-length span input.
+\section{Conclusion}
 
-\section{Retirement test}
-
-Any formal theorem in this part should be checked against the source input
-above.  It is source-faithful if it states one of the following:
-\begin{enumerate}
-  \item exact-length direct-sum span for the selected canonical BNT
-        representatives;
-  \item the trace-dual homogeneous separation statement at one positive length;
-  \item a period-window package that implies the same homogeneous conclusion.
-\end{enumerate}
-It is too weak if it only records cumulative span fullness.  It is too strong
-or misleading if it claims homogeneous identity padding from the empty-word
-identity or from cumulative identity membership alone.
+The present status is a theorem-level gap.  The source-paper theorem itself has
+not yet been formalized in MPS notation: from the canonical-form BNT
+representatives, their injectivity after the prescribed blocking, and their
+phase-gauge inequivalence, one must derive the exact-length direct-sum span, or
+equivalently the homogeneous trace-dual separation statement at one positive
+length.  Until that theorem is formalized, the final BNT pair-separation theorem
+should remain conditional on an explicit period-window or fixed-length span
+input.  A candidate formal theorem is too weak if it only records cumulative
+span fullness, and it is misleading if it claims homogeneous identity padding
+from the empty-word identity or from cumulative identity membership alone.
 
 \bibliographystyle{alpha}
 \bibliography{docs/paper-gaps/references}

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -1,0 +1,129 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{docs/paper-gaps/command}
+
+\title{The Direct-Sum Input from the Older MPS Representation Paper}
+\author{}
+\date{2026-05-05}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+The finite-length direct-sum input used behind the block-injective
+canonical-form route is not proved in the 2016 MPDO source.  The 2016 paper
+cites the older representation paper for the block-injective-after-blocking
+step \cite[lines~340--345]{Cirac2016MPDO_arXiv}.  The local source for the
+older argument is \path{Papers/quant-ph_0608197/MPSarchive.tex}.
+
+That source first introduces the injectivity condition \(C1\): for some
+\(L_0\), the map
+\[
+  \Gamma_{L_0}(X)
+    =
+    \sum_{i_1,\ldots,i_{L_0}}
+      \operatorname{tr}(X A_{i_1}\cdots A_{i_{L_0}})
+      |i_1,\ldots,i_{L_0}\rangle
+\]
+is injective.  It immediately identifies this with the exact-length word
+products of length \(L_0\) spanning the full matrix algebra
+\cite[lines~888--908]{PerezGarcia2007MPSReps}.
+
+The technical algebraic lemma then says that, for nonzero \(D\times D\)
+matrices \(C\), every matrix \(X\) is a finite sum
+\[
+  X = \sum_i R_i C S_i .
+\]
+The proof reduces \(C\) to a matrix unit by elementary matrix operations and
+then reconstructs \(X\) from permuted copies of that matrix unit
+\cite[lines~1333--1344]{PerezGarcia2007MPSReps}.
+
+The next lemma is the direct-sum statement.  Its local hypotheses are important:
+the tensor has \(b \ge 2\) canonical blocks \(A^1,\ldots,A^b\), each block
+satisfies \(C1\), the common length is
+\(L_0=\max_j L_0^{A^j}\), the block sizes are ordered, and the block states are
+assumed pairwise different
+\cite[lines~1321--1330]{PerezGarcia2007MPSReps}.  Under these hypotheses, if
+\(L \ge 3(b-1)(L_0+1)\), then
+\[
+  \sum_{j=1}^b \mathcal G_L^{A^j}
+\]
+is a direct sum \cite[lines~1346--1408]{PerezGarcia2007MPSReps}.  The proof is
+by induction on the number of blocks.  The base case uses \(C1\) and the
+matrix-factorization lemma to show that a nontrivial linear dependence would
+force inclusion, then equality, of the two length-\(L_0+1\) MPS subspaces,
+contradicting uniqueness of the associated injective parent-space
+characterization.  The induction step isolates one block with a local
+projector, applies the induction hypothesis to the remaining blocks, and then
+uses \(C1\) plus the factorization lemma to force the remaining coefficient to
+vanish.
+
+\section{MPS translation}
+
+For the non-periodic Fundamental Theorem route, the mathematical consequence is
+homogeneous and positive-length.  After the canonical-form and
+basis-of-normal-tensors reduction, the selected representatives should admit one
+length at which their simultaneous word evaluations separate the direct-sum
+blocks.  In trace-dual form, if
+\[
+  \sum_{j=1}^g \operatorname{tr}(\Delta_j A_j^w)=0
+  \qquad\text{for every word } w \text{ of length } L,
+\]
+then each \(\Delta_j\) is zero.  This is the finite-length direct-sum span input
+needed by the BNT pair-separation route.
+
+This statement is not a consequence of the empty word and is not a cumulative
+span statement.  The exact length \(L\) is part of the content.  Therefore the
+formal proof should not replace the source input by a hypothesis that only says
+the cumulative pair algebra is full, nor by a theorem that uses the length-zero
+identity as padding.
+
+\section{Formal boundary}
+
+The current formal development has safe consumers of this input.
+\begin{itemize}
+  \item \leanid{WordTupleSpanTop} expresses exact-length span of a direct-sum
+        block family.
+  \item \leanid{PairWordTupleSpanTop} and \leanid{PairTraceSeparatingAt}
+        express the two-block trace-dual form used in the pair route.
+  \item The period-window theorems in
+        \path{TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean} turn a
+        positive homogeneous window of \leanid{PairWordTupleSpanTop} data into
+        homogeneous trace separation.
+  \item The BNT wrappers in
+        \path{TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean} turn
+        pairwise period-window data into a common \leanid{WordTupleSpanTop}
+        length for a canonical-form BNT family.
+\end{itemize}
+
+What remains is the producer theorem matching the source statement: from the
+canonical-form BNT representatives, their injectivity after the prescribed
+blocking, and their phase-gauge inequivalence, produce the exact-length
+direct-sum span or the equivalent homogeneous period-window certificates.  Until
+that theorem is formalized, the final BNT pair-separation theorem should remain
+conditional on the explicit period-window or fixed-length span input.
+
+\section{Retirement test}
+
+Any formal theorem in this part should be checked against the source input
+above.  It is source-faithful if it states one of the following:
+\begin{enumerate}
+  \item exact-length direct-sum span for the selected canonical BNT
+        representatives;
+  \item the trace-dual homogeneous separation statement at one positive length;
+  \item a period-window package that implies the same homogeneous conclusion.
+\end{enumerate}
+It is too weak if it only records cumulative span fullness.  It is too strong
+or misleading if it claims homogeneous identity padding from the empty-word
+identity or from cumulative identity membership alone.
+
+\bibliographystyle{alpha}
+\bibliography{docs/paper-gaps/references}
+
+\end{document}

--- a/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
@@ -162,6 +162,23 @@ the \(3D^5\) bound
 block-injective conclusion and bound
 \cite[lines~2114--2124]{Cirac2021Matrix}.
 
+The older representation paper contains the direct-sum input behind this cited
+step.  Its condition \(C1\) is exact-length injectivity of \(\Gamma_{L_0}\), or
+equivalently length-\(L_0\) word products spanning the full matrix algebra
+\cite[lines~888--908]{PerezGarcia2007MPSReps}.  It then fixes canonical blocks
+which each satisfy \(C1\), sets \(L_0=\max_j L_0^{A^j}\), orders their bond
+dimensions, and assumes the block states are pairwise different
+\cite[lines~1321--1330]{PerezGarcia2007MPSReps}.  Under those hypotheses, a
+matrix factorization lemma and a direct-sum lemma show that the sum of the
+corresponding length-\(L\) MPS subspaces is direct once
+\(L \ge 3(b-1)(L_0+1)\)
+\cite[lines~1333--1408]{PerezGarcia2007MPSReps}.  The formal proof boundary is
+therefore a homogeneous fixed-length direct-sum span or its trace-dual
+separation form.  The note
+\path{docs/paper-gaps/david2006_direct_sum_input.tex} records this source input
+separately because it is a cited proof component, not a named theorem in the
+2016 source.
+
 This block-injective conclusion is stronger than separate injectivity of the
 individual blocks. It includes the cross-block separation needed to prescribe
 different matrices in different basis components at one common length. In dual


### PR DESCRIPTION
### Motivation

- Issue #1278 requires that whenever a result is cited but not proved in the non-periodic MPS FT proof route, the formal development must identify the exact mathematical statement, the hypotheses in MPS notation after blocking, and the proof source. The direct-sum span input behind the block-injective canonical-form step, from the 2006 MPS representation paper, was cited without this breakdown.
- The comparison-input note and theorem-surface audit in `docs/paper-gaps/` needed updating to identify the fixed-length direct-sum / trace-dual proof boundary precisely.

### Description

- Adds `docs/paper-gaps/david2006_direct_sum_input.tex`, recording the direct-sum input for the block-injective canonical-form step: local injectivity in each block, a common blocking length equal to the maximum over all constituent blocks, ordered block dimensions, and pairwise distinct block states.
- Updates `docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex` to point to the fixed-length direct-sum / trace-dual proof boundary identified in `david2006_direct_sum_input.tex`.
- Updates `docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex` to note that `IsCanonicalFormBNT` provides data for selected BNT representatives, rather than encoding the source paper's fixed-length span condition (`biCF`) directly.
- Tightens `blueprint/src/chapter/ch11_assembly.tex` prose so that blocked-word relabeling is described as explicit coordinate input to the current conditional theorem, and the coordinate-grouping step is identified as the place where that input is supplied.
- Retires the placeholder `wielandt_roadmap : True` declaration in `TNLean/Wielandt/WielandtBound.lean` and converts the surrounding text to a comment.
- Replaces "external eigenvectors" with "supplied word-eigenvector data" in `TNLean/Wielandt/RankOne/ExtractionFull.lean`.
- The remaining proof obligations are unchanged; this does not close the related issues.

### Testing

- `lake env lean TNLean/MPS/BNT/Construction.lean`
- `lake env lean TNLean/Wielandt/WielandtBound.lean`
- `lake env lean TNLean/Wielandt/RankOne/ExtractionFull.lean`
- `lake build TNLean.MPS.BNT.Construction TNLean.Wielandt.WielandtBound TNLean.Wielandt.RankOne.ExtractionFull -q --log-level=info`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/david2006_direct_sum_input.tex`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`
- `leanblueprint web` and `leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

Related to #1170, #944, #1178, and #1133.

---
Addresses #1278

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/prose clarifications plus removal of a placeholder `True` theorem; no core mathematical definitions or proofs are materially altered.
> 
> **Overview**
> Clarifies the meaning and boundaries of `IsCanonicalFormBNT`/CF-BNT data by explicitly distinguishing **BNT representative separation** from the paper’s **block-injective canonical form (biCF)** fixed-length direct-sum span condition.
> 
> Adds a new `docs/paper-gaps/` note (`david2006_direct_sum_input.tex`) and updates existing gap/blueprint text to pinpoint the *exact* older-source proof input (fixed-length direct-sum / trace-dual separation) behind the cited biCF-after-blocking step, and to frame blocked-word identification hypotheses as formal coordinate data rather than new paper-level assumptions.
> 
> Cleans up minor narrative/structure: retitles comments in `Wielandt/RankOne/ExtractionFull.lean`, and removes the placeholder `wielandt_roadmap : True` from `WielandtBound.lean` (leaving a roadmap comment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccf16a4a52923fe2309a54a955c2d7dfc449a32a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->