### PR TITLE
docs(MPS/CanonicalForm): clarify zero-tail convention

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
@@ -10,14 +10,15 @@ open Filter
 /-!
 # Zero-tail comparison for nonzero block tensors
 
-When two matrix-product-vector families are written as a zero-tail contribution
-plus a weighted nonzero block tensor, equality at positive lengths compares the
-nonzero parts directly. The length-zero equation records the residual
-zero-tail contribution, and full equality of the nonzero parts follows once the
-zero tails agree.
+When two matrix-product-vector families are written as a leftover all-zero-block
+contribution plus a weighted nonzero block tensor, equality at positive lengths
+compares the nonzero parts directly. The length-zero equation records the
+residual all-zero-block contribution, and full equality of the nonzero parts
+follows once the leftover dimensions agree.
 
-Here "zero-tail" is the total bond dimension of the separated all-zero leftover
-blocks.  It is the dimension gap allowed by `∑ k, D_k ≤ D`, where the block
+Here "zero-tail" is only the formal variable name for the total bond dimension of
+the separated all-zero leftover blocks. It is the dimension gap allowed by `∑ k, D_k ≤ D`,
+where the block
 decomposition may include zero blocks.
 
 ## References
@@ -36,14 +37,14 @@ variable {d D : ℕ}
 
 /-- **Zero-tail identity for nonzero block tensors.**
 
-Suppose two tensors with the same MPV family are each written as a zero-tail
+Suppose two tensors with the same MPV family are each written as an all-zero-block
 contribution plus a weighted nonzero block tensor. Then the nonzero parts agree at every
 positive length, while the length-zero equation gives exactly the difference
-between the zero-tail dimensions and the nonzero block bond dimensions.
+between the leftover all-zero-block dimensions and the nonzero block bond dimensions.
 
 This is the local length-zero identity needed before a full `SameMPV₂` comparison of the
 nonzero block tensors can be recovered: the only missing datum is equality of the
-two zero-tail dimensions (or an equivalent replacement for the `N = 0` case). -/
+two leftover all-zero-block dimensions (or an equivalent replacement for the `N = 0` case). -/
 theorem nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
     {d D₁ D₂ rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -88,10 +89,10 @@ theorem nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
 
 /-- **Reblocked nonzero-block equality with a zero-tail identity.**
 
-If two tensors have the same MPVs and each is expressed as a zero tail plus a
+If two tensors have the same MPVs and each is expressed as a leftover all-zero block plus a
 weighted nonzero block tensor, then every positive common reblocking transports the
 nonzero weights to powers, preserves positive-length equality of the nonzero parts,
-and leaves the zero-tail contribution as the sole length-zero term. -/
+and leaves the all-zero-block contribution as the sole length-zero term. -/
 theorem nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
     {d D₁ D₂ rA rB p : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -147,12 +148,12 @@ theorem nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sam
       hAblock hBblock
   exact ⟨fun N hN σ => hBook.1 hN σ, hBook.2⟩
 
-/-- **Recover full nonzero-block `SameMPV₂` once zero tails agree.**
+/-- **Recover full nonzero-block `SameMPV₂` once leftover all-zero blocks agree.**
 
 This combines the positive-length theorem with the single additional
-length-zero datum needed to remove the zero tails. It does not assert that the
-zero-tail dimensions agree automatically; that remains a separate paper-level
-length-zero condition for the unconditional after-blocking sector comparison. -/
+length-zero datum needed to remove the leftover all-zero blocks. It does not assert that the
+leftover dimensions agree automatically; that remains a separate paper-level length-zero
+condition for the unconditional after-blocking sector comparison. -/
 theorem nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq
     {d D₁ D₂ rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
@@ -16,9 +16,8 @@ compares the nonzero parts directly. The length-zero equation records the
 residual all-zero-block contribution, and full equality of the nonzero parts
 follows once the leftover dimensions agree.
 
-Here "zero-tail" is only the formal variable name for the total bond dimension of
-the separated all-zero leftover blocks. It is the dimension gap allowed by `∑ k, D_k ≤ D`,
-where the block
+Here "zero-tail" names the total bond dimension of the separated all-zero leftover
+blocks. It is the dimension gap allowed by `∑ k, D_k ≤ D`, where the block
 decomposition may include zero blocks.
 
 ## References

--- a/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean
@@ -10,10 +10,10 @@ open Filter
 /-!
 # Zero-tail comparison for nonzero block tensors
 
-When two matrix-product-vector families are written as a leftover all-zero-block
+When two matrix-product-vector families are written as an all-zero leftover block
 contribution plus a weighted nonzero block tensor, equality at positive lengths
 compares the nonzero parts directly. The length-zero equation records the
-residual all-zero-block contribution, and full equality of the nonzero parts
+residual all-zero leftover block contribution, and full equality of the nonzero parts
 follows once the leftover dimensions agree.
 
 Here "zero-tail" names the total bond dimension of the separated all-zero leftover
@@ -36,14 +36,14 @@ variable {d D : ℕ}
 
 /-- **Zero-tail identity for nonzero block tensors.**
 
-Suppose two tensors with the same MPV family are each written as an all-zero-block
+Suppose two tensors with the same MPV family are each written as an all-zero leftover block
 contribution plus a weighted nonzero block tensor. Then the nonzero parts agree at every
 positive length, while the length-zero equation gives exactly the difference
-between the leftover all-zero-block dimensions and the nonzero block bond dimensions.
+between the all-zero leftover block dimensions and the nonzero block bond dimensions.
 
 This is the local length-zero identity needed before a full `SameMPV₂` comparison of the
 nonzero block tensors can be recovered: the only missing datum is equality of the
-two leftover all-zero-block dimensions (or an equivalent replacement for the `N = 0` case). -/
+two all-zero leftover block dimensions (or an equivalent replacement for the `N = 0` case). -/
 theorem nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
     {d D₁ D₂ rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -88,10 +88,10 @@ theorem nonzeroBlock_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
 
 /-- **Reblocked nonzero-block equality with a zero-tail identity.**
 
-If two tensors have the same MPVs and each is expressed as a leftover all-zero block plus a
+If two tensors have the same MPVs and each is expressed as an all-zero leftover block plus a
 weighted nonzero block tensor, then every positive common reblocking transports the
 nonzero weights to powers, preserves positive-length equality of the nonzero parts,
-and leaves the all-zero-block contribution as the sole length-zero term. -/
+and leaves the all-zero leftover block contribution as the sole length-zero term. -/
 theorem nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sameMPV₂
     {d D₁ D₂ rA rB p : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -147,10 +147,10 @@ theorem nonzeroBlock_blockPower_positive_sameMPV₂_and_zeroTail_identity_of_sam
       hAblock hBblock
   exact ⟨fun N hN σ => hBook.1 hN σ, hBook.2⟩
 
-/-- **Recover full nonzero-block `SameMPV₂` once leftover all-zero blocks agree.**
+/-- **Recover full nonzero-block `SameMPV₂` once all-zero leftover blocks agree.**
 
 This combines the positive-length theorem with the single additional
-length-zero datum needed to remove the leftover all-zero blocks. It does not assert that the
+length-zero datum needed to remove the all-zero leftover blocks. It does not assert that the
 leftover dimensions agree automatically; that remains a separate paper-level length-zero
 condition for the unconditional after-blocking sector comparison. -/
 theorem nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq

--- a/TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean
@@ -19,7 +19,7 @@ all-zero leftover blocks, corresponding to the source-paper allowance
 
 namespace MPSTensor
 
-/-! ## Zero-tail and weight transport through blocking -/
+/-! ## All-zero-block and weight transport through blocking -/
 
 /-- Reblocking preserves an all-zero-block/nonzero-part MPV decomposition.
 
@@ -102,7 +102,7 @@ lemma zeroTail_eq_of_sameMPV₂
     _ = mpv (zeroMPSTensor d z) σ + mpv flat σ := by
       rw [hFlat N σ]
 
-/-- At positive lengths, a zero-tail decomposition reduces to the nonzero part. -/
+/-- At positive lengths, an all-zero-block decomposition reduces to the nonzero part. -/
 lemma sameMPV₂Pos_of_zeroTail_eq
     {d D L z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
     (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),
@@ -117,12 +117,12 @@ lemma sameMPV₂Pos_of_zeroTail_eq
     _ = mpv live σ := by
       rw [hZero, zero_add]
 
-/-- Remove matching zero tails from two MPV identities.
+/-- Remove matching all-zero-block contributions from two MPV identities.
 
-If `A` and `B` have the same MPVs, and each is expressed as a zero tail plus a nonzero part,
-then equality of the zero-tail dimensions gives full `SameMPV₂` equality of the nonzero parts.
-For positive lengths the zero tails vanish; at length zero this is exactly the missing
-zero-tail condition. -/
+If `A` and `B` have the same MPVs, and each is expressed as a leftover all-zero block plus a
+nonzero part, then equality of the leftover block dimensions gives full `SameMPV₂` equality of
+the nonzero parts. For positive lengths the all-zero blocks vanish; at length zero this is
+exactly the missing dimension condition. -/
 lemma sameMPV₂_live_of_sameMPV₂_with_zeroTail_eq
     {d D₁ D₂ L₁ L₂ z₁ z₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -425,7 +425,7 @@ private theorem mpv_eq_dim_at_zero (A : MPSTensor d' D') (σ : Fin 0 → Fin d')
 Every MPS tensor `A : MPSTensor d D` admits an irreducible block decomposition that is
 faithfully partitioned into:
 
-* a **zero tail** of dimension `zeroTailDim` (accumulating all-zero irreducible blocks), and
+* an **all-zero leftover block** of bond dimension `zeroTailDim`, and
 * a family of **nonzero blocks** `blocks k : MPSTensor d (dim k)` for `k : Fin r`, each with at
   least one nonzero Kraus operator, positive bond dimension, and irreducibility.
 
@@ -434,10 +434,10 @@ The MPV relationship is:
   `mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ + mpv (toTensorFromBlocks μ≡1 blocks) σ`
 
 which at `N = 0` reduces to `D = zeroTailDim + ∑ k, dim k` and at `N > 0` reduces to
-`mpv A σ = mpv (toTensorFromBlocks μ≡1 blocks) σ` (zero tail vanishes).
+`mpv A σ = mpv (toTensorFromBlocks μ≡1 blocks) σ` (the all-zero block vanishes).
 
-This separation is **exact**: the zero tail is not silently discarded, and the length-zero
-identity is preserved. -/
+This separation is **exact**: the leftover all-zero block is not silently discarded, and the
+length-zero identity is preserved. -/
 theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
       (blocks : (k : Fin r) → MPSTensor d (dim k)),

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -434,9 +434,9 @@ The MPV relationship is:
   `mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ + mpv (toTensorFromBlocks μ≡1 blocks) σ`
 
 which at `N = 0` reduces to `D = zeroTailDim + ∑ k, dim k` and at `N > 0` reduces to
-`mpv A σ = mpv (toTensorFromBlocks μ≡1 blocks) σ` (the all-zero block vanishes).
+`mpv A σ = mpv (toTensorFromBlocks μ≡1 blocks) σ` (the all-zero leftover block vanishes).
 
-This separation is **exact**: the leftover all-zero block is not silently discarded, and the
+This separation is **exact**: the all-zero leftover block is not silently discarded, and the
 length-zero identity is preserved. -/
 theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -263,7 +263,7 @@ This section composes the zero-block separation from `Existence.lean` with the
 blockwise Perron–Frobenius / TP-gauge theorem `exists_tp_gauge_blockwise`, producing an
 arbitrary-input result: from any `A : MPSTensor d D`, we obtain:
 
-* a zero-tail dimension `zeroTailDim` (accumulating all-zero irreducible blocks), and
+* an all-zero leftover block of bond dimension `zeroTailDim`, and
 * a TP-gauged family of irreducible blocks with nonzero weights.
 
 The MPV relationship accounts exactly for both contributions:
@@ -279,7 +279,7 @@ the cyclic-sector and equal-weight arguments.
 1606.00608 Section 2.3 and Appendix A, with zero-block separation.
 
 From any `A : MPSTensor d D`, produce:
-* a zero-tail of dimension `zeroTailDim` accumulating all-zero irreducible blocks;
+* an all-zero leftover block of bond dimension `zeroTailDim`;
 * TP-gauged irreducible blocks `blocks k` with nonzero weights `μ k`.
 
 Every nonzero block satisfies:
@@ -288,7 +288,7 @@ Every nonzero block satisfies:
 * positive bond dimension;
 * nonzero weight.
 
-The MPV of `A` equals the zero-tail contribution plus the weighted nonzero-block sum. -/
+The MPV of `A` equals the all-zero-block contribution plus the weighted nonzero-block sum. -/
 theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
       (μ : Fin r → ℂ)


### PR DESCRIPTION
### Motivation

Closes #1323.
Supports #1170, #1278, and #1282.

The formal name `zeroTail` was understandable only after reading the code. The paper-facing object is the leftover all-zero block allowed by the inequality `sum_k D_k <= D`; this PR makes that convention explicit and keeps the terminology aligned with the source.

### Description

- Clarify that formal `zeroTail` variables are source-faithful shorthand for leftover all-zero block dimensions.
- Update canonical-form and after-blocking docstrings to prefer the paper-facing language of all-zero leftover blocks.
- Make the Chapter 11 proportional-comparison statement display the all-zero block `0_{d^[p],D_0}` instead of introducing a bare zero-tail tensor.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ZeroTailTransport.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/NonzeroBlockComparison.lean`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

### Automation Note

The live build, blueprint compile, file-length, and Cursor Bugbot checks are green at head `7710ba0b0e9a9517035d738d1b96e52e2c7cc499`. The failing `blueprint-and-prose` and `claude-review` checks are automation/quota failures, so this body and labels were applied manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that rename/clarify the meaning of `zeroTail` as the bond dimension of leftover all-zero blocks; no proofs or definitions are modified.
> 
> **Overview**
> Clarifies canonical-form documentation to align the formal `zeroTail` variables with the *paper-facing* concept of a leftover **all-zero block** allowed by `∑ k, D_k ≤ D`.
> 
> Updates module/theorem docstrings in `Existence.lean`, `Assembly/ZeroTailTransport.lean`, `Assembly/NonzeroBlockComparison.lean`, and `NormalReduction/TPGauge.lean` to consistently describe length-zero vs positive-length behavior in terms of this leftover all-zero contribution, without changing any Lean statements or proof code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 062e90311cece6680840ec5c2de12847fbbcf08d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->