### PR TITLE
refactor(MPS/CanonicalForm): split commutant inputs

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -159,59 +159,102 @@ theorem isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_s
       (d := d) (dim := dim) μ A hμ hSpan)
     hComm
 
-/-- Canonical-form/BNT data plus finite block-selector words give full product-word span.
+/-- Block injectivity plus finite block-selector words give full product-word span.
 
-The remaining paper-level separation step is the construction of the selector words
-from the BNT non-equivalence hypothesis. Once those selectors are available,
-canonical-form injectivity supplies a one-letter prefix spanning the selected
-block algebra, and concatenating prefix and selector words spans the whole
-product algebra. -/
-theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords
-    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
-    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+Once the selector words are available, only blockwise injectivity is needed:
+a one-letter prefix spans the selected block algebra, and concatenating the
+prefix and selector words spans the whole product algebra. -/
+theorem wordTupleSpanTop_of_hasInjectiveBlocks_of_blockSelectorWords
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hInj : HasInjectiveBlocks (d := d) A) {S : ℕ}
     (hSel : HasBlockSelectorWords A S) :
     WordTupleSpanTop A (1 + S) := by
   refine wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
     (A := A) (L := 1) (S := S) ?_ hSel
   intro k
-  exact isNBlkInjective_one_of_isInjective (hCF.toHasInjectiveBlocks.block_injective k)
+  exact isNBlkInjective_one_of_isInjective (hInj.block_injective k)
 
-/-- Canonical-form/BNT data plus pairwise block-separating word polynomials give
-full product-word span.
+/-- Canonical-form/BNT data plus finite block-selector words give full product-word span. -/
+theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
+    (hSel : HasBlockSelectorWords A S) :
+    WordTupleSpanTop A (1 + S) :=
+  wordTupleSpanTop_of_hasInjectiveBlocks_of_blockSelectorWords A hCF.toHasInjectiveBlocks hSel
+
+/-- Block injectivity plus pairwise block-separating word polynomials give full
+product-word span.
 
 The pairwise hypotheses ask only for a word polynomial separating one ordered
 pair of distinct blocks at a time.  The finite selector assembly in
 `hasBlockSelectorWords_of_pairBlockSeparatingWords` turns these pairwise
 separators into full block selectors, and the selector-word reduction then gives
 product-word span. -/
+theorem wordTupleSpanTop_of_hasInjectiveBlocks_of_pairBlockSeparatingWords
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hInj : HasInjectiveBlocks (d := d) A) {S : ℕ}
+    (hPair : HasPairBlockSeparatingWords A S) :
+    WordTupleSpanTop A (1 + (r - 1) * S) :=
+  wordTupleSpanTop_of_hasInjectiveBlocks_of_blockSelectorWords A hInj
+    (hasBlockSelectorWords_of_pairBlockSeparatingWords A hPair)
+
+/-- Canonical-form/BNT data plus pairwise block-separating word polynomials give
+full product-word span. -/
 theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
     (hPair : HasPairBlockSeparatingWords A S) :
     WordTupleSpanTop A (1 + (r - 1) * S) :=
-  wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords μ A hCF
-    (hasBlockSelectorWords_of_pairBlockSeparatingWords A hPair)
+  wordTupleSpanTop_of_hasInjectiveBlocks_of_pairBlockSeparatingWords A
+    hCF.toHasInjectiveBlocks hPair
 
-/-- Canonical-form/BNT data plus a finite pair trace-separation criterion give
-full product-word span.
+/-- Block injectivity plus a finite pair trace-separation criterion give full
+product-word span.
 
 Once every ordered distinct pair has a common homogeneous trace-separating
 length, pair trace-separation duality gives pairwise separating word
 polynomials, and the selector-word construction spans the full product algebra. -/
+theorem wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingAt
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hInj : HasInjectiveBlocks (d := d) A) {S : ℕ}
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S) :
+    WordTupleSpanTop A (1 + (r - 1) * S) :=
+  wordTupleSpanTop_of_hasInjectiveBlocks_of_pairBlockSeparatingWords A hInj
+    (hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt A hSep)
+
+/-- Canonical-form/BNT data plus a finite pair trace-separation criterion give
+full product-word span. -/
 theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
     (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S) :
     WordTupleSpanTop A (1 + (r - 1) * S) :=
-  wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords μ A hCF
-    (hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt A hSep)
+  wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingAt A
+    hCF.toHasInjectiveBlocks hSep
 
-/-- Canonical-form/BNT data plus cumulative pair trace separation and exact
-identity padding give full product-word span.
+/-- Block injectivity plus cumulative pair trace separation and exact identity
+padding give full product-word span.
 
 The cumulative finite cutoff gives homogeneous separation at length `T` when
 each ordered pair has simultaneous identity padding at the complementary lengths
 needed to reach `T`. -/
+theorem wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingUpTo_of_identity_padding
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hInj : HasInjectiveBlocks (d := d) A) {S T : ℕ}
+    (hST : S ≤ T)
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingUpTo (A k) (A j) S)
+    (hPad : ∀ k j : Fin r, j ≠ k → ∀ l : ℕ, l ≤ S →
+      ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T - l)))) :
+    WordTupleSpanTop A (1 + (r - 1) * T) :=
+  wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingAt A hInj
+    (fun k j hjk =>
+      pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
+        (A k) (A j) hST (hSep k j hjk) (hPad k j hjk))
+
+/-- Canonical-form/BNT data plus cumulative pair trace separation and exact
+identity padding give full product-word span. -/
 theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) {S T : ℕ}
@@ -222,10 +265,23 @@ theorem wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_ide
           (1 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
         Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T - l)))) :
     WordTupleSpanTop A (1 + (r - 1) * T) :=
-  wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF
-    (fun k j hjk =>
-      pairTraceSeparatingAt_of_pairTraceSeparatingUpTo_of_identity_padding
-        (A k) (A j) hST (hSep k j hjk) (hPad k j hjk))
+  wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingUpTo_of_identity_padding
+    A hCF.toHasInjectiveBlocks hST hSep hPad
+
+/-- Positive-length product-word span from block injectivity and
+pairwise block-separating word polynomials. -/
+theorem exists_pos_productWordSpan_of_hasInjectiveBlocks_of_pairBlockSeparatingWords
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hInj : HasInjectiveBlocks (d := d) A) {S : ℕ}
+    (hPair : HasPairBlockSeparatingWords A S) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  refine ⟨1 + (r - 1) * S, Nat.add_pos_left Nat.zero_lt_one _, ?_⟩
+  simpa [WordTupleSpanTop, wordTuple] using
+    wordTupleSpanTop_of_hasInjectiveBlocks_of_pairBlockSeparatingWords A hInj hPair
 
 /-- Positive-length product-word span from canonical-form/BNT data and
 pairwise block-separating word polynomials. -/
@@ -237,10 +293,24 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingW
       Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
         fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
       (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) :=
+  exists_pos_productWordSpan_of_hasInjectiveBlocks_of_pairBlockSeparatingWords A
+    hCF.toHasInjectiveBlocks hPair
+
+/-- Positive-length product-word span obtained from block injectivity and
+the finite pair trace-separation criterion. -/
+theorem exists_pos_productWordSpan_of_hasInjectiveBlocks_of_pairTraceSeparatingAt
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hInj : HasInjectiveBlocks (d := d) A) {S : ℕ}
+    (hSep : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
         ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
   refine ⟨1 + (r - 1) * S, Nat.add_pos_left Nat.zero_lt_one _, ?_⟩
   simpa [WordTupleSpanTop, wordTuple] using
-    wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords μ A hCF hPair
+    wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingAt A hInj hSep
 
 /-- Positive-length product-word span obtained from canonical-form/BNT data and
 the finite pair trace-separation criterion. -/
@@ -252,10 +322,9 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingA
       Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
         fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
       (⊤ : Submodule ℂ
-        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
-  refine ⟨1 + (r - 1) * S, Nat.add_pos_left Nat.zero_lt_one _, ?_⟩
-  simpa [WordTupleSpanTop, wordTuple] using
-    wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt μ A hCF hSep
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) :=
+  exists_pos_productWordSpan_of_hasInjectiveBlocks_of_pairTraceSeparatingAt A
+    hCF.toHasInjectiveBlocks hSep
 
 /-- Positive-length product-word span from canonical-form/BNT separation and
 the source-faithful three-block direct-sum hypotheses.
@@ -618,11 +687,29 @@ theorem
     wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding
       μ A hCF hST hSep hPad
 
+/-- Positive-length product-word span obtained from block injectivity and finite
+block-selector words.
+
+This separates the selector-word hypothesis from the product-span conclusion, anticipating
+the finite selector-word existence theorem. -/
+theorem exists_pos_productWordSpan_of_hasInjectiveBlocks_of_blockSelectorWords
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hInj : HasInjectiveBlocks (d := d) A) {S : ℕ}
+    (hSel : HasBlockSelectorWords A S) :
+    ∃ m : ℕ, 0 < m ∧
+      Submodule.span ℂ (Set.range fun ω : Fin m → Fin d =>
+        fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
+      (⊤ : Submodule ℂ
+        ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+  refine ⟨1 + S, Nat.add_pos_left Nat.zero_lt_one S, ?_⟩
+  simpa [WordTupleSpanTop, wordTuple] using
+    wordTupleSpanTop_of_hasInjectiveBlocks_of_blockSelectorWords A hInj hSel
+
 /-- Positive-length product-word span obtained from canonical-form/BNT data and
 finite block-selector words.
 
-This is the goal shape with the still-missing selector-word theorem
-kept explicit rather than replaced by the conclusion. -/
+This separates the selector-word hypothesis from the product-span conclusion, anticipating
+the finite selector-word existence theorem. -/
 theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A) {S : ℕ}
@@ -632,9 +719,24 @@ theorem exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords
         fun k : Fin r => evalWord (A k) (List.ofFn ω)) =
       (⊤ : Submodule ℂ
         ((k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
-  refine ⟨1 + S, Nat.add_pos_left Nat.zero_lt_one S, ?_⟩
-  simpa [WordTupleSpanTop, wordTuple] using
-    wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords μ A hCF hSel
+  exact exists_pos_productWordSpan_of_hasInjectiveBlocks_of_blockSelectorWords A
+    hCF.toHasInjectiveBlocks hSel
+
+/-- Nonzero weights, block injectivity, and selector words give the projection-span
+input for the assembled tensor. -/
+theorem blockProjection_mem_span_reindexed_toTensorFromBlocks_of_selectorWords
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    (hInj : HasInjectiveBlocks (d := d) A) {S : ℕ}
+    (hSel : HasBlockSelectorWords A S) :
+    ∀ k : Fin r,
+      Matrix.blockProjection (n := fun k : Fin r => Fin (dim k)) (R := ℂ) k ∈
+        Submodule.span ℂ (Set.range fun ω : Fin (1 + S) → Fin d =>
+          Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
+            (evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω))) := by
+  exact blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTupleSpanTop
+    (d := d) (dim := dim) μ A hμ
+    (wordTupleSpanTop_of_hasInjectiveBlocks_of_blockSelectorWords A hInj hSel)
 
 /-- Canonical-form/BNT data and selector words give the projection-span input for
 the assembled tensor. -/
@@ -647,9 +749,30 @@ theorem blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWord
         Submodule.span ℂ (Set.range fun ω : Fin (1 + S) → Fin d =>
           Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm
             (evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω))) := by
-  exact blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTupleSpanTop
+  exact blockProjection_mem_span_reindexed_toTensorFromBlocks_of_selectorWords
     (d := d) (dim := dim) μ A hCF.toHasStrictOrderedNonzeroWeights.mu_ne_zero
-    (wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords μ A hCF hSel)
+    hCF.toHasInjectiveBlocks hSel
+
+/-- Selector-word version of the assembled-tensor commutant criterion.
+
+The finite selectors and block injectivity give the projection-span input; only
+nonzero assembly weights are needed to pass through `toTensorFromBlocks`. -/
+theorem isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_selectorWords
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    (hInj : HasInjectiveBlocks (d := d) A) {S : ℕ}
+    (hSel : HasBlockSelectorWords A S)
+    {X : Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ}
+    (hComm : ∀ ω : Fin (1 + S) → Fin d,
+      X * evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω) =
+        evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω) * X) :
+    Matrix.IsBlockDiagonal'
+      (Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm X) := by
+  exact isBlockDiagonal'_of_commutes_reindexed_wordSpan
+    (B := toTensorFromBlocks (d := d) (μ := μ) A)
+    (blockProjection_mem_span_reindexed_toTensorFromBlocks_of_selectorWords
+      (d := d) (dim := dim) μ A hμ hInj hSel)
+    hComm
 
 /-- Selector-word version of the assembled-tensor commutant criterion.
 
@@ -666,11 +789,9 @@ theorem isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelector
         evalWord (toTensorFromBlocks (d := d) (μ := μ) A) (List.ofFn ω) * X) :
     Matrix.IsBlockDiagonal'
       (Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm X) := by
-  exact isBlockDiagonal'_of_commutes_reindexed_wordSpan
-    (B := toTensorFromBlocks (d := d) (μ := μ) A)
-    (blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords
-      (d := d) (dim := dim) μ A hCF hSel)
-    hComm
+  exact isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_selectorWords
+    (d := d) (dim := dim) μ A hCF.toHasStrictOrderedNonzeroWeights.mu_ne_zero
+    hCF.toHasInjectiveBlocks hSel hComm
 
 /-- Entrywise off-block-zero corollary of
 `isBlockDiagonal'_of_commutes_reindexed_wordSpan`.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3398,40 +3398,53 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     of block-selector words.
 \end{proof}
 
-\begin{lemma}[Product-word span from BNT selector words]
+\begin{lemma}[Product-word span from block-injective selector words]
     \label{lem:product_word_span_from_bnt_selectors}
+    \lean{MPSTensor.wordTupleSpanTop_of_hasInjectiveBlocks_of_blockSelectorWords}
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords}
+    \lean{MPSTensor.wordTupleSpanTop_of_hasInjectiveBlocks_of_pairBlockSeparatingWords}
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingAt}
     \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
+    \lean{MPSTensor.wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingUpTo_of_identity_padding}
+    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_hasInjectiveBlocks_of_pairBlockSeparatingWords}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_hasInjectiveBlocks_of_pairTraceSeparatingAt}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
     \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_identity_period_windows}
     \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_pairSpanTop_period_windows}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows}
+    \lean{MPSTensor.exists_pos_productWordSpan_of_hasInjectiveBlocks_of_blockSelectorWords}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}
+    \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_selectorWords}
     \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords}
+    \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_selectorWords}
     \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords}
     \leanok
     \uses{def:cf_bnt, lem:pair_trace_separation_to_pairwise_selectors,
         lem:pair_trace_separation_homogenization_with_padding,
         lem:block_selectors_from_pairwise_separators,
         lem:block_projection_span_from_product_word_span}
-    Let $((\mu_j),(A_j))$ be in canonical form with BNT separation.  Suppose there are
+    Let $(A_j)$ be a finite family of block-injective tensors.  Suppose there are
     length-$S$ block-selector words: for each sector $k$, a linear combination of
     length-$S$ words evaluates to $I$ on $A_k$ and to $0$ on every other block.
     Then the simultaneous length-$(1+S)$ block-word evaluations span
-    $\prod_j \MN{D_j}$, with positive length.  It is enough, by
-    Lemma~\ref{lem:block_selectors_from_pairwise_separators}, to construct
-    pairwise separators for every ordered pair of distinct blocks; by
+    $\prod_j \MN{D_j}$, with positive length.  In particular, a canonical form
+    with BNT separation supplies the required block injectivity, but the
+    selector-word conclusion does not require the full canonical-form/BNT data.
+    It is enough, by Lemma~\ref{lem:block_selectors_from_pairwise_separators}, to
+    construct pairwise separators for every ordered pair of distinct blocks.
     Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}, a common
     pair trace-separation length is one sufficient finite-dimensional witness.
     This witness remains homogeneous: either it is supplied
     directly as fixed-length pair separation, or it is obtained from an explicit
     period-window hypothesis as in
     Lemma~\ref{lem:pair_trace_separation_homogenization_with_padding}.
-    Consequently, the pulled-back words at the resulting length for
-    $\operatorname{Assemble}(\mu,A)$ span every virtual sector projection, and the
-    corresponding commutant reduction is available.
+    If the assembly weights are all nonzero, then the pulled-back words at the
+    resulting length for $\operatorname{Assemble}(\mu,A)$ span every virtual
+    sector projection, and the corresponding commutant reduction is available.
 \end{lemma}
 
 \begin{proof}
@@ -3440,6 +3453,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         lem:pair_trace_separation_to_pairwise_selectors,
         lem:block_selectors_from_pairwise_separators,
         lem:block_projection_span_from_product_word_span}
+    Block injectivity writes each target sector matrix as a fixed-length linear
+    combination of word evaluations.  For a canonical-form/BNT family,
     Definition~\ref{def:cf_bnt} gives one-site injectivity of each block, hence
     $1$-block injectivity by Lemma~\ref{lem:one_block_injective_of_injective}.
     For a target tuple $(M_j)_j$, write $M_k$ as a


### PR DESCRIPTION
### Motivation

- Slice of #1384: separates the downstream commutant algebra from the restricted strict CF-BNT data, exposing the actual hypotheses consumed by the proofs.
- The core lemmas now require only `HasInjectiveBlocks` plus selector words, nonzero weights, and pair-separation criteria, rather than the full `IsCanonicalFormBNT` predicate.

### Description

- Added split-input word-span lemmas for selector, pair-separation, and pair-trace inputs using `HasInjectiveBlocks` instead of full `IsCanonicalFormBNT` in `TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean` (+162/−40).
- Added split-input projection-span and commutant criteria using only nonzero weights plus block injectivity once selector words are supplied.
- Existing CF-BNT-named lemmas are retained as compatibility formulations that delegate to the more general core lemmas.

### Testing

- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Addresses #1384
Addresses #1170

> [!NOTE]
> **Low Risk**
> Low risk mathematical reorganization that mostly generalizes lemma hypotheses and adds compatibility formulations; primary risk is downstream breakage due to renamed/retargeted theorem statements.
> 
> **Overview**
> **Separates the commutant/word-span reduction into weaker, split hypotheses.** New theorems derive `WordTupleSpanTop` and positive-length product-word spans from `HasInjectiveBlocks` plus selector words, pairwise block-separating words, or pair trace-separation criteria, instead of requiring full `IsCanonicalFormBNT`.
> 
> **Adds split-input projection-span and commutant criteria for assembled tensors.** Introduces selector-word variants that take nonzero assembly weights (`hμ`) and block injectivity (`hInj`) separately, and rewires the existing `IsCanonicalFormBNT`-named results to delegate to these more general lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f425744ee877ade93befdddb66c4fb018f108b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to public theorem/API reshaping (new generalized lemmas and rewired proofs) that may break downstream imports or require updating lemma references, despite no intended change in mathematical conclusions.
> 
> **Overview**
> Refactors the `BlockDiagonalCommutant` proof pipeline to **separate commutant/projection-span and product-word-span conclusions from full `IsCanonicalFormBNT` assumptions**. Core lemmas now take **`HasInjectiveBlocks` + selector/pair-separation hypotheses** (and nonzero assembly weights where needed), while the existing CF-BNT-named theorems are retained as compatibility wrappers delegating to these generalized results.
> 
> Adds new “selector-word” variants that directly derive projection-span and the assembled-tensor commutant/block-diagonality criterion from **nonzero weights + block injectivity + selector words**, plus new positive-length product-word span existence lemmas under the weaker hypotheses. Updates the blueprint (`ch14_parent_hamiltonian.tex`) to reflect the generalized statements and new Lean lemma references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a378e7bf187d2bca0599c5f13a48d9b139b6a60e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->