### PR TITLE
feat(Algebra): prove bounded power-sum multiset equality

### DIFF
--- a/TNLean/Algebra/NewtonGirard.lean
+++ b/TNLean/Algebra/NewtonGirard.lean
@@ -358,6 +358,21 @@ theorem charpolyRev_eq_of_trace_pow_eq_of_le_card
       exact coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt hdeg (by omega))
     rw [hA, hB]
 
+omit [IsDomain R] in
+private lemma charpoly_eq_of_charpolyRev_eq
+    (A B : Matrix n n R)
+    (hrev : A.charpolyRev = B.charpolyRev) :
+    A.charpoly = B.charpoly := by
+  have hrA := reverse_charpoly A
+  have hrB := reverse_charpoly B
+  have h_rev_eq : A.charpoly.reverse = B.charpoly.reverse := by
+    rw [hrA, hrB, hrev]
+  have hdA := charpoly_natDegree_eq_dim A
+  have hdB := charpoly_natDegree_eq_dim B
+  rw [Polynomial.reverse, Polynomial.reverse, hdA, hdB] at h_rev_eq
+  have := congr_arg (Polynomial.reflect (Fintype.card n)) h_rev_eq
+  rwa [Polynomial.reflect_reflect, Polynomial.reflect_reflect] at this
+
 /-- **Main result**: If `tr(A^k) = tr(B^k)` for all `k ≥ 1`, then
 `A.charpoly = B.charpoly`.
 
@@ -368,23 +383,9 @@ theorem charpoly_eq_of_forall_trace_pow_eq
     (A B : Matrix n n R)
     (h : ∀ k : ℕ, 0 < k → trace (A ^ k) = trace (B ^ k)) :
     A.charpoly = B.charpoly := by
-  -- charpolyRev equality
   have hrev : A.charpolyRev = B.charpolyRev :=
     charpolyRev_eq_of_forall_trace_pow_eq A B h
-  -- A.charpoly.reverse = A.charpolyRev (and same for B)
-  have hrA := reverse_charpoly A  -- A.charpoly.reverse = A.charpolyRev
-  have hrB := reverse_charpoly B
-  -- So A.charpoly.reverse = B.charpoly.reverse
-  have h_rev_eq : A.charpoly.reverse = B.charpoly.reverse := by
-    rw [hrA, hrB, hrev]
-  -- reverse = reflect natDegree, and both charpolys have natDegree = card n
-  have hdA := charpoly_natDegree_eq_dim A
-  have hdB := charpoly_natDegree_eq_dim B
-  -- Unfold reverse and use that reflect N is involutive
-  rw [Polynomial.reverse, Polynomial.reverse, hdA, hdB] at h_rev_eq
-  -- reflect_reflect : reflect N (reflect N p) = p
-  have := congr_arg (Polynomial.reflect (Fintype.card n)) h_rev_eq
-  rwa [Polynomial.reflect_reflect, Polynomial.reflect_reflect] at this
+  exact charpoly_eq_of_charpolyRev_eq A B hrev
 
 /-- If `tr(A^k) = tr(B^k)` for `1 ≤ k ≤ card n`, then `A.charpoly = B.charpoly`. -/
 theorem charpoly_eq_of_trace_pow_eq_of_le_card
@@ -393,15 +394,7 @@ theorem charpoly_eq_of_trace_pow_eq_of_le_card
     A.charpoly = B.charpoly := by
   have hrev : A.charpolyRev = B.charpolyRev :=
     charpolyRev_eq_of_trace_pow_eq_of_le_card A B h
-  have hrA := reverse_charpoly A
-  have hrB := reverse_charpoly B
-  have h_rev_eq : A.charpoly.reverse = B.charpoly.reverse := by
-    rw [hrA, hrB, hrev]
-  have hdA := charpoly_natDegree_eq_dim A
-  have hdB := charpoly_natDegree_eq_dim B
-  rw [Polynomial.reverse, Polynomial.reverse, hdA, hdB] at h_rev_eq
-  have := congr_arg (Polynomial.reflect (Fintype.card n)) h_rev_eq
-  rwa [Polynomial.reflect_reflect, Polynomial.reflect_reflect] at this
+  exact charpoly_eq_of_charpolyRev_eq A B hrev
 
 end CharZeroDomain
 

--- a/TNLean/Algebra/NewtonGirard.lean
+++ b/TNLean/Algebra/NewtonGirard.lean
@@ -44,8 +44,8 @@ Specifically, Jacobi's formula gives `P'(X) = -tr(adj(1 - X·M) * M.map C)`,
 and expanding the adjugate in powers of X and comparing coefficients yields the
 recursion.
 
-The downstream results (charpolyRev equality and charpoly equality) follow from
-the recursion by strong induction on the coefficient index, using the fact that
+The characteristic-polynomial equalities follow from the recursion by strong
+induction on the coefficient index, using the fact that
 `(m+1 : R) ≠ 0` in characteristic zero rings for cancellation.
 -/
 
@@ -390,8 +390,8 @@ theorem charpoly_eq_of_trace_pow_eq_of_le_card
 /-- **Main result**: If `tr(A^k) = tr(B^k)` for all `k ≥ 1`, then
 `A.charpoly = B.charpoly`.
 
-This is the finite-range theorem with the all-positive-power hypothesis restricted to
-`1 ≤ k ≤ card n`. -/
+This is an immediate corollary of `charpoly_eq_of_trace_pow_eq_of_le_card`,
+obtained by restricting the all-positive-power hypothesis to `1 ≤ k ≤ card n`. -/
 theorem charpoly_eq_of_forall_trace_pow_eq
     (A B : Matrix n n R)
     (h : ∀ k : ℕ, 0 < k → trace (A ^ k) = trace (B ^ k)) :

--- a/TNLean/Algebra/NewtonGirard.lean
+++ b/TNLean/Algebra/NewtonGirard.lean
@@ -30,6 +30,9 @@ characteristic polynomials.
 * `Matrix.charpolyRev_eq_of_trace_pow_eq_of_le_card`: If `tr(A^k) = tr(B^k)`
   for `1 ≤ k ≤ card n`, then `A.charpolyRev = B.charpolyRev`.
 
+* `Matrix.charpoly_eq_of_trace_pow_eq_of_le_card`: If `tr(A^k) = tr(B^k)`
+  for `1 ≤ k ≤ card n`, then `A.charpoly = B.charpoly`.
+
 * `Matrix.charpoly_eq_of_forall_trace_pow_eq`: If `tr(A^k) = tr(B^k)` for all
   `k ≥ 1`, then `A.charpoly = B.charpoly`.
 
@@ -372,20 +375,6 @@ private lemma charpoly_eq_of_charpolyRev_eq
   have := congr_arg (Polynomial.reflect (Fintype.card n)) h_rev_eq
   rwa [Polynomial.reflect_reflect, Polynomial.reflect_reflect] at this
 
-/-- **Main result**: If `tr(A^k) = tr(B^k)` for all `k ≥ 1`, then
-`A.charpoly = B.charpoly`.
-
-Follows from `charpolyRev_eq_of_forall_trace_pow_eq` using the fact that
-`charpoly` and `charpolyRev` determine each other via polynomial reversal.
--/
-theorem charpoly_eq_of_forall_trace_pow_eq
-    (A B : Matrix n n R)
-    (h : ∀ k : ℕ, 0 < k → trace (A ^ k) = trace (B ^ k)) :
-    A.charpoly = B.charpoly := by
-  have hrev : A.charpolyRev = B.charpolyRev :=
-    charpolyRev_eq_of_forall_trace_pow_eq A B h
-  exact charpoly_eq_of_charpolyRev_eq A B hrev
-
 /-- If `tr(A^k) = tr(B^k)` for `1 ≤ k ≤ card n`, then `A.charpoly = B.charpoly`. -/
 theorem charpoly_eq_of_trace_pow_eq_of_le_card
     (A B : Matrix n n R)
@@ -394,6 +383,17 @@ theorem charpoly_eq_of_trace_pow_eq_of_le_card
   have hrev : A.charpolyRev = B.charpolyRev :=
     charpolyRev_eq_of_trace_pow_eq_of_le_card A B h
   exact charpoly_eq_of_charpolyRev_eq A B hrev
+
+/-- **Main result**: If `tr(A^k) = tr(B^k)` for all `k ≥ 1`, then
+`A.charpoly = B.charpoly`.
+
+This is the finite-range theorem with the all-positive-power hypothesis restricted to
+`1 ≤ k ≤ card n`. -/
+theorem charpoly_eq_of_forall_trace_pow_eq
+    (A B : Matrix n n R)
+    (h : ∀ k : ℕ, 0 < k → trace (A ^ k) = trace (B ^ k)) :
+    A.charpoly = B.charpoly :=
+  charpoly_eq_of_trace_pow_eq_of_le_card A B (fun k hk _ => h k hk)
 
 end CharZeroDomain
 

--- a/TNLean/Algebra/NewtonGirard.lean
+++ b/TNLean/Algebra/NewtonGirard.lean
@@ -331,7 +331,6 @@ theorem charpolyRev_eq_of_trace_pow_eq_of_le_card
       | m + 1 =>
         have hA := newton_girard_charpolyRev_coeff A m
         have hB := newton_girard_charpolyRev_coeff B m
-        have hm_succ : m + 1 ≤ Fintype.card n := hm_card
         have h_sum_eq :
             ∑ j ∈ range (m + 1), (A.charpolyRev).coeff j * trace (A ^ (m + 1 - j)) =
               ∑ j ∈ range (m + 1), (B.charpolyRev).coeff j *

--- a/TNLean/Algebra/NewtonGirard.lean
+++ b/TNLean/Algebra/NewtonGirard.lean
@@ -390,8 +390,8 @@ theorem charpoly_eq_of_trace_pow_eq_of_le_card
 /-- **Main result**: If `tr(A^k) = tr(B^k)` for all `k ≥ 1`, then
 `A.charpoly = B.charpoly`.
 
-This is an immediate corollary of `charpoly_eq_of_trace_pow_eq_of_le_card`,
-obtained by restricting the all-positive-power hypothesis to `1 ≤ k ≤ card n`. -/
+Now a corollary of `charpoly_eq_of_trace_pow_eq_of_le_card`, obtained by
+restricting the all-positive-power hypothesis to `1 ≤ k ≤ card n`. -/
 theorem charpoly_eq_of_forall_trace_pow_eq
     (A B : Matrix n n R)
     (h : ∀ k : ℕ, 0 < k → trace (A ^ k) = trace (B ^ k)) :

--- a/TNLean/Algebra/NewtonGirard.lean
+++ b/TNLean/Algebra/NewtonGirard.lean
@@ -375,7 +375,10 @@ private lemma charpoly_eq_of_charpolyRev_eq
   have := congr_arg (Polynomial.reflect (Fintype.card n)) h_rev_eq
   rwa [Polynomial.reflect_reflect, Polynomial.reflect_reflect] at this
 
-/-- If `tr(A^k) = tr(B^k)` for `1 ≤ k ≤ card n`, then `A.charpoly = B.charpoly`. -/
+/-- If `tr(A^k) = tr(B^k)` for `1 ≤ k ≤ card n`, then `A.charpoly = B.charpoly`.
+
+The all-positive-power statement below is the immediate corollary obtained by restricting its
+hypothesis to this finite range. -/
 theorem charpoly_eq_of_trace_pow_eq_of_le_card
     (A B : Matrix n n R)
     (h : ∀ k : ℕ, 0 < k → k ≤ Fintype.card n → trace (A ^ k) = trace (B ^ k)) :

--- a/TNLean/Algebra/NewtonGirard.lean
+++ b/TNLean/Algebra/NewtonGirard.lean
@@ -27,6 +27,9 @@ characteristic polynomials.
 * `Matrix.charpolyRev_eq_of_forall_trace_pow_eq`: If `tr(A^k) = tr(B^k)` for
   all `k ≥ 1`, then `A.charpolyRev = B.charpolyRev`.
 
+* `Matrix.charpolyRev_eq_of_trace_pow_eq_of_le_card`: If `tr(A^k) = tr(B^k)`
+  for `1 ≤ k ≤ card n`, then `A.charpolyRev = B.charpolyRev`.
+
 * `Matrix.charpoly_eq_of_forall_trace_pow_eq`: If `tr(A^k) = tr(B^k)` for all
   `k ≥ 1`, then `A.charpoly = B.charpoly`.
 
@@ -307,6 +310,54 @@ theorem charpolyRev_eq_of_forall_trace_pow_eq
       have hm_ne : (↑(m + 1) : R) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
       exact mul_left_cancel₀ hm_ne heq
 
+/-- `charpolyRev` coefficients are determined by the first `card n` traces of powers.
+
+For an `n × n` matrix, the Newton--Girard recursion for coefficient `m+1` only uses
+the traces `tr(M^k)` with `1 ≤ k ≤ m+1`. Coefficients above `card n` vanish for
+`charpolyRev`, so traces through degree `card n` determine the whole polynomial. -/
+theorem charpolyRev_eq_of_trace_pow_eq_of_le_card
+    (A B : Matrix n n R)
+    (h : ∀ k : ℕ, 0 < k → k ≤ Fintype.card n → trace (A ^ k) = trace (B ^ k)) :
+    A.charpolyRev = B.charpolyRev := by
+  suffices ∀ m : ℕ, A.charpolyRev.coeff m = B.charpolyRev.coeff m from
+    Polynomial.ext this
+  intro m
+  by_cases hm_card : m ≤ Fintype.card n
+  · induction m using Nat.strong_induction_on with
+    | _ m ih =>
+      match m with
+      | 0 =>
+        rw [coeff_zero_eq_eval_zero, coeff_zero_eq_eval_zero, eval_charpolyRev, eval_charpolyRev]
+      | m + 1 =>
+        have hA := newton_girard_charpolyRev_coeff A m
+        have hB := newton_girard_charpolyRev_coeff B m
+        have hm_succ : m + 1 ≤ Fintype.card n := hm_card
+        have h_sum_eq :
+            ∑ j ∈ range (m + 1), (A.charpolyRev).coeff j * trace (A ^ (m + 1 - j)) =
+              ∑ j ∈ range (m + 1), (B.charpolyRev).coeff j *
+                trace (B ^ (m + 1 - j)) := by
+          apply sum_congr rfl
+          intro j hj
+          rw [mem_range] at hj
+          rw [ih j (by omega) (by omega),
+            h (m + 1 - j) (by omega) (by omega)]
+        have heq : (↑(m + 1) : R) * A.charpolyRev.coeff (m + 1) =
+                   (↑(m + 1) : R) * B.charpolyRev.coeff (m + 1) := by
+          rw [hA, hB, h_sum_eq]
+        have hm_ne : (↑(m + 1) : R) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+        exact mul_left_cancel₀ hm_ne heq
+  · have hA : A.charpolyRev.coeff m = 0 := by
+      have hdeg : A.charpolyRev.natDegree ≤ Fintype.card n := by
+        rw [← reverse_charpoly A]
+        exact (reverse_natDegree_le A.charpoly).trans_eq (charpoly_natDegree_eq_dim A)
+      exact coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt hdeg (by omega))
+    have hB : B.charpolyRev.coeff m = 0 := by
+      have hdeg : B.charpolyRev.natDegree ≤ Fintype.card n := by
+        rw [← reverse_charpoly B]
+        exact (reverse_natDegree_le B.charpoly).trans_eq (charpoly_natDegree_eq_dim B)
+      exact coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt hdeg (by omega))
+    rw [hA, hB]
+
 /-- **Main result**: If `tr(A^k) = tr(B^k)` for all `k ≥ 1`, then
 `A.charpoly = B.charpoly`.
 
@@ -332,6 +383,23 @@ theorem charpoly_eq_of_forall_trace_pow_eq
   -- Unfold reverse and use that reflect N is involutive
   rw [Polynomial.reverse, Polynomial.reverse, hdA, hdB] at h_rev_eq
   -- reflect_reflect : reflect N (reflect N p) = p
+  have := congr_arg (Polynomial.reflect (Fintype.card n)) h_rev_eq
+  rwa [Polynomial.reflect_reflect, Polynomial.reflect_reflect] at this
+
+/-- If `tr(A^k) = tr(B^k)` for `1 ≤ k ≤ card n`, then `A.charpoly = B.charpoly`. -/
+theorem charpoly_eq_of_trace_pow_eq_of_le_card
+    (A B : Matrix n n R)
+    (h : ∀ k : ℕ, 0 < k → k ≤ Fintype.card n → trace (A ^ k) = trace (B ^ k)) :
+    A.charpoly = B.charpoly := by
+  have hrev : A.charpolyRev = B.charpolyRev :=
+    charpolyRev_eq_of_trace_pow_eq_of_le_card A B h
+  have hrA := reverse_charpoly A
+  have hrB := reverse_charpoly B
+  have h_rev_eq : A.charpoly.reverse = B.charpoly.reverse := by
+    rw [hrA, hrB, hrev]
+  have hdA := charpoly_natDegree_eq_dim A
+  have hdB := charpoly_natDegree_eq_dim B
+  rw [Polynomial.reverse, Polynomial.reverse, hdA, hdB] at h_rev_eq
   have := congr_arg (Polynomial.reflect (Fintype.card n)) h_rev_eq
   rwa [Polynomial.reflect_reflect, Polynomial.reflect_reflect] at this
 

--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -31,7 +31,7 @@ by observing that the trace of a power of a diagonal matrix equals the correspon
 
   `trace (diagonal a ^ k) = ∑ i, a i ^ k`
 
-## Main results, in declaration order
+## Principal statements
 
 * `Matrix.trace_diagonal_pow`: `trace (diagonal a ^ k) = ∑ i, a i ^ k`.
 
@@ -151,8 +151,9 @@ theorem sum_pow_eq_implies_multiset_eq_of_le_card
 /-- Equal power sums of two families indexed by the same finite type imply that the families
 give rise to the same multiset of values.
 
-This is the finite-range theorem with the all-positive-power hypothesis restricted to
-`1 ≤ k ≤ card n`.  Note that this is a **same-cardinality** result; the paper's
+This is an immediate corollary of `sum_pow_eq_implies_multiset_eq_of_le_card`,
+obtained by restricting the all-positive-power hypothesis to `1 ≤ k ≤ card n`.
+Note that this is a **same-cardinality** result; the paper's
 `Lem:app_simple` additionally deduces cardinality equality when the sizes may differ. -/
 theorem sum_pow_eq_implies_multiset_eq
     (a b : n → ℂ)

--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -51,7 +51,11 @@ by observing that the trace of a power of a diagonal matrix equals the correspon
   positive exponent, then the multisets `Finset.univ.val.map a` and
   `Finset.univ.val.map b` are equal.
 
-## Design note: missing exact source statement
+* `Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card`: If two nonzero
+  families indexed by `Fin m` and `Fin n` have equal power sums for
+  `1 ≤ k ≤ max m n`, then `m = n` and the multisets of values are equal.
+
+## Design note: relation to the exact source statement
 
 The paper's Lemma `Lem:app_simple` (arXiv:1606.00608, lines 1155–1163) states:
 
@@ -61,22 +65,16 @@ The paper's Lemma `Lem:app_simple` (arXiv:1606.00608, lines 1155–1163) states:
     `∑_{k=1}^{x_a} λ_{a,k}^N = ∑_{k=1}^{x_b} λ_{b,k}^N`,
   then `x_a = x_b` and `λ_{a,k} = λ_{b,k}` for all k.
 
-The all-positive-power theorem in this file differs in three ways:
+The unequal-cardinality finite-range theorem below differs from the paper's list statement in
+one way:
 
-  1. **Same cardinality**: both families share the same finite type `n` (no deduction of
-     `x_a = x_b`).
-  2. **Unbounded exponent range**: equality is for *all* `k > 0`, not just `k ≤ max{x_a, x_b}`.
-  3. **No sorting hypothesis**: we work directly with multisets through the characteristic
+  1. **No sorting hypothesis**: we work directly with multisets through the characteristic
      polynomial, making lexicographic-phase sorting unnecessary — the polynomial equality
      absorbs the ordering.
 
-These relaxations suffice for the coefficient-comparison path taken in the formalized
-fundamental theorems when the two families are already known to have the same length.
-A full formalization of `Lem:app_simple` as written would require:
-  - a "sorted complex list" type with the paper's sorting convention,
-  - powers up to the larger cardinality,
-  - a nonzero-entry or exponent-zero mechanism to rule out invisible zero terms,
-  - a combinatorial counting-via-Vandermonde proof to conclude cardinality equality.
+The theorem assumes all entries are nonzero. This is the mechanism that makes padded zeros
+visible: after padding both families to `max m n`, the same-cardinality theorem gives equality
+of padded multisets, and counting zeros forces `m = n`.
 -/
 
 open scoped Matrix BigOperators
@@ -165,5 +163,99 @@ theorem sum_pow_eq_implies_multiset_eq_of_le_card
   have hroots : (∏ i : n, (X - C (a i))).roots = (∏ i : n, (X - C (b i))).roots :=
     congrArg Polynomial.roots hcp
   simpa [roots_prod_X_sub_C] using hroots
+
+private def padFin (m N : ℕ) (a : Fin m → ℂ) : Fin N → ℂ :=
+  fun i => if h : (i : ℕ) < m then a ⟨i, h⟩ else 0
+
+private theorem sum_padFin_pow {m N : ℕ} (a : Fin m → ℂ) (hmN : m ≤ N)
+    {k : ℕ} (hk : 0 < k) :
+    (∑ i : Fin N, padFin m N a i ^ k) = ∑ i : Fin m, a i ^ k := by
+  let fN : ℕ → ℂ := fun i => if h : i < N then padFin m N a ⟨i, h⟩ ^ k else 0
+  let fm : ℕ → ℂ := fun i => if h : i < m then a ⟨i, h⟩ ^ k else 0
+  have hleft :
+      (∑ i : Fin N, padFin m N a i ^ k) = ∑ i ∈ Finset.range N, fN i := by
+    simpa [fN] using Fin.sum_univ_eq_sum_range fN N
+  have hright : (∑ i : Fin m, a i ^ k) = ∑ i ∈ Finset.range m, fm i := by
+    simpa [fm] using Fin.sum_univ_eq_sum_range fm m
+  rw [hleft, hright]
+  rw [← Finset.sum_range_add_sum_Ico fN hmN]
+  have hrange : (∑ i ∈ Finset.range m, fN i) = ∑ i ∈ Finset.range m, fm i := by
+    apply Finset.sum_congr rfl
+    intro i hi
+    have him : i < m := Finset.mem_range.mp hi
+    have hiN : i < N := Nat.lt_of_lt_of_le him hmN
+    simp [fN, fm, padFin, him, hiN]
+  have hIco : (∑ i ∈ Finset.Ico m N, fN i) = 0 := by
+    apply Finset.sum_eq_zero
+    intro i hi
+    have hmi : m ≤ i := (Finset.mem_Ico.mp hi).1
+    have hiN : i < N := (Finset.mem_Ico.mp hi).2
+    simp [fN, padFin, hiN, not_lt_of_ge hmi, ne_of_gt hk]
+  rw [hrange, hIco, add_zero]
+
+private theorem count_zero_padFin {m N : ℕ} (a : Fin m → ℂ)
+    (ha : ∀ i, a i ≠ 0) :
+    (Finset.univ.val.map (padFin m N a)).count 0 = N - m := by
+  rw [Multiset.count_map]
+  rw [← Finset.filter_val]
+  have hfilter :
+      (Finset.univ.filter fun i : Fin N => 0 = padFin m N a i) =
+        (Finset.univ.filter fun i : Fin N => m ≤ (i : ℕ)) := by
+    apply Finset.ext
+    intro i
+    by_cases him : (i : ℕ) < m
+    · have hne : ¬ 0 = a ⟨i, him⟩ := (ha ⟨i, him⟩).symm
+      simp [padFin, him, hne, not_le_of_gt him]
+    · simp [padFin, him, le_of_not_gt him]
+  rw [hfilter]
+  have hfilterIco :
+      (Finset.univ.filter fun i : Fin N => m ≤ (i : ℕ)) =
+        (Finset.Ico m N).attachFin (fun x hx => (Finset.mem_Ico.mp hx).2) := by
+    apply Finset.ext
+    intro i
+    simp [Finset.mem_Ico]
+  rw [hfilterIco]
+  rw [← Finset.card_def, Finset.card_attachFin, Nat.card_Ico]
+
+/-- Unequal-cardinality finite-range scalar power-sum identity under a nonzero-entry
+hypothesis.
+
+If two finite families of nonzero complex scalars have equal power sums for
+`1 ≤ k ≤ max m n`, then the indexing cardinalities are equal and the two families give the
+same multiset of values.  The proof pads the shorter family by zeros, applies
+`sum_pow_eq_implies_multiset_eq_of_le_card`, and then counts the padded zeros. -/
+theorem sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card
+    (m n : ℕ) (a : Fin m → ℂ) (b : Fin n → ℂ)
+    (ha : ∀ i, a i ≠ 0) (hb : ∀ i, b i ≠ 0)
+    (h : ∀ k : ℕ, 0 < k → k ≤ max m n →
+      ∑ i : Fin m, a i ^ k = ∑ i : Fin n, b i ^ k) :
+    m = n ∧ Finset.univ.val.map a = Finset.univ.val.map b := by
+  let N := max m n
+  let apad : Fin N → ℂ := padFin m N a
+  let bpad : Fin N → ℂ := padFin n N b
+  have hpad : Finset.univ.val.map apad = Finset.univ.val.map bpad := by
+    apply sum_pow_eq_implies_multiset_eq_of_le_card
+    intro k hk hkcard
+    rw [show (∑ i : Fin N, apad i ^ k) = ∑ i : Fin m, a i ^ k from
+        sum_padFin_pow a (by dsimp [N]; exact le_max_left m n) hk,
+      show (∑ i : Fin N, bpad i ^ k) = ∑ i : Fin n, b i ^ k from
+        sum_padFin_pow b (by dsimp [N]; exact le_max_right m n) hk]
+    exact h k hk (by simpa [N] using hkcard)
+  have hcount : N - m = N - n := by
+    have hcount' := congrArg (Multiset.count (0 : ℂ)) hpad
+    change (Finset.univ.val.map (padFin m N a)).count 0 =
+      (Finset.univ.val.map (padFin n N b)).count 0 at hcount'
+    rw [count_zero_padFin a ha, count_zero_padFin b hb] at hcount'
+    exact hcount'
+  have hmn : m = n := by
+    have hmN : m ≤ N := by dsimp [N]; exact le_max_left m n
+    have hnN : n ≤ N := by dsimp [N]; exact le_max_right m n
+    omega
+  constructor
+  · exact hmn
+  subst n
+  apply sum_pow_eq_implies_multiset_eq_of_le_card
+  intro k hk hkcard
+  exact h k hk (by simpa using hkcard)
 
 end Matrix

--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -35,12 +35,12 @@ by observing that the trace of a power of a diagonal matrix equals the correspon
 
 * `Matrix.trace_diagonal_pow`: `trace (diagonal a ^ k) = ∑ i, a i ^ k`.
 
-* `Matrix.sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card`: If
-  `∑ i, a i ^ k = ∑ i, b i ^ k` for `1 ≤ k ≤ card n`, then
-  `(diagonal a).charpoly = (diagonal b).charpoly`.
-
 * `Matrix.sum_pow_eq_implies_charpoly_diagonal_eq`: If
   `∑ i, a i ^ k = ∑ i, b i ^ k` for all `k ≥ 1`, then
+  `(diagonal a).charpoly = (diagonal b).charpoly`.
+
+* `Matrix.sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card`: If
+  `∑ i, a i ^ k = ∑ i, b i ^ k` for `1 ≤ k ≤ card n`, then
   `(diagonal a).charpoly = (diagonal b).charpoly`.
 
 * `Matrix.sum_pow_eq_implies_multiset_eq_of_le_card`: Under the finite-range
@@ -130,24 +130,6 @@ private lemma roots_prod_X_sub_C (f : n → ℂ) :
   rw [roots_prod _ _ hne]
   simp
 
-/-- Equal power sums of two families indexed by the same finite type imply that the families
-give rise to the same multiset of values.
-
-This is a direct corollary: equal characteristic polynomials of diagonal matrices unfold (via
-`charpoly_diagonal`) to `∏ i, (X - C (a i)) = ∏ i, (X - C (b i))`, from which we extract equal
-roots.  Note that this is a **same-cardinality** result; the paper's `Lem:app_simple` additionally
-deduces cardinality equality when the sizes may differ. -/
-theorem sum_pow_eq_implies_multiset_eq
-    (a b : n → ℂ)
-    (h : ∀ k : ℕ, 0 < k → ∑ i, a i ^ k = ∑ i, b i ^ k) :
-    Finset.univ.val.map a = Finset.univ.val.map b := by
-  classical
-  have hcp := sum_pow_eq_implies_charpoly_diagonal_eq a b h
-  rw [charpoly_diagonal, charpoly_diagonal] at hcp
-  have hroots : (∏ i : n, (X - C (a i))).roots = (∏ i : n, (X - C (b i))).roots :=
-    congrArg Polynomial.roots hcp
-  simpa [roots_prod_X_sub_C] using hroots
-
 /-- Equal power sums through `card n` determine the same multiset of values for
 two families indexed by the same finite type.
 
@@ -163,6 +145,18 @@ theorem sum_pow_eq_implies_multiset_eq_of_le_card
   have hroots : (∏ i : n, (X - C (a i))).roots = (∏ i : n, (X - C (b i))).roots :=
     congrArg Polynomial.roots hcp
   simpa [roots_prod_X_sub_C] using hroots
+
+/-- Equal power sums of two families indexed by the same finite type imply that the families
+give rise to the same multiset of values.
+
+This is the finite-range theorem with the all-positive-power hypothesis restricted to
+`1 ≤ k ≤ card n`.  Note that this is a **same-cardinality** result; the paper's
+`Lem:app_simple` additionally deduces cardinality equality when the sizes may differ. -/
+theorem sum_pow_eq_implies_multiset_eq
+    (a b : n → ℂ)
+    (h : ∀ k : ℕ, 0 < k → ∑ i, a i ^ k = ∑ i, b i ^ k) :
+    Finset.univ.val.map a = Finset.univ.val.map b :=
+  sum_pow_eq_implies_multiset_eq_of_le_card a b (fun k hk _ => h k hk)
 
 private def padFin (m N : ℕ) (a : Fin m → ℂ) : Fin N → ℂ :=
   fun i => if h : (i : ℕ) < m then a ⟨i, h⟩ else 0

--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -31,7 +31,7 @@ by observing that the trace of a power of a diagonal matrix equals the correspon
 
   `trace (diagonal a ^ k) = ∑ i, a i ^ k`
 
-## Main results
+## Main results, in declaration order
 
 * `Matrix.trace_diagonal_pow`: `trace (diagonal a ^ k) = ∑ i, a i ^ k`.
 
@@ -45,7 +45,8 @@ by observing that the trace of a power of a diagonal matrix equals the correspon
 
 * `Matrix.sum_pow_eq_implies_multiset_eq_of_le_card`: Under the finite-range
   hypothesis `1 ≤ k ≤ card n`, the multisets `Finset.univ.val.map a` and
-  `Finset.univ.val.map b` are equal.
+  `Finset.univ.val.map b` are equal. The all-positive-power multiset theorem
+  is its immediate corollary.
 
 * `Matrix.sum_pow_eq_implies_multiset_eq`: If the power sums agree for every
   positive exponent, then the multisets `Finset.univ.val.map a` and
@@ -134,7 +135,8 @@ private lemma roots_prod_X_sub_C (f : n → ℂ) :
 two families indexed by the same finite type.
 
 This is the finite-range, same-cardinality part of Lemma `Lem:app_simple` in
-arXiv:1606.00608. -/
+arXiv:1606.00608. The all-positive-power theorem below is obtained by restricting
+its hypothesis to `1 ≤ k ≤ card n`. -/
 theorem sum_pow_eq_implies_multiset_eq_of_le_card
     (a b : n → ℂ)
     (h : ∀ k : ℕ, 0 < k → k ≤ Fintype.card n → ∑ i, a i ^ k = ∑ i, b i ^ k) :

--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -25,9 +25,9 @@ statement.
 
 ## Strategy
 
-We reduce to the already-proved `Matrix.charpoly_eq_of_forall_trace_pow_eq` from
-`TNLean.Algebra.NewtonGirard` by observing that the trace of a power of a diagonal matrix equals
-the corresponding power sum:
+We reduce to `Matrix.charpoly_eq_of_forall_trace_pow_eq` and
+`Matrix.charpoly_eq_of_trace_pow_eq_of_le_card` from `TNLean.Algebra.NewtonGirard`
+by observing that the trace of a power of a diagonal matrix equals the corresponding power sum:
 
   `trace (diagonal a ^ k) = ∑ i, a i ^ k`
 
@@ -47,8 +47,9 @@ the corresponding power sum:
   hypothesis `1 ≤ k ≤ card n`, the multisets `Finset.univ.val.map a` and
   `Finset.univ.val.map b` are equal.
 
-* `Matrix.sum_pow_eq_implies_multiset_eq`: Under the same hypotheses, the multisets
-  `Finset.univ.val.map a` and `Finset.univ.val.map b` are equal.
+* `Matrix.sum_pow_eq_implies_multiset_eq`: If the power sums agree for every
+  positive exponent, then the multisets `Finset.univ.val.map a` and
+  `Finset.univ.val.map b` are equal.
 
 ## Design note: missing exact source statement
 
@@ -84,11 +85,12 @@ open Polynomial
 
 namespace Matrix
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {n : Type*} [Fintype n]
 
 /-- Trace of a power of a diagonal matrix equals the power sum of the entries. -/
-theorem trace_diagonal_pow (a : n → ℂ) (k : ℕ) :
+theorem trace_diagonal_pow [DecidableEq n] (a : n → ℂ) (k : ℕ) :
     trace (diagonal a ^ k) = ∑ i, a i ^ k := by
+  classical
   simp [diagonal_pow, trace_diagonal]
 
 /-- **Scalar power-sum identity** (same-cardinality support lemma for
@@ -97,6 +99,7 @@ theorem trace_diagonal_pow (a : n → ℂ) (k : ℕ) :
 If two families of complex scalars, indexed by the same finite type, have equal power sums for all
 positive exponents, then their characteristic polynomials (as diagonal matrices) agree. -/
 theorem sum_pow_eq_implies_charpoly_diagonal_eq
+    [DecidableEq n]
     (a b : n → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i, a i ^ k = ∑ i, b i ^ k) :
     (diagonal a).charpoly = (diagonal b).charpoly := by
@@ -112,6 +115,7 @@ If two families of complex scalars, indexed by the same finite type `n`, have eq
 power sums for `1 ≤ k ≤ card n`, then their characteristic polynomials as diagonal
 matrices agree. -/
 theorem sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card
+    [DecidableEq n]
     (a b : n → ℂ)
     (h : ∀ k : ℕ, 0 < k → k ≤ Fintype.card n → ∑ i, a i ^ k = ∑ i, b i ^ k) :
     (diagonal a).charpoly = (diagonal b).charpoly := by
@@ -120,8 +124,14 @@ theorem sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card
   rw [trace_diagonal_pow, trace_diagonal_pow]
   exact h k hk hkcard
 
--- `DecidableEq n` is only needed to define diagonal matrices in the proof, not in the statement.
-set_option linter.unusedDecidableInType false in
+private lemma roots_prod_X_sub_C (f : n → ℂ) :
+    (∏ i : n, (X - C (f i))).roots = Finset.univ.val.map f := by
+  have hne : (∏ i : n, (X - C (f i))) ≠ 0 := by
+    rw [Finset.prod_ne_zero_iff]
+    exact fun i _ => X_sub_C_ne_zero (f i)
+  rw [roots_prod _ _ hne]
+  simp
+
 /-- Equal power sums of two families indexed by the same finite type imply that the families
 give rise to the same multiset of values.
 
@@ -133,20 +143,13 @@ theorem sum_pow_eq_implies_multiset_eq
     (a b : n → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i, a i ^ k = ∑ i, b i ^ k) :
     Finset.univ.val.map a = Finset.univ.val.map b := by
+  classical
   have hcp := sum_pow_eq_implies_charpoly_diagonal_eq a b h
   rw [charpoly_diagonal, charpoly_diagonal] at hcp
   have hroots : (∏ i : n, (X - C (a i))).roots = (∏ i : n, (X - C (b i))).roots :=
     congrArg Polynomial.roots hcp
-  have roots_eq (f : n → ℂ) : (∏ i : n, (X - C (f i))).roots = Finset.univ.val.map f := by
-    have hne : (∏ i : n, (X - C (f i))) ≠ 0 := by
-      rw [Finset.prod_ne_zero_iff]
-      exact fun i _ => X_sub_C_ne_zero (f i)
-    rw [roots_prod _ _ hne]
-    simp
-  simpa [roots_eq] using hroots
+  simpa [roots_prod_X_sub_C] using hroots
 
--- `DecidableEq n` is only needed to define diagonal matrices in the proof, not in the statement.
-set_option linter.unusedDecidableInType false in
 /-- Equal power sums through `card n` determine the same multiset of values for
 two families indexed by the same finite type.
 
@@ -156,16 +159,11 @@ theorem sum_pow_eq_implies_multiset_eq_of_le_card
     (a b : n → ℂ)
     (h : ∀ k : ℕ, 0 < k → k ≤ Fintype.card n → ∑ i, a i ^ k = ∑ i, b i ^ k) :
     Finset.univ.val.map a = Finset.univ.val.map b := by
+  classical
   have hcp := sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card a b h
   rw [charpoly_diagonal, charpoly_diagonal] at hcp
   have hroots : (∏ i : n, (X - C (a i))).roots = (∏ i : n, (X - C (b i))).roots :=
     congrArg Polynomial.roots hcp
-  have roots_eq (f : n → ℂ) : (∏ i : n, (X - C (f i))).roots = Finset.univ.val.map f := by
-    have hne : (∏ i : n, (X - C (f i))) ≠ 0 := by
-      rw [Finset.prod_ne_zero_iff]
-      exact fun i _ => X_sub_C_ne_zero (f i)
-    rw [roots_prod _ _ hne]
-    simp
-  simpa [roots_eq] using hroots
+  simpa [roots_prod_X_sub_C] using hroots
 
 end Matrix

--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -31,30 +31,12 @@ by observing that the trace of a power of a diagonal matrix equals the correspon
 
   `trace (diagonal a ^ k) = ∑ i, a i ^ k`
 
-## Principal statements
-
-* `Matrix.trace_diagonal_pow`: `trace (diagonal a ^ k) = ∑ i, a i ^ k`.
-
-* `Matrix.sum_pow_eq_implies_charpoly_diagonal_eq`: If
-  `∑ i, a i ^ k = ∑ i, b i ^ k` for all `k ≥ 1`, then
-  `(diagonal a).charpoly = (diagonal b).charpoly`.
-
-* `Matrix.sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card`: If
-  `∑ i, a i ^ k = ∑ i, b i ^ k` for `1 ≤ k ≤ card n`, then
-  `(diagonal a).charpoly = (diagonal b).charpoly`.
-
-* `Matrix.sum_pow_eq_implies_multiset_eq_of_le_card`: Under the finite-range
-  hypothesis `1 ≤ k ≤ card n`, the multisets `Finset.univ.val.map a` and
-  `Finset.univ.val.map b` are equal. The all-positive-power multiset theorem
-  is its immediate corollary.
-
-* `Matrix.sum_pow_eq_implies_multiset_eq`: If the power sums agree for every
-  positive exponent, then the multisets `Finset.univ.val.map a` and
-  `Finset.univ.val.map b` are equal.
-
-* `Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card`: If two nonzero
-  families indexed by `Fin m` and `Fin n` have equal power sums for
-  `1 ≤ k ≤ max m n`, then `m = n` and the multisets of values are equal.
+The main theorem in this file says that, for nonzero families
+`a : Fin m → ℂ` and `b : Fin n → ℂ`, equality of
+`∑ i : Fin m, a i ^ k` and `∑ i : Fin n, b i ^ k` for
+`1 ≤ k ≤ max m n` implies `m = n` and equality of the two multisets of values.
+The same-cardinality theorems are the corresponding finite-range and
+all-positive-power consequences for families indexed by a single finite type.
 
 ## Design note: relation to the exact source statement
 
@@ -151,9 +133,9 @@ theorem sum_pow_eq_implies_multiset_eq_of_le_card
 /-- Equal power sums of two families indexed by the same finite type imply that the families
 give rise to the same multiset of values.
 
-This is an immediate corollary of `sum_pow_eq_implies_multiset_eq_of_le_card`,
-obtained by restricting the all-positive-power hypothesis to `1 ≤ k ≤ card n`.
-Note that this is a **same-cardinality** result; the paper's
+Now a corollary of `sum_pow_eq_implies_multiset_eq_of_le_card`, obtained by
+restricting the all-positive-power hypothesis to `1 ≤ k ≤ card n`. Note that
+this is a **same-cardinality** result; the paper's
 `Lem:app_simple` additionally deduces cardinality equality when the sizes may differ. -/
 theorem sum_pow_eq_implies_multiset_eq
     (a b : n → ℂ)

--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -133,10 +133,11 @@ theorem sum_pow_eq_implies_multiset_eq_of_le_card
 /-- Equal power sums of two families indexed by the same finite type imply that the families
 give rise to the same multiset of values.
 
-Now a corollary of `sum_pow_eq_implies_multiset_eq_of_le_card`, obtained by
-restricting the all-positive-power hypothesis to `1 ≤ k ≤ card n`. Note that
-this is a **same-cardinality** result; the paper's
-`Lem:app_simple` additionally deduces cardinality equality when the sizes may differ. -/
+This all-positive-power statement follows from
+`sum_pow_eq_implies_multiset_eq_of_le_card` by restricting the hypothesis to
+`1 ≤ k ≤ card n`. The theorem is still same-cardinality; Lemma `Lem:app_simple`
+in arXiv:1606.00608 also proves equality of cardinalities when the sizes may
+differ. -/
 theorem sum_pow_eq_implies_multiset_eq
     (a b : n → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i, a i ^ k = ∑ i, b i ^ k) :

--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -10,18 +10,18 @@ import Mathlib.Data.Matrix.Basic
 /-!
 # Scalar Power-Sum Identity
 
-This file provides a **same-cardinality, all-positive-power corollary** used as a support lemma
-for the Appendix argument of arXiv:1606.00608.  It is *not* the exact statement of Lemma
+This file provides **same-cardinality power-sum corollaries** used as support lemmas
+for the Appendix argument of arXiv:1606.00608. It is *not* the exact statement of Lemma
 `Lem:app_simple` (lines 1155–1163 of the paper), which treats two sorted families of complex
 numbers with **possibly different cardinalities** and only requires equality up to
-`N ≤ max{x_a, x_b}`.  See the design note below for what would be needed to formalize the
+`N ≤ max{x_a, x_b}`. See the design note below for what would be needed to formalize the
 precise lemma.
 
-Given two families of `n` complex scalars whose power sums agree for all positive exponents,
+Given two families of `n` complex scalars whose power sums agree for `1 ≤ k ≤ n`,
 Newton's identities imply their diagonal matrices have equal characteristic polynomials, and
-hence the families give the same multiset of values (counted with multiplicity).  This is the
-version used throughout the coefficient-comparison and weight-recovery arguments in
-`SectorWeightComparison` and `EqualProportional`.
+hence the families give the same multiset of values counted with multiplicity. This is the
+finite-range, same-cardinality part needed before treating the full unequal-cardinality source
+statement.
 
 ## Strategy
 
@@ -35,8 +35,17 @@ the corresponding power sum:
 
 * `Matrix.trace_diagonal_pow`: `trace (diagonal a ^ k) = ∑ i, a i ^ k`.
 
-* `Matrix.sum_pow_eq_implies_charpoly_diagonal_eq`: If `∑ i, a i ^ k = ∑ i, b i ^ k` for all
-  `k ≥ 1`, then `(diagonal a).charpoly = (diagonal b).charpoly`.
+* `Matrix.sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card`: If
+  `∑ i, a i ^ k = ∑ i, b i ^ k` for `1 ≤ k ≤ card n`, then
+  `(diagonal a).charpoly = (diagonal b).charpoly`.
+
+* `Matrix.sum_pow_eq_implies_charpoly_diagonal_eq`: If
+  `∑ i, a i ^ k = ∑ i, b i ^ k` for all `k ≥ 1`, then
+  `(diagonal a).charpoly = (diagonal b).charpoly`.
+
+* `Matrix.sum_pow_eq_implies_multiset_eq_of_le_card`: Under the finite-range
+  hypothesis `1 ≤ k ≤ card n`, the multisets `Finset.univ.val.map a` and
+  `Finset.univ.val.map b` are equal.
 
 * `Matrix.sum_pow_eq_implies_multiset_eq`: Under the same hypotheses, the multisets
   `Finset.univ.val.map a` and `Finset.univ.val.map b` are equal.
@@ -51,7 +60,7 @@ The paper's Lemma `Lem:app_simple` (arXiv:1606.00608, lines 1155–1163) states:
     `∑_{k=1}^{x_a} λ_{a,k}^N = ∑_{k=1}^{x_b} λ_{b,k}^N`,
   then `x_a = x_b` and `λ_{a,k} = λ_{b,k}` for all k.
 
-The formalized version in this file differs in three ways:
+The all-positive-power theorem in this file differs in three ways:
 
   1. **Same cardinality**: both families share the same finite type `n` (no deduction of
      `x_a = x_b`).
@@ -61,10 +70,11 @@ The formalized version in this file differs in three ways:
      absorbs the ordering.
 
 These relaxations suffice for the coefficient-comparison path taken in the formalized
-fundamental theorems (where the two families are already known to have the same length).
+fundamental theorems when the two families are already known to have the same length.
 A full formalization of `Lem:app_simple` as written would require:
   - a "sorted complex list" type with the paper's sorting convention,
   - powers up to the larger cardinality,
+  - a nonzero-entry or exponent-zero mechanism to rule out invisible zero terms,
   - a combinatorial counting-via-Vandermonde proof to conclude cardinality equality.
 -/
 
@@ -95,6 +105,21 @@ theorem sum_pow_eq_implies_charpoly_diagonal_eq
   rw [trace_diagonal_pow, trace_diagonal_pow]
   exact h k hk
 
+/-- **Bounded scalar power-sum identity** (same-cardinality part of
+`Lem:app_simple` of arXiv:1606.00608).
+
+If two families of complex scalars, indexed by the same finite type `n`, have equal
+power sums for `1 ≤ k ≤ card n`, then their characteristic polynomials as diagonal
+matrices agree. -/
+theorem sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card
+    (a b : n → ℂ)
+    (h : ∀ k : ℕ, 0 < k → k ≤ Fintype.card n → ∑ i, a i ^ k = ∑ i, b i ^ k) :
+    (diagonal a).charpoly = (diagonal b).charpoly := by
+  apply charpoly_eq_of_trace_pow_eq_of_le_card
+  intro k hk hkcard
+  rw [trace_diagonal_pow, trace_diagonal_pow]
+  exact h k hk hkcard
+
 -- `DecidableEq n` is only needed to define diagonal matrices in the proof, not in the statement.
 set_option linter.unusedDecidableInType false in
 /-- Equal power sums of two families indexed by the same finite type imply that the families
@@ -109,6 +134,29 @@ theorem sum_pow_eq_implies_multiset_eq
     (h : ∀ k : ℕ, 0 < k → ∑ i, a i ^ k = ∑ i, b i ^ k) :
     Finset.univ.val.map a = Finset.univ.val.map b := by
   have hcp := sum_pow_eq_implies_charpoly_diagonal_eq a b h
+  rw [charpoly_diagonal, charpoly_diagonal] at hcp
+  have hroots : (∏ i : n, (X - C (a i))).roots = (∏ i : n, (X - C (b i))).roots :=
+    congrArg Polynomial.roots hcp
+  have roots_eq (f : n → ℂ) : (∏ i : n, (X - C (f i))).roots = Finset.univ.val.map f := by
+    have hne : (∏ i : n, (X - C (f i))) ≠ 0 := by
+      rw [Finset.prod_ne_zero_iff]
+      exact fun i _ => X_sub_C_ne_zero (f i)
+    rw [roots_prod _ _ hne]
+    simp
+  simpa [roots_eq] using hroots
+
+-- `DecidableEq n` is only needed to define diagonal matrices in the proof, not in the statement.
+set_option linter.unusedDecidableInType false in
+/-- Equal power sums through `card n` determine the same multiset of values for
+two families indexed by the same finite type.
+
+This is the finite-range, same-cardinality part of Lemma `Lem:app_simple` in
+arXiv:1606.00608. -/
+theorem sum_pow_eq_implies_multiset_eq_of_le_card
+    (a b : n → ℂ)
+    (h : ∀ k : ℕ, 0 < k → k ≤ Fintype.card n → ∑ i, a i ^ k = ∑ i, b i ^ k) :
+    Finset.univ.val.map a = Finset.univ.val.map b := by
+  have hcp := sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card a b h
   rw [charpoly_diagonal, charpoly_diagonal] at hcp
   have hroots : (∏ i : n, (X - C (a i))).roots = (∏ i : n, (X - C (b i))).roots :=
     congrArg Polynomial.roots hcp

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -470,7 +470,7 @@ theorem fundamentalTheorem_equalMPV_full
 
 This wraps the same-cardinality power-sum lemmas from `ScalarPowerSumIdentity.lean`.
 The bounded version is the same-cardinality part of the paper's Lemma `Lem:app_simple`;
-the full source statement also compares possibly unequal cardinalities.
+the nonzero-entry version below also compares possibly unequal cardinalities.
 -/
 
 /-- **Equal power sums imply equal multisets** (same-cardinality support lemma for
@@ -504,6 +504,20 @@ theorem power_sum_eq_implies_multiset_eq_of_le_card (n : ℕ)
   apply Matrix.sum_pow_eq_implies_multiset_eq_of_le_card
   intro k hk hkcard
   exact h k hk (by simpa using hkcard)
+
+/-- **Bounded unequal-cardinality power sums imply equal cardinality and equal multisets**
+under a nonzero-entry hypothesis.
+
+If two nonzero finite sequences `α : Fin m → ℂ` and `β : Fin n → ℂ` satisfy
+`∑ i, (α i)^k = ∑ i, (β i)^k` for `1 ≤ k ≤ max m n`, then `m = n` and the two
+sequences have the same multiset of values counted with multiplicity. -/
+theorem power_sum_eq_implies_card_eq_and_multiset_eq_of_le_max_card
+    (m n : ℕ) (α : Fin m → ℂ) (β : Fin n → ℂ)
+    (hα : ∀ i, α i ≠ 0) (hβ : ∀ i, β i ≠ 0)
+    (h : ∀ k : ℕ, 0 < k → k ≤ max m n →
+      ∑ i : Fin m, (α i) ^ k = ∑ i : Fin n, (β i) ^ k) :
+    m = n ∧ Finset.univ.val.map α = Finset.univ.val.map β :=
+  Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card m n α β hα hβ h
 
 /-! ## Combined corollaries -/
 

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -468,7 +468,7 @@ theorem fundamentalTheorem_equalMPV_full
 
 /-! ## Theorem 4: Power-sum multiset equality (Lem:app_simple support lemma)
 
-This wraps the same-cardinality power-sum lemmas from `ScalarPowerSumIdentity.lean`.
+This provides the same-cardinality power-sum lemmas from `ScalarPowerSumIdentity.lean`.
 The bounded version is the same-cardinality part of the paper's Lemma `Lem:app_simple`;
 the nonzero-entry version below also compares possibly unequal cardinalities.
 -/

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -468,9 +468,9 @@ theorem fundamentalTheorem_equalMPV_full
 
 /-! ## Theorem 4: Power-sum multiset equality (Lem:app_simple support lemma)
 
-This wraps `Matrix.sum_pow_eq_implies_multiset_eq` from `ScalarPowerSumIdentity.lean`
-to provide a convenience wrapper for the same-cardinality power-sum argument.
-See the design note there for what the exact `Lem:app_simple` statement would require.
+This wraps the same-cardinality power-sum lemmas from `ScalarPowerSumIdentity.lean`.
+The bounded version is the same-cardinality part of the paper's Lemma `Lem:app_simple`;
+the full source statement also compares possibly unequal cardinalities.
 -/
 
 /-- **Equal power sums imply equal multisets** (same-cardinality support lemma for
@@ -489,6 +489,21 @@ theorem power_sum_eq_implies_multiset_eq (n : ℕ)
     (h : ∀ k : ℕ, 0 < k → ∑ i : Fin n, (α i) ^ k = ∑ i : Fin n, (β i) ^ k) :
     Finset.univ.val.map α = Finset.univ.val.map β :=
   Matrix.sum_pow_eq_implies_multiset_eq α β h
+
+/-- **Bounded equal power sums imply equal multisets** (same-cardinality part of
+Lemma `Lem:app_simple`).
+
+If two sequences of complex numbers `α : Fin n → ℂ` and `β : Fin n → ℂ` satisfy
+`∑ i, (α i)^k = ∑ i, (β i)^k` for `1 ≤ k ≤ n`, then `α` and `β` have the same
+multiset of values counted with multiplicity. -/
+theorem power_sum_eq_implies_multiset_eq_of_le_card (n : ℕ)
+    (α β : Fin n → ℂ)
+    (h : ∀ k : ℕ, 0 < k → k ≤ n →
+      ∑ i : Fin n, (α i) ^ k = ∑ i : Fin n, (β i) ^ k) :
+    Finset.univ.val.map α = Finset.univ.val.map β := by
+  apply Matrix.sum_pow_eq_implies_multiset_eq_of_le_card
+  intro k hk hkcard
+  exact h k hk (by simpa using hkcard)
 
 /-! ## Combined corollaries -/
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -579,11 +579,13 @@ and~\cite{Cirac2021Matrix}.
 \section{Newton--Girard identities}
 
 \begin{theorem}[Newton--Girard trace recursion]\label{thm:newton_girard}
-	\lean{Matrix.charpoly_eq_of_forall_trace_pow_eq}
+	\lean{Matrix.charpoly_eq_of_forall_trace_pow_eq,
+		Matrix.charpoly_eq_of_trace_pow_eq_of_le_card}
 	\leanok
 	If $A, B \in \MN{n}$ satisfy
 	$\tr(A^k) = \tr(B^k)$ for all $k \ge 1$,
 	then $A$ and $B$ have the same characteristic polynomial.
+	It is enough to assume this equality for $1 \le k \le n$.
 \end{theorem}
 
 \begin{proof}
@@ -628,6 +630,24 @@ and~\cite{Cirac2021Matrix}.
 	cardinality are assumed, and the conclusion is equality of the ordered
 	families.
 \end{remark}
+
+\begin{theorem}[Finite-range equal power sums imply equal multisets]
+	\label{thm:bounded_power_sum_multiset}
+	\lean{Matrix.sum_pow_eq_implies_multiset_eq_of_le_card,
+		MPSTensor.power_sum_eq_implies_multiset_eq_of_le_card}
+	\leanok
+	Let $\alpha, \beta : \{1, \ldots, n\} \to \C$.
+	If $\sum_i \alpha_i^k = \sum_i \beta_i^k$ for $1 \le k \le n$,
+	then the multisets $\{\alpha_i\}$ and $\{\beta_i\}$ are equal.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	\uses{thm:newton_girard}
+	Apply the finite-range Newton--Girard theorem to
+	$\diag(\alpha)$ and $\diag(\beta)$, then extract the roots of
+	$\prod_i (X-\alpha_i)$ and $\prod_i (X-\beta_i)$.
+\end{proof}
 
 \begin{theorem}[Equal power sums imply equal multisets]\label{thm:power_sum_multiset}
 	\lean{Matrix.sum_pow_eq_implies_multiset_eq}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -623,22 +623,29 @@ and~\cite{Cirac2021Matrix}.
 	multiplicity and weight equality needed to identify the weighted
 	block-diagonal gauge.
 
-	The statement below is the same-cardinality form with equality for all
-	positive exponents used by the BNT comparison in this section. The Appendix
-	lemma in the source is sharper: the two finite families need not initially
-	have the same cardinality, only finitely many power sums up to the larger
-	cardinality are assumed, and the conclusion is equality of the ordered
-	families.
+	The finite-range statement below includes both the same-cardinality form and
+	the nonzero-entry unequal-cardinality form. The latter pads the shorter
+	family by zeros, applies the same-cardinality result at length
+	\(\max(m,n)\), and then uses the nonzero-entry hypothesis to count the
+	padded zeros. The Appendix lemma in the source also fixes an ordering
+	convention for the two families; here the conclusion is stated as multiset
+	equality, so no sorting hypothesis is needed.
 \end{remark}
 
 \begin{theorem}[Finite-range equal power sums imply equal multisets]
 	\label{thm:bounded_power_sum_multiset}
 	\lean{Matrix.sum_pow_eq_implies_multiset_eq_of_le_card,
-		MPSTensor.power_sum_eq_implies_multiset_eq_of_le_card}
+		Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card,
+		MPSTensor.power_sum_eq_implies_multiset_eq_of_le_card,
+		MPSTensor.power_sum_eq_implies_card_eq_and_multiset_eq_of_le_max_card}
 	\leanok
 	Let $\alpha, \beta : \{1, \ldots, n\} \to \C$.
 	If $\sum_i \alpha_i^k = \sum_i \beta_i^k$ for $1 \le k \le n$,
 	then the multisets $\{\alpha_i\}$ and $\{\beta_i\}$ are equal.
+	More generally, if $\alpha : \{1,\ldots,m\}\to\C$ and
+	$\beta : \{1,\ldots,n\}\to\C$ have no zero entries and their power sums
+	agree for \(1 \le k \le \max(m,n)\), then \(m=n\) and the two multisets
+	are equal.
 \end{theorem}
 
 \begin{proof}
@@ -646,7 +653,11 @@ and~\cite{Cirac2021Matrix}.
 	\uses{thm:newton_girard}
 	Apply the finite-range Newton--Girard theorem to
 	$\diag(\alpha)$ and $\diag(\beta)$, then extract the roots of
-	$\prod_i (X-\alpha_i)$ and $\prod_i (X-\beta_i)$.
+	$\prod_i (X-\alpha_i)$ and $\prod_i (X-\beta_i)$. For unequal
+	cardinalities, pad both lists with zeros to length \(\max(m,n)\). The
+	equal-root conclusion compares the padded multisets, and the nonzero-entry
+	hypothesis makes the number of padded zeros exactly \(\max(m,n)-m\) and
+	\(\max(m,n)-n\), forcing \(m=n\).
 \end{proof}
 
 \begin{theorem}[Equal power sums imply equal multisets]\label{thm:power_sum_multiset}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -639,11 +639,11 @@ and~\cite{Cirac2021Matrix}.
 		MPSTensor.power_sum_eq_implies_multiset_eq_of_le_card,
 		MPSTensor.power_sum_eq_implies_card_eq_and_multiset_eq_of_le_max_card}
 	\leanok
-	Let $\alpha, \beta : \{1, \ldots, n\} \to \C$.
+	Let $\alpha, \beta : \{0, \ldots, n-1\} \to \C$.
 	If $\sum_i \alpha_i^k = \sum_i \beta_i^k$ for $1 \le k \le n$,
 	then the multisets $\{\alpha_i\}$ and $\{\beta_i\}$ are equal.
-	More generally, if $\alpha : \{1,\ldots,m\}\to\C$ and
-	$\beta : \{1,\ldots,n\}\to\C$ have no zero entries and their power sums
+	More generally, if $\alpha : \{0,\ldots,m-1\}\to\C$ and
+	$\beta : \{0,\ldots,n-1\}\to\C$ have no zero entries and their power sums
 	agree for \(1 \le k \le \max(m,n)\), then \(m=n\) and the two multisets
 	are equal.
 \end{theorem}
@@ -663,7 +663,7 @@ and~\cite{Cirac2021Matrix}.
 \begin{theorem}[Equal power sums imply equal multisets]\label{thm:power_sum_multiset}
 	\lean{Matrix.sum_pow_eq_implies_multiset_eq}
 	\leanok
-	Let $\alpha, \beta : \{1, \ldots, n\} \to \C$.
+	Let $\alpha, \beta : \{0, \ldots, n-1\} \to \C$.
 	If $\sum_i \alpha_i^k = \sum_i \beta_i^k$ for all $k \ge 1$,
 	then the multisets $\{\alpha_i\}$ and $\{\beta_i\}$ are equal.
 \end{theorem}


### PR DESCRIPTION
### Motivation
- First source-faithful step toward full `Lem:app_simple` (see #1476) from arXiv:1606.00608, Appendix A.
- Proves the bounded-range Newton–Girard recovery: equality of traces `trace(A^k) = trace(B^k)` for `1 ≤ k ≤ card n` implies equal characteristic polynomials and equal eigenvalue multisets when both matrices have the same size.
- Extends the power-sum identity infrastructure from #1456 with finite-range support.

### Description
- `TNLean/Algebra/NewtonGirard.lean`: added theorems recovering `charpolyRev` and `charpoly` from finite-range trace equalities (`1 ≤ k ≤ Fintype.card n`).
- `TNLean/Algebra/ScalarPowerSumIdentity.lean`: added `sum_pow_eq_implies_multiset_eq_of_le_card` — for diagonal matrices, equality of power sums `∑_i a_i^k` for `1 ≤ k ≤ card n` implies equal multisets of entries (same-cardinality case).
- `TNLean/MPS/FundamentalTheorem/EqualProportional.lean`: exposed bounded wrapper for the same-cardinality result.
- `blueprint/src/chapter/ch10_bnt.tex`: updated blueprint text and `\lean{}`/`\leanok` tags for the new bounded theorems.
- This is not the full `Lem:app_simple` — the paper statement allows unequal cardinalities. Positive powers alone do not detect extra zero terms, so the remaining full lemma needs either a nonzero-entry hypothesis, an exponent-zero/cardinality mechanism, or a paper-context argument ruling out zero padding.

### Testing
- `lake build TNLean.MPS.FundamentalTheorem.EqualProportional`
- `leanblueprint web` and `leanblueprint checkdecls`
- `rg -n "sorry|axiom|admit|unsafeCast|native_decide"` on all changed `.lean` files
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---
Addresses #1476

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new bounded-range theorems and supporting padding/counting lemmas that affect downstream proof dependencies; risk is mainly proof fragility/typeclass assumption changes rather than runtime behavior.
> 
> **Overview**
> Extends the Newton–Girard trace machinery to a **finite trace range**: proves `charpolyRev` and `charpoly` equality from `trace (A^k) = trace (B^k)` for `1 ≤ k ≤ card n`, and refactors the existing all-`k>0` `charpoly` theorem to be a corollary of this bounded version.
> 
> Builds bounded and unequal-cardinality scalar power-sum results on top: adds same-cardinality `sum_pow_eq_implies_multiset_eq_of_le_card` plus a new nonzero-entry theorem `sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card` via zero-padding and counting. Exposes new wrappers in `MPSTensor.EqualProportional` and updates the blueprint chapter to reference and explain the new bounded/unequal-cardinality statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b034028ba5fa7a3dab48f0961a3edc553c312f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->