### PR TITLE
feat(MPS/FT): add symmetric fixed-block Lem1 input

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -780,7 +780,8 @@ lemma eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_C
       Tendsto (fun N => mpvOverlap (d := d) (B k) (Asingle j) N) atTop
         (nhds 0) := by
     intro k j
-    simpa [Asingle] using tendsto_mpvOverlap_zero_swap (d := d) (A j₀) (B k) (hAllDecay k)
+    simpa [Asingle] using
+      tendsto_mpvOverlap_zero_swap (d := d) (A j₀) (B k) (hAllDecay k)
   have hLI :=
     eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal
       B Asingle hB_self hB_cross hAsingle_self hAsingle_cross hBA

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -732,6 +732,60 @@ lemma eventually_linearIndependent_all_left_single_right_of_all_overlaps_decay_C
       A Bsingle hA_self hA_cross hBsingle_self hBsingle_cross hAB
   simpa [Bsingle] using hLI
 
+/-- **Symmetric fixed-block Lemma `Lem1` input for the proportional BNT theorem.**
+
+Source: arXiv:1606.00608, Corollary `Lem1` and Theorem `thm1`, lines
+1182--1185. The proof of Theorem `thm1` repeats the fixed-block argument with
+the two tensor families interchanged. If one fixes a block `A_j` and assumes
+that all overlaps with the `B_k` tend to zero, Corollary `Lem1` gives linear
+independence, for all sufficiently large lengths, of the combined family
+consisting of all `B_k` and this one fixed block `A_j`. -/
+lemma eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (j₀ : Fin rA)
+    (hAllDecay : ∀ k : Fin rB,
+      Tendsto (fun N => mpvOverlap (d := d) (A j₀) (B k) N) atTop (nhds 0)) :
+    ∀ᶠ N in atTop,
+      LinearIndependent ℂ
+        (Sum.elim
+          (fun k : Fin rB => mpvState (d := d) (B k) N)
+          (fun _ : Fin 1 => mpvState (d := d) (A j₀) N)) := by
+  classical
+  let dimAsingle : Fin 1 → ℕ := fun _ => dimA j₀
+  let Asingle : (j : Fin 1) → MPSTensor d (dimAsingle j) := fun _ => A j₀
+  have hB_self : ∀ k : Fin rB,
+      Tendsto (fun N => mpvOverlap (d := d) (B k) (B k) N) atTop (nhds 1) :=
+    hB.toHasNormalizedSelfOverlap.overlap_tendsto_one
+  have hB_cross : ∀ i j : Fin rB, i ≠ j →
+      Tendsto (fun N => mpvOverlap (d := d) (B i) (B j) N) atTop (nhds 0) :=
+    hB.cross_overlap_tendsto_zero
+  have hAsingle_self : ∀ j : Fin 1,
+      Tendsto (fun N => mpvOverlap (d := d) (Asingle j) (Asingle j) N) atTop
+        (nhds 1) := by
+    intro j
+    simpa [Asingle] using hA.toHasNormalizedSelfOverlap.overlap_tendsto_one j₀
+  have hAsingle_cross : ∀ j₁ j₂ : Fin 1, j₁ ≠ j₂ →
+      Tendsto (fun N => mpvOverlap (d := d) (Asingle j₁) (Asingle j₂) N)
+        atTop (nhds 0) := by
+    intro j₁ j₂ hj
+    exact (hj (Subsingleton.elim j₁ j₂)).elim
+  have hBA : ∀ k : Fin rB, ∀ j : Fin 1,
+      Tendsto (fun N => mpvOverlap (d := d) (B k) (Asingle j) N) atTop
+        (nhds 0) := by
+    intro k j
+    simpa [Asingle] using tendsto_mpvOverlap_zero_swap (d := d) (A j₀) (B k) (hAllDecay k)
+  have hLI :=
+    eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal
+      B Asingle hB_self hB_cross hAsingle_self hAsingle_cross hBA
+  simpa [Asingle] using hLI
+
 /-- **Non-decaying overlap existence for proportional-MPV BNT families.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the proof,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -792,12 +792,36 @@ with an extra $Z$-gauge degree of freedom.
 	\cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv}.
 \end{proof}
 
+\begin{lemma}[Symmetric fixed-block Lemma Lem1 input for proportional BNT families]%
+\label{lem:fixed_left_lem1_input_eventual_proportional}
+	\lean{MPSTensor.eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_CFBNT}
+	\leanok
+	\uses{lem:bnt_two_family_overlap_orthonormal_li}
+	Fix one block \(A_{j_0}\) of a BNT canonical-form family.  If
+	\(O_{A_{j_0},B_k}(N)\to 0\) for every block \(B_k\) in the other BNT
+	family, then the combined MPV family consisting of all \(B_k\) and the
+	single block \(A_{j_0}\) is linearly independent for all sufficiently large
+	\(N\).  This is the symmetric fixed-block application of
+	\cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} in the proof of
+	\cite[Theorem~II.1, lines~1182--1185]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	The assumed mixed overlaps, the BNT asymptotic orthonormality of the
+	\(B\)-family, and the normalized self-overlap of \(A_{j_0}\) make the Gram
+	matrix of the combined family tend to the identity.  The mixed overlaps are
+	first conjugated to put the family in the displayed order, and then the
+	two-family orthonormal-overlap form of
+	\cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} applies.
+\end{proof}
+
 \begin{theorem}[Proportional BNT families have non-decaying block overlaps]%
 \label{thm:proportional_bnt_nondecaying_overlap}
 	\lean{MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT}
 	\leanok
 	\uses{def:cf_bnt, def:mpv_overlap, def:nonzero_proportional_mpv,
-		lem:fixed_right_lem1_input_eventual_proportional}
+		lem:fixed_right_lem1_input_eventual_proportional,
+		lem:fixed_left_lem1_input_eventual_proportional}
 	Let \(A=\bigoplus_j \mu_j A_j\) and
 	\(B=\bigoplus_k \nu_k B_k\) be canonical-form tensors with already
 	selected one-copy BNT representatives, with \(r_A\ge 1\) and


### PR DESCRIPTION
## Summary

Adds the symmetric fixed-block application of CPSV16 Lemma `Lem1` for the proportional BNT theorem.  The new lemma fixes a block `A j₀`; if all overlaps with the `B`-blocks tend to zero, then the family consisting of all `B_k` together with the single fixed `A j₀` is eventually linearly independent.

This is the left-hand counterpart to #1605 and supplies the Lemma `Lem1` input needed by the symmetric tail-removal lemma `MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li_left`.

Parent: #1603
Parent tracker: #1563
Umbrella: #1559

## Source

CPSV16, arXiv:1606.00608, Corollary `Lem1` and Theorem `thm1`, lines 1182--1185.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean` passed, with the pre-existing warning that `exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT` still contains the Stage C proof obligation.
- `lake build` passed, with pre-existing warnings.
- `cd blueprint && leanblueprint checkdecls` passed.
- `git diff --check` passed.
- touched-file scan: only the pre-existing `sorry` in `NondecayingOverlap.lean` was reported.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new auxiliary Lean lemma and corresponding blueprint documentation, without altering existing core proofs or definitions.
> 
> **Overview**
> Adds the symmetric fixed-block variant of the CPSV16 `Lem1` input used in the proportional BNT argument: fixing an `A j₀` block, if all overlaps with `B k` decay, then the combined family `(all B_k) ∪ {A j₀}` is eventually linearly independent (`eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_CFBNT`).
> 
> Updates the blueprint to document this new lemma and includes it in the dependency list for `Proportional BNT families have non-decaying block overlaps`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b57fa569e137cdda3e5dde1415b895f46423d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->