### PR TITLE
feat(MPS/FT): add eventual proportional projection helpers

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -475,6 +475,33 @@ lemma weighted_mpvInner_eq_mul_sequence_of_weighted_mpvState_eq_smul_sequence
     congrArg (fun v : MPVSpace d N => ⟪mpvState (d := d) X N, v⟫_ℂ) (hState N)
   simpa [mpvInner, inner_sum, inner_smul_right] using hinner
 
+/-- **Eventual projection of a weighted MPV-state scalar sequence.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After Lemma
+`Lem1` is used, the relevant weighted-state identity is only needed for all
+sufficiently large lengths; projection against a fixed block MPV preserves the
+same eventual scalar sequence. -/
+lemma eventually_weighted_mpvInner_eq_mul_sequence_of_eventually_weighted_mpvState_eq_smul_sequence
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (c : ℕ → ℂ)
+    (hState : ∀ᶠ N in atTop,
+      (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)) :
+    ∀ {D : ℕ} (X : MPSTensor d D),
+      ∀ᶠ N in atTop,
+        (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) X (A j) N) =
+          c N * (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N) := by
+  intro D X
+  refine hState.mono ?_
+  intro N hN
+  have hinner :=
+    congrArg (fun v : MPVSpace d N => ⟪mpvState (d := d) X N, v⟫_ℂ) hN
+  simpa [mpvInner, inner_sum, inner_smul_right] using hinner
+
 -- The fixed-length projection statement below is retained separately because
 -- issue #1563 uses it before passing to the scalar sequence in the CPSV16
 -- lines 1170--1192 block-selection contradiction.
@@ -531,6 +558,31 @@ lemma exists_weighted_mpvInner_eq_mul_sequence_of_nonzeroProportionalMPV₂_toTe
     weighted_mpvInner_eq_mul_sequence_of_weighted_mpvState_eq_smul_sequence
       A B c hstate X⟩
 
+/-- **An eventual scalar sequence for proportional weighted MPV projections.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. This is the
+projection form of the eventual weighted-state scalar sequence obtained after
+applying the sufficiently-large-length linear-independence input `Lem1`. -/
+lemma exists_eventually_weighted_mpvInner_eq_mul_sequence_of_eventuallyNonzeroProportionalMPV₂
+    {d rA rB D : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (X : MPSTensor d D) :
+    ∃ c : ℕ → ℂ, (∀ᶠ N in atTop, c N ≠ 0) ∧
+      ∀ᶠ N in atTop,
+        (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) X (A j) N) =
+          c N * (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N) := by
+  obtain ⟨c, hc, hstate⟩ :=
+    exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroProportionalMPV₂
+      A B hProp
+  exact ⟨c, hc,
+    eventually_weighted_mpvInner_eq_mul_sequence_of_eventually_weighted_mpvState_eq_smul_sequence
+      A B c hstate X⟩
+
 /-- **A scalar sequence for normalized proportional weighted projections.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. This records
@@ -559,6 +611,45 @@ lemma exists_normalized_weighted_mpvInner_eq_mul_adjusted_sequence_of_nonzeroPro
       A B hProp X
   exact ⟨c, hc,
     normalized_weighted_mpvInner_eq_mul_adjusted_of_eq_mul A B X c μ ν hμ hν hinner⟩
+
+/-- **An eventual scalar sequence for normalized proportional weighted projections.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. In the recursive
+tail-reduction stage the proportionality of the assembled tail tensors is only
+eventual. After choosing the eventual scalar sequence, the normalized projected
+weighted sums are still related by the same adjusted scalar for all
+sufficiently large lengths. -/
+lemma exists_eventually_adjusted_weighted_mpvInner_sequence_of_eventuallyNonzeroProportionalMPV₂
+    {d rA rB D : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (X : MPSTensor d D) (μ ν : ℂ) (hμ : μ ≠ 0) (hν : ν ≠ 0) :
+    ∃ c : ℕ → ℂ, (∀ᶠ N in atTop, c N ≠ 0) ∧
+      ∀ᶠ N in atTop,
+        (μ ^ N)⁻¹ *
+            (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) X (A j) N) =
+          (c N * (ν / μ) ^ N) *
+            ((ν ^ N)⁻¹ *
+              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N)) := by
+  obtain ⟨c, hc, hinner⟩ :=
+    exists_eventually_weighted_mpvInner_eq_mul_sequence_of_eventuallyNonzeroProportionalMPV₂
+      A B hProp X
+  refine ⟨c, hc, ?_⟩
+  refine hinner.mono ?_
+  intro N hN
+  let S : ℂ := ∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N
+  rw [hN]
+  change (μ ^ N)⁻¹ * (c N * S) =
+    (c N * (ν / μ) ^ N) * ((ν ^ N)⁻¹ * S)
+  calc
+    (μ ^ N)⁻¹ * (c N * S) = ((μ ^ N)⁻¹ * c N) * S := by ring
+    _ = ((c N * (ν / μ) ^ N) * (ν ^ N)⁻¹) * S := by
+      rw [adjusted_scalar_factor_eq (c N) μ ν N hμ hν]
+    _ = (c N * (ν / μ) ^ N) * ((ν ^ N)⁻¹ * S) := by ring
 
 end ProportionalExpansion
 

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalScalar.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalScalar.lean
@@ -49,6 +49,30 @@ lemma tendsto_norm_scalar_of_tendsto_norm_one
     exact mul_div_cancel_right₀ (‖c N‖) hN
   exact Tendsto.congr' hRatio_eq hRatio
 
+/-- **Eventual norm convergence for a scalar sequence between normalized vectors.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. Lemma `Lem1`
+only supplies linear independence for all sufficiently large lengths, so the
+scalar-normalization argument must tolerate replacing a lengthwise identity by
+an eventual one. -/
+lemma tendsto_norm_scalar_of_eventually_tendsto_norm_one
+    {E : ℕ → Type*} [∀ N, NormedAddCommGroup (E N)] [∀ N, NormedSpace ℂ (E N)]
+    (x y : (N : ℕ) → E N) (c : ℕ → ℂ)
+    (hxy : ∀ᶠ N in atTop, x N = c N • y N)
+    (hx_norm : Tendsto (fun N : ℕ => ‖x N‖) atTop (nhds (1 : ℝ)))
+    (hy_norm : Tendsto (fun N : ℕ => ‖y N‖) atTop (nhds (1 : ℝ))) :
+    Tendsto (fun N : ℕ => ‖c N‖) atTop (nhds (1 : ℝ)) := by
+  have hRatio :
+      Tendsto (fun N : ℕ => ‖x N‖ / ‖y N‖) atTop (nhds (1 : ℝ)) := by
+    simpa using hx_norm.div hy_norm one_ne_zero
+  have hy_norm_ne : ∀ᶠ N in atTop, ‖y N‖ ≠ (0 : ℝ) :=
+    hy_norm.eventually_ne one_ne_zero
+  have hRatio_eq : (fun N : ℕ => ‖x N‖ / ‖y N‖) =ᶠ[atTop] fun N : ℕ => ‖c N‖ := by
+    filter_upwards [hxy, hy_norm_ne] with N hN hN_ne
+    rw [hN, norm_smul]
+    exact mul_div_cancel_right₀ (‖c N‖) hN_ne
+  exact Tendsto.congr' hRatio_eq hRatio
+
 -- The two scalar-convergence statements below are named separately because
 -- issue #1563 uses them as analytic steps in the CPSV16 lines 1170--1192
 -- block-selection contradiction.
@@ -308,6 +332,55 @@ lemma tendsto_norm_adjusted_weighted_mpvState_scalar_of_tendsto_norm_one
         ((ν ^ N)⁻¹ •
           (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N))
   rw [hState N]
+  rw [smul_smul, smul_smul]
+  congr 1
+  exact adjusted_scalar_factor_eq (c N) μ ν N hμ hν
+
+/-- **Eventual norm convergence for the adjusted proportional scalar.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. In the
+tail-reduction stage only sufficiently large lengths remain after applying
+Lemma `Lem1`. The same dominant-weight normalization therefore yields modulus
+convergence for the adjusted scalar from an eventual weighted-state identity. -/
+lemma tendsto_norm_adjusted_weighted_mpvState_scalar_of_eventually_tendsto_norm_one
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (c : ℕ → ℂ) (μ ν : ℂ)
+    (hμ : μ ≠ 0) (hν : ν ≠ 0)
+    (hState : ∀ᶠ N in atTop,
+      (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N))
+    (hA_norm : Tendsto
+      (fun N : ℕ =>
+        ‖(μ ^ N)⁻¹ •
+          (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N)‖)
+      atTop (nhds (1 : ℝ)))
+    (hB_norm : Tendsto
+      (fun N : ℕ =>
+        ‖(ν ^ N)⁻¹ •
+          (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)‖)
+      atTop (nhds (1 : ℝ))) :
+    Tendsto (fun N : ℕ => ‖c N * (ν / μ) ^ N‖) atTop (nhds (1 : ℝ)) := by
+  refine tendsto_norm_scalar_of_eventually_tendsto_norm_one
+    (fun N : ℕ =>
+      (μ ^ N)⁻¹ •
+        (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N))
+    (fun N : ℕ =>
+      (ν ^ N)⁻¹ •
+        (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N))
+    (fun N : ℕ => c N * (ν / μ) ^ N) ?_ hA_norm hB_norm
+  refine hState.mono ?_
+  intro N hN
+  change
+    (μ ^ N)⁻¹ •
+        (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+      (c N * (ν / μ) ^ N) •
+        ((ν ^ N)⁻¹ •
+          (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N))
+  rw [hN]
   rw [smul_smul, smul_smul]
   congr 1
   exact adjusted_scalar_factor_eq (c N) μ ν N hμ hν

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -221,6 +221,20 @@ with an extra $Z$-gauge degree of freedom.
 	use that \(\|y_N\|\to 1\), so the denominator is eventually nonzero.
 \end{proof}
 
+\begin{lemma}[Eventual norm convergence for scalar-related normalized vectors]%
+\label{lem:eventual_proportional_scalar_norm_core}
+	\lean{MPSTensor.tendsto_norm_scalar_of_eventually_tendsto_norm_one}
+	\leanok
+	\uses{lem:proportional_scalar_norm_core}
+	Suppose \(x_N=c_N y_N\) for all sufficiently large \(N\). If
+	\(\|x_N\|\to 1\) and \(\|y_N\|\to 1\), then \(|c_N|\to 1\).
+\end{lemma}
+
+\begin{proof}\leanok
+	The proof of Lemma~\ref{lem:proportional_scalar_norm_core} is unchanged
+	after discarding finitely many lengths.
+\end{proof}
+
 \begin{lemma}[Self-overlap normalization gives MPV-state norm normalization]%
 \label{lem:self_overlap_to_mpv_state_norm}
 	\lean{MPSTensor.tendsto_norm_mpvState_one}
@@ -295,6 +309,24 @@ with an extra $Z$-gauge degree of freedom.
 	applies to the two normalized state sums.
 \end{proof}
 
+\begin{lemma}[Eventual norm convergence of the normalized proportional scalar]%
+\label{lem:eventual_proportional_tensor_from_blocks_adjusted_scalar_norm}
+	\lean{MPSTensor.tendsto_norm_adjusted_weighted_mpvState_scalar_of_eventually_tendsto_norm_one}
+	\leanok
+	\uses{lem:eventual_proportional_scalar_norm_core}
+	Suppose the weighted state sums for the two assembled block tensors are
+	related by a scalar sequence \(c_N\) for all sufficiently large \(N\). If,
+	after division by nonzero scalars \(\mu^N\) and \(\nu^N\), the two
+	normalized state sums have norms converging to \(1\), then
+	\(|c_N(\nu/\mu)^N|\to 1\).
+\end{lemma}
+
+\begin{proof}\leanok
+	For all sufficiently large lengths, rewrite the proportionality identity
+	after multiplying the two sides by \(\mu^{-N}\) and \(\nu^{-N}\), and apply
+	Lemma~\ref{lem:eventual_proportional_scalar_norm_core}.
+\end{proof}
+
 \begin{lemma}[Proportional weighted states give proportional weighted projections]%
 \label{lem:proportional_tensor_from_blocks_weighted_inner}
 	\lean{MPSTensor.exists_weighted_mpvInner_eq_mul_of_nonzeroProportionalMPV₂_toTensorFromBlocks}
@@ -336,6 +368,23 @@ with an extra $Z$-gauge degree of freedom.
 	for the chosen scalar sequence.
 \end{proof}
 
+\begin{lemma}[Eventual weighted projections from eventual weighted states]%
+\label{lem:eventual_proportional_tensor_from_blocks_weighted_inner_sequence}
+	\lean{MPSTensor.eventually_weighted_mpvInner_eq_mul_sequence_of_eventually_weighted_mpvState_eq_smul_sequence}
+	\lean{MPSTensor.exists_eventually_weighted_mpvInner_eq_mul_sequence_of_eventuallyNonzeroProportionalMPV₂}
+	\leanok
+	\uses{lem:eventual_proportional_tensor_from_blocks_weighted_state_sequence,
+		def:mpv_inner}
+	If the weighted state sums are eventually related by a scalar sequence,
+	then, for each fixed tensor \(X\), the corresponding weighted projections
+	against \(V^{(N)}(X)\) are eventually related by the same scalar sequence.
+\end{lemma}
+
+\begin{proof}\leanok
+	For all sufficiently large lengths, apply the inner product with
+	\(V^{(N)}(X)\) to the weighted state identity.
+\end{proof}
+
 \begin{lemma}[Normalized proportional weighted projections]%
 	\label{lem:proportional_tensor_from_blocks_adjusted_weighted_inner}
 	\lean{MPSTensor.normalized_weighted_mpvInner_eq_mul_adjusted_of_eq_mul}
@@ -370,6 +419,25 @@ with an extra $Z$-gauge degree of freedom.
 	Lemma~\ref{lem:proportional_tensor_from_blocks_weighted_inner_sequence}
 	and apply
 	Lemma~\ref{lem:proportional_tensor_from_blocks_adjusted_weighted_inner}.
+\end{proof}
+
+\begin{lemma}[Eventual normalized projection sequence from proportional tails]%
+\label{lem:eventual_proportional_tensor_from_blocks_adjusted_weighted_inner_sequence}
+	\lean{MPSTensor.exists_eventually_adjusted_weighted_mpvInner_sequence_of_eventuallyNonzeroProportionalMPV₂}
+	\leanok
+	\uses{lem:eventual_proportional_tensor_from_blocks_weighted_inner_sequence,
+		lem:proportional_tensor_from_blocks_adjusted_weighted_inner}
+	For eventually proportional assembled block tensors, any tensor \(X\), and
+	any nonzero scalars \(\mu,\nu\in\C\), one may choose a scalar sequence
+	\(c_N\), nonzero for all sufficiently large \(N\), such that the normalized
+	weighted projections against \(\ket{V^{(N)}(X)}\) are eventually related by
+	the adjusted scalar \(c_N(\nu/\mu)^N\).
+\end{lemma}
+
+\begin{proof}\leanok
+	Choose the eventual scalar sequence from
+	Lemma~\ref{lem:eventual_proportional_tensor_from_blocks_weighted_inner_sequence}
+	and apply the normalized scalar rewrite at every sufficiently large length.
 \end{proof}
 
 \begin{theorem}[Proportional BNT families have non-decaying block overlaps]%


### PR DESCRIPTION
## Summary

This is the next small Stage C helper after #1583. It adds eventual versions of the scalar/projection identities needed once the tail reduction produces only sufficiently-large-length proportionality.

New Lean declarations:

- `MPSTensor.tendsto_norm_scalar_of_eventually_tendsto_norm_one`
- `MPSTensor.tendsto_norm_adjusted_weighted_mpvState_scalar_of_eventually_tendsto_norm_one`
- `MPSTensor.eventually_weighted_mpvInner_eq_mul_sequence_of_eventually_weighted_mpvState_eq_smul_sequence`
- `MPSTensor.exists_eventually_weighted_mpvInner_eq_mul_sequence_of_eventuallyNonzeroProportionalMPV₂`
- `MPSTensor.exists_eventually_adjusted_weighted_mpvInner_sequence_of_eventuallyNonzeroProportionalMPV₂`

The statements cite arXiv:1606.00608, Theorem `thm1`, line 1182: after Lemma `Lem1`, the relevant identities only need to hold for all sufficiently large chain lengths. No source-absent hypothesis is introduced.

Blueprint entries were added for the eventual scalar and projection helpers.

## Remaining work

#1563 remains open. The next proof step is to use these eventual projection identities together with #1582 and #1583 inside `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean` to discharge the proportional nondecaying-overlap theorem.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalScalar.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.ProportionalExpansion`
- `cd blueprint && leanblueprint checkdecls`
- `lake build`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalScalar.lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

Related: #1559
Related: #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean lemmas and blueprint documentation to support eventual ("sufficiently large N") variants of existing proportionality/projection and norm-convergence facts, without changing existing theorem statements or core definitions.
> 
> **Overview**
> Adds *eventual* ("for all sufficiently large lengths") helper lemmas needed after tail-reduction in the Fundamental Theorem proof.
> 
> In `ProportionalExpansion.lean`, introduces eventual versions of the weighted-state to weighted-projection transfer, plus existence lemmas that package an eventual nonzero scalar sequence for projected sums and for the normalized/adjusted projection identity.
> 
> In `ProportionalScalar.lean`, adds eventual analogues of the scalar-norm convergence step and of the dominant-weight adjusted-scalar norm convergence lemma. Updates the blueprint chapter to document and reference these new eventual lemmas alongside the existing fixed-length ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98c7e9677d49dee4111799a9a57ef7a26146379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->