### PR TITLE
doc(MPS/CanonicalForm): separate PF normality inputs

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean
@@ -72,9 +72,8 @@ For a single MPS tensor that is left-canonical (TP), has a primitive transfer ma
 (peripheral eigenvalues = {1}), and is irreducible (no nontrivial invariant
 projection), the tensor is normal (eventually full Kraus rank).
 
-Here `hPrim` is the peripheral-primitivity hypothesis for the transfer map:
-the only peripheral eigenvalue is `1`.  The conclusion is obtained by the
-following implications:
+The transfer-map primitivity hypothesis says that the only peripheral eigenvalue
+is `1`.  The conclusion is obtained by the following implications:
 
 * TP + peripheral primitivity + irreducibility give an `IsPrimitiveMPS` datum,
   including a Perron fixed point for the transfer map.
@@ -88,7 +87,8 @@ theorem isNormal_of_tp_primitive_irreducible [NeZero D]
     (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
     (hIrr : IsIrreducibleTensor A) :
     IsNormal A := by
-  -- Step 1: Peripheral primitivity plus irreducibility gives primitive MPS data.
+  -- Step 1: TP normalization, peripheral primitivity, and irreducibility give
+  -- primitive MPS data.
   have hMPSPrim : MPSTensor.HasPrimitiveFixedPoint A :=
     hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hIrr hTP hPrim
   -- Step 2: Extract the Perron fixed point.

--- a/TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean
@@ -15,11 +15,14 @@ This file collects the part of the canonical-form reduction that upgrades
 TP-primitive irreducible blocks to normal blocks and shows that normality is
 preserved by blocking.
 
-The core chain is the standard Perron–Frobenius route: peripheral primitivity
-and tensor irreducibility give a primitive fixed point, irreducibility upgrades
-that fixed point to positive definiteness, and the positive-definite fixed point
-implies normality. A separate word-span argument then shows that blocking keeps
-normality.
+The core chain is the channel Perron–Frobenius route with all hypotheses kept
+separate: trace preservation fixes the normalization convention, peripheral
+primitivity says that the peripheral spectrum of the transfer map is `{1}`,
+tensor irreducibility rules out nontrivial invariant projections, and these
+inputs produce a positive definite Perron fixed point.  The primitive spectral
+gap together with this faithful fixed point gives eventual full Kraus rank,
+which is the normality condition used here. A separate word-span argument then
+shows that blocking keeps normality.
 
 ## Main statements
 
@@ -34,6 +37,7 @@ normality.
 ## References
 
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3 + Appendix A]
+* [Wolf, *Quantum Channels & Operations*, Chapter 6]
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:2011.12127, Section IV]
 
 ## Tags
@@ -48,7 +52,7 @@ variable {d D : ℕ}
 /-!
 ## Per-block chain from TP + primitive + irreducible to IsNormal
 
-For a single block that is TP, has a primitive transfer map, AND is irreducible
+For a single block that is TP, has a primitive transfer map, and is irreducible
 (all three conditions), the full chain to `IsNormal` is available:
 
 1. `_root_.IsPrimitive (transferMap A)` + `IsIrreducibleTensor A` + TP
@@ -68,25 +72,31 @@ For a single MPS tensor that is left-canonical (TP), has a primitive transfer ma
 (peripheral eigenvalues = {1}), and is irreducible (no nontrivial invariant
 projection), the tensor is normal (eventually full Kraus rank).
 
-This chains:
-- Peripheral primitivity + irreducibility → existence of a primitive fixed point
-- Spectral-gap + irreducibility → PosDef fixed point
-- Spectral-gap + PosDef → HasEventuallyFullKrausRank → IsNormal -/
+Here `hPrim` is the peripheral-primitivity hypothesis for the transfer map:
+the only peripheral eigenvalue is `1`.  The conclusion is obtained by the
+following implications:
+
+* TP + peripheral primitivity + irreducibility give an `IsPrimitiveMPS` datum,
+  including a Perron fixed point for the transfer map.
+* Irreducibility upgrades the nonzero positive semidefinite Perron fixed point
+  in that datum to a positive definite, faithful fixed point.
+* The primitive spectral gap together with the faithful fixed point gives
+  eventual full Kraus rank, equivalently `IsNormal A`. -/
 theorem isNormal_of_tp_primitive_irreducible [NeZero D]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
     (hIrr : IsIrreducibleTensor A) :
     IsNormal A := by
-  -- Step 1: Get spectral-gap primitivity from peripheral primitivity + irreducibility.
+  -- Step 1: Peripheral primitivity plus irreducibility gives primitive MPS data.
   have hMPSPrim : MPSTensor.HasPrimitiveFixedPoint A :=
     hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible A hIrr hTP hPrim
-  -- Step 2: Extract the PSD fixed point.
+  -- Step 2: Extract the Perron fixed point.
   obtain ⟨ρ, hPrimMPS⟩ := hMPSPrim
   -- Step 3: Upgrade PSD → PosDef using tensor irreducibility.
   have hPD : ρ.PosDef :=
     posDef_of_isIrreducibleTensor_of_isPrimitiveMPS hPrimMPS hIrr
-  -- Step 4: IsNormal from spectral gap + PosDef.
+  -- Step 4: IsNormal from the primitive spectral gap and a faithful fixed point.
   exact isNormal_of_isPrimitiveMPS_with_posDef hPrimMPS hPD
 
 /-- **TP + primitive + irreducible → injective after blocking**.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2701,9 +2701,9 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 \begin{theorem}[TP-primitive irreducible tensor is normal]%
 	\label{thm:normal_tp_primitive_irred}
 	\lean{MPSTensor.isNormal_of_tp_primitive_irreducible}
-	\leanok
-	\uses{def:primitive_mps, def:irreducible_tensor, def:normal,
-		thm:psd_fp_pd_irred}
+		\leanok
+		\uses{def:primitive_mps, def:primitive_channel, def:irreducible_tensor,
+			def:normal}
 	Let $A$ be a left-canonical MPS tensor with $D > 0$,
 	irreducible tensor action, and primitive transfer map, equivalently
 	peripheral spectrum $\{1\}$.
@@ -2712,8 +2712,9 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 
 \begin{proof}\leanok
 	\uses{thm:normal_from_primitive_posdef, thm:psd_fp_pd_irred}
-	The channel-theoretic input from Wolf Chapter~6 is used in three distinct
-	places.  First, trace preservation fixes the left-canonical convention, and
+		The channel-theoretic results of \cite[Chapter~6]{Wolf2012Quantum} are used
+		in three distinct places.  First, trace preservation fixes the
+		left-canonical convention, and
 	peripheral primitivity says that the only peripheral eigenvalue of
 	$\E_A$ is~$1$.  Together with irreducibility, this gives a primitive
 	Perron fixed-point datum.  Second, irreducibility upgrades the nonzero

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2701,9 +2701,9 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 \begin{theorem}[TP-primitive irreducible tensor is normal]%
 	\label{thm:normal_tp_primitive_irred}
 	\lean{MPSTensor.isNormal_of_tp_primitive_irreducible}
-		\leanok
-		\uses{def:primitive_mps, def:primitive_channel, def:irreducible_tensor,
-			def:normal}
+	\leanok
+	\uses{def:primitive_mps, def:primitive_channel, def:irreducible_tensor,
+		def:normal}
 	Let $A$ be a left-canonical MPS tensor with $D > 0$,
 	irreducible tensor action, and primitive transfer map, equivalently
 	peripheral spectrum $\{1\}$.
@@ -2712,9 +2712,9 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 
 \begin{proof}\leanok
 	\uses{thm:normal_from_primitive_posdef, thm:psd_fp_pd_irred}
-		The channel-theoretic results of \cite[Chapter~6]{Wolf2012Quantum} are used
-		in three distinct places.  First, trace preservation fixes the
-		left-canonical convention, and
+	The channel-theoretic results of \cite[Chapter~6]{Wolf2012Quantum} are used
+	in three distinct places.  First, trace preservation fixes the
+	left-canonical convention, and
 	peripheral primitivity says that the only peripheral eigenvalue of
 	$\E_A$ is~$1$.  Together with irreducibility, this gives a primitive
 	Perron fixed-point datum.  Second, irreducibility upgrades the nonzero

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2702,17 +2702,25 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\label{thm:normal_tp_primitive_irred}
 	\lean{MPSTensor.isNormal_of_tp_primitive_irreducible}
 	\leanok
-	\uses{def:primitive_mps, def:irreducible_tensor, def:normal}
+	\uses{def:primitive_mps, def:irreducible_tensor, def:normal,
+		thm:psd_fp_pd_irred}
 	Let $A$ be a left-canonical MPS tensor with $D > 0$,
-	irreducible transfer map, and peripheral spectrum $\{1\}$.
+	irreducible tensor action, and primitive transfer map, equivalently
+	peripheral spectrum $\{1\}$.
 	Then $A$ is normal.
 \end{theorem}
 
 \begin{proof}\leanok
 	\uses{thm:normal_from_primitive_posdef, thm:psd_fp_pd_irred}
-	Peripheral primitivity and irreducibility yield the spectral-gap
-	condition.  The PSD fixed point is positive definite by
-	Theorem~\ref{thm:psd_fp_pd_irred}.
+	The channel-theoretic input from Wolf Chapter~6 is used in three distinct
+	places.  First, trace preservation fixes the left-canonical convention, and
+	peripheral primitivity says that the only peripheral eigenvalue of
+	$\E_A$ is~$1$.  Together with irreducibility, this gives a primitive
+	Perron fixed-point datum.  Second, irreducibility upgrades the nonzero
+	positive semidefinite fixed point to a positive definite faithful fixed
+	point by Theorem~\ref{thm:psd_fp_pd_irred}.  Third, the primitive
+	spectral gap with this faithful fixed point is the hypothesis of
+	Theorem~\ref{thm:normal_from_primitive_posdef}.
 	Apply Theorem~\ref{thm:normal_from_primitive_posdef}.
 \end{proof}
 
@@ -2724,7 +2732,8 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\uses{thm:normal_tp_primitive_irred,
 		lem:isNBlkInjective_iff_blockTensor_isInjective}
 	Let $A$ be a left-canonical MPS tensor with $D > 0$,
-	irreducible transfer map, and peripheral spectrum $\{1\}$.
+	irreducible tensor action, and primitive transfer map, equivalently
+	peripheral spectrum $\{1\}$.
 	Then some positive blocking $A^{[L]}$ is one-site injective.
 \end{theorem}
 


### PR DESCRIPTION
### Motivation

- The normality route in `NormalityChain.lean` draws on several distinct Perron–Frobenius and peripheral-spectrum inputs from Wolf Chapters 5 and 6, but the previous presentation did not separate their individual roles or cite their sources explicitly (see #1308).
- The correct implication chain is: trace preservation + peripheral primitivity + irreducibility → positive definite fixed point → eventual full Kraus rank → `IsNormal`. Each step relies on a different channel-theoretic fact, and conflating them obscures which hypotheses are needed at each stage.

### Description

- Clarified the implication chain `TP + peripheral primitivity + irreducibility → positive definite fixed point → eventual full Kraus rank → IsNormal` in `TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean`, making explicit the separate roles of trace preservation, peripheral primitivity (peripheral spectrum `{1}`), tensor irreducibility, faithful Perron fixed points, primitive spectral gap, and eventual full Kraus rank.
- Updated Chapter 8 blueprint prose in `blueprint/src/chapter/ch08_canonical.tex` to state the same channel-theoretic inputs explicitly, citing Wolf Chapter 6 as the source of the peripheral-spectrum step, and adjusted `\uses` annotations to reflect the added fixed-point upgrade lemma.

### Testing

- `git diff --check`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/NormalityChain.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint web`

---
Closes #1308
Part of #1278, #1170, and #1282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/proof commentary and blueprint text/annotations, with no changes to theorem statements or core proof structure.
> 
> **Overview**
> Clarifies the TP+primitive+irreducible-to-normality proof narrative in `NormalityChain.lean` by explicitly separating the roles of trace preservation, peripheral-spectrum primitivity (`{1}`), tensor irreducibility, faithful Perron fixed points, and the spectral-gap-to-"eventual full Kraus rank" step.
> 
> Updates Chapter 8 blueprint prose (`ch08_canonical.tex`) to match this refined implication chain, adds a Wolf Chapter 6 reference, and adjusts `\uses{...}` annotations/wording to distinguish primitive-channel assumptions from primitive-MPS fixed-point data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 204328e0c5459e2d63482d29ef7e148b54e1c447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->