### PR TITLE
doc(MPS/FT): explain external inputs in non-periodic MPS FT proof route

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -46,6 +46,62 @@ What is **not** yet proved here:
 
 Accordingly, this file gives reduction lemmas and explicit conditional statements,
 **not** a complete canonical-form existence theorem for arbitrary input tensors.
+
+## External input — Quantum Wielandt strong irreducibility ⇒ full Kraus rank
+
+This file imports `TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank`,
+which supplies the hardest direction of the Quantum Wielandt primitivity equivalence:
+
+> **Proposition 3(c)→(b) of arXiv:0909.5347 / Wolf Theorem 6.7 case (iii).**
+> If `E_A` is **strongly irreducible** — the Kraus operators' word products
+> eventually span the full matrix algebra `M_D(ℂ)` — then the fixed-point
+> space of `E_A` has full Kraus rank: `dim S_1(A) = D` (the Kraus operators
+> themselves span `M_D(ℂ)` at word-length `1`).
+
+In MPS notation after blocking: `IsStronglyIrreducible A` (Kraus word products
+eventually span `M_D(ℂ)`) implies `IsInjective A` (the single-site
+Kraus operators `{A_i}` already span `M_D(ℂ)`).  This is a critical
+step in the canonical-form existence argument: it upgrades the cumulative word
+span to single-site injectivity, which then yields block injectivity at every
+positive length.
+
+The formal Lean declaration:
+
+> `Wielandt.Primitivity.StronglyIrreducibleToFullRank` proves the implication
+> `IsStronglyIrreduciblePaper A → krausRank A = D` (equivalently,
+> `wordSpan A 1 = ⊤`).  This is the paper-faithful proof of the hardest direction
+> in the Sanz–Pérez-García–Wolf–Cirac primitivity equivalence.
+
+## External input — Perez-Garcia et al. invariant subspace decomposition
+
+The iterated invariant-projection splitting in Section 2.3 (Wolf/Cirac/Verstraete
+canonical-form reduction) is formalized in `TNLean.MPS.Structure.InvariantSubspaceDecomp`.
+This external input provides:
+
+> **Perez-Garcia et al., quant-ph/0608197, Theorem 3 (lines 769–803).**
+> An invariant orthogonal projection `P` on the bond space (satisfying
+> `(1-P) A_i P = 0` for all `i`) yields an MPV-equivalent two-block direct-sum
+> tensor with strictly smaller block dimensions.
+
+The formal Lean declaration:
+
+> `MPSTensor.exists_twoBlock_decomp_of_lowerZero` produces a two-block
+> block-diagonal tensor MPV-equivalent to the original, with a strict dimension
+> decrease (`exists_strict_twoBlock_decomp_of_lowerZero`).
+
+## External input — Wolf spectral theory: Perron-Frobenius fixed point
+
+The Appendix A PF/TP gauge step uses the Perron-Frobenius theorem for
+completely positive maps (Wolf Chapter 6), formalized in
+`TNLean.Channel.PerronFrobenius.Existence`:
+
+> An irreducible CP map on `M_D(ℂ)` with spectral radius `1` has a
+> positive-definite fixed point `ρ > 0`.  This provides the TP gauge
+> transformation `A_i ↦ ρ^{1/2} A_i ρ^{-1/2}` that makes the
+> tensor left-canonical.
+
+The spectral-gap bridge to peripheral primitivity is supplied by
+`TNLean.MPS.Overlap.PeripheralToSpectralGap` (Wolf Proposition 6.8).
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -60,7 +60,7 @@ which supplies the hardest direction of the Quantum Wielandt primitivity equival
 
 In MPS notation after blocking: `IsStronglyIrreducible A` (Kraus word products
 eventually span `M_D(ℂ)`) implies `IsInjective A` (the single-site
-Kraus operators `{A_i}` already span `M_D(ℂ)`).  This is a critical
+Kraus operators `{A_i}` already span `M_D(ℂ)`).  This is a
 step in the canonical-form existence argument: it upgrades the cumulative word
 span to single-site injectivity, which then yields block injectivity at every
 positive length.
@@ -100,7 +100,7 @@ completely positive maps (Wolf Chapter 6), formalized in
 > transformation `A_i ↦ ρ^{1/2} A_i ρ^{-1/2}` that makes the
 > tensor left-canonical.
 
-The spectral-gap bridge to peripheral primitivity is supplied by
+The spectral-gap connection to peripheral primitivity is supplied by
 `TNLean.MPS.Overlap.PeripheralToSpectralGap` (Wolf Proposition 6.8).
 -/
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
@@ -55,6 +55,38 @@ primitive block decomposition.
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3 + Appendix A]
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:2011.12127, Section IV]
 
+## External inputs
+
+This file is the main integration point for the Quantum Wielandt machinery in the
+canonical-form reduction.  It imports four Wielandt modules:
+
+1. **`Wielandt.SpanGrowth.VectorToMatrixSpan`** — the vector-to-matrix spanning step
+   (arXiv:0909.5347, Lemma 2(a)/Wolf Chapter 6): if a vector-valued linear image of the
+   Kraus word products spans the full vector space, then the matrix-valued word products
+   span the full matrix algebra.
+
+2. **`Wielandt.SpanGrowth.CumulativeSpan`** — the cumulative span growth machinery
+   (arXiv:0909.5347, Lemma 1): the cumulative span `S_n(A)` grows strictly until it
+   reaches the full matrix algebra, with an explicit bound on the stopping time.
+
+3. **`Wielandt.RectangularSpan.Basic`** — the rectangular span theory for Wielandt
+   Lemma 2(b): provides the conditional assembly `wielandt_lemma2b_conditional` that
+   reduces the full-rank conclusion to finding a rank-one element in the word span.
+
+4. **`Wielandt.Primitivity.StronglyIrreducibleToFullRank`** — the hardest direction
+   of the primitivity equivalence (Proposition 3(a)→(c) of arXiv:0909.5347): strong
+   irreducibility of the transfer map implies `krausRank A = D`.
+
+5. **`Wielandt.Primitivity.ToNormal`** — the primitivity-to-normality implication:
+   when the peripheral spectrum condition is satisfied, the transfer map becomes normal
+   (commutes with its adjoint), which unlocks the full Wielandt chain.
+
+Together, these inputs supply the fact that a TP-primitive block (after the
+Perron-Frobenius gauge and periodicity blocking) is injective — its Kraus operators
+span the full matrix algebra at length 1, and therefore block-injective at every
+positive length.  This is the critical mathematical content that justifies the
+"primitive ⇒ injective" implication used in the blocked canonical-form decomposition.
+
 ## Tags
 
 matrix product states, canonical form, blocking, primitive transfer maps

--- a/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
@@ -84,7 +84,7 @@ canonical-form reduction.  It imports four Wielandt modules:
 Together, these inputs supply the fact that a TP-primitive block (after the
 Perron-Frobenius gauge and periodicity blocking) is injective — its Kraus operators
 span the full matrix algebra at length 1, and therefore block-injective at every
-positive length.  This is the critical mathematical content that justifies the
+positive length.  This is the mathematical content that justifies the
 "primitive ⇒ injective" implication used in the blocked canonical-form decomposition.
 
 ## Tags

--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -51,7 +51,7 @@ bound `n`.  This "cumulative span to top" is provided by the Wielandt chain:
 
 The formal Lean import is `TNLean.Wielandt.SpanGrowth.CumulativeSpan`, which
 provides `Wielandt.cumulativeSpan_eq_top_of_...` and the cumulative-to-word-span
-bridge `CumulativeToWordSpan`.  These are the declarations that make the
+connection `CumulativeToWordSpan`.  These are the declarations that make the
 finite-length word-span conclusion available inside the MPS proof route.
 -/
 

--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -24,6 +24,35 @@ hypothesis from all-length to finite-length agreement.
 ## References
 
 * Pérez-García, Verstraete, Wolf, Cirac, quant-ph/0608197
+* Sanz, Pérez-García, Wolf, Cirac, *A quantum version of Wielandt's inequality*,
+  arXiv:0909.5347, Theorem 1
+* Wolf, *Quantum Channels & Operations*, Theorem 6.9
+
+## External input — Quantum Wielandt cumulative span
+
+The proof that `SameMPVFrom N₀ A B` implies `SameMPV A B` relies on the
+Quantum Wielandt cumulative-span machinery (`Wielandt.SpanGrowth.CumulativeSpan`).
+The key mathematical consequence used here is:
+
+> **Quantum Wielandt (arXiv:0909.5347, Theorem 1 / Wolf Theorem 6.9).**
+> For a normal quantum channel $E_A$ on $M_D(\mathbb C)$, the Kraus operators'
+> word products of length $\le D^2$ span the full matrix algebra $M_D(\mathbb C)$
+> **unless** the channel is strictly non-expanding on the complement of its
+> peripheral eigenprojection.
+
+In MPS notation after blocking: for an injective tensor `A` (which is
+automatically normal up to a gauge), the finite-length word span
+`wordSpan A n` reaches the full matrix algebra $M_D(\mathbb C)$ for some explicit
+bound `n`.  This "cumulative span to top" is provided by the Wielandt chain:
+
+> `Wielandt.SpanGrowth.CumulativeToWordSpan` supplies the transition from
+> the cumulative Wielandt bound to a word-span theorem that `∃ n, wordSpan A n = ⊤`
+> (or more precisely, that `cumulativeSpan A n = ⊤` for some `n`).
+
+The formal Lean import is `TNLean.Wielandt.SpanGrowth.CumulativeSpan`, which
+provides `Wielandt.cumulativeSpan_eq_top_of_...` and the cumulative-to-word-span
+bridge `CumulativeToWordSpan`.  These are the declarations that make the
+finite-length word-span conclusion available inside the MPS proof route.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/FundamentalTheorem/ProportionalPrimitive.lean
+++ b/TNLean/MPS/FundamentalTheorem/ProportionalPrimitive.lean
@@ -28,10 +28,36 @@ implies irreducibility, left-canonicality is built in, and the spectral gap
 gives overlap convergence), the formulation here reduces the hypothesis count from
 7 to 4.
 
+## External input — Quantum Wielandt primitivity ⇒ irreducibility
+
+This file imports `TNLean.Wielandt.Primitivity.ImpliesIrreducible`, which
+supplies the Quantum Wielandt theorem that a primitive (aperiodic) transfer
+map yields irreducible Kraus operators:
+
+> **Quantum Wielandt, primitivity-to-irreducibility direction**
+> (arXiv:0909.5347, Proposition 3 / Wolf Theorem 6.7).
+> If `E_A` is primitive (has a unique peripheral eigenvalue `1`), then the
+> Kraus operators `{A_i}` are **irreducible**: their word products span the
+> full matrix algebra `M_D(ℂ)`.
+
+In MPS notation: `IsPrimitiveMPS A ρ` (primitive transfer map with PD fixed
+point `ρ`) implies `IsIrreducible A` (the Kraus operators `{A_i}` generate
+`M_D(ℂ)` as an algebra).  This implication is used here to eliminate the
+separate irreducibility hypothesis from the proportional FT statement.
+
+The formal Lean declaration that supplies this external input is:
+
+> `Wielandt.Primitivity.ImpliesIrreducible` provides the bridge from the
+> peripheral-spectrum primitivity predicate (`_root_.IsPrimitive`) to the
+> irreducibility conclusion.
+
 ## References
 
 - Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product States and Projected
   Entangled Pair States*, arXiv:2011.12127, Theorem 4.4
+- Sanz, Pérez-García, Wolf, Cirac, *A quantum version of Wielandt's inequality*,
+  arXiv:0909.5347, Proposition 3
+- Wolf, *Quantum Channels & Operations*, Theorem 6.7
 -/
 
 open scoped Matrix BigOperators ComplexOrder

--- a/TNLean/MPS/FundamentalTheorem/ProportionalPrimitive.lean
+++ b/TNLean/MPS/FundamentalTheorem/ProportionalPrimitive.lean
@@ -47,7 +47,7 @@ separate irreducibility hypothesis from the proportional FT statement.
 
 The formal Lean declaration that supplies this external input is:
 
-> `Wielandt.Primitivity.ImpliesIrreducible` provides the bridge from the
+> `Wielandt.Primitivity.ImpliesIrreducible` provides the connection from the
 > peripheral-spectrum primitivity predicate (`_root_.IsPrimitive`) to the
 > irreducibility conclusion.
 

--- a/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
+++ b/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
@@ -24,6 +24,29 @@ Concretely, for the transfer map of an injective normalized tensor `A`, we prove
 * peripheral primitivity implies a spectral gap for the complementary map `E - P`,
 * hence `MPSTensor.HasPrimitiveFixedPoint A` and the overlap convergence
   `mpvOverlap → 1`.
+
+## External input — Wolf spectral theory: Proposition 6.8
+
+The trace-zero fixed-point argument uses Wolf Proposition 6.8 from
+*Quantum Channels & Operations*, Chapter 6:
+
+> **Wolf Proposition 6.8 (PSD decomposition of Hermitian fixed points).**
+> If $E$ is a quantum channel and $H = H^\dagger$ is a Hermitian fixed point
+> ($E(H) = H$), then $H$ decomposes as $H = Q_1 - Q_2$ where both $Q_1, Q_2$
+> are positive semidefinite and also fixed by $E$.
+
+In MPS notation: for the transfer map $E_A(X) = \sum_i A_i X A_i^\dagger$ of a
+normalized tensor, any Hermitian fixed point $Y$ with $\operatorname{tr}(Y) = 0$
+decomposes into two PSD fixed points.  Combined with the unique-PD-fixed-point
+property of injective tensors (QPF), this forces $Y = 0$.
+
+The formal Lean declaration:
+
+> `IsChannel.posSemidef_parts_of_hermitian_fixedPoint` from
+> `TNLean.Channel.FixedPoint.Cesaro` supplies the PSD decomposition used in
+> `transferMap_hermitian_fixedPoint_eq_zero_of_trace_eq_zero` (line 93).
+> This is the Wolf Proposition 6.8 formalization consumed by the
+> peripheral-to-spectral-gap bridge.
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal

--- a/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
+++ b/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
@@ -46,7 +46,7 @@ The formal Lean declaration:
 > `TNLean.Channel.FixedPoint.Cesaro` supplies the PSD decomposition used in
 > `transferMap_hermitian_fixedPoint_eq_zero_of_trace_eq_zero` (line 93).
 > This is the Wolf Proposition 6.8 formalization consumed by the
-> peripheral-to-spectral-gap bridge.
+> peripheral-to-spectral-gap connection.
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -38,6 +38,31 @@ of the parent Hamiltonian (see `UniqueGroundState.lean`).
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, parent Hamiltonian section (lines 2013–2094)
 * [MPGSC18] arXiv:1804.04964, Section 3 (one-sided inverse)
 * [FNW92] Sections 3–4
+
+## External input — Quantum Wielandt cumulative-to-word-span
+
+This file imports `TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which supplies
+the bridge from the cumulative Wielandt bound to a concrete word-span theorem:
+
+> **Cumulative-to-word-span bridge (Wielandt chain, Lemma 2(b) of arXiv:0909.5347).**
+> The cumulative span `S_n(A)` is the linear span of all word products of length
+> `≤ n`.  `CumulativeToWordSpan` converts the statement "`S_n(A)` reaches the
+> full matrix algebra" into "`wordSpan A n = ⊤`" — i.e., the
+> word products of exactly length `n` (not just up to `n`) span `M_D(ℂ)`.
+
+In the intersection property proof: the injectivity of `groundSpaceMap A L`
+(for `L ≥ 1`) requires that `wordSpan A L = ⊤`.  The Wielandt machinery
+supplies this conclusion from the injectivity hypothesis `IsInjective A`:
+injectivity at length 1 implies word-span fullness at all positive lengths
+via the cumulative span chain, and `CumulativeToWordSpan` upgrades the
+cumulative conclusion to an exact-length word-span theorem.
+
+The formal Lean declaration:
+
+> `Wielandt.SpanGrowth.CumulativeToWordSpan` supplies the lemma
+> `cumulativeSpan_eq_top_iff_wordSpan_eq_top` and related declarations that
+> connect cumulative and exact-length span.  These are consumed by the
+> ground-space injectivity proof `groundSpaceMap_injective`.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -42,9 +42,9 @@ of the parent Hamiltonian (see `UniqueGroundState.lean`).
 ## External input — Quantum Wielandt cumulative-to-word-span
 
 This file imports `TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which supplies
-the bridge from the cumulative Wielandt bound to a concrete word-span theorem:
+the connection from the cumulative Wielandt bound to a concrete word-span theorem:
 
-> **Cumulative-to-word-span bridge (Wielandt chain, Lemma 2(b) of arXiv:0909.5347).**
+> **Cumulative-to-word-span connection (Wielandt chain, Lemma 2(b) of arXiv:0909.5347).**
 > The cumulative span `S_n(A)` is the linear span of all word products of length
 > `≤ n`.  `CumulativeToWordSpan` converts the statement "`S_n(A)` reaches the
 > full matrix algebra" into "`wordSpan A n = ⊤`" — i.e., the

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -80,7 +80,7 @@ argument.
 The formal Lean declaration:
 
 > `wrapped_mirror_witness_agree_of_chainGroundSpace` is the **unproven gap**
-> at line 749 of this file.  It is the remaining hard step in the proof of
+> at line 786 of this file.  It is the remaining hard step in the proof of
 > `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.  Once supplied,
 > it yields the normal-range reduction
 > `chainGroundSpace A L N = mpvSubmodule A N` for `L > L₀` (instead of `2L₀`).
@@ -97,7 +97,7 @@ The supplementary files providing the open-chain build-up to this closure proper
 
 This file imports `TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which supplies:
 
-> **Wielandt cumulative-to-word-span bridge.**  The Wielandt chain
+> **Wielandt cumulative-to-word-span connection.**  The Wielandt chain
 > (`WielandtBound.lean`) proves that under normality, the cumulative span
 > `S_n(A)` reaches the full matrix algebra for some `n ≤ D²`.
 > `CumulativeToWordSpan` converts this cumulative conclusion to a word-span
@@ -107,7 +107,7 @@ This file imports `TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which suppl
 
 The formal Lean declaration:
 
-> `Wielandt.SpanGrowth.CumulativeToWordSpan` supplies the bridge from
+> `Wielandt.SpanGrowth.CumulativeToWordSpan` supplies the connection from
 > `cumulativeSpan_eq_top` to `wordSpan_eq_top`, the concrete word-span conclusion
 > consumed by the parent-Hamiltonian ground-space uniqueness argument.
 -/

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -54,6 +54,62 @@ with the periodic boundary condition:
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, lines 2013–2094 (full argument)
 * [FNW92] Sections 3–4
 * [PGVWC07] arXiv:quant-ph/0608197, Sections 5–6
+
+## External inputs
+
+### CPGSV closure property (§IV.C of arXiv:2011.12127)
+
+The theorem `wrapped_mirror_witness_agree_of_chainGroundSpace` is the formalization of the
+**closure-property comparison** from Cirac–Pérez-García–Schuch–Verstraete (2021), §IV.C:
+
+> **CPGSV21, Section IV.C (lines 2049–2078).**  On a periodic chain, the two
+> wrapped-boundary witnesses extracted from a chain ground state (one from the
+> left-cyclic window, one from the right-cyclic window) must agree when their
+> complements are reindexed to a common middle word.  This agreement follows
+> because the two cyclic restrictions differ only by a cyclic shift, and the
+> boundary matrix is simultaneously constrained by all interior windows.
+
+In MPS notation after blocking: for an `L₀`-block-injective tensor `A` on a
+periodic chain of `N` sites with window size `L > L₀`, a chain ground state
+`ψ = groundSpaceMap A N X` induces two families of boundary matrices
+`Y_wrap, Y_mirror` satisfying universal word compatibility relations.  The CPGSV
+closure property states that these two families must agree on every common middle
+word `μ`, yielding the key comparison identity needed to close the range-reduction
+argument.
+
+The formal Lean declaration:
+
+> `wrapped_mirror_witness_agree_of_chainGroundSpace` is the **unproven gap**
+> at line 749 of this file.  It is the remaining hard step in the proof of
+> `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.  Once supplied,
+> it yields the normal-range reduction
+> `chainGroundSpace A L N = mpvSubmodule A N` for `L > L₀` (instead of `2L₀`).
+
+The supplementary files providing the open-chain build-up to this closure property are:
+
+* `TNLean.MPS.ParentHamiltonian.ExtendRight` — the right-extension (grow-back) step
+  that extracts a common right factor from universal word compatibility
+  (CPGSV21, lines 2049–2078).
+* `TNLean.MPS.ParentHamiltonian.SuffixWindow` — suffix-window restrictions and
+  the existence of left-tail compatibility families.
+
+### Quantum Wielandt cumulative-to-word-span
+
+This file imports `TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which supplies:
+
+> **Wielandt cumulative-to-word-span bridge.**  The Wielandt chain
+> (`WielandtBound.lean`) proves that under normality, the cumulative span
+> `S_n(A)` reaches the full matrix algebra for some `n ≤ D²`.
+> `CumulativeToWordSpan` converts this cumulative conclusion to a word-span
+> theorem: `∃ n, wordSpan A n = ⊤`.  This is used in the unique-ground-state
+> argument to deduce that sufficiently long word products of the Kraus operators
+> span `M_D(ℂ)`, which forces the boundary matrix to be a scalar.
+
+The formal Lean declaration:
+
+> `Wielandt.SpanGrowth.CumulativeToWordSpan` supplies the bridge from
+> `cumulativeSpan_eq_top` to `wordSpan_eq_top`, the concrete word-span conclusion
+> consumed by the parent-Hamiltonian ground-space uniqueness argument.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -58,6 +58,31 @@ proceeds as follows:
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, lines 2013–2094
 * [FNW92] Sections 3–4
+
+## External input — Quantum Wielandt vector-to-matrix span
+
+This file imports `TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan`, which supplies
+the critical spanning step used in the wrapping-window argument:
+
+> **Vector-to-matrix spanning step (arXiv:0909.5347, Lemma 2(a) / Wolf Chapter 6).**
+> If the vector-valued images of Kraus word products span the full vector space
+> `ℂ^D`, then the matrix-valued word products span the full matrix
+> algebra `M_D(ℂ)`.  Concretely: `span{A_w v} = ℂ^D` for all `v ≠ 0` implies
+> `span{A_w} = M_D(ℂ)`.
+
+In MPS notation after blocking: for an injective tensor `A`, the Kraus word
+products of length `L-1` span `M_D(ℂ)` (`wordSpan A (L-1) = ⊤`).
+This spanning conclusion is what allows the proof to extend the word-compatibility
+identity from `evalWord` values to arbitrary matrices `M₁`, yielding the
+commutation condition `X M₁ = M₁ X` for all matrices `M₁`, hence
+`X A_j = A_j X` for each generator.
+
+The formal Lean declaration:
+
+> `Wielandt.SpanGrowth.VectorToMatrixSpan` provides the lemmas that turn
+> a vector-span hypothesis into a matrix-span conclusion.  In the wrapping-window
+> proof, this is applied after the injectivity hypothesis `IsInjective A` gives
+> `wordSpan A (L-1) = ⊤` via `wordSpan_eq_top_of_isInjective`.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -62,7 +62,7 @@ proceeds as follows:
 ## External input — Quantum Wielandt vector-to-matrix span
 
 This file imports `TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan`, which supplies
-the critical spanning step used in the wrapping-window argument:
+the spanning step used in the wrapping-window argument:
 
 > **Vector-to-matrix spanning step (arXiv:0909.5347, Lemma 2(a) / Wolf Chapter 6).**
 > If the vector-valued images of Kraus word products span the full vector space

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -18,6 +18,30 @@ equivalent to a block-diagonal tensor with two smaller bond dimensions.
 
 This is the "invariant subspace ⇒ direct sum decomposition" step used in canonical-form existence
 arguments before blocking/normalization.
+
+## External input — Perez-Garcia et al. canonical-form recursion
+
+This file formalizes the invariant-subspace decomposition from two sources:
+
+> **Perez-Garcia et al., quant-ph/0608197, Theorem 3 (lines 769–803).**
+> The recursion on bond dimension: a PSD fixed point of the transfer map yields an
+> invariant support projection; after block-diagonalization, the tensor splits into
+> a direct sum of smaller blocks.  The strict dimension decrease
+> (`exists_strict_twoBlock_decomp_of_lowerZero`) guarantees termination of the
+> canonical-form recursion.
+
+> **Cirac et al., arXiv:1606.00608, Section 2.3.**
+> The same step in the "canonical forms" reduction: invariant projection ⇒
+> block upper-triangular ⇒ drop strict off-diagonal blocks ⇒ explicit 2-block
+> direct sum.  This is the Wolf/Cirac/Verstraete canonical-form reduction.
+
+The formal Lean declarations:
+
+* `exists_twoBlock_decomp_of_lowerZero` — invariant projection ⇒ two-block direct sum
+  with MPV equivalence (`SameMPV₂`)
+* `exists_strict_twoBlock_decomp_of_lowerZero` — the strict dimension decrease variant
+  (both block dimensions strictly smaller than `D`), which is the key ingredient for
+  proving termination of the canonical-form recursion
 -/
 
 open scoped Matrix BigOperators


### PR DESCRIPTION
### Motivation

- Documents the external mathematical results used in the non-periodic MPS Fundamental Theorem proof chain, as identified in #1278.
- Part of the broader FT, BNT, canonical-form, and Wielandt cleanup (#1170).

### Description

- Adds module-level documentation to 9 files identifying four categories of external mathematical input:
  - **Quantum Wielandt** (arXiv:0909.5347, Wolf Chapter 6): cumulative span (FiniteLength.lean), primitivity to irreducibility (ProportionalPrimitive.lean), strong irreducibility to full Kraus rank (Existence.lean), all Wielandt imports (TPPrimitiveReduction.lean), cumulative-to-word-span (IntersectionProperty.lean), vector-to-matrix span (WrappingWindow.lean).
  - **Pérez-García direct sum** (quant-ph/0608197): invariant subspace decomposition (InvariantSubspaceDecomp.lean), canonical-form recursion (Existence.lean).
  - **Wolf spectral theory** (Wolf, Quantum Channels & Operations, Chapter 6): Proposition 6.8 PSD decomposition (PeripheralToSpectralGap.lean), Perron–Frobenius fixed point (Existence.lean).
  - **CPGSV closure property** (arXiv:2011.12127, §IV.C): wrapped-mirror witness comparison (UniqueGroundState.lean).
- Each section states the mathematical statement, hypotheses in MPS notation after blocking/reindexing, proof idea with source citation, and the formal Lean declaration.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate that the documentation additions do not break the build.
- No proof logic is modified; additions are documentation-only.

---
Closes #1278

> [!NOTE]
> **Low Risk**
> Documentation-only changes adding citations and explanations of where external Quantum Wielandt / Wolf / Pérez-García results are used; no proof logic or API behavior is modified.
> 
> **Overview**
> Adds **detailed module-level documentation** across the MPS canonical-form, fundamental-theorem, overlap, and parent-Hamiltonian proof files to explicitly call out *external mathematical inputs* (Quantum Wielandt span/primitivity results, Pérez-García invariant-subspace decomposition, and Wolf spectral/Perron–Frobenius tools).
> 
> The new docs include precise paper/theorem citations and point to the corresponding Lean imports/lemmas that supply each input, clarifying how these results are threaded through the non-periodic FT and canonical-form reduction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6ab1419a1f33822cbf16aab0cad591200299db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions that annotate where external Quantum Wielandt/Wolf/Pérez-García results are imported and used; no proof logic or APIs are changed.
> 
> **Overview**
> Adds extensive module-level documentation across canonical-form, fundamental-theorem, overlap, and parent-Hamiltonian files to explicitly cite *external mathematical inputs* (Quantum Wielandt span/primitivity results, Wolf spectral/PF theorems, and Pérez-García invariant-subspace decomposition/recursion).
> 
> These new sections describe the referenced theorems, how they map into the MPS notation used in the repo, and point to the specific Lean imports/lemmas providing each input, clarifying proof dependencies without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c00014c2896fa4f790b32b9ebd2aa3baf38e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->