### PR TITLE
doc(MPS/FT): mark tail LI helpers conditional

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -668,14 +668,19 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
       (fun k : Fin nB => B (b0.succAbove k))
       c hc hTailReindex
 
-/-- **Eventual proportionality of tails from phase substitution and Lemma `Lem1`.**
+/-- **Conditional tail proportionality from phase substitution and Lemma `Lem1`.**
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. Once a selected non-decaying block pair has been converted into a
 phase relation, Lemma `Lem1` gives eventual linear independence for the family
 obtained by replacing the selected block by its phase-matched partner. This
 lemma packages the resulting coefficient extraction, selected-summand
-subtraction, and arbitrary-tail reindexing. -/
+subtraction, and arbitrary-tail reindexing.
+
+This is conditional bookkeeping: the eventual linear-independence hypothesis is
+not a global consequence of the BNT hypotheses for an arbitrary remaining
+family.  In the proof of Theorem `thm1` it must be supplied by the fixed-block
+application of Lemma `Lem1` at the current peeling step. -/
 lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li
     {d nA nB : ℕ}
     {dimA : Fin (nA + 1) → ℕ} {dimB : Fin (nB + 1) → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -668,7 +668,7 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
       (fun k : Fin nB => B (b0.succAbove k))
       c hc hTailReindex
 
-/-- **Conditional tail proportionality from phase substitution and Lemma `Lem1`.**
+/-- **Tail proportionality from phase substitution and a Lemma `Lem1` input.**
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. Once a selected non-decaying block pair has been converted into a
@@ -677,10 +677,10 @@ obtained by replacing the selected block by its phase-matched partner. This
 lemma packages the resulting coefficient extraction, selected-summand
 subtraction, and arbitrary-tail reindexing.
 
-This is conditional bookkeeping: the eventual linear-independence hypothesis is
-not a global consequence of the BNT hypotheses for an arbitrary remaining
-family.  In the proof of Theorem `thm1` it must be supplied by the fixed-block
-application of Lemma `Lem1` at the current peeling step. -/
+The assumption is that the displayed combined MPV family is linearly independent
+for all sufficiently large lengths. In the proof of Theorem `thm1` this
+assumption is supplied by the fixed-block application of Lemma `Lem1` at the
+current peeling step. -/
 lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li
     {d nA nB : ℕ}
     {dimA : Fin (nA + 1) → ℕ} {dimB : Fin (nB + 1) → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean
@@ -25,7 +25,7 @@ namespace MPSTensor
 
 section ProportionalExpansionLeft
 
-/-- **Conditional tail proportionality from the left phase-substituted family.**
+/-- **Tail proportionality from the left phase-substituted family.**
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. This is the symmetric bookkeeping form of
@@ -35,10 +35,10 @@ eventual linear-independence input is taken for the family consisting of all
 nonzero so that the selected `A`-summand can be rewritten in terms of the
 selected `B`-summand before coefficient extraction.
 
-This is conditional bookkeeping: the eventual linear-independence hypothesis is
-not a global consequence of the BNT hypotheses for an arbitrary remaining
-family.  In the proof of Theorem `thm1` it must be supplied by the fixed-block
-application of Lemma `Lem1` at the current peeling step. -/
+The assumption is that the displayed combined MPV family is linearly independent
+for all sufficiently large lengths. In the proof of Theorem `thm1` this
+assumption is supplied by the fixed-block application of Lemma `Lem1` at the
+current peeling step. -/
 lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li_left
     {d nA nB : ℕ}
     {dimA : Fin (nA + 1) → ℕ} {dimB : Fin (nB + 1) → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean
@@ -25,7 +25,7 @@ namespace MPSTensor
 
 section ProportionalExpansionLeft
 
-/-- **Eventual proportionality of tails from the left phase-substituted family.**
+/-- **Conditional tail proportionality from the left phase-substituted family.**
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. This is the symmetric bookkeeping form of
@@ -33,7 +33,12 @@ Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 eventual linear-independence input is taken for the family consisting of all
 `B`-blocks together with the remaining `A`-blocks. The phase is assumed
 nonzero so that the selected `A`-summand can be rewritten in terms of the
-selected `B`-summand before coefficient extraction. -/
+selected `B`-summand before coefficient extraction.
+
+This is conditional bookkeeping: the eventual linear-independence hypothesis is
+not a global consequence of the BNT hypotheses for an arbitrary remaining
+family.  In the proof of Theorem `thm1` it must be supplied by the fixed-block
+application of Lemma `Lem1` at the current peeling step. -/
 lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li_left
     {d nA nB : ℕ}
     {dimA : Fin (nA + 1) → ℕ} {dimB : Fin (nB + 1) → ℕ}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -360,12 +360,17 @@ with an extra $Z$-gauge degree of freedom.
 	\leanok
 	\uses{lem:selected_weighted_summand_from_phase_sum_li,
 		lem:eventual_proportional_weighted_tail_succAbove_package}
-	Suppose the total weighted state sums are eventually related by a nonzero
+	This is a conditional bookkeeping lemma.  Suppose the total weighted state
+	sums are eventually related by a nonzero
 	scalar sequence.  If a selected pair satisfies
 	\(\ket{V^{(N)}(B_{b_0})}=\zeta^N\ket{V^{(N)}(A_{a_0})}\) for every \(N\),
 	and the family consisting of all \(A\)-blocks together with the remaining
 	\(B\)-blocks is eventually linearly independent, then the two complements,
 	reindexed by the insertion maps, are eventually nonzero proportional.
+	The linear-independence hypothesis is not a global consequence of the BNT
+	hypotheses for an arbitrary remaining family; in the proof of the theorem
+	it must be supplied by the fixed-block application of Lemma
+	\texttt{Lem1} at the current peeling step.
 	This combines \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} and
 	\cite[Corollary~\texttt{eqV}]{Cirac2016MPDO_arXiv} at the recursive
 	peeling point of
@@ -385,13 +390,18 @@ with an extra $Z$-gauge degree of freedom.
 	\leanok
 	\uses{lem:selected_coefficient_from_two_family_linear_independence,
 		lem:eventual_proportional_weighted_tail_succAbove_package}
-	Suppose the total weighted state sums are eventually related by a nonzero
+	This is a conditional bookkeeping lemma.  Suppose the total weighted state
+	sums are eventually related by a nonzero
 	scalar sequence, and suppose
 	\(\ket{V^{(N)}(B_{b_0})}=\zeta^N\ket{V^{(N)}(A_{a_0})}\) for every \(N\),
 	with \(\zeta\ne 0\).  If the family consisting of all \(B\)-blocks together
 	with the remaining \(A\)-blocks is eventually linearly independent, then the
 	two complements, reindexed by the insertion maps, are eventually nonzero
 	proportional.
+	The linear-independence hypothesis is not a global consequence of the BNT
+	hypotheses for an arbitrary remaining family; in the proof of the theorem
+	it must be supplied by the fixed-block application of Lemma
+	\texttt{Lem1} at the current peeling step.
 	This is the same recursive peeling step with the linearly independent
 	family ordered as all \(B\)-blocks together with the remaining
 	\(A\)-blocks; it is used for the symmetric half of

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -354,23 +354,23 @@ with an extra $Z$-gauge degree of freedom.
 	assembled tail tensors.
 \end{proof}
 
+% Proof-boundary note: the assumption that the displayed combined MPV family is
+% linearly independent for all sufficiently large N is not a global consequence
+% of the BNT hypotheses for arbitrary remaining blocks. In the proof of
+% Theorem II.1 it must be supplied by the fixed-block application of Lemma
+% \texttt{Lem1} at the current peeling step.
 \begin{lemma}[Eventual tail proportionality from phase substitution and Lemma Lem1]%
 \label{lem:eventual_tail_proportional_from_phase_sum_li}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li}
 	\leanok
 	\uses{lem:selected_weighted_summand_from_phase_sum_li,
 		lem:eventual_proportional_weighted_tail_succAbove_package}
-	This is a conditional bookkeeping lemma.  Suppose the total weighted state
-	sums are eventually related by a nonzero
+	Suppose the total weighted state sums are eventually related by a nonzero
 	scalar sequence.  If a selected pair satisfies
 	\(\ket{V^{(N)}(B_{b_0})}=\zeta^N\ket{V^{(N)}(A_{a_0})}\) for every \(N\),
 	and the family consisting of all \(A\)-blocks together with the remaining
 	\(B\)-blocks is eventually linearly independent, then the two complements,
 	reindexed by the insertion maps, are eventually nonzero proportional.
-	The linear-independence hypothesis is not a global consequence of the BNT
-	hypotheses for an arbitrary remaining family; in the proof of the theorem
-	it must be supplied by the fixed-block application of Lemma
-	\texttt{Lem1} at the current peeling step.
 	This combines \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} and
 	\cite[Corollary~\texttt{eqV}]{Cirac2016MPDO_arXiv} at the recursive
 	peeling point of
@@ -384,24 +384,24 @@ with an extra $Z$-gauge degree of freedom.
 	and reindex the two complements.
 \end{proof}
 
+% Proof-boundary note: the assumption that the displayed combined MPV family is
+% linearly independent for all sufficiently large N is not a global consequence
+% of the BNT hypotheses for arbitrary remaining blocks. In the proof of
+% Theorem II.1 it must be supplied by the fixed-block application of Lemma
+% \texttt{Lem1} at the current peeling step.
 \begin{lemma}[Eventual tail proportionality from the left substituted family]%
 \label{lem:eventual_tail_proportional_from_phase_sum_li_left}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li_left}
 	\leanok
 	\uses{lem:selected_coefficient_from_two_family_linear_independence,
 		lem:eventual_proportional_weighted_tail_succAbove_package}
-	This is a conditional bookkeeping lemma.  Suppose the total weighted state
-	sums are eventually related by a nonzero
+	Suppose the total weighted state sums are eventually related by a nonzero
 	scalar sequence, and suppose
 	\(\ket{V^{(N)}(B_{b_0})}=\zeta^N\ket{V^{(N)}(A_{a_0})}\) for every \(N\),
 	with \(\zeta\ne 0\).  If the family consisting of all \(B\)-blocks together
 	with the remaining \(A\)-blocks is eventually linearly independent, then the
 	two complements, reindexed by the insertion maps, are eventually nonzero
 	proportional.
-	The linear-independence hypothesis is not a global consequence of the BNT
-	hypotheses for an arbitrary remaining family; in the proof of the theorem
-	it must be supplied by the fixed-block application of Lemma
-	\texttt{Lem1} at the current peeling step.
 	This is the same recursive peeling step with the linearly independent
 	family ordered as all \(B\)-blocks together with the remaining
 	\(A\)-blocks; it is used for the symmetric half of

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -357,8 +357,8 @@ with an extra $Z$-gauge degree of freedom.
 % Proof-boundary note: the assumption that the displayed combined MPV family is
 % linearly independent for all sufficiently large N is not a global consequence
 % of the BNT hypotheses for arbitrary remaining blocks. In the proof of
-% Theorem II.1 it must be supplied by the fixed-block application of Lemma
-% \texttt{Lem1} at the current peeling step.
+% Theorem II.1 it must be supplied by the fixed-block application of
+% \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} at the current peeling step.
 \begin{lemma}[Eventual tail proportionality from phase substitution and Lemma Lem1]%
 \label{lem:eventual_tail_proportional_from_phase_sum_li}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li}
@@ -387,8 +387,8 @@ with an extra $Z$-gauge degree of freedom.
 % Proof-boundary note: the assumption that the displayed combined MPV family is
 % linearly independent for all sufficiently large N is not a global consequence
 % of the BNT hypotheses for arbitrary remaining blocks. In the proof of
-% Theorem II.1 it must be supplied by the fixed-block application of Lemma
-% \texttt{Lem1} at the current peeling step.
+% Theorem II.1 it must be supplied by the fixed-block application of
+% \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} at the current peeling step.
 \begin{lemma}[Eventual tail proportionality from the left substituted family]%
 \label{lem:eventual_tail_proportional_from_phase_sum_li_left}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li_left}


### PR DESCRIPTION
## Summary

This PR clarifies the proof boundary after #1600/#1601. The right- and left-tail phase-substitution helpers are conditional bookkeeping lemmas: they require the eventual linear independence supplied at a particular fixed-block Lemma `Lem1` step, and that hypothesis is not a global consequence of the BNT assumptions for arbitrary residual families.

Changes:
- mark `eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li` as conditional bookkeeping in its Lean docstring;
- make the same clarification for the left-hand symmetric helper;
- update the Chapter 11 blueprint statements so the extra linear-independence input is not mistaken for a source theorem hypothesis.

This supports #1563 and records #1603 as the next proof sub-issue. It does not discharge the remaining `NondecayingOverlap.lean` paper-realignment sorry.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean`
- `leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean`
- `lake build`

## Issues

- Parent: #1563
- New sub-issue: #1603
- Umbrella: #1559

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes clarifying proof assumptions; no changes to Lean statements, proofs, or runtime behavior.
> 
> **Overview**
> Clarifies that the tail phase-substitution helpers `eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li` and `_left` are *conditional bookkeeping lemmas* whose eventual linear-independence hypothesis must be supplied by the fixed-block application of Lemma `Lem1` at each peeling step (not derived globally from BNT assumptions).
> 
> Updates the Chapter 11 blueprint to add matching proof-boundary notes so reviewers don’t misread the linear-independence input as a standing theorem hypothesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b27b8ac4b5b51c886b11af1eb504e61469887b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->