### PR TITLE
doc(MPS/FundamentalTheorem, MPS/BNT): rewrite sector/BNT docstrings with leading formulas

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -14,8 +14,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 /-!
 # Basis of normal tensors from canonical form
 
-This module introduces `IsCanonicalFormBNT`: a predicate on a family of tensors
-`A_j` with weights `μ_j` that requires
+This module introduces `IsCanonicalFormBNT`: hypotheses on a family of tensors
+`A_j` with weights `μ_j` that require
 
 * `IsCanonicalForm` — the tensors are in left-canonical form, with antitone weight moduli,
 * strict ordering `‖μ_j‖ > ‖μ_{j+1}‖`, and
@@ -23,8 +23,8 @@ This module introduces `IsCanonicalFormBNT`: a predicate on a family of tensors
 
 Equivalent blocks are therefore already merged into a single BNT representative.
 This is not the general BNT normal form of arXiv:1606.00608, which allows repeated
-copies inside a sector with coefficients `μ_{j,q}` and multiplicities `M_j` — those terms
-is obtained from `SectorDecomposition` and the sector-weight comparison theorems.
+copies inside a sector with coefficients `μ_{j,q}` and multiplicities `M_j`; those are
+obtained from `SectorDecomposition` and the sector-weight comparison theorems.
 
 ## Main results
 
@@ -34,8 +34,8 @@ is obtained from `SectorDecomposition` and the sector-weight comparison theorems
 
 2. **`cross_overlap_tendsto_zero_of_separated_CFBNT_data`**: distinct CF-BNT blocks have
    decaying cross-overlaps.  The theorem
-   **`IsCanonicalFormBNT.cross_overlap_tendsto_zero`** states the same conclusion under
-   the predicate `IsCanonicalFormBNT`. The proof combines:
+   **`IsCanonicalFormBNT.cross_overlap_tendsto_zero`** states the same conclusion from
+   `IsCanonicalFormBNT`. The proof combines:
    - Dimension-mismatch case: `mpvOverlap_tendsto_zero_of_dim_ne`
    - Same-dimension case: `mpvOverlap_tendsto_zero` (using `blocks_not_equiv` to supply
      `¬GaugePhaseEquiv`)
@@ -59,8 +59,8 @@ tensors uses summed coefficients `c_j(N) = Σ_{q in group j} μ_{j,q}^N`.
 In the strict-dominance branch one first normalizes by the dominant weight, so the relevant
 coefficients are `(μ j / μ 0)^N` and the discarded factor `μ 0^N` is absorbed into the overall
 proportionality constant. In the grouped setting, the normalized sums can still oscillate: unit-
-modulus terms may survive inside a single group. The present `IsCanonicalFormBNT` predicate
-sidesteps that issue by requiring that the grouping has already been done (each block in the
+modulus terms may survive inside a single group. The present `IsCanonicalFormBNT` hypotheses
+sidestep that issue by requiring that the grouping has already been done (each block in the
 basis of normal tensors corresponds to a single CF block), and the proportional-case theorem
 below takes the required convergent coefficient limits as explicit hypotheses.
 -/
@@ -79,7 +79,7 @@ abbrev BlocksNotGaugePhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
     ∀ h : dim j = dim k,
       ¬ GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (A j)) (A k)
 
-/-! ### `IsCanonicalFormBNT` predicate -/
+/-! ### `IsCanonicalFormBNT` hypotheses -/
 
 /-- **Canonical form with basis-of-normal-tensors (BNT) separation**: extends
 `IsCanonicalForm` with the requirement that distinct blocks are not gauge-phase equivalent
@@ -163,19 +163,19 @@ theorem IsCanonicalForm.toIsCanonicalFormBNT_of_distinct_dims
     hCF.toHasNormalizedSelfOverlap
     (fun _ _ hjk h => absurd (hDistinct h) hjk)
 
-/-! ### `IsNormalCanonicalFormBNT` predicate -/
+/-! ### `IsNormalCanonicalFormBNT` hypotheses -/
 
 /-- Normal canonical form with BNT separation: extends `IsNormalCanonicalForm` with
 the requirement that distinct blocks are not gauge-phase equivalent and that the
 block weight moduli `‖μ_j‖` are **strictly decreasing**.
 
-This predicate keeps one representative per strict weight-modulus class. It does
+These hypotheses keep one representative per strict weight-modulus class. They do
 not retain repeated equal-modulus sectors; the full multiplicity structure (weights
 `μ_{j,q}` and multiplicities `M_j` as in arXiv:1606.00608) is recorded in
 `SectorDecomposition` and the sector-weight comparison theorems.
 
 **Formalization note.** `IsNormalCanonicalFormBNT` uses the spectral/primitive-transfer-map
-version of normality (`IsNormalCanonicalForm`), while the later `IsBNT` predicate asks
+version of normality (`IsNormalCanonicalForm`), while the later `IsBNT` hypotheses ask
 for blockwise `IsNormal` (the equivalent algebraic eventual-block-injectivity notion).
 The primitive-to-normal implication must be supplied explicitly when passing to `IsBNT`. -/
 structure IsNormalCanonicalFormBNT {r : ℕ} {dim : Fin r → ℕ}
@@ -460,7 +460,7 @@ theorem spans_mpv_and_eventually_li_of_separated_normalCFBNT_data [∀ k, NeZero
 /-- Separated-hypotheses version of `IsNormalCanonicalFormBNT.isBNT`.
 
 Here `hNCF` supplies normality via the primitive-transfer-map characterization from
-`IsNormalCanonicalForm`, while `hNormal` supplies the equivalent algebraic `IsNormal` predicate
+`IsNormalCanonicalForm`, while `hNormal` supplies the equivalent algebraic `IsNormal` hypotheses
 (eventual block injectivity) required by `IsBNT`. In applications `hNormal` comes from the
 Wielandt / primitive-to-normal implication. -/
 theorem isBNT_of_separated_normalCFBNT_data [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -12,7 +12,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
 /-!
-# Construction of basis-of-normal-tensors data from canonical form
+# Basis of normal tensors from canonical form
 
 This module introduces `IsCanonicalFormBNT`: a predicate on a family of tensors
 `A_j` with weights `μ_j` that requires
@@ -23,7 +23,7 @@ This module introduces `IsCanonicalFormBNT`: a predicate on a family of tensors
 
 Equivalent blocks are therefore already merged into a single BNT representative.
 This is not the general BNT normal form of arXiv:1606.00608, which allows repeated
-copies inside a sector with coefficients `μ_{j,q}` and multiplicities `M_j` — that data
+copies inside a sector with coefficients `μ_{j,q}` and multiplicities `M_j` — those terms
 is obtained from `SectorDecomposition` and the sector-weight comparison theorems.
 
 ## Main results
@@ -32,23 +32,25 @@ is obtained from `SectorDecomposition` and the sector-weight comparison theorems
    distinct blocks are gauge-phase equivalent and the representative weight moduli are
    strictly decreasing.
 
-2. **`cross_overlap_tendsto_zero_of_separated_CFBNT_data`** and the bundled-data formulation
-   **`IsCanonicalFormBNT.cross_overlap_tendsto_zero`**: distinct CF-BNT blocks have decaying
-   cross-overlaps. The proof combines:
+2. **`cross_overlap_tendsto_zero_of_separated_CFBNT_data`**: distinct CF-BNT blocks have
+   decaying cross-overlaps.  The theorem
+   **`IsCanonicalFormBNT.cross_overlap_tendsto_zero`** states the same conclusion under
+   the predicate `IsCanonicalFormBNT`. The proof combines:
    - Dimension-mismatch case: `mpvOverlap_tendsto_zero_of_dim_ne`
    - Same-dimension case: `mpvOverlap_tendsto_zero` (using `blocks_not_equiv` to supply
      `¬GaugePhaseEquiv`)
 
-3. **`isBNT_of_separated_CFBNT_data`** and the bundled-data formulation
-   **`IsCanonicalFormBNT.isBNT`**:
-   the restricted separated block data give a valid `IsBNT`
-   structure, assembling all overlap and independence properties.
+3. **`isBNT_of_separated_CFBNT_data`**: the restricted separated block hypotheses give
+   a valid `IsBNT` structure with the required overlap and independence properties.
+   The lemma **`IsCanonicalFormBNT.isBNT`** states the same implication under
+   `IsCanonicalFormBNT`.
 
-4. **`fundamentalTheorem_of_separated_CFBNT_data`** and the bundled-data formulation
-   **`fundamentalTheorem_of_IsCanonicalFormBNT`**: if two CF-BNT decompositions generate
-   proportional MPVs with convergent nonzero coefficients, then the blocks match up to
-   permutation, dimension equality, and gauge-phase equivalence. This connects
-   canonical/BNT split data to the hypotheses of `BNT/PermutationRigidity`.
+4. **`fundamentalTheorem_of_separated_CFBNT_data`**: if two CF-BNT decompositions
+   generate proportional MPVs with convergent nonzero coefficients, then the blocks
+   match up to permutation, dimension equality, and gauge-phase equivalence. The theorem
+   **`fundamentalTheorem_of_IsCanonicalFormBNT`** states the same implication under
+   `IsCanonicalFormBNT`. This connects the separated canonical/BNT hypotheses to
+   `BNT/PermutationRigidity`.
 
 ## Design note on coefficients
 
@@ -60,7 +62,7 @@ proportionality constant. In the grouped setting, the normalized sums can still 
 modulus terms may survive inside a single group. The present `IsCanonicalFormBNT` predicate
 sidesteps that issue by requiring that the grouping has already been done (each block in the
 basis of normal tensors corresponds to a single CF block), and the proportional-case theorem
-below takes whatever convergent coefficient data it needs as explicit hypotheses.
+below takes the required convergent coefficient limits as explicit hypotheses.
 -/
 
 open scoped Matrix BigOperators
@@ -106,16 +108,16 @@ namespace IsCanonicalFormBNT
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
-/-- Project CF-BNT data to blockwise injectivity. -/
+/-- Project CF-BNT hypotheses to blockwise injectivity. -/
 def toHasInjectiveBlocks (hCF : IsCanonicalFormBNT μ A) : HasInjectiveBlocks (d := d) A :=
   hCF.toIsCanonicalForm.toHasInjectiveBlocks
 
-/-- Project CF-BNT data to left-canonical block-family normalization. -/
+/-- Project CF-BNT hypotheses to left-canonical block-family normalization. -/
 def toIsLeftCanonicalBlockFamily (hCF : IsCanonicalFormBNT μ A) :
     IsLeftCanonicalBlockFamily (d := d) A :=
   hCF.toIsCanonicalForm.toIsLeftCanonicalBlockFamily
 
-/-- Project restricted CF-BNT data to strict weight data.
+/-- Project restricted CF-BNT hypotheses to strict weight inequalities.
 
 This projection is for the already-grouped single-representative special case, not
 for the full CPSV multiplicity BNT surface. -/
@@ -124,7 +126,7 @@ def toHasStrictOrderedNonzeroWeights (hCF : IsCanonicalFormBNT μ A) :
   mu_strict_anti := hCF.mu_strict_anti
   mu_ne_zero := hCF.toIsCanonicalForm.mu_ne_zero
 
-/-- Project CF-BNT data to self-overlap normalization. -/
+/-- Project CF-BNT hypotheses to self-overlap normalization. -/
 def toHasNormalizedSelfOverlap (hCF : IsCanonicalFormBNT μ A) :
     HasNormalizedSelfOverlap (d := d) A :=
   hCF.toIsCanonicalForm.toHasNormalizedSelfOverlap
@@ -168,7 +170,7 @@ the requirement that distinct blocks are not gauge-phase equivalent and that the
 block weight moduli `‖μ_j‖` are **strictly decreasing**.
 
 This predicate keeps one representative per strict weight-modulus class. It does
-not retain repeated equal-modulus sectors; that full multiplicity data (weights
+not retain repeated equal-modulus sectors; the full multiplicity structure (weights
 `μ_{j,q}` and multiplicities `M_j` as in arXiv:1606.00608) is recorded in
 `SectorDecomposition` and the sector-weight comparison theorems.
 
@@ -191,22 +193,22 @@ namespace IsNormalCanonicalFormBNT
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
-/-- Project normal-CF-BNT data to blockwise irreducibility. -/
+/-- Project normal-CF-BNT hypotheses to blockwise irreducibility. -/
 def toHasIrreducibleBlocks (hNCF : IsNormalCanonicalFormBNT μ A) :
     HasIrreducibleBlocks (d := d) A :=
   hNCF.toIsNormalCanonicalForm.toHasIrreducibleBlocks
 
-/-- Project normal-CF-BNT data to left-canonical block-family normalization. -/
+/-- Project normal-CF-BNT hypotheses to left-canonical block-family normalization. -/
 def toIsLeftCanonicalBlockFamily (hNCF : IsNormalCanonicalFormBNT μ A) :
     IsLeftCanonicalBlockFamily (d := d) A :=
   hNCF.toIsNormalCanonicalForm.toIsLeftCanonicalBlockFamily
 
-/-- Project normal-CF-BNT data to blockwise primitive transfer maps. -/
+/-- Project normal-CF-BNT hypotheses to blockwise primitive transfer maps. -/
 def toHasPrimitiveBlocks (hNCF : IsNormalCanonicalFormBNT μ A) :
     HasPrimitiveBlocks (d := d) A :=
   hNCF.toIsNormalCanonicalForm.toHasPrimitiveBlocks
 
-/-- Project restricted normal-CF-BNT data to strict weight data.
+/-- Project restricted normal-CF-BNT hypotheses to strict weight inequalities.
 
 This projection is for the already-grouped single-representative special case, not
 for the full CPSV multiplicity BNT surface. -/
@@ -215,7 +217,7 @@ def toHasStrictOrderedNonzeroWeights (hNCF : IsNormalCanonicalFormBNT μ A) :
   mu_strict_anti := hNCF.mu_strict_anti
   mu_ne_zero := hNCF.toIsNormalCanonicalForm.mu_ne_zero
 
-/-- Project normal-CF-BNT data to self-overlap normalization. -/
+/-- Project normal-CF-BNT hypotheses to self-overlap normalization. -/
 def toHasNormalizedSelfOverlap [∀ k, NeZero (dim k)]
     (hNCF : IsNormalCanonicalFormBNT μ A) :
     HasNormalizedSelfOverlap (d := d) A :=
@@ -304,14 +306,14 @@ lemma exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal
   obtain ⟨N0, hN0⟩ := Filter.mem_atTop_sets.mp hOrtho
   exact ⟨N0, fun N hN => hN0 N (le_of_lt hN)⟩
 
-/-! ### Cross-overlap decay from separated CF-BNT data -/
+/-! ### Cross-overlap decay from separated CF-BNT hypotheses -/
 
 section SeparatedCFBNT
 
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
-/-- Split-data version of CF-BNT cross-overlap decay.
+/-- Separated-hypotheses version of CF-BNT cross-overlap decay.
 
 Only injectivity, left-canonical normalization, and the BNT non-equivalence assumption are used. -/
 theorem cross_overlap_tendsto_zero_of_separated_CFBNT_data
@@ -337,7 +339,7 @@ theorem cross_overlap_tendsto_zero_of_separated_CFBNT_data
       (hLeft.leftCanonical k)
       hdim
 
-/-- Split-data version of `IsCanonicalFormBNT.isBNT`.
+/-- Separated-hypotheses version of `IsCanonicalFormBNT.isBNT`.
 
 The only role of `μ` is to specify the block-diagonal tensor `toTensorFromBlocks μ A` and its
 obvious coefficient decomposition.  Strict weight ordering is not used here. -/
@@ -369,7 +371,7 @@ variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 /-- **Cross-overlap decay for CF-BNT blocks**: distinct blocks have
 `mpvOverlap (A j) (A k) N → 0` as `N → ∞`.
 
-This bundled-data theorem is a direct consequence of
+This theorem is a direct consequence of
 `cross_overlap_tendsto_zero_of_separated_CFBNT_data`. -/
 theorem cross_overlap_tendsto_zero
     [∀ k, NeZero (dim k)]
@@ -386,7 +388,7 @@ theorem cross_overlap_tendsto_zero
 /-- A canonical-form decomposition into a basis of normal tensors yields a valid `IsBNT`
 structure.
 
-This bundled-data lemma is a direct consequence of `isBNT_of_separated_CFBNT_data`. -/
+This lemma is a direct consequence of `isBNT_of_separated_CFBNT_data`. -/
 lemma isBNT [∀ k, NeZero (dim k)]
     (hCF : IsCanonicalFormBNT μ A) :
     IsBNT (toTensorFromBlocks μ A) r dim A :=
@@ -398,14 +400,14 @@ lemma isBNT [∀ k, NeZero (dim k)]
 
 end IsCanonicalFormBNT
 
-/-! ### Cross-overlap decay from separated normal-CF-BNT data -/
+/-! ### Cross-overlap decay from separated normal-CF-BNT hypotheses -/
 
 section SeparatedNormalCFBNT
 
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
-/-- Split-data version of normal-CF-BNT cross-overlap decay.
+/-- Separated-hypotheses version of normal-CF-BNT cross-overlap decay.
 
 Only irreducibility, left-canonical normalization, and the BNT non-equivalence
 assumption are used. -/
@@ -432,7 +434,7 @@ theorem cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
       (hLeft.leftCanonical k)
       hdim
 
-/-- The NT hypotheses already supply the `spans_mpv` and `eventually_li` data used by the
+/-- The NT hypotheses already supply the `spans_mpv` and `eventually_li` hypotheses used by the
 proportional-FT / permutation arguments. The only missing ingredient for a full `IsBNT`
 construction is blockwise `IsNormal`. -/
 theorem spans_mpv_and_eventually_li_of_separated_normalCFBNT_data [∀ k, NeZero (dim k)]
@@ -455,7 +457,7 @@ theorem spans_mpv_and_eventually_li_of_separated_normalCFBNT_data [∀ k, NeZero
             hNCF.toIsLeftCanonicalBlockFamily
             hBlocks i j hij)
 
-/-- Split-data version of `IsNormalCanonicalFormBNT.isBNT`.
+/-- Separated-hypotheses version of `IsNormalCanonicalFormBNT.isBNT`.
 
 Here `hNCF` supplies normality via the primitive-transfer-map characterization from
 `IsNormalCanonicalForm`, while `hNormal` supplies the equivalent algebraic `IsNormal` predicate

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -14,17 +14,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 /-!
 # Construction of basis-of-normal-tensors data from canonical form
 
-This module introduces `IsCanonicalFormBNT`, a restricted already-grouped canonical-form
-predicate. It extends `IsCanonicalForm` with strict ordering of weight moduli and the
-requirement that distinct blocks are not gauge-phase equivalent, so equivalent blocks have
-already been merged and each remaining block is a chosen BNT representative.
+This module introduces `IsCanonicalFormBNT`: a predicate on a family of tensors
+`A_j` with weights `μ_j` that requires
 
-This is not the general BNT normal form of arXiv:1606.00608.  The paper allows repeated
-copies inside a BNT sector, with coefficients `μ_{j,q}` and multiplicities `M_j`; that
-general comparison data is represented by `SectorDecomposition` and the sector-weight
-comparison theorems.  It is also not the paper's "block-injective canonical form" (biCF),
-which is the separate exact-length direct-sum span condition from arXiv:1606.00608,
-lines 317–345.
+* `IsCanonicalForm` — the tensors are in left-canonical form, with antitone weight moduli,
+* strict ordering `‖μ_j‖ > ‖μ_{j+1}‖`, and
+* distinct blocks with equal dimension are not gauge-phase equivalent.
+
+Equivalent blocks are therefore already merged into a single BNT representative.
+This is not the general BNT normal form of arXiv:1606.00608, which allows repeated
+copies inside a sector with coefficients `μ_{j,q}` and multiplicities `M_j` — that data
+is obtained from `SectorDecomposition` and the sector-weight comparison theorems.
 
 ## Main results
 
@@ -163,19 +163,19 @@ theorem IsCanonicalForm.toIsCanonicalFormBNT_of_distinct_dims
 
 /-! ### `IsNormalCanonicalFormBNT` predicate -/
 
-/-- Normal canonical form with basis-of-normal-tensors (BNT) separation: extends
-`IsNormalCanonicalForm` with the requirement that distinct blocks are not gauge-phase equivalent
-and that the block weight moduli are **strictly decreasing**.
+/-- Normal canonical form with BNT separation: extends `IsNormalCanonicalForm` with
+the requirement that distinct blocks are not gauge-phase equivalent and that the
+block weight moduli `‖μ_j‖` are **strictly decreasing**.
 
-Here `IsNormalCanonicalForm` encodes the spectral / primitive-transfer-map version of
-normality with non-increasing moduli. This predicate is the restricted,
-already-grouped analogue of the BNT comparison data: it keeps one representative per
-strict norm class and therefore does not represent the full CPSV multiplicity
-BNT surface, where repeated equal-modulus sectors are retained.
+This predicate keeps one representative per strict weight-modulus class. It does
+not retain repeated equal-modulus sectors; that full multiplicity data (weights
+`μ_{j,q}` and multiplicities `M_j` as in arXiv:1606.00608) is recorded in
+`SectorDecomposition` and the sector-weight comparison theorems.
 
-The later `IsBNT` predicate instead asks for blockwise `IsNormal`, i.e. the
-equivalent algebraic eventual-block-injectivity notion, so the primitive-to-normal
-implication must be supplied explicitly when passing from this predicate to `IsBNT`. -/
+**Formalization note.** `IsNormalCanonicalFormBNT` uses the spectral/primitive-transfer-map
+version of normality (`IsNormalCanonicalForm`), while the later `IsBNT` predicate asks
+for blockwise `IsNormal` (the equivalent algebraic eventual-block-injectivity notion).
+The primitive-to-normal implication must be supplied explicitly when passing to `IsBNT`. -/
 structure IsNormalCanonicalFormBNT {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) : Prop extends
     IsNormalCanonicalForm μ A where
@@ -548,12 +548,18 @@ abbrev ProportionalDecompositionConclusion
             (cast (congr_arg (MPSTensor d) hdim) (A j))
             (B (perm j))
 
-/-- Split-data comparison lemma for separated CF-BNT-style decompositions.
+/-- **Proportional comparison lemma for CF-BNT decompositions.**
 
-The lemma only needs the separated pieces of data used by the proportional-MPV argument:
-blockwise injectivity, left-canonical normalization, self-overlap normalization, and the BNT
-non-equivalence condition that forces cross-overlap decay. It is a strict
-special case of the CPSV comparison argument, not the full multiplicity BNT theorem. -/
+Given two families of tensors `A_j`, `B_k` in canonical form with BNT separation
+(distinct blocks not gauge-phase equivalent), and a proportional decomposition
+of their MPVs with convergent nonzero coefficients, this lemma concludes that the
+families have the same number of blocks, and blocks match up to permutation,
+dimension equality, and gauge-phase equivalence.
+
+This is a special case of the CPSV comparison argument (arXiv:1606.00608) where
+each block already represents a distinct gauge-phase class; it does not cover the
+full multiplicity theorem where repeated equal-modulus sectors contribute via
+power sums `∑_q μ_{j,q}^N`. -/
 lemma fundamentalTheorem_of_separated_CFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -592,19 +598,19 @@ lemma fundamentalTheorem_of_separated_CFBNT_data
     (_haLim_ne := hDecomp.haLim_ne) (_hbLim_ne := hDecomp.hbLim_ne)
     (hProp := hDecomp.hProp) (hc := hDecomp.hc) (_hcLim_ne := hDecomp.hcLim_ne)
 
-/-- **Proportional comparison for restricted CF-BNT decompositions.**
+/-- **Proportional comparison for CF-BNT decompositions.**
 
-If two families of tensors in canonical-form BNT give rise to proportional MPVs
-(with convergent nonzero coefficients), then the families have the same number
-of blocks, and blocks match up to permutation, dimension equality, and gauge-phase
-equivalence.
+If two families of tensors `A_j`, `B_k` satisfy `IsCanonicalFormBNT` and give rise
+to proportional MPVs with convergent nonzero coefficients, then the families have
+the same number of blocks, and blocks match up to permutation, dimension equality,
+and gauge-phase equivalence.
 
-This bundled lemma uses the strict/already-grouped CF-BNT special case. The general
-CPSV BNT comparison keeps repeated sectors through the multiplicity data handled
-elsewhere in the sector-decomposition surface.
+This lemma covers the case where each block represents a single gauge-phase class
+(the blocks are already merged). The general CPSV BNT comparison, where repeated
+equal-modulus sectors contribute via power sums `∑_q μ_{j,q}^N`, is handled by the
+`SectorDecomposition` theorems.
 
-This bundled-data lemma is a direct consequence of
-`fundamentalTheorem_of_separated_CFBNT_data`. -/
+This is a direct consequence of `fundamentalTheorem_of_separated_CFBNT_data`. -/
 lemma fundamentalTheorem_of_IsCanonicalFormBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -644,10 +650,11 @@ lemma fundamentalTheorem_of_IsCanonicalFormBNT
     ⟨A_total, B_total, aCoeff, bCoeff, aLim, bLim, c, cLim,
       hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
-/-- Split-data comparison lemma for separated normal-CF-BNT-style decompositions.
+/-- **Proportional comparison lemma for normal CF-BNT decompositions.**
 
-This is the normal-form analogue of the strict comparison above. It is
-not the full CPSV multiplicity BNT theorem. -/
+Normal-form analogue of `fundamentalTheorem_of_separated_CFBNT_data`, using
+`IsNormalCanonicalForm` in place of strict weight ordering. This is not the full
+CPSV multiplicity BNT theorem. -/
 lemma fundamentalTheorem_of_separated_normalCFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -76,10 +76,9 @@ If the total tensors are `SameMPV₂` and the basis of `P` is eventually linearl
 independent, then the copy counts are forced to agree. After absorbing the same
 phases into the weights of `Q`, the per-basis sector weight multisets agree.
 
-This is the coefficient-extraction part of the heterogeneous sector comparison:
-copy-count equality is not an input, but is recovered from the exponent-zero
-case of the power-sum identity after eventual coefficient equality has been
-extrapolated to all exponents. -/
+This is the coefficient-extraction part of the comparison: copy-count equality
+is recovered from the exponent-zero case of the power-sum identity after eventual
+coefficient equality has been extrapolated to all exponents. -/
 lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies
     (P Q : SectorDecomposition d)
     (perm : Fin P.basisCount ≃ Fin Q.basisCount)
@@ -285,24 +284,23 @@ lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
   exact fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis
     P Q perm hCopies hScaling hLI hEqual
 
-/-! ## Witness bundle for the heterogeneous sector comparison
+/-! ## Basis matching witness for two sector decompositions with different bases
 
-The sector-comparison theorems above consume the matching data as four separate
-hypotheses: a permutation of sector bases, equality of copy numbers, per-block
-dimension equality, and per-block gauge-phase equivalence. The matching
-structure below collects these data as a single witness. It is the consumer side
-of the heterogeneous comparison: overlap/span hypotheses or common-cover phase
-data produce the witness, and the sector comparison then recovers the
-corresponding weight multisets.
+The sector-comparison theorems above take four separate hypotheses: a permutation
+of sector bases, equality of copy numbers, per-block dimension equality, and
+per-block gauge-phase equivalence. The structures below collect these into a
+single witness. Overlap/span hypotheses or common-cover phase data produce the
+witness; the sector comparison then recovers the corresponding weight multisets.
 -/
 
 /-- Basis matching before sector multiplicities have been recovered.
 
-This structure captures the part of the heterogeneous BNT comparison supplied by
-the overlap-dichotomy argument: a permutation of basis blocks, equality of their
-bond dimensions, and gauge-phase equivalence of the matched blocks. It does not
-include copy-count alignment; that alignment is recovered from total MPV equality
-by `SectorBasisPreMatching.exists_sectorBasisMatching_of_sameMPV`. -/
+This structure captures the part of the BNT comparison for two sector decompositions
+with different bases, supplied by the overlap-dichotomy argument: a permutation of
+basis blocks, equality of their bond dimensions, and gauge-phase equivalence of the
+matched blocks. It does not include copy-count alignment; that alignment is recovered
+from total MPV equality by
+`SectorBasisPreMatching.exists_sectorBasisMatching_of_sameMPV`. -/
 structure SectorBasisPreMatching (P Q : SectorDecomposition d) where
   /-- Permutation matching basis indices of `P` and `Q`. -/
   perm : Fin P.basisCount ≃ Fin Q.basisCount
@@ -314,9 +312,9 @@ structure SectorBasisPreMatching (P Q : SectorDecomposition d) where
       (cast (congr_arg (MPSTensor d) (dim_eq j)) (P.basis j))
       (Q.basis (perm j))
 
-/-- Bundled witness data matching two sector decompositions block-by-block.
+/-- Witness matching two sector decompositions block-by-block.
 
-This structure collects the four pieces of data consumed by
+This structure collects the four hypotheses required by
 `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`:
 
 * a basis permutation,
@@ -324,11 +322,10 @@ This structure collects the four pieces of data consumed by
 * per-block bond-dimension equality, and
 * per-block gauge-phase equivalence of the (dimension-transported) basis blocks.
 
-The overlap/span route produces this witness when the corresponding comparison
-hypotheses are available. For sector decompositions obtained after blocking, the
-producer-side task is to supply overlap/span data, or an equivalent common-phase
-BNT-cover comparison. Once those data are supplied, the heterogeneous sector
-comparison applies directly. -/
+**Formalization note.** The overlap/span route produces this witness when the
+corresponding comparison hypotheses are available. For sector decompositions
+obtained after blocking, those hypotheses may instead be supplied by an equivalent
+common-phase BNT-cover comparison. -/
 structure SectorBasisMatching (P Q : SectorDecomposition d) where
   /-- Permutation matching basis indices of `P` and `Q`. -/
   perm : Fin P.basisCount ≃ Fin Q.basisCount
@@ -594,13 +591,14 @@ lemma exists_sectorBasisMatching
 
 end SectorBasisOverlapSpanHypotheses
 
-/-- **Heterogeneous sector comparison via a bundled basis matching witness.**
+/-- **Sector comparison for two decompositions with different bases, via a basis matching witness.**
 
 Corollary of `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`
-obtained by supplying the matching data in bundled form as a `SectorBasisMatching`.
-The matching can be extracted from `SectorBasisOverlapSpanHypotheses`; for
-after-blocking sector decompositions, the producer-side task is to supply those
-hypotheses, or equivalent common-phase BNT-cover data. -/
+obtained by packaging the matching hypotheses as a `SectorBasisMatching`.
+The matching can be extracted from `SectorBasisOverlapSpanHypotheses`.
+
+**Formalization note.** For after-blocking sector decompositions, those hypotheses may
+instead be supplied by equivalent common-phase BNT-cover data. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching
     {P Q : SectorDecomposition d}
     (M : SectorBasisMatching P Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -176,7 +176,7 @@ lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exist
   have hproof : hCopies' j = hCopies j := Subsingleton.elim _ _
   simpa [T, hproof] using hMultiset j
 
-/-- **Heterogeneous sector comparison reduces to the shared-basis case after phase matching.**
+/-- **Sector comparison for different bases reduces to the shared-basis case after phase matching.**
 
 Assume two sector decompositions `P` and `Q` have basis blocks matched by a permutation `perm`,
 matching multiplicities, and per-basis MPV relations

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -42,7 +42,7 @@ linear-independence condition.**
 `HasBNTSectorData P` asserts that the basis of the sector decomposition `P` is
 a basis of normal tensors in the sense of Definition 4.2 of arXiv:2011.12127: for all
 sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
-are linearly independent.  It is a `Prop`; no data is bundled.
+are linearly independent.  It is a `Prop`; no witness is bundled.
 
 Mathematically, this is the eventual linear-independence hypothesis on the basis
 sector MPV families. In comparison theorems for two sector decompositions, it
@@ -60,23 +60,23 @@ sector coefficient functions, and Newton identities recover the multisets of
 sector weights inside each basis block.
 
 The result formalized here is the BNT coefficient comparison that recovers both
-copy counts and sector weights. A global gauge-equivalence statement for the
+multiplicities and sector weights. A global gauge-equivalence statement for the
 assembled tensors still requires a theorem deriving the coefficient and phase
-data required by the proportional decomposition theorem from bare equality of
-matrix-product vectors. In sector form the coefficients are finite sums of powers
+hypotheses required by the proportional decomposition theorem from bare equality
+of matrix-product vectors. In sector form the coefficients are finite sums of powers
 of unit-modulus weights, so convergence is not automatic without a dominant
 weight, normalization, or an explicit common-phase comparison.
 -/
 
-/-- **Phase matching and total MPV equality recover copy counts and sector weights.**
+/-- **Phase matching and total MPV equality recover multiplicities and sector weights.**
 
 Assume two sector decompositions `P` and `Q` have basis blocks matched by a
 permutation `perm`, and the matched basis MPVs differ by nonzero phase powers.
 If the total tensors are `SameMPV₂` and the basis of `P` is eventually linearly
-independent, then the copy counts are forced to agree. After absorbing the same
+independent, then the multiplicities are forced to agree. After absorbing the same
 phases into the weights of `Q`, the per-basis sector weight multisets agree.
 
-This is the coefficient-extraction part of the comparison: copy-count equality
+This is the coefficient-extraction part of the comparison: equality of multiplicities
 is recovered from the exponent-zero case of the power-sum identity after eventual
 coefficient equality has been extrapolated to all exponents. -/
 lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies
@@ -179,7 +179,7 @@ lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exist
 /-- **Heterogeneous sector comparison reduces to the shared-basis case after phase matching.**
 
 Assume two sector decompositions `P` and `Q` have basis blocks matched by a permutation `perm`,
-matching copy counts, and per-basis MPV relations
+matching multiplicities, and per-basis MPV relations
 `mpv (Q.basis (perm j)) σ = ζ_j^N * mpv (P.basis j) σ`. If the total tensors are
 `SameMPV₂`, then after absorbing the phases `ζ_j` into the sector weights on the `Q` side,
 the per-basis sector weight multisets agree. -/
@@ -210,7 +210,7 @@ lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
 
 /-- **Cast-compatible MPV scaling implies the phase-matched heterogeneous sector comparison.**
 
-This lemma isolates the weaker data actually consumed by the
+This lemma isolates the weaker hypotheses actually consumed by the
 phase-absorption argument: after matching basis dimensions, each block pair
 only needs a nonzero phase `ζ` relating the MPVs of the matched basis tensors. -/
 lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_matched_basis
@@ -250,7 +250,7 @@ This lemma converts blockwise gauge-phase equivalence into the corresponding
 power-law scaling of matrix-product vectors, then consumes the heterogeneous
 sector comparison for a supplied permutation of basis blocks. Thus the
 phase-absorption step is already available once the basis permutation,
-multiplicity equality, and per-block phase data have been supplied. -/
+multiplicity equality, and per-block phase factors have been supplied. -/
 lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
     (P Q : SectorDecomposition d)
     (perm : Fin P.basisCount ≃ Fin Q.basisCount)
@@ -287,9 +287,9 @@ lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
 /-! ## Basis matching witness for two sector decompositions with different bases
 
 The sector-comparison theorems above take four separate hypotheses: a permutation
-of sector bases, equality of copy numbers, per-block dimension equality, and
+of sector bases, equality of multiplicities, per-block dimension equality, and
 per-block gauge-phase equivalence. The structures below collect these into a
-single witness. Overlap/span hypotheses or common-cover phase data produce the
+single witness. Overlap/span hypotheses or common-cover phase hypotheses produce the
 witness; the sector comparison then recovers the corresponding weight multisets.
 -/
 
@@ -298,7 +298,7 @@ witness; the sector comparison then recovers the corresponding weight multisets.
 This structure captures the part of the BNT comparison for two sector decompositions
 with different bases, supplied by the overlap-dichotomy argument: a permutation of
 basis blocks, equality of their bond dimensions, and gauge-phase equivalence of the
-matched blocks. It does not include copy-count alignment; that alignment is recovered
+matched blocks. It does not include equality of multiplicities; that equality is recovered
 from total MPV equality by
 `SectorBasisPreMatching.exists_sectorBasisMatching_of_sameMPV`. -/
 structure SectorBasisPreMatching (P Q : SectorDecomposition d) where
@@ -358,7 +358,7 @@ namespace SectorBasisMatching
 
 variable {P Q : SectorDecomposition d}
 
-/-- Reformulate the per-block data in the existential form consumed by
+/-- Reformulate the per-block hypotheses in the existential form consumed by
 `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`. -/
 lemma basis_match_exists (M : SectorBasisMatching P Q) :
     ∀ j : Fin P.basisCount,
@@ -374,7 +374,7 @@ namespace SectorBasisPreMatching
 
 variable {P Q : SectorDecomposition d}
 
-/-- Reformulate pre-matching data in the existential form used by the theorem with
+/-- Reformulate pre-matching hypotheses in the existential form used by the theorem with
 a supplied permutation of basis blocks. -/
 lemma basis_match_exists (M : SectorBasisPreMatching P Q) :
     ∀ j : Fin P.basisCount,
@@ -399,7 +399,7 @@ lemma phase_match_exists (M : SectorBasisPreMatching P Q) :
 
 /-- Promote a basis pre-matching to a full sector basis matching.
 
-The new information is the copy-count equality. It follows from total MPV equality
+The new information is equality of multiplicities. It follows from total MPV equality
 and BNT linear independence by recovering the exponent-zero power sums for the
 matched sector coefficients. -/
 lemma exists_sectorBasisMatching_of_sameMPV
@@ -419,7 +419,7 @@ lemma exists_sectorBasisMatching_of_sameMPV
 
 end SectorBasisPreMatching
 
-/-- Single-family primitive overlap-orthogonality data for a sector basis.
+/-- Single-family primitive overlap-orthogonality hypotheses for a sector basis.
 
 This is the part of `SectorBasisOverlapSpanHypotheses` that can be checked one
 sector decomposition at a time: positive basis dimensions, left-canonical
@@ -448,7 +448,7 @@ This structure collects the analytic inputs used by
 `exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV`: nonzero bond
 dimensions, injectivity, left-canonical normalization, asymptotic self/orthogonal
 overlaps, and equality of the finite-length MPV spans. It deliberately does
-not contain a permutation or copy-count equality; those are produced by the
+not contain a permutation or equality of multiplicities; those are produced by the
 overlap rigidity theorem and the BNT coefficient comparison. -/
 structure SectorBasisOverlapSpanHypotheses (P Q : SectorDecomposition d) : Prop where
   /-- The left basis blocks have nonzero bond dimension. -/
@@ -492,7 +492,7 @@ namespace SectorBasisOverlapOrthoHypotheses
 
 variable {P Q : SectorDecomposition d}
 
-/-- Combine the single-family overlap-orthogonality data for two sector bases
+/-- Combine the single-family overlap-orthogonality hypotheses for two sector bases
 with the one-site injectivity and finite-length span comparison inputs needed by
 the primitive overlap-rigidity theorem. -/
 lemma to_overlapSpan
@@ -524,7 +524,7 @@ end SectorBasisOverlapOrthoHypotheses
 
 The overlap-rigidity theorem gives the basis permutation, dimension equalities,
 and gauge-phase equivalences. The preceding pre-matching result then recovers
-the sector copy-count alignment from total MPV equality. -/
+the equality of sector multiplicities from total MPV equality. -/
 theorem exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV
     (P Q : SectorDecomposition d)
     [∀ j : Fin P.basisCount, NeZero (P.basisDim j)]
@@ -594,11 +594,11 @@ end SectorBasisOverlapSpanHypotheses
 /-- **Sector comparison for two decompositions with different bases, via a basis matching witness.**
 
 Corollary of `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis`
-obtained by packaging the matching hypotheses as a `SectorBasisMatching`.
+obtained by expressing the matching hypotheses as a `SectorBasisMatching`.
 The matching can be extracted from `SectorBasisOverlapSpanHypotheses`.
 
 **Formalization note.** For after-blocking sector decompositions, those hypotheses may
-instead be supplied by equivalent common-phase BNT-cover data. -/
+instead be supplied by equivalent common-phase BNT-cover hypotheses. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching
     {P Q : SectorDecomposition d}
     (M : SectorBasisMatching P Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -42,7 +42,7 @@ linear-independence condition.**
 `HasBNTSectorData P` asserts that the basis of the sector decomposition `P` is
 a basis of normal tensors in the sense of Definition 4.2 of arXiv:2011.12127: for all
 sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
-are linearly independent.  It is a `Prop`; no witness is bundled.
+are linearly independent.  It is a `Prop`; no witness is included.
 
 Mathematically, this is the eventual linear-independence hypothesis on the basis
 sector MPV families. In comparison theorems for two sector decompositions, it
@@ -208,7 +208,7 @@ lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
   have hproof : hCopies' j = hCopies j := Subsingleton.elim _ _
   simpa [hproof] using hMultiset j
 
-/-- **Cast-compatible MPV scaling implies the phase-matched heterogeneous sector comparison.**
+/-- **Cast-compatible MPV scaling gives the phase-matched sector comparison.**
 
 This lemma isolates the weaker hypotheses actually consumed by the
 phase-absorption argument: after matching basis dimensions, each block pair
@@ -244,11 +244,11 @@ lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_mpvScaling_match
   exact fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch
     P Q perm hCopies hPhase hLI hEqual
 
-/-- **Gauge-phase matched sector bases imply the phase-matched heterogeneous sector comparison.**
+/-- **Gauge-phase matched sector bases give the phase-matched sector comparison.**
 
 This lemma converts blockwise gauge-phase equivalence into the corresponding
-power-law scaling of matrix-product vectors, then consumes the heterogeneous
-sector comparison for a supplied permutation of basis blocks. Thus the
+power-law scaling of matrix-product vectors, then uses the sector comparison for
+a supplied permutation of basis blocks. Thus the
 phase-absorption step is already available once the basis permutation,
 multiplicity equality, and per-block phase factors have been supplied. -/
 lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
@@ -573,7 +573,7 @@ namespace SectorBasisOverlapSpanHypotheses
 
 variable {P Q : SectorDecomposition d}
 
-/-- Convert the bundled primitive overlap-rigidity hypotheses into a sector basis
+/-- Convert the combined primitive overlap-rigidity hypotheses into a sector basis
 matching. The produced witness is not part of the hypotheses: it is obtained by
 `exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV`. -/
 lemma exists_sectorBasisMatching

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -36,13 +36,13 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- **Predicate asserting a sector decomposition's basis satisfies the BNT
-linear-independence condition.**
+/-- **BNT linear-independence hypothesis for sector bases.**
 
 `HasBNTSectorData P` asserts that the basis of the sector decomposition `P` is
 a basis of normal tensors in the sense of Definition 4.2 of arXiv:2011.12127: for all
 sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
-are linearly independent.  It is a `Prop`; no witness is included.
+are linearly independent.  The statement records only the eventual condition;
+no witness is included.
 
 Mathematically, this is the eventual linear-independence hypothesis on the basis
 sector MPV families. In comparison theorems for two sector decompositions, it


### PR DESCRIPTION
### Motivation
- Make the sector-decomposition and BNT-construction docstrings state the mathematics before Lean-specific structure.
- Replace process vocabulary with formulas and paper terminology for gauge-phase matching, multiplicities, weights mu_{j,q}, and power sums sum_q mu_{j,q}^N.

### Description
- `TNLean/MPS/BNT/Construction.lean`: describe CF-BNT as the already-grouped strict-modulus special case and point to `SectorDecomposition` for the full CPSV multiplicity structure.
- `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`: state sector matching through the permutation of sectors, dimension casts, gauge-phase equivalence, and equality of weight multisets.

### Testing
- `lake env lean TNLean/MPS/BNT/Construction.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`
- `git diff --check`
- Terminology scan for the reviewed words in the touched files

Closes #1399

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that rephrase hypotheses and theorem statements; no functional or proof logic changes are introduced.
> 
> **Overview**
> Rewrites the module and theorem docstrings in `MPS/BNT/Construction.lean` and `MPS/FundamentalTheorem/SectorDecomposition.lean` to state the *mathematical* hypotheses/conclusions up front (canonical/BNT separation, gauge-phase matching, multiplicities/weights `μ_{j,q}`, and power sums `∑ μ^N`) and to clarify that `IsCanonicalFormBNT` is the already-grouped strict-modulus special case.
> 
> Also standardizes terminology in comments (e.g., “separated hypotheses” vs “split data”, “multiplicities” vs “copy counts”) and clarifies the role of bundled witnesses like `SectorBasisPreMatching`/`SectorBasisMatching` without changing definitions or proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5dd8a063f1976a7a4b4cb51e51eb65a9d5ec2ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->