### PR TITLE
doc(CanonicalForm): record BlockDiagonalCommutant parent-Hamiltonian role

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -24,6 +24,18 @@ BNT block families, the results here use only restricted consequences of that
 hypotheses: block injectivity, nonzero weights, pair separation, selector words, and
 homogeneous padding hypotheses.  They are not the general CPSV repeated-sector
 comparison, where multiplicities and sector weights remain explicit data.
+
+## Routing decision (issue #1510)
+
+This module is a **live ParentHamiltonian dependency**, retained specifically for
+`TNLean/MPS/ParentHamiltonian/DegenerateGS.lean`.  The central theorem
+`isBlockDiagonal'_of_commutes_reindexed_wordSpan` provides the commutant reduction
+used in the parent-Hamiltonian ground-space decomposition
+(`groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed_projectionSpan`).
+It is **not on the non-periodic Fundamental Theorem path** and is not required by
+the sector-comparison or FT infrastructure.  The CPSV repeated-sector comparison
+(CPSV, arXiv:2011.12127, §V) is handled separately in
+`TNLean/MPS/CanonicalForm/SectorComparison`.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -25,17 +25,15 @@ hypotheses: block injectivity, nonzero weights, pair separation, selector words,
 homogeneous padding hypotheses.  They are not the general CPSV repeated-sector
 comparison, where multiplicities and sector weights remain explicit data.
 
-## Routing decision (issue #1510)
+## Implementation notes
 
-This module is a **live ParentHamiltonian dependency**, retained specifically for
-`TNLean/MPS/ParentHamiltonian/DegenerateGS.lean`.  The central theorem
-`isBlockDiagonal'_of_commutes_reindexed_wordSpan` provides the commutant reduction
-used in the parent-Hamiltonian ground-space decomposition
-(`groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed_projectionSpan`).
-It is **not on the non-periodic Fundamental Theorem path** and is not required by
-the sector-comparison or FT infrastructure.  The CPSV repeated-sector comparison
-(CPSV, arXiv:2011.12127, §V) is handled separately in
-`TNLean/MPS/CanonicalForm/SectorComparison`.
+The commutant theorem `isBlockDiagonal'_of_commutes_reindexed_wordSpan` is used
+in the parent-Hamiltonian ground-space decomposition
+`groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed_projectionSpan`
+in `TNLean/MPS/ParentHamiltonian/DegenerateGS.lean`.  It is a restricted
+block-diagonal commutant statement: the CPSV repeated-sector comparison
+(CPSV, arXiv:2011.12127, §V) is stated in
+`TNLean/MPS/CanonicalForm/SectorComparison`.  (Issue #1510.)
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant/ProjectionSpan.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant/ProjectionSpan.lean
@@ -12,7 +12,9 @@ import TNLean.Algebra.ScalarCommutant
 
 This module contains the algebraic span facts used to turn commutation with a
 family of generators into block diagonality with respect to dependent
-direct-sum sectors.
+direct-sum sectors.  It is a linear-algebra substrate for the restricted
+block-diagonal commutant interface in `BlockDiagonalCommutant.lean`, supporting
+the parent-Hamiltonian ground-space decomposition route (see issue #1510).
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant/ProjectionSpan.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant/ProjectionSpan.lean
@@ -12,9 +12,9 @@ import TNLean.Algebra.ScalarCommutant
 
 This module contains the algebraic span facts used to turn commutation with a
 family of generators into block diagonality with respect to dependent
-direct-sum sectors.  It is a linear-algebra substrate for the restricted
-block-diagonal commutant interface in `BlockDiagonalCommutant.lean`, supporting
-the parent-Hamiltonian ground-space decomposition route (see issue #1510).
+direct-sum sectors.  These linear-algebra lemmas support the restricted
+block-diagonal commutant theorem in `BlockDiagonalCommutant.lean` and are used
+in the parent-Hamiltonian ground-space decomposition.  (Issue #1510.)
 -/
 
 open scoped Matrix BigOperators


### PR DESCRIPTION
## Summary

Closes #1510

This PR documents the routing decision from issue #1510: `BlockDiagonalCommutant` is a **live ParentHamiltonian dependency**, retained specifically for `DegenerateGS.lean`. It is **not on the non-periodic FT path** and is not the general CPSV repeated-sector comparison.

## Changes

- **`BlockDiagonalCommutant.lean`**: Add a `Routing decision` section to the module docstring recording:
  - Consumer: `TNLean/MPS/ParentHamiltonian/DegenerateGS.lean`
  - Key theorem: `isBlockDiagonal'\_of\_commutes\_reindexed\_wordSpan`
  - Not on non-periodic FT path
  - CPSV repeated-sector comparison handled separately in `SectorComparison`
  - Source reference: arXiv:2011.12127 (CPSV) §V

- **`ProjectionSpan.lean`**: Lightweight note that this module is a linear-algebra substrate for the restricted commutant interface and the parent-Hamiltonian route (issue #1510).

## Verification

- `lake build` succeeds on both files
- Grep confirms consumers: `DegenerateGS.lean` (and top-level `TNLean.lean`)
- No errors in Lean diagnostics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify module routing/usage; no theorem statements or proofs were modified.
> 
> **Overview**
> Adds an *Implementation notes* section to `BlockDiagonalCommutant.lean` documenting that `isBlockDiagonal'_of_commutes_reindexed_wordSpan` is a **live dependency** of the parent-Hamiltonian ground-space decomposition in `ParentHamiltonian/DegenerateGS.lean`, and explicitly distinguishes this restricted commutant result from the general CPSV repeated-sector comparison (`SectorComparison`).
> 
> Updates the `ProjectionSpan.lean` module header comment to note it is the linear-algebra substrate for the same restricted commutant interface and parent-Hamiltonian route (Issue #1510).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe418c4d6df29f9b0a8769d9c93a63a0dc31845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->