### PR TITLE
refactor(MPS/FT): simplify multiplicity comparison surface

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -44,11 +44,10 @@ a basis of normal tensors in the sense of Definition 4.2 of arXiv:2011.12127: fo
 sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
 are linearly independent.  It is a `Prop`; no data is bundled.
 
-This is exactly the linear-independence hypothesis consumed by the heterogeneous
-sector comparison lemmas in this file. It is the linear-independence output
-expected from a general BNT sector construction in the after-blocking
-canonical-form reduction, and it is the input consumed by the final after-blocking
-sector comparison. -/
+Mathematically, this is the eventual linear-independence hypothesis on the basis
+sector MPV families. In comparison theorems for two sector decompositions, it
+lets equality of total MPVs determine the scalar coefficients after the basis
+blocks have been matched, even when the two decompositions use different bases. -/
 def HasBNTSectorData (P : SectorDecomposition d) : Prop :=
   ∃ N0 : ℕ, ∀ N > N0,
     LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N)

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -44,13 +44,11 @@ a basis of normal tensors in the sense of Definition 4.2 of arXiv:2011.12127: fo
 sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
 are linearly independent.  It is a `Prop`; no data is bundled.
 
-This is exactly the linear-independence hypothesis consumed by the equal-case
-sector comparison theorems in this file, i.e.
-`fundamentalTheorem_equalMPV_sectorDecomposition` and the heterogeneous variants
-for matched sector decompositions.  It is the linear-independence output expected
-from a general BNT sector construction in the after-blocking canonical-form
-reduction, and it is the input consumed by the final after-blocking sector
-comparison. -/
+This is exactly the linear-independence hypothesis consumed by the heterogeneous
+sector comparison lemmas in this file. It is the linear-independence output
+expected from a general BNT sector construction in the after-blocking
+canonical-form reduction, and it is the input consumed by the final after-blocking
+sector comparison. -/
 def HasBNTSectorData (P : SectorDecomposition d) : Prop :=
   ∃ N0 : ℕ, ∀ N > N0,
     LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N)
@@ -62,49 +60,14 @@ tensors. Equality of the total matrix-product vectors gives equality of the
 sector coefficient functions, and Newton identities recover the multisets of
 sector weights inside each basis block.
 
-The result formalized here is the equal-coefficient comparison for a shared BNT
-basis with matching multiplicities. A global gauge-equivalence statement for the
+The result formalized here is the BNT coefficient comparison that recovers both
+copy counts and sector weights. A global gauge-equivalence statement for the
 assembled tensors still requires a theorem deriving the coefficient and phase
 data required by the proportional decomposition theorem from bare equality of
 matrix-product vectors. In sector form the coefficients are finite sums of powers
 of unit-modulus weights, so convergence is not automatic without a dominant
 weight, normalization, or an explicit common-phase comparison.
 -/
-
-/-- **Equal-case FT for sector decompositions with shared BNT basis.**
-
-If two sector decompositions built from the same BNT basis family, with the same
-multiplicities, produce equal total MPVs (via `SameMPV₂`), then the sector weight
-multisets are equal for each basis block.
-
-This composes:
-1. `SectorDecomposition.mpv_toTensor_eq_sum_coeff` (MPV expansion),
-2. `SectorWeightData.coeff_eventually_eq_of_sameMPV` (BNT LI → eventual coefficient equality),
-3. `eventually_coeff_eq_implies_all_pos_eq` (telescoping extrapolation),
-4. `weight_multiset_eq_of_copies_eq_of_coeff_eq` (Newton–Girard). -/
-theorem fundamentalTheorem_equalMPV_sectorDecomposition
-    {d g : ℕ}
-    {dim : Fin g → ℕ}
-    (basis : (j : Fin g) → MPSTensor d (dim j))
-    (S T : SectorWeightData g)
-    (hCopies : ∀ j, S.copies j = T.copies j)
-    (hLI : ∃ N0 : ℕ, ∀ N > N0,
-      LinearIndependent ℂ (fun j : Fin g => mpvState (basis j) N))
-    (hEqual : SameMPV₂
-        (SectorDecomposition.mk g dim basis S).toTensor
-        (SectorDecomposition.mk g dim basis T).toTensor) :
-    ∀ j : Fin g,
-      Finset.univ.val.map (S.weight j) =
-        Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
-  apply SectorWeightData.weight_multiset_eq_of_sameMPV_bnt basis S T hCopies hLI
-  intro N σ
-  have hExpandS := (SectorDecomposition.mk g dim basis S).mpv_toTensor_eq_sum_coeff σ (N := N)
-  have hExpandT := (SectorDecomposition.mk g dim basis T).mpv_toTensor_eq_sum_coeff σ (N := N)
-  -- These are exactly the coefficient expansions for the two assembled tensors.
-  calc ∑ j, S.coeff N j * mpv (basis j) σ
-      = mpv (SectorDecomposition.mk g dim basis S).toTensor σ := hExpandS.symm
-    _ = mpv (SectorDecomposition.mk g dim basis T).toTensor σ := hEqual N σ
-    _ = ∑ j, T.coeff N j * mpv (basis j) σ := hExpandT
 
 /-- **Phase matching and total MPV equality recover copy counts and sector weights.**
 
@@ -409,32 +372,6 @@ lemma basis_match_exists (M : SectorBasisMatching P Q) :
           (Q.basis (M.perm j)) :=
   sectorBasisMatchExists_of_fields M.perm M.dim_eq M.basis_equiv
 
-/-- Build a `SectorBasisMatching` from a bijective index correspondence together with the
-per-block copy / dimension / gauge-phase data.
-
-This is the natural output shape of a general basis-of-normal-tensors matching
-extractor: such an extractor delivers a function on basis indices, a bijectivity
-certificate, and per-index compatibility data. -/
-noncomputable def ofBijective
-    (f : Fin P.basisCount → Fin Q.basisCount)
-    (hf : Function.Bijective f)
-    (hCopies : ∀ j, P.copies j = Q.copies (f j))
-    (hDim : ∀ j, P.basisDim j = Q.basisDim (f j))
-    (hEquiv : ∀ j, GaugePhaseEquiv (d := d)
-      (cast (congr_arg (MPSTensor d) (hDim j)) (P.basis j)) (Q.basis (f j))) :
-    SectorBasisMatching P Q where
-  perm := Equiv.ofBijective f hf
-  copies_eq := fun j => by
-    change P.copies j = Q.copies (f j)
-    exact hCopies j
-  dim_eq := fun j => by
-    change P.basisDim j = Q.basisDim (f j)
-    exact hDim j
-  basis_equiv := fun j => by
-    change GaugePhaseEquiv (d := d)
-      (cast (congr_arg (MPSTensor d) (hDim j)) (P.basis j)) (Q.basis (f j))
-    exact hEquiv j
-
 end SectorBasisMatching
 
 namespace SectorBasisPreMatching
@@ -485,27 +422,6 @@ lemma exists_sectorBasisMatching_of_sameMPV
   }, rfl⟩
 
 end SectorBasisPreMatching
-
-/-- **Heterogeneous sector comparison from a basis pre-matching.**
-
-A pre-matching supplies the permutation, bond-dimension equalities, and
-gauge-phase equivalences of the basis blocks. Total MPV equality and BNT linear
-independence then recover the missing copy-count equalities and the phase-adjusted
-sector weight multisets. -/
-theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_preMatching
-    {P Q : SectorDecomposition d}
-    (M : SectorBasisPreMatching P Q)
-    (hLI : HasBNTSectorData P)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ hCopies : ∀ j : Fin P.basisCount, P.copies j = Q.copies (M.perm j),
-      ∃ ζ : Fin P.basisCount → ℂ,
-        (∀ j, ζ j ≠ 0) ∧
-        ∀ j : Fin P.basisCount,
-          Finset.univ.val.map (P.weight j) =
-            Finset.univ.val.map
-              (fun q => ζ j * Q.weight (M.perm j) (Fin.cast (hCopies j) q)) :=
-  fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies
-    P Q M.perm M.phase_match_exists hLI hEqual
 
 /-- Single-family primitive overlap-orthogonality data for a sector basis.
 

--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -287,31 +287,6 @@ private lemma eventually_coeff_eq_implies_all_pos_eq
   simp only [SectorWeightData.coeff]
   exact hAll.trans (hReindex k)
 
-/-- **Equal-case corollary: BNT linear independence + same multiplicities + equal total MPVs
-→ equal sector weight multisets.**
-
-BNT linear independence turns equality of the total matrix-product-vector
-families into eventual equality of the sector coefficients.  The geometric
-extrapolation above promotes eventual equality to equality of all positive
-power sums, and Newton--Girard then recovers the weight multiset in each
-sector once the copy counts have been aligned. -/
-lemma weight_multiset_eq_of_sameMPV_bnt
-    {dim : Fin g → ℕ}
-    (basis : (j : Fin g) → MPSTensor d (dim j))
-    (S T : SectorWeightData g)
-    (hCopies : ∀ j, S.copies j = T.copies j)
-    (hLI : ∃ N0 : ℕ, ∀ N > N0,
-      LinearIndependent ℂ (fun j : Fin g => mpvState (basis j) N))
-    (hSame : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      ∑ j : Fin g, S.coeff N j * mpv (basis j) σ =
-      ∑ j : Fin g, T.coeff N j * mpv (basis j) σ) :
-    ∀ j : Fin g,
-      Finset.univ.val.map (S.weight j) =
-        Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
-  obtain ⟨_, hCoeffEventuallyEq⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
-  have hCoeffAllPosEq := eventually_coeff_eq_implies_all_pos_eq S T hCopies hCoeffEventuallyEq
-  exact weight_multiset_eq_of_copies_eq_of_coeff_eq S T hCopies hCoeffAllPosEq
-
 /-- **BNT coefficient comparison recovers multiplicities and weight multisets.**
 
 This variant does not assume matching copy counts. Eventual coefficient equality is

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -359,11 +359,18 @@ the power sum
 \[
 	c_{S,j}^{(N)}=\sum_{q=1}^{r_j}\mu_{j,q}^{N}.
 \]
-Thus BNT linear independence separates the coefficient arrays
+This is the scalar part of the source decomposition
+\[
+	A^i=\bigoplus_{j=1}^g\bigoplus_{q=1}^{r_j}
+		\mu_{j,q}X_{j,q}A_j^iX_{j,q}^{-1}.
+\]
+The sector tensor used below is the representative form after the gauge
+conjugations $X_{j,q}$ have already been absorbed into the choice of basis
+block and gauge-phase data.  Thus BNT linear independence separates the coefficient arrays
 $c_{S,j}^{(N)}$, and elementary power-sum algebra recovers both the
 multiplicity $r_j$ and the multiset of weights attached to the basis block.
-In the source paper this information is not presented as a separate chain of
-MPS comparison theorems: Theorem~IV.13 of~\cite{Cirac2017MPDO_AnnPhys} uses
+In the later PEPS application this information is not presented as a separate
+chain of MPS comparison theorems: Theorem~IV.13 of~\cite{Cirac2017MPDO_AnnPhys} uses
 structure coefficients
 \[
 	c_{\alpha,\beta,\gamma}^{(L)}
@@ -531,34 +538,6 @@ facts used to recover the lists of weights from those power sums.
 	Lemma~\ref{lem:geom_extrapolation}, and Newton--Girard
 	(Theorem~\ref{thm:power_sum_multiset}) recovers the weight multisets.
 \end{proof}
-
-\begin{lemma}[Weight multiset recovery with fixed multiplicities]%
-\label{lem:route_b_equal}
-	\lean{MPSTensor.SectorWeightData.weight_multiset_eq_of_sameMPV_bnt}
-	\leanok
-	\uses{lem:coeff_eventually_eq, lem:geom_extrapolation, thm:power_sum_multiset, def:paper_sector_data, def:bnt}
-	Let $S$ and $T$ be two sector data over the same basis with
-	the same multiplicities ($r_j^S = r_j^T$ for all~$j$).
-	If the basis is eventually linearly independent and the total MPVs
-	of $S$ and $T$ agree, then for each basis block~$j$ the sector weight
-	multisets $\{\mu_{j,q}^S\}$ and $\{\mu_{j,q}^T\}$ are equal.
-
-	The argument proceeds as follows:
-	\begin{enumerate}
-		\item BNT LI $+$ equal MPVs $\Rightarrow$ eventual coefficient
-		      equality (Lemma~\ref{lem:coeff_eventually_eq});
-		\item Geometric extrapolation $\Rightarrow$ full coefficient
-		      equality for all positive~$k$
-		      (Lemma~\ref{lem:geom_extrapolation});
-		\item Newton--Girard $\Rightarrow$ equal weight multisets
-		      (Theorem~\ref{thm:power_sum_multiset}).
-	\end{enumerate}
-	At the level of block contributions, this is the fixed-multiplicity
-	specialization of Lemma~\ref{lem:route_b_equal_with_copies}: one compares
-	the weighted sector sums
-	$\sum_j c_{S,j}^{(N)} V^{(N)}(A_j)$ and
-	$\sum_j c_{T,j}^{(N)} V^{(N)}(A_j)$ over the same basis block family.
-\end{lemma}
 
 \begin{lemma}[Two-basis sector comparison after phase matching]%
 \label{lem:route_b_hetero_phase_match}
@@ -731,27 +710,6 @@ facts used to recover the lists of weights from those power sums.
 	the corresponding basis MPVs. Lemma~\ref{lem:route_b_hetero_phase_match_copies}
 	recovers the missing copy-count equalities, which are precisely the extra
 	fields needed for Definition~\ref{def:sector_basis_matching}.
-\end{proof}
-
-\begin{theorem}[Two-basis sector comparison from a pre-matching]%
-\label{thm:route_b_hetero_pre_matching}
-	\lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_preMatching}
-	\leanok
-	\uses{def:sector_basis_pre_matching, def:paper_sector_data}
-	Let $M$ be a sector basis pre-matching between sector decompositions $P$
-	and $Q$. If the total MPV families agree and the basis MPVs of $P$ are
-	eventually linearly independent, then the matched copy counts agree, and
-	after absorbing the gauge phases into the weights of $Q$ the corresponding
-	sector-weight multisets agree.
-\end{theorem}
-
-\begin{proof}
-	\leanok
-	\uses{lem:route_b_hetero_phase_match_copies}
-	The gauge-phase equivalences in the pre-matching give the phase-scaling
-	identities for the corresponding basis MPVs.
-	Lemma~\ref{lem:route_b_hetero_phase_match_copies} then gives the
-	copy-count equalities and the phase-adjusted multiset equalities.
 \end{proof}
 
 \begin{theorem}[Overlap rigidity gives a sector basis matching]%


### PR DESCRIPTION
### Motivation

- The BNT repeated-block source formula in arXiv:1606.00608 compares power sums and recovers both multiplicities and weights.
- The current Chapter 11 surface also exposed weaker fixed-multiplicity and pre-matching wrapper results that were not used downstream and were not separate source statements.
- Reducing that surface makes the formal route easier to compare with the paper.

### Description

- Removes the unused fixed-multiplicity weight-recovery lemma and the common-basis same-copy wrapper theorem.
- Removes the unused `SectorBasisMatching.ofBijective` constructor and the unused pre-matching sector-comparison wrapper.
- Keeps the stronger copy-count-and-weight recovery lemma as the paper-facing recovery statement.
- Updates Chapter 11 prose to state explicitly that the sector tensor is a representative form of the paper decomposition after the `X_{j,q}` gauge conjugations are absorbed into basis and gauge-phase data.

### Testing

- `lake env lean TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- exact grep for retired declaration and blueprint label names under `TNLean`, `blueprint/src`, and `docs`

---

Addresses #1342.
Partially addresses #1170.
Partially addresses #1282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mainly deletes unused lemmas/constructors and updates documentation; primary risk is downstream breakage for any external users referencing the removed declarations.
> 
> **Overview**
> Simplifies the sector-decomposition comparison API by **removing unused fixed-multiplicity/common-basis wrappers** and pushing callers to the stronger BNT result that *recovers both copy counts and weight multisets*.
> 
> Concretely, drops the common-basis equal-MPV theorem in `SectorDecomposition.lean`, removes `SectorBasisMatching.ofBijective` and the pre-matching wrapper theorem, and deletes the fixed-multiplicity weight-recovery lemma `weight_multiset_eq_of_sameMPV_bnt` in `SectorWeightComparison.lean`. The Chapter 11 blueprint is updated to match the trimmed surface and clarifies the representative-form interpretation of the sector tensor after absorbing gauge conjugations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead858cfae93b061a56f0866d3b41c8d7b3c7c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->