### PR TITLE
refactor(MPS/Overlap): deduplicate `tendsto_norm_selfOverlap_one` into shared module

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -164,6 +164,7 @@ import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Overlap.Basic
+import TNLean.MPS.Overlap.SelfOverlapAux
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Core.OrthogonalProjectionInvariance
 import TNLean.MPS.Core.BlockingTransfer

--- a/TNLean/MPS/BNT/PermutationRigidity/Matching.lean
+++ b/TNLean/MPS/BNT/PermutationRigidity/Matching.lean
@@ -1,4 +1,5 @@
 import TNLean.MPS.BNT.PermutationRigidity.NonzeroOverlap
+import TNLean.MPS.Overlap.SelfOverlapAux
 
 open scoped BigOperators Matrix
 open Filter Finset
@@ -48,13 +49,6 @@ private lemma gaugePhaseEquiv_of_not_tendsto_zero_mpvOverlap
       (B k) := by
   by_contra hNot
   exact h_nonzero (h_zero_of_not_gauge hNot)
-
-private lemma tendsto_norm_selfOverlap_one
-    {d D : ℕ} (A : MPSTensor d D)
-    (hSelf :
-      Tendsto (fun N => mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ))) :
-    Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) atTop (nhds 1) := by
-  simpa using hSelf.norm
 
 private lemma tendsto_norm_mpvOverlap_one_of_scaled_self
     {d D₁ D₂ : ℕ}
@@ -121,11 +115,11 @@ private lemma rightMatching_injective_of_gaugePhaseEquiv
       hk.symm]
   have hAA_norm_tendsto :
       Tendsto (fun N => ‖mpvOverlap (d := d) (A (f k1)) (A (f k1)) N‖) atTop (nhds 1) :=
-    tendsto_norm_selfOverlap_one (d := d) (A := A (f k1)) (hSelf := hA_self (f k1))
+    tendsto_norm_selfOverlap_one (d := d) (A (f k1)) (hA_self (f k1))
   have hBB1_norm : Tendsto (fun N => ‖mpvOverlap (d := d) (B k1) (B k1) N‖) atTop (nhds 1) :=
-    tendsto_norm_selfOverlap_one (d := d) (A := B k1) (hSelf := hB_self k1)
+    tendsto_norm_selfOverlap_one (d := d) (B k1) (hB_self k1)
   have hBB2_norm : Tendsto (fun N => ‖mpvOverlap (d := d) (B k2) (B k2) N‖) atTop (nhds 1) :=
-    tendsto_norm_selfOverlap_one (d := d) (A := B k2) (hSelf := hB_self k2)
+    tendsto_norm_selfOverlap_one (d := d) (B k2) (hB_self k2)
   have hζ1_norm : ‖ζ1‖ = 1 :=
     norm_eq_one_of_selfOverlap_scale hAA_norm_tendsto hBB1_norm
       (mpvOverlap_self_scale_of_mpv_eq_pow_mul
@@ -221,13 +215,13 @@ private lemma leftMatching_injective_of_gaugePhaseEquiv
       htmp hj.symm
   have hB_norm_tendsto :
       Tendsto (fun N => ‖mpvOverlap (d := d) (B (g j1)) (B (g j1)) N‖) atTop (nhds 1) :=
-    tendsto_norm_selfOverlap_one (d := d) (A := B (g j1)) (hSelf := hB_self (g j1))
+    tendsto_norm_selfOverlap_one (d := d) (B (g j1)) (hB_self (g j1))
   have hA1_norm_tendsto : Tendsto (fun N => ‖mpvOverlap (d := d) (A j1) (A j1) N‖)
       atTop (nhds 1) :=
-    tendsto_norm_selfOverlap_one (d := d) (A := A j1) (hSelf := hA_self j1)
+    tendsto_norm_selfOverlap_one (d := d) (A j1) (hA_self j1)
   have hA2_norm_tendsto : Tendsto (fun N => ‖mpvOverlap (d := d) (A j2) (A j2) N‖)
       atTop (nhds 1) :=
-    tendsto_norm_selfOverlap_one (d := d) (A := A j2) (hSelf := hA_self j2)
+    tendsto_norm_selfOverlap_one (d := d) (A j2) (hA_self j2)
   have hζ1_norm : ‖ζ1‖ = 1 :=
     norm_eq_one_of_selfOverlap_scale hA1_norm_tendsto hB_norm_tendsto
       (mpvOverlap_self_scale_of_mpv_eq_pow_mul

--- a/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.EqualProportional
 import TNLean.MPS.FundamentalTheorem.OverlapConvergenceAux
+import TNLean.MPS.Overlap.SelfOverlapAux
 
 /-!
 # Auxiliary lemmas for heterogeneous equal-case block matching
@@ -19,9 +20,11 @@ source-paper Fundamental Theorem.
 
 ## Main statements
 
-* `tendsto_norm_selfOverlap_one`: normed form of a self-overlap tending to `1`.
 * `tendsto_inner_zero_swap`: swapping a decaying overlap conjugates the inner product.
 * `eq_one_of_pow_tendsto_nhds_one`: powers converging to `1` force the base to be `1`.
+
+The companion `tendsto_norm_selfOverlap_one`, also used in this file's downstream
+consumers, lives upstream in `TNLean.MPS.Overlap.SelfOverlapAux`.
 
 This file collects public auxiliary lemmas used by heterogeneous equal-case
 block matching.
@@ -46,13 +49,6 @@ namespace MPSTensor
 variable {d : ℕ}
 
 /-! ## Helpers for the heterogeneous equal-case fundamental theorem -/
-
-/-- Norm-convergence form of normalized self-overlap convergence. -/
-lemma tendsto_norm_selfOverlap_one
-    {D : ℕ} (A : MPSTensor d D)
-    (hA : Tendsto (fun N => mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ))) :
-    Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) atTop (nhds 1) := by
-  simpa [norm_one] using hA.norm
 
 /-- Swapping a decaying overlap conjugates the corresponding inner product. -/
 lemma tendsto_inner_zero_swap

--- a/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/Helpers.lean
@@ -23,8 +23,9 @@ source-paper Fundamental Theorem.
 * `tendsto_inner_zero_swap`: swapping a decaying overlap conjugates the inner product.
 * `eq_one_of_pow_tendsto_nhds_one`: powers converging to `1` force the base to be `1`.
 
-The companion `tendsto_norm_selfOverlap_one`, also used in this file's downstream
-consumers, lives upstream in `TNLean.MPS.Overlap.SelfOverlapAux`.
+The companion `tendsto_norm_selfOverlap_one`, which converts self-overlap convergence
+in $\mathbb{C}$ to norm convergence, is proved in `TNLean.MPS.Overlap.SelfOverlapAux`
+and imported here.
 
 This file collects public auxiliary lemmas used by heterogeneous equal-case
 block matching.

--- a/TNLean/MPS/Overlap/SelfOverlapAux.lean
+++ b/TNLean/MPS/Overlap/SelfOverlapAux.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Overlap.Basic
+
+/-!
+# Self-overlap convergence auxiliaries
+
+This module collects small auxiliary lemmas about the convergence of MPV self-overlaps
+that are shared between `MPS/BNT/PermutationRigidity` and `MPS/FundamentalTheorem/Full`.
+
+## Main statements
+
+* `tendsto_norm_selfOverlap_one`: normed form of a self-overlap tending to `1`.
+
+## Tags
+
+matrix product states, overlap, convergence
+-/
+
+open Filter
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- Norm-convergence form of normalized self-overlap convergence. -/
+lemma tendsto_norm_selfOverlap_one
+    {D : ℕ} (A : MPSTensor d D)
+    (hA : Tendsto (fun N => mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ))) :
+    Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) atTop (nhds 1) := by
+  simpa [norm_one] using hA.norm
+
+end MPSTensor

--- a/TNLean/MPS/Overlap/SelfOverlapAux.lean
+++ b/TNLean/MPS/Overlap/SelfOverlapAux.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.Overlap.Basic
 # Self-overlap convergence auxiliaries
 
 This module collects small auxiliary lemmas about the convergence of MPV self-overlaps
-that are shared between `MPS/BNT/PermutationRigidity` and `MPS/FundamentalTheorem/Full`.
+used by both the BNT Permutation Rigidity argument and the Fundamental Theorem helpers.
 
 ## Main statements
 

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1653,3 +1653,17 @@ this spectral-gap input under explicit hypotheses.
     By Theorem~\ref{thm:trace_pow_one},
     $\Tr(\E_A^N) \to 1$.
 \end{proof}
+
+\begin{lemma}[Norm of self-overlap convergence]\label{lem:norm_selfOverlap_tendsto}
+    \lean{MPSTensor.tendsto_norm_selfOverlap_one}\leanok
+    \uses{def:mpv_overlap}
+    If $A$ is an MPS tensor and $O_{AA}(N) \to 1$ in $\mathbb{C}$ as
+    $N \to \infty$, then $\|O_{AA}(N)\| \to 1$ as
+    $N \to \infty$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Follows from the continuity of the norm:
+    $O_{AA}(N) \to 1$ implies
+    $\|O_{AA}(N)\| \to \|1\| = 1$.
+\end{proof}


### PR DESCRIPTION
### Motivation

- The lemma `tendsto_norm_selfOverlap_one` (norm convergence of self-overlaps to 1)
  was duplicated across `MPS/BNT/PermutationRigidity/Matching` and
  `MPS/FundamentalTheorem/Full/Helpers`, with effectively identical proofs; see #1508.
- `BNT.PermutationRigidity` is upstream of `FundamentalTheorem.Full`, so the shared
  lemma must live in a module reachable by both layers.

### Description

- Adds `TNLean/MPS/Overlap/SelfOverlapAux.lean` as a new shared module containing
  `tendsto_norm_selfOverlap_one`.
- Removes the duplicate private copy from `MPS/BNT/PermutationRigidity/Matching.lean`
  and the redundant public copy from `MPS/FundamentalTheorem/Full/Helpers.lean`.
- Updates `TNLean.lean` to import the new module.
- The companion lemmas `tendsto_inner_zero_swap` and `eq_one_of_pow_tendsto_nhds_one`
  remain in `Helpers` as they depend on `MPS/FundamentalTheorem/OverlapConvergenceAux`
  and do not fit the upstream `MPS/Overlap` layer.
- No mathematical statements are changed; this is a pure reorganization.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #1508

> [!NOTE]
> **Low Risk**
> Low risk refactor that only moves a small auxiliary lemma into a shared module and updates imports/call sites; no changes to core mathematical statements beyond reusing the same proof.
>
> **Overview**
> Introduces a new shared module `TNLean.MPS.Overlap.SelfOverlapAux` containing `tendsto_norm_selfOverlap_one` (norm convergence of self-overlaps).
>
> Removes the duplicated local versions of this lemma from `MPS/BNT/PermutationRigidity/Matching.lean` and `MPS/FundamentalTheorem/Full/Helpers.lean`, updating those files (and the root `TNLean.lean` import surface) to import and use the centralized definition.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a80ac03a135bf17401b481469087be715f1ddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only moves a small auxiliary lemma into `TNLean.MPS.Overlap` and updates imports/call sites; no proof logic or mathematical statements change.
> 
> **Overview**
> Centralizes the duplicated lemma `MPSTensor.tendsto_norm_selfOverlap_one` into a new shared module `TNLean.MPS.Overlap.SelfOverlapAux`, so it can be reused by both permutation-rigidity and fundamental-theorem layers.
> 
> Removes the local copies from `MPS/BNT/PermutationRigidity/Matching.lean` and `MPS/FundamentalTheorem/Full/Helpers.lean`, updates those files (and the root `TNLean.lean` import surface) to import the new module, and adjusts call sites accordingly.
> 
> Updates the blueprint (Ch. 6 spectral) to reference and document the centralized lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ecf786c250bfe781c3c2c319f53cb0a18d7230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->