### PR TITLE
doc(blueprint+MPS/ParentHamiltonian): reorder chapters, cite Sanz, drop jargon

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -42,7 +42,8 @@ with the periodic boundary condition:
 * `MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective` — cyclic
   normal-range constraints imply open-chain ground-space membership
 * `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes`
-  — the algebraic MPV-line endgame once long-word commutation is known
+  — once a boundary matrix commutes with all long-enough word products, its
+  boundary contraction lies in the MPV span
 * `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility`
   — same-witness common-middle compatibilities imply MPV-line membership
 * `MPSTensor.groundSpace_unique_periodic` — uniqueness on the periodic chain
@@ -655,7 +656,8 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes
   simp only [groundSpaceMap_apply, Pi.smul_apply, smul_eq_mul, mpv, coeff]
   rw [hX_eq, Algebra.mul_smul_comm, mul_one, Matrix.trace_smul, smul_eq_mul]
 
-/-- Positive-length word commutation is enough for the MPV-line endgame.
+/-- Boundary contraction lies in the MPV span when `X` commutes with words of
+some positive length.
 
 If `X` commutes with all words of any positive length `m`, then chunking gives
 commutation at the multiple `L₀ * m`, which is at least `L₀`.  The long-word

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -674,8 +674,9 @@ theorem commutes_words_of_two_sided_middle_compatibility
 with all words whose length is any multiple of `m`.
 
 The proof chunks a list of length `q * m` into a length-`m` prefix and a shorter
-multiple-length suffix. This formalizes the amplification observation used to
-feed positive-length commutation into the block-injective long-word endgame. -/
+multiple-length suffix. This formalizes the amplification step that promotes
+fixed-length commutation to the long-word commutation hypothesis required by
+the block-injective boundary-contraction theorem. -/
 theorem commutes_words_mul_of_commutes_words {A : MPSTensor d D}
     {m q : ℕ} {X : Matrix (Fin D) (Fin D) ℂ}
     (hComm : ∀ ω : Fin m → Fin d,

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -611,10 +611,9 @@ The results follow~\cite{Sanz2010Quantum}.
     \[
         S_{D^2-\krausrk(A)+1}(A)=\MN{D}.
     \]
-    In the terminology of Sanz--Pérez-García--Wolf--Cirac, this is
-    the case where the first application space $S_1(A)$ contains an
-    invertible operator. This is the exact word-span form of
-    \cite[Theorem~1, case~(2)]{Sanz2010Quantum}.
+    In the terminology of~\cite{Sanz2010Quantum}, this is the case where
+    the first application space $S_1(A)$ contains an invertible operator.
+    This is the exact word-span form of~\cite[Theorem~1, case~(2)]{Sanz2010Quantum}.
 \end{theorem}
 
 \begin{proof}
@@ -719,11 +718,10 @@ The results follow~\cite{Sanz2010Quantum}.
         S_{D^2}(A)=\MN{D}.
     \]
     More explicitly, it is enough to have $X\varphi=\mu\varphi$ with
-    $\varphi\ne 0$ and $\mu\ne 0$. In the terminology of
-    Sanz--Pérez-García--Wolf--Cirac, this is the case where the first
-    application space $S_1(A)$ contains a non-invertible operator with a
-    nonzero eigenvalue. This is the exact word-span form of
-    \cite[Theorem~1, case~(3)]{Sanz2010Quantum}.
+    $\varphi\ne 0$ and $\mu\ne 0$. In the terminology of~\cite{Sanz2010Quantum},
+    this is the case where the first application space $S_1(A)$ contains a
+    non-invertible operator with a nonzero eigenvalue. This is the exact
+    word-span form of~\cite[Theorem~1, case~(3)]{Sanz2010Quantum}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -10,8 +10,8 @@
 \input{chapter/ch09_block_perm}
 \input{chapter/ch10_bnt}
 \input{chapter/ch11_fundamental_theorem_proof}
-\input{chapter/ch11b_periodic_ft}
 \input{chapter/ch13b_symmetry}
+\input{chapter/ch11b_periodic_ft}
 \input{chapter/ch13_algebraic_ft}
 \input{chapter/ch13a_peps_ft}
 \input{chapter/ch12_semigroup}


### PR DESCRIPTION
### Motivation

- Issue #1530 item 3: move "Symmetries and String Order" to immediately after "Proof of Fundamental Theorem" in the blueprint chapter ordering.
- Issue #1530 item 14: replace inline author-list phrases ("Sanz–Pérez-García–Wolf–Cirac") with `\cite{Sanz2010Quantum}` in the Wielandt chapter, matching citation style used elsewhere.
- Replace non-mathematical "MPV-line endgame" jargon in `MPS/ParentHamiltonian` docstrings with plain mathematical language describing boundary contraction in the MPV span and amplification to long-word commutation.

### Description

- `blueprint/src/content.tex`: placed "Symmetries and String Order" immediately after chapter 12 ("Proof of the Fundamental Theorem"), before the periodic FT chapter.
- `blueprint/src/chapter/ch07_wielandt.tex`: replaced inline "Sanz–Pérez-García–Wolf–Cirac" author-list phrases in the case-(2) and case-(3) Wielandt theorems with `\cite{Sanz2010Quantum}`.
- `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`: replaced "MPV-line endgame" in module summary and theorem docstrings with "boundary contraction lying in the MPV span".
- `TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`: updated docstrings to describe the amplification-to-long-word-commutation step in mathematical terms. No proof terms changed.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) and Blueprint Lint (`lint-blueprint.yml`) to validate build and blueprint label references.

---
Addresses #1530

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates docstrings/comments and blueprint LaTeX wording/include ordering; no proof terms or definitions change, so risk is limited to documentation/build ordering regressions.
> 
> **Overview**
> Clarifies the documentation around the block-injective "boundary contraction to MPV span" endgame by rewording comments in `UniqueGroundState.lean` and `WrappingWindow.lean` (including explicitly tying fixed-length commutation amplification to the long-word commutation hypothesis).
> 
> Polishes blueprint text in `ch07_wielandt.tex` (citation wording/line breaks) and reorders `blueprint/src/content.tex` to include `ch11b_periodic_ft` later in the document.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa80bf1cb738ceebbd81745a1cca9a1e58d9ffee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->