### PR TITLE
style(MPS/FundamentalTheorem): demote sector-weight helper statements to lemma

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -46,7 +46,7 @@ is eventually linearly independent (the BNT property), then the coefficient arra
 
 This is the key step converting MPV equality into the algebraic statement needed for
 Newton–Girard. -/
-theorem coeff_eventually_eq_of_sameMPV
+lemma coeff_eventually_eq_of_sameMPV
     {dim : Fin g → ℕ}
     (basis : (j : Fin g) → MPSTensor d (dim j))
     (S T : SectorWeightData g)
@@ -228,7 +228,7 @@ lemma power_sums_eq_of_eventually_eq
     (m := m) (n := m) a b ha hb (M := M) hEv
 
 /-- Eventual equality of coefficient power sums forces equality of multiplicities. -/
-theorem copies_eq_of_eventually_coeff_eq
+lemma copies_eq_of_eventually_coeff_eq
     (S T : SectorWeightData g)
     {N0 : ℕ}
     (hEv : ∀ N > N0, ∀ j : Fin g, S.coeff N j = T.coeff N j) :

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -412,7 +412,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	\lean{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq_hetero}
 	\leanok
 	If two finite families of nonzero complex numbers, possibly with different
-	cardinalities, have equal power sums for all sufficiently large exponents,
+	cardinalities, have equal power sums eventually, so there is $N_0$ such that
 	\[
 		\forall N\ge N_0,\qquad
 		\sum_i \alpha_i^N = \sum_j \beta_j^N,
@@ -436,8 +436,8 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 \label{lem:geom_extrapolation}
 	\lean{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq}
 	\leanok
-	If two finite families of nonzero complex numbers with the same
-	cardinality have equal power sums for all sufficiently large exponents,
+	If two finite families of nonzero complex numbers with the same cardinality
+	have equal power sums eventually, so there is $N_0$ such that
 	\[
 		\forall N\ge N_0,\qquad
 		\sum_i \alpha_i^N = \sum_i \beta_i^N,

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -457,8 +457,8 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	\lean{MPSTensor.SectorWeightData.copies_eq_of_eventually_coeff_eq}
 	\leanok
 	\uses{def:paper_sector_data}
-	Let $S$ and $T$ be sector data over the same basis. If their coefficient
-	arrays satisfy
+	Let $S$ and $T$ be sector data over the same basis. If there is $N_0$
+	such that their coefficient arrays satisfy
 	\[
 		\forall N>N_0,\ \forall j,\qquad
 		c_{S,j}^{(N)} = c_{T,j}^{(N)},

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -392,27 +392,36 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	\]
 \end{theorem}
 
-\begin{theorem}[Eventual coefficient comparison from BNT linear independence]%
-\label{thm:coeff_eventually_eq}
+\begin{lemma}[Eventual coefficient comparison from BNT linear independence]%
+\label{lem:coeff_eventually_eq}
 	\lean{MPSTensor.SectorWeightData.coeff_eventually_eq_of_sameMPV}
 	\leanok
 	\uses{def:paper_sector_data, def:bnt}
 	If two sector data $S, T$ over the same basis, with coefficient arrays
 	$c_{S,j}^{(N)}$ and $c_{T,j}^{(N)}$, produce equal total MPVs
 	and the basis is eventually linearly independent (the BNT property),
-	then $c_{S,j}^{(N)} = c_{T,j}^{(N)}$ for all
-	sufficiently large $N$.
-\end{theorem}
+	then there is $N_0$ such that
+	\[
+		\forall N>N_0,\ \forall j,\qquad
+		c_{S,j}^{(N)}=c_{T,j}^{(N)}.
+	\]
+\end{lemma}
 
 \begin{lemma}[Heterogeneous geometric sequence extrapolation]%
 \label{lem:geom_extrapolation_hetero}
 	\lean{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq_hetero}
 	\leanok
 	If two finite families of nonzero complex numbers, possibly with different
-	cardinalities, have equal power sums
-	$\sum_i \alpha_i^k = \sum_j \beta_j^k$ for all sufficiently large
-	exponents $k$, then the same equality holds for every exponent
-	$k \geq 0$.
+	cardinalities, have equal power sums for all sufficiently large exponents,
+	\[
+		\forall N\ge N_0,\qquad
+		\sum_i \alpha_i^N = \sum_j \beta_j^N,
+	\]
+	then the same equality holds for every exponent:
+	\[
+		\forall k\ge 0,\qquad
+		\sum_i \alpha_i^k = \sum_j \beta_j^k.
+	\]
 \end{lemma}
 
 \begin{proof}
@@ -428,9 +437,12 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	\lean{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq}
 	\leanok
 	If two finite families of nonzero complex numbers with the same
-	cardinality have equal power sums
-	$\sum_i \alpha_i^k = \sum_i \beta_i^k$ for all $k > N_0$, then
-	equality holds for all $k \geq 0$.
+	cardinality have equal power sums for all sufficiently large exponents,
+	\[
+		\forall N\ge N_0,\qquad
+		\sum_i \alpha_i^N = \sum_i \beta_i^N,
+	\]
+	then equality holds for all exponents $k\ge 0$.
 \end{lemma}
 
 \begin{proof}
@@ -440,16 +452,22 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	Lemma~\ref{lem:geom_extrapolation_hetero}.
 \end{proof}
 
-\begin{theorem}[Copy-count recovery from eventual coefficient equality]%
-\label{thm:copies_eq_of_eventually_coeff_eq}
+\begin{lemma}[Copy-count recovery from eventual coefficient equality]%
+\label{lem:copies_eq_of_eventually_coeff_eq}
 	\lean{MPSTensor.SectorWeightData.copies_eq_of_eventually_coeff_eq}
 	\leanok
 	\uses{def:paper_sector_data}
 	Let $S$ and $T$ be sector data over the same basis. If their coefficient
-	arrays satisfy $c_{S,j}^{(N)} = c_{T,j}^{(N)}$ for every basis block $j$
-	and all sufficiently large $N$, then their copy counts agree:
-	$r_j^S = r_j^T$ for every~$j$.
-\end{theorem}
+	arrays satisfy
+	\[
+		\forall N>N_0,\ \forall j,\qquad
+		c_{S,j}^{(N)} = c_{T,j}^{(N)},
+	\]
+	then their copy counts agree:
+	\[
+		\forall j,\qquad r_j^S = r_j^T.
+	\]
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -480,11 +498,11 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 
 \begin{proof}
 	\leanok
-	\uses{thm:coeff_eventually_eq, thm:copies_eq_of_eventually_coeff_eq,
+	\uses{lem:coeff_eventually_eq, lem:copies_eq_of_eventually_coeff_eq,
 	      lem:geom_extrapolation, thm:power_sum_multiset}
 	BNT linear independence and equality of total MPVs give eventual
-	coefficient equality by Theorem~\ref{thm:coeff_eventually_eq}. Then
-	Theorem~\ref{thm:copies_eq_of_eventually_coeff_eq} recovers the
+	coefficient equality by Lemma~\ref{lem:coeff_eventually_eq}. Then
+	Lemma~\ref{lem:copies_eq_of_eventually_coeff_eq} recovers the
 	copy-count equalities. After identifying the two index sets via these
 	copy-count equalities, the positive-power coefficient equalities extend
 	to all positive exponents by
@@ -496,7 +514,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 \label{thm:route_b_equal}
 	\lean{MPSTensor.SectorWeightData.weight_multiset_eq_of_sameMPV_bnt}
 	\leanok
-	\uses{thm:coeff_eventually_eq, lem:geom_extrapolation, thm:power_sum_multiset, def:paper_sector_data, def:bnt}
+	\uses{lem:coeff_eventually_eq, lem:geom_extrapolation, thm:power_sum_multiset, def:paper_sector_data, def:bnt}
 	Let $S$ and $T$ be two sector data over the same basis with
 	the same multiplicities ($r_j^S = r_j^T$ for all~$j$).
 	If the basis is eventually linearly independent and the total MPVs
@@ -506,7 +524,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	The argument proceeds as follows:
 	\begin{enumerate}
 		\item BNT LI $+$ equal MPVs $\Rightarrow$ eventual coefficient
-		      equality (Theorem~\ref{thm:coeff_eventually_eq});
+		      equality (Lemma~\ref{lem:coeff_eventually_eq});
 		\item Geometric extrapolation $\Rightarrow$ full coefficient
 		      equality for all positive~$k$
 		      (Lemma~\ref{lem:geom_extrapolation});


### PR DESCRIPTION
### Motivation

- `SectorWeightData.coeff_eventually_eq_of_sameMPV` and `SectorWeightData.copies_eq_of_eventually_coeff_eq` are auxiliary algebraic facts supporting the BNT sector-weight comparison, not standalone paper-level theorems; their prominence in the blueprint overstated their mathematical status (see #1287).
- The Chapter 11 blueprint cards for these results used prose-only summaries; a formula-first presentation is more precise and consistent with the surrounding material.

### Description

- `TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean`: demote `SectorWeightData.coeff_eventually_eq_of_sameMPV` and `SectorWeightData.copies_eq_of_eventually_coeff_eq` from `theorem` to `lemma`; declaration names are preserved.
- `blueprint/src/chapter/ch11_assembly.tex`: change the corresponding blueprint environments from `theorem` to `lemma`, rename labels from `thm:*` to `lem:*`, update `\uses{...}` references accordingly, and rewrite the geometric power-sum extrapolation and copy-count recovery statements in formula-first style.

### Testing

- `lake build TNLean.MPS.FundamentalTheorem.SectorWeightComparison`
- `lake build TNLean.MPS.FundamentalTheorem.SectorDecomposition`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Closes #1287

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust declaration kinds (`theorem`→`lemma`) and blueprint documentation/labels, with no algorithmic or proof-logic modifications.
> 
> **Overview**
> Demotes `SectorWeightData.coeff_eventually_eq_of_sameMPV` and `SectorWeightData.copies_eq_of_eventually_coeff_eq` from `theorem` to `lemma` in `SectorWeightComparison.lean` (no name changes).
> 
> Updates Chapter 11 blueprint cards to match: changes the environments to `lemma`, renames labels from `thm:*` to `lem:*`, adjusts `\uses{...}` references, and rewrites the geometric extrapolation/copy-count statements in a formula-first style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3dd86d184daf5188ddfccbb45e65933d616b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to declaration classification (`theorem`→`lemma`) and blueprint documentation/label updates, with no proof logic or computational behavior changes.
> 
> **Overview**
> Demotes `SectorWeightData.coeff_eventually_eq_of_sameMPV` and `SectorWeightData.copies_eq_of_eventually_coeff_eq` from `theorem` to `lemma` in `SectorWeightComparison.lean` without renaming or altering statements/proofs.
> 
> Updates the Chapter 11 blueprint cards accordingly by switching `theorem` environments to `lemma`, renaming labels/references from `thm:*` to `lem:*`, and rewriting several statements (notably geometric extrapolation and copy-count recovery) in a more formula-first style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 380cebd56ba6feaa1d65988e4c3d55e47d2eadd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->