### PR TITLE
feat(MPS/FT): expose dominant adjusted scalar limit

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -285,11 +285,11 @@ lemma tendsto_phase_normalized_weighted_mpvInner_sum_of_leading_CFBNT
 
 /-- **Dominant adjusted scalar has asymptotic modulus one.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the
+Source: arXiv:1606.00608, lines 1170--1192. In the
 dominant-block projection comparison, eventual nonzero proportionality of the
-assembled weighted BNT sums gives a scalar sequence `c_N`. After normalizing
+assembled weighted BNT sums gives a scalar sequence. After normalizing
 the two sums by their leading weights, this scalar is adjusted by
-`(μB₀ / μA₀)^N`; the normalized dominant terms on both sides have norm tending
+the leading-weight ratio; the normalized dominant terms on both sides have norm tending
 to one, and therefore the adjusted scalar has modulus tending to one.
 
 **Scope restriction (one-copy-per-sector):** The predicate `IsCanonicalFormBNT`
@@ -621,14 +621,12 @@ lemma dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_
         Tendsto
           (fun N => mpvOverlap (d := d)
             (A ⟨0, Nat.pos_of_ne_zero hrA⟩) (B k) N)
-        atTop (nhds 0)) → False) := by
+          atTop (nhds 0)) → False) := by
   let a0 : Fin rA := ⟨0, Nat.pos_of_ne_zero hrA⟩
   let b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
   obtain ⟨c, _hc, hState, hAdjustedScalar_dom⟩ :=
     exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT
       A B hA hB hrA hrB hProp
-  have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
-  have hμB_ne : μB b0 ≠ 0 := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero b0
   have hInner :
       ∀ {D : ℕ} (X : MPSTensor d D),
         ∀ᶠ N in atTop,

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -283,6 +283,88 @@ lemma tendsto_phase_normalized_weighted_mpvInner_sum_of_leading_CFBNT
       (A a0) B b0 hμB_ne hζ (by simpa [a0, b0] using hPhase)
       hdiag hoff hratio
 
+/-- **Dominant adjusted scalar has asymptotic modulus one.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the
+dominant-block projection comparison, eventual nonzero proportionality of the
+assembled weighted BNT sums gives a scalar sequence `c_N`. After normalizing
+the two sums by their leading weights, this scalar is adjusted by
+`(μB₀ / μA₀)^N`; the normalized dominant terms on both sides have norm tending
+to one, and therefore the adjusted scalar has modulus tending to one.
+
+**Scope restriction (one-copy-per-sector):** The predicate `IsCanonicalFormBNT`
+selects one BNT representative in each sector. The general CPSV16 BNT
+canonical form allows multiplicities inside a sector. This restriction is documented in
+`docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
+lemma exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
+    ∃ c : ℕ → ℂ,
+      (∀ᶠ N in atTop, c N ≠ 0) ∧
+      (∀ᶠ N in atTop,
+        (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+          c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)) ∧
+      Tendsto
+        (fun N : ℕ =>
+          ‖c N * (μB ⟨0, Nat.pos_of_ne_zero hrB⟩ /
+            μA ⟨0, Nat.pos_of_ne_zero hrA⟩) ^ N‖)
+        atTop (nhds (1 : ℝ)) := by
+  let a0 : Fin rA := ⟨0, Nat.pos_of_ne_zero hrA⟩
+  let b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
+  have hA_self : ∀ j : Fin rA,
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (A j) N) atTop (nhds 1) :=
+    hA.toHasNormalizedSelfOverlap.overlap_tendsto_one
+  have hB_self : ∀ k : Fin rB,
+      Tendsto (fun N => mpvOverlap (d := d) (B k) (B k) N) atTop (nhds 1) :=
+    hB.toHasNormalizedSelfOverlap.overlap_tendsto_one
+  obtain ⟨c, hc, hState⟩ :=
+    exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroProportionalMPV₂
+      A B hProp
+  have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
+  have hμB_ne : μB b0 ≠ 0 := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero b0
+  have hA_norm_dominant :
+      Tendsto
+        (fun N : ℕ =>
+          ‖(μA a0 ^ N)⁻¹ •
+            (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N)‖)
+        atTop (nhds (1 : ℝ)) := by
+    exact tendsto_norm_normalized_weighted_mpvState_sum_of_dominant
+      A a0 hμA_ne hA_self (fun j hj => by
+        rw [norm_div]
+        exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
+          (hA.mu_strict_anti (by
+            simp only [a0, Fin.lt_def]
+            exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h)))))
+  have hB_norm_dominant :
+      Tendsto
+        (fun N : ℕ =>
+          ‖(μB b0 ^ N)⁻¹ •
+            (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)‖)
+        atTop (nhds (1 : ℝ)) := by
+    exact tendsto_norm_normalized_weighted_mpvState_sum_of_dominant
+      B b0 hμB_ne hB_self (fun k hk => by
+        rw [norm_div]
+        exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
+          (hB.mu_strict_anti (by
+            simp only [b0, Fin.lt_def]
+            exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h)))))
+  have hAdjustedScalar_dom :
+      Tendsto (fun N : ℕ => ‖c N * (μB b0 / μA a0) ^ N‖) atTop
+        (nhds (1 : ℝ)) :=
+    tendsto_norm_adjusted_weighted_mpvState_scalar_of_eventually_tendsto_norm_one
+      A B c (μA a0) (μB b0) hμA_ne hμB_ne hState
+      hA_norm_dominant hB_norm_dominant
+  exact ⟨c, hc, hState, by simpa [a0, b0] using hAdjustedScalar_dom⟩
+
 /-- **Dominant-block projection contradiction for proportional BNT families.**
 
 Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. If the normalized
@@ -539,52 +621,14 @@ lemma dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_
         Tendsto
           (fun N => mpvOverlap (d := d)
             (A ⟨0, Nat.pos_of_ne_zero hrA⟩) (B k) N)
-          atTop (nhds 0)) → False) := by
+        atTop (nhds 0)) → False) := by
   let a0 : Fin rA := ⟨0, Nat.pos_of_ne_zero hrA⟩
   let b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
-  have hA_self : ∀ j : Fin rA,
-      Tendsto (fun N => mpvOverlap (d := d) (A j) (A j) N) atTop (nhds 1) :=
-    hA.toHasNormalizedSelfOverlap.overlap_tendsto_one
-  have hB_self : ∀ k : Fin rB,
-      Tendsto (fun N => mpvOverlap (d := d) (B k) (B k) N) atTop (nhds 1) :=
-    hB.toHasNormalizedSelfOverlap.overlap_tendsto_one
-  obtain ⟨c, _hc, hState⟩ :=
-    exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroProportionalMPV₂
-      A B hProp
+  obtain ⟨c, _hc, hState, hAdjustedScalar_dom⟩ :=
+    exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hProp
   have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
   have hμB_ne : μB b0 ≠ 0 := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero b0
-  have hA_norm_dominant :
-      Tendsto
-        (fun N : ℕ =>
-          ‖(μA a0 ^ N)⁻¹ •
-            (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N)‖)
-        atTop (nhds (1 : ℝ)) := by
-    exact tendsto_norm_normalized_weighted_mpvState_sum_of_dominant
-      A a0 hμA_ne hA_self (fun j hj => by
-        rw [norm_div]
-        exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
-          (hA.mu_strict_anti (by
-            simp only [a0, Fin.lt_def]
-            exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h)))))
-  have hB_norm_dominant :
-      Tendsto
-        (fun N : ℕ =>
-          ‖(μB b0 ^ N)⁻¹ •
-            (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)‖)
-        atTop (nhds (1 : ℝ)) := by
-    exact tendsto_norm_normalized_weighted_mpvState_sum_of_dominant
-      B b0 hμB_ne hB_self (fun k hk => by
-        rw [norm_div]
-        exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
-          (hB.mu_strict_anti (by
-            simp only [b0, Fin.lt_def]
-            exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h)))))
-  have hAdjustedScalar_dom :
-      Tendsto (fun N : ℕ => ‖c N * (μB b0 / μA a0) ^ N‖) atTop
-        (nhds (1 : ℝ)) :=
-    tendsto_norm_adjusted_weighted_mpvState_scalar_of_eventually_tendsto_norm_one
-      A B c (μA a0) (μB b0) hμA_ne hμB_ne hState
-      hA_norm_dominant hB_norm_dominant
   have hInner :
       ∀ {D : ℕ} (X : MPSTensor d D),
         ∀ᶠ N in atTop,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -605,6 +605,35 @@ with an extra $Z$-gauge degree of freedom.
 	Lemma~\ref{lem:eventual_proportional_scalar_norm_core}.
 \end{proof}
 
+\begin{lemma}[Dominant adjusted proportional scalar has unit limiting modulus]%
+\label{lem:dominant_adjusted_scalar_norm}
+	\lean{MPSTensor.exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
+	\leanok
+	\uses{lem:eventual_proportional_tensor_from_blocks_adjusted_scalar_norm,
+		lem:dominant_weight_normalized_bnt_state_sum_norm}
+	Let \((\mu^A_j,A_j)\) and \((\mu^B_k,B_k)\) be one-copy BNT
+	canonical-form families with nonempty index sets, and suppose that the
+	assembled weighted MPV families are eventually nonzero proportional.  Then
+	there is an eventual nonzero scalar sequence \(c_N\) relating the two
+	assembled weighted sums, and, for the leading indices \(a_0,b_0\),
+	\[
+		\left|c_N\left(\frac{\mu^B_{b_0}}{\mu^A_{a_0}}\right)^N\right|
+		\longrightarrow 1 .
+	\]
+	This is the leading-weight normalization step in the dominant projection
+	argument.  \cite[Theorem~\texttt{thm1}, lines~1170--1192]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	Eventual proportionality supplies the scalar sequence \(c_N\).  Divide the
+	two weighted sums by the leading powers \((\mu^A_{a_0})^N\) and
+	\((\mu^B_{b_0})^N\).  Strict ordering of the BNT weight moduli and
+	normalized self-overlap give norm convergence to \(1\) for both normalized
+	sums, so
+	Lemma~\ref{lem:eventual_proportional_tensor_from_blocks_adjusted_scalar_norm}
+	applies.
+\end{proof}
+
 \begin{lemma}[Proportional weighted states give proportional weighted projections]%
 \label{lem:proportional_tensor_from_blocks_weighted_inner}
 	\lean{MPSTensor.exists_weighted_mpvInner_eq_mul_of_nonzeroProportionalMPV₂_toTensorFromBlocks}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -610,18 +610,26 @@ with an extra $Z$-gauge degree of freedom.
 	\lean{MPSTensor.exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
 	\leanok
 	\uses{lem:eventual_proportional_tensor_from_blocks_adjusted_scalar_norm,
-		lem:dominant_weight_normalized_bnt_state_sum_norm}
+		lem:dominant_weight_normalized_bnt_state_sum_norm,
+		lem:eventual_proportional_tensor_from_blocks_weighted_state_sequence}
 	Let \((\mu^A_j,A_j)\) and \((\mu^B_k,B_k)\) be one-copy BNT
 	canonical-form families with nonempty index sets, and suppose that the
 	assembled weighted MPV families are eventually nonzero proportional.  Then
-	there is an eventual nonzero scalar sequence \(c_N\) relating the two
-	assembled weighted sums, and, for the leading indices \(a_0,b_0\),
+	there is an eventual nonzero scalar sequence \(c_N\) such that, for all
+	sufficiently large \(N\),
+	\[
+		\sum_j (\mu^A_j)^N \ket{V^{(N)}(A_j)}
+		=
+		c_N
+		\sum_k (\mu^B_k)^N \ket{V^{(N)}(B_k)} .
+	\]
+	For the leading indices \(a_0,b_0\),
 	\[
 		\left|c_N\left(\frac{\mu^B_{b_0}}{\mu^A_{a_0}}\right)^N\right|
 		\longrightarrow 1 .
 	\]
 	This is the leading-weight normalization step in the dominant projection
-	argument.  \cite[Theorem~\texttt{thm1}, lines~1170--1192]{Cirac2016MPDO_arXiv}.
+	argument.  \cite[lines~1170--1192]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Summary

- add a source-cited lemma extracting the dominant adjusted scalar norm limit from eventual proportionality of one-copy BNT weighted sums
- refactor the existing dominant projection contradiction to consume the named scalar-limit lemma
- add the corresponding blueprint entry with the CPSV16 `thm1` citation at the end of the statement

This does not close the fixed-block cancellation gap by itself. It records a reusable leading-weight normalization step needed for #1612/#1607/#1563, without assuming global tail linear independence.

## Source

- CPSV16, `Papers/1606.00608/MPDO-22-12-17-2.tex`, Theorem `thm1`, lines 1170--1192.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean`
- `leanblueprint checkdecls` from `blueprint/`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean`
- `lake build`

## Notes

- Existing repository warnings remain outside the touched files.
- The known paper-realignment sorries in `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean` are unchanged and remain tracked by #1607/#1563.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a proof-only refactor that factors an existing argument into a named lemma and updates downstream proofs/docs to use it, without changing computational behavior.
> 
> **Overview**
> Adds a new Lean lemma `exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT` that extracts an eventual nonzero scalar sequence from eventual proportionality of one-copy BNT weighted state sums and proves the *leading-weight adjusted* scalar has norm tending to `1`.
> 
> Refactors the dominant projection contradiction proof to consume this lemma instead of re-deriving the scalar and norm-limit setup inline, and updates the blueprint with a corresponding formally-linked lemma statement and CPSV16 citation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b60e083302df70819f4d349fc51dc734589c07cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->