### PR TITLE
feat(MPS/FT): package eventual proportional tail reduction

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -388,6 +388,69 @@ lemma weighted_mpvState_sum_erase_zero_eq_sum_succ
       exact Finset.mem_erase.mpr ⟨succ_ne_zero j, Finset.mem_univ _⟩
   rw [h_eq, Finset.sum_image (fun j _ k _ h => succ_inj h)]
 
+/-- **Eventual proportionality of reindexed tails after removing the leading summand.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After a leading
+matched BNT component has been removed, the remaining components are reindexed
+and the argument is repeated. This lemma packages that bookkeeping in eventual
+form: an eventual total weighted-state identity, together with an eventual
+selected-summand identity for the leading components, gives eventual nonzero
+proportionality of the two reindexed tail tensors. -/
+lemma eventuallyNonzeroProportionalMPV₂_tail_succ_of_total_and_selected
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (c : ℕ → ℂ) (hrA : 0 < rA) (hrB : 0 < rB)
+    (hc : ∀ᶠ N in atTop, c N ≠ 0)
+    (hState : ∀ᶠ N in atTop,
+      (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N))
+    (hSelected : ∀ᶠ N in atTop,
+      (μA (⟨0, hrA⟩ : Fin rA)) ^ N •
+          mpvState (d := d) (A (⟨0, hrA⟩ : Fin rA)) N =
+        c N •
+          ((μB (⟨0, hrB⟩ : Fin rB)) ^ N •
+            mpvState (d := d) (B (⟨0, hrB⟩ : Fin rB)) N)) :
+    EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks
+        (fun j : Fin (rA - 1) => μA ⟨j.val + 1, by omega⟩)
+        (fun j : Fin (rA - 1) => A ⟨j.val + 1, by omega⟩))
+      (toTensorFromBlocks
+        (fun k : Fin (rB - 1) => μB ⟨k.val + 1, by omega⟩)
+        (fun k : Fin (rB - 1) => B ⟨k.val + 1, by omega⟩)) := by
+  let a0 : Fin rA := ⟨0, hrA⟩
+  let b0 : Fin rB := ⟨0, hrB⟩
+  have hTailErase :
+      ∀ᶠ N in atTop,
+        ∑ j ∈ Finset.univ.erase a0,
+            (μA j) ^ N • mpvState (d := d) (A j) N =
+          c N •
+            (∑ k ∈ Finset.univ.erase b0,
+              (μB k) ^ N • mpvState (d := d) (B k) N) := by
+    exact eventually_weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected
+      A B c a0 b0 hState (by simpa [a0, b0] using hSelected)
+  have hTailReindex :
+      ∀ᶠ N in atTop,
+        (∑ j : Fin (rA - 1),
+            (μA ⟨j.val + 1, by omega⟩) ^ N •
+              mpvState (d := d) (A ⟨j.val + 1, by omega⟩) N) =
+          c N •
+            (∑ k : Fin (rB - 1),
+              (μB ⟨k.val + 1, by omega⟩) ^ N •
+                mpvState (d := d) (B ⟨k.val + 1, by omega⟩) N) := by
+    refine hTailErase.mono ?_
+    intro N hN
+    rw [weighted_mpvState_sum_erase_zero_eq_sum_succ A hrA N] at hN
+    rw [weighted_mpvState_sum_erase_zero_eq_sum_succ B hrB N] at hN
+    exact hN
+  exact
+    eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weighted_mpvState
+      (fun j : Fin (rA - 1) => A ⟨j.val + 1, by omega⟩)
+      (fun k : Fin (rB - 1) => B ⟨k.val + 1, by omega⟩)
+      c hc hTailReindex
+
 /-- **Projection of a fixed weighted MPV-state scalar sequence.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. Once the

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -187,6 +187,27 @@ with an extra $Z$-gauge degree of freedom.
 	erasing the leading index.  Rewrite the finite sum along this bijection.
 \end{proof}
 
+\begin{lemma}[Eventual proportionality of reindexed weighted tails]%
+\label{lem:eventual_proportional_weighted_tail_package}
+	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succ_of_total_and_selected}
+	\leanok
+	\uses{lem:eventual_proportional_weighted_state_tail_subtraction,
+		lem:proportional_weighted_state_tail_reindex,
+		lem:eventual_weighted_state_sequence_to_proportional_tensor_from_blocks}
+	Suppose the total weighted state sums are eventually related by a nonzero
+	scalar sequence and the leading selected summands are eventually related by
+	the same sequence.  Then, after erasing the leading blocks and reindexing
+	the remaining families by \(j\mapsto j+1\), the assembled tail tensors are
+	eventually nonzero proportional.
+\end{lemma}
+
+\begin{proof}\leanok
+	First subtract the selected summands from the eventual total identity.
+	Then reindex both erased finite sums by \(j\mapsto j+1\), and convert the
+	eventual weighted tail identity back into eventual proportionality of the
+	assembled tail tensors.
+\end{proof}
+
 \begin{lemma}[Norm convergence for scalar-related normalized vectors]%
 \label{lem:proportional_scalar_norm_core}
 	\lean{MPSTensor.tendsto_norm_scalar_of_tendsto_norm_one}


### PR DESCRIPTION
## Summary

This is a small Stage C helper step after #1581 and #1582.

It adds:

- `MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succ_of_total_and_selected`

The lemma packages the tail-reduction bookkeeping after a leading selected pair has been removed. From an eventual total weighted-state identity, eventual nonzero scalar sequence, and eventual selected-summand identity for the leading components, it:

1. subtracts the leading summands,
2. reindexes both erased tails by `j ↦ j + 1`,
3. converts the eventual weighted tail identity into `EventuallyNonzeroProportionalMPV₂` for the assembled reindexed tail tensors.

Blueprint entry: `lem:eventual_proportional_weighted_tail_package`.

## Remaining work

#1563 remains open. The remaining proof gap is still `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean:897`, in `MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT`.

Next step: prove the eventual selected-summand identity for the leading matched pair, using #1582's coefficient extraction and the dominant-pair overlap/gauge data.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.ProportionalExpansion`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

Related: #1559
Related: #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new helper lemma and accompanying blueprint documentation without changing existing definitions or core proof structure; main risk is only proof/lemma integration or typeclass/automation fragility in Lean.
> 
> **Overview**
> Adds a new Lean lemma `MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succ_of_total_and_selected` that packages the “remove leading summand → reindex tails by `j ↦ j+1` → recover eventual proportionality” bookkeeping into a single reusable step.
> 
> Updates the blueprint (Chapter 11) with a corresponding statement `lem:eventual_proportional_weighted_tail_package` describing this packaged tail-reduction step and its dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 702c3aabae4ac37046f803893fb29511021e23c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->