### PR TITLE
style(MPS/FT): demote equal-proportional helper lemmas

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -36,7 +36,7 @@ coefficients from the hypotheses of the source-paper theorem is not part of this
 Trivial but useful: `SameMPV₂ A B → ProportionalMPV₂ A B` (take `c_N = 1`).
 
 ### Power-sum multiset equality
-(`mu_multiset_eq_of_power_sum_eq`)
+(`power_sum_eq_implies_multiset_eq`)
 
 If two sequences of complex numbers have equal power sums for all exponents, their multisets
 (as roots) are equal. This is the formalized version of Lemma Lem:app_simple from the paper.
@@ -285,13 +285,13 @@ theorem fundamentalTheorem_proportionalMPV_normalCFBNT
     A_total B_total aCoeff bCoeff aLim bLim c cLim
     hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
 
-/-! ## Theorem 3: Equal MPVs imply proportional MPVs -/
+/-! ## Equal MPVs imply proportional MPVs -/
 
 /-- **Equal MPVs imply proportional MPVs** (with proportionality constant `1`).
 
 This converts an equality hypothesis into the proportionality hypothesis used by the
 explicit-coefficient comparison theorems. -/
-theorem sameMPV₂_implies_proportionalMPV₂
+lemma sameMPV₂_implies_proportionalMPV₂
     {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (h : SameMPV₂ A B) :
     ProportionalMPV₂ A B := by
@@ -308,7 +308,7 @@ with per-block `GaugePhaseEquiv` data.
 Under those coefficient hypotheses, equal MPVs force the phase-corrected
 weights to match blockwise.  After reindexing the `B`-family by the permutation from the
 proportional FT, the assembled weighted block tensors are globally gauge equivalent. -/
-theorem fundamentalTheorem_equalMPV_of_explicit_coefficients
+lemma fundamentalTheorem_equalMPV_of_explicit_coefficients
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -460,10 +460,10 @@ theorem fundamentalTheorem_equalMPV_of_explicit_coefficients
   rw [hA_tot, hB_tot]
   exact hGaugeWeighted
 
-/-! ## Theorem 4: Power-sum multiset equality (Lem:app_simple)
+/-! ## Power-sum multiset equality
 
-This wraps `Matrix.sum_pow_eq_implies_multiset_eq` from `ScalarPowerSumIdentity.lean`
-to provide the paper's Lemma Lem:app_simple in a convenient form.
+This gives the paper's auxiliary power-sum lemma in the notation of the BNT
+comparison.  It is not an additional Fundamental Theorem statement.
 -/
 
 /-- **Equal power sums imply equal multisets (Lem:app_simple).**
@@ -474,7 +474,7 @@ multiset of values (counted with multiplicity).
 
 This is the paper's Lemma Lem:app_simple, proved via Newton's identities
 (`Matrix.sum_pow_eq_implies_multiset_eq` from `ScalarPowerSumIdentity.lean`). -/
-theorem power_sum_eq_implies_multiset_eq (n : ℕ)
+lemma power_sum_eq_implies_multiset_eq (n : ℕ)
     (α β : Fin n → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i : Fin n, (α i) ^ k = ∑ i : Fin n, (β i) ^ k) :
     Finset.univ.val.map α = Finset.univ.val.map β :=
@@ -487,7 +487,7 @@ section Corollaries
 /-- **Per-block SameMPV from CF-BNT equal MPVs.**
 
 Extracts the per-block `SameMPV` conclusion from the equal-MPV theorem. -/
-theorem perBlock_sameMPV_of_equalMPV_CFBNT
+lemma perBlock_sameMPV_of_equalMPV_CFBNT
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ}
     (A B : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -466,13 +466,13 @@ This gives the paper's auxiliary power-sum lemma in the notation of the BNT
 comparison.  It is not an additional Fundamental Theorem statement.
 -/
 
-/-- **Equal power sums imply equal multisets (Lem:app_simple).**
+/-- **Equal power sums imply equal multisets.**
 
 If two sequences of complex numbers `α : Fin n → ℂ` and `β : Fin n → ℂ` satisfy
 `∑ i, (α i)^k = ∑ i, (β i)^k` for all positive `k`, then `α` and `β` have the same
 multiset of values (counted with multiplicity).
 
-This is the paper's Lemma Lem:app_simple, proved via Newton's identities
+This is the paper's auxiliary power-sum lemma, proved via Newton's identities
 (`Matrix.sum_pow_eq_implies_multiset_eq` from `ScalarPowerSumIdentity.lean`). -/
 lemma power_sum_eq_implies_multiset_eq (n : ℕ)
     (α β : Fin n → ℂ)

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -560,6 +560,6 @@ The main references are
 	Theorem~\ref{thm:ft_equal}, where one expects a power-sum step to
 	recover the multiplicity-weight data.
 	The explicit-coefficient special case,
-	Theorem~\ref{thm:ft_equal_explicit}, instead uses linear independence
+	Lemma~\ref{lem:ft_equal_explicit}, instead uses linear independence
 	of the block MPV family supplied by a basis of normal tensors.
 \end{remark}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -206,7 +206,7 @@ used in this chapter.
 \end{theorem}
 
 \begin{proof}
-	\uses{thm:ft_equal_explicit, thm:fundamentalTheorem_equalMPV_CFBNT_hetero,
+	\uses{lem:ft_equal_explicit, thm:fundamentalTheorem_equalMPV_CFBNT_hetero,
 	      thm:mpv_decomposition,
 	      rem:cf_coeff_arrays, thm:route_b_equal_with_copies,
 	      thm:afterBlocking_sectorComparison_reindexed_bntCover,
@@ -215,7 +215,7 @@ used in this chapter.
 	Theorem~\ref{thm:mpv_decomposition} expands the two canonical-form tensors in
 	their BNT bases, and Remark~\ref{rem:cf_coeff_arrays} describes the resulting
 	coefficient arrays.  When the required coefficient identities are supplied,
-	Theorem~\ref{thm:ft_equal_explicit} proves gauge equivalence after permuting
+	Lemma~\ref{lem:ft_equal_explicit} proves gauge equivalence after permuting
 	the weighted block-diagonal tensors.  The sector-multiplicity comparison of
 	Theorem~\ref{thm:route_b_equal_with_copies} uses the supplied multiplicity
 	data to recover both the copy counts and the sector-weight multisets from
@@ -238,7 +238,7 @@ used in this chapter.
 	and the blockwise conjugacies assemble into a global gauge equivalence.
 \end{proof}
 
-\begin{theorem}[Equal MPV comparison with explicit coefficients]\label{thm:ft_equal_explicit}
+\begin{lemma}[Equal MPV comparison with explicit coefficients]\label{lem:ft_equal_explicit}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_of_explicit_coefficients}
 	\leanok
 	\uses{def:cf_bnt, def:gauge_equiv}
@@ -267,7 +267,7 @@ used in this chapter.
 	$\bigoplus_{j=1}^{g_A} \mu_j^A A_j$ and
 	$\bigoplus_{j=1}^{g_A} \mu_{\pi(j)}^B B_{\pi(j)}$
 	are gauge equivalent.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -313,10 +313,10 @@ used in this chapter.
 \end{proof}
 
 \begin{remark}
-	Theorem~\ref{thm:ft_equal_explicit} recovers
+	Lemma~\ref{lem:ft_equal_explicit} gives a conditional special case of
 	\cite[Corollary~IV.5]{Cirac2021Matrix} for tensors in canonical form with
-	BNT separation, without assuming common block structure and without
-	Newton--Girard identities. The weight matching uses BNT linear
+	BNT separation, assuming the coefficient identities explicitly rather than
+	deriving them by Newton--Girard identities. The weight matching uses BNT linear
 	independence (Theorem~\ref{thm:cf_bnt_is_bnt} and
 	Definition~\ref{def:bnt}) directly.
 \end{remark}
@@ -2076,7 +2076,7 @@ two-basis sector comparison theorem.
 	\cite{Cirac2016MPDO_arXiv}, restated in \cite{Cirac2021Matrix}.
 
 	The comparison theorems in this chapter cover this latter part of the argument.
-	Theorem~\ref{thm:ft_equal_explicit} proves the equal case when the coefficient
+	Lemma~\ref{lem:ft_equal_explicit} proves the equal case when the coefficient
 	identities are given explicitly,
 	Theorem~\ref{thm:ft_equal_same_structure} proves the common block-structure
 	special case, and Theorem~\ref{thm:route_b_equal_with_copies} recovers the

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -216,11 +216,12 @@ paper-level theorems.
     Fundamental Theorem.
   \item The implication
     \[
-      \texttt{sameMPV2\_implies\_proportionalMPV2}
+      \texttt{sameMPV}_{2}\texttt{\_implies\_proportionalMPV}_{2}
     \]
     from equal MPV families to proportional MPV families with proportionality
-    constant \(1\) is also lemma-level.  It is a logical conversion between
-    hypotheses, not a separate source theorem.
+    constant \(1\) is also lemma-level.  The displayed subscript \(2\) denotes
+    the Unicode subscript \(2\) used in the Lean declaration name.  It is a
+    logical conversion between hypotheses, not a separate source theorem.
 \end{itemize}
 
 \section{Statements to keep visibly conditional}

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -112,6 +112,8 @@ This applies in particular to the following families of external input.
     they are not proved in the MPS source.  When they are used to recover
     coefficients, multiplicities, or weight multisets, the blueprint should
     explain the finite linear system or the power-sum recursion.
+    Declarations that only restate these finite-sequence facts in BNT notation
+    should be lemmas, even when they are applied inside a paper-level theorem.
   \item Perron--Frobenius and peripheral-spectrum facts for quantum channels are
     standard inputs from finite-dimensional channel theory, but they are not
     interchangeable.  A formal theorem should specify whether it uses
@@ -123,6 +125,49 @@ This rule also gives a retirement test.  If an external-looking lemma has no
 source citation, no proof explanation, and no current proof path needing it, it
 should not remain as a headline theorem in the paper-level blueprint.
 
+\section{Dependency-chain classification}
+
+The non-periodic Fundamental Theorem route should be read with the following
+separation of proof roles.
+
+\paragraph{Paper-level targets.}
+The proportional canonical-form theorem and the equal-MPV corollary are the
+source targets.  Their formal representatives include
+\path{fundamentalTheorem_proportionalMPV_CFBNT} and
+\path{fundamentalTheorem_equalMPV_CFBNT}.
+Heterogeneous variants that also state the permutation, phases, gauges, and
+weight matching for possibly different sector indices are legitimate theorem
+endpoints when they are the formal form of the same BNT comparison.
+
+\paragraph{Conditional after-blocking consumers.}
+The after-blocking comparison theorems are useful only after the source
+canonical-form, BNT selection, block-injective span, and BNT matching inputs have
+been supplied.  Results such as
+\path{fundamentalTheorem_after_blocking_sector_of_common_blocks_blockSpan}
+and the corresponding common-phase-cover or BNT-cover formulations are
+conditional consumers of those inputs.  They should stay visibly conditional
+until the hypotheses are produced from the paper's assumptions.  In particular,
+the finite-length span or phase-cover assumptions are not extra hypotheses in
+the source theorem; they are the formal names for proof inputs that still have
+to be obtained from the source argument.
+
+\paragraph{Data structures and transport lemmas.}
+Objects such as \path{SectorBasisOverlapSpanHypotheses} and
+\path{CommonPrimitiveBNTCoverHypotheses}
+are formal comparison data for the proof.  They should not be cited as paper
+theorems.  Lemmas converting one data structure into another are needed in the
+formal proof chain, but they are auxiliary unless they state one of the source
+mathematical claims directly.
+
+\paragraph{External finite-dimensional inputs.}
+The formal route also contains named statements for linear algebra that the
+paper uses without proof: Vandermonde separation, Newton--Girard recovery,
+finite-dimensional Perron--Frobenius structure, Burnside--Jacobson algebra
+generation, and quantum Wielandt bounds.  These may be important mathematical
+theorems in their own right, but in this proof chain they enter as cited inputs.
+Their statements should be explained, and their formal names should normally be
+lemma-level when they are merely restated in MPS notation.
+
 \section{Current demotions}
 
 The following declarations are auxiliary and should not be read as independent
@@ -132,8 +177,8 @@ paper-level theorems.
     \[
       \texttt{fundamentalTheorem\_equalMPV\_of\_explicit\_coefficients}.
     \]
-    It is not the full equal-MPV corollary from the papers.  It assumes the
-    coefficient arrays and their nonzero limits.
+    It is now lemma-level.  It is not the full equal-MPV corollary from the
+    papers, since it assumes the coefficient arrays and their nonzero limits.
   \item The proportional result
     \[
       \texttt{fundamentalTheorem\_proportionalMPV\_CFBNT}
@@ -157,6 +202,25 @@ paper-level theorems.
     from \cite{Cirac2016MPDO_arXiv}; the source only says that canonical forms
     may have zero blocks through the inequality
     \(\sum_k D_k \le D\) \cite[lines~217--219]{Cirac2016MPDO_arXiv}.
+  \item The power-sum multiset recovery statement
+    \[
+      \texttt{power\_sum\_eq\_implies\_multiset\_eq}
+    \]
+    is a lemma-level restatement of the elementary Newton--Girard input used in
+    the equal-MPV proof.  Likewise,
+    \[
+      \texttt{perBlock\_sameMPV\_of\_equalMPV\_CFBNT}
+    \]
+    is only the extraction of the blockwise equality conclusion from the
+    equal-MPV theorem.  Neither should be counted as an additional source-level
+    Fundamental Theorem.
+  \item The implication
+    \[
+      \texttt{sameMPV2\_implies\_proportionalMPV2}
+    \]
+    from equal MPV families to proportional MPV families with proportionality
+    constant \(1\) is also lemma-level.  It is a logical conversion between
+    hypotheses, not a separate source theorem.
 \end{itemize}
 
 \section{Statements to keep visibly conditional}


### PR DESCRIPTION
## Summary

This theorem-surface cleanup is under #1282/#1278 for the equal/proportional Fundamental Theorem route.

- demotes auxiliary declarations in `EqualProportional.lean` from `theorem` to `lemma`: `sameMPV₂_implies_proportionalMPV₂`, `fundamentalTheorem_equalMPV_of_explicit_coefficients`, `power_sum_eq_implies_multiset_eq`, and `perBlock_sameMPV_of_equalMPV_CFBNT`;
- changes the explicit-coefficient equal-MPV blueprint entry from theorem to lemma and updates dependent references in Chapters 10 and 11;
- extends `docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex` with a dependency-chain classification separating paper-level FT targets, conditional after-blocking consumers, formal comparison data, and external finite-dimensional inputs.

## Validation

- `git diff --check`
- `lake env lean TNLean/MPS/FundamentalTheorem/EqualProportional.lean`
- `lake env lean TNLean/MPS/Periodic/FundamentalTheorem.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint web`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`

Refs #1282
Refs #1278

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to renaming/demoting proof declarations (`theorem`→`lemma`) and updating blueprint/documentation references, with no change to core MPV comparison logic.
> 
> **Overview**
> **Theorem-surface cleanup for the non-periodic Fundamental Theorem route.** Several helper results in `EqualProportional.lean` are demoted from `theorem` to `lemma` (including the equal→proportional bridge, the explicit-coefficient equal-MPV comparison, the power-sum multiset lemma, and a per-block corollary), and their section docs are tweaked to emphasize these are auxiliary inputs.
> 
> The blueprint is updated to match: the explicit-coefficient equal-MPV entry is now a `lemma` (`thm:ft_equal_explicit`→`lem:ft_equal_explicit`) with all cross-references adjusted in Chapters 10–11, and the paper-gap audit doc adds a dependency-chain classification plus notes explaining which statements are auxiliary vs paper-level targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584449155665803766cbd81ac3b743506627f53d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->