### PR TITLE
doc(FT): correct chain and pi-algebra source prose

### DIFF
--- a/TNLean/MPS/Chain/FundamentalTheorem.lean
+++ b/TNLean/MPS/Chain/FundamentalTheorem.lean
@@ -24,11 +24,13 @@ namespace MPSChainTensor
 
 variable {d D n : ℕ}
 
-/-- **Fundamental Theorem for injective MPS chains** (Theorem 1 of arXiv:1804.04964).
+/-- **Combined-tensor form of the injective chain Fundamental Theorem**
+(Theorem 1 of arXiv:1804.04964).
 
 If `A` and `B` are `n`-site chains with `A` injective and
 `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`, then `A` and `B`
-are cyclically gauge equivalent.  The proof produces a *uniform* gauge
+are cyclically gauge equivalent. The hypothesis is stated for the combined
+tensors, whose physical index is the pair `(k, i)`. The proof produces a uniform gauge
 (the same `X ∈ GL(D, ℂ)` at every bond), which is a special case of cyclic
 gauge equivalence. -/
 theorem fundamentalTheorem_injective_chain

--- a/TNLean/MPS/Chain/FundamentalTheorem.lean
+++ b/TNLean/MPS/Chain/FundamentalTheorem.lean
@@ -9,7 +9,7 @@ Two injective MPS chains `A` and `B` whose combined tensors
 family are related by cyclic gauge transformations on the virtual bonds.
 
 The hypothesis `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)` is
-trace agreement for all mixed-site words of all lengths.  The paper bridges
+trace agreement for all mixed-site words of all lengths. The paper bridges
 the gap from fixed-length `SameState` to this hypothesis via a blocking
 argument for `n ≥ 3`; this bridging step is not formalized here.
 
@@ -30,9 +30,10 @@ variable {d D n : ℕ}
 If `A` and `B` are `n`-site chains with `A` injective and
 `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`, then `A` and `B`
 are cyclically gauge equivalent. The hypothesis is stated for the combined
-tensors, whose physical index is the pair `(k, i)`. The proof produces a uniform gauge
-(the same `X ∈ GL(D, ℂ)` at every bond), which is a special case of cyclic
-gauge equivalence. -/
+tensors, whose physical index in `Fin (n * d)` is identified with a pair
+`(k, i)` by `finProdFinEquiv`. The proof produces a uniform gauge (the same
+`X ∈ GL(D, ℂ)` at every bond), which is a special case of cyclic gauge
+equivalence. -/
 theorem fundamentalTheorem_injective_chain
     (A B : MPSChainTensor d D n)
     (hA : IsInjective A)

--- a/TNLean/MPS/Chain/GaugePhase.lean
+++ b/TNLean/MPS/Chain/GaugePhase.lean
@@ -3,9 +3,10 @@ import TNLean.MPS.Chain.FundamentalTheorem
 /-!
 # Gauge-phase variant of the injective-chain Fundamental Theorem
 
-Let $\widetilde A$ and $\widetilde B$ denote the tensors obtained by contracting
-the chains $A$ and $B$ around the period.  If they are gauge-phase equivalent,
-i.e. there exist $X \in GL(D,\C)$ and $\zeta \ne 0$ with
+Let $\widetilde A$ and $\widetilde B$ denote the combined tensors
+$\widetilde A^{(k,i)}=A_k^i$ and $\widetilde B^{(k,i)}=B_k^i$, obtained by
+using the pair of indices $(k,i)$ as one physical index. If they are
+gauge-phase equivalent, i.e. there exist $X \in GL(D,\C)$ and $\zeta \ne 0$ with
 $$
   \widetilde B^j = \zeta\, X\,\widetilde A^j\,X^{-1},
 $$

--- a/TNLean/MPS/Chain/GaugePhase.lean
+++ b/TNLean/MPS/Chain/GaugePhase.lean
@@ -10,8 +10,8 @@ gauge-phase equivalent, i.e. there exist $X \in GL(D,\C)$ and $\zeta \ne 0$ with
 $$
   \widetilde B^j = \zeta\, X\,\widetilde A^j\,X^{-1},
 $$
-then the chains themselves are cyclically gauge equivalent with a common
-nonzero phase $\zeta$ multiplying every site tensor:
+then the chains themselves are cyclically gauge equivalent with the same
+nonzero scalar $\zeta$ multiplying every site tensor:
 $$
   B_k^i = \zeta\, Z_k\, A_k^i\, Z_{k+1}^{-1}.
 $$
@@ -44,7 +44,7 @@ open MPSTensor
 
 variable {d D n : ℕ}
 
-/-- **Injective-chain Fundamental Theorem up to gauge phase.**
+/-- **Injective-chain Fundamental Theorem up to a nonzero scalar.**
 
 If `GaugePhaseEquiv (chainCombinedTensor A) (chainCombinedTensor B)` and
 `A` is injective, there exist `Z_k ∈ GL(D, ℂ)` and `ζ ≠ 0` such that

--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -410,9 +410,9 @@ Under strict weight ordering, injectivity, left-canonical normalization, and
 The proof follows Pérez-García et al. (2007, Appendix E) and
 Cirac et al. (2021, Theorem IV.3): take mixed overlaps with the leading block,
 divide by the leading weight, and use `peeling_exponential_bound` with
-`‖μ k / μ 0‖ < 1`. The nonzero limiting overlap rules out unequal bond dimensions;
-in equal dimension, overlap decay forces gauge-phase equivalence of the leading
-blocks, and induction removes that block.
+`‖μ k / μ 0‖ < 1`. The leading blocks already share the bond dimension `dim 0`;
+the nonzero limiting overlap gives `GaugePhaseEquiv`, i.e. conjugacy up to a
+nonzero scalar, and induction removes that block.
 -/
 lemma block_separation_core
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -410,7 +410,7 @@ Under strict weight ordering, injectivity, left-canonical normalization, and
 The proof follows Pérez-García et al. (2007, Appendix E) and
 Cirac et al. (2021, Theorem IV.3): take mixed overlaps with the leading block,
 divide by the leading weight, and use `peeling_exponential_bound` with
-`‖μ k / μ 0‖ < 1`. The leading blocks already share the bond dimension `dim 0`;
+`‖μ k / μ 0‖ < 1`. The leading blocks already have the same bond dimension;
 the nonzero limiting overlap gives `GaugePhaseEquiv`, i.e. conjugacy up to a
 nonzero scalar, and induction removes that block.
 -/

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -784,7 +784,7 @@ private lemma eq_one_of_tendsto_pow_atTop_nhds_one (z : ℂ)
   simpa [eq_comm] using huniq
 
 /-- For injective left-canonical tensors of the same bond dimension, a mixed overlap
-converging to `1` forces gauge-phase equivalence.
+converging to `1` forces `GaugePhaseEquiv`, i.e. conjugacy up to a nonzero scalar.
 
 In the block-separation proof, the equal-dimension hypothesis is encoded by the
 shared type parameter `D`; any bond-dimension mismatch is excluded one step earlier
@@ -805,8 +805,8 @@ lemma gaugePhaseEquiv_of_mpvOverlap_tendsto_one
 Again the two tensors already share the bond dimension `D`; in the block-separation
 proof the dimension-mismatch case is ruled out separately by
 `mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP`, and the nondecaying
-equal-dimension overlap is then identified via the modulus-one-eigenvalue
-rigidity theorem for irreducible tensors. -/
+equal-dimension overlap gives `GaugePhaseEquiv`, i.e. conjugacy up to a nonzero
+scalar, via the modulus-one-eigenvalue rigidity theorem for irreducible tensors. -/
 lemma gaugePhaseEquiv_of_mpvOverlap_tendsto_one_of_irreducible_TP
     {D : ℕ} [NeZero D] (A B : MPSTensor d D)
     (hA_irr : IsIrreducibleTensor A) (hB_irr : IsIrreducibleTensor B)


### PR DESCRIPTION
### Summary
- replace the misleading period-contraction description in `GaugePhase.lean`
- state the actual combined tensor formula `\widetilde A^{(k,i)} = A_k^i`
- use “nonzero scalar” for `ζ ≠ 0` rather than “phase” where no unit-modulus condition is present
- clarify that the chain FT theorem is the combined-tensor formulation and align PiAlgebra block-separation prose with the shared-dimension statements

### Validation
- `lake env lean TNLean/MPS/Chain/GaugePhase.lean`
- `lake env lean TNLean/MPS/Chain/FundamentalTheorem.lean`
- `lake build TNLean.MPS.Core.RepeatedWord`
- `lake env lean TNLean/PiAlgebra/CanonicalFormSepAux.lean`
- `lake env lean TNLean/PiAlgebra/CanonicalFormSep.lean`
- `git diff --check`

Refs #1417.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that clarify theorem statements and terminology; no proof logic or APIs are changed, so risk is low aside from potential reviewer confusion if wording mismatches existing definitions.
> 
> **Overview**
> Clarifies the injective-chain Fundamental Theorem docs to explicitly state the **combined-tensor** formulation (including the `Fin (n * d)` physical index identification via `finProdFinEquiv`) and fixes minor prose/formatting.
> 
> Updates `GaugePhase.lean` and Pi-algebra block-separation comments to describe combined tensors as `\widetilde A^{(k,i)} = A_k^i` and to consistently refer to `ζ ≠ 0` as a **nonzero scalar** (not a unit-modulus “phase”), aligning the narrative with `GaugePhaseEquiv` semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac93ce762f21bb500311d78e9b94f5baeab752a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->