### PR TITLE
doc(blueprint): clarify zero-tail and Burnside bridge provenance

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3314,7 +3314,7 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\leanok
 	\uses{def:blocked_tensor, def:zero_mps_tensor, def:tensor_from_blocks}
 	Each of two tensors admits some blocking after which it decomposes
-	independently into an all-zero tensor, carrying the zero-block bond dimension
+	independently into an all-zero tensor of the zero-tail bond dimension
 	defined in Section~\ref{sec:zero_block_separation}, plus
 	left-canonical blocks with
 	primitive transfer maps, nonzero scalar weights, and positive bond
@@ -3381,8 +3381,8 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\leanok
 	\uses{def:same_mpv2, def:zero_mps_tensor, def:tensor_from_blocks}
 	Suppose two tensors have the same MPV family and each is expressed as an
-	all-zero tensor, carrying the separated zero-block bond dimension, plus a
-	weighted nonzero-block
+	all-zero tensor of the zero-tail bond dimension from
+	Section~\ref{sec:zero_block_separation}, plus a weighted nonzero-block
 	tensor. Then the two nonzero-block tensors agree on every positive system
 	size, and at size $0$ the equality is exactly the equality of the two
 	all-zero-block contributions plus the two nonzero
@@ -3440,7 +3440,7 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\leanok
 	\uses{thm:tp_primitive_blockdecomp, def:same_mpv2, def:zero_mps_tensor}
 	If two tensors generate the same MPV family, then each tensor admits a blocked
-	decomposition into an all-zero tensor, carrying the zero-block bond dimension,
+	decomposition into an all-zero tensor of the zero-tail bond dimension,
 	plus nonzero left-canonical blocks
 	with primitive transfer maps and positive bond dimensions. The theorem also
 	retains, for each blocking period, the relation that the blocked tensors

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -384,11 +384,11 @@ The irreducibility condition (Definition~\ref{def:irreducible_tensor}) is formul
 in terms of invariant \emph{projections}.
 For Burnside-style arguments it is more natural to work with invariant
 \emph{subspaces} of $\C^D$ under the Kraus operators.
-The canonical-form papers provide the invariant-subspace reduction: repeated
-removal of invariant subspaces leaves blocks with no nontrivial invariant
-subspace.  The next step used here is a separate finite-dimensional algebra
-input: over $\C$, an irreducible matrix action generates the full
-endomorphism algebra.
+The canonical-form reduction of \cite[Section~2.3]{Cirac2016MPDO_arXiv}
+provides the invariant-subspace reduction: repeated removal of invariant
+subspaces leaves blocks with no nontrivial invariant subspace.  The next step
+used here is a separate finite-dimensional algebra input: over $\C$, an
+irreducible matrix action generates the full endomorphism algebra.
 
 \begin{definition}[Algebra span]\label{def:alg_span}
 	\lean{MPSTensor.algSpan}\leanok
@@ -443,6 +443,9 @@ endomorphism algebra.
 	\]
 	This is the complex finite-dimensional case of Burnside's theorem
 	(equivalently, Jacobson's density theorem); see~\cite{Jacobson2009BasicAlgebraII}.
+	It is not a step stated in \cite[Section~2.3]{Cirac2016MPDO_arXiv}; it is the
+	external algebraic input that turns irreducible action into full algebra
+	spanning.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -458,9 +461,9 @@ endomorphism algebra.
 
 \begin{remark}\leanok
 	This Burnside--Jacobson density step is a substantial external algebraic
-	ingredient in the chapter.  The cited MPS arguments provide the
+	ingredient in the chapter.  The source MPS argument provides the
 	invariant-subspace decomposition and the later blocking-to-injectivity
-	results; they do not name Burnside as a separate theorem at this point.
+	results; it does not name Burnside as a separate theorem at this point.
 	The formal algebraic input used here is precisely
 	\[
 		\text{irreducible action on }\C^D
@@ -999,12 +1002,12 @@ In the irreducible block decomposition, some blocks may have all-zero
 Kraus operators. Such blocks contribute to the MPV only at word length
 $N = 0$ (where their contribution equals their bond dimension).
 The following results separate the zero blocks from the nonzero blocks.
-Following arXiv:1606.00608, equation~(8), this is the case
-$\sum_k D_k \le D$, where ``there can be zero blocks''.  In this
-case the \emph{zero-tail bond dimension} is the total bond
-dimension of these all-zero leftover blocks.  It is not an additional
-source-paper structure; it is a name for the all-zero summand
-$\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
+In the block decomposition of \cite[Section~2.3]{Cirac2016MPDO_arXiv},
+the allowance $\sum_k D_k \le D$ is explained by the statement that
+``there can be zero blocks''.  In this chapter the \emph{zero-tail bond
+dimension} is the total bond dimension of these all-zero leftover blocks.
+It is not an additional structure in the cited source; it is a name for the all-zero
+summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 
 \begin{definition}[Zero MPS tensor]\label{def:zero_mps_tensor}
 	\lean{MPSTensor.zeroMPSTensor}
@@ -1039,7 +1042,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	Every MPS tensor $A$ admits a block decomposition into:
 	\begin{enumerate}
 		\item a \emph{trivial block} of bond dimension $D_0$ with all Kraus operators zero
-		      (accumulating all all-zero irreducible blocks), and
+		      (accumulating all irreducible all-zero blocks), and
 		\item a finite family of \emph{nontrivial blocks} $(B_k)_{k=1}^r$,
 		      each irreducible, each with at least one nonzero Kraus
 		      operator, and each with positive bond dimension,
@@ -1052,7 +1055,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\]
 	for every spin configuration $\sigma$ of length $N$.
 	At $N = 0$ this reads $D = D_0 + \sum_{k=1}^r D_k$.
-	For $N \ge 1$ this all-zero, zero-tail term vanishes.
+	For $N \ge 1$ this all-zero-block term vanishes.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2672,7 +2675,8 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\leanok
 	\uses{def:blocked_tensor, def:zero_mps_tensor}
 	For any MPS tensor $A$, there exist a period $p \ge 1$,
-	a zero-tail bond dimension $D_0$, nonzero weights $(\mu_k)_{k=1}^r$,
+	a zero-tail bond dimension $D_0$ for the separated all-zero blocks,
+	nonzero weights $(\mu_k)_{k=1}^r$,
 	and left-canonical blocks $(B_k)_{k=1}^r$ with primitive transfer
 	maps and positive bond dimensions, such that
 	\[
@@ -2691,7 +2695,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	blocking period $p$ making all transfer maps primitive. Lemma~\ref{lem:block_weights_ne_zero}
 	keeps the blocked weights nonzero, and
 	Theorem~\ref{thm:zero_tail_to_tensor_from_blocks_block_power} transports the
-	zero-tail/nonzero MPV identity through the blocking step.
+	all-zero-block/nonzero MPV identity through the blocking step.
 \end{proof}
 
 \begin{theorem}[TP-primitive irreducible tensor is normal]%
@@ -3310,11 +3314,12 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\leanok
 	\uses{def:blocked_tensor, def:zero_mps_tensor, def:tensor_from_blocks}
 	Each of two tensors admits some blocking after which it decomposes
-	independently into an all-zero tensor of zero-tail bond dimension plus
+	independently into an all-zero tensor, carrying the zero-block bond dimension
+	defined in Section~\ref{sec:zero_block_separation}, plus
 	left-canonical blocks with
 	primitive transfer maps, nonzero scalar weights, and positive bond
 	dimensions. Moreover, at every blocked system size and every blocked word,
-	the MPV of the blocked tensor is the sum of the zero-tail MPV and the MPV of
+	the MPV of the blocked tensor is the sum of this all-zero-block MPV and the MPV of
 	the weighted nonzero-block tensor:
 	\[
 		V^{(N)}(A^{[p_A]})_\sigma
@@ -3337,15 +3342,17 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\lean{MPSTensor.zeroTail_mpv_decomp_blockTensor}
 	\leanok
 	\uses{def:blocked_tensor, def:zero_mps_tensor}
-	Suppose $A$ is expressed as an all-zero tensor of zero-tail bond dimension
-	plus a nonzero part $L$ at all system sizes. For every positive blocking length $p$, the blocked tensor
-	$A^{[p]}$ is expressed as the same zero-tail bond dimension plus $L^{[p]}$.
+	Suppose $A$ is expressed as an all-zero tensor, carrying the zero-block bond
+	dimension from Section~\ref{sec:zero_block_separation}, plus a nonzero part
+	$L$ at all system sizes. For every positive blocking length $p$, the blocked
+	tensor $A^{[p]}$ is expressed as the same all-zero-block contribution plus
+	$L^{[p]}$.
 	The all-zero term still contributes only at blocked length $0$.
 \end{theorem}
 
 \begin{proof}\leanok
 	Flatten a blocked word of length $N$ to an original word of length $Np$. Since
-	$p>0$, this length is zero exactly when $N=0$, so the zero-tail MPV is
+	$p>0$, this length is zero exactly when $N=0$, so the all-zero-block MPV is
 	unchanged by the reblocking convention.
 \end{proof}
 
@@ -3355,9 +3362,10 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\leanok
 	\uses{thm:zero_tail_decomp_block_tensor, thm:block_tensor_to_tensor_from_blocks,
 	      def:tensor_from_blocks}
-	Suppose $A$ is expressed as an all-zero tensor of zero-tail bond dimension plus the weighted nonzero-block
+	Suppose $A$ is expressed as an all-zero tensor, carrying the zero-block bond
+	dimension, plus the weighted nonzero-block
 	tensor $\bigoplus_k \mu_k B_k$. For every positive blocking length $p$,
-	$A^{[p]}$ is expressed as the same zero-tail contribution plus the weighted
+	$A^{[p]}$ is expressed as the same all-zero-block contribution plus the weighted
 	blocked nonzero tensor $\bigoplus_k \mu_k^p B_k^{[p]}$.
 \end{theorem}
 
@@ -3373,10 +3381,11 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\leanok
 	\uses{def:same_mpv2, def:zero_mps_tensor, def:tensor_from_blocks}
 	Suppose two tensors have the same MPV family and each is expressed as an
-	all-zero tensor of zero-tail bond dimension plus a weighted nonzero-block
+	all-zero tensor, carrying the separated zero-block bond dimension, plus a
+	weighted nonzero-block
 	tensor. Then the two nonzero-block tensors agree on every positive system
-	size, and at size $0$ the equality is
-	exactly the equality of the two zero-tail contributions plus the two nonzero
+	size, and at size $0$ the equality is exactly the equality of the two
+	all-zero-block contributions plus the two nonzero
 	bond-dimension traces.
 \end{theorem}
 
@@ -3384,7 +3393,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\uses{def:zero_mps_tensor}
 	For $N>0$, the MPV of the all-zero tensor is zero, so the two decompositions
 	can be compared directly through the common MPV family. For $N=0$, the
-	zero-tail MPV is its bond dimension, giving the stated length-zero identity.
+	all-zero-block MPV is its bond dimension, giving the stated length-zero identity.
 \end{proof}
 
 \begin{theorem}[Blocked nonzero parts and length zero]%
@@ -3396,13 +3405,13 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	In the setting of Theorem~\ref{thm:nonzero_block_zero_tail_identity}, after
 	any positive common blocking length $p$, the powered weighted nonzero-block tensors
 	agree on all positive blocked system sizes. At blocked length $0$, the same
-	zero-tail identity holds with weights transported from $\mu_k$ to
+	length-zero identity holds with weights transported from $\mu_k$ to
 	$\mu_k^p$.
 \end{theorem}
 
 \begin{proof}\leanok
 	Use Theorem~\ref{thm:zero_tail_to_tensor_from_blocks_block_power} on both
-	zero-tail decompositions, block the original MPV equality, and apply
+	all-zero-block decompositions, block the original MPV equality, and apply
 	Theorem~\ref{thm:nonzero_block_zero_tail_identity} at the blocked physical
 	dimension.
 \end{proof}
@@ -3413,7 +3422,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\leanok
 	\uses{thm:nonzero_block_zero_tail_identity}
 	In the setting of Theorem~\ref{thm:nonzero_block_zero_tail_identity}, if
-	the two zero-tail dimensions are equal, then the two nonzero-block tensors have
+	the two leftover zero-block dimensions are equal, then the two nonzero-block tensors have
 	the same MPV family, including the length-zero case.
 \end{theorem}
 
@@ -3421,7 +3430,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\uses{thm:nonzero_block_zero_tail_identity}
 	The positive-length cases are exactly the first conclusion of
 	Theorem~\ref{thm:nonzero_block_zero_tail_identity}. At $N=0$, substitute
-	the equality of zero-tail dimensions into the length-zero identity and cancel
+	the equality of leftover zero-block dimensions into the length-zero identity and cancel
 	the common scalar term.
 \end{proof}
 
@@ -3431,7 +3440,8 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\leanok
 	\uses{thm:tp_primitive_blockdecomp, def:same_mpv2, def:zero_mps_tensor}
 	If two tensors generate the same MPV family, then each tensor admits a blocked
-	decomposition into a zero-tail tensor plus nonzero left-canonical blocks
+	decomposition into an all-zero tensor, carrying the zero-block bond dimension,
+	plus nonzero left-canonical blocks
 	with primitive transfer maps and positive bond dimensions. The theorem also
 	retains, for each blocking period, the relation that the blocked tensors
 	generate the same MPV family.
@@ -3440,7 +3450,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 \begin{proof}\leanok
 	\uses{thm:tp_primitive_blockdecomp}
 	Apply Theorem~\ref{thm:tp_primitive_blockdecomp} separately to the two
-	tensors and keep the zero-tail MPV equations returned by that theorem. The
+	tensors and keep the length-zero all-zero-block equations returned by that theorem. The
 	property that the blocked tensors generate the same MPV family follows by
 	blocking the original equality.
 \end{proof}
@@ -3455,7 +3465,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	If two tensors generate the same MPV family, then after all-zero-block separation and
 	trace-preserving gauge each side has irreducible nonzero-weight blocks.
 	The nonzero-block tensors agree at all positive system sizes, while the
-	length-zero case is included as the exact zero-tail identity.
+	length-zero case is included as the exact all-zero-block identity.
 	Moreover each nonzero-weight block has primitive irreducible cyclic sectors. The
 	period-removal length for those sectors is kept separate from any later common
 	blocking or injectivity length.
@@ -3478,13 +3488,13 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
 		thm:exists_common_blocked_cyclic_sector_family,
 		thm:common_blocked_cyclic_sector_flat_weight_ne_zero}
-	If two tensors generate the same MPV family, then the zero-tail/TP-gauge
+	If two tensors generate the same MPV family, then the all-zero-block/TP-gauge
 	reduction for nonzero-weight blocks can be combined with a common reblocking
 	of all per-block cyclic sectors.  Each side obtains a finite flattened sector family
 	at one physical blocking length, with trace preservation, primitive transfer
 	maps, tensor irreducibility, positive bond dimensions, and nonzero unit
 	weights.  The theorem keeps the positive-length equality of the nonzero parts and the exact
-	$N=0$ zero-tail identity for the original nonzero-block tensors.
+	$N=0$ all-zero-block identity for the original nonzero-block tensors.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3499,7 +3509,7 @@ $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 
 The next results put the cyclic-sector decompositions on a common blocked
 alphabet.  They compare direct blocking with iterated cyclic-sector blocking and
-transport the zero-tail identity through this comparison.
+transport the all-zero-block identity through this comparison.
 
 \begin{theorem}[Common cyclic sectors after reblocking]%
 \label{thm:ft_after_blocking_reindexed_common_sector_live_zero_tail}
@@ -3512,7 +3522,7 @@ transport the zero-tail identity through this comparison.
 	If two tensors generate the same MPV family, then after reblocking the nonzero
 	blocks one obtains cyclic-sector families over a common alphabet.  These
 	families preserve the MPV of the reblocked nonzero part, with nonzero
-	transported weights $\mu_k^p$, and retain the zero-tail identity.
+	transported weights $\mu_k^p$, and retain the all-zero-block identity.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3521,7 +3531,7 @@ transport the zero-tail identity through this comparison.
 		thm:common_blocked_cyclic_sector_reindexed_samempv,
 		thm:common_blocked_cyclic_sector_derived_properties}
 	Start from the common reblocked cyclic-sector families on the two sides.  Apply
-	the zero-tail reblocking theorem to the original nonzero-block decomposition, then
+	the all-zero-block reblocking theorem to the original nonzero-block decomposition, then
 		use the common-alphabet sector decomposition and the derived structural
 	properties of the common-sector family.
 \end{proof}
@@ -3539,7 +3549,7 @@ transport the zero-tail identity through this comparison.
 	If two tensors generate the same MPV family, then the cyclic-sector
 	decompositions on the two sides can be expressed at one common positive
 	blocking length.  At this length the nonzero parts still agree at positive
-	system sizes, and the length-zero identity is exactly the zero-tail identity.
+	system sizes, and the length-zero identity is exactly the all-zero-block identity.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3552,7 +3562,7 @@ transport the zero-tail identity through this comparison.
 	Start from the per-block cyclic-sector theorem.  Let $p_A$ and $p_B$ be the
 	least common multiples of the period-removal lengths on the two sides, and
 	use $p=\mathrm{lcm}(p_A,p_B)$.  The prescribed-common-multiple theorem constructs both
-	one-sided sector families at this same length.  The zero-tail and positive-
+	one-sided sector families at this same length.  The all-zero-block and positive-
 	length equalities are the existing reblocking statements, and the sector
 	conclusions are the common-alphabet MPV equalities.
 \end{proof}
@@ -3568,9 +3578,9 @@ transport the zero-tail identity through this comparison.
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:common_blocked_cyclic_sector_blocked_word_comparison,
 		def:same_mpv2_pos}
-	Assume a zero-tail/nonzero decomposition on one side.  If direct blocking of
+	Assume an all-zero-block/nonzero decomposition on one side.  If direct blocking of
 	each nonzero block agrees with the corresponding iterated cyclic-sector
-	blocking, then the zero-tail identity can be rewritten using the common
+	blocking, then the all-zero-block identity can be rewritten using the common
 	cyclic-sector family.  The coordinate-grouping condition supplies this
 	agreement at any prescribed common blocking length.
 \end{theorem}
@@ -3579,7 +3589,7 @@ transport the zero-tail identity through this comparison.
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:common_blocked_cyclic_sector_blocked_word_comparison,
 		def:same_mpv2_pos}
-	Transport the zero-tail/nonzero decomposition to the common blocking length.
+	Transport the all-zero-block/nonzero decomposition to the common blocking length.
 	The blockwise comparison then replaces the directly blocked nonzero part by the
 	weighted common-sector tensor.
 \end{proof}
@@ -3592,9 +3602,9 @@ transport the zero-tail identity through this comparison.
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
-	Assume a zero-tail/nonzero decomposition on one side.  If the blocked nonzero
+	Assume an all-zero-block/nonzero decomposition on one side.  If the blocked nonzero
 	tensor agrees, after identifying blocked words, with the common cyclic-sector
-	family, then the same zero-tail identity can be written in that common
+	family, then the same all-zero-block identity can be written in that common
 	alphabet.  At positive system sizes this says that the blocked tensor and the
 	weighted common-sector tensor have the same MPV coefficients.
 \end{theorem}
@@ -3602,9 +3612,9 @@ transport the zero-tail identity through this comparison.
 \begin{proof}\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
-	Transport the zero-tail/nonzero decomposition to the common blocking length.
+	Transport the all-zero-block/nonzero decomposition to the common blocking length.
 	The word-identification hypothesis then replaces the blocked nonzero tensor by the
-	weighted common-sector tensor.  At positive lengths the zero-tail tensor has
+	weighted common-sector tensor.  At positive lengths the all-zero tensor has
 	zero MPV coefficients.
 \end{proof}
 
@@ -3628,7 +3638,7 @@ transport the zero-tail identity through this comparison.
 	Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}
 	to choose the common blocking length and the two common cyclic-sector families.
 	The assumed word identification converts the blocked nonzero part into the weighted
-	common-sector family on each side.  The zero-tail equations then give the
+	common-sector family on each side.  The all-zero-block equations then give the
 	displayed decompositions.  The structural properties and nonzero weights come
 	from the common-sector families.
 \end{proof}
@@ -3639,10 +3649,10 @@ transport the zero-tail identity through this comparison.
 	\leanok
 	\uses{def:same_mpv2, def:same_mpv2_pos}
 	Let $L_A,L_B$ be two nonzero parts whose MPV families agree at positive
-	lengths and whose zero-tail dimensions satisfy the length-zero identity.  If
+	lengths and whose leftover zero-block dimensions satisfy the length-zero identity.  If
 	$L_A'$ and $L_B'$ generate the same MPV families as $L_A$ and $L_B$, respectively,
 	then $L_A'$ and $L_B'$ satisfy the same positive-length equality and the same
-	length-zero zero-tail identity.
+	length-zero all-zero-block identity.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -3659,7 +3669,7 @@ transport the zero-tail identity through this comparison.
 		thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
 		thm:common_blocked_cyclic_sector_derived_properties}
 	If the blocked nonzero part agrees with the common-sector tensor,
-	then the zero-tail identity can be written with that common-sector tensor.
+	then the all-zero-block identity can be written with that common-sector tensor.
 	Nonzero original weights remain nonzero after the blocking power.
 \end{theorem}
 
@@ -3679,9 +3689,9 @@ transport the zero-tail identity through this comparison.
 		thm:common_blocked_cyclic_sector_blocked_word_comparison,
 		thm:common_blocked_cyclic_sector_derived_properties,
 		def:same_mpv2}
-	Assume a zero-tail/nonzero decomposition with nonzero weights.  If the common
+	Assume an all-zero-block/nonzero decomposition with nonzero weights.  If the common
 	blocked alphabet is identified with each iterated alphabet by grouping
-	consecutive words, then the zero-tail identity can be written with the
+	consecutive words, then the all-zero-block identity can be written with the
 	weighted common-sector family.
 \end{theorem}
 
@@ -3691,7 +3701,7 @@ transport the zero-tail identity through this comparison.
 		thm:common_blocked_cyclic_sector_derived_properties,
 		def:same_mpv2}
 	The coordinate-grouping comparison identifies the directly blocked nonzero part
-	with the weighted common-sector family.  Combine this with the zero-tail
+	with the weighted common-sector family.  Combine this with the all-zero-block
 	identity and the nonzero-weight statement.
 \end{proof}
 
@@ -3703,7 +3713,7 @@ transport the zero-tail identity through this comparison.
 		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	If two tensors generate the same MPV family, choose a common blocking length
 	for their cyclic-sector decompositions.  If each blocked nonzero part agrees
-	with its common-sector form after identifying words, then all zero-tail
+	with its common-sector form after identifying words, then all length-zero
 	identities and positive-length MPV equalities can be stated using the common
 	sector families.
 \end{theorem}
@@ -3714,7 +3724,7 @@ transport the zero-tail identity through this comparison.
 	Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}.
 	The two word-identification hypotheses identify the blocked nonzero parts with the
 	weighted common-sector tensors.  Substituting these MPV equalities into the
-	zero-tail equations gives the rewritten zero-tail identities, the
+	all-zero-block equations gives the rewritten all-zero-block identities, the
 	positive-length MPV equalities, and the $N=0$ identity.
 \end{proof}
 
@@ -3738,15 +3748,15 @@ transport the zero-tail identity through this comparison.
 	\cite[Proposition~IV.4 and Corollary~IV.5]{Cirac2021Matrix}.
 
 	The statements in this chapter follow this reduction.  Theorem~\ref{thm:tp_gauge_arbitrary}
-	gives the zero-tail block and the trace-preserving irreducible nonzero block
+	gives the all-zero block and the trace-preserving irreducible nonzero block
 	family.  Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
 	applies the cyclic-sector decomposition to each nonzero block, preserving the
-	positive-length MPV equality and the zero-tail identity at $N=0$.
+	positive-length MPV equality and the all-zero-block identity at $N=0$.
 	Theorem~\ref{thm:exists_common_blocked_cyclic_sector_family_common_multiple}
 	constructs the common reblocked sector family at any common multiple of the
 	period-removal lengths.  Consequently
 	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} chooses
-	one physical blocking length for both tensors, transports the zero-tail
+	one physical blocking length for both tensors, transports the all-zero-block
 	identities to that length, and supplies cyclic-sector families on a common
 	blocked alphabet.  The supporting blocking and transport results, including
 	Theorem~\ref{thm:iterated_blocking_samempv_reindex}, identify iterated blocking
@@ -3759,7 +3769,7 @@ transport the zero-tail identity through this comparison.
 	alphabet equals the word obtained by flattening an iterated $(m_k,e_k)$ block,
 	the weighted direct sum of directly blocked nonzero blocks agrees with the
 	common-sector family.  Theorem~\ref{thm:zero_tail_common_flat_of_blocked_word_comparison}
-	then rewrites the one-sided zero-tail identity with the weighted common-length
+	then rewrites the one-sided all-zero-block identity with the weighted common-length
 	cyclic sectors under this blockwise word equality.
 
 	The remaining blocked-word equality, after identifying blocked physical
@@ -3784,11 +3794,11 @@ transport the zero-tail identity through this comparison.
 	common MPV phase cover or proportional-decomposition conclusion supplies the
 	finite-length nonzero-block span equality.
 	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
-	states the exact inputs after this point: equality of the zero-tail
+	states the exact inputs after this point: equality of the leftover zero-block
 	dimensions, injectivity at the chosen common length, and a common MPV phase cover
 	(or the equivalent finite-length span equality) for the two nonzero-sector
 	families.  Thus the canonical-form assertions are the blocked-word
-	identification for the whole weighted nonzero family, the zero-tail and
+	identification for the whole weighted nonzero family, the all-zero-block and
 	injectivity refinements, and the common-phase or proportional-decomposition
 	comparison for the common-length nonzero sectors.
 


### PR DESCRIPTION
### Motivation
- Blueprint Chapter 8 uses `zero-tail bond dimension` without a first-use definition, making it unclear whether the term denotes a source-paper object or a formalization-only package; see #1290.
- The Burnside–Jacobson full-algebra-spanning step in the canonical-form chapter could be misread as part of the 1606.00608 canonical-form reduction, when it is in fact an external algebraic bridge not present in that paper; see #1301.
- Part of the source-faithfulness cleanup tracked by #1282, under #1170.

### Description
- `blueprint/src/chapter/ch08_canonical.tex`: defines `zero-tail bond dimension` at first use as the total bond dimension of the separated all-zero blocks, aligned with the zero-block allowance in \cite[Section 2.3]{Cirac2016MPDO_arXiv}.
- Rewrites later after-blocking prose to say "all-zero-block" or "length-zero identity" in place of the unexplained `zero-tail` shorthand.
- Adds explicit language that the Burnside–Jacobson "irreducible action implies full matrix algebra" step is an external algebraic input and is not a step stated in the 1606.00608 canonical-form reduction.
- No Lean declarations changed.

### Testing
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- Relies on Lean CI (`lean_action_ci.yml`) for build validation (no `.lean` files changed).

---
Addresses #1290
Addresses #1301

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX prose edits that clarify terminology and citations; no Lean declarations or mathematical statements are changed, so risk is limited to wording/reader interpretation.
>
> **Overview**
> Clarifies Chapter 8's prose to be more source-faithful about what comes from the cited canonical-form reductions versus what is additional input.
>
> Specifically, it (1) attributes the invariant-subspace reduction to
> `\cite[Section~2.3]{Cirac2016MPDO_arXiv}` and explicitly labels the Burnside/Jacobson "irreducible action ⇒ full matrix algebra" step as *external algebraic input*, and (2) defines `zero-tail bond dimension` at first use as the total bond dimension of separated all-zero blocks, then consistently rewrites later after-blocking statements to refer to the *all-zero-block / length-zero identity* rather than unexplained "zero-tail" terminology.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6feef67fffda33b4ffd1fbdc916d94a9e4c99f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only LaTeX edits that refine terminology and citations without changing Lean declarations or formal statements; main risk is unintended wording/citation ambiguity.
> 
> **Overview**
> Clarifies Chapter 8’s source provenance by explicitly attributing the invariant-subspace reduction to `\cite[Section~2.3]{Cirac2016MPDO_arXiv}` and marking the Burnside/Jacobson step (`irreducible action ⇒ \algspn(A)=\MN{D}`) as an **external algebraic input** not stated in that reduction.
> 
> Defines *zero-tail bond dimension* at first use as the total bond dimension of the separated all-zero blocks, and consistently rewrites later after-blocking prose to refer to the *all-zero-block / length-zero identity* (instead of the previously unexplained “zero-tail” shorthand).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 374c07eaec545b745c08b5c43774b41ab738fb64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->