### PR TITLE
feat(MPS/FT): derive residual span exclusion from independence

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
@@ -23,6 +23,72 @@ namespace MPSTensor
 
 section ProportionalResidualSpan
 
+/-- **Linear independence gives residual-span exclusion.**
+
+Source context: arXiv:1606.00608, Theorem II.1, line 1182. The paper uses
+CPSV16, Lem1 to separate a fixed BNT block from the remaining contributions.
+This lemma records the elementary linear-algebra consequence needed by the
+residual-span coefficient extraction: if the selected vector together with the
+residual family is linearly independent, then the selected vector is not in the
+span of the residual family.
+
+**Scope restriction (derived separation input):** The linear-independence
+hypothesis is not a new source hypothesis for CPSV16. In a source-faithful
+application it must be derived from the BNT separation argument, or replaced by
+the equivalent residual-span exclusion supplied by that argument. See
+`docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
+lemma selected_notMem_residual_span_of_linearIndependent_option
+    {E : Type*} [AddCommGroup E] [Module ℂ E]
+    {κ : Type*} (u : κ → E) (v₀ : E)
+    (hLI : LinearIndependent ℂ
+      (fun o : Option κ =>
+        match o with
+        | none => v₀
+        | some k => u k)) :
+    v₀ ∉ Submodule.span ℂ (Set.range u) := by
+  classical
+  have hnone_not_mem : (none : Option κ) ∉ Set.range some := by
+    rintro ⟨k, hk⟩
+    cases hk
+  have himage :
+      ((fun o : Option κ =>
+          match o with
+          | none => v₀
+          | some k => u k) '' Set.range some) = Set.range u := by
+    ext x
+    constructor
+    · rintro ⟨o, ⟨k, rfl⟩, rfl⟩
+      exact ⟨k, rfl⟩
+    · rintro ⟨k, rfl⟩
+      exact ⟨some k, ⟨k, rfl⟩, rfl⟩
+  simpa [himage] using hLI.notMem_span_image (s := Set.range some) (x := none) hnone_not_mem
+
+/-- **Eventual residual-span exclusion from eventual selected-plus-residual
+linear independence.**
+
+This is the eventual form of
+`selected_notMem_residual_span_of_linearIndependent_option`, suited to the
+CPSV16 line-1182 peeling argument where the block-separation statement is used
+only for sufficiently large chain lengths.
+
+**Scope restriction (derived separation input):** The eventual
+linear-independence hypothesis is an intermediate condition that must be
+derived from the BNT separation argument before this lemma can be used in a
+source-faithful proof; see
+`docs/paper-gaps/cpsv16_fixed_block_cancellation.tex`. -/
+lemma eventually_selected_notMem_residual_span_of_linearIndependent_option
+    {κ : Type*}
+    {E : ℕ → Type*} [∀ N, AddCommGroup (E N)] [∀ N, Module ℂ (E N)]
+    (u : (N : ℕ) → κ → E N) (v₀ : (N : ℕ) → E N)
+    (hLI : ∀ᶠ N in atTop, LinearIndependent ℂ
+      (fun o : Option κ =>
+        match o with
+        | none => v₀ N
+        | some k => u N k)) :
+    ∀ᶠ N in atTop, v₀ N ∉ Submodule.span ℂ (Set.range (u N)) := by
+  filter_upwards [hLI] with N hLIN
+  exact selected_notMem_residual_span_of_linearIndependent_option (u N) (v₀ N) hLIN
+
 /-- **Selected coefficient extraction modulo a residual span.**
 
 This is a pure linear-algebra form of the coefficient-isolation step. If two

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -134,6 +134,42 @@ with an extra $Z$-gauge degree of freedom.
 	and evaluate the eventual state identity on each basis word.
 \end{proof}
 
+\begin{lemma}[Selected vector is outside the residual span]%
+\label{lem:selected_not_in_residual_span_from_li}
+	\lean{MPSTensor.selected_notMem_residual_span_of_linearIndependent_option}
+	\leanok
+	Let \(v_0\) be a selected vector and let \(\{u_k\}_k\) be a residual
+	family.  If the family consisting of \(v_0\) together with the residual
+	vectors \(u_k\) is linearly independent, then
+	\(v_0\notin\operatorname{span}\{u_k\}_k\).  In the CPSV16 peeling step,
+	this is the algebraic consequence required after the BNT argument has
+	separated the selected block from the residual contributions
+	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	Linear independence says that no member of the family lies in the span of
+	the remaining members.  Apply this to the selected member.
+\end{proof}
+
+\begin{lemma}[Eventual selected vector is outside the residual span]%
+\label{lem:eventual_selected_not_in_residual_span_from_li}
+	\lean{MPSTensor.eventually_selected_notMem_residual_span_of_linearIndependent_option}
+	\leanok
+	If, for all sufficiently large \(N\), the selected vector \(v_N\) together
+	with the residual family \(\{u_{N,k}\}_k\) is linearly independent, then
+	\(v_N\notin\operatorname{span}\{u_{N,k}\}_k\) for all sufficiently large
+	\(N\).  This records the passage from an eventual BNT separation statement
+	to the residual-span exclusion used by coefficient extraction
+	\cite[Theorem~II.1, line~1182]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+	\uses{lem:selected_not_in_residual_span_from_li}
+	Apply Lemma~\ref{lem:selected_not_in_residual_span_from_li} at every
+	sufficiently large length.
+\end{proof}
+
 \begin{lemma}[Selected coefficient extraction modulo a residual span]%
 \label{lem:selected_coefficient_from_residual_span}
 	\lean{MPSTensor.selected_coefficient_eq_of_residual_span}


### PR DESCRIPTION
Parent issues: #1631, #1612, #1563, #1559.

This follow-up replaces closed stacked PR #1634, whose base branch was deleted when #1633 merged. It adds the algebraic bridge needed after the residual-span coefficient extraction: if the selected vector together with the residual family is linearly independent, then the selected vector is outside the residual span, plus the eventual version used in the CPSV16 peeling argument.

Mathematical scope:

- Source context: CPSV16 arXiv:1606.00608, Theorem II.1, line 1182.
- The linear-independence input is marked as a derived separation condition, not as an additional source hypothesis. A source-faithful use must derive it from the BNT separation/Lem1 step, or replace it by the equivalent residual-span exclusion.
- The declarations cite docs/paper-gaps/cpsv16_fixed_block_cancellation.tex through their scope markers.

Changes:

- MPSTensor.selected_notMem_residual_span_of_linearIndependent_option
- MPSTensor.eventually_selected_notMem_residual_span_of_linearIndependent_option
- Blueprint entries in Chapter 11 for both lemmas.

Verification:

- lake env lean TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
- lake env lean TNLean/MPS/FundamentalTheorem/Full.lean
- cd blueprint && leanblueprint checkdecls
- rg -n "sorry|axiom" TNLean/MPS/FundamentalTheorem/Full/ProportionalResidualSpan.lean
- git diff --check
- lake build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds two small linear-algebra lemmas (and blueprint documentation) without changing existing theorem statements or computational code.
> 
> **Overview**
> Adds a new algebraic bridge used in the Fundamental Theorem peeling step: from linear independence of a selected vector plus a residual family to the conclusion that the selected vector is *not* in the residual span (`selected_notMem_residual_span_of_linearIndependent_option`), plus an `atTop`/eventual version for large lengths.
> 
> Updates the Chapter 11 blueprint to document and reference these two new lemmas as the derived separation input feeding into residual-span coefficient extraction, including notes that the linear-independence assumption must come from the BNT separation argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c6bc9060c57766c8108a14c2a1ffb185d61cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->