### PR TITLE
refactor(Wielandt): name cumulative bound surface explicitly

### DIFF
--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -162,6 +162,9 @@ theorem cumulative_wielandt_bound [NeZero D]
     cumulativeSpan A (D ^ 2) = ⊤ :=
   cumulativeSpan_eq_top A hN
 
+@[deprecated (since := "2026-05-06")]
+alias isNormal_implies_cumulativeSpan := cumulative_wielandt_bound
+
 /-- **Normality implies cumulative spanning.**
 
 If `IsNormal A` (word products of a single fixed length span M_D(ℂ)),

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -179,17 +179,6 @@ lemma isNormal_implies_cumulativeSpan_eq_top'
     ∃ N, cumulativeSpan A N = ⊤ :=
   cumulativeSpan_eq_top_of_isNormal A hN
 
-/-- **Normality implies cumulative spanning at D².**
-
-The forward direction of the characterization: if `IsNormal A`, then
-`cumulativeSpan A (D²) = ⊤`.
-
-Paper: arXiv:0909.5347, Lemma 1. -/
-theorem isNormal_implies_cumulativeSpan [NeZero D]
-    (A : MPSTensor d D) (hN : IsNormal A) :
-    cumulativeSpan A (D ^ 2) = ⊤ :=
-  cumulativeSpan_eq_top A hN
-
 /-! ## Part 4: Cumulative Wielandt analysis
 
 The paper states the pieces below as Lemma 1, eigenvector extraction in the proof

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -142,8 +142,8 @@ normality-to-spanning input for that fixed-length passage.
 
 ### What we prove:
 - `cumulative_wielandt_bound`: T_{D²}(A) = ⊤ for normal tensors
-- `isNormal_iff_cumulativeSpan_eq_top`: characterization of normality
-  via cumulative span
+- `isNormal_implies_cumulativeSpan_eq_top'`: eventual cumulative spanning
+  from normality
 
 ### Fixed-length passage:
 The conversion from vector spanning to fixed-length matrix spanning is the

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -459,8 +459,8 @@ The results follow~\cite{Sanz2010Quantum}.
     (Theorem~\ref{thm:eigenvector_spreading}).
 \end{proof}
 
-\begin{theorem}[Wielandt bound]\label{thm:wielandt_bound}
-    \lean{MPSTensor.isNormal_implies_cumulativeSpan}
+\begin{theorem}[Cumulative Wielandt bound]\label{thm:cumulative_wielandt_bound}
+    \lean{MPSTensor.cumulative_wielandt_bound}
     \leanok
     \uses{def:cumulative_span, def:normal}
     If $A$ is a normal MPS tensor with bond dimension~$D$,
@@ -480,7 +480,7 @@ The results follow~\cite{Sanz2010Quantum}.
 \end{proof}
 
 \begin{remark}[Explicit blocking-length estimates]\leanok
-    Theorem~\ref{thm:wielandt_bound} gives the $D^2$
+    Theorem~\ref{thm:cumulative_wielandt_bound} gives the $D^2$
     cumulative-span bound.
     The full-rank index bound $\iota(A) \le (D^2 - d + 1) \cdot D^2$
     (Theorem 1 case (1) of \cite{Sanz2010Quantum}) is proved in
@@ -982,7 +982,7 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     The source papers use the quantum Wielandt theorem as an input converting
     normality into injectivity after blocking. In the notation of this chapter,
     the input has two distinct conclusions. First,
-    Theorem~\ref{thm:wielandt_bound} gives cumulative saturation
+    Theorem~\ref{thm:cumulative_wielandt_bound} gives cumulative saturation
     $T_{D^2}(A)=\MN{D}$. This alone is not the injectivity statement used in
     canonical form, because injectivity requires products of one fixed length.
     Second, Lemma~2(b) of~\cite{Sanz2010Quantum}, formalized here through

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -203,7 +203,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:spectral_gap_wielandt}
     \lean{MPSTensor.spectral_gap_of_injective}
     \leanok
-    \uses{thm:spectral_gap, thm:wielandt_bound}
+    \uses{thm:spectral_gap, thm:cumulative_wielandt_bound}
     For an injective trace-preserving MPS tensor, there exists
     $\delta > 0$ such that every eigenvalue $\mu \neq 1$ of the
     transfer map satisfies $|\mu| \le 1 - \delta$.

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -203,7 +203,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:spectral_gap_wielandt}
     \lean{MPSTensor.spectral_gap_of_injective}
     \leanok
-    \uses{thm:spectral_gap, thm:cumulative_wielandt_bound}
+    \uses{thm:spectral_gap}
     For an injective trace-preserving MPS tensor, there exists
     $\delta > 0$ such that every eigenvalue $\mu \neq 1$ of the
     transfer map satisfies $|\mu| \le 1 - \delta$.


### PR DESCRIPTION
### Motivation

- Removes the duplicate cumulative-span theorem `MPSTensor.isNormal_implies_cumulativeSpan` in favor of the existing `MPSTensor.cumulative_wielandt_bound`, which already provides the same implication.
- Renames the blueprint theorem label from the broad `Wielandt bound` to `Cumulative Wielandt bound`, so that the chapter distinguishes the cumulative statement `T_{D^2}(A) = M_D` from the stronger fixed-length/full-rank index statement supplied later through Lemma 2(b).

### Description

- `TNLean/Wielandt/WielandtBound.lean`: removes the redundant theorem `isNormal_implies_cumulativeSpan` — the same implication is already captured by `cumulative_wielandt_bound`.
- `blueprint/src/chapter/ch07_wielandt.tex`: renames theorem label from `Wielandt bound` to `thm:cumulative_wielandt_bound` and updates surrounding prose.
- `blueprint/src/chapter/ch15_correlations.tex`: updates cross-reference to `thm:cumulative_wielandt_bound`.

### Testing

- `lake env lean TNLean/Wielandt/WielandtBound.lean`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `git diff --check`

---

Addresses #1170

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant Lean theorem and updates blueprint references/labels without changing underlying proofs or mathematics.
> 
> **Overview**
> Removes the duplicate Lean theorem `MPSTensor.isNormal_implies_cumulativeSpan` (the D² cumulative-span consequence of normality), relying on the existing `MPSTensor.cumulative_wielandt_bound` instead.
> 
> Updates the blueprint to explicitly name/label the result as the **Cumulative Wielandt bound** and retargets cross-references (including the correlations chapter) from the old `Wielandt bound` wording to `thm:cumulative_wielandt_bound`/`cumulative_wielandt_bound`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6649ec0d08388e115e417cd322f4c8a209d2c8bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: removes a redundant Lean theorem in favor of the existing `cumulative_wielandt_bound` and updates blueprint theorem labels/references without changing proofs or mathematical statements.
> 
> **Overview**
> Renames the surface statement of the D² cumulative-span result to be explicitly the **Cumulative Wielandt bound**: the Lean theorem remains `MPSTensor.cumulative_wielandt_bound`, while the old `isNormal_implies_cumulativeSpan` theorem is removed and replaced by a deprecated alias.
> 
> Updates the blueprint to match this naming by retitling/relabeling the theorem as `thm:cumulative_wielandt_bound` and adjusting surrounding cross-references (including removing the stale `thm:wielandt_bound` dependency mention in the correlations chapter).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5353ce8b7c5e11388de4114318157f38cb633ef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->