### PR TITLE
ci(github): sync CI improvements from MIPStarRE and harden checks

### DIFF
--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -1,3 +1,5 @@
+# ci-sync-version: claude-provider-deepseek-v1
+# ci-sync-source: shared Lean automation, prompts externalized under .github/prompts
 name: 'Claude Code with Provider'
 description: 'Run anthropics/claude-code-action with automatic Anthropic/DeepSeek provider selection'
 
@@ -51,15 +53,6 @@ inputs:
     description: 'Allowed bots override.'
     required: false
     default: 'claude,chatgpt-codex-connector,cursor[bot],cursor,copilot-pull-request-reviewer'
-  bot-id:
-    description: 'GitHub user ID for Claude Code git operations.'
-    required: false
-    default: '41898282'
-  bot-name:
-    description: 'GitHub username for Claude Code git operations.'
-    required: false
-    default: 'claude[bot]'
-
   allowed_tools:
     description: 'Optional --allowedTools value applied by default.'
     required: false
@@ -73,6 +66,14 @@ inputs:
     description: 'Branch-name template for the checkout branch.'
     required: false
     default: ''
+  bot-id:
+    description: 'GitHub user ID to use for git operations.'
+    required: false
+    default: '41898282'
+  bot-name:
+    description: 'GitHub username to use for git operations.'
+    required: false
+    default: 'claude[bot]'
 
   additional-permissions:
     description: 'Additional permissions for the Claude bot.'
@@ -137,9 +138,9 @@ runs:
         INPUT_DEEPSEEK_SONNET_MODEL: ${{ inputs['deepseek-sonnet-model'] }}
         INPUT_MODEL_TIER: ${{ inputs['model-tier'] }}
         INPUT_ALLOWED_BOTS: ${{ inputs['allowed-bots'] }}
+        INPUT_BRANCH_NAME_TEMPLATE: ${{ inputs['branch-name-template'] }}
         INPUT_BOT_ID: ${{ inputs['bot-id'] }}
         INPUT_BOT_NAME: ${{ inputs['bot-name'] }}
-        INPUT_BRANCH_NAME_TEMPLATE: ${{ inputs['branch-name-template'] }}
         INPUT_ADDITIONAL_PERMISSIONS: ${{ inputs['additional-permissions'] }}
         INPUT_PLUGIN_MARKETPLACES: ${{ inputs.plugin_marketplaces }}
         INPUT_PLUGINS: ${{ inputs['plugins'] }}
@@ -238,9 +239,9 @@ runs:
         fi
 
         allowed_bots="$INPUT_ALLOWED_BOTS"
+        branch_name_template="$INPUT_BRANCH_NAME_TEMPLATE"
         bot_id="$INPUT_BOT_ID"
         bot_name="$INPUT_BOT_NAME"
-        branch_name_template="$INPUT_BRANCH_NAME_TEMPLATE"
         additional_permissions="$INPUT_ADDITIONAL_PERMISSIONS"
         plugin_marketplaces="$INPUT_PLUGIN_MARKETPLACES"
         plugins="$INPUT_PLUGINS"
@@ -373,9 +374,9 @@ runs:
         write_output model "$model"
         write_output provider "$provider"
         write_output allowed_bots "$allowed_bots"
+        write_output branch_name_template "$branch_name_template"
         write_output bot_id "$bot_id"
         write_output bot_name "$bot_name"
-        write_output branch_name_template "$branch_name_template"
         write_output additional_permissions "$additional_permissions"
         write_output plugin_marketplaces "$plugin_marketplaces"
         write_output plugins "$plugins"
@@ -392,9 +393,9 @@ runs:
         claude_code_oauth_token: ${{ steps.resolve.outputs.claude_code_oauth_token }}
         anthropic_api_key: ${{ steps.resolve.outputs.anthropic_api_key }}
         allowed_bots: ${{ steps.resolve.outputs.allowed_bots }}
+        branch_name_template: ${{ steps.resolve.outputs.branch_name_template }}
         bot_id: ${{ steps.resolve.outputs.bot_id }}
         bot_name: ${{ steps.resolve.outputs.bot_name }}
-        branch_name_template: ${{ steps.resolve.outputs.branch_name_template }}
         additional_permissions: ${{ steps.resolve.outputs.additional_permissions }}
         plugin_marketplaces: ${{ steps.resolve.outputs.plugin_marketplaces }}
         plugins: ${{ steps.resolve.outputs.plugins }}

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,0 +1,38 @@
+name: Badges
+
+on:
+  schedule:
+    # Refresh informational badges weekly on Sunday at 05:30 UTC.
+    - cron: '30 5 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  badges:
+    runs-on: ubuntu-latest
+    name: Generate Lean badges
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Generate badge JSON
+        run: python3 scripts/generate_badges.py --output-dir badge-output
+
+      - name: Deploy badges
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/deploy-to-gh-pages.sh --badges-dir badge-output --badges-only --ci

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   claude-review:

--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -127,6 +127,7 @@ jobs:
         run: python3 scripts/blueprint_lean_sync.py --root . --ci
 
       - name: Fetch PR base ref for diff
+        id: fetch-base-ref
         if: github.event_name == 'pull_request' && steps.lean-setup.outcome == 'success'
         continue-on-error: true
         env:
@@ -134,7 +135,7 @@ jobs:
         run: git fetch --no-tags origin "$BASE_REF"
 
       - name: Error on changed Lean declarations missing blueprint entries
-        if: github.event_name == 'pull_request' && steps.lean-setup.outcome == 'success'
+        if: github.event_name == 'pull_request' && steps.lean-setup.outcome == 'success' && steps.fetch-base-ref.outcome == 'success'
         env:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: |

--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -133,9 +133,8 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: git fetch --no-tags origin "$BASE_REF"
 
-      - name: Warn on changed Lean declarations missing blueprint entries
+      - name: Error on changed Lean declarations missing blueprint entries
         if: github.event_name == 'pull_request' && steps.lean-setup.outcome == 'success'
-        continue-on-error: true
         env:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: |

--- a/.github/workflows/oversized-lean-files.yml
+++ b/.github/workflows/oversized-lean-files.yml
@@ -4,8 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# This check is advisory while main still has files above the 1000-line style
-# limit. Remove continue-on-error below once those files have been split.
+# Two known oversized files remain on main and are grandfathered as warnings:
+#   TNLean/MPS/ParentHamiltonian/Martingale.lean (1562 lines)
+#   TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean (1425 lines)
+# These are tracked for future splitting. Once split, remove the corresponding
+# ``--known`` argument below.
+# New oversized files (any file over 1000 lines not listed here) cause the
+# check to fail.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,5 +33,8 @@ jobs:
           python-version: '3.12'
 
       - name: Run oversized-file guard
-        continue-on-error: true
-        run: python3 scripts/check_oversized_lean_files.py --root .
+        run: >
+          python3 scripts/check_oversized_lean_files.py
+          --root .
+          --known TNLean/MPS/ParentHamiltonian/Martingale.lean
+          --known TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean

--- a/.github/workflows/stale-issue-audit.yml
+++ b/.github/workflows/stale-issue-audit.yml
@@ -1,0 +1,101 @@
+name: Stale issue audit
+
+on:
+  schedule:
+    # Report-only stale citation sweep, aligned with the Monday standup window.
+    - cron: "30 8 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: stale-issue-audit
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  audit:
+    name: Run stale-issue audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Export open issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh issue list \
+            --repo "$GH_REPO" \
+            --state open \
+            --limit 500 \
+            --json number,title,body,url,labels \
+            > "$RUNNER_TEMP/open-issues.json"
+
+      - name: Run report-only audit
+        run: |
+          # The audit contract is documented in docs/stale_issue_audit.md:
+          # it only reports stale citations and never edits GitHub issues.
+          python3 scripts/audit_stale_issues.py \
+            --issues "$RUNNER_TEMP/open-issues.json" \
+            --format json \
+            --output "$RUNNER_TEMP/stale-issue-audit.json"
+          python3 scripts/audit_stale_issues.py \
+            --issues "$RUNNER_TEMP/open-issues.json" \
+            --output "$RUNNER_TEMP/stale-issue-audit.txt"
+
+      - name: Summarize audit result
+        id: summarize
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          from pathlib import Path
+
+          report_path = Path(os.environ["RUNNER_TEMP"]) / "stale-issue-audit.json"
+          report = json.loads(report_path.read_text())
+          flagged = [issue for issue in report if issue["flagged"]]
+          with_citations = [
+              issue for issue in report
+              if issue["file_citations"] or issue["decl_citations"]
+          ]
+          print(f"scanned={len(report)}")
+          print(f"with_citations={len(with_citations)}")
+          print(f"flagged={len(flagged)}")
+          PY
+
+      - name: Add flagged-citation summary
+        if: steps.summarize.outputs.flagged != '0'
+        run: |
+          {
+            echo "## Stale-issue audit"
+            echo
+            echo "- Issues scanned: ${{ steps.summarize.outputs.scanned }}"
+            echo "- Issues with citations: ${{ steps.summarize.outputs.with_citations }}"
+            echo "- Issues flagged stale: ${{ steps.summarize.outputs.flagged }}"
+            echo
+            echo "The workflow is report-only; maintainers must review the flags manually."
+            echo "When updating an issue, keep its mathematical source citation precise: paper or blueprint path, line, label, and a short quotation or precise paraphrase."
+            echo "See docs/stale_issue_audit.md for the triage policy."
+            echo
+            echo '```text'
+            cat "$RUNNER_TEMP/stale-issue-audit.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload flagged-citation report
+        if: steps.summarize.outputs.flagged != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: stale-issue-audit-report
+          path: |
+            ${{ runner.temp }}/stale-issue-audit.json
+            ${{ runner.temp }}/stale-issue-audit.txt
+          if-no-files-found: error

--- a/scripts/audit_stale_issues.py
+++ b/scripts/audit_stale_issues.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+r"""
+Stale-issue audit for theorem / sorry tracking tickets.
+
+Scans exported GitHub issue JSON (from ``gh issue list --json``) and flags
+references whose state on current ``main`` looks outdated:
+
+  * ``TNLean/**/*.lean`` paths that no longer exist;
+  * cited ``file.lean:LINE`` or ``line NNN`` markers where the line is no
+    longer a ``sorry`` / ``admit``;
+  * backtick-quoted declaration names that no longer resolve to any
+    ``def`` / ``theorem`` / ``lemma`` / ``structure`` / ``instance`` /
+    ``class`` / ``abbrev`` / ``inductive`` declaration under ``TNLean/``.
+
+The tool is **report-only**: it never edits or closes issues.  It is intended
+as a triage aid for humans who will decide whether a flagged issue is truly
+stale or simply needs its body updated.
+
+Typical workflow::
+
+    gh issue list --repo OWNER/REPO --state open --limit 500 \
+      --json number,title,body,url,labels > issues.json
+    python scripts/audit_stale_issues.py --issues issues.json
+
+See ``docs/stale_issue_audit.md`` for the documented workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+# ---------------------------------------------------------------------------
+# Regexes
+# ---------------------------------------------------------------------------
+
+# Lean file path under the project. ``:LINE`` suffix captured when present.
+# The outer ``(?:/…)*`` also matches the root ``TNLean.lean`` file.  A
+# leading ``\b`` keeps the match from starting mid-identifier.
+_FILE_RE = re.compile(r"\b(TNLean(?:/[A-Za-z0-9_.\-]+)*\.lean)(?::(\d+))?")
+
+# GitHub blob URLs often appear in issue bodies; normalize them to plain
+# ``TNLean/...`` citations before scanning so we don't greedily match the
+# repo-name prefix (``.../TNLean/blob/main/...``) as part of the path.
+_GITHUB_BLOB_RE = re.compile(
+    r"https?://github\.com/[^/\s]+/[^/\s]+/blob/[^\s#]+?/"
+    r"(TNLean(?:/[A-Za-z0-9_.\-]+)*\.lean)(?:#L(\d+)(?:-L\d+)?)?"
+)
+
+# "line 141" / "Line 131" — used when a path is mentioned nearby without the
+# bare ``:LINE`` suffix (the common table-cell idiom in this repo's issues).
+_LINE_WORD_RE = re.compile(r"\bline\s+(\d{1,6})\b", re.IGNORECASE)
+
+# Backtick-quoted token that looks like a Lean identifier.  Deliberately
+# conservative: must start with a letter, minimum two chars, only identifier
+# punctuation allowed.  This filters out inline prose like `main` and `sorry`
+# via the _DECL_STOPLIST below rather than by regex alone.
+_BACKTICK_DECL_RE = re.compile(r"`([A-Za-z][A-Za-z0-9_.']{1,})`")
+
+# Declaration-definition pattern used to build the "known declarations" set.
+# Matches the header line of a Lean declaration; mirrors the lighter-weight
+# variant used by scripts/blueprint_lean_sync.py but only returns the short
+# (unqualified) name.
+_DECL_DEFN_RE = re.compile(
+    r"^\s*(?:@\[[^\]]*\]\s*)?"
+    r"(?:(?:noncomputable|protected|private|local)\s+)*"
+    r"(?:def|theorem|lemma|abbrev|instance|class|structure|inductive|opaque)\s+"
+    r"([A-Za-z_][\w.']*)",
+    re.MULTILINE,
+)
+
+_NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z_][\w.']*)\b")
+_END_NAMESPACE_RE = re.compile(r"^\s*end(?:\s+([A-Za-z_][\w.']*))?\s*(?:--.*)?$")
+
+# Sorry markers we count as "still unproven".
+_SORRY_LINE_RE = re.compile(r"\b(sorry|admit)\b")
+
+# Tokens that are common English words, Lean keywords, or otherwise too
+# ambiguous to treat as declaration citations.  Any backtick token in this
+# set is skipped.
+_DECL_STOPLIST = frozenset({
+    "sorry", "admit", "main", "by", "true", "false", "Prop", "Type",
+    "True", "False", "Nat", "Int", "Rat", "Real", "Complex",
+    "rfl", "simp", "rw", "exact", "apply", "intro", "cases",
+    "this", "self", "it", "foo", "bar", "baz", "qux",
+    # Common command / tool names that show up in validation snippets.
+    "lean", "lake", "gh", "git", "rg", "grep", "sed", "awk",
+    "python", "python3", "bash", "sh", "ls", "cd",
+})
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class FileCitation:
+    """A ``TNLean/...`` path (with optional line) cited in an issue body."""
+    path: str
+    line: int | None
+
+
+@dataclass(frozen=True)
+class DeclCitation:
+    """A backtick-quoted identifier cited in an issue body."""
+    name: str
+
+
+@dataclass
+class IssueReport:
+    """Per-issue findings."""
+    number: int
+    title: str
+    url: str
+    missing_files: list[str] = field(default_factory=list)
+    non_sorry_lines: list[tuple[str, int]] = field(default_factory=list)
+    missing_decls: list[str] = field(default_factory=list)
+    file_citations: int = 0
+    decl_citations: int = 0
+
+    @property
+    def is_flagged(self) -> bool:
+        return bool(self.missing_files or self.non_sorry_lines or self.missing_decls)
+
+
+# ---------------------------------------------------------------------------
+# Citation extraction
+# ---------------------------------------------------------------------------
+
+def _normalize_github_blob_urls(body: str) -> str:
+    """Rewrite GitHub blob URLs to plain ``TNLean/...[:LINE]`` citations."""
+
+    def repl(match: re.Match[str]) -> str:
+        path = match.group(1)
+        line = match.group(2)
+        return f"{path}:{line}" if line is not None else path
+
+    return _GITHUB_BLOB_RE.sub(repl, body)
+
+
+def extract_file_citations(body: str) -> list[FileCitation]:
+    """Pull ``TNLean/.../file.lean[:LINE]`` references out of ``body``.
+
+    When the path appears in a table row that separately lists ``line NNN``
+    (the common convention in sorry-site trackers), we attach the nearest
+    ``line NNN`` on the same line as the path.
+    """
+    out: list[FileCitation] = []
+    for raw_line in _normalize_github_blob_urls(body).splitlines():
+        paths_on_line = list(_FILE_RE.finditer(raw_line))
+        if not paths_on_line:
+            continue
+        line_hints = [int(m.group(1)) for m in _LINE_WORD_RE.finditer(raw_line)]
+        for idx, m in enumerate(paths_on_line):
+            path = m.group(1)
+            if m.group(2) is not None:
+                out.append(FileCitation(path=path, line=int(m.group(2))))
+                continue
+            # No ``:LINE`` suffix — fall back to a ``line NNN`` word on the
+            # same line only when exactly one path appears (avoids cross
+            # attribution in tables with multiple rows on one wrapped line).
+            if len(paths_on_line) == 1 and len(line_hints) == 1:
+                out.append(FileCitation(path=path, line=line_hints[0]))
+            else:
+                out.append(FileCitation(path=path, line=None))
+    # Deduplicate while preserving order.
+    seen: set[tuple[str, int | None]] = set()
+    unique: list[FileCitation] = []
+    for fc in out:
+        key = (fc.path, fc.line)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(fc)
+    return unique
+
+
+def extract_decl_citations(body: str) -> list[DeclCitation]:
+    """Pull backtick-quoted Lean-identifier-shaped tokens out of ``body``."""
+    out: list[DeclCitation] = []
+    seen: set[str] = set()
+    for m in _BACKTICK_DECL_RE.finditer(body):
+        name = m.group(1)
+        if name in _DECL_STOPLIST or name in seen:
+            continue
+        # Require at least one lowercase or digit; purely uppercase backtick
+        # items are dropped, which helps exclude obvious sentence starts like
+        # `The`.  This is a soft filter.
+        if not any(c.islower() or c.isdigit() for c in name):
+            continue
+        seen.add(name)
+        out.append(DeclCitation(name=name))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main-branch indices
+# ---------------------------------------------------------------------------
+
+def build_decl_index(lean_root: Path) -> set[str]:
+    """Collect declaration names under ``lean_root``.
+
+    The index stores both short names (for unqualified issue citations) and the
+    namespace-qualified names visible from simple ``namespace ...`` blocks.  A
+    cited qualified name is later matched exactly, so ``Foo.bar`` cannot be
+    silently satisfied by some unrelated short declaration named ``bar``.
+    """
+    names: set[str] = set()
+    for path in sorted(lean_root.rglob("*.lean")):
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        namespace_stack: list[str] = []
+        for line in text.splitlines():
+            if m := _NAMESPACE_RE.match(line):
+                namespace_stack.extend(m.group(1).split("."))
+                continue
+            if m := _END_NAMESPACE_RE.match(line):
+                end_name = m.group(1)
+                if end_name:
+                    parts = end_name.split(".")
+                    if namespace_stack[-len(parts):] == parts:
+                        del namespace_stack[-len(parts):]
+                    # Otherwise this is likely closing a named section, not a
+                    # tracked namespace; leave the namespace stack unchanged.
+                # An anonymous ``end`` is ambiguous: in this repo it commonly
+                # closes an unnamed ``section`` inside a namespace.  Do not pop
+                # the namespace stack unless Lean text explicitly names the
+                # namespace being closed.
+                continue
+            if m := _DECL_DEFN_RE.match(line):
+                declared = m.group(1)
+                short = declared.rsplit(".", 1)[-1]
+                names.add(short)
+                names.add(declared)
+                if namespace_stack:
+                    names.add(".".join([*namespace_stack, declared]))
+    return names
+
+
+def line_is_sorry(path: Path, line_no: int) -> bool | None:
+    """Return True/False if ``path:line_no`` still contains a ``sorry``/``admit``.
+
+    Returns ``None`` if the file can't be read or the line number is out of
+    range.  Single-line ``--`` comments are stripped before matching so that
+    commented-out mentions (``-- sorry``) don't masquerade as active sorry
+    sites.
+    """
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        return None
+    lines = text.splitlines()
+    if line_no < 1 or line_no > len(lines):
+        return None
+    line = lines[line_no - 1].split("--", 1)[0]
+    return _SORRY_LINE_RE.search(line) is not None
+
+
+# ---------------------------------------------------------------------------
+# Audit driver
+# ---------------------------------------------------------------------------
+
+def _repo_file_path(repo_root: Path, citation_path: str) -> Path | None:
+    """Resolve a cited file path, rejecting paths that escape ``repo_root``.
+
+    Issue text is untrusted input.  The path regex intentionally recognizes
+    broad ``TNLean/...``-shaped strings, so normalize away any ``..``
+    segments before opening the file.  A citation that resolves outside the
+    checkout is treated as an invalid/missing in-repository file instead of
+    letting the audit inspect arbitrary host files.
+    """
+    root = repo_root.resolve()
+    candidate = (root / citation_path).resolve(strict=False)
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
+def audit_issue(
+    issue: dict,
+    repo_root: Path,
+    decl_index: set[str],
+) -> IssueReport:
+    """Run all checks against a single issue dict from ``gh issue list``."""
+    number = int(issue.get("number", 0))
+    title = str(issue.get("title", ""))
+    url = str(issue.get("url", ""))
+    body = str(issue.get("body") or "")
+
+    report = IssueReport(number=number, title=title, url=url)
+
+    file_cites = extract_file_citations(body)
+    decl_cites = extract_decl_citations(body)
+    report.file_citations = len(file_cites)
+    report.decl_citations = len(decl_cites)
+
+    for fc in file_cites:
+        full = _repo_file_path(repo_root, fc.path)
+        if full is None or not full.is_file():
+            report.missing_files.append(
+                fc.path if fc.line is None else f"{fc.path}:{fc.line}"
+            )
+            continue
+        if fc.line is not None:
+            sorry = line_is_sorry(full, fc.line)
+            # Treat both an explicit "no sorry on this line" (False) and an
+            # out-of-range line number (None) as stale: trackers drift as
+            # files are edited, and a citation past EOF is exactly the kind
+            # of stale reference this audit is meant to surface.
+            if sorry is not True:
+                report.non_sorry_lines.append((fc.path, fc.line))
+
+    for dc in decl_cites:
+        if "." in dc.name:
+            # Qualified citations are meant to disambiguate.  Require an exact
+            # qualified-name match instead of accepting any declaration with the
+            # same final component.
+            if dc.name not in decl_index:
+                report.missing_decls.append(dc.name)
+        else:
+            short = dc.name.rsplit(".", 1)[-1]
+            if dc.name not in decl_index and short not in decl_index:
+                report.missing_decls.append(dc.name)
+
+    return report
+
+
+def load_issues(path: Path) -> list[dict]:
+    """Load issues from a JSON file produced by ``gh issue list --json``."""
+    data = json.loads(path.read_text())
+    if not isinstance(data, list):
+        raise ValueError(
+            f"{path}: expected a JSON array (from `gh issue list --json ...`)"
+        )
+    return data
+
+
+def run_audit(
+    issues: Iterable[dict],
+    repo_root: Path,
+) -> list[IssueReport]:
+    decl_index = build_decl_index(repo_root / "TNLean")
+    reports: list[IssueReport] = []
+    for issue in issues:
+        reports.append(audit_issue(issue, repo_root, decl_index))
+    return reports
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def render_text_report(reports: list[IssueReport], only_flagged: bool) -> str:
+    total = len(reports)
+    flagged = [r for r in reports if r.is_flagged]
+    scanned = [r for r in reports if r.file_citations or r.decl_citations]
+    lines = [
+        "Stale-issue audit report",
+        "========================",
+        f"issues scanned        : {total}",
+        f"issues with citations : {len(scanned)}",
+        f"issues flagged stale  : {len(flagged)}",
+        "triage note           : keep mathematical source citations precise",
+        "                       (paper/blueprint path, line, label, and",
+        "                       short quotation or precise paraphrase)",
+        "",
+    ]
+    show = flagged if only_flagged else reports
+    for r in show:
+        header = f"#{r.number} — {r.title}"
+        lines.append(header)
+        lines.append("-" * len(header))
+        if r.url:
+            lines.append(f"  {r.url}")
+        if not r.is_flagged:
+            lines.append("  (no stale citations detected)")
+            lines.append("")
+            continue
+        if r.missing_files:
+            lines.append("  missing files:")
+            for p in r.missing_files:
+                lines.append(f"    - {p}")
+        if r.non_sorry_lines:
+            lines.append("  lines no longer containing `sorry`/`admit`:")
+            for path, ln in r.non_sorry_lines:
+                lines.append(f"    - {path}:{ln}")
+        if r.missing_decls:
+            lines.append("  declarations not found under TNLean/:")
+            for name in r.missing_decls:
+                lines.append(f"    - {name}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_json_report(reports: list[IssueReport]) -> str:
+    payload = [
+        {
+            "number": r.number,
+            "title": r.title,
+            "url": r.url,
+            "flagged": r.is_flagged,
+            "missing_files": r.missing_files,
+            "non_sorry_lines": [
+                {"path": p, "line": ln} for p, ln in r.non_sorry_lines
+            ],
+            "missing_decls": r.missing_decls,
+            "file_citations": r.file_citations,
+            "decl_citations": r.decl_citations,
+        }
+        for r in reports
+    ]
+    return json.dumps(payload, indent=2) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="audit_stale_issues",
+        description=(
+            "Flag open GitHub issues whose cited files, line numbers, or "
+            "backtick-quoted declarations look stale on current main. "
+            "Report-only: never edits or closes issues."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Example:\n"
+            "  gh issue list --repo OWNER/REPO --state open --limit 500 \\\n"
+            "    --json number,title,body,url > issues.json\n"
+            "  python scripts/audit_stale_issues.py --issues issues.json\n"
+        ),
+    )
+    parser.add_argument(
+        "--issues",
+        type=Path,
+        help=(
+            "Path to a JSON file produced by `gh issue list --json "
+            "number,title,body,url`.  Required unless --self-test is used."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Repository root (default: parent of this script's directory).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Include non-flagged issues in text reports (default: flagged only).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write report to this file instead of stdout.",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help=(
+            "Run a credentials-free smoke test against a synthetic issue "
+            "and the current repository state.  Exits 0 on success."
+        ),
+    )
+    return parser
+
+
+def _self_test(repo_root: Path) -> int:
+    """Minimal credentials-free smoke test.
+
+    Builds one synthetic issue whose body references this very script and a
+    deliberately bogus declaration, then confirms the audit emits the
+    expected flags.  Used by CI and by human reviewers to verify the tool
+    works on a fresh checkout without talking to GitHub.
+    """
+    synthetic = {
+        "number": 0,
+        "title": "[self-test] synthetic audit fixture",
+        "url": "https://example.invalid/issue/0",
+        "body": (
+            "Refers to `TNLean/Does/Not/Exist.lean:10` and to "
+            "`definitely_not_a_real_declaration`.\n"
+            "Also mentions `scripts/audit_stale_issues.py` (should be ignored)."
+        ),
+    }
+    reports = run_audit([synthetic], repo_root)
+    r = reports[0]
+    problems: list[str] = []
+    if "TNLean/Does/Not/Exist.lean:10" not in r.missing_files:
+        problems.append(
+            f"expected missing-file flag, got: {r.missing_files!r}"
+        )
+    if "definitely_not_a_real_declaration" not in r.missing_decls:
+        problems.append(
+            f"expected missing-decl flag, got: {r.missing_decls!r}"
+        )
+    if problems:
+        print("self-test FAILED:", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+    print("self-test OK: synthetic issue flagged as expected.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    if not (repo_root / "TNLean").is_dir():
+        parser.error(f"--repo-root {repo_root} has no TNLean/ subdirectory")
+
+    if args.self_test:
+        return _self_test(repo_root)
+
+    if args.issues is None:
+        parser.error("--issues is required (or pass --self-test)")
+
+    issues = load_issues(args.issues)
+    reports = run_audit(issues, repo_root)
+
+    if args.format == "json":
+        output = render_json_report(reports)
+    else:
+        output = render_text_report(reports, only_flagged=not args.all)
+
+    if args.output is not None:
+        args.output.write_text(output)
+    else:
+        sys.stdout.write(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_oversized_lean_files.py
+++ b/scripts/check_oversized_lean_files.py
@@ -1,46 +1,92 @@
 #!/usr/bin/env python3
-"""Report Lean files longer than the repository style limit."""
+"""Guard against oversized Lean files (>1000 lines).
+
+Every Lean file over 1000 lines must be split.
+This is a hard gate: any ``.lean`` file exceeding 1000 lines fails the check.
+
+Known oversized files can be listed via ``--known`` arguments; they are
+reported as warnings but do **not** cause the check to fail.  Once a known
+file is split, remove it from the ``--known`` list.
+"""
 
 from __future__ import annotations
 
 import argparse
 from pathlib import Path
 
-THRESHOLD = 1000
-EXCLUDE_DIRS = (".lake", "lake-packages", "tmp")
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+THRESHOLD: int = 1000  # lines — files exceeding this fail the check
+
+# Directories to exclude from scanning (matched against relative-to-root parts)
+EXCLUDE_DIRS: tuple[str, ...] = (".lake", "lake-packages", "tmp")
 
 
-def is_excluded(path: Path, root: Path) -> bool:
-    """Return whether path should be skipped by the line-count guard."""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_excluded(path: Path, root: Path) -> bool:
+    """Return True if *path* lives under an excluded directory or is not a .lean file."""
     if path.suffix != ".lean":
         return True
     try:
         rel_parts = path.relative_to(root).parts
     except ValueError:
         return True
-    return any(part in EXCLUDE_DIRS for part in rel_parts)
+    return any(d in rel_parts for d in EXCLUDE_DIRS)
 
 
-def count_lines(path: Path) -> int:
-    """Count lines in a file without decoding Lean source text."""
-    with path.open("rb") as handle:
-        return sum(1 for _ in handle)
+def _count_lines(path: Path) -> int:
+    """Count lines in *path* efficiently."""
+    with path.open("rb") as fh:
+        return sum(1 for _ in fh)
 
 
-def check_files(root: Path) -> int:
-    """Scan Lean files under root and return 1 when any exceed the limit."""
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def check_files(root: Path, known_oversized: set[str]) -> int:
+    """Scan all .lean files under *root*; return 1 if any exceed the threshold, else 0.
+
+    Files listed in *known_oversized* are reported as warnings (not errors)
+    and do not cause the check to fail.  Unknown oversized files cause failure.
+    """
     oversized: list[tuple[int, str]] = []
-    total = 0
+    known: list[tuple[int, str]] = []
+    total: int = 0
 
     for path in root.rglob("*.lean"):
-        if is_excluded(path, root):
+        if _is_excluded(path, root):
             continue
         total += 1
-        rel = path.relative_to(root).as_posix()
-        lines = count_lines(path)
-        if lines > THRESHOLD:
-            oversized.append((lines, rel))
 
+        try:
+            rel = path.relative_to(root).as_posix()
+        except ValueError:
+            rel = str(path)
+
+        lines = _count_lines(path)
+        if lines > THRESHOLD:
+            if rel in known_oversized:
+                known.append((lines, rel))
+            else:
+                oversized.append((lines, rel))
+
+    # Report known oversized files as warnings
+    for lines, rel in sorted(known, reverse=True):
+        print(
+            f"::warning file={rel},line={THRESHOLD + 1},"
+            f"title=Known oversized Lean file::{rel}: {lines} lines "
+            f"(limit: {THRESHOLD}) — known, tracked for future splitting"
+        )
+
+    # Report unknown oversized files as errors
     for lines, rel in sorted(oversized, reverse=True):
         print(
             f"::error file={rel},line={THRESHOLD + 1},"
@@ -48,19 +94,55 @@ def check_files(root: Path) -> int:
             f"(limit: {THRESHOLD})"
         )
 
-    print(f"Scanned {total} .lean files, {len(oversized)} exceed {THRESHOLD} lines.")
+    total_oversized = len(known) + len(oversized)
+    print(f"Scanned {total} .lean files, {total_oversized} exceed {THRESHOLD} lines"
+          f" ({len(known)} known, {len(oversized)} new).")
     if oversized:
-        print(f"::error::{len(oversized)} oversized file(s) detected.")
+        print(f"::error::{len(oversized)} new oversized file(s) detected.")
         return 1
-    print("All .lean files are within the line limit.")
+    if total_oversized == 0:
+        print("All .lean files are within the line limit.")
+    else:
+        print(f"{len(known)} known oversized file(s) — no new oversized files.")
     return 0
 
 
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--root", type=Path, default=Path("."), help="repository root")
+    parser = argparse.ArgumentParser(
+        description="Check Lean files for oversized length violations."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("."),
+        help="Repository root (default: .)",
+    )
+    parser.add_argument(
+        "--known",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Known oversized file (can be used multiple times). "
+             "Reported as a warning, not an error.",
+    )
     args = parser.parse_args()
-    return check_files(args.root.resolve())
+    root_resolved = args.root.resolve()
+    known_set: set[str] = set()
+    for k in args.known:
+        p = Path(k)
+        if not p.is_absolute():
+            p = root_resolved / p
+        try:
+            known_set.add(p.resolve().relative_to(root_resolved).as_posix())
+        except ValueError:
+            # If the path is not under root, keep it as-is
+            known_set.add(p.as_posix())
+    return check_files(root_resolved, known_set)
 
 
 if __name__ == "__main__":

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -1,19 +1,36 @@
 #!/usr/bin/env bash
 # Shared deploy logic for pushing to gh-pages branch.
-# Usage: ./scripts/deploy-to-gh-pages.sh [--with-docs] [--ci]
+# Usage: ./scripts/deploy-to-gh-pages.sh [--with-docs] [--ci] [--badges-dir DIR] [--badges-only]
 #
 # --with-docs   Also deploy API docs from docbuild/.lake/build/doc (fails if missing)
 # --ci          Use github-actions[bot] as committer instead of local git config
+# --badges-dir DIR  Use pre-generated badge JSON from DIR instead of regenerating
+# --badges-only     Only deploy badges (skip blueprint, homepage, docs, paper-gaps)
 set -euo pipefail
 
 WITH_DOCS=false
 CI_MODE=false
+BADGES_DIR=""
+BADGES_ONLY=false
+BADGES_DIR_NEXT=false
 for arg in "$@"; do
+  if [ "$BADGES_DIR_NEXT" = true ]; then
+    BADGES_DIR="$arg"
+    BADGES_DIR_NEXT=false
+    continue
+  fi
   case $arg in
     --with-docs) WITH_DOCS=true ;;
     --ci) CI_MODE=true ;;
+    --badges-only) BADGES_ONLY=true ;;
+    --badges-dir) BADGES_DIR_NEXT=true ;;
   esac
 done
+
+if [ "$BADGES_DIR_NEXT" = true ]; then
+  echo "::error::--badges-dir requires a path argument"
+  exit 1
+fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORK_DIR="$(mktemp -d)"
@@ -26,6 +43,25 @@ else
   REPO_URL="$(git -C "$REPO_ROOT" remote get-url origin)"
 fi
 git clone --branch gh-pages --single-branch --depth 1 "$REPO_URL" "$WORK_DIR/site"
+
+if [ "$BADGES_ONLY" = true ]; then
+  echo "==> Badges-only mode: skipping blueprint, homepage, docs, paper-gaps"
+
+  # Deploy pre-generated badges
+  if [ -n "$BADGES_DIR" ]; then
+    echo "==> Copying pre-generated badges from $BADGES_DIR..."
+    rm -rf "$WORK_DIR/site/badges"
+    mkdir -p "$WORK_DIR/site/badges"
+    cp -r "$BADGES_DIR"/*.json "$WORK_DIR/site/badges/" 2>/dev/null || {
+      echo "::warning::No badge JSON files found in $BADGES_DIR"
+    }
+  else
+    # Fall back to regenerating badges live
+    echo "==> Regenerating badge endpoints..."
+    mkdir -p "$WORK_DIR/site/badges"
+    python3 "$REPO_ROOT/scripts/write_badges.py" "$WORK_DIR/site/badges"
+  fi
+else
 
 # Update blueprint
 echo "==> Updating blueprint..."
@@ -92,6 +128,8 @@ else
 fi
 shopt -u nullglob
 
+fi  # end of if-not-BADGES_ONLY
+
 # Commit and push
 echo "==> Committing and pushing..."
 cd "$WORK_DIR/site"
@@ -108,6 +146,7 @@ if git diff --cached --quiet; then
 else
   MSG="Update blueprint"
   [ "$WITH_DOCS" = true ] && MSG="Full docs update"
+  [ "$BADGES_ONLY" = true ] && MSG="Update badge endpoints"
   git commit -m "$MSG ($(date -u '+%Y-%m-%d %H:%M UTC'))"
   git push origin gh-pages
   echo "==> Deployed!"

--- a/scripts/generate_badges.py
+++ b/scripts/generate_badges.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Generate Shields.io endpoint JSON for Lean repository badges.
+
+Badges
+------
+* sorries — count of sorry in tracked .lean files.
+* axioms — count of axiom declarations in tracked .lean files.
+* lean / mathlib — toolchain versions.
+* blueprint_no_leanok — unique blueprint declarations that have a
+  \lean{...} reference but **no** \leanok marker anywhere (neither
+  statement-level nor proof-level).  A declaration is counted when every
+  blueprint entry that references it lacks \leanok.  This is the count
+  of declarations whose Lean statement has not been matched to the blueprint
+  yet.
+* blueprint_not_ready — unique blueprint declarations that are **not
+  fully formalized** in Lean according to the convention in
+  docs/blueprint_style_guide.md:
+
+  * for theorem-/lemma-/proposition-/corollary-scoped declarations: both
+    statement-level **and** proof-level \leanok must be present;
+  * for definition-only declarations: statement-level \leanok must
+    be present (definitions have no proof block);
+  * remark-/example-only declarations are excluded from the denominator
+    because they are not expected to carry a proof.
+
+  This badge shows the count of declarations that still need proof work or
+  (for definitions) statement matching.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from collections import defaultdict
+from pathlib import Path
+
+
+SORRY_RE = re.compile(r"sorry")
+AXIOM_RE = re.compile(
+    r"(?m)^\s*"
+    r"(?:@\[[^\]
+]*(?:
+\s*[^\]
+]*)*\]\s*)*"
+    r"(?:(?:private|protected|noncomputable|unsafe|partial)\s+)*"
+    r"axiom\s+[A-Za-z_]"
+)
+
+
+def tracked_lean_files(repo_root: Path) -> list[Path]:
+    output = subprocess.check_output(
+        ["git", "ls-files", "*.lean"], cwd=repo_root, text=True
+    )
+    return [repo_root / line for line in output.splitlines() if line]
+
+
+def strip_comments_and_strings(source: str) -> str:
+    result: list[str] = []
+    i = 0
+    block_depth = 0
+    in_string = False
+
+    while i < len(source):
+        char = source[i]
+        nxt = source[i + 1] if i + 1 < len(source) else ""
+
+        if in_string:
+            if char == "\\" and nxt:
+                i += 2
+                continue
+            if char == '"':
+                in_string = False
+            result.append("
+" if char == "
+" else " ")
+            i += 1
+            continue
+
+        if block_depth > 0:
+            if char == "/" and nxt == "-":
+                block_depth += 1
+                i += 2
+                continue
+            if char == "-" and nxt == "/":
+                block_depth -= 1
+                i += 2
+                continue
+            result.append("
+" if char == "
+" else " ")
+            i += 1
+            continue
+
+        if char == "-" and nxt == "-":
+            while i < len(source) and source[i] != "
+":
+                result.append(" ")
+                i += 1
+            continue
+
+        if char == "/" and nxt == "-":
+            block_depth = 1
+            i += 2
+            continue
+
+        if char == '"':
+            in_string = True
+            result.append(" ")
+            i += 1
+            continue
+
+        result.append(char)
+        i += 1
+
+    return "".join(result)
+
+
+def badge(label: str, message: str, color: str) -> dict[str, str | int]:
+    return {
+        "schemaVersion": 1,
+        "label": label,
+        "message": message,
+        "color": color,
+    }
+
+
+def count_pattern(files: list[Path], pattern: re.Pattern[str]) -> int:
+    count = 0
+    for path in files:
+        source = path.read_text(encoding="utf-8")
+        count += len(pattern.findall(strip_comments_and_strings(source)))
+    return count
+
+
+def count_color(count: int, *, warn: int, danger: int) -> str:
+    if count == 0:
+        return "brightgreen"
+    if count < warn:
+        return "yellow"
+    if count < danger:
+        return "orange"
+    return "red"
+
+
+def lean_version(repo_root: Path) -> str:
+    toolchain = (repo_root / "lean-toolchain").read_text(encoding="utf-8").strip()
+    return toolchain.rsplit(":", maxsplit=1)[-1]
+
+
+def mathlib_version(repo_root: Path) -> str:
+    lakefile = tomllib.loads((repo_root / "lakefile.toml").read_text(encoding="utf-8"))
+    for requirement in lakefile.get("require", []):
+        if requirement.get("name") == "mathlib":
+            return str(requirement.get("rev", "unknown"))
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Blueprint badge helpers
+# ---------------------------------------------------------------------------
+
+# Environment types that are expected to carry a proof in the blueprint.
+_PROOF_BEARING_ENV_TYPES: frozenset[str] = frozenset(
+    {"theorem", "lemma", "proposition", "corollary"}
+)
+
+# Environment types that are ignored in the "not ready" denominator because
+# they are auxiliary annotations, not formalization targets.
+_SKIP_ENV_TYPES: frozenset[str] = frozenset({"remark", "example"})
+
+
+def _blueprint_badge_counts(
+    entries: list,
+) -> tuple[int, int]:
+    """Return (no_leanok_count, not_ready_count) for **unique declarations**.
+
+    The caller must pass a list of objects with attributes lean_decl,
+    has_leanok, proof_has_leanok, and env_type (the
+    :class: protocol).
+
+    no_leanok_count
+       Number of unique lean_decl values that have **no** \leanok
+       marker anywhere — neither has_leanok nor proof_has_leanok on
+       any entry that references the declaration.
+
+    not_ready_count
+       Number of unique lean_decl values that are **not fully
+       formalized** per the :ref::
+
+       * Proof-bearing declarations (theorem, lemma, proposition,
+         corollary) require **both** statement-level and proof-level
+         \leanok.
+       * Definition-only declarations require statement-level \leanok
+         (they cannot carry a proof).
+       * Remark-/example-only declarations are excluded from the denominator.
+
+       Declarations that mix proof-bearing and non-proof-bearing environment
+       types are treated as proof-bearing.
+    """
+    # Group entries by declaration name.
+    decl_entries: dict[str, list] = defaultdict(list)
+    for entry in entries:
+        decl_entries[entry.lean_decl].append(entry)
+
+    no_leanok = 0
+    not_ready = 0
+
+    for decl, elist in decl_entries.items():
+        has_stmt = any(e.has_leanok for e in elist)
+        has_proof = any(e.proof_has_leanok for e in elist)
+        env_types = {e.env_type for e in elist}
+
+        # --- no-leanok: no marker at all ---
+        if not has_stmt and not has_proof:
+            no_leanok += 1
+
+        # --- not-ready: not fully formalized ---
+        is_proof_bearing = bool(env_types & _PROOF_BEARING_ENV_TYPES)
+        is_skip_only = env_types <= _SKIP_ENV_TYPES
+        if is_skip_only:
+            # Remark/example-only: not a formalization target.
+            continue
+        if is_proof_bearing:
+            if not (has_stmt and has_proof):
+                not_ready += 1
+        else:
+            # Definition-only (or other non-proof-bearing): needs statement-level.
+            if not has_stmt:
+                not_ready += 1
+
+    return no_leanok, not_ready
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=Path("badges"))
+    parser.add_argument(
+        "--blueprint-src",
+        type=Path,
+        default=None,
+        help=(
+            "Path to blueprint/src directory.  When provided, also emit "
+            "blueprint_no_leanok.json and blueprint_not_ready.json badges "
+            "by parsing \lean{} and \leanok annotations in the chapter "
+            ".tex files."
+        ),
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    lean_files = tracked_lean_files(repo_root)
+
+    sorry_count = count_pattern(lean_files, SORRY_RE)
+    axiom_count = count_pattern(lean_files, AXIOM_RE)
+
+    badge_records = {
+        "sorries.json": badge(
+            "sorries", str(sorry_count), count_color(sorry_count, warn=10, danger=50)
+        ),
+        "axioms.json": badge(
+            "axioms", str(axiom_count), "brightgreen" if axiom_count == 0 else "red"
+        ),
+        "lean.json": badge("Lean", lean_version(repo_root), "blue"),
+        "mathlib.json": badge("Mathlib", mathlib_version(repo_root), "blue"),
+    }
+
+    # --- Blueprint badges ---
+    if args.blueprint_src is not None:
+        blueprint_src = args.blueprint_src
+        if not blueprint_src.is_absolute():
+            blueprint_src = repo_root / blueprint_src
+
+        # Import the blueprint parser (lazy, so the script still works without
+        # the blueprint source tree checked out).
+        sys.path.insert(0, str(repo_root / "scripts"))
+        from blueprint_lean_sync import collect_blueprint_entries  # noqa: E402
+
+        entries = collect_blueprint_entries(blueprint_src)
+        no_leanok_count, not_ready_count = _blueprint_badge_counts(entries)
+
+        badge_records["blueprint_no_leanok.json"] = badge(
+            r"blueprint: no \leanok",
+            str(no_leanok_count),
+            count_color(no_leanok_count, warn=100, danger=300),
+        )
+        badge_records["blueprint_not_ready.json"] = badge(
+            "blueprint: not ready",
+            str(not_ready_count),
+            count_color(not_ready_count, warn=100, danger=300),
+        )
+
+    # --- Write badges ---
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    for filename, payload in badge_records.items():
+        path = args.output_dir / filename
+        path.write_text(json.dumps(payload, indent=2) + "
+", encoding="utf-8")
+        print(f"Wrote {path}: {payload['message']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_badges.py
+++ b/scripts/generate_badges.py
@@ -39,13 +39,10 @@ from collections import defaultdict
 from pathlib import Path
 
 
-SORRY_RE = re.compile(r"sorry")
+SORRY_RE = re.compile(r"\bsorry\b")
 AXIOM_RE = re.compile(
     r"(?m)^\s*"
-    r"(?:@\[[^\]
-]*(?:
-\s*[^\]
-]*)*\]\s*)*"
+    r"(?:@\[[^\]\n]*(?:\n\s*[^\]\n]*)*\]\s*)*"
     r"(?:(?:private|protected|noncomputable|unsafe|partial)\s+)*"
     r"axiom\s+[A-Za-z_]"
 )
@@ -74,9 +71,7 @@ def strip_comments_and_strings(source: str) -> str:
                 continue
             if char == '"':
                 in_string = False
-            result.append("
-" if char == "
-" else " ")
+            result.append("\n" if char == "\n" else " ")
             i += 1
             continue
 
@@ -89,15 +84,12 @@ def strip_comments_and_strings(source: str) -> str:
                 block_depth -= 1
                 i += 2
                 continue
-            result.append("
-" if char == "
-" else " ")
+            result.append("\n" if char == "\n" else " ")
             i += 1
             continue
 
         if char == "-" and nxt == "-":
-            while i < len(source) and source[i] != "
-":
+            while i < len(source) and source[i] != "\n":
                 result.append(" ")
                 i += 1
             continue
@@ -302,8 +294,7 @@ def main() -> None:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     for filename, payload in badge_records.items():
         path = args.output_dir / filename
-        path.write_text(json.dumps(payload, indent=2) + "
-", encoding="utf-8")
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         print(f"Wrote {path}: {payload['message']}")
 
 


### PR DESCRIPTION
## Summary

Syncs CI infrastructure improvements from the MIPStarRE sister repo to TNLean, and hardens several checks that were previously advisory.

## Changes

### 1. `lint-blueprint.yml` — harden missing-blueprint check
Renames the step from "Warn on changed Lean declarations missing blueprint entries" to "Error on changed Lean declarations missing blueprint entries" and removes `continue-on-error: true`. Changed Lean declarations that lack blueprint entries now fail the check rather than warning.

### 2. `scripts/check_oversized_lean_files.py` — add `--known` support
Replaces the simple scanner with the MIPStarRE version that supports `--known PATH` flags. Known oversized files are reported as GitHub warnings (not errors) and do not block the check. New oversized files (not in the known list) cause failure. This is a hard gate going forward.

### 3. `.github/workflows/oversized-lean-files.yml` — hard gate with grandfathered files
Removes the advisory `continue-on-error: true` and adds `--known` flags for the two currently-oversized files on `main`:
- `TNLean/MPS/ParentHamiltonian/Martingale.lean` (1562 lines)
- `TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean` (1425 lines)

Once these files are split, remove the corresponding `--known` arguments. New oversized files now fail the check immediately.

### 4. `.github/workflows/claude-code-review.yml` — preserve in-progress reviews
Changes `cancel-in-progress: true` to `cancel-in-progress: false` in the concurrency block. New commits to a PR no longer cancel ongoing Claude code reviews.

### 5. `.github/actions/claude-code-with-provider/action.yml` — sync from MIPStarRE
- Adds two header comment lines: `ci-sync-version: claude-provider-deepseek-v1` and `ci-sync-source: shared Lean automation, prompts externalized under .github/prompts`
- Updates `bot-id` description to `'GitHub user ID to use for git operations.'`
- Updates `bot-name` description to `'GitHub username to use for git operations.'`
- Aligns `branch-name-template` / `bot-id` / `bot-name` ordering in inputs, env, variable assignments, `write_output` calls, and the final `Run Claude Code` step to match MIPStarRE exactly

### 6a. Add stale issue audit
- `.github/workflows/stale-issue-audit.yml` — copied as-is from MIPStarRE (repo-agnostic scheduled workflow)
- `scripts/audit_stale_issues.py` — adapted from MIPStarRE: all path patterns and subdir checks changed from `MIPStarRE/` to `TNLean/` (file regex, GitHub blob URL regex, declaration index scan, self-test fixture, CLI validation)

### 6b. Add badge generation
- `.github/workflows/badges.yml` — copied as-is from MIPStarRE (repo-agnostic)
- `scripts/generate_badges.py` — copied as-is from MIPStarRE (no repo-specific hardcoding); generates sorry/axiom/Lean/Mathlib Shields.io endpoint JSON. Complements the existing `scripts/write_badges.py`, which is kept as-is.

### 6c. README freshness audit — skipped
`scripts/audit_readme_freshness.py` from MIPStarRE was **not** copied because it contains substantial MIPStarRE-specific hard-coded logic that cannot be trivially generalised:
- `_FILE_RE`, `_GITHUB_BLOB_RE`, `_RAW_PROJECT_PATH_RE`, and `_PATH_PREFIXES` all reference `MIPStarRE/`-specific directory names and root paths
- `audit_ldt_submodule_count` is specific to MIPStarRE's `MIPStarRE/LDT/` submodule layout with no TNLean equivalent
- `_TOP_LEVEL_PATHS` includes `MIPStarRE.lean`
- The workflow summary step mentions MIPStarRE/LDT/ by name

Generalising this script for TNLean would require a targeted rewrite (different project layout, no LDT submodule concept). This is deferred to a follow-up if desired.

## Test plan
- [ ] Verify `oversized-lean-files` check passes on this PR (known files warned, no new errors)
- [ ] Verify `lint-blueprint` check passes
- [ ] Confirm no existing workflows are broken by action.yml ordering change
- [ ] Confirm `stale-issue-audit` can be manually dispatched (`workflow_dispatch`)
- [ ] Confirm `badges` workflow can be manually dispatched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI gating behavior (blueprint sync and oversized-file guard) and modifies the `gh-pages` deploy script, which can break merges or deployments if misconfigured.
> 
> **Overview**
> **CI is tightened and expanded** by turning previously advisory checks into hard gates and adding new scheduled maintenance workflows.
> 
> Blueprint sync enforcement is hardened: `lint-blueprint.yml` now fails PRs when changed Lean declarations lack corresponding blueprint entries (and requires a successful base-ref fetch for the diff). The oversized Lean file guard is upgraded to a strict >1000-line gate, with a `--known` allowlist for two grandfathered files.
> 
> New automation is added: a weekly `badges.yml` workflow generates Shields.io endpoint JSON via `scripts/generate_badges.py` and deploys them to `gh-pages`, and a weekly `stale-issue-audit.yml` workflow runs `scripts/audit_stale_issues.py` to report (not modify) open issues with stale `TNLean/` file/line/decl citations.
> 
> Deployment tooling is updated: `deploy-to-gh-pages.sh` gains `--badges-only`/`--badges-dir` modes to publish only badge JSON, and the Claude provider composite action/workflow is synced (input ordering/metadata) plus review concurrency is changed to not cancel in-progress runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f5c04755f373f578332d2206046c8b13a3deba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->