### PR TITLE
feat(MPS/FT): Plan C (B) — IsBNTCanonicalFormSD + dominant-block CFBNT discharge

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -219,6 +219,7 @@ import TNLean.MPS.FundamentalTheorem.Full
 import TNLean.MPS.FundamentalTheorem.Full.DominantWeight
 import TNLean.MPS.FundamentalTheorem.Full.ProportionalScalar
 import TNLean.MPS.FundamentalTheorem.Full.ProportionalExpansion
+import TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap.FixedBlockDecay
 import TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap
 import TNLean.MPS.FundamentalTheorem.Full.BlocksMatch
 import TNLean.MPS.FundamentalTheorem.OverlapConvergenceAux
@@ -227,6 +228,7 @@ import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.HNoCancelDischarge
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.IsBNTCanonicalFormSD
 import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.Applications

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.Full.NondecayingPartnerUnique
+import TNLean.MPS.FundamentalTheorem.Full.NondecayingOverlap.FixedBlockDecay
 
 /-!
 # Non-decaying overlap existence for BNT families
@@ -812,106 +813,6 @@ lemma eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_C
       B Asingle hB_self hB_cross hAsingle_self hAsingle_cross hBA
   simpa [Asingle] using hLI
 
-/-- **Fixed-right all-overlaps-decay contradiction for proportional BNT families.**
-
-Source: arXiv:1606.00608, Theorem `thm1`, line 1182. In the proof, after
-fixing a block `B_k`, the authors say that it is impossible for all overlaps
-with the `A_j` blocks to tend to zero, because otherwise the total MPV families
-could not be proportional by Lemma `Lem1`.
-
-This statement names the cancellation step implicit in that sentence. The
-local Lemma `Lem1` input is
-`eventually_linearIndependent_all_left_single_right_of_all_overlaps_decay_CFBNT`.
-The remaining formal proof obligation is documented in
-`docs/paper-gaps/cpsv16_fixed_block_cancellation.tex` and tracked in issue
-#1607.
-
-**Scope restriction (one-copy-per-sector):** The local hypotheses
-`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
-forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
-documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
-
-**Plan C (issue #1641) status.** The corresponding per-block projection
-argument is recorded on the paper-faithful `SectorDecomposition` surface in
-`TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection`
-(`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`),
-with the load-bearing non-cancellation step factored as the hypothesis
-`hNoCancel`.
-
-Bridging the present `IsCanonicalFormBNT` surface to the new SectorDecomposition
-lemma is blocked by the strict-anti restriction of `IsCanonicalFormBNT`:
-under `mu_strict_anti`, the unit-modulus hypothesis required by the
-SectorDecomposition lemma fails for every weight after the first.  Resolving
-this requires a structural reorganization of `IsCanonicalFormBNT` that splits the
-spectral level (`λ_j` with `|λ_0| > |λ_1| > …`) from the within-sector
-unit-modulus weights (`μ_{j,q}` with `|μ_{j,q}| = 1`).  See
-`audits/2026-05-13_cpsv16_ft_bridge_gap.md` for the full analysis. -/
-lemma fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
-    {d rA rB : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
-    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
-    (A : (j : Fin rA) → MPSTensor d (dimA j))
-    (B : (k : Fin rB) → MPSTensor d (dimB k))
-    (hA : IsCanonicalFormBNT μA A)
-    (hB : IsCanonicalFormBNT μB B)
-    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
-    (hProp : EventuallyNonzeroProportionalMPV₂
-      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
-    (k₀ : Fin rB)
-    (hAllDecay : ∀ j : Fin rA,
-      Tendsto (fun N => mpvOverlap (d := d) (A j) (B k₀) N) atTop (nhds 0)) :
-    False := by
-  sorry
-
-/-- **Fixed-left all-overlaps-decay contradiction for proportional BNT families.**
-
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1182--1185. The proof repeats
-the fixed-block argument with the two tensor families interchanged to obtain
-the opposite block-count inequality. Thus, for a fixed block `A_j`, it is
-impossible for all overlaps with the `B_k` blocks to tend to zero under
-eventual nonzero proportionality of the total MPV families.
-
-This statement names the symmetric cancellation step implicit in the source.
-The local Lemma `Lem1` input is
-`eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_CFBNT`.
-The remaining formal proof obligation is documented in
-`docs/paper-gaps/cpsv16_fixed_block_cancellation.tex` and tracked in issue
-#1607.
-
-**Scope restriction (one-copy-per-sector):** The local hypotheses
-`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
-forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
-documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
-
-**Plan C (issue #1641) status.** The corresponding per-block projection
-argument is recorded on the paper-faithful `SectorDecomposition` surface in
-`TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection`
-(`fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`),
-with the load-bearing non-cancellation step factored as the hypothesis
-`hNoCancel`.
-
-Bridging the present `IsCanonicalFormBNT` surface to that SectorDecomposition
-lemma is blocked by the same strict-anti vs. unit-modulus mismatch as the
-right-block case.  See `audits/2026-05-13_cpsv16_ft_bridge_gap.md`. -/
-lemma fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
-    {d rA rB : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
-    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
-    (A : (j : Fin rA) → MPSTensor d (dimA j))
-    (B : (k : Fin rB) → MPSTensor d (dimB k))
-    (hA : IsCanonicalFormBNT μA A)
-    (hB : IsCanonicalFormBNT μB B)
-    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
-    (hProp : EventuallyNonzeroProportionalMPV₂
-      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
-    (j₀ : Fin rA)
-    (hAllDecay : ∀ k : Fin rB,
-      Tendsto (fun N => mpvOverlap (d := d) (A j₀) (B k) N) atTop (nhds 0)) :
-    False := by
-  sorry
-
 /-- **Non-decaying overlap existence for proportional-MPV BNT families.**
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the proof,
@@ -928,7 +829,19 @@ BNT canonical form with possible multiplicities. This restriction is documented 
 
 The proof reduces the two quantified non-decaying-overlap claims to the named
 fixed-block contradictions corresponding to the two directions of the source
-argument. Those fixed-block cancellation proofs are tracked in issue #1607. -/
+argument. Those fixed-block contradictions are tracked in issue #1607.
+
+**Open obligation.** The fixed-block contradictions
+`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+and `fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+are themselves open for non-dominant fixed blocks under `mu_strict_anti`; only
+the dominant-block specialisations
+(`fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+and `fixed_left_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`)
+are closed.  Closing the general statement on the `IsCanonicalFormBNT` surface
+requires the structural reorganization described in
+`audits/2026-05-13_cpsv16_ft_bridge_gap.md` §Resolution and tracked in issue
+#1641 (Plan C). -/
 lemma exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -956,6 +869,49 @@ lemma exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT
     push Not at h
     exact fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
       A B hA hB hrA hrB hProp.eventually k₀ h
+
+/-- **Dominant-block non-decaying-overlap existence for proportional-MPV BNT families.**
+
+Specialisation of
+`exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT` to the dominant
+blocks (`j₀ = ⟨0, _⟩` and `k₀ = ⟨0, _⟩`).  Both directions of the source
+argument restricted to dominant blocks are routed through the dominant-block
+fixed-block contradictions (`fixed_right_dominant_…_CFBNT` and
+`fixed_left_dominant_…_CFBNT`), which are proved unconditionally on the
+`IsCanonicalFormBNT` surface.
+
+This is the part of `exists_nondecaying_overlap_…_CFBNT` that is currently
+closed on the `IsCanonicalFormBNT` surface; the general (non-dominant fixed
+block) obligation remains open — see the parent docstring. -/
+lemma exists_nondecaying_dominant_overlap_of_nonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : NonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B)) :
+    (∃ k₀ : Fin rB,
+      ¬ Tendsto (fun N =>
+        mpvOverlap (d := d) (A ⟨0, Nat.pos_of_ne_zero hrA⟩) (B k₀) N)
+        atTop (nhds 0)) ∧
+    (∃ j₀ : Fin rA,
+      ¬ Tendsto (fun N =>
+        mpvOverlap (d := d) (A j₀) (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N)
+        atTop (nhds 0)) := by
+  refine ⟨?_, ?_⟩
+  · by_contra h
+    push Not at h
+    exact fixed_left_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hProp.eventually h
+  · by_contra h
+    push Not at h
+    exact fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hProp.eventually h
 
 end HeteroEqualCase
 

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean
@@ -4,13 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.Full.NondecayingPartnerUnique
 import TNLean.MPS.FundamentalTheorem.Full.ProportionalDominant
-import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
 
 /-!
 # Fixed-block decay contradictions for proportional BNT families
 
-This module hosts the two fixed-block decay contradictions used in the proof
-of Theorem `thm1` in arXiv:1606.00608 (CPSV16):
+The two fixed-block decay contradictions used in the proof of Theorem
+`thm1` in arXiv:1606.00608 (CPSV16):
 
 * the right form, fixing a `B`-block `B_{k₀}` and ruling out the assumption
   that all overlaps `⟪V^{(N)}(A_j), V^{(N)}(B_{k₀})⟫ → 0`;
@@ -21,7 +20,7 @@ The general (arbitrary fixed block) form is currently an open obligation on
 the `IsCanonicalFormBNT` surface — see the structural analysis in
 `audits/2026-05-13_cpsv16_ft_bridge_gap.md`.  The **dominant**-block
 specialisations (`k₀ = ⟨0, _⟩` for the right form, `j₀ = ⟨0, _⟩` for the left
-form) are unconditionally proved in this module using the dominant-weight
+form) are unconditionally proved below using the dominant-weight
 adjusted scalar limit (`ProportionalDominant.lean`) and the self-overlap
 normalisation supplied by `IsCanonicalForm`.
 
@@ -46,7 +45,7 @@ normalisation supplied by `IsCanonicalForm`.
 matrix product states, fundamental theorem, BNT, overlap, decay contradiction
 -/
 
-open scoped Matrix BigOperators InnerProductSpace
+open scoped BigOperators
 open Filter
 
 namespace MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean
+++ b/TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean
@@ -1,0 +1,489 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.Full.NondecayingPartnerUnique
+import TNLean.MPS.FundamentalTheorem.Full.ProportionalDominant
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
+
+/-!
+# Fixed-block decay contradictions for proportional BNT families
+
+This module hosts the two fixed-block decay contradictions used in the proof
+of Theorem `thm1` in arXiv:1606.00608 (CPSV16):
+
+* the right form, fixing a `B`-block `B_{k₀}` and ruling out the assumption
+  that all overlaps `⟪V^{(N)}(A_j), V^{(N)}(B_{k₀})⟫ → 0`;
+* the left form, fixing an `A`-block `A_{j₀}` and ruling out the assumption
+  that all overlaps `⟪V^{(N)}(A_{j₀}), V^{(N)}(B_k)⟫ → 0`.
+
+The general (arbitrary fixed block) form is currently an open obligation on
+the `IsCanonicalFormBNT` surface — see the structural analysis in
+`audits/2026-05-13_cpsv16_ft_bridge_gap.md`.  The **dominant**-block
+specialisations (`k₀ = ⟨0, _⟩` for the right form, `j₀ = ⟨0, _⟩` for the left
+form) are unconditionally proved in this module using the dominant-weight
+adjusted scalar limit (`ProportionalDominant.lean`) and the self-overlap
+normalisation supplied by `IsCanonicalForm`.
+
+## Main statements
+
+* `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+  (open, general fixed block);
+* `fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+  (open, general fixed block);
+* `fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+  (closed, dominant `B` block);
+* `fixed_left_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+  (closed, dominant `A` block).
+
+## References
+
+* Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2017).
+
+## Tags
+
+matrix product states, fundamental theorem, BNT, overlap, decay contradiction
+-/
+
+open scoped Matrix BigOperators InnerProductSpace
+open Filter
+
+namespace MPSTensor
+
+section HeteroEqualCase
+
+/-- **Fixed-right all-overlaps-decay contradiction for proportional BNT families.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, line 1182. In the proof, after
+fixing a block `B_k`, the authors say that it is impossible for all overlaps
+with the `A_j` blocks to tend to zero, because otherwise the total MPV families
+could not be proportional by Lemma `Lem1`.
+
+This statement names the cancellation step implicit in that sentence. The
+local Lemma `Lem1` input is
+`eventually_linearIndependent_all_left_single_right_of_all_overlaps_decay_CFBNT`.
+The remaining formal proof obligation is documented in
+`docs/paper-gaps/cpsv16_fixed_block_cancellation.tex` and tracked in issue
+#1607.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
+
+**Open obligation (non-dominant `k₀`).** The general statement for arbitrary
+fixed block `k₀ : Fin rB` is currently open on the `IsCanonicalFormBNT`
+surface.  The dominant block (`k₀ = ⟨0, _⟩`) is handled separately by
+`fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+below.  For non-dominant `k₀`, under `mu_strict_anti` the canonical-form
+unit-modulus hypothesis required by the paper-faithful per-block projection
+lemma fails (every weight after the first has modulus strictly less than the
+dominant weight), so the correspondence with
+`TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection`
+established for the `SectorDecomposition` surface does not transfer
+directly.  Resolution requires the structural reorganization of
+`IsCanonicalFormBNT` described in
+`audits/2026-05-13_cpsv16_ft_bridge_gap.md` §Resolution, separating the
+spectral level (`λ_j` with `|λ_0| > |λ_1| > …`) from the within-sector
+unit-modulus weights (`μ_{j,q}` with `‖μ_{j,q}‖ = 1`).  Tracked in
+issue #1641 (Plan C). -/
+lemma fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (k₀ : Fin rB)
+    (hAllDecay : ∀ j : Fin rA,
+      Tendsto (fun N => mpvOverlap (d := d) (A j) (B k₀) N) atTop (nhds 0)) :
+    False := by
+  sorry
+
+/-- **Fixed-left all-overlaps-decay contradiction for proportional BNT families.**
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1182--1185. The proof repeats
+the fixed-block argument with the two tensor families interchanged to obtain
+the opposite block-count inequality. Thus, for a fixed block `A_j`, it is
+impossible for all overlaps with the `B_k` blocks to tend to zero under
+eventual nonzero proportionality of the total MPV families.
+
+This statement names the symmetric cancellation step implicit in the source.
+The local Lemma `Lem1` input is
+`eventually_linearIndependent_all_right_single_left_of_all_overlaps_decay_CFBNT`.
+The remaining formal proof obligation is documented in
+`docs/paper-gaps/cpsv16_fixed_block_cancellation.tex` and tracked in issue
+#1607.
+
+**Scope restriction (one-copy-per-sector):** The local hypotheses
+`IsCanonicalFormBNT` are the already-grouped one-copy-per-sector canonical
+forms. CPSV16 allows BNT multiplicities inside a sector. This restriction is
+documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
+
+**Open obligation (non-dominant `j₀`).** The general statement for arbitrary
+fixed block `j₀ : Fin rA` is currently open.  The dominant block
+(`j₀ = ⟨0, _⟩`) is handled by
+`fixed_left_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+below.  See the right-block sibling
+`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+for the structural notes shared with this lemma. -/
+lemma fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (j₀ : Fin rA)
+    (hAllDecay : ∀ k : Fin rB,
+      Tendsto (fun N => mpvOverlap (d := d) (A j₀) (B k) N) atTop (nhds 0)) :
+    False := by
+  sorry
+
+/-! ### Dominant-block specialisations -/
+
+/-- **Dominant-block fixed-right all-overlaps-decay contradiction.**
+
+The specialisation of
+`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+to the dominant `B`-block `k₀ = ⟨0, _⟩`.  In this case the analytic
+non-cancellation step that obstructs the non-dominant statement is supplied
+unconditionally by combining
+
+* the dominant-weight-adjusted scalar limit
+  `‖c N · (μB 0 / μA 0)^N‖ → 1`
+  (`exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT`),
+* the normalised self-overlap limit
+  `(μB 0)^(-N) · ⟨V^{(N)}(B), V^{(N)}(B_0)⟩ → 1`
+  (from `hB.toHasNormalizedSelfOverlap.overlap_tendsto_one` together with
+  the decay of cross-overlaps `mpvOverlap (B k) (B 0) → 0` for `k ≠ 0`
+  obtained from `hB.cross_overlap_tendsto_zero` plus `bounded_mul_tendsto_zero`).
+
+The product of these two limits has modulus tending to `1`, but the same
+quantity also tends to `0` by the LHS expansion (Steps 1--6 of the original
+argument).  Contradiction.
+
+**Scope restriction (one-copy-per-sector):** inherited from `IsCanonicalFormBNT`.
+See `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
+lemma fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (hAllDecay : ∀ j : Fin rA,
+      Tendsto (fun N => mpvOverlap (d := d) (A j)
+        (B ⟨0, Nat.pos_of_ne_zero hrB⟩) N) atTop (nhds 0)) :
+    False := by
+  classical
+  set a0 : Fin rA := ⟨0, Nat.pos_of_ne_zero hrA⟩
+  set b0 : Fin rB := ⟨0, Nat.pos_of_ne_zero hrB⟩
+  have hμA_ne : μA a0 ≠ 0 := hA.toHasStrictOrderedNonzeroWeights.mu_ne_zero a0
+  have hμB_ne : μB b0 ≠ 0 := hB.toHasStrictOrderedNonzeroWeights.mu_ne_zero b0
+  -- Step 0: dominant-adjusted scalar.  Modulus of `c N · (μB 0 / μA 0)^N` → 1.
+  obtain ⟨c, _hcNe, hState, hcAdj⟩ :=
+    exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+      A B hA hB hrA hrB hProp
+  -- Step 1: convert weighted-mpvState equality `hState` to σ-level mpv proportionality.
+  have hc_eq : ∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+      mpv (toTensorFromBlocks μA A) σ =
+        c N * mpv (toTensorFromBlocks μB B) σ := by
+    refine hState.mono ?_
+    intro N hN σ
+    have hAstate :
+        mpvState (d := d) (toTensorFromBlocks μA A) N =
+          ∑ j : Fin rA, (μA j) ^ N • mpvState (d := d) (A j) N := by
+      refine mpvState_eq_sum_of_decomp (d := d) (toTensorFromBlocks μA A) A
+        (N := N) (fun j : Fin rA => (μA j) ^ N) ?_
+      intro σ'
+      simpa [smul_eq_mul] using
+        mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μA) (A := A) σ'
+    have hBstate :
+        mpvState (d := d) (toTensorFromBlocks μB B) N =
+          ∑ k : Fin rB, (μB k) ^ N • mpvState (d := d) (B k) N := by
+      refine mpvState_eq_sum_of_decomp (d := d) (toTensorFromBlocks μB B) B
+        (N := N) (fun k : Fin rB => (μB k) ^ N) ?_
+      intro σ'
+      simpa [smul_eq_mul] using
+        mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μB) (A := B) σ'
+    have hTotal :
+        mpvState (d := d) (toTensorFromBlocks μA A) N =
+          c N • mpvState (d := d) (toTensorFromBlocks μB B) N := by
+      rw [hAstate, hN, hBstate]
+    have hσ := congr_arg (fun v => v σ) hTotal
+    simpa [mpvState_apply, mpv, smul_eq_mul] using hσ
+  -- Step 2: project σ-level proportionality onto `B b0`.
+  have hOverlap : ∀ᶠ N in atTop,
+      mpvOverlap (d := d) (toTensorFromBlocks μA A) (B b0) N
+        = c N * mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N := by
+    refine hc_eq.mono ?_
+    intro N hN
+    exact mpvOverlap_eq_mul_of_mpv_eq_mul (d := d)
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B) (c N) hN (B b0)
+  -- Step 3: expand the LHS overlap as a block sum on `A`-side.
+  have hLHS_decomp : ∀ N : ℕ,
+      mpvOverlap (d := d) (toTensorFromBlocks μA A) (B b0) N
+        = ∑ j : Fin rA, (μA j) ^ N * mpvOverlap (d := d) (A j) (B b0) N := by
+    intro N
+    refine mpvOverlap_eq_sum_of_decomp_left
+      (d := d) (g := rA) (dim := dimA)
+      (toTensorFromBlocks μA A) A (N := N)
+      (fun j => (μA j) ^ N) ?_ (B b0)
+    intro σ
+    have hexp := mpv_toTensorFromBlocks_eq_sum μA A σ (N := N)
+    simpa [smul_eq_mul] using hexp
+  -- Step 4: each normalised `(μA a0)^(-N) · (μA j)^N · overlap → 0`.
+  have hSummandA : ∀ j : Fin rA,
+      Tendsto
+        (fun N =>
+          (μA a0 ^ N)⁻¹ * ((μA j) ^ N * mpvOverlap (d := d) (A j) (B b0) N))
+        atTop (nhds 0) := by
+    intro j
+    by_cases hj : j = a0
+    · subst hj
+      have hcong : ∀ N : ℕ,
+          (μA a0 ^ N)⁻¹ * ((μA a0) ^ N * mpvOverlap (d := d) (A a0) (B b0) N)
+            = mpvOverlap (d := d) (A a0) (B b0) N := by
+        intro N
+        rw [← mul_assoc, inv_mul_cancel₀ (pow_ne_zero N hμA_ne), one_mul]
+      refine Tendsto.congr ?_ (hAllDecay a0)
+      intro N; exact (hcong N).symm
+    · have hratio_lt : ‖μA j / μA a0‖ < 1 := by
+        rw [norm_div]
+        exact (div_lt_one (norm_pos_iff.mpr hμA_ne)).mpr
+          (hA.mu_strict_anti (by
+            simp only [a0, Fin.lt_def]
+            exact Nat.pos_of_ne_zero (fun h => hj (Fin.ext h))))
+      have hgeom :
+          Tendsto
+            (fun N => (μA j / μA a0) ^ N * mpvOverlap (d := d) (A j) (B b0) N)
+            atTop (nhds 0) :=
+        bounded_mul_tendsto_zero (μA j / μA a0) _
+          (le_of_lt hratio_lt) (hAllDecay j)
+      have hpow_eq : ∀ N : ℕ,
+          (μA a0 ^ N)⁻¹ * ((μA j) ^ N * mpvOverlap (d := d) (A j) (B b0) N)
+            = (μA j / μA a0) ^ N * mpvOverlap (d := d) (A j) (B b0) N := by
+        intro N
+        rw [div_pow]
+        field_simp [pow_ne_zero N hμA_ne]
+      refine Tendsto.congr ?_ hgeom
+      intro N; exact (hpow_eq N).symm
+  -- Step 5: normalised LHS overlap tends to zero.
+  have hSumZero : Tendsto
+      (fun N => (μA a0 ^ N)⁻¹ *
+        mpvOverlap (d := d) (toTensorFromBlocks μA A) (B b0) N)
+      atTop (nhds 0) := by
+    have hSum :
+        Tendsto
+          (fun N =>
+            ∑ j : Fin rA, (μA a0 ^ N)⁻¹ *
+              ((μA j) ^ N * mpvOverlap (d := d) (A j) (B b0) N))
+          atTop (nhds (∑ _j : Fin rA, (0 : ℂ))) :=
+      tendsto_finset_sum Finset.univ (fun j _ => hSummandA j)
+    have hSumZero' : Tendsto
+        (fun N =>
+          ∑ j : Fin rA, (μA a0 ^ N)⁻¹ *
+            ((μA j) ^ N * mpvOverlap (d := d) (A j) (B b0) N))
+        atTop (nhds 0) := by simpa using hSum
+    refine hSumZero'.congr ?_
+    intro N
+    rw [hLHS_decomp N, Finset.mul_sum]
+  -- Step 6: combine with proportionality to land the LHS-of-contradiction expression.
+  have hContra : Tendsto
+      (fun N => (μA a0 ^ N)⁻¹ * c N *
+        mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N)
+      atTop (nhds 0) := by
+    refine hSumZero.congr' ?_
+    filter_upwards [hOverlap] with N hN
+    show (μA a0 ^ N)⁻¹ * mpvOverlap (d := d) (toTensorFromBlocks μA A) (B b0) N
+      = (μA a0 ^ N)⁻¹ * c N
+        * mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N
+    rw [hN]; ring
+  -- Step 7: dominant self-overlap normalisation on the `B` side.
+  have hRHS_decomp : ∀ N : ℕ,
+      mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N
+        = ∑ k : Fin rB, (μB k) ^ N * mpvOverlap (d := d) (B k) (B b0) N := by
+    intro N
+    refine mpvOverlap_eq_sum_of_decomp_left
+      (d := d) (g := rB) (dim := dimB)
+      (toTensorFromBlocks μB B) B (N := N)
+      (fun k => (μB k) ^ N) ?_ (B b0)
+    intro σ
+    have hexp := mpv_toTensorFromBlocks_eq_sum μB B σ (N := N)
+    simpa [smul_eq_mul] using hexp
+  have hSelfTendOne :
+      Tendsto (fun N => mpvOverlap (d := d) (B b0) (B b0) N) atTop (nhds 1) :=
+    hB.toHasNormalizedSelfOverlap.overlap_tendsto_one b0
+  have hCrossTendZero : ∀ k : Fin rB, k ≠ b0 →
+      Tendsto (fun N => mpvOverlap (d := d) (B k) (B b0) N) atTop (nhds 0) :=
+    fun k hk => hB.cross_overlap_tendsto_zero k b0 hk
+  have hSummandB : ∀ k : Fin rB,
+      Tendsto
+        (fun N =>
+          (μB b0 ^ N)⁻¹ * ((μB k) ^ N * mpvOverlap (d := d) (B k) (B b0) N))
+        atTop (nhds (if k = b0 then (1 : ℂ) else 0)) := by
+    intro k
+    by_cases hk : k = b0
+    · subst hk
+      simp only [↓reduceIte]
+      have hcong : ∀ N : ℕ,
+          (μB b0 ^ N)⁻¹ * ((μB b0) ^ N * mpvOverlap (d := d) (B b0) (B b0) N)
+            = mpvOverlap (d := d) (B b0) (B b0) N := by
+        intro N
+        rw [← mul_assoc, inv_mul_cancel₀ (pow_ne_zero N hμB_ne), one_mul]
+      refine Tendsto.congr ?_ hSelfTendOne
+      intro N; exact (hcong N).symm
+    · simp only [if_neg hk]
+      have hratio_lt : ‖μB k / μB b0‖ < 1 := by
+        rw [norm_div]
+        exact (div_lt_one (norm_pos_iff.mpr hμB_ne)).mpr
+          (hB.mu_strict_anti (by
+            simp only [b0, Fin.lt_def]
+            exact Nat.pos_of_ne_zero (fun h => hk (Fin.ext h))))
+      have hgeom :
+          Tendsto
+            (fun N => (μB k / μB b0) ^ N * mpvOverlap (d := d) (B k) (B b0) N)
+            atTop (nhds 0) :=
+        bounded_mul_tendsto_zero (μB k / μB b0) _
+          (le_of_lt hratio_lt) (hCrossTendZero k hk)
+      have hpow_eq : ∀ N : ℕ,
+          (μB b0 ^ N)⁻¹ * ((μB k) ^ N * mpvOverlap (d := d) (B k) (B b0) N)
+            = (μB k / μB b0) ^ N * mpvOverlap (d := d) (B k) (B b0) N := by
+        intro N
+        rw [div_pow]
+        field_simp [pow_ne_zero N hμB_ne]
+      refine Tendsto.congr ?_ hgeom
+      intro N; exact (hpow_eq N).symm
+  have hSumOne : Tendsto
+      (fun N => (μB b0 ^ N)⁻¹ *
+        mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N)
+      atTop (nhds (1 : ℂ)) := by
+    have hSum :
+        Tendsto
+          (fun N =>
+            ∑ k : Fin rB, (μB b0 ^ N)⁻¹ *
+              ((μB k) ^ N * mpvOverlap (d := d) (B k) (B b0) N))
+          atTop (nhds (∑ k : Fin rB, if k = b0 then (1 : ℂ) else 0)) :=
+      tendsto_finset_sum Finset.univ (fun k _ => hSummandB k)
+    have hSumIf : (∑ k : Fin rB, if k = b0 then (1 : ℂ) else 0) = 1 := by
+      rw [Finset.sum_ite_eq']
+      simp [Finset.mem_univ]
+    have hSumOne' : Tendsto
+        (fun N =>
+          ∑ k : Fin rB, (μB b0 ^ N)⁻¹ *
+            ((μB k) ^ N * mpvOverlap (d := d) (B k) (B b0) N))
+        atTop (nhds (1 : ℂ)) := by
+      rw [← hSumIf]; exact hSum
+    refine hSumOne'.congr ?_
+    intro N
+    rw [hRHS_decomp N, Finset.mul_sum]
+  -- Step 8: factor the LHS-of-contradiction expression and derive modulus → 1.
+  have hFactored : ∀ N : ℕ,
+      (μA a0 ^ N)⁻¹ * c N *
+        mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N
+      = c N * (μB b0 / μA a0) ^ N *
+        ((μB b0 ^ N)⁻¹ * mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N) := by
+    intro N
+    rw [div_pow]
+    field_simp [pow_ne_zero N hμA_ne, pow_ne_zero N hμB_ne]
+  have hSumOneNorm :
+      Tendsto
+        (fun N => ‖(μB b0 ^ N)⁻¹ * mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N‖)
+        atTop (nhds (1 : ℝ)) := by
+    have h := hSumOne.norm
+    simpa using h
+  have hNormProd : Tendsto
+      (fun N => ‖(μA a0 ^ N)⁻¹ * c N *
+        mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N‖)
+      atTop (nhds (1 : ℝ)) := by
+    have hMul :
+        Tendsto
+          (fun N => ‖c N * (μB b0 / μA a0) ^ N‖ *
+            ‖(μB b0 ^ N)⁻¹ * mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N‖)
+          atTop (nhds ((1 : ℝ) * 1)) :=
+      hcAdj.mul hSumOneNorm
+    have hMul' :
+        Tendsto
+          (fun N => ‖c N * (μB b0 / μA a0) ^ N‖ *
+            ‖(μB b0 ^ N)⁻¹ * mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N‖)
+          atTop (nhds (1 : ℝ)) := by
+      simpa using hMul
+    refine Tendsto.congr ?_ hMul'
+    intro N
+    have heq :
+        ‖(μA a0 ^ N)⁻¹ * c N *
+            mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N‖
+        = ‖c N * (μB b0 / μA a0) ^ N‖ *
+            ‖(μB b0 ^ N)⁻¹ * mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N‖ := by
+      rw [hFactored N, norm_mul]
+    exact heq.symm
+  -- Step 9: combine `hContra` (norm → 0) and `hNormProd` (norm → 1).
+  have hContraNorm :
+      Tendsto
+        (fun N => ‖(μA a0 ^ N)⁻¹ * c N *
+          mpvOverlap (d := d) (toTensorFromBlocks μB B) (B b0) N‖)
+        atTop (nhds 0) := by
+    have := hContra.norm
+    simpa using this
+  have h01 : (0 : ℝ) = 1 := tendsto_nhds_unique hContraNorm hNormProd
+  exact absurd h01 (by norm_num)
+
+/-- **Dominant-block fixed-left all-overlaps-decay contradiction.**
+
+Symmetric specialisation of
+`fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+to the dominant `A`-block `j₀ = ⟨0, _⟩`.  The proof reduces to
+`fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+after swapping the two families via `EventuallyNonzeroProportionalMPV₂.symm`
+and `tendsto_mpvOverlap_zero_swap`.
+
+**Scope restriction (one-copy-per-sector):** inherited from `IsCanonicalFormBNT`.
+See `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
+lemma fixed_left_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    {d rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    [∀ k, NeZero (dimA k)] [∀ k, NeZero (dimB k)]
+    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k))
+    (hA : IsCanonicalFormBNT μA A)
+    (hB : IsCanonicalFormBNT μB B)
+    (hrA : rA ≠ 0) (hrB : rB ≠ 0)
+    (hProp : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μA A) (toTensorFromBlocks μB B))
+    (hAllDecay : ∀ k : Fin rB,
+      Tendsto (fun N => mpvOverlap (d := d)
+        (A ⟨0, Nat.pos_of_ne_zero hrA⟩) (B k) N) atTop (nhds 0)) :
+    False := by
+  have hPropSwap : EventuallyNonzeroProportionalMPV₂
+      (toTensorFromBlocks μB B) (toTensorFromBlocks μA A) :=
+    hProp.symm
+  have hAllDecaySwap : ∀ k : Fin rB,
+      Tendsto (fun N => mpvOverlap (d := d) (B k)
+        (A ⟨0, Nat.pos_of_ne_zero hrA⟩) N) atTop (nhds 0) := by
+    intro k
+    exact tendsto_mpvOverlap_zero_swap (d := d)
+      (A ⟨0, Nat.pos_of_ne_zero hrA⟩) (B k) (hAllDecay k)
+  exact fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT
+    B A hB hA hrB hrA hPropSwap hAllDecaySwap
+
+end HeteroEqualCase
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
+
+/-!
+# Paper-faithful BNT canonical form on the `SectorDecomposition` surface
+
+This module defines the `Prop`-level predicate `IsBNTCanonicalFormSD` over a
+`SectorDecomposition P`, recording the two paper-faithful hypotheses of
+arXiv:1606.00608 Definition 4.2 / arXiv:2011.12127 Definition 4.2:
+
+* every within-sector weight has unit modulus
+  (`P.sectors.weight j q` with `‖P.sectors.weight j q‖ = 1`);
+* the basis of normal tensors is eventually linearly independent
+  (the `HasBNTSectorData` field from
+  `TNLean.MPS.FundamentalTheorem.SectorDecomposition`).
+
+The structure is the eventual landing target of the
+`IsCanonicalFormBNT`→`SectorDecomposition` reorganization described in
+`audits/2026-05-13_cpsv16_ft_bridge_gap.md` §Resolution.
+
+The `SD` suffix abbreviates "Sector Decomposition" — the predicate lives on
+the `SectorDecomposition` surface, in contrast with the existing
+`IsCanonicalFormBNT` predicate which lives on the assembled
+`toTensorFromBlocks` surface and conflates the spectral level with the
+within-sector multiplicities under `mu_strict_anti`.
+
+## References
+
+* CPSV16: Cirac--Pérez-García--Schuch--Verstraete, *Matrix Product Density
+  Operators: Renormalization Fixed Points and Boundary Theories*,
+  Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.  Definition of the BNT
+  canonical form, §II.
+* CPSV21: Cirac--Pérez-García--Schuch--Verstraete, *Matrix product states
+  and projected entangled pair states: Concepts, symmetries, theorems*,
+  Rev. Mod. Phys. **93**, 045003 (2021); arXiv:2011.12127.
+  Definition 4.2 (two-layer BNT canonical form).
+* `audits/2026-05-13_cpsv16_ft_definition_audit.md` §10.
+* `audits/2026-05-13_cpsv16_ft_bridge_gap.md`.
+-/
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- **Paper-faithful BNT canonical form on the `SectorDecomposition` surface
+(`SD = Sector Decomposition`).**
+
+A `SectorDecomposition` `P` carries the BNT canonical form of CPSV16 §II
+(arXiv:1606.00608; equivalently CPSV21 Definition 4.2, arXiv:2011.12127)
+when its sector weights have unit modulus and its basis of normal tensors is
+eventually linearly independent.
+
+The unit-modulus field is the load-bearing hypothesis of the per-block
+projection lemmas in
+`TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection`. -/
+structure IsBNTCanonicalFormSD (P : SectorDecomposition d) : Prop where
+  /-- Every within-sector weight has unit modulus. -/
+  unit_modulus : ∀ j q, ‖P.sectors.weight j q‖ = 1
+  /-- The basis of normal tensors is eventually linearly independent. -/
+  bnt_data : HasBNTSectorData P
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
@@ -2,13 +2,13 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 
 /-!
 # Paper-faithful BNT canonical form on the `SectorDecomposition` surface
 
-This module defines the `Prop`-level predicate `IsBNTCanonicalFormSD` over a
-`SectorDecomposition P`, recording the two paper-faithful hypotheses of
+The `Prop`-level predicate `IsBNTCanonicalFormSD` over a
+`SectorDecomposition P` records the two paper-faithful hypotheses of
 arXiv:1606.00608 Definition 4.2 / arXiv:2011.12127 Definition 4.2:
 
 * every within-sector weight has unit modulus
@@ -17,7 +17,7 @@ arXiv:1606.00608 Definition 4.2 / arXiv:2011.12127 Definition 4.2:
   (the `HasBNTSectorData` field from
   `TNLean.MPS.FundamentalTheorem.SectorDecomposition`).
 
-The structure is the eventual landing target of the
+The structure is the target signature for the
 `IsCanonicalFormBNT`→`SectorDecomposition` reorganization described in
 `audits/2026-05-13_cpsv16_ft_bridge_gap.md` §Resolution.
 

--- a/audits/2026-05-13_cpsv16_ft_bridge_b_status.md
+++ b/audits/2026-05-13_cpsv16_ft_bridge_b_status.md
@@ -1,0 +1,148 @@
+# CPSV16 FT — `IsCanonicalFormBNT` → `SectorDecomposition` status memo (Plan C, Objective B)
+
+**Date:** 2026-05-13 (revised after corrective restoration)
+**Scope:** Plan C follow-up workstream B (per issue #1641 — branch
+`feat/mps-ft-plan-c-B-bridge-wrapper`).
+**Status:** Dominant-block discharge added; general `_CFBNT` sorries
+explicitly open with documented obstruction.
+
+## Summary
+
+This memo documents the current state of the connection between
+`IsCanonicalFormBNT` (the existing one-copy-per-sector local hypothesis in
+`TNLean/MPS/BNT/Construction.lean`) and the paper-faithful per-block
+projection lemmas of
+`TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean`
+(Plan C, PR #1643).
+
+A previous revision of this workstream attempted to close the two `_CFBNT`
+fixed-block sorries by routing the analytic non-cancellation content
+through an explicit hypothesis `hAdjustedOverlapNoDecay`.  That hypothesis
+is **false for any non-dominant fixed block** under
+`IsCanonicalFormBNT.mu_strict_anti` (the dominant-adjusted scalar times the
+projected self-overlap on `B_{k₀}` with `k₀ ≠ 0` decays geometrically), so
+the resulting lemma was vacuously true by ex-falso rather than genuinely
+discharged.  Reviewers (claude review §1a/§1b on PR #1645 and the PR
+author) flagged this; the present revision restores the sorries with an
+honest **Open obligation** docstring section and adds the genuinely-closed
+dominant-block specialisations.
+
+This workstream now delivers:
+
+* a paper-faithful BNT canonical-form predicate
+  `IsBNTCanonicalFormSD` on the `SectorDecomposition` surface, staged for
+  the eventual upstream refactor (no consumers in this PR — see
+  Constraints honoured below);
+* the dominant-block discharges
+  `fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+  and
+  `fixed_left_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+  in `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean`,
+  proved unconditionally from `IsCanonicalFormBNT` plus the existing
+  dominant-adjusted scalar limit
+  `exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT`;
+* an upstream specialisation
+  `exists_nondecaying_dominant_overlap_of_nonzeroProportionalMPV₂_CFBNT`
+  in `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean`
+  consuming the two dominant-block discharges.
+
+The two general `_CFBNT` sorries are **explicitly open**.  The upstream
+caller `exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT` keeps
+its prior (merge-base) signature, so the blueprint `\leanok` tags at
+`blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` remain valid for
+the statements they were attached to.
+
+## Status of the `_CFBNT` sorries
+
+* **`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`**
+  — **open for non-dominant `k₀`**.  Dominant case
+  (`k₀ = ⟨0, _⟩`) closed by
+  `fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`.
+* **`fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`**
+  — **open for non-dominant `j₀`**.  Dominant case
+  (`j₀ = ⟨0, _⟩`) closed by
+  `fixed_left_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`.
+
+Resolving the general case requires the structural refactor described in
+`audits/2026-05-13_cpsv16_ft_bridge_gap.md` §Resolution — splitting
+`IsCanonicalFormBNT` into a spectral level (`λ_j` with strict
+modulus ordering) and a within-sector unit-modulus level
+(`μ_{j,q}` with `‖μ_{j,q}‖ = 1`).  Without that split, the unit-modulus
+hypothesis required by
+`TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection`
+fails for every non-dominant weight under
+`IsCanonicalFormBNT.mu_strict_anti`, and the analytic non-cancellation
+argument cannot be transported across the surfaces.
+
+## Dominant-block discharge
+
+`fixed_right_dominant_…_CFBNT` proves the case `k₀ = ⟨0, _⟩` of the right
+fixed-block contradiction.  The proof combines:
+
+1. the LHS-overlap expansion `∑_j (μA j)^N · ⟨V^{(N)}(A_j), V^{(N)}(B_0)⟩`
+   normalised by `(μA ⟨0,_⟩)^N`, with each summand tending to zero by
+   `bounded_mul_tendsto_zero` (geometric `(μA j / μA ⟨0,_⟩)^N` against
+   `hAllDecay` for `j ≠ ⟨0,_⟩`; direct `hAllDecay` for `j = ⟨0,_⟩`);
+2. the RHS-overlap expansion
+   `∑_k (μB k)^N · ⟨V^{(N)}(B_k), V^{(N)}(B_0)⟩` normalised by
+   `(μB ⟨0,_⟩)^N`, with the diagonal `k = ⟨0,_⟩` term contributing the
+   self-overlap limit `1`
+   (`hB.toHasNormalizedSelfOverlap.overlap_tendsto_one`) and off-diagonal
+   `k ≠ ⟨0,_⟩` terms decaying geometrically against
+   `hB.cross_overlap_tendsto_zero`;
+3. the dominant-weight-adjusted scalar limit
+   `‖c N · (μB ⟨0,_⟩ / μA ⟨0,_⟩)^N‖ → 1` from
+   `exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT`.
+
+Combining (1) gives the asymptotic
+`(μA ⟨0,_⟩)^{-N} · c N · ⟨V^{(N)}(toTensorFromBlocks μB B), V^{(N)}(B_0)⟩ → 0`,
+while combining (2) and (3) shows the same quantity has modulus tending to
+`1`.  Contradiction.
+
+`fixed_left_dominant_…_CFBNT` reduces to the right form by swapping
+families via `eventuallyNonzeroProportionalMPV₂_symm` and using
+`tendsto_mpvOverlap_zero_swap`.
+
+## Files added / modified (this revision)
+
+| Path | Change |
+| --- | --- |
+| `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean` | Restored the two `_CFBNT` sorries with open-obligation docstrings; added the two `_dominant_…_CFBNT` lemmas |
+| `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean` | Restored prior signature of `exists_nondecaying_overlap_…_CFBNT`; added `exists_nondecaying_dominant_overlap_…_CFBNT` |
+| `TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean` | Trimmed to just the `IsBNTCanonicalFormSD` structure + paper docstring; removed the unused `dominantPhaseSectorDecomp` adapter, `of_isCanonicalFormBNT`, and `hc_lower_of_isCanonicalFormBNT` |
+| `audits/2026-05-13_cpsv16_ft_bridge_b_status.md` | This revised memo |
+
+`IsBNTCanonicalFormSD` is the eventual landing target of the upstream
+refactor in `audits/2026-05-13_cpsv16_ft_bridge_gap.md` §Resolution.  It is
+staged here without consumers in this PR; the follow-on PR that introduces
+its first consumer will also add the corresponding blueprint entry.
+
+## Constraints honoured
+
+* **No new `sorry` / `axiom` / `unsafe`** beyond the two restored sorries
+  (which carry the merge-base statement; the blueprint `\leanok` tags
+  remain valid).
+* **No combined-family LI / RSE / Option-LI hypotheses.**
+* **No peel-arbitrary-`k₀` induction architecture.**
+* **No `ProportionalDecompositionData` arrays.**
+* **No edits to the wrong-direction-cleanup retired modules from #1639.**
+* **`lake build` passes** (8673 jobs).
+
+## References
+
+* arXiv:1606.00608 Theorem `thm1`, lines 1170--1192 (paper Step 1).
+* arXiv:2011.12127 Definition 4.2 (the two-layer BNT canonical form).
+* `audits/2026-05-13_cpsv16_ft_bridge_gap.md` (structural obstruction
+  analysis; §Resolution describes the upstream refactor needed to close
+  the non-dominant case).
+* `audits/2026-05-13_cpsv16_ft_definition_audit.md` §10 (Plan C YES
+  verdict).
+* `docs/paper-gaps/ft_one_copy_scope_restriction.tex` (scope restriction).
+* `docs/paper-gaps/cpsv16_fixed_block_cancellation.tex` (cancellation
+  obligation tracker for the open non-dominant case).
+* Issue #1641 (Plan C workplan).
+* Issue #1607 (fixed-block contradiction tracker).
+* PR #1643 (Plan C, `SectorDecomposition` surface).
+* PR #1644 (Plan C, branch A, `hNoCancel` analytic discharge — companion).
+* PR #1645 (this PR, with review feedback prompting the corrective
+  restoration).


### PR DESCRIPTION
Stacked on **#1643**.  Companion of **#1644** (Plan C Objective A).

**Updated scope after critical review (claude + LionSR "sus" comment):**
the previous version of this PR claimed to discharge the `_CFBNT` sorries
via a new `hAdjustedOverlapNoDecay` hypothesis, but that hypothesis was
vacuously false for non-dominant `k₀` under `mu_strict_anti`, making the
"discharge" ex-falso and not genuine progress.  This PR has been
corrected per the review feedback: the `sorry`s are restored, and the
genuine progress (the dominant-block specialisation) is added as a
separate lemma family.

## What's here (corrected)

### `IsBNTCanonicalFormSD` (in `BNTWrapper.lean`, 71 lines, 0 sorries)

```lean
structure IsBNTCanonicalFormSD (P : SectorDecomposition d) : Prop where
  unit_modulus : ∀ j q, ‖P.sectors.weight j q‖ = 1
  bnt_data     : HasBNTSectorData P
```

A `Prop`-level predicate naming the paper-faithful BNT canonical form on
the `SectorDecomposition` surface (arXiv:2011.12127 Def 4.2, two-layer:
outer spectral level + within-sector unit-modulus weights, multiplicity
`r_j ≥ 1` per sector).  Trimmed to just the predicate; no
hypothetical-future scaffolding.

### Dominant-block discharge (in `NondecayingOverlap/FixedBlockDecay.lean`)

Two **new lemmas**, fully proved (no factored analytic hypothesis):

* `fixed_right_dominant_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
  - specialises `k₀ = ⟨0, _⟩` (dominant `B`-block).
  - proof extracts `c` from
    `exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
    (the restored block from #1639) and uses `tendsto_nhds_unique` to
    contradict the conflict between `→ 0` (from the all-decay
    hypothesis) and `→ 1` (from the dominant-adjusted limit).
* `fixed_left_dominant_*_CFBNT` — symmetric, reduces to the right case.

Plus a wrapper:

* `exists_nondecaying_dominant_overlap_of_nonzeroProportionalMPV₂_CFBNT`
  — public entry point for the dominant-block existence.

This is **the actual mathematical progress over the merge base**: the
existing infrastructure (`exists_dominant_adjusted_scalar_*`,
`HasNormalizedSelfOverlap`) is enough to close the contradiction at the
dominant block.  Non-dominant `k₀` remains open.

### The two `_CFBNT` sorries restored

Per claude review §1a, the previous discharge was vacuous for
non-dominant `k₀` (the new `hAdjustedOverlapNoDecay` hypothesis was
unsatisfiable in the strict-anti setting).  The `sorry`s are restored
with byte-identical signatures to merge-base, and each carries an
**Open obligation (non-dominant `k₀`)** docstring section citing
`audits/2026-05-13_cpsv16_ft_bridge_gap.md` §Resolution and issue
#1641.

The upstream `exists_nondecaying_overlap_of_nonzeroProportionalMPV₂_CFBNT`
is restored to its pre-#1645 signature.

### Audit memo `audits/2026-05-13_cpsv16_ft_bridge_b_status.md`

Rewritten to honestly reflect the scope:
* Acknowledges the vacuous nature of the previous "discharge".
* Documents the dominant-block lemmas as the genuine progress.
* Records `IsBNTCanonicalFormSD` as the staging structure for the
  follow-on substantive `IsCanonicalFormBNT` refactor (per LionSR's
  directive: "IsCanonicalFromBNT we need to change") — that refactor
  is out of scope here.

## What's not here

* **The full `_CFBNT` discharge for non-dominant `k₀`** is still open —
  it genuinely requires the substantive `IsCanonicalFormBNT` refactor
  (splitting `mu_strict_anti` from the base, exposing the inner
  unit-modulus weight layer).  That is a separate workstream.
* **`hc_lower_of_isCanonicalFormBNT`** and **`dominantPhaseSectorDecomp`**
  were dropped (per claude review §3a: scaffolding without consumers).

## Local CI

```
lake build              ✅  8673 jobs
sorry/axiom/unsafe      2 sorries (matching merge-base), 0 axioms, 0 unsafe
file lengths            all under 1000 lines
```

## Refs

Refs #1641 (Plan C tracker).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new theorems and exposes them on the root import surface; while mostly additive, it changes proof dependencies and introduces a new public API predicate, and the general fixed-block lemmas remain `sorry`-backed obligations.
> 
> **Overview**
> Adds `IsBNTCanonicalFormSD` (a new `SectorDecomposition`-surface predicate capturing unit-modulus sector weights + `HasBNTSectorData`) and wires it into the public import surface (`TNLean.lean`).
> 
> Refactors the proportional-MPV nondecaying-overlap pipeline by moving the two fixed-block decay-contradiction lemmas into a new `NondecayingOverlap/FixedBlockDecay.lean` module (keeping the general versions as explicit open `sorry` obligations) and **adds fully proved dominant-block specialisations** plus a new wrapper lemma `exists_nondecaying_dominant_overlap_of_nonzeroProportionalMPV₂_CFBNT` that relies only on the dominant cases.
> 
> Updates documentation/audit notes to explicitly record the non-dominant obstruction and the scope of what is actually discharged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73ada4d3ec26b0437b4223c9967fea418ad4cbc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->