### PR TITLE
refactor(MPS/FT): retire explicit equal-MPV surface

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.BNT.Construction
+import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 
 /-!
@@ -28,11 +29,6 @@ This theorem proves the block-matching conclusion under the coefficient hypothes
 the proportional-MPV argument. The decomposition coefficients, their limits, and the
 non-vanishing of those limits are explicit assumptions. The extraction of these
 coefficients from the hypotheses of the source-paper theorem is not part of this statement.
-
-### Equal MPVs imply proportional MPVs
-(`sameMPV₂_implies_proportionalMPV₂`)
-
-Trivial but useful: `SameMPV₂ A B → ProportionalMPV₂ A B` (take `c_N = 1`).
 
 ## References
 
@@ -277,181 +273,6 @@ theorem fundamentalTheorem_proportionalMPV_normalCFBNT
   fundamentalTheorem_of_IsNormalCanonicalFormBNT A B hA hB
     A_total B_total aCoeff bCoeff aLim bLim c cLim
     hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
-
-/-! ## Equal MPVs imply proportional MPVs -/
-
-/-- **Equal MPVs imply proportional MPVs** (with proportionality constant `1`).
-
-This converts an equality hypothesis into the proportionality hypothesis used by the
-explicit-coefficient comparison theorems. -/
-lemma sameMPV₂_implies_proportionalMPV₂
-    {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (h : SameMPV₂ A B) :
-    ProportionalMPV₂ A B := by
-  intro N
-  exact ⟨1, fun σ => by simpa using h N σ⟩
-
-/-- **Equal-MPV comparison from explicit coefficient data for CF-BNT.**
-
-The equal-MPV corollary in the papers starts from the CF-BNT data and `SameMPV₂`.
-This theorem assumes more data: the same coefficient arrays and nonzero limits required by
-`fundamentalTheorem_proportionalMPV_CFBNT`. Its conclusion is a block permutation together
-with per-block `GaugePhaseEquiv` data.
-
-Under those coefficient hypotheses, equal MPVs force the phase-corrected
-weights to match blockwise.  After reindexing the `B`-family by the permutation from the
-proportional FT, the assembled weighted block tensors are globally gauge equivalent. -/
-lemma fundamentalTheorem_equalMPV_of_explicit_coefficients
-    {d rA rB : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
-    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
-    (A : (j : Fin rA) → MPSTensor d (dimA j))
-    (B : (k : Fin rB) → MPSTensor d (dimB k))
-    (hA : IsCanonicalFormBNT μA A)
-    (hB : IsCanonicalFormBNT μB B)
-    (aCoeff : ℕ → Fin rA → ℂ) (bCoeff : ℕ → Fin rB → ℂ)
-    (aLim : Fin rA → ℂ) (bLim : Fin rB → ℂ)
-    (hA_decomp : ∀ N (σ : Fin N → Fin d),
-      mpv (toTensorFromBlocks μA A) σ = ∑ j : Fin rA, (aCoeff N j) * mpv (A j) σ)
-    (hB_decomp : ∀ N (σ : Fin N → Fin d),
-      mpv (toTensorFromBlocks μB B) σ = ∑ k : Fin rB, (bCoeff N k) * mpv (B k) σ)
-    (haCoeff : ∀ j, Tendsto (fun N => aCoeff N j) atTop (nhds (aLim j)))
-    (hbCoeff : ∀ k, Tendsto (fun N => bCoeff N k) atTop (nhds (bLim k)))
-    (haLim_ne : ∀ j, aLim j ≠ 0)
-    (hbLim_ne : ∀ k, bLim k ≠ 0)
-    (hEqual : SameMPV₂ (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
-    ∃ perm : Fin rA ≃ Fin rB,
-      ∃ hdim : ∀ j : Fin rA, dimA j = dimB (perm j),
-        GaugeEquiv
-          (toTensorFromBlocks μA
-            (fun j => cast (congr_arg (MPSTensor d) (hdim j)) (A j)))
-          (toTensorFromBlocks (fun j => μB (perm j))
-            (fun j => B (perm j))) := by
-  have hProp : ∀ N (σ : Fin N → Fin d),
-      mpv (toTensorFromBlocks μA A) σ = (1 : ℂ) * mpv (toTensorFromBlocks μB B) σ := by
-    intro N σ
-    simpa only [one_mul] using hEqual N σ
-  obtain ⟨_hcount, perm, hperm⟩ :=
-    fundamentalTheorem_proportionalMPV_CFBNT A B hA hB
-      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)
-      aCoeff bCoeff aLim bLim (fun _ => (1 : ℂ)) (1 : ℂ)
-      hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne
-      hProp tendsto_const_nhds one_ne_zero
-  choose hdim hGP using hperm
-  choose X ζ hζ hX using hGP
-  have hBNTA := hA.isBNT
-  obtain ⟨N0, hLI⟩ := hBNTA.eventually_li
-  have hμA_ne : ∀ j : Fin rA, μA j ≠ 0 :=
-    hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero
-  have hμB_ne : ∀ k : Fin rB, μB k ≠ 0 :=
-    hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero
-  have hCoeffEq :
-      ∀ N : ℕ, N > N0 →
-        ∀ j : Fin rA, μA j ^ N = (μB (perm j) * ζ j) ^ N := by
-    intro N hN j
-    have hLIN : LinearIndependent ℂ (fun j : Fin rA => mpvState (d := d) (A j) N) := hLI N hN
-    have hsums :
-        ∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N =
-          ∑ j : Fin rA, (μB (perm j) * ζ j) ^ N • mpvState (d := d) (A j) N := by
-      ext σ
-      simp only [WithLp.ofLp_sum, WithLp.ofLp_smul, Finset.sum_apply, Pi.smul_apply,
-        mpvState_apply, smul_eq_mul]
-      calc
-        ∑ j : Fin rA, (μA j) ^ N * mpv (A j) σ
-            = mpv (toTensorFromBlocks μA A) σ := by
-              symm
-              simpa only [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μA A σ
-        _ = mpv (toTensorFromBlocks μB B) σ := hEqual N σ
-        _ = ∑ k : Fin rB, (μB k) ^ N * mpv (B k) σ := by
-              simpa only [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μB B σ
-        _ = ∑ j : Fin rA, (μB (perm j)) ^ N * mpv (B (perm j)) σ := by
-              exact
-                (Equiv.sum_comp perm (fun k : Fin rB => (μB k) ^ N * mpv (B k) σ)).symm
-        _ = ∑ j : Fin rA, (μB (perm j) * ζ j) ^ N * mpv (A j) σ := by
-              refine Finset.sum_congr rfl ?_
-              intro j _
-              have hmpv :=
-                mpv_eq_pow_mul_of_gaugePhase
-                  (A := cast (congr_arg (MPSTensor d) (hdim j)) (A j))
-                  (B := B (perm j))
-                  (X := X j) (ζ := ζ j) (hX := hX j)
-                  N σ
-              rw [hmpv, mpv_cast_dim (hdim j) (A j) N σ]
-              calc
-                (μB (perm j)) ^ N * (ζ j ^ N * mpv (A j) σ)
-                    = ((μB (perm j)) ^ N * ζ j ^ N) * mpv (A j) σ := by ring
-                _ = (μB (perm j) * ζ j) ^ N * mpv (A j) σ := by rw [← mul_pow]
-    have hdiff :
-        ∑ j : Fin rA, ((μA j) ^ N - (μB (perm j) * ζ j) ^ N) •
-            mpvState (d := d) (A j) N = 0 := by
-      simpa only [Finset.sum_sub_distrib, sub_smul] using (sub_eq_zero.mpr hsums)
-    have hzero :=
-      Fintype.linearIndependent_iff.mp hLIN
-        (fun j : Fin rA => (μA j) ^ N - (μB (perm j) * ζ j) ^ N)
-        hdiff
-    exact sub_eq_zero.mp (hzero j)
-  have hWeight : ∀ j : Fin rA, μA j = μB (perm j) * ζ j := by
-    intro j
-    have hpow1 := hCoeffEq (N0 + 1) (Nat.lt_succ_self N0) j
-    have hpow2 := hCoeffEq ((N0 + 1) + 1) (by omega) j
-    have hmul :
-        μA j ^ (N0 + 1) * μA j = μA j ^ (N0 + 1) * (μB (perm j) * ζ j) := by
-      calc
-        μA j ^ (N0 + 1) * μA j = μA j ^ ((N0 + 1) + 1) := by ring
-        _ = (μB (perm j) * ζ j) ^ ((N0 + 1) + 1) := hpow2
-        _ = (μB (perm j) * ζ j) ^ (N0 + 1) * (μB (perm j) * ζ j) := by ring
-        _ = μA j ^ (N0 + 1) * (μB (perm j) * ζ j) := by rw [hpow1]
-    exact mul_left_cancel₀ (pow_ne_zero (N0 + 1) (hμA_ne j)) hmul
-  let Acast : (j : Fin rA) → MPSTensor d (dimB (perm j)) :=
-    fun j => cast (congr_arg (MPSTensor d) (hdim j)) (A j)
-  let Aweighted : (j : Fin rA) → MPSTensor d (dimB (perm j)) :=
-    fun j i => (μA j) • Acast j i
-  let Bweighted : (j : Fin rA) → MPSTensor d (dimB (perm j)) :=
-    fun j i => (μB (perm j)) • B (perm j) i
-  have hWeightedConj : ∀ j : Fin rA, ∀ i : Fin d,
-      Bweighted j i =
-        (X j : Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) *
-          Aweighted j i *
-          (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
-            Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) := by
-    intro j i
-    calc
-      Bweighted j i
-          = (μB (perm j) * ζ j) •
-              ((X j : Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) *
-                Acast j i *
-                (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
-                  Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ)) := by
-            simp only [Bweighted, Acast, hX j i, smul_smul, mul_comm, mul_assoc]
-      _ = (μA j) •
-            ((X j : Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) *
-              Acast j i *
-              (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
-                Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ)) := by
-            rw [(hWeight j).symm]
-      _ = (X j : Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) *
-            Aweighted j i *
-            (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
-              Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) := by
-            simp only [Aweighted, Acast, Algebra.mul_smul_comm,
-              Algebra.smul_mul_assoc, Matrix.mul_assoc]
-  refine ⟨perm, hdim, ?_⟩
-  have hGaugeWeighted :=
-    gaugeEquiv_toTensorFromBlocks_of_blockConj (d := d) (μ := fun _ : Fin rA => (1 : ℂ))
-      Aweighted Bweighted X hWeightedConj
-  have hA_tot :
-      toTensorFromBlocks μA (fun j => cast (congr_arg (MPSTensor d) (hdim j)) (A j)) =
-        toTensorFromBlocks (fun _ : Fin rA => (1 : ℂ)) Aweighted := by
-    ext i
-    simp only [toTensorFromBlocks, Aweighted, Acast, one_smul]
-  have hB_tot :
-      toTensorFromBlocks (fun j => μB (perm j)) (fun j => B (perm j)) =
-        toTensorFromBlocks (fun _ : Fin rA => (1 : ℂ)) Bweighted := by
-    ext i
-    simp only [toTensorFromBlocks, Bweighted, one_smul]
-  rw [hA_tot, hB_tot]
-  exact hGaugeWeighted
 
 /-! ## Combined corollaries -/
 

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.BNT.Construction
-import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 
 /-!

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -71,8 +71,7 @@ forces:
 3. Blockwise gauge-phase equivalence: for each `j`, `dimA j = dimB (perm j)` and
    `GaugePhaseEquiv (cast … (A j)) (B (perm j))`.
 
-Unlike `fundamentalTheorem_proportionalMPV_CFBNT` and
-`fundamentalTheorem_equalMPV_of_explicit_coefficients`, this theorem requires **no** explicit
+Unlike `fundamentalTheorem_proportionalMPV_CFBNT`, this theorem requires **no** explicit
 `aCoeff`, `bCoeff`, `aLim`, `bLim` arguments. The
 coefficient convergence question that plagues the general proportional-case theorem is
 bypassed entirely: the BNT decomposition identity

--- a/blueprint/comments20260315/full_ft_verification.md
+++ b/blueprint/comments20260315/full_ft_verification.md
@@ -1,139 +1,104 @@
-# Verification: literature equal-MPV FT versus the current Lean endpoint
+# Verification: equal-MPV FT endpoints after retiring the explicit-coefficient route
 
-This note records the status after the March 17, 2026 refinement of
-`MPSTensor.fundamentalTheorem_equalMPV_of_explicit_coefficients` in
-`TNLean/MPS/FundamentalTheorem/EqualProportional.lean`.
+This note records the equal-MPV Fundamental Theorem surface after the
+explicit-coefficient equal-case endpoint was retired. The current development
+keeps the literature equal case as the chapter-level target and exposes the
+surviving checked endpoints below.
 
-The key point is simple: the current Lean theorem is now an
-explicit-coefficient equal-case upgrade of the currently formalized
-proportional Fundamental Theorem. It is not yet the unconditional
-literature corollary `[CPGSV21, Corollary IV.5]` / `II_cor2`.
+The source-paper equal case compares repeated BNT blocks through the
+coefficients
+`sum_q mu_{j,q}^N`. The proof therefore needs both BNT matching and the
+power-sum recovery step; it is not just a multiplicity-one coefficient-limit
+argument.
 
 ---
 
-## 1. Distinguish the three statements
+## 1. Literature equal-MPV FT
 
-### Literature equal-MPV FT (`thm:ft_equal` in the blueprint)
+The blueprint theorem `thm:ft_equal` is the literature-level statement:
+if two tensors in canonical form generate the same MPV family at every
+system size, then the total block-diagonal tensors are gauge equivalent.
 
-If two tensors in canonical form generate the same MPV family for all
-system sizes, then the total block-diagonal tensors are gauge
-equivalent.
+This remains the target statement for the full non-periodic equal case.
+The current proof route has source-faithful pieces, but still keeps some
+comparison inputs explicit before the final theorem can be closed.
 
-This is the chapter-level target corresponding to the literature equal
-case. In the papers, however, the equal-case argument keeps additional
-multiplicity data, so this remains a target statement rather than a
-formalized theorem in the present Lean development.
+---
 
-### Explicit-coefficient Lean theorem
-(`fundamentalTheorem_equalMPV_of_explicit_coefficients`)
+## 2. Surviving Lean endpoints
 
-Under the CF-BNT hypotheses, together with explicit coefficient arrays
-`aCoeff`, `bCoeff`, convergence to nonzero limits, and equality of MPVs,
-Lean proves:
-
-- equality of the block counts,
-- a permutation matching the block dimensions,
-- a global `GaugeEquiv` between the reindexed weighted block tensors.
-
-This is the equal-case upgrade of the current formalized proportional FT.
-It is **not** the unconditional literature corollary.
-
-### Same-structure special case (`fundamentalTheorem_equalMPV_CFBNT`)
+### Common-block-structure special case
+`MPSTensor.fundamentalTheorem_equalMPV_CFBNT`
 
 If the block count, block dimensions, and weights are fixed in advance,
-then equal MPVs imply per-block gauge equivalence and hence global gauge
-equivalence.
-
-This remains a different formalized special case.
+equal MPVs imply per-block gauge equivalence and hence global gauge
+equivalence. This is a useful special case, but it is not the full
+literature theorem because the block matching and multiplicity recovery
+are assumed through the shared structure.
 
 ### Heterogeneous block-matching theorem
-(`fundamentalTheorem_equalMPV_CFBNT_hetero`)
+`MPSTensor.fundamentalTheorem_equalMPV_CFBNT_hetero`
 
 This theorem starts from equal MPVs for two CF-BNT families with different
 block counts and bond dimensions. It proves equality of the block counts,
 a permutation preserving bond dimensions, and blockwise gauge-phase
-equivalence. It does not yet assert the final global weighted gauge
-equivalence of the assembled block-diagonal tensors.
+equivalence. It is the block-matching part of the equal case, not the
+final global weighted gauge equivalence.
+
+### Sector-decomposition multiplicity route
+`MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies`
+
+This is the closer match to the source-paper repeated-block argument.
+It compares sector coefficient sums, recovers copy counts and sector
+weight multisets, and packages the phase-matched sector data needed for
+the weighted comparison.
 
 ---
 
-## 2. What the refined Lean theorem actually proves
+## 3. Remaining gap to the literature corollary
 
-The proof in `Full.lean` now follows this route.
+Several ingredients still have to be assembled before `thm:ft_equal`
+matches the paper-level equal case.
 
-1. Convert equal MPVs to proportional MPVs with constant `c_N = 1`.
-2. Apply `fundamentalTheorem_proportionalMPV_CFBNT` using the explicit
-   coefficient hypotheses. This gives a permutation `π`, pointwise
-   dimension equalities, and blockwise gauge-phase equivalences
-   $$B_{\pi(j)}^i = \zeta_j X_j A_j^i X_j^{-1}.$$
-3. Use `mpv_toTensorFromBlocks_eq_sum` together with BNT linear
-   independence to show that for all large `N`,
-   $$ (\mu_j^A)^N = (\mu_{\pi(j)}^B \zeta_j)^N. $$
-4. Compare two consecutive exponents to deduce
-   $$ \mu_j^A = \mu_{\pi(j)}^B \zeta_j. $$
-5. Absorb the factors `\zeta_j` into the weights and assemble the
-   weighted block conjugacies to obtain a global gauge equivalence of the
-   reindexed totals.
+- The heterogeneous CF-BNT theorem stops at blockwise gauge-phase matching.
+- The repeated-copy BNT comparison requires the sector-decomposition data
+  and the power-sum recovery step.
+- The after-blocking route still records comparison hypotheses explicitly
+  before obtaining the final weighted gauge conclusion.
+- Zero-block bookkeeping is tracked separately through the zero-tail
+  dimension identities.
 
-This description matches the current Lean code.
-
----
-
-## 3. Why this is still not Corollary IV.5 / `II_cor2`
-
-Several gaps remain between the current Lean theorem and the paper-level
-full equal-case theorem.
-
-- The theorem still assumes explicit coefficient arrays with nonzero
-  limits. These hypotheses are not discharged internally from the CF-BNT
-  data alone.
-- The current coefficient-convergence lemmas give normalized ratios with
-  limit `1` for the dominant block and `0` for subdominant blocks. They
-  do **not** provide the nonzero limits required by the formalized
-  proportional FT.
-- The paper-level equal case compares multiplicity-weight data, i.e.
-  power sums of the form `\sum_q \mu_{j,q}^N` after the proportional FT.
-  Recovering the individual weights in that generality needs a
-  power-sum / Newton--Girard step (`Lem:app_simple`), not just the
-  multiplicity-one linear-independence shortcut.
-- The heterogeneous block-matching theorem now starts from equal MPVs
-  without explicit coefficient limits, but it stops at blockwise
-  gauge-phase matching. It does not yet upgrade all the way to the final
-  global weighted gauge equivalence of the literature corollary.
-
-So the refined theorem is honest and useful, but it is still a special
-formalized endpoint.
+Thus the full equal-MPV theorem should not be presented as closed merely
+because the common-block and heterogeneous block-matching endpoints exist.
 
 ---
 
 ## 4. Blueprint consequences
 
-The blueprint should reflect the following separation.
+The blueprint should keep the following separation visible.
 
-- `thm:ft_equal` should remain the unformalized target / literature-level
-  equal-MPV theorem.
-- `MPSTensor.fundamentalTheorem_equalMPV_of_explicit_coefficients`
-  should back a separate theorem for the explicit-coefficient equal case.
-- `MPSTensor.fundamentalTheorem_equalMPV_CFBNT_hetero` should back the
-  block-matching part of the heterogeneous equal case.
-- `fundamentalTheorem_equalMPV_CFBNT` should remain labeled as the
-  common-block-structure special case, not as the full equal-MPV theorem.
+- `thm:ft_equal` remains the literature-level target.
+- `MPSTensor.fundamentalTheorem_equalMPV_CFBNT_hetero` backs the
+  heterogeneous block-matching part.
+- `MPSTensor.fundamentalTheorem_equalMPV_CFBNT` backs the
+  common-block-structure special case.
+- The repeated-copy and power-sum route should be described through the
+  sector-decomposition comparison theorems, not through a retired
+  explicit-coefficient endpoint.
 
 ---
 
-## 5. Revised status table
+## 5. Status table
 
 | Item | Status |
 | --- | --- |
-| Literature equal-MPV FT / Cor. IV.5 | target only; not yet formalized |
-| `fundamentalTheorem_equalMPV_of_explicit_coefficients` | formalized explicit-coefficient equal-case upgrade of the proportional FT |
-| `fundamentalTheorem_equalMPV_CFBNT_hetero` | formalized heterogeneous block-matching theorem |
-| `fundamentalTheorem_equalMPV_CFBNT` | formalized common-block-structure special case |
-| Power-sum / Newton--Girard tools | still relevant for the full literature route |
-| BNT linear-independence argument | valid for the explicit-coefficient special theorem now in Lean |
+| Literature equal-MPV FT / Cor. IV.5 | target; not yet closed |
+| `fundamentalTheorem_equalMPV_CFBNT_hetero` | checked heterogeneous block-matching theorem |
+| `fundamentalTheorem_equalMPV_CFBNT` | checked common-block-structure special case |
+| Sector-decomposition repeated-copy route | checked comparison endpoint, still an input to final assembly |
+| Power-sum / Newton-Girard tools | checked support for the repeated-copy route |
+| Zero-block bookkeeping | tracked through zero-tail dimension identities |
 
----
-
-This supersedes the earlier reading in which the bare CF-BNT equal-case
-statement was treated as the current Lean target. That is no longer the
-correct interpretation after the March 17, 2026 refinement.
+This supersedes the March 17, 2026 reading that treated the
+explicit-coefficient equal-case endpoint as part of the current theorem
+surface.

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -569,8 +569,7 @@ The main references are
 	Theorems~\ref{thm:newton_girard} and~\ref{thm:power_sum_multiset}
 	remain relevant for the general equal-MPV
 	Theorem~\ref{thm:ft_equal}, where one expects a power-sum step to
-	recover the multiplicity-weight data.
-	The explicit-coefficient special case,
-	Lemma~\ref{lem:ft_equal_explicit}, instead uses linear independence
-	of the block MPV family supplied by a basis of normal tensors.
+	recover the multiplicity-weight data.  In the current route this recovery is
+	kept in the BNT multiplicity lemmas rather than in a separate
+	explicit-coefficient equal-case theorem.
 \end{remark}

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -206,27 +206,23 @@ used in this chapter.
 \end{theorem}
 
 \begin{proof}
-	\uses{lem:ft_equal_explicit, thm:fundamentalTheorem_equalMPV_CFBNT_hetero,
+	\uses{thm:fundamentalTheorem_equalMPV_CFBNT_hetero,
 	      thm:mpv_decomposition,
-	      rem:cf_coeff_arrays, lem:route_b_equal_with_copies,
+	      lem:route_b_equal_with_copies,
 	      thm:afterBlocking_sectorComparison_reindexed_bntCover,
 	      thm:common_phase_cover_of_proportional_decomposition}
-	The comparison starts with explicit decomposition coefficients.
+	The comparison proceeds directly from equality of the full MPV families.
 	Theorem~\ref{thm:mpv_decomposition} expands the two canonical-form tensors in
-	their BNT bases, and Remark~\ref{rem:cf_coeff_arrays} describes the resulting
-	coefficient arrays.  When the required coefficient identities are supplied,
-	Lemma~\ref{lem:ft_equal_explicit} proves gauge equivalence after permuting
-	the weighted block-diagonal tensors.  The sector-multiplicity comparison of
-	Lemma~\ref{lem:route_b_equal_with_copies} uses the supplied multiplicity
-	data to recover both the copy counts and the sector-weight multisets from
-	these identities.
+	their BNT bases, and the sector-multiplicity comparison of
+	Lemma~\ref{lem:route_b_equal_with_copies} recovers both the copy counts and
+	the sector-weight multisets from the resulting power-sum identities.
 
 	The remaining synchronization statement for the bare equal-MPV theorem must
 	assemble the block-matching data into equality of the weighted block-diagonal
 	tensors.  The heterogeneous equal-case theorem
 	(Theorem~\ref{thm:fundamentalTheorem_equalMPV_CFBNT_hetero}) now proves the
 	block-count, bond-dimension, and gauge-phase matching directly from equality
-	of the full MPV families, without explicit coefficient limits.  The
+	of the full MPV families.  The
 	after-blocking comparison theorem
 	(Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover}) gives the
 	matched sector-weight conclusion once BNT-cover comparison data are supplied.
@@ -237,89 +233,6 @@ used in this chapter.
 	those data are available, the phases are absorbed into the recovered weights
 	and the blockwise conjugacies assemble into a global gauge equivalence.
 \end{proof}
-
-\begin{lemma}[Equal MPV comparison with explicit coefficients]\label{lem:ft_equal_explicit}
-	\lean{MPSTensor.fundamentalTheorem_equalMPV_of_explicit_coefficients}
-	\leanok
-	\uses{def:cf_bnt, def:gauge_equiv}
-	Let $A_{\mathrm{tot}}$ and $B_{\mathrm{tot}}$ be MPS tensors
-	in canonical form with BNT separation, with associated families
-	$(\mu_j^A, A_j)_{j=1}^{g_A}$ and $(\mu_k^B, B_k)_{k=1}^{g_B}$.
-	Suppose there exist coefficient arrays $a_{N,j}$, $b_{N,k}$ and
-	nonzero limits $a_j^\infty$, $b_k^\infty$ such that
-	\[
-		V^{(N)}(A_{\mathrm{tot}})_\sigma
-		= \sum_{j=1}^{g_A} a_{N,j} V^{(N)}(A_j)_\sigma,
-		\qquad
-		V^{(N)}(B_{\mathrm{tot}})_\sigma
-		= \sum_{k=1}^{g_B} b_{N,k} V^{(N)}(B_k)_\sigma,
-	\]
-	with $a_{N,j} \to a_j^\infty \neq 0$ and
-	$b_{N,k} \to b_k^\infty \neq 0$.
-	If
-	\[
-		V^{(N)}(A_{\mathrm{tot}})_\sigma
-		= V^{(N)}(B_{\mathrm{tot}})_\sigma
-	\]
-	for every $N$ and $\sigma$, then $g_A = g_B$, and there is a
-	permutation $\pi$ such that $D_j^A = D_{\pi(j)}^B$ and, after
-	ordering the $B$-blocks by $\pi$, the weighted block-diagonal tensors
-	$\bigoplus_{j=1}^{g_A} \mu_j^A A_j$ and
-	$\bigoplus_{j=1}^{g_A} \mu_{\pi(j)}^B B_{\pi(j)}$
-	are gauge equivalent.
-\end{lemma}
-
-\begin{proof}
-	\leanok
-	\uses{thm:ft_proportional, thm:cf_bnt_is_bnt, def:bnt,
-	      thm:mpv_decomposition, thm:gauge_phase_mpv_scaling}
-	Apply Theorem~\ref{thm:ft_proportional} with $c_N = 1$.
-	This yields $g_A = g_B$, a permutation $\pi$, equal block dimensions,
-	and for each $j$ a gauge-phase equivalence
-	\[
-		B_{\pi(j)}^i = \zeta_j X_j A_j^i X_j^{-1}.
-	\]
-	By Theorem~\ref{thm:mpv_decomposition},
-	\[
-		V^{(N)}(A_{\mathrm{tot}})_\sigma
-		= \sum_{j=1}^{g_A} (\mu_j^A)^N V^{(N)}(A_j)_\sigma,
-	\]
-	and similarly for $B_{\mathrm{tot}}$.
-	Reindex the $B$-sum by $\pi$ and use the gauge-phase identity to rewrite
-	\[
-		V^{(N)}(B_{\pi(j)})_\sigma = \zeta_j^N V^{(N)}(A_j)_\sigma.
-	\]
-	Then equality of MPVs implies
-	\[
-		\sum_{j=1}^{g_A}
-		\left((\mu_j^A)^N - (\mu_{\pi(j)}^B \zeta_j)^N\right)
-		V^{(N)}(A_j)_\sigma = 0.
-	\]
-	By Theorem~\ref{thm:cf_bnt_is_bnt} and Definition~\ref{def:bnt}, the
-	family $\{V^{(N)}(A_j)\}_{j=1}^{g_A}$ is linearly independent for all
-	sufficiently large $N$, so
-	\[
-		(\mu_j^A)^N = (\mu_{\pi(j)}^B \zeta_j)^N
-	\]
-	for every $j$ and all large $N$.
-	Comparing two consecutive values of $N$ and using that the weights are
-	nonzero gives
-	\[
-		\mu_j^A = \mu_{\pi(j)}^B \zeta_j.
-	\]
-	Thus the phase factors can be absorbed into the weights, and the
-	resulting blockwise conjugacies combine to give a gauge equivalence of the
-	permuted weighted block-diagonal tensors.
-\end{proof}
-
-\begin{remark}
-	Lemma~\ref{lem:ft_equal_explicit} gives a conditional special case of
-	\cite[Corollary~IV.5]{Cirac2021Matrix} for tensors in canonical form with
-	BNT separation, assuming the coefficient identities explicitly rather than
-	deriving them by Newton--Girard identities. The weight matching uses BNT linear
-	independence (Theorem~\ref{thm:cf_bnt_is_bnt} and
-	Definition~\ref{def:bnt}) directly.
-\end{remark}
 
 \begin{theorem}[Fundamental Theorem --- equal MPV case, common block structure]\label{thm:ft_equal_same_structure}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_CFBNT}
@@ -2104,10 +2017,8 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	matrix; this is the equal-case corollary of the Fundamental Theorem in
 	\cite{Cirac2016MPDO_arXiv}, restated in \cite{Cirac2021Matrix}.
 
-	The comparison theorems in this chapter cover this latter part of the argument.
-	Lemma~\ref{lem:ft_equal_explicit} proves the equal case when the coefficient
-	identities are given explicitly,
-	Theorem~\ref{thm:ft_equal_same_structure} proves the common block-structure
+	The comparison theorems in this chapter cover this latter part of the
+	argument.  Theorem~\ref{thm:ft_equal_same_structure} proves the common block-structure
 	special case, and Lemma~\ref{lem:route_b_equal_with_copies} recovers the
 	copy counts and sector-weight multisets from the multiplicity data.  The
 	basis-of-normal-tensors construction


### PR DESCRIPTION
## Summary
- remove the unused explicit-coefficient equal-MPV lemma and its trivial equal-to-proportional helper
- remove the matching Chapter 11 blueprint lemma entry and references
- keep the equal-MPV route focused on the coefficient-free heterogeneous theorem, common block-structure theorem, and BNT multiplicity/power-sum recovery lemmas

## Source-faithfulness note
The retired explicit-equal lemma was not used by Lean code and was more assumption-heavy than the source equal-MPV corollary: it routed equality through the proportional theorem with explicit convergent coefficient arrays. The current coefficient-free heterogeneous equal-case theorem is the relevant formal endpoint for block matching, so keeping the old explicit route in the paper-facing surface was confusing.

Linked issues: #1282, #1170, #1324.

## Validation
- lake env lean TNLean/MPS/FundamentalTheorem/EqualProportional.lean
- lake env lean TNLean/MPS/FundamentalTheorem/Full.lean
- python3 scripts/blueprint_lean_sync.py --root . --ci
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: removes an unused Lean lemma and updates documentation/blueprint references without changing the remaining proved equal/proportional FT endpoints.
> 
> **Overview**
> Drops the explicit-coefficient equal-MPV endpoint (`fundamentalTheorem_equalMPV_of_explicit_coefficients`) and its helper lemma (`sameMPV₂_implies_proportionalMPV₂`) from `EqualProportional.lean`, leaving the equal-case surface centered on `fundamentalTheorem_equalMPV_CFBNT` and the coefficient-free heterogeneous block-matching theorem.
> 
> Updates `Full.lean` module docs and the blueprint (verification note + Ch10/Ch11) to remove references to the retired explicit-coefficient route and to describe the equal-case proof narrative in terms of direct block matching plus sector-decomposition / power-sum multiplicity recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0afda70fafbf90baee3aaa151cc38a5e4c03b952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->