### PR TITLE
style(MPS/BNT): mark restricted CFBNT wrappers as lemmas

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -41,7 +41,7 @@ lines 317–345.
 
 3. **`isBNT_of_separated_CFBNT_data`** and the bundled-data formulation
    **`IsCanonicalFormBNT.isBNT`**:
-   a canonical-form decomposition into a basis of normal tensors yields a valid `IsBNT`
+   the restricted separated block data give a valid `IsBNT`
    structure, assembling all overlap and independence properties.
 
 4. **`fundamentalTheorem_of_separated_CFBNT_data`** and the bundled-data formulation
@@ -341,7 +341,7 @@ theorem cross_overlap_tendsto_zero_of_separated_CFBNT_data
 
 The only role of `μ` is to specify the block-diagonal tensor `toTensorFromBlocks μ A` and its
 obvious coefficient decomposition.  Strict weight ordering is not used here. -/
-theorem isBNT_of_separated_CFBNT_data [∀ k, NeZero (dim k)]
+lemma isBNT_of_separated_CFBNT_data [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hInj : HasInjectiveBlocks (d := d) A)
@@ -386,8 +386,8 @@ theorem cross_overlap_tendsto_zero
 /-- A canonical-form decomposition into a basis of normal tensors yields a valid `IsBNT`
 structure.
 
-This bundled-data theorem is a direct consequence of `isBNT_of_separated_CFBNT_data`. -/
-theorem isBNT [∀ k, NeZero (dim k)]
+This bundled-data lemma is a direct consequence of `isBNT_of_separated_CFBNT_data`. -/
+lemma isBNT [∀ k, NeZero (dim k)]
     (hCF : IsCanonicalFormBNT μ A) :
     IsBNT (toTensorFromBlocks μ A) r dim A :=
   isBNT_of_separated_CFBNT_data μ A
@@ -493,7 +493,7 @@ theorem cross_overlap_tendsto_zero
 /-- A normal-canonical-form decomposition with BNT separation yields a valid `IsBNT`
 structure once the equivalent blockwise `IsNormal` witnesses (eventual block injectivity) are
 supplied explicitly. -/
-theorem isBNT [∀ k, NeZero (dim k)]
+lemma isBNT [∀ k, NeZero (dim k)]
     (hNCF : IsNormalCanonicalFormBNT μ A)
     (hNormal : ∀ j, IsNormal (A j)) :
     IsBNT (toTensorFromBlocks μ A) r dim A :=
@@ -548,13 +548,13 @@ abbrev ProportionalDecompositionConclusion
             (cast (congr_arg (MPSTensor d) hdim) (A j))
             (B (perm j))
 
-/-- Split-data comparison theorem for separated CF-BNT-style decompositions.
+/-- Split-data comparison lemma for separated CF-BNT-style decompositions.
 
-The theorem only needs the separated pieces of data used by the proportional-MPV argument:
+The lemma only needs the separated pieces of data used by the proportional-MPV argument:
 blockwise injectivity, left-canonical normalization, self-overlap normalization, and the BNT
 non-equivalence condition that forces cross-overlap decay. It is a strict
 special case of the CPSV comparison argument, not the full multiplicity BNT theorem. -/
-theorem fundamentalTheorem_of_separated_CFBNT_data
+lemma fundamentalTheorem_of_separated_CFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -599,13 +599,13 @@ If two families of tensors in canonical-form BNT give rise to proportional MPVs
 of blocks, and blocks match up to permutation, dimension equality, and gauge-phase
 equivalence.
 
-This bundled theorem uses the strict/already-grouped CF-BNT special case. The general
+This bundled lemma uses the strict/already-grouped CF-BNT special case. The general
 CPSV BNT comparison keeps repeated sectors through the multiplicity data handled
 elsewhere in the sector-decomposition surface.
 
-This bundled-data theorem is a direct consequence of
+This bundled-data lemma is a direct consequence of
 `fundamentalTheorem_of_separated_CFBNT_data`. -/
-theorem fundamentalTheorem_of_IsCanonicalFormBNT
+lemma fundamentalTheorem_of_IsCanonicalFormBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -644,11 +644,11 @@ theorem fundamentalTheorem_of_IsCanonicalFormBNT
     ⟨A_total, B_total, aCoeff, bCoeff, aLim, bLim, c, cLim,
       hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
-/-- Split-data comparison theorem for separated normal-CF-BNT-style decompositions.
+/-- Split-data comparison lemma for separated normal-CF-BNT-style decompositions.
 
 This is the normal-form analogue of the strict comparison above. It is
 not the full CPSV multiplicity BNT theorem. -/
-theorem fundamentalTheorem_of_separated_normalCFBNT_data
+lemma fundamentalTheorem_of_separated_normalCFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -689,8 +689,8 @@ theorem fundamentalTheorem_of_separated_normalCFBNT_data
     (_haLim_ne := hDecomp.haLim_ne) (_hbLim_ne := hDecomp.hbLim_ne)
     (hProp := hDecomp.hProp) (hc := hDecomp.hc) (_hcLim_ne := hDecomp.hcLim_ne)
 
-/-- Proportional comparison for restricted normal-CF-BNT decompositions. -/
-theorem fundamentalTheorem_of_IsNormalCanonicalFormBNT
+/-- Proportional comparison lemma for restricted normal-CF-BNT decompositions. -/
+lemma fundamentalTheorem_of_IsNormalCanonicalFormBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/TNLean/MPS/CanonicalForm/Assembly/PrimitiveBlocks.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/PrimitiveBlocks.lean
@@ -21,7 +21,8 @@ blockwise gauge-phase matching.
 * `isIrreducibleTensor_blockTensor_of_tp_primitive_irr` — blocking a
   TP-primitive irreducible tensor preserves irreducibility.
 * `weakFundamentalTheorem_conditional` — proportional MPVs imply block matching
-  for separated TP-primitive normal canonical form data.
+  for restricted separated representative TP-primitive normal canonical form
+  data.
 
 ## References
 
@@ -238,10 +239,11 @@ permutation + gauge-phase matching of blocks.
 
 /-- **Conditional Fundamental Theorem (irreducibility and distinct weights).**
 
-For two tensor families in TP-primitive normal canonical form with BNT separation,
-if their blocked versions have proportional MPVs (with convergent coefficients), then
-the block counts match and blocks are pairwise gauge-phase equivalent (up to
-permutation). This is the corresponding block-matching statement from `Full.lean`. -/
+For two restricted separated representative families in TP-primitive normal canonical form,
+if their blocked versions have proportional MPVs (with convergent coefficients), then the
+block counts match and blocks are pairwise gauge-phase equivalent (up to permutation). The
+full repeated-copy BNT comparison is supplied separately by sector-decomposition and
+multiplicity data. -/
 theorem weakFundamentalTheorem_conditional
     {d' rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3333,13 +3333,14 @@ sector weights.
 	block decomposition.
 \end{proof}
 
-\begin{theorem}[Conditional block matching after blocking]%
+\begin{theorem}[Conditional matching for restricted separated representatives after blocking]%
 	\label{thm:weak_ft_conditional_ch8}
 	\lean{MPSTensor.weakFundamentalTheorem_conditional}
 	\leanok
 	\uses{def:is_normal_canonical_form}
-	Consider two block families in normal canonical form, with no two distinct
-	blocks of the same dimension related by gauge-phase equivalence.
+	Consider two restricted separated representative block families in normal
+	canonical form, with no two distinct blocks of the same dimension related by
+	gauge-phase equivalence.
 	If two tensors decompose into these families with coefficient sequences having
 	nonzero limits, and the two tensors are asymptotically proportional
 	coefficientwise, then the numbers of blocks agree and the blocks match up to
@@ -3349,7 +3350,8 @@ sector weights.
 \begin{proof}\leanok
 	This is the block-matching statement from the multi-block fundamental theorem
 	applied to two decompositions that already satisfy the normal-canonical-form
-	and BNT-separation hypotheses.
+	and separated-representative hypotheses. The repeated-copy BNT comparison is
+	handled later by sector-decomposition and multiplicity data.
 \end{proof}
 
 \begin{theorem}[Common blocking period for two primitive normal tensors]%

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -178,8 +178,8 @@ The main references are
 	Theorem~\ref{thm:cross_overlap_zero_split} applies directly.
 \end{proof}
 
-\begin{theorem}[BNT from explicit blockwise hypotheses]
-	\label{thm:cf_bnt_is_bnt_split}
+\begin{lemma}[BNT from explicit blockwise hypotheses]
+	\label{lem:cf_bnt_is_bnt_split}
 	\lean{MPSTensor.isBNT_of_separated_CFBNT_data}
 	\leanok
 	\uses{def:bnt, def:mpv_overlap}
@@ -188,7 +188,7 @@ The main references are
 	$O_{A_kA_k}(N) \to 1$ for each $k$, and that distinct equal-dimension
 	blocks are not gauge-phase equivalent. Then the blocks form a basis of
 	normal tensors for the block-diagonal tensor $\bigoplus_k \mu_k A_k$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 	\uses{thm:mpv_decomposition, lem:bnt_overlap_orthonormal_li, thm:cross_overlap_zero_split}
@@ -200,19 +200,19 @@ The main references are
 	eventual linear independence required in Definition~\ref{def:bnt}.
 \end{proof}
 
-\begin{theorem}[Canonical form with BNT separation yields a basis of normal tensors]\label{thm:cf_bnt_is_bnt}
+\begin{lemma}[Restricted CF-BNT data yield a basis of normal tensors]\label{lem:cf_bnt_is_bnt}
 	\lean{MPSTensor.IsCanonicalFormBNT.isBNT}
 	\leanok
 	\uses{def:cf_bnt, def:bnt}
 	If $((\mu_k), (A_k))$ is in canonical form with BNT separation, then
 	the block tensors form a basis of normal tensors for the
 	block-diagonal tensor $\bigoplus_k \mu_k A_k$.
-\end{theorem}
+\end{lemma}
 
-\begin{proof}\leanok\uses{def:cf_bnt, thm:cf_bnt_is_bnt_split}
+\begin{proof}\leanok\uses{def:cf_bnt, lem:cf_bnt_is_bnt_split}
 	Definition~\ref{def:cf_bnt} provides injective blocks, left-canonical
 	normalization, normalized self-overlaps, and BNT separation. Hence
-	Theorem~\ref{thm:cf_bnt_is_bnt_split} applies.
+	Lemma~\ref{lem:cf_bnt_is_bnt_split} applies.
 \end{proof}
 
 \begin{remark}[Comparing the two normality conditions]\label{rem:normalcf_bnt_gap}
@@ -227,15 +227,15 @@ The main references are
 	eventual block injectivity needed here.
 \end{remark}
 
-\begin{theorem}[Normal canonical-form BNT data give a BNT]
-	\label{thm:normal_cf_bnt_is_bnt}
+\begin{lemma}[Restricted normal-CF-BNT data give a BNT]
+	\label{lem:normal_cf_bnt_is_bnt}
 	\lean{MPSTensor.IsNormalCanonicalFormBNT.isBNT}
 	\leanok
 	\uses{def:normal_cf_bnt, def:bnt}
 	If a family is in normal canonical form with BNT separation and each block
 	is also known to be normal in the algebraic sense, then the blocks form a
 	basis of normal tensors for the associated block-diagonal tensor.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok\uses{rem:normalcf_bnt_gap}
 	Normal-canonical BNT data already give the block-diagonal MPV expansion,
@@ -453,8 +453,8 @@ The main references are
 	would force gauge-phase equivalence.  This contradicts the hypothesis.
 \end{proof}
 
-\begin{theorem}[Canonical-form proportional decomposition theorem]
-	\label{thm:cf_bnt_ft_proportional}
+\begin{lemma}[Restricted CF-BNT proportional comparison]
+	\label{lem:cf_bnt_ft_proportional}
 	\lean{MPSTensor.fundamentalTheorem_of_IsCanonicalFormBNT}
 	\leanok
 	\uses{def:cf_bnt, thm:bnt_perm_prop}
@@ -462,7 +462,7 @@ The main references are
 	MPV decompositions with convergent nonzero coefficients, then they have
 	the same number of blocks and match blockwise up to permutation,
 	bond-dimension equality, and gauge-phase equivalence.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok\uses{thm:bnt_perm_prop, thm:cross_overlap_zero}
 	Project the two canonical-form hypotheses to blockwise injectivity,
@@ -471,8 +471,8 @@ The main references are
 	proportional decomposition data.
 \end{proof}
 
-\begin{theorem}[Normal-canonical proportional decomposition theorem]
-	\label{thm:normal_cf_bnt_ft_proportional}
+\begin{lemma}[Restricted normal-CF-BNT proportional comparison]
+	\label{lem:normal_cf_bnt_ft_proportional}
 	\lean{MPSTensor.fundamentalTheorem_of_IsNormalCanonicalFormBNT}
 	\leanok
 	\uses{def:normal_cf_bnt, thm:bnt_perm_prop_nt}
@@ -480,7 +480,7 @@ The main references are
 	proportional MPV decompositions with convergent nonzero coefficients,
 	then they have the same number of blocks and match blockwise up to
 	permutation, bond-dimension equality, and gauge-phase equivalence.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok\uses{thm:bnt_perm_prop_nt}
 	Project the two normal-canonical hypotheses to irreducibility,

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -62,7 +62,7 @@ used in this chapter.
 
 \begin{proof}\leanok
     \uses{thm:ft_proportional_nt}
-    This is exactly the normal-canonical-form Fundamental Theorem
+    This is the restricted normal-CF-BNT proportional comparison
     (Theorem~\ref{thm:ft_proportional_nt}).
     The normal canonical form data provide the BNT separation
     and overlap convergence hypotheses;
@@ -197,14 +197,14 @@ obtained after the proportional Fundamental Theorem by matching the BNT blocks,
 then comparing the sector-weight power sums.
 
 We record the comparison statements in the two forms needed below. The
-heterogeneous equal-case theorem, stated as
+restricted heterogeneous equal-case theorem, stated as
 Theorem~\ref{thm:fundamentalTheorem_equalMPV_CFBNT_hetero}, gives the
 block-count, bond-dimension, and gauge-phase matching directly from equality of
 the assembled MPV families. The common-structure theorem below proves the
 global gauge statement when the two sides already share the same block data.
-The remaining source-facing assembly step is to combine the heterogeneous
-matching with sector-weight recovery and the copy-count equalities into one
-global block-diagonal gauge.
+The general CPSV endpoint still passes through sector decompositions, copy-count
+recovery, and sector-weight multiset comparison before one obtains a global
+block-diagonal gauge.
 
 \begin{theorem}[Fundamental Theorem --- equal MPV case, common block structure]\label{thm:ft_equal_same_structure}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_CFBNT}


### PR DESCRIPTION
### Motivation

- Continues the strict CFBNT audit from #1384, following #1354 and #1380.
- Demotes restricted CF-BNT/BNT comparison wrappers from theorem-level to lemma-level, since they are already-grouped special cases, not general CPSV BNT comparison endpoints.
- Tightens Chapter 11 wording to route the equal-MPV case through sector decompositions, copy-count recovery, and sector-weight multiset comparison.

### Description

- `TNLean/MPS/BNT/Construction.lean`: changed `theorem` to `lemma` for restricted CF-BNT declarations (`isBNT_of_separated_CFBNT_data`, `fundamentalTheorem_of_separated_CFBNT_data`, and bundled proportional-comparison wrappers) without modifying names or statements.
- `blueprint/src/chapter/ch10_bnt.tex`: updated statement environments, labels, and cross-references to match lemma status; renamed headings.
- `blueprint/src/chapter/ch11_assembly.tex`: tightened narrative so the general equal-MPV CPSV route explicitly references sector decompositions, copy-count recovery, and sector-weight multiset comparison.

### Testing

- `lake build TNLean.MPS.BNT.Construction TNLean.MPS.FundamentalTheorem.EqualProportional`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Addresses #1384

> [!NOTE]
> **Low Risk**
> Purely presentational changes that reclassify several restricted CF-BNT results from `theorem` to `lemma` in Lean and the blueprint, with minor wording/label updates; no proof logic or statements change.
> 
> **Overview**
> Demotes the restricted/"already-grouped" CF-BNT wrapper results from `theorem` to `lemma` in `TNLean/MPS/BNT/Construction.lean` (e.g. `isBNT_of_separated_CFBNT_data`, `fundamentalTheorem_of_separated_CFBNT_data`, and the bundled proportional-comparison wrappers), clarifying they are special-case helpers rather than paper-level endpoints.
> 
> Updates Chapter 10 blueprint statements, labels, and cross-references to match the lemma status and renames headings accordingly, and tweaks Chapter 11 narrative to emphasize the general equal-MPV CPSV route still proceeds via sector decompositions, copy-count recovery, and sector-weight multiset comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c50c9fffd9cfa3ac96a32ed91631ddd52b990d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: these are presentational reclassifications (`theorem`→`lemma`) plus blueprint wording/label updates, with no changes to statements or proof logic.
> 
> **Overview**
> Reclassifies the restricted/already-grouped CF-BNT wrapper results in `MPS/BNT/Construction.lean` from `theorem` to `lemma` (including `isBNT_of_separated_CFBNT_data`, the bundled `isBNT` lemmas, and the restricted proportional-comparison wrappers), to clarify they are helper special cases rather than full CPSV endpoints.
> 
> Updates the blueprint (Ch. 8/10/11) to match the new lemma status by adjusting statement environments/labels/cross-references, and tightens Ch. 11 narrative to explicitly route the general equal-MPV CPSV result through sector decomposition, copy-count recovery, and sector-weight multiset comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dccfbf207d43923b14bfb4177449ca4e3d8fb5de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->