### PR TITLE
feat(MPS/FT): add BNT tail inheritance helper

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -775,6 +775,38 @@ lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
       rw [hk0_eq]; exact hall (succA j')
 termination_by rA + rB
 
+/-- **Leading-erased tails of restricted BNT canonical forms.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof
+removes a matched leading BNT block and repeats the argument on the remaining
+blocks. In the one-copy-per-sector restricted surface used here, the inherited
+tail family is again in restricted BNT canonical form. -/
+lemma isCanonicalFormBNT_tail_succ
+    {d r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    (hA : IsCanonicalFormBNT μ A) (hr : 0 < r) :
+    IsCanonicalFormBNT
+      (fun j : Fin (r - 1) => μ ⟨j.val + 1, by omega⟩)
+      (fun j : Fin (r - 1) => A ⟨j.val + 1, by omega⟩) := by
+  let succ : Fin (r - 1) → Fin r := fun j => ⟨j.val + 1, by omega⟩
+  have succ_inj : Function.Injective succ := fun j₁ j₂ h => by
+    simp [succ, Fin.ext_iff] at h
+    exact Fin.ext (by omega)
+  have succ_strictMono : StrictMono succ := fun a b h => by
+    simp only [succ, Fin.mk_lt_mk]
+    omega
+  exact
+    IsCanonicalFormBNT.ofSeparatedData
+      (HasInjectiveBlocks.ofForall (fun k => hA.toHasInjectiveBlocks.block_injective (succ k)))
+      (IsLeftCanonicalBlockFamily.ofForall
+        (fun k => hA.toIsLeftCanonicalBlockFamily.leftCanonical (succ k)))
+      ⟨hA.mu_strict_anti.comp_strictMono succ_strictMono,
+       fun k => hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero (succ k)⟩
+      (HasNormalizedSelfOverlap.ofForall
+        (fun k => hA.toHasNormalizedSelfOverlap.overlap_tendsto_one (succ k)))
+      (fun j k hjk hdim => hA.blocks_not_equiv (succ j) (succ k)
+        (fun h => hjk (succ_inj h)) hdim)
+
 /-- **Non-decaying overlap existence for proportional-MPV BNT families.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the proof,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -458,6 +458,23 @@ with an extra $Z$-gauge degree of freedom.
 	identities give the two dominant-block contradictions.
 \end{proof}
 
+\begin{lemma}[Leading-erased tails preserve restricted BNT canonical form]%
+\label{lem:cf_bnt_tail_succ}
+	\lean{MPSTensor.isCanonicalFormBNT_tail_succ}
+	\leanok
+	\uses{def:cf_bnt}
+	If a finite one-copy BNT canonical-form family has a leading block, then
+	after deleting that leading block and reindexing the remaining blocks by
+	\(j\mapsto j+1\), the tail is again a one-copy BNT canonical-form family.
+\end{lemma}
+
+\begin{proof}\leanok
+	Each blockwise hypothesis restricts to the subfamily.  Strict decrease of
+	the weights is preserved because the reindexing map \(j\mapsto j+1\) is
+	strictly monotone, and block separation is inherited from the original
+	family.
+\end{proof}
+
 \begin{theorem}[Proportional BNT families have non-decaying block overlaps]%
 \label{thm:proportional_bnt_nondecaying_overlap}
 	\lean{MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT}


### PR DESCRIPTION
## Summary

This is a small Stage C helper for the remaining #1563 tail/induction lift.

It adds:

- `MPSTensor.isCanonicalFormBNT_tail_succ`

The lemma records that, in the already-grouped one-copy BNT surface, deleting the leading block and reindexing the remaining blocks by `j ↦ j + 1` preserves `IsCanonicalFormBNT`. This packages a structural step already used inline in the equal-MPV proof and needed for the proportional tail induction.

Blueprint entry: `lem:cf_bnt_tail_succ`.

No new `sorry` is introduced. The existing `sorry` in `MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT` remains the #1563 target.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap`
- `cd blueprint && leanblueprint checkdecls`
- `lake build`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

Related: #1559
Related: #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone helper lemma and corresponding blueprint documentation without changing existing theorem statements or proof behavior.
> 
> **Overview**
> Adds `MPSTensor.isCanonicalFormBNT_tail_succ`, a helper lemma showing that deleting the leading block of a nonempty one-copy `IsCanonicalFormBNT` family and reindexing by `j ↦ j+1` preserves restricted BNT canonical form.
> 
> Updates the blueprint (Lemma `lem:cf_bnt_tail_succ`) to document and reference this new tail-inheritance step for upcoming tail/induction arguments in the proportional-overlap proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d42c2ffb07bfc863c3ff18b71a738bc567c4f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->