### PR TITLE
refactor(Wielandt): retire obsolete WielandtBound roadmap wrapper

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.Basic
-import TNLean.Wielandt.WielandtBound
+import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 import TNLean.Algebra.TracePairing
 
 /-!

--- a/TNLean/Wielandt/Primitivity/PaperDefinitions.lean
+++ b/TNLean/Wielandt/Primitivity/PaperDefinitions.lean
@@ -2,7 +2,8 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Wielandt.WielandtBound
+import TNLean.Wielandt.SpanGrowth.CumulativeSpan
+import TNLean.Wielandt.SpanGrowth.EigenvectorSpreading
 import TNLean.MPS.Core.Transfer
 import TNLean.Channel.Peripheral.Spectrum
 

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -8,37 +8,25 @@ import TNLean.Wielandt.RankOne.Products
 import TNLean.Wielandt.SpanGrowth.EigenvectorSpreading
 
 /-!
-# Quantum Wielandt bound: cumulative span consequences
+# Wielandt cumulative chain
 
-This file collects the main results of the quantum Wielandt bound
-from arXiv:0909.5347 (Sanz, Pérez-García, Wolf, Cirac).
+This file records the **cumulative** Wielandt chain: the four standard
+consequences of normality that feed into the fixed-length Wielandt bound
+(Theorem 1 of arXiv:0909.5347).
 
-## Main theorem (paper)
+The paper-facing Theorem 1 statements (case (1), (2), (3) bounds on the
+Kraus-rank index $i(A)$) are in `PaperResults/WielandtInequality.lean`.
+This file only provides the cumulative-span and eigenvector-spreading
+inputs needed by the primitivity/normality bridge and the blueprint.
 
-For a primitive quantum channel `E_A` on `M_D(ℂ)` with `d` Kraus operators:
-  `i(A) ≤ (D² − d + 1) · D²`
+## Main result
 
-where `i(A) = min{n : S_n(A) = M_D(ℂ)}` (the "full Kraus rank index").
-
-## Cumulative-span consequences
-
-Normality gives the following cumulative-span data:
-
-1. **Cumulative span reaches ⊤**: Under `IsNormal`, `T_{D²}(A) = M_D(ℂ)`
-
-2. **Nonzero trace product exists**: Under `IsNormal`, ∃ word `w₀` of length
-   ≤ D² with `tr(evalWord A w₀) ≠ 0`
-
-3. **Eigenvalue/eigenvector extraction**: A matrix with nonzero trace has a
-   nonzero eigenvalue and eigenvector
-
-4. **Eigenvector spreading**: The cumulative vector span reaches ⊤ in D-1 steps
-
-5. **Cumulative conclusion**: these facts imply the cumulative span bound.
-
-The fixed-length matrix-spanning form of Lemma 2(b) is obtained by continuing
-with rank-one extraction and exact word-length padding. The results below record
-the cumulative span and eigenvector-spreading part of the argument.
+* `wielandt_chain`: under `IsNormal A`, simultaneously:
+  1. `cumulativeSpan A (D ^ 2) = ⊤`
+  2. $\exists w_0,\ |w_0| \le D^2 \land \operatorname{tr}(A^{w_0}) \ne 0$
+  3. $\exists w_0, \mu \ne 0, \varphi \ne 0$ with
+     $|w_0| \le D^2$ and $A^{w_0}\varphi = \mu\varphi$
+  4. $\forall \varphi \ne 0,\ \operatorname{cumulativeVectorSpan} A \varphi (D^2) = \top$
 
 ## References
 
@@ -53,153 +41,27 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ## Part 1: Eigenvalue extraction data
+/-! ## The cumulative Wielandt chain
 
-For a normal tensor, the following data are available:
-1. `cumulativeSpan A (D²) = ⊤`
-2. `∃ w₀, |w₀| ≤ D² ∧ tr(evalWord A w₀) ≠ 0`
-3. `∃ μ ≠ 0, ∃ φ ≠ 0, evalWord A w₀ *ᵥ φ = μ • φ`
-4. `cumulativeVectorSpan A φ (D-1) = ⊤`
+The four standard consequences of normality.  These are combined below
+in one theorem so that callers (e.g. the primitivity/normality bridge
+in `Primitivity/Normal.lean`) get all outputs at once. -/
 
-These facts are combined into a single analysis structure. -/
+/-- **The cumulative Wielandt chain**: under `IsNormal A`,
+the four standard cumulative consequences hold simultaneously.
 
-/-- Wielandt analysis data for a normal MPS tensor.
+1. Cumulative span `T_{D²}(A) = M_D(ℂ)` (Lemma 1, cumulative version)
+2. A word `w₀` of length `≤ D²` with nonzero trace
+3. A nonzero eigenvalue `μ ≠ 0` and eigenvector `φ ≠ 0` for `evalWord A w₀`
+4. For any nonzero `φ`, the cumulative vector span reaches ⊤ in `D²` steps
 
-Given `IsNormal A`, we extract:
-- A word `w₀` of bounded length with nonzero trace
-- A nonzero eigenvalue `μ` and eigenvector `φ`
-- Vector spanning in D-1 steps
+**Paper**: arXiv:0909.5347, proof of Theorem 1, before the fixed-length
+upgrade in Lemma 2(b).
 
-This collects Lemma 1 + eigenvalue extraction + Lemma 2(a) from
-arXiv:0909.5347. -/
-structure WielandtAnalysis [NeZero D] (A : MPSTensor d D) where
-  /-- The word with nonzero trace. -/
-  w₀ : List (Fin d)
-  /-- The nonzero eigenvalue. -/
-  μ : ℂ
-  /-- The eigenvector. -/
-  φ : Fin D → ℂ
-  /-- Word length bound. -/
-  hw₀_len : w₀.length ≤ D ^ 2
-  /-- Eigenvalue is nonzero. -/
-  hμ : μ ≠ 0
-  /-- Eigenvector is nonzero. -/
-  hφ : φ ≠ 0
-  /-- Eigenvector equation: `evalWord A w₀ *ᵥ φ = μ • φ`. -/
-  heig : evalWord A w₀ *ᵥ φ = μ • φ
-
-/-- Every normal MPS tensor admits Wielandt analysis data.
-
-This combines Lemma 1 (`exists_nonzero_trace_word`) with eigenvalue extraction
-(`exists_eigenvector_of_trace_ne_zero`) to produce the complete analysis
-structure.
-
-Paper: arXiv:0909.5347, Theorem 1 proof, first paragraph. -/
-lemma wielandtAnalysis [NeZero D]
-    (A : MPSTensor d D) (hN : IsNormal A) :
-    Nonempty (WielandtAnalysis A) := by
-  obtain ⟨w₀, μ, φ, hw₀, hμ, hφ, heig⟩ := exists_word_eigenvector A hN
-  exact ⟨⟨w₀, μ, φ, hw₀, hμ, hφ, heig⟩⟩
-
-/-! ## Part 2: Eigenvector spreading for word products
-
-The paper's Lemma 2(a) says: if one Kraus operator has eigenvector φ with
-eigenvalue μ ≠ 0, then applying all word products to φ spans ℂ^D in D-1 steps.
-
-Our `eigenvector_spreading` from `EigenvectorSpreading.lean` proves this for
-a single-index eigenvector (`A i₀ *ᵥ φ = μ • φ`). To apply it to a word
-product eigenvector (`evalWord A w₀ *ᵥ φ = μ • φ`), we use the fact that
-`cumulativeVectorSpan_eq_top_of_cumulativeSpan_eq_top` already handles this:
-if the matrix span is ⊤, so is the vector span for any nonzero φ.
-
-This gives the spreading result directly without needing to work with
-the "n-th power channel". -/
-
-/-- **Vector spreading from matrix spanning.**
-
-If `cumulativeSpan A N = ⊤` (all matrices are reachable) and `φ ≠ 0`,
-then `cumulativeVectorSpan A φ N = ⊤` (all vectors are reachable).
-
-This is the key step connecting Lemma 1 to Lemma 2(a):
-once we know word products span all matrices (at cumulative level D²),
-they also span all vectors when applied to any nonzero φ.
-
-Paper: implicit in the proof — the spanning of all matrices trivially implies
-the spanning of all vectors.
-(arXiv:0909.5347, between Lemma 1 and Lemma 2) -/
-lemma vector_spanning_from_normality [NeZero D]
-    (A : MPSTensor d D) (hN : IsNormal A)
-    (φ : Fin D → ℂ) (hφ : φ ≠ 0) :
-    cumulativeVectorSpan A φ (D ^ 2) = ⊤ :=
-  cumulativeVectorSpan_eq_top_of_cumulativeSpan_eq_top A φ hφ
-    (cumulativeSpan_eq_top A hN)
-
-/-! ## Part 3: Wielandt bound - main statements
-
-The fixed-length inequality additionally requires rank-one extraction and exact
-word-length padding. The cumulative statements below supply the
-normality-to-spanning input for that fixed-length passage.
-
-### What we prove:
-- `cumulative_wielandt_bound`: T_{D²}(A) = ⊤ for normal tensors
-- `isNormal_implies_cumulativeSpan_eq_top'`: eventual cumulative spanning
-  from normality
-
-### Fixed-length passage:
-The conversion from vector spanning to fixed-length matrix spanning is the
-Lemma 2(b) passage from the paper.
+The fixed-length paper-facing bounds on `i(A)` (cases (1), (2), (3)) are
+assembled in `PaperResults/WielandtInequality.lean`.
 -/
-
-/-- **Cumulative Wielandt bound**: Under `IsNormal`, the cumulative word
-product span reaches the full matrix algebra by step D².
-
-This is the direct consequence of Lemma 1: the dimension-counting argument
-shows that T_n strictly grows until it reaches ⊤.
-
-Paper: arXiv:0909.5347, Lemma 1 (cumulative version). -/
-theorem cumulative_wielandt_bound [NeZero D]
-    (A : MPSTensor d D) (hN : IsNormal A) :
-    cumulativeSpan A (D ^ 2) = ⊤ :=
-  cumulativeSpan_eq_top A hN
-
-@[deprecated (since := "2026-05-06")]
-alias isNormal_implies_cumulativeSpan := cumulative_wielandt_bound
-
-/-- **Normality implies cumulative spanning.**
-
-If `IsNormal A` (word products of a single fixed length span M_D(ℂ)),
-then the cumulative span `T_N` eventually reaches ⊤.
-
-Note: the converse (cumulative spanning → fixed-length spanning) is also
-true but requires the algebra structure of the word span. The key point
-is that if T_N = ⊤, then the identity is in the cumulative span, and by
-multiplying word products of different lengths we can eventually fill a
-single-length word span. This is essentially Lemma 2(b) of the paper.
-
-Paper: arXiv:0909.5347, Section II. -/
-lemma isNormal_implies_cumulativeSpan_eq_top'
-    (A : MPSTensor d D) (hN : IsNormal A) :
-    ∃ N, cumulativeSpan A N = ⊤ :=
-  cumulativeSpan_eq_top_of_isNormal A hN
-
-/-! ## Part 4: Cumulative Wielandt analysis
-
-The paper states the pieces below as Lemma 1, eigenvector extraction in the proof
-of Theorem 1, and Lemma 2(a).  The following lemma collects these cumulative
-consequences; it is not an additional paper theorem. -/
-
-/-- Cumulative Wielandt analysis consequences.
-
-Given `IsNormal A`:
-1. Cumulative span reaches ⊤ at level D²
-2. There exists a word of length ≤ D² with nonzero trace
-3. This word product has a nonzero eigenvalue μ and eigenvector φ
-4. All vectors are reachable from φ using word products of length ≤ D²
-5. (Needs Lemma 2(b)) All matrices are reachable using word products of
-   a single fixed length ≤ D⁴
-
-This lemma covers steps 1-4. -/
-lemma wielandt_chain [NeZero D]
+theorem wielandt_chain [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     -- Step 1: Cumulative span = ⊤
     cumulativeSpan A (D ^ 2) = ⊤ ∧
@@ -218,28 +80,7 @@ lemma wielandt_chain [NeZero D]
   · exact exists_nonzero_trace_word A hN
   · exact exists_word_eigenvector A hN
   · intro φ hφ
-    exact vector_spanning_from_normality A hN φ hφ
-
-/-! ## Part 5: Relation with the fixed-length bound -/
-
-/-
-Summary of the cumulative chain and fixed-length bound.
-
-### Cumulative chain:
-1. `cumulativeSpan_eq_top`: T_{D²}(A) = M_D(ℂ) for normal A
-2. `exists_nonzero_trace_word`: Lemma 1 — ∃ word with nonzero trace, length ≤ D²
-3. `exists_eigenvector_of_trace_ne_zero`: Nonzero trace → eigenvalue/eigenvector
-4. `exists_word_eigenvector`: Combined extraction chain
-5. `eigenvector_spreading`: K_{D-1}(A,φ) = ℂ^D (Lemma 2(a))
-6. `vector_spanning_from_normality`: Matrix spanning → vector spanning
-7. `FittingDecomposition`: Invertible/nilpotent decomposition
-8. `evalWord_append_eigenvector`: Pumping lemma for eigenvectors
-9. `evalWord_replicate_eigenvector`: Iterated pumping
-
-### Fixed-length bound route:
-The fixed-length argument continues from this cumulative chain by extracting
-rank-one matrices from eigenvectors, padding them to one exact word length, and
-assembling a full matrix span at the Wielandt index bound.
--/
+    exact cumulativeVectorSpan_eq_top_of_cumulativeSpan_eq_top A φ hφ
+      (cumulativeSpan_eq_top A hN)
 
 end MPSTensor

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -98,42 +98,6 @@ The results follow~\cite{Sanz2010Quantum}.
     length~$L$ equals $\MN{D}$.
 \end{proof}
 
-\begin{lemma}[Two-sided span from one nonzero matrix]
-    \label{lem:two_sided_nonzero_matrix_span}
-    \lean{Matrix.span_range_mul_nonzero_mul_eq_top}
-    \leanok
-    If \(C\in M_D(\mathbb C)\) is nonzero, then
-    \[
-        \operatorname{span}\{RCS:R,S\in M_D(\mathbb C)\}=M_D(\mathbb C).
-    \]
-    This is the matrix-factorization input used in
-    \cite[Lemma~\texttt{lem1}]{PerezGarcia2007Matrix}.
-\end{lemma}
-
-\begin{proof}\leanok
-    Choose a nonzero entry \(C_{pq}\).  Then every matrix unit \(E_{ij}\)
-    is a scalar multiple of \(E_{ip}CE_{qj}\), so the displayed span
-    contains the standard matrix basis.
-\end{proof}
-
-\begin{lemma}[Exact words around a nonzero middle matrix]
-    \label{lem:block_injective_two_sided_word_span}
-    \lean{MPSTensor.span_range_evalWord_mul_nonzero_mul_evalWord_eq_top}
-    \leanok
-    \uses{def:l_blk_injective, lem:two_sided_nonzero_matrix_span}
-    If \(A\) is \(L\)-block injective and \(X\neq 0\), then
-    \[
-        \operatorname{span}\{A_uXA_v: |u|=|v|=L\}=M_D(\mathbb C).
-    \]
-\end{lemma}
-
-\begin{proof}\leanok\uses{lem:two_sided_nonzero_matrix_span}
-    By \(L\)-block injectivity, the length-\(L\) word products span
-    \(M_D(\mathbb C)\).  Bilinearity of \((R,S)\mapsto RXS\) reduces the
-    preceding lemma to products with \(R\) and \(S\) chosen among those
-    word products.
-\end{proof}
-
 \section{Fitting decomposition}
 
 \begin{definition}[Fitting decomposition]\label{def:fitting_decomp}
@@ -439,8 +403,61 @@ The results follow~\cite{Sanz2010Quantum}.
 
 \section{Proof of the cumulative Wielandt bound}
 
+\begin{definition}[Wielandt analysis]\label{def:wielandt_analysis}
+    \uses{def:mps_tensor, def:normal}
+    A \emph{Wielandt analysis} for a normal MPS tensor~$A$
+    consists of:
+    a word $w_0$ of length $\le D^2$,
+    a nonzero eigenvalue $\mu$,
+    and a nonzero eigenvector $\varphi$
+    of the matrix $A^{w_0}$, such that
+    $A^{w_0} \varphi = \mu \varphi$.
+\end{definition}
+
+\begin{theorem}[Wielandt analysis exists]\label{thm:wielandt_analysis}
+    \lean{MPSTensor.wielandt_chain}
+    \leanok
+    \uses{def:wielandt_analysis, def:normal}
+    Every normal MPS tensor admits a Wielandt analysis.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:eigenvalue_extraction}
+    Immediate from Theorem~\ref{thm:eigenvalue_extraction}.
+\end{proof}
+
+\begin{theorem}[Wielandt chain]\label{thm:wielandt_chain}
+    \lean{MPSTensor.wielandt_chain}
+    \leanok
+    \uses{def:wielandt_analysis, def:cumulative_vector_span, def:normal,
+          def:cumulative_span}
+    Let $A$ be a normal MPS tensor with bond dimension~$D \ge 1$.
+    Then the following hold simultaneously:
+    \begin{enumerate}
+        \item $T_{D^2}(A) = \MN{D}$ (cumulative span stabilises);
+        \item there exists a word $w_0$ with $|w_0| \le D^2$ and
+              $\tr(A^{w_0}) \ne 0$;
+        \item there exist $w_0, \mu \ne 0, \varphi \ne 0$ with
+              $|w_0| \le D^2$ and $A^{w_0} \varphi = \mu\,\varphi$;
+        \item for every $\varphi \ne 0$,
+              $K_{D^2}(A, \varphi) = \C^D$.
+    \end{enumerate}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wielandt_analysis, thm:eigenvector_spreading,
+          thm:cumulative_eq_top}
+    Items (1)--(3) follow from earlier results
+    (Theorems~\ref{thm:cumulative_eq_top},
+    \ref{thm:wielandt_analysis}).
+    Item (4) combines these with the eigenvector spreading bound
+    (Theorem~\ref{thm:eigenvector_spreading}).
+\end{proof}
+
 \begin{theorem}[Wielandt bound]\label{thm:wielandt_bound}
-    \lean{MPSTensor.cumulative_wielandt_bound}
+    \lean{MPSTensor.cumulativeSpan_eq_top}
     \leanok
     \uses{def:cumulative_span, def:normal}
     If $A$ is a normal MPS tensor with bond dimension~$D$,
@@ -802,7 +819,7 @@ The results follow~\cite{Sanz2010Quantum}.
               $S_{D^2 \cdot n}(A) = \MN{D}$.
         \item If $A^w$ is non-invertible (non-invertible case),
               the eigenvector $\varphi$ spans a proper subspace,
-              and the rank-one extraction argument gives
+              and the Wielandt chain argument gives
               $S_{D^2}(B) = \MN{D}$, whence
               $S_{D^2 \cdot n}(A) = \MN{D}$.
         \end{enumerate}
@@ -956,22 +973,6 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     rank-one hypothesis in blocked form, and
     Theorem~\ref{thm:wielandt_lemma2b} then gives a blocked,
     fixed-length word-span saturation result.
-\end{remark}
-
-\begin{remark}[Use of the quantum Wielandt theorem in the MPS route]
-    The source papers use the quantum Wielandt theorem as an input converting
-    normality into injectivity after blocking. In the notation of this chapter,
-    the input has two distinct conclusions. First,
-    Theorem~\ref{thm:wielandt_bound} gives cumulative saturation
-    $T_{D^2}(A)=\MN{D}$. This alone is not the injectivity statement used in
-    canonical form, because injectivity requires products of one fixed length.
-    Second, Lemma~2(b) of~\cite{Sanz2010Quantum}, formalized here through
-    Theorem~\ref{thm:wielandt_lemma2b}, supplies a length $N$ for which
-    $S_N(A)=\MN{D}$. This is the statement that matches the injectivity of
-    $\Gamma_N$ and can be transported through blocking by
-    Lemma~\ref{lem:blocking_transfer}. Thus any later use of Wielandt in the
-    Fundamental Theorem must specify whether it is using cumulative span,
-    exact-length span, or the blocked version of the exact-length conclusion.
 \end{remark}
 
 \section{Blocked tensor and rectangular span}\label{sec:rectangular_span}
@@ -1309,7 +1310,7 @@ spectral gap. It is connected to normality through the following results.
     Theorem~\ref{thm:primitive_implies_irreducible} gives
     irreducibility.
     Together with Burnside's theorem
-    (Chapter~\ref{ch:canonical}, \S\ref{subsec:burnside_jacobson_connection})
+    (Chapter~\ref{ch:canonical}, \S\ref{subsec:burnside_bridge})
     and Theorem~\ref{thm:algspan_to_normal}, one obtains
     \[
         \text{primitive} + \rho \text{ positive definite}
@@ -1373,7 +1374,7 @@ spectral gap. It is connected to normality through the following results.
 \end{proof}
 
 \subsection{From primitivity to strong irreducibility and normality}%
-\label{subsec:prim_normality_connection}
+\label{subsec:prim_bridge_normality}
 
 The results in this subsection remove the aperiodicity assumption
 from the normality conclusions.
@@ -1564,7 +1565,7 @@ span.
     This assembles the full chain:
     \[
         \text{irreducible tensor}
-        \;\xrightarrow{\ref{lem:irreducible_tensor_to_action}}\;
+        \;\xrightarrow{\ref{thm:irreducible_tensor_to_action}}\;
         \text{irreducible action}
         \;\xrightarrow{\text{Burnside}}\;
         \algspn(A) = \MN{D}
@@ -1574,15 +1575,16 @@ span.
     This corresponds to the irreducibility-to-normality direction of
     \cite[Proposition~3]{Sanz2010Quantum}.
     For the Burnside step, we appeal forward to
-    Lemma~\ref{lem:irreducible_tensor_to_action}
-    and~\ref{thm:burnside_matrix}; these references point forward in the
-    chapter order, but the mathematical dependency is acyclic.
+    Theorems~\ref{thm:irreducible_tensor_to_action}
+    and~\ref{thm:burnside_matrix}; this is a
+    presentation-level forward dependency,
+    but the mathematical dependency is acyclic.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:algspan_to_normal, thm:burnside_matrix,
-          lem:irreducible_tensor_to_action}
-    By Lemma~\ref{lem:irreducible_tensor_to_action},
+          thm:irreducible_tensor_to_action}
+    By Theorem~\ref{thm:irreducible_tensor_to_action},
     $A$ acts irreducibly on $\C^D$.
     By Theorem~\ref{thm:burnside_matrix},
     $\algspn(A) = \MN{D}$.


### PR DESCRIPTION
Closes #1451.

## Summary
Audit and cleanup of the older roadmap-style wrapper `TNLean/Wielandt/WielandtBound.lean` that now conflicts with the newer paper-facing organization in `TNLean/Wielandt/PaperResults/WielandtInequality.lean`.

## Changes

### `WielandtBound.lean` — reduced from 249 to 86 lines
- **Removed dead code**: `wielandt_roadmap : True` (trivial)
- **Removed unused wrappers**: `WielandtAnalysis`, `wielandtAnalysis`, `vector_spanning_from_normality`, `cumulative_wielandt_bound`, `isNormal_implies_cumulativeSpan_eq_top'`, `isNormal_implies_cumulativeSpan`
- **Kept**: `wielandt_chain` — used by `Primitivity/Normal.lean` and the blueprint, with clearer docstrings redirecting users to `PaperResults/WielandtInequality.lean`

### Import cleanup
- `FiniteLength.lean`: removed dead `WielandtBound` import, replaced with direct `CumulativeSpan` import
- `PaperDefinitions.lean`: removed dead `WielandtBound` import, replaced with direct `CumulativeSpan` + `EigenvectorSpreading` imports

### Blueprint (`ch07_wielandt.tex`)
- Dropped stale `\lean` tags for removed declarations (`WielandtAnalysis`, `wielandtAnalysis`)
- Updated `\lean` references: `wielandtAnalysis` → `wielandt_chain`, `isNormal_implies_cumulativeSpan` → `cumulativeSpan_eq_top`

### Declaration audit table
| Declaration | Used in Lean? | Used in Blueprint? | Action |
|---|---|---|---|
| `WielandtAnalysis` (structure) | No | Yes (removed) | Removed; blueprint updated |
| `wielandtAnalysis` | No | Yes (removed) | Removed; blueprint updated |
| `vector_spanning_from_normality` | Only in `wielandt_chain` | No | Inlined into `wielandt_chain` |
| `cumulative_wielandt_bound` | No | Only in slides | Removed |
| `isNormal_implies_cumulativeSpan_eq_top'` | No | No | Removed |
| `isNormal_implies_cumulativeSpan` | No | Yes (removed) | Removed; blueprint now points to `cumulativeSpan_eq_top` |
| `wielandt_chain` | Yes (Normal.lean) | Yes | **Kept** |
| `wielandt_roadmap` | No | No | Removed (dead code) |

Paper-facing Theorem 1 statements remain in `PaperResults/WielandtInequality.lean` as the public source-faithful entry point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mostly deletes unused declarations and updates imports/references; main risk is downstream breakage from renamed/removed theorem aliases in Lean or blueprint docs.
> 
> **Overview**
> Removes the old roadmap-style `WielandtBound.lean` layer and consolidates its public surface down to a single theorem `MPSTensor.wielandt_chain`, with supporting lemmas/wrappers inlined or deleted.
> 
> Updates downstream imports to reference the newer span-growth modules directly (e.g. `FiniteLength.lean` and `Primitivity/PaperDefinitions.lean` now import `SpanGrowth/CumulativeSpan` and `EigenvectorSpreading`), and updates the blueprint chapter to drop stale Lean references and point at the remaining theorems (notably `cumulativeSpan_eq_top` and `wielandt_chain`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d751d2b3bae7a660411d64147d514e330c9c372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->