### PR TITLE
feat(MPS/FT): add arbitrary BNT tail helper

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -649,6 +649,34 @@ lemma isCanonicalFormBNT_tail_succ
       (fun j k hjk hdim => hA.blocks_not_equiv (succ j) (succ k)
         (fun h => hjk (succ_inj h)) hdim)
 
+/-- **Arbitrary-erased tails of restricted BNT canonical forms.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The
+proof removes matched BNT block pairs and repeats the argument on the
+remaining blocks. Since the source theorem permits a permutation of blocks, the
+removed block need not be the leading one. In the one-copy-per-sector
+restricted surface used here, the complement indexed by `Fin.succAbove` is
+again in restricted BNT canonical form. -/
+lemma isCanonicalFormBNT_tail_succAbove
+    {d n : ℕ} {dim : Fin (n + 1) → ℕ} {μ : Fin (n + 1) → ℂ}
+    (A : (j : Fin (n + 1)) → MPSTensor d (dim j))
+    (hA : IsCanonicalFormBNT μ A) (a0 : Fin (n + 1)) :
+    IsCanonicalFormBNT
+      (fun j : Fin n => μ (a0.succAbove j))
+      (fun j : Fin n => A (a0.succAbove j)) := by
+  exact
+    IsCanonicalFormBNT.ofSeparatedData
+      (HasInjectiveBlocks.ofForall
+        (fun k => hA.toHasInjectiveBlocks.block_injective (a0.succAbove k)))
+      (IsLeftCanonicalBlockFamily.ofForall
+        (fun k => hA.toIsLeftCanonicalBlockFamily.leftCanonical (a0.succAbove k)))
+      ⟨hA.mu_strict_anti.comp_strictMono (Fin.succAboveOrderEmb a0).strictMono,
+       fun k => hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero (a0.succAbove k)⟩
+      (HasNormalizedSelfOverlap.ofForall
+        (fun k => hA.toHasNormalizedSelfOverlap.overlap_tendsto_one (a0.succAbove k)))
+      (fun j k hjk hdim => hA.blocks_not_equiv (a0.succAbove j) (a0.succAbove k)
+        (fun h => hjk (Fin.succAbove_right_injective h)) hdim)
+
 /-- **Non-decaying overlap existence for proportional-MPV BNT families.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the proof,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -604,6 +604,24 @@ with an extra $Z$-gauge degree of freedom.
 	family.
 \end{proof}
 
+\begin{lemma}[Arbitrary-erased tails preserve restricted BNT canonical form]%
+\label{lem:cf_bnt_tail_succAbove}
+	\lean{MPSTensor.isCanonicalFormBNT_tail_succAbove}
+	\leanok
+	\uses{def:cf_bnt}
+	If a finite one-copy BNT canonical-form family has a selected block, then
+	after deleting that block and reindexing the complement by the
+	order-preserving insertion map, the remaining family is again a one-copy
+	BNT canonical-form family.
+\end{lemma}
+
+\begin{proof}\leanok
+	Each blockwise hypothesis restricts to the complementary subfamily.  The
+	complement insertion map is strictly monotone, so strict decrease of the
+	weights is preserved; block separation is inherited from the original
+	family.
+\end{proof}
+
 \begin{theorem}[Proportional BNT families have non-decaying block overlaps]%
 \label{thm:proportional_bnt_nondecaying_overlap}
 	\lean{MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT}


### PR DESCRIPTION
## Summary

This is a small CPSV16 Theorem II.1 follow-up after #1596.  The proportional block-matching proof may erase a matched block pair away from the leading index, so the recursive step also needs the canonical-form hypotheses for the arbitrary complements.

This PR adds:

- `MPSTensor.isCanonicalFormBNT_tail_succAbove`, showing that deleting any selected block from a one-copy BNT canonical-form family and reindexing the complement by `Fin.succAbove` preserves the restricted BNT canonical-form hypothesis.

The statement is conditional bookkeeping for the CPSV16 lines 1170--1192 peeling argument, not a standalone source theorem.

## Blueprint

- Added `lem:cf_bnt_tail_succAbove`.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
- `lake build`
- `leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` reports the pre-existing `NondecayingOverlap.lean` paper-realignment `sorry`; this PR introduces no new `sorry` or `axiom`.

Related: #1563 remains open for the remaining CPSV16 lines 1170--1192 nondecaying-overlap proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new helper lemma and corresponding blueprint statement without altering existing theorem statements or proof flow.
> 
> **Overview**
> Adds `MPSTensor.isCanonicalFormBNT_tail_succAbove`, a new lemma showing that deleting *any* chosen block from a finite one-copy `IsCanonicalFormBNT` family and reindexing the remaining blocks via `Fin.succAbove` preserves the restricted BNT canonical-form hypotheses.
> 
> Updates the blueprint with `lem:cf_bnt_tail_succAbove`, documenting the new arbitrary-tail canonical-form preservation result alongside the existing leading-tail lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd1663b485417cdee09efc2e1ed415cc19c2f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->