### PR TITLE
refactor(MPS/CanonicalForm): demote conditional after-blocking FT theorems

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -66,7 +66,7 @@ The imported modules provide the canonical-form reduction theorems, including
 `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`,
 `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking`,
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
-`afterBlocking_structuralData_of_sameMPV₂`.
+`exists_bilateral_tp_primitive_blockDecomp_after_blocking`.
 
 This public entry point also records a conditional formulation of the
 Cirac--Pérez-García--Schuch--Verstraete after-blocking theorem that does not

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
@@ -20,8 +20,8 @@ sides have TP-primitive decompositions.
 * `bilateral_commonPeriod_blocking_tp_primitive_normal` — two tensors with
   primitive blocked transfer maps have a common positive blocking period that
   preserves primitivity, left-canonical normalization, and normality.
-* `afterBlocking_structuralData_of_sameMPV₂` — two tensors with the
-  same MPVs have blocked TP-primitive decompositions on both sides.
+* `exists_bilateral_tp_primitive_blockDecomp_after_blocking` — two tensors
+  have blocked TP-primitive decompositions on both sides.
 
 ## References
 
@@ -179,24 +179,19 @@ theorem bilateral_commonPeriod_blocking_tp_primitive_normal
   · exact isNormal_blockTensor_of_isNormal (d := d) (D := D₁) A hp hNormalA
   · exact isNormal_blockTensor_of_isNormal (d := d) (D := D₂) B hp hNormalB
 
-/-- **Fundamental Theorem of MPS (1606.00608, after blocking): current structural shell.**
+/-- **Bilateral one-sided structural decomposition after blocking.**
 
-For any two MPS tensors `A, B` with `SameMPV₂ A B`, this theorem gives the
-currently formalized one-sided reduction data on both sides: after blocking,
-each tensor admits a decomposition into a zero-tail tensor and TP blocks with
-primitive transfer maps, nonzero weights, and positive bond dimensions.
+For any two MPS tensors `A, B`, this theorem gives the one-sided reduction data
+on both sides: after blocking, each tensor admits a decomposition into a
+zero-tail tensor and TP blocks with primitive transfer maps, nonzero weights,
+and positive bond dimensions.
 
-The theorem does not yet use `SameMPV₂ A B` to compare the two blocked
-families. The subsequent content is the sector-level comparison:
-a BNT sector construction for each side,
-followed by a two-basis equal-case comparison theorem for those sector decompositions.
-
-This theorem therefore gives the structural statement currently available on the
-way to arXiv:1606.00608, Theorem 1. -/
-theorem afterBlocking_structuralDecompositionData_of_sameMPV₂
+This theorem intentionally has no `SameMPV₂ A B` hypothesis: it does not compare
+the two blocked families. The comparison enters only in later statements that
+also keep blocked `SameMPV₂` data. -/
+lemma exists_bilateral_tp_primitive_blockDecomp_after_blocking
     {d D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (_hSame : SameMPV₂ A B) :
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
     -- Both tensors have blocked TP-primitive decompositions
     ∃ (zeroTailA : ℕ) (pA : ℕ) (_ : 0 < pA)
       (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
@@ -235,41 +230,6 @@ theorem afterBlocking_structuralDecompositionData_of_sameMPV₂
     zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
     hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, hMPVA, hMPVB⟩
 
-/-- Compatibility formulation for the older structural data shape.
-
-This keeps the historical witness order while the stronger decomposition version
-`afterBlocking_structuralDecompositionData_of_sameMPV₂` exposes the zero-tail MPV
-equations needed for the paper-facing statement. -/
-theorem afterBlocking_structuralData_of_sameMPV₂
-    {d D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :
-    -- Both tensors have blocked TP-primitive decompositions
-    ∃ (pA : ℕ) (_ : 0 < pA)
-      (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
-      (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d pA) (dimA k)),
-    ∃ (pB : ℕ) (_ : 0 < pB)
-      (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
-      (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d pB) (dimB k)),
-      -- Blocks are TP
-      (∀ k, ∑ i, (blocksA k i)ᴴ * blocksA k i = 1) ∧
-      (∀ k, ∑ i, (blocksB k i)ᴴ * blocksB k i = 1) ∧
-      -- Blocks have primitive transfer maps
-      (∀ k, _root_.IsPrimitive (transferMap (blocksA k))) ∧
-      (∀ k, _root_.IsPrimitive (transferMap (blocksB k))) ∧
-      -- Nonzero weights
-      (∀ k, μA k ≠ 0) ∧
-      (∀ k, μB k ≠ 0) ∧
-      -- Positive bond dimensions
-      (∀ k, 0 < dimA k) ∧
-      (∀ k, 0 < dimB k) := by
-  obtain ⟨_zeroTailA, pA, hpA, rA, dimA, μA, blocksA,
-    _zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
-    hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, _hMPVA, _hMPVB⟩ :=
-    afterBlocking_structuralDecompositionData_of_sameMPV₂ A B hSame
-  exact ⟨pA, hpA, rA, dimA, μA, blocksA, pB, hpB, rB, dimB, μB, blocksB,
-    hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB⟩
-
 /-- A strengthened after-blocking structural statement that keeps the blocked `SameMPV₂`
 relations at the reduction periods. This is a genuine step forward because the
 common equality is no longer discarded by the public structural theorem. -/
@@ -295,10 +255,10 @@ theorem afterBlocking_structuralDataWithBlockedSameMPV₂_of_sameMPV₂
       (∀ k, μB k ≠ 0) ∧
       (∀ k, 0 < dimA k) ∧
       (∀ k, 0 < dimB k) := by
-  obtain ⟨pA, hpA, rA, dimA, μA, blocksA,
-    pB, hpB, rB, dimB, μB, blocksB,
-    hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB⟩ :=
-    afterBlocking_structuralData_of_sameMPV₂ A B hSame
+  obtain ⟨_zeroTailA, pA, hpA, rA, dimA, μA, blocksA,
+    _zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
+    hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, _hMPVA, _hMPVB⟩ :=
+    exists_bilateral_tp_primitive_blockDecomp_after_blocking A B
   refine ⟨pA, hpA, rA, dimA, μA, blocksA, pB, hpB, rB, dimB, μB, blocksB,
     ?_, ?_, hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB⟩
   · exact sameMPV₂_blockTensor A B hSame pA

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
@@ -179,14 +179,14 @@ theorem bilateral_commonPeriod_blocking_tp_primitive_normal
   · exact isNormal_blockTensor_of_isNormal (d := d) (D := D₁) A hp hNormalA
   · exact isNormal_blockTensor_of_isNormal (d := d) (D := D₂) B hp hNormalB
 
-/-- **Bilateral one-sided structural decomposition after blocking.**
+/-- **Independent one-sided structural decompositions after blocking.**
 
-For any two MPS tensors `A, B`, this theorem gives the one-sided reduction data
+For any two MPS tensors `A, B`, this lemma gives the one-sided reduction data
 on both sides: after blocking, each tensor admits a decomposition into a
 zero-tail tensor and TP blocks with primitive transfer maps, nonzero weights,
 and positive bond dimensions.
 
-This theorem intentionally has no `SameMPV₂ A B` hypothesis: it does not compare
+This lemma intentionally has no `SameMPV₂ A B` hypothesis: it does not compare
 the two blocked families. The comparison enters only in later statements that
 also keep blocked `SameMPV₂` data. -/
 lemma exists_bilateral_tp_primitive_blockDecomp_after_blocking

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -62,7 +62,7 @@ basis-of-normal-tensors construction from
   distinct-norm block family a `SectorDecomposition` with all multiplicities
   `copies j = 1`.
 
-### Section 4 BNT grouping for possibly-equal norms (proved via norm-class enumeration)
+### Section 4 Restricted norm-class collapse for possibly-equal norms
 
 * `exists_bnt_grouping` — For blocks with possibly equal norms, given that equal-norm
   blocks have the same MPV function (a consequence of BNT uniqueness), there exists a
@@ -273,14 +273,14 @@ lemma sameMPV₂_trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
           symm
           simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
 
-/-- **Trivial `SectorDecomposition` from a sorted block family.**
+/-- **Granular `SectorDecomposition` from a sorted block family.**
 
 Specialization of `trivialSectorDecomp` to the sorted distinct-norm case: every block
 becomes its own basis tensor with `copies j = 1`, the assembled tensor has
 `SameMPV₂` with `toTensorFromBlocks μ blocks`, and the BNT-level norm ordering is
 `StrictAnti` because each basis carries exactly one weight `μ j`, already strictly
 decreasing. -/
-theorem exists_trivialSectorDecomp_of_sorted_distinct_norms
+lemma exists_trivialSectorDecomp_of_sorted_distinct_norms
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -296,7 +296,7 @@ theorem exists_trivialSectorDecomp_of_sorted_distinct_norms
   intro i j hij
   simpa [trivialSectorDecomp] using hAnti hij
 
-/-! ### Section 5. BNT grouping for blocks with possibly equal norms -/
+/-! ### Section 5. Restricted norm-class collapse for blocks with possibly equal norms -/
 
 /-- Shared norm-class enumeration used by the BNT grouping constructions. -/
 structure NormClassGroupingData {r : ℕ} (μ : Fin r → ℂ) where
@@ -382,7 +382,7 @@ noncomputable def normClassGroupingData {r : ℕ} (μ : Fin r → ℂ) :
     regroup := hRegroup
   }
 
-/-- **Restricted BNT grouping step (equal-norm collapse via norm-class enumeration).**
+/-- **Restricted norm-class collapse via norm-class enumeration.**
 
 Given a weighted block family `(μ, blocks)` where some blocks may share the same norm
 `‖μ j‖ = ‖μ k‖`, and given that equal-norm blocks already share the same MPV function,
@@ -402,7 +402,7 @@ fixed by the chosen representative `reprFn j`, and other members of the same nor
 class may have different dimensions — their MPV values are matched via `hMPVEq`,
 which uses the heterogeneous `SameMPV₂` to accommodate different bond dimensions.
 
-This theorem is intentionally a **restricted collapse theorem**. It is not the
+This lemma is intentionally a **restricted collapse statement**. It is not the
 paper's full basis-of-normal-tensors construction: if two distinct basis tensors
 occur at the same modulus, they should survive as different basis elements rather
 than being forced into one norm class.
@@ -432,7 +432,7 @@ theorems (see `exists_sectorDecomp_of_tp_primitive_irr_blocks`).
    `= mpv (toTensorFromBlocks μ blocks) σ`.
 5. **StrictAnti** holds because the `v_j` are strictly decreasing and
    `‖P.weight j ⟨0, _⟩‖ = ‖μ (enum j 0)‖ = v_j`. -/
-theorem exists_bnt_grouping
+lemma exists_bnt_grouping
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -56,7 +56,7 @@ basis-of-normal-tensors construction from
   and the assembled tensor is `SameMPV₂`-equivalent to the original.  This is the key
   bridging step from the reduction output to the canonical form.
 
-### Section 3 Trivial sector decomposition for the sorted distinct-norm case
+### Section 3 Granular sector decomposition for the sorted distinct-norm case
 
 * `exists_trivialSectorDecomp_of_sorted_distinct_norms` — Forms from a sorted
   distinct-norm block family a `SectorDecomposition` with all multiplicities
@@ -224,7 +224,7 @@ theorem exists_sortedNCF_of_distinct_norms
     dim_pos           := fun k => hDim (e k)
   }⟩
 
-/-! ### Section 4. Trivial sector decomposition -/
+/-! ### Section 4. Granular sector decomposition -/
 
 /-- **Granular `SectorDecomposition` with one basis tensor per input block.**
 

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -38,17 +38,19 @@ basis-of-normal-tensors construction from
 
 ## Main results
 
-### Section 1 Sorting step: distinct norms → strictly decreasing permutation
+### Section 1 Sorting permutation
 
 * `exists_sorted_reindexing` — If the norms `‖μ k‖` are pairwise distinct, there exists
   a bijection `e : Fin r ≃ Fin r` with `StrictAnti (fun k => ‖μ (e k)‖)`.  This is a
   pure combinatorial sorting result.
 
+### Section 2 MPV-preserving sorted block decomposition
+
 * `exists_sorted_blockDecomp_of_distinct_norms` — Combines sorting with
   `sameMPV₂_toTensorFromBlocks_perm` to produce a permuted block family that
   (i) has `SameMPV₂` to the original family and (ii) has strictly decreasing norms.
 
-### Section 2 NCF construction from unsorted distinct-norm data
+### Section 3 Normal canonical form from unsorted distinct-norm block data
 
 * `exists_sortedNCF_of_distinct_norms` — If blocks satisfy all `IsNormalCanonicalForm`
   conditions except norm ordering (norms distinct but not yet decreasing), there exists
@@ -56,13 +58,13 @@ basis-of-normal-tensors construction from
   and the assembled tensor is `SameMPV₂`-equivalent to the original.  This is the key
   bridging step from the reduction output to the canonical form.
 
-### Section 3 Granular sector decomposition for the sorted distinct-norm case
+### Section 4 Granular sector decomposition for the sorted distinct-norm case
 
 * `exists_trivialSectorDecomp_of_sorted_distinct_norms` — Forms from a sorted
   distinct-norm block family a `SectorDecomposition` with all multiplicities
   `copies j = 1`.
 
-### Section 4 Restricted norm-class collapse for possibly-equal norms
+### Section 5 Restricted norm-class collapse for possibly-equal norms
 
 * `exists_bnt_grouping` — For blocks with possibly equal norms, given that equal-norm
   blocks have the same MPV function (a consequence of BNT uniqueness), there exists a

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -19,17 +19,17 @@ open Filter
 /-!
 # Equal-norm comparison for restricted norm-class collapse hypotheses
 
-This file relates the BNT overlap/spectral theory to the
-restricted norm-class collapse lemma (`exists_bnt_grouping`), which requires `hMPVEq`
-for equal-norm blocks.
+This file relates the BNT overlap/spectral theory to the restricted norm-class
+collapse: blocks with the same weight norm must already generate the same MPS
+family before they can be represented by one sector.
 
 ## Background
 
 The canonical-form reduction produces TP + primitive blocks with
 nonzero weights. The restricted norm-class collapse groups blocks by weight norm into a
-`SectorDecomposition`, and requires one hypothesis for equal-norm blocks:
+sector decomposition, and requires one mathematical input for equal-norm blocks:
 
-* `hMPVEq`: equal-norm blocks have `SameMPV₂`.
+* equal-norm blocks generate the same MPS family.
 
 The grouped sector's bond dimension is fixed by the chosen representative of each
 norm class, so no separate equal-dimension hypothesis is needed.

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -17,16 +17,16 @@ open scoped Matrix BigOperators
 open Filter
 
 /-!
-# Equal-norm comparison for BNT grouping hypotheses
+# Equal-norm comparison for restricted norm-class collapse hypotheses
 
 This file relates the BNT overlap/spectral theory to the
-BNT grouping theorem (`exists_bnt_grouping`), which requires `hMPVEq`
+restricted norm-class collapse lemma (`exists_bnt_grouping`), which requires `hMPVEq`
 for equal-norm blocks.
 
 ## Background
 
 The canonical-form reduction produces TP + primitive blocks with
-nonzero weights.  The BNT grouping theorem groups blocks by weight norm into a
+nonzero weights. The restricted norm-class collapse groups blocks by weight norm into a
 `SectorDecomposition`, and requires one hypothesis for equal-norm blocks:
 
 * `hMPVEq`: equal-norm blocks have `SameMPV₂`.
@@ -34,7 +34,7 @@ nonzero weights.  The BNT grouping theorem groups blocks by weight norm into a
 The grouped sector's bond dimension is fixed by the chosen representative of each
 norm class, so no separate equal-dimension hypothesis is needed.
 
-## Strategy: gauge-phase-aware BNT grouping
+## Strategy: gauge-phase-aware norm-class collapse
 
 When equal-norm blocks are known to be gauge-phase equivalent (e.g., because they
 originate from the cyclic-sector decomposition of a single irreducible block, or
@@ -66,7 +66,7 @@ Theorem matching, etc.).
   TP + irreducible blocks implies equal bond dimensions and gauge-phase equivalence.
   Uses the spectral dichotomy from `SpectralGap.lean`.  **Fully proved.**
 
-* `exists_bnt_grouping_of_gaugePhaseEquiv` — BNT grouping theorem taking gauge-phase
+* `exists_bnt_grouping_of_gaugePhaseEquiv` — restricted collapse taking gauge-phase
   equivalence data (rather than `SameMPV₂`) for equal-norm blocks.  **Fully proved.**
 
 * `exists_sectorDecomp_of_tp_primitive_irr_blocks` — Construction connecting
@@ -174,9 +174,9 @@ theorem gaugePhaseEquiv_of_nonDecaying_overlap
     (mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP
       hdim A B hA_irr hB_irr hA_TP hB_TP hNotGPE)
 
-/-! ### Section 2. BNT grouping with gauge-phase equivalence -/
+/-! ### Section 2. Restricted norm-class collapse with gauge-phase equivalence -/
 
-/-- **BNT grouping step with gauge-phase equivalence for equal-norm blocks.**
+/-- **Restricted norm-class collapse with gauge-phase equivalence for equal-norm blocks.**
 
 This form of `exists_bnt_grouping` uses gauge-phase equivalence data
 (rather than `SameMPV₂`) for equal-norm blocks.  The gauge phases are absorbed into
@@ -319,7 +319,7 @@ theorem exists_sectorDecomp_of_tp_primitive_irr_blocks
     exact gaugePhaseEquiv_of_nonDecaying_overlap
       (blocks j) (blocks k) (hIrr j) (hIrr k) (hTP j) (hTP k)
       (hNonDecay j k hjk hNorm)
-  -- Step 2: Derive GPE data with unit-norm phase for the grouping theorem.
+  -- Step 2: Derive GPE data with unit-norm phase for the collapse lemma.
   have hGPEζ : ∀ j k : Fin r, ‖μ j‖ = ‖μ k‖ →
       ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧
         ∀ (N : ℕ) (σ : Fin N → Fin d),
@@ -352,7 +352,7 @@ theorem exists_sectorDecomp_of_tp_primitive_irr_blocks
           (hPrim k)
           X ζ hX
       exact ⟨ζ, hζne, hζ_norm, hmpv⟩
-  -- Step 3: Apply the gauge-phase-aware BNT grouping theorem.
+  -- Step 3: Apply the gauge-phase-aware collapse lemma.
   exact exists_bnt_grouping_of_gaugePhaseEquiv μ blocks hμne hGPEζ
 
 /-- One-sector specialization of the TP + primitive + irreducible grouping route.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3274,8 +3274,8 @@ The following results separate the zero blocks from the nonzero blocks.
 	\leanok
 	\uses{def:blocked_tensor, def:zero_mps_tensor, def:tensor_from_blocks}
 	Each of two tensors admits some blocking after which it decomposes
-	independently into a zero-tail tensor plus nonzero
-	left-canonical blocks with primitive transfer maps and positive bond
+	independently into a zero-tail tensor plus left-canonical blocks with
+	primitive transfer maps, nonzero scalar weights, and positive bond
 	dimensions. Moreover, at every blocked system size and every blocked word,
 	the MPV of the blocked tensor is the sum of the zero-tail MPV and the MPV of
 	the weighted nonzero-block tensor:

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2771,8 +2771,9 @@ The following results separate the zero blocks from the nonzero blocks.
 	\lean{MPSTensor.exists_trivialSectorDecomp_of_sorted_distinct_norms}\leanok
 	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv}
 	If all weights are nonzero and strictly decreasing in norm, one obtains a
-	sector decomposition with one copy per sector that preserves the represented
-	MPS family.
+	sector decomposition $P$ with one basis block per original block such that
+	$P$ represents the same MPS family as $\bigoplus_k \mu_k B_k$ and whose
+	sector-weight norms are strictly decreasing.
 \end{lemma}
 
 \begin{definition}[Norm-class partition]
@@ -2794,11 +2795,9 @@ The following results separate the zero blocks from the nonzero blocks.
 	\uses{def:norm_class_grouping, thm:bnt_trivial_sector}
 	Let $(\mu_k,A_k)_{k=1}^r$ be a weighted block family with
 	$\mu_k \neq 0$ for every $k$. If equal-norm blocks represent the same
-	MPS family, then one obtains a sector decomposition $P$ such that
-	\[
-		P_{\mathrm{tot}} \sim \bigoplus_{k=1}^r \mu_k A_k
-	\]
-	as MPV families, and whose sector norms are strictly decreasing.
+	MPS family, then one obtains a sector decomposition whose associated total
+	tensor generates the same MPV family as $\bigoplus_{k=1}^r \mu_k A_k$, and
+	whose sector norms are strictly decreasing.
 \end{lemma}
 
 \subsection{Equal-Norm Blocks}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2792,8 +2792,13 @@ The following results separate the zero blocks from the nonzero blocks.
 	\label{thm:bnt_grouping}
 	\lean{MPSTensor.exists_bnt_grouping}\leanok
 	\uses{def:norm_class_grouping, thm:bnt_trivial_sector}
-	If equal-norm blocks represent the same MPS family, then one obtains a sector
-	decomposition whose sector norms are strictly decreasing.
+	Let $(\mu_k,A_k)_{k=1}^r$ be a weighted block family with
+	$\mu_k \neq 0$ for every $k$. If equal-norm blocks represent the same
+	MPS family, then one obtains a sector decomposition $P$ such that
+	\[
+		P_{\mathrm{tot}} \sim \bigoplus_{k=1}^r \mu_k A_k
+	\]
+	as MPV families, and whose sector norms are strictly decreasing.
 \end{lemma}
 
 \subsection{Equal-Norm Blocks}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2766,14 +2766,14 @@ The following results separate the zero blocks from the nonzero blocks.
 	block-sum expression for $\bigoplus_k \mu_k B_k$.
 \end{proof}
 
-\begin{theorem}[Trivial sector decomposition for the sorted distinct-norm case]
+\begin{lemma}[Granular sector decomposition for the sorted distinct-norm case]
 	\label{thm:bnt_trivial_sector}
 	\lean{MPSTensor.exists_trivialSectorDecomp_of_sorted_distinct_norms}\leanok
 	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv}
 	If all weights are nonzero and strictly decreasing in norm, one obtains a
 	sector decomposition with one copy per sector that preserves the represented
 	MPS family.
-\end{theorem}
+\end{lemma}
 
 \begin{definition}[Norm-class partition]
 	\label{def:norm_class_grouping_data}
@@ -2788,13 +2788,13 @@ The following results separate the zero blocks from the nonzero blocks.
 	From any finite weight family, construct norm classes ordered by strictly decreasing norm values.
 \end{definition}
 
-\begin{theorem}[BNT grouping theorem]
+\begin{lemma}[Restricted norm-class collapse]
 	\label{thm:bnt_grouping}
 	\lean{MPSTensor.exists_bnt_grouping}\leanok
 	\uses{def:norm_class_grouping, thm:bnt_trivial_sector}
 	If equal-norm blocks represent the same MPS family, then one obtains a sector
 	decomposition whose sector norms are strictly decreasing.
-\end{theorem}
+\end{lemma}
 
 \subsection{Equal-Norm Blocks}
 
@@ -3264,13 +3264,13 @@ The following results separate the zero blocks from the nonzero blocks.
 	normality are both preserved under blocking.
 \end{proof}
 
-\begin{theorem}[Structural after-blocking form of the fundamental theorem]%
+\begin{lemma}[Bilateral structural decomposition after blocking]%
 	\label{thm:ft_after_blocking_structural}
-	\lean{MPSTensor.afterBlocking_structuralDecompositionData_of_sameMPV₂}
+	\lean{MPSTensor.exists_bilateral_tp_primitive_blockDecomp_after_blocking}
 	\leanok
-	\uses{def:blocked_tensor, def:same_mpv2, def:zero_mps_tensor, def:tensor_from_blocks}
-	If two tensors generate the same MPV family, then each tensor admits some
-	blocking after which it decomposes into a zero-tail tensor plus nonzero
+	\uses{def:blocked_tensor, def:zero_mps_tensor, def:tensor_from_blocks}
+	Each of two tensors admits some blocking after which it decomposes
+	independently into a zero-tail tensor plus nonzero
 	left-canonical blocks with primitive transfer maps and positive bond
 	dimensions. Moreover, at every blocked system size and every blocked word,
 	the MPV of the blocked tensor is the sum of the zero-tail MPV and the MPV of
@@ -3281,7 +3281,10 @@ The following results separate the zero blocks from the nonzero blocks.
 		  + V^{(N)}\!\left(\bigoplus_k \mu^A_k A_k\right)_\sigma,
 	\]
 	and likewise for $B$.
-\end{theorem}
+	This lemma does not use an equality hypothesis between the two original
+	families; the comparison is supplied only by later after-blocking
+	statements.
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{thm:tp_primitive_blockdecomp}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3268,7 +3268,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	normality are both preserved under blocking.
 \end{proof}
 
-\begin{lemma}[Bilateral structural decomposition after blocking]%
+\begin{lemma}[Independent one-sided structural decompositions after blocking]%
 	\label{thm:ft_after_blocking_structural}
 	\lean{MPSTensor.exists_bilateral_tp_primitive_blockDecomp_after_blocking}
 	\leanok

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -110,7 +110,7 @@ The main references are
 	\end{enumerate}
 \end{definition}
 
-\begin{theorem}[Equal-norm grouping step]
+\begin{lemma}[Restricted equal-norm collapse]
 	\label{thm:bnt_grouping_equal_norm}
 	\lean{MPSTensor.exists_bnt_grouping}
 	\leanok
@@ -122,7 +122,7 @@ The main references are
 	decomposition whose associated total tensor generates the same MPV family
 	as $\bigoplus_k \mu_k A_k$, and whose sector-weight norms are strictly
 	decreasing.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	Order the distinct norms of the weights in decreasing order, choose one


### PR DESCRIPTION
### Motivation

- Several public theorem-level declarations in the after-blocking and BNT grouping
  route were named or presented in ways that could be read as source-level fundamental
  theorem statements, while their actual content is conditional infrastructure
  (see #1283 for the full audit and list of candidates).
- Part of the source-faithfulness cleanup tracked in #1282 and #1170.

### Description

- Renames `afterBlocking_structuralDecompositionData_of_sameMPV₂` to
  `exists_bilateral_tp_primitive_blockDecomp_after_blocking`, restating it as the
  independent one-sided after-blocking decomposition it actually proves (the `hSame`
  hypothesis was unused and the result is two independent reductions, not a two-sided
  consequence).
  **No compatibility alias is provided.** The old name encodes `sameMPV₂` terminology
  that overstates the result as a two-sided comparison consequence
  (see [`docs/CONTRIBUTING.md` Section Mathematical-language renames](../blob/main/docs/CONTRIBUTING.md#mathematical-language-renames)).
- Removes `afterBlocking_structuralData_of_sameMPV₂`, the corresponding compatibility
  theorem that preserved the same misleading hypothesis without adding new mathematical
  content.
  **No compatibility alias is provided** for the same reason above.
- Demotes the restricted norm-class collapse results in `BNTGrouping.lean` from
  theorem presentation to lemma presentation, keeping declaration names stable.
- Updates blueprint prose in `ch08_canonical.tex` and `ch10_bnt.tex` to describe BNT
  grouping results as restricted norm-class regrouping rather than as paper-level BNT
  constructions.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly.lean`
- `lake env lean TNLean/MPS/CanonicalForm/BNTGrouping.lean`
- `lake env lean TNLean/MPS/CanonicalForm/EqualNormBridge.lean`
- `lake build TNLean.MPS.CanonicalForm.Assembly.StructuralData TNLean.MPS.CanonicalForm.BNTGrouping TNLean.MPS.CanonicalForm.EqualNormBridge TNLean.MPS.CanonicalForm.Assembly -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Addresses #1283.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a documentation/API refactor (renames, signature change, and removal of a compatibility theorem) with low logical risk but medium integration risk due to breaking downstream references to the old theorems.
> 
> **Overview**
> Recasts the after-blocking “structural” result as an *independent one-sided decomposition*: `afterBlocking_structuralDecompositionData_of_sameMPV₂` is renamed to `exists_bilateral_tp_primitive_blockDecomp_after_blocking`, drops the unused `SameMPV₂` hypothesis, and is re-exported from `Assembly.lean`; the older compatibility wrapper `afterBlocking_structuralData_of_sameMPV₂` is removed, and callers are updated to use the new lemma.
> 
> Demotes the restricted norm grouping results in `BNTGrouping.lean` from `theorem` to `lemma` and updates surrounding prose/comments (plus blueprint tex in `ch08_canonical.tex`/`ch10_bnt.tex`) to describe them as **restricted norm-class collapse/granular sector decomposition**, not full paper-level BNT constructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb3a0fd66f7f6ee91ff654f549888e3ddedbadc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->