### PR TITLE
feat(MPS/FT): extract selected coefficient from LI relation

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Defs
+import TNLean.MPS.BNT.Basic
 import TNLean.MPS.FundamentalTheorem.Full.ProportionalScalar
 
 /-!
@@ -285,6 +286,45 @@ lemma eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weigh
       simp [smul_eq_mul]
     _ = c N * mpv (toTensorFromBlocks μB B) σ := by
       rw [← hBcoeff]
+
+/-- **Selected coefficient extraction from an eventual two-family relation.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
+`Lem1`. Once the selected block on one side has been rewritten as a phase
+multiple of the selected block on the other side, Lemma `Lem1` supplies
+eventual linear independence for the remaining two-family list. This lemma is
+the coefficient bookkeeping for that step: equality of the two finite linear
+combinations forces the coefficient of the selected vector to agree
+eventually. -/
+lemma eventually_selected_coefficient_eq_of_eventually_linearIndependent_sum
+    {ι κ : Type*} [Fintype ι] [Fintype κ]
+    {E : ℕ → Type*} [∀ N, AddCommGroup (E N)] [∀ N, Module ℂ (E N)]
+    (v : (N : ℕ) → ι → E N) (w : (N : ℕ) → κ → E N)
+    (a : ℕ → ι → ℂ) (b₀ : ℕ → ℂ) (b : ℕ → κ → ℂ)
+    (i₀ : ι)
+    (hLI : ∀ᶠ N in atTop, LinearIndependent ℂ (Sum.elim (v N) (w N)))
+    (hEq : ∀ᶠ N in atTop,
+      ∑ i : ι, a N i • v N i =
+        b₀ N • v N i₀ + ∑ k : κ, b N k • w N k) :
+    ∀ᶠ N in atTop, a N i₀ = b₀ N := by
+  classical
+  let lhs : (N : ℕ) → Sum ι κ → ℂ := fun N =>
+    Sum.elim (a N) (fun _ => 0)
+  let rhs : (N : ℕ) → Sum ι κ → ℂ := fun N =>
+    Sum.elim (fun i => if i = i₀ then b₀ N else 0) (b N)
+  have hEqSum :
+      ∀ᶠ N in atTop,
+        ∑ x : Sum ι κ, lhs N x • Sum.elim (v N) (w N) x =
+          ∑ x : Sum ι κ, rhs N x • Sum.elim (v N) (w N) x := by
+    refine hEq.mono ?_
+    intro N hN
+    simp [lhs, rhs, Fintype.sum_sum_type, hN]
+  have hCoeff :=
+    coefficient_eventually_eq_of_eventually_linearIndependent
+      (fun N => Sum.elim (v N) (w N)) lhs rhs hLI hEqSum
+  refine hCoeff.mono ?_
+  intro N hN
+  simpa [lhs, rhs] using hN (Sum.inl i₀)
 
 /-- **Selected weighted summand from phase and coefficient equality.**
 

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -134,6 +134,30 @@ with an extra $Z$-gauge degree of freedom.
 	and evaluate the eventual state identity on each basis word.
 \end{proof}
 
+\begin{lemma}[Selected coefficient extraction after one phase substitution]%
+\label{lem:selected_coefficient_from_two_family_linear_independence}
+	\lean{MPSTensor.eventually_selected_coefficient_eq_of_eventually_linearIndependent_sum}
+	\leanok
+	\uses{def:mpv_state}
+	Let \(v_i^{(N)}\) and \(w_k^{(N)}\) be two finite families which, together,
+	are linearly independent for all sufficiently large \(N\).  Suppose that
+	for all sufficiently large \(N\),
+	\[
+		\sum_i a_i^{(N)} v_i^{(N)}
+		=
+		b_0^{(N)} v_{i_0}^{(N)}
+		+\sum_k b_k^{(N)} w_k^{(N)}.
+	\]
+	Then \(a_{i_0}^{(N)}=b_0^{(N)}\) for all sufficiently large \(N\).
+\end{lemma}
+
+\begin{proof}\leanok
+	Regard both sides as linear combinations of the single family indexed by
+	the disjoint union of the two finite index sets.  Linear independence
+	forces equality of every coefficient, in particular the coefficient of
+	\(v_{i_0}^{(N)}\).
+\end{proof}
+
 \begin{lemma}[Selected weighted summand from phase and coefficient equality]%
 \label{lem:selected_weighted_summand_from_phase_coeff}
 	\lean{MPSTensor.eventually_selected_weighted_mpvState_eq_smul_of_phase_and_coeff}


### PR DESCRIPTION
## Summary

Adds the next small post-#1564 helper for the CPSV16 Theorem thm1 tail argument: after replacing one matched block by its phase multiple, an eventual two-family linear-independent relation identifies the selected coefficient.

## Faithfulness

This is not a new source theorem. It is the finite-dimensional coefficient bookkeeping used after Lemma Lem1 in arXiv:1606.00608, Theorem thm1, line 1182. It adds no paper-level hypothesis to the fundamental theorem statement.

## Changes

- Adds MPSTensor.eventually_selected_coefficient_eq_of_eventually_linearIndependent_sum.
- Adds the corresponding blueprint entry.

## Verification

- lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
- lake build
- leanblueprint checkdecls
- git diff --check
- rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex

References #1563 and #1559. Follow-up to #1564.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small new helper lemma and documentation entry; it’s localized to proof/bookkeeping code and should not affect core definitions or runtime behavior.
> 
> **Overview**
> Adds `MPSTensor.eventually_selected_coefficient_eq_of_eventually_linearIndependent_sum`, a bookkeeping lemma that turns an eventual equality of two finite sums over *two* families plus eventual linear independence into eventual equality of the selected coefficient.
> 
> Updates the blueprint to include the corresponding lemma and proof sketch, and imports `TNLean.MPS.BNT.Basic` to reuse the existing `coefficient_eventually_eq_of_eventually_linearIndependent` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6d9725d89c5a75c0e8d1e65a9ca57f1b79201c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->