### PR TITLE
feat(MPS/FT): prove dominant proportional projection contradictions

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.FundamentalTheorem.Full.ProportionalExpansion
+import TNLean.MPS.FundamentalTheorem.Full.ProportionalDominant
 
 /-!
 # Non-decaying overlap existence for BNT families
@@ -821,18 +821,6 @@ lemma exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT
   have hB_cross : ∀ j k : Fin rB, j ≠ k →
       Tendsto (fun N => mpvOverlap (d := d) (B j) (B k) N) atTop (nhds 0) :=
     hB.cross_overlap_tendsto_zero
-  have hA_inner_diag : ∀ j : Fin rA,
-      Tendsto (fun N => mpvInner (d := d) (A j) (A j) N) atTop (nhds 1) :=
-    fun j => tendsto_inner_one (A j) (hA_self j)
-  have hA_inner_off : ∀ i j : Fin rA, i ≠ j →
-      Tendsto (fun N => mpvInner (d := d) (A i) (A j) N) atTop (nhds 0) :=
-    fun i j hij => tendsto_inner_zero (A i) (A j) (hA_cross i j hij)
-  have hB_inner_diag : ∀ k : Fin rB,
-      Tendsto (fun N => mpvInner (d := d) (B k) (B k) N) atTop (nhds 1) :=
-    fun k => tendsto_inner_one (B k) (hB_self k)
-  have hB_inner_off : ∀ i j : Fin rB, i ≠ j →
-      Tendsto (fun N => mpvInner (d := d) (B i) (B j) N) atTop (nhds 0) :=
-    fun i j hij => tendsto_inner_zero (B i) (B j) (hB_cross i j hij)
   obtain ⟨c, hc, hState⟩ :=
     exists_weighted_mpvState_eq_smul_sequence_of_nonzeroProportionalMPV₂_toTensorFromBlocks
       A B hProp
@@ -890,198 +878,19 @@ lemma exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT
     tendsto_norm_adjusted_weighted_mpvState_scalar_of_tendsto_norm_one
       A B c (μA a0) (μB b0) hμA_ne hμB_ne hState
       hA_norm_dominant hB_norm_dominant
+  have hDominant_contra :=
+    dominant_projection_contradictions_of_normalized_proportional_inner
+      A B hA hB hrA hrB c hNormalizedInner
+      (by simpa [a0, b0] using hAdjustedScalar_dom)
+      hA_self hB_self hA_cross hB_cross
   have hDominantB_contra :
       (∀ j : Fin rA, Tendsto (fun N => mpvOverlap (d := d) (A j) (B b0) N)
         atTop (nhds 0)) → False := by
-    intro hall
-    have hall_inner : ∀ j : Fin rA,
-        Tendsto (fun N => mpvInner (d := d) (B b0) (A j) N) atTop (nhds 0) :=
-      fun j => tendsto_inner_zero_swap (d := d) (A j) (B b0) (hall j)
-    have hA_proj_sum :
-        Tendsto
-          (fun N : ℕ =>
-            ∑ j : Fin rA, (μA j / μA a0) ^ N *
-              mpvInner (d := d) (B b0) (A j) N)
-          atTop (nhds 0) := by
-      have := tendsto_finset_sum (Finset.univ : Finset (Fin rA))
-        (fun (j : Fin rA) _ => show
-          Tendsto
-            (fun N : ℕ =>
-              (μA j / μA a0) ^ N * mpvInner (d := d) (B b0) (A j) N)
-            atTop (nhds (0 : ℂ)) from
-          bounded_mul_tendsto_zero _ _ (by
-            rw [norm_div]
-            exact (div_le_one (norm_pos_iff.mpr hμA_ne)).mpr
-              (hA.toIsCanonicalForm.mu_antitone
-                (show a0 ≤ j from Fin.mk_le_mk.mpr (Nat.zero_le _))))
-            (hall_inner j))
-      simpa using this
-    have hA_proj :
-        Tendsto
-          (fun N : ℕ =>
-            (μA a0 ^ N)⁻¹ *
-              (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N))
-          atTop (nhds 0) := by
-      convert hA_proj_sum using 1
-      ext N
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro j _
-      rw [div_pow]
-      field_simp [pow_ne_zero N hμA_ne]
-    have hB_proj :
-        Tendsto
-          (fun N : ℕ =>
-            (μB b0 ^ N)⁻¹ *
-              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N))
-          atTop (nhds 1) := by
-      have hsum :
-          Tendsto
-            (fun N : ℕ =>
-              ∑ k : Fin rB, (μB k / μB b0) ^ N *
-                mpvInner (d := d) (B b0) (B k) N)
-            atTop (nhds 1) :=
-        sum_tendsto_one_of_diag (hμ0 := hμB_ne) (j0 := b0) rfl (hB_inner_diag b0)
-          (fun k hk => by
-            rw [norm_div]
-            exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
-              (hB.mu_strict_anti (by
-                simp only [b0, Fin.lt_def]
-                exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h)))))
-          (fun k hk => hB_inner_off b0 k hk.symm)
-      convert hsum using 1
-      ext N
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro k _
-      rw [div_pow]
-      field_simp [pow_ne_zero N hμB_ne]
-    have hRHS_norm_one :
-        Tendsto
-          (fun N : ℕ =>
-            ‖(c N * (μB b0 / μA a0) ^ N) *
-              ((μB b0 ^ N)⁻¹ *
-                (∑ k : Fin rB, (μB k) ^ N *
-                  mpvInner (d := d) (B b0) (B k) N))‖)
-          atTop (nhds (1 : ℝ)) := by
-      have hmul := hAdjustedScalar_dom.mul hB_proj.norm
-      simpa [norm_mul] using hmul
-    have hRHS_norm_zero :
-        Tendsto
-          (fun N : ℕ =>
-            ‖(c N * (μB b0 / μA a0) ^ N) *
-              ((μB b0 ^ N)⁻¹ *
-                (∑ k : Fin rB, (μB k) ^ N *
-                  mpvInner (d := d) (B b0) (B k) N))‖)
-          atTop (nhds (0 : ℝ)) := by
-      have hnorm := hA_proj.norm
-      have hnorm_zero :
-          Tendsto
-            (fun N : ℕ =>
-              ‖(μA a0 ^ N)⁻¹ *
-                (∑ j : Fin rA, (μA j) ^ N *
-                  mpvInner (d := d) (B b0) (A j) N)‖)
-            atTop (nhds (0 : ℝ)) := by
-        simpa using hnorm
-      refine hnorm_zero.congr (fun N => ?_)
-      rw [hNormalizedInner (B b0) (μA a0) (μB b0) hμA_ne hμB_ne N]
-    exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
+    simpa [b0] using hDominant_contra.1
   have hDominantA_contra :
       (∀ k : Fin rB, Tendsto (fun N => mpvOverlap (d := d) (A a0) (B k) N)
         atTop (nhds 0)) → False := by
-    intro hall
-    have hall_inner : ∀ k : Fin rB,
-        Tendsto (fun N => mpvInner (d := d) (A a0) (B k) N) atTop (nhds 0) :=
-      fun k => tendsto_inner_zero (A a0) (B k) (hall k)
-    have hA_proj :
-        Tendsto
-          (fun N : ℕ =>
-            (μA a0 ^ N)⁻¹ *
-              (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (A a0) (A j) N))
-          atTop (nhds 1) := by
-      have hsum :
-          Tendsto
-            (fun N : ℕ =>
-              ∑ j : Fin rA, (μA j / μA a0) ^ N *
-                mpvInner (d := d) (A a0) (A j) N)
-            atTop (nhds 1) :=
-        sum_tendsto_one_of_diag (hμ0 := hμA_ne) (j0 := a0) rfl (hA_inner_diag a0)
-          (fun j hj => by
-            rw [norm_div]
-            exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
-              (hA.mu_strict_anti (by
-                simp only [a0, Fin.lt_def]
-                exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h)))))
-          (fun j hj => hA_inner_off a0 j hj.symm)
-      convert hsum using 1
-      ext N
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro j _
-      rw [div_pow]
-      field_simp [pow_ne_zero N hμA_ne]
-    have hB_proj_sum :
-        Tendsto
-          (fun N : ℕ =>
-            ∑ k : Fin rB, (μB k / μB b0) ^ N *
-              mpvInner (d := d) (A a0) (B k) N)
-          atTop (nhds 0) := by
-      have := tendsto_finset_sum (Finset.univ : Finset (Fin rB))
-        (fun (k : Fin rB) _ => show
-          Tendsto
-            (fun N : ℕ =>
-              (μB k / μB b0) ^ N * mpvInner (d := d) (A a0) (B k) N)
-            atTop (nhds (0 : ℂ)) from
-          bounded_mul_tendsto_zero _ _ (by
-            rw [norm_div]
-            exact (div_le_one (norm_pos_iff.mpr hμB_ne)).mpr
-              (hB.toIsCanonicalForm.mu_antitone
-                (show b0 ≤ k from Fin.mk_le_mk.mpr (Nat.zero_le _))))
-            (hall_inner k))
-      simpa using this
-    have hB_proj :
-        Tendsto
-          (fun N : ℕ =>
-            (μB b0 ^ N)⁻¹ *
-              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (A a0) (B k) N))
-          atTop (nhds 0) := by
-      convert hB_proj_sum using 1
-      ext N
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro k _
-      rw [div_pow]
-      field_simp [pow_ne_zero N hμB_ne]
-    have hRHS_norm_zero :
-        Tendsto
-          (fun N : ℕ =>
-            ‖(c N * (μB b0 / μA a0) ^ N) *
-              ((μB b0 ^ N)⁻¹ *
-                (∑ k : Fin rB, (μB k) ^ N *
-                  mpvInner (d := d) (A a0) (B k) N))‖)
-          atTop (nhds (0 : ℝ)) := by
-      have hmul := hAdjustedScalar_dom.mul hB_proj.norm
-      simpa [norm_mul] using hmul
-    have hRHS_norm_one :
-        Tendsto
-          (fun N : ℕ =>
-            ‖(c N * (μB b0 / μA a0) ^ N) *
-              ((μB b0 ^ N)⁻¹ *
-                (∑ k : Fin rB, (μB k) ^ N *
-                  mpvInner (d := d) (A a0) (B k) N))‖)
-          atTop (nhds (1 : ℝ)) := by
-      have hnorm := hA_proj.norm
-      have hnorm_one :
-          Tendsto
-            (fun N : ℕ =>
-              ‖(μA a0 ^ N)⁻¹ *
-                (∑ j : Fin rA, (μA j) ^ N *
-                  mpvInner (d := d) (A a0) (A j) N)‖)
-            atTop (nhds (1 : ℝ)) := by
-        simpa using hnorm
-      refine hnorm_one.congr (fun N => ?_)
-      rw [hNormalizedInner (A a0) (μA a0) (μB b0) hμA_ne hμB_ne N]
-    exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
+    simpa [a0] using hDominant_contra.2
   -- Remaining CPSV16 line 1170--1192 step: lift the dominant contradictions
   -- `hDominantA_contra` and `hDominantB_contra` to arbitrary blocks by the
   -- same tail-reduction argument used in the equal-MPV theorem above.

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -821,6 +821,18 @@ lemma exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT
   have hB_cross : ∀ j k : Fin rB, j ≠ k →
       Tendsto (fun N => mpvOverlap (d := d) (B j) (B k) N) atTop (nhds 0) :=
     hB.cross_overlap_tendsto_zero
+  have hA_inner_diag : ∀ j : Fin rA,
+      Tendsto (fun N => mpvInner (d := d) (A j) (A j) N) atTop (nhds 1) :=
+    fun j => tendsto_inner_one (A j) (hA_self j)
+  have hA_inner_off : ∀ i j : Fin rA, i ≠ j →
+      Tendsto (fun N => mpvInner (d := d) (A i) (A j) N) atTop (nhds 0) :=
+    fun i j hij => tendsto_inner_zero (A i) (A j) (hA_cross i j hij)
+  have hB_inner_diag : ∀ k : Fin rB,
+      Tendsto (fun N => mpvInner (d := d) (B k) (B k) N) atTop (nhds 1) :=
+    fun k => tendsto_inner_one (B k) (hB_self k)
+  have hB_inner_off : ∀ i j : Fin rB, i ≠ j →
+      Tendsto (fun N => mpvInner (d := d) (B i) (B j) N) atTop (nhds 0) :=
+    fun i j hij => tendsto_inner_zero (B i) (B j) (hB_cross i j hij)
   obtain ⟨c, hc, hState⟩ :=
     exists_weighted_mpvState_eq_smul_sequence_of_nonzeroProportionalMPV₂_toTensorFromBlocks
       A B hProp
@@ -878,10 +890,201 @@ lemma exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT
     tendsto_norm_adjusted_weighted_mpvState_scalar_of_tendsto_norm_one
       A B c (μA a0) (μB b0) hμA_ne hμB_ne hState
       hA_norm_dominant hB_norm_dominant
-  -- Remaining CPSV16 line 1170--1192 step: use `hNormalizedInner`, `hc`,
-  -- `hAdjustedScalar_dom`, and the BNT self/cross-overlap convergence facts
-  -- above to rule out simultaneous decay against a fixed block, then repeat
-  -- with A and B interchanged.
+  have hDominantB_contra :
+      (∀ j : Fin rA, Tendsto (fun N => mpvOverlap (d := d) (A j) (B b0) N)
+        atTop (nhds 0)) → False := by
+    intro hall
+    have hall_inner : ∀ j : Fin rA,
+        Tendsto (fun N => mpvInner (d := d) (B b0) (A j) N) atTop (nhds 0) :=
+      fun j => tendsto_inner_zero_swap (d := d) (A j) (B b0) (hall j)
+    have hA_proj_sum :
+        Tendsto
+          (fun N : ℕ =>
+            ∑ j : Fin rA, (μA j / μA a0) ^ N *
+              mpvInner (d := d) (B b0) (A j) N)
+          atTop (nhds 0) := by
+      have := tendsto_finset_sum (Finset.univ : Finset (Fin rA))
+        (fun (j : Fin rA) _ => show
+          Tendsto
+            (fun N : ℕ =>
+              (μA j / μA a0) ^ N * mpvInner (d := d) (B b0) (A j) N)
+            atTop (nhds (0 : ℂ)) from
+          bounded_mul_tendsto_zero _ _ (by
+            rw [norm_div]
+            exact (div_le_one (norm_pos_iff.mpr hμA_ne)).mpr
+              (hA.toIsCanonicalForm.mu_antitone
+                (show a0 ≤ j from Fin.mk_le_mk.mpr (Nat.zero_le _))))
+            (hall_inner j))
+      simpa using this
+    have hA_proj :
+        Tendsto
+          (fun N : ℕ =>
+            (μA a0 ^ N)⁻¹ *
+              (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N))
+          atTop (nhds 0) := by
+      convert hA_proj_sum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμA_ne]
+    have hB_proj :
+        Tendsto
+          (fun N : ℕ =>
+            (μB b0 ^ N)⁻¹ *
+              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N))
+          atTop (nhds 1) := by
+      have hsum :
+          Tendsto
+            (fun N : ℕ =>
+              ∑ k : Fin rB, (μB k / μB b0) ^ N *
+                mpvInner (d := d) (B b0) (B k) N)
+            atTop (nhds 1) :=
+        sum_tendsto_one_of_diag (hμ0 := hμB_ne) (j0 := b0) rfl (hB_inner_diag b0)
+          (fun k hk => by
+            rw [norm_div]
+            exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
+              (hB.mu_strict_anti (by
+                simp only [b0, Fin.lt_def]
+                exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h)))))
+          (fun k hk => hB_inner_off b0 k hk.symm)
+      convert hsum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμB_ne]
+    have hRHS_norm_one :
+        Tendsto
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (B b0) (B k) N))‖)
+          atTop (nhds (1 : ℝ)) := by
+      have hmul := hAdjustedScalar_dom.mul hB_proj.norm
+      simpa [norm_mul] using hmul
+    have hRHS_norm_zero :
+        Tendsto
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (B b0) (B k) N))‖)
+          atTop (nhds (0 : ℝ)) := by
+      have hnorm := hA_proj.norm
+      have hnorm_zero :
+          Tendsto
+            (fun N : ℕ =>
+              ‖(μA a0 ^ N)⁻¹ *
+                (∑ j : Fin rA, (μA j) ^ N *
+                  mpvInner (d := d) (B b0) (A j) N)‖)
+            atTop (nhds (0 : ℝ)) := by
+        simpa using hnorm
+      refine hnorm_zero.congr (fun N => ?_)
+      rw [hNormalizedInner (B b0) (μA a0) (μB b0) hμA_ne hμB_ne N]
+    exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
+  have hDominantA_contra :
+      (∀ k : Fin rB, Tendsto (fun N => mpvOverlap (d := d) (A a0) (B k) N)
+        atTop (nhds 0)) → False := by
+    intro hall
+    have hall_inner : ∀ k : Fin rB,
+        Tendsto (fun N => mpvInner (d := d) (A a0) (B k) N) atTop (nhds 0) :=
+      fun k => tendsto_inner_zero (A a0) (B k) (hall k)
+    have hA_proj :
+        Tendsto
+          (fun N : ℕ =>
+            (μA a0 ^ N)⁻¹ *
+              (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (A a0) (A j) N))
+          atTop (nhds 1) := by
+      have hsum :
+          Tendsto
+            (fun N : ℕ =>
+              ∑ j : Fin rA, (μA j / μA a0) ^ N *
+                mpvInner (d := d) (A a0) (A j) N)
+            atTop (nhds 1) :=
+        sum_tendsto_one_of_diag (hμ0 := hμA_ne) (j0 := a0) rfl (hA_inner_diag a0)
+          (fun j hj => by
+            rw [norm_div]
+            exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
+              (hA.mu_strict_anti (by
+                simp only [a0, Fin.lt_def]
+                exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h)))))
+          (fun j hj => hA_inner_off a0 j hj.symm)
+      convert hsum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμA_ne]
+    have hB_proj_sum :
+        Tendsto
+          (fun N : ℕ =>
+            ∑ k : Fin rB, (μB k / μB b0) ^ N *
+              mpvInner (d := d) (A a0) (B k) N)
+          atTop (nhds 0) := by
+      have := tendsto_finset_sum (Finset.univ : Finset (Fin rB))
+        (fun (k : Fin rB) _ => show
+          Tendsto
+            (fun N : ℕ =>
+              (μB k / μB b0) ^ N * mpvInner (d := d) (A a0) (B k) N)
+            atTop (nhds (0 : ℂ)) from
+          bounded_mul_tendsto_zero _ _ (by
+            rw [norm_div]
+            exact (div_le_one (norm_pos_iff.mpr hμB_ne)).mpr
+              (hB.toIsCanonicalForm.mu_antitone
+                (show b0 ≤ k from Fin.mk_le_mk.mpr (Nat.zero_le _))))
+            (hall_inner k))
+      simpa using this
+    have hB_proj :
+        Tendsto
+          (fun N : ℕ =>
+            (μB b0 ^ N)⁻¹ *
+              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (A a0) (B k) N))
+          atTop (nhds 0) := by
+      convert hB_proj_sum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμB_ne]
+    have hRHS_norm_zero :
+        Tendsto
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (A a0) (B k) N))‖)
+          atTop (nhds (0 : ℝ)) := by
+      have hmul := hAdjustedScalar_dom.mul hB_proj.norm
+      simpa [norm_mul] using hmul
+    have hRHS_norm_one :
+        Tendsto
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (A a0) (B k) N))‖)
+          atTop (nhds (1 : ℝ)) := by
+      have hnorm := hA_proj.norm
+      have hnorm_one :
+          Tendsto
+            (fun N : ℕ =>
+              ‖(μA a0 ^ N)⁻¹ *
+                (∑ j : Fin rA, (μA j) ^ N *
+                  mpvInner (d := d) (A a0) (A j) N)‖)
+            atTop (nhds (1 : ℝ)) := by
+        simpa using hnorm
+      refine hnorm_one.congr (fun N => ?_)
+      rw [hNormalizedInner (A a0) (μA a0) (μB b0) hμA_ne hμB_ne N]
+    exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
+  -- Remaining CPSV16 line 1170--1192 step: lift the dominant contradictions
+  -- `hDominantA_contra` and `hDominantB_contra` to arbitrary blocks by the
+  -- same tail-reduction argument used in the equal-MPV theorem above.
   sorry
 
 end HeteroEqualCase

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.Full.ProportionalExpansion
+
+/-!
+# Dominant projected contradiction for proportional BNT families
+
+This module contains the dominant-block projection contradiction used in the
+proportional non-decaying-overlap step of the fundamental theorem.
+
+## References
+
+* Cirac, Pérez-García, Schuch, Verstraete, *Fundamental Theorems for PEPS*,
+  arXiv:1606.00608 (2017), Theorem `thm1`, lines 1170--1192.
+-/
+
+open scoped Matrix BigOperators InnerProductSpace
+open Filter
+
+namespace MPSTensor
+
+section ProportionalDominant
+
+/-- **Dominant-block projection contradiction for proportional BNT families.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. If the normalized
+proportional projection identity has an adjusted scalar whose modulus tends to
+one, then the dominant block on either side cannot have all cross-overlaps
+tending to zero. This is the dominant case of the CPSV16 line 1182 argument. -/
+lemma dominant_projection_contradictions_of_normalized_proportional_inner
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (c : ℕ → ℂ)
+    (hNormalizedInner :
+      ∀ {D : ℕ} (X : MPSTensor d D) (μ ν : ℂ),
+        μ ≠ 0 → ν ≠ 0 → ∀ N : ℕ,
+          (μ ^ N)⁻¹ *
+              (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) X (A j) N) =
+            (c N * (ν / μ) ^ N) *
+              ((ν ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N)))
+    (hAdjustedScalar_dom :
+      Tendsto
+        (fun N : ℕ =>
+          ‖c N * (μB ⟨0, Nat.pos_of_ne_zero hrB⟩ /
+            μA ⟨0, Nat.pos_of_ne_zero hrA⟩) ^ N‖)
+        atTop (nhds (1 : ℝ)))
+    (hA_self : ∀ j : Fin rA,
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (A j) N) atTop (nhds 1))
+    (hB_self : ∀ k : Fin rB,
+      Tendsto (fun N => mpvOverlap (d := d) (B k) (B k) N) atTop (nhds 1))
+    (hA_cross : ∀ j k : Fin rA, j ≠ k →
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (A k) N) atTop (nhds 0))
+    (hB_cross : ∀ j k : Fin rB, j ≠ k →
+      Tendsto (fun N => mpvOverlap (d := d) (B j) (B k) N) atTop (nhds 0)) :
+    ((∀ j : Fin rA,
+        Tendsto
+          (fun N => mpvOverlap (d := d) (A j)
+            (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N)
+          atTop (nhds 0)) → False) ∧
+    ((∀ k : Fin rB,
+        Tendsto
+          (fun N => mpvOverlap (d := d)
+            (A ⟨0, Nat.pos_of_ne_zero hrA⟩) (B k) N)
+          atTop (nhds 0)) → False) := by
+  let a0 : Fin rA := ⟨0, Nat.pos_of_ne_zero hrA⟩
+  let b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
+  have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
+  have hμB_ne : μB b0 ≠ 0 := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero b0
+  have hA_inner_diag : ∀ j : Fin rA,
+      Tendsto (fun N => mpvInner (d := d) (A j) (A j) N) atTop (nhds 1) :=
+    fun j => tendsto_inner_one (A j) (hA_self j)
+  have hA_inner_off : ∀ i j : Fin rA, i ≠ j →
+      Tendsto (fun N => mpvInner (d := d) (A i) (A j) N) atTop (nhds 0) :=
+    fun i j hij => tendsto_inner_zero (A i) (A j) (hA_cross i j hij)
+  have hB_inner_diag : ∀ k : Fin rB,
+      Tendsto (fun N => mpvInner (d := d) (B k) (B k) N) atTop (nhds 1) :=
+    fun k => tendsto_inner_one (B k) (hB_self k)
+  have hB_inner_off : ∀ i j : Fin rB, i ≠ j →
+      Tendsto (fun N => mpvInner (d := d) (B i) (B j) N) atTop (nhds 0) :=
+    fun i j hij => tendsto_inner_zero (B i) (B j) (hB_cross i j hij)
+  have hAdjustedScalar :
+      Tendsto (fun N : ℕ => ‖c N * (μB b0 / μA a0) ^ N‖) atTop
+        (nhds (1 : ℝ)) := by
+    simpa [a0, b0] using hAdjustedScalar_dom
+  have hDominantB_contra :
+      (∀ j : Fin rA, Tendsto (fun N => mpvOverlap (d := d) (A j) (B b0) N)
+        atTop (nhds 0)) → False := by
+    intro hall
+    have hall_inner : ∀ j : Fin rA,
+        Tendsto (fun N => mpvInner (d := d) (B b0) (A j) N) atTop (nhds 0) :=
+      fun j => tendsto_inner_zero_swap (d := d) (A j) (B b0) (hall j)
+    have hA_proj_sum :
+        Tendsto
+          (fun N : ℕ =>
+            ∑ j : Fin rA, (μA j / μA a0) ^ N *
+              mpvInner (d := d) (B b0) (A j) N)
+          atTop (nhds 0) := by
+      have := tendsto_finset_sum (Finset.univ : Finset (Fin rA))
+        (fun (j : Fin rA) _ => show
+          Tendsto
+            (fun N : ℕ =>
+              (μA j / μA a0) ^ N * mpvInner (d := d) (B b0) (A j) N)
+            atTop (nhds (0 : ℂ)) from
+          bounded_mul_tendsto_zero _ _ (by
+            rw [norm_div]
+            exact (div_le_one (norm_pos_iff.mpr hμA_ne)).mpr
+              (hA.toIsCanonicalForm.mu_antitone
+                (show a0 ≤ j from Fin.mk_le_mk.mpr (Nat.zero_le _))))
+            (hall_inner j))
+      simpa using this
+    have hA_proj :
+        Tendsto
+          (fun N : ℕ =>
+            (μA a0 ^ N)⁻¹ *
+              (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N))
+          atTop (nhds 0) := by
+      convert hA_proj_sum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμA_ne]
+    have hB_proj :
+        Tendsto
+          (fun N : ℕ =>
+            (μB b0 ^ N)⁻¹ *
+              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N))
+          atTop (nhds 1) := by
+      have hsum :
+          Tendsto
+            (fun N : ℕ =>
+              ∑ k : Fin rB, (μB k / μB b0) ^ N *
+                mpvInner (d := d) (B b0) (B k) N)
+            atTop (nhds 1) :=
+        sum_tendsto_one_of_diag (hμ0 := hμB_ne) (j0 := b0) rfl (hB_inner_diag b0)
+          (fun k hk => by
+            rw [norm_div]
+            exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
+              (hB.mu_strict_anti (by
+                simp only [b0, Fin.lt_def]
+                exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h)))))
+          (fun k hk => hB_inner_off b0 k hk.symm)
+      convert hsum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμB_ne]
+    have hRHS_norm_one :
+        Tendsto
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (B b0) (B k) N))‖)
+          atTop (nhds (1 : ℝ)) := by
+      have hmul := hAdjustedScalar.mul hB_proj.norm
+      simpa [norm_mul] using hmul
+    have hRHS_norm_zero :
+        Tendsto
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (B b0) (B k) N))‖)
+          atTop (nhds (0 : ℝ)) := by
+      have hnorm := hA_proj.norm
+      have hnorm_zero :
+          Tendsto
+            (fun N : ℕ =>
+              ‖(μA a0 ^ N)⁻¹ *
+                (∑ j : Fin rA, (μA j) ^ N *
+                  mpvInner (d := d) (B b0) (A j) N)‖)
+            atTop (nhds (0 : ℝ)) := by
+        simpa using hnorm
+      refine hnorm_zero.congr (fun N => ?_)
+      rw [hNormalizedInner (B b0) (μA a0) (μB b0) hμA_ne hμB_ne N]
+    exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
+  have hDominantA_contra :
+      (∀ k : Fin rB, Tendsto (fun N => mpvOverlap (d := d) (A a0) (B k) N)
+        atTop (nhds 0)) → False := by
+    intro hall
+    have hall_inner : ∀ k : Fin rB,
+        Tendsto (fun N => mpvInner (d := d) (A a0) (B k) N) atTop (nhds 0) :=
+      fun k => tendsto_inner_zero (A a0) (B k) (hall k)
+    have hA_proj :
+        Tendsto
+          (fun N : ℕ =>
+            (μA a0 ^ N)⁻¹ *
+              (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (A a0) (A j) N))
+          atTop (nhds 1) := by
+      have hsum :
+          Tendsto
+            (fun N : ℕ =>
+              ∑ j : Fin rA, (μA j / μA a0) ^ N *
+                mpvInner (d := d) (A a0) (A j) N)
+            atTop (nhds 1) :=
+        sum_tendsto_one_of_diag (hμ0 := hμA_ne) (j0 := a0) rfl (hA_inner_diag a0)
+          (fun j hj => by
+            rw [norm_div]
+            exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
+              (hA.mu_strict_anti (by
+                simp only [a0, Fin.lt_def]
+                exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h)))))
+          (fun j hj => hA_inner_off a0 j hj.symm)
+      convert hsum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμA_ne]
+    have hB_proj_sum :
+        Tendsto
+          (fun N : ℕ =>
+            ∑ k : Fin rB, (μB k / μB b0) ^ N *
+              mpvInner (d := d) (A a0) (B k) N)
+          atTop (nhds 0) := by
+      have := tendsto_finset_sum (Finset.univ : Finset (Fin rB))
+        (fun (k : Fin rB) _ => show
+          Tendsto
+            (fun N : ℕ =>
+              (μB k / μB b0) ^ N * mpvInner (d := d) (A a0) (B k) N)
+            atTop (nhds (0 : ℂ)) from
+          bounded_mul_tendsto_zero _ _ (by
+            rw [norm_div]
+            exact (div_le_one (norm_pos_iff.mpr hμB_ne)).mpr
+              (hB.toIsCanonicalForm.mu_antitone
+                (show b0 ≤ k from Fin.mk_le_mk.mpr (Nat.zero_le _))))
+            (hall_inner k))
+      simpa using this
+    have hB_proj :
+        Tendsto
+          (fun N : ℕ =>
+            (μB b0 ^ N)⁻¹ *
+              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (A a0) (B k) N))
+          atTop (nhds 0) := by
+      convert hB_proj_sum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμB_ne]
+    have hRHS_norm_zero :
+        Tendsto
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (A a0) (B k) N))‖)
+          atTop (nhds (0 : ℝ)) := by
+      have hmul := hAdjustedScalar.mul hB_proj.norm
+      simpa [norm_mul] using hmul
+    have hRHS_norm_one :
+        Tendsto
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (A a0) (B k) N))‖)
+          atTop (nhds (1 : ℝ)) := by
+      have hnorm := hA_proj.norm
+      have hnorm_one :
+          Tendsto
+            (fun N : ℕ =>
+              ‖(μA a0 ^ N)⁻¹ *
+                (∑ j : Fin rA, (μA j) ^ N *
+                  mpvInner (d := d) (A a0) (A j) N)‖)
+            atTop (nhds (1 : ℝ)) := by
+        simpa using hnorm
+      refine hnorm_one.congr (fun N => ?_)
+      rw [hNormalizedInner (A a0) (μA a0) (μB b0) hμA_ne hμB_ne N]
+    exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
+  exact ⟨by simpa [b0] using hDominantB_contra, by simpa [a0] using hDominantA_contra⟩
+
+end ProportionalDominant
+
+end MPSTensor


### PR DESCRIPTION
## Summary

This continues Stage C of the CPSV16 Section II realignment after #1577.

It proves the two dominant-block normalized projection contradictions in the
new helper
`MPSTensor.dominant_projection_contradictions_of_normalized_proportional_inner`:

- fixed dominant `B b0`: simultaneous decay of all overlaps with the `A_j` contradicts normalized proportionality;
- fixed dominant `A a0`: simultaneous decay of all overlaps with the `B_k` contradicts normalized proportionality.

The argument uses exactly the source-facing data already present in the theorem:
`hNormalizedInner`, `hAdjustedScalar_dom`, BNT self/cross-overlap convergence, and strict weight ordering. It does not reintroduce the deleted proportional coefficient-array branch.

## Remaining work

The theorem still has the same intentional paper-realignment proof gap from #1563, now at
`TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean:897`.

What remains is the tail-reduction step lifting the two dominant contradictions to arbitrary blocks, analogous to the equal-MPV theorem earlier in the same file.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap`
- `lake build`
- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py --root TNLean`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`

The only `sorry` reported in the edited file is the tracked #1563 paper-realignment gap.

Refs #1559
Refs #1563
