### PR TITLE
doc(BNT): demote cumulative separation adapters

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -256,12 +256,16 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingA
   simpa [WordTupleSpanTop, wordTuple] using
     wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hSep
 
-/-- Positive-length product-word span from all-words pair separation plus eventual
+/-- Conditional positive-length product-word span from all-words pair separation plus eventual
 identity padding for every ordered pair of distinct BNT blocks.
 
 The proof takes a finite maximum over the separating and padding lengths for the
 ordered block pairs, obtaining a single homogeneous word length whose block-product
-word evaluations span the full direct product algebra. -/
+word evaluations span the full direct product algebra.
+
+This is an auxiliary adapter, not a source-facing BNT separation producer: the
+homogeneous identity-padding input must be supplied separately, preferably via
+the fixed-length or period-window interfaces below. -/
 theorem exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A)
@@ -312,7 +316,10 @@ homogeneous trace-separating length for all ordered pairs of distinct blocks.
 This is the finite-maximum step after the pairwise Burnside-Jacobson
 identity-padding hypotheses have been supplied. The BNT hypotheses provide
 all-words trace separation for each pair; the generic homogenization lemma
-chooses one length that works for the whole finite block family. -/
+chooses one length that works for the whole finite block family.
+
+This declaration is deliberately conditional on the homogeneous padding data and
+should not be read as the David/Perez-Garcia finite-length direct-sum input. -/
 theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_padding
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -325,13 +332,17 @@ theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_pa
   exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding
     A (pairTraceSeparatingAll_of_isCanonicalFormBNT μ A hCF) hPad
 
-/-- Positive-length product-word span from canonical-form/BNT data plus eventual
+/-- Conditional positive-length product-word span from canonical-form/BNT data plus eventual
 identity padding for every ordered pair of distinct blocks.
 
 Canonical-form/BNT separation gives all-words trace separation for distinct blocks.
 Together with eventual homogeneous identity padding for each ordered block pair, this
 gives a positive word length at which the block-product word evaluations span the full
-direct product algebra. -/
+direct product algebra.
+
+This is an auxiliary conditional adapter. The source-faithful route should use an
+explicit fixed-length or period-window hypothesis rather than treating cumulative
+or all-words separation as a producer. -/
 theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -263,9 +263,9 @@ The proof takes a finite maximum over the separating and padding lengths for the
 ordered block pairs, obtaining a single homogeneous word length whose block-product
 word evaluations span the full direct product algebra.
 
-This is an auxiliary adapter, not a source-facing BNT separation producer: the
-homogeneous identity-padding input must be supplied separately, preferably via
-the fixed-length or period-window interfaces below. -/
+This theorem does not supply BNT separation by itself: the homogeneous
+identity-padding input must be supplied separately, preferably by fixed-length
+or period-window hypotheses. -/
 theorem exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A)
@@ -318,8 +318,8 @@ identity-padding hypotheses have been supplied. The BNT hypotheses provide
 all-words trace separation for each pair; the generic homogenization lemma
 chooses one length that works for the whole finite block family.
 
-This declaration is deliberately conditional on the homogeneous padding data and
-should not be read as the David/Perez-Garcia finite-length direct-sum input. -/
+The conclusion depends explicitly on homogeneous padding data; it is not the
+David/Perez-Garcia finite-length direct-sum input. -/
 theorem exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_padding
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -340,9 +340,9 @@ Together with eventual homogeneous identity padding for each ordered block pair,
 gives a positive word length at which the block-product word evaluations span the full
 direct product algebra.
 
-This is an auxiliary conditional adapter. The source-faithful route should use an
-explicit fixed-length or period-window hypothesis rather than treating cumulative
-or all-words separation as a producer. -/
+This theorem depends explicitly on homogeneous padding data. Use a
+fixed-length or period-window hypothesis rather than replacing that input by
+cumulative or all-words separation. -/
 theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -1051,7 +1051,14 @@ theorem pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
     (pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding
       A B hST (pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo A B hSep) hPad)
 
-/-! ### Conditional all-words homogenization -/
+/-! ### Conditional all-words homogenization
+
+The declarations in this subsection are padding adapters: they convert
+all-length or cumulative separation to one homogeneous length only after an
+explicit homogeneous identity-padding hypothesis has already been supplied.
+They are not source-facing BNT separation producers. The paper-facing route
+should use the fixed-length or period-window interfaces below.
+-/
 
 /-- All-words pair separation plus eventual homogeneous identity padding gives
 one homogeneous pair-trace separating length.
@@ -1059,7 +1066,11 @@ one homogeneous pair-trace separating length.
 This is the proved interface between the pair-product algebra density theorem
 (`PairAllWordsSpanTop`) and the Burnside-Jacobson identity-padding theorem.
 It records that once the two independent inputs are available, no additional
-BNT-specific argument is needed to obtain `PairTraceSeparatingAt`. -/
+BNT-specific argument is needed to obtain `PairTraceSeparatingAt`.
+
+This is a conditional auxiliary lemma, not the David/Perez-Garcia direct-sum
+input. In source-faithful BNT applications the homogeneous padding must be
+supplied by a fixed-length or period-window hypothesis. -/
 theorem exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding
     {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSpan : PairAllWordsSpanTop A B)
@@ -1082,7 +1093,10 @@ padding hypotheses admits one common homogeneous trace-separating length.
 
 For finitely many ordered pairs of blocks, if each pair has trace separation over all
 word lengths and the pair identity belongs to every sufficiently long homogeneous
-pair-word span, then one word length separates all ordered pairs simultaneously. -/
+pair-word span, then one word length separates all ordered pairs simultaneously.
+
+This finite-family adapter is conditional on homogeneous identity padding; it is
+not a producer of the source-paper finite-length direct-sum input. -/
 theorem exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAll (A k) (A j))

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -1051,13 +1051,13 @@ theorem pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
     (pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding
       A B hST (pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo A B hSep) hPad)
 
-/-! ### Conditional all-words homogenization
+/-! ### Homogeneous separation from all-length hypotheses
 
-The declarations in this subsection are padding adapters: they convert
-all-length or cumulative separation to one homogeneous length only after an
-explicit homogeneous identity-padding hypothesis has already been supplied.
-They are not source-facing BNT separation producers. The paper-facing route
-should use the fixed-length or period-window interfaces below.
+The declarations in this subsection convert all-length or cumulative separation
+to one homogeneous length only after an explicit homogeneous identity-padding
+hypothesis has already been supplied. They do not supply the finite-length
+direct-sum input used in the David/Perez-Garcia BNT argument. For that input,
+BNT applications should use fixed-length or period-window hypotheses.
 -/
 
 /-- All-words pair separation plus eventual homogeneous identity padding gives
@@ -1068,9 +1068,9 @@ This is the proved interface between the pair-product algebra density theorem
 It records that once the two independent inputs are available, no additional
 BNT-specific argument is needed to obtain `PairTraceSeparatingAt`.
 
-This is a conditional auxiliary lemma, not the David/Perez-Garcia direct-sum
-input. In source-faithful BNT applications the homogeneous padding must be
-supplied by a fixed-length or period-window hypothesis. -/
+This lemma is conditional on identity padding; it is not the
+David/Perez-Garcia direct-sum input. In BNT applications the homogeneous
+padding must be supplied by a fixed-length or period-window hypothesis. -/
 theorem exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding
     {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSpan : PairAllWordsSpanTop A B)
@@ -1095,8 +1095,8 @@ For finitely many ordered pairs of blocks, if each pair has trace separation ove
 word lengths and the pair identity belongs to every sufficiently long homogeneous
 pair-word span, then one word length separates all ordered pairs simultaneously.
 
-This finite-family adapter is conditional on homogeneous identity padding; it is
-not a producer of the source-paper finite-length direct-sum input. -/
+This finite-family statement is conditional on homogeneous identity padding; it
+does not supply the finite-length direct-sum input. -/
 theorem exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAll (A k) (A j))
@@ -1156,8 +1156,8 @@ trace-separating length.
 
 This is the homogeneous-span version of
 `exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows`.
-It keeps the fixed-length period-window producer explicit and only converts full
-homogeneous pair span into the identity-padding certificates needed by the
+It keeps the fixed-length period-window hypothesis explicit and only converts
+full homogeneous pair span into the identity-padding certificates needed by the
 generic homogenization theorem. -/
 theorem
     exists_forall_pairTraceSeparatingAt_of_pairSpanTop_period_windows

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3141,42 +3141,37 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     equivalence with scalar $1$.
 \end{proof}
 
-\begin{lemma}[Homogenizing cumulative pair separation]
+\begin{lemma}[Conditional padding from exact homogeneous identity witnesses]
     \label{lem:pair_trace_separation_homogenization_with_padding}
     \lean{MPSTensor.pairEvalWordTuple_mem_span_pairWordTuple_length}
     \lean{MPSTensor.pair_mul_mem_span_pairWordTuple_add}
     \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_add}
     \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop_period_window}
-    \lean{MPSTensor.pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding}
-    \lean{MPSTensor.pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding}
-    \lean{MPSTensor.exists_pairTraceSeparatingAt_of_pairAllWordsSpanTop_of_identity_padding}
-    \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_padding}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairTraceSeparatingAll_of_identity_period_windows}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_pairSpanTop_period_windows}
-    \lean{MPSTensor.pairTraceSeparatingAll_of_injective_not_gaugePhaseEquiv_cast_left}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv_of_pairWordTupleSpanTop_period_window}
     \lean{MPSTensor.exists_pairTraceSeparatingAt_of_injective_dim_ne_of_pairWordTupleSpanTop_period_window}
     \leanok
     \uses{def:pair_trace_separation_words, lem:all_length_pair_trace_separation_finite_cutoff}
-    Suppose $S\le T$ and pair words of length at most $S$ span the product
-    algebra.  If, for every $\ell\le S$, the simultaneous identity pair belongs
-    to the span of pair words of length $T-\ell$, then pair words of the single
-    length $T$ already span the product algebra.  Equivalently, cumulative
-    trace separation up to $S$ becomes homogeneous trace separation at length
-    $T$ under the same identity-padding hypothesis.  Consequently, an all-word
-    product-span theorem together with eventual homogeneous identity padding
-    yields a homogeneous pair trace-separation length.
+    Homogeneous identity-padding witnesses multiply by concatenation of words.
+    Therefore, if one has a positive period and a full residue window of
+    homogeneous pair spans, then the simultaneous identity pair lies in all
+    sufficiently large homogeneous pair spans.  Combined with all-length pair
+    trace separation, this period-window input gives one homogeneous
+    pair trace-separation length.  The cumulative-to-homogeneous conversion
+    remains only a conditional auxiliary: cumulative span-top alone is not the
+    source-paper direct-sum input and is not used here as a producer.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    A pair word of length $\ell$ is multiplied by a length-$T-\ell$ expression
-    for the simultaneous identity.  Componentwise multiplication concatenates
-    words, so each cumulative generator is rewritten as a linear combination of
-    length-$T$ pair words.  The trace-dual version follows from homogeneous
-    pair trace duality.  In particular, homogeneous identity-padding witnesses
-    multiply to give another identity-padding witness at the sum of their
-    lengths.
+    The length-zero word gives the identity only at length zero, so it is not a
+    positive-length padding theorem.  The useful padding facts are homogeneous:
+    if the identity pair is in the span at lengths $m$ and $n$, componentwise
+    multiplication puts it in the span at length $m+n$.  A period witness and a
+    complete residue window therefore give homogeneous padding at every
+    sufficiently large length, which is the input needed by the conditional
+    all-length-to-fixed-length adapter.
 \end{proof}
 
 \begin{lemma}[Pair trace separation gives pairwise selectors]
@@ -3247,14 +3242,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_pairTraceSeparatingAll_of_identity_padding}
-    \lean{MPSTensor.pairTraceSeparatingAll_of_isCanonicalFormBNT}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_padding}
     \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_identity_period_windows}
     \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_pairSpanTop_period_windows}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows}
-    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}
     \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords}
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords}
@@ -3272,8 +3262,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     pairwise separators for every ordered pair of distinct blocks; by
     Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}, a common
     pair trace-separation length is one sufficient finite-dimensional witness.
-    A cumulative pair trace cutoff is also enough, once $S\le T$, when paired
-    with the simultaneous identity-padding hypothesis of
+    The paper-facing route keeps this witness homogeneous: either it is supplied
+    directly as fixed-length pair separation, or it is obtained from an explicit
+    period-window hypothesis as in
     Lemma~\ref{lem:pair_trace_separation_homogenization_with_padding}.
     Consequently, the pulled-back words at the resulting length for
     $\operatorname{Assemble}(\mu,A)$ span every virtual sector projection, and the

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3158,9 +3158,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     homogeneous pair spans, then the simultaneous identity pair lies in all
     sufficiently large homogeneous pair spans.  Combined with all-length pair
     trace separation, this period-window input gives one homogeneous
-    pair trace-separation length.  The cumulative-to-homogeneous conversion
-    remains only a conditional auxiliary: cumulative span-top alone is not the
-    source-paper direct-sum input and is not used here as a producer.
+    pair trace-separation length.  This does not prove the
+    David--Perez-Garcia direct-sum input by itself: fullness of spans up to a
+    bounded length is weaker than the exact homogeneous input used here.
 \end{lemma}
 
 \begin{proof}
@@ -3170,8 +3170,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     if the identity pair is in the span at lengths $m$ and $n$, componentwise
     multiplication puts it in the span at length $m+n$.  A period witness and a
     complete residue window therefore give homogeneous padding at every
-    sufficiently large length, which is the input needed by the conditional
-    all-length-to-fixed-length adapter.
+    sufficiently large length, which is the input needed by the
+    all-length-to-fixed-length implication.
 \end{proof}
 
 \begin{lemma}[Pair trace separation gives pairwise selectors]
@@ -3262,7 +3262,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     pairwise separators for every ordered pair of distinct blocks; by
     Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}, a common
     pair trace-separation length is one sufficient finite-dimensional witness.
-    The paper-facing route keeps this witness homogeneous: either it is supplied
+    This witness remains homogeneous: either it is supplied
     directly as fixed-length pair separation, or it is obtained from an explicit
     period-window hypothesis as in
     Lemma~\ref{lem:pair_trace_separation_homogenization_with_padding}.

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -115,6 +115,12 @@ input.  A candidate formal theorem is too weak if it only records cumulative
 span fullness, and it is misleading if it claims homogeneous identity padding
 from the empty-word identity or from cumulative identity membership alone.
 
+Accordingly, the paper-facing blueprint no longer presents the cumulative or
+all-word identity-padding adapters as BNT separation producers.  Those Lean
+declarations are conditional algebraic auxiliaries: they may be used after a
+homogeneous padding or period-window hypothesis has been supplied, but they are
+not substitutes for the David/Perez-Garcia exact-length direct-sum input.
+
 \bibliographystyle{alpha}
 \bibliography{docs/paper-gaps/references}
 

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -115,11 +115,11 @@ input.  A candidate formal theorem is too weak if it only records cumulative
 span fullness, and it is misleading if it claims homogeneous identity padding
 from the empty-word identity or from cumulative identity membership alone.
 
-Accordingly, the paper-facing blueprint no longer presents the cumulative or
-all-word identity-padding adapters as BNT separation producers.  Those Lean
-declarations are conditional algebraic auxiliaries: they may be used after a
-homogeneous padding or period-window hypothesis has been supplied, but they are
-not substitutes for the David/Perez-Garcia exact-length direct-sum input.
+Accordingly, the blueprint no longer presents cumulative or all-word
+identity-padding consequences as BNT separation theorems.  Those Lean
+declarations may be used after a homogeneous padding or period-window
+hypothesis has been supplied, but they are not substitutes for the
+David/Perez-Garcia exact-length direct-sum input.
 
 \bibliographystyle{alpha}
 \bibliography{docs/paper-gaps/references}


### PR DESCRIPTION
### Motivation

- The cumulative and all-word identity-padding declarations in `BlockDiagonalCommutant.lean` and `PairHomogenization.lean` were treated as BNT separation producers, but they hold only once homogeneous identity-padding or period-window hypotheses are already given; they cannot substitute for the positive exact-length direct-sum input required by the source theorem (arXiv:2011.12127 §IV).
- The blueprint incorrectly tagged these conditional statements with `\lean{}` references in the paper-facing theorem path, overstating their role as separation producers.
- The David/Pérez-García direct-sum gap note (see #1280) needed updating to record this distinction and clarify the remaining proof boundary for #1178, #1133, and #944.

### Description

- `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`: reframed cumulative/all-word identity-padding declarations as conditional auxiliary lemmas; these require explicit period-window or exact-length hypotheses and are not unconditional BNT separation producers.
- `TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean`: same adjustment; conditional routes from pairwise trace separation plus identity-padding or period-window data remain.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: removed `\lean{}` coverage for the conditional auxiliary lemmas; exact-length and period-window interfaces remain tagged.
- `docs/paper-gaps/david2006_direct_sum_input.tex`: added note recording that the conditional auxiliary lemmas are not substitutes for the positive exact-length direct-sum input.
- No new Lean declarations or proofs are introduced.

### Testing

- `git diff --check`
- `lake build TNLean` — completed with pre-existing warnings in unrelated modules; no new sorry or type error introduced by this PR.
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Closes #1281

Also addresses #1170, #1178, #1133, and #944.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docstrings/comments and blueprint/gap documentation, with no modifications to Lean theorem statements or proofs.
> 
> **Overview**
> Reframes several BNT-related “homogenization” results as **explicitly conditional**: all-length/cumulative pair separation only yields a single fixed length once *homogeneous identity-padding* (ideally via fixed-length or period-window hypotheses) is separately provided.
> 
> Updates the blueprint to remove/retarget `\lean{}` references so the paper-facing theorem path no longer treats these adapters as BNT separation producers, and updates the David/Pérez-García direct-sum gap note to clarify that these conditional lemmas are **not** substitutes for the missing exact-length direct-sum input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703f258e8ffc503c534207b73a73b443d5bcce2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->