### PR TITLE
doc(MPS/CanonicalForm): scope Chapter 9 PGVWC07 uniqueness

### DIFF
--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -9,10 +9,10 @@ lemmas: they assume blockwise normalization and separation hypotheses, including
 strict ordering of the weight moduli when required below. They should not be read
 as a formalization of the translation-invariant canonical-form uniqueness theorem
 of~\cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007Matrix},
-which uses condition C1, uniqueness of the OBC canonical representation, and a
-finite-size lower bound. The source theorem is stated in the cited PGVWC07
-passage; the project-level scope distinction is recorded in
-\texttt{docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex}.
+which requires injectivity at some finite blocking length, uniqueness of the
+OBC canonical representation, and a finite-size lower bound. The source theorem
+is stated in the cited PGVWC07 passage; the project-level scope distinction is
+recorded in \path{docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex}.
 
 \section{Block permutation algebra}
 

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -10,8 +10,8 @@ strict ordering of the weight moduli when required below. They should not be rea
 as a formalization of the translation-invariant canonical-form uniqueness theorem
 of~\cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007Matrix},
 which uses condition C1, uniqueness of the OBC canonical representation, and a
-finite-size lower bound. The distinction is recorded in
-\cite{PerezGarcia2007Matrix} and in
+finite-size lower bound. The source theorem is stated in the cited PGVWC07
+passage; the project-level scope distinction is recorded in
 \texttt{docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex}.
 
 \section{Block permutation algebra}
@@ -428,7 +428,7 @@ We use this notation throughout the block-separation argument.
     If $\sum_k \mu_k^N (V^{(N)}(A_k)_\sigma - V^{(N)}(B_k)_\sigma) = 0$
     for all $N,\sigma$,
     then each pair $(A_k, B_k)$ generates the same MPV family
-    \cite[Appendix~E]{PerezGarcia2007Matrix}.
+    \cite[Appendix~\texttt{AppendixMPV}, lines~1054--1192]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -478,7 +478,7 @@ We use this notation throughout the block-separation argument.
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
     generate the same MPV family, then each pair
     $(A_k, B_k)$ generates the same MPV family
-    \cite[Appendix~E]{PerezGarcia2007Matrix}.
+    \cite[Appendix~\texttt{AppendixMPV}, lines~1054--1192]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}
@@ -511,7 +511,7 @@ We use this notation throughout the block-separation argument.
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
     generate the same MPV family, then each pair
     $(A_k, B_k)$ generates the same MPV family
-    \cite[Appendix~E]{PerezGarcia2007Matrix}.
+    \cite[Appendix~\texttt{AppendixMPV}, lines~1054--1192]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -552,7 +552,8 @@ We use this notation throughout the block-separation argument.
 \begin{remark}[Relation to the literature]\label{rem:block_perm_literature}
     The block-permutation part follows the decomposition of automorphisms of
     semisimple matrix algebras used in~\cite[Section~IV.A]{Cirac2021Matrix}.
-    The separation part follows the induction on blocks from
-    \cite[Appendix~E]{PerezGarcia2007Matrix}; the checked proof here uses
-    overlap bounds and mixed-transfer decay.
+    The separation part is the local strict-weight peeling argument used in
+    \cite[Appendix~\texttt{AppendixMPV}, lines~1054--1192]{Cirac2016MPDO_arXiv};
+    the checked proof here packages it as a same-structure block-separation lemma
+    using overlap bounds and mixed-transfer decay.
 \end{remark}

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -4,9 +4,15 @@ This chapter develops the algebra of block permutations, the product-algebra map
 built from per-block same-MPV data, the invariant-projection splitting step that
 reduces a tensor to smaller blocks, and the block-separation argument that
 recovers the individual blocks from a block-diagonal same-MPV hypothesis.
-The results correspond to the canonical-form uniqueness
-of~\cite{PerezGarcia2007Matrix} and the block-separation
-results of~\cite{Cirac2021Matrix}.
+The block-separation results in this chapter are conditional same-structure
+lemmas: they assume blockwise normalization and separation hypotheses, including
+strict ordering of the weight moduli when required below. They should not be read
+as a formalization of the translation-invariant canonical-form uniqueness theorem
+of~\cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007Matrix},
+which uses condition C1, uniqueness of the OBC canonical representation, and a
+finite-size lower bound. The distinction is recorded in
+\cite{PerezGarcia2007Matrix} and in
+\texttt{docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex}.
 
 \section{Block permutation algebra}
 
@@ -350,6 +356,20 @@ We use this notation throughout the block-separation argument.
     proof.
 \end{definition}
 
+\begin{remark}[Canonical-form theorem versus local predicates]\label{rem:pgvwc07_vs_local_cf}
+    The translation-invariant canonical-form theorem of
+    \cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}
+    starts from an arbitrary TI-MPS representation and constructs a block
+    canonical form with positive weights, unital block normalization, full-rank
+    diagonal invariant densities, and uniqueness of the identity fixed point.
+    Definition~\ref{def:is_canonical_form} is a local predicate used after such
+    structure has already been supplied or separately proved. In particular, it
+    assumes injectivity and the self-overlap limit, and the block-separation
+    lemmas below additionally require strict separation of the weight moduli.
+    These results are therefore conditional consequences, not the source
+    canonical-form existence or uniqueness theorems.
+\end{remark}
+
 \begin{remark}[Normalization convention]\label{rem:tp_vs_unital}
     The convention here differs from
     \cite[Theorem~4]{PerezGarcia2007Matrix}, which uses the unital gauge
@@ -400,10 +420,15 @@ We use this notation throughout the block-separation argument.
     \uses{def:is_canonical_form, def:injective}
     Let $((\mu_k), (A_k))$ satisfy the canonical form conditions,
     and let $(B_k)$ be injective tensors satisfying the same TP
-    normalization $\sum_i (B_k^i)^\dagger B_k^i = \Id$.
+    normalization $\sum_i (B_k^i)^\dagger B_k^i = \Id$. Assume moreover that
+    the weight moduli are strictly ordered:
+    \[
+        |\mu_1| > |\mu_2| > \cdots > |\mu_r|.
+    \]
     If $\sum_k \mu_k^N (V^{(N)}(A_k)_\sigma - V^{(N)}(B_k)_\sigma) = 0$
     for all $N,\sigma$,
-    then each pair $(A_k, B_k)$ generates the same MPV family.
+    then each pair $(A_k, B_k)$ generates the same MPV family
+    \cite[Appendix~E]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -444,11 +469,16 @@ We use this notation throughout the block-separation argument.
     \uses{def:is_canonical_form}
     Let $((\mu_k), (A_k))$ satisfy the canonical form conditions,
     and let $(B_k)$ be injective tensors satisfying the same TP
-    normalization $\sum_i (B_k^i)^\dagger B_k^i = \Id$.
+    normalization $\sum_i (B_k^i)^\dagger B_k^i = \Id$. Assume moreover that
+    the weight moduli are strictly ordered:
+    \[
+        |\mu_1| > |\mu_2| > \cdots > |\mu_r|.
+    \]
     If the block-diagonal tensors
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
     generate the same MPV family, then each pair
-    $(A_k, B_k)$ generates the same MPV family.
+    $(A_k, B_k)$ generates the same MPV family
+    \cite[Appendix~E]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
@@ -470,12 +500,18 @@ We use this notation throughout the block-separation argument.
     \lean{MPSTensor.per_block_sameMPV_of_normal_canonical_form}\leanok
     \uses{def:is_normal_canonical_form}
     Let $((\mu_k), (A_k))$ satisfy the normal canonical form conditions,
-    and let $(B_k)$ be irreducible tensors of the same bond dimensions, satisfying the same TP
-    normalization $\sum_i (B_k^i)^\dagger B_k^i = \Id$.
+    and let $(B_k)$ be irreducible tensors of the same bond dimensions,
+    satisfying the same TP normalization
+    $\sum_i (B_k^i)^\dagger B_k^i = \Id$. Assume moreover that the weight
+    moduli are strictly ordered:
+    \[
+        |\mu_1| > |\mu_2| > \cdots > |\mu_r|.
+    \]
     If the block-diagonal tensors
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
     generate the same MPV family, then each pair
-    $(A_k, B_k)$ generates the same MPV family.
+    $(A_k, B_k)$ generates the same MPV family
+    \cite[Appendix~E]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -495,10 +531,13 @@ We use this notation throughout the block-separation argument.
     \lean{MPSTensor.fundamentalTheorem_canonicalForm}
     \leanok
     \uses{def:is_canonical_form, def:gauge_equiv, def:tensor_from_blocks}
-    Under the hypotheses of Lemma~\ref{lem:block_sep}, each pair
-    $(A_k, B_k)$ is gauge equivalent. Hence the block-diagonal tensors
+    Under the hypotheses of Lemma~\ref{lem:block_sep}, including strict
+    ordering of the weight moduli, each pair $(A_k, B_k)$ is gauge equivalent.
+    Hence the block-diagonal tensors
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
-    are gauge equivalent.
+    are gauge equivalent. This is a same-structure local comparison theorem,
+    not the full PGVWC07 uniqueness theorem
+    \cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -554,6 +554,6 @@ We use this notation throughout the block-separation argument.
     semisimple matrix algebras used in~\cite[Section~IV.A]{Cirac2021Matrix}.
     The separation part is the local strict-weight peeling argument used in
     \cite[Appendix~\texttt{AppendixMPV}, lines~1054--1192]{Cirac2016MPDO_arXiv};
-    the checked proof here packages it as a same-structure block-separation lemma
+    the checked proof here formulates it as a same-structure block-separation lemma
     using overlap bounds and mixed-transfer decay.
 \end{remark}

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -12,7 +12,8 @@ of~\cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007Matrix},
 which requires injectivity at some finite blocking length, uniqueness of the
 OBC canonical representation, and a finite-size lower bound. The source theorem
 is stated in the cited PGVWC07 passage; the project-level scope distinction is
-recorded in \path{docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex}.
+recorded in the accompanying paper-gap note.\footnote{%
+	\path{docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex}.}
 
 \section{Block permutation algebra}
 

--- a/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
@@ -18,14 +18,24 @@
 
 The translation-invariant canonical-form uniqueness theorem of
 P\'erez-Garc\'ia, Verstraete, Wolf, and Cirac starts with two TI canonical
-\(D\)-MPS representations of the same finite-ring state
+\(D\)-MPS representations of the same finite-ring state.  We write their
+matrices as \(B_i\) and \(C_i\), following the source theorem
 \cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007MPSReps}.
-Its hypotheses are:
+For a TI representation \(A_i\), PGVWC07 defines
+\[
+  \Gamma_L(X)
+  =
+  \sum_{i_1,\ldots,i_L}
+    \operatorname{tr}\!\left[X A_{i_1}\cdots A_{i_L}\right]
+    |i_1\cdots i_L\rangle .
+\]
+The finite injectivity hypothesis called C1 in the source is the existence of
+a finite length \(L_0\) for which \(\Gamma_{L_0}\) is injective
+\cite[lines~888--908]{PerezGarcia2007MPSReps}.  The theorem assumes:
 \begin{enumerate}
-  \item condition C1 holds: there is a finite length \(L_0\) for which
-    \(\Gamma_{L_0}\) is injective
-    \cite[lines~888--908]{PerezGarcia2007MPSReps};
-  \item the OBC canonical representation is unique;
+  \item this finite injectivity hypothesis holds;
+  \item the open-boundary-condition (OBC) canonical representation of the MPS
+    state is unique;
   \item the length satisfies \(N > 2L_0 + D^4\).
 \end{enumerate}
 The conclusion is the existence of a unitary matrix \(U\) such that
@@ -43,10 +53,10 @@ comparison results. Their hypotheses include blockwise normalization, injective
 or irreducible block hypotheses, a common block index set and dimension
 function, and strict ordering of the weight moduli.\footnote{The corresponding
 formal declarations are
-\path{MPSTensor.per_block_sameMPV_of_canonical_form},
-\path{MPSTensor.per_block_sameMPV_of_normal_canonical_form},
-\path{MPSTensor.fundamentalTheorem_canonicalForm}, and
-\path{MPSTensor.fundamentalTheorem_canonicalForm_explicit}.}
+\leanid{MPSTensor.per\_block\_sameMPV\_of\_\allowbreak canonical\_form},
+\leanid{MPSTensor.per\_block\_sameMPV\_of\_\allowbreak normal\_canonical\_form},
+\leanid{MPSTensor.fundamentalTheorem\_\allowbreak canonicalForm}, and
+\leanid{MPSTensor.fundamentalTheorem\_\allowbreak canonicalForm\_explicit}.}
 
 These assumptions are useful local inputs for later MPS arguments, but they are
 not the hypothesis set of the PGVWC07 uniqueness theorem. In particular, the
@@ -64,8 +74,8 @@ cited as formalizations of that source theorem.
 \section{Required formalization}
 
 A source-faithful formalization of PGVWC07 Theorem~\texttt{thm-uniq} should
-state the finite-ring hypotheses C1, uniqueness of the OBC canonical
-representation, and \(N > 2L_0 + D^4\), and should conclude a single unitary
+state the finite-ring injectivity hypothesis above, uniqueness of the OBC
+canonical representation, and \(N > 2L_0 + D^4\), and should conclude a single unitary
 intertwiner between the two TI canonical \(D\)-MPS representations. The current
 Chapter~9 block-separation lemmas may be used only as local consequences after
 their stronger hypotheses have been proved in the argument at hand.
@@ -75,8 +85,8 @@ their stronger hypotheses have been proved in the argument at hand.
 Blueprint statements that point to Chapter~9 block separation must explicitly
 state the strict weight-modulus hypothesis when their Lean declarations require
 it. Downstream CPSV16 uses should not cite these statements as PGVWC07
-canonical-form uniqueness unless the C1, OBC uniqueness, finite-size bound, and
-unitary-conclusion theorem have been formalized separately.
+canonical-form uniqueness unless the finite-injectivity, OBC uniqueness,
+finite-size-bound, and unitary-conclusion theorem have been formalized separately.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
@@ -5,7 +5,7 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
-\input{./command}
+\input{command}
 
 \title{Scope of the Formal Block-Separation Lemmas Relative to PGVWC07 Uniqueness}
 \author{}

--- a/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
@@ -1,0 +1,72 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{./command}
+
+\title{Scope of the Formal Block-Separation Lemmas Relative to PGVWC07 Uniqueness}
+\author{}
+\date{2026-05-12}
+
+\begin{document}
+\maketitle
+
+\section{Source theorem}
+
+The translation-invariant canonical-form uniqueness theorem of
+P\'erez-Garc\'ia, Verstraete, Wolf, and Cirac starts with two TI canonical
+\(D\)-MPS representations of the same finite-ring state
+\cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007MPSReps}.
+Its hypotheses are:
+\begin{enumerate}
+  \item condition C1 holds;
+  \item the OBC canonical representation is unique;
+  \item the length satisfies \(N > 2L_0 + D^4\).
+\end{enumerate}
+The conclusion is the existence of a unitary matrix \(U\) such that
+\[
+  B_i = U C_i U^\dagger
+\]
+for every physical index \(i\), with the usual permutation-and-phase
+interpretation when the Schmidt weights are non-degenerate.
+
+\section{Formal boundary}
+
+The checked block-separation lemmas in Chapter~9 are not formalizations of
+PGVWC07 Theorem~\texttt{thm-uniq}. They are conditional same-structure
+comparison results. Their hypotheses include blockwise normalization, injective
+or irreducible block hypotheses, a common block index set and dimension
+function, and strict ordering of the weight moduli.
+
+These assumptions are useful local inputs for later MPS arguments, but they are
+not the hypothesis set of the PGVWC07 uniqueness theorem. In particular, the
+source theorem does not assume a same-structure block decomposition of the two
+representations, nor does it assume the Chapter~9 strict-modulus separation
+lemma as an input. Its proof uses the OBC canonical representation and the
+Horn--Johnson matrix lemma route described after
+\cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007MPSReps}.
+
+\section{Required formalization}
+
+A source-faithful formalization of PGVWC07 Theorem~\texttt{thm-uniq} should
+state the finite-ring hypotheses C1, uniqueness of the OBC canonical
+representation, and \(N > 2L_0 + D^4\), and should conclude a single unitary
+intertwiner between the two TI canonical \(D\)-MPS representations. The current
+Chapter~9 block-separation lemmas may be used only as local consequences after
+their stronger hypotheses have been proved in the argument at hand.
+
+\section{Tracked consequences}
+
+Blueprint statements that point to Chapter~9 block separation must explicitly
+state the strict weight-modulus hypothesis when their Lean declarations require
+it. Downstream CPSV16 uses should not cite these statements as PGVWC07
+canonical-form uniqueness unless the C1, OBC uniqueness, finite-size bound, and
+unitary-conclusion theorem have been formalized separately.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
@@ -22,7 +22,9 @@ P\'erez-Garc\'ia, Verstraete, Wolf, and Cirac starts with two TI canonical
 \cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007MPSReps}.
 Its hypotheses are:
 \begin{enumerate}
-  \item condition C1 holds;
+  \item condition C1 holds: there is a finite length \(L_0\) for which
+    \(\Gamma_{L_0}\) is injective
+    \cite[lines~888--908]{PerezGarcia2007MPSReps};
   \item the OBC canonical representation is unique;
   \item the length satisfies \(N > 2L_0 + D^4\).
 \end{enumerate}
@@ -39,7 +41,12 @@ The checked block-separation lemmas in Chapter~9 are not formalizations of
 PGVWC07 Theorem~\texttt{thm-uniq}. They are conditional same-structure
 comparison results. Their hypotheses include blockwise normalization, injective
 or irreducible block hypotheses, a common block index set and dimension
-function, and strict ordering of the weight moduli.
+function, and strict ordering of the weight moduli.\footnote{The corresponding
+formal declarations are
+\path{MPSTensor.per_block_sameMPV_of_canonical_form},
+\path{MPSTensor.per_block_sameMPV_of_normal_canonical_form},
+\path{MPSTensor.fundamentalTheorem_canonicalForm}, and
+\path{MPSTensor.fundamentalTheorem_canonicalForm_explicit}.}
 
 These assumptions are useful local inputs for later MPS arguments, but they are
 not the hypothesis set of the PGVWC07 uniqueness theorem. In particular, the
@@ -48,6 +55,11 @@ representations, nor does it assume the Chapter~9 strict-modulus separation
 lemma as an input. Its proof uses the OBC canonical representation and the
 Horn--Johnson matrix lemma route described after
 \cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007MPSReps}.
+
+Thus this is a theorem-level gap. PGVWC07 Theorem~\texttt{thm-uniq} is not
+currently formalized. The available formal lemmas are conditional
+same-structure consequences with stronger hypotheses, and therefore must not be
+cited as formalizations of that source theorem.
 
 \section{Required formalization}
 


### PR DESCRIPTION
## Summary

This PR addresses part of #1628 under the PGVWC07 faithfulness audit #1613.

It clarifies that Chapter 9 block-separation and same-structure comparison statements are conditional local lemmas, not formalizations of PGVWC07 `thm-uniq`. It also amends the affected blueprint statements so their strict weight-modulus hypothesis is explicit, matching the Lean declarations.

## Changes

- Update `blueprint/src/chapter/ch09_block_perm.tex`:
  - revise the Chapter 9 opening paragraph;
  - add a remark distinguishing PGVWC07 `Th:TIcanonical` from the local canonical-form predicates;
  - add strict weight-modulus hypotheses to `lem:block_sep_core`, `lem:block_sep`, `lem:block_sep_normal`, and `lem:ft_canonical` prose.
- Add `docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex` documenting why the checked Chapter 9 lemmas are not PGVWC07 `thm-uniq`.

## Verification

- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web`
- `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode pgvwc07_ti_uniqueness_scope.tex`
- `git diff --check`

The generated `docs/paper-gaps/pgvwc07_ti_uniqueness_scope.pdf` exists locally for reading; paper-gap PDFs are ignored by repository policy and are not committed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/blueprint text updates only, clarifying assumptions and literature scope without changing Lean code or algorithms.
> 
> **Overview**
> Clarifies in `ch09_block_perm.tex` that Chapter 9’s block-separation and same-structure comparison statements are *conditional* lemmas and **not** a formalization of PGVWC07 translation-invariant canonical-form uniqueness (`thm-uniq`).
> 
> Makes the strict weight-modulus separation assumption explicit in the prose of the block-separation lemmas (and related gauge-comparison lemma) and adds a remark contrasting the PGVWC07 canonical-form construction theorem with the local predicates used here.
> 
> Adds a new paper-gap note `docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex` documenting the hypothesis/conclusion mismatch and what would be required for a source-faithful formalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e05688a71e7c8c49cf7c518fee1afc01d3b411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->