### PR TITLE
feat(MPS/FT): two-layer IsBNTCanonicalFormSD + adapter (path β, PR 1 + 1.5)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
@@ -13,8 +13,9 @@ The `Prop`-level predicate `IsBNTCanonicalFormSD` over a
 `SectorDecomposition P` records the two-layer BNT canonical form of
 arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2:
 
-* a **spectral level** `λ : Fin P.basisCount → ℂ` with `λ_j ≠ 0` and
-  strictly-decreasing modulus;
+* a **spectral level** `λ : Fin P.basisCount → ℂ` with `λ_j ≠ 0`,
+  strictly-decreasing modulus, and **dominant normalization**
+  `‖λ_0‖ = 1`;
 * **within-sector weights** factor as `P.sectors.weight j q = λ_j · ν_{j,q}`
   with `‖ν_{j,q}‖ = 1`, expressed as `‖P.sectors.weight j q / λ_j‖ = 1`;
 * eventual linear independence of the basis blocks
@@ -23,13 +24,20 @@ arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2:
 The spectral level is packaged inside an existential so the whole
 predicate stays `Prop`-valued; the layer data is exposed via
 `spectralLevel`, `spectralLevel_ne_zero`, `spectralLevel_strict_anti`,
-and `weight_factor`.
+`weight_factor`, and `spectralLevel_dom_norm_one`.
 
 This file also exposes the adapter `IsCanonicalFormBNT.toIsBNTCanonicalFormSD`
-from the existing one-copy-per-sector `IsCanonicalFormBNT` data: the
-spectral level is `μ`, the within-sector phase is `μ_j / ‖μ_j‖`, and
-the assembled tensor `P.toTensor` is MPV-equal to
-`toTensorFromBlocks μ A` via `sameMPV₂_trivialSectorDecomp`.
+from the existing one-copy-per-sector `IsCanonicalFormBNT` data.  Because
+`IsCanonicalFormBNT` does **not** require the dominant weight to have
+unit modulus, the adapter rescales: it sets `λ_j = μ_j / ‖μ_0‖` (and
+`ρ = 1` when there are no blocks).  The assembled tensor `P.toTensor`
+then differs from `toTensorFromBlocks μ A` by a uniform per-length
+scalar `ρ^{-N}`, which is exposed as a `NonzeroProportionalMPV₂`
+relation (the scalar is nonzero because `‖μ_0‖ > 0`).  This rescaling
+is the **Choice B** discharge described in the audit memo: it absorbs
+the dominant-block normalization at the adapter level so callers on
+the `IsCanonicalFormBNT` surface do not have to add an extra
+`‖μ ⟨0, _⟩‖ = 1` hypothesis.
 
 The `SD` suffix abbreviates "Sector Decomposition" — the predicate lives on
 the `SectorDecomposition` surface, in contrast with the existing
@@ -47,7 +55,7 @@ within-sector multiplicities under `mu_strict_anti`.
   and projected entangled pair states: Concepts, symmetries, theorems*,
   Rev. Mod. Phys. **93**, 045003 (2021); arXiv:2011.12127.
   Definition 4.2 (two-layer BNT canonical form).
-* `audits/2026-05-13_cpsv16_ft_path_beta_scout.md`.
+* `audits/2026-05-13_cpsv16_ft_path_beta_scout.md`, §"PR 1.5 amendment".
 -/
 
 namespace MPSTensor
@@ -61,26 +69,37 @@ A `SectorDecomposition` `P` carries the two-layer BNT canonical form of
 CPSV16 §II (arXiv:1606.00608; equivalently CPSV21 Definition 4.2,
 arXiv:2011.12127) when:
 
-* there is a spectral level `λ : Fin P.basisCount → ℂ` with `λ_j ≠ 0`
-  and `StrictAnti (fun j => ‖λ_j‖)`;
+* there is a spectral level `λ : Fin P.basisCount → ℂ` with `λ_j ≠ 0`,
+  `StrictAnti (fun j => ‖λ_j‖)`, and **dominant normalization**
+  `‖λ_0‖ = 1` whenever `P.basisCount > 0`;
 * the within-sector weight `P.sectors.weight j q` factors as `λ_j · ν_{j,q}`
   with `‖ν_{j,q}‖ = 1`, recorded as `‖P.sectors.weight j q / λ_j‖ = 1`;
 * the basis of normal tensors is eventually linearly independent
   (`HasBNTSectorData`).
 
+The dominant normalization `‖λ_0‖ = 1` is the CPSV21 Definition 4.2
+convention.  Combined with `StrictAnti`, it forces `‖λ_j‖ ≤ 1` for
+every `j`, hence the per-length coefficients `coeff N j` are uniformly
+controlled by the within-sector multiplicities.  This uniform bound is
+what powers the analytic discharge of `HNoCancelDischarge` on the
+non-dominant `k₀` branch (see the PR 1.5 amendment to the audit memo).
+
 The spectral level is packaged inside an existential to keep the
-predicate `Prop`-valued; the four layer projections are exposed via the
-`spectralLevel`, `spectralLevel_ne_zero`, `spectralLevel_strict_anti`,
-and `weight_factor` accessors below. -/
+predicate `Prop`-valued; the five layer projections are exposed via
+the `spectralLevel`, `spectralLevel_ne_zero`, `spectralLevel_strict_anti`,
+`weight_factor`, and `spectralLevel_dom_norm_one` accessors below. -/
 structure IsBNTCanonicalFormSD (P : SectorDecomposition d) : Prop where
-  /-- A spectral level `λ_j` exists with the three two-layer properties:
-  nonvanishing, strictly-decreasing modulus, and unit-modulus quotient
-  by every within-sector weight `P.sectors.weight j q`. -/
+  /-- A spectral level `λ_j` exists with the four two-layer properties:
+  nonvanishing, strictly-decreasing modulus, unit-modulus quotient by
+  every within-sector weight `P.sectors.weight j q`, and dominant
+  normalization `‖λ_0‖ = 1`.  The dominant normalization is vacuous
+  when `P.basisCount = 0`. -/
   exists_spectralLevel :
     ∃ lam : Fin P.basisCount → ℂ,
       (∀ j, lam j ≠ 0) ∧
       StrictAnti (fun j : Fin P.basisCount => ‖lam j‖) ∧
-      (∀ j q, ‖P.sectors.weight j q / lam j‖ = 1)
+      (∀ j q, ‖P.sectors.weight j q / lam j‖ = 1) ∧
+      (∀ h : 0 < P.basisCount, ‖lam ⟨0, h⟩‖ = 1)
   /-- The basis of normal tensors is eventually linearly independent. -/
   bnt_data : HasBNTSectorData P
 
@@ -91,7 +110,7 @@ variable {P : SectorDecomposition d}
 /-- **Spectral level** of the two-layer BNT canonical form.
 
 One complex number `λ_j` per basis block, with `‖λ_j‖` strictly decreasing
-in `j` (cf. arXiv:2011.12127 Definition 4.2). -/
+in `j` and `‖λ_0‖ = 1` (cf. arXiv:2011.12127 Definition 4.2). -/
 noncomputable def spectralLevel (h : IsBNTCanonicalFormSD P) :
     Fin P.basisCount → ℂ :=
   h.exists_spectralLevel.choose
@@ -111,7 +130,35 @@ the quotient `P.sectors.weight j q / λ_j` has unit modulus. -/
 theorem weight_factor (h : IsBNTCanonicalFormSD P)
     (j : Fin P.basisCount) (q : Fin (P.copies j)) :
     ‖P.sectors.weight j q / h.spectralLevel j‖ = 1 :=
-  h.exists_spectralLevel.choose_spec.2.2 j q
+  h.exists_spectralLevel.choose_spec.2.2.1 j q
+
+/-- **Dominant normalization of the spectral level** (CPSV21 Definition 4.2).
+
+When `P` has at least one basis block, the dominant spectral level has
+unit modulus, `‖λ_0‖ = 1`.  Combined with `spectralLevel_strict_anti`
+this gives `‖λ_j‖ < 1` for `j ≥ 1` and `‖λ_j‖ ≤ 1` for every `j`. -/
+theorem spectralLevel_dom_norm_one (h : IsBNTCanonicalFormSD P)
+    (hpos : 0 < P.basisCount) :
+    ‖h.spectralLevel ⟨0, hpos⟩‖ = 1 :=
+  h.exists_spectralLevel.choose_spec.2.2.2 hpos
+
+/-- All spectral-level moduli are bounded by `1`.
+
+Source: CPSV21 Definition 4.2.  Combines `spectralLevel_dom_norm_one`
+with `spectralLevel_strict_anti`: the dominant block has unit modulus
+and every other block has strictly smaller modulus, so all moduli are
+at most `1`. -/
+theorem spectralLevel_norm_le_one (h : IsBNTCanonicalFormSD P)
+    (j : Fin P.basisCount) : ‖h.spectralLevel j‖ ≤ 1 := by
+  have hpos : 0 < P.basisCount := Nat.lt_of_le_of_lt (Nat.zero_le _) j.isLt
+  have hdom : ‖h.spectralLevel ⟨0, hpos⟩‖ = 1 :=
+    h.spectralLevel_dom_norm_one hpos
+  have hle : (⟨0, hpos⟩ : Fin P.basisCount) ≤ j :=
+    Fin.mk_le_of_le_val (Nat.zero_le _)
+  have hanti : ‖h.spectralLevel j‖ ≤ ‖h.spectralLevel ⟨0, hpos⟩‖ :=
+    h.spectralLevel_strict_anti.antitone hle
+  rw [hdom] at hanti
+  exact hanti
 
 end IsBNTCanonicalFormSD
 
@@ -119,39 +166,89 @@ end IsBNTCanonicalFormSD
 
 The one-copy-per-sector BNT canonical form `IsCanonicalFormBNT μ A`
 yields the two-layer `IsBNTCanonicalFormSD` on the trivial sector
-decomposition (`trivialSectorDecomp μ A`, `copies j = 1`):
+decomposition (`copies j = 1`) after rescaling by the dominant-block
+modulus `ρ = ‖μ_0‖` (or `ρ = 1` when there are no blocks).  The
+spectral level is `λ_j = μ_j / ρ`, which satisfies the CPSV21 Def 4.2
+dominant normalization `‖λ_0‖ = 1`.  This is the **Choice B**
+discharge: the rescaling is absorbed at the adapter level so callers
+do not need to add a `‖μ ⟨0, _⟩‖ = 1` hypothesis to existing
+`IsCanonicalFormBNT`-shaped lemmas.
 
-* the spectral level is `λ_j = μ_j` (the original block weights),
-* the within-sector phase is `ν_{j,0} = μ_j / ‖μ_j‖`, witnessed by
-  `weight_factor` because `(trivialSectorDecomp μ A).sectors.weight j q = μ j`
-  and `‖μ_j / μ_j‖ = ‖1‖ = 1`;
-* `HasBNTSectorData` follows from `IsCanonicalFormBNT.isBNT`'s
-  `eventually_li` field, since the trivial sector decomposition has
-  `basis = A`.
+Because the weights are rescaled, `P.toTensor` is no longer
+`SameMPV₂`-equal to `toTensorFromBlocks μ A`; instead, the two assembled
+tensors satisfy a uniform `NonzeroProportionalMPV₂` relation with
+scalar `ρ^{-N}` (nonzero for every `N`).  Compose this with the
+input `EventuallyNonzeroProportionalMPV₂` to transfer
+proportionality to the `SectorDecomposition` surface.
 
-The assembled tensor `P.toTensor` is MPV-equal to `toTensorFromBlocks μ A`
-via `sameMPV₂_trivialSectorDecomp`, so proportionality hypotheses on the
-`IsCanonicalFormBNT` surface transfer to the SD surface unchanged
-(cf. arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2). -/
+(cf. arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2.) -/
 theorem IsCanonicalFormBNT.toIsBNTCanonicalFormSD
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
     (hCF : IsCanonicalFormBNT μ A) :
     ∃ P : SectorDecomposition d,
       IsBNTCanonicalFormSD P ∧
-      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) A) := by
+      NonzeroProportionalMPV₂ P.toTensor
+        (toTensorFromBlocks (d := d) (μ := μ) A) := by
+  classical
   have hμne : ∀ j, μ j ≠ 0 := hCF.toIsCanonicalForm.mu_ne_zero
-  refine ⟨trivialSectorDecomp μ A hμne, ?_, sameMPV₂_trivialSectorDecomp μ A hμne⟩
-  refine
-    { exists_spectralLevel := ?_
-      bnt_data := ?_ }
-  · refine ⟨μ, hμne, hCF.mu_strict_anti, ?_⟩
-    intro j q
-    have hdiv : μ j / μ j = 1 := div_self (hμne j)
-    simp [trivialSectorDecomp, hdiv]
-  · -- `HasBNTSectorData (trivialSectorDecomp μ A hμne)` unfolds to eventual
-    -- linear independence of `mpvState (A j) N`, which is the `eventually_li`
-    -- field of `IsCanonicalFormBNT.isBNT`.
-    simpa [HasBNTSectorData, trivialSectorDecomp] using hCF.isBNT.eventually_li
+  -- Rescaling factor: `‖μ_0‖` when `r > 0`, else `1` (vacuous).
+  set ρ : ℝ := if h : 0 < r then ‖μ ⟨0, h⟩‖ else 1 with hρdef
+  have hρpos : 0 < ρ := by
+    rw [hρdef]
+    split_ifs with hh
+    · exact norm_pos_iff.mpr (hμne ⟨0, hh⟩)
+    · exact one_pos
+  have hρne : (ρ : ℂ) ≠ 0 := by exact_mod_cast hρpos.ne'
+  have hρcomplex_norm : ‖(ρ : ℂ)‖ = ρ := by
+    rw [Complex.norm_real, Real.norm_of_nonneg hρpos.le]
+  -- Rescaled weights.
+  let lam : Fin r → ℂ := fun j => μ j / (ρ : ℂ)
+  have hlamne : ∀ j, lam j ≠ 0 := fun j => div_ne_zero (hμne j) hρne
+  refine ⟨trivialSectorDecomp lam A hlamne, ?_, ?_⟩
+  · -- Two-layer predicate: build the existential layer-by-layer.
+    refine
+      { exists_spectralLevel := ⟨lam, hlamne, ?_, ?_, ?_⟩
+        bnt_data := ?_ }
+    · -- StrictAnti: dividing by a positive real preserves strict order.
+      intro i j hij
+      have hμij : ‖μ j‖ < ‖μ i‖ := hCF.mu_strict_anti hij
+      simp only [lam, norm_div, hρcomplex_norm]
+      exact div_lt_div_of_pos_right hμij hρpos
+    · -- weight_factor: `(trivialSectorDecomp lam A).sectors.weight j q = lam j`
+      -- and `lam j / lam j = 1`.
+      intro j q
+      simp [trivialSectorDecomp, div_self (hlamne j)]
+    · -- Dominant normalization: `‖lam ⟨0, h⟩‖ = ‖μ_0‖ / ρ = 1`.
+      intro hpos
+      have hpos' : 0 < r := hpos
+      have hρeq : ρ = ‖μ ⟨0, hpos'⟩‖ := by rw [hρdef]; exact dif_pos hpos'
+      change ‖lam ⟨0, hpos'⟩‖ = 1
+      simp only [lam, norm_div]
+      rw [hρcomplex_norm, hρeq]
+      exact div_self (norm_ne_zero_iff.mpr (hμne ⟨0, hpos'⟩))
+    · -- `HasBNTSectorData (trivialSectorDecomp lam A hlamne)` unfolds to
+      -- eventual linear independence of `mpvState (A j) N`, which is the
+      -- `eventually_li` field of `IsCanonicalFormBNT.isBNT`.  The basis
+      -- of `trivialSectorDecomp` is `A`, independent of the weight choice.
+      simpa [HasBNTSectorData, trivialSectorDecomp] using hCF.isBNT.eventually_li
+  · -- `NonzeroProportionalMPV₂ P.toTensor (toTensorFromBlocks μ A)`:
+    -- `mpv P.toTensor σ = (ρ^N)⁻¹ · mpv (toTensorFromBlocks μ A) σ`.
+    intro N
+    refine ⟨((ρ : ℂ) ^ N)⁻¹, inv_ne_zero (pow_ne_zero _ hρne), ?_⟩
+    intro σ
+    -- Step 1: rewrite `mpv P.toTensor` using `sameMPV₂_trivialSectorDecomp`.
+    have hP_mpv :
+        mpv (trivialSectorDecomp lam A hlamne).toTensor σ
+          = mpv (toTensorFromBlocks (d := d) (μ := lam) A) σ :=
+      sameMPV₂_trivialSectorDecomp lam A hlamne N σ
+    rw [hP_mpv]
+    -- Step 2: expand both `toTensorFromBlocks` MPVs as sums over blocks.
+    rw [mpv_toTensorFromBlocks_eq_sum lam A σ,
+        mpv_toTensorFromBlocks_eq_sum μ A σ, Finset.mul_sum]
+    -- Step 3: pointwise — `(μ_k / ρ)^N · mpv A_k = (ρ^N)⁻¹ · μ_k^N · mpv A_k`.
+    refine Finset.sum_congr rfl fun k _ => ?_
+    simp only [lam, smul_eq_mul, div_eq_mul_inv]
+    ring
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
@@ -10,8 +10,9 @@ import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 # Two-layer BNT canonical form on the `SectorDecomposition` surface
 
 The `Prop`-level predicate `IsBNTCanonicalFormSD` over a
-`SectorDecomposition P` records the two-layer BNT canonical form of
-arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2:
+`SectorDecomposition P` is a **project-specific refinement** of the
+BNT decomposition of CPSV16 §II (`eq:II_ABasicTensors`, arXiv:1606.00608)
+in which equal-modulus blocks are grouped into sectors:
 
 * a **spectral level** `λ : Fin P.basisCount → ℂ` with `λ_j ≠ 0`,
   strictly-decreasing modulus, and **dominant normalization**
@@ -20,6 +21,16 @@ arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2:
   with `‖ν_{j,q}‖ = 1`, expressed as `‖P.sectors.weight j q / λ_j‖ = 1`;
 * eventual linear independence of the basis blocks
   (`HasBNTSectorData`).
+
+The `StrictAnti` and `weight_factor` conditions are **not** present in
+CPSV16's general `eq:II_ABasicTensors` (which allows arbitrary complex
+`μ_{j,q}`); they arise from grouping equal-modulus coefficients into
+sectors and extracting a common spectral factor `λ_j`.  The unit-modulus
+condition `‖ν_{j,q}‖ = 1` is conceptually related to the RFP
+characterization in CPSV16 `thm:charact-MPS` (§III, lines 543–555), which
+is a strict sub-class.  The dominant normalization `‖λ_0‖ = 1` mirrors
+the `IsNormalCanonicalFormBNT.mu_dom_norm_one` convention used throughout
+`TNLean/MPS/BNT/Construction.lean`.
 
 The spectral level is packaged inside an existential so the whole
 predicate stays `Prop`-valued; the layer data is exposed via
@@ -49,13 +60,26 @@ within-sector multiplicities under `mu_strict_anti`.
 
 * CPSV16: Cirac--Pérez-García--Schuch--Verstraete, *Matrix Product Density
   Operators: Renormalization Fixed Points and Boundary Theories*,
-  Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.  Definition of the BNT
-  canonical form, §II.
+  Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.
+  - `eq:II_ABasicTensors` (§II, line 286): the BNT decomposition shape
+    `A^i = ⊕_j ⊕_q μ_{j,q} X_{j,q} A^i_j X_{j,q}^{-1}` with **arbitrary**
+    complex `μ_{j,q}` (no strictness or unit-modulus condition).
+  - `thm:charact-MPS` (§III, lines 543–555): the RFP characterization in
+    which `|μ_{j,q}| = 1`; this is the conceptual ancestor of `weight_factor`.
 * CPSV21: Cirac--Pérez-García--Schuch--Verstraete, *Matrix product states
   and projected entangled pair states: Concepts, symmetries, theorems*,
   Rev. Mod. Phys. **93**, 045003 (2021); arXiv:2011.12127.
-  Definition 4.2 (two-layer BNT canonical form).
+  - Definition 4.3 (`def:4:BNT`, lines 1846–1850): eventual linear
+    independence of the BNT vectors; this is what `bnt_data` captures.
+  - **Note:** Definition 4.2 (`def:4:normal-tensor-mps`) is the one-layer
+    canonical form `A^i = ⊕_k μ_k A^i_k` — it does *not* define the
+    two-layer BNT structure, spectral levels, or unit-modulus conditions.
+* `IsNormalCanonicalFormBNT.mu_dom_norm_one` in
+  `TNLean/MPS/BNT/Construction.lean` for the dominant normalization
+  convention that `spectralLevel_dom_norm_one` mirrors.
 * `audits/2026-05-13_cpsv16_ft_path_beta_scout.md`, §"PR 1.5 amendment".
+* `docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex` for the
+  paper-gap note recording the extra hypotheses beyond CPSV16 §II.
 -/
 
 namespace MPSTensor
@@ -65,9 +89,9 @@ variable {d : ℕ}
 /-- **Two-layer BNT canonical form on the `SectorDecomposition` surface
 (`SD = Sector Decomposition`).**
 
-A `SectorDecomposition` `P` carries the two-layer BNT canonical form of
-CPSV16 §II (arXiv:1606.00608; equivalently CPSV21 Definition 4.2,
-arXiv:2011.12127) when:
+A `SectorDecomposition` `P` satisfies this predicate — a project-specific
+refinement of CPSV16 `eq:II_ABasicTensors` (§II, arXiv:1606.00608) via
+equal-modulus sector grouping — when:
 
 * there is a spectral level `λ : Fin P.basisCount → ℂ` with `λ_j ≠ 0`,
   `StrictAnti (fun j => ‖λ_j‖)`, and **dominant normalization**
@@ -77,12 +101,19 @@ arXiv:2011.12127) when:
 * the basis of normal tensors is eventually linearly independent
   (`HasBNTSectorData`).
 
-The dominant normalization `‖λ_0‖ = 1` is the CPSV21 Definition 4.2
-convention.  Combined with `StrictAnti`, it forces `‖λ_j‖ ≤ 1` for
-every `j`, hence the per-length coefficients `coeff N j` are uniformly
-controlled by the within-sector multiplicities.  This uniform bound is
-what powers the analytic discharge of `HNoCancelDischarge` on the
-non-dominant `k₀` branch (see the PR 1.5 amendment to the audit memo).
+The three extra conditions (`StrictAnti`, `weight_factor`, dominant
+normalization) are **not** present in CPSV16 `eq:II_ABasicTensors`, which
+allows arbitrary complex `μ_{j,q}` without any modulus ordering or
+factorization.  They are introduced by the project's `SectorDecomposition`
+grouping and the `IsNormalCanonicalFormBNT` convention for `‖λ_0‖ = 1`
+(cf. `IsNormalCanonicalFormBNT.mu_dom_norm_one`).  The eventual linear
+independence `bnt_data` corresponds to CPSV21 Definition 4.3 (not Def. 4.2).
+
+Combined with `StrictAnti`, the dominant normalization forces `‖λ_j‖ ≤ 1`
+for every `j`, so per-length coefficients `coeff N j` are uniformly
+controlled by the within-sector multiplicities.  This uniform bound powers
+the analytic discharge of `HNoCancelDischarge` on the non-dominant `k₀`
+branch (see the PR 1.5 amendment to the audit memo).
 
 The spectral level is packaged inside an existential to keep the
 predicate `Prop`-valued; the five layer projections are exposed via
@@ -110,7 +141,10 @@ variable {P : SectorDecomposition d}
 /-- **Spectral level** of the two-layer BNT canonical form.
 
 One complex number `λ_j` per basis block, with `‖λ_j‖` strictly decreasing
-in `j` and `‖λ_0‖ = 1` (cf. arXiv:2011.12127 Definition 4.2). -/
+in `j` and `‖λ_0‖ = 1`.  This is the equal-modulus grouping factor
+introduced by the project's `SectorDecomposition` surface; it is not a
+direct field of CPSV16 `eq:II_ABasicTensors`, which uses bare `μ_{j,q}`.
+The dominant normalization mirrors `IsNormalCanonicalFormBNT.mu_dom_norm_one`. -/
 noncomputable def spectralLevel (h : IsBNTCanonicalFormSD P) :
     Fin P.basisCount → ℂ :=
   h.exists_spectralLevel.choose
@@ -132,11 +166,15 @@ theorem weight_factor (h : IsBNTCanonicalFormSD P)
     ‖P.sectors.weight j q / h.spectralLevel j‖ = 1 :=
   h.exists_spectralLevel.choose_spec.2.2.1 j q
 
-/-- **Dominant normalization of the spectral level** (CPSV21 Definition 4.2).
+/-- **Dominant normalization of the spectral level.**
 
 When `P` has at least one basis block, the dominant spectral level has
-unit modulus, `‖λ_0‖ = 1`.  Combined with `spectralLevel_strict_anti`
-this gives `‖λ_j‖ < 1` for `j ≥ 1` and `‖λ_j‖ ≤ 1` for every `j`. -/
+unit modulus, `‖λ_0‖ = 1`.  This mirrors the convention
+`IsNormalCanonicalFormBNT.mu_dom_norm_one` in
+`TNLean/MPS/BNT/Construction.lean`; it is not asserted by CPSV16
+`eq:II_ABasicTensors` (which imposes no normalization on `μ_{j,q}`).
+Combined with `spectralLevel_strict_anti` this gives `‖λ_j‖ < 1` for
+`j ≥ 1` and `‖λ_j‖ ≤ 1` for every `j`. -/
 theorem spectralLevel_dom_norm_one (h : IsBNTCanonicalFormSD P)
     (hpos : 0 < P.basisCount) :
     ‖h.spectralLevel ⟨0, hpos⟩‖ = 1 :=
@@ -144,10 +182,10 @@ theorem spectralLevel_dom_norm_one (h : IsBNTCanonicalFormSD P)
 
 /-- All spectral-level moduli are bounded by `1`.
 
-Source: CPSV21 Definition 4.2.  Combines `spectralLevel_dom_norm_one`
-with `spectralLevel_strict_anti`: the dominant block has unit modulus
-and every other block has strictly smaller modulus, so all moduli are
-at most `1`. -/
+Combines `spectralLevel_dom_norm_one` with `spectralLevel_strict_anti`:
+the dominant block has unit modulus and every other block has strictly
+smaller modulus, so all moduli are at most `1`.  Both inputs are
+project-specific conditions not present in CPSV16 `eq:II_ABasicTensors`. -/
 theorem spectralLevel_norm_le_one (h : IsBNTCanonicalFormSD P)
     (j : Fin P.basisCount) : ‖h.spectralLevel j‖ ≤ 1 := by
   have hpos : 0 < P.basisCount := Nat.lt_of_le_of_lt (Nat.zero_le _) j.isLt
@@ -168,20 +206,24 @@ The one-copy-per-sector BNT canonical form `IsCanonicalFormBNT μ A`
 yields the two-layer `IsBNTCanonicalFormSD` on the trivial sector
 decomposition (`copies j = 1`) after rescaling by the dominant-block
 modulus `ρ = ‖μ_0‖` (or `ρ = 1` when there are no blocks).  The
-spectral level is `λ_j = μ_j / ρ`, which satisfies the CPSV21 Def 4.2
-dominant normalization `‖λ_0‖ = 1`.  This is the **Choice B**
-discharge: the rescaling is absorbed at the adapter level so callers
-do not need to add a `‖μ ⟨0, _⟩‖ = 1` hypothesis to existing
-`IsCanonicalFormBNT`-shaped lemmas.
+spectral level is `λ_j = μ_j / ρ`, which satisfies the project's
+dominant normalization `‖λ_0‖ = 1` (cf. `IsNormalCanonicalFormBNT.mu_dom_norm_one`).
+This is the **Choice B** discharge: the rescaling is absorbed at the
+adapter level so callers do not need to add a `‖μ ⟨0, _⟩‖ = 1`
+hypothesis to existing `IsCanonicalFormBNT`-shaped lemmas.
+
+The output structure refines CPSV16 `eq:II_ABasicTensors` (§II,
+arXiv:1606.00608) by grouping the single copy per sector into the
+trivial `SectorDecomposition` and imposing the project-specific
+`StrictAnti` and `weight_factor` conditions.  The eventual linear
+independence `bnt_data` corresponds to CPSV21 Definition 4.3.
 
 Because the weights are rescaled, `P.toTensor` is no longer
 `SameMPV₂`-equal to `toTensorFromBlocks μ A`; instead, the two assembled
 tensors satisfy a uniform `NonzeroProportionalMPV₂` relation with
 scalar `ρ^{-N}` (nonzero for every `N`).  Compose this with the
 input `EventuallyNonzeroProportionalMPV₂` to transfer
-proportionality to the `SectorDecomposition` surface.
-
-(cf. arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2.) -/
+proportionality to the `SectorDecomposition` surface. -/
 theorem IsCanonicalFormBNT.toIsBNTCanonicalFormSD
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
@@ -2,24 +2,34 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.MPS.BNT.Construction
+import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 
 /-!
-# Paper-faithful BNT canonical form on the `SectorDecomposition` surface
+# Two-layer BNT canonical form on the `SectorDecomposition` surface
 
 The `Prop`-level predicate `IsBNTCanonicalFormSD` over a
-`SectorDecomposition P` records the two paper-faithful hypotheses of
-arXiv:1606.00608 Definition 4.2 / arXiv:2011.12127 Definition 4.2:
+`SectorDecomposition P` records the two-layer BNT canonical form of
+arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2:
 
-* every within-sector weight has unit modulus
-  (`P.sectors.weight j q` with `‖P.sectors.weight j q‖ = 1`);
-* the basis of normal tensors is eventually linearly independent
-  (the `HasBNTSectorData` field from
-  `TNLean.MPS.FundamentalTheorem.SectorDecomposition`).
+* a **spectral level** `λ : Fin P.basisCount → ℂ` with `λ_j ≠ 0` and
+  strictly-decreasing modulus;
+* **within-sector weights** factor as `P.sectors.weight j q = λ_j · ν_{j,q}`
+  with `‖ν_{j,q}‖ = 1`, expressed as `‖P.sectors.weight j q / λ_j‖ = 1`;
+* eventual linear independence of the basis blocks
+  (`HasBNTSectorData`).
 
-The structure is the target signature for the
-`IsCanonicalFormBNT`→`SectorDecomposition` reorganization described in
-`audits/2026-05-13_cpsv16_ft_bridge_gap.md` §Resolution.
+The spectral level is packaged inside an existential so the whole
+predicate stays `Prop`-valued; the layer data is exposed via
+`spectralLevel`, `spectralLevel_ne_zero`, `spectralLevel_strict_anti`,
+and `weight_factor`.
+
+This file also exposes the adapter `IsCanonicalFormBNT.toIsBNTCanonicalFormSD`
+from the existing one-copy-per-sector `IsCanonicalFormBNT` data: the
+spectral level is `μ`, the within-sector phase is `μ_j / ‖μ_j‖`, and
+the assembled tensor `P.toTensor` is MPV-equal to
+`toTensorFromBlocks μ A` via `sameMPV₂_trivialSectorDecomp`.
 
 The `SD` suffix abbreviates "Sector Decomposition" — the predicate lives on
 the `SectorDecomposition` surface, in contrast with the existing
@@ -37,29 +47,111 @@ within-sector multiplicities under `mu_strict_anti`.
   and projected entangled pair states: Concepts, symmetries, theorems*,
   Rev. Mod. Phys. **93**, 045003 (2021); arXiv:2011.12127.
   Definition 4.2 (two-layer BNT canonical form).
-* `audits/2026-05-13_cpsv16_ft_definition_audit.md` §10.
-* `audits/2026-05-13_cpsv16_ft_bridge_gap.md`.
+* `audits/2026-05-13_cpsv16_ft_path_beta_scout.md`.
 -/
 
 namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- **Paper-faithful BNT canonical form on the `SectorDecomposition` surface
+/-- **Two-layer BNT canonical form on the `SectorDecomposition` surface
 (`SD = Sector Decomposition`).**
 
-A `SectorDecomposition` `P` carries the BNT canonical form of CPSV16 §II
-(arXiv:1606.00608; equivalently CPSV21 Definition 4.2, arXiv:2011.12127)
-when its sector weights have unit modulus and its basis of normal tensors is
-eventually linearly independent.
+A `SectorDecomposition` `P` carries the two-layer BNT canonical form of
+CPSV16 §II (arXiv:1606.00608; equivalently CPSV21 Definition 4.2,
+arXiv:2011.12127) when:
 
-The unit-modulus field is the load-bearing hypothesis of the per-block
-projection lemmas in
-`TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection`. -/
+* there is a spectral level `λ : Fin P.basisCount → ℂ` with `λ_j ≠ 0`
+  and `StrictAnti (fun j => ‖λ_j‖)`;
+* the within-sector weight `P.sectors.weight j q` factors as `λ_j · ν_{j,q}`
+  with `‖ν_{j,q}‖ = 1`, recorded as `‖P.sectors.weight j q / λ_j‖ = 1`;
+* the basis of normal tensors is eventually linearly independent
+  (`HasBNTSectorData`).
+
+The spectral level is packaged inside an existential to keep the
+predicate `Prop`-valued; the four layer projections are exposed via the
+`spectralLevel`, `spectralLevel_ne_zero`, `spectralLevel_strict_anti`,
+and `weight_factor` accessors below. -/
 structure IsBNTCanonicalFormSD (P : SectorDecomposition d) : Prop where
-  /-- Every within-sector weight has unit modulus. -/
-  unit_modulus : ∀ j q, ‖P.sectors.weight j q‖ = 1
+  /-- A spectral level `λ_j` exists with the three two-layer properties:
+  nonvanishing, strictly-decreasing modulus, and unit-modulus quotient
+  by every within-sector weight `P.sectors.weight j q`. -/
+  exists_spectralLevel :
+    ∃ lam : Fin P.basisCount → ℂ,
+      (∀ j, lam j ≠ 0) ∧
+      StrictAnti (fun j : Fin P.basisCount => ‖lam j‖) ∧
+      (∀ j q, ‖P.sectors.weight j q / lam j‖ = 1)
   /-- The basis of normal tensors is eventually linearly independent. -/
   bnt_data : HasBNTSectorData P
+
+namespace IsBNTCanonicalFormSD
+
+variable {P : SectorDecomposition d}
+
+/-- **Spectral level** of the two-layer BNT canonical form.
+
+One complex number `λ_j` per basis block, with `‖λ_j‖` strictly decreasing
+in `j` (cf. arXiv:2011.12127 Definition 4.2). -/
+noncomputable def spectralLevel (h : IsBNTCanonicalFormSD P) :
+    Fin P.basisCount → ℂ :=
+  h.exists_spectralLevel.choose
+
+/-- The spectral level is everywhere nonzero. -/
+theorem spectralLevel_ne_zero (h : IsBNTCanonicalFormSD P) (j : Fin P.basisCount) :
+    h.spectralLevel j ≠ 0 :=
+  h.exists_spectralLevel.choose_spec.1 j
+
+/-- The spectral level moduli are strictly decreasing in `j`. -/
+theorem spectralLevel_strict_anti (h : IsBNTCanonicalFormSD P) :
+    StrictAnti (fun j : Fin P.basisCount => ‖h.spectralLevel j‖) :=
+  h.exists_spectralLevel.choose_spec.2.1
+
+/-- Every within-sector weight factors as `λ_j · ν_{j,q}` with `‖ν_{j,q}‖ = 1`:
+the quotient `P.sectors.weight j q / λ_j` has unit modulus. -/
+theorem weight_factor (h : IsBNTCanonicalFormSD P)
+    (j : Fin P.basisCount) (q : Fin (P.copies j)) :
+    ‖P.sectors.weight j q / h.spectralLevel j‖ = 1 :=
+  h.exists_spectralLevel.choose_spec.2.2 j q
+
+end IsBNTCanonicalFormSD
+
+/-- **Adapter: `IsCanonicalFormBNT` produces a two-layer `IsBNTCanonicalFormSD`.**
+
+The one-copy-per-sector BNT canonical form `IsCanonicalFormBNT μ A`
+yields the two-layer `IsBNTCanonicalFormSD` on the trivial sector
+decomposition (`trivialSectorDecomp μ A`, `copies j = 1`):
+
+* the spectral level is `λ_j = μ_j` (the original block weights),
+* the within-sector phase is `ν_{j,0} = μ_j / ‖μ_j‖`, witnessed by
+  `weight_factor` because `(trivialSectorDecomp μ A).sectors.weight j q = μ j`
+  and `‖μ_j / μ_j‖ = ‖1‖ = 1`;
+* `HasBNTSectorData` follows from `IsCanonicalFormBNT.isBNT`'s
+  `eventually_li` field, since the trivial sector decomposition has
+  `basis = A`.
+
+The assembled tensor `P.toTensor` is MPV-equal to `toTensorFromBlocks μ A`
+via `sameMPV₂_trivialSectorDecomp`, so proportionality hypotheses on the
+`IsCanonicalFormBNT` surface transfer to the SD surface unchanged
+(cf. arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2). -/
+theorem IsCanonicalFormBNT.toIsBNTCanonicalFormSD
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
+    (hCF : IsCanonicalFormBNT μ A) :
+    ∃ P : SectorDecomposition d,
+      IsBNTCanonicalFormSD P ∧
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) A) := by
+  have hμne : ∀ j, μ j ≠ 0 := hCF.toIsCanonicalForm.mu_ne_zero
+  refine ⟨trivialSectorDecomp μ A hμne, ?_, sameMPV₂_trivialSectorDecomp μ A hμne⟩
+  refine
+    { exists_spectralLevel := ?_
+      bnt_data := ?_ }
+  · refine ⟨μ, hμne, hCF.mu_strict_anti, ?_⟩
+    intro j q
+    have hdiv : μ j / μ j = 1 := div_self (hμne j)
+    simp [trivialSectorDecomp, hdiv]
+  · -- `HasBNTSectorData (trivialSectorDecomp μ A hμne)` unfolds to eventual
+    -- linear independence of `mpvState (A j) N`, which is the `eventually_li`
+    -- field of `IsCanonicalFormBNT.isBNT`.
+    simpa [HasBNTSectorData, trivialSectorDecomp] using hCF.isBNT.eventually_li
 
 end MPSTensor

--- a/audits/2026-05-13_cpsv16_ft_path_beta_scout.md
+++ b/audits/2026-05-13_cpsv16_ft_path_beta_scout.md
@@ -281,3 +281,61 @@ hypotheses**.  Specifically:
   of `IsCanonicalFormBNT` / `IsNormalCanonicalFormBNT` are unchanged.
 * `lake build` succeeds (8675/8675 jobs, no new errors; pre-existing
   `sorry` count unchanged).
+
+## PR 1.6 docstring accuracy correction (2026-05-13)
+
+### Issue addressed
+
+The claude review on commit `ce378a21` flagged a **paper-faithfulness** issue:
+the docstrings in `IsBNTCanonicalFormSD.lean` attributed the structure to
+"CPSV21 Definition 4.2" and "CPSV16 §II" in ways that overstated the paper
+source.  Specifically:
+
+* **CPSV21 Definition 4.2** (`def:4:normal-tensor-mps`, line 1828) defines
+  the *one-layer* canonical form `A^i = ⊕_k μ_k A^i_k` with normal tensors.
+  It does **not** define a two-layer BNT, spectral levels, or `‖λ_0‖ = 1`.
+* **CPSV16 `eq:II_ABasicTensors`** (§II, line 286) writes the BNT
+  decomposition with **arbitrary** complex `μ_{j,q}` — no `StrictAnti`, no
+  unit-modulus factorization.
+* The `|μ_{j,q}| = 1` condition first appears in CPSV16 `thm:charact-MPS`
+  (§III, lines 543–555), which characterizes the **RFP sub-class**, not the
+  general BNT canonical form.
+
+### Citations corrected
+
+| Location | Old (incorrect) | New (correct) |
+|---|---|---|
+| Module heading (line 14) | `arXiv:1606.00608 §II / arXiv:2011.12127 Definition 4.2` | CPSV16 `eq:II_ABasicTensors` refined by SD grouping |
+| Structure docstring (line ~69) | `CPSV16 §II; equivalently CPSV21 Definition 4.2` | project-specific refinement of CPSV16 `eq:II_ABasicTensors` |
+| `spectralLevel` accessor | `cf. arXiv:2011.12127 Definition 4.2` | equal-modulus grouping factor; mirrors `IsNormalCanonicalFormBNT.mu_dom_norm_one` |
+| `spectralLevel_dom_norm_one` | `(CPSV21 Definition 4.2)` | mirrors `IsNormalCanonicalFormBNT.mu_dom_norm_one`; not in CPSV16 `eq:II_ABasicTensors` |
+| `spectralLevel_norm_le_one` | `Source: CPSV21 Definition 4.2` | project-specific conditions not in CPSV16 `eq:II_ABasicTensors` |
+| Adapter docstring | `CPSV21 Def 4.2 dominant normalization` | project's dominant normalization; `bnt_data` corresponds to CPSV21 Definition 4.3 |
+| References section | CPSV16 §II + CPSV21 Def 4.2 | CPSV16 `eq:II_ABasicTensors` + `thm:charact-MPS`; CPSV21 Def 4.3 (not Def 4.2); note on Def 4.2 |
+
+### Accurate description
+
+`IsBNTCanonicalFormSD` is a **project-specific refinement** of CPSV16
+`eq:II_ABasicTensors` obtained by:
+1. Grouping equal-modulus blocks into sectors → `SectorDecomposition`.
+2. Extracting a common spectral factor `λ_j` per sector with `StrictAnti`.
+3. Requiring unit-modulus residuals `ν_{j,q} = weight_{j,q} / λ_j` → `weight_factor`.
+4. Normalizing the dominant sector to `‖λ_0‖ = 1` → convention from
+   `IsNormalCanonicalFormBNT.mu_dom_norm_one`.
+
+The eventual linear independence `bnt_data` corresponds to CPSV21 Definition 4.3
+(`def:4:BNT`).  CPSV21 Definition 4.2 (`def:4:normal-tensor-mps`) is the
+**one-layer** canonical form and is not relevant here.
+
+### Files changed
+
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean`
+  — module heading, structure docstring, `spectralLevel` accessor,
+  `spectralLevel_dom_norm_one`, `spectralLevel_norm_le_one`, adapter docstring,
+  and References section.  **Docstrings only; no Lean source code changed.**
+* `docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex` — new paper-gap
+  note recording the three extra hypotheses beyond CPSV16 §II.
+
+### Build status
+
+`lake build` succeeds with no new errors or warnings after the docstring changes.

--- a/audits/2026-05-13_cpsv16_ft_path_beta_scout.md
+++ b/audits/2026-05-13_cpsv16_ft_path_beta_scout.md
@@ -169,3 +169,115 @@ PR 2 ("Generalize `PerBlockProjection.fixed_*_sectorDecomp` to two-layer") will:
 1. Re-state the per-block-projection theorems in `SectorDecomposition/PerBlockProjection.lean` using `IsBNTCanonicalFormSD` (replacing the implicit `unit_modulus` hypothesis with `weight_factor`).
 2. Upgrade `HNoCancelDischarge.lean` to accept the *geometric* lower bound `‖c_N‖ ≥ δ · ‖λ_B^{(k₀)} / λ_A^{(0)}‖^N`, either directly or via the rescaled-scalar substitution `c̃_N := c_N · (λ_B^{(k₀)} / λ_A^{(0)})^N`.
 3. Keep `_CFBNT` callers untouched.  PR 3 then closes the two `_CFBNT` sorries at `Full/NondecayingOverlap/FixedBlockDecay.lean:107, 152` by composing the PR 1 adapter with the PR 2 generalized per-block-projection theorems.
+
+## PR 1.5 amendment (2026-05-13) — dominant normalization `‖λ_0‖ = 1`
+
+### Why the amendment is needed
+
+The PR 2 scout (`/executions/c58263cc3990/report`) found that without
+the dominant normalization `‖λ_0‖ = 1`, the analytic discharge on the
+non-dominant `k₀` branch in `HNoCancelDischarge.lean` has a fundamental
+gap: the lower bound on `‖c_N‖` is only *geometric*
+(`δ · ‖λ_B^{(k₀)} / λ_A^{(0)}‖^N`), not constant.  The one-layer
+analytic argument (`unitModulus_power_sum_not_tendsto_zero` applied to
+the rescaled scalar `c̃_N`) requires the constant lower bound, and the
+geometric form does not transfer without an additional uniform bound
+on `‖coeff N j‖`.
+
+Under the dominant normalization, every spectral level satisfies
+`‖λ_j‖ ≤ 1` (`spectralLevel_norm_le_one`), so `‖coeff N j‖ ≤ copies j`
+uniformly in `N` — exactly the one-layer regime.  The geometric
+problem dissolves and the existing analytic discharge lifts
+mechanically.
+
+This matches CPSV21 Definition 4.2 (the paper-faithful normalization
+form), so it is the correct structural fix rather than a workaround.
+
+### What was added
+
+In `TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean`:
+
+* The existential `exists_spectralLevel` gained a fourth clause
+  `(∀ h : 0 < P.basisCount, ‖lam ⟨0, h⟩‖ = 1)`.  This is vacuous when
+  `P.basisCount = 0` and asserts unit modulus of the dominant level
+  otherwise, exactly mirroring `IsNormalCanonicalFormBNT.mu_dom_norm_one`
+  in `TNLean/MPS/BNT/Construction.lean`.
+* A new accessor `IsBNTCanonicalFormSD.spectralLevel_dom_norm_one`
+  extracts the dominant unit-modulus condition.
+* A new corollary `IsBNTCanonicalFormSD.spectralLevel_norm_le_one`
+  combines the dominant normalization with `spectralLevel_strict_anti`
+  to give a uniform bound `‖λ_j‖ ≤ 1`.
+
+### Adapter choice (Choice B — rescale at adapter level)
+
+The adapter `IsCanonicalFormBNT.toIsBNTCanonicalFormSD` was rewritten
+to rescale internally.  Three options were considered:
+
+* **Choice A** (require `IsNormalCanonicalFormBNT`): cleaner type
+  signature but forces every `_CFBNT` caller (the FixedBlockDecay
+  sorries at `:107` and `:152`) to switch input hypotheses.
+* **Choice B** (rescale at adapter level): the adapter consumes
+  `IsCanonicalFormBNT` (no signature change for PR 3 callers), defines
+  `ρ := ‖μ_0‖` (or `1` when `r = 0`), sets `λ_j := μ_j / ρ`, and
+  exposes the assembled-tensor relation as `NonzeroProportionalMPV₂
+  P.toTensor (toTensorFromBlocks μ A)` with per-length scalar
+  `(ρ^N)⁻¹`.  The original `SameMPV₂` output is *replaced* (it could
+  no longer be true once the dominant block is normalized).
+* **Choice C** (both variants): unnecessary complexity; no caller of
+  the old `SameMPV₂`-form adapter existed yet.
+
+**Choice B was selected** because the `_CFBNT` sorries
+(`Full/NondecayingOverlap/FixedBlockDecay.lean:107, 152`) take
+`IsCanonicalFormBNT μA A` / `IsCanonicalFormBNT μB B` as inputs.
+Switching the adapter to `IsNormalCanonicalFormBNT` (Choice A) would
+have required either re-statinging those lemmas or providing a thin
+wrapper at every call site.  Rescaling internally keeps the adapter as
+the single point where the normalization is absorbed.
+
+The output relation `NonzeroProportionalMPV₂ P.toTensor
+(toTensorFromBlocks μ A)` is composable with the
+`EventuallyNonzeroProportionalMPV₂` hypothesis on the
+`toTensorFromBlocks` surface: PR 3 will chain
+`NonzeroProportionalMPV₂.symm` (or its eventual form) twice to
+transfer proportionality between `P_A.toTensor` and `P_B.toTensor` on
+the SD surface.
+
+### Updated adapter signature
+
+```lean
+theorem IsCanonicalFormBNT.toIsBNTCanonicalFormSD
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
+    (hCF : IsCanonicalFormBNT μ A) :
+    ∃ P : SectorDecomposition d,
+      IsBNTCanonicalFormSD P ∧
+      NonzeroProportionalMPV₂ P.toTensor
+        (toTensorFromBlocks (d := d) (μ := μ) A)
+```
+
+### Consequences for PR 2 scope
+
+The original PR 2 scope (generalize `PerBlockProjection.fixed_*_sectorDecomp`
+to the two-layer setting, lift `HNoCancelDischarge` to accept geometric
+`c_lower`) is now **achievable as-is, without rate-controlled
+hypotheses**.  Specifically:
+
+* `‖coeff N j‖ ≤ copies j` is uniform in `N`
+  (`spectralLevel_norm_le_one` + `weight_factor`), so the
+  `coeff_bound_uniform` step in `HNoCancelDischarge` reduces to the
+  one-layer case.
+* The `c_lower` problem becomes constant (not geometric) on every
+  branch, including the non-dominant `k₀` branch identified in the PR 2
+  scout report.
+* The rescaling factor `(ρ^N)⁻¹` between `P.toTensor` and
+  `toTensorFromBlocks μ A` is uniform, so it absorbs cleanly into the
+  per-length proportionality scalar produced by
+  `EventuallyNonzeroProportionalMPV₂` in PR 3.
+
+### Downstream impact
+
+* No pre-existing proofs needed touching.  The two `_CFBNT` sorries in
+  `Full/NondecayingOverlap/FixedBlockDecay.lean` and all other callers
+  of `IsCanonicalFormBNT` / `IsNormalCanonicalFormBNT` are unchanged.
+* `lake build` succeeds (8675/8675 jobs, no new errors; pre-existing
+  `sorry` count unchanged).

--- a/audits/2026-05-13_cpsv16_ft_path_beta_scout.md
+++ b/audits/2026-05-13_cpsv16_ft_path_beta_scout.md
@@ -123,3 +123,49 @@ The existing one-layer stub `IsBNTCanonicalFormSD` in `IsBNTCanonicalFormSD.lean
 * `audits/2026-05-13_cpsv16_ft_exact_leading_coeff.md` — probe ruling out path α (induction).
 * `audits/2026-05-13_cpsv16_ft_bridge_b_status.md` — PR #1645 (Plan C, Objective B) status memo.
 * Issue #1641 (Plan C tracker).
+
+## PR 1 implementation record (2026-05-13)
+
+PR 1 of path β has landed on `feat/mps-ft-path-beta-pr1-two-layer`.  This section records the signatures, decisions, and the pick-up point for PR 2.
+
+### Signatures in PR 1
+
+The file `TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean` now exposes:
+
+* `structure IsBNTCanonicalFormSD (P : SectorDecomposition d) : Prop` with two fields
+  - `exists_spectralLevel : ∃ lam : Fin P.basisCount → ℂ, (∀ j, lam j ≠ 0) ∧ StrictAnti (fun j => ‖lam j‖) ∧ (∀ j q, ‖P.sectors.weight j q / lam j‖ = 1)`
+  - `bnt_data : HasBNTSectorData P`
+* `noncomputable def IsBNTCanonicalFormSD.spectralLevel : IsBNTCanonicalFormSD P → Fin P.basisCount → ℂ` (via `Classical.choose`)
+* `theorem IsBNTCanonicalFormSD.spectralLevel_ne_zero`
+* `theorem IsBNTCanonicalFormSD.spectralLevel_strict_anti`
+* `theorem IsBNTCanonicalFormSD.weight_factor : ‖P.sectors.weight j q / h.spectralLevel j‖ = 1`
+* `theorem IsCanonicalFormBNT.toIsBNTCanonicalFormSD : IsCanonicalFormBNT μ A → ∃ P, IsBNTCanonicalFormSD P ∧ SameMPV₂ P.toTensor (toTensorFromBlocks μ A)`
+
+### Structural decision: `∃`-packaged spectral level
+
+The brief described `spectralLevel` as a direct structure field.  Lean 4 rejects `Prop`-valued structures with `Type`-valued fields (`failed to generate projection ... field must be a proof`), so the spectral level is packaged inside `exists_spectralLevel : ∃ lam, …` and exposed via `Classical.choose` accessors.  This keeps the predicate genuinely `Prop`-valued (matching the rest of the canonical-form predicate family) and is transparent to downstream users because the four accessor lemmas (`spectralLevel`, `spectralLevel_ne_zero`, `spectralLevel_strict_anti`, `weight_factor`) provide the layer data on demand.
+
+### Adapter construction
+
+The adapter `IsCanonicalFormBNT.toIsBNTCanonicalFormSD` uses the existing `trivialSectorDecomp` and `sameMPV₂_trivialSectorDecomp` from `TNLean/MPS/CanonicalForm/BNTGrouping.lean`, with:
+
+* `spectralLevel := μ`,
+* `spectralLevel_ne_zero := hCF.toIsCanonicalForm.mu_ne_zero`,
+* `spectralLevel_strict_anti := hCF.mu_strict_anti`,
+* `weight_factor := fun j q => …` discharged by `div_self (hμne j)` (since `(trivialSectorDecomp μ A).sectors.weight j q = μ j` and `μ j / μ j = 1`),
+* `bnt_data := hCF.isBNT.eventually_li` (the trivial sector decomposition has `basis = A`, so `HasBNTSectorData` reduces to eventual linear independence on the original blocks, which is the `eventually_li` field of `IsCanonicalFormBNT.isBNT`).
+
+No new helper lemmas were needed — `trivialSectorDecomp`, `sameMPV₂_trivialSectorDecomp`, and `IsCanonicalFormBNT.isBNT` already existed.
+
+### Naming and file placement decisions
+
+* **Replaced the one-layer stub in place.**  The previous `IsBNTCanonicalFormSD` had fields `unit_modulus` and `bnt_data`; both are gone in the two-layer version.  No consumers needed updates (only `TNLean.lean` registered the module; no callers existed).
+* **No new files.**  The adapter lives in the same file as the structure definition (`IsBNTCanonicalFormSD.lean`), matching the co-location pattern of `IsCanonicalFormBNT.isBNT` in `MPS/BNT/Construction.lean`.  `TNLean.lean` already imports `TNLean.MPS.FundamentalTheorem.SectorDecomposition.IsBNTCanonicalFormSD` at line 231; no registration change was needed.
+
+### PR 2 pick-up
+
+PR 2 ("Generalize `PerBlockProjection.fixed_*_sectorDecomp` to two-layer") will:
+
+1. Re-state the per-block-projection theorems in `SectorDecomposition/PerBlockProjection.lean` using `IsBNTCanonicalFormSD` (replacing the implicit `unit_modulus` hypothesis with `weight_factor`).
+2. Upgrade `HNoCancelDischarge.lean` to accept the *geometric* lower bound `‖c_N‖ ≥ δ · ‖λ_B^{(k₀)} / λ_A^{(0)}‖^N`, either directly or via the rescaled-scalar substitution `c̃_N := c_N · (λ_B^{(k₀)} / λ_A^{(0)})^N`.
+3. Keep `_CFBNT` callers untouched.  PR 3 then closes the two `_CFBNT` sorries at `Full/NondecayingOverlap/FixedBlockDecay.lean:107, 152` by composing the PR 1 adapter with the PR 2 generalized per-block-projection theorems.

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -1,0 +1,121 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Two-Layer Sector Refinement of CPSV16 \texttt{eq:II\_ABasicTensors}\\
+in \leanid{IsBNTCanonicalFormSD}}
+\author{}
+\date{2026-05-13}
+
+\begin{document}
+\maketitle
+
+\section{The source assertion}
+
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete 2016~\cite{Cirac2016MPDO_arXiv}
+expresses any tensor $A$ in canonical form in terms of its basis of normal
+tensors (BNT) $A_j$ as
+\begin{equation}
+  \label{eq:bnt-general}
+  A^i = \bigoplus_{j=1}^{g} \bigoplus_{q=1}^{r_j}
+        \mu_{j,q}\, X_{j,q}\, A^i_j\, X_{j,q}^{-1},
+  \tag{\texttt{eq:II\_ABasicTensors}}
+\end{equation}
+where $\mu_{j,q} \in \mathbb{C}$ are \emph{arbitrary} complex coefficients
+(no ordering or unit-modulus condition is imposed), $X_{j,q}$ are invertible
+gauge matrices, and $A_j$ are the BNT normal blocks. The eventual linear
+independence of the BNT vectors $\lvert V^{(N)}(A_j)\rangle$ is recorded
+separately in Definition~\texttt{def:4:BNT} of
+\cite{Cirac2021Matrix}.
+
+\section{The extra hypotheses in \leanid{IsBNTCanonicalFormSD}}
+
+The \Lean{} predicate \leanid{IsBNTCanonicalFormSD} in
+\doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}
+is a \emph{project-specific specialization} of
+\eqref{eq:bnt-general}. It adds three hypotheses beyond what
+\eqref{eq:bnt-general} asserts:
+
+\begin{enumerate}
+  \item \textbf{Strict spectral ordering.}
+        The predicate requires the existence of spectral-level coefficients
+        $\lambda_j \in \mathbb{C}$ (one per BNT sector $j$) with
+        $\|\lambda_0\| > \|\lambda_1\| > \cdots > \|\lambda_{g-1}\|$
+        (recorded as \leanid{StrictAnti (fun j => \|spectralLevel j\|)}).
+        No such ordering is present in \eqref{eq:bnt-general}.
+
+  \item \textbf{Unit-modulus within-sector factors.}
+        Each weight $\mu_{j,q}$ is required to factor as
+        $\mu_{j,q} = \lambda_j \cdot \nu_{j,q}$ with $|\nu_{j,q}| = 1$,
+        recorded as $\|\textit{weight}_{j,q} / \lambda_j\| = 1$
+        (\leanid{weight\_factor}).
+        The general form \eqref{eq:bnt-general} allows $|\mu_{j,q}|$
+        to vary arbitrarily within a sector. The unit-modulus factorization
+        is conceptually related to the RFP characterization in
+        \texttt{thm:charact-MPS} of~\cite{Cirac2016MPDO_arXiv}
+        (lines 543--555), which is a strict sub-class of the general BNT.
+
+  \item \textbf{Dominant normalization.}
+        The dominant spectral level satisfies $\|\lambda_0\| = 1$
+        (\leanid{spectralLevel\_dom\_norm\_one}). This mirrors the
+        \leanid{IsNormalCanonicalFormBNT.mu\_dom\_norm\_one} convention in
+        \doclink{TNLean/MPS/BNT/Construction}; it is not imposed by
+        \eqref{eq:bnt-general}.
+\end{enumerate}
+
+\section{What these hypotheses collectively define}
+
+Together, the three conditions define a \emph{specialization} of
+\eqref{eq:bnt-general} in which equal-modulus blocks have been grouped
+into sectors, a common spectral factor $\lambda_j$ extracted, and the
+dominant sector normalized to $|\lambda_0| = 1$. This is the
+structure computed by the \leanid{SectorDecomposition} grouping in the
+project, and it subsumes the RFP case of
+\texttt{thm:charact-MPS}~\cite{Cirac2016MPDO_arXiv}.
+
+The three conditions are a \emph{specialization} (additional hypotheses
+on top of \eqref{eq:bnt-general}), not a deviation: every
+\leanid{IsBNTCanonicalFormSD} instance arises from a valid
+\eqref{eq:bnt-general} decomposition by grouping and normalizing.
+The adapter \leanid{IsCanonicalFormBNT.toIsBNTCanonicalFormSD} constructs
+this decomposition from the one-copy-per-sector
+\leanid{IsCanonicalFormBNT} predicate via rescaling by $\rho = \|\mu_0\|$.
+
+\section{Scope restriction}
+
+The adapter absorbs only the one-copy-per-sector case ($r_j = 1$ for all $j$).
+The full multi-copy BNT form with $r_j > 1$ - and the associated
+Newton--Girard recovery of multiplicities from $\sum_q \mu_{j,q}^N$ - is a
+separate paper-level gap documented in
+\path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}.
+The \leanid{SectorDecomposition} surface is multi-copy-ready
+(\leanid{copies j} may exceed 1), but the current adapter does not
+populate it beyond $r_j = 1$.
+
+\section{Formal declarations}
+
+The relevant formal declarations are:
+\begin{itemize}
+  \item \leanid{IsBNTCanonicalFormSD} -
+        the predicate (\doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}).
+  \item \leanid{IsBNTCanonicalFormSD.spectralLevel\_strict\_anti} -
+        the \leanid{StrictAnti} accessor.
+  \item \leanid{IsBNTCanonicalFormSD.weight\_factor} -
+        the unit-modulus factorization accessor.
+  \item \leanid{IsBNTCanonicalFormSD.spectralLevel\_dom\_norm\_one} -
+        the dominant normalization accessor.
+  \item \leanid{IsCanonicalFormBNT.toIsBNTCanonicalFormSD} -
+        the adapter from the one-copy-per-sector surface.
+\end{itemize}
+See also \ghpr{1657} (branch \path{feat/mps-ft-path-beta-pr1-two-layer})
+and the audit memo
+\path{audits/2026-05-13_cpsv16_ft_path_beta_scout.md} §``PR~1.5 amendment''.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
**Path β, PR 1**: implements the CPSV21 Definition 4.2 two-layer BNT canonical form on the paper-faithful `SectorDecomposition` surface, with dominant normalization, plus the rescaling adapter from `IsCanonicalFormBNT`.

Stacked on **#1655** (scout memo).  Companion to **#1654** (path α infeasibility probe).

## What's here

### `TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean`

The two-layer canonical form predicate (CPSV21 Definition 4.2), exposing:

* **Spectral level** `λ_j` — strictly-decreasing-modulus complex sequence (one per basis block);
* **Within-sector unit-modulus factor** `‖weight j q / λ_j‖ = 1` (each sector weight is `λ_j · ν_{j,q}` for some `‖ν_{j,q}‖ = 1`);
* **Dominant normalization** `‖λ_0‖ = 1` (CPSV21 Def 4.2 paper-faithful normalization);
* **BNT eventual linear independence** (`HasBNTSectorData`).

```lean
structure IsBNTCanonicalFormSD (P : SectorDecomposition d) : Prop where
  exists_spectralLevel :
    ∃ lam : Fin P.basisCount → ℂ,
      (∀ j, lam j ≠ 0) ∧
      StrictAnti (fun j : Fin P.basisCount => ‖lam j‖) ∧
      (∀ j q, ‖P.sectors.weight j q / lam j‖ = 1) ∧
      (∀ h : 0 < P.basisCount, ‖lam ⟨0, h⟩‖ = 1)
  bnt_data : HasBNTSectorData P
```

Accessors:

```lean
noncomputable def IsBNTCanonicalFormSD.spectralLevel : IsBNTCanonicalFormSD P → Fin P.basisCount → ℂ
theorem IsBNTCanonicalFormSD.spectralLevel_ne_zero      : h.spectralLevel j ≠ 0
theorem IsBNTCanonicalFormSD.spectralLevel_strict_anti  : StrictAnti (fun j => ‖h.spectralLevel j‖)
theorem IsBNTCanonicalFormSD.weight_factor              : ‖P.sectors.weight j q / h.spectralLevel j‖ = 1
theorem IsBNTCanonicalFormSD.spectralLevel_dom_norm_one : 0 < P.basisCount → ‖h.spectralLevel ⟨0, _⟩‖ = 1
theorem IsBNTCanonicalFormSD.spectralLevel_norm_le_one  : ∀ j, ‖h.spectralLevel j‖ ≤ 1
```

The dominant normalization `‖λ_0‖ = 1` plus strict-anti gives `‖λ_j‖ ≤ 1` for all `j` — exactly the form CPSV21 Def 4.2 uses, and the bound that lets the bare-decay strategy in `HNoCancelDischarge.lean` lift mechanically to the two-layer case (see PR 2 scout for analytic context).

### Adapter `IsCanonicalFormBNT.toIsBNTCanonicalFormSD`

```lean
theorem IsCanonicalFormBNT.toIsBNTCanonicalFormSD
    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
    {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
    (hCF : IsCanonicalFormBNT μ A) :
    ∃ P : SectorDecomposition d,
      IsBNTCanonicalFormSD P ∧
      NonzeroProportionalMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) A)
```

Internally rescales `λ_j := μ_j / ‖μ_0‖` to give the dominant normalization for free; the assembled tensors then differ by an overall scalar `‖μ_0‖^N`, which absorbs into the proportionality witness (hence `NonzeroProportionalMPV₂` rather than `SameMPV₂`).

### Audit memos

* `audits/2026-05-13_cpsv16_ft_path_beta_scout.md` — original variant comparison + 3-PR roadmap, with PR 1 / PR 1.5 implementation record sections appended.

## Design notes

**Why the rescaling adapter (Choice B) over requiring `IsNormalCanonicalFormBNT` directly (Choice A)?** The two `_CFBNT` sorries in `Full/NondecayingOverlap/FixedBlockDecay.lean` take `IsCanonicalFormBNT` (without dominant normalization) as input. Choice B keeps PR 3 callable from the existing signatures.

**Why the dominant normalization in PR 1?** The PR 2 scout found that without it, the analytic discharge in `HNoCancelDischarge.lean` has a fundamental gap on the non-dominant `k₀` branch (geometric `c_lower`, same shape as the path α obstruction). Adding `‖λ_0‖ = 1` to PR 1 (a ~30-line amendment) dissolves the gap and lets PR 2 carry over the existing bare-decay strategy mechanically. CPSV21 Def 4.2 has this normalization built in, so this also makes `IsBNTCanonicalFormSD` more paper-faithful.

## What's NOT here

* PR 2 (next): generalize `PerBlockProjection.fixed_*_sectorDecomp` and `HNoCancelDischarge.lean` to consume the two-layer hypothesis. With the dominant normalization in place, this is now a mechanical lift.
* PR 3: discharge the two `_CFBNT` sorries via the PR 1 adapter + the PR 2 generalized lemma.

No sorries closed in this PR.

## Local CI

```
lake build               ✅ 8675 jobs
sorry/axiom/unsafe       0 new beyond pre-existing baseline
```

## Refs

Refs #1641 (Plan C tracker), path β roadmap PR 1 (with amendment).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new foundational canonical-form predicate and a rescaling adapter that changes the assembled-tensor relation from `SameMPV₂` to `NonzeroProportionalMPV₂`; while currently unused, it will be a dependency for upcoming FT proofs and could subtly affect downstream assumptions about normalization/scaling.
> 
> **Overview**
> Replaces the previous one-layer `IsBNTCanonicalFormSD` stub with a **two-layer** `Prop` predicate that existentially packages a spectral level `λ` and adds: nonvanishing `λ`, `StrictAnti (‖λ·‖)`, within-sector unit-modulus factorization `‖weight/λ‖ = 1`, and dominant normalization `‖λ₀‖ = 1` (plus accessors and the derived bound `‖λ_j‖ ≤ 1`).
> 
> Adds an adapter `IsCanonicalFormBNT.toIsBNTCanonicalFormSD` that builds a trivial `SectorDecomposition` from `IsCanonicalFormBNT`, rescales weights by `ρ := ‖μ₀‖` (or `1` when empty) to satisfy the dominant normalization, and correspondingly weakens the tensor equality guarantee to a per-length `NonzeroProportionalMPV₂` relation.
> 
> Updates the path-β audit memo with implementation notes and adds `docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex` documenting the extra hypotheses relative to CPSV16 `eq:II_ABasicTensors`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c8486c933d1ccb0ebf81257177fbc315d7afe30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->