### PR TITLE
doc(MPS): source-faithful prose in definitions chapter

### DIFF
--- a/TNLean/MPS/Core/Transfer.lean
+++ b/TNLean/MPS/Core/Transfer.lean
@@ -9,8 +9,8 @@ import Mathlib.LinearAlgebra.Matrix.PosDef
 
 This file defines the transfer operator `transferMap` associated to an MPS
 tensor. It proves the basic properties needed later: the evaluation formula, gauge
-covariance, and preservation of positive semidefiniteness. These lemmas bridge
-between tensor data and channel-theoretic arguments.
+covariance, and preservation of positive semidefiniteness. These results connect
+the tensor-level definitions to channel-theoretic arguments.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/MPS/Overlap/Basic.lean
+++ b/TNLean/MPS/Overlap/Basic.lean
@@ -35,7 +35,8 @@ abbrev Cfg (d N : ℕ) := Fin N → Fin d
 /-- The Hilbert space of MPV coefficients, viewed as an `ℓ²` space over configurations. -/
 abbrev MPVSpace (d N : ℕ) := EuclideanSpace ℂ (Cfg d N)
 
-/-- The MPV coefficients of `A` at system size `N`, bundled as a vector in `MPVSpace d N`. -/
+/-- The MPV coefficients of `A` at system size `N`, as an element of the Hilbert space
+`MPVSpace d N`. -/
 noncomputable def mpvState {d D : ℕ} (A : MPSTensor d D) (N : ℕ) : MPVSpace d N :=
   (EuclideanSpace.equiv (ι := Cfg d N) (𝕜 := ℂ)).symm (fun σ => mpv A σ)
 

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -414,8 +414,9 @@ boundary conditions (PBC).
     \[
         A^i \;=\; \bigoplus_{k=1}^{r} \mu_k \, A_k^i.
     \]
-    This is the block-injective version of the canonical-form data;
-    see~\cite{PerezGarcia2007Matrix} and~\cite{Cirac2021Matrix}.
+    This block-injective formulation of the canonical form is used in
+    \cite{PerezGarcia2007Matrix}; see also~\cite{Cirac2021Matrix} for the
+    normal canonical form.
 \end{definition}
 
 \begin{remark}\label{rem:cf_injective_vs_normal}\leanok


### PR DESCRIPTION
### Motivation
- Implements #1405: audit of MPS definitions chapter for source-faithful
  mathematical terminology (arXiv:2011.12127).
- Replaces banned software-engineering prose in Lean docstrings and the
  blueprint with precise mathematical language.

### Description
- `TNLean/MPS/Core/Transfer.lean`: refined `transferMap` docstring to use
  Hilbert-space and channel-theoretic terminology consistent with the source.
- `TNLean/MPS/Overlap/Basic.lean`: updated `mpvState` documentation phrasing.
- `blueprint/src/chapter/ch02_mps.tex`: updated canonical-form references to
  cite Perez-Garcia et al. 2007 and Cirac et al. 2021.
- No definitional or proof changes — documentation-only.

### Testing
- Relies on Lean CI (`lean_action_ci.yml`) and blueprint lint
  (`lint-blueprint.yml`) to validate build and references.

---
Addresses #1405

> [!NOTE]
> **Low Risk**
> Documentation-only wording updates in Lean docstrings/comments and the blueprint TeX; no definitional or proof changes, so behavior and correctness risk is minimal.
> 
> **Overview**
> Updates MPS documentation phrasing to be more precise and source-faithful.
> 
> In Lean files, refines module/doc comments around `transferMap` and `mpvState` to better describe the Hilbert-space packaging and the connection to channel-theoretic arguments. In the blueprint, adjusts the canonical-form discussion to cite \cite{PerezGarcia2007Matrix} as the source for the block-injective formulation and clarifies the relationship to the normal canonical form in \cite{Cirac2021Matrix}.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c620ca3b60fd257ce53e9d981f0372141b39cb31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>