### PR TITLE
feat(MPDO): formalize direct-sum trace input

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -21,6 +21,7 @@ Extracted from various files for reusability.
 ## Main results
 
 - `Matrix.sum_mul_mul`: pull fixed left/right factors through a finite sum
+- `Matrix.finrank_matrix_fin_eq_sq`: square `Fin D` matrices have dimension `D ^ 2`
 - `Matrix.dim_le_of_mulVec_injective`: injective mulVec implies dimension bound
 - `Matrix.PosSemidef.mulVec_eq_zero_left/right`: kernel containment for PSD matrix sums
 - `Matrix.trace_eq_of_charpoly_eq`: equal characteristic polynomials imply equal traces
@@ -29,6 +30,22 @@ Extracted from various files for reusability.
 open scoped Matrix BigOperators ComplexOrder
 
 namespace Matrix
+
+/-- The complex vector-space dimension of `D × D` matrices is `D ^ 2`. -/
+theorem finrank_matrix_fin_eq_sq (D : ℕ) :
+    Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) = D ^ 2 := by
+  calc
+    Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ)
+        = Fintype.card (Fin D) * Fintype.card (Fin D) * Module.finrank ℂ ℂ :=
+            Module.finrank_matrix ℂ ℂ _ _
+    _ = D * D * 1 := by
+          simp only [Fintype.card_fin, Module.finrank_self, mul_one]
+    _ = D ^ 2 := by ring
+
+/-- The top submodule of `D × D` matrices has dimension `D ^ 2`. -/
+theorem finrank_top_matrix_fin_eq_sq (D : ℕ) :
+    Module.finrank ℂ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) = D ^ 2 := by
+  simpa using finrank_matrix_fin_eq_sq D
 
 /-- Pull fixed left and right matrix factors through a finite sum indexed by `Fin d`. -/
 theorem sum_mul_mul {α : Type*} [NonUnitalNonAssocSemiring α]

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -1,5 +1,4 @@
 import TNLean.MPS.Defs
-import TNLean.Algebra.MatrixAux
 
 import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Matrix.Basis

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -32,6 +32,47 @@ open scoped Matrix BigOperators
 
 namespace Matrix
 
+/-- **David/Perez-Garcia et al. Lemma `lem1` (two-sided nonzero matrix span).**
+
+If `C` is a nonzero square complex matrix, then the linear span of all
+two-sided products `R * C * S` is the full matrix algebra. This is the
+linear-algebra input used in `Papers/quant-ph_0608197/MPSarchive.tex`,
+Lemma `lem1`, in the finite-length direct-sum argument for canonical MPS
+blocks. -/
+theorem span_range_mul_nonzero_mul_eq_top {n : Type*} [Fintype n]
+    {C : Matrix n n ℂ} (hC : C ≠ 0) :
+    Submodule.span ℂ
+        (Set.range fun RS : Matrix n n ℂ × Matrix n n ℂ => RS.1 * C * RS.2) = ⊤ := by
+  classical
+  obtain ⟨p, q, hpq⟩ : ∃ p q, C p q ≠ 0 := by
+    by_contra h
+    push Not at h
+    exact hC (by ext p q; exact h p q)
+  have hsingle :
+      ∀ i j : n,
+        Matrix.single i j (1 : ℂ) ∈
+          Submodule.span ℂ
+            (Set.range fun RS : Matrix n n ℂ × Matrix n n ℂ => RS.1 * C * RS.2) := by
+    intro i j
+    let R : Matrix n n ℂ := Matrix.single i p (C p q)⁻¹
+    let S : Matrix n n ℂ := Matrix.single q j (1 : ℂ)
+    have hprod : R * C * S = Matrix.single i j (1 : ℂ) := by
+      rw [Matrix.single_mul_mul_single]
+      simp [hpq]
+    exact hprod ▸
+      Submodule.subset_span
+        (Set.mem_range_self (R, S))
+  apply eq_top_iff.mpr
+  have hbasis :
+      Submodule.span ℂ (Set.range (Matrix.stdBasis ℂ n n)) ≤
+        Submodule.span ℂ
+          (Set.range fun RS : Matrix n n ℂ × Matrix n n ℂ => RS.1 * C * RS.2) := by
+    refine Submodule.span_le.2 ?_
+    rintro M ⟨ij, rfl⟩
+    rcases ij with ⟨i, j⟩
+    simpa [Matrix.stdBasis_eq_single] using hsingle i j
+  simpa [(Matrix.stdBasis ℂ n n).span_eq] using hbasis
+
 /-- Nondegeneracy of the trace pairing on square matrices over `ℂ`:
 if `trace (M * N) = 0` for all `N`, then `M = 0`. -/
 theorem trace_mul_right_eq_zero_iff {n : Type*} [Fintype n]
@@ -50,6 +91,83 @@ end Matrix
 namespace MPSTensor
 
 variable {d D : ℕ}
+
+/-- **Exact-length two-sided span from block injectivity.**
+
+This is the word-product form of David/Perez-Garcia et al. Lemma `lem1`
+used in the proof of `Papers/quant-ph_0608197/MPSarchive.tex`,
+Lemma `lem:direct-sum`: if words of length `N` span the full matrix algebra
+and `X` is nonzero, then the span of all products `A_u * X * A_v`, with
+`u` and `v` both of length `N`, is again the full matrix algebra. -/
+theorem span_range_evalWord_mul_nonzero_mul_evalWord_eq_top {A : MPSTensor d D}
+    {N : ℕ} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hA : IsNBlkInjective A N) (hX : X ≠ 0) :
+    Submodule.span ℂ
+        (Set.range fun uv : (Fin N → Fin d) × (Fin N → Fin d) =>
+          evalWord A (List.ofFn uv.1) * X * evalWord A (List.ofFn uv.2)) = ⊤ := by
+  classical
+  let E : Set (Matrix (Fin D) (Fin D) ℂ) :=
+    Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)
+  let T : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Submodule.span ℂ
+      (Set.range fun uv : (Fin N → Fin d) × (Fin N → Fin d) =>
+        evalWord A (List.ofFn uv.1) * X * evalWord A (List.ofFn uv.2))
+  have hspanE : Submodule.span ℂ E = ⊤ := by
+    simpa [E, IsNBlkInjective] using hA
+  have hmul_right_gen : ∀ {R : Matrix (Fin D) (Fin D) ℂ},
+      R ∈ Submodule.span ℂ E → ∀ v : Fin N → Fin d,
+        R * X * evalWord A (List.ofFn v) ∈ T := by
+    intro R hR v
+    exact Submodule.span_induction
+      (fun M hM v => by
+        rcases hM with ⟨u, rfl⟩
+        exact Submodule.subset_span ⟨(u, v), rfl⟩)
+      (by
+        intro v
+        simp [T])
+      (fun R₁ R₂ _ _ hR₁ hR₂ v => by
+        simpa [Matrix.add_mul, Matrix.mul_add, Matrix.mul_assoc, T] using
+          Submodule.add_mem T (hR₁ v) (hR₂ v))
+      (fun a R _ hR v => by
+        have hEq : (a • R) * X * evalWord A (List.ofFn v) =
+            a • (R * X * evalWord A (List.ofFn v)) := by
+          simp [Matrix.mul_assoc]
+        rw [hEq]
+        exact Submodule.smul_mem T a (hR v))
+      hR v
+  have hmul : ∀ {R S : Matrix (Fin D) (Fin D) ℂ},
+      R ∈ Submodule.span ℂ E → S ∈ Submodule.span ℂ E → R * X * S ∈ T := by
+    intro R S hR hS
+    exact Submodule.span_induction
+      (fun M hM => by
+        rcases hM with ⟨v, rfl⟩
+        exact hmul_right_gen hR v)
+      (by
+        simp [T])
+      (fun S₁ S₂ _ _ hS₁ hS₂ => by
+        simpa [Matrix.mul_add, Matrix.mul_assoc, T] using
+          Submodule.add_mem T hS₁ hS₂)
+      (fun a S _ hS => by
+        have hEq : R * X * (a • S) = a • (R * X * S) := by
+          simp [Matrix.mul_assoc]
+        rw [hEq]
+        exact Submodule.smul_mem T a hS)
+      hS
+  apply eq_top_iff.mpr
+  have hsource :
+      Submodule.span ℂ
+          (Set.range fun RS : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ =>
+            RS.1 * X * RS.2) ≤ T := by
+    refine Submodule.span_le.2 ?_
+    rintro Y ⟨RS, rfl⟩
+    exact hmul (by rw [hspanE]; exact Submodule.mem_top)
+      (by rw [hspanE]; exact Submodule.mem_top)
+  have htop :
+      Submodule.span ℂ
+          (Set.range fun RS : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ =>
+            RS.1 * X * RS.2) = ⊤ :=
+    Matrix.span_range_mul_nonzero_mul_eq_top hX
+  simpa [T, htop] using hsource
 
 /-- Lemma 2 (paper proof sketch): `SameMPV` implies agreement of traces of all products.
 

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -1,4 +1,5 @@
 import TNLean.MPS.Defs
+import TNLean.Algebra.MatrixAux
 
 import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Matrix.Basis

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -117,42 +117,43 @@ theorem span_range_evalWord_mul_nonzero_mul_evalWord_eq_top {A : MPSTensor d D}
   have hmul_right_gen : ∀ {R : Matrix (Fin D) (Fin D) ℂ},
       R ∈ Submodule.span ℂ E → ∀ v : Fin N → Fin d,
         R * X * evalWord A (List.ofFn v) ∈ T := by
-    intro R hR v
-    exact Submodule.span_induction
-      (fun M hM v => by
-        rcases hM with ⟨u, rfl⟩
-        exact Submodule.subset_span ⟨(u, v), rfl⟩)
-      (by
-        intro v
-        simp [T])
-      (fun R₁ R₂ _ _ hR₁ hR₂ v => by
-        simpa [Matrix.add_mul, Matrix.mul_add, Matrix.mul_assoc, T] using
-          Submodule.add_mem T (hR₁ v) (hR₂ v))
-      (fun a R _ hR v => by
-        have hEq : (a • R) * X * evalWord A (List.ofFn v) =
-            a • (R * X * evalWord A (List.ofFn v)) := by
-          simp [Matrix.mul_assoc]
-        rw [hEq]
-        exact Submodule.smul_mem T a (hR v))
-      hR v
+    intro R hR
+    induction hR using Submodule.span_induction with
+    | mem M hM =>
+      intro v
+      rcases hM with ⟨u, rfl⟩
+      exact Submodule.subset_span ⟨(u, v), rfl⟩
+    | zero =>
+      intro v
+      simp [T]
+    | add R₁ R₂ _ _ hR₁ hR₂ =>
+      intro v
+      simpa [Matrix.add_mul, Matrix.mul_add, Matrix.mul_assoc, T] using
+        Submodule.add_mem T (hR₁ v) (hR₂ v)
+    | smul a R _ hR =>
+      intro v
+      have hEq : (a • R) * X * evalWord A (List.ofFn v) =
+          a • (R * X * evalWord A (List.ofFn v)) := by
+        simp [Matrix.mul_assoc]
+      rw [hEq]
+      exact Submodule.smul_mem T a (hR v)
   have hmul : ∀ {R S : Matrix (Fin D) (Fin D) ℂ},
       R ∈ Submodule.span ℂ E → S ∈ Submodule.span ℂ E → R * X * S ∈ T := by
     intro R S hR hS
-    exact Submodule.span_induction
-      (fun M hM => by
-        rcases hM with ⟨v, rfl⟩
-        exact hmul_right_gen hR v)
-      (by
-        simp [T])
-      (fun S₁ S₂ _ _ hS₁ hS₂ => by
-        simpa [Matrix.mul_add, Matrix.mul_assoc, T] using
-          Submodule.add_mem T hS₁ hS₂)
-      (fun a S _ hS => by
-        have hEq : R * X * (a • S) = a • (R * X * S) := by
-          simp [Matrix.mul_assoc]
-        rw [hEq]
-        exact Submodule.smul_mem T a hS)
-      hS
+    induction hS using Submodule.span_induction with
+    | mem M hM =>
+      rcases hM with ⟨v, rfl⟩
+      exact hmul_right_gen hR v
+    | zero =>
+      simp [T]
+    | add S₁ S₂ _ _ hS₁ hS₂ =>
+      simpa [Matrix.mul_add, Matrix.mul_assoc, T] using
+        Submodule.add_mem T hS₁ hS₂
+    | smul a S _ hS =>
+      have hEq : R * X * (a • S) = a • (R * X * S) := by
+        simp [Matrix.mul_assoc]
+      rw [hEq]
+      exact Submodule.smul_mem T a hS
   apply eq_top_iff.mpr
   have hsource :
       Submodule.span ℂ

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -1,6 +1,7 @@
 import TNLean.PiAlgebra.CanonicalFormSep
 import TNLean.Spectral.SpectralGapRect
 import TNLean.Spectral.SpectralGapNT
+import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.MPS.BNT.Basic
 import TNLean.MPS.BNT.PermutationRigidity
 import TNLean.MPS.Overlap.CastDecay
@@ -221,6 +222,40 @@ def ofSeparatedData
   blocks_not_equiv := hBlocks
 
 end IsNormalCanonicalFormBNT
+
+/-- Distinct same-dimension blocks in a separated irreducible trace-preserving
+family are not proportional at arbitrarily large chain lengths. -/
+theorem exists_ge_not_forall_mpv_eq_mul_of_blocksNotGaugePhaseEquiv_of_irreducible_TP
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {j k : Fin r} (hjk : j ≠ k) (hdim : dim j = dim k) (Nmin : ℕ) :
+    ∃ N : ℕ, Nmin ≤ N ∧
+      ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d,
+        mpv (cast (congr_arg (MPSTensor d) hdim) (A j)) σ = c * mpv (A k) σ := by
+  have hA_self_cast :
+      Tendsto
+        (fun N =>
+          mpvOverlap (d := d) (cast (congr_arg (MPSTensor d) hdim) (A j))
+            (cast (congr_arg (MPSTensor d) hdim) (A j)) N)
+        atTop (nhds (1 : ℂ)) := by
+    refine (hOverlap.overlap_tendsto_one j).congr ?_
+    intro N
+    unfold mpvOverlap
+    apply Finset.sum_congr rfl
+    intro σ _
+    rw [mpv_cast_dim hdim (A j) N σ]
+  exact exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP
+    (cast (congr_arg (MPSTensor d) hdim) (A j)) (A k)
+    ((isIrreducibleTensor_cast_dim hdim (A j)).mpr (hIrr.block_irreducible j))
+    (hIrr.block_irreducible k)
+    ((leftCanonical_cast_dim hdim (A j)).mpr (hLeft.leftCanonical j))
+    (hLeft.leftCanonical k)
+    hA_self_cast (hOverlap.overlap_tendsto_one k)
+    (hBlocks j k hjk hdim) Nmin
 
 /-- The block-diagonal tensor `toTensorFromBlocks μ A` carries the obvious coefficient
 expansion over its blocks. -/

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -343,6 +343,32 @@ lemma exists_pos_productWordSpan_of_isNormalCanonicalFormBNT_of_directSum_inject
   exact exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
     μ A hCF hNCF.toHasIrreducibleBlocks
 
+/-- `WordTupleSpanTop` version of the direct-sum span theorem for
+canonical-form/BNT block families. -/
+lemma exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hIrr : HasIrreducibleBlocks (d := d) A) :
+    ∃ m : ℕ, 0 < m ∧ WordTupleSpanTop A m := by
+  obtain ⟨m, hm, hSpan⟩ :=
+    exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+      μ A hCF hIrr
+  exact ⟨m, hm, by simpa [WordTupleSpanTop, wordTuple] using hSpan⟩
+
+/-- `WordTupleSpanTop` version of the direct-sum span theorem for
+normal-CF-BNT block families with explicit one-site injectivity. -/
+lemma exists_wordTupleSpanTop_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hNCF : IsNormalCanonicalFormBNT μ A)
+    (hInj : ∀ k : Fin r, IsInjective (A k)) :
+    ∃ m : ℕ, 0 < m ∧ WordTupleSpanTop A m := by
+  obtain ⟨m, hm, hSpan⟩ :=
+    exists_pos_productWordSpan_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks
+      μ A hNCF hInj
+  exact ⟨m, hm, by simpa [WordTupleSpanTop, wordTuple] using hSpan⟩
+
 /-- Conditional positive-length product-word span from all-words pair separation plus eventual
 identity padding for every ordered pair of distinct BNT blocks.
 

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -369,6 +369,33 @@ lemma exists_wordTupleSpanTop_of_isNormalCanonicalFormBNT_of_directSum_injective
       μ A hNCF hInj
   exact ⟨m, hm, by simpa [WordTupleSpanTop, wordTuple] using hSpan⟩
 
+/-- Canonical-form/BNT direct-sum separation gives the block-injective
+horizontal-canonical-form field used by the MPDO bicanonical-form package. -/
+lemma hasBiCF_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hIrr : HasIrreducibleBlocks (d := d) A) :
+    HasBiCF A := by
+  obtain ⟨m, _hm, hSpan⟩ :=
+    exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+      μ A hCF hIrr
+  exact hasBiCF_of_wordTupleSpanTop A hSpan
+
+/-- Normal-CF-BNT direct-sum separation gives the block-injective
+horizontal-canonical-form field used by the MPDO bicanonical-form package,
+provided one-site injectivity is supplied explicitly. -/
+lemma hasBiCF_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hNCF : IsNormalCanonicalFormBNT μ A)
+    (hInj : ∀ k : Fin r, IsInjective (A k)) :
+    HasBiCF A := by
+  obtain ⟨m, _hm, hSpan⟩ :=
+    exists_wordTupleSpanTop_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks
+      μ A hNCF hInj
+  exact hasBiCF_of_wordTupleSpanTop A hSpan
+
 /-- Conditional positive-length product-word span from all-words pair separation plus eventual
 identity padding for every ordered pair of distinct BNT blocks.
 

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -315,6 +315,34 @@ lemma exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlo
         (hCF.toHasInjectiveBlocks.block_injective k))
   · norm_num
 
+/-- Positive-length product-word span from normal-CF-BNT data plus explicit
+one-site injectivity.
+
+Normal-CF-BNT data provide the irreducibility, trace-preserving normalization,
+self-overlap normalization, weight ordering, and BNT separation used by the
+direct-sum comparison.  The additional one-site injectivity hypothesis supplies
+the `IsCanonicalFormBNT` injectivity field, after which the previous lemma
+specializes the fixed-length direct-sum input to \(L=2\). -/
+lemma exists_pos_productWordSpan_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hNCF : IsNormalCanonicalFormBNT μ A)
+    (hInj : ∀ k : Fin r, IsInjective (A k)) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  let hCF : IsCanonicalFormBNT μ A :=
+    IsCanonicalFormBNT.ofSeparatedData
+      (HasInjectiveBlocks.ofForall hInj)
+      hNCF.toIsLeftCanonicalBlockFamily
+      hNCF.toHasStrictOrderedNonzeroWeights
+      hNCF.toHasNormalizedSelfOverlap
+      hNCF.blocks_not_equiv
+  exact exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+    μ A hCF hNCF.toHasIrreducibleBlocks
+
 /-- Conditional positive-length product-word span from all-words pair separation plus eventual
 identity padding for every ordered pair of distinct BNT blocks.
 

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.BlockDiagonalCommutant.ProjectionSpan
+import TNLean.MPS.CanonicalForm.Assembly.NormalityChain
 import TNLean.MPS.BNT.Construction
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.BiCFDerivation.PairHomogenization
@@ -282,6 +283,37 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock
     (forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
       A hIrr hCF.toIsLeftCanonicalBlockFamily hCF.toHasNormalizedSelfOverlap
       hCF.blocks_not_equiv hBlk hBlk3 hCF.toHasInjectiveBlocks.block_injective hL)
+
+/-- Positive-length product-word span from canonical-form/BNT separation and
+one-site injectivity of the BNT blocks.
+
+This specializes the three-block direct-sum theorem to `L = 2`.  The
+canonical-form/BNT hypotheses provide one-site injectivity for each block, and
+fixed-length injectivity persists at positive multiples, giving the length-`2`
+and length-`6` direct-sum inputs required by the source argument.  Irreducibility
+remains explicit because the BNT predicate records injectivity and normalization
+but not the tensor-irreducibility hypothesis used by the direct-sum comparison. -/
+lemma exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hIrr : HasIrreducibleBlocks (d := d) A) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  refine exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock
+    (d := d) (dim := dim) μ A hCF hIrr (L := 2) ?_ ?_ ?_
+  · intro k
+    simpa using isNBlkInjective_mul_of_isNBlkInjective (A k) (N := 1) (m := 2)
+      (by norm_num) (isNBlkInjective_one_of_isInjective
+        (hCF.toHasInjectiveBlocks.block_injective k))
+  · intro k
+    simpa using isNBlkInjective_mul_of_isNBlkInjective (A k) (N := 1) (m := 6)
+      (by norm_num) (isNBlkInjective_one_of_isInjective
+        (hCF.toHasInjectiveBlocks.block_injective k))
+  · norm_num
 
 /-- Conditional positive-length product-word span from all-words pair separation plus eventual
 identity padding for every ordered pair of distinct BNT blocks.

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -256,6 +256,33 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingA
   simpa [WordTupleSpanTop, wordTuple] using
     wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hSep
 
+/-- Positive-length product-word span from canonical-form/BNT separation and
+the source-faithful three-block direct-sum hypotheses.
+
+The BNT data supply non-gauge-equivalence for equal-dimensional distinct
+blocks.  Unequal-dimensional pairs use the strict-size branch of the
+direct-sum argument.  The fixed-length block-injectivity hypotheses are kept
+explicit, matching the direct-sum input rather than inferring them from BNT
+data. -/
+theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    {L : ℕ}
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) (L + (L + L)))
+    (hL : 1 < L) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) :=
+  exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF
+    (forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
+      A hIrr hCF.toIsLeftCanonicalBlockFamily hCF.toHasNormalizedSelfOverlap
+      hCF.blocks_not_equiv hBlk hBlk3 hCF.toHasInjectiveBlocks.block_injective hL)
+
 /-- Conditional positive-length product-word span from all-words pair separation plus eventual
 identity padding for every ordered pair of distinct BNT blocks.
 

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -60,89 +60,6 @@ section Main
 variable [NeZero D]
 
 omit [NeZero D] in
-private theorem gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one_of_tendsto_zero
-    (A B : MPSTensor d D)
-    (hA_self :
-      Filter.Tendsto (fun N => mpvOverlap (d := d) A A N) Filter.atTop (nhds (1 : ℂ)))
-    (hB_self :
-      Filter.Tendsto (fun N => mpvOverlap (d := d) B B N) Filter.atTop (nhds (1 : ℂ)))
-    (hProp : ProportionalMPV₂ (d := d) A B)
-    (hZero : ¬ GaugePhaseEquiv A B →
-      Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop (nhds 0)) :
-    GaugePhaseEquiv A B := by
-  classical
-  choose c hc using hProp
-  have hOverlapAB :
-      ∀ N : ℕ,
-        mpvOverlap (d := d) A B N = c N * mpvOverlap (d := d) B B N := by
-    intro N
-    unfold mpvOverlap
-    rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro σ _
-    rw [hc N σ]; ring
-  have hOverlapAA :
-      ∀ N : ℕ,
-        mpvOverlap (d := d) A A N = (c N * star (c N)) * mpvOverlap (d := d) B B N := by
-    intro N
-    unfold mpvOverlap
-    rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro σ _
-    rw [hc N σ]
-    simp only [star_mul]
-    ring
-  have hA_self_norm :
-      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds (1 : ℝ)) := by
-    simpa using hA_self.norm
-  have hB_self_norm :
-      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds (1 : ℝ)) := by
-    simpa using hB_self.norm
-  have hRatio :
-      Filter.Tendsto
-        (fun N => ‖mpvOverlap (d := d) A A N‖ / ‖mpvOverlap (d := d) B B N‖)
-        Filter.atTop (nhds (1 : ℝ)) := by
-    simpa using hA_self_norm.div hB_self_norm one_ne_zero
-  have hB_self_norm_ne :
-      (∀ᶠ N in Filter.atTop, ‖mpvOverlap (d := d) B B N‖ ≠ (0 : ℝ)) :=
-    hB_self_norm.eventually_ne one_ne_zero
-  have hRatio_eq :
-      (fun N => ‖mpvOverlap (d := d) A A N‖ / ‖mpvOverlap (d := d) B B N‖)
-        =ᶠ[Filter.atTop] fun N => ‖c N‖ ^ 2 := by
-    filter_upwards [hB_self_norm_ne] with N hN
-    calc
-      ‖mpvOverlap (d := d) A A N‖ / ‖mpvOverlap (d := d) B B N‖
-          = ‖(c N * star (c N)) * mpvOverlap (d := d) B B N‖ /
-              ‖mpvOverlap (d := d) B B N‖ := by
-                simp [hOverlapAA N]
-      _ = (‖c N * star (c N)‖ * ‖mpvOverlap (d := d) B B N‖) /
-            ‖mpvOverlap (d := d) B B N‖ := by
-                simp
-      _ = ‖c N * star (c N)‖ := by
-            simpa using
-              (mul_div_cancel_right₀ (a := ‖c N * star (c N)‖)
-                (b := ‖mpvOverlap (d := d) B B N‖) hN)
-      _ = ‖c N‖ ^ 2 := by
-            simp [pow_two]
-  have hc_normsq :
-      Filter.Tendsto (fun N => ‖c N‖ ^ 2) Filter.atTop (nhds (1 : ℝ)) :=
-    Filter.Tendsto.congr' hRatio_eq hRatio
-  have hc_norm :
-      Filter.Tendsto (fun N => ‖c N‖) Filter.atTop (nhds (1 : ℝ)) := by
-    simpa [Real.sqrt_sq (norm_nonneg _)] using hc_normsq.sqrt
-  have hCrossNorm :
-      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A B N‖) Filter.atTop (nhds (1 : ℝ)) := by
-    have hmul : Filter.Tendsto (fun N => ‖c N‖ * ‖mpvOverlap (d := d) B B N‖)
-        Filter.atTop (nhds (1 : ℝ)) := by
-      simpa using hc_norm.mul hB_self_norm
-    exact hmul.congr fun N => by simp [hOverlapAB N]
-  by_contra hNot
-  have hto0 :
-      Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop (nhds 0) :=
-    hZero hNot
-  exact (hCrossNorm.ne_nhds one_ne_zero) (by simpa using hto0.norm)
-
-omit [NeZero D] in
 private theorem gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_decay
     (A B : MPSTensor d D)
     (hA_self :
@@ -271,8 +188,9 @@ theorem gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one
       Filter.Tendsto (fun N => mpvOverlap (d := d) B B N) Filter.atTop (nhds (1 : ℂ)))
     (hProp : ProportionalMPV₂ (d := d) A B) :
     GaugePhaseEquiv A B :=
-  gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one_of_tendsto_zero
-    A B hA_self hB_self hProp
+  gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_decay
+    A B hA_self hB_self
+    (Filter.Eventually.of_forall fun N => hProp N)
     (fun hNot => mpvOverlap_tendsto_zero (A := A) (B := B) hA hB hA_norm hB_norm hNot)
 
 /-- NT / irreducible version of
@@ -291,8 +209,9 @@ theorem gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one_of_irreduci
       Filter.Tendsto (fun N => mpvOverlap (d := d) B B N) Filter.atTop (nhds (1 : ℂ)))
     (hProp : ProportionalMPV₂ (d := d) A B) :
     GaugePhaseEquiv A B :=
-  gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one_of_tendsto_zero
-    A B hA_self hB_self hProp
+  gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_decay
+    A B hA_self hB_self
+    (Filter.Eventually.of_forall fun N => hProp N)
     (fun hNot =>
       mpvOverlap_tendsto_zero_of_irreducible_TP
         (A := A) (B := B) hA_irr hB_irr hA_norm hB_norm hNot)

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -142,6 +142,115 @@ private theorem gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one_of_
     hZero hNot
   exact (hCrossNorm.ne_nhds one_ne_zero) (by simpa using hto0.norm)
 
+omit [NeZero D] in
+private theorem gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_decay
+    (A B : MPSTensor d D)
+    (hA_self :
+      Filter.Tendsto (fun N => mpvOverlap (d := d) A A N) Filter.atTop (nhds (1 : ℂ)))
+    (hB_self :
+      Filter.Tendsto (fun N => mpvOverlap (d := d) B B N) Filter.atTop (nhds (1 : ℂ)))
+    (hProp :
+      ∀ᶠ N in Filter.atTop, ∃ c : ℂ, ∀ σ : Fin N → Fin d,
+        mpv A σ = c * mpv B σ)
+    (hZero : ¬ GaugePhaseEquiv A B →
+      Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop (nhds 0)) :
+    GaugePhaseEquiv A B := by
+  classical
+  let c : ℕ → ℂ := fun N =>
+    if h : ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ then
+      Classical.choose h
+    else 0
+  have hc_event :
+      ∀ᶠ N in Filter.atTop, ∀ σ : Fin N → Fin d, mpv A σ = c N * mpv B σ := by
+    filter_upwards [hProp] with N hN σ
+    have hN' :
+        ∃ c : ℂ, ∀ σ : Fin N → Fin d,
+          Matrix.trace (evalWord A (List.ofFn σ)) =
+            c * Matrix.trace (evalWord B (List.ofFn σ)) := by
+      simpa [mpv, coeff] using hN
+    dsimp [c]
+    rw [dif_pos hN']
+    simpa [mpv, coeff] using Classical.choose_spec hN' σ
+  have hOverlapAB :
+      (fun N => mpvOverlap (d := d) A B N) =ᶠ[Filter.atTop]
+        fun N => c N * mpvOverlap (d := d) B B N := by
+    filter_upwards [hc_event] with N hc
+    unfold mpvOverlap
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro σ _
+    rw [hc σ]
+    ring
+  have hOverlapAA :
+      (fun N => mpvOverlap (d := d) A A N) =ᶠ[Filter.atTop]
+        fun N => (c N * star (c N)) * mpvOverlap (d := d) B B N := by
+    filter_upwards [hc_event] with N hc
+    unfold mpvOverlap
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro σ _
+    rw [hc σ]
+    simp only [star_mul]
+    ring
+  have hA_self_norm :
+      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop
+        (nhds (1 : ℝ)) := by
+    simpa using hA_self.norm
+  have hB_self_norm :
+      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop
+        (nhds (1 : ℝ)) := by
+    simpa using hB_self.norm
+  have hRatio :
+      Filter.Tendsto
+        (fun N => ‖mpvOverlap (d := d) A A N‖ / ‖mpvOverlap (d := d) B B N‖)
+        Filter.atTop (nhds (1 : ℝ)) := by
+    simpa using hA_self_norm.div hB_self_norm one_ne_zero
+  have hB_self_norm_ne :
+      (∀ᶠ N in Filter.atTop, ‖mpvOverlap (d := d) B B N‖ ≠ (0 : ℝ)) :=
+    hB_self_norm.eventually_ne one_ne_zero
+  have hRatio_eq :
+      (fun N => ‖mpvOverlap (d := d) A A N‖ / ‖mpvOverlap (d := d) B B N‖)
+        =ᶠ[Filter.atTop] fun N => ‖c N‖ ^ 2 := by
+    filter_upwards [hOverlapAA, hB_self_norm_ne] with N hAA hN
+    calc
+      ‖mpvOverlap (d := d) A A N‖ / ‖mpvOverlap (d := d) B B N‖
+          = ‖(c N * star (c N)) * mpvOverlap (d := d) B B N‖ /
+              ‖mpvOverlap (d := d) B B N‖ := by
+                simp [hAA]
+      _ = (‖c N * star (c N)‖ * ‖mpvOverlap (d := d) B B N‖) /
+            ‖mpvOverlap (d := d) B B N‖ := by
+                simp
+      _ = ‖c N * star (c N)‖ := by
+            simpa using
+              (mul_div_cancel_right₀ (a := ‖c N * star (c N)‖)
+                (b := ‖mpvOverlap (d := d) B B N‖) hN)
+      _ = ‖c N‖ ^ 2 := by
+            simp [pow_two]
+  have hc_normsq :
+      Filter.Tendsto (fun N => ‖c N‖ ^ 2) Filter.atTop (nhds (1 : ℝ)) :=
+    Filter.Tendsto.congr' hRatio_eq hRatio
+  have hc_norm :
+      Filter.Tendsto (fun N => ‖c N‖) Filter.atTop (nhds (1 : ℝ)) := by
+    simpa [Real.sqrt_sq (norm_nonneg _)] using hc_normsq.sqrt
+  have hCrossNorm :
+      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A B N‖) Filter.atTop
+        (nhds (1 : ℝ)) := by
+    have hmul :
+        Filter.Tendsto (fun N => ‖c N‖ * ‖mpvOverlap (d := d) B B N‖)
+          Filter.atTop (nhds (1 : ℝ)) := by
+      simpa using hc_norm.mul hB_self_norm
+    have hCross_eq :
+        (fun N => ‖mpvOverlap (d := d) A B N‖) =ᶠ[Filter.atTop]
+          fun N => ‖c N‖ * ‖mpvOverlap (d := d) B B N‖ := by
+      filter_upwards [hOverlapAB] with N hAB
+      simp [hAB]
+    exact Filter.Tendsto.congr' hCross_eq.symm hmul
+  by_contra hNot
+  have hto0 :
+      Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop (nhds 0) :=
+    hZero hNot
+  exact (hCrossNorm.ne_nhds one_ne_zero) (by simpa using hto0.norm)
+
 /-- **Proportional Fundamental Theorem (primitive case).**
 
 If `A` and `B` are injective, left-canonical / trace-preserving, both self-overlaps tend to `1`,
@@ -187,6 +296,34 @@ theorem gaugePhaseEquiv_of_proportionalMPV₂_of_overlap_tendsto_one_of_irreduci
     (fun hNot =>
       mpvOverlap_tendsto_zero_of_irreducible_TP
         (A := A) (B := B) hA_irr hB_irr hA_norm hB_norm hNot)
+
+/-- Non-gauge-phase-equivalent irreducible trace-preserving blocks cannot have
+proportional MPV states at all sufficiently large lengths. -/
+theorem exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP
+    (A B : MPSTensor d D)
+    (hA_irr : IsIrreducibleTensor A) (hB_irr : IsIrreducibleTensor B)
+    (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
+    (hA_self :
+      Filter.Tendsto (fun N => mpvOverlap (d := d) A A N) Filter.atTop (nhds (1 : ℂ)))
+    (hB_self :
+      Filter.Tendsto (fun N => mpvOverlap (d := d) B B N) Filter.atTop (nhds (1 : ℂ)))
+    (hNot : ¬ GaugePhaseEquiv A B) (Nmin : ℕ) :
+    ∃ N : ℕ, Nmin ≤ N ∧
+      ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ := by
+  by_contra hNo
+  have hProp :
+      ∀ᶠ N in Filter.atTop, ∃ c : ℂ, ∀ σ : Fin N → Fin d,
+        mpv A σ = c * mpv B σ := by
+    exact Filter.eventually_atTop.2 ⟨Nmin, fun N hN => by
+      by_contra hNprop
+      exact hNo ⟨N, hN, hNprop⟩⟩
+  exact hNot
+    (gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_decay
+      A B hA_self hB_self hProp
+      (fun hNot' =>
+        mpvOverlap_tendsto_zero_of_irreducible_TP
+          (A := A) (B := B) hA_irr hB_irr hA_norm hB_norm hNot'))
 
 end Main
 

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -73,18 +73,19 @@ private theorem gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_deca
       Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop (nhds 0)) :
     GaugePhaseEquiv A B := by
   classical
+  let proportionalAt : ℕ → Prop := fun N =>
+    ∃ c : ℂ, ∀ σ : Fin N → Fin d,
+      Matrix.trace (evalWord A (List.ofFn σ)) =
+        c * Matrix.trace (evalWord B (List.ofFn σ))
   let c : ℕ → ℂ := fun N =>
-    if h : ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ then
+    if h : proportionalAt N then
       Classical.choose h
     else 0
   have hc_event :
       ∀ᶠ N in Filter.atTop, ∀ σ : Fin N → Fin d, mpv A σ = c N * mpv B σ := by
     filter_upwards [hProp] with N hN σ
-    have hN' :
-        ∃ c : ℂ, ∀ σ : Fin N → Fin d,
-          Matrix.trace (evalWord A (List.ofFn σ)) =
-            c * Matrix.trace (evalWord B (List.ofFn σ)) := by
-      simpa [mpv, coeff] using hN
+    have hN' : proportionalAt N := by
+      simpa [proportionalAt, mpv, coeff] using hN
     dsimp [c]
     rw [dif_pos hN']
     simpa [mpv, coeff] using Classical.choose_spec hN' σ

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -33,10 +33,10 @@ The supporting modules are:
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness` — the parent-Hamiltonian
   uniqueness input that rules out the equal-size direct-sum collapse once the
   two injective block states have distinct MPV lines.
-* `TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum` — the BNT-facing direct-sum form that
-  supplies that distinctness input from separated same-dimension blocks and
-  packages the fixed three-block pair separation for all ordered pairs, while
-  keeping the direct-sum injectivity hypotheses explicit.
+* `TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum` — the BNT-facing direct-sum
+  form that supplies that distinctness input from separated same-dimension
+  blocks and gives the fixed three-block pair separation for all ordered pairs,
+  while keeping the direct-sum injectivity hypotheses explicit.
 
 ## References
 

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.Counterexample
+import TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace
 import TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput
 
 /-!
@@ -28,6 +29,8 @@ The supporting modules are:
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput` — the trace-dual algebraic
   input from David--Perez-Garcia--Schuch--Wolf Lemma `lem:direct-sum` that
   follows from the two-sided nonzero span lemma.
+* `TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace` — the corresponding
+  inclusion/equality of finite-chain image spaces.
 
 ## References
 

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.Counterexample
 import TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace
-import TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput
 
 /-!
 # Finite-length sufficient conditions and obstructions for MPDO biCF

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.Counterexample
 import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
-import TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace
-import TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness
 
 /-!
 # Finite-length sufficient conditions and obstructions for MPDO biCF
@@ -35,7 +33,7 @@ The supporting modules are:
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness` — the parent-Hamiltonian
   uniqueness input that rules out the equal-size direct-sum collapse once the
   two injective block states have distinct MPV lines.
-* `TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum` — the BNT-facing wrapper that
+* `TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum` — the BNT-facing direct-sum form that
   supplies that distinctness input from separated same-dimension blocks and
   packages the fixed three-block pair separation for all ordered pairs, while
   keeping the direct-sum injectivity hypotheses explicit.

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -36,7 +36,8 @@ The supporting modules are:
   uniqueness input that rules out the equal-size direct-sum collapse once the
   two injective block states have distinct MPV lines.
 * `TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum` — the BNT-facing wrapper that
-  supplies that distinctness input from separated same-dimension blocks, while
+  supplies that distinctness input from separated same-dimension blocks and
+  packages the fixed three-block pair separation for all ordered pairs, while
   keeping the direct-sum injectivity hypotheses explicit.
 
 ## References

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.Counterexample
+import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
 import TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace
 import TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness
 
@@ -34,6 +35,9 @@ The supporting modules are:
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness` — the parent-Hamiltonian
   uniqueness input that rules out the equal-size direct-sum collapse once the
   two injective block states have distinct MPV lines.
+* `TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum` — the BNT-facing wrapper that
+  supplies that distinctness input from separated same-dimension blocks, while
+  keeping the direct-sum injectivity hypotheses explicit.
 
 ## References
 

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.Counterexample
+import TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput
 
 /-!
 # Finite-length sufficient conditions and obstructions for MPDO biCF
@@ -24,10 +25,14 @@ The supporting modules are:
 * `TNLean.MPS.MPDO.BiCFDerivation.Counterexample` — the duplicate scalar-block
   obstruction showing that blockwise injectivity, left-canonicality, and
   nonzero weights do not imply the biCF property.
+* `TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput` — the trace-dual algebraic
+  input from David--Perez-Garcia--Schuch--Wolf Lemma `lem:direct-sum` that
+  follows from the two-sided nonzero span lemma.
 
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Proposition IV.3]
+* [David--Perez-Garcia--Schuch--Wolf 2006, Lemmas `lem1` and `lem:direct-sum`]
 
 ## Tags
 

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.Counterexample
 import TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace
+import TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness
 
 /-!
 # Finite-length sufficient conditions and obstructions for MPDO biCF
@@ -30,6 +31,9 @@ The supporting modules are:
   follows from the two-sided nonzero span lemma.
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace` — the corresponding
   inclusion/equality of finite-chain image spaces.
+* `TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness` — the parent-Hamiltonian
+  uniqueness input that rules out the equal-size direct-sum collapse once the
+  two injective block states have distinct MPV lines.
 
 ## References
 

--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -88,4 +88,56 @@ theorem pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of
     hAj_blk hAk_blk hAj_blk3 hAk_blk3 hAj_inj hAk_inj le_rfl hL
     ⟨N, hN, hLN, hSep⟩
 
+/-- BNT-separated blocks give a common three-block homogeneous pair trace
+separation length for every ordered pair, once the direct-sum injectivity
+hypotheses are supplied.
+
+The same-dimension branch uses the BNT non-gauge-equivalence witness.  The
+unequal-dimension branch uses the strict-size part of the direct-sum argument.
+No block injectivity is inferred here; the direct-sum hypotheses remain
+explicit. -/
+theorem forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) (L + (L + L)))
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L) :
+    ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) (L + (L + L)) := by
+  intro k j hjk
+  by_cases hdim : dim k = dim j
+  · apply pairTraceSeparatingAt_uncast_left hdim
+    exact pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge
+      A hIrr hLeft hOverlap hBlocks hjk.symm hdim
+      ((isNBlkInjective_cast_dim hdim (A k) L).2 (hBlk k))
+      (hBlk j)
+      ((isNBlkInjective_cast_dim hdim (A k) (L + (L + L))).2 (hBlk3 k))
+      (hBlk3 j)
+      ((isInjective_cast_dim hdim (A k)).2 (hInj k))
+      (hInj j) hL
+  · exact pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_ne
+      (hBlk k) (hBlk j) (hBlk3 k) (hBlk3 j) hdim
+
+/-- Existential common-length form of
+`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv`. -/
+theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) (L + (L + L)))
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L) :
+    ∃ S : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S :=
+  ⟨L + (L + L),
+    forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
+      A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL⟩
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.BNT.Construction
+import TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness
+
+/-!
+# BNT input for the equal-size direct-sum branch
+
+This file connects the same-dimension BNT separation hypothesis to the
+parent-Hamiltonian uniqueness input for David--Perez-Garcia--Schuch--Wolf,
+Lemma `lem:direct-sum`.
+
+The statement deliberately keeps the direct-sum hypotheses explicit:
+`BlocksNotGaugePhaseEquiv` gives the long-chain non-proportional MPV witness,
+while injectivity and length-`L` block injectivity are still separate inputs to
+the parent-Hamiltonian argument.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d L : ℕ}
+
+/-- Same-dimension BNT-separated blocks give the equal-size direct-sum
+directness conclusion once the direct-sum injectivity hypotheses are supplied.
+
+This is the BNT-facing form of the equal-size branch of
+David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`.  The theorem does
+not infer injectivity or transport non-equivalence through blocking; those
+inputs remain explicit. -/
+theorem groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {j k : Fin r} (hjk : j ≠ k) (hdim : dim j = dim k)
+    (hAj_blk : IsNBlkInjective (cast (congr_arg (MPSTensor d) hdim) (A j)) L)
+    (hAk_blk : IsNBlkInjective (A k) L)
+    (hAj_inj : IsInjective (cast (congr_arg (MPSTensor d) hdim) (A j)))
+    (hAk_inj : IsInjective (A k))
+    (hL : 1 < L) :
+    groundSpace (cast (congr_arg (MPSTensor d) hdim) (A j)) (L + (L + L)) ⊓
+        groundSpace (A k) (L + (L + L)) = ⊥ := by
+  obtain ⟨N, hNmin, hSep⟩ :=
+    exists_ge_not_forall_mpv_eq_mul_of_blocksNotGaugePhaseEquiv_of_irreducible_TP
+      A hIrr hLeft hOverlap hBlocks hjk hdim (max 2 L)
+  have hN : 2 ≤ N := le_trans (Nat.le_max_left 2 L) hNmin
+  have hLN : L ≤ N := le_trans (Nat.le_max_right 2 L) hNmin
+  exact groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
+    hAj_blk hAk_blk hAj_inj hAk_inj le_rfl hL ⟨N, hN, hLN, hSep⟩
+
+/-- Same-dimension BNT-separated blocks give homogeneous pair trace separation
+at the three-block length once the direct-sum injectivity hypotheses are
+supplied.
+
+This is the pair-trace form consumed by selector and word-span constructions.
+The theorem still does not infer block injectivity at either length; those
+remain explicit direct-sum inputs. -/
+theorem pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {j k : Fin r} (hjk : j ≠ k) (hdim : dim j = dim k)
+    (hAj_blk : IsNBlkInjective (cast (congr_arg (MPSTensor d) hdim) (A j)) L)
+    (hAk_blk : IsNBlkInjective (A k) L)
+    (hAj_blk3 : IsNBlkInjective
+      (cast (congr_arg (MPSTensor d) hdim) (A j)) (L + (L + L)))
+    (hAk_blk3 : IsNBlkInjective (A k) (L + (L + L)))
+    (hAj_inj : IsInjective (cast (congr_arg (MPSTensor d) hdim) (A j)))
+    (hAk_inj : IsInjective (A k))
+    (hL : 1 < L) :
+    PairTraceSeparatingAt
+      (cast (congr_arg (MPSTensor d) hdim) (A j)) (A k) (L + (L + L)) := by
+  obtain ⟨N, hNmin, hSep⟩ :=
+    exists_ge_not_forall_mpv_eq_mul_of_blocksNotGaugePhaseEquiv_of_irreducible_TP
+      A hIrr hLeft hOverlap hBlocks hjk hdim (max 2 L)
+  have hN : 2 ≤ N := le_trans (Nat.le_max_left 2 L) hNmin
+  have hLN : L ≤ N := le_trans (Nat.le_max_right 2 L) hNmin
+  exact pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge
+    hAj_blk hAk_blk hAj_blk3 hAk_blk3 hAj_inj hAk_inj le_rfl hL
+    ⟨N, hN, hLN, hSep⟩
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -30,7 +30,9 @@ directness conclusion once the direct-sum injectivity hypotheses are supplied.
 This is the BNT-facing form of the equal-size branch of
 David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`.  The theorem does
 not infer injectivity or transport non-equivalence through blocking; those
-inputs remain explicit. -/
+inputs remain explicit. It is exported for the pair-trace theorem below and for
+downstream direct-sum comparisons that need the image-space directness statement
+before applying trace separation. -/
 theorem groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -78,15 +80,11 @@ theorem pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of
     (hAk_inj : IsInjective (A k))
     (hL : 1 < L) :
     PairTraceSeparatingAt
-      (cast (congr_arg (MPSTensor d) hdim) (A j)) (A k) (L + (L + L)) := by
-  obtain ⟨N, hNmin, hSep⟩ :=
-    exists_ge_not_forall_mpv_eq_mul_of_blocksNotGaugePhaseEquiv_of_irreducible_TP
-      A hIrr hLeft hOverlap hBlocks hjk hdim (max 2 L)
-  have hN : 2 ≤ N := le_trans (Nat.le_max_left 2 L) hNmin
-  have hLN : L ≤ N := le_trans (Nat.le_max_right 2 L) hNmin
-  exact pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge
-    hAj_blk hAk_blk hAj_blk3 hAk_blk3 hAj_inj hAk_inj le_rfl hL
-    ⟨N, hN, hLN, hSep⟩
+    (cast (congr_arg (MPSTensor d) hdim) (A j)) (A k) (L + (L + L)) := by
+  exact pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective
+    (groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge
+      A hIrr hLeft hOverlap hBlocks hjk hdim hAj_blk hAk_blk hAj_inj hAk_inj hL)
+    hAj_blk3 hAk_blk3
 
 /-- BNT-separated blocks give a common three-block homogeneous pair trace
 separation length for every ordered pair, once the direct-sum injectivity
@@ -123,7 +121,10 @@ theorem forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
       (hBlk k) (hBlk j) (hBlk3 k) (hBlk3 j) hdim
 
 /-- Existential common-length form of
-`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv`. -/
+`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv`.
+
+This is the API expected by selector and word-span consumers that only need a
+single finite separating length for all ordered block pairs. -/
 theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -203,7 +203,7 @@ theorem pairTraceSeparatingAt_symm {D₁ D₂ : ℕ}
 /-- Remove a propositional bond-dimension cast from the left block in
 homogeneous pair trace separation. -/
 theorem pairTraceSeparatingAt_uncast_left {D₁ D₁' D₂ : ℕ}
-    (h : D₁ = D₁') (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (h : D₁ = D₁') {A : MPSTensor d D₁} {B : MPSTensor d D₂} {S : ℕ}
     (hSep : PairTraceSeparatingAt (cast (congr_arg (MPSTensor d) h) A) B S) :
     PairTraceSeparatingAt A B S := by
   subst h

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -190,6 +190,25 @@ def PairTraceSeparatingAt {D₁ D₂ : ℕ}
           Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) →
       ΔA = 0 ∧ ΔB = 0
 
+/-- Homogeneous pair trace separation is symmetric in the two blocks. -/
+theorem pairTraceSeparatingAt_symm {D₁ D₂ : ℕ}
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} {S : ℕ}
+    (hSep : PairTraceSeparatingAt A B S) :
+    PairTraceSeparatingAt B A S := by
+  intro ΔB ΔA hRel
+  obtain ⟨hA, hB⟩ := hSep ΔA ΔB fun w => by
+    simpa [add_comm] using hRel w
+  exact ⟨hB, hA⟩
+
+/-- Remove a propositional bond-dimension cast from the left block in
+homogeneous pair trace separation. -/
+theorem pairTraceSeparatingAt_uncast_left {D₁ D₁' D₂ : ℕ}
+    (h : D₁ = D₁') (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hSep : PairTraceSeparatingAt (cast (congr_arg (MPSTensor d) h) A) B S) :
+    PairTraceSeparatingAt A B S := by
+  subst h
+  simpa using hSep
+
 /-- The simultaneous word evaluation of two blocks for an arbitrary finite word. -/
 def pairEvalWordTuple {D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput
-import TNLean.MPS.ParentHamiltonian.BlockStrip
+import TNLean.MPS.ParentHamiltonian.GroundSpace
 
 /-!
 # Direct-sum image-space consequences
@@ -28,6 +28,20 @@ namespace MPSTensor
 
 variable {d D₁ D₂ L : ℕ}
 
+/-- The ground-space map and the trace-test map have the same values; the only
+difference is the side on which the boundary matrix is written before applying
+trace cyclicity. -/
+theorem groundSpaceMap_eq_leftTraceWordMap {D : ℕ} (A : MPSTensor d D) (L : ℕ) :
+    groundSpaceMap A L = leftTraceWordMap A L := by
+  ext X t
+  simpa [groundSpaceMap_apply, leftTraceWordMap_apply] using
+    Matrix.trace_mul_comm (evalWord A (List.ofFn t)) X
+
+/-- The finite-chain image space is the range of the trace-test map. -/
+theorem groundSpace_eq_leftTraceWordMap_range {D : ℕ} (A : MPSTensor d D) (L : ℕ) :
+    groundSpace A L = (leftTraceWordMap A L).range := by
+  rw [groundSpace, groundSpaceMap_eq_leftTraceWordMap]
+
 /-- The three-block trace relation gives inclusion of the finite-chain image
 spaces \(\mathcal G_L^A\subseteq \mathcal G_L^B\).
 
@@ -43,22 +57,8 @@ theorem groundSpace_le_of_three_block_trace_relation_left
       Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
         Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) :
     groundSpace A L ≤ groundSpace B L := by
-  rintro ψ ⟨Z, rfl⟩
-  obtain ⟨W, hW⟩ :=
-    exists_right_trace_test_of_three_block_trace_relation_left hA hΔA hRel Z
-  refine ⟨-W, ?_⟩
-  ext t
-  calc
-    groundSpaceMap B L (-W) t =
-        Matrix.trace (evalWord B (List.ofFn t) * (-W)) := by simp
-    _ = Matrix.trace ((-W) * evalWord B (List.ofFn t)) := by
-        rw [Matrix.trace_mul_comm]
-    _ = -Matrix.trace (W * evalWord B (List.ofFn t)) := by simp
-    _ = Matrix.trace (Z * evalWord A (List.ofFn t)) := by
-        simpa using neg_eq_of_add_eq_zero_left (hW t)
-    _ = Matrix.trace (evalWord A (List.ofFn t) * Z) := by
-        rw [Matrix.trace_mul_comm]
-    _ = groundSpaceMap A L Z t := by simp
+  rw [groundSpace_eq_leftTraceWordMap_range A L, groundSpace_eq_leftTraceWordMap_range B L]
+  exact leftTraceWordMap_range_le_of_three_block_trace_relation_left hA hΔA hRel
 
 /-- If both middle test matrices are nonzero, the three-block trace relation
 gives equality of the finite-chain image spaces at length `L`. -/
@@ -72,38 +72,16 @@ theorem groundSpace_eq_of_three_block_trace_relation
       Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
         Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) :
     groundSpace A L = groundSpace B L := by
-  apply le_antisymm
-  · exact groundSpace_le_of_three_block_trace_relation_left hA hΔA hRel
-  · rintro ψ ⟨W, rfl⟩
-    obtain ⟨Z, hZ⟩ :=
-      exists_left_trace_test_of_three_block_trace_relation_right hB hΔB hRel W
-    refine ⟨-Z, ?_⟩
-    ext t
-    calc
-      groundSpaceMap A L (-Z) t =
-          Matrix.trace (evalWord A (List.ofFn t) * (-Z)) := by simp
-      _ = Matrix.trace ((-Z) * evalWord A (List.ofFn t)) := by
-          rw [Matrix.trace_mul_comm]
-      _ = -Matrix.trace (Z * evalWord A (List.ofFn t)) := by simp
-      _ = Matrix.trace (W * evalWord B (List.ofFn t)) := by
-          simpa using neg_eq_of_add_eq_zero_right (hZ t)
-      _ = Matrix.trace (evalWord B (List.ofFn t) * W) := by
-          rw [Matrix.trace_mul_comm]
-      _ = groundSpaceMap B L W t := by simp
+  rw [groundSpace_eq_leftTraceWordMap_range A L, groundSpace_eq_leftTraceWordMap_range B L]
+  exact leftTraceWordMap_range_eq_of_three_block_trace_relation hA hB hΔA hΔB hRel
 
 /-- Under block injectivity, the finite-chain image space has dimension equal to
 the boundary matrix algebra. -/
 theorem groundSpace_finrank_eq_of_isNBlkInjective {A : MPSTensor d D}
     (hA : IsNBlkInjective A L) :
     Module.finrank ℂ (groundSpace A L) = D ^ 2 := by
-  rw [groundSpace, LinearMap.finrank_range_of_inj
-    (groundSpaceMap_injective_of_isNBlkInjective hA)]
-  calc
-    Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ)
-        = (Fintype.card (Fin D) * Fintype.card (Fin D)) * Module.finrank ℂ ℂ := by
-            simpa using (Module.finrank_matrix ℂ ℂ (Fin D) (Fin D))
-    _ = D * D := by simp
-    _ = D ^ 2 := by simp [pow_two]
+  rw [groundSpace_eq_leftTraceWordMap_range]
+  exact leftTraceWordMap_range_finrank_eq_of_isNBlkInjective hA
 
 /-- Equal finite-chain image spaces for two block-injective tensors force equal
 bond dimensions. -/

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput
+import TNLean.MPS.ParentHamiltonian.GroundSpace
+
+/-!
+# Direct-sum image-space consequences
+
+This file packages the algebraic three-block trace transfer as the image-space
+inclusion used in David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`.
+It uses only the finite-chain image-space definitions `groundSpaceMap` and
+`groundSpace`; it does not use the parent-Hamiltonian uniqueness theorem.
+
+## References
+
+* [David--Perez-Garcia--Schuch--Wolf 2006, Lemma `lem:direct-sum`]
+
+## Tags
+
+matrix product states, canonical form, direct sum, block separation
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D₁ D₂ L : ℕ}
+
+/-- The three-block trace relation gives inclusion of the finite-chain image
+spaces \(\mathcal G_L^A\subseteq \mathcal G_L^B\).
+
+This is the formal version of the sentence “This means that
+\(\mathcal G^{A^1}_{L_0+1}\subset \mathcal G^{A^2}_{L_0+1}\)” in the
+two-block part of David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`. -/
+theorem groundSpace_le_of_three_block_trace_relation_left
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {ΔA : Matrix (Fin D₁) (Fin D₁) ℂ}
+    {ΔB : Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hA : IsNBlkInjective A L) (hΔA : ΔA ≠ 0)
+    (hRel : ∀ w : Fin (L + (L + L)) → Fin d,
+      Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+        Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) :
+    groundSpace A L ≤ groundSpace B L := by
+  rintro ψ ⟨Z, rfl⟩
+  obtain ⟨W, hW⟩ :=
+    exists_right_trace_test_of_three_block_trace_relation_left hA hΔA hRel Z
+  refine ⟨-W, ?_⟩
+  ext t
+  calc
+    groundSpaceMap B L (-W) t =
+        Matrix.trace (evalWord B (List.ofFn t) * (-W)) := by simp
+    _ = Matrix.trace ((-W) * evalWord B (List.ofFn t)) := by
+        rw [Matrix.trace_mul_comm]
+    _ = -Matrix.trace (W * evalWord B (List.ofFn t)) := by simp
+    _ = Matrix.trace (Z * evalWord A (List.ofFn t)) := by
+        simpa using neg_eq_of_add_eq_zero_left (hW t)
+    _ = Matrix.trace (evalWord A (List.ofFn t) * Z) := by
+        rw [Matrix.trace_mul_comm]
+    _ = groundSpaceMap A L Z t := by simp
+
+/-- If both middle test matrices are nonzero, the three-block trace relation
+gives equality of the finite-chain image spaces at length `L`. -/
+theorem groundSpace_eq_of_three_block_trace_relation
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {ΔA : Matrix (Fin D₁) (Fin D₁) ℂ}
+    {ΔB : Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hΔA : ΔA ≠ 0) (hΔB : ΔB ≠ 0)
+    (hRel : ∀ w : Fin (L + (L + L)) → Fin d,
+      Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+        Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) :
+    groundSpace A L = groundSpace B L := by
+  apply le_antisymm
+  · exact groundSpace_le_of_three_block_trace_relation_left hA hΔA hRel
+  · rintro ψ ⟨W, rfl⟩
+    obtain ⟨Z, hZ⟩ :=
+      exists_left_trace_test_of_three_block_trace_relation_right hB hΔB hRel W
+    refine ⟨-Z, ?_⟩
+    ext t
+    calc
+      groundSpaceMap A L (-Z) t =
+          Matrix.trace (evalWord A (List.ofFn t) * (-Z)) := by simp
+      _ = Matrix.trace ((-Z) * evalWord A (List.ofFn t)) := by
+          rw [Matrix.trace_mul_comm]
+      _ = -Matrix.trace (Z * evalWord A (List.ofFn t)) := by simp
+      _ = Matrix.trace (W * evalWord B (List.ofFn t)) := by
+          simpa using neg_eq_of_add_eq_zero_right (hZ t)
+      _ = Matrix.trace (evalWord B (List.ofFn t) * W) := by
+          rw [Matrix.trace_mul_comm]
+      _ = groundSpaceMap B L W t := by simp
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
@@ -109,18 +109,9 @@ theorem bondDim_eq_and_groundSpace_eq_of_groundSpace_le_of_isNBlkInjective_of_di
     (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
     (hD : D₂ ≤ D₁) (hLe : groundSpace A L ≤ groundSpace B L) :
     D₁ = D₂ ∧ groundSpace A L = groundSpace B L := by
-  have hfinLe := Submodule.finrank_mono hLe
-  have hfinA := groundSpace_finrank_eq_of_isNBlkInjective (A := A) hA
-  have hfinB := groundSpace_finrank_eq_of_isNBlkInjective (A := B) hB
-  have hsq_le : D₁ ^ 2 ≤ D₂ ^ 2 := by
-    simpa [hfinA, hfinB] using hfinLe
-  have hsq_ge : D₂ ^ 2 ≤ D₁ ^ 2 := Nat.pow_le_pow_left hD 2
-  have hsq : D₁ ^ 2 = D₂ ^ 2 := le_antisymm hsq_le hsq_ge
-  have hD_eq : D₁ = D₂ := Nat.mul_self_inj.mp (by simpa [pow_two] using hsq)
-  have hfinEq :
-      Module.finrank ℂ (groundSpace A L) = Module.finrank ℂ (groundSpace B L) := by
-    simpa [hfinA, hfinB] using hsq
-  exact ⟨hD_eq, Submodule.eq_of_le_of_finrank_eq hLe hfinEq⟩
+  rw [groundSpace_eq_leftTraceWordMap_range A L, groundSpace_eq_leftTraceWordMap_range B L]
+    at hLe ⊢
+  exact leftTraceWordMap_range_eq_of_range_le_of_isNBlkInjective_of_dim_ge hA hB hD hLe
 
 /-- The three-block trace relation plus the paper's size ordering gives equality
 of finite-chain image spaces in the two-block direct-sum argument. -/

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
@@ -8,9 +8,9 @@ import TNLean.MPS.ParentHamiltonian.GroundSpace
 /-!
 # Direct-sum image-space consequences
 
-This file packages the algebraic three-block trace transfer as the image-space
-inclusion used in David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`.
-It uses only the finite-chain image-space definitions `groundSpaceMap` and
+The algebraic three-block trace transfer gives the image-space inclusion used
+in David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`.  The argument
+uses only the finite-chain image-space definitions `groundSpaceMap` and
 `groundSpace`; it does not use the parent-Hamiltonian uniqueness theorem.
 
 ## References
@@ -135,10 +135,9 @@ theorem bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_
 
 If the source-level contradiction input says that the two blocks cannot have
 both equal bond dimension and equal length-`L` image space, then their
-three-block image spaces have zero intersection.  This packages the formal
-part of the two-block direct-sum argument: a nonzero vector in the intersection
-would give a homogeneous three-block trace relation, and the dimension step
-would force the forbidden equality. -/
+three-block image spaces have zero intersection.  A nonzero vector in the
+intersection would give a homogeneous three-block trace relation, and the
+dimension step would force the forbidden equality. -/
 theorem groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
@@ -137,4 +137,48 @@ theorem bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_
   exact bondDim_eq_and_groundSpace_eq_of_groundSpace_le_of_isNBlkInjective_of_dim_ge
     hA hB hD (groundSpace_le_of_three_block_trace_relation_left hA hΔA hRel)
 
+/-- Conditional two-block directness for the three-block image spaces.
+
+If the source-level contradiction input says that the two blocks cannot have
+both equal bond dimension and equal length-`L` image space, then their
+three-block image spaces have zero intersection.  This packages the formal
+part of the two-block direct-sum argument: a nonzero vector in the intersection
+would give a homogeneous three-block trace relation, and the dimension step
+would force the forbidden equality. -/
+theorem groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hD : D₂ ≤ D₁)
+    (hNoCollapse : ¬ (D₁ = D₂ ∧ groundSpace A L = groundSpace B L)) :
+    groundSpace A (L + (L + L)) ⊓ groundSpace B (L + (L + L)) = ⊥ := by
+  rw [eq_bot_iff]
+  intro ψ hψ
+  rcases Submodule.mem_inf.mp hψ with ⟨hψA, hψB⟩
+  rw [groundSpace, LinearMap.mem_range] at hψA hψB
+  rcases hψA with ⟨X, hXψ⟩
+  rcases hψB with ⟨Y, hYψ⟩
+  by_cases hX : X = 0
+  · subst hX
+    simpa using hXψ.symm
+  · exfalso
+    apply hNoCollapse
+    refine bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge
+      (ΔA := X) (ΔB := -Y)
+      hA hB hD hX ?_
+    intro w
+    let Aw := evalWord A (List.ofFn w)
+    let Bw := evalWord B (List.ofFn w)
+    have hcoeff :
+        Matrix.trace (Aw * X) = Matrix.trace (Bw * Y) := by
+      simpa [Aw, Bw, groundSpaceMap_apply] using
+        congrArg (fun f : NSiteSpace d (L + (L + L)) => f w) (hXψ.trans hYψ.symm)
+    calc
+      Matrix.trace (X * evalWord A (List.ofFn w)) +
+          Matrix.trace ((-Y) * evalWord B (List.ofFn w))
+          = Matrix.trace (Aw * X) + -Matrix.trace (Y * Bw) := by
+              simp [Aw, Bw, Matrix.trace_mul_comm X Aw]
+      _ = Matrix.trace (Aw * X) + -Matrix.trace (Bw * Y) := by
+              rw [Matrix.trace_mul_comm Y Bw]
+      _ = 0 := by simp [hcoeff]
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
@@ -172,4 +172,65 @@ theorem groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
               rw [Matrix.trace_mul_comm Y Bw]
       _ = 0 := by simp [hcoeff]
 
+/-- Zero intersection of the two finite-chain image spaces gives homogeneous
+pair trace separation at the same length, provided the two boundary-to-chain
+maps are injective. -/
+theorem pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_injective_groundSpaceMap
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} {S : ℕ}
+    (hInf : groundSpace A S ⊓ groundSpace B S = ⊥)
+    (hAinj : Function.Injective (groundSpaceMap A S))
+    (hBinj : Function.Injective (groundSpaceMap B S)) :
+    PairTraceSeparatingAt A B S := by
+  intro ΔA ΔB hRel
+  have hEq :
+      groundSpaceMap A S ΔA = groundSpaceMap B S (-ΔB) := by
+    ext σ
+    let Aw := evalWord A (List.ofFn σ)
+    let Bw := evalWord B (List.ofFn σ)
+    have hRelσ := hRel σ
+    have hRelσ' :
+        Matrix.trace (ΔA * Aw) + Matrix.trace (ΔB * Bw) = 0 := by
+      simpa [Aw, Bw] using hRelσ
+    calc
+      groundSpaceMap A S ΔA σ = Matrix.trace (Aw * ΔA) := by
+        simp [Aw, groundSpaceMap_apply]
+      _ = Matrix.trace (ΔA * Aw) := Matrix.trace_mul_comm Aw ΔA
+      _ = -Matrix.trace (ΔB * Bw) := eq_neg_of_add_eq_zero_left hRelσ'
+      _ = -Matrix.trace (Bw * ΔB) := by
+        rw [Matrix.trace_mul_comm ΔB Bw]
+      _ = Matrix.trace (Bw * (-ΔB)) := by
+        simp
+      _ = groundSpaceMap B S (-ΔB) σ := by
+        simp [Bw, groundSpaceMap_apply]
+  have hmem :
+      groundSpaceMap A S ΔA ∈ groundSpace A S ⊓ groundSpace B S := by
+    exact Submodule.mem_inf.mpr
+      ⟨⟨ΔA, rfl⟩, by rw [hEq]; exact ⟨-ΔB, rfl⟩⟩
+  have hzero : groundSpaceMap A S ΔA = 0 := by
+    have hbot : groundSpaceMap A S ΔA ∈ (⊥ : Submodule ℂ (NSiteSpace d S)) := by
+      rwa [← hInf]
+    simpa using hbot
+  have hΔA : ΔA = 0 := hAinj (by simpa using hzero)
+  have hBzero : groundSpaceMap B S (-ΔB) = 0 := by
+    rw [← hEq, hzero]
+  have hneg : -ΔB = 0 := hBinj (by simpa using hBzero)
+  exact ⟨hΔA, neg_eq_zero.mp hneg⟩
+
+/-- Block-injectivity at the target length is a convenient way to supply the
+injectivity hypotheses in
+`pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_injective_groundSpaceMap`. -/
+theorem pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} {S : ℕ}
+    (hInf : groundSpace A S ⊓ groundSpace B S = ⊥)
+    (hA : IsNBlkInjective A S) (hB : IsNBlkInjective B S) :
+    PairTraceSeparatingAt A B S :=
+  pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_injective_groundSpaceMap
+    hInf
+    (by
+      rw [groundSpaceMap_eq_leftTraceWordMap]
+      exact leftTraceWordMap_injective_of_isNBlkInjective hA)
+    (by
+      rw [groundSpaceMap_eq_leftTraceWordMap]
+      exact leftTraceWordMap_injective_of_isNBlkInjective hB)
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput
-import TNLean.MPS.ParentHamiltonian.GroundSpace
+import TNLean.MPS.ParentHamiltonian.BlockStrip
 
 /-!
 # Direct-sum image-space consequences
@@ -90,5 +90,73 @@ theorem groundSpace_eq_of_three_block_trace_relation
       _ = Matrix.trace (evalWord B (List.ofFn t) * W) := by
           rw [Matrix.trace_mul_comm]
       _ = groundSpaceMap B L W t := by simp
+
+/-- Under block injectivity, the finite-chain image space has dimension equal to
+the boundary matrix algebra. -/
+theorem groundSpace_finrank_eq_of_isNBlkInjective {A : MPSTensor d D}
+    (hA : IsNBlkInjective A L) :
+    Module.finrank ℂ (groundSpace A L) = D ^ 2 := by
+  rw [groundSpace, LinearMap.finrank_range_of_inj
+    (groundSpaceMap_injective_of_isNBlkInjective hA)]
+  calc
+    Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ)
+        = (Fintype.card (Fin D) * Fintype.card (Fin D)) * Module.finrank ℂ ℂ := by
+            simpa using (Module.finrank_matrix ℂ ℂ (Fin D) (Fin D))
+    _ = D * D := by simp
+    _ = D ^ 2 := by simp [pow_two]
+
+/-- Equal finite-chain image spaces for two block-injective tensors force equal
+bond dimensions. -/
+theorem bondDim_eq_of_groundSpace_eq_of_isNBlkInjective
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hG : groundSpace A L = groundSpace B L) :
+    D₁ = D₂ := by
+  have hfinA := groundSpace_finrank_eq_of_isNBlkInjective (A := A) hA
+  have hfinB := groundSpace_finrank_eq_of_isNBlkInjective (A := B) hB
+  have hsq : D₁ ^ 2 = D₂ ^ 2 := by
+    calc
+      D₁ ^ 2 = Module.finrank ℂ (groundSpace A L) := hfinA.symm
+      _ = Module.finrank ℂ (groundSpace B L) := by rw [hG]
+      _ = D₂ ^ 2 := hfinB
+  exact Nat.mul_self_inj.mp (by simpa [pow_two] using hsq)
+
+/-- The paper's dimension step for the two-block direct-sum argument.
+
+If the finite-chain image space of the larger block is contained in that of the
+smaller block, and both blocks are length-`L` block-injective, then their bond
+dimensions are equal and the image spaces are equal. -/
+theorem bondDim_eq_and_groundSpace_eq_of_groundSpace_le_of_isNBlkInjective_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hD : D₂ ≤ D₁) (hLe : groundSpace A L ≤ groundSpace B L) :
+    D₁ = D₂ ∧ groundSpace A L = groundSpace B L := by
+  have hfinLe := Submodule.finrank_mono hLe
+  have hfinA := groundSpace_finrank_eq_of_isNBlkInjective (A := A) hA
+  have hfinB := groundSpace_finrank_eq_of_isNBlkInjective (A := B) hB
+  have hsq_le : D₁ ^ 2 ≤ D₂ ^ 2 := by
+    simpa [hfinA, hfinB] using hfinLe
+  have hsq_ge : D₂ ^ 2 ≤ D₁ ^ 2 := Nat.pow_le_pow_left hD 2
+  have hsq : D₁ ^ 2 = D₂ ^ 2 := le_antisymm hsq_le hsq_ge
+  have hD_eq : D₁ = D₂ := Nat.mul_self_inj.mp (by simpa [pow_two] using hsq)
+  have hfinEq :
+      Module.finrank ℂ (groundSpace A L) = Module.finrank ℂ (groundSpace B L) := by
+    simpa [hfinA, hfinB] using hsq
+  exact ⟨hD_eq, Submodule.eq_of_le_of_finrank_eq hLe hfinEq⟩
+
+/-- The three-block trace relation plus the paper's size ordering gives equality
+of finite-chain image spaces in the two-block direct-sum argument. -/
+theorem bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {ΔA : Matrix (Fin D₁) (Fin D₁) ℂ}
+    {ΔB : Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hD : D₂ ≤ D₁) (hΔA : ΔA ≠ 0)
+    (hRel : ∀ w : Fin (L + (L + L)) → Fin d,
+      Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+        Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) :
+    D₁ = D₂ ∧ groundSpace A L = groundSpace B L := by
+  exact bondDim_eq_and_groundSpace_eq_of_groundSpace_le_of_isNBlkInjective_of_dim_ge
+    hA hB hD (groundSpace_le_of_three_block_trace_relation_left hA hΔA hRel)
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean
@@ -84,7 +84,10 @@ theorem groundSpace_finrank_eq_of_isNBlkInjective {A : MPSTensor d D}
   exact leftTraceWordMap_range_finrank_eq_of_isNBlkInjective hA
 
 /-- Equal finite-chain image spaces for two block-injective tensors force equal
-bond dimensions. -/
+bond dimensions.
+
+This dimension step is exported separately because the direct-sum argument uses
+it before strengthening an image-space inclusion to equality. -/
 theorem bondDim_eq_of_groundSpace_eq_of_isNBlkInjective
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.TracePairing
+import TNLean.MPS.MPDO.BiCFDerivation.Core
+
+/-!
+# Direct-sum trace input for canonical-form block separation
+
+This file formalizes the first algebraic step in the proof of
+David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`
+(`Papers/quant-ph_0608197/MPSarchive.tex`): from a homogeneous three-block
+trace relation and the two-sided nonzero span lemma, every trace test on one
+block has a matching trace test on the other block at the single-block length.
+
+The remaining source step, not proved here, is the contradiction with equality
+of the finite-chain image spaces using the injective parent-Hamiltonian
+uniqueness theorem.
+
+## References
+
+* [David--Perez-Garcia--Schuch--Wolf 2006, Lemmas `lem1` and `lem:direct-sum`]
+
+## Tags
+
+matrix product states, canonical form, direct sum, block separation
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D₁ D₂ L : ℕ}
+
+/-- **Three-block direct-sum input, left block.**
+
+Assume the word products of `A` of length `L` span the full matrix algebra and
+`ΔA` is nonzero. If a homogeneous trace relation holds on three consecutive
+length-`L` blocks, then every matrix trace test against `A` at length `L` has a
+matching matrix trace test against `B` at the same length.
+
+This is the formal trace-dual version of the first `b = 2` step in
+David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`, after applying
+Lemma `lem1` to the nonzero middle matrix. -/
+theorem exists_right_trace_test_of_three_block_trace_relation_left
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {ΔA : Matrix (Fin D₁) (Fin D₁) ℂ}
+    {ΔB : Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hA : IsNBlkInjective A L) (hΔA : ΔA ≠ 0)
+    (hRel : ∀ w : Fin (L + (L + L)) → Fin d,
+      Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+        Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0)
+    (Z : Matrix (Fin D₁) (Fin D₁) ℂ) :
+    ∃ W : Matrix (Fin D₂) (Fin D₂) ℂ, ∀ t : Fin L → Fin d,
+      Matrix.trace (Z * evalWord A (List.ofFn t)) +
+        Matrix.trace (W * evalWord B (List.ofFn t)) = 0 := by
+  classical
+  let spanA : Submodule ℂ (Matrix (Fin D₁) (Fin D₁) ℂ) :=
+    Submodule.span ℂ
+      (Set.range fun uv : (Fin L → Fin d) × (Fin L → Fin d) =>
+        evalWord A (List.ofFn uv.1) * ΔA * evalWord A (List.ofFn uv.2))
+  have hZ : Z ∈ spanA := by
+    change Z ∈ Submodule.span ℂ
+      (Set.range fun uv : (Fin L → Fin d) × (Fin L → Fin d) =>
+        evalWord A (List.ofFn uv.1) * ΔA * evalWord A (List.ofFn uv.2))
+    rw [span_range_evalWord_mul_nonzero_mul_evalWord_eq_top hA hΔA]
+    exact Submodule.mem_top
+  refine Submodule.span_induction
+    (p := fun Y _ => ∃ W : Matrix (Fin D₂) (Fin D₂) ℂ, ∀ t : Fin L → Fin d,
+      Matrix.trace (Y * evalWord A (List.ofFn t)) +
+        Matrix.trace (W * evalWord B (List.ofFn t)) = 0)
+    ?mem ?zero ?add ?smul hZ
+  · rintro Y ⟨uv, rfl⟩
+    rcases uv with ⟨u, v⟩
+    refine ⟨evalWord B (List.ofFn u) * ΔB * evalWord B (List.ofFn v), ?_⟩
+    intro t
+    let Au := evalWord A (List.ofFn u)
+    let Av := evalWord A (List.ofFn v)
+    let At := evalWord A (List.ofFn t)
+    let Bu := evalWord B (List.ofFn u)
+    let Bv := evalWord B (List.ofFn v)
+    let Bt := evalWord B (List.ofFn t)
+    have hAcycle :
+        Matrix.trace ((Au * ΔA * Av) * At) =
+          Matrix.trace (ΔA * (Av * (At * Au))) := by
+      simpa [Au, Av, At, Matrix.mul_assoc] using
+        (Matrix.trace_mul_comm Au (ΔA * Av * At))
+    have hBcycle :
+        Matrix.trace ((Bu * ΔB * Bv) * Bt) =
+          Matrix.trace (ΔB * (Bv * (Bt * Bu))) := by
+      simpa [Bu, Bv, Bt, Matrix.mul_assoc] using
+        (Matrix.trace_mul_comm Bu (ΔB * Bv * Bt))
+    have hRel' := hRel (Fin.append v (Fin.append t u))
+    rw [hAcycle, hBcycle]
+    simpa [Au, Av, At, Bu, Bv, Bt, List.ofFn_fin_append, evalWord_append,
+      Matrix.mul_assoc] using hRel'
+  · refine ⟨0, ?_⟩
+    intro t
+    simp
+  · intro Y₁ Y₂ _ _ hY₁ hY₂
+    rcases hY₁ with ⟨W₁, hW₁⟩
+    rcases hY₂ with ⟨W₂, hW₂⟩
+    refine ⟨W₁ + W₂, ?_⟩
+    intro t
+    have h1 := hW₁ t
+    have h2 := hW₂ t
+    calc
+      Matrix.trace ((Y₁ + Y₂) * evalWord A (List.ofFn t)) +
+          Matrix.trace ((W₁ + W₂) * evalWord B (List.ofFn t))
+          = (Matrix.trace (Y₁ * evalWord A (List.ofFn t)) +
+              Matrix.trace (W₁ * evalWord B (List.ofFn t))) +
+            (Matrix.trace (Y₂ * evalWord A (List.ofFn t)) +
+              Matrix.trace (W₂ * evalWord B (List.ofFn t))) := by
+              simp [Matrix.add_mul, Matrix.trace_add, add_assoc, add_left_comm]
+      _ = 0 := by simp [h1, h2]
+  · intro a Y _ hY
+    rcases hY with ⟨W, hW⟩
+    refine ⟨a • W, ?_⟩
+    intro t
+    calc
+      Matrix.trace ((a • Y) * evalWord A (List.ofFn t)) +
+          Matrix.trace ((a • W) * evalWord B (List.ofFn t))
+          = a * (Matrix.trace (Y * evalWord A (List.ofFn t)) +
+              Matrix.trace (W * evalWord B (List.ofFn t))) := by
+              simp [Matrix.trace_smul, mul_add]
+      _ = 0 := by simp [hW t]
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Algebra.TracePairing
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.MPDO.BiCFDerivation.Core
 
 /-!

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -311,4 +311,28 @@ lemma not_three_block_trace_relation_left_of_isNBlkInjective_of_dim_gt
       hA hB (Nat.le_of_lt hD) hΔA hRel
   exact (Nat.ne_of_gt hD) hEq
 
+/-- Strictly unequal bond dimensions give homogeneous pair trace separation at
+the three-block length in the dimension-ordered branch.
+
+This is the selector-facing form of the strict-size case of
+David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`.  If a homogeneous
+three-block trace relation annihilates the ordered pair, the larger block's
+test matrix must vanish by the strict-size contradiction.  The remaining test
+matrix then vanishes by block injectivity at the three-block length. -/
+lemma pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_gt
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hB3 : IsNBlkInjective B (L + (L + L))) (hD : D₂ < D₁) :
+    PairTraceSeparatingAt A B (L + (L + L)) := by
+  intro ΔA ΔB hRel
+  have hΔA : ΔA = 0 := by
+    by_contra hΔA_ne
+    exact not_three_block_trace_relation_left_of_isNBlkInjective_of_dim_gt
+      (A := A) (B := B) (ΔA := ΔA) (ΔB := ΔB) hA hB hD hΔA_ne hRel
+  have hΔB : ΔB = 0 := by
+    apply leftTraceWordMap_injective_of_isNBlkInjective hB3
+    ext w
+    simpa [leftTraceWordMap_apply, hΔA] using hRel w
+  exact ⟨hΔA, hΔB⟩
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -245,12 +245,7 @@ theorem leftTraceWordMap_range_finrank_eq_of_isNBlkInjective {A : MPSTensor d D}
     Module.finrank ℂ ((leftTraceWordMap A L).range) = D ^ 2 := by
   rw [LinearMap.finrank_range_of_inj
     (leftTraceWordMap_injective_of_isNBlkInjective hA)]
-  calc
-    Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ)
-        = (Fintype.card (Fin D) * Fintype.card (Fin D)) * Module.finrank ℂ ℂ := by
-            simpa using (Module.finrank_matrix ℂ ℂ (Fin D) (Fin D))
-    _ = D * D := by simp
-    _ = D ^ 2 := by simp [pow_two]
+  exact Matrix.finrank_matrix_fin_eq_sq D
 
 /-- The paper's dimension step for the two-block direct-sum argument.
 

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -83,12 +83,9 @@ theorem exists_right_trace_test_of_three_block_trace_relation_left
         evalWord A (List.ofFn uv.1) * ΔA * evalWord A (List.ofFn uv.2))
     rw [span_range_evalWord_mul_nonzero_mul_evalWord_eq_top hA hΔA]
     exact Submodule.mem_top
-  refine Submodule.span_induction
-    (p := fun Y _ => ∃ W : Matrix (Fin D₂) (Fin D₂) ℂ, ∀ t : Fin L → Fin d,
-      Matrix.trace (Y * evalWord A (List.ofFn t)) +
-        Matrix.trace (W * evalWord B (List.ofFn t)) = 0)
-    ?mem ?zero ?add ?smul hZ
-  · rintro Y ⟨uv, rfl⟩
+  induction hZ using Submodule.span_induction with
+  | mem Y hY =>
+    rcases hY with ⟨uv, rfl⟩
     rcases uv with ⟨u, v⟩
     refine ⟨evalWord B (List.ofFn u) * ΔB * evalWord B (List.ofFn v), ?_⟩
     intro t
@@ -112,10 +109,11 @@ theorem exists_right_trace_test_of_three_block_trace_relation_left
     rw [hAcycle, hBcycle]
     simpa [Au, Av, At, Bu, Bv, Bt, List.ofFn_fin_append, evalWord_append,
       Matrix.mul_assoc] using hRel'
-  · refine ⟨0, ?_⟩
+  | zero =>
+    refine ⟨0, ?_⟩
     intro t
     simp
-  · intro Y₁ Y₂ _ _ hY₁ hY₂
+  | add Y₁ Y₂ _ _ hY₁ hY₂ =>
     rcases hY₁ with ⟨W₁, hW₁⟩
     rcases hY₂ with ⟨W₂, hW₂⟩
     refine ⟨W₁ + W₂, ?_⟩
@@ -131,7 +129,7 @@ theorem exists_right_trace_test_of_three_block_trace_relation_left
               Matrix.trace (W₂ * evalWord B (List.ofFn t))) := by
               simp [Matrix.add_mul, Matrix.trace_add, add_assoc, add_left_comm]
       _ = 0 := by simp [h1, h2]
-  · intro a Y _ hY
+  | smul a Y _ hY =>
     rcases hY with ⟨W, hW⟩
     refine ⟨a • W, ?_⟩
     intro t

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -33,6 +33,23 @@ namespace MPSTensor
 
 variable {d D₁ D₂ L : ℕ}
 
+/-- The length-`L` trace-test map \(Z\mapsto(t\mapsto \operatorname{tr}(ZA_t))\).
+
+This is the trace-dual coordinate form of the finite-chain image space
+\(\mathcal G_L^A\) used in the direct-sum argument. -/
+noncomputable def leftTraceWordMap (A : MPSTensor d D) (L : ℕ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] (Fin L → Fin d) → ℂ :=
+  LinearMap.pi fun t : Fin L → Fin d =>
+    (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
+      (LinearMap.mulRight ℂ (evalWord A (List.ofFn t)))
+
+@[simp]
+lemma leftTraceWordMap_apply (A : MPSTensor d D) (L : ℕ)
+    (Z : Matrix (Fin D) (Fin D) ℂ) (t : Fin L → Fin d) :
+    leftTraceWordMap A L Z t =
+      Matrix.trace (Z * evalWord A (List.ofFn t)) := by
+  simp [leftTraceWordMap, Matrix.traceLinearMap_apply]
+
 /-- **Three-block direct-sum input, left block.**
 
 Assume the word products of `A` of length `L` span the full matrix algebra and
@@ -152,5 +169,56 @@ theorem exists_left_trace_test_of_three_block_trace_relation_right
         simpa [add_comm] using hRel w) W
   exact ⟨Z, fun t => by
     simpa [add_comm] using hZ t⟩
+
+/-- The three-block relation gives inclusion of length-`L` trace-test images.
+
+This is the formal image-space version of the first inclusion step in
+David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`. -/
+theorem leftTraceWordMap_range_le_of_three_block_trace_relation_left
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {ΔA : Matrix (Fin D₁) (Fin D₁) ℂ}
+    {ΔB : Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hA : IsNBlkInjective A L) (hΔA : ΔA ≠ 0)
+    (hRel : ∀ w : Fin (L + (L + L)) → Fin d,
+      Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+        Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) :
+    (leftTraceWordMap A L).range ≤ (leftTraceWordMap B L).range := by
+  rintro f ⟨Z, rfl⟩
+  obtain ⟨W, hW⟩ :=
+    exists_right_trace_test_of_three_block_trace_relation_left hA hΔA hRel Z
+  refine ⟨-W, ?_⟩
+  ext t
+  calc
+    leftTraceWordMap B L (-W) t =
+        -Matrix.trace (W * evalWord B (List.ofFn t)) := by simp
+    _ = Matrix.trace (Z * evalWord A (List.ofFn t)) := by
+        simpa using neg_eq_of_add_eq_zero_left (hW t)
+    _ = leftTraceWordMap A L Z t := by simp
+
+/-- If both middle test matrices are nonzero, the three-block relation gives
+equality of the two length-`L` trace-test images. -/
+theorem leftTraceWordMap_range_eq_of_three_block_trace_relation
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {ΔA : Matrix (Fin D₁) (Fin D₁) ℂ}
+    {ΔB : Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hΔA : ΔA ≠ 0) (hΔB : ΔB ≠ 0)
+    (hRel : ∀ w : Fin (L + (L + L)) → Fin d,
+      Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+        Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) :
+    (leftTraceWordMap A L).range = (leftTraceWordMap B L).range := by
+  apply le_antisymm
+  · exact leftTraceWordMap_range_le_of_three_block_trace_relation_left hA hΔA hRel
+  · rintro f ⟨W, rfl⟩
+    obtain ⟨Z, hZ⟩ :=
+      exists_left_trace_test_of_three_block_trace_relation_right hB hΔB hRel W
+    refine ⟨-Z, ?_⟩
+    ext t
+    calc
+      leftTraceWordMap A L (-Z) t =
+          -Matrix.trace (Z * evalWord A (List.ofFn t)) := by simp
+      _ = Matrix.trace (W * evalWord B (List.ofFn t)) := by
+          simpa using neg_eq_of_add_eq_zero_right (hZ t)
+      _ = leftTraceWordMap B L W t := by simp
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -221,4 +221,78 @@ theorem leftTraceWordMap_range_eq_of_three_block_trace_relation
           simpa using neg_eq_of_add_eq_zero_right (hZ t)
       _ = leftTraceWordMap B L W t := by simp
 
+/-- Block injectivity makes the length-`L` trace-test map injective. -/
+theorem leftTraceWordMap_injective_of_isNBlkInjective {A : MPSTensor d D}
+    (hA : IsNBlkInjective A L) :
+    Function.Injective (leftTraceWordMap A L) := by
+  classical
+  apply LinearMap.ker_eq_bot.mp
+  apply (LinearMap.ker_eq_bot').2
+  intro Z hZ
+  have hφ :
+      (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulLeft ℂ Z) = 0 := by
+    apply LinearMap.ext_on_range
+      (v := fun t : Fin L → Fin d => evalWord A (List.ofFn t))
+    · simpa [IsNBlkInjective] using hA
+    · intro t
+      simpa [leftTraceWordMap_apply, Matrix.traceLinearMap_apply] using
+        congrArg (fun f => f t) hZ
+  exact trace_mul_right_eq_zero fun N => by
+    simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
+
+/-- Under block injectivity, the trace-test image has the full boundary-matrix
+dimension. -/
+theorem leftTraceWordMap_range_finrank_eq_of_isNBlkInjective {A : MPSTensor d D}
+    (hA : IsNBlkInjective A L) :
+    Module.finrank ℂ ((leftTraceWordMap A L).range) = D ^ 2 := by
+  rw [LinearMap.finrank_range_of_inj
+    (leftTraceWordMap_injective_of_isNBlkInjective hA)]
+  calc
+    Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ)
+        = (Fintype.card (Fin D) * Fintype.card (Fin D)) * Module.finrank ℂ ℂ := by
+            simpa using (Module.finrank_matrix ℂ ℂ (Fin D) (Fin D))
+    _ = D * D := by simp
+    _ = D ^ 2 := by simp [pow_two]
+
+/-- The paper's dimension step for the two-block direct-sum argument.
+
+If the length-`L` trace-test image of the larger block is contained in that of
+the smaller block, and both blocks are length-`L` block-injective, then their
+bond dimensions are equal and the trace-test images are equal. -/
+theorem leftTraceWordMap_range_eq_of_range_le_of_isNBlkInjective_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hD : D₂ ≤ D₁)
+    (hLe : (leftTraceWordMap A L).range ≤ (leftTraceWordMap B L).range) :
+    D₁ = D₂ ∧ (leftTraceWordMap A L).range = (leftTraceWordMap B L).range := by
+  have hfinLe := Submodule.finrank_mono hLe
+  have hfinA := leftTraceWordMap_range_finrank_eq_of_isNBlkInjective (A := A) hA
+  have hfinB := leftTraceWordMap_range_finrank_eq_of_isNBlkInjective (A := B) hB
+  have hsq_le : D₁ ^ 2 ≤ D₂ ^ 2 := by
+    simpa [hfinA, hfinB] using hfinLe
+  have hsq_ge : D₂ ^ 2 ≤ D₁ ^ 2 := Nat.pow_le_pow_left hD 2
+  have hsq : D₁ ^ 2 = D₂ ^ 2 := le_antisymm hsq_le hsq_ge
+  have hD_eq : D₁ = D₂ := by
+    exact Nat.mul_self_inj.mp (by simpa [pow_two] using hsq)
+  have hfinEq :
+      Module.finrank ℂ ((leftTraceWordMap A L).range) =
+        Module.finrank ℂ ((leftTraceWordMap B L).range) := by
+    simpa [hfinA, hfinB] using hsq
+  exact ⟨hD_eq, Submodule.eq_of_le_of_finrank_eq hLe hfinEq⟩
+
+/-- The three-block relation plus the paper's size ordering gives equality of
+the trace-test images in the two-block direct-sum argument. -/
+theorem leftTraceWordMap_range_eq_of_three_block_trace_relation_left_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {ΔA : Matrix (Fin D₁) (Fin D₁) ℂ}
+    {ΔB : Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hD : D₂ ≤ D₁) (hΔA : ΔA ≠ 0)
+    (hRel : ∀ w : Fin (L + (L + L)) → Fin d,
+      Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+        Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0) :
+    D₁ = D₂ ∧ (leftTraceWordMap A L).range = (leftTraceWordMap B L).range := by
+  exact leftTraceWordMap_range_eq_of_range_le_of_isNBlkInjective_of_dim_ge
+    hA hB hD (leftTraceWordMap_range_le_of_three_block_trace_relation_left hA hΔA hRel)
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -293,4 +293,26 @@ theorem leftTraceWordMap_range_eq_of_three_block_trace_relation_left_of_dim_ge
   exact leftTraceWordMap_range_eq_of_range_le_of_isNBlkInjective_of_dim_ge
     hA hB hD (leftTraceWordMap_range_le_of_three_block_trace_relation_left hA hΔA hRel)
 
+/-- Strictly unequal bond dimensions rule out the three-block relation in the
+dimension-ordered branch of the two-block direct-sum argument.
+
+This is the strict-size case in David--Perez-Garcia--Schuch--Wolf,
+Lemma `lem:direct-sum`: once the length-`L` trace-test image of the larger block
+is included in the smaller one, the dimension step would force equal bond
+dimensions. -/
+lemma not_three_block_trace_relation_left_of_isNBlkInjective_of_dim_gt
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {ΔA : Matrix (Fin D₁) (Fin D₁) ℂ}
+    {ΔB : Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hD : D₂ < D₁) (hΔA : ΔA ≠ 0) :
+    ¬ ∀ w : Fin (L + (L + L)) → Fin d,
+      Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+        Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0 := by
+  intro hRel
+  obtain ⟨hEq, _⟩ :=
+    leftTraceWordMap_range_eq_of_three_block_trace_relation_left_of_dim_ge
+      hA hB (Nat.le_of_lt hD) hΔA hRel
+  exact (Nat.ne_of_gt hD) hEq
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -126,4 +126,31 @@ theorem exists_right_trace_test_of_three_block_trace_relation_left
               simp [Matrix.trace_smul, mul_add]
       _ = 0 := by simp [hW t]
 
+/-- **Three-block direct-sum input, right block.**
+
+This is the symmetric form of
+`exists_right_trace_test_of_three_block_trace_relation_left`: a nonzero test
+matrix on `B` lets every trace test against `B` be matched by a trace test
+against `A`. -/
+theorem exists_left_trace_test_of_three_block_trace_relation_right
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    {ΔA : Matrix (Fin D₁) (Fin D₁) ℂ}
+    {ΔB : Matrix (Fin D₂) (Fin D₂) ℂ}
+    (hB : IsNBlkInjective B L) (hΔB : ΔB ≠ 0)
+    (hRel : ∀ w : Fin (L + (L + L)) → Fin d,
+      Matrix.trace (ΔA * evalWord A (List.ofFn w)) +
+        Matrix.trace (ΔB * evalWord B (List.ofFn w)) = 0)
+    (W : Matrix (Fin D₂) (Fin D₂) ℂ) :
+    ∃ Z : Matrix (Fin D₁) (Fin D₁) ℂ, ∀ t : Fin L → Fin d,
+      Matrix.trace (Z * evalWord A (List.ofFn t)) +
+        Matrix.trace (W * evalWord B (List.ofFn t)) = 0 := by
+  classical
+  obtain ⟨Z, hZ⟩ :=
+    exists_right_trace_test_of_three_block_trace_relation_left
+      (A := B) (B := A) (ΔA := ΔB) (ΔB := ΔA) hB hΔB
+      (fun w => by
+        simpa [add_comm] using hRel w) W
+  exact ⟨Z, fun t => by
+    simpa [add_comm] using hZ t⟩
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -9,11 +9,11 @@ import TNLean.MPS.MPDO.BiCFDerivation.Core
 /-!
 # Direct-sum trace input for canonical-form block separation
 
-This file formalizes the first algebraic step in the proof of
-David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`
-(`Papers/quant-ph_0608197/MPSarchive.tex`): from a homogeneous three-block
-trace relation and the two-sided nonzero span lemma, every trace test on one
-block has a matching trace test on the other block at the single-block length.
+The first algebraic step in David--Perez-Garcia--Schuch--Wolf,
+Lemma `lem:direct-sum` (`Papers/quant-ph_0608197/MPSarchive.tex`) turns a
+homogeneous three-block trace relation and the two-sided nonzero span lemma
+into a transfer statement for trace tests: every trace test on one block has a
+matching trace test on the other block at the single-block length.
 
 The remaining source step, not proved here, is the contradiction with equality
 of the finite-chain image spaces using the injective parent-Hamiltonian

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -335,4 +335,20 @@ lemma pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_gt
     simpa [leftTraceWordMap_apply, hΔA] using hRel w
   exact ⟨hΔA, hΔB⟩
 
+/-- Unequal bond dimensions give homogeneous pair trace separation at the
+three-block length once both blocks are injective at the source length and the
+target three-block length. -/
+lemma pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_ne
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hA3 : IsNBlkInjective A (L + (L + L)))
+    (hB3 : IsNBlkInjective B (L + (L + L))) (hD : D₁ ≠ D₂) :
+    PairTraceSeparatingAt A B (L + (L + L)) := by
+  rcases lt_or_gt_of_ne hD with hlt | hgt
+  · exact pairTraceSeparatingAt_symm
+      (pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_gt
+        (A := B) (B := A) hB hA hA3 hlt)
+  · exact pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_gt
+      (A := A) (B := B) hA hB hB3 hgt
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace
+import TNLean.MPS.ParentHamiltonian.UniqueGroundState
+
+/-!
+# Direct-sum uniqueness input
+
+This file records the equal-size branch of the two-block direct-sum argument
+from David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`.
+
+The preceding direct-sum files prove the trace-dual and finite-dimensional
+steps: a homogeneous three-block relation forces equality of bond dimensions
+and equality of the length-`L` local image spaces.  The remaining equal-size
+contradiction in the source uses the uniqueness of injective parent ground
+spaces: if the local image spaces are equal, then the periodic ground-state
+line is the same.  Therefore distinct injective block states rule out the
+equal-size collapse.
+
+## References
+
+* [David--Perez-Garcia--Schuch--Wolf 2006, Lemma `lem:direct-sum`]
+
+## Tags
+
+matrix product states, canonical form, direct sum, parent Hamiltonian
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D₁ D₂ L N : ℕ}
+
+/-- Equal local image spaces impose the same periodic-chain constraints. -/
+theorem chainGroundSpace_eq_of_groundSpace_eq
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hG : groundSpace A L = groundSpace B L) :
+    chainGroundSpace A L N = chainGroundSpace B L N := by
+  rw [chainGroundSpace, chainGroundSpace]
+  by_cases h : 0 < N ∧ L ≤ N
+  · simp [h, hG]
+  · simp [h]
+
+/-- Distinct periodic MPV lines rule out the equal-size local-image collapse.
+
+This is the parent-Hamiltonian uniqueness input used in the equal-size branch
+of the two-block direct-sum proof.  It is intentionally stated with the
+external distinctness hypothesis on the MPV lines: later BNT-level arguments
+must supply that hypothesis from the paper's pairwise-different block states. -/
+theorem not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    (hA : IsInjective A) (hB : IsInjective B)
+    (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N)
+    (hDistinct : mpvSubmodule A N ≠ mpvSubmodule B N) :
+    ¬ (D₁ = D₂ ∧ groundSpace A L = groundSpace B L) := by
+  rintro ⟨hD, hG⟩
+  subst hD
+  have hChain : chainGroundSpace A L N = chainGroundSpace B L N :=
+    chainGroundSpace_eq_of_groundSpace_eq hG
+  have hAeq : chainGroundSpace A L N = mpvSubmodule A N :=
+    chainGroundSpace_eq_mpvSubmodule hA hN hL hLN
+  have hBeq : chainGroundSpace B L N = mpvSubmodule B N :=
+    chainGroundSpace_eq_mpvSubmodule hB hN hL hLN
+  apply hDistinct
+  calc
+    mpvSubmodule A N = chainGroundSpace A L N := hAeq.symm
+    _ = chainGroundSpace B L N := hChain
+    _ = mpvSubmodule B N := hBeq
+
+/-- Two-block directness with the equal-size branch discharged by distinct MPV
+lines.
+
+The hypotheses mirror the already-formalized finite-dimensional step together
+with the source-paper uniqueness input: block injectivity controls the
+three-block trace relation, while injective parent-Hamiltonian uniqueness and a
+distinct MPV-line hypothesis exclude the equal-size collapse. -/
+theorem groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    (hAblk : IsNBlkInjective A L) (hBblk : IsNBlkInjective B L)
+    (hA : IsInjective A) (hB : IsInjective B)
+    (hD : D₂ ≤ D₁) (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N)
+    (hDistinct : mpvSubmodule A N ≠ mpvSubmodule B N) :
+    groundSpace A (L + (L + L)) ⊓ groundSpace B (L + (L + L)) = ⊥ := by
+  exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
+    hAblk hBblk hD
+    (not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne hA hB hN hL hLN hDistinct)
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -206,4 +206,25 @@ theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
     (not_bondDim_eq_and_groundSpace_eq_of_exists_not_forall_mpv_eq_mul
       hA hB hL hDistinct)
 
+/-- Homogeneous pair trace separation at the three-block length from a
+sufficiently long pointwise non-proportional MPV state.
+
+The length-`L` block-injectivity hypotheses are the direct-sum dimension-step
+input.  The additional block-injectivity hypotheses at `L + (L + L)` are only
+used to identify zero image vectors with zero boundary matrices. -/
+theorem pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    (hAblk : IsNBlkInjective A L) (hBblk : IsNBlkInjective B L)
+    (hAblk3 : IsNBlkInjective A (L + (L + L)))
+    (hBblk3 : IsNBlkInjective B (L + (L + L)))
+    (hA : IsInjective A) (hB : IsInjective B) (hD : D₂ ≤ D₁) (hL : 1 < L)
+    (hDistinct :
+      ∃ N : ℕ, 2 ≤ N ∧ L ≤ N ∧
+        ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
+    PairTraceSeparatingAt A B (L + (L + L)) := by
+  exact pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective
+    (groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
+      hAblk hBblk hA hB hD hL hDistinct)
+    hAblk3 hBblk3
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -59,6 +59,28 @@ theorem mpvSubmodule_ne_of_not_exists_mpv_eq_smul
   obtain ⟨c, hc⟩ := hmem
   exact ⟨c, hc.symm⟩
 
+/-- Pointwise non-proportionality implies non-proportionality of the bundled
+MPV states. -/
+theorem not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hDistinct :
+      ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
+    ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N) := by
+  rintro ⟨c, hc⟩
+  apply hDistinct
+  refine ⟨c, ?_⟩
+  intro σ
+  simpa [Pi.smul_apply, smul_eq_mul] using congrFun hc σ
+
+/-- A pointwise non-proportional MPV state has a distinct MPV line. -/
+theorem mpvSubmodule_ne_of_not_exists_forall_mpv_eq_mul
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hDistinct :
+      ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
+    mpvSubmodule A N ≠ mpvSubmodule B N :=
+  mpvSubmodule_ne_of_not_exists_mpv_eq_smul
+    (not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul hDistinct)
+
 /-- Distinct periodic MPV lines rule out the equal-size local-image collapse.
 
 This is the parent-Hamiltonian uniqueness input used in the equal-size branch
@@ -110,6 +132,20 @@ theorem not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul
   exact not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul
     hA hB hN hL hLN hSep
 
+/-- A sufficiently long pointwise non-proportional MPV state rules out the
+equal-size local-image collapse. -/
+theorem not_bondDim_eq_and_groundSpace_eq_of_exists_not_forall_mpv_eq_mul
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    (hA : IsInjective A) (hB : IsInjective B) (hL : 1 < L)
+    (hDistinct :
+      ∃ N : ℕ, 2 ≤ N ∧ L ≤ N ∧
+        ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
+    ¬ (D₁ = D₂ ∧ groundSpace A L = groundSpace B L) := by
+  rcases hDistinct with ⟨N, hN, hLN, hSep⟩
+  exact not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul
+    hA hB hN hL hLN
+    (not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul hSep)
+
 /-- Two-block directness with the equal-size branch discharged by distinct MPV
 lines.
 
@@ -154,5 +190,20 @@ theorem groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge
   exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
     hAblk hBblk hD
     (not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul hA hB hL hDistinct)
+
+/-- Two-block directness from a sufficiently long pointwise non-proportional
+MPV state. -/
+theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    (hAblk : IsNBlkInjective A L) (hBblk : IsNBlkInjective B L)
+    (hA : IsInjective A) (hB : IsInjective B) (hD : D₂ ≤ D₁) (hL : 1 < L)
+    (hDistinct :
+      ∃ N : ℕ, 2 ≤ N ∧ L ≤ N ∧
+        ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
+    groundSpace A (L + (L + L)) ⊓ groundSpace B (L + (L + L)) = ⊥ := by
+  exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
+    hAblk hBblk hD
+    (not_bondDim_eq_and_groundSpace_eq_of_exists_not_forall_mpv_eq_mul
+      hA hB hL hDistinct)
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -44,6 +44,21 @@ theorem chainGroundSpace_eq_of_groundSpace_eq
   · simp [h, hG]
   · simp [h]
 
+/-- Non-proportional MPV states have distinct MPV lines. -/
+theorem mpvSubmodule_ne_of_not_exists_mpv_eq_smul
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hDistinct :
+      ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N)) :
+    mpvSubmodule A N ≠ mpvSubmodule B N := by
+  intro hEq
+  apply hDistinct
+  have hmem : (mpv A : NSiteSpace d N) ∈ mpvSubmodule B N := by
+    rw [← hEq, mpvSubmodule, Submodule.mem_span_singleton]
+    exact ⟨1, by simp⟩
+  rw [mpvSubmodule, Submodule.mem_span_singleton] at hmem
+  obtain ⟨c, hc⟩ := hmem
+  exact ⟨c, hc.symm⟩
+
 /-- Distinct periodic MPV lines rule out the equal-size local-image collapse.
 
 This is the parent-Hamiltonian uniqueness input used in the equal-size branch
@@ -70,6 +85,18 @@ theorem not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne
     _ = chainGroundSpace B L N := hChain
     _ = mpvSubmodule B N := hBeq
 
+/-- Non-proportional periodic MPV states rule out the equal-size local-image
+collapse. -/
+theorem not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    (hA : IsInjective A) (hB : IsInjective B)
+    (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N)
+    (hDistinct :
+      ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N)) :
+    ¬ (D₁ = D₂ ∧ groundSpace A L = groundSpace B L) := by
+  exact not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne hA hB hN hL hLN
+    (mpvSubmodule_ne_of_not_exists_mpv_eq_smul hDistinct)
+
 /-- Two-block directness with the equal-size branch discharged by distinct MPV
 lines.
 
@@ -87,5 +114,19 @@ theorem groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge
   exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
     hAblk hBblk hD
     (not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne hA hB hN hL hLN hDistinct)
+
+/-- Two-block directness with the equal-size branch discharged by
+non-proportional MPV states. -/
+theorem groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    (hAblk : IsNBlkInjective A L) (hBblk : IsNBlkInjective B L)
+    (hA : IsInjective A) (hB : IsInjective B)
+    (hD : D₂ ≤ D₁) (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N)
+    (hDistinct :
+      ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N)) :
+    groundSpace A (L + (L + L)) ⊓ groundSpace B (L + (L + L)) = ⊥ := by
+  exact groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge
+    hAblk hBblk hA hB hD hN hL hLN
+    (mpvSubmodule_ne_of_not_exists_mpv_eq_smul hDistinct)
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -97,6 +97,19 @@ theorem not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul
   exact not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne hA hB hN hL hLN
     (mpvSubmodule_ne_of_not_exists_mpv_eq_smul hDistinct)
 
+/-- A sufficiently long non-proportional MPV state rules out the equal-size
+local-image collapse. -/
+theorem not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    (hA : IsInjective A) (hB : IsInjective B) (hL : 1 < L)
+    (hDistinct :
+      ∃ N : ℕ, 2 ≤ N ∧ L ≤ N ∧
+        ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N)) :
+    ¬ (D₁ = D₂ ∧ groundSpace A L = groundSpace B L) := by
+  rcases hDistinct with ⟨N, hN, hLN, hSep⟩
+  exact not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul
+    hA hB hN hL hLN hSep
+
 /-- Two-block directness with the equal-size branch discharged by distinct MPV
 lines.
 
@@ -128,5 +141,18 @@ theorem groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge
   exact groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge
     hAblk hBblk hA hB hD hN hL hLN
     (mpvSubmodule_ne_of_not_exists_mpv_eq_smul hDistinct)
+
+/-- Two-block directness from a sufficiently long non-proportional MPV state. -/
+theorem groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    (hAblk : IsNBlkInjective A L) (hBblk : IsNBlkInjective B L)
+    (hA : IsInjective A) (hB : IsInjective B) (hD : D₂ ≤ D₁) (hL : 1 < L)
+    (hDistinct :
+      ∃ N : ℕ, 2 ≤ N ∧ L ≤ N ∧
+        ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N)) :
+    groundSpace A (L + (L + L)) ⊓ groundSpace B (L + (L + L)) = ⊥ := by
+  exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
+    hAblk hBblk hD
+    (not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul hA hB hL hDistinct)
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -72,15 +72,6 @@ theorem not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul
   intro σ
   simpa [Pi.smul_apply, smul_eq_mul] using congrFun hc σ
 
-/-- A pointwise non-proportional MPV state has a distinct MPV line. -/
-theorem mpvSubmodule_ne_of_not_exists_forall_mpv_eq_mul
-    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
-    (hDistinct :
-      ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
-    mpvSubmodule A N ≠ mpvSubmodule B N :=
-  mpvSubmodule_ne_of_not_exists_mpv_eq_smul
-    (not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul hDistinct)
-
 /-- Distinct periodic MPV lines rule out the equal-size local-image collapse.
 
 This is the parent-Hamiltonian uniqueness input used in the equal-size branch
@@ -107,90 +98,6 @@ theorem not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne
     _ = chainGroundSpace B L N := hChain
     _ = mpvSubmodule B N := hBeq
 
-/-- Non-proportional periodic MPV states rule out the equal-size local-image
-collapse. -/
-theorem not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul
-    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
-    (hA : IsInjective A) (hB : IsInjective B)
-    (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N)
-    (hDistinct :
-      ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N)) :
-    ¬ (D₁ = D₂ ∧ groundSpace A L = groundSpace B L) := by
-  exact not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne hA hB hN hL hLN
-    (mpvSubmodule_ne_of_not_exists_mpv_eq_smul hDistinct)
-
-/-- A sufficiently long non-proportional MPV state rules out the equal-size
-local-image collapse. -/
-theorem not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul
-    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
-    (hA : IsInjective A) (hB : IsInjective B) (hL : 1 < L)
-    (hDistinct :
-      ∃ N : ℕ, 2 ≤ N ∧ L ≤ N ∧
-        ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N)) :
-    ¬ (D₁ = D₂ ∧ groundSpace A L = groundSpace B L) := by
-  rcases hDistinct with ⟨N, hN, hLN, hSep⟩
-  exact not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul
-    hA hB hN hL hLN hSep
-
-/-- A sufficiently long pointwise non-proportional MPV state rules out the
-equal-size local-image collapse. -/
-theorem not_bondDim_eq_and_groundSpace_eq_of_exists_not_forall_mpv_eq_mul
-    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
-    (hA : IsInjective A) (hB : IsInjective B) (hL : 1 < L)
-    (hDistinct :
-      ∃ N : ℕ, 2 ≤ N ∧ L ≤ N ∧
-        ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
-    ¬ (D₁ = D₂ ∧ groundSpace A L = groundSpace B L) := by
-  rcases hDistinct with ⟨N, hN, hLN, hSep⟩
-  exact not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul
-    hA hB hN hL hLN
-    (not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul hSep)
-
-/-- Two-block directness with the equal-size branch discharged by distinct MPV
-lines.
-
-The hypotheses mirror the already-formalized finite-dimensional step together
-with the source-paper uniqueness input: block injectivity controls the
-three-block trace relation, while injective parent-Hamiltonian uniqueness and a
-distinct MPV-line hypothesis exclude the equal-size collapse. -/
-theorem groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge
-    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
-    (hAblk : IsNBlkInjective A L) (hBblk : IsNBlkInjective B L)
-    (hA : IsInjective A) (hB : IsInjective B)
-    (hD : D₂ ≤ D₁) (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N)
-    (hDistinct : mpvSubmodule A N ≠ mpvSubmodule B N) :
-    groundSpace A (L + (L + L)) ⊓ groundSpace B (L + (L + L)) = ⊥ := by
-  exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
-    hAblk hBblk hD
-    (not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne hA hB hN hL hLN hDistinct)
-
-/-- Two-block directness with the equal-size branch discharged by
-non-proportional MPV states. -/
-theorem groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge
-    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
-    (hAblk : IsNBlkInjective A L) (hBblk : IsNBlkInjective B L)
-    (hA : IsInjective A) (hB : IsInjective B)
-    (hD : D₂ ≤ D₁) (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N)
-    (hDistinct :
-      ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N)) :
-    groundSpace A (L + (L + L)) ⊓ groundSpace B (L + (L + L)) = ⊥ := by
-  exact groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge
-    hAblk hBblk hA hB hD hN hL hLN
-    (mpvSubmodule_ne_of_not_exists_mpv_eq_smul hDistinct)
-
-/-- Two-block directness from a sufficiently long non-proportional MPV state. -/
-theorem groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge
-    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
-    (hAblk : IsNBlkInjective A L) (hBblk : IsNBlkInjective B L)
-    (hA : IsInjective A) (hB : IsInjective B) (hD : D₂ ≤ D₁) (hL : 1 < L)
-    (hDistinct :
-      ∃ N : ℕ, 2 ≤ N ∧ L ≤ N ∧
-        ¬ ∃ c : ℂ, (mpv A : NSiteSpace d N) = c • (mpv B : NSiteSpace d N)) :
-    groundSpace A (L + (L + L)) ⊓ groundSpace B (L + (L + L)) = ⊥ := by
-  exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
-    hAblk hBblk hD
-    (not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul hA hB hL hDistinct)
-
 /-- Two-block directness from a sufficiently long pointwise non-proportional
 MPV state. -/
 theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
@@ -201,10 +108,12 @@ theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
       ∃ N : ℕ, 2 ≤ N ∧ L ≤ N ∧
         ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
     groundSpace A (L + (L + L)) ⊓ groundSpace B (L + (L + L)) = ⊥ := by
+  rcases hDistinct with ⟨N, hN, hLN, hSep⟩
   exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
     hAblk hBblk hD
-    (not_bondDim_eq_and_groundSpace_eq_of_exists_not_forall_mpv_eq_mul
-      hA hB hL hDistinct)
+    (not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne hA hB hN hL hLN
+      (mpvSubmodule_ne_of_not_exists_mpv_eq_smul
+        (not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul hSep)))
 
 /-- Homogeneous pair trace separation at the three-block length from a
 sufficiently long pointwise non-proportional MPV state.

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -8,8 +8,10 @@ import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 /-!
 # Direct-sum uniqueness input
 
-This file records the equal-size branch of the two-block direct-sum argument
-from David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`.
+The equal-size branch of the two-block direct-sum argument from
+David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`, uses uniqueness of
+injective parent ground states to rule out equality of local image spaces for
+distinct injective block states.
 
 The preceding direct-sum files prove the trace-dual and finite-dimensional
 steps: a homogeneous three-block relation forces equality of bond dimensions

--- a/TNLean/MPS/Overlap/CastLemmas.lean
+++ b/TNLean/MPS/Overlap/CastLemmas.lean
@@ -41,6 +41,14 @@ lemma isInjective_cast_dim {d D₁ D₂ : ℕ} (h : D₁ = D₂) (A : MPSTensor 
     IsInjective (cast (congr_arg (MPSTensor d) h) A) ↔ IsInjective A := by
   subst h; simp
 
+/-- Casting the bond dimension preserves fixed-length block injectivity. -/
+lemma isNBlkInjective_cast_dim {d D₁ D₂ : ℕ} (h : D₁ = D₂)
+    (A : MPSTensor d D₁) (N : ℕ) :
+    IsNBlkInjective (cast (congr_arg (MPSTensor d) h) A) N ↔
+      IsNBlkInjective A N := by
+  subst h
+  simp
+
 /-- Casting the bond dimension preserves irreducibility. -/
 lemma isIrreducibleTensor_cast_dim {d D₁ D₂ : ℕ} (h : D₁ = D₂) (A : MPSTensor d D₁) :
     IsIrreducibleTensor (cast (congr_arg (MPSTensor d) h) A) ↔ IsIrreducibleTensor A := by

--- a/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
@@ -1,3 +1,4 @@
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.Defs
 import TNLean.MPS.Overlap.Basic
 
@@ -45,13 +46,8 @@ lemma groundSpace_finrank_le (A : MPSTensor d D) (L : ℕ) :
   have hRange : Module.finrank ℂ (groundSpace A L) ≤
       Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) := by
     simpa [groundSpace] using LinearMap.finrank_range_le (groundSpaceMap A L)
-  have hMatrix : Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) = D ^ 2 := by
-    calc
-      Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ)
-          = (Fintype.card (Fin D) * Fintype.card (Fin D)) * Module.finrank ℂ ℂ := by
-              simpa using (Module.finrank_matrix ℂ ℂ (Fin D) (Fin D))
-      _ = D * D := by simp
-      _ = D ^ 2 := by simp [pow_two]
+  have hMatrix : Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) = D ^ 2 :=
+    Matrix.finrank_matrix_fin_eq_sq D
   exact hRange.trans (by simp [hMatrix])
 
 /-- The ambient local space has dimension `d^L`. -/

--- a/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan
+import TNLean.Algebra.MatrixAux
 import TNLean.Wielandt.Primitivity.PaperDefinitions
 import TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
 import TNLean.Wielandt.RectangularSpan.Universality
@@ -65,11 +66,7 @@ theorem wordSpan_finrank_le (A : MPSTensor d D) (n : ℕ) :
   calc Module.finrank ℂ (wordSpan A n)
       ≤ Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) :=
         Submodule.finrank_le _
-    _ = Fintype.card (Fin D) * Fintype.card (Fin D) *
-        Module.finrank ℂ ℂ := Module.finrank_matrix ℂ ℂ _ _
-    _ = D * D * 1 := by
-          simp only [Fintype.card_fin, Module.finrank_self, mul_one]
-    _ = D ^ 2 := by ring
+    _ = D ^ 2 := Matrix.finrank_matrix_fin_eq_sq D
 
 
 /-! ## One-step span elements as redundant generators -/
@@ -323,18 +320,6 @@ theorem wordSpan_eq_top_of_ge_of_isUnit (A : MPSTensor d D)
 
 /-! ## Right-multiplication stabilization and strict growth -/
 
-private theorem finrank_top_matrix :
-    Module.finrank ℂ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) = D ^ 2 := by
-  calc
-    Module.finrank ℂ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
-        = Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) := by
-          simp
-    _ = Fintype.card (Fin D) * Fintype.card (Fin D) *
-        Module.finrank ℂ ℂ := Module.finrank_matrix ℂ ℂ _ _
-    _ = D * D * 1 := by
-          simp only [Fintype.card_fin, Module.finrank_self, mul_one]
-    _ = D ^ 2 := by ring
-
 private theorem finrank_eq_finrank_map_mulRight_of_isUnit
     (S : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
     {b : Matrix (Fin D) (Fin D) ℂ} (hU : IsUnit b) :
@@ -516,7 +501,7 @@ theorem wordSpan_finrank_strict_mono_of_isUnit_of_isNormal
     wordSpan_eq_top_of_ge_of_isUnit A i₀ hU hNtop (le_max_right n N)
   have hfull : Module.finrank ℂ (wordSpan A (max n N)) = D ^ 2 := by
     rw [htopMax]
-    exact finrank_top_matrix (D := D)
+    exact Matrix.finrank_top_matrix_fin_eq_sq D
   have hconst' : Module.finrank ℂ (wordSpan A (max n N)) =
       Module.finrank ℂ (wordSpan A n) := by
     rw [hk]
@@ -533,7 +518,7 @@ private theorem wordSpan_eq_top_of_finrank_eq_sq
     _ = Module.finrank ℂ
           (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) := by
           symm
-          exact finrank_top_matrix (D := D)
+          exact Matrix.finrank_top_matrix_fin_eq_sq D
 
 private theorem wordSpan_finrank_lt_of_ne_top
     (A : MPSTensor d D) (n : ℕ) (hneq : wordSpan A n ≠ ⊤) :

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -98,6 +98,42 @@ The results follow~\cite{Sanz2010Quantum}.
     length~$L$ equals $\MN{D}$.
 \end{proof}
 
+\begin{lemma}[Two-sided span from one nonzero matrix]
+    \label{lem:two_sided_nonzero_matrix_span}
+    \lean{Matrix.span_range_mul_nonzero_mul_eq_top}
+    \leanok
+    If \(C\in M_D(\mathbb C)\) is nonzero, then
+    \[
+        \operatorname{span}\{RCS:R,S\in M_D(\mathbb C)\}=M_D(\mathbb C).
+    \]
+    This is the matrix-factorization input used in
+    \cite[Lemma~\texttt{lem1}]{PerezGarcia2007Matrix}.
+\end{lemma}
+
+\begin{proof}\leanok
+    Choose a nonzero entry \(C_{pq}\).  Then every matrix unit \(E_{ij}\)
+    is a scalar multiple of \(E_{ip}CE_{qj}\), so the displayed span
+    contains the standard matrix basis.
+\end{proof}
+
+\begin{lemma}[Exact words around a nonzero middle matrix]
+    \label{lem:block_injective_two_sided_word_span}
+    \lean{MPSTensor.span_range_evalWord_mul_nonzero_mul_evalWord_eq_top}
+    \leanok
+    \uses{def:l_blk_injective, lem:two_sided_nonzero_matrix_span}
+    If \(A\) is \(L\)-block injective and \(X\neq 0\), then
+    \[
+        \operatorname{span}\{A_uXA_v: |u|=|v|=L\}=M_D(\mathbb C).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok\uses{lem:two_sided_nonzero_matrix_span}
+    By \(L\)-block injectivity, the length-\(L\) word products span
+    \(M_D(\mathbb C)\).  Bilinearity of \((R,S)\mapsto RXS\) reduces the
+    preceding lemma to products with \(R\) and \(S\) chosen among those
+    word products.
+\end{proof}
+
 \section{Fitting decomposition}
 
 \begin{definition}[Fitting decomposition]\label{def:fitting_decomp}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -426,7 +426,7 @@ The main references are
 	replaced by the corresponding irreducible trace-preserving decay theorems.
 \end{proof}
 
-\begin{theorem}[Non-equivalent primitive blocks are eventually non-proportional]
+\begin{theorem}[Non-equivalent irreducible TP blocks are eventually non-proportional]
 	\label{thm:not_gauge_phase_eventually_not_proportional}
 	\lean{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP}
 	\lean{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_blocksNotGaugePhaseEquiv_of_irreducible_TP}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -426,6 +426,23 @@ The main references are
 	replaced by the corresponding irreducible trace-preserving decay theorems.
 \end{proof}
 
+\begin{theorem}[Non-equivalent primitive blocks are eventually non-proportional]
+	\label{thm:not_gauge_phase_eventually_not_proportional}
+	\lean{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP}
+	\leanok
+	\uses{def:gauge_phase_equiv, def:mpv_overlap, def:irreducible_tensor}
+	Let \(A\) and \(B\) be irreducible trace-preserving blocks whose
+	self-overlaps converge to \(1\).  If they are not gauge-phase equivalent,
+	then for every lower bound \(N_0\) there is \(N\ge N_0\) such that
+	\(V^{(N)}(A)\) is not proportional to \(V^{(N)}(B)\).
+\end{theorem}
+
+\begin{proof}\leanok
+	If the two MPV states were proportional for all sufficiently large \(N\),
+	the same overlap argument used in Theorem~\ref{thm:bnt_perm_prop_nt}
+	would force gauge-phase equivalence.  This contradicts the hypothesis.
+\end{proof}
+
 \begin{theorem}[Canonical-form proportional decomposition theorem]
 	\label{thm:cf_bnt_ft_proportional}
 	\lean{MPSTensor.fundamentalTheorem_of_IsCanonicalFormBNT}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -429,12 +429,16 @@ The main references are
 \begin{theorem}[Non-equivalent primitive blocks are eventually non-proportional]
 	\label{thm:not_gauge_phase_eventually_not_proportional}
 	\lean{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP}
+	\lean{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_blocksNotGaugePhaseEquiv_of_irreducible_TP}
 	\leanok
 	\uses{def:gauge_phase_equiv, def:mpv_overlap, def:irreducible_tensor}
 	Let \(A\) and \(B\) be irreducible trace-preserving blocks whose
 	self-overlaps converge to \(1\).  If they are not gauge-phase equivalent,
 	then for every lower bound \(N_0\) there is \(N\ge N_0\) such that
-	\(V^{(N)}(A)\) is not proportional to \(V^{(N)}(B)\).
+	\(V^{(N)}(A)\) is not proportional to \(V^{(N)}(B)\).  Consequently,
+	in an already separated same-dimensional BNT block family, any two
+	distinct blocks have such non-proportional MPV states at arbitrarily
+	large lengths.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3140,6 +3140,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_groundSpace_le_of_isNBlkInjective_of_dim_ge}
     \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}
+    \lean{MPSTensor.pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_gt}
     \lean{MPSTensor.chainGroundSpace_eq_of_groundSpace_eq}
     \lean{MPSTensor.mpvSubmodule_ne_of_not_exists_mpv_eq_smul}
     \lean{MPSTensor.not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul}
@@ -3168,6 +3169,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     simultaneous conclusion \(D_A=D_B\) and
     \(\mathcal G_L^A=\mathcal G_L^B\), then the three-block image spaces
     \(\mathcal G_{3L}^A\) and \(\mathcal G_{3L}^B\) have zero intersection.
+    With injectivity at the three-block length, the strict-size branch itself
+    already gives homogeneous pair trace separation at length \(3L\).
     One such source input is non-proportionality of the periodic MPV states
     at a sufficiently long chain length, equivalently distinctness of the
     corresponding periodic MPV lines: equality of the local image spaces gives

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3094,6 +3094,38 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     gives the required \(W\), and linearity gives the general case.
 \end{proof}
 
+\begin{lemma}[Finite-chain image inclusion from a three-block relation]
+    \label{lem:three_block_relation_ground_space_inclusion}
+    \lean{MPSTensor.leftTraceWordMap}
+    \lean{MPSTensor.leftTraceWordMap_range_le_of_three_block_trace_relation_left}
+    \lean{MPSTensor.leftTraceWordMap_range_eq_of_three_block_trace_relation}
+    \lean{MPSTensor.groundSpace_le_of_three_block_trace_relation_left}
+    \lean{MPSTensor.groundSpace_eq_of_three_block_trace_relation}
+    \leanok
+    \uses{lem:three_block_trace_reduction_nonzero_middle}
+    Under the hypotheses of
+    Lemma~\ref{lem:three_block_trace_reduction_nonzero_middle}, the length-\(L\)
+    image spaces satisfy
+    \[
+        \mathcal G_L^A \subseteq \mathcal G_L^B .
+    \]
+    If the corresponding nonzero middle matrix exists on both sides, then
+    \(\mathcal G_L^A=\mathcal G_L^B\).
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:three_block_trace_reduction_nonzero_middle}
+    Write a vector in \(\mathcal G_L^A\) as
+    \(t\mapsto \tr(A_tZ)\).  The preceding lemma supplies \(W\) with
+    \(\tr(ZA_t)+\tr(WB_t)=0\) for every word \(t\).  Cyclicity of the
+    trace gives
+    \[
+        \tr(A_tZ)=\tr(ZA_t)=-\tr(WB_t)=\tr(B_t(-W)),
+    \]
+    so the vector lies in \(\mathcal G_L^B\).  The equality statement follows
+    by applying the same argument with the two blocks exchanged.
+\end{proof}
+
 \begin{lemma}[All-length pair trace separation has finite cumulative length]
     \label{lem:all_length_pair_trace_separation_finite_cutoff}
     \lean{MPSTensor.pairEvalWordTuple_mem_pairCumulativeSpan}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3156,6 +3156,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
+    \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
+    \lean{MPSTensor.exists_wordTupleSpanTop_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3158,6 +3158,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.exists_pos_productWordSpan_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_wordTupleSpanTop_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
+    \lean{MPSTensor.hasBiCF_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
+    \lean{MPSTensor.hasBiCF_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3140,8 +3140,12 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_groundSpace_le_of_isNBlkInjective_of_dim_ge}
     \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}
+    \lean{MPSTensor.chainGroundSpace_eq_of_groundSpace_eq}
+    \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne}
+    \lean{MPSTensor.groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge}
     \leanok
-    \uses{lem:three_block_relation_ground_space_inclusion}
+    \uses{lem:three_block_relation_ground_space_inclusion,
+        thm:chain_ground_space_eq_mpv_blk}
     If \(A\) and \(B\) are length-\(L\) block-injective, the map
     \(Z\mapsto(t\mapsto\tr(A_tZ))\) has image dimension \(D_A^2\), and
     similarly for \(B\).  Therefore an inclusion
@@ -3157,6 +3161,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     simultaneous conclusion \(D_A=D_B\) and
     \(\mathcal G_L^A=\mathcal G_L^B\), then the three-block image spaces
     \(\mathcal G_{3L}^A\) and \(\mathcal G_{3L}^B\) have zero intersection.
+    One such source input is distinctness of the periodic MPV lines: equality
+    of the local image spaces gives equality of the periodic-chain constraint
+    spaces, and injective uniqueness identifies those spaces with the two MPV
+    lines.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -3171,7 +3179,11 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     has two boundary representations.  If the first boundary matrix is zero,
     the vector is zero.  Otherwise the difference of the two coefficient
     formulas is exactly the homogeneous three-block trace relation, so the
-    dimension step gives the forbidden collapse.
+    dimension step gives the forbidden collapse.  In the equal-size branch,
+    equal local image spaces impose the same cyclic local constraints on a
+    periodic chain.  The injective uniqueness theorem then identifies both
+    cyclic ground spaces with the spans of their MPV states, contradicting
+    distinctness of those spans.
 \end{proof}
 
 \begin{lemma}[All-length pair trace separation has finite cumulative length]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3058,6 +3058,41 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     $S$, and the all-length variant allows every finite word.
 \end{definition}
 
+\begin{lemma}[Three-block trace reduction from a nonzero middle matrix]
+    \label{lem:three_block_trace_reduction_nonzero_middle}
+    \lean{MPSTensor.exists_right_trace_test_of_three_block_trace_relation_left}
+    \leanok
+    \uses{def:l_blk_injective, def:pair_trace_separation_words,
+        lem:block_injective_two_sided_word_span}
+    Let \(A\) be \(L\)-block injective, and let \(\Delta_A\neq 0\).
+    Suppose that, for all words \(u,v,t\) of length \(L\),
+    \[
+        \tr\!\bigl(\Delta_A A_v A_t A_u\bigr)
+        + \tr\!\bigl(\Delta_B B_v B_t B_u\bigr)=0 .
+    \]
+    Then for every \(Z\in M_{D_A}(\mathbb C)\) there is a matrix
+    \(W\in M_{D_B}(\mathbb C)\) such that, for all words \(t\) of
+    length \(L\),
+    \[
+        \tr(ZA_t)+\tr(WB_t)=0 .
+    \]
+    This is the trace-dual algebraic step in the two-block case of the
+    direct-sum lemma of \cite{PerezGarcia2007Matrix}.
+\end{lemma}
+
+\begin{proof}\leanok\uses{lem:block_injective_two_sided_word_span}
+    Since \(\Delta_A\neq0\), Lemma~\ref{lem:block_injective_two_sided_word_span}
+    writes \(Z\) as a linear combination of matrices \(A_u\Delta_A A_v\).
+    For one such term, cyclicity of the trace rewrites the three-block relation
+    as
+    \[
+        \tr(A_u\Delta_A A_vA_t)
+        +\tr(B_u\Delta_B B_vB_t)=0 .
+    \]
+    Taking the same linear combination of the matrices \(B_u\Delta_BB_v\)
+    gives the required \(W\), and linearity gives the general case.
+\end{proof}
+
 \begin{lemma}[All-length pair trace separation has finite cumulative length]
     \label{lem:all_length_pair_trace_separation_finite_cutoff}
     \lean{MPSTensor.pairEvalWordTuple_mem_pairCumulativeSpan}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3097,6 +3097,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{lemma}[Finite-chain image inclusion from a three-block relation]
     \label{lem:three_block_relation_ground_space_inclusion}
     \lean{MPSTensor.leftTraceWordMap}
+    \lean{MPSTensor.groundSpaceMap_eq_leftTraceWordMap}
+    \lean{MPSTensor.groundSpace_eq_leftTraceWordMap_range}
     \lean{MPSTensor.leftTraceWordMap_range_le_of_three_block_trace_relation_left}
     \lean{MPSTensor.leftTraceWordMap_range_eq_of_three_block_trace_relation}
     \lean{MPSTensor.groundSpace_le_of_three_block_trace_relation_left}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3142,12 +3142,16 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}
     \lean{MPSTensor.chainGroundSpace_eq_of_groundSpace_eq}
     \lean{MPSTensor.mpvSubmodule_ne_of_not_exists_mpv_eq_smul}
+    \lean{MPSTensor.not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul}
+    \lean{MPSTensor.mpvSubmodule_ne_of_not_exists_forall_mpv_eq_mul}
     \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne}
     \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul}
     \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul}
+    \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_exists_not_forall_mpv_eq_mul}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge}
+    \lean{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3155,6 +3155,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}
@@ -3191,7 +3192,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     product-word span required by the selector construction.  Since
     canonical-form/BNT blocks are one-site injective, one may take \(L=2\);
     injectivity at lengths \(2\) and \(6\) then follows by passing from a
-    fixed injective length to positive multiples.
+    fixed injective length to positive multiples.  The same conclusion applies
+    to normal-CF-BNT data once one-site injectivity is supplied explicitly,
+    since the normal-CF-BNT predicate carries the irreducibility and
+    normalization hypotheses used in the direct-sum comparison.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3141,8 +3141,11 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}
     \lean{MPSTensor.chainGroundSpace_eq_of_groundSpace_eq}
+    \lean{MPSTensor.mpvSubmodule_ne_of_not_exists_mpv_eq_smul}
     \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne}
+    \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge}
+    \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}
@@ -3161,10 +3164,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     simultaneous conclusion \(D_A=D_B\) and
     \(\mathcal G_L^A=\mathcal G_L^B\), then the three-block image spaces
     \(\mathcal G_{3L}^A\) and \(\mathcal G_{3L}^B\) have zero intersection.
-    One such source input is distinctness of the periodic MPV lines: equality
-    of the local image spaces gives equality of the periodic-chain constraint
-    spaces, and injective uniqueness identifies those spaces with the two MPV
-    lines.
+    One such source input is non-proportionality of the periodic MPV states,
+    equivalently distinctness of the periodic MPV lines: equality of the local
+    image spaces gives equality of the periodic-chain constraint spaces, and
+    injective uniqueness identifies those spaces with the two MPV lines.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -3183,7 +3186,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     equal local image spaces impose the same cyclic local constraints on a
     periodic chain.  The injective uniqueness theorem then identifies both
     cyclic ground spaces with the spans of their MPV states, contradicting
-    distinctness of those spans.
+    non-proportionality of those states.
 \end{proof}
 
 \begin{lemma}[All-length pair trace separation has finite cumulative length]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3152,6 +3152,11 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge}
+    \lean{MPSTensor.pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_injective_groundSpaceMap}
+    \lean{MPSTensor.pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective}
+    \lean{MPSTensor.pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge}
+    \lean{MPSTensor.groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}
+    \lean{MPSTensor.pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}
@@ -3174,7 +3179,13 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     at a sufficiently long chain length, equivalently distinctness of the
     corresponding periodic MPV lines: equality of the local image spaces gives
     equality of the periodic-chain constraint spaces, and injective uniqueness
-    identifies those spaces with the two MPV lines.
+    identifies those spaces with the two MPV lines.  For same-dimensional
+    separated BNT blocks, the non-equivalence condition supplies such
+    non-proportional MPV states at arbitrarily large chain lengths; the
+    direct-sum injectivity hypotheses remain explicit.  Zero intersection of
+    the two three-block image spaces also gives homogeneous pair trace
+    separation at that length once the boundary-to-chain maps at the
+    three-block length are injective.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3134,10 +3134,12 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.leftTraceWordMap_range_finrank_eq_of_isNBlkInjective}
     \lean{MPSTensor.leftTraceWordMap_range_eq_of_range_le_of_isNBlkInjective_of_dim_ge}
     \lean{MPSTensor.leftTraceWordMap_range_eq_of_three_block_trace_relation_left_of_dim_ge}
+    \lean{MPSTensor.not_three_block_trace_relation_left_of_isNBlkInjective_of_dim_gt}
     \lean{MPSTensor.groundSpace_finrank_eq_of_isNBlkInjective}
     \lean{MPSTensor.bondDim_eq_of_groundSpace_eq_of_isNBlkInjective}
     \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_groundSpace_le_of_isNBlkInjective_of_dim_ge}
     \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge}
+    \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion}
     If \(A\) and \(B\) are length-\(L\) block-injective, the map
@@ -3148,7 +3150,13 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \(\mathcal G_L^A=\mathcal G_L^B\).  In particular, the three-block
     trace relation from
     Lemma~\ref{lem:three_block_relation_ground_space_inclusion} gives this
-    equality whenever the source-paper size ordering is available.
+    equality whenever the source-paper size ordering is available.  If the
+    inclusion comes from the strictly larger block, \(D_B<D_A\), then the same
+    dimension step already contradicts the existence of the three-block trace
+    relation.  More generally, if an external source input rules out the
+    simultaneous conclusion \(D_A=D_B\) and
+    \(\mathcal G_L^A=\mathcal G_L^B\), then the three-block image spaces
+    \(\mathcal G_{3L}^A\) and \(\mathcal G_{3L}^B\) have zero intersection.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -3157,7 +3165,13 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \(\dim\mathcal G_L^A=D_A^2\) and \(\dim\mathcal G_L^B=D_B^2\).
     Inclusion gives \(D_A^2\le D_B^2\), while \(D_B\le D_A\) gives the
     reverse inequality.  Hence \(D_A=D_B\), and equality of dimensions inside
-    the inclusion gives equality of the image spaces.
+    the inclusion gives equality of the image spaces.  In the strict-size
+    branch this contradicts \(D_B<D_A\).  For the conditional directness
+    statement, a vector in the intersection of the two three-block image spaces
+    has two boundary representations.  If the first boundary matrix is zero,
+    the vector is zero.  Otherwise the difference of the two coefficient
+    formulas is exactly the homogeneous three-block trace relation, so the
+    dimension step gives the forbidden collapse.
 \end{proof}
 
 \begin{lemma}[All-length pair trace separation has finite cumulative length]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3154,6 +3154,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}
@@ -3187,7 +3188,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     three-block length are injective.  Combining the equal-dimension and
     unequal-dimension branches over all ordered block pairs gives one common
     three-block trace-separation length, and hence the positive-length
-    product-word span required by the selector construction.
+    product-word span required by the selector construction.  Since
+    canonical-form/BNT blocks are one-site injective, one may take \(L=2\);
+    injectivity at lengths \(2\) and \(6\) then follows by passing from a
+    fixed injective length to positive multiples.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3061,6 +3061,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{lemma}[Three-block trace reduction from a nonzero middle matrix]
     \label{lem:three_block_trace_reduction_nonzero_middle}
     \lean{MPSTensor.exists_right_trace_test_of_three_block_trace_relation_left}
+    \lean{MPSTensor.exists_left_trace_test_of_three_block_trace_relation_right}
     \leanok
     \uses{def:l_blk_injective, def:pair_trace_separation_words,
         lem:block_injective_two_sided_word_span}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3141,6 +3141,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}
     \lean{MPSTensor.pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_gt}
+    \lean{MPSTensor.pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_ne}
     \lean{MPSTensor.chainGroundSpace_eq_of_groundSpace_eq}
     \lean{MPSTensor.mpvSubmodule_ne_of_not_exists_mpv_eq_smul}
     \lean{MPSTensor.not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul}
@@ -3151,6 +3152,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}
     \lean{MPSTensor.pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}
+    \lean{MPSTensor.forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}
+    \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}
@@ -3181,7 +3185,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     direct-sum injectivity hypotheses remain explicit.  Zero intersection of
     the two three-block image spaces also gives homogeneous pair trace
     separation at that length once the boundary-to-chain maps at the
-    three-block length are injective.
+    three-block length are injective.  Combining the equal-dimension and
+    unequal-dimension branches over all ordered block pairs gives one common
+    three-block trace-separation length, and hence the positive-length
+    product-word span required by the selector construction.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3063,8 +3063,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.exists_right_trace_test_of_three_block_trace_relation_left}
     \lean{MPSTensor.exists_left_trace_test_of_three_block_trace_relation_right}
     \leanok
-    \uses{def:l_blk_injective, def:pair_trace_separation_words,
-        lem:block_injective_two_sided_word_span}
+    \uses{def:l_blk_injective, lem:block_injective_two_sided_word_span}
     Let \(A\) be \(L\)-block injective, and let \(\Delta_A\neq 0\).
     Suppose that, for all words \(u,v,t\) of length \(L\),
     \[

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3126,6 +3126,38 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     by applying the same argument with the two blocks exchanged.
 \end{proof}
 
+\begin{lemma}[Dimension step for two-block direct-sum image spaces]
+    \label{lem:direct_sum_two_block_dimension_step}
+    \lean{MPSTensor.leftTraceWordMap_injective_of_isNBlkInjective}
+    \lean{MPSTensor.leftTraceWordMap_range_finrank_eq_of_isNBlkInjective}
+    \lean{MPSTensor.leftTraceWordMap_range_eq_of_range_le_of_isNBlkInjective_of_dim_ge}
+    \lean{MPSTensor.leftTraceWordMap_range_eq_of_three_block_trace_relation_left_of_dim_ge}
+    \lean{MPSTensor.groundSpace_finrank_eq_of_isNBlkInjective}
+    \lean{MPSTensor.bondDim_eq_of_groundSpace_eq_of_isNBlkInjective}
+    \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_groundSpace_le_of_isNBlkInjective_of_dim_ge}
+    \lean{MPSTensor.bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge}
+    \leanok
+    \uses{lem:three_block_relation_ground_space_inclusion}
+    If \(A\) and \(B\) are length-\(L\) block-injective, the map
+    \(Z\mapsto(t\mapsto\tr(A_tZ))\) has image dimension \(D_A^2\), and
+    similarly for \(B\).  Therefore an inclusion
+    \(\mathcal G_L^A\subseteq \mathcal G_L^B\), together with
+    \(D_B\le D_A\), forces \(D_A=D_B\) and
+    \(\mathcal G_L^A=\mathcal G_L^B\).  In particular, the three-block
+    trace relation from
+    Lemma~\ref{lem:three_block_relation_ground_space_inclusion} gives this
+    equality whenever the source-paper size ordering is available.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:three_block_relation_ground_space_inclusion}
+    Block injectivity makes the boundary-to-chain map injective, so
+    \(\dim\mathcal G_L^A=D_A^2\) and \(\dim\mathcal G_L^B=D_B^2\).
+    Inclusion gives \(D_A^2\le D_B^2\), while \(D_B\le D_A\) gives the
+    reverse inequality.  Hence \(D_A=D_B\), and equality of dimensions inside
+    the inclusion gives equality of the image spaces.
+\end{proof}
+
 \begin{lemma}[All-length pair trace separation has finite cumulative length]
     \label{lem:all_length_pair_trace_separation_finite_cutoff}
     \lean{MPSTensor.pairEvalWordTuple_mem_pairCumulativeSpan}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3143,14 +3143,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.chainGroundSpace_eq_of_groundSpace_eq}
     \lean{MPSTensor.mpvSubmodule_ne_of_not_exists_mpv_eq_smul}
     \lean{MPSTensor.not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul}
-    \lean{MPSTensor.mpvSubmodule_ne_of_not_exists_forall_mpv_eq_mul}
     \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne}
-    \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul}
-    \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul}
-    \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_exists_not_forall_mpv_eq_mul}
-    \lean{MPSTensor.groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge}
-    \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge}
-    \lean{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge}
     \lean{MPSTensor.pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_injective_groundSpaceMap}
     \lean{MPSTensor.pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3144,8 +3144,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.mpvSubmodule_ne_of_not_exists_mpv_eq_smul}
     \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne}
     \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul}
+    \lean{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge}
     \lean{MPSTensor.groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge}
+    \lean{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}
@@ -3164,10 +3166,11 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     simultaneous conclusion \(D_A=D_B\) and
     \(\mathcal G_L^A=\mathcal G_L^B\), then the three-block image spaces
     \(\mathcal G_{3L}^A\) and \(\mathcal G_{3L}^B\) have zero intersection.
-    One such source input is non-proportionality of the periodic MPV states,
-    equivalently distinctness of the periodic MPV lines: equality of the local
-    image spaces gives equality of the periodic-chain constraint spaces, and
-    injective uniqueness identifies those spaces with the two MPV lines.
+    One such source input is non-proportionality of the periodic MPV states
+    at a sufficiently long chain length, equivalently distinctness of the
+    corresponding periodic MPV lines: equality of the local image spaces gives
+    equality of the periodic-chain constraint spaces, and injective uniqueness
+    identifies those spaces with the two MPV lines.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -129,6 +129,13 @@ and
 \leanid{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge}
 are the corresponding existential forms, where the caller supplies some chain
 length \(N\ge \max\{2,L\}\) at which the two MPV states are not proportional.
+\leanid{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP}
+proves the analytic source of such witnesses for irreducible trace-preserving
+blocks with normalized self-overlaps: if two blocks are not gauge-phase
+equivalent, then arbitrarily far out there is a chain length at which their MPV
+states are not proportional.  The direct-sum file records the pointwise
+conversion by
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge}.
 This is still not the full BNT source theorem: the remaining BNT-level task is
 to derive the required non-proportionality of MPV states from the paper's
 pairwise different canonical blocks, after the prescribed blocking.

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -116,19 +116,11 @@ The equal-size uniqueness branch is now isolated as well:
 \leanid{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne}
 shows that, for injective tensors, equal local image spaces would force equality
 of the periodic MPV lines, so a separately supplied distinct-MPV-line hypothesis
-rules out the equal-size collapse.  Consequently
-\leanid{MPSTensor.groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge}
-combines the finite-dimensional step with this uniqueness input to prove
-zero intersection of the two three-block image spaces.  The equivalent
-non-proportional-state form is recorded by
-\leanid{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul}
-and
-\leanid{MPSTensor.groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge}.
-\leanid{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul}
-and
-\leanid{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge}
-are the corresponding existential forms, where the caller supplies some chain
-length \(N\ge \max\{2,L\}\) at which the two MPV states are not proportional.
+rules out the equal-size collapse.
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge}
+combines this uniqueness input with the finite-dimensional step in the form
+used downstream: the caller supplies some chain length \(N\ge \max\{2,L\}\) at
+which the two MPV states are not pointwise proportional.
 \leanid{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP}
 proves the analytic source of such witnesses for irreducible trace-preserving
 blocks with normalized self-overlaps: if two blocks are not gauge-phase

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -107,6 +107,10 @@ The strict-size branch is also formalized:
 \leanid{MPSTensor.not_three_block_trace_relation_left_of_isNBlkInjective_of_dim_gt}
 states that, if \(D_B<D_A\), a nonzero coefficient on the larger block cannot
 satisfy the homogeneous three-block trace relation.
+\leanid{MPSTensor.pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_gt}
+is the corresponding trace-separation form: once the smaller block is also
+block-injective at the three-block length, the strict-size branch gives
+homogeneous pair trace separation at that exact length.
 The conditional directness package
 \leanid{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}
 turns any external proof of the source contradiction

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -133,11 +133,13 @@ length \(N\ge \max\{2,L\}\) at which the two MPV states are not proportional.
 proves the analytic source of such witnesses for irreducible trace-preserving
 blocks with normalized self-overlaps: if two blocks are not gauge-phase
 equivalent, then arbitrarily far out there is a chain length at which their MPV
-states are not proportional.  The direct-sum file records the pointwise
-conversion by
+states are not proportional.
+\leanid{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_blocksNotGaugePhaseEquiv_of_irreducible_TP}
+is the corresponding already-blocked BNT-family wrapper for same-dimensional
+distinct blocks.  The direct-sum file records the pointwise conversion by
 \leanid{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge}.
 This is still not the full BNT source theorem: the remaining BNT-level task is
-to derive the required non-proportionality of MPV states from the paper's
+to instantiate these witnesses in the direct-sum induction for the paper's
 pairwise different canonical blocks, after the prescribed blocking.
 
 The current formal development also includes downstream lemmas that depend on

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -119,10 +119,14 @@ of the periodic MPV lines, so a separately supplied distinct-MPV-line hypothesis
 rules out the equal-size collapse.  Consequently
 \leanid{MPSTensor.groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge}
 combines the finite-dimensional step with this uniqueness input to prove
-zero intersection of the two three-block image spaces.  This is still not the
-full BNT source theorem: the remaining BNT-level task is to derive the required
-distinctness of the MPV lines from the paper's pairwise different canonical
-blocks, after the prescribed blocking.
+zero intersection of the two three-block image spaces.  The equivalent
+non-proportional-state form is recorded by
+\leanid{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul}
+and
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge}.
+This is still not the full BNT source theorem: the remaining BNT-level task is
+to derive the required non-proportionality of MPV states from the paper's
+pairwise different canonical blocks, after the prescribed blocking.
 
 The current formal development also includes downstream lemmas that depend on
 the remaining direct-sum input.

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -86,7 +86,17 @@ identity as padding.
 
 \section{Formal boundary}
 
-The current formal development includes downstream lemmas that depend on this input.
+The current formal development now formalizes the matrix-factorization input
+from Lemma~\texttt{lem1}: \leanid{Matrix.span_range_mul_nonzero_mul_eq_top}
+states that \(\operatorname{span}\{RCS\}=M_D(\mathbb C)\) whenever
+\(C\ne0\), and
+\leanid{MPSTensor.span_range_evalWord_mul_nonzero_mul_evalWord_eq_top}
+translates this into the exact-length word-product form
+\(\operatorname{span}\{A_u X A_v: |u|=|v|=L\}=M_D(\mathbb C)\) under
+\(L\)-block injectivity and \(X\ne0\).
+
+The current formal development also includes downstream lemmas that depend on
+the remaining direct-sum input.
 \begin{itemize}
   \item \leanid{WordTupleSpanTop} expresses exact-length span of a direct-sum
         block family.

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -103,6 +103,15 @@ length-\(L\) image spaces
 and the source-paper size ordering \(D_B\le D_A\) force \(D_A=D_B\) and
 \(\mathcal G_L^A=\mathcal G_L^B\).  This is recorded by
 \leanid{MPSTensor.bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge}.
+The strict-size branch is also formalized:
+\leanid{MPSTensor.not_three_block_trace_relation_left_of_isNBlkInjective_of_dim_gt}
+states that, if \(D_B<D_A\), a nonzero coefficient on the larger block cannot
+satisfy the homogeneous three-block trace relation.
+The conditional directness package
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}
+turns any external proof of the source contradiction
+\(\neg(D_A=D_B \wedge \mathcal G_L^A=\mathcal G_L^B)\) into
+\(\mathcal G_{3L}^A\cap\mathcal G_{3L}^B=\{0\}\).
 
 The current formal development also includes downstream lemmas that depend on
 the remaining direct-sum input.

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -112,6 +112,17 @@ The conditional directness package
 turns any external proof of the source contradiction
 \(\neg(D_A=D_B \wedge \mathcal G_L^A=\mathcal G_L^B)\) into
 \(\mathcal G_{3L}^A\cap\mathcal G_{3L}^B=\{0\}\).
+The equal-size uniqueness branch is now isolated as well:
+\leanid{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne}
+shows that, for injective tensors, equal local image spaces would force equality
+of the periodic MPV lines, so a separately supplied distinct-MPV-line hypothesis
+rules out the equal-size collapse.  Consequently
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_mpvSubmodule_ne_of_dim_ge}
+combines the finite-dimensional step with this uniqueness input to prove
+zero intersection of the two three-block image spaces.  This is still not the
+full BNT source theorem: the remaining BNT-level task is to derive the required
+distinctness of the MPV lines from the paper's pairwise different canonical
+blocks, after the prescribed blocking.
 
 The current formal development also includes downstream lemmas that depend on
 the remaining direct-sum input.

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -95,6 +95,15 @@ translates this into the exact-length word-product form
 \(\operatorname{span}\{A_u X A_v: |u|=|v|=L\}=M_D(\mathbb C)\) under
 \(L\)-block injectivity and \(X\ne0\).
 
+It also formalizes the next finite-dimensional part of the two-block
+direct-sum proof.  The trace-dual three-block reduction gives inclusion of the
+length-\(L\) image spaces
+\(\mathcal G_L^A\subseteq\mathcal G_L^B\).  Since block injectivity makes
+\(\dim\mathcal G_L^A=D_A^2\) and \(\dim\mathcal G_L^B=D_B^2\), this inclusion
+and the source-paper size ordering \(D_B\le D_A\) force \(D_A=D_B\) and
+\(\mathcal G_L^A=\mathcal G_L^B\).  This is recorded by
+\leanid{MPSTensor.bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge}.
+
 The current formal development also includes downstream lemmas that depend on
 the remaining direct-sum input.
 \begin{itemize}

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -138,6 +138,20 @@ states are not proportional.
 is the corresponding already-blocked BNT-family wrapper for same-dimensional
 distinct blocks.  The direct-sum file records the pointwise conversion by
 \leanid{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge}.
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}
+then packages these two ingredients for the same-dimensional equal-size
+direct-sum branch: BNT separation supplies the long-chain non-proportional MPV
+witness, while injectivity and length-\(L\) block injectivity are still stated
+as explicit direct-sum hypotheses.
+\leanid{MPSTensor.pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective}
+turns zero intersection of the two image spaces at a fixed length into
+homogeneous pair trace separation, provided the two boundary-to-chain maps are
+injective at that fixed length.  Hence
+\leanid{MPSTensor.pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge}
+and
+\leanid{MPSTensor.pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}
+record the pair-trace versions consumed by selector and word-span
+constructions.
 This is still not the full BNT source theorem: the remaining BNT-level task is
 to instantiate these witnesses in the direct-sum induction for the paper's
 pairwise different canonical blocks, after the prescribed blocking.

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -111,6 +111,8 @@ satisfy the homogeneous three-block trace relation.
 is the corresponding trace-separation form: once the smaller block is also
 block-injective at the three-block length, the strict-size branch gives
 homogeneous pair trace separation at that exact length.
+\leanid{MPSTensor.pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_ne}
+removes the ordering convention, using the symmetry of pair trace separation.
 The conditional directness package
 \leanid{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}
 turns any external proof of the source contradiction
@@ -148,9 +150,13 @@ and
 \leanid{MPSTensor.pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}
 record the pair-trace versions consumed by selector and word-span
 constructions.
-This is still not the full BNT source theorem: the remaining BNT-level task is
-to instantiate these witnesses in the direct-sum induction for the paper's
-pairwise different canonical blocks, after the prescribed blocking.
+\leanid{MPSTensor.forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}
+combines the same-dimension BNT branch with the strict-size branch for all
+ordered pairs of distinct blocks at the common length \(3L\), and
+\leanid{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock}
+feeds that common pair separation into the selector/product-span construction.
+This is still conditional on the direct-sum hypotheses: a caller must supply the
+fixed block-injectivity lengths after the prescribed blocking.
 
 The current formal development also includes downstream lemmas that depend on
 the remaining direct-sum input.

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -124,6 +124,11 @@ non-proportional-state form is recorded by
 \leanid{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_not_exists_mpv_eq_smul}
 and
 \leanid{MPSTensor.groundSpace_inf_eq_bot_of_not_exists_mpv_eq_smul_of_dim_ge}.
+\leanid{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_exists_not_mpv_eq_smul}
+and
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_mpv_eq_smul_of_dim_ge}
+are the corresponding existential forms, where the caller supplies some chain
+length \(N\ge \max\{2,L\}\) at which the two MPV states are not proportional.
 This is still not the full BNT source theorem: the remaining BNT-level task is
 to derive the required non-proportionality of MPV states from the paper's
 pairwise different canonical blocks, after the prescribed blocking.


### PR DESCRIPTION
## Summary

- formalize the David--Perez-Garcia `lem1` matrix-factorization input and its exact-length word-span form
- add the three-block trace transfer, finite-chain image-space inclusion/equality, and dimension step for the two-block direct-sum argument
- expose the strict-size branch as homogeneous `PairTraceSeparatingAt` at the three-block length
- add the equal-size uniqueness input: equal local image spaces for injective tensors force equal periodic MPV lines, so a sufficiently long pointwise non-proportional MPV state discharges the source contradiction
- prove the analytic source of that witness for irreducible trace-preserving blocks and expose the already-blocked BNT-family direct-sum form for separated same-dimensional blocks
- package BNT/direct-sum data into one common all-pairs three-block `PairTraceSeparatingAt` length, and feed it into the canonical-form product-word-span consumer
- prune unused direct-sum declarations and factor the proportional FT proof through the eventual-proportional theorem
- extract shared square-matrix finrank and cast lemmas used by the direct-sum route
- address review feedback by reusing the ground-space directness theorem in the pair-trace theorem, making inferred parameters implicit, documenting retained public API, pruning aggregate imports, and correcting blueprint `\uses` data
- update the blueprint and `docs/paper-gaps/david2006_direct_sum_input.tex` with the current formal boundary

## Verification

- `lake env lean TNLean/Algebra/MatrixAux.lean`
- `lake build TNLean.Algebra.MatrixAux`
- `lake build TNLean.Algebra.TracePairing`
- `lake env lean TNLean/MPS/ParentHamiltonian/GroundSpace.lean`
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean`
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/DirectSumGroundSpace.lean`
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean`
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Proportional.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Proportional`
- `lake build TNLean.MPS.BNT.Construction`
- `lake build TNLean.Wielandt.SpanGrowth.InvertibleWordSpan`
- `lake build TNLean.MPS.MPDO.BiCFDerivation`
- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant TNLean.MPS.MPDO.BiCFDerivation`
- `lake build TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.FundamentalTheorem.Proportional`
- `lake build TNLean.MPS.MPDO.BiCFDerivation.Core TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum TNLean.MPS.MPDO.BiCFDerivation`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `git diff --check`

Partially addresses #1133 and narrows #1178/#1170/#1377. The direct-sum/BNT bridge now supplies a common pairwise `PairTraceSeparatingAt` length and the product-word-span consumer under explicit block-injectivity hypotheses. The remaining integration work is to instantiate those fixed-length block-injectivity hypotheses after the prescribed blocking in the canonical-form assembly route.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds several new Lean modules and lemmas that become foundational inputs for later MPDO/parent-Hamiltonian results; risk is mainly proof/assumption correctness and downstream breakage rather than runtime behavior.
> 
> **Overview**
> Formalizes the David–Perez-Garcia–Schuch–Wolf two-block *direct-sum* pipeline in Lean: a new two-sided span lemma for nonzero matrices, its exact-length `evalWord` variant under block injectivity, and the three-block trace-test transfer (`leftTraceWordMap`) leading to image-space inclusion/equality and the associated dimension step.
> 
> Adds the equal-size “uniqueness” branch (using parent-Hamiltonian uniqueness + non-proportional MPV witnesses) and packages both strict-size and equal-size branches into homogeneous `PairTraceSeparatingAt` at the three-block length, including BNT-facing wrappers that supply the non-proportionality witness for separated same-dimension blocks.
> 
> Refactors/cleans up shared infrastructure: extracts reusable finrank lemmas for square matrices (`Matrix.finrank_matrix_fin_eq_sq`/`...top...`), adds cast-preservation for `IsNBlkInjective`, adjusts imports/call sites (e.g. `GroundSpace`, Wielandt span growth, biCF derivation entrypoint), and updates blueprint/docs to reflect the new formal boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0443416aba84c384cdaea43e40c2c04cd5d9b1fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->