### PR TITLE
doc(audits): record root-only theorem-surface boundaries

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -12,12 +12,11 @@ import Mathlib.Analysis.InnerProductSpace.Spectrum
 /-!
 # Martingale-method spectral-gap framework for parent Hamiltonians
 
-**Root-only.** This module is currently not imported downstream — it is a
-source-facing theorem surface that formalizes the martingale-method
-infrastructure for the MPS parent-Hamiltonian spectral gap. The
-Friedrichs-angle estimate needed to close `parentHamiltonian_gapped` is
-tracked by issues #952 and #460 (#190). See issue #1512 for the root-only
-audit.
+**Root-only.** This module is currently not imported downstream — it
+formalizes the martingale-method infrastructure for the MPS
+parent-Hamiltonian spectral gap. The Friedrichs-angle estimate needed
+to close `parentHamiltonian_gapped` is tracked by issues #952 and #460
+(#190). See issue #1512 for the root-only audit.
 
 This file sets up the martingale approach to proving
 that MPS parent Hamiltonians are gapped, following

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -12,6 +12,13 @@ import Mathlib.Analysis.InnerProductSpace.Spectrum
 /-!
 # Martingale-method spectral-gap framework for parent Hamiltonians
 
+**Root-only.** This module is currently not imported downstream — it is a
+source-facing theorem surface that formalizes the martingale-method
+infrastructure for the MPS parent-Hamiltonian spectral gap. The
+Friedrichs-angle estimate needed to close `parentHamiltonian_gapped` is
+tracked by issues #952 and #460 (#190). See issue #1512 for the root-only
+audit.
+
 This file sets up the martingale approach to proving
 that MPS parent Hamiltonians are gapped, following
 Kastoryano–Lucia 2018 (arXiv:1705.09491), Nachtergaele 1996
@@ -1516,6 +1523,7 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
   -- estimate required by `parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs`.
   -- Local projection structure, row cardinality, non-overlap positivity, kernel
   -- identification, and the spectral-theorem conversion are already formalized above.
+  -- Proof obligation tracked by #952 and #460 (#190).
   sorry
 
 /--

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -3,13 +3,6 @@ import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
---
--- **Root-only.**  This module is currently not imported downstream — it
--- records the full statement of the PEPS Fundamental Theorem
--- (arXiv:1804.04964 §3, Theorem 2) with its forward direction fully proved
--- and the converse gaps documented explicitly.  See issue #1512 for the
--- root-only audit.
---
 -- The forward direction and contraction algebra are formalized. The converse
 -- PEPS fundamental theorem still depends on the mathematical hypotheses listed
 -- below.
@@ -43,6 +36,12 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 /-!
 # Fundamental Theorem for injective PEPS
+
+**Root-only.** This module is currently not imported downstream — it
+records the full statement of the PEPS Fundamental Theorem
+(arXiv:1804.04964 §3, Theorem 2) with its forward direction fully proved
+and the converse gaps documented explicitly.  See issue #1512 for the
+root-only audit.
 
 This file develops the Fundamental Theorem for injective PEPS on simple graphs
 (arXiv:1804.04964, Theorem 2, Section 3):

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -4,11 +4,11 @@ import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 --
--- **Root-only.**  This module is currently not imported downstream — it is a
--- source-facing theorem surface that records the full statement of the PEPS
--- Fundamental Theorem (arXiv:1804.04964 §3, Theorem 2) with its forward direction
--- fully proved, while exposing the converse gaps in an explicit, factored form.
--- See issue #1512 for the root-only audit.
+-- **Root-only.**  This module is currently not imported downstream — it
+-- records the full statement of the PEPS Fundamental Theorem
+-- (arXiv:1804.04964 §3, Theorem 2) with its forward direction fully proved
+-- and the converse gaps documented explicitly.  See issue #1512 for the
+-- root-only audit.
 --
 -- The forward direction and contraction algebra are formalized. The converse
 -- PEPS fundamental theorem still depends on the mathematical hypotheses listed
@@ -29,8 +29,7 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 --   `HasFactorizedLocalGauge`. The edge-blocked coefficient and middle tensor are
 --   developed in `PEPS/Blocking`; the abbreviation `BlockedMiddleGaugeFormula`
 --   isolates the remaining implication from `SameState` to the explicit local
---   gauge formula.  Tracked by #780 (`PEPS: local gauge existence, consistency,
---   and main theorem assembly`).
+--   gauge formula.  Tracked by #780.
 -- * The `hDim` step inside `fundamentalTheorem_PEPS` is factored out as the
 --   conditional theorem `fundamentalTheorem_PEPS_of_bondDim`, so that the
 --   bond-dimension equality is orthogonal to `gaugeConsistency`. Its derivation

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -3,6 +3,13 @@ import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
+--
+-- **Root-only.**  This module is currently not imported downstream — it is a
+-- source-facing theorem surface that records the full statement of the PEPS
+-- Fundamental Theorem (arXiv:1804.04964 §3, Theorem 2) with its forward direction
+-- fully proved, while exposing the converse gaps in an explicit, factored form.
+-- See issue #1512 for the root-only audit.
+--
 -- The forward direction and contraction algebra are formalized. The converse
 -- PEPS fundamental theorem still depends on the mathematical hypotheses listed
 -- below.
@@ -22,15 +29,18 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 --   `HasFactorizedLocalGauge`. The edge-blocked coefficient and middle tensor are
 --   developed in `PEPS/Blocking`; the abbreviation `BlockedMiddleGaugeFormula`
 --   isolates the remaining implication from `SameState` to the explicit local
---   gauge formula.
+--   gauge formula.  Tracked by #780 (`PEPS: local gauge existence, consistency,
+--   and main theorem assembly`).
 -- * The `hDim` step inside `fundamentalTheorem_PEPS` is factored out as the
 --   conditional theorem `fundamentalTheorem_PEPS_of_bondDim`, so that the
 --   bond-dimension equality is orthogonal to `gaugeConsistency`. Its derivation
 --   from `SameState` plus vertex injectivity still requires a boundary-insertion
---   / blocking lemma.
+--   / blocking lemma.  Tracked by #874 (`PEPS: bond-dimension equality from
+--   SameState and vertex injectivity`).
 -- * `gauge_unique_mod_edge_scalars` is the repaired uniqueness statement. Its
 --   proof still requires local tensor-factor uniqueness for the balanced
---   edge-scalar quotient.
+--   edge-scalar quotient.  Tracked by #842 (`Discharge sorry in
+--   gauge_unique_mod_edge_scalars`).
 
 /-!
 # Fundamental Theorem for injective PEPS
@@ -541,6 +551,7 @@ theorem gaugeConsistency (A B : Tensor G d)
   -- The key remaining consistency step is: for each edge e = (u,v), the gauges
   -- extracted from u and v must agree as inverse-transposes, with the
   -- orientation convention in `edgeGaugeAt`.
+  -- Proof obligation tracked by #780.
   sorry
 
 /-! ### Main theorem -/
@@ -588,6 +599,7 @@ theorem fundamentalTheorem_PEPS (A B : Tensor G d)
   -- insertions. Linear independence at each vertex (`IsVertexInjective`) gives
   -- the right local data, while the global comparison still requires a
   -- boundary-insertion / blocking lemma.
+  -- Proof obligation tracked by #874.
   have hDim : A.bondDim = B.bondDim := by
     sorry
   -- With matching bond dimensions, `gaugeConsistency` supplies the global gauges.
@@ -721,6 +733,7 @@ theorem gauge_unique_mod_edge_scalars (A B : Tensor G d)
   -- `IsVertexBalanced c`. This is the local scalar-ratio argument of
   -- arXiv:1804.04964 Section 3; it is independent of the virtual-insertion and
   -- blocking lemmas used for local gauge existence.
+  -- Proof obligation tracked by #842.
   sorry
 
 end PEPS


### PR DESCRIPTION
Refs #1512.

## Summary

Audit of two large root-only modules with sorrys/axioms:
`PEPS.FundamentalTheorem` and `ParentHamiltonian.Martingale`.

### Classification: KEEP — fully documented with explicit gap boundaries

Both modules are source-facing theorem surfaces with no downstream
consumers. The remaining proof gaps are all tracked by existing issues.

### PEPS.FundamentalTheorem (3 sorrys)

| Gap | Tracker |
|-----|---------|
| `gaugeConsistency` (edge consistency across graph) | #780 |
| `fundamentalTheorem_PEPS` hDim (bond-dimension equality) | #874 |
| `gauge_unique_mod_edge_scalars` (scalar-ratio uniqueness) | #842 |

### ParentHamiltonian.Martingale (1 sorry)

| Gap | Tracker |
|-----|---------|
| `parentHamiltonianES_gap_bound_of_friedrichs` (Friedrichs-angle estimate) | #952, #460 (#190) |

### Changes

- Add root-only audit headers to both module docstrings
- Add explicit tracker issue references at every sorry site
- Cross-link all tracker issues with comments referencing #1512

### Validation

- `lean_diagnostics` reports zero errors/warnings on both files
- No code changes — comment-only doc/gap-surface updates
- No overlap with open PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only updates that add root-only audit headers and link existing `sorry` proof obligations to tracking issues; no logic or theorem statements change.
> 
> **Overview**
> Adds **root-only audit documentation** to `MPS/ParentHamiltonian/Martingale.lean` and `PEPS/FundamentalTheorem.lean`, explicitly noting these modules are not imported downstream and cross-linking the related audit issue `#1512`.
> 
> Annotates each remaining `sorry` site with the corresponding **tracked issue IDs** (MPS Friedrichs-angle estimate; PEPS gauge consistency, bond-dimension equality, and uniqueness modulo edge scalars), making the unfinished proof boundaries explicit without changing any definitions or proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40acae0e52517ab2db664371ddc6baaf86f5c205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->