### PR TITLE
doc(MPS/CanonicalForm): define remaining zero-tail prose

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/BasicSectorComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/BasicSectorComparison.lean
@@ -13,6 +13,11 @@ This module contains the first sector-comparison consequences used after the
 canonical-form reduction: zero-tail block-span comparisons and common MPV
 phase-cover routes for the leftover all-zero block bookkeeping.
 
+Here "zero-tail" means the total bond dimension of the separated all-zero
+leftover blocks in the block decomposition.  This is formalization shorthand
+for the source-paper allowance `∑ k, D_k ≤ D` and the corresponding zero
+blocks.
+
 ## References
 
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3 + Appendix A]

--- a/TNLean/MPS/CanonicalForm/Assembly/BasicSectorComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/BasicSectorComparison.lean
@@ -14,9 +14,8 @@ canonical-form reduction: zero-tail block-span comparisons and common MPV
 phase-cover routes for the leftover all-zero block bookkeeping.
 
 Here "zero-tail" means the total bond dimension of the separated all-zero
-leftover blocks in the block decomposition.  This is formalization shorthand
-for the source-paper allowance `∑ k, D_k ≤ D` and the corresponding zero
-blocks.
+leftover blocks in the block decomposition.  It is the dimension gap allowed by
+`∑ k, D_k ≤ D`, where the remaining summands are zero blocks.
 
 ## References
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
@@ -15,6 +15,10 @@ hypotheses for common primitive nonzero-sector families.  These structures expre
 the remaining data needed to pass from the common-sector structural theorem to
 the BNT overlap-rigidity comparison.
 
+The zero-tail dimensions below are the formal variables for the total bond
+dimension of the separated all-zero leftover blocks.  They correspond to the
+source-paper allowance `∑ k, D_k ≤ D` and the associated zero blocks.
+
 ## Tags
 
 matrix product states, canonical form, BNT, proportional decomposition

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
@@ -15,9 +15,9 @@ hypotheses for common primitive nonzero-sector families.  These structures expre
 the remaining data needed to pass from the common-sector structural theorem to
 the BNT overlap-rigidity comparison.
 
-The zero-tail dimensions below are the formal variables for the total bond
-dimension of the separated all-zero leftover blocks.  They correspond to the
-source-paper allowance `∑ k, D_k ≤ D` and the associated zero blocks.
+The zero-tail dimensions below are the total bond dimensions of the separated
+all-zero leftover blocks.  They are the dimension gaps allowed by
+`∑ k, D_k ≤ D`, where the remaining summands are zero blocks.
 
 ## Tags
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -17,6 +17,11 @@ This module contains the zero-tail transport lemmas and common-sector
 reindexing hypotheses used after the structural canonical-form reduction has
 produced common cyclic-sector data.
 
+Here "zero-tail" means the total bond dimension of the separated all-zero
+leftover blocks in the block decomposition.  This is formalization shorthand
+for the source-paper allowance `∑ k, D_k ≤ D` and the corresponding zero
+blocks.
+
 ## Main statements
 
 * `zeroTail_commonFlat_of_reindexed` and

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -18,9 +18,8 @@ reindexing hypotheses used after the structural canonical-form reduction has
 produced common cyclic-sector data.
 
 Here "zero-tail" means the total bond dimension of the separated all-zero
-leftover blocks in the block decomposition.  This is formalization shorthand
-for the source-paper allowance `∑ k, D_k ≤ D` and the corresponding zero
-blocks.
+leftover blocks in the block decomposition.  It is the dimension gap allowed by
+`∑ k, D_k ≤ D`, where the remaining summands are zero blocks.
 
 ## Main statements
 

--- a/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
@@ -16,6 +16,11 @@ nonzero parts directly. The length-zero equation records the residual
 zero-tail contribution, and full equality of the nonzero parts follows once the
 zero tails agree.
 
+Here "zero-tail" is the formal variable for the total bond dimension of the
+separated all-zero leftover blocks.  It corresponds to the source-paper
+allowance `∑ k, D_k ≤ D`, where the block decomposition may include zero
+blocks.
+
 ## References
 
 * [Cirac-Perez-Garcia-Schuch-Verstraete, arXiv:1606.00608, Section 2.3 + Appendix A]
@@ -23,7 +28,7 @@ zero tails agree.
 
 ## Tags
 
-matrix product states, canonical form, zero tail, blocking
+matrix product states, canonical form, zero-tail convention, blocking
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
@@ -16,10 +16,9 @@ nonzero parts directly. The length-zero equation records the residual
 zero-tail contribution, and full equality of the nonzero parts follows once the
 zero tails agree.
 
-Here "zero-tail" is the formal variable for the total bond dimension of the
-separated all-zero leftover blocks.  It corresponds to the source-paper
-allowance `∑ k, D_k ≤ D`, where the block decomposition may include zero
-blocks.
+Here "zero-tail" is the total bond dimension of the separated all-zero leftover
+blocks.  It is the dimension gap allowed by `∑ k, D_k ≤ D`, where the block
+decomposition may include zero blocks.
 
 ## References
 

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -13,6 +13,10 @@ The results here give after-blocking sector-comparison consequences from finite-
 comparisons and common MPV phase covers, and record the special case where the cover comes from a
 BNT proportional-decomposition comparison of the nonzero-weight block families.
 
+The zero-tail hypotheses mentioned below compare the total bond dimensions of
+the separated all-zero leftover blocks.  This is the formal counterpart of the
+source-paper block-decomposition allowance `∑ k, D_k ≤ D` and its zero blocks.
+
 ## Main statements
 
 * `TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison` contains the basic

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -14,8 +14,8 @@ comparisons and common MPV phase covers, and record the special case where the c
 BNT proportional-decomposition comparison of the nonzero-weight block families.
 
 The zero-tail hypotheses mentioned below compare the total bond dimensions of
-the separated all-zero leftover blocks.  This is the formal counterpart of the
-source-paper block-decomposition allowance `∑ k, D_k ≤ D` and its zero blocks.
+the separated all-zero leftover blocks.  These dimensions are the gaps allowed
+by `∑ k, D_k ≤ D`, where the remaining summands are zero blocks.
 
 ## Main statements
 

--- a/TNLean/MPS/CanonicalForm/Assembly/SectorComparisonCore.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/SectorComparisonCore.lean
@@ -17,8 +17,8 @@ public declaration names while separating the BNT/overlap-span comparison layer
 from the structural-data construction.
 
 When later statements in this route mention zero-tail data, the term denotes
-the total bond dimension of the separated all-zero leftover blocks, corresponding
-to the source-paper allowance `∑ k, D_k ≤ D`.
+the total bond dimension of the separated all-zero leftover blocks, namely the
+dimension gap allowed by `∑ k, D_k ≤ D`.
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/SectorComparisonCore.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/SectorComparisonCore.lean
@@ -15,6 +15,10 @@ This module contains the conditional sector-comparison consequences used after
 structural common-period blocking.  The statements preserve the historical
 public declaration names while separating the BNT/overlap-span comparison layer
 from the structural-data construction.
+
+When later statements in this route mention zero-tail data, the term denotes
+the total bond dimension of the separated all-zero leftover blocks, corresponding
+to the source-paper allowance `∑ k, D_k ≤ D`.
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
@@ -30,6 +30,10 @@ families. It combines the zero-block separation, TP gauge, and
 common blocking steps into a blocked decomposition whose nontrivial blocks are
 left-canonical and have primitive transfer maps.
 
+The "zero tail" in the produced decomposition is the total bond dimension of
+the separated all-zero leftover blocks.  This is formalization shorthand for
+the source-paper allowance `∑ k, D_k ≤ D` and its possible zero blocks.
+
 It also includes two immediate consequences when extra hypotheses are already
 available: the sorted normal-canonical-form criterion for blocked primitive
 families and the trivial-blocking shortcut for tensors that already come with a

--- a/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
@@ -31,8 +31,8 @@ common blocking steps into a blocked decomposition whose nontrivial blocks are
 left-canonical and have primitive transfer maps.
 
 The "zero tail" in the produced decomposition is the total bond dimension of
-the separated all-zero leftover blocks.  This is formalization shorthand for
-the source-paper allowance `∑ k, D_k ≤ D` and its possible zero blocks.
+the separated all-zero leftover blocks.  It is the dimension gap allowed by
+`∑ k, D_k ≤ D`, where the remaining summands are zero blocks.
 
 It also includes two immediate consequences when extra hypotheses are already
 available: the sorted normal-canonical-form criterion for blocked primitive


### PR DESCRIPTION
### Motivation

- Follow-up to #1290/#1303: a fresh audit still found assembly comparison modules using `zero-tail` prose before defining the term locally.
- The user-facing prose should define zero-tail as a local mathematical name for the separated all-zero block dimension, tied to the paper zero-block allowance.

### Description

- Adds local module-docstring definitions of `zero-tail` across the remaining canonical-form assembly comparison modules that rely on it.
- Each definition identifies the quantity as the total bond dimension of the separated all-zero leftover blocks.
- Each definition relates the shorthand to the source-paper block-decomposition allowance `∑ k, D_k ≤ D` and the corresponding zero blocks.
- No Lean declaration names, theorem statements, or proofs change.

### Validation

- `git diff --check`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/BasicSectorComparison.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/SectorComparisonCore.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Closes #1310

Part of #1170 and #1282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes: adds/clarifies the definition of “zero-tail” in several canonical-form assembly modules without touching Lean declarations, theorem statements, or proofs, so functional risk is minimal.
> 
> **Overview**
> Adds consistent module-level prose defining *“zero-tail”* across the remaining canonical-form assembly comparison modules that use the term.
> 
> Each docstring now states that “zero-tail” is the **total bond dimension of separated all-zero leftover blocks** in a block decomposition, and relates it explicitly to the allowance `∑ k, D_k ≤ D` (with remaining summands treated as zero blocks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9192d969d7f410086ce096adaeb4a2fda39ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->