### PR TITLE
doc(MPS/CanonicalForm): clarify cyclic-sector sources

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean
@@ -71,7 +71,7 @@ private lemma cyclicShift_succ_left {m : ℕ} [NeZero m] (k : Fin m) (n : ℕ) :
 
 /-- Iterating the cyclic relation `E†(P(k+1)) = P_k` exactly `m` times gives
 `(E†)^m (P_k) = P_k`. -/
-theorem adjointTransferMap_pow_fixes_cyclic_projection
+lemma adjointTransferMap_pow_fixes_cyclic_projection
     {d D m : ℕ} [NeZero m]
     (K : Fin d → MatrixAlg D)
     (P : Fin m → MatrixAlg D)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1455,9 +1455,9 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 \section{Cyclic sector decomposition}%
 \label{sec:cyclic_sectors}
 
-The non-periodic canonical-form argument in arXiv:1606.00608 uses only the
-blocking consequence: after blocking by the least common multiple of the
-periods, each block has no non-trivial peripheral period.  The explicit
+The non-periodic canonical-form argument of \cite{Cirac2016MPDO_arXiv} uses
+only the blocking consequence: after blocking by the least common multiple of
+the periods, each block has no non-trivial peripheral period.  The explicit
 projection-sector form used here comes from the periodic decomposition of
 \cite[Theorem~5.7]{PerezGarcia2007Matrix}, refined by the cyclic-block form in
 \cite[equation~(1) and Lemma~1]{DeLasCuevas2017Irreducible}, together with the
@@ -1605,7 +1605,7 @@ one physical alphabet; they are not separate cyclic-decomposition assertions.
 	\label{lem:cyclic_projection_periodic_fixed}
 	\lean{MPSTensor.adjointTransferMap_pow_fixes_cyclic_projection}
 	\leanok
-	If a family of projections $(P_k)_{k=1}^m$ satisfies
+	If a family of projections $(P_k)_{k=0}^{m-1}$ satisfies
 	$\E^\dagger(P_{k+1}) = P_k$, then the $m$-th iterate of $\E^\dagger$
 	fixes each projection $P_k$.
 \end{lemma}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1455,13 +1455,17 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 \section{Cyclic sector decomposition}%
 \label{sec:cyclic_sectors}
 
-The source input is the cyclic peripheral structure of an irreducible unital
-map from \cite[Chapter~6]{Wolf2012Quantum}, applied to the adjoint transfer
-map, together with the cyclic-block form used in
-\cite[equation~(1) and Lemma~1]{DeLasCuevas2017Irreducible}.  The source writes
-$\E_A^\dagger(P_u)=P_{u+1}$ and
-$A^i=\sum_u P_u A^i P_{u+1}$.  After reversing the cyclic order, the convention
-here is, with sector indices modulo the period $m$,
+The non-periodic canonical-form argument in arXiv:1606.00608 uses only the
+blocking consequence: after blocking by the least common multiple of the
+periods, each block has no non-trivial peripheral period.  The explicit
+projection-sector form used here comes from the periodic decomposition of
+\cite[Theorem~5.7]{PerezGarcia2007Matrix}, refined by the cyclic-block form in
+\cite[equation~(1) and Lemma~1]{DeLasCuevas2017Irreducible}, together with the
+cyclic peripheral structure of an irreducible unital map from
+\cite[Chapter~6]{Wolf2012Quantum}.  In the convention of
+\cite{PerezGarcia2007Matrix}, the sector projections satisfy
+$A^i P_u=P_{u-1} A^i$.  After reversing the cyclic order, the convention here
+is, with sector indices modulo the period $m$,
 \[
 	\E_A^\dagger(P_{u+1}) = P_u,\qquad
 	A^i = \sum_u P_{u+1} A^i P_u .
@@ -1597,14 +1601,14 @@ one physical alphabet; they are not separate cyclic-decomposition assertions.
 	point.
 \end{proof}
 
-\begin{theorem}[One full cyclic turn fixes the sector projections]%
-	\label{thm:cyclic_projection_periodic_fixed}
+\begin{lemma}[One full cyclic turn fixes the sector projections]%
+	\label{lem:cyclic_projection_periodic_fixed}
 	\lean{MPSTensor.adjointTransferMap_pow_fixes_cyclic_projection}
 	\leanok
 	If a family of projections $(P_k)_{k=1}^m$ satisfies
 	$\E^\dagger(P_{k+1}) = P_k$, then the $m$-th iterate of $\E^\dagger$
 	fixes each projection $P_k$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	Iterate the cyclic relation $m$ times.
@@ -1649,11 +1653,11 @@ one physical alphabet; they are not separate cyclic-decomposition assertions.
 \end{theorem}
 
 \begin{proof}\leanok
-	\uses{thm:cyclic_projection_periodic_fixed, thm:blocked_adjoint_transfer_pow,
+	\uses{lem:cyclic_projection_periodic_fixed, thm:blocked_adjoint_transfer_pow,
 	      thm:blockdecomp_adjoint_fixed}
 	The cyclic decomposition of the adjoint transfer map gives projections
 	$(P_k)$ with $\E_{A^\dagger}(P_{k+1}) = P_k$.
-	Theorem~\ref{thm:cyclic_projection_periodic_fixed} upgrades this to
+	Lemma~\ref{lem:cyclic_projection_periodic_fixed} upgrades this to
 	$(\E_{A^\dagger})^m(P_k) = P_k$, and
 	Theorem~\ref{thm:blocked_adjoint_transfer_pow} identifies
 	$(\E_{A^\dagger})^m$ with the adjoint transfer map of the blocked tensor.


### PR DESCRIPTION
### Motivation

Addresses part of #1322.
Supports #1282 and #1170.

The cyclic-sector section should distinguish the actual non-periodic source step from the extra projection-sector formalization used to justify period removal. In arXiv:1606.00608, the non-periodic route only needs blocking by the least common multiple of the periods; the projection formula belongs to the periodic-decomposition input from the older MPS representation paper and later cyclic-block refinements.

### Description

- Clarify the Chapter 8 source paragraph for cyclic sectors:
  - arXiv:1606.00608 supplies the blocking-by-lcm consequence.
  - the sector-projection relation comes from the periodic decomposition in `quant-ph/0608197` and the later cyclic-block form.
  - the blueprint convention is obtained by reversing the cyclic order.
- Demote the finite cyclic-iteration fact `adjointTransferMap_pow_fixes_cyclic_projection` from theorem-level to lemma-level.
- Update the blueprint label and reference from `thm:` to `lem:` for that finite iteration fact.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CyclicSectorRelation.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation/blueprint wording and a theorem-to-lemma relabeling/label update; no core algorithms or data handling logic is modified.
> 
> **Overview**
> Clarifies the Chapter 8 cyclic-sector introduction to distinguish the *blocking-by-lcm* input from \\cite{Cirac2016MPDO_arXiv} versus the *explicit projection/sector relations* taken from periodic-decomposition and cyclic-block sources, and explicitly notes the reversed cyclic-order convention.
> 
> Relabels the finite cyclic-iteration result `adjointTransferMap_pow_fixes_cyclic_projection` from a theorem to a lemma in both Lean (`CyclicSectorRelation.lean`) and the blueprint (`thm:...`  `lem:...`), updating downstream references and the stated projection indexing to `k=0..m-1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d4b13955020c6a9d8fa6b21ec23f0c168b35e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->