### PR TITLE
feat(MPS/FT): add selected weighted summand helper

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -286,6 +286,34 @@ lemma eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weigh
     _ = c N * mpv (toTensorFromBlocks μB B) σ := by
       rw [← hBcoeff]
 
+/-- **Selected weighted summand from phase and coefficient equality.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After a
+non-decaying block pair has supplied a phase relation between the two MPV
+families, the coefficient comparison identifies the corresponding weighted
+summands. This is only the algebraic bridge from the phase relation and the
+eventual coefficient identity to the selected-summand identity used before
+erasing matched blocks. -/
+lemma eventually_selected_weighted_mpvState_eq_smul_of_phase_and_coeff
+    {d DA DB : ℕ} {μA μB ζ : ℂ} {c : ℕ → ℂ}
+    (A : MPSTensor d DA) (B : MPSTensor d DB)
+    (hPhase : ∀ N : ℕ,
+      mpvState (d := d) B N = ζ ^ N • mpvState (d := d) A N)
+    (hCoeff : ∀ᶠ N in atTop, μA ^ N = c N * (μB * ζ) ^ N) :
+    ∀ᶠ N in atTop,
+      μA ^ N • mpvState (d := d) A N =
+        c N • (μB ^ N • mpvState (d := d) B N) := by
+  refine hCoeff.mono ?_
+  intro N hN
+  calc
+    μA ^ N • mpvState (d := d) A N =
+        (c N * (μB * ζ) ^ N) • mpvState (d := d) A N := by
+          rw [hN]
+    _ = c N • (μB ^ N • mpvState (d := d) B N) := by
+      rw [hPhase N, mul_pow, smul_smul, smul_smul]
+      congr 1
+      ring
+
 /-- **Subtracting a proportional dominant summand from weighted MPV-state sums.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof removes

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -134,6 +134,29 @@ with an extra $Z$-gauge degree of freedom.
 	and evaluate the eventual state identity on each basis word.
 \end{proof}
 
+\begin{lemma}[Selected weighted summand from phase and coefficient equality]%
+\label{lem:selected_weighted_summand_from_phase_coeff}
+	\lean{MPSTensor.eventually_selected_weighted_mpvState_eq_smul_of_phase_and_coeff}
+	\leanok
+	\uses{def:mpv_state}
+	Suppose a pair of blocks satisfies
+	\(\ket{V^{(N)}(B)}=\zeta^N\ket{V^{(N)}(A)}\) for every \(N\), and suppose
+	that the corresponding coefficients satisfy
+	\(\mu_A^N=c_N(\mu_B\zeta)^N\) for all sufficiently large \(N\).  Then the
+	selected weighted summands are eventually related by the same scalar
+	sequence:
+	\[
+		\mu_A^N\ket{V^{(N)}(A)}
+		=
+		c_N\mu_B^N\ket{V^{(N)}(B)}.
+	\]
+\end{lemma}
+
+\begin{proof}\leanok
+	Substitute the phase relation into the right-hand side and use
+	\((\mu_B\zeta)^N=\mu_B^N\zeta^N\).
+\end{proof}
+
 \begin{lemma}[Subtracting a proportional selected summand]%
 \label{lem:proportional_weighted_state_tail_subtraction}
 	\lean{MPSTensor.weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected}


### PR DESCRIPTION
## Summary

Follow-up after #1564.  This adds the small algebraic bridge needed in the CPSV16 lines 1170--1192 nondecaying-overlap route: once a matched block pair has a phase relation and the coefficient powers agree eventually, the corresponding weighted MPV summands agree eventually with the same scalar sequence.

The statement is deliberately conditional.  It is not presented as a source theorem by itself; it records the algebra used after the source-faithful nondecaying-pair and coefficient-comparison steps have supplied their hypotheses.

## Blueprint

- Added `lem:selected_weighted_summand_from_phase_coeff` in Chapter 11.
- Marked the new Lean declaration and proof `\leanok`.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean`
- `lake build`
- `leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

Related: #1563 remains open for the remaining CPSV16 lines 1170--1192 lifting step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small standalone algebraic lemma and corresponding blueprint documentation, without changing existing theorem statements or behavior.
> 
> **Overview**
> Adds a new Lean helper lemma, `eventually_selected_weighted_mpvState_eq_smul_of_phase_and_coeff`, that converts an *all-length* MPV phase relation plus an *eventual* coefficient-power identity into an *eventual* equality of the corresponding weighted MPV-state summands.
> 
> Updates the Chapter 11 blueprint to include the new lemma statement/proof (`lem:selected_weighted_summand_from_phase_coeff`) and mark it `\leanok`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 618db1c4f217fdf377f9f79947996f120c1de4f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->