### PR TITLE
feat(MPS/FT): record dominant inner concentration

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -136,15 +136,7 @@ lemma dominant_projection_contradictions_of_normalized_proportional_inner
         (fun N : ℕ =>
           ‖c N * (μB ⟨0, Nat.pos_of_ne_zero hrB⟩ /
             μA ⟨0, Nat.pos_of_ne_zero hrA⟩) ^ N‖)
-        atTop (nhds (1 : ℝ)))
-    (hA_self : ∀ j : Fin rA,
-      Tendsto (fun N => mpvOverlap (d := d) (A j) (A j) N) atTop (nhds 1))
-    (hB_self : ∀ k : Fin rB,
-      Tendsto (fun N => mpvOverlap (d := d) (B k) (B k) N) atTop (nhds 1))
-    (hA_cross : ∀ j k : Fin rA, j ≠ k →
-      Tendsto (fun N => mpvOverlap (d := d) (A j) (A k) N) atTop (nhds 0))
-    (hB_cross : ∀ j k : Fin rB, j ≠ k →
-      Tendsto (fun N => mpvOverlap (d := d) (B j) (B k) N) atTop (nhds 0)) :
+        atTop (nhds (1 : ℝ))) :
     ((∀ j : Fin rA,
         Tendsto
           (fun N => mpvOverlap (d := d) (A j)
@@ -159,18 +151,6 @@ lemma dominant_projection_contradictions_of_normalized_proportional_inner
   let b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
   have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
   have hμB_ne : μB b0 ≠ 0 := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero b0
-  have hA_inner_diag : ∀ j : Fin rA,
-      Tendsto (fun N => mpvInner (d := d) (A j) (A j) N) atTop (nhds 1) :=
-    fun j => tendsto_inner_one (A j) (hA_self j)
-  have hA_inner_off : ∀ i j : Fin rA, i ≠ j →
-      Tendsto (fun N => mpvInner (d := d) (A i) (A j) N) atTop (nhds 0) :=
-    fun i j hij => tendsto_inner_zero (A i) (A j) (hA_cross i j hij)
-  have hB_inner_diag : ∀ k : Fin rB,
-      Tendsto (fun N => mpvInner (d := d) (B k) (B k) N) atTop (nhds 1) :=
-    fun k => tendsto_inner_one (B k) (hB_self k)
-  have hB_inner_off : ∀ i j : Fin rB, i ≠ j →
-      Tendsto (fun N => mpvInner (d := d) (B i) (B j) N) atTop (nhds 0) :=
-    fun i j hij => tendsto_inner_zero (B i) (B j) (hB_cross i j hij)
   have hAdjustedScalar :
       Tendsto (fun N : ℕ => ‖c N * (μB b0 / μA a0) ^ N‖) atTop
         (nhds (1 : ℝ)) := by
@@ -220,27 +200,7 @@ lemma dominant_projection_contradictions_of_normalized_proportional_inner
             (μB b0 ^ N)⁻¹ *
               (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N))
           atTop (nhds 1) := by
-      have hsum :
-          Tendsto
-            (fun N : ℕ =>
-              ∑ k : Fin rB, (μB k / μB b0) ^ N *
-                mpvInner (d := d) (B b0) (B k) N)
-            atTop (nhds 1) :=
-        sum_tendsto_one_of_diag (hμ0 := hμB_ne) (j0 := b0) rfl (hB_inner_diag b0)
-          (fun k hk => by
-            rw [norm_div]
-            exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
-              (hB.mu_strict_anti (by
-                simp only [b0, Fin.lt_def]
-                exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h)))))
-          (fun k hk => hB_inner_off b0 k hk.symm)
-      convert hsum using 1
-      ext N
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro k _
-      rw [div_pow]
-      field_simp [pow_ne_zero N hμB_ne]
+      simpa [b0] using tendsto_normalized_weighted_mpvInner_sum_of_leading_CFBNT B hB hrB
     have hRHS_norm_one :
         Tendsto
           (fun N : ℕ =>
@@ -296,27 +256,7 @@ lemma dominant_projection_contradictions_of_normalized_proportional_inner
             (μA a0 ^ N)⁻¹ *
               (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (A a0) (A j) N))
           atTop (nhds 1) := by
-      have hsum :
-          Tendsto
-            (fun N : ℕ =>
-              ∑ j : Fin rA, (μA j / μA a0) ^ N *
-                mpvInner (d := d) (A a0) (A j) N)
-            atTop (nhds 1) :=
-        sum_tendsto_one_of_diag (hμ0 := hμA_ne) (j0 := a0) rfl (hA_inner_diag a0)
-          (fun j hj => by
-            rw [norm_div]
-            exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
-              (hA.mu_strict_anti (by
-                simp only [a0, Fin.lt_def]
-                exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h)))))
-          (fun j hj => hA_inner_off a0 j hj.symm)
-      convert hsum using 1
-      ext N
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro j _
-      rw [div_pow]
-      field_simp [pow_ne_zero N hμA_ne]
+      simpa [a0] using tendsto_normalized_weighted_mpvInner_sum_of_leading_CFBNT A hA hrA
     have hB_proj_sum :
         Tendsto
           (fun N : ℕ =>
@@ -504,7 +444,6 @@ lemma dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_
     dominant_projection_contradictions_of_normalized_proportional_inner
       A B hA hB hrA hrB c hNormalizedInner
       (by simpa [a0, b0] using hAdjustedScalar_dom)
-      hA_self hB_self hA_cross hB_cross
 
 /-- **Dominant blocks have non-decaying partners under eventual proportionality.**
 

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -66,9 +66,13 @@ lemma tendsto_normalized_weighted_mpvInner_sum_of_dominant
 
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. This is
 the preceding dominant projection estimate specialized to the leading block of
-an `IsCanonicalFormBNT` family in the present one-copy-per-sector formalization.
-The strict ordering of BNT weight moduli supplies the required strict
-dominance of the leading weight. -/
+an `IsCanonicalFormBNT` family. The strict ordering of BNT weight moduli
+supplies the required strict dominance of the leading weight.
+
+**Scope restriction (one-copy-per-sector):** The predicate `IsCanonicalFormBNT`
+is the single-representative BNT surface. The general CPSV16 BNT canonical form
+allows multiplicities inside a sector. This restriction is documented in
+`docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma tendsto_normalized_weighted_mpvInner_sum_of_leading_CFBNT
     {d r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ}

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -24,6 +24,83 @@ namespace MPSTensor
 
 section ProportionalDominant
 
+/-- **Dominant normalized inner-product concentration.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the
+fixed-block argument, after expanding a canonical-form tensor into weighted BNT
+blocks, one projects the weighted sum against a selected dominant block. If all
+other weights have strictly smaller modulus and the selected block is
+asymptotically normalized while the off-diagonal overlaps decay, the normalized
+projection tends to one. This is the inner-product concentration step used
+before comparing the two proportional block sums. -/
+lemma tendsto_normalized_weighted_mpvInner_sum_of_dominant
+    {d r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    (j₀ : Fin r) (hμ0 : μ j₀ ≠ 0)
+    (hdiag :
+      Tendsto (fun N => mpvInner (d := d) (A j₀) (A j₀) N) atTop (nhds 1))
+    (hoff : ∀ j : Fin r, j ≠ j₀ →
+      Tendsto (fun N => mpvInner (d := d) (A j₀) (A j) N) atTop (nhds 0))
+    (hratio : ∀ j : Fin r, j ≠ j₀ → ‖μ j / μ j₀‖ < 1) :
+    Tendsto
+      (fun N : ℕ =>
+        (μ j₀ ^ N)⁻¹ *
+          (∑ j : Fin r, (μ j) ^ N * mpvInner (d := d) (A j₀) (A j) N))
+      atTop (nhds 1) := by
+  have hsum :
+      Tendsto
+        (fun N : ℕ =>
+          ∑ j : Fin r, (μ j / μ j₀) ^ N *
+            mpvInner (d := d) (A j₀) (A j) N)
+        atTop (nhds 1) :=
+    sum_tendsto_one_of_diag (hμ0 := hμ0) (j0 := j₀) rfl hdiag hratio hoff
+  convert hsum using 1
+  ext N
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [div_pow]
+  field_simp [pow_ne_zero N hμ0]
+
+/-- **Leading BNT normalized inner-product concentration.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. This is
+the preceding dominant projection estimate specialized to the leading block of
+an `IsCanonicalFormBNT` family in the present one-copy-per-sector formalization.
+The strict ordering of BNT weight moduli supplies the required strict
+dominance of the leading weight. -/
+lemma tendsto_normalized_weighted_mpvInner_sum_of_leading_CFBNT
+    {d r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    {μ : Fin r → ℂ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    (hA : IsCanonicalFormBNT μ A) (hr : r ≠ 0) :
+    Tendsto
+      (fun N : ℕ =>
+        (μ ⟨0, Nat.pos_of_ne_zero hr⟩ ^ N)⁻¹ *
+          (∑ j : Fin r,
+            (μ j) ^ N *
+              mpvInner (d := d) (A ⟨0, Nat.pos_of_ne_zero hr⟩) (A j) N))
+      atTop (nhds 1) := by
+  let j₀ : Fin r := ⟨0, Nat.pos_of_ne_zero hr⟩
+  have hμ0 : μ j₀ ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero j₀
+  have hdiag :
+      Tendsto (fun N => mpvInner (d := d) (A j₀) (A j₀) N) atTop (nhds 1) :=
+    tendsto_inner_one (A j₀) (hA.toHasNormalizedSelfOverlap.overlap_tendsto_one j₀)
+  have hoff : ∀ j : Fin r, j ≠ j₀ →
+      Tendsto (fun N => mpvInner (d := d) (A j₀) (A j) N) atTop (nhds 0) := by
+    intro j hj
+    exact tendsto_inner_zero (A j₀) (A j) (hA.cross_overlap_tendsto_zero j₀ j hj.symm)
+  have hratio : ∀ j : Fin r, j ≠ j₀ → ‖μ j / μ j₀‖ < 1 := by
+    intro j hj
+    rw [norm_div]
+    exact (div_lt_one (norm_pos_iff.mpr hμ0)).mpr
+      (hA.mu_strict_anti (by
+        simp only [j₀, Fin.lt_def]
+        exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h))))
+  simpa [j₀] using
+    tendsto_normalized_weighted_mpvInner_sum_of_dominant
+      A j₀ hμ0 hdiag hoff hratio
+
 /-- **Dominant-block projection contradiction for proportional BNT families.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. If the normalized

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -14,7 +14,7 @@ proportional non-decaying-overlap step of the fundamental theorem.
 
 * Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
   Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017),
-  Theorem `thm1`, lines 1170--1192.
+  Theorem thm1, lines 1170--1192.
 -/
 
 open scoped Matrix BigOperators InnerProductSpace
@@ -26,7 +26,7 @@ section ProportionalDominant
 
 /-- **Dominant normalized inner-product concentration.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the
+Source context: arXiv:1606.00608, Theorem thm1, lines 1170--1192. In the
 fixed-block argument, after expanding a canonical-form tensor into weighted BNT
 blocks, one projects the weighted sum against a selected dominant block. If all
 other weights have strictly smaller modulus and the selected block is
@@ -64,14 +64,14 @@ lemma tendsto_normalized_weighted_mpvInner_sum_of_dominant
 
 /-- **Leading BNT normalized inner-product concentration.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. This is
+Source context: arXiv:1606.00608, Theorem thm1, lines 1170--1192. This is
 the preceding dominant projection estimate specialized to the leading block of
 an `IsCanonicalFormBNT` family. The strict ordering of BNT weight moduli
 supplies the required strict dominance of the leading weight.
 
 **Scope restriction (one-copy-per-sector):** The predicate `IsCanonicalFormBNT`
-is the single-representative BNT surface. The general CPSV16 BNT canonical form
-allows multiplicities inside a sector. This restriction is documented in
+selects one BNT representative in each sector. The general CPSV16 BNT
+canonical form allows multiplicities inside a sector. This restriction is documented in
 `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma tendsto_normalized_weighted_mpvInner_sum_of_leading_CFBNT
     {d r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -107,7 +107,7 @@ lemma tendsto_normalized_weighted_mpvInner_sum_of_leading_CFBNT
 
 /-- **Dominant-block projection contradiction for proportional BNT families.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. If the normalized
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. If the normalized
 proportional projection identity eventually holds and has an adjusted scalar
 whose modulus tends to one, then the dominant block on either side cannot have
 all cross-overlaps tending to zero. This is the dominant case of the CPSV16
@@ -335,7 +335,7 @@ lemma dominant_projection_contradictions_of_normalized_proportional_inner
 
 /-- **Dominant-block projection contradiction from eventual proportionality.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After expanding
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. After expanding
 the two canonical-form tensors into their BNT block sums, eventual nonzero
 proportionality supplies the scalar sequence used in the dominant-block
 projection contradiction. This is the dominant case of the line 1182 argument,
@@ -447,7 +447,7 @@ lemma dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_
 
 /-- **Dominant blocks have non-decaying partners under eventual proportionality.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The dominant
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. The dominant
 projection contradiction rules out the alternative that the leading block on
 one side has vanishing overlap with every block on the other side. Hence each
 leading block admits a non-decaying overlap partner. -/

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -370,12 +370,6 @@ lemma dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_
   have hB_self : ∀ k : Fin rB,
       Tendsto (fun N => mpvOverlap (d := d) (B k) (B k) N) atTop (nhds 1) :=
     hB.toHasNormalizedSelfOverlap.overlap_tendsto_one
-  have hA_cross : ∀ j k : Fin rA, j ≠ k →
-      Tendsto (fun N => mpvOverlap (d := d) (A j) (A k) N) atTop (nhds 0) :=
-    hA.cross_overlap_tendsto_zero
-  have hB_cross : ∀ j k : Fin rB, j ≠ k →
-      Tendsto (fun N => mpvOverlap (d := d) (B j) (B k) N) atTop (nhds 0) :=
-    hB.cross_overlap_tendsto_zero
   obtain ⟨c, _hc, hState⟩ :=
     exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroProportionalMPV₂
       A B hProp

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -484,6 +484,36 @@ with an extra $Z$-gauge degree of freedom.
 	dominant term has norm tending to \(1\).
 \end{proof}
 
+\begin{lemma}[Dominant-weight normalized BNT projections concentrate]%
+\label{lem:dominant_weight_normalized_bnt_projection}
+	\lean{MPSTensor.tendsto_normalized_weighted_mpvInner_sum_of_dominant}
+	\lean{MPSTensor.tendsto_normalized_weighted_mpvInner_sum_of_leading_CFBNT}
+	\leanok
+	\uses{def:mpv_inner}
+	Let \(A_j\) be a finite BNT family.  Fix a dominant weight
+	\(\mu_{j_0}\ne 0\), and assume that every other weight ratio satisfies
+	\(|\mu_j/\mu_{j_0}|<1\).  If the selected self-projection tends to \(1\)
+	and all off-diagonal projections from the selected block tend to \(0\),
+	then
+	\[
+		\mu_{j_0}^{-N}
+		\sum_j \mu_j^N
+		\langle V^{(N)}(A_{j_0}),V^{(N)}(A_j)\rangle
+		\longrightarrow 1 .
+	\]
+	In particular, this holds for the leading block of a one-copy BNT
+	canonical-form family.  \cite[Theorem~\texttt{thm1},
+	lines~1170--1192]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	After division by the dominant weight, the selected term has coefficient
+	one.  The selected self-projection tends to \(1\), and every other term is
+	a geometrically damped off-diagonal projection.  Summing these limits gives
+	the asserted concentration.  In the BNT-leading case, strict ordering of
+	the weight moduli supplies the geometric damping.
+\end{proof}
+
 \begin{lemma}[Norm convergence of the proportional scalar sequence]%
 \label{lem:proportional_tensor_from_blocks_scalar_norm}
 	\lean{MPSTensor.tendsto_norm_weighted_mpvState_scalar_of_tendsto_norm_one}


### PR DESCRIPTION
## Summary

This PR adds the source-cited dominant inner-product concentration step needed for the CPSV16 fixed-block peeling route.

It introduces:

- `MPSTensor.tendsto_normalized_weighted_mpvInner_sum_of_dominant`
- `MPSTensor.tendsto_normalized_weighted_mpvInner_sum_of_leading_CFBNT`

These lemmas isolate the normalized projection estimate used when the weighted BNT sum is tested against a dominant block. They do not assume global cross-family linear independence; they use only a dominant weight ratio, diagonal normalization, and off-diagonal decay.

The blueprint entry cites CPSV16 arXiv:1606.00608, Theorem `thm1`, lines 1170--1192, at the end of the statement.

## Relation to issues

- Advances #1612 by supplying the inner-product concentration input for the selected scalar coefficient isolation lemma.
- Supports #1607 and therefore #1563.
- Does not close #1612 or #1607; the next missing step is still exact selected coefficient isolation without global cross-family LI.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean`
- `cd blueprint && leanblueprint checkdecls`
- `lake build`
- `git diff --check`

`lake build` succeeds with pre-existing warnings, including the known two `sorry`s in `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean` tracked by #1607.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core fundamental-theorem proof lemmas by adding new convergence results and refactoring the dominant projection contradiction to depend on them; mistakes could break downstream proof steps even though changes are purely formal/proof-level.
> 
> **Overview**
> Adds two new Lean lemmas (`tendsto_normalized_weighted_mpvInner_sum_of_dominant` and the `IsCanonicalFormBNT`-leading specialization) that formalize the *dominant-block normalized projection* limit used in the CPSV16 fixed-block argument.
> 
> Refactors `dominant_projection_contradictions_of_normalized_proportional_inner` (and its eventual-proportionality wrapper) to reuse these new concentration lemmas, dropping now-redundant explicit self/cross-overlap hypotheses and simplifying the proof.
> 
> Updates the blueprint to include a new cited lemma statement/proof (“Dominant-weight normalized BNT projections concentrate”) and aligns CPSV16 citation wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66a5009ec4e6acd61aee7879f9d417b69f3c7ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->