### PR TITLE
style(Wielandt): demote cumulative analysis lemma

### DIFF
--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -137,8 +137,7 @@ Given `IsNormal A`, the cumulative part of the Wielandt argument provides:
 3. A nonzero eigenvalue μ and eigenvector φ for evalWord A w₀
 4. Vector spanning: for any nonzero φ, word products applied to φ span ℂ^D
 
-This is the same cumulative consequence expressed at the primitivity-normality
-interface. -/
+This restates `wielandt_chain` in the normality setting. -/
 lemma wielandt_full_analysis [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     cumulativeSpan A (D ^ 2) = ⊤ ∧

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -137,7 +137,8 @@ Given `IsNormal A`, the cumulative part of the Wielandt argument provides:
 3. A nonzero eigenvalue μ and eigenvector φ for evalWord A w₀
 4. Vector spanning: for any nonzero φ, word products applied to φ span ℂ^D
 
-This restates `wielandt_chain` from `WielandtBound.lean` under a shorter name. -/
+This is the same cumulative consequence expressed at the primitivity-normality
+interface. -/
 lemma wielandt_full_analysis [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     cumulativeSpan A (D ^ 2) = ⊤ ∧

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -32,7 +32,7 @@ positivity witnesses still require the separate aperiodicity input.
 
 ### From normality
 
-* `wielandt_full_analysis`: collects the four standard Wielandt-chain outputs
+* `wielandt_full_analysis`: collects the four cumulative consequences of normality
 
 ## References
 
@@ -127,18 +127,18 @@ theorem transferMap_pow_ne_zero_of_hasPrimitiveFixedPoint [NeZero D]
   rcases hP with ⟨ρ, hρ⟩
   exact transferMap_pow_ne_zero_of_isPrimitiveMPS hρ n
 
-/-! ## Part 3: Recall the Wielandt chain from normality -/
+/-! ## Part 3: Recall cumulative consequences of normality -/
 
-/-- **The complete Wielandt analysis from normality.**
+/-- Cumulative Wielandt analysis data from normality.
 
-Given `IsNormal A`, the full Wielandt chain provides:
+Given `IsNormal A`, the cumulative part of the Wielandt argument provides:
 1. Cumulative span T_{D²} = ⊤ (all matrices reachable)
 2. A word w₀ with |w₀| ≤ D² and tr(evalWord A w₀) ≠ 0
 3. A nonzero eigenvalue μ and eigenvector φ for evalWord A w₀
 4. Vector spanning: for any nonzero φ, word products applied to φ span ℂ^D
 
-This states `wielandt_chain` from `WielandtBound.lean` under a cleaner name. -/
-theorem wielandt_full_analysis [NeZero D]
+This restates `wielandt_chain` from `WielandtBound.lean` under a shorter name. -/
+lemma wielandt_full_analysis [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     cumulativeSpan A (D ^ 2) = ⊤ ∧
     (∃ (w₀ : List (Fin d)),

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -190,11 +190,15 @@ theorem isNormal_implies_cumulativeSpan [NeZero D]
     cumulativeSpan A (D ^ 2) = ⊤ :=
   cumulativeSpan_eq_top A hN
 
-/-! ## Part 4: The complete Wielandt analysis chain
+/-! ## Part 4: Cumulative Wielandt analysis bundle
 
-Here we document the full chain of results. -/
+The paper states the pieces below as Lemma 1, eigenvector extraction in the proof
+of Theorem 1, and Lemma 2(a).  The bundled statement is a collected
+lemma, not an additional paper theorem. -/
 
-/-- **The full Wielandt chain**: Given `IsNormal A`:
+/-- Cumulative Wielandt analysis bundle.
+
+Given `IsNormal A`:
 1. Cumulative span reaches ⊤ at level D²
 2. There exists a word of length ≤ D² with nonzero trace
 3. This word product has a nonzero eigenvalue μ and eigenvector φ
@@ -202,8 +206,8 @@ Here we document the full chain of results. -/
 5. (Needs Lemma 2(b)) All matrices are reachable using word products of
    a single fixed length ≤ D⁴
 
-This theorem covers steps 1-4. -/
-theorem wielandt_chain [NeZero D]
+This lemma packages steps 1-4 for later arguments. -/
+lemma wielandt_chain [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     -- Step 1: Cumulative span = ⊤
     cumulativeSpan A (D ^ 2) = ⊤ ∧

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -190,13 +190,13 @@ theorem isNormal_implies_cumulativeSpan [NeZero D]
     cumulativeSpan A (D ^ 2) = ⊤ :=
   cumulativeSpan_eq_top A hN
 
-/-! ## Part 4: Cumulative Wielandt analysis bundle
+/-! ## Part 4: Cumulative Wielandt analysis
 
 The paper states the pieces below as Lemma 1, eigenvector extraction in the proof
-of Theorem 1, and Lemma 2(a).  The bundled statement is a collected
-lemma, not an additional paper theorem. -/
+of Theorem 1, and Lemma 2(a).  The following lemma collects these cumulative
+consequences; it is not an additional paper theorem. -/
 
-/-- Cumulative Wielandt analysis bundle.
+/-- Cumulative Wielandt analysis consequences.
 
 Given `IsNormal A`:
 1. Cumulative span reaches ⊤ at level D²
@@ -206,7 +206,7 @@ Given `IsNormal A`:
 5. (Needs Lemma 2(b)) All matrices are reachable using word products of
    a single fixed length ≤ D⁴
 
-This lemma packages steps 1-4 for later arguments. -/
+The conclusion is the conjunction of steps 1-4. -/
 lemma wielandt_chain [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     -- Step 1: Cumulative span = ⊤

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -429,13 +429,13 @@ The results follow~\cite{Sanz2010Quantum}.
     Immediate from Theorem~\ref{thm:eigenvalue_extraction}.
 \end{proof}
 
-\begin{theorem}[Wielandt chain]\label{thm:wielandt_chain}
+\begin{lemma}[Cumulative Wielandt analysis]\label{lem:wielandt_chain}
     \lean{MPSTensor.wielandt_chain}
     \leanok
     \uses{def:wielandt_analysis, def:cumulative_vector_span, def:normal,
           def:cumulative_span}
     Let $A$ be a normal MPS tensor with bond dimension~$D \ge 1$.
-    Then the following hold simultaneously:
+    Then the following auxiliary consequences hold simultaneously:
     \begin{enumerate}
         \item $T_{D^2}(A) = \MN{D}$ (cumulative span stabilises);
         \item there exists a word $w_0$ with $|w_0| \le D^2$ and
@@ -445,7 +445,7 @@ The results follow~\cite{Sanz2010Quantum}.
         \item for every $\varphi \ne 0$,
               $K_{D^2}(A, \varphi) = \C^D$.
     \end{enumerate}
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
@@ -821,7 +821,7 @@ The results follow~\cite{Sanz2010Quantum}.
               $S_{D^2 \cdot n}(A) = \MN{D}$.
         \item If $A^w$ is non-invertible (non-invertible case),
               the eigenvector $\varphi$ spans a proper subspace,
-              and the Wielandt chain argument gives
+              and the rank-one extraction argument gives
               $S_{D^2}(B) = \MN{D}$, whence
               $S_{D^2 \cdot n}(A) = \MN{D}$.
         \end{enumerate}


### PR DESCRIPTION
### Motivation

- `wielandt_chain` (`TNLean/Wielandt/WielandtBound.lean`) is classified as a `theorem` but collects three auxiliary results from arXiv:0909.5347 (Lemma 1, eigenvector extraction from the proof of Theorem 1, and Lemma 2(a)) rather than stating an independent paper theorem; the `lemma` classification is more accurate.
- `wielandt_full_analysis` (`TNLean/Wielandt/Primitivity/Normal.lean`) restates the cumulative consequences of normality without adding a distinct mathematical claim, warranting the same demotion.
- The Chapter 7 blueprint entry and surrounding prose retained theorem-level phrasing inconsistent with the corrected Lean declarations (see #1282).

### Description

- `TNLean/Wielandt/WielandtBound.lean`: demote `wielandt_chain` from `theorem` to `lemma`; revise surrounding comments to reflect that the declaration collects Lemma 1, eigenvector extraction, and Lemma 2(a) from arXiv:0909.5347, not an additional paper theorem.
- `TNLean/Wielandt/Primitivity/Normal.lean`: demote `wielandt_full_analysis` from `theorem` to `lemma`; revise wording to describe the four cumulative consequences of normality rather than a standalone theorem statement.
- `blueprint/src/chapter/ch07_wielandt.tex`: update the Chapter 7 entry from theorem to lemma; replace remaining "Wielandt chain" prose in the fixed-length proof sketch with the paper's rank-one extraction language from arXiv:0909.5347.

### Testing

- `git diff --check`
- `lake env lean TNLean/Wielandt/WielandtBound.lean`
- `lake env lean TNLean/Wielandt/Primitivity/Normal.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`

---
Addresses #1282

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational changes: reclassifies `wielandt_chain`/`wielandt_full_analysis` as `lemma` and updates surrounding documentation/blueprint wording, with no changes to statements or proofs. Low risk aside from potential minor doc/reference mismatches in downstream writeups.
> 
> **Overview**
> Reclassifies the “cumulative Wielandt analysis” collectors as auxiliary results: `wielandt_chain` (in `WielandtBound.lean`) and its restatement `wielandt_full_analysis` (in `Primitivity/Normal.lean`) are changed from `theorem` to `lemma` and their docstrings are rewritten to emphasize they *collect cumulative consequences* (Lemma 1 + eigenvector extraction + Lemma 2(a)) rather than asserting a new paper theorem.
> 
> Updates the blueprint (`ch07_wielandt.tex`) to match: the corresponding entry is demoted from a theorem to a lemma, wording is adjusted (“auxiliary consequences”), and one proof-sketch sentence swaps “Wielandt chain argument” for “rank-one extraction argument” terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf119e55e5d3a5d953897aed90fc13f73dcb365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->