### PR TITLE
refactor(Wielandt): rename source-facing theorem module path

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -310,9 +310,8 @@ import TNLean.Wielandt.RankOne.Products
 import TNLean.Wielandt.WielandtBound
 
 -- Layer 6b: Preferred paper-facing Proposition 3 / Theorem 1 endpoints.
--- `SourceTheorems/` is the source-facing arXiv:0909.5347 / Wolf §6.9 theorem
--- interface, currently root-imported for citation and exposition and **not**
--- a downstream FT / BNT dependency.
+-- `SourceTheorems/` records the theorems of arXiv:0909.5347 / Wolf §6.9
+-- in the notation of the source; the FT/BNT formalization does not use them.
 -- These wrappers remain standalone with respect to the canonical / FT / BNT
 -- assembly above. `Prop3.lean` is the preferred Proposition 3 entry point; the
 -- direction-specific files `Prop3_ac` and `Prop3_cb` remain available

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -309,7 +309,10 @@ import TNLean.Wielandt.RankOne.Construction
 import TNLean.Wielandt.RankOne.Products
 import TNLean.Wielandt.WielandtBound
 
--- Layer 6b: Preferred paper-facing Proposition 3 / Theorem 1 endpoints
+-- Layer 6b: Preferred paper-facing Proposition 3 / Theorem 1 endpoints.
+-- `SourceTheorems/` is the source-facing arXiv:0909.5347 / Wolf §6.9 theorem
+-- interface, currently root-imported for citation and exposition and **not**
+-- a downstream FT / BNT dependency.
 -- These wrappers remain standalone with respect to the canonical / FT / BNT
 -- assembly above. `Prop3.lean` is the preferred Proposition 3 entry point; the
 -- direction-specific files `Prop3_ac` and `Prop3_cb` remain available
@@ -318,11 +321,11 @@ import TNLean.Wielandt.Primitivity.PaperDefinitions
 import TNLean.Wielandt.Primitivity.EasyDirections
 import TNLean.Wielandt.Primitivity.PrimitiveBridge
 import TNLean.Wielandt.Primitivity.Equivalence
-import TNLean.Wielandt.PaperResults.NonzeroTraceWord
-import TNLean.Wielandt.PaperResults.EigenvectorSpreading
-import TNLean.Wielandt.PaperResults.MatrixSpanExistence
-import TNLean.Wielandt.PaperResults.MatrixSpanSharpBound
-import TNLean.Wielandt.PaperResults.WielandtInequality
+import TNLean.Wielandt.SourceTheorems.NonzeroTraceWord
+import TNLean.Wielandt.SourceTheorems.EigenvectorSpreading
+import TNLean.Wielandt.SourceTheorems.MatrixSpanExistence
+import TNLean.Wielandt.SourceTheorems.MatrixSpanSharpBound
+import TNLean.Wielandt.SourceTheorems.WielandtInequality
 
 -- Layer 6c: Conditional / backend Wielandt assembly
 -- These modules support specialized span-growth and aperiodicity routes. They

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -166,7 +166,7 @@ Other items: PARTIALLY via spectral gap formalization in `TNLean.Spectral.*`.
 
 ### Wolf Theorem 6.9 (Quantum Wielandt inequality)
 
-Current paper-level statements live in `TNLean.Wielandt.PaperResults.WielandtInequality`:
+Current paper-level statements live in `TNLean.Wielandt.SourceTheorems.WielandtInequality`:
 * `qIndex_le_iIndex_of_isPrimitivePaper`
 * `wordSpan_eq_top_of_isPrimitivePaper_of_isUnit` /
   `iIndex_le_of_isPrimitivePaper_of_isUnit`

--- a/TNLean/Wielandt/QuantumWielandt.lean
+++ b/TNLean/Wielandt/QuantumWielandt.lean
@@ -32,7 +32,7 @@ spectrum `{1}`.
 
 This module is intentionally auxiliary. Downstream users who only need
 Proposition 3 / Theorem 1 statements should prefer
-`Primitivity/Equivalence.lean` and `PaperResults/WielandtInequality.lean`.
+`Primitivity/Equivalence.lean` and `SourceTheorems/WielandtInequality.lean`.
 
 ## References
 

--- a/TNLean/Wielandt/SourceTheorems/EigenvectorSpreading.lean
+++ b/TNLean/Wielandt/SourceTheorems/EigenvectorSpreading.lean
@@ -32,9 +32,8 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
 This keeps the public statement in the exact fixed-length `H_{D-1}` form of the
 paper/Wolf lemma, while reusing the existing underlying formalization.
 
-This file is part of `SourceTheorems/`, the source-facing arXiv:0909.5347 /
-Wolf §6.9 theorem interface, root-imported for citation/exposition, not a
-downstream FT dependency.
+These statements record Lemma 2(a) of arXiv:0909.5347 / Wolf Section 6.9
+in the notation of the source; the FT/BNT formalization does not use them.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Wielandt/SourceTheorems/EigenvectorSpreading.lean
+++ b/TNLean/Wielandt/SourceTheorems/EigenvectorSpreading.lean
@@ -31,6 +31,10 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
 
 This keeps the public statement in the exact fixed-length `H_{D-1}` form of the
 paper/Wolf lemma, while reusing the existing underlying formalization.
+
+This file is part of `SourceTheorems/`, the source-facing arXiv:0909.5347 /
+Wolf §6.9 theorem interface, root-imported for citation/exposition, not a
+downstream FT dependency.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Wielandt/SourceTheorems/MatrixSpanExistence.lean
+++ b/TNLean/Wielandt/SourceTheorems/MatrixSpanExistence.lean
@@ -32,8 +32,8 @@ claiming the paper's exact bound.
 They state only the qualitative conclusion `∃ N, S_N(A) = M_D(ℂ)`. In
 particular, they do **not** track the explicit `D²` blocked noninvertible bound
 or the sharp `D² − D + 1` fixed-length bound. Those quantitative statements are
-formalized separately in `PaperResults/MatrixSpanSharpBound.lean` and in the
-case analysis of `PaperResults/WielandtInequality.lean`.
+formalized separately in `SourceTheorems/MatrixSpanSharpBound.lean` and in the
+case analysis of `SourceTheorems/WielandtInequality.lean`.
 
 ## Proof strategy
 
@@ -41,6 +41,10 @@ case analysis of `PaperResults/WielandtInequality.lean`.
    rank (`HasEventuallyFullKrausRank A`).
 2. Rewrite as `IsNormal A`.
 3. Apply the existential theorem `wielandt_lemma2b`.
+
+This file is part of `SourceTheorems/`, the source-facing arXiv:0909.5347 /
+Wolf §6.9 theorem interface, root-imported for citation/exposition, not a
+downstream FT dependency.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Wielandt/SourceTheorems/MatrixSpanExistence.lean
+++ b/TNLean/Wielandt/SourceTheorems/MatrixSpanExistence.lean
@@ -42,9 +42,8 @@ case analysis of `SourceTheorems/WielandtInequality.lean`.
 2. Rewrite as `IsNormal A`.
 3. Apply the existential theorem `wielandt_lemma2b`.
 
-This file is part of `SourceTheorems/`, the source-facing arXiv:0909.5347 /
-Wolf §6.9 theorem interface, root-imported for citation/exposition, not a
-downstream FT dependency.
+These statements record Lemma 2(b) of arXiv:0909.5347 / Wolf Section 6.9
+in the notation of the source; the FT/BNT formalization does not use them.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Wielandt/SourceTheorems/MatrixSpanSharpBound.lean
+++ b/TNLean/Wielandt/SourceTheorems/MatrixSpanSharpBound.lean
@@ -55,9 +55,9 @@ strictly stronger than the qualitative `∃ N` statement exported by
 * [SPGWC09] Sanz, Pérez-García, Wolf, Cirac, arXiv:0909.5347, Lemma 2.
 * [Wolf12] Wolf, *Quantum Channels & Operations*, Chapter 6.
 
-This file is part of `SourceTheorems/`, the source-facing arXiv:0909.5347 /
-Wolf §6.9 theorem interface, root-imported for citation/exposition, not a
-downstream FT dependency.
+These statements record Lemma 2(b) (sharp bound) of arXiv:0909.5347 /
+Wolf Section 6.9 in the notation of the source; the FT/BNT formalization
+does not use them.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Wielandt/SourceTheorems/MatrixSpanSharpBound.lean
+++ b/TNLean/Wielandt/SourceTheorems/MatrixSpanSharpBound.lean
@@ -28,16 +28,16 @@ Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequalit
 
 ## Quantitative status
 
-Unlike `PaperResults/MatrixSpanExistence.lean` (which provides only a coarse existential `∃ N`
+Unlike `SourceTheorems/MatrixSpanExistence.lean` (which provides only a coarse existential `∃ N`
 witness), this file delivers the **exact paper bound** `D² − D + 1` under
 the additional hypotheses that a specific Kraus operator `A i₀` is
 noninvertible and possesses a nonzero eigenvector `φ`.
 
 These hypotheses match the paper's Lemma 2(b) statement precisely.
 Consequently, this file supplies the exact fixed-length ingredient behind the
-blocked noninvertible branch of `PaperResults/WielandtInequality.lean`; it is
+blocked noninvertible branch of `SourceTheorems/WielandtInequality.lean`; it is
 strictly stronger than the qualitative `∃ N` statement exported by
-`PaperResults/MatrixSpanExistence.lean`.
+`SourceTheorems/MatrixSpanExistence.lean`.
 
 ## Proof strategy
 
@@ -54,6 +54,10 @@ strictly stronger than the qualitative `∃ N` statement exported by
 
 * [SPGWC09] Sanz, Pérez-García, Wolf, Cirac, arXiv:0909.5347, Lemma 2.
 * [Wolf12] Wolf, *Quantum Channels & Operations*, Chapter 6.
+
+This file is part of `SourceTheorems/`, the source-facing arXiv:0909.5347 /
+Wolf §6.9 theorem interface, root-imported for citation/exposition, not a
+downstream FT dependency.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Wielandt/SourceTheorems/NonzeroTraceWord.lean
+++ b/TNLean/Wielandt/SourceTheorems/NonzeroTraceWord.lean
@@ -40,6 +40,10 @@ in the `IsPrimitivePaper` language of the paper.
 Use Proposition 3 to pass from `IsPrimitivePaper A` to eventually full Kraus
 rank, rewrite this as `IsNormal A`, and then apply the nonzero-trace
 result from `NonzeroTraceProduct.lean`.
+
+This file is part of `SourceTheorems/`, the source-facing arXiv:0909.5347 /
+Wolf §6.9 theorem interface, root-imported for citation/exposition, not a
+downstream FT dependency.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Wielandt/SourceTheorems/NonzeroTraceWord.lean
+++ b/TNLean/Wielandt/SourceTheorems/NonzeroTraceWord.lean
@@ -41,9 +41,8 @@ Use Proposition 3 to pass from `IsPrimitivePaper A` to eventually full Kraus
 rank, rewrite this as `IsNormal A`, and then apply the nonzero-trace
 result from `NonzeroTraceProduct.lean`.
 
-This file is part of `SourceTheorems/`, the source-facing arXiv:0909.5347 /
-Wolf §6.9 theorem interface, root-imported for citation/exposition, not a
-downstream FT dependency.
+These statements record Lemma 1 of arXiv:0909.5347 / Wolf Section 6.9
+in the notation of the source; the FT/BNT formalization does not use them.
 -/
 
 open scoped Matrix ComplexOrder BigOperators

--- a/TNLean/Wielandt/SourceTheorems/WielandtInequality.lean
+++ b/TNLean/Wielandt/SourceTheorems/WielandtInequality.lean
@@ -67,9 +67,8 @@ word-span invariance lemmas from `SpanGrowth/InvertibleWordSpan.lean`.
 Within TNLean these results are currently standalone paper-level theorem statements:
 the canonical / FT / BNT development does not import them directly.
 
-This directory (`SourceTheorems/`) is the source-facing arXiv:0909.5347 / Wolf §6.9
-theorem interface, currently root-imported for citation and exposition and not a
-downstream FT dependency.
+These statements record Theorem 1 of arXiv:0909.5347 / Wolf Section 6.9 in the
+notation of the source; the FT/BNT formalization does not use them.
 
 This file is the preferred public entry point for the currently formalized
 Theorem 1 statements. The auxiliary module `QuantumWielandt.lean` keeps a

--- a/TNLean/Wielandt/SourceTheorems/WielandtInequality.lean
+++ b/TNLean/Wielandt/SourceTheorems/WielandtInequality.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
 import TNLean.Wielandt.Primitivity.Equivalence
-import TNLean.Wielandt.PaperResults.EigenvectorSpreading
-import TNLean.Wielandt.PaperResults.MatrixSpanSharpBound
-import TNLean.Wielandt.PaperResults.NonzeroTraceWord
+import TNLean.Wielandt.SourceTheorems.EigenvectorSpreading
+import TNLean.Wielandt.SourceTheorems.MatrixSpanSharpBound
+import TNLean.Wielandt.SourceTheorems.NonzeroTraceWord
 import TNLean.Wielandt.SpanGrowth.InvertibleWordSpan
 import TNLean.Wielandt.RankOne.Products
 
@@ -66,6 +66,10 @@ word-span invariance lemmas from `SpanGrowth/InvertibleWordSpan.lean`.
 
 Within TNLean these results are currently standalone paper-level theorem statements:
 the canonical / FT / BNT development does not import them directly.
+
+This directory (`SourceTheorems/`) is the source-facing arXiv:0909.5347 / Wolf §6.9
+theorem interface, currently root-imported for citation and exposition and not a
+downstream FT dependency.
 
 This file is the preferred public entry point for the currently formalized
 Theorem 1 statements. The auxiliary module `QuantumWielandt.lean` keeps a

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -15,7 +15,7 @@ consequences of normality that feed into the fixed-length Wielandt bound
 (Theorem 1 of arXiv:0909.5347).
 
 The paper-facing Theorem 1 statements (case (1), (2), (3) bounds on the
-Kraus-rank index $i(A)$) are in `PaperResults/WielandtInequality.lean`.
+Kraus-rank index $i(A)$) are in `SourceTheorems/WielandtInequality.lean`.
 This file only provides the cumulative-span and eigenvector-spreading
 inputs needed by the primitivity/normality bridge and the blueprint.
 
@@ -59,7 +59,7 @@ the four standard cumulative consequences hold simultaneously.
 upgrade in Lemma 2(b).
 
 The fixed-length paper-facing bounds on `i(A)` (cases (1), (2), (3)) are
-assembled in `PaperResults/WielandtInequality.lean`.
+assembled in `SourceTheorems/WielandtInequality.lean`.
 -/
 theorem wielandt_chain [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :

--- a/docs/audits/issue-1449-wielandt-source-audit.md
+++ b/docs/audits/issue-1449-wielandt-source-audit.md
@@ -3,7 +3,7 @@
 **Audit date**: 2026-05-07
 **Source**: Sanz-Perez-Garcia-Wolf-Cirac, *A quantum version of Wielandt's inequality*, arXiv:0909.5347, Theorem 1
 **Blueprint**: `blueprint/src/chapter/ch07_wielandt.tex`
-**Formal**: `TNLean/Wielandt/PaperResults/WielandtInequality.lean`
+**Formal**: `TNLean/Wielandt/SourceTheorems/WielandtInequality.lean`
 
 ---
 
@@ -104,18 +104,18 @@ These are the **standalone paper-level** declarations -- correct as-is:
 
 | File | Status |
 |---|---|
-| `PaperResults/WielandtInequality.lean` | **Standalone paper-facing** Theorem 1. Not on FT critical path. |
-| `PaperResults/EigenvectorSpreading.lean` | Standalone paper-facing Lemma 2(a). |
-| `PaperResults/MatrixSpanExistence.lean` | Standalone paper-facing Lemma 2(b). |
-| `PaperResults/MatrixSpanSharpBound.lean` | Standalone sharp bound. |
-| `PaperResults/NonzeroTraceWord.lean` | Standalone Lemma 1. |
+| `SourceTheorems/WielandtInequality.lean` | **Standalone paper-facing** Theorem 1. Not on FT critical path. |
+| `SourceTheorems/EigenvectorSpreading.lean` | Standalone paper-facing Lemma 2(a). |
+| `SourceTheorems/MatrixSpanExistence.lean` | Standalone paper-facing Lemma 2(b). |
+| `SourceTheorems/MatrixSpanSharpBound.lean` | Standalone sharp bound. |
+| `SourceTheorems/NonzeroTraceWord.lean` | Standalone Lemma 1. |
 | `Primitivity/Equivalence.lean` | Standalone Proposition 3 full equivalence. |
 | `Primitivity/PaperDefinitions.lean` | Paper-facing definition layer (`iIndex`, `qIndex`, `IsPrimitivePaper`). |
 | `QuantumWielandt.lean` | Backward-compatible auxiliary (uses aperiodicity). |
 | `RankOne/ExtractionFull.lean` | Contains `wielandt_lemma2b` (existential Lemma 2(b)). Not directly imported by MPS pipeline. |
 | `Channel/WolfChapter6Index.lean` | Documentation-only index. |
 
-### Verdict: **Correct separation.** The paper-facing theorems live in `PaperResults/` and are not accidentally imported by the MPS pipeline. The pipeline uses a narrower set of Wielandt lemmas (`CumulativeSpan`, `CumulativeToWordSpan`, `VectorToMatrixSpan`, `ToNormal`, `ImpliesIrreducible`, `StronglyIrreducibleToFullRank`).
+### Verdict: **Correct separation.** The paper-facing theorems live in `SourceTheorems/` and are not accidentally imported by the MPS pipeline. The pipeline uses a narrower set of Wielandt lemmas (`CumulativeSpan`, `CumulativeToWordSpan`, `VectorToMatrixSpan`, `ToNormal`, `ImpliesIrreducible`, `StronglyIrreducibleToFullRank`).
 
 ---
 
@@ -160,7 +160,7 @@ The cumulative-span variety in `WielandtBound.lean` is imported by `FiniteLength
 | Declaration | File | Used by |
 |---|---|---|
 | `cumulativeSpan_eq_top` | `SpanGrowth/NonzeroTraceProduct.lean` | Pipeline |
-| `eigenvector_spreading` | `SpanGrowth/EigenvectorSpreading.lean` | Pipeline & PaperResults |
+| `eigenvector_spreading` | `SpanGrowth/EigenvectorSpreading.lean` | Pipeline & SourceTheorems |
 | `wielandt_blocked_assembly` | `RectangularSpan/Basic.lean` | `wielandt_lemma2b` |
 | `isIrreducibleTensor_of_isPrimitiveMPS_of_posDef` | `Primitivity/ImpliesIrreducible.lean` | `ProportionalPrimitive.lean` |
 | `isNormal_of_isPrimitiveMPS_with_posDef` | `Primitivity/StronglyIrreducibleToFullRank.lean` | `Existence.lean`, `TPPrimitiveReduction.lean` |
@@ -187,5 +187,5 @@ The cumulative-span variety in `WielandtBound.lean` is imported by `FiniteLength
 
 - None required. All three cases of Theorem 1 are correctly formalized with paper-faithful hypotheses.
 - The `_of_isPrimitivePaper_of_isUnit` and `_of_isPrimitivePaper_of_noninvertible_eigenvector` single-generator variants are legitimate convenience corollaries.
-- The `PaperResults/` files correctly serve as standalone documentation entry points.
-- No retirements or renames needed.
+- The `SourceTheorems/` files correctly serve as standalone documentation entry points.
+- No retirements needed. (Issue #1509 renamed the directory from `PaperResults/` to `SourceTheorems/` in PR #1519.)

--- a/docs/paper-gaps/quantum_wielandt_deviation.tex
+++ b/docs/paper-gaps/quantum_wielandt_deviation.tex
@@ -83,7 +83,7 @@ blocking argument, but the conclusion is the equality
 $S_n(A)=M_D(\mathbb C)$ for one fixed length $n$. It is not merely a statement
 about the increasing sum $S_0(A)+\cdots+S_n(A)$.\footnote{The paper-facing
 general theorem is \leanid{MPSTensor.iIndex\_le\_general\_of\_isPrimitivePaper}
-in \path{TNLean/Wielandt/PaperResults/WielandtInequality.lean:251--348}. The
+in \path{TNLean/Wielandt/SourceTheorems/WielandtInequality.lean:394--473}. The
 formal equivalence between the primitive condition used by Sanz--Pérez-García--Wolf--Cirac
 and eventual full Kraus rank under normalization is in
 \path{TNLean/Wielandt/Primitivity/Equivalence.lean:169--191}.}
@@ -115,7 +115,7 @@ of\_\allowbreak noninvertible\_\allowbreak eigenvector} and
 mem\_\allowbreak wordSpan\_\allowbreak one\_\allowbreak of\_\allowbreak noninvertible\_\allowbreak
 eigenvector} for
 the non-invertible case, all in
-\path{TNLean/Wielandt/PaperResults/WielandtInequality.lean}.  The shorter
+\path{TNLean/Wielandt/SourceTheorems/WielandtInequality.lean}.  The shorter
 chosen-generator statements in the same file are corollaries.}
 
 \section{Resolved one-step-subspace issue}

--- a/docs/paper-gaps/quantum_wielandt_deviation_v1.tex
+++ b/docs/paper-gaps/quantum_wielandt_deviation_v1.tex
@@ -83,7 +83,7 @@ blocking argument, but the conclusion is the equality
 $S_n(A)=M_D(\mathbb C)$ for one fixed length $n$. It is not merely a statement
 about the increasing sum $S_0(A)+\cdots+S_n(A)$.\footnote{The paper-facing
 general theorem is \leanid{MPSTensor.iIndex\_le\_general\_of\_isPrimitivePaper}
-in \path{TNLean/Wielandt/PaperResults/WielandtInequality.lean:251--348}. The
+in \path{TNLean/Wielandt/SourceTheorems/WielandtInequality.lean:394--473}. The
 formal equivalence between the primitive condition used by Sanz--Pérez-García--Wolf--Cirac
 and eventual full Kraus rank under normalization is in
 \path{TNLean/Wielandt/Primitivity/Equivalence.lean:169--191}.}
@@ -104,11 +104,11 @@ matrix to be any element of $S_1(A)$, hence any linear combination of the Kraus
 matrices.\footnote{The formal invertible case is
 \leanid{MPSTensor.wordSpan\_eq\_top\_of\_isPrimitivePaper\_of\_isUnit} and
 \leanid{MPSTensor.iIndex\_le\_of\_isPrimitivePaper\_of\_isUnit} in
-\path{TNLean/Wielandt/PaperResults/WielandtInequality.lean:182--217}. The
+\path{TNLean/Wielandt/SourceTheorems/WielandtInequality.lean:318--337}. The
 formal non-invertible case is
 \leanid{MPSTensor.wordSpan\_eq\_top\_of\_isPrimitivePaper\_of\_noninvertible\_eigenvector}
 and \leanid{MPSTensor.iIndex\_le\_sq\_of\_noninvertible\_eigenvector} in
-\path{TNLean/Wielandt/PaperResults/WielandtInequality.lean:119--178}.}
+\path{TNLean/Wielandt/SourceTheorems/WielandtInequality.lean:218--245}.}
 
 \section{The mathematical difference}
 


### PR DESCRIPTION
## Summary

Rename `TNLean/Wielandt/PaperResults/` → `TNLean/Wielandt/SourceTheorems/` per maintainer feedback (should not call them PaperResults).

## Changes

- Move 5 .lean files to new directory
- Update internal imports (WielandtInequality self-references)
- Update root `TNLean.lean` imports
- Update docstring references in `QuantumWielandt.lean`, `WielandtBound.lean`, `WolfChapter6Index.lean`
- Add disclaimers clarifying source-facing purpose (arXiv:0909.5347 / Wolf §6.9 theorem interface)

## Rationale

The five files contain the paper-faithful arXiv:0909.5347 / Wolf §6.9 theorem interface (Lemmas 1, 2(a), 2(b) and Theorem 1). They remain root-imported for citation/exposition and are not a downstream FT/BNT dependency.

The new name `SourceTheorems` aligns with the project's 'source-faithful' convention used in recent PRs (#1408, LionSR/QICLean#152, LionSR/TNLean#1420, LionSR/TNLean#1421, LionSR/QICLean#151).

Closes LionSR/TNLean#1509

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a directory/path rename and documentation update, but it is a breaking change for any downstream imports still referencing `TNLean.Wielandt.PaperResults.*` and could cause build failures until updated.
> 
> **Overview**
> Renames the paper-facing Quantum Wielandt theorem modules from `TNLean.Wielandt.PaperResults.*` to `TNLean.Wielandt.SourceTheorems.*`, updating root imports (`TNLean.lean`) and all internal references accordingly.
> 
> Updates docs/comments (e.g. `WolfChapter6Index.lean`, `QuantumWielandt.lean`, `WielandtBound.lean`, audit and paper-gap docs) to point at the new module paths and to clarify that these theorems are *source-faithful wrappers* not used by the FT/BNT pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f0ddbd251022fa64bf272a320ea8e140015470c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->