### PR TITLE
doc(MPS/CanonicalForm/Assembly): clarify after-blocking comparison boundary

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -68,14 +68,12 @@ The imported modules provide the canonical-form reduction theorems, including
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
 `exists_bilateral_tp_primitive_blockDecomp_after_blocking`.
 
-This public entry point also records a conditional formulation of the
-Cirac--Pérez-García--Schuch--Verstraete after-blocking theorem that does not
-invoke the periodic Fundamental Theorem.  The structure
-`AfterBlockingFundamentalTheoremHypotheses` names the remaining comparison inputs,
-while `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` gives the
-corresponding sector-decomposition conclusion: after blocking, the two tensors
-are represented by BNT sector decompositions whose basis sectors and weights
-match up to permutation and nonzero phases.
+The end-to-end after-blocking comparison has a conditional form here. Equality
+of MPV families gives the common blocking and common primitive sector data; the
+BNT-cover comparison data for those sectors are separate hypotheses. Under those
+hypotheses, `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` gives
+BNT sector decompositions whose basis sectors and weights match up to
+permutation and nonzero phases.
 
 ## References
 
@@ -91,21 +89,20 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
 namespace MPSTensor
 
-/-- Remaining hypotheses for the after-blocking Fundamental Theorem formulation.
+/-- BNT-cover comparison hypotheses for the after-blocking comparison theorem.
 
-Starting from `SameMPV₂ A B`, the present derivation constructs common primitive
-nonzero-sector families after a common blocking.  The blocked-word relabeling assertion is now
-derived in this formulation from the grouped-block cast theorem.  To reach the sector-weight
-conclusion of the Cirac--Pérez-García--Schuch--Verstraete Fundamental Theorem for exactly those
-produced families, one still needs comparison data for those produced families.  The field
-`comparison` is supplied with their trace-preserving, primitive, irreducible, and positive
-bond-dimension evidence, so the remaining assumptions cannot be applied to a different
-decomposition. -/
+For tensors with the same MPV family, the structural reduction gives common primitive
+nonzero-sector families after a common blocking.  The blocked-word relabeling assertion is
+derived from the grouped-block cast theorem.  This predicate supplies the additional BNT-cover
+comparison data for those exact families; equality of MPV families alone is not used here to
+derive that data.  The field `comparison` includes their trace-preserving, primitive,
+irreducible, and positive bond-dimension evidence, so the comparison assumptions are tied to the
+families obtained after blocking. -/
 structure AfterBlockingFundamentalTheoremHypotheses
     {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop where
-  /-- The remaining BNT-cover comparison data for the produced common primitive
-  nonzero-sector families, with the structural evidence for trace preservation,
-  primitivity, irreducibility, and positive bond dimensions supplied. -/
+  /-- BNT-cover comparison data for the reindexed common primitive nonzero-sector families, with
+  the structural evidence for trace preservation, primitivity, irreducibility, and positive bond
+  dimensions supplied. -/
   comparison : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
       {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
       [∀ x : Fin rA, NeZero (dimA x)]
@@ -151,7 +148,7 @@ structure AfterBlockingFundamentalTheoremHypotheses
           (CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
             (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB)
 
-/-- Conclusion of the conditional after-blocking Fundamental Theorem formulation.
+/-- Conclusion obtained from supplied after-blocking comparison data.
 
 The conclusion follows the Cirac--Pérez-García--Schuch--Verstraete statement at the level of
 BNT sector decompositions.  After one positive blocking, there are sector decompositions `P` and
@@ -196,15 +193,14 @@ structure AfterBlockingFundamentalTheoremConclusion
       Finset.univ.val.map
         (fun q => phase j * Q.weight (perm j) (Fin.cast (copies_eq j) q))
 
-/-- **Conditional after-blocking Fundamental Theorem formulation.**
+/-- **After-blocking comparison from supplied BNT-cover data.**
 
-Let `A` and `B` generate the same MPV family.  Under the explicit remaining comparison
-hypotheses, there is a positive blocking after which the two tensors admit BNT sector
+Let `A` and `B` generate the same MPV family.  If BNT-cover comparison data are supplied for
+the common primitive nonzero-sector families obtained after blocking, there is a positive
+blocking after which the two tensors admit BNT sector
 decompositions with the same sector MPV family, matched basis-sector multiplicities, and matched
-sector-weight multisets up to nonzero phases.  This is the conditional formulation proved by the
-present periodic-theorem-free derivation: it is a direct consequence of
-`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover`, not a hidden
-assumption or an appeal to the periodic Fundamental Theorem. -/
+sector-weight multisets up to nonzero phases.  The `comparison` field is an independent
+hypothesis of this theorem; the result does not derive it from `SameMPV₂`. -/
 theorem fundamentalTheorem_afterBlocking_of_comparisonHypotheses
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.CanonicalForm.Assembly.SectorComparisonCore
 /-!
 # Canonical-form reduction after blocking
 
-This module is the public entry point for the end-to-end canonical-form
+This module is the public entry point for the complete canonical-form
 reduction after blocking. It keeps the historical import path
 `TNLean.MPS.CanonicalForm.Assembly` available while the underlying development is
 split across focused supporting modules.
@@ -68,12 +68,13 @@ The imported modules provide the canonical-form reduction theorems, including
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
 `exists_bilateral_tp_primitive_blockDecomp_after_blocking`.
 
-The end-to-end after-blocking comparison has a conditional form here. Equality
-of MPV families gives the common blocking and common primitive sector data; the
-BNT-cover comparison data for those sectors are separate hypotheses. Under those
-hypotheses, `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` gives
-BNT sector decompositions whose basis sectors and weights match up to
-permutation and nonzero phases.
+The after-blocking comparison of two tensors with the same MPV family has a
+conditional form here. Equality of MPV families gives the common blocking and
+common primitive sector data; the BNT-cover comparison data for those sectors
+are separate hypotheses. Under those hypotheses,
+`fundamentalTheorem_afterBlocking_of_comparisonHypotheses` gives BNT sector
+decompositions whose basis sectors and weights match up to permutation and
+nonzero phases.
 
 ## References
 

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1871,20 +1871,20 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis}
-	Let $A$ and $B$ have the same MPV family.  Assume the formal blocked-word
+	Let $A$ and $B$ have the same MPV family. Assume the formal blocked-word
 	identification for the common-sector data.  The common-sector structural
-	theorem then produces the common primitive nonzero-sector families. If
-	those families satisfy the BNT-cover hypotheses, then the same sector-weight
-	comparison conclusion holds.
+	theorem gives common primitive nonzero-sector families. If those families
+	satisfy the BNT-cover hypotheses, then the same sector-weight comparison
+	conclusion holds.
 \end{theorem}
 
 \begin{proof}
 	\leanok
 	\uses{thm:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses,
 		thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
-	Convert the BNT-cover hypotheses for the produced families to common
-	phase-cover hypotheses, and then apply the common-sector comparison theorem
-	with common phase-cover data.
+	Convert the BNT-cover hypotheses for the common primitive nonzero-sector
+	families to common phase-cover hypotheses, and then apply the common-sector
+	comparison theorem with common phase-cover data.
 \end{proof}
 
 \begin{theorem}[Common sectors from explicit common primitive BNT data]%
@@ -1896,8 +1896,8 @@ two-basis sector comparison theorem.
 		thm:afterBlocking_sectorComparison_reindexed_bntCover}
 	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
 	identification hypothesis for the cyclic-sector data. The common-sector
-	structural theorem produces the common primitive nonzero-sector families. If
-	these families have strict weight ordering, internal gauge-phase separation,
+	structural theorem gives common primitive nonzero-sector families. If these
+	families have strict weight ordering, gauge-phase separation,
 	equal zero-tail dimension, one-site injectivity, and proportional-decomposition
 	data, then the same sector-weight comparison conclusion holds.
 \end{theorem}
@@ -1907,8 +1907,9 @@ two-basis sector comparison theorem.
 	\uses{def:common_primitive_bnt_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis,
 		thm:afterBlocking_sectorComparison_reindexed_bntCover}
-	First form the BNT-cover hypotheses for the produced families from the stated
-	common primitive data. Then apply the BNT-cover comparison theorem.
+	First form the BNT-cover hypotheses for the common primitive nonzero-sector
+	families from the stated common primitive data. Then apply the BNT-cover
+	comparison theorem.
 \end{proof}
 
 \begin{theorem}[Common sectors from proportional-comparison data]%
@@ -1919,8 +1920,8 @@ two-basis sector comparison theorem.
 		def:common_sector_relabeling_hypothesis}
 	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
 	identification hypothesis for the cyclic-sector data. The common-sector
-	structural theorem produces the common primitive nonzero-sector families. If
-	those families satisfy the proportional-comparison hypotheses of
+	structural theorem gives common primitive nonzero-sector families. If those
+	families satisfy the proportional-comparison hypotheses of
 	Definition~\ref{def:common_primitive_proportional_hypotheses}, then the same
 	sector-weight comparison conclusion holds.
 \end{theorem}
@@ -1929,27 +1930,27 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{thm:common_primitive_proportional_hypotheses_to_phase_cover_hypotheses,
 		thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
-	Convert the BNT proportional-decomposition comparison for the produced families
-	to common phase-cover hypotheses, and then apply the common-sector
-	comparison theorem with common phase-cover data.
+	Convert the BNT proportional-decomposition comparison for the common primitive
+	nonzero-sector families to common phase-cover hypotheses, and then apply the
+	common-sector comparison theorem with common phase-cover data.
 \end{proof}
 
-\begin{definition}[After-blocking hypotheses for the CPSV formulation]%
+\begin{definition}[After-blocking BNT-cover comparison hypotheses]%
 	\label{def:after_blocking_fundamental_theorem_hypotheses}
 	\lean{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses}
-	These hypotheses consist of the comparison data for the after-blocking
-	formulation of the CPSV Fundamental Theorem that does not use the periodic
-	theorem. The blocked-word identification for common cyclic sectors is
+	For two tensors with the same MPV family, the structural reduction supplies
+	a common blocking, zero-tail identities, and common primitive nonzero-sector
+	families. These hypotheses add the BNT-cover comparison data for those
+	families. The blocked-word identification for common cyclic sectors is
 	derived from the grouped-block cast theorem.
 
-	For the common primitive nonzero-sector families produced from two tensors
-	with the same MPV family, the comparison data include their
+	The comparison data include the sectors'
 	trace-preserving normalization, primitivity, irreducibility, and positive
 	bond-dimension evidence before returning BNT-cover comparison hypotheses for
-	those blocks. The hypotheses are tied to the produced families rather than
-	to an arbitrary chosen decomposition.
+	those blocks. Thus the assumptions apply to the common primitive sectors
+	obtained after blocking, not to an arbitrary chosen decomposition.
 \end{definition}
 
 \begin{definition}[CPSV after-blocking Fundamental Theorem conclusion]%
@@ -1966,14 +1967,14 @@ two-basis sector comparison theorem.
 	side by nonzero sector phases.
 \end{definition}
 
-\begin{theorem}[Conditional after-blocking CPSV formulation]%
+\begin{theorem}[After-blocking comparison from supplied BNT-cover data]%
 \label{thm:fundamental_theorem_after_blocking_comparison_hypotheses}
 	\lean{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}
 	\leanok
 	\uses{def:after_blocking_fundamental_theorem_hypotheses,
 			def:after_blocking_fundamental_theorem_conclusion}
 	Let $A$ and $B$ generate the same MPV family. Assume the after-blocking
-	comparison hypotheses of
+	BNT-cover comparison hypotheses of
 	Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. Then the
 	CPSV conclusion of
 	Definition~\ref{def:after_blocking_fundamental_theorem_conclusion} is
@@ -1985,9 +1986,11 @@ two-basis sector comparison theorem.
 	whose basis sectors and weights match up to permutation and nonzero phases,
 	as in \cite{Cirac2016MPDO_arXiv} and \cite{Cirac2021Matrix}.
 
-	The explicit hypotheses include the zero-tail, trace-preserving
-	normalization, primitivity, irreducibility, positive bond-dimension, and
-	BNT-cover comparison inputs.
+	The BNT-cover comparison hypotheses are independent assumptions in this
+	statement. The theorem does not derive them from equality of MPV families;
+	it derives the after-blocking conclusion once the zero-tail,
+	trace-preserving normalization, primitivity, irreducibility, positive
+	bond-dimension, and BNT-cover comparison inputs are supplied.
 \end{theorem}
 
 	\begin{proof}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1897,7 +1897,7 @@ two-basis sector comparison theorem.
 	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
 	identification hypothesis for the cyclic-sector data. The common-sector
 	structural theorem gives common primitive nonzero-sector families. If these
-	families have strict weight ordering, gauge-phase separation,
+	families have strict weight ordering, internal gauge-phase separation,
 	equal zero-tail dimension, one-site injectivity, and proportional-decomposition
 	data, then the same sector-weight comparison conclusion holds.
 \end{theorem}


### PR DESCRIPTION
### Motivation

- The docstring of `AfterBlockingFundamentalTheoremHypotheses` and the public theorem `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` could be misread as claiming that the BNT-cover comparison data for the common primitive nonzero-sector families is derivable from `SameMPV₂`; it is in fact supplied as an independent hypothesis. This ambiguity risks conflating the conditional scope of the after-blocking theorem with the unconditional conclusion of the source paper (arXiv:1606.00608; arXiv:2011.12127 §IV). See #1283.
- The corresponding Chapter 11 blueprint entries carried analogous ambiguous phrasing ("produced families") in the adjacent BNT and proportional-comparison statements.

### Description

- `TNLean/MPS/CanonicalForm/Assembly.lean`: rewrites module-level and declaration-level docstrings for `AfterBlockingFundamentalTheoremHypotheses` and `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` to make explicit that the BNT-cover comparison data is an independent hypothesis, not a consequence of `SameMPV₂`.
- `blueprint/src/chapter/ch11_assembly.tex`: aligns the after-blocking hypothesis and comparison statements with the clarified Lean documentation; removes the ambiguous "produced families" phrasing from the adjacent BNT and proportional-comparison entries.
- No proof terms, definitions, or type signatures are modified; this is a documentation-only pass.

### Testing

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean.MPS.CanonicalForm.Assembly`
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`

---
Addresses #1283

> [!NOTE]
> **Low Risk**
> Documentation-only updates that clarify theorem hypotheses; no changes to proof terms, definitions, or APIs beyond comments and section titles.
> 
> **Overview**
> Clarifies the *boundary of assumptions* in the after-blocking comparison entry point: `AfterBlockingFundamentalTheoremHypotheses` is now documented explicitly as **independently supplying** the BNT-cover comparison data for the common primitive nonzero-sector families produced after blocking, rather than being derivable from `SameMPV₂`.
> 
> Updates the corresponding Chapter 11 blueprint text to match this interpretation, renaming/rewriting the after-blocking hypothesis/comparison statements and removing ambiguous "produced families" phrasing in nearby BNT/proportional comparison entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2458abe1f8f9fa087daa545da57357d4d9168efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes clarifying that BNT-cover comparison data are an explicit independent hypothesis (not derived from `SameMPV₂`), with no changes to proofs, definitions, or APIs.
> 
> **Overview**
> Clarifies the public `TNLean.MPS.CanonicalForm.Assembly` documentation around the conditional after-blocking comparison theorem: the `AfterBlockingFundamentalTheoremHypotheses.comparison` field is now described as **independent BNT-cover comparison data** for the post-blocking common primitive sectors, and `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` is reworded to avoid implying this data follows from `SameMPV₂`.
> 
> Updates the Chapter 11 blueprint statements to match this boundary (renaming/rewriting the after-blocking hypotheses/comparison statements and removing ambiguous “produced families” phrasing in adjacent BNT/proportional comparison entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 279a01aa04f17c4324881e2318538fe607d0a15f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->