### PR TITLE
fix(paper-gaps): support unicode subscript identifiers

### DIFF
--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -1,5 +1,7 @@
 % Shared commands for notes in docs/paper-gaps/.
 
+\DeclareUnicodeCharacter{2082}{\ensuremath{_2}}
+
 \newcommand{\Lean}{\textsc{Lean}}
 \newcommand{\leanid}[1]{\textsf{#1}}
 \newcommand{\tnleanIssueBase}{https://github.com/LionSR/TNLean/issues/}

--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -1,6 +1,6 @@
 % Shared commands for notes in docs/paper-gaps/.
 
-\DeclareUnicodeCharacter{2082}{\ifmmode{}_2\else\textsubscript{2}\fi}
+\DeclareUnicodeCharacter{2082}{\ifmmode{}_{2}\else\textsubscript{2}\fi}
 
 \newcommand{\Lean}{\textsc{Lean}}
 \newcommand{\leanid}[1]{\textsf{#1}}

--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -1,6 +1,6 @@
 % Shared commands for notes in docs/paper-gaps/.
 
-\DeclareUnicodeCharacter{2082}{\ensuremath{_2}}
+\DeclareUnicodeCharacter{2082}{\ifmmode{}_2\else\textsubscript{2}\fi}
 
 \newcommand{\Lean}{\textsc{Lean}}
 \newcommand{\leanid}[1]{\textsf{#1}}


### PR DESCRIPTION
## Summary
- add a shared pdflatex declaration for Unicode subscript ₂ in paper-gap notes
- allows Lean identifiers such as MPV₂ to appear in leanid entries without breaking PDF compilation

## Verification
- latexmk -pdf -interaction=nonstopmode -halt-on-error cpsv16_fixed_block_cancellation.tex from docs/paper-gaps
- git diff --check
- lake build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc-only change: adds a LaTeX unicode mapping so `pdflatex` can compile notes containing the `₂` character without affecting code or data paths.
> 
> **Overview**
> Adds a shared LaTeX `\DeclareUnicodeCharacter{2082}{...}` in `docs/paper-gaps/command.tex` so the Unicode subscript `₂` renders as a subscript (in math mode) or text subscript (in text mode).
> 
> This prevents `pdflatex` compilation failures when identifiers in paper-gap notes include `₂` (e.g., `MPV₂`) via the shared `\input{command}` setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c8bf762accdba8c7f46935b7abdfa38708768a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->