### PR TITLE
style(MPS/CanonicalForm): demote zero-tail transport lemmas

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -68,7 +68,7 @@ theorem isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
 
 /-- If each directly blocked nonzero block agrees with its iterated-blocking version,
 the zero-tail equation can be written using the derived common-sector family. -/
-theorem zeroTail_commonFlat_of_blockwise
+lemma zeroTail_commonFlat_of_blockwise
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -93,7 +93,7 @@ theorem zeroTail_commonFlat_of_blockwise
 
 /-- If the blocked-word decodings agree for every nonzero block, the zero-tail equation
 can be written using the derived common-sector family. -/
-theorem zeroTail_commonFlat_of_word_eq
+lemma zeroTail_commonFlat_of_word_eq
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -116,7 +116,7 @@ theorem zeroTail_commonFlat_of_word_eq
 
 /-- If the canonical identifications agree with consecutive grouping for every nonzero block,
 the zero-tail equation can be written using the derived common-sector family. -/
-theorem zeroTail_commonFlat_of_groupedBlockCastAgrees
+lemma zeroTail_commonFlat_of_groupedBlockCastAgrees
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -135,7 +135,7 @@ theorem zeroTail_commonFlat_of_groupedBlockCastAgrees
 
 /-- The preceding zero-tail rewriting from the coordinate-grouping condition, expressed at a
 prescribed common length. -/
-theorem zeroTail_commonFlatAt_of_groupedBlockCastAgrees
+lemma zeroTail_commonFlatAt_of_groupedBlockCastAgrees
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -156,7 +156,7 @@ theorem zeroTail_commonFlatAt_of_groupedBlockCastAgrees
 
 /-- At positive lengths, the blocked tensor has the same MPV coefficients as the
 weighted common-sector family whenever the coordinate-grouping condition holds. -/
-theorem sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees
+lemma sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -177,9 +177,9 @@ theorem sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees
 
 /-- If the canonical blocked nonzero part agrees with the common reindexed blocks,
 the zero-tail equation can be rewritten using the derived common-sector family.
-This is the one-sided theorem that puts the reindexed data above in the form used
+This is the one-sided statement that puts the reindexed data above in the form used
 by the span and BNT comparison theorems. -/
-theorem zeroTail_commonFlat_of_reindexed
+lemma zeroTail_commonFlat_of_reindexed
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -205,7 +205,7 @@ theorem zeroTail_commonFlat_of_reindexed
   exact zeroTail_eq_of_sameMPV₂ _ _ _ hCanon hFlat
 
 /-- The preceding zero-tail rewriting expressed at a prescribed common length. -/
-theorem zeroTail_commonFlatAt_of_reindexed
+lemma zeroTail_commonFlatAt_of_reindexed
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -231,7 +231,7 @@ theorem zeroTail_commonFlatAt_of_reindexed
 
 /-- At positive lengths, the blocked tensor has the same MPV coefficients as the
 weighted common-sector family once the blocked words have been reindexed. -/
-theorem sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed
+lemma sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -257,7 +257,7 @@ theorem sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed
 
 /-- Replacing nonzero parts by MPV-equivalent tensors preserves the positive-length
 MPV equality and the length-zero zero-tail identity. -/
-theorem sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂
+lemma sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂
     {d LA LB LA' LB' zeroTailA zeroTailB : ℕ}
     (liveA : MPSTensor d LA) (liveB : MPSTensor d LB)
     (flatA : MPSTensor d LA') (flatB : MPSTensor d LB')
@@ -285,7 +285,7 @@ theorem sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂
 /-- Once the canonical blocked nonzero part agrees with the reindexed common-sector
 nonzero part, the zero-tail equation, the transported-weight equality, and the
 nonvanishing of the common-sector weights are available together. -/
-theorem zeroTail_commonFlat_transport_of_reindexed
+lemma zeroTail_commonFlat_transport_of_reindexed
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -320,7 +320,7 @@ theorem zeroTail_commonFlat_transport_of_reindexed
 
 /-- The one-sided zero-tail equation, weighted nonzero-part equality, and nonvanishing
 of transported common-sector weights obtained from the coordinate-grouping condition. -/
-theorem zeroTail_commonFlat_transport_of_groupedBlockCastAgrees
+lemma zeroTail_commonFlat_transport_of_groupedBlockCastAgrees
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -177,8 +177,8 @@ lemma sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees
 
 /-- If the canonical blocked nonzero part agrees with the common reindexed blocks,
 the zero-tail equation can be rewritten using the derived common-sector family.
-This is the one-sided statement that puts the reindexed data above in the form used
-by the span and BNT comparison theorems. -/
+Thus the blocked tensor has the same MPV coefficients as the weighted common-sector
+tensor, with the same all-zero-block contribution at length zero. -/
 lemma zeroTail_commonFlat_of_reindexed
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3616,8 +3616,8 @@ transport the all-zero-block identity through this comparison.
 	conclusions are the common-alphabet MPV equalities.
 \end{proof}
 
-\begin{theorem}[Length-zero identity under compatible blocking]%
-\label{thm:zero_tail_common_flat_of_blocked_word_comparison}
+\begin{lemma}[Length-zero identity under compatible blocking]%
+\label{lem:zero_tail_common_flat_of_blocked_word_comparison}
 	\lean{MPSTensor.zeroTail_commonFlat_of_blockwise,
 		MPSTensor.zeroTail_commonFlat_of_word_eq,
 		MPSTensor.zeroTail_commonFlat_of_groupedBlockCastAgrees,
@@ -3632,7 +3632,7 @@ transport the all-zero-block identity through this comparison.
 	blocking, then the all-zero-block identity can be rewritten using the common
 	cyclic-sector family.  The coordinate-grouping condition supplies this
 	agreement at any prescribed common blocking length.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
@@ -3643,8 +3643,8 @@ transport the all-zero-block identity through this comparison.
 	weighted common-sector tensor.
 \end{proof}
 
-\begin{theorem}[Length-zero identity under word identification]%
-\label{thm:zero_tail_common_flat_of_reindexed}
+\begin{lemma}[Length-zero identity under word identification]%
+\label{lem:zero_tail_common_flat_of_reindexed}
 	\lean{MPSTensor.zeroTail_commonFlat_of_reindexed,
 		MPSTensor.zeroTail_commonFlatAt_of_reindexed,
 		MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed}
@@ -3656,7 +3656,7 @@ transport the all-zero-block identity through this comparison.
 	family, then the same all-zero-block identity can be written in that common
 	alphabet.  At positive system sizes this says that the blocked tensor and the
 	weighted common-sector tensor have the same MPV coefficients.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{thm:zero_tail_to_tensor_from_blocks_block_power,
@@ -3692,8 +3692,8 @@ transport the all-zero-block identity through this comparison.
 	from the common-sector families.
 \end{proof}
 
-\begin{theorem}[Transport of MPV and length-zero identities]%
-\label{thm:samempv_pos_zero_tail_identity_transport}
+\begin{lemma}[Transport of MPV and length-zero identities]%
+\label{lem:samempv_pos_zero_tail_identity_transport}
 	\lean{MPSTensor.sameMPV₂Pos_and_zeroTail_identity_of_sameMPV₂}
 	\leanok
 	\uses{def:same_mpv2, def:same_mpv2_pos}
@@ -3702,7 +3702,7 @@ transport the all-zero-block identity through this comparison.
 	$L_A'$ and $L_B'$ generate the same MPV families as $L_A$ and $L_B$, respectively,
 	then $L_A'$ and $L_B'$ satisfy the same positive-length equality and the same
 	length-zero all-zero-block identity.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{def:same_mpv2, def:same_mpv2_pos}
@@ -3710,31 +3710,31 @@ transport the all-zero-block identity through this comparison.
 	the positive-length equality and in the $N=0$ identity.
 \end{proof}
 
-\begin{theorem}[Length-zero identity for common sectors]%
-\label{thm:zero_tail_common_flat_transport_of_reindexed}
+\begin{lemma}[Length-zero identity for common sectors]%
+\label{lem:zero_tail_common_flat_transport_of_reindexed}
 	\lean{MPSTensor.zeroTail_commonFlat_transport_of_reindexed}
 	\leanok
-	\uses{thm:zero_tail_common_flat_of_reindexed,
+	\uses{lem:zero_tail_common_flat_of_reindexed,
 		lem:common_blocked_cyclic_sector_reindexed_nonzero_part,
 		lem:common_blocked_cyclic_sector_derived_properties}
 	If the blocked nonzero part agrees with the common-sector tensor,
 	then the all-zero-block identity can be written with that common-sector tensor.
 	Nonzero original weights remain nonzero after the blocking power.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
-	\uses{thm:zero_tail_common_flat_of_reindexed,
+	\uses{lem:zero_tail_common_flat_of_reindexed,
 		lem:common_blocked_cyclic_sector_reindexed_nonzero_part,
 		lem:common_blocked_cyclic_sector_derived_properties}
-	Combine Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} with the
+	Combine Lemma~\ref{lem:zero_tail_common_flat_of_reindexed} with the
 	common-sector MPV equality and the nonzero-weight statement.
 \end{proof}
 
-\begin{theorem}[Common sectors from grouped coordinates]%
-\label{thm:zero_tail_common_flat_transport_of_grouped_block_cast}
+\begin{lemma}[Common sectors from grouped coordinates]%
+\label{lem:zero_tail_common_flat_transport_of_grouped_block_cast}
 	\lean{MPSTensor.zeroTail_commonFlat_transport_of_groupedBlockCastAgrees}
 	\leanok
-	\uses{thm:zero_tail_common_flat_of_blocked_word_comparison,
+	\uses{lem:zero_tail_common_flat_of_blocked_word_comparison,
 		lem:common_blocked_cyclic_sector_blocked_word_comparison,
 		lem:common_blocked_cyclic_sector_derived_properties,
 		def:same_mpv2}
@@ -3742,10 +3742,10 @@ transport the all-zero-block identity through this comparison.
 	blocked alphabet is identified with each iterated alphabet by grouping
 	consecutive words, then the all-zero-block identity can be written with the
 	weighted common-sector family.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
-	\uses{thm:zero_tail_common_flat_of_blocked_word_comparison,
+	\uses{lem:zero_tail_common_flat_of_blocked_word_comparison,
 		lem:common_blocked_cyclic_sector_blocked_word_comparison,
 		lem:common_blocked_cyclic_sector_derived_properties,
 		def:same_mpv2}
@@ -3817,21 +3817,21 @@ transport the all-zero-block identity through this comparison.
 	shows that, once the length-$p$ word read directly from the common blocked
 	alphabet equals the word obtained by flattening an iterated $(m_k,e_k)$ block,
 	the weighted direct sum of directly blocked nonzero blocks agrees with the
-	common-sector family.  Theorem~\ref{thm:zero_tail_common_flat_of_blocked_word_comparison}
+	common-sector family.  Lemma~\ref{lem:zero_tail_common_flat_of_blocked_word_comparison}
 	then rewrites the one-sided all-zero-block identity with the weighted common-length
 	cyclic sectors under this blockwise word equality.
 
 	The remaining blocked-word equality, after identifying blocked physical
 	words, is the equality between the blocked nonzero part and the cyclic-sector
 	tensor for the whole weighted family.
-	Theorem~\ref{thm:zero_tail_common_flat_of_reindexed} gives the
+	Lemma~\ref{lem:zero_tail_common_flat_of_reindexed} gives the
 	one-sided form of this conversion, and
 	Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_reindexed}
 	states it simultaneously for the two common-length sector families.  The
 	auxiliary transport statements,
-	Theorems~\ref{thm:zero_tail_common_flat_transport_of_reindexed},
-	\ref{thm:zero_tail_common_flat_transport_of_grouped_block_cast}, and
-	\ref{thm:samempv_pos_zero_tail_identity_transport}, give the nonzero
+	Lemmas~\ref{lem:zero_tail_common_flat_transport_of_reindexed},
+	\ref{lem:zero_tail_common_flat_transport_of_grouped_block_cast}, and
+	\ref{lem:samempv_pos_zero_tail_identity_transport}, give the nonzero
 	transported weights and the preservation of the positive-length and length-zero
 	identities, while
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}


### PR DESCRIPTION
## Motivation

This continues the #1170/#1282/#1323 theorem-surface cleanup for the non-periodic canonical-form reduction. The common-sector zero-tail transport statements are bookkeeping for the leftover all-zero block and the common blocked alphabet; they are not source-facing theorem statements from arXiv:1606.00608.

## Description

- Demote the zero-tail/common-flat transport declarations in `CommonSectorTransport.lean` from `theorem` to `lemma`.
- Update the corresponding Chapter 8 blueprint entries, labels, and references from theorem-level to lemma-level.
- Keep the actual after-blocking/common-sector structural endpoints theorem-level.

Supports #1323, #1282, and #1170.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are purely declaration/blueprint surface-level (demoting `theorem` to `lemma` and updating LaTeX labels), with no substantive proof or behavior changes expected beyond downstream reference churn.
> 
> **Overview**
> Demotes several zero-tail/common-sector transport results in `CommonSectorTransport.lean` from `theorem` to `lemma`, including the `zeroTail_commonFlat*`, `sameMPV₂Pos_*`, and related transport statements.
> 
> Updates Chapter 8 blueprint entries accordingly by renaming environments from *theorem* to *lemma*, changing `thm:` labels to `lem:` labels, and adjusting cross-references/`\uses{}` to match the new lemma-level status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1eead3d536b0f16127a7a745d53bf652f084e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->