### PR TITLE
feat(docs): display proof-gap note PDFs on GitHub Pages

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py
 
+      - name: Build paper-gap PDFs
+        run: bash scripts/build-paper-gaps.sh
+
       - name: Build blueprint
         working-directory: blueprint
         run: |

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -5,7 +5,7 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
-\input{docs/paper-gaps/command}
+\input{command}
 
 \title{Theorem Surface Audit for Canonical Form, BNT, and the Non-periodic MPS Fundamental Theorem}
 \author{}
@@ -349,6 +349,6 @@ should be a lemma or a clearly conditional theorem, not a headline replacement
 for the paper theorem.
 
 \bibliographystyle{alpha}
-\bibliography{docs/paper-gaps/references}
+\bibliography{references}
 
 \end{document}

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -5,7 +5,7 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
-\input{docs/paper-gaps/command}
+\input{command}
 
 \title{The Direct-Sum Input from the Older MPS Representation Paper}
 \author{}
@@ -195,6 +195,6 @@ hypothesis has been supplied, but they are not substitutes for the
 David/Perez-Garcia exact-length direct-sum input.
 
 \bibliographystyle{alpha}
-\bibliography{docs/paper-gaps/references}
+\bibliography{references}
 
 \end{document}

--- a/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
@@ -5,7 +5,7 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
-\input{docs/paper-gaps/command}
+\input{command}
 
 \title{Paper Comparison for BNT Inputs in the Non-periodic MPS Fundamental Theorem}
 \author{}
@@ -585,6 +585,6 @@ until the corresponding assertion has been proved or the final theorem is
 deliberately restated with that hypothesis.
 
 \bibliographystyle{alpha}
-\bibliography{docs/paper-gaps/references}
+\bibliography{references}
 
 \end{document}

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -5,7 +5,7 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
-\input{docs/paper-gaps/command}
+\input{command}
 
 \title{Documenting Possible Gaps, Counterexamples, and Formalization Deviations}
 \author{}

--- a/docs/paper-gaps/template.tex
+++ b/docs/paper-gaps/template.tex
@@ -4,7 +4,7 @@
 \usepackage{xurl}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
 
-\input{docs/paper-gaps/command}
+\input{command}
 
 \title{Model Note: Comparing a Cited Argument with a Formal Statement}
 \author{}
@@ -93,6 +93,6 @@ such a derivation or a different proof of \(C\), the original implication
 \(\mathcal H\Rightarrow C\) remains unjustified.
 
 \bibliographystyle{alpha}
-\bibliography{docs/paper-gaps/references}
+\bibliography{references}
 
 \end{document}

--- a/scripts/build-paper-gaps.sh
+++ b/scripts/build-paper-gaps.sh
@@ -16,7 +16,6 @@ for texfile in *.tex; do
     continue
   fi
 
-  base="${texfile%.tex}"
   echo "::group::Building $texfile"
 
   # Run latexmk non-interactively with pdf output.  Halt on error so the CI
@@ -29,4 +28,7 @@ for texfile in *.tex; do
   echo "::endgroup::"
 done
 
-echo "::notice::Compiled $(ls *.pdf 2>/dev/null | wc -l) paper-gap PDFs"
+shopt -s nullglob
+pdfs=(*.pdf)
+echo "::notice::Compiled ${#pdfs[@]} paper-gap PDFs"
+shopt -u nullglob

--- a/scripts/build-paper-gaps.sh
+++ b/scripts/build-paper-gaps.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Compile all proof-gap notes in docs/paper-gaps/ to PDF.
+# Usage: ./scripts/build-paper-gaps.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GAPS_DIR="$REPO_ROOT/docs/paper-gaps"
+
+# Switch to the paper-gaps directory so \input{command} and \bibliography{references}
+# resolve relative to docs/paper-gaps/.
+cd "$GAPS_DIR"
+
+for texfile in *.tex; do
+  # Skip includes and the template
+  if [ "$texfile" = "command.tex" ] || [ "$texfile" = "template.tex" ]; then
+    continue
+  fi
+
+  base="${texfile%.tex}"
+  echo "::group::Building $texfile"
+
+  # Run latexmk non-interactively with pdf output.  Halt on error so the CI
+  # catches bad runs, but allow warnings.
+  latexmk -pdf -interaction=nonstopmode -halt-on-error "$texfile"
+
+  # Clean auxiliary files
+  latexmk -c "$texfile"
+
+  echo "::endgroup::"
+done
+
+echo "::notice::Compiled $(ls *.pdf 2>/dev/null | wc -l) paper-gap PDFs"

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -67,6 +67,25 @@ if [ ${#GAP_PDFS[@]} -gt 0 ]; then
   rm -rf "$WORK_DIR/site/paper-gaps"
   mkdir -p "$WORK_DIR/site/paper-gaps"
   cp "${GAP_PDFS[@]}" "$WORK_DIR/site/paper-gaps/"
+  {
+    echo "<!doctype html>"
+    echo "<html lang=\"en\">"
+    echo "<head>"
+    echo "  <meta charset=\"utf-8\">"
+    echo "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+    echo "  <title>TNLean paper-gap notes</title>"
+    echo "</head>"
+    echo "<body>"
+    echo "  <h1>TNLean paper-gap notes</h1>"
+    echo "  <ul>"
+    for pdf in "${GAP_PDFS[@]}"; do
+      name="$(basename "$pdf")"
+      echo "    <li><a href=\"$name\">$name</a></li>"
+    done
+    echo "  </ul>"
+    echo "</body>"
+    echo "</html>"
+  } > "$WORK_DIR/site/paper-gaps/index.html"
   echo "Copied ${#GAP_PDFS[@]} paper-gap PDFs"
 else
   echo "No paper-gap PDFs found; keeping existing site content"

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -59,6 +59,20 @@ if [ "$WITH_DOCS" = true ]; then
   cp -r "$REPO_ROOT/docbuild/.lake/build/doc" "$WORK_DIR/site/docs"
 fi
 
+# Update paper-gap PDFs (only if built)
+echo "==> Updating paper-gap PDFs..."
+shopt -s nullglob
+GAP_PDFS=("$REPO_ROOT"/docs/paper-gaps/*.pdf)
+if [ ${#GAP_PDFS[@]} -gt 0 ]; then
+  rm -rf "$WORK_DIR/site/paper-gaps"
+  mkdir -p "$WORK_DIR/site/paper-gaps"
+  cp "${GAP_PDFS[@]}" "$WORK_DIR/site/paper-gaps/"
+  echo "Copied ${#GAP_PDFS[@]} paper-gap PDFs"
+else
+  echo "No paper-gap PDFs found; keeping existing site content"
+fi
+shopt -u nullglob
+
 # Commit and push
 echo "==> Committing and pushing..."
 cd "$WORK_DIR/site"


### PR DESCRIPTION
### Motivation
- The proof-gap notes in `docs/paper-gaps/` document mathematical gaps between the blueprint and the formalization, but were only available as LaTeX source.
- Making compiled PDFs accessible on the GitHub Pages site allows readers to browse the gap notes without needing a LaTeX toolchain.

### Description
- **Standardized LaTeX paths**: All `docs/paper-gaps/*.tex` files now use consistent `\input{command}` and `\bibliography{references}` paths relative to the `docs/paper-gaps/` directory.
- **Build script**: New `scripts/build-paper-gaps.sh` compiles all proof-gap notes to PDF using `latexmk` (skips `command.tex` and `template.tex`).
- **CI integration**: Added paper-gap PDF build step to `.github/workflows/docgen.yml`, which runs weekly and on manual trigger.
- **Deploy**: Updated `scripts/deploy-to-gh-pages.sh` to copy compiled PDFs to `paper-gaps/` on the gh-pages deployment. When PDFs are not built, existing site content is preserved.

### Testing
- Validated by the `docgen.yml` workflow (weekly and manual trigger), which runs the PDF build and deployment.

---
Closes #1468

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the docs CI and `gh-pages` deployment flow to build and publish additional artifacts, which could break the documentation pipeline or overwrite site content if paths/scripts misbehave.
> 
> **Overview**
> Adds CI support to compile `docs/paper-gaps/*.tex` into PDFs during the `docgen.yml` documentation workflow via a new `scripts/build-paper-gaps.sh` (runs `latexmk` per note).
> 
> Standardizes paper-gap LaTeX sources to use local-relative `\input{command}` and `\bibliography{references}` so they build from within `docs/paper-gaps/`.
> 
> Extends `scripts/deploy-to-gh-pages.sh` to (when PDFs exist) copy them to `site/paper-gaps/` and generate a simple `index.html` listing, while preserving existing site content when PDFs are not present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ebe22b3a92c7c02f32fe15a14cecf9240e60998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->