### PR TITLE
doc(ci): document auto-fix intervention policy

### DIFF
--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -24,6 +24,12 @@ This repository uses [Claude Code](https://docs.anthropic.com/en/docs/claude-cod
   - [Shared CI Auto-Fix Template (Codex)](#shared-ci-auto-fix-template-codex-_codex-auto-fix-sharedyml)
 - [Safety Mechanisms](#safety-mechanisms)
 - [How to Use](#how-to-use)
+  - [For any PR (automatic)](#for-any-pr-automatic)
+  - [Auto-fix labels are PR-only](#auto-fix-labels-are-pr-only)
+  - [To enable Codex auto-fix](#to-enable-codex-auto-fix)
+  - [To enable the review-fix loop](#to-enable-the-review-fix-loop)
+  - [Human intervention while auto-fix is active](#human-intervention-while-auto-fix-is-active)
+  - [To ask Claude for help directly](#to-ask-claude-for-help-directly)
 - [Commit Message Conventions](#commit-message-conventions)
 - [Permissions](#permissions)
 - [Changing the Configuration](#changing-the-configuration)
@@ -514,9 +520,12 @@ human maintainers may still do workflow-control actions:
 - add or remove `auto-fix-claude` / `auto-fix-codex`
 - refresh status and inspect review threads
 - merge only after all required checks are complete and every current review
-  thread is resolved or outdated
+  thread is resolved or outdated, and no auto-fix job is still running for the
+  branch
 - close or supersede the pull request after verifying that no unique
-  mathematical content would be lost
+  mathematical content would be lost; remove auto-fix labels first, and do not
+  delete the branch until in-progress auto-fix jobs have finished or been
+  cancelled
 
 Manual commits to an auto-fix branch are appropriate only after the automated
 cycle has exhausted its iteration budget, failed without a useful follow-up

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -504,6 +504,24 @@ To disable Claude auto-fix globally, set repository variable
 `CLAUDE_AUTO_FIX_ENABLED=false`. Unset it, or set another value, to restore the
 default enabled behavior.
 
+### Human intervention while auto-fix is active
+
+Once a pull request has entered the auto-fix loop, do not manually patch that
+pull request's branch while CI, blueprint, review, or auto-fix jobs are still
+running. Let the automated cycle reach a terminal state first. During the loop,
+human maintainers may still do workflow-control actions:
+
+- add or remove `auto-fix-claude` / `auto-fix-codex`
+- refresh status and inspect review threads
+- merge only after all required checks are complete and every current review
+  thread is resolved or outdated
+- close or supersede the pull request after verifying that no unique
+  mathematical content would be lost
+
+Manual commits to an auto-fix branch are appropriate only after the automated
+cycle has exhausted its iteration budget, failed without a useful follow-up
+commit, or a maintainer explicitly hands the branch back for local repair.
+
 ### To ask Claude for help directly
 
 Write a comment on any issue or PR that includes `@claude` followed by your request. For example:


### PR DESCRIPTION
### Motivation
- We are using `@claude auto fix` to launch multiple source-faithful cleanup PRs in parallel.
- Maintainers need a written rule for when to let the automated loop finish before making local commits on those branches.

### Description
- Adds a `docs/ci-automation.md` subsection on human intervention while auto-fix is active.
- Allows workflow-control actions such as labels, status checks, review-thread inspection, merge, and superseding.
- Reserves manual branch commits for exhausted, failed, or explicitly handed-back auto-fix loops.

### Testing
- `git diff --check`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
<!-- No linked issue — please link a relevant issue. -->

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change with no impact on CI behavior or production code paths.
> 
> **Overview**
> Documents a new **"Human intervention while auto-fix is active"** policy in `docs/ci-automation.md`, advising maintainers not to push manual commits to an auto-fix branch while automation jobs are running.
> 
> Clarifies what actions *are* acceptable during the loop (label toggling, status/review inspection, merging once checks pass, or superseding/closing after verifying no unique math is lost) and when manual commits are appropriate (after iteration cap exhaustion, failed runs, or explicit hand-back for local repair).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit decc7f6271cb28afd0bcb663ac943d8f21f9a1f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates documentation and does not change any workflow code or CI behavior.
> 
> **Overview**
> Adds a new **"Human intervention while auto-fix is active"** section to `docs/ci-automation.md`, clarifying that maintainers should avoid pushing manual commits to branches while CI/review/auto-fix jobs are running.
> 
> Documents which workflow-control actions are still acceptable during the loop (label toggling, status/review inspection, merging after checks complete, and safely closing/superseding), and when manual commits are appropriate (after iteration cap exhaustion, failed runs, or explicit hand-off).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6262dbd2ba1344ef02cdaa7265f7a2b30bb7715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->