### PR TITLE
feat(Channel): prove Wolf.infimum_is_attained (#1117)

### DIFF
--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -8,6 +8,10 @@ import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.NormalForm
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Order
+import Mathlib.Topology.Instances.Matrix
+import Mathlib.Topology.Order.Compact
+import Mathlib.Analysis.Normed.Lp.PiLp
+import Mathlib.Analysis.RCLike.Lemmas
 
 /-!
 # Lorentz normal form for quantum channels (Wolf Section 2.3)
@@ -155,29 +159,146 @@ section GenericNormalForm
 
 variable {D : ℕ}
 
-/-- **Key lemma (not yet formalised).**  For a positive-definite Choi matrix τ,
+/-! ### Compactness helpers for the minimisation argument -/
+
+/-- The set of matrices with determinant 1 is closed. -/
+lemma isClosed_det_one : IsClosed {S : Matrix (Fin D) (Fin D) ℂ | S.det = (1 : ℂ)} :=
+  isClosed_singleton.preimage (Continuous.matrix_det continuous_id)
+
+/-- Matrices with determinant 1 are bounded away from 0. -/
+lemma det_one_lower_bound : ∃ (r : ℝ), 0 < r ∧ ∀ (S : Matrix (Fin D) (Fin D) ℂ),
+    S.det = (1 : ℂ) → r ≤ ‖S‖ := by
+  have h_closed : IsClosed {S : Matrix (Fin D) (Fin D) ℂ | S.det = (1 : ℂ)} := isClosed_det_one
+  have h_ne : (0 : Matrix (Fin D) (Fin D) ℂ) ∉ {S | S.det = (1 : ℂ)} := by
+    simp
+  have h_nonempty : {S : Matrix (Fin D) (Fin D) ℂ | S.det = (1 : ℂ)}.Nonempty := by
+    refine ⟨1, ?_⟩; simp
+  have h_dist_pos : 0 < Metric.infDist (0 : Matrix (Fin D) (Fin D) ℂ)
+      {S | S.det = (1 : ℂ)} := by
+    rwa [IsClosed.notMem_iff_infDist_pos h_closed h_nonempty]
+  refine ⟨Metric.infDist 0 {S | S.det = (1 : ℂ)}, h_dist_pos, fun S hS => ?_⟩
+  exact Metric.infDist_le_dist_of_mem hS
+
+/-- The objective function `(S₁, S₂) ↦ re(trace((S₂⊗ₖS₁) τ (S₂⊗ₖS₁)ᴴ))` is continuous. -/
+lemma continuous_obj (τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) :
+    Continuous (fun (p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ) =>
+      (Matrix.trace (((p.2 ⊗ₖ p.1) * τ * ((p.2 ⊗ₖ p.1)ᴴ)))).re) := by
+  continuity
+
+/-- Frobenius norm of Kronecker product: `‖A ⊗ₖ B‖ = ‖A‖ * ‖B‖`. -/
+lemma norm_kronecker (A B : Matrix (Fin D) (Fin D) ℂ) : ‖A ⊗ₖ B‖ = ‖A‖ * ‖B‖ := by
+  have h_norm_sq : ‖A ⊗ₖ B‖ ^ 2 = (‖A‖ * ‖B‖) ^ 2 := by
+    calc
+      ‖A ⊗ₖ B‖ ^ 2 = ∑ i : Fin D × Fin D, ∑ j : Fin D × Fin D, ‖(A ⊗ₖ B) i j‖ ^ 2 := by
+        rw [PiLp.norm_sq_eq_of_L2 (A ⊗ₖ B)]
+      _ = ∑ i : Fin D × Fin D, ∑ j : Fin D × Fin D, ‖A i.1 j.1 * B i.2 j.2‖ ^ 2 := by
+        simp [Matrix.kroneckerMap_apply]
+      _ = ∑ i : Fin D × Fin D, ∑ j : Fin D × Fin D, (‖A i.1 j.1‖ ^ 2 * ‖B i.2 j.2‖ ^ 2) := by
+        simp [norm_mul, mul_pow]
+      _ = (∑ i₁ : Fin D, ∑ j₁ : Fin D, ‖A i₁ j₁‖ ^ 2) *
+          (∑ i₂ : Fin D, ∑ j₂ : Fin D, ‖B i₂ j₂‖ ^ 2) := by
+        simp [Finset.sum_product, Finset.mul_sum, Finset.sum_mul]
+      _ = ‖A‖ ^ 2 * ‖B‖ ^ 2 := by
+        simp_rw [PiLp.norm_sq_eq_of_L2 A, PiLp.norm_sq_eq_of_L2 B]
+      _ = (‖A‖ * ‖B‖) ^ 2 := by ring
+  have h_nonneg_A : 0 ≤ ‖A‖ := norm_nonneg _
+  have h_nonneg_B : 0 ≤ ‖B‖ := norm_nonneg _
+  have h_nonneg_kron : 0 ≤ ‖A ⊗ₖ B‖ := norm_nonneg _
+  have h_nonneg_mul : 0 ≤ ‖A‖ * ‖B‖ := mul_nonneg h_nonneg_A h_nonneg_B
+  nlinarith
+
+/-- For a positive definite τ, the trace form `re(trace(A * τ * Aᴴ))` is positive for A ≠ 0. -/
+lemma trace_form_pos {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hτ : τ.PosDef)
+    {A : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hA : A ≠ 0) :
+    0 < (Matrix.trace (A * τ * Aᴴ)).re := by
+  have h_trace_eq : (Matrix.trace (A * τ * Aᴴ)).re =
+      ∑ i : Fin (D * D), RCLike.re (star (fun j => A i j) ⬝ᵥ (τ.mulVec (fun j => A i j))) := by
+    simp [Matrix.trace, Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Finset.sum_mul, Finset.mul_sum, RCLike.re_sum, Matrix.mulVec]
+  rw [h_trace_eq]
+  have h_exists_row : ∃ i : Fin (D * D), (fun j => A i j) ≠ 0 := by
+    contrapose! hA
+    ext i j; exact hA i ▸ rfl
+  rcases h_exists_row with ⟨i, hi⟩
+  have h_psd : τ.PosSemidef := hτ.posSemidef
+  have h_nonneg : ∀ i : Fin (D * D),
+      0 ≤ RCLike.re (star (fun j => A i j) ⬝ᵥ (τ.mulVec (fun j => A i j))) := by
+    intro k
+    exact h_psd.re_dotProduct_nonneg (fun j => A k j)
+  have h_pos_i : 0 < RCLike.re (star (fun j => A i j) ⬝ᵥ (τ.mulVec (fun j => A i j))) :=
+    hτ.re_dotProduct_pos hi
+  refine Finset.sum_pos' h_nonneg ?_
+  exact ⟨i, Finset.mem_univ _, h_pos_i⟩
+
+/-- There exists `c > 0` such that for all matrices `A`,
+`c * ‖A‖² ≤ re(trace(A * τ * Aᴴ))`. -/
+lemma exists_pos_trace_bound {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hτ : τ.PosDef) :
+    ∃ (c : ℝ), 0 < c ∧ ∀ (A : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ),
+      c * ‖A‖ ^ 2 ≤ (Matrix.trace (A * τ * Aᴴ)).re := by
+  let E := Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ
+  have h_fin : FiniteDimensional ℂ E := Matrix.finiteDimensional
+  have h_proper : ProperSpace E := FiniteDimensional.proper_rclike ℂ E
+  have h_sphere_compact : IsCompact (Metric.sphere (0 : E) 1) := isCompact_sphere _ _
+  have h_sphere_nonempty : (Metric.sphere (0 : E) 1).Nonempty := by
+    refine ⟨1, ?_⟩
+    rw [Metric.mem_sphere, dist_eq_norm, sub_zero, norm_one]
+  let f : E → ℝ := fun A => (Matrix.trace (A * τ * Aᴴ)).re
+  have hf_cont : Continuous f := by
+    unfold f; continuity
+  have hf_contOn : ContinuousOn f (Metric.sphere (0 : E) 1) :=
+    hf_cont.continuousOn
+  obtain ⟨A₀, hA₀, hmin⟩ := h_sphere_compact.exists_isMinOn h_sphere_nonempty hf_contOn
+  have h_norm_A₀ : ‖A₀‖ = 1 := by
+    rw [Metric.mem_sphere, dist_eq_norm, sub_zero] at hA₀; exact hA₀
+  have h_A₀_ne_zero : A₀ ≠ 0 := by
+    intro hzero; rw [hzero, norm_zero] at h_norm_A₀; linarith
+  have h_c_pos : 0 < f A₀ := trace_form_pos hτ h_A₀_ne_zero
+  set c := f A₀ with hc_def
+  have hc_pos : 0 < c := h_c_pos
+  refine ⟨c, hc_pos, fun A => ?_⟩
+  by_cases hA_zero : A = 0
+  · subst hA_zero; simp [f, c, hc_def, Matrix.trace]
+  · have h_norm_pos : 0 < ‖A‖ := norm_pos.mpr hA_zero
+    set A' := (‖A‖⁻¹ : ℝ) • A with hA'_def
+    have hA'_sphere : A' ∈ Metric.sphere (0 : E) 1 := by
+      rw [Metric.mem_sphere, dist_eq_norm, sub_zero, hA'_def]
+      rw [norm_smul, Real.norm_of_nonneg (by positivity : 0 ≤ (‖A‖⁻¹ : ℝ)), norm_norm]
+      field_simp [ne_of_gt h_norm_pos]
+    have h_bound : c ≤ f A' := hmin hA'_sphere
+    have h_scale : f A' = ((‖A‖⁻¹ : ℝ) ^ 2) * f A := by
+      dsimp [f, A']
+      calc
+        (Matrix.trace (((‖A‖⁻¹ : ℝ) • A) * τ * (((‖A‖⁻¹ : ℝ) • A)ᴴ))).re
+            = (Matrix.trace (((‖A‖⁻¹ : ℂ) • A) * τ * (((‖A‖⁻¹ : ℂ) • A)ᴴ))).re := by simp
+        _ = (Matrix.trace (((‖A‖⁻¹ : ℂ) • A) * τ * ((‖A‖⁻¹ : ℂ) • Aᴴ))).re := by simp
+        _ = (Matrix.trace (((‖A‖⁻¹ : ℂ) ^ 2) • (A * τ * Aᴴ))).re := by
+          simp [smul_mul_assoc, mul_smul_comm, smul_smul, mul_assoc]
+        _ = (((‖A‖⁻¹ : ℂ) ^ 2) • Matrix.trace (A * τ * Aᴴ)).re := by simp [Matrix.trace_smul]
+        _ = RCLike.re ((↑((‖A‖⁻¹ : ℝ) ^ 2) : ℂ) * Matrix.trace (A * τ * Aᴴ)) := by
+          push_cast; simp
+        _ = ((‖A‖⁻¹ : ℝ) ^ 2) * RCLike.re (Matrix.trace (A * τ * Aᴴ)) := by
+          rw [RCLike.re_ofReal_mul]
+        _ = ((‖A‖⁻¹ : ℝ) ^ 2) * f A := by simp [f]
+    have h_scale_inv : f A = (‖A‖ ^ 2) * f A' := by
+      rw [h_scale]
+      have h_norm_sq_pos : ‖A‖ ^ 2 ≠ 0 := by positivity
+      field_simp [h_norm_sq_pos]
+      ring
+    calc
+      c * ‖A‖ ^ 2 ≤ f A' * (‖A‖ ^ 2) := by
+        nlinarith
+      _ = f A := by rw [h_scale_inv]
+
+/-- **Key lemma.**  For a positive-definite Choi matrix τ,
 the infimum of `tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]` over `S₁, S₂` with `det = 1`
-is attained.  That is, the continuous function
-`(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
-achieves its minimum on the domain of SL(n, ℂ) × SL(n, ℂ).
+is attained.
 
-**Proof sketch** (Wolf Section 2.3).  There exist bounds
-  `0 < λ_min(τ) · ‖S₂ ⊗ₖ S₁‖² ≤ tr[τ'] ≤ tr[τ]`,
-so we may restrict to a bounded subset `{S_i | ‖S_i‖ ≤ C}` inside
-`{S | det S = 1}`.  In finite dimensions this set is compact, and the
-continuous trace functional attains its infimum by the extreme value theorem.
-
-**Missing Mathlib facts:**
-- Compactness of the set `{S : Matrix n n ℂ | det S = 1 ∧ ‖S‖ ≤ C}`.
-  This needs: (a) the determinant condition `det S = 1` defines a closed set
-  (it is a polynomial equation), and (b) the spectral-norm ball `‖S‖ ≤ C` is
-  compact (finite-dimensional Heine–Borel).
-- The extreme value theorem for the continuous map
-  `(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
-  on this compact product set.
-Both should be obtainable from `Mathlib.Topology.Instances.Matrix` and
-`Mathlib.Topology.Algebra.Module.FiniteDimension`, but the connecting results
-are not yet in Mathlib. -/
+The proof uses:
+1. Finite-dimensional Heine–Borel: closed bounded sets are compact
+2. Positivity of τ gives a coercivity estimate `f(A) ≥ c·‖A‖²` via the compact unit sphere
+3. The determinant-1 condition keeps SL matrices away from zero
+4. Kronecker product norm identity: `‖S₂⊗ₖS₁‖ = ‖S₁‖·‖S₂‖`
+5. Extreme value theorem on the resulting compact sublevel set -/
 lemma infimum_is_attained
     {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
     (_hτ_posDef : τ.PosDef) :
@@ -187,7 +308,102 @@ lemma infimum_is_attained
         T₁.det = 1 → T₂.det = 1 →
         (Matrix.trace (((T₂ ⊗ₖ T₁) * τ * ((T₂ ⊗ₖ T₁)ᴴ)))).re ≥
           (Matrix.trace (((S₂ ⊗ₖ S₁) * τ * ((S₂ ⊗ₖ S₁)ᴴ)))).re := by
-  sorry
+  let Md := Matrix (Fin D) (Fin D) ℂ
+  set F : Md × Md → ℝ := fun p =>
+    (Matrix.trace (((p.2 ⊗ₖ p.1) * τ * ((p.2 ⊗ₖ p.1)ᴴ)))).re
+  with hF_def
+  have hF_cont : Continuous F := by
+    dsimp [F]; continuity
+  let Ω : Set Md := {S | S.det = (1 : ℂ)}
+  have hΩ_closed : IsClosed Ω := isClosed_det_one
+  have hΩ_nonempty : Ω.Nonempty := by
+    refine ⟨1, ?_⟩; simp [Ω]
+  have hΩprod_closed : IsClosed (Ω ×ˢ Ω) :=
+    IsClosed.prod hΩ_closed hΩ_closed
+  have hΩprod_nonempty : (Ω ×ˢ Ω).Nonempty := by
+    rcases hΩ_nonempty with ⟨S, hS⟩
+    exact ⟨(S, S), hS, hS⟩
+  obtain ⟨c, hc_pos, hc_bound⟩ := exists_pos_trace_bound _hτ_posDef
+  obtain ⟨r, hr_pos, hr_bound⟩ := det_one_lower_bound
+  obtain ⟨⟨S₀₁, S₀₂⟩, hS₀₁, hS₀₂⟩ := hΩprod_nonempty
+  set M := max (F (S₀₁, S₀₂)) 0 with hM_def
+  let K : Set (Md × Md) := {p | p ∈ Ω ×ˢ Ω ∧ F p ≤ M}
+  have hK_closed : IsClosed K := by
+    apply IsClosed.inter hΩprod_closed
+    exact isClosed_Iic.preimage hF_cont
+  set R := Real.sqrt (M / (c * r ^ 2)) with hR_def
+  have h_K_subset_ball : K ⊆ Metric.closedBall (0 : Md × Md) R := by
+    intro p hp
+    rcases hp with ⟨⟨hp₁, hp₂⟩, hpF⟩
+    rw [Metric.mem_closedBall, dist_eq_norm, sub_zero]
+    rw [Prod.norm_def]
+    apply max_le ?_ ?_
+    · have h_det₁ : p.1.det = (1 : ℂ) := hp₁
+      have h_det₂ : p.2.det = (1 : ℂ) := hp₂
+      have h_lower₂ : r ≤ ‖p.2‖ := hr_bound _ h_det₂
+      have h_coer : F p ≥ c * ‖p.1‖ ^ 2 * ‖p.2‖ ^ 2 := by
+        calc
+          F p = (Matrix.trace (((p.2 ⊗ₖ p.1) * τ * ((p.2 ⊗ₖ p.1)ᴴ)))).re := rfl
+          _ ≥ c * ‖(p.2 ⊗ₖ p.1)‖ ^ 2 := hc_bound _
+          _ = c * (‖p.1‖ * ‖p.2‖) ^ 2 := by rw [norm_kronecker]
+          _ = c * (‖p.1‖ ^ 2 * ‖p.2‖ ^ 2) := by ring
+          _ = c * ‖p.1‖ ^ 2 * ‖p.2‖ ^ 2 := by ring
+      have h_ineq : c * r ^ 2 * ‖p.1‖ ^ 2 ≤ M := by
+        calc
+          c * r ^ 2 * ‖p.1‖ ^ 2 ≤ c * ‖p.2‖ ^ 2 * ‖p.1‖ ^ 2 := by nlinarith
+          _ = c * ‖p.1‖ ^ 2 * ‖p.2‖ ^ 2 := by ring
+          _ ≤ F p := by nlinarith
+          _ ≤ M := hpF
+      have h_sq_bound : ‖p.1‖ ^ 2 ≤ M / (c * r ^ 2) := by
+        have h_denom_pos : 0 < c * r ^ 2 := by positivity
+        nlinarith
+      have h_nonneg : 0 ≤ ‖p.1‖ := norm_nonneg _
+      calc
+        ‖p.1‖ = Real.sqrt (‖p.1‖ ^ 2) := by rw [Real.sqrt_sq h_nonneg]
+        _ ≤ Real.sqrt (M / (c * r ^ 2)) := Real.sqrt_le_sqrt h_sq_bound
+        _ = R := rfl
+    · have h_det₁ : p.1.det = (1 : ℂ) := hp₁
+      have h_det₂ : p.2.det = (1 : ℂ) := hp₂
+      have h_lower₁ : r ≤ ‖p.1‖ := hr_bound _ h_det₁
+      have h_coer : F p ≥ c * ‖p.1‖ ^ 2 * ‖p.2‖ ^ 2 := by
+        calc
+          F p = (Matrix.trace (((p.2 ⊗ₖ p.1) * τ * ((p.2 ⊗ₖ p.1)ᴴ)))).re := rfl
+          _ ≥ c * ‖(p.2 ⊗ₖ p.1)‖ ^ 2 := hc_bound _
+          _ = c * (‖p.1‖ * ‖p.2‖) ^ 2 := by rw [norm_kronecker]
+          _ = c * (‖p.1‖ ^ 2 * ‖p.2‖ ^ 2) := by ring
+          _ = c * ‖p.1‖ ^ 2 * ‖p.2‖ ^ 2 := by ring
+      have h_ineq : c * r ^ 2 * ‖p.2‖ ^ 2 ≤ M := by
+        calc
+          c * r ^ 2 * ‖p.2‖ ^ 2 ≤ c * ‖p.1‖ ^ 2 * ‖p.2‖ ^ 2 := by nlinarith
+          _ ≤ F p := by nlinarith
+          _ ≤ M := hpF
+      have h_sq_bound : ‖p.2‖ ^ 2 ≤ M / (c * r ^ 2) := by
+        have h_denom_pos : 0 < c * r ^ 2 := by positivity
+        nlinarith
+      have h_nonneg : 0 ≤ ‖p.2‖ := norm_nonneg _
+      calc
+        ‖p.2‖ = Real.sqrt (‖p.2‖ ^ 2) := by rw [Real.sqrt_sq h_nonneg]
+        _ ≤ Real.sqrt (M / (c * r ^ 2)) := Real.sqrt_le_sqrt h_sq_bound
+        _ = R := rfl
+  have h_proper : ProperSpace (Md × Md) := FiniteDimensional.proper_rclike ℂ (Md × Md)
+  have h_ball_compact : IsCompact (Metric.closedBall (0 : Md × Md) R) :=
+    isCompact_closedBall _ _
+  have hK_compact : IsCompact K :=
+    IsCompact.of_isClosed_subset h_ball_compact hK_closed h_K_subset_ball
+  have hK_nonempty : K.Nonempty := by
+    refine ⟨(S₀₁, S₀₂), ⟨hS₀₁, hS₀₂⟩, ?_⟩
+    rw [hM_def]
+    exact le_max_left _ _
+  have hF_contOn_K : ContinuousOn F K := hF_cont.continuousOn
+  obtain ⟨p₀, hp₀, hmin⟩ := hK_compact.exists_isMinOn hK_nonempty hF_contOn_K
+  rcases p₀ with ⟨S₁, S₂⟩
+  rcases hp₀ with ⟨⟨hS₁, hS₂⟩, hF_le⟩
+  refine ⟨S₁, S₂, hS₁, hS₂, fun T₁ T₂ hT₁ hT₂ => ?_⟩
+  by_cases hF_le_M : F (T₁, T₂) ≤ M
+  · have h_mem : (T₁, T₂) ∈ K := ⟨⟨hT₁, hT₂⟩, hF_le_M⟩
+    have hle := hmin h_mem
+    simpa [hF_def] using hle
+  · nlinarith
 
 /-- **Wolf Proposition 2.9: generic normal form for CP maps with full Kraus rank.**
 

--- a/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean
@@ -293,4 +293,88 @@ lemma afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
       hPrimA hPrimB hIrrA hIrrB hDimA hDimB
   exact hBNTCover.toCommonPrimitivePhaseCoverHypotheses
 
+/-! ### Unconditional (no blocked-word relabeling) variants
+
+The lemmas below use `unconditional_commonPrimitiveIrreducibleBlocks` in place of
+`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`, removing the
+`CommonSectorRelabelingHypothesis d` requirement.  All remaining hypotheses (zero-tail equality,
+injectivity, finite-length span equality, BNT-cover data) remain explicitly conditional.
+See `CommonPrimitiveProportionalData` for the paper-source references for each missing input. -/
+
+/-- **Sector comparison from unconditional common primitive blocks and span hypotheses.**
+
+The unconditional structural theorem supplies the common primitive nonzero-sector families
+without any blocked-word relabeling hypothesis. If the remaining `CommonPrimitiveSpanHypotheses`
+are supplied for those families, the sector-weight comparison conclusion holds. -/
+lemma unconditional_afterBlocking_sectorComparison_zeroTail_spanHypotheses
+    {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hSame : SameMPV₂ A B)
+    (hRemaining : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
+      {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+      {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+      {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+      {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)},
+      0 < p →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₁) A p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ) →
+      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
+        mpv (blockTensor (d := d) (D := D₂) B p) σ =
+          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) →
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) →
+      (∀ σ : Fin 0 → Fin (blockPhysDim d p),
+        (zeroTailA : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) σ =
+          (zeroTailB : ℂ) +
+            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) σ) →
+      (∀ x, μA x ≠ 0) →
+      (∀ x, μB x ≠ 0) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) →
+      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) →
+      (∀ x, _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) →
+      (∀ x, IsIrreducibleTensor (blocksA x)) →
+      (∀ x, IsIrreducibleTensor (blocksB x)) →
+      (∀ x, 0 < dimA x) →
+      (∀ x, 0 < dimB x) →
+      CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB) :
+    ∃ p' : ℕ, 0 < p' ∧
+    ∃ P Q : SectorDecomposition (blockPhysDim d p'),
+      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p') P.toTensor ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p') Q.toTensor ∧
+      SameMPV₂ P.toTensor Q.toTensor ∧
+      HasBNTSectorData P ∧ HasBNTSectorData Q ∧
+      ∃ perm : Fin P.basisCount ≃ Fin Q.basisCount,
+      ∃ hCopies : ∀ j, P.copies j = Q.copies (perm j),
+      ∃ ζ : Fin P.basisCount → ℂ,
+        (∀ j, ζ j ≠ 0) ∧
+        ∀ j : Fin P.basisCount,
+          Finset.univ.val.map (P.weight j) =
+            Finset.univ.val.map
+              (fun q => ζ j * Q.weight (perm j) (Fin.cast (hCopies j) q)) := by
+  obtain ⟨p, hp, zeroTailA, zeroTailB, rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB, hAblocks, hBblocks, hAPos, hBPos, hNonzeroPos,
+      hZero, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
+    unconditional_commonPrimitiveIrreducibleBlocks A B hSame
+  have hHyp : CommonPrimitiveSpanHypotheses zeroTailA zeroTailB blocksA blocksB :=
+    hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
+      hPrimA hPrimB hIrrA hIrrB hDimA hDimB
+  letI : ∀ x : Fin rA, NeZero (dimA x) := fun x => ⟨Nat.ne_of_gt (hDimA x)⟩
+  letI : ∀ x : Fin rB, NeZero (dimB x) := fun x => ⟨Nat.ne_of_gt (hDimB x)⟩
+  exact afterBlocking_sectorComparison_zeroTail_of_blockSpan
+    A B hSame hp μA blocksA μB blocksB hAblocks hBblocks hHyp.zeroTail_eq hTPA hTPB
+    hIrrA hIrrB hPrimA hPrimB hHyp.left_injective hHyp.right_injective
+    hμA hμB hHyp.span_eq
+
 end MPSTensor

--- a/TNLean/Wielandt/QuantumWielandt.lean
+++ b/TNLean/Wielandt/QuantumWielandt.lean
@@ -5,16 +5,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 import TNLean.Algebra.BurnsideTheorem
 import TNLean.Algebra.IrreducibleTensorAction
-import TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan
 import TNLean.Wielandt.Primitivity.ImpliesIrreducible
 import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
 
 /-!
 # Quantum Wielandt: primitivity implies normality under `PosDef`
 
-This file collects results on the primitive-to-normal implication:
-`isNormal_of_isPrimitiveMPS_of_posDef`, together with an exact-word-span
-witness theorem that additionally requires aperiodicity.
+This file contains the primitive-to-normal implication:
+`isNormal_of_isPrimitiveMPS_of_posDef`.
 
 ## Proof route for normality
 
@@ -28,16 +26,9 @@ witness theorem that additionally requires aperiodicity.
 The `(a)→(c)` part is provided by `ImpliesStronglyIrreducible.lean`, while the
 `(c)→(b)` part is provided by `Primitivity/StronglyIrreducibleToFullRank.lean`.
 
-## Aperiodicity
-
-The main theorem `isNormal_of_isPrimitiveMPS_of_posDef` requires only
-`IsPrimitiveMPS A ρ` and `ρ.PosDef` — no aperiodicity assumption. Strong
-irreducibility already yields peripheral spectrum `{1}`.
-
-The witness theorem
-`wordSpan_eq_top_eventually_of_isPrimitiveMPS_of_posDef_of_aperiodic` takes an
-additional `hAper : 1 ∈ wordSpan A 1` to upgrade `IsNormal A` to monotone
-exact-length word spans.
+The main theorem requires only `IsPrimitiveMPS A ρ` and `ρ.PosDef` —
+no aperiodicity assumption. Strong irreducibility already yields peripheral
+spectrum `{1}`.
 
 This module is intentionally auxiliary. Downstream users who only need
 Proposition 3 / Theorem 1 statements should prefer
@@ -77,24 +68,5 @@ theorem isNormal_of_isPrimitiveMPS_of_posDef
     (hPD : ρ.PosDef) :
     IsNormal A := by
   exact isNormal_of_isPrimitiveMPS_with_posDef hPrim hPD
-
-/-- Under `IsPrimitiveMPS`, `PosDef`, and aperiodicity, exact word spans are eventually `⊤`.
-
-This is the witness form of `isNormal_of_isPrimitiveMPS_of_posDef`: once
-`IsNormal A` is known, the extra aperiodicity hypothesis makes exact word spans
-monotone, so from one full span one gets `wordSpan A n = ⊤` for all sufficiently
-large `n`. -/
-theorem wordSpan_eq_top_eventually_of_isPrimitiveMPS_of_posDef_of_aperiodic
-    {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
-    (hPrim : IsPrimitiveMPS A ρ)
-    (hPD : ρ.PosDef)
-    (hAper : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A 1) :
-    ∃ N : ℕ, ∀ n : ℕ, N ≤ n → wordSpan A n = ⊤ := by
-  obtain ⟨N, hN⟩ := isNormal_of_isPrimitiveMPS_of_posDef hPrim hPD
-  rw [← wordSpan_eq_top_iff_isNBlkInjective] at hN
-  refine ⟨N, fun n hn => ?_⟩
-  exact eq_top_iff.mpr <| by
-    simpa [hN] using wordSpan_mono'_of_one_mem_wordSpan_one A hAper hn
-
 
 end MPSTensor

--- a/audits/2026-04-29_issue944_overlap_span_from_common_live.md
+++ b/audits/2026-04-29_issue944_overlap_span_from_common_live.md
@@ -136,3 +136,39 @@ lines 271--302 and 349--352, while the injectivity/Wielandt blocking requirement
 is the passage in lines 317--332.  In the review article, the corresponding BNT
 comparison is `Papers/2011.12127/TN-Review-main.tex` lines 1846--1859,
 1864--1885, and 1891--1894.
+
+## 2026-05-07 update: unconditional primitive block variants and gap documentation
+
+The `OverlapSpanComparison.lean` module now includes a detailed doc-block enumerating
+the remaining paper-source gaps that prevent an unconditional derivation of
+`SectorBasisOverlapSpanHypotheses` from the structural data alone:
+
+1. **One-site injectivity** — not derivable from the structural theorem; requires
+   a further Wielandt-type blocking (paper lines 317--332, arXiv:1606.00608).
+
+2. **Finite-length MPV span equality** — requires the BNT comparison and
+   proportional-decomposition data (paper lines 271--302, 349--352).
+
+3. **Phase-gauge matching data** — requires normal canonical form, strict weight
+   ordering, gauge-phase separation, and proportional decomposition data
+   (packaged as `CommonPrimitiveBNTCoverHypotheses`).
+
+New unconditional (hReindexed-free) theorem variants added at the end of the file:
+
+- `sectorBasisOverlapSpanHypotheses_of_unconditionalPrimitiveBlocks`
+- `sectorBasisOverlapSpanHypotheses_of_unconditionalPrimitiveBlocks_commonPhaseCover`
+- `sectorBasisOverlapSpanHypotheses_of_unconditionalPrimitiveBlocks_bntCover`
+- `sectorBasisOverlapSpanHypotheses_of_unconditionalPrimitiveBlocks_commonPrimitiveBNTData`
+- `sectorBasisOverlapSpanHypotheses_of_unconditionalPrimitiveBlocks_proportional`
+
+These theorems use `unconditional_commonPrimitiveIrreducibleBlocks` (which needs no
+`CommonSectorRelabelingHypothesis`) instead of
+`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`.
+All remaining hypotheses (injectivity, span equality, BNT comparison) remain
+explicitly conditional — consistent with the paper gap analysis.
+
+The gap is genuine and not an artifact of the formalization: injectivity requires
+a separate Wielandt blocking step beyond period removal, and span equality requires
+the BNT comparison theorem with normal canonical-form and proportional-decomposition
+data. These are both substantive paper-level arguments that have not yet been
+formalized in the project.


### PR DESCRIPTION
### Motivation
- Required to complete the Lorentz normal form existence proofs
  (`Wolf.exists_normal_form_generic` and `Wolf.exists_lorentz_normal_form_qubit`),
  which are blocked by the compactness/minimisation argument from Wolf §2.3 Prop 2.8.
- Cleanup of dead code in Wielandt and documentation of remaining overlap-span gaps.

### Description
- `TNLean/Channel/LorentzNormalForm.lean`: proved `Wolf.infimum_is_attained` — the
  infimum of `tr[(S₂ ⊗ S₁) τ (S₂ ⊗ S₁)†]` over `S₁, S₂ ∈ SL(D, ℂ)` with
  positive-definite τ is attained. Added auxiliary lemmas `isClosed_det_one`,
  `det_one_lower_bound`, `norm_kronecker`, `trace_form_pos`, `exists_pos_trace_bound`,
  and `continuous_obj`.
- `TNLean/Wielandt/QuantumWielandt.lean`: removed dead declaration
  `wordSpan_eq_top_eventually_of_isPrimitiveMPS_of_posDef_of_aperiodic` and
  the now-unused import of `CumulativeToWordSpan`.
- `TNLean/MPS/CanonicalForm/Assembly/ProportionalComparison.lean`: added
  unconditional sector comparison lemma.
- `audits/2026-04-29_issue944_overlap_span_from_common_live.md`: updated audit
  for post-refactor gap documentation.

### Testing
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Closes LionSR/QICLean#143