### PR TITLE
doc(Entropy): source-faithful formulas for entropy chapter

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -51,10 +51,13 @@ specialized to `Fin d × Fin d'` indices.
 
 ## References
 
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
+  (Distance Measures), Section 8.2 (Entropies)][Wolf2012QChannels]
 * Lieb, Ruskai, "Proof of the strong subadditivity of quantum-mechanical
-  entropy", JMP 14, 1938 (1973)
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*][Wolf2012QChannels]
-* arXiv:1606.00608 Section 4.4
+  entropy", JMP 14, 1938 (1973) — source of SSA
+* arXiv:1606.00608 Section 4.4 — MPDO target paper entropy chapter
+* Blueprint Chapter 4 (Quantum Entropy): `ch04b_entropy.tex`,
+  `ch04c_entropy_corollaries.tex`
 -/
 
 open scoped Matrix ComplexOrder
@@ -71,8 +74,11 @@ variable {n : Type*} [Fintype n] [DecidableEq n]
 For a Hermitian matrix `ρ` with eigenvalues `λᵢ`, the von Neumann entropy is
 `S(ρ) = ∑ᵢ negMulLog(λᵢ) = -∑ᵢ λᵢ log(λᵢ)`.
 
-When `ρ` is a density matrix (PSD with trace 1), this gives the standard
-quantum entropy `S(ρ) = -tr(ρ log ρ)`. -/
+When `ρ` is a density matrix (PSD with trace 1), this equals the standard
+quantum entropy `S(ρ) = -tr(ρ log ρ)`.
+
+Source: [Wolf, Chapter 8, Section 8.2 (Entropies), Eq. (8.15)][Wolf2012QChannels];
+blueprint `def:von_neumann_entropy`. -/
 noncomputable def vonNeumannEntropy
     (ρ : Matrix n n ℂ) (hρ : ρ.IsHermitian) : ℝ :=
   ∑ i, negMulLog (hρ.eigenvalues i)
@@ -107,7 +113,10 @@ theorem densityMatrices_eigenvalues_le_one
 /-- Von Neumann entropy is nonneg for density matrices.
 
 Each eigenvalue `λᵢ` of a density matrix satisfies `0 ≤ λᵢ ≤ 1`, and
-`negMulLog` is nonneg on `[0, 1]`. -/
+`negMulLog` is nonneg on `[0, 1]`.
+
+Source: [Wolf, Chapter 8, Section 8.2][Wolf2012QChannels];
+blueprint `thm:entropy_nonneg`. -/
 theorem vonNeumannEntropy_nonneg
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D) :
     0 ≤ vonNeumannEntropy ρ hρ.1.isHermitian := by
@@ -120,7 +129,10 @@ theorem vonNeumannEntropy_nonneg
 
 Proved via Jensen's inequality (`ConcaveOn.le_map_sum` applied to
 `concaveOn_negMulLog`): the entropy is maximized when all eigenvalues
-are equal to `1/D`, giving `S(ρ) ≤ D · negMulLog(1/D) = log D`. -/
+are equal to `1/D`, giving `S(ρ) ≤ D · negMulLog(1/D) = log D`.
+
+Source: [Wolf, Chapter 8, Section 8.2][Wolf2012QChannels];
+blueprint `thm:entropy_le_log_dim`. -/
 theorem vonNeumannEntropy_le_log_dim
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
     (hD : 0 < D) :
@@ -164,7 +176,10 @@ end VonNeumannEntropyFinD
 
 Partial traces for tripartite systems `A ⊗ B ⊗ C`, defined directly via
 summation over the traced-out indices. The tripartite state is indexed by
-`Fin dA × Fin dB × Fin dC` (right-associated: `Fin dA × (Fin dB × Fin dC)`). -/
+`Fin dA × Fin dB × Fin dC` (right-associated: `Fin dA × (Fin dB × Fin dC)`).
+
+Source: blueprint `def:traceA_ABC`, `def:traceC_ABC`, `def:traceAC_ABC`;
+standard quantum-information texts (e.g., [Wolf, Chapter 1][Wolf2012QChannels]). -/
 
 section TripartiteTrace
 
@@ -292,8 +307,12 @@ end BipartiteHermiticity
 /-! ## SSA equality condition
 
 The Hayashi (2003) characterization of equality in strong subadditivity is
-defined as a predicate. The characterization theorem (equality ↔ recovery map
-condition) is deferred.
+defined as a predicate. The theorem (equality ↔ recovery map condition) is the
+sanctioned axiom `hayashi_ssa_equality_characterization` in
+`TNLean/Axioms/Entropy.lean`.
+
+Source: Hayashi, J. Phys. A: Math. Gen. 37 (2004) L205--L208;
+blueprint `def:ssa_equality`.
 
 TODO: Replace with a proof following Hayashi, "Quantum Information: An
 Introduction", Springer 2006, Theorem 5.24. -/
@@ -304,7 +323,13 @@ variable {dA dB dC : ℕ}
 
 /-- Predicate asserting that equality holds in strong subadditivity for a
 tripartite state `ρ_ABC`. Hermiticity of reduced states is derived
-automatically from `hρ_ABC` via partial-trace preservation lemmas. -/
+automatically from `hρ_ABC` via partial-trace preservation lemmas.
+
+Formula: `S(ρ_ABC) + S(ρ_B) = S(ρ_AB) + S(ρ_BC)`.
+
+Source: blueprint `def:ssa_equality`;
+Lieb--Ruskai, JMP 14, 1938 (1973);
+Hayashi, J. Phys. A: Math. Gen. 37 (2004) L205--L208. -/
 def IsSSAEquality
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
@@ -328,7 +353,10 @@ variable {dA dB : ℕ}
 
 Measures the total correlations (classical + quantum) between A and B.
 Hermiticity of reduced states is derived from `hρ_AB` via partial-trace
-preservation lemmas. -/
+preservation lemmas.
+
+Source: [Wolf, Chapter 8][Wolf2012QChannels];
+blueprint `def:mutual_information`. -/
 noncomputable def mutualInformation
     (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
     (hρ_AB : ρ_AB.IsHermitian) : ℝ :=

--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -42,12 +42,17 @@ case of strong subadditivity. A faithful formalization is expected to require:
 ## References
 
 * Lieb, Ruskai, "Proof of the strong subadditivity of quantum-mechanical
-  entropy", JMP 14, 1938 (1973)
-* Hayashi, J. Phys. A: Math. Gen. 37 (2004) L205--L208
+  entropy", JMP 14, 1938 (1973) — source of SSA
+* Hayashi, J. Phys. A: Math. Gen. 37 (2004) L205--L208 — SSA equality
 * Ruskai, "Inequalities for quantum entropy: A review with conditions for
   equality", JMP 43, 4358 (2002)
 * Hayden, Jozsa, Petz, Winter, Commun. Math. Phys. 246, 359--374 (2004)
   (the structural formulation cited as `Hay03` in arXiv:1606.00608 Appendix C)
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
+  (Distance Measures)][Wolf2012QChannels]
+* arXiv:1606.00608 Appendix C — downstream target of MPDO entropy input
+* Blueprint `ch04b_entropy.tex` (Quantum Entropy chapter): `thm:strong_subadditivity`,
+  `def:hayashi_markov_decomposition`, `thm:hayashi_ssa_equality_characterization`
 -/
 
 open scoped Matrix ComplexOrder
@@ -126,7 +131,11 @@ system `B`, an explicit unitary basis change on `B`, probabilities `p_j`, and
 left/right density matrices `ρ_{A B_jᴸ}` and `ρ_{B_jᴿ C}` such that after
 conjugating `ρ_ABC` by `1_A ⊗ U_B ⊗ 1_C` and reindexing `B` along the chosen
 finite decomposition, the state becomes the block-diagonal direct sum
-`⊕_j p_j (ρ_{A B_jᴸ} ⊗ ρ_{B_jᴿ C})`. -/
+`⊕_j p_j (ρ_{A B_jᴸ} ⊗ ρ_{B_jᴿ C})`.
+
+Source: Hayashi, J. Phys. A: Math. Gen. 37 (2004) L205--L208;
+Hayden--Jozsa--Petz--Winter, Commun. Math. Phys. 246, 359--374 (2004);
+blueprint `def:hayashi_markov_decomposition`. -/
 structure HayashiMarkovDecomposition {dA dB dC : ℕ}
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ) where
@@ -174,8 +183,9 @@ This is axiomatized; see the module docstring for the deferred proof plan.
 Hermiticity of reduced states is derived via `traceA_ABC_isHermitian` etc.
 from `hρ_dm.1.isHermitian`.
 
-References:
-* Lieb, Ruskai, JMP 14, 1938 (1973) -/
+Source: Lieb, Ruskai, JMP 14, 1938 (1973);
+[Wolf, Chapter 8, Section 8.7 (Contractivity and the increase of entropy)][Wolf2012QChannels];
+blueprint `thm:strong_subadditivity`. -/
 axiom strong_subadditivity
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
@@ -216,10 +226,11 @@ operator-algebra and recovery-map theory that is not yet formalized in
 Mathlib or in this repository. Downstream consumers should import the theorem
 statement from `TNLean/Entropy/MarkovChain.lean`, not this axiom module.
 
-References:
-* Hayashi, J. Phys. A: Math. Gen. 37 (2004) L205--L208
-* Ruskai, JMP 43, 4358 (2002)
-* Hayden, Jozsa, Petz, Winter, Commun. Math. Phys. 246, 359--374 (2004) -/
+Source: Hayashi, J. Phys. A: Math. Gen. 37 (2004) L205--L208;
+Ruskai, JMP 43, 4358 (2002);
+Hayden--Jozsa--Petz--Winter, Commun. Math. Phys. 246, 359--374 (2004);
+arXiv:1606.00608 Appendix C;
+blueprint `thm:hayashi_ssa_equality_characterization`. -/
 axiom hayashi_ssa_equality_characterization
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/Entropy/MarkovChain.lean
+++ b/TNLean/Entropy/MarkovChain.lean
@@ -41,6 +41,8 @@ the namespace abbreviation for the quantum-Markov-chain decomposition.
   equality", JMP 43, 4358 (2002)
 * Hayden, Jozsa, Petz, Winter, Commun. Math. Phys. 246, 359--374 (2004)
 * arXiv:1606.00608 Appendix C (the downstream target of issue #632 / #236)
+* Blueprint `def:entropy_quantum_markov_decomposition`,
+  `thm:entropy_ssa_equality_quantum_markov`
 -/
 
 open scoped Matrix ComplexOrder
@@ -53,7 +55,9 @@ section MarkovChain
 variable {dA dB dC : ℕ}
 
 /-- Namespace abbreviation for the quantum-Markov-chain decomposition witness
-associated to equality in strong subadditivity. -/
+associated to equality in strong subadditivity.
+
+Source: blueprint `def:entropy_quantum_markov_decomposition`. -/
 abbrev QuantumMarkovDecomposition
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ) : Type :=
@@ -64,7 +68,9 @@ quantum-Markov-chain decomposition on the middle subsystem.
 
 This is a statement of the sanctioned axiom
 `_root_.hayashi_ssa_equality_characterization`; no new axiom is introduced by
-this file. -/
+this file.
+
+Source: blueprint `thm:entropy_ssa_equality_quantum_markov`. -/
 theorem ssaEquality_iff_exists_quantumMarkovDecomposition
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/Entropy/MutualInformation.lean
+++ b/TNLean/Entropy/MutualInformation.lean
@@ -32,8 +32,9 @@ entropy namespace used by the Simple MPDO RFP track
 
 ## References
 
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8][Wolf2012QChannels]
 * arXiv:1606.00608 Section 4.4 (Proposition 4.5)
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*][Wolf2012QChannels]
+* Blueprint `def:entropy_mutual_information`, `thm:mutual_information_nonneg`
 -/
 
 open scoped Matrix ComplexOrder
@@ -45,7 +46,9 @@ namespace Entropy
 namespaced alias.
 
 `I(A:B) = S(ρ_A) + S(ρ_B) − S(ρ_AB)` measures the total correlations
-between A and B. Definitionally equal to `_root_.mutualInformation`. -/
+between A and B. Definitionally equal to `_root_.mutualInformation`.
+
+Source: blueprint `def:entropy_mutual_information`. -/
 noncomputable alias mutualInformation := _root_.mutualInformation
 
 /-! ## Nonnegativity via subadditivity (trivial-middle form)
@@ -65,7 +68,9 @@ variable {dA dC : ℕ}
 
 /-- Mutual information is nonneg in the tripartite trivial-middle
 form: `S(ρ_AB) + S(ρ_BC) − S(ρ_ABC) ≥ 0`. Direct corollary of
-`subadditivity_ssa_trivial_B`. -/
+`subadditivity_ssa_trivial_B`.
+
+Source: blueprint `thm:mutual_information_nonneg`. -/
 theorem mutualInformation_ssa_trivial_B_nonneg
     (ρ_ABC : Matrix (Fin dA × Fin 1 × Fin dC)
       (Fin dA × Fin 1 × Fin dC) ℂ)

--- a/TNLean/Entropy/StrongSubadditivity.lean
+++ b/TNLean/Entropy/StrongSubadditivity.lean
@@ -58,9 +58,12 @@ A review with conditions for equality", JMP 43, 4358 (2002).
 ## References
 
 * Lieb, Ruskai, "Proof of the strong subadditivity of quantum-mechanical
-  entropy", JMP 14, 1938 (1973)
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*][Wolf2012QChannels]
+  entropy", JMP 14, 1938 (1973) — source of SSA
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8][Wolf2012QChannels]
 * arXiv:1606.00608 Section 4.4
+* Blueprint `thm:entropy_strong_subadditivity`,
+  `thm:entropy_subadditivity_trivial_B`,
+  `thm:entropy_fin_one_zero`
 -/
 
 open scoped Matrix ComplexOrder
@@ -89,8 +92,8 @@ This theorem forwards the sanctioned axiom
 new axiom is introduced by this module. See the module-level TODO for
 the roadmap replacing the underlying axiom with a proof.
 
-References:
-* Lieb, Ruskai, JMP 14, 1938 (1973). -/
+Source: Lieb, Ruskai, JMP 14, 1938 (1973);
+blueprint `thm:entropy_strong_subadditivity`. -/
 theorem strongSubadditivity
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
@@ -108,7 +111,9 @@ theorem strongSubadditivity
 "conditional entropy" form: `S(ρ_ABC) − S(ρ_AB) ≤ S(ρ_BC) − S(ρ_B)`.
 
 This follows from the axiom by adding `−S(ρ_AB) − S(ρ_B)` to both
-sides of the basic SSA inequality. -/
+sides of the basic SSA inequality.
+
+Source: [Wolf, Chapter 8, Section 8.7][Wolf2012QChannels]. -/
 theorem strongSubadditivity_rearranged
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
@@ -138,7 +143,9 @@ section FinOneEntropy
 von Neumann entropy.
 
 The single eigenvalue equals the trace (which is `1`), and
-`negMulLog 1 = -(1 * log 1) = 0`. -/
+`negMulLog 1 = -(1 * log 1) = 0`.
+
+Source: blueprint `thm:entropy_fin_one_zero`. -/
 theorem vonNeumannEntropy_eq_zero_of_fin_one
     (M : Matrix (Fin 1) (Fin 1) ℂ)
     (hM : M.IsHermitian) (hM_trace : M.trace = 1) :

--- a/TNLean/Entropy/StrongSubadditivity.lean
+++ b/TNLean/Entropy/StrongSubadditivity.lean
@@ -176,7 +176,10 @@ For a density matrix `ρ_ABC` on `A ⊗ 1 ⊗ C`, SSA reduces to
 `S(ρ_ABC) ≤ S(ρ_AB) + S(ρ_BC)` because the `Fin 1`-indexed middle
 reduced state contributes zero entropy, and
 `Matrix.trace_eq_trace_traceAC_ABC` supplies the unit-trace condition
-needed by `vonNeumannEntropy_eq_zero_of_fin_one`. -/
+needed by `vonNeumannEntropy_eq_zero_of_fin_one`.
+
+Source: blueprint `thm:entropy_subadditivity_trivial_B`;
+[Wolf, Chapter 8 (SSA corollary)][Wolf2012QChannels]. -/
 theorem subadditivity_ssa_trivial_B
     (ρ_ABC : Matrix (Fin dA × Fin 1 × Fin dC)
       (Fin dA × Fin 1 × Fin dC) ℂ)

--- a/TNLean/Entropy/TripartiteTrace.lean
+++ b/TNLean/Entropy/TripartiteTrace.lean
@@ -21,7 +21,10 @@ resulting finite sums.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 1
+  (partial-trace basics)][Wolf2012QChannels]
+* Blueprint `thm:trace_tracea_abc`, `thm:trace_tracec_abc`,
+  `thm:trace_traceac_abc`
 -/
 
 open scoped Matrix ComplexOrder
@@ -34,7 +37,9 @@ variable {dA dB dC : ℕ}
 namespace Matrix
 
 /-- The full trace equals the trace of the `A`-partial trace:
-`tr(ρ_ABC) = tr(tr_A(ρ_ABC))`. -/
+`tr(ρ_ABC) = tr(tr_A(ρ_ABC))`.
+
+Source: blueprint `thm:trace_tracea_abc`. -/
 theorem trace_eq_trace_traceA_ABC
     (ρ : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ) :
@@ -44,7 +49,9 @@ theorem trace_eq_trace_traceA_ABC
   exact Finset.sum_comm
 
 /-- The full trace equals the trace of the `C`-partial trace:
-`tr(ρ_ABC) = tr(tr_C(ρ_ABC))`. -/
+`tr(ρ_ABC) = tr(tr_C(ρ_ABC))`.
+
+Source: blueprint `thm:trace_tracec_abc`. -/
 theorem trace_eq_trace_traceC_ABC
     (ρ : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ) :
@@ -54,7 +61,9 @@ theorem trace_eq_trace_traceC_ABC
   simp_rw [Fintype.sum_prod_type]
 
 /-- The full trace equals the trace of the `AC`-partial trace:
-`tr(ρ_ABC) = tr(tr_AC(ρ_ABC))`. -/
+`tr(ρ_ABC) = tr(tr_AC(ρ_ABC))`.
+
+Source: blueprint `thm:trace_traceac_abc`. -/
 theorem trace_eq_trace_traceAC_ABC
     (ρ : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ) :

--- a/TNLean/Entropy/VonNeumann.lean
+++ b/TNLean/Entropy/VonNeumann.lean
@@ -36,8 +36,10 @@ two spellings are interchangeable in tactics; in particular no
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8,
+  Section 8.2 (Entropies)][Wolf2012QChannels]
 * arXiv:1606.00608 Section 4.4
+* Blueprint `def:entropy_von_neumann_entropy` — entropy formulation
 -/
 
 namespace Entropy
@@ -46,7 +48,9 @@ namespace Entropy
 
 For a Hermitian matrix `ρ` with eigenvalues `λᵢ`, the von Neumann
 entropy is `S(ρ) = ∑ᵢ negMulLog(λᵢ) = -∑ᵢ λᵢ log(λᵢ)`. Definitionally
-equal to `_root_.vonNeumannEntropy`. -/
+equal to `_root_.vonNeumannEntropy`.
+
+Source: blueprint `def:entropy_von_neumann_entropy`. -/
 noncomputable alias vonNeumannEntropy := _root_.vonNeumannEntropy
 
 /-- **Von Neumann entropy is nonneg for density matrices**, namespaced

--- a/TNLean/MPS/Core/Correlations.lean
+++ b/TNLean/MPS/Core/Correlations.lean
@@ -19,8 +19,10 @@ by subtracting the product of one-point expectations.
 
 The spectral statements `connectedCorrelator_eq_sum` and
 `connectedCorrelator_bound` take the spectral decomposition or bound
-as an explicit hypothesis; the source (arXiv:2011.12127, Sec. 4.5)
-derives these hypotheses from the transfer-map eigendecomposition.
+as an explicit hypothesis; the source (arXiv:2011.12127 [CPGSV21])
+states the connected-correlation formulas in Sec. 2.3
+("Correlations, Entanglement, and the Transfer Matrix") and derives
+the spectral-gap hypotheses in Sec. 4 ("Formal results").
 The definitions here are used by the zero-correlation-length results.
 -/
 
@@ -35,13 +37,16 @@ private abbrev Mat (D : ℕ) := Matrix (Fin D) (Fin D) ℂ
 /-- One-site expectation value in terms of a chosen right fixed point `ρR`.
 
 In the thermodynamic limit for a normal MPS, one takes `ρR` to be the positive
-right fixed point of the transfer map. -/
+right fixed point of the transfer map.  Cf. CPGSV21, Sec. 2.3:
+`⟨X⟩ := tr(Xρ^R)`. -/
 noncomputable def onePointExpectation
     (ρR X : Mat D) : ℂ :=
   Matrix.trace (X * ρR)
 
 /-- Two-point function at distance `n`, written by sandwiching `E^n` between
-single-site insertions and evaluating against `ρR`. -/
+single-site insertions and evaluating against `ρR`.
+
+Cf. CPGSV21, Sec. 2.3: `⟨X₀ Yₙ⟩ := tr(Y E_A^n (X ρ^R))`. -/
 noncomputable def twoPointExpectation (A : MPSTensor d D)
     (ρR X Y : Mat D) (n : ℕ) : ℂ :=
   Matrix.trace (Y * ((transferMap (d := d) (D := D) A) ^ n) (X * ρR))
@@ -74,8 +79,11 @@ If coefficients `cⱼ` and eigenvalues `λⱼ` satisfying the spectral expansion
 identity are supplied, then the connected correlator equals the sum of
 exponentials `∑ⱼ cⱼ λⱼⁿ`.
 
-The source (arXiv:2011.12127, Sec. 4.5) asserts that such `cⱼ, λⱼ`
-always exist for a normal MPS via the transfer-map eigendecomposition.
+The source CPGSV21, Sec. 2.3, asserts that the connected correlator
+`C(X,Y;n)` is of the form `∑_{j≥2}^{D²} c_{XY}(j) λⱼⁿ`, a sum of
+`D²−1` pure exponentials, where `λⱼ` are the subleading eigenvalues of
+the transfer matrix.  The leading eigenvalue `λ₁=1` contributes
+`⟨X⟩⟨Y⟩` which is subtracted in the connected part.
 -/
 theorem connectedCorrelator_eq_sum
     (A : MPSTensor d D)
@@ -97,8 +105,11 @@ If a constant `C_X_Y` and a subleading eigenvalue `λ₂` with the
 exponential-decay bound are supplied, then the connected correlator
 satisfies `|C(X,Y;n)| ≤ C_X_Y · |λ₂|ⁿ`.
 
-The source (arXiv:2011.12127, Sec. 4.5) derives this from the
-sum-of-exponentials expansion and the spectral gap condition.
+The source CPGSV21, Sec. 2.3, notes that `|λ₂| < 1` defines the
+correlation length `ξ = −1/log|λ₂|`.  The exponential decay bound
+follows by applying the triangle inequality to the sum-of-exponentials
+expansion and using `|λⱼ| ≤ |λ₂| < 1` for all subleading eigenvalues
+(the spectral gap proved in Sec. 4).
 -/
 theorem connectedCorrelator_bound
     (A : MPSTensor d D)
@@ -109,7 +120,9 @@ theorem connectedCorrelator_bound
       ‖connectedCorrelator (d := d) (D := D) A ρR X Y n‖ ≤ CXY * ‖lam₂‖ ^ n :=
   hbound
 
-/-- Correlation length associated with a chosen subleading eigenvalue `λ₂`. -/
+/-- Correlation length associated with a chosen subleading eigenvalue `λ₂`.
+
+Formula from CPGSV21, Sec. 2.3: `ξ := −1/log|λ₂|`. -/
 noncomputable def correlationLength (lam₂ : ℂ) : ℝ :=
   -1 / Real.log ‖lam₂‖
 

--- a/TNLean/Spectral/CrossCorrelation.lean
+++ b/TNLean/Spectral/CrossCorrelation.lean
@@ -20,6 +20,10 @@ cross-correlations between distinct blocks decay exponentially.
 
 ## References
 
+* CPGSV21: Cirac, Pérez-García, Schuch, Verstraete,
+  *Matrix Product States and Projected Entangled Pair States*,
+  Rev. Mod. Phys. 93 (2021), arXiv:2011.12127.
+  Sec. 2.3 (correlations and transfer matrix), Sec. 4 (spectral gap).
 * [PerezGarcia2007String] Pérez-García, Verstraete, Wolf, Cirac,
   *Matrix Product State Representations*, 2007.
 -/

--- a/TNLean/Spectral/MixedTransfer.lean
+++ b/TNLean/Spectral/MixedTransfer.lean
@@ -32,6 +32,10 @@ multi-block fundamental theorem.
 
 ## References
 
+* CPGSV21: Cirac, Pérez-García, Schuch, Verstraete,
+  *Matrix Product States and Projected Entangled Pair States:
+  Concepts, Symmetries, Theorems*, Rev. Mod. Phys. 93 (2021), arXiv:2011.12127.
+  Sec. 2.3 (standard transfer matrix `E`), Sec. 4 (mixed transfer `F_{AB}`).
 * [PerezGarcia2007String] Pérez-García, Verstraete, Wolf, Cirac,
   *Matrix Product State Representations*, 2007. (transfer maps, §II.B)
 * [Wolf2012Quantum] Wolf, *Quantum Channels & Operations: Guided Tour*,
@@ -51,7 +55,11 @@ section MixedTransfer
 /-- The **mixed transfer operator** for MPS tensors `A` and `B`:
 $$F_{AB}(X) = \sum_i A^i \, X \, (B^i)^\dagger.$$
 This is a linear map on `D × D` complex matrices. When `A = B`, it
-recovers the standard transfer map `transferMap A`. -/
+recovers the standard transfer map `transferMap A`.
+
+Cf. CPGSV21, Sec. 4: the mixed transfer operator `F_{jk}` is used in
+the basis-of-normal-tensors construction to distinguish gauge-equivalent
+blocks.  The standard transfer matrix `E` is introduced in Sec. 2.3. -/
 noncomputable def mixedTransferMap (A B : MPSTensor d D) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
   ∑ i : Fin d,

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -32,6 +32,11 @@ to zero. This is the mechanism by which the mixed transfer operator
 
 ## References
 
+* CPGSV21: Cirac, Pérez-García, Schuch, Verstraete,
+  *Matrix Product States and Projected Entangled Pair States*,
+  Rev. Mod. Phys. 93 (2021), arXiv:2011.12127.
+  Sec. 2.3 (correlations and transfer matrix), Sec. 4 (spectral gap and
+  mixed transfer operator `F_{jk}`).
 * [Wolf2012Quantum] Wolf, *Quantum Channels & Operations: Guided Tour*,
   Proposition 6.1, Theorem 6.6, Section 6.2.
 * [PerezGarcia2007String] Pérez-García, Verstraete, Wolf, Cirac,

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -71,15 +71,17 @@ their spectral decomposition, and quantitative bounds on decay rates.
         C(X,Y;n) = \sum_{j=1}^{D^2-1} c_j\,\lambda_j^n,
     \]
     then the connected correlator equals the stated sum of exponentials.
-    The source~\cite[Sec.~4.5]{Cirac2021Matrix} asserts that such an expansion
-    always exists for a normal MPS via the transfer-map spectral decomposition.
+    The source~\cite[Sec.~2.3]{Cirac2021Matrix} states that the connected
+    correlator is a sum of $D^2-1$ pure exponentials
+    $C(X,Y;n) = \sum_{j\ge 2}^{D^2} c_{XY}(j)\lambda_j^n$,
+    which always exists for a normal MPS via the transfer-map spectral decomposition.
     % Constructing $c_j,\lambda_j$ from $\E_A$ is tracked in Issue~\#1447.
 \end{theorem}
 
 \begin{proof}
     \leanok
     Given the expansion hypothesis, the equality is immediate.
-    The source~\cite[Sec.~4.5]{Cirac2021Matrix} derives this expansion
+    The source~\cite[Sec.~2.3]{Cirac2021Matrix} derives this expansion
     from the spectral decomposition of $\E_A^n$ restricted to the
     complement of the fixed-point eigenspace: the leading eigenvalue
     $\lambda_1=1$ contributes $\langle X_0\rangle\langle Y_0\rangle$,
@@ -99,8 +101,10 @@ their spectral decomposition, and quantitative bounds on decay rates.
         |C(X,Y;n)| \le C_{XY}\,|\lambda_2|^n,
     \]
     then the connected correlator satisfies that exponential decay bound.
-    The source~\cite[Sec.~4.5]{Cirac2021Matrix} obtains this by combining
-    the sum-of-exponentials expansion with the triangle inequality.
+    The source~\cite[Sec.~2.3]{Cirac2021Matrix} obtains this by combining
+    the sum-of-exponentials expansion with the triangle inequality, and
+    Sec.~4 provides the spectral gap condition $|\lambda_j|<1$ for the
+    subleading eigenvalues.
     % Extracting $C_{XY}$ and $\lambda_2$ from the transfer-map spectrum
     % is tracked in Issue~\#1447.
 \end{theorem}
@@ -108,7 +112,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
 \begin{proof}
     \leanok
     Given the bound hypothesis, the estimate is immediate.
-    The source~\cite[Sec.~4.5]{Cirac2021Matrix} obtains this bound
+    The source~\cite[Sec.~2.3]{Cirac2021Matrix} obtains this bound
     by applying the triangle inequality to the sum-of-exponentials
     expansion and using the spectral gap condition
     $|\lambda_j|\le|\lambda_2|<1$ for all subleading eigenvalues.


### PR DESCRIPTION
### Motivation
- Continues source-faithful formula and terminology standardization across the entropy chapter, tracked by LionSR/TNLean#1404
- Audit blueprint `ch04b_entropy.tex` and cited Lean docstrings for formula-first documentation with explicit Wolf section/equation references

### Description
- Added source references to all 7 entropy files: Wolf Chapter 8 (Distance Measures, Entropies) section refs, blueprint label refs, and arXiv:1606.00608 annotations
- Expanded docstrings with explicit formulas for von Neumann entropy, tripartite traces, SSA equality predicate, mutual information, and SSA axioms
- Refreshed Channel module docstrings with Wolf Chapter 2 equation numbers (Choi–Jamiolkowski, Kraus, Stinespring, Radon–Nikodym, POVM, normal forms)
- Corrected CPGSV21 section references in correlation docstrings (`Sec. 4.5` → `Sec. 2.3`) across Lean and blueprint
- Files modified: 22 (see commit history for full list)

### Testing
- Documentation-only changes; no theorem statements, proofs, or type signatures change
- Relies on Lean CI (`lean_action_ci.yml`) to validate build

---
Closes LionSR/QICLean#151

> [!NOTE]
> **Low Risk**
> Documentation-only updates across entropy/channel/MPS modules; no theorem statements, proofs, or APIs change, so risk is limited to minor comment/reference accuracy.
> 
> **Overview**
> Adds *source-faithful* documentation across the entropy stack by expanding docstrings with explicit formulas, Wolf section/equation pointers, and blueprint tags (e.g., `vonNeumannEntropy`, tripartite traces, SSA equality predicate, mutual information, SSA wrappers/axioms).
> 
> Also refreshes chapter/section citations in multiple channel modules (Choi–Jamiolkowski, Kraus/Stinespring/Radon–Nikodym/POVM, normal forms) and updates MPS correlation text (Lean + blueprint) to cite CPGSV21 sections more precisely. No functional Lean code changes beyond comments/docstrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83341eef11af351dd0461c91862d453f2bdb1256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates across entropy and MPS/correlation modules; no theorem statements, proofs, or APIs change, so risk is limited to citation/formula accuracy.
> 
> **Overview**
> Expands docstrings across the entropy stack to be *formula-first* and source-faithful: adds explicit equations for `vonNeumannEntropy`, tripartite partial traces, `IsSSAEquality`, mutual information, and SSA results/axioms, with consistent Wolf section/equation citations and blueprint tags.
> 
> Corrects/clarifies literature references in the MPS correlation/spectral docs and blueprint (notably CPGSV21 section pointers), and adds missing reference annotations in related modules; functional Lean code remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5649e2d94bb82acd200a8b8aa5c6ea7f83a14a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->