### PR TITLE
docs(paper-gaps): record BNT multiplicity formula surface

### DIFF
--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -101,6 +101,8 @@ and the resulting multiset equality
   =
   \{\!\{\mu^T_{j,q}:1\le q\le r_j^T\}\!\}.
 \]
+Here the double braces denote multisets, so repeated weights are counted with
+their multiplicities.
 In this notation, BNT linear independence separates the coefficient arrays, and
 Newton--Girard recovers the weights.  The formal declarations that only package
 these two algebra steps in sector-data notation are support lemmas, even when

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -93,13 +93,13 @@ linear-algebra support lemmas for the permutation-rigidity theorem, not
 additional BNT theorems from the source.
 The repeated-copy part should be written around the displayed coefficients
 \[
-  c_{S,j}^{(N)}=\sum_{q=1}^{r_j}\mu_{j,q}^N
+  c_{S,j}^{(N)}=\sum_{q=1}^{r_j^S}(\mu^S_{j,q})^N
 \]
 and the resulting multiset equality
 \[
-  \{\mu^S_{j,q}:1\le q\le r_j^S\}
+  \{\!\{\mu^S_{j,q}:1\le q\le r_j^S\}\!\}
   =
-  \{\mu^T_{j,q}:1\le q\le r_j^T\}.
+  \{\!\{\mu^T_{j,q}:1\le q\le r_j^T\}\!\}.
 \]
 In this notation, BNT linear independence separates the coefficient arrays, and
 Newton--Girard recovers the weights.  The formal declarations that only package

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -91,6 +91,20 @@ the paper-level equal-MPV target.
 The overlap-to-linear-independence and change-of-basis declarations are
 linear-algebra support lemmas for the permutation-rigidity theorem, not
 additional BNT theorems from the source.
+The repeated-copy part should be written around the displayed coefficients
+\[
+  c_{S,j}^{(N)}=\sum_{q=1}^{r_j}\mu_{j,q}^N
+\]
+and the resulting multiset equality
+\[
+  \{\mu^S_{j,q}:1\le q\le r_j^S\}
+  =
+  \{\mu^T_{j,q}:1\le q\le r_j^T\}.
+\]
+In this notation, BNT linear independence separates the coefficient arrays, and
+Newton--Girard recovers the weights.  The formal declarations that only package
+these two algebra steps in sector-data notation are support lemmas, even when
+their names mention the Fundamental Theorem.
 
 \section{External lemmas need explanations}
 
@@ -235,6 +249,21 @@ paper-level theorems.
     constant \(1\) is also lemma-level.  The displayed subscript \(2\) denotes
     the Unicode subscript \(2\) used in the Lean declaration name.  It is a
     logical conversion between hypotheses, not a separate source theorem.
+  \item The BNT sector-weight recovery declarations
+    \path{weight_multiset_eq_of_sameMPV_bnt} and
+    \path{exists_copies_eq_and_weight_multiset_eq_of_sameMPV_bnt}
+    are lemma-level.  They formalize the coefficient comparison
+    \(c_{S,j}^{(N)}=c_{T,j}^{(N)}\) and the elementary recovery of copy counts
+    and weight multisets; they are not additional BNT theorems beyond the
+    source's basis-normal-tensor comparison.
+  \item The phase-matched sector-comparison adapters
+    \path{fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch}
+    and
+    \path{fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis}
+    are also lemma-level.  They transport the same coefficient and multiset
+    formulas across a supplied phase or matched-basis identification.  The
+    theorem-level surface begins only when the proof supplies the actual
+    matching data from the BNT hypotheses.
 \end{itemize}
 
 \section{Statements to keep visibly conditional}


### PR DESCRIPTION
## Motivation

This keeps the theorem-surface audit aligned with the repeated-block cleanup in #1324/#1282/#1170. The point is to answer the source-faithfulness question mathematically, using the coefficient formulas, rather than only by pointing to issue threads.

## Description

- Add the repeated-copy coefficient formula `c_{S,j}^{(N)} = sum_q mu_{j,q}^N` to the theorem-surface audit.
- Record the corresponding sector-weight multiset equality as the mathematical content of the recovery layer.
- Classify the BNT sector-weight recovery and phase/matched-basis adapters as lemma-level support statements, not additional source-level Fundamental Theorems.

Supports #1324, #1282, and #1170.

## Validation

- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates clarifying the mathematical coefficient/multiset formulas used in the BNT repeated-copy step and reclassifying related declarations as lemma-level, with no code or logic changes.
> 
> **Overview**
> Adds an explicit repeated-copy coefficient formula `c_{S,j}^{(N)} = \sum_q (\mu_{j,q})^N` and the resulting **weight multiset equality** to the canonical BNT theorem-surface audit, clarifying that linear independence plus Newton–Girard are the key algebra steps.
> 
> Updates the “Current demotions” section to explicitly mark the sector-weight recovery declarations and the phase/matched-basis adapter declarations as **lemma-level support** (transport/recovery of coefficients and multisets), not additional source-level Fundamental Theorem statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d86d4d1a100e94189ea8fd2b588be534b77fb2e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->