### PR TITLE
feat(MPS/FT): two-layer norm_coeff bounds + per-block projection skeleton (path β, PR 2)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean
@@ -51,6 +51,13 @@ per-block projection contradiction then closes as in
   — corollaries assembling the per-block-projection skeleton with the
   analytic discharge of the non-cancellation hypothesis.
 
+* `fixed_right_all_overlaps_decay_false_paperFaithful_twoLayer`
+  `fixed_left_all_overlaps_decay_false_paperFaithful_twoLayer`
+  — two-layer counterparts consuming `IsBNTCanonicalFormSD P` (resp.
+  `IsBNTCanonicalFormSD Q`).  The abstract `hNoCancel` is kept in the
+  signature: the analytic discharge of `hNoCancel` in the two-layer
+  setting is deferred (see audit memo for the analytic content).
+
 ## References
 
 * Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
@@ -417,6 +424,68 @@ theorem fixed_left_all_overlaps_decay_false_paperFaithful
     (hNoCancel_of_unitModulus_decay_c_norm_lower
       (P := Q) (Q := P) hP_unit j₀ hP_decay_offdiag hℓ_ne
       hP_self_limit hc_lower)
+
+set_option linter.style.longLine false in
+/-- **Two-layer right-block per-block projection contradiction.**
+
+Two-layer counterpart of `fixed_right_all_overlaps_decay_false_paperFaithful`
+on the `IsBNTCanonicalFormSD` surface.  The two-layer canonical-form
+hypothesis on `P` supplies the uniform coefficient bound
+`‖P.coeff N j‖ ≤ copies j` via
+`SectorDecomposition.norm_coeff_le_copies_of_IsBNTCanonicalFormSD`;
+the canonical-form hypothesis on `Q` is bundled in the signature for
+the eventual analytic discharge of `hNoCancel` (currently abstract).
+
+In contrast to `fixed_right_all_overlaps_decay_false_paperFaithful`,
+the analytic non-cancellation conclusion is **not** discharged here:
+the `hNoCancel` hypothesis is consumed in the same shape as in
+`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer`.
+The downstream analytic argument that produces `hNoCancel` for the
+non-dominant `k₀` branch on the `IsBNTCanonicalFormSD` surface lives
+outside this module. -/
+theorem fixed_right_all_overlaps_decay_false_paperFaithful_twoLayer
+    (P Q : SectorDecomposition d)
+    (hP : IsBNTCanonicalFormSD P)
+    (_hQ : IsBNTCanonicalFormSD Q)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (k₀ : Fin Q.basisCount)
+    (hAllDecay_PtoQ : ∀ j : Fin P.basisCount,
+        Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+          atTop (nhds 0))
+    (hNoCancel : ∀ c : ℕ → ℂ,
+        (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+          mpv P.toTensor σ = c N * mpv Q.toTensor σ) →
+        ¬ Tendsto
+            (fun N => c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+            atTop (nhds 0)) :
+    False :=
+  fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer
+    P Q hP hProp k₀ hAllDecay_PtoQ hNoCancel
+
+set_option linter.style.longLine false in
+/-- **Two-layer left-block per-block projection contradiction.**
+
+Symmetric counterpart of `fixed_right_all_overlaps_decay_false_paperFaithful_twoLayer`
+fixing a `P`-block `j₀` instead of a `Q`-block.  Reduces to the
+right-block two-layer version after swapping `P` and `Q`. -/
+theorem fixed_left_all_overlaps_decay_false_paperFaithful_twoLayer
+    (P Q : SectorDecomposition d)
+    (_hP : IsBNTCanonicalFormSD P)
+    (hQ : IsBNTCanonicalFormSD Q)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (j₀ : Fin P.basisCount)
+    (hAllDecay_QtoP : ∀ k : Fin Q.basisCount,
+        Tendsto (fun N => mpvOverlap (d := d) (P.basis j₀) (Q.basis k) N)
+          atTop (nhds 0))
+    (hNoCancel : ∀ c : ℕ → ℂ,
+        (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+          mpv Q.toTensor σ = c N * mpv P.toTensor σ) →
+        ¬ Tendsto
+            (fun N => c N * mpvOverlap (d := d) P.toTensor (P.basis j₀) N)
+            atTop (nhds 0)) :
+    False :=
+  fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer
+    P Q hQ hProp j₀ hAllDecay_QtoP hNoCancel
 
 end PerBlockProjectionContradiction
 

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.IsBNTCanonicalFormSD
 
 /-!
 # Paper Step 1 on the `SectorDecomposition` surface
@@ -22,6 +23,18 @@ This module re-states and proves Step 1 of arXiv:1606.00608, Theorem `thm1`
 * `EventuallyNonzeroProportionalMPV₂.symm` (in `TNLean.MPS.Defs`):
   `EventuallyNonzeroProportionalMPV₂` is symmetric in its two arguments;
   used (via dot notation `hProp.symm`) to reduce the left case to the right case.
+* `SectorDecomposition.norm_coeff_le_spectral_pow_mul_copies` and
+  `SectorDecomposition.norm_coeff_le_copies_of_IsBNTCanonicalFormSD`:
+  two-layer counterparts of `norm_coeff_le_copies`, giving a geometric
+  bound `‖coeff N j‖ ≤ ‖λ_j‖^N · copies j` and (under dominant
+  normalization) the uniform bound `‖coeff N j‖ ≤ copies j`.
+* The two-layer counterparts
+  `fixed_{right,left}_all_overlaps_decay_false_of`
+  `_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer`: they consume
+  `IsBNTCanonicalFormSD P` (resp. `IsBNTCanonicalFormSD Q`) in place of
+  the unit-modulus hypothesis on the per-sector weights.  The abstract
+  `hNoCancel` hypothesis is unchanged in shape; analytic discharge in
+  the two-layer setting is deferred to a downstream module.
 
 ## Scope and load-bearing hypothesis
 
@@ -82,6 +95,87 @@ lemma SectorDecomposition.norm_coeff_le_copies
       _ = (P.copies j : ℝ) := by
             simp
   exact hsum.le
+
+/-- **Geometric BNT coefficient bound on the two-layer surface.**
+
+For a two-layer BNT canonical form (`IsBNTCanonicalFormSD`), the spectral
+level `λ_j` extracted by `hP.spectralLevel` and the unit-modulus quotient
+`weight j q / λ_j` jointly give the geometric bound
+`‖coeff N j‖ ≤ ‖λ_j‖^N · copies j`.  This is the natural two-layer
+counterpart of `norm_coeff_le_copies`: each summand
+`(weight j q)^N` has norm `‖λ_j‖^N` (since `‖weight j q‖ = ‖λ_j‖` by
+the unit-modulus quotient), so the triangle inequality on the inner
+sum of `copies j` terms yields the stated bound.
+
+Combined with `IsBNTCanonicalFormSD.spectralLevel_norm_le_one` (dominant
+normalization + strict-anti gives `‖λ_j‖ ≤ 1`), this specialises to the
+uniform bound `‖coeff N j‖ ≤ copies j` in
+`norm_coeff_le_copies_of_IsBNTCanonicalFormSD`. -/
+lemma SectorDecomposition.norm_coeff_le_spectral_pow_mul_copies
+    (P : SectorDecomposition d) (hP : IsBNTCanonicalFormSD P)
+    (N : ℕ) (j : Fin P.basisCount) :
+    ‖P.coeff N j‖ ≤ ‖hP.spectralLevel j‖ ^ N * (P.copies j : ℝ) := by
+  classical
+  unfold SectorDecomposition.coeff SectorWeightData.coeff
+  refine (norm_sum_le _ _).trans ?_
+  -- `‖weight j q‖ = ‖λ j‖` from the unit-modulus quotient.
+  have hlam_ne : hP.spectralLevel j ≠ 0 := hP.spectralLevel_ne_zero j
+  have hlam_norm_ne : ‖hP.spectralLevel j‖ ≠ 0 := norm_ne_zero_iff.mpr hlam_ne
+  have hwnorm : ∀ q : Fin (P.copies j), ‖P.weight j q‖ = ‖hP.spectralLevel j‖ := by
+    intro q
+    have hquot : ‖P.sectors.weight j q / hP.spectralLevel j‖ = 1 :=
+      hP.weight_factor j q
+    rw [norm_div] at hquot
+    -- `‖weight‖ / ‖lam‖ = 1`, with `‖lam‖ ≠ 0` ⇒ `‖weight‖ = ‖lam‖`.
+    have := (div_eq_one_iff_eq hlam_norm_ne).mp hquot
+    -- `P.weight` is an `abbrev` for `P.sectors.weight`, so they are defeq.
+    change ‖P.sectors.weight j q‖ = ‖hP.spectralLevel j‖
+    exact this
+  have hterm : ∀ q : Fin (P.copies j),
+      ‖(P.weight j q) ^ N‖ = ‖hP.spectralLevel j‖ ^ N := by
+    intro q
+    rw [norm_pow, hwnorm q]
+  have hsum_eq : (∑ q : Fin (P.copies j), ‖(P.weight j q) ^ N‖)
+      = ‖hP.spectralLevel j‖ ^ N * (P.copies j : ℝ) := by
+    calc
+      (∑ q : Fin (P.copies j), ‖(P.weight j q) ^ N‖)
+          = ∑ _q : Fin (P.copies j), ‖hP.spectralLevel j‖ ^ N := by
+            refine Finset.sum_congr rfl ?_
+            intro q _
+            exact hterm q
+      _ = (P.copies j : ℝ) * ‖hP.spectralLevel j‖ ^ N := by
+            rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+                nsmul_eq_mul]
+      _ = ‖hP.spectralLevel j‖ ^ N * (P.copies j : ℝ) := by ring
+  exact hsum_eq.le
+
+/-- **Uniform BNT coefficient bound on the two-layer surface
+(dominant-normalized).**
+
+Specialization of `norm_coeff_le_spectral_pow_mul_copies` using the
+dominant normalization `‖λ_0‖ = 1` together with strict-anti
+(`IsBNTCanonicalFormSD.spectralLevel_norm_le_one`): every spectral
+level satisfies `‖λ_j‖ ≤ 1`, hence `‖λ_j‖^N ≤ 1`, and the geometric
+bound collapses to the uniform bound `‖coeff N j‖ ≤ copies j`.
+
+This matches the one-layer `norm_coeff_le_copies` conclusion and is
+exactly what the per-block projection argument consumes, allowing the
+two-layer `_sectorDecomp_twoLayer` lemmas to reuse the one-layer
+algebraic skeleton without change. -/
+lemma SectorDecomposition.norm_coeff_le_copies_of_IsBNTCanonicalFormSD
+    (P : SectorDecomposition d) (hP : IsBNTCanonicalFormSD P)
+    (N : ℕ) (j : Fin P.basisCount) :
+    ‖P.coeff N j‖ ≤ (P.copies j : ℝ) := by
+  refine (P.norm_coeff_le_spectral_pow_mul_copies hP N j).trans ?_
+  have hlam_le : ‖hP.spectralLevel j‖ ≤ 1 := hP.spectralLevel_norm_le_one j
+  have hlam_nn : 0 ≤ ‖hP.spectralLevel j‖ := norm_nonneg _
+  have hpow : ‖hP.spectralLevel j‖ ^ N ≤ 1 := pow_le_one₀ hlam_nn hlam_le
+  have hcopies_nn : 0 ≤ (P.copies j : ℝ) := Nat.cast_nonneg _
+  calc
+    ‖hP.spectralLevel j‖ ^ N * (P.copies j : ℝ)
+        ≤ 1 * (P.copies j : ℝ) :=
+          mul_le_mul_of_nonneg_right hpow hcopies_nn
+    _ = (P.copies j : ℝ) := one_mul _
 
 
 /-- **Per-block projection contradiction (fixed right block).**
@@ -244,6 +338,152 @@ lemma fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂
   refine
     fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp
       Q P hQ_unit hProp.symm j₀ ?_ hNoCancel
+  intro k
+  exact tendsto_mpvOverlap_zero_swap (d := d) (P.basis j₀) (Q.basis k)
+    (hAllDecay k)
+
+set_option linter.style.longLine false in
+/-- **Two-layer per-block projection contradiction (fixed right block).**
+
+Two-layer counterpart of
+`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp`
+consuming `IsBNTCanonicalFormSD P` in place of the unit-modulus
+hypothesis on the per-sector weights of `P`.  The two-layer surface
+gives the uniform coefficient bound `‖P.coeff N j‖ ≤ copies j` via
+`norm_coeff_le_copies_of_IsBNTCanonicalFormSD` (combining the unit-modulus
+quotient `‖weight j q / λ_j‖ = 1` with the dominant-normalised
+`‖λ_j‖ ≤ 1`), so the algebraic skeleton of the one-layer argument lifts
+without change.
+
+The abstract `hNoCancel` hypothesis retains the same shape as in the
+one-layer statement.  The two-layer analytic discharge of `hNoCancel`
+on the `SectorDecomposition` surface is not provided here; it is the
+subject of a separate downstream module on the
+`IsBNTCanonicalFormSD` surface. -/
+lemma fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer
+    (P Q : SectorDecomposition d)
+    (hP : IsBNTCanonicalFormSD P)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (k₀ : Fin Q.basisCount)
+    (hAllDecay : ∀ j : Fin P.basisCount,
+      Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+        atTop (nhds 0))
+    (hNoCancel : ∀ c : ℕ → ℂ,
+      (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+        mpv P.toTensor σ = c N * mpv Q.toTensor σ) →
+      ¬ Tendsto
+        (fun N => c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+        atTop (nhds 0)) :
+    False := by
+  classical
+  -- Extract a scalar sequence `c` witnessing the eventual proportionality.
+  set Pprop : ℕ → Prop := fun N =>
+    ∃ c : ℂ, c ≠ 0 ∧ ∀ σ : Fin N → Fin d,
+      mpv P.toTensor σ = c * mpv Q.toTensor σ
+  have hEvent : ∀ᶠ N in atTop, Pprop N := hProp
+  let c : ℕ → ℂ := fun N => if hN : Pprop N then Classical.choose hN else 1
+  have hc_eq : ∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+      mpv P.toTensor σ = c N * mpv Q.toTensor σ := by
+    refine hEvent.mono ?_
+    intro N hN
+    simp only [c]
+    rw [dif_pos hN]
+    exact (Classical.choose_spec hN).2
+  -- Projected proportionality identity holds eventually.
+  have hProj : ∀ᶠ N in atTop,
+      mpvOverlap (d := d) P.toTensor (Q.basis k₀) N
+        = c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N := by
+    refine hc_eq.mono ?_
+    intro N hN
+    exact
+      mpvOverlap_eq_mul_of_mpv_eq_mul (d := d) P.toTensor Q.toTensor
+        (c N) hN (Q.basis k₀)
+  -- LHS expansion by BNT decomposition for `P.toTensor`.
+  have hLHS_decomp : ∀ N : ℕ,
+      mpvOverlap (d := d) P.toTensor (Q.basis k₀) N
+        = ∑ j : Fin P.basisCount,
+            P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N := by
+    intro N
+    refine mpvOverlap_eq_sum_of_decomp_left
+      (d := d) (g := P.basisCount) (dim := P.basisDim)
+      P.toTensor P.basis (N := N)
+      (fun j => P.coeff N j) ?_ (Q.basis k₀)
+    intro σ
+    exact P.mpv_toTensor_eq_sum_coeff (N := N) σ
+  -- Each summand tends to zero (uniform `copies j` bound on `‖coeff‖`).
+  have hSummand : ∀ j : Fin P.basisCount,
+      Tendsto
+        (fun N => P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+        atTop (nhds 0) := by
+    intro j
+    refine squeeze_zero_norm
+      (f := fun N => P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+      (a := fun N => (P.copies j : ℝ)
+                      * ‖mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N‖)
+      ?_ ?_
+    · intro N
+      simp only [norm_mul]
+      exact mul_le_mul_of_nonneg_right
+        (P.norm_coeff_le_copies_of_IsBNTCanonicalFormSD hP N j) (norm_nonneg _)
+    · have h0 : Tendsto
+          (fun N => ‖mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N‖)
+          atTop (nhds 0) :=
+        (tendsto_zero_iff_norm_tendsto_zero.mp (hAllDecay j))
+      have := h0.const_mul (P.copies j : ℝ)
+      simpa using this
+  -- LHS tends to zero.
+  have hLHS_tendsto : Tendsto
+      (fun N => mpvOverlap (d := d) P.toTensor (Q.basis k₀) N)
+      atTop (nhds 0) := by
+    have hSum : Tendsto
+        (fun N => ∑ j : Fin P.basisCount,
+            P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+        atTop (nhds 0) := by
+      have hTo : Tendsto
+          (fun N => ∑ j : Fin P.basisCount,
+              P.coeff N j * mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+          atTop (nhds (∑ _j : Fin P.basisCount, (0 : ℂ))) :=
+        tendsto_finset_sum (Finset.univ : Finset (Fin P.basisCount))
+          (fun j _ => hSummand j)
+      simpa using hTo
+    refine hSum.congr' ?_
+    refine Filter.Eventually.of_forall ?_
+    intro N
+    exact (hLHS_decomp N).symm
+  -- Combine with projected proportionality to get the scalar limit.
+  have hRHS_tendsto : Tendsto
+      (fun N => c N * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+      atTop (nhds 0) := by
+    refine hLHS_tendsto.congr' ?_
+    exact hProj
+  -- Contradiction with `hNoCancel`.
+  exact hNoCancel c hc_eq hRHS_tendsto
+
+set_option linter.style.longLine false in
+/-- **Two-layer per-block projection contradiction (fixed left block).**
+
+Symmetric counterpart of
+`fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer`
+fixing a `P`-block `j₀` instead of a `Q`-block.  Reduces to the
+right-block two-layer version after swapping `P` and `Q`. -/
+lemma fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer
+    (P Q : SectorDecomposition d)
+    (hQ : IsBNTCanonicalFormSD Q)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (j₀ : Fin P.basisCount)
+    (hAllDecay : ∀ k : Fin Q.basisCount,
+      Tendsto (fun N => mpvOverlap (d := d) (P.basis j₀) (Q.basis k) N)
+        atTop (nhds 0))
+    (hNoCancel : ∀ c : ℕ → ℂ,
+      (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+        mpv Q.toTensor σ = c N * mpv P.toTensor σ) →
+      ¬ Tendsto
+        (fun N => c N * mpvOverlap (d := d) P.toTensor (P.basis j₀) N)
+        atTop (nhds 0)) :
+    False := by
+  refine
+    fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer
+      Q P hQ hProp.symm j₀ ?_ hNoCancel
   intro k
   exact tendsto_mpvOverlap_zero_swap (d := d) (P.basis j₀) (Q.basis k)
     (hAllDecay k)

--- a/audits/2026-05-13_cpsv16_ft_path_beta_scout.md
+++ b/audits/2026-05-13_cpsv16_ft_path_beta_scout.md
@@ -339,3 +339,97 @@ The eventual linear independence `bnt_data` corresponds to CPSV21 Definition 4.3
 ### Build status
 
 `lake build` succeeds with no new errors or warnings after the docstring changes.
+
+## PR 2 implementation record (2026-05-13)
+
+PR 2 lands the algebraic skeleton of the two-layer per-block projection
+on the `IsBNTCanonicalFormSD` surface.  The analytic discharge of the
+non-cancellation hypothesis in two-layer form is intentionally deferred
+to PR 2.5 / PR 3 — see "Scope adjustment" below.
+
+### Files changed
+
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean`
+  — adds two two-layer coefficient bounds and two two-layer
+  per-block-projection contradictions.  The existing one-layer
+  `norm_coeff_le_copies` and `fixed_{right,left}_..._sectorDecomp`
+  remain callable; the new declarations sit alongside.  The import bumps
+  to include `IsBNTCanonicalFormSD`.
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean`
+  — adds two `_paperFaithful_twoLayer` corollaries on the
+  `IsBNTCanonicalFormSD` surface that retain the abstract `hNoCancel`
+  hypothesis (no analytic discharge).
+
+### New declarations
+
+In `PerBlockProjection.lean`:
+
+* `SectorDecomposition.norm_coeff_le_spectral_pow_mul_copies`
+  — geometric coefficient bound: `‖coeff N j‖ ≤ ‖λ_j‖^N · copies j`.
+* `SectorDecomposition.norm_coeff_le_copies_of_IsBNTCanonicalFormSD`
+  — uniform coefficient bound under dominant normalization:
+  `‖coeff N j‖ ≤ copies j`.  Combines the geometric bound with
+  `IsBNTCanonicalFormSD.spectralLevel_norm_le_one` (`‖λ_j‖ ≤ 1`).
+* `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer`
+  — two-layer counterpart of the one-layer
+  `_sectorDecomp` lemma, consuming `IsBNTCanonicalFormSD P` in place of
+  `hP_unit`.  The `hNoCancel` hypothesis shape is unchanged.
+* `fixed_left_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer`
+  — symmetric counterpart, consuming `IsBNTCanonicalFormSD Q`.
+
+In `HNoCancelDischarge.lean`:
+
+* `fixed_right_all_overlaps_decay_false_paperFaithful_twoLayer`
+  and `fixed_left_all_overlaps_decay_false_paperFaithful_twoLayer`
+  — corollaries packaging `IsBNTCanonicalFormSD P` + `IsBNTCanonicalFormSD Q`
+  + abstract `hNoCancel`.  In contrast to the one-layer
+  `_paperFaithful` form, they do **not** discharge `hNoCancel` from
+  unit modulus + decay + `c_lower`; the discharge is deferred.
+
+### Scope adjustment from the original PR 2 outline
+
+The original PR 2 plan included a "Commit 2" — generalising
+`mpvOverlap_toTensor_basis_not_tendsto_zero` to a two-layer form on the
+`IsBNTCanonicalFormSD` surface.  On re-examination of the math:
+
+* The one-layer lemma asserts that the assembled-tensor-to-block overlap
+  `mpvOverlap Q.toTensor (Q.basis k₀) N` does **not** tend to zero.
+  This holds because under unit-modulus weights, the BNT coefficient
+  `Q.coeff N k₀ = ∑_q (weight)^N` is a unit-modulus power sum that does
+  not decay (`unitModulus_power_sum_not_tendsto_zero`).
+* On the two-layer surface, the unit-modulus property lives only on the
+  inner quotient `weight / λ_j`.  The factored form
+  `Q.coeff N k₀ = λ_{k₀}^N · ∑_q (weight / λ_{k₀})^N` has a prefactor
+  `λ_{k₀}^N` which can decay (`‖λ_{k₀}‖ < 1` for non-dominant `k₀`).
+* For non-dominant `k₀`, `mpvOverlap Q.toTensor (Q.basis k₀) N` actually
+  **does** tend to zero generically; the natural non-decaying object is
+  the **normalized** overlap `λ_{k₀}^{-N} · mpvOverlap Q.toTensor (Q.basis k₀) N`,
+  whose cross-overlap analysis introduces ratios `λ_k / λ_{k₀}` that
+  blow up for `k < k₀` (rank-wise).  The decay of cross-overlaps would
+  have to beat these ratios — a rate-controlled separation that
+  `IsBNTCanonicalFormSD` does not currently supply.
+
+Conclusion: the two-layer analog of
+`mpvOverlap_toTensor_basis_not_tendsto_zero` cannot be stated
+unconditionally on the `IsBNTCanonicalFormSD` surface.  The cleanest
+path is to keep `hNoCancel` abstract in PR 2 and defer the analytic
+discharge to a follow-up PR that supplies rate-controlled cross-overlap
+hypotheses (or, alternatively, restricts to dominant `k₀`).
+
+### Build status
+
+`lake build` succeeds (8674/8674 jobs).  No new `sorry` introduced;
+pre-existing `sorry` count unchanged (21).  No new linter warnings
+above the file boundary (long-line warnings on the long two-layer
+lemma names are suppressed locally via `set_option linter.style.longLine
+false in` immediately before each declaration).
+
+### Downstream pick-up (PR 2.5 / PR 3)
+
+PR 3 will close the two `_CFBNT` sorries at
+`TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean:107, 152`
+by composing the adapter `IsCanonicalFormBNT.toIsBNTCanonicalFormSD`
+with the two-layer `_paperFaithful_twoLayer` corollaries from this PR.
+The abstract `hNoCancel` hypothesis still needs an analytic discharge
+on the two-layer surface; this is the genuinely hard analytic content
+inherited from the path α / β scouts and is the focus of PR 2.5.


### PR DESCRIPTION
**Path β, PR 2**: generalizes the per-block projection algebraic skeleton + `_paperFaithful` corollaries to consume the two-layer `IsBNTCanonicalFormSD` predicate.  Builds on the merged path-β PR 1 (#1657).

## What's here

### `PerBlockProjection.lean` — two-layer coefficient bounds

Two new lemmas:

```lean
lemma SectorDecomposition.norm_coeff_le_spectral_pow_mul_copies
    (P : SectorDecomposition d) (hP : IsBNTCanonicalFormSD P)
    (N : ℕ) (j : Fin P.basisCount) :
    ‖P.coeff N j‖ ≤ ‖hP.spectralLevel j‖ ^ N * (P.copies j : ℝ)

lemma SectorDecomposition.norm_coeff_le_copies_of_IsBNTCanonicalFormSD
    (P : SectorDecomposition d) (hP : IsBNTCanonicalFormSD P)
    (N : ℕ) (j : Fin P.basisCount) :
    ‖P.coeff N j‖ ≤ (P.copies j : ℝ)
```

The first gives a geometric bound from the factorization `coeff N j = (λ_j)^N · (∑_q ν_{j,q}^N)`; the second uses `spectralLevel_norm_le_one` (from PR 1's dominant normalization) for a uniform bound matching the one-layer `norm_coeff_le_copies`.

### `PerBlockProjection.lean` — two-layer `fixed_*_sectorDecomp_twoLayer`

Parallel to the existing one-layer lemmas, but consuming
`IsBNTCanonicalFormSD` and applying the two-layer coefficient bound.
Abstract `hNoCancel` hypothesis (same shape as one-layer).

### `HNoCancelDischarge.lean` — two-layer `_paperFaithful_twoLayer` corollaries

Bundle `IsBNTCanonicalFormSD` on both sides + the abstract
`hNoCancel`.  These are the targets that PR 3 will consume.

### Audit memo update

`audits/2026-05-13_cpsv16_ft_path_beta_scout.md` extended with a "PR 2 implementation record" section explaining the scope-adjustment rationale (see below).

## What's NOT here — honest scope adjustment

The scout's original PR 2 design included a **discharge of the analytic non-cancellation step** in two-layer form (analog of `mpvOverlap_toTensor_basis_not_tendsto_zero`).  This was **dropped** after re-examining the math:

* For the **dominant** `k₀` (with `‖λ_{k₀}‖ = 1`), the one-layer proof lifts cleanly.
* For **non-dominant** `k₀` (with `‖λ_{k₀}‖ < 1`), the assembled overlap `mpvOverlap Q.toTensor (Q.basis k₀) N` generically **does** tend to zero (the `(λ_{k₀})^N` prefactor decays).  The natural non-decaying object would be the normalized overlap `λ_{k₀}^{-N} · mpvOverlap`, but its expansion contains cross-overlap terms with ratios `λ_k / λ_{k₀}` that **blow up** for `k < k₀` rank-wise.  Bounding these requires rate-controlled cross-overlap decay, which `IsBNTCanonicalFormSD` does not currently supply.

So PR 2 stops at the algebraic skeleton + abstract `hNoCancel`.  The discharge of `hNoCancel` is deferred to **PR 2.5 / PR 3** where the correct math for the non-dominant case will be confronted.

This is the same shape of obstruction the path-α probe (#1654) hit at the exact-coefficient sub-lemma.  The two-layer surface gives us a **cleaner language** for the problem, but the analytic content is not magically resolved.

## Local CI

```
lake build               ✅ 8674 jobs
sorry/axiom/unsafe       0 new beyond pre-existing baseline (21 total, unchanged)
file lengths             all under 1000 lines
```

## Refs

Refs #1641 (Plan C tracker), path β roadmap PR 2 (scoped).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new foundational Lean lemmas for the per-block projection argument on the two-layer `IsBNTCanonicalFormSD` surface; risk is mainly proof/assumption correctness and downstream theorem compatibility, not runtime behavior.
> 
> **Overview**
> Extends the Step-1 per-block projection development to the two-layer `IsBNTCanonicalFormSD` surface.
> 
> Adds two-layer coefficient bounds (`SectorDecomposition.norm_coeff_le_spectral_pow_mul_copies` and `...norm_coeff_le_copies_of_IsBNTCanonicalFormSD`) and uses them to introduce two-layer versions of the fixed-block projection contradictions (`fixed_{right,left}_..._sectorDecomp_twoLayer`) that reuse the existing algebraic skeleton but take `IsBNTCanonicalFormSD` instead of unit-modulus weights.
> 
> Adds two `_paperFaithful_twoLayer` corollaries in `HNoCancelDischarge.lean` that package the new two-layer contradiction lemmas while **keeping `hNoCancel` abstract** (no two-layer analytic discharge yet), and updates the audit memo with the implementation record and rationale for deferring that analytic step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 147fc22d72d653fc79110bac3ff3f5cabdfd2964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->