### PR TITLE
doc(MPS/CanonicalForm): clarify Burnside source boundary

### DIFF
--- a/TNLean/Algebra/BurnsideMatrix.lean
+++ b/TNLean/Algebra/BurnsideMatrix.lean
@@ -168,7 +168,7 @@ theorem mem_cumulativeSpan_of_mem_algSpan (A : MPSTensor d D)
 is all of `M_D(ℂ)`, then the cumulative span reaches ⊤ at some finite level.
 
 Uses the Noetherian property of finite-dimensional modules. -/
-theorem exists_cumulativeSpan_eq_top_of_algSpan_eq_top (A : MPSTensor d D)
+lemma exists_cumulativeSpan_eq_top_of_algSpan_eq_top (A : MPSTensor d D)
     (h : algSpan A = ⊤) :
     ∃ N : ℕ, cumulativeSpan A N = ⊤ := by
   -- Every matrix is in the algebra span, hence in some cumulative span
@@ -211,7 +211,7 @@ private theorem mul_proj_eq {P M : Matrix (Fin D) (Fin D) ℂ}
 
 If there are no nontrivial invariant submodules, then there are no
 nontrivial invariant orthogonal projections. -/
-theorem isIrreducibleTensor_of_isIrreducibleAction
+lemma isIrreducibleTensor_of_isIrreducibleAction
     (A : MPSTensor d D) (hIrr : IsIrreducibleAction A) :
     IsIrreducibleTensor (d := d) (D := D) A := by
   intro ⟨P, horth, hne0, hne1, hinv⟩
@@ -260,7 +260,7 @@ theorem isIrreducibleTensor_of_isIrreducibleAction
 
 This is Burnside's theorem (`burnside_matrix`, proven in `TNLean.Algebra.BurnsideTheorem`)
 combined with `exists_cumulativeSpan_eq_top_of_algSpan_eq_top`. -/
-theorem exists_cumulativeSpan_eq_top_of_isIrreducibleAction [NeZero D]
+lemma exists_cumulativeSpan_eq_top_of_isIrreducibleAction [NeZero D]
     (A : MPSTensor d D) (hIrr : IsIrreducibleAction A) :
     ∃ N : ℕ, cumulativeSpan A N = ⊤ := by
   have hBurn : algSpan A = ⊤ := burnside_matrix (A := A) hIrr

--- a/TNLean/Algebra/IrreducibleTensorAction.lean
+++ b/TNLean/Algebra/IrreducibleTensorAction.lean
@@ -31,7 +31,7 @@ noncomputable section
 
 If a nontrivial `A`-invariant submodule `W` existed, its orthogonal projection would give a
 nontrivial invariant orthogonal projection matrix, contradicting `IsIrreducibleTensor`. -/
-theorem isIrreducibleAction_of_isIrreducibleTensor
+lemma isIrreducibleAction_of_isIrreducibleTensor
     {d D : ℕ} (A : MPSTensor d D)
     (hIrrT : IsIrreducibleTensor (d := d) (D := D) A) :
     IsIrreducibleAction (d := d) (D := D) A := by

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1584,7 +1584,7 @@ span.
     This assembles the full chain:
     \[
         \text{irreducible tensor}
-        \;\xrightarrow{\ref{thm:irreducible_tensor_to_action}}\;
+        \;\xrightarrow{\ref{lem:irreducible_tensor_to_action}}\;
         \text{irreducible action}
         \;\xrightarrow{\text{Burnside}}\;
         \algspn(A) = \MN{D}
@@ -1594,16 +1594,15 @@ span.
     This corresponds to the irreducibility-to-normality direction of
     \cite[Proposition~3]{Sanz2010Quantum}.
     For the Burnside step, we appeal forward to
-    Theorems~\ref{thm:irreducible_tensor_to_action}
-    and~\ref{thm:burnside_matrix}; this is a
-    presentation-level forward dependency,
-    but the mathematical dependency is acyclic.
+    Lemma~\ref{lem:irreducible_tensor_to_action}
+    and~\ref{thm:burnside_matrix}; these references point forward in the
+    chapter order, but the mathematical dependency is acyclic.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:algspan_to_normal, thm:burnside_matrix,
-          thm:irreducible_tensor_to_action}
-    By Theorem~\ref{thm:irreducible_tensor_to_action},
+          lem:irreducible_tensor_to_action}
+    By Lemma~\ref{lem:irreducible_tensor_to_action},
     $A$ acts irreducibly on $\C^D$.
     By Theorem~\ref{thm:burnside_matrix},
     $\algspn(A) = \MN{D}$.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -377,18 +377,27 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
 	normalization.
 \end{proof}
 
-\subsection{External Burnside--Jacobson connection to algebra span}
+\subsection{External Burnside--Jacobson input for algebra span}
 \label{subsec:burnside_jacobson_connection}
 
-The irreducibility condition (Definition~\ref{def:irreducible_tensor}) is formulated
-in terms of invariant \emph{projections}.
-For Burnside-style arguments it is more natural to work with invariant
-\emph{subspaces} of $\C^D$ under the Kraus operators.
 The canonical-form reduction of \cite[Section~2.3]{Cirac2016MPDO_arXiv}
-provides the invariant-subspace reduction: repeated removal of invariant
-subspaces leaves blocks with no nontrivial invariant subspace.  The next step
-used here is a separate finite-dimensional algebra input: over $\C$, an
-irreducible matrix action generates the full endomorphism algebra.
+is stated in terms of invariant subspaces $S \le \C^D$ for the matrices
+$A^i$.  Repeated removal of minimal invariant subspaces leaves blocks with
+no nontrivial invariant subspace.  The paper does not invoke Burnside's
+theorem at this point, and this absence matters: injectivity, meaning
+one-site spanning of $\MN{D}$, is introduced later and is obtained only after
+blocking by the quantum Wielandt theorem.
+
+The algebraic input isolated here is external to that source step.  It is the
+finite-dimensional complex theorem
+\[
+	\bigl(\text{the only common invariant subspaces of the }A^i
+	\text{ are }0\text{ and }\C^D\bigr)
+	\quad\Longrightarrow\quad
+	\C\langle A^i\rangle = \MN{D}.
+\]
+The projection language in Definition~\ref{def:irreducible_tensor} is bridged
+to this subspace formulation first.
 
 \begin{definition}[Algebra span]\label{def:alg_span}
 	\lean{MPSTensor.algSpan}\leanok
@@ -416,13 +425,13 @@ irreducible matrix action generates the full endomorphism algebra.
 	$A$-invariant subspace is trivial, i.e. equal to $0$ or to $\C^D$.
 \end{definition}
 
-\begin{theorem}[Irreducible tensor implies irreducible action]\label{thm:irreducible_tensor_to_action}
+\begin{lemma}[Irreducible tensor implies irreducible action]\label{lem:irreducible_tensor_to_action}
 	\lean{MPSTensor.isIrreducibleAction_of_isIrreducibleTensor}\leanok
 	\uses{def:irreducible_tensor, def:irreducible_action}
 	If $A$ is irreducible as a tensor (Definition~\ref{def:irreducible_tensor}),
 	then the Kraus operators act irreducibly on $\C^D$
 	(Definition~\ref{def:irreducible_action}).
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	Let $W \le \C^D$ be an $A$-invariant subspace.
@@ -464,7 +473,7 @@ irreducible matrix action generates the full endomorphism algebra.
 	ingredient in the chapter.  The source MPS argument provides the
 	invariant-subspace decomposition and the later blocking-to-injectivity
 	results; it does not name Burnside as a separate theorem at this point.
-	The formal algebraic input used here is precisely
+	The algebraic input used here is precisely
 	\[
 		\text{irreducible action on }\C^D
 		\quad\Longrightarrow\quad
@@ -473,8 +482,8 @@ irreducible matrix action generates the full endomorphism algebra.
 	It does not by itself assert fixed-length word-span injectivity or normality.
 \end{remark}
 
-\begin{theorem}[Irreducible action implies eventual cumulative spanning]%
-	\label{thm:irreducible_action_cumulative_span}
+\begin{lemma}[Irreducible action implies eventual cumulative spanning]%
+	\label{lem:irreducible_action_cumulative_span}
 	\lean{MPSTensor.exists_cumulativeSpan_eq_top_of_isIrreducibleAction}\leanok
 	\uses{def:cumulative_span, def:irreducible_action}
 	Assume $D > 0$.
@@ -484,7 +493,7 @@ irreducible matrix action generates the full endomorphism algebra.
 	\[
 		T_N(A) = \MN{D}.
 	\]
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok\uses{thm:burnside_matrix}
 	By Theorem~\ref{thm:burnside_matrix}, $\algspn(A) = \MN{D}$.
@@ -496,7 +505,7 @@ irreducible matrix action generates the full endomorphism algebra.
 \end{proof}
 
 \begin{remark}\leanok
-	The conclusion of Theorem~\ref{thm:irreducible_action_cumulative_span}
+	The conclusion of Lemma~\ref{lem:irreducible_action_cumulative_span}
 	is a cumulative-span statement:
 	\[
 		\exists N,\ T_N(A)=\MN{D}.

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -222,13 +222,13 @@ results of~\cite{Cirac2021Matrix}.
 
 \section{Burnside and invariant projections}
 
-\begin{theorem}[The algebra span reaches a finite cumulative span]\label{thm:algspan_cumulative_span}
+\begin{lemma}[The algebra span reaches a finite cumulative span]\label{lem:algspan_cumulative_span}
     \lean{MPSTensor.exists_cumulativeSpan_eq_top_of_algSpan_eq_top}
     \leanok
     \uses{def:alg_span, def:cumulative_span}
     If the generated unital algebra satisfies $\algspn(A) = \MN{D}$,
     then there exists $N$ such that $T_N(A) = \MN{D}$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok
@@ -241,13 +241,14 @@ results of~\cite{Cirac2021Matrix}.
     single $N$ with $T_N(A) = \MN{D}$.
 \end{proof}
 
-\begin{theorem}[Irreducible action gives an irreducible tensor]\label{thm:irreducible_action_to_tensor}
+\begin{lemma}[Irreducible action gives an irreducible tensor]%
+\label{lem:irreducible_action_to_tensor}
     \lean{MPSTensor.isIrreducibleTensor_of_isIrreducibleAction}
     \leanok
     \uses{def:irreducible_action, def:irreducible_tensor}
     If the letters of $A$ act irreducibly on $\C^D$, then $A$ has no nontrivial
     invariant orthogonal projection.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -241,8 +241,7 @@ results of~\cite{Cirac2021Matrix}.
     single $N$ with $T_N(A) = \MN{D}$.
 \end{proof}
 
-\begin{lemma}[Irreducible action gives an irreducible tensor]%
-\label{lem:irreducible_action_to_tensor}
+\begin{lemma}[Irreducible action gives an irreducible tensor]\label{lem:irreducible_action_to_tensor}
     \lean{MPSTensor.isIrreducibleTensor_of_isIrreducibleAction}
     \leanok
     \uses{def:irreducible_action, def:irreducible_tensor}


### PR DESCRIPTION
### Motivation

Addresses #1321.
Supports #1170, #1278, and #1282.

The canonical-form reduction passage in arXiv:1606.00608, Section 2.3 is phrased through invariant subspaces. It does not itself cite or invoke Burnside/Jacobson. This PR separates that paper-facing reduction from the external algebraic input used later in the formal development.

### Description

- Make the Chapter 8 Burnside subsection explicit that the source reduction uses invariant subspaces, not a named Burnside/Jacobson step.
- State the external algebra input formula-first: an irreducible common action on `C^D` gives `C<A^i> = M_D(C)`.
- Demote the projection/subspace bridge and cumulative-span extraction surfaces to lemmas in Lean and the blueprint.
- Keep the Burnside/Jacobson algebra theorem theorem-level.
- Update Chapter 7 and Chapter 9 references to the demoted lemma labels.

### Source Audit

Compared against `Papers/1606.00608/MPDO-22-12-17-2.tex`:

- Section 2.3 chooses invariant subspaces `S_k` for the matrices `B^i` and stops when there is no non-trivial invariant subspace.
- Injectivity is introduced later as one-site spanning of `M_{D x D}` and obtained after blocking via the quantum Wielandt theorem.
- No Burnside/Jacobson citation or named Burnside step appears in that canonical-form reduction passage.

### Testing

- `lake env lean TNLean/Algebra/BurnsideMatrix.lean`
- `lake env lean TNLean/Algebra/IrreducibleTensorAction.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

### Automation Note

The live build, blueprint compile, file-length, and Cursor Bugbot checks are green at head `d9529f3734c2a7ef0dd3d2cc26e2448023c4b26f`. The failing `blueprint-and-prose`, `claude-review`, `track`, and `cleanup` checks are automation/quota failures, so this body and labels were applied manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly renames (`theorem`→`lemma`) and documentation/blueprint wording updates, with no changes to proof logic or core algebraic statements.
> 
> **Overview**
> Clarifies in the blueprint that the canonical-form reduction step is *invariant-subspace* based and that the Burnside/Jacobson implication (`IsIrreducibleAction` → `algSpan A = ⊤`) is an **external algebraic input**, not something taken from the cited reduction.
> 
> Demotes the projection/subspace bridge and the `algSpan`→`cumulativeSpan` extraction results from `theorem` to `lemma` in Lean (`BurnsideMatrix.lean`, `IrreducibleTensorAction.lean`) and updates blueprint labels/references across Chapters 7–9 accordingly, while keeping the Burnside/Jacobson algebra generation statement theorem-level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6adcdc538478a4b83bde666ceef6955c2ad59f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->