### PR TITLE
doc(MPS/FT): source-align sector multiplicities

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -16,10 +16,18 @@ sector decompositions over a common BNT basis.  Eventual coefficient equality is
 upgraded to equality of the sector-weight multisets by a geometric-sequence
 extrapolation and the Newton identities.
 
+In arXiv:1606.00608, Theorem IV.13 and its appendix proof use positive diagonal
+matrices whose traces enter the structure coefficients as power sums.  The
+geometric extrapolation and Newton--Girard steps below are the finite-sequence
+algebra needed to recover the weight lists from those power sums once the basis
+blocks have been matched.
+
 ## References
 
 - [PGVWC07] Pérez-García, Verstraete, Wolf, Cirac, *Matrix Product State Representations*,
   Quantum Inf. Comput. 7 (2007), arXiv:quant-ph/0608197.
+- [CPSV17] Cirac, Pérez-García, Schuch, Verstraete, *Fundamental Theorems for PEPS*,
+  arXiv:1606.00608 (2017).
 - [CPSV21] Cirac, Pérez-García, Schuch, Verstraete, *Matrix product states and projected
   entangled pair states: Concepts, symmetries, theorems*, Rev. Mod. Phys. 93 (2021),
   arXiv:2011.12127.
@@ -84,7 +92,7 @@ basis block. Uses `Fin.cast (hCopies j)` to align the two families over the same
 
 This is a direct application of Newton–Girard
 (`Matrix.sum_pow_eq_implies_multiset_eq`). -/
-theorem weight_multiset_eq_of_copies_eq_of_coeff_eq
+lemma weight_multiset_eq_of_copies_eq_of_coeff_eq
     (S T : SectorWeightData g)
     (hCopies : ∀ j, S.copies j = T.copies j)
     (hCoeff : ∀ (k : ℕ), 0 < k → ∀ j : Fin g,

--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -46,7 +46,7 @@ is eventually linearly independent (the BNT property), then the coefficient arra
 
 This is the key step converting MPV equality into the algebraic statement needed for
 Newton–Girard. -/
-theorem coeff_eventually_eq_of_sameMPV
+lemma coeff_eventually_eq_of_sameMPV
     {dim : Fin g → ℕ}
     (basis : (j : Fin g) → MPSTensor d (dim j))
     (S T : SectorWeightData g)
@@ -228,7 +228,7 @@ lemma power_sums_eq_of_eventually_eq
     (m := m) (n := m) a b ha hb (M := M) hEv
 
 /-- Eventual equality of coefficient power sums forces equality of multiplicities. -/
-theorem copies_eq_of_eventually_coeff_eq
+lemma copies_eq_of_eventually_coeff_eq
     (S T : SectorWeightData g)
     {N0 : ℕ}
     (hEv : ∀ N > N0, ∀ j : Fin g, S.coeff N j = T.coeff N j) :

--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -26,8 +26,8 @@ blocks have been matched.
 
 - [PGVWC07] Pérez-García, Verstraete, Wolf, Cirac, *Matrix Product State Representations*,
   Quantum Inf. Comput. 7 (2007), arXiv:quant-ph/0608197.
-- [CPSV17] Cirac, Pérez-García, Schuch, Verstraete, *Fundamental Theorems for PEPS*,
-  arXiv:1606.00608 (2017).
+- [CPSV16] Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2016).
 - [CPSV21] Cirac, Pérez-García, Schuch, Verstraete, *Matrix product states and projected
   entangled pair states: Concepts, symmetries, theorems*, Rev. Mod. Phys. 93 (2021),
   arXiv:2011.12127.

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -179,7 +179,7 @@ theorem mpv_toTensor_eq_sum_sectors (P : SectorDecomposition d) {N : ℕ}
 Decomposition formula: the MPV of the assembled tensor expands with coefficients
 `coeff N j = ∑_q (μ_{j,q})^N` against the basis MPVs.
 -/
-theorem mpv_toTensor_eq_sum_coeff (P : SectorDecomposition d) {N : ℕ}
+lemma mpv_toTensor_eq_sum_coeff (P : SectorDecomposition d) {N : ℕ}
     (σ : Fin N → Fin d) :
     mpv P.toTensor σ =
       ∑ j : Fin P.basisCount, P.coeff N j * mpv (P.basis j) σ := by

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -362,6 +362,25 @@ the power sum
 Thus BNT linear independence separates the coefficient arrays
 $c_{S,j}^{(N)}$, and elementary power-sum algebra recovers both the
 multiplicity $r_j$ and the multiset of weights attached to the basis block.
+In the source paper this information is not presented as a separate chain of
+MPS comparison theorems: Theorem~IV.13 of~\cite{Cirac2017MPDO_AnnPhys} uses
+structure coefficients
+\[
+	c_{\alpha,\beta,\gamma}^{(L)}
+	=\operatorname{tr}\!\left(\chi_{\alpha,\beta,\gamma}^L\right),
+	\qquad
+	m_\gamma=\sum_{\alpha,\beta}c_{\alpha,\beta,\gamma}^{(1)}
+		m_\alpha m_\beta,
+\]
+and the appendix writes the vertical canonical forms as
+$\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$ and
+$\bigoplus_\beta \nu_\beta\otimes A_\beta$, with
+$m_\alpha=\operatorname{tr}(\mu_\alpha)$ and
+$n_\beta=\operatorname{tr}(\nu_\beta)$.
+The one-index coefficients $c_{S,j}^{(N)}$ below are the corresponding
+power-sum comparison after the basis blocks have already been matched.  The
+geometric extrapolation and Newton--Girard steps are external finite-sequence
+facts used to recover the lists of weights from those power sums.
 
 \begin{definition}[Sector data and sector decomposition]%
 \label{def:paper_sector_data}
@@ -379,8 +398,8 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	$(A_j)_{j=1}^g$ together with their sector data.
 \end{definition}
 
-\begin{theorem}[Sector decomposition formula]%
-\label{thm:paper_decomp_formula}
+\begin{lemma}[Sector decomposition formula]%
+\label{lem:paper_decomp_formula}
 	\lean{MPSTensor.SectorDecomposition.mpv_toTensor_eq_sum_coeff}
 	\leanok
 	\uses{def:paper_sector_data}
@@ -390,7 +409,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 		V^{(N)}(A_{\mathrm{tot}})_\sigma
 		= \sum_{j=1}^{g} c_{S,j}^{(N)} V^{(N)}(A_j)_\sigma.
 	\]
-\end{theorem}
+\end{lemma}
 
 \begin{lemma}[Eventual coefficient comparison from BNT linear independence]%
 \label{lem:coeff_eventually_eq}
@@ -558,7 +577,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 
 \begin{proof}
 	\leanok
-	\uses{thm:paper_decomp_formula, thm:route_b_equal}
+	\uses{lem:paper_decomp_formula, thm:route_b_equal}
 	Absorb the factors $\zeta_j$ into the sector weights of $Q$ and keep the
 	basis blocks of $P$. The phase-matching hypothesis and the sector
 	decomposition formula show that the resulting decomposition has the same

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -372,12 +372,15 @@ structure coefficients
 	m_\gamma=\sum_{\alpha,\beta}c_{\alpha,\beta,\gamma}^{(1)}
 		m_\alpha m_\beta,
 \]
-and the appendix writes the vertical canonical forms as
-$\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$ and
-$\bigoplus_\beta \nu_\beta\otimes A_\beta$, with
-$m_\alpha=\operatorname{tr}(\mu_\alpha)$ and
-$n_\beta=\operatorname{tr}(\nu_\beta)$.
-The one-index coefficients $c_{S,j}^{(N)}$ below are the corresponding
+	and the appendix writes the vertical canonical forms as
+	$\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$ and
+	$\bigoplus_\beta \nu_\beta\otimes A_\beta$, with
+	$m_\alpha=\operatorname{tr}(\mu_\alpha)$ and
+	$n_\beta=\operatorname{tr}(\nu_\beta)$.
+	Here $\mu_\alpha$ and $\nu_\beta$ are diagonal positive matrices in the
+	source paper; only their traces are the scalar coefficients compared in this
+	subsection.
+	The one-index coefficients $c_{S,j}^{(N)}$ below are the corresponding
 power-sum comparison after the basis blocks have already been matched.  The
 geometric extrapolation and Newton--Girard steps are external finite-sequence
 facts used to recover the lists of weights from those power sums.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -412,7 +412,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	\lean{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq_hetero}
 	\leanok
 	If two finite families of nonzero complex numbers, possibly with different
-	cardinalities, have equal power sums for all sufficiently large exponents,
+	cardinalities, have equal power sums eventually, so there is $N_0$ such that
 	\[
 		\forall N\ge N_0,\qquad
 		\sum_i \alpha_i^N = \sum_j \beta_j^N,
@@ -436,8 +436,8 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 \label{lem:geom_extrapolation}
 	\lean{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq}
 	\leanok
-	If two finite families of nonzero complex numbers with the same
-	cardinality have equal power sums for all sufficiently large exponents,
+	If two finite families of nonzero complex numbers with the same cardinality
+	have equal power sums eventually, so there is $N_0$ such that
 	\[
 		\forall N\ge N_0,\qquad
 		\sum_i \alpha_i^N = \sum_i \beta_i^N,

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -577,13 +577,14 @@ facts used to recover the lists of weights from those power sums.
 
 \begin{proof}
 	\leanok
-	\uses{lem:paper_decomp_formula, thm:route_b_equal}
+	\uses{lem:paper_decomp_formula, thm:route_b_equal_with_copies}
 	Absorb the factors $\zeta_j$ into the sector weights of $Q$ and keep the
 	basis blocks of $P$. The phase-matching hypothesis and the sector
 	decomposition formula show that the resulting decomposition has the same
 	total MPV family as~$Q$, hence also as~$P$. One is then in the
-	shared-basis situation of Theorem~\ref{thm:route_b_equal}, which yields
-	the claimed equality of multisets.
+	shared-basis situation with recovered copy counts in
+	Theorem~\ref{thm:route_b_equal_with_copies}, which yields the claimed
+	equality of multisets.
 \end{proof}
 
 \begin{theorem}[Gauge-phase paired bases imply phase-matched sector comparison]%

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -372,15 +372,15 @@ structure coefficients
 	m_\gamma=\sum_{\alpha,\beta}c_{\alpha,\beta,\gamma}^{(1)}
 		m_\alpha m_\beta,
 \]
-	and the appendix writes the vertical canonical forms as
-	$\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$ and
-	$\bigoplus_\beta \nu_\beta\otimes A_\beta$, with
-	$m_\alpha=\operatorname{tr}(\mu_\alpha)$ and
-	$n_\beta=\operatorname{tr}(\nu_\beta)$.
-	Here $\mu_\alpha$ and $\nu_\beta$ are diagonal positive matrices in the
-	source paper; only their traces are the scalar coefficients compared in this
-	subsection.
-	The one-index coefficients $c_{S,j}^{(N)}$ below are the corresponding
+and the appendix writes the vertical canonical forms as
+$\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$ and
+$\bigoplus_\beta \nu_\beta\otimes A_\beta$, with
+$m_\alpha=\operatorname{tr}(\mu_\alpha)$ and
+$n_\beta=\operatorname{tr}(\nu_\beta)$.
+Here $\mu_\alpha$ and $\nu_\beta$ are diagonal positive matrices in the
+source paper; only their traces are the scalar coefficients compared in this
+subsection.
+The one-index coefficients $c_{S,j}^{(N)}$ below are the corresponding
 power-sum comparison after the basis blocks have already been matched.  The
 geometric extrapolation and Newton--Girard steps are external finite-sequence
 facts used to recover the lists of weights from those power sums.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -457,8 +457,8 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	\lean{MPSTensor.SectorWeightData.copies_eq_of_eventually_coeff_eq}
 	\leanok
 	\uses{def:paper_sector_data}
-	Let $S$ and $T$ be sector data over the same basis. If their coefficient
-	arrays satisfy
+	Let $S$ and $T$ be sector data over the same basis. If there is $N_0$
+	such that their coefficient arrays satisfy
 	\[
 		\forall N>N_0,\ \forall j,\qquad
 		c_{S,j}^{(N)} = c_{T,j}^{(N)},

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -392,27 +392,36 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	\]
 \end{theorem}
 
-\begin{theorem}[Eventual coefficient comparison from BNT linear independence]%
-\label{thm:coeff_eventually_eq}
+\begin{lemma}[Eventual coefficient comparison from BNT linear independence]%
+\label{lem:coeff_eventually_eq}
 	\lean{MPSTensor.SectorWeightData.coeff_eventually_eq_of_sameMPV}
 	\leanok
 	\uses{def:paper_sector_data, def:bnt}
 	If two sector data $S, T$ over the same basis, with coefficient arrays
 	$c_{S,j}^{(N)}$ and $c_{T,j}^{(N)}$, produce equal total MPVs
 	and the basis is eventually linearly independent (the BNT property),
-	then $c_{S,j}^{(N)} = c_{T,j}^{(N)}$ for all
-	sufficiently large $N$.
-\end{theorem}
+	then there is $N_0$ such that
+	\[
+		\forall N>N_0,\ \forall j,\qquad
+		c_{S,j}^{(N)}=c_{T,j}^{(N)}.
+	\]
+\end{lemma}
 
 \begin{lemma}[Heterogeneous geometric sequence extrapolation]%
 \label{lem:geom_extrapolation_hetero}
 	\lean{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq_hetero}
 	\leanok
 	If two finite families of nonzero complex numbers, possibly with different
-	cardinalities, have equal power sums
-	$\sum_i \alpha_i^k = \sum_j \beta_j^k$ for all sufficiently large
-	exponents $k$, then the same equality holds for every exponent
-	$k \geq 0$.
+	cardinalities, have equal power sums for all sufficiently large exponents,
+	\[
+		\forall N\ge N_0,\qquad
+		\sum_i \alpha_i^N = \sum_j \beta_j^N,
+	\]
+	then the same equality holds for every exponent:
+	\[
+		\forall k\ge 0,\qquad
+		\sum_i \alpha_i^k = \sum_j \beta_j^k.
+	\]
 \end{lemma}
 
 \begin{proof}
@@ -428,9 +437,12 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	\lean{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq}
 	\leanok
 	If two finite families of nonzero complex numbers with the same
-	cardinality have equal power sums
-	$\sum_i \alpha_i^k = \sum_i \beta_i^k$ for all $k > N_0$, then
-	equality holds for all $k \geq 0$.
+	cardinality have equal power sums for all sufficiently large exponents,
+	\[
+		\forall N\ge N_0,\qquad
+		\sum_i \alpha_i^N = \sum_i \beta_i^N,
+	\]
+	then equality holds for all exponents $k\ge 0$.
 \end{lemma}
 
 \begin{proof}
@@ -440,16 +452,22 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	Lemma~\ref{lem:geom_extrapolation_hetero}.
 \end{proof}
 
-\begin{theorem}[Copy-count recovery from eventual coefficient equality]%
-\label{thm:copies_eq_of_eventually_coeff_eq}
+\begin{lemma}[Copy-count recovery from eventual coefficient equality]%
+\label{lem:copies_eq_of_eventually_coeff_eq}
 	\lean{MPSTensor.SectorWeightData.copies_eq_of_eventually_coeff_eq}
 	\leanok
 	\uses{def:paper_sector_data}
 	Let $S$ and $T$ be sector data over the same basis. If their coefficient
-	arrays satisfy $c_{S,j}^{(N)} = c_{T,j}^{(N)}$ for every basis block $j$
-	and all sufficiently large $N$, then their copy counts agree:
-	$r_j^S = r_j^T$ for every~$j$.
-\end{theorem}
+	arrays satisfy
+	\[
+		\forall N>N_0,\ \forall j,\qquad
+		c_{S,j}^{(N)} = c_{T,j}^{(N)},
+	\]
+	then their copy counts agree:
+	\[
+		\forall j,\qquad r_j^S = r_j^T.
+	\]
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -480,11 +498,11 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 
 \begin{proof}
 	\leanok
-	\uses{thm:coeff_eventually_eq, thm:copies_eq_of_eventually_coeff_eq,
+	\uses{lem:coeff_eventually_eq, lem:copies_eq_of_eventually_coeff_eq,
 	      lem:geom_extrapolation, thm:power_sum_multiset}
 	BNT linear independence and equality of total MPVs give eventual
-	coefficient equality by Theorem~\ref{thm:coeff_eventually_eq}. Then
-	Theorem~\ref{thm:copies_eq_of_eventually_coeff_eq} recovers the
+	coefficient equality by Lemma~\ref{lem:coeff_eventually_eq}. Then
+	Lemma~\ref{lem:copies_eq_of_eventually_coeff_eq} recovers the
 	copy-count equalities. After identifying the two index sets via these
 	copy-count equalities, the positive-power coefficient equalities extend
 	to all positive exponents by
@@ -496,7 +514,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 \label{thm:route_b_equal}
 	\lean{MPSTensor.SectorWeightData.weight_multiset_eq_of_sameMPV_bnt}
 	\leanok
-	\uses{thm:coeff_eventually_eq, lem:geom_extrapolation, thm:power_sum_multiset, def:paper_sector_data, def:bnt}
+	\uses{lem:coeff_eventually_eq, lem:geom_extrapolation, thm:power_sum_multiset, def:paper_sector_data, def:bnt}
 	Let $S$ and $T$ be two sector data over the same basis with
 	the same multiplicities ($r_j^S = r_j^T$ for all~$j$).
 	If the basis is eventually linearly independent and the total MPVs
@@ -506,7 +524,7 @@ multiplicity $r_j$ and the multiset of weights attached to the basis block.
 	The argument proceeds as follows:
 	\begin{enumerate}
 		\item BNT LI $+$ equal MPVs $\Rightarrow$ eventual coefficient
-		      equality (Theorem~\ref{thm:coeff_eventually_eq});
+		      equality (Lemma~\ref{lem:coeff_eventually_eq});
 		\item Geometric extrapolation $\Rightarrow$ full coefficient
 		      equality for all positive~$k$
 		      (Lemma~\ref{lem:geom_extrapolation});


### PR DESCRIPTION
### Motivation

- The Chapter 11 subsection on multiplicity structure for repeated blocks (blueprint §sec:route_b) was not aligned with its primary source: arXiv:1606.00608 / Ann. Phys. Theorem IV.13 and its appendix direct-sum formulas (lines 972–985 and 1956–1970 of the MPDO paper); see #1304.
- Several blueprint entries in this subsection were at theorem-level despite being auxiliary to the main sector-weight comparison, including the Newton–Girard bridge and the sector-decomposition expansion.
- #1300 has landed, so this PR is now based directly on `main`.

### Description

- `blueprint/src/chapter/ch11_assembly.tex`: adds explicit citations to arXiv:1606.00608 Theorem IV.13 and the appendix direct-sum formulas; reclassifies the sector-decomposition expansion entry as lemma-level; fixes the phase-matched comparison proof dependency to the with-copies recovery theorem.
- `TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean`: demotes the Newton–Girard bridge declaration from `theorem` to `lemma`; the main BNT sector-weight recovery statements remain theorem-level.
- `TNLean/MPS/SharedInfra/SectorDecomposition.lean`: demotes the sector-decomposition MPV expansion helper from `theorem` to `lemma` to match the blueprint's auxiliary status.

### Testing

- `git diff --check`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`
- `lake env lean TNLean/MPS/SharedInfra/SectorDecomposition.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint web`

---
Addresses #1304

Part of #1170 and #1282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and declaration-level changes (demoting helper results from `theorem` to `lemma`) with no algorithmic changes; risk is limited to downstream Lean reference breakage due to renamed statement kinds.
> 
> **Overview**
> Aligns the sector-multiplicity/weight recovery presentation with the CPSV MPDO source by adding explicit discussion and citations around the trace/power-sum coefficients and the Newton–Girard recovery steps.
> 
> Demotes several auxiliary results from `theorem` to `lemma` in Lean (`coeff_eventually_eq_of_sameMPV`, `weight_multiset_eq_of_copies_eq_of_coeff_eq`, `copies_eq_of_eventually_coeff_eq`, and `SectorDecomposition.mpv_toTensor_eq_sum_coeff`) and updates the blueprint subsection accordingly (including correcting a dependency to reference the *with-copies* recovery theorem).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdeae8c1f3c52a9441ae03702896e40c2ea56978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->