### PR TITLE
doc(Algebra+MPS/FT): qualify power-sum identity as Appendix support

### DIFF
--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -15,7 +15,12 @@ equal power sums for all positive exponents, then their diagonal matrices have e
 characteristic polynomials, and consequently the two families give rise to the same multiset of
 values.
 
-This is the content of **Lemma Lem:app_simple** of arXiv:1606.00608 (lines 1155–1163).
+This is the same-cardinality, all-positive-exponent support lemma used for the
+power-sum argument in **Lemma Lem:app_simple** of arXiv:1606.00608
+(lines 1155-1163). The paper's lemma is sharper: it compares two sorted finite
+families whose cardinalities are not assumed equal, only needs finitely many
+power sums up to the larger cardinality, and concludes equality of the ordered
+families.
 
 ## Strategy
 
@@ -49,10 +54,13 @@ theorem trace_diagonal_pow (a : n → ℂ) (k : ℕ) :
     trace (diagonal a ^ k) = ∑ i, a i ^ k := by
   simp [diagonal_pow, trace_diagonal]
 
-/-- **Scalar power-sum identity** (Lemma Lem:app_simple of arXiv:1606.00608).
+/-- **Scalar power-sum identity.**
 
 If two families of complex scalars, indexed by the same finite type, have equal power sums for all
-positive exponents, then their characteristic polynomials (as diagonal matrices) agree. -/
+positive exponents, then their characteristic polynomials (as diagonal matrices) agree.
+This is a same-cardinality support lemma for the power-sum step in
+arXiv:1606.00608 (Appendix, lines 1155-1163), not the exact finite-range
+statement proved there. -/
 theorem sum_pow_eq_implies_charpoly_diagonal_eq
     (a b : n → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i, a i ^ k = ∑ i, b i ^ k) :

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.BNT.Construction
-import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 
 /-!
@@ -34,12 +33,6 @@ coefficients from the hypotheses of the source-paper theorem is not part of this
 (`sameMPV₂_implies_proportionalMPV₂`)
 
 Trivial but useful: `SameMPV₂ A B → ProportionalMPV₂ A B` (take `c_N = 1`).
-
-### Power-sum multiset equality
-(`power_sum_eq_implies_multiset_eq`)
-
-If two sequences of complex numbers have equal power sums for all exponents, their multisets
-(as roots) are equal. This is the formalized version of Lemma Lem:app_simple from the paper.
 
 ## References
 
@@ -459,26 +452,6 @@ lemma fundamentalTheorem_equalMPV_of_explicit_coefficients
     simp only [toTensorFromBlocks, Bweighted, one_smul]
   rw [hA_tot, hB_tot]
   exact hGaugeWeighted
-
-/-! ## Power-sum multiset equality
-
-This gives the paper's auxiliary power-sum lemma in the notation of the BNT
-comparison.  It is not an additional Fundamental Theorem statement.
--/
-
-/-- **Equal power sums imply equal multisets.**
-
-If two sequences of complex numbers `α : Fin n → ℂ` and `β : Fin n → ℂ` satisfy
-`∑ i, (α i)^k = ∑ i, (β i)^k` for all positive `k`, then `α` and `β` have the same
-multiset of values (counted with multiplicity).
-
-This is the paper's auxiliary power-sum lemma, proved via Newton's identities
-(`Matrix.sum_pow_eq_implies_multiset_eq` from `ScalarPowerSumIdentity.lean`). -/
-lemma power_sum_eq_implies_multiset_eq (n : ℕ)
-    (α β : Fin n → ℂ)
-    (h : ∀ k : ℕ, 0 < k → ∑ i : Fin n, (α i) ^ k = ∑ i : Fin n, (β i) ^ k) :
-    Finset.univ.val.map α = Finset.univ.val.map β :=
-  Matrix.sum_pow_eq_implies_multiset_eq α β h
 
 /-! ## Combined corollaries -/
 

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Periodic.Defs
+import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.MPS.FundamentalTheorem.Full
 import TNLean.MPS.Overlap.Basic
 import TNLean.MPS.Periodic.Overlap
@@ -830,12 +831,12 @@ theorem perBlock_zgauge_of_power_eq
 /-- **Weight multiset recovery via Newton-Girard (Theorem 3.8, step 6).**
 
 If two weight families have equal power sums for all positive exponents, they determine
-the same multiset. Direct reformulation of `power_sum_eq_implies_multiset_eq`. -/
+the same multiset. Direct reformulation of `Matrix.sum_pow_eq_implies_multiset_eq`. -/
 theorem weight_multisets_eq_of_power_sums_eq
     {r : ℕ} (μ ν : Fin r → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i : Fin r, μ i ^ k = ∑ i : Fin r, ν i ^ k) :
     Finset.univ.val.map μ = Finset.univ.val.map ν :=
-  power_sum_eq_implies_multiset_eq r μ ν h
+  Matrix.sum_pow_eq_implies_multiset_eq μ ν h
 
 /-- **Full Z-gauge construction (Theorem 3.8, steps 5–7 composed).**
 

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -7,7 +7,6 @@ import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Core.Correlations
 import TNLean.MPS.BNT.Construction
 import TNLean.Spectral.SpectralGap
-import TNLean.Algebra.ScalarPowerSumIdentity
 
 /-!
 # Zero correlation length (ZCL) for MPS tensors

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -532,6 +532,13 @@ The main references are
 	compared. Once that matching is available, the power-sum lemma supplies the
 	multiplicity and weight equality needed to assemble the weighted
 	block-diagonal gauge.
+
+	The statement below is the same-cardinality form with equality for all
+	positive exponents used by the BNT comparison in this section. The Appendix
+	lemma in the source is sharper: the two finite families need not initially
+	have the same cardinality, only finitely many power sums up to the larger
+	cardinality are assumed, and the conclusion is equality of the ordered
+	families.
 \end{remark}
 
 \begin{theorem}[Equal power sums imply equal multisets]\label{thm:power_sum_multiset}


### PR DESCRIPTION
## Summary

- qualify the scalar power-sum identity as a same-cardinality, all-positive-exponent support lemma for `Lem:app_simple`
- update the BNT comparison blueprint remark to state the difference from the sharper finite-range Appendix lemma
- delete the redundant `MPSTensor.power_sum_eq_implies_multiset_eq` wrapper and call `Matrix.sum_pow_eq_implies_multiset_eq` directly from the periodic theorem
- remove a stale `ScalarPowerSumIdentity` import from the RFP zero-correlation-length file

Refs #1350.

## Validation

- `lake env lean TNLean/Algebra/ScalarPowerSumIdentity.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/EqualProportional.lean`
- `lake env lean TNLean/MPS/Periodic/FundamentalTheorem.lean`
- `lake env lean TNLean/MPS/RFP/ZeroCorrelationLength.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/clarifications plus minor refactors to imports and lemma calls, with no change to the underlying mathematical statements or proofs.
> 
> **Overview**
> Clarifies the `ScalarPowerSumIdentity` results as a **same-cardinality, all-positive-exponent** support lemma for the arXiv appendix power-sum step (and explicitly notes the paper’s sharper finite-range statement), with matching wording updates in the blueprint remark.
> 
> Removes the redundant `power_sum_eq_implies_multiset_eq` wrapper from the BNT equal/proportional module, updates the periodic FT to call `Matrix.sum_pow_eq_implies_multiset_eq` directly (and adds the needed import there), and drops a stale `ScalarPowerSumIdentity` import from the ZCL file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f62a692a1ee84667f20dd572adbc752ade63530b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->