### PR TITLE
feat(MPS/FT): add proportional tail state helpers

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -107,6 +107,93 @@ lemma exists_weighted_mpvState_eq_smul_sequence_of_nonzeroProportionalMPV₂_toT
   choose c hc hEq using h
   exact ⟨c, hc, hEq⟩
 
+/-- **Nonzero proportionality from a weighted MPV-state scalar sequence.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the
+block-selection proof, after expanding canonical-form tensors into weighted
+BNT block sums, a lengthwise nonzero scalar identity of the weighted MPV-state
+sums is exactly the corresponding projective proportionality of the assembled
+tensors. This is the converse bookkeeping direction to
+`exists_weighted_mpvState_eq_smul_sequence_of_nonzeroProportionalMPV₂_toTensorFromBlocks`. -/
+lemma nonzeroProportionalMPV₂_toTensorFromBlocks_of_weighted_mpvState_eq_smul_sequence
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (c : ℕ → ℂ) (hc : ∀ N : ℕ, c N ≠ 0)
+    (hState : ∀ N : ℕ,
+      (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)) :
+    NonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B) := by
+  intro N
+  refine ⟨c N, hc N, fun σ => ?_⟩
+  have hAstate :
+      mpvState (d := d) (toTensorFromBlocks μA A) N =
+        ∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N := by
+    refine mpvState_eq_sum_of_decomp
+      (d := d) (toTensorFromBlocks μA A) A
+      (N := N) (fun j : Fin rA => (μA j) ^ N) ?_
+    intro τ
+    simpa [smul_eq_mul] using
+      mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μA) (A := A) τ
+  have hBstate :
+      mpvState (d := d) (toTensorFromBlocks μB B) N =
+        ∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N := by
+    refine mpvState_eq_sum_of_decomp
+      (d := d) (toTensorFromBlocks μB B) B
+      (N := N) (fun k : Fin rB => (μB k) ^ N) ?_
+    intro τ
+    simpa [smul_eq_mul] using
+      mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μB) (A := B) τ
+  have hN := congrArg (fun v : MPVSpace d N => v σ) (hState N)
+  have hAcoeff :=
+    mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μA) (A := A) σ
+  have hBcoeff :=
+    mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μB) (A := B) σ
+  calc
+    mpv (toTensorFromBlocks μA A) σ =
+        ∑ j : Fin rA, (μA j) ^ N * mpv (A j) σ := by
+          simpa [smul_eq_mul] using hAcoeff
+    _ = c N * (∑ k : Fin rB, (μB k) ^ N * mpv (B k) σ) := by
+      simpa [mpvState_apply, hAstate, hBstate, Pi.smul_apply, smul_eq_mul] using hN
+    _ = c N * (∑ k : Fin rB, (μB k) ^ N • mpv (B k) σ) := by
+      simp [smul_eq_mul]
+    _ = c N * mpv (toTensorFromBlocks μB B) σ := by
+      rw [← hBcoeff]
+
+/-- **Subtracting a proportional dominant summand from weighted MPV-state sums.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof removes
+the already matched leading BNT component and continues with the remaining
+blocks. This lemma isolates the linear algebra: if the total weighted MPV-state
+sums are related by the scalar `c_N`, and the selected summands are related by
+the same scalar, then the erased tails are related by the same scalar. -/
+lemma weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (c : ℕ → ℂ) (a0 : Fin rA) (b0 : Fin rB)
+    (hState : ∀ N : ℕ,
+      (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N))
+    (hSelected : ∀ N : ℕ,
+      (μA a0) ^ N • mpvState (d := d) (A a0) N =
+        c N • ((μB b0) ^ N • mpvState (d := d) (B b0) N)) :
+    ∀ N : ℕ,
+      ∑ j ∈ Finset.univ.erase a0, (μA j) ^ N • mpvState (d := d) (A j) N =
+        c N •
+          (∑ k ∈ Finset.univ.erase b0, (μB k) ^ N • mpvState (d := d) (B k) N) := by
+  intro N
+  have hN := hState N
+  rw [← Finset.add_sum_erase _ _ (Finset.mem_univ a0),
+    ← Finset.add_sum_erase _ _ (Finset.mem_univ b0), smul_add] at hN
+  rw [hSelected N] at hN
+  exact add_left_cancel hN
+
 /-- **Projection of a fixed weighted MPV-state scalar sequence.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. Once the

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -63,6 +63,49 @@ with an extra $Z$-gauge degree of freedom.
 	Lemma~\ref{lem:proportional_tensor_from_blocks_weighted_states}.
 \end{proof}
 
+\begin{lemma}[Weighted state sequences are exactly assembled proportionality]%
+\label{lem:weighted_state_sequence_to_proportional_tensor_from_blocks}
+	\lean{MPSTensor.nonzeroProportionalMPV₂_toTensorFromBlocks_of_weighted_mpvState_eq_smul_sequence}
+	\leanok
+	\uses{def:nonzero_proportional_mpv, def:tensor_from_blocks, def:mpv_state}
+	Conversely, suppose that for assembled block tensors
+	\(A=\bigoplus_j \mu_j A_j\) and \(B=\bigoplus_k \nu_k B_k\) there is a
+	sequence of nonzero scalars \(c_N\) such that
+	\[
+		\sum_j \mu_j^N \ket{V^{(N)}(A_j)}
+		=
+		c_N\sum_k \nu_k^N \ket{V^{(N)}(B_k)}
+	\]
+	for every \(N\).  Then the assembled MPV families are nonzero
+	proportional.
+\end{lemma}
+
+\begin{proof}\leanok
+	Expand the MPV state of each assembled tensor into its weighted block sum
+	and evaluate the state identity on each basis word.
+\end{proof}
+
+\begin{lemma}[Subtracting a proportional selected summand]%
+\label{lem:proportional_weighted_state_tail_subtraction}
+	\lean{MPSTensor.weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected}
+	\leanok
+	\uses{lem:proportional_tensor_from_blocks_weighted_state_sequence}
+	Suppose two weighted block-state sums are related by a scalar sequence
+	\(c_N\).  If selected summands \(A_{j_0}\) and \(B_{k_0}\) are themselves
+	related by the same scalar sequence, then the sums over the erased tails
+	are also related by \(c_N\):
+	\[
+		\sum_{j\ne j_0}\mu_j^N\ket{V^{(N)}(A_j)}
+		=
+		c_N\sum_{k\ne k_0}\nu_k^N\ket{V^{(N)}(B_k)}.
+	\]
+\end{lemma}
+
+\begin{proof}\leanok
+	Split both finite sums into the selected summand and the erased tail, use
+	the selected-summand identity, and cancel the common selected term.
+\end{proof}
+
 \begin{lemma}[Norm convergence for scalar-related normalized vectors]%
 \label{lem:proportional_scalar_norm_core}
 	\lean{MPSTensor.tendsto_norm_scalar_of_tendsto_norm_one}


### PR DESCRIPTION
## Summary

This is a small Stage C helper step for #1563.

It adds two source-cited proportional expansion lemmas:

- `MPSTensor.nonzeroProportionalMPV₂_toTensorFromBlocks_of_weighted_mpvState_eq_smul_sequence`
- `MPSTensor.weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected`

Together these package the algebra needed for the remaining CPSV16 line 1182 tail reduction: after the matched leading summand is removed, the erased tail weighted-state identity can be converted back into `NonzeroProportionalMPV₂` for the recursively reindexed tail families.

The blueprint now records both helper lemmas.

## Remaining work

This PR does not close #1563. The remaining gap is still the tail-recursive proof at
`TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean:897`.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.ProportionalExpansion`
- `lake build TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

Refs #1559
Refs #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean helper lemmas and corresponding blueprint documentation, with no runtime behavior changes; main risk is proof breakage or downstream lemma dependency changes.
> 
> **Overview**
> Adds a converse lemma `nonzeroProportionalMPV₂_toTensorFromBlocks_of_weighted_mpvState_eq_smul_sequence` showing that a *lengthwise nonzero* scalar sequence relating the weighted block `mpvState` sums implies `NonzeroProportionalMPV₂` for the assembled tensors.
> 
> Adds `weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected`, which cancels a selected proportional summand from both sides of a weighted-state identity to derive the same scalar relation for the erased tail sums.
> 
> Updates the blueprint to document and reference both new lemmas in the fundamental theorem proof chapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51699d393ad0d48c19548f5e4f196b8939adfb52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->