### PR TITLE
fix(MPS/CanonicalForm): relax common flat normal weights

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorFamily.lean
@@ -291,12 +291,16 @@ lemma commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
   simpa [commonFlatDim, y] using F.commonSectorBlock_dim_pos y.1 y.2
 
 /-- A common blocked cyclic-sector family is a normal canonical form once its
-transported flat weights are sorted by strictly decreasing modulus. -/
+transported flat weights are sorted by non-increasing modulus.
+
+Equal flat weights can occur for different cyclic sectors of the same original
+block.  They are allowed in the paper's canonical form and should be retained as
+sector multiplicity data rather than collapsed by a strict-ordering hypothesis. -/
 lemma isNormalCanonicalForm_commonFlatBlocks
     (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ)
     (hμ : ∀ k, μ k ≠ 0)
-    (hAnti : StrictAnti
+    (hAnti : Antitone
       (fun x : Fin (∑ k : Fin r, F.period k) => ‖F.commonFlatWeight μ x‖)) :
     IsNormalCanonicalForm (d := blockPhysDim d F.p)
       (F.commonFlatWeight μ) F.commonFlatBlocks :=
@@ -318,7 +322,7 @@ lemma isNormalCanonicalForm_commonFlatBlocksAt
     {p' : ℕ} (hp : F.p = p')
     (μ : Fin r → ℂ)
     (hμ : ∀ k, μ k ≠ 0)
-    (hAnti : StrictAnti
+    (hAnti : Antitone
       (fun x : Fin (∑ k : Fin r, F.period k) => ‖F.commonFlatWeight μ x‖)) :
     IsNormalCanonicalForm (d := blockPhysDim d p')
       (F.commonFlatWeight μ) (F.commonFlatBlocksAt hp) := by

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonBlockedCyclicSectorRepresentatives.lean
@@ -211,12 +211,15 @@ lemma exists_commonRepresentativeBlocksAt_blockTensor_isInjective
     hp ⟨L, hL_pos, hL⟩
 
 /-- A representative common-sector family is a normal canonical form once its transported
-representative weights are sorted by strictly decreasing modulus. -/
+representative weights are sorted by non-increasing modulus.
+
+The target normal canonical form permits equal moduli.  Strict ordering is a
+separate restricted branch, not part of the general canonical-form reduction. -/
 lemma isNormalCanonicalForm_commonRepresentativeBlocks
     (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ)
     (hμ : ∀ k, μ k ≠ 0)
-    (hAnti : StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
+    (hAnti : Antitone (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
     IsNormalCanonicalForm (d := blockPhysDim d F.p)
       (F.commonRepresentativeWeight μ) F.commonRepresentativeBlocks :=
   isNormalCanonicalForm_of_tp_primitive_irr_sorted
@@ -237,7 +240,7 @@ lemma isNormalCanonicalForm_commonRepresentativeBlocksAt
     {p' : ℕ} (hp : F.p = p')
     (μ : Fin r → ℂ)
     (hμ : ∀ k, μ k ≠ 0)
-    (hAnti : StrictAnti (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
+    (hAnti : Antitone (fun k : Fin r => ‖F.commonRepresentativeWeight μ k‖)) :
     IsNormalCanonicalForm (d := blockPhysDim d p')
       (F.commonRepresentativeWeight μ) (F.commonRepresentativeBlocksAt hp) := by
   subst p'

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonPrimitiveProportionalData.lean
@@ -347,11 +347,13 @@ def ofCommonPrimitiveData
   ncfA := by
     have hDimA : ∀ x, 0 < dimA x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimA x))
     exact isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA hAntiA
+      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA
+      hAntiA.antitone
   ncfB := by
     have hDimB : ∀ x, 0 < dimB x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimB x))
     exact isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB hAntiB
+      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB
+      hAntiB.antitone
   notGpeA := hNotGpeA
   notGpeB := hNotGpeB
   zeroTail_eq := hZeroTail
@@ -397,10 +399,12 @@ def ofCommonPrimitiveData_zeroTailIdentity
   have hDimB : ∀ x, 0 < dimB x := fun x => Nat.pos_of_ne_zero (NeZero.ne (dimB x))
   have hNcfA : IsNormalCanonicalForm (d := blockPhysDim d p) μA blocksA :=
     isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA hAntiA
+      (d' := blockPhysDim d p) (μ := μA) blocksA hTPA hPrimA hDimA hμA hIrrA
+      hAntiA.antitone
   have hNcfB : IsNormalCanonicalForm (d := blockPhysDim d p) μB blocksB :=
     isNormalCanonicalForm_of_tp_primitive_irr_sorted
-      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB hAntiB
+      (d' := blockPhysDim d p) (μ := μB) blocksB hTPB hPrimB hDimB hμB hIrrB
+      hAntiB.antitone
   have hMatch : ProportionalDecompositionConclusion (d := blockPhysDim d p) blocksA blocksB :=
     fundamentalTheorem_of_separated_normalCFBNT_data
       blocksA blocksB hNcfA hNotGpeA hNcfB hNotGpeB hDecomp

--- a/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/CommonSectorTransport.lean
@@ -62,7 +62,7 @@ theorem isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
     IsNormalCanonicalFormBNT (d := blockPhysDim d p)
       (F.commonRepresentativeWeight μ) (F.commonRepresentativeBlocksAt hp) where
   toIsNormalCanonicalForm :=
-    F.isNormalCanonicalForm_commonRepresentativeBlocksAt hp μ hμ hAnti
+    F.isNormalCanonicalForm_commonRepresentativeBlocksAt hp μ hμ hAnti.antitone
   mu_strict_anti := hAnti
   blocks_not_equiv := hNotGpe
 

--- a/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
@@ -146,11 +146,12 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
 /-!
 ## Conditional normal canonical form
 
-If the blocked weights happen to have pairwise distinct norms, and the blocked
+If the blocked weights are ordered by non-increasing norm, and the blocked
 blocks are irreducible, then the data can be shown to satisfy
-`IsNormalCanonicalForm` after sorting by weight norm.
+`IsNormalCanonicalForm`.  Equal weight moduli are allowed; requiring pairwise
+distinct norms is only a restricted separated-representative branch.
 
-This is a conditional theorem: the two extra hypotheses are genuine conditions
+This is a conditional theorem: the extra hypotheses are genuine conditions
 that the reduction does not produce automatically (see gap documentation above).
 -/
 

--- a/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/TPPrimitiveReduction.lean
@@ -44,7 +44,7 @@ primitive block decomposition.
 * `exists_tp_primitive_blockDecomp_after_blocking` — arbitrary tensors admit a
   blocked decomposition into a zero tail and TP-primitive blocks.
 * `isNormalCanonicalForm_of_tp_primitive_irr_sorted` — a blocked TP-primitive
-  family with irreducible blocks and strictly separated weights is already in
+  family with irreducible blocks and non-increasing weights is already in
   normal canonical form.
 * `exists_normalCanonicalForm_of_primitive_input` — primitive block data with
   distinct weight norms yields a normal canonical form without nontrivial
@@ -157,8 +157,10 @@ that the reduction does not produce automatically (see gap documentation above).
 /-- **Conditional normal canonical form after blocking.**
 
 If the blocked data additionally satisfy tensor irreducibility for each block,
-pairwise distinct weight norms, and strict weight ordering (already sorted), then
-the data forms an `IsNormalCanonicalForm` directly.
+and the weight moduli are already sorted in non-increasing order, then the data
+forms an `IsNormalCanonicalForm` directly.  Equal moduli are allowed here, as in
+the canonical form of arXiv:1606.00608; strict separation belongs only to the
+restricted strict-representative branch.
 
 For the unsorted case, use `exists_normalCanonicalForm_of_primitive_blockDecomp`
 which handles both sorting and blocking internally. -/
@@ -172,13 +174,13 @@ theorem isNormalCanonicalForm_of_tp_primitive_irr_sorted
     (hDim : ∀ k, 0 < dim k)
     (hμne : ∀ k, μ k ≠ 0)
     (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
-    (hAnti : StrictAnti (fun k : Fin r => ‖μ k‖)) :
+    (hAnti : Antitone (fun k : Fin r => ‖μ k‖)) :
     IsNormalCanonicalForm (d := d') μ blocks :=
-  IsNormalCanonicalForm.ofStrictSeparatedData
+  IsNormalCanonicalForm.ofSeparatedData
     (HasIrreducibleBlocks.ofForall hIrr)
     (IsLeftCanonicalBlockFamily.ofForall hTP)
     (HasPrimitiveBlocks.ofForall hPrim)
-    { mu_strict_anti := hAnti
+    { mu_antitone := hAnti
       mu_ne_zero := hμne }
     hDim
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1823,7 +1823,7 @@ the common length $p=m_k e_k$.
 	nonzero weights remain nonzero after being transported to the common
 	blocking length and replicated over the flattened sector family.  If the
 	original weights are nonzero and the transported weights are sorted by
-	strictly decreasing norm, the flattened common-sector family is a normal
+	non-increasing norm, the flattened common-sector family is a normal
 	canonical form.
 \end{lemma}
 
@@ -3289,8 +3289,8 @@ primitivity and normality results to the sector blocks.
 	\lean{MPSTensor.isNormalCanonicalForm_of_tp_primitive_irr_sorted}
 	\leanok
 	\uses{def:is_normal_canonical_form}
-	Let $(\mu_k, A_k)$ be a finite block family with strictly decreasing norms
-	$|\mu_1| > \cdots > |\mu_r|$.
+	Let $(\mu_k, A_k)$ be a finite block family with non-increasing norms
+	$|\mu_1| \geq \cdots \geq |\mu_r|$.
 	If every block $A_k$ is left-canonical, primitive, irreducible, has positive
 	bond dimension, and every $\mu_k \neq 0$, then $(\mu_k,A_k)$ is a normal
 	canonical form.


### PR DESCRIPTION
### Motivation

- The common flat cyclic-sector reduction required strictly decreasing weight moduli (`StrictAnti`), even though the target predicate `IsNormalCanonicalForm` requires only non-increasing weights (`Antitone`). This overly strong precondition conflicts with the canonical form in arXiv:1606.00608, where equal moduli are permitted and repeated BNT copies appear as multiplicity data rather than being excluded.

### Description

- Relaxes `isNormalCanonicalForm_of_tp_primitive_irr_sorted` from `StrictAnti` to `Antitone`, switching to the `IsNormalCanonicalForm.ofSeparatedData` constructor.
- Relaxes the common flat and common representative normal-form lemmas to non-increasing transported weights.
- Keeps strict ordering at the `IsNormalCanonicalFormBNT` layer by passing the antitone projection to the underlying normal-form field.
- Updates docstrings to clarify that strict separation applies only to restricted strict-representative branches, not the general canonical-form reduction.

### Testing

- `lake build TNLean.MPS.CanonicalForm.Assembly.TPPrimitiveReduction TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily`
- `lake build TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorRepresentatives`
- `lake build TNLean.MPS.CanonicalForm.Assembly.CommonPrimitiveProportionalData`
- `lake build TNLean.MPS.CanonicalForm.Assembly`
- Blueprint sync check: `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Closes #1355.
Partially addresses #1354.
Partially addresses #1170.
Partially addresses #1282.

> [!NOTE]
> **Medium Risk**
> Moderate proof-level refactor that changes ordering assumptions from strict to non-strict, which may affect downstream lemmas relying on uniqueness/distinctness but does not change computational behavior.
>
> **Overview**
> Relaxes the canonical-form "sorted weights" requirement from `StrictAnti` (strictly decreasing norms) to `Antitone` (non-increasing norms) in `isNormalCanonicalForm_of_tp_primitive_irr_sorted`, switching from `IsNormalCanonicalForm.ofStrictSeparatedData` to `IsNormalCanonicalForm.ofSeparatedData`.
>
> Propagates this relaxation through the common-sector lemmas (`isNormalCanonicalForm_commonFlatBlocks*`, `isNormalCanonicalForm_commonRepresentativeBlocks*`) and updates BNT/transport wrappers to pass `hAnti.antitone` where strict order is still stored, with docstrings clarified to allow equal moduli as sector multiplicities rather than forbidding them.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53b68b4a8ee77185b9eb914d6f60491b2c55ed89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate proof-level API change: several canonical-form lemmas now accept `Antitone` (non-increasing) weight norms instead of `StrictAnti`, which may require downstream proof updates where strict separation was assumed implicitly.
> 
> **Overview**
> Relaxes the “sorted weights” precondition for proving `IsNormalCanonicalForm` across the TP-primitive and common-sector pipeline: `isNormalCanonicalForm_of_tp_primitive_irr_sorted` now takes `Antitone` (non-increasing) weight norms and uses `IsNormalCanonicalForm.ofSeparatedData` rather than requiring strict separation.
> 
> Propagates the relaxed ordering requirement to the common flattened-sector and representative-sector normal-form lemmas, while keeping the BNT-level wrapper strict by passing `hAnti.antitone` into the underlying normal-canonical-form field. Documentation and the blueprint are updated to explicitly allow equal weight moduli as multiplicity data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a51822523ac56d49365b210419a4c9327fb34b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->