### PR TITLE
feat(MPS/FT): add eventual proportional tail helpers

### DIFF
--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -2,6 +2,7 @@ import Mathlib.Data.Complex.Basic
 import Mathlib.Data.List.OfFn
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.Order.Filter.AtTopBot.Basic
 
 /-!
 # Basic definitions for matrix product state tensors
@@ -122,6 +123,22 @@ def NonzeroProportionalMPV₂ {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
   ∀ N : ℕ, ∃ c : ℂ, c ≠ 0 ∧ ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ
 
+/-- Eventual nonzero proportionality of MPV families.
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
+`Lem1`, an eventual linear-independence statement. This auxiliary predicate is
+the corresponding eventual version of the projective proportionality relation:
+for all sufficiently large lengths, the two MPV vectors lie on the same nonzero
+projective line. The theorem hypothesis in line 1169 gives the stronger
+all-length predicate `NonzeroProportionalMPV₂`; this predicate is used only for
+tail reductions where finitely many initial lengths are irrelevant to the
+asymptotic conclusion. -/
+def EventuallyNonzeroProportionalMPV₂ {d D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
+  Filter.Eventually
+    (fun N : ℕ => ∃ c : ℂ, c ≠ 0 ∧ ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ)
+    Filter.atTop
+
 /-- Nonzero MPV proportionality forgets to weak MPV proportionality.
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. This is the
@@ -135,6 +152,18 @@ theorem NonzeroProportionalMPV₂.toProportionalMPV₂ {d D₁ D₂ : ℕ}
   intro N
   rcases h N with ⟨c, _hc, hN⟩
   exact ⟨c, hN⟩
+
+/-- All-length nonzero MPV proportionality gives eventual nonzero MPV proportionality.
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1169--1182. The theorem assumes
+proportionality at every length; the proof later invokes the eventual
+linear-independence Lemma `Lem1`, so the same hypothesis may be used in eventual
+form. -/
+theorem NonzeroProportionalMPV₂.eventually {d D₁ D₂ : ℕ}
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (h : NonzeroProportionalMPV₂ A B) :
+    EventuallyNonzeroProportionalMPV₂ A B :=
+  Filter.Eventually.of_forall h
 
 /-- Nonzero MPV proportionality is symmetric.
 

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -20,32 +20,32 @@ external coefficient-array hypotheses are introduced.
 -/
 
 open scoped BigOperators InnerProductSpace
+open Filter
 
 namespace MPSTensor
 
 section ProportionalExpansion
 
-/-- **Weighted MPV-state proportionality from proportional assembled block tensors.**
+/-- **Fixed-length weighted MPV-state proportionality from assembled block tensors.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof of the
-block-selection step expands the two canonical-form tensors into their BNT
-block sums and then uses proportionality of the total MPV families. This lemma
-formalizes exactly that expansion, without adding coefficient-array hypotheses:
-the scalar is the one supplied by the proportionality of the assembled tensors
-at the fixed length `N`. -/
-lemma exists_weighted_mpvState_eq_smul_of_nonzeroProportionalMPV₂_toTensorFromBlocks
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. At a fixed length
+`N`, proportionality of the two assembled tensors expands into proportionality
+of the two weighted BNT block sums at that same length. This is the fixed-length
+form used before passing to scalar sequences or eventual tail reductions. -/
+lemma exists_weighted_mpvState_eq_smul_of_nonzeroProportional_at_length_toTensorFromBlocks
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
     {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
     (A : (j : Fin rA) → MPSTensor d (dimA j))
     (B : (k : Fin rB) → MPSTensor d (dimB k))
-    (hProp : NonzeroProportionalMPV₂
-      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
-    (N : ℕ) :
+    (N : ℕ)
+    (hN : ∃ c : ℂ, c ≠ 0 ∧
+      ∀ σ : Fin N → Fin d,
+        mpv (toTensorFromBlocks μA A) σ = c * mpv (toTensorFromBlocks μB B) σ) :
     ∃ c : ℂ, c ≠ 0 ∧
       (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
         c • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N) := by
-  rcases hProp N with ⟨c, hc, hN⟩
+  rcases hN with ⟨c, hc, hN⟩
   have hAstate :
       mpvState (d := d) (toTensorFromBlocks μA A) N =
         ∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N := by
@@ -78,6 +78,29 @@ lemma exists_weighted_mpvState_eq_smul_of_nonzeroProportionalMPV₂_toTensorFrom
     _ = c • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N) := by
       rw [hBstate]
 
+/-- **Weighted MPV-state proportionality from proportional assembled block tensors.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof of the
+block-selection step expands the two canonical-form tensors into their BNT
+block sums and then uses proportionality of the total MPV families. This lemma
+formalizes exactly that expansion, without adding coefficient-array hypotheses:
+the scalar is the one supplied by the proportionality of the assembled tensors
+at the fixed length `N`. -/
+lemma exists_weighted_mpvState_eq_smul_of_nonzeroProportionalMPV₂_toTensorFromBlocks
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hProp : NonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (N : ℕ) :
+    ∃ c : ℂ, c ≠ 0 ∧
+      (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N) := by
+  exact exists_weighted_mpvState_eq_smul_of_nonzeroProportional_at_length_toTensorFromBlocks
+    A B N (hProp N)
+
 /-- **A scalar sequence for proportional weighted MPV-state sums.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof uses
@@ -106,6 +129,49 @@ lemma exists_weighted_mpvState_eq_smul_sequence_of_nonzeroProportionalMPV₂_toT
         A B hProp N
   choose c hc hEq using h
   exact ⟨c, hc, hEq⟩
+
+/-- **An eventual scalar sequence for eventually proportional weighted MPV-state sums.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 uses Lemma
+`Lem1`, hence only sufficiently large chain lengths enter the contradiction.
+This lemma is the eventual version of the preceding scalar-sequence
+bookkeeping: eventual nonzero proportionality of the assembled tensors gives an
+eventual nonzero scalar sequence for the expanded weighted BNT block sums. -/
+lemma exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroProportionalMPV₂
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
+    ∃ c : ℕ → ℂ, (∀ᶠ N in atTop, c N ≠ 0) ∧
+      ∀ᶠ N in atTop,
+        (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+          c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N) := by
+  classical
+  let P : ℕ → Prop := fun N =>
+    ∃ c : ℂ, c ≠ 0 ∧
+      (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)
+  have hWeighted : ∀ᶠ N in atTop, P N := by
+    refine hProp.mono ?_
+    intro N hN
+    exact
+      exists_weighted_mpvState_eq_smul_of_nonzeroProportional_at_length_toTensorFromBlocks
+        A B N hN
+  let c : ℕ → ℂ := fun N => if hN : P N then Classical.choose hN else 1
+  refine ⟨c, ?_, ?_⟩
+  · refine hWeighted.mono ?_
+    intro N hN
+    dsimp [c]
+    rw [dif_pos hN]
+    exact (Classical.choose_spec hN).1
+  · refine hWeighted.mono ?_
+    intro N hN
+    dsimp [c]
+    rw [dif_pos hN]
+    exact (Classical.choose_spec hN).2
 
 /-- **Nonzero proportionality from a weighted MPV-state scalar sequence.**
 
@@ -163,6 +229,63 @@ lemma nonzeroProportionalMPV₂_toTensorFromBlocks_of_weighted_mpvState_eq_smul_
     _ = c N * mpv (toTensorFromBlocks μB B) σ := by
       rw [← hBcoeff]
 
+/-- **Eventual proportionality from an eventual weighted MPV-state scalar sequence.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After a finite
+number of leading BNT components has been removed, Lemma `Lem1` supplies
+linear independence only for sufficiently large lengths. This bookkeeping lemma
+turns an eventual weighted MPV-state identity into eventual nonzero
+proportionality of the assembled tail tensors. -/
+lemma eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weighted_mpvState
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (c : ℕ → ℂ) (hc : ∀ᶠ N in atTop, c N ≠ 0)
+    (hState : ∀ᶠ N in atTop,
+      (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)) :
+    EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B) := by
+  refine (hc.and hState).mono ?_
+  intro N hN
+  rcases hN with ⟨hcN, hStateN⟩
+  refine ⟨c N, hcN, fun σ => ?_⟩
+  have hAstate :
+      mpvState (d := d) (toTensorFromBlocks μA A) N =
+        ∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N := by
+    refine mpvState_eq_sum_of_decomp
+      (d := d) (toTensorFromBlocks μA A) A
+      (N := N) (fun j : Fin rA => (μA j) ^ N) ?_
+    intro τ
+    simpa [smul_eq_mul] using
+      mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μA) (A := A) τ
+  have hBstate :
+      mpvState (d := d) (toTensorFromBlocks μB B) N =
+        ∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N := by
+    refine mpvState_eq_sum_of_decomp
+      (d := d) (toTensorFromBlocks μB B) B
+      (N := N) (fun k : Fin rB => (μB k) ^ N) ?_
+    intro τ
+    simpa [smul_eq_mul] using
+      mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μB) (A := B) τ
+  have hNσ := congrArg (fun v : MPVSpace d N => v σ) hStateN
+  have hAcoeff :=
+    mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μA) (A := A) σ
+  have hBcoeff :=
+    mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μB) (A := B) σ
+  calc
+    mpv (toTensorFromBlocks μA A) σ =
+        ∑ j : Fin rA, (μA j) ^ N * mpv (A j) σ := by
+          simpa [smul_eq_mul] using hAcoeff
+    _ = c N * (∑ k : Fin rB, (μB k) ^ N * mpv (B k) σ) := by
+      simpa [mpvState_apply, hAstate, hBstate, Pi.smul_apply, smul_eq_mul] using hNσ
+    _ = c N * (∑ k : Fin rB, (μB k) ^ N • mpv (B k) σ) := by
+      simp [smul_eq_mul]
+    _ = c N * mpv (toTensorFromBlocks μB B) σ := by
+      rw [← hBcoeff]
+
 /-- **Subtracting a proportional dominant summand from weighted MPV-state sums.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof removes
@@ -193,6 +316,38 @@ lemma weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected
     ← Finset.add_sum_erase _ _ (Finset.mem_univ b0), smul_add] at hN
   rw [hSelected N] at hN
   exact add_left_cancel hN
+
+/-- **Eventual subtraction of a proportional selected summand.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. The recursive
+block-selection argument uses Lemma `Lem1`, so tail identities produced after
+coefficient extraction are needed only for sufficiently large lengths. This is
+the eventual analogue of
+`weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected`. -/
+lemma eventually_weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (c : ℕ → ℂ) (a0 : Fin rA) (b0 : Fin rB)
+    (hState : ∀ᶠ N in atTop,
+      (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N))
+    (hSelected : ∀ᶠ N in atTop,
+      (μA a0) ^ N • mpvState (d := d) (A a0) N =
+        c N • ((μB b0) ^ N • mpvState (d := d) (B b0) N)) :
+    ∀ᶠ N in atTop,
+      ∑ j ∈ Finset.univ.erase a0, (μA j) ^ N • mpvState (d := d) (A j) N =
+        c N •
+          (∑ k ∈ Finset.univ.erase b0, (μB k) ^ N • mpvState (d := d) (B k) N) := by
+  refine (hState.and hSelected).mono ?_
+  intro N hN
+  rcases hN with ⟨hStateN, hSelectedN⟩
+  rw [← Finset.add_sum_erase _ _ (Finset.mem_univ a0),
+    ← Finset.add_sum_erase _ _ (Finset.mem_univ b0), smul_add] at hStateN
+  rw [hSelectedN] at hStateN
+  exact add_left_cancel hStateN
 
 /-- **Reindexing a leading-erased weighted MPV-state tail.**
 

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -228,22 +228,38 @@ boundary conditions (PBC).
     % docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex.
 \end{definition}
 
+\begin{definition}[Eventually nonzero proportional MPV]%
+\label{def:eventually_nonzero_proportional_mpv}
+    \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂}
+    \leanok
+    \uses{def:mpv}
+    Two tensors \(A\) and \(B\) are eventually nonzero proportional if, for all
+    sufficiently large \(N\), there is a nonzero scalar \(c_N\in\C\) such that
+    \(\ket{V^{(N)}(A)}=c_N\ket{V^{(N)}(B)}\). This auxiliary form is used with
+    the eventual linear-independence statement
+    Lemma~\ref{lem:bnt_overlap_orthonormal_li}.
+\end{definition}
+
 \begin{lemma}[Elementary nonzero proportionality rules]%
 \label{lem:nonzero_proportional_mpv_basic}
     \lean{MPSTensor.NonzeroProportionalMPV₂.toProportionalMPV₂,
+        MPSTensor.NonzeroProportionalMPV₂.eventually,
         MPSTensor.NonzeroProportionalMPV₂.symm,
         MPSTensor.SameMPV₂.toNonzeroProportionalMPV₂}
     \leanok
-    \uses{def:proportional_mpv, def:nonzero_proportional_mpv, def:same_mpv2}
-    Nonzero proportionality implies weak proportionality, is symmetric, and
-    equality of MPV families is the special case with scalar \(1\).
+    \uses{def:proportional_mpv, def:nonzero_proportional_mpv,
+        def:eventually_nonzero_proportional_mpv, def:same_mpv2}
+    Nonzero proportionality implies weak proportionality and eventual nonzero
+    proportionality, is symmetric, and equality of MPV families is the special
+    case with scalar \(1\).
 \end{lemma}
 
 \begin{proof}
     \leanok
-    Forgetting the nonvanishing condition gives weak proportionality.  Symmetry
-    follows by inverting the scalar \(c_N\) at each length, and equality is the
-    case \(c_N=1\).
+    Forgetting the nonvanishing condition gives weak proportionality. The
+    eventual form follows by viewing an all-length statement as an eventual one.
+    Symmetry follows by inverting the scalar \(c_N\) at each length, and equality
+    is the case \(c_N=1\).
 \end{proof}
 
 \begin{lemma}[Scaling of word evaluation]\label{lem:eval_word_smul}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -22,11 +22,27 @@ irreducible-form framework of \cite{DeLasCuevas2017Irreducible},
 which gives a fundamental theorem valid for periodic tensors directly,
 with an extra $Z$-gauge degree of freedom.
 
+\begin{lemma}[Fixed-length proportional assembled blocks give weighted states]%
+\label{lem:proportional_tensor_from_blocks_weighted_states_at_length}
+	\lean{MPSTensor.exists_weighted_mpvState_eq_smul_of_nonzeroProportional_at_length_toTensorFromBlocks}
+	\leanok
+	\uses{def:tensor_from_blocks, def:mpv_state}
+	At a fixed length \(N\), if the two assembled block tensors have
+	proportional MPV vectors with nonzero scalar \(c\), then their expanded
+	weighted BNT state sums at length \(N\) are related by the same scalar.
+\end{lemma}
+
+\begin{proof}\leanok
+	Expand the MPV state of each assembled tensor into its weighted block sum
+	and use the fixed-length proportionality identity.
+\end{proof}
+
 \begin{lemma}[Proportional assembled blocks give proportional weighted states]%
 \label{lem:proportional_tensor_from_blocks_weighted_states}
 	\lean{MPSTensor.exists_weighted_mpvState_eq_smul_of_nonzeroProportionalMPV₂_toTensorFromBlocks}
 	\leanok
-	\uses{def:nonzero_proportional_mpv, def:tensor_from_blocks, def:mpv_state}
+	\uses{def:nonzero_proportional_mpv,
+		lem:proportional_tensor_from_blocks_weighted_states_at_length}
 	Let \(A=\bigoplus_j \mu_j A_j\) and
 	\(B=\bigoplus_k \nu_k B_k\) be assembled block tensors. If their MPV
 	families are nonzero proportional, then for every length \(N\) there is a
@@ -63,6 +79,23 @@ with an extra $Z$-gauge degree of freedom.
 	Lemma~\ref{lem:proportional_tensor_from_blocks_weighted_states}.
 \end{proof}
 
+\begin{lemma}[An eventual scalar sequence for proportional weighted states]%
+\label{lem:eventual_proportional_tensor_from_blocks_weighted_state_sequence}
+	\lean{MPSTensor.exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroProportionalMPV₂}
+	\leanok
+	\uses{def:eventually_nonzero_proportional_mpv,
+		lem:proportional_tensor_from_blocks_weighted_states_at_length}
+	If two assembled block tensors are eventually nonzero proportional, then
+	one may choose a scalar sequence \(c_N\), nonzero for all sufficiently large
+	\(N\), such that the expanded weighted state sums are related by \(c_N\) for
+	all sufficiently large \(N\).
+\end{lemma}
+
+\begin{proof}\leanok
+	Apply the fixed-length expansion at every sufficiently large length and
+	choose one scalar for each such length.
+\end{proof}
+
 \begin{lemma}[Weighted state sequences are exactly assembled proportionality]%
 \label{lem:weighted_state_sequence_to_proportional_tensor_from_blocks}
 	\lean{MPSTensor.nonzeroProportionalMPV₂_toTensorFromBlocks_of_weighted_mpvState_eq_smul_sequence}
@@ -85,6 +118,22 @@ with an extra $Z$-gauge degree of freedom.
 	and evaluate the state identity on each basis word.
 \end{proof}
 
+\begin{lemma}[Eventual weighted state sequences give eventual proportionality]%
+\label{lem:eventual_weighted_state_sequence_to_proportional_tensor_from_blocks}
+	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weighted_mpvState}
+	\leanok
+	\uses{def:eventually_nonzero_proportional_mpv, def:tensor_from_blocks,
+		def:mpv_state}
+	If the expanded weighted block-state sums are related by a scalar sequence
+	for all sufficiently large lengths, and the scalar is eventually nonzero,
+	then the assembled tail tensors are eventually nonzero proportional.
+\end{lemma}
+
+\begin{proof}\leanok
+	Expand the MPV state of each assembled tensor into its weighted block sum
+	and evaluate the eventual state identity on each basis word.
+\end{proof}
+
 \begin{lemma}[Subtracting a proportional selected summand]%
 \label{lem:proportional_weighted_state_tail_subtraction}
 	\lean{MPSTensor.weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected}
@@ -104,6 +153,22 @@ with an extra $Z$-gauge degree of freedom.
 \begin{proof}\leanok
 	Split both finite sums into the selected summand and the erased tail, use
 	the selected-summand identity, and cancel the common selected term.
+\end{proof}
+
+\begin{lemma}[Eventual subtraction of a proportional selected summand]%
+\label{lem:eventual_proportional_weighted_state_tail_subtraction}
+	\lean{MPSTensor.eventually_weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected}
+	\leanok
+	\uses{lem:eventual_proportional_tensor_from_blocks_weighted_state_sequence}
+	If two weighted block-state sums are eventually related by a scalar sequence
+	\(c_N\), and selected summands are eventually related by the same scalar
+	sequence, then the erased tails are eventually related by \(c_N\).
+\end{lemma}
+
+\begin{proof}\leanok
+	At every sufficiently large length, split both finite sums into the selected
+	summand and the erased tail, use the selected-summand identity, and cancel
+	the common selected term.
 \end{proof}
 
 \begin{lemma}[Reindexing a leading-erased weighted state tail]%


### PR DESCRIPTION
## Summary

This is a Stage C helper step for the CPSV16 line 1182 tail argument.

It adds:

- `MPSTensor.EventuallyNonzeroProportionalMPV₂`
- `MPSTensor.NonzeroProportionalMPV₂.eventually`
- fixed-length weighted-state expansion from a single proportionality witness
- eventual weighted-state scalar-sequence bookkeeping
- eventual conversion from weighted state identities back to assembled-tail proportionality
- eventual selected-summand tail subtraction

The point is to separate the source-facing all-length proportionality hypothesis
from the eventual statements produced by Lemma `Lem1` / eventual linear
independence. This avoids forcing the remaining tail reduction through an
all-length selected-summand identity that the asymptotic source argument does
not immediately provide.

Blueprint entries were added for the new eventual predicate and helper lemmas.

## Remaining work

#1563 remains open. The remaining proof gap is still
`TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean:897`, in
`MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT`.

Next mathematical step: derive the selected dominant-pair summand identity in
eventual form by coefficient extraction from the eventual linear-independence
argument, then combine these helpers with the tail reindexing from #1580.

## Verification

- `lake env lean TNLean/MPS/Defs.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.ProportionalExpansion`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/Defs.lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean blueprint/src/chapter/ch02_mps.tex blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

Related: #1559
Related: #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `Filter.Eventually`-based predicates and helper lemmas used in the fundamental-theorem tail argument; while mostly additive, it changes the shape of key proportionality hypotheses and could affect downstream proof scripts that rely on the older all-length forms.
> 
> **Overview**
> Introduces an *eventual* version of nonzero MPV proportionality (`EventuallyNonzeroProportionalMPV₂`) plus a bridge lemma `NonzeroProportionalMPV₂.eventually` to treat all-length hypotheses as tail-only statements.
> 
> Refactors the proportional-expansion bookkeeping to separate **fixed-length** proportionality witnesses from all-length hypotheses, and adds eventual analogues: constructing an eventual nonzero scalar sequence from eventual proportionality, converting eventual weighted-state identities back into eventual assembled-tensor proportionality, and performing eventual “selected-summand subtraction” on weighted block sums.
> 
> Updates the blueprint to document the new definition and lemmas used in the fundamental-theorem proof narrative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 956ecb5b9e5385755916050fbb2e2c9fca5fd0ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->