### PR TITLE
feat(MPS/FT): Plan C (A) — discharge `hNoCancel` from unit-modulus + decay + c-lower

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -28,6 +28,7 @@ import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.LinearMapAux
 import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.ScalarPowerSumIdentity
+import TNLean.Algebra.UnitModulusPowerSum
 import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.MatrixFrobenius
@@ -225,6 +226,7 @@ import TNLean.MPS.FundamentalTheorem.Multi
 import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.HNoCancelDischarge
 import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.Applications

--- a/TNLean/Algebra/UnitModulusPowerSum.lean
+++ b/TNLean/Algebra/UnitModulusPowerSum.lean
@@ -6,7 +6,6 @@ import Mathlib.Analysis.Asymptotics.SpecificAsymptotics
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Field.GeomSum
-import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Analysis.CStarAlgebra.Basic
 
 /-!
@@ -130,7 +129,7 @@ sequence `N ↦ ∑_q (μ q) ^ N` does not tend to `0` as `N → ∞`.
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192 (the
 unit-modulus power-sum non-decay used inside the per-block projection
 step).  Proof via Cesaro averaging of `‖S N‖²` in `ℂ`. -/
-theorem unitModulus_powerSum_not_tendsto_zero
+theorem unitModulus_power_sum_not_tendsto_zero
     {r : ℕ} (hr : 0 < r) (μ : Fin r → ℂ) (hμ : ∀ q, ‖μ q‖ = 1) :
     ¬ Tendsto (fun N : ℕ => ∑ q : Fin r, (μ q) ^ N) atTop (nhds 0) := by
   classical

--- a/TNLean/Algebra/UnitModulusPowerSum.lean
+++ b/TNLean/Algebra/UnitModulusPowerSum.lean
@@ -1,0 +1,294 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Asymptotics.SpecificAsymptotics
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Field.GeomSum
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Analysis.CStarAlgebra.Basic
+
+/-!
+# Power-sum non-decay for unit-modulus complex families
+
+This module proves a purely analytic fact about finite power sums of
+unit-modulus complex numbers: the sequence
+
+  `N ↦ ∑_q (μ q) ^ N`
+
+does **not** tend to zero as `N → ∞`, provided the family `μ : Fin r → ℂ`
+is nonempty and every `μ q` has modulus one.  The argument is the standard
+Wiener / Cesaro one:
+
+* `‖S N‖² = ∑_{q, q'} (μ q · star (μ q'))^N`.
+* Cesaro-averaging in `N` produces, for each pair `(q, q')`,
+  either `1` (when the unit-modulus ratio `μ q · star (μ q')` equals `1`)
+  or `0` (when the unit-modulus ratio differs from `1`, the geometric
+  sum is bounded uniformly in `T`).
+* The Cesaro limit therefore equals the cardinality of the resonant set
+  `{(q, q') | μ q · star (μ q') = 1}`, which contains the diagonal
+  `{(q, q)}` and is therefore `≥ r > 0`; the assumption that the original
+  sequence tends to zero would force the Cesaro mean to vanish, a
+  contradiction.
+
+This is the analytic ingredient used to discharge the load-bearing
+`hNoCancel` hypothesis in the per-block projection argument of
+arXiv:1606.00608, Theorem `thm1` (lines 1170--1192).  The MPS-side
+discharge lives in
+`TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean`.
+
+The module is purely about complex power sums; it has no MPS
+dependencies and uses no `sorry`/`axiom`/`unsafe`.
+
+## References
+
+* Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608
+  (2017), Theorem `thm1`, lines 1170--1192 (the unit-modulus power-sum
+  non-decay used inside the per-block projection step).
+-/
+
+open scoped BigOperators
+open Filter
+
+namespace UnitModulusPowerSum
+
+/-- For unit-modulus `ν ≠ 1`, the partial sums `∑_{N < T} ν^N` are uniformly
+bounded in `T` by `2 / ‖ν - 1‖`. -/
+lemma norm_geom_sum_le {ν : ℂ} (hν : ‖ν‖ = 1) (hne : ν ≠ 1) (T : ℕ) :
+    ‖∑ N ∈ Finset.range T, ν ^ N‖ ≤ 2 / ‖ν - 1‖ := by
+  classical
+  have hsub : ν - 1 ≠ 0 := sub_ne_zero.mpr hne
+  rw [geom_sum_eq hne T, norm_div]
+  have hnum : ‖ν ^ T - 1‖ ≤ 2 := by
+    calc ‖ν ^ T - 1‖
+        ≤ ‖ν ^ T‖ + ‖(1 : ℂ)‖ := by
+          have := norm_sub_le (ν ^ T) (1 : ℂ)
+          simpa using this
+      _ = 2 := by
+          rw [norm_pow, hν, one_pow, norm_one]
+          norm_num
+  have hden_pos : 0 < ‖ν - 1‖ := norm_pos_iff.mpr hsub
+  exact div_le_div_of_nonneg_right hnum hden_pos.le
+
+/-- Cesaro average of unit-modulus powers vanishes when the base is not `1`. -/
+lemma cesaro_geom_sum_tendsto_zero {ν : ℂ} (hν : ‖ν‖ = 1) (hne : ν ≠ 1) :
+    Tendsto (fun T : ℕ => (T : ℂ)⁻¹ * ∑ N ∈ Finset.range T, ν ^ N)
+      atTop (nhds 0) := by
+  classical
+  refine (tendsto_zero_iff_norm_tendsto_zero).mpr ?_
+  have hbound : ∀ T : ℕ,
+      ‖(T : ℂ)⁻¹ * ∑ N ∈ Finset.range T, ν ^ N‖ ≤ (2 / ‖ν - 1‖) * (T : ℝ)⁻¹ := by
+    intro T
+    rcases Nat.eq_zero_or_pos T with hT | hT
+    · subst hT
+      simp
+    · rw [norm_mul]
+      have h1 : ‖(T : ℂ)⁻¹‖ = (T : ℝ)⁻¹ := by
+        rw [norm_inv, Complex.norm_natCast]
+      rw [h1]
+      have h2 := norm_geom_sum_le hν hne T
+      have hTpos : (0 : ℝ) < T := by exact_mod_cast hT
+      calc (T : ℝ)⁻¹ * ‖∑ N ∈ Finset.range T, ν ^ N‖
+          ≤ (T : ℝ)⁻¹ * (2 / ‖ν - 1‖) :=
+            mul_le_mul_of_nonneg_left h2 (inv_nonneg.mpr hTpos.le)
+        _ = (2 / ‖ν - 1‖) * (T : ℝ)⁻¹ := by ring
+  -- The RHS tends to zero.
+  have hRHS : Tendsto (fun T : ℕ => (2 / ‖ν - 1‖) * (T : ℝ)⁻¹)
+      atTop (nhds 0) := by
+    have hT : Tendsto (fun T : ℕ => ((T : ℝ))⁻¹) atTop (nhds 0) := by
+      have hAtTop : Tendsto (fun T : ℕ => ((T : ℝ))) atTop atTop := by
+        exact_mod_cast tendsto_natCast_atTop_atTop (R := ℝ)
+      have := Filter.Tendsto.inv_tendsto_atTop hAtTop
+      simpa [Function.comp] using this
+    have := hT.const_mul (2 / ‖ν - 1‖)
+    simpa using this
+  refine squeeze_zero (fun T => norm_nonneg _) hbound hRHS
+
+/-- Cesaro average of unit-modulus powers at the base `1` equals `1`. -/
+lemma cesaro_geom_sum_one_tendsto_one :
+    Tendsto (fun T : ℕ => (T : ℂ)⁻¹ * ∑ _N ∈ Finset.range T, (1 : ℂ) ^ _N)
+      atTop (nhds 1) := by
+  classical
+  -- Show the sequence is eventually equal to 1 (for T ≥ 1).
+  refine tendsto_const_nhds.congr' ?_
+  refine (Filter.eventually_ge_atTop 1).mono ?_
+  intro T hT
+  have hTne : (T : ℂ) ≠ 0 := by
+    have hT' : 0 < T := hT
+    exact_mod_cast hT'.ne'
+  simp [Finset.sum_const, Finset.card_range]
+  field_simp
+
+/-- **Power-sum of a finite, nonempty unit-modulus family does not tend
+to zero.**
+
+For `μ : Fin r → ℂ` with `r > 0` and `‖μ q‖ = 1` for every `q`, the
+sequence `N ↦ ∑_q (μ q) ^ N` does not tend to `0` as `N → ∞`.
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192 (the
+unit-modulus power-sum non-decay used inside the per-block projection
+step).  Proof via Cesaro averaging of `‖S N‖²` in `ℂ`. -/
+theorem unitModulus_powerSum_not_tendsto_zero
+    {r : ℕ} (hr : 0 < r) (μ : Fin r → ℂ) (hμ : ∀ q, ‖μ q‖ = 1) :
+    ¬ Tendsto (fun N : ℕ => ∑ q : Fin r, (μ q) ^ N) atTop (nhds 0) := by
+  classical
+  intro hT
+  set S : ℕ → ℂ := fun N => ∑ q : Fin r, (μ q) ^ N with hS_def
+  -- Step 1: cast `‖S N‖^2` into `ℂ` and show it tends to 0.
+  have hS_norm : Tendsto (fun N : ℕ => ‖S N‖) atTop (nhds 0) :=
+    (tendsto_zero_iff_norm_tendsto_zero.mp hT)
+  have hSsq_ℝ : Tendsto (fun N : ℕ => (‖S N‖ : ℝ) ^ 2) atTop (nhds 0) := by
+    have := hS_norm.mul hS_norm
+    simpa [sq] using this
+  have hSsq_ℂ :
+      Tendsto (fun N : ℕ => ((‖S N‖ ^ 2 : ℝ) : ℂ)) atTop (nhds 0) := by
+    have hcont : Tendsto (fun x : ℝ => (x : ℂ)) (nhds (0 : ℝ)) (nhds (0 : ℂ)) := by
+      have := Complex.continuous_ofReal.tendsto (0 : ℝ)
+      simpa using this
+    exact hcont.comp hSsq_ℝ
+  -- Step 2: Cesaro mean of `(‖S N‖^2 : ℂ)` tends to 0.
+  have hCes :
+      Tendsto
+        (fun T : ℕ => (T : ℂ)⁻¹ *
+          ∑ N ∈ Finset.range T, ((‖S N‖ ^ 2 : ℝ) : ℂ))
+        atTop (nhds 0) := by
+    have hsmul := hSsq_ℂ.cesaro_smul
+    refine hsmul.congr ?_
+    intro T
+    rcases Nat.eq_zero_or_pos T with hT0 | hT0
+    · subst hT0
+      simp
+    · -- (T : ℝ)⁻¹ • z = (T : ℂ)⁻¹ * z
+      change ((T : ℝ))⁻¹ • (∑ N ∈ Finset.range T, ((‖S N‖ ^ 2 : ℝ) : ℂ))
+          = (T : ℂ)⁻¹ * ∑ N ∈ Finset.range T, ((‖S N‖ ^ 2 : ℝ) : ℂ)
+      rw [Complex.real_smul]
+      simp
+  -- Step 3: ‖S N‖^2 expands as a complex double-sum over Fin r × Fin r.
+  have hSqExpand : ∀ N : ℕ,
+      ((‖S N‖ ^ 2 : ℝ) : ℂ)
+        = ∑ p : Fin r × Fin r, (μ p.1 * star (μ p.2)) ^ N := by
+    intro N
+    have hnormSq : ((‖S N‖ ^ 2 : ℝ) : ℂ) = S N * star (S N) := by
+      have h1 : Complex.normSq (S N) = ‖S N‖ ^ 2 :=
+        Complex.normSq_eq_norm_sq (S N)
+      have h2 : S N * (starRingEnd ℂ) (S N) = (Complex.normSq (S N) : ℂ) :=
+        Complex.mul_conj (S N)
+      have h3 : S N * star (S N) = ((‖S N‖ ^ 2 : ℝ) : ℂ) := by
+        rw [show star (S N) = (starRingEnd ℂ) (S N) from rfl, h2, h1]
+      exact h3.symm
+    rw [hnormSq, hS_def]
+    -- S N = ∑_q μ_q^N; star (S N) = ∑_q' star (μ_q')^N
+    have hStar : star (∑ q : Fin r, (μ q) ^ N)
+        = ∑ q : Fin r, (star (μ q)) ^ N := by
+      rw [star_sum]
+      refine Finset.sum_congr rfl ?_
+      intro q _
+      exact star_pow (μ q) N
+    rw [hStar, Fintype.sum_mul_sum]
+    -- Now want: ∑ i, ∑ j, μ i ^ N * star (μ j) ^ N
+    --          = ∑ p : Fin r × Fin r, (μ p.1 * star (μ p.2)) ^ N
+    rw [← Finset.sum_product']
+    refine Finset.sum_congr rfl ?_
+    rintro ⟨i, j⟩ _
+    change (μ i) ^ N * (star (μ j)) ^ N = (μ i * star (μ j)) ^ N
+    rw [mul_pow]
+  -- Step 4: Cesaro mean of the double-sum tends to a positive count.
+  have hPair_unit : ∀ p : Fin r × Fin r, ‖μ p.1 * star (μ p.2)‖ = 1 := by
+    intro p
+    rw [norm_mul, hμ p.1, norm_star, hμ p.2, one_mul]
+  -- target is the count of pairs (q, q') with μ q * star (μ q') = 1.
+  let resonant : Finset (Fin r × Fin r) :=
+    Finset.univ.filter (fun p => μ p.1 * star (μ p.2) = 1)
+  let target : ℂ :=
+    ∑ p : Fin r × Fin r, if μ p.1 * star (μ p.2) = 1 then (1 : ℂ) else 0
+  -- The diagonal {(q,q) | q : Fin r} ⊆ resonant, so resonant.card ≥ r.
+  have hDiag_sub :
+      (Finset.univ.image (fun q : Fin r => (q, q))) ⊆ resonant := by
+    intro p hp
+    rcases Finset.mem_image.mp hp with ⟨q, _, rfl⟩
+    have hμq_sq : μ q * star (μ q) = 1 := by
+      have h := Complex.mul_conj (μ q)
+      have h2 : Complex.normSq (μ q) = 1 := by
+        have := Complex.normSq_eq_norm_sq (μ q)
+        rw [this, hμ q, one_pow]
+      have h3 : μ q * (starRingEnd ℂ) (μ q) = 1 := by
+        rw [h, h2]; norm_num
+      rw [show star (μ q) = (starRingEnd ℂ) (μ q) from rfl]
+      exact h3
+    exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, hμq_sq⟩
+  have hDiag_card : (Finset.univ.image (fun q : Fin r => (q, q))).card = r := by
+    rw [Finset.card_image_of_injective _ (fun a b h => (Prod.mk.inj h).1)]
+    exact (Finset.card_univ : (Finset.univ : Finset (Fin r)).card = _).trans
+      (Fintype.card_fin r)
+  have hResonant_card_ge : r ≤ resonant.card := by
+    have := Finset.card_le_card hDiag_sub
+    rw [hDiag_card] at this
+    exact this
+  -- target = (resonant.card : ℂ).
+  have htarget_card : target = (resonant.card : ℂ) := by
+    change (∑ p : Fin r × Fin r,
+        if μ p.1 * star (μ p.2) = 1 then (1 : ℂ) else 0) = (resonant.card : ℂ)
+    rw [Finset.sum_boole]
+  -- target ≠ 0.
+  have htarget_ne : target ≠ 0 := by
+    rw [htarget_card]
+    have : 0 < resonant.card := lt_of_lt_of_le hr hResonant_card_ge
+    exact_mod_cast this.ne'
+  -- Cesaro mean of each summand tends to `if (ν p) = 1 then 1 else 0`.
+  have hPair_cesaro : ∀ p : Fin r × Fin r,
+      Tendsto
+        (fun T : ℕ => (T : ℂ)⁻¹ *
+          ∑ N ∈ Finset.range T, (μ p.1 * star (μ p.2)) ^ N)
+        atTop
+        (nhds (if μ p.1 * star (μ p.2) = 1 then (1 : ℂ) else 0)) := by
+    intro p
+    by_cases hν1 : μ p.1 * star (μ p.2) = 1
+    · rw [if_pos hν1]
+      have := cesaro_geom_sum_one_tendsto_one
+      refine this.congr' ?_
+      refine Filter.Eventually.of_forall ?_
+      intro T
+      rw [hν1]
+    · rw [if_neg hν1]
+      exact cesaro_geom_sum_tendsto_zero (hPair_unit p) hν1
+  -- Sum of Cesaro limits is the Cesaro limit of the sum.
+  have hSum_cesaro :
+      Tendsto
+        (fun T : ℕ => (T : ℂ)⁻¹ *
+          ∑ N ∈ Finset.range T, ∑ p : Fin r × Fin r,
+            (μ p.1 * star (μ p.2)) ^ N)
+        atTop (nhds target) := by
+    have hSum : Tendsto
+        (fun T : ℕ => ∑ p : Fin r × Fin r,
+          (T : ℂ)⁻¹ * ∑ N ∈ Finset.range T, (μ p.1 * star (μ p.2)) ^ N)
+        atTop (nhds target) :=
+      tendsto_finset_sum
+        (Finset.univ : Finset (Fin r × Fin r))
+        (fun p _ => hPair_cesaro p)
+    refine hSum.congr' ?_
+    refine Filter.Eventually.of_forall ?_
+    intro T
+    -- ∑ p, (T)⁻¹ * ∑ N, f p N = (T)⁻¹ * ∑ p, ∑ N, f p N = (T)⁻¹ * ∑ N, ∑ p, f p N
+    change (∑ p : Fin r × Fin r, (T : ℂ)⁻¹ *
+              ∑ N ∈ Finset.range T, (μ p.1 * star (μ p.2)) ^ N)
+        = (T : ℂ)⁻¹ * ∑ N ∈ Finset.range T,
+              ∑ p : Fin r × Fin r, (μ p.1 * star (μ p.2)) ^ N
+    rw [← Finset.mul_sum, Finset.sum_comm]
+  -- Step 5: the two limits 0 and target must agree, but target ≠ 0.
+  have hCes' : Tendsto
+      (fun T : ℕ => (T : ℂ)⁻¹ *
+        ∑ N ∈ Finset.range T,
+          ∑ p : Fin r × Fin r, (μ p.1 * star (μ p.2)) ^ N)
+      atTop (nhds 0) := by
+    refine hCes.congr ?_
+    intro T
+    congr 1
+    refine Finset.sum_congr rfl ?_
+    intro N _
+    exact hSqExpand N
+  have hUnique : (0 : ℂ) = target := tendsto_nhds_unique hCes' hSum_cesaro
+  exact htarget_ne hUnique.symm
+
+end UnitModulusPowerSum

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean
@@ -1,0 +1,384 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.UnitModulusPowerSum
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
+
+/-!
+# Discharge of the `hNoCancel` hypothesis in the per-block projection
+
+This module discharges the load-bearing hypothesis `hNoCancel` of
+
+  `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
+  `fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
+
+from three paper-faithful inputs:
+
+* **Unit-modulus sector weights.**  Together with
+  `unitModulus_powerSum_not_tendsto_zero`, this forces the BNT coefficient
+  `Q.coeff N k₀ = ∑_q (Q.weight k₀ q)^N` to not tend to zero as `N → ∞`.
+
+* **Decay of `Q`-off-diagonal cross-overlaps.**  The off-diagonal terms of
+  the expansion
+  `mpvOverlap Q.toTensor (Q.basis k₀) N
+      = ∑_k Q.coeff N k · mpvOverlap (Q.basis k) (Q.basis k₀) N`
+  vanish in the limit.
+
+* **Nonzero self-overlap limit at `k₀`.**  The diagonal term tends to a
+  nonzero limit, so the expansion is asymptotically equivalent to
+  `Q.coeff N k₀ · mpvOverlap (Q.basis k₀) (Q.basis k₀) N`.
+
+* **Lower bound on `‖c N‖`.**  The scalar witness of the eventual
+  proportionality is bounded below by a positive constant.
+
+Combining these inputs, the load-bearing `hNoCancel` follows, and the
+per-block projection contradiction then closes as in
+`PerBlockProjection.lean`.
+
+## Main statements
+
+* `mpvOverlap_toTensor_basis_not_tendsto_zero` (a Q-only analytic
+  statement: assuming unit-modulus, off-diagonal decay, and nonzero
+  self-overlap limit, the assembled-tensor-to-block overlap does not
+  tend to zero).
+
+* `hNoCancel_of_unitModulus_decay_clower` (the universally-quantified
+  hNoCancel discharge consumed by the per-block projection theorems).
+
+* `fixed_right_all_overlaps_decay_false_paperFaithful`
+  `fixed_left_all_overlaps_decay_false_paperFaithful`
+  end-to-end paper-faithful corollaries.
+
+## References
+
+* Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608
+  (2017), Theorem `thm1`, lines 1170--1192.
+-/
+
+open scoped Matrix BigOperators
+open Filter
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+section HNoCancelDischarge
+
+/-- **Assembled-tensor-to-block overlap does not vanish.**
+
+For a sector decomposition `Q` with unit-modulus sector weights, a fixed
+block index `k₀`, decaying off-diagonal cross-overlaps to `Q.basis k₀`,
+and a nonzero self-overlap limit at `k₀`, the assembled-tensor-to-block
+overlap `mpvOverlap Q.toTensor (Q.basis k₀) N` does not tend to zero as
+`N → ∞`.
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192 (Q-side
+non-cancellation in the per-block projection step). -/
+lemma mpvOverlap_toTensor_basis_not_tendsto_zero
+    (Q : SectorDecomposition d)
+    (hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)
+    (k₀ : Fin Q.basisCount)
+    (hQ_decay_offdiag : ∀ k, k ≠ k₀ →
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)
+          atTop (nhds 0))
+    {ℓ : ℂ} (hℓ_ne : ℓ ≠ 0)
+    (hQ_self_limit :
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+          atTop (nhds ℓ)) :
+    ¬ Tendsto (fun N => mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+        atTop (nhds 0) := by
+  classical
+  intro hZero
+  -- Step 1: Expand the overlap via the basis decomposition of `Q.toTensor`.
+  have hExpand : ∀ N : ℕ,
+      mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N
+        = ∑ k : Fin Q.basisCount,
+            Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N := by
+    intro N
+    refine mpvOverlap_eq_sum_of_decomp_left
+      (d := d) (g := Q.basisCount) (dim := Q.basisDim)
+      Q.toTensor Q.basis (N := N)
+      (fun k => Q.coeff N k) ?_ (Q.basis k₀)
+    intro σ
+    exact Q.mpv_toTensor_eq_sum_coeff (N := N) σ
+  -- Step 2: For each k ≠ k₀, `Q.coeff N k * overlap_k N → 0`.
+  have hOffDiag : ∀ k : Fin Q.basisCount, k ≠ k₀ →
+      Tendsto
+        (fun N =>
+          Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)
+        atTop (nhds 0) := by
+    intro k hk
+    refine squeeze_zero_norm
+      (f := fun N =>
+        Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)
+      (a := fun N => (Q.copies k : ℝ)
+                      * ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N‖)
+      ?_ ?_
+    · intro N
+      simp only [norm_mul]
+      exact mul_le_mul_of_nonneg_right
+        (Q.norm_coeff_le_copies hQ_unit N k) (norm_nonneg _)
+    · have h0 : Tendsto
+          (fun N => ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N‖)
+          atTop (nhds 0) :=
+        (tendsto_zero_iff_norm_tendsto_zero.mp (hQ_decay_offdiag k hk))
+      have := h0.const_mul (Q.copies k : ℝ)
+      simpa using this
+  -- Step 3: Total off-diagonal contribution tends to zero.
+  have hOffDiagSum : Tendsto
+      (fun N => ∑ k ∈ (Finset.univ.erase k₀),
+          Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)
+      atTop (nhds 0) := by
+    have hTo : Tendsto
+        (fun N => ∑ k ∈ (Finset.univ.erase k₀),
+            Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)
+        atTop
+        (nhds (∑ _k ∈ (Finset.univ.erase k₀ : Finset (Fin Q.basisCount)),
+                (0 : ℂ))) := by
+      refine tendsto_finset_sum (Finset.univ.erase k₀) ?_
+      intro k hk
+      exact hOffDiag k (Finset.ne_of_mem_erase hk)
+    simpa using hTo
+  -- Step 4: From the assumption, the diagonal term tends to zero.
+  have hDiag_tendsto : Tendsto
+      (fun N =>
+        Q.coeff N k₀ * mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+      atTop (nhds 0) := by
+    -- diagonal = whole sum - off-diagonal sum
+    have hRew : ∀ N : ℕ,
+        Q.coeff N k₀ * mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N
+          = mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N
+            - ∑ k ∈ (Finset.univ.erase k₀),
+                Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N := by
+      intro N
+      have hcomb :
+          mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N
+            = Q.coeff N k₀ * mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N
+              + ∑ k ∈ (Finset.univ.erase k₀),
+                  Q.coeff N k *
+                    mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N := by
+        rw [hExpand N]
+        exact (Finset.add_sum_erase _ _ (Finset.mem_univ k₀)).symm
+      exact eq_sub_of_add_eq hcomb.symm
+    have hSub := hZero.sub hOffDiagSum
+    have hZero' : (0 : ℂ) - 0 = 0 := by ring
+    rw [hZero'] at hSub
+    refine hSub.congr' ?_
+    refine Filter.Eventually.of_forall ?_
+    intro N
+    exact (hRew N).symm
+  -- Step 5: Since self-overlap → ℓ ≠ 0, `Q.coeff N k₀ → 0`.
+  have hCoeff_tendsto : Tendsto (fun N => Q.coeff N k₀) atTop (nhds 0) := by
+    -- Q.coeff N k₀ = (coeff * self) / self  (eventually, self ≠ 0)
+    -- Use: coeff * self → 0, self → ℓ ≠ 0  ⟹  coeff → 0/ℓ = 0
+    have hQuot : Tendsto
+        (fun N =>
+          (Q.coeff N k₀ * mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+            / mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+        atTop (nhds (0 / ℓ)) :=
+      hDiag_tendsto.div hQ_self_limit hℓ_ne
+    have hRewQuot : ∀ᶠ N in atTop,
+        (Q.coeff N k₀ * mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+            / mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N
+          = Q.coeff N k₀ := by
+      have hself_ne : ∀ᶠ N in atTop,
+          mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N ≠ 0 :=
+        hQ_self_limit.eventually_ne hℓ_ne
+      filter_upwards [hself_ne] with N hN
+      field_simp
+    have := hQuot.congr' hRewQuot
+    simpa using this
+  -- Step 6: Contradict unit-modulus power-sum non-decay at block `k₀`.
+  refine UnitModulusPowerSum.unitModulus_powerSum_not_tendsto_zero
+    (r := Q.copies k₀) (Q.copies_pos k₀) (Q.weight k₀) (hQ_unit k₀) ?_
+  -- Convert `Q.coeff N k₀ → 0` to `∑ q, (Q.weight k₀ q)^N → 0`.
+  refine hCoeff_tendsto.congr ?_
+  intro N
+  change Q.coeff N k₀ = ∑ q : Fin (Q.copies k₀), (Q.weight k₀ q) ^ N
+  rfl
+
+/-- **Single-sequence `hNoCancel` discharge.**
+
+For a sector decomposition `Q` with unit-modulus weights and a fixed
+block index `k₀` admitting both decaying off-diagonal cross-overlaps and a
+nonzero self-overlap limit, every scalar sequence `c : ℕ → ℂ` whose norm
+is eventually bounded below by a positive constant satisfies the
+non-cancellation conclusion of `hNoCancel`. -/
+lemma hNoCancel_singleSeq
+    (Q : SectorDecomposition d)
+    (hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)
+    (k₀ : Fin Q.basisCount)
+    (hQ_decay_offdiag : ∀ k, k ≠ k₀ →
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)
+          atTop (nhds 0))
+    {ℓ : ℂ} (hℓ_ne : ℓ ≠ 0)
+    (hQ_self_limit :
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+          atTop (nhds ℓ))
+    (c : ℕ → ℂ)
+    (hc_lower : ∃ δ : ℝ, 0 < δ ∧ ∀ᶠ N in atTop, δ ≤ ‖c N‖) :
+    ¬ Tendsto (fun N => c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+        atTop (nhds 0) := by
+  classical
+  intro hCancel
+  -- From `c N * X N → 0` and `‖c N‖ ≥ δ`, deduce `X N → 0`.
+  rcases hc_lower with ⟨δ, hδpos, hδ⟩
+  have hXnorm : Tendsto
+      (fun N => ‖mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖)
+      atTop (nhds 0) := by
+    -- ‖X N‖ ≤ ‖c N * X N‖ / δ
+    have hCancel_norm : Tendsto
+        (fun N => ‖c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖)
+        atTop (nhds 0) := by
+      have := hCancel.norm
+      simpa using this
+    -- Upper bound function.
+    set bound : ℕ → ℝ := fun N =>
+      ‖c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖ / δ with hbound_def
+    have hbound_tendsto : Tendsto bound atTop (nhds 0) := by
+      have := hCancel_norm.div_const δ
+      simpa [bound] using this
+    have hle : ∀ᶠ N in atTop,
+        ‖mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖ ≤ bound N := by
+      filter_upwards [hδ] with N hN
+      have h1 : ‖c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖
+          = ‖c N‖ * ‖mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖ :=
+        norm_mul _ _
+      have hXnn : 0 ≤ ‖mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖ :=
+        norm_nonneg _
+      have h2 : δ * ‖mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖
+          ≤ ‖c N‖ * ‖mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖ :=
+        mul_le_mul_of_nonneg_right hN hXnn
+      have h3 : ‖mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖
+          ≤ ‖c N‖ * ‖mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖ / δ := by
+        rw [le_div_iff₀ hδpos, mul_comm]
+        exact h2
+      have h4 : ‖c N‖ * ‖mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N‖ / δ
+            = bound N := by
+        simp only [bound]
+        rw [h1]
+      exact h3.trans h4.le
+    exact squeeze_zero' (Filter.Eventually.of_forall (fun N => norm_nonneg _))
+      hle hbound_tendsto
+  have hXtendsto : Tendsto
+      (fun N => mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+      atTop (nhds 0) :=
+    tendsto_zero_iff_norm_tendsto_zero.mpr hXnorm
+  exact mpvOverlap_toTensor_basis_not_tendsto_zero Q hQ_unit k₀
+    hQ_decay_offdiag hℓ_ne hQ_self_limit hXtendsto
+
+/-- **Universally-quantified `hNoCancel` discharge.**
+
+The form consumed by
+`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`.
+Each scalar witness `c` of the eventual proportionality is assumed to
+admit a positive lower bound (`hc_lower`), and the non-cancellation
+conclusion then follows from `hNoCancel_singleSeq`. -/
+lemma hNoCancel_of_unitModulus_decay_clower
+    {P Q : SectorDecomposition d}
+    (hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)
+    (k₀ : Fin Q.basisCount)
+    (hQ_decay_offdiag : ∀ k, k ≠ k₀ →
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)
+          atTop (nhds 0))
+    {ℓ : ℂ} (hℓ_ne : ℓ ≠ 0)
+    (hQ_self_limit :
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+          atTop (nhds ℓ))
+    (hc_lower :
+        ∀ c : ℕ → ℂ,
+        (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+          mpv P.toTensor σ = c N * mpv Q.toTensor σ) →
+        ∃ δ : ℝ, 0 < δ ∧ ∀ᶠ N in atTop, δ ≤ ‖c N‖) :
+    ∀ c : ℕ → ℂ,
+        (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+          mpv P.toTensor σ = c N * mpv Q.toTensor σ) →
+        ¬ Tendsto
+            (fun N => c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+            atTop (nhds 0) := by
+  intro c hProp
+  exact hNoCancel_singleSeq Q hQ_unit k₀ hQ_decay_offdiag hℓ_ne
+    hQ_self_limit c (hc_lower c hProp)
+
+end HNoCancelDischarge
+
+section PaperFaithfulCorollaries
+
+/-- **Paper-faithful right-block per-block projection contradiction.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192.
+
+End-to-end specialization of
+`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
+with the load-bearing `hNoCancel` hypothesis discharged from three
+paper-faithful inputs: unit-modulus `Q`-sector weights, decay of `Q`
+off-diagonal cross-overlaps, a nonzero `Q`-self-overlap limit, and a
+lower bound on the proportionality scalar `‖c N‖`. -/
+theorem fixed_right_all_overlaps_decay_false_paperFaithful
+    (P Q : SectorDecomposition d)
+    (hP_unit : ∀ j q, ‖P.sectors.weight j q‖ = 1)
+    (hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (k₀ : Fin Q.basisCount)
+    (hAllDecay_PtoQ : ∀ j : Fin P.basisCount,
+        Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+          atTop (nhds 0))
+    (hQ_decay_offdiag : ∀ k : Fin Q.basisCount, k ≠ k₀ →
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)
+          atTop (nhds 0))
+    {ℓ : ℂ} (hℓ_ne : ℓ ≠ 0)
+    (hQ_self_limit :
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+          atTop (nhds ℓ))
+    (hc_lower :
+        ∀ c : ℕ → ℂ,
+        (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+          mpv P.toTensor σ = c N * mpv Q.toTensor σ) →
+        ∃ δ : ℝ, 0 < δ ∧ ∀ᶠ N in atTop, δ ≤ ‖c N‖) :
+    False :=
+  fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp
+    P Q hP_unit hProp k₀ hAllDecay_PtoQ
+    (hNoCancel_of_unitModulus_decay_clower
+      (P := P) (Q := Q) hQ_unit k₀ hQ_decay_offdiag hℓ_ne
+      hQ_self_limit hc_lower)
+
+/-- **Paper-faithful left-block per-block projection contradiction.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1182--1185.
+
+Symmetric counterpart of
+`fixed_right_all_overlaps_decay_false_paperFaithful`.  The proof reduces
+to the right-block version after swapping the two families. -/
+theorem fixed_left_all_overlaps_decay_false_paperFaithful
+    (P Q : SectorDecomposition d)
+    (hP_unit : ∀ j q, ‖P.sectors.weight j q‖ = 1)
+    (hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (j₀ : Fin P.basisCount)
+    (hAllDecay_QtoP : ∀ k : Fin Q.basisCount,
+        Tendsto (fun N => mpvOverlap (d := d) (P.basis j₀) (Q.basis k) N)
+          atTop (nhds 0))
+    (hP_decay_offdiag : ∀ j : Fin P.basisCount, j ≠ j₀ →
+        Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
+          atTop (nhds 0))
+    {ℓ : ℂ} (hℓ_ne : ℓ ≠ 0)
+    (hP_self_limit :
+        Tendsto (fun N => mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N)
+          atTop (nhds ℓ))
+    (hc_lower :
+        ∀ c : ℕ → ℂ,
+        (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+          mpv Q.toTensor σ = c N * mpv P.toTensor σ) →
+        ∃ δ : ℝ, 0 < δ ∧ ∀ᶠ N in atTop, δ ≤ ‖c N‖) :
+    False :=
+  fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp
+    P Q hQ_unit hProp j₀ hAllDecay_QtoP
+    (hNoCancel_of_unitModulus_decay_clower
+      (P := Q) (Q := P) hP_unit j₀ hP_decay_offdiag hℓ_ne
+      hP_self_limit hc_lower)
+
+end PaperFaithfulCorollaries
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean
@@ -13,10 +13,10 @@ This module discharges the load-bearing hypothesis `hNoCancel` of
   `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
   `fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
 
-from three paper-faithful inputs:
+from the following four hypotheses:
 
 * **Unit-modulus sector weights.**  Together with
-  `unitModulus_powerSum_not_tendsto_zero`, this forces the BNT coefficient
+  `unitModulus_power_sum_not_tendsto_zero`, this forces the BNT coefficient
   `Q.coeff N k₀ = ∑_q (Q.weight k₀ q)^N` to not tend to zero as `N → ∞`.
 
 * **Decay of `Q`-off-diagonal cross-overlaps.**  The off-diagonal terms of
@@ -32,7 +32,7 @@ from three paper-faithful inputs:
 * **Lower bound on `‖c N‖`.**  The scalar witness of the eventual
   proportionality is bounded below by a positive constant.
 
-Combining these inputs, the load-bearing `hNoCancel` follows, and the
+Combining these hypotheses, the load-bearing `hNoCancel` follows, and the
 per-block projection contradiction then closes as in
 `PerBlockProjection.lean`.
 
@@ -48,7 +48,8 @@ per-block projection contradiction then closes as in
 
 * `fixed_right_all_overlaps_decay_false_paperFaithful`
   `fixed_left_all_overlaps_decay_false_paperFaithful`
-  end-to-end paper-faithful corollaries.
+  — corollaries assembling the per-block-projection skeleton with the
+  analytic discharge of the non-cancellation hypothesis.
 
 ## References
 
@@ -191,7 +192,7 @@ lemma mpvOverlap_toTensor_basis_not_tendsto_zero
     have := hQuot.congr' hRewQuot
     simpa using this
   -- Step 6: Contradict unit-modulus power-sum non-decay at block `k₀`.
-  refine UnitModulusPowerSum.unitModulus_powerSum_not_tendsto_zero
+  refine UnitModulusPowerSum.unitModulus_power_sum_not_tendsto_zero
     (r := Q.copies k₀) (Q.copies_pos k₀) (Q.weight k₀) (hQ_unit k₀) ?_
   -- Convert `Q.coeff N k₀ → 0` to `∑ q, (Q.weight k₀ q)^N → 0`.
   refine hCoeff_tendsto.congr ?_
@@ -304,18 +305,37 @@ lemma hNoCancel_of_unitModulus_decay_clower
 
 end HNoCancelDischarge
 
-section PaperFaithfulCorollaries
+section PerBlockProjectionContradiction
 
-/-- **Paper-faithful right-block per-block projection contradiction.**
+/-- **Right-block per-block projection contradiction.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192.
 
-End-to-end specialization of
+Specialization of
 `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
 with the load-bearing `hNoCancel` hypothesis discharged from three
-paper-faithful inputs: unit-modulus `Q`-sector weights, decay of `Q`
+analytic inputs: unit-modulus `Q`-sector weights, decay of `Q`
 off-diagonal cross-overlaps, a nonzero `Q`-self-overlap limit, and a
-lower bound on the proportionality scalar `‖c N‖`. -/
+lower bound on the proportionality scalar `‖c N‖`.
+
+**Scope restriction (factored analytic discharge).**  The signature adds
+four hypotheses absent from arXiv:1606.00608 Theorem `thm1`
+(lines 1170--1192):
+
+* `hP_unit`, `hQ_unit`: unit-modulus sector weights on `P` and `Q`.
+  These match CPSV21 Definition 4.2, and both are explicit assumptions
+  in this surface.
+* `hQ_decay_offdiag`: BNT separation expressed as off-diagonal
+  cross-overlap decay on `Q`.  Present in the source via the
+  equal-MPV BNT structure.
+* `hℓ_ne` + `hQ_self_limit`: the self-overlap on the fixed block tends
+  to a nonzero limit.  Source: `HasNormalizedSelfOverlap` field of the
+  canonical form.
+* `hc_lower`: eventual lower bound on the proportionality scalar.
+  Source: the dominant-adjusted scalar limit; in the strict-anti
+  `IsCanonicalFormBNT` surface this follows from
+  `exists_dominant_phase_adjusted_scalar_tendsto_one_*`, but the
+  derivation is deferred to Plan C Objective B. -/
 theorem fixed_right_all_overlaps_decay_false_paperFaithful
     (P Q : SectorDecomposition d)
     (hP_unit : ∀ j q, ‖P.sectors.weight j q‖ = 1)
@@ -344,13 +364,32 @@ theorem fixed_right_all_overlaps_decay_false_paperFaithful
       (P := P) (Q := Q) hQ_unit k₀ hQ_decay_offdiag hℓ_ne
       hQ_self_limit hc_lower)
 
-/-- **Paper-faithful left-block per-block projection contradiction.**
+/-- **Left-block per-block projection contradiction.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1182--1185.
 
 Symmetric counterpart of
 `fixed_right_all_overlaps_decay_false_paperFaithful`.  The proof reduces
-to the right-block version after swapping the two families. -/
+to the right-block version after swapping the two families.
+
+**Scope restriction (factored analytic discharge).**  The signature adds
+four hypotheses absent from arXiv:1606.00608 Theorem `thm1`
+(lines 1182--1185):
+
+* `hP_unit`, `hQ_unit`: unit-modulus sector weights on `P` and `Q`.
+  These match CPSV21 Definition 4.2, and both are explicit assumptions
+  in this surface.
+* `hP_decay_offdiag`: BNT separation expressed as off-diagonal
+  cross-overlap decay on `P`.  Present in the source via the
+  equal-MPV BNT structure.
+* `hℓ_ne` + `hP_self_limit`: the self-overlap on the fixed block tends
+  to a nonzero limit.  Source: `HasNormalizedSelfOverlap` field of the
+  canonical form.
+* `hc_lower`: eventual lower bound on the proportionality scalar.
+  Source: the dominant-adjusted scalar limit; in the strict-anti
+  `IsCanonicalFormBNT` surface this follows from
+  `exists_dominant_phase_adjusted_scalar_tendsto_one_*`, but the
+  derivation is deferred to Plan C Objective B. -/
 theorem fixed_left_all_overlaps_decay_false_paperFaithful
     (P Q : SectorDecomposition d)
     (hP_unit : ∀ j q, ‖P.sectors.weight j q‖ = 1)
@@ -379,6 +418,6 @@ theorem fixed_left_all_overlaps_decay_false_paperFaithful
       (P := Q) (Q := P) hP_unit j₀ hP_decay_offdiag hℓ_ne
       hP_self_limit hc_lower)
 
-end PaperFaithfulCorollaries
+end PerBlockProjectionContradiction
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean
@@ -43,7 +43,7 @@ per-block projection contradiction then closes as in
   self-overlap limit, the assembled-tensor-to-block overlap does not
   tend to zero).
 
-* `hNoCancel_of_unitModulus_decay_clower` (the universally-quantified
+* `hNoCancel_of_unitModulus_decay_c_norm_lower` (the universally-quantified
   hNoCancel discharge consumed by the per-block projection theorems).
 
 * `fixed_right_all_overlaps_decay_false_paperFaithful`
@@ -65,7 +65,7 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-section HNoCancelDischarge
+section UnitModulusNonCancellation
 
 /-- **Assembled-tensor-to-block overlap does not vanish.**
 
@@ -207,7 +207,7 @@ block index `k₀` admitting both decaying off-diagonal cross-overlaps and a
 nonzero self-overlap limit, every scalar sequence `c : ℕ → ℂ` whose norm
 is eventually bounded below by a positive constant satisfies the
 non-cancellation conclusion of `hNoCancel`. -/
-lemma hNoCancel_singleSeq
+lemma hNoCancel_single_seq
     (Q : SectorDecomposition d)
     (hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)
     (k₀ : Fin Q.basisCount)
@@ -276,8 +276,8 @@ The form consumed by
 `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`.
 Each scalar witness `c` of the eventual proportionality is assumed to
 admit a positive lower bound (`hc_lower`), and the non-cancellation
-conclusion then follows from `hNoCancel_singleSeq`. -/
-lemma hNoCancel_of_unitModulus_decay_clower
+conclusion then follows from `hNoCancel_single_seq`. -/
+lemma hNoCancel_of_unitModulus_decay_c_norm_lower
     {P Q : SectorDecomposition d}
     (hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)
     (k₀ : Fin Q.basisCount)
@@ -300,10 +300,10 @@ lemma hNoCancel_of_unitModulus_decay_clower
             (fun N => c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
             atTop (nhds 0) := by
   intro c hProp
-  exact hNoCancel_singleSeq Q hQ_unit k₀ hQ_decay_offdiag hℓ_ne
+  exact hNoCancel_single_seq Q hQ_unit k₀ hQ_decay_offdiag hℓ_ne
     hQ_self_limit c (hc_lower c hProp)
 
-end HNoCancelDischarge
+end UnitModulusNonCancellation
 
 section PerBlockProjectionContradiction
 
@@ -313,7 +313,7 @@ Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192.
 
 Specialization of
 `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
-with the load-bearing `hNoCancel` hypothesis discharged from three
+with the load-bearing `hNoCancel` hypothesis discharged from four
 analytic inputs: unit-modulus `Q`-sector weights, decay of `Q`
 off-diagonal cross-overlaps, a nonzero `Q`-self-overlap limit, and a
 lower bound on the proportionality scalar `‖c N‖`.
@@ -360,7 +360,7 @@ theorem fixed_right_all_overlaps_decay_false_paperFaithful
     False :=
   fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp
     P Q hP_unit hProp k₀ hAllDecay_PtoQ
-    (hNoCancel_of_unitModulus_decay_clower
+    (hNoCancel_of_unitModulus_decay_c_norm_lower
       (P := P) (Q := Q) hQ_unit k₀ hQ_decay_offdiag hℓ_ne
       hQ_self_limit hc_lower)
 
@@ -414,7 +414,7 @@ theorem fixed_left_all_overlaps_decay_false_paperFaithful
     False :=
   fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp
     P Q hQ_unit hProp j₀ hAllDecay_QtoP
-    (hNoCancel_of_unitModulus_decay_clower
+    (hNoCancel_of_unitModulus_decay_c_norm_lower
       (P := Q) (Q := P) hP_unit j₀ hP_decay_offdiag hℓ_ne
       hP_self_limit hc_lower)
 

--- a/audits/2026-05-13_cpsv16_ft_unit_modulus_axiom.md
+++ b/audits/2026-05-13_cpsv16_ft_unit_modulus_axiom.md
@@ -1,0 +1,113 @@
+# CPSV16 FT — unit-modulus power-sum non-decay (Objective A, Plan C)
+
+**Date:** 2026-05-13
+**Scope:** Plan C, Objective A (per issue #1641) — discharge of the load-
+bearing `hNoCancel` hypothesis in the paper-faithful per-block projection
+on `SectorDecomposition`.
+**Status:** Closed.  Both the analytic ingredient and the MPS-side
+discharge are formalized; no new `sorry`, `axiom`, or `unsafe` is
+introduced.
+
+## Context
+
+Plan C (issue #1641) re-states arXiv:1606.00608 Theorem `thm1` Step 1 on
+the paper-faithful `SectorDecomposition` surface in
+`TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean`.
+The two main theorems
+
+  `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
+  `fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
+
+both carry a load-bearing analytic hypothesis `hNoCancel`, factored out
+on purpose to keep the per-block-projection algebraic skeleton clean and
+independent of the analytic content.  Objective A asks to **discharge**
+`hNoCancel` from paper-faithful inputs.
+
+## Resolution
+
+A single new analytic theorem is proved and lives in
+`TNLean/Algebra/UnitModulusPowerSum.lean`:
+
+```lean
+theorem unitModulus_powerSum_not_tendsto_zero
+    {r : ℕ} (hr : 0 < r) (μ : Fin r → ℂ) (hμ : ∀ q, ‖μ q‖ = 1) :
+    ¬ Tendsto (fun N : ℕ => ∑ q : Fin r, (μ q) ^ N) atTop (nhds 0)
+```
+
+The proof is the standard Cesaro / Wiener argument:
+
+1. If the power sum tended to zero, so would its squared norm `‖S N‖²`.
+2. Expand `‖S N‖² = ∑_{q, q'} (μ q · star (μ q'))^N` as a finite double
+   sum over `Fin r × Fin r`.
+3. Cesaro-average term-by-term: each pair `(q, q')` contributes either
+   `1` (when the unit-modulus ratio `μ q · star (μ q')` equals `1`, in
+   particular for diagonal `q = q'`) or `0` (when the ratio differs from
+   `1`, the geometric partial sums are bounded uniformly in `T`).
+4. The Cesaro limit is therefore the cardinality of the resonant set
+   `{(q, q') : μ q · star (μ q') = 1}`, which contains the diagonal and
+   is `≥ r > 0`.  Combined with the Cesaro mean of a vanishing sequence
+   being `0`, this is a contradiction.
+
+The proof is entirely self-contained: it depends only on
+`Filter.Tendsto.cesaro_smul`, `geom_sum_eq`, `Complex.mul_conj`,
+`Complex.normSq_eq_norm_sq`, and standard finite-sum manipulations.  No
+external axiom is introduced.
+
+## MPS-side use
+
+The discharge of the full `hNoCancel` is in
+`TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean`.
+The intermediate lemma
+
+```lean
+lemma mpvOverlap_toTensor_basis_not_tendsto_zero
+    (Q : SectorDecomposition d)
+    (hQ_unit : ∀ k q, ‖Q.sectors.weight k q‖ = 1)
+    (k₀ : Fin Q.basisCount)
+    (hQ_decay_offdiag : ∀ k, k ≠ k₀ →
+        Tendsto (mpvOverlap (Q.basis k) (Q.basis k₀)) atTop (nhds 0))
+    {ℓ : ℂ} (hℓ_ne : ℓ ≠ 0)
+    (hQ_self_limit :
+        Tendsto (mpvOverlap (Q.basis k₀) (Q.basis k₀)) atTop (nhds ℓ)) :
+    ¬ Tendsto (mpvOverlap Q.toTensor (Q.basis k₀)) atTop (nhds 0)
+```
+
+is the bridge from the analytic ingredient to the projected
+proportionality identity.  Combined with a lower bound `‖c N‖ ≥ δ > 0`
+on the proportionality scalar, this gives the single-sequence
+`hNoCancel_singleSeq` and the universally-quantified
+`hNoCancel_of_unitModulus_decay_clower`.
+
+End-to-end corollaries with discharged `hNoCancel`:
+
+```lean
+theorem fixed_right_all_overlaps_decay_false_paperFaithful : False
+theorem fixed_left_all_overlaps_decay_false_paperFaithful : False
+```
+
+The `hc_lower` ingredient (positive lower bound on the proportionality
+scalar) is taken as a hypothesis.  Deriving `hc_lower` from
+`IsCanonicalFormBNT` is Objective B (the strict-anti structural refactor
+of `IsCanonicalFormBNT`, out of scope for this workstream — see
+`audits/2026-05-13_cpsv16_ft_bridge_gap.md`).
+
+## Why this is *not* a factored axiom
+
+The original Objective A plan permitted leaving the unit-modulus
+power-sum non-decay statement as a factored axiom if a Lean proof proved
+too analytically expensive (Bohr / Weyl equidistribution).  In the
+event, the Wiener-style Cesaro argument is elementary enough to
+formalize directly, and we did so.  No new `axiom` is introduced.
+
+## References
+
+* arXiv:1606.00608 Theorem `thm1`, lines 1170--1192 (per-block projection
+  step; the unit-modulus power-sum non-decay is the non-cancellation
+  ingredient there).
+* `audits/2026-05-13_cpsv16_ft_definition_audit.md` §10 (Plan C YES
+  verdict).
+* `audits/2026-05-13_cpsv16_ft_bridge_gap.md` (Objective B / bridge gap
+  to `IsCanonicalFormBNT`; out of scope for Objective A).
+* `audits/2026-05-13_cpsv16_ft_discharge_attempt.md` (Plan A blocker;
+  context only).
+* Issue #1641 (Plan C workplan).

--- a/audits/2026-05-13_cpsv16_ft_unit_modulus_axiom.md
+++ b/audits/2026-05-13_cpsv16_ft_unit_modulus_axiom.md
@@ -29,7 +29,7 @@ A single new analytic theorem is proved and lives in
 `TNLean/Algebra/UnitModulusPowerSum.lean`:
 
 ```lean
-theorem unitModulus_powerSum_not_tendsto_zero
+theorem unitModulus_power_sum_not_tendsto_zero
     {r : ℕ} (hr : 0 < r) (μ : Fin r → ℂ) (hμ : ∀ q, ‖μ q‖ = 1) :
     ¬ Tendsto (fun N : ℕ => ∑ q : Fin r, (μ q) ^ N) atTop (nhds 0)
 ```
@@ -75,8 +75,8 @@ lemma mpvOverlap_toTensor_basis_not_tendsto_zero
 is the bridge from the analytic ingredient to the projected
 proportionality identity.  Combined with a lower bound `‖c N‖ ≥ δ > 0`
 on the proportionality scalar, this gives the single-sequence
-`hNoCancel_singleSeq` and the universally-quantified
-`hNoCancel_of_unitModulus_decay_clower`.
+`hNoCancel_single_seq` and the universally-quantified
+`hNoCancel_of_unitModulus_decay_c_norm_lower`.
 
 End-to-end corollaries with discharged `hNoCancel`:
 

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -907,6 +907,68 @@ with an extra $Z$-gauge degree of freedom.
 	Lemma~\ref{lem:fixed_right_all_overlaps_decay_sectorDecomp}.
 \end{proof}
 
+
+% ---- Plan C Objective A: analytic discharge of hNoCancel ----
+
+\begin{lemma}[Power-sum of a unit-modulus family does not tend to zero]%
+\label{lem:unitModulus_power_sum_not_tendsto_zero}
+	\lean{UnitModulusPowerSum.unitModulus_power_sum_not_tendsto_zero}
+	\leanok
+	For $\mu : \{1,\ldots,r\} \to \mathbb{C}$ with $r > 0$ and $|\mu_q| = 1$
+	for every $q$, the sequence $N \mapsto \sum_q (\mu_q)^N$ does not tend to
+	$0$ as $N \to \infty$.
+\end{lemma}
+
+\begin{proof}\leanok
+	Cesaro-average $\|S(N)\|^2 = \sum_{q,q'} (\mu_q \overline{\mu_{q'}})^N$
+	in $N$.  Each off-diagonal pair contributes $0$ to the average (the
+	geometric sum is uniformly bounded and divided by $T \to \infty$), while
+	each diagonal pair contributes $1$.  The Cesaro limit therefore equals the
+	cardinality of the resonant set $\{(q,q') \mid \mu_q\overline{\mu_{q'}} = 1\}$,
+	which is at least $r > 0$.  If $S(N) \to 0$, the Cesaro mean also tends to
+	$0$, a contradiction.
+\end{proof}
+
+\begin{theorem}[Right-block per-block projection contradiction under analytic discharge]%
+\label{thm:fixed_right_all_overlaps_decay_paperFaithful}
+	\lean{MPSTensor.fixed_right_all_overlaps_decay_false_paperFaithful}
+	\leanok
+	\uses{lem:unitModulus_power_sum_not_tendsto_zero,
+		lem:fixed_right_all_overlaps_decay_sectorDecomp}
+	Let $P$ and $Q$ be sector decompositions with unit-modulus weights on both.
+	Fix a block $Q_{k_0}$.  Suppose the assembled tensors are eventually
+	nonzero proportional, every cross-overlap $O_{P_j,Q_{k_0}}(N) \to 0$,
+	the off-diagonal cross-overlaps on $Q$ decay, the self-overlap at $k_0$
+	tends to a nonzero limit $\ell$, and the proportionality scalar admits
+	a positive eventual lower bound.  Then a contradiction follows.
+\end{theorem}
+
+\begin{proof}\leanok
+	Apply Lemma~\ref{lem:fixed_right_all_overlaps_decay_sectorDecomp} after
+	discharging $\mathtt{hNoCancel}$ from
+	Lemma~\ref{lem:unitModulus_power_sum_not_tendsto_zero}: the BNT coefficient
+	at $k_0$ is a unit-modulus power sum, hence does not tend to zero, so
+	the scalar-weighted block overlap cannot vanish.
+\end{proof}
+
+\begin{theorem}[Left-block per-block projection contradiction under analytic discharge]%
+\label{thm:fixed_left_all_overlaps_decay_paperFaithful}
+	\lean{MPSTensor.fixed_left_all_overlaps_decay_false_paperFaithful}
+	\leanok
+	\uses{lem:unitModulus_power_sum_not_tendsto_zero,
+		lem:fixed_left_all_overlaps_decay_sectorDecomp}
+	Symmetric counterpart of
+	Theorem~\ref{thm:fixed_right_all_overlaps_decay_paperFaithful} with the
+	roles of $P$ and $Q$ interchanged.  Fix a block $P_{j_0}$ and assume
+	the analogous unit-modulus, decay, self-overlap, and scalar-lower-bound
+	conditions on $P$.  Then a contradiction follows.
+\end{theorem}
+
+\begin{proof}\leanok
+	Swap $P$ and $Q$ and invoke
+	Theorem~\ref{thm:fixed_right_all_overlaps_decay_paperFaithful}.
+\end{proof}
+
 \begin{theorem}[Proportional BNT families have non-decaying block overlaps]%
 \label{thm:proportional_bnt_nondecaying_overlap}
 	\lean{MPSTensor.exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT}

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -115,25 +115,34 @@ identity is available, the proportional case can clone the equal-MPV tail
 subtraction and induction architecture, without assuming linear independence of
 all residual blocks on both sides.
 
-\subsection{Factored analytic discharge and the \texttt{hc\_lower} gap}
+\subsection{Factored analytic discharge and the lower-bound gap}
 
-Plan~C, Objective~A (PR~\#1644) introduces a factored analytic discharge of the
-non-cancellation hypothesis \texttt{hNoCancel} through four explicit assumptions:
-unit-modulus sector weights on both $P$ and $Q$, off-diagonal cross-overlap
-decay on the fixed family, a nonzero self-overlap limit at the fixed block, and
-an eventual positive lower bound \texttt{hc\_lower} on $\|c_N\|$.  The first
-three are present in the source via the BNT structure.  The fourth,
-\texttt{hc\_lower}, is not directly supplied by
-\cite[Theorem~\texttt{thm1}]{Cirac2016MPDO_arXiv}: the paper uses the
-dominant-adjusted scalar limit, which in the strict-anti $\mathtt{IsCanonicalFormBNT}$
-surface follows from
-$\mathtt{exists\_dominant\_phase\_adjusted\_scalar\_tendsto\_one\_*}$, but the
-derivation connecting that limit to the eventual lower bound on $\|c_N\|$
-belongs to Plan~C, Objective~B and is recorded as an open obligation in
-\path{audits/2026-05-13_cpsv16_ft_sorry_discharge_plan.md}.  The scope
-restriction is documented in the docstrings of
-$\mathtt{fixed\_right\_all\_overlaps\_decay\_false\_paperFaithful}$ and
-$\mathtt{fixed\_left\_all\_overlaps\_decay\_false\_paperFaithful}$.
+\textit{Classification: Scope restriction.}
+
+The non-cancellation conclusion is formally established under four explicit
+analytic hypotheses:
+\begin{enumerate}
+  \item unit-modulus sector weights on both the $A$-family and the $B$-family;
+  \item off-diagonal cross-overlap decay on the fixed-block family, i.e.,
+        $\langle V^{(N)}(B_{k_0}), V^{(N)}(B_k)\rangle \to 0$ for $k \neq k_0$;
+  \item a nonzero limit of the self-overlap at the fixed block,
+        $\langle V^{(N)}(B_{k_0}), V^{(N)}(B_{k_0})\rangle \to \ell \neq 0$; and
+  \item an eventual positive lower bound $\|c_N\| \geq \delta > 0$.
+\end{enumerate}
+Hypotheses~(1)--(3) are present in the source via the BNT structure
+\cite[Theorem~\texttt{thm1}]{Cirac2016MPDO_arXiv}.  Hypothesis~(4) is not
+directly supplied: the cited argument rules out cancellation by appeal to the
+dominant-adjusted scalar limit, but deriving the explicit lower bound
+$\|c_N\|\geq\delta$ from the structural data of the canonical form is not yet
+formalized and is recorded as an open obligation in
+\path{audits/2026-05-13_cpsv16_ft_sorry_discharge_plan.md}.\footnote{%
+  The universally-quantified non-cancellation discharge is
+  \leanid{MPSTensor.hNoCancel\_of\_unitModulus\_decay\_c\_norm\_lower}.
+  The two assembled contradictions are
+  \leanid{MPSTensor.fixed\_right\_all\_overlaps\_decay\_false\_paperFaithful}
+  and
+  \leanid{MPSTensor.fixed\_left\_all\_overlaps\_decay\_false\_paperFaithful};
+  both carry hypothesis~(4) as an explicit parameter.}
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -115,6 +115,26 @@ identity is available, the proportional case can clone the equal-MPV tail
 subtraction and induction architecture, without assuming linear independence of
 all residual blocks on both sides.
 
+\subsection{Factored analytic discharge and the \texttt{hc\_lower} gap}
+
+Plan~C, Objective~A (PR~\#1644) introduces a factored analytic discharge of the
+non-cancellation hypothesis \texttt{hNoCancel} through four explicit assumptions:
+unit-modulus sector weights on both $P$ and $Q$, off-diagonal cross-overlap
+decay on the fixed family, a nonzero self-overlap limit at the fixed block, and
+an eventual positive lower bound \texttt{hc\_lower} on $\|c_N\|$.  The first
+three are present in the source via the BNT structure.  The fourth,
+\texttt{hc\_lower}, is not directly supplied by
+\cite[Theorem~\texttt{thm1}]{Cirac2016MPDO_arXiv}: the paper uses the
+dominant-adjusted scalar limit, which in the strict-anti $\mathtt{IsCanonicalFormBNT}$
+surface follows from
+$\mathtt{exists\_dominant\_phase\_adjusted\_scalar\_tendsto\_one\_*}$, but the
+derivation connecting that limit to the eventual lower bound on $\|c_N\|$
+belongs to Plan~C, Objective~B and is recorded as an open obligation in
+\path{audits/2026-05-13_cpsv16_ft_sorry_discharge_plan.md}.  The scope
+restriction is documented in the docstrings of
+$\mathtt{fixed\_right\_all\_overlaps\_decay\_false\_paperFaithful}$ and
+$\mathtt{fixed\_left\_all\_overlaps\_decay\_false\_paperFaithful}$.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
Stacked on **#1643**.  Discharges the load-bearing analytic hypothesis `hNoCancel` of the per-block projection theorem on the paper-faithful `SectorDecomposition` surface (Objective A of issue #1641).

## What's here

### New module `TNLean/Algebra/UnitModulusPowerSum.lean` (294 lines, 0 sorries)

Proves the standalone analytic sub-lemma:

```lean
theorem unitModulus_powerSum_not_tendsto_zero
    {r : ℕ} (hr : 0 < r) (μ : Fin r → ℂ) (hμ : ∀ q, ‖μ q‖ = 1) :
    ¬ Tendsto (fun N : ℕ => ∑ q : Fin r, (μ q) ^ N) atTop (nhds 0)
```

Proof: Wiener / Cesaro argument on the squared modulus.  Fully `sorry`-free / `axiom`-free.

### New module `TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean` (384 lines, 0 sorries)

The end-to-end **paper-faithful** corollaries of `fixed_right_…_sectorDecomp` / `fixed_left_…_sectorDecomp` (introduced on #1643), with `hNoCancel` discharged from:

* `hP_unit`, `hQ_unit` — unit-modulus sector weights on both sides;
* `hAllDecay_PtoQ` — decay of cross-overlaps from `P.basis j` to `Q.basis k₀`;
* `hQ_decay_offdiag` — decay of off-diagonal Q→Q cross-overlaps;
* `hQ_self_limit` — nonzero self-overlap limit on the fixed block;
* `hc_lower` — eventual lower bound on the proportionality scalar.

Symmetric `fixed_left_*_paperFaithful` added by reduction to the right version.

### Audit memo `audits/2026-05-13_cpsv16_ft_unit_modulus_axiom.md`

Documents the Cesaro proof choice, the MPS-side discharge wiring, and the deliberate scoping of `hc_lower` to Objective B.

## What's NOT here (deliberate)

Deriving `hc_lower` from `IsCanonicalFormBNT` is **Objective B** — it requires the structural refactor of `IsCanonicalFormBNT` (splitting spectral-level from within-sector unit-modulus weights), which is on a separate branch `feat/mps-ft-plan-c-B-bridge-wrapper`.

Discharging the existing `_CFBNT` sorries in `NondecayingOverlap.lean` is also Objective B.

## Local CI

`lake build` succeeds; no new sorries/warnings.

## Refs

Refs #1641 (Plan C tracker), partial Objective A.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new analytic lemmas and rewires key per-block-projection theorems to remove a previously-factored non-cancellation assumption, which can affect core Fundamental Theorem proof obligations if any hypothesis mismatch or proof bug exists. No unsafe constructs are introduced, but the change touches central convergence/overlap arguments.
> 
> **Overview**
> Adds a new standalone analytic result `UnitModulusPowerSum.unitModulus_power_sum_not_tendsto_zero`, proving (via a Cesàro/Wiener argument) that finite power sums of unit-modulus complex numbers cannot converge to `0`.
> 
> Uses this lemma to *discharge the previously-factored* per-block-projection non-cancellation hypothesis `hNoCancel` on the paper-faithful `SectorDecomposition` surface: introduces `mpvOverlap_toTensor_basis_not_tendsto_zero`, packages it into `hNoCancel_of_unitModulus_decay_c_norm_lower`, and provides end-to-end contradiction corollaries `fixed_right/left_all_overlaps_decay_false_paperFaithful` under explicit unit-modulus/decay/self-overlap/nonzero-scalar-lower-bound assumptions.
> 
> Wires the new modules into the root import surface (`TNLean.lean`) and updates the blueprint and paper-gaps docs with the new lemma/theorem statements plus an audit memo documenting the proof strategy and remaining `hc_lower` gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8046d2a518cafa3a01ef0cdcc1866db3610b013f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->