### PR TITLE
style(MPS/CanonicalForm): demote proportional comparison wrappers

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -54,10 +54,9 @@ obtained after blocked-word reindexing. If the remaining zero-tail equality, one
 injectivity, and finite-length span equality are supplied for those same families, then the
 zero-tail block-span comparison theorem gives the sector-weight conclusion.
 
-This theorem deliberately keeps the blocked-word reindexing equality and the final span or
-common-cover assertion as hypotheses, so it does not duplicate the separate coordinate and
-common-cover constructions. -/
-theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses
+This lemma states the blocked-word reindexing equality and the final span or
+common-cover assertion as separate hypotheses. -/
+lemma afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -142,10 +141,10 @@ dimensions, injectivity at that blocking level, and a common MPV phase cover --
 then `CommonPrimitivePhaseCoverHypotheses.toSpanHypotheses` gives the span hypotheses
 needed by `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses`.
 
-Thus this theorem isolates the remaining open inputs: the blocked-word relabeling
+Thus this statement isolates the remaining open inputs: the blocked-word relabeling
 equality, the zero-tail/injectivity refinements, and the common phase cover (or
 equivalently the finite-length span equality supplied by that cover). -/
-theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover
+lemma afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
@@ -216,10 +215,10 @@ theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonP
 Assume the blocked-word relabeling statement for cyclic-sector data. The structural
 theorem supplies common primitive nonzero-sector families; if those families carry
 BNT-cover data, then the conversion to phase-cover hypotheses gives the common
-phase-cover hypotheses. The common-phase-cover consumer theorem gives the same
+phase-cover hypotheses. The common-phase-cover comparison gives the same
 sector-weight comparison
 conclusion. -/
-theorem afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
+lemma afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -54,8 +54,8 @@ obtained after blocked-word reindexing. If the remaining zero-tail equality, one
 injectivity, and finite-length span equality are supplied for those same families, then the
 zero-tail block-span comparison theorem gives the sector-weight conclusion.
 
-This lemma states the blocked-word reindexing equality and the final span or
-common-cover assertion as separate hypotheses. -/
+Keeping these comparison inputs explicit lets the same sector data be used after
+either a direct span certificate or a common-cover certificate has supplied it. -/
 lemma afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3852,7 +3852,7 @@ transport the all-zero-block identity through this comparison.
 	collects the resulting primitive irreducible sector decompositions needed for
 	comparison.  Lemma~\ref{lem:common_blocked_cyclic_sector_flatten_word_of_block_cast}
 	supplies the direct word equality for the chosen coordinates.
-	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	Lemma~\ref{lem:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
 	states the exact inputs after this point: equality of the leftover zero-block
 	dimensions, injectivity at the chosen common length, and a common MPV phase cover
 	(or the equivalent finite-length span equality) for the two nonzero-sector

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1140,8 +1140,8 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	hypotheses. The preceding lemma supplies the common MPV phase cover.
 \end{proof}
 
-\begin{theorem}[Common primitive sectors with span hypotheses]%
-\label{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
+\begin{lemma}[Common primitive sectors with span hypotheses]%
+\label{lem:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
 	\leanok
 	\uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed,
@@ -1159,7 +1159,7 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	sector decompositions $P,Q$ agreeing with $A$ and $B$ at all positive lengths,
 	with $P$ and $Q$ generating the same full MPV family, carrying BNT data, and
 	with their sector weights matched up to a permutation and nonzero phases.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -1257,8 +1257,8 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	unconditional decomposition.
 \end{proof}
 
-\begin{theorem}[Common sectors from phase-cover data]%
-\label{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+\begin{lemma}[Common sectors from phase-cover data]%
+\label{lem:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover}
 	\leanok
 	\uses{def:common_primitive_phase_cover_hypotheses,
@@ -1271,11 +1271,11 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	Definition~\ref{def:common_primitive_phase_cover_hypotheses}, then the sector
 	decompositions obtained from the two sides have BNT data, agree as full MPV
 	families, and their sector weights satisfy the matched sector-weight conclusion.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
-	\uses{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses,
+	\uses{lem:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses,
 		lem:common_primitive_phase_cover_hypotheses_to_span_hypotheses}
 	Use Lemma~\ref{lem:common_primitive_phase_cover_hypotheses_to_span_hypotheses}
 		to form the span hypotheses of
@@ -1283,8 +1283,8 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	common-sector comparison theorem with those span hypotheses.
 \end{proof}
 
-\begin{theorem}[Common sectors from BNT-cover data]%
-\label{thm:afterBlocking_sectorComparison_reindexed_bntCover}
+\begin{lemma}[Common sectors from BNT-cover data]%
+\label{lem:afterBlocking_sectorComparison_reindexed_bntCover}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses,
@@ -1294,12 +1294,12 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	theorem gives common primitive nonzero-sector families. If those families
 	satisfy the BNT-cover hypotheses, then the same sector-weight comparison
 	conclusion holds.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
 	\uses{lem:common_primitive_bnt_cover_hypotheses_to_phase_cover_hypotheses,
-		thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+		lem:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
 	Convert the BNT-cover hypotheses for the common primitive nonzero-sector
 	families to common phase-cover hypotheses, and then apply the common-sector
 	comparison theorem with common phase-cover data.
@@ -1367,9 +1367,9 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 		\leanok
 		\uses{lem:common_grouped_block_cast_of_flatten_word,
 			lem:common_grouped_block_cast_to_relabeling,
-			thm:afterBlocking_sectorComparison_reindexed_bntCover}
+			lem:afterBlocking_sectorComparison_reindexed_bntCover}
 		Apply
-		Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover} with
+		Lemma~\ref{lem:afterBlocking_sectorComparison_reindexed_bntCover} with
 			the word-identification derived from
 		Lemma~\ref{lem:common_grouped_block_cast_to_relabeling} and the BNT-cover
 		comparison data from
@@ -1462,11 +1462,11 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	common primitive irreducible nonzero-sector decompositions are now part of the
 	reduction, culminating in
 	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}.
-	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
+	Lemma~\ref{lem:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
 		then states the hypotheses: equality of the
 	zero-tail dimensions, injectivity of the common nonzero-sector blocks, and
 	finite-length MPV span equality.
-	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
+	Lemma~\ref{lem:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
 	adds the zero-tail and injectivity data to the common phase-cover route and
 	therefore gives the same sector-weight conclusion.  Establishing these
 	hypotheses is the mathematical passage from equality of total MPV vectors to the

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -1280,7 +1280,7 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	Use Lemma~\ref{lem:common_primitive_phase_cover_hypotheses_to_span_hypotheses}
 		to form the span hypotheses of
 	Definition~\ref{def:common_primitive_span_hypotheses}.  Then apply the
-	common-sector comparison theorem with those span hypotheses.
+	common-sector comparison lemma with those span hypotheses.
 \end{proof}
 
 \begin{lemma}[Common sectors from BNT-cover data]%
@@ -1302,7 +1302,7 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 		lem:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
 	Convert the BNT-cover hypotheses for the common primitive nonzero-sector
 	families to common phase-cover hypotheses, and then apply the common-sector
-	comparison theorem with common phase-cover data.
+	comparison lemma with common phase-cover data.
 \end{proof}
 
 \begin{definition}[After-blocking BNT-cover comparison hypotheses]%


### PR DESCRIPTION
### Motivation

- Continue the #1282/#1170 cleanup of theorem-level surface around the non-periodic after-blocking comparison.
- Keep source-level comparison statements visually distinct from internal packaging and conversion statements.

### Description

- Demotes the exported wrapper declarations in `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean` from `theorem` to `lemma`.
- Updates the corresponding Chapter 11 blueprint entries, labels, and references from `thm:` to `lem:`.
- Leaves the mathematical statements unchanged.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Addresses #1282
Addresses #1170

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational: changes three exported Lean declarations from `theorem` to `lemma` and updates blueprint LaTeX labels/references accordingly; no proof terms or mathematical statements change.
> 
> **Overview**
> Demotes the after-blocking sector-comparison wrapper statements in `ProportionalComparison.lean` from `theorem` to `lemma`, keeping names, signatures, and proofs unchanged.
> 
> Updates the blueprint (Ch. 8 and Ch. 11) to match, switching affected environments/labels and all cross-references from `thm:` to `lem:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b9786ceb4ba781a0382cc9d0b800c67c80cc57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->