### PR TITLE
feat(MPS/FT): extract gauge phase from nondecaying overlap

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean
@@ -18,6 +18,63 @@ namespace MPSTensor
 
 section HeteroEqualCase
 
+/-- **Bond dimension equality from a non-decaying BNT overlap.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof
+uses the overlap dichotomy before applying Corollary `eqV`: if two injective
+left-canonical BNT blocks have a cross-overlap which does not tend to zero, then
+their bond dimensions must agree. -/
+lemma dim_eq_of_nondecaying_overlap_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (j : Fin rA) (k : Fin rB)
+    (hnd : ¬ Tendsto (fun N => mpvOverlap (d := d) (A j) (B k) N) atTop (nhds 0)) :
+    dimA j = dimB k := by
+  by_contra hdim
+  exact hnd (mpvOverlap_tendsto_zero_of_dim_ne (A j) (B k)
+    (hA.toHasInjectiveBlocks.block_injective j)
+    (hB.toHasInjectiveBlocks.block_injective k)
+    (hA.toIsLeftCanonicalBlockFamily.leftCanonical j)
+    (hB.toIsLeftCanonicalBlockFamily.leftCanonical k)
+    hdim)
+
+/-- **Gauge-phase equivalence from a non-decaying BNT overlap.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After a
+non-decaying overlap partner is found, the overlap dichotomy and Corollary
+`eqV` identify the two BNT blocks up to gauge and phase. This lemma packages
+the Lean form of that extraction. -/
+lemma gaugePhaseEquiv_of_nondecaying_overlap_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (j : Fin rA) (k : Fin rB)
+    (hnd : ¬ Tendsto (fun N => mpvOverlap (d := d) (A j) (B k) N) atTop (nhds 0)) :
+    GaugePhaseEquiv (d := d)
+      (cast (congr_arg (MPSTensor d)
+        (dim_eq_of_nondecaying_overlap_CFBNT A B hA hB j k hnd)) (A j))
+      (B k) := by
+  let hdim := dim_eq_of_nondecaying_overlap_CFBNT A B hA hB j k hnd
+  by_contra hNot
+  exact hnd (mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left
+    hdim (A j) (B k)
+    (hA.toHasInjectiveBlocks.block_injective j)
+    (hB.toHasInjectiveBlocks.block_injective k)
+    (hA.toIsLeftCanonicalBlockFamily.leftCanonical j)
+    (hB.toIsLeftCanonicalBlockFamily.leftCanonical k)
+    hNot)
+
 /-- **Uniqueness of a non-decaying left partner for a BNT block.**
 
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After the

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -474,6 +474,24 @@ with an extra $Z$-gauge degree of freedom.
 	Lemma~\ref{lem:dominant_projection_contradiction_eventual_proportional}.
 \end{proof}
 
+\begin{lemma}[Non-decaying BNT overlap gives a gauge phase]%
+\label{lem:bnt_nondecaying_overlap_gauge_phase}
+	\lean{MPSTensor.dim_eq_of_nondecaying_overlap_CFBNT,
+		MPSTensor.gaugePhaseEquiv_of_nondecaying_overlap_CFBNT}
+	\leanok
+	\uses{def:cf_bnt, def:mpv_overlap}
+	If two blocks from BNT canonical-form families have an overlap which does
+	not tend to zero, then their bond dimensions agree and the two blocks are
+	gauge-phase equivalent.
+\end{lemma}
+
+\begin{proof}\leanok
+	The overlap dichotomy says that dimension mismatch forces the overlap to
+	decay to zero, and that non-equivalent blocks of the same dimension also
+	have decaying overlap.  The two contrapositive applications give the
+	claimed dimension equality and gauge-phase equivalence.
+\end{proof}
+
 \begin{lemma}[Non-decaying BNT partners are unique]%
 \label{lem:bnt_nondecaying_partner_unique}
 	\lean{MPSTensor.unique_left_nondecaying_overlap_partner_CFBNT,


### PR DESCRIPTION
## Summary

Adds the overlap-dichotomy extraction needed after the CPSV16 line 1182 non-decaying partner is found.

## Details

- Adds `MPSTensor.dim_eq_of_nondecaying_overlap_CFBNT`.
- Adds `MPSTensor.gaugePhaseEquiv_of_nondecaying_overlap_CFBNT`.
- Records both declarations in Chapter 11 as `lem:bnt_nondecaying_overlap_gauge_phase`.

## Faithfulness

The statements use only CF-BNT data and the non-decaying overlap hypothesis. No proportionality, coefficient-array, or extra source-absent hypothesis is introduced. Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192, where Corollary `eqV` and Lemma `equalMPS` are invoked after the non-decaying partner is found.

Related: #1563, #1559.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.NondecayingPartnerUnique`
- `lake build`
- `leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean` finds only the pre-existing Stage C `sorry` in `NondecayingOverlap.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two small Lean lemmas and corresponding blueprint documentation without changing existing definitions or algorithms; main risk is only downstream proof breakage if assumptions/casts are misapplied.
> 
> **Overview**
> Adds two helper lemmas, `dim_eq_of_nondecaying_overlap_CFBNT` and `gaugePhaseEquiv_of_nondecaying_overlap_CFBNT`, packaging the *contrapositive* use of the overlap dichotomy: a non-decaying `mpvOverlap` forces matching bond dimensions and then `GaugePhaseEquiv` (with the necessary `cast`).
> 
> Updates Chapter 11 of the blueprint to include a new lemma (`lem:bnt_nondecaying_overlap_gauge_phase`) recording these extracted consequences as a named step used before the existing non-decaying-partner uniqueness lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edbf9b01c5bbb8b69e8b09c47ea291ce312678fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->