### PR TITLE
doc(algebraicFT): source-faithful formulas for chain FT

### DIFF
--- a/TNLean/MPS/Chain/AlgebraIsomorphism.lean
+++ b/TNLean/MPS/Chain/AlgebraIsomorphism.lean
@@ -65,9 +65,9 @@ For two 3-site injective periodic MPS chains `A = (A₀, A₁, A₂)` and
 there exists `Z ∈ GL(D, ℂ)` such that for all `X ∈ M_D(ℂ)` and all
 physical configurations `σ : Fin 3 → Fin d`,
 $$
-  \operatorname{virtualInsertCoeff}(A_0,A_1,A_2;\sigma,X)
+  \operatorname{tr}(A_0^{\sigma_0} X A_1^{\sigma_1} A_2^{\sigma_2})
   =
-  \operatorname{virtualInsertCoeff}(B_0,B_1,B_2;\sigma,Z^{-1}XZ).
+  \operatorname{tr}(B_0^{\sigma_0} Z^{-1} X Z B_1^{\sigma_1} B_2^{\sigma_2}).
 $$
 where the hypothesis `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`
 is trace agreement for all mixed-site words of all lengths. -/

--- a/TNLean/MPS/Chain/AlgebraIsomorphism.lean
+++ b/TNLean/MPS/Chain/AlgebraIsomorphism.lean
@@ -9,10 +9,11 @@ For two 3-site injective periodic MPS chains
 `A = (A₀, A₁, A₂)` and `B = (B₀, B₁, B₂)` whose combined tensors generate
 the same MPV family, the virtual-insertion coefficients on bond 0–1 are
 related by conjugation through an invertible matrix `Z ∈ GL(D, ℂ)`:
-```
-  tr(A₀^{σ₀} · X · A₁^{σ₁} · A₂^{σ₂})
-= tr(B₀^{σ₀} · Z⁻¹ X Z · B₁^{σ₁} · B₂^{σ₂})
-```
+$$
+  \operatorname{tr}(A_0^{\sigma_0} X A_1^{\sigma_1} A_2^{\sigma_2})
+  =
+  \operatorname{tr}(B_0^{\sigma_0} Z^{-1} X Z B_1^{\sigma_1} B_2^{\sigma_2}).
+$$
 for all `X ∈ M_D(ℂ)` and physical configurations `σ`.  The proof uses the
 linear extension from `SameMPV`, multiplicativity, simplicity of `M_D(ℂ)`,
 and Skolem–Noether.
@@ -63,10 +64,11 @@ For two 3-site injective periodic MPS chains `A = (A₀, A₁, A₂)` and
 `B = (B₀, B₁, B₂)` whose combined tensors generate the same MPV family,
 there exists `Z ∈ GL(D, ℂ)` such that for all `X ∈ M_D(ℂ)` and all
 physical configurations `σ : Fin 3 → Fin d`,
-```
-  virtualInsertCoeff A₀ A₁ A₂ σ X
-= virtualInsertCoeff B₀ B₁ B₂ σ (Z⁻¹ · X · Z)
-```
+$$
+  \operatorname{virtualInsertCoeff}(A_0,A_1,A_2;\sigma,X)
+  =
+  \operatorname{virtualInsertCoeff}(B_0,B_1,B_2;\sigma,Z^{-1}XZ).
+$$
 where the hypothesis `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`
 is trace agreement for all mixed-site words of all lengths. -/
 theorem virtual_bond_gauge [NeZero D]

--- a/TNLean/MPS/Chain/AlgebraIsomorphism.lean
+++ b/TNLean/MPS/Chain/AlgebraIsomorphism.lean
@@ -3,25 +3,19 @@ import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Structure.LinearExtension
 import TNLean.Algebra.SkolemNoether
 /-!
-# Algebra isomorphism between virtual bond algebras (Lemma 1)
+# Algebra isomorphism between virtual bond algebras
 
-For two injective MPS chains whose combined tensor generates the same MPV family,
-virtual insertions on bond 0–1 are related by conjugation (Skolem–Noether).
-
-## Overview of the proof
-
-1. Combine the site-local tensors `A₁, A₂, A₃` into a single family
-   `chainCombinedTensor A` indexed by `Fin (3 * d)` via `finProdFinEquiv`.
-2. Apply the linear extension theorem (`linearExtension_exists_unique`) to
-   obtain the unique linear map `T` with `T(Aₖ(σ)) = Bₖ(σ)` for all sites
-   `k` and physical indices `σ`.
-3. Apply `linearExtension_mul` to show `T` is multiplicative.
-4. By simplicity of the matrix algebra (`linear_mul_endomorphism_bijective`),
-   `T` is bijective.
-5. Apply Skolem–Noether (`skolemNoether_matrix`) to extract the gauge
-   matrix `W` with `T(M) = W M W⁻¹`.
-6. The virtual-insertion identity follows from multiplicativity of `T` and
-   trace-cyclicity.
+For two 3-site injective periodic MPS chains
+`A = (A₀, A₁, A₂)` and `B = (B₀, B₁, B₂)` whose combined tensors generate
+the same MPV family, the virtual-insertion coefficients on bond 0–1 are
+related by conjugation through an invertible matrix `Z ∈ GL(D, ℂ)`:
+```
+  tr(A₀^{σ₀} · X · A₁^{σ₁} · A₂^{σ₂})
+= tr(B₀^{σ₀} · Z⁻¹ X Z · B₁^{σ₁} · B₂^{σ₂})
+```
+for all `X ∈ M_D(ℂ)` and physical configurations `σ`.  The proof uses the
+linear extension from `SameMPV`, multiplicativity, simplicity of `M_D(ℂ)`,
+and Skolem–Noether.
 
 ## References
 
@@ -34,12 +28,11 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ### Combined tensor for the linear-extension approach -/
+/-! ### Combined tensor for a chain -/
 
 /-- The combined MPS tensor for a chain: packs site index `k : Fin n` and
 physical index `σ : Fin d` into a single index in `Fin (n * d)` via
-`finProdFinEquiv`. This lets us apply the single-tensor `linearExtension`
-construction to a non-translation-invariant chain. -/
+`finProdFinEquiv`. -/
 noncomputable def chainCombinedTensor {n : ℕ} (A : Fin n → MPSTensor d D) :
     MPSTensor (n * d) D :=
   fun i => A (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm i).2
@@ -50,9 +43,7 @@ lemma chainCombinedTensor_apply {n : ℕ} (A : Fin n → MPSTensor d D)
     chainCombinedTensor A (finProdFinEquiv (k, σ)) = A k σ := by
   simp [chainCombinedTensor]
 
-/-- If any site tensor is injective, the combined tensor is injective.
-This is because `{Aₖ(σ)} ⊆ {chainCombinedTensor A (i)}`, so the
-larger set spans if the smaller one does. -/
+/-- If any site tensor is injective, the combined tensor is injective. -/
 theorem chainCombinedTensor_isInjective {n : ℕ} (A : Fin n → MPSTensor d D)
     (k : Fin n) (hk : IsInjective (A k)) :
     IsInjective (chainCombinedTensor A) := by
@@ -66,24 +57,18 @@ theorem chainCombinedTensor_isInjective {n : ℕ} (A : Fin n → MPSTensor d D)
 
 /-! ### The main theorem -/
 
-/-- **Lemma 1 (arXiv:1804.04964)**: Virtual bond gauge theorem.
+/-- **Virtual bond gauge** (Lemma 1 of arXiv:1804.04964).
 
-For two injective MPS chains whose combined tensors generate the same MPV
-family (`SameMPV` on `chainCombinedTensor`), virtual insertions on bond 0–1
-are related by conjugation: there exists `Z ∈ GL(D,ℂ)` such that for all `X`
-and all physical configurations `σ`,
+For two 3-site injective periodic MPS chains `A = (A₀, A₁, A₂)` and
+`B = (B₀, B₁, B₂)` whose combined tensors generate the same MPV family,
+there exists `Z ∈ GL(D, ℂ)` such that for all `X ∈ M_D(ℂ)` and all
+physical configurations `σ : Fin 3 → Fin d`,
 ```
-virtualInsertCoeff A₁ A₂ A₃ σ X = virtualInsertCoeff B₁ B₂ B₃ σ (Z⁻¹ X Z)
+  virtualInsertCoeff A₀ A₁ A₂ σ X
+= virtualInsertCoeff B₀ B₁ B₂ σ (Z⁻¹ · X · Z)
 ```
-
-The hypothesis `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`
-requires trace agreement for all mixed-site words of all lengths:
-`tr(A_{s₁}(σ₁) ⋯ A_{sₙ}(σₙ)) = tr(B_{s₁}(σ₁) ⋯ B_{sₙ}(σₙ))`
-for arbitrary site-index sequences `s₁, …, sₙ`.
-
-The proof constructs the linear extension `T` with `T(Aₖ(σ)) = Bₖ(σ)`,
-shows it is multiplicative, promotes it to a bijective algebra endomorphism
-(by simplicity of the matrix ring), and applies Skolem–Noether to extract `Z`. -/
+where the hypothesis `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`
+is trace agreement for all mixed-site words of all lengths. -/
 theorem virtual_bond_gauge [NeZero D]
     (A B : Fin 3 → MPSTensor d D)
     (hA : ∀ k, IsInjective (A k)) (_hB : ∀ k, IsInjective (B k))

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -18,8 +18,8 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Equivalence between `L`-block injectivity and injectivity of the blocked
-tensor `blockTensor A L`. -/
+/-- Equivalence between `N`-block injectivity and injectivity of the blocked
+tensor `blockTensor A N`. -/
 lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
     IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by
   classical

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -4,20 +4,22 @@ import TNLean.MPS.Chain.FundamentalTheorem
 /-!
 # Fundamental theorem for blocked chains
 
-This module states a fundamental theorem for blocked chains. The theorem
-`fundamentalTheorem_blockedChain` applies to blocked chains built from a
-common blocking length `L`.
+For an MPS tensor `A` and blocking length `L`, the constant blocked chain of
+`A^{[L]}` satisfies the chain fundamental theorem with respect to the blocked
+combined tensor.  The theorem hypothesis uses `SameMPV` on the combined
+blocked tensors.
 
-Design note: the theorem is stated in explicit-assumption style (`L`, `hA_block`,
-`hMPV`) so that subsequent uses can choose blocking witnesses locally.
+## References
+
+* [arXiv:1804.04964](https://arxiv.org/abs/1804.04964)
 -/
 
 namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Equivalence between project `N`-block injectivity and injectivity of the physically
-blocked tensor `blockTensor A N`. -/
+/-- Equivalence between `L`-block injectivity and injectivity of the blocked
+tensor `blockTensor A L`. -/
 lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
     IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by
   classical
@@ -65,10 +67,11 @@ lemma blockedChain_isInjective (A : MPSTensor d D) (L n : ℕ)
   simpa [blockedChain] using
     (MPSTensor.isNBlkInjective_iff_blockTensor_isInjective A L).1 hA
 
-/-- Fundamental theorem for blocked chains at a common blocking length.
+/-- **Fundamental Theorem for blocked chains**.
 
-The hypothesis `hA_block` chooses a witness `L` used in the blocked-chain
-reduction to the injective-chain theorem. -/
+If `A` is `L`-block injective and the constant blocked chains built from
+`A^{[L]}` and `B^{[L]}` satisfy `SameMPV` on their combined tensors, then
+the blocked chains are gauge equivalent. -/
 theorem fundamentalTheorem_blockedChain
     (A B : MPSTensor d D) (L n : ℕ)
     (hA_block : MPSTensor.IsNBlkInjective A L)

--- a/TNLean/MPS/Chain/FundamentalTheorem.lean
+++ b/TNLean/MPS/Chain/FundamentalTheorem.lean
@@ -4,27 +4,14 @@ import TNLean.MPS.FundamentalTheorem.Basic
 /-!
 # Fundamental Theorem for injective MPS chains
 
-This file proves the Fundamental Theorem for non-translation-invariant injective
-MPS chains (Theorem 1 of [arXiv:1804.04964](https://arxiv.org/abs/1804.04964)):
+Two injective MPS chains `A` and `B` whose combined tensors
+`chainCombinedTensor A` and `chainCombinedTensor B` generate the same MPV
+family are related by cyclic gauge transformations on the virtual bonds.
 
-Two injective MPS chains whose combined tensors generate the same MPV family are
-related by cyclic gauge transformations on the virtual bonds.
-
-## Proof strategy
-
-We pack all site-local tensors into a single combined tensor via
-`chainCombinedTensor`, then apply the single-block Fundamental Theorem
-(`fundamentalTheorem_singleBlock`) to obtain a uniform gauge. A uniform gauge
-is a special case of cyclic gauge equivalence.
-
-## Hypothesis
-
-The hypothesis `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)` asks
-for trace agreement of all mixed-site words of all lengths. This is stronger
-than the paper's `SameState` (trace agreement at a single chain length). The
-paper bridges this gap via a blocking argument requiring n ≥ 3; that bridging
-step is not formalized here, so the theorem is stated with the stronger
-hypothesis.
+The hypothesis `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)` is
+trace agreement for all mixed-site words of all lengths.  The paper bridges
+the gap from fixed-length `SameState` to this hypothesis via a blocking
+argument for `n ≥ 3`; this bridging step is not formalized here.
 
 ## References
 
@@ -37,16 +24,13 @@ namespace MPSChainTensor
 
 variable {d D n : ℕ}
 
-/-- **Fundamental Theorem for injective MPS chains** (Theorem 1, arXiv:1804.04964).
+/-- **Fundamental Theorem for injective MPS chains** (Theorem 1 of arXiv:1804.04964).
 
-Two injective MPS chains whose combined tensors generate the same MPV family
-are related by cyclic gauge transformations on the virtual bonds. The proof
-produces a *uniform* gauge (the same invertible matrix at every bond), which is
-stronger than the general cyclic gauge equivalence.
-
-The hypothesis is `SameMPV` on the combined tensor (all-length trace agreement
-for mixed-site words), which is stronger than the paper's fixed-length
-`SameState`. See the module docstring for discussion. -/
+If `A` and `B` are `n`-site chains with `A` injective and
+`SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`, then `A` and `B`
+are cyclically gauge equivalent.  The proof produces a *uniform* gauge
+(the same `X ∈ GL(D, ℂ)` at every bond), which is a special case of cyclic
+gauge equivalence. -/
 theorem fundamentalTheorem_injective_chain
     (A B : MPSChainTensor d D n)
     (hA : IsInjective A)

--- a/TNLean/MPS/Chain/GaugePhase.lean
+++ b/TNLean/MPS/Chain/GaugePhase.lean
@@ -5,13 +5,14 @@ import TNLean.MPS.Chain.FundamentalTheorem
 
 If the combined tensors `chainCombinedTensor A` and `chainCombinedTensor B`
 are gauge-phase equivalent, i.e. there exist `X ∈ GL(D, ℂ)` and `ζ ≠ 0` with
-```
-  chainCombinedTensor B = ζ · X · (chainCombinedTensor A) · X⁻¹
-```
+$$
+  (\operatorname{chainCombinedTensor} B)^j
+    = \zeta\, X\,(\operatorname{chainCombinedTensor} A)^j\,X^{-1},
+$$
 then the chains themselves are cyclically gauge equivalent with a common
 nonzero phase `ζ` multiplying every site tensor:
 $$
-  B_k^i = ζ · Z_k · A_k^i · Z_{k+1}^{-1}.
+  B_k^i = \zeta\, Z_k\, A_k^i\, Z_{k+1}^{-1}.
 $$
 
 ## Main declarations
@@ -46,9 +47,9 @@ variable {d D n : ℕ}
 
 If `GaugePhaseEquiv (chainCombinedTensor A) (chainCombinedTensor B)` and
 `A` is injective, there exist `Z_k ∈ GL(D, ℂ)` and `ζ ≠ 0` such that
-```
-  B_k^i = ζ · Z_k · A_k^i · Z_{k+1}⁻¹
-```
+$$
+  B_k^i = \zeta\, Z_k\, A_k^i\, Z_{k+1}^{-1}
+$$
 for all sites `k` and physical indices `i`. -/
 theorem fundamentalTheorem_injective_chain_gaugePhase
     (A B : MPSChainTensor d D n)

--- a/TNLean/MPS/Chain/GaugePhase.lean
+++ b/TNLean/MPS/Chain/GaugePhase.lean
@@ -3,14 +3,14 @@ import TNLean.MPS.Chain.FundamentalTheorem
 /-!
 # Gauge-phase variant of the injective-chain Fundamental Theorem
 
-If the combined tensors `chainCombinedTensor A` and `chainCombinedTensor B`
-are gauge-phase equivalent, i.e. there exist `X ∈ GL(D, ℂ)` and `ζ ≠ 0` with
+Let $\widetilde A$ and $\widetilde B$ denote the tensors obtained by contracting
+the chains $A$ and $B$ around the period.  If they are gauge-phase equivalent,
+i.e. there exist $X \in GL(D,\C)$ and $\zeta \ne 0$ with
 $$
-  (\operatorname{chainCombinedTensor} B)^j
-    = \zeta\, X\,(\operatorname{chainCombinedTensor} A)^j\,X^{-1},
+  \widetilde B^j = \zeta\, X\,\widetilde A^j\,X^{-1},
 $$
 then the chains themselves are cyclically gauge equivalent with a common
-nonzero phase `ζ` multiplying every site tensor:
+nonzero phase $\zeta$ multiplying every site tensor:
 $$
   B_k^i = \zeta\, Z_k\, A_k^i\, Z_{k+1}^{-1}.
 $$

--- a/TNLean/MPS/Chain/GaugePhase.lean
+++ b/TNLean/MPS/Chain/GaugePhase.lean
@@ -3,29 +3,21 @@ import TNLean.MPS.Chain.FundamentalTheorem
 /-!
 # Gauge-phase variant of the injective-chain Fundamental Theorem
 
-This file upgrades the exact injective-chain Fundamental Theorem to the case
-where the two **combined tensors** agree only up to a nonzero scalar.  The
-result is the chain-level contraction statement needed in periodic Case 3:
-from a gauge-phase equivalence between `chainCombinedTensor A` and
-`chainCombinedTensor B`, one recovers a cyclic gauge on the underlying chain
-together with a **common** nonzero phase on every site.
+If the combined tensors `chainCombinedTensor A` and `chainCombinedTensor B`
+are gauge-phase equivalent, i.e. there exist `X ∈ GL(D, ℂ)` and `ζ ≠ 0` with
+```
+  chainCombinedTensor B = ζ · X · (chainCombinedTensor A) · X⁻¹
+```
+then the chains themselves are cyclically gauge equivalent with a common
+nonzero phase `ζ` multiplying every site tensor:
+$$
+  B_k^i = ζ · Z_k · A_k^i · Z_{k+1}^{-1}.
+$$
 
 ## Main declarations
 
 * `MPSTensor.chainCombinedTensor_smul_chain`
 * `MPSChainTensor.fundamentalTheorem_injective_chain_gaugePhase`
-
-## Mathematical idea
-
-If $\widetilde A$ and $\widetilde B$ denote the combined tensors of `A` and
-`B`, and if
-$$
-\widetilde B = \zeta \cdot X \, \widetilde A \, X^{-1},
-$$
-then rescaling every site tensor of `B` by `ζ⁻¹` removes the global scalar on
-its combined tensor.  The exact chain Fundamental Theorem then applies to the
-rescaled chain, and multiplying the site relations back by `ζ` gives the
-required cyclic gauge-phase relation.
 -/
 
 open scoped Matrix
@@ -50,17 +42,14 @@ open MPSTensor
 
 variable {d D n : ℕ}
 
-/-- **Injective-chain contraction up to phase.**
+/-- **Injective-chain Fundamental Theorem up to gauge phase.**
 
-If the combined tensors of two chains are gauge-phase equivalent, then the
-chains themselves are cyclically gauge equivalent with one common nonzero phase
-`ζ` multiplying every site tensor of `A`.
-
-This is the finite-chain `$m$-factor cyclic contraction` used by the periodic
-Case-3 program: once a cyclic family of sector-transition tensors is
-formulated as an injective chain and the corresponding combined tensors are
-known to satisfy `GaugePhaseEquiv`, the conclusion recovers sitewise
-proportionality with a cyclic gauge. -/
+If `GaugePhaseEquiv (chainCombinedTensor A) (chainCombinedTensor B)` and
+`A` is injective, there exist `Z_k ∈ GL(D, ℂ)` and `ζ ≠ 0` such that
+```
+  B_k^i = ζ · Z_k · A_k^i · Z_{k+1}⁻¹
+```
+for all sites `k` and physical indices `i`. -/
 theorem fundamentalTheorem_injective_chain_gaugePhase
     (A B : MPSChainTensor d D n)
     (hA : IsInjective A)

--- a/TNLean/MPS/Chain/TranslationInvariance.lean
+++ b/TNLean/MPS/Chain/TranslationInvariance.lean
@@ -3,12 +3,9 @@ import TNLean.MPS.Chain.FundamentalTheorem
 /-!
 # Translation-invariance corollaries for injective MPS chains
 
-This file contains the translation-invariant specialization of the chain
-fundamental theorem as a corollary.
-
-Because `fundamentalTheorem_injective_chain` currently yields a uniform gauge,
-the translation-invariant collapse can be witnessed with scalar `λ = 1`.
-The periodicity statement then follows immediately as `1 ^ n = 1`.
+For constant (translation-invariant) chains `(A, …, A)` and `(B, …, B)`,
+the chain fundamental theorem reduces to a single matrix gauge:
+`B^i = X · A^i · X⁻¹` with `λ = 1`.
 -/
 
 open scoped Matrix
@@ -17,9 +14,11 @@ namespace MPSChainTensor
 
 variable {d D n : ℕ}
 
-/-- For translation-invariant chains `A` and `B` (constant tensors at every site),
-`SameMPV` on the combined tensors yields a single matrix gauge relating the site
-tensors. -/
+/-- **Single gauge for translation-invariant chains**.
+
+If `A` is injective and the constant chains `(A, …, A)` and `(B, …, B)`
+satisfy `SameMPV` on their combined tensors, there exists
+`X ∈ GL(D, ℂ)` with `B^i = X · A^i · X⁻¹` for all `i`. -/
 theorem ti_tensors_single_gauge
     (A B : MPSTensor d D)
     (hn : 0 < n)
@@ -39,14 +38,12 @@ theorem ti_tensors_single_gauge
   intro i
   simpa [MPSTensor.chainCombinedTensor_apply] using hX (finProdFinEquiv (k0, i))
 
-/-- Corollary 1 (TI collapse to a single gauge).
+/-- **Translation-invariant collapse to a single gauge**.
 
-For translation-invariant chains `A` and `B` (constant tensors at every site),
-a chain-level fundamental-theorem hypothesis yields a single matrix gauge and a
-phase `λ` with `lam ^ n = 1` such that
-`B i = lam • (Z⁻¹ * A i * Z)` for all physical indices `i`.
-
-In the current formalization this is realized by `λ = 1`. -/
+If `A` is injective and the constant chains `(A, …, A)` and `(B, …, B)`
+satisfy `SameMPV` on their combined tensors, there exist
+`Z ∈ GL(D, ℂ)` with `Z⁻¹` invertible and `λ ∈ ℂ^×`, `λ^n = 1` such that
+`B^i = λ · Z⁻¹ · A^i · Z` for all `i`.  The proof yields `λ = 1`. -/
 theorem ti_tensors_collapse_to_single_gauge
     (A B : MPSTensor d D)
     (hn : 0 < n)

--- a/TNLean/MPS/Chain/TranslationInvariance.lean
+++ b/TNLean/MPS/Chain/TranslationInvariance.lean
@@ -5,7 +5,7 @@ import TNLean.MPS.Chain.FundamentalTheorem
 
 For constant (translation-invariant) chains `(A, …, A)` and `(B, …, B)`,
 the chain fundamental theorem reduces to a single matrix gauge:
-`B^i = X · A^i · X⁻¹` with `λ = 1`.
+$B^i = X A^i X^{-1}$ with `λ = 1`.
 -/
 
 open scoped Matrix
@@ -18,7 +18,7 @@ variable {d D n : ℕ}
 
 If `A` is injective and the constant chains `(A, …, A)` and `(B, …, B)`
 satisfy `SameMPV` on their combined tensors, there exists
-`X ∈ GL(D, ℂ)` with `B^i = X · A^i · X⁻¹` for all `i`. -/
+`X ∈ GL(D, ℂ)` with $B^i = X A^i X^{-1}$ for all `i`. -/
 theorem ti_tensors_single_gauge
     (A B : MPSTensor d D)
     (hn : 0 < n)

--- a/TNLean/MPS/Chain/TranslationInvariance.lean
+++ b/TNLean/MPS/Chain/TranslationInvariance.lean
@@ -42,8 +42,8 @@ theorem ti_tensors_single_gauge
 
 If `A` is injective and the constant chains `(A, …, A)` and `(B, …, B)`
 satisfy `SameMPV` on their combined tensors, there exist
-`Z ∈ GL(D, ℂ)` with `Z⁻¹` invertible and `λ ∈ ℂ^×`, `λ^n = 1` such that
-`B^i = λ · Z⁻¹ · A^i · Z` for all `i`.  The proof yields `λ = 1`. -/
+a matrix `Z` with `IsUnit Z` and a scalar `λ : ℂ` with `λ^n = 1` such that
+`B^i = λ • (Z⁻¹ * A^i * Z)` for all `i`. The proof yields `λ = 1`. -/
 theorem ti_tensors_collapse_to_single_gauge
     (A B : MPSTensor d D)
     (hn : 0 < n)

--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -9,45 +9,21 @@ import TNLean.Algebra.TracePairing
 /-!
 # Fundamental Theorem with finite-length MPV agreement
 
-This file strengthens the single-block Fundamental Theorem of MPS by weakening
-the hypothesis from `SameMPV` (agreement for **all** system sizes) to
-`SameMPVFrom N₀` (agreement for system sizes `N ≥ N₀`).
+If `A` is injective and `A`, `B` agree on all MPV coefficients for system
+sizes `N ≥ N₀` (any threshold `N₀`), then `A` and `B` are gauge equivalent.
+This strengthens the single-block fundamental theorem by weakening the
+hypothesis from all-length to finite-length agreement.
 
 ## Main results
 
-* `SameMPVFrom` — definition of finite-length MPV agreement
+* `SameMPVFrom` — finite-length MPV agreement from `N₀` onward
 * `sameMPV_of_sameMPVFrom_of_injective` — finite-length agreement implies
   full agreement for injective tensors
 * `fundamentalTheorem_singleBlock_finiteLength` — the strengthened FT
 
-## Mathematical content
-
-The key mathematical challenge is converting trace agreement on long words into
-`evalWord` agreement on all words. The naive approach of pairing
-`tr(evalWord A w * A i) = tr(evalWord B w * A i)` fails because the extensions
-`w ++ [i]` produce `evalWord B w * B i`, not `evalWord B w * A i`.
-
-The correct proof strategy uses the **linear extension** approach from the
-existing FT proof (`LinearExtension.lean`): if `SameMPV A B` holds, there is
-a unique linear map `T` with `T(A i) = B i` that is multiplicative. For the
-finite-length case, one shows that `SameMPVFrom N₀` still determines `T`
-uniquely, because word products of length `≥ 1` span `M_D(ℂ)` (by injectivity)
-and the trace agreements of length `≥ N₀` pin down the action of `T`.
-
-This requires a non-trivial inductive argument that interleaves the linear
-extension construction with the trace pairing.
-
-## Strengthening relative to the literature
-
-The standard formulation of the FT (Pérez-García et al. 2007, Cirac et al. 2021)
-requires either all-length agreement or works in the thermodynamic limit.
-This formalization shows that a finite threshold suffices, making the theorem
-applicable to fixed-size quantum systems.
-
 ## References
 
-* [Pérez-García, Verstraete, Wolf, Cirac, *Matrix Product State Representations*,
-  arXiv:quant-ph/0608197]
+* Pérez-García, Verstraete, Wolf, Cirac, quant-ph/0608197
 -/
 
 open scoped Matrix BigOperators
@@ -80,8 +56,8 @@ theorem SameMPVFrom.mono {A B : MPSTensor d D} {N₀ N₁ : ℕ}
 
 /-! ## Trace agreement on word extensions -/
 
-/-- If `SameMPVFrom N₀ A B`, then traces of word evaluations agree for words
-of length `≥ N₀`. -/
+/-- If `SameMPVFrom N₀ A B`, then `tr(evalWord A w) = tr(evalWord B w)` for
+all words `w` of length `|w| ≥ N₀`. -/
 lemma SameMPVFrom.trace_evalWord_of_length_ge
     {A B : MPSTensor d D} {N₀ : ℕ}
     (h : SameMPVFrom N₀ A B) {w : List (Fin d)} (hw : N₀ ≤ w.length) :
@@ -92,10 +68,7 @@ lemma SameMPVFrom.trace_evalWord_of_length_ge
 
 /-! ## Auxiliary: word span for injective tensors -/
 
-/-- For an injective tensor, `wordSpan A n = ⊤` for all `n ≥ 1`.
-
-Base: `wordSpan A 1 = span(range A) = ⊤`. Step: right-multiply each generator
-by the A-decomposition of `1` to embed `wordSpan A n` into `wordSpan A (n+1)`. -/
+/-- For an injective tensor, `wordSpan A n = ⊤` for all `n ≥ 1`. -/
 theorem wordSpan_eq_top_of_isInjective
     {A : MPSTensor d D} (hA : IsInjective A)
     {n : ℕ} (hn : 0 < n) : wordSpan A n = ⊤ := by
@@ -132,18 +105,10 @@ theorem wordSpan_eq_top_of_isInjective
 
 /-- **Finite-length agreement implies full agreement** for injective tensors.
 
-**Proof**: For `N₀ ≥ 1`, let `1 = Σ cᵢ Aⁱ` (by injectivity) and `S = Σ cᵢ Bⁱ`.
-
-1. Show `wordSpan B N₀ = ⊤` via the composition identity
-   `traceMulRightPi A ∘ lcA = traceMulRightPi B ∘ lcB` (at word level `N₀`),
-   using trace agreement at length `N₀ + 1` and the finrank transfer
-   `ker_bot_of_range_le`.
-2. Show `S = 1` by trace nondegeneracy on `wordSpan B N₀ = ⊤`:
-   for `|v| = N₀`, the identity `tr(v_B · S) = tr(v_A) = tr(v_B)` gives
-   `tr(M(S−1)) = 0` for all `M`.
-3. Step down: for `|w| < N₀`, use `tr(w_A) = Σ cᵢ tr((w++[i])_A)` and
-   `tr(w_B) = Σ cᵢ tr((w++[i])_B)` (the latter by `S = 1`), plus the
-   inductive hypothesis at length `|w|+1`. -/
+If `SameMPVFrom N₀ A B` with `A` injective, then `SameMPV A B`.  The proof
+proceeds in three steps: (1) `wordSpan B N₀ = ⊤` by composition identity
+and finrank transfer; (2) `S = Σ cᵢ Bⁱ = 1` by trace nondegeneracy;
+(3) downward induction on word length using the `A`-decomposition of `1`. -/
 theorem sameMPV_of_sameMPVFrom_of_injective [NeZero D]
     {A B : MPSTensor d D}
     (hA : IsInjective A)
@@ -282,8 +247,8 @@ theorem sameMPV_of_sameMPVFrom_of_injective [NeZero D]
 
 /-- **Strengthened single-block Fundamental Theorem (finite-length version).**
 
-If `A` is injective and `A`, `B` agree on all MPV coefficients for system sizes
-`N ≥ N₀` (for **any** threshold `N₀`), then they are gauge equivalent. -/
+If `A` is injective and `SameMPVFrom N₀ A B` for any threshold `N₀`, then
+`A` and `B` are gauge equivalent. -/
 theorem fundamentalTheorem_singleBlock_finiteLength [NeZero D]
     {A B : MPSTensor d D}
     (hA : IsInjective A)

--- a/TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean
@@ -7,38 +7,14 @@ import TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap
 /-!
 # Block matching for equal-MPV BNT families
 
-This module proves `blocks_match_of_sameMPV₂_CFBNT`, which converts the equality of
-total matrix product vectors (`SameMPV₂`) between two assembled `IsCanonicalFormBNT`
-families into a concrete `BlockPermutationGaugeWitness`: equal block counts, a block
-permutation, and blockwise dimension equality together with gauge-phase equivalence.
-This is **Layer 1b** of the heterogeneous equal-case fundamental theorem, combining
-Layer 1a (`exists_nondecaying_overlap_of_sameMPV₂_CFBNT` from
-`TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap`) with the overlap dichotomy.
-
-## Main statements
-
-* `blocks_match_of_sameMPV₂_CFBNT`: `SameMPV₂` of assembled CF-BNT families yields a
-  `BlockPermutationGaugeWitness` without any caller-supplied coefficient convergence
-  data.
-
-## Implementation notes
-
-The proof uses `mpv_toTensorFromBlocks_eq_sum` to translate `SameMPV₂` into a weighted
-identity on `mpvState`, applies the non-decaying overlap existence result of Layer 1a,
-then completes matching via the overlap dichotomy
-(`mpvOverlap_tendsto_zero_of_dim_ne`,
-`mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left`) and BNT injectivity.
+`blocks_match_of_sameMPV₂_CFBNT`: from `SameMPV₂` on two assembled
+`IsCanonicalFormBNT` families, obtain a `BlockPermutationGaugeWitness`:
+equal block counts, a block permutation, and per-block gauge-phase equivalence.
 
 ## References
 
-* Cirac, Pérez-García, Schuch, Verstraete, *Matrix product states and projected entangled
-  pair states: Concepts, symmetries, theorems*, Rev. Mod. Phys. 93 (2021), arXiv:2011.12127.
-* Cirac, Pérez-García, Schuch, Verstraete, *Fundamental Theorems for PEPS*,
-  arXiv:1606.00608 (2017), Appendix A.
-
-## Tags
-
-matrix product states, fundamental theorem, BNT, block permutation, gauge-phase equivalence
+* Cirac, Pérez-García, Schuch, Verstraete, Rev. Mod. Phys. 93 (2021), arXiv:2011.12127.
+* Cirac, Pérez-García, Schuch, Verstraete, arXiv:1606.00608 Appendix A.
 -/
 
 open scoped Matrix BigOperators
@@ -48,59 +24,16 @@ namespace MPSTensor
 
 section HeteroEqualCase
 
-/-- **Block matching from equal weighted MPV sums via overlap dichotomy.**
+/-- **Heterogeneous equal-case block matching**.
 
-Given two `IsCanonicalFormBNT` families generating equal total MPVs via
-`toTensorFromBlocks`, this lemma produces the block matching: equal block counts,
-a permutation, and per-block gauge-phase equivalence.
+Given two `IsCanonicalFormBNT` families with `SameMPV₂` on their assembled
+block-diagonal tensors, this produces equal block counts `rA = rB`, a block
+permutation, and per-block gauge-phase equivalence.
 
-### Mathematical content (overlap dichotomy approach, CPSV17 Appendix A)
-
-The `SameMPV₂` hypothesis combined with `mpv_toTensorFromBlocks_eq_sum` gives the identity
-  `∑_j (μA j)^N * mpv(A j) σ = ∑_k (μB k)^N * mpv(B k) σ`   for all N, σ.
-
-**Step 1 — Finding matches via overlap dichotomy**: For each B-block k₀, take the inner
-product of the identity with `mpvState(B k₀, N)`. The B-side gives a sum where
-`mpvOverlap(B k₀, B k₀)(N) → 1` and cross-BNT terms `→ 0`. If ALL cross-family
-overlaps `mpvOverlap(A j, B k₀)` tended to 0, the Gram-matrix projection would force
-`|μB k₀|^N ≤ o(1) · |μA 0|^N`, giving `|μB k₀| < |μA 0|`. By symmetry from the A-side,
-`|μA 0| < |μB 0|`. Combining gives `|μB 0| < |μA 0| < |μB 0|` — a contradiction.
-So ∃ at least one pair (j, k) with non-decaying overlap. By the overlap dichotomy
-(`mpvOverlap_tendsto_zero_of_dim_ne`, `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv`),
-this forces dim equality and gauge-phase equivalence.
-
-**Step 2 — Injectivity**: If two distinct B-blocks k₁ ≠ k₂ were both matched to the
-same A-block j₀, both would be GPE with A j₀, hence GPE with each other — contradicting
-the B-side BNT separation (`hB.blocks_not_equiv`).
-
-**Step 3 — Induction**: Matched pairs can be peeled off using `μA j = μB k · ζ` (from
-BNT LI at consecutive large N), reducing to a smaller problem. Induction on `rA + rB`
-gives the full matching, with `rA = rB` following from injectivity on finite sets.
-
-### Note on SameMPV vs GaugePhaseEquiv
-
-The conclusion is per-block `GaugePhaseEquiv`, NOT exact per-block `SameMPV₂`. This is
-optimal: from `SameMPV₂` of the assembled tensors, one can only derive GPE for individual
-blocks (the phases may be non-trivial). A counterexample: take `B = ζ • (X · A · X⁻¹)`
-with `|ζ| = 1, ζ ≠ 1` and `μB = μA / ζ`; then the assembled tensors have equal MPVs
-but the blocks differ by phase `ζ^N`.
-
-### Proof structure
-
-The proof has the following fully-formal components:
-
-1. **Base cases** (`rA = 0` or `rB = 0`): linear independence + vanishing sum → ⊥.
-2. **Overlap dichotomy**: non-decaying overlap → dim match + GPE (contrapositives of
-   `mpvOverlap_tendsto_zero_of_dim_ne` and `..._of_not_gaugePhaseEquiv_cast_left`).
-3. **Matching injectivity**: GPE of two A-blocks with the same B-block gives cross-overlap
-   norm → 1 (via `mpv_eq_pow_mul_of_gaugePhase` + `norm_eq_one_of_selfOverlap_scale`),
-   contradicting A-BNT cross-overlap → 0. Similarly for B-side.
-4. **rA = rB**: injective maps `Fin rA → Fin rB` and `Fin rB → Fin rA` on finite types.
-5. **Permutation**: `Equiv.ofBijective` on the now-bijective matching function.
-
-The non-decaying overlap existence (`exists_nondecaying_A` and `exists_nondecaying_B`)
-is established by `exists_nondecaying_overlap_of_sameMPV₂_CFBNT`, which uses strong
-induction on `rA + rB` together with a dominant-weight projection argument. -/
+The proof uses the overlap dichotomy: non-decaying cross-family overlap
+forces equal block dimensions and gauge-phase equivalence; injectivity of
+the matching follows from BNT separation.  The argument follows Cirac et al.
+2021 (CPSV17) Appendix A. -/
 lemma blocks_match_of_sameMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -400,27 +400,19 @@ private theorem block_separation_core_of_crossOverlap_tendsto_one
 
 end BlockSeparationCoreInduction
 
-/-! ### Block separation core lemma (mixed-transfer / overlap argument)
+/-! ### Block separation core
 
-This is the literature-aligned block-separation step in canonical form.  The
-statement includes the additional hypotheses needed for the checked
-mixed-transfer proof:
+Under strict weight ordering, injectivity, left-canonical normalization, and
+`mpvOverlap (A k) (A k) N → 1`, the block identity
+`∑ k, μ k ^ N • (mpv (A k) σ - mpv (B k) σ) = 0` implies
+`SameMPV (A k) (B k)` for every block `k`.
 
-* `hB_inj` : every block of `B` is injective (needed for the overlap decay lemma
-  `mpvOverlap_tendsto_zero`), and
-* `hA_overlap` : aperiodicity / primitive normalization, expressed as
-  `mpvOverlap (A k) (A k) N → 1` as `N → ∞`. This rules out the "overlap → 0" branch
-  in the equal-or-orthogonal dichotomy.
-
-The proof follows Pérez-García et al. (2007, Appendix E) / Cirac et al. (2021, Theorem IV.3):
-we take overlaps with the leading block, divide by the leading weight, and use the
-strict modulus ordering of the weights together with uniform overlap bounds to invoke
-`peeling_exponential_bound`. Thus the geometric decay comes from the weight ratio,
-while the overlap theorems are used only for boundedness and contradiction steps.
-Once the leading mixed overlap is shown to tend to `1`, a nonzero limit first rules
-out a bond-dimension mismatch via the rectangular decay lemma; in the equal-dimension
-case, the usual overlap-decay contradiction forces gauge-phase equivalence of the
-leading block. Finally one iterates by induction on the number of blocks.
+The proof follows Pérez-García et al. (2007, Appendix E) and
+Cirac et al. (2021, Theorem IV.3): take mixed overlaps with the leading block,
+divide by the leading weight, and use `peeling_exponential_bound` with
+`‖μ k / μ 0‖ < 1`. The nonzero limiting overlap rules out unequal bond dimensions;
+in equal dimension, overlap decay forces gauge-phase equivalence of the leading
+blocks, and induction removes that block.
 -/
 lemma block_separation_core
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -510,21 +502,11 @@ lemma block_separation_all_words
     ∀ k, SameMPV (A k) (B k) :=
   block_separation_core μ A B hμ_strict hμ_ne_zero hA_inj hB_inj hA_lc hB_lc hA_overlap h_summed
 
-/-- NT / normal-canonical formulation of `block_separation_all_words`.
+/-- **Normal-canonical block separation**.
 
-Besides irreducibility and left-canonical normalization on both block families,
-this lemma also assumes the self-overlap convergence hypothesis on the
-`A`-blocks: `mpvOverlap (A k) (A k) N → 1`.
-
-The proof is the same peeling / induction argument as `block_separation_core`.
-The geometric decay again comes from the strict weight ordering after dividing by
-the leading weight, while the NT overlap lemmas provide the boundedness and
-contradiction hypotheses. At the identification step,
-`mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP` first excludes a
-bond-dimension mismatch, and
-`gaugePhaseEquiv_of_mpvOverlap_tendsto_one_of_irreducible_TP` replaces the
-injective equal-dimension overlap-decay contradiction via the irreducible
-modulus-one-eigenvalue-rigidity argument. -/
+Irreducible-block variant of `block_separation_all_words`:
+uses the irreducible modulus-one-eigenvalue rigidity argument
+instead of injective overlap-decay at the block-identification step. -/
 lemma block_separation_all_words_of_irreducible_TP
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)

--- a/TNLean/PiAlgebra/TIReduction.lean
+++ b/TNLean/PiAlgebra/TIReduction.lean
@@ -9,22 +9,14 @@ import TNLean.MPS.Chain.TranslationInvariance
 /-!
 # TI Reduction Corollary (Section 5, arXiv:1804.04964)
 
-Given two constant (TI) chains with the same combined tensor span, the
-Fundamental Theorem forces them to be gauge equivalent via a single matrix.
-
-More precisely: given a constant (TI) chain `fun _ => A` with `A` injective, and
-another constant chain `fun _ => B` whose combined tensor generates the same MPV
-family, the Fundamental Theorem gives a single gauge `X ∈ GL(D,ℂ)` such that
-`B i = X * A i * X⁻¹` for all `i`. In particular, `B` is also injective (gauge
-equivalent to an injective tensor), so within this constant-chain setting one
-can pass to a TI injective description.
+For constant (translation-invariant) chains `(A, …, A)` and `(B, …, B)` with
+`A` injective, `SameMPV` on the combined tensors gives
+`B^i = X · A^i · X⁻¹` for a single `X ∈ GL(D, ℂ)`, so `B` is injective.
 
 ## Main results
 
-* `ti_reduction_corollary` — from `SameMPV` on combined tensors: TI gauge
-  equivalence plus injectivity of `B`.
-* `ti_reduction_of_sameState` — from `SameState` (via the blocking bridge
-  hypothesis): same conclusion.
+* `ti_reduction_corollary` — from `SameMPV` on combined tensors
+* `ti_reduction_of_sameState` — from `SameState` via the blocking bridge hypothesis
 
 ## References
 
@@ -37,14 +29,11 @@ namespace MPSChainTensor
 
 variable {d D n : ℕ}
 
-/-- **TI Reduction Corollary** (Section 5, arXiv:1804.04964).
+/-- **TI Reduction Corollary**.
 
-For constant (TI) chains `fun _ => A` and `fun _ => B` with `A` injective, if
-their combined tensors generate the same MPV family, then `B` is gauge
-equivalent to `A` via a single invertible matrix, and `B` is also injective.
-
-This shows that translation invariance of the state forces translation
-invariance of the tensor description (up to gauge). -/
+If `A` is injective and the constant chains `(A, …, A)` and `(B, …, B)` satisfy
+`SameMPV` on their combined tensors, then `B` is gauge equivalent to `A` and
+`B` is injective. -/
 theorem ti_reduction_corollary
     (A B : MPSTensor d D)
     (hn : 0 < n)
@@ -60,11 +49,10 @@ theorem ti_reduction_corollary
   · exact ⟨X, hGauge⟩
   · exact MPSTensor.isInjective_of_gaugeEquiv hA ⟨X, hGauge⟩
 
-/-- **TI Reduction from SameState** (via blocking bridge hypothesis).
+/-- **TI Reduction from SameState**.
 
-The same conclusion as `ti_reduction_corollary`, but starting from fixed-length
-`SameState` (trace agreement at chain length `n`) and the blocking bridge
-hypothesis that upgrades this to `SameMPV` on combined tensors. -/
+Same conclusion as `ti_reduction_corollary`, from fixed-length `SameState`
+at chain length `n ≥ 3` using the blocking bridge hypothesis. -/
 theorem ti_reduction_of_sameState
     (hBridge : SameStateBridgeHyp d D)
     (A B : MPSTensor d D)

--- a/TNLean/PiAlgebra/TIReduction.lean
+++ b/TNLean/PiAlgebra/TIReduction.lean
@@ -16,7 +16,7 @@ For constant (translation-invariant) chains `(A, …, A)` and `(B, …, B)` with
 ## Main results
 
 * `ti_reduction_corollary` — from `SameMPV` on combined tensors
-* `ti_reduction_of_sameState` — from `SameState` via the blocking bridge hypothesis
+* `ti_reduction_of_sameState` — from `SameState` via the blocking connection hypothesis
 
 ## References
 
@@ -52,7 +52,8 @@ theorem ti_reduction_corollary
 /-- **TI Reduction from SameState**.
 
 Same conclusion as `ti_reduction_corollary`, from fixed-length `SameState`
-at chain length `n ≥ 3` using the blocking bridge hypothesis. -/
+at chain length `n ≥ 3` using the blocking connection hypothesis
+`SameStateBridgeHyp`. -/
 theorem ti_reduction_of_sameState
     (hBridge : SameStateBridgeHyp d D)
     (A B : MPSTensor d D)

--- a/TNLean/PiAlgebra/TIReduction.lean
+++ b/TNLean/PiAlgebra/TIReduction.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.Chain.TranslationInvariance
 
 For constant (translation-invariant) chains `(A, …, A)` and `(B, …, B)` with
 `A` injective, `SameMPV` on the combined tensors gives
-`B^i = X · A^i · X⁻¹` for a single `X ∈ GL(D, ℂ)`, so `B` is injective.
+$B^i = X A^i X^{-1}$ for a single `X ∈ GL(D, ℂ)`, so `B` is injective.
 
 ## Main results
 


### PR DESCRIPTION
### Motivation
- #1417 asks for source-faithful formulas in the algebraic fundamental theorem material.
- The affected files are reader-facing Lean docstrings and comments around the finite-length/chain FT and PiAlgebra reduction path.

### Description
- Rebased onto current `main` after the retired repeated-word file was deleted.
- Drops the obsolete edit to deleted `TNLean/PiAlgebra/BlockSeparation.lean`.
- Rewrites selected module and theorem docstrings toward formulas for the chain FT, finite-length FT, virtual-bond gauge, block matching, and TI reduction.
- Addresses review comments: removes banned "bridge" prose in `TIReduction`, aligns the TI collapse docstring with the actual `IsUnit Z` and `lam : ℂ` conclusion, formats gauge-phase formulas as LaTeX displays, and fixes the `N`-block injectivity wording.
- No theorem statements or proof terms changed.

### Testing
- `git diff --check`
- `lake env lean TNLean/PiAlgebra/TIReduction.lean`
- `lake env lean TNLean/PiAlgebra/CanonicalFormSep.lean`
- `lake env lean TNLean/MPS/Chain/AlgebraIsomorphism.lean`
- `lake env lean TNLean/MPS/Chain/BlockedChainFT.lean`
- `lake env lean TNLean/MPS/Chain/FundamentalTheorem.lean`
- `lake env lean TNLean/MPS/Chain/GaugePhase.lean`
- `lake env lean TNLean/MPS/Chain/TranslationInvariance.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/FiniteLength.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean`

Closes #1417

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates across multiple Lean modules; no theorem statements or proofs are modified, so behavioral risk is minimal aside from potential comment/docstring confusion.
> 
> **Overview**
> Updates reader-facing docstrings/comments across the algebraic Fundamental Theorem path to be more source-faithful and formula-driven (virtual-bond gauge, chain FT, gauge-phase variant, translation-invariant corollaries, blocked-chain FT, finite-length FT, block matching, and TI reduction).
> 
> Clarifies hypotheses/conclusions (e.g., `SameMPV` meaning, TI collapse output matching the actual `IsUnit Z`/`lam` statement, and `N`-block injectivity wording) and standardizes references/notation; no declarations, statements, or proof terms change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f2443af7eb39cce91a5ed5c1aa75d3233fa26b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->