### PR TITLE
doc(MPS/FT): mark CFBNT one-copy scope

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean
@@ -34,7 +34,12 @@ permutation, and per-block gauge-phase equivalence.
 The proof uses the overlap dichotomy: non-decaying cross-family overlap
 forces equal block dimensions and gauge-phase equivalence; injectivity of
 the matching follows from BNT separation.  The argument follows Cirac et al.
-2021 (CPSV17) Appendix A. -/
+2021 (CPSV17) Appendix A.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma blocks_match_of_sameMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/DominantWeight.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/DominantWeight.lean
@@ -91,7 +91,7 @@ section HeteroEqualCase
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192.
 
 **Scope restriction (one-copy-per-sector):** The local hypotheses
-`IsCanonicalFormBNT` are already-grouped one-copy-per-sector canonical
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
 forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
 documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma dominant_weight_norm_eq_of_sameMPV₂_CFBNT

--- a/TNLean/MPS/FundamentalTheorem/Full/DominantWeight.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/DominantWeight.lean
@@ -90,9 +90,9 @@ section HeteroEqualCase
 
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192.
 
-**Scope restriction (one-copy-per-sector):** The local hypothesis
-`IsCanonicalFormBNT` is the already-grouped one-copy-per-sector canonical
-form. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
 documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma dominant_weight_norm_eq_of_sameMPV₂_CFBNT
     {d rA rB : ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/DominantWeight.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/DominantWeight.lean
@@ -86,7 +86,14 @@ lemma eq_one_of_pow_tendsto_nhds_one {c : ℂ}
 
 section HeteroEqualCase
 
-/-- Dominant BNT block weights have equal norms for equal total MPVs. -/
+/-- Dominant BNT block weights have equal norms for equal total MPVs.
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192.
+
+**Scope restriction (one-copy-per-sector):** The local hypothesis
+`IsCanonicalFormBNT` is the already-grouped one-copy-per-sector canonical
+form. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma dominant_weight_norm_eq_of_sameMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/FixedBlockSingleton.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/FixedBlockSingleton.lean
@@ -36,7 +36,12 @@ the fixed-block cancellation step when the `B`-side has only the selected
 block. Then the proportional weighted-state identity has no other `B`-summands
 which could cancel the selected block, so Lemma `Lem1` coefficient extraction
 directly contradicts the nonzero selected weight and nonzero proportionality
-scalar. -/
+scalar.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT_finOne
     {d rA : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin 1 → ℕ}
@@ -114,7 +119,12 @@ symmetric base case of the fixed-block cancellation step when the `A`-side has
 only the selected block. Then the proportional weighted-state identity has no
 other `A`-summands which could cancel the selected block, so Lemma `Lem1`
 coefficient extraction directly contradicts the nonzero selected weight and
-nonzero proportionality scalar. -/
+nonzero proportionality scalar.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT_finOne
     {d rB : ℕ}
     {dimA : Fin 1 → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -73,7 +73,12 @@ The proof proceeds by strong induction on `rA + rB`:
   identity.  The reduced identity involves `rA − 1` and `rB − 1` blocks that still satisfy
   `IsCanonicalFormBNT` (all per-block properties are inherited, and the strict weight
   ordering restricts to the sub-range).  The strong induction hypothesis then closes the
-  remaining cases. -/
+  remaining cases.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma exists_nondecaying_overlap_of_sameMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -622,7 +627,12 @@ termination_by rA + rB
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof
 removes a matched leading BNT block and repeats the argument on the remaining
 blocks. In the one-copy-per-sector restricted surface used here, the inherited
-tail family is again in restricted BNT canonical form. -/
+tail family is again in restricted BNT canonical form.
+
+**Scope restriction (one-copy-per-sector):** The local hypothesis
+`IsCanonicalFormBNT` is the already-grouped one-copy-per-sector canonical
+form. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma isCanonicalFormBNT_tail_succ
     {d r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -656,7 +666,12 @@ proof removes matched BNT block pairs and repeats the argument on the
 remaining blocks. Since the source theorem permits a permutation of blocks, the
 removed block need not be the leading one. In the one-copy-per-sector
 restricted surface used here, the complement indexed by `Fin.succAbove` is
-again in restricted BNT canonical form. -/
+again in restricted BNT canonical form.
+
+**Scope restriction (one-copy-per-sector):** The local hypothesis
+`IsCanonicalFormBNT` is the already-grouped one-copy-per-sector canonical
+form. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma isCanonicalFormBNT_tail_succAbove
     {d n : ℕ} {dim : Fin (n + 1) → ℕ} {μ : Fin (n + 1) → ℂ}
     (A : (j : Fin (n + 1)) → MPSTensor d (dim j))
@@ -685,7 +700,12 @@ contradiction, that all overlaps with the `A_j` tend to zero. Together with
 the BNT asymptotic orthonormality inside the `A`-family and the normalized
 self-overlap of `B_k`, Corollary `Lem1` gives linear independence, for all
 sufficiently large lengths, of the combined family consisting of all `A_j`
-and this one fixed block `B_k`. -/
+and this one fixed block `B_k`.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma eventually_linearIndependent_all_left_single_right_of_all_overlaps_decay_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -739,7 +759,12 @@ Source: arXiv:1606.00608, Corollary `Lem1` and Theorem `thm1`, lines
 the two tensor families interchanged. If one fixes a block `A_j` and assumes
 that all overlaps with the `B_k` tend to zero, Corollary `Lem1` gives linear
 independence, for all sufficiently large lengths, of the combined family
-consisting of all `B_k` and this one fixed block `A_j`. -/
+consisting of all `B_k` and this one fixed block `A_j`.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -793,7 +818,12 @@ Source: arXiv:1606.00608, Theorem `thm1`, line 1182. This is the fixed-block
 cancellation step for the leading block of the `B`-family. In the
 one-copy-per-sector setting, the dominant projection argument already
 rules out decay of all overlaps with that leading `B`-block under eventual
-nonzero proportionality of the total MPV families. -/
+nonzero proportionality of the total MPV families.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma fixed_right_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -820,7 +850,12 @@ Source: arXiv:1606.00608, Theorem `thm1`, lines 1182--1185. This is the
 symmetric leading-block cancellation step for the leading block of the
 `A`-family. The dominant projection argument rules out simultaneous decay of
 all overlaps with that leading `A`-block under eventual nonzero proportionality
-of the total MPV families. -/
+of the total MPV families.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma fixed_left_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -853,7 +888,12 @@ local Lemma `Lem1` input is
 `eventually_linearIndependent_all_left_single_right_of_all_overlaps_decay_CFBNT`.
 The remaining formal proof obligation is documented in
 `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex` and tracked in issue
-#1607. -/
+#1607.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -885,7 +925,12 @@ The local Lemma `Lem1` input is
 `eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_CFBNT`.
 The remaining formal proof obligation is documented in
 `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex` and tracked in issue
-#1607. -/
+#1607.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean
@@ -23,7 +23,12 @@ section HeteroEqualCase
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof
 uses the overlap dichotomy before applying Corollary `eqV`: if two injective
 left-canonical BNT blocks have a cross-overlap which does not tend to zero, then
-their bond dimensions must agree. -/
+their bond dimensions must agree.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma dim_eq_of_nondecaying_overlap_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -49,7 +54,12 @@ lemma dim_eq_of_nondecaying_overlap_CFBNT
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After a
 non-decaying overlap partner is found, the overlap dichotomy and Corollary
 `eqV` identify the two BNT blocks up to gauge and phase. This lemma packages
-the Lean form of that extraction. -/
+the Lean form of that extraction.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma gaugePhaseEquiv_of_nondecaying_overlap_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -81,7 +91,12 @@ Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After
 Corollary `eqV` gives a phase relation
 \(|V^{(N)}(B_k)\rangle = e^{i\phi N}|V^{(N)}(A_j)\rangle\), the selected
 summand in the weighted BNT expansion can be compared coefficientwise. This
-lemma packages the corresponding Lean consequence of a non-decaying overlap. -/
+lemma packages the corresponding Lean consequence of a non-decaying overlap.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma exists_phase_mpvState_eq_smul_of_nondecaying_overlap_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -121,7 +136,12 @@ Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the
 Lean proof, each non-decaying overlap is converted to a gauge-phase equivalence
 by the overlap-decay dichotomy. Two distinct partners for the same fixed block
 would then force two distinct BNT blocks on the other side to have a
-non-decaying mutual overlap, contradicting BNT block separation. -/
+non-decaying mutual overlap, contradicting BNT block separation.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma unique_left_nondecaying_overlap_partner_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -241,7 +261,12 @@ lemma unique_left_nondecaying_overlap_partner_CFBNT
 This is the symmetric form of
 `unique_left_nondecaying_overlap_partner_CFBNT`; it is the same CPSV16
 Theorem `thm1`, lines 1170--1192, uniqueness step with the two tensor
-families interchanged. -/
+families interchanged.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma unique_right_nondecaying_overlap_partner_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -371,7 +371,12 @@ Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. If the normalized
 proportional projection identity eventually holds and has an adjusted scalar
 whose modulus tends to one, then the dominant block on either side cannot have
 all cross-overlaps tending to zero. This is the dominant case of the CPSV16
-line 1182 argument after applying Lemma `Lem1`. -/
+line 1182 argument after applying Lemma `Lem1`.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma dominant_projection_contradictions_of_normalized_proportional_inner
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -599,7 +604,12 @@ Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. After expanding
 the two canonical-form tensors into their BNT block sums, eventual nonzero
 proportionality supplies the scalar sequence used in the dominant-block
 projection contradiction. This is the dominant case of the line 1182 argument,
-with Lemma `Lem1` accounting for the sufficiently-large-length formulation. -/
+with Lemma `Lem1` accounting for the sufficiently-large-length formulation.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -664,7 +674,12 @@ lemma dominant_projection_contradictions_of_eventuallyNonzeroProportionalMPV₂_
 Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. The dominant
 projection contradiction rules out the alternative that the leading block on
 one side has vanishing overlap with every block on the other side. Hence each
-leading block admits a non-decaying overlap partner. -/
+leading block admits a non-decaying overlap partner.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma exists_nondecaying_overlap_dominant_of_eventuallyNonzeroProportionalMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}


### PR DESCRIPTION
## Summary

This PR marks downstream CPSV16 BNT comparison lemmas whose statements assume
`IsCanonicalFormBNT` as one-copy-per-sector restricted results.

The affected lemmas live in `TNLean/MPS/FundamentalTheorem/Full/` and feed the
equal/proportional BNT block-matching route. Their mathematical content is still
the same; this PR only makes the existing restriction explicit in the
docstrings and points readers to
`docs/paper-gaps/ft_one_copy_scope_restriction.tex`.

Tracked by #1618. Related to the faithfulness tracker #1565 and CPSV16 §II
tracker #1559.

## Source Boundary

CPSV16 Theorem `thm1`, lines 1170--1192, and the BNT construction around
lines 1135--1148 allow BNT multiplicities inside a sector. The local
`IsCanonicalFormBNT` surface is already grouped to one representative per
sector, so public downstream lemmas using it must be read as scoped variants,
not as the full multiplicity statement.

## Checks

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/DominantWeight.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/FixedBlockSingleton.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

No theorem statements or proofs are changed. No new `sorry` is introduced; the
two `sorry` warnings in `NondecayingOverlap.lean` are the pre-existing #1563
obligations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are docstring-only, clarifying that several BNT comparison lemmas assume the already-grouped one-copy-per-sector `IsCanonicalFormBNT` surface and linking to the gap note.
> 
> **Overview**
> Adds explicit docstring annotations across the equal/proportional BNT block-matching lemmas (`DominantWeight`, `NondecayingOverlap`, `NondecayingPartnerUnique`, `BlocksMatch`, `FixedBlockSingleton`, `ProportionalDominant`) stating they are **scoped to one-copy-per-sector** `IsCanonicalFormBNT` (no within-sector multiplicities) and pointing to `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
> 
> No theorem statements, proofs, or behavior are changed; this PR only makes the existing scope restriction explicit and improves source-context references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56539e3db24747eb259eade543b54d87063c8142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->