### PR TITLE
feat(MPS/FT): Plan C — proportional FT on paper-faithful SectorDecomposition surface (issue #1641)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -224,6 +224,7 @@ import TNLean.MPS.FundamentalTheorem.OverlapConvergenceAux
 import TNLean.MPS.FundamentalTheorem.Multi
 import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
 import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.Applications

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -829,7 +829,25 @@ The remaining formal proof obligation is documented in
 **Scope restriction (one-copy-per-sector):** The local hypotheses
 `IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
 forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
-documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
+
+**Plan C (issue #1641) status.** The per-block projection argument
+(paper Step 1) has been re-stated and proven on the paper-faithful
+`SectorDecomposition` surface in
+`TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection`
+(`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`).
+That theorem does *not* assume strict-anti weight ordering and works for an
+arbitrary fixed block `k₀`, with the load-bearing non-cancellation step
+factored out as a hypothesis.
+
+Bridging the present `IsCanonicalFormBNT` surface to the new SectorDecomposition
+lemma is blocked by the strict-anti restriction of `IsCanonicalFormBNT`:
+under `mu_strict_anti`, the unit-modulus hypothesis required by the
+SectorDecomposition lemma fails for every weight after the first.  Resolving
+this requires a structural refactor of `IsCanonicalFormBNT` that splits the
+spectral level (`λ_j` with `|λ_0| > |λ_1| > …`) from the within-sector
+unit-modulus weights (`μ_{j,q}` with `|μ_{j,q}| = 1`).  See
+`audits/2026-05-13_cpsv16_ft_bridge_gap.md` for the full analysis. -/
 lemma fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -866,7 +884,16 @@ The remaining formal proof obligation is documented in
 **Scope restriction (one-copy-per-sector):** The local hypotheses
 `IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
 forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
-documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
+
+**Plan C (issue #1641) status.** The symmetric per-block projection has been
+re-stated and proven on the paper-faithful `SectorDecomposition` surface in
+`TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection`
+(`fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`).
+The remaining bridge from the present `IsCanonicalFormBNT` surface to that
+SectorDecomposition lemma is blocked by the same strict-anti vs. unit-modulus
+mismatch as the right-block case.  See
+`audits/2026-05-13_cpsv16_ft_bridge_gap.md`. -/
 lemma fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean
@@ -1,0 +1,271 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition
+import TNLean.MPS.FundamentalTheorem.Full.ProportionalExpansion
+
+/-!
+# Paper Step 1 on the `SectorDecomposition` surface
+
+This module re-states and proves Step 1 of arXiv:1606.00608, Theorem `thm1`
+(the per-block-projection cancellation argument) on the paper-faithful
+`SectorDecomposition` surface introduced by issue #1641 / Plan C.
+
+## Main statements
+
+* `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`:
+  fix a `Q`-block `k₀` and assume all overlaps from `P.basis j` to `Q.basis k₀`
+  decay; the projected proportionality identity is then asymptotically
+  contradictory.
+* `fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`:
+  the symmetric statement obtained by swapping the two families.
+* `eventuallyNonzeroProportionalMPV₂_symm`: `EventuallyNonzeroProportionalMPV₂`
+  is symmetric in its two arguments; used to reduce the left case to the
+  right case.
+
+## Scope and load-bearing hypothesis
+
+The argument is decoupled from `IsCanonicalFormBNT`.  The hypotheses are the
+paper's: every per-sector weight has unit modulus, so the BNT coefficient
+`coeff N j = ∑_q (weight j q)^N` is bounded in modulus by the multiplicity
+`copies j`.  The load-bearing non-cancellation hypothesis `hNoCancel` is
+factored out: it asserts that the projected proportionality right-hand side
+`c_N · ⟪V(Q.toTensor), V(Q.basis k₀)⟫_N` does not tend to zero for the scalar
+witnesses `c` produced by `hProp`.  In the paper this non-cancellation
+follows from almost-periodicity of finite `N`-th power sums of unit-modulus
+complex numbers combined with the dominant-weight-adjusted scalar limit;
+both ingredients live outside this module.
+
+## References
+
+* Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017),
+  Theorem `thm1`, lines 1170--1192.
+* `audits/2026-05-13_cpsv16_ft_definition_audit.md` §10 (the per-block
+  projection algebra).
+-/
+
+open scoped Matrix BigOperators
+open Filter
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+section PerBlockProjection
+
+/-- **Bounded BNT coefficient from unit-modulus sector weights.**
+
+If every sector weight has unit modulus, then the coefficient
+`coeff N j = ∑_q (μ_{j,q})^N` is bounded in modulus by the multiplicity
+`copies j` uniformly in `N`.  This is the boundedness ingredient required for
+the per-block projection argument. -/
+lemma SectorDecomposition.norm_coeff_le_copies
+    (P : SectorDecomposition d)
+    (hP_unit : ∀ j q, ‖P.sectors.weight j q‖ = 1)
+    (N : ℕ) (j : Fin P.basisCount) :
+    ‖P.coeff N j‖ ≤ (P.copies j : ℝ) := by
+  classical
+  unfold SectorDecomposition.coeff SectorWeightData.coeff
+  refine (norm_sum_le _ _).trans ?_
+  have hterm : ∀ q : Fin (P.copies j), ‖(P.weight j q) ^ N‖ = 1 := by
+    intro q
+    rw [norm_pow, hP_unit j q, one_pow]
+  have hsum :
+      (∑ q : Fin (P.copies j), ‖(P.weight j q) ^ N‖) = (P.copies j : ℝ) := by
+    calc
+      (∑ q : Fin (P.copies j), ‖(P.weight j q) ^ N‖)
+          = ∑ q : Fin (P.copies j), (1 : ℝ) := by
+            refine Finset.sum_congr rfl ?_
+            intro q _
+            exact hterm q
+      _ = (P.copies j : ℝ) := by
+            simp
+  exact hsum.le
+
+/-- **Symmetry of `EventuallyNonzeroProportionalMPV₂`.**
+
+The eventual nonzero-proportionality predicate is symmetric in its two
+arguments: inverting the per-length scalar swaps the two MPV families. -/
+lemma eventuallyNonzeroProportionalMPV₂_symm
+    {d D₁ D₂ : ℕ} {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (h : EventuallyNonzeroProportionalMPV₂ A B) :
+    EventuallyNonzeroProportionalMPV₂ B A := by
+  refine h.mono ?_
+  intro N hN
+  rcases hN with ⟨c, hc, hEq⟩
+  refine ⟨c⁻¹, inv_ne_zero hc, fun σ => ?_⟩
+  calc
+    mpv B σ = c⁻¹ * (c * mpv B σ) := by
+      rw [inv_mul_cancel_left₀ hc]
+    _ = c⁻¹ * mpv A σ := by
+      rw [← hEq σ]
+
+/-- **Per-block projection contradiction (fixed right block).**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192.
+
+Given two paper-faithful sector decompositions `P, Q` with unit-modulus
+sector weights on `P`, eventual nonzero proportionality of the assembled
+tensors, and a fixed `Q`-block index `k₀` such that all cross-overlaps from
+`P.basis j` to `Q.basis k₀` decay to zero, the projected proportionality
+forces the scalar-weighted projected sum to tend to zero.  Combined with the
+non-cancellation hypothesis `hNoCancel`, this is contradictory.
+
+This is Plan C on the `SectorDecomposition` surface (paper Step 1) for an
+arbitrary fixed block, without any combined-family linear-independence input.
+
+**Load-bearing hypothesis:** `hNoCancel` asserts that for every scalar
+sequence `c` witnessing the eventual proportionality, the product
+`c N · ⟪V(Q.toTensor), V(Q.basis k₀)⟫_N` does not tend to zero.  In the paper
+this follows from (i) almost-periodicity giving `lim sup |coeff_Q N k₀| > 0`,
+(ii) decay of off-diagonal `Q` cross-overlaps and bounded `|coeff_Q|` from
+unit-modulus weights, and (iii) `|c_N|` bounded below via the dominant-weight
+scaling lemma.  Folding (i)--(iii) into a single hypothesis decouples the
+algebraic skeleton (here) from the analytic content (a future workstream). -/
+lemma fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp
+    (P Q : SectorDecomposition d)
+    (hP_unit : ∀ j q, ‖P.sectors.weight j q‖ = 1)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (k₀ : Fin Q.basisCount)
+    (hAllDecay : ∀ j : Fin P.basisCount,
+      Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+        atTop (nhds 0))
+    (hNoCancel : ∀ c : ℕ → ℂ,
+      (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+        mpv P.toTensor σ = c N * mpv Q.toTensor σ) →
+      ¬ Tendsto
+        (fun N => c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+        atTop (nhds 0)) :
+    False := by
+  classical
+  -- Step 1: extract a scalar sequence `c` witnessing the eventual
+  -- proportionality, in the same style as
+  -- `exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroProportionalMPV₂`.
+  set Pprop : ℕ → Prop := fun N =>
+    ∃ c : ℂ, c ≠ 0 ∧ ∀ σ : Fin N → Fin d,
+      mpv P.toTensor σ = c * mpv Q.toTensor σ with hPprop_def
+  have hEvent : ∀ᶠ N in atTop, Pprop N := hProp
+  let c : ℕ → ℂ := fun N => if hN : Pprop N then Classical.choose hN else 1
+  have hc_eq : ∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+      mpv P.toTensor σ = c N * mpv Q.toTensor σ := by
+    refine hEvent.mono ?_
+    intro N hN
+    simp only [c]
+    rw [dif_pos hN]
+    exact (Classical.choose_spec hN).2
+  -- Step 2: the projected proportionality identity holds eventually in `N`.
+  --   `mpvOverlap P.toTensor (Q.basis k₀) N = c N * mpvOverlap Q.toTensor (Q.basis k₀) N`
+  have hProj : ∀ᶠ N in atTop,
+      mpvOverlap (d := d) P.toTensor (Q.basis k₀) N
+        = c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N := by
+    refine hc_eq.mono ?_
+    intro N hN
+    exact
+      mpvOverlap_eq_mul_of_mpv_eq_mul (d := d) P.toTensor Q.toTensor
+        (c N) hN (Q.basis k₀)
+  -- Step 3: the LHS expands by the BNT decomposition for `P.toTensor`.
+  have hLHS_decomp : ∀ N : ℕ,
+      mpvOverlap (d := d) P.toTensor (Q.basis k₀) N
+        = ∑ j : Fin P.basisCount,
+            P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N := by
+    intro N
+    refine mpvOverlap_eq_sum_of_decomp_left
+      (d := d) (g := P.basisCount) (dim := P.basisDim)
+      P.toTensor P.basis (N := N)
+      (fun j => P.coeff N j) ?_ (Q.basis k₀)
+    intro σ
+    exact P.mpv_toTensor_eq_sum_coeff (N := N) σ
+  -- Step 4: each summand on the LHS tends to zero.
+  -- Bounded coefficient × decaying overlap = decaying product.
+  have hSummand : ∀ j : Fin P.basisCount,
+      Tendsto
+        (fun N => P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+        atTop (nhds 0) := by
+    intro j
+    -- `|coeff N j * overlap N| ≤ copies j * |overlap N|`.
+    refine squeeze_zero_norm
+      (f := fun N => P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+      (a := fun N => (P.copies j : ℝ)
+                      * ‖mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N‖)
+      ?_ ?_
+    · intro N
+      simp only [norm_mul]
+      exact mul_le_mul_of_nonneg_right
+        (P.norm_coeff_le_copies hP_unit N j) (norm_nonneg _)
+    · -- multiply the decay limit by the constant `(copies j : ℝ)`.
+      have h0 : Tendsto
+          (fun N => ‖mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N‖)
+          atTop (nhds 0) :=
+        (tendsto_zero_iff_norm_tendsto_zero.mp (hAllDecay j))
+      have := h0.const_mul (P.copies j : ℝ)
+      simpa using this
+  -- Step 5: the LHS therefore tends to zero.
+  have hLHS_tendsto : Tendsto
+      (fun N => mpvOverlap (d := d) P.toTensor (Q.basis k₀) N)
+      atTop (nhds 0) := by
+    have hSum : Tendsto
+        (fun N => ∑ j : Fin P.basisCount,
+            P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+        atTop (nhds 0) := by
+      have hTo : Tendsto
+          (fun N => ∑ j : Fin P.basisCount,
+              P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+          atTop (nhds (∑ _j : Fin P.basisCount, (0 : ℂ))) :=
+        tendsto_finset_sum (Finset.univ : Finset (Fin P.basisCount))
+          (fun j _ => hSummand j)
+      simpa using hTo
+    refine hSum.congr' ?_
+    refine Filter.Eventually.of_forall ?_
+    intro N
+    exact (hLHS_decomp N).symm
+  -- Step 6: combine with the projected proportionality identity to obtain the
+  -- scalar limit `c N * mpvOverlap Q.toTensor (Q.basis k₀) N → 0`.
+  have hRHS_tendsto : Tendsto
+      (fun N => c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+      atTop (nhds 0) := by
+    refine hLHS_tendsto.congr' ?_
+    exact hProj
+  -- Step 7: contradiction with `hNoCancel`.
+  exact hNoCancel c hc_eq hRHS_tendsto
+
+/-- **Per-block projection contradiction (fixed left block).**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1182--1185.
+
+Symmetric counterpart of
+`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`.
+Fixing a `P`-block `j₀` instead of a `Q`-block, the projected proportionality
+identity is contradictory with the per-block decay of all cross-overlaps to
+`P.basis j₀`.
+
+The proof reduces to the right-block version after swapping `P` and `Q`:
+the swapped proportionality witness `c⁻¹` plays the role of `c`, and the
+hypothesis `hAllDecay` is rephrased via `tendsto_mpvOverlap_zero_swap`. -/
+lemma fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp
+    (P Q : SectorDecomposition d)
+    (hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (j₀ : Fin P.basisCount)
+    (hAllDecay : ∀ k : Fin Q.basisCount,
+      Tendsto (fun N => mpvOverlap (d := d) (P.basis j₀) (Q.basis k) N)
+        atTop (nhds 0))
+    (hNoCancel : ∀ c : ℕ → ℂ,
+      (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+        mpv Q.toTensor σ = c N * mpv P.toTensor σ) →
+      ¬ Tendsto
+        (fun N => c N * mpvOverlap (d := d) P.toTensor (P.basis j₀) N)
+        atTop (nhds 0)) :
+    False := by
+  -- Swap P and Q and apply the right-block version.
+  refine
+    fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp
+      Q P hQ_unit (eventuallyNonzeroProportionalMPV₂_symm hProp) j₀ ?_ hNoCancel
+  intro k
+  exact tendsto_mpvOverlap_zero_swap (d := d) (P.basis j₀) (Q.basis k)
+    (hAllDecay k)
+
+end PerBlockProjection
+
+end MPSTensor

--- a/audits/2026-05-13_cpsv16_ft_bridge_gap.md
+++ b/audits/2026-05-13_cpsv16_ft_bridge_gap.md
@@ -1,0 +1,173 @@
+# CPSV16 FT — bridge gap between `IsCanonicalFormBNT` and `SectorDecomposition`
+
+**Date:** 2026-05-13
+**Scope:** Plan C, Objective 3 (per issue #1641).
+**Status:** Identified blocker; bridge not direct.  See "Resolution" below.
+
+## Context
+
+Plan C (issue #1641) re-states Paper Step 1 of arXiv:1606.00608 Theorem `thm1`
+on the paper-faithful `SectorDecomposition` + `HasBNTSectorData` surface, in
+
+  `TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean`
+
+The lemmas
+
+  `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
+  `fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
+
+require the **unit-modulus** hypothesis on at least one family's sector
+weights:
+
+  `(hP_unit : ∀ j q, ‖P.sectors.weight j q‖ = 1)`
+  (`hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)`
+
+This is the spectral-radius-1 normalization paper-faithful CPSV16 imposes at
+every block in the BNT canonical form (every sector lives at the unit circle,
+multiplicity is recovered inside the sector via Newton identities on
+unit-modulus `μ_{j,q}`).
+
+Objective 3 of #1641 asks to bridge this surface to the existing local
+hypothesis `IsCanonicalFormBNT μ A` driving the two `sorry`s in
+
+  `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
+
+at the lemmas `_CFBNT` (`fixed_right_…_CFBNT`, `fixed_left_…_CFBNT`).
+
+## The mismatch
+
+`IsCanonicalFormBNT` (`TNLean/MPS/BNT/Construction.lean:99`) bundles, among
+other fields, the **strict-anti** weight ordering:
+
+```
+mu_strict_anti : StrictAnti (fun k : Fin r => ‖μ k‖)
+```
+
+This is the one-copy-per-sector restriction (`copies j = 1`, `r_j = 1` for
+every sector); the file's own scope comment names this explicitly:
+
+> SCOPE(one-copy-per-sector): `mu_strict_anti` forces `r_j = 1`; all
+> downstream FT theorems are restricted to this special case.
+
+Under `StrictAnti`, the moduli `‖μ k‖` are pairwise distinct.  CPSV16's
+paper-faithful canonical form normalizes the dominant weight to `‖μ 0‖ = 1`
+and then has `‖μ k‖ < 1` for every `k ≥ 1` (a geometric decay).  In
+particular, the unit-modulus hypothesis `∀ k, ‖μ k‖ = 1` is satisfied
+**only at `k = 0`** and **fails for `k ≥ 1`**.
+
+The Plan C theorems therefore do not directly apply to the
+`IsCanonicalFormBNT` data shape: the bridge would need to supply `hP_unit` /
+`hQ_unit`, and the strict-anti ordering forbids it for `r ≥ 2`.
+
+## Why a direct bridge fails
+
+The naive bridge would be:
+
+1. From `IsCanonicalFormBNT μ A` (with `μ : Fin r → ℂ`,
+   `A : Fin r → MPSTensor d _`) construct a `SectorDecomposition`
+   `P_{μ,A}` with `basisCount = r`, `copies j = 1`, `weight j 0 = μ j`,
+   `basis j = A j`.
+
+2. Note `toTensor (P_{μ,A})` is propositionally equal to
+   `toTensorFromBlocks μ A` (as the assembled block-diagonal tensor).
+
+3. Derive `HasBNTSectorData` from the existing BNT linear-independence
+   construction for separated CF blocks.
+
+4. **Provide `hP_unit`.**  Here the bridge breaks: under `mu_strict_anti`,
+   `‖μ j‖ ≠ 1` whenever `j ≥ 1` (after the normalization `‖μ 0‖ = 1` that
+   CPSV16 uses; for general data, all `‖μ j‖` are distinct so unit-modulus
+   fails for at least `r - 1` indices).
+
+A rescaling that turns each `‖μ j‖` into 1 would require multiplying `μ j` by
+`μ j / ‖μ j‖` (i.e., conjugating by `‖μ j‖`), but this is **not** an allowed
+transformation: it changes the assembled MPV vectors by length-dependent
+factors, breaking the proportionality hypothesis.  Equivalently, we cannot
+rescale the blocks `A j` individually without breaking the left-canonical
+normalization (`hCF.toIsLeftCanonicalBlockFamily`) and the self-overlap
+limit (`hCF.toHasNormalizedSelfOverlap`).
+
+## What the paper does instead
+
+CPSV16's argument lives one layer up: the BNT canonical form sits *inside*
+each spectral sector, with the sector weight `μ_{j,q}` all carrying modulus
+1 *within sector* `j`, and the sector index `j` carrying a separate scaling
+`λ_j` with `|λ_j| < |λ_0|` for `j ≥ 1`.  The Plan C `hP_unit` is about the
+inside-sector weights `μ_{j,q}`, not about the sector-level `λ_j`.
+
+The current `IsCanonicalFormBNT` formalization conflates these two layers
+into a single one-copy-per-sector index, with `μ_k = λ_k` (no inside-sector
+multiplicity recovered).  In particular it does **not** carry data of the
+form
+
+  "spectral level `λ_j` with associated within-sector weights `μ_{j,q}`,
+   all of modulus 1, with multiplicity `r_j`."
+
+To bridge cleanly, we need a refactor that splits `IsCanonicalFormBNT` into
+two layers, or a new structure `IsBNTCanonicalForm` over `SectorDecomposition`
+that bakes in `hP_unit` / `hQ_unit` at the sector-weight layer.
+
+## Resolution
+
+Objective 3 of #1641 is **NOT-STARTED** (intentional): the bridge cannot be
+produced without a structural refactor of `IsCanonicalFormBNT` to expose the
+two-layer spectral/within-sector decomposition.  Objective 4 (discharge of
+the existing `_CFBNT` sorries) is therefore also **NOT-STARTED**.
+
+The Plan C algebraic skeleton on the `SectorDecomposition` surface is in
+place and stands on its own — `PerBlockProjection.lean` builds cleanly,
+introduces no new `sorry`s, and is referenced from `TNLean.lean`.  The
+follow-up workstream is to:
+
+1. Introduce a `SectorDecomposition`-level "BNT canonical form" wrapper
+   bundling `hP_unit` / `hQ_unit` (sector-weight unit-modulus) alongside
+   `HasBNTSectorData`, decay of self/cross-overlaps inside the basis, and
+   the dominant-weight normalization.  Call it `IsBNTCanonicalForm` (or
+   similar) over a `SectorDecomposition`.
+
+2. Provide the unconditional construction of this wrapper from the
+   irreducible-primitive-TP block input (extending the existing
+   `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` in
+   `TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean`).
+
+3. Retire the strict-anti restriction inside `IsCanonicalFormBNT`, or pull
+   it apart into a strict-anti wrapper over `IsBNTCanonicalForm`.
+
+4. Discharge the load-bearing `hNoCancel` hypothesis of the Plan C lemmas
+   for the new wrapper.  This is the analytic content: almost-periodicity
+   of `∑_q μ_{j,q}^N` for unit-modulus weights, plus the dominant-weight-
+   adjusted scalar limit from `ProportionalScalar.lean`.
+
+5. Use the wrapper to rewrite `_CFBNT` callers in `NondecayingOverlap.lean`.
+
+This is a multi-PR sequence and outside the time budget of #1641.
+
+## Related infrastructure
+
+* `TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean` already provides
+  `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks` returning a
+  `SectorDecomposition` + `HasBNTSectorData` from TP/primitive/irreducible
+  block input.  It produces the assembled `P.toTensor` equal in MPV to the
+  original `toTensorFromBlocks μ A`.  This is the natural foundation for
+  the wrapper in step 1 above.
+
+* `TNLean/MPS/FundamentalTheorem/Full/ProportionalScalar.lean` has
+  `tendsto_norm_adjusted_weighted_mpvState_scalar_of_eventually_tendsto_norm_one`
+  which controls `|c_N (ν/μ)^N| → 1` and is the input for the dominant-weight
+  side of `hNoCancel`.
+
+* `TNLean/Algebra/ScalarPowerSumIdentity.lean` is the natural home for the
+  Newton-identity / almost-periodicity sub-lemma `coeff_N k₀ ↛ 0` for
+  unit-modulus sector weights.
+
+## References
+
+* arXiv:1606.00608 Theorem `thm1`, lines 1170–1192 (the per-block
+  projection argument).
+* arXiv:2011.12127 Definition 4.2 (the two-layer BNT canonical form).
+* `audits/2026-05-13_cpsv16_ft_definition_audit.md` §10 (Plan C YES verdict
+  on the SectorDecomposition surface).
+* `audits/2026-05-13_cpsv16_ft_discharge_attempt.md` (Plan A blocker on the
+  restricted `IsCanonicalFormBNT` surface).
+* Issue #1641 (Plan C workplan).
+* PR #1639 (the wrong-direction-cleanup baseline).


### PR DESCRIPTION
## Summary

Implements **Plan C** for issue #1641 — migrates the CPSV16 FT proportional case (paper Step 1: per-block projection contradiction) onto the paper-faithful `SectorDecomposition` + `HasBNTSectorData` surface, decoupled from `IsCanonicalFormBNT`.

The Plan C **algebraic skeleton** is complete on the new surface (no `sorry`, no `axiom`, no combined-family LI, no peel-off induction). The bridge from the existing `IsCanonicalFormBNT` data shape to the new lemmas turns out to be **blocked at the data shape**: it is documented in detail in a new audit memo and is a separate workstream.

Branched off `feat/mps-ft-delete-wrong-direction-scaffolding` (the PR #1639 wrong-direction-cleanup baseline).

## Objective status

| Objective | Status | Notes |
|---|---|---|
| 1. Re-state Paper Step 1 on SectorDecomposition surface | ✅ DONE | `PerBlockProjection.lean`, both `fixed_right` and `fixed_left`. |
| 2. Prove the theorems | ✅ DONE | Full algebraic argument (Steps 1–7 of audit §10). No `sorry`. |
| 3. Bridge `IsCanonicalFormBNT` → `SectorDecomposition` | ⚠️ BLOCKED & DOCUMENTED | `mu_strict_anti` field of `IsCanonicalFormBNT` forbids the unit-modulus hypothesis required by Plan C. |
| 4. Discharge the existing `_CFBNT` sorries | ⚠️ NOT-STARTED | Same blocker as #3. Sorries left in place with updated docstrings cross-referencing the new theorems + bridge-gap memo. |

**Net `sorry` count delta: 0** (the 2 existing `_CFBNT` sorries remain by design; no new `sorry` introduced).

## What's new

### `TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean`

Three main contents:

1. `SectorDecomposition.norm_coeff_le_copies`: under unit-modulus weights, the BNT coefficient `coeff N j = ∑_q (μ_{j,q})^N` is bounded by `copies j` uniformly in `N`. This is the boundedness ingredient for LHS-tends-to-zero.

2. `eventuallyNonzeroProportionalMPV₂_symm`: symmetry of the eventual nonzero-proportionality predicate, used to reduce the `fixed_left` case to `fixed_right` by swapping `P` and `Q`.

3. `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp` (+ symmetric `fixed_left_*`):

```
lemma fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp
    (P Q : SectorDecomposition d)
    (hP_unit : ∀ j q, ‖P.sectors.weight j q‖ = 1)
    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
    (k₀ : Fin Q.basisCount)
    (hAllDecay : ∀ j, Tendsto (fun N => mpvOverlap (P.basis j) (Q.basis k₀) N) atTop (nhds 0))
    (hNoCancel : ∀ c : ℕ → ℂ,
      (∀ᶠ N in atTop, ∀ σ, mpv P.toTensor σ = c N * mpv Q.toTensor σ) →
      ¬ Tendsto (fun N => c N * mpvOverlap Q.toTensor (Q.basis k₀) N) atTop (nhds 0)) :
    False
```

Proof structure (audit memo `2026-05-13_cpsv16_ft_definition_audit.md` §10):

1. Extract a scalar sequence `c` from `hProp` via `Classical.choose` (same pattern as `exists_eventually_weighted_mpvState_eq_smul_sequence_of_eventuallyNonzeroProportionalMPV₂`).
2. Project the proportionality onto `Q.basis k₀` (right slot) via `mpvOverlap_eq_mul_of_mpv_eq_mul`.
3. Expand the LHS via `mpv_toTensor_eq_sum_coeff` + `mpvOverlap_eq_sum_of_decomp_left`.
4. Each summand tends to zero: `|coeff_P N j| ≤ P.copies j` (bounded, from `hP_unit`) × `mpvOverlap → 0` (from `hAllDecay`). Use `squeeze_zero_norm`.
5. Finite sum of tendsto-zero terms is tendsto-zero (`tendsto_finset_sum`).
6. The projected proportionality identity transports this to `c N * mpvOverlap Q.toTensor (Q.basis k₀) N → 0`.
7. Contradiction with `hNoCancel`.

### Load-bearing hypothesis `hNoCancel`

Factored out (per the task spec's fallback option): in the paper this follows from
- (i) almost-periodicity of finite N-th power sums of unit-modulus complex numbers giving `lim sup |coeff_Q N k₀| > 0`,
- (ii) bounded off-diagonal `Q`-cross-overlap decay (from per-block BNT structure),
- (iii) `|c_N|` bounded below via the dominant-weight-adjusted scalar limit (`ProportionalScalar.lean`).

Discharging `hNoCancel` from (i)–(iii) is a separate analytic workstream; the algebraic skeleton here is independent.

### `audits/2026-05-13_cpsv16_ft_bridge_gap.md`

Documents the structural mismatch between `IsCanonicalFormBNT` (whose `mu_strict_anti` field forces `r_j = 1` per sector and `|μ_k|` strictly decreasing) and the Plan C unit-modulus hypothesis. Includes the follow-up workstream sketch: introduce a `SectorDecomposition`-level `IsBNTCanonicalForm` wrapper bundling `hP_unit` alongside `HasBNTSectorData`, decay structures, and dominant-weight normalization; then provide the unconditional construction from TP/primitive/irreducible block data; then retire the strict-anti restriction.

### `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`

Docstrings of the two `_CFBNT` sorries (`fixed_right_…_CFBNT`, `fixed_left_…_CFBNT`) updated to reference the new SectorDecomposition lemma and the bridge-gap audit memo. The sorries themselves are unchanged.

### `TNLean.lean`

Wires the new `PerBlockProjection` module into the project root.

## Verification

- `lake build TNLean` ✅ clean
- `lean_diagnostics PerBlockProjection.lean` ✅ no errors / warnings / hints
- No new `sorry`, no `axiom`, no `unsafe`
- No combined-family LI (CFLI / RSE / Option-LI), per the PR #1639 baseline policy
- No peel-arbitrary-`k₀` induction

## Commit map

- `a18fe0d0` `feat(MPS/FT): per-block projection on SectorDecomposition surface (Plan C, #1641)` — Objectives 1 + 2.
- `023f533b` `doc(MPS/FT): document IsCanonicalFormBNT→SectorDecomposition bridge gap (#1641)` — Objectives 3 + 4 (with docs cross-referencing).

## References

- Issue #1641 — Plan C workplan.
- PR #1639 — the wrong-direction-cleanup baseline.
- Issue #1607 — the original `_CFBNT` cancellation gap.
- `audits/2026-05-13_cpsv16_ft_definition_audit.md` §10 — the YES verdict for Plan C.
- `audits/2026-05-13_cpsv16_ft_discharge_attempt.md` — Plan A blocker on the restricted surface.
- `audits/2026-05-13_cpsv16_ft_bridge_gap.md` — **new** bridge-gap analysis.
- `blueprint/comments202605/cpsv16_fundamental_theorem_analysis.md` §4.2 — paper's projection algebra.

## Honest reporting (per task spec)

The work was scoped at "up to 120 minutes". The Plan C algebraic skeleton (Objectives 1+2) went through cleanly on the SectorDecomposition surface; the bridge analysis (Objective 3) reached a clean go/no-go decision early enough to write up the structural blocker. Objective 4 is **deferred** to a follow-up PR that completes the structural refactor identified in the bridge-gap memo. Two existing `sorry`s in `NondecayingOverlap.lean` remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new proof module and documentation with minimal impact on existing logic (only new imports and docstring updates), and introduces no new `sorry`s or behavior changes.
> 
> **Overview**
> Implements Plan C Step 1 of CPSV16 Theorem `thm1` on the paper-faithful `SectorDecomposition` surface by adding `PerBlockProjection.lean`, proving fixed-block projection contradictions for proportional MPVs (and a symmetry lemma for `EventuallyNonzeroProportionalMPV₂`) under unit-modulus sector weights and an explicit non-cancellation hypothesis.
> 
> Wires the new module into the root `TNLean.lean` import surface, and updates the two existing `_CFBNT` fixed-block `sorry` docstrings in `Full/NondecayingOverlap.lean` to cross-reference the new SectorDecomposition results and a new audit memo (`audits/2026-05-13_cpsv16_ft_bridge_gap.md`) describing why the current `IsCanonicalFormBNT` shape cannot directly satisfy the unit-modulus hypotheses needed for the new lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023f533b448115b47ebc5f68283e8b7f02d0bf05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->