### PR TITLE
docs(blueprint): reorganize FT prose and audits

### DIFF
--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -44,10 +44,10 @@ domain, Perron--Frobenius, and overlap-decay tools used to control normal
 blocks.  Chapters~\ref{ch:wielandt} and~\ref{ch:canonical} supply the blocking,
 primitivity, irreducibility, and canonical-form reductions.  Chapters~\ref{ch:block_perm}
 and~\ref{ch:bnt} isolate block permutation, block separation, bases of normal
-tensors, and the power-sum comparison.  Chapter~\ref{ch:ft_proof} records the
-current non-periodic theorem surface; the remaining BNT matching and fixed-
-length span inputs are kept as explicit hypotheses until the corresponding
-source steps are formalized.
+tensors, and the power-sum comparison.  Chapter~\ref{ch:ft_proof} records
+the current conditional non-periodic theorem statements; the remaining BNT
+matching and fixed-length span inputs are kept as explicit hypotheses until the
+corresponding source steps are formalized.
 
 The chapters after Chapter~\ref{ch:ft_proof} collect applications,
 alternative formulations, and later tensor-network material.  Chapter~\ref{ch:periodic_ft_apps}

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1,6 +1,6 @@
 \chapter{Introduction}\label{ch:intro}
 
-This blueprint formalizes the Fundamental Theorem for translation-invariant
+The central result is the Fundamental Theorem for translation-invariant
 matrix product vectors.  The basic object is a family of matrices
 $A=(A^i)_{i=0}^{d-1}$, which assigns to each chain length $N$ the vector
 $\ket{V^{(N)}(A)}$ with coefficients

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1,29 +1,61 @@
 \chapter{Introduction}\label{ch:intro}
 
-We study the fundamental theorem for periodic, translation-invariant matrix product vectors. The basic object is a family of matrices $\{A^i\}$, viewed as a tensor that generates vectors $\ket{V^{(N)}(A)}$ on chains of length $N$.
+This blueprint formalizes the Fundamental Theorem for translation-invariant
+matrix product vectors.  The basic object is a family of matrices
+$A=(A^i)_{i=0}^{d-1}$, which assigns to each chain length $N$ the vector
+$\ket{V^{(N)}(A)}$ with coefficients
+\[
+    \langle i_1,\ldots,i_N\mid V^{(N)}(A)\rangle
+    = \tr(A^{i_1}\cdots A^{i_N}).
+\]
+The main non-periodic route follows the canonical-form and basis-of-normal-
+tensors argument of \cite{Cirac2016MPDO_arXiv,Cirac2021Matrix}, with the
+single-block injective case anchored in the earlier representation theorem
+of \cite{PerezGarcia2007Matrix}.
 
-The standard MPS form of the theorem is the following.  Put two tensors in
-canonical form,
+In canonical form one writes
 \[
     A^i = \bigoplus_{j=1}^{g} \mu_j A_j^i,
     \qquad
     B^i = \bigoplus_{k=1}^{h} \nu_k B_k^i,
 \]
-with normal blocks forming bases of normal tensors
-\cite{PerezGarcia2007Matrix,Cirac2021Matrix}.  If
-$\ket{V^{(N)}(A)}=\ket{V^{(N)}(B)}$ for every chain length~$N$, then
-$g=h$ and, after permuting the blocks of~$B$, for each block $j$ there are
-an invertible matrix $X_j$ and a nonzero scalar $\zeta_j$ such that
+where the displayed blocks are normal tensors.  If
+$\ket{V^{(N)}(A)}=\ket{V^{(N)}(B)}$ for every positive chain length $N$, then
+the bases of normal tensors have the same size.  After relabelling the blocks
+of $B$, each matched pair satisfies
 \[
-    B_j^i = \zeta_j X_j A_j^i X_j^{-1},
-    \qquad
-    \mu_j = \nu_j \zeta_j .
+    B_j^i = \zeta_j X_j A_j^i X_j^{-1}
 \]
-Equivalently, after the block permutation and phase absorption, the two
-weighted block-diagonal tensors are gauge equivalent.  In the single
-injective-block case this reduces to the familiar conclusion
-$B^i=X A^i X^{-1}$ for all physical indices~$i$.
+for some invertible matrix $X_j$ and nonzero scalar $\zeta_j$, and the equal
+case compares the coefficient power sums attached to this matched basis.  The
+block gauges and the weight comparison then assemble into a single gauge
+conjugacy of the two weighted block-diagonal tensors.  For a single injective
+block this reduces to the familiar conclusion
+$B^i=X A^i X^{-1}$ for all physical indices $i$.
 
-Chapters~\ref{ch:mps} and~\ref{ch:single} describe the algebraic core. Chapter~\ref{ch:mps} introduces word evaluation, MPV coefficients, gauge equivalence, injectivity, blocking, overlap, and the block-injective canonical-form data. Chapter~\ref{ch:single} proves the single-block fundamental theorem by a purely algebraic argument through trace pairings, linear extension, simplicity of matrix algebras, and Skolem--Noether.
+Chapters~\ref{ch:mps}--\ref{ch:ft_proof} contain the aperiodic proof route.
+Chapter~\ref{ch:mps} fixes the matrix product vector notation, word
+evaluations, transfer maps, gauge equivalence, injectivity, blocking, and
+periodic-chain tensor families.  Chapter~\ref{ch:single} proves the
+single-block theorem by trace pairings, linear extension, simplicity of matrix
+algebras, and Skolem--Noether.  Chapters~\ref{ch:channels}, \ref{ch:schwarz},
+\ref{ch:qpf}, and~\ref{ch:spectral} develop the positive-map, multiplicative-
+domain, Perron--Frobenius, and overlap-decay tools used to control normal
+blocks.  Chapters~\ref{ch:wielandt} and~\ref{ch:canonical} supply the blocking,
+primitivity, irreducibility, and canonical-form reductions.  Chapters~\ref{ch:block_perm}
+and~\ref{ch:bnt} isolate block permutation, block separation, bases of normal
+tensors, and the power-sum comparison.  Chapter~\ref{ch:ft_proof} records the
+current non-periodic theorem surface; the remaining BNT matching and fixed-
+length span inputs are kept as explicit hypotheses until the corresponding
+source steps are formalized.
 
-The later chapters develop the spectral and canonical-form machinery needed for the full multi-block theorem. Chapter~\ref{ch:channels} studies positive maps and quantum channels. Chapters~\ref{ch:qpf} and~\ref{ch:spectral} supply Perron--Frobenius theory and overlap decay. Chapters~\ref{ch:wielandt} and~\ref{ch:canonical} connect blocking, primitivity, irreducibility, and the normal/canonical-form reductions. Chapters~\ref{ch:block_perm} and~\ref{ch:bnt} carry out block permutation and BNT theory; Chapter~\ref{ch:ft_proof} proves the blocking-based Fundamental Theorem, while Chapter~\ref{ch:periodic_ft_apps} develops the direct periodic extension.
+The chapters after Chapter~\ref{ch:ft_proof} collect applications,
+alternative formulations, and later tensor-network material.  Chapter~\ref{ch:periodic_ft_apps}
+develops the direct periodic theorem in irreducible form.  Chapter~\ref{ch:symmetry}
+uses the Fundamental Theorem to obtain virtual symmetry gauges, projective bond
+representations, and string-order criteria.  Chapter~\ref{ch:algebraic_ft}
+gives the fixed-length algebraic Fundamental Theorem of \cite{Molnar2018NormalPEPS},
+and Chapter~\ref{ch:peps_ft} records the PEPS analogues.  The later chapters
+cover dynamical semigroups, entropy, matrix product density operators, parent
+Hamiltonians, correlations, and examples; these are downstream of the
+aperiodic proof rather than part of its dependency chain.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -116,13 +116,13 @@ boundary conditions (PBC).
     framework appears in Chapter~\ref{ch:channels}.
 \end{remark}
 
-\section{Periodic-chain aliases}
+\section{Site-dependent periodic chains}
 
-\begin{definition}[Periodic-chain tensor alias]\label{def:periodic_mps_tensor}
+\begin{definition}[Periodic-chain tensor family]\label{def:periodic_mps_tensor}
     \lean{MPSTensor.PeriodicMPSTensor}
     \leanok
-    For a fixed period $m$, a \emph{periodic-chain tensor} is a
-    site-dependent tensor family indexed by $\{0,\ldots,m-1\}$, with
+    For a fixed period $m$, a \emph{periodic-chain tensor family} is a
+    site-dependent family of local tensors indexed by $\{0,\ldots,m-1\}$, with
     local physical dimension~$d$ and bond dimension~$D$.
 \end{definition}
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1,6 +1,13 @@
 \chapter{Schwarz Inequalities and Multiplicative Domains}\label{ch:schwarz}
 
-This chapter develops the Schwarz-inequality theory from Wolf's Chapter~5~\cite{Wolf2012Quantum}. We begin with the Kadison--Schwarz inequality for Kraus maps, then describe the multiplicative domain and its algebraic structure. We also establish the extension to normal operators for positive subunital maps, the resulting order and spectral contractivity statements, and Wolf's standard example of a Schwarz map that is not completely positive.
+This chapter develops the Schwarz-inequality theory following
+\cite[Chapter~5]{Wolf2012Quantum}. We begin with the Kadison--Schwarz
+inequality for Kraus maps, then describe the multiplicative domain and its
+algebraic structure. These two parts are used in the non-periodic Fundamental
+Theorem through peripheral-eigenvector rigidity and normal-block comparison.
+We also establish the extension to normal operators for positive subunital maps,
+the resulting order and spectral contractivity statements, and the standard
+example of a Schwarz map that is not completely positive.
 
 \section{Kadison--Schwarz inequality}
 
@@ -724,14 +731,15 @@ convenience.
 
 \section{Operator convexity and Jensen inequalities}
 
-This section collects the operator convexity/concavity results, trace
-inequalities, the operator Jensen inequality for positive maps, and the
-Lieb concavity theorem. These are standard results in matrix analysis
-(Bhatia's \emph{Matrix Analysis}, Chapter~V; \cite[Theorem~5.1]{Wolf2012Quantum};
-Hansen--Pedersen's Jensen inequality; and Lieb's concavity theorem). They are
-used here as cited inputs, since the corresponding matrix-analysis proofs for
-real powers $x\mapsto x^p$ on the Loewner order and for the matrix logarithm
-are not developed in this chapter.
+This section collects operator convexity and concavity results, trace
+inequalities, the operator Jensen inequality for positive maps, and the Lieb
+concavity theorem. These are standard matrix-analysis inputs
+\cite[Chapter~V]{Bhatia1997Matrix} and
+\cite[Theorem~5.1]{Wolf2012Quantum}. They are not used in the current
+non-periodic Fundamental Theorem dependency chain. They are retained here as
+analytic background for entropy and parent-Hamiltonian material; a later
+chapter split can move this section downstream without changing the theorem
+statements.
 
 \subsection{Diagonal Jensen inequality}
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -603,36 +603,30 @@ and~\cite{Cirac2021Matrix}.
 \end{proof}
 
 \begin{remark}[How the power-sum equality is used]
-	The equal-MPV corollary in the source compares, for each matched basis
-	tensor, the power sums
-	\[
-		\sum_q \mu_{j,q}^N
-	\]
-	on the two sides.  After the BNT permutation has matched \(A_j\) with
-	\(B_j = e^{i\phi_j}Y_jA_jY_j^{-1}\), the source comparison is
-	\[
-		\sum_{q=1}^{r_{a,j}} \mu_{j,q}^N
-		=
-		\sum_{q=1}^{r_{b,j}}(\nu_{j,q}e^{i\phi_j})^N .
-	\]
-	The Newton--Girard input says that equality of all these power sums
-	determines the multiset of weights with multiplicity. It is not a
-	replacement for the BNT matching argument: the block permutation and the
-	phase gauges must already have identified which basis tensor is being
-	compared. Once that matching is available, the power-sum lemma supplies the
-	multiplicity and weight equality needed to identify the weighted
+	The equal-MPV corollary in the source compares scalar power sums only after
+	the BNT representatives have already been matched.  If the matched basis
+	tensors satisfy $B_j=e^{i\phi_j}Y_jA_jY_j^{-1}$, then for every positive
+	length $N$ the coefficient $\sum_q \mu_{j,q}^N$ of
+	$\ket{V^{(N)}(A_j)}$ in the BNT expansion of $A$ equals the coefficient
+	$\sum_q(\nu_{j,q}e^{i\phi_j})^N$ coming from $B$.  This scalar equality
+	is the input to the Newton--Girard step.
+
+	Thus the power-sum lemma determines the multiset of weights with
+	multiplicity, but it is not a replacement for the BNT matching argument.  The
+	block permutation and the phase gauges must first identify which basis tensor
+	is being compared.  Once that matching is available, the power-sum lemma
+	supplies the multiplicity and weight equality needed to identify the weighted
 	block-diagonal gauge.
 
 	The finite-range statement below includes the same-cardinality form, the
 	nonzero-entry unequal-cardinality form, and the positive-power conclusion
-	after deleting zeros. The nonzero-entry form pads the shorter
-	family by zeros, applies the same-cardinality result at length
-	\(\max(m,n)\), and then uses the nonzero-entry hypothesis to count the
-	padded zeros. The Appendix lemma in the source also fixes an ordering
-	convention for the two families; here the conclusion is stated as multiset
-	equality, so no sorting hypothesis is needed.
-	If equality at exponent \(0\) is also assumed, the nonzero-entry hypothesis
-	can be omitted because \(\sum_k \lambda_{a,k}^0=x_a\) and
+	after deleting zeros.  The nonzero-entry form pads the shorter family by zeros,
+	applies the same-cardinality result at length \(\max(m,n)\), and then uses the
+	nonzero-entry hypothesis to count the padded zeros.  The Appendix lemma in the
+	source fixes an ordering convention for the two families; here the conclusion
+	is stated as multiset equality, so no sorting hypothesis is needed.  If
+	equality at exponent \(0\) is also assumed, the nonzero-entry hypothesis can be
+	omitted because \(\sum_k \lambda_{a,k}^0=x_a\) and
 	\(\sum_k \lambda_{b,k}^0=x_b\).
 \end{remark}
 

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -615,7 +615,6 @@ facts used to recover the lists of weights from those power sums.
 	that theorem gives the matching witness.
 \end{proof}
 
-
 \begin{theorem}[Span equality for representative sector bases]%
 \label{thm:bnt_sector_decomp_pair_overlap_span_of_block_span}
 	\lean{MPSTensor.exists_bnt_sectorDecomp_pair_with_overlapSpan_of_block_span_eq}
@@ -772,16 +771,24 @@ facts used to recover the lists of weights from those power sums.
 	\lean{MPSTensor.nonempty_mpvCommonPhaseCover_of_equiv_phase}
 	\leanok
 	\uses{def:mpv_common_phase_cover, def:mpv_block_phase_equiv}
-	If two block families are matched by a bijection and corresponding blocks have
-	the same matrix product vectors up to a nonzero scalar power depending on the
-	length, then the two families have a common MPV phase cover.
+	Let \((A_s)_{s \in S}\) and \((B_t)_{t \in T}\) be two finite families of
+	nonzero blocks.  Suppose there is a bijection \(\sigma:S \to T\) and, for
+	each \(s \in S\), a scalar \(\omega_s \in \C^\times\) such that
+	\[
+		\ket{V^{(N)}(B_{\sigma(s)})}
+		=
+		\omega_s^N \ket{V^{(N)}(A_s)}
+	\]
+	for every positive length \(N\).  Then the two block families admit a common
+	MPV phase cover.
 \end{lemma}
 
 \begin{proof}
 	\leanok
-	Take the first block family as the common family. The bijection and its inverse
-	give the two class maps, and the assumed phase match gives the second
-	family's phase factors.
+	Use the first family as the common family.  The two covering maps are the
+	identity on \(S\) and the inverse of \(\sigma\).  The displayed phase relation
+	provides the required phase factor for the corresponding block of the second
+	family.
 \end{proof}
 
 \begin{lemma}[Span equality from a proportional-decomposition comparison]%
@@ -1176,7 +1183,7 @@ BNT comparison hypotheses for the common primitive sectors.
 	% not part of the source terminology and is intentionally not displayed.
 \end{definition}
 
-\begin{definition}[BNT-cover inputs for representative common-sector families]%
+\begin{definition}[BNT matching inputs for representative common-sector families]%
 \label{def:common_representative_bnt_cover_hypotheses}
 	\lean{MPSTensor.CommonRepresentativeBNTCoverHypotheses}
 	\leanok
@@ -1191,7 +1198,7 @@ BNT comparison hypotheses for the common primitive sectors.
 	data linking the two representative families.
 \end{definition}
 
-\begin{theorem}[Representative common-sector families supply BNT-cover hypotheses]%
+\begin{theorem}[Representative common-sector families supply BNT matching hypotheses]%
 \label{thm:ofCommonRepresentatives_zeroTailIdentity}
 	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentatives_zeroTailIdentity}
 	\leanok
@@ -1201,19 +1208,28 @@ BNT comparison hypotheses for the common primitive sectors.
 	the length-zero identity holds for the representative nonzero parts, each
 	representative block is one-site injective, and proportional-decomposition
 	data links the two representative families, then the zero-tail identity
-	and normal-CF-BNT conditions produce BNT-cover hypotheses for the
+	and normal-CF-BNT conditions produce BNT matching hypotheses for the
 	representative blocks.
 \end{theorem}
 
-\begin{theorem}[Representative BNT-cover structure supplies BNT-cover hypotheses]%
+\begin{theorem}[Representative common-sector data give BNT matching hypotheses]%
 \label{thm:ofCommonRepresentativeBNTCoverHypotheses}
 	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentativeBNTCoverHypotheses}
 	\leanok
 	\uses{def:common_representative_bnt_cover_hypotheses}
-	A \texttt{CommonRepresentativeBNTCoverHypotheses} structure directly
-	produces the primitive BNT-cover hypotheses for the representative
-	common-sector families by extracting its fields and calling the previous
-	theorem.
+	Let $(A_j)_{j \in J}$ and $(B_j)_{j \in J}$ be the representative
+	common-sector families obtained after choosing one representative from each
+	nonzero phase-gauge class.  Assume the representative weights are nonzero and
+	strictly ordered by norm, distinct representatives are not gauge equivalent up
+	to phase, the length-zero identity for the representative nonzero parts holds,
+	each representative block is one-site injective, and the proportional
+	comparison supplies a permutation $\pi$, equal matched bond dimensions, gauges
+	$X_j$, and phases $\zeta_j \in \C^\times$ with
+	\[
+		B_{\pi(j)}^i=\zeta_j X_j A_j^i X_j^{-1}.
+	\]
+	Then these representative families satisfy the BNT matching hypotheses for
+	common primitive sectors.
 \end{theorem}
 
 \begin{theorem}[BNT matching hypotheses produce a common phase cover]%
@@ -1416,23 +1432,33 @@ BNT comparison hypotheses for the common primitive sectors.
 	common-sector comparison theorem with those span hypotheses.
 \end{proof}
 
-\begin{theorem}[Sector comparison from relabeled common sectors and proportional-decomposition data]%
+\begin{lemma}[Sector comparison from relabelled common sectors and proportional data]%
 \label{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
 	\leanok
 	\uses{def:common_primitive_proportional_hypotheses,
 		def:common_sector_relabeling_hypothesis,
 		thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
-	Assume the blocked-word identification for the common-sector families.
-	The structural theorem supplies one common positive blocking length with
-	trace-preserving, primitive, irreducible nonzero-sector families on both
-	sides. If the remaining comparison assertions for exactly those families
-	are available -- equality of the two zero-tail dimensions, injectivity at
-	that blocking level, and a BNT proportional-decomposition comparison --
-	then the common-sector families satisfy the proportional-decomposition
-	hypotheses, which convert to common phase-cover hypotheses and give the
-	sector-weight comparison conclusion.
-\end{theorem}
+	Let $A$ and $B$ generate the same MPV family, and let $p>0$ be the common
+	blocking length supplied by the structural reduction.  After identifying
+	blocked words, assume that
+	\[
+		A^{[p]} \sim \mathbf{0}_{d^p,z_A}\oplus P,
+		\qquad
+		B^{[p]} \sim \mathbf{0}_{d^p,z_B}\oplus Q,
+	\]
+	where $P=(P_j)_{j \in J}$ and $Q=(Q_j)_{j \in J}$ are the common primitive
+	nonzero-sector families.  If $z_A=z_B$, all sectors in $P$ and $Q$ are
+	one-site injective, and the two sector families satisfy the BNT proportional
+	comparison
+	\[
+		Q_{\pi(j)}^i=\zeta_j X_j P_j^iX_j^{-1}
+		\qquad (j \in J)
+	\]
+	for a permutation $\pi$, gauges $X_j$, and nonzero phases
+	$\zeta_j \in \C^\times$, then the blocked sector decompositions have the
+	matched sector-weight conclusion of the source theorem.
+\end{lemma}
 
 \begin{theorem}[Common sectors from BNT matching hypotheses]%
 \label{thm:afterBlocking_sectorComparison_reindexed_bntCover}
@@ -1512,30 +1538,36 @@ BNT comparison hypotheses for the common primitive sectors.
 	\leanok
 	\uses{def:after_blocking_sector_comparison_hypotheses,
 			def:after_blocking_sector_comparison_conclusion}
-	Let $A$ and $B$ generate the same MPV family. Assume the after-blocking
-	BNT matching hypotheses of
-	Definition~\ref{def:after_blocking_sector_comparison_hypotheses}. Then the
-	source-paper sector-comparison conclusion of
-	Definition~\ref{def:after_blocking_sector_comparison_conclusion} is
-	nonempty.
+	Let $A$ and $B$ generate the same MPV family.  Assume the after-blocking BNT
+	matching hypotheses of
+	Definition~\ref{def:after_blocking_sector_comparison_hypotheses}.  Then the
+	sector-comparison conclusion of
+	Definition~\ref{def:after_blocking_sector_comparison_conclusion} is nonempty.
 
-	The conclusion matches the sector-decomposition part of the
-	Cirac--P\'erez-Garc\'ia--Schuch--Verstraete Fundamental Theorem: after
-	blocking, the tensor families are represented by BNT sector decompositions
-	whose basis sectors and weights match up to permutation and nonzero phases,
-	as in \cite{Cirac2016MPDO_arXiv} and \cite{Cirac2021Matrix}.
+	The conclusion is the sector-decomposition part of the source theorem
+	\cite{Cirac2016MPDO_arXiv,Cirac2021Matrix}: after a positive blocking length,
+	the tensors have BNT sector decompositions whose basis sectors are matched by
+	a permutation, with equal multiplicities and weight multisets after the
+	prescribed sector phases are absorbed.
 
-	This lemma assumes the BNT matching hypotheses. It does not prove
-	them from equality of MPV families. Under those hypotheses, together with
-	\(A^{[p]}\sim\mathbf{0}_{d^p,z_A}\oplus A_{\mathrm{nz}}\),
-	\(B^{[p]}\sim\mathbf{0}_{d^p,z_B}\oplus B_{\mathrm{nz}}\), \(z_A=z_B\),
-	trace-preserving normalization, primitivity, irreducibility, and positive
-	bond dimensions, the sector-decomposition conclusion is nonempty.
+	This lemma does not derive the BNT matching hypotheses from equality of MPV
+	families.  The upstream canonical reduction supplies the common blocking,
+	zero-tail equality
+	\[
+		A^{[p]}\sim \mathbf{0}_{d^p,z_A}\oplus A_{\mathrm{nz}},
+		\qquad
+		B^{[p]}\sim \mathbf{0}_{d^p,z_B}\oplus B_{\mathrm{nz}},
+		\qquad z_A=z_B,
+	\]
+	and the trace-preserving, primitive, irreducible nonzero-sector families.
+	Injectivity at that blocking length and the BNT proportional-decomposition
+	comparison remain explicit assumptions here.  Under precisely those
+	assumptions, the sector-decomposition conclusion is nonempty.
 \end{lemma}
 
-	\begin{proof}
-		\leanok
-		\uses{lem:common_grouped_block_cast_of_flatten_word,
+\begin{proof}
+	\leanok
+	\uses{lem:common_grouped_block_cast_of_flatten_word,
 			lem:common_grouped_block_cast_to_relabeling,
 			thm:afterBlocking_sectorComparison_reindexed_bntCover}
 	Apply Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_bntCover} with
@@ -1548,72 +1580,61 @@ BNT comparison hypotheses for the common primitive sectors.
 	multiset equalities as the conclusion structure.
 \end{proof}
 
+
 \begin{remark}[Equal-case comparison after canonical reduction]\notready
-	The equal-case proof in the literature begins with both tensors in canonical
-	form.  One chooses a basis of normal tensors for each tensor, so that every
-	canonical-form block is a phase times a gauge transform of exactly one basis
-	tensor; this is the basis characterization of
-	\cite{Cirac2021Matrix} and \cite{Cirac2016MPDO_arXiv}.
-	Equality, or proportionality, of the MPV families then pairs the two bases by
-	phase and gauge, as in the Fundamental Theorem of Matrix Product Vectors.
-	In the equal case, one expands each tensor in its basis of normal tensors and
-	compares, for every basis tensor and every length $N$, the power sums
+	The equal-case proof in the source starts after both tensors have been put in
+	canonical form and after a basis of normal tensors has been chosen.  In that
+	notation the BNT expansion has the form
 	\[
-		\sum_q \mu_{j,q}^N = \sum_q (\nu_{j,q}e^{i\phi_j})^N.
+		\ket{V^{(N)}(A)}
+		=
+		\sum_{j=1}^g
+		\left(\sum_{q=1}^{r^A_j}(\mu^A_{j,q})^N\right)
+		\ket{V^{(N)}(A_j)},
 	\]
-	Newton identities, equivalently the elementary power-sum lemma used in the
-	CPSV argument, recover the multiplicities and the weights.  The per-sector
-	gauge matrices are then placed on the diagonal to obtain the global conjugating
-	matrix; this is the equal-case corollary of the Fundamental Theorem in
-	\cite{Cirac2016MPDO_arXiv}, restated in \cite{Cirac2021Matrix}.
-
-	% Maintainer note: the comparison statements in this chapter cover this
-	% latter part of the argument.  Lemma~\ref{lem:ft_equal_same_structure}
-	% proves the common block-structure special case, and
-	% Lemma~\ref{lem:bnt_power_sum_recover_copies_weights} recovers the copy
-	% counts and sector-weight multisets from the multiplicities and weights.
-	% The basis-of-normal-tensors construction is available for
-	% trace-preserving primitive irreducible nonzero blocks with positive bond
-	% dimensions and nonzero weights in
-	% Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}.  When these
-	% blocks are injective,
-	% Theorems~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data}
-	% and~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed_overlap_data_span}
-	% give the asymptotic orthogonality and finite-length span preservation
-	% needed to separate coefficients.
-	% Theorem~\ref{thm:bnt_sector_decomp_pair_overlap_span_of_block_span} then
-	% turns equality of nonzero-sector spans into the hypotheses used by the
-	% sector comparison theorem.
-
-	Common phases are used here only to obtain the required span hypothesis.  A common
-	MPV phase cover gives equality of finite-length nonzero-block spans by
-	Lemma~\ref{lem:mpv_common_phase_cover_span_eq}.  A sector basis pre-matching
-	gives the same span equality and the primitive overlap-span hypotheses by
-	Lemma~\ref{lem:sector_basis_pre_matching_span_eq} and
-	Lemma~\ref{lem:sector_basis_pre_matching_to_overlap_span}.  The BNT comparison
-	lemmas produce such common phases from a proportional-decomposition conclusion in
-	Lemmas~\ref{lem:common_phase_cover_of_proportional_decomposition}
-	and~\ref{lem:common_phase_cover_of_separated_normal_bnt}.  These common phase-cover
-	facts are not a separate form of the source theorem; they are used only to
-	obtain the finite-length span equality required by the sector comparison.
-
-	Chapter~\ref{ch:canonical} supplies the canonical-form reduction needed before
-	these comparison theorems can be applied: a common physical blocking length
-	with \(A^{[p]}\sim\mathbf{0}_{d^p,z_A}\oplus A_{\mathrm{nz}}\),
-	\(B^{[p]}\sim\mathbf{0}_{d^p,z_B}\oplus B_{\mathrm{nz}}\), and
-	\(z_A=z_B\), plus cyclic-sector families for both tensors on a common
-	blocked alphabet.  The blocked-word relabelling and the
-	common primitive irreducible nonzero-sector decompositions are now part of the
-	reduction, culminating in
-	Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}.
-	Theorem~\ref{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_spanHypotheses}
-		then states the hypotheses: \(z_A=z_B\), injectivity of the common
-	nonzero-sector blocks, and
-	finite-length MPV span equality.
-	Theorem~\ref{thm:afterBlocking_sectorComparison_reindexed_commonPhaseCover}
-	adds the zero-block dimension equality and injectivity hypotheses to the common phase-cover theorem and
-	therefore gives the same sector-weight conclusion.  Establishing these
-	hypotheses is the mathematical passage from equality of total MPV vectors to the
-	componentwise power-sum identities used in
+	and similarly for $B$.  The proportional theorem of
+	\cite{Cirac2016MPDO_arXiv,Cirac2021Matrix} first matches the BNT
+	representatives: after a relabelling,
+	\[
+		B_j^i=e^{i\phi_j}Y_jA_j^iY_j^{-1}.
+	\]
+	Only after this representative matching does the equal case compare the scalar
+	coefficient power sums
+	\[
+		\sum_{q=1}^{r^A_j}(\mu^A_{j,q})^N
+		=
+		\sum_{q=1}^{r^B_j}(\mu^B_{j,q}e^{i\phi_j})^N
+		\qquad (j=1,\ldots,g; N\ge 1).
+	\]
+	Newton--Girard then recovers the multiplicities and weight multisets, and the
+	block gauges $Y_j$ are placed on the diagonal to give the global conjugating
+	matrix.  This is the equal-case corollary in the source, restated in
 	\cite[Corollary~IV.5]{Cirac2021Matrix}.
+
+	The comparison theorems above formalize only the part of this route after the
+	common blocked nonzero sectors and their BNT matching data have been supplied.
+	The structural reduction supplies a common positive blocking length and
+	decompositions
+	\[
+		A^{[p]}\sim\mathbf{0}_{d^p,z_A}\oplus A_{\mathrm{nz}},
+		\qquad
+		B^{[p]}\sim\mathbf{0}_{d^p,z_B}\oplus B_{\mathrm{nz}},
+		\qquad z_A=z_B,
+	\]
+	with trace-preserving, primitive, irreducible nonzero sectors.  The remaining
+	inputs are the one-site injectivity of those sectors and the BNT
+	proportional-decomposition comparison for the representative families.  These
+	are genuine upstream assumptions of the conditional statements here; they are
+	not proved from equality of MPV families in this chapter.
+
+	Common phase covers are an auxiliary way to package the finite-length span
+	equality needed by the sector-comparison theorem.  They are not a separate
+	form of the source theorem.  Lemma~\ref{lem:mpv_common_phase_cover_span_eq}
+	turns a common phase cover into span equality, while
+	Lemmas~\ref{lem:common_phase_cover_of_proportional_decomposition}
+	and~\ref{lem:common_phase_cover_of_separated_normal_bnt} construct such
+	covers from BNT proportional-decomposition data.  Establishing the missing
+	representative BNT comparison and exact-length block-injective span remains the
+	open source-faithful passage from equality of total MPV vectors to the
+	componentwise power-sum identities.
 \end{remark}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -779,8 +779,10 @@ facts used to recover the lists of weights from those power sums.
 		=
 		\omega_s^N \ket{V^{(N)}(A_s)}
 	\]
-	for every length \(N\ge 0\).  The case \(N=0\) records the matching
-	bond dimensions.  Then the two block families admit a common MPV phase cover.
+	for every length \(N\ge 0\), with \(\ket{V^{(0)}(C)}\) interpreted as the
+	bond dimension of \(C\).  For each matched pair, the case \(N=0\) records
+	equality of bond dimensions.  Then the two block families admit a common MPV
+	phase cover.
 \end{lemma}
 
 \begin{proof}
@@ -1222,14 +1224,13 @@ BNT comparison hypotheses for the common primitive sectors.
 	nonzero phase-gauge class.  Assume the representative weights are nonzero and
 	strictly ordered by norm, distinct representatives are not gauge equivalent up
 	to phase, the length-zero identity for the representative nonzero parts holds,
-	each representative block is one-site injective, and the proportional
-	comparison supplies a permutation $\pi$, equal matched bond dimensions, gauges
-	$X_j$, and phases $\zeta_j \in \C^\times$ with
-	\[
-		B_{\pi(j)}^i=\zeta_j X_j A_j^i X_j^{-1}.
-	\]
-	Then these representative families satisfy the BNT matching hypotheses for
-	common primitive sectors.
+	and each representative block is one-site injective.  Assume also the
+	proportional-decomposition input for these representative families: total
+	tensors decompose at every length over the two representative BNT families with
+	coefficient functions converging to nonzero limits, and the two total MPV
+	families are proportional at every length by scalars converging to a nonzero
+	limit.  Then these representative families satisfy the BNT matching hypotheses
+	for common primitive sectors.
 \end{theorem}
 
 \begin{theorem}[BNT matching hypotheses produce a common phase cover]%
@@ -1432,8 +1433,8 @@ BNT comparison hypotheses for the common primitive sectors.
 	common-sector comparison theorem with those span hypotheses.
 \end{proof}
 
-\begin{lemma}[Sector comparison from relabelled common sectors and proportional data]%
-\label{lem:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
+\begin{theorem}[Sector comparison from relabelled common sectors and proportional data]%
+\label{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
 	\leanok
 	\uses{def:common_primitive_proportional_hypotheses,
@@ -1458,7 +1459,7 @@ BNT comparison hypotheses for the common primitive sectors.
 	for a permutation $\pi$, gauges $X_j$, and nonzero phases
 	$\zeta_j \in \C^\times$, then the blocked sector decompositions have the
 	matched sector-weight conclusion of the source theorem.
-\end{lemma}
+\end{theorem}
 
 \begin{theorem}[Common sectors from BNT matching hypotheses]%
 \label{thm:afterBlocking_sectorComparison_reindexed_bntCover}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -771,16 +771,16 @@ facts used to recover the lists of weights from those power sums.
 	\lean{MPSTensor.nonempty_mpvCommonPhaseCover_of_equiv_phase}
 	\leanok
 	\uses{def:mpv_common_phase_cover, def:mpv_block_phase_equiv}
-	Let \((A_s)_{s \in S}\) and \((B_t)_{t \in T}\) be two finite families of
-	nonzero blocks.  Suppose there is a bijection \(\sigma:S \to T\) and, for
-	each \(s \in S\), a scalar \(\omega_s \in \C^\times\) such that
+	Let \((A_s)_{s \in S}\) and \((B_t)_{t \in T}\) be two finite block
+	families.  Suppose there is a bijection \(\sigma:S \to T\) and, for each
+	\(s \in S\), a scalar \(\omega_s \in \C^\times\) such that
 	\[
 		\ket{V^{(N)}(B_{\sigma(s)})}
 		=
 		\omega_s^N \ket{V^{(N)}(A_s)}
 	\]
-	for every positive length \(N\).  Then the two block families admit a common
-	MPV phase cover.
+	for every length \(N\ge 0\).  The case \(N=0\) records the matching
+	bond dimensions.  Then the two block families admit a common MPV phase cover.
 \end{lemma}
 
 \begin{proof}
@@ -1433,7 +1433,7 @@ BNT comparison hypotheses for the common primitive sectors.
 \end{proof}
 
 \begin{lemma}[Sector comparison from relabelled common sectors and proportional data]%
-\label{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
+\label{lem:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
 	\leanok
 	\uses{def:common_primitive_proportional_hypotheses,
@@ -1627,7 +1627,7 @@ BNT comparison hypotheses for the common primitive sectors.
 	are genuine upstream assumptions of the conditional statements here; they are
 	not proved from equality of MPV families in this chapter.
 
-	Common phase covers are an auxiliary way to package the finite-length span
+	Common phase covers are an auxiliary way to express the finite-length span
 	equality needed by the sector-comparison theorem.  They are not a separate
 	form of the source theorem.  Lemma~\ref{lem:mpv_common_phase_cover_span_eq}
 	turns a common phase cover into span equality, while

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1181,7 +1181,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Apply Theorem~\ref{thm:block_word_strip_central} with $M = A^i$.
 \end{proof}
 
-\begin{theorem}[MPV-line endgame from long-word commutation]
+\begin{theorem}[Boundary contraction in the MPV span from long-word commutation]
     \label{thm:ground_space_map_mpv_of_long_word_commutes}
     \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes}
     \leanok
@@ -1198,7 +1198,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $X=c\Id$, and therefore $\Gamma_N(X)=cV^{(N)}(A)$.
 \end{proof}
 
-\begin{theorem}[MPV-line endgame from positive-length commutation]
+\begin{theorem}[Boundary contraction in the MPV span from positive-length commutation]
     \label{thm:ground_space_map_mpv_of_positive_word_commutes}
     \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes}
     \leanok
@@ -1216,7 +1216,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:ground_space_map_mpv_of_long_word_commutes} applies.
 \end{proof}
 
-\begin{theorem}[MPV-line endgame from a same-witness common middle]
+\begin{theorem}[Boundary contraction in the MPV span from a common-middle witness]
     \label{thm:ground_space_map_mpv_of_common_middle}
     \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}
     \leanok
@@ -1231,11 +1231,11 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     The common-middle identities give commutation with all words of length
-    $|\mu|+2$, a positive length. The positive-length MPV-line endgame then
-    finishes.
+    $|\mu|+2$, a positive length. The positive-length containment theorem then
+    applies.
 \end{proof}
 
-\begin{theorem}[MPV-line endgame from compared wrapped witnesses]
+\begin{theorem}[Boundary contraction in the MPV span from wrapped-witness comparison]
     \label{thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison}
     \leanok
@@ -3554,7 +3554,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     Lemma~\ref{lem:conditional_boundary_matrix_block_split_projection_span} then
     gives the reverse inclusion.  The equality and BNT-span forms are the
     corresponding projection-span results after this product-word-to-projection-span
-    reduction, followed by the blockwise uniqueness endgame already built into the
+    reduction, followed by the blockwise uniqueness argument already built into the
     projection-span theorem.
 \end{proof}
 

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -1,10 +1,7 @@
 \input{chapter/ch01_intro}
 \input{chapter/ch02_mps}
-\input{chapter/ch02b_mpdo}
 \input{chapter/ch03_single}
 \input{chapter/ch04_channels}
-\input{chapter/ch04b_entropy}
-\input{chapter/ch04c_entropy_corollaries}
 \input{chapter/ch05_schwarz}
 \input{chapter/ch05_qpf}
 \input{chapter/ch06_spectral}
@@ -14,10 +11,13 @@
 \input{chapter/ch10_bnt}
 \input{chapter/ch11_fundamental_theorem_proof}
 \input{chapter/ch11b_periodic_ft}
-\input{chapter/ch12_semigroup}
+\input{chapter/ch13b_symmetry}
 \input{chapter/ch13_algebraic_ft}
 \input{chapter/ch13a_peps_ft}
-\input{chapter/ch13b_symmetry}
+\input{chapter/ch12_semigroup}
+\input{chapter/ch04b_entropy}
+\input{chapter/ch04c_entropy_corollaries}
+\input{chapter/ch02b_mpdo}
 % --- Parent Hamiltonians & Correlations (planned) ---
 \input{chapter/ch14_parent_hamiltonian}
 \input{chapter/ch15_correlations}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -49,6 +49,18 @@
                   archival PDF at \url{https://mediatum.ub.tum.de/doc/1099654/1099654.pdf}},
 }
 
+
+@book{Bhatia1997Matrix,
+  author       = {Bhatia, Rajendra},
+  title        = {Matrix Analysis},
+  series       = {Graduate Texts in Mathematics},
+  volume       = {169},
+  publisher    = {Springer},
+  address      = {New York},
+  year         = {1997},
+  isbn         = {9780387948461},
+}
+
 @article{Sanz2010Quantum,
   author       = {Sanz, M. and P{\'e}rez-Garc{\'i}a, D. and Wolf, M. M. and Cirac, J. I.},
   title        = {A Quantum Version of {Wielandt}'s Inequality},

--- a/docs/paper-gaps/issue1530_ft_dependency_audit.tex
+++ b/docs/paper-gaps/issue1530_ft_dependency_audit.tex
@@ -17,83 +17,101 @@
 \section{Scope}
 
 This note records the source-faithful answer to the organizational questions in
-\href{https://github.com/LionSR/TNLean/issues/1530}{issue~1530}.  It concerns
+\href{https://github.com/LionSR/TNLean/issues/1530}{issue~1530}. It concerns
 the non-periodic Fundamental Theorem route based on
 \cite{Cirac2016MPDO_arXiv,Cirac2021Matrix}, not the direct periodic theorem of
 \cite{DeLasCuevas2017Irreducible} and not the fixed-length algebraic theorem of
-\cite{Molnar2018NormalPEPS}.  It also records which assumptions in the current
-conditional theorem surface are source inputs that still have to be produced,
-rather than conclusions already proved in the blueprint.
+\cite{Molnar2018NormalPEPS}. It also records which assumptions in the current
+conditional after-blocking statements are source inputs that still have to be
+produced, rather than conclusions already proved in the blueprint.
 
-The guiding source passages are the BNT definition and characterization, the
-block-injective canonical-form input, the proportional Fundamental Theorem, and
-the equal-MPV corollary in \cite[lines~271--352]{Cirac2016MPDO_arXiv}, together
-with the proof appendix \cite[lines~1155--1192]{Cirac2016MPDO_arXiv}.  The
-review version is \cite[Section~IV]{Cirac2021Matrix}.  This note follows the
-same convention as the previous paper-gap notes: the source theorem is the
-standard of comparison, while formal helper structures are acceptable only when
-they are identified as helper structures.
+The guiding source passages are the BNT definition, Proposition~\texttt{prop:char-BNT},
+the expansion \texttt{eq:II\_ABasicTensors}, the block-injective input
+Proposition~\texttt{propblockinj}, the proportional Fundamental Theorem
+\texttt{thm1}, and the equal-MPV Corollary~\texttt{II\_cor2} in
+\cite[lines~271--356]{Cirac2016MPDO_arXiv}, together with the proof appendix
+\cite[lines~1155--1192]{Cirac2016MPDO_arXiv}, which repeats \texttt{thm1} and
+proves the global gauge formula \texttt{eq:II:A=XAX}. The review version is
+\cite[Section~IV]{Cirac2021Matrix}. This note follows the same convention as
+the previous paper-gap notes: the source theorem is the standard of comparison,
+while formal helper structures are acceptable only when they are identified as
+helper structures.
+
+\paragraph{Notation.}
+Let $d$ be the physical dimension. For a tensor $A=(A^i)_{i=1}^d$, write
+$A^{[p]}$ for its length-$p$ blocking, whose physical dimension is $d^p$. For a
+word $w=i_1\cdots i_L$, write $|w|=L$ and $A^w=A^{i_1}\cdots A^{i_L}$. If
+$(A_j)_{j=1}^g$ is a basis of normal tensors, set
+$\tilde A^i=\bigoplus_{j=1}^g A_j^i$ and
+$\tilde A^w=\tilde A^{i_1}\cdots\tilde A^{i_L}$. The tensor
+$\mathbf{0}_{d^p,z}$ is the zero tensor of physical dimension $d^p$ and bond
+dimension $z$, and $A_{\mathrm{nz}}$ denotes the nonzero part after removing a
+zero direct summand. The symbol $\sim$ denotes the canonical-form direct-sum
+decomposition, up to the usual gauge change. In BNT comparisons, $\pi$ denotes
+a permutation of the representative normal tensors, $X_j$ an invertible gauge,
+and $\zeta_j\in\mathbb C^\times$ the nonzero phase factor in the derived
+relation $B_{\pi(j)}^i=\zeta_j X_j A_j^i X_j^{-1}$.
 
 \section{Block permutation and separation}
 
 The blueprint chapter titled ``Block Permutation and Separation'' contains more
-than one mathematical ingredient.  The product-algebra part proves that an
+than one mathematical ingredient. The product-algebra part proves that an
 automorphism of
 \[
   \prod_{j=1}^g M_{D_j}(\mathbb C)
 \]
-permutes the simple factors and is inner on each factor.  This is the algebraic
+permutes the simple factors and is inner on each factor. This is the algebraic
 mechanism used by same-structure and block-injective comparison statements.
-The invariant-projection material belongs to canonical-form reduction.  The
+The invariant-projection material belongs to canonical-form reduction. The
 block-separation lemmas prove that, under strict canonical-form hypotheses, a
 same-MPV identity for two block-diagonal tensors separates into same-MPV
 identities for the individual blocks.
 
-For the current non-periodic Fundamental Theorem surface, this chapter is not
-used wholesale.  Its visible downstream uses are the canonical-form condition
-for BNT data and the same-structure comparison lemma.  The latter is the special
-case in which the two tensors already have the same number of blocks, the same
-bond dimensions, and the same weights; it is not the CPSV BNT matching step.  In
-the source proof, the general non-periodic theorem instead proceeds through BNT
-representatives, eventual linear independence, block-injective fixed-length
-span, and scalar power sums.
+For the current conditional non-periodic Fundamental Theorem statements, this
+chapter is not used wholesale. Its visible downstream uses are the
+canonical-form condition for BNT data and the same-structure comparison lemma.
+The latter is the special case in which the two tensors already have the same
+number of blocks, the same bond dimensions, and the same weights; it is not the
+CPSV BNT matching step. In the source proof, the general non-periodic theorem
+instead proceeds through BNT representatives, eventual linear independence,
+block-injective fixed-length span, and scalar power sums.
 
 Thus the block-permutation chapter should stay before the non-periodic theorem,
 but the blueprint should not suggest that all of its material is a required
-input for the remaining CPSV comparison.  The required source input still
+input for the remaining CPSV comparison. The required source input still
 missing from the general route is the homogeneous block-injective direct-sum
 span after blocking,
 \[
   \operatorname{span}\{\tilde A^w: |w|=L\}
   = \bigoplus_{j=1}^g M_{D_j}(\mathbb C),
 \]
-or its trace-dual separation form.  This is the input recorded separately in
+or its trace-dual separation form. This is the input recorded separately in
 \path{docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex} and
 \path{docs/paper-gaps/david2006_direct_sum_input.tex}.
 
 \section{Multiplicative domain versus operator convexity}
 
 The Kadison--Schwarz and multiplicative-domain part of the Schwarz chapter is a
-real dependency of the aperiodic route.  It is used to turn peripheral
+real dependency of the aperiodic route. It is used to turn peripheral
 eigenvectors of normalized completely positive maps into multiplicative-domain
 relations, and then into the commutation and phase-gauge rigidity needed in the
-spectral and canonical-form chapters.  Consequently this material should remain
+spectral and canonical-form chapters. Consequently this material should remain
 before Perron--Frobenius theory and the non-periodic Fundamental Theorem.
 
-The operator convexity, Jensen, and Lieb-concavity material is different.  A
+The operator convexity, Jensen, and Lieb-concavity material is different. A
 label audit finds no current use of that section in the non-periodic Fundamental
-Theorem chapter or its BNT comparison chain.  Its natural downstream uses are
+Theorem chapter or its BNT comparison chain. Its natural downstream uses are
 entropy, MPDO, and parent-Hamiltonian arguments, especially the open
 operator-convexity and POVM-resolution work around the parent-Hamiltonian gap.
-Therefore the safe first step is not to move the whole Schwarz chapter.  The
+Therefore the safe first step is not to move the whole Schwarz chapter. The
 safe split, if desired in a later PR, is to keep Kadison--Schwarz and the
 multiplicative domain upstream, and to move only the operator-convexity/Jensen
 section to a downstream analytic chapter after the Fundamental Theorem.
 
 \section{Which assumptions are extra}
 
-In the conditional after-blocking theorem surface, the following data are not
-extra mathematical assumptions relative to the source theorem once the upstream
+In the conditional after-blocking statements, the following data are not extra
+mathematical assumptions relative to the source theorem once the upstream
 canonical-form reduction has been proved: a common positive blocking length,
 zero-tail equality
 \[
@@ -102,35 +120,45 @@ zero-tail equality
   B^{[p]}\sim \mathbf{0}_{d^p,z_B}\oplus B_{\mathrm{nz}},
   \qquad z_A=z_B,
 \]
-and trace-preserving, primitive, irreducible nonzero sectors.  These are the
+and trace-preserving, primitive, irreducible nonzero sectors. These are the
 formal names for the canonical-form and period-removal output in the source
 route.
 
-The remaining hypotheses are genuine proof obligations at the current theorem
-surface.  They are one-site injectivity at the chosen blocking length, the BNT
-representative comparison, and the proportional-decomposition data which match
-representatives by a permutation, gauges, and nonzero phases,
+The remaining hypotheses are genuine proof obligations in the current
+conditional after-blocking statements. They are one-site injectivity at the
+chosen blocking length and the proportional-decomposition input needed for the
+BNT representative comparison. This input consists of total tensors whose
+finite-length MPV families decompose over the representative BNT families with
+coefficient functions converging to nonzero limits, together with lengthwise
+proportionality
+\[
+  \ket{V^{(N)}(A_{\mathrm{tot}})}
+  = c_N\ket{V^{(N)}(B_{\mathrm{tot}})},
+  \qquad c_N\to c\ne 0.
+\]
+The BNT comparison theorem then derives the permutation, matched bond
+dimensions, gauges, and nonzero phases satisfying
 \[
   B_{\pi(j)}^i=\zeta_j X_j A_j^i X_j^{-1}.
 \]
-The formal statements which assume these data do not prove them from equality
-of MPV families.  They only transport them through the common blocking and then
-recover the sector weights.  This is why the blueprint and the paper-gap notes
-must continue to mark the passage as conditional.  In particular, this audit
-does not claim that the proof gaps tracked by issues~1499, 1500, or 1501 have
-been solved.
+The formal statements which assume the proportional-decomposition input do not
+prove it from equality of MPV families. They only transport it through the
+common blocking and then recover the sector weights. This is why the blueprint
+and the paper-gap notes must continue to mark the passage as conditional. In
+particular, this audit does not claim that the proof gaps tracked by
+issues~1499, 1500, or 1501 have been solved.
 
 \section{Staged blueprint organization}
 
-The chapter order can be improved without changing theorem statements.  A safe
+The chapter order can be improved without changing theorem statements. A safe
 organization is to keep the aperiodic proof dependencies first, ending with the
-proof of the Fundamental Theorem.  The direct periodic theorem, symmetries and
+proof of the Fundamental Theorem. The direct periodic theorem, symmetries and
 string order, and the algebraic fixed-length theorem then form the first
-post-FT block.  Entropy and MPDO material should be placed before parent
+post-FT block. Entropy and MPDO material should be placed before parent
 Hamiltonians, since the parent-Hamiltonian chapter depends conceptually on
 state and density-operator technology rather than conversely.
 
-The larger split of the Schwarz chapter should be staged separately.  It is a
+The larger split of the Schwarz chapter should be staged separately. It is a
 pure organization change once the operator-convexity section is isolated, but it
 touches many labels and should not be combined with proof-gap claims.
 

--- a/docs/paper-gaps/issue1530_ft_dependency_audit.tex
+++ b/docs/paper-gaps/issue1530_ft_dependency_audit.tex
@@ -1,0 +1,140 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Dependency Audit for the Non-periodic MPS Fundamental Theorem Blueprint}
+\author{}
+\date{2026-05-08}
+
+\begin{document}
+\maketitle
+
+\section{Scope}
+
+This note records the source-faithful answer to the organizational questions in
+\href{https://github.com/LionSR/TNLean/issues/1530}{issue~1530}.  It concerns
+the non-periodic Fundamental Theorem route based on
+\cite{Cirac2016MPDO_arXiv,Cirac2021Matrix}, not the direct periodic theorem of
+\cite{DeLasCuevas2017Irreducible} and not the fixed-length algebraic theorem of
+\cite{Molnar2018NormalPEPS}.  It also records which assumptions in the current
+conditional theorem surface are source inputs that still have to be produced,
+rather than conclusions already proved in the blueprint.
+
+The guiding source passages are the BNT definition and characterization, the
+block-injective canonical-form input, the proportional Fundamental Theorem, and
+the equal-MPV corollary in \cite[lines~271--352]{Cirac2016MPDO_arXiv}, together
+with the proof appendix \cite[lines~1155--1192]{Cirac2016MPDO_arXiv}.  The
+review version is \cite[Section~IV]{Cirac2021Matrix}.  This note follows the
+same convention as the previous paper-gap notes: the source theorem is the
+standard of comparison, while formal helper structures are acceptable only when
+they are identified as helper structures.
+
+\section{Block permutation and separation}
+
+The blueprint chapter titled ``Block Permutation and Separation'' contains more
+than one mathematical ingredient.  The product-algebra part proves that an
+automorphism of
+\[
+  \prod_{j=1}^g M_{D_j}(\mathbb C)
+\]
+permutes the simple factors and is inner on each factor.  This is the algebraic
+mechanism used by same-structure and block-injective comparison statements.
+The invariant-projection material belongs to canonical-form reduction.  The
+block-separation lemmas prove that, under strict canonical-form hypotheses, a
+same-MPV identity for two block-diagonal tensors separates into same-MPV
+identities for the individual blocks.
+
+For the current non-periodic Fundamental Theorem surface, this chapter is not
+used wholesale.  Its visible downstream uses are the canonical-form condition
+for BNT data and the same-structure comparison lemma.  The latter is the special
+case in which the two tensors already have the same number of blocks, the same
+bond dimensions, and the same weights; it is not the CPSV BNT matching step.  In
+the source proof, the general non-periodic theorem instead proceeds through BNT
+representatives, eventual linear independence, block-injective fixed-length
+span, and scalar power sums.
+
+Thus the block-permutation chapter should stay before the non-periodic theorem,
+but the blueprint should not suggest that all of its material is a required
+input for the remaining CPSV comparison.  The required source input still
+missing from the general route is the homogeneous block-injective direct-sum
+span after blocking,
+\[
+  \operatorname{span}\{\tilde A^w: |w|=L\}
+  = \bigoplus_{j=1}^g M_{D_j}(\mathbb C),
+\]
+or its trace-dual separation form.  This is the input recorded separately in
+\path{docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex} and
+\path{docs/paper-gaps/david2006_direct_sum_input.tex}.
+
+\section{Multiplicative domain versus operator convexity}
+
+The Kadison--Schwarz and multiplicative-domain part of the Schwarz chapter is a
+real dependency of the aperiodic route.  It is used to turn peripheral
+eigenvectors of normalized completely positive maps into multiplicative-domain
+relations, and then into the commutation and phase-gauge rigidity needed in the
+spectral and canonical-form chapters.  Consequently this material should remain
+before Perron--Frobenius theory and the non-periodic Fundamental Theorem.
+
+The operator convexity, Jensen, and Lieb-concavity material is different.  A
+label audit finds no current use of that section in the non-periodic Fundamental
+Theorem chapter or its BNT comparison chain.  Its natural downstream uses are
+entropy, MPDO, and parent-Hamiltonian arguments, especially the open
+operator-convexity and POVM-resolution work around the parent-Hamiltonian gap.
+Therefore the safe first step is not to move the whole Schwarz chapter.  The
+safe split, if desired in a later PR, is to keep Kadison--Schwarz and the
+multiplicative domain upstream, and to move only the operator-convexity/Jensen
+section to a downstream analytic chapter after the Fundamental Theorem.
+
+\section{Which assumptions are extra}
+
+In the conditional after-blocking theorem surface, the following data are not
+extra mathematical assumptions relative to the source theorem once the upstream
+canonical-form reduction has been proved: a common positive blocking length,
+zero-tail equality
+\[
+  A^{[p]}\sim \mathbf{0}_{d^p,z_A}\oplus A_{\mathrm{nz}},
+  \qquad
+  B^{[p]}\sim \mathbf{0}_{d^p,z_B}\oplus B_{\mathrm{nz}},
+  \qquad z_A=z_B,
+\]
+and trace-preserving, primitive, irreducible nonzero sectors.  These are the
+formal names for the canonical-form and period-removal output in the source
+route.
+
+The remaining hypotheses are genuine proof obligations at the current theorem
+surface.  They are one-site injectivity at the chosen blocking length, the BNT
+representative comparison, and the proportional-decomposition data which match
+representatives by a permutation, gauges, and nonzero phases,
+\[
+  B_{\pi(j)}^i=\zeta_j X_j A_j^i X_j^{-1}.
+\]
+The formal statements which assume these data do not prove them from equality
+of MPV families.  They only transport them through the common blocking and then
+recover the sector weights.  This is why the blueprint and the paper-gap notes
+must continue to mark the passage as conditional.  In particular, this audit
+does not claim that the proof gaps tracked by issues~1499, 1500, or 1501 have
+been solved.
+
+\section{Staged blueprint organization}
+
+The chapter order can be improved without changing theorem statements.  A safe
+organization is to keep the aperiodic proof dependencies first, ending with the
+proof of the Fundamental Theorem.  The direct periodic theorem, symmetries and
+string order, and the algebraic fixed-length theorem then form the first
+post-FT block.  Entropy and MPDO material should be placed before parent
+Hamiltonians, since the parent-Hamiltonian chapter depends conceptually on
+state and density-operator technology rather than conversely.
+
+The larger split of the Schwarz chapter should be staged separately.  It is a
+pure organization change once the operator-convexity section is isolated, but it
+touches many labels and should not be combined with proof-gap claims.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/issue1530_ft_dependency_audit.tex
+++ b/docs/paper-gaps/issue1530_ft_dependency_audit.tex
@@ -127,13 +127,15 @@ route.
 The remaining hypotheses are genuine proof obligations in the current
 conditional after-blocking statements. They are one-site injectivity at the
 chosen blocking length and the proportional-decomposition input needed for the
-BNT representative comparison. This input consists of total tensors whose
-finite-length MPV families decompose over the representative BNT families with
-coefficient functions converging to nonzero limits, together with lengthwise
-proportionality
+BNT representative comparison. Let $A_{\mathrm{tot}}$ and $B_{\mathrm{tot}}$ be
+the total tensors in this input, and let $(c_N)_N$ be proportionality scalars
+with limit $c\ne 0$.  The input also includes decompositions of the finite-length
+MPV families of $A_{\mathrm{tot}}$ and $B_{\mathrm{tot}}$ over the representative
+BNT families, with coefficient functions converging to nonzero limits, together
+with the lengthwise proportionality
 \[
-  \ket{V^{(N)}(A_{\mathrm{tot}})}
-  = c_N\ket{V^{(N)}(B_{\mathrm{tot}})},
+  |V^{(N)}(A_{\mathrm{tot}})\rangle
+  = c_N\,|V^{(N)}(B_{\mathrm{tot}})\rangle,
   \qquad c_N\to c\ne 0.
 \]
 The BNT comparison theorem then derives the permutation, matched bond


### PR DESCRIPTION
## Summary

This is a safe first blueprint/prose PR for #1530.  It treats the issue as an editorial/audit bundle rather than a Lean proof task.

Implemented:
- reorganize the blueprint chapter order so the aperiodic Fundamental Theorem dependency chain comes first, followed by the post-FT block (periodic FT, symmetries/string order, algebraic FT, PEPS, semigroup, entropy, MPDO, parent Hamiltonians, correlations, examples);
- rewrite the introduction around the current CPSV16/RMP source route and put post-FT contents in a separate paragraph;
- rename the poor subsection title “Periodic-chain aliases” to “Site-dependent periodic chains”;
- document that the Kadison--Schwarz/multiplicative-domain material is part of the non-periodic FT dependency chain, while operator convexity/Jensen is downstream analytic material rather than currently used in the FT proof;
- rewrite the BNT power-sum remark so the source equal-MPV coefficient comparison is not a displayed theorem-level equation and is clearly after BNT representative matching;
- improve the dense statements around the requested ch11 items with formulas and remove the visible Lean-structure wording from the representative BNT matching theorem;
- clarify the after-blocking theorem surface: canonical reduction supplies common blocking/zero-tail/primitive-sector data, while injectivity at that blocking level and BNT proportional-decomposition matching remain explicit assumptions;
- add `docs/paper-gaps/issue1530_ft_dependency_audit.tex` as a concise source-faithful audit for Block Permutation/Separation, multiplicative-domain vs operator-convexity usefulness, and the extra-assumption boundary.

## Deferred / staged work

- I did not split the Schwarz chapter in this PR.  The audit recommends a later, narrower split that keeps Kadison--Schwarz and multiplicative domains upstream and moves only operator-convexity/Jensen downstream.
- I did not claim that #1499/#1500/#1501 are solved.  The new prose explicitly keeps those proof obligations conditional.
- I kept the periodic FT chapter immediately before Symmetries because the symmetry chapter uses the periodic rotation/theorem machinery; Symmetries now precedes the Algebraic Fundamental Theorem in the post-FT block.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `cd blueprint && leanblueprint web`

Note: I attempted to subscribe to #1530 before starting, but the available token lacks the GitHub `notifications` scope required by the subscription mutation.

Closes part of #1530.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/prose edits plus chapter ordering in `content.tex`, with no algorithmic or proof-logic modifications expected to affect Lean or generated results beyond references/structure.
> 
> **Overview**
> Refocuses the blueprint’s *non-periodic Fundamental Theorem* narrative on the CPSV16/RMP source route: rewrites the Introduction, clarifies when BNT representative matching happens before power-sum/Newton–Girard comparisons, and tightens several FT-proof statements to explicitly separate **canonical-reduction outputs** from still-conditional assumptions (injectivity at the chosen blocking length and proportional-decomposition/BNT matching inputs).
> 
> Reorganizes the compiled chapter order in `content.tex` so the aperiodic FT dependency chain appears first, followed by post-FT material (periodic FT, symmetry, algebraic FT/PEPS, semigroups, entropy/MPDO, etc.), and makes smaller editorial renames/retitles (e.g. “Site-dependent periodic chains”, parent-Hamiltonian theorem titles).
> 
> Adds a new dependency-audit note `docs/paper-gaps/issue1530_ft_dependency_audit.tex` documenting which chapters/sections are actually upstream dependencies vs downstream analytic background, and introduces the missing citation `Bhatia1997Matrix` used by the operator-convexity/Jensen section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adbf7f503bbafe192cc7b5fde3b9aa50e7f91a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->