### PR TITLE
style(MPS/CanonicalForm): demote cyclic transport helpers

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
@@ -184,13 +184,13 @@ noncomputable def commonFlatWeight (F : CommonBlockedCyclicSectorFamily blocks)
 This named form gives the per-block weight transport used before flattening;
 `commonFlatWeight_ne_zero` is the corresponding statement after passing to flattened
 sector indices. -/
-theorem commonBlockWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonBlockWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) (k : Fin r) :
     (μ k) ^ F.p ≠ 0 :=
   pow_ne_zero F.p (hμ k)
 
 /-- Flattened sector weights remain nonzero after common blocking. -/
-theorem commonFlatWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonFlatWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0)
     (x : Fin (∑ k : Fin r, F.period k)) : F.commonFlatWeight μ x ≠ 0 :=
   pow_ne_zero F.p (hμ (F.flatKey x).1)
@@ -237,14 +237,14 @@ private theorem commonSectorBlock_structural (F : CommonBlockedCyclicSectorFamil
     simpa [commonSectorBlock] using hcast
 
 /-- Derived common-alphabet sectors are trace-preserving. -/
-theorem commonSectorBlock_tp (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonSectorBlock_tp (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :
     ∑ i : Fin (blockPhysDim d F.p),
       (F.commonSectorBlock k s i)ᴴ * F.commonSectorBlock k s i = 1 :=
   (commonSectorBlock_structural F k s).1
 
 /-- Derived common-alphabet sectors have primitive transfer maps. -/
-theorem commonSectorBlock_primitive (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonSectorBlock_primitive (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :
     _root_.IsPrimitive
       (transferMap (d := blockPhysDim d F.p) (D := F.sectorDim k s)
@@ -252,17 +252,17 @@ theorem commonSectorBlock_primitive (F : CommonBlockedCyclicSectorFamily blocks)
   (commonSectorBlock_structural F k s).2.1
 
 /-- Derived common-alphabet sectors are tensor-irreducible. -/
-theorem commonSectorBlock_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonSectorBlock_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) : IsIrreducibleTensor (F.commonSectorBlock k s) :=
   (commonSectorBlock_structural F k s).2.2
 
 /-- Derived common-alphabet sectors have positive bond dimensions. -/
-theorem commonSectorBlock_dim_pos (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonSectorBlock_dim_pos (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) : 0 < F.sectorDim k s :=
   F.sector_dim_pos k s
 
 /-- The derived flattened common-sector family is trace-preserving. -/
-theorem commonFlatBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonFlatBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
     (x : Fin (∑ k : Fin r, F.period k)) :
     ∑ i : Fin (blockPhysDim d F.p),
       (F.commonFlatBlocks x i)ᴴ * F.commonFlatBlocks x i = 1 := by
@@ -270,7 +270,7 @@ theorem commonFlatBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
   simpa [commonFlatBlocks, commonFlatDim, y] using F.commonSectorBlock_tp y.1 y.2
 
 /-- The derived flattened common-sector family has primitive transfer maps. -/
-theorem commonFlatBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonFlatBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
     (x : Fin (∑ k : Fin r, F.period k)) :
     _root_.IsPrimitive
       (transferMap (d := blockPhysDim d F.p) (D := F.commonFlatDim x)
@@ -279,20 +279,20 @@ theorem commonFlatBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
   simpa [commonFlatBlocks, commonFlatDim, y] using F.commonSectorBlock_primitive y.1 y.2
 
 /-- The derived flattened common-sector family is tensor-irreducible. -/
-theorem commonFlatBlocks_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonFlatBlocks_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
     (x : Fin (∑ k : Fin r, F.period k)) : IsIrreducibleTensor (F.commonFlatBlocks x) := by
   let y := F.flatKey x
   simpa [commonFlatBlocks, commonFlatDim, y] using F.commonSectorBlock_irreducible y.1 y.2
 
 /-- The derived flattened common-sector family has positive bond dimensions. -/
-theorem commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
     (x : Fin (∑ k : Fin r, F.period k)) : 0 < F.commonFlatDim x := by
   let y := F.flatKey x
   simpa [commonFlatDim, y] using F.commonSectorBlock_dim_pos y.1 y.2
 
 /-- A common blocked cyclic-sector family is a normal canonical form once its
 transported flat weights are sorted by strictly decreasing modulus. -/
-theorem isNormalCanonicalForm_commonFlatBlocks
+lemma isNormalCanonicalForm_commonFlatBlocks
     (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ)
     (hμ : ∀ k, μ k ≠ 0)
@@ -313,7 +313,7 @@ theorem isNormalCanonicalForm_commonFlatBlocks
 
 /-- The derived flattened common-sector family is a normal canonical form when
 expressed at a prescribed common blocking length. -/
-theorem isNormalCanonicalForm_commonFlatBlocksAt
+lemma isNormalCanonicalForm_commonFlatBlocksAt
     (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p')
     (μ : Fin r → ℂ)
@@ -327,7 +327,7 @@ theorem isNormalCanonicalForm_commonFlatBlocksAt
     F.isNormalCanonicalForm_commonFlatBlocks μ hμ hAnti
 
 /-- Iterated blocking of a nonzero-weight block is the relabeled common block. -/
-theorem nestedBlock_sameMPV₂_commonReindexedBlock
+lemma nestedBlock_sameMPV₂_commonReindexedBlock
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     SameMPV₂
       (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
@@ -343,7 +343,7 @@ theorem nestedBlock_sameMPV₂_commonReindexedBlock
       (blockTensor (d := d) (D := dim k) (blocks k) (F.period k * F.extra k)))).2 h
 
 /-- A relabeled nonzero-weight block is represented by its common-alphabet cyclic sectors. -/
-theorem commonReindexedBlock_sameMPV₂_commonSectorTensor
+lemma commonReindexedBlock_sameMPV₂_commonSectorTensor
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     SameMPV₂ (F.commonReindexedBlock k) (F.commonSectorTensor k) := by
   intro N σ
@@ -357,7 +357,7 @@ theorem commonReindexedBlock_sameMPV₂_commonSectorTensor
       simpa [commonSectorTensor, commonSectorBlock] using F.nested_same k N σ
 
 /-- Weighted nonzero blocks with explicit relabelings flatten to the common-sector family. -/
-theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
+lemma sameMPV₂_weightedCommonReindexedBlock_commonFlat
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
     SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)
@@ -416,7 +416,7 @@ def groupedBlockCastAgrees (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin
 order-preserving cast from the common blocked alphabet gives the corresponding direct
 blocked index.  This isolates the remaining point as a comparison between the `Fin.cast`
 identification and the canonical direct/iterated blocking equivalence. -/
-theorem groupedBlockCastAgrees_iff_iteratedBlockIndex_cast
+lemma groupedBlockCastAgrees_iff_iteratedBlockIndex_cast
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     F.groupedBlockCastAgrees k ↔
       ∀ i : Fin (blockPhysDim d F.p),
@@ -456,7 +456,7 @@ private lemma Nat.div_pow_mod_pow_block (x d m j t : ℕ) (ht : t < m) :
 
 /-- Flattening the explicit length-`n` blocked decoding of a length-`m*n` index agrees with
 the direct length-`m*n` decoding. -/
-theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
+lemma flattenWordOfBlock_cast_eq {d m n p : ℕ}
     (hp_eq : p = m * n) (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
     (i : Fin (blockPhysDim d p)) :
     flattenBlockedWord d m
@@ -476,7 +476,7 @@ theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
 
 /-- The global grouping-cast hypothesis applied to a specific family reduces to the
 core Fintype-level assertion. -/
-theorem groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+lemma groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
     {d : ℕ} (h_flatten : ∀ {m n p : ℕ} (_ : p = m * n)
       (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
       (i : Fin (blockPhysDim d p)),
@@ -513,7 +513,7 @@ theorem groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
 /-- The blocked-word comparison follows if the canonical identification from the common
 alphabet to an iterated alphabet agrees with the grouping map that reads a direct word in
 consecutive blocks of length $m_k$ (the period of block $k$). -/
-theorem wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees
+lemma wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hCast : F.groupedBlockCastAgrees k) :
     ∀ i : Fin (blockPhysDim d F.p),
@@ -544,7 +544,7 @@ one original block gives the corresponding block obtained through iterated block
 
 The hypothesis compares the word read from the common block alphabet with the word
 read after first viewing the same index as an iterated block and then flattening it. -/
-theorem blockTensor_eq_commonReindexedBlock_of_word_eq
+lemma blockTensor_eq_commonReindexedBlock_of_word_eq
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hWord : ∀ i : Fin (blockPhysDim d F.p),
       wordOfBlock d F.p i =
@@ -559,7 +559,7 @@ theorem blockTensor_eq_commonReindexedBlock_of_word_eq
 /-- Direct blocking of one original block is the relabeled common block when the
 canonical identification with the iterated alphabet agrees with consecutive grouping of the
 direct word. -/
-theorem blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees
+lemma blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hCast : F.groupedBlockCastAgrees k) :
     blockTensor (d := d) (D := dim k) (blocks k) F.p = F.commonReindexedBlock k :=
@@ -568,7 +568,7 @@ theorem blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees
 
 /-- Direct blocking of one original block has the same MPV family as the block obtained
 through iterated blocking, whenever the associated blocked-word decodings agree. -/
-theorem blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq
+lemma blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hWord : ∀ i : Fin (blockPhysDim d F.p),
       wordOfBlock d F.p i =
@@ -583,7 +583,7 @@ theorem blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq
 
 /-- Direct and iterated common blocking of one original block have the same MPV family
 when the canonical identification with the iterated alphabet agrees with consecutive grouping. -/
-theorem blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees
+lemma blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hCast : F.groupedBlockCastAgrees k) :
     SameMPV₂
@@ -594,7 +594,7 @@ theorem blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees
   rfl
 
 /-- Blockwise MPV comparisons assemble over the weighted direct sum after common blocking. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise
+lemma sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hBlock : ∀ k : Fin r,
       SameMPV₂
@@ -625,7 +625,7 @@ theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise
 
 /-- Agreement of blocked-word decodings assembles the weighted direct sum obtained by
 blocking the original nonzero blocks with the one obtained through iterated blocking. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq
+lemma sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hWord : ∀ (k : Fin r) (i : Fin (blockPhysDim d F.p)),
       wordOfBlock d F.p i =
@@ -644,7 +644,7 @@ theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_word_eq
 /-- Agreement between the canonical identifications and the consecutive grouping maps assembles
 the weighted direct sum obtained by direct blocking with the one obtained through iterated
 blocking. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees
+lemma sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
     SameMPV₂
@@ -658,7 +658,7 @@ theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCa
 
 /-- If every original block has the same MPV family after direct blocking as after
 iterated blocking, then the weighted nonzero part agrees with the derived common-sector family. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise
+lemma sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hBlock : ∀ k : Fin r,
       SameMPV₂
@@ -676,7 +676,7 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise
 
 /-- Agreement of blocked-word decodings identifies the directly blocked weighted
 nonzero part with the derived common-sector family. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq
+lemma sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hWord : ∀ (k : Fin r) (i : Fin (blockPhysDim d F.p)),
       wordOfBlock d F.p i =
@@ -694,7 +694,7 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_word_eq
 
 /-- Agreement between the canonical identifications and the consecutive grouping maps identifies
 the directly blocked weighted nonzero part with the derived common-sector family. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_groupedBlockCastAgrees
+lemma sameMPV₂_weightedCanonicalBlock_commonFlat_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
     SameMPV₂
@@ -712,7 +712,7 @@ blocks, then the weighted nonzero part agrees with the derived common-sector fam
 The hypothesis isolates the remaining equality after relabeling blocked physical
 words by `iteratedBlockIndex`; the canonical blocked tensor uses the ambient blocked
 alphabet directly. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
+lemma sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hRelabel : SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)
@@ -731,7 +731,7 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
     (F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ)
 
 /-- The preceding comparison expressed at a prescribed common length. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed
+lemma sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     {p' : ℕ} (hp : F.p = p')
     (hRelabel : SameMPV₂

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
@@ -38,7 +38,7 @@ noncomputable def commonRepresentativeWeight (F : CommonBlockedCyclicSectorFamil
   fun k => (μ k) ^ F.p
 
 /-- Representative weights agree with flattened weights at the chosen representatives. -/
-theorem commonRepresentativeWeight_apply (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonRepresentativeWeight_apply (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ) (k : Fin r) :
     F.commonRepresentativeWeight μ k =
       F.commonFlatWeight μ (F.flatRepresentativeIndex k) := by
@@ -46,14 +46,14 @@ theorem commonRepresentativeWeight_apply (F : CommonBlockedCyclicSectorFamily bl
     commonFlatWeight, flatKey]
 
 /-- Representative weights remain nonzero after common blocking. -/
-theorem commonRepresentativeWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonRepresentativeWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) (k : Fin r) :
     F.commonRepresentativeWeight μ k ≠ 0 :=
   F.commonBlockWeight_ne_zero μ hμ k
 
 /-- Strict ordering by weight norm is preserved when passing to representative
 common-sector weights. -/
-theorem commonRepresentativeWeight_strictAnti_of_weight_strictAnti
+lemma commonRepresentativeWeight_strictAnti_of_weight_strictAnti
     (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ)
     (hAnti : StrictAnti (fun k : Fin r => ‖μ k‖)) :
@@ -64,7 +64,7 @@ theorem commonRepresentativeWeight_strictAnti_of_weight_strictAnti
   simpa [commonRepresentativeWeight, norm_pow] using hpow
 
 /-- The representative common-sector family is trace-preserving. -/
-theorem commonRepresentativeBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonRepresentativeBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) :
     ∑ i : Fin (blockPhysDim d F.p),
       (F.commonRepresentativeBlocks k i)ᴴ * F.commonRepresentativeBlocks k i = 1 := by
@@ -72,7 +72,7 @@ theorem commonRepresentativeBlocks_tp (F : CommonBlockedCyclicSectorFamily block
     F.commonSectorBlock_tp k ⟨0, F.period_pos k⟩
 
 /-- The representative common-sector family has primitive transfer maps. -/
-theorem commonRepresentativeBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonRepresentativeBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) :
     _root_.IsPrimitive
       (transferMap (d := blockPhysDim d F.p) (D := F.commonRepresentativeDim k)
@@ -81,14 +81,14 @@ theorem commonRepresentativeBlocks_primitive (F : CommonBlockedCyclicSectorFamil
     F.commonSectorBlock_primitive k ⟨0, F.period_pos k⟩
 
 /-- The representative common-sector family is tensor-irreducible. -/
-theorem commonRepresentativeBlocks_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonRepresentativeBlocks_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) : IsIrreducibleTensor (F.commonRepresentativeBlocks k) := by
   simpa [commonRepresentativeBlocks, commonRepresentativeDim] using
     F.commonSectorBlock_irreducible k ⟨0, F.period_pos k⟩
 
 /-- The representative common-sector family is trace-preserving at a prescribed
 common blocking length. -/
-theorem commonRepresentativeBlocksAt_tp (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonRepresentativeBlocksAt_tp (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p') (k : Fin r) :
     ∑ i : Fin (blockPhysDim d p'),
       (F.commonRepresentativeBlocksAt hp k i)ᴴ *
@@ -98,7 +98,7 @@ theorem commonRepresentativeBlocksAt_tp (F : CommonBlockedCyclicSectorFamily blo
 
 /-- The representative common-sector family has primitive transfer maps at a
 prescribed common blocking length. -/
-theorem commonRepresentativeBlocksAt_primitive (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonRepresentativeBlocksAt_primitive (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p') (k : Fin r) :
     _root_.IsPrimitive
       (transferMap (d := blockPhysDim d p') (D := F.commonRepresentativeDim k)
@@ -108,14 +108,14 @@ theorem commonRepresentativeBlocksAt_primitive (F : CommonBlockedCyclicSectorFam
 
 /-- The representative common-sector family is tensor-irreducible at a prescribed
 common blocking length. -/
-theorem commonRepresentativeBlocksAt_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonRepresentativeBlocksAt_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p') (k : Fin r) :
     IsIrreducibleTensor (F.commonRepresentativeBlocksAt hp k) := by
   subst p'
   simpa [commonRepresentativeBlocksAt] using F.commonRepresentativeBlocks_irreducible k
 
 /-- The representative common-sector family has positive bond dimensions. -/
-theorem commonRepresentativeDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
+lemma commonRepresentativeDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) : 0 < F.commonRepresentativeDim k := by
   simpa [commonRepresentativeDim] using
     F.commonSectorBlock_dim_pos k ⟨0, F.period_pos k⟩
@@ -123,7 +123,7 @@ theorem commonRepresentativeDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
 /-- Each representative common-sector block becomes injective after a further
 blocking.  This deliberately does not assert one-site injectivity at the chosen
 common blocking length. -/
-theorem commonRepresentativeBlocksAt_exists_blockTensor_isInjective
+lemma commonRepresentativeBlocksAt_exists_blockTensor_isInjective
     (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p') (k : Fin r) :
     ∃ L : ℕ, IsInjective (blockTensor (F.commonRepresentativeBlocksAt hp k) L) := by
@@ -137,7 +137,7 @@ theorem commonRepresentativeBlocksAt_exists_blockTensor_isInjective
 
 /-- Each representative common-sector block becomes injective after a positive
 further blocking. -/
-theorem commonRepresentativeBlocksAt_exists_pos_blockTensor_isInjective
+lemma commonRepresentativeBlocksAt_exists_pos_blockTensor_isInjective
     (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p') (k : Fin r) :
     ∃ L : ℕ, 0 < L ∧
@@ -155,7 +155,7 @@ provided positive local injective-blocking witnesses have already been chosen.
 
 This is the source-faithful finite-max/common-multiple step: it does not assert
 that the representatives are injective at the common cyclic period itself. -/
-theorem commonRepresentativeBlocksAt_blockTensor_isInjective_commonMultiple
+lemma commonRepresentativeBlocksAt_blockTensor_isInjective_commonMultiple
     (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p')
     (L : Fin r → ℕ)
@@ -178,7 +178,7 @@ theorem commonRepresentativeBlocksAt_blockTensor_isInjective_commonMultiple
 
 /-- Existential form of
 `commonRepresentativeBlocksAt_blockTensor_isInjective_commonMultiple`. -/
-theorem exists_commonRepresentativeBlocksAt_blockTensor_isInjective_of_positive_witnesses
+lemma exists_commonRepresentativeBlocksAt_blockTensor_isInjective_of_positive_witnesses
     (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p')
     (h : ∃ L : Fin r → ℕ,
@@ -192,7 +192,7 @@ theorem exists_commonRepresentativeBlocksAt_blockTensor_isInjective_of_positive_
 
 /-- Representative common-sector blocks have one positive common further
 blocking length at which every representative is one-site injective. -/
-theorem exists_commonRepresentativeBlocksAt_blockTensor_isInjective
+lemma exists_commonRepresentativeBlocksAt_blockTensor_isInjective
     (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p') :
     ∃ L₀ : ℕ, 0 < L₀ ∧
@@ -212,7 +212,7 @@ theorem exists_commonRepresentativeBlocksAt_blockTensor_isInjective
 
 /-- A representative common-sector family is a normal canonical form once its transported
 representative weights are sorted by strictly decreasing modulus. -/
-theorem isNormalCanonicalForm_commonRepresentativeBlocks
+lemma isNormalCanonicalForm_commonRepresentativeBlocks
     (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ)
     (hμ : ∀ k, μ k ≠ 0)
@@ -232,7 +232,7 @@ theorem isNormalCanonicalForm_commonRepresentativeBlocks
 
 /-- The representative common-sector family is a normal canonical form when expressed at a
 prescribed common blocking length. -/
-theorem isNormalCanonicalForm_commonRepresentativeBlocksAt
+lemma isNormalCanonicalForm_commonRepresentativeBlocksAt
     (F : CommonBlockedCyclicSectorFamily blocks)
     {p' : ℕ} (hp : F.p = p')
     (μ : Fin r → ℂ)

--- a/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean
@@ -56,7 +56,7 @@ theorem isPrimitive_transferMap_commonPeriodBlocking
       (dvd_lcmPeriod periods i) (lcmPeriod_pos hPeriodsPos) (hPrim i)
 
 /-- The common-period blocked family has the expected physical dimension. -/
-theorem commonPeriodBlocking_apply
+lemma commonPeriodBlocking_apply
     {dim : Fin k → ℕ}
     (blocks : (i : Fin k) → MPSTensor d (dim i)) (periods : Fin k → ℕ) (i : Fin k) :
     commonPeriodBlocking (d := d) blocks periods i =

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1438,14 +1438,14 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	Theorem~\ref{thm:primitive_blocking_divisible} applies to every block.
 \end{proof}
 
-\begin{theorem}[Formula for common-period blocking]%
-	\label{thm:common_period_blocking_apply}
+\begin{lemma}[Formula for common-period blocking]%
+	\label{lem:common_period_blocking_apply}
 	\lean{MPSTensor.commonPeriodBlocking_apply}
 	\leanok
 	\uses{def:common_period_blocking_ch8}
 	Each block of the common-period blocking is exactly the corresponding tensor
 	blocked at the common least common multiple.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{def:common_period_blocking_ch8}
@@ -1800,8 +1800,8 @@ the common length $p=m_k e_k$.
 	$(m_k,e_k)$ block.
 \end{definition}
 
-\begin{theorem}[Common-alphabet cyclic sectors retain structural properties]%
-\label{thm:common_blocked_cyclic_sector_derived_properties}
+\begin{lemma}[Common-alphabet cyclic sectors retain structural properties]%
+\label{lem:common_blocked_cyclic_sector_derived_properties}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock_tp,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock_primitive,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonSectorBlock_irreducible,
@@ -1825,7 +1825,7 @@ the common length $p=m_k e_k$.
 	original weights are nonzero and the transported weights are sorted by
 	strictly decreasing norm, the flattened common-sector family is a normal
 	canonical form.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{thm:tp_primitive_irreducible_extra_blocking,
@@ -1847,7 +1847,7 @@ the common length $p=m_k e_k$.
 		MPSTensor.isNormalCanonicalFormBNT_commonRepresentativeBlocksAt}
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
-		thm:common_blocked_cyclic_sector_derived_properties,
+		lem:common_blocked_cyclic_sector_derived_properties,
 		def:normal_cf_bnt}
 	For a prescribed common blocking length, choose one representative for
 	each original block among the common-alphabet cyclic sectors.  Strict
@@ -1860,7 +1860,7 @@ the common length $p=m_k e_k$.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:common_blocked_cyclic_sector_derived_properties,
+	\uses{lem:common_blocked_cyclic_sector_derived_properties,
 		def:normal_cf_bnt}
 	First transport the strict ordering of weights and the structural
 	trace-preserving, primitive, and tensor-irreducible properties to the
@@ -1869,8 +1869,8 @@ the common length $p=m_k e_k$.
 	the assumed separation of distinct representatives.
 \end{proof}
 
-\begin{theorem}[Common further blocking for representative sectors]%
-\label{thm:common_representative_common_further_blocking}
+\begin{lemma}[Common further blocking for representative sectors]%
+\label{lem:common_representative_common_further_blocking}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_exists_pos_blockTensor_isInjective,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_blockTensor_isInjective_commonMultiple,
 		MPSTensor.CommonBlockedCyclicSectorFamily.exists_commonRepresentativeBlocksAt_blockTensor_isInjective,
@@ -1881,7 +1881,7 @@ the common length $p=m_k e_k$.
 	representatives, the product of these local blocking lengths is one
 	positive common further blocking length at which every representative
 	remains one-site injective.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{thm:tp_primitive_irred_block_injective,
@@ -1922,8 +1922,8 @@ the common length $p=m_k e_k$.
 	Apply the formula for each sector of the fixed original block.
 \end{proof}
 
-\begin{theorem}[Blocked sectors on a common alphabet]%
-\label{thm:common_blocked_cyclic_sector_reindexed_samempv}
+\begin{lemma}[Blocked sectors on a common alphabet]%
+\label{lem:common_blocked_cyclic_sector_reindexed_samempv}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.nestedBlock_sameMPV₂_commonReindexedBlock,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonReindexedBlock_sameMPV₂_commonSectorTensor,
 		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCommonReindexedBlock_commonFlat}
@@ -1931,19 +1931,19 @@ the common length $p=m_k e_k$.
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		thm:iterated_blocking_samempv_reindex,
 		thm:samempv_cast_phys_dim, thm:samempv_blocking_distributes,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		lem:common_blocked_cyclic_sector_derived_properties}
 	For each block, the iterated block $(B_k^{[m_k]})^{[e_k]}$ agrees, after the
 	explicit identification of blocked physical words, with the block of length
 	$m_k e_k$.  Combining this with the given cyclic-sector decomposition gives an
 	MPV equality between the identified block and the corresponding common-sector tensor.
 	Summing over the original blocks transports the weights to $\mu_k^p$ and
 	flattens the two-level block/sector sum into one sector family.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{thm:iterated_blocking_samempv_reindex,
 		thm:samempv_cast_phys_dim, thm:samempv_blocking_distributes,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		lem:common_blocked_cyclic_sector_derived_properties}
 	First use the iterated-blocking comparison theorem and substitute the common
 	physical alphabet.  Then compose with the per-block cyclic-sector MPV
 	equivalence supplied by the family.  Finally expand both block-diagonal tensors as
@@ -1963,15 +1963,15 @@ the common length $p=m_k e_k$.
 	consecutive words of length $m_k$.
 \end{definition}
 
-\begin{theorem}[Flattening direct blocked words]%
-\label{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+\begin{lemma}[Flattening direct blocked words]%
+\label{lem:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq}
 	\leanok
 	Let $p=m n$.  For every physical alphabet index $i \in \{0,\ldots,d^p-1\}$, the
 	word obtained by direct base-$d$ decoding is the same as the word obtained by
 	decoding the index as $n$ consecutive blocks of length $m$ and concatenating
 	those $n$ words.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -1981,8 +1981,8 @@ the common length $p=m_k e_k$.
 	block decomposition.
 \end{proof}
 
-\begin{theorem}[Direct and iterated blocking for weighted blocks]%
-\label{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+\begin{lemma}[Direct and iterated blocking for weighted blocks]%
+\label{lem:common_blocked_cyclic_sector_blocked_word_comparison}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees,
 		MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_word_eq,
 		MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees,
@@ -1997,7 +1997,7 @@ the common length $p=m_k e_k$.
 	\leanok
 	\uses{def:common_blocked_cyclic_sector_derived_blocks,
 		def:common_blocked_cyclic_sector_grouped_block_cast,
-		thm:common_blocked_cyclic_sector_reindexed_samempv}
+		lem:common_blocked_cyclic_sector_reindexed_samempv}
 	The comparison has two forms.  First, assume that each directly blocked
 	nonzero block has the same MPV family as its corresponding iterated-blocking
 	tensor.  Then the weighted direct sum of the directly blocked nonzero blocks
@@ -2007,40 +2007,40 @@ the common length $p=m_k e_k$.
 	read from the common blocked alphabet is the same word as the one obtained by
 	viewing the index as an iterated $(m_k,e_k)$ block and flattening it; under this
 	condition the two individual block tensors are equal.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{thm:mpv_decomposition,
 		def:common_blocked_cyclic_sector_grouped_block_cast,
-		thm:common_blocked_cyclic_sector_reindexed_samempv}
+		lem:common_blocked_cyclic_sector_reindexed_samempv}
 	The word equality gives equality of the corresponding block tensors, hence
 	blockwise MPV equality. The coordinate-grouping predicate supplies this word
 	equality by comparing the canonical identification with the explicit consecutive grouping
 	of a direct blocked word. Expanding both weighted block-diagonal tensors as
 	finite sums over the original block index and applying the blockwise equality
 	term by term gives the weighted comparison.  Composing with
-	Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_samempv} gives the
+	Lemma~\ref{lem:common_blocked_cyclic_sector_reindexed_samempv} gives the
 	common-sector statement.
 \end{proof}
 
-\begin{theorem}[Blocked nonzero part on the common alphabet]%
-\label{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
+\begin{lemma}[Blocked nonzero part on the common alphabet]%
+\label{lem:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed,
 		MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed}
 	\leanok
-	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
+	\uses{lem:common_blocked_cyclic_sector_reindexed_samempv,
 		def:common_blocked_cyclic_sector_derived_blocks}
 	Assume that the canonical blocked nonzero part agrees, as an MPV family, with
 	the cyclic-sector tensor coming from iterated blocking.  Then the
 	canonical weighted nonzero part agrees with the weighted common-sector
 	tensor.  The prescribed-length form gives the same conclusion after substituting
 	an equality between the family length and the chosen common length.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
-	\uses{thm:common_blocked_cyclic_sector_reindexed_samempv}
+	\uses{lem:common_blocked_cyclic_sector_reindexed_samempv}
 	Compose the assumed MPV equality with the sector decomposition of
-	Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_samempv}.
+	Lemma~\ref{lem:common_blocked_cyclic_sector_reindexed_samempv}.
 \end{proof}
 
 \begin{theorem}[Common reblocking at a prescribed common multiple]%
@@ -3566,8 +3566,8 @@ transport the all-zero-block identity through this comparison.
 	\leanok
 	\uses{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail,
 		thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_reindexed_samempv,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		lem:common_blocked_cyclic_sector_reindexed_samempv,
+		lem:common_blocked_cyclic_sector_derived_properties}
 	If two tensors generate the same MPV family, then after reblocking the nonzero
 	blocks one obtains cyclic-sector families over a common alphabet.  These
 	families preserve the MPV of the reblocked nonzero part, with nonzero
@@ -3577,8 +3577,8 @@ transport the all-zero-block identity through this comparison.
 \begin{proof}\leanok
 	\uses{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail,
 		thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_reindexed_samempv,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		lem:common_blocked_cyclic_sector_reindexed_samempv,
+		lem:common_blocked_cyclic_sector_derived_properties}
 	Start from the common reblocked cyclic-sector families on the two sides.  Apply
 	the all-zero-block reblocking theorem to the original nonzero-block decomposition, then
 		use the common-alphabet sector decomposition and the derived structural
@@ -3593,8 +3593,8 @@ transport the all-zero-block identity through this comparison.
 		thm:exists_common_blocked_cyclic_sector_family_common_multiple,
 		thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:nonzero_block_block_power_zero_tail_identity,
-		thm:common_blocked_cyclic_sector_reindexed_samempv,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		lem:common_blocked_cyclic_sector_reindexed_samempv,
+		lem:common_blocked_cyclic_sector_derived_properties}
 	If two tensors generate the same MPV family, then the cyclic-sector
 	decompositions on the two sides can be expressed at one common positive
 	blocking length.  At this length the nonzero parts still agree at positive
@@ -3606,8 +3606,8 @@ transport the all-zero-block identity through this comparison.
 		thm:exists_common_blocked_cyclic_sector_family_common_multiple,
 		thm:zero_tail_to_tensor_from_blocks_block_power,
 		thm:nonzero_block_block_power_zero_tail_identity,
-		thm:common_blocked_cyclic_sector_reindexed_samempv,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		lem:common_blocked_cyclic_sector_reindexed_samempv,
+		lem:common_blocked_cyclic_sector_derived_properties}
 	Start from the per-block cyclic-sector theorem.  Let $p_A$ and $p_B$ be the
 	least common multiples of the period-removal lengths on the two sides, and
 	use $p=\mathrm{lcm}(p_A,p_B)$.  The prescribed-common-multiple theorem constructs both
@@ -3625,7 +3625,7 @@ transport the all-zero-block identity through this comparison.
 		MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees}
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_blocked_word_comparison,
+		lem:common_blocked_cyclic_sector_blocked_word_comparison,
 		def:same_mpv2_pos}
 	Assume an all-zero-block/nonzero decomposition on one side.  If direct blocking of
 	each nonzero block agrees with the corresponding iterated cyclic-sector
@@ -3636,7 +3636,7 @@ transport the all-zero-block identity through this comparison.
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_blocked_word_comparison,
+		lem:common_blocked_cyclic_sector_blocked_word_comparison,
 		def:same_mpv2_pos}
 	Transport the all-zero-block/nonzero decomposition to the common blocking length.
 	The blockwise comparison then replaces the directly blocked nonzero part by the
@@ -3650,7 +3650,7 @@ transport the all-zero-block identity through this comparison.
 		MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed}
 	\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
+		lem:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	Assume an all-zero-block/nonzero decomposition on one side.  If the blocked nonzero
 	tensor agrees, after identifying blocked words, with the common cyclic-sector
 	family, then the same all-zero-block identity can be written in that common
@@ -3660,7 +3660,7 @@ transport the all-zero-block identity through this comparison.
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
-		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
+		lem:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	Transport the all-zero-block/nonzero decomposition to the common blocking length.
 	The word-identification hypothesis then replaces the blocked nonzero tensor by the
 	weighted common-sector tensor.  At positive lengths the all-zero tensor has
@@ -3672,7 +3672,7 @@ transport the all-zero-block identity through this comparison.
 	\lean{MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts}
 	\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
+		lem:common_blocked_cyclic_sector_reindexed_nonzero_part,
 		def:same_mpv2_pos}
 	Assume that the nonzero part can be identified with the common blocked
 	alphabet.  Then two tensors with the same MPV family admit one positive
@@ -3683,7 +3683,7 @@ transport the all-zero-block identity through this comparison.
 
 \begin{proof}\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
+		lem:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}
 	to choose the common blocking length and the two common cyclic-sector families.
 	The assumed word identification converts the blocked nonzero part into the weighted
@@ -3715,8 +3715,8 @@ transport the all-zero-block identity through this comparison.
 	\lean{MPSTensor.zeroTail_commonFlat_transport_of_reindexed}
 	\leanok
 	\uses{thm:zero_tail_common_flat_of_reindexed,
-		thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		lem:common_blocked_cyclic_sector_reindexed_nonzero_part,
+		lem:common_blocked_cyclic_sector_derived_properties}
 	If the blocked nonzero part agrees with the common-sector tensor,
 	then the all-zero-block identity can be written with that common-sector tensor.
 	Nonzero original weights remain nonzero after the blocking power.
@@ -3724,8 +3724,8 @@ transport the all-zero-block identity through this comparison.
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_common_flat_of_reindexed,
-		thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
-		thm:common_blocked_cyclic_sector_derived_properties}
+		lem:common_blocked_cyclic_sector_reindexed_nonzero_part,
+		lem:common_blocked_cyclic_sector_derived_properties}
 	Combine Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} with the
 	common-sector MPV equality and the nonzero-weight statement.
 \end{proof}
@@ -3735,8 +3735,8 @@ transport the all-zero-block identity through this comparison.
 	\lean{MPSTensor.zeroTail_commonFlat_transport_of_groupedBlockCastAgrees}
 	\leanok
 	\uses{thm:zero_tail_common_flat_of_blocked_word_comparison,
-		thm:common_blocked_cyclic_sector_blocked_word_comparison,
-		thm:common_blocked_cyclic_sector_derived_properties,
+		lem:common_blocked_cyclic_sector_blocked_word_comparison,
+		lem:common_blocked_cyclic_sector_derived_properties,
 		def:same_mpv2}
 	Assume an all-zero-block/nonzero decomposition with nonzero weights.  If the common
 	blocked alphabet is identified with each iterated alphabet by grouping
@@ -3746,8 +3746,8 @@ transport the all-zero-block identity through this comparison.
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_common_flat_of_blocked_word_comparison,
-		thm:common_blocked_cyclic_sector_blocked_word_comparison,
-		thm:common_blocked_cyclic_sector_derived_properties,
+		lem:common_blocked_cyclic_sector_blocked_word_comparison,
+		lem:common_blocked_cyclic_sector_derived_properties,
 		def:same_mpv2}
 	The coordinate-grouping comparison identifies the directly blocked nonzero part
 	with the weighted common-sector family.  Combine this with the all-zero-block
@@ -3759,7 +3759,7 @@ transport the all-zero-block identity through this comparison.
 	\lean{MPSTensor.afterBlocking_commonLengthCommonSectorData_of_reindexed}
 	\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
+		lem:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	If two tensors generate the same MPV family, choose a common blocking length
 	for their cyclic-sector decompositions.  If each blocked nonzero part agrees
 	with its common-sector form after identifying words, then all length-zero
@@ -3769,7 +3769,7 @@ transport the all-zero-block identity through this comparison.
 
 \begin{proof}\leanok
 	\uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-		thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
+		lem:common_blocked_cyclic_sector_reindexed_nonzero_part}
 	Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}.
 	The two word-identification hypotheses identify the blocked nonzero parts with the
 	weighted common-sector tensors.  Substituting these MPV equalities into the
@@ -3813,7 +3813,7 @@ transport the all-zero-block identity through this comparison.
 	words.
 
 	The results above separate the finite-sum comparison from the blocked-word
-	assertion.  Theorem~\ref{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	assertion.  Lemma~\ref{lem:common_blocked_cyclic_sector_blocked_word_comparison}
 	shows that, once the length-$p$ word read directly from the common blocked
 	alphabet equals the word obtained by flattening an iterated $(m_k,e_k)$ block,
 	the weighted direct sum of directly blocked nonzero blocks agrees with the
@@ -3836,7 +3836,7 @@ transport the all-zero-block identity through this comparison.
 	identities, while
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	collects the resulting primitive irreducible sector decompositions needed for
-	comparison.  Theorem~\ref{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+	comparison.  Lemma~\ref{lem:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 	supplies the direct word equality for the chosen coordinates.
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_block_span_consequences}
 	gives the intermediate span consequence for these common-sector families: a

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1788,14 +1788,14 @@ two-basis sector comparison theorem.
 		\lean{MPSTensor.CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq}
 		\leanok
 		\uses{def:common_grouped_block_cast_hypothesis,
-			thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+			lem:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 		The canonical coordinate grouping holds for every common blocked
 		cyclic-sector family.  The proof identifies each grouped block with the
 		corresponding direct blocked word.
 	\end{theorem}
 
 	\begin{proof}\leanok
-		\uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+		\uses{lem:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 		Apply the grouped-block cast comparison to each original nonzero block.
 	\end{proof}
 
@@ -1805,7 +1805,7 @@ two-basis sector comparison theorem.
 	\leanok
 	\uses{def:common_grouped_block_cast_hypothesis,
 		def:common_sector_relabeling_hypothesis,
-		thm:common_blocked_cyclic_sector_blocked_word_comparison}
+		lem:common_blocked_cyclic_sector_blocked_word_comparison}
 		If the global coordinate-grouping hypothesis holds, then the blocked-word
 		identification used by the common-sector structural theorem holds.  The
 	proof is exactly the weighted finite-sum comparison for direct and iterated
@@ -1814,7 +1814,7 @@ two-basis sector comparison theorem.
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+	\uses{lem:common_blocked_cyclic_sector_blocked_word_comparison}
 	Apply the coordinate-grouping comparison to each one-sided family and sum over
 	the original nonzero blocks with the transported powers of the weights.
 \end{proof}
@@ -1871,7 +1871,7 @@ two-basis sector comparison theorem.
 
 \begin{proof}
 	\leanok
-	\uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast,
+	\uses{lem:common_blocked_cyclic_sector_flatten_word_of_block_cast,
 		thm:common_grouped_block_cast_to_relabeling,
 		thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	The direct digit computation gives the global coordinate-grouping hypothesis.


### PR DESCRIPTION
## Summary

- demotes common-alphabet cyclic-sector transport and structural-preservation helpers from theorem-level to lemma-level
- demotes the definitional common-period blocking formula from theorem-level to lemma-level
- keeps the source-level cyclic-sector existence and common-family construction as the theorem surface
- updates Ch8/Ch11 labels and references so the blueprint distinguishes period-removal statements from bookkeeping for common blocked alphabets

Addresses part of #1322 and #1282. Supports #1170.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean`
- `lake env lean TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a refactor of proof/API surface (changing `theorem` to `lemma` and updating documentation references) with no intended mathematical or computational behavior changes.
> 
> **Overview**
> Demotes a large set of common-blocked cyclic-sector *transport/structural helper statements* from `theorem` to `lemma` in `CommonBlockedCyclicSectorFamily.lean` and `CommonBlockedCyclicSectorRepresentatives.lean` (e.g. nonzero-weight transport, TP/primitive/irreducible properties, word/blocked-index comparison, and MPV assembly lemmas).
> 
> Updates the blueprint (Ch8 and related assembly chapters) to rename the affected results from theorem to lemma, adjust labels (`thm:` → `lem:`), and retarget all cross-references accordingly so period-removal/existence statements remain the theorem-level surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ac23fbc5ec5c3f2bba208cd2d86b169a4c01d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->