### PR TITLE
fix(MPS/Periodic): discharge overlap wrapper proofs

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -280,13 +280,10 @@ lemma exists_sector_match_of_gaugePhaseEquiv
           (MPSTensor (blockPhysDim d m)) hdim)
           (blocksA u))
         (blocksB v) := by
-  -- PROOF STRUCTURE: see lemma
-  -- `exists_sector_match_of_blockedGaugePhaseEquiv_cyclicDecomp` for the
-  -- planned proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicDecomp`
-  -- and `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`.
-  sorry
+  exact exists_sector_match_of_blockedGaugePhaseEquiv_cyclicDecomp
+    A B hA hB blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
+    hA_cyclic hB_cyclic hNondegA hNondegB
+    (gaugePhaseEquiv_blockTensor A B m hGPE)
 
 /-- If no nonzero compressed sector pair matches, then the original periodic
 tensors cannot be globally gauge-phase equivalent. -/
@@ -323,12 +320,12 @@ lemma not_gaugePhaseEquiv_of_no_sector_match
           (blocksA u))
         (blocksB v)) :
     ¬ GaugePhaseEquiv A B := by
-  -- PROOF STRUCTURE: see lemma
-  -- `exists_sector_match_of_gaugePhaseEquiv` for the planned proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicDecomp`
-  -- and `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`.
-  sorry
+  intro hGPE
+  obtain ⟨u, v, hdim, hNondeg, hMatch⟩ :=
+    exists_sector_match_of_gaugePhaseEquiv
+      A B hA hB blocksA blocksB hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv
+      hA_cyclic hB_cyclic hNondegA hNondegB hGPE
+  exact hNoMatch u v hdim hNondeg hMatch
 
 /-- Same-period / no-match statement using compressed sector tensors.
 

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -379,11 +379,9 @@ lemma sectorTensor_proportional_of_blockedMatch
     (hNondeg : ∀ u, dimA u ≠ 0)
     (hNormal : ∀ u, IsNormal (blocksA u)) :
     RepeatedBlocks A B := by
-  -- PROOF STRUCTURE: see lemma
-  -- `repeatedBlocks_of_blockedSectorGaugePhase` for the planned proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `repeatedBlocks_of_blockedSectorGaugePhase`.
-  sorry
+  exact repeatedBlocks_of_blockedSectorGaugePhase
+    A B hA_lc hB_lc blocksA blocksB hA_blocks_lc hB_blocks_lc
+    hA_mpv hB_mpv hA_cyclic hB_cyclic q hBlockMatch hNondeg hNormal
 
 /-- **Case 3: a matching sector implies gauge equivalence**. If two periodic tensors have
 the same period and a compressed sector match exists, then they are related by a gauge

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -824,12 +824,21 @@ theorem periodicSelfOverlap_tendsto
     [NeZero D] (A : MPSTensor d D) {m : ℕ}
     (hP : IsPeriodic m A) :
     Tendsto (fun k => mpvOverlap A A (m * k)) atTop (nhds (m : ℂ)) := by
-  -- PROOF STRUCTURE: see lemma
-  -- `blockTensor_selfOverlap_tendsto_of_cyclicSectorDecomp` for the planned
-  -- proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`.
-  sorry
+  letI : NeZero m := ⟨Nat.ne_of_gt hP.period_pos⟩
+  obtain ⟨dim, blocks, hBlocks_lc, hBlocks_mpv, hCyclic, hNondeg⟩ :=
+    exists_cyclic_sector_decomp_after_blocking_of_isPeriodic A hP
+  have hBlocked :
+      Tendsto
+        (fun k => mpvOverlap (d := blockPhysDim d m)
+          (blockTensor (d := d) (D := D) A m)
+          (blockTensor (d := d) (D := D) A m) k)
+        atTop (nhds (m : ℂ)) :=
+    blockTensor_selfOverlap_tendsto_of_cyclicSectorDecomp
+      A hP blocks hBlocks_lc hBlocks_mpv hCyclic hNondeg
+  refine hBlocked.congr' ?_
+  filter_upwards with k
+  rw [mpvOverlap_blockTensor_self_eq]
+  simp [Nat.mul_comm]
 
 
 end MPSTensor


### PR DESCRIPTION
## Summary
- Prove the periodic self-overlap top-level wrapper by reducing to the blocked cyclic-sector self-overlap theorem.
- Prove the global gauge-phase sector-match wrapper from the blocked-sector statement.
- Prove the no-sector-match contrapositive wrapper.
- Prove the sector proportionality wrapper by forwarding to the isolated full-cycle contraction lemma.

## Proof integrity
These wrappers no longer contain direct Lean placeholders. They intentionally still depend on the existing lower periodic-sector placeholders, including primitive_and_irreducible_sectorBlocks_of_cyclicDecomp, blocked sector uniqueness, sector transport, and the full-cycle contraction theorem, so I did not mark the periodic blueprint theorem fully ready.

## Checks
- lake env lean TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
- lake env lean TNLean/MPS/Periodic/Overlap/Case2.lean
- lake env lean TNLean/MPS/Periodic/Overlap/Case3.lean
- lake build TNLean.MPS.Periodic.Overlap.Case2 TNLean.MPS.Periodic.Overlap.Case3 TNLean.MPS.Periodic.Overlap.SelfOverlap
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: replaces `sorry` placeholders with proof terms in Lean theorems without changing any definitions or runtime behavior.
> 
> **Overview**
> **Discharges previously `sorry`-backed wrapper theorems** in the periodic-overlap development.
> 
> In `Case2.lean`, `exists_sector_match_of_gaugePhaseEquiv` is now proved by reducing to the blocked-tensor sector-match lemma (via `gaugePhaseEquiv_blockTensor`), and `not_gaugePhaseEquiv_of_no_sector_match` is proved by extracting a sector match and contradicting `hNoMatch`.
> 
> In `Case3.lean`, `sectorTensor_proportional_of_blockedMatch` is completed by delegating to `repeatedBlocks_of_blockedSectorGaugePhase`. In `SelfOverlap.lean`, `periodicSelfOverlap_tendsto` is proved by building a cyclic-sector decomposition after blocking, applying the blocked self-overlap limit theorem, and rewriting back with `mpvOverlap_blockTensor_self_eq`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0395fc5615556e43e3868dddfdea584c6fbc9db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->