### PR TITLE
feat(MPS/FT): add fixed-block Lem1 input

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -677,6 +677,61 @@ lemma isCanonicalFormBNT_tail_succAbove
       (fun j k hjk hdim => hA.blocks_not_equiv (a0.succAbove j) (a0.succAbove k)
         (fun h => hjk (Fin.succAbove_right_injective h)) hdim)
 
+/-- **Fixed-block Lemma `Lem1` input for the proportional BNT theorem.**
+
+Source: arXiv:1606.00608, Corollary `Lem1` and Theorem `thm1`, line 1182.
+In the proof of Theorem `thm1`, one fixes a block `B_k` and assumes, for
+contradiction, that all overlaps with the `A_j` tend to zero. Together with
+the BNT asymptotic orthonormality inside the `A`-family and the normalized
+self-overlap of `B_k`, Corollary `Lem1` gives linear independence, for all
+sufficiently large lengths, of the combined family consisting of all `A_j`
+and this one fixed block `B_k`. -/
+lemma eventually_linearIndependent_all_left_single_right_of_all_overlaps_decay_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (k₀ : Fin rB)
+    (hAllDecay : ∀ j : Fin rA,
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (B k₀) N) atTop (nhds 0)) :
+    ∀ᶠ N in atTop,
+      LinearIndependent ℂ
+        (Sum.elim
+          (fun j : Fin rA => mpvState (d := d) (A j) N)
+          (fun _ : Fin 1 => mpvState (d := d) (B k₀) N)) := by
+  classical
+  let dimBsingle : Fin 1 → ℕ := fun _ => dimB k₀
+  let Bsingle : (k : Fin 1) → MPSTensor d (dimBsingle k) := fun _ => B k₀
+  have hA_self : ∀ j : Fin rA,
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (A j) N) atTop (nhds 1) :=
+    hA.toHasNormalizedSelfOverlap.overlap_tendsto_one
+  have hA_cross : ∀ i j : Fin rA, i ≠ j →
+      Tendsto (fun N => mpvOverlap (d := d) (A i) (A j) N) atTop (nhds 0) :=
+    hA.cross_overlap_tendsto_zero
+  have hBsingle_self : ∀ k : Fin 1,
+      Tendsto (fun N => mpvOverlap (d := d) (Bsingle k) (Bsingle k) N) atTop
+        (nhds 1) := by
+    intro k
+    simpa [Bsingle] using hB.toHasNormalizedSelfOverlap.overlap_tendsto_one k₀
+  have hBsingle_cross : ∀ k₁ k₂ : Fin 1, k₁ ≠ k₂ →
+      Tendsto (fun N => mpvOverlap (d := d) (Bsingle k₁) (Bsingle k₂) N)
+        atTop (nhds 0) := by
+    intro k₁ k₂ hk
+    exact (hk (Subsingleton.elim k₁ k₂)).elim
+  have hAB : ∀ j : Fin rA, ∀ k : Fin 1,
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (Bsingle k) N) atTop
+        (nhds 0) := by
+    intro j k
+    simpa [Bsingle] using hAllDecay j
+  have hLI :=
+    eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal
+      A Bsingle hA_self hA_cross hBsingle_self hBsingle_cross hAB
+  simpa [Bsingle] using hLI
+
 /-- **Non-decaying overlap existence for proportional-MPV BNT families.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the proof,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -770,11 +770,34 @@ with an extra $Z$-gauge degree of freedom.
 	family.
 \end{proof}
 
+\begin{lemma}[Fixed-block Lemma Lem1 input for proportional BNT families]%
+\label{lem:fixed_right_lem1_input_eventual_proportional}
+	\lean{MPSTensor.eventually_linearIndependent_all_left_single_right_of_all_overlaps_decay_CFBNT}
+	\leanok
+	\uses{lem:bnt_two_family_overlap_orthonormal_li}
+	Fix one block \(B_{k_0}\) of a BNT canonical-form family.  If
+	\(O_{A_j,B_{k_0}}(N)\to 0\) for every block \(A_j\) in the other BNT
+	family, then the combined MPV family consisting of all \(A_j\) and the
+	single block \(B_{k_0}\) is linearly independent for all sufficiently large
+	\(N\).  This is the fixed-block application of
+	\cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} in the proof of
+	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	The assumed mixed overlaps, the BNT asymptotic orthonormality of the
+	\(A\)-family, and the normalized self-overlap of \(B_{k_0}\) make the Gram
+	matrix of the combined family tend to the identity.  Apply the two-family
+	orthonormal-overlap form of
+	\cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv}.
+\end{proof}
+
 \begin{theorem}[Proportional BNT families have non-decaying block overlaps]%
 \label{thm:proportional_bnt_nondecaying_overlap}
 	\lean{MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT}
 	\leanok
-	\uses{def:cf_bnt, def:mpv_overlap, def:nonzero_proportional_mpv}
+	\uses{def:cf_bnt, def:mpv_overlap, def:nonzero_proportional_mpv,
+		lem:fixed_right_lem1_input_eventual_proportional}
 	Let \(A=\bigoplus_j \mu_j A_j\) and
 	\(B=\bigoplus_k \nu_k B_k\) be canonical-form tensors with already
 	selected one-copy BNT representatives, with \(r_A\ge 1\) and


### PR DESCRIPTION
## Summary

This PR proves the fixed-block Lemma `Lem1` input needed for #1603 and the remaining #1563 proportional block-selection proof.

New Lean lemma:
- `MPSTensor.eventually_linearIndependent_all_left_single_right_of_all_overlaps_decay_CFBNT`
- location: `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`

Mathematical content: if a fixed block `B k₀` has vanishing overlap with every `A j`, then the combined family consisting of all `A j` together with this single `B k₀` is linearly independent for all sufficiently large lengths. This is the fixed-block application of CPSV16 Corollary `Lem1` used in Theorem `thm1`, line 1182.

The PR also adds the corresponding blueprint entry `lem:fixed_right_lem1_input_eventual_proportional` and wires it into the uses of `thm:proportional_bnt_nondecaying_overlap`.

This does not discharge the remaining `NondecayingOverlap.lean` paper-realignment `sorry`; it supplies the local Lemma `Lem1` input needed by the next contradiction step.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
- `leanblueprint checkdecls`
- `git diff --check`
- touched-file `rg -n "eventually_linearIndependent_all_left_single_right|fixed_right_lem1|sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` — only the pre-existing main theorem `sorry` remains in the touched Lean file
- `lake build`

## Issues

- Advances #1603
- Parent: #1563
- Umbrella: #1559

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a self-contained Lean lemma and corresponding blueprint documentation, with no changes to existing theorem statements or runtime code paths.
> 
> **Overview**
> Adds a new Lean lemma `eventually_linearIndependent_all_left_single_right_of_all_overlaps_decay_CFBNT` proving the fixed-block Corollary `Lem1` input used in the proportional BNT non-decaying overlap argument (linear independence of all `A` blocks plus one fixed `B k₀` under vanishing mixed overlaps).
> 
> Updates the blueprint to document this lemma (`lem:fixed_right_lem1_input_eventual_proportional`) and references it in the `thm:proportional_bnt_nondecaying_overlap` dependency list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b166fc110dd927996c1a140aa465970a44ff8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->