### PR TITLE
feat(MPS/FT): record leading fixed-block cancellation

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -787,6 +787,60 @@ lemma eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_C
       B Asingle hB_self hB_cross hAsingle_self hAsingle_cross hBA
   simpa [Asingle] using hLI
 
+/-- **Leading fixed-right all-overlaps-decay contradiction.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, line 1182. This is the fixed-block
+cancellation step for the leading block of the `B`-family. In the
+one-copy-per-sector surface used here, the dominant projection argument already
+rules out decay of all overlaps with that leading `B`-block under eventual
+nonzero proportionality of the total MPV families. -/
+lemma fixed_right_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (hAllDecay : ∀ j : Fin rA,
+      Tendsto
+        (fun N => mpvOverlap (d := d) (A j) (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N)
+        atTop (nhds 0)) :
+    False :=
+  (dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    A B hA hB hrA hrB hProp).1 hAllDecay
+
+/-- **Leading fixed-left all-overlaps-decay contradiction.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1182--1185. This is the
+symmetric leading-block cancellation step for the leading block of the
+`A`-family. The dominant projection argument rules out simultaneous decay of
+all overlaps with that leading `A`-block under eventual nonzero proportionality
+of the total MPV families. -/
+lemma fixed_left_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (hAllDecay : ∀ k : Fin rB,
+      Tendsto
+        (fun N => mpvOverlap (d := d) (A ⟨0, Nat.pos_of_ne_zero hrA⟩) (B k) N)
+        atTop (nhds 0)) :
+    False :=
+  (dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    A B hA hB hrA hrB hProp).2 hAllDecay
+
 /-- **Fixed-right all-overlaps-decay contradiction for proportional BNT families.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, line 1182. In the proof, after

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -791,7 +791,7 @@ lemma eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_C
 
 Source: arXiv:1606.00608, Theorem `thm1`, line 1182. This is the fixed-block
 cancellation step for the leading block of the `B`-family. In the
-one-copy-per-sector surface used here, the dominant projection argument already
+one-copy-per-sector setting, the dominant projection argument already
 rules out decay of all overlaps with that leading `B`-block under eventual
 nonzero proportionality of the total MPV families. -/
 lemma fixed_right_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -815,6 +815,42 @@ with an extra $Z$-gauge degree of freedom.
 	\cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} applies.
 \end{proof}
 
+\begin{lemma}[Leading fixed-right all-overlaps-decay contradiction]%
+\label{lem:fixed_right_leading_all_overlaps_decay_contradiction}
+	\lean{MPSTensor.fixed_right_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
+	\leanok
+	\uses{def:cf_bnt, def:nonzero_proportional_mpv,
+		lem:dominant_projection_contradiction_eventual_proportional}
+	Under eventual nonzero proportionality of the two total weighted MPV
+	families, the leading block \(B_0\) of the \(B\)-family cannot have
+	\(O_{A_j,B_0}(N)\to 0\) for every block \(A_j\).  This is the
+	leading-block instance of the fixed-\(B_k\) sentence in
+	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	This is exactly the \(B\)-leading half of the dominant projection
+	contradiction.
+\end{proof}
+
+\begin{lemma}[Leading fixed-left all-overlaps-decay contradiction]%
+\label{lem:fixed_left_leading_all_overlaps_decay_contradiction}
+	\lean{MPSTensor.fixed_left_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
+	\leanok
+	\uses{def:cf_bnt, def:nonzero_proportional_mpv,
+		lem:dominant_projection_contradiction_eventual_proportional}
+	Under eventual nonzero proportionality of the two total weighted MPV
+	families, the leading block \(A_0\) of the \(A\)-family cannot have
+	\(O_{A_0,B_k}(N)\to 0\) for every block \(B_k\).  This is the
+	symmetric leading-block instance of the fixed-block argument in
+	\cite[Theorem~II.1, lines~1182--1185]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	This is exactly the \(A\)-leading half of the dominant projection
+	contradiction.
+\end{proof}
+
 \begin{lemma}[Fixed-right all-overlaps-decay contradiction]%
 \label{lem:fixed_right_all_overlaps_decay_contradiction}
 	\lean{MPSTensor.fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT}

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -72,16 +72,28 @@ selected coefficient to vanish.  The corresponding declarations are
 \end{aligned}
 \]
 
+The leading-block cases are also formalized.  They are discharged by the
+dominant projection contradiction already available for eventually nonzero
+proportional BNT families:
+\[
+\begin{aligned}
+&\leanid{MPSTensor.fixed\_right\_leading\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT},\\
+&\leanid{MPSTensor.fixed\_left\_leading\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}.
+\end{aligned}
+\]
+
 \section{Elimination plan}
 
 The intended elimination is to prove the two fixed-block contradiction
 declarations from the BNT hypotheses, eventual nonzero proportionality, and the
 already formalized fixed-block Lemma~\texttt{Lem1} inputs.  A proof may use an
-induction through matched block removal or a direct argument isolating the
-selected summand in the quotient by the span of the opposite family.  It must
-not assume global linear independence of all remaining blocks, since that is
-not a consequence of the BNT hypotheses once a block on one side may be
-phase-equivalent to a block on the other.
+induction through matched block removal, using the leading-block
+contradictions above as the case in which the selected block has become
+dominant, or a direct argument isolating the selected summand in the quotient
+by the span of the opposite family.  It must not assume global linear
+independence of all remaining blocks, since that is not a consequence of the
+BNT hypotheses once a block on one side may be phase-equivalent to a block on
+the other.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- adds source-cited leading fixed-right and fixed-left all-overlaps-decay contradictions for CPSV16 Theorem II.1, lines 1182--1185
- records the corresponding blueprint entries with citations to Cirac2016MPDO_arXiv
- updates the fixed-block cancellation paper-gap note to separate the proved leading cases from the remaining arbitrary fixed-block isolation problem

## Remaining paper-realignment obligations

The two arbitrary fixed-block cancellation declarations in NondecayingOverlap.lean remain as the documented issue #1607 obligations. No new sorry is introduced by this PR.

## Verification

- lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
- lake build
- cd blueprint && leanblueprint checkdecls
- git diff --check
- latexmk -pdf -interaction=nonstopmode -halt-on-error cpsv16_fixed_block_cancellation.tex from docs/paper-gaps

PR #1610 was merged first so the paper-gap Unicode subscript mapping is available on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two small wrapper lemmas and documentation entries that reuse an existing dominant-projection contradiction, with no changes to core definitions or algorithms.
> 
> **Overview**
> Adds two new Lean lemmas, `fixed_right_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT` and `fixed_left_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`, capturing the *leading-block* fixed-block cancellation cases by directly invoking the existing `dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT` result.
> 
> Updates the blueprint (Chapter 11) and the `cpsv16_fixed_block_cancellation` paper-gap note to record these leading-case cancellations with source citations, and to clarify that the remaining open obligation is the arbitrary fixed-block isolation/cancellation step (issue `#1607`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b6177789fd7c61377e8726b74c714dddea4a31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->