### PR TITLE
doc(CanonicalForm): use block-diagonal tensor wording

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -174,10 +174,10 @@ not retain repeated equal-modulus sectors; the full multiplicity structure (weig
 `μ_{j,q}` and multiplicities `M_j` as in arXiv:1606.00608) is recorded in
 `SectorDecomposition` and the sector-weight comparison theorems.
 
-**Formalization note.** `IsNormalCanonicalFormBNT` uses the spectral/primitive-transfer-map
-version of normality (`IsNormalCanonicalForm`), while the later `IsBNT` hypotheses ask
-for blockwise `IsNormal` (the equivalent algebraic eventual-block-injectivity notion).
-The primitive-to-normal implication must be supplied explicitly when passing to `IsBNT`. -/
+`IsNormalCanonicalFormBNT` uses the spectral/primitive-transfer-map version of normality
+(`IsNormalCanonicalForm`), while the later `IsBNT` hypotheses ask for blockwise
+`IsNormal` (the equivalent algebraic eventual-block-injectivity notion). The
+primitive-to-normal implication must be supplied explicitly when passing to `IsBNT`. -/
 structure IsNormalCanonicalFormBNT {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) : Prop extends
     IsNormalCanonicalForm μ A where

--- a/TNLean/MPS/CanonicalForm/BNTGrouping.lean
+++ b/TNLean/MPS/CanonicalForm/BNTGrouping.lean
@@ -56,8 +56,9 @@ basis-of-normal-tensors construction from
 * `exists_sortedNCF_of_distinct_norms` — If blocks satisfy all `IsNormalCanonicalForm`
   conditions except norm ordering (norms distinct but not yet decreasing), there exists
   a permutation `e` such that `(μ ∘ e, blocks ∘ e)` is a proper `IsNormalCanonicalForm`
-  and the assembled tensor is `SameMPV₂`-equivalent to the original.  This is the key
-  connection from the reduction output to the canonical form.
+  and `toTensorFromBlocks (μ ∘ e) (blocks ∘ e)` is `SameMPV₂`-equivalent to
+  `toTensorFromBlocks μ blocks`.  This is the key connection from the reduction output
+  to the canonical form.
 
 ### Section 4 One-sector-per-block sector decomposition for the sorted distinct-norm case
 
@@ -70,8 +71,9 @@ basis-of-normal-tensors construction from
 * `exists_normClassSectorDecomp_of_equalNorm_sameMPV` — For blocks with possibly equal norms,
   given the hypothesis that equal-norm blocks have the same MPV family
   (`SameMPV₂ (blocks j) (blocks k)` whenever `‖μ j‖ = ‖μ k‖`), there exists a
-  `SectorDecomposition` whose assembled tensor is `SameMPV₂`-equivalent to the original
-  and whose sector-level norms are strictly decreasing.  The proof constructs a
+  `SectorDecomposition` whose tensor is `SameMPV₂`-equivalent to
+  `toTensorFromBlocks μ blocks` and whose sector-level norms are strictly decreasing.
+  The proof constructs a
   `SectorDecomposition` from norm-class enumeration and uses the representative block's
   dimension for the sector `basisDim`.  A same-dimension hypothesis is not needed: the
   choice of representative fixes the sector's bond dimension regardless of other
@@ -183,7 +185,8 @@ theorem exists_sorted_blockDecomp_of_distinct_norms
 Starting from a weighted block family satisfying all `IsNormalCanonicalForm` conditions
 *except* that the norms `‖μ k‖` are distinct but not yet ordered, this theorem produces:
 * a sorting permutation `e : Fin r ≃ Fin r`,
-* a `SameMPV₂` equivalence between the original and the permuted assembled tensors,
+* a `SameMPV₂` equivalence between `toTensorFromBlocks μ blocks` and
+  `toTensorFromBlocks (μ ∘ e) (blocks ∘ e)`,
 * an `IsNormalCanonicalForm` certificate for the permuted family `(μ ∘ e, blocks ∘ e)`.
 
 This is the key reduction: the theorem takes a family with distinct but unsorted
@@ -192,7 +195,7 @@ norms (the output of the TP-gauge / blocking reduction) and produces an
 
 **Note on types**: The permutation changes the bond-dimension type from
 `∑ k, dim k` to `∑ k, dim (e k)`; these are equal as natural numbers (via
-`Equiv.sum_comp`) but the assembled tensors live in different types in Lean.
+`Equiv.sum_comp`) but the two block-diagonal tensors live in different types in Lean.
 `SameMPV₂` is the right heterogeneous equivalence for comparing them.
 
 **Proof**: `exists_sorted_reindexing` gives `e` with `StrictAnti (‖μ ∘ e‖)`.
@@ -253,7 +256,7 @@ def trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
 
 /-- **MPV identity for `trivialSectorDecomp`.**
 
-The assembled tensor of `trivialSectorDecomp μ blocks hμne` has the same MPV family
+The tensor of `trivialSectorDecomp μ blocks hμne` has the same MPV family
 as `toTensorFromBlocks μ blocks`.  The proof expands both sides using the
 sector-decomposition formula and the block-sum formula, together with the identity
 `coeff N j = (μ j)^N` because `copies j = 1`. -/
@@ -281,7 +284,7 @@ lemma sameMPV₂_trivialSectorDecomp {r : ℕ} {dim : Fin r → ℕ}
 /-- **One-sector-per-block `SectorDecomposition` from a sorted block family.**
 
 Specialization of `trivialSectorDecomp` to the sorted distinct-norm case: every block
-becomes its own basis tensor with `copies j = 1`, the assembled tensor has
+becomes its own basis tensor with `copies j = 1`, the resulting tensor has
 `SameMPV₂` with `toTensorFromBlocks μ blocks`, and the sector-level norm ordering is
 `StrictAnti` because each basis carries exactly one weight `μ j`, already strictly
 decreasing. -/
@@ -404,10 +407,10 @@ there exists a `SectorDecomposition P` with:
   representative `reprFn j` suffices for the class; the remaining blocks are counted
   as additional copies (`copies j ≥ 1`).
 
-**Formalization note.** No equal-dimension hypothesis is needed: the sector's bond
-dimension is fixed by the representative `reprFn j`, and other members of the same
-norm class may have different dimensions. Their MPV values are matched via `hMPVEq`,
-which uses the heterogeneous `SameMPV₂` to compare blocks of different dimensions.
+No equal-dimension hypothesis is needed: the sector's bond dimension is fixed by the
+representative `reprFn j`, and other members of the same norm class may have different
+dimensions. Their MPV values are matched via `hMPVEq`, which uses the heterogeneous
+`SameMPV₂` to compare blocks of different dimensions.
 
 **Scope.** This theorem groups blocks by norm class alone; it does not split a
 norm class further into distinct MPV classes. If two blocks have the same norm

--- a/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
@@ -20,7 +20,7 @@ open Matrix Finset Complex
 /-!
 ## Helper lemmas: adjoint eigenvalues and primitivity
 
-We need a small bridge between the peripheral spectrum of a linear map and that of its adjoint.
+We need a small comparison between the peripheral spectrum of a linear map and that of its adjoint.
 For finite-dimensional complex inner product spaces, eigenvalues of `E.adjoint` are complex
 conjugates of eigenvalues of `E`.
 

--- a/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
@@ -20,7 +20,7 @@ open Matrix Finset Complex
 /-!
 ## Helper lemmas: adjoint eigenvalues and primitivity
 
-We need a small comparison between the peripheral spectrum of a linear map and that of its adjoint.
+We need a small connection between the peripheral spectrum of a linear map and that of its adjoint.
 For finite-dimensional complex inner product spaces, eigenvalues of `E.adjoint` are complex
 conjugates of eigenvalues of `E`.
 

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -41,7 +41,7 @@ What is **not** yet proved here:
   handling possible zero blocks exactly under `SameMPV₂` (which remembers the `N = 0` sector).
 * Resolve the post-blocking cyclic-sector / equal-weight issues needed to produce a primitive
   weighted block family with strictly ordered nonzero weights.
-* Pass that data to the block-injective / `IsCanonicalForm` hypotheses needed for the
+* Pass these hypotheses to the block-injective / `IsCanonicalForm` predicates needed for the
   fundamental-theorem results.
 
 Accordingly, this file gives reduction lemmas and explicit conditional statements,
@@ -119,7 +119,7 @@ theorem exists_CFII_data_of_TP_of_isIrreducibleTensor
     -- Existing lemma is stated with `star` rather than `ᴴ`.
     simpa only [Matrix.star_eq_conjTranspose] using
       sameMPV_conj_unitary (d := d) (D := D) A U
-  -- Assemble the collected data under the `let B := ...` binder.
+  -- Collect the statements under the `let B := ...` binder.
   exact ⟨hSame, hΛ_pd, hΛ_diag, hTP_conj, hΛ_fix⟩
 
 

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -461,9 +461,9 @@ theorem exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq
     span_eq := hSpan
   }
 
-/-- **Two-sided overlap-span data from common phase-cover data.**
+/-- **Two-sided overlap-span data from a common MPV phase cover.**
 
-This is the common-cover form of
+This is the common MPV phase-cover form of
 `exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq`.  The cover
 supplies the finite-length span equality for the two nonzero-weight block families,
 and the one-sided BNT representative construction supplies the remaining overlap,

--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -14,7 +14,7 @@ open Filter
 # MPV phase covers for canonical-form block families
 
 This file contains the MPV phase-equivalence and phase-cover constructions used by the
-canonical-form equal-norm bridge and sector-comparison layers.
+canonical-form equal-norm comparison and sector-comparison layers.
 -/
 
 namespace MPSTensor
@@ -383,7 +383,7 @@ lemma nonempty_mpvCommonPhaseCover_of_equiv_phase
 /-- A BNT proportional-decomposition conclusion gives finite-length MPV span equality.
 
 The conclusion is obtained by taking the left family as the common MPV phase-cover family and
-then applying the common-cover span lemma. -/
+then applying the common phase-cover span lemma. -/
 lemma mpv_span_eq_of_proportionalDecompositionConclusion
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
@@ -436,7 +436,8 @@ lemma nonempty_mpvCommonPhaseCover_of_separated_normalCFBNT_data
 /-- Separated normal canonical-form data give finite-length MPV span equality.
 
 The BNT comparison theorem gives a proportional-decomposition conclusion, hence a common
-MPV phase cover, and the common-cover span lemma gives equality of the two block-family spans. -/
+MPV phase cover, and the common phase-cover span lemma gives equality of the two block-family
+spans. -/
 lemma mpv_span_eq_of_separated_normalCFBNT_data
     {rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/TNLean/MPS/CanonicalForm/SectorComparison.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison.lean
@@ -2,10 +2,10 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison
-import TNLean.MPS.CanonicalForm.Assembly.CommonPrimitiveProportionalData
-import TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison
-import TNLean.MPS.CanonicalForm.Assembly.CommonSectorData
+import TNLean.MPS.CanonicalForm.SectorComparison.ProportionalComparison
+import TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData
+import TNLean.MPS.CanonicalForm.SectorComparison.BasicSectorComparison
+import TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData
 
 /-!
 # Canonical-form reduction after blocking
@@ -17,35 +17,35 @@ split across focused supporting modules.
 
 The supporting modules are:
 
-* `TNLean.MPS.CanonicalForm.Assembly.TPPrimitiveReduction` — blocked
+* `TNLean.MPS.CanonicalForm.SectorComparison.TPPrimitiveReduction` — blocked
   TP-primitive decomposition from arbitrary input.
-* `TNLean.MPS.CanonicalForm.Assembly.NormalityChain` — the normality chain for
+* `TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain` — the normality chain for
   TP-primitive irreducible blocks and preservation of normality under blocking.
-* `TNLean.MPS.CanonicalForm.Assembly.PrimitiveBlocks` — blocked irreducibility
+* `TNLean.MPS.CanonicalForm.SectorComparison.PrimitiveBlocks` — blocked irreducibility
   and the conditional weak block-matching theorem.
-* `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily` —
+* `TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorFamily` —
   definitions and lemmas for common-period cyclic-sector families.
-* `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorRepresentatives` —
+* `TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorRepresentatives` —
   definitions and lemmas for representative common-sector families.
-* `TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition` — cyclic sector
+* `TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorDecomposition` — cyclic sector
   decomposition after blocking.
-* `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorConstruction` —
+* `TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorConstruction` —
   construction of common-period cyclic-sector families.
-* `TNLean.MPS.CanonicalForm.Assembly.ZeroTailTransport` — generic zero-tail
+* `TNLean.MPS.CanonicalForm.SectorComparison.ZeroTailTransport` — generic zero-tail
   MPV transport lemmas.
-* `TNLean.MPS.CanonicalForm.Assembly.CommonSectorData` — common-sector data
+* `TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData` — common-sector data
   after the zero-tail and TP-gauge structural reduction.
-* `TNLean.MPS.CanonicalForm.Assembly.StructuralData` — common-period blocking
+* `TNLean.MPS.CanonicalForm.SectorComparison.StructuralData` — common-period blocking
   and structural after-blocking data.
-* `TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` — historical re-export
+* `TNLean.MPS.CanonicalForm.SectorComparison.StructuralTheorem` — historical re-export
   path for structural data and common-sector transport.
-* `TNLean.MPS.CanonicalForm.Assembly.CommonSectorTransport` — zero-tail and
+* `TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport` — zero-tail and
   common-sector transport after the structural theorem.
-* `TNLean.MPS.CanonicalForm.Assembly.CommonPrimitiveProportionalData` —
+* `TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData` —
   common primitive span, phase-cover, proportional, and BNT comparison hypotheses.
-* `TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison` — basic sector
+* `TNLean.MPS.CanonicalForm.SectorComparison.BasicSectorComparison` — basic sector
   comparisons from block-span, phase-cover, and proportional data.
-* `TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison` — sector comparison
+* `TNLean.MPS.CanonicalForm.SectorComparison.ProportionalComparison` — sector comparison
   from BNT proportional-decomposition data.
 
 ## Main statements

--- a/TNLean/MPS/CanonicalForm/SectorComparison.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison.lean
@@ -2,49 +2,50 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.CanonicalForm.SectorComparison.ProportionalComparison
-import TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData
-import TNLean.MPS.CanonicalForm.SectorComparison.BasicSectorComparison
-import TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData
+import TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison
+import TNLean.MPS.CanonicalForm.Assembly.CommonPrimitiveProportionalData
+import TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison
+import TNLean.MPS.CanonicalForm.Assembly.CommonSectorData
 
 /-!
 # Canonical-form reduction after blocking
 
-The canonical-form reduction after blocking combines sector comparison,
-common-period blocking, zero-block comparison, and weight-comparison statements
-used in the non-periodic fundamental theorem.
+This module is the public entry point for the complete canonical-form
+reduction after blocking. It keeps the historical import path
+`TNLean.MPS.CanonicalForm.Assembly` available while the underlying development is
+split across focused supporting modules.
 
 The supporting modules are:
 
-* `TNLean.MPS.CanonicalForm.SectorComparison.TPPrimitiveReduction` — blocked
+* `TNLean.MPS.CanonicalForm.Assembly.TPPrimitiveReduction` — blocked
   TP-primitive decomposition from arbitrary input.
-* `TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain` — the normality chain for
+* `TNLean.MPS.CanonicalForm.Assembly.NormalityChain` — the normality chain for
   TP-primitive irreducible blocks and preservation of normality under blocking.
-* `TNLean.MPS.CanonicalForm.SectorComparison.PrimitiveBlocks` — blocked irreducibility
+* `TNLean.MPS.CanonicalForm.Assembly.PrimitiveBlocks` — blocked irreducibility
   and the conditional weak block-matching theorem.
-* `TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorFamily` —
+* `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorFamily` —
   definitions and lemmas for common-period cyclic-sector families.
-* `TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorRepresentatives` —
+* `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorRepresentatives` —
   definitions and lemmas for representative common-sector families.
-* `TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorDecomposition` — cyclic sector
+* `TNLean.MPS.CanonicalForm.Assembly.CyclicSectorDecomposition` — cyclic sector
   decomposition after blocking.
-* `TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorConstruction` —
+* `TNLean.MPS.CanonicalForm.Assembly.CommonBlockedCyclicSectorConstruction` —
   construction of common-period cyclic-sector families.
-* `TNLean.MPS.CanonicalForm.SectorComparison.ZeroTailTransport` — generic zero-tail
+* `TNLean.MPS.CanonicalForm.Assembly.ZeroTailTransport` — generic zero-tail
   MPV transport lemmas.
-* `TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData` — common-sector hypotheses
+* `TNLean.MPS.CanonicalForm.Assembly.CommonSectorData` — common-sector data
   after the zero-tail and TP-gauge structural reduction.
-* `TNLean.MPS.CanonicalForm.SectorComparison.StructuralData` — common-period blocking
-  and structural after-blocking hypotheses.
-* `TNLean.MPS.CanonicalForm.SectorComparison.StructuralTheorem` — structural theorem
-  imports and common-sector transport.
-* `TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport` — zero-tail and
+* `TNLean.MPS.CanonicalForm.Assembly.StructuralData` — common-period blocking
+  and structural after-blocking data.
+* `TNLean.MPS.CanonicalForm.Assembly.StructuralTheorem` — historical re-export
+  path for structural data and common-sector transport.
+* `TNLean.MPS.CanonicalForm.Assembly.CommonSectorTransport` — zero-tail and
   common-sector transport after the structural theorem.
-* `TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData` —
-  common primitive span, phase-cover, proportional, and BNT-cover hypotheses.
-* `TNLean.MPS.CanonicalForm.SectorComparison.BasicSectorComparison` — basic sector
+* `TNLean.MPS.CanonicalForm.Assembly.CommonPrimitiveProportionalData` —
+  common primitive span, phase-cover, proportional, and BNT comparison hypotheses.
+* `TNLean.MPS.CanonicalForm.Assembly.BasicSectorComparison` — basic sector
   comparisons from block-span, phase-cover, and proportional data.
-* `TNLean.MPS.CanonicalForm.SectorComparison.ProportionalComparison` — sector comparison
+* `TNLean.MPS.CanonicalForm.Assembly.ProportionalComparison` — sector comparison
   from BNT proportional-decomposition data.
 
 ## Main statements
@@ -60,7 +61,7 @@ The imported modules provide the canonical-form reduction theorems, including
 `bilateral_commonPeriod_blocking_tp_primitive_normal`, and
 `afterBlocking_structuralData_of_sameMPV₂`.
 
-This collection also records a conditional formulation of the
+This public entry point also records a conditional formulation of the
 Cirac--Pérez-García--Schuch--Verstraete after-blocking theorem that does not
 invoke the periodic Fundamental Theorem.  The structure
 `BlockedNormalFormHypotheses` names the source proof obligations (blocking
@@ -90,7 +91,7 @@ explicit hypotheses:
   summands at a common blocking length;
 * **Equality of the residual zero-block dimension** — the zero-tail
   contributions of the two blocked tensors must be identified;
-* **Matching of nonzero normal summands** — the BNT-cover comparison data
+* **Matching of nonzero normal summands** — the BNT comparison hypotheses
   links the two families of nonzero blocks; and
 * **The phase-gauge formula** — the conclusion delivers a permutation of
   basis sectors, matched multiplicities, and nonzero phases transforming
@@ -130,7 +131,7 @@ implicitly when the tensors are already in canonical form:
    adding the nonzero-part contributions;
 
 3. **Matching of nonzero normal summands** — for the produced nonzero-block
-   families there exist common primitive BNT-cover hypotheses linking the
+   families there exist common primitive BNT comparison hypotheses linking the
    two decompositions.
 
 The fourth source obligation, the phase-gauge formula, appears as the conclusion
@@ -141,7 +142,7 @@ The field `comparison` is supplied with structural evidence so the remaining
 assumptions cannot be applied to a different decomposition. -/
 structure BlockedNormalFormHypotheses
     {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop where
-  /-- The remaining BNT-cover comparison data for the produced common primitive
+  /-- The remaining BNT comparison hypotheses for the produced common primitive
   nonzero-sector families, with the structural evidence for trace preservation,
   primitivity, irreducibility, and positive bond dimensions supplied. -/
   comparison : ∀ {p zeroTailA zeroTailB rA rB : ℕ}
@@ -192,7 +193,7 @@ structure BlockedNormalFormHypotheses
 /-- Blocked normal-form sector matching: the conclusion of the after-blocking theorem.
 
 This structure records the fourth source proof obligation (the phase-gauge formula)
-together with the structural data that the blocked tensors admit matching BNT sector
+together with the structural data that the blocked tensors have matching BNT sector
 decompositions: after a common positive blocking length `p`, the two blocked tensors
 are represented by sector decompositions `P` and `Q` that carry BNT data, generate the
 same full MPV family, and agree with the blocked tensors at every positive length.
@@ -243,7 +244,7 @@ Let `A` and `B` generate the same MPV family.  Given the source proof obligation
 collected in `BlockedNormalFormHypotheses` (blocking to normal tensors, matching
 of nonzero normal summands, equality of the residual zero-block dimension), the
 conclusion `BlockedNormalFormSectorMatching` (the phase-gauge formula) follows:
-there is a positive blocking after which the two tensors admit BNT sector
+there is a positive blocking after which the two tensors have BNT sector
 decompositions with the same sector MPV family, matched basis-sector multiplicities,
 and matched sector-weight multisets up to nonzero phases.
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -10,8 +10,8 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 /-!
 # Common primitive proportional data
 
-This file records the span, phase-cover, and BNT-cover hypotheses for common
-primitive nonzero-sector families.  These structures express the remaining data
+This file records the span, phase-cover, and BNT comparison hypotheses for common
+primitive nonzero-sector families.  These structures express the remaining hypotheses
 needed to pass from the common-sector structural theorem to the BNT
 overlap-rigidity comparison.
 
@@ -74,7 +74,7 @@ end CommonPrimitiveSpanHypotheses
 /-- Remaining two-sided hypotheses for common primitive nonzero-sector families,
 formulated with a common MPV phase cover.
 
-This is the common-cover variant of `CommonPrimitiveSpanHypotheses`: the structural
+This is the common phase-cover variant of `CommonPrimitiveSpanHypotheses`: the structural
 theorem supplies the same primitive nonzero-sector data, while the remaining inputs
 are equality of the zero-tail dimensions, one-site injectivity on both sides, and a
 common phase cover for the two block families. -/
@@ -181,9 +181,10 @@ with nonzero weights and positive bond dimensions at a common blocking
 length.  The fields below record the additional BNT hypotheses needed
 to compare the two families and obtain a common MPV phase cover.
 
-For non-periodic tensors, the comparison is applied at the BNT-cover level:
-the representative/grouping choices are implementation details of the
-structural construction, not a separate paper-level hypothesis surface. -/
+For non-periodic tensors, these fields are exactly the BNT comparison hypotheses
+for the produced common-length sector families.  The representative and grouping
+choices belong to the structural construction, not to a separate source-paper
+hypothesis. -/
 structure CommonPrimitiveBNTCoverHypotheses
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -315,7 +316,7 @@ def ofCommonPrimitiveData_zeroTailIdentity
     hAntiA hAntiB hNotGpeA hNotGpeB
     (zeroTail_eq_of_proportionalDecompositionConclusion hZero hMatch) hInjA hInjB hDecomp
 
-/-- BNT-cover hypotheses produce a common MPV phase cover. -/
+/-- BNT comparison hypotheses produce a common MPV phase cover. -/
 lemma toMPVCommonPhaseCover
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
@@ -330,7 +331,7 @@ lemma toMPVCommonPhaseCover
     (d := blockPhysDim d p) blocksA blocksB
     h.ncfA h.notGpeA h.ncfB h.notGpeB h.decompData
 
-/-- BNT-cover hypotheses produce the common primitive phase-cover hypotheses. -/
+/-- BNT comparison hypotheses produce the common primitive phase-cover hypotheses. -/
 lemma toCommonPrimitivePhaseCoverHypotheses
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -606,7 +606,7 @@ exposed by `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_with_overlapOrtho
 The sector matching extraction is available from primitive overlap-rigidity
 hypotheses through `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching`.
 
-The current comparison route passes through
+The current comparison uses
 `afterBlocking_sectorComparison_zeroTail_of_blockSpan` and the common phase-cover
 or BNT comparison theorems. This avoids keeping separate common-block comparison
 variants as public waypoints: the formal residue is the paper-level residue,

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -608,7 +608,7 @@ hypotheses through `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching`
 
 The current comparison route passes through
 `afterBlocking_sectorComparison_zeroTail_of_blockSpan` and the common phase-cover
-or BNT-cover theorems. This avoids keeping separate common-block comparison
+or BNT comparison theorems. This avoids keeping separate common-block comparison
 variants as public waypoints: the formal residue is the paper-level residue,
 namely blocked-word relabeling, finite-length nonzero-block span comparison,
 and BNT sector matching.
@@ -622,7 +622,7 @@ formal work for the completely unconditional
 2. one-site injectivity of the nonzero-weight blocks, or a blocked replacement of the
    rigidity hypothesis; and
 3. equality of the finite-length MPV spans for the original nonzero-weight block families
-   (or directly for the two BNT bases), equivalently a common phase/BNT-cover comparison,
+   (or directly for the two BNT bases), equivalently a common phase/BNT comparison,
    followed by the final global gauge construction of the equal-case FT.
 
 Thus the common-period arithmetic, the blocked-word relabeling, the common

--- a/TNLean/MPS/CanonicalForm/SectorComparison/ProportionalComparison.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/ProportionalComparison.lean
@@ -23,16 +23,16 @@ by `∑ k, D_k ≤ D`, where the remaining summands are zero blocks.
   block-span sector comparison.
 * `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPhaseCover` — the
   common-length cyclic-sector output, together with the blocked-word relabeling
-  equality and the remaining zero-tail, injectivity, and common-cover assertions,
+  equality and the remaining zero-tail, injectivity, and common phase-cover assertions,
   implies the sector-weight comparison.
 * `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses` —
   the common primitive nonzero-sector theorem, followed by the remaining zero-tail,
   injectivity, and finite-length span hypotheses.
-* `CommonPrimitiveBNTCoverHypotheses` — bundles the BNT-level remaining hypotheses
+* `CommonPrimitiveBNTCoverHypotheses` — bundles the remaining BNT comparison hypotheses
   (`IsNormalCanonicalForm`, `BlocksNotGaugePhaseEquiv`, `ProportionalDecompositionData`,
   zero-tail equality, and one-site injectivity) for the common-length cyclic sector families.
   The structure provides `.toMPVCommonPhaseCover` and `.toCommonPrimitivePhaseCoverHypotheses`
-  bridges to the common phase-cover layer.
+  as the corresponding common phase-cover hypotheses.
   See the structure docstring for the explicit mathematical gaps that remain.
 
 ## References
@@ -54,8 +54,9 @@ obtained after blocked-word reindexing. If the remaining zero-tail equality, one
 injectivity, and finite-length span equality are supplied for those same families, then the
 zero-tail block-span comparison theorem gives the sector-weight conclusion.
 
-Keeping these comparison inputs explicit lets the same sector data be used after
-either a direct span certificate or a common-cover certificate has supplied it. -/
+Keeping these comparison inputs explicit lets the same sector family be used after
+either a direct span certificate or a common phase-cover certificate has supplied the span
+identity. -/
 lemma afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -210,11 +211,11 @@ lemma afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_commonPha
   exact (hRemaining hp hAblocks hBblocks hAPos hBPos hNonzeroPos hZero hμA hμB hTPA hTPB
     hPrimA hPrimB hIrrA hIrrB hDimA hDimB).toSpanHypotheses
 
-/-- **Sector comparison from relabeled common sectors and BNT-cover data.**
+/-- **Sector comparison from relabeled common sectors and BNT comparison hypotheses.**
 
 Assume the blocked-word relabeling statement for cyclic-sector data. The structural
 theorem supplies common primitive nonzero-sector families; if those families carry
-BNT-cover data, then the conversion to phase-cover hypotheses gives the common
+BNT comparison hypotheses, then the conversion to phase-cover hypotheses gives the common
 phase-cover hypotheses. The common-phase-cover comparison gives the same
 sector-weight comparison
 conclusion. -/
@@ -298,7 +299,7 @@ lemma afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_bntCover
 The lemmas below use `unconditional_commonPrimitiveIrreducibleBlocks` in place of
 `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`, removing the
 `CommonSectorRelabelingHypothesis d` requirement.  All remaining hypotheses (zero-tail equality,
-injectivity, finite-length span equality, BNT-cover data) remain explicitly conditional.
+injectivity, finite-length span equality, BNT comparison hypotheses) remain explicitly conditional.
 See `CommonPrimitiveProportionalData` for the paper-source references for each missing input. -/
 
 /-- **Sector comparison from unconditional common primitive blocks and span hypotheses.**

--- a/TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean
@@ -67,7 +67,7 @@ The after-blocking primitive block decomposition provides:
 The current library already settles the common-period blocking arithmetic and
 now has a one-sided phase-class BNT construction for TP primitive irreducible
 nonzero-weight blocks, one-sided overlap data, and zero-tail sector comparison
-from finite-length span or BNT-cover hypotheses. The theorem
+from finite-length span or BNT comparison hypotheses. The theorem
 `afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂`
 keeps the faithful paper order: first separate the all-zero leftover block and
 TP-gauge the irreducible nonzero-weight blocks, then remove each block's period by
@@ -77,7 +77,7 @@ finite blocking length used for common refinement or injectivity.
 
 The formal comparison uses the zero-tail block-span theorem
 `afterBlocking_sectorComparison_zeroTail_of_blockSpan` and the common
-phase-cover or BNT-cover theorems.  The mathematical assumptions are:
+phase-cover or BNT comparison theorems.  The mathematical assumptions are:
 zero-block cancellation, finite-length span equality, and BNT sector matching.
 
 The common-sector theorem then rewrites the cyclic sectors at one common

--- a/TNLean/MPS/FundamentalTheorem/Multi.lean
+++ b/TNLean/MPS/FundamentalTheorem/Multi.lean
@@ -190,9 +190,9 @@ lemma fundamentalTheorem_multiBlock_global
 
 end FundamentalTheoremMulti
 
-/-! ## Bridge to `CanonicalForm` -/
+/-! ## Comparison with `CanonicalForm` -/
 
-section CanonicalFormBridge
+section CanonicalFormComparison
 
 open CanonicalForm
 
@@ -209,7 +209,7 @@ theorem fundamentalTheorem_canonicalForm_sameStructure
   rw [C.toTensor_eq_toTensorFromBlocks]
   exact fundamentalTheorem_multiBlock_global C.μ C.blockTensor B hB_inj hSame
 
-end CanonicalFormBridge
+end CanonicalFormComparison
 
 /-! ## Converse and global `SameMPV` transfer -/
 

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -60,7 +60,7 @@ sector weights inside each basis block.
 
 The result formalized here is the BNT coefficient comparison that recovers both
 multiplicities and sector weights. A global gauge-equivalence statement for the
-assembled tensors still requires a theorem deriving the coefficient and phase
+block-diagonal tensors still requires a theorem deriving the coefficient and phase
 hypotheses required by the proportional decomposition theorem from bare equality
 of matrix-product vectors. In sector form the coefficients are finite sums of powers
 of unit-modulus weights, so convergence is not automatic without a dominant
@@ -288,7 +288,7 @@ lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis
 The sector-comparison theorems above take four separate hypotheses: a permutation
 of sector bases, equality of multiplicities, per-block dimension equality, and
 per-block gauge-phase equivalence. The structures below collect these into a
-single witness. Overlap/span hypotheses or common-cover phase hypotheses produce the
+single witness. Overlap/span hypotheses or common MPV phase-cover hypotheses produce the
 witness; the sector comparison then recovers the corresponding weight multisets.
 -/
 
@@ -321,10 +321,9 @@ This structure collects the four hypotheses required by
 * per-block bond-dimension equality, and
 * per-block gauge-phase equivalence of the (dimension-transported) basis blocks.
 
-**Formalization note.** The overlap/span route produces this witness when the
-corresponding comparison hypotheses are available. For sector decompositions
-obtained after blocking, those hypotheses may instead be supplied by an equivalent
-common-phase BNT-cover comparison. -/
+The overlap/span route produces this witness when the corresponding comparison hypotheses
+are available. For sector decompositions obtained after blocking, the same witness may be
+supplied by common-phase BNT comparison hypotheses. -/
 structure SectorBasisMatching (P Q : SectorDecomposition d) where
   /-- Permutation matching basis indices of `P` and `Q`. -/
   perm : Fin P.basisCount ≃ Fin Q.basisCount
@@ -596,8 +595,8 @@ Corollary of `fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_
 obtained by expressing the matching hypotheses as a `SectorBasisMatching`.
 The matching can be extracted from `SectorBasisOverlapSpanHypotheses`.
 
-**Formalization note.** For after-blocking sector decompositions, those hypotheses may
-instead be supplied by equivalent common-phase BNT-cover hypotheses. -/
+For after-blocking sector decompositions, those hypotheses may instead be supplied by
+common-phase BNT comparison hypotheses. -/
 theorem fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching
     {P Q : SectorDecomposition d}
     (M : SectorBasisMatching P Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -60,7 +60,7 @@ sector weights inside each basis block.
 
 The result formalized here is the BNT coefficient comparison that recovers both
 multiplicities and sector weights. A global gauge-equivalence statement for the
-block-diagonal tensors still requires a theorem deriving the coefficient and phase
+block-diagonal tensors still require a theorem deriving the coefficient and phase
 hypotheses required by the proportional decomposition theorem from bare equality
 of matrix-product vectors. In sector form the coefficients are finite sums of powers
 of unit-modulus weights, so convergence is not automatic without a dominant

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -407,8 +407,8 @@ finite-dimensional complex theorem
 	\quad\Longrightarrow\quad
 	\C\langle A^i\rangle = \MN{D}.
 \]
-The projection language in Definition~\ref{def:irreducible_tensor} is bridged
-to this subspace formulation first.
+We first translate the projection language in Definition~\ref{def:irreducible_tensor}
+to this subspace formulation.
 
 \begin{definition}[Algebra span]\label{def:alg_span}
 	\lean{MPSTensor.algSpan}\leanok
@@ -1144,7 +1144,7 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 	then gives the equivalence at length $N$ with weights $\mu_k^p$.
 \end{proof}
 
-\begin{theorem}[Blocking assembled weighted blocks]%
+\begin{theorem}[Blocking weighted block-diagonal tensors]%
 	\label{thm:block_tensor_to_tensor_from_blocks}
 	\lean{MPSTensor.sameMPV₂_blockTensor_toTensorFromBlocks}
 	\leanok
@@ -1156,7 +1156,7 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 
 \begin{proof}\leanok
 	Apply Theorem~\ref{thm:samempv_blocking_distributes} to the identity MPV
-	relation for the assembled weighted block tensor.
+	relation for the weighted block-diagonal tensor.
 \end{proof}
 
 \begin{theorem}[Positive-length MPV equality after blocking]%
@@ -1186,8 +1186,8 @@ summand $\mathbf{0}_{d,D_0}$ used to retain the $N=0$ MPV coefficient.
 \end{theorem}
 
 \begin{proof}\leanok
-	Use Theorem~\ref{thm:samempv2pos_block_tensor} for the assembled nonzero parts,
-	then rewrite each blocked assembled tensor by
+	Use Theorem~\ref{thm:samempv2pos_block_tensor} for the nonzero block-diagonal
+	parts, then rewrite each blocked block-diagonal tensor by
 	Theorem~\ref{thm:block_tensor_to_tensor_from_blocks}.
 \end{proof}
 
@@ -3492,8 +3492,8 @@ gauge-phase representatives and keeps those repeated weights explicit.
 \end{lemma}
 
 \begin{proof}\leanok
-	Apply Lemma~\ref{lem:zero_tail_decomp_block_tensor} to the assembled
-	weighted nonzero tensor and rewrite the blocked assembled tensor using
+	Apply Lemma~\ref{lem:zero_tail_decomp_block_tensor} to the weighted
+	nonzero block-diagonal tensor and rewrite the blocked block-diagonal tensor using
 	Theorem~\ref{thm:block_tensor_to_tensor_from_blocks}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -722,7 +722,7 @@ facts used to recover the lists of weights from those power sums.
 \begin{proof}
 	\leanok
 	\uses{lem:mpv_common_phase_cover_span_eq}
-	Apply the common-cover span lemma to the common phase cover constructed from
+	Apply the common phase-cover span lemma to the common phase cover constructed from
 	the pre-matching.
 \end{proof}
 
@@ -797,7 +797,7 @@ facts used to recover the lists of weights from those power sums.
 	\uses{lem:common_phase_cover_of_proportional_decomposition,
 		lem:mpv_common_phase_cover_span_eq}
 	First form the common MPV phase cover from the proportional-decomposition
-	comparison. The common-cover span lemma then gives the stated span equality.
+	comparison. The common phase-cover span lemma then gives the stated span equality.
 \end{proof}
 
 \begin{lemma}[Span equality from a bijective phase matching]%
@@ -813,7 +813,7 @@ facts used to recover the lists of weights from those power sums.
 \begin{proof}
 	\leanok
 	First form the common MPV phase cover from the bijective phase matching. The
-	common-cover span lemma then gives the stated span equality.
+	common phase-cover span lemma then gives the stated span equality.
 \end{proof}
 
 \begin{theorem}[Overlap-span hypotheses from a common phase cover]%
@@ -900,7 +900,7 @@ facts used to recover the lists of weights from those power sums.
 	\uses{lem:common_phase_cover_of_separated_normal_bnt,
 		lem:mpv_common_phase_cover_span_eq}
 	The separated normal-form comparison first gives a common MPV phase cover.
-	Applying the common-cover span lemma to that cover gives the span equality.
+	Applying the common phase-cover span lemma to that cover gives the span equality.
 \end{proof}
 
 \begin{theorem}[Sector comparison via a sector-basis matching]%
@@ -1403,7 +1403,7 @@ BNT comparison hypotheses for the common primitive sectors.
 	Lemma~\ref{lem:sector_basis_pre_matching_to_overlap_span}.  The BNT comparison
 	lemmas produce such common phases from a proportional-decomposition conclusion in
 	Lemmas~\ref{lem:common_phase_cover_of_proportional_decomposition}
-	and~\ref{lem:common_phase_cover_of_separated_normal_bnt}.  These common-cover
+	and~\ref{lem:common_phase_cover_of_separated_normal_bnt}.  These common phase-cover
 	facts are not a separate form of the source theorem; they are used only to
 	obtain the finite-length span equality required by the sector comparison.
 


### PR DESCRIPTION
### Motivation
- Replace process and software-engineering shorthand in canonical-form and fundamental-theorem prose with source-faithful mathematical terminology: block-diagonal tensor, common MPV phase cover, and BNT comparison hypotheses.
- Clarify that `zeroTailDim` packages the paper-source zero-block allowance, not a separate source-paper object.

### Description
- Updated docstrings and comments in `TNLean/MPS/CanonicalForm/` (BNTGrouping, BlockingViaAdjoint, Existence, PhaseCover, PhaseClassSectorData, Assembly modules), `TNLean/MPS/BNT/Construction`, and `TNLean/MPS/FundamentalTheorem/` (Multi, SectorDecomposition).
- Synced `blueprint/src/chapter/ch08_canonical.tex` and `blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` prose with the same mathematical terminology.
- Renamed one narrative section header (`CanonicalFormBridge` → `CanonicalFormComparison`) without changing any underlying APIs.

### Testing
- `lake env lean` checks passed for all modified Lean files.
- `leanblueprint web` built successfully.
- `git diff --check` clean.

---
Addresses #1334

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes across Lean and blueprint sources; no functional code or API behavior is altered, aside from a section-name rename that should not affect imports.
> 
> **Overview**
> Updates canonical-form and fundamental-theorem prose to use source-faithful mathematical terminology (e.g. *block-diagonal tensors*, *common MPV phase cover*, and *BNT comparison hypotheses*) instead of internal shorthand like “assembled blocks”/“BNT-cover”.
> 
> Clarifies docstrings around `toTensorFromBlocks`/`SectorDecomposition` relationships and the role of `zeroTailDim`, and renames the narrative section `CanonicalFormBridge` → `CanonicalFormComparison` (no underlying API changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1db60e144a996034d6e470a8e270d4bcb5dd45a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->