### PR TITLE
doc(blueprint): sync power-sum and canonical references

### DIFF
--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -11,11 +11,10 @@ import Mathlib.Data.Matrix.Basic
 # Scalar Power-Sum Identity
 
 This file formalizes the **finite-range power-sum identity** from arXiv:1606.00608
-(Appendix A, lines 1155–1163). It provides both the same-cardinality support lemmas used in
-the Appendix argument and the full unequal-cardinality statement
-`sum_pow_eq_implies_multiset_eq_of_le_max_length`, which takes two lists of complex
-numbers of possibly different lengths and deduces multiset equality from equality of
-power sums up to the larger length.
+(Appendix A, lines 1155–1163). It provides the same-cardinality support lemmas
+used in the Appendix argument and the list form for two complex families
+`(λ_{a,k})` and `(λ_{b,k})` of possibly different lengths. If their power sums
+agree for `0 ≤ N ≤ max(x_a, x_b)`, then they determine the same multiset.
 
 Given two families of `n` complex scalars whose power sums agree for `1 ≤ k ≤ n`,
 Newton's identities imply their diagonal matrices have equal characteristic polynomials, and
@@ -40,7 +39,7 @@ all-positive-power consequences for families indexed by a single finite type.
 
 ## Relation to the source statement
 
-The paper's Lemma `Lem:app_simple` (arXiv:1606.00608, lines 1155–1163) states:
+The Appendix lemma of arXiv:1606.00608, lines 1155–1163, states:
 
   Let `λ_{a,k}` (k=1,…,x_a) and `λ_{b,k}` (k=1,…,x_b) be two **sorted** finite families
   of complex numbers (sorted by nonincreasing absolute value, then nondecreasing argument).
@@ -55,10 +54,9 @@ one way:
      polynomial, making lexicographic-phase sorting unnecessary — the polynomial equality
      absorbs the ordering.
 
-The `Fin`-based unequal-cardinality theorem
-`sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card` assumes all entries are
-nonzero; the list-based theorem `sum_pow_eq_implies_multiset_eq_of_le_max_length`
-drops this requirement by using the $N=0$ power sum to deduce equal lengths.
+The `Fin`-indexed unequal-cardinality theorem assumes all entries are nonzero.
+The list form drops this requirement by using the $N=0$ power sum to deduce equal
+lengths, and then applies the same-cardinality finite-range theorem.
 -/
 
 open scoped Matrix BigOperators
@@ -75,8 +73,8 @@ theorem trace_diagonal_pow [DecidableEq n] (a : n → ℂ) (k : ℕ) :
   classical
   simp [diagonal_pow, trace_diagonal]
 
-/-- **Scalar power-sum identity** (same-cardinality support lemma for
-`Lem:app_simple` of arXiv:1606.00608).
+/-- **Scalar power-sum identity** (same-cardinality support lemma for the
+Appendix argument of arXiv:1606.00608).
 
 If two families of complex scalars, indexed by the same finite type, have equal power sums for all
 positive exponents, then their characteristic polynomials (as diagonal matrices) agree. -/
@@ -90,8 +88,8 @@ theorem sum_pow_eq_implies_charpoly_diagonal_eq
   rw [trace_diagonal_pow, trace_diagonal_pow]
   exact h k hk
 
-/-- **Bounded scalar power-sum identity** (same-cardinality part of
-`Lem:app_simple` of arXiv:1606.00608).
+/-- **Bounded scalar power-sum identity** (same-cardinality part of the Appendix
+argument of arXiv:1606.00608).
 
 If two families of complex scalars, indexed by the same finite type `n`, have equal
 power sums for `1 ≤ k ≤ card n`, then their characteristic polynomials as diagonal
@@ -117,7 +115,7 @@ private lemma roots_prod_X_sub_C (f : n → ℂ) :
 /-- Equal power sums through `card n` determine the same multiset of values for
 two families indexed by the same finite type.
 
-This is the finite-range, same-cardinality part of Lemma `Lem:app_simple` in
+This is the finite-range, same-cardinality part of the Appendix lemma in
 arXiv:1606.00608. The all-positive-power theorem below is obtained by restricting
 its hypothesis to `1 ≤ k ≤ card n`. -/
 theorem sum_pow_eq_implies_multiset_eq_of_le_card
@@ -134,10 +132,9 @@ theorem sum_pow_eq_implies_multiset_eq_of_le_card
 /-- Equal power sums of two families indexed by the same finite type imply that the families
 give rise to the same multiset of values.
 
-This all-positive-power statement follows from
-`sum_pow_eq_implies_multiset_eq_of_le_card` by restricting the hypothesis to
-`1 ≤ k ≤ card n`. The theorem is still same-cardinality; Lemma `Lem:app_simple`
-in arXiv:1606.00608 also proves equality of cardinalities when the sizes may
+This all-positive-power statement is the finite-range same-cardinality theorem
+with the hypothesis restricted to `1 ≤ k ≤ card n`. The Appendix lemma in
+arXiv:1606.00608 also proves equality of cardinalities when the sizes may
 differ. -/
 theorem sum_pow_eq_implies_multiset_eq
     (a b : n → ℂ)
@@ -203,8 +200,8 @@ hypothesis.
 
 If two finite families of nonzero complex scalars have equal power sums for
 `1 ≤ k ≤ max m n`, then the indexing cardinalities are equal and the two families give the
-same multiset of values.  The proof pads the shorter family by zeros, applies
-`sum_pow_eq_implies_multiset_eq_of_le_card`, and then counts the padded zeros. -/
+same multiset of values.  The proof pads the shorter family by zeros, applies the
+same-cardinality finite-range theorem, and then counts the padded zeros. -/
 theorem sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card
     (m n : ℕ) (a : Fin m → ℂ) (b : Fin n → ℂ)
     (ha : ∀ i, a i ≠ 0) (hb : ∀ i, b i ≠ 0)
@@ -251,16 +248,16 @@ private lemma list_pow_sum_eq_ofFn (f : Fin m → ℂ) (l : List ℂ)
             = (List.ofFn ((fun z : ℂ => z ^ k) ∘ f)).sum := rfl
         _ = ((List.ofFn f).map fun z => z ^ k).sum := by rw [← List.map_ofFn]
     _ = (l.map fun z => z ^ k).sum := by rw [h_ofFn]
+
 /-- **Finite-range power-sum identity for possibly unequal cardinalities**
 (from arXiv:1606.00608, Appendix A, lines 1155–1163).
 
 Given two lists of complex numbers of possibly different lengths, if the power sums
 agree for all $N \le \max(|la|, |lb|)$, then the two lists have the same multiset.
 
-Uses $N=0$ (where $\lambda^0 = 1$) to deduce equal lengths, then
-`sum_pow_eq_implies_multiset_eq_of_le_card` for finite-range multiset equality.
-Drops the nonzero-entry hypothesis of
-`sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card`. -/
+Uses $N=0$ (where $\lambda^0 = 1$) to deduce equal lengths, then applies the
+same-cardinality finite-range theorem. This removes the nonzero-entry hypothesis
+needed by the `Fin`-indexed unequal-cardinality version. -/
 theorem sum_pow_eq_implies_multiset_eq_of_le_max_length (la lb : List ℂ)
     (hp : ∀ N, N ≤ max la.length lb.length →
       (la.map fun z => z ^ N).sum = (lb.map fun z => z ^ N).sum) :
@@ -277,12 +274,12 @@ theorem sum_pow_eq_implies_multiset_eq_of_le_max_length (la lb : List ℂ)
   let a : Fin m → ℂ := fun i => la.get ⟨i.val, i.is_lt⟩
   let b : Fin m → ℂ := fun i => lb.get ⟨i.val, hm_card ▸ i.is_lt⟩
   have h_ofFn_a : List.ofFn a = la := by
-    apply List.ext_get
+    apply List.ext_getElem
     · simp [a, m]
     · intro i hi1 hi2
       simp [a, m]
   have h_ofFn_b : List.ofFn b = lb := by
-    apply List.ext_get
+    apply List.ext_getElem
     · simp [b, m, hm_card]
     · intro i hi1 hi2
       simp [b, m, hm_card]

--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -10,11 +10,10 @@ import Mathlib.Data.Matrix.Basic
 /-!
 # Scalar Power-Sum Identity
 
-This file formalizes the **finite-range power-sum identity** from arXiv:1606.00608
+This file formalizes finite-range power-sum identities used in arXiv:1606.00608
 (Appendix A, lines 1155–1163). It provides the same-cardinality support lemmas
-used in the Appendix argument and the list form for two complex families
-`(λ_{a,k})` and `(λ_{b,k})` of possibly different lengths. If their power sums
-agree for `0 ≤ N ≤ max(x_a, x_b)`, then they determine the same multiset.
+and two unequal-cardinality forms for finite complex families
+`(λ_{a,k})` and `(λ_{b,k})`.
 
 Given two families of `n` complex scalars whose power sums agree for `1 ≤ k ≤ n`,
 Newton's identities imply their diagonal matrices have equal characteristic polynomials, and
@@ -30,12 +29,14 @@ by observing that the trace of a power of a diagonal matrix equals the correspon
 
   `trace (diagonal a ^ k) = ∑ i, a i ^ k`
 
-The main theorem in this file says that, for nonzero families
+The main unequal-cardinality theorem in this file says that, for nonzero families
 `a : Fin m → ℂ` and `b : Fin n → ℂ`, equality of
 `∑ i : Fin m, a i ^ k` and `∑ i : Fin n, b i ^ k` for
 `1 ≤ k ≤ max m n` implies `m = n` and equality of the two multisets of values.
-The same-cardinality theorems are the corresponding finite-range and
-all-positive-power consequences for families indexed by a single finite type.
+This is the form used when the compared coefficients are known to be nonzero, and
+in some applications the coefficients are explicitly positive. The same-cardinality
+theorems are the corresponding finite-range and all-positive-power consequences for
+families indexed by a single finite type.
 
 ## Relation to the source statement
 
@@ -47,16 +48,20 @@ The Appendix lemma of arXiv:1606.00608, lines 1155–1163, states:
     `∑_{k=1}^{x_a} λ_{a,k}^N = ∑_{k=1}^{x_b} λ_{b,k}^N`,
   then `x_a = x_b` and `λ_{a,k} = λ_{b,k}` for all k.
 
-The unequal-cardinality finite-range theorem below differs from the paper's list statement in
-one way:
+The unequal-cardinality finite-range theorem differs from the paper's list statement in
+two formal ways:
 
   1. **No sorting hypothesis**: we work directly with multisets through the characteristic
      polynomial, making lexicographic-phase sorting unnecessary — the polynomial equality
      absorbs the ordering.
+  2. **Nonzero entries for positive powers**: with only positive powers, zero entries cannot
+     be counted; for example `[]` and `[0]` have equal positive power sums. Thus the
+     positive-power theorem assumes all entries are nonzero.
 
-The `Fin`-indexed unequal-cardinality theorem assumes all entries are nonzero.
-The list form drops this requirement by using the $N=0$ power sum to deduce equal
-lengths, and then applies the same-cardinality finite-range theorem.
+A second list theorem assumes equality also at exponent $N=0$.  Then
+`∑_k λ_{a,k}^0 = x_a` and `∑_k λ_{b,k}^0 = x_b`, so the lengths are equal before
+Newton--Girard is applied.  This exponent-zero theorem does not replace the
+positive-power theorems in arguments where only positive exponents are available.
 -/
 
 open scoped Matrix BigOperators
@@ -249,15 +254,94 @@ private lemma list_pow_sum_eq_ofFn (f : Fin m → ℂ) (l : List ℂ)
         _ = ((List.ofFn f).map fun z => z ^ k).sum := by rw [← List.map_ofFn]
     _ = (l.map fun z => z ^ k).sum := by rw [h_ofFn]
 
-/-- **Finite-range power-sum identity for possibly unequal cardinalities**
-(from arXiv:1606.00608, Appendix A, lines 1155–1163).
+/-- Removing zero entries does not change a positive power sum. -/
+private lemma sum_filter_ne_zero_pow (l : List ℂ) {k : ℕ} (hk : 0 < k) :
+    ((l.filter fun z => z != 0).map fun z => z ^ k).sum =
+      (l.map fun z => z ^ k).sum := by
+  induction l with
+  | nil => simp
+  | cons z zs ih =>
+      by_cases hz : z = 0
+      · have hk0 : k ≠ 0 := Nat.ne_of_gt hk
+        simp [hz, ih, hk0]
+      · simp [hz, ih]
+
+/-- **Positive finite-range power sums determine the nonzero multiset.**
 
 Given two lists of complex numbers of possibly different lengths, if the power sums
-agree for all $N \le \max(|la|, |lb|)$, then the two lists have the same multiset.
+agree for all $1 \le N \le \max(|la|, |lb|)$, then the nonzero entries in the two
+lists have the same multiset.  This is the exact conclusion available from positive
+powers without assuming that all entries are nonzero. -/
+theorem sum_pow_eq_implies_nonzero_multiset_eq_of_le_max_length (la lb : List ℂ)
+    (hp : ∀ N, 0 < N → N ≤ max la.length lb.length →
+      (la.map fun z => z ^ N).sum = (lb.map fun z => z ^ N).sum) :
+    ((la.filter (fun z => z != 0) : List ℂ) : Multiset ℂ) =
+      ((lb.filter (fun z => z != 0) : List ℂ) : Multiset ℂ) := by
+  let la' := la.filter fun z => z != 0
+  let lb' := lb.filter fun z => z != 0
+  let m := la'.length
+  let n := lb'.length
+  let a : Fin m → ℂ := fun i => la'.get ⟨i.val, i.is_lt⟩
+  let b : Fin n → ℂ := fun i => lb'.get ⟨i.val, i.is_lt⟩
+  have h_ofFn_a : List.ofFn a = la' := by
+    apply List.ext_getElem
+    · simp [a, m]
+    · intro i hi1 hi2
+      simp [a, m]
+  have h_ofFn_b : List.ofFn b = lb' := by
+    apply List.ext_getElem
+    · simp [b, n]
+    · intro i hi1 hi2
+      simp [b, n]
+  have ha : ∀ i, a i ≠ 0 := by
+    intro i
+    have hmem : a i ∈ la' := by simp [a]
+    exact by
+      simpa [la'] using (List.mem_filter.mp hmem).2
+  have hb : ∀ i, b i ≠ 0 := by
+    intro i
+    have hmem : b i ∈ lb' := by simp [b]
+    exact by
+      simpa [lb'] using (List.mem_filter.mp hmem).2
+  have hm_le : m ≤ la.length := by
+    dsimp [m, la']
+    exact List.length_filter_le (fun z => z != 0) la
+  have hn_le : n ≤ lb.length := by
+    dsimp [n, lb']
+    exact List.length_filter_le (fun z => z != 0) lb
+  have hp_fin : ∀ k, 0 < k → k ≤ max m n →
+      ∑ i : Fin m, a i ^ k = ∑ i : Fin n, b i ^ k := by
+    intro k hk hkmax
+    have hsum_a := list_pow_sum_eq_ofFn a la' h_ofFn_a k
+    have hsum_b := list_pow_sum_eq_ofFn b lb' h_ofFn_b k
+    have hfilter_a := sum_filter_ne_zero_pow la (k := k) hk
+    have hfilter_b := sum_filter_ne_zero_pow lb (k := k) hk
+    rw [hsum_a, hsum_b, hfilter_a, hfilter_b]
+    apply hp k hk
+    exact le_trans hkmax (max_le_max hm_le hn_le)
+  have h := sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card m n a b ha hb hp_fin
+  have h_mult_eq : Finset.univ.val.map a = Finset.univ.val.map b := h.2
+  have h_multiset_a : Finset.univ.val.map a = (la' : Multiset ℂ) := by
+    calc
+      Finset.univ.val.map a = (List.ofFn a : Multiset ℂ) := by simp
+      _ = (la' : Multiset ℂ) := by rw [h_ofFn_a]
+  have h_multiset_b : Finset.univ.val.map b = (lb' : Multiset ℂ) := by
+    calc
+      Finset.univ.val.map b = (List.ofFn b : Multiset ℂ) := by simp
+      _ = (lb' : Multiset ℂ) := by rw [h_ofFn_b]
+  rw [h_multiset_a, h_multiset_b] at h_mult_eq
+  exact h_mult_eq
+
+/-- **Finite-range power-sum identity with exponent zero.**
+
+Given two lists of complex numbers of possibly different lengths, if the power sums
+agree for all $0 \le N \le \max(|la|, |lb|)$, then the two lists have the same
+multiset.
 
 Uses $N=0$ (where $\lambda^0 = 1$) to deduce equal lengths, then applies the
 same-cardinality finite-range theorem. This removes the nonzero-entry hypothesis
-needed by the `Fin`-indexed unequal-cardinality version. -/
+needed by the positive-power unequal-cardinality theorem, but it is a different
+hypothesis from the Appendix uses that only provide positive powers. -/
 theorem sum_pow_eq_implies_multiset_eq_of_le_max_length (la lb : List ℂ)
     (hp : ∀ N, N ≤ max la.length lb.length →
       (la.map fun z => z ^ N).sum = (lb.map fun z => z ^ N).sum) :

--- a/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/EqualProportional.lean
@@ -40,11 +40,10 @@ Trivial but useful: `SameMPV₂ A B → ProportionalMPV₂ A B` (take `c_N = 1`)
 
 ### Theorem 4: Power-sum multiset equality (Lem:app_simple support lemma)
 
-If two sequences of complex numbers have equal power sums for all positive exponents, their
-multisets (as roots) are equal.  This is a **same-cardinality support lemma** for the paper's
-Lemma `Lem:app_simple` — the paper additionally allows different cardinalities and only tests
-powers up to `max{x_a, x_b}`.  See the design note in
-`TNLean.Algebra.ScalarPowerSumIdentity`.
+If two same-cardinality sequences of complex numbers have equal power sums for all positive
+exponents, their multisets are equal.  For different cardinalities, the positive-power
+theorem needs nonzero entries; otherwise positive powers determine only the multiset after
+zero entries are deleted.  See `TNLean.Algebra.ScalarPowerSumIdentity`.
 
 ## References
 
@@ -468,9 +467,11 @@ theorem fundamentalTheorem_equalMPV_full
 
 /-! ## Theorem 4: Power-sum multiset equality (Lem:app_simple support lemma)
 
-This provides the same-cardinality power-sum lemmas from `ScalarPowerSumIdentity.lean`.
-The bounded version is the same-cardinality part of the paper's Lemma `Lem:app_simple`;
-the nonzero-entry version below also compares possibly unequal cardinalities.
+This provides the power-sum lemmas from `ScalarPowerSumIdentity.lean`.
+The bounded same-cardinality version is the common Newton--Girard input.
+The nonzero-entry version below compares possibly unequal cardinalities using
+positive powers only; without a nonzero-entry hypothesis, positive powers do not
+count zero entries.
 -/
 
 /-- **Equal power sums imply equal multisets** (same-cardinality support lemma for
@@ -482,8 +483,7 @@ multiset of values (counted with multiplicity).
 
 This is a corollary of Newton's identities via
 `Matrix.sum_pow_eq_implies_multiset_eq` from `ScalarPowerSumIdentity.lean`.
-Note: the paper's `Lem:app_simple` additionally allows `α` and `β` to have different
-lengths and only requires equality up to `max{|α|, |β|}`. -/
+The unequal-cardinality Appendix use requires the nonzero-entry version below. -/
 theorem power_sum_eq_implies_multiset_eq (n : ℕ)
     (α β : Fin n → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i : Fin n, (α i) ^ k = ∑ i : Fin n, (β i) ^ k) :
@@ -505,12 +505,15 @@ theorem power_sum_eq_implies_multiset_eq_of_le_card (n : ℕ)
   intro k hk hkcard
   exact h k hk (by simpa using hkcard)
 
-/-- **Bounded unequal-cardinality power sums imply equal cardinality and equal multisets**
-under a nonzero-entry hypothesis.
+/-- **Bounded unequal-cardinality power sums imply equal cardinality and equal
+multisets** under a nonzero-entry hypothesis.
 
 If two nonzero finite sequences `α : Fin m → ℂ` and `β : Fin n → ℂ` satisfy
 `∑ i, (α i)^k = ∑ i, (β i)^k` for `1 ≤ k ≤ max m n`, then `m = n` and the two
-sequences have the same multiset of values counted with multiplicity. -/
+sequences have the same multiset of values counted with multiplicity.
+
+The nonzero-entry hypothesis is mathematically necessary for this positive-power
+statement: zero entries have no effect on the sums for `k > 0`. -/
 theorem power_sum_eq_implies_card_eq_and_multiset_eq_of_le_max_card
     (m n : ℕ) (α : Fin m → ℂ) (β : Fin n → ℂ)
     (hα : ∀ i, α i ≠ 0) (hβ : ∀ i, β i ≠ 0)

--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -22,6 +22,15 @@ geometric extrapolation and Newton--Girard steps below are the finite-sequence
 algebra needed to recover the weight lists from those power sums once the basis
 blocks have been matched.
 
+The earlier formal route recovered the multiplicities by extrapolating the
+eventual positive-power identities to exponent `0`, where the coefficient is
+the number of copies, and then used the same-cardinality Newton--Girard lemma.
+Under the nonzero-weight hypotheses in `SectorWeightData` this is not a gap:
+the extrapolation lemma proves the exponent-zero identity.  The endpoint below
+now uses the unequal-cardinality finite-range power-sum theorem directly, closer
+to the Appendix argument.  Without nonzero weights, positive powers would only
+determine the nonzero submultiset.
+
 ## References
 
 - [PGVWC07] Pérez-García, Verstraete, Wolf, Cirac, *Matrix Product State Representations*,
@@ -111,7 +120,7 @@ lemma weight_multiset_eq_of_copies_eq_of_coeff_eq
     (fun q => (T.weight j q) ^ k)
     (fun q => by simp [Fin.castOrderIso_apply])
 
-/-! ### Extrapolation of power sum sequences
+/-! ### Extrapolation of power-sum sequences
 
 The connection between "eventually equal coefficients" (for `N > N₀`) and
 "equal coefficients for every positive `k`" rests on a **telescoping induction**
@@ -235,7 +244,16 @@ lemma power_sums_eq_of_eventually_eq
   exact power_sums_eq_of_eventually_eq_hetero
     (m := m) (n := m) a b ha hb (M := M) hEv
 
-/-- Eventual equality of coefficient power sums forces equality of multiplicities. -/
+/-- Alternative exponent-zero route: eventual equality of coefficient power sums forces
+equality of multiplicities.
+
+This is the route used by an earlier formal proof.  It is mathematically valid under the
+nonzero-weight hypotheses in `SectorWeightData`: eventual equality at positive system sizes
+is extrapolated to exponent `0`, and then
+`∑ q : Fin (S.copies j), (S.weight j q)^0 = S.copies j`.
+
+The source-facing proof below uses the unequal-cardinality finite-range power-sum theorem
+instead, but this lemma is kept as a checked reference for the alternative Lean proof. -/
 lemma copies_eq_of_eventually_coeff_eq
     (S T : SectorWeightData g)
     {N0 : ℕ}
@@ -255,12 +273,13 @@ lemma copies_eq_of_eventually_coeff_eq
     (M := N0 + 1) hEvj 0
   exact (Nat.cast_injective (R := ℂ)) (by simpa using h0)
 
-/-- Power-sum sequences from finite weight families that eventually agree also agree for all
-positive exponents.
+/-- Alternative exponent-zero route: after multiplicities are known, eventual equality of
+coefficient power sums gives equality at every positive exponent over a common index type.
 
-Proved by reducing to `power_sums_eq_of_eventually_eq` via a reindexing that uses
-`hCopies` to align the two families over the same index type `Fin (S.copies j)`. -/
-private lemma eventually_coeff_eq_implies_all_pos_eq
+Together with `copies_eq_of_eventually_coeff_eq` and
+`weight_multiset_eq_of_copies_eq_of_coeff_eq`, this recovers the same weight-multiset
+conclusion as the source-facing finite-range theorem below. -/
+lemma eventually_coeff_eq_implies_all_pos_eq_after_copies
     (S T : SectorWeightData g)
     (hCopies : ∀ j, S.copies j = T.copies j)
     {N0 : ℕ}
@@ -287,11 +306,63 @@ private lemma eventually_coeff_eq_implies_all_pos_eq
   simp only [SectorWeightData.coeff]
   exact hAll.trans (hReindex k)
 
+/-- Eventual equality of coefficient power sums forces equality of multiplicities and
+weight multisets.
+
+For each basis tensor, eventual equality is first extrapolated to all positive
+exponents.  The finite-range unequal-cardinality power-sum theorem then gives the
+copy count and the multiset of weights, using the nonzero-entry hypotheses carried
+by `SectorWeightData`.  This is the formal counterpart of the Appendix power-sum
+comparison in arXiv:1606.00608. -/
+lemma copies_eq_and_weight_multiset_eq_of_eventually_coeff_eq
+    (S T : SectorWeightData g)
+    {N0 : ℕ}
+    (hEv : ∀ N > N0, ∀ j : Fin g, S.coeff N j = T.coeff N j) :
+    ∃ hCopies : ∀ j, S.copies j = T.copies j,
+      ∀ j : Fin g,
+        Finset.univ.val.map (S.weight j) =
+          Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
+  have hPer :
+      ∀ j : Fin g,
+        ∃ hCopies : S.copies j = T.copies j,
+          Finset.univ.val.map (S.weight j) =
+            Finset.univ.val.map (fun q => T.weight j (Fin.cast hCopies q)) := by
+    intro j
+    have hEvj : ∀ N, N0 + 1 ≤ N →
+        ∑ q : Fin (S.copies j), (S.weight j q) ^ N =
+          ∑ q : Fin (T.copies j), (T.weight j q) ^ N := by
+      intro N hN
+      have h := hEv N (by omega) j
+      simpa only [SectorWeightData.coeff] using h
+    have hAll := power_sums_eq_of_eventually_eq_hetero
+      (S.weight j) (T.weight j)
+      (fun q => S.weight_ne_zero j q)
+      (fun q => T.weight_ne_zero j q)
+      (M := N0 + 1) hEvj
+    obtain ⟨hCopies, hMultiset⟩ :=
+      Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card
+        (S.copies j) (T.copies j) (S.weight j) (T.weight j)
+        (fun q => S.weight_ne_zero j q)
+        (fun q => T.weight_ne_zero j q)
+        (fun k hk _hkMax => hAll k)
+    refine ⟨hCopies, ?_⟩
+    have hReindex :
+        Finset.univ.val.map (fun q : Fin (S.copies j) => T.weight j (Fin.cast hCopies q)) =
+          Finset.univ.val.map (T.weight j) := by
+      simpa [Multiset.map_map, Function.comp_def, Fin.castOrderIso_apply] using
+        congrArg (Multiset.map (T.weight j))
+          (Multiset.map_univ_val_equiv (Fin.castOrderIso hCopies).toEquiv)
+    exact hMultiset.trans hReindex.symm
+  let hCopies : ∀ j, S.copies j = T.copies j := fun j => (hPer j).choose
+  refine ⟨hCopies, ?_⟩
+  intro j
+  exact (hPer j).choose_spec
+
 /-- **BNT coefficient comparison recovers multiplicities and weight multisets.**
 
 This variant does not assume matching copy counts. Eventual coefficient equality is
-first extrapolated to exponent `0`, which recovers the cardinalities of the two
-weight families, and then Newton--Girard recovers the multisets. -/
+first extrapolated to all positive exponents. The unequal-cardinality finite-range
+power-sum theorem then recovers both the copy counts and the multisets of weights. -/
 lemma exists_copies_eq_and_weight_multiset_eq_of_sameMPV_bnt
     {dim : Fin g → ℕ}
     (basis : (j : Fin g) → MPSTensor d (dim j))
@@ -306,11 +377,7 @@ lemma exists_copies_eq_and_weight_multiset_eq_of_sameMPV_bnt
         Finset.univ.val.map (S.weight j) =
           Finset.univ.val.map (fun q => T.weight j (Fin.cast (hCopies j) q)) := by
   obtain ⟨_, hCoeffEventuallyEq⟩ := coeff_eventually_eq_of_sameMPV basis S T hLI hSame
-  let hCopies : ∀ j, S.copies j = T.copies j :=
-    copies_eq_of_eventually_coeff_eq S T hCoeffEventuallyEq
-  refine ⟨hCopies, ?_⟩
-  have hCoeffAllPosEq := eventually_coeff_eq_implies_all_pos_eq S T hCopies hCoeffEventuallyEq
-  exact weight_multiset_eq_of_copies_eq_of_coeff_eq S T hCopies hCoeffAllPosEq
+  exact copies_eq_and_weight_multiset_eq_of_eventually_coeff_eq S T hCoeffEventuallyEq
 
 end SectorWeightData
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2792,20 +2792,23 @@ do not correspond to independent paper-level results.
 	so the gauge phase must have modulus one.
 \end{proof}
 
-\begin{theorem}[BNT partition from gauge equivalence]
+\begin{theorem}[Norm-class sector decomposition]
 	\label{thm:bnt_grouping_gauge_equiv}
-	\lean{MPSTensor.exists_bnt_grouping_of_gaugePhaseEquiv}\leanok
+	\lean{MPSTensor.exists_normClassSectorDecomp_of_equalNorm_sameMPV}\leanok
 	\uses{thm:bnt_grouping}
-	If equal-norm blocks are related by gauge equivalence with unit-modulus phase, the phases can be absorbed into sector weights to obtain a BNT grouping with strictly decreasing sector norms.
+	If equal-norm blocks give the same MPV family, one may choose one
+	representative basis tensor for each norm class and obtain a sector
+	decomposition with strictly decreasing sector norms.
 \end{theorem}
 
 \begin{theorem}[Sector decomposition from TP primitive irreducible blocks]
 	\label{thm:sector_decomp_tp_prim_irr}
-	\lean{MPSTensor.exists_sectorDecomp_of_tp_primitive_irr_blocks}\leanok
+	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks}\leanok
 	\uses{thm:gauge_equiv_nondecay, thm:bnt_grouping_gauge_equiv}
 	From a trace-preserving primitive irreducible block decomposition with nonzero
-	weights and non-decaying cross-overlaps for equal-norm blocks, one obtains a
-	sector decomposition with strict norm ordering.
+	weights, quotient the block indices by MPV phase equivalence and absorb the
+	phases into the sector weights. The resulting sector decomposition represents
+	the same weighted block sum and satisfies the BNT sector conditions.
 \end{theorem}
 
 \begin{theorem}[Existential BNT independence from overlap limits]
@@ -3240,7 +3243,7 @@ do not correspond to independent paper-level results.
 
 \begin{theorem}[Structural after-blocking form of the fundamental theorem]%
 	\label{thm:ft_after_blocking_structural}
-	\lean{MPSTensor.afterBlocking_structuralDecompositionData_of_sameMPV₂}
+	\lean{MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂}
 	\leanok
 	\uses{def:blocked_tensor, def:same_mpv2, def:zero_mps_tensor, def:tensor_from_blocks}
 	If two tensors generate the same MPV family, then each tensor admits some

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2762,14 +2762,6 @@ do not correspond to independent paper-level results.
 	From any finite weight family, construct norm classes ordered by strictly decreasing norm values.
 \end{definition}
 
-\begin{theorem}[BNT grouping theorem]
-	\label{thm:bnt_grouping}
-	\lean{MPSTensor.exists_bnt_grouping}\leanok
-	\uses{def:norm_class_grouping, thm:bnt_trivial_sector}
-	If equal-norm blocks represent the same MPS family, then one obtains a sector
-	decomposition whose sector norms are strictly decreasing.
-\end{theorem}
-
 \subsection{Equal-Norm Blocks}
 
 \begin{theorem}[Gauge equivalence from non-decaying cross-overlap]
@@ -2795,10 +2787,17 @@ do not correspond to independent paper-level results.
 \begin{theorem}[Norm-class sector decomposition]
 	\label{thm:bnt_grouping_gauge_equiv}
 	\lean{MPSTensor.exists_normClassSectorDecomp_of_equalNorm_sameMPV}\leanok
-	\uses{thm:bnt_grouping}
-	If equal-norm blocks give the same MPV family, one may choose one
-	representative basis tensor for each norm class and obtain a sector
-	decomposition with strictly decreasing sector norms.
+	\uses{def:norm_class_grouping}
+	For a weighted block family \((\mu_k,A_k)_{k=1}^r\) with
+	\(\mu_k\neq 0\), assume that
+	\[
+		|\mu_j|=|\mu_k| \quad\Longrightarrow\quad
+		A_j \text{ and } A_k \text{ generate the same MPV family}.
+	\]
+	Then one may choose one representative basis tensor for each norm class and
+	obtain a sector decomposition \(P\) with strictly decreasing sector norms
+	such that \(P\) generates the same MPV family as
+	\(\bigoplus_k \mu_k A_k\).
 \end{theorem}
 
 \begin{theorem}[Sector decomposition from TP primitive irreducible blocks]
@@ -3257,7 +3256,13 @@ do not correspond to independent paper-level results.
 		= V^{(N)}(Z_{p_A,z_A})_\sigma
 		  + V^{(N)}\!\left(\bigoplus_k \mu^A_k A_k\right)_\sigma,
 	\]
-	and likewise for $B$.
+	and likewise for $B$. The blocked tensors also preserve the original MPV
+	equality:
+	\[
+		A^{[p_A]} \sim B^{[p_A]},
+		\qquad
+		A^{[p_B]} \sim B^{[p_B]}.
+	\]
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2796,8 +2796,13 @@ do not correspond to independent paper-level results.
 	\]
 	Then one may choose one representative basis tensor for each norm class and
 	obtain a sector decomposition \(P\) with strictly decreasing sector norms
-	such that \(P\) generates the same MPV family as
-	\(\bigoplus_k \mu_k A_k\).
+	such that
+	\[
+		P_{\mathrm{tot}}
+		\sim
+		\bigoplus_{k=1}^r \mu_k A_k,
+	\]
+	where \(\sim\) denotes equality of the two MPV families.
 \end{theorem}
 
 \begin{theorem}[Sector decomposition from TP primitive irreducible blocks]

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -647,6 +647,11 @@ and~\cite{Cirac2021Matrix}.
 	$\beta : \{0,\ldots,n-1\}\to\C$ have no zero entries and their power sums
 	agree for \(1 \le k \le \max(m,n)\), then \(m=n\) and the two multisets
 	are equal.
+	For lists \((\lambda_{a,k})_{k=1}^{x_a}\) and
+	\((\lambda_{b,k})_{k=1}^{x_b}\), the hypothesis
+	\(\sum_{k=1}^{x_a}\lambda_{a,k}^N
+	  =\sum_{k=1}^{x_b}\lambda_{b,k}^N\) for
+	\(0\le N\le \max(x_a,x_b)\) implies equality of the two multisets.
 \end{theorem}
 
 \begin{proof}
@@ -659,6 +664,8 @@ and~\cite{Cirac2021Matrix}.
 	equal-root conclusion compares the padded multisets, and the nonzero-entry
 	hypothesis makes the number of padded zeros exactly \(\max(m,n)-m\) and
 	\(\max(m,n)-n\), forcing \(m=n\).
+	In the list form, the \(N=0\) power sum first gives \(x_a=x_b\), so the
+	same-cardinality finite-range theorem applies directly.
 \end{proof}
 
 \begin{theorem}[Equal power sums imply equal multisets]\label{thm:power_sum_multiset}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -623,18 +623,23 @@ and~\cite{Cirac2021Matrix}.
 	multiplicity and weight equality needed to identify the weighted
 	block-diagonal gauge.
 
-	The finite-range statement below includes both the same-cardinality form and
-	the nonzero-entry unequal-cardinality form. The latter pads the shorter
+	The finite-range statement below includes the same-cardinality form, the
+	nonzero-entry unequal-cardinality form, and the positive-power conclusion
+	after deleting zeros. The nonzero-entry form pads the shorter
 	family by zeros, applies the same-cardinality result at length
 	\(\max(m,n)\), and then uses the nonzero-entry hypothesis to count the
 	padded zeros. The Appendix lemma in the source also fixes an ordering
 	convention for the two families; here the conclusion is stated as multiset
 	equality, so no sorting hypothesis is needed.
+	If equality at exponent \(0\) is also assumed, the nonzero-entry hypothesis
+	can be omitted because \(\sum_k \lambda_{a,k}^0=x_a\) and
+	\(\sum_k \lambda_{b,k}^0=x_b\).
 \end{remark}
 
 \begin{theorem}[Finite-range equal power sums imply equal multisets]
 	\label{thm:bounded_power_sum_multiset}
 	\lean{Matrix.sum_pow_eq_implies_multiset_eq_of_le_card,
+		Matrix.sum_pow_eq_implies_nonzero_multiset_eq_of_le_max_length,
 		Matrix.sum_pow_eq_implies_multiset_eq_of_le_max_length,
 		Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card,
 		MPSTensor.power_sum_eq_implies_multiset_eq_of_le_card,
@@ -647,11 +652,19 @@ and~\cite{Cirac2021Matrix}.
 	$\beta : \{0,\ldots,n-1\}\to\C$ have no zero entries and their power sums
 	agree for \(1 \le k \le \max(m,n)\), then \(m=n\) and the two multisets
 	are equal.
-	For lists \((\lambda_{a,k})_{k=1}^{x_a}\) and
+	There is also an exponent-zero list form: for lists
+	\((\lambda_{a,k})_{k=1}^{x_a}\) and
 	\((\lambda_{b,k})_{k=1}^{x_b}\), the hypothesis
 	\(\sum_{k=1}^{x_a}\lambda_{a,k}^N
 	  =\sum_{k=1}^{x_b}\lambda_{b,k}^N\) for
-	\(0\le N\le \max(x_a,x_b)\) implies equality of the two multisets.
+	\(1\le N\le \max(x_a,x_b)\) implies
+	\[
+		\{\lambda_{a,k}\mid \lambda_{a,k}\neq 0\}_{k=1}^{x_a}
+		=
+		\{\lambda_{b,k}\mid \lambda_{b,k}\neq 0\}_{k=1}^{x_b}
+	\]
+	as multisets. If the equality is also assumed at \(N=0\), then the original
+	lists have the same multiset.
 \end{theorem}
 
 \begin{proof}
@@ -664,8 +677,11 @@ and~\cite{Cirac2021Matrix}.
 	equal-root conclusion compares the padded multisets, and the nonzero-entry
 	hypothesis makes the number of padded zeros exactly \(\max(m,n)-m\) and
 	\(\max(m,n)-n\), forcing \(m=n\).
-	In the list form, the \(N=0\) power sum first gives \(x_a=x_b\), so the
-	same-cardinality finite-range theorem applies directly.
+	Without a nonzero-entry hypothesis, first delete the zero entries; for
+	positive \(N\), this does not change
+	\(\sum_k\lambda_k^N\).  The nonzero-entry form then compares the remaining
+	multisets. In the exponent-zero list form, the equality at \(N=0\) gives
+	\(x_a=x_b\), so the same-cardinality finite-range theorem applies directly.
 \end{proof}
 
 \begin{theorem}[Equal power sums imply equal multisets]\label{thm:power_sum_multiset}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -371,8 +371,8 @@ facts used to recover the lists of weights from those power sums.
 
 \begin{proof}
 	\leanok
-	\uses{lem:coeff_eventually_eq, lem:copies_eq_of_eventually_coeff_eq,
-		thm:power_sum_multiset}
+	\uses{lem:coeff_eventually_eq, thm:bounded_power_sum_multiset,
+		lem:copies_eq_of_eventually_coeff_eq}
 	BNT linear independence and equality of total MPVs give eventual
 	coefficient equality by Lemma~\ref{lem:coeff_eventually_eq}.  Thus, for each
 	basis sector \(j\), the two finite nonzero weight families satisfy
@@ -381,13 +381,15 @@ facts used to recover the lists of weights from those power sums.
 		=
 		\sum_{q=1}^{r_j^T}(\mu_{j,q}^T)^N
 	\]
-	for all sufficiently large \(N\).  Lemma~\ref{lem:copies_eq_of_eventually_coeff_eq}
-	applies the signed-geometric-sequence argument at exponent \(0\), so
-	\(r_j^S=r_j^T\).  After transporting the right-hand index set along this
-	copy-count equality, the identities for positive powers become equality of
-	the power sums of two same-cardinality weight lists.  Newton--Girard
-	(Theorem~\ref{thm:power_sum_multiset}) then recovers equality of the sector
-	weight multisets.
+	for all sufficiently large \(N\).  The signed-geometric-sequence argument
+	extends this to every positive exponent.  Applying the finite-range
+	unequal-cardinality power-sum theorem
+	(Theorem~\ref{thm:bounded_power_sum_multiset}) gives both
+	\(r_j^S=r_j^T\) and equality of the sector weight multisets.  The
+	exponent-zero route of Lemma~\ref{lem:copies_eq_of_eventually_coeff_eq}
+	is kept as an alternative checked proof: it first recovers \(r_j^S=r_j^T\)
+	from the \(N=0\) identity and then applies the same-cardinality
+	Newton--Girard theorem.
 \end{proof}
 
 \begin{lemma}[Phase matching recovers copy counts and sector weights]%

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -107,6 +107,27 @@ In this notation, BNT linear independence separates the coefficient arrays, and
 Newton--Girard recovers the weights.  The formal declarations that only package
 these two algebra steps in sector-data notation are support lemmas, even when
 their names mention the Fundamental Theorem.
+One previously used formal route recovered the multiplicities \(r_j^S,r_j^T\)
+by first extrapolating eventual equality of the positive-power sums to the
+exponent-zero identity
+\[
+  \sum_{q=1}^{r_j^S}(\mu^S_{j,q})^0
+  =
+  \sum_{q=1}^{r_j^T}(\mu^T_{j,q})^0,
+\]
+and then applying the same-cardinality Newton--Girard theorem.  This is not a
+gap when all weights are nonzero, because the geometric-sequence extrapolation
+lemma proves the \(N=0\) identity from eventual equality at positive lengths.
+It is nevertheless not the route displayed in
+\cite[Lemma~\texttt{Lem:app\_simple}, lines~1155--1163]{Cirac2016MPDO_arXiv};
+the source applies the unequal-cardinality power-sum lemma after the BNT
+representatives have been matched.  Without the nonzero-weight hypothesis,
+positive powers would only determine the nonzero submultiset, so any use that
+counts zero weights must record an additional \(N=0\) hypothesis or a nonzero
+coefficient hypothesis.
+This classification follows the protocol in
+\path{docs/paper-gaps/policy.tex}; the detailed comparison is recorded in
+\path{docs/paper-gaps/power_sum_alternative_route.tex}.
 
 \section{External lemmas need explanations}
 

--- a/docs/paper-gaps/power_sum_alternative_route.tex
+++ b/docs/paper-gaps/power_sum_alternative_route.tex
@@ -1,0 +1,152 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Power Sums in the BNT Weight Comparison}
+\author{}
+\date{2026-05-08}
+
+\begin{document}
+\maketitle
+
+\section{The source lemma}
+
+This note concerns the scalar power-sum step in the non-periodic Fundamental
+Theorem proof for matrix product states in canonical form.  The source is
+\cite[Lemma~\texttt{Lem:app\_simple}, lines~1155--1163]{Cirac2016MPDO_arXiv}.
+It considers two finite families
+\[
+  (\lambda_{a,k})_{k=1}^{x_a},
+  \qquad
+  (\lambda_{b,k})_{k=1}^{x_b},
+\]
+ordered by modulus and phase, and assumes
+\[
+  \sum_{k=1}^{x_a}\lambda_{a,k}^{N}
+  =
+  \sum_{k=1}^{x_b}\lambda_{b,k}^{N},
+  \qquad N\le \max\{x_a,x_b\}.        \tag{\texttt{eq:app\_aux}}
+\]
+The conclusion is \(x_a=x_b\) and equality of the ordered lists.  In the
+equal-case corollary of the Fundamental Theorem, this lemma is applied after
+the BNT representatives have been matched, to the coefficient families
+\[
+  (\mu_{j,q})_{q=1}^{r_{a,j}},
+  \qquad
+  (\nu_{j,q}e^{i\phi_j})_{q=1}^{r_{b,j}}.
+\]
+
+The formal statements do not use the source's ordering convention.  They state
+the conclusion as equality of multisets.  They do, however, keep the relevant
+nonzero-coefficient hypothesis: positive powers alone cannot count zero
+entries.
+
+\section{The source-facing formal route}
+
+For a fixed BNT representative \(j\), the formal coefficient comparison produces
+eventual equality of the power sums
+\[
+  \sum_{q=1}^{r_j^S}(\mu^S_{j,q})^N
+  =
+  \sum_{q=1}^{r_j^T}(\mu^T_{j,q})^N
+\]
+from BNT linear independence.  A finite signed sum of nonzero geometric
+sequences which vanishes eventually vanishes at every exponent, so the equality
+holds for all positive \(N\).  The formal proof then applies the
+unequal-cardinality finite-range power-sum theorem.\footnote{\path{Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card}.}
+The endpoint used by the BNT comparison is the corresponding sector-weight
+comparison lemma.\footnote{\path{MPSTensor.SectorWeightData.copies_eq_and_weight_multiset_eq_of_eventually_coeff_eq}.}
+
+The conclusion is
+\[
+  r_j^S=r_j^T,
+  \qquad
+  \{\!\{\mu^S_{j,q}:1\le q\le r_j^S\}\!\}
+  =
+  \{\!\{\mu^T_{j,q}:1\le q\le r_j^T\}\!\}.
+\]
+This is the multiset form of the source's ordered-list conclusion.
+
+\section{The alternative formal route}
+
+An earlier formal proof reached the same endpoint by using the recurrence
+behind finite sums of geometric sequences before applying Newton--Girard.  The
+mathematical input is the following elementary lemma.  Let
+\[
+  F(N)=\sum_{\ell=1}^{m} c_\ell w_\ell^N,
+  \qquad w_\ell\neq 0.
+\]
+If \(F(N)=0\) for all \(N\ge M\), then \(F(k)=0\) for every \(k\ge 0\).  Indeed,
+subtracting \(w_1F(N)\) from \(F(N+1)\) gives
+\[
+  0
+  =
+  F(N+1)-w_1F(N)
+  =
+  \sum_{\ell=2}^{m} c_\ell(w_\ell-w_1)w_\ell^N
+\]
+for all \(N\ge M\).  This is a signed sum with one fewer term.  Induction on
+\(m\) shows that the displayed sum is zero for every \(N\ge 0\), hence
+\[
+  F(N+1)=w_1F(N)\qquad\text{for all }N\ge 0.
+\]
+Thus \(F(k)=w_1^kF(0)\).  Since \(F(M)=0\) and \(w_1^M\neq 0\), one has
+\(F(0)=0\), and therefore \(F(k)=0\) for all \(k\ge 0\).
+
+For the two sector-weight families, this lemma is applied to the signed union
+\[
+  F(N)
+  =
+  \sum_{q=1}^{r_j^S}(\mu^S_{j,q})^N
+  -
+  \sum_{q=1}^{r_j^T}(\mu^T_{j,q})^N .
+\]
+The nonzero-weight hypothesis is exactly what permits the step \(w_1^M\neq 0\).
+Since all weights in \leanid{SectorWeightData} are nonzero, the exponent-zero
+power sum is
+\[
+  \sum_{q=1}^{r_j}\mu_{j,q}^{0}=r_j.
+\]
+Thus \(F(0)=0\) gives \(r_j^S=r_j^T\).  After transporting the right-hand index
+set along this equality, the same extrapolation gives equality of the positive
+power sums over a common index type:
+\[
+  \sum_{q=1}^{r_j^S}(\mu^S_{j,q})^N
+  =
+  \sum_{q=1}^{r_j^S}(\mu^T_{j,q})^N,
+  \qquad N\ge 1.
+\]
+The proof then applies the same-cardinality Newton--Girard theorem to recover
+the weight multiset.
+
+This route is still present as checked Lean code:
+\begin{itemize}
+  \item \path{MPSTensor.SectorWeightData.copies_eq_of_eventually_coeff_eq};
+  \item \path{MPSTensor.SectorWeightData.eventually_coeff_eq_implies_all_pos_eq_after_copies};
+  \item \path{MPSTensor.SectorWeightData.weight_multiset_eq_of_copies_eq_of_coeff_eq}.
+\end{itemize}
+It is an alternative formal proof, not the route displayed in the source.
+
+\section{Conclusion}
+
+There is no proof gap in the alternative route under the nonzero-weight
+hypotheses used in the formal sector-weight data: the extrapolation theorem
+proves the \(N=0\) identity, so the copy count is justified.  Nevertheless, the
+source-facing theorem surface should use the unequal-cardinality power-sum
+lemma, because that is the lemma invoked in the paper after BNT representative
+matching.
+
+There would be a genuine gap if one tried to count zero weights from positive
+power sums alone.  For example, adjoining a zero to a finite family does not
+change any positive power sum.  Hence a statement without a nonzero-coefficient
+hypothesis can only recover the multiset after deleting zero entries, unless an
+additional \(N=0\) identity is assumed.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation
- Post-#1483 follow-up: make the scalar power-sum lemma precise against arXiv:1606.00608 Appendix A, especially the difference between positive exponents and the exponent-zero variant.
- Keep #1170 blueprint sync current: Chapter 8 canonical-form `\lean{}` tags and Chapter 10 power-sum statements had drifted from the current Lean surface.

### Description
- Added the positive-power list theorem
  `Matrix.sum_pow_eq_implies_nonzero_multiset_eq_of_le_max_length`: equality of
  power sums for `1 ≤ N ≤ max(|la|, |lb|)` determines the multiset after deleting
  zero entries.
- Clarified the three distinct true forms:
  same-cardinality Newton-Girard, unequal-cardinality with nonzero entries, and
  the stronger exponent-zero list statement.
- Updated the non-periodic BNT sector-weight comparison so the theorem surface
  uses the source-facing unequal-cardinality finite-range power-sum route, while
  keeping the exponent-zero route as checked Lean lemmas.
- Added `docs/paper-gaps/power_sum_alternative_route.tex`, a separate LaTeX
  note comparing the source-facing route with the alternative Lean proof and
  identifying exactly where a zero-weight gap would arise.
- Updated the Chapter 10 blueprint to state these formulas separately.
- Updated the related fundamental-theorem wrapper docstrings and the Chapter 8
  blueprint declaration tags that were stale on `main`.

### Testing
- `lake env lean TNLean/Algebra/ScalarPowerSumIdentity.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/EqualProportional.lean`
- `lake build TNLean.Algebra.ScalarPowerSumIdentity`
- `lake build TNLean.MPS.FundamentalTheorem.EqualProportional`
- `lake build TNLean.MPS.FundamentalTheorem.SectorWeightComparison`
- `lake build TNLean.MPS.FundamentalTheorem.SectorDecomposition`
- `lake build TNLean` passed before this follow-up on the same branch.
- `leanblueprint web`
- `leanblueprint checkdecls`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error power_sum_alternative_route.tex`
- `git diff --check`

Addresses #1170

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes theorem surfaces and proof route for core Newton–Girard/power-sum reasoning used in the fundamental-theorem pipeline, even though changes are mechanically verified in Lean.
> 
> **Overview**
> Clarifies and extends the scalar finite-range power-sum results by splitting the unequal-cardinality story into three explicit cases: same-cardinality Newton–Girard, unequal-cardinality with a **nonzero-entry** hypothesis (positive powers), and an exponent-zero variant (length recovery). It adds a new positive-power list theorem `Matrix.sum_pow_eq_implies_nonzero_multiset_eq_of_le_max_length` showing that, without nonzero assumptions, positive powers only determine the multiset *after deleting zeros*.
> 
> Updates the non-periodic BNT sector-weight comparison to use the **unequal-cardinality finite-range** theorem directly (matching the Appendix argument), while keeping the previous exponent-zero approach as alternative checked lemmas. Documentation/blueprint text and `\lean{}` tags are synced accordingly, and a new note `docs/paper-gaps/power_sum_alternative_route.tex` records the comparison and where zero-weight counting would otherwise break.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d9c325c03919f8bda9d5703e5eee0be200a028d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->