### PR TITLE
refactor(MPS/CanonicalForm): retire matched-basis wrapper

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/SectorComparisonCore.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/SectorComparisonCore.lean
@@ -25,89 +25,17 @@ namespace MPSTensor
 
 section FundamentalTheoremAfterBlocking
 
-/-- **Conditional after-blocking sector comparison.**
-
-Given two tensors with `SameMPV₂`, a common-period BNT sector pair, and a
-basis-block matching theorem, this theorem produces the target conclusion: a
-common blocking period, a `SectorDecomposition` on each side carrying BNT basis
-data, and matched sector-weight data for the canonical-form reduction.
-
-The two hypotheses are intentionally separated:
-
-* `bntSectorPair` supplies a common-period BNT sector decomposition for both
-  sides, `SameMPV₂`-equivalent to the blocked tensors and carrying
-  `HasBNTSectorData`.
-* `matchedBasisData` supplies a permutation of basis blocks, equality of copy
-  numbers, and per-block gauge-phase equivalence from `SameMPV₂` between two
-  sector decompositions whose first entry has BNT basis data.
-
-The body is a kernel-checked composition of the existing structural theorem's
-blocking compatibility (`sameMPV₂_blockTensor`), the two hypotheses, and
-`fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`. The
-later theorems below instantiate the matching side with primitive overlap-span
-hypotheses rather than assuming the witness directly. -/
-theorem fundamentalTheorem_after_blocking_sector_of_bntPair_matched
-    {d D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B)
-    (bntSectorPair :
-      ∃ p : ℕ, 0 < p ∧
-      ∃ P Q : SectorDecomposition (blockPhysDim d p),
-        SameMPV₂ (blockTensor (d := d) (D := D₁) A p) P.toTensor ∧
-        SameMPV₂ (blockTensor (d := d) (D := D₂) B p) Q.toTensor ∧
-        HasBNTSectorData P ∧ HasBNTSectorData Q)
-    (matchedBasisData : ∀ {d' : ℕ} (P Q : SectorDecomposition d'),
-      HasBNTSectorData P → SameMPV₂ P.toTensor Q.toTensor →
-      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
-        (∀ j, P.copies j = Q.copies (perm j)) ∧
-        ∀ j : Fin P.basisCount,
-          ∃ hdim : P.basisDim j = Q.basisDim (perm j),
-            GaugePhaseEquiv (d := d')
-              (cast (congr_arg (MPSTensor d') hdim) (P.basis j))
-              (Q.basis (perm j))) :
-    ∃ p : ℕ, 0 < p ∧
-    ∃ P Q : SectorDecomposition (blockPhysDim d p),
-      SameMPV₂ (blockTensor (d := d) (D := D₁) A p) P.toTensor ∧
-      SameMPV₂ (blockTensor (d := d) (D := D₂) B p) Q.toTensor ∧
-      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
-      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
-      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
-      ∃ ζ : Fin P.basisCount → ℂ,
-        (∀ j, ζ j ≠ 0) ∧
-        ∀ j : Fin P.basisCount,
-          Finset.univ.val.map (P.weight j) =
-            Finset.univ.val.map
-              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
-  obtain ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt⟩ := bntSectorPair
-  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
-                      (blockTensor (d := d) (D := D₂) B p) :=
-    sameMPV₂_blockTensor A B hSame p
-  have hPQeq : SameMPV₂ P.toTensor Q.toTensor := by
-    intro N σ
-    calc
-      mpv P.toTensor σ
-          = mpv (blockTensor (d := d) (D := D₁) A p) σ := (hPeq N σ).symm
-      _ = mpv (blockTensor (d := d) (D := D₂) B p) σ := hAB N σ
-      _ = mpv Q.toTensor σ := hQeq N σ
-  obtain ⟨perm, hCopies, hBasisGPE⟩ := matchedBasisData P Q hPbnt hPQeq
-  obtain ⟨ζ, hζne, hMultiset⟩ :=
-    fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
-      P Q perm hCopies hBasisGPE hPbnt hPQeq
-  exact ⟨p, hp, P, Q, hPeq, hQeq, hPbnt, hQbnt,
-          perm, hCopies, ζ, hζne, hMultiset⟩
-
 /-- **After-blocking sector comparison from primitive overlap-span hypotheses.**
 
-This theorem replaces the abstract `matchedBasisData` hypothesis in
-`fundamentalTheorem_after_blocking_sector_of_bntPair_matched` by the
-paper-level overlap-rigidity hypotheses collected in
-`SectorBasisOverlapSpanHypotheses`. The hypotheses still include a BNT sector
-pair at a common blocking period, but the matching witness itself is now
-constructed by `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching` and
-then used in the two-basis sector comparison theorem.
+Assume that a common positive blocking period gives sector decompositions for
+the two blocked tensors, that both sector decompositions carry BNT data, and
+that their bases satisfy the primitive overlap-span hypotheses. These
+hypotheses construct the sector-basis matching, and the two-basis sector
+comparison theorem then gives the matched sector-weight conclusion.
 
-Thus the theorem connects the comparison machinery without assuming a
-`SectorBasisMatching` or a permutation with copy-count equalities as a hypothesis. -/
+Thus the matched sector-weight conclusion is derived from primitive overlap-span
+data, rather than from an assumed `SectorBasisMatching` or an assumed
+permutation with copy-count equalities. -/
 theorem fundamentalTheorem_after_blocking_sector_of_bntPair_overlapSpan
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)


### PR DESCRIPTION
### Motivation

- `MPSTensor.fundamentalTheorem_after_blocking_sector_of_bntPair_matched` was an intermediate theorem assuming an abstract `SectorBasisMatching` datum (a permutation, copy-count equalities, and gauge-phase equivalences) rather than deriving it from the overlap-span hypotheses used by the after-blocking comparison route.
- The theorem had no blueprint entry and a single internal reference (a docstring in its successor), making deletion safe with no downstream impact.
- The successor theorem `MPSTensor.fundamentalTheorem_after_blocking_sector_of_bntPair_overlapSpan` constructs the sector-basis matching from `SectorBasisOverlapSpanHypotheses` directly, so the intermediate result is redundant.
- Continues formalization of the algebraic Fundamental Theorem for MPS; see #1352, parent tracker #1282.

### Description

- Deleted `MPSTensor.fundamentalTheorem_after_blocking_sector_of_bntPair_matched` from `TNLean/MPS/CanonicalForm/Assembly/SectorComparisonCore.lean` (no downstream callers; no blueprint entry; confirmed by `rg`).
- Updated `MPSTensor.fundamentalTheorem_after_blocking_sector_of_bntPair_overlapSpan` to construct a `SectorBasisMatching` instance via `exists_sectorBasisMatching` and apply `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching` directly, replacing the former delegation path through the retired theorem.
- Updated the docstring to state the mathematical inputs — a common positive blocking period, BNT sector data on both blocked tensors, and primitive overlap-span hypotheses — without reference to the retired intermediate result.
- No compatibility alias is provided: the deleted declaration had no blueprint entry and no downstream callers.

### Testing

- `rg "fundamentalTheorem_after_blocking_sector_of_bntPair_matched" TNLean/` returns no matches after removal.
- Blueprint sync validated: `leanblueprint checkdecls` shows `ch08_canonical.tex` at 100% (234/234 declarations).
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
Closes #1352

> [!NOTE]
> **Low Risk**
> Low risk refactor that deletes a redundant theorem wrapper and routes proofs directly through overlap-span-derived `SectorBasisMatching`; potential risk is limited to any external users relying on the removed lemma name/signature.
> 
> **Overview**
> Retires the intermediate lemma `fundamentalTheorem_after_blocking_sector_of_bntPair_matched`, simplifying the after-blocking sector-comparison path to go directly from BNT sector data plus `SectorBasisOverlapSpanHypotheses` to the matched-weight conclusion.
> 
> Updates `fundamentalTheorem_after_blocking_sector_of_bntPair_overlapSpan` documentation and proof to construct a `SectorBasisMatching` via `exists_sectorBasisMatching` and then apply `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching`, instead of requiring an explicit permutation/copy/basis-matching witness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057a991667ab01152080811facef15d49cff1d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>