### PR TITLE
doc(MPS/CanonicalForm): clarify one-sector terminology

### DIFF
--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -58,7 +58,7 @@ basis-of-normal-tensors construction from
   and the assembled tensor is `SameMPV₂`-equivalent to the original.  This is the key
   bridging step from the reduction output to the canonical form.
 
-### Section 4 Granular sector decomposition for the sorted distinct-norm case
+### Section 4 One-sector-per-block sector decomposition for the sorted distinct-norm case
 
 * `exists_trivialSectorDecomp_of_sorted_distinct_norms` — Forms from a sorted
   distinct-norm block family a `SectorDecomposition` with all multiplicities
@@ -226,15 +226,16 @@ theorem exists_sortedNCF_of_distinct_norms
     dim_pos           := fun k => hDim (e k)
   }⟩
 
-/-! ### Section 4. Granular sector decomposition -/
+/-! ### Section 4. One-sector-per-block sector decomposition -/
 
-/-- **Granular `SectorDecomposition` with one basis tensor per input block.**
+/-- **One-sector-per-block `SectorDecomposition`.**
 
 Forms from a block family `(μ, blocks)` a `SectorDecomposition` with `copies j = 1`
 for every `j`.  Each input block becomes its own sector basis tensor with sector
 weight `μ j`.  This construction is deliberately only a structural form: by itself
 it does **not** assert the basis-of-normal-tensors linear-independence condition
-`HasBNTSectorData` from `TNLean.MPS.FundamentalTheorem.SectorDecomposition`. -/
+`HasBNTSectorData` from `TNLean.MPS.FundamentalTheorem.SectorDecomposition`, and it is
+not the paper's minimal BNT representative construction. -/
 def trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
     (hμne : ∀ k, μ k ≠ 0) : SectorDecomposition d where
@@ -275,7 +276,7 @@ lemma sameMPV₂_trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
           symm
           simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
 
-/-- **Granular `SectorDecomposition` from a sorted block family.**
+/-- **One-sector-per-block `SectorDecomposition` from a sorted block family.**
 
 Specialization of `trivialSectorDecomp` to the sorted distinct-norm case: every block
 becomes its own basis tensor with `copies j = 1`, the assembled tensor has

--- a/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
+++ b/TNLean/MPS/CanonicalForm/EqualNormBridge.lean
@@ -82,7 +82,7 @@ Theorem matching, etc.).
   blocks once the family is already separated by non-gauge-phase-equivalence.
 
 * `exists_bnt_sectorDecomp_of_linearIndependent` — conditional construction
-  toward the `HasBNTSectorData` predicate.  It forms the granular
+  toward the `HasBNTSectorData` predicate.  It forms the one-sector-per-block
   `trivialSectorDecomp` as a BNT sector decomposition when the actual BNT
   linear-independence condition is supplied explicitly.
 

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -59,7 +59,7 @@ theorem exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocks
 /-- **Separated-family BNT sector construction.**
 
 If the given TP primitive irreducible blocks are already pairwise separated by
-non-gauge-phase-equivalence, the granular sector decomposition is a genuine BNT
+non-gauge-phase-equivalence, the one-sector-per-block sector decomposition is a genuine BNT
 sector decomposition: it represents the original weighted block sum and satisfies
 `HasBNTSectorData` by the overlap-derived eventual linear independence above.
 
@@ -534,19 +534,18 @@ theorem exists_bnt_sectorDecomp_pair_with_overlapSpan_of_proportionalDecompositi
 
 /-! ### Conditional sector construction under BNT linear independence -/
 
-/-- **Minimal granular sector decomposition carrying current `HasBNTSectorData`.**
+/-- **One-sector-per-block sector decomposition carrying current `HasBNTSectorData`.**
 
 This is the formulation of the conditional sector construction.  The
 predicate `HasBNTSectorData` now means eventual linear independence of the sector
 basis MPV states.  TP, irreducibility, primitivity, and nonzero weights do not by
-themselves provide that linear-independence statement for the granular basis; the
-genuine one-sided BNT construction must first choose representatives forming a basis of normal
-tensors.
+themselves provide that linear-independence statement for the one-sector-per-block basis; the
+one-sided BNT construction must first choose representatives forming a basis of normal tensors.
 
-Accordingly this theorem gives the simplest construction: if the granular basis
-is already known to satisfy the current BNT linear-independence hypothesis,
-then `trivialSectorDecomp` gives the requested `SectorDecomposition` and the
-`HasBNTSectorData` certificate is exactly the supplied `hLI`. -/
+Accordingly this theorem gives the direct structural construction: if the
+one-sector-per-block basis is already known to satisfy the current BNT
+linear-independence hypothesis, then `trivialSectorDecomp` gives the requested
+`SectorDecomposition` and the `HasBNTSectorData` certificate is exactly the supplied `hLI`. -/
 theorem exists_bnt_sectorDecomp_of_linearIndependent
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2765,7 +2765,9 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\label{thm:bnt_sorted_blockdecomp}
 	\lean{MPSTensor.exists_sorted_blockDecomp_of_distinct_norms}\leanok
 	\uses{thm:bnt_sorted_reindexing}
-	Under the same distinct-norm hypothesis, the sorted block family is gauge equivalent to the original decomposition and has strictly decreasing norms.
+	Under the same distinct-norm hypothesis, the sorted block family represents
+	the same MPS family as the original decomposition and has strictly decreasing
+	norms.
 \end{theorem}
 
 \begin{theorem}[Normal canonical form after sorting]
@@ -2775,7 +2777,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	If each block is irreducible, trace-preserving, primitive, and has positive dimension, then sorting by strictly decreasing weight norms produces a normal canonical form.
 \end{theorem}
 
-\begin{definition}[Granular sector decomposition]
+\begin{definition}[One-sector-per-block sector decomposition]
 	\label{def:trivial_sector_decomp}
 	\lean{MPSTensor.trivialSectorDecomp}
 	\leanok
@@ -2783,15 +2785,17 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	Given nonzero weights $(\mu_k)_{k=1}^r$ and blocks $(B_k)_{k=1}^r$,
 	form a sector decomposition with one basis block for each original block,
 	one copy in each sector, and sector weight $\mu_k$ on the $k$th sector.
+	This is a formal one-sector-per-input-block construction, not the paper's
+	minimal BNT representative construction.
 \end{definition}
 
-\begin{lemma}[Granular sector decomposition preserves the represented family]
+\begin{lemma}[One-sector-per-block decomposition preserves the represented family]
 	\label{lem:trivial_sector_decomp_same_mpv}
 	\lean{MPSTensor.sameMPV₂_trivialSectorDecomp}
 	\leanok
 	\uses{def:trivial_sector_decomp}
-	The granular sector decomposition associated to $(\mu_k,B_k)_k$ represents
-	the same MPS family as the original weighted block sum
+	The one-sector-per-block sector decomposition associated to
+	$(\mu_k,B_k)_k$ represents the same MPS family as the original weighted block sum
 	$\bigoplus_k \mu_k B_k$.
 \end{lemma}
 
@@ -2802,7 +2806,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	block-sum expression for $\bigoplus_k \mu_k B_k$.
 \end{proof}
 
-\begin{lemma}[Granular sector decomposition for the sorted distinct-norm case]
+\begin{lemma}[One-sector-per-block decomposition for the sorted distinct-norm case]
 	\label{thm:bnt_trivial_sector}
 	\lean{MPSTensor.exists_trivialSectorDecomp_of_sorted_distinct_norms}\leanok
 	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv}
@@ -2908,14 +2912,14 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	Theorem~\ref{thm:bnt_li_from_overlap_limits_exists}.
 \end{proof}
 
-\begin{theorem}[Granular sector decomposition from eventual BNT independence]
+\begin{theorem}[One-sector-per-block decomposition from eventual BNT independence]
 	\label{thm:bnt_sector_decomp_linear_independent}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_of_linearIndependent}
 	\leanok
 	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv, def:bnt}
 	If the MPV states of the blocks are linearly independent for all sufficiently
-	large system sizes and all weights are nonzero, then the granular sector
-	decomposition represents the same MPS family and satisfies the BNT
+	large system sizes and all weights are nonzero, then the one-sector-per-block
+	sector decomposition represents the same MPS family and satisfies the BNT
 	linear-independence condition.
 \end{theorem}
 
@@ -2923,8 +2927,8 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv}
 	The equality of represented families is
 	Lemma~\ref{lem:trivial_sector_decomp_same_mpv}.  The assumed eventual linear
-	independence is exactly the BNT condition for the basis blocks of the granular
-	sector decomposition.
+	independence is exactly the BNT condition for the basis blocks of the
+	one-sector-per-block sector decomposition.
 \end{proof}
 
 \begin{theorem}[Separated primitive normal sector construction]
@@ -2934,15 +2938,14 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv, thm:bnt_li_tp_prim_irr_separated}
 	For trace-preserving primitive irreducible blocks of positive bond dimension
 	with nonzero weights, if distinct blocks are pairwise not gauge-phase
-	equivalent, then the granular
-	sector decomposition represents the same MPS family and satisfies the BNT
-	linear-independence condition.  Equal-modulus separated blocks remain as
-	distinct basis blocks.
+	equivalent, then the one-sector-per-block sector decomposition represents
+	the same MPS family and satisfies the BNT linear-independence condition.
+	Equal-modulus separated blocks remain as distinct basis blocks.
 \end{theorem}
 
 \begin{proof}\leanok
 	\uses{lem:trivial_sector_decomp_same_mpv, thm:bnt_li_tp_prim_irr_separated}
-	The granular sector decomposition preserves the represented family by
+	The one-sector-per-block sector decomposition preserves the represented family by
 	Lemma~\ref{lem:trivial_sector_decomp_same_mpv}.  The separated primitive
 	normal hypotheses give the eventual linear independence by
 	Theorem~\ref{thm:bnt_li_tp_prim_irr_separated}.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2785,8 +2785,8 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	Given nonzero weights $(\mu_k)_{k=1}^r$ and blocks $(B_k)_{k=1}^r$,
 	form a sector decomposition with one basis block for each original block,
 	one copy in each sector, and sector weight $\mu_k$ on the $k$th sector.
-	This is a formal one-sector-per-input-block construction, not the paper's
-	minimal BNT representative construction.
+	This is an auxiliary construction, not the minimal BNT representative
+	construction of \cite[Proposition~A.6]{Cirac2017MPDO_AnnPhys}.
 \end{definition}
 
 \begin{lemma}[One-sector-per-block decomposition preserves the represented family]


### PR DESCRIPTION
### Motivation

- Reader-facing prose in the Chapter 8 blueprint and related Lean docstrings uses "granular sector decomposition" for the auxiliary construction `trivialSectorDecomp`, but "granular" is not terminology from the source papers (arXiv:1606.00608, arXiv:1708.00029). Those sources define a basis of normal tensors by eventual linear independence and minimality, selecting a subset of canonical-form blocks; the auxiliary construction assigns one sector per input block and is not the paper's minimal BNT representative. See #1292.

### Description

- `TNLean/MPS/CanonicalForm/BNTGrouping.lean`: replaced "granular sector decomposition" with "one-sector-per-block sector decomposition" in docstrings; added explicit statement that `trivialSectorDecomp` is a formal one-sector-per-input-block construction distinct from the paper's minimal BNT representative.
- `TNLean/MPS/CanonicalForm/EqualNormBridge.lean`: aligned docstring phrasing with the above change.
- `blueprint/src/chapter/ch08_canonical.tex`: replaced "granular sector decomposition" with "one-sector-per-block sector decomposition"; clarified at first use that the construction is an auxiliary formal device, not a paper term; no declarations renamed.

### Testing

- `lake build TNLean.MPS.CanonicalForm.BNTGrouping`
- `lake build TNLean.MPS.CanonicalForm.EqualNormBridge`
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`

---
Closes #1292

> [!NOTE]
> **Low Risk**
> Documentation-only terminology updates in Lean docstrings and the blueprint TeX; no changes to definitions, proofs, or behavior.
>
> **Overview**
> Updates reader-facing terminology from **"granular sector decomposition"** to **"one-sector-per-block sector decomposition"** across `BNTGrouping.lean`, `EqualNormBridge.lean`, and the Chapter 8 blueprint.
>
> Clarifies in both Lean and the blueprint that `trivialSectorDecomp` is a *formal one-sector-per-input-block* construction and **not** the paper's minimal BNT representative construction, and tweaks phrasing to consistently describe MPV-family preservation rather than gauge equivalence.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d8c1158adf9712f4af1fcf9c8d75ac1d647bfde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/comments and blueprint text (terminology/wording) with no modifications to Lean definitions, proofs, or behavior.
> 
> **Overview**
> Renames reader-facing terminology for `trivialSectorDecomp` from **“granular sector decomposition”** to **“one-sector-per-block sector decomposition”** across Lean module docstrings and the Chapter 8 blueprint.
> 
> Clarifies that `trivialSectorDecomp` is an auxiliary structural construction (one sector per input block, `copies = 1`) and **not** the paper’s minimal BNT representative construction, and tweaks wording to describe MPV-family preservation rather than gauge equivalence in the distinct-norm sorting narrative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead43be0f7396d48389bcd6b8ad780f887457f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->