### PR TITLE
style(Wielandt): demote proof-chain packaging lemmas

### DIFF
--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -89,7 +89,7 @@ then the MPV states `mpvState (A j) N` are eventually linearly independent.
 This is a convenient formulation around
 `MPSTensor.eventually_linearIndependent_of_gram_tendsto_id`.
 -/
-theorem eventually_linearIndependent_of_overlap_tendsto_orthonormal
+lemma eventually_linearIndependent_of_overlap_tendsto_orthonormal
     {d : ℕ} {g : ℕ} {dim : Fin g → ℕ}
     (A : (j : Fin g) → MPSTensor d (dim j))
     (h_self : ∀ j,
@@ -175,7 +175,7 @@ This is the key algebraic step in the BNT permutation-matching argument: it conv
 subspace-level agreement of two BNT families into a *matrix* equation whose asymptotics
 (as the system size grows) can then be analysed.
 -/
-theorem exists_invertible_changeBasis
+lemma exists_invertible_changeBasis
     (v w : Fin g → V)
     (_hv : LinearIndependent ℂ v)
     (hw : LinearIndependent ℂ w)
@@ -247,7 +247,7 @@ This is a direct repackaging of
 `MPSTensor.eventually_linearIndependent_of_overlap_tendsto_orthonormal`
 in the exact form used by the BNT permutation-matching argument.
 -/
-theorem bntFamilies_eventually_linearIndependent
+lemma bntFamilies_eventually_linearIndependent
     {d g : ℕ} {dim : Fin g → ℕ}
     (A : (j : Fin g) → MPSTensor d (dim j))
     (h_diag : ∀ j,
@@ -268,10 +268,10 @@ satisfying
 
 `mpvState (B j) N = ∑ i, U_N i j • mpvState (A i) N`.
 
-This is the algebraic bridge between "same MPV subspace" and "matrix equation" that is needed
-for the permutation-matching step in Theorem 4.4.
+This converts the equal-MPV-subspace condition into a matrix equation whose
+asymptotics can then be analysed in the permutation-matching step of Theorem 4.4.
 -/
-theorem eventually_exists_invertible_changeBasis
+lemma eventually_exists_invertible_changeBasis
     {d g : ℕ} {dimA dimB : Fin g → ℕ}
     (A : (j : Fin g) → MPSTensor d (dimA j))
     (B : (j : Fin g) → MPSTensor d (dimB j))

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -240,7 +240,7 @@ If the self-overlaps of a finite block family tend to `1` and the cross-overlaps
 of distinct blocks tend to `0`, then the MPV states are linearly independent for
 every sufficiently large system size.  This is the threshold form of
 `bntFamilies_eventually_linearIndependent`. -/
-theorem exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal
+lemma exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hSelf : ∀ j,

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -137,7 +137,7 @@ Given `IsNormal A`, the cumulative part of the Wielandt argument provides:
 3. A nonzero eigenvalue μ and eigenvector φ for evalWord A w₀
 4. Vector spanning: for any nonzero φ, word products applied to φ span ℂ^D
 
-This restates `wielandt_chain` in the normality setting. -/
+This lemma restates `wielandt_chain` in the normality setting. -/
 lemma wielandt_full_analysis [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     cumulativeSpan A (D ^ 2) = ⊤ ∧

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -95,7 +95,7 @@ This combines Lemma 1 (`exists_nonzero_trace_word`) with eigenvalue extraction
 structure.
 
 Paper: arXiv:0909.5347, Theorem 1 proof, first paragraph. -/
-theorem wielandtAnalysis [NeZero D]
+lemma wielandtAnalysis [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     Nonempty (WielandtAnalysis A) := by
   obtain ⟨w₀, μ, φ, hw₀, hμ, hφ, heig⟩ := exists_word_eigenvector A hN
@@ -127,7 +127,7 @@ they also span all vectors when applied to any nonzero φ.
 Paper: implicit in the proof — the spanning of all matrices trivially implies
 the spanning of all vectors.
 (arXiv:0909.5347, between Lemma 1 and Lemma 2) -/
-theorem vector_spanning_from_normality [NeZero D]
+lemma vector_spanning_from_normality [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A)
     (φ : Fin D → ℂ) (hφ : φ ≠ 0) :
     cumulativeVectorSpan A φ (D ^ 2) = ⊤ :=
@@ -174,7 +174,7 @@ multiplying word products of different lengths we can eventually fill a
 single-length word span. This is essentially Lemma 2(b) of the paper.
 
 Paper: arXiv:0909.5347, Section II. -/
-theorem isNormal_implies_cumulativeSpan_eq_top'
+lemma isNormal_implies_cumulativeSpan_eq_top'
     (A : MPSTensor d D) (hN : IsNormal A) :
     ∃ N, cumulativeSpan A N = ⊤ :=
   cumulativeSpan_eq_top_of_isNormal A hN
@@ -206,7 +206,7 @@ Given `IsNormal A`:
 5. (Needs Lemma 2(b)) All matrices are reachable using word products of
    a single fixed length ≤ D⁴
 
-The conclusion is the conjunction of steps 1-4. -/
+This lemma covers steps 1-4. -/
 lemma wielandt_chain [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     -- Step 1: Cumulative span = ⊤

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -416,12 +416,13 @@ The results follow~\cite{Sanz2010Quantum}.
     $A^{w_0} \varphi = \mu \varphi$.
 \end{definition}
 
-\begin{theorem}[Wielandt analysis exists]\label{thm:wielandt_analysis}
+\begin{lemma}[Wielandt analysis exists]\label{lem:wielandt_analysis}
     \lean{MPSTensor.wielandtAnalysis}
     \leanok
     \uses{def:wielandt_analysis, def:normal}
-    Every normal MPS tensor admits a Wielandt analysis.
-\end{theorem}
+    Every normal MPS tensor with bond dimension $D \ge 1$ admits a
+    Wielandt analysis.
+\end{lemma}
 
 \begin{proof}
     \leanok
@@ -449,11 +450,11 @@ The results follow~\cite{Sanz2010Quantum}.
 
 \begin{proof}
     \leanok
-    \uses{thm:wielandt_analysis, thm:eigenvector_spreading,
+    \uses{lem:wielandt_analysis, thm:eigenvector_spreading,
           thm:cumulative_eq_top}
     Items (1)--(3) follow from earlier results
-    (Theorems~\ref{thm:cumulative_eq_top},
-    \ref{thm:wielandt_analysis}).
+    (Theorem~\ref{thm:cumulative_eq_top}
+    and Lemma~\ref{lem:wielandt_analysis}).
     Item (4) combines these with the eigenvector spreading bound
     (Theorem~\ref{thm:eigenvector_spreading}).
 \end{proof}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2892,19 +2892,19 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	sector decomposition with strict norm ordering.
 \end{theorem}
 
-\begin{theorem}[Existential BNT independence from overlap limits]
-	\label{thm:bnt_li_from_overlap_limits_exists}
+\begin{lemma}[Existential BNT independence from overlap limits]
+	\label{lem:bnt_li_from_overlap_limits_exists}
 	\lean{MPSTensor.exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal}
 	\leanok
-	\uses{thm:bnt_overlap_orthonormal_li}
+	\uses{lem:bnt_overlap_orthonormal_li}
 	If the self-overlaps of a finite block family tend to $1$ and the
 	cross-overlaps of distinct blocks tend to $0$, then the MPV states are
 	linearly independent for all sufficiently large system sizes.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
-	\uses{thm:bnt_overlap_orthonormal_li}
-	This is Theorem~\ref{thm:bnt_overlap_orthonormal_li}, restated with an
+	\uses{lem:bnt_overlap_orthonormal_li}
+	This is Lemma~\ref{lem:bnt_overlap_orthonormal_li}, restated with an
 	explicit threshold $N_0$.
 \end{proof}
 
@@ -2912,18 +2912,17 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	\label{thm:bnt_li_tp_prim_irr_separated}
 	\lean{MPSTensor.exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv}
 	\leanok
-	\uses{thm:bnt_li_from_overlap_limits_exists, def:gauge_phase_equiv}
+	\uses{lem:bnt_li_from_overlap_limits_exists, def:gauge_phase_equiv}
 	For trace-preserving primitive irreducible blocks of positive bond dimension
 	that are pairwise not gauge-phase equivalent, the block MPV states are
 	linearly independent for all sufficiently large system sizes.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:bnt_li_from_overlap_limits_exists}
+	\uses{lem:bnt_li_from_overlap_limits_exists}
 	Primitivity and trace preservation give self-overlap convergence to $1$.
 	BNT separation gives cross-overlap convergence to $0$ for distinct blocks.
-	The result follows from
-	Theorem~\ref{thm:bnt_li_from_overlap_limits_exists}.
+	The result follows from Lemma~\ref{lem:bnt_li_from_overlap_limits_exists}.
 \end{proof}
 
 \begin{theorem}[One-sector-per-block decomposition from eventual BNT independence]

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -32,8 +32,8 @@ The main references are
 	This is \cite[Definition~4.2]{Cirac2021Matrix}.
 \end{definition}
 
-\begin{theorem}[Overlap-orthonormality implies eventual linear independence]
-	\label{thm:bnt_overlap_orthonormal_li}
+\begin{lemma}[Overlap-orthonormality implies eventual linear independence]
+	\label{lem:bnt_overlap_orthonormal_li}
 	\lean{MPSTensor.eventually_linearIndependent_of_overlap_tendsto_orthonormal}
 	\leanok
 	\uses{def:mpv_overlap}
@@ -42,7 +42,7 @@ The main references are
 	for $i \neq j$. Then the MPV states
 	$\{\ket{V^{(N)}(A_j)}\}_{j=1}^g$ are linearly independent for all
 	sufficiently large~$N$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	The Gram matrix of the family $\{\ket{V^{(N)}(A_j)}\}_{j=1}^g$
@@ -181,12 +181,12 @@ The main references are
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:mpv_decomposition, thm:bnt_overlap_orthonormal_li, thm:cross_overlap_zero_split}
+	\uses{thm:mpv_decomposition, lem:bnt_overlap_orthonormal_li, thm:cross_overlap_zero_split}
 	Injective blocks are normal. The block-diagonal decomposition theorem gives
 	the MPV expansion of $\bigoplus_k \mu_k A_k$ in terms of the block MPVs.
 	The self-overlap limits are part of the hypotheses, and
 	Theorem~\ref{thm:cross_overlap_zero_split} supplies the off-diagonal
-	decay. Therefore Theorem~\ref{thm:bnt_overlap_orthonormal_li} gives the
+	decay. Therefore Lemma~\ref{lem:bnt_overlap_orthonormal_li} gives the
 	eventual linear independence required in Definition~\ref{def:bnt}.
 \end{proof}
 
@@ -237,8 +237,8 @@ The main references are
 
 \section{Permutation rigidity for bases of normal tensors}
 
-\begin{theorem}[Invertible change of basis]
-	\label{thm:bnt_invertible_change_basis}
+\begin{lemma}[Invertible change of basis]
+	\label{lem:bnt_invertible_change_basis}
 	\lean{exists_invertible_changeBasis}
 	\leanok
 	Let $v_1, \ldots, v_g$ and $w_1, \ldots, w_g$ be two linearly independent
@@ -248,7 +248,7 @@ The main references are
 		w_j = \sum_{i=1}^g U_{ij} v_i
 	\]
 	for every $j$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	Because the two families span the same subspace, each $w_j$ has a unique
@@ -258,22 +258,22 @@ The main references are
 	is injective, hence invertible.
 \end{proof}
 
-\begin{theorem}[Eventual change of basis from equal spans]
-	\label{thm:bnt_eventual_change_basis}
+\begin{lemma}[Eventual change of basis from equal spans]
+	\label{lem:bnt_eventual_change_basis}
 	\lean{MPSTensor.eventually_exists_invertible_changeBasis}
 	\leanok
-	\uses{thm:bnt_invertible_change_basis, def:mpv_overlap}
+	\uses{lem:bnt_invertible_change_basis, def:mpv_overlap}
 	If two finite families of blocks have asymptotically orthonormal overlaps
 	within each family and their MPV spans agree for every system size $N$,
 	then for all sufficiently large $N$ there exists an invertible matrix
 	$U_N$ expressing the MPV states of one family as linear combinations of
 	the MPV states of the other.
-\end{theorem}
+\end{lemma}
 
-\begin{proof}\leanok\uses{thm:bnt_overlap_orthonormal_li, thm:bnt_invertible_change_basis}
-	By Theorem~\ref{thm:bnt_overlap_orthonormal_li}, both families are
+\begin{proof}\leanok\uses{lem:bnt_overlap_orthonormal_li, lem:bnt_invertible_change_basis}
+	By Lemma~\ref{lem:bnt_overlap_orthonormal_li}, both families are
 	linearly independent for all sufficiently large $N$. At such an $N$, the
-	span equality lets us apply Theorem~\ref{thm:bnt_invertible_change_basis}.
+	span equality lets us apply Lemma~\ref{lem:bnt_invertible_change_basis}.
 \end{proof}
 
 \begin{theorem}[Permutation rigidity for equal block counts]
@@ -289,8 +289,8 @@ The main references are
 	same bond dimension and are gauge-phase equivalent.
 \end{theorem}
 
-\begin{proof}\leanok\uses{thm:bnt_eventual_change_basis, thm:overlap_decay, thm:overlap_decay_rect}
-	For large $N$, Theorem~\ref{thm:bnt_eventual_change_basis} gives an
+\begin{proof}\leanok\uses{lem:bnt_eventual_change_basis, thm:overlap_decay, thm:overlap_decay_rect}
+	For large $N$, Lemma~\ref{lem:bnt_eventual_change_basis} gives an
 	invertible matrix $U_N$ relating the two MPV families. Fix $j$. If every
 	mixed overlap $O_{A_iB_j}(N)$ tended to $0$, then taking inner products of
 	the relation with the $A_i$ and using that the Gram matrix of the
@@ -397,8 +397,8 @@ The main references are
 	dimension and are gauge-phase equivalent for each~$j$.
 \end{lemma}
 
-\begin{proof}\leanok\uses{thm:bnt_overlap_orthonormal_li, thm:bnt_perm_same_card}
-	By Theorem~\ref{thm:bnt_overlap_orthonormal_li}, both families are
+\begin{proof}\leanok\uses{lem:bnt_overlap_orthonormal_li, thm:bnt_perm_same_card}
+	By Lemma~\ref{lem:bnt_overlap_orthonormal_li}, both families are
 	linearly independent for all sufficiently large $N$. At such an $N$, the
 	common span has the same dimension when computed from the $A$-family or
 	the $B$-family, so $g_A = g_B$. After identifying the two index sets,

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -70,6 +70,16 @@ persistence of injectivity under further blocking, and the simultaneous
 application to a finite family of representative sectors.  These statements are
 auxiliary, but they are mathematically faithful to the period-removal step.
 
+\paragraph{Wielandt proof-chain statements.}
+The source proof of the quantum-Wielandt bound uses Lemma~1, eigenvalue
+extraction, vector spreading, and the fixed-length rank-one step as an argument,
+not as separate MPS theorem statements
+\cite[Theorem~1 proof]{Sanz2010Quantum}.  Formal conjunctions that bundle
+these inputs, such as the \emph{Wielandt analysis} and \emph{Wielandt chain}
+declarations, should therefore be lemmas.  The visible theorem is the
+cumulative or fixed-length Wielandt conclusion, with the stronger fixed-length
+claim distinguished from the cumulative span bound.
+
 \paragraph{BNT comparison statements.}
 The source BNT characterization selects one representative from each
 phase-gauge equivalence class and compares the power sums of weights.  The
@@ -78,6 +88,9 @@ permutation rigidity, sector-weight comparison, and phase absorption.  The
 heterogeneous block-matching theorem is a genuine formal endpoint for the
 block-matching part, while the final global weighted gauge equivalence remains
 the paper-level equal-MPV target.
+The overlap-to-linear-independence and change-of-basis declarations are
+linear-algebra support lemmas for the permutation-rigidity theorem, not
+additional BNT theorems from the source.
 
 \section{External lemmas need explanations}
 


### PR DESCRIPTION
## Summary

Addresses part of #1282.

This trims auxiliary theorem surface around the Wielandt and BNT proof chains without changing the mathematical statements:

- demotes `MPSTensor.wielandtAnalysis`, `MPSTensor.vector_spanning_from_normality`, `MPSTensor.isNormal_implies_cumulativeSpan_eq_top'`, and `MPSTensor.wielandt_chain` from `theorem` to `lemma`;
- demotes BNT linear-algebra support declarations from `theorem` to `lemma`: overlap-to-eventual-linear-independence, invertible change of basis, eventual change of basis, and the explicit-threshold overlap lemma;
- changes the corresponding Chapter 7, Chapter 8, and Chapter 10 blueprint entries and references from theorem to lemma form;
- records in `docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex` that these are proof-chain/support statements, while the visible theorem surface should be the cumulative or fixed-length Wielandt conclusion and the BNT permutation/Fundamental-Theorem endpoints.

The point is source hierarchy, not proof strength: arXiv:0909.5347 and the BNT source use these ingredients inside proofs rather than as separate paper-level MPS theorem statements.

## Validation

- `lake env lean TNLean/Wielandt/WielandtBound.lean`
- `lake env lean TNLean/Wielandt/Primitivity/Normal.lean`
- `lake env lean TNLean/MPS/BNT/Basic.lean`
- `lake env lean TNLean/MPS/BNT/Construction.lean`
- `lake env lean TNLean/MPS/BNT/PermutationRigidityPrimitive.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of statement classification (`theorem`→`lemma`) plus documentation/blueprint label updates; no mathematical content or proof logic changes, but downstream references may need renaming or import recompilation.
> 
> **Overview**
> Demotes several *proof-chain/support* declarations from `theorem` to `lemma` in the Wielandt and BNT developments (e.g. `wielandtAnalysis`, `wielandt_chain`, overlap→LI, and change-of-basis helpers), clarifying they are packaging steps rather than headline results.
> 
> Updates the blueprint LaTeX chapters and internal documentation to reflect the lemma/theorem hierarchy (including updated labels/references) and adds a short rationale note in `docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex` about keeping the visible theorem surface focused on the main Wielandt and BNT endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 555170c5d1f4e5bbb9f0f16e8b34dd19cbe5e533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->