### PR TITLE
style(PiAlgebra): demote multi-block packaging lemmas

### DIFF
--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -489,7 +489,7 @@ theorem sameMPV_of_charpoly_eq_all_words
 Under canonical form hypotheses, the summed identity implies per-block SameMPV.
 Requires injectivity of all blocks (used in the core lemma for the spectral gap
 argument). -/
-theorem block_separation_all_words
+lemma block_separation_all_words
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))
@@ -512,7 +512,7 @@ theorem block_separation_all_words
 /-- NT / normal-canonical-form version of `block_separation_all_words`.
 
 Besides irreducibility and left-canonical normalization on both block families,
-this theorem also assumes the self-overlap convergence hypothesis on the
+this lemma also assumes the self-overlap convergence hypothesis on the
 `A`-blocks: `mpvOverlap (A k) (A k) N → 1`.
 
 The proof is the same peeling / induction argument as `block_separation_core`.
@@ -524,7 +524,7 @@ bond-dimension mismatch, and
 `gaugePhaseEquiv_of_mpvOverlap_tendsto_one_of_irreducible_TP` replaces the
 injective equal-dimension overlap-decay contradiction via the irreducible
 modulus-one-eigenvalue-rigidity route. -/
-theorem block_separation_all_words_of_irreducible_TP
+lemma block_separation_all_words_of_irreducible_TP
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))
@@ -591,12 +591,12 @@ private lemma per_block_sameMPV_of_sameMPV₂_of_card_le_one
 
 /-- Additive split version of `per_block_sameMPV_of_canonical_form`.
 
-This theorem isolates exactly the pieces of the canonical-form bundle used in the
+This lemma isolates exactly the pieces of the canonical-form bundle used in the
 block-separation argument: injectivity, left-canonical normalization, strict nonzero weights,
 and self-overlap normalization. The backwards-compatible wrapper below is recovered by
 projection from `IsCanonicalForm`.
 -/
-theorem per_block_sameMPV_of_separated_canonical_data
+lemma per_block_sameMPV_of_separated_canonical_data
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))
     (hWeights : HasStrictOrderedNonzeroWeights μ)
@@ -618,7 +618,7 @@ theorem per_block_sameMPV_of_separated_canonical_data
 /-- Wrapper extracting per-block `SameMPV` from canonical-form data with a strict ordering
 witness. The strict ordering is available at the BNT level (`IsCanonicalFormBNT.mu_strict_anti`)
 but not from the base `IsCanonicalForm` which only guarantees non-increasing moduli. -/
-theorem per_block_sameMPV_of_canonical_form
+lemma per_block_sameMPV_of_canonical_form
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))
     (hA : IsCanonicalForm μ A)
@@ -641,12 +641,12 @@ theorem per_block_sameMPV_of_canonical_form
 This is the analogue of `per_block_sameMPV_of_canonical_form`, replacing
 injective canonical-form blocks by irreducible + primitive + left-canonical
 blocks. The underlying proof uses the same peeling argument as the injective
-canonical-form theorem, but the leading-block identification step uses the
+canonical-form lemma, but the leading-block identification step uses the
 irreducible modulus-one-eigenvalue-rigidity theorem (after separately ruling out
 a bond-dimension mismatch) instead of the injective overlap-decay
 contradiction. Since both block families use the same dimension function, the
 conclusion is the homogeneous predicate `SameMPV`. -/
-theorem per_block_sameMPV_of_normal_canonical_form
+lemma per_block_sameMPV_of_normal_canonical_form
     {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
     (hA : IsNormalCanonicalForm μ A)
     (hStrict : StrictAnti (fun k : Fin r => ‖μ k‖))
@@ -670,7 +670,7 @@ theorem per_block_sameMPV_of_normal_canonical_form
 This is the preferred interface: it only asks for the pieces of canonical-form
 structure actually used by the proof.  The backwards-compatible wrapper below remains available
 around this one. -/
-theorem fundamentalTheorem_of_separated_canonical_data
+lemma fundamentalTheorem_of_separated_canonical_data
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))
     (hWeights : HasStrictOrderedNonzeroWeights μ)
@@ -687,7 +687,7 @@ theorem fundamentalTheorem_of_separated_canonical_data
   exact fundamentalTheorem_multiBlock_full μ A B hA_inj.block_injective hSep
 
 /-- Explicit gauge-matrix version of `fundamentalTheorem_of_separated_canonical_data`. -/
-theorem fundamentalTheorem_of_separated_canonical_data_explicit
+lemma fundamentalTheorem_of_separated_canonical_data_explicit
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))
     (hWeights : HasStrictOrderedNonzeroWeights μ)
@@ -727,7 +727,7 @@ theorem fundamentalTheorem_canonicalForm
 
 /-- Explicit gauge-matrix wrapper around
 `fundamentalTheorem_of_separated_canonical_data_explicit` with strict-ordering witness. -/
-theorem fundamentalTheorem_canonicalForm_explicit
+lemma fundamentalTheorem_canonicalForm_explicit
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))
     (hA : IsCanonicalForm μ A)

--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -8,18 +8,18 @@ import TNLean.PiAlgebra.CanonicalFormSepAux
 # Separated canonical-form hypotheses and block separation
 
 This file proves the core block-separation result from the separated canonical-form hypotheses
-defined in `CanonicalFormSepAux`, and then rebuilds legacy canonical-form wrappers on top.
+defined in `CanonicalFormSepAux`, and then rebuilds legacy canonical-form formulations on top.
 
 ## Main results
 
 - `block_separation_core` — extracts per-block `SameMPV` from a weighted sum identity,
   using the injective-block variant.
 - `block_separation_all_words` / `block_separation_all_words_of_irreducible_TP` — public
-  wrappers around the core induction.
+  formulations of the core induction.
 - `per_block_sameMPV_of_canonical_form` / `per_block_sameMPV_of_normal_canonical_form` —
   block-separation from bundled canonical-form predicates.
 - `fundamentalTheorem_canonicalForm` / `fundamentalTheorem_canonicalForm_explicit` —
-  backwards-compatible wrappers for the MPS fundamental theorem.
+  canonical-form formulations of the MPS fundamental theorem.
 -/
 
 set_option linter.unusedSectionVars false
@@ -593,7 +593,7 @@ private lemma per_block_sameMPV_of_sameMPV₂_of_card_le_one
 
 This lemma isolates exactly the pieces of the canonical-form bundle used in the
 block-separation argument: injectivity, left-canonical normalization, strict nonzero weights,
-and self-overlap normalization. The backwards-compatible wrapper below is recovered by
+and self-overlap normalization. The canonical-form formulation below is recovered by
 projection from `IsCanonicalForm`.
 -/
 lemma per_block_sameMPV_of_separated_canonical_data
@@ -615,8 +615,8 @@ lemma per_block_sameMPV_of_separated_canonical_data
       hA_overlap.overlap_tendsto_one
       (summed_block_difference_eq_zero_of_sameMPV₂ μ A B hSame₂)
 
-/-- Wrapper extracting per-block `SameMPV` from canonical-form data with a strict ordering
-witness. The strict ordering is available at the BNT level (`IsCanonicalFormBNT.mu_strict_anti`)
+/-- Reformulation extracting per-block `SameMPV` from canonical-form data with a strict
+ordering witness. The strict ordering is available at the BNT level (`IsCanonicalFormBNT.mu_strict_anti`)
 but not from the base `IsCanonicalForm` which only guarantees non-increasing moduli. -/
 lemma per_block_sameMPV_of_canonical_form
     (μ : Fin r → ℂ)
@@ -667,8 +667,8 @@ lemma per_block_sameMPV_of_normal_canonical_form
 
 /-- Separated-data variant of `fundamentalTheorem_canonicalForm`.
 
-This is the preferred interface: it only asks for the pieces of canonical-form
-structure actually used by the proof.  The backwards-compatible wrapper below remains available
+This is the preferred formulation: it only asks for the pieces of canonical-form
+structure actually used by the proof. The canonical-form formulation below remains available
 around this one. -/
 lemma fundamentalTheorem_of_separated_canonical_data
     (μ : Fin r → ℂ)
@@ -704,7 +704,7 @@ lemma fundamentalTheorem_of_separated_canonical_data_explicit
     hWeights hA_inj hA_left hA_overlap hB_inj hB_left hSame₂
   exact fundamentalTheorem_multiBlock_explicit A B hA_inj.block_injective hSep
 
-/-- Wrapper around `fundamentalTheorem_of_separated_canonical_data` for canonical-form data
+/-- Reformulation of `fundamentalTheorem_of_separated_canonical_data` for canonical-form data
 with an explicit strict-ordering witness. -/
 theorem fundamentalTheorem_canonicalForm
     (μ : Fin r → ℂ)
@@ -725,7 +725,7 @@ theorem fundamentalTheorem_canonicalForm
     (IsLeftCanonicalBlockFamily.ofForall hB_lc)
     hSame₂
 
-/-- Explicit gauge-matrix wrapper around
+/-- Explicit gauge-matrix reformulation of
 `fundamentalTheorem_of_separated_canonical_data_explicit` with strict-ordering witness. -/
 lemma fundamentalTheorem_canonicalForm_explicit
     (μ : Fin r → ℂ)

--- a/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
+++ b/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
@@ -6,7 +6,7 @@ import TNLean.PiAlgebra.Construction
 import TNLean.MPS.FundamentalTheorem.Multi
 
 /-!
-# End-to-end multi-block Fundamental Theorem from per-block SameMPV
+# Multi-block Fundamental Theorem from per-block SameMPV
 
 This file provides the complete construction from per-block `SameMPV` to:
 - Per-block gauge equivalence
@@ -18,11 +18,11 @@ It also handles the single-block case where `SameMPV₂` directly gives `SameMPV
 ## Main results
 
 * `fundamentalTheorem_multiBlock_full` — multi-block FT with per-block and global gauge
-* `fundamentalTheorem_multiBlock_decomposition` — support lemma exposing block permutation
+* `fundamentalTheorem_multiBlock_decomposition` — auxiliary lemma exposing block permutation
 * `sameMPV₂_single_block` — for `r = 1`, SameMPV₂ gives per-block SameMPV (no PF needed)
 * `fundamentalTheorem_singleBlock_fromMPV₂` — single-block FT from SameMPV₂
-* `fundamentalTheorem_multiBlock_fromSameMPV₂` — end-to-end from SameMPV₂ + separation hyp
-* `perBlock_sameMPV_iff_gaugeEquiv` — support lemma for SameMPV ↔ GaugeEquiv under injectivity
+* `fundamentalTheorem_multiBlock_fromSameMPV₂` — from SameMPV₂ and separation data
+* `perBlock_sameMPV_iff_gaugeEquiv` — auxiliary lemma for SameMPV ↔ GaugeEquiv under injectivity
 
 ## References
 
@@ -129,7 +129,7 @@ theorem fundamentalTheorem_singleBlock_fromMPV₂
 
 end SingleBlockSeparation
 
-/-! ### Compatibility wrappers exposing the `SameMPV₂` + separation interface
+/-! ### Reformulations using `SameMPV₂` and separation data
 
 These lemmas present the complete construction
 `SameMPV₂` → per-block `SameMPV` (via `hSep`) → per-block `GaugeEquiv`
@@ -144,7 +144,7 @@ section EndToEnd
 
 variable {r : ℕ} {dim : Fin r → ℕ}
 
-/-- **Compatibility wrapper for the end-to-end multi-block FT from `SameMPV₂`.**
+/-- **Multi-block FT reformulation from `SameMPV₂` and separation data.**
 
 Starting from `SameMPV₂` on block-diagonal tensors, the per-block separation
 hypothesis (the only piece requiring PF theory) yields:
@@ -152,9 +152,8 @@ hypothesis (the only piece requiring PF theory) yields:
 - Global gauge equivalence of the block-diagonal tensors
 - Block-permutation decomposition of the product algebra automorphism
 
-The `hSame₂` hypothesis is retained so that this lemma continues to present
-the full end-to-end interface, even though the wrapper proof only uses the
-supplied separation data `hSep`. -/
+The `hSame₂` hypothesis is retained to record the full source hypothesis, even though
+the formal implication used below is the supplied separation data `hSep`. -/
 lemma fundamentalTheorem_multiBlock_fromSameMPV₂
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
@@ -175,10 +174,10 @@ lemma fundamentalTheorem_multiBlock_fromSameMPV₂
   let hFull := fundamentalTheorem_multiBlock_full μ A B hA hSep
   exact ⟨hFull.1, hFull.2, piAlgEquiv_decomposition A B hA hSep⟩
 
-/-- **Compatibility wrapper for the explicit-gauge multi-block FT from `SameMPV₂`.**
+/-- **Explicit-gauge reformulation of the multi-block FT from `SameMPV₂`.**
 
-As above, `hSame₂` is kept for interface compatibility, while the wrapper proof
-itself only uses `hSep`. -/
+As above, `hSame₂` is kept to record the source hypothesis, while the formal implication
+used below is `hSep`. -/
 lemma fundamentalTheorem_multiBlock_explicit_fromSameMPV₂
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
+++ b/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
@@ -17,12 +17,12 @@ It also handles the single-block case where `SameMPV₂` directly gives `SameMPV
 
 ## Main results
 
-* `fundamentalTheorem_multiBlock_full` — full multi-block FT with per-block + global gauge
-* `fundamentalTheorem_multiBlock_decomposition` — version with block-permutation decomposition
+* `fundamentalTheorem_multiBlock_full` — multi-block FT with per-block and global gauge
+* `fundamentalTheorem_multiBlock_decomposition` — support lemma exposing block permutation
 * `sameMPV₂_single_block` — for `r = 1`, SameMPV₂ gives per-block SameMPV (no PF needed)
 * `fundamentalTheorem_singleBlock_fromMPV₂` — single-block FT from SameMPV₂
 * `fundamentalTheorem_multiBlock_fromSameMPV₂` — end-to-end from SameMPV₂ + separation hyp
-* `perBlock_sameMPV_iff_gaugeEquiv` — SameMPV ↔ GaugeEquiv under injectivity
+* `perBlock_sameMPV_iff_gaugeEquiv` — support lemma for SameMPV ↔ GaugeEquiv under injectivity
 
 ## References
 
@@ -56,8 +56,8 @@ theorem fundamentalTheorem_multiBlock_full
   ⟨fundamentalTheorem_multiBlock_blocks A B hA hSame,
     fundamentalTheorem_multiBlock_global μ A B hA hSame⟩
 
-/-- **Multi-block FT with explicit gauge matrices.** -/
-theorem fundamentalTheorem_multiBlock_explicit
+/-- Extract explicit per-block gauge matrices from the blockwise theorem. -/
+lemma fundamentalTheorem_multiBlock_explicit
     (A B : (k : Fin r) → MPSTensor d (dim k))
     (hA : ∀ k, IsInjective (A k))
     (hSame : ∀ k, SameMPV (A k) (B k)) :
@@ -68,8 +68,8 @@ theorem fundamentalTheorem_multiBlock_explicit
   let hGauge := fundamentalTheorem_multiBlock_blocks A B hA hSame
   exact ⟨fun k => (hGauge k).choose, fun k => (hGauge k).choose_spec⟩
 
-/-- **Multi-block FT with decomposition.** -/
-theorem fundamentalTheorem_multiBlock_decomposition
+/-- Decompose the product-algebra automorphism attached to per-block `SameMPV` data. -/
+lemma fundamentalTheorem_multiBlock_decomposition
     [∀ k, NeZero (dim k)]
     (A B : (k : Fin r) → MPSTensor d (dim k))
     (hA : ∀ k, IsInjective (A k))
@@ -101,7 +101,7 @@ variable {dim₀ : ℕ}
 
 /-- For a single block, `SameMPV₂` on the block-diagonal tensor gives `SameMPV` on the block
     tensor, provided the scaling factor is nonzero. -/
-theorem sameMPV₂_single_block
+lemma sameMPV₂_single_block
     (μ₀ : ℂ) (hμ : μ₀ ≠ 0)
     (A₀ B₀ : MPSTensor d dim₀)
     (hSame₂ : SameMPV₂
@@ -131,7 +131,7 @@ end SingleBlockSeparation
 
 /-! ### Compatibility wrappers exposing the `SameMPV₂` + separation interface
 
-These theorems present the complete construction
+These lemmas present the complete construction
 `SameMPV₂` → per-block `SameMPV` (via `hSep`) → per-block `GaugeEquiv`
 → global `GaugeEquiv` → block-permutation decomposition.
 
@@ -152,10 +152,10 @@ hypothesis (the only piece requiring PF theory) yields:
 - Global gauge equivalence of the block-diagonal tensors
 - Block-permutation decomposition of the product algebra automorphism
 
-The `hSame₂` hypothesis is retained so that this theorem continues to present
+The `hSame₂` hypothesis is retained so that this lemma continues to present
 the full end-to-end interface, even though the wrapper proof only uses the
 supplied separation data `hSep`. -/
-theorem fundamentalTheorem_multiBlock_fromSameMPV₂
+lemma fundamentalTheorem_multiBlock_fromSameMPV₂
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))
@@ -179,7 +179,7 @@ theorem fundamentalTheorem_multiBlock_fromSameMPV₂
 
 As above, `hSame₂` is kept for interface compatibility, while the wrapper proof
 itself only uses `hSep`. -/
-theorem fundamentalTheorem_multiBlock_explicit_fromSameMPV₂
+lemma fundamentalTheorem_multiBlock_explicit_fromSameMPV₂
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))
     (hA : ∀ k, IsInjective (A k))
@@ -203,7 +203,7 @@ variable {r : ℕ} {dim : Fin r → ℕ}
 This is the clean reformulation of the single-block Fundamental Theorem applied blockwise:
 the hypothesis that each block `A_k` generates the same MPV family as `B_k` is equivalent to
 the conclusion that they are related by per-block gauge transforms. -/
-theorem perBlock_sameMPV_iff_gaugeEquiv
+lemma perBlock_sameMPV_iff_gaugeEquiv
     (A B : (k : Fin r) → MPSTensor d (dim k))
     (hA : ∀ k, IsInjective (A k)) :
     (∀ k, SameMPV (A k) (B k)) ↔ (∀ k, GaugeEquiv (A k) (B k)) :=
@@ -211,7 +211,7 @@ theorem perBlock_sameMPV_iff_gaugeEquiv
    fun hGauge k => (hGauge k).sameMPV⟩
 
 /-- Global `SameMPV` follows from per-block `SameMPV` for block-diagonal tensors. -/
-theorem global_sameMPV_of_perBlock
+lemma global_sameMPV_of_perBlock
     (μ : Fin r → ℂ) (A B : (k : Fin r) → MPSTensor d (dim k))
     (hSame : ∀ k, SameMPV (A k) (B k)) :
     SameMPV (toTensorFromBlocks μ A) (toTensorFromBlocks μ B) :=

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -483,7 +483,7 @@ We use this notation throughout the block-separation argument.
     $\mu_0^N$, the induction hypothesis applies.
 \end{proof}
 
-\begin{theorem}[Block separation from canonical form]\label{thm:block_sep}
+\begin{lemma}[Block separation from canonical form]\label{lem:block_sep}
     \lean{MPSTensor.per_block_sameMPV_of_canonical_form}
     \leanok
     \uses{def:is_canonical_form}
@@ -494,7 +494,7 @@ We use this notation throughout the block-separation argument.
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
     generate the same MPV family, then each pair
     $(A_k, B_k)$ generates the same MPV family.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
@@ -511,7 +511,7 @@ We use this notation throughout the block-separation argument.
     TP normalization.
 \end{proof}
 
-\begin{theorem}[Block separation from normal canonical form]\label{thm:block_sep_normal}
+\begin{lemma}[Block separation from normal canonical form]\label{lem:block_sep_normal}
     \lean{MPSTensor.per_block_sameMPV_of_normal_canonical_form}\leanok
     \uses{def:is_normal_canonical_form}
     Let $((\mu_k), (A_k))$ satisfy the normal canonical form conditions,
@@ -521,11 +521,11 @@ We use this notation throughout the block-separation argument.
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
     generate the same MPV family, then each pair
     $(A_k, B_k)$ generates the same MPV family.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
-    \uses{thm:ncf_overlap_tendsto_one, thm:nt_modulus_one_gauge, thm:block_sep}
-    The proof follows the same peeling argument as Theorem~\ref{thm:block_sep},
+    \uses{thm:ncf_overlap_tendsto_one, thm:nt_modulus_one_gauge, lem:block_sep}
+    The proof follows the same peeling argument as Lemma~\ref{lem:block_sep},
     with Theorem~\ref{thm:nt_modulus_one_gauge} (modulus-one eigenvalue rigidity
     for irreducible tensors) replacing the injective overlap-decay argument at
     the identification step, since the blocks are irreducible rather than
@@ -540,7 +540,7 @@ We use this notation throughout the block-separation argument.
     \lean{MPSTensor.fundamentalTheorem_canonicalForm}
     \leanok
     \uses{def:is_canonical_form, def:gauge_equiv, def:tensor_from_blocks}
-    Under the hypotheses of Theorem~\ref{thm:block_sep}, each pair
+    Under the hypotheses of Lemma~\ref{lem:block_sep}, each pair
     $(A_k, B_k)$ is gauge equivalent. Hence the block-diagonal tensors
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
     are gauge equivalent.
@@ -548,8 +548,8 @@ We use this notation throughout the block-separation argument.
 
 \begin{proof}
     \leanok
-    \uses{thm:block_sep, thm:per_block_gauge}
-    Theorem~\ref{thm:block_sep} gives per-block same MPV.
+    \uses{lem:block_sep, thm:per_block_gauge}
+    Lemma~\ref{lem:block_sep} gives per-block same MPV.
     Theorem~\ref{thm:per_block_gauge} then converts this to
     per-block gauge equivalence and then to global gauge equivalence
     of the block-diagonal tensors.

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1228,7 +1228,7 @@ which is then combined with overlap estimates and the leading-block peel.
     \label{lem:fundamentalTheorem_canonicalForm_explicit}
     \lean{MPSTensor.fundamentalTheorem_canonicalForm_explicit}
     \leanok
-    \uses{thm:fundamentalTheorem_canonicalForm}
+    \uses{lem:fundamentalTheorem_of_separated_canonical_data_explicit}
     Under the same hypotheses, there exist invertible matrices
     $X_k \in \GL_{D_k}(\C)$ such that
     $B_k^i = X_k\, A_k^i\, X_k^{-1}$
@@ -1236,9 +1236,9 @@ which is then combined with overlap estimates and the leading-block peel.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{thm:fundamentalTheorem_canonicalForm}
-    Extract the gauge matrices from
-    Theorem~\ref{thm:fundamentalTheorem_canonicalForm} by choice.
+    \uses{lem:fundamentalTheorem_of_separated_canonical_data_explicit}
+    Apply Lemma~\ref{lem:fundamentalTheorem_of_separated_canonical_data_explicit}
+    with the strict-ordering data extracted from the canonical form.
 \end{proof}
 
 %% ---------------------------------------------------------

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -953,8 +953,8 @@ decomposition.
     the block-diagonal structure.
 \end{proof}
 
-\begin{theorem}[Explicit per-block gauges]%
-    \label{thm:fundamentalTheorem_multiBlock_explicit}
+\begin{lemma}[Explicit per-block gauges]%
+    \label{lem:fundamentalTheorem_multiBlock_explicit}
     \lean{MPSTensor.fundamentalTheorem_multiBlock_explicit}
     \leanok
     \uses{thm:fundamentalTheorem_multiBlock_full}
@@ -965,7 +965,7 @@ decomposition.
         B_k^i = X_k\, A_k^i\, X_k^{-1}
     \]
     for every block $k$ and every physical index $i$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
@@ -974,8 +974,8 @@ decomposition.
     Theorem~\ref{thm:fundamentalTheorem_multiBlock_full} for each block.
 \end{proof}
 
-\begin{theorem}[Product-algebra decomposition of the multi-block theorem]%
-    \label{thm:fundamentalTheorem_multiBlock_decomposition}
+\begin{lemma}[Product-algebra decomposition of the multi-block theorem]%
+    \label{lem:fundamentalTheorem_multiBlock_decomposition}
     \lean{MPSTensor.fundamentalTheorem_multiBlock_decomposition}
     \leanok
     \uses{thm:fundamentalTheorem_multiBlock_full}
@@ -988,7 +988,7 @@ decomposition.
     equalities, and invertible matrices $X_k$ such that, after reindexing the
     target block $\sigma(k)$ back to block $k$, the action on the $k$th matrix
     block is $M \mapsto X_k M X_k^{-1}$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
@@ -997,15 +997,15 @@ decomposition.
     automorphism built from the per-block linear extensions.
 \end{proof}
 
-\begin{theorem}[Per-block equality of MPV families and per-block gauge equivalence]%
-    \label{thm:perBlock_sameMPV_iff_gaugeEquiv}
+\begin{lemma}[Per-block equality of MPV families and per-block gauge equivalence]%
+    \label{lem:perBlock_sameMPV_iff_gaugeEquiv}
     \lean{MPSTensor.perBlock_sameMPV_iff_gaugeEquiv}
     \leanok
     \uses{def:injective, def:same_mpv, def:gauge_equiv}
     Let $\{A_k\}$ be a family of injective block tensors.
     Then $\mc{V}(A_k) = \mc{V}(B_k)$ for all~$k$ if and only if
     $A_k$ and $B_k$ are gauge equivalent for all~$k$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok\uses{def:gauge_equiv}
     The forward direction is the single-block Fundamental Theorem applied
@@ -1062,8 +1062,8 @@ which is then combined with overlap estimates and the leading-block peel.
     \emph{primitive} (the transfer map has spectral gap).
 \end{definition}
 
-\begin{theorem}[Block separation from weighted word identities]%
-    \label{thm:block_separation_all_words}
+\begin{lemma}[Block separation from weighted word identities]%
+    \label{lem:block_separation_all_words}
     \lean{MPSTensor.block_separation_all_words}
     \leanok
     \uses{def:same_mpv}
@@ -1076,7 +1076,7 @@ which is then combined with overlap estimates and the leading-block peel.
         \sum_k \mu_k^N \bigl(V^{(N)}(A_k)_\sigma - V^{(N)}(B_k)_\sigma\bigr)=0.
     \]
     Then $\mc{V}(A_k)=\mc{V}(B_k)$ for every block $k$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
@@ -1086,8 +1086,8 @@ which is then combined with overlap estimates and the leading-block peel.
     weight, and one then iterates on the remaining blocks.
 \end{proof}
 
-\begin{theorem}[Block separation from canonical form]%
-    \label{thm:per_block_sameMPV_of_canonical_form}
+\begin{lemma}[Block separation from canonical form]%
+    \label{lem:per_block_sameMPV_of_canonical_form}
     \lean{MPSTensor.per_block_sameMPV_of_canonical_form}
     \leanok
     \uses{def:isCanonicalForm, def:same_mpv}
@@ -1100,7 +1100,7 @@ which is then combined with overlap estimates and the leading-block peel.
     The proof isolates the leading block and treats the remaining blocks
     as an exponentially decaying tail with
     $\rho = |\mu_1|/|\mu_0| < 1$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
@@ -1137,8 +1137,8 @@ which is then combined with overlap estimates and the leading-block peel.
     yields $\mc{V}(A_k) = \mc{V}(B_k)$ for all remaining $k$.
 \end{proof}
 
-\begin{theorem}[Block separation from separated canonical data]%
-    \label{thm:per_block_sameMPV_of_separated_canonical_data}
+\begin{lemma}[Block separation from separated canonical data]%
+    \label{lem:per_block_sameMPV_of_separated_canonical_data}
     \lean{MPSTensor.per_block_sameMPV_of_separated_canonical_data}
     \leanok
     \uses{def:same_mpv}
@@ -1147,59 +1147,59 @@ which is then combined with overlap estimates and the leading-block peel.
     the $B$-blocks are injective and left-canonical, and the assembled
     block-diagonal tensors generate the same MPV family.
     Then $\mc{V}(A_k)=\mc{V}(B_k)$ for every block $k$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
-    \uses{thm:block_separation_all_words}
+    \uses{lem:block_separation_all_words}
     Equality of the assembled MPV families gives the weighted word identity
-    required by Theorem~\ref{thm:block_separation_all_words}.
+    required by Lemma~\ref{lem:block_separation_all_words}.
     The separated hypotheses supply exactly the injectivity,
     left-canonicality, strict-weight, and self-overlap assumptions needed
     there.
 \end{proof}
 
-\begin{theorem}[Fundamental Theorem from separated canonical data]%
-    \label{thm:fundamentalTheorem_of_separated_canonical_data}
+\begin{lemma}[Fundamental Theorem from separated canonical data]%
+    \label{lem:fundamentalTheorem_of_separated_canonical_data}
     \lean{MPSTensor.fundamentalTheorem_of_separated_canonical_data}
     \leanok
-    \uses{thm:per_block_sameMPV_of_separated_canonical_data}
+    \uses{lem:per_block_sameMPV_of_separated_canonical_data}
     Under the hypotheses of
-    Theorem~\ref{thm:per_block_sameMPV_of_separated_canonical_data}, every
+    Lemma~\ref{lem:per_block_sameMPV_of_separated_canonical_data}, every
     block pair $A_k,B_k$ is gauge equivalent, and the assembled block-diagonal
     tensors are globally gauge equivalent.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
-    \uses{thm:per_block_sameMPV_of_separated_canonical_data,
+    \uses{lem:per_block_sameMPV_of_separated_canonical_data,
         thm:fundamentalTheorem_multiBlock_full}
     First apply
-    Theorem~\ref{thm:per_block_sameMPV_of_separated_canonical_data} to get
+    Lemma~\ref{lem:per_block_sameMPV_of_separated_canonical_data} to get
     $\mc{V}(A_k)=\mc{V}(B_k)$ blockwise.
     Then apply
     Theorem~\ref{thm:fundamentalTheorem_multiBlock_full}.
 \end{proof}
 
-\begin{theorem}[Explicit gauge from separated canonical data]%
-    \label{thm:fundamentalTheorem_of_separated_canonical_data_explicit}
+\begin{lemma}[Explicit gauge from separated canonical data]%
+    \label{lem:fundamentalTheorem_of_separated_canonical_data_explicit}
     \lean{MPSTensor.fundamentalTheorem_of_separated_canonical_data_explicit}
     \leanok
-    \uses{thm:fundamentalTheorem_of_separated_canonical_data}
+    \uses{lem:fundamentalTheorem_of_separated_canonical_data}
     Under the same hypotheses, there exist invertible matrices
     $X_k \in \GL_{D_k}(\C)$ such that
     \[
         B_k^i = X_k\, A_k^i\, X_k^{-1}
     \]
     for every block $k$ and physical index $i$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
-    \uses{thm:per_block_sameMPV_of_separated_canonical_data,
-        thm:fundamentalTheorem_multiBlock_explicit}
+    \uses{lem:per_block_sameMPV_of_separated_canonical_data,
+        lem:fundamentalTheorem_multiBlock_explicit}
     Combine blockwise MPV equality from
-    Theorem~\ref{thm:per_block_sameMPV_of_separated_canonical_data} with the
+    Lemma~\ref{lem:per_block_sameMPV_of_separated_canonical_data} with the
     explicit-gauge form of the multi-block Fundamental Theorem.
 \end{proof}
 
@@ -1207,25 +1207,25 @@ which is then combined with overlap estimates and the leading-block peel.
     \label{thm:fundamentalTheorem_canonicalForm}
     \lean{MPSTensor.fundamentalTheorem_canonicalForm}
     \leanok
-    \uses{thm:per_block_sameMPV_of_canonical_form,
+    \uses{lem:per_block_sameMPV_of_canonical_form,
         thm:fundamentalTheorem_multiBlock_full}
     Under the hypotheses of
-    Theorem~\ref{thm:per_block_sameMPV_of_canonical_form},
+    Lemma~\ref{lem:per_block_sameMPV_of_canonical_form},
     every block pair $A_k, B_k$ is gauge equivalent, and the
     block-diagonal tensors are globally gauge equivalent.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:per_block_sameMPV_of_canonical_form,
+    \uses{lem:per_block_sameMPV_of_canonical_form,
         thm:fundamentalTheorem_multiBlock_full}
-    Theorem~\ref{thm:per_block_sameMPV_of_canonical_form} gives per-block
+    Lemma~\ref{lem:per_block_sameMPV_of_canonical_form} gives per-block
     $\mc{V}(A_k) = \mc{V}(B_k)$.
     Theorem~\ref{thm:fundamentalTheorem_multiBlock_full} converts this
     to per-block and global gauge equivalence.
 \end{proof}
 
-\begin{theorem}[Explicit gauge from canonical form]%
-    \label{thm:fundamentalTheorem_canonicalForm_explicit}
+\begin{lemma}[Explicit gauge from canonical form]%
+    \label{lem:fundamentalTheorem_canonicalForm_explicit}
     \lean{MPSTensor.fundamentalTheorem_canonicalForm_explicit}
     \leanok
     \uses{thm:fundamentalTheorem_canonicalForm}
@@ -1233,7 +1233,7 @@ which is then combined with overlap estimates and the leading-block peel.
     $X_k \in \GL_{D_k}(\C)$ such that
     $B_k^i = X_k\, A_k^i\, X_k^{-1}$
     for every block $k$ and physical index $i$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
     \uses{thm:fundamentalTheorem_canonicalForm}


### PR DESCRIPTION
### Motivation
- The ch13 algebraic Fundamental Theorem section in arXiv:1606.00608 has a narrow theorem/corollary surface; several Lean declarations in `PiAlgebra/` were mis-classified as `theorem` even though they serve as proof-packaging steps rather than source-level endpoints (see #1316).
- The corresponding blueprint environments used `thm:*` labels for these packaging results, creating a mismatch between the blueprint and the paper's stated theorem surface.
- Part of the broader theorem-surface and source-faithfulness cleanup tracked in #1282 and #1170.

### Description
- In `TNLean/PiAlgebra/CanonicalFormSep.lean`: demoted block-separation wrappers and separated-canonical-data packaging results from `theorem` to `lemma`.
- In `TNLean/PiAlgebra/FundamentalTheoremComplete.lean`: demoted multi-block explicit-gauge extraction, product-algebra decomposition wrappers, per-block equivalence helpers, and `SameMPV₂`/gauge-equivalence support results from `theorem` to `lemma`; the canonical-form Fundamental Theorem endpoint remains `theorem`-level.
- In `blueprint/src/chapter/ch09_block_perm.tex` and `ch13_algebraic_ft.tex`: updated duplicate block-separation entries and multi-block section environments to use `lem:*` labels where declarations were demoted, synchronizing blueprint environments with updated Lean keywords.

### Testing
- `lake env lean TNLean/PiAlgebra/FundamentalTheoremComplete.lean`
- `lake env lean TNLean/PiAlgebra/CanonicalFormSep.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web`
- `git diff --check`

---
Closes #1316

> [!NOTE]
> **Low Risk**
> Low risk: changes are largely declaration-kind and documentation updates (switching `theorem` → `lemma`), with no substantive proof/logic modifications expected beyond potential downstream name/reference adjustments.
>
> **Overview**
> Demotes several proof-packaging results in `CanonicalFormSep.lean` and `FundamentalTheoremComplete.lean` from `theorem` to `lemma` (e.g., block-separation wrappers, separated-canonical-data wrappers, multi-block explicit/decomposition helpers, and `SameMPV₂`/gauge equivalence support lemmas), keeping the core canonical-form FT endpoint as a `theorem`.
>
> Synchronizes the LaTeX blueprint (`ch09_block_perm.tex`, `ch13_algebraic_ft.tex`) to match the updated lemma/theorem status and cross-references (`thm:*` → `lem:*`).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b4682752df666cd006430ec7bd40240410b8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are mostly `theorem`→`lemma` reclassifications and blueprint label updates, with no substantive proof/logic changes expected aside from downstream reference adjustments.
> 
> **Overview**
> **Reclassifies several proof-packaging declarations from `theorem` to `lemma`** in the separated canonical-form/block-separation and multi-block Fundamental Theorem files (e.g. block-separation wrappers, separated-canonical-data FT formulations, explicit-gauge/decomposition helpers, and `SameMPV₂` support lemmas), while keeping the main canonical-form FT endpoint as a `theorem`.
> 
> **Synchronizes the LaTeX blueprint** by switching the corresponding environments/labels and cross-references from `thm:*` to `lem:*` to match the updated Lean declaration kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a39a6736f02a8718efbfc293ebcc47ca86ff3dfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->