### PR TITLE
feat(MPS/FT): isolate selected coefficient by residual span

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -6,6 +6,7 @@ import TNLean.MPS.FundamentalTheorem.Full.BlocksMatch
 import TNLean.MPS.FundamentalTheorem.Full.FixedBlockSingleton
 import TNLean.MPS.FundamentalTheorem.Full.LeadingPartner
 import TNLean.MPS.FundamentalTheorem.Full.LeadingTail
+import TNLean.MPS.FundamentalTheorem.Full.ProportionalResidualSpan
 import TNLean.MPS.FundamentalTheorem.Full.ProportionalTail
 
 /-!

--- a/TNLean/MPS/FundamentalTheorem/Full.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full.lean
@@ -60,6 +60,8 @@ The proof is split across supporting sub-modules for readability:
   full proportionality identity.
 * `TNLean.MPS.FundamentalTheorem.Full.LeadingTail` — leading phase relation
   and leading-erased tail asymptotics for proportional peeling.
+* `TNLean.MPS.FundamentalTheorem.Full.ProportionalResidualSpan` — linear-algebra
+  residual-span coefficient extraction used in the selected-summand isolation step.
 * `TNLean.MPS.FundamentalTheorem.Full.BlocksMatch` — Layer 1b,
   `blocks_match_of_sameMPV₂_CFBNT`, which converts the non-decaying overlap data into a
   full `BlockPermutationGaugePhaseConclusion` via the overlap dichotomy.

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -288,6 +288,73 @@ lemma eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weigh
     _ = c N * mpv (toTensorFromBlocks μB B) σ := by
       rw [← hBcoeff]
 
+/-- **Selected coefficient extraction modulo a residual span.**
+
+This is a pure linear-algebra form of the coefficient-isolation step. If two
+expressions differ only by terms in the span of a residual family, and the
+selected vector is not in that residual span, then the selected coefficients
+agree.
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. In the paper,
+Lemma `Lem1` is used to separate a fixed BNT block from the remaining
+contributions. This lemma records the algebraic separation needed once the
+appropriate residual-span exclusion has been proved.
+
+**Scope restriction (residual-span exclusion):** The hypothesis
+`v₀ ∉ Submodule.span ℂ (Set.range u)` is not a new source hypothesis for
+CPSV16; it is the local algebraic condition that must be derived from the BNT
+separation argument before this lemma can be used in a source-faithful proof.
+See `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
+lemma selected_coefficient_eq_of_residual_span
+    {E : Type*} [AddCommGroup E] [Module ℂ E]
+    {κ : Type*} (u : κ → E) {v₀ R S : E} {a b : ℂ}
+    (hR : R ∈ Submodule.span ℂ (Set.range u))
+    (hS : S ∈ Submodule.span ℂ (Set.range u))
+    (hEq : a • v₀ + R = b • v₀ + S)
+    (hnot : v₀ ∉ Submodule.span ℂ (Set.range u)) :
+    a = b := by
+  by_contra hne
+  have hdiff_ne : a - b ≠ 0 := sub_ne_zero.mpr hne
+  have hdiff_mem : (a - b) • v₀ ∈ Submodule.span ℂ (Set.range u) := by
+    have hdiff_eq : (a - b) • v₀ = S - R := by
+      calc
+        (a - b) • v₀ = a • v₀ - b • v₀ := by rw [sub_smul]
+        _ = a • v₀ + R - R - b • v₀ := by abel
+        _ = b • v₀ + S - R - b • v₀ := by rw [hEq]
+        _ = S - R := by abel
+    rw [hdiff_eq]
+    exact (Submodule.span ℂ (Set.range u)).sub_mem hS hR
+  have hv₀_mem : v₀ ∈ Submodule.span ℂ (Set.range u) := by
+    have hscaled :
+        (a - b)⁻¹ • ((a - b) • v₀) ∈ Submodule.span ℂ (Set.range u) :=
+      (Submodule.span ℂ (Set.range u)).smul_mem _ hdiff_mem
+    simpa [smul_smul, inv_mul_cancel₀ hdiff_ne] using hscaled
+  exact hnot hv₀_mem
+
+/-- **Eventual selected coefficient extraction modulo residual spans.**
+
+This is the eventual form of
+`selected_coefficient_eq_of_residual_span`, suited to the CPSV16 line-1182
+peeling argument where Lemma `Lem1` supplies statements only for sufficiently
+large chain lengths.
+
+**Scope restriction (residual-span exclusion):** The eventual exclusion of the
+selected MPV state from the residual span must be derived from the BNT
+separation argument. It is not an additional hypothesis of the source theorem;
+see `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
+lemma eventually_selected_coefficient_eq_of_residual_span
+    {κ : Type*}
+    {E : ℕ → Type*} [∀ N, AddCommGroup (E N)] [∀ N, Module ℂ (E N)]
+    (u : (N : ℕ) → κ → E N) (v₀ R S : (N : ℕ) → E N)
+    (a b : ℕ → ℂ)
+    (hR : ∀ᶠ N in atTop, R N ∈ Submodule.span ℂ (Set.range (u N)))
+    (hS : ∀ᶠ N in atTop, S N ∈ Submodule.span ℂ (Set.range (u N)))
+    (hEq : ∀ᶠ N in atTop, a N • v₀ N + R N = b N • v₀ N + S N)
+    (hnot : ∀ᶠ N in atTop, v₀ N ∉ Submodule.span ℂ (Set.range (u N))) :
+    ∀ᶠ N in atTop, a N = b N := by
+  filter_upwards [hR, hS, hEq, hnot] with N hRN hSN hEqN hnotN
+  exact selected_coefficient_eq_of_residual_span (u N) hRN hSN hEqN hnotN
+
 /-- **Selected coefficient extraction from an eventual two-family relation.**
 
 Source context: arXiv:1606.00608, Theorem `thm1`, lines 1181--1183. This

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -18,7 +18,7 @@ external coefficient-array hypotheses are introduced.
 
 * Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
   Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017),
-  Theorem `thm1`, lines 1170--1192.
+  Theorem thm1, lines 1170--1192.
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -30,7 +30,7 @@ section ProportionalExpansion
 
 /-- **Fixed-length weighted MPV-state proportionality from assembled block tensors.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. At a fixed length
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. At a fixed length
 `N`, proportionality of the two assembled tensors expands into proportionality
 of the two weighted BNT block sums at that same length. This is the fixed-length
 form used before passing to scalar sequences or eventual tail reductions. -/
@@ -82,7 +82,7 @@ lemma exists_weighted_mpvState_eq_smul_of_nonzeroProportional_at_length_toTensor
 
 /-- **Weighted MPV-state proportionality from proportional assembled block tensors.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof of the
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. The proof of the
 block-selection step expands the two canonical-form tensors into their BNT
 block sums and then uses proportionality of the total MPV families. This lemma
 formalizes exactly that expansion, without adding coefficient-array hypotheses:
@@ -105,7 +105,7 @@ lemma exists_weighted_mpvState_eq_smul_of_nonzeroProportionalMPV₂_toTensorFrom
 
 /-- **A scalar sequence for proportional weighted MPV-state sums.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof uses
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. The proof uses
 one proportionality scalar at each chain length. This lemma collects those
 lengthwise scalars into a single nonzero sequence so that later convergence
 arguments can refer to the same scalar at each occurrence of the fixed length. -/
@@ -134,8 +134,8 @@ lemma exists_weighted_mpvState_eq_smul_sequence_of_nonzeroProportionalMPV₂_toT
 
 /-- **An eventual scalar sequence for eventually proportional weighted MPV-state sums.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 uses Lemma
-`Lem1`, hence only sufficiently large chain lengths enter the contradiction.
+Source context: arXiv:1606.00608, Theorem thm1, line 1182 uses Lemma
+Lem1, hence only sufficiently large chain lengths enter the contradiction.
 This lemma is the eventual version of the preceding scalar-sequence
 bookkeeping: eventual nonzero proportionality of the assembled tensors gives an
 eventual nonzero scalar sequence for the expanded weighted BNT block sums. -/
@@ -177,7 +177,7 @@ lemma exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroP
 
 /-- **Nonzero proportionality from a weighted MPV-state scalar sequence.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. In the
 block-selection proof, after expanding canonical-form tensors into weighted
 BNT block sums, a lengthwise nonzero scalar identity of the weighted MPV-state
 sums is exactly the corresponding projective proportionality of the assembled
@@ -233,7 +233,7 @@ lemma nonzeroProportionalMPV₂_toTensorFromBlocks_of_weighted_mpvState_eq_smul_
 
 /-- **Eventual proportionality from an eventual weighted MPV-state scalar sequence.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. At recursive
+Source context: arXiv:1606.00608, Theorem thm1, line 1182. At recursive
 stages in the block-deletion argument the available weighted MPV-state identity
 may hold only for sufficiently large lengths. This bookkeeping lemma turns such
 an eventual weighted identity into eventual nonzero proportionality of the
@@ -290,14 +290,14 @@ lemma eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weigh
 
 /-- **Selected coefficient extraction from an eventual two-family relation.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, lines 1181--1183. This
+Source context: arXiv:1606.00608, Theorem thm1, lines 1181--1183. This
 lemma is conditional algebra: once the selected block on one side has been
 rewritten as a phase multiple of the selected block on the other side, an
 explicit eventual linear-independence hypothesis for the displayed two-family
 list lets one compare the selected coefficient.
 
 **Scope restriction (explicit residual-family independence):** In the
-fixed-block step of CPSV16 Theorem `thm1`, Lemma `Lem1` supplies linear
+fixed-block step of CPSV16 Theorem thm1, Lemma Lem1 supplies linear
 independence for the family made from all blocks on one side together with one
 fixed block on the other side; it does not directly supply the residual
 two-family hypothesis appearing here. The missing source-faithful isolation
@@ -334,7 +334,7 @@ lemma eventually_selected_coefficient_eq_of_eventually_linearIndependent_sum
 
 /-- **Selected weighted summand from phase and coefficient equality.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After a
+Source context: arXiv:1606.00608, Theorem thm1, lines 1170--1192. After a
 non-decaying block pair has supplied a phase relation between the two MPV
 families, the coefficient comparison identifies the corresponding weighted
 summands. This is only the algebraic bridge from the phase relation and the
@@ -362,15 +362,15 @@ lemma eventually_selected_weighted_mpvState_eq_smul_of_phase_and_coeff
 
 /-- **Selected weighted summand from phase substitution and linear independence.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
-`Lem1`. After a non-decaying block pair has supplied the phase relation for
+Source context: arXiv:1606.00608, Theorem thm1, line 1182 invokes Lemma
+Lem1. After a non-decaying block pair has supplied the phase relation for
 the selected block, this auxiliary lemma uses an explicit eventual
 linear-independence hypothesis for the displayed residual family. The total
 weighted-state relation then identifies the selected coefficient, and hence the
 selected weighted summand.
 
 **Scope restriction (explicit residual-family independence):** In the
-fixed-block step of CPSV16 Theorem `thm1`, lines 1181--1185, Lemma `Lem1`
+fixed-block step of CPSV16 Theorem thm1, lines 1181--1185, Lemma Lem1
 does not by itself supply the residual-family independence assumed here. See
 `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
 lemma eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li
@@ -424,7 +424,7 @@ lemma eventually_selected_weighted_mpvState_eq_smul_of_phase_sum_and_li
 
 /-- **Subtracting a proportional dominant summand from weighted MPV-state sums.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof removes
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. The proof removes
 the already matched leading BNT component and continues with the remaining
 blocks. This lemma isolates the linear algebra: if the total weighted MPV-state
 sums are related by the scalar `c_N`, and the selected summands are related by
@@ -455,8 +455,8 @@ lemma weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected
 
 /-- **Eventual subtraction of a proportional selected summand.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. The recursive
-block-selection argument uses Lemma `Lem1`, so tail identities produced after
+Source context: arXiv:1606.00608, Theorem thm1, line 1182. The recursive
+block-selection argument uses Lemma Lem1, so tail identities produced after
 coefficient extraction are needed only for sufficiently large lengths. This is
 the eventual analogue of
 `weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected`. -/
@@ -487,7 +487,7 @@ lemma eventually_weighted_mpvState_tail_eq_smul_sequence_of_total_and_selected
 
 /-- **Reindexing a leading-erased weighted MPV-state tail.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After removing
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. After removing
 the already matched leading BNT component, the remaining components are viewed
 again as a finite BNT family indexed by `Fin (r - 1)`. This lemma isolates the
 finite reindexing of the corresponding weighted MPV-state sum. -/
@@ -526,7 +526,7 @@ lemma weighted_mpvState_sum_erase_zero_eq_sum_succ
 
 /-- **Reindexing an arbitrary erased weighted MPV-state tail.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The proof may
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. The proof may
 remove a matched block pair that is not the leading pair, because the theorem
 allows a permutation of BNT blocks. This lemma identifies the weighted
 MPV-state sum over the complement of an arbitrary selected block with the
@@ -559,7 +559,7 @@ lemma weighted_mpvState_sum_erase_eq_sum_succAbove
 
 /-- **Eventual proportionality of reindexed tails after removing the leading summand.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After a leading
+Source context: arXiv:1606.00608, Theorem thm1, line 1182. After a leading
 matched BNT component has been removed, the remaining components are reindexed
 and the argument is repeated. This lemma records that bookkeeping in eventual
 form: an eventual total weighted-state identity, together with an eventual
@@ -622,7 +622,7 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succ_of_total_and_selected
 
 /-- **Eventual proportionality of reindexed tails after an arbitrary matched block.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The
+Source context: arXiv:1606.00608, Theorem thm1, lines 1170--1192. The
 source proof permits a permutation of BNT blocks: after a block pair has been
 matched and its weighted summands have been identified, one removes that pair
 and repeats the argument on the two complements. This lemma records only the
@@ -680,15 +680,15 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_total_and_selected
 
 /-- **Tail proportionality from phase substitution and a linear-independence hypothesis.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
-`Lem1`. Once a selected non-decaying block pair has been converted into a
+Source context: arXiv:1606.00608, Theorem thm1, line 1182 invokes Lemma
+Lem1. Once a selected non-decaying block pair has been converted into a
 phase relation, this auxiliary lemma records the coefficient extraction,
 selected-summand subtraction, and arbitrary-tail reindexing under an explicit
 eventual linear-independence hypothesis for the displayed residual family.
 
 **Scope restriction (explicit residual-family independence):** CPSV16 Lemma
-`Lem1` gives this kind of independence only for the family in which all
-off-diagonal overlaps tend to zero. In the fixed-block step of Theorem `thm1`,
+Lem1 gives this kind of independence only for the family in which all
+off-diagonal overlaps tend to zero. In the fixed-block step of Theorem thm1,
 lines 1181--1185, the local application gives independence for all blocks on
 one side together with one fixed block on the other side, not for the whole
 remaining tail appearing in this lemma. This auxiliary lemma must therefore
@@ -754,7 +754,7 @@ lemma eventuallyNonzeroProportionalMPV₂_tail_succAbove_of_phase_sum_li
 
 /-- **Projection of a fixed weighted MPV-state scalar sequence.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. Once the
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. Once the
 proportionality scalars for the weighted assembled MPV-state sums have been
 chosen, projecting against a fixed block MPV preserves the same scalar
 sequence at every length. -/
@@ -778,8 +778,8 @@ lemma weighted_mpvInner_eq_mul_sequence_of_weighted_mpvState_eq_smul_sequence
 
 /-- **Eventual projection of a weighted MPV-state scalar sequence.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. After Lemma
-`Lem1` is used, the relevant weighted-state identity is only needed for all
+Source context: arXiv:1606.00608, Theorem thm1, line 1182. After Lemma
+Lem1 is used, the relevant weighted-state identity is only needed for all
 sufficiently large lengths; projection against a fixed block MPV preserves the
 same eventual scalar sequence. -/
 lemma eventually_weighted_mpvInner_eq_mul_sequence_of_eventually_weighted_mpvState_eq_smul_sequence
@@ -809,7 +809,7 @@ lemma eventually_weighted_mpvInner_eq_mul_sequence_of_eventually_weighted_mpvSta
 
 /-- **Weighted inner-product proportionality from proportional assembled block tensors.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. After expanding
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. After expanding
 the proportional assembled MPV states into weighted BNT block sums, the proof
 projects the equality against a single block MPV. This lemma records that
 projection for an arbitrary tensor `X`. -/
@@ -835,7 +835,7 @@ lemma exists_weighted_mpvInner_eq_mul_of_nonzeroProportionalMPV₂_toTensorFromB
 
 /-- **A scalar sequence for proportional weighted MPV projections.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. This is the
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. This is the
 projection form of the previous scalar-sequence lemma: after projecting the
 weighted state sums against a fixed block MPV, the same nonzero scalar sequence
 relates the projected weighted sums at every length. -/
@@ -861,9 +861,9 @@ lemma exists_weighted_mpvInner_eq_mul_sequence_of_nonzeroProportionalMPV₂_toTe
 
 /-- **An eventual scalar sequence for proportional weighted MPV projections.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. This is the
+Source context: arXiv:1606.00608, Theorem thm1, line 1182. This is the
 projection form of the eventual weighted-state scalar sequence obtained after
-applying the sufficiently-large-length linear-independence input `Lem1`. -/
+applying the sufficiently-large-length linear-independence input Lem1. -/
 lemma exists_eventually_weighted_mpvInner_eq_mul_sequence_of_eventuallyNonzeroProportionalMPV₂
     {d rA rB D : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -886,7 +886,7 @@ lemma exists_eventually_weighted_mpvInner_eq_mul_sequence_of_eventuallyNonzeroPr
 
 /-- **A scalar sequence for normalized proportional weighted projections.**
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. This records
+Source: arXiv:1606.00608, Theorem thm1, lines 1170--1192. This records
 the projected weighted-sum identity supplied by proportional assembled tensors
 in the normalized form used in the block-selection contradiction. The same
 nonzero scalar sequence is corrected by the factor `(\nu/\mu)^N` after
@@ -915,7 +915,7 @@ lemma exists_normalized_weighted_mpvInner_eq_mul_adjusted_sequence_of_nonzeroPro
 
 /-- **An eventual scalar sequence for normalized proportional weighted projections.**
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. In the recursive
+Source context: arXiv:1606.00608, Theorem thm1, line 1182. In the recursive
 tail-reduction stage the proportionality of the assembled tail tensors is only
 eventual. After choosing the eventual scalar sequence, the normalized projected
 weighted sums are still related by the same adjusted scalar for all

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Defs
 import TNLean.MPS.BNT.Basic
-import TNLean.MPS.FundamentalTheorem.Full.ProportionalResidualSpan
 import TNLean.MPS.FundamentalTheorem.Full.ProportionalScalar
 
 /-!

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Defs
 import TNLean.MPS.BNT.Basic
+import TNLean.MPS.FundamentalTheorem.Full.ProportionalResidualSpan
 import TNLean.MPS.FundamentalTheorem.Full.ProportionalScalar
 
 /-!
@@ -287,73 +288,6 @@ lemma eventuallyNonzeroProportionalMPV₂_toTensorFromBlocks_of_eventually_weigh
       simp [smul_eq_mul]
     _ = c N * mpv (toTensorFromBlocks μB B) σ := by
       rw [← hBcoeff]
-
-/-- **Selected coefficient extraction modulo a residual span.**
-
-This is a pure linear-algebra form of the coefficient-isolation step. If two
-expressions differ only by terms in the span of a residual family, and the
-selected vector is not in that residual span, then the selected coefficients
-agree.
-
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. In the paper,
-Lemma `Lem1` is used to separate a fixed BNT block from the remaining
-contributions. This lemma records the algebraic separation needed once the
-appropriate residual-span exclusion has been proved.
-
-**Scope restriction (residual-span exclusion):** The hypothesis
-`v₀ ∉ Submodule.span ℂ (Set.range u)` is not a new source hypothesis for
-CPSV16; it is the local algebraic condition that must be derived from the BNT
-separation argument before this lemma can be used in a source-faithful proof.
-See `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
-lemma selected_coefficient_eq_of_residual_span
-    {E : Type*} [AddCommGroup E] [Module ℂ E]
-    {κ : Type*} (u : κ → E) {v₀ R S : E} {a b : ℂ}
-    (hR : R ∈ Submodule.span ℂ (Set.range u))
-    (hS : S ∈ Submodule.span ℂ (Set.range u))
-    (hEq : a • v₀ + R = b • v₀ + S)
-    (hnot : v₀ ∉ Submodule.span ℂ (Set.range u)) :
-    a = b := by
-  by_contra hne
-  have hdiff_ne : a - b ≠ 0 := sub_ne_zero.mpr hne
-  have hdiff_mem : (a - b) • v₀ ∈ Submodule.span ℂ (Set.range u) := by
-    have hdiff_eq : (a - b) • v₀ = S - R := by
-      calc
-        (a - b) • v₀ = a • v₀ - b • v₀ := by rw [sub_smul]
-        _ = a • v₀ + R - R - b • v₀ := by abel
-        _ = b • v₀ + S - R - b • v₀ := by rw [hEq]
-        _ = S - R := by abel
-    rw [hdiff_eq]
-    exact (Submodule.span ℂ (Set.range u)).sub_mem hS hR
-  have hv₀_mem : v₀ ∈ Submodule.span ℂ (Set.range u) := by
-    have hscaled :
-        (a - b)⁻¹ • ((a - b) • v₀) ∈ Submodule.span ℂ (Set.range u) :=
-      (Submodule.span ℂ (Set.range u)).smul_mem _ hdiff_mem
-    simpa [smul_smul, inv_mul_cancel₀ hdiff_ne] using hscaled
-  exact hnot hv₀_mem
-
-/-- **Eventual selected coefficient extraction modulo residual spans.**
-
-This is the eventual form of
-`selected_coefficient_eq_of_residual_span`, suited to the CPSV16 line-1182
-peeling argument where Lemma `Lem1` supplies statements only for sufficiently
-large chain lengths.
-
-**Scope restriction (residual-span exclusion):** The eventual exclusion of the
-selected MPV state from the residual span must be derived from the BNT
-separation argument. It is not an additional hypothesis of the source theorem;
-see `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
-lemma eventually_selected_coefficient_eq_of_residual_span
-    {κ : Type*}
-    {E : ℕ → Type*} [∀ N, AddCommGroup (E N)] [∀ N, Module ℂ (E N)]
-    (u : (N : ℕ) → κ → E N) (v₀ R S : (N : ℕ) → E N)
-    (a b : ℕ → ℂ)
-    (hR : ∀ᶠ N in atTop, R N ∈ Submodule.span ℂ (Set.range (u N)))
-    (hS : ∀ᶠ N in atTop, S N ∈ Submodule.span ℂ (Set.range (u N)))
-    (hEq : ∀ᶠ N in atTop, a N • v₀ N + R N = b N • v₀ N + S N)
-    (hnot : ∀ᶠ N in atTop, v₀ N ∉ Submodule.span ℂ (Set.range (u N))) :
-    ∀ᶠ N in atTop, a N = b N := by
-  filter_upwards [hR, hS, hEq, hnot] with N hRN hSN hEqN hnotN
-  exact selected_coefficient_eq_of_residual_span (u N) hRN hSN hEqN hnotN
 
 /-- **Selected coefficient extraction from an eventual two-family relation.**
 

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
@@ -14,7 +14,7 @@ the proportional peeling argument for the Fundamental Theorem of MPS.
 
 * Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
   Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017),
-  Theorem `thm1`, line 1182.
+  Theorem II.1, line 1182.
 -/
 
 open Filter
@@ -30,8 +30,8 @@ expressions differ only by terms in the span of a residual family, and the
 selected vector is not in that residual span, then the selected coefficients
 agree.
 
-Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. In the paper,
-Lemma `Lem1` is used to separate a fixed BNT block from the remaining
+Source context: arXiv:1606.00608, Theorem II.1, line 1182. In the paper,
+CPSV16, Lem1 is used to separate a fixed BNT block from the remaining
 contributions. This lemma records the algebraic separation needed once the
 appropriate residual-span exclusion has been proved.
 
@@ -70,7 +70,7 @@ lemma selected_coefficient_eq_of_residual_span
 
 This is the eventual form of
 `selected_coefficient_eq_of_residual_span`, suited to the CPSV16 line-1182
-peeling argument where Lemma `Lem1` supplies statements only for sufficiently
+peeling argument where CPSV16, Lem1 supplies statements only for sufficiently
 large chain lengths.
 
 **Scope restriction (residual-span exclusion):** The eventual exclusion of the

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Defs
+
+/-!
+# Residual-span coefficient extraction
+
+This module contains the linear-algebra coefficient-extraction lemmas used in
+the proportional peeling argument for the Fundamental Theorem of MPS.
+
+## References
+
+* Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017),
+  Theorem `thm1`, line 1182.
+-/
+
+open Filter
+
+namespace MPSTensor
+
+section ProportionalResidualSpan
+
+/-- **Selected coefficient extraction modulo a residual span.**
+
+This is a pure linear-algebra form of the coefficient-isolation step. If two
+expressions differ only by terms in the span of a residual family, and the
+selected vector is not in that residual span, then the selected coefficients
+agree.
+
+Source context: arXiv:1606.00608, Theorem `thm1`, line 1182. In the paper,
+Lemma `Lem1` is used to separate a fixed BNT block from the remaining
+contributions. This lemma records the algebraic separation needed once the
+appropriate residual-span exclusion has been proved.
+
+**Scope restriction (residual-span exclusion):** The hypothesis
+`v₀ ∉ Submodule.span ℂ (Set.range u)` is not a new source hypothesis for
+CPSV16; it is the local algebraic condition that must be derived from the BNT
+separation argument before this lemma can be used in a source-faithful proof.
+See `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
+lemma selected_coefficient_eq_of_residual_span
+    {E : Type*} [AddCommGroup E] [Module ℂ E]
+    {κ : Type*} (u : κ → E) {v₀ R S : E} {a b : ℂ}
+    (hR : R ∈ Submodule.span ℂ (Set.range u))
+    (hS : S ∈ Submodule.span ℂ (Set.range u))
+    (hEq : a • v₀ + R = b • v₀ + S)
+    (hnot : v₀ ∉ Submodule.span ℂ (Set.range u)) :
+    a = b := by
+  by_contra hne
+  have hdiff_ne : a - b ≠ 0 := sub_ne_zero.mpr hne
+  have hdiff_mem : (a - b) • v₀ ∈ Submodule.span ℂ (Set.range u) := by
+    have hdiff_eq : (a - b) • v₀ = S - R := by
+      calc
+        (a - b) • v₀ = a • v₀ - b • v₀ := by rw [sub_smul]
+        _ = a • v₀ + R - R - b • v₀ := by abel
+        _ = b • v₀ + S - R - b • v₀ := by rw [hEq]
+        _ = S - R := by abel
+    rw [hdiff_eq]
+    exact (Submodule.span ℂ (Set.range u)).sub_mem hS hR
+  have hv₀_mem : v₀ ∈ Submodule.span ℂ (Set.range u) := by
+    have hscaled :
+        (a - b)⁻¹ • ((a - b) • v₀) ∈ Submodule.span ℂ (Set.range u) :=
+      (Submodule.span ℂ (Set.range u)).smul_mem _ hdiff_mem
+    simpa [smul_smul, inv_mul_cancel₀ hdiff_ne] using hscaled
+  exact hnot hv₀_mem
+
+/-- **Eventual selected coefficient extraction modulo residual spans.**
+
+This is the eventual form of
+`selected_coefficient_eq_of_residual_span`, suited to the CPSV16 line-1182
+peeling argument where Lemma `Lem1` supplies statements only for sufficiently
+large chain lengths.
+
+**Scope restriction (residual-span exclusion):** The eventual exclusion of the
+selected MPV state from the residual span must be derived from the BNT
+separation argument. It is not an additional hypothesis of the source theorem;
+see `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
+lemma eventually_selected_coefficient_eq_of_residual_span
+    {κ : Type*}
+    {E : ℕ → Type*} [∀ N, AddCommGroup (E N)] [∀ N, Module ℂ (E N)]
+    (u : (N : ℕ) → κ → E N) (v₀ R S : (N : ℕ) → E N)
+    (a b : ℕ → ℂ)
+    (hR : ∀ᶠ N in atTop, R N ∈ Submodule.span ℂ (Set.range (u N)))
+    (hS : ∀ᶠ N in atTop, S N ∈ Submodule.span ℂ (Set.range (u N)))
+    (hEq : ∀ᶠ N in atTop, a N • v₀ N + R N = b N • v₀ N + S N)
+    (hnot : ∀ᶠ N in atTop, v₀ N ∉ Submodule.span ℂ (Set.range (u N))) :
+    ∀ᶠ N in atTop, a N = b N := by
+  filter_upwards [hR, hS, hEq, hnot] with N hRN hSN hEqN hnotN
+  exact selected_coefficient_eq_of_residual_span (u N) hRN hSN hEqN hnotN
+
+end ProportionalResidualSpan
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
@@ -60,10 +60,7 @@ lemma selected_coefficient_eq_of_residual_span
     rw [hdiff_eq]
     exact (Submodule.span ℂ (Set.range u)).sub_mem hS hR
   have hv₀_mem : v₀ ∈ Submodule.span ℂ (Set.range u) := by
-    have hscaled :
-        (a - b)⁻¹ • ((a - b) • v₀) ∈ Submodule.span ℂ (Set.range u) :=
-      (Submodule.span ℂ (Set.range u)).smul_mem _ hdiff_mem
-    simpa [smul_smul, inv_mul_cancel₀ hdiff_ne] using hscaled
+    exact ((Submodule.span ℂ (Set.range u)).smul_mem_iff hdiff_ne).mp hdiff_mem
   exact hnot hv₀_mem
 
 /-- **Eventual selected coefficient extraction modulo residual spans.**

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -159,7 +159,6 @@ with an extra $Z$-gauge degree of freedom.
 \label{lem:eventual_selected_coefficient_from_residual_span}
 	\lean{MPSTensor.eventually_selected_coefficient_eq_of_residual_span}
 	\leanok
-	\uses{lem:selected_coefficient_from_residual_span}
 	Suppose that, for all sufficiently large \(N\), the residual terms \(R_N\)
 	and \(S_N\) lie in the span of a residual family \(\{u_{N,k}\}_k\), the
 	identity
@@ -167,13 +166,14 @@ with an extra $Z$-gauge degree of freedom.
 		a_N v_N+R_N=b_N v_N+S_N
 	\]
 	holds, and \(v_N\) is not in that residual span.  Then \(a_N=b_N\) for
-	all sufficiently large \(N\).  This records the weaker coefficient
-	extraction target needed before replacing the conditional residual
-	linear-independence route
+	all sufficiently large \(N\).  This is the weaker form of coefficient
+	extraction that applies when only the span-exclusion condition is available,
+	before linear independence of the full family has been established
 	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
+	\uses{lem:selected_coefficient_from_residual_span}
 	Apply Lemma~\ref{lem:selected_coefficient_from_residual_span} at every
 	sufficiently large length.
 \end{proof}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -134,6 +134,50 @@ with an extra $Z$-gauge degree of freedom.
 	and evaluate the eventual state identity on each basis word.
 \end{proof}
 
+\begin{lemma}[Selected coefficient extraction modulo a residual span]%
+\label{lem:selected_coefficient_from_residual_span}
+	\lean{MPSTensor.selected_coefficient_eq_of_residual_span}
+	\leanok
+	Let \(v_0\) be a vector and let \(R,S\) lie in the span of a residual
+	family \(\{u_k\}_k\).  If
+	\[
+		a v_0+R=b v_0+S
+	\]
+	and \(v_0\notin\operatorname{span}\{u_k\}_k\), then \(a=b\).  This is the
+	algebraic coefficient-isolation step which remains after the BNT argument
+	has separated the selected block from the residual span
+	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	Subtract the two sides.  Then \((a-b)v_0\) lies in the residual span.  If
+	\(a\ne b\), scalar division places \(v_0\) itself in the same span,
+	contradicting the span-exclusion hypothesis.
+\end{proof}
+
+\begin{lemma}[Eventual selected coefficient extraction modulo residual spans]%
+\label{lem:eventual_selected_coefficient_from_residual_span}
+	\lean{MPSTensor.eventually_selected_coefficient_eq_of_residual_span}
+	\leanok
+	\uses{lem:selected_coefficient_from_residual_span}
+	Suppose that, for all sufficiently large \(N\), the residual terms \(R_N\)
+	and \(S_N\) lie in the span of a residual family \(\{u_{N,k}\}_k\), the
+	identity
+	\[
+		a_N v_N+R_N=b_N v_N+S_N
+	\]
+	holds, and \(v_N\) is not in that residual span.  Then \(a_N=b_N\) for
+	all sufficiently large \(N\).  This records the weaker coefficient
+	extraction target needed before replacing the conditional residual
+	linear-independence route
+	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	Apply Lemma~\ref{lem:selected_coefficient_from_residual_span} at every
+	sufficiently large length.
+\end{proof}
+
 \begin{lemma}[Selected coefficient extraction after one phase substitution]%
 \label{lem:selected_coefficient_from_two_family_linear_independence}
 	\lean{MPSTensor.eventually_selected_coefficient_eq_of_eventually_linearIndependent_sum}


### PR DESCRIPTION
## Summary

Adds a weaker coefficient-isolation auxiliary for the CPSV16 line-1182 peeling step. Instead of assuming full residual-family linear independence, the new lemma extracts the selected coefficient from an identity modulo a residual span, assuming only that the selected vector is not in that residual span.

## Faithfulness

This PR does not claim to discharge CPSV16 Theorem II.1 line 1182. The residual-span exclusion remains a local condition to be derived from BNT separation before the lemma can be used in the source-faithful proof. Both Lean docstrings and blueprint statements mark this as a scope-restricted algebraic auxiliary and point to `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`.

This is intended to replace the too-strong residual-linear-independence branch with a weaker target for #1631.

## Verification

- `lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalExpansion.lean` (no matches)

## Tracking

Refs #1631, #1563, #1559.

Stacked on #1630.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new self-contained linear-algebra lemmas and documentation/import wiring, without changing existing proof logic or APIs beyond an additional module import.
> 
> **Overview**
> Adds a new module `Full/ProportionalResidualSpan.lean` with coefficient-extraction lemmas that isolate a selected scalar from an equality *modulo* a residual `Submodule.span`, plus an eventual (`Filter.atTop`) version for the CPSV16 line-1182 peeling step.
> 
> Wires the module into `Full.lean` and the blueprint, and adjusts `ProportionalExpansion.lean` docstrings/references to consistently cite “Theorem thm1 / Lem1” (no behavior changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71bf882250ba1fc1d215904d3936ba72b77a964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->