### PR TITLE
doc(blueprint): demote auxiliary theorem surfaces

### DIFF
--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -8,9 +8,9 @@ import TNLean.MPS.SharedInfra.SectorDecomposition
 open scoped Matrix BigOperators
 
 /-!
-# BNT grouping step for the canonical form existence reduction
+# Norm-class sector regrouping for the canonical form existence reduction
 
-This file provides the **BNT grouping / sorting** step that bridges the output of the
+This file provides the **norm sorting and sector regrouping** step that bridges the output of the
 canonical form existence reduction (blocks with nonzero weights, not necessarily strictly
 ordered by norm) with the `IsNormalCanonicalForm` predicate (which requires
 `Antitone (fun k => ‖μ k‖)`).
@@ -27,7 +27,7 @@ period `P` the weights become `(μ₀ k)^P`, and two distinct original weights `
 `IsNormalCanonicalFormBNT` further requires `StrictAnti`.  Two resolutions are possible:
 
 * **(a)** Relax the predicate to match the paper's canonical form definition.
-* **(b)** Add a BNT grouping/sorting step.
+* **(b)** Add a norm-sorting and sector-regrouping step.
 
 This file implements strategy **(b)** only in the restricted case where equal-modulus
 blocks on one side are already known to collapse to a single basis tensor. It is
@@ -66,10 +66,11 @@ basis-of-normal-tensors construction from
 
 ### Section 5 Restricted norm-class collapse for possibly-equal norms
 
-* `exists_bnt_grouping` — For blocks with possibly equal norms, given the explicit
-  hypothesis that equal-norm blocks have the same MPV function, there exists a
+* `exists_normClassSectorDecomp_of_equalNorm_sameMPV` — For blocks with possibly equal norms,
+  given the restricted hypothesis that equal-norm blocks have the same MPV function,
+  there exists a
   `SectorDecomposition` whose assembled tensor is `SameMPV₂`-equivalent to the original
-  and whose BNT-level norms are strictly decreasing.  The proof constructs a
+  and whose sector-level norms are strictly decreasing.  The proof constructs a
   `SectorDecomposition` from norm-class enumeration and uses the representative block's
   dimension for the sector `basisDim`.  A same-dimension hypothesis is not needed: the
   choice of representative fixes the sector's bond dimension regardless of other
@@ -78,7 +79,7 @@ basis-of-normal-tensors construction from
 ## References
 
 - [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6, Proposition 2.7]:
-  BNT minimality condition and grouping.
+  BNT minimal representative condition.
 - [Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.A]: Existence of canonical form.
 -/
 
@@ -280,7 +281,7 @@ lemma sameMPV₂_trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
 
 Specialization of `trivialSectorDecomp` to the sorted distinct-norm case: every block
 becomes its own basis tensor with `copies j = 1`, the assembled tensor has
-`SameMPV₂` with `toTensorFromBlocks μ blocks`, and the BNT-level norm ordering is
+`SameMPV₂` with `toTensorFromBlocks μ blocks`, and the sector-level norm ordering is
 `StrictAnti` because each basis carries exactly one weight `μ j`, already strictly
 decreasing. -/
 lemma exists_trivialSectorDecomp_of_sorted_distinct_norms
@@ -301,7 +302,7 @@ lemma exists_trivialSectorDecomp_of_sorted_distinct_norms
 
 /-! ### Section 5. Restricted norm-class collapse for blocks with possibly equal norms -/
 
-/-- Shared norm-class enumeration used by the BNT grouping constructions. -/
+/-- Shared norm-class enumeration used by the norm-class sector constructions. -/
 structure NormClassGroupingData {r : ℕ} (μ : Fin r → ℂ) where
   g : ℕ
   vals : Fin g → ℝ
@@ -392,7 +393,7 @@ Given a weighted block family `(μ, blocks)` where some blocks may share the sam
 there exists a `SectorDecomposition P` with:
 
 1. `SameMPV₂ P.toTensor (toTensorFromBlocks μ blocks)`.
-2. `StrictAnti` on the BNT-level norms (one norm value per group).
+2. `StrictAnti` on the sector-level norms (one norm value per group).
 
 **Hypotheses**:
 - `hμne`: all weights are nonzero.
@@ -410,13 +411,14 @@ paper's full basis-of-normal-tensors construction: if two distinct basis tensors
 occur at the same modulus, they should survive as different basis elements rather
 than being forced into one norm class.
 
-**Role of `hMPVEq`**:
-The hypothesis is an extra input for this restricted collapse lemma.  The full
+**Where `hMPVEq` comes from**:
+The hypothesis is an extra input for this restricted collapse lemma. The full
 BNT theory of Cirac--Perez-Garcia--Schuch--Verstraete 2017, Section 2.3 does not
 collapse all equal-modulus sectors into one block: repeated basis tensors can
-survive as multiplicities with separate coefficients.  Thus `hMPVEq` should be
-proved only in situations where a restricted same-MPV collapse has already been
-justified, not assumed as a general consequence of equal weight norm alone.
+survive as multiplicities with separate coefficients. Only blocks that are
+already known to be gauge-phase equivalent should collapse to one sector basis
+tensor; the phase-class construction carries this identification data through
+representative sectors and repeated weights.
 
 **Proof:**
 1. Let `S = Finset.univ.image (‖μ ·‖)`, `g = S.card`.
@@ -435,7 +437,7 @@ justified, not assumed as a general consequence of equal weight norm alone.
    `= mpv (toTensorFromBlocks μ blocks) σ`.
 5. **StrictAnti** holds because the `v_j` are strictly decreasing and
    `‖P.weight j ⟨0, _⟩‖ = ‖μ (enum j 0)‖ = v_j`. -/
-lemma exists_bnt_grouping
+lemma exists_normClassSectorDecomp_of_equalNorm_sameMPV
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -503,5 +505,78 @@ lemma exists_bnt_grouping
     rw [classes.enum_norm j ⟨0, classes.copies_pos j⟩,
       classes.enum_norm i ⟨0, classes.copies_pos i⟩]
     exact classes.vals_strictAnti hij
+
+/-- Collapse a single norm class onto one sector basis tensor, keeping the full sector-weight
+multiplicity data. This is the one-class special case of the norm-class sector-decomposition
+surface. -/
+theorem exists_singleNormClassSectorDecomp_of_phaseMPV
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (k0 : Fin r)
+    (hμne : ∀ k, μ k ≠ 0)
+    (hNorm : ∀ k : Fin r, ‖μ k‖ = ‖μ k0‖)
+    (hPhase : ∀ k : Fin r,
+      ∃ ζ : ℂ, ζ ≠ 0 ∧ ‖ζ‖ = 1 ∧
+        ∀ (N : ℕ) (σ : Fin N → Fin d),
+          mpv (blocks k) σ = ζ ^ N * mpv (blocks k0) σ) :
+    ∃ P : SectorDecomposition d,
+      P.basisCount = 1 ∧
+      P.totalCopies = r ∧
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      (∀ s : Fin P.totalCopies, ‖P.flatWeight s‖ = ‖μ k0‖) := by
+  classical
+  let ζFn : Fin r → ℂ := fun k => (hPhase k).choose
+  have hζ_ne : ∀ k : Fin r, ζFn k ≠ 0 := fun k => (hPhase k).choose_spec.1
+  have hζ_norm : ∀ k : Fin r, ‖ζFn k‖ = 1 := fun k => (hPhase k).choose_spec.2.1
+  have hζ_mpv : ∀ (k : Fin r) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (blocks k) σ = (ζFn k) ^ N * mpv (blocks k0) σ :=
+    fun k N σ => (hPhase k).choose_spec.2.2 N σ
+  have hr : 0 < r := by
+    exact Nat.lt_of_lt_of_le (Nat.zero_lt_succ _) (Nat.succ_le_of_lt k0.isLt)
+  let sectors : SectorWeightData 1 := {
+    copies := fun _ => r
+    copies_pos := fun _ => hr
+    weight := fun _ q => ζFn q * μ q
+    weight_ne_zero := fun _ q => mul_ne_zero (hζ_ne q) (hμne q)
+  }
+  let P : SectorDecomposition d := {
+    basisCount := 1
+    basisDim := fun _ => dim k0
+    basis := fun _ => blocks k0
+    sectors := sectors
+  }
+  refine ⟨P, rfl, ?_, ?_, ?_⟩
+  · simp [P, sectors, SectorDecomposition.totalCopies]
+  · intro N σ
+    calc
+      mpv P.toTensor σ
+          = ∑ j : Fin P.basisCount,
+              ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
+              P.mpv_toTensor_eq_sum_sectors σ
+      _ = ∑ q : Fin r, (ζFn q * μ q) ^ N * mpv (blocks k0) σ := by
+            simp [P, sectors]
+      _ = ∑ q : Fin r, (μ q) ^ N * mpv (blocks q) σ := by
+            refine Finset.sum_congr rfl fun q _ => ?_
+            rw [mul_pow, hζ_mpv q N σ]
+            ring
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+            symm
+            simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
+  · intro s
+    set t : ((j : Fin P.basisCount) × Fin (P.copies j)) := P.flatIndexEquiv.symm s with ht
+    rcases t with ⟨j, q⟩
+    have hj : j = 0 := Subsingleton.elim _ _
+    subst hj
+    rw [SectorDecomposition.flatWeight, ht.symm]
+    change ‖P.weight 0 q‖ = ‖μ k0‖
+    change ‖ζFn q * μ q‖ = ‖μ k0‖
+    rw [norm_mul, hζ_norm q, one_mul, hNorm q]
+
+@[deprecated exists_normClassSectorDecomp_of_equalNorm_sameMPV (since := "2026-05-06")]
+alias exists_bnt_grouping := exists_normClassSectorDecomp_of_equalNorm_sameMPV
+
+@[deprecated exists_singleNormClassSectorDecomp_of_phaseMPV (since := "2026-05-06")]
+alias bnt_grouping_single_norm_class := exists_singleNormClassSectorDecomp_of_phaseMPV
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/CoefficientConvergence.lean
+++ b/TNLean/MPS/FundamentalTheorem/CoefficientConvergence.lean
@@ -8,9 +8,17 @@ import Mathlib.Analysis.SpecificLimits.Normed
 /-!
 # Coefficient convergence for canonical-form BNT decompositions
 
-This module proves that the normalized decomposition coefficients `(μ k / μ 0)^N` converge
-from separated nonzero weights, and provides a self-contained version of the Fundamental Theorem
-(Theorem 4.4) that derives the decomposition data from canonical-form structure.
+This module proves the geometric strict-dominance facts for normalized
+coefficients `(μ k / μ 0)^N` and provides an equivalent formulation of the
+proportional Fundamental Theorem that derives the structural BNT data from
+canonical-form hypotheses.
+
+The ratio convergence lemmas are auxiliary. They are not the source paper's
+BNT coefficient theorem: away from a single surviving dominant sector the
+limits of the normalized ratios are zero, while the proportional matching
+theorem used below assumes nonzero coefficient limits. The full source route
+uses the BNT comparison and, in equal-modulus situations, power-sum arguments
+or induction over matched sectors.
 
 ## Main results
 
@@ -32,13 +40,14 @@ an adjusted proportionality constant; equivalently, the dominant factors `μ₀^
 into `c`.
 
 ### `fundamentalTheorem_proportionalMPV_CFBNT_auto`
-Self-contained Fundamental Theorem (Theorem 4.4) that derives the BNT decomposition
-data from `IsCanonicalFormBNT`. Its remaining hypotheses are:
+Reformulation of the proportional Fundamental Theorem that derives the BNT
+decomposition data from `IsCanonicalFormBNT`. Its remaining hypotheses are:
 - Two CF-BNT families
 - A proportionality constant `c : ℕ → ℂ` with
   `mpv(toTensorFromBlocks μA A) σ = c N * mpv(toTensorFromBlocks μB B) σ`
-- Convergent nonzero coefficients `aLim`, `bLim` for re-weighted decompositions
-  (typically built from `(μ j / μ 0)^N` after dominant-weight normalization)
+- Convergent nonzero coefficients `aLim`, `bLim` for the comparison
+  decompositions. Strict-dominance ratios alone do not provide these nonzero
+  limits for subdominant blocks.
 
 ## References
 
@@ -219,12 +228,12 @@ The user only needs to supply:
 
 The coefficient data `aLim`/`bLim` is needed because the direct decomposition coefficients
 `(μ k)^N` do not satisfy the convergence hypotheses directly. In the strict-dominance regime one
-first normalizes by the dominant weight, so the relevant arrays are `(μ k / μ 0)^N`; these
-converge to `0` for non-dominant blocks, while the overall factor `μ 0^N` is absorbed into the
-proportionality constant. In grouped equal-modulus sectors even the normalized sums can still
-oscillate. The paper resolves this via induction on block count, matching dominant blocks first
-and stripping them off. The needed convergent coefficient data is therefore recorded as
-explicit hypotheses.
+can normalize by the dominant weight, but then `(μ k / μ 0)^N` converges to `0` for
+non-dominant blocks. Those zero limits do not satisfy the nonzero-limit hypotheses of the
+proportional matching theorem except after restricting to the surviving dominant sector. In
+grouped equal-modulus sectors even the normalized sums can still oscillate. The paper resolves
+this via induction on block count, matching dominant blocks first and stripping them off. The
+needed convergent nonzero coefficient data is therefore recorded as explicit hypotheses.
 
 **Consequences of the canonical-form hypotheses:**
 - The overlap properties (self → 1, cross → 0)

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -440,7 +440,7 @@ The results follow~\cite{Sanz2010Quantum}.
 \section{Proof of the cumulative Wielandt bound}
 
 \begin{theorem}[Wielandt bound]\label{thm:wielandt_bound}
-    \lean{MPSTensor.isNormal_implies_cumulativeSpan}
+    \lean{MPSTensor.cumulative_wielandt_bound}
     \leanok
     \uses{def:cumulative_span, def:normal}
     If $A$ is a normal MPS tensor with bond dimension~$D$,

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -439,64 +439,8 @@ The results follow~\cite{Sanz2010Quantum}.
 
 \section{Proof of the cumulative Wielandt bound}
 
-\begin{definition}[Wielandt analysis]\label{def:wielandt_analysis}
-    \lean{MPSTensor.WielandtAnalysis}
-    \leanok
-    \uses{def:mps_tensor, def:normal}
-    A \emph{Wielandt analysis} for a normal MPS tensor~$A$
-    consists of:
-    a word $w_0$ of length $\le D^2$,
-    a nonzero eigenvalue $\mu$,
-    and a nonzero eigenvector $\varphi$
-    of the matrix $A^{w_0}$, such that
-    $A^{w_0} \varphi = \mu \varphi$.
-\end{definition}
-
-\begin{lemma}[Wielandt analysis exists]\label{lem:wielandt_analysis}
-    \lean{MPSTensor.wielandtAnalysis}
-    \leanok
-    \uses{def:wielandt_analysis, def:normal}
-    Every normal MPS tensor with bond dimension $D \ge 1$ admits a
-    Wielandt analysis.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    \uses{thm:eigenvalue_extraction}
-    Immediate from Theorem~\ref{thm:eigenvalue_extraction}.
-\end{proof}
-
-\begin{lemma}[Cumulative Wielandt analysis]\label{lem:wielandt_chain}
-    \lean{MPSTensor.wielandt_chain}
-    \leanok
-    \uses{def:wielandt_analysis, def:cumulative_vector_span, def:normal,
-          def:cumulative_span}
-    Let $A$ be a normal MPS tensor with bond dimension~$D \ge 1$.
-    Then the following auxiliary consequences hold simultaneously:
-    \begin{enumerate}
-        \item $T_{D^2}(A) = \MN{D}$ (cumulative span stabilises);
-        \item there exists a word $w_0$ with $|w_0| \le D^2$ and
-              $\tr(A^{w_0}) \ne 0$;
-        \item there exist $w_0, \mu \ne 0, \varphi \ne 0$ with
-              $|w_0| \le D^2$ and $A^{w_0} \varphi = \mu\,\varphi$;
-        \item for every $\varphi \ne 0$,
-              $K_{D^2}(A, \varphi) = \C^D$.
-    \end{enumerate}
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    \uses{lem:wielandt_analysis, thm:eigenvector_spreading,
-          thm:cumulative_eq_top}
-    Items (1)--(3) follow from earlier results
-    (Theorem~\ref{thm:cumulative_eq_top}
-    and Lemma~\ref{lem:wielandt_analysis}).
-    Item (4) combines these with the eigenvector spreading bound
-    (Theorem~\ref{thm:eigenvector_spreading}).
-\end{proof}
-
-\begin{theorem}[Cumulative Wielandt bound]\label{thm:cumulative_wielandt_bound}
-    \lean{MPSTensor.cumulative_wielandt_bound}
+\begin{theorem}[Wielandt bound]\label{thm:wielandt_bound}
+    \lean{MPSTensor.isNormal_implies_cumulativeSpan}
     \leanok
     \uses{def:cumulative_span, def:normal}
     If $A$ is a normal MPS tensor with bond dimension~$D$,
@@ -516,7 +460,7 @@ The results follow~\cite{Sanz2010Quantum}.
 \end{proof}
 
 \begin{remark}[Explicit blocking-length estimates]\leanok
-    Theorem~\ref{thm:cumulative_wielandt_bound} gives the $D^2$
+    Theorem~\ref{thm:wielandt_bound} gives the $D^2$
     cumulative-span bound.
     The full-rank index bound $\iota(A) \le (D^2 - d + 1) \cdot D^2$
     (Theorem 1 case (1) of \cite{Sanz2010Quantum}) is proved in

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -962,7 +962,7 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     The source papers use the quantum Wielandt theorem as an input converting
     normality into injectivity after blocking. In the notation of this chapter,
     the input has two distinct conclusions. First,
-    Theorem~\ref{thm:cumulative_wielandt_bound} gives cumulative saturation
+    Theorem~\ref{thm:wielandt_bound} gives cumulative saturation
     $T_{D^2}(A)=\MN{D}$. This alone is not the injectivity statement used in
     canonical form, because injectivity requires products of one fixed length.
     Second, Lemma~2(b) of~\cite{Sanz2010Quantum}, formalized here through

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2894,8 +2894,8 @@ primitivity and normality results to the sector blocks.
 \end{definition}
 
 \begin{lemma}[Restricted norm-class collapse]
-	\label{lem:bnt_grouping}
-	\lean{MPSTensor.exists_bnt_grouping}\leanok
+	\label{lem:restricted_norm_class_collapse}
+	\lean{MPSTensor.exists_normClassSectorDecomp_of_equalNorm_sameMPV}\leanok
 	\uses{def:norm_class_grouping, thm:bnt_trivial_sector}
 	Let $(\mu_k,A_k)_{k=1}^r$ be a weighted block family with
 	$\mu_k \neq 0$ for every $k$. If equal-norm blocks represent the same

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2904,6 +2904,17 @@ primitivity and normality results to the sector blocks.
 	whose sector norms are strictly decreasing.
 \end{lemma}
 
+\begin{lemma}[Single norm class from phase-related MPVs]
+	\label{lem:single_norm_class_phase_mpv}
+	\lean{MPSTensor.exists_singleNormClassSectorDecomp_of_phaseMPV}\leanok
+	\uses{def:tensor_from_blocks, def:paper_sector_data, def:mpv}
+	If all weights have the same norm and, for a chosen block, every block has
+	a unit-modulus phase relating its MPV family to that block, then the family
+	admits a sector decomposition with one basis tensor and one copy for each
+	original block. The total tensor represents the original weighted block
+	sum, and every resulting sector weight has the common norm.
+\end{lemma}
+
 \subsection{Equal-Norm Blocks}
 
 \begin{theorem}[Gauge equivalence from non-decaying cross-overlap]

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2908,11 +2908,11 @@ primitivity and normality results to the sector blocks.
 	\label{lem:single_norm_class_phase_mpv}
 	\lean{MPSTensor.exists_singleNormClassSectorDecomp_of_phaseMPV}\leanok
 	\uses{def:tensor_from_blocks, def:paper_sector_data, def:mpv}
-	If all weights have the same norm and, for a chosen block, every block has
-	a unit-modulus phase relating its MPV family to that block, then the family
-	admits a sector decomposition with one basis tensor and one copy for each
-	original block. The total tensor represents the original weighted block
-	sum, and every resulting sector weight has the common norm.
+	If all weights are nonzero with the same norm and, for a chosen block, every
+	block has a unit-modulus phase relating its MPV family to that block, then
+	the family admits a sector decomposition with one basis tensor and one copy
+	for each original block. The total tensor represents the original weighted
+	block sum, and every resulting sector weight has the common norm.
 \end{lemma}
 
 \subsection{Equal-Norm Blocks}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -371,19 +371,19 @@ The main references are
 		\qquad
 		B_{\mathrm{tot}} = \bigoplus_{k=1}^{g_B} \nu_k B_k,
 	\]
-	and Theorem~\ref{thm:mpv_decomposition} gives the coefficient arrays
-	$a_{N,j} = \mu_j^N$ and $b_{N,k} = \nu_k^N$.
-	To fit the convergence hypotheses of
-	Theorem~\ref{thm:bnt_perm_prop}, one first normalizes by the dominant
-	weight on each side: the relevant arrays are $(\mu_j/\mu_0)^N$ and
-	$(\nu_k/\nu_0)^N$, with $(\mu_j/\mu_0)^N \to 0$ for $j \ge 1$ and
-	$(\nu_k/\nu_0)^N \to 0$ for $k \ge 1$ by
-	Theorem~\ref{thm:coeff_ratio_decay}, while the overall factors
-	$\mu_0^N$ and $\nu_0^N$ are absorbed into the proportionality
-	constant $c_N$.
+	and Theorem~\ref{thm:mpv_decomposition} gives coefficient arrays
+	built from powers of the sector weights.
+	The hypotheses of Theorem~\ref{thm:bnt_perm_prop} require nonzero
+	coefficient limits for every sector being compared. Therefore the
+	geometric strict-dominance normalization
+	$(\mu_j/\mu_0)^N \to 0$ for $j \ge 1$ is not by itself an input to
+	that theorem for all blocks at once: it only isolates the currently
+	surviving dominant sector.  The source proof matches such sectors
+	and then removes them, while equal-modulus sectors require the
+	power-sum comparison below.
 	Definition~\ref{def:cf_bnt} supplies injectivity, TP normalization,
-	and the within-family overlap limits, so the theorem isolates the
-	abstract permutation argument from this canonical-form setting.
+	and the within-family overlap limits; the remaining coefficient
+	data is kept explicit in Theorem~\ref{thm:bnt_perm_prop}.
 \end{remark}
 
 \begin{lemma}[Permutation rigidity with asymptotically orthonormal overlaps]\label{lem:bnt_perm_simple}
@@ -496,26 +496,8 @@ The main references are
 
 \section{Coefficient convergence}
 
-\begin{theorem}[Coefficient ratio decay]\label{thm:coeff_ratio_decay}
-	\lean{MPSTensor.IsCanonicalFormBNT.coeff_ratio_tendsto}
-	\leanok
-	\uses{def:cf_bnt}
-	Under the canonical form with BNT separation of
-	Definition~\ref{def:cf_bnt}, indexed so that $\mu_0$ is the
-	(strictly) dominant weight, one has
-	$(\mu_k / \mu_0)^N \to 0$
-	for every $k \ge 1$ as $N \to \infty$.
-\end{theorem}
-
-\begin{proof}\leanok
-	By the BNT separation condition in Definition~\ref{def:cf_bnt},
-	$|\mu_k| < |\mu_0|$ strictly, so
-	$|\mu_k / \mu_0| < 1$ and the geometric sequence
-	converges to~$0$.
-\end{proof}
-
 \begin{remark}[Strict-dominance regime]\notready
-	Theorem~\ref{thm:coeff_ratio_decay} applies when one
+	The coefficient-ratio decay auxiliary applies when one
 	modulus is strictly dominant:
 	$|\mu_0| > |\mu_k|$ for $k \ge 1$.
 	In the more general periodic setting of
@@ -594,9 +576,9 @@ The main references are
 
 \begin{remark}
 	Theorems~\ref{thm:newton_girard} and~\ref{thm:power_sum_multiset}
-	remain relevant for the general equal-MPV
-	Theorem~\ref{thm:ft_equal}, where one expects a power-sum step to
-	recover the multiplicity-weight data.  In the current route this recovery is
+	remain relevant for the equal-MPV source corollary discussed in
+	Section~\ref{sec:assembly_equal}, where the paper uses a power-sum step to
+	recover the multiplicity-weight data. In the current route this recovery is
 	kept in the BNT multiplicity lemmas rather than in a separate
 	explicit-coefficient equal-case theorem.
 \end{remark}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -121,8 +121,8 @@ The main references are
 \end{definition}
 
 \begin{lemma}[Restricted norm-class collapse]
-	\label{lem:bnt_grouping_equal_norm}
-	\lean{MPSTensor.exists_bnt_grouping}
+	\label{lem:restricted_norm_class_collapse_bnt}
+	\lean{MPSTensor.exists_normClassSectorDecomp_of_equalNorm_sameMPV}
 	\leanok
 	\uses{def:mpv}
 	Let $(\mu_k, A_k)_{k=1}^r$ be a weighted block family with

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -500,6 +500,9 @@ The main references are
 	The coefficient-ratio decay auxiliary applies when one
 	modulus is strictly dominant:
 	$|\mu_0| > |\mu_k|$ for $k \ge 1$.
+	In that restricted situation the ratios \((\mu_k/\mu_0)^N\) tend to
+	zero, and the MPV of the normalized block family gives the corresponding
+	proportional comparison after factoring out the leading weight.
 	In the more general periodic setting of
 	\cite[Equation~(72a)]{Cirac2021Matrix}, the coefficient attached to block~$j$
 	can take the form $\sum_q \mu_{j,q}^N$, where the $\mu_{j,q}$ are the

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -496,6 +496,40 @@ The main references are
 
 \section{Coefficient convergence}
 
+\begin{lemma}[Strict-dominance coefficient ratios]
+	\label{lem:strict_dominance_coefficient_ratios}
+	\lean{MPSTensor.HasStrictOrderedNonzeroWeights.coeff_ratio_tendsto}
+	\lean{MPSTensor.IsCanonicalFormBNT.coeff_ratio_tendsto}
+	\leanok
+	Let \((\mu_k)_k\) be a strictly ordered nonzero weight family with
+	\(\mu_0\) dominant.  Then the normalized powers
+	\((\mu_k/\mu_0)^N\) converge to \(1\) for the dominant block and to
+	\(0\) for every other block.
+\end{lemma}
+
+\begin{proof}\leanok
+	The dominant ratio is \(1\).  For every other block, strict ordering gives
+	\(|\mu_k/\mu_0|<1\), so its powers converge to \(0\).
+\end{proof}
+
+\begin{lemma}[Dominant-weight normalization]
+	\label{lem:dominant_weight_normalization}
+	\lean{MPSTensor.mpv_toTensorFromBlocks_eq_mu0_pow_mul_normalized}
+	\lean{MPSTensor.proportional_normalized_of_proportional}
+	\leanok
+	Factoring the dominant weight from a block-diagonal tensor rewrites its
+	MPV as \(\mu_0^N\) times the MPV of the normalized block family.  Hence
+	a proportionality relation between two such tensors induces the
+	corresponding proportionality relation between their normalized block
+	families, with the scalar adjusted by the dominant-weight ratio.
+\end{lemma}
+
+\begin{proof}\leanok
+	Expand the MPV of the block-diagonal tensor as the sum over blocks and
+	factor \(\mu_0^N\) from each coefficient.  The proportionality statement
+	follows by dividing by the nonzero dominant power.
+\end{proof}
+
 \begin{remark}[Strict-dominance regime]\notready
 	The coefficient-ratio decay auxiliary applies when one
 	modulus is strictly dominant:

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -501,6 +501,7 @@ The main references are
 	\lean{MPSTensor.HasStrictOrderedNonzeroWeights.coeff_ratio_tendsto}
 	\lean{MPSTensor.IsCanonicalFormBNT.coeff_ratio_tendsto}
 	\leanok
+	\uses{def:cf_bnt}
 	Let \((\mu_k)_k\) be a strictly ordered nonzero weight family with
 	\(\mu_0\) dominant.  Then the normalized powers
 	\((\mu_k/\mu_0)^N\) converge to \(1\) for the dominant block and to
@@ -517,6 +518,7 @@ The main references are
 	\lean{MPSTensor.mpv_toTensorFromBlocks_eq_mu0_pow_mul_normalized}
 	\lean{MPSTensor.proportional_normalized_of_proportional}
 	\leanok
+	\uses{def:tensor_from_blocks, def:mpv}
 	Factoring the dominant weight from a block-diagonal tensor rewrites its
 	MPV as \(\mu_0^N\) times the MPV of the normalized block family.  Hence
 	a proportionality relation between two such tensors induces the

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -196,9 +196,8 @@ coincide and the full tensors are related by one invertible gauge
 obtained after the proportional Fundamental Theorem by matching the BNT blocks,
 then comparing the sector-weight power sums.
 
-The formalization currently exposes the proved pieces below rather than a
-separate not-ready theorem for the bare global corollary. The heterogeneous
-equal-case theorem, stated as
+We record the comparison statements in the two forms needed below. The
+heterogeneous equal-case theorem, stated as
 Theorem~\ref{thm:fundamentalTheorem_equalMPV_CFBNT_hetero}, gives the
 block-count, bond-dimension, and gauge-phase matching directly from equality of
 the assembled MPV families. The common-structure theorem below proves the

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -189,51 +189,23 @@ used in this chapter.
 \section{Equal-MPV Fundamental Theorem}%
 \label{sec:assembly_equal}
 
-\begin{theorem}[Fundamental Theorem --- equal MPV case]\label{thm:ft_equal}
-	\notready
-	\uses{def:cf_bnt, def:gauge_equiv}
-	Let $A_{\mathrm{tot}}$ and $B_{\mathrm{tot}}$ be MPS tensors
-	in canonical form with BNT separation, with associated families
-	$(\mu_j^A, A_j)_{j=1}^{g_A}$ and $(\mu_k^B, B_k)_{k=1}^{g_B}$.
-	If
-	\[
-		V^{(N)}(A_{\mathrm{tot}})_\sigma
-		= V^{(N)}(B_{\mathrm{tot}})_\sigma
-	\]
-	for every $N$ and $\sigma$, then the block-diagonal tensors
-	$\bigoplus_{j=1}^{g_A} \mu_j^A A_j$ and
-	$\bigoplus_{k=1}^{g_B} \mu_k^B B_k$
-	are gauge equivalent.
-\end{theorem}
+The source corollary for equal MPVs says that if two canonical-form tensors
+generate the same MPV family for all system sizes, then their matrix dimensions
+coincide and the full tensors are related by one invertible gauge
+\cite[Corollary~II.2]{Cirac2017MPDO_AnnPhys}. In the proof, this corollary is
+obtained after the proportional Fundamental Theorem by matching the BNT blocks,
+then comparing the sector-weight power sums.
 
-\begin{proof}
-	\uses{thm:fundamentalTheorem_equalMPV_CFBNT_hetero,
-	      thm:mpv_decomposition,
-	      lem:route_b_equal_with_copies,
-	      thm:afterBlocking_sectorComparison_reindexed_bntCover,
-	      lem:common_phase_cover_of_proportional_decomposition}
-	The comparison proceeds directly from equality of the full MPV families.
-	Theorem~\ref{thm:mpv_decomposition} expands the two canonical-form tensors in
-	their BNT bases, and the sector-multiplicity comparison of
-	Lemma~\ref{lem:route_b_equal_with_copies} recovers both the copy counts and
-	the sector-weight multisets from the resulting power-sum identities.
-
-	The remaining synchronization statement for the bare equal-MPV theorem must
-	assemble the block-matching data into equality of the weighted block-diagonal
-	tensors.  The heterogeneous equal-case theorem
-	(Theorem~\ref{thm:fundamentalTheorem_equalMPV_CFBNT_hetero}) now proves the
-	block-count, bond-dimension, and gauge-phase matching directly from equality
-	of the full MPV families.  The
-	after-blocking comparison theorem
-	(Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover}) gives the
-	matched sector-weight conclusion once BNT-cover comparison data are supplied.
-	Lemma~\ref{lem:common_phase_cover_of_proportional_decomposition} explains
-	how proportional block comparisons supply common phases.  Completing this
-	theorem therefore amounts to deriving the BNT-cover and sector-weight data for
-	the canonical decompositions produced from the bare equality assumption.  Once
-	those data are available, the phases are absorbed into the recovered weights
-	and the blockwise conjugacies assemble into a global gauge equivalence.
-\end{proof}
+The formalization currently exposes the proved pieces below rather than a
+separate not-ready theorem for the bare global corollary. The heterogeneous
+equal-case theorem, stated as
+Theorem~\ref{thm:fundamentalTheorem_equalMPV_CFBNT_hetero}, gives the
+block-count, bond-dimension, and gauge-phase matching directly from equality of
+the assembled MPV families. The common-structure theorem below proves the
+global gauge statement when the two sides already share the same block data.
+The remaining source-facing assembly step is to combine the heterogeneous
+matching with sector-weight recovery and the copy-count equalities into one
+global block-diagonal gauge.
 
 \begin{theorem}[Fundamental Theorem --- equal MPV case, common block structure]\label{thm:ft_equal_same_structure}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_CFBNT}

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -595,13 +595,13 @@ literature theorem is not yet a single unconditional Lean statement.
 
 \begin{remark}[Comparison with the blocking approach]\notready
     \label{rem:periodic_vs_blocking_ft}
-    Theorem~\ref{thm:periodic_ft} and the equal-MPV Fundamental Theorem
-    (Theorem~\ref{thm:ft_equal}) both characterize the gauge freedom
+    Theorem~\ref{thm:periodic_ft} and the equal-MPV source corollary
+    discussed in Section~\ref{sec:assembly_equal} both characterize the gauge freedom
     between two tensors with equal MPV families, but they do so at
     different levels:
 
     \begin{enumerate}
-        \item \emph{Blocking approach} (Theorem~\ref{thm:ft_equal},
+        \item \emph{Blocking approach} (Section~\ref{sec:assembly_equal},
               following \cite{Cirac2017MPDO_AnnPhys}):
               Block both $A$ and $B$ by a common period $p$ so that all
               blocks of $A^{[p]}$ and $B^{[p]}$ are primitive


### PR DESCRIPTION
### Motivation
- #1282 asks us to audit and retire theorem surfaces that are implementation scaffolding or ahead of the formalized source-faithful result.
- The Wielandt blueprint was exposing `WielandtAnalysis` and `wielandt_chain` as paper-facing entries, although the source paper has Lemma 1, Lemma 2, and Theorem 1 instead.
- The BNT chapter was presenting strict-dominance coefficient-ratio decay as if it supplied the nonzero coefficient limits needed by the proportional BNT matching theorem; those ratios actually vanish off the dominant sector.
- The Chapter 11 equal-MPV global gauge theorem was a `\notready` surface with no Lean target; the proved heterogeneous result is block matching (`BlockPermutationGaugeWitness`), not yet full global weighted gauge equivalence.

### Description
- Removes the `Wielandt analysis`, `Wielandt analysis exists`, and `Cumulative Wielandt analysis` blueprint entries while keeping the Lean aggregation declarations available for internal use.
- Rewrites the BNT proportional-decomposition remark to state that strict-dominance normalization isolates a surviving dominant sector and does not satisfy the all-sector nonzero-limit hypothesis.
- Demotes coefficient-ratio decay from a theorem-style blueprint entry to a source-boundary remark, and updates Lean module docs to quarantine the ratio lemmas as auxiliary strict-dominance facts rather than the paper BNT coefficient theorem.
- Replaces the not-ready Chapter 11 equal-MPV global theorem entry with a source-boundary paragraph that points to the already Lean-linked heterogeneous block-matching theorem and the common-block specialization; dangling references now point to the equal-MPV section instead of a missing theorem label.

### Testing
- `lake env lean TNLean/MPS/FundamentalTheorem/CoefficientConvergence.lean`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `git diff --check`
- `leanblueprint web` exits 0 locally; this environment still emits the known plasTeX `leanblueprint` package-hook import warnings and bibliography warnings.

---
Refs #1282.
Refs #1170.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly documentation/blueprint reshaping and renaming to clarify which results are paper-facing, but it also adds a new Lean theorem and introduces deprecations/aliases that could affect downstream references.
> 
> **Overview**
> Reframes the “BNT grouping” material as **norm-class sector regrouping**: renames the main lemma to `exists_normClassSectorDecomp_of_equalNorm_sameMPV`, updates surrounding terminology/docs from BNT-level to sector-level, and keeps backward compatibility via deprecated aliases.
> 
> Adds a new Lean result `exists_singleNormClassSectorDecomp_of_phaseMPV` for the one-norm-class case (collapsing all blocks into a single sector while preserving multiplicities and weight norms).
> 
> Adjusts blueprint chapters to **demote/retire auxiliary theorem surfaces**: removes Wielandt “analysis/chain” exposition in favor of the core bound statement, relabels coefficient-ratio decay as strict-dominance auxiliary (not sufficient for nonzero coefficient limits), and replaces the unproved equal-MPV global theorem surface with source-boundary text pointing to existing proved comparison statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aa8f5177d04ef208453cea6e5cbb566ba2afeae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->