### PR TITLE
feat(MPS): transport BNT covers across physical reindexing

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.SectorComparison.ProportionalComparison
 import TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData
+import TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveReindexTransport
 import TNLean.MPS.CanonicalForm.SectorComparison.BasicSectorComparison
 import TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData
 
@@ -43,6 +44,8 @@ The supporting modules are:
   common-sector transport after the structural theorem.
 * `TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData` —
   common primitive span, phase-cover, proportional, and BNT comparison hypotheses.
+* `TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveReindexTransport` —
+  physical-reindex transport for primitive BNT-cover hypotheses.
 * `TNLean.MPS.CanonicalForm.SectorComparison.BasicSectorComparison` — basic sector
   comparisons from block-span, phase-cover, and proportional data.
 * `TNLean.MPS.CanonicalForm.SectorComparison.ProportionalComparison` — sector comparison

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveReindexTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveReindexTransport.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData
+import TNLean.MPS.Core.PhysicalReindexTransport
+
+/-!
+# Physical reindexing for common primitive BNT hypotheses
+
+This file transports the normal-form and BNT hypotheses used in the common primitive
+comparison along a bijection of physical alphabets.
+
+## Main statements
+
+* `IsNormalCanonicalForm.reindexPhysical_equiv` — normal canonical form is preserved by
+  reindexing all physical letters.
+* `BlocksNotGaugePhaseEquiv.reindexPhysical_equiv` and
+  `IsNormalCanonicalFormBNT.reindexPhysical_equiv` — BNT separation and normal-CF-BNT
+  hypotheses are preserved.
+* `ProportionalDecompositionData.reindexPhysical_equiv` — proportional-decomposition
+  proofs are transported by evaluating on the relabelled physical configuration.
+* `CommonPrimitiveBNTCoverHypotheses.reindexPhysical_equiv` — the full common primitive
+  BNT hypotheses are transported across a physical alphabet equivalence.
+* `CommonPrimitiveBNTCoverHypotheses.reindexPhysical_directIteratedBlockEquiv` — the
+  preceding transport specialized to `directIteratedBlockEquiv`, turning iterated blocked
+  hypotheses into flattened iterated hypotheses on the direct length-`p * L` alphabet.
+-/
+
+open scoped BigOperators
+
+namespace MPSTensor
+
+namespace IsNormalCanonicalForm
+
+/-- Transport a normal canonical form proof along a physical-index equivalence. -/
+def reindexPhysical_equiv
+    {d₁ d₂ r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
+    {A : (k : Fin r) → MPSTensor d₂ (dim k)}
+    (h : IsNormalCanonicalForm (d := d₂) μ A) (e : Fin d₁ ≃ Fin d₂) :
+    IsNormalCanonicalForm (d := d₁) μ (fun k => reindexPhysical e (A k)) where
+  block_irreducible := fun k =>
+    (isIrreducibleTensor_reindexPhysical_equiv e (A k)).mpr (h.block_irreducible k)
+  leftCanonical := fun k =>
+    (leftCanonical_reindexPhysical_equiv e (A k)).mpr (h.leftCanonical k)
+  block_primitive := fun k =>
+    (isPrimitive_transferMap_reindexPhysical_equiv e (A k)).mpr (h.block_primitive k)
+  mu_antitone := h.mu_antitone
+  mu_ne_zero := h.mu_ne_zero
+  dim_pos := h.dim_pos
+
+end IsNormalCanonicalForm
+
+namespace BlocksNotGaugePhaseEquiv
+
+/-- Transport BNT separation along a physical-index equivalence. -/
+theorem reindexPhysical_equiv
+    {d₁ d₂ r : ℕ} {dim : Fin r → ℕ}
+    {A : (k : Fin r) → MPSTensor d₂ (dim k)}
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d₂) A) (e : Fin d₁ ≃ Fin d₂) :
+    BlocksNotGaugePhaseEquiv (d := d₁) (fun k => reindexPhysical e (A k)) := by
+  intro j k hjk hdim hG
+  apply hBlocks j k hjk hdim
+  have hG' : GaugePhaseEquiv
+      (reindexPhysical e (cast (congr_arg (MPSTensor d₂) hdim) (A j)))
+      (reindexPhysical e (A k)) := by
+    rw [reindexPhysical_cast_dim e hdim (A j)]
+    exact hG
+  exact (gaugePhaseEquiv_reindexPhysical_equiv e
+    (cast (congr_arg (MPSTensor d₂) hdim) (A j)) (A k)).mp hG'
+
+end BlocksNotGaugePhaseEquiv
+
+namespace IsNormalCanonicalFormBNT
+
+/-- Transport a normal-CF-BNT proof along a physical-index equivalence. -/
+def reindexPhysical_equiv
+    {d₁ d₂ r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
+    {A : (k : Fin r) → MPSTensor d₂ (dim k)}
+    (h : IsNormalCanonicalFormBNT (d := d₂) μ A) (e : Fin d₁ ≃ Fin d₂) :
+    IsNormalCanonicalFormBNT (d := d₁) μ (fun k => reindexPhysical e (A k)) where
+  toIsNormalCanonicalForm := h.toIsNormalCanonicalForm.reindexPhysical_equiv e
+  mu_strict_anti := h.mu_strict_anti
+  blocks_not_equiv := BlocksNotGaugePhaseEquiv.reindexPhysical_equiv h.blocks_not_equiv e
+
+end IsNormalCanonicalFormBNT
+
+namespace ProportionalDecompositionData
+
+/-- Transport a proportional-decomposition proof along a physical-index equivalence. -/
+noncomputable def reindexPhysical_equiv
+    {d₁ d₂ rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {A : (j : Fin rA) → MPSTensor d₂ (dimA j)}
+    {B : (k : Fin rB) → MPSTensor d₂ (dimB k)}
+    {DtotA DtotB : ℕ}
+    (h : ProportionalDecompositionData (d := d₂) A B DtotA DtotB)
+    (e : Fin d₁ ≃ Fin d₂) :
+    ProportionalDecompositionData (d := d₁)
+      (fun j => reindexPhysical e (A j))
+      (fun k => reindexPhysical e (B k)) DtotA DtotB where
+  A_total := reindexPhysical e h.A_total
+  B_total := reindexPhysical e h.B_total
+  aCoeff := h.aCoeff
+  bCoeff := h.bCoeff
+  aLim := h.aLim
+  bLim := h.bLim
+  c := h.c
+  cLim := h.cLim
+  hA_decomp := fun N σ => by
+    rw [mpv_reindexPhysical]
+    calc
+      mpv h.A_total (fun n => e (σ n)) =
+          ∑ j : Fin rA, h.aCoeff N j * mpv (A j) (fun n => e (σ n)) :=
+        h.hA_decomp N (fun n => e (σ n))
+      _ = ∑ j : Fin rA, h.aCoeff N j * mpv (reindexPhysical e (A j)) σ := by
+        refine Finset.sum_congr rfl fun j _ => ?_
+        rw [mpv_reindexPhysical]
+  hB_decomp := fun N σ => by
+    rw [mpv_reindexPhysical]
+    calc
+      mpv h.B_total (fun n => e (σ n)) =
+          ∑ k : Fin rB, h.bCoeff N k * mpv (B k) (fun n => e (σ n)) :=
+        h.hB_decomp N (fun n => e (σ n))
+      _ = ∑ k : Fin rB, h.bCoeff N k * mpv (reindexPhysical e (B k)) σ := by
+        refine Finset.sum_congr rfl fun k _ => ?_
+        rw [mpv_reindexPhysical]
+  haCoeff := h.haCoeff
+  hbCoeff := h.hbCoeff
+  haLim_ne := h.haLim_ne
+  hbLim_ne := h.hbLim_ne
+  hProp := fun N σ => by
+    rw [mpv_reindexPhysical, mpv_reindexPhysical]
+    exact h.hProp N (fun n => e (σ n))
+  hc := h.hc
+  hcLim_ne := h.hcLim_ne
+
+end ProportionalDecompositionData
+
+namespace CommonPrimitiveBNTCoverHypotheses
+
+/-- Transport primitive BNT-cover hypotheses along a physical-index equivalence. -/
+noncomputable def reindexPhysical_equiv
+    {d₁ p₁ d₂ p₂ rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d₂ p₂) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d₂ p₂) (dimB x)}
+    (h : CommonPrimitiveBNTCoverHypotheses (d := d₂) (p := p₂)
+      (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB) μA μB blocksA blocksB)
+    (e : Fin (blockPhysDim d₁ p₁) ≃ Fin (blockPhysDim d₂ p₂)) :
+    CommonPrimitiveBNTCoverHypotheses (d := d₁) (p := p₁)
+      (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB) μA μB
+      (fun x => reindexPhysical e (blocksA x))
+      (fun x => reindexPhysical e (blocksB x)) where
+  ncfA := h.ncfA.reindexPhysical_equiv e
+  ncfB := h.ncfB.reindexPhysical_equiv e
+  notGpeA := BlocksNotGaugePhaseEquiv.reindexPhysical_equiv h.notGpeA e
+  notGpeB := BlocksNotGaugePhaseEquiv.reindexPhysical_equiv h.notGpeB e
+  zeroTail_eq := h.zeroTail_eq
+  left_injective := fun x =>
+    (isInjective_reindexPhysical_equiv e (blocksA x)).mpr (h.left_injective x)
+  right_injective := fun x =>
+    (isInjective_reindexPhysical_equiv e (blocksB x)).mpr (h.right_injective x)
+  decompData := h.decompData.reindexPhysical_equiv e
+
+/-- Transport an iterated-block BNT cover to the flattened `p * L` physical alphabet. -/
+noncomputable def reindexPhysical_directIteratedBlockEquiv
+    {d p L rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {zeroTailA zeroTailB DtotA DtotB : ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    {blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)}
+    {blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)}
+    (h : CommonPrimitiveBNTCoverHypotheses (d := blockPhysDim d p) (p := L)
+      (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB) μA μB
+      (fun x => blockTensor (d := blockPhysDim d p) (D := dimA x) (blocksA x) L)
+      (fun x => blockTensor (d := blockPhysDim d p) (D := dimB x) (blocksB x) L)) :
+    CommonPrimitiveBNTCoverHypotheses (d := d) (p := p * L)
+      (zeroTailA := zeroTailA) (zeroTailB := zeroTailB)
+      (DtotA := DtotA) (DtotB := DtotB) μA μB
+      (fun x => flattenedIteratedBlockTensor (d := d) (p := p) (D := dimA x)
+        (blocksA x) L)
+      (fun x => flattenedIteratedBlockTensor (d := d) (p := p) (D := dimB x)
+        (blocksB x) L) := by
+  simpa [flattenedIteratedBlockTensor] using
+    h.reindexPhysical_equiv (d₁ := d) (p₁ := p * L)
+      (d₂ := blockPhysDim d p) (p₂ := L) (directIteratedBlockEquiv d p L)
+
+end CommonPrimitiveBNTCoverHypotheses
+
+end MPSTensor

--- a/TNLean/MPS/Core/PhysicalReindexTransport.lean
+++ b/TNLean/MPS/Core/PhysicalReindexTransport.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Core.BlockingInfrastructure
+
+/-!
+# Physical reindexing along alphabet equivalences
+
+This file proves that changing physical letters by a bijection preserves the
+basic tensor properties used by blocking and canonical-form arguments.
+
+## Main statements
+
+* `reindexPhysical_cast_dim` — physical reindexing commutes with bond-dimension casts.
+* `transferMap_reindexPhysical_equiv` — the transfer map is unchanged by a physical
+  alphabet bijection.
+* `leftCanonical_reindexPhysical_equiv` and
+  `isPrimitive_transferMap_reindexPhysical_equiv` — left-canonical normalization and
+  transfer-map primitivity are preserved.
+* `hasInvariantProj_reindexPhysical_equiv`, `isIrreducibleTensor_reindexPhysical_equiv`,
+  and `isInjective_reindexPhysical_equiv` — invariant projections, irreducibility, and
+  one-site injectivity are preserved.
+* `gaugePhaseEquiv_reindexPhysical_equiv` — gauge-phase equivalence is preserved
+  when both tensors are reindexed by the same physical alphabet bijection.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+/-- Physical reindexing commutes with bond-dimension casts. -/
+theorem reindexPhysical_cast_dim {d₁ d₂ D₁ D₂ : ℕ} (e : Fin d₁ ≃ Fin d₂)
+    (h : D₁ = D₂) (A : MPSTensor d₂ D₁) :
+    reindexPhysical e (cast (congr_arg (MPSTensor d₂) h) A) =
+      cast (congr_arg (MPSTensor d₁) h) (reindexPhysical e A) := by
+  subst h
+  rfl
+
+/-- Reindexing by a physical-index equivalence does not change the transfer map. -/
+theorem transferMap_reindexPhysical_equiv {d₁ d₂ D : ℕ} (e : Fin d₁ ≃ Fin d₂)
+    (A : MPSTensor d₂ D) :
+    transferMap (d := d₁) (D := D) (reindexPhysical e A) =
+      transferMap (d := d₂) (D := D) A := by
+  ext X i j
+  simp only [transferMap_apply, reindexPhysical]
+  have hsum :
+      (∑ x : Fin d₁, A (e x) * X * (A (e x))ᴴ) =
+        ∑ x : Fin d₂, A x * X * (A x)ᴴ :=
+    Fintype.sum_equiv e
+      (fun x : Fin d₁ => A (e x) * X * (A (e x))ᴴ)
+      (fun x : Fin d₂ => A x * X * (A x)ᴴ)
+      (fun _ => rfl)
+  exact congr_fun (congr_fun hsum i) j
+
+/-- Reindexing by a physical-index equivalence preserves left-canonical normalization. -/
+theorem leftCanonical_reindexPhysical_equiv {d₁ d₂ D : ℕ} (e : Fin d₁ ≃ Fin d₂)
+    (A : MPSTensor d₂ D) :
+    (∑ i : Fin d₁,
+        (reindexPhysical e A i)ᴴ * reindexPhysical e A i = 1) ↔
+      (∑ i : Fin d₂, (A i)ᴴ * A i = 1) := by
+  simp only [reindexPhysical]
+  have hsum :
+      (∑ i : Fin d₁, (A (e i))ᴴ * A (e i)) =
+        ∑ i : Fin d₂, (A i)ᴴ * A i :=
+    Fintype.sum_equiv e
+      (fun i : Fin d₁ => (A (e i))ᴴ * A (e i))
+      (fun i : Fin d₂ => (A i)ᴴ * A i)
+      (fun _ => rfl)
+  rw [hsum]
+
+/-- Reindexing by a physical-index equivalence preserves transfer-map primitivity. -/
+theorem isPrimitive_transferMap_reindexPhysical_equiv {d₁ d₂ D : ℕ}
+    (e : Fin d₁ ≃ Fin d₂) (A : MPSTensor d₂ D) :
+    _root_.IsPrimitive
+        (transferMap (d := d₁) (D := D) (reindexPhysical e A)) ↔
+      _root_.IsPrimitive (transferMap (d := d₂) (D := D) A) := by
+  rw [transferMap_reindexPhysical_equiv e A]
+
+/-- Reindexing by a physical-index equivalence preserves invariant projections. -/
+theorem hasInvariantProj_reindexPhysical_equiv {d₁ d₂ D : ℕ} (e : Fin d₁ ≃ Fin d₂)
+    (A : MPSTensor d₂ D) :
+    HasInvariantProj (reindexPhysical e A) ↔ HasInvariantProj A := by
+  constructor
+  · rintro ⟨P, hPproj, hP0, hP1, hLower⟩
+    refine ⟨P, hPproj, hP0, hP1, ?_⟩
+    intro i
+    simpa [reindexPhysical] using hLower (e.symm i)
+  · rintro ⟨P, hPproj, hP0, hP1, hLower⟩
+    refine ⟨P, hPproj, hP0, hP1, ?_⟩
+    intro i
+    exact hLower (e i)
+
+/-- Reindexing by a physical-index equivalence preserves tensor irreducibility. -/
+theorem isIrreducibleTensor_reindexPhysical_equiv {d₁ d₂ D : ℕ}
+    (e : Fin d₁ ≃ Fin d₂) (A : MPSTensor d₂ D) :
+    IsIrreducibleTensor (reindexPhysical e A) ↔ IsIrreducibleTensor A := by
+  rw [IsIrreducibleTensor, IsIrreducibleTensor, hasInvariantProj_reindexPhysical_equiv e A]
+
+/-- Reindexing by a physical-index equivalence preserves algebraic injectivity. -/
+theorem isInjective_reindexPhysical_equiv {d₁ d₂ D : ℕ} (e : Fin d₁ ≃ Fin d₂)
+    (A : MPSTensor d₂ D) :
+    IsInjective (reindexPhysical e A) ↔ IsInjective A := by
+  have hRange : Set.range (reindexPhysical e A) = Set.range A := by
+    ext X
+    constructor
+    · rintro ⟨i, rfl⟩
+      exact ⟨e i, rfl⟩
+    · rintro ⟨i, rfl⟩
+      exact ⟨e.symm i, by simp [reindexPhysical]⟩
+  simp [IsInjective, hRange]
+
+/-- Reindexing both tensors by a physical-index equivalence preserves gauge-phase equivalence. -/
+theorem gaugePhaseEquiv_reindexPhysical_equiv {d₁ d₂ D : ℕ}
+    (e : Fin d₁ ≃ Fin d₂) (A B : MPSTensor d₂ D) :
+    GaugePhaseEquiv (reindexPhysical e A) (reindexPhysical e B) ↔
+      GaugePhaseEquiv A B := by
+  constructor
+  · rintro ⟨X, ζ, hζ, hXB⟩
+    refine ⟨X, ζ, hζ, ?_⟩
+    intro i
+    simpa [reindexPhysical] using hXB (e.symm i)
+  · rintro ⟨X, ζ, hζ, hXB⟩
+    refine ⟨X, ζ, hζ, ?_⟩
+    intro i
+    simpa [reindexPhysical] using hXB (e i)
+
+end MPSTensor

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1128,6 +1128,32 @@ The following results separate the zero blocks from the nonzero blocks.
 	the iterated block on the grouped physical configuration.
 \end{lemma}
 
+\begin{lemma}[Transport across a physical alphabet equivalence]%
+	\label{lem:physical_reindex_equiv_transport}
+	\lean{MPSTensor.reindexPhysical_cast_dim,
+		MPSTensor.transferMap_reindexPhysical_equiv,
+		MPSTensor.leftCanonical_reindexPhysical_equiv,
+		MPSTensor.isPrimitive_transferMap_reindexPhysical_equiv,
+		MPSTensor.hasInvariantProj_reindexPhysical_equiv,
+		MPSTensor.isIrreducibleTensor_reindexPhysical_equiv,
+		MPSTensor.isInjective_reindexPhysical_equiv,
+		MPSTensor.gaugePhaseEquiv_reindexPhysical_equiv}
+	\leanok
+	\uses{def:transfer_map, def:primitive_channel}
+	A bijection between physical alphabets of sizes $d_1$ and $d_2$ merely
+	relabels the Kraus summation.  Therefore physical reindexing commutes with
+	bond-dimension casts, leaves the transfer map unchanged, and carries
+	left-canonical normalization, transfer-map primitivity, invariant
+	projections, irreducibility, injectivity, and gauge-phase equivalence back
+	and forth across the bijection.
+\end{lemma}
+
+\begin{proof}\leanok
+	The transfer-map and left-canonical identities are reindexings of finite sums
+	by the chosen bijection.  The primitive-transfer statement follows from equality
+	of the transfer maps.
+\end{proof}
+
 \begin{theorem}[Flattened iterated blocking agrees with direct blocking]%
 	\label{thm:flattened_iterated_blocking}
 	\lean{MPSTensor.flattenedIteratedBlockTensor_blockTensor,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1243,6 +1243,34 @@ BNT comparison hypotheses for the common primitive sectors.
 	% not part of the source terminology and is intentionally not displayed.
 \end{definition}
 
+\begin{lemma}[Physical relabelling of common primitive BNT hypotheses]%
+	\label{lem:common_primitive_bnt_reindex_transport}
+	\lean{MPSTensor.IsNormalCanonicalForm.reindexPhysical_equiv,
+		MPSTensor.BlocksNotGaugePhaseEquiv.reindexPhysical_equiv,
+		MPSTensor.IsNormalCanonicalFormBNT.reindexPhysical_equiv,
+		MPSTensor.ProportionalDecompositionData.reindexPhysical_equiv,
+		MPSTensor.CommonPrimitiveBNTCoverHypotheses.reindexPhysical_equiv,
+		MPSTensor.CommonPrimitiveBNTCoverHypotheses.reindexPhysical_directIteratedBlockEquiv}
+	\leanok
+	\uses{def:common_primitive_bnt_cover_hypotheses,
+		def:flattened_iterated_block_tensor, lem:physical_reindex_equiv_transport}
+	A bijection of physical alphabets transports the common primitive BNT
+	hypotheses by relabelling every block in both families.  Normal canonical
+	form, BNT separation, proportional decomposition, one-site injectivity, and
+	zero-tail equality are preserved.  Applying this to the canonical bijection
+	between the direct length-$pL$ alphabet and the iterated length-$L$ alphabet
+	over length-$p$ blocks transports the iterated blocked hypotheses to the
+	flattened iterated families on the direct alphabet.
+\end{lemma}
+
+\begin{proof}\leanok
+	Each assertion is transported along the same relabelling.  BNT separation uses the
+	iff for gauge-phase equivalence under physical reindexing, while the
+	proportional-decomposition equalities are evaluated on the relabelled physical
+	configuration.  The final statement is the specialization to the
+	length-$pL$ grouping bijection used in flattened iterated blocking.
+\end{proof}
+
 \begin{definition}[BNT matching inputs for representative common-sector families]%
 \label{def:common_representative_bnt_cover_hypotheses}
 	\lean{MPSTensor.CommonRepresentativeBNTCoverHypotheses}


### PR DESCRIPTION
## Summary

Adds generic transport along physical-index equivalences for the #1498/#1501 BNT-cover pipeline.

- adds core `reindexPhysical` transport lemmas for transfer maps, left-canonical normalization, primitivity, irreducibility, injectivity, and gauge-phase equivalence
- transports normal canonical/BNT separation and proportional-decomposition data along a physical equivalence
- adds `CommonPrimitiveBNTCoverHypotheses.reindexPhysical_equiv`
- specializes the transport to #1553's `directIteratedBlockEquiv` / `flattenedIteratedBlockTensor` bridge

This keeps blocked not-GPE and power-limit hypotheses explicit; it only transports them across a physical reindexing equivalence.

## Validation

- `lake build TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveProportionalData`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- forbidden-token scan for new `sorry`, `axiom`, `admit`, `unsafeCast`, `native_decide`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR is additive, introducing new transport lemmas and re-export wiring without changing existing definitions or algorithms. Main risk is proof fragility/compile breakage due to new lemma dependencies and equivalence rewrites.
> 
> **Overview**
> Adds a new core module `PhysicalReindexTransport.lean` proving that reindexing physical letters by an equivalence preserves key tensor properties (casts, `transferMap`, left-canonicality, primitivity, irreducibility, injectivity, and `GaugePhaseEquiv`).
> 
> Builds on this with `CommonPrimitiveReindexTransport.lean`, which transports normal-canonical-form, BNT-separation, proportional-decomposition, and the full `CommonPrimitiveBNTCoverHypotheses` across a physical equivalence, plus a specialization to `directIteratedBlockEquiv` to move iterated-block hypotheses onto the flattened direct `p * L` alphabet.
> 
> Updates the `SectorComparison` entry-point to import the new transport module, and extends the blueprint (Ch. 8 & 11) with corresponding lemmas documenting the new transport results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b5c5aaa772ecd07132628afca05c7541667f890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->