### PR TITLE
style(MPS, Algebra): replace banned vocabulary in prose

### DIFF
--- a/TNLean/Algebra/ProjectionTriangularTrace.lean
+++ b/TNLean/Algebra/ProjectionTriangularTrace.lean
@@ -37,7 +37,7 @@ abbrev Q (P : Matrix (Fin D) (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ :=
 noncomputable def diagPart (A : MPSTensor d D) (P : Matrix (Fin D) (Fin D) ℂ) : MPSTensor d D :=
   fun i => P * A i * P + (1 - P) * A i * (1 - P)
 
-section Helpers
+section Auxiliary
 
 variable (P : Matrix (Fin D) (Fin D) ℂ)
 
@@ -56,7 +56,7 @@ lemma projCompl_mul_projCompl (hP : IsOrthogonalProjection P) : (1 - P) * (1 - P
   -- `(1-P)^2 = (1-P) - (1-P)P`.
   rw [mul_sub, mul_one, projCompl_mul_proj (P := P) hP, sub_zero]
 
-end Helpers
+end Auxiliary
 
 
 /-- If each letter satisfies `(1-P) * A i * P = 0`, then every word evaluation satisfies

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -500,7 +500,7 @@ lemma exists_wordTupleSpanTop_of_isNormalCanonicalFormBNT_of_directSum_injective
   exact ⟨m, hm, by simpa [WordTupleSpanTop, wordTuple] using hSpan⟩
 
 /-- Canonical-form/BNT direct-sum separation gives the block-injective
-horizontal-canonical-form field used by the MPDO bicanonical-form package. -/
+horizontal-canonical-form field used by the MPDO bicanonical-form structure. -/
 lemma hasBiCF_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -513,7 +513,7 @@ lemma hasBiCF_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
   exact hasBiCF_of_wordTupleSpanTop A hSpan
 
 /-- Normal-CF-BNT direct-sum separation gives the block-injective
-horizontal-canonical-form field used by the MPDO bicanonical-form package,
+horizontal-canonical-form field used by the MPDO bicanonical-form structure,
 provided one-site injectivity is supplied explicitly. -/
 lemma hasBiCF_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks
     [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorConstruction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorConstruction.lean
@@ -12,7 +12,7 @@ open Filter
 
 This file constructs the common blocked cyclic-sector family used in the
 canonical-form reduction.  The cyclic-sector decomposition itself lives in
-`CyclicSectorDecomposition`; this module packages the one-block period-removal
+`CyclicSectorDecomposition`; this module encodes the one-block period-removal
 data and chooses a common physical blocking length for a finite block family.
 -/
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -15,7 +15,7 @@ have different physical alphabets.  This file provides the common-reblocking
 data that reblocks every sector to a single shared physical blocking length
 so that all sectors can be compared in a uniform canonical form.
 
-The structure and its derived theorems are internal plumbing — they
+The structure and its derived theorems are internal intermediate construction — they
 record reindexing, flattening, and common-alphabet transport.  They are
 not paper-level results of 1606.00608 or 2011.12127.
 -/
@@ -405,7 +405,7 @@ theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ := by
           exact (mpv_toTensorFromBlocks_eq_sum (F.commonFlatWeight μ) (F.commonFlatBlocks) σ).symm
 
-/-! ### Direct-vs-iterated blocking identifications (internal plumbing)
+/-! ### Direct-vs-iterated blocking identifications (internal intermediate construction)
 
 The remaining theorems compare the directly-blocked and iteratively-blocked
 forms of each nonzero-weight block.  They verify that the canonical

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -15,7 +15,7 @@ have different physical alphabets.  This file provides the common-reblocking
 data that reblocks every sector to a single shared physical blocking length
 so that all sectors can be compared in a uniform canonical form.
 
-The structure and its derived theorems are internal intermediate construction — they
+The structure and its derived theorems are internal intermediate constructions — they
 record reindexing, flattening, and common-alphabet transport.  They are
 not paper-level results of 1606.00608 or 2011.12127.
 -/

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -27,7 +27,7 @@ leftover blocks in the block decomposition.  It is the dimension gap allowed by
   `sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed` transport zero-tail
   decompositions through the common-sector relabeling data.
 * `CommonSectorRelabelingHypothesis` and
-  `CommonGroupedBlockCastHypothesis` package the remaining blocked-word
+  `CommonGroupedBlockCastHypothesis` encode the remaining blocked-word
   comparison data.
 * `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
   and `unconditional_commonPrimitiveIrreducibleBlocks` turn the structural

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -773,7 +773,7 @@ multiple of its periods the blocked tensor is a unit-weight sum of
 primitive, tensor-irreducible, trace-preserving sector blocks with
 positive bond dimensions.
 
-This packages the unconditional sector-orbit lift into the single
+This encodes the unconditional sector-orbit lift into the single
 result consumed by the downstream common-blocking construction.  It is
 the period-removal counterpart of `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
 strengthened with primitivity and irreducibility. -/

--- a/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
+++ b/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
@@ -411,7 +411,7 @@ theorem spectralRadius_compl_lt_one_of_peripheralPrimitive
       (A := A) hNorm hPrim ρ hρ_psd hρ_ne hρ_fix huniq_fp
   exact ⟨ρ, hρ_psd, hρ_ne, hρ_fix, htrρ, hgap⟩
 
-/-! ## Step 3: package as MPS primitivity + overlap -/
+/-! ## Step 3: express as MPS primitivity + overlap -/
 
 /-- Peripheral primitivity of the transfer map implies
 `MPSTensor.HasPrimitiveFixedPoint` (spectral-gap primitivity). -/


### PR DESCRIPTION
Replace remaining banned vocabulary in scope (excluding Channel/Archive):

- **ProjectionTriangularTrace**: `section Helpers` → `section Auxiliary` / `end Auxiliary`
- **CommonBlockedCyclicSectorFamily**: both `plumbing` → `intermediate construction`
- **BlockDiagonalCommutant**: both `bicanonical-form package` → `bicanonical-form structure`
- **CommonSectorTransport**: `package` → `encode`
- **PeripheralToSpectralGap**: `package as MPS primitivity + overlap` → `express as MPS primitivity + overlap`

Also fixes two additional `packages` uses surfaced by the acceptance grep in `CommonBlockedCyclicSectorConstruction` and `CyclicSectorDecomposition`.

Acceptance grep:
```bash
rg -n "Helpers|plumbing|package" TNLean/Algebra/ProjectionTriangularTrace.lean TNLean/MPS/CanonicalForm/ TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
# exit code 1 (no matches)
```

Closes #1513

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only wording changes across several Lean files; no changes to definitions, statements, or proofs, so behavioral risk is minimal.
> 
> **Overview**
> Updates docstrings/comments to replace specific banned terms and improve phrasing across canonical-form/sector-comparison and overlap documentation (e.g., `Helpers`→`Auxiliary`, `plumbing`→`intermediate construction`, `package`→`encode/express`, and `package`→`structure` in BiCF docs).
> 
> No functional Lean code, theorem statements, or proofs are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43e4aef167f49c4666e28b23bc40ecc0a2eca670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->