### PR TITLE
doc(MPS/FT): mark residual LI peeling conditional

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -233,11 +233,11 @@ lemma nonzeroProportionalMPV₂_toTensorFromBlocks_of_weighted_mpvState_eq_smul_
 
 /-- **Eventual proportionality from an eventual weighted MPV-state scalar sequence.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After a finite
-number of leading BNT components has been removed, Lemma `Lem1` supplies
-linear independence only for sufficiently large lengths. This bookkeeping lemma
-turns an eventual weighted MPV-state identity into eventual nonzero
-proportionality of the assembled tail tensors. -/
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. At recursive
+stages in the block-deletion argument the available weighted MPV-state identity
+may hold only for sufficiently large lengths. This bookkeeping lemma turns such
+an eventual weighted identity into eventual nonzero proportionality of the
+assembled tail tensors. -/
 lemma eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weighted_mpvState
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -290,13 +290,18 @@ lemma eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weigh
 
 /-- **Selected coefficient extraction from an eventual two-family relation.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
-`Lem1`. Once the selected block on one side has been rewritten as a phase
-multiple of the selected block on the other side, Lemma `Lem1` supplies
-eventual linear independence for the remaining two-family list. This lemma is
-the coefficient bookkeeping for that step: equality of the two finite linear
-combinations forces the coefficient of the selected vector to agree
-eventually. -/
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1181--1183. This
+lemma is conditional algebra: once the selected block on one side has been
+rewritten as a phase multiple of the selected block on the other side, an
+explicit eventual linear-independence hypothesis for the displayed two-family
+list lets one compare the selected coefficient.
+
+**Scope restriction (explicit residual-family independence):** In the
+fixed-block step of CPSV16 Theorem `thm1`, Lemma `Lem1` supplies linear
+independence for the family made from all blocks on one side together with one
+fixed block on the other side; it does not directly supply the residual
+two-family hypothesis appearing here. The missing source-faithful isolation
+argument is recorded in `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
 lemma eventually_selected_coefficient_eq_of_eventually_linearIndependent_sum
     {ι κ : Type*} [Fintype ι] [Fintype κ]
     {E : ℕ → Type*} [∀ N, AddCommGroup (E N)] [∀ N, Module ℂ (E N)]
@@ -359,10 +364,15 @@ lemma eventually_selected_weighted_mpvState_eq_smul_of_phase_and_coeff
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. After a non-decaying block pair has supplied the phase relation for
-the selected block, Lemma `Lem1` gives eventual linear independence of the
-family obtained by replacing that selected block by its phase-matched partner.
-The total weighted-state relation then identifies the selected coefficient,
-and hence the selected weighted summand. -/
+the selected block, this conditional helper uses an explicit eventual
+linear-independence hypothesis for the displayed residual family. The total
+weighted-state relation then identifies the selected coefficient, and hence the
+selected weighted summand.
+
+**Scope restriction (explicit residual-family independence):** In the
+fixed-block step of CPSV16 Theorem `thm1`, lines 1181--1185, Lemma `Lem1`
+does not by itself supply the residual-family independence assumed here. See
+`docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
 lemma eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li
     {d : ℕ} {ι κ : Type*} [Fintype ι] [Fintype κ]
     {dimA : ι → ℕ} {dimB₀ : ℕ} {dimB : κ → ℕ}
@@ -668,7 +678,7 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
       (fun k : Fin nB => B (b0.succAbove k))
       c hc hTailReindex
 
-/-- **Tail proportionality from phase substitution and a Lemma `Lem1` input.**
+/-- **Tail proportionality from phase substitution and a linear-independence hypothesis.**
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. Once a selected non-decaying block pair has been converted into a

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -551,7 +551,7 @@ lemma weighted_mpvState_sum_erase_eq_sum_succAbove
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After a leading
 matched BNT component has been removed, the remaining components are reindexed
-and the argument is repeated. This lemma packages that bookkeeping in eventual
+and the argument is repeated. This lemma records that bookkeeping in eventual
 form: an eventual total weighted-state identity, together with an eventual
 selected-summand identity for the leading components, gives eventual nonzero
 proportionality of the two reindexed tail tensors. -/
@@ -615,7 +615,7 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succ_of_total_and_selected
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The
 source proof permits a permutation of BNT blocks: after a block pair has been
 matched and its weighted summands have been identified, one removes that pair
-and repeats the argument on the two complements. This lemma packages only the
+and repeats the argument on the two complements. This lemma records only the
 finite reindexing and eventual-proportionality bookkeeping for that step. -/
 lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
     {d nA nB : ℕ}
@@ -672,15 +672,19 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. Once a selected non-decaying block pair has been converted into a
-phase relation, Lemma `Lem1` gives eventual linear independence for the family
-obtained by replacing the selected block by its phase-matched partner. This
-lemma packages the resulting coefficient extraction, selected-summand
-subtraction, and arbitrary-tail reindexing.
+phase relation, this conditional helper records the coefficient extraction,
+selected-summand subtraction, and arbitrary-tail reindexing under an explicit
+eventual linear-independence hypothesis for the displayed residual family.
 
-The assumption is that the displayed combined MPV family is linearly independent
-for all sufficiently large lengths. In the proof of Theorem `thm1` this
-assumption is supplied by the fixed-block application of Lemma `Lem1` at the
-current peeling step. -/
+**Scope restriction (explicit residual-family independence):** CPSV16 Lemma
+`Lem1` gives this kind of independence only for the family in which all
+off-diagonal overlaps tend to zero. In the fixed-block step of Theorem `thm1`,
+lines 1181--1185, the local application gives independence for all blocks on
+one side together with one fixed block on the other side, not for the whole
+remaining tail appearing in this lemma. This conditional helper must therefore
+not be used as the source-faithful discharge of fixed-block cancellation unless
+that residual-family independence has first been proved in the current
+argument. See `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
 lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li
     {d nA nB : ℕ}
     {dimA : Fin (nA + 1) → ℕ} {dimB : Fin (nB + 1) → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -364,7 +364,7 @@ lemma eventually_selected_weighted_mpvState_eq_smul_of_phase_and_coeff
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. After a non-decaying block pair has supplied the phase relation for
-the selected block, this conditional helper uses an explicit eventual
+the selected block, this auxiliary lemma uses an explicit eventual
 linear-independence hypothesis for the displayed residual family. The total
 weighted-state relation then identifies the selected coefficient, and hence the
 selected weighted summand.
@@ -682,7 +682,7 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
 
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. Once a selected non-decaying block pair has been converted into a
-phase relation, this conditional helper records the coefficient extraction,
+phase relation, this auxiliary lemma records the coefficient extraction,
 selected-summand subtraction, and arbitrary-tail reindexing under an explicit
 eventual linear-independence hypothesis for the displayed residual family.
 
@@ -691,7 +691,7 @@ eventual linear-independence hypothesis for the displayed residual family.
 off-diagonal overlaps tend to zero. In the fixed-block step of Theorem `thm1`,
 lines 1181--1185, the local application gives independence for all blocks on
 one side together with one fixed block on the other side, not for the whole
-remaining tail appearing in this lemma. This conditional helper must therefore
+remaining tail appearing in this lemma. This auxiliary lemma must therefore
 not be used as the source-faithful discharge of fixed-block cancellation unless
 that residual-family independence has first been proved in the current
 argument. See `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean
@@ -30,15 +30,20 @@ section ProportionalExpansionLeft
 Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 `Lem1`. This is the symmetric bookkeeping form of
 `eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li`: the
-eventual linear-independence input is taken for the family consisting of all
-`B`-blocks together with the remaining `A`-blocks. The phase is assumed
-nonzero so that the selected `A`-summand can be rewritten in terms of the
-selected `B`-summand before coefficient extraction.
+eventual linear-independence input is taken explicitly for the family
+consisting of all `B`-blocks together with the remaining `A`-blocks. The phase
+is assumed nonzero so that the selected `A`-summand can be rewritten in terms
+of the selected `B`-summand before coefficient extraction.
 
-The assumption is that the displayed combined MPV family is linearly independent
-for all sufficiently large lengths. In the proof of Theorem `thm1` this
-assumption is supplied by the fixed-block application of Lemma `Lem1` at the
-current peeling step. -/
+**Scope restriction (explicit residual-family independence):** CPSV16 Lemma
+`Lem1` gives this kind of independence only for the family in which all
+off-diagonal overlaps tend to zero. In the fixed-block step of Theorem `thm1`,
+lines 1181--1185, the local application gives independence for all blocks on
+one side together with one fixed block on the other side, not for the whole
+remaining tail appearing in this lemma. This conditional helper must therefore
+not be used as the source-faithful discharge of fixed-block cancellation unless
+that residual-family independence has first been proved in the current
+argument. See `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
 lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li_left
     {d nA nB : ℕ}
     {dimA : Fin (nA + 1) → ℕ} {dimB : Fin (nB + 1) → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean
@@ -40,7 +40,7 @@ of the selected `B`-summand before coefficient extraction.
 off-diagonal overlaps tend to zero. In the fixed-block step of Theorem `thm1`,
 lines 1181--1185, the local application gives independence for all blocks on
 one side together with one fixed block on the other side, not for the whole
-remaining tail appearing in this lemma. This conditional helper must therefore
+remaining tail appearing in this lemma. This auxiliary lemma must therefore
 not be used as the source-faithful discharge of fixed-block cancellation unless
 that residual-family independence has first been proved in the current
 argument. See `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -187,7 +187,7 @@ with an extra $Z$-gauge degree of freedom.
 	\((\mu_B\zeta)^N=\mu_B^N\zeta^N\).
 \end{proof}
 
-\begin{lemma}[Selected weighted summand from phase substitution and Lemma Lem1]%
+\begin{lemma}[Selected weighted summand from phase substitution and a linear-independence hypothesis]%
 \label{lem:selected_weighted_summand_from_phase_sum_li}
 	\lean{MPSTensor.eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li}
 	\leanok
@@ -210,12 +210,12 @@ with an extra $Z$-gauge degree of freedom.
 		c_N\nu_0^N\ket{V^{(N)}(B_0)}
 	\]
 	for all sufficiently large \(N\).
-	This corresponds to the step in the proof of
-	\cite[Theorem~II.1, lines~1181--1183]{Cirac2016MPDO_arXiv} where
-	\cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} rules out the
-	vanishing-overlap alternative and
-	\cite[Corollary~\texttt{eqV}]{Cirac2016MPDO_arXiv} supplies the phase
-	relation for the selected block.
+	This is a conditional coefficient-extraction statement.  In the fixed-block
+	step, \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} does not by itself
+	supply the displayed residual-family linear independence; the gap is
+	recorded in
+	\texttt{docs/paper-gaps/cpsv16\_fixed\_block\_cancellation.tex}.
+	\cite[Theorem~II.1, lines~1181--1183]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -257,10 +257,9 @@ with an extra $Z$-gauge degree of freedom.
 	If two weighted block-state sums are eventually related by a scalar sequence
 	\(c_N\), and selected summands are eventually related by the same scalar
 	sequence, then the erased tails are eventually related by \(c_N\).
-	This is the eventual form of the preceding deletion step in the proof of
-	\cite[Theorem~II.1, lines~1181--1185]{Cirac2016MPDO_arXiv}, used after
-	\cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} supplies linear
-	independence only for sufficiently large lengths.
+	This is the eventual form of the preceding deletion step, used at the
+	sufficiently-large-length stage of
+	\cite[Theorem~II.1, lines~1181--1185]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -360,7 +359,7 @@ with an extra $Z$-gauge degree of freedom.
 % only the family whose off-diagonal overlaps all tend to zero; for the
 % fixed-block step this is all blocks on one side together with one fixed block
 % on the other side, not the whole remaining tail.
-\begin{lemma}[Eventual tail proportionality from phase substitution and an LI hypothesis]%
+\begin{lemma}[Eventual tail proportionality from phase substitution and a linear-independence hypothesis]%
 \label{lem:eventual_tail_proportional_from_phase_sum_li}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li}
 	\leanok

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -187,6 +187,9 @@ with an extra $Z$-gauge degree of freedom.
 	\((\mu_B\zeta)^N=\mu_B^N\zeta^N\).
 \end{proof}
 
+% Proof-boundary note: the residual-family linear-independence hypothesis below
+% is not supplied by the fixed-block application of Lemma Lem1 in Theorem II.1.
+% See docs/paper-gaps/cpsv16_fixed_block_cancellation.tex.
 \begin{lemma}[Selected weighted summand from phase substitution and a linear-independence hypothesis]%
 \label{lem:selected_weighted_summand_from_phase_sum_li}
 	\lean{MPSTensor.eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li}
@@ -212,9 +215,7 @@ with an extra $Z$-gauge degree of freedom.
 	for all sufficiently large \(N\).
 	This is a conditional coefficient-extraction statement.  In the fixed-block
 	step, \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} does not by itself
-	supply the displayed residual-family linear independence; the gap is
-	recorded in
-	\texttt{docs/paper-gaps/cpsv16\_fixed\_block\_cancellation.tex}.
+	supply the displayed residual-family linear independence
 	\cite[Theorem~II.1, lines~1181--1183]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
@@ -359,6 +360,7 @@ with an extra $Z$-gauge degree of freedom.
 % only the family whose off-diagonal overlaps all tend to zero; for the
 % fixed-block step this is all blocks on one side together with one fixed block
 % on the other side, not the whole remaining tail.
+% See docs/paper-gaps/cpsv16_fixed_block_cancellation.tex.
 \begin{lemma}[Eventual tail proportionality from phase substitution and a linear-independence hypothesis]%
 \label{lem:eventual_tail_proportional_from_phase_sum_li}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li}
@@ -372,10 +374,9 @@ with an extra $Z$-gauge degree of freedom.
 	$B$-blocks is eventually linearly independent, then the two complements,
 	reindexed by the insertion maps, are eventually nonzero proportional.
 	This is a conditional algebraic peeling statement.  The displayed
-	residual-family independence is not supplied by the fixed-block application
-	of \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv}; the remaining
-	source-faithful cancellation step is documented in
-	\texttt{docs/paper-gaps/cpsv16\_fixed\_block\_cancellation.tex}.
+	residual-family independence is not supplied by the fixed-block step; in
+	that step \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} is applied only
+	to the fixed-block family
 	\cite[Theorem~II.1, lines~1181--1185]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
@@ -392,6 +393,7 @@ with an extra $Z$-gauge degree of freedom.
 % only the family whose off-diagonal overlaps all tend to zero; for the
 % fixed-block step this is all blocks on one side together with one fixed block
 % on the other side, not the whole remaining tail.
+% See docs/paper-gaps/cpsv16_fixed_block_cancellation.tex.
 \begin{lemma}[Eventual tail proportionality from the left substituted family]%
 \label{lem:eventual_tail_proportional_from_phase_sum_li_left}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li_left}
@@ -407,9 +409,7 @@ with an extra $Z$-gauge degree of freedom.
 	proportional.
 	This is the same conditional algebraic peeling statement with the linearly
 	independent family ordered as all $B$-blocks together with the remaining
-	$A$-blocks.  The fixed-block source gap is documented in
-	\texttt{docs/paper-gaps/cpsv16\_fixed\_block\_cancellation.tex}.
-	\cite[Theorem~II.1, lines~1181--1185]{Cirac2016MPDO_arXiv}.
+	$A$-blocks \cite[Theorem~II.1, lines~1181--1185]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -355,11 +355,12 @@ with an extra $Z$-gauge degree of freedom.
 \end{proof}
 
 % Proof-boundary note: the assumption that the displayed combined MPV family is
-% linearly independent for all sufficiently large N is not a global consequence
-% of the BNT hypotheses for arbitrary remaining blocks. In the proof of
-% Theorem II.1 it must be supplied by the fixed-block application of
-% \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} at the current peeling step.
-\begin{lemma}[Eventual tail proportionality from phase substitution and Lemma Lem1]%
+% linearly independent for all sufficiently large N is not supplied by the
+% fixed-block application of Lemma Lem1 in Theorem II.1.  Lemma Lem1 supplies
+% only the family whose off-diagonal overlaps all tend to zero; for the
+% fixed-block step this is all blocks on one side together with one fixed block
+% on the other side, not the whole remaining tail.
+\begin{lemma}[Eventual tail proportionality from phase substitution and an LI hypothesis]%
 \label{lem:eventual_tail_proportional_from_phase_sum_li}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li}
 	\leanok
@@ -367,13 +368,15 @@ with an extra $Z$-gauge degree of freedom.
 		lem:eventual_proportional_weighted_tail_succAbove_package}
 	Suppose the total weighted state sums are eventually related by a nonzero
 	scalar sequence.  If a selected pair satisfies
-	\(\ket{V^{(N)}(B_{b_0})}=\zeta^N\ket{V^{(N)}(A_{a_0})}\) for every \(N\),
-	and the family consisting of all \(A\)-blocks together with the remaining
-	\(B\)-blocks is eventually linearly independent, then the two complements,
+	$\ket{V^{(N)}(B_{b_0})}=\zeta^N\ket{V^{(N)}(A_{a_0})}$ for every $N$,
+	and the family consisting of all $A$-blocks together with the remaining
+	$B$-blocks is eventually linearly independent, then the two complements,
 	reindexed by the insertion maps, are eventually nonzero proportional.
-	This combines \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} and
-	\cite[Corollary~\texttt{eqV}]{Cirac2016MPDO_arXiv} at the recursive
-	peeling point of
+	This is a conditional algebraic peeling statement.  The displayed
+	residual-family independence is not supplied by the fixed-block application
+	of \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv}; the remaining
+	source-faithful cancellation step is documented in
+	\texttt{docs/paper-gaps/cpsv16\_fixed\_block\_cancellation.tex}.
 	\cite[Theorem~II.1, lines~1181--1185]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
@@ -385,10 +388,11 @@ with an extra $Z$-gauge degree of freedom.
 \end{proof}
 
 % Proof-boundary note: the assumption that the displayed combined MPV family is
-% linearly independent for all sufficiently large N is not a global consequence
-% of the BNT hypotheses for arbitrary remaining blocks. In the proof of
-% Theorem II.1 it must be supplied by the fixed-block application of
-% \cite[Lemma~\texttt{Lem1}]{Cirac2016MPDO_arXiv} at the current peeling step.
+% linearly independent for all sufficiently large N is not supplied by the
+% fixed-block application of Lemma Lem1 in Theorem II.1.  Lemma Lem1 supplies
+% only the family whose off-diagonal overlaps all tend to zero; for the
+% fixed-block step this is all blocks on one side together with one fixed block
+% on the other side, not the whole remaining tail.
 \begin{lemma}[Eventual tail proportionality from the left substituted family]%
 \label{lem:eventual_tail_proportional_from_phase_sum_li_left}
 	\lean{MPSTensor.eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li_left}
@@ -397,14 +401,15 @@ with an extra $Z$-gauge degree of freedom.
 		lem:eventual_proportional_weighted_tail_succAbove_package}
 	Suppose the total weighted state sums are eventually related by a nonzero
 	scalar sequence, and suppose
-	\(\ket{V^{(N)}(B_{b_0})}=\zeta^N\ket{V^{(N)}(A_{a_0})}\) for every \(N\),
-	with \(\zeta\ne 0\).  If the family consisting of all \(B\)-blocks together
-	with the remaining \(A\)-blocks is eventually linearly independent, then the
+	$\ket{V^{(N)}(B_{b_0})}=\zeta^N\ket{V^{(N)}(A_{a_0})}$ for every $N$,
+	with $\zeta\ne 0$.  If the family consisting of all $B$-blocks together
+	with the remaining $A$-blocks is eventually linearly independent, then the
 	two complements, reindexed by the insertion maps, are eventually nonzero
 	proportional.
-	This is the same recursive peeling step with the linearly independent
-	family ordered as all \(B\)-blocks together with the remaining
-	\(A\)-blocks; it is used for the symmetric half of
+	This is the same conditional algebraic peeling statement with the linearly
+	independent family ordered as all $B$-blocks together with the remaining
+	$A$-blocks.  The fixed-block source gap is documented in
+	\texttt{docs/paper-gaps/cpsv16\_fixed\_block\_cancellation.tex}.
 	\cite[Theorem~II.1, lines~1181--1185]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -82,7 +82,7 @@ proportional BNT families:
 \end{aligned}
 \]
 
-There are also conditional tail-peeling helpers:
+There are also conditional tail-peeling auxiliary lemmas:
 \[
 \begin{aligned}
 &\leanid{MPSTensor.eventually\_selected\_weighted\_mpvState\_eq\_smul\_of\_phase\_sum\_and\_li},\\
@@ -92,13 +92,13 @@ There are also conditional tail-peeling helpers:
 \]
 These are correct algebraic statements, but their linear-independence
 hypotheses are stronger than the fixed-block application of
-Lemma~\texttt{Lem1}.  The right-handed helper assumes eventual linear
+Lemma~\texttt{Lem1}.  The right-handed auxiliary lemma assumes eventual linear
 independence of all \(A\)-blocks together with the whole remaining \(B\)-tail;
-the left-handed helper assumes the symmetric condition.  In contrast, the
-source sentence at line 1182 supplies only the family consisting of all blocks
-on one side together with the single fixed block on the other side.  These
-helpers are therefore conditional local tools, not formalizations of the
-fixed-block cancellation step.
+the left-handed auxiliary lemma assumes the symmetric condition.  In contrast,
+the source sentence at line 1182 supplies only the family consisting of all
+blocks on one side together with the single fixed block on the other side.
+These auxiliary lemmas are therefore conditional local tools, not
+formalizations of the fixed-block cancellation step.
 
 \section{Elimination plan}
 

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -85,6 +85,7 @@ proportional BNT families:
 There are also conditional tail-peeling helpers:
 \[
 \begin{aligned}
+&\leanid{MPSTensor.eventually\_selected\_weighted\_mpvState\_eq\_smul\_of\_phase\_sum\_and\_li},\\
 &\leanid{MPSTensor.eventuallyNonzeroProportionalMPV₂\_tail\_succAbove\_of\_phase\_sum\_li},\\
 &\leanid{MPSTensor.eventuallyNonzeroProportionalMPV₂\_tail\_succAbove\_of\_phase\_sum\_li\_left}.
 \end{aligned}

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -4,7 +4,7 @@
 \usepackage{xurl}
 \usepackage[hidelinks]{hyperref}
 
-\input{command}
+\input{./command}
 
 \title{The Fixed-Block Cancellation Step in CPSV16 Theorem II.1}
 \author{}
@@ -81,6 +81,23 @@ proportional BNT families:
 &\leanid{MPSTensor.fixed\_left\_leading\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}.
 \end{aligned}
 \]
+
+There are also conditional tail-peeling helpers:
+\[
+\begin{aligned}
+&\leanid{MPSTensor.eventuallyNonzeroProportionalMPV₂\_tail\_succAbove\_of\_phase\_sum\_li},\\
+&\leanid{MPSTensor.eventuallyNonzeroProportionalMPV₂\_tail\_succAbove\_of\_phase\_sum\_li\_left}.
+\end{aligned}
+\]
+These are correct algebraic statements, but their linear-independence
+hypotheses are stronger than the fixed-block application of
+Lemma~\texttt{Lem1}.  The right-handed helper assumes eventual linear
+independence of all \(A\)-blocks together with the whole remaining \(B\)-tail;
+the left-handed helper assumes the symmetric condition.  In contrast, the
+source sentence at line 1182 supplies only the family consisting of all blocks
+on one side together with the single fixed block on the other side.  These
+helpers are therefore conditional local tools, not formalizations of the
+fixed-block cancellation step.
 
 \section{Elimination plan}
 


### PR DESCRIPTION
## Summary

- mark the `phase_sum_li` tail-peeling helpers as conditional on an explicit residual-family linear-independence hypothesis
- update the blueprint entries so they no longer say fixed-block Lemma `Lem1` supplies that residual-tail independence
- extend `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex` to record why these helpers are not the source-faithful discharge of fixed-block cancellation
- make the paper-gap note input its local `command.tex`, then rebuild `docs/paper-gaps/cpsv16_fixed_block_cancellation.pdf`

This advances #1607/#1612 by pruning a wrong hypothesis branch: the global residual-tail LI helper remains available as conditional algebra, but it is no longer presented as what CPSV16 line 1182 gives.

## Source

- CPSV16, `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1122--1132 and 1181--1185.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean`
- `leanblueprint checkdecls` from `blueprint/`
- `pdflatex -interaction=nonstopmode cpsv16_fixed_block_cancellation.tex` from `docs/paper-gaps/`
- `git diff --check`
- touched-file scan for long Lean lines
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansionLeft.lean`
- `lake build`

## Notes

- No Lean theorem statement changes.
- No new `sorry` or `axiom`.
- The two known paper-realignment sorries in `NondecayingOverlap.lean` remain the open fixed-block cancellation obligations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/comment-only updates in Lean and LaTeX, clarifying assumptions and adding a paper-gap note without modifying theorem statements or proofs.
> 
> **Overview**
> Clarifies that the `phase_sum_li` tail-peeling helper lemmas (and related coefficient-extraction step) are **conditional** on an explicit *residual-family* eventual linear-independence hypothesis, and that this hypothesis is **not** what CPSV16’s fixed-block use of Lemma `Lem1` directly provides.
> 
> Updates the Lean docstrings and blueprint narrative to reflect this scope restriction, and expands `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex` (including fixing its `command.tex` include path) to document the missing source-faithful cancellation/isolation argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99479fa7181cac20d5a4e3c128474c595b060033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->