### PR TITLE
doc(MPS/Periodic): align irreducible-form terminology with source

### DIFF
--- a/TNLean/MPS/Periodic/ProjectiveRep.lean
+++ b/TNLean/MPS/Periodic/ProjectiveRep.lean
@@ -63,9 +63,9 @@ variable {d D : ℕ} {G : Type*} [Group G]
 
 /-- **Periodic projective-representation rigidity hypothesis.**
 
-A tensor `A : MPSTensor d D` in irreducible form carrying an on-site symmetry
-`U : G →* Mat_d(ℂ)` satisfies `PeriodicProjectiveRigidity A U` if the `Y`-gauges
-implementing Corollary 4.1 can be chosen coherently: there is a family
+For an on-site symmetry `U : G →* Mat_d(ℂ)` of a periodic tensor `A`,
+`PeriodicProjectiveRigidity A U` records the coherent choice of the
+`Y`-gauges obtained from Corollary 4.1: there is a family
 `Y : G → GL (Fin D) ℂ` and a scalar 2-cochain `u : G × G → ℂˣ` such that
 
 1. Each `Y g`, together with some `Z`-matrix (satisfying the period, commutation
@@ -156,10 +156,9 @@ the bond-space symmetry data of Corollary 4.1 to a coherent projective
 representation of `G` on the bond space, with factor system satisfying the
 2-cocycle identity whenever `D > 0`.
 
-Callers that already have the Corollary 4.1 data (irreducible form, unitary
-on-site action, symmetry, periodic equal-case FT) can produce
-`PeriodicProjectiveRigidity A U` in the presence of an additional analytic
-coherence hypothesis. -/
+The irreducible-form and unitarity hypotheses belong to the theorem producing
+`PeriodicProjectiveRigidity A U`; this theorem records only the resulting
+projective representation on the bond space. -/
 theorem projectiveRep_of_symmetry
     (A : MPSTensor d D)
     (U : G →* Matrix (Fin d) (Fin d) ℂ)

--- a/TNLean/MPS/Periodic/ProjectiveRep.lean
+++ b/TNLean/MPS/Periodic/ProjectiveRep.lean
@@ -63,7 +63,7 @@ variable {d D : ℕ} {G : Type*} [Group G]
 
 /-- **Periodic projective-representation rigidity hypothesis.**
 
-A tensor `A : MPSTensor d D` in irreducible form II carrying an on-site symmetry
+A tensor `A : MPSTensor d D` in irreducible form carrying an on-site symmetry
 `U : G →* Mat_d(ℂ)` satisfies `PeriodicProjectiveRigidity A U` if the `Y`-gauges
 implementing Corollary 4.1 can be chosen coherently: there is a family
 `Y : G → GL (Fin D) ℂ` and a scalar 2-cochain `u : G × G → ℂˣ` such that
@@ -156,7 +156,7 @@ the bond-space symmetry data of Corollary 4.1 to a coherent projective
 representation of `G` on the bond space, with factor system satisfying the
 2-cocycle identity whenever `D > 0`.
 
-Callers that already have the Corollary 4.1 data (irreducible form II, unitary
+Callers that already have the Corollary 4.1 data (irreducible form, unitary
 on-site action, symmetry, periodic equal-case FT) can produce
 `PeriodicProjectiveRigidity A U` in the presence of an additional analytic
 coherence hypothesis. -/

--- a/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
@@ -29,7 +29,7 @@ lemma twistedTensor_eq_rotatePhysical
 
 /-- **Corollary 4.1 (arXiv:1708.00029, Section 4.2): physical symmetry → virtual `Z`-gauge.**
 
-Let `A` be in irreducible form and let `U : G →* Mat_d ℂ` be a representation of a
+Let `A` be in irreducible form II and let `U : G →* Mat_d ℂ` be a representation of a
 group `G` on the physical leg, acting unitarily. If `A` is on-site symmetric under `U`
 (i.e. each twisted tensor `twistedTensor A U g` has the same MPV family as `A`), then
 for each `g ∈ G` there exists a positive period `m_g` and a `Z_{m_g}`-gauge equivalence
@@ -59,7 +59,7 @@ theorem cor_4_1_physical_symmetry_zgauge
   -- Twisting by `U g` is the same as the physical-index rotation by `U g`.
   have hRotEq : twistedTensor A U g = rotatePhysical (U g) A :=
     twistedTensor_eq_rotatePhysical A U g
-  -- The rotated tensor is again in irreducible form (preserved by unitary rotation).
+  -- The rotated tensor is again in irreducible form II (preserved by unitary rotation).
   have hRot : IsIrreducibleForm (rotatePhysical (U g) A) :=
     isIrreducibleForm_rotatePhysical A (U g) (hUnit g) hA
   -- The on-site symmetry hypothesis gives `SameMPV A (rotatePhysical (U g) A)`.

--- a/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
@@ -29,7 +29,7 @@ lemma twistedTensor_eq_rotatePhysical
 
 /-- **Corollary 4.1 (arXiv:1708.00029, Section 4.2): physical symmetry → virtual `Z`-gauge.**
 
-Let `A` be in irreducible form II and let `U : G →* Mat_d ℂ` be a representation of a
+Let `A` be in irreducible form and let `U : G →* Mat_d ℂ` be a representation of a
 group `G` on the physical leg, acting unitarily. If `A` is on-site symmetric under `U`
 (i.e. each twisted tensor `twistedTensor A U g` has the same MPV family as `A`), then
 for each `g ∈ G` there exists a positive period `m_g` and a `Z_{m_g}`-gauge equivalence
@@ -59,7 +59,7 @@ theorem cor_4_1_physical_symmetry_zgauge
   -- Twisting by `U g` is the same as the physical-index rotation by `U g`.
   have hRotEq : twistedTensor A U g = rotatePhysical (U g) A :=
     twistedTensor_eq_rotatePhysical A U g
-  -- The rotated tensor is again in irreducible form II (preserved by unitary rotation).
+  -- The rotated tensor is again in irreducible form (preserved by unitary rotation).
   have hRot : IsIrreducibleForm (rotatePhysical (U g) A) :=
     isIrreducibleForm_rotatePhysical A (U g) (hUnit g) hA
   -- The on-site symmetry hypothesis gives `SameMPV A (rotatePhysical (U g) A)`.

--- a/TNLean/MPS/Periodic/Symmetry/EqualCaseFTHyp.lean
+++ b/TNLean/MPS/Periodic/Symmetry/EqualCaseFTHyp.lean
@@ -33,7 +33,7 @@ variable {d D : ℕ}
 /-- The **periodic equal-case Fundamental Theorem of MPS** (Theorem 3.8 of
 arXiv:1708.00029) stated as a Prop, suitable for use as an explicit hypothesis.
 
-Given two tensors of the same physical/bond dimensions in irreducible form II that
+Given two tensors of the same physical/bond dimensions in irreducible form that
 generate the same matrix-product-vector family, this hypothesis asserts the existence
 of a positive period `m` and a `Z_m`-gauge equivalence between the two tensors.
 

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -11,7 +11,7 @@ This chapter develops the periodic equal-case Fundamental Theorem of MPS
 (Theorem~\ref{thm:periodic_ft}) following
 \cite{DeLasCuevas2017Irreducible}, and gives its two applications:
 the symmetry corollary lifting a physical on-site symmetry of a tensor
-in irreducible form to a virtual $Z$-gauge, and the equivalence between
+in irreducible form~II to a virtual $Z$-gauge, and the equivalence between
 $p$-refinability of the matrix-product-vector family and
 $p$-divisibility of the transfer map.
 
@@ -646,7 +646,7 @@ literature theorem is not yet a single unconditional Lean statement.
     \leanok
     \uses{def:irreducible_form, def:z_gauge_equiv, def:on_site_symmetric,
           def:twisted_tensor, thm:periodic_ft}
-    Let $A$ be an MPS tensor in irreducible form and let
+    Let $A$ be an MPS tensor in irreducible form~II and let
     $U : G \to \GL_d(\C)$ be a representation of a group $G$ on the
     physical leg, acting unitarily ($U(g)\, U(g)^{\dagger} = \Id$).
     Assume moreover the periodic equal-case Fundamental Theorem of MPS
@@ -671,7 +671,7 @@ literature theorem is not yet a single unconditional Lean statement.
     The twisted tensor $\widetilde{A}_g$ coincides with the physical-index
     rotation $A_{U(g)}$ of Definition~\ref{def:rotate_physical}.
     By Theorem~\ref{thm:irreducible_form_rotate_physical} the rotated
-    tensor remains in irreducible form, and the on-site symmetry
+    tensor remains in irreducible form~II, and the on-site symmetry
     hypothesis supplies the equality $\mathcal{V}(A) = \mathcal{V}(A_{U(g)})$.
     Apply the periodic equal-case Fundamental Theorem
     (Theorem~\ref{thm:periodic_ft}) to obtain the asserted
@@ -841,21 +841,21 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.pRefinementCanonicalization_pullback_of_irreducibleForm}
     \leanok
     \uses{def:irreducible_form, def:p_refinable}
-    Let $B$ be an MPS tensor in irreducible form. If $B$ is
+    Let $B$ be an MPS tensor in irreducible form~II. If $B$ is
     $p$-refinable, then there exist a tensor $A$, an isometry
     $W : \C^d \to (\C^d)^{\otimes p}$, and the pullback tensor
     $$
         C^{\alpha} := \sum_{i=0}^{d-1} W_{\alpha,i} B^i
         \qquad (\alpha \in \{0,\ldots,d^p-1\})
     $$
-    such that $C$ is again in irreducible form, $\mathcal E_C = \mathcal E_B$,
+    such that $C$ is again in irreducible form~II, $\mathcal E_C = \mathcal E_B$,
     and $C$ has the same MPV family as $A^{[p]}$.
 \end{theorem}
 
 \begin{proof}\leanok
     Choose $(A,W)$ from the refinement data. The pullback construction gives
     $\mathcal E_C = \mathcal E_B$ and equality of MPV families between $C$
-    and $A^{[p]}$. To see that $C$ is still in irreducible form, transport
+    and $A^{[p]}$. To see that $C$ is still in irreducible form~II, transport
     each periodic block $B_j$ of $B$ through the same physical isometry $W$.
     The left-canonical normalization is preserved because $W^{\dagger}W = \Id$,
     while irreducibility and the peripheral spectrum are preserved because the
@@ -870,7 +870,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:same_mpv, def:z_gauge_equiv}
     Fix $(d,D,p)$. This hypothesis says that whenever a blocked tensor $C$ in
-    irreducible form has the same MPV family as a blocked root $A^{[p]}$,
+    irreducible form~II has the same MPV family as a blocked root $A^{[p]}$,
     there exists an integer $m \ge 1$ and a $\mathbb Z_m$-gauge equivalence
     between $C$ and $A^{[p]}$.
 \end{definition}
@@ -881,7 +881,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:z_gauge_equiv}
     Fix $(d,D,p)$. This hypothesis says that if $m \ge 1$ and a blocked tensor
-    $C$ in irreducible form is $\mathbb Z_m$-gauge equivalent to $A^{[p]}$,
+    $C$ in irreducible form~II is $\mathbb Z_m$-gauge equivalent to $A^{[p]}$,
     then there exists a tensor $A'$ with
     $\sum_i (A'^i)^\dagger A'^i = \Id$ and
     $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
@@ -893,7 +893,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:same_mpv}
     Fix $(d,D,p)$. This states the combined root-existence statement: whenever a
-    blocked tensor $C$ in irreducible form has the same MPV family as a
+    blocked tensor $C$ in irreducible form~II has the same MPV family as a
     blocked root $A^{[p]}$, one can replace $A$ by a left-canonical tensor $A'$
     with $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
 \end{definition}
@@ -924,14 +924,14 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
           def:irreducible_form, def:p_refinable,
           thm:p_refinement_pullback_irreducible_form}
     Assume the blocked equal-case root hypothesis. Then every
-    $p$-refinable tensor $B$ in irreducible form admits a left-canonical root
+    $p$-refinable tensor $B$ in irreducible form~II admits a left-canonical root
     $A'$ with $\mathcal E_B = \mathcal E_{A'^{[p]}}$.
 \end{theorem}
 
 \begin{proof}\leanok
     Apply Theorem~\ref{thm:p_refinement_pullback_irreducible_form} to the
     refinement witness of $B$. This produces a blocked tensor $C$ in
-    irreducible form with $\mathcal E_C = \mathcal E_B$ and the same MPV
+    irreducible form~II with $\mathcal E_C = \mathcal E_B$ and the same MPV
     family as $A^{[p]}$. The blocked equal-case root hypothesis then
     gives a left-canonical tensor $A'$ with
     $\mathcal E_C = \mathcal E_{A'^{[p]}}$. Combining the two transfer-map
@@ -946,7 +946,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
           def:irreducible_form, def:p_refinable, def:p_divisible_channel,
           thm:p_refinement_forward_equalcase_reduction}
     Assume the blocked equal-case root hypothesis. Then for every tensor
-    $B$ in irreducible form, $p$-refinability of $B$ implies
+    $B$ in irreducible form~II, $p$-refinability of $B$ implies
     $p$-divisibility of $\mathcal E_B$.
 \end{theorem}
 
@@ -967,7 +967,7 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
     \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel,
           thm:periodic_ft, thm:thm_4_1_p_refinement_forward,
           thm:thm_4_1_p_refinement_reverse}
-    Let $B$ be an MPS tensor in irreducible form and let $p \ge 1$.
+    Let $B$ be an MPS tensor in irreducible form~II and let $p \ge 1$.
     Assume the two root hypotheses used in the one-way statements: the forward
     left-canonical root hypothesis for refinability $\Rightarrow$ divisibility
     and the reverse transfer-map root hypothesis for divisibility
@@ -990,7 +990,7 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.thm_4_1_p_refinement_forward}
     \leanok
     \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel}
-    Let $B$ be an MPS tensor in irreducible form. Assume a left-canonical
+    Let $B$ be an MPS tensor in irreducible form~II. Assume a left-canonical
     root hypothesis: every refinement witness gives a tensor $A$ with
     $\sum_i (A^i)^\dagger A^i = \Id$ and
     $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$. Then
@@ -1042,7 +1042,7 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.thm_4_1_p_refinement_reverse}
     \leanok
     \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel}
-    Let $B$ be an MPS tensor in irreducible form and let $p \ge 1$.
+    Let $B$ be an MPS tensor in irreducible form~II and let $p \ge 1$.
     Assume the reverse transfer-map root hypothesis: there is a tensor $A$ with
     $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$ whenever $\mathcal{E}_B$ is
     $p$-divisible. Then $p$-divisibility of $\mathcal{E}_B$ implies

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -175,8 +175,8 @@ $p$-divisibility of the transfer map.
         thm:periodic_rotate_physical,
         thm:same_mpv_rotate_physical,
         thm:rotate_physical_blocks}
-    If $u u^\dagger = I$ and $A$ is in irreducible form~II, then
-    $A_u$ is in irreducible form~II with the same block structure and
+    If $u u^\dagger = I$ and $A$ is in irreducible form, then
+    $A_u$ is in irreducible form with the same block structure and
     rotated blocks.
 \end{theorem}
 
@@ -646,7 +646,7 @@ literature theorem is not yet a single unconditional Lean statement.
     \leanok
     \uses{def:irreducible_form, def:z_gauge_equiv, def:on_site_symmetric,
           def:twisted_tensor, thm:periodic_ft}
-    Let $A$ be an MPS tensor in irreducible form~II and let
+    Let $A$ be an MPS tensor in irreducible form and let
     $U : G \to \GL_d(\C)$ be a representation of a group $G$ on the
     physical leg, acting unitarily ($U(g)\, U(g)^{\dagger} = \Id$).
     Assume moreover the periodic equal-case Fundamental Theorem of MPS
@@ -671,7 +671,7 @@ literature theorem is not yet a single unconditional Lean statement.
     The twisted tensor $\widetilde{A}_g$ coincides with the physical-index
     rotation $A_{U(g)}$ of Definition~\ref{def:rotate_physical}.
     By Theorem~\ref{thm:irreducible_form_rotate_physical} the rotated
-    tensor remains in irreducible form~II, and the on-site symmetry
+    tensor remains in irreducible form, and the on-site symmetry
     hypothesis supplies the equality $\mathcal{V}(A) = \mathcal{V}(A_{U(g)})$.
     Apply the periodic equal-case Fundamental Theorem
     (Theorem~\ref{thm:periodic_ft}) to obtain the asserted
@@ -841,21 +841,21 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.pRefinementCanonicalization_pullback_of_irreducibleForm}
     \leanok
     \uses{def:irreducible_form, def:p_refinable}
-    Let $B$ be an MPS tensor in irreducible form~II. If $B$ is
+    Let $B$ be an MPS tensor in irreducible form. If $B$ is
     $p$-refinable, then there exist a tensor $A$, an isometry
     $W : \C^d \to (\C^d)^{\otimes p}$, and the pullback tensor
     $$
         C^{\alpha} := \sum_{i=0}^{d-1} W_{\alpha,i} B^i
         \qquad (\alpha \in \{0,\ldots,d^p-1\})
     $$
-    such that $C$ is again in irreducible form~II, $\mathcal E_C = \mathcal E_B$,
+    such that $C$ is again in irreducible form, $\mathcal E_C = \mathcal E_B$,
     and $C$ has the same MPV family as $A^{[p]}$.
 \end{theorem}
 
 \begin{proof}\leanok
     Choose $(A,W)$ from the refinement data. The pullback construction gives
     $\mathcal E_C = \mathcal E_B$ and equality of MPV families between $C$
-    and $A^{[p]}$. To see that $C$ is still in irreducible form~II, transport
+    and $A^{[p]}$. To see that $C$ is still in irreducible form, transport
     each periodic block $B_j$ of $B$ through the same physical isometry $W$.
     The left-canonical normalization is preserved because $W^{\dagger}W = \Id$,
     while irreducibility and the peripheral spectrum are preserved because the
@@ -870,7 +870,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:same_mpv, def:z_gauge_equiv}
     Fix $(d,D,p)$. This hypothesis says that whenever a blocked tensor $C$ in
-    irreducible form~II has the same MPV family as a blocked root $A^{[p]}$,
+    irreducible form has the same MPV family as a blocked root $A^{[p]}$,
     there exists an integer $m \ge 1$ and a $\mathbb Z_m$-gauge equivalence
     between $C$ and $A^{[p]}$.
 \end{definition}
@@ -881,7 +881,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:z_gauge_equiv}
     Fix $(d,D,p)$. This hypothesis says that if $m \ge 1$ and a blocked tensor
-    $C$ in irreducible form~II is $\mathbb Z_m$-gauge equivalent to $A^{[p]}$,
+    $C$ in irreducible form is $\mathbb Z_m$-gauge equivalent to $A^{[p]}$,
     then there exists a tensor $A'$ with
     $\sum_i (A'^i)^\dagger A'^i = \Id$ and
     $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
@@ -893,7 +893,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:same_mpv}
     Fix $(d,D,p)$. This states the combined root-existence statement: whenever a
-    blocked tensor $C$ in irreducible form~II has the same MPV family as a
+    blocked tensor $C$ in irreducible form has the same MPV family as a
     blocked root $A^{[p]}$, one can replace $A$ by a left-canonical tensor $A'$
     with $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
 \end{definition}
@@ -924,14 +924,14 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
           def:irreducible_form, def:p_refinable,
           thm:p_refinement_pullback_irreducible_form}
     Assume the blocked equal-case root hypothesis. Then every
-    $p$-refinable tensor $B$ in irreducible form~II admits a left-canonical root
+    $p$-refinable tensor $B$ in irreducible form admits a left-canonical root
     $A'$ with $\mathcal E_B = \mathcal E_{A'^{[p]}}$.
 \end{theorem}
 
 \begin{proof}\leanok
     Apply Theorem~\ref{thm:p_refinement_pullback_irreducible_form} to the
     refinement witness of $B$. This produces a blocked tensor $C$ in
-    irreducible form~II with $\mathcal E_C = \mathcal E_B$ and the same MPV
+    irreducible form with $\mathcal E_C = \mathcal E_B$ and the same MPV
     family as $A^{[p]}$. The blocked equal-case root hypothesis then
     gives a left-canonical tensor $A'$ with
     $\mathcal E_C = \mathcal E_{A'^{[p]}}$. Combining the two transfer-map
@@ -946,7 +946,7 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
           def:irreducible_form, def:p_refinable, def:p_divisible_channel,
           thm:p_refinement_forward_equalcase_reduction}
     Assume the blocked equal-case root hypothesis. Then for every tensor
-    $B$ in irreducible form~II, $p$-refinability of $B$ implies
+    $B$ in irreducible form, $p$-refinability of $B$ implies
     $p$-divisibility of $\mathcal E_B$.
 \end{theorem}
 
@@ -967,7 +967,7 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
     \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel,
           thm:periodic_ft, thm:thm_4_1_p_refinement_forward,
           thm:thm_4_1_p_refinement_reverse}
-    Let $B$ be an MPS tensor in irreducible form~II and let $p \ge 1$.
+    Let $B$ be an MPS tensor in irreducible form and let $p \ge 1$.
     Assume the two root hypotheses used in the one-way statements: the forward
     left-canonical root hypothesis for refinability $\Rightarrow$ divisibility
     and the reverse transfer-map root hypothesis for divisibility
@@ -990,7 +990,7 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.thm_4_1_p_refinement_forward}
     \leanok
     \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel}
-    Let $B$ be an MPS tensor in irreducible form~II. Assume a left-canonical
+    Let $B$ be an MPS tensor in irreducible form. Assume a left-canonical
     root hypothesis: every refinement witness gives a tensor $A$ with
     $\sum_i (A^i)^\dagger A^i = \Id$ and
     $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$. Then
@@ -1042,7 +1042,7 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.thm_4_1_p_refinement_reverse}
     \leanok
     \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel}
-    Let $B$ be an MPS tensor in irreducible form~II and let $p \ge 1$.
+    Let $B$ be an MPS tensor in irreducible form and let $p \ge 1$.
     Assume the reverse transfer-map root hypothesis: there is a tensor $A$ with
     $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$ whenever $\mathcal{E}_B$ is
     $p$-divisible. Then $p$-divisibility of $\mathcal{E}_B$ implies


### PR DESCRIPTION
### Motivation
- arXiv:1708.00029 uses both "irreducible form" and "irreducible form II" in different statements.
- The periodic FT equal-case material uses irreducible form, while Corollary 4.1 and Theorem 4.1/refinability-divisibility use irreducible form II.

### Description
- Keeps "irreducible form" in the periodic FT/equal-case framing.
- Restores "irreducible form II" in the blueprint and Lean docstrings for source Corollary 4.1 and Theorem 4.1.
- Rephrases `PeriodicProjectiveRigidity` so the definition records the coherent `Y`-gauge conclusion without claiming an irreducible-form hypothesis that is not an argument.
- No proof terms, definitions, or APIs changed.

### Testing
- `git diff --check`
- `lake env lean TNLean/MPS/Periodic/ProjectiveRep.lean`
- `lake env lean TNLean/MPS/Periodic/Symmetry/Corollary41.lean`
- `lake env lean TNLean/MPS/Periodic/Symmetry/EqualCaseFTHyp.lean`

Closes #1415