### PR TITLE
style(Wielandt): replace assembly prose by theorem-content names

### DIFF
--- a/TNLean/Wielandt/RankOne/Construction.lean
+++ b/TNLean/Wielandt/RankOne/Construction.lean
@@ -12,7 +12,7 @@ import Mathlib.Data.List.FinRange
 /-!
 # Rank-one construction (reductions)
 
-`TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean` already proves the **assembly step** of
+`TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean` already proves the **vector-to-matrix spanning step** of
 Wielandt Lemma 2(b): if
 
 * word products of length `n` applied to a vector `φ` span all of `ℂ^D`, and
@@ -391,11 +391,11 @@ theorem vecMulVec_pi_single_mem_wordSpan_of_rankOne
   -- Substitute the chosen `M` so that `ψ ᵥ* M = e_j`.
   simpa [hcalc, hvec] using hprod
 
-/-- **(Optional assembly)** If `vectorSpreadSpan A φ n = ⊤`, and one can build a
+/-- **Rank-one reduction** If `vectorSpreadSpan A φ n = ⊤`, and one can build a
 single rank-one element `|φ⟩⟨ψ|` inside `wordSpan A m` together with a row
 spreading statement `rowSpreadSpan A ψ k = ⊤`, then `wordSpan A (n + (m+k)) = ⊤`.
 
-This composes the reduction above with the assembly lemma from `SpanGrowth/VectorToMatrixSpan.lean`.
+This composes the reduction above with the vector-to-matrix spanning lemma from `SpanGrowth/VectorToMatrixSpan.lean`.
 -/
 theorem wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOne
     (A : MPSTensor d D) (φ ψ : Fin D → ℂ) {n m k : ℕ}
@@ -408,7 +408,7 @@ theorem wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOne
       Matrix.vecMulVec φ (Pi.single j (1 : ℂ)) ∈ wordSpan A (m + k) :=
     vecMulVec_pi_single_mem_wordSpan_of_rankOne (A := A) (φ := φ) (ψ := ψ)
       (m := m) (k := k) hRankOne hRow
-  -- Then apply the existing assembly lemma.
+  -- Then apply the existing vector-to-matrix spanning lemma.
   simpa [Nat.add_assoc] using
     (wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis
       (A := A) (φ := φ) (n := n) (m := m + k) hVec hRankOneBasis)

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -339,12 +339,12 @@ section WielandtLemma2b
 For any `IsNormal` MPS tensor `A` with `[NeZero D]`, there exists `N` such that
 `wordSpan A N = ⊤`.
 
-This combines the rank-one extraction with the blocked rectangular span theorem.
+This combines the rank-one extraction with the blocked fixed-length matrix spanning theorem.
 
 - When `N₀ = 0`: `wordSpan A 0 = ⊤` directly.
 - When `N₀ ≥ 1`: writing `B := blockTensor A N₀`, the rank-one extraction gives
   `vecMulVec φ ψ ∈ wordSpan B (D + N₀ + D)`, where the middle `N₀` is the
-  blocked-tensor full-span witness `wordSpan B N₀ = ⊤`; the blocked rectangular span then
+  blocked-tensor full-span witness `wordSpan B N₀ = ⊤`; the blocked fixed-length matrix spanning then
   produces `wordSpan A ((4D - 2 + N₀) * N₀) = ⊤`.
 
 The bound `N = (4D - 2 + N₀) * N₀` is coarse. -/
@@ -494,7 +494,7 @@ theorem wielandt_blocked_assembly_complete [NeZero D]
   obtain ⟨m_blocked, hRankOne⟩ :=
     exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors
       A L hL σ₀ τ₀ φ ψ μ ν hμ hν heigφ heigψ hNormal
-  -- Step 2: Apply the conditional rectangular span
+  -- Step 2: Apply the blocked fixed-length matrix spanning lemma
   exact ⟨(D - 1 + (m_blocked + (D - 1))) * L,
     wielandt_blocked_assembly A hNormal L hL σ₀ φ hφ μ hμ heigφ
       τ₀ ψ hψ ν hν heigψ hRankOne⟩

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -269,7 +269,7 @@ section RankOneExtraction
 /-- **Full rank-one extraction for Wielandt Lemma 2(b).**
 
 Under a positive normality witness `N₀ ≥ 1`, produces all data for the blocked
-rectangular span theorem:
+fixed-length matrix spanning theorem:
 - word functions `σ₀`, `τ₀` of length `N₀` with eigenvector conditions,
 - `vecMulVec φ ψ ∈ wordSpan (blockTensor A N₀) (D + N₀ + D)`.
 

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -269,7 +269,7 @@ section RankOneExtraction
 /-- **Full rank-one extraction for Wielandt Lemma 2(b).**
 
 Under a positive normality witness `N₀ ≥ 1`, produces all data for the blocked
-assembly theorem:
+rectangular span theorem:
 - word functions `σ₀`, `τ₀` of length `N₀` with eigenvector conditions,
 - `vecMulVec φ ψ ∈ wordSpan (blockTensor A N₀) (D + N₀ + D)`.
 
@@ -339,12 +339,12 @@ section WielandtLemma2b
 For any `IsNormal` MPS tensor `A` with `[NeZero D]`, there exists `N` such that
 `wordSpan A N = ⊤`.
 
-This combines the rank-one extraction with the blocked assembly theorem.
+This combines the rank-one extraction with the blocked rectangular span theorem.
 
 - When `N₀ = 0`: `wordSpan A 0 = ⊤` directly.
 - When `N₀ ≥ 1`: writing `B := blockTensor A N₀`, the rank-one extraction gives
   `vecMulVec φ ψ ∈ wordSpan B (D + N₀ + D)`, where the middle `N₀` is the
-  blocked-tensor full-span witness `wordSpan B N₀ = ⊤`; the blocked assembly then
+  blocked-tensor full-span witness `wordSpan B N₀ = ⊤`; the blocked rectangular span then
   produces `wordSpan A ((4D - 2 + N₀) * N₀) = ⊤`.
 
 The bound `N = (4D - 2 + N₀) * N₀` is coarse. -/
@@ -471,7 +471,7 @@ theorem exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors
   exact ⟨D + N₁ + D, by
     simpa [data.hB] using data.rankOne_mem_wordSpan_of_wordSpan_eq_top hBtop⟩
 
-/-- **Wielandt Lemma 2(b) blocked assembly from supplied word-eigenvector data.**
+/-- **Wielandt Lemma 2(b) blocked word-span saturation from supplied word-eigenvector data.**
 
 Given word eigenvectors of length `L` with nonzero eigenvalues and `IsNormal A`,
 produces `wordSpan A N = ⊤` for an explicit `N`.
@@ -494,7 +494,7 @@ theorem wielandt_blocked_assembly_complete [NeZero D]
   obtain ⟨m_blocked, hRankOne⟩ :=
     exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors
       A L hL σ₀ τ₀ φ ψ μ ν hμ hν heigφ heigψ hNormal
-  -- Step 2: Apply the conditional assembly
+  -- Step 2: Apply the conditional rectangular span
   exact ⟨(D - 1 + (m_blocked + (D - 1))) * L,
     wielandt_blocked_assembly A hNormal L hL σ₀ φ hφ μ hμ heigφ
       τ₀ ψ hψ ν hν heigψ hRankOne⟩

--- a/TNLean/Wielandt/RankOne/Products.lean
+++ b/TNLean/Wielandt/RankOne/Products.lean
@@ -16,7 +16,7 @@ import Mathlib.Analysis.Complex.Polynomial.Basic
 # Eigenvalue Extraction and Rank-One Products (Lemma 2(b) Ingredients)
 
 This file provides the eigenvalue/eigenvector extraction lemmas needed for
-the Quantum Wielandt bound assembly, corresponding to **Lemma 2(b)** of
+the Quantum Wielandt bound, corresponding to **Lemma 2(b)** of
 arXiv:0909.5347 (Sanz, Pérez-García, Wolf, Cirac).
 
 ## Mathematical background
@@ -296,7 +296,7 @@ theorem evalWord_replicate_eigenvector (A : MPSTensor d D)
     -- evalWord A w₀ *ᵥ (μ ^ k • φ) = μ ^ (k + 1) • φ
     rw [Matrix.mulVec_smul, heig, smul_smul, pow_succ]
 
-/-! ### Part 7: Connection lemmas for the Wielandt assembly -/
+/-! ### Part 7: Connection lemmas for the Wielandt fixed-length word span -/
 
 /-- **Word products of a normal tensor eventually span all matrices.**
 

--- a/TNLean/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/Basic.lean
@@ -12,12 +12,12 @@ import TNLean.Wielandt.RectangularSpan.Ranges
 import Mathlib.Data.Fin.Tuple.Basic
 
 /-!
-# Rectangular Span Foundations and Lemma 2(b) Assembly
+# Rectangular Span Foundations: Lemma 2(b) (conditional and blocked rectangular span)
 
 This module contains the foundational rectangular-span theory used in the Wielandt
 bound: blocking preserves normality, blocked eigenvector transfer, the basic
 one-sided and cumulative rectangular spans, and the conditional and blocked
-assembly steps for Lemma 2(b).
+rectangular-span theorems for Lemma 2(b).
 
 The later growth, stabilization, universality, and sharp quantitative theorems
 live in `TNLean.Wielandt.RectangularSpan.Growth` and
@@ -256,9 +256,9 @@ theorem cumulativeRectSpan_eq_range_of_isNormal [NeZero D]
   cumulativeRectSpan_eq_range_of_cumulativeSpan_eq_top P A
     (cumulativeSpan_eq_top A hN)
 
-/-! ## Section 5: Conditional assembly (Lemma 2(b)) -/
+/-! ## Section 5: Conditional rectangular span (Lemma 2(b)) -/
 
-/-- **Lemma 2(b) conditional assembly.**
+/-- **Lemma 2(b) conditional fixed-length matrix spanning.**
 
 If `IsNormal A`, and we have single-index eigenvectors (column and row)
 and a rank-one element in bounded `wordSpan`, then `wordSpan = ⊤`.
@@ -290,9 +290,9 @@ theorem wielandt_lemma2b_conditional [NeZero D]
   exact wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOne
     A φ ψ hVecSpread hRankOne hRowSpread
 
-/-! ## Section 6: Blocked assembly -/
+/-! ## Section 6: Blocked rectangular span -/
 
-/-- **Assembly at the blocked level.**
+/-- **Fixed-length matrix spanning at the blocked level.**
 
 Reduces the Wielandt bound to producing a rank-one element in the word
 span of the **blocked** tensor. The blocking period `L` absorbs the
@@ -330,7 +330,7 @@ theorem wielandt_blocked_assembly [NeZero D]
     exact heigψ
   -- B is normal
   have hNormalB : IsNormal B := isNormal_blockTensor A L hL hNormal
-  -- Apply the conditional assembly to B
+  -- Apply the conditional rectangular span lemma to B
   have hBtop : wordSpan B ((D - 1) + (m_blocked + (D - 1))) = ⊤ :=
     wielandt_lemma2b_conditional B hNormalB i₀ μ hμ φ hφ heigφ_B i₁ ν hν ψ hψ
       heigψ_B hRankOne

--- a/TNLean/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/Basic.lean
@@ -12,12 +12,12 @@ import TNLean.Wielandt.RectangularSpan.Ranges
 import Mathlib.Data.Fin.Tuple.Basic
 
 /-!
-# Rectangular Span Foundations: Lemma 2(b) (conditional and blocked rectangular span)
+# Rectangular Span Foundations: Lemma 2(b) (conditional and blocked fixed-length matrix spanning)
 
 This module contains the foundational rectangular-span theory used in the Wielandt
 bound: blocking preserves normality, blocked eigenvector transfer, the basic
 one-sided and cumulative rectangular spans, and the conditional and blocked
-rectangular-span theorems for Lemma 2(b).
+fixed-length matrix spanning theorems for Lemma 2(b).
 
 The later growth, stabilization, universality, and sharp quantitative theorems
 live in `TNLean.Wielandt.RectangularSpan.Growth` and
@@ -256,7 +256,7 @@ theorem cumulativeRectSpan_eq_range_of_isNormal [NeZero D]
   cumulativeRectSpan_eq_range_of_cumulativeSpan_eq_top P A
     (cumulativeSpan_eq_top A hN)
 
-/-! ## Section 5: Conditional rectangular span (Lemma 2(b)) -/
+/-! ## Section 5: Conditional fixed-length matrix spanning (Lemma 2(b)) -/
 
 /-- **Lemma 2(b) conditional fixed-length matrix spanning.**
 
@@ -290,7 +290,7 @@ theorem wielandt_lemma2b_conditional [NeZero D]
   exact wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOne
     A φ ψ hVecSpread hRankOne hRowSpread
 
-/-! ## Section 6: Blocked rectangular span -/
+/-! ## Section 6: Blocked fixed-length matrix spanning -/
 
 /-- **Fixed-length matrix spanning at the blocked level.**
 
@@ -330,7 +330,7 @@ theorem wielandt_blocked_assembly [NeZero D]
     exact heigψ
   -- B is normal
   have hNormalB : IsNormal B := isNormal_blockTensor A L hL hNormal
-  -- Apply the conditional rectangular span lemma to B
+  -- Apply the conditional fixed-length matrix spanning lemma to B
   have hBtop : wordSpan B ((D - 1) + (m_blocked + (D - 1))) = ⊤ :=
     wielandt_lemma2b_conditional B hNormalB i₀ μ hμ φ hφ heigφ_B i₁ ν hν ψ hψ
       heigψ_B hRankOne

--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -26,7 +26,7 @@ theorems.
   reduction of the sharp D²−D+1 bound to a single strict-growth hypothesis, and the
   structural invariance theorem `rectSpan_eq_mulLeft_image_of_finrank_eq`.
 - **Section 8h** (`ExactPropagation`): permanence chain via right-expansion of `rectSpan`,
-  strict growth under `IsNormal`, unconditional assembly, and eigenvector padding to exact
+  strict growth under `IsNormal`, unconditional rectangular span, and eigenvector padding to exact
   word-level.
 -/
 
@@ -194,7 +194,7 @@ every rank-one matrix `vecMulVec φ ψ` lies in `cumulativeSpan A (D² - D + 1)`
 
 Monotonicity is now automatic (via `rectSpan_nilpIndex_finrank_mono`).
 
-This is the assembly that combines:
+This is the rectangular span step that combines:
 1. Strict growth → rectSpan = range within D·D̃ steps
 2. Sharp direct route → vecMulVec φ ψ ∈ wordSpan A (r + n₀)
 3. Arithmetic: r + D·D̃ ≤ D²-D+1
@@ -773,7 +773,7 @@ end ExactPropagation
 /-!
 The subsequent rank-one step applies the exact word-span result above to word
 eigenvectors of suitable blocked tensors. Combined with the conditional
-rank-one assembly theorem, this gives a single word length whose evaluations span
+rank-one rectangular span theorem, this gives a single word length whose evaluations span
 the full matrix algebra, and hence the fully unconditional form of Lemma 2(b).
 -/
 

--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -773,7 +773,7 @@ end ExactPropagation
 /-!
 The subsequent rank-one step applies the exact word-span result above to word
 eigenvectors of suitable blocked tensors. Combined with the conditional
-rank-one rectangular span theorem, this gives a single word length whose evaluations span
+rank-one reduction theorem, this gives a single word length whose evaluations span
 the full matrix algebra, and hence the fully unconditional form of Lemma 2(b).
 -/
 

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
@@ -242,7 +242,7 @@ there exists `n` such that for **every** `ψ`,
 `vecMulVec φ ψ ∈ wordSpan A (D + n)`.
 
 This is the theorem that directly feeds into the paper's Lemma 2(b) conditional
-assembly. -/
+rectangular span. -/
 theorem exists_wordSpan_forall_vecMulVec_eigenvector
     (A : MPSTensor d D) (i₀ : Fin d) (hN : IsNormal A)
     {φ : Fin D → ℂ} {μ : ℂ} (hμ : μ ≠ 0)

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
@@ -242,7 +242,7 @@ there exists `n` such that for **every** `ψ`,
 `vecMulVec φ ψ ∈ wordSpan A (D + n)`.
 
 This is the theorem that directly feeds into the paper's Lemma 2(b) conditional
-rectangular span. -/
+fixed-length matrix spanning. -/
 theorem exists_wordSpan_forall_vecMulVec_eigenvector
     (A : MPSTensor d D) (i₀ : Fin d) (hN : IsNormal A)
     {φ : Fin D → ℂ} {μ : ℂ} (hμ : μ ≠ 0)

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
@@ -232,14 +232,14 @@ theorem finrank_range_mulLeft_pow_le_sq (A : MPSTensor d D) (i₀ : Fin d) :
       ≤ D * D := Nat.mul_le_mul_left D (rank_pow_le A i₀)
     _ = D ^ 2 := by ring
 
-/-! ### Part 6: Parametric assembly — toward exact Lemma 2(b)
+/-! ### Part 6: Parametric rectangular span — toward exact Lemma 2(b)
 
-The parametric assembly theorem combines:
+The parametric rectangular span theorem combines:
 1. Power membership: `(A i₀)^D ∈ wordSpan A D`
 2. Eigenvector in range: `φ ∈ range(toLin' ((A i₀)^D))`
 3. Stabilization: `rectSpan ((A i₀)^D) A n₀ = range(mulLeft ((A i₀)^D))`
 4. Transfer: `vecMulVec φ ψ ∈ wordSpan A (D + n₀)`
-5. Conditional assembly: `wordSpan A (D + n₀ + 2(D-1)) = ⊤`
+5. Conditional rectangular span: `wordSpan A (D + n₀ + 2(D-1)) = ⊤`
 
 into a single theorem parameterized by the stabilization witness `n₀`.
 
@@ -247,7 +247,7 @@ When the Wielandt inductive bound is available (giving `n₀ ≤ D² - 3D + 3`),
 this yields `wordSpan A (D² - D + 1) = ⊤`.
 -/
 
-/-- **Parametric Lemma 2(b) assembly.**
+/-- **Parametric Lemma 2(b) (rectangular span).**
 
 Given the full eigenvector/row-eigenvector setup AND a stabilization witness `n₀`
 such that `rectSpan ((A i₀)^D) A n₀ = range(mulLeft ((A i₀)^D))`, we get:
@@ -260,7 +260,7 @@ i.e., the word span at length `D + n₀ + 2D - 2` is the full matrix algebra.
 1. Eigenvector `φ` lies in `range(toLin' ((A i₀)^D))`, so for all `ψ`,
    `vecMulVec φ ψ ∈ rectSpan`.
 2. `rectSpan` stabilized at `n₀` → `vecMulVec φ ψ ∈ wordSpan A (D + n₀)`
-3. Apply conditional assembly (eigenvector spreading + row spreading)
+3. Apply conditional rectangular span (eigenvector spreading + row spreading)
 4. Output: `wordSpan A ((D-1) + ((D + n₀) + (D-1))) = ⊤`
 
 This simplifies to `wordSpan A (3D + n₀ - 2) = ⊤`.
@@ -276,7 +276,7 @@ theorem wielandt_parametric_assembly [NeZero D]
     (i₀ : Fin d) (μ : ℂ) (hμ : μ ≠ 0)
     (φ : Fin D → ℂ) (hφ : φ ≠ 0)
     (heigφ : A i₀ *ᵥ φ = μ • φ)
-    -- Row eigenvector (for the conditional assembly)
+    -- Row eigenvector (for the conditional rectangular span)
     (i₁ : Fin d) (ν : ℂ) (hν : ν ≠ 0)
     (ψ₀ : Fin D → ℂ) (hψ₀ : ψ₀ ≠ 0)
     (heigψ : (A i₁)ᵀ *ᵥ ψ₀ = ν • ψ₀)
@@ -288,7 +288,7 @@ theorem wielandt_parametric_assembly [NeZero D]
   -- Step 1: vecMulVec φ ψ₀ ∈ wordSpan A (D + n₀)
   have hRankOne : vecMulVec φ ψ₀ ∈ wordSpan A (D + n₀) :=
     vecMulVec_eigenvector_mem_wordSpan A i₀ hμ heigφ hstab ψ₀
-  -- Step 2: Apply conditional assembly
+  -- Step 2: Apply conditional rectangular span
   exact wielandt_lemma2b_conditional A hNormal i₀ μ hμ φ hφ heigφ
     i₁ ν hν ψ₀ hψ₀ heigψ hRankOne
 

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
@@ -239,7 +239,7 @@ The parametric rectangular span theorem combines:
 2. Eigenvector in range: `φ ∈ range(toLin' ((A i₀)^D))`
 3. Stabilization: `rectSpan ((A i₀)^D) A n₀ = range(mulLeft ((A i₀)^D))`
 4. Transfer: `vecMulVec φ ψ ∈ wordSpan A (D + n₀)`
-5. Conditional rectangular span: `wordSpan A (D + n₀ + 2(D-1)) = ⊤`
+5. Conditional fixed-length matrix spanning: `wordSpan A (D + n₀ + 2(D-1)) = ⊤`
 
 into a single theorem parameterized by the stabilization witness `n₀`.
 
@@ -260,7 +260,7 @@ i.e., the word span at length `D + n₀ + 2D - 2` is the full matrix algebra.
 1. Eigenvector `φ` lies in `range(toLin' ((A i₀)^D))`, so for all `ψ`,
    `vecMulVec φ ψ ∈ rectSpan`.
 2. `rectSpan` stabilized at `n₀` → `vecMulVec φ ψ ∈ wordSpan A (D + n₀)`
-3. Apply conditional rectangular span (eigenvector spreading + row spreading)
+3. Apply conditional fixed-length matrix spanning (eigenvector spreading + row spreading)
 4. Output: `wordSpan A ((D-1) + ((D + n₀) + (D-1))) = ⊤`
 
 This simplifies to `wordSpan A (3D + n₀ - 2) = ⊤`.
@@ -276,7 +276,7 @@ theorem wielandt_parametric_assembly [NeZero D]
     (i₀ : Fin d) (μ : ℂ) (hμ : μ ≠ 0)
     (φ : Fin D → ℂ) (hφ : φ ≠ 0)
     (heigφ : A i₀ *ᵥ φ = μ • φ)
-    -- Row eigenvector (for the conditional rectangular span)
+    -- Row eigenvector (for the conditional fixed-length matrix spanning)
     (i₁ : Fin d) (ν : ℂ) (hν : ν ≠ 0)
     (ψ₀ : Fin D → ℂ) (hψ₀ : ψ₀ ≠ 0)
     (heigψ : (A i₁)ᵀ *ᵥ ψ₀ = ν • ψ₀)
@@ -288,7 +288,7 @@ theorem wielandt_parametric_assembly [NeZero D]
   -- Step 1: vecMulVec φ ψ₀ ∈ wordSpan A (D + n₀)
   have hRankOne : vecMulVec φ ψ₀ ∈ wordSpan A (D + n₀) :=
     vecMulVec_eigenvector_mem_wordSpan A i₀ hμ heigφ hstab ψ₀
-  -- Step 2: Apply conditional rectangular span
+  -- Step 2: Apply conditional fixed-length matrix spanning
   exact wielandt_lemma2b_conditional A hNormal i₀ μ hμ φ hφ heigφ
     i₁ ν hν ψ₀ hψ₀ heigψ hRankOne
 

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
@@ -256,7 +256,7 @@ theorem vecMulVec_eigenvector_sharp_of_rectSpan
           sharp_bound_le A i₀ hNotInv
   exact wordSpan_le_cumulativeSpan A hbound hmem
 
-/-- **Parametric sharp assembly via nilpIndex.** -/
+/-- **Parametric sharp rectangular span via nilpIndex.** -/
 theorem wielandt_sharp_parametric_assembly [NeZero D]
     (A : MPSTensor d D)
     (hNormal : IsNormal (d := d) (D := D) A)

--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -17,7 +17,7 @@ import Mathlib.LinearAlgebra.Matrix.StdBasis
 This module starts closing the main remaining gap in the Quantum Wielandt proof
 (arXiv:0909.5347, Lemma 2(b)).
 
-We currently formalize the **algebraic assembly** part of Lemma 2(b):
+We currently formalize the **algebraic fixed-length matrix spanning** part of Lemma 2(b):
 
 * If (fixed-length) word products applied to a vector `φ` span all of `ℂ^D`, and
 * If we can produce the rank-one operators `|φ⟩⟨e_j|` as word products of a
@@ -283,9 +283,9 @@ theorem vectorSpreadSpan_eq_top_of_cumulativeVectorSpan_eq_top_of_eigenvector
   simpa [cumulativeVectorSpan_eq_vectorSpreadSpan_of_eigenvector (A := A) (φ := φ) (n := n)
     i₀ μ hμ heig] using htop
 
-/-! ## Vector spanning → fixed-length matrix spanning (assembly step) -/
+/-! ## Vector spanning → fixed-length matrix spanning -/
 
-/-- **Lemma 2(b) (assembly step, rank-one hypothesis)**.
+/-- **Lemma 2(b) (rank-one hypothesis)**.
 
 Assume:
 * `vectorSpreadSpan A φ n = ⊤`, i.e. length-`n` word products applied to `φ`

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1093,7 +1093,7 @@ used to produce rank-one elements.
     \uses{thm:rankone_extraction_blockTensor, thm:wielandt_blocked_assembly}
     The rank-one extraction theorem supplies the blocked rank-one element
     required by Theorem~\ref{thm:wielandt_blocked_assembly}; apply the blocked
-    assembly theorem.
+    fixed-length matrix spanning theorem.
 \end{proof}
 
 \begin{theorem}[Rank-one extraction for blocked tensor]%


### PR DESCRIPTION
### Motivation
- Tracks #1170 and follows #1395; addresses #1401.
- Removes "assembly" as title-level and process language in Wielandt
  blueprint prose and Lean docstrings, replacing it with theorem-content
  descriptions from the source (Wolf Chapter 7).

### Description
- Updated section headers, docstrings, and blueprint prose in:
  - `TNLean/Wielandt/RankOne/Construction.lean`
  - `TNLean/Wielandt/RankOne/ExtractionFull.lean`
  - `TNLean/Wielandt/RankOne/Products.lean`
  - `TNLean/Wielandt/RectangularSpan/Basic.lean`
  - `TNLean/Wielandt/RectangularSpan/Universality.lean`
  - `TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean`
  - `TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean`
  - `TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean`
  - `TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean`
  - `blueprint/src/chapter/ch07_wielandt.tex`
- Descriptive replacements: "rectangular span", "fixed-length matrix
  spanning", "vector-to-matrix spanning", "word-span saturation" in
  place of generic "assembly" headings.
- No declaration names, theorem statements, or proofs are changed.
  Internal Lean identifiers and LaTeX labels are unchanged.

### Testing
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- Blueprint changes are prose-only; `leanblueprint checkdecls` should
  pass because no `\lean{}` tags were added or removed.

---
Addresses #1401

> [!NOTE]
> **Low Risk**
> Pure documentation/prose updates (Lean docstrings and blueprint text) with no changes to definitions, theorems, or proofs; very low risk aside from potential confusion if wording no longer matches external references.
> 
> **Overview**
> Updates docstrings and blueprint prose throughout the Wielandt Lemma 2(b) development to consistently describe results in terms of **fixed-length matrix spanning** and **rectangular span** rather than generic "assembly".
> 
> This includes renaming section headings/descriptions (e.g., rank-one reduction vs optional assembly, conditional/blocked rectangular span) and aligning references in `RankOne/*`, `RectangularSpan/*`, `SpanGrowth/VectorToMatrixSpan.lean`, and the `ch07_wielandt.tex` blueprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 497ac4674902e6ee3098ce11ad103ef312ab11e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely documentation/prose edits across Lean docstrings, section headers, and blueprint text; no theorems/definitions/proofs or identifiers change, so behavioral risk is negligible aside from wording/reference mismatches.
> 
> **Overview**
> Updates the Wielandt Lemma 2(b) documentation to replace generic **“assembly”** language with theorem-content names, consistently describing results as **fixed-length matrix spanning**, **vector-to-matrix spanning**, **rectangular span**, **rank-one reduction**, and **word-span saturation**.
> 
> Applies these wording/heading tweaks across the `RankOne/*`, `RectangularSpan/*`, and `SpanGrowth/VectorToMatrixSpan.lean` docstrings, and mirrors the same prose change in the Chapter 7 blueprint (`ch07_wielandt.tex`), without modifying any Lean statements, proofs, or internal identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887e4efa3e30e58530ef85abff555337efd691dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->