### PR TITLE
feat(MPS/FT): add dominant nondecaying witnesses

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -424,6 +424,45 @@ lemma dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_
       (by simpa [a0, b0] using hAdjustedScalar_dom)
       hA_self hB_self hA_cross hB_cross
 
+/-- **Dominant blocks have non-decaying partners under eventual proportionality.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The dominant
+projection contradiction rules out the alternative that the leading block on
+one side has vanishing overlap with every block on the other side. Hence each
+leading block admits a non-decaying overlap partner. -/
+lemma exists_nondecaying_overlap_dominant_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
+    (∃ k₀ : Fin rB,
+      ¬ Tendsto
+        (fun N => mpvOverlap (d := d)
+          (A ⟨0, Nat.pos_of_ne_zero hrA⟩) (B k₀) N)
+        atTop (nhds 0)) ∧
+    (∃ j₀ : Fin rA,
+      ¬ Tendsto
+        (fun N => mpvOverlap (d := d)
+          (A j₀) (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N)
+        atTop (nhds 0)) := by
+  have hContra :=
+    dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hProp
+  constructor
+  · by_contra h
+    push Not at h
+    exact hContra.2 h
+  · by_contra h
+    push Not at h
+    exact hContra.1 h
+
 end ProportionalDominant
 
 end MPSTensor

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -458,6 +458,22 @@ with an extra $Z$-gauge degree of freedom.
 	identities give the two dominant-block contradictions.
 \end{proof}
 
+\begin{lemma}[Dominant blocks have non-decaying partners]%
+\label{lem:dominant_nondecaying_partner_eventual_proportional}
+	\lean{MPSTensor.exists_nondecaying_overlap_dominant_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
+	\leanok
+	\uses{lem:dominant_projection_contradiction_eventual_proportional}
+	Under eventual nonzero proportionality of the assembled BNT block tensors,
+	the leading block of each family has a block in the other family whose
+	overlap does not tend to zero.
+\end{lemma}
+
+\begin{proof}\leanok
+	If every overlap from a leading block to the other family vanished, this
+	would contradict
+	Lemma~\ref{lem:dominant_projection_contradiction_eventual_proportional}.
+\end{proof}
+
 \begin{lemma}[Leading-erased tails preserve restricted BNT canonical form]%
 \label{lem:cf_bnt_tail_succ}
 	\lean{MPSTensor.isCanonicalFormBNT_tail_succ}


### PR DESCRIPTION
## Summary

This is a small Stage C helper for #1563.

It adds:

- `MPSTensor.exists_nondecaying_overlap_dominant_of_eventuallyNonzeroProportionalMPV₂_CFBNT`

The lemma turns the dominant-block contradiction from #1586 into actual nondecaying overlap witnesses for the leading blocks on both sides. This is the dominant-block existence step before the remaining tail recursion.

Blueprint entry: `lem:dominant_nondecaying_partner_eventual_proportional`.

No new `sorry` is introduced.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.ProportionalDominant`
- `cd blueprint && leanblueprint checkdecls`
- `lake build`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

Related: #1559
Related: #1563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small helper lemma and matching blueprint text without changing existing proof logic or interfaces beyond the new lemma.
> 
> **Overview**
> Adds `MPSTensor.exists_nondecaying_overlap_dominant_of_eventuallyNonzeroProportionalMPV₂_CFBNT`, which turns the previously proved dominant-block projection contradiction into explicit *existence* witnesses of a block on the opposite side whose `mpvOverlap` does **not** tend to `0` for each leading block.
> 
> Updates the blueprint (Chapter 11) with a new lemma, `lem:dominant_nondecaying_partner_eventual_proportional`, referencing the new Lean statement and linking it to the dominant-projection contradiction lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77658f9c394012bd4e56c9812d5e2d4bae76940a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->