### PR TITLE
feat(MPS/FT): add arbitrary tail reindex package

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -416,6 +416,39 @@ lemma weighted_mpvState_sum_erase_zero_eq_sum_succ
       exact Finset.mem_erase.mpr ⟨succ_ne_zero j, Finset.mem_univ _⟩
   rw [h_eq, Finset.sum_image (fun j _ k _ h => succ_inj h)]
 
+/-- **Reindexing an arbitrary erased weighted MPV-state tail.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof may
+remove a matched block pair that is not the leading pair, because the theorem
+allows a permutation of BNT blocks. This lemma identifies the weighted
+MPV-state sum over the complement of an arbitrary selected block with the
+corresponding sum over `Fin n`, using `Fin.succAbove` to preserve the remaining
+order. -/
+lemma weighted_mpvState_sum_erase_eq_sum_succAbove
+    {d n : ℕ} {dim : Fin (n + 1) → ℕ} {μ : Fin (n + 1) → ℂ}
+    (A : (j : Fin (n + 1)) → MPSTensor d (dim j))
+    (a0 : Fin (n + 1)) :
+    ∀ N : ℕ,
+      ∑ j ∈ Finset.univ.erase a0,
+          (μ j) ^ N • mpvState (d := d) (A j) N =
+        ∑ j : Fin n,
+          (μ (a0.succAbove j)) ^ N •
+            mpvState (d := d) (A (a0.succAbove j)) N := by
+  intro N
+  have h_eq :
+      Finset.univ.erase a0 =
+        (Finset.univ : Finset (Fin n)).image a0.succAbove := by
+    ext x
+    constructor
+    · intro hx
+      rw [Finset.mem_erase] at hx
+      obtain ⟨j, hj⟩ := Fin.exists_succAbove_eq hx.1
+      exact Finset.mem_image.mpr ⟨j, Finset.mem_univ _, hj⟩
+    · intro hx
+      obtain ⟨j, _, rfl⟩ := Finset.mem_image.mp hx
+      exact Finset.mem_erase.mpr ⟨Fin.succAbove_ne _ _, Finset.mem_univ _⟩
+  rw [h_eq, Finset.sum_image (fun _ _ _ _ h => Fin.succAbove_right_injective h)]
+
 /-- **Eventual proportionality of reindexed tails after removing the leading summand.**
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After a leading
@@ -477,6 +510,64 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succ_of_total_and_selected
     eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weighted_mpvState
       (fun j : Fin (rA - 1) => A ⟨j.val + 1, by omega⟩)
       (fun k : Fin (rB - 1) => B ⟨k.val + 1, by omega⟩)
+      c hc hTailReindex
+
+/-- **Eventual proportionality of reindexed tails after an arbitrary matched block.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The
+source proof permits a permutation of BNT blocks: after a block pair has been
+matched and its weighted summands have been identified, one removes that pair
+and repeats the argument on the two complements. This lemma packages only the
+finite reindexing and eventual-proportionality bookkeeping for that step. -/
+lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
+    {d nA nB : ℕ}
+    {dimA : Fin (nA + 1) → ℕ} {dimB : Fin (nB + 1) → ℕ}
+    {μA : Fin (nA + 1) → ℂ} {μB : Fin (nB + 1) → ℂ}
+    (A : (j : Fin (nA + 1)) → MPSTensor d (dimA j))
+    (B : (k : Fin (nB + 1)) → MPSTensor d (dimB k))
+    (c : ℕ → ℂ) (a0 : Fin (nA + 1)) (b0 : Fin (nB + 1))
+    (hc : ∀ᶠ N in atTop, c N ≠ 0)
+    (hState : ∀ᶠ N in atTop,
+      (∑ j : Fin (nA + 1), (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c N •
+          (∑ k : Fin (nB + 1), (μB k) ^ N • mpvState (d := d) (B k) N))
+    (hSelected : ∀ᶠ N in atTop,
+      (μA a0) ^ N • mpvState (d := d) (A a0) N =
+        c N • ((μB b0) ^ N • mpvState (d := d) (B b0) N)) :
+    EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks
+        (fun j : Fin nA => μA (a0.succAbove j))
+        (fun j : Fin nA => A (a0.succAbove j)))
+      (toTensorFromBlocks
+        (fun k : Fin nB => μB (b0.succAbove k))
+        (fun k : Fin nB => B (b0.succAbove k))) := by
+  have hTailErase :
+      ∀ᶠ N in atTop,
+        ∑ j ∈ Finset.univ.erase a0,
+            (μA j) ^ N • mpvState (d := d) (A j) N =
+          c N •
+            (∑ k ∈ Finset.univ.erase b0,
+              (μB k) ^ N • mpvState (d := d) (B k) N) := by
+    exact eventually_weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected
+      A B c a0 b0 hState hSelected
+  have hTailReindex :
+      ∀ᶠ N in atTop,
+        (∑ j : Fin nA,
+            (μA (a0.succAbove j)) ^ N •
+              mpvState (d := d) (A (a0.succAbove j)) N) =
+          c N •
+            (∑ k : Fin nB,
+              (μB (b0.succAbove k)) ^ N •
+                mpvState (d := d) (B (b0.succAbove k)) N) := by
+    refine hTailErase.mono ?_
+    intro N hN
+    rw [weighted_mpvState_sum_erase_eq_sum_succAbove A a0 N] at hN
+    rw [weighted_mpvState_sum_erase_eq_sum_succAbove B b0 N] at hN
+    exact hN
+  exact
+    eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weighted_mpvState
+      (fun j : Fin nA => A (a0.succAbove j))
+      (fun k : Fin nB => B (b0.succAbove k))
       c hc hTailReindex
 
 /-- **Projection of a fixed weighted MPV-state scalar sequence.**

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -210,6 +210,22 @@ with an extra $Z$-gauge degree of freedom.
 	erasing the leading index.  Rewrite the finite sum along this bijection.
 \end{proof}
 
+\begin{lemma}[Reindexing an arbitrary erased weighted state tail]%
+\label{lem:proportional_weighted_state_tail_reindex_succAbove}
+	\lean{MPSTensor.weighted_mpvState_sum_erase_eq_sum_succAbove}
+	\leanok
+	\uses{def:mpv_state}
+	Let \(A_0,\ldots,A_n\) be a finite weighted block family and let \(a\)
+	be any selected index.  The weighted MPV-state sum over all indices
+	different from \(a\) can be reindexed over \(\{0,\ldots,n-1\}\) by the
+	order-preserving insertion map whose image is the complement of \(a\).
+\end{lemma}
+
+\begin{proof}\leanok
+	The image of the insertion map is exactly the complement of the selected
+	index.  Rewrite the finite sum along this bijection.
+\end{proof}
+
 \begin{lemma}[Eventual proportionality of reindexed weighted tails]%
 \label{lem:eventual_proportional_weighted_tail_package}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succ_of_total_and_selected}
@@ -228,6 +244,27 @@ with an extra $Z$-gauge degree of freedom.
 	First subtract the selected summands from the eventual total identity.
 	Then reindex both erased finite sums by \(j\mapsto j+1\), and convert the
 	eventual weighted tail identity back into eventual proportionality of the
+	assembled tail tensors.
+\end{proof}
+
+\begin{lemma}[Eventual proportionality of arbitrary reindexed weighted tails]%
+\label{lem:eventual_proportional_weighted_tail_succAbove_package}
+	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected}
+	\leanok
+	\uses{lem:eventual_proportional_weighted_state_tail_subtraction,
+		lem:proportional_weighted_state_tail_reindex_succAbove,
+		lem:eventual_weighted_state_sequence_to_proportional_tensor_from_blocks}
+	Suppose the total weighted state sums are eventually related by a nonzero
+	scalar sequence, and suppose a selected pair of summands is eventually
+	related by the same sequence.  Then, after erasing that pair and reindexing
+	both complements, the assembled tail tensors are eventually nonzero
+	proportional.
+\end{lemma}
+
+\begin{proof}\leanok
+	Subtract the selected summands from the eventual total identity.  Reindex
+	the two erased finite sums by the complement insertion maps, and convert the
+	eventual weighted tail identity into eventual proportionality of the
 	assembled tail tensors.
 \end{proof}
 


### PR DESCRIPTION
## Summary

This is the next small CPSV16 Theorem II.1 bookkeeping step after #1595.  The proportional theorem permits a permutation of BNT blocks, so the recursive tail step must erase an arbitrary matched pair, not only the leading pair.

This PR adds:

- `MPSTensor.weighted_mpvState_sum_erase_eq_sum_succAbove`, reindexing the weighted MPV-state sum over the complement of an arbitrary selected block by `Fin.succAbove`;
- `MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected`, which converts an eventual total weighted-state identity plus an eventual selected-summand identity into eventual nonzero proportionality of the two arbitrary reindexed tails.

Both statements are conditional bookkeeping lemmas for the CPSV16 lines 1170--1192 peeling argument. They are not presented as the source theorem itself.

## Blueprint

- Added `lem:proportional_weighted_state_tail_reindex_succAbove`.
- Added `lem:eventual_proportional_weighted_tail_succAbove_package`.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean`
- `lake build`
- `leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

Related: #1563 remains open for the remaining CPSV16 lines 1170--1192 nondecaying-overlap proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean bookkeeping lemmas and corresponding blueprint documentation without changing existing APIs or runtime behavior.
> 
> **Overview**
> Extends the proportional-expansion bookkeeping to handle removing an *arbitrary* matched block (not just the leading one) in the CPSV16 tail-peeling step.
> 
> Adds `weighted_mpvState_sum_erase_eq_sum_succAbove` to reindex erased weighted MPV-state sums via `Fin.succAbove`, and `eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected` to turn an eventual total weighted-state identity plus a selected-summand identity into eventual nonzero proportionality of the reindexed tails.
> 
> Updates the blueprint chapter to document these two new lemmas and their roles in the proof outline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ccdc4da5ad468a744aa7497d32b0e33844c288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->