### PR TITLE
feat(MPS/FT): derive dominant contradiction from eventual proportionality

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -809,81 +809,13 @@ lemma exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT
       ¬ Tendsto (fun N => mpvOverlap (d := d) (A j₀) (B k₀) N) atTop (nhds 0)) ∧
     (∀ k₀ : Fin rB, ∃ j₀ : Fin rA,
       ¬ Tendsto (fun N => mpvOverlap (d := d) (A j₀) (B k₀) N) atTop (nhds 0)) := by
-  have hA_self : ∀ j : Fin rA,
-      Tendsto (fun N => mpvOverlap (d := d) (A j) (A j) N) atTop (nhds 1) :=
-    hA.toHasNormalizedSelfOverlap.overlap_tendsto_one
-  have hB_self : ∀ k : Fin rB,
-      Tendsto (fun N => mpvOverlap (d := d) (B k) (B k) N) atTop (nhds 1) :=
-    hB.toHasNormalizedSelfOverlap.overlap_tendsto_one
-  have hA_cross : ∀ j k : Fin rA, j ≠ k →
-      Tendsto (fun N => mpvOverlap (d := d) (A j) (A k) N) atTop (nhds 0) :=
-    hA.cross_overlap_tendsto_zero
-  have hB_cross : ∀ j k : Fin rB, j ≠ k →
-      Tendsto (fun N => mpvOverlap (d := d) (B j) (B k) N) atTop (nhds 0) :=
-    hB.cross_overlap_tendsto_zero
-  obtain ⟨c, hc, hState⟩ :=
-    exists_weighted_mpvState_eq_smul_sequence_of_nonzeroProportionalMPV₂_toTensorFromBlocks
-      A B hProp
-  have hInner : ∀ {D : ℕ} (X : MPSTensor d D) (N : ℕ),
-      (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) X (A j) N) =
-        c N * (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N) := by
-    exact weighted_mpvInner_eq_mul_sequence_of_weighted_mpvState_eq_smul_sequence
-      A B c hState
-  have hNormalizedInner :
-      ∀ {D : ℕ} (X : MPSTensor d D) (μ ν : ℂ),
-        μ ≠ 0 → ν ≠ 0 → ∀ N : ℕ,
-          (μ ^ N)⁻¹ *
-              (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) X (A j) N) =
-            (c N * (ν / μ) ^ N) *
-              ((ν ^ N)⁻¹ *
-                (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N)) := by
-    intro D X μ ν hμ hν
-    exact normalized_weighted_mpvInner_eq_mul_adjusted_of_eq_mul
-      A B X c μ ν hμ hν (hInner X)
   have hrA_pos : 0 < rA := Nat.pos_of_ne_zero hrA
   have hrB_pos : 0 < rB := Nat.pos_of_ne_zero hrB
   let a0 : Fin rA := ⟨0, hrA_pos⟩
   let b0 : Fin rB := ⟨0, hrB_pos⟩
-  have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
-  have hμB_ne : μB b0 ≠ 0 := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero b0
-  have hA_norm_dominant :
-      Tendsto
-        (fun N : ℕ =>
-          ‖(μA a0 ^ N)⁻¹ •
-            (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N)‖)
-        atTop (nhds (1 : ℝ)) := by
-    exact tendsto_norm_normalized_weighted_mpvState_sum_of_dominant
-      A a0 hμA_ne hA_self (fun j hj => by
-        rw [norm_div]
-        exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
-          (hA.mu_strict_anti (by
-            simp only [a0, Fin.lt_def]
-            exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h)))))
-  have hB_norm_dominant :
-      Tendsto
-        (fun N : ℕ =>
-          ‖(μB b0 ^ N)⁻¹ •
-            (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)‖)
-        atTop (nhds (1 : ℝ)) := by
-    exact tendsto_norm_normalized_weighted_mpvState_sum_of_dominant
-      B b0 hμB_ne hB_self (fun k hk => by
-        rw [norm_div]
-        exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
-          (hB.mu_strict_anti (by
-            simp only [b0, Fin.lt_def]
-            exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h)))))
-  have hAdjustedScalar_dom :
-      Tendsto (fun N : ℕ => ‖c N * (μB b0 / μA a0) ^ N‖) atTop
-        (nhds (1 : ℝ)) :=
-    tendsto_norm_adjusted_weighted_mpvState_scalar_of_tendsto_norm_one
-      A B c (μA a0) (μB b0) hμA_ne hμB_ne hState
-      hA_norm_dominant hB_norm_dominant
   have hDominant_contra :=
-    dominant_projection_contradictions_of_normalized_proportional_inner
-      A B hA hB hrA hrB c
-      (fun X μ ν hμ hν => Filter.Eventually.of_forall (hNormalizedInner X μ ν hμ hν))
-      (by simpa [a0, b0] using hAdjustedScalar_dom)
-      hA_self hB_self hA_cross hB_cross
+    dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hProp.eventually
   have hDominantB_contra :
       (∀ j : Fin rA, Tendsto (fun N => mpvOverlap (d := d) (A j) (B b0) N)
         atTop (nhds 0)) → False := by

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -311,6 +311,119 @@ lemma dominant_projection_contradictions_of_normalized_proportional_inner
     exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
   exact ⟨by simpa [b0] using hDominantB_contra, by simpa [a0] using hDominantA_contra⟩
 
+/-- **Dominant-block projection contradiction from eventual proportionality.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After expanding
+the two canonical-form tensors into their BNT block sums, eventual nonzero
+proportionality supplies the scalar sequence used in the dominant-block
+projection contradiction. This is the dominant case of the line 1182 argument,
+with Lemma `Lem1` accounting for the sufficiently-large-length formulation. -/
+lemma dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
+    ((∀ j : Fin rA,
+        Tendsto
+          (fun N => mpvOverlap (d := d) (A j)
+            (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N)
+          atTop (nhds 0)) → False) ∧
+    ((∀ k : Fin rB,
+        Tendsto
+          (fun N => mpvOverlap (d := d)
+            (A ⟨0, Nat.pos_of_ne_zero hrA⟩) (B k) N)
+          atTop (nhds 0)) → False) := by
+  let a0 : Fin rA := ⟨0, Nat.pos_of_ne_zero hrA⟩
+  let b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
+  have hA_self : ∀ j : Fin rA,
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (A j) N) atTop (nhds 1) :=
+    hA.toHasNormalizedSelfOverlap.overlap_tendsto_one
+  have hB_self : ∀ k : Fin rB,
+      Tendsto (fun N => mpvOverlap (d := d) (B k) (B k) N) atTop (nhds 1) :=
+    hB.toHasNormalizedSelfOverlap.overlap_tendsto_one
+  have hA_cross : ∀ j k : Fin rA, j ≠ k →
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (A k) N) atTop (nhds 0) :=
+    hA.cross_overlap_tendsto_zero
+  have hB_cross : ∀ j k : Fin rB, j ≠ k →
+      Tendsto (fun N => mpvOverlap (d := d) (B j) (B k) N) atTop (nhds 0) :=
+    hB.cross_overlap_tendsto_zero
+  obtain ⟨c, _hc, hState⟩ :=
+    exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroProportionalMPV₂
+      A B hProp
+  have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
+  have hμB_ne : μB b0 ≠ 0 := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero b0
+  have hA_norm_dominant :
+      Tendsto
+        (fun N : ℕ =>
+          ‖(μA a0 ^ N)⁻¹ •
+            (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N)‖)
+        atTop (nhds (1 : ℝ)) := by
+    exact tendsto_norm_normalized_weighted_mpvState_sum_of_dominant
+      A a0 hμA_ne hA_self (fun j hj => by
+        rw [norm_div]
+        exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
+          (hA.mu_strict_anti (by
+            simp only [a0, Fin.lt_def]
+            exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h)))))
+  have hB_norm_dominant :
+      Tendsto
+        (fun N : ℕ =>
+          ‖(μB b0 ^ N)⁻¹ •
+            (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)‖)
+        atTop (nhds (1 : ℝ)) := by
+    exact tendsto_norm_normalized_weighted_mpvState_sum_of_dominant
+      B b0 hμB_ne hB_self (fun k hk => by
+        rw [norm_div]
+        exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
+          (hB.mu_strict_anti (by
+            simp only [b0, Fin.lt_def]
+            exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h)))))
+  have hAdjustedScalar_dom :
+      Tendsto (fun N : ℕ => ‖c N * (μB b0 / μA a0) ^ N‖) atTop
+        (nhds (1 : ℝ)) :=
+    tendsto_norm_adjusted_weighted_mpvState_scalar_of_eventually_tendsto_norm_one
+      A B c (μA a0) (μB b0) hμA_ne hμB_ne hState
+      hA_norm_dominant hB_norm_dominant
+  have hInner :
+      ∀ {D : ℕ} (X : MPSTensor d D),
+        ∀ᶠ N in atTop,
+          (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) X (A j) N) =
+            c N * (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N) :=
+    eventually_weighted_mpvInner_eq_mul_sequence_of_eventually_weighted_mpvState_eq_smul_sequence
+      A B c hState
+  have hNormalizedInner :
+      ∀ {D : ℕ} (X : MPSTensor d D) (μ ν : ℂ),
+        μ ≠ 0 → ν ≠ 0 → ∀ᶠ N in atTop,
+          (μ ^ N)⁻¹ *
+              (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) X (A j) N) =
+            (c N * (ν / μ) ^ N) *
+              ((ν ^ N)⁻¹ *
+                (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N)) := by
+    intro D X μ ν hμ hν
+    refine (hInner X).mono ?_
+    intro N hN
+    let S : ℂ := ∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) X (B k) N
+    rw [hN]
+    change (μ ^ N)⁻¹ * (c N * S) =
+      (c N * (ν / μ) ^ N) * ((ν ^ N)⁻¹ * S)
+    calc
+      (μ ^ N)⁻¹ * (c N * S) = ((μ ^ N)⁻¹ * c N) * S := by ring
+      _ = ((c N * (ν / μ) ^ N) * (ν ^ N)⁻¹) * S := by
+        rw [adjusted_scalar_factor_eq (c N) μ ν N hμ hν]
+      _ = (c N * (ν / μ) ^ N) * ((ν ^ N)⁻¹ * S) := by ring
+  simpa [a0, b0] using
+    dominant_projection_contradictions_of_normalized_proportional_inner
+      A B hA hB hrA hrB c hNormalizedInner
+      (by simpa [a0, b0] using hAdjustedScalar_dom)
+      hA_self hB_self hA_cross hB_cross
+
 end ProportionalDominant
 
 end MPSTensor

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -440,6 +440,24 @@ with an extra $Z$-gauge degree of freedom.
 	and apply the normalized scalar rewrite at every sufficiently large length.
 \end{proof}
 
+\begin{lemma}[Dominant-block contradiction from eventual proportionality]%
+\label{lem:dominant_projection_contradiction_eventual_proportional}
+	\lean{MPSTensor.dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
+	\leanok
+	\uses{lem:eventual_proportional_tensor_from_blocks_adjusted_scalar_norm,
+		lem:eventual_proportional_tensor_from_blocks_adjusted_weighted_inner_sequence}
+	Suppose the assembled weighted BNT block tensors are eventually
+	proportional by nonzero scalars.  Then the dominant block on either side
+	cannot have vanishing overlaps with every block on the other side.
+\end{lemma}
+
+\begin{proof}\leanok
+	Expand eventual proportionality into an eventual scalar sequence for the
+	weighted state sums.  Dominant-weight normalization gives modulus
+	convergence for the adjusted scalar, and the normalized projected
+	identities give the two dominant-block contradictions.
+\end{proof}
+
 \begin{theorem}[Proportional BNT families have non-decaying block overlaps]%
 \label{thm:proportional_bnt_nondecaying_overlap}
 	\lean{MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT}


### PR DESCRIPTION
## Summary

This is a Stage C helper after #1585.

It adds:

- `MPSTensor.dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT`

The lemma starts from eventual nonzero proportionality of the assembled BNT block tensors, expands it into the eventual weighted-state and weighted-projection identities, derives the adjusted scalar norm convergence from dominant-weight normalization, and calls the dominant projection contradiction.

`NondecayingOverlap.lean` now uses this wrapper for the dominant cases, removing the local reconstruction of the scalar/projection setup from the remaining theorem.

Blueprint entry: `lem:dominant_projection_contradiction_eventual_proportional`.

No new `sorry` is introduced. The existing `sorry` in `MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT` remains the #1563 target.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap`
- `cd blueprint && leanblueprint checkdecls`
- `lake build`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

Related: #1559
Related: #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a proof refactor/addition that introduces a new helper lemma and updates callers/docs, without changing core definitions or adding new axioms.
> 
> **Overview**
> Factors the dominant-block contradiction for proportional BNT families into a new lemma `dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT`, which derives the needed scalar/inner-product setup from *eventual* nonzero proportionality and then reuses the existing normalized-projection contradiction.
> 
> Updates `exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT` in `NondecayingOverlap.lean` to call this new wrapper, deleting the previously inlined reconstruction of the scalar sequence and normalization steps. Adds the corresponding blueprint lemma entry documenting the new result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a79925390525866dd2626e73d35485e96fbdcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->