### PR TITLE
feat(MPS/FT): package tail proportionality after phase substitution

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -667,6 +667,71 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
       (fun k : Fin nB => B (b0.succAbove k))
       c hc hTailReindex
 
+/-- **Eventual proportionality of tails from phase substitution and Lemma `Lem1`.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
+`Lem1`. Once a selected non-decaying block pair has been converted into a
+phase relation, Lemma `Lem1` gives eventual linear independence for the family
+obtained by replacing the selected block by its phase-matched partner. This
+lemma packages the resulting coefficient extraction, selected-summand
+subtraction, and arbitrary-tail reindexing. -/
+lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li
+    {d nA nB : ℕ}
+    {dimA : Fin (nA + 1) → ℕ} {dimB : Fin (nB + 1) → ℕ}
+    {μA : Fin (nA + 1) → ℂ} {μB : Fin (nB + 1) → ℂ}
+    {ζ : ℂ}
+    (A : (j : Fin (nA + 1)) → MPSTensor d (dimA j))
+    (B : (k : Fin (nB + 1)) → MPSTensor d (dimB k))
+    (c : ℕ → ℂ) (a0 : Fin (nA + 1)) (b0 : Fin (nB + 1))
+    (hc : ∀ᶠ N in atTop, c N ≠ 0)
+    (hPhase : ∀ N : ℕ,
+      mpvState (d := d) (B b0) N = ζ ^ N • mpvState (d := d) (A a0) N)
+    (hLI : ∀ᶠ N in atTop,
+      LinearIndependent ℂ
+        (Sum.elim
+          (fun j : Fin (nA + 1) => mpvState (d := d) (A j) N)
+          (fun k : Fin nB => mpvState (d := d) (B (b0.succAbove k)) N)))
+    (hState : ∀ᶠ N in atTop,
+      (∑ j : Fin (nA + 1), (μA j) ^ N • mpvState (d := d) (A j) N) =
+        c N •
+          (∑ k : Fin (nB + 1), (μB k) ^ N • mpvState (d := d) (B k) N)) :
+    EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks
+        (fun j : Fin nA => μA (a0.succAbove j))
+        (fun j : Fin nA => A (a0.succAbove j)))
+      (toTensorFromBlocks
+        (fun k : Fin nB => μB (b0.succAbove k))
+        (fun k : Fin nB => B (b0.succAbove k))) := by
+  have hStateSplit :
+      ∀ᶠ N in atTop,
+        (∑ j : Fin (nA + 1), (μA j) ^ N • mpvState (d := d) (A j) N) =
+          c N •
+            (((μB b0) ^ N • mpvState (d := d) (B b0) N) +
+              ∑ k : Fin nB,
+                (μB (b0.succAbove k)) ^ N •
+                  mpvState (d := d) (B (b0.succAbove k)) N) := by
+    refine hState.mono ?_
+    intro N hN
+    have hBsplit :
+        (∑ k : Fin (nB + 1), (μB k) ^ N • mpvState (d := d) (B k) N) =
+          ((μB b0) ^ N • mpvState (d := d) (B b0) N) +
+            ∑ k : Fin nB,
+              (μB (b0.succAbove k)) ^ N •
+                mpvState (d := d) (B (b0.succAbove k)) N := by
+      rw [← Finset.add_sum_erase _ _ (Finset.mem_univ b0)]
+      congr 1
+      exact weighted_mpvState_sum_erase_eq_sum_succAbove B b0 N
+    rw [hBsplit] at hN
+    exact hN
+  have hSelected :
+      ∀ᶠ N in atTop,
+        (μA a0) ^ N • mpvState (d := d) (A a0) N =
+          c N • ((μB b0) ^ N • mpvState (d := d) (B b0) N) :=
+    eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li
+      A (B b0) (fun k : Fin nB => B (b0.succAbove k)) a0 hPhase hLI hStateSplit
+  exact eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
+    A B c a0 b0 hc hState hSelected
+
 /-- **Projection of a fixed weighted MPV-state scalar sequence.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. Once the

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -324,6 +324,27 @@ with an extra $Z$-gauge degree of freedom.
 	assembled tail tensors.
 \end{proof}
 
+\begin{lemma}[Eventual tail proportionality from phase substitution and Lemma Lem1]%
+\label{lem:eventual_tail_proportional_from_phase_sum_li}
+	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li}
+	\leanok
+	\uses{lem:selected_weighted_summand_from_phase_sum_li,
+		lem:eventual_proportional_weighted_tail_succAbove_package}
+	Suppose the total weighted state sums are eventually related by a nonzero
+	scalar sequence.  If a selected pair satisfies
+	\(\ket{V^{(N)}(B_{b_0})}=\zeta^N\ket{V^{(N)}(A_{a_0})}\) for every \(N\),
+	and the family consisting of all \(A\)-blocks together with the remaining
+	\(B\)-blocks is eventually linearly independent, then the two complements,
+	reindexed by the insertion maps, are eventually nonzero proportional.
+\end{lemma}
+
+\begin{proof}\leanok
+	Rewrite the \(B\)-side weighted sum as the selected summand plus its
+	complement.  The phase-substitution coefficient lemma gives the selected
+	weighted summand identity.  Subtract that identity from the total relation
+	and reindex the two complements.
+\end{proof}
+
 \begin{lemma}[Norm convergence for scalar-related normalized vectors]%
 \label{lem:proportional_scalar_norm_core}
 	\lean{MPSTensor.tendsto_norm_scalar_of_tendsto_norm_one}


### PR DESCRIPTION
## Summary

Adds the next CPSV16 Theorem thm1 tail bridge for #1563: from a full eventual weighted-state identity, a phase relation for a selected pair, and Lemma Lem1 eventual linear independence after deleting the selected B block, the two reindexed erased tails are eventually nonzero proportional.

## Faithfulness

This is local proof bookkeeping for arXiv:1606.00608, Theorem thm1, line 1182. It does not alter the source-level nondecaying-overlap theorem or add a source-absent hypothesis to that theorem; the linear-independence input is precisely the local use of Lemma Lem1 on the substituted family.

## Changes

- Adds MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li.
- Adds the corresponding blueprint entry.

## Verification

- lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
- lake build
- leanblueprint checkdecls
- git diff --check
- rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex

References #1563 and #1559.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean lemma and matching blueprint documentation without changing existing definitions or rewriting core logic. Main risk is proof fragility or tighter assumptions affecting downstream lemma dependencies.
> 
> **Overview**
> Adds a new Lean bookkeeping lemma, `eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li`, that turns an eventual total weighted-state proportionality plus a *selected* phase relation and eventual linear independence (via `Lem1`) into eventual nonzero proportionality of the two reindexed “tails” after deleting the matched block.
> 
> Updates the blueprint (Chapter 11) with the corresponding statement and proof sketch, documenting the phase-substitution tail-reduction step used in the CPSV16 Theorem `thm1` proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eba7794944fd90ee933ab33581c7d980a2f074d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->