### PR TITLE
doc(Channel/PF): source-faithful formulas for quantum Perron Frobenius

### DIFF
--- a/TNLean/Channel/Irreducible/Ergodicity.lean
+++ b/TNLean/Channel/Irreducible/Ergodicity.lean
@@ -16,7 +16,11 @@ For a quantum channel `E : M_D(ℂ) → M_D(ℂ)`, we prove:
 * any subsequential limit of the Cesàro means is a density-matrix fixed point;
 * if `E` is irreducible, then there is a unique density-matrix fixed point `σ > 0`;
 * consequently, for every density matrix `ρ`,
-  `cesaroMean E ρ (N + 1) → σ` as `N → ∞`.
+
+$$\lim_{N \to \infty} \frac{1}{N} \sum_{t=0}^{N-1} E^t(\rho) = \sigma$$
+
+(Wolf Eq. 6.35). This is the quantum analogue of the classical ergodic theorem:
+the time average converges to a unique full-rank stationary state.
 
 The convergence proof avoids a full spectral/Jordan decomposition. Instead, it uses:
 

--- a/TNLean/Channel/Irreducible/FromSpectral.lean
+++ b/TNLean/Channel/Irreducible/FromSpectral.lean
@@ -15,6 +15,18 @@ import TNLean.Algebra.MatrixOperatorSpace
 This file collects Wolf's spectral characterization of irreducibility for
 completely positive maps on `M_D(ℂ)`.
 
+**Wolf Theorem 6.4** states: for a positive map `T` with spectral radius `%`,
+the following are equivalent:
+1. `T` is irreducible.
+2. The spectral radius `%` is a non-degenerate eigenvalue and the corresponding
+   right and left eigenvectors are positive definite, i.e.,
+   `T(X) = %X > 0` and `T*(Y) = %Y > 0`.
+
+The proof of `1 → 2` follows from Theorem 6.3 applied to `T` and `T*`.
+The converse `2 → 1` uses the similarity transformation Eq. (6.34) with
+`c = 1/%` and `C = Y^{-1/2}` to obtain a TP map with PD fixed point, then
+derives a contradiction from a hypothetical invariant projection.
+
 ## Main declarations
 
 * `HasSpectralProperties`:

--- a/TNLean/Channel/Irreducible/KrausSetup.lean
+++ b/TNLean/Channel/Irreducible/KrausSetup.lean
@@ -12,6 +12,13 @@ This file factors out the common boilerplate used when an irreducible
 completely positive map is converted into an irreducible Kraus family and then
 paired with the adjoint Perron--Frobenius eigenvector of that family.
 
+The adjoint eigenvector extraction (`exists_posDef_adjoint_eigenvector`)
+corresponds to applying **Wolf Theorem 6.3** items 2–4 to the dual map
+`T*`, obtaining a positive-definite left eigenvector for the Perron eigenvalue.
+This is used in the proofs of Theorem 6.3(3) (eigenvalue uniqueness via the
+dual-map trace argument, Eq. 6.33) and Theorem 6.3(4) (spectral radius identity
+via TP-gauge reduction).
+
 ## Main declarations
 
 - `IrreducibleCPKrausSetup`: shared Kraus witness for an irreducible CP map
@@ -21,6 +28,11 @@ paired with the adjoint Perron--Frobenius eigenvector of that family.
   setup has a nonzero Kraus operator
 - `IrreducibleCPKrausSetup.exists_posDef_adjoint_eigenvector`: shared adjoint
   Perron--Frobenius data extracted from an irreducible CP map
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2,
+  Theorem 6.3 (spectral radius of irreducible maps)][Wolf2012QChannels]
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Channel/Irreducible/Similarity.lean
+++ b/TNLean/Channel/Irreducible/Similarity.lean
@@ -172,6 +172,11 @@ private lemma not_posDef_of_conj_projection_ne_one
 if `E` is an irreducible CP map and `C` is an invertible matrix, then
 `X ↦ C⁻¹ * E (C * X * Cᴴ) * (Cᴴ)⁻¹` is also irreducible.
 
+In Wolf's notation (Eq. 6.34):
+`T'(·) := c C⁻¹ T(C · C†) C⁻†` is irreducible whenever `T` is irreducible,
+`c > 0`, and `C` is invertible. Our version covers the invertible-matrix case
+(the scalar factor `c` is handled by `isIrreducibleMap_full_similarity` below).
+
 The proof shows that any invariant projection `Q` for the similarity transform
 gives rise to a projection `P = supportProj(CQCᴴ)` that is invariant for `E`;
 irreducibility of `E` then forces `P = 0` or `P = 1`, which in turn forces

--- a/TNLean/Channel/Irreducible/TraceAdjoint.lean
+++ b/TNLean/Channel/Irreducible/TraceAdjoint.lean
@@ -9,7 +9,21 @@ import TNLean.MPS.Core.Transfer
 # Shared trace-adjoint auxiliary lemma for irreducible-channel developments
 
 This file factors out a common trace-pairing identity used in multiple
-irreducibility proofs.
+irreducibility proofs:
+
+`tr(σ · E(X)) = tr(E*(σ) · X)`
+
+where `E*(Y) = ∑ K_i* Y K_i` is the adjoint (Heisenberg-picture) map.
+
+This identity corresponds to **Wolf's Eq. (6.33)** in the proof of
+**Theorem 6.3(3)** (uniqueness of the positive eigenvalue): taking traces
+against a positive-definite left eigenvector `X' > 0` of `T*` gives
+`r tr(X' Y) = tr(X' T(Y)) = λ tr(X' Y)`, forcing `r = λ`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2,
+  proof of Theorem 6.3(3), Eq. (6.33)][Wolf2012QChannels]
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Channel/Peripheral/Spectrum.lean
+++ b/TNLean/Channel/Peripheral/Spectrum.lean
@@ -36,7 +36,10 @@ the eigenvalues on the unit circle.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2–6.3, Theorem 6.6][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2,
+  Theorem 6.6 (peripheral spectrum of irreducible Schwarz maps)][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.3,
+  Theorem 6.7 (primitive maps)][Wolf2012QChannels]
 * [arXiv:2011.12127, Section IV — peripheral spectrum structure]
 -/
 

--- a/TNLean/Channel/PerronFrobenius/Normalization.lean
+++ b/TNLean/Channel/PerronFrobenius/Normalization.lean
@@ -17,10 +17,25 @@ This module sets up the **normalization map**
 $$\rho \mapsto \frac{E(\rho)}{\operatorname{tr}(E(\rho))}$$
 
 on density matrices, together with the key denominator/nonvanishing lemmas
-needed for the Perron–Frobenius / TP-gauge existence step in
-arXiv:1606.00608, Appendix A.
+needed for the Perron–Frobenius / TP-gauge existence step.
 
-No fixed-point theorem is assumed here.
+The normalization map is the central construction in the Brouwer fixed-point
+proof of **Wolf Theorem 6.5** (spectral radius and positive eigenvectors): one
+considers the continuous self-map `ρ ↦ E(ρ) / tr(E(ρ))` on the compact convex set
+of density matrices; any fixed point yields an eigenvector identity
+`E(ρ) = tr(E(ρ)) · ρ`. The nonvanishing lemma
+`IsIrreducibleMap.map_posSemidef_ne_zero` provides the denominator-nonzero
+hypothesis for irreducible CP maps (used in **Wolf Theorem 6.3** item 2).
+
+No fixed-point theorem is assumed here — that is proved in
+`TNLean.Axioms.BrouwerFixedPoint` and consumed in
+`TNLean.Channel.PerronFrobenius.Existence`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2,
+  proof of Theorem 6.5 via Brouwer fixed point][Wolf2012QChannels]
+* [Cirac et al., arXiv:1606.00608, Appendix A][Cirac2017Annals]
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators TNMatrixCFC


### PR DESCRIPTION
### Motivation
- Audits docstrings in Channel/Irreducible/, Channel/Peripheral/, and Channel/PerronFrobenius/ for source-faithful Wolf Chapter 6 theorem references and formula citations; see LionSR/QICLean#152.
- Part of the broader source-faithful formulas audit tracking issue (#1404).

### Description
- **`Channel/PerronFrobenius/Normalization.lean`**: Added Wolf Theorem 6.5 (Brouwer fixed-point via normalization map) and Theorem 6.3 (nonvanishing for irreducible CP maps) references.
- **`Channel/Irreducible/KrausSetup.lean`**: Added Wolf Theorem 6.3 reference for adjoint Perron–Frobenius eigenvector extraction and Eq. (6.33) trace argument.
- **`Channel/Irreducible/TraceAdjoint.lean`**: Added Wolf Theorem 6.3(3) Eq. (6.33) reference for the trace-pairing identity $\operatorname{tr}(\sigma \cdot E(X)) = \operatorname{tr}(E^*(\sigma) \cdot X)$.
- **`Channel/Peripheral/Spectrum.lean`**: Split imprecise reference into separate citations: Theorem 6.6 in §6.2 and Theorem 6.7 in §6.3.
- **`Channel/Irreducible/Ergodicity.lean`**: Added Cesàro limit formula reference (Wolf Eq. 6.35).
- **`Channel/Irreducible/FromSpectral.lean`**: Added explicit formulation of Theorem 6.4 equivalence with right/left positive-definite eigenvector formulas.
- **`Channel/Irreducible/Similarity.lean`**: Added Wolf Eq. (6.34) similarity formula to Proposition 6.6 docstring.
- No definitions or proofs changed — documentation only.

### Testing
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Closes LionSR/QICLean#152

> [!NOTE]
> **Low Risk**
> Documentation-only updates: adds/clarifies Wolf theorem/equation references and math formulas without changing any definitions or proofs.
>
> **Overview**
> Adds source-faithful documentation across irreducibility/peripheral-spectrum/Perron–Frobenius modules, including explicit Cesàro-limit and similarity-transform formulas and clearer statements of Wolf Theorems 6.3–6.7.
>
> Tightens and expands reference citations (e.g., splitting peripheral-spectrum references between Theorems 6.6 and 6.7, and linking trace-adjoint and normalization-map lemmas to the specific Wolf equations 6.33–6.35) to better align the formalization with the source text.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75f45058681dba6a8c763b46bc690f6458bfcbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>