### PR TITLE
feat(MPS/FT): derive selected summand from LI relation

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -354,6 +354,63 @@ lemma eventually_selected_weighted_mpvState_eq_smul_of_phase_and_coeff
       congr 1
       ring
 
+/-- **Selected weighted summand from phase substitution and linear independence.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
+`Lem1`. After a non-decaying block pair has supplied the phase relation for
+the selected block, Lemma `Lem1` gives eventual linear independence of the
+family obtained by replacing that selected block by its phase-matched partner.
+The total weighted-state relation then identifies the selected coefficient,
+and hence the selected weighted summand. -/
+lemma eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li
+    {d : ℕ} {ι κ : Type*} [Fintype ι] [Fintype κ]
+    {dimA : ι → ℕ} {dimB₀ : ℕ} {dimB : κ → ℕ}
+    {μA : ι → ℂ} {μB₀ ζ : ℂ} {μB : κ → ℂ} {c : ℕ → ℂ}
+    (A : (i : ι) → MPSTensor d (dimA i))
+    (B₀ : MPSTensor d dimB₀)
+    (B : (k : κ) → MPSTensor d (dimB k))
+    (i₀ : ι)
+    (hPhase : ∀ N : ℕ,
+      mpvState (d := d) B₀ N = ζ ^ N • mpvState (d := d) (A i₀) N)
+    (hLI : ∀ᶠ N in atTop,
+      LinearIndependent ℂ
+        (Sum.elim
+          (fun i : ι => mpvState (d := d) (A i) N)
+          (fun k : κ => mpvState (d := d) (B k) N)))
+    (hState : ∀ᶠ N in atTop,
+      (∑ i : ι, (μA i) ^ N • mpvState (d := d) (A i) N) =
+        c N •
+          ((μB₀ ^ N • mpvState (d := d) B₀ N) +
+            ∑ k : κ, (μB k) ^ N • mpvState (d := d) (B k) N)) :
+    ∀ᶠ N in atTop,
+      (μA i₀) ^ N • mpvState (d := d) (A i₀) N =
+        c N • (μB₀ ^ N • mpvState (d := d) B₀ N) := by
+  classical
+  have hCoeff :
+      ∀ᶠ N in atTop, (μA i₀) ^ N = c N * (μB₀ * ζ) ^ N := by
+    refine eventually_selected_coefficient_eq_of_eventually_linearIndependent_sum
+      (fun N i => mpvState (d := d) (A i) N)
+      (fun N k => mpvState (d := d) (B k) N)
+      (fun N i => (μA i) ^ N)
+      (fun N => c N * (μB₀ * ζ) ^ N)
+      (fun N k => c N * (μB k) ^ N)
+      i₀ hLI ?_
+    refine hState.mono ?_
+    intro N hN
+    calc
+      (∑ i : ι, (μA i) ^ N • mpvState (d := d) (A i) N) =
+          c N •
+            ((μB₀ ^ N • mpvState (d := d) B₀ N) +
+              ∑ k : κ, (μB k) ^ N • mpvState (d := d) (B k) N) := hN
+      _ =
+          (c N * (μB₀ * ζ) ^ N) • mpvState (d := d) (A i₀) N +
+            ∑ k : κ,
+              (c N * (μB k) ^ N) • mpvState (d := d) (B k) N := by
+        rw [hPhase N, smul_add, Finset.smul_sum]
+        simp [smul_smul, mul_pow]
+  exact eventually_selected_weighted_mpvState_eq_smul_of_phase_and_coeff
+    (A i₀) B₀ hPhase hCoeff
+
 /-- **Subtracting a proportional dominant summand from weighted MPV-state sums.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof removes

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -181,6 +181,38 @@ with an extra $Z$-gauge degree of freedom.
 	\((\mu_B\zeta)^N=\mu_B^N\zeta^N\).
 \end{proof}
 
+\begin{lemma}[Selected weighted summand from phase substitution and Lemma Lem1]%
+\label{lem:selected_weighted_summand_from_phase_sum_li}
+	\lean{MPSTensor.eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li}
+	\leanok
+	\uses{lem:selected_coefficient_from_two_family_linear_independence,
+		lem:selected_weighted_summand_from_phase_coeff}
+	Suppose a total weighted-state identity has the form
+	\[
+		\sum_i \mu_i^N \ket{V^{(N)}(A_i)}
+		=
+		c_N\left(\nu_0^N\ket{V^{(N)}(B_0)}
+		+\sum_k \nu_k^N\ket{V^{(N)}(B_k)}\right)
+	\]
+	for all sufficiently large \(N\).  If
+	\(\ket{V^{(N)}(B_0)}=\zeta^N\ket{V^{(N)}(A_{i_0})}\) for every \(N\), and
+	the family consisting of the \(A_i\) together with the remaining \(B_k\)
+	is eventually linearly independent, then
+	\[
+		\mu_{i_0}^N\ket{V^{(N)}(A_{i_0})}
+		=
+		c_N\nu_0^N\ket{V^{(N)}(B_0)}
+	\]
+	for all sufficiently large \(N\).
+\end{lemma}
+
+\begin{proof}\leanok
+	Substitute the phase relation for \(B_0\) and apply coefficient
+	extraction to the eventually linearly independent disjoint family.  The
+	resulting coefficient equality gives the selected weighted-summand
+	identity.
+\end{proof}
+
 \begin{lemma}[Subtracting a proportional selected summand]%
 \label{lem:proportional_weighted_state_tail_subtraction}
 	\lean{MPSTensor.weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected}


### PR DESCRIPTION
## Summary

Adds the next CPSV16 Theorem thm1 bookkeeping bridge for #1563: after a non-decaying pair supplies a phase relation and Lemma Lem1 supplies eventual linear independence of the phase-substituted family, the total weighted-state identity identifies the selected weighted summand.

## Faithfulness

This is not a new source theorem. It formalizes the coefficient step used at arXiv:1606.00608, Theorem thm1, line 1182, without adding any hypothesis to the source-level nondecaying-overlap statement. The linear-independence hypothesis is exactly the local output of Lemma Lem1 for the substituted family.

## Changes

- Adds MPSTensor.eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li.
- Adds the corresponding blueprint entry.

## Verification

- lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
- lake build
- leanblueprint checkdecls
- git diff --check
- rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex

References #1563 and #1559.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new derived lemma and corresponding blueprint documentation without changing existing definitions or proof behavior elsewhere.
> 
> **Overview**
> Adds a new Lean lemma `MPSTensor.eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li` that combines (1) a phase relation for a selected block, (2) eventual linear independence of the phase-substituted two-family, and (3) an eventual total weighted-state identity to conclude the **eventual equality of the selected weighted summand**.
> 
> Updates the blueprint (Chapter 11) with a matching lemma statement and proof sketch, linking it to the existing coefficient-extraction and phase+coefficient summand lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dabce7082bd46c371c4f62a7c61943a17a5bf55d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->