### PR TITLE
doc(MPS/CanonicalForm): clarify cyclic-sector sources

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
@@ -13,11 +13,10 @@ This file contains the common reblocking data used to compare the primitive cycl
 sectors of finitely many nonzero-weight blocks at a shared physical blocking length.
 
 For one periodic block, arXiv:1708.00029 blocks by the period and obtains normal
-sector tensors $C_u = P_u A^{[m]} P_u$.  This file starts after that one-block
-decomposition has been chosen for each original block.  It records a common
-length $p = m_k e_k$ so that every sector can be regarded as a tensor over the
-same blocked physical alphabet.  Thus this shared-alphabet condition is
-finite-family comparison data, not a separate theorem in the paper source.
+sector tensors $C_u = P_u A^{[m]} P_u$.  For a finite family of nonzero-weight
+blocks, choose positive integers $e_k$ and a common length $p = m_k e_k$ for
+each block period $m_k$.  Every cyclic sector can then be regarded as a tensor
+over the same blocked physical alphabet.
 
 ## References
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
@@ -9,8 +9,23 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 /-!
 # Common blocked cyclic-sector families
 
-This file contains the common reblocking data used to assemble the primitive cyclic
+This file contains the common reblocking data used to compare the primitive cyclic
 sectors of finitely many nonzero-weight blocks at a shared physical blocking length.
+
+For one periodic block, arXiv:1708.00029 blocks by the period and obtains normal
+sector tensors $C_u = P_u A^{[m]} P_u$.  This file starts after that one-block
+decomposition has been chosen for each original block.  It records a common
+length $p = m_k e_k$ so that every sector can be regarded as a tensor over the
+same blocked physical alphabet.  Thus this shared-alphabet condition is
+finite-family comparison data, not a separate theorem in the paper source.
+
+## References
+
+* [De las Cuevas et al., arXiv:1708.00029, blocking periodic tensors]
+
+## Tags
+
+matrix product states, cyclic sectors, blocking, canonical form
 -/
 
 namespace MPSTensor
@@ -64,7 +79,7 @@ structure CommonBlockedCyclicSectorFamily {d r : ℕ} {dim : Fin r → ℕ}
   sector_irreducible : ∀ k s, IsIrreducibleTensor (sectorBlocks k s)
   /-- The sector bond dimensions are positive before later reblocking. -/
   sector_dim_pos : ∀ k s, 0 < sectorDim k s
-  /-- The iterated blocked physical alphabet is propositionally the common alphabet. -/
+  /-- The iterated blocked physical alphabet is propositionally the shared alphabet. -/
   blockPhysDim_nested_eq : ∀ k,
     blockPhysDim (blockPhysDim d (period k)) (extra k) = blockPhysDim d p
   /-- The checked MPV compatibility condition for each original nonzero-weight block

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -20,16 +20,15 @@ relates powers of the adjoint transfer map to blocked transfer maps, applies the
 channel-level cyclic decomposition to a blocked periodic tensor, and then derives
 its MPS-formulation for irreducible TP tensors.
 
-The paper-level theorem being formalized is the passage from a periodic
-irreducible block to normal blocks after blocking by the period.  In the notation
-of arXiv:1708.00029, the cyclic projections satisfy
+A periodic irreducible block becomes a family of normal blocks after blocking by
+its period.  In the notation of arXiv:1708.00029, the cyclic projections satisfy
 $$
   \mathcal E_A^*(P_{u+1}) = P_u,
   \qquad A^i = \sum_u P_u A^i P_{u+1},
   \qquad C_u = P_u A^{[m]} P_u.
 $$
-The later common-length constructions for several original blocks are separate
-finite-family data used by the non-periodic fundamental-theorem proof.
+For a finite family of original blocks, a further common blocking length puts all
+cyclic sectors over one physical alphabet.
 
 ## Main statements
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -20,6 +20,17 @@ relates powers of the adjoint transfer map to blocked transfer maps, applies the
 channel-level cyclic decomposition to a blocked periodic tensor, and then derives
 its MPS-formulation for irreducible TP tensors.
 
+The paper-level theorem being formalized is the passage from a periodic
+irreducible block to normal blocks after blocking by the period.  In the notation
+of arXiv:1708.00029, the cyclic projections satisfy
+$$
+  \mathcal E_A^*(P_{u+1}) = P_u,
+  \qquad A^i = \sum_u P_u A^i P_{u+1},
+  \qquad C_u = P_u A^{[m]} P_u.
+$$
+The later common-length constructions for several original blocks are separate
+finite-family data used by the non-periodic fundamental-theorem proof.
+
 ## Main statements
 
 The first theorem derives the MPS-level cyclic-sector decomposition for an
@@ -30,8 +41,8 @@ extra assumptions.
 
 ## References
 
-* [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix A]
-* [Cirac–Pérez-García–Schuch–Verstraete, arXiv:2011.12127, Section IV]
+* [Wolf, *Quantum Channels & Operations*, Chapter 6]
+* [De las Cuevas et al., arXiv:1708.00029, periodic-block decomposition]
 
 ## Tags
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean
@@ -21,12 +21,16 @@ channel-level cyclic decomposition to a blocked periodic tensor, and then derive
 its MPS-formulation for irreducible TP tensors.
 
 A periodic irreducible block becomes a family of normal blocks after blocking by
-its period.  In the notation of arXiv:1708.00029, the cyclic projections satisfy
+its period.  In the cyclic order used in arXiv:1708.00029, the cyclic
+projections satisfy
 $$
-  \mathcal E_A^*(P_{u+1}) = P_u,
+  \mathcal E_A^*(P_u) = P_{u+1},
   \qquad A^i = \sum_u P_u A^i P_{u+1},
   \qquad C_u = P_u A^{[m]} P_u.
 $$
+Reversing the cyclic order gives the equivalent convention
+$\mathcal E_A^*(P_{u+1}) = P_u$, which is the indexing used by the cyclic
+iteration lemmas.
 For a finite family of original blocks, a further common blocking length puts all
 cyclic sectors over one physical alphabet.
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean
@@ -14,10 +14,9 @@ decomposition for the tensor obtained by blocking over one full period.  The
 connection is made by comparing the blocked adjoint transfer map with the
 corresponding power of the original adjoint transfer map.
 
-The mathematical source is the cyclic projection structure for irreducible
-quantum channels from Wolf Chapter 6, together with the off-diagonal form and
-period-blocking lemmas for periodic MPS blocks in arXiv:1708.00029.  The formulas
-formalized here are
+An irreducible quantum channel has cyclic projections as in Wolf Chapter 6, and
+periodic MPS blocks have the off-diagonal form and period-blocking behavior of
+arXiv:1708.00029.  The relevant identities are
 $$
   \mathcal E_A^*(P_{u+1}) = P_u,\qquad
   A^i = \sum_u P_u A^i P_{u+1},\qquad

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean
@@ -14,10 +14,20 @@ decomposition for the tensor obtained by blocking over one full period.  The
 connection is made by comparing the blocked adjoint transfer map with the
 corresponding power of the original adjoint transfer map.
 
+The mathematical source is the cyclic projection structure for irreducible
+quantum channels from Wolf Chapter 6, together with the off-diagonal form and
+period-blocking lemmas for periodic MPS blocks in arXiv:1708.00029.  The formulas
+formalized here are
+$$
+  \mathcal E_A^*(P_{u+1}) = P_u,\qquad
+  A^i = \sum_u P_u A^i P_{u+1},\qquad
+  C_u = P_u A^{[m]} P_u.
+$$
+
 ## References
 
-* [Cirac-Perez-Garcia-Schuch-Verstraete, arXiv:1606.00608, Appendix A]
-* [Cirac-Perez-Garcia-Schuch-Verstraete, arXiv:2011.12127, Section IV]
+* [Wolf, *Quantum Channels & Operations*, Chapter 6]
+* [De las Cuevas et al., arXiv:1708.00029, periodic-block decomposition]
 
 ## Tags
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean
@@ -16,12 +16,15 @@ corresponding power of the original adjoint transfer map.
 
 An irreducible quantum channel has cyclic projections as in Wolf Chapter 6, and
 periodic MPS blocks have the off-diagonal form and period-blocking behavior of
-arXiv:1708.00029.  The relevant identities are
+arXiv:1708.00029.  In the cyclic order used there, the relevant identities are
 $$
-  \mathcal E_A^*(P_{u+1}) = P_u,\qquad
+  \mathcal E_A^*(P_u) = P_{u+1},\qquad
   A^i = \sum_u P_u A^i P_{u+1},\qquad
   C_u = P_u A^{[m]} P_u.
 $$
+Reversing the cyclic order gives the equivalent convention
+$\mathcal E_A^*(P_{u+1}) = P_u$, which is the indexing used by the cyclic
+iteration lemmas below.
 
 ## References
 


### PR DESCRIPTION
### Motivation
- The cyclic-sector files should point to the actual source used by #1288/#1289: Wolf Chapter 6 for cyclic projections and arXiv:1708.00029 for periodic-block decomposition.
- The previous module references made this surface look tied to 1606.00608/2011, which obscured the boundary between the one-block theorem and finite-family comparison data.

### Description
- Replaced the cyclic-sector relation/decomposition module references with Wolf Chapter 6 and arXiv:1708.00029.
- Added the formulas `E_A^*(P_{u+1}) = P_u`, `A^i = sum_u P_u A^i P_{u+1}`, and `C_u = P_u A^[m] P_u` to the Lean module documentation.
- Clarified that `CommonBlockedCyclicSectorFamily` starts after the one-block decomposition and records a shared blocking length for comparing finitely many sector families.

### Testing
- `git diff --check`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "\b(sorry|axiom|admit|native_decide|unsafeCast)\b" TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean TNLean/MPS/CanonicalForm/Assembly/CyclicSectorDecomposition.lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean || true`

---
Addresses #1288
Addresses #1289

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes: updates module-level references and adds clarifying formulas/conventions without touching proofs or definitions, so behavioral risk is minimal.
> 
> **Overview**
> Clarifies the module documentation around cyclic-sector decomposition/relations and multi-block comparison.
> 
> Updates the cited sources to **Wolf Ch. 6** (cyclic projections) and **arXiv:1708.00029** (periodic-block decomposition), and adds the key cyclic identities plus an explicit note about the *reversed cyclic indexing convention* used by the iteration lemmas. Also refines `CommonBlockedCyclicSectorFamily`’s docstring to emphasize it starts after the one-block decomposition and records a *shared* blocking length for comparing finitely many sector families.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31e9d039f44bacedc0cfebe1ae622a0cddf9ba6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->