### PR TITLE
fix(blueprint): demote sector-comparison label prefix thm: to lem:

### DIFF
--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1482,8 +1482,8 @@ BNT comparison hypotheses for the common primitive sectors.
 	common-sector comparison theorem with those span hypotheses.
 \end{proof}
 
-\begin{theorem}[Sector comparison from relabelled common sectors and proportional data]%
-\label{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
+\begin{lemma}[Sector comparison from relabelled common sectors and proportional data]%
+\label{lem:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
 	\lean{MPSTensor.afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}
 	\leanok
 	\uses{def:common_primitive_proportional_hypotheses,
@@ -1508,7 +1508,8 @@ BNT comparison hypotheses for the common primitive sectors.
 	for a permutation $\pi$, gauges $X_j$, and nonzero phases
 	$\zeta_j \in \C^\times$, then the blocked sector decompositions have the
 	matched sector-weight conclusion of the source theorem.
-\end{theorem}
+\end{lemma}
+
 
 \begin{theorem}[Common sectors from BNT matching hypotheses]%
 \label{thm:afterBlocking_sectorComparison_reindexed_bntCover}


### PR DESCRIPTION
Closes #1536.

Changes:
- Renames `\label{thm:afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional}` to `\label{lem:...}`
- Changes enclosing environment from `theorem` to `lemma`

No `\ref` references to this label were found in any `.tex` file, so no reference updates were needed.

Validation:
- `git diff --check` passed
- `python3 scripts/blueprint_lean_sync.py --root . --ci` ran (pre-existing sync issues only)
- `cd blueprint && leanblueprint web` completed successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that renames a LaTeX label and demotes an environment from `theorem` to `lemma`, with no functional or mathematical content changes.
> 
> **Overview**
> Renames the sector-comparison statement `afterBlocking_sectorComparison_zeroTail_of_reindexedNonzeroParts_proportional` from a `theorem` to a `lemma`, updating its `\label` prefix from `thm:` to `lem:` in `ch11_fundamental_theorem_proof.tex`.
> 
> No other references required updating (no `\ref{thm:...}` usages were found).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a6aeea4af31c87ad14784a74ce2721f562cf43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->