### PR TITLE
feat(MPS/CanonicalForm): derive BNT pair-span period windows

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -412,6 +412,95 @@ lemma exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_inj
         (hCF.toHasInjectiveBlocks.block_injective k))
   · norm_num
 
+/-- Direct-sum BNT comparison supplies a finite period window of full homogeneous
+pair spans.
+
+Specializing the three-block comparison to `L = 2` gives homogeneous pair trace
+separation at length `6`.  The trace-separation criterion is dual to full pair
+span, and full homogeneous pair span at a positive length propagates to all later
+lengths by multiplying by one-letter words.  Thus we can take `start = period = 6`. -/
+lemma forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hIrr : HasIrreducibleBlocks (d := d) A) :
+    ∀ k j : Fin r, j ≠ k → ∃ start period : ℕ, 0 < period ∧
+      PairWordTupleSpanTop (A k) (A j) period ∧
+      ∀ s : ℕ, s < period → PairWordTupleSpanTop (A k) (A j) (start + s) := by
+  classical
+  have hSep6 : ∀ k j : Fin r, j ≠ k →
+      PairTraceSeparatingAt (A k) (A j) (2 + (2 + 2)) := by
+    refine forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock
+      (d := d) (dim := dim) μ A hCF hIrr (L := 2) ?_ ?_ ?_
+    · intro k
+      simpa using isNBlkInjective_mul_of_isNBlkInjective (A k) (N := 1) (m := 2)
+        (by norm_num) (isNBlkInjective_one_of_isInjective
+          (hCF.toHasInjectiveBlocks.block_injective k))
+    · intro k
+      simpa using isNBlkInjective_mul_of_isNBlkInjective (A k) (N := 1) (m := 6)
+        (by norm_num) (isNBlkInjective_one_of_isInjective
+          (hCF.toHasInjectiveBlocks.block_injective k))
+    · norm_num
+  intro k j hneq
+  let S : ℕ := 2 + (2 + 2)
+  have hSpos : 0 < S := by norm_num [S]
+  have hSpanS : PairWordTupleSpanTop (A k) (A j) S := by
+    dsimp [S]
+    exact pairWordTupleSpanTop_of_pairTraceSeparatingAt (A k) (A j) (hSep6 k j hneq)
+  have hsucc : ∀ {T : ℕ}, 0 < T → PairWordTupleSpanTop (A k) (A j) T →
+      PairWordTupleSpanTop (A k) (A j) (T + 1) := by
+    intro T hT hTop
+    rcases T with _ | T
+    · cases hT
+    unfold PairWordTupleSpanTop
+    apply eq_top_iff.mpr
+    intro M _
+    have hM : M ∈ Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T + 1))) := by
+      rw [hTop]
+      exact Submodule.mem_top
+    have hle : Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T + 1))) ≤
+        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) ((T + 1) + 1))) := by
+      apply Submodule.span_le.mpr
+      rintro N ⟨w, rfl⟩
+      let i : Fin d := w 0
+      let tail : Fin T → Fin d := fun j => w j.succ
+      have hletter : pairEvalWordTuple (A k) (A j) [i] ∈
+          Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) 1)) :=
+        pairEvalWordTuple_mem_span_pairWordTuple_length (A k) (A j) [i]
+      have htail : pairEvalWordTuple (A k) (A j) (List.ofFn tail) ∈
+          Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T + 1))) := by
+        rw [hTop]
+        exact Submodule.mem_top
+      have hmul :=
+        pair_mul_mem_span_pairWordTuple_add (A := A k) (B := A j)
+          (L := 1) (S := T + 1)
+          (M := pairEvalWordTuple (A k) (A j) [i])
+          (N := pairEvalWordTuple (A k) (A j) (List.ofFn tail)) hletter htail
+      rw [Nat.add_comm 1 (T + 1)] at hmul
+      have hprod :
+          ((pairEvalWordTuple (A k) (A j) [i]).1 *
+              (pairEvalWordTuple (A k) (A j) (List.ofFn tail)).1,
+            (pairEvalWordTuple (A k) (A j) [i]).2 *
+              (pairEvalWordTuple (A k) (A j) (List.ofFn tail)).2) =
+            pairWordTuple (A k) (A j) (T + 1) w := by
+        ext <;> simp [pairWordTuple, pairEvalWordTuple, i, tail]
+      simpa [hprod] using hmul
+    exact hle hM
+  have hTopOfLe : ∀ {T : ℕ}, S ≤ T → PairWordTupleSpanTop (A k) (A j) T := by
+    intro T hST
+    obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hST
+    have hTopAdd : ∀ m : ℕ, PairWordTupleSpanTop (A k) (A j) (S + m) := by
+      intro m
+      induction m with
+      | zero => simpa using hSpanS
+      | succ m ih =>
+          simpa [Nat.add_assoc] using
+            hsucc (Nat.lt_of_lt_of_le hSpos (Nat.le_add_right S m)) ih
+    exact hTopAdd m
+  refine ⟨S, S, hSpos, hSpanS, ?_⟩
+  intro s _hs
+  exact hTopOfLe (Nat.le_add_right S s)
+
 /-- Positive-length product-word span from canonical-form/BNT separation and
 one-site injectivity of the BNT blocks.
 

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -412,13 +412,9 @@ lemma exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_inj
         (hCF.toHasInjectiveBlocks.block_injective k))
   · norm_num
 
-/-- Direct-sum BNT comparison supplies a finite period window of full homogeneous
-pair spans.
-
-Specializing the three-block comparison to `L = 2` gives homogeneous pair trace
-separation at length `6`.  The trace-separation criterion is dual to full pair
-span, and full homogeneous pair span at a positive length propagates to all later
-lengths by multiplying by one-letter words.  Thus we can take `start = period = 6`. -/
+/-- From BNT direct-sum comparison at `L = 2`, get concrete `start = period = 6`
+full homogeneous pair-span windows; length-`6` trace separation becomes full span
+by duality and propagates by one-letter padding. -/
 lemma forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -498,8 +494,7 @@ lemma forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_inject
             hsucc (Nat.lt_of_lt_of_le hSpos (Nat.le_add_right S m)) ih
     exact hTopAdd m
   refine ⟨S, S, hSpos, hSpanS, ?_⟩
-  intro s _hs
-  exact hTopOfLe (Nat.le_add_right S s)
+  intro s _hs; exact hTopOfLe (Nat.le_add_right S s)
 
 /-- Positive-length product-word span from canonical-form/BNT separation and
 one-site injectivity of the BNT blocks.

--- a/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean
@@ -389,18 +389,17 @@ lemma exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock
   exact exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt
     μ A hCF hSep
 
-/-- One-site injectivity of the BNT blocks gives one homogeneous pair-separation
-length for all ordered pairs of distinct blocks.
+/-- One-site injectivity of the BNT blocks gives homogeneous pair separation at length `6`.
 
-The proof specializes the three-block direct-sum theorem to `L = 2`; one-site
+This specializes the three-block direct-sum theorem to `L = 2`; one-site
 injectivity gives the length-`2` and length-`6` fixed-length inputs. -/
-lemma exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+lemma forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A)
     (hIrr : HasIrreducibleBlocks (d := d) A) :
-    ∃ S : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S := by
-  refine exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock
+    ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) (2 + (2 + 2)) := by
+  refine forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock
     (d := d) (dim := dim) μ A hCF hIrr (L := 2) ?_ ?_ ?_
   · intro k
     simpa using isNBlkInjective_mul_of_isNBlkInjective (A k) (N := 1) (m := 2)
@@ -412,89 +411,42 @@ lemma exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_inj
         (hCF.toHasInjectiveBlocks.block_injective k))
   · norm_num
 
-/-- From BNT direct-sum comparison at `L = 2`, get concrete `start = period = 6`
-full homogeneous pair-span windows; length-`6` trace separation becomes full span
-by duality and propagates by one-letter padding. -/
-lemma forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+/-- Existential form of
+`forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks`. -/
+lemma exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
     [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : IsCanonicalFormBNT μ A)
     (hIrr : HasIrreducibleBlocks (d := d) A) :
-    ∀ k j : Fin r, j ≠ k → ∃ start period : ℕ, 0 < period ∧
-      PairWordTupleSpanTop (A k) (A j) period ∧
-      ∀ s : ℕ, s < period → PairWordTupleSpanTop (A k) (A j) (start + s) := by
-  classical
-  have hSep6 : ∀ k j : Fin r, j ≠ k →
-      PairTraceSeparatingAt (A k) (A j) (2 + (2 + 2)) := by
-    refine forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock
-      (d := d) (dim := dim) μ A hCF hIrr (L := 2) ?_ ?_ ?_
-    · intro k
-      simpa using isNBlkInjective_mul_of_isNBlkInjective (A k) (N := 1) (m := 2)
-        (by norm_num) (isNBlkInjective_one_of_isInjective
-          (hCF.toHasInjectiveBlocks.block_injective k))
-    · intro k
-      simpa using isNBlkInjective_mul_of_isNBlkInjective (A k) (N := 1) (m := 6)
-        (by norm_num) (isNBlkInjective_one_of_isInjective
-          (hCF.toHasInjectiveBlocks.block_injective k))
-    · norm_num
-  intro k j hneq
+    ∃ S : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S :=
+  ⟨2 + (2 + 2),
+    forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+      μ A hCF hIrr⟩
+
+/-- From BNT direct-sum comparison at `L = 2`, get a uniform `start = period = 6`
+full homogeneous pair-span window for all ordered pairs of distinct blocks. -/
+lemma exists_forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+    [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : IsCanonicalFormBNT μ A)
+    (hIrr : HasIrreducibleBlocks (d := d) A) :
+    ∃ start period : ℕ, 0 < period ∧
+      ∀ k j : Fin r, j ≠ k →
+        PairWordTupleSpanTop (A k) (A j) period ∧
+        ∀ s : ℕ, s < period → PairWordTupleSpanTop (A k) (A j) (start + s) := by
   let S : ℕ := 2 + (2 + 2)
   have hSpos : 0 < S := by norm_num [S]
+  refine ⟨S, S, hSpos, ?_⟩
+  intro k j hneq
   have hSpanS : PairWordTupleSpanTop (A k) (A j) S := by
     dsimp [S]
-    exact pairWordTupleSpanTop_of_pairTraceSeparatingAt (A k) (A j) (hSep6 k j hneq)
-  have hsucc : ∀ {T : ℕ}, 0 < T → PairWordTupleSpanTop (A k) (A j) T →
-      PairWordTupleSpanTop (A k) (A j) (T + 1) := by
-    intro T hT hTop
-    rcases T with _ | T
-    · cases hT
-    unfold PairWordTupleSpanTop
-    apply eq_top_iff.mpr
-    intro M _
-    have hM : M ∈ Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T + 1))) := by
-      rw [hTop]
-      exact Submodule.mem_top
-    have hle : Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T + 1))) ≤
-        Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) ((T + 1) + 1))) := by
-      apply Submodule.span_le.mpr
-      rintro N ⟨w, rfl⟩
-      let i : Fin d := w 0
-      let tail : Fin T → Fin d := fun j => w j.succ
-      have hletter : pairEvalWordTuple (A k) (A j) [i] ∈
-          Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) 1)) :=
-        pairEvalWordTuple_mem_span_pairWordTuple_length (A k) (A j) [i]
-      have htail : pairEvalWordTuple (A k) (A j) (List.ofFn tail) ∈
-          Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) (T + 1))) := by
-        rw [hTop]
-        exact Submodule.mem_top
-      have hmul :=
-        pair_mul_mem_span_pairWordTuple_add (A := A k) (B := A j)
-          (L := 1) (S := T + 1)
-          (M := pairEvalWordTuple (A k) (A j) [i])
-          (N := pairEvalWordTuple (A k) (A j) (List.ofFn tail)) hletter htail
-      rw [Nat.add_comm 1 (T + 1)] at hmul
-      have hprod :
-          ((pairEvalWordTuple (A k) (A j) [i]).1 *
-              (pairEvalWordTuple (A k) (A j) (List.ofFn tail)).1,
-            (pairEvalWordTuple (A k) (A j) [i]).2 *
-              (pairEvalWordTuple (A k) (A j) (List.ofFn tail)).2) =
-            pairWordTuple (A k) (A j) (T + 1) w := by
-        ext <;> simp [pairWordTuple, pairEvalWordTuple, i, tail]
-      simpa [hprod] using hmul
-    exact hle hM
-  have hTopOfLe : ∀ {T : ℕ}, S ≤ T → PairWordTupleSpanTop (A k) (A j) T := by
-    intro T hST
-    obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hST
-    have hTopAdd : ∀ m : ℕ, PairWordTupleSpanTop (A k) (A j) (S + m) := by
-      intro m
-      induction m with
-      | zero => simpa using hSpanS
-      | succ m ih =>
-          simpa [Nat.add_assoc] using
-            hsucc (Nat.lt_of_lt_of_le hSpos (Nat.le_add_right S m)) ih
-    exact hTopAdd m
-  refine ⟨S, S, hSpos, hSpanS, ?_⟩
-  intro s _hs; exact hTopOfLe (Nat.le_add_right S s)
+    exact pairWordTupleSpanTop_of_pairTraceSeparatingAt (A k) (A j)
+      (forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks
+        μ A hCF hIrr k j hneq)
+  refine ⟨hSpanS, ?_⟩
+  intro s _hs
+  exact pairWordTupleSpanTop_of_le_of_pos (A k) (A j) hSpos
+    (Nat.le_add_right S s) hSpanS
 
 /-- Positive-length product-word span from canonical-form/BNT separation and
 one-site injectivity of the BNT blocks.

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean
@@ -926,6 +926,63 @@ theorem pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop {D₁ D₂ : 
   rw [hSpan]
   exact Submodule.mem_top
 
+/-- Full homogeneous pair span at a positive length propagates by one letter. -/
+theorem pairWordTupleSpanTop_succ_of_pos {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {T : ℕ}
+    (hT : 0 < T) (hTop : PairWordTupleSpanTop A B T) :
+    PairWordTupleSpanTop A B (T + 1) := by
+  classical
+  rcases T with _ | T
+  · cases hT
+  unfold PairWordTupleSpanTop
+  apply eq_top_iff.mpr
+  intro M _
+  have hM : M ∈ Submodule.span ℂ (Set.range (pairWordTuple A B (T + 1))) := by
+    rw [hTop]
+    exact Submodule.mem_top
+  have hle : Submodule.span ℂ (Set.range (pairWordTuple A B (T + 1))) ≤
+      Submodule.span ℂ (Set.range (pairWordTuple A B ((T + 1) + 1))) := by
+    apply Submodule.span_le.mpr
+    rintro N ⟨w, rfl⟩
+    let i : Fin d := w 0
+    let tail : Fin T → Fin d := fun j => w j.succ
+    have hletter : pairEvalWordTuple A B [i] ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B 1)) :=
+      pairEvalWordTuple_mem_span_pairWordTuple_length A B [i]
+    have htail : pairEvalWordTuple A B (List.ofFn tail) ∈
+        Submodule.span ℂ (Set.range (pairWordTuple A B (T + 1))) := by
+      rw [hTop]
+      exact Submodule.mem_top
+    have hmul :=
+      pair_mul_mem_span_pairWordTuple_add (A := A) (B := B)
+        (L := 1) (S := T + 1)
+        (M := pairEvalWordTuple A B [i])
+        (N := pairEvalWordTuple A B (List.ofFn tail)) hletter htail
+    rw [Nat.add_comm 1 (T + 1)] at hmul
+    have hprod :
+        ((pairEvalWordTuple A B [i]).1 * (pairEvalWordTuple A B (List.ofFn tail)).1,
+          (pairEvalWordTuple A B [i]).2 * (pairEvalWordTuple A B (List.ofFn tail)).2) =
+          pairWordTuple A B (T + 1) w := by
+      ext <;> simp [pairWordTuple, pairEvalWordTuple, i, tail]
+    simpa [hprod] using hmul
+  exact hle hM
+
+/-- Full homogeneous pair span at one positive length propagates to every later length. -/
+theorem pairWordTupleSpanTop_of_le_of_pos {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S T : ℕ}
+    (hS : 0 < S) (hST : S ≤ T) (hSpan : PairWordTupleSpanTop A B S) :
+    PairWordTupleSpanTop A B T := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hST
+  have hTopAdd : ∀ k : ℕ, PairWordTupleSpanTop A B (S + k) := by
+    intro k
+    induction k with
+    | zero => simpa using hSpan
+    | succ k ih =>
+        simpa [Nat.add_assoc] using
+          pairWordTupleSpanTop_succ_of_pos A B
+            (Nat.lt_of_lt_of_le hS (Nat.le_add_right S k)) ih
+  exact hTopAdd k
+
 /-- If the homogeneous pair span is full at one positive length, then the
 simultaneous pair identity lies in every sufficiently long homogeneous pair-word
 span. -/
@@ -935,58 +992,10 @@ theorem pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop {D
     ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
       ((1 : Matrix (Fin D₁) (Fin D₁) ℂ), (1 : Matrix (Fin D₂) (Fin D₂) ℂ)) ∈
         Submodule.span ℂ (Set.range (pairWordTuple A B n)) := by
-  classical
-  have hsucc : ∀ {T : ℕ}, 0 < T → PairWordTupleSpanTop A B T →
-      PairWordTupleSpanTop A B (T + 1) := by
-    intro T hT hTop
-    rcases T with _ | T
-    · cases hT
-    unfold PairWordTupleSpanTop
-    apply eq_top_iff.mpr
-    intro M _
-    have hM : M ∈ Submodule.span ℂ (Set.range (pairWordTuple A B (T + 1))) := by
-      rw [hTop]
-      exact Submodule.mem_top
-    have hle : Submodule.span ℂ (Set.range (pairWordTuple A B (T + 1))) ≤
-        Submodule.span ℂ (Set.range (pairWordTuple A B ((T + 1) + 1))) := by
-      apply Submodule.span_le.mpr
-      rintro N ⟨w, rfl⟩
-      let i : Fin d := w 0
-      let tail : Fin T → Fin d := fun j => w j.succ
-      have hletter : pairEvalWordTuple A B [i] ∈
-          Submodule.span ℂ (Set.range (pairWordTuple A B 1)) :=
-        pairEvalWordTuple_mem_span_pairWordTuple_length A B [i]
-      have htail : pairEvalWordTuple A B (List.ofFn tail) ∈
-          Submodule.span ℂ (Set.range (pairWordTuple A B (T + 1))) := by
-        rw [hTop]
-        exact Submodule.mem_top
-      have hmul :=
-        pair_mul_mem_span_pairWordTuple_add (A := A) (B := B)
-          (L := 1) (S := T + 1)
-          (M := pairEvalWordTuple A B [i])
-          (N := pairEvalWordTuple A B (List.ofFn tail)) hletter htail
-      rw [Nat.add_comm 1 (T + 1)] at hmul
-      have hprod :
-          ((pairEvalWordTuple A B [i]).1 * (pairEvalWordTuple A B (List.ofFn tail)).1,
-            (pairEvalWordTuple A B [i]).2 * (pairEvalWordTuple A B (List.ofFn tail)).2) =
-            pairWordTuple A B (T + 1) w := by
-        ext <;> simp [pairWordTuple, pairEvalWordTuple, i, tail]
-      simpa [hprod] using hmul
-    exact hle hM
-  have hTopOfLe : ∀ {T : ℕ}, S ≤ T → PairWordTupleSpanTop A B T := by
-    intro T hST
-    obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hST
-    have hTopAdd : ∀ k : ℕ, PairWordTupleSpanTop A B (S + k) := by
-      intro k
-      induction k with
-      | zero => simpa using hSpan
-      | succ k ih =>
-          simpa [Nat.add_assoc] using
-            hsucc (Nat.lt_of_lt_of_le hS (Nat.le_add_right S k)) ih
-    exact hTopAdd k
   refine ⟨S, ?_⟩
   intro n hn
-  exact pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop A B (hTopOfLe hn)
+  exact pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop A B
+    (pairWordTupleSpanTop_of_le_of_pos A B hS hn hSpan)
 
 /-- A finite residue window plus one period supplies identity padding at every
 sufficiently large length. -/

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -35,6 +35,8 @@ pair-span step.
 
 \begin{lemma}[Identity pair from full homogeneous pair-word span]\label{lem:pair_identity_span_top}
   \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_of_pairWordTupleSpanTop}
+  \lean{MPSTensor.pairWordTupleSpanTop_succ_of_pos}
+  \lean{MPSTensor.pairWordTupleSpanTop_of_le_of_pos}
   \lean{MPSTensor.pairIdentity_mem_pairWordTupleSpan_eventually_of_pairWordTupleSpanTop}
   \leanok
   \uses{def:pair_trace_separation_words}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3156,8 +3156,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock}
+    \lean{MPSTensor.forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
+    \lean{MPSTensor.exists_forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
@@ -3204,8 +3205,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     fixed injective length to positive multiples.  This length-\(6\) trace
     separation is equivalently a full homogeneous pair span; concatenating
     one-letter words propagates fullness to all later homogeneous lengths, so
-    the direct-sum witness also gives a finite pair-span period window.  The
-    same conclusion applies
+    the direct-sum witness also gives a uniform finite pair-span period window.
+    The same conclusion applies
     to normal-CF-BNT data once one-site injectivity is supplied explicitly,
     since the normal-CF-BNT predicate carries the irreducibility and
     normalization hypotheses used in the direct-sum comparison.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3157,6 +3157,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
+    \lean{MPSTensor.forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
     \lean{MPSTensor.exists_pos_productWordSpan_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
@@ -3200,7 +3201,11 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     product-word span required by the selector construction.  Since
     canonical-form/BNT blocks are one-site injective, one may take \(L=2\);
     injectivity at lengths \(2\) and \(6\) then follows by passing from a
-    fixed injective length to positive multiples.  The same conclusion applies
+    fixed injective length to positive multiples.  This length-\(6\) trace
+    separation is equivalently a full homogeneous pair span; concatenating
+    one-letter words propagates fullness to all later homogeneous lengths, so
+    the direct-sum witness also gives a finite pair-span period window.  The
+    same conclusion applies
     to normal-CF-BNT data once one-site injectivity is supplied explicitly,
     since the normal-CF-BNT predicate carries the irreducibility and
     normalization hypotheses used in the direct-sum comparison.


### PR DESCRIPTION
## Summary

Implements the next bounded #1499 bridge lemma in `BlockDiagonalCommutant.lean`:

- `MPSTensor.forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_injectiveBlocks`

The lemma packages the canonical-form/BNT direct-sum comparison into the finite period-window hypothesis needed by the homogeneous padding route: for every ordered pair of distinct blocks, it returns `start = period = 6`, proves `0 < period`, proves `PairWordTupleSpanTop` at the period length, and proves the finite window `PairWordTupleSpanTop` for `start + s`, `s < period`.

## Source route

This follows the CPSV/BNT direct-sum route already formalized nearby:

1. specialize `forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock` to `L = 2`, using one-site injectivity of BNT blocks to obtain the length-`2` and length-`6` block-injectivity inputs;
2. convert length-`6` `PairTraceSeparatingAt` to `PairWordTupleSpanTop` using `pairWordTupleSpanTop_of_pairTraceSeparatingAt`;
3. inline the small homogeneous propagation argument from positive full pair span to all later lengths by multiplying with one-letter words;
4. take the trivial finite window `start = period = 6`.

Blueprint coverage is added to the existing direct-sum dimension-step entry, with prose explaining the length-`6` period-window packaging.

## Validation

- `lake build TNLean.MPS.CanonicalForm.BlockDiagonalCommutant`
- `lake env lean TNLean/MPS/CanonicalForm/BlockDiagonalCommutant.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

## What remains

This does not start #1500/#1501 synthesis.  Remaining #1499 work is to plug this period-window witness into the downstream conditional homogenization/product-span theorem(s) and then continue the non-periodic FT chain.

Refs #1499.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds/repackages Lean lemmas and refactors proof structure without changing computational behavior, though it may affect downstream proofs due to renamed/reshaped theorem statements.
> 
> **Overview**
> Derives a **uniform homogeneous pair-span “period window” witness** from canonical-form/BNT direct-sum separation: for any distinct block pair, it now produces `start = period = 6` together with `PairWordTupleSpanTop` at the period and across the finite residue window.
> 
> Refactors the existing direct-sum pair-separation lemma by introducing a non-existential `forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks` (fixed length `6`) and re-adding the existential wrapper, then uses new pair-span propagation lemmas (`pairWordTupleSpanTop_succ_of_pos`, `pairWordTupleSpanTop_of_le_of_pos`) to extend fullness to later lengths.
> 
> Updates the blueprint LaTeX to reference the new homogenization lemmas and to document the new period-window packaging in the parent-Hamiltonian direct-sum discussion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c9e3278baee5d531b30d67cfd971979aa1cedc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->