### PR TITLE
feat(MPS): add flattened iterated blocking map

### DIFF
--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -527,7 +527,7 @@ theorem mpv_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
     mpv (reindexPhysical f A) σ = mpv A (fun n => f (σ n)) := by
   simp [mpv, coeff, evalWord_reindexPhysical, List.map_ofFn, Function.comp_def]
 
-/-- Physical reindexing preserves heterogeneous MPV equality. -/
+/-- Physical reindexing preserves MPV equality for tensors of arbitrary bond dimensions. -/
 theorem sameMPV₂_reindexPhysical {d₁ d₂ D₁ D₂ : ℕ} (f : Fin d₁ → Fin d₂)
     {A : MPSTensor d₂ D₁} {B : MPSTensor d₂ D₂}
     (hSame : SameMPV₂ A B) :
@@ -595,9 +595,9 @@ theorem reindexPhysical_directToIteratedBlockIndex_blockTensor {D : ℕ}
 /-- Refine a tensor already blocked by `p` through a further length-`L` blocking, but expose
 the resulting physical alphabet as the direct length-`p * L` alphabet.
 
-This is the small conceptual interface for flattened iterated blocking: it is ordinary blocking
-over the already blocked alphabet, followed by the canonical grouping map from direct
-length-`p * L` physical indices to iterated length-`L` indices. -/
+It is ordinary length-`L` blocking over the already blocked alphabet, followed by
+physical reindexing along the canonical grouping map from direct length-`p * L`
+indices to iterated length-`L` indices. -/
 noncomputable def flattenedIteratedBlockTensor
     {d p D : ℕ}
     (A : MPSTensor (blockPhysDim d p) D) (L : ℕ) :
@@ -645,9 +645,9 @@ theorem toTensorFromBlocks_flattenedIteratedBlockTensor
 /-- Full MPV equality of assembled weighted block tensors is preserved after a further
 flattened iterated blocking, with the direct length-`p * L` physical alphabet exposed.
 
-This is the reusable bridge to the existing iterated-blocking results: the proof applies
-`sameMPV₂_toTensorFromBlocks_blockPower` over the already blocked alphabet and uses the
-grouping map to return to direct length-`p * L` indices. -/
+The proof applies `sameMPV₂_toTensorFromBlocks_blockPower` over the already blocked
+alphabet and uses the grouping map to express the result on direct length-`p * L`
+indices. -/
 theorem sameMPV₂_toTensorFromBlocks_flattenedIteratedBlockPower
     {d p rA rB L : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     (μA : Fin rA → ℂ)

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -513,6 +513,29 @@ noncomputable def reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂
     (A : MPSTensor d₂ D) : MPSTensor d₁ D :=
   fun i => A (f i)
 
+/-- Word evaluation after physical reindexing is word evaluation on the mapped word. -/
+theorem evalWord_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
+    (A : MPSTensor d₂ D) (w : List (Fin d₁)) :
+    evalWord (reindexPhysical f A) w = evalWord A (w.map f) := by
+  induction w with
+  | nil => simp
+  | cons i w ih => simp [evalWord, reindexPhysical, ih]
+
+/-- MPVs after physical reindexing are MPVs on the reindexed configuration. -/
+theorem mpv_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
+    (A : MPSTensor d₂ D) {N : ℕ} (σ : Fin N → Fin d₁) :
+    mpv (reindexPhysical f A) σ = mpv A (fun n => f (σ n)) := by
+  simp [mpv, coeff, evalWord_reindexPhysical, List.map_ofFn, Function.comp_def]
+
+/-- Physical reindexing preserves heterogeneous MPV equality. -/
+theorem sameMPV₂_reindexPhysical {d₁ d₂ D₁ D₂ : ℕ} (f : Fin d₁ → Fin d₂)
+    {A : MPSTensor d₂ D₁} {B : MPSTensor d₂ D₂}
+    (hSame : SameMPV₂ A B) :
+    SameMPV₂ (reindexPhysical f A) (reindexPhysical f B) := by
+  intro N σ
+  rw [mpv_reindexPhysical, mpv_reindexPhysical]
+  exact hSame N (fun n => f (σ n))
+
 /-- Iterated physical blocking agrees with direct blocking after the canonical
 index relabeling from iterated blocks to flattened blocks. -/
 @[mps_block_words]
@@ -568,6 +591,86 @@ theorem reindexPhysical_directToIteratedBlockIndex_blockTensor {D : ℕ}
     _ = blockTensor (d := d) (D := D) A (m * n) := by
       ext i
       simp [reindexPhysical, iteratedBlockIndex_directToIteratedBlockIndex d m n]
+
+/-- Refine a tensor already blocked by `p` through a further length-`L` blocking, but expose
+the resulting physical alphabet as the direct length-`p * L` alphabet.
+
+This is the small conceptual interface for flattened iterated blocking: it is ordinary blocking
+over the already blocked alphabet, followed by the canonical grouping map from direct
+length-`p * L` physical indices to iterated length-`L` indices. -/
+noncomputable def flattenedIteratedBlockTensor
+    {d p D : ℕ}
+    (A : MPSTensor (blockPhysDim d p) D) (L : ℕ) :
+    MPSTensor (blockPhysDim d (p * L)) D :=
+  reindexPhysical (directToIteratedBlockIndex d p L)
+    (blockTensor (d := blockPhysDim d p) (D := D) A L)
+
+/-- Evaluating a flattened iterated block is evaluating the iterated block on the grouped
+physical configuration. -/
+theorem mpv_flattenedIteratedBlockTensor
+    {d p D L N : ℕ} (A : MPSTensor (blockPhysDim d p) D)
+    (σ : Fin N → Fin (blockPhysDim d (p * L))) :
+    mpv (flattenedIteratedBlockTensor (d := d) (p := p) (D := D) A L) σ =
+      mpv (blockTensor (d := blockPhysDim d p) (D := D) A L)
+        (fun n => directToIteratedBlockIndex d p L (σ n)) := by
+  simpa [flattenedIteratedBlockTensor] using
+    (mpv_reindexPhysical (directToIteratedBlockIndex d p L)
+      (blockTensor (d := blockPhysDim d p) (D := D) A L) σ)
+
+/-- Flattened iterated blocking of an already `p`-blocked tensor agrees with direct blocking by
+`p * L` of the original tensor. -/
+theorem flattenedIteratedBlockTensor_blockTensor
+    {d D : ℕ} (A : MPSTensor d D) (p L : ℕ) :
+    flattenedIteratedBlockTensor
+        (d := d) (p := p) (D := D)
+        (blockTensor (d := d) (D := D) A p) L =
+      blockTensor (d := d) (D := D) A (p * L) := by
+  exact reindexPhysical_directToIteratedBlockIndex_blockTensor (d := d) A p L
+
+/-- Assembling flattened iterated blocks is the physical reindexing of assembling the
+iterated blocked tensors. -/
+theorem toTensorFromBlocks_flattenedIteratedBlockTensor
+    {d p r L : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor (blockPhysDim d p) (dim k)) :
+    toTensorFromBlocks (d := blockPhysDim d (p * L)) (μ := μ)
+        (fun k => flattenedIteratedBlockTensor
+          (d := d) (p := p) (D := dim k) (blocks k) L) =
+      reindexPhysical (directToIteratedBlockIndex d p L)
+        (toTensorFromBlocks (d := blockPhysDim (blockPhysDim d p) L) (μ := μ)
+          (fun k => blockTensor (d := blockPhysDim d p) (D := dim k) (blocks k) L)) := by
+  funext i
+  rfl
+
+/-- Full MPV equality of assembled weighted block tensors is preserved after a further
+flattened iterated blocking, with the direct length-`p * L` physical alphabet exposed.
+
+This is the reusable bridge to the existing iterated-blocking results: the proof applies
+`sameMPV₂_toTensorFromBlocks_blockPower` over the already blocked alphabet and uses the
+grouping map to return to direct length-`p * L` indices. -/
+theorem sameMPV₂_toTensorFromBlocks_flattenedIteratedBlockPower
+    {d p rA rB L : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (μA : Fin rA → ℂ)
+    (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d p) (dimA k))
+    (μB : Fin rB → ℂ)
+    (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d p) (dimB k))
+    (hSame : SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
+      (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB)) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d (p * L))
+        (fun k => (μA k) ^ L)
+        (fun k => flattenedIteratedBlockTensor
+          (d := d) (p := p) (D := dimA k) (blocksA k) L))
+      (toTensorFromBlocks (d := blockPhysDim d (p * L))
+        (fun k => (μB k) ^ L)
+        (fun k => flattenedIteratedBlockTensor
+          (d := d) (p := p) (D := dimB k) (blocksB k) L)) := by
+  have hIter := sameMPV₂_toTensorFromBlocks_blockPower
+    (d := blockPhysDim d p) μA blocksA μB blocksB hSame L
+  rw [toTensorFromBlocks_flattenedIteratedBlockTensor,
+    toTensorFromBlocks_flattenedIteratedBlockTensor]
+  exact sameMPV₂_reindexPhysical (directToIteratedBlockIndex d p L) hIter
 
 /-- Iterated blocking expressed with the block-grouping bijection equals direct blocking.
 This is the tensor-level version of the blocked-word identity that underlies

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1103,20 +1103,30 @@ The following results separate the zero blocks from the nonzero blocks.
 \begin{definition}[Flattened iterated blocking]%
 	\label{def:flattened_iterated_block_tensor}
 	\lean{MPSTensor.reindexPhysical,
-		MPSTensor.evalWord_reindexPhysical,
-		MPSTensor.mpv_reindexPhysical,
-		MPSTensor.sameMPV₂_reindexPhysical,
-		MPSTensor.flattenedIteratedBlockTensor,
-		MPSTensor.mpv_flattenedIteratedBlockTensor}
+		MPSTensor.flattenedIteratedBlockTensor}
 	\leanok
 	\uses{def:blocked_tensor}
-	If a tensor $A$ already has physical alphabet $d^p$, its flattened iterated blocking by
-	a further length $L$ block is the tensor on the direct alphabet $d^{pL}$ obtained
+	If a tensor $A$ already has physical alphabet $d^p$, its flattened iterated
+	blocking by a further length $L$ block is the tensor on the direct alphabet
+	$d^{pL}$ obtained
 	by first taking the ordinary length-$L$ block over the alphabet $d^p$ and then
 	grouping each direct length-$pL$ word into $L$ consecutive length-$p$ words.
-	The same physical reindexing formula applies to MPVs and preserves heterogeneous
-	MPV equality.
 \end{definition}
+
+\begin{lemma}[MPVs under physical reindexing and flattened iterated blocking]%
+	\label{lem:mpv_flattened_iterated_blocking}
+	\lean{MPSTensor.evalWord_reindexPhysical,
+		MPSTensor.mpv_reindexPhysical,
+		MPSTensor.sameMPV₂_reindexPhysical,
+		MPSTensor.mpv_flattenedIteratedBlockTensor}
+	\leanok
+	\uses{def:flattened_iterated_block_tensor, def:same_mpv2}
+	Word evaluation and MPV evaluation after physical reindexing are obtained by
+	applying the index map to every physical letter.  Therefore MPV equality between
+	two tensors of arbitrary bond dimensions is preserved by the same physical
+	reindexing.  For flattened iterated blocking, evaluation is the evaluation of
+	the iterated block on the grouped physical configuration.
+\end{lemma}
 
 \begin{theorem}[Flattened iterated blocking agrees with direct blocking]%
 	\label{thm:flattened_iterated_blocking}
@@ -1124,11 +1134,14 @@ The following results separate the zero blocks from the nonzero blocks.
 		MPSTensor.toTensorFromBlocks_flattenedIteratedBlockTensor,
 		MPSTensor.sameMPV₂_toTensorFromBlocks_flattenedIteratedBlockPower}
 	\leanok
-	\uses{def:flattened_iterated_block_tensor, thm:samempv_toTensorFromBlocks_block_power}
-	For a tensor first blocked by $p$, flattened iterated blocking by $L$ agrees with direct
-	blocking by $pL$.  The same statement holds for assembled weighted block sums:
-	flattened iterated blocking is the physical reindexing of the iterated blocked assembled
-	family, and full MPV equality of two assembled families is preserved after this
+	\uses{def:flattened_iterated_block_tensor, lem:mpv_flattened_iterated_blocking,
+		thm:samempv_toTensorFromBlocks_block_power}
+	For a tensor first blocked by $p$, flattened iterated blocking by $L$ agrees
+	with direct blocking by $pL$.  The same statement holds for assembled weighted
+	block sums:
+	flattened iterated blocking is the physical reindexing of the iterated blocked
+	assembled family, and full MPV equality of two assembled families is preserved
+	after this
 	blocking with weights transported to the powers $\mu_k^L$.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1100,6 +1100,45 @@ The following results separate the zero blocks from the nonzero blocks.
 	blocked assembled tensor by Theorem~\ref{thm:block_tensor_to_tensor_from_blocks}.
 \end{proof}
 
+\begin{definition}[Flattened iterated blocking]%
+	\label{def:flattened_iterated_block_tensor}
+	\lean{MPSTensor.reindexPhysical,
+		MPSTensor.evalWord_reindexPhysical,
+		MPSTensor.mpv_reindexPhysical,
+		MPSTensor.sameMPV₂_reindexPhysical,
+		MPSTensor.flattenedIteratedBlockTensor,
+		MPSTensor.mpv_flattenedIteratedBlockTensor}
+	\leanok
+	\uses{def:blocked_tensor}
+	If a tensor $A$ already has physical alphabet $d^p$, its flattened iterated blocking by
+	a further length $L$ block is the tensor on the direct alphabet $d^{pL}$ obtained
+	by first taking the ordinary length-$L$ block over the alphabet $d^p$ and then
+	grouping each direct length-$pL$ word into $L$ consecutive length-$p$ words.
+	The same physical reindexing formula applies to MPVs and preserves heterogeneous
+	MPV equality.
+\end{definition}
+
+\begin{theorem}[Flattened iterated blocking agrees with direct blocking]%
+	\label{thm:flattened_iterated_blocking}
+	\lean{MPSTensor.flattenedIteratedBlockTensor_blockTensor,
+		MPSTensor.toTensorFromBlocks_flattenedIteratedBlockTensor,
+		MPSTensor.sameMPV₂_toTensorFromBlocks_flattenedIteratedBlockPower}
+	\leanok
+	\uses{def:flattened_iterated_block_tensor, thm:samempv_toTensorFromBlocks_block_power}
+	For a tensor first blocked by $p$, flattened iterated blocking by $L$ agrees with direct
+	blocking by $pL$.  The same statement holds for assembled weighted block sums:
+	flattened iterated blocking is the physical reindexing of the iterated blocked assembled
+	family, and full MPV equality of two assembled families is preserved after this
+	blocking with weights transported to the powers $\mu_k^L$.
+\end{theorem}
+
+\begin{proof}\leanok
+	The proof is the combinatorial identity identifying a direct length-$pL$ word
+	with an $L$-tuple of length-$p$ words.  For assembled block sums, apply the
+	ordinary blocking theorem over the already blocked alphabet and then reindex the
+	physical alphabet by this grouping map.
+\end{proof}
+
 \begin{theorem}[Blocking assembled weighted blocks]%
 	\label{thm:block_tensor_to_tensor_from_blocks}
 	\lean{MPSTensor.sameMPV₂_blockTensor_toTensorFromBlocks}


### PR DESCRIPTION
## Summary

Adds a small flattened-iterated-blocking construction for tensors that are already blocked by a length `p`.

The new operation

- `MPSTensor.flattenedIteratedBlockTensor`

takes a tensor over the alphabet `blockPhysDim d p`, blocks it again by `L`, and exposes the result over the direct alphabet `blockPhysDim d (p * L)` by the canonical grouping map from length-`p * L` words to `L` consecutive length-`p` words.

New supporting lemmas:

- `MPSTensor.evalWord_reindexPhysical`
- `MPSTensor.mpv_reindexPhysical`
- `MPSTensor.sameMPV₂_reindexPhysical`
- `MPSTensor.mpv_flattenedIteratedBlockTensor`
- `MPSTensor.flattenedIteratedBlockTensor_blockTensor`
- `MPSTensor.toTensorFromBlocks_flattenedIteratedBlockTensor`
- `MPSTensor.sameMPV₂_toTensorFromBlocks_flattenedIteratedBlockPower`

These show that a further iterated blocking can be read over the flattened/direct `p * L` alphabet by physical reindexing, and that assembled weighted block sums preserve full MPV equality under this operation with weights transported to `μ^L`.

## Terminology

The original draft used `directRefinedBlockTensor`. After the maintainer question on #1498, I renamed the public declarations and blueprint prose to the mathematical description `flattenedIteratedBlockTensor`: it is an iterated block tensor whose physical index has been flattened back to the direct length-`p * L` alphabet.

## Why this shape

This is intentionally smaller than duplicating the long #1551 BNT-cover construction with `p * L` everywhere. The key tensor-level equality lets later work reuse the #1551 reblocking constructors and transport along a canonical physical reindexing, rather than repeating the full hypothesis list.

## Blueprint

Added a short blueprint entry in Chapter 8 covering the physical reindexing and flattened-iterated-blocking lemmas.

## Validation

- `lake build TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- committed-diff scan found no new `sorry`, `axiom`, `admit`, `unsafeCast`, or `native_decide`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean definitions/lemmas around physical reindexing and a flattened iterated blocking construction; risk is low since it is proof-only but it touches core blocking infrastructure and could affect downstream theorem dependencies.
> 
> **Overview**
> Introduces a general `reindexPhysical` operation for MPSTensors and proves that it commutes with `evalWord`/`mpv` and preserves `SameMPV₂`.
> 
> Adds `flattenedIteratedBlockTensor`, which re-blocks an already `p`-blocked tensor by `L` and then reindexes physical labels to the direct `p * L` alphabet, plus theorems showing it matches direct blocking and interacts well with `toTensorFromBlocks` and powered-weight MPV-equality preservation.
> 
> Extends the Chapter 8 blueprint with corresponding definition/lemma/theorem statements documenting flattened iterated blocking and its MPV-equality consequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2fc3ad85b5dc8e2248a4d8651b640da619e572f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->