### PR TITLE
refactor(FT): replace conditional after-blocking FT hypothesis surface by source proof obligations

### DIFF
--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -5,12 +5,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison
 import TNLean.MPS.CanonicalForm.Assembly.CommonPrimitiveProportionalData
 import TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison
+import TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison
 import TNLean.MPS.CanonicalForm.Assembly.CommonSectorData
+import TNLean.MPS.CanonicalForm.Assembly.SectorComparisonCore
 
 /-!
 # Canonical-form reduction after blocking
 
-This module is the public entry point for the complete canonical-form
+This module is the public entry point for the end-to-end canonical-form
 reduction after blocking. It keeps the historical import path
 `TNLean.MPS.CanonicalForm.Assembly` available while the underlying development is
 split across focused supporting modules.
@@ -37,6 +39,8 @@ The supporting modules are:
   after the zero-tail and TP-gauge structural reduction.
 * `TNLean.MPS.CanonicalForm.Assembly.StructuralData` — common-period blocking
   and structural after-blocking data.
+* `TNLean.MPS.CanonicalForm.Assembly.SectorComparisonCore` — conditional
+  sector comparison after structural blocking.
 * `TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` — historical re-export
   path for structural data and common-sector transport.
 * `TNLean.MPS.CanonicalForm.Assembly.CommonSectorTransport` — zero-tail and
@@ -45,6 +49,9 @@ The supporting modules are:
   common primitive span, phase-cover, proportional, and BNT-cover hypotheses.
 * `TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison` — basic sector
   comparisons from block-span, phase-cover, and proportional data.
+* `TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison` — overlap-span
+  hypothesis constructors from common primitive span, phase-cover, BNT-cover,
+  and proportional data.
 * `TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison` — sector comparison
   from BNT proportional-decomposition data.
 
@@ -59,15 +66,48 @@ The imported modules provide the canonical-form reduction theorems, including
 `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_fixedAlgebraRigidity`,
 `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking`,
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
-`exists_bilateral_tp_primitive_blockDecomp_after_blocking`.
+`afterBlocking_structuralData_of_sameMPV₂`.
 
-The after-blocking comparison of two tensors with the same MPV family has a
-conditional form here. Equality of MPV families gives the common blocking and
-common primitive sector data; the BNT-cover comparison data for those sectors
-are separate hypotheses. Under those hypotheses,
-`fundamentalTheorem_afterBlocking_of_comparisonHypotheses` gives BNT sector
-decompositions whose basis sectors and weights match up to permutation and
-nonzero phases.
+This public entry point also records a conditional formulation of the
+Cirac--Pérez-García--Schuch--Verstraete after-blocking theorem that does not
+invoke the periodic Fundamental Theorem.  The structure
+`BlockedNormalFormHypotheses` names the source proof obligations (blocking
+to normal tensors, matching of nonzero normal summands, equality of the
+residual zero-block dimension, and the phase-gauge formula), while
+`fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses` deduces
+the blocked normal-form sector matching conclusion: after a common blocking,
+the two tensors are represented by BNT sector decompositions whose basis
+sectors and weights match up to permutation and nonzero phases.
+
+## Formalization note: packaging as proof obligations
+
+The source CPSV statement is written for tensors already in canonical form:
+after finitely many blocking steps the matrices are replaced by block-diagonal
+matrices $A^i = \bigoplus_k \mu_k A_k^i$ generating the same matrix product
+vector family, the basis-of-normal-tensor expansion is applied, and the
+sector-weight comparison is stated without listing separate hypotheses about
+trace preservation, primitivity, irreducibility, or zero-tail dimension
+matching.
+
+The structures `BlockedNormalFormHypotheses` and
+`BlockedNormalFormSectorMatching` explicitly package these source proof
+obligations as formal inputs:
+
+* **Blocking to normal tensors** — the blocked tensors decompose into a zero
+  block plus a direct sum of trace-preserving, primitive, irreducible
+  summands at a common blocking length;
+* **Equality of the residual zero-block dimension** — the zero-tail
+  contributions of the two blocked tensors must be identified;
+* **Matching of nonzero normal summands** — the BNT-cover comparison data
+  links the two families of nonzero blocks; and
+* **The phase-gauge formula** — the conclusion delivers a permutation of
+  basis sectors, matched multiplicities, and nonzero phases transforming
+  one multiset of sector weights into the other.
+
+This packaging is the current formal boundary between the canonical-form
+reduction that is already proved in Lean and the source-level comparison
+argument that passes from equal matrix product vector families to the BNT
+sector-matching theorem.
 
 ## References
 
@@ -83,20 +123,35 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
 namespace MPSTensor
 
-/-- BNT-cover comparison hypotheses for the after-blocking comparison theorem.
+/-- Source proof obligations for the after-blocking fundamental theorem.
 
-For tensors with the same MPV family, the structural reduction gives common primitive
-nonzero-sector families after a common blocking.  The blocked-word relabeling assertion is
-derived from the grouped-block cast theorem.  This predicate supplies the additional BNT-cover
-comparison data for those exact families; equality of MPV families alone is not used here to
-derive that data.  The field `comparison` includes their trace-preserving, primitive,
-irreducible, and positive bond-dimension evidence, so the comparison assumptions are tied to the
-families obtained after blocking. -/
-structure AfterBlockingFundamentalTheoremHypotheses
+This structure collects the four source proof obligations that the CPSV paper uses
+implicitly when the tensors are already in canonical form:
+
+1. **Blocking to normal tensors** — the blocked tensors `blockTensor A p` and
+   `blockTensor B p` decompose as a zero block plus a direct sum of normal
+   summands (trace-preserving, primitive, irreducible, with positive bond
+   dimensions and nonzero weights);
+
+2. **Equality of the residual zero-block dimension** — the zero-tail contributions
+   `zeroTailA` and `zeroTailB` satisfy the same length-zero identity after
+   adding the nonzero-part contributions;
+
+3. **Matching of nonzero normal summands** — for the produced nonzero-block
+   families there exist common primitive BNT-cover hypotheses linking the
+   two decompositions.
+
+The fourth source obligation, the phase-gauge formula, appears as the conclusion
+of `fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses` (see
+`BlockedNormalFormSectorMatching`).
+
+The field `comparison` is supplied with structural evidence so the remaining
+assumptions cannot be applied to a different decomposition. -/
+structure BlockedNormalFormHypotheses
     {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop where
-  /-- BNT-cover comparison data for the reindexed common primitive nonzero-sector families, with
-  the structural evidence for trace preservation, primitivity, irreducibility, and positive bond
-  dimensions supplied. -/
+  /-- The remaining BNT-cover comparison data for the produced common primitive
+  nonzero-sector families, with the structural evidence for trace preservation,
+  primitivity, irreducibility, and positive bond dimensions supplied. -/
   comparison : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
       {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
       [∀ x : Fin rA, NeZero (dimA x)]
@@ -142,18 +197,21 @@ structure AfterBlockingFundamentalTheoremHypotheses
           (CommonPrimitiveBNTCoverHypotheses (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
             (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB)
 
-/-- Conclusion obtained from supplied after-blocking comparison data.
+/-- Blocked normal-form sector matching: the conclusion of the after-blocking theorem.
 
-The conclusion follows the Cirac--Pérez-García--Schuch--Verstraete statement at the level of
-BNT sector decompositions.  After one positive blocking, there are sector decompositions `P` and
-`Q` with BNT data.  The blocked tensors agree with these sector tensors at all positive lengths,
-the two sector tensors generate the same full MPV family, and the basis sectors have matching
-multiplicities and weights up to a permutation and nonzero phases.
+This structure records the fourth source proof obligation (the phase-gauge formula)
+together with the structural data that the blocked tensors admit matching BNT sector
+decompositions: after a common positive blocking length `p`, the two blocked tensors
+are represented by sector decompositions `P` and `Q` that carry BNT data, generate the
+same full MPV family, and agree with the blocked tensors at every positive length.
+The basis sectors are matched by a permutation, the corresponding multiplicities
+agree, and the sector-weight multisets match after multiplying the weights on one
+side by nonzero sector phases.
 
-The positive-length comparison with the original blocked tensors is intentional: before the
-zero-tail dimensions are identified, the zero-tail contribution is the only obstruction at
-length zero. -/
-structure AfterBlockingFundamentalTheoremConclusion
+The positive-length comparison with the original blocked tensors is intentional:
+before the zero-tail dimensions are identified, the zero-tail contribution is the
+only obstruction at length zero. -/
+structure BlockedNormalFormSectorMatching
     {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) where
   /-- The common physical blocking length. -/
   p : ℕ
@@ -187,20 +245,26 @@ structure AfterBlockingFundamentalTheoremConclusion
       Finset.univ.val.map
         (fun q => phase j * Q.weight (perm j) (Fin.cast (copies_eq j) q))
 
-/-- **After-blocking comparison from supplied BNT-cover data.**
+/-- **Conditional after-blocking fundamental theorem from blocked normal-form hypotheses.**
 
-Let `A` and `B` generate the same MPV family.  If BNT-cover comparison data are supplied for
-the common primitive nonzero-sector families obtained after blocking, there is a positive
-blocking after which the two tensors admit BNT sector
-decompositions with the same sector MPV family, matched basis-sector multiplicities, and matched
-sector-weight multisets up to nonzero phases.  The `comparison` field is an independent
-hypothesis of this lemma; the result does not derive it from `SameMPV₂`. -/
-lemma fundamentalTheorem_afterBlocking_of_comparisonHypotheses
+Let `A` and `B` generate the same MPV family.  Given the source proof obligations
+collected in `BlockedNormalFormHypotheses` (blocking to normal tensors, matching
+of nonzero normal summands, equality of the residual zero-block dimension), the
+conclusion `BlockedNormalFormSectorMatching` (the phase-gauge formula) follows:
+there is a positive blocking after which the two tensors admit BNT sector
+decompositions with the same sector MPV family, matched basis-sector multiplicities,
+and matched sector-weight multisets up to nonzero phases.
+
+This is the conditional formulation proved by the present periodic-theorem-free
+derivation: it is a direct consequence of
+`afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover`, not
+a hidden assumption or an appeal to the periodic Fundamental Theorem. -/
+theorem fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B)
-    (h : AfterBlockingFundamentalTheoremHypotheses A B) :
-    Nonempty (AfterBlockingFundamentalTheoremConclusion A B) := by
+    (h : BlockedNormalFormHypotheses A B) :
+    Nonempty (BlockedNormalFormSectorMatching A B) := by
   have h_group : CommonGroupedBlockCastHypothesis d :=
     CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq d
   have h_relabel : CommonSectorRelabelingHypothesis d :=

--- a/TNLean/MPS/CanonicalForm/Assembly.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly.lean
@@ -5,14 +5,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison
 import TNLean.MPS.CanonicalForm.Assembly.CommonPrimitiveProportionalData
 import TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison
-import TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison
 import TNLean.MPS.CanonicalForm.Assembly.CommonSectorData
-import TNLean.MPS.CanonicalForm.Assembly.SectorComparisonCore
 
 /-!
 # Canonical-form reduction after blocking
 
-This module is the public entry point for the end-to-end canonical-form
+This module is the public entry point for the complete canonical-form
 reduction after blocking. It keeps the historical import path
 `TNLean.MPS.CanonicalForm.Assembly` available while the underlying development is
 split across focused supporting modules.
@@ -39,8 +37,6 @@ The supporting modules are:
   after the zero-tail and TP-gauge structural reduction.
 * `TNLean.MPS.CanonicalForm.Assembly.StructuralData` — common-period blocking
   and structural after-blocking data.
-* `TNLean.MPS.CanonicalForm.Assembly.SectorComparisonCore` — conditional
-  sector comparison after structural blocking.
 * `TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` — historical re-export
   path for structural data and common-sector transport.
 * `TNLean.MPS.CanonicalForm.Assembly.CommonSectorTransport` — zero-tail and
@@ -49,9 +45,6 @@ The supporting modules are:
   common primitive span, phase-cover, proportional, and BNT-cover hypotheses.
 * `TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison` — basic sector
   comparisons from block-span, phase-cover, and proportional data.
-* `TNLean.MPS.CanonicalForm.Assembly.OverlapSpanComparison` — overlap-span
-  hypothesis constructors from common primitive span, phase-cover, BNT-cover,
-  and proportional data.
 * `TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison` — sector comparison
   from BNT proportional-decomposition data.
 
@@ -79,7 +72,7 @@ the blocked normal-form sector matching conclusion: after a common blocking,
 the two tensors are represented by BNT sector decompositions whose basis
 sectors and weights match up to permutation and nonzero phases.
 
-## Formalization note: packaging as proof obligations
+## Conditional comparison hypotheses
 
 The source CPSV statement is written for tensors already in canonical form:
 after finitely many blocking steps the matrices are replaced by block-diagonal
@@ -90,8 +83,8 @@ trace preservation, primitivity, irreducibility, or zero-tail dimension
 matching.
 
 The structures `BlockedNormalFormHypotheses` and
-`BlockedNormalFormSectorMatching` explicitly package these source proof
-obligations as formal inputs:
+`BlockedNormalFormSectorMatching` state these source proof obligations as
+explicit hypotheses:
 
 * **Blocking to normal tensors** — the blocked tensors decompose into a zero
   block plus a direct sum of trace-preserving, primitive, irreducible
@@ -104,10 +97,10 @@ obligations as formal inputs:
   basis sectors, matched multiplicities, and nonzero phases transforming
   one multiset of sector weights into the other.
 
-This packaging is the current formal boundary between the canonical-form
-reduction that is already proved in Lean and the source-level comparison
-argument that passes from equal matrix product vector families to the BNT
-sector-matching theorem.
+These hypotheses mark the current comparison boundary: the canonical-form
+reduction gives the normal blocks, while the source comparison argument still
+has to derive the BNT sector matching from equality of the matrix product
+vector families.
 
 ## References
 

--- a/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
+++ b/audits/2026-05-01_issue1093_non_gemma_ft_reorganization_scout.md
@@ -43,17 +43,17 @@ The declaration group in `TNLean/MPS/CanonicalForm/Assembly.lean` records a
 conditional statement in the language of the Cirac--Pérez-García--Schuch--Verstraete
 Fundamental Theorem:
 
-- `MPSTensor.AfterBlockingFundamentalTheoremHypotheses` names the remaining
+- `MPSTensor.BlockedNormalFormHypotheses` names the remaining
   comparison data.  It includes blocked-word relabeling, and its comparison field
   is supplied with the produced sectors' trace-preserving, primitive, and
   irreducible structure before returning the remaining zero-tail, injectivity, and
   BNT proportional-comparison hypotheses for those same sectors.
-- `MPSTensor.AfterBlockingFundamentalTheoremConclusion` records the conclusion:
+- `MPSTensor.BlockedNormalFormSectorMatching` records the conclusion:
   after a positive blocking, there are BNT sector decompositions `P` and `Q`; the
   original blocked tensors agree with them at positive lengths; `P` and `Q`
   generate the same full MPV family; and the basis sectors, multiplicities, and
   sector-weight multisets match up to a permutation and nonzero phases.
-- `MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses` derives the
+- `MPSTensor.fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses` derives the
   conclusion from `SameMPV₂ A B` and those named hypotheses by applying the
   existing relabeled-common-sector proportional theorem.
 

--- a/audits/2026-05-02_issue652_gap1_scout.md
+++ b/audits/2026-05-02_issue652_gap1_scout.md
@@ -23,7 +23,7 @@ The four remaining hypotheses are:
 | H3 | Zero-tail equality + injectivity + common phase cover / BNT-cover comparison | `CommonPrimitivePhaseCoverHypotheses` (or the `CommonPrimitiveBNTCoverHypotheses` bridge) | #1068 / #652 | Genuine paper-level math |
 | H4 | (Resolved: one-sided BNT construction with overlap data) | `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho` | #877 / #945 / #923 | Resolved (Wave 17G PR #945) |
 
-The conditional after-blocking theorem `fundamentalTheorem_afterBlocking_of_comparisonHypotheses`
+The conditional after-blocking theorem `fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses`
 in `TNLean/MPS/CanonicalForm/Assembly.lean` already accepts H1–H3 as explicit hypotheses
 and produces the full sector-weight conclusion.  The remaining work to reach the
 unconditional theorem is the proof of H1 and the derivation of H3 from the
@@ -50,12 +50,12 @@ Each step in this chain is now explained in detail.
 
 **File:** `TNLean/MPS/CanonicalForm/Assembly.lean` lines 67–201
 
-**Structure:** `AfterBlockingFundamentalTheoremHypotheses` bundles:
+**Structure:** `BlockedNormalFormHypotheses` bundles:
 - `relabel : CommonSectorRelabelingHypothesis d`
 - `comparison :` (a forall accepting the produced common nonzero-sector families and requiring BNT-cover data for them)
 
-**Theorem:** `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` takes
-`SameMPV₂ A B` and `AfterBlockingFundamentalTheoremHypotheses A B` and produces
+**Theorem:** `fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses` takes
+`SameMPV₂ A B` and `BlockedNormalFormHypotheses A B` and produces
 the BNT sector-weight comparison conclusion.
 
 This conditional theorem is already proved.  It composes:
@@ -194,7 +194,7 @@ case, organized by dependency level:
 - BNT-cover sector comparison — needs H1+H2+H3
 
 ### Level 5: Conditional full FT statement
-- `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` — clean conditional form, proved
+- `fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses` — clean conditional form, proved
 
 ### Level 6: Special-case unconditional
 - `fundamentalTheorem_after_blocking_sector_of_common_blocks_injectiveSpan` — unconditional **if** exact common blocks, injectivity, and span equality are supplied as hypotheses
@@ -352,7 +352,7 @@ theorem nonzero_block_span_eq_of_sameMPV₂_after_blocking
 | One-sided BNT construction | ✅ proved | paper math | #877, #945 | `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho` |
 | Two-sided BNT matching from span | ✅ proved | paper math | #860, #935 | `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching` |
 | Common-period blocking arithmetic | ✅ proved | bookkeeping | — | `lcmPeriod`, `isPrimitive_transferMap_blockTensor_of_dvd` |
-| Conditional full FT | ✅ proved | organizational | — | `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` |
+| Conditional full FT | ✅ proved | organizational | — | `fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses` |
 
 ## References
 

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1283,7 +1283,7 @@ BNT comparison hypotheses for the common primitive sectors.
 
 \begin{definition}[After-blocking BNT matching hypotheses]%
 	\label{def:after_blocking_sector_comparison_hypotheses}
-	\lean{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}
+	\lean{MPSTensor.BlockedNormalFormHypotheses}
 	\leanok
 	\uses{def:common_primitive_bnt_cover_hypotheses}
 	For two tensors with the same MPV family, the structural reduction supplies
@@ -1304,7 +1304,7 @@ BNT comparison hypotheses for the common primitive sectors.
 
 \begin{definition}[After-blocking sector-comparison conclusion]%
 \label{def:after_blocking_sector_comparison_conclusion}
-	\lean{MPSTensor.AfterBlockingFundamentalTheoremConclusion}
+	\lean{MPSTensor.BlockedNormalFormSectorMatching}
 	\leanok
 	\uses{def:paper_sector_data}
 	The conclusion consists of a positive blocking length and sector
@@ -1318,7 +1318,7 @@ BNT comparison hypotheses for the common primitive sectors.
 
 \begin{lemma}[After-blocking comparison from supplied BNT matching hypotheses]%
 \label{lem:after_blocking_sector_comparison_of_supplied_bnt_cover}
-	\lean{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}
+	\lean{MPSTensor.fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses}
 	\leanok
 	\uses{def:after_blocking_sector_comparison_hypotheses,
 			def:after_blocking_sector_comparison_conclusion}

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -89,11 +89,11 @@ blocked tensors agree with these sector decompositions at positive lengths, the
 sector decompositions have the same full matrix product vector family, and the
 sector multiplicities and weights match up to a permutation and nonzero phases.
 Formally this is the structure
-\path{MPSTensor.AfterBlockingFundamentalTheoremConclusion} and the theorem
-\path{MPSTensor.fundamentalTheorem_afterBlocking_of_comparisonHypotheses}.
+\path{MPSTensor.BlockedNormalFormSectorMatching} and the theorem
+\path{MPSTensor.fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses}.
 
 The hypotheses of this theorem are collected in
-\path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses}.  They now consist
+\path{MPSTensor.BlockedNormalFormHypotheses}.  They now consist
 of the comparison field for the common primitive nonzero-sector families
 produced by the preceding structural theorem; the blocked-word relabeling
 assertion for cyclic-sector data is derived in the formal theorem.  The comparison
@@ -174,7 +174,7 @@ identities survive these changes of description.
 \section{Conclusion}
 
 The papers do not state the hypotheses of
-\path{MPSTensor.AfterBlockingFundamentalTheoremHypotheses} as explicit theorem
+\path{MPSTensor.BlockedNormalFormHypotheses} as explicit theorem
 hypotheses. The conditional theorem in \ghpr{1104} is therefore not yet the
 unconditional CPSV/CPGSV statement. It records the theorem form proved by the
 present derivation without the periodic Fundamental Theorem, with the remaining

--- a/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
@@ -499,10 +499,10 @@ mathematical layers.
 
   \item \path{TNLean/MPS/CanonicalForm/Assembly.lean} records the
   after-blocking theorem in conditional form. The structure
-  \leanid{AfterBlockingFundamentalTheoremHypotheses} supplies the remaining
+  \leanid{BlockedNormalFormHypotheses} supplies the remaining
   comparison data for the common primitive nonzero-sector families produced from
   the two original tensors. The conclusion
-  \leanid{AfterBlockingFundamentalTheoremConclusion} states the BNT sector
+  \leanid{BlockedNormalFormSectorMatching} states the BNT sector
   matching after one positive common blocking length.
 
   \item \path{TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean}


### PR DESCRIPTION
Closes #1430.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a public API rename/repackaging (`AfterBlockingFundamentalTheorem*` → `BlockedNormalForm*`) that can break downstream imports/usages, but it does not change proof logic or core algorithms.
> 
> **Overview**
> Renames and reframes the conditional after-blocking CPSV fundamental-theorem entry point in `Assembly.lean` to expose the paper’s *source proof obligations* explicitly. The old `AfterBlockingFundamentalTheoremHypotheses`/`AfterBlockingFundamentalTheoremConclusion` and `fundamentalTheorem_afterBlocking_of_comparisonHypotheses` surface is replaced by `BlockedNormalFormHypotheses`, `BlockedNormalFormSectorMatching`, and `fundamentalTheorem_afterBlocking_from_blockedNormalFormHypotheses`, with expanded docstrings clarifying the four obligations and the phase-gauge sector-matching conclusion.
> 
> Updates accompanying audits and LaTeX documentation/blueprint references to use the new names and description of the conditional theorem boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c113a3653cb026c2a8c60e70faafd6402d3a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->