### PR TITLE
refactor(Channel/Schwarz): remove unused declarations after #841 audit

### DIFF
--- a/TNLean/Channel/Schwarz/KadisonSchwarz.lean
+++ b/TNLean/Channel/Schwarz/KadisonSchwarz.lean
@@ -107,12 +107,6 @@ private theorem isUnitalKraus_conjTranspose (h : IsTPKraus K) :
   change ∑ i, (K i)ᴴ * ((K i)ᴴ)ᴴ = 1
   simp only [conjTranspose_conjTranspose]; exact h
 
-/-- The conjugate-transposed operators of a unital family form a TP family. -/
-private theorem isTPKraus_conjTranspose (h : IsUnitalKraus K) :
-    IsTPKraus (fun i => (K i)ᴴ) := by
-  change ∑ i, ((K i)ᴴ)ᴴ * (K i)ᴴ = 1
-  simp only [conjTranspose_conjTranspose]; exact h
-
 /-- **Kadison-Schwarz inequality** (Wolf, Chapter 5, Equation (5.2)).
 
 For a unital CP map `E(X) = ∑ᵢ Kᵢ X Kᵢ†` with `∑ᵢ Kᵢ Kᵢ† = I`,
@@ -221,23 +215,5 @@ theorem hilbertSchmidt_contraction (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     rw [← trace_sum, ← Finset.sum_mul, show ∑ i : Fin d, (K i)ᴴ * K i = 1 from h_tp, one_mul]
   rw [h_pres] at h_nonneg
   exact le_of_sub_nonneg h_nonneg
-
-/-- **HS contraction for the adjoint channel** (MPS version).
-
-If `∑ Kᵢ† Kᵢ = I` (TP / left-canonical) and `∑ Kᵢ Kᵢ† = I`
-(unital / right-canonical), then the adjoint map
-`E*(X) = ∑ Kᵢ† X Kᵢ` contracts the Hilbert-Schmidt norm:
-`tr(E*(X)† E*(X)) ≤ tr(X† X)`.
-
-Note: both conditions are needed — Kadison-Schwarz uses unitality of E*
-(which follows from TP of E), while the trace computation uses TP of E*
-(which requires unitality of E). -/
-theorem hilbertSchmidt_contraction_adjoint (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (h_tp : IsTPKraus K) (h_unital : IsUnitalKraus K)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    trace ((krausAdjointMap K X)ᴴ * krausAdjointMap K X) ≤ trace (Xᴴ * X) := by
-  simp only [krausAdjointMap_eq]
-  exact hilbertSchmidt_contraction _ (isUnitalKraus_conjTranspose h_tp)
-    (isTPKraus_conjTranspose h_unital) X
 
 end KadisonSchwarz


### PR DESCRIPTION
### Motivation

Follow-up from audit LionSR/TNLean#841 and PR LionSR/TNLean#875: confirm and remove unused declarations in `TNLean/Channel/Schwarz/` that have no downstream dependencies.

This PR has been rebased/narrowed after review. The earlier paper-gap PDF pipeline changes and `TraceCFC.lean` deletion are **not** part of the current diff.

### Current scope

This PR now contains only the genuine LionSR/QICLean#141 Schwarz cleanup in `TNLean/Channel/Schwarz/KadisonSchwarz.lean`:

- remove unused theorem `hilbertSchmidt_contraction_adjoint`;
- remove dead private helper `isTPKraus_conjTranspose`.

### Explicitly preserved

The following items remain in the repository and are not removed by this PR:

- `TNLean/Channel/Schwarz/TraceCFC.lean` — restored/preserved because it is imported by `TNLean.lean` and `TNLean/Analysis/OperatorConvexity.lean`;
- public canonical Kraus aliases and iff lemmas:
  - `IsRightCanonicalKraus`, `IsLeftCanonicalKraus`,
  - `isRightCanonicalKraus_iff`, `isLeftCanonicalKraus_iff`,
  - `krausMap_one_of_rightCanonical`, `krausAdjointMap_one_of_leftCanonical`;
- `isUnitalKraus_conjTranspose` and `krausAdjointMap_eq`, still used by `kadison_schwarz_adjoint`.

### Dropped as obsolete / out of scope

The original PR body mentioned script and docs-pipeline changes for paper-gap PDFs. Those commits were dropped because that work was already handled on `main` by the paper-gap pipeline PRs. This PR no longer changes:

- `scripts/build-paper-gaps.sh`,
- `scripts/deploy-to-gh-pages.sh`,
- `.github/workflows/docgen.yml`,
- `docs/paper-gaps/*.tex`.

### Validation

- `git diff --check` clean.
- Local Lean diagnostics/checks were run on:
  - `TNLean/Channel/Schwarz/KadisonSchwarz.lean`,
  - `TNLean/Analysis/OperatorConvexity.lean`.
- GitHub CI is green on the narrowed branch:
  - build,
  - blueprint/prose,
  - blueprint compile,
  - file-length guard,
  - Claude review checks.

Closes LionSR/QICLean#141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: removes unused theorems without changing any remaining statements or proofs; main risk is accidental downstream breakage, but grep indicates no remaining references.
> 
> **Overview**
> Removes unused declarations in `TNLean/Channel/Schwarz/KadisonSchwarz.lean`, specifically the private helper `isTPKraus_conjTranspose` and the theorem `hilbertSchmidt_contraction_adjoint`.
> 
> No functional/proof behavior changes are introduced beyond deleting these now-dead lemmas; existing Kadison–Schwarz and Hilbert–Schmidt contraction results remain intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e35f390a3402a2ba60080293d5bdee2b7fbc03b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->