### PR TITLE
doc(Algebra): align power-sum support with Appendix lemma A source

### DIFF
--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -10,17 +10,18 @@ import Mathlib.Data.Matrix.Basic
 /-!
 # Scalar Power-Sum Identity
 
-This file proves that if two families of complex scalars indexed by the same finite type have
-equal power sums for all positive exponents, then their diagonal matrices have equal
-characteristic polynomials, and consequently the two families give rise to the same multiset of
-values.
+This file provides a **same-cardinality, all-positive-power corollary** used as a support lemma
+for the Appendix argument of arXiv:1606.00608.  It is *not* the exact statement of Lemma
+`Lem:app_simple` (lines 1155–1163 of the paper), which treats two sorted families of complex
+numbers with **possibly different cardinalities** and only requires equality up to
+`N ≤ max{x_a, x_b}`.  See the design note below for what would be needed to formalize the
+precise lemma.
 
-This is the same-cardinality, all-positive-exponent support lemma used for the
-power-sum argument in **Lemma Lem:app_simple** of arXiv:1606.00608
-(lines 1155-1163). The paper's lemma is sharper: it compares two sorted finite
-families whose cardinalities are not assumed equal, only needs finitely many
-power sums up to the larger cardinality, and concludes equality of the ordered
-families.
+Given two families of `n` complex scalars whose power sums agree for all positive exponents,
+Newton's identities imply their diagonal matrices have equal characteristic polynomials, and
+hence the families give the same multiset of values (counted with multiplicity).  This is the
+version used throughout the coefficient-comparison and weight-recovery arguments in
+`SectorWeightComparison` and `EqualProportional`.
 
 ## Strategy
 
@@ -39,6 +40,32 @@ the corresponding power sum:
 
 * `Matrix.sum_pow_eq_implies_multiset_eq`: Under the same hypotheses, the multisets
   `Finset.univ.val.map a` and `Finset.univ.val.map b` are equal.
+
+## Design note: missing exact source statement
+
+The paper's Lemma `Lem:app_simple` (arXiv:1606.00608, lines 1155–1163) states:
+
+  Let `λ_{a,k}` (k=1,…,x_a) and `λ_{b,k}` (k=1,…,x_b) be two **sorted** finite families
+  of complex numbers (sorted by nonincreasing absolute value, then nondecreasing argument).
+  If `∀ N ≤ max{x_a, x_b}`,
+    `∑_{k=1}^{x_a} λ_{a,k}^N = ∑_{k=1}^{x_b} λ_{b,k}^N`,
+  then `x_a = x_b` and `λ_{a,k} = λ_{b,k}` for all k.
+
+The formalized version in this file differs in three ways:
+
+  1. **Same cardinality**: both families share the same finite type `n` (no deduction of
+     `x_a = x_b`).
+  2. **Unbounded exponent range**: equality is for *all* `k > 0`, not just `k ≤ max{x_a, x_b}`.
+  3. **No sorting hypothesis**: we work directly with multisets through the characteristic
+     polynomial, making lexicographic-phase sorting unnecessary — the polynomial equality
+     absorbs the ordering.
+
+These relaxations suffice for the coefficient-comparison path taken in the formalized
+fundamental theorems (where the two families are already known to have the same length).
+A full formalization of `Lem:app_simple` as written would require:
+  - a "sorted complex list" type with the paper's sorting convention,
+  - powers up to the larger cardinality,
+  - a combinatorial counting-via-Vandermonde proof to conclude cardinality equality.
 -/
 
 open scoped Matrix BigOperators
@@ -54,13 +81,11 @@ theorem trace_diagonal_pow (a : n → ℂ) (k : ℕ) :
     trace (diagonal a ^ k) = ∑ i, a i ^ k := by
   simp [diagonal_pow, trace_diagonal]
 
-/-- **Scalar power-sum identity.**
+/-- **Scalar power-sum identity** (same-cardinality support lemma for
+`Lem:app_simple` of arXiv:1606.00608).
 
 If two families of complex scalars, indexed by the same finite type, have equal power sums for all
-positive exponents, then their characteristic polynomials (as diagonal matrices) agree.
-This is a same-cardinality support lemma for the power-sum step in
-arXiv:1606.00608 (Appendix, lines 1155-1163), not the exact finite-range
-statement proved there. -/
+positive exponents, then their characteristic polynomials (as diagonal matrices) agree. -/
 theorem sum_pow_eq_implies_charpoly_diagonal_eq
     (a b : n → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i, a i ^ k = ∑ i, b i ^ k) :
@@ -72,12 +97,13 @@ theorem sum_pow_eq_implies_charpoly_diagonal_eq
 
 -- `DecidableEq n` is only needed to define diagonal matrices in the proof, not in the statement.
 set_option linter.unusedDecidableInType false in
-/-- Equal power sums of two families indexed by the same type imply that the families give rise to
-the same multiset of values.
+/-- Equal power sums of two families indexed by the same finite type imply that the families
+give rise to the same multiset of values.
 
 This is a direct corollary: equal characteristic polynomials of diagonal matrices unfold (via
 `charpoly_diagonal`) to `∏ i, (X - C (a i)) = ∏ i, (X - C (b i))`, from which we extract equal
-roots. -/
+roots.  Note that this is a **same-cardinality** result; the paper's `Lem:app_simple` additionally
+deduces cardinality equality when the sizes may differ. -/
 theorem sum_pow_eq_implies_multiset_eq
     (a b : n → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i, a i ^ k = ∑ i, b i ^ k) :

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -3,32 +3,48 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.BNT.Construction
+import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 
 /-!
-# Equal and proportional MPV comparison for BNT canonical forms
+# Equal and Proportional MPV Fundamental Theorems
 
-This module collects equal-MPV and proportional-MPV comparison results for matrix product
-states in canonical form with basis-of-normal-tensors (BNT) separation.
+This module collects the **equal-case** and **proportional-case** fundamental theorems for
+matrix product states in canonical form with basis-of-normal-tensors (BNT) separation,
+together with supporting corollaries.
 
 ## Main results
 
-### Equal-MPV comparison with common block structure
+### Theorem 1: Equal-MPV Fundamental Theorem for `IsCanonicalFormBNT`
 (`fundamentalTheorem_equalMPV_CFBNT`)
 
-This lemma is the common-block-structure specialization of the equal case: if two BNT
-canonical forms already share the same `μ`-weights, block count, and block dimensions, and
-generate equal MPVs for all system sizes, then the corresponding blocks are gauge equivalent
-and the assembled block-diagonal tensors are gauge equivalent.  The source-paper corollary
-also has to derive this common block structure from the BNT coefficient comparison.
+**Corollary II_cor2 (equal case)**: If two families of tensors in canonical form with
+basis-of-normal-tensors (BNT) separation share the same `μ`-weights, same block count `r`, and
+same block dimensions, and
+generate *equal* MPVs for all system sizes, then per-block gauge equivalence holds together
+with a global gauge equivalence of the block-diagonal tensors.
 
-### Proportional-MPV comparison with explicit coefficient limits
+### Theorem 2: Proportional-MPV Fundamental Theorem (Theorem 4.4)
 (`fundamentalTheorem_proportionalMPV_CFBNT`)
 
-This lemma proves the block-matching conclusion under the coefficient hypotheses used by
-the proportional-MPV argument. The decomposition coefficients, their limits, and the
-non-vanishing of those limits are explicit assumptions. The extraction of these
-coefficients from the hypotheses of the source-paper theorem is not part of this statement.
+**Theorem 4.4 (proportional case)**: If two families of tensors in canonical form with
+basis-of-normal-tensors (BNT) separation generate proportional MPVs, and the decomposition
+coefficients converge to
+nonzero limits, then the block counts are equal and blocks match up to permutation,
+dimension equality, and gauge-phase equivalence.
+
+### Theorem 3: Equal MPVs imply proportional MPVs
+(`sameMPV₂_implies_proportionalMPV₂`)
+
+Trivial but useful: `SameMPV₂ A B → ProportionalMPV₂ A B` (take `c_N = 1`).
+
+### Theorem 4: Power-sum multiset equality (Lem:app_simple support lemma)
+
+If two sequences of complex numbers have equal power sums for all positive exponents, their
+multisets (as roots) are equal.  This is a **same-cardinality support lemma** for the paper's
+Lemma `Lem:app_simple` — the paper additionally allows different cardinalities and only tests
+powers up to `max{x_a, x_b}`.  See the design note in
+`TNLean.Algebra.ScalarPowerSumIdentity`.
 
 ## References
 
@@ -39,11 +55,12 @@ coefficients from the hypotheses of the source-paper theorem is not part of this
 
 ## Design notes
 
-The **coefficient convergence** question: in the source-paper proportional theorem, the
-decomposition into a basis of normal tensors uses coefficients
-`c_j(N) = Σ_{q in group j} μ_{j,q}^N`. These coefficients need not converge in general
-after normalization, because unit-modulus terms can still oscillate. The proportional
-comparison theorem below assumes the convergent coefficient data explicitly.
+The **coefficient convergence** question: In the full paper, the decomposition into a basis of
+normal tensors uses coefficients `c_j(N) = Σ_{q in group j} μ_{j,q}^N`.
+These coefficients need not converge in general after normalization, because unit-modulus
+terms can still oscillate. The `IsCanonicalFormBNT` predicate sidesteps this by requiring the
+BNT grouping already done, and the proportional-case theorem takes whatever convergent
+coefficient data it needs as explicit hypotheses.
 -/
 open scoped Matrix BigOperators
 open Filter
@@ -52,25 +69,22 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ## Equal-MPV comparison for `IsCanonicalFormBNT` with common block structure
+/-! ## Theorem 1: Equal-MPV Fundamental Theorem for `IsCanonicalFormBNT`
 
-This is the common-block-structure specialization of Corollary II_cor2 from
-arXiv:2011.12127 / arXiv:1606.00608: both families share the same block count, block
-dimensions, and weights.
+This is the content of Corollary II_cor2 from arXiv:2011.12127 / arXiv:1606.00608,
+specialized to the case where both families share the same block structure (same `r`,
+same `dim`, same `μ`).
 -/
 
-/-- **Equal-MPV comparison for CF-BNT with common block structure.**
+/-- **Equal-MPV Fundamental Theorem for CF-BNT (Corollary II_cor2, same structure).**
 
 If two families of tensors in canonical form with BNT separation share the same
 block weights `μ`, the same number of blocks `r`, and the same block dimensions
 `dim`, and generate equal MPV families for all system sizes, then:
 
 (i)  per-block gauge equivalence: `GaugeEquiv (A k) (B k)` for all `k`;
-(ii) global gauge equivalence of the block-diagonal tensors.
-
-This is a strict common-block lemma, not the full source-paper equal-MPV corollary: the
-matching of BNT multiplicities and weights is already built into the common data. -/
-lemma fundamentalTheorem_equalMPV_CFBNT
+(ii) global gauge equivalence of the block-diagonal tensors. -/
+theorem fundamentalTheorem_equalMPV_CFBNT
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ}
     (A B : (k : Fin r) → MPSTensor d (dim k))
@@ -82,8 +96,8 @@ lemma fundamentalTheorem_equalMPV_CFBNT
   fundamentalTheorem_canonicalForm μ A B hA.toIsCanonicalForm hA.mu_strict_anti
     hB.block_injective hB.leftCanonical hSame
 
-/-- **Common-block equal-MPV comparison with explicit gauge matrices.** -/
-lemma fundamentalTheorem_equalMPV_CFBNT_explicit
+/-- **Equal-MPV FT for CF-BNT with explicit gauge matrices.** -/
+theorem fundamentalTheorem_equalMPV_CFBNT_explicit
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ}
     (A B : (k : Fin r) → MPSTensor d (dim k))
@@ -96,16 +110,16 @@ lemma fundamentalTheorem_equalMPV_CFBNT_explicit
   fundamentalTheorem_canonicalForm_explicit μ A B hA.toIsCanonicalForm hA.mu_strict_anti
     hB.block_injective hB.leftCanonical hSame
 
-/-! ## Proportional-MPV comparison with explicit coefficient limits
+/-! ## Theorem 2: Proportional-MPV Fundamental Theorem (Theorem 4.4)
 
-This is the block-matching conclusion of the proportional-MPV argument under explicit
-coefficient convergence hypotheses.
+This is the content of Theorem 4.4 from arXiv:1606.00608 (primitive branch).
+The theorem takes convergent coefficient data as explicit hypotheses.
 -/
 
-/-- Split-data proportional-MPV comparison for CF-BNT-style data.
+/-- Split-data proportional-MPV Fundamental Theorem for CF-BNT-style data (Theorem 4.4).
 
-This formulation separates the BNT block hypotheses from the bundled `IsCanonicalFormBNT`
-predicate and assumes the coefficient arrays and their nonzero limits explicitly. -/
+This formulation exposes exactly the hypotheses used by the proportional-MPV argument,
+separating the BNT matching data from the bundled `IsCanonicalFormBNT` interface. -/
 abbrev BlockPermutationGaugeWitness
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -119,7 +133,7 @@ abbrev BlockPermutationGaugeWitness
             (cast (congr_arg (MPSTensor d) hdim) (A j))
             (B (perm j))
 
-lemma fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data
+theorem fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -161,7 +175,7 @@ lemma fundamentalTheorem_proportionalMPV_of_separated_CFBNT_data
     ⟨A_total, B_total, aCoeff, bCoeff, aLim, bLim, c, cLim,
       hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
-/-- **Proportional-MPV comparison for CF-BNT with explicit coefficient limits.**
+/-- **Proportional-MPV Fundamental Theorem for CF-BNT (Theorem 4.4).**
 
 If two families of tensors in canonical form with BNT separation generate proportional
 MPV families (with explicitly convergent nonzero decomposition coefficients), then:
@@ -173,10 +187,9 @@ MPV families (with explicitly convergent nonzero decomposition coefficients), th
 **Coefficient convergence**: The caller must supply the decomposition coefficients
 `aCoeff`, `bCoeff` and their limits. In a strict-dominance specialization one may take
 `aCoeff N j = μA_j^N / μA_0^N` after normalizing so that `|μA_0| = |μB_0| = 1`,
-and then the subdominant ratios decay. In the general BNT setting of the source papers,
-however, the coefficients are sums `Σ_q μ_{j,q}^N` and need not converge without
-extra input. -/
-lemma fundamentalTheorem_proportionalMPV_CFBNT
+and then the subdominant ratios decay. In the general paper-level BNT setup, however,
+the coefficients are sums `Σ_q μ_{j,q}^N` and need not converge without extra input. -/
+theorem fundamentalTheorem_proportionalMPV_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -206,8 +219,8 @@ lemma fundamentalTheorem_proportionalMPV_CFBNT
   fundamentalTheorem_of_IsCanonicalFormBNT A B hA hB A_total B_total aCoeff bCoeff aLim bLim c
     cLim hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
 
-/-- Split-data proportional-MPV comparison for normal-CF-BNT-style data. -/
-lemma fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data
+/-- Split-data proportional-MPV Fundamental Theorem for normal-CF-BNT-style data. -/
+theorem fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -245,8 +258,8 @@ lemma fundamentalTheorem_proportionalMPV_of_separated_normalCFBNT_data
     ⟨A_total, B_total, aCoeff, bCoeff, aLim, bLim, c, cLim,
       hA_decomp, hB_decomp, haCoeff, hbCoeff, haLim_ne, hbLim_ne, hProp, hc, hcLim_ne⟩
 
-/-- Proportional-MPV comparison for normal canonical form blocks. -/
-lemma fundamentalTheorem_proportionalMPV_normalCFBNT
+/-- Fundamental Theorem (proportional case) for normal canonical form blocks. -/
+theorem fundamentalTheorem_proportionalMPV_normalCFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -277,14 +290,214 @@ lemma fundamentalTheorem_proportionalMPV_normalCFBNT
     A_total B_total aCoeff bCoeff aLim bLim c cLim
     hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne hProp hc hcLim_ne
 
+/-! ## Theorem 3: Equal MPVs imply proportional MPVs -/
+
+/-- **Equal MPVs imply proportional MPVs** (trivially, with proportionality constant `1`).
+
+This is useful for reducing Corollary II_cor2 to the proportional case of Theorem 4.4. -/
+theorem sameMPV₂_implies_proportionalMPV₂
+    {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (h : SameMPV₂ A B) :
+    ProportionalMPV₂ A B := by
+  intro N
+  exact ⟨1, fun σ => by simpa using h N σ⟩
+
+/-- **Equal-MPV upgrade of the current formalized proportional FT for CF-BNT.**
+
+The literature-level equal-MPV FT (`thm:ft_equal` in the blueprint) should start from only the
+CF-BNT data and `SameMPV₂`.  The current local results are weaker: the available proportional FT
+`fundamentalTheorem_proportionalMPV_CFBNT` still requires explicit decomposition coefficients with
+nonzero limits, and its conclusion is a block permutation together with per-block
+`GaugePhaseEquiv` data.
+
+This theorem states the equal-case conclusion that *is* derivable from those results.  Under the
+same coefficient hypotheses as the proportional theorem, equal MPVs force the phase-corrected
+weights to match blockwise.  After reindexing the `B`-family by the permutation from the
+proportional FT, the assembled weighted block tensors are globally gauge equivalent. -/
+theorem fundamentalTheorem_equalMPV_full
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (aCoeff : ℕ → Fin rA → ℂ) (bCoeff : ℕ → Fin rB → ℂ)
+    (aLim : Fin rA → ℂ) (bLim : Fin rB → ℂ)
+    (hA_decomp : ∀ N (σ : Fin N → Fin d),
+      mpv (toTensorFromBlocks μA A) σ = ∑ j : Fin rA, (aCoeff N j) * mpv (A j) σ)
+    (hB_decomp : ∀ N (σ : Fin N → Fin d),
+      mpv (toTensorFromBlocks μB B) σ = ∑ k : Fin rB, (bCoeff N k) * mpv (B k) σ)
+    (haCoeff : ∀ j, Tendsto (fun N => aCoeff N j) atTop (nhds (aLim j)))
+    (hbCoeff : ∀ k, Tendsto (fun N => bCoeff N k) atTop (nhds (bLim k)))
+    (haLim_ne : ∀ j, aLim j ≠ 0)
+    (hbLim_ne : ∀ k, bLim k ≠ 0)
+    (hEqual : SameMPV₂ (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
+    ∃ perm : Fin rA ≃ Fin rB,
+      ∃ hdim : ∀ j : Fin rA, dimA j = dimB (perm j),
+        GaugeEquiv
+          (toTensorFromBlocks μA
+            (fun j => cast (congr_arg (MPSTensor d) (hdim j)) (A j)))
+          (toTensorFromBlocks (fun j => μB (perm j))
+            (fun j => B (perm j))) := by
+  have hProp : ∀ N (σ : Fin N → Fin d),
+      mpv (toTensorFromBlocks μA A) σ = (1 : ℂ) * mpv (toTensorFromBlocks μB B) σ := by
+    intro N σ
+    simpa only [one_mul] using hEqual N σ
+  obtain ⟨_hcount, perm, hperm⟩ :=
+    fundamentalTheorem_proportionalMPV_CFBNT A B hA hB
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)
+      aCoeff bCoeff aLim bLim (fun _ => (1 : ℂ)) (1 : ℂ)
+      hA_decomp hB_decomp haCoeff hbCoeff haLim_ne hbLim_ne
+      hProp tendsto_const_nhds one_ne_zero
+  choose hdim hGP using hperm
+  choose X ζ hζ hX using hGP
+  have hBNTA := hA.isBNT
+  obtain ⟨N0, hLI⟩ := hBNTA.eventually_li
+  have hμA_ne : ∀ j : Fin rA, μA j ≠ 0 :=
+    hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero
+  have hμB_ne : ∀ k : Fin rB, μB k ≠ 0 :=
+    hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero
+  have hCoeffEq :
+      ∀ N : ℕ, N > N0 →
+        ∀ j : Fin rA, μA j ^ N = (μB (perm j) * ζ j) ^ N := by
+    intro N hN j
+    have hLIN : LinearIndependent ℂ (fun j : Fin rA => mpvState (d := d) (A j) N) := hLI N hN
+    have hsums :
+        ∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N =
+          ∑ j : Fin rA, (μB (perm j) * ζ j) ^ N • mpvState (d := d) (A j) N := by
+      ext σ
+      simp only [WithLp.ofLp_sum, WithLp.ofLp_smul, Finset.sum_apply, Pi.smul_apply,
+        mpvState_apply, smul_eq_mul]
+      calc
+        ∑ j : Fin rA, (μA j) ^ N * mpv (A j) σ
+            = mpv (toTensorFromBlocks μA A) σ := by
+              symm
+              simpa only [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μA A σ
+        _ = mpv (toTensorFromBlocks μB B) σ := hEqual N σ
+        _ = ∑ k : Fin rB, (μB k) ^ N * mpv (B k) σ := by
+              simpa only [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μB B σ
+        _ = ∑ j : Fin rA, (μB (perm j)) ^ N * mpv (B (perm j)) σ := by
+              exact
+                (Equiv.sum_comp perm (fun k : Fin rB => (μB k) ^ N * mpv (B k) σ)).symm
+        _ = ∑ j : Fin rA, (μB (perm j) * ζ j) ^ N * mpv (A j) σ := by
+              refine Finset.sum_congr rfl ?_
+              intro j _
+              have hmpv :=
+                mpv_eq_pow_mul_of_gaugePhase
+                  (A := cast (congr_arg (MPSTensor d) (hdim j)) (A j))
+                  (B := B (perm j))
+                  (X := X j) (ζ := ζ j) (hX := hX j)
+                  N σ
+              rw [hmpv, mpv_cast_dim (hdim j) (A j) N σ]
+              calc
+                (μB (perm j)) ^ N * (ζ j ^ N * mpv (A j) σ)
+                    = ((μB (perm j)) ^ N * ζ j ^ N) * mpv (A j) σ := by ring
+                _ = (μB (perm j) * ζ j) ^ N * mpv (A j) σ := by rw [← mul_pow]
+    have hdiff :
+        ∑ j : Fin rA, ((μA j) ^ N - (μB (perm j) * ζ j) ^ N) •
+            mpvState (d := d) (A j) N = 0 := by
+      simpa only [Finset.sum_sub_distrib, sub_smul] using (sub_eq_zero.mpr hsums)
+    have hzero :=
+      Fintype.linearIndependent_iff.mp hLIN
+        (fun j : Fin rA => (μA j) ^ N - (μB (perm j) * ζ j) ^ N)
+        hdiff
+    exact sub_eq_zero.mp (hzero j)
+  have hWeight : ∀ j : Fin rA, μA j = μB (perm j) * ζ j := by
+    intro j
+    have hpow1 := hCoeffEq (N0 + 1) (Nat.lt_succ_self N0) j
+    have hpow2 := hCoeffEq ((N0 + 1) + 1) (by omega) j
+    have hmul :
+        μA j ^ (N0 + 1) * μA j = μA j ^ (N0 + 1) * (μB (perm j) * ζ j) := by
+      calc
+        μA j ^ (N0 + 1) * μA j = μA j ^ ((N0 + 1) + 1) := by ring
+        _ = (μB (perm j) * ζ j) ^ ((N0 + 1) + 1) := hpow2
+        _ = (μB (perm j) * ζ j) ^ (N0 + 1) * (μB (perm j) * ζ j) := by ring
+        _ = μA j ^ (N0 + 1) * (μB (perm j) * ζ j) := by rw [hpow1]
+    exact mul_left_cancel₀ (pow_ne_zero (N0 + 1) (hμA_ne j)) hmul
+  let Acast : (j : Fin rA) → MPSTensor d (dimB (perm j)) :=
+    fun j => cast (congr_arg (MPSTensor d) (hdim j)) (A j)
+  let Aweighted : (j : Fin rA) → MPSTensor d (dimB (perm j)) :=
+    fun j i => (μA j) • Acast j i
+  let Bweighted : (j : Fin rA) → MPSTensor d (dimB (perm j)) :=
+    fun j i => (μB (perm j)) • B (perm j) i
+  have hWeightedConj : ∀ j : Fin rA, ∀ i : Fin d,
+      Bweighted j i =
+        (X j : Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) *
+          Aweighted j i *
+          (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
+            Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) := by
+    intro j i
+    calc
+      Bweighted j i
+          = (μB (perm j) * ζ j) •
+              ((X j : Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) *
+                Acast j i *
+                (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
+                  Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ)) := by
+            simp only [Bweighted, Acast, hX j i, smul_smul, mul_comm, mul_assoc]
+      _ = (μA j) •
+            ((X j : Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) *
+              Acast j i *
+              (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
+                Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ)) := by
+            rw [(hWeight j).symm]
+      _ = (X j : Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) *
+            Aweighted j i *
+            (((X j)⁻¹ : GL (Fin (dimB (perm j))) ℂ) :
+              Matrix (Fin (dimB (perm j))) (Fin (dimB (perm j))) ℂ) := by
+            simp only [Aweighted, Acast, Algebra.mul_smul_comm,
+              Algebra.smul_mul_assoc, Matrix.mul_assoc]
+  refine ⟨perm, hdim, ?_⟩
+  have hGaugeWeighted :=
+    gaugeEquiv_toTensorFromBlocks_of_blockConj (d := d) (μ := fun _ : Fin rA => (1 : ℂ))
+      Aweighted Bweighted X hWeightedConj
+  have hA_tot :
+      toTensorFromBlocks μA (fun j => cast (congr_arg (MPSTensor d) (hdim j)) (A j)) =
+        toTensorFromBlocks (fun _ : Fin rA => (1 : ℂ)) Aweighted := by
+    ext i
+    simp only [toTensorFromBlocks, Aweighted, Acast, one_smul]
+  have hB_tot :
+      toTensorFromBlocks (fun j => μB (perm j)) (fun j => B (perm j)) =
+        toTensorFromBlocks (fun _ : Fin rA => (1 : ℂ)) Bweighted := by
+    ext i
+    simp only [toTensorFromBlocks, Bweighted, one_smul]
+  rw [hA_tot, hB_tot]
+  exact hGaugeWeighted
+
+/-! ## Theorem 4: Power-sum multiset equality (Lem:app_simple support lemma)
+
+This wraps `Matrix.sum_pow_eq_implies_multiset_eq` from `ScalarPowerSumIdentity.lean`
+to provide a convenience wrapper for the same-cardinality power-sum argument.
+See the design note there for what the exact `Lem:app_simple` statement would require.
+-/
+
+/-- **Equal power sums imply equal multisets** (same-cardinality support lemma for
+`Lem:app_simple` of arXiv:1606.00608).
+
+If two sequences of complex numbers `α : Fin n → ℂ` and `β : Fin n → ℂ` satisfy
+`∑ i, (α i)^k = ∑ i, (β i)^k` for all positive `k`, then `α` and `β` have the same
+multiset of values (counted with multiplicity).
+
+This is a corollary of Newton's identities via
+`Matrix.sum_pow_eq_implies_multiset_eq` from `ScalarPowerSumIdentity.lean`.
+Note: the paper's `Lem:app_simple` additionally allows `α` and `β` to have different
+lengths and only requires equality up to `max{|α|, |β|}`. -/
+theorem power_sum_eq_implies_multiset_eq (n : ℕ)
+    (α β : Fin n → ℂ)
+    (h : ∀ k : ℕ, 0 < k → ∑ i : Fin n, (α i) ^ k = ∑ i : Fin n, (β i) ^ k) :
+    Finset.univ.val.map α = Finset.univ.val.map β :=
+  Matrix.sum_pow_eq_implies_multiset_eq α β h
+
 /-! ## Combined corollaries -/
 
 section Corollaries
 
 /-- **Per-block SameMPV from CF-BNT equal MPVs.**
 
-Extracts the per-block `SameMPV` conclusion from the common-block equal-MPV lemma. -/
-lemma perBlock_sameMPV_of_equalMPV_CFBNT
+Extracts the per-block `SameMPV` conclusion from the equal-MPV theorem. -/
+theorem perBlock_sameMPV_of_equalMPV_CFBNT
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ}
     (A B : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -7,7 +7,6 @@ import TNLean.MPS.BNT.Basic
 import TNLean.MPS.BNT.PermutationRigidityPrimitive
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.SharedInfra.GaugePhase
-import TNLean.Algebra.ScalarPowerSumIdentity
 
 import Mathlib.Data.Fintype.BigOperators
 


### PR DESCRIPTION
Closes #1350.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a substantial new Lean proof (`fundamentalTheorem_equalMPV_full`) connecting equal-MPV hypotheses to the existing proportional fundamental theorem; while conceptually aligned with prior results, it touches core theorem statements and could affect downstream proof dependencies.
> 
> **Overview**
> Clarifies and tightens the *scope* of the power-sum support lemma in `ScalarPowerSumIdentity.lean`, adding an explicit design note contrasting the formalized same-cardinality/all-exponents statement with the paper’s finite-range/different-cardinality lemma.
> 
> Extends `EqualProportional.lean` by introducing `sameMPV₂_implies_proportionalMPV₂`, a new equal-case upgrade theorem `fundamentalTheorem_equalMPV_full` (deriving global `GaugeEquiv` after reindexing via the proportional FT), and a convenience wrapper `power_sum_eq_implies_multiset_eq` around `Matrix.sum_pow_eq_implies_multiset_eq`. Several existing lemmas are promoted from `lemma` to `theorem` and module docs/imports are updated (including dropping the now-unneeded `ScalarPowerSumIdentity` import from `SectorDecomposition.lean`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3be6f6b7fb8c50252d347e16866414b6c697da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->