### PR TITLE
feat(MPS/FT): extract phase relation from nondecaying overlap

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean
@@ -75,6 +75,46 @@ lemma gaugePhaseEquiv_of_nondecaying_overlap_CFBNT
     (hB.toIsLeftCanonicalBlockFamily.leftCanonical k)
     hNot)
 
+/-- **MPV-state phase relation from a non-decaying BNT overlap.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After
+Corollary `eqV` gives a phase relation
+\(|V^{(N)}(B_k)\rangle = e^{i\phi N}|V^{(N)}(A_j)\rangle\), the selected
+summand in the weighted BNT expansion can be compared coefficientwise. This
+lemma packages the corresponding Lean consequence of a non-decaying overlap. -/
+lemma exists_phase_mpvState_eq_smul_of_nondecaying_overlap_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (j : Fin rA) (k : Fin rB)
+    (hnd : ¬ Tendsto (fun N => mpvOverlap (d := d) (A j) (B k) N) atTop (nhds 0)) :
+    ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+      ∀ N : ℕ, mpvState (d := d) (B k) N = ζ ^ N • mpvState (d := d) (A j) N := by
+  let hdim := dim_eq_of_nondecaying_overlap_CFBNT A B hA hB j k hnd
+  obtain ⟨X, ζ, _, hX⟩ := gaugePhaseEquiv_of_nondecaying_overlap_CFBNT A B hA hB j k hnd
+  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv (B k) σ = ζ ^ N * mpv (A j) σ := fun N σ => by
+    rw [mpv_eq_pow_mul_of_gaugePhase _ _ X ζ hX N σ, mpv_cast_dim hdim]
+  have hBB_norm :
+      Tendsto (fun N => ‖mpvOverlap (d := d) (B k) (B k) N‖) atTop (nhds 1) :=
+    tendsto_norm_selfOverlap_one (d := d) (B k)
+      (hB.toHasNormalizedSelfOverlap.overlap_tendsto_one k)
+  have hAA_norm :
+      Tendsto (fun N => ‖mpvOverlap (d := d) (A j) (A j) N‖) atTop (nhds 1) :=
+    tendsto_norm_selfOverlap_one (d := d) (A j)
+      (hA.toHasNormalizedSelfOverlap.overlap_tendsto_one j)
+  refine ⟨ζ, ?_, ?_⟩
+  · exact norm_eq_one_of_selfOverlap_scale hAA_norm hBB_norm
+      (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := A j) (B := B k) (ζ := ζ) hmpv)
+  · intro N
+    ext σ
+    simp only [PiLp.smul_apply, smul_eq_mul, mpvState_apply, hmpv]
+
 /-- **Uniqueness of a non-decaying left partner for a BNT block.**
 
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -492,6 +492,23 @@ with an extra $Z$-gauge degree of freedom.
 	claimed dimension equality and gauge-phase equivalence.
 \end{proof}
 
+\begin{lemma}[Non-decaying BNT overlap gives an MPV phase relation]%
+\label{lem:bnt_nondecaying_overlap_mpv_phase}
+	\lean{MPSTensor.exists_phase_mpvState_eq_smul_of_nondecaying_overlap_CFBNT}
+	\leanok
+	\uses{lem:bnt_nondecaying_overlap_gauge_phase}
+	If two BNT blocks have an overlap which does not tend to zero, then there
+	is a unit complex number \(\zeta\) such that the MPV state of the second
+	block is \(\zeta^N\) times the MPV state of the first block at every
+	length \(N\).
+\end{lemma}
+
+\begin{proof}\leanok
+	Apply the gauge-phase equivalence obtained from the non-decaying overlap.
+	The gauge cancels under the trace defining the MPV, leaving only the phase
+	\(\zeta^N\); normalized self-overlap convergence gives \(|\zeta|=1\).
+\end{proof}
+
 \begin{lemma}[Non-decaying BNT partners are unique]%
 \label{lem:bnt_nondecaying_partner_unique}
 	\lean{MPSTensor.unique_left_nondecaying_overlap_partner_CFBNT,


### PR DESCRIPTION
## Summary

Adds the MPV-state phase relation obtained after a non-decaying BNT overlap identifies two blocks up to gauge and phase.

## Details

- Adds `MPSTensor.exists_phase_mpvState_eq_smul_of_nondecaying_overlap_CFBNT`.
- Records the helper in Chapter 11 as `lem:bnt_nondecaying_overlap_mpv_phase`.

## Faithfulness

The lemma uses only CF-BNT data and a non-decaying overlap hypothesis. It packages the CPSV16 Theorem `thm1`, lines 1170--1192 step where Corollary `eqV` gives `|V^(N)(B_k)> = exp(i phi N) |V^(N)(A_j)>` after a non-decaying partner has been found.

Related: #1563, #1559.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean`
- `lake build TNLean.MPS.FundamentalTheorem.Full.NondecayingPartnerUnique`
- `lake build`
- `leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean` finds only the pre-existing Stage C `sorry` in `NondecayingOverlap.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new helper lemma and accompanying blueprint documentation without changing existing definitions or core algorithms.
> 
> **Overview**
> Adds a new Lean lemma, `exists_phase_mpvState_eq_smul_of_nondecaying_overlap_CFBNT`, which turns a *non-decaying* BNT block overlap into an explicit per-length MPV-state phase relation `mpvState(B) = ζ^N • mpvState(A)` with `‖ζ‖ = 1`.
> 
> Updates the Chapter 11 blueprint to include and explain this extracted “MPV phase relation from non-decaying overlap” step, referencing the new lemma and its dependency on the existing gauge-phase extraction lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9611d28e85655cf251d70bf11d2293b763c4c618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->