### PR TITLE
docs(paper-gaps): update Wielandt source boundary

### DIFF
--- a/TNLean/Wielandt/PaperResults/WielandtInequality.lean
+++ b/TNLean/Wielandt/PaperResults/WielandtInequality.lean
@@ -211,7 +211,7 @@ then the exact word span at level `D ^ 2` is the full matrix algebra.
 
 Paper: arXiv:0909.5347, Theorem 1 case (3); Wolf, Theorem 6.9.
 -/
-theorem wordSpan_eq_top_of_isPrimitivePaper_of_noninvertible_eigenvector
+lemma wordSpan_eq_top_of_isPrimitivePaper_of_noninvertible_eigenvector
     [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -229,7 +229,7 @@ theorem wordSpan_eq_top_of_isPrimitivePaper_of_noninvertible_eigenvector
 
 Paper: arXiv:0909.5347, Theorem 1 case (3); Wolf, Theorem 6.9.
 -/
-theorem iIndex_le_sq_of_noninvertible_eigenvector
+lemma iIndex_le_sq_of_noninvertible_eigenvector
     [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -311,7 +311,7 @@ If `A` is normalized and primitive in the paper's sense and some Kraus operator
 
 Paper: arXiv:0909.5347, Theorem 1 case (2); Wolf, Theorem 6.9.
 -/
-theorem wordSpan_eq_top_of_isPrimitivePaper_of_isUnit
+lemma wordSpan_eq_top_of_isPrimitivePaper_of_isUnit
     [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -326,7 +326,7 @@ theorem wordSpan_eq_top_of_isPrimitivePaper_of_isUnit
 
 Paper: arXiv:0909.5347, Theorem 1 case (2); Wolf, Theorem 6.9.
 -/
-theorem iIndex_le_of_isPrimitivePaper_of_isUnit
+lemma iIndex_le_of_isPrimitivePaper_of_isUnit
     [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/docs/paper-gaps/quantum_wielandt_deviation.tex
+++ b/docs/paper-gaps/quantum_wielandt_deviation.tex
@@ -9,7 +9,7 @@
 
 \title{The One-Step Subspace in the Quantum Wielandt Inequality}
 \author{}
-\date{2026-04-30}
+\date{2026-05-06}
 
 \begin{document}
 \maketitle
@@ -88,31 +88,31 @@ formal equivalence between the primitive condition used by Sanz--Pérez-García-
 and eventual full Kraus rank under normalization is in
 \path{TNLean/Wielandt/Primitivity/Equivalence.lean:169--191}.}
 
-The two improved estimates are where the statements diverge. The formal
-invertible case assumes that one of the Kraus matrices, say $A_{i_0}$, is
-invertible; under that assumption it proves
+The two improved estimates now use the paper's one-step subspace hypotheses.
+For the invertible case, the formal statement assumes a matrix
+\(X\in S_1(A)\) and \(X\) invertible; under that assumption it proves
 \[
   S_{D^2-\operatorname{kr}(A)+1}(A)=M_D(\mathbb C).
 \]
-The formal non-invertible case assumes that one Kraus matrix $A_{i_0}$ is
-non-invertible and has a nonzero eigenvalue; under that assumption it proves
+For the non-invertible case, the formal statement assumes a matrix
+\(X\in S_1(A)\), \(X\) non-invertible, and a nonzero eigenvalue of \(X\);
+under that assumption it proves
 \[
   S_{D^2}(A)=M_D(\mathbb C).
 \]
-The paper's hypotheses are weaker: they allow the invertible or non-invertible
-matrix to be any element of $S_1(A)$, hence any linear combination of the Kraus
-matrices.\footnote{The formal invertible case is
-\leanid{MPSTensor.wordSpan\_eq\_top\_of\_isPrimitivePaper\_of\_isUnit} and
-\leanid{MPSTensor.iIndex\_le\_of\_isPrimitivePaper\_of\_isUnit} in
-\path{TNLean/Wielandt/PaperResults/WielandtInequality.lean:182--217}. The
-formal non-invertible case is
-\leanid{MPSTensor.wordSpan\_eq\_top\_of\_isPrimitivePaper\_of\_noninvertible\_eigenvector}
-and \leanid{MPSTensor.iIndex\_le\_sq\_of\_noninvertible\_eigenvector} in
-\path{TNLean/Wielandt/PaperResults/WielandtInequality.lean:119--178}.}
+These are the hypotheses in \cite[Theorem~1]{Sanz2010Quantum}.  The older
+chosen-Kraus statements are still present, but only as corollaries obtained by
+taking \(X=A_{i_0}\).\footnote{The paper-facing names are the two
+``\path{mem_wordSpan_one}'' word-span and index statements for the invertible
+case, and the two corresponding
+``\path{mem_wordSpan_one_of_noninvertible_eigenvector}'' statements for the
+non-invertible case, in
+\path{TNLean/Wielandt/PaperResults/WielandtInequality.lean}.  The shorter
+chosen-generator statements in the same file are corollaries.}
 
-\section{The mathematical difference}
+\section{Resolved one-step-subspace issue}
 
-The distinction is small but genuine. Suppose first that the paper gives an
+The former distinction was small but genuine. Suppose first that the paper gives an
 invertible matrix $X\in S_1(A)$. Since $X$ is a linear combination of the
 $A_i$, multiplication by $X$ sends $S_n(A)$ into $S_{n+1}(A)$. Since $X$ is
 invertible, this multiplication is injective on $M_D(\mathbb C)$. This is the
@@ -120,24 +120,16 @@ linear-algebra reason why the dimensions of the spaces $S_n(A)$ cannot stagnate
 for too long; it is the dimension-growth step used in the proof of the sharper
 bound.
 
-If $X$ is itself one of the Kraus matrices, then every product $XW$ with
-$W\in S_n(A)$ is visibly a linear combination of words of length $n+1$ whose
-first letter is fixed. This is the case now covered by the formal theorem. If
-$X$ is only a linear combination of Kraus matrices, the same inclusion
-$XS_n(A)\subseteq S_{n+1}(A)$ is still true, but it has to be used in that more
-linear form. The proof should not need the matrix $X$ to be a distinguished
-letter; it only needs $X$ to lie in $S_1(A)$ and to have the relevant spectral
-property.
+The formal proof now uses this one-step-subspace version.  It adjoins the
+chosen \(X\in S_1(A)\) as a redundant generator and proves that the exact word
+spans and the Kraus rank are unchanged.  This reduces the paper's hypothesis to
+the single-generator argument without changing the channel invariant being
+bounded.
 
 The same issue appears in the non-invertible case. The source hypothesis gives
 a matrix $X\in S_1(A)$ which is singular but has a nonzero eigenvalue. The
-formal theorem proves the corresponding statement when this matrix is one of
-the Kraus matrices. The natural generalization is to run the same argument with
-an arbitrary such $X\in S_1(A)$, using the inclusion $XS_n(A)\subseteq S_{n+1}(A)$
-rather than a distinguished first letter. Equivalently, one could prove a change
-of Kraus representation which places $X$ among the displayed Kraus operators
-without changing the channel or the spaces $S_n(A)$ in the relevant way. Either
-approach would match the paper's statement.
+formal proof again uses the redundant-generator construction, so the theorem is
+stated for an arbitrary such \(X\), not only for a distinguished Kraus matrix.
 
 \section{What is not a discrepancy}
 
@@ -170,18 +162,16 @@ intermediate hypothesis is legitimate.
 \section{Conclusion}
 
 The general quantum Wielandt bound has been formalized with the right index and
-with the paper's linearly independent Kraus count made explicit. The remaining
-difference concerns only the two improved estimates.
+with the paper's linearly independent Kraus count made explicit. The two
+improved estimates have also been upgraded to the paper's hypotheses: the
+distinguished matrix is any element of \(S_1(A)\) with the required spectral
+property. The chosen-Kraus statements remain useful corollaries, but they should
+not be cited as the paper-facing theorem surface.
 
-For those estimates, the paper assumes that the one-step space $S_1(A)$ contains
-a matrix with a specified spectral property. The formal statements presently
-assume that such a matrix is one of the chosen Kraus operators. This is a
-stronger hypothesis. Mathematically, the expected correction is clear: prove the
-two arguments for an arbitrary qualifying matrix $X\in S_1(A)$, using the
-inclusion $XS_n(A)\subseteq S_{n+1}(A)$ and the same dimension-growth reasoning,
-or prove an explicit Kraus-representation invariance result which reduces the
-paper's hypotheses to the chosen-Kraus-matrix hypotheses without changing the
-channel or the index $i(A)$.
+The remaining caution is theorem-surface hygiene.  Cumulative-span declarations
+and bundled analysis chains are useful support lemmas for the proof, while the
+paper-facing results are the exact-length statements about \(S_n(A)\) and the
+index \(i(A)\).
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/quantum_wielandt_deviation.tex
+++ b/docs/paper-gaps/quantum_wielandt_deviation.tex
@@ -102,11 +102,12 @@ under that assumption it proves
 \]
 These are the hypotheses in \cite[Theorem~1]{Sanz2010Quantum}.  The older
 chosen-Kraus statements are still present, but only as corollaries obtained by
-taking \(X=A_{i_0}\).\footnote{The paper-facing names are the two
-``\path{mem_wordSpan_one}'' word-span and index statements for the invertible
-case, and the two corresponding
-``\path{mem_wordSpan_one_of_noninvertible_eigenvector}'' statements for the
-non-invertible case, in
+taking \(X=A_{i_0}\).\footnote{The paper-facing declarations are
+\path{wordSpan_eq_top_of_isPrimitivePaper_of_mem_wordSpan_one_of_isUnit} and
+\path{iIndex_le_of_mem_wordSpan_one_of_isUnit} for the invertible case, and
+\path{wordSpan_eq_top_of_isPrimitivePaper_of_mem_wordSpan_one_of_noninvertible_eigenvector}
+and \path{iIndex_le_sq_of_mem_wordSpan_one_of_noninvertible_eigenvector} for
+the non-invertible case, all in
 \path{TNLean/Wielandt/PaperResults/WielandtInequality.lean}.  The shorter
 chosen-generator statements in the same file are corollaries.}
 
@@ -122,9 +123,12 @@ bound.
 
 The formal proof now uses this one-step-subspace version.  It adjoins the
 chosen \(X\in S_1(A)\) as a redundant generator and proves that the exact word
-spans and the Kraus rank are unchanged.  This reduces the paper's hypothesis to
-the single-generator argument without changing the channel invariant being
-bounded.
+spans and the Kraus rank are unchanged.  The span equality is
+\path{wordSpan_oneStepAugment_eq}, and the Kraus-rank equality is
+\path{krausRank_oneStepAugment}, both in
+\path{TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean}.  This reduces the
+paper's hypothesis to the single-generator argument without changing the
+channel invariant being bounded.
 
 The same issue appears in the non-invertible case. The source hypothesis gives
 a matrix $X\in S_1(A)$ which is singular but has a nonzero eigenvalue. The

--- a/docs/paper-gaps/quantum_wielandt_deviation_v1.tex
+++ b/docs/paper-gaps/quantum_wielandt_deviation_v1.tex
@@ -9,7 +9,7 @@
 
 \title{The One-Step Subspace in the Quantum Wielandt Inequality}
 \author{}
-\date{2026-05-06}
+\date{2026-04-30}
 
 \begin{document}
 \maketitle
@@ -88,39 +88,31 @@ formal equivalence between the primitive condition used by Sanz--Pérez-García-
 and eventual full Kraus rank under normalization is in
 \path{TNLean/Wielandt/Primitivity/Equivalence.lean:169--191}.}
 
-The two improved estimates now use the paper's one-step subspace hypotheses.
-For the invertible case, the formal statement assumes a matrix
-\(X\in S_1(A)\) and \(X\) invertible; under that assumption it proves
+The two improved estimates are where the statements diverge. The formal
+invertible case assumes that one of the Kraus matrices, say $A_{i_0}$, is
+invertible; under that assumption it proves
 \[
   S_{D^2-\operatorname{kr}(A)+1}(A)=M_D(\mathbb C).
 \]
-For the non-invertible case, the formal statement assumes a matrix
-\(X\in S_1(A)\), \(X\) non-invertible, and a nonzero eigenvalue of \(X\);
-under that assumption it proves
+The formal non-invertible case assumes that one Kraus matrix $A_{i_0}$ is
+non-invertible and has a nonzero eigenvalue; under that assumption it proves
 \[
   S_{D^2}(A)=M_D(\mathbb C).
 \]
-These are the hypotheses in \cite[Theorem~1]{Sanz2010Quantum}.  The older
-chosen-Kraus statements are still present, but only as corollaries obtained by
-taking \(X=A_{i_0}\).\footnote{The paper-facing declarations are
-\leanid{MPSTensor.wordSpan\_\allowbreak eq\_\allowbreak top\_\allowbreak of\_\allowbreak
-isPrimitivePaper\_\allowbreak of\_\allowbreak mem\_\allowbreak wordSpan\_\allowbreak one\_\allowbreak
-of\_\allowbreak isUnit} and
-\leanid{MPSTensor.iIndex\_\allowbreak le\_\allowbreak of\_\allowbreak mem\_\allowbreak
-wordSpan\_\allowbreak one\_\allowbreak of\_\allowbreak isUnit} for the invertible case, and
-\leanid{MPSTensor.wordSpan\_\allowbreak eq\_\allowbreak top\_\allowbreak of\_\allowbreak
-isPrimitivePaper\_\allowbreak of\_\allowbreak mem\_\allowbreak wordSpan\_\allowbreak one\_\allowbreak
-of\_\allowbreak noninvertible\_\allowbreak eigenvector} and
-\leanid{MPSTensor.iIndex\_\allowbreak le\_\allowbreak sq\_\allowbreak of\_\allowbreak
-mem\_\allowbreak wordSpan\_\allowbreak one\_\allowbreak of\_\allowbreak noninvertible\_\allowbreak
-eigenvector} for
-the non-invertible case, all in
-\path{TNLean/Wielandt/PaperResults/WielandtInequality.lean}.  The shorter
-chosen-generator statements in the same file are corollaries.}
+The paper's hypotheses are weaker: they allow the invertible or non-invertible
+matrix to be any element of $S_1(A)$, hence any linear combination of the Kraus
+matrices.\footnote{The formal invertible case is
+\leanid{MPSTensor.wordSpan\_eq\_top\_of\_isPrimitivePaper\_of\_isUnit} and
+\leanid{MPSTensor.iIndex\_le\_of\_isPrimitivePaper\_of\_isUnit} in
+\path{TNLean/Wielandt/PaperResults/WielandtInequality.lean:182--217}. The
+formal non-invertible case is
+\leanid{MPSTensor.wordSpan\_eq\_top\_of\_isPrimitivePaper\_of\_noninvertible\_eigenvector}
+and \leanid{MPSTensor.iIndex\_le\_sq\_of\_noninvertible\_eigenvector} in
+\path{TNLean/Wielandt/PaperResults/WielandtInequality.lean:119--178}.}
 
-\section{Resolved one-step-subspace issue}
+\section{The mathematical difference}
 
-The former distinction was small but genuine. Suppose first that the paper gives an
+The distinction is small but genuine. Suppose first that the paper gives an
 invertible matrix $X\in S_1(A)$. Since $X$ is a linear combination of the
 $A_i$, multiplication by $X$ sends $S_n(A)$ into $S_{n+1}(A)$. Since $X$ is
 invertible, this multiplication is injective on $M_D(\mathbb C)$. This is the
@@ -128,19 +120,24 @@ linear-algebra reason why the dimensions of the spaces $S_n(A)$ cannot stagnate
 for too long; it is the dimension-growth step used in the proof of the sharper
 bound.
 
-The formal proof now uses this one-step-subspace version.  It adjoins the
-chosen \(X\in S_1(A)\) as a redundant generator and proves that the exact word
-spans and the Kraus rank are unchanged.  The span equality is
-\leanid{MPSTensor.wordSpan\_oneStepAugment\_eq}, and the Kraus-rank equality is
-\leanid{MPSTensor.krausRank\_oneStepAugment}, both in
-\path{TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean}.  This reduces the
-paper's hypothesis to the single-generator argument without changing the
-channel invariant being bounded.
+If $X$ is itself one of the Kraus matrices, then every product $XW$ with
+$W\in S_n(A)$ is visibly a linear combination of words of length $n+1$ whose
+first letter is fixed. This is the case now covered by the formal theorem. If
+$X$ is only a linear combination of Kraus matrices, the same inclusion
+$XS_n(A)\subseteq S_{n+1}(A)$ is still true, but it has to be used in that more
+linear form. The proof should not need the matrix $X$ to be a distinguished
+letter; it only needs $X$ to lie in $S_1(A)$ and to have the relevant spectral
+property.
 
 The same issue appears in the non-invertible case. The source hypothesis gives
 a matrix $X\in S_1(A)$ which is singular but has a nonzero eigenvalue. The
-formal proof again uses the redundant-generator construction, so the theorem is
-stated for an arbitrary such \(X\), not only for a distinguished Kraus matrix.
+formal theorem proves the corresponding statement when this matrix is one of
+the Kraus matrices. The natural generalization is to run the same argument with
+an arbitrary such $X\in S_1(A)$, using the inclusion $XS_n(A)\subseteq S_{n+1}(A)$
+rather than a distinguished first letter. Equivalently, one could prove a change
+of Kraus representation which places $X$ among the displayed Kraus operators
+without changing the channel or the spaces $S_n(A)$ in the relevant way. Either
+approach would match the paper's statement.
 
 \section{What is not a discrepancy}
 
@@ -173,16 +170,18 @@ intermediate hypothesis is legitimate.
 \section{Conclusion}
 
 The general quantum Wielandt bound has been formalized with the right index and
-with the paper's linearly independent Kraus count made explicit. The two
-improved estimates have also been upgraded to the paper's hypotheses: the
-distinguished matrix is any element of \(S_1(A)\) with the required spectral
-property. The chosen-Kraus statements remain useful corollaries, but they should
-not be cited as the paper-facing theorem surface.
+with the paper's linearly independent Kraus count made explicit. The remaining
+difference concerns only the two improved estimates.
 
-The remaining caution is theorem-surface hygiene.  Cumulative-span declarations
-and bundled analysis chains are useful support lemmas for the proof, while the
-paper-facing results are the exact-length statements about \(S_n(A)\) and the
-index \(i(A)\).
+For those estimates, the paper assumes that the one-step space $S_1(A)$ contains
+a matrix with a specified spectral property. The formal statements presently
+assume that such a matrix is one of the chosen Kraus operators. This is a
+stronger hypothesis. Mathematically, the expected correction is clear: prove the
+two arguments for an arbitrary qualifying matrix $X\in S_1(A)$, using the
+inclusion $XS_n(A)\subseteq S_{n+1}(A)$ and the same dimension-growth reasoning,
+or prove an explicit Kraus-representation invariance result which reduces the
+paper's hypotheses to the chosen-Kraus-matrix hypotheses without changing the
+channel or the index $i(A)$.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Motivation

The Wielandt paper-gap note still described the improved estimates as stronger-than-source because it said the formal statements required the special matrix to be a chosen Kraus operator. Current `main` has already upgraded those statements to the paper's one-step subspace hypotheses `X ∈ S₁(A)`, with chosen-generator statements retained only as corollaries.

## Description

- Update `docs/paper-gaps/quantum_wielandt_deviation.tex` to mark the one-step-subspace issue as resolved.
- State that the paper-facing improved estimates now use an arbitrary qualifying `X ∈ S₁(A)`.
- Cite the exact paper-facing Lean declarations and the redundant-generator lemmas `wordSpan_oneStepAugment_eq` and `krausRank_oneStepAugment`.
- Demote the shorter chosen-generator declarations in `TNLean/Wielandt/PaperResults/WielandtInequality.lean` from `theorem` to `lemma`, because they are corollaries of the source-facing one-step-subspace statements.
- Keep the remaining warning focused on theorem-surface hygiene: cumulative-span declarations and analysis chains are support lemmas, while the source-facing results are exact-length statements about `S_n(A)` and `i(A)`.

Supports #1278, #1282, and #1170.

## Validation

- `latexmk -pdf -interaction=nonstopmode -halt-on-error quantum_wielandt_deviation.tex` from `docs/paper-gaps/`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake env lean TNLean/Wielandt/PaperResults/WielandtInequality.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation updates and Lean declaration kind changes (`theorem`→`lemma`) for corollary statements, with no proof logic modified.
> 
> **Overview**
> Updates the quantum Wielandt paper-gap note to reflect that the *improved estimates now match the paper’s one-step subspace hypotheses* (allowing an arbitrary `X ∈ S₁(A)` with the required spectral property), and documents the redundant-generator/invariance lemmas used to justify this.
> 
> In `WielandtInequality.lean`, the older “chosen Kraus operator” corollaries are demoted from `theorem` to `lemma` to clarify they are not the primary paper-facing results. Adds `quantum_wielandt_deviation_v1.tex` as a snapshot of the prior note and updates the note date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211f1e1209395ebce593b6b9c56f48aa980aacb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->