### PR TITLE
doc(CPSV16): add source line-range and #1498 refs to three hypothesis structures

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -32,7 +32,14 @@ The common-sector structural theorem supplies zero-tail decompositions, positive
 nonzero-part equality, nonzero weights, trace-preserving normalization, primitive transfer maps,
 irreducibility, and positive bond dimensions. To pass to the overlap-rigidity sector comparison
 one still needs equality of zero-tail dimensions, one-site injectivity for the two block families,
-and equality of their finite-length MPV spans. -/
+and equality of their finite-length MPV spans.
+
+This structure is a deliberate parameterization — the lightest boundary wrapping the span-level
+inputs needed to proceed from the structural theorem to the BNT overlap-rigidity comparison.
+It cites the CPSV16 §II decomposition (arXiv:1606.00608, lines 283–302) where the block families
+and their MPV spans are matched after the canonical-form reduction.  When the BNT-cover data in
+`CommonPrimitiveBNTCoverHypotheses` have been discharged (tracker #1498, sub-issue #1501), this
+structure is automatically satisfied via `toSpanHypotheses`. -/
 structure CommonPrimitiveSpanHypotheses
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (zeroTailA zeroTailB : ℕ)
@@ -114,7 +121,15 @@ formulated with a BNT proportional-decomposition comparison.
 This is the proportional-comparison version of `CommonPrimitivePhaseCoverHypotheses`: the
 structural theorem supplies the same primitive nonzero-sector data, while the remaining inputs
 are equality of the zero-tail dimensions, one-site injectivity on both sides, and a
-BNT comparison conclusion for the two block families. -/
+BNT comparison conclusion for the two block families.
+
+This structure is a deliberate parameterization.  It wraps the proportional Fundamental Theorem
+conclusion (CPSV16 Thm II.1, arXiv:1606.00608 lines 283–345): after the block-injective span
+is established, the two block families are compared by a permutation of the BNT representatives
+with equal dimensions.  The `proportional` field records that conclusion; the remaining fields
+(`zeroTail_eq`, injectivity) ensure the comparison is well-typed.  Once the BNT-cover data in
+`CommonPrimitiveBNTCoverHypotheses` are discharged (tracker #1498, sub-issue #1501), this
+structure follows from `fundamentalTheorem_of_separated_normalCFBNT_data`. -/
 structure CommonPrimitiveProportionalHypotheses
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (zeroTailA zeroTailB : ℕ)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -34,12 +34,13 @@ irreducibility, and positive bond dimensions. To pass to the overlap-rigidity se
 one still needs equality of zero-tail dimensions, one-site injectivity for the two block families,
 and equality of their finite-length MPV spans.
 
-This structure is a deliberate parameterization — the lightest boundary wrapping the span-level
-inputs needed to proceed from the structural theorem to the BNT overlap-rigidity comparison.
-It cites the CPSV16 §II decomposition (arXiv:1606.00608, lines 283–302) where the block families
-and their MPV spans are matched after the canonical-form reduction.  When the BNT-cover data in
-`CommonPrimitiveBNTCoverHypotheses` have been discharged (tracker #1498, sub-issue #1501), this
-structure is automatically satisfied via `toSpanHypotheses`. -/
+This structure is a deliberate parameterization — the lightest boundary that collects the
+span-level inputs needed to proceed from the structural theorem to the BNT overlap-rigidity
+comparison.  It records the decomposition of arXiv:1606.00608, Section II, lines 283–302
+where the block families and their MPV spans are matched after the canonical-form reduction.
+When the BNT-cover data in `CommonPrimitiveBNTCoverHypotheses` have been discharged
+(tracker #1498, sub-issue #1501), this structure is automatically satisfied via
+`toSpanHypotheses`. -/
 structure CommonPrimitiveSpanHypotheses
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (zeroTailA zeroTailB : ℕ)
@@ -123,13 +124,14 @@ structural theorem supplies the same primitive nonzero-sector data, while the re
 are equality of the zero-tail dimensions, one-site injectivity on both sides, and a
 BNT comparison conclusion for the two block families.
 
-This structure is a deliberate parameterization.  It wraps the proportional Fundamental Theorem
-conclusion (CPSV16 Thm II.1, arXiv:1606.00608 lines 283–345): after the block-injective span
-is established, the two block families are compared by a permutation of the BNT representatives
-with equal dimensions.  The `proportional` field records that conclusion; the remaining fields
-(`zeroTail_eq`, injectivity) ensure the comparison is well-typed.  Once the BNT-cover data in
-`CommonPrimitiveBNTCoverHypotheses` are discharged (tracker #1498, sub-issue #1501), this
-structure follows from `fundamentalTheorem_of_separated_normalCFBNT_data`. -/
+This structure is a deliberate parameterization.  It records the proportional Fundamental
+Theorem conclusion (arXiv:1606.00608, Theorem II.1, lines 283–352): after the
+block-injective span is established, the two block families are compared by a permutation
+of the BNT representatives with equal dimensions.  The `proportional` field records that
+conclusion; the remaining fields (`zeroTail_eq`, injectivity) ensure the dimensions are
+compatible.  Once the BNT-cover data in `CommonPrimitiveBNTCoverHypotheses` are discharged
+(tracker #1498, sub-issue #1501), this structure follows from
+`fundamentalTheorem_of_separated_normalCFBNT_data`. -/
 structure CommonPrimitiveProportionalHypotheses
     {d p rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (zeroTailA zeroTailB : ℕ)

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -424,7 +424,16 @@ sector decomposition at a time: positive basis dimensions, left-canonical
 normalization, self-overlap convergence to `1`, and off-diagonal overlap
 convergence to `0`. It intentionally omits one-site injectivity and the
 finite-length span comparison between two different bases, because those are
-separate inputs in the after-blocking comparison. -/
+separate inputs in the after-blocking comparison.
+
+This structure is a deliberate parameterization — the analytic half of the
+overlap-rigidity route.  It records the per-family convergence properties that follow
+from the basis-of-normal-tensors definition in CPSV16 §II (arXiv:1606.00608, lines 271–274)
+and the overlap-dichotomy argument (arXiv:1804.04964 §4).  The combined two-family
+structure `SectorBasisOverlapSpanHypotheses` adds the injectivity and span-comparison
+fields.  When the after-blocking BNT cover is discharged (tracker #1498, sub-issue #1501),
+the fields recorded here are consequences of the CF-BNT structure already present in
+`IsCanonicalFormBNT`. -/
 structure SectorBasisOverlapOrthoHypotheses (P : SectorDecomposition d) : Prop where
   /-- The basis blocks have nonzero bond dimension. -/
   dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -428,12 +428,11 @@ separate inputs in the after-blocking comparison.
 
 This structure is a deliberate parameterization — the analytic half of the
 overlap-rigidity route.  It records the per-family convergence properties that follow
-from the basis-of-normal-tensors definition in CPSV16 §II (arXiv:1606.00608, lines 271–274)
-and the overlap-dichotomy argument (arXiv:1804.04964 §4).  The combined two-family
-structure `SectorBasisOverlapSpanHypotheses` adds the injectivity and span-comparison
-fields.  When the after-blocking BNT cover is discharged (tracker #1498, sub-issue #1501),
-the fields recorded here are consequences of the CF-BNT structure already present in
-`IsCanonicalFormBNT`. -/
+from the basis-of-normal-tensors definition in arXiv:1606.00608, Section II, lines 271–274.
+The combined two-family structure `SectorBasisOverlapSpanHypotheses` adds the injectivity
+and span-comparison fields.  When the after-blocking BNT cover is discharged
+(tracker #1498, sub-issue #1501), the fields recorded here are consequences of the
+CF-BNT structure already present in `IsCanonicalFormBNT`. -/
 structure SectorBasisOverlapOrthoHypotheses (P : SectorDecomposition d) : Prop where
   /-- The basis blocks have nonzero bond dimension. -/
   dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j


### PR DESCRIPTION
Refs #1514 — Tracker #1498 follow-up: three untracked CPSV16 sub-discharge hypothesis structures.

## Classification

All three structures are **option (c)** — deliberate parameterizations (paper-faithful boundary markers kept abstract for re-use).  Each will be automatically satisfied once sub-issue #1501 discharges `CommonPrimitiveBNTCoverHypotheses` from canonical-form + equal-MPV, but they remain as reusable interfaces in the hierarchy below that discharge.

| Structure | File:Line | CPSV16 citation | Relation to #1501 |
|---|---|---|---|
| `CommonPrimitiveSpanHypotheses` | `CommonPrimitiveProportionalData.lean:36` | §II lines 283–302 (decomposition + span matching) | Lightest boundary; satisfied via `toSpanHypotheses` after BNT cover |
| `CommonPrimitiveProportionalHypotheses` | `CommonPrimitiveProportionalData.lean:118` | §II Thm II.1 lines 283–345 (proportional FT) | Sits between phase-cover and BNT-cover; follows from `fundamentalTheorem_of_separated_normalCFBNT_data` |
| `SectorBasisOverlapOrthoHypotheses` | `SectorDecomposition.lean:428` | §II lines 271–274 (+ arXiv:1804.04964 §4) | Analytic per-family checks; fields follow from `IsCanonicalFormBNT` |

## Change

Docstring-only — no signature or statement changes.  Each structure docstring now cites CPSV16 line ranges, arXiv:1804.04964 (where applicable), and tracker #1498, with a brief note explaining the relationship to the #1501 discharge plan.

## Verification

```sh
lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
```
— both compile cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only updates: adds citations and discharge-plan notes without changing any definitions or proofs, so behavior and theorem statements are unchanged.
> 
> **Overview**
> Adds expanded docstrings to three hypothesis structures (`CommonPrimitiveSpanHypotheses`, `CommonPrimitiveProportionalHypotheses`, and `SectorBasisOverlapOrthoHypotheses`) to explicitly frame them as *deliberate parameterizations*, cite the relevant CPSV16/arXiv line ranges, and note how they relate to tracker `#1498` / sub-issue `#1501` (i.e., when they become automatically derivable). No signatures, statements, or proof terms change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0661e2753e959e195741d44feb2d99002595e135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->