### PR TITLE
feat(MPS/FT): recover rectangular equalMPS dimensions

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -271,6 +271,41 @@ theorem mixedTransferSpectralRadius_ge_one_of_mpvOverlap_norm_tendsto_one
   have h01 : (1 : ℝ) = 0 := tendsto_nhds_unique hOverlap hnorm_zero
   exact one_ne_zero h01
 
+/-- **Bond-dimension equality from unit-modulus overlap.**
+
+Source: arXiv:1606.00608, Lemma equalMPS, lines 1085--1117, especially the
+dimension conclusion in line 1090 and the final dimension argument in
+lines 1115--1117. If two irreducible trace-preserving left-canonical blocks
+have asymptotically unit-modulus overlap, then their bond dimensions agree.
+
+The proof is the contrapositive of the rectangular overlap-decay theorem
+`mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP`: different bond
+dimensions force the overlap to tend to `0`, contradicting the assumed limit
+of its modulus to `1`. -/
+theorem dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP
+    {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hA_irr : IsIrreducibleTensor (d := d) (D := D₁) A)
+    (hB_irr : IsIrreducibleTensor (d := d) (D := D₂) B)
+    (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
+    (hOverlap :
+      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A B N‖) Filter.atTop
+        (nhds (1 : ℝ))) :
+    D₁ = D₂ := by
+  by_contra hD
+  have hzero :
+      Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop
+        (nhds (0 : ℂ)) :=
+    mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP
+      A B hA_irr hB_irr hA_norm hB_norm hD
+  have hnorm_zero :
+      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A B N‖) Filter.atTop
+        (nhds (0 : ℝ)) := by
+    simpa using hzero.norm
+  have h10 : (1 : ℝ) = 0 := tendsto_nhds_unique hOverlap hnorm_zero
+  exact one_ne_zero h10
+
 /-- **Gauge-phase equivalence from unit-modulus overlap.**
 
 Source: arXiv:1606.00608, Lemma equalMPS, statement lines 1080-1091 and
@@ -290,8 +325,9 @@ together with the rigidity theorem
 **Scope restriction (same bond dimension):** The source Lemma equalMPS also
 concludes equality of the two bond dimensions in the unit-overlap case; this
 theorem assumes a common bond dimension as a hypothesis instead. The
-rectangular component is recorded in
-docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex. -/
+rectangular component is proved separately as
+`dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP` in this file; together
+the two theorems recover the full structural conclusion of the source lemma. -/
 theorem gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP
     (A B : MPSTensor d D)
     (hA_irr : IsIrreducibleTensor (d := d) (D := D) A)

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -295,6 +295,27 @@ The general CPSV theorem still passes through sector decompositions, copy-count
 recovery, and sector-weight multiset comparison before one obtains a global
 block-diagonal gauge.
 
+\begin{theorem}[Bond dimension equality from unit overlap]%
+\label{thm:equalMPS_dimension_from_unit_overlap}
+	\lean{MPSTensor.dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP}
+	\leanok
+	\uses{def:mpv_overlap}
+	Let \(A\) and \(B\) be irreducible trace-preserving blocks, possibly with
+	different bond dimensions.  If
+	\[
+		\lim_{N\to\infty}
+		\left|\left\langle V^{(N)}(B)\mid V^{(N)}(A)\right\rangle\right|=1,
+	\]
+	then the two bond dimensions are equal.
+\end{theorem}
+
+\begin{proof}
+	\leanok
+	The proof is the contrapositive of rectangular overlap decay: if the two
+	bond dimensions differ, the mixed overlap tends to \(0\), contradicting
+	the assumed convergence of its modulus to \(1\).
+\end{proof}
+
 \begin{lemma}[Common-block equal-MPV comparison]\label{lem:ft_equal_same_structure}
 	\lean{MPSTensor.fundamentalTheorem_equalMPV_CFBNT}
 	\leanok

--- a/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
+++ b/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{Residual Bond-Dimension Gap in CPSV16 Lemma~\texttt{equalMPS}}
+\title{CPSV16 Lemma~\texttt{equalMPS} Gauge-Phase Components}
 \author{}
 \date{2026-05-10}
 
@@ -88,7 +88,7 @@ The proportionality-based theorem in the same file is a correct corollary for a
 stronger hypothesis.  It is not a formalization of Lemma~\texttt{equalMPS},
 because the source does not assume proportional MPV families.
 
-\section{Remaining rectangular component}
+\section{Formalized rectangular component}
 
 Lemma~\texttt{equalMPS} also concludes \(D_a=D_b\) in the unit-overlap case.
 This is a rectangular statement: before the conclusion is known, the two normal
@@ -96,6 +96,14 @@ tensors may have different bond dimensions.  The proof derives an isometry
 between the two bond spaces and then uses normality of the larger tensor to rule
 out a proper missing subspace, forcing equality of dimensions
 \cite[lines~1115--1117]{Cirac2016MPDO_arXiv}.
+
+The formalization records this conclusion as
+\leanid{MPSTensor.dim\_eq\_of\_overlap\_norm\_tendsto\_one\_of\_irreducible\_TP}
+in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}.  Its proof uses the
+contrapositive of the rectangular overlap-decay theorem
+\leanid{MPSTensor.mpvOverlap\_tendsto\_zero\_of\_dim\_ne\_of\_irreducible\_TP}:
+if the bond dimensions differ, the overlap tends to zero, contradicting the
+unit-modulus overlap hypothesis.
 
 This rectangular dimension recovery is genuinely needed in the proof of
 \cite[Theorem~II.1, lines~1170--1192]{Cirac2016MPDO_arXiv}.  There the relevant
@@ -109,11 +117,10 @@ after the rectangular dimension conclusion has been supplied separately.
 
 The same-bond-dimension gauge component is formalized without the
 source-absent MPV proportionality hypothesis.  The rectangular
-bond-dimension conclusion \(D_a=D_b\) remains a hypothesis-level gap in this
-branch: the source proves it from unit-modulus overlap, while the present gauge
-theorem assumes a common bond dimension before it applies.  This remaining
-component is still needed for the proof of
-\cite[Theorem~II.1, lines~1170--1192]{Cirac2016MPDO_arXiv}.
+bond-dimension conclusion \(D_a=D_b\) is now formalized as a separate theorem.
+Together these two components recover the structural conclusion of the
+unit-overlap branch of Lemma~\texttt{equalMPS}, though the upstream normal-tensor
+periodicity and dichotomy statements remain separate from this note.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Restacks the source-faithful rectangular dimension conclusion from the old #1568 branch onto current `main` after #1574 and #1573.

- adds `MPSTensor.dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP`, the bond-dimension equality part of CPSV16 Lemma `equalMPS`
- records the theorem in the blueprint as `thm:equalMPS_dimension_from_unit_overlap`
- updates `docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex` to say the rectangular component is now formalized

This PR intentionally does not restore the old proportional-data branch or the stale renamed module from #1568.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Proportional.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Proportional`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
