### PR TITLE
feat(MPS/CanonicalForm/SectorComparison): assemble per-block GaugePhase to global X (CPSV16 Cor II.2)

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -479,5 +479,118 @@ theorem toCommonPrimitivePhaseCoverHypotheses
 
 end CommonPrimitiveBNTCoverHypotheses
 
+/-! ### Per-block to global proportional gauge
+
+The per-block matchers from `ProportionalDecompositionConclusion` produce, for every
+block index `k`, a dimension equality, an invertible matrix `X_k`, and a phase
+`ζ_k ≠ 0` with `B (perm k) i = ζ_k • X_k * (cast (A k)) i * X_k⁻¹`.  The records
+below repackage that data and assemble the per-block `X_k` into a single
+block-diagonal element of `GL`, the global proportionality matrix from CPSV16
+Cor II.2 (`eq:II:A=XAX`). -/
+
+/-- Per-block gauge-phase data attached to a `ProportionalDecompositionConclusion`.
+
+This is the structural record realizing CPSV16 Cor II.2 (eq. `eq:II:A=XAX`):
+a permutation matching the block indices, per-block dimension equalities, and per-block
+gauge matrices `X k` with phases `phase k` satisfying
+`blocksB (perm k) i = phase k • X k * cast (blocksA k) i * (X k)⁻¹`. -/
+structure BlockProportionalGaugePhaseData
+    {d rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k)) : Type where
+  /-- Permutation matching the two block index sets. -/
+  perm : Fin rA ≃ Fin rB
+  /-- Per-block dimension equality. -/
+  hdim : ∀ k : Fin rA, dimA k = dimB (perm k)
+  /-- Per-block gauge matrix. -/
+  X : (k : Fin rA) → GL (Fin (dimB (perm k))) ℂ
+  /-- Per-block phase. -/
+  phase : Fin rA → ℂ
+  /-- Each per-block phase is nonzero. -/
+  phase_ne : ∀ k, phase k ≠ 0
+  /-- Per-block conjugation identity with phase. -/
+  conj : ∀ k : Fin rA, ∀ i : Fin d,
+    blocksB (perm k) i =
+      phase k • ((X k : Matrix (Fin (dimB (perm k))) (Fin (dimB (perm k))) ℂ) *
+        (cast (congr_arg (MPSTensor d) (hdim k)) (blocksA k)) i *
+        (((X k)⁻¹ : GL (Fin (dimB (perm k))) ℂ) :
+          Matrix (Fin (dimB (perm k))) (Fin (dimB (perm k))) ℂ))
+
+namespace BlockProportionalGaugePhaseData
+
+variable {d rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+variable {blocksA : (j : Fin rA) → MPSTensor d (dimA j)}
+variable {blocksB : (k : Fin rB) → MPSTensor d (dimB k)}
+
+/-- Extract per-block gauge-phase data from a `ProportionalDecompositionConclusion`. -/
+noncomputable def ofConclusion
+    (h : ProportionalDecompositionConclusion (d := d) blocksA blocksB) :
+    BlockProportionalGaugePhaseData blocksA blocksB :=
+  let perm := h.choose_spec.choose
+  let hperm := h.choose_spec.choose_spec
+  let hdim : ∀ k : Fin rA, dimA k = dimB (perm k) :=
+    fun k => (hperm k).choose
+  let hGP : ∀ k : Fin rA, GaugePhaseEquiv (d := d)
+      (cast (congr_arg (MPSTensor d) (hdim k)) (blocksA k)) (blocksB (perm k)) :=
+    fun k => (hperm k).choose_spec
+  let X : (k : Fin rA) → GL (Fin (dimB (perm k))) ℂ :=
+    fun k => (hGP k).choose
+  let ζ : Fin rA → ℂ := fun k => (hGP k).choose_spec.choose
+  have hζ : ∀ k, ζ k ≠ 0 := fun k => (hGP k).choose_spec.choose_spec.1
+  have hX : ∀ k i, blocksB (perm k) i =
+      ζ k • ((X k : Matrix (Fin (dimB (perm k))) (Fin (dimB (perm k))) ℂ) *
+        (cast (congr_arg (MPSTensor d) (hdim k)) (blocksA k)) i *
+        (((X k)⁻¹ : GL (Fin (dimB (perm k))) ℂ) :
+          Matrix (Fin (dimB (perm k))) (Fin (dimB (perm k))) ℂ)) :=
+    fun k => (hGP k).choose_spec.choose_spec.2
+  { perm := perm
+    hdim := hdim
+    X := X
+    phase := ζ
+    phase_ne := hζ
+    conj := hX }
+
+/-- The reindexed `B`-side block family at the matched dimensions. -/
+noncomputable def reindexB (G : BlockProportionalGaugePhaseData blocksA blocksB) :
+    (k : Fin rA) → MPSTensor d (dimB (G.perm k)) :=
+  fun k => blocksB (G.perm k)
+
+/-- The cast `A`-side block family at the matched dimensions. -/
+noncomputable def castA (G : BlockProportionalGaugePhaseData blocksA blocksB) :
+    (k : Fin rA) → MPSTensor d (dimB (G.perm k)) :=
+  fun k => cast (congr_arg (MPSTensor d) (G.hdim k)) (blocksA k)
+
+/-- The global block-diagonal gauge matrix assembled from the per-block `X k`,
+viewed on the dependent total index. -/
+noncomputable def globalGL (G : BlockProportionalGaugePhaseData blocksA blocksB) :
+    GL ((k : Fin rA) × Fin (dimB (G.perm k))) ℂ :=
+  blockDiagonalGL G.X
+
+/-- The global block-diagonal gauge matrix as an element of
+`GL (Fin (∑ k, dimB (perm k))) ℂ`, the bond dimension of the assembled tensor. -/
+noncomputable def globalX (G : BlockProportionalGaugePhaseData blocksA blocksB) :
+    GL (Fin (∑ k : Fin rA, dimB (G.perm k))) ℂ :=
+  Units.map
+    (Matrix.reindexAlgEquiv ℂ ℂ
+      (finSigmaFinEquiv (n := fun k : Fin rA => dimB (G.perm k)))).toRingEquiv.toMonoidHom
+    G.globalGL
+
+/-- When per-block phases are absorbed into the block weights via
+`μA k = μB (perm k) * phase k`, the per-block conjugation identities assemble into a
+gauge equivalence between the weighted block-diagonal tensors built from the cast
+left family and the permuted right family. -/
+theorem gaugeEquiv_toTensorFromBlocks
+    (G : BlockProportionalGaugePhaseData blocksA blocksB)
+    (μA : Fin rA → ℂ) (μB : Fin rB → ℂ)
+    (hμ : ∀ k, μA k = μB (G.perm k) * G.phase k) :
+    GaugeEquiv
+      (toTensorFromBlocks (d := d) (μ := μA) G.castA)
+      (toTensorFromBlocks (d := d) (μ := fun k => μB (G.perm k)) G.reindexB) :=
+  gaugeEquiv_toTensorFromBlocks_of_blockGaugePhase_weight
+    (μA := μA) (μB := fun k => μB (G.perm k))
+    (A := G.castA) (B := G.reindexB)
+    G.X G.phase G.conj hμ
+
+end BlockProportionalGaugePhaseData
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.SectorComparison.StructuralTheorem
 import TNLean.MPS.CanonicalForm.PhaseCover
+import TNLean.MPS.FundamentalTheorem.Multi
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
@@ -448,7 +449,7 @@ noncomputable def ofCommonRepresentativeBNTCoverHypotheses
     h.zero_length_identity h.left_injective h.right_injective h.decompData
 
 /-- BNT-cover hypotheses produce a common MPV phase cover. -/
-theorem toMPVCommonPhaseCover    {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+theorem toMPVCommonPhaseCover {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
     {zeroTailA zeroTailB DtotA DtotB : ℕ}
     {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
@@ -484,15 +485,16 @@ end CommonPrimitiveBNTCoverHypotheses
 The per-block matchers from `ProportionalDecompositionConclusion` produce, for every
 block index `k`, a dimension equality, an invertible matrix `X_k`, and a phase
 `ζ_k ≠ 0` with `B (perm k) i = ζ_k • X_k * (cast (A k)) i * X_k⁻¹`.  The records
-below repackage that data and assemble the per-block `X_k` into a single
-block-diagonal element of `GL`, the global proportionality matrix from CPSV16
-Cor II.2 (`eq:II:A=XAX`). -/
+below store that data and assemble the per-block `X_k` into a single block-diagonal
+element of `GL`, the global proportionality matrix from arXiv:1606.00608,
+lines 1155–1192 (Corollary II.2, `eq:II:A=XAX`). -/
 
 /-- Per-block gauge-phase data attached to a `ProportionalDecompositionConclusion`.
 
-This is the structural record realizing CPSV16 Cor II.2 (eq. `eq:II:A=XAX`):
-a permutation matching the block indices, per-block dimension equalities, and per-block
-gauge matrices `X k` with phases `phase k` satisfying
+This is the structural record realizing arXiv:1606.00608, lines 1155–1192
+(Corollary II.2, eq. `eq:II:A=XAX`): a permutation matching the block indices,
+per-block dimension equalities, and per-block gauge matrices `X k` with phases
+`phase k` satisfying
 `blocksB (perm k) i = phase k • X k * cast (blocksA k) i * (X k)⁻¹`. -/
 structure BlockProportionalGaugePhaseData
     {d rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -570,10 +572,62 @@ noncomputable def globalGL (G : BlockProportionalGaugePhaseData blocksA blocksB)
 `GL (Fin (∑ k, dimB (perm k))) ℂ`, the bond dimension of the assembled tensor. -/
 noncomputable def globalX (G : BlockProportionalGaugePhaseData blocksA blocksB) :
     GL (Fin (∑ k : Fin rA, dimB (G.perm k))) ℂ :=
-  Units.map
-    (Matrix.reindexAlgEquiv ℂ ℂ
-      (finSigmaFinEquiv (n := fun k : Fin rA => dimB (G.perm k)))).toRingEquiv.toMonoidHom
-    G.globalGL
+  globalGaugeOfBlocks G.X
+
+/-- Explicit global-gauge witness for the proportional block assembly.
+
+When per-block phases are absorbed into the block weights via
+`μA k = μB (perm k) * phase k`, the weighted direct sum of the permuted right
+blocks is conjugate to the weighted direct sum of the cast left blocks by
+`G.globalX`. -/
+theorem toTensorFromBlocks_reindexB_eq_globalX_conj
+    (G : BlockProportionalGaugePhaseData blocksA blocksB)
+    (μA : Fin rA → ℂ) (μB : Fin rB → ℂ)
+    (hμ : ∀ k, μA k = μB (G.perm k) * G.phase k) :
+    ∀ i : Fin d,
+      toTensorFromBlocks (d := d) (μ := fun k => μB (G.perm k)) G.reindexB i =
+        (G.globalX : Matrix (Fin (∑ k : Fin rA, dimB (G.perm k)))
+          (Fin (∑ k : Fin rA, dimB (G.perm k))) ℂ) *
+          toTensorFromBlocks (d := d) (μ := μA) G.castA i *
+          (((G.globalX)⁻¹ : GL (Fin (∑ k : Fin rA, dimB (G.perm k))) ℂ) :
+            Matrix (Fin (∑ k : Fin rA, dimB (G.perm k)))
+              (Fin (∑ k : Fin rA, dimB (G.perm k))) ℂ) := by
+  classical
+  have hWeighted :
+      ∀ k : Fin rA, ∀ i : Fin d,
+        (μB (G.perm k)) • G.reindexB k i =
+          (G.X k : Matrix (Fin (dimB (G.perm k))) (Fin (dimB (G.perm k))) ℂ) *
+            ((μA k) • G.castA k i) *
+            (((G.X k)⁻¹ : GL (Fin (dimB (G.perm k))) ℂ) :
+              Matrix (Fin (dimB (G.perm k))) (Fin (dimB (G.perm k))) ℂ) := by
+    intro k i
+    change (μB (G.perm k)) • blocksB (G.perm k) i =
+      (G.X k : Matrix (Fin (dimB (G.perm k))) (Fin (dimB (G.perm k))) ℂ) *
+        ((μA k) • G.castA k i) *
+        (((G.X k)⁻¹ : GL (Fin (dimB (G.perm k))) ℂ) :
+          Matrix (Fin (dimB (G.perm k))) (Fin (dimB (G.perm k))) ℂ)
+    rw [G.conj k i, hμ k]
+    simp [castA, smul_smul, Matrix.mul_assoc, Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
+  have hFormula :=
+    toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
+      (μ := fun _ : Fin rA => (1 : ℂ))
+      (A := fun k i => μA k • G.castA k i)
+      (B := fun k i => μB (G.perm k) • G.reindexB k i)
+      G.X hWeighted
+  have hLeft :
+      toTensorFromBlocks (d := d) (μ := fun _ : Fin rA => (1 : ℂ))
+        (fun k i => μA k • G.castA k i) =
+        toTensorFromBlocks (d := d) (μ := μA) G.castA := by
+    funext i
+    simp [toTensorFromBlocks]
+  have hRight :
+      toTensorFromBlocks (d := d) (μ := fun _ : Fin rA => (1 : ℂ))
+        (fun k i => μB (G.perm k) • G.reindexB k i) =
+        toTensorFromBlocks (d := d) (μ := fun k => μB (G.perm k)) G.reindexB := by
+    funext i
+    simp [toTensorFromBlocks]
+  intro i
+  simpa [globalX, hLeft, hRight] using hFormula i
 
 /-- When per-block phases are absorbed into the block weights via
 `μA k = μB (perm k) * phase k`, the per-block conjugation identities assemble into a
@@ -585,11 +639,8 @@ theorem gaugeEquiv_toTensorFromBlocks
     (hμ : ∀ k, μA k = μB (G.perm k) * G.phase k) :
     GaugeEquiv
       (toTensorFromBlocks (d := d) (μ := μA) G.castA)
-      (toTensorFromBlocks (d := d) (μ := fun k => μB (G.perm k)) G.reindexB) :=
-  gaugeEquiv_toTensorFromBlocks_of_blockGaugePhase_weight
-    (μA := μA) (μB := fun k => μB (G.perm k))
-    (A := G.castA) (B := G.reindexB)
-    G.X G.phase G.conj hμ
+      (toTensorFromBlocks (d := d) (μ := fun k => μB (G.perm k)) G.reindexB) := by
+  exact ⟨G.globalX, G.toTensorFromBlocks_reindexB_eq_globalX_conj μA μB hμ⟩
 
 end BlockProportionalGaugePhaseData
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -485,9 +485,10 @@ end CommonPrimitiveBNTCoverHypotheses
 The per-block matchers from `ProportionalDecompositionConclusion` produce, for every
 block index `k`, a dimension equality, an invertible matrix `X_k`, and a phase
 `ζ_k ≠ 0` with `B (perm k) i = ζ_k • X_k * (cast (A k)) i * X_k⁻¹`.  The records
-below store that data and assemble the per-block `X_k` into a single block-diagonal
-element of `GL`, the global proportionality matrix from arXiv:1606.00608,
-lines 1155–1192 (Corollary II.2, `eq:II:A=XAX`). -/
+below package the permutation, per-block dimension equalities, gauge matrices
+`X k`, and phases `ζ k` into a single structure, and assemble the per-block
+`X_k` into a block-diagonal element of `GL`, the global proportionality matrix
+from arXiv:1606.00608, lines 1155–1192 (Corollary II.2, `eq:II:A=XAX`). -/
 
 /-- Per-block gauge-phase data attached to a `ProportionalDecompositionConclusion`.
 
@@ -573,13 +574,13 @@ noncomputable def globalGL (G : BlockProportionalGaugePhaseData blocksA blocksB)
   blockDiagonalGL G.X
 
 /-- The flattened block-diagonal gauge matrix as an element of
-`GL (Fin (∑ k, dimB (perm k))) ℂ`, the bond dimension of the assembled tensor. -/
+`GL (Fin (∑ k, dimB (perm k))) ℂ`, the bond dimension of the assembled tensor.
+
+Defined as the canonical reindexing of `G.globalGL`, so that
+`G.globalX = globalGaugeOfBlocks G.X` definitionally. -/
 noncomputable def globalX (G : BlockProportionalGaugePhaseData blocksA blocksB) :
     GL (Fin (∑ k : Fin rA, dimB (G.perm k))) ℂ :=
-  Units.map
-    (Matrix.reindexAlgEquiv ℂ ℂ
-      (finSigmaFinEquiv (n := fun k : Fin rA => dimB (G.perm k)))).toRingEquiv.toMonoidHom
-    G.globalGL
+  globalGaugeOfBlocks G.X
 
 /-- Explicit global-gauge witness for the proportional block assembly.
 
@@ -634,7 +635,7 @@ theorem toTensorFromBlocks_reindexB_eq_globalX_conj
     funext i
     simp [toTensorFromBlocks]
   intro i
-  simpa [globalX, globalGL, globalGaugeOfBlocks, hLeft, hRight] using hFormula i
+  simpa [globalX, hLeft, hRight] using hFormula i
 
 /-- When per-block phases are absorbed into the block weights via
 `μA k = μB (perm k) * phase k`, the per-block conjugation identities assemble into a

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -562,13 +562,17 @@ noncomputable def castA (G : BlockProportionalGaugePhaseData blocksA blocksB) :
     (k : Fin rA) → MPSTensor d (dimB (G.perm k)) :=
   fun k => cast (congr_arg (MPSTensor d) (G.hdim k)) (blocksA k)
 
-/-- The global block-diagonal gauge matrix assembled from the per-block `X k`,
-viewed on the dependent total index. -/
+/-- The unflattened block-diagonal gauge assembled from the per-block `X k`.
+
+This lives on the dependent sigma-indexed bond space
+`(k : Fin rA) × Fin (dimB (G.perm k))`, with diagonal block `X k` over the
+matched `B`-side block `G.perm k`.  The flattened/reindexed gauge acting on the
+bond dimension of `toTensorFromBlocks` is `G.globalX`. -/
 noncomputable def globalGL (G : BlockProportionalGaugePhaseData blocksA blocksB) :
     GL ((k : Fin rA) × Fin (dimB (G.perm k))) ℂ :=
   blockDiagonalGL G.X
 
-/-- The global block-diagonal gauge matrix as an element of
+/-- The flattened block-diagonal gauge matrix as an element of
 `GL (Fin (∑ k, dimB (perm k))) ℂ`, the bond dimension of the assembled tensor. -/
 noncomputable def globalX (G : BlockProportionalGaugePhaseData blocksA blocksB) :
     GL (Fin (∑ k : Fin rA, dimB (G.perm k))) ℂ :=

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -576,7 +576,10 @@ noncomputable def globalGL (G : BlockProportionalGaugePhaseData blocksA blocksB)
 `GL (Fin (∑ k, dimB (perm k))) ℂ`, the bond dimension of the assembled tensor. -/
 noncomputable def globalX (G : BlockProportionalGaugePhaseData blocksA blocksB) :
     GL (Fin (∑ k : Fin rA, dimB (G.perm k))) ℂ :=
-  globalGaugeOfBlocks G.X
+  Units.map
+    (Matrix.reindexAlgEquiv ℂ ℂ
+      (finSigmaFinEquiv (n := fun k : Fin rA => dimB (G.perm k)))).toRingEquiv.toMonoidHom
+    G.globalGL
 
 /-- Explicit global-gauge witness for the proportional block assembly.
 
@@ -631,7 +634,7 @@ theorem toTensorFromBlocks_reindexB_eq_globalX_conj
     funext i
     simp [toTensorFromBlocks]
   intro i
-  simpa [globalX, hLeft, hRight] using hFormula i
+  simpa [globalX, globalGL, globalGaugeOfBlocks, hLeft, hRight] using hFormula i
 
 /-- When per-block phases are absorbed into the block weights via
 `μA k = μB (perm k) * phase k`, the per-block conjugation identities assemble into a

--- a/TNLean/MPS/FundamentalTheorem/Multi.lean
+++ b/TNLean/MPS/FundamentalTheorem/Multi.lean
@@ -46,15 +46,16 @@ noncomputable def blockDiagonalGL (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
    blockDiagonal'_mul_one _ _ (fun k => by simp),
    blockDiagonal'_mul_one _ _ (fun k => by simp)⟩
 
+/-- Assemble per-block gauges into the flattened global `GL` element used by
+`toTensorFromBlocks`.  This is the reindexed block-diagonal matrix `⊕ₖ X k` on the
+canonical `Fin (∑ k, dim k)` bond index. -/
+noncomputable def globalGaugeOfBlocks (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
+    GL (Fin (∑ k : Fin r, dim k)) ℂ :=
+  Units.map
+    (Matrix.reindexAlgEquiv ℂ ℂ (finSigmaFinEquiv (n := dim))).toRingEquiv.toMonoidHom
+    (blockDiagonalGL X)
+
 end BlockDiagonalGL
-
-/-! ## Reindexing `GL` -/
-
-section ReindexGL
-
-variable {m n : Type*} [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
-
-end ReindexGL
 
 /-! ## Gauge equivalence for direct sums -/
 
@@ -64,23 +65,27 @@ variable {r : ℕ} {dim : Fin r → ℕ}
 variable (μ : Fin r → ℂ)
 variable (A B : (k : Fin r) → MPSTensor d (dim k))
 
-/-- If `B_k^i = X_k A_k^i X_k⁻¹` for every block, then the weighted direct sums
-are gauge equivalent by the block-diagonal matrix `⊕_k X_k`. -/
-lemma gaugeEquiv_toTensorFromBlocks_of_blockConj
+/-- Direct conjugation formula for weighted direct sums using the explicit flattened
+global gauge assembled from the per-block gauges. -/
+theorem toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
     (X : (k : Fin r) → GL (Fin (dim k)) ℂ)
     (hX : ∀ k : Fin r, ∀ i : Fin d,
       B k i =
         (X k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) * A k i *
           (((X k)⁻¹ : GL (Fin (dim k)) ℂ) : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) :
-    GaugeEquiv (toTensorFromBlocks (d := d) (μ := μ) A)
-      (toTensorFromBlocks (d := d) (μ := μ) B) := by
+    ∀ i : Fin d,
+      toTensorFromBlocks (d := d) (μ := μ) B i =
+        (globalGaugeOfBlocks X : Matrix (Fin (∑ k : Fin r, dim k))
+          (Fin (∑ k : Fin r, dim k)) ℂ) *
+          toTensorFromBlocks (d := d) (μ := μ) A i *
+          (((globalGaugeOfBlocks X)⁻¹ : GL (Fin (∑ k : Fin r, dim k)) ℂ) :
+            Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ) := by
   classical
+  intro i
   let α := (k : Fin r) × Fin (dim k)
   let e : α ≃ Fin (∑ k : Fin r, dim k) := finSigmaFinEquiv
   let f : Matrix α α ℂ →* Matrix (Fin _) (Fin _) ℂ :=
     (Matrix.reindexAlgEquiv ℂ ℂ e).toRingEquiv.toMonoidHom
-  let Xfin : GL (Fin _) ℂ := (Units.map f) (blockDiagonalGL X)
-  refine ⟨Xfin, fun i => ?_⟩
   let BD := fun (T : (k : Fin r) → MPSTensor d (dim k)) =>
     Matrix.blockDiagonal' fun k => (μ k) • T k i
   let XBD : Matrix α α ℂ :=
@@ -97,11 +102,29 @@ lemma gaugeEquiv_toTensorFromBlocks_of_blockConj
         fun k => (X k : Matrix _ _ ℂ) * ((μ k) • A k i) * ((X k)⁻¹ : Matrix _ _ ℂ) := by
       funext k; simp [hX k i, Algebra.mul_smul_comm, Algebra.smul_mul_assoc, Matrix.mul_assoc]
     rw [this, ← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
-  have hXfin : (Xfin : Matrix _ _ ℂ) = f XBD := by simp [Xfin, XBD, blockDiagonalGL]
-  have hXfin_inv : ((Xfin⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) = f XBDinv := by
-    simp [Xfin, XBDinv, blockDiagonalGL]
+  have hXfin :
+      (globalGaugeOfBlocks X : Matrix (Fin (∑ k : Fin r, dim k))
+        (Fin (∑ k : Fin r, dim k)) ℂ) = f XBD := by
+    simp [globalGaugeOfBlocks, XBD, blockDiagonalGL, f, e]
+  have hXfin_inv :
+      (((globalGaugeOfBlocks X)⁻¹ : GL (Fin (∑ k : Fin r, dim k)) ℂ) :
+        Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ) = f XBDinv := by
+    simp [globalGaugeOfBlocks, XBDinv, blockDiagonalGL, f, e]
   rw [htoB, htoA, hBD]
   simp [map_mul, hXfin, hXfin_inv, Matrix.mul_assoc]
+
+/-- If `B_k^i = X_k A_k^i X_k⁻¹` for every block, then the weighted direct sums
+are gauge equivalent by the block-diagonal matrix `⊕_k X_k`. -/
+lemma gaugeEquiv_toTensorFromBlocks_of_blockConj
+    (X : (k : Fin r) → GL (Fin (dim k)) ℂ)
+    (hX : ∀ k : Fin r, ∀ i : Fin d,
+      B k i =
+        (X k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) * A k i *
+          (((X k)⁻¹ : GL (Fin (dim k)) ℂ) : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) :
+    GaugeEquiv (toTensorFromBlocks (d := d) (μ := μ) A)
+      (toTensorFromBlocks (d := d) (μ := μ) B) := by
+  exact ⟨globalGaugeOfBlocks X,
+    toTensorFromBlocks_eq_globalGaugeOfBlocks_conj (μ := μ) (A := A) (B := B) X hX⟩
 
 /-- Gauge equivalence of weighted direct sums from gauge equivalence of each summand. -/
 lemma gaugeEquiv_toTensorFromBlocks_of_blockGauge

--- a/TNLean/MPS/FundamentalTheorem/Multi.lean
+++ b/TNLean/MPS/FundamentalTheorem/Multi.lean
@@ -48,7 +48,10 @@ noncomputable def blockDiagonalGL (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
 
 /-- Assemble per-block gauges into the flattened global `GL` element used by
 `toTensorFromBlocks`.  This is the reindexed block-diagonal matrix `⊕ₖ X k` on the
-canonical `Fin (∑ k, dim k)` bond index. -/
+canonical `Fin (∑ k, dim k)` bond index, naming the global gauge `X = ⊕ₖ X k`
+that arises in the proportional decomposition.
+
+Reference: arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192). -/
 noncomputable def globalGaugeOfBlocks (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
     GL (Fin (∑ k : Fin r, dim k)) ℂ :=
   Units.map
@@ -65,8 +68,13 @@ variable {r : ℕ} {dim : Fin r → ℕ}
 variable (μ : Fin r → ℂ)
 variable (A B : (k : Fin r) → MPSTensor d (dim k))
 
-/-- Direct conjugation formula for weighted direct sums using the explicit flattened
-global gauge assembled from the per-block gauges. -/
+/-- Direct conjugation formula for weighted direct sums.
+
+If `B k i = X k * A k i * (X k)⁻¹` for every `k, i`, then for every `i`,
+`toTensorFromBlocks μ B i = (⊕ X) * toTensorFromBlocks μ A i * (⊕ X)⁻¹`,
+where `⊕ X = globalGaugeOfBlocks X` is the reindexed block-diagonal gauge.
+
+Reference: arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192). -/
 theorem toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
     (X : (k : Fin r) → GL (Fin (dim k)) ℂ)
     (hX : ∀ k : Fin r, ∀ i : Fin d,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1107,6 +1107,50 @@ BNT comparison hypotheses for the common primitive sectors.
 	theorem, and the phase-cover hypotheses imply the span hypotheses.
 \end{proof}
 
+\begin{definition}[Per-block proportional gauge-phase data]%
+\label{def:block_proportional_gauge_phase_data}
+	\lean{MPSTensor.BlockProportionalGaugePhaseData,
+		MPSTensor.BlockProportionalGaugePhaseData.ofConclusion,
+		MPSTensor.BlockProportionalGaugePhaseData.reindexB,
+		MPSTensor.BlockProportionalGaugePhaseData.castA,
+		MPSTensor.BlockProportionalGaugePhaseData.globalGL,
+		MPSTensor.BlockProportionalGaugePhaseData.globalX}
+	\leanok
+	\uses{def:common_primitive_proportional_hypotheses, def:gauge_phase_equiv}
+	The proportional-decomposition conclusion can be unpacked into explicit
+	per-block data: a permutation matching the two block families, equalities of
+	matched bond dimensions, gauges $X_k$, and nonzero phases $\zeta_k$ such that
+	\[
+		B_{\sigma(k)}^i=\zeta_k X_k A_k^i X_k^{-1}
+	\]
+	after casting the source block along the dimension equality.  The auxiliary
+	projections name the reindexed target family, the cast source family, and the
+	dependent and flattened block-diagonal gauges assembled from the $X_k$.
+\end{definition}
+
+\begin{theorem}[Per-block gauge phases assemble to an explicit global gauge]%
+\label{thm:block_proportional_globalX_conj}
+	\lean{MPSTensor.BlockProportionalGaugePhaseData.toTensorFromBlocks_reindexB_eq_globalX_conj,
+		MPSTensor.BlockProportionalGaugePhaseData.gaugeEquiv_toTensorFromBlocks}
+	\leanok
+	\uses{def:block_proportional_gauge_phase_data, def:tensor_from_blocks,
+		def:gauge_equiv}
+	If the block weights absorb the per-block phases,
+	$\mu_A(k)=\mu_B(\sigma(k))\zeta_k$, then the weighted direct sum of the
+	permuted right blocks is conjugate to the weighted direct sum of the cast left
+	blocks by the explicit flattened gauge $X=\bigoplus_k X_k$.  Consequently this
+	global matrix witnesses the gauge equivalence of the two assembled tensors.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	The scalar identity moves each phase $\zeta_k$ from the tensor relation into
+	the corresponding block weight.  After this absorption, every weighted block
+	satisfies an ordinary conjugation identity by $X_k$; the block-diagonal
+	conjugation formula assembles those identities into the displayed global
+	gauge equivalence.
+\end{proof}
+
 \begin{definition}[BNT matching hypotheses for common primitive sectors]%
 \label{def:common_primitive_bnt_cover_hypotheses}
 	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses,

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -986,12 +986,49 @@ decomposition.
 \label{sec:multi_block_ft}
 %% ---------------------------------------------------------
 
+\begin{definition}[Flattened block-diagonal gauge]%
+    \label{def:global_gauge_of_blocks}
+    \lean{MPSTensor.blockDiagonalGL, MPSTensor.globalGaugeOfBlocks}
+    \leanok
+    \uses{def:tensor_from_blocks}
+    Given per-block gauges $X_k \in \GL_{D_k}(\C)$, first form the
+    dependent block-diagonal unit $\bigoplus_k X_k$ and then reindex the
+    dependent sum of block coordinates to the flattened bond index
+    $\Fin(\sum_k D_k)$.  The resulting element of
+    $\GL_{\sum_k D_k}(\C)$ is the global gauge used by the assembled tensor
+    $\bigoplus_k \mu_k A_k$.
+\end{definition}
+
+\begin{lemma}[Explicit direct-sum conjugation by the flattened gauge]%
+    \label{lem:tensor_from_blocks_globalGauge_conj}
+    \lean{MPSTensor.toTensorFromBlocks_eq_globalGaugeOfBlocks_conj,
+        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockConj}
+    \leanok
+    \uses{def:global_gauge_of_blocks, def:tensor_from_blocks, def:gauge_equiv}
+    If each block satisfies $B_k^i=X_k A_k^i X_k^{-1}$, then the weighted
+    direct sums satisfy, for every physical index~$i$,
+    \[
+        \bigoplus_k \mu_k B_k^i
+        = X\left(\bigoplus_k \mu_k A_k^i\right)X^{-1},
+    \]
+    where $X$ is the flattened block-diagonal gauge of
+    Definition~\ref{def:global_gauge_of_blocks}.  Hence the two assembled
+    tensors are gauge equivalent with this explicit witness.
+\end{lemma}
+
+\begin{proof}\leanok
+    The block-diagonal matrix product is computed blockwise.  The scalar weight
+    $\mu_k$ commutes with the per-block conjugation, so each diagonal block of
+    the right-hand side is $\mu_k B_k^i$.  Reindexing from the dependent block
+    coordinates to $\Fin(\sum_k D_k)$ preserves multiplication and inverses.
+\end{proof}
+
 \begin{lemma}[Gauge equivalence of direct sums from per-block MPV equality]%
     \label{lem:fundamentalTheorem_multiBlock_full}
     \lean{MPSTensor.fundamentalTheorem_multiBlock_full}
     \leanok
     \uses{def:injective, def:same_mpv, def:gauge_equiv,
-        def:tensor_from_blocks}
+        def:tensor_from_blocks, lem:tensor_from_blocks_globalGauge_conj}
     Let $\{A_k\}_{k=0}^{r-1}$ and $\{B_k\}_{k=0}^{r-1}$ be two families
     of MPS tensors with block dimensions $D_k$, each $A_k$ injective, and
     $\mc{V}(A_k) = \mc{V}(B_k)$ for all~$k$.

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1002,9 +1002,7 @@ decomposition.
 \begin{lemma}[Explicit direct-sum conjugation by the flattened gauge]%
     \label{lem:tensor_from_blocks_globalGauge_conj}
     \lean{MPSTensor.toTensorFromBlocks_eq_globalGaugeOfBlocks_conj,
-        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockConj,
-        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockGauge,
-        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockGaugePhase_weight}
+        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockConj}
     \leanok
     \uses{def:global_gauge_of_blocks, def:tensor_from_blocks, def:gauge_equiv}
     If each block satisfies $B_k^i=X_k A_k^i X_k^{-1}$, then the weighted
@@ -1014,8 +1012,8 @@ decomposition.
         = X\left(\bigoplus_k \mu_k A_k^i\right)X^{-1},
     \]
     where $X$ is the flattened block-diagonal gauge of
-    Definition~\ref{def:global_gauge_of_blocks}.  Hence the two assembled
-    tensors are gauge equivalent with this explicit witness.
+    Definition~\ref{def:global_gauge_of_blocks}.  Consequently the two
+    assembled tensors are gauge equivalent with this explicit witness.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1023,7 +1021,45 @@ decomposition.
     $\mu_k$ commutes with the per-block conjugation, so each diagonal block of
     the right-hand side is $\mu_k B_k^i$.  Reindexing from the dependent block
     coordinates to the standard bond index preserves multiplication and
-    inverses.
+    inverses.  The gauge equivalence follows directly from the conjugation
+    identity.
+\end{proof}
+
+\begin{lemma}[Gauge equivalence of direct sums from per-block gauge equivalence]%
+    \label{lem:gauge_equiv_from_block_gauge}
+    \lean{MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockGauge}\leanok
+    \uses{lem:tensor_from_blocks_globalGauge_conj, def:gauge_equiv}
+    If each pair $(A_k, B_k)$ is gauge equivalent, then the weighted
+    block-diagonal tensors $\bigoplus_k \mu_k A_k$ and
+    $\bigoplus_k \mu_k B_k$ are gauge equivalent.
+\end{lemma}
+
+\begin{proof}\leanok
+    Choose per-block gauge matrices via the hypothesis; then apply
+    Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj}.
+\end{proof}
+
+\begin{lemma}[Gauge equivalence of direct sums with phase-weight absorption]%
+    \label{lem:gauge_equiv_block_gauge_phase_weight}
+    \lean{MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockGaugePhase_weight}\leanok
+    \uses{lem:tensor_from_blocks_globalGauge_conj, def:gauge_equiv,
+        def:gauge_phase_equiv}
+    Let $A_k, B_k$ be block families, and let $X_k \in \GL_{D_k}(\C)$
+    and nonzero phases $\zeta_k \in \C^\times$ satisfy
+    $B_k^i = \zeta_k \cdot X_k A_k^i X_k^{-1}$ for every block $k$ and
+    physical index $i$.  If the weights satisfy $\mu_A(k) = \mu_B(k)\,\zeta_k$,
+    then the weighted block-diagonal tensors
+    $\bigoplus_k \mu_A(k) A_k$ and $\bigoplus_k \mu_B(k) B_k$ are gauge
+    equivalent.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:tensor_from_blocks_globalGauge_conj}
+    Absorb each phase $\zeta_k$ into the weight $\mu_B(k)$ by rescaling the
+    per-block tensors: define $\tilde B_k^i = \zeta_k^{-1} B_k^i$ and
+    $\tilde\mu_B(k) = \mu_B(k)\,\zeta_k = \mu_A(k)$.  Then
+    $\tilde B_k^i = X_k A_k^i X_k^{-1}$ and the two weighted direct sums
+    coincide with those in Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj}.
 \end{proof}
 
 \begin{lemma}[Gauge equivalence of direct sums from per-block MPV equality]%

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1002,7 +1002,9 @@ decomposition.
 \begin{lemma}[Explicit direct-sum conjugation by the flattened gauge]%
     \label{lem:tensor_from_blocks_globalGauge_conj}
     \lean{MPSTensor.toTensorFromBlocks_eq_globalGaugeOfBlocks_conj,
-        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockConj}
+        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockConj,
+        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockGauge,
+        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockGaugePhase_weight}
     \leanok
     \uses{def:global_gauge_of_blocks, def:tensor_from_blocks, def:gauge_equiv}
     If each block satisfies $B_k^i=X_k A_k^i X_k^{-1}$, then the weighted
@@ -1098,6 +1100,94 @@ decomposition.
     \uses{thm:piAlgEquiv_decomposition}
     Apply Theorem~\ref{thm:piAlgEquiv_decomposition} to the product-algebra
     automorphism built from the per-block linear extensions.
+\end{proof}
+
+%% ---------------------------------------------------------
+\subsection{MPV invariance under reindexing}%
+\label{subsec:mpv_reindexing}
+%% ---------------------------------------------------------
+
+\begin{lemma}[MPV invariance under block permutation]\label{lem:mpv_perm_blocks}
+    \lean{MPSTensor.sameMPV₂_toTensorFromBlocks_perm}\leanok
+    \uses{def:tensor_from_blocks, def:same_mpv2}
+    Permuting the block index set and transporting the weights
+    correspondingly does not change the $\mathrm{SameMPV}_2$ family of the
+    weighted block-diagonal tensor.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:tensor_from_blocks}
+    The sum of per-block MPV contributions is invariant under rearrangement
+    of the summands.
+\end{proof}
+
+\begin{lemma}[MPV invariance under dimension cast]\label{lem:mpv_cast_blocks}
+    \lean{MPSTensor.sameMPV₂_toTensorFromBlocks_cast}\leanok
+    \uses{def:tensor_from_blocks, def:same_mpv2}
+    If two block-dimension families agree pointwise, the corresponding
+    weighted block-diagonal tensors generate the same $\mathrm{SameMPV}_2$
+    family after transporting the blocks across the dimension equalities.
+\end{lemma}
+
+\begin{proof}\leanok
+    Substituting the equality of dimensions makes the two tensor families
+    identical.
+\end{proof}
+
+%% ---------------------------------------------------------
+\subsection{Converse: gauge equivalence implies same MPV}%
+\label{subsec:converse_gauge_mpv}
+%% ---------------------------------------------------------
+
+\begin{lemma}[Gauge equivalence of direct sums implies same MPV]\label{lem:gauge_equiv_implies_same_mpv}
+    \lean{MPSTensor.gaugeEquiv_toTensorFromBlocks_implies_sameMPV}\leanok
+    \uses{def:tensor_from_blocks, def:gauge_equiv, def:same_mpv}
+    If the weighted block-diagonal tensors $\bigoplus_k \mu_k A_k$ and
+    $\bigoplus_k \mu_k B_k$ are gauge equivalent, then they generate the
+    same MPV family.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:gauge_equiv}
+    Gauge equivalence preserves all traces of word evaluations, hence all
+    MPV coefficients.
+\end{proof}
+
+%% ---------------------------------------------------------
+\subsection{Canonical-form bridge}%
+\label{subsec:canonical_form_bridge}
+%% ---------------------------------------------------------
+
+\begin{lemma}[Canonical-form tensor agrees with block sum]\label{lem:canonical_toTensor_eq}
+    \lean{MPSTensor.CanonicalForm.toTensor_eq_toTensorFromBlocks}\leanok
+    \uses{def:tensor_from_blocks}
+    For a canonical-form record $C$, the tensor $C.\mathtt{toTensor}$
+    is definitionally equal to the weighted block-diagonal tensor
+    $\bigoplus_k C.\mu_k\; C.\mathtt{blockTensor}_k$.
+\end{lemma}
+
+\begin{proof}\leanok
+    The equality holds by definition; $C.\mathtt{toTensor}$ is defined as
+    $\mathtt{toTensorFromBlocks}\; C.\mu\; C.\mathtt{blockTensor}$.
+\end{proof}
+
+\begin{theorem}[Fundamental theorem for canonical forms with the same block structure]\label{thm:ft_canonical_form_same_structure}
+    \lean{MPSTensor.fundamentalTheorem_canonicalForm_sameStructure}\leanok
+    \uses{lem:canonical_toTensor_eq, thm:multi_block_global}
+    Let $C$ be a canonical-form record, let $\{B_k\}$ be a family of MPS
+    tensors on the same block dimensions as $C$, and assume that each
+    $C.\mathtt{blockTensor}_k$ is injective and generates the same MPV
+    family as $B_k$.
+    Then $C.\mathtt{toTensor}$ and $\bigoplus_k C.\mu_k\, B_k$ are gauge
+    equivalent.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:canonical_toTensor_eq, thm:multi_block_global}
+    Rewrite the canonical-form tensor as a weighted block-diagonal tensor
+    via Lemma~\ref{lem:canonical_toTensor_eq}, then apply the multi-block
+    global fundamental theorem
+    (Theorem~\ref{thm:multi_block_global}).
 \end{proof}
 
 \begin{lemma}[Per-block equality of MPV families and per-block gauge equivalence]%
@@ -1380,6 +1470,40 @@ which is then combined with overlap estimates and the leading-block peel.
     show that the matched blocks must have equal dimension and differ only by a
     phase gauge, and finally upgrades the resulting matching to a permutation of
     all blocks.
+\end{proof}
+
+%% ---------------------------------------------------------
+\section{Per-block to global proportional gauge}%
+\label{sec:proportional_gauge}
+%% ---------------------------------------------------------
+
+The proportional-decomposition conclusion (see
+Definition~\ref{def:block_proportional_gauge_phase_data}) provides per-block
+gauge matrices $X_k$ and phases $\zeta_k$.  Using the block-diagonal $\GL$
+construction of Definition~\ref{def:global_gauge_of_blocks}, one assembles
+these per-block gauges into a single global gauge matrix acting on the total
+bond space of the weighted direct sum.  This is the \emph{global
+proportionality matrix} of~\cite[Corollary~II.2, lines~1155--1192]{Cirac2017MPDO_AnnPhys}.
+
+\begin{theorem}[Global conjugation from per-block gauge-phase data]\label{thm:global_x_conj}
+    \lean{MPSTensor.BlockProportionalGaugePhaseData.toTensorFromBlocks_reindexB_eq_globalX_conj,
+        MPSTensor.BlockProportionalGaugePhaseData.gaugeEquiv_toTensorFromBlocks}\leanok
+    \uses{def:block_proportional_gauge_phase_data, def:global_gauge_of_blocks,
+        def:gauge_equiv}
+    Let the block weights absorb the per-block phases via
+    $\mu_A(k) = \mu_B(\sigma(k))\,\zeta_k$.  Then the weighted direct sum of
+    the permuted right-side blocks is conjugate to the weighted direct sum of
+    the cast left-side blocks by the flattened global gauge
+    $\mathtt{globalGaugeOfBlocks}(X)$.  Consequently the two assembled tensors
+    are gauge equivalent.
+\end{theorem}
+
+\begin{proof}\leanok
+    Absorb each phase $\zeta_k$ into the corresponding weight; after this
+    absorption the per-block identities become ordinary conjugation relations
+    $B_{\sigma(k)}^i = X_k (\mathtt{cast}\,A_k)^i X_k^{-1}$.
+    Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} then assembles the per-block
+    $X_k$ into the global block-diagonal gauge.
 \end{proof}
 
 %% ---------------------------------------------------------

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1045,7 +1045,7 @@ decomposition.
     \uses{lem:tensor_from_blocks_globalGauge_conj, def:gauge_equiv,
         def:gauge_phase_equiv}
     Let $A_k, B_k$ be block families, and let $X_k \in \GL_{D_k}(\C)$
-    and nonzero phases $\zeta_k \in \C^\times$ satisfy
+    and scalars $\zeta_k \in \C$ satisfy
     $B_k^i = \zeta_k \cdot X_k A_k^i X_k^{-1}$ for every block $k$ and
     physical index $i$.  If the weights satisfy $\mu_A(k) = \mu_B(k)\,\zeta_k$,
     then the weighted block-diagonal tensors
@@ -1055,11 +1055,13 @@ decomposition.
 
 \begin{proof}\leanok
     \uses{lem:tensor_from_blocks_globalGauge_conj}
-    Absorb each phase $\zeta_k$ into the weight $\mu_B(k)$ by rescaling the
-    per-block tensors: define $\tilde B_k^i = \zeta_k^{-1} B_k^i$ and
-    $\tilde\mu_B(k) = \mu_B(k)\,\zeta_k = \mu_A(k)$.  Then
-    $\tilde B_k^i = X_k A_k^i X_k^{-1}$ and the two weighted direct sums
-    coincide with those in Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj}.
+    Per-block, the weight identity $\mu_A(k) = \mu_B(k)\,\zeta_k$ rewrites the
+    scaled relation as
+    $\mu_B(k)\,B_k^i = X_k\,(\mu_A(k)\,A_k^i)\,X_k^{-1}$.
+    Each weighted block then satisfies an ordinary conjugation, and the
+    block-diagonal conjugation formula assembles the per-block $X_k$ into the
+    flattened global gauge $\bigoplus_k X_k$ relating
+    $\bigoplus_k \mu_A(k) A_k$ to $\bigoplus_k \mu_B(k) B_k$.
 \end{proof}
 
 \begin{lemma}[Gauge equivalence of direct sums from per-block MPV equality]%
@@ -1192,7 +1194,7 @@ decomposition.
 
 %% ---------------------------------------------------------
 \subsection{Canonical-form tensor as a weighted direct sum}%
-\label{subsec:canonical_form_bridge}
+\label{subsec:canonical_form_block_sum}
 %% ---------------------------------------------------------
 
 \begin{lemma}[Canonical-form tensor agrees with block sum]\label{lem:canonical_toTensor_eq}
@@ -1524,6 +1526,9 @@ bond space of the weighted direct sum.  This is the \emph{global
 proportionality matrix} of~\cite[Corollary~II.2, lines~1155--1192]{Cirac2017MPDO_AnnPhys}.
 
 \begin{theorem}[Global conjugation from per-block gauge-phase data]\label{thm:global_x_conj}
+    \lean{MPSTensor.BlockProportionalGaugePhaseData.toTensorFromBlocks_reindexB_eq_globalX_conj,
+        MPSTensor.BlockProportionalGaugePhaseData.gaugeEquiv_toTensorFromBlocks}
+    \leanok
     \uses{thm:block_proportional_globalX_conj, def:global_gauge_of_blocks,
         def:gauge_equiv}
     Let the block weights absorb the per-block phases via
@@ -1534,9 +1539,9 @@ proportionality matrix} of~\cite[Corollary~II.2, lines~1155--1192]{Cirac2017MPDO
     are gauge equivalent.
 \end{theorem}
 
-\begin{proof}
+\begin{proof}\leanok
     Let $\tilde A_k$ denote the block $A_k$ transported along the dimension
-    equality $h_k : \dim^A_k = \dim^B_{\sigma(k)}$.
+    equality $\dim^A_k = \dim^B_{\sigma(k)}$.
     Absorb each phase $\zeta_k$ into the corresponding weight via the
     identity $\mu_A(k) = \mu_B(\sigma(k))\,\zeta_k$.  After this absorption
     each weighted block satisfies an ordinary conjugation relation

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1498,13 +1498,17 @@ proportionality matrix} of~\cite[Corollary~II.2, lines~1155--1192]{Cirac2017MPDO
     are gauge equivalent.
 \end{theorem}
 
-\begin{proof}\leanok
-    Absorb each phase $\zeta_k$ into the corresponding weight; after this
-    absorption the per-block identities become ordinary conjugation relations
-    $B_{\sigma(k)}^i = X_k\, (A_k\text{ with bond dimension identified via the
-    dimension equality})^i\, X_k^{-1}$.
-    Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} then assembles the per-block
-    $X_k$ into the global block-diagonal gauge $X = \bigoplus_k X_k$.
+\begin{proof}
+    Let $\tilde A_k$ denote the block $A_k$ transported along the dimension
+    equality $h_k : \dim^A_k = \dim^B_{\sigma(k)}$.
+    Absorb each phase $\zeta_k$ into the corresponding weight via the
+    identity $\mu_A(k) = \mu_B(\sigma(k))\,\zeta_k$.  After this absorption
+    each weighted block satisfies an ordinary conjugation relation
+    $\mu_B(\sigma(k)) B_{\sigma(k)}^i
+     = X_k\, \bigl(\mu_A(k)\, \tilde A_k^i\bigr)\, X_k^{-1}$.
+    Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} then assembles the
+    per-block $X_k$ into the global block-diagonal gauge
+    $X = \bigoplus_k X_k$.
 \end{proof}
 
 %% ---------------------------------------------------------

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -992,11 +992,11 @@ decomposition.
     \leanok
     \uses{def:tensor_from_blocks}
     Given per-block gauges $X_k \in \GL_{D_k}(\C)$, first form the
-    dependent block-diagonal unit $\bigoplus_k X_k$ and then reindex the
-    dependent sum of block coordinates to the flattened bond index
-    $\Fin(\sum_k D_k)$.  The resulting element of
-    $\GL_{\sum_k D_k}(\C)$ is the global gauge used by the assembled tensor
-    $\bigoplus_k \mu_k A_k$.
+    dependent block-diagonal element $\bigoplus_k X_k$ and then reindex the
+    dependent block-coordinate index to the standard index
+    $\{0,\dots,\sum_k D_k-1\}$ of the assembled tensor.
+    The resulting element of $\GL_{\sum_k D_k}(\C)$ is the global gauge used
+    in the conjugation formula for $\bigoplus_k \mu_k A_k$.
 \end{definition}
 
 \begin{lemma}[Explicit direct-sum conjugation by the flattened gauge]%
@@ -1022,7 +1022,8 @@ decomposition.
     The block-diagonal matrix product is computed blockwise.  The scalar weight
     $\mu_k$ commutes with the per-block conjugation, so each diagonal block of
     the right-hand side is $\mu_k B_k^i$.  Reindexing from the dependent block
-    coordinates to $\Fin(\sum_k D_k)$ preserves multiplication and inverses.
+    coordinates to the standard bond index preserves multiplication and
+    inverses.
 \end{proof}
 
 \begin{lemma}[Gauge equivalence of direct sums from per-block MPV equality]%
@@ -1154,38 +1155,39 @@ decomposition.
 \end{proof}
 
 %% ---------------------------------------------------------
-\subsection{Canonical-form bridge}%
+\subsection{Canonical-form tensor as a weighted direct sum}%
 \label{subsec:canonical_form_bridge}
 %% ---------------------------------------------------------
 
 \begin{lemma}[Canonical-form tensor agrees with block sum]\label{lem:canonical_toTensor_eq}
     \lean{MPSTensor.CanonicalForm.toTensor_eq_toTensorFromBlocks}\leanok
     \uses{def:tensor_from_blocks}
-    For a canonical-form record $C$, the tensor $C.\mathtt{toTensor}$
-    is definitionally equal to the weighted block-diagonal tensor
-    $\bigoplus_k C.\mu_k\; C.\mathtt{blockTensor}_k$.
+    For a canonical-form record $C$, the assembled tensor $T_C$ is
+    definitionally equal to the weighted block-diagonal tensor
+    $\bigoplus_k \mu_k^C\, A_k^C$,
+    where $\mu_k^C$ are the block weights and $A_k^C$ are the block tensors
+    stored in $C$.
 \end{lemma}
 
 \begin{proof}\leanok
-    The equality holds by definition; $C.\mathtt{toTensor}$ is defined as
-    $\mathtt{toTensorFromBlocks}\; C.\mu\; C.\mathtt{blockTensor}$.
+    The equality holds by definition; $T_C$ is defined as the weighted
+    block-diagonal tensor formed from the weights and block tensors of $C$.
 \end{proof}
 
 \begin{theorem}[Fundamental theorem for canonical forms with the same block structure]\label{thm:ft_canonical_form_same_structure}
     \lean{MPSTensor.fundamentalTheorem_canonicalForm_sameStructure}\leanok
     \uses{lem:canonical_toTensor_eq, thm:multi_block_global}
-    Let $C$ be a canonical-form record, let $\{B_k\}$ be a family of MPS
-    tensors on the same block dimensions as $C$, and assume that each
-    $C.\mathtt{blockTensor}_k$ is injective and generates the same MPV
-    family as $B_k$.
-    Then $C.\mathtt{toTensor}$ and $\bigoplus_k C.\mu_k\, B_k$ are gauge
-    equivalent.
+    Let $C$ be a canonical-form record with block weights $\mu_k^C$ and block
+    tensors $A_k^C$.  Let $\{B_k\}$ be a family of MPS tensors on the same
+    block dimensions, and assume that each $A_k^C$ is injective and generates
+    the same MPV family as $B_k$.
+    Then $T_C$ and $\bigoplus_k \mu_k^C\, B_k$ are gauge equivalent.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{lem:canonical_toTensor_eq, thm:multi_block_global}
-    Rewrite the canonical-form tensor as a weighted block-diagonal tensor
-    via Lemma~\ref{lem:canonical_toTensor_eq}, then apply the multi-block
+    Rewrite $T_C$ as a weighted block-diagonal tensor via
+    Lemma~\ref{lem:canonical_toTensor_eq}, then apply the multi-block
     global fundamental theorem
     (Theorem~\ref{thm:multi_block_global}).
 \end{proof}
@@ -1486,24 +1488,23 @@ bond space of the weighted direct sum.  This is the \emph{global
 proportionality matrix} of~\cite[Corollary~II.2, lines~1155--1192]{Cirac2017MPDO_AnnPhys}.
 
 \begin{theorem}[Global conjugation from per-block gauge-phase data]\label{thm:global_x_conj}
-    \lean{MPSTensor.BlockProportionalGaugePhaseData.toTensorFromBlocks_reindexB_eq_globalX_conj,
-        MPSTensor.BlockProportionalGaugePhaseData.gaugeEquiv_toTensorFromBlocks}\leanok
-    \uses{def:block_proportional_gauge_phase_data, def:global_gauge_of_blocks,
+    \uses{thm:block_proportional_globalX_conj, def:global_gauge_of_blocks,
         def:gauge_equiv}
     Let the block weights absorb the per-block phases via
     $\mu_A(k) = \mu_B(\sigma(k))\,\zeta_k$.  Then the weighted direct sum of
     the permuted right-side blocks is conjugate to the weighted direct sum of
-    the cast left-side blocks by the flattened global gauge
-    $\mathtt{globalGaugeOfBlocks}(X)$.  Consequently the two assembled tensors
+    the cast left-side blocks by the flattened block-diagonal gauge
+    $X = \bigoplus_k X_k$.  Consequently the two assembled tensors
     are gauge equivalent.
 \end{theorem}
 
 \begin{proof}\leanok
     Absorb each phase $\zeta_k$ into the corresponding weight; after this
     absorption the per-block identities become ordinary conjugation relations
-    $B_{\sigma(k)}^i = X_k (\mathtt{cast}\,A_k)^i X_k^{-1}$.
+    $B_{\sigma(k)}^i = X_k\, (A_k\text{ with bond dimension identified via the
+    dimension equality})^i\, X_k^{-1}$.
     Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} then assembles the per-block
-    $X_k$ into the global block-diagonal gauge.
+    $X_k$ into the global block-diagonal gauge $X = \bigoplus_k X_k$.
 \end{proof}
 
 %% ---------------------------------------------------------


### PR DESCRIPTION
### Motivation

- CPSV16 Cor II.2 (arXiv:1606.00608, eq. `eq:II:A=XAX`) requires assembling per-block gauge-phase data into a single global gauge matrix $X$ conjugating the pair of block-diagonal tensors; this assembly step was flagged as missing in `docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex`.
- Continues formalization of the algebraic Fundamental Theorem for MPS, tracked in #1498.

### Description

- Modified `TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean`.
- Introduces `BlockProportionalGaugePhaseData`: a record extracted from a `ProportionalDecompositionConclusion` storing the block permutation, per-block dimension equalities, per-block gauge matrices, and per-block phases satisfying $\tilde A_k = e^{i\phi_k} X_k A_j X_k^{-1}$.
- Adds `globalGL` building the block-diagonal element of `GL ((k : Fin rA) × Fin (dimB (perm k))) ℂ`, and `globalX` reindexing it to the bond dimension of the assembled block-diagonal tensor.
- Proves `gaugeEquiv_toTensorFromBlocks`: lifts the per-block conjugation identities to a global `GaugeEquiv` between the cast left family and the permuted right family once per-block phases are absorbed into block weights.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #1502

> [!NOTE]
> **Low Risk**
> Adds new Lean definitions and theorems to repackage and assemble existing per-block proportionality witnesses; no changes to existing logic, but may affect downstream proofs that rely on these new abstractions.
>
> **Overview**
> Implements the missing "per-block to global" assembly step for proportional decomposition results (CPSV16 Cor II.2) by introducing `BlockProportionalGaugePhaseData` and constructors to extract `perm`, per-block dimension casts, gauge matrices, and phases from `ProportionalDecompositionConclusion`.
>
> Adds helpers to build the corresponding global block-diagonal gauge matrix (`globalGL`/`globalX`) and a theorem (`gaugeEquiv_toTensorFromBlocks`) that assembles the per-block conjugation identities into a single `GaugeEquiv` between the weighted block-diagonal tensors once phases are absorbed into weights.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d125a61d85dcf7e2c738d042699da6455e382dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive, but refactors the direct-sum gauge lemma in `FundamentalTheorem/Multi.lean` into a new explicit conjugation theorem and a wrapper, which could subtly affect downstream proof dependencies and definitional equality expectations.
> 
> **Overview**
> Adds an explicit “per-block → global” assembly step for proportional decompositions: `BlockProportionalGaugePhaseData` packages the matched permutation, dimension casts, per-block `GL` gauges, and nonzero phases extracted from `ProportionalDecompositionConclusion`, and provides `globalGL`/`globalX` plus a proof that phase-absorbed weights yield a single global conjugation and `GaugeEquiv` for `toTensorFromBlocks`.
> 
> In `FundamentalTheorem/Multi.lean`, introduces `globalGaugeOfBlocks` (flattened/reindexed block-diagonal `GL`) and refactors the direct-sum result into `toTensorFromBlocks_eq_globalGaugeOfBlocks_conj`, with `gaugeEquiv_toTensorFromBlocks_of_blockConj` rebuilt on top. The blueprint is updated to document these new definitions/lemmas and the resulting global proportionality matrix statement (CPSV16 Cor II.2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8066360bf9b1cc3e688374fcf8b7d1c230bc43c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->