### PR TITLE
doc(MPS/CanonicalForm): describe common-period blocking mathematically

### DIFF
--- a/TNLean/MPS/CanonicalForm/CommonPeriodCyclicSectors.lean
+++ b/TNLean/MPS/CanonicalForm/CommonPeriodCyclicSectors.lean
@@ -9,10 +9,11 @@ import TNLean.MPS.Core.BlockingInfrastructure
 /-!
 # Common-period cyclic-sector blocking
 
-The common-period blocking operation for cyclic-sector blocks transports
-per-block primitivity witnesses to a common blocking level. The abbreviation
-`lcmPeriod` is defined in `TNLean.MPS.Core.BlockingInfrastructure`, together
-with its positivity and divisibility lemmas.
+The common-period blocking operation sends each cyclic-sector block to the
+period `lcmPeriod periods`, giving a family with physical dimension
+`blockPhysDim d (lcmPeriod periods)` and the same block-dependent bond
+dimensions. Per-block primitivity witnesses are transported along the
+divisibility `periods i ∣ lcmPeriod periods`.
 -/
 
 namespace MPSTensor
@@ -22,8 +23,8 @@ variable {d k : ℕ}
 /-- Block each family member to the common `lcmPeriod`.
 
 This keeps a uniform physical dimension across the common-period family while
-allowing the bond dimension to vary with the index. The
-resulting family is the basic input for common-period cyclic-sector comparison.
+allowing the bond dimension to vary with the index. The resulting family is the
+basic input for common-period cyclic-sector comparison.
 -/
 noncomputable def commonPeriodBlocking
     {dim : Fin k → ℕ}


### PR DESCRIPTION
### Motivation

- The project's prose style guide (`docs/prose_style.md`) bans "Assembly" as a
  section/chapter title and in organizational names. The file
  `CyclicSectorAssembly.lean` used "assembly" / "assembled" wording in docstrings.
- This change aligns the file's documentation with the mathematical terminology
  (common-period blocking, decomposition) already used in its definitions
  (`commonPeriodBlocking`, `lcmPeriod`).

### Description

- Updated the module header docstring and inline docstrings in
  `TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean` (5 insertions, 5 deletions).
- Replaced "assembly" / "assembled" language with "common-period blocking" and
  "cyclic-sector decomposition" terminology throughout.
- No definitions, theorems, or proofs were changed.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean` passed.
- `git diff --check` clean.
- `rg -n "assembly|assembled|downstream|bridge|wrapper" TNLean/MPS/CanonicalForm/CyclicSectorAssembly.lean`
  confirms banned terms removed.

---
Addresses #1402

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes in `CyclicSectorAssembly.lean`, with no changes to definitions or proofs, so behavioral risk is minimal.
>
> **Overview**
> Renames and rewrites the module/header documentation in `CyclicSectorAssembly.lean` to describe the file as **common-period blocking** (via `commonPeriodBlocking` and `lcmPeriod`) rather than "assembly," and updates associated docstrings to align with cyclic-sector *decomposition* terminology.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d385e72d07bde1f450f3a720c552e8bf154f41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes in `CommonPeriodCyclicSectors.lean`; no definitions or proofs were modified, so behavioral risk is minimal.
> 
> **Overview**
> Updates the module header and `commonPeriodBlocking` docstrings in `CommonPeriodCyclicSectors.lean` to more explicitly describe the common-period blocking construction (mapping to `lcmPeriod periods`, resulting physical dimension, and transport of primitivity along divisibility).
> 
> No Lean definitions, lemmas, or proofs change—this is purely documentation/wording cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b13398ac319ed6e00c6f4cd66252ada2aac10414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->