### PR TITLE
style(MPS/CanonicalForm): demote BNT-cover hypothesis bridges

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
@@ -196,7 +196,7 @@ The structural theorem already supplies the length-zero equation for the two zer
 nonzero-sector decompositions. A proportional-decomposition conclusion matches the nonzero
 blocks by a permutation with equal bond dimensions, so the nonzero length-zero contributions
 cancel. -/
-theorem zeroTail_eq_of_proportionalDecompositionConclusion
+lemma zeroTail_eq_of_proportionalDecompositionConclusion
     {d rA rB zeroTailA zeroTailB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
@@ -347,11 +347,13 @@ def ofCommonPrimitiveData
   ncfA := by
     have hDimA : ∀ x, 0 < dimA x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimA x))
     exact isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA hAntiA
+      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA
+      hAntiA.antitone
   ncfB := by
     have hDimB : ∀ x, 0 < dimB x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimB x))
     exact isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB hAntiB
+      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB
+      hAntiB.antitone
   notGpeA := hNotGpeA
   notGpeB := hNotGpeB
   zeroTail_eq := hZeroTail
@@ -397,10 +399,12 @@ def ofCommonPrimitiveData_zeroTailIdentity
   have hDimB : ∀ x, 0 < dimB x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimB x))
   have hNcfA : IsNormalCanonicalForm (d := blockPhysDim d p) μA blocksA :=
     isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA hAntiA
+      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA
+      hAntiA.antitone
   have hNcfB : IsNormalCanonicalForm (d := blockPhysDim d p) μB blocksB :=
     isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB hAntiB
+      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB
+      hAntiB.antitone
   have hMatch : ProportionalDecompositionConclusion (d := blockPhysDim d p) blocksA blocksB :=
     fundamentalTheorem_of_separated_normalCFBNT_data
       blocksA blocksB hNcfA hNotGpeA hNcfB hNotGpeB hDecomp

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
@@ -347,13 +347,11 @@ def ofCommonPrimitiveData
   ncfA := by
     have hDimA : ∀ x, 0 < dimA x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimA x))
     exact isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA
-      hAntiA.antitone
+      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA hAntiA
   ncfB := by
     have hDimB : ∀ x, 0 < dimB x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimB x))
     exact isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB
-      hAntiB.antitone
+      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB hAntiB
   notGpeA := hNotGpeA
   notGpeB := hNotGpeB
   zeroTail_eq := hZeroTail
@@ -399,12 +397,10 @@ def ofCommonPrimitiveData_zeroTailIdentity
   have hDimB : ∀ x, 0 < dimB x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimB x))
   have hNcfA : IsNormalCanonicalForm (d := blockPhysDim d p) μA blocksA :=
     isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA
-      hAntiA.antitone
+      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA hAntiA
   have hNcfB : IsNormalCanonicalForm (d := blockPhysDim d p) μB blocksB :=
     isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB
-      hAntiB.antitone
+      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB hAntiB
   have hMatch : ProportionalDecompositionConclusion (d := blockPhysDim d p) blocksA blocksB :=
     fundamentalTheorem_of_separated_normalCFBNT_data
       blocksA blocksB hNcfA hNotGpeA hNcfB hNotGpeB hDecomp

--- a/TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean
@@ -35,10 +35,10 @@ phase-class BNT construction separately to the two families gives sector bases
 with positive dimensions, left-canonical normalization, self-overlap limit `1`,
 and off-overlap limit `0` for distinct representatives.
 
-This theorem contains only the one-sided overlap-orthogonality conclusions. It
+This lemma contains only the one-sided overlap-orthogonality conclusions. It
 does not assume or prove the two-family finite-length span comparison or
 one-site injectivity hypotheses needed for `SectorBasisOverlapSpanHypotheses`. -/
-theorem sectorBasisOverlapOrthoHypotheses_of_reindexedNonzeroParts
+lemma sectorBasisOverlapOrthoHypotheses_of_reindexedNonzeroParts
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -96,7 +96,7 @@ of the nonzero-weight blocks, and equality of their finite-length MPV spans. The
 these can be supplied by a common MPV phase cover (via
 `CommonPrimitiveSpanHypotheses.of_commonPhaseCover`) or by a BNT proportional-decomposition
 comparison (via `CommonPrimitiveProportionalHypotheses.toSpanHypotheses`). -/
-theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts
+lemma sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -183,7 +183,7 @@ This is the common-phase-cover form of
 finite-length span equality directly, it asks for a common MPV phase cover of the two
 nonzero-weight block families. The cover supplies the span equality through
 `MPVCommonPhaseCover.span_eq`. -/
-theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover
+lemma sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -272,8 +272,8 @@ This is the BNT-cover form of
 The additional input provides the BNT-level data for the reindexed nonzero-sector
 families, with whatever total dimensions support the proportional-decomposition
 data. The conversion from BNT-cover hypotheses to common primitive phase-cover
-hypotheses then lets the common-phase-cover theorem supply the overlap-span data. -/
-theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
+hypotheses then lets the common-phase-cover lemma supply the overlap-span data. -/
+lemma sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -344,8 +344,8 @@ theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover
 This is the explicit-data form of
 `sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover`. It forms the
 BNT-cover hypotheses from the common primitive structural data together with the
-BNT comparison inputs, then applies the BNT-cover overlap-span theorem. -/
-theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData
+BNT comparison inputs, then applies the BNT-cover overlap-span lemma. -/
+lemma sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -426,7 +426,7 @@ deriving the zero-tail identity.**
 This form of `sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData`
 removes the explicit zero-tail equality from the hypotheses. The identity is derived
 from the length-zero MPV equality and proportional-decomposition data. -/
-theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdentity
+lemma sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdentity
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -507,7 +507,7 @@ Normal canonical form together with BNT separation for the common primitive
 families, proportional-decomposition data, and injectivity of the nonzero blocks
 imply the overlap-span hypotheses.  The equality of the zero tails follows from
 the length-zero proportionality relation. -/
-theorem sectorBasisOverlapSpanHypotheses_of_commonPrimitiveNormalBNTData_zeroTailIdentity
+lemma sectorBasisOverlapSpanHypotheses_of_commonPrimitiveNormalBNTData_zeroTailIdentity
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -584,7 +584,7 @@ This is the proportional-comparison form of
 conclusion for the two nonzero-weight block families gives a common MPV phase cover, hence the
 finite-length span equality needed to construct BNT representatives of MPV
 phase-equivalence classes. -/
-theorem sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_proportional
+lemma sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_proportional
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1383,8 +1383,8 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	hypotheses. The preceding lemma supplies the common MPV phase cover.
 \end{proof}
 
-\begin{theorem}[Reindexed sectors give single-family overlap data]%
-\label{thm:sector_basis_overlap_ortho_reindexed}
+\begin{lemma}[Reindexed sectors give single-family overlap data]%
+\label{lem:sector_basis_overlap_ortho_reindexed}
 	\lean{MPSTensor.sectorBasisOverlapOrthoHypotheses_of_reindexedNonzeroParts}
 	\leanok
 	\uses{def:common_sector_relabeling_hypothesis,
@@ -1394,7 +1394,7 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	blocking and reindexing, each nonzero-sector family admits a BNT sector
 	decomposition with positive-length MPV agreement, BNT data, and the
 	single-family overlap-orthogonality hypotheses.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -1406,8 +1406,8 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	families.
 \end{proof}
 
-\begin{theorem}[Phase-cover data give overlap-span hypotheses]%
-\label{thm:sector_basis_overlap_span_reindexed_commonPhaseCover}
+\begin{lemma}[Phase-cover data give overlap-span hypotheses]%
+\label{lem:sector_basis_overlap_span_reindexed_commonPhaseCover}
 	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_commonPhaseCover}
 	\leanok
 	\uses{def:common_primitive_phase_cover_hypotheses,
@@ -1418,7 +1418,7 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	families satisfy the phase-cover hypotheses, then the associated sector
 	decompositions have BNT data, agree as full MPV families, and satisfy the
 	primitive overlap-span hypotheses.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -1429,8 +1429,8 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	gives the sector decompositions and their primitive overlap-span hypotheses.
 \end{proof}
 
-\begin{theorem}[BNT-cover data give overlap-span hypotheses]%
-\label{thm:sector_basis_overlap_span_reindexed_bnt_cover}
+\begin{lemma}[BNT-cover data give overlap-span hypotheses]%
+\label{lem:sector_basis_overlap_span_reindexed_bnt_cover}
 	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_reindexedNonzeroParts_bntCover}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
@@ -1441,24 +1441,24 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	families satisfy the BNT-cover hypotheses, then the associated sector
 	decompositions have BNT data, agree as full MPV families, and satisfy the
 	primitive overlap-span hypotheses.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
 	\uses{lem:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses,
-		thm:sector_basis_overlap_span_reindexed_commonPhaseCover}
+		lem:sector_basis_overlap_span_reindexed_commonPhaseCover}
 	Convert the BNT-cover hypotheses for the produced families into common
 	phase-cover hypotheses. The common phase-cover construction then gives the
 	sector decompositions and their primitive overlap-span hypotheses.
 \end{proof}
 
-\begin{theorem}[Explicit BNT data give overlap-span hypotheses]%
-\label{thm:sector_basis_overlap_span_commonPrimitiveBNTData}
+\begin{lemma}[Explicit BNT data give overlap-span hypotheses]%
+\label{lem:sector_basis_overlap_span_commonPrimitiveBNTData}
 	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis,
-		thm:sector_basis_overlap_span_reindexed_bnt_cover}
+		lem:sector_basis_overlap_span_reindexed_bnt_cover}
 	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
 	identification hypothesis for the cyclic-sector data. The common-sector
 	structural theorem produces common primitive nonzero-sector families. If
@@ -1466,24 +1466,24 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	equal zero-tail dimension, one-site injectivity, and proportional-decomposition
 	data, then the associated sector decompositions have BNT data, agree as full
 	MPV families, and satisfy the primitive overlap-span hypotheses.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis,
-		thm:sector_basis_overlap_span_reindexed_bnt_cover}
+		lem:sector_basis_overlap_span_reindexed_bnt_cover}
 	First form the BNT-cover hypotheses for the produced families from the stated
-	common primitive data. Then apply the BNT-cover overlap-span theorem.
+	common primitive data. Then apply the BNT-cover overlap-span lemma.
 \end{proof}
 
-\begin{theorem}[Explicit BNT data with derived zero-tail identity give overlap-span hypotheses]%
-\label{thm:sector_basis_overlap_span_commonPrimitiveBNTData_zeroTailIdentity}
+\begin{lemma}[Explicit BNT data with derived zero-tail identity give overlap-span hypotheses]%
+\label{lem:sector_basis_overlap_span_commonPrimitiveBNTData_zeroTailIdentity}
 	\lean{MPSTensor.sectorBasisOverlapSpanHypotheses_of_commonPrimitiveBNTData_zeroTailIdentity}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
 		def:common_sector_relabeling_hypothesis,
-		thm:sector_basis_overlap_span_reindexed_bnt_cover}
+		lem:sector_basis_overlap_span_reindexed_bnt_cover}
 	Let $A$ and $B$ have the same MPV family, and assume the blocked-word
 	identification hypothesis for the cyclic-sector data. The common-sector
 	structural theorem produces common primitive nonzero-sector families. If
@@ -1492,15 +1492,15 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	MPV identity determines the zero tail, and the associated sector decompositions
 	have BNT data, agree as full MPV families, and satisfy the primitive
 	overlap-span hypotheses.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
-		thm:sector_basis_overlap_span_reindexed_bnt_cover}
+		lem:sector_basis_overlap_span_reindexed_bnt_cover}
 	First form the BNT-cover hypotheses for the produced families, deriving the
 	zero-tail identity from the proportional-decomposition data. Then apply the
-	BNT-cover overlap-span theorem.
+	BNT-cover overlap-span lemma.
 \end{proof}
 
 \begin{theorem}[Common primitive sectors with span hypotheses]%


### PR DESCRIPTION
## Motivation

The common primitive BNT-cover and overlap-span bridge declarations are converters between bundled hypotheses, not source-level statements of the non-periodic Fundamental Theorem. Keeping them as `theorem`s makes the after-blocking/BNT surface look more substantial than the source comparison warrants.

## Description

- Demote common primitive span/phase/proportional/BNT-cover bridge declarations in `CommonPrimitiveProportionalData.lean` from `theorem` to `lemma`.
- Demote adjacent overlap-span bridge declarations in `OverlapSpanComparison.lean` from `theorem` to `lemma`, including the common-phase-cover, BNT-cover, explicit BNT-data, zero-tail-identity, normal-BNT, and proportional-comparison forms.
- Keep the mathematical content unchanged: the declarations still convert the same internal hypotheses into phase-cover, span, and overlap-span hypotheses.
- Update Chapter 11 blueprint entries and references from theorem labels to lemma labels for the demoted bridge facts.

Supports #1282, #1334, and #1170.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/OverlapSpanComparison.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are proof-style refactors (switching `theorem` to `lemma`) plus documentation label updates, with no expected impact on semantics but potential for minor downstream reference/label churn.
> 
> **Overview**
> Demotes several proof “bridge” declarations from `theorem` to `lemma` in `CommonPrimitiveProportionalData.lean` and `OverlapSpanComparison.lean`, including the zero-tail cancellation lemma and multiple overlap-span hypothesis constructors (common-phase-cover, BNT-cover, explicit BNT data, derived zero-tail identity, normal-BNT, and proportional-comparison forms).
> 
> Updates the Chapter 11 blueprint (`ch11_assembly.tex`) to match, converting the corresponding environment types and labels/references from theorem to lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b70758af38597d0d3fec9024fc5764fbc2313f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->