### PR TITLE
refactor(MPS/CanonicalForm): remove vacuous _of_linearIndependent variant (Ch9 audit W2)

### DIFF
--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -524,26 +524,4 @@ theorem exists_bnt_sectorDecomp_of_linearIndependent
     sameMPV₂_trivialSectorDecomp μ blocks hμne, ?_⟩
   simpa [trivialSectorDecomp] using hLI
 
-/-- Signature-compatible reformulation for TP / primitive / irreducible block data.
-
-The extra block-normality hypotheses are intentionally retained here to match the
-shape expected by the one-sided BNT-construction route, but only nonzero weights and the
-current BNT linear-independence hypothesis are used.  Use
-`exists_bnt_sectorDecomp_of_linearIndependent` when those extra hypotheses are not
-already present. -/
-theorem exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent
-    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
-    (μ : Fin r → ℂ)
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (_hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
-    (_hIrr : ∀ k, IsIrreducibleTensor (blocks k))
-    (_hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
-    (hμne : ∀ k, μ k ≠ 0)
-    (hLI : ∃ N0 : ℕ, ∀ N > N0,
-      LinearIndependent ℂ (fun k : Fin r => mpvState (blocks k) N)) :
-    ∃ P : SectorDecomposition d,
-      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
-      HasBNTSectorData (d := d) P :=
-  exists_bnt_sectorDecomp_of_linearIndependent μ blocks hμne hLI
-
 end MPSTensor

--- a/audits/2026-04-25_issue876_bnt_sector_blocker.md
+++ b/audits/2026-04-25_issue876_bnt_sector_blocker.md
@@ -39,17 +39,14 @@ construction theorem that produces such a basis from the blocked data.
 
 ## Replacement branch contribution
 
-The replacement branch adds the small post-#886 adapter that is actually true:
+The replacement branch adds the small post-#886 adapters that are actually true:
 
 - `MPSTensor.trivialSectorDecomp`
 - `MPSTensor.sameMPV₂_trivialSectorDecomp`
-- `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent`
 
-The last theorem has the old TP/primitive/irreducible inputs but also requires
-
-a supplied eventual-linear-independence hypothesis
-`∃ N0, ∀ N > N0, LinearIndependent ℂ (fun k => mpvState (blocks k) N)`.
-It then packages the granular sector decomposition and discharges the current
+The later-retained construction with a supplied eventual-linear-independence
+hypothesis is `MPSTensor.exists_bnt_sectorDecomp_of_linearIndependent`.  It
+packages the granular sector decomposition and discharges the current
 `HasBNTSectorData` by exactly that hypothesis.  This is not a closure of #876;
 it is the clean adapter that future real BNT construction can feed.
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3133,25 +3133,6 @@ do not correspond to independent paper-level results.
 	for the chosen sector basis.
 \end{proof}
 
-\begin{theorem}[TP primitive irreducible version with eventual BNT independence]
-	\label{thm:bnt_sector_decomp_tp_prim_irr_linear_independent}
-	\lean{MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent}
-	\leanok
-	\uses{thm:bnt_sector_decomp_linear_independent}
-	For trace-preserving primitive irreducible blocks of positive bond dimension,
-	if the block MPV states are linearly independent for all sufficiently large
-	system sizes and the weights are nonzero, then there is a sector decomposition
-	representing the same MPS family and satisfying the BNT linear-independence
-	condition.
-\end{theorem}
-
-\begin{proof}\leanok
-	\uses{thm:bnt_sector_decomp_linear_independent}
-	Apply Theorem~\ref{thm:bnt_sector_decomp_linear_independent}; the additional
-	trace-preserving, primitive, irreducible, and positivity assumptions are carried
-	along for compatibility with the one-sided BNT construction.
-\end{proof}
-
 \subsection{Cyclic Sectors}
 
 \begin{definition}[Left sector tensor]


### PR DESCRIPTION
## Summary

Deletes the vacuous theorem `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent` from `TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean`.

## Why

Identified by the Chapter 9 (Canonical Form Reduction) audit. The theorem takes TP / primitive / irreducible hypotheses but never uses them in the proof body — the body is just a direct call into the strictly weaker `exists_bnt_sectorDecomp_of_linearIndependent`.

Verdict: VACUOUS by both audit passes (opus47T + gpt55) and both fact-check passes (deepseek + gpt55). See `audits/2026-05-13_chapter9_canonical_form_synthesis.md` Tier-A item 4 and `audits/2026-05-13_chapter9_factcheck.md` Block B.

## Changes

- Delete the Lean theorem (`PhaseClassSectorData.lean` lines 534–555 + docstring).
- Delete the blueprint entry `thm:bnt_sector_decomp_tp_prim_irr_linear_independent` in `ch08_canonical.tex`.
- Remove one stale reference in `audits/2026-04-25_issue876_bnt_sector_blocker.md`.

## Verification

- `lake build TNLean.MPS.CanonicalForm.PhaseClassSectorData`: ✅ pass
- `lake build TNLean`: ✅ pass
- `grep -rn "exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent" .`: no matches

## Audit chain reference

- `audits/2026-05-13_chapter9_canonical_form_audit.md` (opus47T)
- `audits/2026-05-13_chapter9_canonical_form_audit_gpt55.md` (gpt55)
- `audits/2026-05-13_chapter9_canonical_form_synthesis.md` (synthesis Tier A.4)
- `audits/2026-05-13_chapter9_factcheck.md` (deepseek fact-check)
- `audits/2026-05-13_chapter9_factcheck_gpt55.md` (gpt55 fact-check)
- `audits/2026-05-13_chapter9_FINAL_corrected.md` §1.1.B

Part of a 3-PR Chapter-9 cleanup wave; sibling PRs are blueprint dedup (#TBD) and BDC relocation (#TBD).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR removes an unused/vacuous wrapper theorem and updates documentation/audit text to point at the remaining constructor, without changing any core construction logic.
> 
> **Overview**
> Deletes `MPSTensor.exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks_of_linearIndependent` (a signature-compatible wrapper whose extra hypotheses were unused), leaving `MPSTensor.exists_bnt_sectorDecomp_of_linearIndependent` as the single conditional constructor.
> 
> Updates the audit note and blueprint chapter to remove the stale theorem reference and describe the remaining construction path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b240ab2dbbf95b5ebd210ae859b1e99dccec55b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->