### PR TITLE
feat(Wielandt): bound injective blocking for normal left-canonical tensors

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.SectorComparison.TPPrimitiveReduction
 import TNLean.MPS.Chain.BlockedChainFT
+import TNLean.Wielandt.SourceTheorems.WielandtInequality
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 open Filter
@@ -217,6 +218,74 @@ For the pre-blocking blocks (which ARE irreducible), the chain to IsNormal
 works directly. This shows that the original nonzero-weight blocks become
 normal once we know their transfer maps are primitive.
 -/
+
+
+/-- **Left-canonical normal tensor → bounded positive injective blocking**.
+
+This is the blocked-injectivity form of the quantum Wielandt bound needed by the
+canonical-form comparison chain.  The trace-preserving/left-canonical hypothesis rules out the
+scalar zero-physical-letter edge case and supplies a nonzero one-step Kraus matrix, which makes
+the general index bound `(D ^ 2 - krausRank A + 1) * D ^ 2` at most `D ^ 4`.
+
+The conclusion is stated for `blockTensor` because this is the form consumed by the BNT-sector
+comparison infrastructure. -/
+theorem exists_pos_blockTensor_isInjective_le_pow_four_of_isNormal_leftCanonical [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hN : IsNormal A) :
+    ∃ L : ℕ, 0 < L ∧ L ≤ D ^ 4 ∧ IsInjective (blockTensor A L) := by
+  by_cases hD1 : D = 1
+  · subst D
+    have hInj : IsInjective A :=
+      isInjective_of_dim_one_of_exists_nonzero A (exists_nonzero_kraus_of_tp A hTP)
+    refine ⟨1, Nat.zero_lt_one, by norm_num, ?_⟩
+    exact (isNBlkInjective_iff_blockTensor_isInjective A 1).1
+      (isNBlkInjective_one_of_isInjective hInj)
+  · have hDpos : 0 < D := NeZero.pos D
+    have hD2 : 2 ≤ D := by omega
+    let L : ℕ := iIndex A
+    have hNonempty : ({n : ℕ | wordSpan A n = ⊤}).Nonempty := by
+      obtain ⟨N, hNblk⟩ := hN
+      exact ⟨N, (wordSpan_eq_top_iff_isNBlkInjective A N).mpr hNblk⟩
+    have hTop : wordSpan A L = ⊤ := by
+      simpa [L, iIndex] using Nat.sInf_mem hNonempty
+    have hIndexBound : L ≤ (D ^ 2 - krausRank A + 1) * D ^ 2 := by
+      simpa [L] using
+        iIndex_le_general_of_isPrimitivePaper A hTP (isPrimitivePaper_of_isNormal A hN)
+    have hKraus_pos : 1 ≤ krausRank A := by
+      rw [krausRank, Nat.one_le_iff_ne_zero]
+      intro hzero
+      have hbot : wordSpan A 1 = (⊥ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) :=
+        Submodule.finrank_eq_zero.mp hzero
+      obtain ⟨i₀, hi₀⟩ := exists_nonzero_kraus_of_tp A hTP
+      have hmem : A i₀ ∈ wordSpan A 1 := by
+        have := evalWord_mem_wordSpan A ([i₀] : List (Fin d))
+        simpa [evalWord] using this
+      rw [hbot] at hmem
+      exact hi₀ hmem
+    have hDsq_pos : 1 ≤ D ^ 2 := by
+      nlinarith
+    have hFactor : D ^ 2 - krausRank A + 1 ≤ D ^ 2 := by
+      by_cases hKraus_le : krausRank A ≤ D ^ 2
+      · omega
+      · have hsub : D ^ 2 - krausRank A = 0 :=
+          Nat.sub_eq_zero_of_le (le_of_not_ge hKraus_le)
+        rw [hsub]
+        exact hDsq_pos
+    have hBound : L ≤ D ^ 4 := by
+      calc
+        L ≤ (D ^ 2 - krausRank A + 1) * D ^ 2 := hIndexBound
+        _ ≤ D ^ 2 * D ^ 2 := Nat.mul_le_mul_right _ hFactor
+        _ = D ^ 4 := by ring
+    have hLpos : 0 < L := by
+      by_contra hnot
+      have hL0 : L = 0 := Nat.eq_zero_of_not_pos hnot
+      have hzeroTop : wordSpan A 0 = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) := by
+        simpa [hL0] using hTop
+      exact wordSpan_zero_ne_top_of_two_le A hD2 hzeroTop
+    refine ⟨L, hLpos, hBound, ?_⟩
+    exact (isNBlkInjective_iff_blockTensor_isInjective A L).1
+      ((wordSpan_eq_top_iff_isNBlkInjective A L).mp hTop)
 
 /-- **Pre-blocking blocks are normal once primitive.**
 

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -973,6 +973,35 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     so $S_n(A^{[L]}) \subseteq S_{nL}(A)$.
 \end{proof}
 
+
+\begin{theorem}[Bounded injective blocking for left-canonical normal tensors]%
+\label{thm:bounded_injective_blocking_normal_left_canonical}
+    \lean{MPSTensor.exists_pos_blockTensor_isInjective_le_pow_four_of_isNormal_leftCanonical}
+    \leanok
+    \uses{def:normal, def:blocked_tensor, thm:wielandt_bound}
+    Let $A$ be a left-canonical normal MPS tensor with bond dimension $D>0$.
+    Then there is a positive blocking length $L \le D^4$ such that the blocked
+    tensor $A^{[L]}$ is one-site injective.
+
+    This is the blocked-injectivity form of the quantum Wielandt input used in
+    the non-periodic Fundamental Theorem chain.  It corresponds to the statement
+    in \cite[Section~II, line~332]{Cirac2016MPDO_arXiv} that every normal tensor
+    becomes injective after at most $D^4$ blockings, using the index estimate of
+    \cite[Theorem~1]{Sanz2010Quantum}.  The Lean statement includes the
+    left-canonical/trace-preserving hypothesis because that is the canonical-form
+    context in which the blocked-injectivity input is consumed.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The proof uses the full-Kraus-rank index bound from the quantum Wielandt
+    inequality.  Since $A$ is normal, the index is attained; the one-step Kraus
+    rank is nonzero in the left-canonical case, so the bound
+    $(D^2-\operatorname{rank}S_1(A)+1)D^2$ is at most $D^4$.  The bridge from
+    exact word-span fullness to injectivity of the blocked tensor is
+    Lemma~\ref{lem:blocking_transfer}.
+\end{proof}
+
 \begin{remark}[Relation with the rank-one extraction lemma]\label{rem:lemma2b_status}\leanok
     In~\cite{Sanz2010Quantum}, Lemma~2(b) combines a rank-one
     extraction for fixed-length spans with a product

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2658,7 +2658,8 @@ do not correspond to independent paper-level results.
 
 \begin{theorem}[TP-primitive irreducible tensor is injective after blocking]%
 	\label{thm:tp_primitive_irred_block_injective}
-	\lean{MPSTensor.exists_blockTensor_isInjective_of_tp_primitive_irreducible}
+	\lean{MPSTensor.exists_blockTensor_isInjective_of_tp_primitive_irreducible,
+		MPSTensor.exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible}
 	\leanok
 	\uses{thm:normal_tp_primitive_irred,
 		lem:isNBlkInjective_iff_blockTensor_isInjective}


### PR DESCRIPTION
### Motivation

#1543 tracks the Wielandt-blocked injectivity input for the non-periodic FT chain: normal blocks should become one-site injective after a bounded positive blocking length.

The project definition `IsNormal` permits a zero-length normality witness.  In the scalar zero-physical-letter edge case this is too weak to force any positive-length injective blocking.  The canonical-form route, however, always has the left-canonical / trace-preserving normalization.  This PR therefore proves the source-faithful canonical-form version with the left-canonical hypothesis explicit.

### Source anchors

- CPSV16, arXiv:1606.00608 §II, line 332: every normal tensor becomes injective after at most `D^4` blockings.
- Sanz–Pérez-García–Wolf–Cirac, arXiv:0909.5347 Theorem 1: the full-Kraus-rank index estimate `(D^2 - rank S_1(A) + 1) D^2`, used here to obtain the `D^4` bound.

### Description

Adds:

```lean
MPSTensor.exists_pos_blockTensor_isInjective_le_pow_four_of_isNormal_leftCanonical
```

in `TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean`.

The theorem states: if `A` is left-canonical and `IsNormal A`, then there exists `L` such that

```lean
0 < L ∧ L ≤ D ^ 4 ∧ IsInjective (blockTensor A L)
```

Proof route:
- `IsNormal A` gives an attained full word-span index via `Nat.sInf_mem`.
- `iIndex_le_general_of_isPrimitivePaper` gives the `(D^2 - krausRank A + 1) * D^2` bound after converting `IsNormal` to `IsPrimitivePaper`.
- left-canonical normalization gives a nonzero one-step Kraus matrix, hence `1 ≤ krausRank A`, so the index bound is at most `D^4`.
- exact word-span fullness is converted to `IsInjective (blockTensor A L)` by `isNBlkInjective_iff_blockTensor_isInjective`.
- the scalar `D = 1` case uses the left-canonical hypothesis to produce a nonzero Kraus matrix and direct one-site injectivity at `L = 1`.

Blueprint coverage was added in `ch07_wielandt.tex` with the source-line note.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py --root . --known TNLean/MPS/ParentHamiltonian/Martingale.lean --known TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization.lean`
- `git diff --check`
- Diff grep found no new `sorry`, `axiom`, `native_decide`, `unsafeCast`, or `admit`.

Contributes to #1543 and the #1498 non-periodic FT chain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new theorem and supporting proof/blueprint documentation without changing existing APIs or runtime behavior; main risk is proof fragility due to additional dependencies and arithmetic bounds.
> 
> **Overview**
> Adds `exists_pos_blockTensor_isInjective_le_pow_four_of_isNormal_leftCanonical`, giving a **positive** blocking length `L` with `L ≤ D^4` such that `blockTensor A L` is one-site injective for **left-canonical (TP) normal** tensors, handling the `D = 1` and `D ≥ 2` edge cases explicitly.
> 
> Wires this result into the blueprint by introducing a corresponding Wielandt chapter theorem statement/proof sketch, and updates the canonical-form blueprint to also reference the existing positive-blocking injectivity theorem for TP-primitive irreducible tensors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449ab6b1c725520efb41134328ef4a03478f92f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->