### PR TITLE
feat(MPS/FT): allow eventual dominant projection identities

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -880,7 +880,8 @@ lemma exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT
       hA_norm_dominant hB_norm_dominant
   have hDominant_contra :=
     dominant_projection_contradictions_of_normalized_proportional_inner
-      A B hA hB hrA hrB c hNormalizedInner
+      A B hA hB hrA hrB c
+      (fun X μ ν hμ hν => Filter.Eventually.of_forall (hNormalizedInner X μ ν hμ hν))
       (by simpa [a0, b0] using hAdjustedScalar_dom)
       hA_self hB_self hA_cross hB_cross
   have hDominantB_contra :

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -26,9 +26,10 @@ section ProportionalDominant
 /-- **Dominant-block projection contradiction for proportional BNT families.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. If the normalized
-proportional projection identity has an adjusted scalar whose modulus tends to
-one, then the dominant block on either side cannot have all cross-overlaps
-tending to zero. This is the dominant case of the CPSV16 line 1182 argument. -/
+proportional projection identity eventually holds and has an adjusted scalar
+whose modulus tends to one, then the dominant block on either side cannot have
+all cross-overlaps tending to zero. This is the dominant case of the CPSV16
+line 1182 argument after applying Lemma `Lem1`. -/
 lemma dominant_projection_contradictions_of_normalized_proportional_inner
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -42,7 +43,7 @@ lemma dominant_projection_contradictions_of_normalized_proportional_inner
     (c : ℕ → ℂ)
     (hNormalizedInner :
       ∀ {D : ℕ} (X : MPSTensor d D) (μ ν : ℂ),
-        μ ≠ 0 → ν ≠ 0 → ∀ N : ℕ,
+        μ ≠ 0 → ν ≠ 0 → ∀ᶠ N in atTop,
           (μ ^ N)⁻¹ *
               (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) X (A j) N) =
             (c N * (ν / μ) ^ N) *
@@ -185,8 +186,20 @@ lemma dominant_projection_contradictions_of_normalized_proportional_inner
                   mpvInner (d := d) (B b0) (A j) N)‖)
             atTop (nhds (0 : ℝ)) := by
         simpa using hnorm
-      refine hnorm_zero.congr (fun N => ?_)
-      rw [hNormalizedInner (B b0) (μA a0) (μB b0) hμA_ne hμB_ne N]
+      have hEq :
+          (fun N : ℕ =>
+            ‖(μA a0 ^ N)⁻¹ *
+              (∑ j : Fin rA, (μA j) ^ N *
+                mpvInner (d := d) (B b0) (A j) N)‖) =ᶠ[atTop]
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (B b0) (B k) N))‖) := by
+        filter_upwards [hNormalizedInner (B b0) (μA a0) (μB b0) hμA_ne hμB_ne]
+          with N hN
+        rw [hN]
+      exact Tendsto.congr' hEq hnorm_zero
     exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
   have hDominantA_contra :
       (∀ k : Fin rB, Tendsto (fun N => mpvOverlap (d := d) (A a0) (B k) N)
@@ -281,8 +294,20 @@ lemma dominant_projection_contradictions_of_normalized_proportional_inner
                   mpvInner (d := d) (A a0) (A j) N)‖)
             atTop (nhds (1 : ℝ)) := by
         simpa using hnorm
-      refine hnorm_one.congr (fun N => ?_)
-      rw [hNormalizedInner (A a0) (μA a0) (μB b0) hμA_ne hμB_ne N]
+      have hEq :
+          (fun N : ℕ =>
+            ‖(μA a0 ^ N)⁻¹ *
+              (∑ j : Fin rA, (μA j) ^ N *
+                mpvInner (d := d) (A a0) (A j) N)‖) =ᶠ[atTop]
+          (fun N : ℕ =>
+            ‖(c N * (μB b0 / μA a0) ^ N) *
+              ((μB b0 ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N *
+                  mpvInner (d := d) (A a0) (B k) N))‖) := by
+        filter_upwards [hNormalizedInner (A a0) (μA a0) (μB b0) hμA_ne hμB_ne]
+          with N hN
+        rw [hN]
+      exact Tendsto.congr' hEq hnorm_one
     exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
   exact ⟨by simpa [b0] using hDominantB_contra, by simpa [a0] using hDominantA_contra⟩
 


### PR DESCRIPTION
## Summary

This is a small Stage C API step after #1584.

It weakens `MPSTensor.dominant_projection_contradictions_of_normalized_proportional_inner` so the normalized proportional projection identity only has to hold eventually. This matches the post-`Lem1` situation in CPSV16 Theorem `thm1`, line 1182, and lets the dominant contradiction consume eventual tail identities.

The existing all-length caller in `NondecayingOverlap.lean` is preserved by wrapping its identity with `Filter.Eventually.of_forall`.

No new `sorry` is introduced. The existing `sorry` in `MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT` remains the #1563 target.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap`
- `cd blueprint && leanblueprint checkdecls`
- `lake build`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`

Related: #1559
Related: #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the statement and proof obligations of a core foundational lemma (`dominant_projection_contradictions_of_normalized_proportional_inner`), which may affect downstream proofs and typeclass/Filter reasoning, though the change is localized and mechanically wrapped at the existing call site.
> 
> **Overview**
> Updates the dominant-block contradiction lemma `dominant_projection_contradictions_of_normalized_proportional_inner` to require the normalized proportional projection identity only *eventually* (`∀ᶠ N in atTop`) instead of for all lengths, and refactors the proof to use `Filter.Eventually` equalities when rewriting limits.
> 
> Adjusts the `NondecayingOverlap.lean` caller by wrapping its existing lengthwise identity with `Filter.Eventually.of_forall`, preserving prior behavior while enabling future callers that only have tail identities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88bd93239f5a3e9eeeb2f824a80b0e3361e915b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->