### PR TITLE
feat(MPS/FT): record asymptotic selected cancellation

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -413,6 +413,114 @@ lemma exists_dominant_phase_adjusted_scalar_tendsto_one_of_eventuallyNonzeroProp
     exact mul_div_cancel_right₀ (c N * ((μB b0 * ζ) / μA a0) ^ N) hB_ne
   exact ⟨c, hc, hState, by simpa [a0, b0] using hPhaseAdjusted⟩
 
+/-- **Leading phase-adjusted selected difference vanishes asymptotically.**
+
+Source context: arXiv:1606.00608, Theorem thm1, lines 1170--1192. Once a
+leading \(B\)-block is phase-matched to the leading \(A\)-block, the projected
+scalar convergence gives an asymptotic cancellation of the selected weighted
+summands after normalization by the leading \(A\)-weight.
+
+This is still weaker than the exact selected-summand equality needed for
+literal tail subtraction. It records only the norm convergence forced by the
+phase relation and the phase-adjusted scalar limit.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
+lemma exists_dominant_selected_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ} {ζ : ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hζ : ‖ζ‖ = 1)
+    (hPhase : ∀ N : ℕ,
+      mpvState (d := d) (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N =
+        ζ ^ N • mpvState (d := d) (A ⟨0, Nat.pos_of_ne_zero hrA⟩) N)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
+    ∃ c : ℕ → ℂ,
+      (∀ᶠ N in atTop, c N ≠ 0) ∧
+      (∀ᶠ N in atTop,
+        (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+          c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)) ∧
+      Tendsto
+        (fun N : ℕ =>
+          ‖(μA ⟨0, Nat.pos_of_ne_zero hrA⟩ ^ N)⁻¹ •
+            ((μA ⟨0, Nat.pos_of_ne_zero hrA⟩) ^ N •
+                mpvState (d := d) (A ⟨0, Nat.pos_of_ne_zero hrA⟩) N -
+              c N •
+                ((μB ⟨0, Nat.pos_of_ne_zero hrB⟩) ^ N •
+                  mpvState (d := d) (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N))‖)
+        atTop (nhds (0 : ℝ)) := by
+  let a0 : Fin rA := ⟨0, Nat.pos_of_ne_zero hrA⟩
+  let b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
+  obtain ⟨c, hc, hState, hScalar⟩ :=
+    exists_dominant_phase_adjusted_scalar_tendsto_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hζ hPhase hProp
+  have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
+  have hA_norm :
+      Tendsto (fun N : ℕ => ‖mpvState (d := d) (A a0) N‖)
+        atTop (nhds (1 : ℝ)) :=
+    tendsto_norm_mpvState_one (A a0)
+      (hA.toHasNormalizedSelfOverlap.overlap_tendsto_one a0)
+  have hScalar_zero :
+      Tendsto
+        (fun N : ℕ => ‖(1 : ℂ) - c N * ((μB b0 * ζ) / μA a0) ^ N‖)
+        atTop (nhds (0 : ℝ)) := by
+    have hsub :
+        Tendsto
+          (fun N : ℕ => (1 : ℂ) - c N * ((μB b0 * ζ) / μA a0) ^ N)
+          atTop (nhds 0) := by
+      have hScalar' :
+          Tendsto (fun N : ℕ => c N * ((μB b0 * ζ) / μA a0) ^ N)
+            atTop (nhds (1 : ℂ)) := by
+        simpa [a0, b0] using hScalar
+      simpa using ((tendsto_const_nhds (x := (1 : ℂ))).sub hScalar')
+    simpa using hsub.norm
+  have hProduct :
+      Tendsto
+        (fun N : ℕ =>
+          ‖(1 : ℂ) - c N * ((μB b0 * ζ) / μA a0) ^ N‖ *
+            ‖mpvState (d := d) (A a0) N‖)
+        atTop (nhds (0 : ℝ)) := by
+    simpa using hScalar_zero.mul hA_norm
+  have hDiff :
+      Tendsto
+        (fun N : ℕ =>
+          ‖(μA a0 ^ N)⁻¹ •
+            ((μA a0) ^ N • mpvState (d := d) (A a0) N -
+              c N • ((μB b0) ^ N • mpvState (d := d) (B b0) N))‖)
+        atTop (nhds (0 : ℝ)) := by
+    refine Tendsto.congr' ?_ hProduct
+    filter_upwards with N
+    let v := mpvState (d := d) (A a0) N
+    have hμA_pow_ne : μA a0 ^ N ≠ 0 := pow_ne_zero N hμA_ne
+    have hvec :
+        (μA a0 ^ N)⁻¹ •
+            ((μA a0) ^ N • mpvState (d := d) (A a0) N -
+              c N • ((μB b0) ^ N • mpvState (d := d) (B b0) N)) =
+          ((1 : ℂ) - c N * ((μB b0 * ζ) / μA a0) ^ N) •
+            mpvState (d := d) (A a0) N := by
+      rw [hPhase N]
+      simp only [smul_sub, smul_smul]
+      rw [← sub_smul]
+      congr 1
+      calc
+        (μA a0 ^ N)⁻¹ * (μA a0) ^ N -
+            (μA a0 ^ N)⁻¹ * (c N * ((μB b0) ^ N * ζ ^ N)) =
+            1 - c N * (((μB b0) ^ N * ζ ^ N) / (μA a0 ^ N)) := by
+              field_simp [hμA_pow_ne]
+        _ = 1 - c N * ((μB b0 * ζ) / μA a0) ^ N := by
+              rw [← mul_pow, ← div_pow]
+    rw [hvec, norm_smul]
+  exact ⟨c, hc, hState, by simpa [a0, b0] using hDiff⟩
+
 /-- **Dominant adjusted scalar has asymptotic modulus one.**
 
 Source: arXiv:1606.00608, lines 1170--1192. In the

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean
@@ -499,7 +499,6 @@ lemma exists_dominant_selected_diff_tendsto_zero_of_eventuallyNonzeroProportiona
         atTop (nhds (0 : ℝ)) := by
     refine Tendsto.congr' ?_ hProduct
     filter_upwards with N
-    let v := mpvState (d := d) (A a0) N
     have hμA_pow_ne : μA a0 ^ N ≠ 0 := pow_ne_zero N hμA_ne
     have hvec :
         (μA a0 ^ N)⁻¹ •

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -695,17 +695,23 @@ with an extra $Z$-gauge degree of freedom.
 		\ket{V^{(N)}(B_{b_0})}
 		= \zeta^N \ket{V^{(N)}(A_{a_0})}
 	\]
-	with \(|\zeta|=1\), then there is an eventual nonzero scalar sequence
-	\(c_N\) relating the assembled weighted sums such that
+	with \(|\zeta|=1\), then there is a scalar sequence \(c_N\), eventually
+	nonzero, such that
+	\[
+		\sum_j(\mu^A_j)^N\ket{V^{(N)}(A_j)}
+		=
+		c_N\sum_k(\mu^B_k)^N\ket{V^{(N)}(B_k)}
+	\]
+	for all sufficiently large \(N\), and
 	\[
 		\left\|(\mu^A_{a_0})^{-N}
 		\Big((\mu^A_{a_0})^N \ket{V^{(N)}(A_{a_0})}
 		- c_N(\mu^B_{b_0})^N \ket{V^{(N)}(B_{b_0})}\Big)\right\|
 		\longrightarrow 0 .
 	\]
-	This is an asymptotic selected-summand cancellation. It is not the exact
-	selected-summand equality needed for tail subtraction.
 	\cite[lines~1170--1192]{Cirac2016MPDO_arXiv}.
+	% This is an asymptotic selected-summand cancellation; it does not give
+	% the exact selected-summand equality needed for tail subtraction.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -682,6 +682,46 @@ with an extra $Z$-gauge degree of freedom.
 	of \(c_N((\mu^B_{b_0}\zeta)/\mu^A_{a_0})^N\).
 \end{proof}
 
+\begin{lemma}[Dominant selected difference vanishes after phase adjustment]%
+\label{lem:dominant_phase_adjusted_selected_difference}
+	\lean{MPSTensor.exists_dominant_selected_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
+	\leanok
+	\uses{lem:dominant_phase_adjusted_scalar_convergence}
+	Let \((\mu^A_j,A_j)\) and \((\mu^B_k,B_k)\) be one-copy BNT
+	canonical-form families with nonempty index sets, and suppose that the
+	assembled weighted MPV families are eventually nonzero proportional.  If
+	for every \(N\), the leading blocks satisfy
+	\[
+		\ket{V^{(N)}(B_{b_0})}
+		= \zeta^N \ket{V^{(N)}(A_{a_0})}
+	\]
+	with \(|\zeta|=1\), then there is an eventual nonzero scalar sequence
+	\(c_N\) relating the assembled weighted sums such that
+	\[
+		\left\|(\mu^A_{a_0})^{-N}
+		\Big((\mu^A_{a_0})^N \ket{V^{(N)}(A_{a_0})}
+		- c_N(\mu^B_{b_0})^N \ket{V^{(N)}(B_{b_0})}\Big)\right\|
+		\longrightarrow 0 .
+	\]
+	This is an asymptotic selected-summand cancellation. It is not the exact
+	selected-summand equality needed for tail subtraction.
+	\cite[lines~1170--1192]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	Lemma~\ref{lem:dominant_phase_adjusted_scalar_convergence} gives
+	\(c_N((\mu^B_{b_0}\zeta)/\mu^A_{a_0})^N\to 1\).  After substituting the
+	phase relation, the normalized selected difference is
+	\[
+		\left(1-
+		c_N\left(\frac{\mu^B_{b_0}\zeta}{\mu^A_{a_0}}\right)^N\right)
+		\ket{V^{(N)}(A_{a_0})}.
+	\]
+	The first factor tends to \(0\), while the norm of
+	\(\ket{V^{(N)}(A_{a_0})}\) tends to \(1\) by the BNT self-overlap
+	normalization.
+\end{proof}
+
 \begin{lemma}[Proportional weighted states give proportional weighted projections]%
 \label{lem:proportional_tensor_from_blocks_weighted_inner}
 	\lean{MPSTensor.exists_weighted_mpvInner_eq_mul_of_nonzeroProportionalMPV₂_toTensorFromBlocks}


### PR DESCRIPTION
## Summary

Adds the next CPSV16 fixed-block step after PR #1624: from a leading block phase relation and the phase-adjusted scalar convergence, the normalized selected weighted-summand difference tends to zero.

This is deliberately weaker than exact selected-summand equality. It does not use residual-family linear independence and does not claim tail subtraction.

## Source boundary

Source context: arXiv:1606.00608, Theorem thm1, lines 1170--1192. The formal statement is a one-copy-per-sector BNT consequence and keeps the existing scope marker pointing to docs/paper-gaps/ft_one_copy_scope_restriction.tex.

## Changes

- Adds `MPSTensor.exists_dominant_selected_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT` in `TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean`.
- Adds blueprint lemma `lem:dominant_phase_adjusted_selected_difference` in `blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- `lake build`

The full build is green. Existing repository warnings include unrelated pre-existing `sorry` warnings outside this PR and the two standing `NondecayingOverlap.lean` obligations tracked by #1563.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean lemma and corresponding blueprint text without changing existing definitions or proof interfaces; main risk is only proof maintenance/regression in downstream theorem dependencies.
> 
> **Overview**
> Adds a new dominant-block fixed-step lemma, `exists_dominant_selected_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT`, proving that **after phase matching** the leading blocks and using the previously established phase-adjusted scalar limit, the **normalized difference of the selected leading weighted summands converges to 0 in norm** (an asymptotic cancellation, not an exact equality).
> 
> Updates the blueprint (Chapter 11) with the corresponding statement and proof sketch (`lem:dominant_phase_adjusted_selected_difference`), explicitly documenting the *asymptotic-only* scope (no tail subtraction / coefficient extraction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89164ee8dc800472e995e546d9ab44b5182be8bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->