### PR TITLE
doc(MPS/CanonicalForm): define zero-tail convention

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorData.lean
@@ -14,9 +14,11 @@ open Filter
 
 This file collects the common-sector continuation of the structural
 canonical-form reduction following arXiv:1606.00608. Starting from the
-zero-tail and TP-gauge decomposition, it records the per-block cyclic-sector
-data, chooses common blocking lengths, and states the relabeled common-sector
-data needed to compare the resulting sector families.
+all-zero leftover block and TP-gauge decomposition, it records the per-block
+cyclic-sector data, chooses common blocking lengths, and states the relabeled
+common-sector data needed to compare the resulting sector families.  The
+`zeroTail` variables below name the total bond dimension of the all-zero blocks,
+corresponding to the source-paper allowance `∑ k, D_k ≤ D`.
 
 ## Main statements
 
@@ -46,9 +48,9 @@ section FundamentalTheoremAfterBlocking
 /-- **Per-block cyclic-sector decomposition with a zero-tail identity.**
 
 This is the faithful predecessor to the common nonzero-sector statement. From
-`SameMPV₂ A B`, it first uses the invariant-subspace/zero-tail split and TP gauge
-to obtain irreducible nonzero-weight blocks on both sides. It then removes the period of
-each block separately, producing primitive irreducible cyclic sectors for
+`SameMPV₂ A B`, it first separates the all-zero leftover block and then applies
+the TP gauge to obtain irreducible nonzero-weight blocks on both sides. It then
+removes the period of each block separately, producing primitive irreducible cyclic sectors for
 every nonzero-weight block. The nonzero parts agree at positive lengths, and the length-zero
 case is given as the explicit zero-tail identity.
 

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
@@ -57,7 +57,7 @@ The full proof chain is:
 
 ### Remaining mathematical inputs
 
-The theorem `exists_tp_sector_decomp_after_blocking` below provides:
+The after-blocking primitive block decomposition provides:
 - A blocking period `p > 0`
 - A trivial all-zero block of dimension `zeroTailDim`, representing the source-paper
   allowance `∑ k, D_k ≤ D` where zero blocks may occur

--- a/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean
@@ -59,7 +59,8 @@ The full proof chain is:
 
 The theorem `exists_tp_sector_decomp_after_blocking` below provides:
 - A blocking period `p > 0`
-- A trivial block of dimension `zeroTailDim`
+- A trivial all-zero block of dimension `zeroTailDim`, representing the source-paper
+  allowance `∑ k, D_k ≤ D` where zero blocks may occur
 - A family of TP sector blocks
 - The MPV relationship: `blockTensor A p` is `SameMPV₂`-equivalent to
   `zeroMPSTensor + toTensorFromBlocks μ sectors` for some weights `μ`
@@ -69,8 +70,9 @@ now has a one-sided phase-class BNT construction for TP primitive irreducible
 nonzero-weight blocks, one-sided overlap data, and witness-producing sector comparison
 from primitive overlap-span hypotheses. The theorem
 `afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂`
-keeps the faithful paper order: first split off the zero tail and TP-gauge the
-irreducible nonzero-weight blocks, then remove each block's period by cyclic sectors.
+keeps the faithful paper order: first separate the all-zero leftover block and
+TP-gauge the irreducible nonzero-weight blocks, then remove each block's period by
+cyclic sectors.
 It deliberately does not identify that period-removal length with the later
 finite blocking length used for common refinement or injectivity.
 

--- a/TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean
@@ -8,19 +8,22 @@ import TNLean.MPS.Core.BlockingInfrastructure
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
 /-!
-# Zero-tail MPV transport
+# All-zero-block MPV transport
 
 This module contains generic lemmas for transporting decompositions of an MPS
-tensor into a zero tail plus a nonzero part.
+tensor into an all-zero-block contribution plus a nonzero part.  The `zeroTail`
+names in this file are the formal variables for the total bond dimension of the
+all-zero leftover blocks, corresponding to the source-paper allowance
+`∑ k, D_k ≤ D`.
 -/
 
 namespace MPSTensor
 
 /-! ## Zero-tail and weight transport through blocking -/
 
-/-- Reblocking preserves a zero-tail/nonzero-part MPV decomposition.
+/-- Reblocking preserves an all-zero-block/nonzero-part MPV decomposition.
 
-The positive-period hypothesis is exactly what keeps the zero-tail contribution
+The positive-period hypothesis is exactly what keeps the all-zero-block contribution
 confined to length zero after blocking: a blocked chain of positive length expands
 to a positive number of original sites. -/
 theorem zeroTail_mpv_decomp_blockTensor
@@ -49,7 +52,7 @@ theorem zeroTail_mpv_decomp_blockTensor
   congr 1
   exact (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) nonzeroPart p σ).symm
 
-/-- Reblocking a zero-tail plus weighted nonzero-block decomposition transports every
+/-- Reblocking an all-zero-block plus weighted nonzero-block decomposition transports every
 nonzero-block weight to the corresponding blocking power. -/
 theorem zeroTail_toTensorFromBlocks_blockPower
     {d D r z p : ℕ} {dim : Fin r → ℕ}
@@ -84,7 +87,7 @@ theorem zeroTail_toTensorFromBlocks_blockPower
             (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) σ := by
           rw [hNonzeroPart N σ]
 
-/-- Transport a zero-tail decomposition along an MPV equivalence of its nonzero part. -/
+/-- Transport an all-zero-block decomposition along an MPV equivalence of its nonzero part. -/
 theorem zeroTail_eq_of_sameMPV₂
     {d D L L' z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
     (flat : MPSTensor d L')

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -378,21 +378,22 @@ theorem exists_irreducible_blockDecomp_with_CFII
       (A := blocks k) (hTP := hTPk) (hIrr := hIrr k) (hD := hDk))
 
 /-!
-## Zero-block separation (1606.00608 Section 2.3: partition into zero tail + nonzero blocks)
+## Zero-block separation (1606.00608 Section 2.3)
 
 The irreducible block decomposition may produce all-zero blocks. Because `SameMPV₂`
 at `N = 0` includes the identity `trace(I_D) = D`, we cannot silently drop these.
-Instead we accumulate them into a **zero tail** of dimension `zeroTailDim` (the sum
-of their bond dimensions) and retain a family of **nonzero blocks** (each having at
-least one nonzero Kraus operator).
+The source paper states the resulting block form with `∑ k, D_k ≤ D`, "i.e.,
+there can be zero blocks" (arXiv:1606.00608, equation (8)). In this file,
+`zeroTailDim` is the total bond dimension of those all-zero leftover blocks; it is
+not an extra source-paper object.
 
 Key facts:
 - All-zero irreducible blocks have `dim ≤ 1` (`isIrreducibleTensor_allZero_dim_le_one`).
 - For `N > 0`, all-zero blocks contribute `0` to the MPV (`mpv_eq_zero_of_all_zero`).
 - For `N = 0`, each block of dimension `Dₖ` contributes `Dₖ` (the trace of the identity).
 
-The zero tail is represented as a single all-zero tensor of dimension `zeroTailDim`; its MPV is
-`zeroTailDim` at `N = 0` and `0` for `N > 0`.
+The zero-tail contribution is represented as a single all-zero tensor of dimension
+`zeroTailDim`; its MPV is `zeroTailDim` at `N = 0` and `0` for `N > 0`.
 -/
 
 /-- The all-zero MPS tensor of given physical and bond dimension.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -999,6 +999,12 @@ In the irreducible block decomposition, some blocks may have all-zero
 Kraus operators. Such blocks contribute to the MPV only at word length
 $N = 0$ (where their contribution equals their bond dimension).
 The following results separate the zero blocks from the nonzero blocks.
+Following arXiv:1606.00608, equation~(8), this is the case
+$\sum_k D_k \le D$, where ``there can be zero blocks''.  In this
+case the \emph{zero-tail bond dimension} is the total bond
+dimension of these all-zero leftover blocks.  It is not an additional
+source-paper structure; it is a name for the all-zero summand
+$\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 
 \begin{definition}[Zero MPS tensor]\label{def:zero_mps_tensor}
 	\lean{MPSTensor.zeroMPSTensor}
@@ -1046,7 +1052,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	\]
 	for every spin configuration $\sigma$ of length $N$.
 	At $N = 0$ this reads $D = D_0 + \sum_{k=1}^r D_k$.
-	For $N \ge 1$ the zero-tail term vanishes.
+	For $N \ge 1$ this all-zero, zero-tail term vanishes.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1069,7 +1075,8 @@ The following results separate the zero blocks from the nonzero blocks.
 	\uses{def:irreducible_tensor, def:zero_mps_tensor}
 	For any MPS tensor $A$, there exist:
 	\begin{enumerate}
-		\item a zero-tail bond dimension $D_0$,
+		\item a zero-tail bond dimension $D_0$, namely the total bond
+		      dimension of the separated all-zero blocks,
 		\item nontrivial blocks $(B_k)_{k=1}^r$ with nonzero weights
 		      $(\mu_k)_{k=1}^r$, each block irreducible and
 		      left-canonical ($\sum_i (B_k^i)^\dagger B_k^i = \Id$),
@@ -3303,7 +3310,8 @@ The following results separate the zero blocks from the nonzero blocks.
 	\leanok
 	\uses{def:blocked_tensor, def:zero_mps_tensor, def:tensor_from_blocks}
 	Each of two tensors admits some blocking after which it decomposes
-	independently into a zero-tail tensor plus left-canonical blocks with
+	independently into an all-zero tensor of zero-tail bond dimension plus
+	left-canonical blocks with
 	primitive transfer maps, nonzero scalar weights, and positive bond
 	dimensions. Moreover, at every blocked system size and every blocked word,
 	the MPV of the blocked tensor is the sum of the zero-tail MPV and the MPV of
@@ -3324,15 +3332,15 @@ The following results separate the zero blocks from the nonzero blocks.
 	Apply Theorem~\ref{thm:tp_primitive_blockdecomp} separately to the two tensors.
 \end{proof}
 
-\begin{theorem}[Zero-tail decomposition after blocking]%
+\begin{theorem}[All-zero-block contribution after blocking]%
 	\label{thm:zero_tail_decomp_block_tensor}
 	\lean{MPSTensor.zeroTail_mpv_decomp_blockTensor}
 	\leanok
 	\uses{def:blocked_tensor, def:zero_mps_tensor}
-	Suppose $A$ is expressed as a zero-tail tensor plus a nonzero part $L$ at all
-	system sizes. For every positive blocking length $p$, the blocked tensor
+	Suppose $A$ is expressed as an all-zero tensor of zero-tail bond dimension
+	plus a nonzero part $L$ at all system sizes. For every positive blocking length $p$, the blocked tensor
 	$A^{[p]}$ is expressed as the same zero-tail bond dimension plus $L^{[p]}$.
-	The zero-tail term still contributes only at blocked length $0$.
+	The all-zero term still contributes only at blocked length $0$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3341,13 +3349,13 @@ The following results separate the zero blocks from the nonzero blocks.
 	unchanged by the reblocking convention.
 \end{proof}
 
-\begin{theorem}[Zero-tail weighted block decomposition after blocking]%
+\begin{theorem}[All-zero-block weighted block decomposition after blocking]%
 	\label{thm:zero_tail_to_tensor_from_blocks_block_power}
 	\lean{MPSTensor.zeroTail_toTensorFromBlocks_blockPower}
 	\leanok
 	\uses{thm:zero_tail_decomp_block_tensor, thm:block_tensor_to_tensor_from_blocks,
 	      def:tensor_from_blocks}
-	Suppose $A$ is expressed as a zero-tail tensor plus the weighted nonzero-block
+	Suppose $A$ is expressed as an all-zero tensor of zero-tail bond dimension plus the weighted nonzero-block
 	tensor $\bigoplus_k \mu_k B_k$. For every positive blocking length $p$,
 	$A^{[p]}$ is expressed as the same zero-tail contribution plus the weighted
 	blocked nonzero tensor $\bigoplus_k \mu_k^p B_k^{[p]}$.
@@ -3359,21 +3367,22 @@ The following results separate the zero blocks from the nonzero blocks.
 	Theorem~\ref{thm:block_tensor_to_tensor_from_blocks}.
 \end{proof}
 
-\begin{theorem}[Zero-tail identity for nonzero block tensors]%
+\begin{theorem}[Length-zero identity for nonzero block tensors]%
 \label{thm:nonzero_block_zero_tail_identity}
 	\lean{MPSTensor.nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂}
 	\leanok
 	\uses{def:same_mpv2, def:zero_mps_tensor, def:tensor_from_blocks}
-	Suppose two tensors have the same MPV family and each is expressed as a
-	zero-tail tensor plus a weighted nonzero-block tensor. Then the two nonzero-block
-	tensors agree on every positive system size, and at size $0$ the equality is
+	Suppose two tensors have the same MPV family and each is expressed as an
+	all-zero tensor of zero-tail bond dimension plus a weighted nonzero-block
+	tensor. Then the two nonzero-block tensors agree on every positive system
+	size, and at size $0$ the equality is
 	exactly the equality of the two zero-tail contributions plus the two nonzero
 	bond-dimension traces.
 \end{theorem}
 
 \begin{proof}\leanok
 	\uses{def:zero_mps_tensor}
-	For $N>0$, the MPV of a zero-tail tensor is zero, so the two decompositions
+	For $N>0$, the MPV of the all-zero tensor is zero, so the two decompositions
 	can be compared directly through the common MPV family. For $N=0$, the
 	zero-tail MPV is its bond dimension, giving the stated length-zero identity.
 \end{proof}
@@ -3398,7 +3407,7 @@ The following results separate the zero blocks from the nonzero blocks.
 	dimension.
 \end{proof}
 
-\begin{theorem}[Equal zero tails give full nonzero-part MPV equality]%
+\begin{theorem}[Equal leftover zero-block dimensions give full nonzero-part MPV equality]%
 \label{thm:nonzero_block_same_mpv_zero_tail_eq}
 	\lean{MPSTensor.nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq}
 	\leanok
@@ -3436,14 +3445,14 @@ The following results separate the zero blocks from the nonzero blocks.
 	blocking the original equality.
 \end{proof}
 
-\begin{theorem}[Cyclic sectors after the zero-tail split]%
+\begin{theorem}[Cyclic sectors after all-zero-block separation]%
 \label{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
 	\lean{MPSTensor.afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂}
 	\leanok
 	\uses{thm:tp_gauge_arbitrary, thm:nonzero_block_zero_tail_identity,
 		def:primitive_irreducible_cyclic_sectors,
 		thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
-	If two tensors generate the same MPV family, then after the zero-tail split and
+	If two tensors generate the same MPV family, then after all-zero-block separation and
 	trace-preserving gauge each side has irreducible nonzero-weight blocks.
 	The nonzero-block tensors agree at all positive system sizes, while the
 	length-zero case is included as the exact zero-tail identity.
@@ -3455,8 +3464,8 @@ The following results separate the zero blocks from the nonzero blocks.
 \begin{proof}\leanok
 	\uses{thm:tp_gauge_arbitrary, thm:nonzero_block_zero_tail_identity,
 		thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
-	Apply the arbitrary-tensor TP-gauge theorem separately to $A$ and $B$. The
-	zero-tail identity theorem compares the two resulting nonzero parts at
+		Apply the arbitrary-tensor TP-gauge theorem separately to $A$ and $B$. The
+		length-zero identity theorem compares the two resulting nonzero parts at
 	positive lengths and gives the $N=0$ identity. Finally apply
 	Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr} to every
 	trace-preserving irreducible nonzero-weight block.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1242,7 +1242,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	\leanok
 	\uses{def:same_mpv2, def:mpv}
 	Let $A$ and $B$ have the same MPV family, each decomposed as an all-zero
-	leftover block, called the zero-tail part in this formal convention, plus a
+	leftover block, called the zero-tail part in this convention, plus a
 	nonzero part. If the leftover zero-block dimensions agree, then the nonzero
 	parts themselves have the same MPV family, including at length zero.
 \end{lemma}
@@ -1259,7 +1259,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	at length zero as well.
 \end{proof}
 
-\begin{theorem}[Sector comparison with zero-tail zero-block agreement]%
+\begin{theorem}[Sector comparison with leftover zero-block agreement]%
 \label{thm:after_blocking_sector_common_blocks_overlap_span_zero_tail}
 	\lean{MPSTensor.fundamentalTheorem_after_blocking_sector_of_common_blocks_overlapSpan_zeroTail}
 	\leanok
@@ -1295,7 +1295,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 two-basis sector comparison theorem.
 \end{proof}
 
-\begin{theorem}[Sector comparison from zero-tail and span data]%
+\begin{theorem}[Sector comparison from leftover zero blocks and span data]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_blockSpan}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_blockSpan}
 	\leanok


### PR DESCRIPTION
### Motivation

- Blueprint prose and Lean module docstrings used `zero tail` as if it were source-paper terminology, without first defining it against the original reference.
- arXiv:1606.00608 equation (8) allows zero blocks in the block decomposition; the corresponding Lean quantity `zeroTail` records the total bond dimension of those all-zero leftover blocks.
- Defining this term at first use and relating it to the source-paper object makes the blueprint self-contained for readers of the original paper (see #1290).

### Description

- `blueprint/src/chapter/ch08_canonical.tex`: adds a definition of the all-zero-block convention anchored to arXiv:1606.00608 equation (8); renames nearby section titles to use all-zero/leftover-zero-block language instead of formalization shorthand.
- `blueprint/src/chapter/ch11_assembly.tex`: aligns surrounding terminology with the updated convention.
- `TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean`, `StructuralData.lean`, `CommonSectorData.lean`, `Existence.lean`: clarifies docstrings so that `zeroTail` is explicitly identified as the total bond dimension of all-zero leftover blocks, not a source-paper term. Lean declaration names are unchanged.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/StructuralData.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonSectorData.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- Note: local `leanblueprint checkdecls` reaches the known missing declaration `MPSTensor.afterBlocking_structuralDecompositionData_of_sameMPV₂` (fixed by #1284); the repository workflow treats this check as advisory while formalization is in progress.

---
Addresses #1290

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes clarifying that `zeroTail` denotes the total bond dimension of separated all-zero leftover blocks; no theorem statements or proofs are modified, so behavioral risk is minimal.
> 
> **Overview**
> Clarifies the **“zero-tail” convention** across the canonical-form after-blocking reduction: `zeroTail` is explicitly defined as the *total bond dimension of the separated all-zero leftover blocks* allowed by arXiv:1606.00608 (eq. (8), `∑ k, D_k ≤ D`), rather than paper terminology.
> 
> Updates Lean module docstrings (`Existence.lean`, `Assembly/ZeroTailTransport.lean`, `Assembly/StructuralData.lean`, `Assembly/CommonSectorData.lean`) and blueprint prose (`ch08_canonical.tex`, `ch11_assembly.tex`) to consistently use *all-zero/leftover-zero-block* language, and renames related section/theorem titles in the blueprint accordingly (Lean declaration names unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a93540d1ef6c47f00d3973c02021ca083f994d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->