### PR TITLE
doc(MPS/FT): trace final theorem target

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -194,8 +194,8 @@ the common primitive nonzero-sector families obtained after blocking, there is a
 blocking after which the two tensors admit BNT sector
 decompositions with the same sector MPV family, matched basis-sector multiplicities, and matched
 sector-weight multisets up to nonzero phases.  The `comparison` field is an independent
-hypothesis of this theorem; the result does not derive it from `SameMPV₂`. -/
-theorem fundamentalTheorem_afterBlocking_of_comparisonHypotheses
+hypothesis of this lemma; the result does not derive it from `SameMPV₂`. -/
+lemma fundamentalTheorem_afterBlocking_of_comparisonHypotheses
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)

--- a/TNLean/MPS/CanonicalForm/Assembly/PrimitiveBlocks.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/PrimitiveBlocks.lean
@@ -226,10 +226,10 @@ theorem tp_primitive_irreducible_extra_blocking [NeZero D]
       (d := d) (D := D) A hTP hPrim hIrr hk
 
 /-!
-## Conditional Fundamental Theorem: proportional MPVs → block matching
+## Conditional block matching: proportional MPVs → matched blocks
 
 This combines the full reduction data with the block-matching conclusions
-of the fundamental theorem.
+available for restricted normal-CF-BNT data.
 
 For two arbitrary tensors A, B with proportional MPVs, the reduction produces
 blocked TP-primitive decompositions. Under the additional hypotheses needed
@@ -237,14 +237,14 @@ for `IsNormalCanonicalForm` (irreducibility and distinct weight norms), one obta
 permutation + gauge-phase matching of blocks.
 -/
 
-/-- **Conditional Fundamental Theorem (irreducibility and distinct weights).**
+/-- **Conditional block matching for restricted normal-CF-BNT data.**
 
 For two restricted separated representative families in TP-primitive normal canonical form,
 if their blocked versions have proportional MPVs (with convergent coefficients), then the
 block counts match and blocks are pairwise gauge-phase equivalent (up to permutation). The
 full repeated-copy BNT comparison is supplied separately by sector-decomposition and
 multiplicity data. -/
-theorem weakFundamentalTheorem_conditional
+lemma weakFundamentalTheorem_conditional
     {d' rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/TNLean/MPS/FundamentalTheorem/CoefficientConvergence.lean
+++ b/TNLean/MPS/FundamentalTheorem/CoefficientConvergence.lean
@@ -10,8 +10,9 @@ import Mathlib.Analysis.SpecificLimits.Normed
 
 This module proves the geometric strict-dominance facts for normalized
 coefficients `(μ k / μ 0)^N` and provides an equivalent formulation of the
-proportional Fundamental Theorem that derives the structural BNT data from
-canonical-form hypotheses.
+restricted CF-BNT proportional comparison that derives the structural BNT data
+from canonical-form hypotheses while still assuming the needed coefficient
+convergence data.
 
 The ratio convergence lemmas are auxiliary. They are not the source paper's
 BNT coefficient theorem: away from a single surviving dominant sector the
@@ -40,8 +41,8 @@ an adjusted proportionality constant; equivalently, the dominant factors `μ₀^
 into `c`.
 
 ### `fundamentalTheorem_proportionalMPV_CFBNT_auto`
-Reformulation of the proportional Fundamental Theorem that derives the BNT
-decomposition data from `IsCanonicalFormBNT`. Its remaining hypotheses are:
+Reformulation of the restricted CF-BNT proportional comparison that derives the
+BNT decomposition data from `IsCanonicalFormBNT`. Its remaining hypotheses are:
 - Two CF-BNT families
 - A proportionality constant `c : ℕ → ℂ` with
   `mpv(toTensorFromBlocks μA A) σ = c N * mpv(toTensorFromBlocks μB B) σ`
@@ -218,9 +219,10 @@ theorem proportional_normalized_of_proportional
   rw [div_pow, ← inv_pow]
   ring
 
-/-! ## Self-contained Fundamental Theorem (Theorem 4.4)
+/-! ## Conditional CF-BNT proportional comparison adapter
 
-The auto version derives the BNT decomposition data from the canonical form structure.
+The auto version derives the BNT decomposition data from the canonical form structure,
+but it still assumes explicit coefficient convergence data.
 The user only needs to supply:
 1. Two CF-BNT families with proportional block-diagonal MPVs
 2. Coefficients and their limits for the re-weighted decomposition
@@ -244,9 +246,8 @@ needed convergent nonzero coefficient data is therefore recorded as explicit hyp
 - The proportionality `mpv(A_total) = c_N * mpv(B_total)`
 - Convergent decomposition coefficients `aCoeff`, `bCoeff` with nonzero limits
 - The convergence of the proportionality constant `c` -/
-/-- Self-contained CF-BNT proportional FT version using the assembled theorem from
-`FundamentalTheoremFull`. -/
-theorem fundamentalTheorem_proportionalMPV_CFBNT_auto
+/-- Conditional CF-BNT proportional comparison using the assembled comparison lemma. -/
+lemma fundamentalTheorem_proportionalMPV_CFBNT_auto
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -16,15 +16,16 @@ states in canonical form with basis-of-normal-tensors (BNT) separation.
 ### Equal-MPV comparison with common block structure
 (`fundamentalTheorem_equalMPV_CFBNT`)
 
-This is the common-block-structure specialization of the equal case: if two BNT canonical
-forms share the same `μ`-weights, block count, and block dimensions, and generate equal
-MPVs for all system sizes, then the corresponding blocks are gauge equivalent and the
-assembled block-diagonal tensors are gauge equivalent.
+This lemma is the common-block-structure specialization of the equal case: if two BNT
+canonical forms already share the same `μ`-weights, block count, and block dimensions, and
+generate equal MPVs for all system sizes, then the corresponding blocks are gauge equivalent
+and the assembled block-diagonal tensors are gauge equivalent.  The source-paper corollary
+also has to derive this common block structure from the BNT coefficient comparison.
 
 ### Proportional-MPV comparison with explicit coefficient limits
 (`fundamentalTheorem_proportionalMPV_CFBNT`)
 
-This theorem proves the block-matching conclusion under the coefficient hypotheses used by
+This lemma proves the block-matching conclusion under the coefficient hypotheses used by
 the proportional-MPV argument. The decomposition coefficients, their limits, and the
 non-vanishing of those limits are explicit assumptions. The extraction of these
 coefficients from the hypotheses of the source-paper theorem is not part of this statement.
@@ -65,8 +66,11 @@ block weights `μ`, the same number of blocks `r`, and the same block dimensions
 `dim`, and generate equal MPV families for all system sizes, then:
 
 (i)  per-block gauge equivalence: `GaugeEquiv (A k) (B k)` for all `k`;
-(ii) global gauge equivalence of the block-diagonal tensors. -/
-theorem fundamentalTheorem_equalMPV_CFBNT
+(ii) global gauge equivalence of the block-diagonal tensors.
+
+This is a strict common-block lemma, not the full source-paper equal-MPV corollary: the
+matching of BNT multiplicities and weights is already built into the common data. -/
+lemma fundamentalTheorem_equalMPV_CFBNT
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ}
     (A B : (k : Fin r) → MPSTensor d (dim k))
@@ -78,8 +82,8 @@ theorem fundamentalTheorem_equalMPV_CFBNT
   fundamentalTheorem_canonicalForm μ A B hA.toIsCanonicalForm hA.mu_strict_anti
     hB.block_injective hB.leftCanonical hSame
 
-/-- **Equal-MPV FT for CF-BNT with explicit gauge matrices.** -/
-theorem fundamentalTheorem_equalMPV_CFBNT_explicit
+/-- **Common-block equal-MPV comparison with explicit gauge matrices.** -/
+lemma fundamentalTheorem_equalMPV_CFBNT_explicit
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ}
     (A B : (k : Fin r) → MPSTensor d (dim k))
@@ -115,7 +119,7 @@ abbrev BlockPermutationGaugeWitness
             (cast (congr_arg (MPSTensor d) hdim) (A j))
             (B (perm j))
 
-theorem fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data
+lemma fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -172,7 +176,7 @@ MPV families (with explicitly convergent nonzero decomposition coefficients), th
 and then the subdominant ratios decay. In the general BNT setting of the source papers,
 however, the coefficients are sums `Σ_q μ_{j,q}^N` and need not converge without
 extra input. -/
-theorem fundamentalTheorem_proportionalMPV_CFBNT
+lemma fundamentalTheorem_proportionalMPV_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -203,7 +207,7 @@ theorem fundamentalTheorem_proportionalMPV_CFBNT
     cLim hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
 
 /-- Split-data proportional-MPV comparison for normal-CF-BNT-style data. -/
-theorem fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data
+lemma fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -242,7 +246,7 @@ theorem fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data
       hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
 /-- Proportional-MPV comparison for normal canonical form blocks. -/
-theorem fundamentalTheorem_proportionalMPV_normalCFBNT
+lemma fundamentalTheorem_proportionalMPV_normalCFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -279,7 +283,7 @@ section Corollaries
 
 /-- **Per-block SameMPV from CF-BNT equal MPVs.**
 
-Extracts the per-block `SameMPV` conclusion from the equal-MPV theorem. -/
+Extracts the per-block `SameMPV` conclusion from the common-block equal-MPV lemma. -/
 lemma perBlock_sameMPV_of_equalMPV_CFBNT
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ}

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -5,26 +5,30 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.FundamentalTheorem.Full.BlocksMatch
 
 /-!
-# Full Fundamental Theorem of MPS — Heterogeneous Equal Case
+# Heterogeneous BNT block matching
 
-This module contains **Theorem 5**: the self-contained equal-case fundamental theorem for
-heterogeneous `IsCanonicalFormBNT` families. It is the entry point that exposes the
-constructions developed in three supporting sub-modules and provides the public theorem
-`fundamentalTheorem_equalMPV_CFBNT_hetero`.
+This module contains the heterogeneous block-matching lemma for canonical-form BNT
+families.  It exposes the constructions developed in three supporting sub-modules and
+provides the public lemma `fundamentalTheorem_equalMPV_CFBNT_hetero`.
 
-For Theorems 1–4 (equal-MPV FT, proportional-MPV FT, equal ⟹ proportional, power-sum
-multiset equality) and combined corollaries, see
+The source-paper equal-MPV corollary is stronger: after the BNT blocks have been matched,
+it compares the repeated-copy coefficients and obtains one global gauge for the original
+canonical-form tensors.  The lemma in this file proves the block-count, dimension, and
+gauge-phase matching part only.
+
+For common-block and proportional comparison lemmas, see
 `TNLean.MPS.FundamentalTheorem.EqualProportional`.
 
 ## Main statements
 
-### Theorem 5: Self-contained equal-case FT for heterogeneous CF-BNT
+### Heterogeneous equal-MPV block matching
 (`fundamentalTheorem_equalMPV_CFBNT_hetero`)
 
 Given two `IsCanonicalFormBNT` families with *different* block structures
 (`rA`, `rB`, `dimA`, `dimB`, `μA`, `μB`), the hypothesis `SameMPV₂` alone (no coefficient
 convergence data from the caller) forces block-count equality, a block permutation, and
-blockwise gauge-phase equivalence.
+blockwise gauge-phase equivalence.  It does not yet produce the global weighted gauge
+conclusion of Corollary II.2 in the source paper.
 
 ## Implementation notes
 
@@ -52,29 +56,27 @@ The proof is split across supporting sub-modules for readability:
 
 ## Tags
 
-matrix product states, fundamental theorem, BNT, heterogeneous, gauge-phase equivalence
+matrix product states, BNT, heterogeneous, block matching, gauge-phase equivalence
 -/
 
 open scoped Matrix BigOperators
 
 namespace MPSTensor
 
-/-- **Self-contained equal-case Fundamental Theorem for heterogeneous CF-BNT**
-([CPSV21, Corollary IV.5] / [CPSV17, Theorem 4.4 + equal-case corollary]).
+/-- **Heterogeneous equal-MPV block matching for CF-BNT families.**
 
 Given two `IsCanonicalFormBNT` families with *different* block structures
 (`rA`, `rB`, `dimA`, `dimB`, `μA`, `μB`), the hypothesis `SameMPV₂` for the assembled
-block-diagonal tensors — with **no** coefficient convergence data from the caller —
+block-diagonal tensors, with no coefficient convergence data from the caller,
 forces:
 1. Equal block counts: `rA = rB`.
 2. A block permutation: `perm : Fin rA ≃ Fin rB`.
 3. Blockwise gauge-phase equivalence: for each `j`, `dimA j = dimB (perm j)` and
    `GaugePhaseEquiv (cast … (A j)) (B (perm j))`.
 
-Unlike `fundamentalTheorem_proportionalMPV_CFBNT`, this theorem requires **no** explicit
-`aCoeff`, `bCoeff`, `aLim`, `bLim` arguments. The
-coefficient convergence question that plagues the general proportional-case theorem is
-bypassed entirely: the BNT decomposition identity
+This lemma is not the full equal-MPV corollary of the source paper.  It does not compare
+the repeated-copy coefficient power sums and does not construct one global gauge for the
+original canonical-form tensors.  Instead, the BNT decomposition identity
   `∑_j (μA j)^N * mpv(A j) σ = ∑_k (μB k)^N * mpv(B k) σ`
 is analyzed directly via the overlap dichotomy (CPSV17 Appendix A), yielding per-block
 gauge-phase matching.
@@ -92,7 +94,7 @@ The proof delegates to `blocks_match_of_sameMPV₂_CFBNT`, which is fully proved
 - Matching injectivity (BNT separation + GPE cross-overlap norm → 1): fully proved.
 - `rA = rB` (injective maps on finite types): fully proved.
 - Permutation construction and per-block data extraction: fully proved. -/
-theorem fundamentalTheorem_equalMPV_CFBNT_hetero
+lemma fundamentalTheorem_equalMPV_CFBNT_hetero
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3333,8 +3333,8 @@ sector weights.
 	block decomposition.
 \end{proof}
 
-\begin{theorem}[Conditional matching for restricted separated representatives after blocking]%
-	\label{thm:weak_ft_conditional_ch8}
+\begin{lemma}[Conditional matching for restricted separated representatives after blocking]%
+	\label{lem:weak_ft_conditional_ch8}
 	\lean{MPSTensor.weakFundamentalTheorem_conditional}
 	\leanok
 	\uses{def:is_normal_canonical_form}
@@ -3345,10 +3345,10 @@ sector weights.
 	nonzero limits, and the two tensors are asymptotically proportional
 	coefficientwise, then the numbers of blocks agree and the blocks match up to
 	permutation and gauge-phase equivalence.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
-	This is the block-matching statement from the multi-block fundamental theorem
+	This is the block-matching statement for decompositions
 	applied to two decompositions that already satisfy the normal-canonical-form
 	and separated-representative hypotheses. The repeated-copy BNT comparison is
 	handled later by sector-decomposition and multiplicity data.

--- a/blueprint/src/chapter/ch11_assembly.tex
+++ b/blueprint/src/chapter/ch11_assembly.tex
@@ -22,20 +22,20 @@ irreducible-form framework of \cite{DeLasCuevas2017Irreducible},
 which gives a fundamental theorem valid for periodic tensors directly,
 with an extra $Z$-gauge degree of freedom.
 
-\section{Conditional Fundamental Theorem}%
+\section{Conditional Block Matching}%
 \label{sec:assembly_weak}
 
-The following theorem combines the reduction to canonical form
+The following lemma combines the reduction to canonical form
 (zero-block separation, TP gauge, blocking, primitivity)
-with the Fundamental Theorem for normal canonical form.
+with the restricted normal-CF-BNT proportional comparison.
 It is still conditional on the two post-blocking hypotheses left open in
 Chapter~\ref{ch:canonical}: irreducibility for the blocked sectors and
 pairwise distinct nonzero weight norms.
 The direct periodic route of Chapter~\ref{ch:periodic_ft_apps} is not
 used in this chapter.
 
-\begin{theorem}[Conditional Fundamental Theorem]%
-    \label{thm:weak_ft_conditional}
+\begin{lemma}[Conditional block matching from restricted normal-CF-BNT data]%
+    \label{lem:weak_ft_conditional}
     \lean{MPSTensor.weakFundamentalTheorem_conditional}
     \leanok
     \uses{def:is_normal_canonical_form, def:gauge_phase_equiv}
@@ -58,12 +58,12 @@ used in this chapter.
     Then $g_A = g_B$ and there is a permutation $\pi$ such that
     $D_j^A = D_{\pi(j)}^B$ and $A_j$ is gauge-phase equivalent to
     $B_{\pi(j)}$ for every~$j$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
-    \uses{thm:ft_proportional_nt}
+    \uses{lem:ft_proportional_nt}
     This is the restricted normal-CF-BNT proportional comparison
-    (Theorem~\ref{thm:ft_proportional_nt}).
+    (Lemma~\ref{lem:ft_proportional_nt}).
     The normal canonical form data provide the BNT separation
     and overlap convergence hypotheses;
     the non-degeneracy condition (no two distinct blocks in the same
@@ -75,7 +75,7 @@ used in this chapter.
 \section{Restricted Proportional Comparisons}%
 \label{sec:assembly_proportional}
 
-\begin{theorem}[Proportional comparison for restricted CF-BNT data]\label{thm:ft_proportional}
+\begin{lemma}[Proportional comparison for restricted CF-BNT data]\label{lem:ft_proportional}
 	\lean{MPSTensor.fundamentalTheorem_proportionalMPV_CFBNT}
 	\leanok
 	\uses{def:cf_bnt, def:gauge_phase_equiv}
@@ -101,7 +101,7 @@ used in this chapter.
 	Then $g_A = g_B$, and there is a permutation $\pi$ such that
 	$D_j^A = D_{\pi(j)}^B$ and $A_j$ is gauge-phase equivalent to
 	$B_{\pi(j)}$ for each~$j$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -122,7 +122,7 @@ used in this chapter.
 \begin{remark}[Coefficient arrays for canonical-form decompositions]
 	\label{rem:cf_coeff_arrays}
 	In applications the coefficient arrays in
-	Theorem~\ref{thm:ft_proportional} come from the block-diagonal
+	Lemma~\ref{lem:ft_proportional} come from the block-diagonal
 	decomposition itself. If
 	\[
 		A_{\mathrm{tot}} = \bigoplus_{j=1}^{g_A} \mu_j^A A_j,
@@ -141,11 +141,11 @@ used in this chapter.
 	$b_{N,k} = (\mu_k^B)^N$, while the sequence $c_N$ is the global
 	proportionality factor from the hypothesis
 	$V^{(N)}(A_{\mathrm{tot}}) = c_N V^{(N)}(B_{\mathrm{tot}})$.
-	Theorem~\ref{thm:ft_proportional} keeps these arrays explicit because
+	Lemma~\ref{lem:ft_proportional} keeps these arrays explicit because
 	Theorem~\ref{thm:bnt_perm_prop} is formulated in that abstract form.
 \end{remark}
 
-\begin{theorem}[Proportional comparison for restricted normal-CF-BNT data]\label{thm:ft_proportional_nt}
+\begin{lemma}[Proportional comparison for restricted normal-CF-BNT data]\label{lem:ft_proportional_nt}
 		\lean{MPSTensor.fundamentalTheorem_proportionalMPV_normalCFBNT}\leanok
 		\uses{def:normal_cf_bnt, def:gauge_phase_equiv}
 		Let $A_{\mathrm{tot}}$ and $B_{\mathrm{tot}}$ be MPS tensors
@@ -170,7 +170,7 @@ used in this chapter.
 		Then $g_A = g_B$, and there is a permutation $\pi$ such that
 		$D_j^A = D_{\pi(j)}^B$ and $A_j$ is gauge-phase equivalent to
 		$B_{\pi(j)}$ for each~$j$.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
 		\uses{thm:ncf_overlap_tendsto_one, thm:nt_modulus_one_gauge, rem:normalcf_bnt_gap}
@@ -186,7 +186,7 @@ used in this chapter.
 		this separated normal-canonical level.
 \end{proof}
 
-\section{Equal-MPV Fundamental Theorem}%
+\section{Equal-MPV Comparisons}%
 \label{sec:assembly_equal}
 
 The source corollary for equal MPVs says that if two canonical-form tensors
@@ -197,16 +197,16 @@ obtained after the proportional Fundamental Theorem by matching the BNT blocks,
 then comparing the sector-weight power sums.
 
 We record the comparison statements in the two forms needed below. The
-restricted heterogeneous equal-case theorem, stated as
-Theorem~\ref{thm:fundamentalTheorem_equalMPV_CFBNT_hetero}, gives the
+restricted heterogeneous equal-case lemma, stated as
+Lemma~\ref{lem:fundamentalTheorem_equalMPV_CFBNT_hetero}, gives the
 block-count, bond-dimension, and gauge-phase matching directly from equality of
-the assembled MPV families. The common-structure theorem below proves the
+the assembled MPV families. The common-structure lemma below proves the
 global gauge statement when the two sides already share the same block data.
-The general CPSV endpoint still passes through sector decompositions, copy-count
+The general CPSV theorem still passes through sector decompositions, copy-count
 recovery, and sector-weight multiset comparison before one obtains a global
 block-diagonal gauge.
 
-\begin{theorem}[Fundamental Theorem --- equal MPV case, common block structure]\label{thm:ft_equal_same_structure}
+\begin{lemma}[Common-block equal-MPV comparison]\label{lem:ft_equal_same_structure}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_CFBNT}
 	\leanok
 	\uses{def:cf_bnt, def:gauge_equiv}
@@ -220,7 +220,7 @@ block-diagonal gauge.
 	generate the same MPV family, then each pair $(A_k, B_k)$ is
 	gauge equivalent, and hence the corresponding block-diagonal tensors
 	are gauge equivalent.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
 	\leanok
@@ -1304,8 +1304,8 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	side by nonzero sector phases.
 \end{definition}
 
-\begin{theorem}[After-blocking comparison from supplied BNT-cover data]%
-\label{thm:fundamental_theorem_after_blocking_comparison_hypotheses}
+\begin{lemma}[After-blocking comparison from supplied BNT-cover data]%
+\label{lem:fundamental_theorem_after_blocking_comparison_hypotheses}
 	\lean{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}
 	\leanok
 	\uses{def:after_blocking_fundamental_theorem_hypotheses,
@@ -1328,7 +1328,7 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	it derives the after-blocking conclusion once the zero-tail,
 	trace-preserving normalization, primitivity, irreducibility, positive
 	bond-dimension, and BNT-cover comparison inputs are supplied.
-\end{theorem}
+\end{lemma}
 
 	\begin{proof}
 		\leanok
@@ -1365,8 +1365,8 @@ BNT-cover inputs needed by the zero-block sector comparison below.
 	matrix; this is the equal-case corollary of the Fundamental Theorem in
 	\cite{Cirac2016MPDO_arXiv}, restated in \cite{Cirac2021Matrix}.
 
-	The comparison theorems in this chapter cover this latter part of the
-	argument.  Theorem~\ref{thm:ft_equal_same_structure} proves the common block-structure
+	The comparison statements in this chapter cover this latter part of the
+	argument.  Lemma~\ref{lem:ft_equal_same_structure} proves the common block-structure
 	special case, and Lemma~\ref{lem:route_b_equal_with_copies} recovers the
 	copy counts and sector-weight multisets from the multiplicity data.  The
 	basis-of-normal-tensors construction

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -633,8 +633,8 @@ literature theorem is not yet a single unconditional Lean statement.
     proportionality $\mathcal{V}(A_{\mathrm{tot}}) = \lambda_N
     \mathcal{V}(B_{\mathrm{tot}})$ with $\lambda_N \to \lambda \neq 0$, then the
     bases of periodic tensors match up to the same repeated-block/gauge freedom as
-    above.  This extends Theorems~\ref{thm:ft_proportional}
-    and~\ref{thm:ft_proportional_nt} to the periodic setting while isolating the
+    above.  This extends Lemmas~\ref{lem:ft_proportional}
+    and~\ref{lem:ft_proportional_nt} to the periodic setting while isolating the
     remaining coefficient-extraction input from irreducible-form assembly.
 \end{remark}
 

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1251,12 +1251,12 @@ which is then combined with overlap estimates and the leading-block peel.
 \end{proof}
 
 %% ---------------------------------------------------------
-\section{Heterogeneous equal-case result}%
+\section{Heterogeneous equal-case block matching}%
 \label{sec:hetero_equal_case_ft}
 %% ---------------------------------------------------------
 
-\begin{theorem}[Heterogeneous equal-case Fundamental Theorem]%
-    \label{thm:fundamentalTheorem_equalMPV_CFBNT_hetero}
+\begin{lemma}[Heterogeneous equal-case block matching]%
+    \label{lem:fundamentalTheorem_equalMPV_CFBNT_hetero}
     \lean{MPSTensor.fundamentalTheorem_equalMPV_CFBNT_hetero}
     \leanok
     \uses{def:same_mpv, def:cf_bnt, def:gauge_phase_equiv}
@@ -1269,7 +1269,7 @@ which is then combined with overlap estimates and the leading-block peel.
     gauge-phase equivalent.
     This is the block-matching conclusion, not yet the final global weighted
     gauge-equivalence statement for the assembled tensors.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}
     \leanok

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -85,7 +85,7 @@ The source BNT characterization selects one representative from each
 phase-gauge equivalence class and compares the power sums of weights.  The
 formalization separates this into overlap decay, eventual linear independence,
 permutation rigidity, sector-weight comparison, and phase absorption.  The
-heterogeneous block-matching theorem is a genuine formal endpoint for the
+heterogeneous block-matching theorem is a genuine formal conclusion for the
 block-matching part, while the final global weighted gauge equivalence remains
 the paper-level equal-MPV target.
 The overlap-to-linear-independence and change-of-basis declarations are
@@ -159,6 +159,49 @@ should not remain as a headline theorem in the paper-level blueprint.
 The non-periodic Fundamental Theorem route should be read with the following
 separation of proof roles.
 
+\subsection{Final target trace-back}
+
+For the non-periodic route, the source target is the Fundamental Theorem for
+canonical-form MPS and its equal-MPV corollary, after the tensor has been put in
+normal form and the periodicity has been removed by blocking.  In the notation
+of \cite[lines~347--356]{Cirac2016MPDO_arXiv}, the proportional statement
+compares two canonical-form tensors with the same family of MPVs up to a scalar
+sequence and concludes a block permutation, phases, and blockwise gauges.  The
+equal-MPV corollary is the special case in which the scalar sequence is
+identically \(1\), but the proof still passes through the BNT coefficient
+comparison.
+
+The formal route currently has three distinct layers that should not be
+identified with one another.
+\begin{enumerate}
+  \item The single-block injective theorem
+    \path{MPSTensor.fundamentalTheorem_singleBlock} is the injective-block
+    gauge theorem.  It is a source-level theorem only for one injective block,
+    not for the multi-block BNT comparison.
+  \item The strict canonical-form BNT declarations
+    \path{MPSTensor.fundamentalTheorem_proportionalMPV_CFBNT} and
+    \path{MPSTensor.fundamentalTheorem_equalMPV_CFBNT} are strict
+    representative forms.  Their exact restrictions are recorded in the
+    paragraph on paper-level targets below.
+  \item The sector-decomposition theorem
+    \path{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching}
+    is the current formal statement closest to the BNT part of the source
+    proof: from a supplied sector-basis matching, linear independence, and
+    equality of total MPV families, it proves the corresponding equality of
+    sector-weight multisets, up to the phases in the matching.  The source-level
+    equal-MPV corollary is obtained only after the sector-basis matching itself
+    is derived from the source hypotheses.
+\end{enumerate}
+
+Thus the proof gap is not that the paper has many hidden Fundamental Theorems.
+Rather, the paper suppresses the formal separation between deriving the BNT
+comparison data from the source hypotheses and applying the existing comparison
+theorems to that data.  The remaining theorem-level work is to obtain the
+sector matching, copy-count equalities, and fixed-length direct-sum span
+hypotheses from the source assumptions.  Once those inputs are available, the
+existing strict and sector-decomposition statements combine to give the
+paper-level theorem; they are not additional paper theorems.
+
 \paragraph{Paper-level targets.}
 The proportional canonical-form theorem and the equal-MPV corollary are the
 source targets.  Their source proof is formulated after choosing BNT
@@ -169,20 +212,21 @@ representatives and retaining the repeated-copy coefficients
 \]
 The current strict-representative declarations
 \path{fundamentalTheorem_proportionalMPV_CFBNT} and
-\path{fundamentalTheorem_equalMPV_CFBNT} are therefore special-case endpoints:
-they apply after the repeated-copy structure has been eliminated or supplied as
-explicit coefficient data.  They should not be cited as the general
-arXiv:1606.00608 theorem unless the missing BNT multiplicity comparison has
-already been discharged.  Heterogeneous variants that state the permutation,
-phases, gauges, and weight matching for possibly different sector indices are
-legitimate theorem endpoints only when their hypotheses are obtained from the
-same BNT comparison.
+\path{fundamentalTheorem_equalMPV_CFBNT} are therefore special-case statements.
+The proportional comparison assumes explicit coefficient data; the equal-MPV
+common-block comparison assumes the repeated-copy structure has already been
+matched into common weights and dimensions.  Neither statement should be cited
+as the general arXiv:1606.00608 theorem unless the missing BNT multiplicity
+comparison has already been discharged.  Heterogeneous variants that state the
+permutation, phases, gauges, and weight matching for possibly different sector
+indices are legitimate theorem statements only when their hypotheses are
+obtained from the same BNT comparison.
 
-\paragraph{Conditional after-blocking consumers.}
+\paragraph{Conditional after-blocking statements.}
 The after-blocking comparison theorems are useful only after the source
 canonical-form, BNT selection, block-injective span, and BNT matching inputs have
 been supplied.  The common-phase-cover and BNT-cover formulations are
-conditional consumers of those inputs.  They should stay visibly conditional
+conditional statements using those inputs.  They should stay visibly conditional
 until the hypotheses are produced from the paper's assumptions.  In particular,
 the finite-length span or phase-cover assumptions are not extra hypotheses in
 the source theorem; they are the formal names for proof inputs that still have
@@ -250,7 +294,7 @@ paper-level theorems.
       \texttt{perBlock\_sameMPV\_of\_equalMPV\_CFBNT}
     \]
     is only the extraction of the blockwise equality conclusion from the
-    equal-MPV theorem.  Neither should be counted as an additional source-level
+    common-block equal-MPV lemma.  Neither should be counted as an additional source-level
     Fundamental Theorem.
   \item The implication
     \[


### PR DESCRIPTION
## Summary

- Add a final target trace-back section to `docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`.
- Separate the single-block injective theorem, restricted strict CF-BNT comparison lemmas, and the sector-decomposition statement closest to the BNT source proof.
- Demote explicit-coefficient proportional CF-BNT comparison statements from theorem to lemma level in Lean and Chapter 11.
- Demote common-block and heterogeneous equal-MPV block-matching statements from theorem to lemma level, and document that they are not the full CPSV equal-MPV corollary.
- Demote conditional after-blocking and weak normal-CF-BNT block-matching statements from theorem to lemma level because their missing comparison inputs remain explicit hypotheses.
- Retitle Chapter 8 / Chapter 11 / Chapter 13 entries so conditional block matching and common-block or heterogeneous equal-MPV comparisons are not presented as the full source theorem.

Addresses #1392. Related to #1282 and #1170.

## Validation

- `lake env lean TNLean/MPS/FundamentalTheorem/EqualProportional.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/CoefficientConvergence.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly/PrimitiveBlocks.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Assembly.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are naming/documentation-level (theorem→lemma demotions and blueprint text/labels) with no apparent changes to proof logic, but it may require downstream updates to references due to renamed declarations.
> 
> **Overview**
> Reframes several “Fundamental Theorem” statements as *restricted comparison/block-matching lemmas* rather than full source-paper endpoints by demoting multiple Lean declarations from `theorem` to `lemma` (after-blocking comparison, conditional block matching, common-block equal-MPV, proportional-MPV with explicit coefficient limits, and heterogeneous equal-MPV block matching) and updating their docstrings accordingly.
> 
> Updates the blueprint (chapters 8/11/13 and periodic FT notes) to match the new lemma status: renames sections/titles, adjusts labels/references (`thm:`→`lem:`), and adds a new “final target trace-back” discussion in `docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex` clarifying which results are strict/conditional adapters vs the remaining paper-level equal-MPV corollary work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 929456bd9bea0d9f47c7fa10c36dd1b3c6977e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->