### PR TITLE
feat(MPS/FT): record leading proportional peeling data

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -6,6 +6,7 @@ import TNLean.MPS.FundamentalTheorem.Full.BlocksMatch
 import TNLean.MPS.FundamentalTheorem.Full.FixedBlockSingleton
 import TNLean.MPS.FundamentalTheorem.Full.LeadingPartner
 import TNLean.MPS.FundamentalTheorem.Full.ProportionalTail
+import TNLean.MPS.FundamentalTheorem.Full.LeadingTail
 
 /-!
 # Heterogeneous BNT block matching
@@ -57,6 +58,8 @@ The proof is split across supporting sub-modules for readability:
 * `TNLean.MPS.FundamentalTheorem.Full.ProportionalTail` — asymptotic erased-tail
   cancellation obtained from the phase-adjusted selected-summand cancellation and the
   full proportionality identity.
+* `TNLean.MPS.FundamentalTheorem.Full.LeadingTail` — leading phase relation
+  and leading-erased tail asymptotics for proportional peeling.
 * `TNLean.MPS.FundamentalTheorem.Full.BlocksMatch` — Layer 1b,
   `blocks_match_of_sameMPV₂_CFBNT`, which converts the non-decaying overlap data into a
   full `BlockPermutationGaugePhaseConclusion` via the overlap dichotomy.

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.Full.BlocksMatch
 import TNLean.MPS.FundamentalTheorem.Full.FixedBlockSingleton
+import TNLean.MPS.FundamentalTheorem.Full.LeadingPartner
 import TNLean.MPS.FundamentalTheorem.Full.ProportionalTail
 
 /-!
@@ -51,6 +52,8 @@ The proof is split across supporting sub-modules for readability:
   dominant-weight projection argument.
 * `TNLean.MPS.FundamentalTheorem.Full.FixedBlockSingleton` — no-tail fixed-block
   cancellation base cases for the CPSV16 Lemma `Lem1` peeling step.
+* `TNLean.MPS.FundamentalTheorem.Full.LeadingPartner` — leading-block
+  partner identification for the proportional peeling argument.
 * `TNLean.MPS.FundamentalTheorem.Full.ProportionalTail` — asymptotic erased-tail
   cancellation obtained from the phase-adjusted selected-summand cancellation and the
   full proportionality identity.

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.FundamentalTheorem.Full.BlocksMatch
 import TNLean.MPS.FundamentalTheorem.Full.FixedBlockSingleton
 import TNLean.MPS.FundamentalTheorem.Full.LeadingPartner
-import TNLean.MPS.FundamentalTheorem.Full.ProportionalTail
 import TNLean.MPS.FundamentalTheorem.Full.LeadingTail
+import TNLean.MPS.FundamentalTheorem.Full.ProportionalTail
 
 /-!
 # Heterogeneous BNT block matching
@@ -55,11 +55,11 @@ The proof is split across supporting sub-modules for readability:
   cancellation base cases for the CPSV16 Lemma `Lem1` peeling step.
 * `TNLean.MPS.FundamentalTheorem.Full.LeadingPartner` — leading-block
   partner identification for the proportional peeling argument.
+* `TNLean.MPS.FundamentalTheorem.Full.LeadingTail` — leading phase relation
+  and leading-erased tail asymptotics for proportional peeling.
 * `TNLean.MPS.FundamentalTheorem.Full.ProportionalTail` — asymptotic erased-tail
   cancellation obtained from the phase-adjusted selected-summand cancellation and the
   full proportionality identity.
-* `TNLean.MPS.FundamentalTheorem.Full.LeadingTail` — leading phase relation
-  and leading-erased tail asymptotics for proportional peeling.
 * `TNLean.MPS.FundamentalTheorem.Full.BlocksMatch` — Layer 1b,
   `blocks_match_of_sameMPV₂_CFBNT`, which converts the non-decaying overlap data into a
   full `BlockPermutationGaugePhaseConclusion` via the overlap dichotomy.

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -6,7 +6,6 @@ import TNLean.MPS.FundamentalTheorem.Full.BlocksMatch
 import TNLean.MPS.FundamentalTheorem.Full.FixedBlockSingleton
 import TNLean.MPS.FundamentalTheorem.Full.LeadingPartner
 import TNLean.MPS.FundamentalTheorem.Full.LeadingTail
-import TNLean.MPS.FundamentalTheorem.Full.ProportionalTail
 
 /-!
 # Heterogeneous BNT block matching

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -54,11 +54,11 @@ The proof is split across supporting sub-modules for readability:
   cancellation base cases for the CPSV16 Lemma `Lem1` peeling step.
 * `TNLean.MPS.FundamentalTheorem.Full.LeadingPartner` — leading-block
   partner identification for the proportional peeling argument.
-* `TNLean.MPS.FundamentalTheorem.Full.LeadingTail` — leading phase relation
-  and leading-erased tail asymptotics for proportional peeling.
 * `TNLean.MPS.FundamentalTheorem.Full.ProportionalTail` — asymptotic erased-tail
   cancellation obtained from the phase-adjusted selected-summand cancellation and the
   full proportionality identity.
+* `TNLean.MPS.FundamentalTheorem.Full.LeadingTail` — leading phase relation
+  and leading-erased tail asymptotics for proportional peeling.
 * `TNLean.MPS.FundamentalTheorem.Full.BlocksMatch` — Layer 1b,
   `blocks_match_of_sameMPV₂_CFBNT`, which converts the non-decaying overlap data into a
   full `BlockPermutationGaugePhaseConclusion` via the overlap dichotomy.

--- a/TNLean/MPS/FundamentalTheorem/Full/LeadingPartner.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/LeadingPartner.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.Full.NondecayingPartnerUnique
+
+/-!
+# Leading non-decaying partners for proportional BNT families
+
+This module records the first partner-identification step in the CPSV16
+proportional fundamental theorem argument.
+
+## References
+
+* Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017),
+  Theorem `thm1`, lines 1170--1192.
+-/
+
+open scoped Matrix BigOperators InnerProductSpace
+open Filter
+
+namespace MPSTensor
+
+section LeadingPartner
+
+/-- **The leading right block can only have the leading left block as non-decaying partner.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. Before peeling
+the dominant pair, the source argument first identifies a non-decaying partner
+of the fixed leading block. In the restricted one-copy-per-sector BNT setting,
+strict ordering of the weights forces such a partner for the leading `B`-block
+to be the leading `A`-block.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
+lemma leading_right_nondecaying_partner_eq_leading_left_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (j₁ : Fin rA)
+    (hnd : ¬ Tendsto
+      (fun N => mpvOverlap (d := d) (A j₁) (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N)
+      atTop (nhds 0)) :
+    j₁ = ⟨0, Nat.pos_of_ne_zero hrA⟩ := by
+  classical
+  let a0 : Fin rA := ⟨0, Nat.pos_of_ne_zero hrA⟩
+  let b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
+  by_contra hj₁_ne
+  have hA_self : ∀ j : Fin rA,
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (A j) N) atTop (nhds 1) :=
+    hA.toHasNormalizedSelfOverlap.overlap_tendsto_one
+  have hB_self : ∀ k : Fin rB,
+      Tendsto (fun N => mpvOverlap (d := d) (B k) (B k) N) atTop (nhds 1) :=
+    hB.toHasNormalizedSelfOverlap.overlap_tendsto_one
+  have hB_inner : ∀ k : Fin rB,
+      Tendsto (fun N => mpvInner (d := d) (B k) (B k) N) atTop (nhds 1) :=
+    fun k => tendsto_inner_one (B k) (hB_self k)
+  have hB_cross_inner : ∀ k l : Fin rB, k ≠ l →
+      Tendsto (fun N => mpvInner (d := d) (B k) (B l) N) atTop (nhds 0) :=
+    fun k l hkl => tendsto_inner_zero (B k) (B l) (hB.cross_overlap_tendsto_zero k l hkl)
+  have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
+  have hμB_ne : μB b0 ≠ 0 := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero b0
+  obtain ⟨c, _hc, hState, hAdjusted⟩ :=
+    exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hProp
+  have hWeightedInner :
+      ∀ᶠ N in atTop,
+        (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N) =
+          c N * (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N) :=
+    eventually_weighted_mpvInner_eq_mul_sequence_of_eventually_weighted_mpvState_eq_smul_sequence
+      A B c hState (B b0)
+  have hNormInner :
+      ∀ᶠ N in atTop,
+        (μA a0 ^ N)⁻¹ *
+            (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N) =
+          (c N * (μB b0 / μA a0) ^ N) *
+            ((μB b0 ^ N)⁻¹ *
+              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N)) := by
+    refine hWeightedInner.mono ?_
+    intro N hN
+    let S : ℂ := ∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N
+    rw [hN]
+    change (μA a0 ^ N)⁻¹ * (c N * S) =
+      (c N * (μB b0 / μA a0) ^ N) * ((μB b0 ^ N)⁻¹ * S)
+    calc
+      (μA a0 ^ N)⁻¹ * (c N * S) = ((μA a0 ^ N)⁻¹ * c N) * S := by ring
+      _ = ((c N * (μB b0 / μA a0) ^ N) * (μB b0 ^ N)⁻¹) * S := by
+        rw [adjusted_scalar_factor_eq (c N) (μA a0) (μB b0) N hμA_ne hμB_ne]
+      _ = (c N * (μB b0 / μA a0) ^ N) * ((μB b0 ^ N)⁻¹ * S) := by ring
+  have huniq : ∀ j : Fin rA, j ≠ j₁ →
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (B b0) N) atTop (nhds 0) := by
+    intro j hj
+    by_contra hnot
+    exact hj (unique_left_nondecaying_overlap_partner_CFBNT A B hA hB b0 j j₁ hnot hnd)
+  have hLHS_zero :
+      Tendsto
+        (fun N : ℕ =>
+          (μA a0 ^ N)⁻¹ *
+            (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N))
+        atTop (nhds (0 : ℂ)) := by
+    have hsplit : ∀ N,
+        (μA a0 ^ N)⁻¹ *
+            (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N) =
+          (μA a0 ^ N)⁻¹ *
+              ((μA j₁) ^ N * mpvInner (d := d) (B b0) (A j₁) N) +
+            (μA a0 ^ N)⁻¹ *
+              (∑ j ∈ Finset.univ.erase j₁,
+                (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N) := by
+      intro N
+      rw [← Finset.add_sum_erase _ _ (Finset.mem_univ j₁), mul_add]
+    simp_rw [hsplit]
+    have h_j₁ :
+        Tendsto
+          (fun N : ℕ =>
+            (μA a0 ^ N)⁻¹ *
+              ((μA j₁) ^ N * mpvInner (d := d) (B b0) (A j₁) N))
+          atTop (nhds (0 : ℂ)) := by
+      have hRatio : ‖μA j₁ / μA a0‖ < 1 := by
+        rw [norm_div]
+        exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
+          (hA.mu_strict_anti (by
+            simp only [a0, Fin.lt_def]
+            exact Nat.pos_of_ne_zero (fun h => hj₁_ne (Fin.ext h))))
+      convert geometric_mul_inner_tendsto_zero (μA j₁ / μA a0) (B b0) (A j₁)
+        hRatio (hB_self b0) (hA_self j₁) using 1
+      ext N
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμA_ne]
+    have h_rest :
+        Tendsto
+          (fun N : ℕ =>
+            (μA a0 ^ N)⁻¹ *
+              (∑ j ∈ Finset.univ.erase j₁,
+                (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N))
+          atTop (nhds (0 : ℂ)) := by
+      have hsum :
+          Tendsto
+            (fun N : ℕ =>
+              ∑ j ∈ Finset.univ.erase j₁,
+                (μA j / μA a0) ^ N * mpvInner (d := d) (B b0) (A j) N)
+            atTop (nhds (0 : ℂ)) := by
+        have := tendsto_finset_sum (Finset.univ.erase j₁)
+          (fun (j : Fin rA) (hj : j ∈ Finset.univ.erase j₁) =>
+            show Tendsto _ atTop (nhds (0 : ℂ)) from
+            bounded_mul_tendsto_zero (μA j / μA a0)
+              (fun N => mpvInner (d := d) (B b0) (A j) N) (by
+                rw [norm_div]
+                exact (div_le_one (norm_pos_iff.mpr hμA_ne)).mpr
+                  (hA.toIsCanonicalForm.mu_antitone
+                    (show a0 ≤ j from Fin.mk_le_mk.mpr (Nat.zero_le _))))
+              (tendsto_inner_zero_swap (d := d) (A j) (B b0)
+                (huniq j (Finset.ne_of_mem_erase hj))))
+        simpa using this
+      convert hsum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμA_ne]
+    convert h_j₁.add h_rest using 1
+    simp
+  have hRHS_norm_one :
+      Tendsto
+        (fun N : ℕ =>
+          ‖(c N * (μB b0 / μA a0) ^ N) *
+            ((μB b0 ^ N)⁻¹ *
+              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N))‖)
+        atTop (nhds (1 : ℝ)) := by
+    have hB_proj :
+        Tendsto
+          (fun N : ℕ =>
+            (μB b0 ^ N)⁻¹ *
+              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N))
+          atTop (nhds (1 : ℂ)) := by
+      have hsum :
+          Tendsto
+            (fun N : ℕ =>
+              ∑ k : Fin rB, (μB k / μB b0) ^ N *
+                mpvInner (d := d) (B b0) (B k) N)
+            atTop (nhds (1 : ℂ)) :=
+        sum_tendsto_one_of_diag (hμ0 := hμB_ne) (j0 := b0) rfl (hB_inner b0)
+          (fun k hk => by
+            rw [norm_div]
+            exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
+              (hB.mu_strict_anti (by
+                simp only [b0, Fin.lt_def]
+                exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h)))))
+          (fun k hk => hB_cross_inner b0 k hk.symm)
+      convert hsum using 1
+      ext N
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [div_pow]
+      field_simp [pow_ne_zero N hμB_ne]
+    simpa [norm_mul] using hAdjusted.mul hB_proj.norm
+  have hLHS_norm_zero :
+      Tendsto
+        (fun N : ℕ =>
+          ‖(μA a0 ^ N)⁻¹ *
+            (∑ j : Fin rA, (μA j) ^ N * mpvInner (d := d) (B b0) (A j) N)‖)
+        atTop (nhds (0 : ℝ)) := by
+    simpa using hLHS_zero.norm
+  have hRHS_norm_zero :
+      Tendsto
+        (fun N : ℕ =>
+          ‖(c N * (μB b0 / μA a0) ^ N) *
+            ((μB b0 ^ N)⁻¹ *
+              (∑ k : Fin rB, (μB k) ^ N * mpvInner (d := d) (B b0) (B k) N))‖)
+        atTop (nhds (0 : ℝ)) := by
+    refine Tendsto.congr' ?_ hLHS_norm_zero
+    filter_upwards [hNormInner] with N hN
+    rw [hN]
+  exact zero_ne_one (tendsto_nhds_unique hRHS_norm_zero hRHS_norm_one)
+
+end LeadingPartner
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/Full/LeadingPartner.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/LeadingPartner.lean
@@ -14,7 +14,7 @@ proportional fundamental theorem argument.
 
 * Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
   Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017),
-  Theorem `thm1`, lines 1170--1192.
+  Theorem II.1, lines 1170--1192.
 -/
 
 open scoped Matrix BigOperators InnerProductSpace
@@ -26,7 +26,7 @@ section LeadingPartner
 
 /-- **The leading right block can only have the leading left block as non-decaying partner.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. Before peeling
+Source context: arXiv:1606.00608, Theorem II.1, line 1182. Before peeling
 the dominant pair, the source argument first identifies a non-decaying partner
 of the fixed leading block. In the restricted one-copy-per-sector BNT setting,
 strict ordering of the weights forces such a partner for the leading `B`-block

--- a/TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.Full.LeadingPartner
+import TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap
+import TNLean.MPS.FundamentalTheorem.Full.ProportionalTail
+
+/-!
+# Leading phase relation and erased-tail asymptotics
+
+This module records the leading peeling data obtained from eventual
+proportionality of two restricted BNT block families.
+
+## References
+
+* Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017),
+  Theorem `thm1`, line 1182.
+-/
+
+open scoped Matrix BigOperators InnerProductSpace
+open Filter
+
+namespace MPSTensor
+
+section LeadingTail
+
+/-- **Leading phase relation and leading-erased tail asymptotic.**
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After the leading
+`B`-block has been shown to have a non-decaying overlap with some `A`-block,
+the leading-partner lemma identifies that block as the leading `A`-block.
+Corollary `eqV` then supplies the phase relation used to start the peeling
+argument, and the selected-summand cancellation gives the leading-erased tail
+asymptotic.
+
+The conclusion keeps the proportionality scalar sequence for the assembled
+weighted sums together with the normalized leading-tail estimate.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
+lemma exists_leading_phase_tail_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
+    ∃ (ζ : ℂ) (c : ℕ → ℂ),
+      ‖ζ‖ = 1 ∧
+      (∀ N : ℕ,
+        mpvState (d := d) (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N =
+          ζ ^ N • mpvState (d := d) (A ⟨0, Nat.pos_of_ne_zero hrA⟩) N) ∧
+      (∀ᶠ N in atTop, c N ≠ 0) ∧
+      (∀ᶠ N in atTop,
+        (∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N) =
+          c N • (∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N)) ∧
+      Tendsto
+        (fun N : ℕ =>
+          ‖(μA ⟨0, Nat.pos_of_ne_zero hrA⟩ ^ N)⁻¹ •
+            ((∑ j ∈ Finset.univ.erase ⟨0, Nat.pos_of_ne_zero hrA⟩,
+                (μA j) ^ N • mpvState (d := d) (A j) N) -
+              c N •
+                (∑ k ∈ Finset.univ.erase ⟨0, Nat.pos_of_ne_zero hrB⟩,
+                  (μB k) ^ N • mpvState (d := d) (B k) N))‖)
+        atTop (nhds (0 : ℝ)) := by
+  classical
+  let a0 : Fin rA := ⟨0, Nat.pos_of_ne_zero hrA⟩
+  let b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
+  have hnd_exists : ∃ j : Fin rA,
+      ¬ Tendsto (fun N => mpvOverlap (d := d) (A j) (B b0) N) atTop (nhds 0) := by
+    by_contra h
+    push Not at h
+    exact fixed_right_leading_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hProp (by simpa [b0] using h)
+  obtain ⟨j, hnd⟩ := hnd_exists
+  have hj : j = a0 :=
+    leading_right_nondecaying_partner_eq_leading_left_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hProp j (by simpa [b0] using hnd)
+  subst j
+  have hnd0 : ¬ Tendsto (fun N => mpvOverlap (d := d) (A a0) (B b0) N) atTop (nhds 0) := by
+    simpa using hnd
+  obtain ⟨ζ, hζ, hPhase⟩ :=
+    exists_phase_mpvState_eq_smul_of_nondecaying_overlap_CFBNT
+      A B hA hB a0 b0 hnd0
+  obtain ⟨c, hc, hState, hTail⟩ :=
+    exists_dominant_tail_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hζ (by simpa [a0, b0] using hPhase) hProp
+  exact ⟨ζ, c, hζ, by simpa [a0, b0] using hPhase, hc, hState, hTail⟩
+
+end LeadingTail
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean
@@ -16,7 +16,7 @@ proportionality of two restricted BNT block families.
 
 * Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
   Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017),
-  Theorem `thm1`, line 1182.
+  Theorem II.1, line 1182.
 -/
 
 open scoped Matrix BigOperators InnerProductSpace
@@ -28,10 +28,10 @@ section LeadingTail
 
 /-- **Leading phase relation and leading-erased tail asymptotic.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After the leading
+Source context: arXiv:1606.00608, Theorem II.1, line 1182. After the leading
 `B`-block has been shown to have a non-decaying overlap with some `A`-block,
 the leading-partner lemma identifies that block as the leading `A`-block.
-Corollary `eqV` then supplies the phase relation used to start the peeling
+Corollary eqV then supplies the phase relation used to start the peeling
 argument, and the selected-summand cancellation gives the leading-erased tail
 asymptotic.
 

--- a/TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean
@@ -31,9 +31,10 @@ section LeadingTail
 Source context: arXiv:1606.00608, Theorem II.1, line 1182. After the leading
 `B`-block has been shown to have a non-decaying overlap with some `A`-block,
 the leading-partner lemma identifies that block as the leading `A`-block.
-Corollary eqV then supplies the phase relation used to start the peeling
-argument, and the selected-summand cancellation gives the leading-erased tail
-asymptotic.
+The non-decaying-overlap phase theorem then gives the relation
+that the MPV state of B_0 at length N is ζ^N times the MPV state of
+A_0; this starts the peeling argument, and the selected-summand cancellation
+gives the leading-erased tail asymptotic.
 
 The conclusion keeps the proportionality scalar sequence for the assembled
 weighted sums together with the normalized leading-tail estimate.

--- a/TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean
@@ -9,8 +9,9 @@ import TNLean.MPS.FundamentalTheorem.Full.ProportionalTail
 /-!
 # Leading phase relation and erased-tail asymptotics
 
-This module records the leading peeling data obtained from eventual
-proportionality of two restricted BNT block families.
+This module records the leading phase relation and leading-erased tail
+asymptotic obtained from eventual proportionality of two restricted BNT block
+families.
 
 ## References
 

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1009,7 +1009,7 @@ with an extra $Z$-gauge degree of freedom.
 \label{lem:leading_phase_tail_difference_eventual_proportional}
 	\lean{MPSTensor.exists_leading_phase_tail_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
 	\leanok
-	\uses{lem:dominant_nondecaying_partner_eventual_proportional,
+	\uses{lem:fixed_right_leading_all_overlaps_decay_contradiction,
 		lem:leading_right_partner_is_leading_left_eventual_proportional,
 		lem:bnt_nondecaying_overlap_mpv_phase,
 		lem:dominant_phase_adjusted_tail_difference}
@@ -1025,7 +1025,8 @@ with an extra $Z$-gauge degree of freedom.
 \end{lemma}
 
 \begin{proof}\leanok
-	The dominant-block contradiction gives a non-decaying partner for \(B_0\).
+	The leading all-overlaps-decay contradiction for \(B_0\) gives a
+	non-decaying partner for \(B_0\).
 	The leading-partner lemma identifies it with \(A_0\), and the
 	non-decaying-overlap phase lemma gives the displayed phase relation.  The
 	dominant tail-difference lemma then applies to the phase-matched leading

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -948,6 +948,28 @@ with an extra $Z$-gauge degree of freedom.
 	Lemma~\ref{lem:dominant_projection_contradiction_eventual_proportional}.
 \end{proof}
 
+\begin{lemma}[Leading right partner is the leading left block]%
+\label{lem:leading_right_partner_is_leading_left_eventual_proportional}
+	\lean{MPSTensor.leading_right_nondecaying_partner_eq_leading_left_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
+	\leanok
+	\uses{lem:dominant_projection_contradiction_eventual_proportional,
+		lem:bnt_nondecaying_partner_unique}
+	Under eventual nonzero proportionality of the assembled BNT block tensors,
+	if the leading block \(B_0\) has non-decaying overlap with some block
+	\(A_j\), then \(j=0\).  Thus the leading \(B\)-block can only be matched
+	with the leading \(A\)-block in the first peeling step.
+	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	If \(j\neq 0\), uniqueness of the non-decaying partner of \(B_0\) makes every
+	other \(A\)-overlap with \(B_0\) decay.  Project the eventual proportional
+	weighted-sum identity against \(B_0\) and normalize by the leading
+	\(A\)-weight.  The \(A_j\)-term is suppressed by strict dominance of
+	\(|\mu_0|\), while the normalized \(B_0\)-projection on the \(B\)-side has
+	norm tending to \(1\), contradicting the adjusted-scalar projection identity.
+\end{proof}
+
 \begin{lemma}[Non-decaying BNT overlap gives a gauge phase]%
 \label{lem:bnt_nondecaying_overlap_gauge_phase}
 	\lean{MPSTensor.dim_eq_of_nondecaying_overlap_CFBNT,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -952,7 +952,7 @@ with an extra $Z$-gauge degree of freedom.
 \label{lem:leading_right_partner_is_leading_left_eventual_proportional}
 	\lean{MPSTensor.leading_right_nondecaying_partner_eq_leading_left_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
 	\leanok
-	\uses{lem:dominant_projection_contradiction_eventual_proportional,
+	\uses{lem:dominant_adjusted_scalar_norm,
 		lem:bnt_nondecaying_partner_unique}
 	Under eventual nonzero proportionality of the assembled BNT block tensors,
 	if some block \(A_j\) has non-decaying overlap with the leading block

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -955,8 +955,8 @@ with an extra $Z$-gauge degree of freedom.
 	\uses{lem:dominant_projection_contradiction_eventual_proportional,
 		lem:bnt_nondecaying_partner_unique}
 	Under eventual nonzero proportionality of the assembled BNT block tensors,
-	if the leading block \(B_0\) has non-decaying overlap with some block
-	\(A_j\), then \(j=0\).  Thus the leading \(B\)-block can only be matched
+	if some block \(A_j\) has non-decaying overlap with the leading block
+	\(B_0\), then \(j=0\).  Thus the leading \(B\)-block can only be matched
 	with the leading \(A\)-block in the first peeling step.
 	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
 \end{lemma}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1005,6 +1005,33 @@ with an extra $Z$-gauge degree of freedom.
 	\(\zeta^N\); normalized self-overlap convergence gives \(|\zeta|=1\).
 \end{proof}
 
+\begin{lemma}[Leading phase relation gives leading-erased tail asymptotics]%
+\label{lem:leading_phase_tail_difference_eventual_proportional}
+	\lean{MPSTensor.exists_leading_phase_tail_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
+	\leanok
+	\uses{lem:dominant_nondecaying_partner_eventual_proportional,
+		lem:leading_right_partner_is_leading_left_eventual_proportional,
+		lem:bnt_nondecaying_overlap_mpv_phase,
+		lem:dominant_phase_adjusted_tail_difference}
+	Under eventual nonzero proportionality of the assembled BNT block tensors,
+	there is a unit complex number \(\zeta\) such that
+	\[
+		\ket{V^{(N)}(B_0)}=\zeta^N\ket{V^{(N)}(A_0)}
+	\]
+	for all \(N\), and the corresponding leading-erased weighted tails have
+	normalized difference tending to \(0\).  The scalar sequence is the same
+	eventual proportionality sequence for the assembled weighted MPV sums.
+	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	The dominant-block contradiction gives a non-decaying partner for \(B_0\).
+	The leading-partner lemma identifies it with \(A_0\), and the
+	non-decaying-overlap phase lemma gives the displayed phase relation.  The
+	dominant tail-difference lemma then applies to the phase-matched leading
+	pair.
+\end{proof}
+
 \begin{lemma}[Non-decaying BNT partners are unique]%
 \label{lem:bnt_nondecaying_partner_unique}
 	\lean{MPSTensor.unique_left_nondecaying_overlap_partner_CFBNT,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -952,16 +952,18 @@ with an extra $Z$-gauge degree of freedom.
 \label{lem:leading_right_partner_is_leading_left_eventual_proportional}
 	\lean{MPSTensor.leading_right_nondecaying_partner_eq_leading_left_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
 	\leanok
-	\uses{lem:dominant_adjusted_scalar_norm,
-		lem:bnt_nondecaying_partner_unique}
-	Under eventual nonzero proportionality of the assembled BNT block tensors,
-	if some block \(A_j\) has non-decaying overlap with the leading block
-	\(B_0\), then \(j=0\).  Thus the leading \(B\)-block can only be matched
-	with the leading \(A\)-block in the first peeling step.
+	Let \((\mu^A_j,A_j)\) and \((\mu^B_k,B_k)\) be nonempty one-copy BNT
+	canonical-form families.  Under eventual nonzero proportionality of the
+	assembled BNT block tensors, if some block \(A_j\) has non-decaying overlap
+	with the leading block \(B_0\), then \(j=0\).  Thus the leading
+	\(B\)-block can only be matched with the leading \(A\)-block in the first
+	peeling step.
 	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
+	\uses{lem:dominant_adjusted_scalar_norm,
+		lem:bnt_nondecaying_partner_unique}
 	If \(j\neq 0\), uniqueness of the non-decaying partner of \(B_0\) makes every
 	other \(A\)-overlap with \(B_0\) decay.  Project the eventual proportional
 	weighted-sum identity against \(B_0\) and normalize by the leading
@@ -1009,12 +1011,9 @@ with an extra $Z$-gauge degree of freedom.
 \label{lem:leading_phase_tail_difference_eventual_proportional}
 	\lean{MPSTensor.exists_leading_phase_tail_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT}
 	\leanok
-	\uses{lem:fixed_right_leading_all_overlaps_decay_contradiction,
-		lem:leading_right_partner_is_leading_left_eventual_proportional,
-		lem:bnt_nondecaying_overlap_mpv_phase,
-		lem:dominant_phase_adjusted_tail_difference}
-	Under eventual nonzero proportionality of the assembled BNT block tensors,
-	there is a unit complex number \(\zeta\) such that
+	Let \((\mu^A_j,A_j)\) and \((\mu^B_k,B_k)\) be nonempty one-copy BNT
+	canonical-form families.  Under eventual nonzero proportionality of the
+	assembled BNT block tensors, there is a unit complex number \(\zeta\) such that
 	\[
 		\ket{V^{(N)}(B_0)}=\zeta^N\ket{V^{(N)}(A_0)}
 	\]
@@ -1025,6 +1024,10 @@ with an extra $Z$-gauge degree of freedom.
 \end{lemma}
 
 \begin{proof}\leanok
+	\uses{lem:fixed_right_leading_all_overlaps_decay_contradiction,
+		lem:leading_right_partner_is_leading_left_eventual_proportional,
+		lem:bnt_nondecaying_overlap_mpv_phase,
+		lem:dominant_phase_adjusted_tail_difference}
 	The leading all-overlaps-decay contradiction for \(B_0\) gives a
 	non-decaying partner for \(B_0\).
 	The leading-partner lemma identifies it with \(A_0\), and the

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -93,6 +93,19 @@ a preparatory step: it identifies the pair eligible for dominant tail
 subtraction, but it does not by itself prove the arbitrary fixed-block
 cancellation statements.
 
+The resulting leading phase relation and asymptotic leading-tail estimate are
+recorded in:
+\begin{flushleft}\small
+\leanid{MPSTensor.exists\_leading\_phase\_tail\_diff\_tendsto\_zero}\\
+\leanid{\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}.
+\end{flushleft}
+This lemma supplies the phase relation for \(A_0,B_0\) and proves that the
+normalized leading-erased tail difference tends to zero.  It is not the missing
+exact selected-summand cancellation: the remaining proof must still extract the
+leading coefficient identity, or an equivalent tail proportionality statement,
+without assuming residual-family linear independence beyond the fixed-block
+Lemma~\(\mathrm{Lem1}\) input.
+
 There are also conditional tail-peeling auxiliary lemmas:
 \[
 \begin{aligned}

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -84,8 +84,7 @@ proportional BNT families:
 
 The first partner-identification step for peeling is now also formalized:
 \begin{flushleft}\small
-\leanid{MPSTensor.leading\_right\_nondecaying\_partner\_eq\_leading\_left}\\
-\leanid{\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}.
+\leanid{MPSTensor.leading\_right\_nondecaying\_partner\_eq\_leading\_left\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}.
 \end{flushleft}
 It proves that, under eventual nonzero proportionality, a non-decaying partner
 of the leading \(B\)-block must be the leading \(A\)-block.  This is still only
@@ -96,15 +95,14 @@ cancellation statements.
 The resulting leading phase relation and asymptotic leading-tail estimate are
 recorded in:
 \begin{flushleft}\small
-\leanid{MPSTensor.exists\_leading\_phase\_tail\_diff\_tendsto\_zero}\\
-\leanid{\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}.
+\leanid{MPSTensor.exists\_leading\_phase\_tail\_diff\_tendsto\_zero\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}.
 \end{flushleft}
 This lemma supplies the phase relation for \(A_0,B_0\) and proves that the
 normalized leading-erased tail difference tends to zero.  It is not the missing
 exact selected-summand cancellation: the remaining proof must still extract the
 leading coefficient identity, or an equivalent tail proportionality statement,
 without assuming residual-family linear independence beyond the fixed-block
-Lemma~\(\mathrm{Lem1}\) input.
+Lemma~\texttt{Lem1} input.
 
 There are also conditional tail-peeling auxiliary lemmas:
 \[

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -82,6 +82,17 @@ proportional BNT families:
 \end{aligned}
 \]
 
+The first partner-identification step for peeling is now also formalized:
+\begin{flushleft}\small
+\leanid{MPSTensor.leading\_right\_nondecaying\_partner\_eq\_leading\_left}\\
+\leanid{\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}.
+\end{flushleft}
+It proves that, under eventual nonzero proportionality, a non-decaying partner
+of the leading \(B\)-block must be the leading \(A\)-block.  This is still only
+a preparatory step: it identifies the pair eligible for dominant tail
+subtraction, but it does not by itself prove the arbitrary fixed-block
+cancellation statements.
+
 There are also conditional tail-peeling auxiliary lemmas:
 \[
 \begin{aligned}


### PR DESCRIPTION
## Summary

This PR formalizes two preparatory steps in the CPSV16 proportional peeling argument for Theorem II.1, line 1182.

First, it proves that under eventual nonzero proportionality, if the leading B-block has a non-decaying overlap with an A-block, then that A-block is the leading A-block.

Second, it uses that identified leading pair to obtain the phase relation for A_0 and B_0 and the normalized asymptotic cancellation of the leading-erased weighted tails.

Main Lean statements:

- MPSTensor.leading_right_nondecaying_partner_eq_leading_left_of_eventuallyNonzeroProportionalMPV₂_CFBNT in TNLean/MPS/FundamentalTheorem/Full/LeadingPartner.lean
- MPSTensor.exists_leading_phase_tail_diff_tendsto_zero_of_eventuallyNonzeroProportionalMPV₂_CFBNT in TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean

The blueprint entry cites \cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv} at the end of the relevant statements, and docs/paper-gaps/cpsv16_fixed_block_cancellation.tex records that these are still preparatory. The exact fixed-block selected-summand cancellation, without residual-family linear independence, remains the missing step.

This is a preparatory step for #1563 and #1612. It does not close #1563: the two arbitrary fixed-block cancellation statements in NondecayingOverlap.lean remain as the known proof gaps.

## Verification

- lake env lean TNLean/MPS/FundamentalTheorem/Full/LeadingPartner.lean
- lake env lean TNLean/MPS/FundamentalTheorem/Full/LeadingTail.lean
- lake env lean TNLean/MPS/FundamentalTheorem/Full.lean
- lake build
- cd blueprint && leanblueprint checkdecls
- cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode cpsv16_fixed_block_cancellation.tex
- git diff --check

The full build succeeds with pre-existing repository warnings, including the two known NondecayingOverlap.lean sorries tracked by #1563.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new Lean lemmas and documentation wiring; it doesn’t change existing definitions or core algorithms, but the new proofs are nontrivial and may affect downstream compilation dependencies.
> 
> **Overview**
> Records two new preparatory results for the CPSV16 proportional peeling argument.
> 
> It adds `LeadingPartner.lean`, proving the leading `B₀` block’s unique non-decaying overlap partner must be the leading `A₀` block under `EventuallyNonzeroProportionalMPV₂`.
> 
> It adds `LeadingTail.lean`, packaging the resulting `ζ^N` MPV phase relation between `A₀`/`B₀` together with an `atTop` limit statement that the normalized *leading-erased* weighted tail difference tends to `0`, and wires these modules into `Full.lean` plus updates the blueprint and paper-gap docs to cite the new lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8875bcabd6c4555f951971b26f5685f087bba14f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->