### PR TITLE
doc(ci): clarify mention trigger locations

### DIFF
--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -506,7 +506,10 @@ default enabled behavior.
 
 ### To ask Claude for help directly
 
-Write a comment on any issue or PR that includes `@claude` followed by your request. For example:
+For existing issues and PRs, write a comment that includes `@claude` followed by
+the request.  For a new issue, the issue title or body may contain `@claude`;
+that triggers the same responder on `issues: opened` or `issues: assigned`.
+Examples:
 - `@claude fix the sorry in line 42 of TNLean/MPS/Basic.lean`
 - `@claude why does this tactic fail?`
 - `@claude refactor this proof to use simp instead`

--- a/docs/pr_review_management.md
+++ b/docs/pr_review_management.md
@@ -139,8 +139,22 @@ gh api "repos/$REPO/pulls/$PR/reviews" --jq '.[] | "REVIEW [\(.user.login)] stat
 
 ## How @codex and @claude Respond
 
-### @codex/@claude only trigger from COMMENTS, not issue/PR body
-Putting `@codex` or `@claude` in the body text when creating an issue does nothing. They only trigger from **comments** posted after creation. Must post a separate comment to activate them.
+### Mention trigger locations
+The current workflows do not all have the same trigger surface.
+
+- `@claude` triggers from issue comments, PR review comments, PR reviews, and
+  issue title/body text on `issues: opened` or `issues: assigned`.
+- `@chatgpt` triggers the Codex workflow from issue comments, PR review
+  comments, PR reviews, and issue title/body text.  The repository uses
+  `@chatgpt`, not `@codex`, to avoid colliding with the OpenAI Codex GitHub
+  Connector handle.
+- PR bodies do not trigger either mention handler; post a PR comment or review
+  comment for existing PR work.
+
+For issue-started work, putting the mention and the request directly in the new
+issue body is valid. Posting a separate comment remains useful when the issue
+body should stay as a stable specification and the agent instruction should be a
+separate operational request.
 
 ### Issue comments vs PR comments — critical distinction
 

--- a/docs/pr_review_management.md
+++ b/docs/pr_review_management.md
@@ -158,14 +158,14 @@ separate operational request.
 
 ### Issue comments vs PR comments — critical distinction
 
-| Where you post | @codex behavior | @claude behavior |
+| Where you post | `@chatgpt` / Codex workflow behavior | `@claude` behavior |
 |---|---|---|
-| **Issue comment** | Creates a **new branch from main**, writes code from scratch. Cannot see any existing PR branch. | Creates a **new branch from main**, writes code from scratch. Same as codex. |
-| **PR comment** | Runs a cloud task on the PR's diff. **CAN push fix commits** to the branch (confirmed: pushed to #215, #214, #213, #200, #198, #133). Sometimes fails with "Codex couldn't complete this request" (#212, #211, #206, #201, #196, #167, #91). Also posts review comments. Works on `]` branches! | Checks out **that PR's branch**, can push fix commits to it. BUT fails on branches with `]` in the name (all codex branches) due to `claude-code-action` branch name validation. |
+| **Issue comment** | Creates a **new branch from main**, writes code from scratch. Cannot see any existing PR branch. | Creates a **new branch from main**, writes code from scratch. Same as the Codex workflow. |
+| **PR comment** | Runs a cloud task on the PR's diff. **CAN push fix commits** to the branch (confirmed: pushed to #215, #214, #213, #200, #198, #133). Sometimes fails with "Codex couldn't complete this request" (#212, #211, #206, #201, #196, #167, #91). Also posts review comments. Works on `]` branches! | Checks out **that PR's branch**, can push fix commits to it. BUT fails on branches with `]` in the name (Codex-created branches from old bracketed issue titles) due to `claude-code-action` branch name validation. |
 | **Merged PR comment** | May trigger but no useful effect. | May trigger but no useful effect. |
 
 ### Key implications
-1. **@codex on issues = fresh start from main.** It will never see the existing PR's code. Good for: creating replacement PRs. Bad for: reviewing or fixing existing PRs.
+1. **`@chatgpt` on issues = fresh start from main.** It will never see the existing PR's code. Good for: creating replacement PRs. Bad for: reviewing or fixing existing PRs.
 2. **@claude on PRs = works on that branch.** Good for: pushing fix commits to an existing PR. Bad for: codex branches (name has `]`).
 3. **Neither can rebase.** Must do locally.
 4. **@codex cannot fetch other branches.** Sandboxed environment blocks `git fetch` (HTTP 403). Asking it to "review branch X" or "push to branch Y" will always fail.


### PR DESCRIPTION
### Motivation

- `docs/pr_review_management.md` stated that Claude/Codex mentions only trigger from comments, but the live workflows also support issue title/body mentions on issue open/assignment.
- The direct-help section in `docs/ci-automation.md` described new-issue body mentions as invalid, which is no longer accurate.

### Description

- Document the real Claude and ChatGPT/Codex mention trigger surfaces in `docs/pr_review_management.md`.
- Clarify that PR bodies do not trigger mention handlers.
- Update the direct-help section in `docs/ci-automation.md` so new-issue body mentions are not described as invalid.

### Testing

- `git diff --check`
- Documentation-only change; no Lean build required.

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update clarifying where `@claude`/`@chatgpt` mentions are detected; no workflow or code changes.
> 
> **Overview**
> Updates CI/review docs to reflect the actual mention-handler trigger surfaces.
> 
> Clarifies that `@claude` and `@chatgpt` can be invoked from issue title/body on `issues: opened`/`assigned` (in addition to comments/reviews), while PR bodies still do not trigger handlers, and adjusts the "ask Claude for help" instructions accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0c415626d385408e4cc6e1f3b8635d96ac52f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits clarifying where `@claude`/`@chatgpt` mention handlers trigger; no workflow or runtime behavior changes.
> 
> **Overview**
> Updates CI/review documentation to accurately describe where automation mention handlers trigger.
> 
> Clarifies that `@claude` and `@chatgpt` can be invoked from issue title/body on `issues: opened`/`assigned` in addition to comments/reviews, and explicitly notes that PR bodies do *not* trigger mention handlers (use PR comments/reviews instead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326d97978732c936dfac2ea826955e23d29fcf4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->