### PR TITLE
docs(MPS/FT): distinguish strict separated data

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -114,8 +114,8 @@ The main references are
 	\end{enumerate}
 \end{definition}
 
-\begin{lemma}[Restricted equal-norm collapse]
-	\label{thm:bnt_grouping_equal_norm}
+\begin{lemma}[Restricted norm-class collapse]
+	\label{lem:bnt_grouping_equal_norm}
 	\lean{MPSTensor.exists_bnt_grouping}
 	\leanok
 	\uses{def:mpv}
@@ -125,7 +125,11 @@ The main references are
 	same MPV family. Then one can regroup the blocks into a sector
 	decomposition whose associated total tensor generates the same MPV family
 	as $\bigoplus_k \mu_k A_k$, and whose sector-weight norms are strictly
-	decreasing.
+	decreasing.  This is a special-case regrouping lemma, not the full BNT
+	characterization of arXiv:1606.00608: the hypothesis that equal-norm
+	blocks already generate the same MPV family is an input here, while the
+	source BNT construction obtains the representatives by the minimal
+	phase-gauge equivalence relation.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1050,7 +1050,7 @@ which is then combined with overlap estimates and the leading-block peel.
         \item the self-overlaps are normalised:
               $O_{A_k A_k}(N) \to 1$ as $N \to \infty$.
     \end{enumerate}
-    This is the separated hypothesis package used in the algebraic proof
+    These are the separated hypotheses used in the algebraic proof
     below.  It is stronger than the canonical form definition in
     arXiv:1606.00608, where the block weights are only ordered after the
     canonical decomposition and repeated BNT representatives are handled by
@@ -1246,7 +1246,7 @@ which is then combined with overlap estimates and the leading-block peel.
 \begin{proof}\leanok
     \uses{lem:fundamentalTheorem_of_separated_canonical_data_explicit}
     Apply Lemma~\ref{lem:fundamentalTheorem_of_separated_canonical_data_explicit}
-    with the strict-ordering data from the separated hypothesis package.
+    with the strict-ordering data from the separated hypotheses.
 \end{proof}
 
 %% ---------------------------------------------------------

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1015,7 +1015,7 @@ decomposition.
 \end{proof}
 
 %% ---------------------------------------------------------
-\section{Block separation from canonical form}%
+\section{Block separation from strict separated canonical-form data}%
 \label{sec:block_separation}
 %% ---------------------------------------------------------
 
@@ -1034,13 +1034,13 @@ The first step is the weighted block-sum identity
 \]
 which is then combined with overlap estimates and the leading-block peel.
 
-\begin{definition}[Canonical form]\label{def:isCanonicalForm}
+\begin{definition}[Strict separated canonical-form data]\label{def:isCanonicalForm}
     \lean{MPSTensor.IsCanonicalForm}
     \leanok
     \uses{def:injective}
     A family of block tensors $\{A_k\}_{k=0}^{r-1}$ with scaling
-    weights $\mu_0, \ldots, \mu_{r-1} \in \C^{\times}$ is in
-    \emph{canonical form} if:
+    weights $\mu_0, \ldots, \mu_{r-1} \in \C^{\times}$ has
+    \emph{strict separated canonical-form data} if:
     \begin{enumerate}
         \item each $A_k$ is injective,
         \item each $A_k$ is left-canonical:
@@ -1050,14 +1050,20 @@ which is then combined with overlap estimates and the leading-block peel.
         \item the self-overlaps are normalised:
               $O_{A_k A_k}(N) \to 1$ as $N \to \infty$.
     \end{enumerate}
+    This is the separated hypothesis package used in the algebraic proof
+    below.  It is stronger than the canonical form definition in
+    arXiv:1606.00608, where the block weights are only ordered after the
+    canonical decomposition and repeated BNT representatives are handled by
+    multiplicity coefficients rather than by a strict one-block-per-weight
+    condition.
 \end{definition}
 
-\begin{definition}[Normal canonical form]\label{def:normal_canonical_form}
+\begin{definition}[Strict separated normal canonical-form data]\label{def:normal_canonical_form}
     \lean{MPSTensor.IsNormalCanonicalForm}
     \leanok
     \uses{def:isCanonicalForm}
-    A family is in \emph{normal canonical form} if it satisfies the
-    canonical-form conditions with each block additionally
+    A family has \emph{strict separated normal canonical-form data} if it
+    satisfies Definition~\ref{def:isCanonicalForm} with each block additionally
     \emph{irreducible} (no nontrivial invariant projection) and
     \emph{primitive} (the transfer map has spectral gap).
 \end{definition}
@@ -1080,18 +1086,20 @@ which is then combined with overlap estimates and the leading-block peel.
 
 \begin{proof}
     \leanok
-    The proof is the peeling argument described below for canonical form.
+    The proof is the peeling argument described below for strict separated
+    canonical-form data.
     The strict weight ordering isolates the leading block, the overlap bounds
     show that the tail decays geometrically after dividing by the dominant
     weight, and one then iterates on the remaining blocks.
 \end{proof}
 
-\begin{lemma}[Block separation from canonical form]%
+\begin{lemma}[Block separation from strict separated canonical-form data]%
     \label{lem:per_block_sameMPV_of_canonical_form}
     \lean{MPSTensor.per_block_sameMPV_of_canonical_form}
     \leanok
     \uses{def:isCanonicalForm, def:same_mpv}
-    Let $\{A_k\}$ be in canonical form with weights $\{\mu_k\}$, and
+    Let $\{A_k\}$ have strict separated canonical-form data with weights
+    $\{\mu_k\}$, and
     let $\{B_k\}$ be another family with each $B_k$ injective and
     left-canonical.
     If $\mc{V}\!(\bigoplus_k \mu_k A_k)
@@ -1203,7 +1211,7 @@ which is then combined with overlap estimates and the leading-block peel.
     explicit-gauge form of the multi-block Fundamental Theorem.
 \end{proof}
 
-\begin{theorem}[Fundamental Theorem from canonical form]%
+\begin{theorem}[Fundamental Theorem from strict separated canonical-form data]%
     \label{thm:fundamentalTheorem_canonicalForm}
     \lean{MPSTensor.fundamentalTheorem_canonicalForm}
     \leanok
@@ -1224,7 +1232,7 @@ which is then combined with overlap estimates and the leading-block peel.
     to per-block and global gauge equivalence.
 \end{proof}
 
-\begin{lemma}[Explicit gauge from canonical form]%
+\begin{lemma}[Explicit gauge from strict separated canonical-form data]%
     \label{lem:fundamentalTheorem_canonicalForm_explicit}
     \lean{MPSTensor.fundamentalTheorem_canonicalForm_explicit}
     \leanok
@@ -1238,7 +1246,7 @@ which is then combined with overlap estimates and the leading-block peel.
 \begin{proof}\leanok
     \uses{lem:fundamentalTheorem_of_separated_canonical_data_explicit}
     Apply Lemma~\ref{lem:fundamentalTheorem_of_separated_canonical_data_explicit}
-    with the strict-ordering data extracted from the canonical form.
+    with the strict-ordering data from the separated hypothesis package.
 \end{proof}
 
 %% ---------------------------------------------------------

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1015,7 +1015,7 @@ decomposition.
 \end{proof}
 
 %% ---------------------------------------------------------
-\section{Block separation from strict separated canonical-form data}%
+\section{Block separation from ordered canonical-form data}%
 \label{sec:block_separation}
 %% ---------------------------------------------------------
 
@@ -1027,42 +1027,43 @@ block-diagonal tensors satisfy the same MPV family:
 $\mc{V}\!(\bigoplus_k \mu_k A_k) =
     \mc{V}\!(\bigoplus_k \mu_k B_k)$.
 Block separation extracts the per-block identities from the global one
-under canonical-form normalization.
+under canonical-form normalization plus a strict separation of the
+weight moduli.
 The first step is the weighted block-sum identity
 \[
     \sum_k \mu_k^N V^{(N)}(A_k)_\sigma = \sum_k \mu_k^N V^{(N)}(B_k)_\sigma,
 \]
 which is then combined with overlap estimates and the leading-block peel.
 
-\begin{definition}[Strict separated canonical-form data]\label{def:isCanonicalForm}
+\begin{definition}[Canonical-form data with ordered weights]\label{def:isCanonicalForm}
     \lean{MPSTensor.IsCanonicalForm}
     \leanok
     \uses{def:injective}
     A family of block tensors $\{A_k\}_{k=0}^{r-1}$ with scaling
     weights $\mu_0, \ldots, \mu_{r-1} \in \C^{\times}$ has
-    \emph{strict separated canonical-form data} if:
+    \emph{canonical-form data with ordered weights} if:
     \begin{enumerate}
         \item each $A_k$ is injective,
         \item each $A_k$ is left-canonical:
               $\sum_i (A_k^i)^{\dagger}\, A_k^i = \Id_{D_k}$,
-        \item the weights are strictly ordered by norm:
-              $|\mu_0| > |\mu_1| > \cdots > |\mu_{r-1}| > 0$,
+        \item the weights are non-increasing by norm and nonzero:
+              $|\mu_0| \ge |\mu_1| \ge \cdots \ge |\mu_{r-1}| > 0$,
         \item the self-overlaps are normalised:
               $O_{A_k A_k}(N) \to 1$ as $N \to \infty$.
     \end{enumerate}
-    These are the separated hypotheses used in the algebraic proof
-    below.  It is stronger than the canonical form definition in
-    arXiv:1606.00608, where the block weights are only ordered after the
-    canonical decomposition and repeated BNT representatives are handled by
-    multiplicity coefficients rather than by a strict one-block-per-weight
-    condition.
+    This records the normalized ordered data used before the final
+    block-separation argument.  Equal-modulus blocks are still allowed here,
+    as in the canonical decompositions in arXiv:1606.00608.  The strict
+    inequality needed for the leading-block peeling argument is a separate
+    hypothesis in the block-separation lemmas below, and at the BNT level it
+    is obtained only after grouping repeated representatives.
 \end{definition}
 
-\begin{definition}[Strict separated normal canonical-form data]\label{def:normal_canonical_form}
+\begin{definition}[Normal canonical-form data with ordered weights]\label{def:normal_canonical_form}
     \lean{MPSTensor.IsNormalCanonicalForm}
     \leanok
     \uses{def:isCanonicalForm}
-    A family has \emph{strict separated normal canonical-form data} if it
+    A family has \emph{normal canonical-form data with ordered weights} if it
     satisfies Definition~\ref{def:isCanonicalForm} with each block additionally
     \emph{irreducible} (no nontrivial invariant projection) and
     \emph{primitive} (the transfer map has spectral gap).
@@ -1086,22 +1087,22 @@ which is then combined with overlap estimates and the leading-block peel.
 
 \begin{proof}
     \leanok
-    The proof is the peeling argument described below for strict separated
-    canonical-form data.
+    The proof is the peeling argument described below for canonical-form data
+    equipped with a separate strict ordering of the weight moduli.
     The strict weight ordering isolates the leading block, the overlap bounds
     show that the tail decays geometrically after dividing by the dominant
     weight, and one then iterates on the remaining blocks.
 \end{proof}
 
-\begin{lemma}[Block separation from strict separated canonical-form data]%
+\begin{lemma}[Block separation from canonical-form data and strict weights]%
     \label{lem:per_block_sameMPV_of_canonical_form}
     \lean{MPSTensor.per_block_sameMPV_of_canonical_form}
     \leanok
     \uses{def:isCanonicalForm, def:same_mpv}
-    Let $\{A_k\}$ have strict separated canonical-form data with weights
-    $\{\mu_k\}$, and
-    let $\{B_k\}$ be another family with each $B_k$ injective and
-    left-canonical.
+    Let $\{A_k\}$ have canonical-form data with ordered weights
+    $\{\mu_k\}$, and assume in addition that the weight norms are strictly
+    decreasing.  Let $\{B_k\}$ be another family with each $B_k$ injective
+    and left-canonical.
     If $\mc{V}\!(\bigoplus_k \mu_k A_k)
         = \mc{V}\!(\bigoplus_k \mu_k B_k)$,
     then $\mc{V}(A_k) = \mc{V}(B_k)$ for each block~$k$ individually.
@@ -1211,7 +1212,7 @@ which is then combined with overlap estimates and the leading-block peel.
     explicit-gauge form of the multi-block Fundamental Theorem.
 \end{proof}
 
-\begin{theorem}[Fundamental Theorem from strict separated canonical-form data]%
+\begin{theorem}[Fundamental Theorem from canonical-form data and strict weights]%
     \label{thm:fundamentalTheorem_canonicalForm}
     \lean{MPSTensor.fundamentalTheorem_canonicalForm}
     \leanok
@@ -1232,7 +1233,7 @@ which is then combined with overlap estimates and the leading-block peel.
     to per-block and global gauge equivalence.
 \end{proof}
 
-\begin{lemma}[Explicit gauge from strict separated canonical-form data]%
+\begin{lemma}[Explicit gauge from canonical-form data and strict weights]%
     \label{lem:fundamentalTheorem_canonicalForm_explicit}
     \lean{MPSTensor.fundamentalTheorem_canonicalForm_explicit}
     \leanok


### PR DESCRIPTION
## Summary
- rename the Chapter 13 algebraic-FT `IsCanonicalForm` blueprint entry to ordered canonical-form data
- state explicitly that `IsCanonicalForm` only gives non-increasing nonzero weights, while strict weight separation is an additional hypothesis for the peeling/block-separation lemmas
- clarify the adjacent BNT grouping statement as a restricted norm-class collapse rather than the full arXiv:1606.00608 BNT characterization

## Source-faithfulness note
This PR addresses a real terminology and statement-boundary issue. The base Lean declaration `MPSTensor.IsCanonicalForm` matches ordered canonical data: repeated weight moduli are allowed. The stronger strict-weight assumption appears only in the downstream block-separation route, where the proof uses geometric decay after isolating the leading block.

Compared with arXiv:1606.00608, that strict separated route is an auxiliary proof interface, not the final BNT canonical-form statement. Repeated BNT representatives should be handled by grouping/multiplicity data, so this PR documents that boundary instead of presenting the strict route as the paper definition.

Linked issues: #1334, #1282, #1170.

## Validation
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`