### PR TITLE
fix(blueprint/PEPS): put complement in middle of edge-blocking chain

### DIFF
--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -533,8 +533,8 @@
         \TN@upleg{\n}{0.46}
       }
       \node at ($(blkL.south)+(0,-0.30)$) {$A'_1$};
-      \node at ($(blkM.south)+(0,-0.30)$) {$A'_2$};
-      \node at ($(blkR.south)+(0,-0.30)$) {$A'_3$};
+      \node at ($(blkM.south)+(0,-0.30)$) {$A'_3$};
+      \node at ($(blkR.south)+(0,-0.30)$) {$A'_2$};
     \end{scope}
   \end{tikzpicture}%
 }

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -550,8 +550,8 @@
     }
     \TN@opdotabove{edgeCoeffX}{(1.50,0)}{X}
     \node at ($(edgeCoeffL.south)+(0,-0.30)$) {$A'_1$};
-    \node at ($(edgeCoeffM.south)+(0,-0.30)$) {$A'_2$};
-    \node at ($(edgeCoeffR.south)+(0,-0.30)$) {$A'_3$};
+    \node at ($(edgeCoeffM.south)+(0,-0.30)$) {$A'_3$};
+    \node at ($(edgeCoeffR.south)+(0,-0.30)$) {$A'_2$};
   \end{tikzpicture}%
 }
 


### PR DESCRIPTION
## Summary

The right-hand three-site chain drawn by `\TNPEPSEdgeBlockingReduction` now has the boxed complement `$A'_3$` in the middle position, with the two endpoint regions `$A'_1$` and `$A'_2$` as the outer sites.

### Before

`$A'_1$` (left) — `$A'_2$` (middle) — `$A'_3$` (right)

### After

`$A'_1$` (left) — `$A'_3$` (middle) — `$A'_2$` (right)

This matches the intended structure of `eq:block_to_mps` in arXiv:1804.04964, where the complement (the grouped-together vertices) sits between the two endpoints in the resulting three-site MPS chain.

## Changes

- **`blueprint/src/macros/tn_print.tex`**: Swap `$A'_2$` and `$A'_3$` labels on the right-hand three-site chain in `\TNPEPSEdgeBlockingReduction`.

## Validation

- Macro compiles successfully with lualatex (standalone test)
- Left-side graph endpoint labels are preserved unchanged
- No surrounding prose changes needed

Closes #1497

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only reorder LaTeX/TikZ labels in two PEPS diagram macros, with no code logic or data handling impact.
> 
> **Overview**
> Corrects the right-hand three-site edge-blocking chain labeling so the complement region `A'_3` appears in the middle and `A'_2` is the right endpoint.
> 
> Applies the same `A'_2`/`A'_3` swap to the related `\TNPEPSEdgeInsertedCoeff` diagram to keep the three-site chain labeling consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb6a8ba3456e2cc91f910205ba5c6d272ae1cd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->