### PR TITLE
feat(MPS/CanonicalForm): add SameMPV₂ wrapper for BNT decomp data

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -392,8 +392,8 @@ def ofNormalCanonicalFormBNT_zeroTailIdentity
 /-- Construct `ProportionalDecompositionData` for two normal-CF-BNT block families
 whose assembled block-diagonal tensors generate the same MPV family.
 
-For the equal-MPV case the proportional decomposition is essentially trivial:
-the per-block coefficients are the constant block-weight families `μA`, `μB`
+For the equal-MPV case the proportional decomposition uses constant data:
+the per-block coefficients are the block-weight families `μA`, `μB`
 themselves (nonzero by `IsNormalCanonicalForm.mu_ne_zero`), the proportionality
 ratio is identically `1`, and the substantive content is the block-diagonal MPV
 identity `mpv (toTensorFromBlocks μ A) σ = ∑_k μ_k * mpv (A_k) σ` together with

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -389,23 +389,24 @@ def ofNormalCanonicalFormBNT_zeroTailIdentity
   exact ofNormalCanonicalFormBNT hA hB
     (zeroTail_eq_of_proportionalDecompositionConclusion hZero hMatch) hInjA hInjB hDecomp
 
-/-- Construct `ProportionalDecompositionData` for two normal-CF-BNT block families
-whose assembled block-diagonal tensors generate the same MPV family, once the
-block-weight power coefficient families have specified nonzero limits.
+/-- Construct `ProportionalDecompositionData` for two assembled block-diagonal tensor
+families with the same MPV family, once the block-weight power coefficient families
+have specified nonzero limits.
 
 The block-diagonal MPV expansion has coefficients `(μA j) ^ N` and `(μB k) ^ N` at
 length `N`, as in `mpv_toTensorFromBlocks_eq_sum`.  Therefore this constructor keeps
 the required coefficient convergence as an explicit input; it does not replace the
 spectral/power-sum comparison needed to obtain such nonzero limits in the general
-BNT setting.  The proportionality ratio is identically `1`, supplied by `SameMPV₂`. -/
-noncomputable def proportionalDecompositionData_of_sameMPV_of_isNormalCanonicalFormBNT
+BNT setting.  The proportionality ratio is identically `1`, supplied by `SameMPV₂`.
+
+This construction is formal in the block families and does not use normal-CF-BNT
+hypotheses; callers add those hypotheses when assembling `CommonPrimitiveBNTCoverHypotheses`. -/
+noncomputable def proportionalDecompositionData_of_sameMPV_toTensorFromBlocks
     {d rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
     {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
     (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
-    (_hA : IsNormalCanonicalFormBNT (d := d) μA blocksA)
-    (_hB : IsNormalCanonicalFormBNT (d := d) μB blocksB)
     (aLim : Fin rA → ℂ) (bLim : Fin rB → ℂ)
     (haCoeff : ∀ j, Filter.Tendsto (fun N : ℕ => (μA j) ^ N) Filter.atTop (nhds (aLim j)))
     (hbCoeff : ∀ k, Filter.Tendsto (fun N : ℕ => (μB k) ^ N) Filter.atTop (nhds (bLim k)))

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -389,6 +389,50 @@ def ofNormalCanonicalFormBNT_zeroTailIdentity
   exact ofNormalCanonicalFormBNT hA hB
     (zeroTail_eq_of_proportionalDecompositionConclusion hZero hMatch) hInjA hInjB hDecomp
 
+/-- Construct `ProportionalDecompositionData` for two normal-CF-BNT block families
+whose assembled block-diagonal tensors generate the same MPV family.
+
+For the equal-MPV case the proportional decomposition is essentially trivial:
+the per-block coefficients are the constant block-weight families `μA`, `μB`
+themselves (nonzero by `IsNormalCanonicalForm.mu_ne_zero`), the proportionality
+ratio is identically `1`, and the substantive content is the block-diagonal MPV
+identity `mpv (toTensorFromBlocks μ A) σ = ∑_k μ_k * mpv (A_k) σ` together with
+the `SameMPV₂` hypothesis. -/
+noncomputable def proportionalDecompositionData_of_sameMPV_of_isNormalCanonicalFormBNT
+    {d rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
+    (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsNormalCanonicalFormBNT (d := d) μA blocksA)
+    (hB : IsNormalCanonicalFormBNT (d := d) μB blocksB)
+    (hSame : SameMPV₂
+      (toTensorFromBlocks (d := d) (μ := μA) blocksA)
+      (toTensorFromBlocks (d := d) (μ := μB) blocksB)) :
+    ProportionalDecompositionData (d := d) blocksA blocksB
+      (∑ j : Fin rA, dimA j) (∑ k : Fin rB, dimB k) where
+  A_total := toTensorFromBlocks (d := d) (μ := μA) blocksA
+  B_total := toTensorFromBlocks (d := d) (μ := μB) blocksB
+  aCoeff := fun _ j => μA j
+  bCoeff := fun _ k => μB k
+  aLim := μA
+  bLim := μB
+  c := fun _ => 1
+  cLim := 1
+  hA_decomp := fun _ σ => by
+    simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum (d := d) μA blocksA σ
+  hB_decomp := fun _ σ => by
+    simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum (d := d) μB blocksB σ
+  haCoeff := fun _ => tendsto_const_nhds
+  hbCoeff := fun _ => tendsto_const_nhds
+  haLim_ne := hA.toIsNormalCanonicalForm.mu_ne_zero
+  hbLim_ne := hB.toIsNormalCanonicalForm.mu_ne_zero
+  hProp := fun N σ => by
+    rw [one_mul]
+    exact hSame N σ
+  hc := tendsto_const_nhds
+  hcLim_ne := one_ne_zero
+
 /-- Representative common-sector families give the BNT-cover hypotheses once the
 representative weights are strictly ordered, representatives are BNT-separated, and the
 remaining zero-tail, injectivity, and proportional-decomposition inputs are supplied. -/

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean
@@ -390,22 +390,26 @@ def ofNormalCanonicalFormBNT_zeroTailIdentity
     (zeroTail_eq_of_proportionalDecompositionConclusion hZero hMatch) hInjA hInjB hDecomp
 
 /-- Construct `ProportionalDecompositionData` for two normal-CF-BNT block families
-whose assembled block-diagonal tensors generate the same MPV family.
+whose assembled block-diagonal tensors generate the same MPV family, once the
+block-weight power coefficient families have specified nonzero limits.
 
-For the equal-MPV case the proportional decomposition uses constant data:
-the per-block coefficients are the block-weight families `μA`, `μB`
-themselves (nonzero by `IsNormalCanonicalForm.mu_ne_zero`), the proportionality
-ratio is identically `1`, and the substantive content is the block-diagonal MPV
-identity `mpv (toTensorFromBlocks μ A) σ = ∑_k μ_k * mpv (A_k) σ` together with
-the `SameMPV₂` hypothesis. -/
+The block-diagonal MPV expansion has coefficients `(μA j) ^ N` and `(μB k) ^ N` at
+length `N`, as in `mpv_toTensorFromBlocks_eq_sum`.  Therefore this constructor keeps
+the required coefficient convergence as an explicit input; it does not replace the
+spectral/power-sum comparison needed to obtain such nonzero limits in the general
+BNT setting.  The proportionality ratio is identically `1`, supplied by `SameMPV₂`. -/
 noncomputable def proportionalDecompositionData_of_sameMPV_of_isNormalCanonicalFormBNT
     {d rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
     {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
     (blocksA : (j : Fin rA) → MPSTensor d (dimA j))
     (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
-    (hA : IsNormalCanonicalFormBNT (d := d) μA blocksA)
-    (hB : IsNormalCanonicalFormBNT (d := d) μB blocksB)
+    (_hA : IsNormalCanonicalFormBNT (d := d) μA blocksA)
+    (_hB : IsNormalCanonicalFormBNT (d := d) μB blocksB)
+    (aLim : Fin rA → ℂ) (bLim : Fin rB → ℂ)
+    (haCoeff : ∀ j, Filter.Tendsto (fun N : ℕ => (μA j) ^ N) Filter.atTop (nhds (aLim j)))
+    (hbCoeff : ∀ k, Filter.Tendsto (fun N : ℕ => (μB k) ^ N) Filter.atTop (nhds (bLim k)))
+    (haLim_ne : ∀ j, aLim j ≠ 0) (hbLim_ne : ∀ k, bLim k ≠ 0)
     (hSame : SameMPV₂
       (toTensorFromBlocks (d := d) (μ := μA) blocksA)
       (toTensorFromBlocks (d := d) (μ := μB) blocksB)) :
@@ -413,20 +417,20 @@ noncomputable def proportionalDecompositionData_of_sameMPV_of_isNormalCanonicalF
       (∑ j : Fin rA, dimA j) (∑ k : Fin rB, dimB k) where
   A_total := toTensorFromBlocks (d := d) (μ := μA) blocksA
   B_total := toTensorFromBlocks (d := d) (μ := μB) blocksB
-  aCoeff := fun _ j => μA j
-  bCoeff := fun _ k => μB k
-  aLim := μA
-  bLim := μB
+  aCoeff := fun N j => (μA j) ^ N
+  bCoeff := fun N k => (μB k) ^ N
+  aLim := aLim
+  bLim := bLim
   c := fun _ => 1
   cLim := 1
   hA_decomp := fun _ σ => by
     simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum (d := d) μA blocksA σ
   hB_decomp := fun _ σ => by
     simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum (d := d) μB blocksB σ
-  haCoeff := fun _ => tendsto_const_nhds
-  hbCoeff := fun _ => tendsto_const_nhds
-  haLim_ne := hA.toIsNormalCanonicalForm.mu_ne_zero
-  hbLim_ne := hB.toIsNormalCanonicalForm.mu_ne_zero
+  haCoeff := haCoeff
+  hbCoeff := hbCoeff
+  haLim_ne := haLim_ne
+  hbLim_ne := hbLim_ne
   hProp := fun N σ => by
     rw [one_mul]
     exact hSame N σ

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1205,6 +1205,7 @@ BNT comparison hypotheses for the common primitive sectors.
 	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT_zeroTailIdentity,
+		MPSTensor.CommonPrimitiveBNTCoverHypotheses.proportionalDecompositionData_of_sameMPV_of_isNormalCanonicalFormBNT,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentatives_zeroTailIdentity,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentativeBNTCoverHypotheses,
 		MPSTensor.zeroTail_eq_of_proportionalDecompositionConclusion}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1205,7 +1205,7 @@ BNT comparison hypotheses for the common primitive sectors.
 	\lean{MPSTensor.CommonPrimitiveBNTCoverHypotheses,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofNormalCanonicalFormBNT_zeroTailIdentity,
-		MPSTensor.CommonPrimitiveBNTCoverHypotheses.proportionalDecompositionData_of_sameMPV_of_isNormalCanonicalFormBNT,
+		MPSTensor.CommonPrimitiveBNTCoverHypotheses.proportionalDecompositionData_of_sameMPV_toTensorFromBlocks,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentatives_zeroTailIdentity,
 		MPSTensor.CommonPrimitiveBNTCoverHypotheses.ofCommonRepresentativeBNTCoverHypotheses,
 		MPSTensor.zeroTail_eq_of_proportionalDecompositionConclusion}
@@ -1217,8 +1217,8 @@ BNT comparison hypotheses for the common primitive sectors.
 	normal canonical form on both sides, no phase-gauge-equivalent distinct
 	blocks in either family, equality \(z_A=z_B\) of the leftover all-zero block
 	dimensions, one-site injectivity, and proportionality of the two block MPV
-	families.  The tagged constructor from equal MPVs uses the correct
-	block-diagonal expansion coefficients \(\mu_j^N\), so the convergence and
+	families.  The tagged constructor from equal MPVs is formal in the assembled
+	block-diagonal tensors and uses the correct expansion coefficients \(\mu_j^N\), so the convergence and
 	nonzero-limit data for those coefficient families remain explicit inputs.
 	Its output is the source-form matching
 	\(B_{\pi(j)}^i=e^{i\phi_j}X_jA_j^iX_j^{-1}\), hence

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1217,7 +1217,10 @@ BNT comparison hypotheses for the common primitive sectors.
 	normal canonical form on both sides, no phase-gauge-equivalent distinct
 	blocks in either family, equality \(z_A=z_B\) of the leftover all-zero block
 	dimensions, one-site injectivity, and proportionality of the two block MPV
-	families.  Its output is the source-form matching
+	families.  The tagged constructor from equal MPVs uses the correct
+	block-diagonal expansion coefficients \(\mu_j^N\), so the convergence and
+	nonzero-limit data for those coefficient families remain explicit inputs.
+	Its output is the source-form matching
 	\(B_{\pi(j)}^i=e^{i\phi_j}X_jA_j^iX_j^{-1}\), hence
 	\(\ket{V^{(N)}(B_{\pi(j)})}=e^{iN\phi_j}\ket{V^{(N)}(A_j)}\).
 


### PR DESCRIPTION
### Motivation

- Issue #1501/#1542 needs a way to package equal-MPV information into `ProportionalDecompositionData` for the common-primitive BNT comparison pipeline.
- Review correctly identified that the block-diagonal expansion of `toTensorFromBlocks` uses coefficients `(μ j)^N`, not constant coefficients `μ j`.
- Therefore this PR keeps the coefficient-limit data explicit: `SameMPV₂` supplies the proportionality relation with ratio `1`, while callers must still provide convergence and nonzero limits for the power coefficient families.
- A later review also noted that this construction does not actually use normal-CF-BNT hypotheses, so the helper is now named and typed as the general formal wrapper it is.

### Description

- Adds `CommonPrimitiveBNTCoverHypotheses.proportionalDecompositionData_of_sameMPV_toTensorFromBlocks` in `CommonPrimitiveProportionalData.lean`.
- The constructor uses the mathematically correct coefficients:
  - `aCoeff N j = (μA j)^N`
  - `bCoeff N k = (μB k)^N`
- The fields `aLim`, `bLim`, their convergence proofs, and nonzero-limit proofs are explicit hypotheses.
- The total tensors are the assembled block tensors, the decomposition equalities come from `mpv_toTensorFromBlocks_eq_sum`, and `hProp` comes from `SameMPV₂` after `one_mul`.
- The helper no longer takes unused `IsNormalCanonicalFormBNT` arguments; normality/BNT hypotheses enter later when assembling `CommonPrimitiveBNTCoverHypotheses`.
- Updates the blueprint entry for `CommonPrimitiveBNTCoverHypotheses` to document that these power-coefficient limits remain explicit inputs.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveProportionalData.lean`
- `python3 scripts/check_oversized_lean_files.py --root . --known TNLean/MPS/ParentHamiltonian/Martingale.lean --known TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean`
- `git diff --check`
- Diff grep found no new `sorry`, `axiom`, `native_decide`, `unsafeCast`, or `admit`.

Related to #1542 and #1501.
