### PR TITLE
ci(github): load trusted automation from base branch

### DIFF
--- a/.github/workflows/blueprint-prose-review.yml
+++ b/.github/workflows/blueprint-prose-review.yml
@@ -76,7 +76,7 @@ jobs:
         if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.ref }}
           path: .trusted-actions
           fetch-depth: 1
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -115,7 +115,7 @@ jobs:
         if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true' && steps.provider-token.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.ref }}
           path: .trusted-actions
           fetch-depth: 1
 

--- a/.github/workflows/tracking-issue-sync.yml
+++ b/.github/workflows/tracking-issue-sync.yml
@@ -75,7 +75,7 @@ jobs:
         if: steps.claude-switch.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          ref: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           path: .trusted-actions
           fetch-depth: 1
 


### PR DESCRIPTION
Use the trusted base branch checkout for local automation actions and prompt files, rather than the historical pull-request base SHA. This keeps the trusted checkout non-PR-controlled while allowing existing open PRs whose base SHA predates the newly merged wrapper to run the DeepSeek-backed review workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how CI selects the “trusted” automation code, which can affect review/automation behavior and trust boundaries across branches. Impact is limited to workflow execution and should be quickly observable if misconfigured.
> 
> **Overview**
> All Claude-related workflows now checkout the `.trusted-actions` directory using `github.event.pull_request.base.ref` (and the same fallback in `tracking-issue-sync`) instead of `github.event.pull_request.base.sha`.
> 
> This makes the “trusted automation” come from the base branch tip rather than a specific historical base commit, so existing PRs keep using up-to-date automation without pulling from PR-controlled code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de3bdbb4fc5add1a1a5e08f91a7a9ba61234a887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->