### PR TITLE
feat(MPS/BNT): add eventual coefficient extraction lemma

### DIFF
--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -162,6 +162,29 @@ lemma eventually_linearIndependent_of_overlap_tendsto_orthonormal
       LinearIndependent ℂ (fun j : Fin g => mpvState (d := d) (A j) N) :=
   eventually_linearIndependent_of_finite_overlap_tendsto_orthonormal A h_self h_cross
 
+/-- **Eventual coefficient extraction from eventual linear independence.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
+`Lem1` to rule out a vanishing-overlap alternative. Once Lemma `Lem1` gives
+linear independence for all sufficiently large lengths, equality of two finite
+linear combinations forces equality of the corresponding coefficients for all
+sufficiently large lengths. -/
+lemma coefficient_eventually_eq_of_eventually_linearIndependent
+    {ι : Type*} [Fintype ι]
+    {E : ℕ → Type*} [∀ N, AddCommGroup (E N)] [∀ N, Module ℂ (E N)]
+    (v : (N : ℕ) → ι → E N) (a b : ℕ → ι → ℂ)
+    (hLI : ∀ᶠ N in atTop, LinearIndependent ℂ (v N))
+    (hEq : ∀ᶠ N in atTop, ∑ i : ι, a N i • v N i = ∑ i : ι, b N i • v N i) :
+    ∀ᶠ N in atTop, ∀ i : ι, a N i = b N i := by
+  refine (hLI.and hEq).mono ?_
+  intro N hN i
+  rcases hN with ⟨hLIN, hEqN⟩
+  have hdiff : ∑ j : ι, (a N j - b N j) • v N j = 0 := by
+    simpa [Finset.sum_sub_distrib, sub_smul] using sub_eq_zero.mpr hEqN
+  have hzero := Fintype.linearIndependent_iff.mp hLIN
+    (fun j : ι => a N j - b N j) hdiff
+  exact sub_eq_zero.mp (hzero i)
+
 /-- Eventual linear independence for the union of two asymptotically orthonormal
 MPV families whose mixed overlaps vanish.
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -74,6 +74,21 @@ and~\cite{Cirac2021Matrix}.
 	$I=\{1,\ldots,g\}$.
 \end{proof}
 
+\begin{lemma}[Eventual coefficient extraction from linear independence]%
+\label{lem:eventual_coeff_eq_of_eventual_li}
+	\lean{MPSTensor.coefficient_eventually_eq_of_eventually_linearIndependent}
+	\leanok
+	If a finite family of vectors is linearly independent for all sufficiently
+	large \(N\), and two finite linear combinations of that family are equal
+	for all sufficiently large \(N\), then the corresponding coefficients are
+	equal for all sufficiently large \(N\).
+\end{lemma}
+
+\begin{proof}\leanok
+	Move the two linear combinations to one side. Linear independence forces
+	each coefficient difference to vanish at every sufficiently large length.
+\end{proof}
+
 \begin{lemma}[Overlap-orthonormality for two families]%
 	\label{lem:bnt_two_family_overlap_orthonormal_li}
 	\lean{MPSTensor.eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal}


### PR DESCRIPTION
## Summary

This is a small Stage C helper step after #1581.

It adds:

- `MPSTensor.coefficient_eventually_eq_of_eventually_linearIndependent`

The lemma packages the linear-algebra consequence of the CPSV16 line 1182
`Lem1` step: once a finite family is linearly independent for all sufficiently
large lengths, eventual equality of two finite linear combinations gives
eventual equality of their coefficients.

The blueprint records this as
`lem:eventual_coeff_eq_of_eventual_li` next to the BNT eventual linear
independence lemmas.

## Remaining work

#1563 remains open. The remaining proof gap is still
`TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean:897`, in
`MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT`.

Next step: specialize this coefficient-extraction lemma to the matched
dominant-pair/tail-state setting in `NondecayingOverlap.lean`.

## Verification

- `lake env lean TNLean/MPS/BNT/Basic.lean`
- `lake build TNLean.MPS.BNT.Basic`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/BNT/Basic.lean blueprint/src/chapter/ch10_bnt.tex`

Related: #1559
Related: #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, self-contained linear-algebra lemma plus blueprint documentation, without changing existing proof behavior or core MPS definitions.
> 
> **Overview**
> Adds `MPSTensor.coefficient_eventually_eq_of_eventually_linearIndependent`, a helper lemma that turns *eventual* linear independence plus *eventual* equality of two finite linear combinations into eventual pointwise equality of the coefficients.
> 
> Updates the BNT blueprint (Chapter 10) to document and reference this lemma as `lem:eventual_coeff_eq_of_eventual_li` alongside the existing eventual linear-independence results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8844f669e6de22f38baa0b74240d30cf5536991d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->