### PR TITLE
style(MPS/CanonicalForm): demote common-sector transport bridges

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -49,7 +49,7 @@ BNT-separated.
 
 It combines the representative normal-canonical-form statement with the
 explicit hypothesis that distinct representatives are not gauge-phase equivalent. -/
-theorem isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
+lemma isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
     {d r : ℕ} {dim : Fin r → ℕ}
     {blocks : (k : Fin r) → MPSTensor d (dim k)}
     (F : CommonBlockedCyclicSectorFamily blocks)
@@ -379,7 +379,7 @@ abbrev CommonGroupedBlockCastHypothesis (d : ℕ) : Prop :=
 namespace CommonGroupedBlockCastHypothesis
 
 /-- The canonical coordinate grouping for common blocked cyclic-sector families. -/
-theorem of_flattenWordOfBlock_cast_eq (d : ℕ) : CommonGroupedBlockCastHypothesis d := by
+lemma of_flattenWordOfBlock_cast_eq (d : ℕ) : CommonGroupedBlockCastHypothesis d := by
   intro r dim blocks F k
   exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
     (fun hp_eq h_card i =>
@@ -387,7 +387,7 @@ theorem of_flattenWordOfBlock_cast_eq (d : ℕ) : CommonGroupedBlockCastHypothes
 
 /-- The coordinate-grouping assertion implies the one-sided reindexing hypothesis
 used by the common-sector structural theorem. -/
-theorem toRelabelingHypothesis {d : ℕ}
+lemma toRelabelingHypothesis {d : ℕ}
     (hCast : CommonGroupedBlockCastHypothesis d) :
     CommonSectorRelabelingHypothesis d := by
   intro r dim μ blocks F

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -62,7 +62,7 @@ lemma isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
     IsNormalCanonicalFormBNT (d := blockPhysDim d p)
       (F.commonRepresentativeWeight μ) (F.commonRepresentativeBlocksAt hp) where
   toIsNormalCanonicalForm :=
-    F.isNormalCanonicalForm_commonRepresentativeBlocksAt hp μ hμ hAnti.antitone
+    F.isNormalCanonicalForm_commonRepresentativeBlocksAt hp μ hμ hAnti
   mu_strict_anti := hAnti
   blocks_not_equiv := hNotGpe
 

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -62,7 +62,7 @@ lemma isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
     IsNormalCanonicalFormBNT (d := blockPhysDim d p)
       (F.commonRepresentativeWeight μ) (F.commonRepresentativeBlocksAt hp) where
   toIsNormalCanonicalForm :=
-    F.isNormalCanonicalForm_commonRepresentativeBlocksAt hp μ hμ hAnti
+    F.isNormalCanonicalForm_commonRepresentativeBlocksAt hp μ hμ hAnti.antitone
   mu_strict_anti := hAnti
   blocks_not_equiv := hNotGpe
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1838,8 +1838,8 @@ the common length $p=m_k e_k$.
 	these derived sector data.
 \end{proof}
 
-\begin{theorem}[Common-sector representatives form a BNT-separated normal canonical form]%
-\label{thm:common_representative_normal_bnt}
+\begin{lemma}[Common-sector representatives form a BNT-separated normal canonical form]%
+\label{lem:common_representative_normal_bnt}
 	\lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeWeight_strictAnti_of_weight_strictAnti,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_tp,
 		MPSTensor.CommonBlockedCyclicSectorFamily.commonRepresentativeBlocksAt_primitive,
@@ -1857,7 +1857,7 @@ the common length $p=m_k e_k$.
 	at the prescribed length.  If distinct representatives are not
 	gauge-phase equivalent, then the representative family is in normal
 	canonical form with BNT separation.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{lem:common_blocked_cyclic_sector_derived_properties,

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1556,12 +1556,12 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	common blocked cyclic-sector family satisfies the coordinate-grouping condition
 	for each original nonzero block.  Equivalently, the canonical identification with
 	each iterated blocked alphabet agrees with grouping the direct blocked word into
-	consecutive words of the period-removal length.  The next theorem proves this
+	consecutive words of the period-removal length.  The next lemma proves this
 	assertion from the concrete word-cast construction.
 \end{definition}
 
-	\begin{theorem}[Canonical coordinate grouping]%
-	\label{thm:common_grouped_block_cast_of_flatten_word}
+	\begin{lemma}[Canonical coordinate grouping]%
+	\label{lem:common_grouped_block_cast_of_flatten_word}
 		\lean{MPSTensor.CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq}
 		\leanok
 		\uses{def:common_grouped_block_cast_hypothesis,
@@ -1569,15 +1569,15 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 		The canonical coordinate grouping holds for every common blocked
 		cyclic-sector family.  The proof identifies each grouped block with the
 		corresponding direct blocked word.
-	\end{theorem}
+	\end{lemma}
 
 	\begin{proof}\leanok
 		\uses{lem:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 		Apply the grouped-block cast comparison to each original nonzero block.
 	\end{proof}
 
-	\begin{theorem}[Coordinate grouping gives the word identification]%
-\label{thm:common_grouped_block_cast_to_relabeling}
+	\begin{lemma}[Coordinate grouping gives the word identification]%
+\label{lem:common_grouped_block_cast_to_relabeling}
 		\lean{MPSTensor.CommonGroupedBlockCastHypothesis.toRelabelingHypothesis}
 	\leanok
 	\uses{def:common_grouped_block_cast_hypothesis,
@@ -1587,7 +1587,7 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 		identification used by the common-sector structural theorem holds.  The
 	proof is exactly the weighted finite-sum comparison for direct and iterated
 	blocking applied to each common cyclic-sector family.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -1649,7 +1649,7 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 \begin{proof}
 	\leanok
 	\uses{lem:common_blocked_cyclic_sector_flatten_word_of_block_cast,
-		thm:common_grouped_block_cast_to_relabeling,
+		lem:common_grouped_block_cast_to_relabeling,
 		thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
 	The direct digit computation gives the global coordinate-grouping hypothesis.
 	This implies the blocked-word identification for common sectors.  Applying the
@@ -1813,13 +1813,13 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 
 	\begin{proof}
 		\leanok
-		\uses{thm:common_grouped_block_cast_of_flatten_word,
-			thm:common_grouped_block_cast_to_relabeling,
+		\uses{lem:common_grouped_block_cast_of_flatten_word,
+			lem:common_grouped_block_cast_to_relabeling,
 			thm:afterBlocking_sectorComparison_reindexed_bntCover}
 		Apply
 		Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover} with
 			the word-identification derived from
-		Theorem~\ref{thm:common_grouped_block_cast_to_relabeling} and the BNT-cover
+		Lemma~\ref{lem:common_grouped_block_cast_to_relabeling} and the BNT-cover
 		comparison data from
 		Definition~\ref{def:after_blocking_fundamental_theorem_hypotheses}. The proof
 	then assembles the resulting blocking length, sector decompositions, BNT data,


### PR DESCRIPTION
## Motivation

The common-sector transport declarations package coordinate identifications, leftover zero-block transport, and positive-length MPV transport through the blocked-word reindexing step. They are supporting bridge facts for the after-blocking canonical-form route, not source-level milestones in the non-periodic MPS Fundamental Theorem.

Keeping these as `theorem`s makes the Chapter 11 theorem surface look more paper-facing than it is. The actual common primitive decomposition statements remain theorem-level.

## Description

- Demote common-sector transport bridge declarations in `CommonSectorTransport.lean` from `theorem` to `lemma`.
- Demote the coordinate-grouping bridge declarations `CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq` and `.toRelabelingHypothesis` from `theorem` to `lemma`.
- Update the Chapter 11 blueprint entries, labels, `\uses{}` references, and prose from theorem to lemma for the coordinate-grouping bridges.
- Leave `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` and `unconditional_commonPrimitiveIrreducibleBlocks` as theorems.

Supports #1170, #1282, and #1334.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a declaration-kind and documentation/label update only, with no changes to proof terms or any canonical-form/decomposition logic.
> 
> **Overview**
> Demotes several common-sector “bridge” results from `theorem` to `lemma` in `CommonSectorTransport.lean`, including `isNormalCanonicalFormBNT_commonRepresentativeBlocksAt` and the coordinate-grouping helpers `CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq` / `.toRelabelingHypothesis`.
> 
> Updates the blueprint (Ch. 8 and Ch. 11) to match: theorem environments become lemma environments, labels switch from `thm:` to `lem:`, and all cross-references/`\uses{}` pointers are adjusted accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4485bd51f487d50e610020f2d656e6a6f9e95a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->