### PR TITLE
doc(Spectral): add Wolf Ch 6 references to blueprint and Lean docstrings

### DIFF
--- a/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
+++ b/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
@@ -15,7 +15,8 @@ import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 # Peripheral eigenvalues closed under powers (fixed-point version)
 
 This file contains the preferred live formulation of peripheral-spectrum
-closure under powers.
+closure under powers, following the proof structure of Wolf Theorem 6.6
+(peripheral spectrum of irreducible Schwarz maps).
 
 Instead of assuming both unitality and trace preservation, we work with a
 unital Kraus family together with a **positive definite fixed point of the
@@ -23,7 +24,9 @@ adjoint map** (a faithful invariant state).
 
 The key new input is the weighted Kadison–Schwarz equality
 `Kraus.ks_equality_of_peripheral_eigenvector_of_fixedPoint` from
-`TNLean/Channel/Schwarz/Basic.lean`.
+`TNLean/Channel/Schwarz/Basic.lean`, which corresponds to Wolf Theorem 5.3
+(the equality case of the Kadison–Schwarz inequality for peripheral
+eigenvectors).
 
 The older special-case formulation `TNLean/Archive/PeripheralClosure.lean` is
 retained only for compatibility and is intentionally off the stable root

--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -12,6 +12,12 @@ Shared Frobenius-norm identities for the spectral-gap modules (`SpectralGap.lean
 `SpectralGapRect.lean`).  Everything here works for *rectangular*
 `Matrix (Fin m) (Fin n) ℂ`; the square case is obtained by setting `m = n`.
 
+The Frobenius (Hilbert--Schmidt) norm is used throughout the spectral-gap
+proofs in this repository (cf. PerezGarcia2007).  Wolf Chapter 6 proves the
+same eigenvalue bound using the operator norm via Russo--Dye
+(Proposition 6.1); both norms yield the same spectral-radius estimate
+for finite-dimensional CP maps.
+
 ## Main definitions
 
 * `MPSTensor.frobSq`: Frobenius norm squared, `∑ i j, ‖X i j‖²`.

--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -8,15 +8,15 @@ import Mathlib.Analysis.Matrix.Order
 /-!
 # Frobenius norm squared and Euclidean-space embedding for matrices
 
-Shared Frobenius-norm identities for the spectral-gap modules (`SpectralGap.lean`,
-`SpectralGapRect.lean`).  Everything here works for *rectangular*
+Frobenius-norm identities for rectangular matrices. Everything here works for
+*rectangular*
 `Matrix (Fin m) (Fin n) ℂ`; the square case is obtained by setting `m = n`.
 
-The Frobenius (Hilbert--Schmidt) norm is used throughout the spectral-gap
-proofs in this repository (cf. PerezGarcia2007).  Wolf Chapter 6 proves the
-same eigenvalue bound using the operator norm via Russo--Dye
-(Proposition 6.1); both norms yield the same spectral-radius estimate
-for finite-dimensional CP maps.
+The Frobenius (Hilbert--Schmidt) norm gives the rectangular Cauchy--Schwarz
+estimates used in the MPS spectral-gap argument of PerezGarcia2007. Wolf
+Chapter 6 proves the analogous eigenvalue bound for positive maps by the
+operator norm and Russo--Dye theorem (Proposition 6.1); in finite dimension
+both norms give the same spectral radius.
 
 ## Main definitions
 

--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -9,7 +9,6 @@ import Mathlib.Analysis.Matrix.Order
 # Frobenius norm squared and Euclidean-space embedding for matrices
 
 Frobenius-norm identities for rectangular matrices. Everything here works for
-*rectangular*
 `Matrix (Fin m) (Fin n) ℂ`; the square case is obtained by setting `m = n`.
 
 The Frobenius (Hilbert--Schmidt) norm gives the rectangular Cauchy--Schwarz

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -11,19 +11,15 @@ import Mathlib.Data.Matrix.Block
 import Mathlib.Analysis.Matrix.Normed
 
 /-!
-# Shared gauge construction for spectral-gap rigidity
+# Gauge construction for spectral-gap rigidity
 
-This module factors out the common "modulus-one eigenvector gives intertwining"
-core used by the spectral-gap rigidity arguments, following the proof pattern
-of Wolf Theorems 6.6 (peripheral spectrum of irreducible Schwarz maps)
-and PerezGarcia2007 Lemma 5 (spectral gap for distinct MPS blocks).
-The shared pattern is:
-
-1. gauge both tensors to left-canonical / unital form;
-2. transport the mixed-transfer eigenvector into that gauge;
-3. block-embed the transported eigenvector into a unital Kraus map;
-4. use weighted Kadison--Schwarz equality (Wolf Theorem 5.3) to obtain Kraus-level intertwining;
-5. feed the intertwining identities into the file-specific endgames.
+For tensors $A$ and $B$, a mixed-transfer eigenvector with $|\lambda|=1$
+can be transported through left-canonical gauges.  After embedding the
+transported matrix into a block Kraus map, equality in the weighted
+Kadison--Schwarz inequality gives intertwining relations between the
+gauged Kraus operators.  This is the common argument in Wolf Theorem 6.6
+(peripheral spectrum of irreducible Schwarz maps) and PerezGarcia2007
+Lemma 5 (spectral gap for distinct MPS blocks).
 -/
 
 open scoped Matrix Matrix.Norms.Operator MatrixOrder ComplexOrder BigOperators
@@ -32,9 +28,8 @@ attribute [local instance] Matrix.linftyOpNormedAddCommGroup Matrix.linftyOpNorm
 
 /-! ### ContinuousLinearMap endomorphism structure
 
-These definitions provide the analytic structure on `Matrix (Fin m) (Fin n) ℂ →L[ℂ] …`
-needed by the spectral-radius arguments. They are activated locally via
-`attribute [local instance]` in each consumer file. -/
+These definitions provide the analytic structure on continuous endomorphisms
+of rectangular complex matrices needed by the spectral-radius arguments. -/
 
 section CLMInstances
 open scoped Matrix.Norms.Frobenius

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -14,12 +14,15 @@ import Mathlib.Analysis.Matrix.Normed
 # Shared gauge construction for spectral-gap rigidity
 
 This module factors out the common "modulus-one eigenvector gives intertwining"
-core used by the spectral-gap rigidity arguments.  The shared pattern is:
+core used by the spectral-gap rigidity arguments, following the proof pattern
+of Wolf Theorems 6.6 (peripheral spectrum of irreducible Schwarz maps)
+and PerezGarcia2007 Lemma 5 (spectral gap for distinct MPS blocks).
+The shared pattern is:
 
 1. gauge both tensors to left-canonical / unital form;
 2. transport the mixed-transfer eigenvector into that gauge;
 3. block-embed the transported eigenvector into a unital Kraus map;
-4. use weighted Kadison--Schwarz equality to obtain Kraus-level intertwining;
+4. use weighted Kadison--Schwarz equality (Wolf Theorem 5.3) to obtain Kraus-level intertwining;
 5. feed the intertwining identities into the file-specific endgames.
 -/
 

--- a/TNLean/Spectral/MPVOverlapDecay.lean
+++ b/TNLean/Spectral/MPVOverlapDecay.lean
@@ -19,7 +19,9 @@ open Matrix Filter
 # MPV overlap decay
 
 This file proves a literature-standard decay statement for the *MPV overlap*
-`mpvOverlap A B N` in the **square bond dimension** case.
+`mpvOverlap A B N` in the **square bond dimension** case
+(cf. PerezGarcia2007 Lemma 5; Wolf Theorem 6.6 for the underlying
+spectral-gap theory).
 
 If `A` and `B` are injective, satisfy the trace-preserving normalization
 `∑ i, (A i)ᴴ * A i = 1` and `∑ i, (B i)ᴴ * B i = 1`, and are **not** gauge-phase

--- a/TNLean/Spectral/MixedTransfer.lean
+++ b/TNLean/Spectral/MixedTransfer.lean
@@ -33,7 +33,9 @@ multi-block fundamental theorem.
 ## References
 
 * [PerezGarcia2007String] Pérez-García, Verstraete, Wolf, Cirac,
-  *Matrix Product State Representations*, 2007.
+  *Matrix Product State Representations*, 2007. (transfer maps, §II.B)
+* [Wolf2012Quantum] Wolf, *Quantum Channels & Operations: Guided Tour*,
+  Chapter 6. (spectral theory of the mixed transfer map as a CP map)
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Spectral/PrimitiveOverlap.lean
+++ b/TNLean/Spectral/PrimitiveOverlap.lean
@@ -16,7 +16,9 @@ This module derives the **primitive/aperiodic overlap normalization**
 
 `mpvOverlap A A N → 1`
 
-from a spectral-gap hypothesis on the transfer map.
+from a spectral-gap hypothesis on the transfer map
+(cf. Wolf Theorem 6.7: a primitive TP map has trivial peripheral spectrum,
+so its powers converge to the rank-one projection onto the stationary state).
 
 More precisely, if a trace-preserving map `E` has a (nonzero) fixed point `ρ`, and the
 spectral radius of the complementary map `N := E - fixedPointProj ρ` is strictly less than `1`,

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -32,8 +32,10 @@ to zero. This is the mechanism by which the mixed transfer operator
 
 ## References
 
+* [Wolf2012Quantum] Wolf, *Quantum Channels & Operations: Guided Tour*,
+  Proposition 6.1, Theorem 6.6, Section 6.2.
 * [PerezGarcia2007String] Pérez-García, Verstraete, Wolf, Cirac,
-  *Matrix Product State Representations*, 2007.
+  *Matrix Product State Representations*, 2007. Lemma 5.
 * [Evans1978Spectral] Evans, Hanche-Olsen, *Spectral properties of positive
   maps on C*-algebras*, 1978.
 -/
@@ -210,7 +212,12 @@ private lemma hs_contraction_mixedTransfer [NeZero D]
 
 /-! ### Eigenvalue bound -/
 
-/-- **Every eigenvalue of the mixed transfer operator has modulus ≤ 1.** -/
+/-- **Every eigenvalue of the mixed transfer operator has modulus ≤ 1.**
+
+This is the MPS specialization of Wolf Proposition 6.1
+(the spectral radius of a positive unital/trace-preserving map is ≤ 1).
+The proof uses a uniform Frobenius-norm contraction estimate rather than
+the Russo--Dye operator-norm argument of Wolf, following PerezGarcia2007. -/
 theorem eigenvalue_norm_le_one [NeZero D]
     (A B : MPSTensor d D)
     (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -412,9 +419,15 @@ end
 set_option synthInstance.maxHeartbeats 200000 in
 -- Instance search for the finite-dimensional continuous endomorphism space of matrices
 -- needs a local heartbeat bump during the spectral-radius extraction.
-/-- **Eigenvalue rigidity** (Pérez-García et al. 2007, Lemma 5):
+/-- **Eigenvalue rigidity** (PerezGarcia2007 Lemma 5, cf. Wolf Theorem 6.6):
 if the mixed transfer spectral radius is ≥ 1, then A and B are
-gauge-phase equivalent. -/
+gauge-phase equivalent.
+
+The proof passes to the left-canonical gauge, uses the Kadison--Schwarz
+equality for peripheral eigenvectors (Wolf Theorem 5.3, 5.4), applies the
+Kraus-commutation step to obtain intertwining relations, and concludes
+invertibility via the Perron--Frobenius fixed-point theory
+(Wolf Theorems 6.2, 6.3). -/
 theorem modulus_one_eigenvalue_implies_gauge
     (A B : MPSTensor d D)
     (hA : IsInjective A) (hB : IsInjective B)

--- a/TNLean/Spectral/SpectralGapNT.lean
+++ b/TNLean/Spectral/SpectralGapNT.lean
@@ -11,13 +11,14 @@ import TNLean.MPS.Irreducible.FormII
 # Spectral gap for normal tensor (irreducible + TP) blocks
 
 This file proves the overlap dichotomy for irreducible trace-preserving / left-canonical
-blocks without assuming injectivity, following the Cauchy--Schwarz argument from
-Cirac et al., arXiv:1606.00608, Appendix A, Lemma A.1.
+blocks without assuming injectivity. The argument combines the Cauchy--Schwarz
+rigidity from Cirac et al., arXiv:1606.00608, Appendix A, Lemma A.1 with the
+irreducibility theory of Wolf Section 6.2 (Theorems 6.2, 6.3).
 
 The key new rigidity statement is
 `modulus_one_eigenvalue_implies_gauge_of_irreducible_TP`: if two irreducible
 left-canonical tensors have mixed-transfer spectral radius at least `1`, then they are
-already gauge-phase equivalent.
+already gauge-phase equivalent (cf. Wolf Theorem 6.6 adapted to MPS transfer maps).
 
 The same-dimension rigidity step is now fully formalized. The downstream strict-gap and
 overlap-decay consequences for equal bond dimension are routed through the existing

--- a/TNLean/Spectral/SpectralGapRect.lean
+++ b/TNLean/Spectral/SpectralGapRect.lean
@@ -19,8 +19,9 @@ dimensions** `D₁ ≠ D₂`, the spectral radius of the rectangular mixed trans
 `mixedTransferMap₂ A B` is strictly less than 1 (assuming both tensors are injective and
 normalized).
 
-This is the "dimension-mismatch" spectral gap: if the bond dimensions differ, then the overlap
-`∑ σ, mpv A σ * conj(mpv B σ)` decays to zero exponentially.
+This is the "dimension-mismatch" spectral gap (cf. Wolf Theorem 6.6 adapted to
+MPS transfer maps with rectangular bond dimensions): if the bond dimensions differ, then
+the overlap `∑ σ, mpv A σ * conj(mpv B σ)` decays to zero exponentially.
 
 ## Main results
 

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -249,10 +249,13 @@ Euclidean space.
 \section{Eigenvalue bound and spectral gap}
 
 The eigenvalue bound comes from a uniform Frobenius-norm estimate
-obtained directly from the trace-preserving normalization.
+obtained directly from the trace-preserving normalization
+(cf.\ \cite[Proposition~6.1]{Wolf2012Quantum} for the general
+operator-norm version via Russo--Dye).
 For the rigidity theorem, one gauges $A$ and $B$ separately using
 positive fixed points of their transfer maps to obtain unital Kraus
-families, and then applies the Kadison--Schwarz equality argument to
+families, and then applies the Kadison--Schwarz equality argument
+(\cite[Theorem~5.3]{Wolf2012Quantum}) to
 a block embedding of a mixed-transfer eigenvector.
 
 \begin{theorem}[Eigenvalue bound]\label{thm:eigenvalue_bound}
@@ -593,7 +596,8 @@ The preceding spectral-gap results require \emph{injectivity} of both
 tensors.  The following variants weaken this to \emph{irreducibility}
 combined with trace-preserving normalization
 ($\sum_i (A^i)^\dagger A^i = \Id$), following Cirac et
-al.~\cite{Cirac2017Annals}.  The argument replaces the
+al.~\cite{Cirac2017Annals} and the irreducibility theory of
+\cite[Section~6.2]{Wolf2012Quantum}.  The argument replaces the
 Kraus-commutation step with a Cauchy--Schwarz rigidity argument for
 the Perron--Frobenius fixed point.
 
@@ -733,6 +737,13 @@ the Perron--Frobenius fixed point.
 \end{proof}
 
 \section{Conditional expectation from a faithful fixed point}
+
+This section follows \cite[Section~6.4, Theorem~6.15]{Wolf2012Quantum}.
+The scalar conditional expectation $E_\sigma$ is the special case where
+the fixed-point $*$-subalgebra is the scalar algebra $\C\cdot\Id$
+(the primitive-channel case). The general irreducible case with
+nontrivial period requires the Wedderburn block decomposition
+(\cite[Theorem~6.14]{Wolf2012Quantum}, not yet formalized here).
 
 \begin{definition}[Conditional expectation]\label{def:is_conditional_expectation}
     \lean{Kraus.IsConditionalExpectation}
@@ -875,7 +886,8 @@ the Perron--Frobenius fixed point.
 \section{Stationary support}
 
 This section develops the support-projection theory
-behind stationary states, following~\cite[Section~6.4]{Wolf2012Quantum}.
+behind stationary states, following
+\cite[Section~6.4, Propositions~6.10--6.11]{Wolf2012Quantum}.
 
 \begin{lemma}[Lower-triangular Kraus condition implies corner invariance]%
     \label{lem:lower_zero_invariance}
@@ -1057,6 +1069,14 @@ sector is positive definite.
 
 \section{Wedderburn decomposition of the fixed-point algebra}
 
+This section formalizes the structure theorem for the fixed-point
+algebra of a trace-preserving Kraus map, following
+\cite[Theorems~6.12--6.14]{Wolf2012Quantum}. The proof uses the
+Jacobson radical characterization of semisimplicity
+(\cite[Theorem~6.14]{Wolf2012Quantum}) and the Wedderburn--Artin
+structure theorem for finite-dimensional semisimple algebras over an
+algebraically closed field.
+
 \begin{theorem}[Fixed-point algebra is semisimple]%
     \label{thm:fixedPointAlgebra_isSemisimpleRing}
     \lean{Kraus.fixedPointAlgebra_isSemisimpleRing}
@@ -1164,7 +1184,8 @@ sector is positive definite.
 
 \section{Further irreducibility and primitivity equivalences}
 
-This section collects several criteria and equivalences from Wolf's Chapter~6 that are
+This section collects several criteria and equivalences from
+\cite[Theorems~6.2, 6.7, 6.8]{Wolf2012Quantum} that are
 used later.
 
 \begin{theorem}[Exponential positivity condition]%
@@ -1219,6 +1240,11 @@ used later.
 \end{theorem}
 
 \section{Multi-cycle block-permutation data}
+
+This section formalizes the block-permutation structure underlying the
+cycle decomposition of \cite[Theorem~6.16]{Wolf2012Quantum}. The
+multi-cycle decomposition refines the single-cycle case to handle
+arbitrary peripheral periods.
 
 \begin{definition}[Block-permutation data]
     \label{def:cycle_structure}
@@ -1308,6 +1334,11 @@ used later.
 \end{definition}
 
 \section{Peripheral eigenvalue group structure}
+
+This section formalizes the peripheral spectrum structure of
+\cite[Theorem~6.6]{Wolf2012Quantum} for irreducible Schwarz maps:
+the peripheral eigenvalues form a finite cyclic group whose order
+divides the bond dimension.
 
 \begin{lemma}[Peripheral eigenvectors are invertible]%
     \label{lem:isUnit_peripheral_eigenvector}
@@ -1569,7 +1600,8 @@ used later.
 
 The theorems in this section are stated directly in terms of the
 complementary map $E - P$. This is the analytic form needed for the later
-overlap argument.
+overlap argument, corresponding to the primitive-case specialization of
+\cite[Theorem~6.7]{Wolf2012Quantum} where $T_\phi$ is a rank-one projection.
 For primitive normalized transfer maps, Chapter~\ref{ch:channels} supplies
 this spectral-gap input under explicit hypotheses.
 

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -743,7 +743,9 @@ The scalar conditional expectation $E_\sigma$ is the special case where
 the fixed-point $*$-subalgebra is the scalar algebra $\C\cdot\Id$
 (the primitive-channel case). The general irreducible case with
 nontrivial period requires the Wedderburn block decomposition
-(\cite[Theorem~6.14]{Wolf2012Quantum}, not yet formalized here).
+of \cite[Theorem~6.14]{Wolf2012Quantum}.
+% The nontrivial-period conditional expectation is outside the present
+% formal scope of this section.
 
 \begin{definition}[Conditional expectation]\label{def:is_conditional_expectation}
     \lean{Kraus.IsConditionalExpectation}
@@ -1069,7 +1071,7 @@ sector is positive definite.
 
 \section{Wedderburn decomposition of the fixed-point algebra}
 
-This section formalizes the structure theorem for the fixed-point
+This section proves the structure theorem for the fixed-point
 algebra of a trace-preserving Kraus map, following
 \cite[Theorems~6.12--6.14]{Wolf2012Quantum}. The proof uses the
 Jacobson radical characterization of semisimplicity
@@ -1239,14 +1241,14 @@ used later.
     expectation onto the adjoint fixed-point $*$-subalgebra.
 \end{theorem}
 
-\section{Multi-cycle block-permutation data}
+\section{Multi-cycle block-permutation structure}
 
-This section formalizes the block-permutation structure underlying the
+This section develops the block-permutation structure underlying the
 cycle decomposition of \cite[Theorem~6.16]{Wolf2012Quantum}. The
 multi-cycle decomposition refines the single-cycle case to handle
 arbitrary peripheral periods.
 
-\begin{definition}[Block-permutation data]
+\begin{definition}[Block-permutation structure]
     \label{def:cycle_structure}
     \lean{CycleStructure}
     \leanok
@@ -1263,7 +1265,7 @@ arbitrary peripheral periods.
     for every $k \in \iota$ and $X \in \MN{D}$.
 \end{definition}
 
-\begin{definition}[Multi-cycle block-permutation data]
+\begin{definition}[Multi-cycle block-permutation structure]
     \label{def:multi_cycle_decomposition}
     \lean{MultiCycleDecomposition}
     \leanok
@@ -1319,7 +1321,7 @@ arbitrary peripheral periods.
     Theorem~\ref{thm:multi_cycle_preserves_corner_pow_period}.
 \end{proof}
 
-\begin{definition}[Flattening to single-index block-permutation data]
+\begin{definition}[Flattening to a single-index block-permutation structure]
     \label{def:multi_cycle_to_cycle_structure}
     \lean{MultiCycleDecomposition.toCycleStructure}
     \leanok
@@ -1335,7 +1337,7 @@ arbitrary peripheral periods.
 
 \section{Peripheral eigenvalue group structure}
 
-This section formalizes the peripheral spectrum structure of
+This section proves the peripheral spectrum structure of
 \cite[Theorem~6.6]{Wolf2012Quantum} for irreducible Schwarz maps:
 the peripheral eigenvalues form a finite cyclic group whose order
 divides the bond dimension.

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -738,7 +738,9 @@ the Perron--Frobenius fixed point.
 
 \section{Conditional expectation from a faithful fixed point}
 
-This section follows \cite[Section~6.4, Theorem~6.15]{Wolf2012Quantum}.
+This section follows \cite[Section~6.4]{Wolf2012Quantum}; the conditional
+expectation is built from the fixed-point algebra of
+\cite[Theorem~6.14]{Wolf2012Quantum} via \cite[(1.40)]{Wolf2012Quantum}.
 The scalar conditional expectation $E_\sigma$ is the special case where
 the fixed-point $*$-subalgebra is the scalar algebra $\C\cdot\Id$
 (the primitive-channel case). The general irreducible case with
@@ -1074,10 +1076,9 @@ sector is positive definite.
 This section proves the structure theorem for the fixed-point
 algebra of a trace-preserving Kraus map, following
 \cite[Theorems~6.12--6.14]{Wolf2012Quantum}. The proof uses the
-Jacobson radical characterization of semisimplicity
-(\cite[Theorem~6.14]{Wolf2012Quantum}) and the Wedderburn--Artin
-structure theorem for finite-dimensional semisimple algebras over an
-algebraically closed field.
+Jacobson radical characterization of semisimplicity together with the
+Wedderburn--Artin structure theorem for finite-dimensional semisimple
+algebras over an algebraically closed field.
 
 \begin{theorem}[Fixed-point algebra is semisimple]%
     \label{thm:fixedPointAlgebra_isSemisimpleRing}
@@ -1339,8 +1340,10 @@ arbitrary peripheral periods.
 
 This section proves the peripheral spectrum structure of
 \cite[Theorem~6.6]{Wolf2012Quantum} for irreducible Schwarz maps:
-the peripheral eigenvalues form a finite cyclic group whose order
-divides the bond dimension.
+the peripheral eigenvalues form a finite cyclic group.
+The trace-preserving refinement that the order divides the bond
+dimension is proved in
+Theorem~\ref{thm:peripheral_cyclic_group}.
 
 \begin{lemma}[Peripheral eigenvectors are invertible]%
     \label{lem:isUnit_peripheral_eigenvector}


### PR DESCRIPTION
### Motivation
- Issue #1413 tracks a source-faithful audit of `blueprint/src/chapter/ch06_spectral.tex` and cited Lean docstrings.
- Wolf Chapter 6 references should be stated as mathematical proof structure, without rendered proof-status notes or process language.

### Description
- Adds Wolf Chapter 6 theorem citations in the spectral/peripheral documentation.
- Replaces visible formalization-status prose in the blueprint with mathematical references and a LaTeX comment for scope.
- Rephrases reviewed Spectral docstrings around Frobenius norm and mixed-transfer gauge construction using mathematical statements.
- Renames the touched block-permutation blueprint headings from data to structure.

### Testing
- `lake env lean TNLean/Spectral/GaugeConstruction.lean`
- `lake env lean TNLean/Spectral/FrobeniusNorm.lean`
- `git diff --check`

Closes #1413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates (Lean module docstrings and the spectral blueprint) that add/clarify literature references and rename headings; no mathematical statements or proofs are changed.
> 
> **Overview**
> Updates spectral/peripheral documentation to be source-faithful to Wolf’s *Quantum Channels & Operations* Chapter 6.
> 
> Lean module docstrings are rephrased to explicitly mirror the Wolf proof structure (notably Theorems 5.3, 6.6, 6.7) and to clarify the role of Frobenius/Hilbert–Schmidt estimates and the gauge/Kadison–Schwarz intertwining step.
> 
> The Chapter 6 blueprint text is revised to add the corresponding Wolf citations, remove formalization-status phrasing in favor of mathematical references (with scoped comments where needed), and rename the “block-permutation data” section headings to “block-permutation structure” to match the intended semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae1aac72b251f59ae5625729cf77421a39a3f22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->