### PR TITLE
style(MPS/CanonicalForm): demote phase-cover span helpers

### DIFF
--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -88,8 +88,8 @@ end MPVBlockPhaseEquiv
 The data consist of the finite common family, the class maps from the two block
 families to it, the MPV-phase equivalences between each block and its chosen
 common block, and surjectivity of both class maps.  These are the paper-level
-data needed by the span comparison theorem; constructing them from the full
-structural `SameMPV₂` data is a separate comparison theorem. -/
+data needed by the span comparison result; constructing them from the full
+structural `SameMPV₂` data is a separate comparison step. -/
 structure MPVCommonPhaseCover {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
@@ -218,7 +218,7 @@ lemma mpv_span_eq_of_surjective_phase_cover {r rC : ℕ}
 /-- Two block families with a common surjective MPV-phase quotient have equal finite-length
 MPV spans.
 
-This theorem is deliberately independent of the sector weights.  It states the precise
+This lemma is deliberately independent of the sector weights.  It states the precise
 linear-algebra hypothesis used by the nonzero-part after-blocking theorem once a common-blocking
 result supplies a common representative family and shows that both sides cover it. -/
 lemma mpv_span_eq_of_common_phase_cover {rA rB rC : ℕ}
@@ -383,7 +383,7 @@ lemma nonempty_mpvCommonPhaseCover_of_equiv_phase
 /-- A BNT proportional-decomposition conclusion gives finite-length MPV span equality.
 
 The conclusion is obtained by taking the left family as the common MPV phase-cover family and
-then applying the common-cover span theorem. -/
+then applying the common-cover span lemma. -/
 lemma mpv_span_eq_of_proportionalDecompositionConclusion
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
@@ -414,7 +414,7 @@ lemma mpv_span_eq_of_equiv_phase
 phase cover.
 
 The proof uses the BNT comparison theorem to obtain a permutation and gauge phases between the
-basis blocks; applying the proportional-decomposition cover theorem to that matching yields the
+basis blocks; applying the proportional-decomposition cover lemma to that matching yields the
 common MPV phase cover. It does not use a finite-length span equality hypothesis. -/
 lemma nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -436,7 +436,7 @@ lemma nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
 /-- Separated normal canonical-form data give finite-length MPV span equality.
 
 The BNT comparison theorem gives a proportional-decomposition conclusion, hence a common
-MPV phase cover, and the common-cover theorem gives equality of the two block-family spans. -/
+MPV phase cover, and the common-cover span lemma gives equality of the two block-family spans. -/
 lemma mpv_span_eq_of_separated_normalCFBNT_data
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -160,7 +160,7 @@ lemma MPVPhaseEquiv.exists_mpvState_eq_smul {r : ℕ} {dim : Fin r → ℕ}
 For each block in `blocksA`, choose a block in `blocksB` whose MPV state differs only by a
 nonzero scalar power. Then, at every finite length, the MPV span of `blocksA` is contained in
 the MPV span of `blocksB`. -/
-theorem mpv_span_le_of_phase_cover {rA rB : ℕ}
+lemma mpv_span_le_of_phase_cover {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
     (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
@@ -179,7 +179,7 @@ theorem mpv_span_le_of_phase_cover {rA rB : ℕ}
   simpa [hstate] using hmem
 
 /-- Mutual MPV-phase covers give equality of finite-length block MPV spans. -/
-theorem mpv_span_eq_of_mutual_phase_cover {rA rB : ℕ}
+lemma mpv_span_eq_of_mutual_phase_cover {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
     (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
@@ -196,7 +196,7 @@ theorem mpv_span_eq_of_mutual_phase_cover {rA rB : ℕ}
 
 This is the abstract span step used after a common nonzero-weight block theorem identifies a
 representative family and shows that every block maps onto it up to MPV phase. -/
-theorem mpv_span_eq_of_surjective_phase_cover {r rC : ℕ}
+lemma mpv_span_eq_of_surjective_phase_cover {r rC : ℕ}
     {dim : Fin r → ℕ} {dimC : Fin rC → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k))
     (common : (c : Fin rC) → MPSTensor d (dimC c))
@@ -221,7 +221,7 @@ MPV spans.
 This theorem is deliberately independent of the sector weights.  It states the precise
 linear-algebra hypothesis used by the nonzero-part after-blocking theorem once a common-blocking
 result supplies a common representative family and shows that both sides cover it. -/
-theorem mpv_span_eq_of_common_phase_cover {rA rB rC : ℕ}
+lemma mpv_span_eq_of_common_phase_cover {rA rB rC : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ} {dimC : Fin rC → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
     (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
@@ -248,7 +248,7 @@ variable {blocksA : (j : Fin rA) → MPSTensor d (dimA j)}
 variable {blocksB : (k : Fin rB) → MPSTensor d (dimB k)}
 
 /-- A common cover gives equality of the finite-length block MPV spans. -/
-theorem span_eq (C : MPVCommonPhaseCover blocksA blocksB) (N : ℕ) :
+lemma span_eq (C : MPVCommonPhaseCover blocksA blocksB) (N : ℕ) :
     Submodule.span ℂ (Set.range (fun j : Fin rA => mpvState (d := d) (blocksA j) N)) =
     Submodule.span ℂ (Set.range (fun k : Fin rB => mpvState (d := d) (blocksB k) N)) :=
   mpv_span_eq_of_common_phase_cover (d := d) blocksA blocksB C.common
@@ -293,7 +293,7 @@ def commonPhaseCover (M : SectorBasisPreMatching P Q) :
 
 /-- A sector-basis pre-matching gives equality of finite-length MPV spans of the two basis
 families. -/
-theorem span_eq (M : SectorBasisPreMatching P Q) (N : ℕ) :
+lemma span_eq (M : SectorBasisPreMatching P Q) (N : ℕ) :
     Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
       mpvState (d := d) (P.basis j) N)) =
     Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
@@ -302,7 +302,7 @@ theorem span_eq (M : SectorBasisPreMatching P Q) (N : ℕ) :
 
 /-- A sector-basis pre-matching establishes the finite-length span equality needed by the
 primitive overlap-span hypotheses. -/
-theorem to_overlapSpan (M : SectorBasisPreMatching P Q)
+lemma to_overlapSpan (M : SectorBasisPreMatching P Q)
     (HP : SectorBasisOverlapOrthoHypotheses P)
     (HQ : SectorBasisOverlapOrthoHypotheses Q)
     (hP_inj : ∀ j : Fin P.basisCount, IsInjective (P.basis j))
@@ -313,7 +313,7 @@ theorem to_overlapSpan (M : SectorBasisPreMatching P Q)
 end SectorBasisPreMatching
 
 /-- A proportional-decomposition BNT comparison conclusion produces a common MPV phase cover. -/
-theorem nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
+lemma nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
     (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
@@ -350,7 +350,7 @@ theorem nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion
 This is the direct implication used when a comparison theorem has already identified
 the phase classes by a bijection, without restating the data as a proportional
 decomposition conclusion. -/
-theorem nonempty_mpvCommonPhaseCover_of_equiv_phase
+lemma nonempty_mpvCommonPhaseCover_of_equiv_phase
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
     (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
@@ -384,7 +384,7 @@ theorem nonempty_mpvCommonPhaseCover_of_equiv_phase
 
 The conclusion is obtained by taking the left family as the common MPV phase-cover family and
 then applying the common-cover span theorem. -/
-theorem mpv_span_eq_of_proportionalDecompositionConclusion
+lemma mpv_span_eq_of_proportionalDecompositionConclusion
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
     (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
@@ -397,7 +397,7 @@ theorem mpv_span_eq_of_proportionalDecompositionConclusion
   exact cover.span_eq N
 
 /-- A bijective MPV-phase matching gives finite-length MPV span equality. -/
-theorem mpv_span_eq_of_equiv_phase
+lemma mpv_span_eq_of_equiv_phase
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
     (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
@@ -416,7 +416,7 @@ phase cover.
 The proof uses the BNT comparison theorem to obtain a permutation and gauge phases between the
 basis blocks; applying the proportional-decomposition cover theorem to that matching yields the
 common MPV phase cover. It does not use a finite-length span equality hypothesis. -/
-theorem nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
+lemma nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
     {DtotA DtotB : ℕ} {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
@@ -437,7 +437,7 @@ theorem nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
 
 The BNT comparison theorem gives a proportional-decomposition conclusion, hence a common
 MPV phase cover, and the common-cover theorem gives equality of the two block-family spans. -/
-theorem mpv_span_eq_of_separated_normalCFBNT_data
+lemma mpv_span_eq_of_separated_normalCFBNT_data
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
     {DtotA DtotB : ℕ} {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -210,7 +210,7 @@ used in this chapter.
 	      thm:mpv_decomposition,
 	      lem:route_b_equal_with_copies,
 	      thm:afterBlocking_sectorComparison_reindexed_bntCover,
-	      thm:common_phase_cover_of_proportional_decomposition}
+	      lem:common_phase_cover_of_proportional_decomposition}
 	The comparison proceeds directly from equality of the full MPV families.
 	Theorem~\ref{thm:mpv_decomposition} expands the two canonical-form tensors in
 	their BNT bases, and the sector-multiplicity comparison of
@@ -226,7 +226,7 @@ used in this chapter.
 	after-blocking comparison theorem
 	(Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover}) gives the
 	matched sector-weight conclusion once BNT-cover comparison data are supplied.
-	Theorem~\ref{thm:common_phase_cover_of_proportional_decomposition} explains
+	Lemma~\ref{lem:common_phase_cover_of_proportional_decomposition} explains
 	how proportional block comparisons supply common phases.  Completing this
 	theorem therefore amounts to deriving the BNT-cover and sector-weight data for
 	the canonical decompositions produced from the bare equality assumption.  Once
@@ -780,8 +780,8 @@ facts used to recover the lists of weights from those power sums.
 	the pre-matching.
 \end{proof}
 
-\begin{theorem}[Pre-matching supplies primitive overlap-span hypotheses]%
-\label{thm:sector_basis_pre_matching_to_overlap_span}
+\begin{lemma}[Pre-matching supplies primitive overlap-span hypotheses]%
+\label{lem:sector_basis_pre_matching_to_overlap_span}
 	\lean{MPSTensor.SectorBasisPreMatching.to_overlapSpan}
 	\leanok
 	\uses{def:sector_basis_pre_matching, def:sector_basis_overlap_ortho_hyps,
@@ -790,7 +790,7 @@ facts used to recover the lists of weights from those power sums.
 	basis blocks are one-site injective, then a sector basis pre-matching between
 	them establishes the finite-length span equality and hence the full primitive
 	overlap-span hypotheses.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -801,15 +801,15 @@ facts used to recover the lists of weights from those power sums.
 	Lemma~\ref{lem:sector_basis_overlap_ortho_to_span}.
 \end{proof}
 
-\begin{theorem}[Common phase cover from a BNT proportional-decomposition conclusion]%
-\label{thm:common_phase_cover_of_proportional_decomposition}
+\begin{lemma}[Common phase cover from a BNT proportional-decomposition conclusion]%
+\label{lem:common_phase_cover_of_proportional_decomposition}
 	\lean{MPSTensor.nonempty_mpvCommonPhaseCover_of_proportionalDecompositionConclusion}
 	\leanok
 	\uses{def:mpv_common_phase_cover}
 	If a BNT proportional-decomposition comparison has produced a permutation of
 	the two basis families together with matched bond dimensions and gauge-phase
 	equivalences, then the two basis families have a common MPV phase cover.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -819,15 +819,15 @@ facts used to recover the lists of weights from those power sums.
 	the required MPV-phase equivalence.
 \end{proof}
 
-\begin{theorem}[Common phase cover from a bijective phase matching]%
-\label{thm:common_phase_cover_of_equiv_phase}
+\begin{lemma}[Common phase cover from a bijective phase matching]%
+\label{lem:common_phase_cover_of_equiv_phase}
 	\lean{MPSTensor.nonempty_mpvCommonPhaseCover_of_equiv_phase}
 	\leanok
 	\uses{def:mpv_common_phase_cover, def:mpv_block_phase_equiv}
 	If two block families are matched by a bijection and corresponding blocks have
 	the same matrix product vectors up to a nonzero scalar power depending on the
 	length, then the two families have a common MPV phase cover.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -836,33 +836,33 @@ facts used to recover the lists of weights from those power sums.
 	family's phase data.
 \end{proof}
 
-\begin{theorem}[Span equality from proportional-decomposition data]%
-\label{thm:nonzero_block_span_eq_of_proportional_decomposition}
+\begin{lemma}[Span equality from proportional-decomposition data]%
+\label{lem:nonzero_block_span_eq_of_proportional_decomposition}
 	\lean{MPSTensor.mpv_span_eq_of_proportionalDecompositionConclusion}
 	\leanok
-	\uses{thm:common_phase_cover_of_proportional_decomposition,
+	\uses{lem:common_phase_cover_of_proportional_decomposition,
 		lem:mpv_common_phase_cover_span_eq}
 	A BNT proportional-decomposition comparison gives equality, for every system
 	size, of the finite-length MPV spans of the two nonzero-weight block families.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_phase_cover_of_proportional_decomposition,
+	\uses{lem:common_phase_cover_of_proportional_decomposition,
 		lem:mpv_common_phase_cover_span_eq}
 	First form the common MPV phase cover from the proportional-decomposition
 	comparison. The common-cover span lemma then gives the stated span equality.
 \end{proof}
 
-\begin{theorem}[Span equality from a bijective phase matching]%
-\label{thm:nonzero_block_span_eq_of_equiv_phase}
+\begin{lemma}[Span equality from a bijective phase matching]%
+\label{lem:nonzero_block_span_eq_of_equiv_phase}
 	\lean{MPSTensor.mpv_span_eq_of_equiv_phase}
 	\leanok
-	\uses{thm:common_phase_cover_of_equiv_phase,
+	\uses{lem:common_phase_cover_of_equiv_phase,
 		lem:mpv_common_phase_cover_span_eq}
 	A bijective phase matching gives equality, for every system size, of the
 	finite-length MPV spans of the two block families.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -907,15 +907,15 @@ facts used to recover the lists of weights from those power sums.
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_phase_cover_of_proportional_decomposition,
+	\uses{lem:common_phase_cover_of_proportional_decomposition,
 		thm:bnt_sectorDecomp_pair_overlapSpan_of_commonPhaseCover}
 	First turn the proportional-decomposition data into common MPV phase-cover data.
 	The preceding theorem then converts that cover into the overlap-span hypotheses
 	for the constructed sector bases.
 \end{proof}
 
-\begin{theorem}[Separated normal canonical-form data produce a common phase cover]%
-\label{thm:common_phase_cover_of_separated_normal_bnt}
+\begin{lemma}[Separated normal canonical-form data produce a common phase cover]%
+\label{lem:common_phase_cover_of_separated_normal_bnt}
 	\lean{MPSTensor.nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data}
 	\leanok
 	\uses{def:mpv_common_phase_cover, def:is_normal_canonical_form,
@@ -925,33 +925,33 @@ facts used to recover the lists of weights from those power sums.
 	limits are nonzero give a common MPV phase cover of the two basis families.
 	This is the BNT route to the cover data; it does not assume equality of
 	finite-length spans.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_phase_cover_of_proportional_decomposition,
+	\uses{lem:common_phase_cover_of_proportional_decomposition,
 		thm:bnt_perm_prop_nt}
 	The irreducible trace-preserving BNT permutation theorem gives the permutation
 	matching the basis blocks, bond-dimension equalities, and gauge-phase
-	equivalences. Applying the previous theorem to that conclusion yields the
+	equivalences. Applying the previous lemma to that conclusion yields the
 	common phase cover data.
 \end{proof}
 
-\begin{theorem}[Separated normal canonical-form data give nonzero-block span equality]%
-\label{thm:separated_normal_bnt_span_eq}
+\begin{lemma}[Separated normal canonical-form data give nonzero-block span equality]%
+\label{lem:separated_normal_bnt_span_eq}
 	\lean{MPSTensor.mpv_span_eq_of_separated_normalCFBNT_data}
 	\leanok
-	\uses{thm:common_phase_cover_of_separated_normal_bnt,
+	\uses{lem:common_phase_cover_of_separated_normal_bnt,
 		lem:mpv_common_phase_cover_span_eq}
 	For two separated normal canonical-form block families as in
-	Theorem~\ref{thm:common_phase_cover_of_separated_normal_bnt}, the BNT
+	Lemma~\ref{lem:common_phase_cover_of_separated_normal_bnt}, the BNT
 	comparison data imply equality, at every system size, of the finite-length
 	MPV spans of the two basis families.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_phase_cover_of_separated_normal_bnt,
+	\uses{lem:common_phase_cover_of_separated_normal_bnt,
 		lem:mpv_common_phase_cover_span_eq}
 	The separated normal-form comparison first gives a common MPV phase cover.
 	Applying the common-cover span lemma to that cover gives the span equality.
@@ -1287,7 +1287,7 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	\leanok
 	\uses{def:common_primitive_proportional_hypotheses,
 		def:common_primitive_phase_cover_hypotheses,
-		thm:common_phase_cover_of_proportional_decomposition}
+		lem:common_phase_cover_of_proportional_decomposition}
 	If two common primitive nonzero-sector families satisfy the proportional-comparison
 	hypotheses, then they satisfy the phase-cover hypotheses of
 	Definition~\ref{def:common_primitive_phase_cover_hypotheses}.
@@ -1295,10 +1295,10 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_phase_cover_of_proportional_decomposition}
+	\uses{lem:common_phase_cover_of_proportional_decomposition}
 	The zero-tail equality and injectivity assumptions are already present. The BNT
 	proportional-decomposition comparison gives a common MPV phase cover by
-	Theorem~\ref{thm:common_phase_cover_of_proportional_decomposition}.
+	Lemma~\ref{lem:common_phase_cover_of_proportional_decomposition}.
 \end{proof}
 
 \begin{lemma}[Proportional comparison implies span hypotheses]%
@@ -1359,10 +1359,10 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_phase_cover_of_separated_normal_bnt}
+	\uses{lem:common_phase_cover_of_separated_normal_bnt}
 	The normal canonical-form data, gauge-phase separation, and proportional
 	decomposition are exactly the hypotheses of
-	Theorem~\ref{thm:common_phase_cover_of_separated_normal_bnt}.
+	Lemma~\ref{lem:common_phase_cover_of_separated_normal_bnt}.
 \end{proof}
 
 \begin{lemma}[BNT-cover hypotheses imply phase-cover hypotheses]%
@@ -1624,13 +1624,13 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	\leanok
 	\uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed,
 		lem:mpv_common_phase_cover_span_eq,
-		thm:nonzero_block_span_eq_of_proportional_decomposition}
+		lem:nonzero_block_span_eq_of_proportional_decomposition}
 	Apply
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	to obtain the common-sector decompositions.  The implication from a common MPV
 	phase cover is Lemma~\ref{lem:mpv_common_phase_cover_span_eq}; the implication
 	from proportional-decomposition data is
-	Theorem~\ref{thm:nonzero_block_span_eq_of_proportional_decomposition}.
+	Lemma~\ref{lem:nonzero_block_span_eq_of_proportional_decomposition}.
 \end{proof}
 
 \begin{theorem}[Unconditional common primitive block decompositions]%
@@ -1896,10 +1896,10 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	Lemma~\ref{lem:mpv_common_phase_cover_span_eq}.  A sector basis pre-matching
 	gives the same span equality and the primitive overlap-span hypotheses by
 	Lemma~\ref{lem:sector_basis_pre_matching_span_eq} and
-	Theorem~\ref{thm:sector_basis_pre_matching_to_overlap_span}.  The BNT comparison
-	theorems produce such common phases from a proportional-decomposition conclusion in
-	Theorems~\ref{thm:common_phase_cover_of_proportional_decomposition}
-	and~\ref{thm:common_phase_cover_of_separated_normal_bnt}.  These common-cover
+	Lemma~\ref{lem:sector_basis_pre_matching_to_overlap_span}.  The BNT comparison
+	lemmas produce such common phases from a proportional-decomposition conclusion in
+	Lemmas~\ref{lem:common_phase_cover_of_proportional_decomposition}
+	and~\ref{lem:common_phase_cover_of_separated_normal_bnt}.  These common-cover
 	facts are not a separate form of the source theorem; they are used only to
 	obtain the finite-length span equality required by the sector comparison.
 


### PR DESCRIPTION
### Motivation

Supports #1282 and #1170.

The phase-cover span transport layer is a support package for the after-blocking comparison, not a source-facing theorem layer. This PR reduces the theorem surface while preserving the paper-facing endpoints.

### Description

- Demote phase-cover/span transport declarations in `TNLean/MPS/CanonicalForm/PhaseCover.lean` from theorem-level to lemma-level.
- Synchronize the Chapter 11 blueprint environments and labels for the same support layer.
- Leave the paper-facing sector-comparison and overlap-span endpoints theorem-level.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/PhaseCover.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

### Automation Note

The live build, blueprint compile, file-length, and Cursor Bugbot checks are green at head `ea7da00183eca40a49b4ade9103cf71efa07ed4a`. The failing `blueprint-and-prose` and `claude-review` checks are automation/quota failures, so this body and labels were applied manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a non-functional change that primarily reclassifies several Lean declarations from `theorem` to `lemma` and updates blueprint labels/references accordingly, without altering proofs or core logic.
> 
> **Overview**
> Demotes the MPV phase-cover/span transport results in `PhaseCover.lean` from `theorem` to `lemma` (e.g. span inclusion/equality helpers, `MPVCommonPhaseCover.span_eq`, and cover constructors), reducing the exported “theorem surface” while keeping statements/proofs the same.
> 
> Synchronizes Chapter 11 blueprint LaTeX to match: converts the corresponding environments/labels from *theorem* to *lemma* and updates all `\uses{}` and cross-references (`thm:` → `lem:`) to keep documentation consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc83ebeb476d9c53ba7e82f7491bdd2f7c80b3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->