### PR TITLE
doc(MPS/CanonicalForm): mark primitive reductions scoped

### DIFF
--- a/TNLean/MPS/CanonicalForm/FromPeripheralPrimitive.lean
+++ b/TNLean/MPS/CanonicalForm/FromPeripheralPrimitive.lean
@@ -25,13 +25,13 @@ The proof first applies `hasPrimitiveFixedPoint_of_peripheralPrimitive`, and the
 injectivity, normalization, weight ordering, and nonzero-weight hypotheses are assumed.
 
 Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
-Theorem `Th:TIcanonical`, lines 742--763, starts from an arbitrary
+Theorem Th:TIcanonical, lines 742--763, starts from an arbitrary
 translation-invariant MPS representation.
 
 **Scope restriction (peripheral-primitive block hypotheses):** this theorem assumes
 injectivity, strict ordering of the weight moduli, nonzero weights, and peripheral-spectrum
 primitivity for every block. Those hypotheses are not assumptions of PGVWC07
-Theorem `Th:TIcanonical`. See
+Theorem Th:TIcanonical. See
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem isCanonicalForm_of_peripheralPrimitive
     {d : ℕ} {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/CanonicalForm/FromPeripheralPrimitive.lean
+++ b/TNLean/MPS/CanonicalForm/FromPeripheralPrimitive.lean
@@ -20,9 +20,9 @@ namespace MPSTensor
 
 /-- Build `IsCanonicalForm` from peripheral-spectrum primitivity of each block transfer map.
 
-The proof first applies `hasPrimitiveFixedPoint_of_peripheralPrimitive`, and then
-`isCanonicalForm_of_primitive`. As in the primitive fixed-point theorem, the blockwise
-injectivity, normalization, weight ordering, and nonzero-weight hypotheses are assumed.
+For a finite family of blocks with injective Kraus span, left-canonical normalization,
+strictly ordered nonzero weights, positive bond dimensions, and primitive peripheral spectrum,
+the weighted family satisfies `IsCanonicalForm`.
 
 Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
 Theorem Th:TIcanonical, lines 742--763, starts from an arbitrary
@@ -30,8 +30,7 @@ translation-invariant MPS representation.
 
 **Scope restriction (peripheral-primitive block hypotheses):** this theorem assumes
 injectivity, strict ordering of the weight moduli, nonzero weights, and peripheral-spectrum
-primitivity for every block. Those hypotheses are not assumptions of PGVWC07
-the source theorem. See
+primitivity for every block. Those hypotheses are not assumptions of the source theorem. See
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem isCanonicalForm_of_peripheralPrimitive
     {d : ℕ} {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/CanonicalForm/FromPeripheralPrimitive.lean
+++ b/TNLean/MPS/CanonicalForm/FromPeripheralPrimitive.lean
@@ -31,7 +31,7 @@ translation-invariant MPS representation.
 **Scope restriction (peripheral-primitive block hypotheses):** this theorem assumes
 injectivity, strict ordering of the weight moduli, nonzero weights, and peripheral-spectrum
 primitivity for every block. Those hypotheses are not assumptions of PGVWC07
-Theorem Th:TIcanonical. See
+the source theorem. See
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem isCanonicalForm_of_peripheralPrimitive
     {d : ℕ} {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/CanonicalForm/FromPeripheralPrimitive.lean
+++ b/TNLean/MPS/CanonicalForm/FromPeripheralPrimitive.lean
@@ -21,8 +21,18 @@ namespace MPSTensor
 /-- Build `IsCanonicalForm` from peripheral-spectrum primitivity of each block transfer map.
 
 The proof first applies `hasPrimitiveFixedPoint_of_peripheralPrimitive`, and then
-`isCanonicalForm_of_primitive`. As in the primitive-builder file, all blockwise injectivity /
-normalization / ordering data are assumed as inputs. -/
+`isCanonicalForm_of_primitive`. As in the primitive fixed-point theorem, the blockwise
+injectivity, normalization, weight ordering, and nonzero-weight hypotheses are assumed.
+
+Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
+Theorem `Th:TIcanonical`, lines 742--763, starts from an arbitrary
+translation-invariant MPS representation.
+
+**Scope restriction (peripheral-primitive block hypotheses):** this theorem assumes
+injectivity, strict ordering of the weight moduli, nonzero weights, and peripheral-spectrum
+primitivity for every block. Those hypotheses are not assumptions of PGVWC07
+Theorem `Th:TIcanonical`. See
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem isCanonicalForm_of_peripheralPrimitive
     {d : ℕ} {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}

--- a/TNLean/MPS/CanonicalForm/FromPrimitive.lean
+++ b/TNLean/MPS/CanonicalForm/FromPrimitive.lean
@@ -20,8 +20,18 @@ namespace MPSTensor
 /-- Build `IsCanonicalForm` once the normalized self-overlap hypothesis has been derived from
 blockwise primitivity.
 
-This is a late-stage builder theorem: all blockwise injectivity / normalization / ordering data are
-assumed as inputs. -/
+This theorem proves the final implication after the blockwise injectivity, normalization, weight
+ordering, and primitivity hypotheses have already been established.
+
+Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
+Theorem `Th:TIcanonical`, lines 742--763, starts from an arbitrary
+translation-invariant MPS representation.
+
+**Scope restriction (primitive block hypotheses):** this theorem assumes
+injectivity, strict ordering of the weight moduli, nonzero weights, and a primitive fixed point
+for every block. Those hypotheses are not assumptions of PGVWC07
+Theorem `Th:TIcanonical`. See
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem isCanonicalForm_of_primitive
     {d : ℕ} {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}

--- a/TNLean/MPS/CanonicalForm/FromPrimitive.lean
+++ b/TNLean/MPS/CanonicalForm/FromPrimitive.lean
@@ -20,8 +20,9 @@ namespace MPSTensor
 /-- Build `IsCanonicalForm` once the normalized self-overlap hypothesis has been derived from
 blockwise primitivity.
 
-This theorem proves the final implication after the blockwise injectivity, normalization, weight
-ordering, and primitivity hypotheses have already been established.
+For a finite family of primitive blocks with injective Kraus span, left-canonical
+normalization, strictly ordered nonzero weights, and positive bond dimensions, the weighted
+family satisfies `IsCanonicalForm`.
 
 Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
 Theorem Th:TIcanonical, lines 742--763, starts from an arbitrary
@@ -29,8 +30,7 @@ translation-invariant MPS representation.
 
 **Scope restriction (primitive block hypotheses):** this theorem assumes
 injectivity, strict ordering of the weight moduli, nonzero weights, and a primitive fixed point
-for every block. Those hypotheses are not assumptions of PGVWC07
-the source theorem. See
+for every block. Those hypotheses are not assumptions of the source theorem. See
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem isCanonicalForm_of_primitive
     {d : ℕ} {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/CanonicalForm/FromPrimitive.lean
+++ b/TNLean/MPS/CanonicalForm/FromPrimitive.lean
@@ -24,13 +24,13 @@ This theorem proves the final implication after the blockwise injectivity, norma
 ordering, and primitivity hypotheses have already been established.
 
 Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
-Theorem `Th:TIcanonical`, lines 742--763, starts from an arbitrary
+Theorem Th:TIcanonical, lines 742--763, starts from an arbitrary
 translation-invariant MPS representation.
 
 **Scope restriction (primitive block hypotheses):** this theorem assumes
 injectivity, strict ordering of the weight moduli, nonzero weights, and a primitive fixed point
 for every block. Those hypotheses are not assumptions of PGVWC07
-Theorem `Th:TIcanonical`. See
+Theorem Th:TIcanonical. See
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem isCanonicalForm_of_primitive
     {d : ℕ} {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/CanonicalForm/FromPrimitive.lean
+++ b/TNLean/MPS/CanonicalForm/FromPrimitive.lean
@@ -30,7 +30,7 @@ translation-invariant MPS representation.
 **Scope restriction (primitive block hypotheses):** this theorem assumes
 injectivity, strict ordering of the weight moduli, nonzero weights, and a primitive fixed point
 for every block. Those hypotheses are not assumptions of PGVWC07
-Theorem Th:TIcanonical. See
+the source theorem. See
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem isCanonicalForm_of_primitive
     {d : ℕ} {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
@@ -301,7 +301,7 @@ translation-invariant MPS representation.
 **Scope restriction (prepared primitive block decomposition):** this theorem assumes an existing
 weighted block decomposition, irreducibility, trace-preserving normalization, primitivity,
 pairwise distinct weight moduli, nonzero weights, and positive bond dimensions. Those hypotheses
-are not assumptions of PGVWC07 Theorem Th:TIcanonical. See
+are not assumptions of the source theorem. See
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_normalCanonicalForm_of_primitive_blockDecomp
     (A : MPSTensor d D)

--- a/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
@@ -295,13 +295,13 @@ Conclusion: after a common blocking (currently `p = 1`) and reordering by decrea
 `IsNormalCanonicalForm`.
 
 Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
-Theorem `Th:TIcanonical`, lines 742--763, starts from an arbitrary
+Theorem Th:TIcanonical, lines 742--763, starts from an arbitrary
 translation-invariant MPS representation.
 
 **Scope restriction (prepared primitive block decomposition):** this theorem assumes an existing
 weighted block decomposition, irreducibility, trace-preserving normalization, primitivity,
 pairwise distinct weight moduli, nonzero weights, and positive bond dimensions. Those hypotheses
-are not assumptions of PGVWC07 Theorem `Th:TIcanonical`. See
+are not assumptions of PGVWC07 Theorem Th:TIcanonical. See
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_normalCanonicalForm_of_primitive_blockDecomp
     (A : MPSTensor d D)

--- a/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
@@ -292,7 +292,17 @@ Hypotheses:
 
 Conclusion: after a common blocking (currently `p = 1`) and reordering by decreasing weight norm,
 `blockTensor A p` is `SameMPV₂`-equivalent to a weighted block family in
-`IsNormalCanonicalForm`. -/
+`IsNormalCanonicalForm`.
+
+Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
+Theorem `Th:TIcanonical`, lines 742--763, starts from an arbitrary
+translation-invariant MPS representation.
+
+**Scope restriction (prepared primitive block decomposition):** this theorem assumes an existing
+weighted block decomposition, irreducibility, trace-preserving normalization, primitivity,
+pairwise distinct weight moduli, nonzero weights, and positive bond dimensions. Those hypotheses
+are not assumptions of PGVWC07 Theorem `Th:TIcanonical`. See
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_normalCanonicalForm_of_primitive_blockDecomp
     (A : MPSTensor d D)
     {r1 : ℕ} {dim1 : Fin r1 → ℕ}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -11,8 +11,8 @@ Thus the normal-canonical reductions recorded here are conditional
 primitive-block results. They should not be read as the full
 translation-invariant canonical-form theorem of
 \cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
-The normalization convention is also dual to the one used there:
-in PGVWC07 the blocks are written in the unital orientation
+The normalization convention is also dual to the one used in the cited theorem:
+the blocks are written in the unital orientation
 $\sum_i A_k^i(A_k^i)^\dagger=\Id$ for
 $\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$
 \cite[Theorem~\texttt{Th:TIcanonical}, lines~754--758]{PerezGarcia2007Matrix},

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -552,11 +552,11 @@ per-block peripheral-spectrum primitivity.
 		\item each block admits a primitive fixed point.
 	\end{enumerate}
 	Then $(\mu_k, A_k)$ satisfies the canonical form conditions.
-	This is a conditional primitive-block consequence; it is not the full
-	translation-invariant canonical-form existence theorem, whose hypotheses
-	start from an arbitrary translation-invariant representation
-	\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
 \end{theorem}
+% Scope restriction (primitive block hypotheses): not the full PGVWC07
+% Theorem Th:TIcanonical (lines 742--763), which starts from an arbitrary
+% translation-invariant MPS representation. See
+% docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
 
 \begin{proof}\leanok
 	\uses{thm:primitive_overlap}
@@ -584,11 +584,11 @@ per-block peripheral-spectrum primitivity.
 	\end{enumerate}
 	Then $(\mu_k, A_k)$ satisfies the canonical form
 	conditions (Definition~\ref{def:is_canonical_form}).
-	This is a conditional peripheral-primitive consequence; it is not the full
-	translation-invariant canonical-form existence theorem, whose hypotheses
-	start from an arbitrary translation-invariant representation
-	\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
 \end{theorem}
+% Scope restriction (peripheral-primitive block hypotheses): not the full
+% PGVWC07 Theorem Th:TIcanonical (lines 742--763), which starts from an
+% arbitrary translation-invariant MPS representation. See
+% docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
 
 \begin{proof}
 	\leanok
@@ -987,12 +987,11 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
 		tensors $(B_k)$ such that $A^{[p]}$ generates the same MPV family as
 		$\bigoplus_k \nu_k B_k$, and $(\nu_k, B_k)$ satisfies the normal canonical
 		form conditions.
-		This is a conditional result from a primitive block decomposition
-		satisfying the listed hypotheses; it is not the full
-		translation-invariant canonical-form existence theorem, whose
-		hypotheses start from an arbitrary translation-invariant representation
-		\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
 \end{theorem}
+% Scope restriction (prepared primitive block decomposition): not the
+% full PGVWC07 Theorem Th:TIcanonical (lines 742--763), which starts from
+% an arbitrary translation-invariant MPS representation. See
+% docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
 
 \begin{proof}\leanok
 		\uses{def:is_normal_canonical_form}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -12,7 +12,7 @@ primitive-block results. They should not be read as the full
 translation-invariant canonical-form theorem of
 \cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
 The normalization convention is also dual to the one used there:
-PGVWC07 writes the blocks in the unital orientation
+in PGVWC07 the blocks are written in the unital orientation
 $\sum_i A_k^i(A_k^i)^\dagger=\Id$ for
 $\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$
 \cite[Theorem~\texttt{Th:TIcanonical}, lines~754--758]{PerezGarcia2007Matrix},

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -14,12 +14,13 @@ translation-invariant canonical-form theorem of
 The normalization convention is also dual to the one used there:
 PGVWC07 writes the blocks in the unital orientation
 $\sum_i A_k^i(A_k^i)^\dagger=\Id$ for
-$\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$, whereas this chapter uses
+$\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$
+\cite[Theorem~\texttt{Th:TIcanonical}, lines~754--758]{PerezGarcia2007Matrix},
+whereas this chapter uses
 the trace-preserving, or left-canonical, orientation
 $\sum_i (A_k^i)^\dagger A_k^i=\Id$.
 Passing to the conjugate-transposed Kraus family exchanges the two
-orientations by Lemma~\ref{lem:transfer_conjtranspose_adjoint}
-\cite[Theorem~\texttt{Th:TIcanonical}, lines~754--758]{PerezGarcia2007Matrix}.
+orientations by Lemma~\ref{lem:transfer_conjtranspose_adjoint}.
 The Perron--Frobenius eigenvector existence and TP-gauge construction
 are in Chapter~\ref{ch:qpf}; this chapter uses them to produce
 left-canonical normalization data and the normal canonical form data.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -553,8 +553,8 @@ per-block peripheral-spectrum primitivity.
 	\end{enumerate}
 	Then $(\mu_k, A_k)$ satisfies the canonical form conditions.
 \end{theorem}
-% Scope restriction (primitive block hypotheses): not the full PGVWC07
-% Theorem Th:TIcanonical (lines 742--763), which starts from an arbitrary
+% Scope restriction (primitive block hypotheses): not the full source theorem
+% (Theorem Th:TIcanonical, lines 742--763), which starts from an arbitrary
 % translation-invariant MPS representation. See
 % docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -11,6 +11,15 @@ Thus the normal-canonical reductions recorded here are conditional
 primitive-block results. They should not be read as the full
 translation-invariant canonical-form theorem of
 \cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
+The normalization convention is also dual to the one used there:
+PGVWC07 writes the blocks in the unital orientation
+$\sum_i A_k^i(A_k^i)^\dagger=\Id$ for
+$\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$, whereas this chapter uses
+the trace-preserving, or left-canonical, orientation
+$\sum_i (A_k^i)^\dagger A_k^i=\Id$.
+Passing to the conjugate-transposed Kraus family exchanges the two
+orientations by Lemma~\ref{lem:transfer_conjtranspose_adjoint}
+\cite[Theorem~\texttt{Th:TIcanonical}, lines~754--758]{PerezGarcia2007Matrix}.
 The Perron--Frobenius eigenvector existence and TP-gauge construction
 are in Chapter~\ref{ch:qpf}; this chapter uses them to produce
 left-canonical normalization data and the normal canonical form data.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -586,7 +586,7 @@ per-block peripheral-spectrum primitivity.
 	conditions (Definition~\ref{def:is_canonical_form}).
 \end{theorem}
 % Scope restriction (peripheral-primitive block hypotheses): not the full
-% PGVWC07 Theorem Th:TIcanonical (lines 742--763), which starts from an
+% source theorem (lines 742--763), which starts from an
 % arbitrary translation-invariant MPS representation. See
 % docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
 
@@ -989,7 +989,7 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
 		form conditions.
 \end{theorem}
 % Scope restriction (prepared primitive block decomposition): not the
-% full PGVWC07 Theorem Th:TIcanonical (lines 742--763), which starts from
+% full source theorem (lines 742--763), which starts from
 % an arbitrary translation-invariant MPS representation. See
 % docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -7,6 +7,10 @@ canonical form conditions of Chapter~\ref{ch:block_perm}. The normal-canonical
 reduction uses a weighted family of irreducible TP-normalized blocks with
 primitive transfer maps and pairwise distinct nonzero weight moduli, in the
 sense of \cite{Cirac2017MPDO_AnnPhys}.
+Thus the normal-canonical reductions recorded here are conditional
+primitive-block results. They should not be read as the full
+translation-invariant canonical-form theorem of
+\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
 The Perron--Frobenius eigenvector existence and TP-gauge construction
 are in Chapter~\ref{ch:qpf}; this chapter uses them to produce
 left-canonical normalization data and the normal canonical form data.
@@ -538,6 +542,10 @@ per-block peripheral-spectrum primitivity.
 		\item each block admits a primitive fixed point.
 	\end{enumerate}
 	Then $(\mu_k, A_k)$ satisfies the canonical form conditions.
+	This is a conditional primitive-block consequence; it is not the full
+	translation-invariant canonical-form existence theorem, whose hypotheses
+	start from an arbitrary translation-invariant representation
+	\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -558,13 +566,18 @@ per-block peripheral-spectrum primitivity.
 		\item each $A_k$ is injective,
 		\item each $A_k$ satisfies the TP normalization
 		      $\sum_i (A_k^i)^\dagger A_k^i = \Id$,
-		\item $|\mu_1| \ge \cdots \ge |\mu_r|$ (non-increasing),
+		\item $|\mu_1| > \cdots > |\mu_r|$ (strictly decreasing),
 		\item all $\mu_k \neq 0$,
+		\item each block has positive bond dimension,
 		\item each transfer map $\E_{A_k}$ is primitive,
 		      i.e. has peripheral spectrum $\{1\}$.
 	\end{enumerate}
 	Then $(\mu_k, A_k)$ satisfies the canonical form
 	conditions (Definition~\ref{def:is_canonical_form}).
+	This is a conditional peripheral-primitive consequence; it is not the full
+	translation-invariant canonical-form existence theorem, whose hypotheses
+	start from an arbitrary translation-invariant representation
+	\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}
@@ -964,6 +977,11 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
 		tensors $(B_k)$ such that $A^{[p]}$ generates the same MPV family as
 		$\bigoplus_k \nu_k B_k$, and $(\nu_k, B_k)$ satisfies the normal canonical
 		form conditions.
+		This is a conditional result from a primitive block decomposition
+		satisfying the listed hypotheses; it is not the full
+		translation-invariant canonical-form existence theorem, whose
+		hypotheses start from an arbitrary translation-invariant representation
+		\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -7,7 +7,7 @@ canonical form conditions of Chapter~\ref{ch:block_perm}. The normal-canonical
 reduction uses a weighted family of irreducible TP-normalized blocks with
 primitive transfer maps and pairwise distinct nonzero weight moduli, in the
 sense of \cite{Cirac2017MPDO_AnnPhys}.
-Thus the normal-canonical reductions recorded here are conditional
+Thus the reductions recorded here are conditional
 primitive-block results. They should not be read as the full
 translation-invariant canonical-form theorem of
 \cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -48,9 +48,9 @@ or that only one block occurs in each weight class. These properties enter
 elsewhere in the paper as later hypotheses, consequences, or genericity
 conditions. For example, the injectivity statement appears only after the
 canonical form has been obtained
-\cite[Proposition~\texttt{prop-inj}, lines~911--955]{PerezGarcia2007MPSReps},
+\cite[Proposition~\texttt{prop-inj}, lines~911--950]{PerezGarcia2007MPSReps},
 and the generic uniqueness discussion is a separate theorem
-\cite[Theorem~\texttt{thm-uniq}, lines~1000--1018]{PerezGarcia2007MPSReps}.
+\cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007MPSReps}.
 
 \section{Normalization orientation}
 

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -100,7 +100,7 @@ assumptions into any later argument that cites canonical-form existence.
 
 The currently checked primitive and peripheral-primitive reductions should
 therefore be read as conditional canonical-form theorems rather than as
-PGVWC07 Theorem~\texttt{Th:TIcanonical}.\footnote{The formal declarations are
+formalizations of the full source theorem.\footnote{The formal declarations are
 \texttt{MPSTensor.isCanonicalForm\_of\_primitive},
 \texttt{MPSTensor.isCanonicalForm\_of\_peripheralPrimitive}, and
 \texttt{MPSTensor.exists\_normalCanonicalForm\_of\_primitive\_blockDecomp}.}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -81,14 +81,14 @@ The currently checked statements in the canonical-form reduction chapter
 prove conditional reductions from prior block hypotheses. In particular,
 the primitive fixed-point reduction assumes
 that the blocks are injective, trace-preserving in the chosen gauge, strictly
-ordered by weight modulus, nonzero, and primitive. The peripheral-spectrum
-variant assumes the same injectivity, normalization, and strict weight
-ordering, together with the statement that each block transfer map has
-peripheral spectrum $\{1\}$. The normal-canonical-form reduction starts
-from a weighted block decomposition already equivalent to the original
-state and assumes irreducibility, trace-preserving normalization,
-primitivity, pairwise distinct weight moduli, nonzero weights, and positive
-bond dimensions.
+ordered by weight modulus, nonzero, positive-dimensional, and primitive. The
+peripheral-spectrum variant assumes the same injectivity, normalization,
+strict weight ordering, nonzero weights, and positive block dimensions,
+together with the statement that each block transfer map has peripheral
+spectrum $\{1\}$. The normal-canonical-form reduction starts from a weighted
+block decomposition already equivalent to the original state and assumes
+irreducibility, trace-preserving normalization, primitivity, pairwise distinct
+weight moduli, nonzero weights, and positive bond dimensions.
 
 These are correct conditional consequences, but they are not formalizations
 of the full PGVWC07 translation-invariant canonical-form theorem. Their
@@ -98,16 +98,12 @@ assumptions into any later argument that cites canonical-form existence.
 
 \section{Formal boundary}
 
-The following declarations should therefore be read as conditional
-canonical-form theorems rather than as PGVWC07
-Theorem~\texttt{Th:TIcanonical}:
-\[
-\begin{gathered}
-  \texttt{MPSTensor.isCanonicalForm\_of\_primitive},\\
-  \texttt{MPSTensor.isCanonicalForm\_of\_peripheralPrimitive},\\
-  \texttt{MPSTensor.exists\_normalCanonicalForm\_of\_primitive\_blockDecomp}.
-\end{gathered}
-\]
+The currently checked primitive and peripheral-primitive reductions should
+therefore be read as conditional canonical-form theorems rather than as
+PGVWC07 Theorem~\texttt{Th:TIcanonical}.\footnote{The formal declarations are
+\texttt{MPSTensor.isCanonicalForm\_of\_primitive},
+\texttt{MPSTensor.isCanonicalForm\_of\_peripheralPrimitive}, and
+\texttt{MPSTensor.exists\_normalCanonicalForm\_of\_primitive\_blockDecomp}.}
 They may be used after their hypotheses have been proved from earlier
 source-faithful reductions, but they should not be cited as giving canonical
 form directly from an arbitrary translation-invariant MPS representation.

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -52,6 +52,29 @@ canonical form has been obtained
 and the generic uniqueness discussion is a separate theorem
 \cite[Theorem~\texttt{thm-uniq}, lines~1000--1018]{PerezGarcia2007MPSReps}.
 
+\section{Normalization orientation}
+
+There is also a convention difference in the direction of the canonical
+normalization. PGVWC07 writes the block transfer map as
+\[
+  \mathcal{E}_j(X) = \sum_i A_i^j X A_i^{j\dagger}
+\]
+and imposes the unital condition
+\[
+  \sum_i A_i^j A_i^{j\dagger} = \mathbf{1}.
+\]
+The local canonical-form chapter usually works in the dual
+trace-preserving, or left-canonical, orientation
+\[
+  \sum_i A_i^{j\dagger} A_i^j = \mathbf{1}.
+\]
+This is a convention difference when it is accompanied by the corresponding
+adjoint transfer map or conjugate-transposed Kraus family. It is nevertheless
+important to state the convention explicitly: a theorem written only in the
+left-canonical orientation should not be read literally as PGVWC07
+Theorem~\texttt{Th:TIcanonical} unless the dualization or gauge conversion
+has also been supplied.
+
 \section{The formal reductions}
 
 The currently checked statements in the canonical-form reduction chapter

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -55,7 +55,7 @@ and the generic uniqueness discussion is a separate theorem
 \section{Normalization orientation}
 
 There is also a convention difference in the direction of the canonical
-normalization. PGVWC07 writes the block transfer map as
+normalization. In the source theorem, the block transfer map is written as
 \[
   \mathcal{E}_j(X) = \sum_i A_i^j X A_i^{j\dagger}
 \]

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -98,8 +98,9 @@ assumptions into any later argument that cites canonical-form existence.
 
 \section{Formal boundary}
 
-The currently checked primitive and peripheral-primitive reductions should
-therefore be read as conditional canonical-form theorems rather than as
+The currently checked primitive, peripheral-primitive, and
+normal-canonical-form reductions should therefore be read as conditional
+canonical-form theorems rather than as
 formalizations of the full source theorem.\footnote{The formal declarations are
 \texttt{MPSTensor.isCanonicalForm\_of\_primitive},
 \texttt{MPSTensor.isCanonicalForm\_of\_peripheralPrimitive}, and
@@ -115,10 +116,10 @@ Theorem~\texttt{Th:TIcanonical} should start with an arbitrary
 translation-invariant MPS representation and construct the block
 decomposition, the positive weights, the unital block gauge, the diagonal
 full-rank fixed points, and the uniqueness of the identity fixed point,
-while preserving the stated bond-dimension bound. The conditional primitive
-and peripheral-primitive reductions can then be used only after the source
-argument has produced the corresponding hypotheses or after a later theorem
-has explicitly assumed them.
+while preserving the stated bond-dimension bound. The conditional primitive,
+peripheral-primitive, and normal-canonical-form reductions can then be used
+only after the source argument has produced the corresponding hypotheses or
+after a later theorem has explicitly assumed them.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -1,0 +1,107 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Scope of the Formal Canonical-Form Reductions Relative to PGVWC07}
+\author{}
+\date{2026-05-12}
+
+\begin{document}
+\maketitle
+
+\section{The source theorem}
+
+The translation-invariant canonical-form theorem of
+P\'erez-Garc\'ia, Verstraete, Wolf, and Cirac starts from an arbitrary
+translation-invariant MPS representation on a finite ring
+\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007MPSReps}.
+It states that the matrices can always be decomposed as
+\[
+  A_i =
+  \begin{pmatrix}
+    \lambda_1 A_i^1 & 0 & 0 \\
+    0 & \lambda_2 A_i^2 & 0 \\
+    0 & 0 & \cdots
+  \end{pmatrix},
+\]
+where $1 \geq \lambda_j > 0$ and each block satisfies:
+\[
+  \sum_i A_i^j A_i^{j\dagger} = \mathbf{1},\qquad
+  \sum_i A_i^{j\dagger}\Lambda^j A_i^j = \Lambda^j,
+\]
+for a diagonal positive full-rank matrix $\Lambda^j$, and $\mathbf{1}$ is the
+only fixed point of
+\[
+  \mathcal{E}_j(X) = \sum_i A_i^j X A_i^{j\dagger}.
+\]
+If the initial representation has bond dimension $D$, the canonical
+representation has bond dimension at most $D$.
+
+The statement does not assume injectivity, a condition C1, blockwise
+primitivity, a prior block decomposition, strict separation of the weights,
+or that only one block occurs in each weight class. These properties enter
+elsewhere in the paper as later hypotheses, consequences, or genericity
+conditions. For example, the injectivity statement appears only after the
+canonical form has been obtained
+\cite[Proposition~\texttt{prop-inj}, lines~911--955]{PerezGarcia2007MPSReps},
+and the generic uniqueness discussion is a separate theorem
+\cite[Theorem~\texttt{thm-uniq}, lines~1000--1018]{PerezGarcia2007MPSReps}.
+
+\section{The formal reductions}
+
+The currently checked statements in the canonical-form reduction chapter
+prove conditional reductions from prior block hypotheses. In particular,
+the primitive fixed-point reduction assumes
+that the blocks are injective, trace-preserving in the chosen gauge, strictly
+ordered by weight modulus, nonzero, and primitive. The peripheral-spectrum
+variant assumes the same injectivity, normalization, and strict weight
+ordering, together with the statement that each block transfer map has
+peripheral spectrum $\{1\}$. The normal-canonical-form reduction starts
+from a weighted block decomposition already equivalent to the original
+state and assumes irreducibility, trace-preserving normalization,
+primitivity, pairwise distinct weight moduli, nonzero weights, and positive
+bond dimensions.
+
+These are correct conditional consequences, but they are not formalizations
+of the full PGVWC07 translation-invariant canonical-form theorem. Their
+hypotheses are stronger and more structured than the source theorem's
+hypotheses. Treating them as the full source theorem would import extra
+assumptions into any later argument that cites canonical-form existence.
+
+\section{Formal boundary}
+
+The following declarations should therefore be read as conditional
+canonical-form theorems rather than as PGVWC07
+Theorem~\texttt{Th:TIcanonical}:
+\[
+\begin{gathered}
+  \texttt{MPSTensor.isCanonicalForm\_of\_primitive},\\
+  \texttt{MPSTensor.isCanonicalForm\_of\_peripheralPrimitive},\\
+  \texttt{MPSTensor.exists\_normalCanonicalForm\_of\_primitive\_blockDecomp}.
+\end{gathered}
+\]
+They may be used after their hypotheses have been proved from earlier
+source-faithful reductions, but they should not be cited as giving canonical
+form directly from an arbitrary translation-invariant MPS representation.
+
+\section{What remains}
+
+A faithful formalization of PGVWC07
+Theorem~\texttt{Th:TIcanonical} should start with an arbitrary
+translation-invariant MPS representation and construct the block
+decomposition, the positive weights, the unital block gauge, the diagonal
+full-rank fixed points, and the uniqueness of the identity fixed point,
+while preserving the stated bond-dimension bound. The conditional primitive
+and peripheral-primitive reductions can then be used only after the source
+argument has produced the corresponding hypotheses or after a later theorem
+has explicitly assumed them.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary
- Records a paper-gap note for PGVWC07 Theorem Th:TIcanonical, lines 742--763.
- Marks the primitive, peripheral-primitive, and primitive-block-decomposition canonical-form reductions as conditional results, not the full PGVWC07 existence theorem.
- Clarifies the PGVWC07 normalization orientation: the source theorem uses the unital orientation, while the local canonical chapter uses the dual trace-preserving / left-canonical orientation.
- Corrects the blueprint statement of the peripheral-primitive theorem from non-increasing weights to strictly decreasing weights, matching the Lean statement.

## Source Boundary
PGVWC07 Theorem Th:TIcanonical starts from an arbitrary translation-invariant MPS representation and does not assume injectivity, primitivity, strict weight separation, or a prior block decomposition. Its displayed canonical-form conditions use the unital orientation sum_i A_i A_i^dagger = 1 for E(X)=sum_i A_i X A_i^dagger. The formal results touched here remain valid conditional consequences in the dual trace-preserving convention.

Refs #1616.
Refs #1617.
Refs #1613.

## Checks
- lake env lean TNLean/MPS/CanonicalForm/FromPrimitive.lean
- lake env lean TNLean/MPS/CanonicalForm/FromPeripheralPrimitive.lean
- lake env lean TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
- pdflatex + bibtex + pdflatex on docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
- leanblueprint checkdecls
- leanblueprint pdf (succeeds; existing unresolved blueprint references remain elsewhere)
- git diff --check
- lake build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/comment updates plus a blueprint statement correction, with no impact on Lean proof logic or runtime behavior.
> 
> **Overview**
> Adds explicit *scope-restriction* documentation to the Lean theorems `isCanonicalForm_of_primitive`, `isCanonicalForm_of_peripheralPrimitive`, and `exists_normalCanonicalForm_of_primitive_blockDecomp`, clarifying they are conditional results assuming prepared primitive/peripheral-primitive block hypotheses (not the full PGVWC07 existence theorem).
> 
> Updates the blueprint canonical-form chapter to (1) highlight the convention mismatch (unital vs trace-preserving/left-canonical orientation), (2) annotate the same scope restriction on the corresponding theorems, and (3) correct the peripheral-primitive theorem’s weight condition to **strictly decreasing** `|μ_k|` to match the Lean statement. Also adds `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex` documenting the formalization boundary relative to PGVWC07.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd42dc2019148905e22c03a23cc9df4df0196e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->