### PR TITLE
Pair identity eventually from pair span-top

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -926,6 +926,76 @@ theorem pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop {D₁ D₂ : 
   rw [hSpan]
   exact Submodule.mem_top
 
+private theorem pairWordTupleSpanTop_succ_of_pos {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hS : 0 < S) (hSpan : PairWordTupleSpanTop A B S) :
+    PairWordTupleSpanTop A B (S + 1) := by
+  classical
+  rcases S with _ | S
+  · cases hS
+  unfold PairWordTupleSpanTop
+  apply eq_top_iff.mpr
+  intro M _
+  have hM : M ∈ Submodule.span ℂ (Set.range (pairWordTuple A B (S + 1))) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hle : Submodule.span ℂ (Set.range (pairWordTuple A B (S + 1))) ≤
+      Submodule.span ℂ (Set.range (pairWordTuple A B ((S + 1) + 1))) := by
+    apply Submodule.span_le.mpr
+    rintro N ⟨w, rfl⟩
+    let i : Fin d := w 0
+    let tail : Fin S → Fin d := fun j => w j.succ
+    have hletter : pairEvalWordTuple A B [i] ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B 1)) :=
+      pairEvalWordTuple_mem_span_pairWordTuple_length A B [i]
+    have htail : pairEvalWordTuple A B (List.ofFn tail) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B (S + 1))) := by
+      rw [hSpan]
+      exact Submodule.mem_top
+    have hmul :=
+      pair_mul_mem_span_pairWordTuple_add (A := A) (B := B)
+        (L := 1) (S := S + 1)
+        (M := pairEvalWordTuple A B [i])
+        (N := pairEvalWordTuple A B (List.ofFn tail)) hletter htail
+    rw [Nat.add_comm 1 (S + 1)] at hmul
+    have hprod :
+        ((pairEvalWordTuple A B [i]).1 * (pairEvalWordTuple A B (List.ofFn tail)).1,
+          (pairEvalWordTuple A B [i]).2 * (pairEvalWordTuple A B (List.ofFn tail)).2) =
+          pairWordTuple A B (S + 1) w := by
+      ext <;> simp [pairWordTuple, pairEvalWordTuple, i, tail]
+    simpa [hprod] using hmul
+  exact hle hM
+
+private theorem pairWordTupleSpanTop_of_le_of_pairWordTupleSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S T : ℕ}
+    (hS : 0 < S) (hSpan : PairWordTupleSpanTop A B S) (hST : S ≤ T) :
+    PairWordTupleSpanTop A B T := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hST
+  have hTopAdd : ∀ k : ℕ, PairWordTupleSpanTop A B (S + k) := by
+    intro k
+    induction k with
+    | zero => simpa using hSpan
+    | succ k ih =>
+        simpa [Nat.add_assoc] using
+          pairWordTupleSpanTop_succ_of_pos (A := A) (B := B)
+            (S := S + k) (Nat.lt_of_lt_of_le hS (Nat.le_add_right S k)) ih
+  exact hTopAdd k
+
+/-- If the homogeneous pair span is full at one positive length, then the
+simultaneous pair identity lies in every sufficiently long homogeneous pair-word
+span. -/
+theorem pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
+    (hS : 0 < S) (hSpan : PairWordTupleSpanTop A B S) :
+    ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
+      ((1 : Matrix (Fin D₁) (Fin D₁) ℂ), (1 : Matrix (Fin D₂) (Fin D₂) ℂ)) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B n)) := by
+  refine ⟨S, ?_⟩
+  intro n hn
+  exact pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop A B
+    (pairWordTupleSpanTop_of_le_of_pairWordTupleSpanTop (A := A) (B := B)
+      hS hSpan hn)
+
 /-- A finite residue window plus one period supplies identity padding at every
 sufficiently large length. -/
 theorem pairIdentity_mem_pairWordTupleSpan_eventually_of_period_window {D₁ D₂ : ℕ}

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -926,61 +926,6 @@ theorem pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop {D₁ D₂ : 
   rw [hSpan]
   exact Submodule.mem_top
 
-private theorem pairWordTupleSpanTop_succ_of_pos {D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
-    (hS : 0 < S) (hSpan : PairWordTupleSpanTop A B S) :
-    PairWordTupleSpanTop A B (S + 1) := by
-  classical
-  rcases S with _ | S
-  · cases hS
-  unfold PairWordTupleSpanTop
-  apply eq_top_iff.mpr
-  intro M _
-  have hM : M ∈ Submodule.span ℂ (Set.range (pairWordTuple A B (S + 1))) := by
-    rw [hSpan]
-    exact Submodule.mem_top
-  have hle : Submodule.span ℂ (Set.range (pairWordTuple A B (S + 1))) ≤
-      Submodule.span ℂ (Set.range (pairWordTuple A B ((S + 1) + 1))) := by
-    apply Submodule.span_le.mpr
-    rintro N ⟨w, rfl⟩
-    let i : Fin d := w 0
-    let tail : Fin S → Fin d := fun j => w j.succ
-    have hletter : pairEvalWordTuple A B [i] ∈
-        Submodule.span ℂ (Set.range (pairWordTuple A B 1)) :=
-      pairEvalWordTuple_mem_span_pairWordTuple_length A B [i]
-    have htail : pairEvalWordTuple A B (List.ofFn tail) ∈
-        Submodule.span ℂ (Set.range (pairWordTuple A B (S + 1))) := by
-      rw [hSpan]
-      exact Submodule.mem_top
-    have hmul :=
-      pair_mul_mem_span_pairWordTuple_add (A := A) (B := B)
-        (L := 1) (S := S + 1)
-        (M := pairEvalWordTuple A B [i])
-        (N := pairEvalWordTuple A B (List.ofFn tail)) hletter htail
-    rw [Nat.add_comm 1 (S + 1)] at hmul
-    have hprod :
-        ((pairEvalWordTuple A B [i]).1 * (pairEvalWordTuple A B (List.ofFn tail)).1,
-          (pairEvalWordTuple A B [i]).2 * (pairEvalWordTuple A B (List.ofFn tail)).2) =
-          pairWordTuple A B (S + 1) w := by
-      ext <;> simp [pairWordTuple, pairEvalWordTuple, i, tail]
-    simpa [hprod] using hmul
-  exact hle hM
-
-private theorem pairWordTupleSpanTop_of_le_of_pairWordTupleSpanTop {D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S T : ℕ}
-    (hS : 0 < S) (hSpan : PairWordTupleSpanTop A B S) (hST : S ≤ T) :
-    PairWordTupleSpanTop A B T := by
-  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hST
-  have hTopAdd : ∀ k : ℕ, PairWordTupleSpanTop A B (S + k) := by
-    intro k
-    induction k with
-    | zero => simpa using hSpan
-    | succ k ih =>
-        simpa [Nat.add_assoc] using
-          pairWordTupleSpanTop_succ_of_pos (A := A) (B := B)
-            (S := S + k) (Nat.lt_of_lt_of_le hS (Nat.le_add_right S k)) ih
-  exact hTopAdd k
-
 /-- If the homogeneous pair span is full at one positive length, then the
 simultaneous pair identity lies in every sufficiently long homogeneous pair-word
 span. -/
@@ -990,11 +935,58 @@ theorem pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop {D
     ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
       ((1 : Matrix (Fin D₁) (Fin D₁) ℂ), (1 : Matrix (Fin D₂) (Fin D₂) ℂ)) ∈
         Submodule.span ℂ (Set.range (pairWordTuple A B n)) := by
+  classical
+  have hsucc : ∀ {T : ℕ}, 0 < T → PairWordTupleSpanTop A B T →
+      PairWordTupleSpanTop A B (T + 1) := by
+    intro T hT hTop
+    rcases T with _ | T
+    · cases hT
+    unfold PairWordTupleSpanTop
+    apply eq_top_iff.mpr
+    intro M _
+    have hM : M ∈ Submodule.span ℂ (Set.range (pairWordTuple A B (T + 1))) := by
+      rw [hTop]
+      exact Submodule.mem_top
+    have hle : Submodule.span ℂ (Set.range (pairWordTuple A B (T + 1))) ≤
+        Submodule.span ℂ (Set.range (pairWordTuple A B ((T + 1) + 1))) := by
+      apply Submodule.span_le.mpr
+      rintro N ⟨w, rfl⟩
+      let i : Fin d := w 0
+      let tail : Fin T → Fin d := fun j => w j.succ
+      have hletter : pairEvalWordTuple A B [i] ∈
+          Submodule.span ℂ (Set.range (pairWordTuple A B 1)) :=
+        pairEvalWordTuple_mem_span_pairWordTuple_length A B [i]
+      have htail : pairEvalWordTuple A B (List.ofFn tail) ∈
+          Submodule.span ℂ (Set.range (pairWordTuple A B (T + 1))) := by
+        rw [hTop]
+        exact Submodule.mem_top
+      have hmul :=
+        pair_mul_mem_span_pairWordTuple_add (A := A) (B := B)
+          (L := 1) (S := T + 1)
+          (M := pairEvalWordTuple A B [i])
+          (N := pairEvalWordTuple A B (List.ofFn tail)) hletter htail
+      rw [Nat.add_comm 1 (T + 1)] at hmul
+      have hprod :
+          ((pairEvalWordTuple A B [i]).1 * (pairEvalWordTuple A B (List.ofFn tail)).1,
+            (pairEvalWordTuple A B [i]).2 * (pairEvalWordTuple A B (List.ofFn tail)).2) =
+            pairWordTuple A B (T + 1) w := by
+        ext <;> simp [pairWordTuple, pairEvalWordTuple, i, tail]
+      simpa [hprod] using hmul
+    exact hle hM
+  have hTopOfLe : ∀ {T : ℕ}, S ≤ T → PairWordTupleSpanTop A B T := by
+    intro T hST
+    obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hST
+    have hTopAdd : ∀ k : ℕ, PairWordTupleSpanTop A B (S + k) := by
+      intro k
+      induction k with
+      | zero => simpa using hSpan
+      | succ k ih =>
+          simpa [Nat.add_assoc] using
+            hsucc (Nat.lt_of_lt_of_le hS (Nat.le_add_right S k)) ih
+    exact hTopAdd k
   refine ⟨S, ?_⟩
   intro n hn
-  exact pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop A B
-    (pairWordTupleSpanTop_of_le_of_pairWordTupleSpanTop (A := A) (B := B)
-      hS hSpan hn)
+  exact pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop A B (hTopOfLe hn)
 
 /-- A finite residue window plus one period supplies identity padding at every
 sufficiently large length. -/

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -22,6 +22,53 @@ irreducible-form framework of \cite{DeLasCuevas2017Irreducible},
 which gives a fundamental theorem valid for periodic tensors directly,
 with an extra $Z$-gauge degree of freedom.
 
+
+\section{Homogeneous Pair-Span Padding}\label{sec:ft_pair_span_padding}
+
+The pair-span padding lemmas below are shared algebraic infrastructure for the
+aperiodic Fundamental Theorem route.  They are used to pass from the
+Wielandt/block-injective homogeneous span information of
+\cite{Cirac2017MPDO_AnnPhys} to the fixed-length separation statements used by
+BNT comparison.  Parent-Hamiltonian arguments later reuse the same predicates,
+but the source role of the identity-pair lemma is the Fundamental Theorem
+pair-span step.
+
+\begin{lemma}[Identity pair from full homogeneous pair-word span]\label{lem:pair_identity_span_top}
+  \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop}
+  \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop}
+  \leanok
+  \uses{def:pair_trace_separation_words}
+  Let \(A\) and \(B\) be MPS tensors of bond dimensions \(D_1\) and \(D_2\).
+  \begin{enumerate}
+    \item If the homogeneous pair-word span is the full product algebra at some
+      length \(n\), i.e.\
+      \[
+        \operatorname{span}\{(A^w,B^w)\mid |w|=n\} = \MN{D_1}\times\MN{D_2},
+      \]
+      then the simultaneous identity pair \((I_{D_1},I_{D_2})\) belongs to that
+      same homogeneous span.
+    \item If the span is full at one positive length \(S>0\), then the identity
+      pair lies in the homogeneous pair-word span at every sufficiently large
+      length:
+      \[
+        \exists L\in\mathbb N,\;
+        \forall n\ge L,\;
+        (I_{D_1},I_{D_2})\in
+        \operatorname{span}\{(A^w,B^w)\mid |w|=n\}.
+      \]
+  \end{enumerate}
+\end{lemma}
+
+\begin{proof}
+  \leanok
+  Statement~(1) is immediate: if the span is already the whole product algebra,
+  then it contains the identity pair.
+  For~(2), fullness at a positive length propagates by multiplying a word of
+  length \(T\) by a one-letter word, so induction gives fullness at every
+  length \(S+k\).  Applying~(1) at each such length gives the conclusion with
+  \(L=S\).
+\end{proof}
+
 \section{Conditional Block Matching}%
 \label{sec:ft_conditional_block_matching}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3308,48 +3308,6 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     equivalence with scalar $1$.
 \end{proof}
 
-\begin{lemma}[Identity pair from full homogeneous pair-word span]\label{lem:pair_identity_span_top}
-  \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop}
-  \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop}
-  \leanok
-  \uses{def:pair_trace_separation_words}
-  Let \(A\) and \(B\) be MPS tensors of bond dimensions \(D_1\) and \(D_2\).
-  \begin{enumerate}
-    \item If the homogeneous pair-word span is the full product algebra at some
-      length \(n\), i.e.\
-      \[
-        \operatorname{span}\{(A^w,B^w)\mid |w|=n\} = \MN{D_1}\times\MN{D_2},
-      \]
-      then the simultaneous identity pair \((I_{D_1},I_{D_2})\) belongs to that
-      same homogeneous span.
-    \item If the span is full at one positive length \(S>0\), then the identity
-      pair lies in the homogeneous pair-word span at every sufficiently large
-      length:
-      \[
-        \exists L\in\mathbb N,\;
-        \forall n\ge L,\;
-        (I_{D_1},I_{D_2})\in
-        \operatorname{span}\{(A^w,B^w)\mid |w|=n\}.
-      \]
-  \end{enumerate}
-\end{lemma}
-
-\begin{proof}
-  \leanok
-  \uses{lem:pair_trace_separation_homogenization_with_padding}
-  Statement~(1) is immediate: if the span is already the whole product algebra,
-  then it contains the identity pair.
-  For~(2), the proof first shows that fullness at a positive length \(T\)
-  propagates to \(T+1\): split a word of length \(T+1\) into its first letter
-  and a suffix of length \(T\), write each as a linear combination in the
-  respective homogeneous spans (using the one-letter span membership and the
-  induction hypothesis), and multiply the two components via
-  Lemma~\ref{lem:pair_trace_separation_homogenization_with_padding}.
-  By induction on the offset \(k\), the span is full at every length \(S+k\),
-  hence at every \(n\ge S\).  Applying~(1) at each such length gives the
-  conclusion with \(L=S\).
-\end{proof}
-
 \begin{lemma}[Conditional padding from exact homogeneous identity witnesses]
     \label{lem:pair_trace_separation_homogenization_with_padding}
     \lean{MPSTensor.pairEvalWordTuple_mem_span_pairWordTuple_length}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3308,6 +3308,41 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     equivalence with scalar $1$.
 \end{proof}
 
+\begin{lemma}[Span-top propagates to eventual identity]\label{lem:pair_identity_span_top_eventual}
+  \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop}
+  \leanok
+  \uses{def:pair_trace_separation_words}
+  Let \(A\) and \(B\) be MPS tensors of bond dimensions \(D_1\) and \(D_2\).
+  If the homogeneous pair-word span is the full product algebra at one positive
+  length \(S>0\), i.e.\
+  \[
+    \operatorname{span}\{(A^w,B^w)\mid |w|=S\} = \MN{D_1}\times\MN{D_2},
+  \]
+  then the simultaneous identity pair \((I_{D_1},I_{D_2})\) lies in the
+  homogeneous pair-word span at every sufficiently large length:
+  \[
+    \exists L\in\mathbb N,\;
+    \forall n\ge L,\;
+    (I_{D_1},I_{D_2})\in
+    \operatorname{span}\{(A^w,B^w)\mid |w|=n\}.
+  \]
+\end{lemma}
+
+\begin{proof}
+  \leanok
+  \uses{lem:pair_trace_separation_homogenization_with_padding}
+  The proof first shows that fullness of the homogeneous pair-word span at a
+  positive length \(T\) propagates to \(T+1\): split a word of length \(T+1\)
+  into its first letter and a suffix of length \(T\), write each as a linear
+  combination in the respective homogeneous spans (using the one-letter span
+  membership and the induction hypothesis), and multiply the two components
+  via Lemma~\ref{lem:pair_trace_separation_homogenization_with_padding}.
+  By induction on the offset \(k\), the span is full at every length \(S+k\),
+  hence at every \(n\ge S\).  At each such length the identity pair belongs
+  to the span because the span is already the whole product algebra; thus
+  \(L=S\) is a witness.
+\end{proof}
+
 \begin{lemma}[Conditional padding from exact homogeneous identity witnesses]
     \label{lem:pair_trace_separation_homogenization_with_padding}
     \lean{MPSTensor.pairEvalWordTuple_mem_span_pairWordTuple_length}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3308,39 +3308,46 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     equivalence with scalar $1$.
 \end{proof}
 
-\begin{lemma}[Span-top propagates to eventual identity]\label{lem:pair_identity_span_top_eventual}
+\begin{lemma}[Identity pair from full homogeneous pair-word span]\label{lem:pair_identity_span_top}
+  \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop}
   \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop}
   \leanok
   \uses{def:pair_trace_separation_words}
   Let \(A\) and \(B\) be MPS tensors of bond dimensions \(D_1\) and \(D_2\).
-  If the homogeneous pair-word span is the full product algebra at one positive
-  length \(S>0\), i.e.\
-  \[
-    \operatorname{span}\{(A^w,B^w)\mid |w|=S\} = \MN{D_1}\times\MN{D_2},
-  \]
-  then the simultaneous identity pair \((I_{D_1},I_{D_2})\) lies in the
-  homogeneous pair-word span at every sufficiently large length:
-  \[
-    \exists L\in\mathbb N,\;
-    \forall n\ge L,\;
-    (I_{D_1},I_{D_2})\in
-    \operatorname{span}\{(A^w,B^w)\mid |w|=n\}.
-  \]
+  \begin{enumerate}
+    \item If the homogeneous pair-word span is the full product algebra at some
+      length \(n\), i.e.\
+      \[
+        \operatorname{span}\{(A^w,B^w)\mid |w|=n\} = \MN{D_1}\times\MN{D_2},
+      \]
+      then the simultaneous identity pair \((I_{D_1},I_{D_2})\) belongs to that
+      same homogeneous span.
+    \item If the span is full at one positive length \(S>0\), then the identity
+      pair lies in the homogeneous pair-word span at every sufficiently large
+      length:
+      \[
+        \exists L\in\mathbb N,\;
+        \forall n\ge L,\;
+        (I_{D_1},I_{D_2})\in
+        \operatorname{span}\{(A^w,B^w)\mid |w|=n\}.
+      \]
+  \end{enumerate}
 \end{lemma}
 
 \begin{proof}
   \leanok
   \uses{lem:pair_trace_separation_homogenization_with_padding}
-  The proof first shows that fullness of the homogeneous pair-word span at a
-  positive length \(T\) propagates to \(T+1\): split a word of length \(T+1\)
-  into its first letter and a suffix of length \(T\), write each as a linear
-  combination in the respective homogeneous spans (using the one-letter span
-  membership and the induction hypothesis), and multiply the two components
-  via Lemma~\ref{lem:pair_trace_separation_homogenization_with_padding}.
+  Statement~(1) is immediate: if the span is already the whole product algebra,
+  then it contains the identity pair.
+  For~(2), the proof first shows that fullness at a positive length \(T\)
+  propagates to \(T+1\): split a word of length \(T+1\) into its first letter
+  and a suffix of length \(T\), write each as a linear combination in the
+  respective homogeneous spans (using the one-letter span membership and the
+  induction hypothesis), and multiply the two components via
+  Lemma~\ref{lem:pair_trace_separation_homogenization_with_padding}.
   By induction on the offset \(k\), the span is full at every length \(S+k\),
-  hence at every \(n\ge S\).  At each such length the identity pair belongs
-  to the span because the span is already the whole product algebra; thus
-  \(L=S\) is a witness.
+  hence at every \(n\ge S\).  Applying~(1) at each such length gives the
+  conclusion with \(L=S\).
 \end{proof}
 
 \begin{lemma}[Conditional padding from exact homogeneous identity witnesses]


### PR DESCRIPTION
## Summary
- add `pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop` in `PairHomogenization.lean`
- prove that a positive homogeneous `PairWordTupleSpanTop A B S` propagates to later lengths locally, then use it to place `(1,1)` in all sufficiently long pair-word spans

Refs #1499

## Validation
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean lemma and accompanying blueprint documentation without changing existing definitions or algorithms; the main risk is proof brittleness in downstream developments relying on these lemmas.
> 
> **Overview**
> Adds a new Lean lemma `pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop` showing that if `PairWordTupleSpanTop A B S` holds for some *positive* length `S`, then the identity pair `(1,1)` lies in every homogeneous pair-word span for all `n ≥ S` (via an induction step propagating span-top to `S+k`).
> 
> Updates the blueprint (Chapter 11) to introduce a short “Homogeneous Pair-Span Padding” section and lemma statement/proof referencing the new result alongside the existing one-step identity-from-span-top lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699098d4fa9da330a736feefc73f4533c5af8581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->